### PR TITLE
added: Gettext PO file support for xbmc

### DIFF
--- a/addons/skin.confluence/language/Afrikaans/strings.po
+++ b/addons/skin.confluence/language/Afrikaans/strings.po
@@ -1,0 +1,576 @@
+# Converted from xbmc strings.xml with xbmc-xml2po (by Team-XBMC)
+msgid ""
+msgstr ""
+"Project-Id-Version: xbmc.skin.confluence-FRODO_GIT953c09c336\n"
+"Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
+"POT-Creation-Date: 2012-04-09 18:03+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE\n"
+"Language: af\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: id:31000
+msgid "Change Your"
+msgstr "Verander Jou"
+
+#: id:31001
+msgid "Love"
+msgstr "Lief Vir"
+
+#: id:31002
+msgid "Hate"
+msgstr "Haat"
+
+#: id:31003
+msgid "Power Options"
+msgstr "Krag Opsies"
+
+#: id:31004
+msgid "Working..."
+msgstr "Werk..."
+
+#: id:31005
+msgid "Hide Information"
+msgstr "Versteek INFO"
+
+#: id:31006
+msgid "View Options"
+msgstr ""
+
+#: id:31007
+msgid "Plugins"
+msgstr "Inproppe"
+
+#: id:31008
+msgid "Fullscreen"
+msgstr ""
+
+#: id:31020
+msgctxt "Auto context with id 31020"
+msgid "Recently Added"
+msgstr "Onlangs Bygevoeg"
+
+#: id:31021
+msgid "Video - Files"
+msgstr "Video - LÃªers"
+
+#: id:31022
+msgid "Music - Files"
+msgstr "Musiek - LÃªers"
+
+#: id:31023
+msgid "Playing"
+msgstr "Speel"
+
+#: id:31024
+msgid "Page"
+msgstr "Bladsy"
+
+#: id:31025
+msgid "Items"
+msgstr "Items"
+
+#: id:31026
+msgid "Misc Options"
+msgstr "Diverse Opsies"
+
+#: id:31027
+msgid "Location"
+msgstr "Ligging"
+
+#: id:31028
+msgid "Poster Wrap"
+msgstr "Plakkaat Toedraai"
+
+#: id:31029
+msgid "Fanart"
+msgstr "Ondersteunerkuns"
+
+#: id:31030
+msgid "Full list"
+msgstr "Vol lys"
+
+#: id:31031
+msgid "Pic Thumbs"
+msgstr "Prent Duime"
+
+#: id:31032
+msgid "Image Wrap"
+msgstr "Prent Toedraai"
+
+#: id:31033
+msgid "Info"
+msgstr "Info"
+
+#: id:31040
+msgid "Now Playing"
+msgstr "Speel Nou"
+
+#: id:31042
+msgid "PLAYING"
+msgstr "SPEEL"
+
+#: id:31043
+msgid "PAUSED"
+msgstr "GEPOUSEER"
+
+#: id:31044
+msgid "FAST FORWARD"
+msgstr "VORENTOE SPOEL"
+
+#: id:31045
+msgid "REWIND"
+msgstr "TERUGSPOEL"
+
+#: id:31046
+msgid "Audio Properties"
+msgstr "Audio Eienskappe"
+
+#: id:31047
+msgid "Current Preset"
+msgstr "Huidige Instelling"
+
+#: id:31048
+msgid "Visualization Presets"
+msgstr "Visualisering Instellings"
+
+#: id:31049
+msgid "End Time"
+msgstr "Eind Tyd"
+
+#: id:31050
+msgid "Sort: Ascending"
+msgstr ""
+
+#: id:31051
+msgid "Sort: Descending"
+msgstr ""
+
+#: id:31055
+msgid "Open playlist"
+msgstr "Maak speellys oop"
+
+#: id:31056
+msgid "Save playlist"
+msgstr "Stoor speellys"
+
+#: id:31057
+msgid "Close playlist"
+msgstr "Maak speellys toe"
+
+#: id:31058
+msgid "System music files"
+msgstr "Stelsel musiek lÃªers"
+
+#: id:31059
+msgid "Current playlist"
+msgstr "Huidige speellys"
+
+#: id:31060
+msgid "This file is stacked, select the part you want to play from."
+msgstr "Hierdie lÃªer is gestapel, selekteer die deel van waar jy wil speel."
+
+#: id:31061
+msgid "Current Selected"
+msgstr "Huidiglik Geselekteer"
+
+#: id:31101
+msgid "Home screen options"
+msgstr "Tuis Venster Opsies"
+
+#: id:31102
+msgid "Background"
+msgstr "Agtergrond"
+
+#: id:31103
+msgid "Show \"Paused\" in picture slide show"
+msgstr "Wys \"Gepouseer\" in prentjie skyfievertoning"
+
+#: id:31104
+msgid "Play Trailers in a window [COLOR=grey3](Video Information Dialog Only)[/COLOR]"
+msgstr "Speel Voorskoue in 'n venster [COLOR=grey3](Slegs Video Informasie Dialoog)[/COLOR]"
+
+#: id:31105
+msgid "\"Videos\" button always goes to video \"Files\""
+msgstr ""
+
+#: id:31106
+msgid "Miscellaneous options"
+msgstr "Diverse Opsies"
+
+#: id:31107
+msgid "Hide Flagging read from video filenames [COLOR=grey3](Blu-ray, HD-DVD)[/COLOR]"
+msgstr "Versteek Vlae gelees van video lÃªername [COLOR=grey3](Blu-ray, HD-DVD)[/COLOR]"
+
+#: id:31108
+msgid "Hide Main Menu Buttons"
+msgstr "Versteek Hoof Kieslys Knoppies"
+
+#: id:31109
+msgid "Media backgrounds"
+msgstr "Media Agtergronde"
+
+#: id:31110
+msgid "Edit Background for Media Type"
+msgstr "Redigeer Agtergrond vir Media Tipe"
+
+#: id:31111
+msgid "Hide"
+msgstr "Versteek"
+
+#: id:31112
+msgid "Options"
+msgstr "Opsies"
+
+#: id:31113
+msgid "Single Image"
+msgstr "Enkele Prentjie"
+
+#: id:31114
+msgid "Multi Image"
+msgstr "Veelvuldige Prentjie"
+
+#: id:31115
+msgid "Customizer"
+msgstr "Verpersoonliker"
+
+#: id:31117
+msgid "Show Recently added Videos"
+msgstr "Wys onlangs bygevoegde Videos"
+
+#: id:31118
+msgid "Home Page Programs Submenu"
+msgstr "Tuis bladsy programme subkieslys"
+
+#: id:31119
+msgid "Hide Background Fanart"
+msgstr "Stel verpersoonlikte byvoegsel knoppie in staat"
+
+#: id:31120
+msgid "BUTTON LABEL"
+msgstr "KNOPPIE ETIKET"
+
+#: id:31122
+msgid "Weather Page"
+msgstr "Weer Bladsy"
+
+#: id:31123
+msgid "Use \"Posters\" instead of \"Banners\" for TV Shows"
+msgstr "Gebruik \"Plakate\" in plaas van \"Baniere\" vir TV vertonings"
+
+#: id:31124
+msgid "Show Background \"Now Playing\" Video"
+msgstr "Wys agtergrond \"Speel Nou\" video"
+
+#: id:31125
+msgid "Show Background \"Now Playing\" Visualization"
+msgstr "Wys agtergrond \"Speel Nou\" visualisering"
+
+#: id:31126
+msgid "Play TV theme songs in video library (TvTunes add-on)"
+msgstr "Stel lirieke in musiek OSD in staat"
+
+#: id:31127
+msgid "TvTunes"
+msgstr "PAD NA LIRIEKE BYVOEGSEL"
+
+#: id:31128
+msgid "Lyrics"
+msgstr "Lirieke"
+
+#: id:31132
+msgid "Lyrics Add-on"
+msgstr ""
+
+#: id:31133
+msgid "Subtitle Add-on"
+msgstr ""
+
+#: id:31134
+msgid "Home Page Videos Submenu"
+msgstr ""
+
+#: id:31135
+msgid "Home Page Music Submenu"
+msgstr ""
+
+#: id:31136
+msgid "Home Page Pictures Submenu"
+msgstr ""
+
+#: id:31140
+msgid "Music OSD"
+msgstr "Musiek OSD"
+
+#: id:31141
+msgid "Video OSD"
+msgstr "Video OSD"
+
+#: id:31200
+msgid "Shortcuts"
+msgstr "Kortpaaie"
+
+#: id:31201
+msgid "Categories"
+msgstr "KategoriÃ«"
+
+#: id:31202
+msgid "Show Cast"
+msgstr "Wys Rolverdeling"
+
+#: id:31203
+msgid "Choose Your Song"
+msgstr "Kies Jou Liedjie"
+
+#: id:31204
+msgid "Section Links"
+msgstr "Seksie Skakels"
+
+#: id:31205
+msgid "Lyrics Source"
+msgstr "Lirieke Bron"
+
+#: id:31300
+msgid "Current Temp"
+msgstr "Huidige Temp"
+
+#: id:31301
+msgid "Last Updated"
+msgstr "Laas Opdateer"
+
+#: id:31302
+msgid "Menu"
+msgstr "Kieslys"
+
+#: id:31303
+msgid "Data provider"
+msgstr ""
+
+#: id:31304
+msgid "Picture"
+msgstr "Prentjie"
+
+#: id:31305
+msgid "No Disc Media Detected"
+msgstr "Geen Skyf Media Bespoor"
+
+#: id:31306
+msgid "Eject"
+msgstr "Haal Skyf Uit"
+
+#: id:31307
+msgid "Hide Fanart"
+msgstr "Versteek Ondersteunerkuns"
+
+#: id:31308
+msgid "Movie Details"
+msgstr "Fliek Besonderhede"
+
+#: id:31309
+msgid "Memory Used:"
+msgstr "Geheue Gebruik:"
+
+#: id:31310
+msgid "Track Number"
+msgstr "Snit Nommer"
+
+#: id:31311
+msgid "Fanart image[CR][CR]Unavailable[CR][CR] Click button to set"
+msgstr "Ondersteunerkuns prentjie[CR][CR]Nie beskikbaar[CR][CR] Kliek knoppie om te stel"
+
+#: id:31312
+msgid "Current Scraper"
+msgstr "Huidige Skraper"
+
+#: id:31313
+msgid "Choose a Scraper"
+msgstr "Kies 'n Skraper"
+
+#: id:31314
+msgid "Content Scanning Options"
+msgstr "Inhoud Deursoek Opsies"
+
+#: id:31315
+msgid "Basic"
+msgstr "Basies"
+
+#: id:31317
+msgid "Set Fanart Path"
+msgstr "Stel Ondersteunerkuns Pad"
+
+#: id:31318
+msgid "Small Fanart"
+msgstr "Klein Ondersteunerkuns"
+
+#: id:31319
+msgid "Selected Profile"
+msgstr "Geselekteerde Profiel"
+
+#: id:31320
+msgid "Last Logged In"
+msgstr "Laaste IngeLog"
+
+#: id:31321
+msgid "Karaoke Song Selector"
+msgstr "Karaoke Liedjie Selekteerder"
+
+#: id:31322
+msgid "Aired"
+msgstr "Gelug"
+
+#: id:31323
+msgid "Latest Movies"
+msgstr "Nuutste Flieks"
+
+#: id:31324
+msgid "Latest Episodes"
+msgstr "Nuutste Episodes"
+
+#: id:31325
+msgid "Playlist Options"
+msgstr "Speellys Opsies"
+
+#: id:31326
+msgid "Created"
+msgstr "Geskep"
+
+#: id:31327
+msgid "Resolution"
+msgstr "Resolusie"
+
+#: id:31328
+msgctxt "Auto context with id 31328"
+msgid "Recently Added"
+msgstr "Onlangs Bygevoeg"
+
+#: id:31329
+msgid "[B]Timer set![/B] [COLOR=grey2] - System auto shutdown in[/COLOR]"
+msgstr "[B]Tydhouer gestel![/B] [COLOR=grey2] - Stelsel auto afskakel in[/COLOR]"
+
+#: id:31330
+msgid "Click button to play[CR][CR]Movie trailer"
+msgstr "Kliek knoppie om[CR][CR]Fliek voorskou te speel"
+
+#: id:31331
+msgid "Album Details"
+msgstr ""
+
+#: id:31351
+msgid "Pause"
+msgstr "Pouseer"
+
+#: id:31352
+msgid "Stop"
+msgstr "Stop"
+
+#: id:31353
+msgid "Fast Forward"
+msgstr "Vorentoe Spoel"
+
+#: id:31354
+msgid "Rewind"
+msgstr "Terugspoel"
+
+#: id:31355
+msgid "Movie menu"
+msgstr "Fliek kieslys"
+
+#: id:31356
+msgid "Download Subtitles"
+msgstr "Laai Subtitels Af"
+
+#: id:31390
+msgid "Skin default"
+msgstr "Bestek omslag"
+
+#: id:31391
+msgid "Skin default with no Caps"
+msgstr "Bestek omslag met geen hoofletters"
+
+#: id:31392
+msgid "Arial based"
+msgstr "Arial gebasseer"
+
+#: id:31400
+msgid "[B]CONFIGURE APPEARANCE SETTINGS[/B][CR][CR]Change the skin · Set language and region · Change file listing options[CR]Set up a screensaver"
+msgstr "[B]KONFIGUREER VOORKOMS VERSTELLINGS[/B][CR][CR]Verander die oortreksel Â· Stel taal en streek Â· Verander lÃªer lyste opsies[CR]Stel 'n skermskut op"
+
+#: id:31401
+msgid "[B]CONFIGURE VIDEO SETTINGS[/B][CR][CR]Manage your video library · Set video playback options · Change video listing options[CR]Set subtitle fonts"
+msgstr "[B]KONFIGUREER VIDEO VERSTELLINGS[/B][CR][CR]Bestuur jou video biblioteek Â· Stel video terugspeel opsies Â· Verander video lyste opsies[CR]Stel subtitel skrifte"
+
+#: id:31402
+msgid "[B]CONFIGURE MUSIC SETTINGS[/B][CR][CR]Manage your music library · Set music playback options · Change music listing options[CR]Setup song submission · Set karaoke options"
+msgstr "[B]KONFIGUREER MUSIEK VERSTELLINGS[/B][CR][CR]Bestuur jou musiek biblioteek Â· Stel musiek speel opsies Â· Verander musiek lyste opsies[CR]Stel liedjie voorlegging op Â· Stel karaoke opsies"
+
+#: id:31403
+msgid "[B]CONFIGURE PICTURE SETTINGS[/B][CR][CR]Set picture listing options · Configure slideshows"
+msgstr "[B]KONFIGUREER PRENTJIE VERSTELLINGS[/B][CR][CR]Stel prentjie lyste opsies Â· Konfigureer skyfievertonings"
+
+#: id:31404
+msgid "[B]CONFIGURE WEATHER SETTINGS[/B][CR][CR]Set three cities to collect weather information"
+msgstr "[B]KONFIGUREER WEER VERSTELLINGS[/B][CR][CR]Stel drie stede om weer inligting te versamel"
+
+#: id:31406
+msgid "[B]CONFIGURE SYSTEM SETTINGS[/B][CR][CR]Setup and calibrate displays · Configure audio output · Setup remote controls[CR]Set power saving options · Enable debugging · Setup master lock"
+msgstr "[B]KONFIGUREER STELSEL VERSTELLINGS[/B][CR][CR]Stel op en kalibreer vertone Â· Konfigureer audio uittree Â· Stel afstandbehere op[CR]Stel krag bespaar opsies Â· Stel ontfouting in staat Â· Stel hoof slot op"
+
+#: id:31407
+msgid "[B]CONFIGURE SKIN SETTINGS[/B][CR][CR]Setup the Confluence skin · Add and remove home menu items[CR]Change skin backgrounds"
+msgstr "[B]KONFIGUREER OORTREKSEL VERSTELLINGS[/B][CR][CR]Stel die Confluence oortreksel op Â· Voeg by en verwyder tuis kieslys items[CR]Verander oortreksel agtergronde"
+
+#: id:31408
+msgid "[B]CONFIGURE ADD-ONS[/B][CR][CR]Manage your installed Add-ons · Browse for and install Add-ons from xbmc.org[CR]Modify Add-on settings"
+msgstr "[B]KONFIGUREER BYVOEGSELS[/B][CR][CR]Bestuur jou geÃ¯nstalleerde Byvoegsels Â· Soek en installeer Byvoegsels vanaf xbmc.org[CR]Verander Byvoeging verstellings"
+
+#: id:31409
+msgid "[B]CONFIGURE SERVICE SETTINGS[/B][CR][CR]Setup control of XBMC via UPnP and HTTP · Configure file sharing[CR]Enable Zeroconf · Configure AirPlay"
+msgstr ""
+
+#: id:31421
+msgid "Select your XBMC user Profile[CR]to login and continue"
+msgstr "Selekteer jou XBMC gebruiker Profiel[CR]om in te log en voort te gaan"
+
+#: id:31900
+msgid "Weather Maps"
+msgstr ""
+
+#: id:31901
+msgid "36 Hour Forecast"
+msgstr ""
+
+#: id:31902
+msgid "Hourly Forecast"
+msgstr ""
+
+#: id:31903
+msgid "Weekend Forecast"
+msgstr ""
+
+#: id:31904
+msgid "10 Day Forecast"
+msgstr ""
+
+#: id:31905
+msgid "Forecast"
+msgstr ""
+
+#: id:31906
+msgid "Maps & Video"
+msgstr ""
+
+#: id:31907
+msgid "Video Forecast [COLOR=grey2](Fullscreen Playback)[/COLOR]"
+msgstr ""
+
+#: id:31908
+msgid "Chance of Precipitation"
+msgstr ""
+
+#: id:31909
+msgid "Fetching forecast info..."
+msgstr ""
+

--- a/addons/skin.confluence/language/Arabic/strings.po
+++ b/addons/skin.confluence/language/Arabic/strings.po
@@ -1,0 +1,576 @@
+# Converted from xbmc strings.xml with xbmc-xml2po (by Team-XBMC)
+msgid ""
+msgstr ""
+"Project-Id-Version: xbmc.skin.confluence-FRODO_GIT953c09c336\n"
+"Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
+"POT-Creation-Date: 2012-04-09 18:03+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE\n"
+"Language: ar\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: id:31000
+msgid "Change Your"
+msgstr "تغيير"
+
+#: id:31001
+msgid "Love"
+msgstr "حب"
+
+#: id:31002
+msgid "Hate"
+msgstr "كراهية"
+
+#: id:31003
+msgid "Power Options"
+msgstr "خيارات الطاقة"
+
+#: id:31004
+msgid "Working..."
+msgstr "...جاري التشغيل"
+
+#: id:31005
+msgid "Hide Information"
+msgstr "إخفاء المعلومات"
+
+#: id:31006
+msgid "View Options"
+msgstr "خيارات العرض"
+
+#: id:31007
+msgid "Plugins"
+msgstr "الملحقات"
+
+#: id:31008
+msgid "Fullscreen"
+msgstr "شاشة كاملة"
+
+#: id:31020
+msgctxt "Auto context with id 31020"
+msgid "Recently Added"
+msgstr "أضيفت مؤخرا"
+
+#: id:31021
+msgid "Video - Files"
+msgstr "الفيديو - ملفات"
+
+#: id:31022
+msgid "Music - Files"
+msgstr "الموسيقى - ملفات"
+
+#: id:31023
+msgid "Playing"
+msgstr "يشتغل الان"
+
+#: id:31024
+msgid "Page"
+msgstr "عناصر"
+
+#: id:31025
+msgid "Items"
+msgstr "صفحة"
+
+#: id:31026
+msgid "Misc Options"
+msgstr "خيارات متنوعه"
+
+#: id:31027
+msgid "Location"
+msgstr "الموقع"
+
+#: id:31028
+msgid "Poster Wrap"
+msgstr "ملصق التفاف"
+
+#: id:31029
+msgid "Fanart"
+msgstr "Fanart"
+
+#: id:31030
+msgid "Full list"
+msgstr "قائمة كاملة"
+
+#: id:31031
+msgid "Pic Thumbs"
+msgstr "مصغرات الصورة"
+
+#: id:31032
+msgid "Image Wrap"
+msgstr "صورة التفاف"
+
+#: id:31033
+msgid "Info"
+msgstr "معلومات"
+
+#: id:31040
+msgid "Now Playing"
+msgstr "يشتغل الان"
+
+#: id:31042
+msgid "PLAYING"
+msgstr "يشتغل الان"
+
+#: id:31043
+msgid "PAUSED"
+msgstr "متوقف"
+
+#: id:31044
+msgid "FAST FORWARD"
+msgstr "تقديم سريع"
+
+#: id:31045
+msgid "REWIND"
+msgstr "إرجاع"
+
+#: id:31046
+msgid "Audio Properties"
+msgstr "خصائص الصوت"
+
+#: id:31047
+msgid "Current Preset"
+msgstr "القيمة الحالية"
+
+#: id:31048
+msgid "Visualization Presets"
+msgstr "التصور المسبقة"
+
+#: id:31049
+msgid "End Time"
+msgstr "وقت الانتهاء"
+
+#: id:31050
+msgid "Sort: Ascending"
+msgstr "الفرز:تصاعدي"
+
+#: id:31051
+msgid "Sort: Descending"
+msgstr "الفرز:تنازلي"
+
+#: id:31055
+msgid "Open playlist"
+msgstr "فتح قائمة التشغيل"
+
+#: id:31056
+msgid "Save playlist"
+msgstr "حفظ قائمة التشغيل"
+
+#: id:31057
+msgid "Close playlist"
+msgstr "إغلاق قائمة التشغيل"
+
+#: id:31058
+msgid "System music files"
+msgstr "ملفات موسيقى النظام"
+
+#: id:31059
+msgid "Current playlist"
+msgstr "قائمة التشغيل الحالية"
+
+#: id:31060
+msgid "This file is stacked, select the part you want to play from."
+msgstr ".هذا الملف مكدس، حدد الجزء الذي تريد تشغيله"
+
+#: id:31061
+msgid "Current Selected"
+msgstr "مختارة حاليا"
+
+#: id:31101
+msgid "Home screen options"
+msgstr "خيارات الصفحة الرئيسية"
+
+#: id:31102
+msgid "Background"
+msgstr "الخلفية"
+
+#: id:31103
+msgid "Show \"Paused\" in picture slide show"
+msgstr "إظهار \"إيقاف مؤقت\" في عرض شرائح الصور"
+
+#: id:31104
+msgid "Play Trailers in a window [COLOR=grey3](Video Information Dialog Only)[/COLOR]"
+msgstr "[COLOR=grey3] (صندوق حوار معلومات الفيديو فقط)[/COLOR]تشغيل مقطع الفيديو في نافذة"
+
+#: id:31105
+msgid "\"Videos\" button always goes to video \"Files\""
+msgstr "\"الفيديو\" الزر يذهب دائما الى \"ملفات الفيديو\""
+
+#: id:31106
+msgid "Miscellaneous options"
+msgstr "خيارات متنوعة"
+
+#: id:31107
+msgid "Hide Flagging read from video filenames [COLOR=grey3](Blu-ray, HD-DVD)[/COLOR]"
+msgstr "[COLOR=grey3](Blu-ray, HD-DVD)[/COLOR]إخفاء وضع علامة القراءة من أسماء الفيديو"
+
+#: id:31108
+msgid "Hide Main Menu Buttons"
+msgstr "إخفاء أزرار القائمة الرئيسية"
+
+#: id:31109
+msgid "Media backgrounds"
+msgstr "خلفيات الوسائط"
+
+#: id:31110
+msgid "Edit Background for Media Type"
+msgstr "تعديل خلفية نوع الوسائط"
+
+#: id:31111
+msgid "Hide"
+msgstr "إخفاء"
+
+#: id:31112
+msgid "Options"
+msgstr "خيارات"
+
+#: id:31113
+msgid "Single Image"
+msgstr "صورة واحدة"
+
+#: id:31114
+msgid "Multi Image"
+msgstr "عدة صورة"
+
+#: id:31115
+msgid "Customizer"
+msgstr "مخصص"
+
+#: id:31117
+msgid "Show Recently added Videos"
+msgstr "إظهار الفيديوات المضافة مؤخراً"
+
+#: id:31118
+msgid "Home Page Programs Submenu"
+msgstr "القائمة الفرعية لقائمة البرامج الرئيسية"
+
+#: id:31119
+msgid "Hide Background Fanart"
+msgstr "Fanart إخفاء خلفية"
+
+#: id:31120
+msgid "BUTTON LABEL"
+msgstr "علامة الزر"
+
+#: id:31122
+msgid "Weather Page"
+msgstr "صفحة الطقس"
+
+#: id:31123
+msgid "Use \"Posters\" instead of \"Banners\" for TV Shows"
+msgstr "استخدام \"ملصقات\" بدلا من \"لافتات\" للمسلسلات التلفزيونية"
+
+#: id:31124
+msgid "Show Background \"Now Playing\" Video"
+msgstr "إظهار خلفية \"التشغيل الآن\" للفيديو"
+
+#: id:31125
+msgid "Show Background \"Now Playing\" Visualization"
+msgstr "إظهار خلفية \"التشغيل الآن\" للتصور"
+
+#: id:31126
+msgid "Play TV theme songs in video library (TvTunes add-on)"
+msgstr "(TvTunes ملحق) تشغيل أغاني سمة التلفزيون في مكتبة الفيديو"
+
+#: id:31127
+msgid "TvTunes"
+msgstr "TvTunes"
+
+#: id:31128
+msgid "Lyrics"
+msgstr "كلمات الأغاني"
+
+#: id:31132
+msgid "Lyrics Add-on"
+msgstr "ملحق كلمات الأغاني"
+
+#: id:31133
+msgid "Subtitle Add-on"
+msgstr "ملحق الترجمات"
+
+#: id:31134
+msgid "Home Page Videos Submenu"
+msgstr "القائمة الفرعية لقائمة الفيديو الرئيسية"
+
+#: id:31135
+msgid "Home Page Music Submenu"
+msgstr "القائمة الفرعية لقائمة الموسيقى الرئيسية"
+
+#: id:31136
+msgid "Home Page Pictures Submenu"
+msgstr "القائمة الفرعية لقائمة الصور الرئيسية"
+
+#: id:31140
+msgid "Music OSD"
+msgstr "عرض الموسيقى على الشاشة"
+
+#: id:31141
+msgid "Video OSD"
+msgstr "عرض الفيديو على الشاشة"
+
+#: id:31200
+msgid "Shortcuts"
+msgstr "اختصارات"
+
+#: id:31201
+msgid "Categories"
+msgstr "الفئات"
+
+#: id:31202
+msgid "Show Cast"
+msgstr "إظهار الرواية"
+
+#: id:31203
+msgid "Choose Your Song"
+msgstr "اختر أغنيتك"
+
+#: id:31204
+msgid "Section Links"
+msgstr "روابط ذات صلة"
+
+#: id:31205
+msgid "Lyrics Source"
+msgstr "مصدر كلمات الأغنية"
+
+#: id:31300
+msgid "Current Temp"
+msgstr "درجة الحرارة الحالية"
+
+#: id:31301
+msgid "Last Updated"
+msgstr "اخر تحديث"
+
+#: id:31302
+msgid "Menu"
+msgstr "القائمة"
+
+#: id:31303
+msgid "Data provider"
+msgstr ": مزود البيانات"
+
+#: id:31304
+msgid "Picture"
+msgstr "الصور"
+
+#: id:31305
+msgid "No Disc Media Detected"
+msgstr "لم يتم الكشف عن قرص وسائط"
+
+#: id:31306
+msgid "Eject"
+msgstr "إخراج"
+
+#: id:31307
+msgid "Hide Fanart"
+msgstr "Fanart إخفاء"
+
+#: id:31308
+msgid "Movie Details"
+msgstr "تفاصيل الفلم"
+
+#: id:31309
+msgid "Memory Used:"
+msgstr "الذاكرة المستخدمة:"
+
+#: id:31310
+msgid "Track Number"
+msgstr "رقم المسار"
+
+#: id:31311
+msgid "Fanart image[CR][CR]Unavailable[CR][CR] Click button to set"
+msgstr "انقر الزر للتعيين[CR][CR]غير متوفرة[CR][CR]Fanart صورة"
+
+#: id:31312
+msgid "Current Scraper"
+msgstr "Current Scraper"
+
+#: id:31313
+msgid "Choose a Scraper"
+msgstr "Choose a Scraper"
+
+#: id:31314
+msgid "Content Scanning Options"
+msgstr "خيارات فحص المحتوى"
+
+#: id:31315
+msgid "Basic"
+msgstr "أساسي"
+
+#: id:31317
+msgid "Set Fanart Path"
+msgstr "Fanart تعيين مسار"
+
+#: id:31318
+msgid "Small Fanart"
+msgstr "Fanart صغيرة"
+
+#: id:31319
+msgid "Selected Profile"
+msgstr "الملف الشخصي المحدد"
+
+#: id:31320
+msgid "Last Logged In"
+msgstr "آخر تسجيل دخول في"
+
+#: id:31321
+msgid "Karaoke Song Selector"
+msgstr "محدد أغاني الكاريوكي"
+
+#: id:31322
+msgid "Aired"
+msgstr "المبث"
+
+#: id:31323
+msgid "Latest Movies"
+msgstr "أحدث الأفلام"
+
+#: id:31324
+msgid "Latest Episodes"
+msgstr "أحدث الحلقات"
+
+#: id:31325
+msgid "Playlist Options"
+msgstr "خيارات قائمة التشغيل"
+
+#: id:31326
+msgid "Created"
+msgstr "أنشئ"
+
+#: id:31327
+msgid "Resolution"
+msgstr "الدقة"
+
+#: id:31328
+msgctxt "Auto context with id 31328"
+msgid "Recently Added"
+msgstr "أضيف مؤخراً"
+
+#: id:31329
+msgid "[B]Timer set![/B] [COLOR=grey2] - System auto shutdown in[/COLOR]"
+msgstr "[COLOR=grey2] إغلاق النظام تلقائيا في - [/COLOR][B]!تعيين مؤقت[B]"
+
+#: id:31330
+msgid "Click button to play[CR][CR]Movie trailer"
+msgstr "مقطع الفلم [CR][CR] انقر على الزر لتشغيل"
+
+#: id:31331
+msgid "Album Details"
+msgstr "تفاصبل الألبوم"
+
+#: id:31351
+msgid "Pause"
+msgstr "توقيف مؤقت"
+
+#: id:31352
+msgid "Stop"
+msgstr "توقف كامل"
+
+#: id:31353
+msgid "Fast Forward"
+msgstr "تقديم سريع"
+
+#: id:31354
+msgid "Rewind"
+msgstr "ترجيع"
+
+#: id:31355
+msgid "Movie menu"
+msgstr "قائمة الفلم"
+
+#: id:31356
+msgid "Download Subtitles"
+msgstr "تحميل الترجمات"
+
+#: id:31390
+msgid "Skin default"
+msgstr "الخلفية الاإفتراضية"
+
+#: id:31391
+msgid "Skin default with no Caps"
+msgstr "Skin default with no Caps"
+
+#: id:31392
+msgid "Arial based"
+msgstr "Arial based"
+
+#: id:31400
+msgid "[B]CONFIGURE APPEARANCE SETTINGS[/B][CR][CR]Change the skin � Set language and region � Change file listing options[CR]Set up a screensaver"
+msgstr "[B]تكوين إعدادات المظهر[/B][CR][CR]تغيير الخلفية · تعيين اللغة والمنطقة · تغيير خيارات قائمة الملف[CR]ضبط شاشة التوقف"
+
+#: id:31401
+msgid "[B]CONFIGURE VIDEO SETTINGS[/B][CR][CR]Manage your video library � Set video playback options � Change video listing options[CR]Set subtitle fonts"
+msgstr "[B]تكوين إعدادات الفيديو[/B][CR][CR]إدارة مكتبة الفيديو · تعيين خيارات تشغيل الفيديو · تغيير خيارات قائمة الفيديو[CR]تعيين خطوط الترجمة"
+
+#: id:31402
+msgid "[B]CONFIGURE MUSIC SETTINGS[/B][CR][CR]Manage your music library � Set music playback options � Change music listing options[CR]Setup song submission � Set karaoke options"
+msgstr "[B]تكوين إعدادات الموسيقى[/B][CR][CR]إدارة مكتبة الموسيقي · تعيين خيارات تشغيل الموسيقى · تغيير خيارات قائمة الموسيقى · تعيين خيارات الكارويوكي"
+
+#: id:31403
+msgid "[B]CONFIGURE PICTURE SETTINGS[/B][CR][CR]Set picture listing options � Configure slideshows"
+msgstr "[B]تكوين إعدادات الصور[/B][CR][CR]ضبط عرض الشرائح · تغيير خيارات قائمة الصور"
+
+#: id:31404
+msgid "[B]CONFIGURE WEATHER SETTINGS[/B][CR][CR]Set three cities to collect weather information"
+msgstr "[B]تكوين إعدادات الطقس[/B][CR][CR]تعيين ثلاث مدن لجمع معلومات عن الطقس"
+
+#: id:31406
+msgid "[B]CONFIGURE SYSTEM SETTINGS[/B][CR][CR]Setup and calibrate displays � Configure audio output � Setup remote controls[CR]Set power saving options � Enable debugging � Setup master lock"
+msgstr "[B]تكوين إعدادات النظام[/B][CR][CR]ضبط المعايرة والعرض· تكوين مخرج الصوت · ضبط التحكم عن بعد[CR]تعيين خيارات توفير الطاقة · تمكين التصحيح · ضبط القفل الرئيسي"
+
+#: id:31407
+msgid "[B]CONFIGURE SKIN SETTINGS[/B][CR][CR]Setup the Confluence skin � Add and remove home menu items[CR]Change skin backgrounds"
+msgstr "[B]تكوين إعدادات الخلفيات [/B][CR][CR]Setup the Confluence skin · أضف وإزالة عناصر القائمة الرئيسية[CR]تغيير الخلفيات"
+
+#: id:31408
+msgid "[B]CONFIGURE ADD-ONS[/B][CR][CR]Manage your installed Add-ons � Browse for and install Add-ons from xbmc.org[CR]Modify Add-on settings"
+msgstr "[B]تكوين الملحقات [/B][CR][CR]xbmc.org إدارة الملحقات المثبتة · تصفح وتثبيت الملحقات من[CR] تعديل إعدادت الملحق"
+
+#: id:31409
+msgid "[B]CONFIGURE SERVICE SETTINGS[/B][CR][CR]Setup control of XBMC via UPnP and HTTP � Configure file sharing[CR]Enable Zeroconf � Configure AirPlay"
+msgstr ""
+
+#: id:31421
+msgid "Select your XBMC user Profile[CR]to login and continue"
+msgstr "للدخول والإستمرارا [CR]XBMC حدد ملفك الشخصي الخاص بـ"
+
+#: id:31900
+msgid "Weather Maps"
+msgstr "خرائط الطقس"
+
+#: id:31901
+msgid "36 Hour Forecast"
+msgstr "36 hour توقعات طقس"
+
+#: id:31902
+msgid "Hourly Forecast"
+msgstr "توقعات الطقس لكل ساعة"
+
+#: id:31903
+msgid "Weekend Forecast"
+msgstr "توقعات طقس نهاية الأسبوع"
+
+#: id:31904
+msgid "10 Day Forecast"
+msgstr "10 Days توقعات طقس"
+
+#: id:31905
+msgid "Forecast"
+msgstr "توقعات الطقس"
+
+#: id:31906
+msgid "Maps & Video"
+msgstr "الخرائط والفيديو"
+
+#: id:31907
+msgid "Video Forecast [COLOR=grey2](Fullscreen Playback)[/COLOR]"
+msgstr "[COLOR=grey2](Fullscreen Playback)[/COLOR]توقعات الطقس فيديو"
+
+#: id:31908
+msgid "Chance of Precipitation"
+msgstr "فرصة هطول الأمطار"
+
+#: id:31909
+msgid "Fetching forecast info..."
+msgstr "...جلب معلومات توقعات الطقس"
+

--- a/addons/skin.confluence/language/Bulgarian/strings.po
+++ b/addons/skin.confluence/language/Bulgarian/strings.po
@@ -1,0 +1,576 @@
+# Converted from xbmc strings.xml with xbmc-xml2po (by Team-XBMC)
+msgid ""
+msgstr ""
+"Project-Id-Version: xbmc.skin.confluence-FRODO_GIT953c09c336\n"
+"Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
+"POT-Creation-Date: 2012-04-09 18:03+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE\n"
+"Language: bg\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: id:31000
+msgid "Change Your"
+msgstr "Променете вашите"
+
+#: id:31001
+msgid "Love"
+msgstr "Love"
+
+#: id:31002
+msgid "Hate"
+msgstr "Hate"
+
+#: id:31003
+msgid "Power Options"
+msgstr "Опции на захранването"
+
+#: id:31004
+msgid "Working..."
+msgstr "Работя..."
+
+#: id:31005
+msgid "Hide Information"
+msgstr "Скрий ИНФО"
+
+#: id:31006
+msgid "View Options"
+msgstr "Изглед"
+
+#: id:31007
+msgid "Plugins"
+msgstr "Добавки"
+
+#: id:31008
+msgid "Fullscreen"
+msgstr "Цял екран"
+
+#: id:31020
+msgctxt "Auto context with id 31020"
+msgid "Recently Added"
+msgstr "Наскоро Добавени"
+
+#: id:31021
+msgid "Video - Files"
+msgstr "Видео - Файлове"
+
+#: id:31022
+msgid "Music - Files"
+msgstr "Музика - Файлове"
+
+#: id:31023
+msgid "Playing"
+msgstr "Възпроизвеждане"
+
+#: id:31024
+msgid "Page"
+msgstr "Страница"
+
+#: id:31025
+msgid "Items"
+msgstr "Позиции"
+
+#: id:31026
+msgid "Misc Options"
+msgstr "Разни Опции"
+
+#: id:31027
+msgid "Location"
+msgstr "Място"
+
+#: id:31028
+msgid "Poster Wrap"
+msgstr "Плакати въртене"
+
+#: id:31029
+msgid "Fanart"
+msgstr "Плакати"
+
+#: id:31030
+msgid "Full list"
+msgstr "Пълен лист"
+
+#: id:31031
+msgid "Pic Thumbs"
+msgstr "Малки картинки"
+
+#: id:31032
+msgid "Image Wrap"
+msgstr "Изображение въртене"
+
+#: id:31033
+msgid "Info"
+msgstr "Инфо"
+
+#: id:31040
+msgid "Now Playing"
+msgstr "Възпроизвежда"
+
+#: id:31042
+msgid "PLAYING"
+msgstr "ВЪЗПРОИЗВЕЖДА"
+
+#: id:31043
+msgid "PAUSED"
+msgstr "НА ПАУЗА"
+
+#: id:31044
+msgid "FAST FORWARD"
+msgstr "НАПРЕД"
+
+#: id:31045
+msgid "REWIND"
+msgstr "НАЗАД"
+
+#: id:31046
+msgid "Audio Properties"
+msgstr "Аудио Свойства"
+
+#: id:31047
+msgid "Current Preset"
+msgstr "Текущо Настроени"
+
+#: id:31048
+msgid "Visualization Presets"
+msgstr "Настроени Визуализации"
+
+#: id:31049
+msgid "End Time"
+msgstr "Крайно Време"
+
+#: id:31050
+msgid "Sort: Ascending"
+msgstr "Сортиране: Възходящ"
+
+#: id:31051
+msgid "Sort: Descending"
+msgstr "Сортиране: Низходящ"
+
+#: id:31055
+msgid "Open playlist"
+msgstr "Отвори плейлист"
+
+#: id:31056
+msgid "Save playlist"
+msgstr "Запази плейлист"
+
+#: id:31057
+msgid "Close playlist"
+msgstr "Затвори плейлист"
+
+#: id:31058
+msgid "System music files"
+msgstr "Системна музика"
+
+#: id:31059
+msgid "Current playlist"
+msgstr "Текущ плейлист"
+
+#: id:31060
+msgid "This file is stacked, select the part you want to play from."
+msgstr "Изберете място, от което искате да възпроизвеждате."
+
+#: id:31061
+msgid "Current Selected"
+msgstr "Текущо избрани"
+
+#: id:31101
+msgid "Home screen options"
+msgstr "Настройки на начален екран"
+
+#: id:31102
+msgid "Background"
+msgstr "Фон"
+
+#: id:31103
+msgid "Show \"Paused\" in picture slide show"
+msgstr "Покажи \"На Пауза\" в слайдшоу на снимки"
+
+#: id:31104
+msgid "Play Trailers in a window [COLOR=grey3](Video Information Dialog Only)[/COLOR]"
+msgstr "Възпроизведи трейлърите в прозорец [COLOR=grey3](Само диалог за видео инфо)[/COLOR]"
+
+#: id:31105
+msgid "\"Videos\" button always goes to video \"Files\""
+msgstr ""
+
+#: id:31106
+msgid "Miscellaneous options"
+msgstr "Разни опции"
+
+#: id:31107
+msgid "Hide Flagging read from video filenames [COLOR=grey3](Blu-ray, HD-DVD)[/COLOR]"
+msgstr ""
+
+#: id:31108
+msgid "Hide Main Menu Buttons"
+msgstr "Скрий бутоните на главното меню"
+
+#: id:31109
+msgid "Media backgrounds"
+msgstr "Фон на начален екран"
+
+#: id:31110
+msgid "Edit Background for Media Type"
+msgstr "Редактиране на фон за Начало:"
+
+#: id:31111
+msgid "Hide"
+msgstr "Скрий"
+
+#: id:31112
+msgid "Options"
+msgstr "Опции"
+
+#: id:31113
+msgid "Single Image"
+msgstr "Една картина"
+
+#: id:31114
+msgid "Multi Image"
+msgstr "Много картини"
+
+#: id:31115
+msgid "Customizer"
+msgstr "Потребителски"
+
+#: id:31117
+msgid "Show Recently added Videos"
+msgstr "Покажи Наскоро добавени видео"
+
+#: id:31118
+msgid "Home Page Programs Submenu"
+msgstr "Подменю Начална страница"
+
+#: id:31119
+msgid "Hide Background Fanart"
+msgstr "Включи протребителски Скрипт Бутон"
+
+#: id:31120
+msgid "BUTTON LABEL"
+msgstr "ЕТИКЕТ НА БУТОН"
+
+#: id:31122
+msgid "Weather Page"
+msgstr "Страница Времето"
+
+#: id:31123
+msgid "Use \"Posters\" instead of \"Banners\" for TV Shows"
+msgstr "Ползвай \"Плакати\" вместо \"Банери\" за ТВ Шоу"
+
+#: id:31124
+msgid "Show Background \"Now Playing\" Video"
+msgstr "Покажи фон \"Възпроизвеждам\" Видео"
+
+#: id:31125
+msgid "Show Background \"Now Playing\" Visualization"
+msgstr "Покажи фон \"Възпроизвеждам\" Визуализация"
+
+#: id:31126
+msgid "Play TV theme songs in video library (TvTunes add-on)"
+msgstr "Пусни тв музика във видео библиотеката (TvTunes добавка)"
+
+#: id:31127
+msgid "TvTunes"
+msgstr "TvTunes"
+
+#: id:31128
+msgid "Lyrics"
+msgstr "Текст"
+
+#: id:31132
+msgid "Lyrics Add-on"
+msgstr "Добавка за текст"
+
+#: id:31133
+msgid "Subtitle Add-on"
+msgstr "Добавка субтитри"
+
+#: id:31134
+msgid "Home Page Videos Submenu"
+msgstr "Начална страница подменю Видео"
+
+#: id:31135
+msgid "Home Page Music Submenu"
+msgstr "Начална страница подменю Музика"
+
+#: id:31136
+msgid "Home Page Pictures Submenu"
+msgstr "Начална страница подменю Снимки"
+
+#: id:31140
+msgid "Music OSD"
+msgstr "Музика OSD"
+
+#: id:31141
+msgid "Video OSD"
+msgstr "Видео OSD"
+
+#: id:31200
+msgid "Shortcuts"
+msgstr "Преки пътища"
+
+#: id:31201
+msgid "Categories"
+msgstr "Категории"
+
+#: id:31202
+msgid "Show Cast"
+msgstr "Покажи ролите"
+
+#: id:31203
+msgid "Choose Your Song"
+msgstr "Избери песен"
+
+#: id:31204
+msgid "Section Links"
+msgstr "Секзия връзки"
+
+#: id:31205
+msgid "Lyrics Source"
+msgstr "Източник на текст на песен"
+
+#: id:31300
+msgid "Current Temp"
+msgstr "Текуща температура"
+
+#: id:31301
+msgid "Last Updated"
+msgstr "Последно обновен"
+
+#: id:31302
+msgid "Menu"
+msgstr "Меню"
+
+#: id:31303
+msgid "Data provider"
+msgstr ""
+
+#: id:31304
+msgid "Picture"
+msgstr "Снимка"
+
+#: id:31305
+msgid "No Disc Media Detected"
+msgstr "Не е открит медия диск"
+
+#: id:31306
+msgid "Eject"
+msgstr "Извади"
+
+#: id:31307
+msgid "Hide Fanart"
+msgstr "Скрий плакат"
+
+#: id:31308
+msgid "Movie Details"
+msgstr "Детайли Филм"
+
+#: id:31309
+msgid "Memory Used:"
+msgstr "Използвана памет:"
+
+#: id:31310
+msgid "Track Number"
+msgstr "Номер на песен"
+
+#: id:31311
+msgid "Fanart image[CR][CR]Unavailable[CR][CR] Click button to set"
+msgstr "ПЛАКАТ[CR][CR]НЕДОСТЪПЕН[CR][CR] НАТИСНИ БУТОНА ЗА ЗАДАВАНЕ"
+
+#: id:31312
+msgid "Current Scraper"
+msgstr "Текущ Сайт Инфо"
+
+#: id:31313
+msgid "Choose a Scraper"
+msgstr "Сайт Инфо"
+
+#: id:31314
+msgid "Content Scanning Options"
+msgstr "Опции Сканиране на съдържание"
+
+#: id:31315
+msgid "Basic"
+msgstr "Основни"
+
+#: id:31317
+msgid "Set Fanart Path"
+msgstr "Задай път до Плакат"
+
+#: id:31318
+msgid "Small Fanart"
+msgstr "Малък Плакат"
+
+#: id:31319
+msgid "Selected Profile"
+msgstr "Избран Профил"
+
+#: id:31320
+msgid "Last Logged In"
+msgstr "Последно влизане"
+
+#: id:31321
+msgid "Karaoke Song Selector"
+msgstr "Караоке избирател на песни"
+
+#: id:31322
+msgid "Aired"
+msgstr "Излъчен"
+
+#: id:31323
+msgid "Latest Movies"
+msgstr "Последни Филми"
+
+#: id:31324
+msgid "Latest Episodes"
+msgstr "Последни Епизоди"
+
+#: id:31325
+msgid "Playlist Options"
+msgstr "Опции на Плейлисти"
+
+#: id:31326
+msgid "Created"
+msgstr "Създаден"
+
+#: id:31327
+msgid "Resolution"
+msgstr "Резолюция"
+
+#: id:31328
+msgctxt "Auto context with id 31328"
+msgid "Recently Added"
+msgstr "Наскоро Добавени"
+
+#: id:31329
+msgid "[B]Timer set![/B] [COLOR=grey2] - System auto shutdown in[/COLOR]"
+msgstr "[B]ТАЙМЕР УСТАНОВЕН![/B] [COLOR=grey2] - АВТОМАТИЧНО ИЗКЛЮЧВАНЕ[/COLOR]"
+
+#: id:31330
+msgid "Click button to play[CR][CR]Movie trailer"
+msgstr "Натисни бутон за възпроизвеждане[CR][CR]Трейлър"
+
+#: id:31331
+msgid "Album Details"
+msgstr "Албум детайли"
+
+#: id:31351
+msgid "Pause"
+msgstr "Пауза"
+
+#: id:31352
+msgid "Stop"
+msgstr "Стоп"
+
+#: id:31353
+msgid "Fast Forward"
+msgstr "Превъртане напред"
+
+#: id:31354
+msgid "Rewind"
+msgstr "Превъртане назад"
+
+#: id:31355
+msgid "Movie menu"
+msgstr "Меню филм"
+
+#: id:31356
+msgid "Download Subtitles"
+msgstr "Свали субтитри"
+
+#: id:31390
+msgid "Skin default"
+msgstr "Кожа подразбиране"
+
+#: id:31391
+msgid "Skin default with no Caps"
+msgstr "Кожа подразбиране без главни букви"
+
+#: id:31392
+msgid "Arial based"
+msgstr "Ариал базилан"
+
+#: id:31400
+msgid "[B]CONFIGURE APPEARANCE SETTINGS[/B][CR][CR]Change the skin � Set language and region � Change file listing options[CR]Set up a screensaver"
+msgstr "[B]КОНФИГУРАЦИЯ НАСТРОЙКИ НА ОБЛИКА[/B][CR][CR]Промяна на кожа · Избор на език и регион · Промяна на файловите опции[CR]Настройки на скрийнсейвър"
+
+#: id:31401
+msgid "[B]CONFIGURE VIDEO SETTINGS[/B][CR][CR]Manage your video library � Set video playback options � Change video listing options[CR]Set subtitle fonts"
+msgstr "[B]КОНФИГУРИРАНЕ НА ВИДЕО НАСТРОЙКИТЕ[/B][CR][CR]Управление на видео библиотека · Настройки на видео възпроизвеждане · Промяна на видео файловите опции · Задаване на шрифт за субтитри"
+
+#: id:31402
+msgid "[B]CONFIGURE MUSIC SETTINGS[/B][CR][CR]Manage your music library � Set music playback options � Change music listing options[CR]Setup song submission � Set karaoke options"
+msgstr "[B]КОНФИГУРИРАНЕ НА НАСТРОЙКИТЕ ЗА МУЗИКА[/B][CR][CR]Управление на музикалната библиотека · Настройки на възпроизвежданена музика · Промяна на музикалните файлови опции · Настройки на караоке"
+
+#: id:31403
+msgid "[B]CONFIGURE PICTURE SETTINGS[/B][CR][CR]Set picture listing options � Configure slideshows"
+msgstr "[B]КОНФИГУРИРАНЕ НА НАСТРОЙКИТЕ ЗА СНИМКИ[/B][CR][CR]Настройка на листингови опции · Конфигуриране на слайдшоу"
+
+#: id:31404
+msgid "[B]CONFIGURE WEATHER SETTINGS[/B][CR][CR]Set three cities to collect weather information"
+msgstr "[B]КОНФИГУРИРАНЕ НА НАСТРОЙКИТЕ ЗА ВРЕМЕТО[/B][CR][CR]Задаване на три града за събиране на информация за времето"
+
+#: id:31406
+msgid "[B]CONFIGURE SYSTEM SETTINGS[/B][CR][CR]Setup and calibrate displays � Configure audio output � Setup remote controls[CR]Set power saving options � Enable debugging � Setup master lock"
+msgstr "[B]КОНФИГУРИРАНЕ НА СИСТЕМНИТЕ НАСТРОЙКИ[/B][CR][CR]Найстройки и калибриране на дисплей · Конфигуриране на аудио изход[CR]Найстройки на дистанционни управления · Настройки на запазване на захранването · Включване на дебъг · Настройки на главно заключване"
+
+#: id:31407
+msgid "[B]CONFIGURE SKIN SETTINGS[/B][CR][CR]Setup the Confluence skin � Add and remove home menu items[CR]Change skin backgrounds"
+msgstr "[B]КОНФИГУРИРАНЕ НАСТРОЙКИ ЗА КОЖА[/B][CR][CR]Настройки на кожа Confluence · Добавяне и премахване на позиции от начален екран · Промяна фона на кожите"
+
+#: id:31408
+msgid "[B]CONFIGURE ADD-ONS[/B][CR][CR]Manage your installed Add-ons � Browse for and install Add-ons from xbmc.org[CR]Modify Add-on settings"
+msgstr "[B]КОНФИГУРИРАНЕ ДОБАВКИ[/B][CR][CR]Управление на инсталираните добавки · Разглеждане и инсталиране на добавки от xbmc.org · Промяна на настройките на добавките"
+
+#: id:31409
+msgid "[B]CONFIGURE SERVICE SETTINGS[/B][CR][CR]Setup control of XBMC via UPnP and HTTP � Configure file sharing[CR]Enable Zeroconf � Configure AirPlay"
+msgstr ""
+
+#: id:31421
+msgid "Select your XBMC user Profile[CR]to login and continue"
+msgstr "Изберете XBMC потребителски профил[CR]за вход и продължаване"
+
+#: id:31900
+msgid "Weather Maps"
+msgstr "Карта на времето"
+
+#: id:31901
+msgid "36 Hour Forecast"
+msgstr "36 часова прогноза"
+
+#: id:31902
+msgid "Hourly Forecast"
+msgstr "Часова прогноза"
+
+#: id:31903
+msgid "Weekend Forecast"
+msgstr "Уикенд прогноза"
+
+#: id:31904
+msgid "10 Day Forecast"
+msgstr "10 дневна прогноза"
+
+#: id:31905
+msgid "Forecast"
+msgstr "Прогноза"
+
+#: id:31906
+msgid "Maps & Video"
+msgstr "Карти & Видео"
+
+#: id:31907
+msgid "Video Forecast [COLOR=grey2](Fullscreen Playback)[/COLOR]"
+msgstr "Видео Прогноза [COLOR=grey2](Fullscreen Playback)[/COLOR]"
+
+#: id:31908
+msgid "Chance of Precipitation"
+msgstr "Възможност от превалявания"
+
+#: id:31909
+msgid "Fetching forecast info..."
+msgstr "Извличане информация за прогноза..."
+

--- a/addons/skin.confluence/language/Catalan/strings.po
+++ b/addons/skin.confluence/language/Catalan/strings.po
@@ -1,0 +1,576 @@
+# Converted from xbmc strings.xml with xbmc-xml2po (by Team-XBMC)
+msgid ""
+msgstr ""
+"Project-Id-Version: xbmc.skin.confluence-FRODO_GIT953c09c336\n"
+"Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
+"POT-Creation-Date: 2012-04-09 18:03+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE\n"
+"Language: ca\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: id:31000
+msgid "Change Your"
+msgstr "Canvia la"
+
+#: id:31001
+msgid "Love"
+msgstr "M'agrada"
+
+#: id:31002
+msgid "Hate"
+msgstr "No m'agrada"
+
+#: id:31003
+msgid "Power Options"
+msgstr "Opcions d'energia"
+
+#: id:31004
+msgid "Working..."
+msgstr "Treballant..."
+
+#: id:31005
+msgid "Hide Information"
+msgstr "Amaga la informació"
+
+#: id:31006
+msgid "View Options"
+msgstr "Veure les opcions"
+
+#: id:31007
+msgid "Plugins"
+msgstr "Connectors"
+
+#: id:31008
+msgid "Fullscreen"
+msgstr "Pantalla completa"
+
+#: id:31020
+msgctxt "Auto context with id 31020"
+msgid "Recently Added"
+msgstr "Afegits recentment"
+
+#: id:31021
+msgid "Video - Files"
+msgstr "Fitxers - Vídeo"
+
+#: id:31022
+msgid "Music - Files"
+msgstr "Fitxers - Música"
+
+#: id:31023
+msgid "Playing"
+msgstr "S'està reproduint"
+
+#: id:31024
+msgid "Page"
+msgstr "Pàgina"
+
+#: id:31025
+msgid "Items"
+msgstr "Elements"
+
+#: id:31026
+msgid "Misc Options"
+msgstr "Opcions vàries"
+
+#: id:31027
+msgid "Location"
+msgstr "Ubicació"
+
+#: id:31028
+msgid "Poster Wrap"
+msgstr "Tapa de cartell"
+
+#: id:31029
+msgid "Fanart"
+msgstr "Fanart"
+
+#: id:31030
+msgid "Full list"
+msgstr "Llista completa"
+
+#: id:31031
+msgid "Pic Thumbs"
+msgstr "Miniatures"
+
+#: id:31032
+msgid "Image Wrap"
+msgstr "Tapa d'imatge"
+
+#: id:31033
+msgid "Info"
+msgstr "Informació"
+
+#: id:31040
+msgid "Now Playing"
+msgstr "S'està reproduint"
+
+#: id:31042
+msgid "PLAYING"
+msgstr "REPRODUINT"
+
+#: id:31043
+msgid "PAUSED"
+msgstr "EN PAUSA"
+
+#: id:31044
+msgid "FAST FORWARD"
+msgstr "AVANÇA RÀPID"
+
+#: id:31045
+msgid "REWIND"
+msgstr "REBOBINA"
+
+#: id:31046
+msgid "Audio Properties"
+msgstr "Propietats de l'àudio"
+
+#: id:31047
+msgid "Current Preset"
+msgstr "Predefinit actual"
+
+#: id:31048
+msgid "Visualization Presets"
+msgstr "Visualitzacions predefinides"
+
+#: id:31049
+msgid "End Time"
+msgstr "Hora de finalització"
+
+#: id:31050
+msgid "Sort: Ascending"
+msgstr "Ordena: Ascendent"
+
+#: id:31051
+msgid "Sort: Descending"
+msgstr "Ordena: Descendent"
+
+#: id:31055
+msgid "Open playlist"
+msgstr "Obre una llista de reproducció"
+
+#: id:31056
+msgid "Save playlist"
+msgstr "Desa la llista de reproducció"
+
+#: id:31057
+msgid "Close playlist"
+msgstr "Tanca la llista de reproducció"
+
+#: id:31058
+msgid "System music files"
+msgstr "Fitxers de música del sistema"
+
+#: id:31059
+msgid "Current playlist"
+msgstr "Llista de reproducció actual"
+
+#: id:31060
+msgid "This file is stacked, select the part you want to play from."
+msgstr "Aquest fitxer està agrupat, seleccioneu la part que desitgeu reproduir."
+
+#: id:31061
+msgid "Current Selected"
+msgstr "Selecció actual"
+
+#: id:31101
+msgid "Home screen options"
+msgstr "Opcions de la pantalla principal"
+
+#: id:31102
+msgid "Background"
+msgstr "Fons"
+
+#: id:31103
+msgid "Show \"Paused\" in picture slide show"
+msgstr "Visualitza \"En pausa\" en mode de presentació d'imatges"
+
+#: id:31104
+msgid "Play Trailers in a window [COLOR=grey3](Video Information Dialog Only)[/COLOR]"
+msgstr "Reprodueix els tràilers en una finestra [COLOR=grey3](Només al diàleg d'informació de vídeo)[/COLOR]"
+
+#: id:31105
+msgid "\"Videos\" button always goes to video \"Files\""
+msgstr "\"Videos\" button always goes to video \"Files\""
+
+#: id:31106
+msgid "Miscellaneous options"
+msgstr "Opcions vàries"
+
+#: id:31107
+msgid "Hide Flagging read from video filenames [COLOR=grey3](Blu-ray, HD-DVD)[/COLOR]"
+msgstr "Hide Flagging read from video filenames [COLOR=grey3](Blu-ray, HD-DVD)[/COLOR]"
+
+#: id:31108
+msgid "Hide Main Menu Buttons"
+msgstr "Amaga els botons del menú principal"
+
+#: id:31109
+msgid "Media backgrounds"
+msgstr "Fons multimèdia"
+
+#: id:31110
+msgid "Edit Background for Media Type"
+msgstr "Edita el fons per els continguts multimèdia"
+
+#: id:31111
+msgid "Hide"
+msgstr "Amaga"
+
+#: id:31112
+msgid "Options"
+msgstr "Opcions"
+
+#: id:31113
+msgid "Single Image"
+msgstr "Una imatge"
+
+#: id:31114
+msgid "Multi Image"
+msgstr "Múltiples imatges"
+
+#: id:31115
+msgid "Customizer"
+msgstr "Personalitzador"
+
+#: id:31117
+msgid "Show Recently added Videos"
+msgstr "Mostra els vídeos afegits recentment"
+
+#: id:31118
+msgid "Home Page Programs Submenu"
+msgstr "Submenú de programes de la pantalla principal"
+
+#: id:31119
+msgid "Hide Background Fanart"
+msgstr "Amaga el fanart del fons"
+
+#: id:31120
+msgid "BUTTON LABEL"
+msgstr "ETIQUETA DEL BOTÓ"
+
+#: id:31122
+msgid "Weather Page"
+msgstr "Pàgina del temps"
+
+#: id:31123
+msgid "Use \"Posters\" instead of \"Banners\" for TV Shows"
+msgstr "Utilitza \"Cartells\" en lloc de \"Bàners\" per als programes de televisió"
+
+#: id:31124
+msgid "Show Background \"Now Playing\" Video"
+msgstr "Mostra el vídeo en reproducció en el fons"
+
+#: id:31125
+msgid "Show Background \"Now Playing\" Visualization"
+msgstr "Mostra la visualització en reproducció en el fons"
+
+#: id:31126
+msgid "Play TV theme songs in video library (TvTunes add-on)"
+msgstr "Play TV theme songs in video library (TvTunes add-on)"
+
+#: id:31127
+msgid "TvTunes"
+msgstr "TvTunes"
+
+#: id:31128
+msgid "Lyrics"
+msgstr "Lletres"
+
+#: id:31132
+msgid "Lyrics Add-on"
+msgstr "Complement de lletres"
+
+#: id:31133
+msgid "Subtitle Add-on"
+msgstr "Complement de subtítols"
+
+#: id:31134
+msgid "Home Page Videos Submenu"
+msgstr "Submenú de vídeos de la pantalla principal"
+
+#: id:31135
+msgid "Home Page Music Submenu"
+msgstr "Submenú de música de la pantalla principal"
+
+#: id:31136
+msgid "Home Page Pictures Submenu"
+msgstr "Submenú d'imatges de la pantalla principal"
+
+#: id:31140
+msgid "Music OSD"
+msgstr "OSD de música"
+
+#: id:31141
+msgid "Video OSD"
+msgstr "OSD de vídeo"
+
+#: id:31200
+msgid "Shortcuts"
+msgstr "Dreceres de teclat"
+
+#: id:31201
+msgid "Categories"
+msgstr "Categories"
+
+#: id:31202
+msgid "Show Cast"
+msgstr "Mostra el repartiment"
+
+#: id:31203
+msgid "Choose Your Song"
+msgstr "Escull la teva cançó"
+
+#: id:31204
+msgid "Section Links"
+msgstr "Enllaços de secció"
+
+#: id:31205
+msgid "Lyrics Source"
+msgstr "Origen de les lletres"
+
+#: id:31300
+msgid "Current Temp"
+msgstr "Temperatura actual"
+
+#: id:31301
+msgid "Last Updated"
+msgstr "Actualització més recent"
+
+#: id:31302
+msgid "Menu"
+msgstr "Menú"
+
+#: id:31303
+msgid "Data provider"
+msgstr "Proveïdor de dades"
+
+#: id:31304
+msgid "Picture"
+msgstr "Imatge"
+
+#: id:31305
+msgid "No Disc Media Detected"
+msgstr "No s'ha detectat cap disc amb continguts multimèdia"
+
+#: id:31306
+msgid "Eject"
+msgstr "Expulsa"
+
+#: id:31307
+msgid "Hide Fanart"
+msgstr "Amaga el fanart"
+
+#: id:31308
+msgid "Movie Details"
+msgstr "Detalls de la pel·lícula"
+
+#: id:31309
+msgid "Memory Used:"
+msgstr "Memòria utilitzada:"
+
+#: id:31310
+msgid "Track Number"
+msgstr "Número de pista"
+
+#: id:31311
+msgid "Fanart image[CR][CR]Unavailable[CR][CR] Click button to set"
+msgstr "Imatge de fanart[CR][CR]No disponible[CR][CR] Feu clic per definir-la"
+
+#: id:31312
+msgid "Current Scraper"
+msgstr "Scraper actual"
+
+#: id:31313
+msgid "Choose a Scraper"
+msgstr "Tria un scraper"
+
+#: id:31314
+msgid "Content Scanning Options"
+msgstr "Opcions d'escaneig de continguts"
+
+#: id:31315
+msgid "Basic"
+msgstr "Bàsic"
+
+#: id:31317
+msgid "Set Fanart Path"
+msgstr "Estableix el camí del fanart"
+
+#: id:31318
+msgid "Small Fanart"
+msgstr "Fanart petit"
+
+#: id:31319
+msgid "Selected Profile"
+msgstr "Perfil seleccionat"
+
+#: id:31320
+msgid "Last Logged In"
+msgstr "Últim accés el"
+
+#: id:31321
+msgid "Karaoke Song Selector"
+msgstr "Selector de cançons del karaoke"
+
+#: id:31322
+msgid "Aired"
+msgstr "Emès"
+
+#: id:31323
+msgid "Latest Movies"
+msgstr "Pel·lícules més recents"
+
+#: id:31324
+msgid "Latest Episodes"
+msgstr "Episodis més recents"
+
+#: id:31325
+msgid "Playlist Options"
+msgstr "Opcions de la llista de reproducció"
+
+#: id:31326
+msgid "Created"
+msgstr "Creat"
+
+#: id:31327
+msgid "Resolution"
+msgstr "Resolució"
+
+#: id:31328
+msgctxt "Auto context with id 31328"
+msgid "Recently Added"
+msgstr "Afegits recentment"
+
+#: id:31329
+msgid "[B]Timer set![/B] [COLOR=grey2] - System auto shutdown in[/COLOR]"
+msgstr "[B]Temporitzador activat[/B] [COLOR=grey2] - El sistema s'apagarà automàticament en[/COLOR]"
+
+#: id:31330
+msgid "Click button to play[CR][CR]Movie trailer"
+msgstr "Feu clic per reproduir[CR][CR]Trailer de la pel·lícula"
+
+#: id:31331
+msgid "Album Details"
+msgstr "Detalls de l'àlbum"
+
+#: id:31351
+msgid "Pause"
+msgstr "Pausa"
+
+#: id:31352
+msgid "Stop"
+msgstr "Atura"
+
+#: id:31353
+msgid "Fast Forward"
+msgstr "Avança ràpid"
+
+#: id:31354
+msgid "Rewind"
+msgstr "Rebobina"
+
+#: id:31355
+msgid "Movie menu"
+msgstr "Menú de la pel·lícula"
+
+#: id:31356
+msgid "Download Subtitles"
+msgstr "Descarrega els subtítols"
+
+#: id:31390
+msgid "Skin default"
+msgstr "Tema per defecte"
+
+#: id:31391
+msgid "Skin default with no Caps"
+msgstr "Tema per defecte sense majúscules"
+
+#: id:31392
+msgid "Arial based"
+msgstr "Basat en Arial"
+
+#: id:31400
+msgid "[B]CONFIGURE APPEARANCE SETTINGS[/B][CR][CR]Change the skin � Set language and region � Change file listing options[CR]Set up a screensaver"
+msgstr "[B]CONFIGUREU ELS PARÀMETRES D'APARENÇA[/B][CR][CR]Canvieu el tema · Establiu l'idioma i la regió · Canvieu les opcions del llistat de fitxers[CR]Establiu un estalvi de pantalla"
+
+#: id:31401
+msgid "[B]CONFIGURE VIDEO SETTINGS[/B][CR][CR]Manage your video library � Set video playback options � Change video listing options[CR]Set subtitle fonts"
+msgstr "[B]CONFIGUREU ELS PARÀMETRES DE VÍDEO[/B][CR][CR]Gestioneu la biblioteca de vídeos · Establiu les opcions de reproducció de vídeo[CR]Canvieu les opcions del llistat de vídeo · Establiu els tipus de lletra dels subtítols"
+
+#: id:31402
+msgid "[B]CONFIGURE MUSIC SETTINGS[/B][CR][CR]Manage your music library � Set music playback options � Change music listing options[CR]Setup song submission � Set karaoke options"
+msgstr "[B]CONFIGUREU ELS PARÀMETRES DE LA MÚSICA[/B][CR][CR]Gestioneu la biblioteca de música · Establiu les opcions de reproducció de la música[CR]Canvieu les opcions del llistat de música · Configureu l'enviament de cançons[CR]Establiu les opcions del karaoke"
+
+#: id:31403
+msgid "[B]CONFIGURE PICTURE SETTINGS[/B][CR][CR]Set picture listing options � Configure slideshows"
+msgstr "[B]CONFIGUREU ELS PARÀMETRES D'IMATGE[/B][CR][CR]Establiu les opcions del llistat d'imatges · Configureu les presentacions de diapositives"
+
+#: id:31404
+msgid "[B]CONFIGURE WEATHER SETTINGS[/B][CR][CR]Set three cities to collect weather information"
+msgstr "[B]CONFIGUREU ELS PARÀMETRES DEL TEMPS[/B][CR][CR]Indiqueu tres ciutats per recollir informació del temps"
+
+#: id:31406
+msgid "[B]CONFIGURE SYSTEM SETTINGS[/B][CR][CR]Setup and calibrate displays � Configure audio output � Setup remote controls[CR]Set power saving options � Enable debugging � Setup master lock"
+msgstr "[B]CONFIGUREU ELS PARÀMETRES DEL SISTEMA[/B][CR][CR]Configureu i calibreu les pantalles · Configureu la sortida d'àudio[CR]Configureu els comandaments a distància · Establiu les opcions d'estalvi d'energia[CR]Habiliteu la depuració · Configureu el bloqueig mestre"
+
+#: id:31407
+msgid "[B]CONFIGURE SKIN SETTINGS[/B][CR][CR]Setup the Confluence skin � Add and remove home menu items[CR]Change skin backgrounds"
+msgstr "[B]CONFIGUREU ELS PARÀMETRES DEL TEMA[/B][CR][CR]Configureu la pell Confluence · Afegiu i elimineu elements del menú d'inici[CR]Canvieu els fons de la pell"
+
+#: id:31408
+msgid "[B]CONFIGURE ADD-ONS[/B][CR][CR]Manage your installed Add-ons � Browse for and install Add-ons from xbmc.org[CR]Modify Add-on settings"
+msgstr "[B]CONFIGUREU ELS COMPLEMENTS[/B][CR][CR]Gestioneu els complements instal·lats · Cerqueu i instal·leu complements des de xbmc.org[CR]Modifiqueu els paràmetres dels complements"
+
+#: id:31409
+msgid "[B]CONFIGURE SERVICE SETTINGS[/B][CR][CR]Setup control of XBMC via UPnP and HTTP � Configure file sharing[CR]Enable Zeroconf � Configure AirPlay"
+msgstr ""
+
+#: id:31421
+msgid "Select your XBMC user Profile[CR]to login and continue"
+msgstr "Seleccioneu el vostre perfil d'usuari[CR]per iniciar la sessió i continuar"
+
+#: id:31900
+msgid "Weather Maps"
+msgstr "Mapes del temps"
+
+#: id:31901
+msgid "36 Hour Forecast"
+msgstr "Predicció a 36 hores"
+
+#: id:31902
+msgid "Hourly Forecast"
+msgstr "Predicció per hores"
+
+#: id:31903
+msgid "Weekend Forecast"
+msgstr "Predicció del cap de setmana"
+
+#: id:31904
+msgid "10 Day Forecast"
+msgstr "Predicció a 10 dies"
+
+#: id:31905
+msgid "Forecast"
+msgstr "Predicció"
+
+#: id:31906
+msgid "Maps & Video"
+msgstr "Mapes i vídeo"
+
+#: id:31907
+msgid "Video Forecast [COLOR=grey2](Fullscreen Playback)[/COLOR]"
+msgstr "Vídeo de la predicció [COLOR=grey2](Reproducció a pantalla completa)[/COLOR]"
+
+#: id:31908
+msgid "Chance of Precipitation"
+msgstr "Possibilitat de precipitació"
+
+#: id:31909
+msgid "Fetching forecast info..."
+msgstr "S'està obtenint la informació de la predicció..."
+

--- a/addons/skin.confluence/language/Chinese (Simple)/strings.po
+++ b/addons/skin.confluence/language/Chinese (Simple)/strings.po
@@ -1,0 +1,576 @@
+# Converted from xbmc strings.xml with xbmc-xml2po (by Team-XBMC)
+msgid ""
+msgstr ""
+"Project-Id-Version: xbmc.skin.confluence-FRODO_GIT953c09c336\n"
+"Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
+"POT-Creation-Date: 2012-04-09 18:03+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE\n"
+"Language: zh\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: id:31000
+msgid "Change Your"
+msgstr "修改您的"
+
+#: id:31001
+msgid "Love"
+msgstr "喜欢"
+
+#: id:31002
+msgid "Hate"
+msgstr "讨厌"
+
+#: id:31003
+msgid "Power Options"
+msgstr "电源选项"
+
+#: id:31004
+msgid "Working..."
+msgstr "工作中..."
+
+#: id:31005
+msgid "Hide Information"
+msgstr "隐藏信息"
+
+#: id:31006
+msgid "View Options"
+msgstr "视图选项"
+
+#: id:31007
+msgid "Plugins"
+msgstr "插件"
+
+#: id:31008
+msgid "Fullscreen"
+msgstr "全屏"
+
+#: id:31020
+msgctxt "Auto context with id 31020"
+msgid "Recently Added"
+msgstr "最新增加"
+
+#: id:31021
+msgid "Video - Files"
+msgstr "视频 - 文件"
+
+#: id:31022
+msgid "Music - Files"
+msgstr "音乐 - 文件"
+
+#: id:31023
+msgid "Playing"
+msgstr "播放"
+
+#: id:31024
+msgid "Page"
+msgstr "页"
+
+#: id:31025
+msgid "Items"
+msgstr "项"
+
+#: id:31026
+msgid "Misc Options"
+msgstr "其他选项"
+
+#: id:31027
+msgid "Location"
+msgstr "所在地"
+
+#: id:31028
+msgid "Poster Wrap"
+msgstr "海报卷动"
+
+#: id:31029
+msgid "Fanart"
+msgstr "同人画"
+
+#: id:31030
+msgid "Full list"
+msgstr "完整列表"
+
+#: id:31031
+msgid "Pic Thumbs"
+msgstr "图片缩略图"
+
+#: id:31032
+msgid "Image Wrap"
+msgstr "图片卷动"
+
+#: id:31033
+msgid "Info"
+msgstr "信息"
+
+#: id:31040
+msgid "Now Playing"
+msgstr "正在播放"
+
+#: id:31042
+msgid "PLAYING"
+msgstr "播放"
+
+#: id:31043
+msgid "PAUSED"
+msgstr "暂停"
+
+#: id:31044
+msgid "FAST FORWARD"
+msgstr "快进"
+
+#: id:31045
+msgid "REWIND"
+msgstr "回退"
+
+#: id:31046
+msgid "Audio Properties"
+msgstr "音频属性"
+
+#: id:31047
+msgid "Current Preset"
+msgstr "当前预设"
+
+#: id:31048
+msgid "Visualization Presets"
+msgstr "可视化效果设置"
+
+#: id:31049
+msgid "End Time"
+msgstr "结束时间"
+
+#: id:31050
+msgid "Sort: Ascending"
+msgstr "排序：升序"
+
+#: id:31051
+msgid "Sort: Descending"
+msgstr "排序：降序"
+
+#: id:31055
+msgid "Open playlist"
+msgstr "打开播放列表"
+
+#: id:31056
+msgid "Save playlist"
+msgstr "保存播放列表"
+
+#: id:31057
+msgid "Close playlist"
+msgstr "关闭播放列表"
+
+#: id:31058
+msgid "System music files"
+msgstr "系统音乐文件"
+
+#: id:31059
+msgid "Current playlist"
+msgstr "当前播放列表"
+
+#: id:31060
+msgid "This file is stacked, select the part you want to play from."
+msgstr "这是一个堆叠文件，请选择要播放的片段。"
+
+#: id:31061
+msgid "Current Selected"
+msgstr "当前选择"
+
+#: id:31101
+msgid "Home screen options"
+msgstr "主界面选项"
+
+#: id:31102
+msgid "Background"
+msgstr "背景"
+
+#: id:31103
+msgid "Show \"Paused\" in picture slide show"
+msgstr "图片幻灯片播放时显示“暂停”状态"
+
+#: id:31104
+msgid "Play Trailers in a window [COLOR=grey3](Video Information Dialog Only)[/COLOR]"
+msgstr "窗口播放预告片[COLOR=grey3]（仅在视频信息显示画面）[/COLOR]"
+
+#: id:31105
+msgid "\"Videos\" button always goes to video \"Files\""
+msgstr "主菜单“视频”进入视频“文件”模式"
+
+#: id:31106
+msgid "Miscellaneous options"
+msgstr "其他选项"
+
+#: id:31107
+msgid "Hide Flagging read from video filenames [COLOR=grey3](Blu-ray, HD-DVD)[/COLOR]"
+msgstr "隐藏视频文件名的媒体标识[COLOR=grey3]（Blu-ray, HD-DVD）[/COLOR]"
+
+#: id:31108
+msgid "Hide Main Menu Buttons"
+msgstr "隐藏主菜单按钮"
+
+#: id:31109
+msgid "Media backgrounds"
+msgstr "媒体背景"
+
+#: id:31110
+msgid "Edit Background for Media Type"
+msgstr "编辑媒体背景"
+
+#: id:31111
+msgid "Hide"
+msgstr "隐藏"
+
+#: id:31112
+msgid "Options"
+msgstr "选项"
+
+#: id:31113
+msgid "Single Image"
+msgstr "单个图片"
+
+#: id:31114
+msgid "Multi Image"
+msgstr "多个图片"
+
+#: id:31115
+msgid "Customizer"
+msgstr "自定义"
+
+#: id:31117
+msgid "Show Recently added Videos"
+msgstr "显示最新加入视频"
+
+#: id:31118
+msgid "Home Page Programs Submenu"
+msgstr "主界面程序子菜单"
+
+#: id:31119
+msgid "Hide Background Fanart"
+msgstr "隐藏同人画背景"
+
+#: id:31120
+msgid "BUTTON LABEL"
+msgstr "按钮标签"
+
+#: id:31122
+msgid "Weather Page"
+msgstr "天气页面"
+
+#: id:31123
+msgid "Use \"Posters\" instead of \"Banners\" for TV Shows"
+msgstr "剧集中以“海报”代替“宽幅图标”"
+
+#: id:31124
+msgid "Show Background \"Now Playing\" Video"
+msgstr "在背景显示“正在播放”视频"
+
+#: id:31125
+msgid "Show Background \"Now Playing\" Visualization"
+msgstr "在背景显示“正在播放”可视效果"
+
+#: id:31126
+msgid "Play TV theme songs in video library (TvTunes add-on)"
+msgstr "视频资料库模式播放电视主题曲（TvTunes扩展功能）"
+
+#: id:31127
+msgid "TvTunes"
+msgstr "TvTunes"
+
+#: id:31128
+msgid "Lyrics"
+msgstr "歌词"
+
+#: id:31132
+msgid "Lyrics Add-on"
+msgstr "歌词扩展功能"
+
+#: id:31133
+msgid "Subtitle Add-on"
+msgstr "字幕扩展功能"
+
+#: id:31134
+msgid "Home Page Videos Submenu"
+msgstr "主界面视频子菜单"
+
+#: id:31135
+msgid "Home Page Music Submenu"
+msgstr "主界面音乐子菜单"
+
+#: id:31136
+msgid "Home Page Pictures Submenu"
+msgstr "主界面图片子菜单"
+
+#: id:31140
+msgid "Music OSD"
+msgstr "音乐OSD"
+
+#: id:31141
+msgid "Video OSD"
+msgstr "视频OSD"
+
+#: id:31200
+msgid "Shortcuts"
+msgstr "快捷方式"
+
+#: id:31201
+msgid "Categories"
+msgstr "分类"
+
+#: id:31202
+msgid "Show Cast"
+msgstr "显示演员表"
+
+#: id:31203
+msgid "Choose Your Song"
+msgstr "选择歌曲"
+
+#: id:31204
+msgid "Section Links"
+msgstr "区块链接"
+
+#: id:31205
+msgid "Lyrics Source"
+msgstr "歌词来源"
+
+#: id:31300
+msgid "Current Temp"
+msgstr "当前温度"
+
+#: id:31301
+msgid "Last Updated"
+msgstr "最近修改"
+
+#: id:31302
+msgid "Menu"
+msgstr "菜单"
+
+#: id:31303
+msgid "Data provider"
+msgstr "数据来源"
+
+#: id:31304
+msgid "Picture"
+msgstr "图片"
+
+#: id:31305
+msgid "No Disc Media Detected"
+msgstr "未检测到光盘"
+
+#: id:31306
+msgid "Eject"
+msgstr "弹出"
+
+#: id:31307
+msgid "Hide Fanart"
+msgstr "隐藏同人画"
+
+#: id:31308
+msgid "Movie Details"
+msgstr "电影详细资料"
+
+#: id:31309
+msgid "Memory Used:"
+msgstr "己用内存："
+
+#: id:31310
+msgid "Track Number"
+msgstr "音轨号"
+
+#: id:31311
+msgid "Fanart image[CR][CR]Unavailable[CR][CR] Click button to set"
+msgstr "同人画图片[CR][CR]不可用[CR][CR]按键设置"
+
+#: id:31312
+msgid "Current Scraper"
+msgstr "当前刮削器"
+
+#: id:31313
+msgid "Choose a Scraper"
+msgstr "选择刮削器"
+
+#: id:31314
+msgid "Content Scanning Options"
+msgstr "内容扫描选项"
+
+#: id:31315
+msgid "Basic"
+msgstr "基本信息"
+
+#: id:31317
+msgid "Set Fanart Path"
+msgstr "设置同人画目录"
+
+#: id:31318
+msgid "Small Fanart"
+msgstr "小同人画"
+
+#: id:31319
+msgid "Selected Profile"
+msgstr "选择用户配置文件"
+
+#: id:31320
+msgid "Last Logged In"
+msgstr "最近登录"
+
+#: id:31321
+msgid "Karaoke Song Selector"
+msgstr "卡拉OK歌曲选择器"
+
+#: id:31322
+msgid "Aired"
+msgstr "首播"
+
+#: id:31323
+msgid "Latest Movies"
+msgstr "最新电影"
+
+#: id:31324
+msgid "Latest Episodes"
+msgstr "最新剧集"
+
+#: id:31325
+msgid "Playlist Options"
+msgstr "播放列表选项"
+
+#: id:31326
+msgid "Created"
+msgstr "创建"
+
+#: id:31327
+msgid "Resolution"
+msgstr "分辨率"
+
+#: id:31328
+msgctxt "Auto context with id 31328"
+msgid "Recently Added"
+msgstr "最新增加"
+
+#: id:31329
+msgid "[B]Timer set![/B] [COLOR=grey2] - System auto shutdown in[/COLOR]"
+msgstr "[B]时钟设置！[/B] [COLOR=grey2] - 系统自动关闭于[/COLOR]"
+
+#: id:31330
+msgid "Click button to play[CR][CR]Movie trailer"
+msgstr "点此按钮播放预告片"
+
+#: id:31331
+msgid "Album Details"
+msgstr "专辑详情"
+
+#: id:31351
+msgid "Pause"
+msgstr "暂停"
+
+#: id:31352
+msgid "Stop"
+msgstr "停止"
+
+#: id:31353
+msgid "Fast Forward"
+msgstr "快进"
+
+#: id:31354
+msgid "Rewind"
+msgstr "快退"
+
+#: id:31355
+msgid "Movie menu"
+msgstr "电影菜单"
+
+#: id:31356
+msgid "Download Subtitles"
+msgstr "下载字幕"
+
+#: id:31390
+msgid "Skin default"
+msgstr "皮肤默认"
+
+#: id:31391
+msgid "Skin default with no Caps"
+msgstr "皮肤默认（无Caps字体）"
+
+#: id:31392
+msgid "Arial based"
+msgstr "基于Arial字体"
+
+#: id:31400
+msgid "[B]CONFIGURE APPEARANCE SETTINGS[/B][CR][CR]Change the skin � Set language and region � Change file listing options[CR]Set up a screensaver"
+msgstr "[B]设置用户界面[/B][CR][CR]变换皮肤 · 设置语言和区域 · 修改文件列表参数 · 设置屏幕保护"
+
+#: id:31401
+msgid "[B]CONFIGURE VIDEO SETTINGS[/B][CR][CR]Manage your video library � Set video playback options � Change video listing options[CR]Set subtitle fonts"
+msgstr "[B]设置视频参数[/B][CR][CR]管理视频资料库 · 设置视频播放参数 · 修改视频列表参数 · 设置字幕字体"
+
+#: id:31402
+msgid "[B]CONFIGURE MUSIC SETTINGS[/B][CR][CR]Manage your music library � Set music playback options � Change music listing options[CR]Setup song submission � Set karaoke options"
+msgstr "[B]设置音乐参数[/B][CR][CR]管理音乐资料库 · 设置音乐播放参数 · 修改音乐列表参数 · 设置音乐提交 · 设置卡拉OK选项"
+
+#: id:31403
+msgid "[B]CONFIGURE PICTURE SETTINGS[/B][CR][CR]Set picture listing options � Configure slideshows"
+msgstr "[B]设置图片参数[/B][CR][CR]设置图片列表参数 · 设置幻灯片播放"
+
+#: id:31404
+msgid "[B]CONFIGURE WEATHER SETTINGS[/B][CR][CR]Set three cities to collect weather information"
+msgstr "[B]设置天气预报[/B][CR][CR]设置三个获取天气信息的城市"
+
+#: id:31406
+msgid "[B]CONFIGURE SYSTEM SETTINGS[/B][CR][CR]Setup and calibrate displays � Configure audio output � Setup remote controls[CR]Set power saving options � Enable debugging � Setup master lock"
+msgstr "[B]设置系统参数[/B][CR][CR]设置和校正显示器 · 设置音频输出 · 设置摇控器 · 设置节电参数 · 启用调试 · 设置管理员和锁定"
+
+#: id:31407
+msgid "[B]CONFIGURE SKIN SETTINGS[/B][CR][CR]Setup the Confluence skin � Add and remove home menu items[CR]Change skin backgrounds"
+msgstr "[B]设置皮肤参数[/B][CR][CR]设置Confluence皮肤 · 增加和删除主菜单项 · 修改皮肤背景"
+
+#: id:31408
+msgid "[B]CONFIGURE ADD-ONS[/B][CR][CR]Manage your installed Add-ons � Browse for and install Add-ons from xbmc.org[CR]Modify Add-on settings"
+msgstr "[B]设置扩展功能[/B][CR][CR]管理你安装的扩展功能 · 在xbmc.org浏览并安装扩展功能 · 修改扩展功能设置"
+
+#: id:31409
+msgid "[B]CONFIGURE SERVICE SETTINGS[/B][CR][CR]Setup control of XBMC via UPnP and HTTP � Configure file sharing[CR]Enable Zeroconf � Configure AirPlay"
+msgstr ""
+
+#: id:31421
+msgid "Select your XBMC user Profile[CR]to login and continue"
+msgstr "选择您的用户配置文件[CR]登录并继续"
+
+#: id:31900
+msgid "Weather Maps"
+msgstr "气象图"
+
+#: id:31901
+msgid "36 Hour Forecast"
+msgstr "36小时预报"
+
+#: id:31902
+msgid "Hourly Forecast"
+msgstr "每小时预报"
+
+#: id:31903
+msgid "Weekend Forecast"
+msgstr "一周预报"
+
+#: id:31904
+msgid "10 Day Forecast"
+msgstr "10日预报"
+
+#: id:31905
+msgid "Forecast"
+msgstr "天气预报"
+
+#: id:31906
+msgid "Maps & Video"
+msgstr "图像 & 视频"
+
+#: id:31907
+msgid "Video Forecast [COLOR=grey2](Fullscreen Playback)[/COLOR]"
+msgstr "视频预报 [COLOR=grey2]（全屏播放）[/COLOR]"
+
+#: id:31908
+msgid "Chance of Precipitation"
+msgstr "降雨概率"
+
+#: id:31909
+msgid "Fetching forecast info..."
+msgstr "获取天气信息..."
+

--- a/addons/skin.confluence/language/Chinese (Traditional)/strings.po
+++ b/addons/skin.confluence/language/Chinese (Traditional)/strings.po
@@ -1,0 +1,576 @@
+# Converted from xbmc strings.xml with xbmc-xml2po (by Team-XBMC)
+msgid ""
+msgstr ""
+"Project-Id-Version: xbmc.skin.confluence-FRODO_GIT953c09c336\n"
+"Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
+"POT-Creation-Date: 2012-04-09 18:03+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE\n"
+"Language: zh_CN\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: id:31000
+msgid "Change Your"
+msgstr "修改您的"
+
+#: id:31001
+msgid "Love"
+msgstr "喜歡"
+
+#: id:31002
+msgid "Hate"
+msgstr "討厭"
+
+#: id:31003
+msgid "Power Options"
+msgstr "電源選項"
+
+#: id:31004
+msgid "Working..."
+msgstr "工作中..."
+
+#: id:31005
+msgid "Hide Information"
+msgstr "隱藏資訊"
+
+#: id:31006
+msgid "View Options"
+msgstr "檢視選項"
+
+#: id:31007
+msgid "Plugins"
+msgstr "外掛"
+
+#: id:31008
+msgid "Fullscreen"
+msgstr "全螢幕"
+
+#: id:31020
+msgctxt "Auto context with id 31020"
+msgid "Recently Added"
+msgstr "最近新增"
+
+#: id:31021
+msgid "Video - Files"
+msgstr "視訊 - 檔案"
+
+#: id:31022
+msgid "Music - Files"
+msgstr "音樂 - 檔案"
+
+#: id:31023
+msgid "Playing"
+msgstr "正在播放"
+
+#: id:31024
+msgid "Page"
+msgstr "頁"
+
+#: id:31025
+msgid "Items"
+msgstr "個項目"
+
+#: id:31026
+msgid "Misc Options"
+msgstr "其他選項"
+
+#: id:31027
+msgid "Location"
+msgstr "位置"
+
+#: id:31028
+msgid "Poster Wrap"
+msgstr "海報捲動"
+
+#: id:31029
+msgid "Fanart"
+msgstr "劇照"
+
+#: id:31030
+msgid "Full list"
+msgstr "全部清單"
+
+#: id:31031
+msgid "Pic Thumbs"
+msgstr "圖片縮圖"
+
+#: id:31032
+msgid "Image Wrap"
+msgstr "圖片捲動"
+
+#: id:31033
+msgid "Info"
+msgstr "資訊"
+
+#: id:31040
+msgid "Now Playing"
+msgstr "正在播放"
+
+#: id:31042
+msgid "PLAYING"
+msgstr "正在播方"
+
+#: id:31043
+msgid "PAUSED"
+msgstr "暫停"
+
+#: id:31044
+msgid "FAST FORWARD"
+msgstr "快轉"
+
+#: id:31045
+msgid "REWIND"
+msgstr "倒轉"
+
+#: id:31046
+msgid "Audio Properties"
+msgstr "音效屬性"
+
+#: id:31047
+msgid "Current Preset"
+msgstr "目前設定"
+
+#: id:31048
+msgid "Visualization Presets"
+msgstr "視覺效果設定"
+
+#: id:31049
+msgid "End Time"
+msgstr "結束時間"
+
+#: id:31050
+msgid "Sort: Ascending"
+msgstr "排序：遞增"
+
+#: id:31051
+msgid "Sort: Descending"
+msgstr "排序：遞減"
+
+#: id:31055
+msgid "Open playlist"
+msgstr "開啟播放清單"
+
+#: id:31056
+msgid "Save playlist"
+msgstr "儲存播放清單"
+
+#: id:31057
+msgid "Close playlist"
+msgstr "關閉播放清單"
+
+#: id:31058
+msgid "System music files"
+msgstr "系統中的音樂檔案"
+
+#: id:31059
+msgid "Current playlist"
+msgstr "目前的播放清單"
+
+#: id:31060
+msgid "This file is stacked, select the part you want to play from."
+msgstr "這個檔案已堆疊，請選擇您要從哪個部分開始播放。"
+
+#: id:31061
+msgid "Current Selected"
+msgstr "目前的選擇"
+
+#: id:31101
+msgid "Home screen options"
+msgstr "主介面選項"
+
+#: id:31102
+msgid "Background"
+msgstr "背景"
+
+#: id:31103
+msgid "Show \"Paused\" in picture slide show"
+msgstr "在圖片幻燈片秀中顯示\"已暫停\"狀態"
+
+#: id:31104
+msgid "Play Trailers in a window [COLOR=grey3](Video Information Dialog Only)[/COLOR]"
+msgstr "在視窗中播放預告片[COLOR=grey3](只在視訊資訊對話框中)[/COLOR]"
+
+#: id:31105
+msgid "\"Videos\" button always goes to video \"Files\""
+msgstr "\"視訊\" 按鈕永遠連到視訊 \"檔案\""
+
+#: id:31106
+msgid "Miscellaneous options"
+msgstr "其他選項"
+
+#: id:31107
+msgid "Hide Flagging read from video filenames [COLOR=grey3](Blu-ray, HD-DVD)[/COLOR]"
+msgstr "隱藏視訊檔案名稱的媒體標示 [COLOR=grey3](Blu-ray, HD-DVD)[/COLOR]"
+
+#: id:31108
+msgid "Hide Main Menu Buttons"
+msgstr "隱藏主選單按鈕"
+
+#: id:31109
+msgid "Media backgrounds"
+msgstr "媒體背景"
+
+#: id:31110
+msgid "Edit Background for Media Type"
+msgstr "編輯媒體類型的背景"
+
+#: id:31111
+msgid "Hide"
+msgstr "隱藏"
+
+#: id:31112
+msgid "Options"
+msgstr "選項"
+
+#: id:31113
+msgid "Single Image"
+msgstr "單一圖片"
+
+#: id:31114
+msgid "Multi Image"
+msgstr "多張圖片"
+
+#: id:31115
+msgid "Customizer"
+msgstr "自訂"
+
+#: id:31117
+msgid "Show Recently added Videos"
+msgstr "顯示最近新增的視訊"
+
+#: id:31118
+msgid "Home Page Programs Submenu"
+msgstr "首頁程式子選單"
+
+#: id:31119
+msgid "Hide Background Fanart"
+msgstr "隱藏背景劇照"
+
+#: id:31120
+msgid "BUTTON LABEL"
+msgstr "按鈕標籤"
+
+#: id:31122
+msgid "Weather Page"
+msgstr "氣象頁面"
+
+#: id:31123
+msgid "Use \"Posters\" instead of \"Banners\" for TV Shows"
+msgstr "以電視節目的海報取代橫幅圖片"
+
+#: id:31124
+msgid "Show Background \"Now Playing\" Video"
+msgstr "在背景顯示正在播放的視訊"
+
+#: id:31125
+msgid "Show Background \"Now Playing\" Visualization"
+msgstr "在背景顯示正在播放的視覺效果"
+
+#: id:31126
+msgid "Play TV theme songs in video library (TvTunes add-on)"
+msgstr ""
+
+#: id:31127
+msgid "TvTunes"
+msgstr ""
+
+#: id:31128
+msgid "Lyrics"
+msgstr "歌詞"
+
+#: id:31132
+msgid "Lyrics Add-on"
+msgstr "歌詞附加元件"
+
+#: id:31133
+msgid "Subtitle Add-on"
+msgstr "字幕附加元件"
+
+#: id:31134
+msgid "Home Page Videos Submenu"
+msgstr "首頁影片子選單"
+
+#: id:31135
+msgid "Home Page Music Submenu"
+msgstr "首頁音樂子選單"
+
+#: id:31136
+msgid "Home Page Pictures Submenu"
+msgstr "首頁圖片子選單"
+
+#: id:31140
+msgid "Music OSD"
+msgstr "音樂播放工具列"
+
+#: id:31141
+msgid "Video OSD"
+msgstr "視訊播放工具列"
+
+#: id:31200
+msgid "Shortcuts"
+msgstr "捷徑"
+
+#: id:31201
+msgid "Categories"
+msgstr "分類"
+
+#: id:31202
+msgid "Show Cast"
+msgstr "顯示演員"
+
+#: id:31203
+msgid "Choose Your Song"
+msgstr "選擇您的歌曲"
+
+#: id:31204
+msgid "Section Links"
+msgstr "段落連結"
+
+#: id:31205
+msgid "Lyrics Source"
+msgstr "歌詞來源"
+
+#: id:31300
+msgid "Current Temp"
+msgstr "現在溫度"
+
+#: id:31301
+msgid "Last Updated"
+msgstr "最後更新"
+
+#: id:31302
+msgid "Menu"
+msgstr "選單"
+
+#: id:31303
+msgid "Data provider"
+msgstr ""
+
+#: id:31304
+msgid "Picture"
+msgstr "圖片"
+
+#: id:31305
+msgid "No Disc Media Detected"
+msgstr "沒有偵測到光碟媒體"
+
+#: id:31306
+msgid "Eject"
+msgstr "退出"
+
+#: id:31307
+msgid "Hide Fanart"
+msgstr "隱藏劇照"
+
+#: id:31308
+msgid "Movie Details"
+msgstr "電影詳細資訊"
+
+#: id:31309
+msgid "Memory Used:"
+msgstr "已使用記憶體："
+
+#: id:31310
+msgid "Track Number"
+msgstr "音軌編號"
+
+#: id:31311
+msgid "Fanart image[CR][CR]Unavailable[CR][CR] Click button to set"
+msgstr "無法取得[CR][CR]劇情照片[CR][CR] 請點擊按鈕來設定"
+
+#: id:31312
+msgid "Current Scraper"
+msgstr "目前的站台"
+
+#: id:31313
+msgid "Choose a Scraper"
+msgstr "選擇一個站台"
+
+#: id:31314
+msgid "Content Scanning Options"
+msgstr "內容掃描選項"
+
+#: id:31315
+msgid "Basic"
+msgstr "基本"
+
+#: id:31317
+msgid "Set Fanart Path"
+msgstr "設定劇照路徑"
+
+#: id:31318
+msgid "Small Fanart"
+msgstr "小劇照"
+
+#: id:31319
+msgid "Selected Profile"
+msgstr "選擇的設定檔"
+
+#: id:31320
+msgid "Last Logged In"
+msgstr "上次登入在"
+
+#: id:31321
+msgid "Karaoke Song Selector"
+msgstr "卡拉OK歌曲選擇器"
+
+#: id:31322
+msgid "Aired"
+msgstr "首播"
+
+#: id:31323
+msgid "Latest Movies"
+msgstr "最新電影"
+
+#: id:31324
+msgid "Latest Episodes"
+msgstr "最新劇集"
+
+#: id:31325
+msgid "Playlist Options"
+msgstr "播放清單選項"
+
+#: id:31326
+msgid "Created"
+msgstr "已建立"
+
+#: id:31327
+msgid "Resolution"
+msgstr "解析度"
+
+#: id:31328
+msgctxt "Auto context with id 31328"
+msgid "Recently Added"
+msgstr "最近新增"
+
+#: id:31329
+msgid "[B]Timer set![/B] [COLOR=grey2] - System auto shutdown in[/COLOR]"
+msgstr "[B]計時器啟動！[/B] [COLOR=grey2] - 系統將自動關機於：[/COLOR]"
+
+#: id:31330
+msgid "Click button to play[CR][CR]Movie trailer"
+msgstr "點擊按鈕播放[CR][CR]電影預告片"
+
+#: id:31331
+msgid "Album Details"
+msgstr "專輯詳細資訊"
+
+#: id:31351
+msgid "Pause"
+msgstr "暫停"
+
+#: id:31352
+msgid "Stop"
+msgstr "停止"
+
+#: id:31353
+msgid "Fast Forward"
+msgstr "快轉"
+
+#: id:31354
+msgid "Rewind"
+msgstr "倒轉"
+
+#: id:31355
+msgid "Movie menu"
+msgstr "電影選單"
+
+#: id:31356
+msgid "Download Subtitles"
+msgstr "下載字幕"
+
+#: id:31390
+msgid "Skin default"
+msgstr "主題預設"
+
+#: id:31391
+msgid "Skin default with no Caps"
+msgstr ""
+
+#: id:31392
+msgid "Arial based"
+msgstr ""
+
+#: id:31400
+msgid "[B]CONFIGURE APPEARANCE SETTINGS[/B][CR][CR]Change the skin � Set language and region � Change file listing options[CR]Set up a screensaver"
+msgstr "[B]設定介面外觀[/B][CR][CR]修改佈景主題 · 選擇語言和地區 · 修改檔案清單選項[CR]設定螢幕保護程式"
+
+#: id:31401
+msgid "[B]CONFIGURE VIDEO SETTINGS[/B][CR][CR]Manage your video library � Set video playback options � Change video listing options[CR]Set subtitle fonts"
+msgstr "[B]設定視訊參數[/B][CR][CR]管理您的音樂資料庫 · 設定視訊播放選項 · 修改視訊清單選項[CR]設定字幕字型"
+
+#: id:31402
+msgid "[B]CONFIGURE MUSIC SETTINGS[/B][CR][CR]Manage your music library � Set music playback options � Change music listing options[CR]Setup song submission � Set karaoke options"
+msgstr "[B]設定音樂參數[/B][CR][CR]管理您的音樂資料庫 · 設定音樂播放選項 · 修改音樂清單選項[CR]設定歌曲提交 · 設定卡拉OK選項"
+
+#: id:31403
+msgid "[B]CONFIGURE PICTURE SETTINGS[/B][CR][CR]Set picture listing options � Configure slideshows"
+msgstr "[B]設定圖片參數[/B][CR][CR]設定圖片清單選項 · 設定幻燈片秀"
+
+#: id:31404
+msgid "[B]CONFIGURE WEATHER SETTINGS[/B][CR][CR]Set three cities to collect weather information"
+msgstr "[B]設定氣象參數[/B][CR][CR]設定三個要收集氣象資料的城市"
+
+#: id:31406
+msgid "[B]CONFIGURE SYSTEM SETTINGS[/B][CR][CR]Setup and calibrate displays � Configure audio output � Setup remote controls[CR]Set power saving options � Enable debugging � Setup master lock"
+msgstr "[B]設定系統參數[/B][CR][CR]設定和校正顯示輸出 · 設定音效輸出 · 設定遙控器[CR]設定節能選項 · 啟用除錯 · 設定鎖定密碼"
+
+#: id:31407
+msgid "[B]CONFIGURE SKIN SETTINGS[/B][CR][CR]Setup the Confluence skin � Add and remove home menu items[CR]Change skin backgrounds"
+msgstr "[B]設定佈景主題[/B][CR][CR]設定 Confluence 佈景主題 · 新增或移除首頁選單項目[CR]修改佈景主題背景"
+
+#: id:31408
+msgid "[B]CONFIGURE ADD-ONS[/B][CR][CR]Manage your installed Add-ons � Browse for and install Add-ons from xbmc.org[CR]Modify Add-on settings"
+msgstr "[B]設定附加元件[/B][CR][CR]管理已安裝的附加元件 · 從 xbmc.org 瀏覽並安裝附加元件[CR]修改附加元件設定"
+
+#: id:31409
+msgid "[B]CONFIGURE SERVICE SETTINGS[/B][CR][CR]Setup control of XBMC via UPnP and HTTP � Configure file sharing[CR]Enable Zeroconf � Configure AirPlay"
+msgstr ""
+
+#: id:31421
+msgid "Select your XBMC user Profile[CR]to login and continue"
+msgstr "選擇您的 XBMC 使用者設定檔[CR]登入並繼續"
+
+#: id:31900
+msgid "Weather Maps"
+msgstr "天氣地圖"
+
+#: id:31901
+msgid "36 Hour Forecast"
+msgstr "36小時預報"
+
+#: id:31902
+msgid "Hourly Forecast"
+msgstr "每小時預報"
+
+#: id:31903
+msgid "Weekend Forecast"
+msgstr "一週預報"
+
+#: id:31904
+msgid "10 Day Forecast"
+msgstr "10天預報"
+
+#: id:31905
+msgid "Forecast"
+msgstr "預報"
+
+#: id:31906
+msgid "Maps & Video"
+msgstr "地圖 & 影片"
+
+#: id:31907
+msgid "Video Forecast [COLOR=grey2](Fullscreen Playback)[/COLOR]"
+msgstr "影片預報 [COLOR=grey2]〈全螢幕播放〉[/COLOR]"
+
+#: id:31908
+msgid "Chance of Precipitation"
+msgstr "降雨機率"
+
+#: id:31909
+msgid "Fetching forecast info..."
+msgstr "正在擷取預報資訊..."
+

--- a/addons/skin.confluence/language/Czech/strings.po
+++ b/addons/skin.confluence/language/Czech/strings.po
@@ -1,0 +1,576 @@
+# Converted from xbmc strings.xml with xbmc-xml2po (by Team-XBMC)
+msgid ""
+msgstr ""
+"Project-Id-Version: xbmc.skin.confluence-FRODO_GIT953c09c336\n"
+"Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
+"POT-Creation-Date: 2012-04-09 18:03+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE\n"
+"Language: cs\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: id:31000
+msgid "Change Your"
+msgstr "Změnit"
+
+#: id:31001
+msgid "Love"
+msgstr "Milovat"
+
+#: id:31002
+msgid "Hate"
+msgstr "Nesnášet"
+
+#: id:31003
+msgid "Power Options"
+msgstr "Napájení"
+
+#: id:31004
+msgid "Working..."
+msgstr "Pracuji..."
+
+#: id:31005
+msgid "Hide Information"
+msgstr "Skrýt Info"
+
+#: id:31006
+msgid "View Options"
+msgstr "Zobrazit možnosti"
+
+#: id:31007
+msgid "Plugins"
+msgstr "Pluginy"
+
+#: id:31008
+msgid "Fullscreen"
+msgstr "Celá obrazovka"
+
+#: id:31020
+msgctxt "Auto context with id 31020"
+msgid "Recently Added"
+msgstr "Nejnovější položky"
+
+#: id:31021
+msgid "Video - Files"
+msgstr "Video - Soubory"
+
+#: id:31022
+msgid "Music - Files"
+msgstr "Hudba - Soubory"
+
+#: id:31023
+msgid "Playing"
+msgstr "Přehrává se"
+
+#: id:31024
+msgid "Page"
+msgstr "Strana"
+
+#: id:31025
+msgid "Items"
+msgstr "Položek"
+
+#: id:31026
+msgid "Misc Options"
+msgstr "Další možnosti"
+
+#: id:31027
+msgid "Location"
+msgstr "Umístění"
+
+#: id:31028
+msgid "Poster Wrap"
+msgstr "Obaly"
+
+#: id:31029
+msgid "Fanart"
+msgstr "Fanart"
+
+#: id:31030
+msgid "Full list"
+msgstr "Seznam"
+
+#: id:31031
+msgid "Pic Thumbs"
+msgstr "Náhledy"
+
+#: id:31032
+msgid "Image Wrap"
+msgstr "Obrázky"
+
+#: id:31033
+msgid "Info"
+msgstr "Info"
+
+#: id:31040
+msgid "Now Playing"
+msgstr "Přehrává se"
+
+#: id:31042
+msgid "PLAYING"
+msgstr "PŘEHRÁVÁ SE"
+
+#: id:31043
+msgid "PAUSED"
+msgstr "POZASTAVENO"
+
+#: id:31044
+msgid "FAST FORWARD"
+msgstr "PŘETÁČÍ SE VPŘED"
+
+#: id:31045
+msgid "REWIND"
+msgstr "PŘETÁČÍ SE ZPĚT"
+
+#: id:31046
+msgid "Audio Properties"
+msgstr "Vlastnosti zvuku"
+
+#: id:31047
+msgid "Current Preset"
+msgstr "Aktuální předvolba"
+
+#: id:31048
+msgid "Visualization Presets"
+msgstr "Předvolby vizualizace"
+
+#: id:31049
+msgid "End Time"
+msgstr "Čas ukončení"
+
+#: id:31050
+msgid "Sort: Ascending"
+msgstr "Seřadit: vzestupně"
+
+#: id:31051
+msgid "Sort: Descending"
+msgstr "Seřadit: sestupně"
+
+#: id:31055
+msgid "Open playlist"
+msgstr "Otevřít seznam stop"
+
+#: id:31056
+msgid "Save playlist"
+msgstr "Uložit seznam stop"
+
+#: id:31057
+msgid "Close playlist"
+msgstr "Zavřít seznam stop"
+
+#: id:31058
+msgid "System music files"
+msgstr "Hudební soubory systému"
+
+#: id:31059
+msgid "Current playlist"
+msgstr "Aktuální seznam stop"
+
+#: id:31060
+msgid "This file is stacked, select the part you want to play from."
+msgstr "Tento soubor se skládá z více částí. Vyberte tu, od které chcete spustit přehrávání."
+
+#: id:31061
+msgid "Current Selected"
+msgstr "Aktuálně vybraný"
+
+#: id:31101
+msgid "Home screen options"
+msgstr "Informace na Úvodní obrazovce"
+
+#: id:31102
+msgid "Background"
+msgstr "Pozadí"
+
+#: id:31103
+msgid "Show \"Paused\" in picture slide show"
+msgstr "Zobrazovat \"Pozastaveno\" při prezentaci obrázků"
+
+#: id:31104
+msgid "Play Trailers in a window [COLOR=grey3](Video Information Dialog Only)[/COLOR]"
+msgstr "Přehrávat upoutávky v okně [COLOR=grey3](pouze z okna Informace o videu)[/COLOR]"
+
+#: id:31105
+msgid "\"Videos\" button always goes to video \"Files\""
+msgstr "V nabídce \"Video\" vždy zobrazit \"Soubory\""
+
+#: id:31106
+msgid "Miscellaneous options"
+msgstr "Různé"
+
+#: id:31107
+msgid "Hide Flagging read from video filenames [COLOR=grey3](Blu-ray, HD-DVD)[/COLOR]"
+msgstr "Nezobrazovat ikony zdroje videí [COLOR=grey3](Blu-ray, HD-DVD)[/COLOR]"
+
+#: id:31108
+msgid "Hide Main Menu Buttons"
+msgstr "Zobrazení sekcí úvodní obrazovky"
+
+#: id:31109
+msgid "Media backgrounds"
+msgstr "Pozadí úvodní obrazovky"
+
+#: id:31110
+msgid "Edit Background for Media Type"
+msgstr "Změnit pozadí úvodní obrazovky - sekce"
+
+#: id:31111
+msgid "Hide"
+msgstr "Skrýt"
+
+#: id:31112
+msgid "Options"
+msgstr "Možnosti"
+
+#: id:31113
+msgid "Single Image"
+msgstr "Jeden obrázek"
+
+#: id:31114
+msgid "Multi Image"
+msgstr "Více obrázků"
+
+#: id:31115
+msgid "Customizer"
+msgstr "Přizpůsobení"
+
+#: id:31117
+msgid "Show Recently added Videos"
+msgstr "Zobrazovat Nejnovější filmy a epizody"
+
+#: id:31118
+msgid "Home Page Programs Submenu"
+msgstr "Úvodní obrazovka - nabídka Programy"
+
+#: id:31119
+msgid "Hide Background Fanart"
+msgstr "Skrýt Fanart na pozadí"
+
+#: id:31120
+msgid "BUTTON LABEL"
+msgstr "NÁZEV POLOŽKY"
+
+#: id:31122
+msgid "Weather Page"
+msgstr "Počasí"
+
+#: id:31123
+msgid "Use \"Posters\" instead of \"Banners\" for TV Shows"
+msgstr "Použít u TV seriálů klasické náhledy místo bannerů"
+
+#: id:31124
+msgid "Show Background \"Now Playing\" Video"
+msgstr "Zobrazovat na pozadí právě přehrávané video"
+
+#: id:31125
+msgid "Show Background \"Now Playing\" Visualization"
+msgstr "Zobrazovat na pozadí vizualizaci"
+
+#: id:31126
+msgid "Play TV theme songs in video library (TvTunes add-on)"
+msgstr "Přehrát znělky v knihovně videí (doplněk TvTunes)"
+
+#: id:31127
+msgid "TvTunes"
+msgstr "TvTunes"
+
+#: id:31128
+msgid "Lyrics"
+msgstr "Texty skladeb"
+
+#: id:31132
+msgid "Lyrics Add-on"
+msgstr "Doplněk Texty skladeb"
+
+#: id:31133
+msgid "Subtitle Add-on"
+msgstr "Doplněk Titulky"
+
+#: id:31134
+msgid "Home Page Videos Submenu"
+msgstr "Úvodní strana - podmenu Videa"
+
+#: id:31135
+msgid "Home Page Music Submenu"
+msgstr "Úvodní strana - podmenu Hudba"
+
+#: id:31136
+msgid "Home Page Pictures Submenu"
+msgstr "Úvodní strana - podmenu Obrázky"
+
+#: id:31140
+msgid "Music OSD"
+msgstr "Hudební OSD"
+
+#: id:31141
+msgid "Video OSD"
+msgstr "Video OSD"
+
+#: id:31200
+msgid "Shortcuts"
+msgstr "Zástupci"
+
+#: id:31201
+msgid "Categories"
+msgstr "Kategorie"
+
+#: id:31202
+msgid "Show Cast"
+msgstr "Zobrazovat obsazení"
+
+#: id:31203
+msgid "Choose Your Song"
+msgstr "Vyberte vaši skladbu"
+
+#: id:31204
+msgid "Section Links"
+msgstr "Odkazy sekcí"
+
+#: id:31205
+msgid "Lyrics Source"
+msgstr "Zdroj textu skladeb"
+
+#: id:31300
+msgid "Current Temp"
+msgstr "Aktuální počasí"
+
+#: id:31301
+msgid "Last Updated"
+msgstr "Naposledy aktualizováno"
+
+#: id:31302
+msgid "Menu"
+msgstr "Menu"
+
+#: id:31303
+msgid "Data provider"
+msgstr "Poskytovatel dat"
+
+#: id:31304
+msgid "Picture"
+msgstr "Obrázky"
+
+#: id:31305
+msgid "No Disc Media Detected"
+msgstr "Není vložen žádný optický disk"
+
+#: id:31306
+msgid "Eject"
+msgstr "Vysunout"
+
+#: id:31307
+msgid "Hide Fanart"
+msgstr "Skrýt Fanart"
+
+#: id:31308
+msgid "Movie Details"
+msgstr "Detaily o filmu"
+
+#: id:31309
+msgid "Memory Used:"
+msgstr "Využitá paměť:"
+
+#: id:31310
+msgid "Track Number"
+msgstr "Číslo stopy"
+
+#: id:31311
+msgid "Fanart image[CR][CR]Unavailable[CR][CR] Click button to set"
+msgstr "Fanart[CR][CR]není k dispozici[CR][CR] Nastavte ho stisknutím tlačítka"
+
+#: id:31312
+msgid "Current Scraper"
+msgstr "Současný stahovač"
+
+#: id:31313
+msgid "Choose a Scraper"
+msgstr "Změnit stahovač"
+
+#: id:31314
+msgid "Content Scanning Options"
+msgstr "Možnosti vyhledávání obsahu"
+
+#: id:31315
+msgid "Basic"
+msgstr "Základní"
+
+#: id:31317
+msgid "Set Fanart Path"
+msgstr "Umístění Fanartu"
+
+#: id:31318
+msgid "Small Fanart"
+msgstr "Malý Fanart"
+
+#: id:31319
+msgid "Selected Profile"
+msgstr "Vybraný profil"
+
+#: id:31320
+msgid "Last Logged In"
+msgstr "Naposledy přihlášen"
+
+#: id:31321
+msgid "Karaoke Song Selector"
+msgstr "Výběr karaoke skladby"
+
+#: id:31322
+msgid "Aired"
+msgstr "Odvysíláno"
+
+#: id:31323
+msgid "Latest Movies"
+msgstr "Nejnovější filmy"
+
+#: id:31324
+msgid "Latest Episodes"
+msgstr "Nejnovější epizody"
+
+#: id:31325
+msgid "Playlist Options"
+msgstr "Možnosti seznamu stop"
+
+#: id:31326
+msgid "Created"
+msgstr "Vytvořeno"
+
+#: id:31327
+msgid "Resolution"
+msgstr "Rozlišení"
+
+#: id:31328
+msgctxt "Auto context with id 31328"
+msgid "Recently Added"
+msgstr "Nejnovější položky"
+
+#: id:31329
+msgid "[B]Timer set![/B] [COLOR=grey2] - System auto shutdown in[/COLOR]"
+msgstr "[B]Časovač byl nastaven![/B] [COLOR=grey2] - Systém se automaticky vypne za[/COLOR]"
+
+#: id:31330
+msgid "Click button to play[CR][CR]Movie trailer"
+msgstr "Pro přehrání upoutávky[CR][CR]stiskněte tlačítko"
+
+#: id:31331
+msgid "Album Details"
+msgstr "Detaily o albu"
+
+#: id:31351
+msgid "Pause"
+msgstr "Pozastavit"
+
+#: id:31352
+msgid "Stop"
+msgstr "Zastavit"
+
+#: id:31353
+msgid "Fast Forward"
+msgstr "Přetočit vpřed"
+
+#: id:31354
+msgid "Rewind"
+msgstr "Přetočit zpět"
+
+#: id:31355
+msgid "Movie menu"
+msgstr "Nabídka filmu"
+
+#: id:31356
+msgid "Download Subtitles"
+msgstr "Stáhnout titulky"
+
+#: id:31390
+msgid "Skin default"
+msgstr "Výchozí vzhled"
+
+#: id:31391
+msgid "Skin default with no Caps"
+msgstr "Výchozí vzhled bez velkých písmen"
+
+#: id:31392
+msgid "Arial based"
+msgstr "Písmo Arial"
+
+#: id:31400
+msgid "[B]CONFIGURE APPEARANCE SETTINGS[/B][CR][CR]Change the skin � Set language and region � Change file listing options[CR]Set up a screensaver"
+msgstr "[B]MOŽNOSTI PROSTŘEDÍ[/B][CR][CR]Změna vzhledu · Výběr jazyka a oblasti · Možnosti zobrazení souborů[CR]Nastavení spořiče obrazovky"
+
+#: id:31401
+msgid "[B]CONFIGURE VIDEO SETTINGS[/B][CR][CR]Manage your video library � Set video playback options � Change video listing options[CR]Set subtitle fonts"
+msgstr "[B]MOŽNOSTI VIDEA[/B][CR][CR]Správa knihovny videí · Možnosti přehrávání videa · Možnosti zobrazení video souborů[CR]Nastavení fontu titulků"
+
+#: id:31402
+msgid "[B]CONFIGURE MUSIC SETTINGS[/B][CR][CR]Manage your music library � Set music playback options � Change music listing options[CR]Setup song submission � Set karaoke options"
+msgstr "[B]MOŽNOSTI HUDBY[/B][CR][CR]Správa knihovny hudby · Možnosti přehrávání hudby · Možnosti zobrazení hudeb. souborů[CR]Služby pro odesílání informací o přehrávaných skladbách · Nastavení karaoke"
+
+#: id:31403
+msgid "[B]CONFIGURE PICTURE SETTINGS[/B][CR][CR]Set picture listing options � Configure slideshows"
+msgstr "[B]MOŽNOSTI OBRÁZKŮ[/B][CR][CR]Možnosti zobrazení obrázků · Konfigurace prezentace"
+
+#: id:31404
+msgid "[B]CONFIGURE WEATHER SETTINGS[/B][CR][CR]Set three cities to collect weather information"
+msgstr "[B]MOŽNOSTI POČASÍ[/B][CR][CR]Nastavení oblastí pro předpověď počasí"
+
+#: id:31406
+msgid "[B]CONFIGURE SYSTEM SETTINGS[/B][CR][CR]Setup and calibrate displays � Configure audio output � Setup remote controls[CR]Set power saving options � Enable debugging � Setup master lock"
+msgstr "[B]MOŽNOSTI SYSTÉMU[/B][CR][CR]Nastavení obrazovky · Konfigurace výstupu zvuku · Nastavení dálkového ovládání[CR]Možnosti úsporného režimu · Ukládání informací o ladění · Rodičovský zámek"
+
+#: id:31407
+msgid "[B]CONFIGURE SKIN SETTINGS[/B][CR][CR]Setup the Confluence skin � Add and remove home menu items[CR]Change skin backgrounds"
+msgstr "[B]MOŽNOSTI VZHLEDU[/B][CR][CR]Přizpůsobení vzhledu Confluence · Správa sekcí na úvodní obrazovce[CR]Nastavení pozadí vzhledu"
+
+#: id:31408
+msgid "[B]CONFIGURE ADD-ONS[/B][CR][CR]Manage your installed Add-ons � Browse for and install Add-ons from xbmc.org[CR]Modify Add-on settings"
+msgstr "[B]MOŽNOSTI DOPLŇKŮ[/B][CR][CR]Správa nainstalovaných doplňků · Vyhledávání a instalace doplňků z xbmc.org[CR]Nastavení doplňků"
+
+#: id:31409
+msgid "[B]CONFIGURE SERVICE SETTINGS[/B][CR][CR]Setup control of XBMC via UPnP and HTTP � Configure file sharing[CR]Enable Zeroconf � Configure AirPlay"
+msgstr ""
+
+#: id:31421
+msgid "Select your XBMC user Profile[CR]to login and continue"
+msgstr "Přihlášení uživatele[CR]Pokračujte výběrem profilu"
+
+#: id:31900
+msgid "Weather Maps"
+msgstr "Mapy počasí"
+
+#: id:31901
+msgid "36 Hour Forecast"
+msgstr "Předpověď na 36 hodin"
+
+#: id:31902
+msgid "Hourly Forecast"
+msgstr "Hodinová předpověď"
+
+#: id:31903
+msgid "Weekend Forecast"
+msgstr "Předpověď na víkend"
+
+#: id:31904
+msgid "10 Day Forecast"
+msgstr "Předpověď na 10 dní"
+
+#: id:31905
+msgid "Forecast"
+msgstr "Předpověď"
+
+#: id:31906
+msgid "Maps & Video"
+msgstr "Mapy a Video"
+
+#: id:31907
+msgid "Video Forecast [COLOR=grey2](Fullscreen Playback)[/COLOR]"
+msgstr "Video předpověď [COLOR=grey2](Přehrávání na celé obrazovce)[/COLOR]"
+
+#: id:31908
+msgid "Chance of Precipitation"
+msgstr "Pravděpodobnost srážek"
+
+#: id:31909
+msgid "Fetching forecast info..."
+msgstr "Načítání informací o předpovědi..."
+

--- a/addons/skin.confluence/language/Danish/strings.po
+++ b/addons/skin.confluence/language/Danish/strings.po
@@ -1,0 +1,576 @@
+# Converted from xbmc strings.xml with xbmc-xml2po (by Team-XBMC)
+msgid ""
+msgstr ""
+"Project-Id-Version: xbmc.skin.confluence-FRODO_GIT953c09c336\n"
+"Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
+"POT-Creation-Date: 2012-04-09 18:03+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE\n"
+"Language: da\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: id:31000
+msgid "Change Your"
+msgstr "Ændr din"
+
+#: id:31001
+msgid "Love"
+msgstr "Elsker"
+
+#: id:31002
+msgid "Hate"
+msgstr "Hader"
+
+#: id:31003
+msgid "Power Options"
+msgstr "Strømstyring"
+
+#: id:31004
+msgid "Working..."
+msgstr ""
+
+#: id:31005
+msgid "Hide Information"
+msgstr ""
+
+#: id:31006
+msgid "View Options"
+msgstr ""
+
+#: id:31007
+msgid "Plugins"
+msgstr "Plugins"
+
+#: id:31008
+msgid "Fullscreen"
+msgstr ""
+
+#: id:31020
+msgctxt "Auto context with id 31020"
+msgid "Recently Added"
+msgstr "Nyligt tilføjet"
+
+#: id:31021
+msgid "Video - Files"
+msgstr "Video - Filer"
+
+#: id:31022
+msgid "Music - Files"
+msgstr "Musik - Filer"
+
+#: id:31023
+msgid "Playing"
+msgstr "Afspiller"
+
+#: id:31024
+msgid "Page"
+msgstr "Side"
+
+#: id:31025
+msgid "Items"
+msgstr "Objekter"
+
+#: id:31026
+msgid "Misc Options"
+msgstr "Div. indstillinger"
+
+#: id:31027
+msgid "Location"
+msgstr "Placering"
+
+#: id:31028
+msgid "Poster Wrap"
+msgstr "Plakatvæg"
+
+#: id:31029
+msgid "Fanart"
+msgstr "Fankunst"
+
+#: id:31030
+msgid "Full list"
+msgstr "Komplet liste"
+
+#: id:31031
+msgid "Pic Thumbs"
+msgstr "Billedeikoner"
+
+#: id:31032
+msgid "Image Wrap"
+msgstr "Billedevæg"
+
+#: id:31033
+msgid "Info"
+msgstr ""
+
+#: id:31040
+msgid "Now Playing"
+msgstr "Spiller nu"
+
+#: id:31042
+msgid "PLAYING"
+msgstr "AFSPILLER"
+
+#: id:31043
+msgid "PAUSED"
+msgstr "PAUSE"
+
+#: id:31044
+msgid "FAST FORWARD"
+msgstr "SPOL FREM"
+
+#: id:31045
+msgid "REWIND"
+msgstr "SPOL TILBAGE"
+
+#: id:31046
+msgid "Audio Properties"
+msgstr "Lydegenskaber"
+
+#: id:31047
+msgid "Current Preset"
+msgstr "Nuværende standard"
+
+#: id:31048
+msgid "Visualization Presets"
+msgstr "Standard til visualisering"
+
+#: id:31049
+msgid "End Time"
+msgstr "Sluttid"
+
+#: id:31050
+msgid "Sort: Ascending"
+msgstr ""
+
+#: id:31051
+msgid "Sort: Descending"
+msgstr ""
+
+#: id:31055
+msgid "Open playlist"
+msgstr "Åbn afspilningsliste"
+
+#: id:31056
+msgid "Save playlist"
+msgstr "Gem afspilningsliste"
+
+#: id:31057
+msgid "Close playlist"
+msgstr "Luk afspilningsliste"
+
+#: id:31058
+msgid "System music files"
+msgstr "Musikfiler til systemet"
+
+#: id:31059
+msgid "Current playlist"
+msgstr "Nuværende afspilningsliste"
+
+#: id:31060
+msgid "This file is stacked, select the part you want to play from."
+msgstr "Denne fil er stakket. Vælg den del du vil afspille fra."
+
+#: id:31061
+msgid "Current Selected"
+msgstr ""
+
+#: id:31101
+msgid "Home screen options"
+msgstr "Indstillinger til hovedsiden"
+
+#: id:31102
+msgid "Background"
+msgstr "Baggrund"
+
+#: id:31103
+msgid "Show \"Paused\" in picture slide show"
+msgstr "Vis \"PAUSE\" i billedserier"
+
+#: id:31104
+msgid "Play Trailers in a window [COLOR=grey3](Video Information Dialog Only)[/COLOR]"
+msgstr ""
+
+#: id:31105
+msgid "\"Videos\" button always goes to video \"Files\""
+msgstr ""
+
+#: id:31106
+msgid "Miscellaneous options"
+msgstr "Diverse indstillinger"
+
+#: id:31107
+msgid "Hide Flagging read from video filenames [COLOR=grey3](Blu-ray, HD-DVD)[/COLOR]"
+msgstr ""
+
+#: id:31108
+msgid "Hide Main Menu Buttons"
+msgstr "Skjul hovedsideknapper"
+
+#: id:31109
+msgid "Media backgrounds"
+msgstr "Baggrunde til hovedsiden"
+
+#: id:31110
+msgid "Edit Background for Media Type"
+msgstr "Skift baggrund på hjem-knappen"
+
+#: id:31111
+msgid "Hide"
+msgstr "Skjul"
+
+#: id:31112
+msgid "Options"
+msgstr "Indstillinger"
+
+#: id:31113
+msgid "Single Image"
+msgstr "Enkelt billede"
+
+#: id:31114
+msgid "Multi Image"
+msgstr "Flere billeder"
+
+#: id:31115
+msgid "Customizer"
+msgstr "Tilpasningsprogram"
+
+#: id:31117
+msgid "Show Recently added Videos"
+msgstr "Vis nyligt tilføjne videoer"
+
+#: id:31118
+msgid "Home Page Programs Submenu"
+msgstr "Undermenu til hovedsiden"
+
+#: id:31119
+msgid "Hide Background Fanart"
+msgstr ""
+
+#: id:31120
+msgid "BUTTON LABEL"
+msgstr "KNAPTITEL"
+
+#: id:31122
+msgid "Weather Page"
+msgstr "Vejrside"
+
+#: id:31123
+msgid "Use \"Posters\" instead of \"Banners\" for TV Shows"
+msgstr "Brug plakater og ikke bannere til TV-serier"
+
+#: id:31124
+msgid "Show Background \"Now Playing\" Video"
+msgstr "Vis \"Spiller nu\" i baggrunden for videoer"
+
+#: id:31125
+msgid "Show Background \"Now Playing\" Visualization"
+msgstr "Vis \"Spiller nu\" i baggrunden for visualisering"
+
+#: id:31126
+msgid "Play TV theme songs in video library (TvTunes add-on)"
+msgstr ""
+
+#: id:31127
+msgid "TvTunes"
+msgstr ""
+
+#: id:31128
+msgid "Lyrics"
+msgstr "XBMC Sangtekster"
+
+#: id:31132
+msgid "Lyrics Add-on"
+msgstr ""
+
+#: id:31133
+msgid "Subtitle Add-on"
+msgstr ""
+
+#: id:31134
+msgid "Home Page Videos Submenu"
+msgstr ""
+
+#: id:31135
+msgid "Home Page Music Submenu"
+msgstr ""
+
+#: id:31136
+msgid "Home Page Pictures Submenu"
+msgstr ""
+
+#: id:31140
+msgid "Music OSD"
+msgstr ""
+
+#: id:31141
+msgid "Video OSD"
+msgstr ""
+
+#: id:31200
+msgid "Shortcuts"
+msgstr "Genveje"
+
+#: id:31201
+msgid "Categories"
+msgstr "Kategorier"
+
+#: id:31202
+msgid "Show Cast"
+msgstr "Vis rolleliste"
+
+#: id:31203
+msgid "Choose Your Song"
+msgstr "Vælg din sang"
+
+#: id:31204
+msgid "Section Links"
+msgstr "Sektionlinks"
+
+#: id:31205
+msgid "Lyrics Source"
+msgstr "Sangtekstkilde"
+
+#: id:31300
+msgid "Current Temp"
+msgstr "Temperatur nu"
+
+#: id:31301
+msgid "Last Updated"
+msgstr "Sidst opdateret"
+
+#: id:31302
+msgid "Menu"
+msgstr "Menu"
+
+#: id:31303
+msgid "Data provider"
+msgstr ""
+
+#: id:31304
+msgid "Picture"
+msgstr "Billede"
+
+#: id:31305
+msgid "No Disc Media Detected"
+msgstr "Intet diskmedie fundet"
+
+#: id:31306
+msgid "Eject"
+msgstr "Skub ud"
+
+#: id:31307
+msgid "Hide Fanart"
+msgstr "Skjul fankunst"
+
+#: id:31308
+msgid "Movie Details"
+msgstr "Filmdetaljer"
+
+#: id:31309
+msgid "Memory Used:"
+msgstr "Hukommelse i brug:"
+
+#: id:31310
+msgid "Track Number"
+msgstr "Spor nummer"
+
+#: id:31311
+msgid "Fanart image[CR][CR]Unavailable[CR][CR] Click button to set"
+msgstr "FANKUNST BILLDE[CR][CR]IKKE TILGÆNGELIG[CR][CR]TRYK FOR AT VÆLGE"
+
+#: id:31312
+msgid "Current Scraper"
+msgstr "Nuværende Scraper"
+
+#: id:31313
+msgid "Choose a Scraper"
+msgstr "Vælg en Scraper"
+
+#: id:31314
+msgid "Content Scanning Options"
+msgstr "Indstillinger til indholdsskanning"
+
+#: id:31315
+msgid "Basic"
+msgstr "Simpel"
+
+#: id:31317
+msgid "Set Fanart Path"
+msgstr "Vælg sti til fankunst"
+
+#: id:31318
+msgid "Small Fanart"
+msgstr "Lille fankunst"
+
+#: id:31319
+msgid "Selected Profile"
+msgstr "Valgt profil"
+
+#: id:31320
+msgid "Last Logged In"
+msgstr "Sidst logget ind"
+
+#: id:31321
+msgid "Karaoke Song Selector"
+msgstr "Sangvalg til karaoke"
+
+#: id:31322
+msgid "Aired"
+msgstr "Sendt"
+
+#: id:31323
+msgid "Latest Movies"
+msgstr "Seneste film"
+
+#: id:31324
+msgid "Latest Episodes"
+msgstr "Seneste episoder"
+
+#: id:31325
+msgid "Playlist Options"
+msgstr "Indstillinger til afspilningsliste"
+
+#: id:31326
+msgid "Created"
+msgstr "Oprettet"
+
+#: id:31327
+msgid "Resolution"
+msgstr "Opløsning"
+
+#: id:31328
+msgctxt "Auto context with id 31328"
+msgid "Recently Added"
+msgstr "Nyligt tilføjet"
+
+#: id:31329
+msgid "[B]Timer set![/B] [COLOR=grey2] - System auto shutdown in[/COLOR]"
+msgstr "[B]TIMER STARTET![/B] [COLOR=grey2] - SYSTEMET LUKKER NED OM[/COLOR]"
+
+#: id:31330
+msgid "Click button to play[CR][CR]Movie trailer"
+msgstr ""
+
+#: id:31331
+msgid "Album Details"
+msgstr ""
+
+#: id:31351
+msgid "Pause"
+msgstr ""
+
+#: id:31352
+msgid "Stop"
+msgstr ""
+
+#: id:31353
+msgid "Fast Forward"
+msgstr ""
+
+#: id:31354
+msgid "Rewind"
+msgstr ""
+
+#: id:31355
+msgid "Movie menu"
+msgstr ""
+
+#: id:31356
+msgid "Download Subtitles"
+msgstr ""
+
+#: id:31390
+msgid "Skin default"
+msgstr ""
+
+#: id:31391
+msgid "Skin default with no Caps"
+msgstr ""
+
+#: id:31392
+msgid "Arial based"
+msgstr ""
+
+#: id:31400
+msgid "[B]CONFIGURE APPEARANCE SETTINGS[/B][CR][CR]Change the skin � Set language and region � Change file listing options[CR]Set up a screensaver"
+msgstr "[B]SKIFT INDSTILLINGER TIL UDSEENDE[/B][CR][CR]Skift skin · Vælg sprog og region · Skift indstillinger til fil-listen[CR]Indstil pauseskærm"
+
+#: id:31401
+msgid "[B]CONFIGURE VIDEO SETTINGS[/B][CR][CR]Manage your video library � Set video playback options � Change video listing options[CR]Set subtitle fonts"
+msgstr "[B]SKIFT INDSTILLINGER TIL VIDEOER[/B][CR][CR]Håndter din videosamling"
+
+#: id:31402
+msgid "[B]CONFIGURE MUSIC SETTINGS[/B][CR][CR]Manage your music library � Set music playback options � Change music listing options[CR]Setup song submission � Set karaoke options"
+msgstr "[B]SKIFT INDSTILLINGER TIL MUSIK[/B][CR][CR]Håndter din musiksamling"
+
+#: id:31403
+msgid "[B]CONFIGURE PICTURE SETTINGS[/B][CR][CR]Set picture listing options � Configure slideshows"
+msgstr "[B]SKIFT INDSTILLINGER TIL BILLEDER[/B][CR][CR]Vælg hvordan billeder vises · Konfigurer billedeserier"
+
+#: id:31404
+msgid "[B]CONFIGURE WEATHER SETTINGS[/B][CR][CR]Set three cities to collect weather information"
+msgstr "[B]SKIFT INDSTILLINGER TIL VEJRSIDEN[/B][CR][CR]Du kan vælge tre byer, der skal hentes vejrudsigter for"
+
+#: id:31406
+msgid "[B]CONFIGURE SYSTEM SETTINGS[/B][CR][CR]Setup and calibrate displays � Configure audio output � Setup remote controls[CR]Set power saving options � Enable debugging � Setup master lock"
+msgstr "[B]SKIFT SYSTEMINDSTILLINGER[/B][CR][CR]Indstil og kalibrer skærmen · Indstil lydudgang · Indstil fjernbetjeninger[CR]Indstil strømstyring · Aktiver fejllogning · Indstil hovedlås"
+
+#: id:31407
+msgid "[B]CONFIGURE SKIN SETTINGS[/B][CR][CR]Setup the Confluence skin � Add and remove home menu items[CR]Change skin backgrounds"
+msgstr "[B]SKIFT SKIN-INDSTILLINGER[/B][CR][CR]Indstil Confluence · Konfigurer hovedsiden[CR]Skift baggrunde i skinnet"
+
+#: id:31408
+msgid "[B]CONFIGURE ADD-ONS[/B][CR][CR]Manage your installed Add-ons � Browse for and install Add-ons from xbmc.org[CR]Modify Add-on settings"
+msgstr ""
+
+#: id:31409
+msgid "[B]CONFIGURE SERVICE SETTINGS[/B][CR][CR]Setup control of XBMC via UPnP and HTTP � Configure file sharing[CR]Enable Zeroconf � Configure AirPlay"
+msgstr ""
+
+#: id:31421
+msgid "Select your XBMC user Profile[CR]to login and continue"
+msgstr "Vælg din XBMC-brugerprofil[CR]for at logge ind og fortsætte"
+
+#: id:31900
+msgid "Weather Maps"
+msgstr ""
+
+#: id:31901
+msgid "36 Hour Forecast"
+msgstr ""
+
+#: id:31902
+msgid "Hourly Forecast"
+msgstr ""
+
+#: id:31903
+msgid "Weekend Forecast"
+msgstr ""
+
+#: id:31904
+msgid "10 Day Forecast"
+msgstr ""
+
+#: id:31905
+msgid "Forecast"
+msgstr ""
+
+#: id:31906
+msgid "Maps & Video"
+msgstr ""
+
+#: id:31907
+msgid "Video Forecast [COLOR=grey2](Fullscreen Playback)[/COLOR]"
+msgstr ""
+
+#: id:31908
+msgid "Chance of Precipitation"
+msgstr ""
+
+#: id:31909
+msgid "Fetching forecast info..."
+msgstr ""
+

--- a/addons/skin.confluence/language/Dutch/strings.po
+++ b/addons/skin.confluence/language/Dutch/strings.po
@@ -1,0 +1,576 @@
+# Converted from xbmc strings.xml with xbmc-xml2po (by Team-XBMC)
+msgid ""
+msgstr ""
+"Project-Id-Version: xbmc.skin.confluence-FRODO_GIT953c09c336\n"
+"Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
+"POT-Creation-Date: 2012-04-09 18:03+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE\n"
+"Language: nl\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: id:31000
+msgid "Change Your"
+msgstr "Aanpassen"
+
+#: id:31001
+msgid "Love"
+msgstr "Liefde"
+
+#: id:31002
+msgid "Hate"
+msgstr "Haat"
+
+#: id:31003
+msgid "Power Options"
+msgstr "Energiebeheer"
+
+#: id:31004
+msgid "Working..."
+msgstr "Bezig..."
+
+#: id:31005
+msgid "Hide Information"
+msgstr "Info verbergen"
+
+#: id:31006
+msgid "View Options"
+msgstr "Weergave Opties"
+
+#: id:31007
+msgid "Plugins"
+msgstr "Plugins"
+
+#: id:31008
+msgid "Fullscreen"
+msgstr "Volledig scherm"
+
+#: id:31020
+msgctxt "Auto context with id 31020"
+msgid "Recently Added"
+msgstr "Hoofdstuktitel"
+
+#: id:31021
+msgid "Video - Files"
+msgstr "Video - Bestanden"
+
+#: id:31022
+msgid "Music - Files"
+msgstr "Muziek - Bestanden"
+
+#: id:31023
+msgid "Playing"
+msgstr "Afspelen"
+
+#: id:31024
+msgid "Page"
+msgstr "Pagina"
+
+#: id:31025
+msgid "Items"
+msgstr "Items"
+
+#: id:31026
+msgid "Misc Options"
+msgstr "Diverse opties"
+
+#: id:31027
+msgid "Location"
+msgstr "Locatie"
+
+#: id:31028
+msgid "Poster Wrap"
+msgstr "Poster Wrap"
+
+#: id:31029
+msgid "Fanart"
+msgstr "Fanart"
+
+#: id:31030
+msgid "Full list"
+msgstr "Volledige lijst"
+
+#: id:31031
+msgid "Pic Thumbs"
+msgstr "Pic Thumbs"
+
+#: id:31032
+msgid "Image Wrap"
+msgstr "Image Wrap"
+
+#: id:31033
+msgid "Info"
+msgstr "Info"
+
+#: id:31040
+msgid "Now Playing"
+msgstr "Afspelen"
+
+#: id:31042
+msgid "PLAYING"
+msgstr "AFSPELEN"
+
+#: id:31043
+msgid "PAUSED"
+msgstr "PAUZE"
+
+#: id:31044
+msgid "FAST FORWARD"
+msgstr "VOORUITSPOELEN"
+
+#: id:31045
+msgid "REWIND"
+msgstr "TERUGSPOELEN"
+
+#: id:31046
+msgid "Audio Properties"
+msgstr "Geluidopties"
+
+#: id:31047
+msgid "Current Preset"
+msgstr "Huidige instelling"
+
+#: id:31048
+msgid "Visualization Presets"
+msgstr "Visualisatiestijl"
+
+#: id:31049
+msgid "End Time"
+msgstr "Eindigt om"
+
+#: id:31050
+msgid "Sort: Ascending"
+msgstr "Sorteren: Oplopend"
+
+#: id:31051
+msgid "Sort: Descending"
+msgstr "Sorteren: Aflopend"
+
+#: id:31055
+msgid "Open playlist"
+msgstr "Afspeellijst openen"
+
+#: id:31056
+msgid "Save playlist"
+msgstr "Afspeellijst bewaren"
+
+#: id:31057
+msgid "Close playlist"
+msgstr "Afspeellijst sluiten"
+
+#: id:31058
+msgid "System music files"
+msgstr "Muziekbestanden systeem"
+
+#: id:31059
+msgid "Current playlist"
+msgstr "Huidige afspeellijst"
+
+#: id:31060
+msgid "This file is stacked, select the part you want to play from."
+msgstr "Dit bestand bestaat uit meerdere delen, selecteer het deel dat u wilt afspelen."
+
+#: id:31061
+msgid "Current Selected"
+msgstr "Nu geselecteerd"
+
+#: id:31101
+msgid "Home screen options"
+msgstr "Beginschermopties"
+
+#: id:31102
+msgid "Background"
+msgstr "Achtergronden"
+
+#: id:31103
+msgid "Show \"Paused\" in picture slide show"
+msgstr "Laat \"PAUZE\" zien in diavoorstelling"
+
+#: id:31104
+msgid "Play Trailers in a window [COLOR=grey3](Video Information Dialog Only)[/COLOR]"
+msgstr "Trailers afspelen in een venster [COLOR=grey3](Alleen Video Informatiedialoog)[/COLOR]"
+
+#: id:31105
+msgid "\"Videos\" button always goes to video \"Files\""
+msgstr "\"Video's\" knop gaat altijd naar video \"Bestanden\""
+
+#: id:31106
+msgid "Miscellaneous options"
+msgstr "Diverse opties"
+
+#: id:31107
+msgid "Hide Flagging read from video filenames [COLOR=grey3](Blu-ray, HD-DVD)[/COLOR]"
+msgstr "Verberg markeringen uit bestandennaam [COLOR=grey3](Blu-ray, HD-DVD)[/COLOR]"
+
+#: id:31108
+msgid "Hide Main Menu Buttons"
+msgstr "Verberg knoppen hoofdmenu"
+
+#: id:31109
+msgid "Media backgrounds"
+msgstr "Beginschermachtergronden"
+
+#: id:31110
+msgid "Edit Background for Media Type"
+msgstr "Achtergrond beginschermknop aanpassen"
+
+#: id:31111
+msgid "Hide"
+msgstr "Verbergen"
+
+#: id:31112
+msgid "Options"
+msgstr "Opties"
+
+#: id:31113
+msgid "Single Image"
+msgstr "Enkele afbeelding"
+
+#: id:31114
+msgid "Multi Image"
+msgstr "Meerdere afbeeldingen"
+
+#: id:31115
+msgid "Customizer"
+msgstr "Aanpassen"
+
+#: id:31117
+msgid "Show Recently added Videos"
+msgstr "Laat onlangs toegevoegde video's zien"
+
+#: id:31118
+msgid "Home Page Programs Submenu"
+msgstr "Beginscherm submenu"
+
+#: id:31119
+msgid "Hide Background Fanart"
+msgstr "Fanart achtergronden verbergen"
+
+#: id:31120
+msgid "BUTTON LABEL"
+msgstr "Knoplabel"
+
+#: id:31122
+msgid "Weather Page"
+msgstr "Weerpagina"
+
+#: id:31123
+msgid "Use \"Posters\" instead of \"Banners\" for TV Shows"
+msgstr "Gebruik \"Posters\" in plaats van \"Banners\" voor series"
+
+#: id:31124
+msgid "Show Background \"Now Playing\" Video"
+msgstr "Laat achtergrond \"Nu Afspelen\" zien voor video"
+
+#: id:31125
+msgid "Show Background \"Now Playing\" Visualization"
+msgstr "Laat achtergrond \"Nu Afspelen\" zien voor visualisatie"
+
+#: id:31126
+msgid "Play TV theme songs in video library (TvTunes add-on)"
+msgstr ""
+
+#: id:31127
+msgid "TvTunes"
+msgstr ""
+
+#: id:31128
+msgid "Lyrics"
+msgstr "XBMC-songteksten"
+
+#: id:31132
+msgid "Lyrics Add-on"
+msgstr "Liedtekst Add-on"
+
+#: id:31133
+msgid "Subtitle Add-on"
+msgstr "Ondertiteling Add-on"
+
+#: id:31134
+msgid "Home Page Videos Submenu"
+msgstr "Begin Scherm Videos Submenu"
+
+#: id:31135
+msgid "Home Page Music Submenu"
+msgstr "Begin Scherm Music Submenu"
+
+#: id:31136
+msgid "Home Page Pictures Submenu"
+msgstr "Begin Scherm Pictures Submenu"
+
+#: id:31140
+msgid "Music OSD"
+msgstr "Muziek-OSD"
+
+#: id:31141
+msgid "Video OSD"
+msgstr "Video-OSD"
+
+#: id:31200
+msgid "Shortcuts"
+msgstr "Snelkoppelingen"
+
+#: id:31201
+msgid "Categories"
+msgstr "CategorieÃ«n"
+
+#: id:31202
+msgid "Show Cast"
+msgstr "Toon cast"
+
+#: id:31203
+msgid "Choose Your Song"
+msgstr "Kies uw nummer"
+
+#: id:31204
+msgid "Section Links"
+msgstr "Sectie links"
+
+#: id:31205
+msgid "Lyrics Source"
+msgstr "Liedtekst bron"
+
+#: id:31300
+msgid "Current Temp"
+msgstr "Huidige temperatuur"
+
+#: id:31301
+msgid "Last Updated"
+msgstr "Laatst bijgewerkt"
+
+#: id:31302
+msgid "Menu"
+msgstr "Menu"
+
+#: id:31303
+msgid "Data provider"
+msgstr ""
+
+#: id:31304
+msgid "Picture"
+msgstr "Afbeelding"
+
+#: id:31305
+msgid "No Disc Media Detected"
+msgstr "Geen media gedetecteerd"
+
+#: id:31306
+msgid "Eject"
+msgstr "Uitwerpen"
+
+#: id:31307
+msgid "Hide Fanart"
+msgstr "Fanart verbergen"
+
+#: id:31308
+msgid "Movie Details"
+msgstr "Filmdetails"
+
+#: id:31309
+msgid "Memory Used:"
+msgstr "Geheugengebruik:"
+
+#: id:31310
+msgid "Track Number"
+msgstr "Tracknummer"
+
+#: id:31311
+msgid "Fanart image[CR][CR]Unavailable[CR][CR] Click button to set"
+msgstr "Fanartafbeelding[CR][CR]niet beschikbaar[CR][CR] klik hier om in te stellen"
+
+#: id:31312
+msgid "Current Scraper"
+msgstr "Huidige scraper"
+
+#: id:31313
+msgid "Choose a Scraper"
+msgstr "Scraper kiezen"
+
+#: id:31314
+msgid "Content Scanning Options"
+msgstr "Opties inhoudsscanner"
+
+#: id:31315
+msgid "Basic"
+msgstr "Basis"
+
+#: id:31317
+msgid "Set Fanart Path"
+msgstr "Fanartpad opgeven"
+
+#: id:31318
+msgid "Small Fanart"
+msgstr "Kleine fanart"
+
+#: id:31319
+msgid "Selected Profile"
+msgstr "Profiel selecteren"
+
+#: id:31320
+msgid "Last Logged In"
+msgstr "Laatst ingelogd op"
+
+#: id:31321
+msgid "Karaoke Song Selector"
+msgstr "Nummerkeuze karaoke"
+
+#: id:31322
+msgid "Aired"
+msgstr "Uitgezonden"
+
+#: id:31323
+msgid "Latest Movies"
+msgstr "Laatste films"
+
+#: id:31324
+msgid "Latest Episodes"
+msgstr "Laatste afleveringen"
+
+#: id:31325
+msgid "Playlist Options"
+msgstr "Afspeellijstopties"
+
+#: id:31326
+msgid "Created"
+msgstr "Gemaakt"
+
+#: id:31327
+msgid "Resolution"
+msgstr "Resolutie"
+
+#: id:31328
+msgctxt "Auto context with id 31328"
+msgid "Recently Added"
+msgstr "Onlangs toegevoegd"
+
+#: id:31329
+msgid "[B]Timer set![/B] [COLOR=grey2] - System auto shutdown in[/COLOR]"
+msgstr "[B]Timer geconfigureerd![/B] [COLOR=grey2] - Systeem schakelt automatisch uit in[/COLOR]"
+
+#: id:31330
+msgid "Click button to play[CR][CR]Movie trailer"
+msgstr "Klik op de knop om af te spelen[CR][CR]Filmtrailer"
+
+#: id:31331
+msgid "Album Details"
+msgstr "Album Details"
+
+#: id:31351
+msgid "Pause"
+msgstr "Pauze"
+
+#: id:31352
+msgid "Stop"
+msgstr "Stop"
+
+#: id:31353
+msgid "Fast Forward"
+msgstr "Vooruitspoelen"
+
+#: id:31354
+msgid "Rewind"
+msgstr "Terugspoelen"
+
+#: id:31355
+msgid "Movie menu"
+msgstr "Filmmenu"
+
+#: id:31356
+msgid "Download Subtitles"
+msgstr "Ondertitels downloaden"
+
+#: id:31390
+msgid "Skin default"
+msgstr "Skinstandaard"
+
+#: id:31391
+msgid "Skin default with no Caps"
+msgstr "Skinstandaard zonder hoofdletters"
+
+#: id:31392
+msgid "Arial based"
+msgstr "Gebaseerd op Arial"
+
+#: id:31400
+msgid "[B]CONFIGURE APPEARANCE SETTINGS[/B][CR][CR]Change the skin · Set language and region · Change file listing options[CR]Set up a screensaver"
+msgstr "[B]INSTELLINGEN UITERLIJK CONFIGUREREN[/B][CR][CR]Wijzig skin Â· Stel taal en regio in Â· Configureer bestandslijstopties en schermbeveiliging"
+
+#: id:31401
+msgid "[B]CONFIGURE VIDEO SETTINGS[/B][CR][CR]Manage your video library · Set video playback options · Change video listing options[CR]Set subtitle fonts"
+msgstr "[B]VIDEO-INSTELLINGEN CONFIGUREREN[/B][CR][CR]Beheer uw videobibliotheek Â· Configureer videoafspeelopties en -bestandslijstsopties Â· Stel lettertype in voor ondertitels"
+
+#: id:31402
+msgid "[B]CONFIGURE MUSIC SETTINGS[/B][CR][CR]Manage your music library · Set music playback options · Change music listing options[CR]Setup song submission · Set karaoke options"
+msgstr "[B]MUZIEKINSTELLINGEN CONFIGUREREN[/B][CR][CR]Beheer uw muziekbibliotheek Â· Configureer muziekafspeelopties en -bestandslijstopties Â· Configureer nummer indienen Â· Configureer karaokeopties"
+
+#: id:31403
+msgid "[B]CONFIGURE PICTURE SETTINGS[/B][CR][CR]Set picture listing options · Configure slideshows"
+msgstr "[B]FOTO-INSTELLINGEN CONFIGUREREN[/B][CR][CR]Configureer fotobestandslijstopties en diavoorstelling."
+
+#: id:31404
+msgid "[B]CONFIGURE WEATHER SETTINGS[/B][CR][CR]Set three cities to collect weather information"
+msgstr "[B]WEERINSTELLINGEN CONFIGUREREN[/B][CR][CR]Geef drie locaties op voor weersverwachtingen."
+
+#: id:31406
+msgid "[B]CONFIGURE SYSTEM SETTINGS[/B][CR][CR]Setup and calibrate displays · Configure audio output · Setup remote controls[CR]Set power saving options · Enable debugging · Setup master lock"
+msgstr "[B]SYSTEEMINSTELLINGEN CONFIGUREREN[/B][CR][CR]Configureer en kalibreer schermgeluidsuitgang Â· Configureer invoerapparaten en energiebeheeropties Â· Schakel debugging in Â· Configureer vergrendelopties"
+
+#: id:31407
+msgid "[B]CONFIGURE SKIN SETTINGS[/B][CR][CR]Setup the Confluence skin · Add and remove home menu items[CR]Change skin backgrounds"
+msgstr "[B]SKININSTELLINGEN CONFIGUREREN[/B][CR][CR]Configureer de Confluence-skin Â· Voeg items toe aan of verwijder ze uit het beginscherm Â· Wijzig skinachtergronden"
+
+#: id:31408
+msgid "[B]CONFIGURE ADD-ONS[/B][CR][CR]Manage your installed Add-ons · Browse for and install Add-ons from xbmc.org[CR]Modify Add-on settings"
+msgstr "[B]ADD-ONS CONFIGUREREN[/B][CR][CR]Beheer uw geÃ¯nstalleerde Add-ons Â· Zoek en installeer Add-ons via xbmc.org Â· Wijzig Add-oninstellingen"
+
+#: id:31409
+msgid "[B]CONFIGURE SERVICE SETTINGS[/B][CR][CR]Setup control of XBMC via UPnP and HTTP · Configure file sharing[CR]Enable Zeroconf · Configure AirPlay"
+msgstr ""
+
+#: id:31421
+msgid "Select your XBMC user Profile[CR]to login and continue"
+msgstr "Selecteer uw XBMC-gebruikersprofiel[CR]om in te loggen"
+
+#: id:31900
+msgid "Weather Maps"
+msgstr "Weer Kaarten"
+
+#: id:31901
+msgid "36 Hour Forecast"
+msgstr "36 Uur Voorspelling"
+
+#: id:31902
+msgid "Hourly Forecast"
+msgstr "Per Uur Voorspelling"
+
+#: id:31903
+msgid "Weekend Forecast"
+msgstr "Weekend Voorspelling"
+
+#: id:31904
+msgid "10 Day Forecast"
+msgstr "10 Dagen Voorspelling"
+
+#: id:31905
+msgid "Forecast"
+msgstr "Voorspelling"
+
+#: id:31906
+msgid "Maps & Video"
+msgstr "Kaarten en Video"
+
+#: id:31907
+msgid "Video Forecast [COLOR=grey2](Fullscreen Playback)[/COLOR]"
+msgstr "Video voorspelling [COLOR=grey2](Volledig scherm Afspelen)[/COLOR]"
+
+#: id:31908
+msgid "Chance of Precipitation"
+msgstr "Kans Op Neerslag"
+
+#: id:31909
+msgid "Fetching forecast info..."
+msgstr "Weersvoorspelling ophalen..."
+

--- a/addons/skin.confluence/language/English/strings.po
+++ b/addons/skin.confluence/language/English/strings.po
@@ -1,0 +1,624 @@
+# Converted from xbmc strings.xml with xbmc-xml2po (by Team-XBMC)
+msgid ""
+msgstr ""
+"Project-Id-Version: xbmc.skin.confluence-FRODO_GIT953c09c336\n"
+"Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
+"POT-Creation-Date: 2012-04-09 18:03+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE\n"
+"Language: en\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#Misc labels
+
+#: id:31000
+msgid "Change Your"
+msgstr ""
+
+#: id:31001
+msgid "Love"
+msgstr ""
+
+#: id:31002
+msgid "Hate"
+msgstr ""
+
+#: id:31003
+msgid "Power Options"
+msgstr ""
+
+#: id:31004
+msgid "Working..."
+msgstr ""
+
+#: id:31005
+msgid "Hide Information"
+msgstr ""
+
+#: id:31006
+msgid "View Options"
+msgstr ""
+
+#: id:31007
+msgid "Plugins"
+msgstr ""
+
+#: id:31008
+msgid "Fullscreen"
+msgstr ""
+
+#empty strings from id 31009 to 31019
+
+#: id:31020
+msgctxt "Auto context with id 31020"
+msgid "Recently Added"
+msgstr ""
+
+#: id:31021
+msgid "Video - Files"
+msgstr ""
+
+#: id:31022
+msgid "Music - Files"
+msgstr ""
+
+#: id:31023
+msgid "Playing"
+msgstr ""
+
+#: id:31024
+msgid "Page"
+msgstr ""
+
+#: id:31025
+msgid "Items"
+msgstr ""
+
+#: id:31026
+msgid "Misc Options"
+msgstr ""
+
+#: id:31027
+msgid "Location"
+msgstr ""
+
+#View Type labels
+
+#: id:31028
+msgid "Poster Wrap"
+msgstr ""
+
+#: id:31029
+msgid "Fanart"
+msgstr ""
+
+#: id:31030
+msgid "Full list"
+msgstr ""
+
+#: id:31031
+msgid "Pic Thumbs"
+msgstr ""
+
+#: id:31032
+msgid "Image Wrap"
+msgstr ""
+
+#: id:31033
+msgid "Info"
+msgstr ""
+
+#Extra labels
+#empty strings from id 31034 to 31039
+
+#: id:31040
+msgid "Now Playing"
+msgstr ""
+
+#empty string with id 31041
+
+#: id:31042
+msgid "PLAYING"
+msgstr ""
+
+#: id:31043
+msgid "PAUSED"
+msgstr ""
+
+#: id:31044
+msgid "FAST FORWARD"
+msgstr ""
+
+#: id:31045
+msgid "REWIND"
+msgstr ""
+
+#: id:31046
+msgid "Audio Properties"
+msgstr ""
+
+#: id:31047
+msgid "Current Preset"
+msgstr ""
+
+#: id:31048
+msgid "Visualization Presets"
+msgstr ""
+
+#: id:31049
+msgid "End Time"
+msgstr ""
+
+#: id:31050
+msgid "Sort: Ascending"
+msgstr ""
+
+#: id:31051
+msgid "Sort: Descending"
+msgstr ""
+
+#Playlist Editor labels
+#empty strings from id 31052 to 31054
+
+#: id:31055
+msgid "Open playlist"
+msgstr ""
+
+#: id:31056
+msgid "Save playlist"
+msgstr ""
+
+#: id:31057
+msgid "Close playlist"
+msgstr ""
+
+#: id:31058
+msgid "System music files"
+msgstr ""
+
+#: id:31059
+msgid "Current playlist"
+msgstr ""
+
+#: id:31060
+msgid "This file is stacked, select the part you want to play from."
+msgstr ""
+
+#: id:31061
+msgid "Current Selected"
+msgstr ""
+
+#Skin Settings labels
+#empty strings from id 31062 to 31100
+
+#: id:31101
+msgid "Home screen options"
+msgstr ""
+
+#: id:31102
+msgid "Background"
+msgstr ""
+
+#: id:31103
+msgid "Show \"Paused\" in picture slide show"
+msgstr ""
+
+#: id:31104
+msgid "Play Trailers in a window [COLOR=grey3](Video Information Dialog Only)[/COLOR]"
+msgstr ""
+
+#: id:31105
+msgid "\"Videos\" button always goes to video \"Files\""
+msgstr ""
+
+#: id:31106
+msgid "Miscellaneous options"
+msgstr ""
+
+#: id:31107
+msgid "Hide Flagging read from video filenames [COLOR=grey3](Blu-ray, HD-DVD)[/COLOR]"
+msgstr ""
+
+#: id:31108
+msgid "Hide Main Menu Buttons"
+msgstr ""
+
+#: id:31109
+msgid "Media backgrounds"
+msgstr ""
+
+#: id:31110
+msgid "Edit Background for Media Type"
+msgstr ""
+
+#: id:31111
+msgid "Hide"
+msgstr ""
+
+#: id:31112
+msgid "Options"
+msgstr ""
+
+#: id:31113
+msgid "Single Image"
+msgstr ""
+
+#: id:31114
+msgid "Multi Image"
+msgstr ""
+
+#: id:31115
+msgid "Customizer"
+msgstr ""
+
+#empty string with id 31116
+
+#: id:31117
+msgid "Show Recently added Videos"
+msgstr ""
+
+#: id:31118
+msgid "Home Page Programs Submenu"
+msgstr ""
+
+#: id:31119
+msgid "Hide Background Fanart"
+msgstr ""
+
+#: id:31120
+msgid "BUTTON LABEL"
+msgstr ""
+
+#empty string with id 31121
+
+#: id:31122
+msgid "Weather Page"
+msgstr ""
+
+#: id:31123
+msgid "Use \"Posters\" instead of \"Banners\" for TV Shows"
+msgstr ""
+
+#: id:31124
+msgid "Show Background \"Now Playing\" Video"
+msgstr ""
+
+#: id:31125
+msgid "Show Background \"Now Playing\" Visualization"
+msgstr ""
+
+#: id:31126
+msgid "Play TV theme songs in video library (TvTunes add-on)"
+msgstr ""
+
+#: id:31127
+msgid "TvTunes"
+msgstr ""
+
+#: id:31128
+msgid "Lyrics"
+msgstr ""
+
+#empty strings from id 31129 to 31131
+
+#: id:31132
+msgid "Lyrics Add-on"
+msgstr ""
+
+#: id:31133
+msgid "Subtitle Add-on"
+msgstr ""
+
+#: id:31134
+msgid "Home Page Videos Submenu"
+msgstr ""
+
+#: id:31135
+msgid "Home Page Music Submenu"
+msgstr ""
+
+#: id:31136
+msgid "Home Page Pictures Submenu"
+msgstr ""
+
+#empty strings from id 31137 to 31139
+
+#: id:31140
+msgid "Music OSD"
+msgstr ""
+
+#: id:31141
+msgid "Video OSD"
+msgstr ""
+
+#Script labels
+#empty strings from id 31142 to 31199
+
+#: id:31200
+msgid "Shortcuts"
+msgstr ""
+
+#: id:31201
+msgid "Categories"
+msgstr ""
+
+#: id:31202
+msgid "Show Cast"
+msgstr ""
+
+#: id:31203
+msgid "Choose Your Song"
+msgstr ""
+
+#: id:31204
+msgid "Section Links"
+msgstr ""
+
+#: id:31205
+msgid "Lyrics Source"
+msgstr ""
+
+#Extra labels
+#empty strings from id 31206 to 31299
+
+#: id:31300
+msgid "Current Temp"
+msgstr ""
+
+#: id:31301
+msgid "Last Updated"
+msgstr ""
+
+#: id:31302
+msgid "Menu"
+msgstr ""
+
+#: id:31303
+msgid "Data provider"
+msgstr ""
+
+#: id:31304
+msgid "Picture"
+msgstr ""
+
+#: id:31305
+msgid "No Disc Media Detected"
+msgstr ""
+
+#: id:31306
+msgid "Eject"
+msgstr ""
+
+#: id:31307
+msgid "Hide Fanart"
+msgstr ""
+
+#: id:31308
+msgid "Movie Details"
+msgstr ""
+
+#: id:31309
+msgid "Memory Used:"
+msgstr ""
+
+#: id:31310
+msgid "Track Number"
+msgstr ""
+
+#: id:31311
+msgid "Fanart image[CR][CR]Unavailable[CR][CR] Click button to set"
+msgstr ""
+
+#: id:31312
+msgid "Current Scraper"
+msgstr ""
+
+#: id:31313
+msgid "Choose a Scraper"
+msgstr ""
+
+#: id:31314
+msgid "Content Scanning Options"
+msgstr ""
+
+#: id:31315
+msgid "Basic"
+msgstr ""
+
+#empty string with id 31316
+
+#: id:31317
+msgid "Set Fanart Path"
+msgstr ""
+
+#: id:31318
+msgid "Small Fanart"
+msgstr ""
+
+#: id:31319
+msgid "Selected Profile"
+msgstr ""
+
+#: id:31320
+msgid "Last Logged In"
+msgstr ""
+
+#: id:31321
+msgid "Karaoke Song Selector"
+msgstr ""
+
+#: id:31322
+msgid "Aired"
+msgstr ""
+
+#: id:31323
+msgid "Latest Movies"
+msgstr ""
+
+#: id:31324
+msgid "Latest Episodes"
+msgstr ""
+
+#: id:31325
+msgid "Playlist Options"
+msgstr ""
+
+#: id:31326
+msgid "Created"
+msgstr ""
+
+#: id:31327
+msgid "Resolution"
+msgstr ""
+
+#: id:31328
+msgctxt "Auto context with id 31328"
+msgid "Recently Added"
+msgstr ""
+
+#: id:31329
+msgid "[B]Timer set![/B] [COLOR=grey2] - System auto shutdown in[/COLOR]"
+msgstr ""
+
+#: id:31330
+msgid "Click button to play[CR][CR]Movie trailer"
+msgstr ""
+
+#: id:31331
+msgid "Album Details"
+msgstr ""
+
+#Video and Music OSD Labels
+#empty strings from id 31332 to 31350
+
+#: id:31351
+msgid "Pause"
+msgstr ""
+
+#: id:31352
+msgid "Stop"
+msgstr ""
+
+#: id:31353
+msgid "Fast Forward"
+msgstr ""
+
+#: id:31354
+msgid "Rewind"
+msgstr ""
+
+#: id:31355
+msgid "Movie menu"
+msgstr ""
+
+#: id:31356
+msgid "Download Subtitles"
+msgstr ""
+
+#empty strings from id 31357 to 31389
+
+#: id:31390
+msgid "Skin default"
+msgstr ""
+
+#: id:31391
+msgid "Skin default with no Caps"
+msgstr ""
+
+#: id:31392
+msgid "Arial based"
+msgstr ""
+
+#Description Labels
+#empty strings from id 31393 to 31399
+
+#: id:31400
+msgid "[B]CONFIGURE APPEARANCE SETTINGS[/B][CR][CR]Change the skin · Set language and region · Change file listing options[CR]Set up a screensaver"
+msgstr ""
+
+#: id:31401
+msgid "[B]CONFIGURE VIDEO SETTINGS[/B][CR][CR]Manage your video library · Set video playback options · Change video listing options[CR]Set subtitle fonts"
+msgstr ""
+
+#: id:31402
+msgid "[B]CONFIGURE MUSIC SETTINGS[/B][CR][CR]Manage your music library · Set music playback options · Change music listing options[CR]Setup song submission · Set karaoke options"
+msgstr ""
+
+#: id:31403
+msgid "[B]CONFIGURE PICTURE SETTINGS[/B][CR][CR]Set picture listing options · Configure slideshows"
+msgstr ""
+
+#: id:31404
+msgid "[B]CONFIGURE WEATHER SETTINGS[/B][CR][CR]Set three cities to collect weather information"
+msgstr ""
+
+#empty string with id 31405
+
+#: id:31406
+msgid "[B]CONFIGURE SYSTEM SETTINGS[/B][CR][CR]Setup and calibrate displays · Configure audio output · Setup remote controls[CR]Set power saving options · Enable debugging · Setup master lock"
+msgstr ""
+
+#: id:31407
+msgid "[B]CONFIGURE SKIN SETTINGS[/B][CR][CR]Setup the Confluence skin · Add and remove home menu items[CR]Change skin backgrounds"
+msgstr ""
+
+#: id:31408
+msgid "[B]CONFIGURE ADD-ONS[/B][CR][CR]Manage your installed Add-ons · Browse for and install Add-ons from xbmc.org[CR]Modify Add-on settings"
+msgstr ""
+
+#: id:31409
+msgid "[B]CONFIGURE SERVICE SETTINGS[/B][CR][CR]Setup control of XBMC via UPnP and HTTP · Configure file sharing[CR]Enable Zeroconf · Configure AirPlay"
+msgstr ""
+
+#empty strings from id 31410 to 31420
+
+#: id:31421
+msgid "Select your XBMC user Profile[CR]to login and continue"
+msgstr ""
+
+#Weather plugin
+#empty strings from id 31422 to 31899
+
+#: id:31900
+msgid "Weather Maps"
+msgstr ""
+
+#: id:31901
+msgid "36 Hour Forecast"
+msgstr ""
+
+#: id:31902
+msgid "Hourly Forecast"
+msgstr ""
+
+#: id:31903
+msgid "Weekend Forecast"
+msgstr ""
+
+#: id:31904
+msgid "10 Day Forecast"
+msgstr ""
+
+#: id:31905
+msgid "Forecast"
+msgstr ""
+
+#: id:31906
+msgid "Maps & Video"
+msgstr ""
+
+#: id:31907
+msgid "Video Forecast [COLOR=grey2](Fullscreen Playback)[/COLOR]"
+msgstr ""
+
+#: id:31908
+msgid "Chance of Precipitation"
+msgstr ""
+
+#: id:31909
+msgid "Fetching forecast info..."
+msgstr ""
+

--- a/addons/skin.confluence/language/Finnish/strings.po
+++ b/addons/skin.confluence/language/Finnish/strings.po
@@ -1,0 +1,576 @@
+# Converted from xbmc strings.xml with xbmc-xml2po (by Team-XBMC)
+msgid ""
+msgstr ""
+"Project-Id-Version: xbmc.skin.confluence-FRODO_GIT953c09c336\n"
+"Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
+"POT-Creation-Date: 2012-04-09 18:03+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE\n"
+"Language: fi\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: id:31000
+msgid "Change Your"
+msgstr "Määritä"
+
+#: id:31001
+msgid "Love"
+msgstr "Pitää"
+
+#: id:31002
+msgid "Hate"
+msgstr "Inhoaa"
+
+#: id:31003
+msgid "Power Options"
+msgstr "Virta-asetukset"
+
+#: id:31004
+msgid "Working..."
+msgstr "Suoritetaan..."
+
+#: id:31005
+msgid "Hide Information"
+msgstr "Piilota tiedot"
+
+#: id:31006
+msgid "View Options"
+msgstr "Näkymän asetukset"
+
+#: id:31007
+msgid "Plugins"
+msgstr "Lisäosat"
+
+#: id:31008
+msgid "Fullscreen"
+msgstr "Kokoruutu"
+
+#: id:31020
+msgctxt "Auto context with id 31020"
+msgid "Recently Added"
+msgstr "Viimeksi lisätyt"
+
+#: id:31021
+msgid "Video - Files"
+msgstr "Video - Tiedostot"
+
+#: id:31022
+msgid "Music - Files"
+msgstr "Musiikki - Tiedostot"
+
+#: id:31023
+msgid "Playing"
+msgstr "Toistaa"
+
+#: id:31024
+msgid "Page"
+msgstr "Sivu"
+
+#: id:31025
+msgid "Items"
+msgstr "Kohdetta"
+
+#: id:31026
+msgid "Misc Options"
+msgstr "Muut asetukset"
+
+#: id:31027
+msgid "Location"
+msgstr "Paikkakunta"
+
+#: id:31028
+msgid "Poster Wrap"
+msgstr "Julistekierto"
+
+#: id:31029
+msgid "Fanart"
+msgstr "Fanitaide"
+
+#: id:31030
+msgid "Full list"
+msgstr "Täysi lista"
+
+#: id:31031
+msgid "Pic Thumbs"
+msgstr "Kuva kuvake"
+
+#: id:31032
+msgid "Image Wrap"
+msgstr "Kuvakierto"
+
+#: id:31033
+msgid "Info"
+msgstr "Tiedot"
+
+#: id:31040
+msgid "Now Playing"
+msgstr "Nyt toistetaan"
+
+#: id:31042
+msgid "PLAYING"
+msgstr "TOISTETAAN"
+
+#: id:31043
+msgid "PAUSED"
+msgstr "TAUKO"
+
+#: id:31044
+msgid "FAST FORWARD"
+msgstr "KELAUS ETEENPÄIN"
+
+#: id:31045
+msgid "REWIND"
+msgstr "KELAUS TAAKSEPÄIN"
+
+#: id:31046
+msgid "Audio Properties"
+msgstr "Ääniasetukset"
+
+#: id:31047
+msgid "Current Preset"
+msgstr "Nykyinen esiasetus"
+
+#: id:31048
+msgid "Visualization Presets"
+msgstr "Visualisoinnin esiasetukset"
+
+#: id:31049
+msgid "End Time"
+msgstr "Päättymisaika"
+
+#: id:31050
+msgid "Sort: Ascending"
+msgstr "Järjestä: Nousevasti"
+
+#: id:31051
+msgid "Sort: Descending"
+msgstr "Järjestä: Laskevasti"
+
+#: id:31055
+msgid "Open playlist"
+msgstr "Avaa toistolista"
+
+#: id:31056
+msgid "Save playlist"
+msgstr "Tallenna toistolista"
+
+#: id:31057
+msgid "Close playlist"
+msgstr "Sulje toistolista"
+
+#: id:31058
+msgid "System music files"
+msgstr "Musiikkitiedostot"
+
+#: id:31059
+msgid "Current playlist"
+msgstr "Nykyinen toistolista"
+
+#: id:31060
+msgid "This file is stacked, select the part you want to play from."
+msgstr "Tämä tiedosto on pinottu, valitse osa jonka haluat toistaa."
+
+#: id:31061
+msgid "Current Selected"
+msgstr "Nyt valittuna"
+
+#: id:31101
+msgid "Home screen options"
+msgstr "Päävalikon asetukset"
+
+#: id:31102
+msgid "Background"
+msgstr "Tausta"
+
+#: id:31103
+msgid "Show \"Paused\" in picture slide show"
+msgstr "Näytä \"Tauko\" kuvaesityksessä"
+
+#: id:31104
+msgid "Play Trailers in a window [COLOR=grey3](Video Information Dialog Only)[/COLOR]"
+msgstr "Toista esittelyt ikkunassa [COLOR=grey3](Videotiedot-ikkuna)[/COLOR]"
+
+#: id:31105
+msgid "\"Videos\" button always goes to video \"Files\""
+msgstr "\"Videot\"-painike avaa aina \"Tiedostot\""
+
+#: id:31106
+msgid "Miscellaneous options"
+msgstr "Yleiset asetukset"
+
+#: id:31107
+msgid "Hide Flagging read from video filenames [COLOR=grey3](Blu-ray, HD-DVD)[/COLOR]"
+msgstr "Piilota tiedostojen nimistä luetut merkinnät [COLOR=grey3](Blu-ray, HD-DVD)[/COLOR]"
+
+#: id:31108
+msgid "Hide Main Menu Buttons"
+msgstr "Piilota päävalikon painikkeet"
+
+#: id:31109
+msgid "Media backgrounds"
+msgstr "Päävalikon taustakuvat"
+
+#: id:31110
+msgid "Edit Background for Media Type"
+msgstr "Muokkaa taustakuvaa päävalikon painikkeelle"
+
+#: id:31111
+msgid "Hide"
+msgstr "Piilota"
+
+#: id:31112
+msgid "Options"
+msgstr "Asetukset"
+
+#: id:31113
+msgid "Single Image"
+msgstr "Yksittäinen kuva"
+
+#: id:31114
+msgid "Multi Image"
+msgstr "Vaihtuva kuva"
+
+#: id:31115
+msgid "Customizer"
+msgstr "Mukautus"
+
+#: id:31117
+msgid "Show Recently added Videos"
+msgstr "Näytä viimeksi lisätyt videot"
+
+#: id:31118
+msgid "Home Page Programs Submenu"
+msgstr "Päävalikon Ohjelmat-alivalikko"
+
+#: id:31119
+msgid "Hide Background Fanart"
+msgstr "Piilota taustan fanitaide"
+
+#: id:31120
+msgid "BUTTON LABEL"
+msgstr "PAINIKKEEN TEKSTI"
+
+#: id:31122
+msgid "Weather Page"
+msgstr "Sääsivu"
+
+#: id:31123
+msgid "Use \"Posters\" instead of \"Banners\" for TV Shows"
+msgstr "Käytä TV-ohjelmilla \"Juliste\"-näkymää"
+
+#: id:31124
+msgid "Show Background \"Now Playing\" Video"
+msgstr "Näytä taustalla \"Nyt katsellaan\"-video"
+
+#: id:31125
+msgid "Show Background \"Now Playing\" Visualization"
+msgstr "Näytä taustalla \"Nyt kuunnellaan\"-visualisointi"
+
+#: id:31126
+msgid "Play TV theme songs in video library (TvTunes add-on)"
+msgstr "Toista TV-tunnusmusiikit videokirjastossa (TvTunes-lisäosa)"
+
+#: id:31127
+msgid "TvTunes"
+msgstr "TvTunes"
+
+#: id:31128
+msgid "Lyrics"
+msgstr "Sanoitukset"
+
+#: id:31132
+msgid "Lyrics Add-on"
+msgstr "Sanoitukset-lisäosa"
+
+#: id:31133
+msgid "Subtitle Add-on"
+msgstr "Tekstitykset-lisäosa"
+
+#: id:31134
+msgid "Home Page Videos Submenu"
+msgstr "Päävalikon Videot-alivalikko"
+
+#: id:31135
+msgid "Home Page Music Submenu"
+msgstr "Päävalikon Musiikki-alivalikko"
+
+#: id:31136
+msgid "Home Page Pictures Submenu"
+msgstr "Päävalikon Kuvat-alivalikko"
+
+#: id:31140
+msgid "Music OSD"
+msgstr "Musiikki-OSD"
+
+#: id:31141
+msgid "Video OSD"
+msgstr "Video-OSD"
+
+#: id:31200
+msgid "Shortcuts"
+msgstr "Pikavalinnat"
+
+#: id:31201
+msgid "Categories"
+msgstr "Kategoriat"
+
+#: id:31202
+msgid "Show Cast"
+msgstr "Näytä näyttelijät"
+
+#: id:31203
+msgid "Choose Your Song"
+msgstr "Valitse kappale"
+
+#: id:31204
+msgid "Section Links"
+msgstr "Valinta linkit"
+
+#: id:31205
+msgid "Lyrics Source"
+msgstr "Sanoitusten lähde"
+
+#: id:31300
+msgid "Current Temp"
+msgstr "Tämänhetkinen säätila"
+
+#: id:31301
+msgid "Last Updated"
+msgstr "Viimeksi päivitetty"
+
+#: id:31302
+msgid "Menu"
+msgstr "Valikko"
+
+#: id:31303
+msgid "Data provider"
+msgstr "Tietojen tarjoaja"
+
+#: id:31304
+msgid "Picture"
+msgstr "Kuva"
+
+#: id:31305
+msgid "No Disc Media Detected"
+msgstr "Levyä ei löytynyt"
+
+#: id:31306
+msgid "Eject"
+msgstr "Avaa asema"
+
+#: id:31307
+msgid "Hide Fanart"
+msgstr "Piilota fanitaide"
+
+#: id:31308
+msgid "Movie Details"
+msgstr "Elokuvan tiedot"
+
+#: id:31309
+msgid "Memory Used:"
+msgstr "Käytetty muisti:"
+
+#: id:31310
+msgid "Track Number"
+msgstr "Kappalenumero"
+
+#: id:31311
+msgid "Fanart image[CR][CR]Unavailable[CR][CR] Click button to set"
+msgstr "Fanitaide kuvaa[CR][CR]ei ole saatavilla[CR][CR]Klikkaa asettaaksesi"
+
+#: id:31312
+msgid "Current Scraper"
+msgstr "Nykyinen hakupaikka"
+
+#: id:31313
+msgid "Choose a Scraper"
+msgstr "Valitse hakupaikka"
+
+#: id:31314
+msgid "Content Scanning Options"
+msgstr "Sisällön hakuasetukset"
+
+#: id:31315
+msgid "Basic"
+msgstr "Perus"
+
+#: id:31317
+msgid "Set Fanart Path"
+msgstr "Polku"
+
+#: id:31318
+msgid "Small Fanart"
+msgstr "Pieni fanitaide"
+
+#: id:31319
+msgid "Selected Profile"
+msgstr "Valittu profiili"
+
+#: id:31320
+msgid "Last Logged In"
+msgstr "Viimeksi kirjauduttu"
+
+#: id:31321
+msgid "Karaoke Song Selector"
+msgstr "Karaoke kappaleen valinta"
+
+#: id:31322
+msgid "Aired"
+msgstr "Esitetty"
+
+#: id:31323
+msgid "Latest Movies"
+msgstr "Uusimmat elokuvat"
+
+#: id:31324
+msgid "Latest Episodes"
+msgstr "Uusimmat jaksot"
+
+#: id:31325
+msgid "Playlist Options"
+msgstr "Toistolistan asetukset"
+
+#: id:31326
+msgid "Created"
+msgstr "Luotu"
+
+#: id:31327
+msgid "Resolution"
+msgstr "Resoluutio"
+
+#: id:31328
+msgctxt "Auto context with id 31328"
+msgid "Recently Added"
+msgstr "Viimeksi lisätty"
+
+#: id:31329
+msgid "[B]Timer set![/B] [COLOR=grey2] - System auto shutdown in[/COLOR]"
+msgstr "[B]Ajastus[/B] [COLOR=grey2] - Aikaa järjestelmän sammuttamiseen[/COLOR]"
+
+#: id:31330
+msgid "Click button to play[CR][CR]Movie trailer"
+msgstr "Paina painiketta katsoaksesi[CR][CR]elokuvaesittelyn"
+
+#: id:31331
+msgid "Album Details"
+msgstr "Albumin tiedot"
+
+#: id:31351
+msgid "Pause"
+msgstr "Tauko"
+
+#: id:31352
+msgid "Stop"
+msgstr "Pysäytä"
+
+#: id:31353
+msgid "Fast Forward"
+msgstr "Kelaa eteenpäin"
+
+#: id:31354
+msgid "Rewind"
+msgstr "Kelaa taaksepäin"
+
+#: id:31355
+msgid "Movie menu"
+msgstr "Elokuvavalikko"
+
+#: id:31356
+msgid "Download Subtitles"
+msgstr "Lataa tekstitykset"
+
+#: id:31390
+msgid "Skin default"
+msgstr "Ulkoasun oletus"
+
+#: id:31391
+msgid "Skin default with no Caps"
+msgstr "Ulkoasun oletus ilman isoja kirjaimia"
+
+#: id:31392
+msgid "Arial based"
+msgstr "Arial pohjainen"
+
+#: id:31400
+msgid "[B]CONFIGURE APPEARANCE SETTINGS[/B][CR][CR]Change the skin � Set language and region � Change file listing options[CR]Set up a screensaver"
+msgstr "[B]Muokkaa käyttöliittymän asetuksia[/B][CR][CR]Vaihda ulkoasua · Vaihda kieliasetuksia · Aseta tiedostolistauksen asetukset[CR]Aseta ruudunsäästäjä"
+
+#: id:31401
+msgid "[B]CONFIGURE VIDEO SETTINGS[/B][CR][CR]Manage your video library � Set video playback options � Change video listing options[CR]Set subtitle fonts"
+msgstr "[B]Muokkaa video-asetuksia[/B][CR][CR]Hallitse videokirjastoa · Aseta videotoiston asetukset · Vaihda videolistauksen asetuksia[CR]Aseta tekstitysasetukset"
+
+#: id:31402
+msgid "[B]CONFIGURE MUSIC SETTINGS[/B][CR][CR]Manage your music library � Set music playback options � Change music listing options[CR]Setup song submission � Set karaoke options"
+msgstr "[B]Muokkaa musiikki-asetuksia[/B][CR][CR]Hallitse musiikkikirjastoa · Aseta musiikkitoiston asetukset · Vaihda musiikkilistauksen[CR]asetuksia · Aseta kappaleen lähetysasetuksia · Aseta karaoke-asetukset"
+
+#: id:31403
+msgid "[B]CONFIGURE PICTURE SETTINGS[/B][CR][CR]Set picture listing options � Configure slideshows"
+msgstr "[B]Muokkaa kuva-asetuksia[/B][CR][CR]Aseta kuvalistauksen asetukset · Määritä kuvaesityksiä"
+
+#: id:31404
+msgid "[B]CONFIGURE WEATHER SETTINGS[/B][CR][CR]Set three cities to collect weather information"
+msgstr "[B]Muokkaa sää-asetuksia[/B][CR][CR]Aseta kolme kaupunkia joista noudetaan säätiedot"
+
+#: id:31406
+msgid "[B]CONFIGURE SYSTEM SETTINGS[/B][CR][CR]Setup and calibrate displays � Configure audio output � Setup remote controls[CR]Set power saving options � Enable debugging � Setup master lock"
+msgstr "[B]Muokkaa järjestelmän asetuksia[/B][CR][CR]Aseta ja kalibroi näyttö · Määritä äänilähtö · Aseta kauko-ohjaus[CR]Aseta sähkönsäästöasetukset · Ota debuggaus käyttöön · Muokkaa pääkäyttäjän lukituksia"
+
+#: id:31407
+msgid "[B]CONFIGURE SKIN SETTINGS[/B][CR][CR]Setup the Confluence skin � Add and remove home menu items[CR]Change skin backgrounds"
+msgstr "[B]Muokkaa ulkoasun asetuksia[/B][CR][CR]Aseta Confluence-ulkoasun asetukset · Lisää ja poista päävalikon kohteita[CR]Vaihda ulkoasun taustakuvia"
+
+#: id:31408
+msgid "[B]CONFIGURE ADD-ONS[/B][CR][CR]Manage your installed Add-ons � Browse for and install Add-ons from xbmc.org[CR]Modify Add-on settings"
+msgstr "[B]Muokkaa lisäosia[/B][CR][CR]Hallitse asennettuja lisäosia · Valitse ja asenna lisäosia xbmc.org:sta[CR]Muokkaa lisäosien asetuksia"
+
+#: id:31409
+msgid "[B]CONFIGURE SERVICE SETTINGS[/B][CR][CR]Setup control of XBMC via UPnP and HTTP � Configure file sharing[CR]Enable Zeroconf � Configure AirPlay"
+msgstr ""
+
+#: id:31421
+msgid "Select your XBMC user Profile[CR]to login and continue"
+msgstr "Valitse XBMC-käyttäjäprofiili[CR]kirjautuaksesi sisään"
+
+#: id:31900
+msgid "Weather Maps"
+msgstr "Sääkartat"
+
+#: id:31901
+msgid "36 Hour Forecast"
+msgstr "36 tunnin ennuste"
+
+#: id:31902
+msgid "Hourly Forecast"
+msgstr "Tunneittainen ennuste"
+
+#: id:31903
+msgid "Weekend Forecast"
+msgstr "Viikonlopun ennuste"
+
+#: id:31904
+msgid "10 Day Forecast"
+msgstr "10 paivän ennuste"
+
+#: id:31905
+msgid "Forecast"
+msgstr "Ennuste"
+
+#: id:31906
+msgid "Maps & Video"
+msgstr "Kartat & Video"
+
+#: id:31907
+msgid "Video Forecast [COLOR=grey2](Fullscreen Playback)[/COLOR]"
+msgstr "Videoennuste [COLOR=grey2](Kokoruututila)[/COLOR]"
+
+#: id:31908
+msgid "Chance of Precipitation"
+msgstr "Sateen mahdollisuus"
+
+#: id:31909
+msgid "Fetching forecast info..."
+msgstr "Noudetaan ennusteen tietoja..."
+

--- a/addons/skin.confluence/language/French/strings.po
+++ b/addons/skin.confluence/language/French/strings.po
@@ -1,0 +1,576 @@
+# Converted from xbmc strings.xml with xbmc-xml2po (by Team-XBMC)
+msgid ""
+msgstr ""
+"Project-Id-Version: xbmc.skin.confluence-FRODO_GIT953c09c336\n"
+"Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
+"POT-Creation-Date: 2012-04-09 18:03+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE\n"
+"Language: fr\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: id:31000
+msgid "Change Your"
+msgstr "Changement des"
+
+#: id:31001
+msgid "Love"
+msgstr "J'aime"
+
+#: id:31002
+msgid "Hate"
+msgstr "Je deteste"
+
+#: id:31003
+msgid "Power Options"
+msgstr "Options d'alimentation"
+
+#: id:31004
+msgid "Working..."
+msgstr "En cours..."
+
+#: id:31005
+msgid "Hide Information"
+msgstr "Cacher INFO"
+
+#: id:31006
+msgid "View Options"
+msgstr "Options d'Affichage"
+
+#: id:31007
+msgid "Plugins"
+msgstr "Plugins"
+
+#: id:31008
+msgid "Fullscreen"
+msgstr "Plein Ecran"
+
+#: id:31020
+msgctxt "Auto context with id 31020"
+msgid "Recently Added"
+msgstr "Récemment ajouté"
+
+#: id:31021
+msgid "Video - Files"
+msgstr "Vidéo - Fichiers"
+
+#: id:31022
+msgid "Music - Files"
+msgstr "Musique - Fichiers"
+
+#: id:31023
+msgid "Playing"
+msgstr "Lecture"
+
+#: id:31024
+msgid "Page"
+msgstr "Page"
+
+#: id:31025
+msgid "Items"
+msgstr "Objets"
+
+#: id:31026
+msgid "Misc Options"
+msgstr "Options diverses"
+
+#: id:31027
+msgid "Location"
+msgstr "Emplacement"
+
+#: id:31028
+msgid "Poster Wrap"
+msgstr "Affiche Wrap"
+
+#: id:31029
+msgid "Fanart"
+msgstr "Fanart"
+
+#: id:31030
+msgid "Full list"
+msgstr "Liste complète"
+
+#: id:31031
+msgid "Pic Thumbs"
+msgstr "Vignettes"
+
+#: id:31032
+msgid "Image Wrap"
+msgstr "Image Wrap"
+
+#: id:31033
+msgid "Info"
+msgstr "Info"
+
+#: id:31040
+msgid "Now Playing"
+msgstr "Lecture en cours"
+
+#: id:31042
+msgid "PLAYING"
+msgstr "LECTURE"
+
+#: id:31043
+msgid "PAUSED"
+msgstr "PAUSE"
+
+#: id:31044
+msgid "FAST FORWARD"
+msgstr "AVANCE RAPIDE"
+
+#: id:31045
+msgid "REWIND"
+msgstr "RETOUR RAPIDE"
+
+#: id:31046
+msgid "Audio Properties"
+msgstr "Propriétés audio"
+
+#: id:31047
+msgid "Current Preset"
+msgstr "Préréglage Actuel"
+
+#: id:31048
+msgid "Visualization Presets"
+msgstr "Préréglages Visualisation"
+
+#: id:31049
+msgid "End Time"
+msgstr "Echéance"
+
+#: id:31050
+msgid "Sort: Ascending"
+msgstr "Tri : Ascendant"
+
+#: id:31051
+msgid "Sort: Descending"
+msgstr "Tri : Descendant"
+
+#: id:31055
+msgid "Open playlist"
+msgstr "Ouvrir playlist"
+
+#: id:31056
+msgid "Save playlist"
+msgstr "Sauvegarder playlist"
+
+#: id:31057
+msgid "Close playlist"
+msgstr "Fermer playlist"
+
+#: id:31058
+msgid "System music files"
+msgstr "Fichiers musique du système"
+
+#: id:31059
+msgid "Current playlist"
+msgstr "Playlist actuelle"
+
+#: id:31060
+msgid "This file is stacked, select the part you want to play from."
+msgstr "Ce fichier est empilé, sélectionnez la partie que vous souhaitez lire."
+
+#: id:31061
+msgid "Current Selected"
+msgstr "Selection actuelle"
+
+#: id:31101
+msgid "Home screen options"
+msgstr "Options de l'écran d'accueil"
+
+#: id:31102
+msgid "Background"
+msgstr "Arrière-plan"
+
+#: id:31103
+msgid "Show \"Paused\" in picture slide show"
+msgstr "Afficher \"Pause\" dans diaporama d'images"
+
+#: id:31104
+msgid "Play Trailers in a window [COLOR=grey3](Video Information Dialog Only)[/COLOR]"
+msgstr "Jouer les trailers dans un fenêtre [COLOR=grey3](Uniquement dans les infos du film)[/COLOR]"
+
+#: id:31105
+msgid "\"Videos\" button always goes to video \"Files\""
+msgstr ""
+
+#: id:31106
+msgid "Miscellaneous options"
+msgstr "Options diverses"
+
+#: id:31107
+msgid "Hide Flagging read from video filenames [COLOR=grey3](Blu-ray, HD-DVD)[/COLOR]"
+msgstr "Ne pas détecter le format par le nom de fichier [COLOR=grey3](Blu-ray, HD-DVD)[/COLOR]"
+
+#: id:31108
+msgid "Hide Main Menu Buttons"
+msgstr "Masquer les Boutons du Menu Principal"
+
+#: id:31109
+msgid "Media backgrounds"
+msgstr "Arrière-plans Média"
+
+#: id:31110
+msgid "Edit Background for Media Type"
+msgstr "Modifier l'arrière-plan pour le type de média"
+
+#: id:31111
+msgid "Hide"
+msgstr "Masquer"
+
+#: id:31112
+msgid "Options"
+msgstr "Options"
+
+#: id:31113
+msgid "Single Image"
+msgstr "Image simple"
+
+#: id:31114
+msgid "Multi Image"
+msgstr "Image multiple"
+
+#: id:31115
+msgid "Customizer"
+msgstr "Personnaliser"
+
+#: id:31117
+msgid "Show Recently added Videos"
+msgstr "Afficher les vidéos récemment ajoutées"
+
+#: id:31118
+msgid "Home Page Programs Submenu"
+msgstr "Sous-menu Programmes de la page d'accueil"
+
+#: id:31119
+msgid "Hide Background Fanart"
+msgstr ""
+
+#: id:31120
+msgid "BUTTON LABEL"
+msgstr "ÉTIQUETTE DU BOUTON"
+
+#: id:31122
+msgid "Weather Page"
+msgstr "Page météo"
+
+#: id:31123
+msgid "Use \"Posters\" instead of \"Banners\" for TV Shows"
+msgstr "Préférer les \"Affiches\" aux \"Bannières\" pour les émissions TV"
+
+#: id:31124
+msgid "Show Background \"Now Playing\" Video"
+msgstr "Afficher la vidéo en cours de lecture en arrière-plan"
+
+#: id:31125
+msgid "Show Background \"Now Playing\" Visualization"
+msgstr "Afficher la visualisation en cours de lecture en arrière-plan"
+
+#: id:31126
+msgid "Play TV theme songs in video library (TvTunes add-on)"
+msgstr ""
+
+#: id:31127
+msgid "TvTunes"
+msgstr ""
+
+#: id:31128
+msgid "Lyrics"
+msgstr "Lyrics"
+
+#: id:31132
+msgid "Lyrics Add-on"
+msgstr "Add-on Lyrics"
+
+#: id:31133
+msgid "Subtitle Add-on"
+msgstr "Add-on Sous-titres"
+
+#: id:31134
+msgid "Home Page Videos Submenu"
+msgstr "Sous-menu Videos de la page d'acceuil"
+
+#: id:31135
+msgid "Home Page Music Submenu"
+msgstr "Sous-menu Musique de la page d'acceuil"
+
+#: id:31136
+msgid "Home Page Pictures Submenu"
+msgstr "Sous-menu Images de la page d'acceuil"
+
+#: id:31140
+msgid "Music OSD"
+msgstr "OSD Musique"
+
+#: id:31141
+msgid "Video OSD"
+msgstr "OSD Vidéo"
+
+#: id:31200
+msgid "Shortcuts"
+msgstr "Raccourcis"
+
+#: id:31201
+msgid "Categories"
+msgstr "Catégories"
+
+#: id:31202
+msgid "Show Cast"
+msgstr "Voir le casting"
+
+#: id:31203
+msgid "Choose Your Song"
+msgstr "Choisissez votre chanson"
+
+#: id:31204
+msgid "Section Links"
+msgstr "Section Liens"
+
+#: id:31205
+msgid "Lyrics Source"
+msgstr "Lyrics Source"
+
+#: id:31300
+msgid "Current Temp"
+msgstr "Temp. Actuelle"
+
+#: id:31301
+msgid "Last Updated"
+msgstr "Dernière mise à jour"
+
+#: id:31302
+msgid "Menu"
+msgstr "Menu"
+
+#: id:31303
+msgid "Data provider"
+msgstr ""
+
+#: id:31304
+msgid "Picture"
+msgstr "Image"
+
+#: id:31305
+msgid "No Disc Media Detected"
+msgstr "Aucun disque de média détecté"
+
+#: id:31306
+msgid "Eject"
+msgstr "Éjecter"
+
+#: id:31307
+msgid "Hide Fanart"
+msgstr "Sans Fanart"
+
+#: id:31308
+msgid "Movie Details"
+msgstr "Détails du film"
+
+#: id:31309
+msgid "Memory Used:"
+msgstr "Mémoire utilisée:"
+
+#: id:31310
+msgid "Track Number"
+msgstr "Numéro de la piste"
+
+#: id:31311
+msgid "Fanart image[CR][CR]Unavailable[CR][CR] Click button to set"
+msgstr "Image fanart[CR][CR]Indisponible[CR][CR]Cliquer sur le bouton pour définir"
+
+#: id:31312
+msgid "Current Scraper"
+msgstr "Scraper Actuel"
+
+#: id:31313
+msgid "Choose a Scraper"
+msgstr "Choisissez un Scraper"
+
+#: id:31314
+msgid "Content Scanning Options"
+msgstr "Options Contenu du Scan"
+
+#: id:31315
+msgid "Basic"
+msgstr "Basic"
+
+#: id:31317
+msgid "Set Fanart Path"
+msgstr "Définir le chemin du Fanart"
+
+#: id:31318
+msgid "Small Fanart"
+msgstr "Petit Fanart"
+
+#: id:31319
+msgid "Selected Profile"
+msgstr "Profil sélectionné"
+
+#: id:31320
+msgid "Last Logged In"
+msgstr "Derniers connectés"
+
+#: id:31321
+msgid "Karaoke Song Selector"
+msgstr "Sélecteur chanson Karaoké"
+
+#: id:31322
+msgid "Aired"
+msgstr "Diffusé"
+
+#: id:31323
+msgid "Latest Movies"
+msgstr "Derniers films"
+
+#: id:31324
+msgid "Latest Episodes"
+msgstr "Derniers épisodes"
+
+#: id:31325
+msgid "Playlist Options"
+msgstr "Options Playliste"
+
+#: id:31326
+msgid "Created"
+msgstr "Créé"
+
+#: id:31327
+msgid "Resolution"
+msgstr "Résolution"
+
+#: id:31328
+msgctxt "Auto context with id 31328"
+msgid "Recently Added"
+msgstr "Récemment ajouté"
+
+#: id:31329
+msgid "[B]Timer set![/B] [COLOR=grey2] - System auto shutdown in[/COLOR]"
+msgstr "[B]Réglage minuterie ![/B] [COLOR=grey2] - Fermer le système automatiquement dans[/COLOR]"
+
+#: id:31330
+msgid "Click button to play[CR][CR]Movie trailer"
+msgstr "Cliquer sur le bouton pour voir[CR][CR]le trailer du film"
+
+#: id:31331
+msgid "Album Details"
+msgstr "Détails de l'Album"
+
+#: id:31351
+msgid "Pause"
+msgstr "Pause"
+
+#: id:31352
+msgid "Stop"
+msgstr "Stop"
+
+#: id:31353
+msgid "Fast Forward"
+msgstr "Avance Rapide"
+
+#: id:31354
+msgid "Rewind"
+msgstr "Retour Rapide"
+
+#: id:31355
+msgid "Movie menu"
+msgstr "Menu film"
+
+#: id:31356
+msgid "Download Subtitles"
+msgstr "Télécharger les sous-titres"
+
+#: id:31390
+msgid "Skin default"
+msgstr "Par défaut"
+
+#: id:31391
+msgid "Skin default with no Caps"
+msgstr "Par défaut sans Majuscule"
+
+#: id:31392
+msgid "Arial based"
+msgstr "Basé sur Arial"
+
+#: id:31400
+msgid "[B]CONFIGURE APPEARANCE SETTINGS[/B][CR][CR]Change the skin � Set language and region � Change file listing options[CR]Set up a screensaver"
+msgstr "[B]CONFIGURATION DES PARAMÈTRES APPARENCE[/B][CR][CR]Changer le skin · Choisir la langue et la région · Changer les options de liste[CR]Changer l'économiseur d'écran"
+
+#: id:31401
+msgid "[B]CONFIGURE VIDEO SETTINGS[/B][CR][CR]Manage your video library � Set video playback options � Change video listing options[CR]Set subtitle fonts"
+msgstr "[B]CONFIGURATION DES PARAMÈTRES VIDÉO[/B][CR][CR]Gérer votre médiathèque · Définir les options de lecture · Changer les options de liste[CR]Régler la police des sous-titres"
+
+#: id:31402
+msgid "[B]CONFIGURE MUSIC SETTINGS[/B][CR][CR]Manage your music library � Set music playback options � Change music listing options[CR]Setup song submission � Set karaoke options"
+msgstr "[B]CONFIGURATION DES PARAMÈTRES MUSIQUE[/B][CR][CR]Gérer votre médiathèque · Définir les options de lecture · Changer les options de liste[CR]Soumettre des chansons · Changer les options karaoké"
+
+#: id:31403
+msgid "[B]CONFIGURE PICTURE SETTINGS[/B][CR][CR]Set picture listing options � Configure slideshows"
+msgstr "[B]CONFIGURATION DES PARAMÈTRES IMAGE[/B][CR][CR]Définir les options de lecture · Configurer les diaporamas"
+
+#: id:31404
+msgid "[B]CONFIGURE WEATHER SETTINGS[/B][CR][CR]Set three cities to collect weather information"
+msgstr "[B]CONFIGURATION DES PARAMÈTRES MÉTÉO[/B][CR][CR]Choisir les trois villes qui recueilleront les informations météorologiques"
+
+#: id:31406
+msgid "[B]CONFIGURE SYSTEM SETTINGS[/B][CR][CR]Setup and calibrate displays � Configure audio output � Setup remote controls[CR]Set power saving options � Enable debugging � Setup master lock"
+msgstr "[B]CONFIGURATION DES PARAMÈTRES SYSTÈME[/B][CR][CR]Configurer les sorties vidéo et audio · Configurer les périphériques de contrôle[CR]Définir les options de gestion d'énergie · Activer le débogage · Configurer la sécurité"
+
+#: id:31407
+msgid "[B]CONFIGURE SKIN SETTINGS[/B][CR][CR]Setup the Confluence skin � Add and remove home menu items[CR]Change skin backgrounds"
+msgstr "[B]CONFIGURATION DES PARAMÈTRES THÈME[/B][CR][CR]Configuration du skin Confluence · Ajouter et supprimer des éléments du menu d'accueil[CR]Changer les arrière-plans du skin"
+
+#: id:31408
+msgid "[B]CONFIGURE ADD-ONS[/B][CR][CR]Manage your installed Add-ons � Browse for and install Add-ons from xbmc.org[CR]Modify Add-on settings"
+msgstr "[B]CONFIGURATION DES ADD-ONS[/B][CR][CR]Gérer les Add-ons installés· Recherche et installation d'Add-ons depuis xbmc.org[CR]Modifier les paramètres Add-on"
+
+#: id:31409
+msgid "[B]CONFIGURE SERVICE SETTINGS[/B][CR][CR]Setup control of XBMC via UPnP and HTTP � Configure file sharing[CR]Enable Zeroconf � Configure AirPlay"
+msgstr ""
+
+#: id:31421
+msgid "Select your XBMC user Profile[CR]to login and continue"
+msgstr "Sélectionnez un profil d'utilisateur[CR]pour vous connecter et continuer"
+
+#: id:31900
+msgid "Weather Maps"
+msgstr "Cartes Météo"
+
+#: id:31901
+msgid "36 Hour Forecast"
+msgstr "Prévisions sur 36 Heures"
+
+#: id:31902
+msgid "Hourly Forecast"
+msgstr "Prévisions Heure par Heure"
+
+#: id:31903
+msgid "Weekend Forecast"
+msgstr "Prévisions pour le Weekend"
+
+#: id:31904
+msgid "10 Day Forecast"
+msgstr "Prévisions sur 10 Jours"
+
+#: id:31905
+msgid "Forecast"
+msgstr "Prévisions"
+
+#: id:31906
+msgid "Maps & Video"
+msgstr "Cartes & Vidéo"
+
+#: id:31907
+msgid "Video Forecast [COLOR=grey2](Fullscreen Playback)[/COLOR]"
+msgstr "Bulletin vidéo [COLOR=grey2](affichage en plein écran)[/COLOR]"
+
+#: id:31908
+msgid "Chance of Precipitation"
+msgstr "Risque de pluie"
+
+#: id:31909
+msgid "Fetching forecast info..."
+msgstr "Récupération des prévisions météo..."
+

--- a/addons/skin.confluence/language/German/strings.po
+++ b/addons/skin.confluence/language/German/strings.po
@@ -1,0 +1,576 @@
+# Converted from xbmc strings.xml with xbmc-xml2po (by Team-XBMC)
+msgid ""
+msgstr ""
+"Project-Id-Version: xbmc.skin.confluence-FRODO_GIT953c09c336\n"
+"Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
+"POT-Creation-Date: 2012-04-09 18:03+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE\n"
+"Language: de\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: id:31000
+msgid "Change Your"
+msgstr "Ändern der"
+
+#: id:31001
+msgid "Love"
+msgstr "Liebe"
+
+#: id:31002
+msgid "Hate"
+msgstr "Hass"
+
+#: id:31003
+msgid "Power Options"
+msgstr "Power Optionen"
+
+#: id:31004
+msgid "Working..."
+msgstr "In Arbeit..."
+
+#: id:31005
+msgid "Hide Information"
+msgstr "Verberge Info"
+
+#: id:31006
+msgid "View Options"
+msgstr "Anzeige Optionen"
+
+#: id:31007
+msgid "Plugins"
+msgstr "Plugins"
+
+#: id:31008
+msgid "Fullscreen"
+msgstr "Vollbild"
+
+#: id:31020
+msgctxt "Auto context with id 31020"
+msgid "Recently Added"
+msgstr "Kürzlich hinzugefügt"
+
+#: id:31021
+msgid "Video - Files"
+msgstr "Video - Dateien"
+
+#: id:31022
+msgid "Music - Files"
+msgstr "Musik - Dateien"
+
+#: id:31023
+msgid "Playing"
+msgstr "Abspielen"
+
+#: id:31024
+msgid "Page"
+msgstr "Seite"
+
+#: id:31025
+msgid "Items"
+msgstr "Einträge"
+
+#: id:31026
+msgid "Misc Options"
+msgstr "Allg. Optionen"
+
+#: id:31027
+msgid "Location"
+msgstr "Ort"
+
+#: id:31028
+msgid "Poster Wrap"
+msgstr "Poster"
+
+#: id:31029
+msgid "Fanart"
+msgstr "Fanart"
+
+#: id:31030
+msgid "Full list"
+msgstr "Komplette Liste"
+
+#: id:31031
+msgid "Pic Thumbs"
+msgstr "Bild Vorschau"
+
+#: id:31032
+msgid "Image Wrap"
+msgstr "Bild Wrap"
+
+#: id:31033
+msgid "Info"
+msgstr "Info"
+
+#: id:31040
+msgid "Now Playing"
+msgstr "Jetzt gespielt"
+
+#: id:31042
+msgid "PLAYING"
+msgstr "ABSPIELEN"
+
+#: id:31043
+msgid "PAUSED"
+msgstr "PAUSE"
+
+#: id:31044
+msgid "FAST FORWARD"
+msgstr "SCHNELL VORLAUF"
+
+#: id:31045
+msgid "REWIND"
+msgstr "RÜCKLAUF"
+
+#: id:31046
+msgid "Audio Properties"
+msgstr "Audio Einstellungen"
+
+#: id:31047
+msgid "Current Preset"
+msgstr "Aktuelle Einstellung"
+
+#: id:31048
+msgid "Visualization Presets"
+msgstr "Visualisierungs Einstellungen"
+
+#: id:31049
+msgid "End Time"
+msgstr "Schluss Zeit"
+
+#: id:31050
+msgid "Sort: Ascending"
+msgstr "Sortieren: Aufsteigend"
+
+#: id:31051
+msgid "Sort: Descending"
+msgstr "Sortieren: Absteigend"
+
+#: id:31055
+msgid "Open playlist"
+msgstr "Öffne Wiedergabeliste"
+
+#: id:31056
+msgid "Save playlist"
+msgstr "Sichere Wiedergabeliste"
+
+#: id:31057
+msgid "Close playlist"
+msgstr "Schliesse Wiedergabeliste"
+
+#: id:31058
+msgid "System music files"
+msgstr "System Musik Dateien"
+
+#: id:31059
+msgid "Current playlist"
+msgstr "Aktuelle Wiedergabeliste"
+
+#: id:31060
+msgid "This file is stacked, select the part you want to play from."
+msgstr "Die Datei ist gestapelt, wähle den Teil zum abspielen."
+
+#: id:31061
+msgid "Current Selected"
+msgstr "Aktuell ausgewählt"
+
+#: id:31101
+msgid "Home screen options"
+msgstr "Home Screen Optionen"
+
+#: id:31102
+msgid "Background"
+msgstr "Hintergrund"
+
+#: id:31103
+msgid "Show \"Paused\" in picture slide show"
+msgstr "Zeige \"Pause\" in Bilder Diaschau"
+
+#: id:31104
+msgid "Play Trailers in a window [COLOR=grey3](Video Information Dialog Only)[/COLOR]"
+msgstr "Trailer im Fenster wiedergeben [COLOR=grey3](Video Information Dialog)[/COLOR]"
+
+#: id:31105
+msgid "\"Videos\" button always goes to video \"Files\""
+msgstr "\"Videos\" Button geht immer zu Video \"Dateien\""
+
+#: id:31106
+msgid "Miscellaneous options"
+msgstr "Sonstige Optionen"
+
+#: id:31107
+msgid "Hide Flagging read from video filenames [COLOR=grey3](Blu-ray, HD-DVD)[/COLOR]"
+msgstr "Flags von Dateinamen ausblenden [COLOR=grey3](Blu-ray, HD-DVD)[/COLOR]"
+
+#: id:31108
+msgid "Hide Main Menu Buttons"
+msgstr "Verstecke Hauptmenü Buttons"
+
+#: id:31109
+msgid "Media backgrounds"
+msgstr "Home Screen Hintergrund"
+
+#: id:31110
+msgid "Edit Background for Media Type"
+msgstr "Ändere Hintergrund für Home Button"
+
+#: id:31111
+msgid "Hide"
+msgstr "Verstecke"
+
+#: id:31112
+msgid "Options"
+msgstr "Optionen"
+
+#: id:31113
+msgid "Single Image"
+msgstr "Einzel Bild"
+
+#: id:31114
+msgid "Multi Image"
+msgstr "Mehrfach Bild"
+
+#: id:31115
+msgid "Customizer"
+msgstr "Spezifische"
+
+#: id:31117
+msgid "Show Recently added Videos"
+msgstr "Zeige kürzlich hinzugefügte Videos"
+
+#: id:31118
+msgid "Home Page Programs Submenu"
+msgstr "Hauptfenster Programme-Untermenü"
+
+#: id:31119
+msgid "Hide Background Fanart"
+msgstr "Verstecke Hintergrund Fanart"
+
+#: id:31120
+msgid "BUTTON LABEL"
+msgstr "BUTTON BESCHRIFTUNG"
+
+#: id:31122
+msgid "Weather Page"
+msgstr "Wetter Seite"
+
+#: id:31123
+msgid "Use \"Posters\" instead of \"Banners\" for TV Shows"
+msgstr "Verwende \"Posters\" anstelle von \"Banners\" für TV Shows"
+
+#: id:31124
+msgid "Show Background \"Now Playing\" Video"
+msgstr "Zeige Hintergrund \"Aktuell abgespielt\" Video"
+
+#: id:31125
+msgid "Show Background \"Now Playing\" Visualization"
+msgstr "Zeige Hintergrund \"Aktuell abgespielt\" Visualisierung"
+
+#: id:31126
+msgid "Play TV theme songs in video library (TvTunes add-on)"
+msgstr "Spiele TV Themes in der Video Datenbank (TvTunes Ad-on)"
+
+#: id:31127
+msgid "TvTunes"
+msgstr "TvTunes"
+
+#: id:31128
+msgid "Lyrics"
+msgstr "Lyrics"
+
+#: id:31132
+msgid "Lyrics Add-on"
+msgstr "Songtext Add-on"
+
+#: id:31133
+msgid "Subtitle Add-on"
+msgstr "Untertitel Add-on"
+
+#: id:31134
+msgid "Home Page Videos Submenu"
+msgstr "Homefenster Videos-Untermenü"
+
+#: id:31135
+msgid "Home Page Music Submenu"
+msgstr "Homefenster Musik-Untermenü"
+
+#: id:31136
+msgid "Home Page Pictures Submenu"
+msgstr "Homefenster Bilder-Untermenü"
+
+#: id:31140
+msgid "Music OSD"
+msgstr "Musik OSD"
+
+#: id:31141
+msgid "Video OSD"
+msgstr "Video OSD"
+
+#: id:31200
+msgid "Shortcuts"
+msgstr "Tastenkürzel"
+
+#: id:31201
+msgid "Categories"
+msgstr "Kategorie"
+
+#: id:31202
+msgid "Show Cast"
+msgstr "Zeige Darsteller"
+
+#: id:31203
+msgid "Choose Your Song"
+msgstr "Wähle Dein Lied"
+
+#: id:31204
+msgid "Section Links"
+msgstr "Sektions Verknüpfung"
+
+#: id:31205
+msgid "Lyrics Source"
+msgstr "Lyrics Quelle"
+
+#: id:31300
+msgid "Current Temp"
+msgstr "Aktuelle Temperatur"
+
+#: id:31301
+msgid "Last Updated"
+msgstr "Letztes Update"
+
+#: id:31302
+msgid "Menu"
+msgstr "Menü"
+
+#: id:31303
+msgid "Data provider"
+msgstr "Quelle"
+
+#: id:31304
+msgid "Picture"
+msgstr "Bild"
+
+#: id:31305
+msgid "No Disc Media Detected"
+msgstr "Keine Disk vorhanden"
+
+#: id:31306
+msgid "Eject"
+msgstr "Auswerfen"
+
+#: id:31307
+msgid "Hide Fanart"
+msgstr "Verberge Fanart"
+
+#: id:31308
+msgid "Movie Details"
+msgstr "Film Details"
+
+#: id:31309
+msgid "Memory Used:"
+msgstr "Speicher in Benutzung:"
+
+#: id:31310
+msgid "Track Number"
+msgstr "Lied Nummer"
+
+#: id:31311
+msgid "Fanart image[CR][CR]Unavailable[CR][CR] Click button to set"
+msgstr "FANART BILD[CR][CR]NICHT VORHANDEN[CR][CR] CLICK BUTTON ZUM SETZEN"
+
+#: id:31312
+msgid "Current Scraper"
+msgstr "Aktueller Scraper"
+
+#: id:31313
+msgid "Choose a Scraper"
+msgstr "Wähle Scraper"
+
+#: id:31314
+msgid "Content Scanning Options"
+msgstr "Inhalt Scanning Optionen"
+
+#: id:31315
+msgid "Basic"
+msgstr "Basic"
+
+#: id:31317
+msgid "Set Fanart Path"
+msgstr "Setze Fanart Pfad"
+
+#: id:31318
+msgid "Small Fanart"
+msgstr "Kleines Fanart"
+
+#: id:31319
+msgid "Selected Profile"
+msgstr "Ausgewähltes Profil"
+
+#: id:31320
+msgid "Last Logged In"
+msgstr "Letzte Anmeldung"
+
+#: id:31321
+msgid "Karaoke Song Selector"
+msgstr "Karaoke Song Selector"
+
+#: id:31322
+msgid "Aired"
+msgstr "Gesendet"
+
+#: id:31323
+msgid "Latest Movies"
+msgstr "Letzte Filme"
+
+#: id:31324
+msgid "Latest Episodes"
+msgstr "Letzte Episoden"
+
+#: id:31325
+msgid "Playlist Options"
+msgstr "Wiedergabeliste Optionen"
+
+#: id:31326
+msgid "Created"
+msgstr "Erstellt"
+
+#: id:31327
+msgid "Resolution"
+msgstr "Auflösung"
+
+#: id:31328
+msgctxt "Auto context with id 31328"
+msgid "Recently Added"
+msgstr "Kürzlich Hinzugefügt"
+
+#: id:31329
+msgid "[B]Timer set![/B] [COLOR=grey2] - System auto shutdown in[/COLOR]"
+msgstr "[B]TIMER SET![/B] [COLOR=grey2] - SYSTEM AUTO SHUTDOWN IN[/COLOR]"
+
+#: id:31330
+msgid "Click button to play[CR][CR]Movie trailer"
+msgstr "Starte[CR][CR]Filmtrailer"
+
+#: id:31331
+msgid "Album Details"
+msgstr "Album Details"
+
+#: id:31351
+msgid "Pause"
+msgstr "Pause"
+
+#: id:31352
+msgid "Stop"
+msgstr "Stop"
+
+#: id:31353
+msgid "Fast Forward"
+msgstr "Vorspulen"
+
+#: id:31354
+msgid "Rewind"
+msgstr "Rückspulen"
+
+#: id:31355
+msgid "Movie menu"
+msgstr "Filmmenü"
+
+#: id:31356
+msgid "Download Subtitles"
+msgstr "Untertitel herunterladen"
+
+#: id:31390
+msgid "Skin default"
+msgstr "Skin Standard"
+
+#: id:31391
+msgid "Skin default with no Caps"
+msgstr "Skin Standard ohne Großbuchstaben"
+
+#: id:31392
+msgid "Arial based"
+msgstr "Arial basiert"
+
+#: id:31400
+msgid "[B]CONFIGURE APPEARANCE SETTINGS[/B][CR][CR]Change the skin � Set language and region � Change file listing options[CR]Set up a screensaver"
+msgstr "[B]KONFIGURIERE DIE DARSTELLUNGS EINSTELLUNGEN[/B][CR][CR]Wechsel den Skin · Wähle Sprache und Region · Wechsel Dateilisten Optionen[CR]Setze Bildschirmschoner"
+
+#: id:31401
+msgid "[B]CONFIGURE VIDEO SETTINGS[/B][CR][CR]Manage your video library � Set video playback options � Change video listing options[CR]Set subtitle fonts"
+msgstr "[B]KONFIGURIERE VIDEO EINSTELLUNGEN[/B][CR][CR]Organisiere die Video DB · Setze die Abspiel Optionen · Wechsel die Video Auflistungs Optionen · Setze Untertitel Schrift"
+
+#: id:31402
+msgid "[B]CONFIGURE MUSIC SETTINGS[/B][CR][CR]Manage your music library � Set music playback options � Change music listing options[CR]Setup song submission � Set karaoke options"
+msgstr "[B]KONFIGURIERE MUSIK EINSTELLUNGEN[/B][CR][CR]Organisiere die Musik DB · Setze die Musik Abspiel Optionen · Wechsel die Musik Auflistungs Optionen · Einrichten der Lied Vorlage · Setze Karaoke Optionen"
+
+#: id:31403
+msgid "[B]CONFIGURE PICTURE SETTINGS[/B][CR][CR]Set picture listing options � Configure slideshows"
+msgstr "[B]KONFIGURIERE BILDER EINSTELLUNGEN[/B][CR][CR]Setze Bild Auflistungs Optionen · Konfiguriere Diaschau"
+
+#: id:31404
+msgid "[B]CONFIGURE WEATHER SETTINGS[/B][CR][CR]Set three cities to collect weather information"
+msgstr "[B]KONFIGURIERE WETTER EINSTELLUNGEN[/B][CR][CR]Wähle drei Städte zum sammeln der Wetter Informationen"
+
+#: id:31406
+msgid "[B]CONFIGURE SYSTEM SETTINGS[/B][CR][CR]Setup and calibrate displays � Configure audio output � Setup remote controls[CR]Set power saving options � Enable debugging � Setup master lock"
+msgstr "[B]KONFIGURIERE SYSTEM EINSTELLUNGEN[/B][CR][CR]Setze und kalibriere Displays · Konfiguriere Audioausgabe · Setze Fernbedienungs Einstellungen · Setze Energiespar Optionen · Aktiviere Debugging · Einrichten Master Sperre"
+
+#: id:31407
+msgid "[B]CONFIGURE SKIN SETTINGS[/B][CR][CR]Setup the Confluence skin � Add and remove home menu items[CR]Change skin backgrounds"
+msgstr "[B]KONFIGURIERE SKIN EINSTELLUNGEN[/B][CR][CR]Einrichten des Confluence Skin · Hinzufügen und entfernen der Home Menü Einträge[CR]Wechseln der Skin Hintergründe"
+
+#: id:31408
+msgid "[B]CONFIGURE ADD-ONS[/B][CR][CR]Manage your installed Add-ons � Browse for and install Add-ons from xbmc.org[CR]Modify Add-on settings"
+msgstr "[B]KONFIGURIERE ADD-ONS[/B][CR][CR]Organisiere die installierten Add-ons · Installiere Add-ons von xbmc.org[CR]Add-on Einstellungen anpassen"
+
+#: id:31409
+msgid "[B]CONFIGURE SERVICE SETTINGS[/B][CR][CR]Setup control of XBMC via UPnP and HTTP � Configure file sharing[CR]Enable Zeroconf � Configure AirPlay"
+msgstr "[B]KONFIGURIERE DIENSTE[/B][CR][CR]Richte Zugriff auf XBMC via UPnP und HTTP ein · Konfiguriere die Dateifreigabe[CR]Aktiviere Zeroconf · Konfiguriere AirPlay"
+
+#: id:31421
+msgid "Select your XBMC user Profile[CR]to login and continue"
+msgstr "Wähle Dein XBMC Benutzer Profil[CR]Zum Anmelden und Weitermachen"
+
+#: id:31900
+msgid "Weather Maps"
+msgstr "Wetterkarten"
+
+#: id:31901
+msgid "36 Hour Forecast"
+msgstr "36 Stunden Prognose"
+
+#: id:31902
+msgid "Hourly Forecast"
+msgstr "Stündliche Prognose"
+
+#: id:31903
+msgid "Weekend Forecast"
+msgstr "Wochenend Prognose"
+
+#: id:31904
+msgid "10 Day Forecast"
+msgstr "10 Tage Prognose"
+
+#: id:31905
+msgid "Forecast"
+msgstr "Prognose"
+
+#: id:31906
+msgid "Maps & Video"
+msgstr "Karten & Video"
+
+#: id:31907
+msgid "Video Forecast [COLOR=grey2](Fullscreen Playback)[/COLOR]"
+msgstr "Video Prognose [COLOR=grey2](Vollbild Wiedergabe)[/COLOR]"
+
+#: id:31908
+msgid "Chance of Precipitation"
+msgstr "Niederschlagswahrscheinlichkeit"
+
+#: id:31909
+msgid "Fetching forecast info..."
+msgstr "Lade Wetterbericht..."
+

--- a/addons/skin.confluence/language/Greek/strings.po
+++ b/addons/skin.confluence/language/Greek/strings.po
@@ -1,0 +1,576 @@
+# Converted from xbmc strings.xml with xbmc-xml2po (by Team-XBMC)
+msgid ""
+msgstr ""
+"Project-Id-Version: xbmc.skin.confluence-FRODO_GIT953c09c336\n"
+"Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
+"POT-Creation-Date: 2012-04-09 18:03+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE\n"
+"Language: el\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: id:31000
+msgid "Change Your"
+msgstr "Αλλαγή"
+
+#: id:31001
+msgid "Love"
+msgstr "Αγαπητό"
+
+#: id:31002
+msgid "Hate"
+msgstr "Απεχθές"
+
+#: id:31003
+msgid "Power Options"
+msgstr "Επιλογές λειτουργίας"
+
+#: id:31004
+msgid "Working..."
+msgstr "Απασχολημένο..."
+
+#: id:31005
+msgid "Hide Information"
+msgstr "Απόκρυψη Πληροφοριών"
+
+#: id:31006
+msgid "View Options"
+msgstr "Προβολή Επιλογών"
+
+#: id:31007
+msgid "Plugins"
+msgstr "Plugin"
+
+#: id:31008
+msgid "Fullscreen"
+msgstr "Πλήρης Οθόνη"
+
+#: id:31020
+msgctxt "Auto context with id 31020"
+msgid "Recently Added"
+msgstr "Προστέθηκαν πρόσφατα"
+
+#: id:31021
+msgid "Video - Files"
+msgstr "Βίντεο - Αρχεία"
+
+#: id:31022
+msgid "Music - Files"
+msgstr "Μουσική - Αρχεία"
+
+#: id:31023
+msgid "Playing"
+msgstr "Αναπαραγωγή"
+
+#: id:31024
+msgid "Page"
+msgstr "Σελίδα"
+
+#: id:31025
+msgid "Items"
+msgstr "Αντικείμενα"
+
+#: id:31026
+msgid "Misc Options"
+msgstr "Διάφορες επιλογές"
+
+#: id:31027
+msgid "Location"
+msgstr "Τοποθεσία"
+
+#: id:31028
+msgid "Poster Wrap"
+msgstr "Αφίσες"
+
+#: id:31029
+msgid "Fanart"
+msgstr "Fanart"
+
+#: id:31030
+msgid "Full list"
+msgstr "Πλήρης λίστα"
+
+#: id:31031
+msgid "Pic Thumbs"
+msgstr "Μικρογραφίες"
+
+#: id:31032
+msgid "Image Wrap"
+msgstr "Εικόνες"
+
+#: id:31033
+msgid "Info"
+msgstr "Πληροφορίες"
+
+#: id:31040
+msgid "Now Playing"
+msgstr "Τώρα Εκτελείται"
+
+#: id:31042
+msgid "PLAYING"
+msgstr "ΑΝΑΠΑΡΑΓΩΓΗ"
+
+#: id:31043
+msgid "PAUSED"
+msgstr "ΠΑΥΣΗ"
+
+#: id:31044
+msgid "FAST FORWARD"
+msgstr "ΜΠΡΟΣΤΑ"
+
+#: id:31045
+msgid "REWIND"
+msgstr "ΠΙΣΩ"
+
+#: id:31046
+msgid "Audio Properties"
+msgstr "Ιδιότητες Ήχου"
+
+#: id:31047
+msgid "Current Preset"
+msgstr "Τρέχον Προκαθορισμένο"
+
+#: id:31048
+msgid "Visualization Presets"
+msgstr "Προκαθορισμένες Οπτικοποιήσεις"
+
+#: id:31049
+msgid "End Time"
+msgstr "Χρόνος λήξης"
+
+#: id:31050
+msgid "Sort: Ascending"
+msgstr "Ταξ.: Αύξουσα"
+
+#: id:31051
+msgid "Sort: Descending"
+msgstr "Ταξ.: Φθίνουσα"
+
+#: id:31055
+msgid "Open playlist"
+msgstr "Άνοιγμα λίστας αναπαραγωγής"
+
+#: id:31056
+msgid "Save playlist"
+msgstr "Αποθήκευση λίστας αναπαραγωγής"
+
+#: id:31057
+msgid "Close playlist"
+msgstr "Κλείσιμο λίστας αναπαραγωγής"
+
+#: id:31058
+msgid "System music files"
+msgstr "Μουσικά αρχεία συστήματος"
+
+#: id:31059
+msgid "Current playlist"
+msgstr "Τρέχουσα λίστα αναπαραγωγής"
+
+#: id:31060
+msgid "This file is stacked, select the part you want to play from."
+msgstr "Αυτό το αρχείο είναι στοιβαγμένο, επιλέξτε από που να γίνει αναπαραγωγή."
+
+#: id:31061
+msgid "Current Selected"
+msgstr "Τρέχουσα Επιλογή"
+
+#: id:31101
+msgid "Home screen options"
+msgstr "Επιλογές αρχικής οθόνης"
+
+#: id:31102
+msgid "Background"
+msgstr "Υπόβαθρο"
+
+#: id:31103
+msgid "Show \"Paused\" in picture slide show"
+msgstr "Εμφάνιση 'Παύσης' σε παρουσίαση διαφανειών"
+
+#: id:31104
+msgid "Play Trailers in a window [COLOR=grey3](Video Information Dialog Only)[/COLOR]"
+msgstr "Αναπαραγωγή Διαφημιστικών σε παράθυρο [COLOR=grey3](Μόνο οι πληροφορίες βίντεο)[/COLOR]"
+
+#: id:31105
+msgid "\"Videos\" button always goes to video \"Files\""
+msgstr "Το πλήκτρο \"Βίντεο\" πάντα οδηγεί στα \"Αρχεία\" βίντεο"
+
+#: id:31106
+msgid "Miscellaneous options"
+msgstr "Διάφορες επιλογές"
+
+#: id:31107
+msgid "Hide Flagging read from video filenames [COLOR=grey3](Blu-ray, HD-DVD)[/COLOR]"
+msgstr "Απόκρυψη των αναγνώσιμων σημαιών από τα ονόματα αρχείων βίντεο [COLOR=grey3](Blu-ray, HD-DVD)[/COLOR]"
+
+#: id:31108
+msgid "Hide Main Menu Buttons"
+msgstr "Απόκρυψη πλήκτρων του Κεντρικού Μενού"
+
+#: id:31109
+msgid "Media backgrounds"
+msgstr "Υπόβαθρα αρχικής οθόνης"
+
+#: id:31110
+msgid "Edit Background for Media Type"
+msgstr "Επεξεργασία υποβάθρου για το αρχικό πλήκτρο"
+
+#: id:31111
+msgid "Hide"
+msgstr "Απόκρυψη"
+
+#: id:31112
+msgid "Options"
+msgstr "Επιλογές"
+
+#: id:31113
+msgid "Single Image"
+msgstr "Μία Εικόνα"
+
+#: id:31114
+msgid "Multi Image"
+msgstr "Πολλαπλές εικόνες"
+
+#: id:31115
+msgid "Customizer"
+msgstr "Προσαρμογή"
+
+#: id:31117
+msgid "Show Recently added Videos"
+msgstr "Εμφάνιση των πρόσφατα προστιθέμενων βίντεο"
+
+#: id:31118
+msgid "Home Page Programs Submenu"
+msgstr "Υπομενού Εφαρμογών αρχικής οθόνης"
+
+#: id:31119
+msgid "Hide Background Fanart"
+msgstr "Απόκρυψη Fanart υποβάθρου"
+
+#: id:31120
+msgid "BUTTON LABEL"
+msgstr "ΕΤΙΚΕΤΑ ΠΛΗΚΤΡΟΥ"
+
+#: id:31122
+msgid "Weather Page"
+msgstr "Σελίδα Καιρού"
+
+#: id:31123
+msgid "Use \"Posters\" instead of \"Banners\" for TV Shows"
+msgstr "Χρήση \"Αφισών\" αντί για \"Πανό\" για τις τηλεοπτικές σειρές"
+
+#: id:31124
+msgid "Show Background \"Now Playing\" Video"
+msgstr "Εμφάνιση ως υπόβαθρο το βίντεο που \"Τώρα Εκτελείται\""
+
+#: id:31125
+msgid "Show Background \"Now Playing\" Visualization"
+msgstr "Εμφάνιση ως υπόβαθρο η οπτικοποίηση που \"Τώρα Εκτελείται\""
+
+#: id:31126
+msgid "Play TV theme songs in video library (TvTunes add-on)"
+msgstr "Αναπαραγωγή τραγουδιών σειρών (πρόσθετο TvTunes)"
+
+#: id:31127
+msgid "TvTunes"
+msgstr "TvTunes"
+
+#: id:31128
+msgid "Lyrics"
+msgstr "Στίχοι"
+
+#: id:31132
+msgid "Lyrics Add-on"
+msgstr "Πρόσθετο στίχων"
+
+#: id:31133
+msgid "Subtitle Add-on"
+msgstr "Πρόσθετο υποτίτλων"
+
+#: id:31134
+msgid "Home Page Videos Submenu"
+msgstr "Υπομενού Βίντεο αρχικής οθόνης"
+
+#: id:31135
+msgid "Home Page Music Submenu"
+msgstr "Υπομενού Μουσικής αρχικής οθόνης"
+
+#: id:31136
+msgid "Home Page Pictures Submenu"
+msgstr "Υπομενού Εικόνων αρχικής οθόνης"
+
+#: id:31140
+msgid "Music OSD"
+msgstr "Aπεικονίσεις οθόνης (OSD) Μουσικής"
+
+#: id:31141
+msgid "Video OSD"
+msgstr "Aπεικονίσεις οθόνης (OSD) Βίντεο"
+
+#: id:31200
+msgid "Shortcuts"
+msgstr "Συντομεύσεις"
+
+#: id:31201
+msgid "Categories"
+msgstr "Κατηγορίες"
+
+#: id:31202
+msgid "Show Cast"
+msgstr "Εμφάνιση διανομής"
+
+#: id:31203
+msgid "Choose Your Song"
+msgstr "Επιλογή τραγουδιού"
+
+#: id:31204
+msgid "Section Links"
+msgstr "Επιλογή Συνδέσμων"
+
+#: id:31205
+msgid "Lyrics Source"
+msgstr "Προέλευση στίχων"
+
+#: id:31300
+msgid "Current Temp"
+msgstr "Τρέχουσα θερμοκρασία"
+
+#: id:31301
+msgid "Last Updated"
+msgstr "Τελευταία ενημέρωση"
+
+#: id:31302
+msgid "Menu"
+msgstr "Μενού"
+
+#: id:31303
+msgid "Data provider"
+msgstr "Πηγή δεδομένων"
+
+#: id:31304
+msgid "Picture"
+msgstr "Εικόνα"
+
+#: id:31305
+msgid "No Disc Media Detected"
+msgstr "Δεν εντοπίστηκε οπτικός δίσκος"
+
+#: id:31306
+msgid "Eject"
+msgstr "Εξαγωγή"
+
+#: id:31307
+msgid "Hide Fanart"
+msgstr "Απόκρυψη Fanart"
+
+#: id:31308
+msgid "Movie Details"
+msgstr "Λεπτομέρειες ταινίας"
+
+#: id:31309
+msgid "Memory Used:"
+msgstr "Χρήση μνήμης:"
+
+#: id:31310
+msgid "Track Number"
+msgstr "Αριθμός κομματιού"
+
+#: id:31311
+msgid "Fanart image[CR][CR]Unavailable[CR][CR] Click button to set"
+msgstr "Εικόνα Fanart[CR][CR]Μη διαθέσιμη[CR][CR] Πιέστε το πλήκτρο για να θέσετε"
+
+#: id:31312
+msgid "Current Scraper"
+msgstr "Τρέχον Scraper"
+
+#: id:31313
+msgid "Choose a Scraper"
+msgstr "Επιλογή Scraper"
+
+#: id:31314
+msgid "Content Scanning Options"
+msgstr "Επιλογές Σάρωσης Περιεχομένου"
+
+#: id:31315
+msgid "Basic"
+msgstr "Βασικό"
+
+#: id:31317
+msgid "Set Fanart Path"
+msgstr "Ορισμός διαδρομής Fanart"
+
+#: id:31318
+msgid "Small Fanart"
+msgstr "Μικρό Fanart"
+
+#: id:31319
+msgid "Selected Profile"
+msgstr "Επιλεγμένο προφίλ"
+
+#: id:31320
+msgid "Last Logged In"
+msgstr "Τελευταία είσοδος"
+
+#: id:31321
+msgid "Karaoke Song Selector"
+msgstr "Επιλογέας τραγουδιού Karaoke"
+
+#: id:31322
+msgid "Aired"
+msgstr "Πρώτη Προβολή"
+
+#: id:31323
+msgid "Latest Movies"
+msgstr "Νεώτερες Ταινίες"
+
+#: id:31324
+msgid "Latest Episodes"
+msgstr "Νεώτερα Επεισόδια"
+
+#: id:31325
+msgid "Playlist Options"
+msgstr "Επιλογές λίστας αναπαραγωγής"
+
+#: id:31326
+msgid "Created"
+msgstr "Δημιουργήθηκε"
+
+#: id:31327
+msgid "Resolution"
+msgstr "Ανάλυση"
+
+#: id:31328
+msgctxt "Auto context with id 31328"
+msgid "Recently Added"
+msgstr "Προστέθηκαν Πρόσφατα"
+
+#: id:31329
+msgid "[B]Timer set![/B] [COLOR=grey2] - System auto shutdown in[/COLOR]"
+msgstr "[B]Εφαρμογή χρονοδιακόπτη![/B] [COLOR=grey2] - Αυτόματος τερματισμός συστήματος σε[/COLOR]"
+
+#: id:31330
+msgid "Click button to play[CR][CR]Movie trailer"
+msgstr "Πιέστε το πλήκτρο για αναπαραγωγή[CR][CR]του Διαφημιστικού Ταινίας"
+
+#: id:31331
+msgid "Album Details"
+msgstr "Λεπτομέρειες Άλμπουμ"
+
+#: id:31351
+msgid "Pause"
+msgstr "Παύση"
+
+#: id:31352
+msgid "Stop"
+msgstr "Διακοπή"
+
+#: id:31353
+msgid "Fast Forward"
+msgstr "Μπροστά"
+
+#: id:31354
+msgid "Rewind"
+msgstr "Πίσω"
+
+#: id:31355
+msgid "Movie menu"
+msgstr "Μενού ταινίας"
+
+#: id:31356
+msgid "Download Subtitles"
+msgstr "Λήψη υποτίτλων"
+
+#: id:31390
+msgid "Skin default"
+msgstr "Προεπιλογή"
+
+#: id:31391
+msgid "Skin default with no Caps"
+msgstr "Προεπιλογή χωρίς Κεφαλαία"
+
+#: id:31392
+msgid "Arial based"
+msgstr "Βασισμένη σε Arial"
+
+#: id:31400
+msgid "[B]CONFIGURE APPEARANCE SETTINGS[/B][CR][CR]Change the skin � Set language and region � Change file listing options[CR]Set up a screensaver"
+msgstr "[B]ΡΥΘΜΙΣΕΙΣ ΕΞΑΤΟΜΙΚΕΥΣΗΣ[/B][CR][CR]Αλλαγή κελύφους · Αλλαγή χώρας και γλώσσας συστήματος · Επιλογές καταλόγου αρχείων[CR]Προσαρμογή της προφύλαξης οθόνης"
+
+#: id:31401
+msgid "[B]CONFIGURE VIDEO SETTINGS[/B][CR][CR]Manage your video library � Set video playback options � Change video listing options[CR]Set subtitle fonts"
+msgstr "[B]ΡΥΘΜΙΣΕΙΣ ΒΙΝΤΕΟ[/B][CR][CR]Διαχείριση της συλλογής βίντεο · Ρύθμιση αναπαραγωγής βίντεο · Επιλογές καταλόγου ταινιών[CR]Ρύθμιση γραμματοσειράς υποτίτλων"
+
+#: id:31402
+msgid "[B]CONFIGURE MUSIC SETTINGS[/B][CR][CR]Manage your music library � Set music playback options � Change music listing options[CR]Setup song submission � Set karaoke options"
+msgstr "[B]ΡΥΘΜΙΣΕΙΣ ΜΟΥΣΙΚΗΣ[/B][CR][CR]Διαχείριση της συλλογής τραγουδιών · Ρύθμιση αναπαραγωγής μουσικής · Επιλογές καταλόγου μουσικής[CR]Ρύθμιση υποβολής τραγουδιού · Επιλογές karaoke"
+
+#: id:31403
+msgid "[B]CONFIGURE PICTURE SETTINGS[/B][CR][CR]Set picture listing options � Configure slideshows"
+msgstr "[B]ΡΥΘΜΙΣΕΙΣ ΕΙΚΟΝΩΝ[/B][CR][CR]Επιλογές καταλόγου εικόνων · Ρύθμιση παρουσίασης διαφανειών"
+
+#: id:31404
+msgid "[B]CONFIGURE WEATHER SETTINGS[/B][CR][CR]Set three cities to collect weather information"
+msgstr "[B]ΡΥΘΜΙΣΕΙΣ ΚΑΙΡΟΥ[/B][CR][CR]Ορισμός τριών πόλεων για τις οποίες θα γίνεται πρόγνωση καιρού"
+
+#: id:31406
+msgid "[B]CONFIGURE SYSTEM SETTINGS[/B][CR][CR]Setup and calibrate displays � Configure audio output � Setup remote controls[CR]Set power saving options � Enable debugging � Setup master lock"
+msgstr "[B]ΡΥΘΜΙΣΕΙΣ ΣΥΣΤΗΜΑΤΟΣ[/B][CR][CR]Διαμόρφωση και βαθμονόμηση οθονών · Ρύθμιση εξόδου ήχου · Εγκατάσταση τηλεχειριστηρίων · Ρύθμιση εξοικονόμησης ενέργειας · Ενεργοποίηση καταγραφής σφαλμάτων (debug) · Ρύθμιση κεντρικού κλειδώματος"
+
+#: id:31407
+msgid "[B]CONFIGURE SKIN SETTINGS[/B][CR][CR]Setup the Confluence skin � Add and remove home menu items[CR]Change skin backgrounds"
+msgstr "[B]ΡΥΘΜΙΣΕΙΣ ΚΕΛΥΦΟΥΣ[/B][CR][CR]Ρύθμιση του κελύφους Confluence · Προσθήκη και απομάκρυνση αντικειμένων από την αρχική οθόνη[CR]Αλλαγή υποβάθρου κελύφους"
+
+#: id:31408
+msgid "[B]CONFIGURE ADD-ONS[/B][CR][CR]Manage your installed Add-ons � Browse for and install Add-ons from xbmc.org[CR]Modify Add-on settings"
+msgstr "[B]ΡΥΘΜΙΣΕΙΣ ΠΡΟΣΘΕΤΩΝ[/B][CR][CR]Διαχείριση εγκατεστημένων Πρόσθετων · Αναζήτηση και εγκατάσταση Πρόσθετων από το xbmc.org[CR]Τροποποίηση ρυθμίσεων των Πρόσθετων"
+
+#: id:31409
+msgid "[B]CONFIGURE SERVICE SETTINGS[/B][CR][CR]Setup control of XBMC via UPnP and HTTP � Configure file sharing[CR]Enable Zeroconf � Configure AirPlay"
+msgstr ""
+
+#: id:31421
+msgid "Select your XBMC user Profile[CR]to login and continue"
+msgstr "Επιλέξτε προφίλ χρήστη για το XBMC[CR]για να συνδεθείτε και να συνεχίσετε"
+
+#: id:31900
+msgid "Weather Maps"
+msgstr "Χάρτες Καιρού"
+
+#: id:31901
+msgid "36 Hour Forecast"
+msgstr "36ωρη Πρόβλεψη"
+
+#: id:31902
+msgid "Hourly Forecast"
+msgstr "Ωριαία Πρόβλεψη"
+
+#: id:31903
+msgid "Weekend Forecast"
+msgstr "Πρόβλεψη Σαββατοκύριακου"
+
+#: id:31904
+msgid "10 Day Forecast"
+msgstr "Πρόβλεψη 10 ημερών"
+
+#: id:31905
+msgid "Forecast"
+msgstr "Πρόβλεψη"
+
+#: id:31906
+msgid "Maps & Video"
+msgstr "Χάρτες & Βίντεο"
+
+#: id:31907
+msgid "Video Forecast [COLOR=grey2](Fullscreen Playback)[/COLOR]"
+msgstr "Βίντεο Πρόβλεψης [COLOR=grey2](Πλήρης Οθόνη)[/COLOR]"
+
+#: id:31908
+msgid "Chance of Precipitation"
+msgstr "Πιθανότητα Υετού"
+
+#: id:31909
+msgid "Fetching forecast info..."
+msgstr "Ανάκτηση πρόβλεψης καιρού..."
+

--- a/addons/skin.confluence/language/Hungarian/strings.po
+++ b/addons/skin.confluence/language/Hungarian/strings.po
@@ -1,0 +1,576 @@
+# Converted from xbmc strings.xml with xbmc-xml2po (by Team-XBMC)
+msgid ""
+msgstr ""
+"Project-Id-Version: xbmc.skin.confluence-FRODO_GIT953c09c336\n"
+"Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
+"POT-Creation-Date: 2012-04-09 18:03+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE\n"
+"Language: hu\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: id:31000
+msgid "Change Your"
+msgstr "Választható"
+
+#: id:31001
+msgid "Love"
+msgstr "Szeretem"
+
+#: id:31002
+msgid "Hate"
+msgstr "Utálom"
+
+#: id:31003
+msgid "Power Options"
+msgstr "Kikapcsolási lehetőségek"
+
+#: id:31004
+msgid "Working..."
+msgstr "Dolgozom..."
+
+#: id:31005
+msgid "Hide Information"
+msgstr "Információ elrejtése"
+
+#: id:31006
+msgid "View Options"
+msgstr "Nézet lehetőségek"
+
+#: id:31007
+msgid "Plugins"
+msgstr "Beépülők"
+
+#: id:31008
+msgid "Fullscreen"
+msgstr "Teljes képernyő"
+
+#: id:31020
+msgctxt "Auto context with id 31020"
+msgid "Recently Added"
+msgstr "Nemrég hozzáadott"
+
+#: id:31021
+msgid "Video - Files"
+msgstr "Videók - Fájlmód"
+
+#: id:31022
+msgid "Music - Files"
+msgstr "Zene - Fájlmód"
+
+#: id:31023
+msgid "Playing"
+msgstr "Éppen játszva"
+
+#: id:31024
+msgid "Page"
+msgstr "Oldal"
+
+#: id:31025
+msgid "Items"
+msgstr "Elem"
+
+#: id:31026
+msgid "Misc Options"
+msgstr "Más beállítások"
+
+#: id:31027
+msgid "Location"
+msgstr "Fekvés"
+
+#: id:31028
+msgid "Poster Wrap"
+msgstr "Poszter"
+
+#: id:31029
+msgid "Fanart"
+msgstr "Fanart"
+
+#: id:31030
+msgid "Full list"
+msgstr "Telj. lista"
+
+#: id:31031
+msgid "Pic Thumbs"
+msgstr "Kép ikonok"
+
+#: id:31032
+msgid "Image Wrap"
+msgstr "Képborító"
+
+#: id:31033
+msgid "Info"
+msgstr "Infó"
+
+#: id:31040
+msgid "Now Playing"
+msgstr "Most játszva"
+
+#: id:31042
+msgid "PLAYING"
+msgstr "LEJÁTSZÁS"
+
+#: id:31043
+msgid "PAUSED"
+msgstr "MEGÁLLÍTVA"
+
+#: id:31044
+msgid "FAST FORWARD"
+msgstr "ELŐRETEKERÉS"
+
+#: id:31045
+msgid "REWIND"
+msgstr "VISSZATEKERÉS"
+
+#: id:31046
+msgid "Audio Properties"
+msgstr "Hang tulajdonságok"
+
+#: id:31047
+msgid "Current Preset"
+msgstr "Jelenlegi beállítás"
+
+#: id:31048
+msgid "Visualization Presets"
+msgstr "Vizualizáció altípus"
+
+#: id:31049
+msgid "End Time"
+msgstr "Befejezés időpontja"
+
+#: id:31050
+msgid "Sort: Ascending"
+msgstr "Sorrend: Növekvő"
+
+#: id:31051
+msgid "Sort: Descending"
+msgstr "Sorrend: Csökkenő"
+
+#: id:31055
+msgid "Open playlist"
+msgstr "Játszáslista megnyitása"
+
+#: id:31056
+msgid "Save playlist"
+msgstr "Játszáslista mentése"
+
+#: id:31057
+msgid "Close playlist"
+msgstr "Játszáslista zárása"
+
+#: id:31058
+msgid "System music files"
+msgstr "Rendszer zene fájlok"
+
+#: id:31059
+msgid "Current playlist"
+msgstr "Jelenlegi játszáslista"
+
+#: id:31060
+msgid "This file is stacked, select the part you want to play from."
+msgstr "Ez a fájl egyesített. Válaszd azt a részt, amelyiket játszani akarod."
+
+#: id:31061
+msgid "Current Selected"
+msgstr "Jelenleg kiválasztott"
+
+#: id:31101
+msgid "Home screen options"
+msgstr "Sajátképernyő lehetőségei"
+
+#: id:31102
+msgid "Background"
+msgstr "Háttér"
+
+#: id:31103
+msgid "Show \"Paused\" in picture slide show"
+msgstr "\"Megállítva\" mutatása a diavetítés közben"
+
+#: id:31104
+msgid "Play Trailers in a window [COLOR=grey3](Video Information Dialog Only)[/COLOR]"
+msgstr "Filmelőzetesek lejátszása ablakban [COLOR=grey3](csak a videóinfó ablakban)[/COLOR]"
+
+#: id:31105
+msgid "\"Videos\" button always goes to video \"Files\""
+msgstr "A \"Videók\" gomb mindíg közvetlenül a fájlokra ugrik"
+
+#: id:31106
+msgid "Miscellaneous options"
+msgstr "Vegyes beállítások"
+
+#: id:31107
+msgid "Hide Flagging read from video filenames [COLOR=grey3](Blu-ray, HD-DVD)[/COLOR]"
+msgstr "Fájlnevekből olvasott filmjellemzők elrejtése [COLOR=grey3](BR, HD-DVD)[/COLOR]"
+
+#: id:31108
+msgid "Hide Main Menu Buttons"
+msgstr "Főmenügombok láthatósága"
+
+#: id:31109
+msgid "Media backgrounds"
+msgstr "Médiahátterek"
+
+#: id:31110
+msgid "Edit Background for Media Type"
+msgstr "Háttér beállítása ehhez a médiatípushoz"
+
+#: id:31111
+msgid "Hide"
+msgstr "Elrejt"
+
+#: id:31112
+msgid "Options"
+msgstr "Lehetőségek"
+
+#: id:31113
+msgid "Single Image"
+msgstr "Egyetlen Kép"
+
+#: id:31114
+msgid "Multi Image"
+msgstr "Több kép"
+
+#: id:31115
+msgid "Customizer"
+msgstr "Testreszabás"
+
+#: id:31117
+msgid "Show Recently added Videos"
+msgstr "Nemrég hozzáadott videók mutatása"
+
+#: id:31118
+msgid "Home Page Programs Submenu"
+msgstr "Sajátképernyő programok almenü"
+
+#: id:31119
+msgid "Hide Background Fanart"
+msgstr "Fanart-háttér elrejtése"
+
+#: id:31120
+msgid "BUTTON LABEL"
+msgstr "GOMBFELIRAT"
+
+#: id:31122
+msgid "Weather Page"
+msgstr "Időjárás oldal"
+
+#: id:31123
+msgid "Use \"Posters\" instead of \"Banners\" for TV Shows"
+msgstr "Poszterek használata keskeny szalagcímek helyett a sorozatoknál"
+
+#: id:31124
+msgid "Show Background \"Now Playing\" Video"
+msgstr "A háttérben az éppen játszott videó megjelenítése"
+
+#: id:31125
+msgid "Show Background \"Now Playing\" Visualization"
+msgstr "A háttérben az éppen futó vizualizáció megjelenítése"
+
+#: id:31126
+msgid "Play TV theme songs in video library (TvTunes add-on)"
+msgstr "TV főtémadalok játszása a videó médiatárban (TvTunes kiegészítő)"
+
+#: id:31127
+msgid "TvTunes"
+msgstr "TvTunes"
+
+#: id:31128
+msgid "Lyrics"
+msgstr "Dalszöveg"
+
+#: id:31132
+msgid "Lyrics Add-on"
+msgstr "Dalszöveg kiegészítő"
+
+#: id:31133
+msgid "Subtitle Add-on"
+msgstr "Filmfelirat kiegészítő"
+
+#: id:31134
+msgid "Home Page Videos Submenu"
+msgstr "Főképernyő Videó almenü"
+
+#: id:31135
+msgid "Home Page Music Submenu"
+msgstr "Főképernyő Zene almenü"
+
+#: id:31136
+msgid "Home Page Pictures Submenu"
+msgstr "Főképernyő Képek almenü"
+
+#: id:31140
+msgid "Music OSD"
+msgstr "Zene tálca"
+
+#: id:31141
+msgid "Video OSD"
+msgstr "Videó tálca"
+
+#: id:31200
+msgid "Shortcuts"
+msgstr "Parancsikonok"
+
+#: id:31201
+msgid "Categories"
+msgstr "Kategóriák"
+
+#: id:31202
+msgid "Show Cast"
+msgstr "Szereposztás mutatása"
+
+#: id:31203
+msgid "Choose Your Song"
+msgstr "Válaszd a dalodat"
+
+#: id:31204
+msgid "Section Links"
+msgstr "Szekció linkek"
+
+#: id:31205
+msgid "Lyrics Source"
+msgstr "Dalszövegforrás"
+
+#: id:31300
+msgid "Current Temp"
+msgstr "Hőmérséklet most"
+
+#: id:31301
+msgid "Last Updated"
+msgstr "Utoljára frissítve"
+
+#: id:31302
+msgid "Menu"
+msgstr "Menü"
+
+#: id:31303
+msgid "Data provider"
+msgstr "Adatszolgáltató"
+
+#: id:31304
+msgid "Picture"
+msgstr "Kép"
+
+#: id:31305
+msgid "No Disc Media Detected"
+msgstr "Lemez média nem található"
+
+#: id:31306
+msgid "Eject"
+msgstr "Nyitás"
+
+#: id:31307
+msgid "Hide Fanart"
+msgstr "Fanart elrejtése"
+
+#: id:31308
+msgid "Movie Details"
+msgstr "Film részletek"
+
+#: id:31309
+msgid "Memory Used:"
+msgstr "Memória használat:"
+
+#: id:31310
+msgid "Track Number"
+msgstr "Zeneszám"
+
+#: id:31311
+msgid "Fanart image[CR][CR]Unavailable[CR][CR] Click button to set"
+msgstr "Fanart kép[CR][CR]Elérhetetlen[CR][CR] Nyomj a gombra a beállításhoz"
+
+#: id:31312
+msgid "Current Scraper"
+msgstr "Jelenlegi leolvasó"
+
+#: id:31313
+msgid "Choose a Scraper"
+msgstr "Válassz leolvasót"
+
+#: id:31314
+msgid "Content Scanning Options"
+msgstr "Tartalomkeresési lehetőségek"
+
+#: id:31315
+msgid "Basic"
+msgstr "Alap"
+
+#: id:31317
+msgid "Set Fanart Path"
+msgstr "Fanart elérési helye"
+
+#: id:31318
+msgid "Small Fanart"
+msgstr "Kis fanart"
+
+#: id:31319
+msgid "Selected Profile"
+msgstr "Választott profil"
+
+#: id:31320
+msgid "Last Logged In"
+msgstr "Utoljára bejelentkezve"
+
+#: id:31321
+msgid "Karaoke Song Selector"
+msgstr "Karaoke dalválasztó"
+
+#: id:31322
+msgid "Aired"
+msgstr "Játszva"
+
+#: id:31323
+msgid "Latest Movies"
+msgstr "Legfrissebb filmek"
+
+#: id:31324
+msgid "Latest Episodes"
+msgstr "Legfrissebb epizódok"
+
+#: id:31325
+msgid "Playlist Options"
+msgstr "Játszáslista lehetőségek"
+
+#: id:31326
+msgid "Created"
+msgstr "Létrehozva"
+
+#: id:31327
+msgid "Resolution"
+msgstr "Felbontás"
+
+#: id:31328
+msgctxt "Auto context with id 31328"
+msgid "Recently Added"
+msgstr "Nemrég hozzáadva"
+
+#: id:31329
+msgid "[B]Timer set![/B] [COLOR=grey2] - System auto shutdown in[/COLOR]"
+msgstr "[B]Időzítő beállítva![/B] [COLOR=grey2] - Automatikus leállítás ennyi idő múlva:[/COLOR]"
+
+#: id:31330
+msgid "Click button to play[CR][CR]Movie trailer"
+msgstr "Nyomd a gombot a filmelőzetes[CR][CR]Lejátszásához"
+
+#: id:31331
+msgid "Album Details"
+msgstr "Album részletek"
+
+#: id:31351
+msgid "Pause"
+msgstr "Pillanatmegállítás"
+
+#: id:31352
+msgid "Stop"
+msgstr "Leállítás"
+
+#: id:31353
+msgid "Fast Forward"
+msgstr "Előretekerés"
+
+#: id:31354
+msgid "Rewind"
+msgstr "Visszatekerés"
+
+#: id:31355
+msgid "Movie menu"
+msgstr "Film menü"
+
+#: id:31356
+msgid "Download Subtitles"
+msgstr "Felirat letöltése"
+
+#: id:31390
+msgid "Skin default"
+msgstr "Felszín alapértelmezése"
+
+#: id:31391
+msgid "Skin default with no Caps"
+msgstr "Alapértelmezett, nagybetűsítés nélkül"
+
+#: id:31392
+msgid "Arial based"
+msgstr "Arial betűkészlet"
+
+#: id:31400
+msgid "[B]CONFIGURE APPEARANCE SETTINGS[/B][CR][CR]Change the skin � Set language and region � Change file listing options[CR]Set up a screensaver"
+msgstr "[B]MEGJELENÍTÉS MÓDJÁNAK BEÁLLÍTÁSA[/B][CR][CR]Felszín váltása · Nyelv, régió váltása · Fájl listázás módjának beállítása[CR]Képernyővédő beállítása"
+
+#: id:31401
+msgid "[B]CONFIGURE VIDEO SETTINGS[/B][CR][CR]Manage your video library � Set video playback options � Change video listing options[CR]Set subtitle fonts"
+msgstr "[B]VIDEÓ BEÁLLÍTÁSOK[/B][CR][CR]Film médiatár kezelése · Videólejátszás beállítása · Videólistázás módjának beállítása[CR]Feliratok karaktertípusának váltása"
+
+#: id:31402
+msgid "[B]CONFIGURE MUSIC SETTINGS[/B][CR][CR]Manage your music library � Set music playback options � Change music listing options[CR]Setup song submission � Set karaoke options"
+msgstr "[B]ZENE BEÁLLÍTÁSOK[/B][CR][CR]Zene médiatár kezelése · Zenelejátszás beállítása · Zenelistázás módjának beállítása[CR]Zene lejátszási szabályok felállítása · Karaoke lehetőségek"
+
+#: id:31403
+msgid "[B]CONFIGURE PICTURE SETTINGS[/B][CR][CR]Set picture listing options � Configure slideshows"
+msgstr "[B]FÉNYKÉP BEÁLLÍTÁSOK[/B][CR][CR]Fényképek listázási módjának beállítása · Diavetítés beállítása"
+
+#: id:31404
+msgid "[B]CONFIGURE WEATHER SETTINGS[/B][CR][CR]Set three cities to collect weather information"
+msgstr "[B]IDŐJÁRÁS BEÁLLÍTÁSOK[/B][CR][CR]Három város megadása, melyekről időjárás információk fognak megjelenni"
+
+#: id:31406
+msgid "[B]CONFIGURE SYSTEM SETTINGS[/B][CR][CR]Setup and calibrate displays � Configure audio output � Setup remote controls[CR]Set power saving options � Enable debugging � Setup master lock"
+msgstr "[B]RENDSZERBEÁLLÍTÁSOK[/B][CR][CR]Kijelzők beállítása, kalibrálása · Hangkimenet konfigurálása · Távkapcsoló beállítása[CR]Energiagazdálkodási lehetőségek beállítása · Hibakeresés bekapcsolása[CR]Mesterzár felállítása"
+
+#: id:31407
+msgid "[B]CONFIGURE SKIN SETTINGS[/B][CR][CR]Setup the Confluence skin � Add and remove home menu items[CR]Change skin backgrounds"
+msgstr "[B]FELSZÍN BEÁLLÍTÁSOK[/B][CR][CR]A Confluence felszín beállítása · Sajátképernyő elemek hozzáadása/elvétele[CR]Felszín hátterek megváltoztatása"
+
+#: id:31408
+msgid "[B]CONFIGURE ADD-ONS[/B][CR][CR]Manage your installed Add-ons � Browse for and install Add-ons from xbmc.org[CR]Modify Add-on settings"
+msgstr "[B]KIEGÉSZÍTŐK BEÁLLÍTÁSA[/B][CR][CR]A telepített kiegészítők kezelése · Kiegészítők böngészése és telepítése az xbmc.org[CR]webhelyről · Kiegészítők beállításainak módosítása"
+
+#: id:31409
+msgid "[B]CONFIGURE SERVICE SETTINGS[/B][CR][CR]Setup control of XBMC via UPnP and HTTP � Configure file sharing[CR]Enable Zeroconf � Configure AirPlay"
+msgstr ""
+
+#: id:31421
+msgid "Select your XBMC user Profile[CR]to login and continue"
+msgstr "Válaszd ki az XBMC felhasználói profilod[CR]a belépéshez"
+
+#: id:31900
+msgid "Weather Maps"
+msgstr "Időjárási térképek"
+
+#: id:31901
+msgid "36 Hour Forecast"
+msgstr "36 órás előrejelzés"
+
+#: id:31902
+msgid "Hourly Forecast"
+msgstr "Előrejelzés óra bontással"
+
+#: id:31903
+msgid "Weekend Forecast"
+msgstr "Hétvégi előrejelzés"
+
+#: id:31904
+msgid "10 Day Forecast"
+msgstr "10 napos előrejelzés"
+
+#: id:31905
+msgid "Forecast"
+msgstr "Előrejelzés"
+
+#: id:31906
+msgid "Maps & Video"
+msgstr "Térképek & Videó"
+
+#: id:31907
+msgid "Video Forecast [COLOR=grey2](Fullscreen Playback)[/COLOR]"
+msgstr "Videó előrejelzés [COLOR=grey2](Teljesképernyős lejátszás)[/COLOR]"
+
+#: id:31908
+msgid "Chance of Precipitation"
+msgstr "Csapadék esélye"
+
+#: id:31909
+msgid "Fetching forecast info..."
+msgstr "Előrejelzési információ letöltése..."
+

--- a/addons/skin.confluence/language/Icelandic/strings.po
+++ b/addons/skin.confluence/language/Icelandic/strings.po
@@ -1,0 +1,576 @@
+# Converted from xbmc strings.xml with xbmc-xml2po (by Team-XBMC)
+msgid ""
+msgstr ""
+"Project-Id-Version: xbmc.skin.confluence-FRODO_GIT953c09c336\n"
+"Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
+"POT-Creation-Date: 2012-04-09 18:03+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE\n"
+"Language: is\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: id:31000
+msgid "Change Your"
+msgstr "Breyta -"
+
+#: id:31001
+msgid "Love"
+msgstr "Ást"
+
+#: id:31002
+msgid "Hate"
+msgstr "Hatri"
+
+#: id:31003
+msgid "Power Options"
+msgstr "Orkukostir"
+
+#: id:31004
+msgid "Working..."
+msgstr "Vinnsla..."
+
+#: id:31005
+msgid "Hide Information"
+msgstr "Fela upplýsingar"
+
+#: id:31006
+msgid "View Options"
+msgstr "Stillingar sjónarhorns"
+
+#: id:31007
+msgid "Plugins"
+msgstr "Tengiforrit"
+
+#: id:31008
+msgid "Fullscreen"
+msgstr "Allur skjárinn"
+
+#: id:31020
+msgctxt "Auto context with id 31020"
+msgid "Recently Added"
+msgstr "Nýlega bætt við"
+
+#: id:31021
+msgid "Video - Files"
+msgstr "Myndefni - Skrár"
+
+#: id:31022
+msgid "Music - Files"
+msgstr "Tónlist - Skrár"
+
+#: id:31023
+msgid "Playing"
+msgstr "Spila"
+
+#: id:31024
+msgid "Page"
+msgstr "Síða"
+
+#: id:31025
+msgid "Items"
+msgstr "Hlutir"
+
+#: id:31026
+msgid "Misc Options"
+msgstr "Ýmsir valkostir"
+
+#: id:31027
+msgid "Location"
+msgstr "Staðsetning"
+
+#: id:31028
+msgid "Poster Wrap"
+msgstr "Veggspjaldafletting"
+
+#: id:31029
+msgid "Fanart"
+msgstr "Aðdáendamyndir"
+
+#: id:31030
+msgid "Full list"
+msgstr "Heildarlisti"
+
+#: id:31031
+msgid "Pic Thumbs"
+msgstr "Smámyndir"
+
+#: id:31032
+msgid "Image Wrap"
+msgstr "Myndafletting"
+
+#: id:31033
+msgid "Info"
+msgstr "Upplýsingar"
+
+#: id:31040
+msgid "Now Playing"
+msgstr "Í spilun"
+
+#: id:31042
+msgid "PLAYING"
+msgstr "SPILA"
+
+#: id:31043
+msgid "PAUSED"
+msgstr "Í BIÐ"
+
+#: id:31044
+msgid "FAST FORWARD"
+msgstr "HRATT ÁFRAM"
+
+#: id:31045
+msgid "REWIND"
+msgstr "TIL BAKA"
+
+#: id:31046
+msgid "Audio Properties"
+msgstr "Hljóðeiginleikar"
+
+#: id:31047
+msgid "Current Preset"
+msgstr "Gildandi forstilling"
+
+#: id:31048
+msgid "Visualization Presets"
+msgstr "Forstillingar myndskreytinga"
+
+#: id:31049
+msgid "End Time"
+msgstr "Lokatími"
+
+#: id:31050
+msgid "Sort: Ascending"
+msgstr "Raða: Hækkandi"
+
+#: id:31051
+msgid "Sort: Descending"
+msgstr "Raða: Lækkandi"
+
+#: id:31055
+msgid "Open playlist"
+msgstr "Opna lagalista"
+
+#: id:31056
+msgid "Save playlist"
+msgstr "Vista lagalista"
+
+#: id:31057
+msgid "Close playlist"
+msgstr "Loka lagalista"
+
+#: id:31058
+msgid "System music files"
+msgstr "Tónlistarskrár kerfis"
+
+#: id:31059
+msgid "Current playlist"
+msgstr "Núgildandi lagalisti"
+
+#: id:31060
+msgid "This file is stacked, select the part you want to play from."
+msgstr "Þessi skrá er stöfluð, veldu þann part sem þú vilt byrja að spila frá."
+
+#: id:31061
+msgid "Current Selected"
+msgstr "Núverandi val"
+
+#: id:31101
+msgid "Home screen options"
+msgstr "Stillingar heimaskjás"
+
+#: id:31102
+msgid "Background"
+msgstr "Bakgrunnur"
+
+#: id:31103
+msgid "Show \"Paused\" in picture slide show"
+msgstr "Sýna \"Í bið\" í myndasýningu"
+
+#: id:31104
+msgid "Play Trailers in a window [COLOR=grey3](Video Information Dialog Only)[/COLOR]"
+msgstr "Spila kvikmyndasýnishorn í glugga [COLOR=grey3](Aðeins myndbandaupplýsingarglugga)[/COLOR]"
+
+#: id:31105
+msgid "\"Videos\" button always goes to video \"Files\""
+msgstr "Myndbandahnappur fer alltaf í myndbandaskrár"
+
+#: id:31106
+msgid "Miscellaneous options"
+msgstr "Ýmsir valkostir"
+
+#: id:31107
+msgid "Hide Flagging read from video filenames [COLOR=grey3](Blu-ray, HD-DVD)[/COLOR]"
+msgstr "Fela flagg lesið frá skráarnöfnum [COLOR=grey3](Blu-ray, HD-DVD)[/COLOR]"
+
+#: id:31108
+msgid "Hide Main Menu Buttons"
+msgstr "Fela hnapp í aðalvalmynd"
+
+#: id:31109
+msgid "Media backgrounds"
+msgstr "Bakgrunnar heimasvæðis"
+
+#: id:31110
+msgid "Edit Background for Media Type"
+msgstr "Breyta bakgrunni fyrir heimahnapp"
+
+#: id:31111
+msgid "Hide"
+msgstr "Fela"
+
+#: id:31112
+msgid "Options"
+msgstr "Valkostir"
+
+#: id:31113
+msgid "Single Image"
+msgstr "Einföld mynd"
+
+#: id:31114
+msgid "Multi Image"
+msgstr "Margföld mynd"
+
+#: id:31115
+msgid "Customizer"
+msgstr "Sérsníðari"
+
+#: id:31117
+msgid "Show Recently added Videos"
+msgstr "Sýna myndbönd sem var nýlega bætt við"
+
+#: id:31118
+msgid "Home Page Programs Submenu"
+msgstr "Undirvalmynd heimasíðu"
+
+#: id:31119
+msgid "Hide Background Fanart"
+msgstr "Fela aðdáendamyndir í bakgrunni"
+
+#: id:31120
+msgid "BUTTON LABEL"
+msgstr "HNAPPAHEITI"
+
+#: id:31122
+msgid "Weather Page"
+msgstr "Veðursíða"
+
+#: id:31123
+msgid "Use \"Posters\" instead of \"Banners\" for TV Shows"
+msgstr "Nota \"Veggspjöld\" í staðinn fyrir \"Borða\" fyrir sjónvarpsþætti"
+
+#: id:31124
+msgid "Show Background \"Now Playing\" Video"
+msgstr "Sýna \"Í spilun\" myndband í bakgrunni"
+
+#: id:31125
+msgid "Show Background \"Now Playing\" Visualization"
+msgstr "Sýna \"Í spilun\" myndskreytingu í bakgrunni"
+
+#: id:31126
+msgid "Play TV theme songs in video library (TvTunes add-on)"
+msgstr "Spila þema lög í myndbandasafni (TvTunes viðbót)"
+
+#: id:31127
+msgid "TvTunes"
+msgstr "TvTunes"
+
+#: id:31128
+msgid "Lyrics"
+msgstr "Lagatextar"
+
+#: id:31132
+msgid "Lyrics Add-on"
+msgstr "Viðbót fyrir lagatexta"
+
+#: id:31133
+msgid "Subtitle Add-on"
+msgstr "Viðbót fyrir þýðingartexta"
+
+#: id:31134
+msgid "Home Page Videos Submenu"
+msgstr "Undirvalmynd myndbandasíðu"
+
+#: id:31135
+msgid "Home Page Music Submenu"
+msgstr "Undirvalmynd tónlistarsíðu"
+
+#: id:31136
+msgid "Home Page Pictures Submenu"
+msgstr "Undirvalmynd ljósmyndaasíðu"
+
+#: id:31140
+msgid "Music OSD"
+msgstr "Tónlistarskjár"
+
+#: id:31141
+msgid "Video OSD"
+msgstr "Myndbandaskjár"
+
+#: id:31200
+msgid "Shortcuts"
+msgstr "Flýtileiðir"
+
+#: id:31201
+msgid "Categories"
+msgstr "Flokkar"
+
+#: id:31202
+msgid "Show Cast"
+msgstr "Sýna leikara"
+
+#: id:31203
+msgid "Choose Your Song"
+msgstr "Veldu þitt lag"
+
+#: id:31204
+msgid "Section Links"
+msgstr "Tenglar svæðis"
+
+#: id:31205
+msgid "Lyrics Source"
+msgstr "Frumkóði lagatexta"
+
+#: id:31300
+msgid "Current Temp"
+msgstr "Núverandi hiti"
+
+#: id:31301
+msgid "Last Updated"
+msgstr "Síðast uppfært"
+
+#: id:31302
+msgid "Menu"
+msgstr "Valmynd"
+
+#: id:31303
+msgid "Data provider"
+msgstr "Gagnaveita"
+
+#: id:31304
+msgid "Picture"
+msgstr "Mynd"
+
+#: id:31305
+msgid "No Disc Media Detected"
+msgstr "Enginn diskur með myndefni fannst"
+
+#: id:31306
+msgid "Eject"
+msgstr "Ýta út"
+
+#: id:31307
+msgid "Hide Fanart"
+msgstr "Fela aðdáendamyndir"
+
+#: id:31308
+msgid "Movie Details"
+msgstr "Kvikmyndaupplýsingar"
+
+#: id:31309
+msgid "Memory Used:"
+msgstr "Minni notað:"
+
+#: id:31310
+msgid "Track Number"
+msgstr "Númer lags"
+
+#: id:31311
+msgid "Fanart image[CR][CR]Unavailable[CR][CR] Click button to set"
+msgstr "Aðdáendamynd[CR][CR]Ekki fáanleg[CR][CR] Smelltu til að breyta"
+
+#: id:31312
+msgid "Current Scraper"
+msgstr "Núverandi skafa"
+
+#: id:31313
+msgid "Choose a Scraper"
+msgstr "Veldu sköfu"
+
+#: id:31314
+msgid "Content Scanning Options"
+msgstr "Stillingar fyrir skönnun innihalds"
+
+#: id:31315
+msgid "Basic"
+msgstr "Einfalt"
+
+#: id:31317
+msgid "Set Fanart Path"
+msgstr "Breyta slóð fyrir aðdáendamyndir"
+
+#: id:31318
+msgid "Small Fanart"
+msgstr "Lítil aðdáendamynd"
+
+#: id:31319
+msgid "Selected Profile"
+msgstr "Veldu notanda"
+
+#: id:31320
+msgid "Last Logged In"
+msgstr "Seinast skráður inn"
+
+#: id:31321
+msgid "Karaoke Song Selector"
+msgstr "Karaoke lagaveljari"
+
+#: id:31322
+msgid "Aired"
+msgstr "Sýnt"
+
+#: id:31323
+msgid "Latest Movies"
+msgstr "Nýjustu kvikmyndirnar"
+
+#: id:31324
+msgid "Latest Episodes"
+msgstr "Nýjustu þættirnir"
+
+#: id:31325
+msgid "Playlist Options"
+msgstr "Valkostir lagalista"
+
+#: id:31326
+msgid "Created"
+msgstr "Búið til"
+
+#: id:31327
+msgid "Resolution"
+msgstr "Upplausn"
+
+#: id:31328
+msgctxt "Auto context with id 31328"
+msgid "Recently Added"
+msgstr "Nýlega bætt við"
+
+#: id:31329
+msgid "[B]Timer set![/B] [COLOR=grey2] - System auto shutdown in[/COLOR]"
+msgstr "[B]Tímamælir virkur![/B] [COLOR=grey2] - Sjálfvirkt Slökkt eftir[/COLOR]"
+
+#: id:31330
+msgid "Click button to play[CR][CR]Movie trailer"
+msgstr "Smelltu á takka til að spila[CR][CR]Kvikmyndasýnishorn"
+
+#: id:31331
+msgid "Album Details"
+msgstr "Hljómplötuupplýsingar"
+
+#: id:31351
+msgid "Pause"
+msgstr "Bið"
+
+#: id:31352
+msgid "Stop"
+msgstr "Stöðva"
+
+#: id:31353
+msgid "Fast Forward"
+msgstr "Hratt áfram"
+
+#: id:31354
+msgid "Rewind"
+msgstr "Til baka"
+
+#: id:31355
+msgid "Movie menu"
+msgstr "Kvikmyndavalmynd"
+
+#: id:31356
+msgid "Download Subtitles"
+msgstr "Niðurhala þýðingartextum"
+
+#: id:31390
+msgid "Skin default"
+msgstr "Sjálfgildi útlits"
+
+#: id:31391
+msgid "Skin default with no Caps"
+msgstr "Sjálfgildi útlits með engum hástöfum"
+
+#: id:31392
+msgid "Arial based"
+msgstr "Byggt á Arial"
+
+#: id:31400
+msgid "[B]CONFIGURE APPEARANCE SETTINGS[/B][CR][CR]Change the skin � Set language and region � Change file listing options[CR]Set up a screensaver"
+msgstr "[B]BREYTA VIÐMÓTSSTILLINGUM[/B][CR][CR]Breyta útlitinu · Breyta tungumáli og svæði · Breyta stillingum skráarlista[CR]Breyta skjáhvílu"
+
+#: id:31401
+msgid "[B]CONFIGURE VIDEO SETTINGS[/B][CR][CR]Manage your video library � Set video playback options � Change video listing options[CR]Set subtitle fonts"
+msgstr "[B]BREYTA SKJÁSTILLINGUM[/B][CR][CR]Sýsla með myndabandasafn · Breyta myndbandaspilun · Breyta stillingum myndbandalista[CR]Breyta leturgerðum þýðingartexta"
+
+#: id:31402
+msgid "[B]CONFIGURE MUSIC SETTINGS[/B][CR][CR]Manage your music library � Set music playback options � Change music listing options[CR]Setup song submission � Set karaoke options"
+msgstr "[B]BREYTA TÓNLISTARSTILLINGUM[/B][CR][CR]Sýsla með tónlistarsafn · Breyta stillingum tónlistarspilara · Breyta stillingum tónlistarlista[CR]Skilgreina laga upphal · Breyta karaoke stillingum"
+
+#: id:31403
+msgid "[B]CONFIGURE PICTURE SETTINGS[/B][CR][CR]Set picture listing options � Configure slideshows"
+msgstr "[B]BREYTA LJÓSMYNDASTILLINGUM[/B][CR][CR]Breyta stillingum ljósmyndalista · Stilla myndasýningar"
+
+#: id:31404
+msgid "[B]CONFIGURE WEATHER SETTINGS[/B][CR][CR]Set three cities to collect weather information"
+msgstr "[B]BREYTA VEÐURSTILLINGUM[/B][CR][CR]Skilgreindu þrjár borgir til að ná í veðurupplýsingar fyrir"
+
+#: id:31406
+msgid "[B]CONFIGURE SYSTEM SETTINGS[/B][CR][CR]Setup and calibrate displays � Configure audio output � Setup remote controls[CR]Set power saving options � Enable debugging � Setup master lock"
+msgstr "[B]BREYTA KERFISSTILLINGUM[/B][CR][CR]Breyta og stilla skjái · Breyta hljóðúttaki · Skilgreina fjarstýringar[CR]Breyta orkukostum · Virkja aflúsun · Skilgreina aðallykilorð"
+
+#: id:31407
+msgid "[B]CONFIGURE SKIN SETTINGS[/B][CR][CR]Setup the Confluence skin � Add and remove home menu items[CR]Change skin backgrounds"
+msgstr "[B]BREYTA ÚTLITSSTILLINGUM[/B][CR][CR]Breyta útliti Confluence · Bæta við og fjarlægja hluti úr aðalvamynd[CR]Breyta bakgrunni"
+
+#: id:31408
+msgid "[B]CONFIGURE ADD-ONS[/B][CR][CR]Manage your installed Add-ons � Browse for and install Add-ons from xbmc.org[CR]Modify Add-on settings"
+msgstr "[B]BREYTA VIÐBÓTUM[/B][CR][CR]Breyttu uppsettum viðbótum · Leitaðu að og settu upp viðbætur frá xbmc.org[CR]Breyta stillingum viðbóta"
+
+#: id:31409
+msgid "[B]CONFIGURE SERVICE SETTINGS[/B][CR][CR]Setup control of XBMC via UPnP and HTTP � Configure file sharing[CR]Enable Zeroconf � Configure AirPlay"
+msgstr ""
+
+#: id:31421
+msgid "Select your XBMC user Profile[CR]to login and continue"
+msgstr "Veldu XBMC notanda[CR]til að skrá þig inn og halda áfram"
+
+#: id:31900
+msgid "Weather Maps"
+msgstr "Veðurkort"
+
+#: id:31901
+msgid "36 Hour Forecast"
+msgstr "36 klst veðurspá"
+
+#: id:31902
+msgid "Hourly Forecast"
+msgstr "Klukkustunda veðurspá"
+
+#: id:31903
+msgid "Weekend Forecast"
+msgstr "Veðurspá helgarinnar"
+
+#: id:31904
+msgid "10 Day Forecast"
+msgstr "10 daga veðurspá"
+
+#: id:31905
+msgid "Forecast"
+msgstr "Veðurspá"
+
+#: id:31906
+msgid "Maps & Video"
+msgstr "Kort og Myndbönd"
+
+#: id:31907
+msgid "Video Forecast [COLOR=grey2](Fullscreen Playback)[/COLOR]"
+msgstr "Myndbandaveðurspá [COLOR=grey2](Spila á öllum skjánum)[/COLOR]"
+
+#: id:31908
+msgid "Chance of Precipitation"
+msgstr "Líkur á úrkomu"
+
+#: id:31909
+msgid "Fetching forecast info..."
+msgstr "Næ í veðurspá..."
+

--- a/addons/skin.confluence/language/Italian/strings.po
+++ b/addons/skin.confluence/language/Italian/strings.po
@@ -1,0 +1,576 @@
+# Converted from xbmc strings.xml with xbmc-xml2po (by Team-XBMC)
+msgid ""
+msgstr ""
+"Project-Id-Version: xbmc.skin.confluence-FRODO_GIT953c09c336\n"
+"Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
+"POT-Creation-Date: 2012-04-09 18:03+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE\n"
+"Language: it\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: id:31000
+msgid "Change Your"
+msgstr "Cambia il tuo"
+
+#: id:31001
+msgid "Love"
+msgstr "Amo"
+
+#: id:31002
+msgid "Hate"
+msgstr "Odio"
+
+#: id:31003
+msgid "Power Options"
+msgstr "Impostazioni Avanzate"
+
+#: id:31004
+msgid "Working..."
+msgstr "Sto lavorando..."
+
+#: id:31005
+msgid "Hide Information"
+msgstr "Nascondi informazioni"
+
+#: id:31006
+msgid "View Options"
+msgstr "Vedi Opzioni"
+
+#: id:31007
+msgid "Plugins"
+msgstr "Plugins"
+
+#: id:31008
+msgid "Fullscreen"
+msgstr "Schermo Intero"
+
+#: id:31020
+msgctxt "Auto context with id 31020"
+msgid "Recently Added"
+msgstr "Aggiunti di recente"
+
+#: id:31021
+msgid "Video - Files"
+msgstr "Files - Video"
+
+#: id:31022
+msgid "Music - Files"
+msgstr "Files - Musica"
+
+#: id:31023
+msgid "Playing"
+msgstr "In Riproduzione"
+
+#: id:31024
+msgid "Page"
+msgstr "Pagina"
+
+#: id:31025
+msgid "Items"
+msgstr "Oggetti"
+
+#: id:31026
+msgid "Misc Options"
+msgstr "Opzioni Varie"
+
+#: id:31027
+msgid "Location"
+msgstr "Località"
+
+#: id:31028
+msgid "Poster Wrap"
+msgstr "Poster"
+
+#: id:31029
+msgid "Fanart"
+msgstr "Fanart"
+
+#: id:31030
+msgid "Full list"
+msgstr "Lista estesa"
+
+#: id:31031
+msgid "Pic Thumbs"
+msgstr "Miniature immagini"
+
+#: id:31032
+msgid "Image Wrap"
+msgstr "Immagine"
+
+#: id:31033
+msgid "Info"
+msgstr "Informazioni"
+
+#: id:31040
+msgid "Now Playing"
+msgstr "In riproduzione"
+
+#: id:31042
+msgid "PLAYING"
+msgstr "IN RIPRODUZIONE"
+
+#: id:31043
+msgid "PAUSED"
+msgstr "IN PAUSA"
+
+#: id:31044
+msgid "FAST FORWARD"
+msgstr "AVANTI VELOCE"
+
+#: id:31045
+msgid "REWIND"
+msgstr "INDIETRO"
+
+#: id:31046
+msgid "Audio Properties"
+msgstr "Proprietà Audio"
+
+#: id:31047
+msgid "Current Preset"
+msgstr "Preset Corrente"
+
+#: id:31048
+msgid "Visualization Presets"
+msgstr "Preset Visualizzazione"
+
+#: id:31049
+msgid "End Time"
+msgstr "Orario fine riproduzione"
+
+#: id:31050
+msgid "Sort: Ascending"
+msgstr "Ordina: Crescente"
+
+#: id:31051
+msgid "Sort: Descending"
+msgstr "Ordina: Decrescente"
+
+#: id:31055
+msgid "Open playlist"
+msgstr "Apri playlist"
+
+#: id:31056
+msgid "Save playlist"
+msgstr "Salva playlist"
+
+#: id:31057
+msgid "Close playlist"
+msgstr "Chiudi playlist"
+
+#: id:31058
+msgid "System music files"
+msgstr "Suoni di sistema"
+
+#: id:31059
+msgid "Current playlist"
+msgstr "Playlist Corrente"
+
+#: id:31060
+msgid "This file is stacked, select the part you want to play from."
+msgstr "Questo file è stato accorpato, scegli la parte da cui vuoi iniziare."
+
+#: id:31061
+msgid "Current Selected"
+msgstr "Correntemente Selezionato"
+
+#: id:31101
+msgid "Home screen options"
+msgstr "Opzioni pagina principale"
+
+#: id:31102
+msgid "Background"
+msgstr "Sfondo"
+
+#: id:31103
+msgid "Show \"Paused\" in picture slide show"
+msgstr "Mostra \"In pausa\" durante la visualizzazione delle immagini"
+
+#: id:31104
+msgid "Play Trailers in a window [COLOR=grey3](Video Information Dialog Only)[/COLOR]"
+msgstr "Riproduci i trailer in finestra [COLOR=grey3](Solo nel pannello informazioni video)[/COLOR]"
+
+#: id:31105
+msgid "\"Videos\" button always goes to video \"Files\""
+msgstr "Il pulsante \"Video\" porta sempre ai \"files\" video"
+
+#: id:31106
+msgid "Miscellaneous options"
+msgstr "Opzioni Varie"
+
+#: id:31107
+msgid "Hide Flagging read from video filenames [COLOR=grey3](Blu-ray, HD-DVD)[/COLOR]"
+msgstr "Nascondi la spunta letto dai nomi dei file video [COLOR=grey3](Blu-ray, HD-DVD)[/COLOR]"
+
+#: id:31108
+msgid "Hide Main Menu Buttons"
+msgstr "Nascondi i bottoni del menù principale"
+
+#: id:31109
+msgid "Media backgrounds"
+msgstr "Sfondi per le sezioni principali"
+
+#: id:31110
+msgid "Edit Background for Media Type"
+msgstr "Modifica lo Sfondo per la Sezione"
+
+#: id:31111
+msgid "Hide"
+msgstr "Nascondi"
+
+#: id:31112
+msgid "Options"
+msgstr "Opzioni"
+
+#: id:31113
+msgid "Single Image"
+msgstr "Singola Immagine"
+
+#: id:31114
+msgid "Multi Image"
+msgstr "Immagini Multiple"
+
+#: id:31115
+msgid "Customizer"
+msgstr "Personalizzazione"
+
+#: id:31117
+msgid "Show Recently added Videos"
+msgstr "Mostra i Video Aggiunti di Recente"
+
+#: id:31118
+msgid "Home Page Programs Submenu"
+msgstr "Sottomenù Pagina Principale"
+
+#: id:31119
+msgid "Hide Background Fanart"
+msgstr "Nascondi i Fanart sullo sfondo"
+
+#: id:31120
+msgid "BUTTON LABEL"
+msgstr "ETICHETTA BOTTONE"
+
+#: id:31122
+msgid "Weather Page"
+msgstr "Pagina Meteo"
+
+#: id:31123
+msgid "Use \"Posters\" instead of \"Banners\" for TV Shows"
+msgstr "Usa i \"Posters\" invece dei \"Banners\" per le Serie Tv"
+
+#: id:31124
+msgid "Show Background \"Now Playing\" Video"
+msgstr "Mostra nello Sfondo il nome del Video \"In Riproduzione\""
+
+#: id:31125
+msgid "Show Background \"Now Playing\" Visualization"
+msgstr "Mostra nello Sfondo Visualizzazioni il nome del file \"In Riproduzione\""
+
+#: id:31126
+msgid "Play TV theme songs in video library (TvTunes add-on)"
+msgstr "Riproduci le sigle TV (sonore) nell'archivio video (add-on TvTunes)"
+
+#: id:31127
+msgid "TvTunes"
+msgstr "TvTunes"
+
+#: id:31128
+msgid "Lyrics"
+msgstr "XBMC Testi Canzoni"
+
+#: id:31132
+msgid "Lyrics Add-on"
+msgstr "Add-on Testi"
+
+#: id:31133
+msgid "Subtitle Add-on"
+msgstr "Add-on Sottotitoli"
+
+#: id:31134
+msgid "Home Page Videos Submenu"
+msgstr "Sottomenù Home Page Video"
+
+#: id:31135
+msgid "Home Page Music Submenu"
+msgstr "Sottomenù Home Page Musica"
+
+#: id:31136
+msgid "Home Page Pictures Submenu"
+msgstr "Sottomenù Home Page Immagini"
+
+#: id:31140
+msgid "Music OSD"
+msgstr "OSD Musica"
+
+#: id:31141
+msgid "Video OSD"
+msgstr "OSD Video"
+
+#: id:31200
+msgid "Shortcuts"
+msgstr "Collegamenti"
+
+#: id:31201
+msgid "Categories"
+msgstr "Categorie"
+
+#: id:31202
+msgid "Show Cast"
+msgstr "Mostra il Cast"
+
+#: id:31203
+msgid "Choose Your Song"
+msgstr "Scegli la canzone"
+
+#: id:31204
+msgid "Section Links"
+msgstr "Sezione Links"
+
+#: id:31205
+msgid "Lyrics Source"
+msgstr "Sorgente Testi"
+
+#: id:31300
+msgid "Current Temp"
+msgstr "Temperatura Corrente"
+
+#: id:31301
+msgid "Last Updated"
+msgstr "Ultimo Aggiornamento"
+
+#: id:31302
+msgid "Menu"
+msgstr "Menù"
+
+#: id:31303
+msgid "Data provider"
+msgstr "Fornitore dei dati"
+
+#: id:31304
+msgid "Picture"
+msgstr "Immagini"
+
+#: id:31305
+msgid "No Disc Media Detected"
+msgstr "Nessun Disco Rilevato"
+
+#: id:31306
+msgid "Eject"
+msgstr "Espelli"
+
+#: id:31307
+msgid "Hide Fanart"
+msgstr "Nascondi Fanart"
+
+#: id:31308
+msgid "Movie Details"
+msgstr "Dettagli Film"
+
+#: id:31309
+msgid "Memory Used:"
+msgstr "Memoria Usata:"
+
+#: id:31310
+msgid "Track Number"
+msgstr "Numero Traccia"
+
+#: id:31311
+msgid "Fanart image[CR][CR]Unavailable[CR][CR] Click button to set"
+msgstr "Immagine Fanart [CR][CR]Nono disponibile[CR][CR] Premi il bottone per impostarla"
+
+#: id:31312
+msgid "Current Scraper"
+msgstr "Scraper Corrente"
+
+#: id:31313
+msgid "Choose a Scraper"
+msgstr "Scegli uno Scraper"
+
+#: id:31314
+msgid "Content Scanning Options"
+msgstr "Opzioni Scansione Contenuti"
+
+#: id:31315
+msgid "Basic"
+msgstr "Base"
+
+#: id:31317
+msgid "Set Fanart Path"
+msgstr "Imposta il percorso per le immagini fanart"
+
+#: id:31318
+msgid "Small Fanart"
+msgstr "Fanart ridotte"
+
+#: id:31319
+msgid "Selected Profile"
+msgstr "Scegli il Profilo"
+
+#: id:31320
+msgid "Last Logged In"
+msgstr "Ultimo Login"
+
+#: id:31321
+msgid "Karaoke Song Selector"
+msgstr "Karaoke Song Selector"
+
+#: id:31322
+msgid "Aired"
+msgstr "Trasmessa"
+
+#: id:31323
+msgid "Latest Movies"
+msgstr "Ultimi Film"
+
+#: id:31324
+msgid "Latest Episodes"
+msgstr "Ultimi Episodi"
+
+#: id:31325
+msgid "Playlist Options"
+msgstr "Opzioni Playlist"
+
+#: id:31326
+msgid "Created"
+msgstr "Creato"
+
+#: id:31327
+msgid "Resolution"
+msgstr "Risoluzione"
+
+#: id:31328
+msgctxt "Auto context with id 31328"
+msgid "Recently Added"
+msgstr "Aggiunti di Recente"
+
+#: id:31329
+msgid "[B]Timer set![/B] [COLOR=grey2] - System auto shutdown in[/COLOR]"
+msgstr "[B]Timer Impostato![/B] [COLOR=grey2] - Il Sistema Verrà Spento in[/COLOR]"
+
+#: id:31330
+msgid "Click button to play[CR][CR]Movie trailer"
+msgstr "Premi il bottone per riprodurre [CR][CR]il trailer del Film"
+
+#: id:31331
+msgid "Album Details"
+msgstr "Dettagli Album"
+
+#: id:31351
+msgid "Pause"
+msgstr "Pausa"
+
+#: id:31352
+msgid "Stop"
+msgstr "Stop"
+
+#: id:31353
+msgid "Fast Forward"
+msgstr "Avanti Veloce"
+
+#: id:31354
+msgid "Rewind"
+msgstr "Indietro"
+
+#: id:31355
+msgid "Movie menu"
+msgstr "Menù Filmato"
+
+#: id:31356
+msgid "Download Subtitles"
+msgstr "Scarica Sottotitoli"
+
+#: id:31390
+msgid "Skin default"
+msgstr "Predefinito della Skin"
+
+#: id:31391
+msgid "Skin default with no Caps"
+msgstr "Predefinito della Skin senza maiuscole"
+
+#: id:31392
+msgid "Arial based"
+msgstr "Basato su Arial"
+
+#: id:31400
+msgid "[B]CONFIGURE APPEARANCE SETTINGS[/B][CR][CR]Change the skin · Set language and region · Change file listing options[CR]Set up a screensaver"
+msgstr "[B]CONFIGURA LE IMPOSTAZIONI PER L'ASPETTO[/B][CR][CR]Cambia la skin · Imposta Lingua e Regione · Cambia le impostazioni di elenco dei file[CR]Imposta uno screensaver"
+
+#: id:31401
+msgid "[B]CONFIGURE VIDEO SETTINGS[/B][CR][CR]Manage your video library · Set video playback options · Change video listing options[CR]Set subtitle fonts"
+msgstr "[B]CONFIGURA IMPOSTAZIONI VIDEO[/B][CR][CR]Gestisci la tua Libreria Video · Imposta le impostazioni di riproduzione dei video · Cambia impostazioni per le liste video[CR]Imposta il fonts dei sottotitoli"
+
+#: id:31402
+msgid "[B]CONFIGURE MUSIC SETTINGS[/B][CR][CR]Manage your music library · Set music playback options · Change music listing options[CR]Setup song submission · Set karaoke options"
+msgstr "[B]CONFIGURA IMPOSTAZIONI MUSICA[/B][CR][CR]Gestisci la tua Libreria Musicale · Imposta le impostazioni di riproduzione della musica · Cambia impostazioni per le liste audio[CR]Setup song submission · Imposta le opzioni per il karaoke"
+
+#: id:31403
+msgid "[B]CONFIGURE PICTURE SETTINGS[/B][CR][CR]Set picture listing options · Configure slideshows"
+msgstr "[B]CONFIGURA IMPOSTAZIONI IMMAGINI[/B][CR][CR]Cambia impostazioni per le liste delle immagini· Configura lo slideshows"
+
+#: id:31404
+msgid "[B]CONFIGURE WEATHER SETTINGS[/B][CR][CR]Set three cities to collect weather information"
+msgstr "[B]CONFIGURA IMPOSTAZIONI METEO[/B][CR][CR]Imposta tre città su cui avere le informazioni meteo"
+
+#: id:31406
+msgid "[B]CONFIGURE SYSTEM SETTINGS[/B][CR][CR]Setup and calibrate displays · Configure audio output · Setup remote controls[CR]Set power saving options · Enable debugging · Setup master lock"
+msgstr "[B]CONFIGURA IMPOSTAZIONI DI SISTEMA[/B][CR][CR]Imposta e calibra il video · Configura l'uscita Audio · Imposta i controlli remoti[CR]Imposta le ozioni di risparmio energetico · Abilita il Debug · Imposta il master lock"
+
+#: id:31407
+msgid "[B]CONFIGURE SKIN SETTINGS[/B][CR][CR]Setup the Confluence skin · Add and remove home menu items[CR]Change skin backgrounds"
+msgstr "[B]CONFIGURA IMPOSTAZIONI SKIN[/B][CR][CR]Configura la skin Confluence · Aggiungi o rimuovi oggetti dalla pagina principale[CR]Cambia gli sfondi"
+
+#: id:31408
+msgid "[B]CONFIGURE ADD-ONS[/B][CR][CR]Manage your installed Add-ons · Browse for and install Add-ons from xbmc.org[CR]Modify Add-on settings"
+msgstr "[B]CONFIGURA GLI ADD-ONS[/B][CR][CR]Gestisci gli Add-ons installati · Esplora e installa gli Add-ons da xbmc.org[CR]Modifica le impostazioni degli Add-ons"
+
+#: id:31409
+msgid "[B]CONFIGURE SERVICE SETTINGS[/B][CR][CR]Setup control of XBMC via UPnP and HTTP · Configure file sharing[CR]Enable Zeroconf · Configure AirPlay"
+msgstr ""
+
+#: id:31421
+msgid "Select your XBMC user Profile[CR]to login and continue"
+msgstr "Scegli il tuo profilo utente di XBMC[CR]per fare il login e continuare"
+
+#: id:31900
+msgid "Weather Maps"
+msgstr "Mappa Meteo"
+
+#: id:31901
+msgid "36 Hour Forecast"
+msgstr "Previsioni a 36 Ore"
+
+#: id:31902
+msgid "Hourly Forecast"
+msgstr "Previsioni Orarie"
+
+#: id:31903
+msgid "Weekend Forecast"
+msgstr "Previsioni per il Weekend"
+
+#: id:31904
+msgid "10 Day Forecast"
+msgstr "Previsioni a 10 giorni"
+
+#: id:31905
+msgid "Forecast"
+msgstr "Previsioni"
+
+#: id:31906
+msgid "Maps & Video"
+msgstr "Mappe & Video"
+
+#: id:31907
+msgid "Video Forecast [COLOR=grey2](Fullscreen Playback)[/COLOR]"
+msgstr "Previsioni Video [COLOR=grey2](Riproduzione a schermo intero)[/COLOR]"
+
+#: id:31908
+msgid "Chance of Precipitation"
+msgstr "Percentuale di precipitazioni"
+
+#: id:31909
+msgid "Fetching forecast info..."
+msgstr "Recuper informazioni previsioni..."
+

--- a/addons/skin.confluence/language/Japanese/strings.po
+++ b/addons/skin.confluence/language/Japanese/strings.po
@@ -1,0 +1,576 @@
+# Converted from xbmc strings.xml with xbmc-xml2po (by Team-XBMC)
+msgid ""
+msgstr ""
+"Project-Id-Version: xbmc.skin.confluence-FRODO_GIT953c09c336\n"
+"Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
+"POT-Creation-Date: 2012-04-09 18:03+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE\n"
+"Language: ja\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: id:31000
+msgid "Change Your"
+msgstr ""
+
+#: id:31001
+msgid "Love"
+msgstr "Love"
+
+#: id:31002
+msgid "Hate"
+msgstr "Hate"
+
+#: id:31003
+msgid "Power Options"
+msgstr "電源オプション"
+
+#: id:31004
+msgid "Working..."
+msgstr "処理中..."
+
+#: id:31005
+msgid "Hide Information"
+msgstr "情報を隠す"
+
+#: id:31006
+msgid "View Options"
+msgstr "表示オプション"
+
+#: id:31007
+msgid "Plugins"
+msgstr "プラグイン"
+
+#: id:31008
+msgid "Fullscreen"
+msgstr ""
+
+#: id:31020
+msgctxt "Auto context with id 31020"
+msgid "Recently Added"
+msgstr "最新の追加"
+
+#: id:31021
+msgid "Video - Files"
+msgstr "ビデオ - ファイル"
+
+#: id:31022
+msgid "Music - Files"
+msgstr "ミュージック - ファイル"
+
+#: id:31023
+msgid "Playing"
+msgstr "再生中"
+
+#: id:31024
+msgid "Page"
+msgstr "ページ"
+
+#: id:31025
+msgid "Items"
+msgstr "アイテム"
+
+#: id:31026
+msgid "Misc Options"
+msgstr "その他のオプション"
+
+#: id:31027
+msgid "Location"
+msgstr "地域"
+
+#: id:31028
+msgid "Poster Wrap"
+msgstr "ポスターラップ"
+
+#: id:31029
+msgid "Fanart"
+msgstr "ファンアート"
+
+#: id:31030
+msgid "Full list"
+msgstr "フルリスト"
+
+#: id:31031
+msgid "Pic Thumbs"
+msgstr "サムネール"
+
+#: id:31032
+msgid "Image Wrap"
+msgstr "イメージラップ"
+
+#: id:31033
+msgid "Info"
+msgstr "情報"
+
+#: id:31040
+msgid "Now Playing"
+msgstr "現在再生中"
+
+#: id:31042
+msgid "PLAYING"
+msgstr "再生中"
+
+#: id:31043
+msgid "PAUSED"
+msgstr "静止中"
+
+#: id:31044
+msgid "FAST FORWARD"
+msgstr "早送り"
+
+#: id:31045
+msgid "REWIND"
+msgstr "巻戻し"
+
+#: id:31046
+msgid "Audio Properties"
+msgstr "オーディオ設定"
+
+#: id:31047
+msgid "Current Preset"
+msgstr "現在の設定"
+
+#: id:31048
+msgid "Visualization Presets"
+msgstr "Visualization Presets"
+
+#: id:31049
+msgid "End Time"
+msgstr "End Time"
+
+#: id:31050
+msgid "Sort: Ascending"
+msgstr "ソート: 昇順"
+
+#: id:31051
+msgid "Sort: Descending"
+msgstr "ソート: 降順"
+
+#: id:31055
+msgid "Open playlist"
+msgstr "プレイリストを開く"
+
+#: id:31056
+msgid "Save playlist"
+msgstr "プレイリストを保存"
+
+#: id:31057
+msgid "Close playlist"
+msgstr "プレイリストを閉じる"
+
+#: id:31058
+msgid "System music files"
+msgstr "システム音楽ファイル"
+
+#: id:31059
+msgid "Current playlist"
+msgstr "現在のプレイリスト"
+
+#: id:31060
+msgid "This file is stacked, select the part you want to play from."
+msgstr "このファイル内から再生したいパートを選択してください。"
+
+#: id:31061
+msgid "Current Selected"
+msgstr "現在選択中"
+
+#: id:31101
+msgid "Home screen options"
+msgstr "ホーム画面オプション"
+
+#: id:31102
+msgid "Background"
+msgstr "背景"
+
+#: id:31103
+msgid "Show \"Paused\" in picture slide show"
+msgstr "ピクチャスライドショーで「静止中」と表示"
+
+#: id:31104
+msgid "Play Trailers in a window [COLOR=grey3](Video Information Dialog Only)[/COLOR]"
+msgstr "ウィンドウ内で予告を再生 [COLOR=grey3](ビデオ情報ダイアログのみ)[/COLOR]"
+
+#: id:31105
+msgid "\"Videos\" button always goes to video \"Files\""
+msgstr "「ビデオ」ボタンで常に「ファイル」を選択"
+
+#: id:31106
+msgid "Miscellaneous options"
+msgstr "その他の設定"
+
+#: id:31107
+msgid "Hide Flagging read from video filenames [COLOR=grey3](Blu-ray, HD-DVD)[/COLOR]"
+msgstr "Hide Flagging read from video filenames [COLOR=grey3](Blu-ray, HD-DVD)[/COLOR]"
+
+#: id:31108
+msgid "Hide Main Menu Buttons"
+msgstr "メインメニューから隠すボタン"
+
+#: id:31109
+msgid "Media backgrounds"
+msgstr "メディア別の背景設定"
+
+#: id:31110
+msgid "Edit Background for Media Type"
+msgstr "編集するメディアタイプを選択"
+
+#: id:31111
+msgid "Hide"
+msgstr "隠す"
+
+#: id:31112
+msgid "Options"
+msgstr "オプション"
+
+#: id:31113
+msgid "Single Image"
+msgstr "単一イメージ"
+
+#: id:31114
+msgid "Multi Image"
+msgstr "複数イメージ"
+
+#: id:31115
+msgid "Customizer"
+msgstr "カスタマイズ"
+
+#: id:31117
+msgid "Show Recently added Videos"
+msgstr "最近追加したビデオを表示"
+
+#: id:31118
+msgid "Home Page Programs Submenu"
+msgstr "ホーム画面「プログラム」のサブメニュー"
+
+#: id:31119
+msgid "Hide Background Fanart"
+msgstr "背景のファンアートを隠す"
+
+#: id:31120
+msgid "BUTTON LABEL"
+msgstr "ボタンラベル"
+
+#: id:31122
+msgid "Weather Page"
+msgstr "天気予報ページ"
+
+#: id:31123
+msgid "Use \"Posters\" instead of \"Banners\" for TV Shows"
+msgstr "Use \"Posters\" instead of \"Banners\" for TV Shows"
+
+#: id:31124
+msgid "Show Background \"Now Playing\" Video"
+msgstr "背景に「現在再生中」ビデオを表示"
+
+#: id:31125
+msgid "Show Background \"Now Playing\" Visualization"
+msgstr "背景に「現在再生中」視覚化を表示"
+
+#: id:31126
+msgid "Play TV theme songs in video library (TvTunes add-on)"
+msgstr "Play TV theme songs in video library (TvTunes add-on)"
+
+#: id:31127
+msgid "TvTunes"
+msgstr "TvTunes"
+
+#: id:31128
+msgid "Lyrics"
+msgstr "歌詞"
+
+#: id:31132
+msgid "Lyrics Add-on"
+msgstr "歌詞アドオン"
+
+#: id:31133
+msgid "Subtitle Add-on"
+msgstr "字幕アドオン"
+
+#: id:31134
+msgid "Home Page Videos Submenu"
+msgstr "ホーム画面「ビデオ』のサブメニュー"
+
+#: id:31135
+msgid "Home Page Music Submenu"
+msgstr "ホーム画面「ミュージック』のサブメニュー"
+
+#: id:31136
+msgid "Home Page Pictures Submenu"
+msgstr "ホーム画面「ピクチャ』のサブメニュー"
+
+#: id:31140
+msgid "Music OSD"
+msgstr "ミュージック OSD"
+
+#: id:31141
+msgid "Video OSD"
+msgstr "ビデオ OSD"
+
+#: id:31200
+msgid "Shortcuts"
+msgstr "ショートカット"
+
+#: id:31201
+msgid "Categories"
+msgstr "カテゴリ"
+
+#: id:31202
+msgid "Show Cast"
+msgstr "キャストを表示"
+
+#: id:31203
+msgid "Choose Your Song"
+msgstr "曲を選択"
+
+#: id:31204
+msgid "Section Links"
+msgstr "セクションリンク"
+
+#: id:31205
+msgid "Lyrics Source"
+msgstr "歌詞の情報源"
+
+#: id:31300
+msgid "Current Temp"
+msgstr "現在の気温"
+
+#: id:31301
+msgid "Last Updated"
+msgstr "最終更新時刻"
+
+#: id:31302
+msgid "Menu"
+msgstr "メニュー"
+
+#: id:31303
+msgid "Data provider"
+msgstr "気象データ提供元"
+
+#: id:31304
+msgid "Picture"
+msgstr "ピクチャ"
+
+#: id:31305
+msgid "No Disc Media Detected"
+msgstr "ディスクメディアが検出されませんでした"
+
+#: id:31306
+msgid "Eject"
+msgstr "イジェクト"
+
+#: id:31307
+msgid "Hide Fanart"
+msgstr "ファンアートを隠す"
+
+#: id:31308
+msgid "Movie Details"
+msgstr "ムービーの詳細"
+
+#: id:31309
+msgid "Memory Used:"
+msgstr "メモリ使用量:"
+
+#: id:31310
+msgid "Track Number"
+msgstr "トラック番号"
+
+#: id:31311
+msgid "Fanart image[CR][CR]Unavailable[CR][CR] Click button to set"
+msgstr "ファンアート画像[CR][CR]使用不可[CR][CR] ボタンを押して設定"
+
+#: id:31312
+msgid "Current Scraper"
+msgstr "現在のメタデータスクレーパー"
+
+#: id:31313
+msgid "Choose a Scraper"
+msgstr "メタデータスクレーパーを選択"
+
+#: id:31314
+msgid "Content Scanning Options"
+msgstr "コンテントスキャンオプション"
+
+#: id:31315
+msgid "Basic"
+msgstr "標準"
+
+#: id:31317
+msgid "Set Fanart Path"
+msgstr "ファンアートのパスを設定"
+
+#: id:31318
+msgid "Small Fanart"
+msgstr "小さなファンアート"
+
+#: id:31319
+msgid "Selected Profile"
+msgstr "選択されたプロファイル"
+
+#: id:31320
+msgid "Last Logged In"
+msgstr "最終ログイン"
+
+#: id:31321
+msgid "Karaoke Song Selector"
+msgstr "カラオケソングセレクター"
+
+#: id:31322
+msgid "Aired"
+msgstr "放映日"
+
+#: id:31323
+msgid "Latest Movies"
+msgstr "最新ムービー"
+
+#: id:31324
+msgid "Latest Episodes"
+msgstr "最新エピソード"
+
+#: id:31325
+msgid "Playlist Options"
+msgstr "プレイリストオプション"
+
+#: id:31326
+msgid "Created"
+msgstr "制作日"
+
+#: id:31327
+msgid "Resolution"
+msgstr "解像度"
+
+#: id:31328
+msgctxt "Auto context with id 31328"
+msgid "Recently Added"
+msgstr "最近追加"
+
+#: id:31329
+msgid "[B]Timer set![/B] [COLOR=grey2] - System auto shutdown in[/COLOR]"
+msgstr "[B]タイマーセット完了![/B] [COLOR=grey2] - システムがシャットダウンします[/COLOR]"
+
+#: id:31330
+msgid "Click button to play[CR][CR]Movie trailer"
+msgstr "ボタンを押して再生[CR][CR]ムービー予告編"
+
+#: id:31331
+msgid "Album Details"
+msgstr "アルバム詳細"
+
+#: id:31351
+msgid "Pause"
+msgstr "一時停止"
+
+#: id:31352
+msgid "Stop"
+msgstr "停止"
+
+#: id:31353
+msgid "Fast Forward"
+msgstr "早送り"
+
+#: id:31354
+msgid "Rewind"
+msgstr "巻き戻し"
+
+#: id:31355
+msgid "Movie menu"
+msgstr "ムービーメニュー"
+
+#: id:31356
+msgid "Download Subtitles"
+msgstr "字幕をダウンロード"
+
+#: id:31390
+msgid "Skin default"
+msgstr "スキンのデフォルト"
+
+#: id:31391
+msgid "Skin default with no Caps"
+msgstr "スキンのデフォルト (小文字のみ)"
+
+#: id:31392
+msgid "Arial based"
+msgstr "Arial ベース"
+
+#: id:31400
+msgid "[B]CONFIGURE APPEARANCE SETTINGS[/B][CR][CR]Change the skin � Set language and region � Change file listing options[CR]Set up a screensaver"
+msgstr "[B]外観設定[/B][CR][CR]スキン選択 - 言語と地域の設定 - ファイル一覧設定変更[CR]スクリーンセーバー設定"
+
+#: id:31401
+msgid "[B]CONFIGURE VIDEO SETTINGS[/B][CR][CR]Manage your video library � Set video playback options � Change video listing options[CR]Set subtitle fonts"
+msgstr "[B]ビデオ設定[/B][CR][CR]ビデオライブラリ管理 - ビデオ再生設定 - ビデオ一覧設定変更[CR]字幕用フォント変更"
+
+#: id:31402
+msgid "[B]CONFIGURE MUSIC SETTINGS[/B][CR][CR]Manage your music library � Set music playback options � Change music listing options[CR]Setup song submission � Set karaoke options"
+msgstr "[B]ミュージック設定[/B][CR][CR]ミュージックライブラリ管理 - ミュージック再生設定 - ミュージック一覧設定変更[CR]楽曲送信設定 - カラオケ設定"
+
+#: id:31403
+msgid "[B]CONFIGURE PICTURE SETTINGS[/B][CR][CR]Set picture listing options � Configure slideshows"
+msgstr "[B]ピクチャ設定[/B][CR][CR]ピクチャ一覧設定変更[CR]スライドショー設定"
+
+#: id:31404
+msgid "[B]CONFIGURE WEATHER SETTINGS[/B][CR][CR]Set three cities to collect weather information"
+msgstr "[B]天気予報設定[/B][CR][CR]天気情報取得都市選択[CR]天気予報プラグイン選択"
+
+#: id:31406
+msgid "[B]CONFIGURE SYSTEM SETTINGS[/B][CR][CR]Setup and calibrate displays � Configure audio output � Setup remote controls[CR]Set power saving options � Enable debugging � Setup master lock"
+msgstr "[B]システム設定[/B][CR][CR]画面の設定・調整 - オーディオ出力設定 - リモートコントローラー設定[CR]省電力設定 - デバッグの有効化 - マスターロック設定"
+
+#: id:31407
+msgid "[B]CONFIGURE SKIN SETTINGS[/B][CR][CR]Setup the Confluence skin � Add and remove home menu items[CR]Change skin backgrounds"
+msgstr "[B]スキン設定[/B][CR][CR]Confluence スキン設定 - ホームメニュー項目の追加と削除[CR]スキン背景設定"
+
+#: id:31408
+msgid "[B]CONFIGURE ADD-ONS[/B][CR][CR]Manage your installed Add-ons � Browse for and install Add-ons from xbmc.org[CR]Modify Add-on settings"
+msgstr "[B]アドオン設定[/B][CR][CR]インストール済みアドオン管理 - xbmc.orgからアドオンを検索・インストール[CR]アドオン設定変更"
+
+#: id:31409
+msgid "[B]CONFIGURE SERVICE SETTINGS[/B][CR][CR]Setup control of XBMC via UPnP and HTTP � Configure file sharing[CR]Enable Zeroconf � Configure AirPlay"
+msgstr ""
+
+#: id:31421
+msgid "Select your XBMC user Profile[CR]to login and continue"
+msgstr "XBMC ユーザープロファイルを選択して[CR]ログインしてください"
+
+#: id:31900
+msgid "Weather Maps"
+msgstr "天気図"
+
+#: id:31901
+msgid "36 Hour Forecast"
+msgstr "36時間予報"
+
+#: id:31902
+msgid "Hourly Forecast"
+msgstr "1時間ごとの予報"
+
+#: id:31903
+msgid "Weekend Forecast"
+msgstr "週末の予報"
+
+#: id:31904
+msgid "10 Day Forecast"
+msgstr "10日予報"
+
+#: id:31905
+msgid "Forecast"
+msgstr "予報"
+
+#: id:31906
+msgid "Maps & Video"
+msgstr "天気図 & ビデオ"
+
+#: id:31907
+msgid "Video Forecast [COLOR=grey2](Fullscreen Playback)[/COLOR]"
+msgstr "ビデオ予報 [COLOR=grey2](フルスクリーン再生)[/COLOR]"
+
+#: id:31908
+msgid "Chance of Precipitation"
+msgstr "降水確率"
+
+#: id:31909
+msgid "Fetching forecast info..."
+msgstr "天気予報データ取得中..."
+

--- a/addons/skin.confluence/language/Korean/strings.po
+++ b/addons/skin.confluence/language/Korean/strings.po
@@ -1,0 +1,576 @@
+# Converted from xbmc strings.xml with xbmc-xml2po (by Team-XBMC)
+msgid ""
+msgstr ""
+"Project-Id-Version: xbmc.skin.confluence-FRODO_GIT953c09c336\n"
+"Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
+"POT-Creation-Date: 2012-04-09 18:03+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE\n"
+"Language: ko\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: id:31000
+msgid "Change Your"
+msgstr "변경"
+
+#: id:31001
+msgid "Love"
+msgstr "좋아함"
+
+#: id:31002
+msgid "Hate"
+msgstr "싫어함"
+
+#: id:31003
+msgid "Power Options"
+msgstr "전원 옵션"
+
+#: id:31004
+msgid "Working..."
+msgstr "동작중..."
+
+#: id:31005
+msgid "Hide Information"
+msgstr "정보 숨기기"
+
+#: id:31006
+msgid "View Options"
+msgstr "보기 옵션"
+
+#: id:31007
+msgid "Plugins"
+msgstr "플러그인"
+
+#: id:31008
+msgid "Fullscreen"
+msgstr "전체화면"
+
+#: id:31020
+msgctxt "Auto context with id 31020"
+msgid "Recently Added"
+msgstr "최근 추가됨"
+
+#: id:31021
+msgid "Video - Files"
+msgstr "비디오 - 파일"
+
+#: id:31022
+msgid "Music - Files"
+msgstr "음악 - 파일"
+
+#: id:31023
+msgid "Playing"
+msgstr "재생중"
+
+#: id:31024
+msgid "Page"
+msgstr "페이지"
+
+#: id:31025
+msgid "Items"
+msgstr "항목"
+
+#: id:31026
+msgid "Misc Options"
+msgstr "기타 옵션"
+
+#: id:31027
+msgid "Location"
+msgstr "위치"
+
+#: id:31028
+msgid "Poster Wrap"
+msgstr "포스터 나열"
+
+#: id:31029
+msgid "Fanart"
+msgstr "팬아트"
+
+#: id:31030
+msgid "Full list"
+msgstr "전체 목록"
+
+#: id:31031
+msgid "Pic Thumbs"
+msgstr "사진 미리보기"
+
+#: id:31032
+msgid "Image Wrap"
+msgstr "이미지 나열"
+
+#: id:31033
+msgid "Info"
+msgstr "정보"
+
+#: id:31040
+msgid "Now Playing"
+msgstr "지금 재생중"
+
+#: id:31042
+msgid "PLAYING"
+msgstr "재생중"
+
+#: id:31043
+msgid "PAUSED"
+msgstr "일시중지됨"
+
+#: id:31044
+msgid "FAST FORWARD"
+msgstr "빨리 감기"
+
+#: id:31045
+msgid "REWIND"
+msgstr "되감기"
+
+#: id:31046
+msgid "Audio Properties"
+msgstr "오디오 속성"
+
+#: id:31047
+msgid "Current Preset"
+msgstr "현재 사전설정"
+
+#: id:31048
+msgid "Visualization Presets"
+msgstr "시각화 사전설정"
+
+#: id:31049
+msgid "End Time"
+msgstr "종료 시간"
+
+#: id:31050
+msgid "Sort: Ascending"
+msgstr "정렬: 오름차순"
+
+#: id:31051
+msgid "Sort: Descending"
+msgstr "정렬: 내림차순"
+
+#: id:31055
+msgid "Open playlist"
+msgstr "재생목록 열기"
+
+#: id:31056
+msgid "Save playlist"
+msgstr "재생목록 저장"
+
+#: id:31057
+msgid "Close playlist"
+msgstr "재생목록 닫기"
+
+#: id:31058
+msgid "System music files"
+msgstr "시스템 음악 파일"
+
+#: id:31059
+msgid "Current playlist"
+msgstr "현재 재생목록"
+
+#: id:31060
+msgid "This file is stacked, select the part you want to play from."
+msgstr "이 파일은 연결되었습니다, 재생하고 싶은 부분을 선택하세요."
+
+#: id:31061
+msgid "Current Selected"
+msgstr "현재 선택됨"
+
+#: id:31101
+msgid "Home screen options"
+msgstr "홈 화면 옵션"
+
+#: id:31102
+msgid "Background"
+msgstr "배경"
+
+#: id:31103
+msgid "Show \"Paused\" in picture slide show"
+msgstr "사진 슬라이드쇼에 \"일시중지됨\" 보이기"
+
+#: id:31104
+msgid "Play Trailers in a window [COLOR=grey3](Video Information Dialog Only)[/COLOR]"
+msgstr "윈도우에 예고편 재생 [COLOR=grey3](비디오 정보 대화창만)[/COLOR]"
+
+#: id:31105
+msgid "\"Videos\" button always goes to video \"Files\""
+msgstr "\"비디오\" 버튼은 항상 비디오 \"파일\"로 이동"
+
+#: id:31106
+msgid "Miscellaneous options"
+msgstr "기타 옵션"
+
+#: id:31107
+msgid "Hide Flagging read from video filenames [COLOR=grey3](Blu-ray, HD-DVD)[/COLOR]"
+msgstr "비디오 파일명에서 읽은 플래그 숨기기 [COLOR=grey3](블루레이, HD-DVD)[/COLOR]"
+
+#: id:31108
+msgid "Hide Main Menu Buttons"
+msgstr "메인 메뉴 버튼 숨기기"
+
+#: id:31109
+msgid "Media backgrounds"
+msgstr "미디어 배경"
+
+#: id:31110
+msgid "Edit Background for Media Type"
+msgstr "미디어 형식의 배경 수정"
+
+#: id:31111
+msgid "Hide"
+msgstr "숨기기"
+
+#: id:31112
+msgid "Options"
+msgstr "옵션"
+
+#: id:31113
+msgid "Single Image"
+msgstr "단일 이미지"
+
+#: id:31114
+msgid "Multi Image"
+msgstr "다중 이미지"
+
+#: id:31115
+msgid "Customizer"
+msgstr "사용자 지정"
+
+#: id:31117
+msgid "Show Recently added Videos"
+msgstr "최근 추가된 비디오 보이기"
+
+#: id:31118
+msgid "Home Page Programs Submenu"
+msgstr "홈 페이지 프로그램 하위메뉴"
+
+#: id:31119
+msgid "Hide Background Fanart"
+msgstr "배경 팬아트 숨기기"
+
+#: id:31120
+msgid "BUTTON LABEL"
+msgstr "버튼 라벨"
+
+#: id:31122
+msgid "Weather Page"
+msgstr "날씨 페이지"
+
+#: id:31123
+msgid "Use \"Posters\" instead of \"Banners\" for TV Shows"
+msgstr "TV 쇼에 \"배너\" 대신 \"포스터\" 사용"
+
+#: id:31124
+msgid "Show Background \"Now Playing\" Video"
+msgstr "배경에 \"지금 재생중\" 비디오 보이기"
+
+#: id:31125
+msgid "Show Background \"Now Playing\" Visualization"
+msgstr "배경에 \"지금 재생중\" 시각화 보이기"
+
+#: id:31126
+msgid "Play TV theme songs in video library (TvTunes add-on)"
+msgstr "라이브러리 모드에서 TV 주제음악 재생 (TvTunes 추가기능)"
+
+#: id:31127
+msgid "TvTunes"
+msgstr "TvTunes"
+
+#: id:31128
+msgid "Lyrics"
+msgstr "가사"
+
+#: id:31132
+msgid "Lyrics Add-on"
+msgstr "가사 추가기능"
+
+#: id:31133
+msgid "Subtitle Add-on"
+msgstr "자막 추가기능"
+
+#: id:31134
+msgid "Home Page Videos Submenu"
+msgstr "홈 페이지 비디오 하위메뉴"
+
+#: id:31135
+msgid "Home Page Music Submenu"
+msgstr "홈 페이지 음악 하위메뉴"
+
+#: id:31136
+msgid "Home Page Pictures Submenu"
+msgstr "홈 페이지 사진 하위메뉴"
+
+#: id:31140
+msgid "Music OSD"
+msgstr "음악 OSD"
+
+#: id:31141
+msgid "Video OSD"
+msgstr "비디오 OSD"
+
+#: id:31200
+msgid "Shortcuts"
+msgstr "바로가기"
+
+#: id:31201
+msgid "Categories"
+msgstr "카테고리"
+
+#: id:31202
+msgid "Show Cast"
+msgstr "배역 보이기"
+
+#: id:31203
+msgid "Choose Your Song"
+msgstr "노래 선택"
+
+#: id:31204
+msgid "Section Links"
+msgstr "섹션 링크"
+
+#: id:31205
+msgid "Lyrics Source"
+msgstr "가사 소스"
+
+#: id:31300
+msgid "Current Temp"
+msgstr "현재 온도"
+
+#: id:31301
+msgid "Last Updated"
+msgstr "마지막 업데이트"
+
+#: id:31302
+msgid "Menu"
+msgstr "메뉴"
+
+#: id:31303
+msgid "Data provider"
+msgstr "날씨 정보 제공"
+
+#: id:31304
+msgid "Picture"
+msgstr "사진"
+
+#: id:31305
+msgid "No Disc Media Detected"
+msgstr "디스크 미디어 감지되지 않음"
+
+#: id:31306
+msgid "Eject"
+msgstr "꺼내기"
+
+#: id:31307
+msgid "Hide Fanart"
+msgstr "팬아트 숨기기"
+
+#: id:31308
+msgid "Movie Details"
+msgstr "영화 상세정보"
+
+#: id:31309
+msgid "Memory Used:"
+msgstr "사용 메모리:"
+
+#: id:31310
+msgid "Track Number"
+msgstr "트랙 번호"
+
+#: id:31311
+msgid "Fanart image[CR][CR]Unavailable[CR][CR] Click button to set"
+msgstr "팬아트 이미지[CR][CR]사용할수 없음[CR][CR] 설정하려면 버튼을 누르세요"
+
+#: id:31312
+msgid "Current Scraper"
+msgstr "현재 자료수집기"
+
+#: id:31313
+msgid "Choose a Scraper"
+msgstr "자료수집기를 선택하세요"
+
+#: id:31314
+msgid "Content Scanning Options"
+msgstr "컨텐츠 검색 옵션"
+
+#: id:31315
+msgid "Basic"
+msgstr "기본"
+
+#: id:31317
+msgid "Set Fanart Path"
+msgstr "팬아트 경로 설정"
+
+#: id:31318
+msgid "Small Fanart"
+msgstr "작은 팬아트"
+
+#: id:31319
+msgid "Selected Profile"
+msgstr "선택된 프로파일"
+
+#: id:31320
+msgid "Last Logged In"
+msgstr "마지막 로그인"
+
+#: id:31321
+msgid "Karaoke Song Selector"
+msgstr "노래방 노래 선택기"
+
+#: id:31322
+msgid "Aired"
+msgstr "방영됨"
+
+#: id:31323
+msgid "Latest Movies"
+msgstr "최근 영화"
+
+#: id:31324
+msgid "Latest Episodes"
+msgstr "최근 에피소드"
+
+#: id:31325
+msgid "Playlist Options"
+msgstr "재생목록 옵션"
+
+#: id:31326
+msgid "Created"
+msgstr "제작일"
+
+#: id:31327
+msgid "Resolution"
+msgstr "해상도"
+
+#: id:31328
+msgctxt "Auto context with id 31328"
+msgid "Recently Added"
+msgstr "최근 추가됨"
+
+#: id:31329
+msgid "[B]Timer set![/B] [COLOR=grey2] - System auto shutdown in[/COLOR]"
+msgstr "[B]타이머 설정![/B] [COLOR=grey2] - 시스템 자동 종료[/COLOR]"
+
+#: id:31330
+msgid "Click button to play[CR][CR]Movie trailer"
+msgstr "영화 예고편을[CR][CR]재생하려면 누르세요"
+
+#: id:31331
+msgid "Album Details"
+msgstr "앨범 정보"
+
+#: id:31351
+msgid "Pause"
+msgstr "일시정지"
+
+#: id:31352
+msgid "Stop"
+msgstr "정지"
+
+#: id:31353
+msgid "Fast Forward"
+msgstr "빨리 감기"
+
+#: id:31354
+msgid "Rewind"
+msgstr "되감기"
+
+#: id:31355
+msgid "Movie menu"
+msgstr "영화 메뉴"
+
+#: id:31356
+msgid "Download Subtitles"
+msgstr "자막 다운로드"
+
+#: id:31390
+msgid "Skin default"
+msgstr "스킨 기본값"
+
+#: id:31391
+msgid "Skin default with no Caps"
+msgstr "대문자 없는 스킨 기본값"
+
+#: id:31392
+msgid "Arial based"
+msgstr "Arial 기본값"
+
+#: id:31400
+msgid "[B]CONFIGURE APPEARANCE SETTINGS[/B][CR][CR]Change the skin � Set language and region � Change file listing options[CR]Set up a screensaver"
+msgstr "[B]모양새 설정[/B][CR][CR]스킨 변경 · 언어 및 지역 설정 · 파일 목록 옵션 변경[CR]화면보호기 설정"
+
+#: id:31401
+msgid "[B]CONFIGURE VIDEO SETTINGS[/B][CR][CR]Manage your video library � Set video playback options � Change video listing options[CR]Set subtitle fonts"
+msgstr "[B]비디오 설정[/B][CR][CR]비디오 라이브러리 관리 · 비디오 재생 옵션 변경 · 비디오 목록 옵션 변경[CR]자막 글꼴 설정"
+
+#: id:31402
+msgid "[B]CONFIGURE MUSIC SETTINGS[/B][CR][CR]Manage your music library � Set music playback options � Change music listing options[CR]Setup song submission � Set karaoke options"
+msgstr "[B]음악 설정[/B][CR][CR]음악 라이브러리 관리 · 음악 재생 옵션 변경 · 음악 목록 옵션 변경[CR]노래 전송 설정 · 노래방 옵션 설정"
+
+#: id:31403
+msgid "[B]CONFIGURE PICTURE SETTINGS[/B][CR][CR]Set picture listing options � Configure slideshows"
+msgstr "[B]사진 설정[/B][CR][CR]사진 목록 옵션 변경 · 슬라이드쇼 설정"
+
+#: id:31404
+msgid "[B]CONFIGURE WEATHER SETTINGS[/B][CR][CR]Set three cities to collect weather information"
+msgstr "[B]날씨 설정[/B][CR][CR]날씨 정보를 수집할 세 도시 설정"
+
+#: id:31406
+msgid "[B]CONFIGURE SYSTEM SETTINGS[/B][CR][CR]Setup and calibrate displays � Configure audio output � Setup remote controls[CR]Set power saving options � Enable debugging � Setup master lock"
+msgstr "[B]시스템 설정[/B][CR][CR]화면 설정 및 조정 · 오디오 출력 설정 · 원격 제어 설정[CR]전원 절약 옵션 설정 · 디버깅 사용 · 마스터 잠금 설정"
+
+#: id:31407
+msgid "[B]CONFIGURE SKIN SETTINGS[/B][CR][CR]Setup the Confluence skin � Add and remove home menu items[CR]Change skin backgrounds"
+msgstr "[B]스킨 설정[/B][CR][CR]Confluence 스킨 설정 · 홈 메뉴 항목 추가 및 제거[CR]스킨 배경 변경"
+
+#: id:31408
+msgid "[B]CONFIGURE ADD-ONS[/B][CR][CR]Manage your installed Add-ons � Browse for and install Add-ons from xbmc.org[CR]Modify Add-on settings"
+msgstr "[B]추가기능 설정[/B][CR][CR]설치된 추가기능 관리 · xbmc.org 에서 추가기능 찾기 및 설치[CR]추가기능 설정 변경"
+
+#: id:31409
+msgid "[B]CONFIGURE SERVICE SETTINGS[/B][CR][CR]Setup control of XBMC via UPnP and HTTP � Configure file sharing[CR]Enable Zeroconf � Configure AirPlay"
+msgstr ""
+
+#: id:31421
+msgid "Select your XBMC user Profile[CR]to login and continue"
+msgstr "로그인할 XBMC 사용자 프로파일을[CR]선택하고 계속하세요"
+
+#: id:31900
+msgid "Weather Maps"
+msgstr "기상도"
+
+#: id:31901
+msgid "36 Hour Forecast"
+msgstr "36 시간 예보"
+
+#: id:31902
+msgid "Hourly Forecast"
+msgstr "시간대별 예보"
+
+#: id:31903
+msgid "Weekend Forecast"
+msgstr "주말 예보"
+
+#: id:31904
+msgid "10 Day Forecast"
+msgstr "10 일 예보"
+
+#: id:31905
+msgid "Forecast"
+msgstr "예보"
+
+#: id:31906
+msgid "Maps & Video"
+msgstr "지도와 비디오"
+
+#: id:31907
+msgid "Video Forecast [COLOR=grey2](Fullscreen Playback)[/COLOR]"
+msgstr "비디오예보 [COLOR=grey2](전체화면 재생)[/COLOR]"
+
+#: id:31908
+msgid "Chance of Precipitation"
+msgstr "강수확률"
+
+#: id:31909
+msgid "Fetching forecast info..."
+msgstr "날씨 정보를 가져오는 중..."
+

--- a/addons/skin.confluence/language/Lithuanian/strings.po
+++ b/addons/skin.confluence/language/Lithuanian/strings.po
@@ -1,0 +1,576 @@
+# Converted from xbmc strings.xml with xbmc-xml2po (by Team-XBMC)
+msgid ""
+msgstr ""
+"Project-Id-Version: xbmc.skin.confluence-FRODO_GIT953c09c336\n"
+"Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
+"POT-Creation-Date: 2012-04-09 18:03+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE\n"
+"Language: lt\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: id:31000
+msgid "Change Your"
+msgstr "Keičiami"
+
+#: id:31001
+msgid "Love"
+msgstr "Patinka"
+
+#: id:31002
+msgid "Hate"
+msgstr "Nepatinka"
+
+#: id:31003
+msgid "Power Options"
+msgstr "Energijos nustatymai"
+
+#: id:31004
+msgid "Working..."
+msgstr "Veikia..."
+
+#: id:31005
+msgid "Hide Information"
+msgstr "Paslėpti Informaciją"
+
+#: id:31006
+msgid "View Options"
+msgstr "Rodinio parinktys"
+
+#: id:31007
+msgid "Plugins"
+msgstr "Pridėtis"
+
+#: id:31008
+msgid "Fullscreen"
+msgstr "Per visą ekraną"
+
+#: id:31020
+msgctxt "Auto context with id 31020"
+msgid "Recently Added"
+msgstr "Neseniai Pridėti"
+
+#: id:31021
+msgid "Video - Files"
+msgstr "Video - Failai"
+
+#: id:31022
+msgid "Music - Files"
+msgstr "Muzikos - Failai"
+
+#: id:31023
+msgid "Playing"
+msgstr "Atkūrimas"
+
+#: id:31024
+msgid "Page"
+msgstr "Puslapis"
+
+#: id:31025
+msgid "Items"
+msgstr "Elementai"
+
+#: id:31026
+msgid "Misc Options"
+msgstr "Kitos Opcijos"
+
+#: id:31027
+msgid "Location"
+msgstr "Vietovė"
+
+#: id:31028
+msgid "Poster Wrap"
+msgstr "Posterių Karuselė"
+
+#: id:31029
+msgid "Fanart"
+msgstr "Fanart"
+
+#: id:31030
+msgid "Full list"
+msgstr "Pilnas sąrašas"
+
+#: id:31031
+msgid "Pic Thumbs"
+msgstr "Miniatiūros"
+
+#: id:31032
+msgid "Image Wrap"
+msgstr "Paveikslėliai žemai"
+
+#: id:31033
+msgid "Info"
+msgstr "Informacija"
+
+#: id:31040
+msgid "Now Playing"
+msgstr "Aktualus failas"
+
+#: id:31042
+msgid "PLAYING"
+msgstr "RODOMA"
+
+#: id:31043
+msgid "PAUSED"
+msgstr "PAUZĖ"
+
+#: id:31044
+msgid "FAST FORWARD"
+msgstr "PRASUKTI PIRMYN"
+
+#: id:31045
+msgid "REWIND"
+msgstr "PRASUKTI ATGAL"
+
+#: id:31046
+msgid "Audio Properties"
+msgstr "Garso Savybės"
+
+#: id:31047
+msgid "Current Preset"
+msgstr "Aktualūs Nustatymai"
+
+#: id:31048
+msgid "Visualization Presets"
+msgstr "Vizualizacijos Parinktys"
+
+#: id:31049
+msgid "End Time"
+msgstr "Pabaigos Laikas"
+
+#: id:31050
+msgid "Sort: Ascending"
+msgstr "Ruš.: Didėjimo tvarka"
+
+#: id:31051
+msgid "Sort: Descending"
+msgstr "Ruš.: Mažėjimo tvarka"
+
+#: id:31055
+msgid "Open playlist"
+msgstr "Atidaryti grojaraštį"
+
+#: id:31056
+msgid "Save playlist"
+msgstr "Įšsaugoti grojaraštį"
+
+#: id:31057
+msgid "Close playlist"
+msgstr "Uždaryti grojaraštį"
+
+#: id:31058
+msgid "System music files"
+msgstr "Sisteminiai audio failai"
+
+#: id:31059
+msgid "Current playlist"
+msgstr "Aktualus grojaraštis"
+
+#: id:31060
+msgid "This file is stacked, select the part you want to play from."
+msgstr "Šie failai yra sugrupuoti, pasirinkite dalį katrą norite atkurti."
+
+#: id:31061
+msgid "Current Selected"
+msgstr "Dabartinis Pasirinkimas"
+
+#: id:31101
+msgid "Home screen options"
+msgstr "Pagrindinio ekrano nustatymai"
+
+#: id:31102
+msgid "Background"
+msgstr "Fonas"
+
+#: id:31103
+msgid "Show \"Paused\" in picture slide show"
+msgstr "Rodyti \"Pauzė\" prezentacijos režime"
+
+#: id:31104
+msgid "Play Trailers in a window [COLOR=grey3](Video Information Dialog Only)[/COLOR]"
+msgstr "Rodyti treilerį lange [COLOR=red](Tik dėl informacijos apie video dialogą)[/COLOR]"
+
+#: id:31105
+msgid "\"Videos\" button always goes to video \"Files\""
+msgstr "Rodyti pavadinimus foniniame nuskaityme"
+
+#: id:31106
+msgid "Miscellaneous options"
+msgstr "Įvairios opcijos"
+
+#: id:31107
+msgid "Hide Flagging read from video filenames [COLOR=grey3](Blu-ray, HD-DVD)[/COLOR]"
+msgstr "Paslėpti nuorodas iš skaitomo failo [COLOR=red](Blu-ray, HD-DVD)[/COLOR]"
+
+#: id:31108
+msgid "Hide Main Menu Buttons"
+msgstr "Slėpti Pagrindinio Menių Nuorodas"
+
+#: id:31109
+msgid "Media backgrounds"
+msgstr "Pagrindinio menių fonas"
+
+#: id:31110
+msgid "Edit Background for Media Type"
+msgstr "Pakeisti pagrindinio ekrano foną"
+
+#: id:31111
+msgid "Hide"
+msgstr "Paslėpti"
+
+#: id:31112
+msgid "Options"
+msgstr "Nustatymai"
+
+#: id:31113
+msgid "Single Image"
+msgstr "Vienas Vaizdas"
+
+#: id:31114
+msgid "Multi Image"
+msgstr "Daug Vaizdų"
+
+#: id:31115
+msgid "Customizer"
+msgstr "Nustatymai"
+
+#: id:31117
+msgid "Show Recently added Videos"
+msgstr "Rodyti Neseniai Patalpintus Video"
+
+#: id:31118
+msgid "Home Page Programs Submenu"
+msgstr "Pagrindinio Ekrano Submeniu"
+
+#: id:31119
+msgid "Hide Background Fanart"
+msgstr "Slėpti Fanart informaciją"
+
+#: id:31120
+msgid "BUTTON LABEL"
+msgstr "MYGTUKO PAVADINIMAS"
+
+#: id:31122
+msgid "Weather Page"
+msgstr "Orų Puslapis"
+
+#: id:31123
+msgid "Use \"Posters\" instead of \"Banners\" for TV Shows"
+msgstr "Naudoti \"Posterius\" vietoi \"Banerių\" serialams"
+
+#: id:31124
+msgid "Show Background \"Now Playing\" Video"
+msgstr "Rodyti foninį \"Atkuriamasis\" Video"
+
+#: id:31125
+msgid "Show Background \"Now Playing\" Visualization"
+msgstr "Rodyti foninį \"Atkuriamasis\" Vizualizacija"
+
+#: id:31126
+msgid "Play TV theme songs in video library (TvTunes add-on)"
+msgstr "Ijungti Dainų Tekstai OSD"
+
+#: id:31127
+msgid "TvTunes"
+msgstr "KELIAS IKI LYRICS PRIEDŲ"
+
+#: id:31128
+msgid "Lyrics"
+msgstr "Dainų Tekstai"
+
+#: id:31132
+msgid "Lyrics Add-on"
+msgstr "Dainų Tekstų Priedas"
+
+#: id:31133
+msgid "Subtitle Add-on"
+msgstr "Subtitrų Priedas"
+
+#: id:31134
+msgid "Home Page Videos Submenu"
+msgstr "Pagrindinio puslapio Video Submeniu"
+
+#: id:31135
+msgid "Home Page Music Submenu"
+msgstr "Pagrindinio puslapio Muzikos Submeniu"
+
+#: id:31136
+msgid "Home Page Pictures Submenu"
+msgstr "Pagrindinio puslapio Paveikslėlių Submeniu"
+
+#: id:31140
+msgid "Music OSD"
+msgstr "Muzika OSD"
+
+#: id:31141
+msgid "Video OSD"
+msgstr "Video OSD"
+
+#: id:31200
+msgid "Shortcuts"
+msgstr "Etiketės"
+
+#: id:31201
+msgid "Categories"
+msgstr "Kategorijos"
+
+#: id:31202
+msgid "Show Cast"
+msgstr "Rodyti Vaidmenis"
+
+#: id:31203
+msgid "Choose Your Song"
+msgstr "Išsirinkti Jūsų Dainą"
+
+#: id:31204
+msgid "Section Links"
+msgstr "Nuorodų Kategorija"
+
+#: id:31205
+msgid "Lyrics Source"
+msgstr "Dainų Tekstų Šaltinis"
+
+#: id:31300
+msgid "Current Temp"
+msgstr "Dabartinė Temperatūra"
+
+#: id:31301
+msgid "Last Updated"
+msgstr "Paskutiniai Atnaujinimai"
+
+#: id:31302
+msgid "Menu"
+msgstr "Meniu"
+
+#: id:31303
+msgid "Data provider"
+msgstr ""
+
+#: id:31304
+msgid "Picture"
+msgstr "Vaizdas"
+
+#: id:31305
+msgid "No Disc Media Detected"
+msgstr "Nėra Disko"
+
+#: id:31306
+msgid "Eject"
+msgstr "Išimti"
+
+#: id:31307
+msgid "Hide Fanart"
+msgstr "Paslėpti Fanart"
+
+#: id:31308
+msgid "Movie Details"
+msgstr "Daugiau apie Filmą"
+
+#: id:31309
+msgid "Memory Used:"
+msgstr "Išnaudota Atminties:"
+
+#: id:31310
+msgid "Track Number"
+msgstr "Takelio Num.:"
+
+#: id:31311
+msgid "Fanart image[CR][CR]Unavailable[CR][CR] Click button to set"
+msgstr "FANART[CR][CR]NEPASIEKIAMAS[CR][CR] PASPAUSTI, KAD PASIRINKTI"
+
+#: id:31312
+msgid "Current Scraper"
+msgstr "Aktualus Skreperis"
+
+#: id:31313
+msgid "Choose a Scraper"
+msgstr "Pasirinkti Skreperį"
+
+#: id:31314
+msgid "Content Scanning Options"
+msgstr "Nuskaitomo Turinio Parinktys"
+
+#: id:31315
+msgid "Basic"
+msgstr "Bazinis(ė/iai)"
+
+#: id:31317
+msgid "Set Fanart Path"
+msgstr "Nurodyti Kelią iki Fanart"
+
+#: id:31318
+msgid "Small Fanart"
+msgstr "Mažas Fanart"
+
+#: id:31319
+msgid "Selected Profile"
+msgstr "Pasirinktas Profilis"
+
+#: id:31320
+msgid "Last Logged In"
+msgstr "Paskutinis Įėjimas"
+
+#: id:31321
+msgid "Karaoke Song Selector"
+msgstr "Karaoke Dainos Pasirinkimas"
+
+#: id:31322
+msgid "Aired"
+msgstr "Rodomas"
+
+#: id:31323
+msgid "Latest Movies"
+msgstr "Nauji Filmai"
+
+#: id:31324
+msgid "Latest Episodes"
+msgstr "Nauji Epizodai"
+
+#: id:31325
+msgid "Playlist Options"
+msgstr "Sąrašo Opcijos"
+
+#: id:31326
+msgid "Created"
+msgstr "Sukurta"
+
+#: id:31327
+msgid "Resolution"
+msgstr "Leidimas"
+
+#: id:31328
+msgctxt "Auto context with id 31328"
+msgid "Recently Added"
+msgstr "Neseniai Dadėta"
+
+#: id:31329
+msgid "[B]Timer set![/B] [COLOR=grey2] - System auto shutdown in[/COLOR]"
+msgstr "[B]NUSTATYTAS LAIKRODIS![/B] [COLOR=red] - AUTOMATIŠKAI ATSIJUNGS PO[/COLOR]"
+
+#: id:31330
+msgid "Click button to play[CR][CR]Movie trailer"
+msgstr "Spustelėkite norėdami atkūrti[CR][CR]Video treilerį"
+
+#: id:31331
+msgid "Album Details"
+msgstr "Albumai Detaliau"
+
+#: id:31351
+msgid "Pause"
+msgstr "Pauzė"
+
+#: id:31352
+msgid "Stop"
+msgstr "Stop"
+
+#: id:31353
+msgid "Fast Forward"
+msgstr "Prasukimas Pirmyn"
+
+#: id:31354
+msgid "Rewind"
+msgstr "Prasukimas Atgal"
+
+#: id:31355
+msgid "Movie menu"
+msgstr "Filmo Menių"
+
+#: id:31356
+msgid "Download Subtitles"
+msgstr "Atsisiųsti Subtitrus"
+
+#: id:31390
+msgid "Skin default"
+msgstr "Pagal nutylėjimą šablonui"
+
+#: id:31391
+msgid "Skin default with no Caps"
+msgstr "Pagal nutylėjimą šablonui be Kaps"
+
+#: id:31392
+msgid "Arial based"
+msgstr "Arial Pagrindu"
+
+#: id:31400
+msgid "[B]CONFIGURE APPEARANCE SETTINGS[/B][CR][CR]Change the skin � Set language and region � Change file listing options[CR]Set up a screensaver"
+msgstr "[B][COLOR=blue]IŠVAIZDOS PARAMETRŲ NUSTATYMAI[/COLOR][/B][CR][CR][COLOR=red]Pakeisti išvaizdą · Nustatyti kalbą ir regioną[CR]Pakeisti failų sarašą · Nustatyti ekrano vaizdą.[/COLOR]"
+
+#: id:31401
+msgid "[B]CONFIGURE VIDEO SETTINGS[/B][CR][CR]Manage your video library � Set video playback options � Change video listing options[CR]Set subtitle fonts"
+msgstr "[B][COLOR=blue]VIDEO PARAMETRŲ NUSTATYMAI[/COLOR][/B][CR][CR][COLOR=red]Tvarkyti video biblioteką · Nustatyti video atkūrimo opcijas.[CR]Nustatyti video sarašą · Nustatyti subtitrų šriftą.[/COLOR]"
+
+#: id:31402
+msgid "[B]CONFIGURE MUSIC SETTINGS[/B][CR][CR]Manage your music library � Set music playback options � Change music listing options[CR]Setup song submission � Set karaoke options"
+msgstr "[B][COLOR=blue]MUZIKOS PARAMETRŲ NUSTATYMAI[/COLOR][/B][CR][CR][COLOR=red]Tvarkyti audio biblioteką· Nustatyti audio atkūrimo opcijas.[CR]Nustatyti audio sarašą · Nustatyti audio pridėjimą · Nustatyti karaoke.[/COLOR]"
+
+#: id:31403
+msgid "[B]CONFIGURE PICTURE SETTINGS[/B][CR][CR]Set picture listing options � Configure slideshows"
+msgstr "[B][COLOR=blue]PAVEIKSLŲ PARAMETRŲ NUSTATYMAI[/COLOR][/B][CR][CR][COLOR=red]Tvarkyti nuotraukų biblioteką · Nustatyti pristatymą · Nustatyti prezentaciją.[/COLOR]"
+
+#: id:31404
+msgid "[B]CONFIGURE WEATHER SETTINGS[/B][CR][CR]Set three cities to collect weather information"
+msgstr "[B][COLOR=blue]ORŲ PARAMETRŲ NUSTATYMAI[/COLOR][/B][CR][CR][COLOR=red]Nustatyti trys Miestus gauti informacijai apie orus.[/COLOR]"
+
+#: id:31406
+msgid "[B]CONFIGURE SYSTEM SETTINGS[/B][CR][CR]Setup and calibrate displays � Configure audio output � Setup remote controls[CR]Set power saving options � Enable debugging � Setup master lock"
+msgstr "[B][COLOR=blue]SISTEMOS PARAMETRŲ NUSTATYMAI[/COLOR][/B][CR][CR][COLOR=red]Nustatyti ekrano kalibravimą · Nustatyti audio išėjimą · Nustatyti distancinį pultą.[CR]Nustatyti energijos sąnaudas · Nustatyti derinimą · Nustatyti blokavimą.[/COLOR]"
+
+#: id:31407
+msgid "[B]CONFIGURE SKIN SETTINGS[/B][CR][CR]Setup the Confluence skin � Add and remove home menu items[CR]Change skin backgrounds"
+msgstr "[B][COLOR=blue]ŠABLONŲ PARAMETRŲ NUSTATYMAI[/COLOR][/B][CR][CR][COLOR=red]Nustatyti pasirinktą šabloną. Pakeisti šablono foną.[CR]Pridėti ir (arba) pašalinti pagrindinius menių punktus.[/COLOR]"
+
+#: id:31408
+msgid "[B]CONFIGURE ADD-ONS[/B][CR][CR]Manage your installed Add-ons � Browse for and install Add-ons from xbmc.org[CR]Modify Add-on settings"
+msgstr "[B][COLOR=blue]PRIEDŲ PARAMETRŲ NUSTATYMAI[/COLOR][/B][CR][CR][COLOR=red]Nustatyti parametrų valdymą · Nustatymų diegimą iš xbmc.org[CR]Nustatyti priedų pakeitimą.[/COLOR]"
+
+#: id:31409
+msgid "[B]CONFIGURE SERVICE SETTINGS[/B][CR][CR]Setup control of XBMC via UPnP and HTTP � Configure file sharing[CR]Enable Zeroconf � Configure AirPlay"
+msgstr ""
+
+#: id:31421
+msgid "Select your XBMC user Profile[CR]to login and continue"
+msgstr "Pasirinkite XBMC vartotojo profilį[CR]įeiti į sistemą ir tęsti."
+
+#: id:31900
+msgid "Weather Maps"
+msgstr "Orų Žemėlapiai"
+
+#: id:31901
+msgid "36 Hour Forecast"
+msgstr "36 Valandų Prognozė"
+
+#: id:31902
+msgid "Hourly Forecast"
+msgstr "Valandinė Prognozė"
+
+#: id:31903
+msgid "Weekend Forecast"
+msgstr "Savaitgalio Prognozė"
+
+#: id:31904
+msgid "10 Day Forecast"
+msgstr "10 Dienų Prognozė"
+
+#: id:31905
+msgid "Forecast"
+msgstr "Prognozė"
+
+#: id:31906
+msgid "Maps & Video"
+msgstr "Žemėlapiai ir Video"
+
+#: id:31907
+msgid "Video Forecast [COLOR=grey2](Fullscreen Playback)[/COLOR]"
+msgstr "Video Prognozė [COLOR=grey2](Pilnaekranis Atkūrimas)[/COLOR]"
+
+#: id:31908
+msgid "Chance of Precipitation"
+msgstr "Kritulių Tikimybė"
+
+#: id:31909
+msgid "Fetching forecast info..."
+msgstr "Parsiunčiama Prognozės Informacija..."
+

--- a/addons/skin.confluence/language/Norwegian/strings.po
+++ b/addons/skin.confluence/language/Norwegian/strings.po
@@ -1,0 +1,576 @@
+# Converted from xbmc strings.xml with xbmc-xml2po (by Team-XBMC)
+msgid ""
+msgstr ""
+"Project-Id-Version: xbmc.skin.confluence-FRODO_GIT953c09c336\n"
+"Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
+"POT-Creation-Date: 2012-04-09 18:03+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE\n"
+"Language: no\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: id:31000
+msgid "Change Your"
+msgstr "Endre dine"
+
+#: id:31001
+msgid "Love"
+msgstr "Elsk"
+
+#: id:31002
+msgid "Hate"
+msgstr "Hat"
+
+#: id:31003
+msgid "Power Options"
+msgstr "Strømalternativer"
+
+#: id:31004
+msgid "Working..."
+msgstr "Opptatt..."
+
+#: id:31005
+msgid "Hide Information"
+msgstr "Gjem INFO"
+
+#: id:31006
+msgid "View Options"
+msgstr ""
+
+#: id:31007
+msgid "Plugins"
+msgstr "Tillegg"
+
+#: id:31008
+msgid "Fullscreen"
+msgstr ""
+
+#: id:31020
+msgctxt "Auto context with id 31020"
+msgid "Recently Added"
+msgstr "Nylig lagt til"
+
+#: id:31021
+msgid "Video - Files"
+msgstr "Videoer - Filer"
+
+#: id:31022
+msgid "Music - Files"
+msgstr "Musikk - Filer"
+
+#: id:31023
+msgid "Playing"
+msgstr "Spiller"
+
+#: id:31024
+msgid "Page"
+msgstr "Side"
+
+#: id:31025
+msgid "Items"
+msgstr "objekter"
+
+#: id:31026
+msgid "Misc Options"
+msgstr "Øvr. alternativer"
+
+#: id:31027
+msgid "Location"
+msgstr "Plassering"
+
+#: id:31028
+msgid "Poster Wrap"
+msgstr "Plakat"
+
+#: id:31029
+msgid "Fanart"
+msgstr "FanArt"
+
+#: id:31030
+msgid "Full list"
+msgstr "Full liste"
+
+#: id:31031
+msgid "Pic Thumbs"
+msgstr "Bildeminiatyrer"
+
+#: id:31032
+msgid "Image Wrap"
+msgstr "Bildeinnpakking"
+
+#: id:31033
+msgid "Info"
+msgstr "Informasjon"
+
+#: id:31040
+msgid "Now Playing"
+msgstr "Nå spilles"
+
+#: id:31042
+msgid "PLAYING"
+msgstr "SPILLER"
+
+#: id:31043
+msgid "PAUSED"
+msgstr "PAUSE"
+
+#: id:31044
+msgid "FAST FORWARD"
+msgstr "SPOL FRAM"
+
+#: id:31045
+msgid "REWIND"
+msgstr "SPOL TILBAKE"
+
+#: id:31046
+msgid "Audio Properties"
+msgstr "Lydegenskaper"
+
+#: id:31047
+msgid "Current Preset"
+msgstr "Nåværende forvalg"
+
+#: id:31048
+msgid "Visualization Presets"
+msgstr "Visualiseringsforvalg"
+
+#: id:31049
+msgid "End Time"
+msgstr "Slutt tid"
+
+#: id:31050
+msgid "Sort: Ascending"
+msgstr ""
+
+#: id:31051
+msgid "Sort: Descending"
+msgstr ""
+
+#: id:31055
+msgid "Open playlist"
+msgstr "Åpne spilleliste"
+
+#: id:31056
+msgid "Save playlist"
+msgstr "Lagre spilleliste"
+
+#: id:31057
+msgid "Close playlist"
+msgstr "Lukk spilleliste"
+
+#: id:31058
+msgid "System music files"
+msgstr "Systemmusikkfiler"
+
+#: id:31059
+msgid "Current playlist"
+msgstr "Nåværende spilleliste"
+
+#: id:31060
+msgid "This file is stacked, select the part you want to play from."
+msgstr "Denne fil er stablet, velg den delen du vil spille."
+
+#: id:31061
+msgid "Current Selected"
+msgstr "Valgt nå"
+
+#: id:31101
+msgid "Home screen options"
+msgstr "Alternativer for hovedskjerm"
+
+#: id:31102
+msgid "Background"
+msgstr "Bakgrunn"
+
+#: id:31103
+msgid "Show \"Paused\" in picture slide show"
+msgstr "Vis \"Pause\" under bildefremvisning"
+
+#: id:31104
+msgid "Play Trailers in a window [COLOR=grey3](Video Information Dialog Only)[/COLOR]"
+msgstr "Spill trailere i et vindu[COLOR=grey3](Kun videoinformasjonsdialog)[/COLOR]"
+
+#: id:31105
+msgid "\"Videos\" button always goes to video \"Files\""
+msgstr ""
+
+#: id:31106
+msgid "Miscellaneous options"
+msgstr "Øvrige alternativer"
+
+#: id:31107
+msgid "Hide Flagging read from video filenames [COLOR=grey3](Blu-ray, HD-DVD)[/COLOR]"
+msgstr "Gjem 'sett'-flagg fra videofilnavn [COLOR=grey3](Blu-ray, HD-DVD)[/COLOR]"
+
+#: id:31108
+msgid "Hide Main Menu Buttons"
+msgstr "Inaktive hovedmenyknapper"
+
+#: id:31109
+msgid "Media backgrounds"
+msgstr "Mediebakgrunner"
+
+#: id:31110
+msgid "Edit Background for Media Type"
+msgstr "Endre bakgrunn for medietype"
+
+#: id:31111
+msgid "Hide"
+msgstr "Skjul"
+
+#: id:31112
+msgid "Options"
+msgstr "Alternativer"
+
+#: id:31113
+msgid "Single Image"
+msgstr "Enkeltbilde"
+
+#: id:31114
+msgid "Multi Image"
+msgstr "Multibilde"
+
+#: id:31115
+msgid "Customizer"
+msgstr "Tilpasser"
+
+#: id:31117
+msgid "Show Recently added Videos"
+msgstr "Vis videoer nylig lagt til"
+
+#: id:31118
+msgid "Home Page Programs Submenu"
+msgstr "Programundermeny i hovedmeny"
+
+#: id:31119
+msgid "Hide Background Fanart"
+msgstr ""
+
+#: id:31120
+msgid "BUTTON LABEL"
+msgstr "KNAPPETIKETT"
+
+#: id:31122
+msgid "Weather Page"
+msgstr "Værside"
+
+#: id:31123
+msgid "Use \"Posters\" instead of \"Banners\" for TV Shows"
+msgstr "Bruk plakat istedet for banner for TV-serier"
+
+#: id:31124
+msgid "Show Background \"Now Playing\" Video"
+msgstr "Vis \"Nå spilles\" for filmer i bakgrunnen"
+
+#: id:31125
+msgid "Show Background \"Now Playing\" Visualization"
+msgstr "Vis visualisering for \"Nå spilles\" i bakgrunnen"
+
+#: id:31126
+msgid "Play TV theme songs in video library (TvTunes add-on)"
+msgstr ""
+
+#: id:31127
+msgid "TvTunes"
+msgstr ""
+
+#: id:31128
+msgid "Lyrics"
+msgstr "Sangtekster"
+
+#: id:31132
+msgid "Lyrics Add-on"
+msgstr ""
+
+#: id:31133
+msgid "Subtitle Add-on"
+msgstr ""
+
+#: id:31134
+msgid "Home Page Videos Submenu"
+msgstr ""
+
+#: id:31135
+msgid "Home Page Music Submenu"
+msgstr ""
+
+#: id:31136
+msgid "Home Page Pictures Submenu"
+msgstr ""
+
+#: id:31140
+msgid "Music OSD"
+msgstr "Musikk OSD"
+
+#: id:31141
+msgid "Video OSD"
+msgstr "Video OSD"
+
+#: id:31200
+msgid "Shortcuts"
+msgstr "Hurtigsti"
+
+#: id:31201
+msgid "Categories"
+msgstr "Kategorier"
+
+#: id:31202
+msgid "Show Cast"
+msgstr "Vis rolleliste"
+
+#: id:31203
+msgid "Choose Your Song"
+msgstr "Velg din låt"
+
+#: id:31204
+msgid "Section Links"
+msgstr "Seksjonslenker"
+
+#: id:31205
+msgid "Lyrics Source"
+msgstr "Sangtekstskilde"
+
+#: id:31300
+msgid "Current Temp"
+msgstr "Været nå"
+
+#: id:31301
+msgid "Last Updated"
+msgstr "Sist oppdatert"
+
+#: id:31302
+msgid "Menu"
+msgstr "Meny"
+
+#: id:31303
+msgid "Data provider"
+msgstr ""
+
+#: id:31304
+msgid "Picture"
+msgstr "Bilde"
+
+#: id:31305
+msgid "No Disc Media Detected"
+msgstr "Ingen diskmedia oppdaget"
+
+#: id:31306
+msgid "Eject"
+msgstr "Løs ut"
+
+#: id:31307
+msgid "Hide Fanart"
+msgstr "Skjul FanArt"
+
+#: id:31308
+msgid "Movie Details"
+msgstr "Filmdetaljer"
+
+#: id:31309
+msgid "Memory Used:"
+msgstr "Brukt minne:"
+
+#: id:31310
+msgid "Track Number"
+msgstr "Spornummer"
+
+#: id:31311
+msgid "Fanart image[CR][CR]Unavailable[CR][CR] Click button to set"
+msgstr "Fanart-bilde[CR][CR]ikke tilgjengelig[CR][CR]Klikk på knappen for å oppgi"
+
+#: id:31312
+msgid "Current Scraper"
+msgstr "Nåværende skraper"
+
+#: id:31313
+msgid "Choose a Scraper"
+msgstr "Velg en skraper"
+
+#: id:31314
+msgid "Content Scanning Options"
+msgstr "Alternativer for innholdsskraper"
+
+#: id:31315
+msgid "Basic"
+msgstr "Grunnleggende"
+
+#: id:31317
+msgid "Set Fanart Path"
+msgstr "Sett søkesti for FanArt"
+
+#: id:31318
+msgid "Small Fanart"
+msgstr "Liten FanArt"
+
+#: id:31319
+msgid "Selected Profile"
+msgstr "Valgt profil"
+
+#: id:31320
+msgid "Last Logged In"
+msgstr "Sist innlogget"
+
+#: id:31321
+msgid "Karaoke Song Selector"
+msgstr "Sangvelger for karaoker"
+
+#: id:31322
+msgid "Aired"
+msgstr "Sendt"
+
+#: id:31323
+msgid "Latest Movies"
+msgstr "Siste filmer"
+
+#: id:31324
+msgid "Latest Episodes"
+msgstr "Siste episoder"
+
+#: id:31325
+msgid "Playlist Options"
+msgstr "Alternativer for spilleliste"
+
+#: id:31326
+msgid "Created"
+msgstr "Laget"
+
+#: id:31327
+msgid "Resolution"
+msgstr "Oppløsning"
+
+#: id:31328
+msgctxt "Auto context with id 31328"
+msgid "Recently Added"
+msgstr "Nylig lagt til"
+
+#: id:31329
+msgid "[B]Timer set![/B] [COLOR=grey2] - System auto shutdown in[/COLOR]"
+msgstr "[B]Tidsinnstilling satt![/B] [COLOR=grey2] - Autoavslutning om[/COLOR]"
+
+#: id:31330
+msgid "Click button to play[CR][CR]Movie trailer"
+msgstr "Klikk for å spille[CR][CR]filmtrailer"
+
+#: id:31331
+msgid "Album Details"
+msgstr ""
+
+#: id:31351
+msgid "Pause"
+msgstr "Pause"
+
+#: id:31352
+msgid "Stop"
+msgstr "Stopp"
+
+#: id:31353
+msgid "Fast Forward"
+msgstr "Spol framover"
+
+#: id:31354
+msgid "Rewind"
+msgstr "Spol bakover"
+
+#: id:31355
+msgid "Movie menu"
+msgstr "Filmmeny"
+
+#: id:31356
+msgid "Download Subtitles"
+msgstr "Hent undertekster"
+
+#: id:31390
+msgid "Skin default"
+msgstr ""
+
+#: id:31391
+msgid "Skin default with no Caps"
+msgstr ""
+
+#: id:31392
+msgid "Arial based"
+msgstr ""
+
+#: id:31400
+msgid "[B]CONFIGURE APPEARANCE SETTINGS[/B][CR][CR]Change the skin � Set language and region � Change file listing options[CR]Set up a screensaver"
+msgstr "[B]ENDRE DINE UTSEENDEINNSTILLINGER:[/B][CR][CR]Kalibrer GUI · Endre skinnet · Oppgi skjermsparer · Endre dine regionale innstillinger · Oppgi globale visningsalternativer"
+
+#: id:31401
+msgid "[B]CONFIGURE VIDEO SETTINGS[/B][CR][CR]Manage your video library � Set video playback options � Change video listing options[CR]Set subtitle fonts"
+msgstr "[B]ENDRE DINE GRAFIKKINNSTILLINGER:[/B][CR][CR]Håndter ditt filmbibliotek · Filmavspillingskvalitet og rendring · Konfigurer skrifttype for undertekster · Oppgi filmautogjenopptaging"
+
+#: id:31402
+msgid "[B]CONFIGURE MUSIC SETTINGS[/B][CR][CR]Manage your music library � Set music playback options � Change music listing options[CR]Setup song submission � Set karaoke options"
+msgstr "[B]ENDRE DINE MUSIKKINNSTILLINGER:[/B][CR][CR] Velg visualisering · Håndter ditt musikkbibliotek · Oppgi din Last.FM konto · Endre karaokeskrifttype og -innstillinger"
+
+#: id:31403
+msgid "[B]CONFIGURE PICTURE SETTINGS[/B][CR][CR]Set picture listing options � Configure slideshows"
+msgstr "[B]ENDRE DINE BILDEINNSTILLINGER:[/B][CR][CR]Aktiver automatisk miniatyrgenerering og lesing av EXIF-tagger · Juster overgangseffekter for bildeframvising · Oppgi din XBMC skjermdumpsmappe"
+
+#: id:31404
+msgid "[B]CONFIGURE WEATHER SETTINGS[/B][CR][CR]Set three cities to collect weather information"
+msgstr "[B]ENDRE DINE VÆRINNSTILLINGER:[/B][CR][CR]Oppgi de tre stedene som XBMC viser på værskjermen · Endre dine regionale innstillinger, inklusive temperaturenheter"
+
+#: id:31406
+msgid "[B]CONFIGURE SYSTEM SETTINGS[/B][CR][CR]Setup and calibrate displays � Configure audio output � Setup remote controls[CR]Set power saving options � Enable debugging � Setup master lock"
+msgstr "[B]ENDRE DINE SYSTEMINNSTILLINGER:[/B][CR][CR]Endre standarden for strømsparingsmodus · Konfigurer videomaskinvare · Still inn din lydmaskinvare · Konfigurer hovedbrukerens passord- og systemlåser"
+
+#: id:31407
+msgid "[B]CONFIGURE SKIN SETTINGS[/B][CR][CR]Setup the Confluence skin � Add and remove home menu items[CR]Change skin backgrounds"
+msgstr "[B]ENDRE SKINNINNSTILLINGER:[/B][CR][CR]Legge til og ta bort hovedmenyknapper · Endre bakgrunner for hver seksjon · Skape sti til skript i hele skinnet"
+
+#: id:31408
+msgid "[B]CONFIGURE ADD-ONS[/B][CR][CR]Manage your installed Add-ons � Browse for and install Add-ons from xbmc.org[CR]Modify Add-on settings"
+msgstr "[B]KONFIGURER TILLEGG[/B][CR][CR]Håndter installerte tillegg · Let etter og installer tillegg fra xbmc.org[CR]Endre tilleggsinnstillinger"
+
+#: id:31409
+msgid "[B]CONFIGURE SERVICE SETTINGS[/B][CR][CR]Setup control of XBMC via UPnP and HTTP � Configure file sharing[CR]Enable Zeroconf � Configure AirPlay"
+msgstr ""
+
+#: id:31421
+msgid "Select your XBMC user Profile[CR]to login and continue"
+msgstr "Velg din XBMC brukerprofil[CR]for å logge inn og fortsette"
+
+#: id:31900
+msgid "Weather Maps"
+msgstr ""
+
+#: id:31901
+msgid "36 Hour Forecast"
+msgstr ""
+
+#: id:31902
+msgid "Hourly Forecast"
+msgstr ""
+
+#: id:31903
+msgid "Weekend Forecast"
+msgstr ""
+
+#: id:31904
+msgid "10 Day Forecast"
+msgstr ""
+
+#: id:31905
+msgid "Forecast"
+msgstr ""
+
+#: id:31906
+msgid "Maps & Video"
+msgstr ""
+
+#: id:31907
+msgid "Video Forecast [COLOR=grey2](Fullscreen Playback)[/COLOR]"
+msgstr ""
+
+#: id:31908
+msgid "Chance of Precipitation"
+msgstr ""
+
+#: id:31909
+msgid "Fetching forecast info..."
+msgstr ""
+

--- a/addons/skin.confluence/language/Polish/strings.po
+++ b/addons/skin.confluence/language/Polish/strings.po
@@ -1,0 +1,576 @@
+# Converted from xbmc strings.xml with xbmc-xml2po (by Team-XBMC)
+msgid ""
+msgstr ""
+"Project-Id-Version: xbmc.skin.confluence-FRODO_GIT953c09c336\n"
+"Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
+"POT-Creation-Date: 2012-04-09 18:03+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE\n"
+"Language: pl\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: id:31000
+msgid "Change Your"
+msgstr "Zmień"
+
+#: id:31001
+msgid "Love"
+msgstr "Lubię"
+
+#: id:31002
+msgid "Hate"
+msgstr "Nie lubię"
+
+#: id:31003
+msgid "Power Options"
+msgstr "Opcje zasilania"
+
+#: id:31004
+msgid "Working..."
+msgstr "Pracuję..."
+
+#: id:31005
+msgid "Hide Information"
+msgstr "Ukryj info"
+
+#: id:31006
+msgid "View Options"
+msgstr "Zobacz opcje"
+
+#: id:31007
+msgid "Plugins"
+msgstr "Wtyczki"
+
+#: id:31008
+msgid "Fullscreen"
+msgstr "Pełny ekran"
+
+#: id:31020
+msgctxt "Auto context with id 31020"
+msgid "Recently Added"
+msgstr "Ostatnio dodane"
+
+#: id:31021
+msgid "Video - Files"
+msgstr "Wideo - pliki"
+
+#: id:31022
+msgid "Music - Files"
+msgstr "Muzyka - pliki"
+
+#: id:31023
+msgid "Playing"
+msgstr "Otwarzam"
+
+#: id:31024
+msgid "Page"
+msgstr "Strona"
+
+#: id:31025
+msgid "Items"
+msgstr "Pozycji"
+
+#: id:31026
+msgid "Misc Options"
+msgstr "Różne opcje"
+
+#: id:31027
+msgid "Location"
+msgstr "Lokalizacja"
+
+#: id:31028
+msgid "Poster Wrap"
+msgstr "Plakaty"
+
+#: id:31029
+msgid "Fanart"
+msgstr "Fanart"
+
+#: id:31030
+msgid "Full list"
+msgstr "Pełna lista"
+
+#: id:31031
+msgid "Pic Thumbs"
+msgstr "Miniatury zdjęć"
+
+#: id:31032
+msgid "Image Wrap"
+msgstr "Zawijaj obrazy"
+
+#: id:31033
+msgid "Info"
+msgstr "Info"
+
+#: id:31040
+msgid "Now Playing"
+msgstr "Teraz odtwarzane"
+
+#: id:31042
+msgid "PLAYING"
+msgstr "ODTWARZAM"
+
+#: id:31043
+msgid "PAUSED"
+msgstr "PAUZA"
+
+#: id:31044
+msgid "FAST FORWARD"
+msgstr "PRZEWIŃ"
+
+#: id:31045
+msgid "REWIND"
+msgstr "COFNIJ"
+
+#: id:31046
+msgid "Audio Properties"
+msgstr "Właściwości audio"
+
+#: id:31047
+msgid "Current Preset"
+msgstr "Obecny efekt"
+
+#: id:31048
+msgid "Visualization Presets"
+msgstr "Efekty wizualizacji"
+
+#: id:31049
+msgid "End Time"
+msgstr "Koniec o godzinie"
+
+#: id:31050
+msgid "Sort: Ascending"
+msgstr "Sortuj: rosnąco"
+
+#: id:31051
+msgid "Sort: Descending"
+msgstr "Sortuj: malejąco"
+
+#: id:31055
+msgid "Open playlist"
+msgstr "Otwórz playlistę"
+
+#: id:31056
+msgid "Save playlist"
+msgstr "Zapisz playlistę"
+
+#: id:31057
+msgid "Close playlist"
+msgstr "Zamknij playlistę"
+
+#: id:31058
+msgid "System music files"
+msgstr "Dostępne w systemie pliki muzyczne"
+
+#: id:31059
+msgid "Current playlist"
+msgstr "Obecna playlista"
+
+#: id:31060
+msgid "This file is stacked, select the part you want to play from."
+msgstr "Pozycja w wyniku połączenia części[CR]wybierz, którą chcesz odtwarzać."
+
+#: id:31061
+msgid "Current Selected"
+msgstr "Aktualnie wybrany"
+
+#: id:31101
+msgid "Home screen options"
+msgstr "Opcje ekranu głównego"
+
+#: id:31102
+msgid "Background"
+msgstr "Tło"
+
+#: id:31103
+msgid "Show \"Paused\" in picture slide show"
+msgstr "Wyświetlaj \"Pauza\" podczas pokazu slajdów"
+
+#: id:31104
+msgid "Play Trailers in a window [COLOR=grey3](Video Information Dialog Only)[/COLOR]"
+msgstr "Odtwarzaj zwiastuny w oknie [COLOR=grey3](tylko w oknie Informacje o wideo)[/COLOR]"
+
+#: id:31105
+msgid "\"Videos\" button always goes to video \"Files\""
+msgstr "Przycisk \"wideo\" przenosi zawsze do plików wideo"
+
+#: id:31106
+msgid "Miscellaneous options"
+msgstr "Różne opcje"
+
+#: id:31107
+msgid "Hide Flagging read from video filenames [COLOR=grey3](Blu-ray, HD-DVD)[/COLOR]"
+msgstr "Ukryj ikony właściwości wideo z nazw plików [COLOR=grey3](Blu-ray, HD-DVD)[/COLOR]"
+
+#: id:31108
+msgid "Hide Main Menu Buttons"
+msgstr "Ukryj przyciski głównego menu"
+
+#: id:31109
+msgid "Media backgrounds"
+msgstr "Tła ekranu głównego"
+
+#: id:31110
+msgid "Edit Background for Media Type"
+msgstr "Edytuj tło dla"
+
+#: id:31111
+msgid "Hide"
+msgstr "Ukryj"
+
+#: id:31112
+msgid "Options"
+msgstr "Opcje"
+
+#: id:31113
+msgid "Single Image"
+msgstr "Pojedynczy obraz"
+
+#: id:31114
+msgid "Multi Image"
+msgstr "Wiele obrazów"
+
+#: id:31115
+msgid "Customizer"
+msgstr "Modyfikacja"
+
+#: id:31117
+msgid "Show Recently added Videos"
+msgstr "Pokazuj ostatnio dodane wideo"
+
+#: id:31118
+msgid "Home Page Programs Submenu"
+msgstr "Podmenu programów Ekranu głównego"
+
+#: id:31119
+msgid "Hide Background Fanart"
+msgstr "Ukryj tło fanartu"
+
+#: id:31120
+msgid "BUTTON LABEL"
+msgstr "ETYKIETA PRZYCISKU"
+
+#: id:31122
+msgid "Weather Page"
+msgstr "Strona pogody"
+
+#: id:31123
+msgid "Use \"Posters\" instead of \"Banners\" for TV Shows"
+msgstr "Użyj plakatów zamiast banerów dla seriali"
+
+#: id:31124
+msgid "Show Background \"Now Playing\" Video"
+msgstr "Pokazuj aktualnie odtwarzane wideo jako tło"
+
+#: id:31125
+msgid "Show Background \"Now Playing\" Visualization"
+msgstr "Pokazuj aktualną wizualizację jako tło"
+
+#: id:31126
+msgid "Play TV theme songs in video library (TvTunes add-on)"
+msgstr "Odtwarzaj motyw TV w bibliotece wideo (wtyczka TvTunes)"
+
+#: id:31127
+msgid "TvTunes"
+msgstr ""
+
+#: id:31128
+msgid "Lyrics"
+msgstr "Teksty piosenek"
+
+#: id:31132
+msgid "Lyrics Add-on"
+msgstr "Wtyczka Teksty piosenek"
+
+#: id:31133
+msgid "Subtitle Add-on"
+msgstr "Wtyczka Napisy do filmów"
+
+#: id:31134
+msgid "Home Page Videos Submenu"
+msgstr "Podmenu wideo Ekranu głównego"
+
+#: id:31135
+msgid "Home Page Music Submenu"
+msgstr "Podmenu muzyki Ekranu głównego"
+
+#: id:31136
+msgid "Home Page Pictures Submenu"
+msgstr "Podmenu zdjęć Ekranu głównego"
+
+#: id:31140
+msgid "Music OSD"
+msgstr "Muzyka - OSD"
+
+#: id:31141
+msgid "Video OSD"
+msgstr "Wideo - OSD"
+
+#: id:31200
+msgid "Shortcuts"
+msgstr "Skróty"
+
+#: id:31201
+msgid "Categories"
+msgstr "Kategorie"
+
+#: id:31202
+msgid "Show Cast"
+msgstr "Pokaż obsadę"
+
+#: id:31203
+msgid "Choose Your Song"
+msgstr "Wybierz swoją piosenkę"
+
+#: id:31204
+msgid "Section Links"
+msgstr "Linki sekcji"
+
+#: id:31205
+msgid "Lyrics Source"
+msgstr "Źródło tekstów piosenek"
+
+#: id:31300
+msgid "Current Temp"
+msgstr "Temperatura"
+
+#: id:31301
+msgid "Last Updated"
+msgstr "Ostatnia aktualizacja"
+
+#: id:31302
+msgid "Menu"
+msgstr "Menu"
+
+#: id:31303
+msgid "Data provider"
+msgstr "Dostawca danych"
+
+#: id:31304
+msgid "Picture"
+msgstr "Zdjęcia"
+
+#: id:31305
+msgid "No Disc Media Detected"
+msgstr "Nie wykryto płyty"
+
+#: id:31306
+msgid "Eject"
+msgstr "Wysuń"
+
+#: id:31307
+msgid "Hide Fanart"
+msgstr "Ukryj fanart"
+
+#: id:31308
+msgid "Movie Details"
+msgstr "Szczegóły o filmie"
+
+#: id:31309
+msgid "Memory Used:"
+msgstr "Używana pamięć:"
+
+#: id:31310
+msgid "Track Number"
+msgstr "Numer ścieżki"
+
+#: id:31311
+msgid "Fanart image[CR][CR]Unavailable[CR][CR] Click button to set"
+msgstr "Fanart[CR][CR]niedostępny[CR][CR] Kliknij przycisk, aby dodać"
+
+#: id:31312
+msgid "Current Scraper"
+msgstr "Bieżący scraper"
+
+#: id:31313
+msgid "Choose a Scraper"
+msgstr "Wybierz scraper"
+
+#: id:31314
+msgid "Content Scanning Options"
+msgstr "Opcje skanowania zawartości"
+
+#: id:31315
+msgid "Basic"
+msgstr "Podstawowe"
+
+#: id:31317
+msgid "Set Fanart Path"
+msgstr "Wskaż ścieżkę fanartu"
+
+#: id:31318
+msgid "Small Fanart"
+msgstr "Mały fanart"
+
+#: id:31319
+msgid "Selected Profile"
+msgstr "Wybrany profil"
+
+#: id:31320
+msgid "Last Logged In"
+msgstr "Ostatnio zalogowany"
+
+#: id:31321
+msgid "Karaoke Song Selector"
+msgstr "Wybór piosenki karaoke"
+
+#: id:31322
+msgid "Aired"
+msgstr "Emisja"
+
+#: id:31323
+msgid "Latest Movies"
+msgstr "Najnowsze filmy"
+
+#: id:31324
+msgid "Latest Episodes"
+msgstr "Najnowsze odcinki"
+
+#: id:31325
+msgid "Playlist Options"
+msgstr "Opcje playlisty"
+
+#: id:31326
+msgid "Created"
+msgstr "Utworzony"
+
+#: id:31327
+msgid "Resolution"
+msgstr "Rozdzielczość"
+
+#: id:31328
+msgctxt "Auto context with id 31328"
+msgid "Recently Added"
+msgstr "Ostatnio dodane"
+
+#: id:31329
+msgid "[B]Timer set![/B] [COLOR=grey2] - System auto shutdown in[/COLOR]"
+msgstr "[B]Timer ustawiony![/B] [COLOR=grey2] - Wyłączenie systemu za[/COLOR]"
+
+#: id:31330
+msgid "Click button to play[CR][CR]Movie trailer"
+msgstr "Kliknij przycisk, aby[CR][CR]odtworzyć zwiastun"
+
+#: id:31331
+msgid "Album Details"
+msgstr "Sczegóły albumu"
+
+#: id:31351
+msgid "Pause"
+msgstr "Pauza"
+
+#: id:31352
+msgid "Stop"
+msgstr "Stop"
+
+#: id:31353
+msgid "Fast Forward"
+msgstr "Przewiń"
+
+#: id:31354
+msgid "Rewind"
+msgstr "Cofnij"
+
+#: id:31355
+msgid "Movie menu"
+msgstr "Menu filmu"
+
+#: id:31356
+msgid "Download Subtitles"
+msgstr "Pobierz napisy"
+
+#: id:31390
+msgid "Skin default"
+msgstr "Domyślne dla skóry"
+
+#: id:31391
+msgid "Skin default with no Caps"
+msgstr "Domyślne dla skóry bez dużych liter"
+
+#: id:31392
+msgid "Arial based"
+msgstr "Bazujące na Arialu"
+
+#: id:31400
+msgid "[B]CONFIGURE APPEARANCE SETTINGS[/B][CR][CR]Change the skin � Set language and region � Change file listing options[CR]Set up a screensaver"
+msgstr "[B]KONFIGURUJ USTAWIENIA WYGLĄDU[/B][CR][CR]Wybór skóry · Język · Lista plików[CR]Wygaszacz ekranu"
+
+#: id:31401
+msgid "[B]CONFIGURE VIDEO SETTINGS[/B][CR][CR]Manage your video library � Set video playback options � Change video listing options[CR]Set subtitle fonts"
+msgstr "[B]KONFIGURUJ USTAWIENIA WIDEO[/B][CR][CR]Biblioteka wideo · Odtwarzanie · Lista wideo[CR]Czcionka napisów"
+
+#: id:31402
+msgid "[B]CONFIGURE MUSIC SETTINGS[/B][CR][CR]Manage your music library � Set music playback options � Change music listing options[CR]Setup song submission � Set karaoke options"
+msgstr "[B]KONFIGURUJ USTAWIENIA MUZYKI[/B][CR][CR]Biblioteka muzyki · Odtwarzanie · Lista utworów[CR]Publikacja piosenek · Opcje karaoke"
+
+#: id:31403
+msgid "[B]CONFIGURE PICTURE SETTINGS[/B][CR][CR]Set picture listing options � Configure slideshows"
+msgstr "[B]KONFIGURUJ USTAWIENIA ZDJĘĆ[/B][CR][CR]Lista zdjęć · Pokaz slajdów"
+
+#: id:31404
+msgid "[B]CONFIGURE WEATHER SETTINGS[/B][CR][CR]Set three cities to collect weather information"
+msgstr "[B]KONFIGURUJ USTAWIENIA POGODY[/B][CR][CR]Ustaw pogodę dla trzech miast"
+
+#: id:31406
+msgid "[B]CONFIGURE SYSTEM SETTINGS[/B][CR][CR]Setup and calibrate displays � Configure audio output � Setup remote controls[CR]Set power saving options � Enable debugging � Setup master lock"
+msgstr "[B]KONFIGURUJ USTAWIENIA SYSTEMU[/B][CR][CR]Ustawienia wyświetlania · Wyjście audio · Zdalne sterowania[CR]Opcje zasilania · Debugging · Blokady"
+
+#: id:31407
+msgid "[B]CONFIGURE SKIN SETTINGS[/B][CR][CR]Setup the Confluence skin � Add and remove home menu items[CR]Change skin backgrounds"
+msgstr "[B]KONFIGURUJ USTAWIENIA SKÓRY[/B][CR][CR]Ustawienia skóry · Pozycje menu głównego[CR]Tła skóry"
+
+#: id:31408
+msgid "[B]CONFIGURE ADD-ONS[/B][CR][CR]Manage your installed Add-ons � Browse for and install Add-ons from xbmc.org[CR]Modify Add-on settings"
+msgstr "[B]KONFIGURUJ USTAWIENIA WTYCZEK[/B][CR][CR]Zarządzaj wtyczkami · Przeglądaj i instaluj wtyczki[CR]Ustawienia wtyczek"
+
+#: id:31409
+msgid "[B]CONFIGURE SERVICE SETTINGS[/B][CR][CR]Setup control of XBMC via UPnP and HTTP � Configure file sharing[CR]Enable Zeroconf � Configure AirPlay"
+msgstr ""
+
+#: id:31421
+msgid "Select your XBMC user Profile[CR]to login and continue"
+msgstr "Wybierz profil użytkownika"
+
+#: id:31900
+msgid "Weather Maps"
+msgstr "Mapy pogody"
+
+#: id:31901
+msgid "36 Hour Forecast"
+msgstr "Pogoda na 36 godzin"
+
+#: id:31902
+msgid "Hourly Forecast"
+msgstr "Pogoda godzinna"
+
+#: id:31903
+msgid "Weekend Forecast"
+msgstr "Pogoda weekendowa"
+
+#: id:31904
+msgid "10 Day Forecast"
+msgstr "Pogoda na 10 dni"
+
+#: id:31905
+msgid "Forecast"
+msgstr "Pogoda"
+
+#: id:31906
+msgid "Maps & Video"
+msgstr "Mapy i wideo"
+
+#: id:31907
+msgid "Video Forecast [COLOR=grey2](Fullscreen Playback)[/COLOR]"
+msgstr "Pogoda wideo [COLOR=grey2](na pełnym ekranie)[/COLOR]"
+
+#: id:31908
+msgid "Chance of Precipitation"
+msgstr "Możliwość opadów"
+
+#: id:31909
+msgid "Fetching forecast info..."
+msgstr "Prognozuję pogodę..."
+

--- a/addons/skin.confluence/language/Portuguese (Brazil)/strings.po
+++ b/addons/skin.confluence/language/Portuguese (Brazil)/strings.po
@@ -1,0 +1,576 @@
+# Converted from xbmc strings.xml with xbmc-xml2po (by Team-XBMC)
+msgid ""
+msgstr ""
+"Project-Id-Version: xbmc.skin.confluence-FRODO_GIT953c09c336\n"
+"Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
+"POT-Creation-Date: 2012-04-09 18:03+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE\n"
+"Language: pt_BR\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: id:31000
+msgid "Change Your"
+msgstr "Alterar seu"
+
+#: id:31001
+msgid "Love"
+msgstr "Amor"
+
+#: id:31002
+msgid "Hate"
+msgstr "Ódio"
+
+#: id:31003
+msgid "Power Options"
+msgstr "Opções de energia"
+
+#: id:31004
+msgid "Working..."
+msgstr "Executando..."
+
+#: id:31005
+msgid "Hide Information"
+msgstr "Esconder INFO"
+
+#: id:31006
+msgid "View Options"
+msgstr ""
+
+#: id:31007
+msgid "Plugins"
+msgstr "Plugins"
+
+#: id:31008
+msgid "Fullscreen"
+msgstr "Tela Cheia"
+
+#: id:31020
+msgctxt "Auto context with id 31020"
+msgid "Recently Added"
+msgstr "Adicionado recentemente"
+
+#: id:31021
+msgid "Video - Files"
+msgstr "Video - Arquivos"
+
+#: id:31022
+msgid "Music - Files"
+msgstr "Música - Arquivos"
+
+#: id:31023
+msgid "Playing"
+msgstr "Executando"
+
+#: id:31024
+msgid "Page"
+msgstr "Página"
+
+#: id:31025
+msgid "Items"
+msgstr "Itens"
+
+#: id:31026
+msgid "Misc Options"
+msgstr "Opções diversas"
+
+#: id:31027
+msgid "Location"
+msgstr "Localização"
+
+#: id:31028
+msgid "Poster Wrap"
+msgstr "Vitrine"
+
+#: id:31029
+msgid "Fanart"
+msgstr "Fanart"
+
+#: id:31030
+msgid "Full list"
+msgstr "Lista Completa"
+
+#: id:31031
+msgid "Pic Thumbs"
+msgstr "Ícones de imagens"
+
+#: id:31032
+msgid "Image Wrap"
+msgstr "Vitrine de Imagens"
+
+#: id:31033
+msgid "Info"
+msgstr "Info"
+
+#: id:31040
+msgid "Now Playing"
+msgstr "Tocando agora"
+
+#: id:31042
+msgid "PLAYING"
+msgstr "TOCANDO"
+
+#: id:31043
+msgid "PAUSED"
+msgstr "PAUSADO"
+
+#: id:31044
+msgid "FAST FORWARD"
+msgstr "AVANÇO RÁPIDO"
+
+#: id:31045
+msgid "REWIND"
+msgstr "RETROCEDER"
+
+#: id:31046
+msgid "Audio Properties"
+msgstr "Propriedades de áudio"
+
+#: id:31047
+msgid "Current Preset"
+msgstr "Pré configuração atual"
+
+#: id:31048
+msgid "Visualization Presets"
+msgstr "Visualizar pré-configurações"
+
+#: id:31049
+msgid "End Time"
+msgstr "Tempo de término"
+
+#: id:31050
+msgid "Sort: Ascending"
+msgstr "Ordem: Ascendente"
+
+#: id:31051
+msgid "Sort: Descending"
+msgstr "Ordem: Descendente"
+
+#: id:31055
+msgid "Open playlist"
+msgstr "Abrir playlist"
+
+#: id:31056
+msgid "Save playlist"
+msgstr "Salvar playlist"
+
+#: id:31057
+msgid "Close playlist"
+msgstr "Fechar playlist"
+
+#: id:31058
+msgid "System music files"
+msgstr "Arquivos de música do sistema"
+
+#: id:31059
+msgid "Current playlist"
+msgstr "Playlist atual"
+
+#: id:31060
+msgid "This file is stacked, select the part you want to play from."
+msgstr "Este arquivo está empilhado, selecione a parte de onde executar."
+
+#: id:31061
+msgid "Current Selected"
+msgstr "Selecionado"
+
+#: id:31101
+msgid "Home screen options"
+msgstr "Opções da tela principal (home)"
+
+#: id:31102
+msgid "Background"
+msgstr "Fundo"
+
+#: id:31103
+msgid "Show \"Paused\" in picture slide show"
+msgstr "Exibir \"Pausado\" em exibição de imagens (slideshow)"
+
+#: id:31104
+msgid "Play Trailers in a window [COLOR=grey3](Video Information Dialog Only)[/COLOR]"
+msgstr "Tocar trailers em uma janela [COLOR=grey3](Só Diálogo de Informações do Vídeo)[/COLOR]"
+
+#: id:31105
+msgid "\"Videos\" button always goes to video \"Files\""
+msgstr "\"Botão Videos\" sempre vai para arquivos de vídeos"
+
+#: id:31106
+msgid "Miscellaneous options"
+msgstr "Opções diversas"
+
+#: id:31107
+msgid "Hide Flagging read from video filenames [COLOR=grey3](Blu-ray, HD-DVD)[/COLOR]"
+msgstr "Ocultar marcadores lidos do arquivo de vídeo [COLOR=grey3](Blu-ray, HD-DVD)[/COLOR]"
+
+#: id:31108
+msgid "Hide Main Menu Buttons"
+msgstr "Ocultar botões do Menu Principal"
+
+#: id:31109
+msgid "Media backgrounds"
+msgstr "Fundos da tela principal (home)"
+
+#: id:31110
+msgid "Edit Background for Media Type"
+msgstr "Editar fundo para botão principal (home)"
+
+#: id:31111
+msgid "Hide"
+msgstr "Ocultar"
+
+#: id:31112
+msgid "Options"
+msgstr "Opções"
+
+#: id:31113
+msgid "Single Image"
+msgstr "Imagem única"
+
+#: id:31114
+msgid "Multi Image"
+msgstr "Multi imagens"
+
+#: id:31115
+msgid "Customizer"
+msgstr "Personalizador"
+
+#: id:31117
+msgid "Show Recently added Videos"
+msgstr "Exibir vídeos adicionados recentemente"
+
+#: id:31118
+msgid "Home Page Programs Submenu"
+msgstr "Submenu Programas da Página Principal"
+
+#: id:31119
+msgid "Hide Background Fanart"
+msgstr "Ocultar fanart fundo da visualização"
+
+#: id:31120
+msgid "BUTTON LABEL"
+msgstr "RÓTULO DE BOTÃO"
+
+#: id:31122
+msgid "Weather Page"
+msgstr "Página do Tempo"
+
+#: id:31123
+msgid "Use \"Posters\" instead of \"Banners\" for TV Shows"
+msgstr "Usar \"Pôsters\" ao invés de \"Faixas\" para Seriados"
+
+#: id:31124
+msgid "Show Background \"Now Playing\" Video"
+msgstr "Exibir fundo Vídeo \"Tocando Agora\""
+
+#: id:31125
+msgid "Show Background \"Now Playing\" Visualization"
+msgstr "Exibir fundo Visualização \"Tocando Agora\""
+
+#: id:31126
+msgid "Play TV theme songs in video library (TvTunes add-on)"
+msgstr "Reproduzir música tema do seriado na biblioteca de vídeo(TvTunes add-on)"
+
+#: id:31127
+msgid "TvTunes"
+msgstr "TvTunes"
+
+#: id:31128
+msgid "Lyrics"
+msgstr "Letras"
+
+#: id:31132
+msgid "Lyrics Add-on"
+msgstr "Add-on de Letras"
+
+#: id:31133
+msgid "Subtitle Add-on"
+msgstr "Add-on de legendas"
+
+#: id:31134
+msgid "Home Page Videos Submenu"
+msgstr "Home Page Submenu de Videos"
+
+#: id:31135
+msgid "Home Page Music Submenu"
+msgstr "Home Page Submenu de Música"
+
+#: id:31136
+msgid "Home Page Pictures Submenu"
+msgstr "Home Page Submenu de Imagens"
+
+#: id:31140
+msgid "Music OSD"
+msgstr "OSD de Música"
+
+#: id:31141
+msgid "Video OSD"
+msgstr "OSD de Video"
+
+#: id:31200
+msgid "Shortcuts"
+msgstr "Atalhos"
+
+#: id:31201
+msgid "Categories"
+msgstr "Categorias"
+
+#: id:31202
+msgid "Show Cast"
+msgstr "Elenco do Seriado"
+
+#: id:31203
+msgid "Choose Your Song"
+msgstr "Escolha sua música"
+
+#: id:31204
+msgid "Section Links"
+msgstr "Seção de Links"
+
+#: id:31205
+msgid "Lyrics Source"
+msgstr "Origem das Letras"
+
+#: id:31300
+msgid "Current Temp"
+msgstr "Temp. Atual"
+
+#: id:31301
+msgid "Last Updated"
+msgstr "Última atualização"
+
+#: id:31302
+msgid "Menu"
+msgstr "Menu"
+
+#: id:31303
+msgid "Data provider"
+msgstr ""
+
+#: id:31304
+msgid "Picture"
+msgstr "Imagem"
+
+#: id:31305
+msgid "No Disc Media Detected"
+msgstr "Nenhum disco de mídia detectado"
+
+#: id:31306
+msgid "Eject"
+msgstr "Ejetar"
+
+#: id:31307
+msgid "Hide Fanart"
+msgstr "Ocultar Fanart"
+
+#: id:31308
+msgid "Movie Details"
+msgstr "Detalhes do vídeo"
+
+#: id:31309
+msgid "Memory Used:"
+msgstr "Memória usada:"
+
+#: id:31310
+msgid "Track Number"
+msgstr "Número da faixa"
+
+#: id:31311
+msgid "Fanart image[CR][CR]Unavailable[CR][CR] Click button to set"
+msgstr "Imagem de Fanart[CR][CR]Indisponível[CR][CR] Clique no botão para definir"
+
+#: id:31312
+msgid "Current Scraper"
+msgstr "Scraper Atual"
+
+#: id:31313
+msgid "Choose a Scraper"
+msgstr "Escolha um Scraper"
+
+#: id:31314
+msgid "Content Scanning Options"
+msgstr "Opções de busca de conteúdo"
+
+#: id:31315
+msgid "Basic"
+msgstr "Básico"
+
+#: id:31317
+msgid "Set Fanart Path"
+msgstr "Definir caminho do Fanart"
+
+#: id:31318
+msgid "Small Fanart"
+msgstr "Fanart Pequeno"
+
+#: id:31319
+msgid "Selected Profile"
+msgstr "Perfil selecionado"
+
+#: id:31320
+msgid "Last Logged In"
+msgstr "Última conexão"
+
+#: id:31321
+msgid "Karaoke Song Selector"
+msgstr "Selecionador de Música Karaoke"
+
+#: id:31322
+msgid "Aired"
+msgstr "Transmitido"
+
+#: id:31323
+msgid "Latest Movies"
+msgstr "Últimos Filmes"
+
+#: id:31324
+msgid "Latest Episodes"
+msgstr "Últimos Episódios"
+
+#: id:31325
+msgid "Playlist Options"
+msgstr "Opções do Playlist"
+
+#: id:31326
+msgid "Created"
+msgstr "Criado"
+
+#: id:31327
+msgid "Resolution"
+msgstr "Resolução"
+
+#: id:31328
+msgctxt "Auto context with id 31328"
+msgid "Recently Added"
+msgstr "Adicionado Recentemente"
+
+#: id:31329
+msgid "[B]Timer set![/B] [COLOR=grey2] - System auto shutdown in[/COLOR]"
+msgstr "[B]Timer definido![/B] [COLOR=grey2] - Sistema se desligará em[/COLOR]"
+
+#: id:31330
+msgid "Click button to play[CR][CR]Movie trailer"
+msgstr "Clique no botão para tocar o[CR][CR]trailer"
+
+#: id:31331
+msgid "Album Details"
+msgstr "Detalhes do Álbum"
+
+#: id:31351
+msgid "Pause"
+msgstr "Pausar"
+
+#: id:31352
+msgid "Stop"
+msgstr "Parar"
+
+#: id:31353
+msgid "Fast Forward"
+msgstr "Avançar"
+
+#: id:31354
+msgid "Rewind"
+msgstr "Voltar"
+
+#: id:31355
+msgid "Movie menu"
+msgstr "Menu do Filme"
+
+#: id:31356
+msgid "Download Subtitles"
+msgstr "Download de Legendas"
+
+#: id:31390
+msgid "Skin default"
+msgstr "Padrão da skin"
+
+#: id:31391
+msgid "Skin default with no Caps"
+msgstr "Padrão da skin sem capslock"
+
+#: id:31392
+msgid "Arial based"
+msgstr "Baseado em Arial"
+
+#: id:31400
+msgid "[B]CONFIGURE APPEARANCE SETTINGS[/B][CR][CR]Change the skin � Set language and region � Change file listing options[CR]Set up a screensaver"
+msgstr "[B]CONFIGURAR AJUSTES DE APARÊNCIA[/B][CR][CR]Mudar o skin · Definir idioma e região · Definir opções de listagem de arquivos · Definir um descanso de tela"
+
+#: id:31401
+msgid "[B]CONFIGURE VIDEO SETTINGS[/B][CR][CR]Manage your video library � Set video playback options � Change video listing options[CR]Set subtitle fonts"
+msgstr "[B]CONFIGURAR AJUSTES DE VÍDEO[/B][CR][CR]Gerenciar sua coleção de vídeos · Definir opções de execução de vídeo · Alterar opções de listagem de vídeo · Definir fonte para legendas"
+
+#: id:31402
+msgid "[B]CONFIGURE MUSIC SETTINGS[/B][CR][CR]Manage your music library � Set music playback options � Change music listing options[CR]Setup song submission � Set karaoke options"
+msgstr "[B]CONFIGURAR AJUSTES DE MÚSICAS[/B][CR][CR]Gerenciar sua coleção de músicas · Definir opções de execução de música · Alterar opções de listagem de música · Configurar submissão de música · Definir opções de karaoke"
+
+#: id:31403
+msgid "[B]CONFIGURE PICTURE SETTINGS[/B][CR][CR]Set picture listing options � Configure slideshows"
+msgstr "[B]CONFIGURAR AJUSTES DE IMAGENS[/B][CR][CR]Definir opções de listagem de imagens · Configurar exibição de imagens(slideshow)"
+
+#: id:31404
+msgid "[B]CONFIGURE WEATHER SETTINGS[/B][CR][CR]Set three cities to collect weather information"
+msgstr "[B]CONFIGURAR AJUSTES DE TEMPO[/B][CR][CR]Definir três cidades para buscar informações sobre o tempo"
+
+#: id:31406
+msgid "[B]CONFIGURE SYSTEM SETTINGS[/B][CR][CR]Setup and calibrate displays � Configure audio output � Setup remote controls[CR]Set power saving options � Enable debugging � Setup master lock"
+msgstr "[B]CONFIGURAR AJUSTES DE SISTEMA[/B][CR][CR]Configurar e calibrar telas · Configurar saída de áudio · Configurar controles remotos · Definir opções para economia de energia · Habilitar depuração · Configurar bloqueio mestre"
+
+#: id:31407
+msgid "[B]CONFIGURE SKIN SETTINGS[/B][CR][CR]Setup the Confluence skin � Add and remove home menu items[CR]Change skin backgrounds"
+msgstr "[B]CONFIGURAR AJUSTES DE SKIN[/B][CR][CR]Configurar o skin Confluence · Adicionar e remover itens no menu principal(home) · Alterar fundos do skin"
+
+#: id:31408
+msgid "[B]CONFIGURE ADD-ONS[/B][CR][CR]Manage your installed Add-ons � Browse for and install Add-ons from xbmc.org[CR]Modify Add-on settings"
+msgstr "[B]CONFIGURAR AJUSTES DE ADD-ONS[/B][CR][CR]Configurar Add-ons existentes · Procurar e instalar novos Add-ons de xbmc.org[CR]Alterar configurações do Add-on"
+
+#: id:31409
+msgid "[B]CONFIGURE SERVICE SETTINGS[/B][CR][CR]Setup control of XBMC via UPnP and HTTP � Configure file sharing[CR]Enable Zeroconf � Configure AirPlay"
+msgstr ""
+
+#: id:31421
+msgid "Select your XBMC user Profile[CR]to login and continue"
+msgstr "Selecione seu Perfil de usuário XBMC[CR]para conectar e continue"
+
+#: id:31900
+msgid "Weather Maps"
+msgstr "Mapas - Clima"
+
+#: id:31901
+msgid "36 Hour Forecast"
+msgstr "Previsão 36 Horas"
+
+#: id:31902
+msgid "Hourly Forecast"
+msgstr "Previsão por hora"
+
+#: id:31903
+msgid "Weekend Forecast"
+msgstr "Previsão fim de semana"
+
+#: id:31904
+msgid "10 Day Forecast"
+msgstr "Previsão 10 Dias"
+
+#: id:31905
+msgid "Forecast"
+msgstr "Previsão"
+
+#: id:31906
+msgid "Maps & Video"
+msgstr "Mapas & Video"
+
+#: id:31907
+msgid "Video Forecast [COLOR=grey2](Fullscreen Playback)[/COLOR]"
+msgstr "Vídeo da Previsão [COLOR=grey2](Playback em tela cheia)[/COLOR]"
+
+#: id:31908
+msgid "Chance of Precipitation"
+msgstr "Chance de precipitação"
+
+#: id:31909
+msgid "Fetching forecast info..."
+msgstr "Buscando informações da previsão..."
+

--- a/addons/skin.confluence/language/Portuguese/strings.po
+++ b/addons/skin.confluence/language/Portuguese/strings.po
@@ -1,0 +1,576 @@
+# Converted from xbmc strings.xml with xbmc-xml2po (by Team-XBMC)
+msgid ""
+msgstr ""
+"Project-Id-Version: xbmc.skin.confluence-FRODO_GIT953c09c336\n"
+"Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
+"POT-Creation-Date: 2012-04-09 18:03+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE\n"
+"Language: pt\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: id:31000
+msgid "Change Your"
+msgstr "Mude o seu"
+
+#: id:31001
+msgid "Love"
+msgstr "Adoro"
+
+#: id:31002
+msgid "Hate"
+msgstr "Odeio"
+
+#: id:31003
+msgid "Power Options"
+msgstr "Opções de Power"
+
+#: id:31004
+msgid "Working..."
+msgstr "A trabalhar..."
+
+#: id:31005
+msgid "Hide Information"
+msgstr "Esconder INFO"
+
+#: id:31006
+msgid "View Options"
+msgstr ""
+
+#: id:31007
+msgid "Plugins"
+msgstr "Plugins"
+
+#: id:31008
+msgid "Fullscreen"
+msgstr ""
+
+#: id:31020
+msgctxt "Auto context with id 31020"
+msgid "Recently Added"
+msgstr "Adicionados recentemente"
+
+#: id:31021
+msgid "Video - Files"
+msgstr "Vídeo - Ficheiros"
+
+#: id:31022
+msgid "Music - Files"
+msgstr "Música - Ficheiros"
+
+#: id:31023
+msgid "Playing"
+msgstr "A reproduzir"
+
+#: id:31024
+msgid "Page"
+msgstr "Página"
+
+#: id:31025
+msgid "Items"
+msgstr "Itens"
+
+#: id:31026
+msgid "Misc Options"
+msgstr "Várias opções"
+
+#: id:31027
+msgid "Location"
+msgstr "Localização"
+
+#: id:31028
+msgid "Poster Wrap"
+msgstr "Posters"
+
+#: id:31029
+msgid "Fanart"
+msgstr "Fanart"
+
+#: id:31030
+msgid "Full list"
+msgstr "Lista completa"
+
+#: id:31031
+msgid "Pic Thumbs"
+msgstr "Imagem de miniaturas"
+
+#: id:31032
+msgid "Image Wrap"
+msgstr "Imagens"
+
+#: id:31033
+msgid "Info"
+msgstr "Info"
+
+#: id:31040
+msgid "Now Playing"
+msgstr "A reproduzir agora"
+
+#: id:31042
+msgid "PLAYING"
+msgstr "A REPRODUZIR"
+
+#: id:31043
+msgid "PAUSED"
+msgstr "PAUSADO"
+
+#: id:31044
+msgid "FAST FORWARD"
+msgstr "FAST FORWARD"
+
+#: id:31045
+msgid "REWIND"
+msgstr "REWIND"
+
+#: id:31046
+msgid "Audio Properties"
+msgstr "Propriedades do áudio"
+
+#: id:31047
+msgid "Current Preset"
+msgstr "Definição corrente"
+
+#: id:31048
+msgid "Visualization Presets"
+msgstr "Definições de visualização"
+
+#: id:31049
+msgid "End Time"
+msgstr "Tempo para terminar"
+
+#: id:31050
+msgid "Sort: Ascending"
+msgstr ""
+
+#: id:31051
+msgid "Sort: Descending"
+msgstr ""
+
+#: id:31055
+msgid "Open playlist"
+msgstr "Abrir lista de reprodução"
+
+#: id:31056
+msgid "Save playlist"
+msgstr "Guardar lista de reprodução"
+
+#: id:31057
+msgid "Close playlist"
+msgstr "Fechar lista de reprodução"
+
+#: id:31058
+msgid "System music files"
+msgstr "Ficheiros de música do sistema"
+
+#: id:31059
+msgid "Current playlist"
+msgstr "Lista de reprodução corrente"
+
+#: id:31060
+msgid "This file is stacked, select the part you want to play from."
+msgstr "Ficheiro multi-parte. Escolha a parte que quer reproduzir."
+
+#: id:31061
+msgid "Current Selected"
+msgstr "Seleccionado neste momento"
+
+#: id:31101
+msgid "Home screen options"
+msgstr "Opções do menu principal"
+
+#: id:31102
+msgid "Background"
+msgstr "Fundo"
+
+#: id:31103
+msgid "Show \"Paused\" in picture slide show"
+msgstr "Mostrar \"Pausado\" na apresentação de slides"
+
+#: id:31104
+msgid "Play Trailers in a window [COLOR=grey3](Video Information Dialog Only)[/COLOR]"
+msgstr "Reproduzir trailers numa janela [COLOR=grey3](Apenas diálogo de informação vídeo)[/COLOR]"
+
+#: id:31105
+msgid "\"Videos\" button always goes to video \"Files\""
+msgstr ""
+
+#: id:31106
+msgid "Miscellaneous options"
+msgstr "Opções várias"
+
+#: id:31107
+msgid "Hide Flagging read from video filenames [COLOR=grey3](Blu-ray, HD-DVD)[/COLOR]"
+msgstr "Esconder leitura de flags dos ficheiros de vídeo [COLOR=grey3](Blu-ray, HD-DVD)[/COLOR]"
+
+#: id:31108
+msgid "Hide Main Menu Buttons"
+msgstr "Esconder botões do menu principal"
+
+#: id:31109
+msgid "Media backgrounds"
+msgstr "Fundos de média"
+
+#: id:31110
+msgid "Edit Background for Media Type"
+msgstr "Editar fundo pra tipo de média"
+
+#: id:31111
+msgid "Hide"
+msgstr "Esconder"
+
+#: id:31112
+msgid "Options"
+msgstr "Opções"
+
+#: id:31113
+msgid "Single Image"
+msgstr "Imagem única"
+
+#: id:31114
+msgid "Multi Image"
+msgstr "Imagens multiplas"
+
+#: id:31115
+msgid "Customizer"
+msgstr "Customizar"
+
+#: id:31117
+msgid "Show Recently added Videos"
+msgstr "Mostrar vídeos adicionados recentemente"
+
+#: id:31118
+msgid "Home Page Programs Submenu"
+msgstr "Submenu de Programas da página inicial"
+
+#: id:31119
+msgid "Hide Background Fanart"
+msgstr ""
+
+#: id:31120
+msgid "BUTTON LABEL"
+msgstr "ETIQUETA DE BOTÃO"
+
+#: id:31122
+msgid "Weather Page"
+msgstr "Página meteorológica"
+
+#: id:31123
+msgid "Use \"Posters\" instead of \"Banners\" for TV Shows"
+msgstr "Usar \"Posters\" en vez de \"Faixas\" para séries de TV"
+
+#: id:31124
+msgid "Show Background \"Now Playing\" Video"
+msgstr "Mostrar vídeo \"A reproduzir\" em fundo"
+
+#: id:31125
+msgid "Show Background \"Now Playing\" Visualization"
+msgstr "Mostrar visualização \"A reproduzir\" em fundo"
+
+#: id:31126
+msgid "Play TV theme songs in video library (TvTunes add-on)"
+msgstr ""
+
+#: id:31127
+msgid "TvTunes"
+msgstr ""
+
+#: id:31128
+msgid "Lyrics"
+msgstr "Letras"
+
+#: id:31132
+msgid "Lyrics Add-on"
+msgstr "Add-on de letras de música"
+
+#: id:31133
+msgid "Subtitle Add-on"
+msgstr "Add-on de legendas"
+
+#: id:31134
+msgid "Home Page Videos Submenu"
+msgstr "Submenu de Vídeos da Página Inicial"
+
+#: id:31135
+msgid "Home Page Music Submenu"
+msgstr "Submenu de Música da Página Inicial"
+
+#: id:31136
+msgid "Home Page Pictures Submenu"
+msgstr "Submenu de Fotos da Página Inicial"
+
+#: id:31140
+msgid "Music OSD"
+msgstr "OSD de Música"
+
+#: id:31141
+msgid "Video OSD"
+msgstr "OSD de Vídeo"
+
+#: id:31200
+msgid "Shortcuts"
+msgstr "Atalhos"
+
+#: id:31201
+msgid "Categories"
+msgstr "Categorias"
+
+#: id:31202
+msgid "Show Cast"
+msgstr "Mostrar elenco"
+
+#: id:31203
+msgid "Choose Your Song"
+msgstr "Escolha a sua música"
+
+#: id:31204
+msgid "Section Links"
+msgstr "Atalhos de secção"
+
+#: id:31205
+msgid "Lyrics Source"
+msgstr "Fonte das letras"
+
+#: id:31300
+msgid "Current Temp"
+msgstr "Temp corrente"
+
+#: id:31301
+msgid "Last Updated"
+msgstr "Última actualização"
+
+#: id:31302
+msgid "Menu"
+msgstr "Menu"
+
+#: id:31303
+msgid "Data provider"
+msgstr ""
+
+#: id:31304
+msgid "Picture"
+msgstr "Imagem"
+
+#: id:31305
+msgid "No Disc Media Detected"
+msgstr "Disco de média não detectado"
+
+#: id:31306
+msgid "Eject"
+msgstr "Ejectar"
+
+#: id:31307
+msgid "Hide Fanart"
+msgstr "Esconder Fanart"
+
+#: id:31308
+msgid "Movie Details"
+msgstr "Detalhes do filme"
+
+#: id:31309
+msgid "Memory Used:"
+msgstr "Memória usada:"
+
+#: id:31310
+msgid "Track Number"
+msgstr "Faixa número"
+
+#: id:31311
+msgid "Fanart image[CR][CR]Unavailable[CR][CR] Click button to set"
+msgstr "Imagem de Fanart[CR][CR]Indisponível[CR][CR] Clique no botão para seleccionar"
+
+#: id:31312
+msgid "Current Scraper"
+msgstr "Scraper corrente"
+
+#: id:31313
+msgid "Choose a Scraper"
+msgstr "Escolher um scraper"
+
+#: id:31314
+msgid "Content Scanning Options"
+msgstr "Opções de procura de conteúdos"
+
+#: id:31315
+msgid "Basic"
+msgstr "Básico"
+
+#: id:31317
+msgid "Set Fanart Path"
+msgstr "Escolher caminho de Fanart"
+
+#: id:31318
+msgid "Small Fanart"
+msgstr "Fanart pequeno"
+
+#: id:31319
+msgid "Selected Profile"
+msgstr "Perfil seleccionado"
+
+#: id:31320
+msgid "Last Logged In"
+msgstr "Último ligado"
+
+#: id:31321
+msgid "Karaoke Song Selector"
+msgstr "Selecção de música de karaoke"
+
+#: id:31322
+msgid "Aired"
+msgstr "Estreia"
+
+#: id:31323
+msgid "Latest Movies"
+msgstr "Filmes recentes"
+
+#: id:31324
+msgid "Latest Episodes"
+msgstr "Episódeos recentes"
+
+#: id:31325
+msgid "Playlist Options"
+msgstr "Opções da lista de reprodução"
+
+#: id:31326
+msgid "Created"
+msgstr "Criado"
+
+#: id:31327
+msgid "Resolution"
+msgstr "Resolução"
+
+#: id:31328
+msgctxt "Auto context with id 31328"
+msgid "Recently Added"
+msgstr "Adicionados recentemente"
+
+#: id:31329
+msgid "[B]Timer set![/B] [COLOR=grey2] - System auto shutdown in[/COLOR]"
+msgstr "[B]Definir temporizador![/B] [COLOR=grey2] - Sistema vai desligar em[/COLOR]"
+
+#: id:31330
+msgid "Click button to play[CR][CR]Movie trailer"
+msgstr "Clique no botão para reproduzir o[CR][CR]Trailer do filme"
+
+#: id:31331
+msgid "Album Details"
+msgstr ""
+
+#: id:31351
+msgid "Pause"
+msgstr "Pausa"
+
+#: id:31352
+msgid "Stop"
+msgstr "Stop"
+
+#: id:31353
+msgid "Fast Forward"
+msgstr "Fast Forward"
+
+#: id:31354
+msgid "Rewind"
+msgstr "Rewind"
+
+#: id:31355
+msgid "Movie menu"
+msgstr "Menu do filme"
+
+#: id:31356
+msgid "Download Subtitles"
+msgstr "Descarregar legenda"
+
+#: id:31390
+msgid "Skin default"
+msgstr "Padrão do tema"
+
+#: id:31391
+msgid "Skin default with no Caps"
+msgstr "Padrão do tema sem 'CAPS'"
+
+#: id:31392
+msgid "Arial based"
+msgstr "Baseada em Arial"
+
+#: id:31400
+msgid "[B]CONFIGURE APPEARANCE SETTINGS[/B][CR][CR]Change the skin � Set language and region � Change file listing options[CR]Set up a screensaver"
+msgstr "[B]CONFIGURAR OPÇÕES DE APARÊNCIA[/B][CR][CR]Mudar o Tema · Definir Linguagem e Região · Mudar opções de listagem de ficheiros[CR]Definir protector de ecrã"
+
+#: id:31401
+msgid "[B]CONFIGURE VIDEO SETTINGS[/B][CR][CR]Manage your video library � Set video playback options � Change video listing options[CR]Set subtitle fonts"
+msgstr "[B]CONFIGURAR OPÇÕES DE VÍDEO[/B][CR][CR]Gerir Biblioteca de Vídeo · Definir opções de reprodução de vídeo · Mudar opções de listagem de vídeo[CR]Definir fonte de legendas"
+
+#: id:31402
+msgid "[B]CONFIGURE MUSIC SETTINGS[/B][CR][CR]Manage your music library � Set music playback options � Change music listing options[CR]Setup song submission � Set karaoke options"
+msgstr "[B]CONFIGURAR OPÇÕES DE MÚSICA[/B][CR][CR]Gerir Biblioteca de Música · Definir opções de reprodução de música · Mudar opções de listagem de música[CR]Definir submissão de músicas · Definir opções de karaoke"
+
+#: id:31403
+msgid "[B]CONFIGURE PICTURE SETTINGS[/B][CR][CR]Set picture listing options � Configure slideshows"
+msgstr "[B]CONFIGURAR OPÇÕES DE IMAGENS[/B][CR][CR]Mudar opções de listagem de imagens · Configurar apresentação de slides"
+
+#: id:31404
+msgid "[B]CONFIGURE WEATHER SETTINGS[/B][CR][CR]Set three cities to collect weather information"
+msgstr "[B]CONFIGURAR OPÇÕES METEOROLÓGICAS[/B][CR][CR]Definir três locais para informação meteorológica"
+
+#: id:31406
+msgid "[B]CONFIGURE SYSTEM SETTINGS[/B][CR][CR]Setup and calibrate displays � Configure audio output � Setup remote controls[CR]Set power saving options � Enable debugging � Setup master lock"
+msgstr "[B]CONFIGURAR OPÇÕES DE SISTEMA[/B][CR][CR]Definir e calibrar ecrãs · Configurar saída de áudio · Configurar comando à distância[CR]Definir opções de poupança de energia · Ligar depuração · Definir bloqueio geral"
+
+#: id:31407
+msgid "[B]CONFIGURE SKIN SETTINGS[/B][CR][CR]Setup the Confluence skin � Add and remove home menu items[CR]Change skin backgrounds"
+msgstr "[B]CONFIGURAR OPÇÕES DO TEMA[/B][CR][CR]Gerir o tema Confluence · Adicionar ou remover itens do menu principal[CR]Mudar fundos do tema"
+
+#: id:31408
+msgid "[B]CONFIGURE ADD-ONS[/B][CR][CR]Manage your installed Add-ons � Browse for and install Add-ons from xbmc.org[CR]Modify Add-on settings"
+msgstr "[B]CONFIGURAR ADD-ONS[/B][CR][CR]Gerir Add-ons instalados · Procurar Add-ons em xbmc.org e instalar[CR]Alterar opções dos Add-ons"
+
+#: id:31409
+msgid "[B]CONFIGURE SERVICE SETTINGS[/B][CR][CR]Setup control of XBMC via UPnP and HTTP � Configure file sharing[CR]Enable Zeroconf � Configure AirPlay"
+msgstr ""
+
+#: id:31421
+msgid "Select your XBMC user Profile[CR]to login and continue"
+msgstr "Escolha o seu perfil de utilizador do XBMC[CR]para ligar e continuar"
+
+#: id:31900
+msgid "Weather Maps"
+msgstr ""
+
+#: id:31901
+msgid "36 Hour Forecast"
+msgstr ""
+
+#: id:31902
+msgid "Hourly Forecast"
+msgstr ""
+
+#: id:31903
+msgid "Weekend Forecast"
+msgstr ""
+
+#: id:31904
+msgid "10 Day Forecast"
+msgstr ""
+
+#: id:31905
+msgid "Forecast"
+msgstr ""
+
+#: id:31906
+msgid "Maps & Video"
+msgstr ""
+
+#: id:31907
+msgid "Video Forecast [COLOR=grey2](Fullscreen Playback)[/COLOR]"
+msgstr ""
+
+#: id:31908
+msgid "Chance of Precipitation"
+msgstr ""
+
+#: id:31909
+msgid "Fetching forecast info..."
+msgstr ""
+

--- a/addons/skin.confluence/language/Romanian/strings.po
+++ b/addons/skin.confluence/language/Romanian/strings.po
@@ -1,0 +1,576 @@
+# Converted from xbmc strings.xml with xbmc-xml2po (by Team-XBMC)
+msgid ""
+msgstr ""
+"Project-Id-Version: xbmc.skin.confluence-FRODO_GIT953c09c336\n"
+"Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
+"POT-Creation-Date: 2012-04-09 18:03+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE\n"
+"Language: ro\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: id:31000
+msgid "Change Your"
+msgstr "Modificare"
+
+#: id:31001
+msgid "Love"
+msgstr "Dragoste"
+
+#: id:31002
+msgid "Hate"
+msgstr "Ură"
+
+#: id:31003
+msgid "Power Options"
+msgstr "Opțiuni de alimentare"
+
+#: id:31004
+msgid "Working..."
+msgstr "Procesare..."
+
+#: id:31005
+msgid "Hide Information"
+msgstr "Ascunde detalii"
+
+#: id:31006
+msgid "View Options"
+msgstr "Opțiuni vizualizare"
+
+#: id:31007
+msgid "Plugins"
+msgstr "Module"
+
+#: id:31008
+msgid "Fullscreen"
+msgstr "Pe tot ecranul"
+
+#: id:31020
+msgctxt "Auto context with id 31020"
+msgid "Recently Added"
+msgstr "Adăugate recent"
+
+#: id:31021
+msgid "Video - Files"
+msgstr "Fișiere video"
+
+#: id:31022
+msgid "Music - Files"
+msgstr "Fișiere audio"
+
+#: id:31023
+msgid "Playing"
+msgstr "Redare"
+
+#: id:31024
+msgid "Page"
+msgstr "Pagina"
+
+#: id:31025
+msgid "Items"
+msgstr "Elemente"
+
+#: id:31026
+msgid "Misc Options"
+msgstr "Opțiuni diverse"
+
+#: id:31027
+msgid "Location"
+msgstr "Locație"
+
+#: id:31028
+msgid "Poster Wrap"
+msgstr "Afișe"
+
+#: id:31029
+msgid "Fanart"
+msgstr "Fanart"
+
+#: id:31030
+msgid "Full list"
+msgstr "Listă completă"
+
+#: id:31031
+msgid "Pic Thumbs"
+msgstr "Detalii"
+
+#: id:31032
+msgid "Image Wrap"
+msgstr "Ciclu imagini"
+
+#: id:31033
+msgid "Info"
+msgstr "Informații"
+
+#: id:31040
+msgid "Now Playing"
+msgstr "În redare"
+
+#: id:31042
+msgid "PLAYING"
+msgstr "ÎN REDARE"
+
+#: id:31043
+msgid "PAUSED"
+msgstr "ÎN PAUZĂ"
+
+#: id:31044
+msgid "FAST FORWARD"
+msgstr "DERULARE ÎNAINTE"
+
+#: id:31045
+msgid "REWIND"
+msgstr "DERULARE ÎNAPOI"
+
+#: id:31046
+msgid "Audio Properties"
+msgstr "Proprietăți audio"
+
+#: id:31047
+msgid "Current Preset"
+msgstr "Viz. predefinită curentă"
+
+#: id:31048
+msgid "Visualization Presets"
+msgstr "Vizualizări predefinite"
+
+#: id:31049
+msgid "End Time"
+msgstr "Se termină la"
+
+#: id:31050
+msgid "Sort: Ascending"
+msgstr "Sort.: Ascendent"
+
+#: id:31051
+msgid "Sort: Descending"
+msgstr "Sort.: Descendent"
+
+#: id:31055
+msgid "Open playlist"
+msgstr "Deschide listă de redare"
+
+#: id:31056
+msgid "Save playlist"
+msgstr "Salvează lista de redare"
+
+#: id:31057
+msgid "Close playlist"
+msgstr "Închide lista de redare"
+
+#: id:31058
+msgid "System music files"
+msgstr "Fișiere de muzică în sistem"
+
+#: id:31059
+msgid "Current playlist"
+msgstr "Listă de redare curentă"
+
+#: id:31060
+msgid "This file is stacked, select the part you want to play from."
+msgstr "Acest fișier este în stivă, selectați partea din care doriți să redați."
+
+#: id:31061
+msgid "Current Selected"
+msgstr "Selectat curent"
+
+#: id:31101
+msgid "Home screen options"
+msgstr "Opțiuni ecran principal"
+
+#: id:31102
+msgid "Background"
+msgstr "Fundal"
+
+#: id:31103
+msgid "Show \"Paused\" in picture slide show"
+msgstr "Arată „În pauză” la prezentare diapozitive"
+
+#: id:31104
+msgid "Play Trailers in a window [COLOR=grey3](Video Information Dialog Only)[/COLOR]"
+msgstr "Redă secvențele intr-o fereastră [COLOR=grey3](doar în dialogul de informații video)[/COLOR]"
+
+#: id:31105
+msgid "\"Videos\" button always goes to video \"Files\""
+msgstr "Butonul „Video” duce întotdeauna către „Fișiere” video"
+
+#: id:31106
+msgid "Miscellaneous options"
+msgstr "Opțiuni diverse"
+
+#: id:31107
+msgid "Hide Flagging read from video filenames [COLOR=grey3](Blu-ray, HD-DVD)[/COLOR]"
+msgstr "Ascunde marcare citită din numele fișierelor video [COLOR=grey3](Blu-ray, HD-DVD)[/COLOR]"
+
+#: id:31108
+msgid "Hide Main Menu Buttons"
+msgstr "Ascundere butoane meniu principal"
+
+#: id:31109
+msgid "Media backgrounds"
+msgstr "Fundale media"
+
+#: id:31110
+msgid "Edit Background for Media Type"
+msgstr "Modificare fundal pentru"
+
+#: id:31111
+msgid "Hide"
+msgstr "Ascunde"
+
+#: id:31112
+msgid "Options"
+msgstr "Opțiuni"
+
+#: id:31113
+msgid "Single Image"
+msgstr "O singură imagine"
+
+#: id:31114
+msgid "Multi Image"
+msgstr "Mai multe imagini"
+
+#: id:31115
+msgid "Customizer"
+msgstr "Personalizator"
+
+#: id:31117
+msgid "Show Recently added Videos"
+msgstr "Arată filme și episoade adăugate recent"
+
+#: id:31118
+msgid "Home Page Programs Submenu"
+msgstr "Submeniu Programe în pagină inițială"
+
+#: id:31119
+msgid "Hide Background Fanart"
+msgstr "Ascunde fundal (Fanart)"
+
+#: id:31120
+msgid "BUTTON LABEL"
+msgstr "ETICHETĂ BUTON"
+
+#: id:31122
+msgid "Weather Page"
+msgstr "Pagină meteo"
+
+#: id:31123
+msgid "Use \"Posters\" instead of \"Banners\" for TV Shows"
+msgstr "Folosește „Afișe” în loc de „Bannere” pentru seriale"
+
+#: id:31124
+msgid "Show Background \"Now Playing\" Video"
+msgstr "Arată video „Acum în redare” pe fundal"
+
+#: id:31125
+msgid "Show Background \"Now Playing\" Visualization"
+msgstr "Arată vizualizare „Acum în redare” pe fundal"
+
+#: id:31126
+msgid "Play TV theme songs in video library (TvTunes add-on)"
+msgstr "Redă cântece temă TV în mediateca video (supliment TvTunes)"
+
+#: id:31127
+msgid "TvTunes"
+msgstr "TvTunes"
+
+#: id:31128
+msgid "Lyrics"
+msgstr "Versuri"
+
+#: id:31132
+msgid "Lyrics Add-on"
+msgstr "Supliment versuri"
+
+#: id:31133
+msgid "Subtitle Add-on"
+msgstr "Supliment subtitrări"
+
+#: id:31134
+msgid "Home Page Videos Submenu"
+msgstr "Submeniu Video în pagina inițială"
+
+#: id:31135
+msgid "Home Page Music Submenu"
+msgstr "Submeniu Muzică în pagina inițială"
+
+#: id:31136
+msgid "Home Page Pictures Submenu"
+msgstr "Submeniu Imagini în pagina inițială"
+
+#: id:31140
+msgid "Music OSD"
+msgstr "Meniu audio"
+
+#: id:31141
+msgid "Video OSD"
+msgstr "Meniu video"
+
+#: id:31200
+msgid "Shortcuts"
+msgstr "Scurtături"
+
+#: id:31201
+msgid "Categories"
+msgstr "Categorii"
+
+#: id:31202
+msgid "Show Cast"
+msgstr "Distribuție serial"
+
+#: id:31203
+msgid "Choose Your Song"
+msgstr "Alegeți-vă cântecul"
+
+#: id:31204
+msgid "Section Links"
+msgstr "Legături secțiune"
+
+#: id:31205
+msgid "Lyrics Source"
+msgstr "Sursă versuri"
+
+#: id:31300
+msgid "Current Temp"
+msgstr "Temperatură curentă"
+
+#: id:31301
+msgid "Last Updated"
+msgstr "Ultima actualizare"
+
+#: id:31302
+msgid "Menu"
+msgstr "Meniu"
+
+#: id:31303
+msgid "Data provider"
+msgstr "Furnizor informații"
+
+#: id:31304
+msgid "Picture"
+msgstr "Imagine"
+
+#: id:31305
+msgid "No Disc Media Detected"
+msgstr "Niciun disc media detectat"
+
+#: id:31306
+msgid "Eject"
+msgstr "Scoate"
+
+#: id:31307
+msgid "Hide Fanart"
+msgstr "Ascunde Fanart"
+
+#: id:31308
+msgid "Movie Details"
+msgstr "Detalii film"
+
+#: id:31309
+msgid "Memory Used:"
+msgstr "Utilizare memorie:"
+
+#: id:31310
+msgid "Track Number"
+msgstr "Număr pistă"
+
+#: id:31311
+msgid "Fanart image[CR][CR]Unavailable[CR][CR] Click button to set"
+msgstr "Imagine Fanart indisponibilă[CR][CR]Clic pe buton pentru setare"
+
+#: id:31312
+msgid "Current Scraper"
+msgstr "Catalog curent"
+
+#: id:31313
+msgid "Choose a Scraper"
+msgstr "Alegeți un catalog (scraper)"
+
+#: id:31314
+msgid "Content Scanning Options"
+msgstr "Opțiuni de scanare conținut"
+
+#: id:31315
+msgid "Basic"
+msgstr "De bază"
+
+#: id:31317
+msgid "Set Fanart Path"
+msgstr "Setează cale Fanart"
+
+#: id:31318
+msgid "Small Fanart"
+msgstr "Fanart mic"
+
+#: id:31319
+msgid "Selected Profile"
+msgstr "Profil selectat"
+
+#: id:31320
+msgid "Last Logged In"
+msgstr "Ultima intrare"
+
+#: id:31321
+msgid "Karaoke Song Selector"
+msgstr "Selector cântec karaoke"
+
+#: id:31322
+msgid "Aired"
+msgstr "Difuzat pe"
+
+#: id:31323
+msgid "Latest Movies"
+msgstr "Ultimele filme"
+
+#: id:31324
+msgid "Latest Episodes"
+msgstr "Ultimele episoade"
+
+#: id:31325
+msgid "Playlist Options"
+msgstr "Opțiuni listă de redare"
+
+#: id:31326
+msgid "Created"
+msgstr "Creat"
+
+#: id:31327
+msgid "Resolution"
+msgstr "Rezoluție"
+
+#: id:31328
+msgctxt "Auto context with id 31328"
+msgid "Recently Added"
+msgstr "Adăugate recent"
+
+#: id:31329
+msgid "[B]Timer set![/B] [COLOR=grey2] - System auto shutdown in[/COLOR]"
+msgstr "[B]Planificare închidere activată![/B] [COLOR=grey2] Închidere sistem în[/COLOR]"
+
+#: id:31330
+msgid "Click button to play[CR][CR]Movie trailer"
+msgstr "Clic pe buton pentru redare[CR][CR]secvențe din film (trailer)"
+
+#: id:31331
+msgid "Album Details"
+msgstr "Detalii album"
+
+#: id:31351
+msgid "Pause"
+msgstr "Pauză"
+
+#: id:31352
+msgid "Stop"
+msgstr "Stop"
+
+#: id:31353
+msgid "Fast Forward"
+msgstr "Derulează înainte"
+
+#: id:31354
+msgid "Rewind"
+msgstr "Derulează înapoi"
+
+#: id:31355
+msgid "Movie menu"
+msgstr "Meniu film"
+
+#: id:31356
+msgid "Download Subtitles"
+msgstr "Descărcare subtitrare"
+
+#: id:31390
+msgid "Skin default"
+msgstr "Standard pentru costum"
+
+#: id:31391
+msgid "Skin default with no Caps"
+msgstr "Standard pentru costum fără majuscule"
+
+#: id:31392
+msgid "Arial based"
+msgstr "Cu Arial la bază"
+
+#: id:31400
+msgid "[B]CONFIGURE APPEARANCE SETTINGS[/B][CR][CR]Change the skin � Set language and region � Change file listing options[CR]Set up a screensaver"
+msgstr "[B]CONFIGURAȚI SETĂRI ASPECT[/B][CR][CR]Schimbați costumul · Alegeți limbă și regiune · Modificați opțiuni de listare fișiere[CR]Alegeți protector ecran"
+
+#: id:31401
+msgid "[B]CONFIGURE VIDEO SETTINGS[/B][CR][CR]Manage your video library � Set video playback options � Change video listing options[CR]Set subtitle fonts"
+msgstr "[B]CONFIGURAȚI SETĂRI VIDEO[/B][CR][CR]Administrați videoteca · Setați opțiuni redare video · Modificați opțiuni de listare video[CR]Alegeți font subtitrare"
+
+#: id:31402
+msgid "[B]CONFIGURE MUSIC SETTINGS[/B][CR][CR]Manage your music library � Set music playback options � Change music listing options[CR]Setup song submission � Set karaoke options"
+msgstr "[B]CONFIGURAȚI SETĂRI MUZICĂ[/B][CR][CR]Administrați fonoteca · Setați opțiuni redare muzică · Modificați opțiuni de listare muzică[CR]Pregătiți trimitere cântec · Setați opțiuni karaoke"
+
+#: id:31403
+msgid "[B]CONFIGURE PICTURE SETTINGS[/B][CR][CR]Set picture listing options � Configure slideshows"
+msgstr "[B]CONFIGURAȚI SETĂRI IMAGINE[/B][CR][CR]Modificați opțiuni de listare imagini · Configurați prezentare diapozitive"
+
+#: id:31404
+msgid "[B]CONFIGURE WEATHER SETTINGS[/B][CR][CR]Set three cities to collect weather information"
+msgstr "[B]CONFIGURAȚI SETĂRI VREME[/B][CR][CR]Alegeți trei orașe pentru care se obțin informații meteo"
+
+#: id:31406
+msgid "[B]CONFIGURE SYSTEM SETTINGS[/B][CR][CR]Setup and calibrate displays � Configure audio output � Setup remote controls[CR]Set power saving options � Enable debugging � Setup master lock"
+msgstr "[B]CONFIGURAȚI SETĂRI SISTEM[/B][CR][CR]Configurați și calibrați afișaje · Configurați ieșire audio · Instalați telecomenzi[CR]Alegeți opțiuni de economisire energie · Activați depanare · Configurați blocarea principală"
+
+#: id:31407
+msgid "[B]CONFIGURE SKIN SETTINGS[/B][CR][CR]Setup the Confluence skin � Add and remove home menu items[CR]Change skin backgrounds"
+msgstr "[B]CONFIGURAȚI SETĂRI COSTUM[/B][CR][CR]Configurați costumul Confluence · Adăugați și eliminați elemente din meniul principal[CR]Schimbați fundale costum"
+
+#: id:31408
+msgid "[B]CONFIGURE ADD-ONS[/B][CR][CR]Manage your installed Add-ons � Browse for and install Add-ons from xbmc.org[CR]Modify Add-on settings"
+msgstr "[B]CONFIGURAȚI SUPLIMENTE[/B][CR][CR]Administrați suplimentele instalate · Căutați și instalați suplimente de la xbmc.org[CR]Modificați setări suplimente"
+
+#: id:31409
+msgid "[B]CONFIGURE SERVICE SETTINGS[/B][CR][CR]Setup control of XBMC via UPnP and HTTP � Configure file sharing[CR]Enable Zeroconf � Configure AirPlay"
+msgstr ""
+
+#: id:31421
+msgid "Select your XBMC user Profile[CR]to login and continue"
+msgstr "Selectați profilul dumneavoastră de utilizator XBMC[CR]pentru a vă autentifica și a continua"
+
+#: id:31900
+msgid "Weather Maps"
+msgstr "Hărți meteo"
+
+#: id:31901
+msgid "36 Hour Forecast"
+msgstr "Previziune pe 36 de ore"
+
+#: id:31902
+msgid "Hourly Forecast"
+msgstr "Previziune la o oră"
+
+#: id:31903
+msgid "Weekend Forecast"
+msgstr "Previziune weekend"
+
+#: id:31904
+msgid "10 Day Forecast"
+msgstr "Previziune pe 10 zile"
+
+#: id:31905
+msgid "Forecast"
+msgstr "Previziune"
+
+#: id:31906
+msgid "Maps & Video"
+msgstr "Hărți și video"
+
+#: id:31907
+msgid "Video Forecast [COLOR=grey2](Fullscreen Playback)[/COLOR]"
+msgstr "Previziune video [COLOR=grey2](Redare pe tot ecranul)[/COLOR]"
+
+#: id:31908
+msgid "Chance of Precipitation"
+msgstr "Șansă de precipitații"
+
+#: id:31909
+msgid "Fetching forecast info..."
+msgstr "Preluare informații previziune..."
+

--- a/addons/skin.confluence/language/Russian/strings.po
+++ b/addons/skin.confluence/language/Russian/strings.po
@@ -1,0 +1,576 @@
+# Converted from xbmc strings.xml with xbmc-xml2po (by Team-XBMC)
+msgid ""
+msgstr ""
+"Project-Id-Version: xbmc.skin.confluence-FRODO_GIT953c09c336\n"
+"Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
+"POT-Creation-Date: 2012-04-09 18:03+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE\n"
+"Language: ru\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: id:31000
+msgid "Change Your"
+msgstr "Измените"
+
+#: id:31001
+msgid "Love"
+msgstr "Нравится"
+
+#: id:31002
+msgid "Hate"
+msgstr "Не нравится"
+
+#: id:31003
+msgid "Power Options"
+msgstr "Настройки питания"
+
+#: id:31004
+msgid "Working..."
+msgstr "Подождите…"
+
+#: id:31005
+msgid "Hide Information"
+msgstr "Без сведений"
+
+#: id:31006
+msgid "View Options"
+msgstr "Настройки просмотра"
+
+#: id:31007
+msgid "Plugins"
+msgstr "Дополнения"
+
+#: id:31008
+msgid "Fullscreen"
+msgstr "Полный экран"
+
+#: id:31020
+msgctxt "Auto context with id 31020"
+msgid "Recently Added"
+msgstr "Последние"
+
+#: id:31021
+msgid "Video - Files"
+msgstr "Видео - файлы"
+
+#: id:31022
+msgid "Music - Files"
+msgstr "Музыка - файлы"
+
+#: id:31023
+msgid "Playing"
+msgstr "Воспроизведение"
+
+#: id:31024
+msgid "Page"
+msgstr "страница"
+
+#: id:31025
+msgid "Items"
+msgstr "в списке"
+
+#: id:31026
+msgid "Misc Options"
+msgstr "Другие параметры"
+
+#: id:31027
+msgid "Location"
+msgstr "Расположение"
+
+#: id:31028
+msgid "Poster Wrap"
+msgstr "Карусель постеров"
+
+#: id:31029
+msgid "Fanart"
+msgstr "Фанарт"
+
+#: id:31030
+msgid "Full list"
+msgstr "Полный список"
+
+#: id:31031
+msgid "Pic Thumbs"
+msgstr "Миниатюры"
+
+#: id:31032
+msgid "Image Wrap"
+msgstr "Карусель картинок"
+
+#: id:31033
+msgid "Info"
+msgstr "Информация"
+
+#: id:31040
+msgid "Now Playing"
+msgstr "Сейчас воспроизводится:"
+
+#: id:31042
+msgid "PLAYING"
+msgstr "ВОСПРОИЗВЕДЕНИЕ"
+
+#: id:31043
+msgid "PAUSED"
+msgstr "ПАУЗА"
+
+#: id:31044
+msgid "FAST FORWARD"
+msgstr "ПЕРЕМОТКА ВПЕРЕД"
+
+#: id:31045
+msgid "REWIND"
+msgstr "ПЕРЕМОТКА НАЗАД"
+
+#: id:31046
+msgid "Audio Properties"
+msgstr "Свойства аудио"
+
+#: id:31047
+msgid "Current Preset"
+msgstr "Текущие настройки"
+
+#: id:31048
+msgid "Visualization Presets"
+msgstr "Настройки визуализации"
+
+#: id:31049
+msgid "End Time"
+msgstr "Время окончания"
+
+#: id:31050
+msgid "Sort: Ascending"
+msgstr "По возрастанию"
+
+#: id:31051
+msgid "Sort: Descending"
+msgstr "По убыванию"
+
+#: id:31055
+msgid "Open playlist"
+msgstr "Открыть плейлист"
+
+#: id:31056
+msgid "Save playlist"
+msgstr "Сохранить плейлист"
+
+#: id:31057
+msgid "Close playlist"
+msgstr "Закрыть плейлист"
+
+#: id:31058
+msgid "System music files"
+msgstr "Системные аудиофайлы"
+
+#: id:31059
+msgid "Current playlist"
+msgstr "Текущий плейлист"
+
+#: id:31060
+msgid "This file is stacked, select the part you want to play from."
+msgstr "Составной файл; выберите часть для проигрывания."
+
+#: id:31061
+msgid "Current Selected"
+msgstr "Текущее выделение"
+
+#: id:31101
+msgid "Home screen options"
+msgstr "Настройки главного экрана"
+
+#: id:31102
+msgid "Background"
+msgstr "Фон"
+
+#: id:31103
+msgid "Show \"Paused\" in picture slide show"
+msgstr "Показывать \"Пауза\" в режиме слайдшоу"
+
+#: id:31104
+msgid "Play Trailers in a window [COLOR=grey3](Video Information Dialog Only)[/COLOR]"
+msgstr "Воспроизводить трейлеры в окне [COLOR=grey3](только для окна сведений)[/COLOR]"
+
+#: id:31105
+msgid "\"Videos\" button always goes to video \"Files\""
+msgstr "Кнопка \"Видео\" всегда открывает \"Файлы\""
+
+#: id:31106
+msgid "Miscellaneous options"
+msgstr "Различные параметры"
+
+#: id:31107
+msgid "Hide Flagging read from video filenames [COLOR=grey3](Blu-ray, HD-DVD)[/COLOR]"
+msgstr "Скрыть флаги, полученные из имени видеофайла [COLOR=grey3](BluRray, HDTV)[/COLOR]"
+
+#: id:31108
+msgid "Hide Main Menu Buttons"
+msgstr "Скрыть кнопки главного меню"
+
+#: id:31109
+msgid "Media backgrounds"
+msgstr "Фон разделов"
+
+#: id:31110
+msgid "Edit Background for Media Type"
+msgstr "Выбрать фон раздела"
+
+#: id:31111
+msgid "Hide"
+msgstr "Скрыть"
+
+#: id:31112
+msgid "Options"
+msgstr "Параметры"
+
+#: id:31113
+msgid "Single Image"
+msgstr "Одна картинка"
+
+#: id:31114
+msgid "Multi Image"
+msgstr "Набор картинок"
+
+#: id:31115
+msgid "Customizer"
+msgstr "Выбор"
+
+#: id:31117
+msgid "Show Recently added Videos"
+msgstr "Показывать последнее добавленное видео"
+
+#: id:31118
+msgid "Home Page Programs Submenu"
+msgstr "Подменю программ главного экрана"
+
+#: id:31119
+msgid "Hide Background Fanart"
+msgstr "Скрыть фоновый фанарт"
+
+#: id:31120
+msgid "BUTTON LABEL"
+msgstr "НАЗВАНИЕ КНОПКИ"
+
+#: id:31122
+msgid "Weather Page"
+msgstr "Страница погоды"
+
+#: id:31123
+msgid "Use \"Posters\" instead of \"Banners\" for TV Shows"
+msgstr "Использовать постеры вместо баннеров для сериалов"
+
+#: id:31124
+msgid "Show Background \"Now Playing\" Video"
+msgstr "Воспроизводимое видео в качестве фона"
+
+#: id:31125
+msgid "Show Background \"Now Playing\" Visualization"
+msgstr "Музыкальная визуализация в качестве фона"
+
+#: id:31126
+msgid "Play TV theme songs in video library (TvTunes add-on)"
+msgstr "Играть мелодию сериала в медиатеке (дополнение TvTunes)"
+
+#: id:31127
+msgid "TvTunes"
+msgstr "TvTunes"
+
+#: id:31128
+msgid "Lyrics"
+msgstr "Тексты"
+
+#: id:31132
+msgid "Lyrics Add-on"
+msgstr "Дополнение текстов песен"
+
+#: id:31133
+msgid "Subtitle Add-on"
+msgstr "Дополнение субтитров"
+
+#: id:31134
+msgid "Home Page Videos Submenu"
+msgstr "Подменю видео главного экрана"
+
+#: id:31135
+msgid "Home Page Music Submenu"
+msgstr "Подменю музыки главного экрана"
+
+#: id:31136
+msgid "Home Page Pictures Submenu"
+msgstr "Подменю фото главного экрана"
+
+#: id:31140
+msgid "Music OSD"
+msgstr "OSD музыки"
+
+#: id:31141
+msgid "Video OSD"
+msgstr "OSD видео"
+
+#: id:31200
+msgid "Shortcuts"
+msgstr "Ярлыки"
+
+#: id:31201
+msgid "Categories"
+msgstr "Категории"
+
+#: id:31202
+msgid "Show Cast"
+msgstr "Показывать роли"
+
+#: id:31203
+msgid "Choose Your Song"
+msgstr "Выберите песню"
+
+#: id:31204
+msgid "Section Links"
+msgstr "Ссылки разделов"
+
+#: id:31205
+msgid "Lyrics Source"
+msgstr "Источник текстов песен"
+
+#: id:31300
+msgid "Current Temp"
+msgstr "Текущая температура"
+
+#: id:31301
+msgid "Last Updated"
+msgstr "Последнее обновление"
+
+#: id:31302
+msgid "Menu"
+msgstr "Меню"
+
+#: id:31303
+msgid "Data provider"
+msgstr "Источник данных"
+
+#: id:31304
+msgid "Picture"
+msgstr "Фотография"
+
+#: id:31305
+msgid "No Disc Media Detected"
+msgstr "Не вставлен диск"
+
+#: id:31306
+msgid "Eject"
+msgstr "Извлечь"
+
+#: id:31307
+msgid "Hide Fanart"
+msgstr "Скрыть фанарт"
+
+#: id:31308
+msgid "Movie Details"
+msgstr "Сведения о фильме"
+
+#: id:31309
+msgid "Memory Used:"
+msgstr "Использовано памяти:"
+
+#: id:31310
+msgid "Track Number"
+msgstr "Номер трека"
+
+#: id:31311
+msgid "Fanart image[CR][CR]Unavailable[CR][CR] Click button to set"
+msgstr "Фанарт[CR][CR]недоступен,[CR][CR] нажмите кнопку, чтобы выбрать"
+
+#: id:31312
+msgid "Current Scraper"
+msgstr "Текущий инфоресурс"
+
+#: id:31313
+msgid "Choose a Scraper"
+msgstr "Выбрать инфоресурс"
+
+#: id:31314
+msgid "Content Scanning Options"
+msgstr "Параметры сканирования содержимого"
+
+#: id:31315
+msgid "Basic"
+msgstr "Базовый"
+
+#: id:31317
+msgid "Set Fanart Path"
+msgstr "Выбрать расположение фанарта"
+
+#: id:31318
+msgid "Small Fanart"
+msgstr "Маленький фанарт"
+
+#: id:31319
+msgid "Selected Profile"
+msgstr "Выбранный профиль"
+
+#: id:31320
+msgid "Last Logged In"
+msgstr "Последний вход"
+
+#: id:31321
+msgid "Karaoke Song Selector"
+msgstr "Выбор песен для караоке"
+
+#: id:31322
+msgid "Aired"
+msgstr "Премьера"
+
+#: id:31323
+msgid "Latest Movies"
+msgstr "Последние фильмы"
+
+#: id:31324
+msgid "Latest Episodes"
+msgstr "Последние серии"
+
+#: id:31325
+msgid "Playlist Options"
+msgstr "Параметры плейлиста"
+
+#: id:31326
+msgid "Created"
+msgstr "Создан"
+
+#: id:31327
+msgid "Resolution"
+msgstr "Размеры"
+
+#: id:31328
+msgctxt "Auto context with id 31328"
+msgid "Recently Added"
+msgstr "Последние"
+
+#: id:31329
+msgid "[B]Timer set![/B] [COLOR=grey2] - System auto shutdown in[/COLOR]"
+msgstr "[B]Установлен таймер![/B] [COLOR=grey2] - Автоматическое отключение через[/COLOR]"
+
+#: id:31330
+msgid "Click button to play[CR][CR]Movie trailer"
+msgstr "Нажмите кнопку,[CR][CR]чтобы посмотреть кино-трейлер"
+
+#: id:31331
+msgid "Album Details"
+msgstr "Сведения об альбоме"
+
+#: id:31351
+msgid "Pause"
+msgstr "Пауза"
+
+#: id:31352
+msgid "Stop"
+msgstr "Стоп"
+
+#: id:31353
+msgid "Fast Forward"
+msgstr "Перемотка вперед"
+
+#: id:31354
+msgid "Rewind"
+msgstr "Перемотка назад"
+
+#: id:31355
+msgid "Movie menu"
+msgstr "Меню фильма"
+
+#: id:31356
+msgid "Download Subtitles"
+msgstr "Скачать субтитры"
+
+#: id:31390
+msgid "Skin default"
+msgstr "Стандартные"
+
+#: id:31391
+msgid "Skin default with no Caps"
+msgstr "Стандартные без ПРОПИСНЫХ"
+
+#: id:31392
+msgid "Arial based"
+msgstr "Стиль Arial"
+
+#: id:31400
+msgid "[B]CONFIGURE APPEARANCE SETTINGS[/B][CR][CR]Change the skin � Set language and region � Change file listing options[CR]Set up a screensaver"
+msgstr "[B]НАСТРОЙКА ВНЕШНЕГО ВИДА[/B][CR][CR]Изменение обложки • Выбор языка и региона • Изменение настроек списка файлов[CR]Настройка хранителя экрана"
+
+#: id:31401
+msgid "[B]CONFIGURE VIDEO SETTINGS[/B][CR][CR]Manage your video library � Set video playback options � Change video listing options[CR]Set subtitle fonts"
+msgstr "[B]НАСТРОЙКА ПАРАМЕТРОВ ВИДЕО[/B][CR][CR]Управление медиатекой видео • Параметры воспроизведения видео[CR]Настройка списка видео • Настройка шрифта субтитров"
+
+#: id:31402
+msgid "[B]CONFIGURE MUSIC SETTINGS[/B][CR][CR]Manage your music library � Set music playback options � Change music listing options[CR]Setup song submission � Set karaoke options"
+msgstr "[B]НАСТРОЙКА ПАРАМЕТРОВ МУЗЫКИ[/B][CR][CR]Управление медиатекой аудио • Параметры воспроизведения аудио[CR]Настройка списка аудио • Настройка добавления песен • Настройка караоке"
+
+#: id:31403
+msgid "[B]CONFIGURE PICTURE SETTINGS[/B][CR][CR]Set picture listing options � Configure slideshows"
+msgstr "[B]НАСТРОЙКА ПАРАМЕТРОВ ФОТО[/B][CR][CR]Параметры списка фото • Настройка слайд-шоу"
+
+#: id:31404
+msgid "[B]CONFIGURE WEATHER SETTINGS[/B][CR][CR]Set three cities to collect weather information"
+msgstr "[B]НАСТРОЙКА ПАРАМЕТРОВ ПОГОДЫ[/B][CR][CR]Выбор трех городов для получения информации о погоде"
+
+#: id:31406
+msgid "[B]CONFIGURE SYSTEM SETTINGS[/B][CR][CR]Setup and calibrate displays � Configure audio output � Setup remote controls[CR]Set power saving options � Enable debugging � Setup master lock"
+msgstr "[B]НАСТРОЙКА ПАРАМЕТРОВ СИСТЕМЫ[/B][CR][CR]Настройка и калибровка дисплеев • Настройка вывода аудио • Настройка[CR]дистанционного управления • Настройка параметров энергосбережения • Включение отладки • Настройка блокировки"
+
+#: id:31407
+msgid "[B]CONFIGURE SKIN SETTINGS[/B][CR][CR]Setup the Confluence skin � Add and remove home menu items[CR]Change skin backgrounds"
+msgstr "[B]НАСТРОЙКА ПАРАМЕТРОВ ОБЛОЖКИ[/B][CR][CR]Настройка обложки Confluence • Добавление и удаление пунктов главного меню[CR]Изменение фона обложки"
+
+#: id:31408
+msgid "[B]CONFIGURE ADD-ONS[/B][CR][CR]Manage your installed Add-ons � Browse for and install Add-ons from xbmc.org[CR]Modify Add-on settings"
+msgstr "[B]НАСТРОЙКА ДОПОЛНЕНИЙ[/B][CR][CR]Управление установленными дополнениями • Установка дополнений с xbmc.org[CR]Изменение настроек дополнений"
+
+#: id:31409
+msgid "[B]CONFIGURE SERVICE SETTINGS[/B][CR][CR]Setup control of XBMC via UPnP and HTTP � Configure file sharing[CR]Enable Zeroconf � Configure AirPlay"
+msgstr ""
+
+#: id:31421
+msgid "Select your XBMC user Profile[CR]to login and continue"
+msgstr "Выберите профиль пользователя XBMC,[CR]чтобы войти в систему"
+
+#: id:31900
+msgid "Weather Maps"
+msgstr "Карты погоды"
+
+#: id:31901
+msgid "36 Hour Forecast"
+msgstr "Прогноз на 36 ч."
+
+#: id:31902
+msgid "Hourly Forecast"
+msgstr "Ежечасный прогноз"
+
+#: id:31903
+msgid "Weekend Forecast"
+msgstr "Прогноз на выходные"
+
+#: id:31904
+msgid "10 Day Forecast"
+msgstr "Прогноз на 10 дней"
+
+#: id:31905
+msgid "Forecast"
+msgstr "Прогноз"
+
+#: id:31906
+msgid "Maps & Video"
+msgstr "Карты и видео"
+
+#: id:31907
+msgid "Video Forecast [COLOR=grey2](Fullscreen Playback)[/COLOR]"
+msgstr "Видео-прогноз [COLOR=grey2](полный экран)[/COLOR]"
+
+#: id:31908
+msgid "Chance of Precipitation"
+msgstr "Возможны осадки"
+
+#: id:31909
+msgid "Fetching forecast info..."
+msgstr "Получение прогноза…"
+

--- a/addons/skin.confluence/language/Serbian (Cyrillic)/strings.po
+++ b/addons/skin.confluence/language/Serbian (Cyrillic)/strings.po
@@ -1,0 +1,576 @@
+# Converted from xbmc strings.xml with xbmc-xml2po (by Team-XBMC)
+msgid ""
+msgstr ""
+"Project-Id-Version: xbmc.skin.confluence-FRODO_GIT953c09c336\n"
+"Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
+"POT-Creation-Date: 2012-04-09 18:03+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE\n"
+"Language: sr_RS\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: id:31000
+msgid "Change Your"
+msgstr "Промените ваше"
+
+#: id:31001
+msgid "Love"
+msgstr "Љубав"
+
+#: id:31002
+msgid "Hate"
+msgstr "Мржња"
+
+#: id:31003
+msgid "Power Options"
+msgstr "Опције напајања"
+
+#: id:31004
+msgid "Working..."
+msgstr "Обрада..."
+
+#: id:31005
+msgid "Hide Information"
+msgstr "Сакриј инфо."
+
+#: id:31006
+msgid "View Options"
+msgstr ""
+
+#: id:31007
+msgid "Plugins"
+msgstr "Додаци"
+
+#: id:31008
+msgid "Fullscreen"
+msgstr ""
+
+#: id:31020
+msgctxt "Auto context with id 31020"
+msgid "Recently Added"
+msgstr "Недавно додато"
+
+#: id:31021
+msgid "Video - Files"
+msgstr "Видео - Датотеке"
+
+#: id:31022
+msgid "Music - Files"
+msgstr "Музика - Датотеке"
+
+#: id:31023
+msgid "Playing"
+msgstr "Репродукција"
+
+#: id:31024
+msgid "Page"
+msgstr "Страна"
+
+#: id:31025
+msgid "Items"
+msgstr "Ставки"
+
+#: id:31026
+msgid "Misc Options"
+msgstr "Остале опције"
+
+#: id:31027
+msgid "Location"
+msgstr "Локација"
+
+#: id:31028
+msgid "Poster Wrap"
+msgstr "Поређано"
+
+#: id:31029
+msgid "Fanart"
+msgstr "Зан. слика"
+
+#: id:31030
+msgid "Full list"
+msgstr "Пуни списак"
+
+#: id:31031
+msgid "Pic Thumbs"
+msgstr "Сличице"
+
+#: id:31032
+msgid "Image Wrap"
+msgstr "Поређано"
+
+#: id:31033
+msgid "Info"
+msgstr "Информације"
+
+#: id:31040
+msgid "Now Playing"
+msgstr "Тренутно се репродукује"
+
+#: id:31042
+msgid "PLAYING"
+msgstr "РЕПРОДУКОВАЊЕ"
+
+#: id:31043
+msgid "PAUSED"
+msgstr "ПАУЗИРАНО"
+
+#: id:31044
+msgid "FAST FORWARD"
+msgstr "ПРЕМОТАВАЊЕ УНАПРЕД"
+
+#: id:31045
+msgid "REWIND"
+msgstr "ПРЕМОТАВАЊЕ"
+
+#: id:31046
+msgid "Audio Properties"
+msgstr "Својства звука"
+
+#: id:31047
+msgid "Current Preset"
+msgstr "Тренутна поставка"
+
+#: id:31048
+msgid "Visualization Presets"
+msgstr "Постојеће визуализације"
+
+#: id:31049
+msgid "End Time"
+msgstr "Време завршетка"
+
+#: id:31050
+msgid "Sort: Ascending"
+msgstr ""
+
+#: id:31051
+msgid "Sort: Descending"
+msgstr ""
+
+#: id:31055
+msgid "Open playlist"
+msgstr "Отвори реп. списак"
+
+#: id:31056
+msgid "Save playlist"
+msgstr "Сачувај реп. списак"
+
+#: id:31057
+msgid "Close playlist"
+msgstr "Затвори реп. списак"
+
+#: id:31058
+msgid "System music files"
+msgstr "Системске музичке датотеке"
+
+#: id:31059
+msgid "Current playlist"
+msgstr "Тренутни реп. списак"
+
+#: id:31060
+msgid "This file is stacked, select the part you want to play from."
+msgstr "Ова датотека је сложена, изаберите део који желите да репродукујете."
+
+#: id:31061
+msgid "Current Selected"
+msgstr "Тренутно изабрано"
+
+#: id:31101
+msgid "Home screen options"
+msgstr "Опције почетног екрана"
+
+#: id:31102
+msgid "Background"
+msgstr "Позадина"
+
+#: id:31103
+msgid "Show \"Paused\" in picture slide show"
+msgstr "Прикажи „Паузирано“ приликом репродукције слика"
+
+#: id:31104
+msgid "Play Trailers in a window [COLOR=grey3](Video Information Dialog Only)[/COLOR]"
+msgstr "Репродукуј најаве филмова у прозору [COLOR=grey3](Video Info. Dialog Only)[/COLOR]"
+
+#: id:31105
+msgid "\"Videos\" button always goes to video \"Files\""
+msgstr ""
+
+#: id:31106
+msgid "Miscellaneous options"
+msgstr "Разне опције"
+
+#: id:31107
+msgid "Hide Flagging read from video filenames [COLOR=grey3](Blu-ray, HD-DVD)[/COLOR]"
+msgstr ""
+
+#: id:31108
+msgid "Hide Main Menu Buttons"
+msgstr "Сакриј тастере главног менија"
+
+#: id:31109
+msgid "Media backgrounds"
+msgstr "Позадине почетног екрана"
+
+#: id:31110
+msgid "Edit Background for Media Type"
+msgstr "Уредите позадину тастера за почетни екран"
+
+#: id:31111
+msgid "Hide"
+msgstr "Сакриј"
+
+#: id:31112
+msgid "Options"
+msgstr "Опције"
+
+#: id:31113
+msgid "Single Image"
+msgstr "Једна слика"
+
+#: id:31114
+msgid "Multi Image"
+msgstr "Више слика"
+
+#: id:31115
+msgid "Customizer"
+msgstr "Прилагођавач"
+
+#: id:31117
+msgid "Show Recently added Videos"
+msgstr "Прикажи недавно додате филмове"
+
+#: id:31118
+msgid "Home Page Programs Submenu"
+msgstr "Подмени почетне стране"
+
+#: id:31119
+msgid "Hide Background Fanart"
+msgstr ""
+
+#: id:31120
+msgid "BUTTON LABEL"
+msgstr "НАТПИС ТАСТЕРА"
+
+#: id:31122
+msgid "Weather Page"
+msgstr "Страна временске прогнозе"
+
+#: id:31123
+msgid "Use \"Posters\" instead of \"Banners\" for TV Shows"
+msgstr "Прикажи постере уместо банера за TV серије"
+
+#: id:31124
+msgid "Show Background \"Now Playing\" Video"
+msgstr "Прикажи тренутни филм у позадини"
+
+#: id:31125
+msgid "Show Background \"Now Playing\" Visualization"
+msgstr "Прикажи тренутну визуализацију у позадини"
+
+#: id:31126
+msgid "Play TV theme songs in video library (TvTunes add-on)"
+msgstr ""
+
+#: id:31127
+msgid "TvTunes"
+msgstr ""
+
+#: id:31128
+msgid "Lyrics"
+msgstr "Текстови песама"
+
+#: id:31132
+msgid "Lyrics Add-on"
+msgstr ""
+
+#: id:31133
+msgid "Subtitle Add-on"
+msgstr ""
+
+#: id:31134
+msgid "Home Page Videos Submenu"
+msgstr ""
+
+#: id:31135
+msgid "Home Page Music Submenu"
+msgstr ""
+
+#: id:31136
+msgid "Home Page Pictures Submenu"
+msgstr ""
+
+#: id:31140
+msgid "Music OSD"
+msgstr "Музички OSD"
+
+#: id:31141
+msgid "Video OSD"
+msgstr "Видео OSD"
+
+#: id:31200
+msgid "Shortcuts"
+msgstr "Пречице"
+
+#: id:31201
+msgid "Categories"
+msgstr "Категорије"
+
+#: id:31202
+msgid "Show Cast"
+msgstr "Прикажи улоге"
+
+#: id:31203
+msgid "Choose Your Song"
+msgstr "Изаберите вашу песму"
+
+#: id:31204
+msgid "Section Links"
+msgstr "Линкови одељка"
+
+#: id:31205
+msgid "Lyrics Source"
+msgstr "Извор текстова песама"
+
+#: id:31300
+msgid "Current Temp"
+msgstr "Тренутна температура"
+
+#: id:31301
+msgid "Last Updated"
+msgstr "Последње ажурирање"
+
+#: id:31302
+msgid "Menu"
+msgstr "Мени"
+
+#: id:31303
+msgid "Data provider"
+msgstr ""
+
+#: id:31304
+msgid "Picture"
+msgstr "Фотографија"
+
+#: id:31305
+msgid "No Disc Media Detected"
+msgstr "Није откривен оптички диск"
+
+#: id:31306
+msgid "Eject"
+msgstr "Избаци"
+
+#: id:31307
+msgid "Hide Fanart"
+msgstr "Сакриј слику"
+
+#: id:31308
+msgid "Movie Details"
+msgstr "Подаци о филму"
+
+#: id:31309
+msgid "Memory Used:"
+msgstr "Искоришћеност меморије:"
+
+#: id:31310
+msgid "Track Number"
+msgstr "Број нумере"
+
+#: id:31311
+msgid "Fanart image[CR][CR]Unavailable[CR][CR] Click button to set"
+msgstr "Занимљива слика[CR]није додељена.[CR][CR]Кликните на дугме да[CR]бисте је доделили."
+
+#: id:31312
+msgid "Current Scraper"
+msgstr "Тренутни добављач"
+
+#: id:31313
+msgid "Choose a Scraper"
+msgstr "Изаберите добављача"
+
+#: id:31314
+msgid "Content Scanning Options"
+msgstr "Опције анализирања садржаја"
+
+#: id:31315
+msgid "Basic"
+msgstr "Основно"
+
+#: id:31317
+msgid "Set Fanart Path"
+msgstr "Пост. пут. до слика"
+
+#: id:31318
+msgid "Small Fanart"
+msgstr "Занимљиве слике малих димензија"
+
+#: id:31319
+msgid "Selected Profile"
+msgstr "Изабран профил"
+
+#: id:31320
+msgid "Last Logged In"
+msgstr "Последња пријава"
+
+#: id:31321
+msgid "Karaoke Song Selector"
+msgstr "Бирач караоке песме"
+
+#: id:31322
+msgid "Aired"
+msgstr "Емитовано"
+
+#: id:31323
+msgid "Latest Movies"
+msgstr "Новији филмови"
+
+#: id:31324
+msgid "Latest Episodes"
+msgstr "Новије епизоде"
+
+#: id:31325
+msgid "Playlist Options"
+msgstr "Опције списка за репродукцију"
+
+#: id:31326
+msgid "Created"
+msgstr "Направљено"
+
+#: id:31327
+msgid "Resolution"
+msgstr "Резолуција"
+
+#: id:31328
+msgctxt "Auto context with id 31328"
+msgid "Recently Added"
+msgstr "Недавно додато"
+
+#: id:31329
+msgid "[B]Timer set![/B] [COLOR=grey2] - System auto shutdown in[/COLOR]"
+msgstr "[B]Одбројавање је постављено![/B] [COLOR=grey2] - Систем ће се искључити за[/COLOR]"
+
+#: id:31330
+msgid "Click button to play[CR][CR]Movie trailer"
+msgstr "Кликните на тастер за репродукцију[CR][CR]најаве филма"
+
+#: id:31331
+msgid "Album Details"
+msgstr ""
+
+#: id:31351
+msgid "Pause"
+msgstr "Пауза"
+
+#: id:31352
+msgid "Stop"
+msgstr "Заустави"
+
+#: id:31353
+msgid "Fast Forward"
+msgstr "Премотај унапред"
+
+#: id:31354
+msgid "Rewind"
+msgstr "Премотај уназад"
+
+#: id:31355
+msgid "Movie menu"
+msgstr "Филмски мени"
+
+#: id:31356
+msgid "Download Subtitles"
+msgstr "Преузми титлове"
+
+#: id:31390
+msgid "Skin default"
+msgstr ""
+
+#: id:31391
+msgid "Skin default with no Caps"
+msgstr ""
+
+#: id:31392
+msgid "Arial based"
+msgstr ""
+
+#: id:31400
+msgid "[B]CONFIGURE APPEARANCE SETTINGS[/B][CR][CR]Change the skin � Set language and region � Change file listing options[CR]Set up a screensaver"
+msgstr "[B]КОНФИГУРИСАЊЕ ПОСТАВКИ ПРИКАЗА[/B][CR][CR]Промените маску · Изаберите језик и област где живите[CR]Промените опције излиставања датотека · Изаберите чувара екрана"
+
+#: id:31401
+msgid "[B]CONFIGURE VIDEO SETTINGS[/B][CR][CR]Manage your video library � Set video playback options � Change video listing options[CR]Set subtitle fonts"
+msgstr "[B]КОНФИГУРИСАЊЕ ПОСТАВКИ ФИЛМОВА[/B][CR][CR]Управљајте вашом библиотеком филмова · Поставите опције репродукције филмова[CR]Промените опције излиставања филмова · Поставите изглед слова у титловима"
+
+#: id:31402
+msgid "[B]CONFIGURE MUSIC SETTINGS[/B][CR][CR]Manage your music library � Set music playback options � Change music listing options[CR]Setup song submission � Set karaoke options"
+msgstr "[B]КОНФИГУРИСАЊЕ ПОСТАВКИ МУЗИКЕ[/B][CR][CR]Управљајте вашом библиотеком музичких нумера · Поставите опције репрод. музике[CR]Промените опције излиставања музике · Поставите слање песама[CR]Поставите караоке опције"
+
+#: id:31403
+msgid "[B]CONFIGURE PICTURE SETTINGS[/B][CR][CR]Set picture listing options � Configure slideshows"
+msgstr "[B]КОНФИГУРИСАЊЕ ПОСТАВКИ СЛИКА[/B][CR][CR]Поставите опције излиставања слика · Конфигуришите репродукцију слајдова"
+
+#: id:31404
+msgid "[B]CONFIGURE WEATHER SETTINGS[/B][CR][CR]Set three cities to collect weather information"
+msgstr "[B]КОНФИГУРИСАЊЕ ПОСТАВКИ ВРЕМЕНСКЕ ПРОГНОЗЕ[/B][CR][CR]Поставите три града за прикупљање информација о временским приликама"
+
+#: id:31406
+msgid "[B]CONFIGURE SYSTEM SETTINGS[/B][CR][CR]Setup and calibrate displays � Configure audio output � Setup remote controls[CR]Set power saving options � Enable debugging � Setup master lock"
+msgstr "[B]КОНФИГУРИСАЊЕ ПОСТАВКИ СИСТЕМА[/B][CR][CR]Подесите и калибришите екране · Конфигуришите звучни излаз[CR]Подесите даљинско управљање · Поставите опције штедње енергије[CR]Омогућите евиденцију грешака · Подесите главну лозинку"
+
+#: id:31407
+msgid "[B]CONFIGURE SKIN SETTINGS[/B][CR][CR]Setup the Confluence skin � Add and remove home menu items[CR]Change skin backgrounds"
+msgstr "[B]КОНФИГУРИСАЊЕ ПОСТАВКИ МАСКЕ[/B][CR][CR]Подесите Confluence маску · Додајте и уклоните ставке почетног екрана[CR]Промените позадине маске"
+
+#: id:31408
+msgid "[B]CONFIGURE ADD-ONS[/B][CR][CR]Manage your installed Add-ons � Browse for and install Add-ons from xbmc.org[CR]Modify Add-on settings"
+msgstr "[B]КОНФИГУРИСАЊЕ ДОДАТНИХ ПРОГРАМА[/B][CR][CR]Управљајте вашим инсталираним додатним програмима · Потражите и инсталирајте додатне прог. са xbmc.org[CR]Прилагодите подешавање додатног програма"
+
+#: id:31409
+msgid "[B]CONFIGURE SERVICE SETTINGS[/B][CR][CR]Setup control of XBMC via UPnP and HTTP � Configure file sharing[CR]Enable Zeroconf � Configure AirPlay"
+msgstr ""
+
+#: id:31421
+msgid "Select your XBMC user Profile[CR]to login and continue"
+msgstr "Изаберите ваш XBMC кориснички[CR]профил за пријаву, а потом наставите даље"
+
+#: id:31900
+msgid "Weather Maps"
+msgstr ""
+
+#: id:31901
+msgid "36 Hour Forecast"
+msgstr ""
+
+#: id:31902
+msgid "Hourly Forecast"
+msgstr ""
+
+#: id:31903
+msgid "Weekend Forecast"
+msgstr ""
+
+#: id:31904
+msgid "10 Day Forecast"
+msgstr ""
+
+#: id:31905
+msgid "Forecast"
+msgstr ""
+
+#: id:31906
+msgid "Maps & Video"
+msgstr ""
+
+#: id:31907
+msgid "Video Forecast [COLOR=grey2](Fullscreen Playback)[/COLOR]"
+msgstr ""
+
+#: id:31908
+msgid "Chance of Precipitation"
+msgstr ""
+
+#: id:31909
+msgid "Fetching forecast info..."
+msgstr ""
+

--- a/addons/skin.confluence/language/Serbian/strings.po
+++ b/addons/skin.confluence/language/Serbian/strings.po
@@ -1,0 +1,576 @@
+# Converted from xbmc strings.xml with xbmc-xml2po (by Team-XBMC)
+msgid ""
+msgstr ""
+"Project-Id-Version: xbmc.skin.confluence-FRODO_GIT953c09c336\n"
+"Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
+"POT-Creation-Date: 2012-04-09 18:03+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE\n"
+"Language: sr\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: id:31000
+msgid "Change Your"
+msgstr "Promenite vaše"
+
+#: id:31001
+msgid "Love"
+msgstr "Ljubav"
+
+#: id:31002
+msgid "Hate"
+msgstr "Mržnja"
+
+#: id:31003
+msgid "Power Options"
+msgstr "Opcije napajanja"
+
+#: id:31004
+msgid "Working..."
+msgstr "Obrada..."
+
+#: id:31005
+msgid "Hide Information"
+msgstr "Sakrij info."
+
+#: id:31006
+msgid "View Options"
+msgstr ""
+
+#: id:31007
+msgid "Plugins"
+msgstr "Dodaci"
+
+#: id:31008
+msgid "Fullscreen"
+msgstr ""
+
+#: id:31020
+msgctxt "Auto context with id 31020"
+msgid "Recently Added"
+msgstr "Nedavno dodato"
+
+#: id:31021
+msgid "Video - Files"
+msgstr "Video - Datoteke"
+
+#: id:31022
+msgid "Music - Files"
+msgstr "Muzika - Datoteke"
+
+#: id:31023
+msgid "Playing"
+msgstr "Reprodukcija"
+
+#: id:31024
+msgid "Page"
+msgstr "Strana"
+
+#: id:31025
+msgid "Items"
+msgstr "Stavki"
+
+#: id:31026
+msgid "Misc Options"
+msgstr "Ostale opcije"
+
+#: id:31027
+msgid "Location"
+msgstr "Lokacija"
+
+#: id:31028
+msgid "Poster Wrap"
+msgstr "Poređano"
+
+#: id:31029
+msgid "Fanart"
+msgstr "Zan. slika"
+
+#: id:31030
+msgid "Full list"
+msgstr "Puni spisak"
+
+#: id:31031
+msgid "Pic Thumbs"
+msgstr "Sličice"
+
+#: id:31032
+msgid "Image Wrap"
+msgstr "Poređano"
+
+#: id:31033
+msgid "Info"
+msgstr "Informacije"
+
+#: id:31040
+msgid "Now Playing"
+msgstr "Trenutno se reprodukuje"
+
+#: id:31042
+msgid "PLAYING"
+msgstr "REPRODUKOVANjE"
+
+#: id:31043
+msgid "PAUSED"
+msgstr "PAUZIRANO"
+
+#: id:31044
+msgid "FAST FORWARD"
+msgstr "PREMOTAVANjE UNAPRED"
+
+#: id:31045
+msgid "REWIND"
+msgstr "PREMOTAVANjE"
+
+#: id:31046
+msgid "Audio Properties"
+msgstr "Svojstva zvuka"
+
+#: id:31047
+msgid "Current Preset"
+msgstr "Trenutna postavka"
+
+#: id:31048
+msgid "Visualization Presets"
+msgstr "Postojeće vizualizacije"
+
+#: id:31049
+msgid "End Time"
+msgstr "Vreme završetka"
+
+#: id:31050
+msgid "Sort: Ascending"
+msgstr ""
+
+#: id:31051
+msgid "Sort: Descending"
+msgstr ""
+
+#: id:31055
+msgid "Open playlist"
+msgstr "Otvori rep. spisak"
+
+#: id:31056
+msgid "Save playlist"
+msgstr "Sačuvaj rep. spisak"
+
+#: id:31057
+msgid "Close playlist"
+msgstr "Zatvori rep. spisak"
+
+#: id:31058
+msgid "System music files"
+msgstr "Sistemske muzičke datoteke"
+
+#: id:31059
+msgid "Current playlist"
+msgstr "Trenutni rep. spisak"
+
+#: id:31060
+msgid "This file is stacked, select the part you want to play from."
+msgstr "Ova datoteka je složena, izaberite deo koji želite da reprodukujete."
+
+#: id:31061
+msgid "Current Selected"
+msgstr "Trenutno izabrano"
+
+#: id:31101
+msgid "Home screen options"
+msgstr "Opcije početnog ekrana"
+
+#: id:31102
+msgid "Background"
+msgstr "Pozadina"
+
+#: id:31103
+msgid "Show \"Paused\" in picture slide show"
+msgstr "Prikaži „Pauzirano“ prilikom reprodukcije slika"
+
+#: id:31104
+msgid "Play Trailers in a window [COLOR=grey3](Video Information Dialog Only)[/COLOR]"
+msgstr "Reprodukuj najave filmova u prozoru [COLOR=grey3](Video Info. Dialog Only)[/COLOR]"
+
+#: id:31105
+msgid "\"Videos\" button always goes to video \"Files\""
+msgstr ""
+
+#: id:31106
+msgid "Miscellaneous options"
+msgstr "Razne opcije"
+
+#: id:31107
+msgid "Hide Flagging read from video filenames [COLOR=grey3](Blu-ray, HD-DVD)[/COLOR]"
+msgstr ""
+
+#: id:31108
+msgid "Hide Main Menu Buttons"
+msgstr "Sakrij tastere glavnog menija"
+
+#: id:31109
+msgid "Media backgrounds"
+msgstr "Pozadine početnog ekrana"
+
+#: id:31110
+msgid "Edit Background for Media Type"
+msgstr "Uredite pozadinu tastera za početni ekran"
+
+#: id:31111
+msgid "Hide"
+msgstr "Sakrij"
+
+#: id:31112
+msgid "Options"
+msgstr "Opcije"
+
+#: id:31113
+msgid "Single Image"
+msgstr "Jedna slika"
+
+#: id:31114
+msgid "Multi Image"
+msgstr "Više slika"
+
+#: id:31115
+msgid "Customizer"
+msgstr "Prilagođavač"
+
+#: id:31117
+msgid "Show Recently added Videos"
+msgstr "Prikaži nedavno dodate filmove"
+
+#: id:31118
+msgid "Home Page Programs Submenu"
+msgstr "Podmeni početne strane"
+
+#: id:31119
+msgid "Hide Background Fanart"
+msgstr ""
+
+#: id:31120
+msgid "BUTTON LABEL"
+msgstr "NATPIS TASTERA"
+
+#: id:31122
+msgid "Weather Page"
+msgstr "Strana vremenske prognoze"
+
+#: id:31123
+msgid "Use \"Posters\" instead of \"Banners\" for TV Shows"
+msgstr "Prikaži postere umesto banera za TV serije"
+
+#: id:31124
+msgid "Show Background \"Now Playing\" Video"
+msgstr "Prikaži trenutni film u pozadini"
+
+#: id:31125
+msgid "Show Background \"Now Playing\" Visualization"
+msgstr "Prikaži trenutnu vizualizaciju u pozadini"
+
+#: id:31126
+msgid "Play TV theme songs in video library (TvTunes add-on)"
+msgstr ""
+
+#: id:31127
+msgid "TvTunes"
+msgstr ""
+
+#: id:31128
+msgid "Lyrics"
+msgstr "Tekstovi pesama"
+
+#: id:31132
+msgid "Lyrics Add-on"
+msgstr ""
+
+#: id:31133
+msgid "Subtitle Add-on"
+msgstr ""
+
+#: id:31134
+msgid "Home Page Videos Submenu"
+msgstr ""
+
+#: id:31135
+msgid "Home Page Music Submenu"
+msgstr ""
+
+#: id:31136
+msgid "Home Page Pictures Submenu"
+msgstr ""
+
+#: id:31140
+msgid "Music OSD"
+msgstr "Muzički OSD"
+
+#: id:31141
+msgid "Video OSD"
+msgstr "Video OSD"
+
+#: id:31200
+msgid "Shortcuts"
+msgstr "Prečice"
+
+#: id:31201
+msgid "Categories"
+msgstr "Kategorije"
+
+#: id:31202
+msgid "Show Cast"
+msgstr "Prikaži uloge"
+
+#: id:31203
+msgid "Choose Your Song"
+msgstr "Izaberite vašu pesmu"
+
+#: id:31204
+msgid "Section Links"
+msgstr "Linkovi odeljka"
+
+#: id:31205
+msgid "Lyrics Source"
+msgstr "Izvor tekstova pesama"
+
+#: id:31300
+msgid "Current Temp"
+msgstr "Trenutna temperatura"
+
+#: id:31301
+msgid "Last Updated"
+msgstr "Poslednje ažuriranje"
+
+#: id:31302
+msgid "Menu"
+msgstr "Meni"
+
+#: id:31303
+msgid "Data provider"
+msgstr ""
+
+#: id:31304
+msgid "Picture"
+msgstr "Fotografija"
+
+#: id:31305
+msgid "No Disc Media Detected"
+msgstr "Nije otkriven optički disk"
+
+#: id:31306
+msgid "Eject"
+msgstr "Izbaci"
+
+#: id:31307
+msgid "Hide Fanart"
+msgstr "Sakrij sliku"
+
+#: id:31308
+msgid "Movie Details"
+msgstr "Podaci o filmu"
+
+#: id:31309
+msgid "Memory Used:"
+msgstr "Iskorišćenost memorije:"
+
+#: id:31310
+msgid "Track Number"
+msgstr "Broj numere"
+
+#: id:31311
+msgid "Fanart image[CR][CR]Unavailable[CR][CR] Click button to set"
+msgstr "Zanimljiva slika[CR]nije dodeljena.[CR][CR]Kliknite na dugme da[CR]biste je dodelili."
+
+#: id:31312
+msgid "Current Scraper"
+msgstr "Trenutni dobavljač"
+
+#: id:31313
+msgid "Choose a Scraper"
+msgstr "Izaberite dobavljača"
+
+#: id:31314
+msgid "Content Scanning Options"
+msgstr "Opcije analiziranja sadržaja"
+
+#: id:31315
+msgid "Basic"
+msgstr "Osnovno"
+
+#: id:31317
+msgid "Set Fanart Path"
+msgstr "Post. put. do slika"
+
+#: id:31318
+msgid "Small Fanart"
+msgstr "Zanimljive slike malih dimenzija"
+
+#: id:31319
+msgid "Selected Profile"
+msgstr "Izabran profil"
+
+#: id:31320
+msgid "Last Logged In"
+msgstr "Poslednja prijava"
+
+#: id:31321
+msgid "Karaoke Song Selector"
+msgstr "Birač karaoke pesme"
+
+#: id:31322
+msgid "Aired"
+msgstr "Emitovano"
+
+#: id:31323
+msgid "Latest Movies"
+msgstr "Noviji filmovi"
+
+#: id:31324
+msgid "Latest Episodes"
+msgstr "Novije epizode"
+
+#: id:31325
+msgid "Playlist Options"
+msgstr "Opcije spiska za reprodukciju"
+
+#: id:31326
+msgid "Created"
+msgstr "Napravljeno"
+
+#: id:31327
+msgid "Resolution"
+msgstr "Rezolucija"
+
+#: id:31328
+msgctxt "Auto context with id 31328"
+msgid "Recently Added"
+msgstr "Nedavno dodato"
+
+#: id:31329
+msgid "[B]Timer set![/B] [COLOR=grey2] - System auto shutdown in[/COLOR]"
+msgstr "[B]Odbrojavanje je postavljeno![/B] [COLOR=grey2] - Sistem će se isključiti za[/COLOR]"
+
+#: id:31330
+msgid "Click button to play[CR][CR]Movie trailer"
+msgstr "Kliknite na taster za reprodukciju[CR][CR]najave filma"
+
+#: id:31331
+msgid "Album Details"
+msgstr ""
+
+#: id:31351
+msgid "Pause"
+msgstr "Pauza"
+
+#: id:31352
+msgid "Stop"
+msgstr "Zaustavi"
+
+#: id:31353
+msgid "Fast Forward"
+msgstr "Premotaj unapred"
+
+#: id:31354
+msgid "Rewind"
+msgstr "Premotaj unazad"
+
+#: id:31355
+msgid "Movie menu"
+msgstr "Filmski meni"
+
+#: id:31356
+msgid "Download Subtitles"
+msgstr "Preuzmi titlove"
+
+#: id:31390
+msgid "Skin default"
+msgstr ""
+
+#: id:31391
+msgid "Skin default with no Caps"
+msgstr ""
+
+#: id:31392
+msgid "Arial based"
+msgstr ""
+
+#: id:31400
+msgid "[B]CONFIGURE APPEARANCE SETTINGS[/B][CR][CR]Change the skin � Set language and region � Change file listing options[CR]Set up a screensaver"
+msgstr "[B]KONFIGURISANjE POSTAVKI PRIKAZA[/B][CR][CR]Promenite masku · Izaberite jezik i oblast gde živite[CR]Promenite opcije izlistavanja datoteka · Izaberite čuvara ekrana"
+
+#: id:31401
+msgid "[B]CONFIGURE VIDEO SETTINGS[/B][CR][CR]Manage your video library � Set video playback options � Change video listing options[CR]Set subtitle fonts"
+msgstr "[B]KONFIGURISANjE POSTAVKI FILMOVA[/B][CR][CR]Upravljajte vašom bibliotekom filmova · Postavite opcije reprodukcije filmova[CR]Promenite opcije izlistavanja filmova · Postavite izgled slova u titlovima"
+
+#: id:31402
+msgid "[B]CONFIGURE MUSIC SETTINGS[/B][CR][CR]Manage your music library � Set music playback options � Change music listing options[CR]Setup song submission � Set karaoke options"
+msgstr "[B]KONFIGURISANjE POSTAVKI MUZIKE[/B][CR][CR]Upravljajte vašom bibliotekom muzičkih numera · Postavite opcije reprod. muzike[CR]Promenite opcije izlistavanja muzike · Postavite slanje pesama[CR]Postavite karaoke opcije"
+
+#: id:31403
+msgid "[B]CONFIGURE PICTURE SETTINGS[/B][CR][CR]Set picture listing options � Configure slideshows"
+msgstr "[B]KONFIGURISANjE POSTAVKI SLIKA[/B][CR][CR]Postavite opcije izlistavanja slika · Konfigurišite reprodukciju slajdova"
+
+#: id:31404
+msgid "[B]CONFIGURE WEATHER SETTINGS[/B][CR][CR]Set three cities to collect weather information"
+msgstr "[B]KONFIGURISANjE POSTAVKI VREMENSKE PROGNOZE[/B][CR][CR]Postavite tri grada za prikupljanje informacija o vremenskim prilikama"
+
+#: id:31406
+msgid "[B]CONFIGURE SYSTEM SETTINGS[/B][CR][CR]Setup and calibrate displays � Configure audio output � Setup remote controls[CR]Set power saving options � Enable debugging � Setup master lock"
+msgstr "[B]KONFIGURISANjE POSTAVKI SISTEMA[/B][CR][CR]Podesite i kalibrišite ekrane · Konfigurišite zvučni izlaz[CR]Podesite daljinsko upravljanje · Postavite opcije štednje energije[CR]Omogućite evidenciju grešaka · Podesite glavnu lozinku"
+
+#: id:31407
+msgid "[B]CONFIGURE SKIN SETTINGS[/B][CR][CR]Setup the Confluence skin � Add and remove home menu items[CR]Change skin backgrounds"
+msgstr "[B]KONFIGURISANjE POSTAVKI MASKE[/B][CR][CR]Podesite Confluence masku · Dodajte i uklonite stavke početnog ekrana[CR]Promenite pozadine maske"
+
+#: id:31408
+msgid "[B]CONFIGURE ADD-ONS[/B][CR][CR]Manage your installed Add-ons � Browse for and install Add-ons from xbmc.org[CR]Modify Add-on settings"
+msgstr "[B]KONFIGURISANjE DODATNIH PROGRAMA[/B][CR][CR]Upravljajte vašim instaliranim dodatnim programima · Potražite i instalirajte dodatne prog. sa xbmc.org[CR]Prilagodite podešavanje dodatnog programa"
+
+#: id:31409
+msgid "[B]CONFIGURE SERVICE SETTINGS[/B][CR][CR]Setup control of XBMC via UPnP and HTTP � Configure file sharing[CR]Enable Zeroconf � Configure AirPlay"
+msgstr ""
+
+#: id:31421
+msgid "Select your XBMC user Profile[CR]to login and continue"
+msgstr "Izaberite vaš XBMC korisnički[CR]profil za prijavu, a potom nastavite dalje"
+
+#: id:31900
+msgid "Weather Maps"
+msgstr ""
+
+#: id:31901
+msgid "36 Hour Forecast"
+msgstr ""
+
+#: id:31902
+msgid "Hourly Forecast"
+msgstr ""
+
+#: id:31903
+msgid "Weekend Forecast"
+msgstr ""
+
+#: id:31904
+msgid "10 Day Forecast"
+msgstr ""
+
+#: id:31905
+msgid "Forecast"
+msgstr ""
+
+#: id:31906
+msgid "Maps & Video"
+msgstr ""
+
+#: id:31907
+msgid "Video Forecast [COLOR=grey2](Fullscreen Playback)[/COLOR]"
+msgstr ""
+
+#: id:31908
+msgid "Chance of Precipitation"
+msgstr ""
+
+#: id:31909
+msgid "Fetching forecast info..."
+msgstr ""
+

--- a/addons/skin.confluence/language/Slovak/strings.po
+++ b/addons/skin.confluence/language/Slovak/strings.po
@@ -1,0 +1,576 @@
+# Converted from xbmc strings.xml with xbmc-xml2po (by Team-XBMC)
+msgid ""
+msgstr ""
+"Project-Id-Version: xbmc.skin.confluence-FRODO_GIT953c09c336\n"
+"Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
+"POT-Creation-Date: 2012-04-09 18:03+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE\n"
+"Language: sk\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: id:31000
+msgid "Change Your"
+msgstr "Zmeniť"
+
+#: id:31001
+msgid "Love"
+msgstr "Milovať"
+
+#: id:31002
+msgid "Hate"
+msgstr "Nenávidieť"
+
+#: id:31003
+msgid "Power Options"
+msgstr "Napájanie"
+
+#: id:31004
+msgid "Working..."
+msgstr "Pracujem..."
+
+#: id:31005
+msgid "Hide Information"
+msgstr "Skryť informácie"
+
+#: id:31006
+msgid "View Options"
+msgstr "Nastavenie zobrazenia"
+
+#: id:31007
+msgid "Plugins"
+msgstr "Pluginy"
+
+#: id:31008
+msgid "Fullscreen"
+msgstr "Celá obrazovka"
+
+#: id:31020
+msgctxt "Auto context with id 31020"
+msgid "Recently Added"
+msgstr "Posledné pridané"
+
+#: id:31021
+msgid "Video - Files"
+msgstr "Video - Súbory"
+
+#: id:31022
+msgid "Music - Files"
+msgstr "Music - Súbory"
+
+#: id:31023
+msgid "Playing"
+msgstr "Prehráva sa"
+
+#: id:31024
+msgid "Page"
+msgstr "Strana"
+
+#: id:31025
+msgid "Items"
+msgstr "Položky"
+
+#: id:31026
+msgid "Misc Options"
+msgstr "Ďaľšie nastavenia"
+
+#: id:31027
+msgid "Location"
+msgstr "Umiestnenie"
+
+#: id:31028
+msgid "Poster Wrap"
+msgstr "Obaly"
+
+#: id:31029
+msgid "Fanart"
+msgstr "Fanart"
+
+#: id:31030
+msgid "Full list"
+msgstr "Celý Zoznam"
+
+#: id:31031
+msgid "Pic Thumbs"
+msgstr "Náhľady"
+
+#: id:31032
+msgid "Image Wrap"
+msgstr "Obrázky"
+
+#: id:31033
+msgid "Info"
+msgstr "Info"
+
+#: id:31040
+msgid "Now Playing"
+msgstr "Práve hráme"
+
+#: id:31042
+msgid "PLAYING"
+msgstr "Prehráva sa"
+
+#: id:31043
+msgid "PAUSED"
+msgstr "PAUZA"
+
+#: id:31044
+msgid "FAST FORWARD"
+msgstr "PRETÁČA SA DOPREDU"
+
+#: id:31045
+msgid "REWIND"
+msgstr "PRETÁČA SA DOZADU"
+
+#: id:31046
+msgid "Audio Properties"
+msgstr "Vlastnosti zvuku"
+
+#: id:31047
+msgid "Current Preset"
+msgstr "Aktuálna predvolba"
+
+#: id:31048
+msgid "Visualization Presets"
+msgstr "Predvolby Vizualizácií"
+
+#: id:31049
+msgid "End Time"
+msgstr "Film končí"
+
+#: id:31050
+msgid "Sort: Ascending"
+msgstr "Zoradiť: Vzostupne"
+
+#: id:31051
+msgid "Sort: Descending"
+msgstr "Zoradiť: Zostupne"
+
+#: id:31055
+msgid "Open playlist"
+msgstr "Otvoriť playlist"
+
+#: id:31056
+msgid "Save playlist"
+msgstr "Uložiť playlist"
+
+#: id:31057
+msgid "Close playlist"
+msgstr "Zatvoriť playlist"
+
+#: id:31058
+msgid "System music files"
+msgstr "Hudobné súbory systému"
+
+#: id:31059
+msgid "Current playlist"
+msgstr "Aktuálny playlist"
+
+#: id:31060
+msgid "This file is stacked, select the part you want to play from."
+msgstr "Tento súbor sa skladá z viac častí. Vyberte tu, od ktorej chcete spustit prehrávaníe."
+
+#: id:31061
+msgid "Current Selected"
+msgstr "Aktuálne vybraný"
+
+#: id:31101
+msgid "Home screen options"
+msgstr "Informácie na Domovskej stránke"
+
+#: id:31102
+msgid "Background"
+msgstr "Pozadie"
+
+#: id:31103
+msgid "Show \"Paused\" in picture slide show"
+msgstr "Zobraziť \"PAUZA\" pri prezentácií obrázkov"
+
+#: id:31104
+msgid "Play Trailers in a window [COLOR=grey3](Video Information Dialog Only)[/COLOR]"
+msgstr "Prehrávať trailer v okne [COLOR=grey3](iba z okna Informácie o videu)[/COLOR]"
+
+#: id:31105
+msgid "\"Videos\" button always goes to video \"Files\""
+msgstr "\"Videá\" tlačítko vždy ide do \"Súbory\""
+
+#: id:31106
+msgid "Miscellaneous options"
+msgstr "Rôzne nastavenia"
+
+#: id:31107
+msgid "Hide Flagging read from video filenames [COLOR=grey3](Blu-ray, HD-DVD)[/COLOR]"
+msgstr "Nezobrazovať ikonky zdroja videí [COLOR=grey3](Blu-ray, HD-DVD)[/COLOR]"
+
+#: id:31108
+msgid "Hide Main Menu Buttons"
+msgstr "Schovať tlačítka hlavného menu"
+
+#: id:31109
+msgid "Media backgrounds"
+msgstr "Pozadie Domovskej stránky"
+
+#: id:31110
+msgid "Edit Background for Media Type"
+msgstr "Zmeniť pozadie domovskej stránky - sekcia"
+
+#: id:31111
+msgid "Hide"
+msgstr "Schovať"
+
+#: id:31112
+msgid "Options"
+msgstr "Možnosti"
+
+#: id:31113
+msgid "Single Image"
+msgstr "Jeden obrázok"
+
+#: id:31114
+msgid "Multi Image"
+msgstr "Viac obrázkov"
+
+#: id:31115
+msgid "Customizer"
+msgstr "Prispôsobenie"
+
+#: id:31117
+msgid "Show Recently added Videos"
+msgstr "Zobraziť Posledné pridané"
+
+#: id:31118
+msgid "Home Page Programs Submenu"
+msgstr "Domovská stránka"
+
+#: id:31119
+msgid "Hide Background Fanart"
+msgstr "Schovať Fanart na pozadí"
+
+#: id:31120
+msgid "BUTTON LABEL"
+msgstr "NÁZOV POLOŽKY"
+
+#: id:31122
+msgid "Weather Page"
+msgstr "Počasie"
+
+#: id:31123
+msgid "Use \"Posters\" instead of \"Banners\" for TV Shows"
+msgstr "Použiť u TV seriálov klasické náhlady namiesto širokouhlých"
+
+#: id:31124
+msgid "Show Background \"Now Playing\" Video"
+msgstr "Zobraziť na pozadí \"Práve hráme\" Video"
+
+#: id:31125
+msgid "Show Background \"Now Playing\" Visualization"
+msgstr "Zobraziť na pozadí \"Práve hráme\" Vizualizáciu"
+
+#: id:31126
+msgid "Play TV theme songs in video library (TvTunes add-on)"
+msgstr "Prehrávať skladbu TV seriálu vo video knižnici (TvTunes doplnok)"
+
+#: id:31127
+msgid "TvTunes"
+msgstr "TvTunes"
+
+#: id:31128
+msgid "Lyrics"
+msgstr "Texty skladieb"
+
+#: id:31132
+msgid "Lyrics Add-on"
+msgstr "Texty skladieb Doplnok"
+
+#: id:31133
+msgid "Subtitle Add-on"
+msgstr "Titulky Doplnok"
+
+#: id:31134
+msgid "Home Page Videos Submenu"
+msgstr "Domovská stránka Videá Podmenu"
+
+#: id:31135
+msgid "Home Page Music Submenu"
+msgstr "Domovská stránka Hudba Podmenu"
+
+#: id:31136
+msgid "Home Page Pictures Submenu"
+msgstr "Domovská stránka Obrázky Podmenu"
+
+#: id:31140
+msgid "Music OSD"
+msgstr "Hudobný OSD"
+
+#: id:31141
+msgid "Video OSD"
+msgstr "Video OSD"
+
+#: id:31200
+msgid "Shortcuts"
+msgstr "Odkazy"
+
+#: id:31201
+msgid "Categories"
+msgstr "Kategórie"
+
+#: id:31202
+msgid "Show Cast"
+msgstr "Zobraziť účinkujúcich"
+
+#: id:31203
+msgid "Choose Your Song"
+msgstr "Vyberte Vašu skladbu"
+
+#: id:31204
+msgid "Section Links"
+msgstr "Odkazy Sekcií"
+
+#: id:31205
+msgid "Lyrics Source"
+msgstr "Zdroj textov skladieb"
+
+#: id:31300
+msgid "Current Temp"
+msgstr "Aktuálna teplota"
+
+#: id:31301
+msgid "Last Updated"
+msgstr "Naposledy aktualizované"
+
+#: id:31302
+msgid "Menu"
+msgstr "Menu"
+
+#: id:31303
+msgid "Data provider"
+msgstr ""
+
+#: id:31304
+msgid "Picture"
+msgstr "Obrázok"
+
+#: id:31305
+msgid "No Disc Media Detected"
+msgstr "Židny disk nie je vložený"
+
+#: id:31306
+msgid "Eject"
+msgstr "Vysunúť"
+
+#: id:31307
+msgid "Hide Fanart"
+msgstr "Schovať Fanart"
+
+#: id:31308
+msgid "Movie Details"
+msgstr "Detaili o filme"
+
+#: id:31309
+msgid "Memory Used:"
+msgstr "Použitá pamäť:"
+
+#: id:31310
+msgid "Track Number"
+msgstr "Číslo skladby"
+
+#: id:31311
+msgid "Fanart image[CR][CR]Unavailable[CR][CR] Click button to set"
+msgstr "Fanart obrázok[CR][CR]Nedostupný[CR][CR] Klik pre nastavenie"
+
+#: id:31312
+msgid "Current Scraper"
+msgstr "Aktuálny sťahovač"
+
+#: id:31313
+msgid "Choose a Scraper"
+msgstr "Vyber sťahovač"
+
+#: id:31314
+msgid "Content Scanning Options"
+msgstr "Možnosti vyhľadávania obsahu"
+
+#: id:31315
+msgid "Basic"
+msgstr "Základné"
+
+#: id:31317
+msgid "Set Fanart Path"
+msgstr "Umiestneni FanArtu"
+
+#: id:31318
+msgid "Small Fanart"
+msgstr "Malý Fanart"
+
+#: id:31319
+msgid "Selected Profile"
+msgstr "Vybratý Profil"
+
+#: id:31320
+msgid "Last Logged In"
+msgstr "Posledné prihlásenie"
+
+#: id:31321
+msgid "Karaoke Song Selector"
+msgstr "Výber Karaoke skladby"
+
+#: id:31322
+msgid "Aired"
+msgstr "Vysielané"
+
+#: id:31323
+msgid "Latest Movies"
+msgstr "Posledné Filmy"
+
+#: id:31324
+msgid "Latest Episodes"
+msgstr "Posledné Epizódy"
+
+#: id:31325
+msgid "Playlist Options"
+msgstr "Nastavenia Playlistu"
+
+#: id:31326
+msgid "Created"
+msgstr "Vytvorené"
+
+#: id:31327
+msgid "Resolution"
+msgstr "Rozlíšenie"
+
+#: id:31328
+msgctxt "Auto context with id 31328"
+msgid "Recently Added"
+msgstr "Posledné pridané"
+
+#: id:31329
+msgid "[B]Timer set![/B] [COLOR=grey2] - System auto shutdown in[/COLOR]"
+msgstr "[B]Časovač nastavený![/B] [COLOR=grey2] - Systém sa automaticky vypne za[/COLOR]"
+
+#: id:31330
+msgid "Click button to play[CR][CR]Movie trailer"
+msgstr "Pre prehratie traileru[CR][CR]stlačte tlačítko"
+
+#: id:31331
+msgid "Album Details"
+msgstr "Album Details"
+
+#: id:31351
+msgid "Pause"
+msgstr "Pauza"
+
+#: id:31352
+msgid "Stop"
+msgstr "Zastaviť"
+
+#: id:31353
+msgid "Fast Forward"
+msgstr "Pretočiť dopredu"
+
+#: id:31354
+msgid "Rewind"
+msgstr "Pretočiť dozadu"
+
+#: id:31355
+msgid "Movie menu"
+msgstr "Menu filmu"
+
+#: id:31356
+msgid "Download Subtitles"
+msgstr "Stiahnuť titulky"
+
+#: id:31390
+msgid "Skin default"
+msgstr "Predvolený Skin"
+
+#: id:31391
+msgid "Skin default with no Caps"
+msgstr "Predvolený Skin bez Caps"
+
+#: id:31392
+msgid "Arial based"
+msgstr "Arial"
+
+#: id:31400
+msgid "[B]CONFIGURE APPEARANCE SETTINGS[/B][CR][CR]Change the skin � Set language and region � Change file listing options[CR]Set up a screensaver"
+msgstr "[B]MOŽNOSTI PROSTREDIA[/B][CR][CR]Zmena vzhľadu · Výber jazyka a oblasti · Možnosti zobrazenia súborov[CR]Nastavenie šporiča obrazovky"
+
+#: id:31401
+msgid "[B]CONFIGURE VIDEO SETTINGS[/B][CR][CR]Manage your video library � Set video playback options � Change video listing options[CR]Set subtitle fonts"
+msgstr "[B]MOŽNOSTI VIDEA[/B][CR][CR]Správa knižnice videí · Možnosti prehrávania videa · Možnosti zobrazenia video súborov[CR]Nastavenie fontu titulkov"
+
+#: id:31402
+msgid "[B]CONFIGURE MUSIC SETTINGS[/B][CR][CR]Manage your music library � Set music playback options � Change music listing options[CR]Setup song submission � Set karaoke options"
+msgstr "[B]MOŽNOSTI HUDBY[/B][CR][CR]Správa knižnice hudby · Možnosti prehrávania hudby · Možnosti zobrazenia hud. súborov[CR]Služby pre odosielanie informácií o prehrávaných skladbách · Nastavenie karaoke"
+
+#: id:31403
+msgid "[B]CONFIGURE PICTURE SETTINGS[/B][CR][CR]Set picture listing options � Configure slideshows"
+msgstr "[B]MOŽNOSTI OBRÁZKOV[/B][CR][CR]Možnosti zobrazenia obrázkov · Konfigurácia prezentácie"
+
+#: id:31404
+msgid "[B]CONFIGURE WEATHER SETTINGS[/B][CR][CR]Set three cities to collect weather information"
+msgstr "[B]MOŽNOSTI POČASIA[/B][CR][CR]Nastavenie oblastí pre predpoveď počasia"
+
+#: id:31406
+msgid "[B]CONFIGURE SYSTEM SETTINGS[/B][CR][CR]Setup and calibrate displays � Configure audio output � Setup remote controls[CR]Set power saving options � Enable debugging � Setup master lock"
+msgstr "[B]MOŽNOSTI SYSTÉMU[/B][CR][CR]Nastavenie a kalibrácia obrazovky · Konfigurácia výstupu zvuku · Nastavenie ovládača[CR]Možnosti úsporného režimu · Ukladanie informácií · Konfigurácia rodičovského zámku"
+
+#: id:31407
+msgid "[B]CONFIGURE SKIN SETTINGS[/B][CR][CR]Setup the Confluence skin � Add and remove home menu items[CR]Change skin backgrounds"
+msgstr "[B]MOŽNOSTI VZHĽADU[/B][CR][CR]Prispôsobenie vzhľadu Confluence · Správa sekcií na domovskej stránke[CR]Nastavenia pozadí vzhľadu"
+
+#: id:31408
+msgid "[B]CONFIGURE ADD-ONS[/B][CR][CR]Manage your installed Add-ons � Browse for and install Add-ons from xbmc.org[CR]Modify Add-on settings"
+msgstr "[B]MOŽNOSTI DOPLNKOV[/B][CR][CR]Správa nainštalovaných doplnkov · Vyhľadávanie a inštalácia doplnkov z xbmc.org[CR]Nastavenie doplnkov"
+
+#: id:31409
+msgid "[B]CONFIGURE SERVICE SETTINGS[/B][CR][CR]Setup control of XBMC via UPnP and HTTP � Configure file sharing[CR]Enable Zeroconf � Configure AirPlay"
+msgstr ""
+
+#: id:31421
+msgid "Select your XBMC user Profile[CR]to login and continue"
+msgstr "Prihlásenie užívateľa[CR]Pokračujte výberom profilu"
+
+#: id:31900
+msgid "Weather Maps"
+msgstr "Mapy Počasia"
+
+#: id:31901
+msgid "36 Hour Forecast"
+msgstr "36 Hodinová Predpoveď"
+
+#: id:31902
+msgid "Hourly Forecast"
+msgstr "Hodinová Predpoveď"
+
+#: id:31903
+msgid "Weekend Forecast"
+msgstr "Predpoveď na víkend"
+
+#: id:31904
+msgid "10 Day Forecast"
+msgstr "Predpoveď na 10 dní"
+
+#: id:31905
+msgid "Forecast"
+msgstr "Predpoveď"
+
+#: id:31906
+msgid "Maps & Video"
+msgstr "Mapy & Video"
+
+#: id:31907
+msgid "Video Forecast [COLOR=grey2](Fullscreen Playback)[/COLOR]"
+msgstr "Video Predpoveď [COLOR=grey2](Prehrávanie na celej obrazovke)[/COLOR]"
+
+#: id:31908
+msgid "Chance of Precipitation"
+msgstr "Šanca zrážok"
+
+#: id:31909
+msgid "Fetching forecast info..."
+msgstr "Zisťujem info o počasí..."
+

--- a/addons/skin.confluence/language/Slovenian/strings.po
+++ b/addons/skin.confluence/language/Slovenian/strings.po
@@ -1,0 +1,576 @@
+# Converted from xbmc strings.xml with xbmc-xml2po (by Team-XBMC)
+msgid ""
+msgstr ""
+"Project-Id-Version: xbmc.skin.confluence-FRODO_GIT953c09c336\n"
+"Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
+"POT-Creation-Date: 2012-04-09 18:03+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE\n"
+"Language: sl\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: id:31000
+msgid "Change Your"
+msgstr "Prilagodite vaše"
+
+#: id:31001
+msgid "Love"
+msgstr "Ljubim"
+
+#: id:31002
+msgid "Hate"
+msgstr "Sovražim"
+
+#: id:31003
+msgid "Power Options"
+msgstr "Zapusti"
+
+#: id:31004
+msgid "Working..."
+msgstr "Delam..."
+
+#: id:31005
+msgid "Hide Information"
+msgstr "Skrij informacije"
+
+#: id:31006
+msgid "View Options"
+msgstr "Možnosti pogleda"
+
+#: id:31007
+msgid "Plugins"
+msgstr "Vtičniki"
+
+#: id:31008
+msgid "Fullscreen"
+msgstr "Celozaslonski način"
+
+#: id:31020
+msgctxt "Auto context with id 31020"
+msgid "Recently Added"
+msgstr "Nazadnje dodano"
+
+#: id:31021
+msgid "Video - Files"
+msgstr "Video - Datoteke"
+
+#: id:31022
+msgid "Music - Files"
+msgstr "Glasba - Datoteke"
+
+#: id:31023
+msgid "Playing"
+msgstr "Predvajam"
+
+#: id:31024
+msgid "Page"
+msgstr "Stran"
+
+#: id:31025
+msgid "Items"
+msgstr "Elementi"
+
+#: id:31026
+msgid "Misc Options"
+msgstr "Razne možnosti"
+
+#: id:31027
+msgid "Location"
+msgstr "Lokacija"
+
+#: id:31028
+msgid "Poster Wrap"
+msgstr "Plakati"
+
+#: id:31029
+msgid "Fanart"
+msgstr "Ozadja"
+
+#: id:31030
+msgid "Full list"
+msgstr "Celoten seznam"
+
+#: id:31031
+msgid "Pic Thumbs"
+msgstr "Sličice"
+
+#: id:31032
+msgid "Image Wrap"
+msgstr "Slike"
+
+#: id:31033
+msgid "Info"
+msgstr "Informacije"
+
+#: id:31040
+msgid "Now Playing"
+msgstr "Trenutno predvajam"
+
+#: id:31042
+msgid "PLAYING"
+msgstr "PREDVAJANJE"
+
+#: id:31043
+msgid "PAUSED"
+msgstr "PREKINJENO"
+
+#: id:31044
+msgid "FAST FORWARD"
+msgstr "PREVIJANJE NAPREJ"
+
+#: id:31045
+msgid "REWIND"
+msgstr "NAZAJ"
+
+#: id:31046
+msgid "Audio Properties"
+msgstr "Zvočne lastnosti"
+
+#: id:31047
+msgid "Current Preset"
+msgstr "Trenutna prednastavitev"
+
+#: id:31048
+msgid "Visualization Presets"
+msgstr "Prednastavitve vizualizacije"
+
+#: id:31049
+msgid "End Time"
+msgstr "Čas zaključka"
+
+#: id:31050
+msgid "Sort: Ascending"
+msgstr "Razvrsti: Naraščajoče"
+
+#: id:31051
+msgid "Sort: Descending"
+msgstr "Razvrsti: Padajoče"
+
+#: id:31055
+msgid "Open playlist"
+msgstr "Odpri predvajalni seznam"
+
+#: id:31056
+msgid "Save playlist"
+msgstr "Shrani predvajalni seznam"
+
+#: id:31057
+msgid "Close playlist"
+msgstr "Zapri predvajalni seznam"
+
+#: id:31058
+msgid "System music files"
+msgstr "Sistemske glasbene datoteke"
+
+#: id:31059
+msgid "Current playlist"
+msgstr "Trenutni predvajalni seznam"
+
+#: id:31060
+msgid "This file is stacked, select the part you want to play from."
+msgstr "Ta datoteka je združena. Izberite del za predvajanje."
+
+#: id:31061
+msgid "Current Selected"
+msgstr "Trenutno izbrano"
+
+#: id:31101
+msgid "Home screen options"
+msgstr "Nastavitve domačega okna"
+
+#: id:31102
+msgid "Background"
+msgstr "Ozadje"
+
+#: id:31103
+msgid "Show \"Paused\" in picture slide show"
+msgstr "Prikaži \"Prekinjeno\" v projekciji slik"
+
+#: id:31104
+msgid "Play Trailers in a window [COLOR=grey3](Video Information Dialog Only)[/COLOR]"
+msgstr "Predvajaj napovednike v oknu [COLOR=grey3](Samo okno z informacijami o videu)[/COLOR]"
+
+#: id:31105
+msgid "\"Videos\" button always goes to video \"Files\""
+msgstr "\"Video\" gumb je vedno v \"Datoteke\" za video"
+
+#: id:31106
+msgid "Miscellaneous options"
+msgstr "Razne nastavitve"
+
+#: id:31107
+msgid "Hide Flagging read from video filenames [COLOR=grey3](Blu-ray, HD-DVD)[/COLOR]"
+msgstr "Skrij oznake videa, prebrane iz datotek [COLOR=grey3](Blu-ray, HD-DVD)[/COLOR]"
+
+#: id:31108
+msgid "Hide Main Menu Buttons"
+msgstr "Skrij gumbe v glavnem menuju"
+
+#: id:31109
+msgid "Media backgrounds"
+msgstr "Ozadja medijev"
+
+#: id:31110
+msgid "Edit Background for Media Type"
+msgstr "Uredi ozadje za tip medija"
+
+#: id:31111
+msgid "Hide"
+msgstr "Skrij"
+
+#: id:31112
+msgid "Options"
+msgstr "Možnosti"
+
+#: id:31113
+msgid "Single Image"
+msgstr "Ena slika"
+
+#: id:31114
+msgid "Multi Image"
+msgstr "Več slik"
+
+#: id:31115
+msgid "Customizer"
+msgstr "Poljubno"
+
+#: id:31117
+msgid "Show Recently added Videos"
+msgstr "Prikaži nazadnje dodane videe"
+
+#: id:31118
+msgid "Home Page Programs Submenu"
+msgstr "Podmenu programov na domačem oknu"
+
+#: id:31119
+msgid "Hide Background Fanart"
+msgstr "Skrij ozadja"
+
+#: id:31120
+msgid "BUTTON LABEL"
+msgstr "OZNAKA GUMBA"
+
+#: id:31122
+msgid "Weather Page"
+msgstr "Vreme"
+
+#: id:31123
+msgid "Use \"Posters\" instead of \"Banners\" for TV Shows"
+msgstr "Uporabi \"Plakate\" namesto \"Transparentov\" za TV serije"
+
+#: id:31124
+msgid "Show Background \"Now Playing\" Video"
+msgstr "Prikaži \"Trenutno predvajam\" video v ozadju"
+
+#: id:31125
+msgid "Show Background \"Now Playing\" Visualization"
+msgstr "Prikaži \"Trenutno predvajam\" vizualizacijo v ozadju"
+
+#: id:31126
+msgid "Play TV theme songs in video library (TvTunes add-on)"
+msgstr "Predvajaj uvodne pesmi TV serij v knjižnici (dodatek TvTunes)"
+
+#: id:31127
+msgid "TvTunes"
+msgstr "TvTunes"
+
+#: id:31128
+msgid "Lyrics"
+msgstr "Besedilo pesmi"
+
+#: id:31132
+msgid "Lyrics Add-on"
+msgstr "Dodatek besedil pesmi"
+
+#: id:31133
+msgid "Subtitle Add-on"
+msgstr "Dodatek podnapisov"
+
+#: id:31134
+msgid "Home Page Videos Submenu"
+msgstr "Podmenu videjev na domačem oknu"
+
+#: id:31135
+msgid "Home Page Music Submenu"
+msgstr "Podmenu glasbe na domačem oknu"
+
+#: id:31136
+msgid "Home Page Pictures Submenu"
+msgstr "Podmenu slik na domačem oknu"
+
+#: id:31140
+msgid "Music OSD"
+msgstr "Glasbeni OSD"
+
+#: id:31141
+msgid "Video OSD"
+msgstr "Video OSD"
+
+#: id:31200
+msgid "Shortcuts"
+msgstr "Bližnjice"
+
+#: id:31201
+msgid "Categories"
+msgstr "Kategorije"
+
+#: id:31202
+msgid "Show Cast"
+msgstr "Prikaži igralce"
+
+#: id:31203
+msgid "Choose Your Song"
+msgstr "Izberite svojo pesem"
+
+#: id:31204
+msgid "Section Links"
+msgstr "Povezave"
+
+#: id:31205
+msgid "Lyrics Source"
+msgstr "Vir besedila pesmi"
+
+#: id:31300
+msgid "Current Temp"
+msgstr "Temperatura"
+
+#: id:31301
+msgid "Last Updated"
+msgstr "Zadnja posodobitev"
+
+#: id:31302
+msgid "Menu"
+msgstr "Menu"
+
+#: id:31303
+msgid "Data provider"
+msgstr "Ponudnik"
+
+#: id:31304
+msgid "Picture"
+msgstr "Slika"
+
+#: id:31305
+msgid "No Disc Media Detected"
+msgstr "Ni zaznanega diska"
+
+#: id:31306
+msgid "Eject"
+msgstr "Izvrzi"
+
+#: id:31307
+msgid "Hide Fanart"
+msgstr "Skrij ozadje"
+
+#: id:31308
+msgid "Movie Details"
+msgstr "Podrobnosti o filmu"
+
+#: id:31309
+msgid "Memory Used:"
+msgstr "Uporabljen pomnilnik:"
+
+#: id:31310
+msgid "Track Number"
+msgstr "Številka pesmi"
+
+#: id:31311
+msgid "Fanart image[CR][CR]Unavailable[CR][CR] Click button to set"
+msgstr "Ozadje[CR][CR]Ni na voljo[CR][CR] Kliknite na gumb in ga nastavite"
+
+#: id:31312
+msgid "Current Scraper"
+msgstr "Trenutni ponudnik"
+
+#: id:31313
+msgid "Choose a Scraper"
+msgstr "Izberi ponudnika"
+
+#: id:31314
+msgid "Content Scanning Options"
+msgstr "Možnosti iskanja"
+
+#: id:31315
+msgid "Basic"
+msgstr "Osnovno"
+
+#: id:31317
+msgid "Set Fanart Path"
+msgstr "Nastavi pot ozadij"
+
+#: id:31318
+msgid "Small Fanart"
+msgstr "Majhno ozadje"
+
+#: id:31319
+msgid "Selected Profile"
+msgstr "Izbran profil"
+
+#: id:31320
+msgid "Last Logged In"
+msgstr "Zadnja prijava"
+
+#: id:31321
+msgid "Karaoke Song Selector"
+msgstr "Izbirnik pesmi za karaoke"
+
+#: id:31322
+msgid "Aired"
+msgstr "Predvajano"
+
+#: id:31323
+msgid "Latest Movies"
+msgstr "Najnovejši filmi"
+
+#: id:31324
+msgid "Latest Episodes"
+msgstr "Najnovejše epizode"
+
+#: id:31325
+msgid "Playlist Options"
+msgstr "Možnosti predvajalnega seznama"
+
+#: id:31326
+msgid "Created"
+msgstr "Ustvarjeno"
+
+#: id:31327
+msgid "Resolution"
+msgstr "Ločljivost"
+
+#: id:31328
+msgctxt "Auto context with id 31328"
+msgid "Recently Added"
+msgstr "Nazadnje dodano"
+
+#: id:31329
+msgid "[B]Timer set![/B] [COLOR=grey2] - System auto shutdown in[/COLOR]"
+msgstr "[B]Zakasnitev nastavljena![/B] [COLOR=grey2] - Sistem se bo izključil po[/COLOR]"
+
+#: id:31330
+msgid "Click button to play[CR][CR]Movie trailer"
+msgstr "Kliknite gumb za predvajanje[CR][CR]Napovednika filma"
+
+#: id:31331
+msgid "Album Details"
+msgstr "Podrobnosti o albumu"
+
+#: id:31351
+msgid "Pause"
+msgstr "Prekini"
+
+#: id:31352
+msgid "Stop"
+msgstr "Ustavi"
+
+#: id:31353
+msgid "Fast Forward"
+msgstr "Previj naprej"
+
+#: id:31354
+msgid "Rewind"
+msgstr "Nazaj"
+
+#: id:31355
+msgid "Movie menu"
+msgstr "Filmski menu"
+
+#: id:31356
+msgid "Download Subtitles"
+msgstr "Prenesi podnapise"
+
+#: id:31390
+msgid "Skin default"
+msgstr "Privzeto"
+
+#: id:31391
+msgid "Skin default with no Caps"
+msgstr "Privzeto brez velikih začetnic"
+
+#: id:31392
+msgid "Arial based"
+msgstr "Arial"
+
+#: id:31400
+msgid "[B]CONFIGURE APPEARANCE SETTINGS[/B][CR][CR]Change the skin � Set language and region � Change file listing options[CR]Set up a screensaver"
+msgstr "[B]PRILAGODITE NASTAVITVE IZGLEDA[/B][CR][CR]Zamenjajte preobleko • Določite jezik in regijo • Spremenite možnosti seznamov[CR]Nastavite ohranjevalnik zaslona"
+
+#: id:31401
+msgid "[B]CONFIGURE VIDEO SETTINGS[/B][CR][CR]Manage your video library � Set video playback options � Change video listing options[CR]Set subtitle fonts"
+msgstr "[B]PRILAGODITE NASTAVITVE VIDEA[/B][CR][CR]Upravljajte s knjižnico videa • Nastavite možnosti predvajanja videa[CR]Spremenite možnosti seznamov videa • Določite pisavo podnapisov"
+
+#: id:31402
+msgid "[B]CONFIGURE MUSIC SETTINGS[/B][CR][CR]Manage your music library � Set music playback options � Change music listing options[CR]Setup song submission � Set karaoke options"
+msgstr "[B]PRILAGODITE NASTAVITVE GLASBE[/B][CR][CR]Upravljajte s knjižnico glasbe • Nastavite možnosti predvajanja glasbe[CR]Spremenite možnosti seznamov glasbe • Nastavite objavo pesmi • Nastavite karaoke"
+
+#: id:31403
+msgid "[B]CONFIGURE PICTURE SETTINGS[/B][CR][CR]Set picture listing options � Configure slideshows"
+msgstr "[B]PRILAGODITE NASTAVITVE SLIK[/B][CR][CR]Spremenite možnosti seznamov slik • Nastavite projekcije slik"
+
+#: id:31404
+msgid "[B]CONFIGURE WEATHER SETTINGS[/B][CR][CR]Set three cities to collect weather information"
+msgstr "[B]PRILAGODITE NASTAVITVE VREMENA[/B][CR][CR]Izberite tri mesta, za katere bo na voljo vremenska napoved"
+
+#: id:31406
+msgid "[B]CONFIGURE SYSTEM SETTINGS[/B][CR][CR]Setup and calibrate displays � Configure audio output � Setup remote controls[CR]Set power saving options � Enable debugging � Setup master lock"
+msgstr "[B]PRILAGODITE NASTAVITVE SISTEMA[/B][CR][CR]Nastavite in prilagodite zaslon • Nastavite zvočni izhod • Nastavite oddaljeno upravljanje[CR]Nastavite varčevanje z energijo • Vključite razhroščevanje • Določite glavno geslo"
+
+#: id:31407
+msgid "[B]CONFIGURE SKIN SETTINGS[/B][CR][CR]Setup the Confluence skin � Add and remove home menu items[CR]Change skin backgrounds"
+msgstr "[B]PRILAGODITE NASTAVITVE PREOBLEKE[/B][CR][CR]Nastavite preobleko Confluence • Dodajte in odstranite elemente na domačem oknu[CR]Spremenite ozadja preobleke"
+
+#: id:31408
+msgid "[B]CONFIGURE ADD-ONS[/B][CR][CR]Manage your installed Add-ons � Browse for and install Add-ons from xbmc.org[CR]Modify Add-on settings"
+msgstr "[B]PRILAGODITE DODATKE[/B][CR][CR]Upravljajte nameščene dodatke • Brskajte in namestite nove dodatke iz xbmc.org[CR]Nastavite dodatke"
+
+#: id:31409
+msgid "[B]CONFIGURE SERVICE SETTINGS[/B][CR][CR]Setup control of XBMC via UPnP and HTTP � Configure file sharing[CR]Enable Zeroconf � Configure AirPlay"
+msgstr ""
+
+#: id:31421
+msgid "Select your XBMC user Profile[CR]to login and continue"
+msgstr "Izberite vaš XBMC uporabniški profil[CR]za prijavo in nadaljujte"
+
+#: id:31900
+msgid "Weather Maps"
+msgstr "Vremenska slika"
+
+#: id:31901
+msgid "36 Hour Forecast"
+msgstr "36-urna napoved"
+
+#: id:31902
+msgid "Hourly Forecast"
+msgstr "Napoved za vsako uro"
+
+#: id:31903
+msgid "Weekend Forecast"
+msgstr "Tedenska napoved"
+
+#: id:31904
+msgid "10 Day Forecast"
+msgstr "10-dnevna napoved"
+
+#: id:31905
+msgid "Forecast"
+msgstr "Napoved"
+
+#: id:31906
+msgid "Maps & Video"
+msgstr "Mape & Video"
+
+#: id:31907
+msgid "Video Forecast [COLOR=grey2](Fullscreen Playback)[/COLOR]"
+msgstr "Video napoved [COLOR=grey2](celozaslonsko predvajanje)[/COLOR]"
+
+#: id:31908
+msgid "Chance of Precipitation"
+msgstr "Možnost padavin"
+
+#: id:31909
+msgid "Fetching forecast info..."
+msgstr "Prenašam vremenske informacije..."
+

--- a/addons/skin.confluence/language/Spanish/strings.po
+++ b/addons/skin.confluence/language/Spanish/strings.po
@@ -1,0 +1,576 @@
+# Converted from xbmc strings.xml with xbmc-xml2po (by Team-XBMC)
+msgid ""
+msgstr ""
+"Project-Id-Version: xbmc.skin.confluence-FRODO_GIT953c09c336\n"
+"Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
+"POT-Creation-Date: 2012-04-09 18:03+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE\n"
+"Language: es\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: id:31000
+msgid "Change Your"
+msgstr "Cambiar tus"
+
+#: id:31001
+msgid "Love"
+msgstr "Me gusta"
+
+#: id:31002
+msgid "Hate"
+msgstr "No me gusta"
+
+#: id:31003
+msgid "Power Options"
+msgstr "Opciones de energía"
+
+#: id:31004
+msgid "Working..."
+msgstr "Cargando..."
+
+#: id:31005
+msgid "Hide Information"
+msgstr "Ocultar INFO"
+
+#: id:31006
+msgid "View Options"
+msgstr "Opciones de vista"
+
+#: id:31007
+msgid "Plugins"
+msgstr "Plugins"
+
+#: id:31008
+msgid "Fullscreen"
+msgstr "Pantalla completa"
+
+#: id:31020
+msgctxt "Auto context with id 31020"
+msgid "Recently Added"
+msgstr "Añadido recientemente"
+
+#: id:31021
+msgid "Video - Files"
+msgstr "Archivos - vídeo"
+
+#: id:31022
+msgid "Music - Files"
+msgstr "Archivos - música"
+
+#: id:31023
+msgid "Playing"
+msgstr "Reproduciendo"
+
+#: id:31024
+msgid "Page"
+msgstr "Página"
+
+#: id:31025
+msgid "Items"
+msgstr "Elementos"
+
+#: id:31026
+msgid "Misc Options"
+msgstr "Opciones varias"
+
+#: id:31027
+msgid "Location"
+msgstr "Ubicación"
+
+#: id:31028
+msgid "Poster Wrap"
+msgstr "Flujo de póster"
+
+#: id:31029
+msgid "Fanart"
+msgstr "Fanart"
+
+#: id:31030
+msgid "Full list"
+msgstr "Lista completa"
+
+#: id:31031
+msgid "Pic Thumbs"
+msgstr "Miniaturas"
+
+#: id:31032
+msgid "Image Wrap"
+msgstr "Flujo de imagen"
+
+#: id:31033
+msgid "Info"
+msgstr "Info"
+
+#: id:31040
+msgid "Now Playing"
+msgstr "Reproduciendo ahora"
+
+#: id:31042
+msgid "PLAYING"
+msgstr "REPRODUCIENDO"
+
+#: id:31043
+msgid "PAUSED"
+msgstr "PAUSA"
+
+#: id:31044
+msgid "FAST FORWARD"
+msgstr "AVANCE RAPIDO"
+
+#: id:31045
+msgid "REWIND"
+msgstr "RETROCESO"
+
+#: id:31046
+msgid "Audio Properties"
+msgstr "Propiedades de audio"
+
+#: id:31047
+msgid "Current Preset"
+msgstr "Opciones preestablecidas actuales"
+
+#: id:31048
+msgid "Visualization Presets"
+msgstr "Visualización preestablecida"
+
+#: id:31049
+msgid "End Time"
+msgstr "Hora de finalización"
+
+#: id:31050
+msgid "Sort: Ascending"
+msgstr "Ordenar: Ascendente"
+
+#: id:31051
+msgid "Sort: Descending"
+msgstr "Ordenar: Descendente"
+
+#: id:31055
+msgid "Open playlist"
+msgstr "Abrir lista de reproducción"
+
+#: id:31056
+msgid "Save playlist"
+msgstr "Guardar lista de reproducción"
+
+#: id:31057
+msgid "Close playlist"
+msgstr "Cerrar lista de reproducción"
+
+#: id:31058
+msgid "System music files"
+msgstr "Sistema de archivos de música"
+
+#: id:31059
+msgid "Current playlist"
+msgstr "Lista de reproducción actual"
+
+#: id:31060
+msgid "This file is stacked, select the part you want to play from."
+msgstr "Este archivo está agrupado, seleccione la parte que desee reproducir."
+
+#: id:31061
+msgid "Current Selected"
+msgstr "Seleccionado"
+
+#: id:31101
+msgid "Home screen options"
+msgstr "Opciones de la pantalla principal"
+
+#: id:31102
+msgid "Background"
+msgstr "Fondo"
+
+#: id:31103
+msgid "Show \"Paused\" in picture slide show"
+msgstr "Ver \"Pausa\" en modo presentación de imágenes"
+
+#: id:31104
+msgid "Play Trailers in a window [COLOR=grey3](Video Information Dialog Only)[/COLOR]"
+msgstr "Reproducir trailers en ventana [COLOR=grey3](Sólo diálogo de información de vídeo)[/COLOR]"
+
+#: id:31105
+msgid "\"Videos\" button always goes to video \"Files\""
+msgstr ""
+
+#: id:31106
+msgid "Miscellaneous options"
+msgstr "Opciones de miscelánea"
+
+#: id:31107
+msgid "Hide Flagging read from video filenames [COLOR=grey3](Blu-ray, HD-DVD)[/COLOR]"
+msgstr "Ocultar marcas de lectura de archivos de vídeo [COLOR=grey3](Blu-ray, HD-DVD)[/COLOR]"
+
+#: id:31108
+msgid "Hide Main Menu Buttons"
+msgstr "Ocultar botones de la pantalla principal"
+
+#: id:31109
+msgid "Media backgrounds"
+msgstr "Fondos de medio"
+
+#: id:31110
+msgid "Edit Background for Media Type"
+msgstr "Editar fondo para el tipo de medio"
+
+#: id:31111
+msgid "Hide"
+msgstr "Ocultar"
+
+#: id:31112
+msgid "Options"
+msgstr "Opciones"
+
+#: id:31113
+msgid "Single Image"
+msgstr "Una imagen"
+
+#: id:31114
+msgid "Multi Image"
+msgstr "Multi-imagen"
+
+#: id:31115
+msgid "Customizer"
+msgstr "Personalizado"
+
+#: id:31117
+msgid "Show Recently added Videos"
+msgstr "Mostrar últimos vídeos añadidos"
+
+#: id:31118
+msgid "Home Page Programs Submenu"
+msgstr "Submenús de programas de la pantalla principal"
+
+#: id:31119
+msgid "Hide Background Fanart"
+msgstr "Ocultar el Fanart del fondo"
+
+#: id:31120
+msgid "BUTTON LABEL"
+msgstr "ETIQUETA DEL BOTON"
+
+#: id:31122
+msgid "Weather Page"
+msgstr "El Clima"
+
+#: id:31123
+msgid "Use \"Posters\" instead of \"Banners\" for TV Shows"
+msgstr "Usar \"Posters\" en lugar de \"Banners\" para las Series de TV"
+
+#: id:31124
+msgid "Show Background \"Now Playing\" Video"
+msgstr "Mostrar vídeo en reproducción en el fondo"
+
+#: id:31125
+msgid "Show Background \"Now Playing\" Visualization"
+msgstr "Mostrar visualización en el fondo"
+
+#: id:31126
+msgid "Play TV theme songs in video library (TvTunes add-on)"
+msgstr ""
+
+#: id:31127
+msgid "TvTunes"
+msgstr ""
+
+#: id:31128
+msgid "Lyrics"
+msgstr "Letras"
+
+#: id:31132
+msgid "Lyrics Add-on"
+msgstr "Add-on para letras"
+
+#: id:31133
+msgid "Subtitle Add-on"
+msgstr "Add-on para subtitulos"
+
+#: id:31134
+msgid "Home Page Videos Submenu"
+msgstr "Submenú de vídeos de la pantalla principal"
+
+#: id:31135
+msgid "Home Page Music Submenu"
+msgstr "Submenú de música de la pantalla principal"
+
+#: id:31136
+msgid "Home Page Pictures Submenu"
+msgstr "Submenú de imágenes de la pantalla principal"
+
+#: id:31140
+msgid "Music OSD"
+msgstr "OSD de música"
+
+#: id:31141
+msgid "Video OSD"
+msgstr "OSD de vídeo"
+
+#: id:31200
+msgid "Shortcuts"
+msgstr "Accesos directos"
+
+#: id:31201
+msgid "Categories"
+msgstr "Categorías"
+
+#: id:31202
+msgid "Show Cast"
+msgstr "Mostrar reparto"
+
+#: id:31203
+msgid "Choose Your Song"
+msgstr "Elige tu canción"
+
+#: id:31204
+msgid "Section Links"
+msgstr "Sección de links"
+
+#: id:31205
+msgid "Lyrics Source"
+msgstr "Fuente para letras"
+
+#: id:31300
+msgid "Current Temp"
+msgstr "Temperatura"
+
+#: id:31301
+msgid "Last Updated"
+msgstr "Última actualización"
+
+#: id:31302
+msgid "Menu"
+msgstr "Menú"
+
+#: id:31303
+msgid "Data provider"
+msgstr "Proveedor de Datos"
+
+#: id:31304
+msgid "Picture"
+msgstr "Imagen"
+
+#: id:31305
+msgid "No Disc Media Detected"
+msgstr "Ningún disco detectado"
+
+#: id:31306
+msgid "Eject"
+msgstr "Expulsar"
+
+#: id:31307
+msgid "Hide Fanart"
+msgstr "Ocultar fanarts"
+
+#: id:31308
+msgid "Movie Details"
+msgstr "Detalles de la película"
+
+#: id:31309
+msgid "Memory Used:"
+msgstr "Memoria usada:"
+
+#: id:31310
+msgid "Track Number"
+msgstr "Pista número"
+
+#: id:31311
+msgid "Fanart image[CR][CR]Unavailable[CR][CR] Click button to set"
+msgstr "Imagen fanart[CR][CR]no disponible[CR][CR]Click para elegir"
+
+#: id:31312
+msgid "Current Scraper"
+msgstr "Scraper actual"
+
+#: id:31313
+msgid "Choose a Scraper"
+msgstr "Elige un scraper"
+
+#: id:31314
+msgid "Content Scanning Options"
+msgstr "Opciones de escanéo de contenido"
+
+#: id:31315
+msgid "Basic"
+msgstr "Básico"
+
+#: id:31317
+msgid "Set Fanart Path"
+msgstr "Selecciona ruta del fanart"
+
+#: id:31318
+msgid "Small Fanart"
+msgstr "Fanart pequeño"
+
+#: id:31319
+msgid "Selected Profile"
+msgstr "Perfil seleccionado"
+
+#: id:31320
+msgid "Last Logged In"
+msgstr "Última visita el"
+
+#: id:31321
+msgid "Karaoke Song Selector"
+msgstr "Selector de canción de karaoke"
+
+#: id:31322
+msgid "Aired"
+msgstr "Estrenado"
+
+#: id:31323
+msgid "Latest Movies"
+msgstr "Últimas películas"
+
+#: id:31324
+msgid "Latest Episodes"
+msgstr "Últimos episodios"
+
+#: id:31325
+msgid "Playlist Options"
+msgstr "Opciones de lista de reproducción"
+
+#: id:31326
+msgid "Created"
+msgstr "Creado"
+
+#: id:31327
+msgid "Resolution"
+msgstr "Resolución"
+
+#: id:31328
+msgctxt "Auto context with id 31328"
+msgid "Recently Added"
+msgstr "Recientes"
+
+#: id:31329
+msgid "[B]Timer set![/B] [COLOR=grey2] - System auto shutdown in[/COLOR]"
+msgstr "[B]Temporizador[/B] [COLOR=grey2] - El sistema se apagará en[/COLOR]"
+
+#: id:31330
+msgid "Click button to play[CR][CR]Movie trailer"
+msgstr "Click para reproducir[CR][CR]trailer de película"
+
+#: id:31331
+msgid "Album Details"
+msgstr "Detalles del Album"
+
+#: id:31351
+msgid "Pause"
+msgstr "Pausar"
+
+#: id:31352
+msgid "Stop"
+msgstr "Detener"
+
+#: id:31353
+msgid "Fast Forward"
+msgstr "Avance rápido"
+
+#: id:31354
+msgid "Rewind"
+msgstr "Retroceder"
+
+#: id:31355
+msgid "Movie menu"
+msgstr "Menú película"
+
+#: id:31356
+msgid "Download Subtitles"
+msgstr "Descargar subtítulos"
+
+#: id:31390
+msgid "Skin default"
+msgstr "Por defecto"
+
+#: id:31391
+msgid "Skin default with no Caps"
+msgstr "Por defecto sin Mayúsculas"
+
+#: id:31392
+msgid "Arial based"
+msgstr "Basada en Arial"
+
+#: id:31400
+msgid "[B]CONFIGURE APPEARANCE SETTINGS[/B][CR][CR]Change the skin � Set language and region � Change file listing options[CR]Set up a screensaver"
+msgstr "[B]Configura las opciones de APARIENCIA[/B][CR][CR]Cambia la skin - Cambia el idioma y la configuración regional - Cambia opciones de listas de archivos[CR]Establece un salvapantallas"
+
+#: id:31401
+msgid "[B]CONFIGURE VIDEO SETTINGS[/B][CR][CR]Manage your video library � Set video playback options � Change video listing options[CR]Set subtitle fonts"
+msgstr "[B]Configura las opciones de VIDEO[/B][CR][CR]Administra su videoteca - Ajusta reproducción de vídeol - Cambia opciones de listas de vídeo[CR]Configura fuentes de subtítulos"
+
+#: id:31402
+msgid "[B]CONFIGURE MUSIC SETTINGS[/B][CR][CR]Manage your music library � Set music playback options � Change music listing options[CR]Setup song submission � Set karaoke options"
+msgstr "[B]Configura las opciones de MUSICA[/B][CR][CR]Administra tu biblioteca musical - Ajusta reproducción de música - Cambia opciones de listas de música[CR[Configura sumisión de canciones - Configura el karaoke"
+
+#: id:31403
+msgid "[B]CONFIGURE PICTURE SETTINGS[/B][CR][CR]Set picture listing options � Configure slideshows"
+msgstr "[B]Configura las opciones de IMAGEN[/B][CR][CR]Cambia opciones de listas de imágenes - Configura presentación de diapositivas"
+
+#: id:31404
+msgid "[B]CONFIGURE WEATHER SETTINGS[/B][CR][CR]Set three cities to collect weather information"
+msgstr "[B]Configura las opciones de EL TIEMPO[/B][CR][CR]Establece tres ciudades para información metereológica"
+
+#: id:31406
+msgid "[B]CONFIGURE SYSTEM SETTINGS[/B][CR][CR]Setup and calibrate displays � Configure audio output � Setup remote controls[CR]Set power saving options � Enable debugging � Setup master lock"
+msgstr "[B]Configura las opciones de SISTEMA[/B][CR][CR]Configura y calibra la pantalla - Configura salida de audio - Configura mandos a distancia[CR]Establece las opciones de ahorro de energía - Habilita depuración de errores - Configura bloqueo maestro"
+
+#: id:31407
+msgid "[B]CONFIGURE SKIN SETTINGS[/B][CR][CR]Setup the Confluence skin � Add and remove home menu items[CR]Change skin backgrounds"
+msgstr "[B]Configura las opciones de la SKIN[/B][CR][CR]Configura Confluence - Añade y elimina elementos del menú Inicio[CR]Cambia los fondos de la skin"
+
+#: id:31408
+msgid "[B]CONFIGURE ADD-ONS[/B][CR][CR]Manage your installed Add-ons � Browse for and install Add-ons from xbmc.org[CR]Modify Add-on settings"
+msgstr "[B]Configura los ADD-ONS[/B][CR][CR]Administra tus addons instalados · Busca e instala addons desde xbmc.org[CR]Modifica la configuración de los addons"
+
+#: id:31409
+msgid "[B]CONFIGURE SERVICE SETTINGS[/B][CR][CR]Setup control of XBMC via UPnP and HTTP � Configure file sharing[CR]Enable Zeroconf � Configure AirPlay"
+msgstr ""
+
+#: id:31421
+msgid "Select your XBMC user Profile[CR]to login and continue"
+msgstr "Seleccione su perfil de usuario de XBMC[CR]para ingresar y continuar"
+
+#: id:31900
+msgid "Weather Maps"
+msgstr "Mapas de clima"
+
+#: id:31901
+msgid "36 Hour Forecast"
+msgstr "Pronóstico de 36 hs"
+
+#: id:31902
+msgid "Hourly Forecast"
+msgstr "Pronóstico por hora"
+
+#: id:31903
+msgid "Weekend Forecast"
+msgstr "Pronóstico semanal"
+
+#: id:31904
+msgid "10 Day Forecast"
+msgstr "Pronóstico de 10 días"
+
+#: id:31905
+msgid "Forecast"
+msgstr "Pronóstico"
+
+#: id:31906
+msgid "Maps & Video"
+msgstr "Mapas y video"
+
+#: id:31907
+msgid "Video Forecast [COLOR=grey2](Fullscreen Playback)[/COLOR]"
+msgstr "Pronóstico de video [COLOR=grey2](A pantalla completa)[/COLOR]"
+
+#: id:31908
+msgid "Chance of Precipitation"
+msgstr "Probabilidada de precipitación"
+
+#: id:31909
+msgid "Fetching forecast info..."
+msgstr "Obteniendo información"
+

--- a/addons/skin.confluence/language/Swedish/strings.po
+++ b/addons/skin.confluence/language/Swedish/strings.po
@@ -1,0 +1,576 @@
+# Converted from xbmc strings.xml with xbmc-xml2po (by Team-XBMC)
+msgid ""
+msgstr ""
+"Project-Id-Version: xbmc.skin.confluence-FRODO_GIT953c09c336\n"
+"Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
+"POT-Creation-Date: 2012-04-09 18:03+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE\n"
+"Language: sv\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: id:31000
+msgid "Change Your"
+msgstr "Ändra din"
+
+#: id:31001
+msgid "Love"
+msgstr "Älska"
+
+#: id:31002
+msgid "Hate"
+msgstr "Hata"
+
+#: id:31003
+msgid "Power Options"
+msgstr "Strömalternativ"
+
+#: id:31004
+msgid "Working..."
+msgstr "Arbetar..."
+
+#: id:31005
+msgid "Hide Information"
+msgstr "Dölj INFO"
+
+#: id:31006
+msgid "View Options"
+msgstr "Visa val"
+
+#: id:31007
+msgid "Plugins"
+msgstr "Tillägg"
+
+#: id:31008
+msgid "Fullscreen"
+msgstr "Helskärm"
+
+#: id:31020
+msgctxt "Auto context with id 31020"
+msgid "Recently Added"
+msgstr "Nyligen tillagda"
+
+#: id:31021
+msgid "Video - Files"
+msgstr "Filmer - Filer"
+
+#: id:31022
+msgid "Music - Files"
+msgstr "Musik - Filer"
+
+#: id:31023
+msgid "Playing"
+msgstr "Spelar"
+
+#: id:31024
+msgid "Page"
+msgstr "Sida"
+
+#: id:31025
+msgid "Items"
+msgstr "Objekt"
+
+#: id:31026
+msgid "Misc Options"
+msgstr "Övr. alternativ"
+
+#: id:31027
+msgid "Location"
+msgstr "Plats"
+
+#: id:31028
+msgid "Poster Wrap"
+msgstr "Omslagssvep"
+
+#: id:31029
+msgid "Fanart"
+msgstr "Fanart"
+
+#: id:31030
+msgid "Full list"
+msgstr "Full lista"
+
+#: id:31031
+msgid "Pic Thumbs"
+msgstr "Bildminiatyrer"
+
+#: id:31032
+msgid "Image Wrap"
+msgstr "Bildsvep"
+
+#: id:31033
+msgid "Info"
+msgstr "Info"
+
+#: id:31040
+msgid "Now Playing"
+msgstr "Nu spelas"
+
+#: id:31042
+msgid "PLAYING"
+msgstr "SPELAR"
+
+#: id:31043
+msgid "PAUSED"
+msgstr "PAUSAD"
+
+#: id:31044
+msgid "FAST FORWARD"
+msgstr "SPOLA FRAMÅT"
+
+#: id:31045
+msgid "REWIND"
+msgstr "SPOLA BAKÅT"
+
+#: id:31046
+msgid "Audio Properties"
+msgstr "Ljudegenskaper"
+
+#: id:31047
+msgid "Current Preset"
+msgstr "Nuvarande förval"
+
+#: id:31048
+msgid "Visualization Presets"
+msgstr "Visualiseringsförval"
+
+#: id:31049
+msgid "End Time"
+msgstr "Sluttid"
+
+#: id:31050
+msgid "Sort: Ascending"
+msgstr "Sort: stigande"
+
+#: id:31051
+msgid "Sort: Descending"
+msgstr "Sort: fallande"
+
+#: id:31055
+msgid "Open playlist"
+msgstr "Öppna spellista"
+
+#: id:31056
+msgid "Save playlist"
+msgstr "Spara spellista"
+
+#: id:31057
+msgid "Close playlist"
+msgstr "Stäng spellista"
+
+#: id:31058
+msgid "System music files"
+msgstr "Systemmusikfiler"
+
+#: id:31059
+msgid "Current playlist"
+msgstr "Nuvarande spellista"
+
+#: id:31060
+msgid "This file is stacked, select the part you want to play from."
+msgstr "Denna fil är sammanslagen, välj den del du vill spela."
+
+#: id:31061
+msgid "Current Selected"
+msgstr "Nuvarande vald"
+
+#: id:31101
+msgid "Home screen options"
+msgstr "Hemskärmsalternativ"
+
+#: id:31102
+msgid "Background"
+msgstr "Bakgrund"
+
+#: id:31103
+msgid "Show \"Paused\" in picture slide show"
+msgstr "Visa \"Pausad\" i bildspel"
+
+#: id:31104
+msgid "Play Trailers in a window [COLOR=grey3](Video Information Dialog Only)[/COLOR]"
+msgstr "Spela trailers i ett fönster [COLOR=grey3](Endast i videoinformationsdialogen)[/COLOR]"
+
+#: id:31105
+msgid "\"Videos\" button always goes to video \"Files\""
+msgstr "Videoknappen öppnar alltid videofiler"
+
+#: id:31106
+msgid "Miscellaneous options"
+msgstr "Övriga alternativ"
+
+#: id:31107
+msgid "Hide Flagging read from video filenames [COLOR=grey3](Blu-ray, HD-DVD)[/COLOR]"
+msgstr "Dölj flaggläsning från videofilnamn [COLOR=grey3](Blu-ray, HD-DVD)[/COLOR]"
+
+#: id:31108
+msgid "Hide Main Menu Buttons"
+msgstr "Dölj huvudmenyknappar"
+
+#: id:31109
+msgid "Media backgrounds"
+msgstr "Mediabakgrunder"
+
+#: id:31110
+msgid "Edit Background for Media Type"
+msgstr "Ändra bakgrund för mediatyp"
+
+#: id:31111
+msgid "Hide"
+msgstr "Göm"
+
+#: id:31112
+msgid "Options"
+msgstr "Alternativ"
+
+#: id:31113
+msgid "Single Image"
+msgstr "Solobild"
+
+#: id:31114
+msgid "Multi Image"
+msgstr "Flerbild"
+
+#: id:31115
+msgid "Customizer"
+msgstr "Anpassare"
+
+#: id:31117
+msgid "Show Recently added Videos"
+msgstr "Visa nyligen tillagda filmer"
+
+#: id:31118
+msgid "Home Page Programs Submenu"
+msgstr "Hemsidans undermeny"
+
+#: id:31119
+msgid "Hide Background Fanart"
+msgstr "Dölj bakgrundsfanart"
+
+#: id:31120
+msgid "BUTTON LABEL"
+msgstr "KNAPPETIKETT"
+
+#: id:31122
+msgid "Weather Page"
+msgstr "Vädersida"
+
+#: id:31123
+msgid "Use \"Posters\" instead of \"Banners\" for TV Shows"
+msgstr "Använd omslag istället för banner för TV-serier"
+
+#: id:31124
+msgid "Show Background \"Now Playing\" Video"
+msgstr "Visa bakgrund \"Nu spelas\" filmer"
+
+#: id:31125
+msgid "Show Background \"Now Playing\" Visualization"
+msgstr "Visa bakgrund \"Nu spelas\" visualisering"
+
+#: id:31126
+msgid "Play TV theme songs in video library (TvTunes add-on)"
+msgstr "Spela TV-temasånger i videobiblioteket (TVTunes-tillägg)"
+
+#: id:31127
+msgid "TvTunes"
+msgstr "TvTunes"
+
+#: id:31128
+msgid "Lyrics"
+msgstr "Sångtexter"
+
+#: id:31132
+msgid "Lyrics Add-on"
+msgstr "Sångtextstillägg"
+
+#: id:31133
+msgid "Subtitle Add-on"
+msgstr "Undertextstillägg"
+
+#: id:31134
+msgid "Home Page Videos Submenu"
+msgstr "Hemskärmens videoundermeny"
+
+#: id:31135
+msgid "Home Page Music Submenu"
+msgstr "Hemskärmens musikundermeny"
+
+#: id:31136
+msgid "Home Page Pictures Submenu"
+msgstr "Hemskärmens bildundermeny"
+
+#: id:31140
+msgid "Music OSD"
+msgstr "Musik-OSD"
+
+#: id:31141
+msgid "Video OSD"
+msgstr "Video-OSD"
+
+#: id:31200
+msgid "Shortcuts"
+msgstr "Genvägar"
+
+#: id:31201
+msgid "Categories"
+msgstr "Kategorier"
+
+#: id:31202
+msgid "Show Cast"
+msgstr "Visa rollista"
+
+#: id:31203
+msgid "Choose Your Song"
+msgstr "Välj din låt"
+
+#: id:31204
+msgid "Section Links"
+msgstr "Sektionslänkar"
+
+#: id:31205
+msgid "Lyrics Source"
+msgstr "Sångtextkälla"
+
+#: id:31300
+msgid "Current Temp"
+msgstr "Nuvarande temp"
+
+#: id:31301
+msgid "Last Updated"
+msgstr "Sist uppdaterad"
+
+#: id:31302
+msgid "Menu"
+msgstr "Meny"
+
+#: id:31303
+msgid "Data provider"
+msgstr "Dataleverantör"
+
+#: id:31304
+msgid "Picture"
+msgstr "Bild"
+
+#: id:31305
+msgid "No Disc Media Detected"
+msgstr "Ingen diskmedia upptäckt"
+
+#: id:31306
+msgid "Eject"
+msgstr "Mata ut"
+
+#: id:31307
+msgid "Hide Fanart"
+msgstr "Dölj fanart"
+
+#: id:31308
+msgid "Movie Details"
+msgstr "Filmdetaljer"
+
+#: id:31309
+msgid "Memory Used:"
+msgstr "Använt minne:"
+
+#: id:31310
+msgid "Track Number"
+msgstr "Spårnummer"
+
+#: id:31311
+msgid "Fanart image[CR][CR]Unavailable[CR][CR] Click button to set"
+msgstr "Fanart-bild[CR][CR]Inte Tillgänglig[CR][CR]Klicka på knappen för att ange"
+
+#: id:31312
+msgid "Current Scraper"
+msgstr "Nuvarande skrapa"
+
+#: id:31313
+msgid "Choose a Scraper"
+msgstr "Välj en skrapa"
+
+#: id:31314
+msgid "Content Scanning Options"
+msgstr "Innehållsskrapealternativ"
+
+#: id:31315
+msgid "Basic"
+msgstr "Grundläggande"
+
+#: id:31317
+msgid "Set Fanart Path"
+msgstr "Sätt fanartsökväg"
+
+#: id:31318
+msgid "Small Fanart"
+msgstr "Liten fanart"
+
+#: id:31319
+msgid "Selected Profile"
+msgstr "Vald profil"
+
+#: id:31320
+msgid "Last Logged In"
+msgstr "Sist inloggad"
+
+#: id:31321
+msgid "Karaoke Song Selector"
+msgstr "Karaoke-låtväljare"
+
+#: id:31322
+msgid "Aired"
+msgstr "Sänt"
+
+#: id:31323
+msgid "Latest Movies"
+msgstr "Senaste filmerna"
+
+#: id:31324
+msgid "Latest Episodes"
+msgstr "Senaste avsnitten"
+
+#: id:31325
+msgid "Playlist Options"
+msgstr "Spellistsalternativ"
+
+#: id:31326
+msgid "Created"
+msgstr "Skapad"
+
+#: id:31327
+msgid "Resolution"
+msgstr "Upplösning"
+
+#: id:31328
+msgctxt "Auto context with id 31328"
+msgid "Recently Added"
+msgstr "Nyligen tillagda"
+
+#: id:31329
+msgid "[B]Timer set![/B] [COLOR=grey2] - System auto shutdown in[/COLOR]"
+msgstr "[B]Timer satt![/B] [COLOR=grey2] - Automatisk avstängning av systemet om[/COLOR]"
+
+#: id:31330
+msgid "Click button to play[CR][CR]Movie trailer"
+msgstr "Klicka på knappen för att[CR][CR]spela filmtrailer"
+
+#: id:31331
+msgid "Album Details"
+msgstr "Albumdetaljer"
+
+#: id:31351
+msgid "Pause"
+msgstr "Paus"
+
+#: id:31352
+msgid "Stop"
+msgstr "Stopp"
+
+#: id:31353
+msgid "Fast Forward"
+msgstr "Spola framåt"
+
+#: id:31354
+msgid "Rewind"
+msgstr "Spola bakåt"
+
+#: id:31355
+msgid "Movie menu"
+msgstr "Filmmeny"
+
+#: id:31356
+msgid "Download Subtitles"
+msgstr "Ladda ner undertexter"
+
+#: id:31390
+msgid "Skin default"
+msgstr "Skalstandard"
+
+#: id:31391
+msgid "Skin default with no Caps"
+msgstr "Skalstandard utan VERSAL"
+
+#: id:31392
+msgid "Arial based"
+msgstr "Arialbaserad"
+
+#: id:31400
+msgid "[B]CONFIGURE APPEARANCE SETTINGS[/B][CR][CR]Change the skin � Set language and region � Change file listing options[CR]Set up a screensaver"
+msgstr "[B]KONFIGURERA UTSEENDEINSTÄLLNINGAR[/B][CR][CR]Ändra skalet · Ange språk och region · Ange fillistningsalternativ[CR]Ange en skärmsläckare"
+
+#: id:31401
+msgid "[B]CONFIGURE VIDEO SETTINGS[/B][CR][CR]Manage your video library � Set video playback options � Change video listing options[CR]Set subtitle fonts"
+msgstr "[B]KONFIGURERA GRAFIKINSTÄLLNINGAR[/B][CR][CR]Hantera ditt filmbibliotek · Ange filmuppspelningsalternativ · Ändra videoförteckningsalternativ[CR]Konfigurera undertextfonter"
+
+#: id:31402
+msgid "[B]CONFIGURE MUSIC SETTINGS[/B][CR][CR]Manage your music library � Set music playback options � Change music listing options[CR]Setup song submission � Set karaoke options"
+msgstr "[B]KONFIGURERA MUSIKINSTÄLLNINGAR[/B][CR][CR]Hantera ditt musikbibliotek · Ange musikuppspelningsalternativ · Ändra musiklistningsalternativ[CR]Ange låtinskickning · Ange karaokealternativ"
+
+#: id:31403
+msgid "[B]CONFIGURE PICTURE SETTINGS[/B][CR][CR]Set picture listing options � Configure slideshows"
+msgstr "[B]KONFIGURERA BILDINSTÄLLNINGAR[/B][CR][CR]Ange bildlistningsalternativ · Justera bildspel"
+
+#: id:31404
+msgid "[B]CONFIGURE WEATHER SETTINGS[/B][CR][CR]Set three cities to collect weather information"
+msgstr "[B]KONFIGURERA VÄDERINSTÄLLNINGAR[/B][CR][CR]Ange tre städer för att insamling av väderinformation"
+
+#: id:31406
+msgid "[B]CONFIGURE SYSTEM SETTINGS[/B][CR][CR]Setup and calibrate displays � Configure audio output � Setup remote controls[CR]Set power saving options � Enable debugging � Setup master lock"
+msgstr "[B]KONFIGURERA SYSTEMINSTÄLLNINGAR[/B][CR][CR]Ange och kalibrera bildskärmar · Konfigurera ljudutgång · Ställa in fjärrkontroller[CR]Ange energisparalternativ · Aktivera debuggningen · Konfigurera huvudkod och lås"
+
+#: id:31407
+msgid "[B]CONFIGURE SKIN SETTINGS[/B][CR][CR]Setup the Confluence skin � Add and remove home menu items[CR]Change skin backgrounds"
+msgstr "[B]KONFIGURERA SKALINSTÄLLNINGAR[/B][CR][CR]Ställa in Confluence-skalet · Lägga till och ta bort hemsidans menyknappar[CR]Ändra skalets bakgrunder"
+
+#: id:31408
+msgid "[B]CONFIGURE ADD-ONS[/B][CR][CR]Manage your installed Add-ons � Browse for and install Add-ons from xbmc.org[CR]Modify Add-on settings"
+msgstr "[B]KONFIGURERA TILLÄGG[/B][CR][CR]Hantera installerade tillägg - Visa och installera tillägg från xbmc.org[CR]Ändra inställningar för tillägg"
+
+#: id:31409
+msgid "[B]CONFIGURE SERVICE SETTINGS[/B][CR][CR]Setup control of XBMC via UPnP and HTTP � Configure file sharing[CR]Enable Zeroconf � Configure AirPlay"
+msgstr ""
+
+#: id:31421
+msgid "Select your XBMC user Profile[CR]to login and continue"
+msgstr "Välj din XBMC användarprofil[CR]för att logga in och fortsätta"
+
+#: id:31900
+msgid "Weather Maps"
+msgstr "Väderkartor"
+
+#: id:31901
+msgid "36 Hour Forecast"
+msgstr "36-timmarsprognos"
+
+#: id:31902
+msgid "Hourly Forecast"
+msgstr "Timprognos"
+
+#: id:31903
+msgid "Weekend Forecast"
+msgstr "Helgprognos"
+
+#: id:31904
+msgid "10 Day Forecast"
+msgstr "10-dagarsprognos"
+
+#: id:31905
+msgid "Forecast"
+msgstr "Prognos"
+
+#: id:31906
+msgid "Maps & Video"
+msgstr "Karta & video"
+
+#: id:31907
+msgid "Video Forecast [COLOR=grey2](Fullscreen Playback)[/COLOR]"
+msgstr "Videoprognost [COLOR=grey2](Helskärmsuppspelning)[/COLOR]"
+
+#: id:31908
+msgid "Chance of Precipitation"
+msgstr "Chans till nederbörd"
+
+#: id:31909
+msgid "Fetching forecast info..."
+msgstr "Hämtar prognosinfo..."
+

--- a/addons/skin.confluence/language/Turkish/strings.po
+++ b/addons/skin.confluence/language/Turkish/strings.po
@@ -1,0 +1,576 @@
+# Converted from xbmc strings.xml with xbmc-xml2po (by Team-XBMC)
+msgid ""
+msgstr ""
+"Project-Id-Version: xbmc.skin.confluence-FRODO_GIT953c09c336\n"
+"Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
+"POT-Creation-Date: 2012-04-09 18:03+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE\n"
+"Language: tr\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: id:31000
+msgid "Change Your"
+msgstr "Değiştir"
+
+#: id:31001
+msgid "Love"
+msgstr "Aşk"
+
+#: id:31002
+msgid "Hate"
+msgstr "Nefret"
+
+#: id:31003
+msgid "Power Options"
+msgstr "Güç Seçenekleri"
+
+#: id:31004
+msgid "Working..."
+msgstr "Çalışıyor..."
+
+#: id:31005
+msgid "Hide Information"
+msgstr "Bilgiyi Gizle"
+
+#: id:31006
+msgid "View Options"
+msgstr "Görünüm Seçenekleri"
+
+#: id:31007
+msgid "Plugins"
+msgstr "Eklentiler"
+
+#: id:31008
+msgid "Fullscreen"
+msgstr "Tam ekran"
+
+#: id:31020
+msgctxt "Auto context with id 31020"
+msgid "Recently Added"
+msgstr "Son Eklenenler"
+
+#: id:31021
+msgid "Video - Files"
+msgstr "Video - Dosyalar"
+
+#: id:31022
+msgid "Music - Files"
+msgstr "Müzik - Dosyalar"
+
+#: id:31023
+msgid "Playing"
+msgstr "Oynatılıyor"
+
+#: id:31024
+msgid "Page"
+msgstr "Sayfa"
+
+#: id:31025
+msgid "Items"
+msgstr "Nesne"
+
+#: id:31026
+msgid "Misc Options"
+msgstr "Çeşitli Ayarlar"
+
+#: id:31027
+msgid "Location"
+msgstr "Yer"
+
+#: id:31028
+msgid "Poster Wrap"
+msgstr "Kayan Poster"
+
+#: id:31029
+msgid "Fanart"
+msgstr "Fanart"
+
+#: id:31030
+msgid "Full list"
+msgstr "Tam liste"
+
+#: id:31031
+msgid "Pic Thumbs"
+msgstr "Küçük Resimler"
+
+#: id:31032
+msgid "Image Wrap"
+msgstr "Kayan Resim"
+
+#: id:31033
+msgid "Info"
+msgstr "Bilgi"
+
+#: id:31040
+msgid "Now Playing"
+msgstr "Şimdi Çalınıyor"
+
+#: id:31042
+msgid "PLAYING"
+msgstr "OYNATILIYOR"
+
+#: id:31043
+msgid "PAUSED"
+msgstr "DURAKLATILDI"
+
+#: id:31044
+msgid "FAST FORWARD"
+msgstr "İLERİ SAR"
+
+#: id:31045
+msgid "REWIND"
+msgstr "GERİ SAR"
+
+#: id:31046
+msgid "Audio Properties"
+msgstr "Ses Özellikleri"
+
+#: id:31047
+msgid "Current Preset"
+msgstr "Geçerli Önayar"
+
+#: id:31048
+msgid "Visualization Presets"
+msgstr "Görsel Öğe Önayarları"
+
+#: id:31049
+msgid "End Time"
+msgstr "Bitiş Zamanı"
+
+#: id:31050
+msgid "Sort: Ascending"
+msgstr "Sırala: Artan"
+
+#: id:31051
+msgid "Sort: Descending"
+msgstr "Sırala: Azalan"
+
+#: id:31055
+msgid "Open playlist"
+msgstr "Çalma listesini aç"
+
+#: id:31056
+msgid "Save playlist"
+msgstr "Çalma listesini kaydet"
+
+#: id:31057
+msgid "Close playlist"
+msgstr "Çalma listesini kapat"
+
+#: id:31058
+msgid "System music files"
+msgstr "Sistem müzik dosyaları"
+
+#: id:31059
+msgid "Current playlist"
+msgstr "Geçerli çalma listesi"
+
+#: id:31060
+msgid "This file is stacked, select the part you want to play from."
+msgstr "Bu dosya istiflendi, oynatmak istediğiniz bölümü seçin."
+
+#: id:31061
+msgid "Current Selected"
+msgstr "Seçilen Geçerli Parça"
+
+#: id:31101
+msgid "Home screen options"
+msgstr "Giriş ekranı seçenekleri"
+
+#: id:31102
+msgid "Background"
+msgstr "Arka Plan"
+
+#: id:31103
+msgid "Show \"Paused\" in picture slide show"
+msgstr "Resim slayt gösterisinde \"DURAKLATILDI\"yı göster"
+
+#: id:31104
+msgid "Play Trailers in a window [COLOR=grey3](Video Information Dialog Only)[/COLOR]"
+msgstr "Fragmanları pencere içinde oynat [COLOR=grey3](Sadece Video Bilgisi İletişim Kutusu İçin)[/COLOR]"
+
+#: id:31105
+msgid "\"Videos\" button always goes to video \"Files\""
+msgstr "\"Videolar\" düğmesi herzaman video \"Dosyalar\"'a gider"
+
+#: id:31106
+msgid "Miscellaneous options"
+msgstr "Çeşitli seçenekler"
+
+#: id:31107
+msgid "Hide Flagging read from video filenames [COLOR=grey3](Blu-ray, HD-DVD)[/COLOR]"
+msgstr "Video dosya adlarında etiket okumayı gizle [COLOR=grey3](Blu-ray, HD-DVD)[/COLOR]"
+
+#: id:31108
+msgid "Hide Main Menu Buttons"
+msgstr "Ana Menü Tuşlarını Gizle"
+
+#: id:31109
+msgid "Media backgrounds"
+msgstr "Medya arka planları"
+
+#: id:31110
+msgid "Edit Background for Media Type"
+msgstr "Medya Türü için Arka planı değiştir"
+
+#: id:31111
+msgid "Hide"
+msgstr "Gizle"
+
+#: id:31112
+msgid "Options"
+msgstr "Seçenekler"
+
+#: id:31113
+msgid "Single Image"
+msgstr "Tek Resim"
+
+#: id:31114
+msgid "Multi Image"
+msgstr "Çoklu Resim"
+
+#: id:31115
+msgid "Customizer"
+msgstr "Özelleştir"
+
+#: id:31117
+msgid "Show Recently added Videos"
+msgstr "Son Eklenen Videoları Göster"
+
+#: id:31118
+msgid "Home Page Programs Submenu"
+msgstr "Ana Sayfa Programlar Alt Menüsü"
+
+#: id:31119
+msgid "Hide Background Fanart"
+msgstr "Arkaplan Fanartını Gizle"
+
+#: id:31120
+msgid "BUTTON LABEL"
+msgstr "TUŞ ETİKETİ"
+
+#: id:31122
+msgid "Weather Page"
+msgstr "Hava Durumu Sayfası"
+
+#: id:31123
+msgid "Use \"Posters\" instead of \"Banners\" for TV Shows"
+msgstr "TV Programları için \"Afiş\" yerine \"Poster\" kullan"
+
+#: id:31124
+msgid "Show Background \"Now Playing\" Video"
+msgstr "Arkaplanda Oynatılan Videoyu göster"
+
+#: id:31125
+msgid "Show Background \"Now Playing\" Visualization"
+msgstr "Arkaplanda Görsel Ögeyi göster"
+
+#: id:31126
+msgid "Play TV theme songs in video library (TvTunes add-on)"
+msgstr "TV tema şarkılarını video kitaplığında çal (TvTunes eklentisi)"
+
+#: id:31127
+msgid "TvTunes"
+msgstr "TvTunes"
+
+#: id:31128
+msgid "Lyrics"
+msgstr "Şarkı Sözleri"
+
+#: id:31132
+msgid "Lyrics Add-on"
+msgstr "Şarkı Sözleri Eklentisi"
+
+#: id:31133
+msgid "Subtitle Add-on"
+msgstr "Altyazı Eklentisi"
+
+#: id:31134
+msgid "Home Page Videos Submenu"
+msgstr "Ana Sayfa Videolar Alt Menüsü"
+
+#: id:31135
+msgid "Home Page Music Submenu"
+msgstr "Ana Sayfa Müzik Alt Menüsü"
+
+#: id:31136
+msgid "Home Page Pictures Submenu"
+msgstr "Ana Sayfa Resimler Alt Menüsü"
+
+#: id:31140
+msgid "Music OSD"
+msgstr "Müzik OSD"
+
+#: id:31141
+msgid "Video OSD"
+msgstr "Video OSD"
+
+#: id:31200
+msgid "Shortcuts"
+msgstr "Kısayollar"
+
+#: id:31201
+msgid "Categories"
+msgstr "Kategoriler"
+
+#: id:31202
+msgid "Show Cast"
+msgstr "Oyuncuları Göster"
+
+#: id:31203
+msgid "Choose Your Song"
+msgstr "Şarkını Seç"
+
+#: id:31204
+msgid "Section Links"
+msgstr "Bölüm Bağlantıları"
+
+#: id:31205
+msgid "Lyrics Source"
+msgstr "Şarkı Sözleri Kaynağı"
+
+#: id:31300
+msgid "Current Temp"
+msgstr "Mevcut Sıcaklık"
+
+#: id:31301
+msgid "Last Updated"
+msgstr "Son Güncelleme"
+
+#: id:31302
+msgid "Menu"
+msgstr "Menü"
+
+#: id:31303
+msgid "Data provider"
+msgstr "Veri sağlayıcı"
+
+#: id:31304
+msgid "Picture"
+msgstr "Resim"
+
+#: id:31305
+msgid "No Disc Media Detected"
+msgstr "Disk Ortamı Algılanmadı"
+
+#: id:31306
+msgid "Eject"
+msgstr "Çıkart"
+
+#: id:31307
+msgid "Hide Fanart"
+msgstr "Fanart'ı gizle"
+
+#: id:31308
+msgid "Movie Details"
+msgstr "Film Detayları"
+
+#: id:31309
+msgid "Memory Used:"
+msgstr "Kullanılan Bellek:"
+
+#: id:31310
+msgid "Track Number"
+msgstr "Parça Numarası"
+
+#: id:31311
+msgid "Fanart image[CR][CR]Unavailable[CR][CR] Click button to set"
+msgstr "Fanart resmi[CR][CR]Mevcut Değil[CR][CR] Ayarlamak için düğmeye basın"
+
+#: id:31312
+msgid "Current Scraper"
+msgstr "Geçerli Scraper"
+
+#: id:31313
+msgid "Choose a Scraper"
+msgstr "Scraper Seç"
+
+#: id:31314
+msgid "Content Scanning Options"
+msgstr "İçerik Tarama Seçenekleri"
+
+#: id:31315
+msgid "Basic"
+msgstr "Temel Bilgiler"
+
+#: id:31317
+msgid "Set Fanart Path"
+msgstr "Fanart Yolunu Ayarla"
+
+#: id:31318
+msgid "Small Fanart"
+msgstr "Küçük Fanart"
+
+#: id:31319
+msgid "Selected Profile"
+msgstr "Seçilen Profil"
+
+#: id:31320
+msgid "Last Logged In"
+msgstr "Son Giriş Yapan"
+
+#: id:31321
+msgid "Karaoke Song Selector"
+msgstr "Karaoke Şarkı Seçici"
+
+#: id:31322
+msgid "Aired"
+msgstr "Gösterim"
+
+#: id:31323
+msgid "Latest Movies"
+msgstr "En Yeni Filmler"
+
+#: id:31324
+msgid "Latest Episodes"
+msgstr "En Yeni Bölümler"
+
+#: id:31325
+msgid "Playlist Options"
+msgstr "Çalma Listesi Seçenekleri"
+
+#: id:31326
+msgid "Created"
+msgstr "Oluşturma"
+
+#: id:31327
+msgid "Resolution"
+msgstr "Çözünürlük"
+
+#: id:31328
+msgctxt "Auto context with id 31328"
+msgid "Recently Added"
+msgstr "Son Eklenenler"
+
+#: id:31329
+msgid "[B]Timer set![/B] [COLOR=grey2] - System auto shutdown in[/COLOR]"
+msgstr "[B]Zamanlayıcı ayarlandı![/B] [COLOR=grey2] - Sistem'in otomatik kapanma süresi[/COLOR]"
+
+#: id:31330
+msgid "Click button to play[CR][CR]Movie trailer"
+msgstr "Oynatmak için düğmeye basın[CR][CR]Film fragmanı"
+
+#: id:31331
+msgid "Album Details"
+msgstr "Albüm Ayrıntıları"
+
+#: id:31351
+msgid "Pause"
+msgstr "Duraklat"
+
+#: id:31352
+msgid "Stop"
+msgstr "Durdur"
+
+#: id:31353
+msgid "Fast Forward"
+msgstr "İleri Sar"
+
+#: id:31354
+msgid "Rewind"
+msgstr "Geri Sar"
+
+#: id:31355
+msgid "Movie menu"
+msgstr "Film menüsü"
+
+#: id:31356
+msgid "Download Subtitles"
+msgstr "Altyazıları İndir"
+
+#: id:31390
+msgid "Skin default"
+msgstr "Dış görünüm varsayılanı"
+
+#: id:31391
+msgid "Skin default with no Caps"
+msgstr "B. Harfsiz dış görünüm varsayılanı"
+
+#: id:31392
+msgid "Arial based"
+msgstr "Arial tabanlı"
+
+#: id:31400
+msgid "[B]CONFIGURE APPEARANCE SETTINGS[/B][CR][CR]Change the skin � Set language and region � Change file listing options[CR]Set up a screensaver"
+msgstr "[B]GÖRÜNÜM AYARLARINI YAPILANDIR[/B][CR][CR]Dış görünümü değiştir · Dil ve bölgesel ayarları değiştir · Dosya listeleme seçeneklerini değiştir · Ekran koruyucuyu ayarla"
+
+#: id:31401
+msgid "[B]CONFIGURE VIDEO SETTINGS[/B][CR][CR]Manage your video library � Set video playback options � Change video listing options[CR]Set subtitle fonts"
+msgstr "[B]VİDEO AYARLARINI YAPILANDIR[/B][CR][CR]Video kitaplığını yönet · Video oynatma seçeneklerini ayarla · Video listeleme seçeneklerini değiştir · Altyazı karakterlerini ayarla"
+
+#: id:31402
+msgid "[B]CONFIGURE MUSIC SETTINGS[/B][CR][CR]Manage your music library � Set music playback options � Change music listing options[CR]Setup song submission � Set karaoke options"
+msgstr "[B]MÜZİK AYARLARINI YAPILANDIR[/B][CR][CR]Müzik kitaplığını yönet · Müzik çalma seçeneklerini ayarla · Müzik listeleme seçeneklerini değiştir · Şarkı sunumu ayarları · Karaoke seçeneklerini ayarla"
+
+#: id:31403
+msgid "[B]CONFIGURE PICTURE SETTINGS[/B][CR][CR]Set picture listing options � Configure slideshows"
+msgstr "[B]RESİM AYARLARINI YAPILANDIR[/B][CR][CR]Resim listeleme seçeneklerini değiştir · Slayt gösterisi ayarlarını yapılandır"
+
+#: id:31404
+msgid "[B]CONFIGURE WEATHER SETTINGS[/B][CR][CR]Set three cities to collect weather information"
+msgstr "[B]HAVA DURUMU AYARLARINI YAPILANDIR[/B][CR][CR]Hava Durumu bilgilerini almak için üç şehir seçin"
+
+#: id:31406
+msgid "[B]CONFIGURE SYSTEM SETTINGS[/B][CR][CR]Setup and calibrate displays � Configure audio output � Setup remote controls[CR]Set power saving options � Enable debugging � Setup master lock"
+msgstr "[B]SİSTEM AYARLARINI YAPILANDIR[/B][CR][CR]Görünüm ayarları · Ses çıkış ayarlarını yapılandır · Uzaktan kumandaları ayarla[CR]Güç tasarrufu seçeneklerini ayarla · Hata ayıklamayı etkinleştir · Sistem kilit ayarları"
+
+#: id:31407
+msgid "[B]CONFIGURE SKIN SETTINGS[/B][CR][CR]Setup the Confluence skin � Add and remove home menu items[CR]Change skin backgrounds"
+msgstr "[B]DIŞ GÖRÜNÜM AYARLARINI YAPILANDIR[/B][CR][CR]Confluence dış görünümü ayarları · Ana menü ögelerini ekle ve kaldır[CR]Arayüz arkaplanlarını değiştir"
+
+#: id:31408
+msgid "[B]CONFIGURE ADD-ONS[/B][CR][CR]Manage your installed Add-ons � Browse for and install Add-ons from xbmc.org[CR]Modify Add-on settings"
+msgstr "[B]EKLENTİLERİ YAPILANDIR[/B][CR][CR]Yüklenmiş eklentileri yönet · Eklentilere gözat ve yenilerini yükle[CR]Eklenti ayarlarını değiştir"
+
+#: id:31409
+msgid "[B]CONFIGURE SERVICE SETTINGS[/B][CR][CR]Setup control of XBMC via UPnP and HTTP � Configure file sharing[CR]Enable Zeroconf � Configure AirPlay"
+msgstr "[B]HİZMET AYARLARINI YAPILANDIR[/B][CR][CR]UPnP ve HTTP üzerinden XBMC kontrolü ayarları · Dosya paylaşımını yapılandır[CR]Zeroconf'u etkinleştir · AirPlay'i yapılandır"
+
+#: id:31421
+msgid "Select your XBMC user Profile[CR]to login and continue"
+msgstr "Oturum açıp devam etmek için[CR]XBMC kullanıcı profilinizi seçin"
+
+#: id:31900
+msgid "Weather Maps"
+msgstr "Hava Durumu Haritaları"
+
+#: id:31901
+msgid "36 Hour Forecast"
+msgstr "36 Saatlik Hava Tahmini"
+
+#: id:31902
+msgid "Hourly Forecast"
+msgstr "Saatlik Hava Tahmini"
+
+#: id:31903
+msgid "Weekend Forecast"
+msgstr "Haftalık Hava Tahmini"
+
+#: id:31904
+msgid "10 Day Forecast"
+msgstr "10 Günlik Hava Tahmini"
+
+#: id:31905
+msgid "Forecast"
+msgstr "Hava Tahmini"
+
+#: id:31906
+msgid "Maps & Video"
+msgstr "Video ve Haritalar"
+
+#: id:31907
+msgid "Video Forecast [COLOR=grey2](Fullscreen Playback)[/COLOR]"
+msgstr "Video Hava Tahmini [COLOR=grey2](Tam ekran oynatım)[/COLOR]"
+
+#: id:31908
+msgid "Chance of Precipitation"
+msgstr "Chance of Precipitation"
+
+#: id:31909
+msgid "Fetching forecast info..."
+msgstr "Hava tahmini bilgisi getiriliyor..."
+

--- a/language/Afrikaans/strings.po
+++ b/language/Afrikaans/strings.po
@@ -1,0 +1,9093 @@
+# Converted from xbmc strings.xml with xbmc-xml2po (by Team-XBMC)
+msgid ""
+msgstr ""
+"Project-Id-Version: xbmc.core-FRODO_GIT3ed1604ad7\n"
+"Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
+"POT-Creation-Date: 2012-04-09 18:00+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE\n"
+"Language: af\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: id:0
+msgctxt "Auto context with id 0"
+msgid "Programs"
+msgstr "Programme"
+
+#: id:1
+msgctxt "Auto context with id 1"
+msgid "Pictures"
+msgstr "Prente"
+
+#: id:2
+msgctxt "Auto context with id 2"
+msgid "Music"
+msgstr "Musiek"
+
+#: id:3
+msgctxt "Auto context with id 3"
+msgid "Videos"
+msgstr "Videos"
+
+#: id:4
+msgid "TV-Guide"
+msgstr "TV-Gids"
+
+#: id:5
+msgctxt "Auto context with id 5"
+msgid "Settings"
+msgstr "Verstellings"
+
+#: id:6
+msgid "XBMC SVN"
+msgstr "XBMC SVN"
+
+#: id:7
+msgctxt "Auto context with id 7"
+msgid "File manager"
+msgstr "Lêer bestuurder"
+
+#: id:8
+msgctxt "Auto context with id 8"
+msgid "Weather"
+msgstr "Weer"
+
+#: id:9
+msgid "xbmc media center"
+msgstr "xbmc media sentrum"
+
+#: id:11
+msgid "Monday"
+msgstr "Maandag"
+
+#: id:12
+msgid "Tuesday"
+msgstr "Dinsdag"
+
+#: id:13
+msgid "Wednesday"
+msgstr "Woensdag"
+
+#: id:14
+msgid "Thursday"
+msgstr "Donderdag"
+
+#: id:15
+msgid "Friday"
+msgstr "Vrydag"
+
+#: id:16
+msgid "Saturday"
+msgstr "Saterdag"
+
+#: id:17
+msgid "Sunday"
+msgstr "Sondag"
+
+#: id:21
+msgid "January"
+msgstr "Januarie"
+
+#: id:22
+msgid "February"
+msgstr "Februarie"
+
+#: id:23
+msgid "March"
+msgstr "Maart"
+
+#: id:24
+msgid "April"
+msgstr "April"
+
+#: id:25
+msgctxt "Auto context with id 25"
+msgid "May"
+msgstr "Mei"
+
+#: id:26
+msgid "June"
+msgstr "Junie"
+
+#: id:27
+msgid "July"
+msgstr "Julie"
+
+#: id:28
+msgid "August"
+msgstr "Augustus"
+
+#: id:29
+msgid "September"
+msgstr "September"
+
+#: id:30
+msgid "October"
+msgstr "Oktober"
+
+#: id:31
+msgid "November"
+msgstr "November"
+
+#: id:32
+msgid "December"
+msgstr "Desember"
+
+#: id:41
+msgid "Mon"
+msgstr "Ma"
+
+#: id:42
+msgid "Tue"
+msgstr "Di"
+
+#: id:43
+msgid "Wed"
+msgstr "Wo"
+
+#: id:44
+msgid "Thu"
+msgstr "Do"
+
+#: id:45
+msgid "Fri"
+msgstr "Vry"
+
+#: id:46
+msgid "Sat"
+msgstr "Sa"
+
+#: id:47
+msgctxt "Auto context with id 47"
+msgid "Sun"
+msgstr "So"
+
+#: id:51
+msgid "Jan"
+msgstr "Jan"
+
+#: id:52
+msgid "Feb"
+msgstr "Feb"
+
+#: id:53
+msgid "Mar"
+msgstr "Mar"
+
+#: id:54
+msgid "Apr"
+msgstr "Apr"
+
+#: id:55
+msgctxt "Auto context with id 55"
+msgid "May"
+msgstr "Mei"
+
+#: id:56
+msgid "Jun"
+msgstr "Jun"
+
+#: id:57
+msgid "Jul"
+msgstr "Jul"
+
+#: id:58
+msgid "Aug"
+msgstr "Aug"
+
+#: id:59
+msgid "Sep"
+msgstr "Sep"
+
+#: id:60
+msgid "Oct"
+msgstr "Okt"
+
+#: id:61
+msgid "Nov"
+msgstr "Nov"
+
+#: id:62
+msgid "Dec"
+msgstr "Des"
+
+#: id:71
+msgid "N"
+msgstr "N"
+
+#: id:72
+msgid "NNE"
+msgstr "NNE"
+
+#: id:73
+msgid "NE"
+msgstr "NE"
+
+#: id:74
+msgid "ENE"
+msgstr "ENE"
+
+#: id:75
+msgid "E"
+msgstr "E"
+
+#: id:76
+msgid "ESE"
+msgstr "ESE"
+
+#: id:77
+msgid "SE"
+msgstr "SE"
+
+#: id:78
+msgid "SSE"
+msgstr "SSE"
+
+#: id:79
+msgid "S"
+msgstr "S"
+
+#: id:80
+msgid "SSW"
+msgstr "SSW"
+
+#: id:81
+msgid "SW"
+msgstr "SW"
+
+#: id:82
+msgid "WSW"
+msgstr "WSW"
+
+#: id:83
+msgid "W"
+msgstr "W"
+
+#: id:84
+msgid "WNW"
+msgstr "WNW"
+
+#: id:85
+msgid "NW"
+msgstr "NW"
+
+#: id:86
+msgid "NNW"
+msgstr "NNW"
+
+#: id:87
+msgid "VAR"
+msgstr "VAR"
+
+#: id:98
+msgid "View: Auto"
+msgstr "Aansig: Auto"
+
+#: id:99
+msgid "View: Auto big"
+msgstr "Aansig: Auto groot"
+
+#: id:100
+msgid "View: Icons"
+msgstr "Aansig: Ikone"
+
+#: id:101
+msgid "View: List"
+msgstr "Aansig: Lys"
+
+#: id:102
+msgctxt "Auto context with id 102"
+msgid "Scan"
+msgstr "Deursoek"
+
+#: id:103
+msgctxt "Auto context with id 103"
+msgid "Sort by: Name"
+msgstr "Sorteer volgens: Naam"
+
+#: id:104
+msgid "Sort by: Date"
+msgstr "Sorteer volgens: Datum"
+
+#: id:105
+msgid "Sort by: Size"
+msgstr "Sorteer volgens: Grootte"
+
+#: id:106
+msgid "No"
+msgstr "Nee"
+
+#: id:107
+msgid "Yes"
+msgstr "Ja"
+
+#: id:108
+msgctxt "Auto context with id 108"
+msgid "Slideshow"
+msgstr "Skyfievertoning"
+
+#: id:109
+msgid "Create thumbs"
+msgstr "Skep duime"
+
+#: id:110
+msgid "Create thumbnails"
+msgstr "Skep duimnaelsketse"
+
+#: id:111
+msgctxt "Auto context with id 111"
+msgid "Shortcuts"
+msgstr "Kortpaaie"
+
+#: id:112
+msgid "Paused"
+msgstr "Gepouseer"
+
+#: id:113
+msgid "Update failed"
+msgstr "Opdatering het gefaal"
+
+#: id:114
+msgid "Installation failed"
+msgstr "Installasie het gefaal"
+
+#: id:115
+msgid "Copy"
+msgstr "Kopiëer"
+
+#: id:116
+msgid "Move"
+msgstr "Skuif"
+
+#: id:117
+msgid "Delete"
+msgstr "Wis uit"
+
+#: id:118
+msgid "Rename"
+msgstr "Hernoem"
+
+#: id:119
+msgid "New folder"
+msgstr "Nuwe vouer"
+
+#: id:120
+msgid "Confirm file copy"
+msgstr "Bevestig lêer kopiëer"
+
+#: id:121
+msgid "Confirm file move"
+msgstr "Bevestig lêer skuif"
+
+#: id:122
+msgid "Confirm file delete?"
+msgstr "Bevestig lêer uitwis"
+
+#: id:123
+msgid "Copy these files?"
+msgstr "Kopiëer hierdie lêers?"
+
+#: id:124
+msgid "Move these files?"
+msgstr "Skuif hierdie lêers?"
+
+#: id:125
+msgid "Delete these files? - Deleting files cannot be undone!"
+msgstr "Wis hierdie lêers uit? Uitwissing kan nie ongedaan gemaak word nie!"
+
+#: id:126
+msgid "Status"
+msgstr "Status"
+
+#: id:127
+msgid "Objects"
+msgstr "Objekte"
+
+#: id:128
+msgctxt "Auto context with id 128"
+msgid "General"
+msgstr "Algemeen"
+
+#: id:129
+msgctxt "Auto context with id 129"
+msgid "Slideshow"
+msgstr "Skyfievertoning"
+
+#: id:130
+msgctxt "Auto context with id 130"
+msgid "System info"
+msgstr "Stelsel info"
+
+#: id:131
+msgid "Display"
+msgstr "Vertoon"
+
+#: id:132
+msgid "Albums"
+msgstr "Albums"
+
+#: id:133
+msgid "Artists"
+msgstr "Kunstenaars"
+
+#: id:134
+msgid "Songs"
+msgstr "Liedjies"
+
+#: id:135
+msgid "Genres"
+msgstr "Genres"
+
+#: id:136
+msgid "Playlists"
+msgstr "Speellyste"
+
+#: id:137
+msgid "Search"
+msgstr "Soek"
+
+#: id:138
+msgid "System Information"
+msgstr "Stelsel Informasie"
+
+#: id:139
+msgid "Temperatures:"
+msgstr "Temperature:"
+
+#: id:140
+msgid "CPU:"
+msgstr "CPU:"
+
+#: id:141
+msgid "GPU:"
+msgstr "GPU:"
+
+#: id:142
+msgid "Time:"
+msgstr "Tyd:"
+
+#: id:143
+msgid "Current:"
+msgstr "Huidiglik:"
+
+#: id:144
+msgid "Build:"
+msgstr "Bou:"
+
+#: id:145
+msgid "Network:"
+msgstr "Netwerk:"
+
+#: id:146
+msgid "Type:"
+msgstr "Tipe:"
+
+#: id:147
+msgid "Static"
+msgstr "Staties"
+
+#: id:148
+msgid "DHCP"
+msgstr "DHCP"
+
+#: id:149
+msgid "MAC address"
+msgstr "MAC adres"
+
+#: id:150
+msgctxt "Auto context with id 150"
+msgid "IP address"
+msgstr "IP adres"
+
+#: id:151
+msgid "Link:"
+msgstr "Skakel:"
+
+#: id:152
+msgid "Half duplex"
+msgstr "Half dupleks"
+
+#: id:153
+msgid "Full duplex"
+msgstr "Vol dupleks"
+
+#: id:154
+msgctxt "Auto context with id 154"
+msgid "Storage"
+msgstr "Storing"
+
+#: id:155
+msgid "Drive"
+msgstr "Skyf"
+
+#: id:156
+msgctxt "Auto context with id 156"
+msgid "Free"
+msgstr "Beskikbaar"
+
+#: id:157
+msgctxt "Auto context with id 157"
+msgid "Video"
+msgstr "Video"
+
+#: id:158
+msgid "Free memory"
+msgstr "Beskikbare geheue"
+
+#: id:159
+msgid "No link"
+msgstr "Geen skakel"
+
+#: id:160
+msgctxt "Auto context with id 160"
+msgid "Free"
+msgstr "Beskikbaar"
+
+#: id:161
+msgid "Unavailable"
+msgstr "Onbeskikbaar"
+
+#: id:162
+msgid "Tray open"
+msgstr "Laai oop"
+
+#: id:163
+msgid "Reading"
+msgstr "Lees"
+
+#: id:164
+msgid "No disc"
+msgstr "Geen skyf"
+
+#: id:165
+msgid "Disc present"
+msgstr "Skyf teenwoordig"
+
+#: id:166
+msgid "Skin"
+msgstr "Omslag"
+
+#: id:169
+msgctxt "Auto context with id 169"
+msgid "Resolution"
+msgstr "Resolusie"
+
+#: id:170
+msgid "Adjust display refresh rate to match video"
+msgstr "Pas vertoon se verfris tempo aan om video te pas"
+
+#: id:172
+msgid "Release date"
+msgstr "Uitgee datum"
+
+#: id:173
+msgid "Display 4:3 videos as"
+msgstr "Vertoon 4:3 videos as"
+
+#: id:175
+msgid "Moods"
+msgstr "Stemmings"
+
+#: id:176
+msgid "Styles"
+msgstr "Style"
+
+#: id:179
+msgid "Song"
+msgstr "Liedjie"
+
+#: id:180
+msgid "Duration"
+msgstr "Durasie"
+
+#: id:181
+msgid "Select album"
+msgstr "Selekteer album"
+
+#: id:182
+msgid "Tracks"
+msgstr "Snitte"
+
+#: id:183
+msgid "Review"
+msgstr "Resensie"
+
+#: id:184
+msgid "Refresh"
+msgstr "Verfris"
+
+#: id:185
+msgid "Searching album"
+msgstr "Soek album"
+
+#: id:186
+msgid "OK"
+msgstr "OK"
+
+#: id:187
+msgid "No albums found!"
+msgstr "Geen albums gevind!"
+
+#: id:188
+msgid "Select all"
+msgstr "Selekteer almal"
+
+#: id:189
+msgid "Scanning media info"
+msgstr "Deursoek media info"
+
+#: id:190
+msgid "Save"
+msgstr "Stoor"
+
+#: id:191
+msgid "Shuffle"
+msgstr "Skommel"
+
+#: id:192
+msgctxt "Auto context with id 192"
+msgid "Clear"
+msgstr "Maak skoon"
+
+#: id:193
+msgctxt "Auto context with id 193"
+msgid "Scan"
+msgstr "Deursoek"
+
+#: id:194
+msgid "Searching..."
+msgstr "Soek..."
+
+#: id:195
+msgid "No info found!"
+msgstr "Geen inligting gevind!"
+
+#: id:196
+msgid "Select movie:"
+msgstr "Selekteer fliek:"
+
+#: id:197
+msgid "Querying %s info"
+msgstr "Vra %s info"
+
+#: id:198
+msgid "Loading movie details"
+msgstr "Laai fliek besonderhede"
+
+#: id:199
+msgid "Web interface"
+msgstr "Web koppelvlak"
+
+#: id:202
+msgid "Tagline"
+msgstr "Tagline"
+
+#: id:203
+msgid "Plot outline"
+msgstr "Plot uitleg"
+
+#: id:205
+msgid "Votes"
+msgstr "Stemme"
+
+#: id:206
+msgid "Cast"
+msgstr "Rolverdeling"
+
+#: id:207
+msgid "Plot"
+msgstr "Plot"
+
+#: id:208
+msgctxt "Auto context with id 208"
+msgid "Play"
+msgstr "Speel"
+
+#: id:209
+msgid "Next"
+msgstr "Volgende"
+
+#: id:210
+msgid "Previous"
+msgstr "Vorige"
+
+#: id:213
+msgid "Calibrate user interface..."
+msgstr "Kalibreer gebruiker koppelvlak..."
+
+#: id:214
+msgid "Video calibration..."
+msgstr "Video kalibrasie..."
+
+#: id:215
+msgid "Soften"
+msgstr "Versag"
+
+#: id:216
+msgid "Zoom amount"
+msgstr "Zoem hoeveelheid"
+
+#: id:217
+msgid "Pixel ratio"
+msgstr "Pixel verhouding"
+
+#: id:218
+msgid "DVD drive"
+msgstr "DVD dryf"
+
+#: id:219
+msgid "Please insert disc"
+msgstr "Plaas asseblief skyf in"
+
+#: id:220
+msgid "Remote share"
+msgstr "Afgeleë saamdeel"
+
+#: id:221
+msgid "Network is not connected"
+msgstr "Netwerk is nie gekonnekteer"
+
+#: id:222
+msgid "Cancel"
+msgstr "Kanselleer"
+
+#: id:224
+msgid "Speed"
+msgstr "Spoed"
+
+#: id:225
+msgid "Vertical Shift"
+msgstr ""
+
+#: id:226
+msgid "Test patterns..."
+msgstr "Toets patrone..."
+
+#: id:227
+msgid "Lookup audio CD track names from freedb.org"
+msgstr "Soek audio CD snit name op vanaf freedb.org"
+
+#: id:228
+msgid "Shuffle playlist on load"
+msgstr "Skommel speellys met laai"
+
+#: id:229
+msgid "HDD spindown time"
+msgstr "HDD afspin tyd"
+
+#: id:230
+msgid "Video filters"
+msgstr "Video filters"
+
+#: id:231
+msgctxt "Auto context with id 231"
+msgid "None"
+msgstr "Geen"
+
+#: id:232
+msgid "Point"
+msgstr "Punt"
+
+#: id:233
+msgid "Linear"
+msgstr "Lineêr"
+
+#: id:234
+msgid "Anisotropic"
+msgstr "Anisotropies"
+
+#: id:235
+msgid "Quincunx"
+msgstr "Quincunx"
+
+#: id:236
+msgid "Gaussian cubic"
+msgstr "Gaussian kubies"
+
+#: id:237
+msgid "Minification"
+msgstr "Minimering"
+
+#: id:238
+msgid "Magnification"
+msgstr "Vergroting"
+
+#: id:239
+msgid "Clear playlist on finish"
+msgstr "Maak speellys skoon wanneer klaar"
+
+#: id:240
+msgid "Display Mode"
+msgstr "Vertoon modus"
+
+#: id:241
+msgid "Full Screen #%d"
+msgstr "Volskerm #%d"
+
+#: id:242
+msgid "Windowed"
+msgstr "Gevenster"
+
+#: id:243
+msgid "Refresh Rate"
+msgstr "Verfris tempo"
+
+#: id:244
+msgid "Full screen"
+msgstr "Volskerm"
+
+#: id:245
+msgid "Sizing: (%i,%i)->(%i,%i) (Zoom x%2.2f) AR:%2.2f:1 (Pixels: %2.2f:1) (VShift: %2.2f)"
+msgstr "Grootte: (%i,%i)->(%i,%i) (Zoem x%2.2f) AR:%2.2f:1 (Pixels: %2.2f:1)"
+
+#: id:247
+msgctxt "Auto context with id 247"
+msgid "Scripts"
+msgstr "Skrip"
+
+#: id:248
+msgctxt "Auto context with id 248"
+msgid "Language"
+msgstr "Taal"
+
+#: id:249
+msgctxt "Auto context with id 249"
+msgid "Music"
+msgstr "Musiek"
+
+#: id:250
+msgctxt "Auto context with id 250"
+msgid "Visualization"
+msgstr "Visualisering"
+
+#: id:251
+msgid "Select destination directory"
+msgstr "Selekteer destinasie vouer"
+
+#: id:252
+msgid "Output stereo to all speakers"
+msgstr "Speel stereo na al die luidsprekers"
+
+#: id:253
+msgid "Number of channels"
+msgstr "Hoeveelheid kanale"
+
+#: id:254
+msgid "- DTS capable receiver"
+msgstr "- Ontvanger wat DTS kan dekodeer"
+
+#: id:255
+msgid "CDDB"
+msgstr "CDDB"
+
+#: id:256
+msgid "Fetching CD information"
+msgstr "Haal CD informasie"
+
+#: id:257
+msgid "Error"
+msgstr "Fout"
+
+#: id:258
+msgid "Enable tag reading"
+msgstr "Stel etiket lees in staat"
+
+#: id:259
+msgid "Opening"
+msgstr "Open"
+
+#: id:260
+msgid "Shoutcast"
+msgstr "Shoutcast"
+
+#: id:261
+msgid "Waiting for start..."
+msgstr "Wag vir begin..."
+
+#: id:262
+msgid "Scripts output"
+msgstr "Skripte uittree"
+
+#: id:263
+msgid "Allow control of XBMC via HTTP"
+msgstr "Laat XBMC beheer toe via HTTP"
+
+#: id:264
+msgid "Record"
+msgstr "Neem op"
+
+#: id:265
+msgid "Stop Rec."
+msgstr "Stop opneem"
+
+#: id:266
+msgid "Sort by: Track"
+msgstr "Sorteer volgens: Snit"
+
+#: id:267
+msgid "Sort by: Time"
+msgstr "Sorteer volgens: Tyd"
+
+#: id:268
+msgid "Sort by: Title"
+msgstr "Sorteer volgens: Titel"
+
+#: id:269
+msgid "Sort by: Artist"
+msgstr "Sorteer volgens: Kunstenaar"
+
+#: id:270
+msgid "Sort by: Album"
+msgstr "Sorteer volgens: Album"
+
+#: id:271
+msgid "Top 100"
+msgstr "Top 100"
+
+#: id:272
+msgid "Top-Left overscan compensation"
+msgstr "Bo-Links oorskandeer kompensasie"
+
+#: id:273
+msgid "Bottom-Right overscan compensation"
+msgstr "Onder-Regs oorskandeer kompensasie"
+
+#: id:274
+msgid "Subtitle positioning"
+msgstr "Subtitel posisionering"
+
+#: id:275
+msgid "Pixel ratio adjustment"
+msgstr "Pixel verhouding aanpassing"
+
+#: id:276
+msgid "Adjust the arrow to change the amount of overscan"
+msgstr "Pas die pyl aan om die hoeveelheid oorskandeer te verander"
+
+#: id:277
+msgid "Adjust the bar to change the subtitles position"
+msgstr "Pas die balk aan om die subtitel posisie te verander"
+
+#: id:278
+msgid "Adjust the rectangle so it is perfectly square"
+msgstr "Pas die reghoek aan sodat dit perfek vierkantig is"
+
+#: id:279
+msgid "Unable to load settings"
+msgstr "Kan nie verstellings laai nie"
+
+#: id:280
+msgid "Using default settings"
+msgstr "Gebruik verstek verstellings"
+
+#: id:281
+msgid "Please check the XML files"
+msgstr "Gaan asseblief die XML lêers na"
+
+#: id:282
+msgid "Found %i items"
+msgstr "%i Items gevind"
+
+#: id:283
+msgid "Search results"
+msgstr "Soektog resultate"
+
+#: id:284
+msgid "No results found"
+msgstr "Geen resultate gevind"
+
+#: id:287
+msgctxt "Auto context with id 287"
+msgid "Subtitles"
+msgstr "Subtitels"
+
+#: id:288
+msgctxt "Auto context with id 288"
+msgid "Font"
+msgstr "Skrif"
+
+#: id:289
+msgctxt "Auto context with id 289"
+msgid "- Size"
+msgstr "- Grootte"
+
+#: id:290
+msgid "Dynamic range compression"
+msgstr "Dinamiese bereik kompressie"
+
+#: id:291
+msgctxt "Auto context with id 291"
+msgid "Video"
+msgstr "Video"
+
+#: id:292
+msgctxt "Auto context with id 292"
+msgid "Audio"
+msgstr "Audio"
+
+#: id:293
+msgid "Browse for subtitles"
+msgstr "Navigeer na subtitels"
+
+#: id:294
+msgid "Create bookmark"
+msgstr "Skep boekmerk"
+
+#: id:296
+msgid "Clear bookmarks"
+msgstr "Maak boekmerke skoon"
+
+#: id:297
+msgid "Audio offset"
+msgstr "Audio afset"
+
+#: id:298
+msgid "Bookmarks"
+msgstr "Boekmerke"
+
+#: id:299
+msgid "- AAC capable receiver"
+msgstr "- Ontvanger wat AAC kan dekodeer"
+
+#: id:300
+msgid "- MP1 capable receiver"
+msgstr "- Ontvanger wat MP1 kan dekodeer"
+
+#: id:301
+msgid "- MP2 capable receiver"
+msgstr "- Ontvanger wat MP2 kan dekodeer"
+
+#: id:302
+msgid "- MP3 capable receiver"
+msgstr "- Ontvanger wat MP3 kan dekodeer"
+
+#: id:303
+msgid "Delay"
+msgstr "Vertraging"
+
+#: id:304
+msgctxt "Auto context with id 304"
+msgid "Language"
+msgstr "Taal"
+
+#: id:305
+msgctxt "Auto context with id 305"
+msgid "Enabled"
+msgstr "In staat gestel"
+
+#: id:306
+msgid "Non-interleaved"
+msgstr "Nie-intervleg"
+
+#: id:312
+msgid "(0=auto)"
+msgstr "(0=auto)"
+
+#: id:313
+msgid "Cleaning database"
+msgstr "Maak databasis skoon"
+
+#: id:314
+msgid "Preparing..."
+msgstr "Maak gereed..."
+
+#: id:315
+msgid "Database error"
+msgstr "Databasis fout"
+
+#: id:316
+msgid "Searching songs..."
+msgstr "Soek deur liedjies..."
+
+#: id:317
+msgid "Cleaned database successfully"
+msgstr "Suksesvol databasis skoon gemaak"
+
+#: id:318
+msgid "Cleaning songs..."
+msgstr "Maak liedjies skoon..."
+
+#: id:319
+msgid "Error cleaning songs"
+msgstr "Fout gedurende liedjies skoonmaak"
+
+#: id:320
+msgid "Cleaning artists..."
+msgstr "Maak kunstenaars skoon..."
+
+#: id:321
+msgid "Error cleaning artists"
+msgstr "Fout gedurende kunstenaars skoonmaak"
+
+#: id:322
+msgid "Cleaning genres..."
+msgstr "Maak genres skoon..."
+
+#: id:323
+msgid "Error cleaning genres"
+msgstr "Fout gedurende genres skoonmaak"
+
+#: id:324
+msgid "Cleaning paths..."
+msgstr "Maak paaie skoon..."
+
+#: id:325
+msgid "Error cleaning paths"
+msgstr "Fout gedurende paaie skoonmaak"
+
+#: id:326
+msgid "Cleaning albums..."
+msgstr "Maak albums skoon..."
+
+#: id:327
+msgid "Error cleaning albums"
+msgstr "Fout gedurende albums skoonmaak"
+
+#: id:328
+msgid "Writing changes..."
+msgstr "Skryf veranderinge..."
+
+#: id:329
+msgid "Error writing changes"
+msgstr "Fout gedurende veranderinge skryf"
+
+#: id:330
+msgid "This may take some time..."
+msgstr "Hierdie mag tyd vat..."
+
+#: id:331
+msgid "Compressing database..."
+msgstr "Kompres databasis..."
+
+#: id:332
+msgid "Error compressing database"
+msgstr "Fout gedurende kompres van databasis"
+
+#: id:333
+msgid "Do you want to clean the library?"
+msgstr "Wil jy die biblioteek skoonmaak?"
+
+#: id:334
+msgid "Clean library..."
+msgstr "Maak biblioteek skoon..."
+
+#: id:335
+msgid "Start"
+msgstr "Begin"
+
+#: id:336
+msgid "Framerate conversion"
+msgstr "Raamtempo omskakeling"
+
+#: id:337
+msgctxt "Auto context with id 337"
+msgid "Audio output"
+msgstr "Audio uittree"
+
+#: id:338
+msgid "Analog"
+msgstr "Analoog"
+
+#: id:339
+msgid "Optical/Coax"
+msgstr "Opties/Koaksiaal"
+
+#: id:340
+msgid "Various artists"
+msgstr "Verskeie kunstenaars"
+
+#: id:341
+msgid "Play disc"
+msgstr "Speel skyf"
+
+#: id:342
+msgctxt "Auto context with id 342"
+msgid "Movies"
+msgstr "Flieks"
+
+#: id:343
+msgid "Adjust framerate"
+msgstr "Pas raamtempo aan"
+
+#: id:344
+msgid "Actors"
+msgstr "Akteurs"
+
+#: id:345
+msgctxt "Auto context with id 345"
+msgid "Year"
+msgstr "Jaar"
+
+#: id:346
+msgid "Boost volume level on downmix"
+msgstr "Versterk volume vlak met afmenging"
+
+#: id:350
+msgctxt "Auto context with id 350"
+msgid "Programs"
+msgstr "Programme"
+
+#: id:351
+msgctxt "Auto context with id 351"
+msgid "Off"
+msgstr "Af"
+
+#: id:352
+msgid "Dim"
+msgstr "Verdof"
+
+#: id:353
+msgid "Black"
+msgstr "Swart"
+
+#: id:354
+msgid "Matrix trails"
+msgstr "Matriks spore"
+
+#: id:355
+msgid "Screensaver time"
+msgstr "Skermskut tyd"
+
+#: id:356
+msgid "Screensaver mode"
+msgstr "Skermskut modus"
+
+#: id:357
+msgid "Shutdown function timer"
+msgstr "Afskakel funksie tydhouer"
+
+#: id:358
+msgid "All albums"
+msgstr "Alle albums"
+
+#: id:359
+msgid "Recently added albums"
+msgstr "Onlangs bygevoegde albums"
+
+#: id:360
+msgctxt "Auto context with id 360"
+msgid "Screensaver"
+msgstr "Skermskut"
+
+#: id:361
+msgid "R. Slideshow"
+msgstr "R. Skyfievertoning"
+
+#: id:362
+msgid "Screensaver dim level"
+msgstr "Skerskut verdof vlak"
+
+#: id:363
+msgid "Sort by: File"
+msgstr "Sorteer volgens: Lêer"
+
+#: id:364
+msgid "- Dolby Digital (AC3) capable receiver"
+msgstr "- Ontvanger wat Dolby Digital (AC3) kan dekodeer"
+
+#: id:365
+msgctxt "Auto context with id 365"
+msgid "Sort by: Name"
+msgstr "Sorteer volgens: Naam"
+
+#: id:366
+msgid "Sort by: Year"
+msgstr "Sorteer volgens: Jaar"
+
+#: id:367
+msgid "Sort by: Rating"
+msgstr "Sorteer volgens: Gradering"
+
+#: id:368
+msgid "IMDb"
+msgstr "IMDb"
+
+#: id:369
+msgctxt "Auto context with id 369"
+msgid "Title"
+msgstr "Titel"
+
+#: id:370
+msgid "Thunderstorms"
+msgstr "Donderstorms"
+
+#: id:371
+msgid "Partly"
+msgstr "Gedeeltelik"
+
+#: id:372
+msgid "Mostly"
+msgstr "Meestal"
+
+#: id:373
+msgid "Sunny"
+msgstr "Sonnig"
+
+#: id:374
+msgid "Cloudy"
+msgstr "Bewolk"
+
+#: id:375
+msgid "Snow"
+msgstr "Sneeu"
+
+#: id:376
+msgid "Rain"
+msgstr "Reen"
+
+#: id:377
+msgid "Light"
+msgstr "Ligte"
+
+#: id:378
+msgid "AM"
+msgstr "AM"
+
+#: id:379
+msgid "PM"
+msgstr "PM"
+
+#: id:380
+msgid "Showers"
+msgstr "Buie"
+
+#: id:381
+msgid "Few"
+msgstr "Min"
+
+#: id:382
+msgid "Scattered"
+msgstr "Verspreide"
+
+#: id:383
+msgctxt "Auto context with id 383"
+msgid "Wind"
+msgstr "Wind"
+
+#: id:384
+msgid "Strong"
+msgstr "Sterk"
+
+#: id:385
+msgid "Fair"
+msgstr "Mooi"
+
+#: id:386
+msgctxt "Auto context with id 386"
+msgid "Clear"
+msgstr "Helder"
+
+#: id:387
+msgid "Clouds"
+msgstr "Wolke"
+
+#: id:388
+msgid "Early"
+msgstr "Vroeë"
+
+#: id:389
+msgid "Shower"
+msgstr "Bui"
+
+#: id:390
+msgid "Flurries"
+msgstr "Windvlae"
+
+#: id:391
+msgctxt "Auto context with id 391"
+msgid "Low"
+msgstr "Laag"
+
+#: id:392
+msgctxt "Auto context with id 392"
+msgid "Medium"
+msgstr "Medium"
+
+#: id:393
+msgctxt "Auto context with id 393"
+msgid "High"
+msgstr "Hoog"
+
+#: id:394
+msgid "Fog"
+msgstr "Mis"
+
+#: id:395
+msgid "Haze"
+msgstr "Dynserigheid"
+
+#: id:396
+msgid "Select location"
+msgstr "Selekteer lokasie"
+
+#: id:397
+msgid "Refresh time"
+msgstr "Verfris tyd"
+
+#: id:398
+msgid "Temperature units"
+msgstr "Temperatuur eenhede"
+
+#: id:399
+msgid "Speed units"
+msgstr "Spoed eenhede"
+
+#: id:400
+msgctxt "Auto context with id 400"
+msgid "Weather"
+msgstr "Weer"
+
+#: id:401
+msgid "Temp"
+msgstr "Temp"
+
+#: id:402
+msgid "Feels like"
+msgstr "Voel soos"
+
+#: id:403
+msgid "UV index"
+msgstr "UV indeks"
+
+#: id:404
+msgctxt "Auto context with id 404"
+msgid "Wind"
+msgstr "Wind"
+
+#: id:405
+msgid "Dew point"
+msgstr "Doupunt"
+
+#: id:406
+msgid "Humidity"
+msgstr "Humiditeit"
+
+#: id:409
+msgid "Defaults"
+msgstr "Versuim waardes"
+
+#: id:410
+msgid "Accessing weather service"
+msgstr "Verkry toegang tot weer diens"
+
+#: id:411
+msgid "Getting weather for:"
+msgstr "Kry die weer vir:"
+
+#: id:412
+msgid "Unable to get weather data"
+msgstr "Kan nie die weer data kry nie"
+
+#: id:413
+msgid "Manual"
+msgstr "Handrolies"
+
+#: id:414
+msgid "No review for this album"
+msgstr "Geen resensie vir hierdie album"
+
+#: id:415
+msgid "Downloading thumbnail..."
+msgstr "Laai duimnaelskets af..."
+
+#: id:416
+msgid "Not available"
+msgstr "Nie beskikbaar"
+
+#: id:417
+msgid "View: Big icons"
+msgstr "Aansig: Groot ikone"
+
+#: id:418
+msgctxt "Auto context with id 418"
+msgid "Low"
+msgstr "Laag"
+
+#: id:419
+msgctxt "Auto context with id 419"
+msgid "High"
+msgstr "Hoog"
+
+#: id:420
+msgid "HDMI"
+msgstr "HDMI"
+
+#: id:422
+msgid "Delete album info"
+msgstr "Wis album info uit"
+
+#: id:423
+msgid "Delete CD information"
+msgstr "Wis CD inligting uit"
+
+#: id:424
+msgid "Select"
+msgstr "Selekteer"
+
+#: id:425
+msgid "No album information found"
+msgstr "Geen album inligting gevind"
+
+#: id:426
+msgid "No CD information found"
+msgstr "Geen CD inligting gevind"
+
+#: id:427
+msgid "Disc"
+msgstr "Skyf"
+
+#: id:428
+msgid "Insert correct CD/DVD"
+msgstr "Plaas korrekte CD/DVD in dryf"
+
+#: id:429
+msgid "Please insert the following disc:"
+msgstr "Plaas asb die volgende CD/DVD in dryf"
+
+#: id:430
+msgid "Sort by: DVD#"
+msgstr "Sorteer volgens: DVD#"
+
+#: id:431
+msgid "No cache"
+msgstr "Geen cache"
+
+#: id:432
+msgid "Remove movie from library"
+msgstr "Verwyder fliek van biblioteek"
+
+#: id:433
+msgid "Really remove '%s'?"
+msgstr "Verwyder regtig '%s'?"
+
+#: id:434
+msgid "From %s at %i %s"
+msgstr "Van %s op %i %s"
+
+#: id:437
+msgid "Removable disk"
+msgstr "Verwyderbare skyf"
+
+#: id:438
+msgid "Opening file"
+msgstr "Maak lêer oop"
+
+#: id:439
+msgid "Cache"
+msgstr "Cache"
+
+#: id:440
+msgid "Harddisk"
+msgstr "Hardeskyf"
+
+#: id:441
+msgid "UDF"
+msgstr "UDF"
+
+#: id:442
+msgid "Local network"
+msgstr "Lokale netwerk"
+
+#: id:443
+msgid "Internet"
+msgstr "Internet"
+
+#: id:444
+msgctxt "Auto context with id 444"
+msgid "Video"
+msgstr "Video"
+
+#: id:445
+msgctxt "Auto context with id 445"
+msgid "Audio"
+msgstr "Audio"
+
+#: id:446
+msgctxt "Auto context with id 446"
+msgid "DVD"
+msgstr "DVD"
+
+#: id:447
+msgid "Autorun media"
+msgstr "Auto-uitvoer media"
+
+#: id:448
+msgid "LCD"
+msgstr "LCD"
+
+#: id:449
+msgctxt "Auto context with id 449"
+msgid "Enabled"
+msgstr "In staat gestel"
+
+#: id:450
+msgid "Columns"
+msgstr "Kolomme"
+
+#: id:451
+msgid "Row 1 address"
+msgstr "Ry 1 adres"
+
+#: id:452
+msgid "Row 2 address"
+msgstr "Ry 2 adres"
+
+#: id:453
+msgid "Row 3 address"
+msgstr "Ry 3 adres"
+
+#: id:454
+msgid "Row 4 address"
+msgstr "Ry 4 adres"
+
+#: id:455
+msgid "Rows"
+msgstr "Rye"
+
+#: id:456
+msgid "Mode"
+msgstr "Modus"
+
+#: id:457
+msgid "Switch view"
+msgstr "Ruil vertoon"
+
+#: id:459
+msgid "Subs"
+msgstr "Onderskrifte"
+
+#: id:460
+msgid "Audio stream"
+msgstr "Audio strome"
+
+#: id:461
+msgid "[active]"
+msgstr "[aktief]"
+
+#: id:462
+msgid "Subtitle"
+msgstr "Subtitel"
+
+#: id:463
+msgid "Backlight"
+msgstr "Agterlig"
+
+#: id:464
+msgid "Brightness"
+msgstr "Helderheid"
+
+#: id:465
+msgid "Contrast"
+msgstr "Kontras"
+
+#: id:466
+msgid "Gamma"
+msgstr "Gamma"
+
+#: id:467
+msgctxt "Auto context with id 467"
+msgid "Type"
+msgstr "Tipe"
+
+#: id:468
+msgid "Move the bar to change the OSD position"
+msgstr "Skuif die balk om die OSD posisie te verander"
+
+#: id:469
+msgid "OSD position"
+msgstr "OSD posisie"
+
+#: id:470
+msgid "Credits"
+msgstr "Krediete"
+
+#: id:471
+msgid "Modchip"
+msgstr "Modchip"
+
+#: id:474
+msgctxt "Auto context with id 474"
+msgid "Off"
+msgstr "Af"
+
+#: id:475
+msgid "Music only"
+msgstr "Slegs musiek"
+
+#: id:476
+msgctxt "Auto context with id 476"
+msgid "Music & video"
+msgstr "Musiek & video"
+
+#: id:477
+msgid "Unable to load playlist"
+msgstr "Kan nie speellys laai nie"
+
+#: id:478
+msgid "OSD"
+msgstr "OSD"
+
+#: id:479
+msgid "Skin & language"
+msgstr "Omslag & taal"
+
+#: id:480
+msgid "Appearance"
+msgstr "Voorkoms"
+
+#: id:481
+msgid "Audio options"
+msgstr "Audio opsies"
+
+#: id:482
+msgid "About XBMC"
+msgstr "Omtrent XBMC"
+
+#: id:485
+msgid "Delete album"
+msgstr "Wis album uit"
+
+#: id:486
+msgid "Repeat"
+msgstr "Herhaal"
+
+#: id:487
+msgid "Repeat one"
+msgstr "Herhaal een"
+
+#: id:488
+msgid "Repeat folder"
+msgstr "Herhaal vouer"
+
+#: id:489
+msgid "Play the next song automatically"
+msgstr "Speel die volgende liedjie automaties"
+
+#: id:491
+msgid "- Use big icons"
+msgstr "- Gebruik groot ikone"
+
+#: id:492
+msgid "Resize VobSubs"
+msgstr "Verander VobSubs grootte"
+
+#: id:493
+msgid "Advanced options (Experts Only!)"
+msgstr "Gevorderde opsies (Eksperte Alleenlik!)"
+
+#: id:494
+msgid "Overall audio headroom"
+msgstr "Algehele audio kopspasie"
+
+#: id:495
+msgid "Upsample videos to GUI resolution"
+msgstr "Monster videos op tot GUI resolusie"
+
+#: id:496
+msgid "Calibration"
+msgstr "Kalibrasie"
+
+#: id:497
+msgid "Show file extensions"
+msgstr "Wys lêer uitbreidings"
+
+#: id:498
+msgid "Sort by: Type"
+msgstr "Sorteer volgens: Tipe"
+
+#: id:499
+msgid "Unable to connect to online lookup service"
+msgstr "Kan nie aan aanlyn opsoek diens verbind nie"
+
+#: id:500
+msgid "Downloading album information failed"
+msgstr "Aflaai van album inligting het gefaal"
+
+#: id:501
+msgid "Looking for album names..."
+msgstr "Soek album name..."
+
+#: id:502
+msgctxt "Auto context with id 502"
+msgid "Open"
+msgstr "Maak oop"
+
+#: id:503
+msgid "Busy"
+msgstr "Besig"
+
+#: id:504
+msgid "Empty"
+msgstr "Leeg"
+
+#: id:505
+msgid "Loading media info from files..."
+msgstr "Laai media inligting vanaf lêers..."
+
+#: id:507
+msgid "Sort by: Usage"
+msgstr "Sorteer volgens: Gebruik"
+
+#: id:510
+msgid "Enable visualizations"
+msgstr "Stel visualiserings in staat"
+
+#: id:511
+msgid "Enable video mode switching"
+msgstr "Stel video modus skakeling in staat"
+
+#: id:512
+msgid "Startup window"
+msgstr "Begin Venster"
+
+#: id:513
+msgid "Home window"
+msgstr "Tuis venster"
+
+#: id:514
+msgid "Manual settings"
+msgstr "Hand verstellings"
+
+#: id:515
+msgid "Genre"
+msgstr "Genre"
+
+#: id:517
+msgid "Recently played albums"
+msgstr "Onlangs gespeelde albums"
+
+#: id:518
+msgid "Launch"
+msgstr "Loods"
+
+#: id:519
+msgid "Launch in..."
+msgstr "Loods in..."
+
+#: id:521
+msgid "Compilations"
+msgstr "Kompilasies"
+
+#: id:522
+msgid "Remove source"
+msgstr "Verwyder bron"
+
+#: id:523
+msgid "Switch media"
+msgstr "Ruil media"
+
+#: id:524
+msgid "Select playlist"
+msgstr "Selekteer speellys"
+
+#: id:525
+msgid "New playlist..."
+msgstr "Nuwe speellys..."
+
+#: id:526
+msgid "Add to playlist"
+msgstr "Voeg by speellys"
+
+#: id:527
+msgid "Manually add to library"
+msgstr "Voeg handrolies by biblioteek"
+
+#: id:528
+msgid "Enter title"
+msgstr "Tik titel in"
+
+#: id:529
+msgid "Error: Duplicate title"
+msgstr "Fout: Duplikaat titel"
+
+#: id:530
+msgid "Select genre"
+msgstr "Selekteer genre"
+
+#: id:531
+msgid "New genre"
+msgstr "Nuwe genre"
+
+#: id:532
+msgid "Manual addition"
+msgstr "Hand byvoeging"
+
+#: id:533
+msgid "Enter genre"
+msgstr "Tik genre in"
+
+#: id:534
+msgid "View: %s"
+msgstr "Aansig: %s"
+
+#: id:535
+msgid "List"
+msgstr "Lys"
+
+#: id:536
+msgid "Icons"
+msgstr "Ikone"
+
+#: id:537
+msgid "Big list"
+msgstr "Groot lys"
+
+#: id:538
+msgid "Big icons"
+msgstr "Groot ikone"
+
+#: id:539
+msgid "Wide"
+msgstr "Wyd"
+
+#: id:540
+msgid "Big wide"
+msgstr "Groot wyd"
+
+#: id:541
+msgid "Album icons"
+msgstr "Album ikone"
+
+#: id:542
+msgid "DVD icons"
+msgstr "DVD ikone"
+
+#: id:543
+msgctxt "Auto context with id 543"
+msgid "DVD"
+msgstr "DVD"
+
+#: id:544
+msgctxt "Auto context with id 544"
+msgid "Media info"
+msgstr "Media info"
+
+#: id:545
+msgid "Audio output device"
+msgstr "Audio uittree toestel"
+
+#: id:546
+msgid "Passthrough output device"
+msgstr "Deurvoer uittree toestel"
+
+#: id:547
+msgid "No biography for this artist"
+msgstr "Geen biografie vir hierdie kunstenaar"
+
+#: id:548
+msgid "Downmix multichannel audio to stereo"
+msgstr "Meng multikanaal audio af na stereo"
+
+#: id:550
+msgid "Sort by: %s"
+msgstr "Sorteer volgens: %s"
+
+#: id:551
+msgctxt "Auto context with id 551"
+msgid "Name"
+msgstr "Naam"
+
+#: id:552
+msgid "Date"
+msgstr "Datum"
+
+#: id:553
+msgid "Size"
+msgstr "Grootte"
+
+#: id:554
+msgid "Track"
+msgstr "Snit"
+
+#: id:555
+msgid "Time"
+msgstr "Tyd"
+
+#: id:556
+msgctxt "Auto context with id 556"
+msgid "Title"
+msgstr "Titel"
+
+#: id:557
+msgid "Artist"
+msgstr "Kunstenaar"
+
+#: id:558
+msgid "Album"
+msgstr "Album"
+
+#: id:559
+msgid "Playlist"
+msgstr "Speellys"
+
+#: id:560
+msgid "ID"
+msgstr "ID"
+
+#: id:561
+msgctxt "Auto context with id 561"
+msgid "File"
+msgstr "Lêer"
+
+#: id:562
+msgctxt "Auto context with id 562"
+msgid "Year"
+msgstr "Jaar"
+
+#: id:563
+msgid "Rating"
+msgstr "Gradering"
+
+#: id:564
+msgctxt "Auto context with id 564"
+msgid "Type"
+msgstr "Tipe"
+
+#: id:565
+msgid "Usage"
+msgstr "Gebruik"
+
+#: id:566
+msgid "Album artist"
+msgstr "Album kunstenaar"
+
+#: id:567
+msgid "Play count"
+msgstr "Speel telling"
+
+#: id:568
+msgid "Last played"
+msgstr "Laaste gespeel"
+
+#: id:569
+msgctxt "Auto context with id 569"
+msgid "Comment"
+msgstr "Kommentaar"
+
+#: id:570
+msgid "Date added"
+msgstr "Datum bygevoeg"
+
+#: id:571
+msgctxt "Auto context with id 571"
+msgid "Default"
+msgstr "Verstek"
+
+#: id:572
+msgid "Studio"
+msgstr "Ateljee"
+
+#: id:573
+msgid "Path"
+msgstr "Stop"
+
+#: id:574
+msgctxt "Auto context with id 574"
+msgid "Country"
+msgstr "Land"
+
+#: id:575
+msgid "In progress"
+msgstr "Aan die gang"
+
+#: id:576
+msgid "Times played"
+msgstr ""
+
+#: id:580
+msgid "Sort direction"
+msgstr "Sorteer rigting"
+
+#: id:581
+msgid "Sort method"
+msgstr "Sorteer metode"
+
+#: id:582
+msgctxt "Auto context with id 582"
+msgid "View mode"
+msgstr "Aansig modus"
+
+#: id:583
+msgid "Remember views for different folders"
+msgstr "Onthou aansigte vir verskillende vouers"
+
+#: id:584
+msgid "Ascending"
+msgstr "Stygend"
+
+#: id:585
+msgid "Descending"
+msgstr "Dalend"
+
+#: id:586
+msgid "Edit playlist"
+msgstr "Redigeer speellys"
+
+#: id:587
+msgid "Filter"
+msgstr "Filter"
+
+#: id:588
+msgid "Cancel party mode"
+msgstr "Kanselleer partytjie modus"
+
+#: id:589
+msgid "Party mode"
+msgstr "Partytjie modus"
+
+#: id:590
+msgid "Random"
+msgstr "Lukraak"
+
+#: id:591
+msgctxt "Auto context with id 591"
+msgid "Off"
+msgstr "Af"
+
+#: id:592
+msgid "One"
+msgstr "Een"
+
+#: id:593
+msgid "All"
+msgstr "Almal"
+
+#: id:594
+msgctxt "Auto context with id 594"
+msgid "Off"
+msgstr "Af"
+
+#: id:595
+msgid "Repeat: Off"
+msgstr "Herhaal: Af"
+
+#: id:596
+msgid "Repeat: One"
+msgstr "Herhaal: Een"
+
+#: id:597
+msgid "Repeat: All"
+msgstr "Herhaal: Almal"
+
+#: id:600
+msgid "Rip audio CD"
+msgstr "Rip audio CD"
+
+#: id:601
+msgctxt "Auto context with id 601"
+msgid "Medium"
+msgstr "Medium"
+
+#: id:602
+msgctxt "Auto context with id 602"
+msgid "Standard"
+msgstr "Standaard"
+
+#: id:603
+msgid "Extreme"
+msgstr "Ekstreme"
+
+#: id:604
+msgid "Constant bitrate"
+msgstr "Konstante bistempo"
+
+#: id:605
+msgid "Ripping..."
+msgstr "Rip..."
+
+#: id:607
+msgid "To:"
+msgstr "Aan:"
+
+#: id:608
+msgid "Could not rip CD or track"
+msgstr "Kon nie CD of snit rip"
+
+#: id:609
+msgid "CDDARipPath is not set."
+msgstr "CDDARipPad is nie gestel."
+
+#: id:610
+msgid "Rip audio track"
+msgstr "Rip audio snit"
+
+#: id:611
+msgid "Enter number"
+msgstr "Tik nommer in"
+
+#: id:612
+msgid "Bits/Sample"
+msgstr "Bisse/Monster"
+
+#: id:613
+msgid "Sample Frequency"
+msgstr "Monster Frekwensie"
+
+#: id:620
+msgid "Audio CDs"
+msgstr "Audio CDs"
+
+#: id:621
+msgid "Encoder"
+msgstr "Enkodeerder"
+
+#: id:622
+msgid "Quality"
+msgstr "Kwaliteit"
+
+#: id:623
+msgid "Bitrate"
+msgstr "Bistempo"
+
+#: id:624
+msgid "Include track number"
+msgstr "Sluit snit nommer in"
+
+#: id:625
+msgid "All songs of"
+msgstr "Alle liedjies of"
+
+#: id:629
+msgctxt "Auto context with id 629"
+msgid "View mode"
+msgstr "Aansig modus"
+
+#: id:630
+msgctxt "Auto context with id 630"
+msgid "Normal"
+msgstr "Normaal"
+
+#: id:631
+msgid "Zoom"
+msgstr "Zoem"
+
+#: id:632
+msgid "Stretch 4:3"
+msgstr "Rek 4:3"
+
+#: id:633
+msgid "Wide Zoom"
+msgstr "Wye Zoem"
+
+#: id:634
+msgid "Stretch 16:9"
+msgstr "Rek 16:9"
+
+#: id:635
+msgid "Original Size"
+msgstr "Oorspronklike Grootte"
+
+#: id:636
+msgctxt "Auto context with id 636"
+msgid "Custom"
+msgstr "Verpersoonlik"
+
+#: id:637
+msgid "Replay gain"
+msgstr "Herspeel aanwins"
+
+#: id:638
+msgid "Replaygain volume adjustments"
+msgstr "Herspeel aanwins volume aanpassings"
+
+#: id:639
+msgid "Use track levels"
+msgstr "Gebruik snit vlakke"
+
+#: id:640
+msgid "Use album levels"
+msgstr "Gebruik album vlakke"
+
+#: id:641
+msgid "PreAmp Level - Replay gained files"
+msgstr "Voorversterker Vlak - Lêers met herspeel aanwins"
+
+#: id:642
+msgid "PreAmp Level - Non replay gained files"
+msgstr "Voorversterker vlak - Lêers sonder herspeel aanwins"
+
+#: id:643
+msgid "Avoid clipping on replay gained files"
+msgstr "Vermy clipping op herspeel versterkte lêers"
+
+#: id:644
+msgid "Crop black bars"
+msgstr "Knip swart stawe"
+
+#: id:645
+msgid "Need to unpack a big file. Continue?"
+msgstr "Moet 'n groot lêer uitpak. Gaan voort?"
+
+#: id:646
+msgid "Remove from library"
+msgstr "Verwyder uit biblioteek"
+
+#: id:647
+msgid "Export video library"
+msgstr "Voer video biblioteek uit"
+
+#: id:648
+msgid "Import video library"
+msgstr "Voer video biblioteek in"
+
+#: id:649
+msgid "Importing"
+msgstr "Voer in"
+
+#: id:650
+msgid "Exporting"
+msgstr "Voer uit"
+
+#: id:651
+msgid "Browse for library"
+msgstr "Soek biblioteek"
+
+#: id:652
+msgid "Years"
+msgstr "Jare"
+
+#: id:653
+msgid "Update library"
+msgstr "Opdateer biblioteek"
+
+#: id:654
+msgid "Show debug info"
+msgstr "Wys ontfout info"
+
+#: id:655
+msgid "Browse for executable"
+msgstr "Soek uitvoerbare"
+
+#: id:656
+msgid "Browse for playlist"
+msgstr "Soek speellys"
+
+#: id:657
+msgid "Browse for folder"
+msgstr "Soek vouer"
+
+#: id:658
+msgid "Song information"
+msgstr "Liedjie inligting"
+
+#: id:659
+msgid "Non-linear stretch"
+msgstr "Nie-lineêre strek"
+
+#: id:660
+msgid "Volume amplification"
+msgstr "Volume versterking"
+
+#: id:661
+msgid "Choose export folder"
+msgstr "Kies uitvoer vouer"
+
+#: id:662
+msgid "This file is no longer available."
+msgstr "Hierdie lêer is nie meer beskikbaar."
+
+#: id:663
+msgid "Would you like to remove it from the library?"
+msgstr "Wil jy dit verwyder uit die biblioteek?"
+
+#: id:664
+msgid "Browse for Script"
+msgstr "Soek Skrip"
+
+#: id:665
+msgid "Compression level"
+msgstr "Kompressie vlak"
+
+#: id:700
+msgid "Cleaning up library"
+msgstr "Maak biblioteek skoon"
+
+#: id:701
+msgid "Removing old songs from the library"
+msgstr "Verwyder ou liedjies uit die biblioteek"
+
+#: id:702
+msgid "This path has been scanned before"
+msgstr "Hierdie pad is al vantevore deursoek"
+
+#: id:705
+msgctxt "Auto context with id 705"
+msgid "Network"
+msgstr "Netwerk"
+
+#: id:706
+msgid "- Server"
+msgstr "- Bediener"
+
+#: id:708
+msgid "Use an HTTP proxy server to access the internet"
+msgstr "Gebruik 'n HTTP proksie bediener vir toegang tot die internet"
+
+#: id:711
+msgid "Internet Protocol (IP)"
+msgstr "Internet Protokol (IP)"
+
+#: id:712
+msgid "Invalid port specified. Value must be between 1 and 65535."
+msgstr "Ongeldige poort gespesifiseer. Waarde moet tussen 1 en 65535 wees."
+
+#: id:713
+msgid "HTTP proxy"
+msgstr "HTTP proksie"
+
+#: id:715
+msgid "- Assignment"
+msgstr "- Toekenning"
+
+#: id:716
+msgid "Automatic (DHCP)"
+msgstr "Automaties (DHCP)"
+
+#: id:717
+msgid "Manual (Static)"
+msgstr "Handrolies (Staties)"
+
+#: id:719
+msgid "- IP address"
+msgstr "- IP adres"
+
+#: id:720
+msgid "- Netmask"
+msgstr "- Netmasker"
+
+#: id:721
+msgid "- Default gateway"
+msgstr "- Verstek portaal"
+
+#: id:722
+msgid "- DNS server"
+msgstr "- DNS bediener"
+
+#: id:723
+msgid "Save & restart"
+msgstr "Stoor & begin oor"
+
+#: id:724
+msgid "Invalid address specified. Value must be AAA.BBB.CCC.DDD"
+msgstr "Ongeldige adres gespesifiseer. Waarde moet AAA.BBB.CCC.DDD wees"
+
+#: id:725
+msgid "with numbers between 0 and 255."
+msgstr "met nommers tussen 0 en 255."
+
+#: id:726
+msgid "Changes not saved. Continue without saving?"
+msgstr "Veranderinge nie gestoor. Gaan voort sonder om te stoor?"
+
+#: id:727
+msgid "Web server"
+msgstr "Web bediener"
+
+#: id:728
+msgctxt "Auto context with id 728"
+msgid "FTP server"
+msgstr "FTP bediener"
+
+#: id:730
+msgid "- Port"
+msgstr "- Poort"
+
+#: id:732
+msgid "Save & apply"
+msgstr "Stoor & wend aan"
+
+#: id:733
+msgid "- Password"
+msgstr "- Wagwoord"
+
+#: id:734
+msgid "No pass"
+msgstr "Geen wagwoord"
+
+#: id:735
+msgid "- Character set"
+msgstr "- Karakter stel"
+
+#: id:736
+msgid "- Style"
+msgstr "- Styl"
+
+#: id:737
+msgid "- Colour"
+msgstr "- Kleur"
+
+#: id:738
+msgctxt "Auto context with id 738"
+msgid "Normal"
+msgstr "Normaal"
+
+#: id:739
+msgid "Bold"
+msgstr "Vet"
+
+#: id:740
+msgid "Italics"
+msgstr "Kursief"
+
+#: id:741
+msgid "Bold italics"
+msgstr "Vet kursief"
+
+#: id:742
+msgctxt "Auto context with id 742"
+msgid "White"
+msgstr "Wit"
+
+#: id:743
+msgctxt "Auto context with id 743"
+msgid "Yellow"
+msgstr "Geel"
+
+#: id:744
+msgctxt "Auto context with id 744"
+msgid "Files"
+msgstr "Lêers"
+
+#: id:745
+msgid "No scanned information for this view"
+msgstr "Geen ondersoekte inligting vir hierdie aansig"
+
+#: id:746
+msgid "Please turn off library mode"
+msgstr "Skakel asseblief biblioteek modus af"
+
+#: id:747
+msgid "Error loading image"
+msgstr "Fout gedurende laai van prentjie"
+
+#: id:748
+msgid "Edit path"
+msgstr "Redigeer pad"
+
+#: id:749
+msgid "Mirror image"
+msgstr "Spieëlbeeld prentjie"
+
+#: id:750
+msgid "Are you sure?"
+msgstr "Is jy seker?"
+
+#: id:751
+msgid "Removing source"
+msgstr "Verwyder bron"
+
+#: id:754
+msgid "Add program link"
+msgstr "Voeg program skakel by"
+
+#: id:755
+msgid "Edit program path"
+msgstr "Redigeer program pad"
+
+#: id:756
+msgid "Edit program name"
+msgstr "Redigeer program naam"
+
+#: id:757
+msgid "Edit path depth"
+msgstr "Redigeer pad diepte"
+
+#: id:759
+msgid "View: Big list"
+msgstr "Aansig: Groot lys"
+
+#: id:760
+msgctxt "Auto context with id 760"
+msgid "Yellow"
+msgstr "Geel"
+
+#: id:761
+msgctxt "Auto context with id 761"
+msgid "White"
+msgstr "Wit"
+
+#: id:762
+msgid "Blue"
+msgstr "Blou"
+
+#: id:763
+msgid "Bright green"
+msgstr "Helder groen"
+
+#: id:764
+msgid "Yellow green"
+msgstr "Geel groen"
+
+#: id:765
+msgid "Cyan"
+msgstr "Siaan"
+
+#: id:766
+msgid "Light grey"
+msgstr "Ligte grys"
+
+#: id:767
+msgid "Grey"
+msgstr "Grys"
+
+#: id:770
+msgid "Error %i: share not available"
+msgstr "Fout %i: saamdeel nie beskikbaar"
+
+#: id:772
+msgctxt "Auto context with id 772"
+msgid "Audio output"
+msgstr "Audio uittree"
+
+#: id:773
+msgid "Seeking"
+msgstr "Soek"
+
+#: id:774
+msgid "Slideshow folder"
+msgstr "Skyfievertoning vouer"
+
+#: id:775
+msgid "Network interface"
+msgstr "Netwerk koppelvlak"
+
+#: id:776
+msgid "- Wireless network name (ESSID)"
+msgstr "- Koortlose netwerk naam (ESSID)"
+
+#: id:777
+msgid "- Wireless password"
+msgstr "- Koortlose wagwoord"
+
+#: id:778
+msgid "- Wireless security"
+msgstr "- Koortlose sekuriteit"
+
+#: id:779
+msgid "Save and apply network interface settings"
+msgstr "Stoor en pas netwerk koppelvlak verstellings toe"
+
+#: id:780
+msgid "No encryption"
+msgstr "Geen enkripsie"
+
+#: id:781
+msgid "WEP"
+msgstr "WEP"
+
+#: id:782
+msgid "WPA"
+msgstr "WPA"
+
+#: id:783
+msgid "WPA2"
+msgstr "WPA2"
+
+#: id:784
+msgid "Applying network interface settings. Please wait."
+msgstr "Pas netwerk koppelvlak verstellings toe. Wag asseblief."
+
+#: id:785
+msgid "Network interface restarted successfully."
+msgstr "Netwerk koppelvlak suksesvol oor begin."
+
+#: id:786
+msgid "Network interface did not start successfully."
+msgstr "Netwerk koppelvlak het nie suksesvol begin."
+
+#: id:787
+msgid "Interface disabled"
+msgstr "Koppelvlak nie in staat gestel"
+
+#: id:788
+msgid "Network interface disabled successfully."
+msgstr "Netwerk koppelvlak nie suksesvol in staat gestel."
+
+#: id:789
+msgid "Wireless network name (ESSID)"
+msgstr "Koortlose netwerk naam (ESSID)"
+
+#: id:790
+msgid "Remote control"
+msgstr ""
+
+#: id:791
+msgid "Allow programs on this system to control XBMC"
+msgstr "Laat programme op hierdie stelsel toe om XBMC te beheer"
+
+#: id:792
+msgctxt "Auto context with id 792"
+msgid "Port"
+msgstr "Poort"
+
+#: id:793
+msgid "Port range"
+msgstr "Poort bereik"
+
+#: id:794
+msgid "Allow programs on other systems to control XBMC"
+msgstr "Laat programme op ander stelsels toe om XBMC te beheer"
+
+#: id:795
+msgid "Initial repeat delay (ms)"
+msgstr "Begin herhaal vertraging (ms)"
+
+#: id:796
+msgid "Continuous repeat delay (ms)"
+msgstr "Kontinuele herhaal vertraging (ms)"
+
+#: id:797
+msgid "Maximum number of clients"
+msgstr "Maksimum hoeveelheid kliënte"
+
+#: id:798
+msgid "Internet access"
+msgstr "Internet toegang"
+
+#: id:850
+msgid "Invalid port number entered"
+msgstr "Ongeldige poort nommer ingetik"
+
+#: id:851
+msgid "Valid port range is 1-65535"
+msgstr "Geldige poort bereik is 1-65535"
+
+#: id:852
+msgid "Valid port range is 1024-65535"
+msgstr "Geldige poort bereik is 1024-65535"
+
+#: id:998
+msgid "Add Music..."
+msgstr ""
+
+#: id:999
+msgid "Add Videos..."
+msgstr ""
+
+#: id:1000
+msgid "- Preview"
+msgstr "- Voorskou"
+
+#: id:1001
+msgid "Unable to connect"
+msgstr "Kan nie konnekteer"
+
+#: id:1002
+msgid "XBMC was unable to connect to the network location."
+msgstr "XBMC kon nie konnekteer aan die netwerk lokasie."
+
+#: id:1003
+msgid "This could be due to the network not being connected."
+msgstr "Dit kan wees dat die netwerk nie gekonnekteer is nie."
+
+#: id:1004
+msgid "Would you like to add it anyway?"
+msgstr "Wil jy dit elk geval byvoeg?"
+
+#: id:1006
+msgctxt "Auto context with id 1006"
+msgid "IP address"
+msgstr "IP adres"
+
+#: id:1007
+msgid "Add network location"
+msgstr "Voeg netwerk lokasie by"
+
+#: id:1008
+msgid "Protocol"
+msgstr "Protokol"
+
+#: id:1009
+msgid "Server address"
+msgstr "Bediener adres"
+
+#: id:1010
+msgid "Server name"
+msgstr "Bediener naam"
+
+#: id:1011
+msgid "Remote path"
+msgstr "Afgeleë pad"
+
+#: id:1012
+msgid "Shared folder"
+msgstr "Saamgedeelde vouer"
+
+#: id:1013
+msgctxt "Auto context with id 1013"
+msgid "Port"
+msgstr "Poort"
+
+#: id:1014
+msgctxt "Auto context with id 1014"
+msgid "Username"
+msgstr "Gebruikersnaam"
+
+#: id:1015
+msgid "Browse for network server"
+msgstr "Soek netwerk bediener"
+
+#: id:1016
+msgid "Enter the network address of the server"
+msgstr "Tik die netwerk adres of die bediener in"
+
+#: id:1017
+msgid "Enter the path on the server"
+msgstr "Tik die pad op die bediener in"
+
+#: id:1018
+msgid "Enter the port number"
+msgstr "Tik die poort nommer in"
+
+#: id:1019
+msgid "Enter the username"
+msgstr "Tik die gebruikersnaam in"
+
+#: id:1020
+msgid "Add %s source"
+msgstr "Voeg %s bron by"
+
+#: id:1021
+msgid "Enter the paths or browse for the media locations."
+msgstr "Tik die paaie in of soek die media lokasies."
+
+#: id:1022
+msgid "Enter a name for this media Source."
+msgstr "Tik 'n naam in vir hierdie media Bron."
+
+#: id:1023
+msgid "Browse for new share"
+msgstr "Soek nuwe saamdeel"
+
+#: id:1024
+msgid "Browse"
+msgstr "Soek"
+
+#: id:1025
+msgid "Could not retrieve directory information."
+msgstr "Kon nie gids inligting kry nie."
+
+#: id:1026
+msgid "Add source"
+msgstr "Voeg bron by"
+
+#: id:1027
+msgid "Edit source"
+msgstr "Redigeer bron"
+
+#: id:1028
+msgid "Edit %s source"
+msgstr "Redigeer %s bron"
+
+#: id:1029
+msgid "Enter the new label"
+msgstr "Tik die nuwe etiket in"
+
+#: id:1030
+msgid "Browse for image"
+msgstr "Soek prentjie"
+
+#: id:1031
+msgid "Browse for image folder"
+msgstr "Soek prentjie vouer"
+
+#: id:1032
+msgid "Add network location..."
+msgstr "Voeg netwerk lokasie by..."
+
+#: id:1033
+msgid "Browse for file"
+msgstr "Soek vir lêer"
+
+#: id:1034
+msgid "Submenu"
+msgstr "Subkieslys"
+
+#: id:1035
+msgid "Enable submenu buttons"
+msgstr "Stel subkieslys knoppies in staat"
+
+#: id:1036
+msgid "Favourites"
+msgstr "Gunstelinge"
+
+#: id:1037
+msgid "Video Add-ons"
+msgstr "Video Byvoegsels"
+
+#: id:1038
+msgid "Music Add-ons"
+msgstr "Musiek Byvoegsels"
+
+#: id:1039
+msgid "Picture Add-ons"
+msgstr "Prentjie Byvoegsels"
+
+#: id:1040
+msgid "Loading directory"
+msgstr "Laai gids"
+
+#: id:1041
+msgid "Retrieved %i items"
+msgstr "%i items gevind"
+
+#: id:1042
+msgid "Retrieved %i of %i items"
+msgstr "%i van %i items gevind"
+
+#: id:1043
+msgid "Program Add-ons"
+msgstr "Program Byvoegsels"
+
+#: id:1044
+msgid "Set plugin thumb"
+msgstr "Stel inprop duim"
+
+#: id:1045
+msgid "Add-on settings"
+msgstr "Byvoegsel verstellings"
+
+#: id:1046
+msgid "Access points"
+msgstr "Toegangs-punte"
+
+#: id:1047
+msgid "Other..."
+msgstr "Ander..."
+
+#: id:1048
+msgid "- Username"
+msgstr "- Gebruikersnaam"
+
+#: id:1049
+msgid "Script settings"
+msgstr "Skrip verstellings"
+
+#: id:1050
+msgid "Singles"
+msgstr "Enkelspelers"
+
+#: id:1051
+msgid "Enter web address"
+msgstr "Tik web adres in"
+
+#: id:1200
+msgid "SMB client"
+msgstr "SMB kliënt"
+
+#: id:1202
+msgid "Workgroup"
+msgstr "Werksgroup"
+
+#: id:1203
+msgid "Default username"
+msgstr "Verstek gebruikersnaam"
+
+#: id:1204
+msgid "Default password"
+msgstr "Verstek wagwoord"
+
+#: id:1207
+msgid "WINS server"
+msgstr "WINS bediener"
+
+#: id:1208
+msgid "Mount SMB shares"
+msgstr "Monteer SMB saamgedeeldes"
+
+#: id:1210
+msgctxt "Auto context with id 1210"
+msgid "Remove"
+msgstr "Verwyder"
+
+#: id:1211
+msgctxt "Auto context with id 1211"
+msgid "Music"
+msgstr "Musiek"
+
+#: id:1212
+msgctxt "Auto context with id 1212"
+msgid "Video"
+msgstr "Video"
+
+#: id:1213
+msgctxt "Auto context with id 1213"
+msgid "Pictures"
+msgstr "Prentjies"
+
+#: id:1214
+msgctxt "Auto context with id 1214"
+msgid "Files"
+msgstr "Lêers"
+
+#: id:1215
+msgctxt "Auto context with id 1215"
+msgid "Music & video"
+msgstr "Musiek & video"
+
+#: id:1216
+msgid "Music & pictures"
+msgstr "Musiek & prentjies"
+
+#: id:1217
+msgid "Music & files"
+msgstr "Musiek & lêers"
+
+#: id:1218
+msgid "Video & pictures"
+msgstr "Video & prentjies"
+
+#: id:1219
+msgid "Video & files"
+msgstr "Video & lêers"
+
+#: id:1220
+msgid "Pictures & files"
+msgstr "Prentjies & lêers"
+
+#: id:1221
+msgid "Music & video & pictures"
+msgstr "Musiek & video & prentjies"
+
+#: id:1222
+msgid "Music & video & pictures & files"
+msgstr "Musiek & video & prentjies & lêers"
+
+#: id:1223
+msgctxt "Auto context with id 1223"
+msgid "Disabled"
+msgstr "Nie in staat gestel"
+
+#: id:1226
+msgid "Files & music & video"
+msgstr "Lêers & musiek & video"
+
+#: id:1227
+msgid "Files & pictures & music"
+msgstr "Lêers & prentjies & musiek"
+
+#: id:1228
+msgid "Files & pictures & video"
+msgstr "Lêers & prentjies & video"
+
+#: id:1229
+msgid "Music & programs"
+msgstr "Musiek & programme"
+
+#: id:1230
+msgid "Video & programs"
+msgstr "Video & programme"
+
+#: id:1231
+msgid "Pictures & programs"
+msgstr "Prentjies & programme"
+
+#: id:1232
+msgid "Music & video & pictures & programs"
+msgstr "Musiek & video & prentjies & programme"
+
+#: id:1233
+msgid "Programs & video & music"
+msgstr "Programme & video & musiek"
+
+#: id:1234
+msgid "Programs & pictures & music"
+msgstr "Programme & prentjies & musiek"
+
+#: id:1235
+msgid "Programs & pictures & video"
+msgstr "Programme & prentjies & video"
+
+#: id:1250
+msgid "Auto-detection"
+msgstr "Auto-opsporing"
+
+#: id:1251
+msgid "Auto-detect system"
+msgstr "Stelsel auto-opspoor"
+
+#: id:1252
+msgid "Nickname"
+msgstr "Bynaam"
+
+#: id:1254
+msgid "Ask to connect"
+msgstr "Vra om te konnekteer"
+
+#: id:1255
+msgid "Send FTP user and password"
+msgstr "Stuur FTP gebruiker en wagwoord"
+
+#: id:1256
+msgid "Ping interval"
+msgstr "Ping interval"
+
+#: id:1257
+msgid "Would you like to connect to the auto-detected system?"
+msgstr "Wil jy aan die auto-opgespoorde stelsel konnekteer?"
+
+#: id:1259
+msgid "Zeroconf"
+msgstr ""
+
+#: id:1260
+msgid "Announce these services to other systems via Zeroconf"
+msgstr "Kondig hierdie dienste aan ander stelsels aan via Zeroconf"
+
+#: id:1270
+msgid "Allow XBMC to receive AirPlay content"
+msgstr ""
+
+#: id:1271
+msgid "Device name"
+msgstr ""
+
+#: id:1272
+msgid "- Use password protection"
+msgstr ""
+
+#: id:1273
+msgid "AirPlay"
+msgstr ""
+
+#: id:1300
+msgid "Custom audio device"
+msgstr "Verpersoonlikte audio toestel"
+
+#: id:1301
+msgid "Custom passthrough device"
+msgstr "Verpersoonlikte deurvoer toestel"
+
+#: id:1396
+msgid "Drifting"
+msgstr "Dryf"
+
+#: id:1397
+msgid "and"
+msgstr "en"
+
+#: id:1398
+msgid "Freezing"
+msgstr "Vries"
+
+#: id:1399
+msgid "Late"
+msgstr "Laat"
+
+#: id:1400
+msgid "Isolated"
+msgstr "Geïsoleerde"
+
+#: id:1401
+msgid "Thundershowers"
+msgstr "Donderbuie"
+
+#: id:1402
+msgid "Thunder"
+msgstr "Donder"
+
+#: id:1403
+msgctxt "Auto context with id 1403"
+msgid "Sun"
+msgstr "Son"
+
+#: id:1404
+msgid "Heavy"
+msgstr "Swaar"
+
+#: id:1405
+msgid "in"
+msgstr "in"
+
+#: id:1406
+msgid "the"
+msgstr "die"
+
+#: id:1407
+msgid "Vicinity"
+msgstr "Omgewing"
+
+#: id:1408
+msgid "Ice"
+msgstr "Ys"
+
+#: id:1409
+msgid "Crystals"
+msgstr "Kristalle"
+
+#: id:1410
+msgid "Calm"
+msgstr "Kalm"
+
+#: id:1411
+msgid "with"
+msgstr "met"
+
+#: id:1412
+msgid "windy"
+msgstr "winderig"
+
+#: id:1413
+msgid "drizzle"
+msgstr "motreën"
+
+#: id:1414
+msgid "Thunderstorm"
+msgstr "Donderstorm"
+
+#: id:1415
+msgid "Drizzle"
+msgstr "Motreën"
+
+#: id:1416
+msgid "Foggy"
+msgstr "Mistig"
+
+#: id:1417
+msgid "Grains"
+msgstr "Grains"
+
+#: id:1418
+msgid "T-Storms"
+msgstr "D-Storms"
+
+#: id:1419
+msgid "T-Showers"
+msgstr "D-Buie"
+
+#: id:1420
+msgid "Moderate"
+msgstr "Matige"
+
+#: id:1421
+msgid "Very High"
+msgstr "Baie hoë"
+
+#: id:1422
+msgid "Windy"
+msgstr "Winderig"
+
+#: id:1423
+msgid "Mist"
+msgstr "Mis"
+
+#: id:1450
+msgid "Put display to sleep when idle"
+msgstr "Sit vertoon aan die slaap wanneer ledig"
+
+#: id:2050
+msgid "Runtime"
+msgstr "Looptyd"
+
+#: id:2100
+msgid "Script failed! : %s"
+msgstr "Skrip het gefaal! : %s"
+
+#: id:2101
+msgid "Newer version needed - See log"
+msgstr "Nuwer weergawe benodig - Sien log"
+
+#: id:4501
+msgid "Enable LCD/VFD"
+msgstr "Stel LCD/VFD in staat"
+
+#: id:10000
+msgid "Home"
+msgstr "Tuis"
+
+#: id:10001
+msgctxt "Auto context with id 10001"
+msgid "Programs"
+msgstr "Programme"
+
+#: id:10002
+msgctxt "Auto context with id 10002"
+msgid "Pictures"
+msgstr "Prentjies"
+
+#: id:10003
+msgctxt "Auto context with id 10003"
+msgid "File manager"
+msgstr "Leêr bestuurder"
+
+#: id:10004
+msgctxt "Auto context with id 10004"
+msgid "Settings"
+msgstr "Verstellings"
+
+#: id:10005
+msgctxt "Auto context with id 10005"
+msgid "Music"
+msgstr "Musiek"
+
+#: id:10006
+msgctxt "Auto context with id 10006"
+msgid "Videos"
+msgstr "Videos"
+
+#: id:10007
+msgid "System information"
+msgstr "Stelsel informasie"
+
+#: id:10008
+msgid "Settings - General"
+msgstr "Verstellings - Algemeen"
+
+#: id:10009
+msgid "Settings - Screen"
+msgstr "Verstellings - Skerm"
+
+#: id:10010
+msgid "Settings - Appearance - GUI Calibration"
+msgstr "Verstellings - Vertoon - GUI kalibrasie"
+
+#: id:10011
+msgid "Settings - Videos - Screen Calibration"
+msgstr "Verstellings - Videos - Skerm kalibrasie"
+
+#: id:10012
+msgid "Settings - Pictures"
+msgstr "Verstellings - Prentjies"
+
+#: id:10013
+msgid "Settings - Programs"
+msgstr "Verstellings - Programme"
+
+#: id:10014
+msgid "Settings - Weather"
+msgstr "Verstellings - Weer"
+
+#: id:10015
+msgid "Settings - Music"
+msgstr "Verstellings - Musiek"
+
+#: id:10016
+msgid "Settings - System"
+msgstr "Verstellings - Stelsel"
+
+#: id:10017
+msgid "Settings - Videos"
+msgstr "Verstellings - Videos"
+
+#: id:10018
+msgid "Settings - Network"
+msgstr "Verstellings - Netwerk"
+
+#: id:10019
+msgid "Settings - Appearance"
+msgstr "Verstellings - Voorkoms"
+
+#: id:10020
+msgctxt "Auto context with id 10020"
+msgid "Scripts"
+msgstr "Skripte"
+
+#: id:10021
+msgid "Web Browser"
+msgstr "Web Blaaier"
+
+#: id:10025
+msgctxt "Auto context with id 10025"
+msgid "Videos"
+msgstr ""
+
+#: id:10028
+msgid "Videos/Playlist"
+msgstr "Videos/Speellys"
+
+#: id:10029
+msgctxt "Auto context with id 10029"
+msgid "Login screen"
+msgstr ""
+
+#: id:10034
+msgid "Settings - Profiles"
+msgstr "Verstellings - Profiele"
+
+#: id:10040
+msgid "Addon browser"
+msgstr ""
+
+#: id:10100
+msgid "Yes/No dialog"
+msgstr "Ja/Nee dialoog"
+
+#: id:10101
+msgid "Progress dialog"
+msgstr "Vorderings-dialoog"
+
+#: id:10210
+msgid "Looking for subtitles..."
+msgstr "Soek subtitels..."
+
+#: id:10211
+msgid "Looking for or caching subtitles..."
+msgstr "Soek, of stoor subtitels..."
+
+#: id:10212
+msgid "terminating"
+msgstr "termineer"
+
+#: id:10213
+msgid "buffering"
+msgstr "buffer"
+
+#: id:10214
+msgid "Opening stream"
+msgstr "Open stroom"
+
+#: id:10500
+msgid "Music/Playlist"
+msgstr "Musiek/Speellys"
+
+#: id:10501
+msgid "Music/Files"
+msgstr "Musiek/Lêers"
+
+#: id:10502
+msgid "Music/Library"
+msgstr "Musiek/Biblioteek"
+
+#: id:10503
+msgid "Playlist editor"
+msgstr "Speellys redigeerder"
+
+#: id:10504
+msgid "Top 100 songs"
+msgstr "Top 100 liedjies"
+
+#: id:10505
+msgid "Top 100 albums"
+msgstr "Top 100 albums"
+
+#: id:10506
+msgctxt "Auto context with id 10506"
+msgid "Programs"
+msgstr "Programme"
+
+#: id:10507
+msgid "Configuration"
+msgstr "Konfigurasie"
+
+#: id:10508
+msgid "Weather forecast"
+msgstr "Weervoorspelling"
+
+#: id:10509
+msgid "Network gaming"
+msgstr "Netwerk speletjies"
+
+#: id:10510
+msgid "Extensions"
+msgstr "Uitbreidings"
+
+#: id:10511
+msgctxt "Auto context with id 10511"
+msgid "System info"
+msgstr "Stelsel info"
+
+#: id:10516
+msgid "Music - Library"
+msgstr "Musiek - Biblioteek"
+
+#: id:10517
+msgid "Now Playing - Music"
+msgstr "Speel nou - Musiek"
+
+#: id:10522
+msgid "Now Playing - Videos"
+msgstr "Speel nou - Videos"
+
+#: id:10523
+msgid "Album info"
+msgstr "Album info"
+
+#: id:10524
+msgid "Movie info"
+msgstr "Fliek info"
+
+#: id:12000
+msgid "Select dialog"
+msgstr "Selekteer dialoog"
+
+#: id:12001
+msgid "Music/Info"
+msgstr "Musiek/Info"
+
+#: id:12002
+msgid "Dialog OK"
+msgstr "Dialoog OK"
+
+#: id:12003
+msgid "Videos/Info"
+msgstr "Videos/Info"
+
+#: id:12004
+msgid "Scripts/Info"
+msgstr "Skripte/Info"
+
+#: id:12005
+msgid "Fullscreen video"
+msgstr "Volskerm video"
+
+#: id:12006
+msgid "Audio visualization"
+msgstr "Audio visualisering"
+
+#: id:12008
+msgid "File stacking dialog"
+msgstr "Lêer stapel dialoog"
+
+#: id:12009
+msgid "Rebuild index..."
+msgstr "Herbou indeks..."
+
+#: id:12010
+msgid "Return to music window"
+msgstr "Keer terug na musiek venster"
+
+#: id:12011
+msgid "Return to videos window"
+msgstr "Keer terug na videos venster"
+
+#: id:12021
+msgid "Start from beginning"
+msgstr "Begin van begin af"
+
+#: id:12022
+msgid "Resume from %s"
+msgstr "Hervat vanaf %s"
+
+#: id:12310
+msgid "0"
+msgstr "0"
+
+#: id:12311
+msgid "1"
+msgstr "1"
+
+#: id:12312
+msgid "2"
+msgstr "2"
+
+#: id:12313
+msgid "3"
+msgstr "3"
+
+#: id:12314
+msgid "4"
+msgstr "4"
+
+#: id:12315
+msgid "5"
+msgstr "5"
+
+#: id:12316
+msgid "6"
+msgstr "6"
+
+#: id:12317
+msgid "7"
+msgstr "7"
+
+#: id:12318
+msgid "8"
+msgstr "8"
+
+#: id:12319
+msgid "9"
+msgstr "9"
+
+#: id:12320
+msgid "c"
+msgstr "c"
+
+#: id:12321
+msgid "Ok"
+msgstr "Ok"
+
+#: id:12322
+msgid "*"
+msgstr "*"
+
+#: id:12325
+msgid "Locked! Enter code..."
+msgstr "Gesluit! Tik kode in..."
+
+#: id:12326
+msgid "Enter password"
+msgstr "Tik wagwoord in"
+
+#: id:12327
+msgid "Enter master code"
+msgstr "Tik meester kode in"
+
+#: id:12328
+msgid "Enter unlock code"
+msgstr "Tik oopsluit kode in"
+
+#: id:12329
+msgid "or press C to cancel"
+msgstr "of druk C om te kanselleer"
+
+#: id:12330
+msgid "Enter gamepad button combo and"
+msgstr "Tik gamepad knoppie kombinasie in en"
+
+#: id:12331
+msgid "press OK, or Back to cancel"
+msgstr "druk OK, of Terug om te kanselleer"
+
+#: id:12332
+msgid "Set lock"
+msgstr "Stel slot"
+
+#: id:12333
+msgid "Unlock"
+msgstr "Sluit oop"
+
+#: id:12334
+msgid "Reset lock"
+msgstr "Herstel slot"
+
+#: id:12335
+msgid "Remove lock"
+msgstr "Verwyder slot"
+
+#: id:12337
+msgid "Numeric password"
+msgstr "Numeriese wagwoord"
+
+#: id:12338
+msgid "Gamepad button combo"
+msgstr "Gamepad knoppie kombinasie"
+
+#: id:12339
+msgid "Full-text password"
+msgstr "Vol-teks wagwoord"
+
+#: id:12340
+msgid "Enter new password"
+msgstr "Tik nuwe wagwoord in"
+
+#: id:12341
+msgid "Re-Enter new password"
+msgstr "Hertik nuwe wagwoord"
+
+#: id:12342
+msgid "Incorrect password,"
+msgstr "Inkorrekte wagwoord,"
+
+#: id:12343
+msgid "retries left"
+msgstr "probeerslae oor"
+
+#: id:12344
+msgid "Passwords entered did not match."
+msgstr "Wagwoorde ingetik nie dieselfde."
+
+#: id:12345
+msgid "Access denied"
+msgstr "Toegang geweier"
+
+#: id:12346
+msgid "Password retry limit exceeded."
+msgstr "Wagwoord herprobeer limiet oorskry."
+
+#: id:12347
+msgid "The system will now shut off."
+msgstr "Die stelsel sal nou afskakel."
+
+#: id:12348
+msgid "Item locked"
+msgstr "Item gesluit"
+
+#: id:12353
+msgid "Reactivate lock"
+msgstr "Heraktiveer slot"
+
+#: id:12356
+msgid "Change lock"
+msgstr "Verander slot"
+
+#: id:12357
+msgid "Source lock"
+msgstr "Bron slot"
+
+#: id:12358
+msgid "Password entry was blank. Try again."
+msgstr "Wagwoord invoer was leeg. Probeer weer."
+
+#: id:12360
+msgid "Master lock"
+msgstr "Meester slot"
+
+#: id:12362
+msgid "Shutdown system if Master Lock retries exceeded"
+msgstr "Skakel stelsel af as Meester Slot herprobeerslae oorskry word"
+
+#: id:12367
+msgid "Master code is not valid"
+msgstr "Meester kode is nie geldig"
+
+#: id:12368
+msgid "Please enter a valid master code"
+msgstr "Tik asb 'n geldige meester kode in"
+
+#: id:12373
+msgid "Settings & file manager"
+msgstr "Verstellings & lêer bestuurder"
+
+#: id:12376
+msgid "Set as default for all movies"
+msgstr "Stel as verstek vir alle flieks"
+
+#: id:12377
+msgid "This will reset any previously saved values"
+msgstr "Hierdie sal enige vorig gestoorde waardes herstel"
+
+#: id:12378
+msgid "Amount of time to display each image"
+msgstr "Hoeveelheid tyd om elke prentjie te vertoon"
+
+#: id:12379
+msgid "Use pan and zoom effects"
+msgstr "Gebruik pan en zoem effekte"
+
+#: id:12383
+msgid "12 hour clock"
+msgstr "12 uur klok"
+
+#: id:12384
+msgid "24 hour clock"
+msgstr "24 uur klok"
+
+#: id:12385
+msgid "Day/Month"
+msgstr "Dag/Maand"
+
+#: id:12386
+msgid "Month/Day"
+msgstr "Maand/Dag"
+
+#: id:12390
+msgid "System uptime"
+msgstr "Stelsel optyd"
+
+#: id:12391
+msgid "Minutes"
+msgstr "Minute"
+
+#: id:12392
+msgid "Hours"
+msgstr "Ure"
+
+#: id:12393
+msgid "Days"
+msgstr "Dae"
+
+#: id:12394
+msgid "Total uptime"
+msgstr "Totale optyd"
+
+#: id:12395
+msgid "Battery level"
+msgstr ""
+
+#: id:12600
+msgctxt "Auto context with id 12600"
+msgid "Weather"
+msgstr "Weer"
+
+#: id:12900
+msgctxt "Auto context with id 12900"
+msgid "Screensaver"
+msgstr "Skermskut"
+
+#: id:12901
+msgid "Fullscreen OSD"
+msgstr "Volskerm OSD"
+
+#: id:13000
+msgid "System"
+msgstr "Stelsel"
+
+#: id:13001
+msgid "Immediate HD spindown"
+msgstr "Onmiddelike HD afspin"
+
+#: id:13002
+msgid "Video only"
+msgstr "Slegs video"
+
+#: id:13003
+msgid "- Delay"
+msgstr "- Vertraging"
+
+#: id:13004
+msgid "- Minimum file duration"
+msgstr "- Minimum lêer lengte"
+
+#: id:13005
+msgid "Shutdown"
+msgstr "Skakel af"
+
+#: id:13008
+msgid "Shutdown function"
+msgstr "Afskakel funksie"
+
+#: id:13009
+msgid "Quit"
+msgstr "Verlaat"
+
+#: id:13010
+msgid "Hibernate"
+msgstr "Hiberneer"
+
+#: id:13011
+msgid "Suspend"
+msgstr "Suspendeer"
+
+#: id:13012
+msgid "Exit"
+msgstr "Gaan Uit"
+
+#: id:13013
+msgid "Reboot"
+msgstr "Reboot"
+
+#: id:13014
+msgid "Minimize"
+msgstr "Minimeer"
+
+#: id:13015
+msgid "Power button action"
+msgstr "Krag knoppie aksie"
+
+#: id:13016
+msgid "Power off System"
+msgstr "Skakel stelsel af"
+
+#: id:13020
+msgid "Is another session active, perhaps over ssh?"
+msgstr "Is nog 'n sessie aktief, miskien oor ssh?"
+
+#: id:13021
+msgid "Mounted removable harddrive"
+msgstr "Gemonteerde verwyderbare hardeskyf"
+
+#: id:13022
+msgid "Unsafe device removal"
+msgstr "Onveilige toestel verwydering"
+
+#: id:13023
+msgid "Successfully removed device"
+msgstr "Toestel suksesvol verwyder"
+
+#: id:13024
+msgid "Joystick plugged"
+msgstr "Stuurstok ingeprop"
+
+#: id:13025
+msgid "Joystick unplugged"
+msgstr "Stuurstok uitgeprop"
+
+#: id:13050
+msgid "Running low on battery"
+msgstr "Loop laag op batterye"
+
+#: id:13100
+msgid "Flicker filter"
+msgstr "Flikker filter"
+
+#: id:13101
+msgid "Let driver choose (requires restart)"
+msgstr "Laat drywer kies (vereis oorbegin)"
+
+#: id:13105
+msgid "Vertical blank sync"
+msgstr "Vertikale blanko sinchronisasie"
+
+#: id:13106
+msgctxt "Auto context with id 13106"
+msgid "Disabled"
+msgstr "Nie in staat gestel"
+
+#: id:13107
+msgid "Enabled during video playback"
+msgstr "In staat gestel gedurende video terugspeel"
+
+#: id:13108
+msgctxt "Auto context with id 13108"
+msgid "Always enabled"
+msgstr "Altyd in staat gestel"
+
+#: id:13109
+msgid "Test & apply resolution"
+msgstr "Toets & pas resolusie toe"
+
+#: id:13110
+msgid "Save resolution?"
+msgstr "Stoor resolusie?"
+
+#: id:13111
+msgid "Would you like to keep this resolution?"
+msgstr "Wil jy hierdie resolusie behou?"
+
+#: id:13112
+msgid "High quality upscaling"
+msgstr "Hoë kwaliteit opskandering"
+
+#: id:13113
+msgctxt "Auto context with id 13113"
+msgid "Disabled"
+msgstr "Nie in staat gestel"
+
+#: id:13114
+msgid "Enabled for SD content"
+msgstr "In staat gestel vir SD inhoud"
+
+#: id:13115
+msgctxt "Auto context with id 13115"
+msgid "Always enabled"
+msgstr "Altyd in staat gestel"
+
+#: id:13116
+msgid "Upscaling method"
+msgstr "Opskanderings metode"
+
+#: id:13117
+msgctxt "Auto context with id 13117"
+msgid "Bicubic"
+msgstr "Bikubies"
+
+#: id:13118
+msgid "Lanczos"
+msgstr "Lanczos"
+
+#: id:13119
+msgid "Sinc"
+msgstr "Sinc"
+
+#: id:13120
+msgctxt "Auto context with id 13120"
+msgid "VDPAU"
+msgstr "VDPAU"
+
+#: id:13121
+msgid "VDPAU HQ Upscaling level"
+msgstr "VDPAU HQ Opskandering vlak"
+
+#: id:13122
+msgid "VDPAU Studio level color conversion"
+msgstr "VDPAU Studio vlak kleur omskakeling"
+
+#: id:13130
+msgid "Blank other displays"
+msgstr "Blanko ander vertone"
+
+#: id:13131
+msgctxt "Auto context with id 13131"
+msgid "Disabled"
+msgstr "Nie in staat gestel"
+
+#: id:13132
+msgid "Blank displays"
+msgstr "Blanko vertone"
+
+#: id:13140
+msgid "Active connections detected!"
+msgstr "Aktiewe konneksies ontdek!"
+
+#: id:13141
+msgid "If you proceed, you might not be able to control XBMC"
+msgstr "As jy voortgaan, mag jy dalk nie meer XBMC kan beheer nie."
+
+#: id:13142
+msgid "any longer. Are you sure you want to stop the Event server?"
+msgstr "Is jy seker jy wil die Gebeurtenis bediener stop?"
+
+#: id:13144
+msgid "Change Apple Remote mode?"
+msgstr "Verander Apple Remote modus?"
+
+#: id:13145
+msgid "If you are currently using the Apple Remote to control"
+msgstr "As jy huidiglik Apple Remote gebruik om XBMC te"
+
+#: id:13146
+msgid "XBMC, changing this setting might affect your ability"
+msgstr "beheer, mag verandering van die verstelling jou"
+
+#: id:13147
+msgid "to continue controlling it. Do you want to proceed?"
+msgstr "vermoë beinvloed om dit te beheer. Wil jy voortgaan?"
+
+#: id:13159
+msgid "Subnet mask"
+msgstr "Subnet masker"
+
+#: id:13160
+msgid "Gateway"
+msgstr "Portaal"
+
+#: id:13161
+msgid "Primary DNS"
+msgstr "Primêre DNS"
+
+#: id:13162
+msgid "Initialize failed"
+msgstr "Initialisasie het gefaal"
+
+#: id:13170
+msgctxt "Auto context with id 13170"
+msgid "Never"
+msgstr "Nooit"
+
+#: id:13171
+msgid "Immediately"
+msgstr "Dadelik"
+
+#: id:13172
+msgid "After %i secs"
+msgstr "Na %i sekondes"
+
+#: id:13173
+msgid "HDD install date:"
+msgstr "HDD installeer datum:"
+
+#: id:13174
+msgid "HDD power cycle count:"
+msgstr "HDD krag wissel telling:"
+
+#: id:13200
+msgid "Profiles"
+msgstr "Profiele"
+
+#: id:13201
+msgid "Delete profile '%s'?"
+msgstr "Wis profiel '%s' uit?"
+
+#: id:13204
+msgid "Last loaded profile:"
+msgstr "Laaste gelaaide profiel:"
+
+#: id:13205
+msgid "Unknown"
+msgstr "Onbekend"
+
+#: id:13206
+msgid "Overwrite"
+msgstr "Oorskryf"
+
+#: id:13208
+msgid "Alarm clock"
+msgstr "Alarm klok"
+
+#: id:13209
+msgid "Alarm clock interval (in minutes)"
+msgstr "Alarm klok interval (in minute)"
+
+#: id:13210
+msgid "Started, alarm in %im"
+msgstr "Het begin, alarm in %im"
+
+#: id:13211
+msgid "Alarm!"
+msgstr "Alarm!"
+
+#: id:13212
+msgid "Canceled with %im%is left"
+msgstr "Gekanselleer met %im%is oor"
+
+#: id:13213
+msgid "%2.0fm"
+msgstr "%2.0fm"
+
+#: id:13214
+msgid "%2.0fs"
+msgstr "%2.0fs"
+
+#: id:13249
+msgid "Search for subtitles in RARs"
+msgstr "Soek vir subtitels in RARs"
+
+#: id:13250
+msgid "Browse for subtitle..."
+msgstr "Soek vir subtitel..."
+
+#: id:13251
+msgid "Move item"
+msgstr "Skuif item"
+
+#: id:13252
+msgid "Move item here"
+msgstr "Skuif item hiernatoe"
+
+#: id:13253
+msgid "Cancel move"
+msgstr "Kanselleer skuif"
+
+#: id:13270
+msgid "Hardware:"
+msgstr "Hardeware:"
+
+#: id:13271
+msgid "CPU Usage:"
+msgstr "CPU Gebruik:"
+
+#: id:13274
+msgid "Connected, but no DNS is available."
+msgstr "Gekonnekteer, maar geen DNS is beskikbaar."
+
+#: id:13275
+msgid "Hard Disk"
+msgstr "Hardeskyf"
+
+#: id:13276
+msgid "DVD-ROM"
+msgstr "DVD-ROM"
+
+#: id:13277
+msgctxt "Auto context with id 13277"
+msgid "Storage"
+msgstr "Storing"
+
+#: id:13278
+msgctxt "Auto context with id 13278"
+msgid "Default"
+msgstr "Verstek"
+
+#: id:13279
+msgctxt "Auto context with id 13279"
+msgid "Network"
+msgstr "Netwerk"
+
+#: id:13280
+msgctxt "Auto context with id 13280"
+msgid "Video"
+msgstr "Video"
+
+#: id:13281
+msgid "Hardware"
+msgstr "Hardeware"
+
+#: id:13283
+msgid "Operating system:"
+msgstr "Bedryfstelsel:"
+
+#: id:13284
+msgid "CPU speed:"
+msgstr "CPU spoed:"
+
+#: id:13286
+msgid "Video encoder:"
+msgstr "Video enkodeerder:"
+
+#: id:13287
+msgid "Screen resolution:"
+msgstr "Skerm resolusie:"
+
+#: id:13292
+msgid "A/V cable:"
+msgstr "A/V kabel:"
+
+#: id:13294
+msgid "DVD region:"
+msgstr "DVD streek:"
+
+#: id:13295
+msgid "Internet:"
+msgstr "Internet:"
+
+#: id:13296
+msgctxt "Auto context with id 13296"
+msgid "Connected"
+msgstr "Gekonnekteer"
+
+#: id:13297
+msgid "Not connected. Check network settings."
+msgstr "Nie gekonnekteer. Gaan netwerk verstellings na."
+
+#: id:13299
+msgid "Target temperature"
+msgstr "Teiken temperatuur"
+
+#: id:13300
+msgid "Fan speed"
+msgstr "Waaier spoed"
+
+#: id:13301
+msgid "Auto temperature control"
+msgstr "Auto temperatuur beheer"
+
+#: id:13302
+msgid "Fan speed override"
+msgstr "Waaier spoed override"
+
+#: id:13303
+msgid "- Fonts"
+msgstr "- Skrifte"
+
+#: id:13304
+msgid "Enable flipping bi-directional strings"
+msgstr "Stel flip van bidireksionele stringe in staat"
+
+#: id:13305
+msgid "Show RSS news feeds"
+msgstr "Wys RSS nuus voere"
+
+#: id:13306
+msgid "Show parent folder items"
+msgstr "Wys ouer se vouer items"
+
+#: id:13307
+msgid "Track naming template"
+msgstr "Snit benaming templaat"
+
+#: id:13308
+msgid "Do you wish to reboot your system"
+msgstr "Wil jy jou stelsel oor boot"
+
+#: id:13309
+msgid "instead of just XBMC?"
+msgstr "in plaas van net XBMC?"
+
+#: id:13310
+msgid "Zoom effect"
+msgstr "Zoem effek"
+
+#: id:13311
+msgid "Float effect"
+msgstr "Dryf effek"
+
+#: id:13312
+msgid "Black bar reduction"
+msgstr "Swart staaf reduksie"
+
+#: id:13313
+msgid "Restart"
+msgstr "Begin oor"
+
+#: id:13314
+msgid "Crossfade between songs"
+msgstr "Kruisdoof tussen liedjies"
+
+#: id:13315
+msgid "Regenerate thumbnails"
+msgstr "Hergenereer duimnaelsketse"
+
+#: id:13316
+msgid "Recursive thumbnails"
+msgstr "Rekursiewe duimnaelsketse"
+
+#: id:13317
+msgid "View slideshow"
+msgstr "Kyk skyfievertoning"
+
+#: id:13318
+msgid "Recursive slideshow"
+msgstr "Herhalende skyfievertoning"
+
+#: id:13319
+msgid "Randomize"
+msgstr "Maak lukraak"
+
+#: id:13320
+msgid "Stereo"
+msgstr "Stereo"
+
+#: id:13321
+msgid "Left only"
+msgstr "Links alleenlik"
+
+#: id:13322
+msgid "Right only"
+msgstr "Regs alleenlik"
+
+#: id:13323
+msgid "Enable karaoke support"
+msgstr "Stel karaoke ondersteuning in staat"
+
+#: id:13324
+msgid "Background transparency"
+msgstr "Agtergrond deursigtigheid"
+
+#: id:13325
+msgid "Foreground transparency"
+msgstr "Voorground deursigtigheid"
+
+#: id:13326
+msgid "A/V delay"
+msgstr "A/V vertraging"
+
+#: id:13327
+msgid "Karaoke"
+msgstr "Karaoke"
+
+#: id:13328
+msgid "%s not found"
+msgstr "%s nie gevind"
+
+#: id:13329
+msgid "Error opening %s"
+msgstr "Fout met open van %s"
+
+#: id:13330
+msgid "Unable to load %s"
+msgstr "Kan nie %s laai nie"
+
+#: id:13331
+msgid "Error: Out of memory"
+msgstr "Fout: Uit geheue uit"
+
+#: id:13332
+msgid "Move up"
+msgstr "Skuif op"
+
+#: id:13333
+msgid "Move down"
+msgstr "Skuif af"
+
+#: id:13334
+msgid "Edit label"
+msgstr "Redigeer etiket"
+
+#: id:13335
+msgid "Make default"
+msgstr "Maak verstek"
+
+#: id:13336
+msgid "Remove button"
+msgstr "Verwyder knoppie"
+
+#: id:13340
+msgid "Leave as is"
+msgstr "Los soos is"
+
+#: id:13341
+msgid "Green"
+msgstr "Groen"
+
+#: id:13342
+msgid "Orange"
+msgstr "Oranje"
+
+#: id:13343
+msgid "Red"
+msgstr "Rooi"
+
+#: id:13344
+msgid "Cycle"
+msgstr "Ruil"
+
+#: id:13345
+msgid "Switch LED off on playback"
+msgstr "Skakel LED af met terugspeel"
+
+#: id:13346
+msgctxt "Auto context with id 13346"
+msgid "Movie information"
+msgstr "Fliek inligting"
+
+#: id:13347
+msgid "Queue item"
+msgstr "Plaas item in tou"
+
+#: id:13348
+msgid "Search IMDb..."
+msgstr "Soek IMDb..."
+
+#: id:13349
+msgid "Scan for new content"
+msgstr "Deursoek vir nuwe inhoud"
+
+#: id:13350
+msgid "Now playing..."
+msgstr "Speel nou..."
+
+#: id:13351
+msgctxt "Auto context with id 13351"
+msgid "Album information"
+msgstr "Album inligting"
+
+#: id:13352
+msgid "Scan item to library"
+msgstr "Deursoek item na biblioteek"
+
+#: id:13353
+msgid "Stop scanning"
+msgstr "Stop deursoek"
+
+#: id:13354
+msgctxt "Auto context with id 13354"
+msgid "Render method"
+msgstr "Teken metode"
+
+#: id:13355
+msgid "Low quality pixel shader"
+msgstr "Lae kwaliteit pixel shader"
+
+#: id:13356
+msgid "Hardware overlays"
+msgstr "Hardeware oorlegte"
+
+#: id:13357
+msgid "High quality pixel shader"
+msgstr "Hoë kwaliteit pixel shader"
+
+#: id:13358
+msgid "Play item"
+msgstr "Speel item"
+
+#: id:13359
+msgid "Set artist thumb"
+msgstr "Stel kunstenaar duim"
+
+#: id:13360
+msgid "Automatically generate thumbnails"
+msgstr "Genereer duimnaelsketse automaties"
+
+#: id:13361
+msgid "Enable voice"
+msgstr "Stel stem in staat"
+
+#: id:13375
+msgid "Enable device"
+msgstr "Stel toestel in staat"
+
+#: id:13376
+msgid "Volume"
+msgstr "Volume"
+
+#: id:13377
+msgid "Default view mode"
+msgstr "Verstek aansig modus"
+
+#: id:13378
+msgid "Default brightness"
+msgstr "Verstek helderheid"
+
+#: id:13379
+msgid "Default contrast"
+msgstr "Verstek kontras"
+
+#: id:13380
+msgid "Default gamma"
+msgstr "Verstek gamma"
+
+#: id:13381
+msgid "Resume video"
+msgstr "Hervat video"
+
+#: id:13382
+msgid "Voice mask - Port 1"
+msgstr "Stem masker - Poort 1"
+
+#: id:13383
+msgid "Voice mask - Port 2"
+msgstr "Stem masker - Poort 2"
+
+#: id:13384
+msgid "Voice mask - Port 3"
+msgstr "Stem masker - Poort 3"
+
+#: id:13385
+msgid "Voice mask - Port 4"
+msgstr "Stem masker - Poort 4"
+
+#: id:13386
+msgid "Use time based seeking"
+msgstr "Gebruik tyd gebasseerde soek"
+
+#: id:13387
+msgid "Track naming template - right"
+msgstr "Snit benaming templaat - regs"
+
+#: id:13388
+msgid "Preset"
+msgstr "Vooropgestel"
+
+#: id:13389
+msgid "There are no presets available\nfor this visualization"
+msgstr "Geen vooropgestelde stellings beskikbaar vir hierdie visualisering"
+
+#: id:13390
+msgid "There are no settings available\nfor this visualization"
+msgstr "Geen verstellings beskikbaar vir hierdie visualisering"
+
+#: id:13391
+msgid "Eject/Load"
+msgstr "Uitwerp/Inlaai"
+
+#: id:13392
+msgid "Use visualization if playing audio"
+msgstr "Gebruik visualisering wanneer audio speel"
+
+#: id:13393
+msgid "Calculate size"
+msgstr "Bereken grootte"
+
+#: id:13394
+msgid "Calculating folder size"
+msgstr "Bereken vouer grootte"
+
+#: id:13395
+msgid "Video settings"
+msgstr "Video verstellings"
+
+#: id:13396
+msgid "Audio and subtitle settings"
+msgstr "Audio en subtitel verstellings"
+
+#: id:13397
+msgid "Enable subtitles"
+msgstr "Stel subtitels in staat"
+
+#: id:13398
+msgctxt "Auto context with id 13398"
+msgid "Shortcuts"
+msgstr "Kortpaaie"
+
+#: id:13399
+msgid "Ignore articles when sorting (e.g. \"the\")"
+msgstr "Ignoreer lidwoorde wanneer sorteer (bv. \"die\")"
+
+#: id:13400
+msgid "Crossfade between songs on the same album"
+msgstr "Kruisdoof tussen liedjies op dieselfde album"
+
+#: id:13401
+msgid "Browse for %s"
+msgstr "Soek vir %s"
+
+#: id:13402
+msgid "Show track position"
+msgstr "Wys snit posisie"
+
+#: id:13403
+msgid "Clear default"
+msgstr "Maak verstek skoon"
+
+#: id:13404
+msgid "Resume"
+msgstr "Hervat"
+
+#: id:13405
+msgid "Get thumb"
+msgstr "Kry duim"
+
+#: id:13406
+msgid "Picture information"
+msgstr "Prentjie inligting"
+
+#: id:13407
+msgid "%s presets"
+msgstr "%s vooropgesteldes"
+
+#: id:13408
+msgid "(IMDb user rating)"
+msgstr "(IMDb gebruiker gradering)"
+
+#: id:13409
+msgid "Top 250"
+msgstr "Top 250"
+
+#: id:13410
+msgid "Tune in on Last.fm"
+msgstr "Stem in op Last.fm"
+
+#: id:13411
+msgid "Minimum fan speed"
+msgstr "Minimum waaier spoed"
+
+#: id:13412
+msgid "Play from here"
+msgstr ""
+
+#: id:13413
+msgid "Downloading"
+msgstr "Laai af"
+
+#: id:13414
+msgid "Include artists who appear only on compilations"
+msgstr "Sluit kunstenaars in wie net op kompilasies voorkom"
+
+#: id:13415
+msgctxt "Auto context with id 13415"
+msgid "Render method"
+msgstr "Teken metode"
+
+#: id:13416
+msgid "Auto detect"
+msgstr "Auto-opsporing"
+
+#: id:13417
+msgid "Basic shaders (ARB)"
+msgstr "Basiese shaders (ARB)"
+
+#: id:13418
+msgid "Advanced shaders (GLSL)"
+msgstr "Gevorderde shaders (GLSL)"
+
+#: id:13419
+msgid "Software"
+msgstr "Sagteware"
+
+#: id:13420
+msgid "Remove safely"
+msgstr "Verwyder veilig"
+
+#: id:13421
+msgctxt "Auto context with id 13421"
+msgid "VDPAU"
+msgstr "VDPAU"
+
+#: id:13422
+msgid "Start slideshow here"
+msgstr "Begin skyfievertoning hier"
+
+#: id:13423
+msgid "Remember for this path"
+msgstr "Onthou vir hierdie pad"
+
+#: id:13424
+msgid "Use pixel buffer objects"
+msgstr "Gebruik pixel buffer objekte"
+
+#: id:13425
+msgid "Allow hardware acceleration (VDPAU)"
+msgstr "Laat hardeware versnelling toe (VDPAU)"
+
+#: id:13426
+msgid "Allow hardware acceleration (VAAPI)"
+msgstr "Laat hardeware versnelling toe (VAAPI)"
+
+#: id:13427
+msgid "Allow hardware acceleration (DXVA2)"
+msgstr "Laat hardeware versnelling toe (DXVA2)"
+
+#: id:13428
+msgid "Allow hardware acceleration (CrystalHD)"
+msgstr "Laat hardeware versnelling toe (CrystalHD)"
+
+#: id:13429
+msgid "Allow hardware acceleration (VDADecoder)"
+msgstr "Laat hardeware versnelling toe (VDADecoder)"
+
+#: id:13430
+msgid "Allow hardware acceleration (OpenMax)"
+msgstr "Laat hardeware versnelling toe (OpenMax)"
+
+#: id:13431
+msgid "Pixel Shaders"
+msgstr "Pixel Shaders"
+
+#: id:13432
+msgid "Allow hardware acceleration (VideoToolbox)"
+msgstr ""
+
+#: id:13500
+msgid "A/V sync method"
+msgstr "A/V sinchroniseer metode"
+
+#: id:13501
+msgid "Audio clock"
+msgstr "Audio klok"
+
+#: id:13502
+msgid "Video clock (Drop/Dupe audio)"
+msgstr "Video klok (Laat val/Dupe audio)"
+
+#: id:13503
+msgid "Video clock (Resample audio)"
+msgstr "Video klok (Hermonster audio)"
+
+#: id:13504
+msgid "Maximum resample amount (%)"
+msgstr "Maksimum hermonster hoeveelheid (%)"
+
+#: id:13505
+msgid "Resample quality"
+msgstr "Hermonster kwaliteit"
+
+#: id:13506
+msgid "Low(fast)"
+msgstr "Laag(vinnig)"
+
+#: id:13507
+msgctxt "Auto context with id 13507"
+msgid "Medium"
+msgstr "Medium"
+
+#: id:13508
+msgctxt "Auto context with id 13508"
+msgid "High"
+msgstr "Hoog"
+
+#: id:13509
+msgid "Really high(slow!)"
+msgstr "Baie hoog (stadig!)"
+
+#: id:13510
+msgid "Sync playback to display"
+msgstr "Sinchroniseer terugspeel met vertoon"
+
+#: id:13550
+msgid "Pause during refresh rate change"
+msgstr "Pauseer gedurende verfris tempo verandering"
+
+#: id:13551
+msgctxt "Auto context with id 13551"
+msgid "Off"
+msgstr "Af"
+
+#: id:13552
+msgid "%.1f Second"
+msgstr "%.1f Sekonde"
+
+#: id:13553
+msgid "%.1f Seconds"
+msgstr "%.1f Sekondes"
+
+#: id:13600
+msgid "Apple remote"
+msgstr "Apple afstandbeheer"
+
+#: id:13602
+msgid "Allow start of XBMC using the remote"
+msgstr "Laat begin van XBMC met die afstandbeheer toe"
+
+#: id:13603
+msgid "Sequence delay time"
+msgstr "Sekwensie vertragings-tyd"
+
+#: id:13610
+msgctxt "Auto context with id 13610"
+msgid "Disabled"
+msgstr "Nie in staat gestel"
+
+#: id:13611
+msgctxt "Auto context with id 13611"
+msgid "Standard"
+msgstr "Standaard"
+
+#: id:13612
+msgid "Universal Remote"
+msgstr "Universele Afstandbeheer"
+
+#: id:13613
+msgid "Multi Remote (Harmony)"
+msgstr "Multi Afstandbeheer (Harmony)"
+
+#: id:13620
+msgid "Apple Remote Error"
+msgstr "Apple Afstandbeheer Fout"
+
+#: id:13621
+msgid "Apple Remote support could be enabled."
+msgstr "Apple Afstandbeheer bystand is in staat gestel."
+
+#: id:14000
+msgid "Stack"
+msgstr "Stapel"
+
+#: id:14001
+msgid "Unstack"
+msgstr "Ontstapel"
+
+#: id:14003
+msgid "Downloading playlist file..."
+msgstr "Laai speellys lêer af..."
+
+#: id:14004
+msgid "Downloading streams list..."
+msgstr "Laai strome lys af..."
+
+#: id:14005
+msgid "Parsing streams list..."
+msgstr "Ontleed strome lys..."
+
+#: id:14006
+msgid "Downloading streams list failed"
+msgstr "Strome lys aflaai het gefaal"
+
+#: id:14007
+msgid "Downloading playlist file failed"
+msgstr "Speellys lêer aflaai het gefaal"
+
+#: id:14009
+msgid "Games directory"
+msgstr "Speletjies gids"
+
+#: id:14010
+msgid "Auto switch to thumbs based on"
+msgstr "Auto skakel na duime gebasseer aan"
+
+#: id:14011
+msgid "Enable auto switching to thumbs view"
+msgstr "Stel auto skakeling na duime aansig in staat"
+
+#: id:14012
+msgid "- Use large icons"
+msgstr "- Gebruik groot ikone"
+
+#: id:14013
+msgid "- Switch based on"
+msgstr "- Skakel gebasseer op"
+
+#: id:14014
+msgid "- Percentage"
+msgstr "- Persentasie"
+
+#: id:14015
+msgid "No files and at least one thumb"
+msgstr "Geen lêers en ten minste een duim"
+
+#: id:14016
+msgid "At least one file and thumb"
+msgstr "Ten minste een lêer en duim"
+
+#: id:14017
+msgid "Percentage of thumbs"
+msgstr "Persentasie van duime"
+
+#: id:14018
+msgid "View options"
+msgstr "Aansig opsies"
+
+#: id:14019
+msgid "Change area code 1"
+msgstr "Verander area kode 1"
+
+#: id:14020
+msgid "Change area code 2"
+msgstr "Verander area kode 2"
+
+#: id:14021
+msgid "Change area code 3"
+msgstr "Verander area kode 3"
+
+#: id:14022
+msgctxt "Auto context with id 14022"
+msgid "Library"
+msgstr "Biblioteek"
+
+#: id:14023
+msgid "No TV"
+msgstr "Geen TV"
+
+#: id:14024
+msgid "Enter the nearest large town"
+msgstr "Tik die naaste groot dorp in"
+
+#: id:14025
+msgid "Video/Audio/DVD cache - Harddisk"
+msgstr "Video/Audio/DVD stoor - Hardeskyf"
+
+#: id:14026
+msgid "Video cache - DVD-ROM"
+msgstr "Video stoor - DVD-ROM"
+
+#: id:14027
+msgctxt "Auto context with id 14027"
+msgid "- Local Network"
+msgstr "- Lokale Netwerk"
+
+#: id:14028
+msgctxt "Auto context with id 14028"
+msgid "- Internet"
+msgstr "- Internet"
+
+#: id:14030
+msgid "Audio cache - DVD-ROM"
+msgstr "Audio stoor - DVD-ROM"
+
+#: id:14031
+msgctxt "Auto context with id 14031"
+msgid "- Local Network"
+msgstr "- Lokale Netwerk"
+
+#: id:14032
+msgctxt "Auto context with id 14032"
+msgid "- Internet"
+msgstr "- Internet"
+
+#: id:14034
+msgid "DVD cache - DVD-ROM"
+msgstr "DVD stoor - DVD-ROM"
+
+#: id:14035
+msgctxt "Auto context with id 14035"
+msgid "- Local Network"
+msgstr "- Lokale Netwerk"
+
+#: id:14036
+msgctxt "Auto context with id 14036"
+msgid "Services"
+msgstr "Dienste"
+
+#: id:14038
+msgid "Network settings changed"
+msgstr "Netwerk verstellings het verander"
+
+#: id:14039
+msgid "XBMC requires to restart to change your"
+msgstr "XBMC vereis dat jy oor begin om jou netwerk"
+
+#: id:14040
+msgid "network setup. Would you like to restart now?"
+msgstr "verstellings te verander. Wil jy nou oorbegin?"
+
+#: id:14041
+msgid "Internet connection bandwidth limitation"
+msgstr "Internet konneksie bandwydte beperking"
+
+#: id:14043
+msgid "- Shutdown while playing"
+msgstr "- Skakel af terwyl speel"
+
+#: id:14044
+msgid "%i min"
+msgstr "%i min"
+
+#: id:14045
+msgid "%i sec"
+msgstr "%i sek"
+
+#: id:14046
+msgid "%i ms"
+msgstr "%i ms"
+
+#: id:14047
+msgid "%i %%"
+msgstr "%i %%"
+
+#: id:14048
+msgid "%i kbps"
+msgstr "%i kbps"
+
+#: id:14049
+msgid "%i kb"
+msgstr "%i kb"
+
+#: id:14050
+msgid "%i.0 dB"
+msgstr "%i.0 dB"
+
+#: id:14051
+msgid "Time format"
+msgstr "Tyd formaat"
+
+#: id:14052
+msgid "Date format"
+msgstr "Datum formaat"
+
+#: id:14053
+msgid "GUI filters"
+msgstr "GUI filters"
+
+#: id:14055
+msgid "Use background scanning"
+msgstr "Gebruik agtergrond deursoeking"
+
+#: id:14056
+msgid "Stop scan"
+msgstr "Stop deursoek"
+
+#: id:14057
+msgid "Not possible while scanning for media info"
+msgstr "Nie moontlik terwyl vir media info soek"
+
+#: id:14058
+msgid "Film grain effect"
+msgstr "Film grein effek"
+
+#: id:14059
+msgid "Search for thumbnails on remote shares"
+msgstr "Soek vir duimnaelsketse op afgeleë saamgedeeldes"
+
+#: id:14060
+msgid "Unknown type cache - Internet"
+msgstr "Onbekende tipe stoor - Internet"
+
+#: id:14061
+msgctxt "Auto context with id 14061"
+msgid "Auto"
+msgstr "Auto"
+
+#: id:14062
+msgid "Enter username for"
+msgstr "Tik gebruikersnaam in vir"
+
+#: id:14063
+msgid "Date & time"
+msgstr "Datum & tyd"
+
+#: id:14064
+msgid "Set date"
+msgstr "Stel datum"
+
+#: id:14065
+msgid "Set time"
+msgstr "Stel tyd"
+
+#: id:14066
+msgid "Enter the time in 24 hour HH:MM format"
+msgstr "Tik die tyd in in 24 uur HH:MM formaat"
+
+#: id:14067
+msgid "Enter the date in DD/MM/YYYY format"
+msgstr "Tik die datum in in DD/MM/YYYY formaat"
+
+#: id:14068
+msgid "Enter the IP address"
+msgstr "Tik die IP adres in"
+
+#: id:14069
+msgid "Apply these settings now?"
+msgstr "Pas hierdie verstellings nou toe?"
+
+#: id:14070
+msgid "Apply changes now"
+msgstr "Pas veranderinge nou toe"
+
+#: id:14071
+msgid "Allow file renaming and deletion"
+msgstr "Laat lêer hernoeming en uitwissing toe"
+
+#: id:14074
+msgid "Set timezone"
+msgstr "Stel tydsone"
+
+#: id:14075
+msgid "Use daylight saving time"
+msgstr "Gebruik daglig-spaar tyd"
+
+#: id:14076
+msgid "Add to favourites"
+msgstr "Voeg by gunstelinge"
+
+#: id:14077
+msgid "Remove from favourites"
+msgstr "Verwyder van gunstelinge"
+
+#: id:14078
+msgctxt "Auto context with id 14078"
+msgid "- Colours"
+msgstr "- Kleure"
+
+#: id:14079
+msgid "Timezone country"
+msgstr "Tydsone land"
+
+#: id:14080
+msgid "Timezone"
+msgstr "Tydsone"
+
+#: id:14081
+msgid "File lists"
+msgstr "Lêer lyste"
+
+#: id:14082
+msgid "Show EXIF picture information"
+msgstr "Wys prentjie EXIF inligting"
+
+#: id:14083
+msgid "Use a fullscreen window rather than true fullscreen"
+msgstr "Gebruik 'n volskerm venster eerder as ware volskerm"
+
+#: id:14084
+msgid "Queue songs on selection"
+msgstr "Voeg seleksie by liedjie tou"
+
+#: id:14086
+msgid "Playback"
+msgstr "Terugspeel"
+
+#: id:14087
+msgid "DVDs"
+msgstr "DVDs"
+
+#: id:14088
+msgid "Play DVDs automatically"
+msgstr "Speel DVDs automaties"
+
+#: id:14089
+msgid "Font to use for text subtitles"
+msgstr "Skrif om vir teks subtitels te gebruik"
+
+#: id:14090
+msgid "International"
+msgstr "Internasionaal"
+
+#: id:14091
+msgid "Character set"
+msgstr "Karakter stel"
+
+#: id:14092
+msgid "Debugging"
+msgstr "Ontfouting"
+
+#: id:14093
+msgid "Security"
+msgstr "Sekuriteit"
+
+#: id:14094
+msgid "Input devices"
+msgstr "Intree toestelle"
+
+#: id:14095
+msgid "Power saving"
+msgstr "Krag besparing"
+
+#: id:14096
+msgid "Rip"
+msgstr ""
+
+#: id:14097
+msgid "Audio CD Insert Action"
+msgstr ""
+
+#: id:14098
+msgctxt "Auto context with id 14098"
+msgid "Play"
+msgstr ""
+
+#: id:14099
+msgid "Eject disc when CD ripping is complete"
+msgstr ""
+
+#: id:15015
+msgctxt "Auto context with id 15015"
+msgid "Remove"
+msgstr "Verwyder"
+
+#: id:15016
+msgid "Games"
+msgstr "Speletjies"
+
+#: id:15019
+msgid "Add"
+msgstr "Voeg by"
+
+#: id:15052
+msgid "Password"
+msgstr "Wagwoord"
+
+#: id:15100
+msgctxt "Auto context with id 15100"
+msgid "Library"
+msgstr "Biblioteek"
+
+#: id:15101
+msgid "Database"
+msgstr "Databasis"
+
+#: id:15102
+msgid "* All albums"
+msgstr "* Alle albums"
+
+#: id:15103
+msgid "* All artists"
+msgstr "* Alle kunstenaars"
+
+#: id:15104
+msgid "* All songs"
+msgstr "* Alle liedjies"
+
+#: id:15105
+msgid "* All genres"
+msgstr "* Alle genres"
+
+#: id:15107
+msgid "Buffering..."
+msgstr "Buffer..."
+
+#: id:15108
+msgid "Navigation sounds"
+msgstr "Navigasie klanke"
+
+#: id:15109
+msgid "Skin default"
+msgstr "Verstek omslag"
+
+#: id:15111
+msgid "- Theme"
+msgstr "- Tema"
+
+#: id:15112
+msgid "Default theme"
+msgstr "Verstek tema"
+
+#: id:15200
+msgid "Last.fm"
+msgstr "Last.fm"
+
+#: id:15201
+msgid "Submit songs to Last.fm"
+msgstr "Dien liedjies in by Last.fm"
+
+#: id:15202
+msgid "Last.fm username"
+msgstr "Last.fm gebruikersnaam"
+
+#: id:15203
+msgid "Last.fm password"
+msgstr "Last.fm wagwoord"
+
+#: id:15204
+msgid "Unable to handshake: sleeping..."
+msgstr "Kan nie handskud nie: slaap..."
+
+#: id:15205
+msgid "Please update XBMC"
+msgstr "Opdateer asseblief XBMC"
+
+#: id:15206
+msgid "Bad authorization: Check username and password"
+msgstr "Slegte magtiging: Gaan gebruikersnaam en wagwoord na"
+
+#: id:15207
+msgctxt "Auto context with id 15207"
+msgid "Connected"
+msgstr "Gekonnekteer"
+
+#: id:15208
+msgid "Not connected"
+msgstr "Nie gekonnekteer"
+
+#: id:15209
+msgid "Submit interval %i"
+msgstr "Indien interval %i"
+
+#: id:15210
+msgid "Cached %i songs"
+msgstr "%i liedjies gestoor"
+
+#: id:15211
+msgid "Submitting..."
+msgstr "Dien in..."
+
+#: id:15212
+msgid "Submitting in %i secs"
+msgstr "Dien in, in %i sekondes"
+
+#: id:15213
+msgid "Play using..."
+msgstr "Speel met..."
+
+#: id:15214
+msgid "Use smoothed A/V synchronization"
+msgstr "Gebruik glad gemaakte A/V sinchronisasie"
+
+#: id:15215
+msgid "Hide file names in thumbs view"
+msgstr "Steek lêer name weg in duime aansig"
+
+#: id:15216
+msgid "Play in party mode"
+msgstr "Speel in partytjie modus"
+
+#: id:15217
+msgid "Submit songs to Libre.fm"
+msgstr "Dien liedjies in by Libre.fm"
+
+#: id:15218
+msgid "Libre.fm username"
+msgstr "Libre.fm gebruikersnaam"
+
+#: id:15219
+msgid "Libre.fm password"
+msgstr "Libre.fm wagwoord"
+
+#: id:15220
+msgid "Libre.fm"
+msgstr "Libre.fm"
+
+#: id:15221
+msgid "Song submission"
+msgstr "Liedjie indiening"
+
+#: id:15250
+msgid "Submit Last.fm radio to Last.fm"
+msgstr "Dien Last.fm radio in na Last.fm"
+
+#: id:15251
+msgid "Connecting to Last.fm..."
+msgstr "Konnekteer aan Last.fm..."
+
+#: id:15252
+msgid "Selecting station..."
+msgstr "Selekteer stasie..."
+
+#: id:15253
+msgid "Search similar artists..."
+msgstr "Soek eenderse kunstenaars..."
+
+#: id:15254
+msgid "Search similar tags..."
+msgstr "Soek eenderse etikette..."
+
+#: id:15255
+msgid "Your profile (%name%)"
+msgstr "Jou profiel (%name%)"
+
+#: id:15256
+msgid "Overall top tags"
+msgstr "Algehele top etikette"
+
+#: id:15257
+msgid "Top artists for tag %name%"
+msgstr "Top kunstenaars vir etiket %name%"
+
+#: id:15258
+msgid "Top albums for tag %name%"
+msgstr "Top albums vir etiket %name%"
+
+#: id:15259
+msgid "Top tracks for tag %name%"
+msgstr "Top snitte vir etiket %name%"
+
+#: id:15260
+msgid "Listen to tag %name% Last.fm radio"
+msgstr "Luister na etiket %name% Last.fm radio"
+
+#: id:15261
+msgid "Similar artists as %name%"
+msgstr "Soortgelyke kunstenaars as %name%"
+
+#: id:15262
+msgid "Top %name% albums"
+msgstr "Top %name% albums"
+
+#: id:15263
+msgid "Top %name% tracks"
+msgstr "Top %name% snitte"
+
+#: id:15264
+msgid "Top %name% tags"
+msgstr "Top %name% etikette"
+
+#: id:15265
+msgid "Biggest fans of %name%"
+msgstr "Grootste ondersteuners van %name%"
+
+#: id:15266
+msgid "Listen to %name% fans Last.fm radio"
+msgstr "Luister na %name% ondersteuners Last.fm radio"
+
+#: id:15267
+msgid "Listen to %name% similar artists Last.fm radio"
+msgstr "Luister na %name% eenderse kunstenaars Last.fm radio"
+
+#: id:15268
+msgid "Top artists for user %name%"
+msgstr "Top kunstenaars vir gebruiker %name%"
+
+#: id:15269
+msgid "Top albums for user %name%"
+msgstr "Top albums vir gebruiker %name%"
+
+#: id:15270
+msgid "Top tracks for user %name%"
+msgstr "Top snitte vir gebruiker %name%"
+
+#: id:15271
+msgid "Friends of user %name%"
+msgstr "Vriende van gebruiker %name%"
+
+#: id:15272
+msgid "Neighbours of user %name%"
+msgstr "Bure van gebruiker %name%"
+
+#: id:15273
+msgid "Weekly artist chart for %name%"
+msgstr "Weeklikse kunstenaar lys vir %name%"
+
+#: id:15274
+msgid "Weekly album chart for %name%"
+msgstr "Weeklikse album lys vir %name%"
+
+#: id:15275
+msgid "Weekly track chart for %name%"
+msgstr "Weeklikse snit lys vir %name%"
+
+#: id:15276
+msgid "Listen to %name%'s neighbours Last.fm radio"
+msgstr "Luister na %name% se buurman se Last.fm radio"
+
+#: id:15277
+msgid "Listen to %name%'s personal Last.fm radio"
+msgstr "Luister na %name% se persoonlike Last.fm radio"
+
+#: id:15278
+msgid "Listen to %name%'s mix Last.fm radio"
+msgstr ""
+
+#: id:15279
+msgid "Retrieving list from Last.fm..."
+msgstr "Verkry lys van Last.fm..."
+
+#: id:15280
+msgid "Can't retrieve list from Last.fm..."
+msgstr "Kan nie lys van Last.fm verkry..."
+
+#: id:15281
+msgid "Enter an artist name to find related ones"
+msgstr "Tik 'n kunstenaar naam in om verwantes te vind"
+
+#: id:15282
+msgid "Enter a tag name to find similar ones"
+msgstr "Tik 'n etiket naam in om eenderses te vind"
+
+#: id:15283
+msgid "Tracks recently listened by %name%"
+msgstr "Snitte onlangs na geluister deur %name%"
+
+#: id:15284
+msgid "Listen to %name%'s recommendations Last.fm radio"
+msgstr "Luister na %name% se aanbevelings Last.fm radio"
+
+#: id:15285
+msgid "Top tags for user %name%"
+msgstr "Top etikette vir gebruiker %name%"
+
+#: id:15287
+msgid "Do you want to add the current track to your loved tracks?"
+msgstr "Wil jy die huidige snit byvoeg by jou gunsteling snitte?"
+
+#: id:15288
+msgid "Do you want to ban the current track?"
+msgstr "Wil jy die huidige snit verban?"
+
+#: id:15289
+msgid "Added to your loved tracks: '%s'."
+msgstr "Bygevoeg by jou gunsteling snitte: '%s'."
+
+#: id:15290
+msgid "Could not add '%s' to your loved tracks."
+msgstr "Kon nie '%s' byvoeg by jou gunsteling snitte."
+
+#: id:15291
+msgid "Banned: '%s'."
+msgstr "Verban: '%s'."
+
+#: id:15292
+msgid "Could not ban '%s'."
+msgstr "Kon nie '%s' verban."
+
+#: id:15293
+msgid "Tracks recently loved by %name%"
+msgstr "Snitte onlangs van gehou deur %name%"
+
+#: id:15294
+msgid "Tracks recently banned by %name%"
+msgstr "Snitte onlangs verban deur %name%"
+
+#: id:15295
+msgid "Remove from loved tracks"
+msgstr "Verwyder vanaf gunsteling snitte"
+
+#: id:15296
+msgid "Un-ban"
+msgstr "On-verban"
+
+#: id:15297
+msgid "Do you want to remove this track from your loved tracks?"
+msgstr "Wil jy hierdie snit verwyder van jou gunsteling snitte?"
+
+#: id:15298
+msgid "Do you want to un-ban this track?"
+msgstr "Wil jy hierdie snit on-verban?"
+
+#: id:15300
+msgid "Path not found or invalid"
+msgstr "Pad nie gevind, of ongeldig"
+
+#: id:15301
+msgid "Could not connect to network server"
+msgstr "Kon nie aan netwerk bediener konnekteer"
+
+#: id:15302
+msgid "No servers found"
+msgstr "Geen bedieners gevind"
+
+#: id:15303
+msgid "Workgroup not found"
+msgstr "Werkgroep nie gevind"
+
+#: id:15310
+msgid "Opening multi-path source"
+msgstr "Maak multi-pad bron oop"
+
+#: id:15311
+msgid "Path:"
+msgstr "Pad:"
+
+#: id:16000
+msgctxt "Auto context with id 16000"
+msgid "General"
+msgstr "Algemeen"
+
+#: id:16002
+msgid "Internet lookup"
+msgstr "Internet opsoek"
+
+#: id:16003
+msgid "Player"
+msgstr "Speler"
+
+#: id:16004
+msgid "Play media from disc"
+msgstr "Speel media vanaf skyf"
+
+#: id:16008
+msgid "Enter new title"
+msgstr "Tik nuwe titel in"
+
+#: id:16009
+msgid "Enter the movie name"
+msgstr "Tik die fliek naam in"
+
+#: id:16010
+msgid "Enter the profile name"
+msgstr "Tik die profiel naam in"
+
+#: id:16011
+msgid "Enter the album name"
+msgstr "Tik die album naam in"
+
+#: id:16012
+msgid "Enter the playlist name"
+msgstr "Tik die speellys naam in"
+
+#: id:16013
+msgid "Enter new filename"
+msgstr "Tik nuwe lêernaam in"
+
+#: id:16014
+msgid "Enter folder name"
+msgstr "Tik vouer naam in"
+
+#: id:16015
+msgid "Enter directory"
+msgstr "Tik gids in"
+
+#: id:16016
+msgid "Available options: %A, %T, %N, %B, %D, %G, %Y, %F, %S"
+msgstr "Beskikbare opsies: %A, %T, %N, %B, %D, %G, %Y, %F, %S"
+
+#: id:16017
+msgid "Enter search string"
+msgstr "Tik soek string in"
+
+#: id:16018
+msgctxt "Auto context with id 16018"
+msgid "None"
+msgstr "Geen"
+
+#: id:16019
+msgid "Auto select"
+msgstr "Auto selekteer"
+
+#: id:16020
+msgid "De-interlace"
+msgstr "Ont-ineenvleg"
+
+#: id:16021
+msgid "Bob"
+msgstr "Bob"
+
+#: id:16022
+msgid "Bob (inverted)"
+msgstr "Bob (geinverteer)"
+
+#: id:16024
+msgid "Canceling..."
+msgstr "Kanselleer..."
+
+#: id:16025
+msgid "Enter the artist name"
+msgstr "Tik die kunstenaar naam in"
+
+#: id:16026
+msgid "Playback failed"
+msgstr "Terugspeel het gefaal"
+
+#: id:16027
+msgid "One or more items failed to play."
+msgstr "Een of meer items het gefaal na speel."
+
+#: id:16028
+msgid "Enter value"
+msgstr "Tik waarde in"
+
+#: id:16029
+msgid "Check the log file for details."
+msgstr "Gaan die log lêer na vir besonderhede."
+
+#: id:16030
+msgid "Party mode aborted."
+msgstr "Partytjie modus gestaak."
+
+#: id:16031
+msgid "No matching songs in the library."
+msgstr "Geen ooreenstemmende liedjies in die biblioteek."
+
+#: id:16032
+msgid "Could not initialize database."
+msgstr "Kon nie databasis inisialiseer."
+
+#: id:16033
+msgid "Could not open database."
+msgstr "Kon nie databasis oopmaak."
+
+#: id:16034
+msgid "Could not get songs from database."
+msgstr "Kon nie liedjies kry vanaf databasis."
+
+#: id:16035
+msgid "Party mode playlist"
+msgstr "Partytjie modus speellys"
+
+#: id:16036
+msgid "De-interlace (Half)"
+msgstr ""
+
+#: id:16037
+msgid "Deinterlace video"
+msgstr ""
+
+#: id:16038
+msgid "Deinterlace method"
+msgstr ""
+
+#: id:16039
+msgctxt "Auto context with id 16039"
+msgid "Off"
+msgstr ""
+
+#: id:16040
+msgctxt "Auto context with id 16040"
+msgid "Auto"
+msgstr ""
+
+#: id:16041
+msgid "On"
+msgstr ""
+
+#: id:16100
+msgid "All Videos"
+msgstr "Alle Videos"
+
+#: id:16101
+msgid "Unwatched"
+msgstr "Ongekyk"
+
+#: id:16102
+msgid "Watched"
+msgstr "Gekyk"
+
+#: id:16103
+msgid "Mark as watched"
+msgstr "Merk as gekyk"
+
+#: id:16104
+msgid "Mark as unwatched"
+msgstr "Merk as ongekyk"
+
+#: id:16105
+msgid "Edit title"
+msgstr "Redigeer titel"
+
+#: id:16200
+msgid "Operation was aborted"
+msgstr "Operasie is gestaak"
+
+#: id:16201
+msgid "Copy failed"
+msgstr "Kopiëer het gefaal"
+
+#: id:16202
+msgid "Failed to copy at least one file"
+msgstr "Gefaal om ten minste een lêer te kopiëer"
+
+#: id:16203
+msgid "Move failed"
+msgstr "Skuif het gefaal"
+
+#: id:16204
+msgid "Failed to move at least one file"
+msgstr "Gefaal om ten minste een lêer te skuif"
+
+#: id:16205
+msgid "Delete failed"
+msgstr "Uitwis het gefaal"
+
+#: id:16206
+msgid "Failed to delete at least one file"
+msgstr "Gefaal om ten minste een lêer uit te wis"
+
+#: id:16300
+msgid "Video scaling method"
+msgstr "Video skalerings metode"
+
+#: id:16301
+msgid "Nearest neighbour"
+msgstr "Naaste buur"
+
+#: id:16302
+msgid "Bilinear"
+msgstr "Bilinêer"
+
+#: id:16303
+msgctxt "Auto context with id 16303"
+msgid "Bicubic"
+msgstr "Bikubies"
+
+#: id:16304
+msgid "Lanczos2"
+msgstr "Lanczos2"
+
+#: id:16305
+msgid "Lanczos3"
+msgstr "Lanczos3"
+
+#: id:16306
+msgid "Sinc8"
+msgstr "Sinc8"
+
+#: id:16307
+msgid "Bicubic (software)"
+msgstr "Bikubies (sagteware)"
+
+#: id:16308
+msgid "Lanczos (software)"
+msgstr "Lanczos (sagteware)"
+
+#: id:16309
+msgid "Sinc (software)"
+msgstr "Sinc (sagteware)"
+
+#: id:16310
+msgid "Temporal"
+msgstr "Temporaal"
+
+#: id:16311
+msgid "Temporal/Spatial"
+msgstr "Temporaal/Spatiaal"
+
+#: id:16312
+msgid "(VDPAU)Noise Reduction"
+msgstr "(VDPAU)Geraas Redusering"
+
+#: id:16313
+msgid "(VDPAU)Sharpness"
+msgstr "(VDPAU)Skerpgeid"
+
+#: id:16314
+msgid "Inverse Telecine"
+msgstr "Inverse Telecine"
+
+#: id:16315
+msgid "Lanczos3 optimized"
+msgstr "Lanczos3 geoptimeer"
+
+#: id:16316
+msgctxt "Auto context with id 16316"
+msgid "Auto"
+msgstr "Auto"
+
+#: id:16317
+msgid "Temporal (Half)"
+msgstr "Temporaal (Half)"
+
+#: id:16318
+msgid "Temporal/Spatial (Half)"
+msgstr "Temporaal/Spatiaal (Half)"
+
+#: id:16319
+msgid "DXVA"
+msgstr "DXVA"
+
+#: id:16320
+msgid "DXVA Bob"
+msgstr ""
+
+#: id:16321
+msgid "DXVA Best"
+msgstr ""
+
+#: id:16322
+msgid "Spline36"
+msgstr ""
+
+#: id:16323
+msgid "Spline36 optimized"
+msgstr ""
+
+#: id:16324
+msgid "Software Blend"
+msgstr ""
+
+#: id:16400
+msgid "Post-processing"
+msgstr "Na-prosessering"
+
+#: id:17500
+msgid "Display sleep timeout"
+msgstr "Vertoon slaap uittel tyd"
+
+#: id:19000
+msgid "Switch to channel"
+msgstr "Skakel oor na kanaal"
+
+#: id:20000
+msgid "Saved music folder"
+msgstr "Gestoorde musiek vouer"
+
+#: id:20001
+msgid "Use external DVD player"
+msgstr "Gebruik eksterne DVD speler"
+
+#: id:20002
+msgid "External DVD player"
+msgstr "Eksterne DVD speler"
+
+#: id:20003
+msgid "Trainers folder"
+msgstr "Afrigters vouer"
+
+#: id:20004
+msgid "Screenshot folder"
+msgstr "Skermkiekie vouer"
+
+#: id:20006
+msgid "Playlists folder"
+msgstr "Speellyste vouer"
+
+#: id:20007
+msgid "Recordings"
+msgstr "Opnames"
+
+#: id:20008
+msgid "Screenshots"
+msgstr "Skermkiekies"
+
+#: id:20009
+msgid "Use XBMC"
+msgstr "Gebruik XBMC"
+
+#: id:20011
+msgid "Music playlists"
+msgstr "Musiek speellyste"
+
+#: id:20012
+msgid "Video playlists"
+msgstr "Video speellyste"
+
+#: id:20013
+msgid "Do you wish to launch the game?"
+msgstr "Wil jy die speletjie loods?"
+
+#: id:20014
+msgid "Sort by: Playlist"
+msgstr "Sorteer volgens: Speellys"
+
+#: id:20015
+msgid "Remote thumb"
+msgstr "Afstandbeheer duim"
+
+#: id:20016
+msgid "Current thumb"
+msgstr "Huidige duim"
+
+#: id:20017
+msgid "Local thumb"
+msgstr "Lokale duim"
+
+#: id:20018
+msgid "No thumb"
+msgstr "Geen duim"
+
+#: id:20019
+msgid "Choose thumbnail"
+msgstr "Kies duimnaelskets"
+
+#: id:20023
+msgid "Conflict"
+msgstr "Konflik"
+
+#: id:20024
+msgid "Scan new"
+msgstr "Deursoek nuwe"
+
+#: id:20025
+msgid "Scan all"
+msgstr "Deursoek almal"
+
+#: id:20026
+msgid "Region"
+msgstr "Streek"
+
+#: id:20037
+msgid "Summary"
+msgstr "Opsomming"
+
+#: id:20038
+msgid "Lock music window"
+msgstr "Sluit musiek venster"
+
+#: id:20039
+msgid "Lock videos window"
+msgstr "Sluit videos venster"
+
+#: id:20040
+msgid "Lock pictures window"
+msgstr "Sluit prentjies venster"
+
+#: id:20041
+msgid "Lock programs & scripts windows"
+msgstr "Sluit programme & skrip vensters"
+
+#: id:20042
+msgid "Lock file manager"
+msgstr "Sluit lêer bestuurder"
+
+#: id:20043
+msgid "Lock settings"
+msgstr "Sluit verstellings"
+
+#: id:20044
+msgid "Start fresh"
+msgstr "Begin vars"
+
+#: id:20045
+msgid "Enter master mode"
+msgstr "Betree meester modus"
+
+#: id:20046
+msgid "Leave master mode"
+msgstr "Verlaat meester modus"
+
+#: id:20047
+msgid "Create profile '%s'?"
+msgstr "Skep profiel '%s'?"
+
+#: id:20048
+msgid "Start with fresh settings"
+msgstr "Begin met vars verstellings"
+
+#: id:20049
+msgid "Best available"
+msgstr "Beste beskikbare"
+
+#: id:20050
+msgid "Auto-switch between 16x9 and 4x3"
+msgstr "Auto-skakel tussen 16x9 en 4x3"
+
+#: id:20051
+msgid "Treat stacked files as single file"
+msgstr "Behandel gestapelde lêers as enkel lêer"
+
+#: id:20052
+msgid "Caution"
+msgstr "Versigtig"
+
+#: id:20053
+msgid "Left master mode"
+msgstr "Meester modus verlaat"
+
+#: id:20054
+msgid "Entered master mode"
+msgstr "Meester modus betree"
+
+#: id:20055
+msgid "Allmusic.com thumb"
+msgstr "Allmusic.com duim"
+
+#: id:20057
+msgid "Remove thumbnail"
+msgstr "Verwyder duimnaelskets"
+
+#: id:20058
+msgid "Add profile..."
+msgstr "Voeg profiel by..."
+
+#: id:20059
+msgid "Query info for all albums"
+msgstr "Vra info vir alle albums"
+
+#: id:20060
+msgctxt "Auto context with id 20060"
+msgid "Media info"
+msgstr "Media info"
+
+#: id:20061
+msgctxt "Auto context with id 20061"
+msgid "Separate"
+msgstr "Appart"
+
+#: id:20062
+msgid "Shares with default"
+msgstr "Saamgedeeldes met verstek"
+
+#: id:20063
+msgid "Shares with default (read only)"
+msgstr "Saamgedeeldes met verstek (lees alleen)"
+
+#: id:20064
+msgid "Copy default"
+msgstr "Kopiëer verstek"
+
+#: id:20065
+msgid "Profile picture"
+msgstr "Profiel prentjie"
+
+#: id:20066
+msgid "Lock preferences"
+msgstr "Sluit voorkeure"
+
+#: id:20067
+msgid "Edit profile"
+msgstr "Redigeer profiel"
+
+#: id:20068
+msgid "Profile lock"
+msgstr "Profiel slot"
+
+#: id:20069
+msgid "Could not create folder"
+msgstr "Kon nie vouer skep"
+
+#: id:20070
+msgid "Profile directory"
+msgstr "Profiel gids"
+
+#: id:20071
+msgid "Start with fresh media sources"
+msgstr "Begin met vars media bronne"
+
+#: id:20072
+msgid "Make sure the selected folder is writable"
+msgstr "Maak seker dat die geselekteerde vouer skryfbaar is"
+
+#: id:20073
+msgid "and that the new folder name is valid"
+msgstr "en die nuwe vouer naam geldig is"
+
+#: id:20074
+msgid "MPAA rating"
+msgstr "MPAA gradering"
+
+#: id:20075
+msgid "Enter master lock code"
+msgstr "Tik meester slot kode in"
+
+#: id:20076
+msgid "Ask for master lock code on startup"
+msgstr "Vra vir meester slot kode uuu"
+
+#: id:20077
+msgid "Skin settings"
+msgstr "Omslag verstellings"
+
+#: id:20078
+msgid "- no link set -"
+msgstr "- geen skakel stel -"
+
+#: id:20079
+msgid "Enable animations"
+msgstr "Stel animasies in staat"
+
+#: id:20080
+msgid "Disable RSS during music"
+msgstr "Stel RSS nie in staat gedurende musiek"
+
+#: id:20081
+msgid "Enable shortcut buttons"
+msgstr "Stel kortpad knoppies in staat"
+
+#: id:20082
+msgid "Show programs in main menu"
+msgstr "Wys programme in hoof kieslys"
+
+#: id:20083
+msgid "Show music info"
+msgstr "Wys musiek info"
+
+#: id:20084
+msgid "Show weather info"
+msgstr "Wys weer info"
+
+#: id:20085
+msgid "Show system info"
+msgstr "Wys stelsel info"
+
+#: id:20086
+msgid "Show available disc space C: E: F:"
+msgstr "Wys beskikbare skyf spasie C: E: F:"
+
+#: id:20087
+msgid "Show available disc space E: F: G:"
+msgstr "Wys beskikbare skyf spasie E: F: G:"
+
+#: id:20088
+msgid "Weather info"
+msgstr "Weer info"
+
+#: id:20089
+msgid "Drive space free"
+msgstr "Skyf spasie beskikbaar"
+
+#: id:20090
+msgid "Enter the name of an existing share"
+msgstr "Tik die naam van 'n bestaande saamdeel in"
+
+#: id:20091
+msgid "Lock code"
+msgstr "Sluit kode"
+
+#: id:20092
+msgid "Load profile"
+msgstr "Laai profiel"
+
+#: id:20093
+msgid "Profile name"
+msgstr "Profiel naam"
+
+#: id:20094
+msgctxt "Auto context with id 20094"
+msgid "Media sources"
+msgstr "Media bronne"
+
+#: id:20095
+msgid "Enter profile lock code"
+msgstr "Tik profiel slot kode in"
+
+#: id:20096
+msgctxt "Auto context with id 20096"
+msgid "Login screen"
+msgstr "Inteken skerm"
+
+#: id:20097
+msgid "Fetching album info"
+msgstr "Gaan haal album info"
+
+#: id:20098
+msgid "Fetching info for album"
+msgstr "Gaan haal info vir album"
+
+#: id:20099
+msgid "Can't rip CD or track while playing from CD"
+msgstr "Kan nie CD of snit rip terwyl CD speel nie"
+
+#: id:20100
+msgid "Master lock code and settings"
+msgstr "Meester slot kode en verstellings"
+
+#: id:20101
+msgid "Entering master lock code always enables master mode"
+msgstr "Intik van meester sluit kode stel altyd meester modus in staat"
+
+#: id:20102
+msgid "or copy from default?"
+msgstr "of kopiëer vanaf verstek?"
+
+#: id:20103
+msgid "Save changes to profile?"
+msgstr "Stoor veranderinge na profiel?"
+
+#: id:20104
+msgid "Old settings found."
+msgstr "Ou verstellings gevind."
+
+#: id:20105
+msgid "Do you want to use them?"
+msgstr "Wil jy hulle gebruik?"
+
+#: id:20106
+msgid "Old media sources found."
+msgstr "Ou media bronne gevind."
+
+#: id:20107
+msgid "Separate (locked)"
+msgstr "Appart (gesluit)"
+
+#: id:20108
+msgid "Root"
+msgstr "Wortelgids"
+
+#: id:20109
+msgid "- Zoom"
+msgstr "- Zoem"
+
+#: id:20110
+msgid "UPnP settings"
+msgstr "UPnP verstellings"
+
+#: id:20111
+msgid "Autostart UPnP client"
+msgstr "Autobegin UPnP kliënt"
+
+#: id:20112
+msgid "Last login: %s"
+msgstr "Laaste inlog: %s"
+
+#: id:20113
+msgid "Never logged on"
+msgstr "Nooit aangelog"
+
+#: id:20114
+msgid "Profile %i / %i"
+msgstr "Profiel %i / %i"
+
+#: id:20115
+msgid "User login / Select a profile"
+msgstr "Gebruiker inlog / Selekteer 'n profiel"
+
+#: id:20116
+msgid "Use lock on login screen"
+msgstr "Gebruik slot op inlog skerm"
+
+#: id:20117
+msgid "Invalid lock code."
+msgstr "Ongeldige slot kode."
+
+#: id:20118
+msgid "This requires the master lock to be set."
+msgstr "Hierdie vereis dat die meester slot gestel is."
+
+#: id:20119
+msgid "Would you like to set it now?"
+msgstr "Wil jy dit nou stel?"
+
+#: id:20120
+msgid "Loading program information"
+msgstr "Laai program inligting"
+
+#: id:20121
+msgid "Party on!"
+msgstr "Partytjie voort!"
+
+#: id:20122
+msgid "True"
+msgstr "Waar"
+
+#: id:20123
+msgid "Mixing drinks"
+msgstr "Meng drankies"
+
+#: id:20124
+msgid "Filling glasses"
+msgstr "Vul glase"
+
+#: id:20125
+msgid "Logged on as"
+msgstr "Aangelog as"
+
+#: id:20126
+msgid "Log off"
+msgstr "Log af"
+
+#: id:20128
+msgid "Go to root"
+msgstr "Gaan na wortelgids"
+
+#: id:20129
+msgid "Weave"
+msgstr "Weef"
+
+#: id:20130
+msgid "Weave (inverted)"
+msgstr "Weef (geinverteer)"
+
+#: id:20131
+msgid "Blend"
+msgstr "Meng"
+
+#: id:20132
+msgid "Restart video"
+msgstr "Begin video oor"
+
+#: id:20133
+msgid "Edit network location"
+msgstr "Redigeer netwerk lokasie"
+
+#: id:20134
+msgid "Remove network location"
+msgstr "Verwyder netwerk lokasie"
+
+#: id:20135
+msgid "Do you want to scan the folder?"
+msgstr "Wil jy die vouer deursoek?"
+
+#: id:20136
+msgid "Memory unit"
+msgstr "Geheue eenheid"
+
+#: id:20137
+msgid "Memory unit mounted"
+msgstr "Geheue eenheid gemonteer"
+
+#: id:20138
+msgid "Unable to mount memory unit"
+msgstr "Kan nie geheue eenheid monteer nie"
+
+#: id:20139
+msgid "In port %i, slot %i"
+msgstr "In poort %i, gleuf %i"
+
+#: id:20140
+msgid "Lock screensaver"
+msgstr "Sluit skermskut"
+
+#: id:20141
+msgid "Set"
+msgstr "Stel"
+
+#: id:20142
+msgctxt "Auto context with id 20142"
+msgid "Username"
+msgstr "Gebruikersnaam"
+
+#: id:20143
+msgid "Enter password for"
+msgstr "Tik wagwoord vir"
+
+#: id:20144
+msgid "Shutdown timer"
+msgstr "Skakel af tydhouer"
+
+#: id:20145
+msgid "Shutdown interval (in minutes)"
+msgstr "Skakel af interval (in minute)"
+
+#: id:20146
+msgid "Started, shutdown in %im"
+msgstr "Begin, skakel af in %im"
+
+#: id:20147
+msgid "Shutdown in 30 minutes"
+msgstr "Skakel af na 30 minute"
+
+#: id:20148
+msgid "Shutdown in 60 minutes"
+msgstr "Skakel af na 60 minute"
+
+#: id:20149
+msgid "Shutdown in 120 minutes"
+msgstr "Skakel af na 120 minute"
+
+#: id:20150
+msgid "Custom shutdown timer"
+msgstr "Verpersoonlikte afskakel tydhouer"
+
+#: id:20151
+msgid "Cancel shutdown timer"
+msgstr "Kanselleer afskakel tydhouer"
+
+#: id:20152
+msgid "Lock preferences for %s"
+msgstr "Sluit voorkeure vir %s"
+
+#: id:20153
+msgid "Browse..."
+msgstr "Soek..."
+
+#: id:20154
+msgid "Summary information"
+msgstr "Opsomming inligting"
+
+#: id:20155
+msgid "Storage information"
+msgstr "Storing inligting"
+
+#: id:20156
+msgid "Hard disk information"
+msgstr "Hardeskyf inligting"
+
+#: id:20157
+msgid "DVD-ROM information"
+msgstr "DVD-ROM inligting"
+
+#: id:20158
+msgid "Network information"
+msgstr "Netwerk inligting"
+
+#: id:20159
+msgid "Video information"
+msgstr "Video inligting"
+
+#: id:20160
+msgid "Hardware information"
+msgstr "Hardeware inligting"
+
+#: id:20161
+msgid "Total"
+msgstr "Totale"
+
+#: id:20162
+msgid "Used"
+msgstr "Gebruik"
+
+#: id:20163
+msgid "of"
+msgstr "van"
+
+#: id:20164
+msgid "Locking not supported"
+msgstr "Sluit nie ondersteun"
+
+#: id:20165
+msgid "Not locked"
+msgstr "Nie gesluit"
+
+#: id:20166
+msgid "Locked"
+msgstr "Gesluit"
+
+#: id:20167
+msgid "Frozen"
+msgstr "Gevries"
+
+#: id:20168
+msgid "Requires reset"
+msgstr "Vereis herstel"
+
+#: id:20169
+msgid "Week"
+msgstr "Week"
+
+#: id:20170
+msgid "Line"
+msgstr "Lyn"
+
+#: id:20171
+msgid "Windows network (SMB)"
+msgstr "Windows netwerk (SMB)"
+
+#: id:20172
+msgid "XBMSP server"
+msgstr "XBMSP bediener"
+
+#: id:20173
+msgctxt "Auto context with id 20173"
+msgid "FTP server"
+msgstr "FTP bediener"
+
+#: id:20174
+msgid "iTunes music share (DAAP)"
+msgstr "iTunes musiek saamdeel (DAAP)"
+
+#: id:20175
+msgid "UPnP server"
+msgstr "UPnP bediener"
+
+#: id:20176
+msgid "Show video info"
+msgstr "Wys video info"
+
+#: id:20177
+msgid "Done"
+msgstr "Klaar"
+
+#: id:20178
+msgid "Shift"
+msgstr "Shift"
+
+#: id:20179
+msgid "Caps Lock"
+msgstr "Caps Lock"
+
+#: id:20180
+msgid "Symbols"
+msgstr "Simbole"
+
+#: id:20181
+msgid "Backspace"
+msgstr "Backspace"
+
+#: id:20182
+msgid "Space"
+msgstr "Spasie"
+
+#: id:20183
+msgid "Reload skin"
+msgstr "Herlaai omslag"
+
+#: id:20184
+msgid "Rotate pictures using EXIF information"
+msgstr "Gebruik EXIF inligting om prentjies te roteer"
+
+#: id:20185
+msgid "Use poster view styles for TV shows"
+msgstr "Gebruik plakaat aansig style vir TV vertonings"
+
+#: id:20186
+msgid "Please wait"
+msgstr "Wag asseblief"
+
+#: id:20187
+msgid "UPnP"
+msgstr ""
+
+#: id:20189
+msgid "Enable auto scrolling for plot & review"
+msgstr "Stel auto rol in staat vir plot & resensie"
+
+#: id:20190
+msgctxt "Auto context with id 20190"
+msgid "Custom"
+msgstr "Verpersoonlikte"
+
+#: id:20191
+msgid "Enable debug logging"
+msgstr "Stel ontfout log in staat"
+
+#: id:20192
+msgid "Download additional information during updates"
+msgstr "Laai addisionele inligting af gedurende opdaterings"
+
+#: id:20193
+msgid "Default service for album information"
+msgstr "Bestek diens vir album inligting"
+
+#: id:20194
+msgid "Default service for artist information"
+msgstr "Bestek diens vir kunstenaar inligting"
+
+#: id:20195
+msgid "Change scraper"
+msgstr "Verander skraper"
+
+#: id:20196
+msgid "Export music library"
+msgstr "Voer musiek biblioteek uit"
+
+#: id:20197
+msgid "Import music library"
+msgstr "Voer musiek biblioteek in"
+
+#: id:20198
+msgid "No artist found!"
+msgstr "Geen kunstenaar gevind!"
+
+#: id:20199
+msgid "Downloading artist info failed"
+msgstr "Aflaai van kunstenaar info het gefaal"
+
+#: id:20250
+msgid "Party on! (videos)"
+msgstr "Partytjie voort! (videos)"
+
+#: id:20251
+msgid "Mixing drinks (videos)"
+msgstr "Meng drankies (videos)"
+
+#: id:20252
+msgid "Filling glasses (videos)"
+msgstr "Vul glase (videos)"
+
+#: id:20253
+msgid "WebDAV server (HTTP)"
+msgstr "WebDAV bediener (HTTP)"
+
+#: id:20254
+msgid "WebDAV server (HTTPS)"
+msgstr "WebDAV bediener (HTTPS)"
+
+#: id:20255
+msgid "First logon, edit your profile"
+msgstr "Eerste aanlog, redigeer jou profiel"
+
+#: id:20256
+msgid "HTS Tvheadend client"
+msgstr "HTS Tvheadend kliënt"
+
+#: id:20257
+msgid "VDR Streamdev client"
+msgstr "VDR Streamdev kliënt"
+
+#: id:20258
+msgid "MythTV client"
+msgstr "MythTV kliënt"
+
+#: id:20259
+msgid "Network Filesystem (NFS)"
+msgstr ""
+
+#: id:20260
+msgid "Secure Shell (SSH/SFTP)"
+msgstr ""
+
+#: id:20261
+msgid "Apple Filing Protocol (AFP)"
+msgstr ""
+
+#: id:20300
+msgid "Web server directory (HTTP)"
+msgstr "Web bediener gids (HTTP)"
+
+#: id:20301
+msgid "Web server directory (HTTPS)"
+msgstr "Web bediener gids (HTTPS)"
+
+#: id:20302
+msgid "Unable to write to folder:"
+msgstr "Kan nie skryf na vouer:"
+
+#: id:20303
+msgid "Do you want to skip and proceed?"
+msgstr "Wil jy oorslaan en voortgaan?"
+
+#: id:20304
+msgid "RSS Feed"
+msgstr "RSS Voer"
+
+#: id:20307
+msgid "Secondary DNS"
+msgstr "Sekondêre DNS"
+
+#: id:20308
+msgid "DHCP server:"
+msgstr "DHCP bediener:"
+
+#: id:20309
+msgid "Make new folder"
+msgstr "Maak nuwe vouer"
+
+#: id:20310
+msgid "Dim LCD on playback"
+msgstr "Dim LCD met terugspeel"
+
+#: id:20311
+msgid "Unknown or onboard (protected)"
+msgstr "Onbekende of aanboord (beskerm)"
+
+#: id:20312
+msgid "Dim LCD on paused"
+msgstr "Dim LCD wanneer gepouseer"
+
+#: id:20314
+msgid "Videos - Library"
+msgstr "Videos - Biblioteek"
+
+#: id:20316
+msgid "Sort by: ID"
+msgstr "Sorteer volgens: ID"
+
+#: id:20324
+msgid "Play part..."
+msgstr "Speel deel..."
+
+#: id:20325
+msgid "Calibration reset"
+msgstr "Kalibrasie herstel"
+
+#: id:20326
+msgid "This will reset the calibration values for %s"
+msgstr "Hierdie sal die kalibrasie waardes vir %s"
+
+#: id:20327
+msgid "to it's default values."
+msgstr "herstel na die verstek waardes."
+
+#: id:20328
+msgid "Browse for destination"
+msgstr "Soek vir destinasie"
+
+#: id:20329
+msgid "Movies are in separate folders that match the movie title"
+msgstr ""
+
+#: id:20330
+msgid "Use folder names for lookups"
+msgstr "Gebruik vouer name vir opsoeke"
+
+#: id:20331
+msgctxt "Auto context with id 20331"
+msgid "File"
+msgstr "Lêer"
+
+#: id:20332
+msgid "Use file or folder names in lookups?"
+msgstr "Gebruik lêer of vouer name in opsoeke?"
+
+#: id:20333
+msgid "Set content"
+msgstr "Stel inhoud"
+
+#: id:20334
+msgid "Folder"
+msgstr "Vouer"
+
+#: id:20335
+msgid "Look for content recursively?"
+msgstr "Soek inhoud rekursief?"
+
+#: id:20336
+msgid "Unlock sources"
+msgstr "Ontsluit bronne"
+
+#: id:20337
+msgid "Actor"
+msgstr "Akteur"
+
+#: id:20338
+msgid "Movie"
+msgstr "Fliek"
+
+#: id:20339
+msgid "Director"
+msgstr "Direkteur"
+
+#: id:20340
+msgid "Do you want to remove all items within"
+msgstr "Wil jy alle items binne hierdie pad"
+
+#: id:20341
+msgid "this path from the XBMC library?"
+msgstr "verwyder van die XBMC biblioteek?"
+
+#: id:20342
+msgctxt "Auto context with id 20342"
+msgid "Movies"
+msgstr "Flieks"
+
+#: id:20343
+msgid "TV shows"
+msgstr "TV Vertonings"
+
+#: id:20344
+msgid "This directory contains"
+msgstr "Hierdie gids bevat"
+
+#: id:20345
+msgid "Run automated scan"
+msgstr "Hardloop geautomatiseerde soektog"
+
+#: id:20346
+msgid "Scan recursively"
+msgstr "Deursoek rekursief"
+
+#: id:20347
+msgid "as"
+msgstr "as"
+
+#: id:20348
+msgid "Directors"
+msgstr "Direkteure"
+
+#: id:20349
+msgid "No video files found in this path!"
+msgstr "Geen video lêers gevind in hierdie pad!"
+
+#: id:20350
+msgid "votes"
+msgstr "stemme"
+
+#: id:20351
+msgid "TV show information"
+msgstr "TV vertoning inligting"
+
+#: id:20352
+msgid "Episode information"
+msgstr "Episode inligting"
+
+#: id:20353
+msgid "Loading TV show details"
+msgstr "Laai TV vertoning besonderhede af"
+
+#: id:20354
+msgid "Fetching episode guide"
+msgstr "Gaan haal episode gids"
+
+#: id:20355
+msgid "Loading info for episodes in directory"
+msgstr "Laai info af vir episodes in gids"
+
+#: id:20356
+msgid "Select TV show:"
+msgstr "Selekteer TV vertoning:"
+
+#: id:20357
+msgid "Enter the TV show name"
+msgstr "Tik die TV vertoning naam in"
+
+#: id:20358
+msgid "Season %i"
+msgstr "Seisoen %i"
+
+#: id:20359
+msgid "Episode"
+msgstr "Episode"
+
+#: id:20360
+msgid "Episodes"
+msgstr "Episodes"
+
+#: id:20361
+msgid "Loading episode details"
+msgstr "Laai episode besonderhede af"
+
+#: id:20362
+msgid "Remove episode from library"
+msgstr "Verwyder episode van biblioteek"
+
+#: id:20363
+msgid "Remove TV show from library"
+msgstr "Verwyder TV vertoning van biblioteek"
+
+#: id:20364
+msgid "TV show"
+msgstr "TV vertoning"
+
+#: id:20365
+msgid "Episode plot"
+msgstr "Episode plot"
+
+#: id:20366
+msgid "* All seasons"
+msgstr "* Alle seisoene"
+
+#: id:20367
+msgid "Hide watched"
+msgstr "Steek gekyktes weg"
+
+#: id:20368
+msgid "Prod code"
+msgstr "Prod kode"
+
+#: id:20369
+msgid "Show plot for unwatched items"
+msgstr "Wys plot vir ongekykte items"
+
+#: id:20370
+msgid "* Hidden to prevent spoilers *"
+msgstr "* Versteek om bederwers te verhoed *"
+
+#: id:20371
+msgid "Set season thumb"
+msgstr "Stel seisoen duim"
+
+#: id:20372
+msgid "Season image"
+msgstr "Seisoen prentjie"
+
+#: id:20373
+msgid "Season"
+msgstr "Seisoen"
+
+#: id:20374
+msgid "Downloading movie information"
+msgstr "Laai fliek inligting af"
+
+#: id:20375
+msgid "Unassign content"
+msgstr "Trek inhoud toekenning terug"
+
+#: id:20376
+msgid "Original title"
+msgstr "Oorspronklike titel"
+
+#: id:20377
+msgid "Refresh TV show information"
+msgstr "Verfris TV vertoning inligting"
+
+#: id:20378
+msgid "Refresh info for all episodes?"
+msgstr "Verfris info vir alle episodes?"
+
+#: id:20379
+msgid "Selected folder contains a single TV show"
+msgstr "Geselekteerde vouer bevat 'n enkele TV vertoning"
+
+#: id:20380
+msgid "Exclude selected folder from scans"
+msgstr "Sluit geselekteerde vouer uit soektogte uit"
+
+#: id:20381
+msgid "Specials"
+msgstr "Spesiale"
+
+#: id:20382
+msgid "Automatically grab season thumbs"
+msgstr "Gryp automaties seisoen duime"
+
+#: id:20383
+msgid "Selected folder contains a single video"
+msgstr "Geselekteerde vouer bevat 'n enkele video"
+
+#: id:20384
+msgid "Link to TV show"
+msgstr "Skakel na TV vertoning"
+
+#: id:20385
+msgid "Remove link to TV show"
+msgstr "Verwyder skakel na TV vertoning"
+
+#: id:20386
+msgid "Recently added movies"
+msgstr "Onlangs bygevoegde flieks"
+
+#: id:20387
+msgid "Recently added episodes"
+msgstr "Onlangs bygevoegde episodes"
+
+#: id:20388
+msgid "Studios"
+msgstr "Studios"
+
+#: id:20389
+msgid "Music videos"
+msgstr "Musiek videos"
+
+#: id:20390
+msgid "Recently added music videos"
+msgstr "Onlangs bygevoegde musiek videos"
+
+#: id:20391
+msgid "Music video"
+msgstr "Musiek video"
+
+#: id:20392
+msgid "Remove music video from library"
+msgstr "Verwyder musiek video van biblioteek"
+
+#: id:20393
+msgctxt "Auto context with id 20393"
+msgid "Music video information"
+msgstr "Musiek video inligting"
+
+#: id:20394
+msgid "Loading music video information"
+msgstr "Laai musiek video inligting af"
+
+#: id:20395
+msgid "Mixed"
+msgstr "Gemeng"
+
+#: id:20396
+msgid "Go to albums by artist"
+msgstr "Gaan na albums deur kunstenaar"
+
+#: id:20397
+msgid "Go to album"
+msgstr "Gaan na album"
+
+#: id:20398
+msgid "Play song"
+msgstr "Speel liedjie"
+
+#: id:20399
+msgid "Go to music videos from album"
+msgstr "Gaan na musiek videos van album"
+
+#: id:20400
+msgid "Go to music videos by artist"
+msgstr "Gaan na musiek videos deur kunstenaar"
+
+#: id:20401
+msgid "Play music video"
+msgstr "Speel musiek video"
+
+#: id:20402
+msgid "Download actor thumbnails when adding to library"
+msgstr "Laai akteur duimnaelsketse af wanneer byvoeg by biblioteek"
+
+#: id:20403
+msgid "Set actor thumb"
+msgstr "Stel akteur duim"
+
+#: id:20405
+msgid "Remove episode bookmark"
+msgstr "Verwyder episode boekmerk"
+
+#: id:20406
+msgid "Set episode bookmark"
+msgstr "Stel episode boekmerk"
+
+#: id:20407
+msgid "Scraper settings"
+msgstr "Skraper verstellings"
+
+#: id:20408
+msgid "Downloading music video information"
+msgstr "Laai musiek video inligting af"
+
+#: id:20409
+msgid "Downloading TV show information"
+msgstr "Laai TV vertoning inligting af"
+
+#: id:20410
+msgid "Trailer"
+msgstr "Voorskou"
+
+#: id:20411
+msgid "Flatten"
+msgstr "Verplat"
+
+#: id:20412
+msgid "Flatten TV shows"
+msgstr "Verplat TV vertonings"
+
+#: id:20413
+msgid "Get fanart"
+msgstr "Kry Ondersteunerkuns"
+
+#: id:20414
+msgid "Show Fanart in video and music libraries"
+msgstr "Wys Ondersteunerkuns in video en musiek biblioteke"
+
+#: id:20415
+msgid "Scanning for new content"
+msgstr "Soek vir nuwe inhoud"
+
+#: id:20416
+msgid "First aired"
+msgstr "Eerste gelug"
+
+#: id:20417
+msgid "Writer"
+msgstr "Skrywer"
+
+#: id:20419
+msgid "Replace file names with library titles"
+msgstr ""
+
+#: id:20420
+msgctxt "Auto context with id 20420"
+msgid "Never"
+msgstr "Nooit"
+
+#: id:20421
+msgid "If only one season"
+msgstr "As net een seisoen"
+
+#: id:20422
+msgid "Always"
+msgstr "Altyd"
+
+#: id:20423
+msgid "Has trailer"
+msgstr "Het voorskou"
+
+#: id:20424
+msgid "False"
+msgstr "Vals"
+
+#: id:20425
+msgid "Fanart slideshow"
+msgstr "Ondersteunerkuns skyfievertoning"
+
+#: id:20426
+msgid "Export to a single file or separate"
+msgstr "Voer uit na 'n enkele lêer of"
+
+#: id:20427
+msgid "files per entry?"
+msgstr "apparte lêers per inskrywing?"
+
+#: id:20428
+msgid "Single file"
+msgstr "Enkele lêer"
+
+#: id:20429
+msgctxt "Auto context with id 20429"
+msgid "Separate"
+msgstr "Appart"
+
+#: id:20430
+msgid "Export thumbnails and fanart?"
+msgstr "Voer duimnaelsketse en ondersteunerkuns uit?"
+
+#: id:20431
+msgid "Overwrite old files?"
+msgstr "Oorskryf ou lêers?"
+
+#: id:20432
+msgid "Exclude path from library updates"
+msgstr "Sluit pad van biblioteek uit opdaterings"
+
+#: id:20433
+msgid "Extract thumbnails and video information"
+msgstr "Onttrek duimnaelsketse en video inligting"
+
+#: id:20434
+msgid "Sets"
+msgstr "Stelle"
+
+#: id:20435
+msgid "Set movieset thumb"
+msgstr "Stel filmstel duim"
+
+#: id:20436
+msgid "Export actor thumbs?"
+msgstr "Voer akteur duime uit?"
+
+#: id:20437
+msgid "Choose fanart"
+msgstr "Kies ondersteunerkuns"
+
+#: id:20438
+msgid "Local fanart"
+msgstr "Lokale ondersteunerkuns"
+
+#: id:20439
+msgid "No fanart"
+msgstr "Geen ondersteunerkuns"
+
+#: id:20440
+msgid "Current fanart"
+msgstr "huidige ondersteunerkuns"
+
+#: id:20441
+msgid "Remote fanart"
+msgstr "Afgeleë ondersteunerkuns"
+
+#: id:20442
+msgid "Change content"
+msgstr "Verander inhoud"
+
+#: id:20443
+msgid "Do you want to refresh info for all"
+msgstr "Wil jy info vir alle items"
+
+#: id:20444
+msgid "items within this path?"
+msgstr "binne hierdie pad verfris?"
+
+#: id:20445
+msgid "Fanart"
+msgstr "Ondersteunerkuns"
+
+#: id:20446
+msgid "Locally stored information found."
+msgstr "Lokaal gestoorde inligting gevind."
+
+#: id:20447
+msgid "Ignore and refresh from internet?"
+msgstr "Ignoreer en verfris vanaf internet?"
+
+#: id:20448
+msgid "Could not download information"
+msgstr "Kon nie inligting aflaai nie"
+
+#: id:20449
+msgid "Unable to connect to remote server"
+msgstr "Kan nie aan afgeleë bediener konnekteer"
+
+#: id:20450
+msgid "Would you like to continue scanning?"
+msgstr "Wil jy deursoeking voortsit?"
+
+#: id:20451
+msgid "Countries"
+msgstr "Lande"
+
+#: id:20452
+msgid "episode"
+msgstr "episode"
+
+#: id:20453
+msgid "episodes"
+msgstr "episodes"
+
+#: id:20454
+msgid "Listener"
+msgstr "Luisteraar"
+
+#: id:20455
+msgid "Listeners"
+msgstr "Luisteraars"
+
+#: id:20456
+msgid "Set movieset fanart"
+msgstr ""
+
+#: id:20457
+msgid "Movie set"
+msgstr ""
+
+#: id:20458
+msgid "Group movies in sets"
+msgstr ""
+
+#: id:21330
+msgid "Show hidden files and directories"
+msgstr "Vertoon versteekte lêers en gidse"
+
+#: id:21331
+msgid "TuxBox client"
+msgstr "TuxBox kliënt"
+
+#: id:21332
+msgid "WARNING: Target TuxBox device is in recording-mode!"
+msgstr "WAARSKUWING: Teiken TuxBox toestel is in opneem-modus!"
+
+#: id:21333
+msgid "The stream will be stopped!"
+msgstr "Die stroom sal gestop word!"
+
+#: id:21334
+msgid "Zap to channel: %s failed!"
+msgstr "Zap na kanaal: %s het gefaal!"
+
+#: id:21335
+msgid "Are you sure to start the stream?"
+msgstr "Seker jy wil die stroom begin?"
+
+#: id:21336
+msgid "Connecting to: %s"
+msgstr "Konnekteer aan: %s"
+
+#: id:21337
+msgid "TuxBox device"
+msgstr "TuxBox toestel"
+
+#: id:21359
+msgid "Add media share..."
+msgstr "Voeg media saamdeel by..."
+
+#: id:21360
+msgid "Share video and music libraries through UPnP"
+msgstr "Saamdeel video en musiek biblioteke met UPnP"
+
+#: id:21364
+msgid "Edit media share"
+msgstr "Redigeer media saamdeel"
+
+#: id:21365
+msgid "Remove media share"
+msgstr "Verwyder media saamdeel"
+
+#: id:21366
+msgid "Subtitle folder"
+msgstr "Subtitel vouer"
+
+#: id:21367
+msgid "Movie & alternate subtitle directory"
+msgstr "Fliek & alternatiewe subtitel gids"
+
+#: id:21368
+msgid "Override ASS/SSA subtitles fonts"
+msgstr ""
+
+#: id:21369
+msgid "Enable mouse and Touch Screen support"
+msgstr "Stel muis in staat"
+
+#: id:21370
+msgid "Play navigation sounds during media playback"
+msgstr "Speel navigasie klanke gedurende media terugspeel"
+
+#: id:21371
+msgid "Thumbnail"
+msgstr "Duimnaelskets"
+
+#: id:21372
+msgid "Forced DVD player region"
+msgstr "Geforseerde DVD speler streek"
+
+#: id:21373
+msgid "Video output"
+msgstr "Video uittree"
+
+#: id:21374
+msgid "Video aspect"
+msgstr "Video aspek"
+
+#: id:21375
+msgctxt "Auto context with id 21375"
+msgid "Normal"
+msgstr "Normaal"
+
+#: id:21376
+msgid "Letterbox"
+msgstr "Letterbox"
+
+#: id:21377
+msgid "Widescreen"
+msgstr "Wyeskerm"
+
+#: id:21378
+msgid "Enable 480p"
+msgstr "Stel 480p in staat"
+
+#: id:21379
+msgid "Enable 720p"
+msgstr "Stel 720p in staat"
+
+#: id:21380
+msgid "Enable 1080i"
+msgstr "Stel 1080i in staat"
+
+#: id:21381
+msgid "Enter name of new playlist"
+msgstr "Tik naam of nuwe speellys in"
+
+#: id:21382
+msgid "Show \"Add source\" buttons in file lists"
+msgstr "Wys \"Voeg bron by\" knoppies in lêer lyste"
+
+#: id:21383
+msgid "Enable scrollbars"
+msgstr "Stel rolbalke in staat"
+
+#: id:21384
+msgid "Make watched filtering a toggle in video library"
+msgstr "Maak gekyk filtrering 'n wissel opsie in video biblioteek"
+
+#: id:21385
+msgctxt "Auto context with id 21385"
+msgid "Open"
+msgstr "Maak oop"
+
+#: id:21386
+msgid "Acoustic management level"
+msgstr "Akoestiese bestuur vlak"
+
+#: id:21387
+msgid "Fast"
+msgstr "Vinnig"
+
+#: id:21388
+msgid "Quiet"
+msgstr "Stil"
+
+#: id:21389
+msgid "Enable custom background"
+msgstr "Stel verpersoonlikte agtergrond in staat"
+
+#: id:21390
+msgid "Power management level"
+msgstr "Krag bestuur vlak"
+
+#: id:21391
+msgid "High power"
+msgstr "Hoë kragverbruik"
+
+#: id:21392
+msgid "Low power"
+msgstr "Lae kragverbruik"
+
+#: id:21393
+msgid "High standby"
+msgstr "Hoë bystand"
+
+#: id:21394
+msgid "Low standby"
+msgstr "Lae bystand"
+
+#: id:21395
+msgid "Unable to cache files bigger than 4GB"
+msgstr "Kan nie lêers groter as 4GB stoor"
+
+#: id:21396
+msgid "Chapter"
+msgstr "Hoofstuk"
+
+#: id:21397
+msgid "High quality pixel shader v2"
+msgstr "Hoë kwaliteit pixel shader v2"
+
+#: id:21398
+msgid "Enable playlist at startup"
+msgstr "Stel speellys aan begin in staat"
+
+#: id:21399
+msgid "Use tween animations"
+msgstr "Gebruik tween animasies"
+
+#: id:21400
+msgid "contains"
+msgstr "bevat"
+
+#: id:21401
+msgid "does not contain"
+msgstr "bevat nie"
+
+#: id:21402
+msgid "is"
+msgstr "is"
+
+#: id:21403
+msgid "is not"
+msgstr "is nie"
+
+#: id:21404
+msgid "starts with"
+msgstr "begin met"
+
+#: id:21405
+msgid "ends with"
+msgstr "eindig met"
+
+#: id:21406
+msgid "greater than"
+msgstr "groter as"
+
+#: id:21407
+msgid "less than"
+msgstr "kleiner as"
+
+#: id:21408
+msgid "after"
+msgstr "na"
+
+#: id:21409
+msgid "before"
+msgstr "voor"
+
+#: id:21410
+msgid "in the last"
+msgstr "in die laaste"
+
+#: id:21411
+msgid "not in the last"
+msgstr "nie in die laaste"
+
+#: id:21412
+msgid "Scrapers"
+msgstr "Skrapers"
+
+#: id:21413
+msgid "Default movie scraper"
+msgstr "Verstek fliek skraper"
+
+#: id:21414
+msgid "Default tvshow scraper"
+msgstr "Verstek tv vertoning skraper"
+
+#: id:21415
+msgid "Default music video scraper"
+msgstr "Bestek musiek video skraper"
+
+#: id:21416
+msgid "Enable fallback based on scraper language"
+msgstr "Stel terugval gebasseer op skraper taal in staat"
+
+#: id:21417
+msgid "- Settings"
+msgstr "- Verstellings"
+
+#: id:21418
+msgid "Multilingual"
+msgstr "Multi-talig"
+
+#: id:21419
+msgid "No scrapers present"
+msgstr "Geen skrapers teenwoordig"
+
+#: id:21420
+msgid "Value to match"
+msgstr "Waarde om ooreen te stem"
+
+#: id:21421
+msgid "Smart playlist rule"
+msgstr "Slim speellys reël"
+
+#: id:21422
+msgid "Match items where"
+msgstr "Items stem ooreen waar"
+
+#: id:21423
+msgid "New rule..."
+msgstr "Nuwe reël..."
+
+#: id:21424
+msgid "Items must match"
+msgstr "Items moet ooreenstem"
+
+#: id:21425
+msgid "all of the rules"
+msgstr "al die reëls"
+
+#: id:21426
+msgid "one or more of the rules"
+msgstr "een of meer van die reëls"
+
+#: id:21427
+msgid "Limit to"
+msgstr "Beperk tot"
+
+#: id:21428
+msgid "No limit"
+msgstr "Geen limiet"
+
+#: id:21429
+msgid "Order by"
+msgstr "Orden"
+
+#: id:21430
+msgid "ascending"
+msgstr "stygend"
+
+#: id:21431
+msgid "descending"
+msgstr "dalend"
+
+#: id:21432
+msgid "Edit smart playlist"
+msgstr "Redigeer slim speellys"
+
+#: id:21433
+msgid "Name of the playlist"
+msgstr "Naam van die speellys"
+
+#: id:21434
+msgid "Find items where"
+msgstr "Vind items waar"
+
+#: id:21435
+msgid "Edit"
+msgstr "Redigeer"
+
+#: id:21436
+msgid "%i items"
+msgstr "%i items"
+
+#: id:21437
+msgid "New smart playlist..."
+msgstr "Nuwe slim speellys..."
+
+#: id:21438
+msgid "%c Drive"
+msgstr "%c Skyf"
+
+#: id:21439
+msgid "Edit party mode rules"
+msgstr "Redigeer partytjie modus reëls"
+
+#: id:21440
+msgid "Home folder"
+msgstr "Tuisgids"
+
+#: id:21441
+msgid "Watched count"
+msgstr "Gekykte telling"
+
+#: id:21442
+msgid "Episode title"
+msgstr "Episode titel"
+
+#: id:21443
+msgid "Video resolution"
+msgstr "Video resolusie"
+
+#: id:21444
+msgid "Audio channels"
+msgstr "Audio kanale"
+
+#: id:21445
+msgid "Video codec"
+msgstr "Video kodek"
+
+#: id:21446
+msgid "Audio codec"
+msgstr "Audio kodek"
+
+#: id:21447
+msgid "Audio language"
+msgstr "Audio taal"
+
+#: id:21448
+msgid "Subtitle language"
+msgstr "Subtitel taal"
+
+#: id:21449
+msgid "Remote control sends keyboard presses"
+msgstr "Afstand beheer stuur sleutelbord drukke"
+
+#: id:21450
+msgid "- Edit"
+msgstr "- Redigeer"
+
+#: id:21451
+msgid "Internet connection required."
+msgstr "Internet konneksie vereis."
+
+#: id:21452
+msgid "Get More..."
+msgstr "Kry Meer..."
+
+#: id:21453
+msgid "Root filesystem"
+msgstr "Wortelgids lêerstelsel"
+
+#: id:21454
+msgid "Cache full"
+msgstr ""
+
+#: id:21455
+msgid "Cache filled before reaching required amount for continous playback"
+msgstr ""
+
+#: id:21460
+msgid "Subtitle location"
+msgstr ""
+
+#: id:21461
+msgid "Fixed"
+msgstr ""
+
+#: id:21462
+msgid "Bottom of video"
+msgstr ""
+
+#: id:21463
+msgid "Below video"
+msgstr ""
+
+#: id:21464
+msgid "Top of video"
+msgstr ""
+
+#: id:21465
+msgid "Above video"
+msgstr ""
+
+#: id:21800
+msgid "File name"
+msgstr "Lêer naam"
+
+#: id:21801
+msgid "File path"
+msgstr "Lêer pad"
+
+#: id:21802
+msgid "File size"
+msgstr "Lêer grootte"
+
+#: id:21803
+msgid "File date/time"
+msgstr "Lêer datum/tyd"
+
+#: id:21804
+msgid "Slide index"
+msgstr "Skyfie indeks"
+
+#: id:21805
+msgctxt "Auto context with id 21805"
+msgid "Resolution"
+msgstr "Resolusie"
+
+#: id:21806
+msgctxt "Auto context with id 21806"
+msgid "Comment"
+msgstr "Kommentaar"
+
+#: id:21807
+msgid "Colour/B&W"
+msgstr "Kleur/B&W"
+
+#: id:21808
+msgid "JPEG process"
+msgstr "JPEG proses"
+
+#: id:21820
+msgid "Date/Time"
+msgstr "Datum/Tyd"
+
+#: id:21821
+msgid "Description"
+msgstr "Beskrywing"
+
+#: id:21822
+msgid "Camera make"
+msgstr "Kamera maak"
+
+#: id:21823
+msgid "Camera model"
+msgstr "Kamera model"
+
+#: id:21824
+msgid "EXIF comment"
+msgstr "EXIF kommentaar"
+
+#: id:21825
+msgid "Firmware"
+msgstr "Fermatuur"
+
+#: id:21826
+msgid "Aperture"
+msgstr "Opening"
+
+#: id:21827
+msgid "Focal length"
+msgstr "Fokale lengte"
+
+#: id:21828
+msgid "Focus distance"
+msgstr "Fokus afstand"
+
+#: id:21829
+msgid "Exposure"
+msgstr "Beligting"
+
+#: id:21830
+msgid "Exposure time"
+msgstr "Beligtings tyd"
+
+#: id:21831
+msgid "Exposure bias"
+msgstr "Beligting afset"
+
+#: id:21832
+msgid "Exposure mode"
+msgstr "Beligting modus"
+
+#: id:21833
+msgid "Flash used"
+msgstr "Flits gebruik"
+
+#: id:21834
+msgid "White-balance"
+msgstr "Wit-balans"
+
+#: id:21835
+msgid "Light source"
+msgstr "Lig bron"
+
+#: id:21836
+msgid "Metering mode"
+msgstr "Meet modus"
+
+#: id:21837
+msgid "ISO"
+msgstr "ISO"
+
+#: id:21838
+msgid "Digital zoom"
+msgstr "Digitale zoem"
+
+#: id:21839
+msgid "CCD width"
+msgstr "CCD wydte"
+
+#: id:21840
+msgid "GPS latitude"
+msgstr "GPS breedtegraad"
+
+#: id:21841
+msgid "GPS longitude"
+msgstr "GPS lengtegraad"
+
+#: id:21842
+msgid "GPS altitude"
+msgstr "GPS hoogte"
+
+#: id:21843
+msgid "Orientation"
+msgstr "Oriëntasie"
+
+#: id:21860
+msgid "Supplemental categories"
+msgstr "Aanvullende kategorië"
+
+#: id:21861
+msgid "Keywords"
+msgstr "Sleutelwoorde"
+
+#: id:21862
+msgid "Caption"
+msgstr "Titel"
+
+#: id:21863
+msgid "Author"
+msgstr "Outeur"
+
+#: id:21864
+msgid "Headline"
+msgstr "Opskrif"
+
+#: id:21865
+msgid "Special instructions"
+msgstr "Spesiale instruksies"
+
+#: id:21866
+msgid "Category"
+msgstr "Kategorie"
+
+#: id:21867
+msgid "Byline"
+msgstr "Byline"
+
+#: id:21868
+msgid "Byline title"
+msgstr "Byline titel"
+
+#: id:21869
+msgid "Credit"
+msgstr "Krediet"
+
+#: id:21870
+msgid "Source"
+msgstr "Bron"
+
+#: id:21871
+msgid "Copyright notice"
+msgstr "Kopiereg kennisgewing"
+
+#: id:21872
+msgid "Object name"
+msgstr "Objek naam"
+
+#: id:21873
+msgid "City"
+msgstr "Stad"
+
+#: id:21874
+msgid "State"
+msgstr "Provinsie"
+
+#: id:21875
+msgctxt "Auto context with id 21875"
+msgid "Country"
+msgstr "Land"
+
+#: id:21876
+msgid "Original Tx Reference"
+msgstr "Oorspronklike Tx Verwysing"
+
+#: id:21877
+msgid "Date created"
+msgstr "Datum geskep"
+
+#: id:21878
+msgid "Copyright flag"
+msgstr "Kopiereg vlag"
+
+#: id:21879
+msgid "Country code"
+msgstr "Land kode"
+
+#: id:21880
+msgid "Reference service"
+msgstr "Verwysings diens"
+
+#: id:21881
+msgid "Allow control of XBMC via UPnP"
+msgstr "Laat beheer van XBMC via UPnP toe"
+
+#: id:21882
+msgid "Attempt to skip introduction before DVD menu"
+msgstr "Probeer inleiding voor DVD kieslys oorslaan"
+
+#: id:21883
+msgid "Saved music"
+msgstr "Gestoorde musiek"
+
+#: id:21884
+msgid "Query info for all artists"
+msgstr "Soek info vir alle kunstenaars"
+
+#: id:21885
+msgid "Downloading album information"
+msgstr "Laai album inligting af"
+
+#: id:21886
+msgid "Downloading artist information"
+msgstr "Laai kunstenaar inligting af"
+
+#: id:21887
+msgid "Biography"
+msgstr "Biografie"
+
+#: id:21888
+msgid "Discography"
+msgstr "Discografie"
+
+#: id:21889
+msgid "Searching artist"
+msgstr "Soek kunstenaar"
+
+#: id:21890
+msgid "Select artist"
+msgstr "Selekteer kunstenaar"
+
+#: id:21891
+msgctxt "Auto context with id 21891"
+msgid "Artist information"
+msgstr "Kunstenaar inligting"
+
+#: id:21892
+msgid "Instruments"
+msgstr "Instrumente"
+
+#: id:21893
+msgid "Born"
+msgstr "Gebore"
+
+#: id:21894
+msgid "Formed"
+msgstr "Gevorm"
+
+#: id:21895
+msgid "Themes"
+msgstr "Temas"
+
+#: id:21896
+msgid "Disbanded"
+msgstr "Opgebreek"
+
+#: id:21897
+msgid "Died"
+msgstr "Gesterf"
+
+#: id:21898
+msgid "Years active"
+msgstr "Jare aktief"
+
+#: id:21899
+msgid "Label"
+msgstr "Etiket"
+
+#: id:21900
+msgid "Born/Formed"
+msgstr "Gebore/Gevorm"
+
+#: id:22000
+msgid "Update library on startup"
+msgstr "Opdateer biblioteek aan begin"
+
+#: id:22001
+msgid "Hide progress of library updates"
+msgstr "Steek vordering van biblioteek opdaterings weg"
+
+#: id:22002
+msgid "- DNS suffix"
+msgstr "- DNS agtervoegsel"
+
+#: id:22003
+msgid "%2.3fs"
+msgstr "%2.3fs"
+
+#: id:22004
+msgid "Delayed by: %2.3fs"
+msgstr "Vertraag met: %2.3fs"
+
+#: id:22005
+msgid "Ahead by: %2.3fs"
+msgstr "Voor met: %2.3fs"
+
+#: id:22006
+msgid "Subtitle offset"
+msgstr "Subtitel afset"
+
+#: id:22007
+msgid "OpenGL vendor:"
+msgstr "OpenGL ondernemer:"
+
+#: id:22008
+msgid "OpenGL renderer:"
+msgstr "OpenGL renderer:"
+
+#: id:22009
+msgid "OpenGL version:"
+msgstr "OpenGL weergawe:"
+
+#: id:22010
+msgid "GPU temperature:"
+msgstr "GPU temperatuur:"
+
+#: id:22011
+msgid "CPU temperature:"
+msgstr "CPU temperatuur:"
+
+#: id:22012
+msgid "Total memory"
+msgstr "Totale geheue"
+
+#: id:22013
+msgid "Profile data"
+msgstr "Profiel data"
+
+#: id:22014
+msgid "Use dim if paused during video playback"
+msgstr "Verdof as pauseer gedurende video terugspeel"
+
+#: id:22015
+msgid "All recordings"
+msgstr "Alle opnames"
+
+#: id:22016
+msgid "By title"
+msgstr "Volgens titel"
+
+#: id:22017
+msgid "By group"
+msgstr "Volgens groep"
+
+#: id:22018
+msgid "Live channels"
+msgstr "Lewendige kanale"
+
+#: id:22019
+msgid "Recordings by title"
+msgstr "Opnames volgens titel"
+
+#: id:22020
+msgid "Guide"
+msgstr "Gids"
+
+#: id:22021
+msgid "Allowed error in aspect ratio to minimize black bars"
+msgstr "Laat fout in aspek toe om swart balke te minimeer"
+
+#: id:22022
+msgid "Show video files in listings"
+msgstr "Wys video lêers in lyste"
+
+#: id:22023
+msgid "DirectX vendor:"
+msgstr "DirectX ondernemer:"
+
+#: id:22024
+msgid "Direct3D version:"
+msgstr "Direct3D weergawe:"
+
+#: id:22030
+msgctxt "Auto context with id 22030"
+msgid "Font"
+msgstr "Skrif"
+
+#: id:22031
+msgctxt "Auto context with id 22031"
+msgid "- Size"
+msgstr "- Grootte"
+
+#: id:22032
+msgctxt "Auto context with id 22032"
+msgid "- Colours"
+msgstr "- Kleure"
+
+#: id:22033
+msgid "- Charset"
+msgstr "- Karakterstel"
+
+#: id:22034
+msgid "Export karaoke titles as HTML"
+msgstr "Voer karaoke titels as HTML uit"
+
+#: id:22035
+msgid "Export karaoke titles as CSV"
+msgstr "Voer karaoke titels as CSV uit"
+
+#: id:22036
+msgid "Import karaoke titles..."
+msgstr "Voer karaoke titels in..."
+
+#: id:22037
+msgid "Show song selector automatically"
+msgstr "Wys liedjie selekteerder automaties"
+
+#: id:22038
+msgid "Export karaoke titles..."
+msgstr "Voer karaoke titels uit..."
+
+#: id:22039
+msgid "Enter song number"
+msgstr "Tik liedjie nommer in"
+
+#: id:22040
+msgid "white/green"
+msgstr "wit/groen"
+
+#: id:22041
+msgid "white/red"
+msgstr "wit/rooi"
+
+#: id:22042
+msgid "white/blue"
+msgstr "wit/blou"
+
+#: id:22043
+msgid "black/white"
+msgstr "swart/wit"
+
+#: id:22079
+msgid "Default select action"
+msgstr "Verstek selekteer aksie"
+
+#: id:22080
+msgid "Choose"
+msgstr "Kies"
+
+#: id:22081
+msgid "Show Information"
+msgstr "Wys Inligting"
+
+#: id:22082
+msgid "More..."
+msgstr "Meer..."
+
+#: id:22083
+msgid "Play all"
+msgstr "Speel alles"
+
+#: id:23049
+msgid "Teletext not available"
+msgstr "Teleteks nie beskikbaar"
+
+#: id:23050
+msgid "Activate Teletext"
+msgstr "Aktiveer Teleteks"
+
+#: id:23051
+msgid "Part %i"
+msgstr "Deel %i"
+
+#: id:23052
+msgid "Buffering %i bytes"
+msgstr "Buffer %i grepe"
+
+#: id:23053
+msgid "Stopping"
+msgstr "Stop"
+
+#: id:23054
+msgid "Running"
+msgstr "Hardloop"
+
+#: id:23100
+msgid "External Player Active"
+msgstr "Eksterne Speler Aktief"
+
+#: id:23101
+msgid "Click OK to terminate the player"
+msgstr "Kliek OK om die speler te termineer"
+
+#: id:23104
+msgid "Click OK when playback has ended"
+msgstr "Kliek OK wanneer terugspeel geëindig het"
+
+#: id:24000
+msgid "Add-on"
+msgstr "Byvoegsel"
+
+#: id:24001
+msgid "Add-ons"
+msgstr "Byvoegsels"
+
+#: id:24002
+msgid "Add-on options"
+msgstr "Byvoegsel opsies"
+
+#: id:24003
+msgid "Add-on Information"
+msgstr "Byvoegsel Inligting"
+
+#: id:24005
+msgctxt "Auto context with id 24005"
+msgid "Media sources"
+msgstr "Media bronne"
+
+#: id:24007
+msgctxt "Auto context with id 24007"
+msgid "Movie information"
+msgstr "Fliek inligting"
+
+#: id:24008
+msgctxt "Auto context with id 24008"
+msgid "Screensaver"
+msgstr "Skermskut"
+
+#: id:24009
+msgid "Script"
+msgstr "Skrip"
+
+#: id:24010
+msgctxt "Auto context with id 24010"
+msgid "Visualization"
+msgstr "Visualisering"
+
+#: id:24011
+msgid "Add-on repository"
+msgstr "Byvoegsel stoorplek"
+
+#: id:24012
+msgctxt "Auto context with id 24012"
+msgid "Subtitles"
+msgstr "Subtitels"
+
+#: id:24013
+msgid "Lyrics"
+msgstr "Lirieke"
+
+#: id:24014
+msgid "TV information"
+msgstr "TV inligting"
+
+#: id:24015
+msgctxt "Auto context with id 24015"
+msgid "Music video information"
+msgstr "Musiek video inligting"
+
+#: id:24016
+msgctxt "Auto context with id 24016"
+msgid "Album information"
+msgstr "Album inligting"
+
+#: id:24017
+msgctxt "Auto context with id 24017"
+msgid "Artist information"
+msgstr "Kunstenaar inligting"
+
+#: id:24018
+msgctxt "Auto context with id 24018"
+msgid "Services"
+msgstr "Dienste"
+
+#: id:24020
+msgid "Configure"
+msgstr "konfigureer"
+
+#: id:24021
+msgctxt "Auto context with id 24021"
+msgid "Disable"
+msgstr "Nie in staat stel"
+
+#: id:24022
+msgid "Enable"
+msgstr "Stel in staat"
+
+#: id:24023
+msgid "Add-on disabled"
+msgstr "Byvoegsel nie in staat gestel"
+
+#: id:24027
+msgctxt "Auto context with id 24027"
+msgid "Weather"
+msgstr "Weer"
+
+#: id:24028
+msgid "Weather.com (standard)"
+msgstr "Weather.com (standaard)"
+
+#: id:24030
+msgid "This Add-on can not be configured"
+msgstr "Hierdie byvoegsel kan nie konfigureer word nie"
+
+#: id:24031
+msgid "Error loading settings"
+msgstr "Fout met laai van verstellings"
+
+#: id:24032
+msgid "All Add-ons"
+msgstr "Alle Byvoegsels"
+
+#: id:24033
+msgid "Get Add-ons"
+msgstr "Kry Byvoegsels"
+
+#: id:24034
+msgid "Check for updates"
+msgstr "Soek vir opdaterings"
+
+#: id:24035
+msgid "Force refresh"
+msgstr "Forseer verfris"
+
+#: id:24036
+msgid "Change log"
+msgstr "Veranderinge log"
+
+#: id:24037
+msgid "Uninstall"
+msgstr "Oninstalleer"
+
+#: id:24038
+msgid "Install"
+msgstr "Installeer"
+
+#: id:24039
+msgid "Disabled Add-ons"
+msgstr "Nie in staat gestelde Byvoegsels"
+
+#: id:24040
+msgid "(Clear the current setting)"
+msgstr "(Maak die huidige verstelling skoon)"
+
+#: id:24041
+msgid "Install from zip file"
+msgstr "Installeer vanaf zip lêer"
+
+#: id:24042
+msgid "Downloading %i%%"
+msgstr "Laai %i%% af"
+
+#: id:24043
+msgid "Available Updates"
+msgstr "Beskikbare opdaterings"
+
+#: id:24044
+msgid "Dependencies not met"
+msgstr ""
+
+#: id:24045
+msgid "Add-on does not have the correct structure"
+msgstr ""
+
+#: id:24046
+msgid "%s is used by the following installed add-on(s)"
+msgstr ""
+
+#: id:24047
+msgid "This add-on cannot be uninstalled"
+msgstr ""
+
+#: id:24048
+msgid "Rollback"
+msgstr ""
+
+#: id:24050
+msgid "Available Add-ons"
+msgstr "Beskikbare Byvoegsels"
+
+#: id:24051
+msgid "Version:"
+msgstr "Weergawe:"
+
+#: id:24052
+msgid "Disclaimer"
+msgstr "Afstanddoening"
+
+#: id:24053
+msgid "License:"
+msgstr "Lisensie:"
+
+#: id:24054
+msgid "Changelog"
+msgstr "Veranderlog"
+
+#: id:24059
+msgid "Would you like to enable this Add-on?"
+msgstr "Wil jy hierdie Byvoegsel in staat stel?"
+
+#: id:24060
+msgid "Would you like to disable this Add-on?"
+msgstr "Wil jy hierdie Byvoegsel buite staat stel?"
+
+#: id:24061
+msgid "Add-on update available!"
+msgstr "Byvoegsel opdatering beskikbaar!"
+
+#: id:24062
+msgid "Enabled Add-ons"
+msgstr "In staat gestelde Byvoegsels"
+
+#: id:24063
+msgid "Auto update"
+msgstr "Auto opdateer"
+
+#: id:24064
+msgid "Add-on enabled"
+msgstr "Byvoegsel in staat gestel"
+
+#: id:24065
+msgid "Add-on updated"
+msgstr "Byvoegsel opgedateer"
+
+#: id:24066
+msgid "Cancel Add-on download?"
+msgstr "Kanselleer Byvoegsel aflaai?"
+
+#: id:24067
+msgid "Currently downloading Add-ons"
+msgstr "Laai huidige Byvoegsels af"
+
+#: id:24068
+msgid "Update available"
+msgstr "Opdateer beskikbare"
+
+#: id:24069
+msgid "Update"
+msgstr "Opdateer"
+
+#: id:24070
+msgid "Add-on could not be loaded."
+msgstr "Byvoegsel kon nie gelaai word."
+
+#: id:24071
+msgid "An unknown error has occurred."
+msgstr "'n Onbekende fout het voorgekom."
+
+#: id:24072
+msgid "Settings required"
+msgstr "Verstellings vereis"
+
+#: id:24073
+msgid "Could not connect"
+msgstr "Kon nie konnekteer"
+
+#: id:24074
+msgid "Needs to restart"
+msgstr "Nodig om oor te begin"
+
+#: id:24075
+msgctxt "Auto context with id 24075"
+msgid "Disable"
+msgstr "Nie in staat stel"
+
+#: id:24076
+msgid "Add-on Required"
+msgstr ""
+
+#: id:24080
+msgid "Try to reconnect?"
+msgstr "Probeer om te herkonnekteer?"
+
+#: id:24089
+msgid "Add-on restarts"
+msgstr "Byvoegsel oorbegin"
+
+#: id:24090
+msgid "Lock Add-on manager"
+msgstr "Sluit Byvoegsel bestuurder"
+
+#: id:24094
+msgid "(current)"
+msgstr ""
+
+#: id:24095
+msgid "(blacklisted)"
+msgstr ""
+
+#: id:24096
+msgid "Add-on has been marked as broken in repository."
+msgstr "Byvoegsel is as gebreek gemerk in stoorplek."
+
+#: id:24097
+msgid "Would you like to disable it on your system?"
+msgstr "Wil jy dit buite staat stel vir jou stelsel?"
+
+#: id:24098
+msgid "Broken"
+msgstr "Gebreek"
+
+#: id:24099
+msgid "Would you like to switch to this skin?"
+msgstr "Wil jy oorskakel na hierdie omslag?"
+
+#: id:24100
+msgid "To use this feature you must download an Add-on:"
+msgstr ""
+
+#: id:24101
+msgid "Would you like to download this Add-on?"
+msgstr ""
+
+#: id:25000
+msgid "Notifications"
+msgstr "Kennisgewings"
+
+#: id:29800
+msgid "Library Mode"
+msgstr "Biblioteek Modus"
+
+#: id:29801
+msgid "QWERTY keyboard"
+msgstr "QWERTY sleutelbord"
+
+#: id:29802
+msgid "Passthrough Audio in use"
+msgstr "Deurvoer Audio in gebruik"
+
+#: id:33001
+msgid "Trailer quality"
+msgstr "Voorskou kwaliteit"
+
+#: id:33002
+msgid "Stream"
+msgstr "Stroom"
+
+#: id:33003
+msgid "Download"
+msgstr "Laai af"
+
+#: id:33004
+msgid "Download & play"
+msgstr "Laai af & speel"
+
+#: id:33005
+msgid "Download & save"
+msgstr "Laai af & stoor"
+
+#: id:33006
+msgid "Today"
+msgstr "Vandag"
+
+#: id:33007
+msgid "Tomorrow"
+msgstr "More"
+
+#: id:33008
+msgid "Saving"
+msgstr "Stoor"
+
+#: id:33009
+msgid "Copying"
+msgstr "Kopiëer"
+
+#: id:33010
+msgid "Set download directory"
+msgstr "Stel aflaai gids"
+
+#: id:33011
+msgid "Search duration"
+msgstr "Soek lengte"
+
+#: id:33012
+msgid "Short"
+msgstr "Kort"
+
+#: id:33013
+msgid "Long"
+msgstr "Lang"
+
+#: id:33014
+msgid "Use DVD player instead of regular player"
+msgstr "Gebruik DVD speler in plaas van gewone speler"
+
+#: id:33015
+msgid "Ask for download before playing video"
+msgstr "Vra vir aflaai voor video speel"
+
+#: id:33016
+msgid "Clips"
+msgstr "Clips"
+
+#: id:33017
+msgid "Restart plugin to enable"
+msgstr "Begin inprop oor om in staat te stel"
+
+#: id:33018
+msgid "Tonight"
+msgstr "Vanaand"
+
+#: id:33019
+msgid "Tomorrow Night"
+msgstr "More Aand"
+
+#: id:33020
+msgid "Condition"
+msgstr "Kondisie"
+
+#: id:33021
+msgid "Precipitation"
+msgstr "Presipitaat"
+
+#: id:33022
+msgid "Precip"
+msgstr "Presip"
+
+#: id:33023
+msgid "Humid"
+msgstr "Humied"
+
+#: id:33024
+msgid "Feels"
+msgstr "Voel"
+
+#: id:33025
+msgid "Observed"
+msgstr "Observeer"
+
+#: id:33026
+msgid "Departure from normal"
+msgstr "Wyk af van normaal"
+
+#: id:33027
+msgid "Sunrise"
+msgstr "Sonopkoms"
+
+#: id:33028
+msgid "Sunset"
+msgstr "Sononder"
+
+#: id:33029
+msgid "Details"
+msgstr "Besonderhede"
+
+#: id:33030
+msgid "Outlook"
+msgstr "Uitkyk"
+
+#: id:33031
+msgid "Coverflow"
+msgstr "Coverflow"
+
+#: id:33032
+msgid "Translate text"
+msgstr "Vertaal teks"
+
+#: id:33033
+msgid "Map list %s category"
+msgstr "Kaart lys %s kategorie"
+
+#: id:33034
+msgid "36 Hour"
+msgstr "36 Uur"
+
+#: id:33035
+msgid "Maps"
+msgstr "Kaarte"
+
+#: id:33036
+msgid "Hourly"
+msgstr "Uurliks"
+
+#: id:33037
+msgid "Weekend"
+msgstr "Naweek"
+
+#: id:33038
+msgid "%s day"
+msgstr "%s dag"
+
+#: id:33049
+msgid "Alert"
+msgstr "Waarsku"
+
+#: id:33050
+msgid "Alerts"
+msgstr "Waarskuwings"
+
+#: id:33051
+msgid "Choose Your"
+msgstr "Kies Jou"
+
+#: id:33052
+msgid "Check"
+msgstr "Gaan na"
+
+#: id:33053
+msgctxt "Auto context with id 33053"
+msgid "Configure the"
+msgstr "Konfigureer die"
+
+#: id:33054
+msgid "Seasons"
+msgstr "Seisoene"
+
+#: id:33055
+msgid "Use your"
+msgstr "Gebruik jou"
+
+#: id:33056
+msgid "Watch your"
+msgstr "Kyk na jou"
+
+#: id:33057
+msgid "Listen to"
+msgstr "Luister na"
+
+#: id:33058
+msgid "View your"
+msgstr "Kyk na jou"
+
+#: id:33059
+msgctxt "Auto context with id 33059"
+msgid "Configure the"
+msgstr "Konfigureer die"
+
+#: id:33060
+msgid "Power"
+msgstr "Krag"
+
+#: id:33061
+msgid "Menu"
+msgstr "Kieslys"
+
+#: id:33062
+msgid "Play the"
+msgstr "Speel die"
+
+#: id:33063
+msgid "Options"
+msgstr "Opsies"
+
+#: id:33065
+msgid "Editor"
+msgstr "Redigeerder"
+
+#: id:33066
+msgid "About your"
+msgstr "Omtrent jou"
+
+#: id:33067
+msgid "Star rating"
+msgstr "Ster gradering"
+
+#: id:33068
+msgid "Background"
+msgstr "Agtergrond"
+
+#: id:33069
+msgid "Backgrounds"
+msgstr "Agtergronde"
+
+#: id:33070
+msgid "Custom background"
+msgstr "Verpersoonlikte agtergrond"
+
+#: id:33071
+msgid "Custom backgrounds"
+msgstr "Verpersoonlikte agtergronde"
+
+#: id:33072
+msgid "View Readme"
+msgstr "Lees Readme"
+
+#: id:33073
+msgid "View Changelog"
+msgstr "Lees Veranderlog"
+
+#: id:33074
+msgid "This version of %s requires an"
+msgstr "Hierdie weergawe van %s vereis 'n XBMC"
+
+#: id:33075
+msgid "XBMC revision of %s or greater to run."
+msgstr "weergawe van %s of groter om te loop."
+
+#: id:33076
+msgid "Please update XBMC."
+msgstr "Opdateer asseblief XBMC."
+
+#: id:33077
+msgid "No data found!"
+msgstr "Geen data gevind!"
+
+#: id:33078
+msgid "Next page"
+msgstr "Volgende bladsy"
+
+#: id:33079
+msgid "Love"
+msgstr "Hou van"
+
+#: id:33080
+msgid "Hate"
+msgstr "Haat"
+
+#: id:33081
+msgid "This file is stacked, select the part you want to play from."
+msgstr "Hierdie lêer is gestapel, selekteer die deel van waar jy wil speel."
+
+#: id:33082
+msgid "Path to script"
+msgstr "Pad na skrip"
+
+#: id:33083
+msgid "Enable custom script button"
+msgstr "Stel verpersoonlikte skrip knoppie in staat"
+
+#: id:33100
+msgid "Failed to start"
+msgstr ""
+
+#: id:33101
+msgid "Webserver"
+msgstr ""
+
+#: id:33102
+msgid "Event Server"
+msgstr ""
+
+#: id:33103
+msgid "Remote communication server"
+msgstr ""
+
+#: id:33200
+msgid "Detected New Connection"
+msgstr ""
+
+#: id:34000
+msgid "Lame"
+msgstr "Lame"
+
+#: id:34001
+msgid "Vorbis"
+msgstr "Vorbis"
+
+#: id:34002
+msgid "Wav"
+msgstr "Wav"
+
+#: id:34003
+msgid "DXVA2"
+msgstr "DXVA2"
+
+#: id:34004
+msgid "VAAPI"
+msgstr "VAAPI"
+
+#: id:34005
+msgid "Flac"
+msgstr "Flac"
+
+#: id:34100
+msgid "Speaker Configuration"
+msgstr "Luidspreker konfigurasie"
+
+#: id:34101
+msgid "2.0"
+msgstr "2.0"
+
+#: id:34102
+msgid "2.1"
+msgstr "2.1"
+
+#: id:34103
+msgid "3.0"
+msgstr "3.0"
+
+#: id:34104
+msgid "3.1"
+msgstr "3.1"
+
+#: id:34105
+msgid "4.0"
+msgstr "4.0"
+
+#: id:34106
+msgid "4.1"
+msgstr "4.1"
+
+#: id:34107
+msgid "5.0"
+msgstr "5.0"
+
+#: id:34108
+msgid "5.1"
+msgstr "5.1"
+
+#: id:34109
+msgid "7.0"
+msgstr "7.0"
+
+#: id:34110
+msgid "7.1"
+msgstr "7.1"
+
+#: id:34201
+msgid "Can't find a next item to play"
+msgstr ""
+
+#: id:34202
+msgid "Can't find a previous item to play"
+msgstr ""
+
+#: id:34300
+msgid "Failed to start zeroconf"
+msgstr ""
+
+#: id:34301
+msgid "Is Apple's Bonjour Service installed? See log for more info."
+msgstr ""
+
+#: id:34400
+msgid "Video Rendering"
+msgstr ""
+
+#: id:34401
+msgid "Failed to init video filters/scalers, falling back to bilinear scaling"
+msgstr ""
+
+#: id:34402
+msgid "Failed to initialize audio device"
+msgstr ""
+
+#: id:34403
+msgid "Check your audiosettings"
+msgstr ""
+
+#: id:34404
+msgid "Use gestures for navigation:"
+msgstr ""
+
+#: id:34405
+msgid "1 finger swipe left,right,up,down for cursors"
+msgstr ""
+
+#: id:34406
+msgid "2 finger swipe left for backspace"
+msgstr ""
+
+#: id:34407
+msgid "1 finger single tap for enter"
+msgstr ""
+
+#: id:34408
+msgid "2 finger single tap for contextmenu"
+msgstr ""
+
+#: id:35000
+msgid "Peripherals"
+msgstr ""
+
+#: id:35001
+msgid "Generic HID device"
+msgstr ""
+
+#: id:35002
+msgid "Generic network adapter"
+msgstr ""
+
+#: id:35003
+msgid "Generic disk"
+msgstr ""
+
+#: id:35004
+msgid "There are no settings available\nfor this peripheral."
+msgstr ""
+
+#: id:35005
+msgid "New device configured"
+msgstr ""
+
+#: id:35006
+msgid "Device removed"
+msgstr ""
+
+#: id:35007
+msgid "Keymap to use for this device"
+msgstr ""
+
+#: id:35008
+msgid "Keymap enabled"
+msgstr ""
+
+#: id:35009
+msgid "Do not use the custom keymap for this device"
+msgstr ""
+
+#: id:35500
+msgid "Location"
+msgstr ""
+
+#: id:35501
+msgid "Class"
+msgstr ""
+
+#: id:35502
+msgctxt "Auto context with id 35502"
+msgid "Name"
+msgstr ""
+
+#: id:35503
+msgid "Vendor"
+msgstr ""
+
+#: id:35504
+msgid "Product ID"
+msgstr ""
+
+#: id:36000
+msgid "Pulse-Eight CEC adapter"
+msgstr ""
+
+#: id:36001
+msgid "Pulse-Eight Nyxboard"
+msgstr ""
+
+#: id:36002
+msgid "Switch to keyboard side command"
+msgstr ""
+
+#: id:36003
+msgid "Switch to remote side command"
+msgstr ""
+
+#: id:36004
+msgid "Press \"user\" button command"
+msgstr ""
+
+#: id:36005
+msgid "Enable switch side commands"
+msgstr ""
+
+#: id:36006
+msgid "Could not open the adapter"
+msgstr ""
+
+#: id:36007
+msgid "Devices to power on when starting XBMC"
+msgstr ""
+
+#: id:36008
+msgid "Devices to power off when stopping XBMC"
+msgstr ""
+
+#: id:36009
+msgid "Put devices in standby mode when activating screensaver"
+msgstr ""
+
+#: id:36011
+msgid "Could not detect the CEC port. Set it up manually."
+msgstr ""
+
+#: id:36012
+msgid "Could not initialise the CEC adapter. Check your settings."
+msgstr ""
+
+#: id:36013
+msgid "Unsupported libCEC interface version. %d is greater than the version XBMC supports (%d)"
+msgstr ""
+
+#: id:36014
+msgid "Put this PC in standby mode when the TV is switched off"
+msgstr ""
+
+#: id:36015
+msgid "HDMI port number"
+msgstr ""
+
+#: id:36016
+msgctxt "Auto context with id 36016"
+msgid "Connected"
+msgstr ""
+
+#: id:36017
+msgid "Adapter found, but libCEC is not available"
+msgstr ""
+
+#: id:36018
+msgid "Use the TV's language setting"
+msgstr ""
+
+#: id:36019
+msgid "Connected to HDMI device"
+msgstr ""
+
+#: id:36020
+msgid "Make XBMC the active source when starting"
+msgstr ""
+
+#: id:36021
+msgid "Physical address (overrules HDMI port)"
+msgstr ""
+
+#: id:36022
+msgid "COM port (leave empty unless needed)"
+msgstr ""
+
+#: id:36023
+msgid "Configuration updated"
+msgstr ""
+
+#: id:36024
+msgid "Failed to set the new configuration. Please check your settings."
+msgstr ""
+
+#: id:36025
+msgid "Send 'inactive source' command when stopping XBMC"
+msgstr ""
+

--- a/language/Arabic/strings.po
+++ b/language/Arabic/strings.po
@@ -1,0 +1,9093 @@
+# Converted from xbmc strings.xml with xbmc-xml2po (by Team-XBMC)
+msgid ""
+msgstr ""
+"Project-Id-Version: xbmc.core-FRODO_GIT3ed1604ad7\n"
+"Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
+"POT-Creation-Date: 2012-04-09 18:00+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE\n"
+"Language: ar\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: id:0
+msgctxt "Auto context with id 0"
+msgid "Programs"
+msgstr "البرامج"
+
+#: id:1
+msgctxt "Auto context with id 1"
+msgid "Pictures"
+msgstr "الصور"
+
+#: id:2
+msgctxt "Auto context with id 2"
+msgid "Music"
+msgstr "الموسيقى"
+
+#: id:3
+msgctxt "Auto context with id 3"
+msgid "Videos"
+msgstr "الفيديو"
+
+#: id:4
+msgid "TV-Guide"
+msgstr "دليل التلفزيون"
+
+#: id:5
+msgctxt "Auto context with id 5"
+msgid "Settings"
+msgstr "الإعدادات"
+
+#: id:6
+msgid "XBMC SVN"
+msgstr ""
+
+#: id:7
+msgctxt "Auto context with id 7"
+msgid "File manager"
+msgstr "إدارة الملفات"
+
+#: id:8
+msgctxt "Auto context with id 8"
+msgid "Weather"
+msgstr "الطقس"
+
+#: id:9
+msgid "xbmc media center"
+msgstr "xbmc مركز وسائط"
+
+#: id:11
+msgid "Monday"
+msgstr "الاثنين"
+
+#: id:12
+msgid "Tuesday"
+msgstr "الثلاثاء"
+
+#: id:13
+msgid "Wednesday"
+msgstr "الاربعاء"
+
+#: id:14
+msgid "Thursday"
+msgstr "الخميس"
+
+#: id:15
+msgid "Friday"
+msgstr "الجمعة"
+
+#: id:16
+msgid "Saturday"
+msgstr "السبت"
+
+#: id:17
+msgid "Sunday"
+msgstr "الاحد"
+
+#: id:21
+msgid "January"
+msgstr "يناير"
+
+#: id:22
+msgid "February"
+msgstr "فبراير"
+
+#: id:23
+msgid "March"
+msgstr "مارس"
+
+#: id:24
+msgid "April"
+msgstr "أبريل"
+
+#: id:25
+msgctxt "Auto context with id 25"
+msgid "May"
+msgstr "مايو"
+
+#: id:26
+msgid "June"
+msgstr "يونيو"
+
+#: id:27
+msgid "July"
+msgstr "يوليو"
+
+#: id:28
+msgid "August"
+msgstr "أغسطس"
+
+#: id:29
+msgid "September"
+msgstr "سبتمبر"
+
+#: id:30
+msgid "October"
+msgstr "أكتوبر"
+
+#: id:31
+msgid "November"
+msgstr "نوفمبر"
+
+#: id:32
+msgid "December"
+msgstr "ديسمبر"
+
+#: id:41
+msgid "Mon"
+msgstr "اثنين"
+
+#: id:42
+msgid "Tue"
+msgstr "ثلاثاء"
+
+#: id:43
+msgid "Wed"
+msgstr "اربعاء"
+
+#: id:44
+msgid "Thu"
+msgstr "خميس"
+
+#: id:45
+msgid "Fri"
+msgstr "جمعة"
+
+#: id:46
+msgid "Sat"
+msgstr "سبت"
+
+#: id:47
+msgctxt "Auto context with id 47"
+msgid "Sun"
+msgstr "أحد"
+
+#: id:51
+msgid "Jan"
+msgstr "يناير"
+
+#: id:52
+msgid "Feb"
+msgstr "فبراير"
+
+#: id:53
+msgid "Mar"
+msgstr "مارس"
+
+#: id:54
+msgid "Apr"
+msgstr "أبريل"
+
+#: id:55
+msgctxt "Auto context with id 55"
+msgid "May"
+msgstr "مايو"
+
+#: id:56
+msgid "Jun"
+msgstr "يونيو"
+
+#: id:57
+msgid "Jul"
+msgstr "يوليو"
+
+#: id:58
+msgid "Aug"
+msgstr "أغسطس"
+
+#: id:59
+msgid "Sep"
+msgstr "سبتمبر"
+
+#: id:60
+msgid "Oct"
+msgstr "أكتوبر"
+
+#: id:61
+msgid "Nov"
+msgstr "نوفمبر"
+
+#: id:62
+msgid "Dec"
+msgstr "ديسمبر"
+
+#: id:71
+msgid "N"
+msgstr "N"
+
+#: id:72
+msgid "NNE"
+msgstr "NNE"
+
+#: id:73
+msgid "NE"
+msgstr "NE"
+
+#: id:74
+msgid "ENE"
+msgstr "ENE"
+
+#: id:75
+msgid "E"
+msgstr "E"
+
+#: id:76
+msgid "ESE"
+msgstr "ESE"
+
+#: id:77
+msgid "SE"
+msgstr "SE"
+
+#: id:78
+msgid "SSE"
+msgstr "SSE"
+
+#: id:79
+msgid "S"
+msgstr "S"
+
+#: id:80
+msgid "SSW"
+msgstr "SSW"
+
+#: id:81
+msgid "SW"
+msgstr "SW"
+
+#: id:82
+msgid "WSW"
+msgstr "WSW"
+
+#: id:83
+msgid "W"
+msgstr "W"
+
+#: id:84
+msgid "WNW"
+msgstr "WNW"
+
+#: id:85
+msgid "NW"
+msgstr "NW"
+
+#: id:86
+msgid "NNW"
+msgstr "NNW"
+
+#: id:87
+msgid "VAR"
+msgstr "VAR"
+
+#: id:98
+msgid "View: Auto"
+msgstr "عرض: تلقائية"
+
+#: id:99
+msgid "View: Auto big"
+msgstr "عرض: تلقائية كبيرة"
+
+#: id:100
+msgid "View: Icons"
+msgstr "عرض: رموز"
+
+#: id:101
+msgid "View: List"
+msgstr "عرض: قائمة"
+
+#: id:102
+msgctxt "Auto context with id 102"
+msgid "Scan"
+msgstr "فحص"
+
+#: id:103
+msgctxt "Auto context with id 103"
+msgid "Sort by: Name"
+msgstr "ترتيب حسب: الإسم"
+
+#: id:104
+msgid "Sort by: Date"
+msgstr "ترتيب حسب: التاريخ"
+
+#: id:105
+msgid "Sort by: Size"
+msgstr "ترتيب حسب: الحجم"
+
+#: id:106
+msgid "No"
+msgstr "لا"
+
+#: id:107
+msgid "Yes"
+msgstr "نعم"
+
+#: id:108
+msgctxt "Auto context with id 108"
+msgid "Slideshow"
+msgstr "عرض الشرائح"
+
+#: id:109
+msgid "Create thumbs"
+msgstr "إنشاء مصغرات"
+
+#: id:110
+msgid "Create thumbnails"
+msgstr "إنشاء مصغرات"
+
+#: id:111
+msgctxt "Auto context with id 111"
+msgid "Shortcuts"
+msgstr "اختصارات"
+
+#: id:112
+msgid "Paused"
+msgstr "متوقف"
+
+#: id:113
+msgid "Update failed"
+msgstr "فشل التحديث"
+
+#: id:114
+msgid "Installation failed"
+msgstr "فشل التثبيت"
+
+#: id:115
+msgid "Copy"
+msgstr "نسخ"
+
+#: id:116
+msgid "Move"
+msgstr "تحريك"
+
+#: id:117
+msgid "Delete"
+msgstr "حذف"
+
+#: id:118
+msgid "Rename"
+msgstr "إعادة تسمية"
+
+#: id:119
+msgid "New folder"
+msgstr "مجلد جديد"
+
+#: id:120
+msgid "Confirm file copy"
+msgstr "تأكيد نسخ ملف"
+
+#: id:121
+msgid "Confirm file move"
+msgstr "تأكيد نقل ملف"
+
+#: id:122
+msgid "Confirm file delete?"
+msgstr "تأكيد حذف ملف؟"
+
+#: id:123
+msgid "Copy these files?"
+msgstr "نسخ هذه الملفات؟"
+
+#: id:124
+msgid "Move these files?"
+msgstr "تحريك هذه الملفات؟"
+
+#: id:125
+msgid "Delete these files? - Deleting files cannot be undone!"
+msgstr "حذف هذه الملفات؟ - لايمكن التراجع بعد حذف هذه الملفات!"
+
+#: id:126
+msgid "Status"
+msgstr "الحالة"
+
+#: id:127
+msgid "Objects"
+msgstr "كائنات"
+
+#: id:128
+msgctxt "Auto context with id 128"
+msgid "General"
+msgstr "عام"
+
+#: id:129
+msgctxt "Auto context with id 129"
+msgid "Slideshow"
+msgstr "عرض الشرائح"
+
+#: id:130
+msgctxt "Auto context with id 130"
+msgid "System info"
+msgstr "معلومات النظام"
+
+#: id:131
+msgid "Display"
+msgstr "عرض"
+
+#: id:132
+msgid "Albums"
+msgstr "البومات"
+
+#: id:133
+msgid "Artists"
+msgstr "الفنانين"
+
+#: id:134
+msgid "Songs"
+msgstr "الأغاني"
+
+#: id:135
+msgid "Genres"
+msgstr "الأنواع"
+
+#: id:136
+msgid "Playlists"
+msgstr "قوائم التشغيل"
+
+#: id:137
+msgid "Search"
+msgstr "بحث"
+
+#: id:138
+msgid "System Information"
+msgstr "معلومات النظام"
+
+#: id:139
+msgid "Temperatures:"
+msgstr "درجات الحرارة:"
+
+#: id:140
+msgid "CPU:"
+msgstr "وحدة المعالجة:"
+
+#: id:141
+msgid "GPU:"
+msgstr "معالج الرسومات:"
+
+#: id:142
+msgid "Time:"
+msgstr "الوقت:"
+
+#: id:143
+msgid "Current:"
+msgstr "الحالي:"
+
+#: id:144
+msgid "Build:"
+msgstr "النسخة:"
+
+#: id:145
+msgid "Network:"
+msgstr "الشبكة:"
+
+#: id:146
+msgid "Type:"
+msgstr "النوع:"
+
+#: id:147
+msgid "Static"
+msgstr "ثابت"
+
+#: id:148
+msgid "DHCP"
+msgstr "DHCP"
+
+#: id:149
+msgid "MAC address"
+msgstr "عنوان التحكم بالوصول إلى الوسائط MAC"
+
+#: id:150
+msgctxt "Auto context with id 150"
+msgid "IP address"
+msgstr "عنوان الآي بي IP"
+
+#: id:151
+msgid "Link:"
+msgstr "الربط:"
+
+#: id:152
+msgid "Half duplex"
+msgstr "Half duplex"
+
+#: id:153
+msgid "Full duplex"
+msgstr "Full duplex"
+
+#: id:154
+msgctxt "Auto context with id 154"
+msgid "Storage"
+msgstr "سعة التخزين"
+
+#: id:155
+msgid "Drive"
+msgstr "السواقة"
+
+#: id:156
+msgctxt "Auto context with id 156"
+msgid "Free"
+msgstr "الخالية"
+
+#: id:157
+msgctxt "Auto context with id 157"
+msgid "Video"
+msgstr "الفيديو"
+
+#: id:158
+msgid "Free memory"
+msgstr "الذاكرة"
+
+#: id:159
+msgid "No link"
+msgstr "لايوجد رابط"
+
+#: id:160
+msgctxt "Auto context with id 160"
+msgid "Free"
+msgstr "الخالية"
+
+#: id:161
+msgid "Unavailable"
+msgstr "تعطيل"
+
+#: id:162
+msgid "Tray open"
+msgstr "فتح علبة"
+
+#: id:163
+msgid "Reading"
+msgstr "قراءة"
+
+#: id:164
+msgid "No disc"
+msgstr "لايوجد قرص"
+
+#: id:165
+msgid "Disc present"
+msgstr "القرص الحالي"
+
+#: id:166
+msgid "Skin"
+msgstr "الخلفيات"
+
+#: id:169
+msgctxt "Auto context with id 169"
+msgid "Resolution"
+msgstr "دقة"
+
+#: id:170
+msgid "Adjust display refresh rate to match video"
+msgstr "ضبط معدل تحديث الشاشة لتتناسب مع الفيديو"
+
+#: id:172
+msgid "Release date"
+msgstr "تاريخ الإصدار"
+
+#: id:173
+msgid "Display 4:3 videos as"
+msgstr "عرض 4:3 فيديو مثل"
+
+#: id:175
+msgid "Moods"
+msgstr "الأمزجة"
+
+#: id:176
+msgid "Styles"
+msgstr "الأنماط"
+
+#: id:179
+msgid "Song"
+msgstr "الأغنية"
+
+#: id:180
+msgid "Duration"
+msgstr "المدة"
+
+#: id:181
+msgid "Select album"
+msgstr "اختر الألبوم"
+
+#: id:182
+msgid "Tracks"
+msgstr "المسارات"
+
+#: id:183
+msgid "Review"
+msgstr "مراجعة"
+
+#: id:184
+msgid "Refresh"
+msgstr "تحديث"
+
+#: id:185
+msgid "Searching album"
+msgstr "بحث ألبوم"
+
+#: id:186
+msgid "OK"
+msgstr "موافق"
+
+#: id:187
+msgid "No albums found!"
+msgstr "لا توجد ألبومات"
+
+#: id:188
+msgid "Select all"
+msgstr "حدد الكل"
+
+#: id:189
+msgid "Scanning media info"
+msgstr "فحص معلومات الوسائط"
+
+#: id:190
+msgid "Save"
+msgstr "حفظ"
+
+#: id:191
+msgid "Shuffle"
+msgstr "خلط"
+
+#: id:192
+msgctxt "Auto context with id 192"
+msgid "Clear"
+msgstr "مسح"
+
+#: id:193
+msgctxt "Auto context with id 193"
+msgid "Scan"
+msgstr "فحص"
+
+#: id:194
+msgid "Searching..."
+msgstr "بحث..."
+
+#: id:195
+msgid "No info found!"
+msgstr "لا توجد معلومات"
+
+#: id:196
+msgid "Select movie:"
+msgstr "اختر الفلم:"
+
+#: id:197
+msgid "Querying %s info"
+msgstr "%s معلومات الإستعلام"
+
+#: id:198
+msgid "Loading movie details"
+msgstr "تحميل تفاصيل الفيلم"
+
+#: id:199
+msgid "Web interface"
+msgstr "واجهة ويب"
+
+#: id:202
+msgid "Tagline"
+msgstr "إشعار"
+
+#: id:203
+msgid "Plot outline"
+msgstr "موجز الرواية"
+
+#: id:205
+msgid "Votes"
+msgstr "اصوات"
+
+#: id:206
+msgid "Cast"
+msgstr "طرح"
+
+#: id:207
+msgid "Plot"
+msgstr "الرواية"
+
+#: id:208
+msgctxt "Auto context with id 208"
+msgid "Play"
+msgstr "تشغيل"
+
+#: id:209
+msgid "Next"
+msgstr "التالي"
+
+#: id:210
+msgid "Previous"
+msgstr "السابق"
+
+#: id:213
+msgid "Calibrate user interface..."
+msgstr "معايرة واجهة المستخدم..."
+
+#: id:214
+msgid "Video calibration..."
+msgstr "معايرة الفيديو..."
+
+#: id:215
+msgid "Soften"
+msgstr "تنعيم"
+
+#: id:216
+msgid "Zoom amount"
+msgstr "مقدار التكبير"
+
+#: id:217
+msgid "Pixel ratio"
+msgstr "نسبة عنصر الصورة"
+
+#: id:218
+msgid "DVD drive"
+msgstr "DVD محرك أقراص"
+
+#: id:219
+msgid "Please insert disc"
+msgstr "الرجاء إدراج القرص"
+
+#: id:220
+msgid "Remote share"
+msgstr "مشاركة عن بعد"
+
+#: id:221
+msgid "Network is not connected"
+msgstr "لم يتم توصيل الشبكة"
+
+#: id:222
+msgid "Cancel"
+msgstr "إلغاء"
+
+#: id:224
+msgid "Speed"
+msgstr "سرعة"
+
+#: id:225
+msgid "Vertical Shift"
+msgstr "تحول عمودي"
+
+#: id:226
+msgid "Test patterns..."
+msgstr "اختبار النماذج..."
+
+#: id:227
+msgid "Lookup audio CD track names from freedb.org"
+msgstr "بحث أسماء مسارات الاسطوانة الصوتية من freedb.org"
+
+#: id:228
+msgid "Shuffle playlist on load"
+msgstr "خلط قائمة التشغيل على التحميل"
+
+#: id:229
+msgid "HDD spindown time"
+msgstr "HDD وقت نسج"
+
+#: id:230
+msgid "Video filters"
+msgstr "تصفية الفيديو"
+
+#: id:231
+msgctxt "Auto context with id 231"
+msgid "None"
+msgstr "بلا"
+
+#: id:232
+msgid "Point"
+msgstr "نقطة"
+
+#: id:233
+msgid "Linear"
+msgstr "طولي"
+
+#: id:234
+msgid "Anisotropic"
+msgstr "تباين"
+
+#: id:235
+msgid "Quincunx"
+msgstr "تخميس"
+
+#: id:236
+msgid "Gaussian cubic"
+msgstr "غاوسي مكعب"
+
+#: id:237
+msgid "Minification"
+msgstr "تقليل"
+
+#: id:238
+msgid "Magnification"
+msgstr "تكبير"
+
+#: id:239
+msgid "Clear playlist on finish"
+msgstr "مسح التشغيل على الانتهاء"
+
+#: id:240
+msgid "Display Mode"
+msgstr "طريقة العرض"
+
+#: id:241
+msgid "Full Screen #%d"
+msgstr "#%d شاشة كاملة"
+
+#: id:242
+msgid "Windowed"
+msgstr "إطارات"
+
+#: id:243
+msgid "Refresh Rate"
+msgstr "معدل التحديث"
+
+#: id:244
+msgid "Full screen"
+msgstr "شاشة كاملة"
+
+#: id:245
+msgid "Sizing: (%i,%i)->(%i,%i) (Zoom x%2.2f) AR:%2.2f:1 (Pixels: %2.2f:1) (VShift: %2.2f)"
+msgstr "تحجيم: (%i,%i)->(%i,%i) (تقريب x%2.2f) AR:%2.2f:1 (%بكسل: 2.2f:1) (VShift: %2.2f)"
+
+#: id:247
+msgctxt "Auto context with id 247"
+msgid "Scripts"
+msgstr "النصية"
+
+#: id:248
+msgctxt "Auto context with id 248"
+msgid "Language"
+msgstr "اللغة"
+
+#: id:249
+msgctxt "Auto context with id 249"
+msgid "Music"
+msgstr "موسيقى"
+
+#: id:250
+msgctxt "Auto context with id 250"
+msgid "Visualization"
+msgstr "التصور"
+
+#: id:251
+msgid "Select destination directory"
+msgstr "حدد دليل الوجهة"
+
+#: id:252
+msgid "Output stereo to all speakers"
+msgstr "إخراج النظام الصوتي لجميع المكبرات"
+
+#: id:253
+msgid "Number of channels"
+msgstr "عدد القنوات"
+
+#: id:254
+msgid "- DTS capable receiver"
+msgstr "- DTS قدرة استقبال"
+
+#: id:255
+msgid "CDDB"
+msgstr "CDDB"
+
+#: id:256
+msgid "Fetching CD information"
+msgstr "إحضار المعلومات الإسطوانة"
+
+#: id:257
+msgid "Error"
+msgstr "خطأ"
+
+#: id:258
+msgid "Enable tag reading"
+msgstr "تمكين علامة القراءة"
+
+#: id:259
+msgid "Opening"
+msgstr "جاري الفتح"
+
+#: id:260
+msgid "Shoutcast"
+msgstr "شوتكاست"
+
+#: id:261
+msgid "Waiting for start..."
+msgstr "انتظار للبدء..."
+
+#: id:262
+msgid "Scripts output"
+msgstr "مخرجات النصية"
+
+#: id:263
+msgid "Allow control of XBMC via HTTP"
+msgstr "سماح تحكم XBMC عبر HTTP"
+
+#: id:264
+msgid "Record"
+msgstr "تسجيل"
+
+#: id:265
+msgid "Stop Rec."
+msgstr "إيقاف التسجيل"
+
+#: id:266
+msgid "Sort by: Track"
+msgstr "ترتيب حسب: المسار"
+
+#: id:267
+msgid "Sort by: Time"
+msgstr "ترتيب حسب: الوقت"
+
+#: id:268
+msgid "Sort by: Title"
+msgstr "ترتيب حسب: العنوان"
+
+#: id:269
+msgid "Sort by: Artist"
+msgstr "ترتيب حسب: الفنان"
+
+#: id:270
+msgid "Sort by: Album"
+msgstr "ترتيب حسب: ألبوم"
+
+#: id:271
+msgid "Top 100"
+msgstr "أعلى 100"
+
+#: id:272
+msgid "Top-Left overscan compensation"
+msgstr "تعويض زيادة الفحص أعلى اليسار"
+
+#: id:273
+msgid "Bottom-Right overscan compensation"
+msgstr "تعويض زيادة الفحص أسفل اليمين"
+
+#: id:274
+msgid "Subtitle positioning"
+msgstr "توضيع الترجمة"
+
+#: id:275
+msgid "Pixel ratio adjustment"
+msgstr "تكييف نسبة البكسل"
+
+#: id:276
+msgid "Adjust the arrow to change the amount of overscan"
+msgstr "ضبط السهم لتغيير مقدار زيادة الفحص"
+
+#: id:277
+msgid "Adjust the bar to change the subtitles position"
+msgstr "ضبط الشريط لتغيير موضع الترجمات"
+
+#: id:278
+msgid "Adjust the rectangle so it is perfectly square"
+msgstr "ضبط المستطيل بحيث يكون مربع تماما"
+
+#: id:279
+msgid "Unable to load settings"
+msgstr "غير قادر على تحميل الإعدادات"
+
+#: id:280
+msgid "Using default settings"
+msgstr "استخدام الإعدادات الافتراضية"
+
+#: id:281
+msgid "Please check the XML files"
+msgstr "يرجى التحقق من ملفات XML"
+
+#: id:282
+msgid "Found %i items"
+msgstr "العثور %i عل بنود"
+
+#: id:283
+msgid "Search results"
+msgstr "نتائج البحث"
+
+#: id:284
+msgid "No results found"
+msgstr "لا توجد نتائج"
+
+#: id:287
+msgctxt "Auto context with id 287"
+msgid "Subtitles"
+msgstr "الترجمات"
+
+#: id:288
+msgctxt "Auto context with id 288"
+msgid "Font"
+msgstr "الخط"
+
+#: id:289
+msgctxt "Auto context with id 289"
+msgid "- Size"
+msgstr "- الحجم"
+
+#: id:290
+msgid "Dynamic range compression"
+msgstr "ضغط النطاق الديناميكي"
+
+#: id:291
+msgctxt "Auto context with id 291"
+msgid "Video"
+msgstr "فيديو"
+
+#: id:292
+msgctxt "Auto context with id 292"
+msgid "Audio"
+msgstr "صوت"
+
+#: id:293
+msgid "Browse for subtitles"
+msgstr "تصفح للبحث عن الترجمة"
+
+#: id:294
+msgid "Create bookmark"
+msgstr "إنشاء علامة"
+
+#: id:296
+msgid "Clear bookmarks"
+msgstr "مسح العلامات"
+
+#: id:297
+msgid "Audio offset"
+msgstr "توازن الصوت"
+
+#: id:298
+msgid "Bookmarks"
+msgstr "العلامات"
+
+#: id:299
+msgid "- AAC capable receiver"
+msgstr "-- AAC قدرة استقبال"
+
+#: id:300
+msgid "- MP1 capable receiver"
+msgstr "-- MP1 قدرة استقبال"
+
+#: id:301
+msgid "- MP2 capable receiver"
+msgstr "-- MP2 قدرة استقبال"
+
+#: id:302
+msgid "- MP3 capable receiver"
+msgstr "-- MP3 قدرة استقبال"
+
+#: id:303
+msgid "Delay"
+msgstr "تأخير"
+
+#: id:304
+msgctxt "Auto context with id 304"
+msgid "Language"
+msgstr "اللغة"
+
+#: id:305
+msgctxt "Auto context with id 305"
+msgid "Enabled"
+msgstr "ممكن"
+
+#: id:306
+msgid "Non-interleaved"
+msgstr "غير معشق"
+
+#: id:312
+msgid "(0=auto)"
+msgstr "(0=auto)"
+
+#: id:313
+msgid "Cleaning database"
+msgstr "تنظيف قاعدة بيانات"
+
+#: id:314
+msgid "Preparing..."
+msgstr "إعداد..."
+
+#: id:315
+msgid "Database error"
+msgstr "خطأ في قاعدة بيانات"
+
+#: id:316
+msgid "Searching songs..."
+msgstr "بحث الأغاني..."
+
+#: id:317
+msgid "Cleaned database successfully"
+msgstr "قاعدة البيانات منظفة بنجاح"
+
+#: id:318
+msgid "Cleaning songs..."
+msgstr "تنظيف الأغاني..."
+
+#: id:319
+msgid "Error cleaning songs"
+msgstr "خطأ تنظيف الأغاني"
+
+#: id:320
+msgid "Cleaning artists..."
+msgstr "تنظيف الفنانين..."
+
+#: id:321
+msgid "Error cleaning artists"
+msgstr "خطأ تنظيف الفنانين"
+
+#: id:322
+msgid "Cleaning genres..."
+msgstr "تنظيف الأنواع..."
+
+#: id:323
+msgid "Error cleaning genres"
+msgstr "خطأ تنظيف الأنواع"
+
+#: id:324
+msgid "Cleaning paths..."
+msgstr "تنظيف مسارات..."
+
+#: id:325
+msgid "Error cleaning paths"
+msgstr "خطأ تنظيف المسارات"
+
+#: id:326
+msgid "Cleaning albums..."
+msgstr "تنظيف ألبومات..."
+
+#: id:327
+msgid "Error cleaning albums"
+msgstr "خطأ تنظيف ألبومات"
+
+#: id:328
+msgid "Writing changes..."
+msgstr "كتابة تغييرات..."
+
+#: id:329
+msgid "Error writing changes"
+msgstr "خطأ كتابة التغييرات"
+
+#: id:330
+msgid "This may take some time..."
+msgstr "هذا قد يستغرق بعض الوقت..."
+
+#: id:331
+msgid "Compressing database..."
+msgstr "ضغط قاعدة بيانات..."
+
+#: id:332
+msgid "Error compressing database"
+msgstr "خطأ ضغط قاعدة بيانات"
+
+#: id:333
+msgid "Do you want to clean the library?"
+msgstr "هل تريد تنظيف المكتبة؟"
+
+#: id:334
+msgid "Clean library..."
+msgstr "تنطيف المكتبة..."
+
+#: id:335
+msgid "Start"
+msgstr "ابدأ"
+
+#: id:336
+msgid "Framerate conversion"
+msgstr "تحويل فراميرات"
+
+#: id:337
+msgctxt "Auto context with id 337"
+msgid "Audio output"
+msgstr "مخرج الصوت"
+
+#: id:338
+msgid "Analog"
+msgstr "النظير"
+
+#: id:339
+msgid "Optical/Coax"
+msgstr "بصري/محوري"
+
+#: id:340
+msgid "Various artists"
+msgstr "فنانين مختلفين"
+
+#: id:341
+msgid "Play disc"
+msgstr "تشغيل القرص"
+
+#: id:342
+msgctxt "Auto context with id 342"
+msgid "Movies"
+msgstr "أفلام"
+
+#: id:343
+msgid "Adjust framerate"
+msgstr "ضبط فراميرات"
+
+#: id:344
+msgid "Actors"
+msgstr "الممثلين"
+
+#: id:345
+msgctxt "Auto context with id 345"
+msgid "Year"
+msgstr "السنة"
+
+#: id:346
+msgid "Boost volume level on downmix"
+msgstr "دفع مستوى الصوت على downmix"
+
+#: id:350
+msgctxt "Auto context with id 350"
+msgid "Programs"
+msgstr "برامج"
+
+#: id:351
+msgctxt "Auto context with id 351"
+msgid "Off"
+msgstr "معطلة"
+
+#: id:352
+msgid "Dim"
+msgstr "خافت"
+
+#: id:353
+msgid "Black"
+msgstr "أسود"
+
+#: id:354
+msgid "Matrix trails"
+msgstr "مسارات ماتركيس"
+
+#: id:355
+msgid "Screensaver time"
+msgstr "وقت شاشة التوقف"
+
+#: id:356
+msgid "Screensaver mode"
+msgstr "وضع شاشة التوقف"
+
+#: id:357
+msgid "Shutdown function timer"
+msgstr "مؤقت عملية الإغلاق"
+
+#: id:358
+msgid "All albums"
+msgstr "جميع الألبومات"
+
+#: id:359
+msgid "Recently added albums"
+msgstr "ألبومات مضافة مؤخرا"
+
+#: id:360
+msgctxt "Auto context with id 360"
+msgid "Screensaver"
+msgstr "شاشة التوقف"
+
+#: id:361
+msgid "R. Slideshow"
+msgstr "R. عرض شرائح"
+
+#: id:362
+msgid "Screensaver dim level"
+msgstr "مستوى خفت شاشة التوقف"
+
+#: id:363
+msgid "Sort by: File"
+msgstr "ترتيب حسب: ملف"
+
+#: id:364
+msgid "- Dolby Digital (AC3) capable receiver"
+msgstr "-Dolby Digital (AC3) قدرة استقبال"
+
+#: id:365
+msgctxt "Auto context with id 365"
+msgid "Sort by: Name"
+msgstr "ترتيب حسب : الإسم"
+
+#: id:366
+msgid "Sort by: Year"
+msgstr "ترتيب حسب : السنة"
+
+#: id:367
+msgid "Sort by: Rating"
+msgstr "ترتيب حسب: التصنيف"
+
+#: id:368
+msgid "IMDb"
+msgstr "IMDb"
+
+#: id:369
+msgctxt "Auto context with id 369"
+msgid "Title"
+msgstr "العنوان"
+
+#: id:370
+msgid "Thunderstorms"
+msgstr ":عواصف رعدية"
+
+#: id:371
+msgid "Partly"
+msgstr ":جزئيا"
+
+#: id:372
+msgid "Mostly"
+msgstr ":غالبيا"
+
+#: id:373
+msgid "Sunny"
+msgstr ":مشمس"
+
+#: id:374
+msgid "Cloudy"
+msgstr ":غائم"
+
+#: id:375
+msgid "Snow"
+msgstr ":ثلج"
+
+#: id:376
+msgid "Rain"
+msgstr ":ممطر"
+
+#: id:377
+msgid "Light"
+msgstr ":خفيفة"
+
+#: id:378
+msgid "AM"
+msgstr "صباحا"
+
+#: id:379
+msgid "PM"
+msgstr "مساءاً"
+
+#: id:380
+msgid "Showers"
+msgstr ":زخات مطر"
+
+#: id:381
+msgid "Few"
+msgstr ":قليل"
+
+#: id:382
+msgid "Scattered"
+msgstr ":غيوم"
+
+#: id:383
+msgctxt "Auto context with id 383"
+msgid "Wind"
+msgstr ":رياح"
+
+#: id:384
+msgid "Strong"
+msgstr ":قوي"
+
+#: id:385
+msgid "Fair"
+msgstr ":عادل"
+
+#: id:386
+msgctxt "Auto context with id 386"
+msgid "Clear"
+msgstr ":صافي"
+
+#: id:387
+msgid "Clouds"
+msgstr ":غائم"
+
+#: id:388
+msgid "Early"
+msgstr "مبكر"
+
+#: id:389
+msgid "Shower"
+msgstr ":ممطر"
+
+#: id:390
+msgid "Flurries"
+msgstr ":موجات"
+
+#: id:391
+msgctxt "Auto context with id 391"
+msgid "Low"
+msgstr "الصغرى"
+
+#: id:392
+msgctxt "Auto context with id 392"
+msgid "Medium"
+msgstr ":متوسطة"
+
+#: id:393
+msgctxt "Auto context with id 393"
+msgid "High"
+msgstr "العظمى"
+
+#: id:394
+msgid "Fog"
+msgstr ":ضباب"
+
+#: id:395
+msgid "Haze"
+msgstr ":ضباب رقيق"
+
+#: id:396
+msgid "Select location"
+msgstr "حدد موقع"
+
+#: id:397
+msgid "Refresh time"
+msgstr "تحديث الوقت"
+
+#: id:398
+msgid "Temperature units"
+msgstr "وحدات درجة الحرارة"
+
+#: id:399
+msgid "Speed units"
+msgstr "وحدات السرعة"
+
+#: id:400
+msgctxt "Auto context with id 400"
+msgid "Weather"
+msgstr "الطقس"
+
+#: id:401
+msgid "Temp"
+msgstr "درجة الحرارة"
+
+#: id:402
+msgid "Feels like"
+msgstr ":Feels like"
+
+#: id:403
+msgid "UV index"
+msgstr ":UV index"
+
+#: id:404
+msgctxt "Auto context with id 404"
+msgid "Wind"
+msgstr ":رياح"
+
+#: id:405
+msgid "Dew point"
+msgstr ":نقطة ندى"
+
+#: id:406
+msgid "Humidity"
+msgstr ":رطوبة"
+
+#: id:409
+msgid "Defaults"
+msgstr "الافتراضية"
+
+#: id:410
+msgid "Accessing weather service"
+msgstr "خدمة الوصول الى الطقس"
+
+#: id:411
+msgid "Getting weather for:"
+msgstr "الحصول على طقس:"
+
+#: id:412
+msgid "Unable to get weather data"
+msgstr "تعذر الحصول على بيانات الطقس"
+
+#: id:413
+msgid "Manual"
+msgstr "يدوي"
+
+#: id:414
+msgid "No review for this album"
+msgstr "لاتوجد استعراضات لهذا الألبوم"
+
+#: id:415
+msgid "Downloading thumbnail..."
+msgstr "...تحميل المصغرة"
+
+#: id:416
+msgid "Not available"
+msgstr "غير متاح"
+
+#: id:417
+msgid "View: Big icons"
+msgstr "عرض: رموز كبيرة"
+
+#: id:418
+msgctxt "Auto context with id 418"
+msgid "Low"
+msgstr "الصغرى"
+
+#: id:419
+msgctxt "Auto context with id 419"
+msgid "High"
+msgstr "العظمى"
+
+#: id:420
+msgid "HDMI"
+msgstr "HDMI"
+
+#: id:422
+msgid "Delete album info"
+msgstr "حذف معلومات الألبوم"
+
+#: id:423
+msgid "Delete CD information"
+msgstr "CD حذف معلومات"
+
+#: id:424
+msgid "Select"
+msgstr "اختر"
+
+#: id:425
+msgid "No album information found"
+msgstr "لا توجد معلومات الألبوم"
+
+#: id:426
+msgid "No CD information found"
+msgstr "CD لا توجد معلومات"
+
+#: id:427
+msgid "Disc"
+msgstr "القرص"
+
+#: id:428
+msgid "Insert correct CD/DVD"
+msgstr "الصحيح CD/DVD إدراج"
+
+#: id:429
+msgid "Please insert the following disc:"
+msgstr ":الرجاء إدراج القرص التالي"
+
+#: id:430
+msgid "Sort by: DVD#"
+msgstr "DVD# :ترتيب بواسطة"
+
+#: id:431
+msgid "No cache"
+msgstr "لاتوجد ذاكرة مؤقته"
+
+#: id:432
+msgid "Remove movie from library"
+msgstr "إزالة الفيلم من المكتبة"
+
+#: id:433
+msgid "Really remove '%s'?"
+msgstr "؟'%s' حقا إزالة"
+
+#: id:434
+msgid "From %s at %i %s"
+msgstr "%s في %i %s من"
+
+#: id:437
+msgid "Removable disk"
+msgstr "القرص قابل للإزالة"
+
+#: id:438
+msgid "Opening file"
+msgstr "جاري فتح الملف"
+
+#: id:439
+msgid "Cache"
+msgstr "ذاكرة تخزين مؤقته"
+
+#: id:440
+msgid "Harddisk"
+msgstr "القرص الصلب"
+
+#: id:441
+msgid "UDF"
+msgstr "UDF"
+
+#: id:442
+msgid "Local network"
+msgstr "الشبكة المحلية"
+
+#: id:443
+msgid "Internet"
+msgstr "الإنترنت"
+
+#: id:444
+msgctxt "Auto context with id 444"
+msgid "Video"
+msgstr "فيديو"
+
+#: id:445
+msgctxt "Auto context with id 445"
+msgid "Audio"
+msgstr "صوت"
+
+#: id:446
+msgctxt "Auto context with id 446"
+msgid "DVD"
+msgstr "DVD"
+
+#: id:447
+msgid "Autorun media"
+msgstr "وسائط تشغيل تلقائية"
+
+#: id:448
+msgid "LCD"
+msgstr "LCD"
+
+#: id:449
+msgctxt "Auto context with id 449"
+msgid "Enabled"
+msgstr "ممكن"
+
+#: id:450
+msgid "Columns"
+msgstr "أعمدة"
+
+#: id:451
+msgid "Row 1 address"
+msgstr "عنوان الصف 1"
+
+#: id:452
+msgid "Row 2 address"
+msgstr "عنوان الصف 2"
+
+#: id:453
+msgid "Row 3 address"
+msgstr "عنوان الصف 3"
+
+#: id:454
+msgid "Row 4 address"
+msgstr "عنوان الصف 4"
+
+#: id:455
+msgid "Rows"
+msgstr "الصفوف"
+
+#: id:456
+msgid "Mode"
+msgstr "الوضع"
+
+#: id:457
+msgid "Switch view"
+msgstr "تبديل االعرض"
+
+#: id:459
+msgid "Subs"
+msgstr "الترجمات"
+
+#: id:460
+msgid "Audio stream"
+msgstr "تدفق الصوت"
+
+#: id:461
+msgid "[active]"
+msgstr "[نشط]"
+
+#: id:462
+msgid "Subtitle"
+msgstr "الترجمة"
+
+#: id:463
+msgid "Backlight"
+msgstr "الاضاءة الخلفية"
+
+#: id:464
+msgid "Brightness"
+msgstr "السطوع"
+
+#: id:465
+msgid "Contrast"
+msgstr "التباين"
+
+#: id:466
+msgid "Gamma"
+msgstr "غاما"
+
+#: id:467
+msgctxt "Auto context with id 467"
+msgid "Type"
+msgstr "النوع"
+
+#: id:468
+msgid "Move the bar to change the OSD position"
+msgstr "تحريك الشريط لتغيير وضعية OSD"
+
+#: id:469
+msgid "OSD position"
+msgstr "وضعية OSD"
+
+#: id:470
+msgid "Credits"
+msgstr "الاعتمادات"
+
+#: id:471
+msgid "Modchip"
+msgstr "Modchip"
+
+#: id:474
+msgctxt "Auto context with id 474"
+msgid "Off"
+msgstr "معطلة"
+
+#: id:475
+msgid "Music only"
+msgstr "موسيقى فقط"
+
+#: id:476
+msgctxt "Auto context with id 476"
+msgid "Music & video"
+msgstr "الموسيقى والفيديو"
+
+#: id:477
+msgid "Unable to load playlist"
+msgstr "غير قادر على تحميل قائمة التشغيل"
+
+#: id:478
+msgid "OSD"
+msgstr "OSD"
+
+#: id:479
+msgid "Skin & language"
+msgstr "الخلفية واللغة"
+
+#: id:480
+msgid "Appearance"
+msgstr "المظهر"
+
+#: id:481
+msgid "Audio options"
+msgstr "خيارات الصوت"
+
+#: id:482
+msgid "About XBMC"
+msgstr "XBMC حول"
+
+#: id:485
+msgid "Delete album"
+msgstr "حذف الألبوم"
+
+#: id:486
+msgid "Repeat"
+msgstr "إعادة"
+
+#: id:487
+msgid "Repeat one"
+msgstr "إعادة مرة واحدة"
+
+#: id:488
+msgid "Repeat folder"
+msgstr "إعادة المجلد"
+
+#: id:489
+msgid "Play the next song automatically"
+msgstr "تشغيل الأغنية القادمة تلقائيا"
+
+#: id:491
+msgid "- Use big icons"
+msgstr "-- استخدام الرموز الكبيرة"
+
+#: id:492
+msgid "Resize VobSubs"
+msgstr "إعادة تحجيم VobSubs"
+
+#: id:493
+msgid "Advanced options (Experts Only!)"
+msgstr "(!خيارات متقدمة - (للخبراء فقط"
+
+#: id:494
+msgid "Overall audio headroom"
+msgstr "Overall Audio Headroom (dB)"
+
+#: id:495
+msgid "Upsample videos to GUI resolution"
+msgstr "إعادة تشكيل دقة عرض الفيديو"
+
+#: id:496
+msgid "Calibration"
+msgstr "المعايرة"
+
+#: id:497
+msgid "Show file extensions"
+msgstr "عرض ملحقات الملف"
+
+#: id:498
+msgid "Sort by: Type"
+msgstr "ترتيب حسب: النوع"
+
+#: id:499
+msgid "Unable to connect to online lookup service"
+msgstr "غير قادر على اتصال خدمة البحث على الانترنت"
+
+#: id:500
+msgid "Downloading album information failed"
+msgstr "فشل تحميل معلومات الألبوم"
+
+#: id:501
+msgid "Looking for album names..."
+msgstr "يبحث عن أسم الألبوم..."
+
+#: id:502
+msgctxt "Auto context with id 502"
+msgid "Open"
+msgstr "فتح"
+
+#: id:503
+msgid "Busy"
+msgstr "مشغول"
+
+#: id:504
+msgid "Empty"
+msgstr "خالي"
+
+#: id:505
+msgid "Loading media info from files..."
+msgstr "تحميل معلومات الوسائط من الملفات..."
+
+#: id:507
+msgid "Sort by: Usage"
+msgstr "ترتيب حسب: الإستخدام"
+
+#: id:510
+msgid "Enable visualizations"
+msgstr "تمكين التصور"
+
+#: id:511
+msgid "Enable video mode switching"
+msgstr "تمكين تغيير وضع الفيديو"
+
+#: id:512
+msgid "Startup window"
+msgstr "نافذة بدء التشغيل"
+
+#: id:513
+msgid "Home window"
+msgstr "النافذة الرئيسية"
+
+#: id:514
+msgid "Manual settings"
+msgstr "الإعدادات اليدوية"
+
+#: id:515
+msgid "Genre"
+msgstr "النوع"
+
+#: id:517
+msgid "Recently played albums"
+msgstr "ألبومات أجريت مؤخرا"
+
+#: id:518
+msgid "Launch"
+msgstr "تشغيل"
+
+#: id:519
+msgid "Launch in..."
+msgstr "تشغيل في.."
+
+#: id:521
+msgid "Compilations"
+msgstr "التجميعات"
+
+#: id:522
+msgid "Remove source"
+msgstr "إزالة مصدر"
+
+#: id:523
+msgid "Switch media"
+msgstr "تغيير الوسائط"
+
+#: id:524
+msgid "Select playlist"
+msgstr "اختر قائمة التشغيل"
+
+#: id:525
+msgid "New playlist..."
+msgstr "قائمة تشغيل جديدة..."
+
+#: id:526
+msgid "Add to playlist"
+msgstr "أضف الى قائمة التشغيل"
+
+#: id:527
+msgid "Manually add to library"
+msgstr "يدويا أضف إلى المكتبة"
+
+#: id:528
+msgid "Enter title"
+msgstr "أدخل عنوان"
+
+#: id:529
+msgid "Error: Duplicate title"
+msgstr "خطأ: عنوان مكرر"
+
+#: id:530
+msgid "Select genre"
+msgstr "اختر النوع"
+
+#: id:531
+msgid "New genre"
+msgstr "نوع جديد"
+
+#: id:532
+msgid "Manual addition"
+msgstr "إضافة يدويا"
+
+#: id:533
+msgid "Enter genre"
+msgstr "أدخل النوع"
+
+#: id:534
+msgid "View: %s"
+msgstr "عرض: %s"
+
+#: id:535
+msgid "List"
+msgstr "قائمة"
+
+#: id:536
+msgid "Icons"
+msgstr "رموز"
+
+#: id:537
+msgid "Big list"
+msgstr "قائمة كبير"
+
+#: id:538
+msgid "Big icons"
+msgstr "رموز كبيرة"
+
+#: id:539
+msgid "Wide"
+msgstr "واسع"
+
+#: id:540
+msgid "Big wide"
+msgstr "واسع كبيرة"
+
+#: id:541
+msgid "Album icons"
+msgstr "رموز الألبوم"
+
+#: id:542
+msgid "DVD icons"
+msgstr "DVD رموز"
+
+#: id:543
+msgctxt "Auto context with id 543"
+msgid "DVD"
+msgstr "DVD"
+
+#: id:544
+msgctxt "Auto context with id 544"
+msgid "Media info"
+msgstr "معلومات الوسائط"
+
+#: id:545
+msgid "Audio output device"
+msgstr "جهاز إخراج الصوت"
+
+#: id:546
+msgid "Passthrough output device"
+msgstr "جهاز عبور الصوت"
+
+#: id:547
+msgid "No biography for this artist"
+msgstr "لا سيرة ذاتية لهذا الفنان"
+
+#: id:548
+msgid "Downmix multichannel audio to stereo"
+msgstr "مزج صوت القنوات المتعددة الى ستيريو"
+
+#: id:550
+msgid "Sort by: %s"
+msgstr "ترتيب حسب: %s"
+
+#: id:551
+msgctxt "Auto context with id 551"
+msgid "Name"
+msgstr "الإسم"
+
+#: id:552
+msgid "Date"
+msgstr "التاريخ"
+
+#: id:553
+msgid "Size"
+msgstr "الحجم"
+
+#: id:554
+msgid "Track"
+msgstr "المسار"
+
+#: id:555
+msgid "Time"
+msgstr "الوقت"
+
+#: id:556
+msgctxt "Auto context with id 556"
+msgid "Title"
+msgstr "العنوان"
+
+#: id:557
+msgid "Artist"
+msgstr "الفنان"
+
+#: id:558
+msgid "Album"
+msgstr "الألبوم"
+
+#: id:559
+msgid "Playlist"
+msgstr "قائمة التشغيل"
+
+#: id:560
+msgid "ID"
+msgstr "المعرف"
+
+#: id:561
+msgctxt "Auto context with id 561"
+msgid "File"
+msgstr "ملف"
+
+#: id:562
+msgctxt "Auto context with id 562"
+msgid "Year"
+msgstr "السنة"
+
+#: id:563
+msgid "Rating"
+msgstr "التقييم"
+
+#: id:564
+msgctxt "Auto context with id 564"
+msgid "Type"
+msgstr "النوع"
+
+#: id:565
+msgid "Usage"
+msgstr "الاستخدام"
+
+#: id:566
+msgid "Album artist"
+msgstr "البوم الفنان"
+
+#: id:567
+msgid "Play count"
+msgstr "عدد المرات التي أجريت"
+
+#: id:568
+msgid "Last played"
+msgstr "أجريت مؤخراً"
+
+#: id:569
+msgctxt "Auto context with id 569"
+msgid "Comment"
+msgstr "تعليق"
+
+#: id:570
+msgid "Date added"
+msgstr "تاريخ الإضافة"
+
+#: id:571
+msgctxt "Auto context with id 571"
+msgid "Default"
+msgstr "الافتراضي"
+
+#: id:572
+msgid "Studio"
+msgstr "ستوديو"
+
+#: id:573
+msgid "Path"
+msgstr "مسار"
+
+#: id:574
+msgctxt "Auto context with id 574"
+msgid "Country"
+msgstr "البلد"
+
+#: id:575
+msgid "In progress"
+msgstr "في المعالجة"
+
+#: id:576
+msgid "Times played"
+msgstr "مرات أجريت"
+
+#: id:580
+msgid "Sort direction"
+msgstr "اتجاه الفرز"
+
+#: id:581
+msgid "Sort method"
+msgstr "طريقة الفرز"
+
+#: id:582
+msgctxt "Auto context with id 582"
+msgid "View mode"
+msgstr "عرض الوضع"
+
+#: id:583
+msgid "Remember views for different folders"
+msgstr "تذكر العرض لمختلف المجلدات"
+
+#: id:584
+msgid "Ascending"
+msgstr "تصاعدي"
+
+#: id:585
+msgid "Descending"
+msgstr "تنازلي"
+
+#: id:586
+msgid "Edit playlist"
+msgstr "تحرير قائمة التشغيل"
+
+#: id:587
+msgid "Filter"
+msgstr "تصفية"
+
+#: id:588
+msgid "Cancel party mode"
+msgstr "إلغاء وضع الطرف"
+
+#: id:589
+msgid "Party mode"
+msgstr "وضع الطرف"
+
+#: id:590
+msgid "Random"
+msgstr "عشوائي"
+
+#: id:591
+msgctxt "Auto context with id 591"
+msgid "Off"
+msgstr "معطلة"
+
+#: id:592
+msgid "One"
+msgstr "واحدة"
+
+#: id:593
+msgid "All"
+msgstr "الكل"
+
+#: id:594
+msgctxt "Auto context with id 594"
+msgid "Off"
+msgstr "معطلة"
+
+#: id:595
+msgid "Repeat: Off"
+msgstr "الإعادة: معطلة"
+
+#: id:596
+msgid "Repeat: One"
+msgstr "إعادة: واحدة"
+
+#: id:597
+msgid "Repeat: All"
+msgstr "إعادة: الكل"
+
+#: id:600
+msgid "Rip audio CD"
+msgstr "نسخ اسطوانة صوت"
+
+#: id:601
+msgctxt "Auto context with id 601"
+msgid "Medium"
+msgstr "متوسطة"
+
+#: id:602
+msgctxt "Auto context with id 602"
+msgid "Standard"
+msgstr "قياسي"
+
+#: id:603
+msgid "Extreme"
+msgstr "أقصى"
+
+#: id:604
+msgid "Constant bitrate"
+msgstr "ثبات معدل البت"
+
+#: id:605
+msgid "Ripping..."
+msgstr "ينسخ..."
+
+#: id:607
+msgid "To:"
+msgstr "إلى:"
+
+#: id:608
+msgid "Could not rip CD or track"
+msgstr "لايمكن نسخ القرص أو المسار"
+
+#: id:609
+msgid "CDDARipPath is not set."
+msgstr "CDDARipPath لم يتم تعريف"
+
+#: id:610
+msgid "Rip audio track"
+msgstr "نسخ مسار الصوت"
+
+#: id:611
+msgid "Enter number"
+msgstr "إدخال رقم"
+
+#: id:612
+msgid "Bits/Sample"
+msgstr "عينه/فئات"
+
+#: id:613
+msgid "Sample Frequency"
+msgstr "عينة التردد"
+
+#: id:620
+msgid "Audio CDs"
+msgstr "قرص الصوت"
+
+#: id:621
+msgid "Encoder"
+msgstr "التشفير"
+
+#: id:622
+msgid "Quality"
+msgstr "الجودة"
+
+#: id:623
+msgid "Bitrate"
+msgstr "معدل بت"
+
+#: id:624
+msgid "Include track number"
+msgstr "تضمين رقم المسار"
+
+#: id:625
+msgid "All songs of"
+msgstr "كل الأغاني من"
+
+#: id:629
+msgctxt "Auto context with id 629"
+msgid "View mode"
+msgstr "وضع العرض"
+
+#: id:630
+msgctxt "Auto context with id 630"
+msgid "Normal"
+msgstr "عادي"
+
+#: id:631
+msgid "Zoom"
+msgstr "تكبير"
+
+#: id:632
+msgid "Stretch 4:3"
+msgstr "4:3 امتداد"
+
+#: id:633
+msgid "Wide Zoom"
+msgstr "14:09 امتداد"
+
+#: id:634
+msgid "Stretch 16:9"
+msgstr "امتداد 16:09"
+
+#: id:635
+msgid "Original Size"
+msgstr "الحجم الأصلي"
+
+#: id:636
+msgctxt "Auto context with id 636"
+msgid "Custom"
+msgstr "فريد"
+
+#: id:637
+msgid "Replay gain"
+msgstr "إعادة العائدات"
+
+#: id:638
+msgid "Replaygain volume adjustments"
+msgstr "إعادة العائدات للكمية المتناسبة"
+
+#: id:639
+msgid "Use track levels"
+msgstr "استخدام مستويات المسار"
+
+#: id:640
+msgid "Use album levels"
+msgstr "استخدام مستويات الألبوم"
+
+#: id:641
+msgid "PreAmp Level - Replay gained files"
+msgstr "مستوى ما قبل مكبر للصوت -- زيادة عائدات ملفات اللحن"
+
+#: id:642
+msgid "PreAmp Level - Non replay gained files"
+msgstr "مستوى ما قبل مكبر للصوت -- لا إعادة لملفات العائدات"
+
+#: id:643
+msgid "Avoid clipping on replay gained files"
+msgstr "منع سرعة زيادة عوائد ملفات اللحن"
+
+#: id:644
+msgid "Crop black bars"
+msgstr "قص الأشرطة السوداء"
+
+#: id:645
+msgid "Need to unpack a big file. Continue?"
+msgstr "يحتاج إلى فتح ملف كبير. مواصلة؟"
+
+#: id:646
+msgid "Remove from library"
+msgstr "إزالة من المكتبة"
+
+#: id:647
+msgid "Export video library"
+msgstr "تصدير مكتبة الفيديو..."
+
+#: id:648
+msgid "Import video library"
+msgstr "استيراد مكتبة الفيديو..."
+
+#: id:649
+msgid "Importing"
+msgstr "استيراد"
+
+#: id:650
+msgid "Exporting"
+msgstr "تصدير"
+
+#: id:651
+msgid "Browse for library"
+msgstr "تصفح للمكتبة"
+
+#: id:652
+msgid "Years"
+msgstr "سنوات"
+
+#: id:653
+msgid "Update library"
+msgstr "تحديث المكتبة"
+
+#: id:654
+msgid "Show debug info"
+msgstr "تصحيح عرض معلومات"
+
+#: id:655
+msgid "Browse for executable"
+msgstr "تصفح لملف تنفيذي"
+
+#: id:656
+msgid "Browse for playlist"
+msgstr "تصفح لقائمة التشغيل"
+
+#: id:657
+msgid "Browse for folder"
+msgstr "تصفح للملفات"
+
+#: id:658
+msgid "Song information"
+msgstr "معلومات الأغنية"
+
+#: id:659
+msgid "Non-linear stretch"
+msgstr "امتداد لاخطي"
+
+#: id:660
+msgid "Volume amplification"
+msgstr "مقدار التكبير"
+
+#: id:661
+msgid "Choose export folder"
+msgstr "اختار ملف التصدير"
+
+#: id:662
+msgid "This file is no longer available."
+msgstr "هذا الملف لم يعد متوفرا"
+
+#: id:663
+msgid "Would you like to remove it from the library?"
+msgstr "هل ترغب في إزالته من المكتبة؟"
+
+#: id:664
+msgid "Browse for Script"
+msgstr "التصفح النصي"
+
+#: id:665
+msgid "Compression level"
+msgstr "مستوى الضغط"
+
+#: id:700
+msgid "Cleaning up library"
+msgstr "تنظيف قاعدة البيانات"
+
+#: id:701
+msgid "Removing old songs from the library"
+msgstr "حذف الأغاني القديمة من المكتبة"
+
+#: id:702
+msgid "This path has been scanned before"
+msgstr "تم فحص هذا المسار من قبل"
+
+#: id:705
+msgctxt "Auto context with id 705"
+msgid "Network"
+msgstr "الشبكة"
+
+#: id:706
+msgid "- Server"
+msgstr "- الخادم"
+
+#: id:708
+msgid "Use an HTTP proxy server to access the internet"
+msgstr "استخدام وكيل HTTP للوصول الإنترنت"
+
+#: id:711
+msgid "Internet Protocol (IP)"
+msgstr "Internet Protocol (IP)"
+
+#: id:712
+msgid "Invalid port specified. Value must be between 1 and 65535."
+msgstr "منفذ غير صحيح. يجب أن تكون القيمة بين 1 و 65535."
+
+#: id:713
+msgid "HTTP proxy"
+msgstr "وكيل HTTP"
+
+#: id:715
+msgid "- Assignment"
+msgstr "إحالة"
+
+#: id:716
+msgid "Automatic (DHCP)"
+msgstr "التلقائي (DHCP)"
+
+#: id:717
+msgid "Manual (Static)"
+msgstr "يدوي (ثابت)"
+
+#: id:719
+msgid "- IP address"
+msgstr "عنوان IP"
+
+#: id:720
+msgid "- Netmask"
+msgstr "قناع الشبكة"
+
+#: id:721
+msgid "- Default gateway"
+msgstr "البوابة الإفتراضية"
+
+#: id:722
+msgid "- DNS server"
+msgstr "خادم DNS"
+
+#: id:723
+msgid "Save & restart"
+msgstr "حفظ وإعادة"
+
+#: id:724
+msgid "Invalid address specified. Value must be AAA.BBB.CCC.DDD"
+msgstr "عنوان خاطئ. يجب أن يكون في AAA.BBB.CCC.DDD"
+
+#: id:725
+msgid "with numbers between 0 and 255."
+msgstr "مع الأرقام من 0 إلى 255."
+
+#: id:726
+msgid "Changes not saved. Continue without saving?"
+msgstr "لم يتم حفظ التغييرات. مواصلة بدون حفظ؟"
+
+#: id:727
+msgid "Web server"
+msgstr "خادم ويب"
+
+#: id:728
+msgctxt "Auto context with id 728"
+msgid "FTP server"
+msgstr "FTP خادم"
+
+#: id:730
+msgid "- Port"
+msgstr "- المنفذ"
+
+#: id:732
+msgid "Save & apply"
+msgstr "حفظ وتطبيق"
+
+#: id:733
+msgid "- Password"
+msgstr "- كلمة المرور"
+
+#: id:734
+msgid "No pass"
+msgstr "لا مرور"
+
+#: id:735
+msgid "- Character set"
+msgstr "-وضع الأحرف"
+
+#: id:736
+msgid "- Style"
+msgstr "- النمط"
+
+#: id:737
+msgid "- Colour"
+msgstr "- اللون"
+
+#: id:738
+msgctxt "Auto context with id 738"
+msgid "Normal"
+msgstr "عادي"
+
+#: id:739
+msgid "Bold"
+msgstr "عريض"
+
+#: id:740
+msgid "Italics"
+msgstr "مائلة"
+
+#: id:741
+msgid "Bold italics"
+msgstr "عريض مائلة"
+
+#: id:742
+msgctxt "Auto context with id 742"
+msgid "White"
+msgstr "أبيض"
+
+#: id:743
+msgctxt "Auto context with id 743"
+msgid "Yellow"
+msgstr "أصفر"
+
+#: id:744
+msgctxt "Auto context with id 744"
+msgid "Files"
+msgstr "ملفات"
+
+#: id:745
+msgid "No scanned information for this view"
+msgstr "لاتوجد معلومات مفحوصة لهذا العرض"
+
+#: id:746
+msgid "Please turn off library mode"
+msgstr "الرجاء إيقاف وضع المكتبة"
+
+#: id:747
+msgid "Error loading image"
+msgstr "خطأ في تحميل الصورة"
+
+#: id:748
+msgid "Edit path"
+msgstr "تعديل مسار"
+
+#: id:749
+msgid "Mirror image"
+msgstr "صورة مرآتية"
+
+#: id:750
+msgid "Are you sure?"
+msgstr "هل أنت متأكد؟"
+
+#: id:751
+msgid "Removing source"
+msgstr "إزالة مصدر"
+
+#: id:754
+msgid "Add program link"
+msgstr "إضافة رابط برنامج"
+
+#: id:755
+msgid "Edit program path"
+msgstr "تحرير مسار برنامج"
+
+#: id:756
+msgid "Edit program name"
+msgstr "تحرير اسم برنامج"
+
+#: id:757
+msgid "Edit path depth"
+msgstr "تحرير عمق مسار"
+
+#: id:759
+msgid "View: Big list"
+msgstr "عرض: قائمة كبيرة"
+
+#: id:760
+msgctxt "Auto context with id 760"
+msgid "Yellow"
+msgstr "أصفر"
+
+#: id:761
+msgctxt "Auto context with id 761"
+msgid "White"
+msgstr "أبيض"
+
+#: id:762
+msgid "Blue"
+msgstr "أزرق"
+
+#: id:763
+msgid "Bright green"
+msgstr "أخضر ساطع"
+
+#: id:764
+msgid "Yellow green"
+msgstr "أصفر أخضر"
+
+#: id:765
+msgid "Cyan"
+msgstr "أزرق"
+
+#: id:766
+msgid "Light grey"
+msgstr "رمادي فاتح"
+
+#: id:767
+msgid "Grey"
+msgstr "رمادي"
+
+#: id:770
+msgid "Error %i: share not available"
+msgstr "خطأ %i: لاتوجد مشاركة"
+
+#: id:772
+msgctxt "Auto context with id 772"
+msgid "Audio output"
+msgstr "مخرج الصوت"
+
+#: id:773
+msgid "Seeking"
+msgstr "يبحث"
+
+#: id:774
+msgid "Slideshow folder"
+msgstr "مجلد عرض الشرائح"
+
+#: id:775
+msgid "Network interface"
+msgstr "واجهة شبكة الاتصال"
+
+#: id:776
+msgid "- Wireless network name (ESSID)"
+msgstr "- اسم الشبكة اللاسلكية (ESSID)"
+
+#: id:777
+msgid "- Wireless password"
+msgstr "- كلمة مرور الشبكة اللاسلكية"
+
+#: id:778
+msgid "- Wireless security"
+msgstr "- حماية الشبكة اللاسلكية"
+
+#: id:779
+msgid "Save and apply network interface settings"
+msgstr "حفظ إعدادات واجهة الشبكة"
+
+#: id:780
+msgid "No encryption"
+msgstr "لاتشفير"
+
+#: id:781
+msgid "WEP"
+msgstr ""
+
+#: id:782
+msgid "WPA"
+msgstr ""
+
+#: id:783
+msgid "WPA2"
+msgstr ""
+
+#: id:784
+msgid "Applying network interface settings. Please wait."
+msgstr "تطبيق إعدادات واجهة الشبكة. يرجى الانتظار."
+
+#: id:785
+msgid "Network interface restarted successfully."
+msgstr "إعادة تشغيل واجهة الشبكة بنجاح"
+
+#: id:786
+msgid "Network interface did not start successfully."
+msgstr "لم يتم تشغيل واجهة الشبكة بنجاح"
+
+#: id:787
+msgid "Interface disabled"
+msgstr "الواجهة معطلة"
+
+#: id:788
+msgid "Network interface disabled successfully."
+msgstr "واجهة الشبكة معطلة بنجاح"
+
+#: id:789
+msgid "Wireless network name (ESSID)"
+msgstr "اسم الشبكة اللاسلكية (ESSID)"
+
+#: id:790
+msgid "Remote control"
+msgstr ""
+
+#: id:791
+msgid "Allow programs on this system to control XBMC"
+msgstr "سماح البرامج على هذا النظام للتحكم على XBMC"
+
+#: id:792
+msgctxt "Auto context with id 792"
+msgid "Port"
+msgstr "المنفذ"
+
+#: id:793
+msgid "Port range"
+msgstr "نطاق المنفذ"
+
+#: id:794
+msgid "Allow programs on other systems to control XBMC"
+msgstr "سماح برامج على أنظمة أخرى للتحكم على XBMC"
+
+#: id:795
+msgid "Initial repeat delay (ms)"
+msgstr ""
+
+#: id:796
+msgid "Continuous repeat delay (ms)"
+msgstr ""
+
+#: id:797
+msgid "Maximum number of clients"
+msgstr "الحد الأقصى لعدد من العملاء"
+
+#: id:798
+msgid "Internet access"
+msgstr "الوصول إلى الإنترنت"
+
+#: id:850
+msgid "Invalid port number entered"
+msgstr "رقم المنفذ المدخل غير صالح"
+
+#: id:851
+msgid "Valid port range is 1-65535"
+msgstr "نطاق المنفذ الصالح هو 1-65535"
+
+#: id:852
+msgid "Valid port range is 1024-65535"
+msgstr "نطاق المنفذ السليم هو 1024-65535"
+
+#: id:998
+msgid "Add Music..."
+msgstr "إضافة موسيقى..."
+
+#: id:999
+msgid "Add Videos..."
+msgstr "إضافة فيديو..."
+
+#: id:1000
+msgid "- Preview"
+msgstr "معاينة"
+
+#: id:1001
+msgid "Unable to connect"
+msgstr "غير قادر على الاتصال"
+
+#: id:1002
+msgid "XBMC was unable to connect to the network location."
+msgstr "XBMC فشل في الاتصال إلى موقع الشبكة."
+
+#: id:1003
+msgid "This could be due to the network not being connected."
+msgstr "قد يكون هذا بسبب عدم توصيل الشبكة."
+
+#: id:1004
+msgid "Would you like to add it anyway?"
+msgstr "هل تريد إضافته على أي حال؟"
+
+#: id:1006
+msgctxt "Auto context with id 1006"
+msgid "IP address"
+msgstr "IP عنوان"
+
+#: id:1007
+msgid "Add network location"
+msgstr "إضافة موقع شبكة"
+
+#: id:1008
+msgid "Protocol"
+msgstr "بروتوكول"
+
+#: id:1009
+msgid "Server address"
+msgstr "عنوان الخدمة"
+
+#: id:1010
+msgid "Server name"
+msgstr "اسم الخدمة"
+
+#: id:1011
+msgid "Remote path"
+msgstr "مسار بعيد"
+
+#: id:1012
+msgid "Shared folder"
+msgstr "مجلد مشترك"
+
+#: id:1013
+msgctxt "Auto context with id 1013"
+msgid "Port"
+msgstr "المنفذ"
+
+#: id:1014
+msgctxt "Auto context with id 1014"
+msgid "Username"
+msgstr "اسم المستخدم"
+
+#: id:1015
+msgid "Browse for network server"
+msgstr "تصفح لخادم الشبكة"
+
+#: id:1016
+msgid "Enter the network address of the server"
+msgstr "أدخل عنوان الشبكة من الخادم"
+
+#: id:1017
+msgid "Enter the path on the server"
+msgstr "أدخل المسار على الخادم"
+
+#: id:1018
+msgid "Enter the port number"
+msgstr "أدخل رقم المنفذ"
+
+#: id:1019
+msgid "Enter the username"
+msgstr "أدخل اسم المستخدم"
+
+#: id:1020
+msgid "Add %s source"
+msgstr "%s إضافة مصدر"
+
+#: id:1021
+msgid "Enter the paths or browse for the media locations."
+msgstr "أدخل المسار أو تصفح موقع الوسائط."
+
+#: id:1022
+msgid "Enter a name for this media Source."
+msgstr "أدخل اسم لمصدر الوسائط."
+
+#: id:1023
+msgid "Browse for new share"
+msgstr "تصفح لمشاركة جديد"
+
+#: id:1024
+msgid "Browse"
+msgstr "تصفح"
+
+#: id:1025
+msgid "Could not retrieve directory information."
+msgstr "لايتمكن من استرجاع معلومات الدليل"
+
+#: id:1026
+msgid "Add source"
+msgstr "إضافة مصدر..."
+
+#: id:1027
+msgid "Edit source"
+msgstr "تحرير مصدر"
+
+#: id:1028
+msgid "Edit %s source"
+msgstr "%s تحرير مصدر"
+
+#: id:1029
+msgid "Enter the new label"
+msgstr "أدخل علامة جديد"
+
+#: id:1030
+msgid "Browse for image"
+msgstr "تصفح للصور"
+
+#: id:1031
+msgid "Browse for image folder"
+msgstr "تصفح لمجلد الصور"
+
+#: id:1032
+msgid "Add network location..."
+msgstr "إضافة موقع شبكة..."
+
+#: id:1033
+msgid "Browse for file"
+msgstr "تصفح لملف"
+
+#: id:1034
+msgid "Submenu"
+msgstr "قائمة ثانوية"
+
+#: id:1035
+msgid "Enable submenu buttons"
+msgstr "تمكين أزرار القائمة الثانوية"
+
+#: id:1036
+msgid "Favourites"
+msgstr "المفضلات"
+
+#: id:1037
+msgid "Video Add-ons"
+msgstr "ملحقات الفيديو"
+
+#: id:1038
+msgid "Music Add-ons"
+msgstr "ملحقات الموسيقى"
+
+#: id:1039
+msgid "Picture Add-ons"
+msgstr "ملحقات الصور"
+
+#: id:1040
+msgid "Loading directory"
+msgstr "تحميل الدليل"
+
+#: id:1041
+msgid "Retrieved %i items"
+msgstr "استرجاع %i عناصر"
+
+#: id:1042
+msgid "Retrieved %i of %i items"
+msgstr "استرجاع %i من %i عناصر"
+
+#: id:1043
+msgid "Program Add-ons"
+msgstr "ملحقات البرامج"
+
+#: id:1044
+msgid "Set plugin thumb"
+msgstr "تعيين صورة مصغرة للملحق"
+
+#: id:1045
+msgid "Add-on settings"
+msgstr "إعدادت الملحق"
+
+#: id:1046
+msgid "Access points"
+msgstr "نقاط الوصول"
+
+#: id:1047
+msgid "Other..."
+msgstr "أخرى..."
+
+#: id:1048
+msgid "- Username"
+msgstr "- اسم المستخدم"
+
+#: id:1049
+msgid "Script settings"
+msgstr "إعدادت النصية"
+
+#: id:1050
+msgid "Singles"
+msgstr "الأفراد"
+
+#: id:1051
+msgid "Enter web address"
+msgstr "أدخل عنوان ويب"
+
+#: id:1200
+msgid "SMB client"
+msgstr "SMB عميل"
+
+#: id:1202
+msgid "Workgroup"
+msgstr "SMB فريق العمل"
+
+#: id:1203
+msgid "Default username"
+msgstr "SMB اسم المستخدم"
+
+#: id:1204
+msgid "Default password"
+msgstr "SMB كلمة السر"
+
+#: id:1207
+msgid "WINS server"
+msgstr "SMB WINS خادم"
+
+#: id:1208
+msgid "Mount SMB shares"
+msgstr "SMB مشاركة"
+
+#: id:1210
+msgctxt "Auto context with id 1210"
+msgid "Remove"
+msgstr "إزالة"
+
+#: id:1211
+msgctxt "Auto context with id 1211"
+msgid "Music"
+msgstr "موسيقى"
+
+#: id:1212
+msgctxt "Auto context with id 1212"
+msgid "Video"
+msgstr "فيديو"
+
+#: id:1213
+msgctxt "Auto context with id 1213"
+msgid "Pictures"
+msgstr "صور"
+
+#: id:1214
+msgctxt "Auto context with id 1214"
+msgid "Files"
+msgstr "ملفات"
+
+#: id:1215
+msgctxt "Auto context with id 1215"
+msgid "Music & video"
+msgstr "الموسيقى والفيديو"
+
+#: id:1216
+msgid "Music & pictures"
+msgstr "الموسيقى والصور"
+
+#: id:1217
+msgid "Music & files"
+msgstr "الموسيقى والملفات"
+
+#: id:1218
+msgid "Video & pictures"
+msgstr "فيديو وصور"
+
+#: id:1219
+msgid "Video & files"
+msgstr "ملفات الفيديو"
+
+#: id:1220
+msgid "Pictures & files"
+msgstr "الصور والملفات"
+
+#: id:1221
+msgid "Music & video & pictures"
+msgstr "الموسيقى والفيديو والصور"
+
+#: id:1222
+msgid "Music & video & pictures & files"
+msgstr "الموسيقى والفيديو والصور والملفات"
+
+#: id:1223
+msgctxt "Auto context with id 1223"
+msgid "Disabled"
+msgstr "معطلة"
+
+#: id:1226
+msgid "Files & music & video"
+msgstr "الملفات والموسيقى والفيديو"
+
+#: id:1227
+msgid "Files & pictures & music"
+msgstr "الملفات والصور والموسيقى"
+
+#: id:1228
+msgid "Files & pictures & video"
+msgstr "الملفات والصور والفيديو"
+
+#: id:1229
+msgid "Music & programs"
+msgstr "الموسيقى والبرامج"
+
+#: id:1230
+msgid "Video & programs"
+msgstr "الفيديو والبرامج"
+
+#: id:1231
+msgid "Pictures & programs"
+msgstr "الصور والبرامج"
+
+#: id:1232
+msgid "Music & video & pictures & programs"
+msgstr "الموسيقى والفيديو والصور والبرامج"
+
+#: id:1233
+msgid "Programs & video & music"
+msgstr "البرامج والفيديو والموسيقى"
+
+#: id:1234
+msgid "Programs & pictures & music"
+msgstr "البرامج والصور والموسيقى"
+
+#: id:1235
+msgid "Programs & pictures & video"
+msgstr "البرامج والصور والفيديو"
+
+#: id:1250
+msgid "Auto-detection"
+msgstr "تحديد الهوية تلقائي"
+
+#: id:1251
+msgid "Auto-detect system"
+msgstr "الكشف التلقائي عن نظام"
+
+#: id:1252
+msgid "Nickname"
+msgstr "كنية"
+
+#: id:1254
+msgid "Ask to connect"
+msgstr "طلب للاتصال"
+
+#: id:1255
+msgid "Send FTP user and password"
+msgstr "FTP إرسال اسم المستخدم وكلمة السر الخاصة للـ"
+
+#: id:1256
+msgid "Ping interval"
+msgstr "Ping تأخير"
+
+#: id:1257
+msgid "Would you like to connect to the auto-detected system?"
+msgstr "هل ترغب في الاتصال إلى نظام الكشف التلقائي؟"
+
+#: id:1259
+msgid "Zeroconf"
+msgstr ""
+
+#: id:1260
+msgid "Announce these services to other systems via Zeroconf"
+msgstr "أعلن هذه الخدمات لأنظمة أخرى عبر Zeroconf"
+
+#: id:1270
+msgid "Allow XBMC to receive AirPlay content"
+msgstr ""
+
+#: id:1271
+msgid "Device name"
+msgstr "اسم الجهاز"
+
+#: id:1272
+msgid "- Use password protection"
+msgstr "-- استخدام حماية كلمة المرور"
+
+#: id:1273
+msgid "AirPlay"
+msgstr ""
+
+#: id:1300
+msgid "Custom audio device"
+msgstr "جهاز صوت مخصص"
+
+#: id:1301
+msgid "Custom passthrough device"
+msgstr "جهاز عبور مخصص"
+
+#: id:1396
+msgid "Drifting"
+msgstr "ينجرف"
+
+#: id:1397
+msgid "and"
+msgstr "و"
+
+#: id:1398
+msgid "Freezing"
+msgstr "يتجمد"
+
+#: id:1399
+msgid "Late"
+msgstr "متأخر"
+
+#: id:1400
+msgid "Isolated"
+msgstr "معزولة"
+
+#: id:1401
+msgid "Thundershowers"
+msgstr "رعد ومطر"
+
+#: id:1402
+msgid "Thunder"
+msgstr "رعد"
+
+#: id:1403
+msgctxt "Auto context with id 1403"
+msgid "Sun"
+msgstr "شمس"
+
+#: id:1404
+msgid "Heavy"
+msgstr "كثيفة"
+
+#: id:1405
+msgid "in"
+msgstr "في"
+
+#: id:1406
+msgid "the"
+msgstr "في"
+
+#: id:1407
+msgid "Vicinity"
+msgstr "كثب"
+
+#: id:1408
+msgid "Ice"
+msgstr "جليد"
+
+#: id:1409
+msgid "Crystals"
+msgstr "بلورات"
+
+#: id:1410
+msgid "Calm"
+msgstr "هدوء"
+
+#: id:1411
+msgid "with"
+msgstr "مع"
+
+#: id:1412
+msgid "windy"
+msgstr "عاصفة"
+
+#: id:1413
+msgid "drizzle"
+msgstr "رذاذ"
+
+#: id:1414
+msgid "Thunderstorm"
+msgstr "عواصف رعدية"
+
+#: id:1415
+msgid "Drizzle"
+msgstr "رذاذ"
+
+#: id:1416
+msgid "Foggy"
+msgstr "ضباب"
+
+#: id:1417
+msgid "Grains"
+msgstr ""
+
+#: id:1418
+msgid "T-Storms"
+msgstr ""
+
+#: id:1419
+msgid "T-Showers"
+msgstr ""
+
+#: id:1420
+msgid "Moderate"
+msgstr ""
+
+#: id:1421
+msgid "Very High"
+msgstr "عالية جدا"
+
+#: id:1422
+msgid "Windy"
+msgstr "عاصفة"
+
+#: id:1423
+msgid "Mist"
+msgstr "ضباب"
+
+#: id:1450
+msgid "Put display to sleep when idle"
+msgstr "مراقبة دخول في وضع السكون عند الخمول"
+
+#: id:2050
+msgid "Runtime"
+msgstr "وقت التشغيل:"
+
+#: id:2100
+msgid "Script failed! : %s"
+msgstr "فشل النصية! %s"
+
+#: id:2101
+msgid "Newer version needed - See log"
+msgstr "بحاجة إلى نسخة جديدة - انظر السجل"
+
+#: id:4501
+msgid "Enable LCD/VFD"
+msgstr "تشغيل LCD / VFD"
+
+#: id:10000
+msgid "Home"
+msgstr "الرئيسية"
+
+#: id:10001
+msgctxt "Auto context with id 10001"
+msgid "Programs"
+msgstr "برامج"
+
+#: id:10002
+msgctxt "Auto context with id 10002"
+msgid "Pictures"
+msgstr "صور"
+
+#: id:10003
+msgctxt "Auto context with id 10003"
+msgid "File manager"
+msgstr "إدارة الملفات"
+
+#: id:10004
+msgctxt "Auto context with id 10004"
+msgid "Settings"
+msgstr "الإعدادات"
+
+#: id:10005
+msgctxt "Auto context with id 10005"
+msgid "Music"
+msgstr "موسيقى"
+
+#: id:10006
+msgctxt "Auto context with id 10006"
+msgid "Videos"
+msgstr "فيديو"
+
+#: id:10007
+msgid "System information"
+msgstr "معلومات النظام"
+
+#: id:10008
+msgid "Settings - General"
+msgstr "العامة - الإعدادات"
+
+#: id:10009
+msgid "Settings - Screen"
+msgstr "الشاشة - إعدادات"
+
+#: id:10010
+msgid "Settings - Appearance - GUI Calibration"
+msgstr "معايرة واجهة المستخدم الرسومية - المظهر - إعدادات"
+
+#: id:10011
+msgid "Settings - Videos - Screen Calibration"
+msgstr "معايرة الشاشة - الفيديو - إعدادات"
+
+#: id:10012
+msgid "Settings - Pictures"
+msgstr "الصور - إعدادات"
+
+#: id:10013
+msgid "Settings - Programs"
+msgstr "البرامج - إعدادات"
+
+#: id:10014
+msgid "Settings - Weather"
+msgstr "الطقس - إعدادات"
+
+#: id:10015
+msgid "Settings - Music"
+msgstr "الموسيقى - إعدادات"
+
+#: id:10016
+msgid "Settings - System"
+msgstr "النظام - إعدادات"
+
+#: id:10017
+msgid "Settings - Videos"
+msgstr "الفيديو - إعدادات"
+
+#: id:10018
+msgid "Settings - Network"
+msgstr "الشبكة - إعدادات"
+
+#: id:10019
+msgid "Settings - Appearance"
+msgstr "المظهر - إعدادات"
+
+#: id:10020
+msgctxt "Auto context with id 10020"
+msgid "Scripts"
+msgstr "النصية"
+
+#: id:10021
+msgid "Web Browser"
+msgstr "متصفح ويب"
+
+#: id:10025
+msgctxt "Auto context with id 10025"
+msgid "Videos"
+msgstr ""
+
+#: id:10028
+msgid "Videos/Playlist"
+msgstr "فيديو / قائمة التشغيل"
+
+#: id:10029
+msgctxt "Auto context with id 10029"
+msgid "Login screen"
+msgstr ""
+
+#: id:10034
+msgid "Settings - Profiles"
+msgstr "إعدادات ملف المستخدم -"
+
+#: id:10040
+msgid "Addon browser"
+msgstr ""
+
+#: id:10100
+msgid "Yes/No dialog"
+msgstr "حوار نعم/لا"
+
+#: id:10101
+msgid "Progress dialog"
+msgstr "تقدم الحوار"
+
+#: id:10210
+msgid "Looking for subtitles..."
+msgstr "يبحث عن الترجمات..."
+
+#: id:10211
+msgid "Looking for or caching subtitles..."
+msgstr "يبحث عن أو تخزين مؤقت للترجمة..."
+
+#: id:10212
+msgid "terminating"
+msgstr "يلغي"
+
+#: id:10213
+msgid "buffering"
+msgstr "تخزين المعلومات"
+
+#: id:10214
+msgid "Opening stream"
+msgstr "يفتح البث"
+
+#: id:10500
+msgid "Music/Playlist"
+msgstr "موسيقى / قائمة التشغيل"
+
+#: id:10501
+msgid "Music/Files"
+msgstr "الموسيقى / ملفات"
+
+#: id:10502
+msgid "Music/Library"
+msgstr "الموسيقى / الدليل"
+
+#: id:10503
+msgid "Playlist editor"
+msgstr "محرر قائمة التشغيل"
+
+#: id:10504
+msgid "Top 100 songs"
+msgstr "أفضل 100 أغنية"
+
+#: id:10505
+msgid "Top 100 albums"
+msgstr "أفضل 100 البوم"
+
+#: id:10506
+msgctxt "Auto context with id 10506"
+msgid "Programs"
+msgstr "برامج"
+
+#: id:10507
+msgid "Configuration"
+msgstr "إعدادات"
+
+#: id:10508
+msgid "Weather forecast"
+msgstr "حالة الطقس"
+
+#: id:10509
+msgid "Network gaming"
+msgstr "ألعاب الشبكة"
+
+#: id:10510
+msgid "Extensions"
+msgstr "ملحقات"
+
+#: id:10511
+msgctxt "Auto context with id 10511"
+msgid "System info"
+msgstr "معلومات النظام"
+
+#: id:10516
+msgid "Music - Library"
+msgstr "موسيقى -- مكتبة"
+
+#: id:10517
+msgid "Now Playing - Music"
+msgstr "التشغيل الآن -- موسيقى"
+
+#: id:10522
+msgid "Now Playing - Videos"
+msgstr "التشغيل الآن -- فيديو"
+
+#: id:10523
+msgid "Album info"
+msgstr "معلومات الألبوم"
+
+#: id:10524
+msgid "Movie info"
+msgstr "معلومات الفيلم"
+
+#: id:12000
+msgid "Select dialog"
+msgstr "تحديد الحوار"
+
+#: id:12001
+msgid "Music/Info"
+msgstr "الموسيقى/معلومات"
+
+#: id:12002
+msgid "Dialog OK"
+msgstr "حوار موافق"
+
+#: id:12003
+msgid "Videos/Info"
+msgstr "الفيديو/معلومات"
+
+#: id:12004
+msgid "Scripts/Info"
+msgstr "النصية / معلومات"
+
+#: id:12005
+msgid "Fullscreen video"
+msgstr "وضع الفيديو في ملء الشاشة"
+
+#: id:12006
+msgid "Audio visualization"
+msgstr "تصور الصوت"
+
+#: id:12008
+msgid "File stacking dialog"
+msgstr "كومة من الملفات"
+
+#: id:12009
+msgid "Rebuild index..."
+msgstr "إعادة مؤشر..."
+
+#: id:12010
+msgid "Return to music window"
+msgstr "عودة إلى الموسيقى"
+
+#: id:12011
+msgid "Return to videos window"
+msgstr "عودة إلى الفيديو"
+
+#: id:12021
+msgid "Start from beginning"
+msgstr "ابدأ من البداية"
+
+#: id:12022
+msgid "Resume from %s"
+msgstr "استئناف من %s"
+
+#: id:12310
+msgid "0"
+msgstr "0"
+
+#: id:12311
+msgid "1"
+msgstr "1"
+
+#: id:12312
+msgid "2"
+msgstr "2"
+
+#: id:12313
+msgid "3"
+msgstr "3"
+
+#: id:12314
+msgid "4"
+msgstr "4"
+
+#: id:12315
+msgid "5"
+msgstr "5"
+
+#: id:12316
+msgid "6"
+msgstr "6"
+
+#: id:12317
+msgid "7"
+msgstr "7"
+
+#: id:12318
+msgid "8"
+msgstr "8"
+
+#: id:12319
+msgid "9"
+msgstr "9"
+
+#: id:12320
+msgid "c"
+msgstr "c"
+
+#: id:12321
+msgid "Ok"
+msgstr "موافق"
+
+#: id:12322
+msgid "*"
+msgstr "*"
+
+#: id:12325
+msgid "Locked! Enter code..."
+msgstr "مقفل! أدخل كلمة الكود..."
+
+#: id:12326
+msgid "Enter password"
+msgstr "أدخل كلمة المرور"
+
+#: id:12327
+msgid "Enter master code"
+msgstr "أدخل الكود الرئيسي"
+
+#: id:12328
+msgid "Enter unlock code"
+msgstr "أدخل رمز القفل"
+
+#: id:12329
+msgid "or press C to cancel"
+msgstr "أو اضغط C للإلغاء"
+
+#: id:12330
+msgid "Enter gamepad button combo and"
+msgstr "أدخل أزرار السرد وانقر"
+
+#: id:12331
+msgid "press OK, or Back to cancel"
+msgstr "اضغط موافق, أو الخلف للإلغاء"
+
+#: id:12332
+msgid "Set lock"
+msgstr "ضع قفل"
+
+#: id:12333
+msgid "Unlock"
+msgstr "القفل"
+
+#: id:12334
+msgid "Reset lock"
+msgstr "إعادة تعيين القفل"
+
+#: id:12335
+msgid "Remove lock"
+msgstr "إزالة القفل"
+
+#: id:12337
+msgid "Numeric password"
+msgstr "كلمة سر رقمية"
+
+#: id:12338
+msgid "Gamepad button combo"
+msgstr "تحكم تركيبة الزر"
+
+#: id:12339
+msgid "Full-text password"
+msgstr "كلمة السر كاملة نصيا"
+
+#: id:12340
+msgid "Enter new password"
+msgstr "إدخال كلمة السر الجديدة"
+
+#: id:12341
+msgid "Re-Enter new password"
+msgstr "إدخال كلمة المرور مرة أخرى"
+
+#: id:12342
+msgid "Incorrect password,"
+msgstr "كلمة مرور خاطئة ،"
+
+#: id:12343
+msgid "retries left"
+msgstr "غادر المحاولة"
+
+#: id:12344
+msgid "Passwords entered did not match."
+msgstr "كلمة المرور غير متطابقة."
+
+#: id:12345
+msgid "Access denied"
+msgstr "الدخول محظور"
+
+#: id:12346
+msgid "Password retry limit exceeded."
+msgstr "فشل العديد من محاولات تسجيل الدخول."
+
+#: id:12347
+msgid "The system will now shut off."
+msgstr "النظام سوف يغلق الان."
+
+#: id:12348
+msgid "Item locked"
+msgstr "العنصر مقفل"
+
+#: id:12353
+msgid "Reactivate lock"
+msgstr "تنشيط قفل"
+
+#: id:12356
+msgid "Change lock"
+msgstr "تغيير قفل"
+
+#: id:12357
+msgid "Source lock"
+msgstr "قفل مصدر"
+
+#: id:12358
+msgid "Password entry was blank. Try again."
+msgstr "حقل كلمة المرور فارغة. الرجاء المحاولة مرة أخرى."
+
+#: id:12360
+msgid "Master lock"
+msgstr "الإغلاق الرئيسي"
+
+#: id:12362
+msgid "Shutdown system if Master Lock retries exceeded"
+msgstr "إيقاف تشغيل النظام إذا تجاوز القفل الرئيسي المحاولات"
+
+#: id:12367
+msgid "Master code is not valid"
+msgstr "الرمز الرئيسي غير متطابق"
+
+#: id:12368
+msgid "Please enter a valid master code"
+msgstr "الرجاء إدخال رمز رئيسي صحيح"
+
+#: id:12373
+msgid "Settings & file manager"
+msgstr "إعدادت إدارة الملف"
+
+#: id:12376
+msgid "Set as default for all movies"
+msgstr "تعيين افتراضيا على جميع الأفلام"
+
+#: id:12377
+msgid "This will reset any previously saved values"
+msgstr "هذا سوف تعيين أية قيم تم حفظها سابقا"
+
+#: id:12378
+msgid "Amount of time to display each image"
+msgstr "مقدار الوقت لعرض كل صورة"
+
+#: id:12379
+msgid "Use pan and zoom effects"
+msgstr "استخدام بان وتأثيرات التكبير"
+
+#: id:12383
+msgid "12 hour clock"
+msgstr "12 ساعة"
+
+#: id:12384
+msgid "24 hour clock"
+msgstr "24 ساعة على مدار الساعة"
+
+#: id:12385
+msgid "Day/Month"
+msgstr "اليوم / الشهر"
+
+#: id:12386
+msgid "Month/Day"
+msgstr "شهر / يوم"
+
+#: id:12390
+msgid "System uptime"
+msgstr "وقت النظام النشط"
+
+#: id:12391
+msgid "Minutes"
+msgstr "دقائق"
+
+#: id:12392
+msgid "Hours"
+msgstr "ساعات"
+
+#: id:12393
+msgid "Days"
+msgstr "أيام"
+
+#: id:12394
+msgid "Total uptime"
+msgstr "النشاط الكلي"
+
+#: id:12395
+msgid "Battery level"
+msgstr "مستوى البطارية"
+
+#: id:12600
+msgctxt "Auto context with id 12600"
+msgid "Weather"
+msgstr "الطقس"
+
+#: id:12900
+msgctxt "Auto context with id 12900"
+msgid "Screensaver"
+msgstr "شاشة"
+
+#: id:12901
+msgid "Fullscreen OSD"
+msgstr "شاشة كاملة OSD"
+
+#: id:13000
+msgid "System"
+msgstr "النظام"
+
+#: id:13001
+msgid "Immediate HD spindown"
+msgstr "Hardisk مزج على الفور"
+
+#: id:13002
+msgid "Video only"
+msgstr "فيديو فقط"
+
+#: id:13003
+msgid "- Delay"
+msgstr "- تأخير"
+
+#: id:13004
+msgid "- Minimum file duration"
+msgstr "- مدة الحد الأدنى للملف"
+
+#: id:13005
+msgid "Shutdown"
+msgstr "إغلاق"
+
+#: id:13008
+msgid "Shutdown function"
+msgstr "عملية الإغلاق"
+
+#: id:13009
+msgid "Quit"
+msgstr "اخرج"
+
+#: id:13010
+msgid "Hibernate"
+msgstr "إسبات"
+
+#: id:13011
+msgid "Suspend"
+msgstr "أجل"
+
+#: id:13012
+msgid "Exit"
+msgstr "إنهاء"
+
+#: id:13013
+msgid "Reboot"
+msgstr "إعادة تشغيل"
+
+#: id:13014
+msgid "Minimize"
+msgstr "تصغير"
+
+#: id:13015
+msgid "Power button action"
+msgstr "زر إيقاف العمل"
+
+#: id:13016
+msgid "Power off System"
+msgstr "إيقاف تشغيل النظام ​​"
+
+#: id:13020
+msgid "Is another session active, perhaps over ssh?"
+msgstr "هل جلسة العمل الأخرى نشطة, ربما خلال ssh?"
+
+#: id:13021
+msgid "Mounted removable harddrive"
+msgstr "الأقراص المحمولة متصلة"
+
+#: id:13022
+msgid "Unsafe device removal"
+msgstr "ليست آمنة لإزالة جهاز محمول"
+
+#: id:13023
+msgid "Successfully removed device"
+msgstr "نجحت في إزالة الجهاز"
+
+#: id:13024
+msgid "Joystick plugged"
+msgstr "جويستيك متصلة"
+
+#: id:13025
+msgid "Joystick unplugged"
+msgstr "جويستيك غير متصلة"
+
+#: id:13050
+msgid "Running low on battery"
+msgstr "يعمل على البطارية المنخفضة"
+
+#: id:13100
+msgid "Flicker filter"
+msgstr "تصفية Flicker"
+
+#: id:13101
+msgid "Let driver choose (requires restart)"
+msgstr "اسمح للسواقه الاختيار (يتطلب إعادة تشغيل )"
+
+#: id:13105
+msgid "Vertical blank sync"
+msgstr ""
+
+#: id:13106
+msgctxt "Auto context with id 13106"
+msgid "Disabled"
+msgstr "تزامن رأسي فارغ"
+
+#: id:13107
+msgid "Enabled during video playback"
+msgstr "ممكن خلال تشغيل الفيديو"
+
+#: id:13108
+msgctxt "Auto context with id 13108"
+msgid "Always enabled"
+msgstr "ممكن دائما"
+
+#: id:13109
+msgid "Test & apply resolution"
+msgstr "اختبار وتطبيق الدقة"
+
+#: id:13110
+msgid "Save resolution?"
+msgstr "حفظ الدقة؟"
+
+#: id:13111
+msgid "Would you like to keep this resolution?"
+msgstr "هل ترغب في الحفاظ على هذه الدقة؟"
+
+#: id:13112
+msgid "High quality upscaling"
+msgstr ""
+
+#: id:13113
+msgctxt "Auto context with id 13113"
+msgid "Disabled"
+msgstr "معطلة"
+
+#: id:13114
+msgid "Enabled for SD content"
+msgstr "SD ممكن لمحتوى"
+
+#: id:13115
+msgctxt "Auto context with id 13115"
+msgid "Always enabled"
+msgstr "دائما ممكن"
+
+#: id:13116
+msgid "Upscaling method"
+msgstr "طريقة التوسيع"
+
+#: id:13117
+msgctxt "Auto context with id 13117"
+msgid "Bicubic"
+msgstr ""
+
+#: id:13118
+msgid "Lanczos"
+msgstr ""
+
+#: id:13119
+msgid "Sinc"
+msgstr ""
+
+#: id:13120
+msgctxt "Auto context with id 13120"
+msgid "VDPAU"
+msgstr ""
+
+#: id:13121
+msgid "VDPAU HQ Upscaling level"
+msgstr ""
+
+#: id:13122
+msgid "VDPAU Studio level color conversion"
+msgstr ""
+
+#: id:13130
+msgid "Blank other displays"
+msgstr "أفرغ العروض الاخرى"
+
+#: id:13131
+msgctxt "Auto context with id 13131"
+msgid "Disabled"
+msgstr "معطلة"
+
+#: id:13132
+msgid "Blank displays"
+msgstr ""
+
+#: id:13140
+msgid "Active connections detected!"
+msgstr "الكشف عن اتصالات نشطة!"
+
+#: id:13141
+msgid "If you proceed, you might not be able to control XBMC"
+msgstr "إذا استمر ، قد تكون غير قادر على التحكم في XBMC المزيد"
+
+#: id:13142
+msgid "any longer. Are you sure you want to stop the Event server?"
+msgstr "؟EventServer هل أنت متأكد تريد إيقاف"
+
+#: id:13144
+msgid "Change Apple Remote mode?"
+msgstr "تغير نمط أبل البعيد؟"
+
+#: id:13145
+msgid "If you are currently using the Apple Remote to control"
+msgstr ""
+
+#: id:13146
+msgid "XBMC, changing this setting might affect your ability"
+msgstr ""
+
+#: id:13147
+msgid "to continue controlling it. Do you want to proceed?"
+msgstr ""
+
+#: id:13159
+msgid "Subnet mask"
+msgstr "قناع الشبكة"
+
+#: id:13160
+msgid "Gateway"
+msgstr "DNS"
+
+#: id:13161
+msgid "Primary DNS"
+msgstr "Primary DNS"
+
+#: id:13162
+msgid "Initialize failed"
+msgstr "فشلت التهيئة"
+
+#: id:13170
+msgctxt "Auto context with id 13170"
+msgid "Never"
+msgstr "أبداً"
+
+#: id:13171
+msgid "Immediately"
+msgstr "فوراٌ"
+
+#: id:13172
+msgid "After %i secs"
+msgstr "بعد %i ثواني"
+
+#: id:13173
+msgid "HDD install date:"
+msgstr "تاريخ تثبيت القرص القلب:"
+
+#: id:13174
+msgid "HDD power cycle count:"
+msgstr ""
+
+#: id:13200
+msgid "Profiles"
+msgstr "الملفات الشخصية"
+
+#: id:13201
+msgid "Delete profile '%s'?"
+msgstr "حذف ملف شخصي '%s'?"
+
+#: id:13204
+msgid "Last loaded profile:"
+msgstr "آخر ملف شخصي تم تحميله:"
+
+#: id:13205
+msgid "Unknown"
+msgstr "غير معروف"
+
+#: id:13206
+msgid "Overwrite"
+msgstr "الكتابة فوق"
+
+#: id:13208
+msgid "Alarm clock"
+msgstr "المنبه"
+
+#: id:13209
+msgid "Alarm clock interval (in minutes)"
+msgstr "فاصل المنبه الزمني (بالدقائق)"
+
+#: id:13210
+msgid "Started, alarm in %im"
+msgstr "بدأ, المنبه في %im"
+
+#: id:13211
+msgid "Alarm!"
+msgstr "المنبه!"
+
+#: id:13212
+msgid "Canceled with %im%is left"
+msgstr "ألغي مع %imis متبقيه"
+
+#: id:13213
+msgid "%2.0fm"
+msgstr "%2.0fm"
+
+#: id:13214
+msgid "%2.0fs"
+msgstr "%2.0fs"
+
+#: id:13249
+msgid "Search for subtitles in RARs"
+msgstr "بحث الترجمات في RARs"
+
+#: id:13250
+msgid "Browse for subtitle..."
+msgstr "تصفح الترجمات..."
+
+#: id:13251
+msgid "Move item"
+msgstr "تحريك عنصر"
+
+#: id:13252
+msgid "Move item here"
+msgstr "تحريك عنصر هنا"
+
+#: id:13253
+msgid "Cancel move"
+msgstr "التراجع عن نقل"
+
+#: id:13270
+msgid "Hardware:"
+msgstr "الأجهزة:"
+
+#: id:13271
+msgid "CPU Usage:"
+msgstr "سرعة وحدة المعالجة المركزية:"
+
+#: id:13274
+msgid "Connected, but no DNS is available."
+msgstr "متصلة بالشبكة بدون إعدادات DNS"
+
+#: id:13275
+msgid "Hard Disk"
+msgstr "القرص الثابت"
+
+#: id:13276
+msgid "DVD-ROM"
+msgstr "DVD - ROM"
+
+#: id:13277
+msgctxt "Auto context with id 13277"
+msgid "Storage"
+msgstr "التخزين"
+
+#: id:13278
+msgctxt "Auto context with id 13278"
+msgid "Default"
+msgstr "الافتراضية"
+
+#: id:13279
+msgctxt "Auto context with id 13279"
+msgid "Network"
+msgstr "الشبكة"
+
+#: id:13280
+msgctxt "Auto context with id 13280"
+msgid "Video"
+msgstr "الفيديو"
+
+#: id:13281
+msgid "Hardware"
+msgstr "الأجهزة"
+
+#: id:13283
+msgid "Operating system:"
+msgstr "نظام التشغيل:"
+
+#: id:13284
+msgid "CPU speed:"
+msgstr ":سرعة وحدة المعالجة المركزية"
+
+#: id:13286
+msgid "Video encoder:"
+msgstr ":ترميز الفيديو"
+
+#: id:13287
+msgid "Screen resolution:"
+msgstr "دقة الشاشة:"
+
+#: id:13292
+msgid "A/V cable:"
+msgstr "A/V كيبل"
+
+#: id:13294
+msgid "DVD region:"
+msgstr "DVD منطقة:"
+
+#: id:13295
+msgid "Internet:"
+msgstr "الانترنت:"
+
+#: id:13296
+msgctxt "Auto context with id 13296"
+msgid "Connected"
+msgstr "متصل"
+
+#: id:13297
+msgid "Not connected. Check network settings."
+msgstr "غير متصل. تحقق من إعدادات الشبكة."
+
+#: id:13299
+msgid "Target temperature"
+msgstr "درجة الحرارة المستهدفة"
+
+#: id:13300
+msgid "Fan speed"
+msgstr ":سرعة المروحة"
+
+#: id:13301
+msgid "Auto temperature control"
+msgstr "التحكم في درجة الحرارة تلقائيا"
+
+#: id:13302
+msgid "Fan speed override"
+msgstr "السيطرة على سرعة المروحة"
+
+#: id:13303
+msgid "- Fonts"
+msgstr "الخطوط"
+
+#: id:13304
+msgid "Enable flipping bi-directional strings"
+msgstr "مكن جعل الأحرف"
+
+#: id:13305
+msgid "Show RSS news feeds"
+msgstr "RSS إظهار أخبار"
+
+#: id:13306
+msgid "Show parent folder items"
+msgstr "عرض عناصر المجلد الأصلي"
+
+#: id:13307
+msgid "Track naming template"
+msgstr "إخفاء أرقام المسار"
+
+#: id:13308
+msgid "Do you wish to reboot your system"
+msgstr "هل تريد إعادة تشغيل النظام الخاص بك"
+
+#: id:13309
+msgid "instead of just XBMC?"
+msgstr "بدلا من مجرد XBMC?"
+
+#: id:13310
+msgid "Zoom effect"
+msgstr "تأثير التكبير"
+
+#: id:13311
+msgid "Float effect"
+msgstr "الأثر المتوقع"
+
+#: id:13312
+msgid "Black bar reduction"
+msgstr "تخفيض الخطوط سوداء"
+
+#: id:13313
+msgid "Restart"
+msgstr "إعادة تشغيل"
+
+#: id:13314
+msgid "Crossfade between songs"
+msgstr "التداخل في الانتقال بين الأغاني"
+
+#: id:13315
+msgid "Regenerate thumbnails"
+msgstr "تجديد المصغرات"
+
+#: id:13316
+msgid "Recursive thumbnails"
+msgstr "تكرير المصغرات"
+
+#: id:13317
+msgid "View slideshow"
+msgstr "مشاهدة صور العرض"
+
+#: id:13318
+msgid "Recursive slideshow"
+msgstr "تكرير المصغرات"
+
+#: id:13319
+msgid "Randomize"
+msgstr "عشوائي"
+
+#: id:13320
+msgid "Stereo"
+msgstr "ستيريو"
+
+#: id:13321
+msgid "Left only"
+msgstr "اليسار فقط"
+
+#: id:13322
+msgid "Right only"
+msgstr "اليمين فقط"
+
+#: id:13323
+msgid "Enable karaoke support"
+msgstr "تمكين دعم الكاريوكي"
+
+#: id:13324
+msgid "Background transparency"
+msgstr "شفافية الخلفية"
+
+#: id:13325
+msgid "Foreground transparency"
+msgstr "شفافية المقدمة"
+
+#: id:13326
+msgid "A/V delay"
+msgstr "تأخير A/V"
+
+#: id:13327
+msgid "Karaoke"
+msgstr "كاريوكي"
+
+#: id:13328
+msgid "%s not found"
+msgstr "%s لم يتم العثور على."
+
+#: id:13329
+msgid "Error opening %s"
+msgstr "خطأ في فتح %s"
+
+#: id:13330
+msgid "Unable to load %s"
+msgstr "غير قادر على تحميل %s"
+
+#: id:13331
+msgid "Error: Out of memory"
+msgstr "خطأ : الذاكرة ممتلئة"
+
+#: id:13332
+msgid "Move up"
+msgstr "تحريك لأعلى"
+
+#: id:13333
+msgid "Move down"
+msgstr "تحريك لأسفل"
+
+#: id:13334
+msgid "Edit label"
+msgstr "تحرير العلامة"
+
+#: id:13335
+msgid "Make default"
+msgstr "تعيين كافتراضي"
+
+#: id:13336
+msgid "Remove button"
+msgstr "إزالة زر"
+
+#: id:13340
+msgid "Leave as is"
+msgstr "دون تغيير"
+
+#: id:13341
+msgid "Green"
+msgstr "الخضراء"
+
+#: id:13342
+msgid "Orange"
+msgstr "البرتقالي"
+
+#: id:13343
+msgid "Red"
+msgstr "الحمراء"
+
+#: id:13344
+msgid "Cycle"
+msgstr "متغير"
+
+#: id:13345
+msgid "Switch LED off on playback"
+msgstr "تبديل ضوء الصمام على القراءة"
+
+#: id:13346
+msgctxt "Auto context with id 13346"
+msgid "Movie information"
+msgstr "معلومات الفيلم"
+
+#: id:13347
+msgid "Queue item"
+msgstr "انتظار عنصر"
+
+#: id:13348
+msgid "Search IMDb..."
+msgstr "تصفح نوع الفيلم..."
+
+#: id:13349
+msgid "Scan for new content"
+msgstr "تفحص محتوى جديد"
+
+#: id:13350
+msgid "Now playing..."
+msgstr "يعرض الان..."
+
+#: id:13351
+msgctxt "Auto context with id 13351"
+msgid "Album information"
+msgstr "معلومات الألبوم"
+
+#: id:13352
+msgid "Scan item to library"
+msgstr "فحص العناصر الى المكتبة"
+
+#: id:13353
+msgid "Stop scanning"
+msgstr "إيقاف التفحص"
+
+#: id:13354
+msgctxt "Auto context with id 13354"
+msgid "Render method"
+msgstr "طريقة التقديم"
+
+#: id:13355
+msgid "Low quality pixel shader"
+msgstr "مضلل بكسل ذات جودة منخفضه"
+
+#: id:13356
+msgid "Hardware overlays"
+msgstr "تراكيب الأجهزة"
+
+#: id:13357
+msgid "High quality pixel shader"
+msgstr "مضلل بكسل ذات جودة عالية"
+
+#: id:13358
+msgid "Play item"
+msgstr "تشغيل عنصر"
+
+#: id:13359
+msgid "Set artist thumb"
+msgstr "تعيين مصغرات للفنان"
+
+#: id:13360
+msgid "Automatically generate thumbnails"
+msgstr "إنشاء مصغرات الصور تلقائياً"
+
+#: id:13361
+msgid "Enable voice"
+msgstr "تمكين صوت"
+
+#: id:13375
+msgid "Enable device"
+msgstr "تمكين جهاز"
+
+#: id:13376
+msgid "Volume"
+msgstr "مقدار الصوت"
+
+#: id:13377
+msgid "Default view mode"
+msgstr "وضع العرض الافتراضي"
+
+#: id:13378
+msgid "Default brightness"
+msgstr "السطوع الافتراضي"
+
+#: id:13379
+msgid "Default contrast"
+msgstr "التباين الافتراضي"
+
+#: id:13380
+msgid "Default gamma"
+msgstr "غاما الافتراضي"
+
+#: id:13381
+msgid "Resume video"
+msgstr "استئناف الفيديو"
+
+#: id:13382
+msgid "Voice mask - Port 1"
+msgstr "قناع الصوت - منفذ 1"
+
+#: id:13383
+msgid "Voice mask - Port 2"
+msgstr "قناع الصوت - منفذ 2"
+
+#: id:13384
+msgid "Voice mask - Port 3"
+msgstr "قناع الصوت - منفذ 3"
+
+#: id:13385
+msgid "Voice mask - Port 4"
+msgstr "قناع الصوت - منفذ 4"
+
+#: id:13386
+msgid "Use time based seeking"
+msgstr "استخدام الوقت على أساس البحث"
+
+#: id:13387
+msgid "Track naming template - right"
+msgstr "تنسيق أسماء المسار - يمين"
+
+#: id:13388
+msgid "Preset"
+msgstr "مسبق"
+
+#: id:13389
+msgid "There are no presets available\nfor this visualization"
+msgstr "لا توجد قيم مسبقة متاحة لهذا التصور"
+
+#: id:13390
+msgid "There are no settings available\nfor this visualization"
+msgstr "لا توجد إعدادات متاحة لهذا التصور"
+
+#: id:13391
+msgid "Eject/Load"
+msgstr "إخراج/تحميل"
+
+#: id:13392
+msgid "Use visualization if playing audio"
+msgstr "استخدام التصور في حالة تشغيل الصوت"
+
+#: id:13393
+msgid "Calculate size"
+msgstr "حساب الحجم"
+
+#: id:13394
+msgid "Calculating folder size"
+msgstr "حساب حجم المجلد"
+
+#: id:13395
+msgid "Video settings"
+msgstr "إعدادات الفيديو"
+
+#: id:13396
+msgid "Audio and subtitle settings"
+msgstr "إعدادات الصوت والترجمة"
+
+#: id:13397
+msgid "Enable subtitles"
+msgstr "تمكين الترجمات"
+
+#: id:13398
+msgctxt "Auto context with id 13398"
+msgid "Shortcuts"
+msgstr "الاختصارات"
+
+#: id:13399
+msgid "Ignore articles when sorting (e.g. \"the\")"
+msgstr "تجاهل المقالات عند الفرز (\"The\")"
+
+#: id:13400
+msgid "Crossfade between songs on the same album"
+msgstr "التداخل بين الأغاني في الألبوم نفسه"
+
+#: id:13401
+msgid "Browse for %s"
+msgstr "%s تصفح لـ"
+
+#: id:13402
+msgid "Show track position"
+msgstr "إظهار موضع المسار"
+
+#: id:13403
+msgid "Clear default"
+msgstr "إزالة الافتراضيات"
+
+#: id:13404
+msgid "Resume"
+msgstr "استئناف"
+
+#: id:13405
+msgid "Get thumb"
+msgstr "احصل عل مصغرة"
+
+#: id:13406
+msgid "Picture information"
+msgstr "معلومات الصورة"
+
+#: id:13407
+msgid "%s presets"
+msgstr ""
+
+#: id:13408
+msgid "(IMDb user rating)"
+msgstr "(IMDB تصنيف المستخدم)"
+
+#: id:13409
+msgid "Top 250"
+msgstr "أفضل 250"
+
+#: id:13410
+msgid "Tune in on Last.fm"
+msgstr "السماع إلى LAST.FM"
+
+#: id:13411
+msgid "Minimum fan speed"
+msgstr "سرعة المروحة الدنيا"
+
+#: id:13412
+msgid "Play from here"
+msgstr "شغل من هنا"
+
+#: id:13413
+msgid "Downloading"
+msgstr "تحميل"
+
+#: id:13414
+msgid "Include artists who appear only on compilations"
+msgstr "يشمل مجموعات الفنانين فقط"
+
+#: id:13415
+msgctxt "Auto context with id 13415"
+msgid "Render method"
+msgstr "طريقة التقديم"
+
+#: id:13416
+msgid "Auto detect"
+msgstr "كشف تلقائيا"
+
+#: id:13417
+msgid "Basic shaders (ARB)"
+msgstr ""
+
+#: id:13418
+msgid "Advanced shaders (GLSL)"
+msgstr ""
+
+#: id:13419
+msgid "Software"
+msgstr "برنامج"
+
+#: id:13420
+msgid "Remove safely"
+msgstr "إزالة بأمان"
+
+#: id:13421
+msgctxt "Auto context with id 13421"
+msgid "VDPAU"
+msgstr ""
+
+#: id:13422
+msgid "Start slideshow here"
+msgstr "ابدأ عرض شرائح من هنا"
+
+#: id:13423
+msgid "Remember for this path"
+msgstr "تذكر هذا المسار"
+
+#: id:13424
+msgid "Use pixel buffer objects"
+msgstr ""
+
+#: id:13425
+msgid "Allow hardware acceleration (VDPAU)"
+msgstr "تمكين تسارع (VDPAU)"
+
+#: id:13426
+msgid "Allow hardware acceleration (VAAPI)"
+msgstr "تمكين تسارع (VAAPI)"
+
+#: id:13427
+msgid "Allow hardware acceleration (DXVA2)"
+msgstr "تمكين تسارع (DXVA2)"
+
+#: id:13428
+msgid "Allow hardware acceleration (CrystalHD)"
+msgstr "تمكين تسارع (CrystalHD)"
+
+#: id:13429
+msgid "Allow hardware acceleration (VDADecoder)"
+msgstr "تمكين تسارع (VDADecoder)"
+
+#: id:13430
+msgid "Allow hardware acceleration (OpenMax)"
+msgstr "تمكين تسارع (OpenMax)"
+
+#: id:13431
+msgid "Pixel Shaders"
+msgstr ""
+
+#: id:13432
+msgid "Allow hardware acceleration (VideoToolbox)"
+msgstr "تمكين تسارع (VideoToolbox)"
+
+#: id:13500
+msgid "A/V sync method"
+msgstr "تزامن أسلوب تشغيل الشاشة"
+
+#: id:13501
+msgid "Audio clock"
+msgstr "ساعة الصوت"
+
+#: id:13502
+msgid "Video clock (Drop/Dupe audio)"
+msgstr ""
+
+#: id:13503
+msgid "Video clock (Resample audio)"
+msgstr ""
+
+#: id:13504
+msgid "Maximum resample amount (%)"
+msgstr ""
+
+#: id:13505
+msgid "Resample quality"
+msgstr ""
+
+#: id:13506
+msgid "Low(fast)"
+msgstr "منخفض (سريع)"
+
+#: id:13507
+msgctxt "Auto context with id 13507"
+msgid "Medium"
+msgstr "متوسط"
+
+#: id:13508
+msgctxt "Auto context with id 13508"
+msgid "High"
+msgstr "مرتفع"
+
+#: id:13509
+msgid "Really high(slow!)"
+msgstr "مرتفع جداً (slow!)"
+
+#: id:13510
+msgid "Sync playback to display"
+msgstr "مزامنة التشغيل إلى الشاشة"
+
+#: id:13550
+msgid "Pause during refresh rate change"
+msgstr "وقف عند تغيير معدل التحديث"
+
+#: id:13551
+msgctxt "Auto context with id 13551"
+msgid "Off"
+msgstr "معطلة"
+
+#: id:13552
+msgid "%.1f Second"
+msgstr "%.if ثانية"
+
+#: id:13553
+msgid "%.1f Seconds"
+msgstr "%.if ثواني"
+
+#: id:13600
+msgid "Apple remote"
+msgstr "Apple ريموت"
+
+#: id:13602
+msgid "Allow start of XBMC using the remote"
+msgstr "تمكين تشغيل XBMC بواسطة الريموت"
+
+#: id:13603
+msgid "Sequence delay time"
+msgstr ""
+
+#: id:13610
+msgctxt "Auto context with id 13610"
+msgid "Disabled"
+msgstr "معطلة"
+
+#: id:13611
+msgctxt "Auto context with id 13611"
+msgid "Standard"
+msgstr "قياسي"
+
+#: id:13612
+msgid "Universal Remote"
+msgstr "ريموت شامل"
+
+#: id:13613
+msgid "Multi Remote (Harmony)"
+msgstr "ريموت متعدد (متوافق)"
+
+#: id:13620
+msgid "Apple Remote Error"
+msgstr "خطأ ريموت أبل"
+
+#: id:13621
+msgid "Apple Remote support could be enabled."
+msgstr ""
+
+#: id:14000
+msgid "Stack"
+msgstr "مكدس"
+
+#: id:14001
+msgid "Unstack"
+msgstr "غير مكدس"
+
+#: id:14003
+msgid "Downloading playlist file..."
+msgstr "تحميل ملف قائمة التشغيل..."
+
+#: id:14004
+msgid "Downloading streams list..."
+msgstr "تحميل قائمة البث..."
+
+#: id:14005
+msgid "Parsing streams list..."
+msgstr "تحليل قائمة البث..."
+
+#: id:14006
+msgid "Downloading streams list failed"
+msgstr "فشل تحميل قائمة البث"
+
+#: id:14007
+msgid "Downloading playlist file failed"
+msgstr "فشل تحميل ملف قائمة التشغيل"
+
+#: id:14009
+msgid "Games directory"
+msgstr "دليل الألعاب"
+
+#: id:14010
+msgid "Auto switch to thumbs based on"
+msgstr "تنقل آلي للمصغرات استنادا على"
+
+#: id:14011
+msgid "Enable auto switching to thumbs view"
+msgstr "تمكين التنقل الى عرض المصغرات تلقائيا"
+
+#: id:14012
+msgid "- Use large icons"
+msgstr "- استخدام رموز كبيرة"
+
+#: id:14013
+msgid "- Switch based on"
+msgstr "- تغيير استنادا على"
+
+#: id:14014
+msgid "- Percentage"
+msgstr "- في المئة"
+
+#: id:14015
+msgid "No files and at least one thumb"
+msgstr "لا توجد ملفات وعلى الأقل صورة مصغرة واحدة"
+
+#: id:14016
+msgid "At least one file and thumb"
+msgstr "​​على الأقل ملف واحد وصورة مصغرة"
+
+#: id:14017
+msgid "Percentage of thumbs"
+msgstr "نسبة المصغرات"
+
+#: id:14018
+msgid "View options"
+msgstr "عرض الخيارات"
+
+#: id:14019
+msgid "Change area code 1"
+msgstr "تغيير منطقة الرمز 1"
+
+#: id:14020
+msgid "Change area code 2"
+msgstr "تغيير منطقة الرمز 2"
+
+#: id:14021
+msgid "Change area code 3"
+msgstr "تتغيير منطقة الرمز 3"
+
+#: id:14022
+msgctxt "Auto context with id 14022"
+msgid "Library"
+msgstr "المكتبة"
+
+#: id:14023
+msgid "No TV"
+msgstr "لا يوجد تلفزيون"
+
+#: id:14024
+msgid "Enter the nearest large town"
+msgstr "أدخل أقرب مدينة كبيرة"
+
+#: id:14025
+msgid "Video/Audio/DVD cache - Harddisk"
+msgstr "التخزين المؤقت للفيديو/الصوت/دي في دي - القرص الصلب"
+
+#: id:14026
+msgid "Video cache - DVD-ROM"
+msgstr "التخزين المؤقت للفيديو - DVD-ROM"
+
+#: id:14027
+msgctxt "Auto context with id 14027"
+msgid "- Local Network"
+msgstr "- الشبكة المحلية"
+
+#: id:14028
+msgctxt "Auto context with id 14028"
+msgid "- Internet"
+msgstr "- الإنترنت"
+
+#: id:14030
+msgid "Audio cache - DVD-ROM"
+msgstr "التخزين المؤقت للصوت - DVD-ROM"
+
+#: id:14031
+msgctxt "Auto context with id 14031"
+msgid "- Local Network"
+msgstr "- الشبكة المحلية"
+
+#: id:14032
+msgctxt "Auto context with id 14032"
+msgid "- Internet"
+msgstr "- الإنترنت"
+
+#: id:14034
+msgid "DVD cache - DVD-ROM"
+msgstr "DVD التخزين المؤقت لـ - DVD-ROM"
+
+#: id:14035
+msgctxt "Auto context with id 14035"
+msgid "- Local Network"
+msgstr "- الشبكة المحلية"
+
+#: id:14036
+msgctxt "Auto context with id 14036"
+msgid "Services"
+msgstr "الخدمات"
+
+#: id:14038
+msgid "Network settings changed"
+msgstr "تم ضبط إعدادات الشبكة"
+
+#: id:14039
+msgid "XBMC requires to restart to change your"
+msgstr "XBMC يتطلب إعادة تشغيل لتغيير"
+
+#: id:14040
+msgid "network setup. Would you like to restart now?"
+msgstr "ضبط الشبكة. هل ترغب في إعادة التشغيل الآن؟"
+
+#: id:14041
+msgid "Internet connection bandwidth limitation"
+msgstr "نطاق الاتصال بالانترنت محدود"
+
+#: id:14043
+msgid "- Shutdown while playing"
+msgstr "- إغلاق أثناء التشغيل"
+
+#: id:14044
+msgid "%i min"
+msgstr "%i دقيقة"
+
+#: id:14045
+msgid "%i sec"
+msgstr "%i ثانية"
+
+#: id:14046
+msgid "%i ms"
+msgstr "%i ms"
+
+#: id:14047
+msgid "%i %%"
+msgstr "%i %%"
+
+#: id:14048
+msgid "%i kbps"
+msgstr "%i kbps"
+
+#: id:14049
+msgid "%i kb"
+msgstr "%i kb"
+
+#: id:14050
+msgid "%i.0 dB"
+msgstr "%i.0 dB"
+
+#: id:14051
+msgid "Time format"
+msgstr "تهيئة الوقت"
+
+#: id:14052
+msgid "Date format"
+msgstr "تهيئة التاريخ"
+
+#: id:14053
+msgid "GUI filters"
+msgstr "فلاتر واجهة المستخدم الرسومية"
+
+#: id:14055
+msgid "Use background scanning"
+msgstr "استخدام فحص الخلفية"
+
+#: id:14056
+msgid "Stop scan"
+msgstr "إيقاف الفحص"
+
+#: id:14057
+msgid "Not possible while scanning for media info"
+msgstr "غير ممكن أثناء الفحص على معلومات الوسائط"
+
+#: id:14058
+msgid "Film grain effect"
+msgstr "تأثير طبعة الفلم"
+
+#: id:14059
+msgid "Search for thumbnails on remote shares"
+msgstr "البحث عن المصغرات في المشاركات البعيدة"
+
+#: id:14060
+msgid "Unknown type cache - Internet"
+msgstr "التخزين المؤقت لأنواع غير معروفة - الانترنت"
+
+#: id:14061
+msgctxt "Auto context with id 14061"
+msgid "Auto"
+msgstr "التلقائية"
+
+#: id:14062
+msgid "Enter username for"
+msgstr "أدخل اسم المستخدم لـ"
+
+#: id:14063
+msgid "Date & time"
+msgstr "التاريخ والوقت"
+
+#: id:14064
+msgid "Set date"
+msgstr "تعيين التاريخ"
+
+#: id:14065
+msgid "Set time"
+msgstr "تعيين الوقت"
+
+#: id:14066
+msgid "Enter the time in 24 hour HH:MM format"
+msgstr "HH : MM تنسيق دخول الوقت 24 ساعة"
+
+#: id:14067
+msgid "Enter the date in DD/MM/YYYY format"
+msgstr "DD / MM / YYYY تنسيق دخول التاريخ"
+
+#: id:14068
+msgid "Enter the IP address"
+msgstr "IP أدخل عنوان"
+
+#: id:14069
+msgid "Apply these settings now?"
+msgstr "تغيير الإعدادات الآن؟"
+
+#: id:14070
+msgid "Apply changes now"
+msgstr "إجراء التغييرات الآن"
+
+#: id:14071
+msgid "Allow file renaming and deletion"
+msgstr "سماح تسمية وحذف الملف"
+
+#: id:14074
+msgid "Set timezone"
+msgstr "تعيين التوقيت"
+
+#: id:14075
+msgid "Use daylight saving time"
+msgstr "استخدام التوقيت الصيفي"
+
+#: id:14076
+msgid "Add to favourites"
+msgstr "أضف إلى المفضلة"
+
+#: id:14077
+msgid "Remove from favourites"
+msgstr "إزالة من المفضلة"
+
+#: id:14078
+msgctxt "Auto context with id 14078"
+msgid "- Colours"
+msgstr "الألوان"
+
+#: id:14079
+msgid "Timezone country"
+msgstr "دولة المنطقة الزمنية"
+
+#: id:14080
+msgid "Timezone"
+msgstr "المنطقة الزمنية"
+
+#: id:14081
+msgid "File lists"
+msgstr "قوائم الملف"
+
+#: id:14082
+msgid "Show EXIF picture information"
+msgstr "عرض معلومات صور EXIF"
+
+#: id:14083
+msgid "Use a fullscreen window rather than true fullscreen"
+msgstr "استخدام نافذة الشاشة الكاملة بدلا من ملء الشاشة الحقيقية"
+
+#: id:14084
+msgid "Queue songs on selection"
+msgstr "انتظار الأغاني المختارة"
+
+#: id:14086
+msgid "Playback"
+msgstr "توليف"
+
+#: id:14087
+msgid "DVDs"
+msgstr ""
+
+#: id:14088
+msgid "Play DVDs automatically"
+msgstr "تشغيل الدي في دي تلقائياً"
+
+#: id:14089
+msgid "Font to use for text subtitles"
+msgstr "استخدام الخط في ترجمات النص"
+
+#: id:14090
+msgid "International"
+msgstr "دولي"
+
+#: id:14091
+msgid "Character set"
+msgstr "تعيين الأحرف"
+
+#: id:14092
+msgid "Debugging"
+msgstr "التصحيح"
+
+#: id:14093
+msgid "Security"
+msgstr "الأمن"
+
+#: id:14094
+msgid "Input devices"
+msgstr "أجهزة الإدخال"
+
+#: id:14095
+msgid "Power saving"
+msgstr "توفير الطاقة"
+
+#: id:14096
+msgid "Rip"
+msgstr ""
+
+#: id:14097
+msgid "Audio CD Insert Action"
+msgstr ""
+
+#: id:14098
+msgctxt "Auto context with id 14098"
+msgid "Play"
+msgstr ""
+
+#: id:14099
+msgid "Eject disc when CD ripping is complete"
+msgstr ""
+
+#: id:15015
+msgctxt "Auto context with id 15015"
+msgid "Remove"
+msgstr "إزالة"
+
+#: id:15016
+msgid "Games"
+msgstr "​​الألعاب"
+
+#: id:15019
+msgid "Add"
+msgstr "إضافة"
+
+#: id:15052
+msgid "Password"
+msgstr "كلمة المرور"
+
+#: id:15100
+msgctxt "Auto context with id 15100"
+msgid "Library"
+msgstr "المكتبة"
+
+#: id:15101
+msgid "Database"
+msgstr "قاعدة البيانات"
+
+#: id:15102
+msgid "* All albums"
+msgstr "* جميع الألبومات"
+
+#: id:15103
+msgid "* All artists"
+msgstr "* جميع الفنانين"
+
+#: id:15104
+msgid "* All songs"
+msgstr "* جميع الأغاني"
+
+#: id:15105
+msgid "* All genres"
+msgstr "* جميع الأنواع"
+
+#: id:15107
+msgid "Buffering..."
+msgstr "تخزين ..."
+
+#: id:15108
+msgid "Navigation sounds"
+msgstr "أصوات التنقل"
+
+#: id:15109
+msgid "Skin default"
+msgstr "الخلفية الافتراضي"
+
+#: id:15111
+msgid "- Theme"
+msgstr "السمات"
+
+#: id:15112
+msgid "Default theme"
+msgstr "السمة الافتراضية"
+
+#: id:15200
+msgid "Last.fm"
+msgstr "Last.fm"
+
+#: id:15201
+msgid "Submit songs to Last.fm"
+msgstr "Last.fm إرسال الأغاني إلى"
+
+#: id:15202
+msgid "Last.fm username"
+msgstr "Last.fm اسم مستخدم"
+
+#: id:15203
+msgid "Last.fm password"
+msgstr "Last.fm كلمة مرور"
+
+#: id:15204
+msgid "Unable to handshake: sleeping..."
+msgstr "يستعد :غير قادر للتبادل..."
+
+#: id:15205
+msgid "Please update XBMC"
+msgstr "XBMC يرجى تحديث"
+
+#: id:15206
+msgid "Bad authorization: Check username and password"
+msgstr "ترخيص سيئ: تحقق من اسم المستخدم وكلمة السر"
+
+#: id:15207
+msgctxt "Auto context with id 15207"
+msgid "Connected"
+msgstr "متصل"
+
+#: id:15208
+msgid "Not connected"
+msgstr "غير متصل"
+
+#: id:15209
+msgid "Submit interval %i"
+msgstr "%i إرسال التأخير"
+
+#: id:15210
+msgid "Cached %i songs"
+msgstr "الأغاني %i المخزنة مؤقتا"
+
+#: id:15211
+msgid "Submitting..."
+msgstr "إرسال..."
+
+#: id:15212
+msgid "Submitting in %i secs"
+msgstr "ثواني %i إرسال في"
+
+#: id:15213
+msgid "Play using..."
+msgstr "التشغيل باستخدام..."
+
+#: id:15214
+msgid "Use smoothed A/V synchronization"
+msgstr "ممهدة A/V استخدام مزامنة"
+
+#: id:15215
+msgid "Hide file names in thumbs view"
+msgstr "إخفاء أسماء الملف في عرض المصغرات"
+
+#: id:15216
+msgid "Play in party mode"
+msgstr "تشغيل في وضع الطرف"
+
+#: id:15217
+msgid "Submit songs to Libre.fm"
+msgstr "Libre.fm إرسال الأغاني إلى"
+
+#: id:15218
+msgid "Libre.fm username"
+msgstr "Libre.fm اسم مستخدم"
+
+#: id:15219
+msgid "Libre.fm password"
+msgstr "Libre.fm كلمة مرور"
+
+#: id:15220
+msgid "Libre.fm"
+msgstr ""
+
+#: id:15221
+msgid "Song submission"
+msgstr "إرسال الأغاني..."
+
+#: id:15250
+msgid "Submit Last.fm radio to Last.fm"
+msgstr "...Last.fm إلى إذاعة Last.fm إرسال"
+
+#: id:15251
+msgid "Connecting to Last.fm..."
+msgstr "Last.fm يتصل..."
+
+#: id:15252
+msgid "Selecting station..."
+msgstr "اختيار المحطة..."
+
+#: id:15253
+msgid "Search similar artists..."
+msgstr "البحث عن فنانين مماثلين..."
+
+#: id:15254
+msgid "Search similar tags..."
+msgstr "البحث عن شعارات مماثلة..."
+
+#: id:15255
+msgid "Your profile (%name%)"
+msgstr "(%name%) ملفك الشخصي"
+
+#: id:15256
+msgid "Overall top tags"
+msgstr "المراكز الأولى"
+
+#: id:15257
+msgid "Top artists for tag %name%"
+msgstr "%name% علامة أفضل المغنين"
+
+#: id:15258
+msgid "Top albums for tag %name%"
+msgstr "%name% علامة أفضل الألبومات"
+
+#: id:15259
+msgid "Top tracks for tag %name%"
+msgstr "%name% علامة أفضل المسارات"
+
+#: id:15260
+msgid "Listen to tag %name% Last.fm radio"
+msgstr "Last.fm في اذاعة %name% استمع الى علامة"
+
+#: id:15261
+msgid "Similar artists as %name%"
+msgstr "%name% فنانين ممثالين مثل"
+
+#: id:15262
+msgid "Top %name% albums"
+msgstr "البومات %name% أفضل"
+
+#: id:15263
+msgid "Top %name% tracks"
+msgstr "مسارات %name% أفضل"
+
+#: id:15264
+msgid "Top %name% tags"
+msgstr "شعارات %name% أفضل"
+
+#: id:15265
+msgid "Biggest fans of %name%"
+msgstr "%name% أكبر المعجبين من"
+
+#: id:15266
+msgid "Listen to %name% fans Last.fm radio"
+msgstr "Last.fm المعجبين في اذاعة %name% استمع الى"
+
+#: id:15267
+msgid "Listen to %name% similar artists Last.fm radio"
+msgstr "Last.fm فنانين مماثلين في اذاعة %name% استمع الى"
+
+#: id:15268
+msgid "Top artists for user %name%"
+msgstr "%name% أفضل الفنانين للمستخدم"
+
+#: id:15269
+msgid "Top albums for user %name%"
+msgstr "%name% أفضل الألبومات"
+
+#: id:15270
+msgid "Top tracks for user %name%"
+msgstr "%name% أفضل المسارات للمستخدم"
+
+#: id:15271
+msgid "Friends of user %name%"
+msgstr "%name% أصدقاء للمستخدم"
+
+#: id:15272
+msgid "Neighbours of user %name%"
+msgstr "%name% جيران للمستخدم"
+
+#: id:15273
+msgid "Weekly artist chart for %name%"
+msgstr "%name% خريطة الفنان الاسبوعية"
+
+#: id:15274
+msgid "Weekly album chart for %name%"
+msgstr "%name% خريطة الألبوم الاسبوعية"
+
+#: id:15275
+msgid "Weekly track chart for %name%"
+msgstr "%name% خريطة المسار الاسبوعية"
+
+#: id:15276
+msgid "Listen to %name%'s neighbours Last.fm radio"
+msgstr "Last.fm الجيران في اذاعة %name%'s استمع الى"
+
+#: id:15277
+msgid "Listen to %name%'s personal Last.fm radio"
+msgstr "Last.fm الشخصية في اذاعة %name%'s استمع الى"
+
+#: id:15278
+msgid "Listen to %name%'s mix Last.fm radio"
+msgstr "Last.fm ميكس في اذاعة %name%'s استمع الى"
+
+#: id:15279
+msgid "Retrieving list from Last.fm..."
+msgstr "Last.fm حصول القائمة من..."
+
+#: id:15280
+msgid "Can't retrieve list from Last.fm..."
+msgstr "Last.fm لا يمكن حصول القائمة من..."
+
+#: id:15281
+msgid "Enter an artist name to find related ones"
+msgstr "إدخال اسم فنان للعثورعلى افنانين مماثلين"
+
+#: id:15282
+msgid "Enter a tag name to find similar ones"
+msgstr "إدخال علامة للعثور على أغاني مشابهة"
+
+#: id:15283
+msgid "Tracks recently listened by %name%"
+msgstr "%name% اخر المسارات استمعت بواسطة"
+
+#: id:15284
+msgid "Listen to %name%'s recommendations Last.fm radio"
+msgstr "Last.fm التوصيات في اذاعة %name%'s استمع الى"
+
+#: id:15285
+msgid "Top tags for user %name%"
+msgstr ""
+
+#: id:15287
+msgid "Do you want to add the current track to your loved tracks?"
+msgstr "هل تريد إضافة القائمة الحالية للمسارات المفضلة؟"
+
+#: id:15288
+msgid "Do you want to ban the current track?"
+msgstr "هل تريد مقاطعة الأغنية الحالية؟"
+
+#: id:15289
+msgid "Added to your loved tracks: '%s'."
+msgstr ".'%s' أضيفت الى الأغاني المفضلة"
+
+#: id:15290
+msgid "Could not add '%s' to your loved tracks."
+msgstr ".لمساراتك المفضلة '%s' لا يمكن إضافة"
+
+#: id:15291
+msgid "Banned: '%s'."
+msgstr "'%s' :حظر"
+
+#: id:15292
+msgid "Could not ban '%s'."
+msgstr ".'%s' لا يمكن حظر"
+
+#: id:15293
+msgid "Tracks recently loved by %name%"
+msgstr "%name% اخر المسارات مفضلة بواسطة"
+
+#: id:15294
+msgid "Tracks recently banned by %name%"
+msgstr "%name% اخر المسارات حظرت بواسطة"
+
+#: id:15295
+msgid "Remove from loved tracks"
+msgstr "ازالة مة المسارات المفضلة"
+
+#: id:15296
+msgid "Un-ban"
+msgstr "الغاء الحظر"
+
+#: id:15297
+msgid "Do you want to remove this track from your loved tracks?"
+msgstr "هل تريد إزالة المسار من الأغاني المفضلة لديك؟"
+
+#: id:15298
+msgid "Do you want to un-ban this track?"
+msgstr "هل تريد إلغاء حظر الأغنية؟"
+
+#: id:15300
+msgid "Path not found or invalid"
+msgstr "لم يتم العثور على المسار أو غير صالح"
+
+#: id:15301
+msgid "Could not connect to network server"
+msgstr "لم يتم العثور على خادم"
+
+#: id:15302
+msgid "No servers found"
+msgstr "لم يتم العثور على الملقم"
+
+#: id:15303
+msgid "Workgroup not found"
+msgstr "لم يتم العثورعلى مجموعة العمل"
+
+#: id:15310
+msgid "Opening multi-path source"
+msgstr "جاري فتح مصدر متعدد المسارات"
+
+#: id:15311
+msgid "Path:"
+msgstr ":المسار"
+
+#: id:16000
+msgctxt "Auto context with id 16000"
+msgid "General"
+msgstr "عام"
+
+#: id:16002
+msgid "Internet lookup"
+msgstr "بحث الويب"
+
+#: id:16003
+msgid "Player"
+msgstr "المشغل"
+
+#: id:16004
+msgid "Play media from disc"
+msgstr "تشغيل الوسائط من القرص"
+
+#: id:16008
+msgid "Enter new title"
+msgstr "إدخال عنوان جديد"
+
+#: id:16009
+msgid "Enter the movie name"
+msgstr "أدخل اسم الفلم"
+
+#: id:16010
+msgid "Enter the profile name"
+msgstr "أدخل لسم ملفك الشخصي"
+
+#: id:16011
+msgid "Enter the album name"
+msgstr "أدخل اسم الألبوم"
+
+#: id:16012
+msgid "Enter the playlist name"
+msgstr "أدخل اسم قائمة التشغيل"
+
+#: id:16013
+msgid "Enter new filename"
+msgstr "أدخل اسم الملف الجديد"
+
+#: id:16014
+msgid "Enter folder name"
+msgstr "أدخل اسم المجلد"
+
+#: id:16015
+msgid "Enter directory"
+msgstr "أدخل الدليل"
+
+#: id:16016
+msgid "Available options: %A, %T, %N, %B, %D, %G, %Y, %F, %S"
+msgstr "%A, %T, %N, %B, %D, %G, %Y, %F, %S الخيارات المتاحة:"
+
+#: id:16017
+msgid "Enter search string"
+msgstr "أدخل نص البحث"
+
+#: id:16018
+msgctxt "Auto context with id 16018"
+msgid "None"
+msgstr "بلا"
+
+#: id:16019
+msgid "Auto select"
+msgstr "اختيار تلقائي"
+
+#: id:16020
+msgid "De-interlace"
+msgstr "تشابك"
+
+#: id:16021
+msgid "Bob"
+msgstr "بوب"
+
+#: id:16022
+msgid "Bob (inverted)"
+msgstr "بوب مزدوج"
+
+#: id:16024
+msgid "Canceling..."
+msgstr "يلغي..."
+
+#: id:16025
+msgid "Enter the artist name"
+msgstr "أدخل اسم الفنان"
+
+#: id:16026
+msgid "Playback failed"
+msgstr "فشل القراءة"
+
+#: id:16027
+msgid "One or more items failed to play."
+msgstr "فشل قراءة عنصر واحد أو أكثر"
+
+#: id:16028
+msgid "Enter value"
+msgstr "إدخال قيمة"
+
+#: id:16029
+msgid "Check the log file for details."
+msgstr "سجل التحقق"
+
+#: id:16030
+msgid "Party mode aborted."
+msgstr "تم إلغاء وضع الطرف"
+
+#: id:16031
+msgid "No matching songs in the library."
+msgstr ".لا توجد أغاني مطابقة في المكتبة"
+
+#: id:16032
+msgid "Could not initialize database."
+msgstr "لم يتمكن من تهيئة قاعدة بيانات"
+
+#: id:16033
+msgid "Could not open database."
+msgstr ".لم يتمكن من فتح قاعدة بيانات"
+
+#: id:16034
+msgid "Could not get songs from database."
+msgstr "لم يتمكن الحصول على الأغاني من قاعدة البيانات"
+
+#: id:16035
+msgid "Party mode playlist"
+msgstr "قائمة تشغيل وضع الطرف"
+
+#: id:16036
+msgid "De-interlace (Half)"
+msgstr ""
+
+#: id:16037
+msgid "Deinterlace video"
+msgstr ""
+
+#: id:16038
+msgid "Deinterlace method"
+msgstr ""
+
+#: id:16039
+msgctxt "Auto context with id 16039"
+msgid "Off"
+msgstr "معطلة"
+
+#: id:16040
+msgctxt "Auto context with id 16040"
+msgid "Auto"
+msgstr "التلقائية"
+
+#: id:16041
+msgid "On"
+msgstr "النشطة"
+
+#: id:16100
+msgid "All Videos"
+msgstr "كل الفيديو"
+
+#: id:16101
+msgid "Unwatched"
+msgstr "غير مشاهدة"
+
+#: id:16102
+msgid "Watched"
+msgstr "شوهدت"
+
+#: id:16103
+msgid "Mark as watched"
+msgstr "أشر إليها على أنها شوهدت"
+
+#: id:16104
+msgid "Mark as unwatched"
+msgstr "أشر إليها على أنها لم تشاهد"
+
+#: id:16105
+msgid "Edit title"
+msgstr "تحرير عنوان"
+
+#: id:16200
+msgid "Operation was aborted"
+msgstr "تم إحباط التشغيل"
+
+#: id:16201
+msgid "Copy failed"
+msgstr "فشل النسخ"
+
+#: id:16202
+msgid "Failed to copy at least one file"
+msgstr "فشل في نسخ ملف واحد على الأقل"
+
+#: id:16203
+msgid "Move failed"
+msgstr "فشل النقل"
+
+#: id:16204
+msgid "Failed to move at least one file"
+msgstr "فشل في نقل ملف واحد على الأقل"
+
+#: id:16205
+msgid "Delete failed"
+msgstr "فشل الحذف"
+
+#: id:16206
+msgid "Failed to delete at least one file"
+msgstr "فشل في حذف ملف واحد على الأقل"
+
+#: id:16300
+msgid "Video scaling method"
+msgstr ""
+
+#: id:16301
+msgid "Nearest neighbour"
+msgstr ""
+
+#: id:16302
+msgid "Bilinear"
+msgstr ""
+
+#: id:16303
+msgctxt "Auto context with id 16303"
+msgid "Bicubic"
+msgstr ""
+
+#: id:16304
+msgid "Lanczos2"
+msgstr ""
+
+#: id:16305
+msgid "Lanczos3"
+msgstr ""
+
+#: id:16306
+msgid "Sinc8"
+msgstr ""
+
+#: id:16307
+msgid "Bicubic (software)"
+msgstr ""
+
+#: id:16308
+msgid "Lanczos (software)"
+msgstr ""
+
+#: id:16309
+msgid "Sinc (software)"
+msgstr ""
+
+#: id:16310
+msgid "Temporal"
+msgstr ""
+
+#: id:16311
+msgid "Temporal/Spatial"
+msgstr ""
+
+#: id:16312
+msgid "(VDPAU)Noise Reduction"
+msgstr ""
+
+#: id:16313
+msgid "(VDPAU)Sharpness"
+msgstr ""
+
+#: id:16314
+msgid "Inverse Telecine"
+msgstr ""
+
+#: id:16315
+msgid "Lanczos3 optimized"
+msgstr ""
+
+#: id:16316
+msgctxt "Auto context with id 16316"
+msgid "Auto"
+msgstr ""
+
+#: id:16317
+msgid "Temporal (Half)"
+msgstr ""
+
+#: id:16318
+msgid "Temporal/Spatial (Half)"
+msgstr ""
+
+#: id:16319
+msgid "DXVA"
+msgstr ""
+
+#: id:16320
+msgid "DXVA Bob"
+msgstr ""
+
+#: id:16321
+msgid "DXVA Best"
+msgstr ""
+
+#: id:16322
+msgid "Spline36"
+msgstr ""
+
+#: id:16323
+msgid "Spline36 optimized"
+msgstr ""
+
+#: id:16324
+msgid "Software Blend"
+msgstr ""
+
+#: id:16400
+msgid "Post-processing"
+msgstr ""
+
+#: id:17500
+msgid "Display sleep timeout"
+msgstr ""
+
+#: id:19000
+msgid "Switch to channel"
+msgstr "تبديل الى القناة"
+
+#: id:20000
+msgid "Saved music folder"
+msgstr "مجلد موسيقى محفوظ"
+
+#: id:20001
+msgid "Use external DVD player"
+msgstr "استخدم مشغل دي في دي خارجي"
+
+#: id:20002
+msgid "External DVD player"
+msgstr "الخارجية لاعب دي في دي"
+
+#: id:20003
+msgid "Trainers folder"
+msgstr "مجلد المربين"
+
+#: id:20004
+msgid "Screenshot folder"
+msgstr "مجلد لقطات الشاشة"
+
+#: id:20006
+msgid "Playlists folder"
+msgstr "مجلد قوائم التشغيل"
+
+#: id:20007
+msgid "Recordings"
+msgstr "التسجيلات"
+
+#: id:20008
+msgid "Screenshots"
+msgstr "اللقطات"
+
+#: id:20009
+msgid "Use XBMC"
+msgstr "XBMC استخدام"
+
+#: id:20011
+msgid "Music playlists"
+msgstr "قوائم تشغيل الموسيقى"
+
+#: id:20012
+msgid "Video playlists"
+msgstr "قوائم تشغيل الفيديو"
+
+#: id:20013
+msgid "Do you wish to launch the game?"
+msgstr "هل تريد تشغيل اللعبة؟"
+
+#: id:20014
+msgid "Sort by: Playlist"
+msgstr "ترتيب حسب: قائمة التشغيل"
+
+#: id:20015
+msgid "Remote thumb"
+msgstr "ريموت المصغرة"
+
+#: id:20016
+msgid "Current thumb"
+msgstr "​​المصغرة الحالية"
+
+#: id:20017
+msgid "Local thumb"
+msgstr "المحلية المصغرة"
+
+#: id:20018
+msgid "No thumb"
+msgstr "المصغرة الحرة"
+
+#: id:20019
+msgid "Choose thumbnail"
+msgstr "حدد صورة مصغرة"
+
+#: id:20023
+msgid "Conflict"
+msgstr "التناقض"
+
+#: id:20024
+msgid "Scan new"
+msgstr "تفحص الجديد"
+
+#: id:20025
+msgid "Scan all"
+msgstr "تفحص كافة"
+
+#: id:20026
+msgid "Region"
+msgstr "المنطقة"
+
+#: id:20037
+msgid "Summary"
+msgstr "الملخص"
+
+#: id:20038
+msgid "Lock music window"
+msgstr "قفل نافذة الموسيقى"
+
+#: id:20039
+msgid "Lock videos window"
+msgstr "قفل نافذة الفيديو"
+
+#: id:20040
+msgid "Lock pictures window"
+msgstr "قفل نافذة الصور"
+
+#: id:20041
+msgid "Lock programs & scripts windows"
+msgstr "قفل نافذة البرامج والبرامج النصية"
+
+#: id:20042
+msgid "Lock file manager"
+msgstr "قفل إدارة الملف"
+
+#: id:20043
+msgid "Lock settings"
+msgstr "إعدادات القفل"
+
+#: id:20044
+msgid "Start fresh"
+msgstr "البدء من جديد"
+
+#: id:20045
+msgid "Enter master mode"
+msgstr "إدخال إلى الوضع الرئيسي"
+
+#: id:20046
+msgid "Leave master mode"
+msgstr "إنهاء الوضع الرئيسي"
+
+#: id:20047
+msgid "Create profile '%s'?"
+msgstr "؟ '% s' إنشاء ملف"
+
+#: id:20048
+msgid "Start with fresh settings"
+msgstr "ابدأ مع الإعدادات الجديدة"
+
+#: id:20049
+msgid "Best available"
+msgstr "أفضل المتوفر"
+
+#: id:20050
+msgid "Auto-switch between 16x9 and 4x3"
+msgstr "4x3 and 16x3 التبديل تلقائيا بين"
+
+#: id:20051
+msgid "Treat stacked files as single file"
+msgstr "تعامل مع الملفات المكدسة كملف واحد"
+
+#: id:20052
+msgid "Caution"
+msgstr "حذر"
+
+#: id:20053
+msgid "Left master mode"
+msgstr "غادر الوضع الرئيسي"
+
+#: id:20054
+msgid "Entered master mode"
+msgstr "في الوضع الرئيسي"
+
+#: id:20055
+msgid "Allmusic.com thumb"
+msgstr "Allmusic.com مصغرة"
+
+#: id:20057
+msgid "Remove thumbnail"
+msgstr "إزالة الصورة المصغرة"
+
+#: id:20058
+msgid "Add profile..."
+msgstr "أضف ملف شخصي..."
+
+#: id:20059
+msgid "Query info for all albums"
+msgstr "استعلام معلومات جميع الألبومات"
+
+#: id:20060
+msgctxt "Auto context with id 20060"
+msgid "Media info"
+msgstr "معلومات الوسائط"
+
+#: id:20061
+msgctxt "Auto context with id 20061"
+msgid "Separate"
+msgstr "فصل"
+
+#: id:20062
+msgid "Shares with default"
+msgstr "مساهمة افتراضية"
+
+#: id:20063
+msgid "Shares with default (read only)"
+msgstr "مساهمة افتراضية (للقراءة فقط)"
+
+#: id:20064
+msgid "Copy default"
+msgstr "نسخ الافتراضية"
+
+#: id:20065
+msgid "Profile picture"
+msgstr "الصورة الشخصية"
+
+#: id:20066
+msgid "Lock preferences"
+msgstr "قفل التفضيلات"
+
+#: id:20067
+msgid "Edit profile"
+msgstr "تحرير الملف الشخصي"
+
+#: id:20068
+msgid "Profile lock"
+msgstr "قفل الملف الشخصي"
+
+#: id:20069
+msgid "Could not create folder"
+msgstr "لا يتمكن من إنشاء المجلد"
+
+#: id:20070
+msgid "Profile directory"
+msgstr "دليل الملف الملف الشخصي"
+
+#: id:20071
+msgid "Start with fresh media sources"
+msgstr "ابدأ مع مصادر الوسائط الجديدة"
+
+#: id:20072
+msgid "Make sure the selected folder is writable"
+msgstr "تأكد من أن المجلد المحدد قابل للكتابة"
+
+#: id:20073
+msgid "and that the new folder name is valid"
+msgstr "وأن اسم المجلد الجديد صالحا"
+
+#: id:20074
+msgid "MPAA rating"
+msgstr ":MPAA تصنيف"
+
+#: id:20075
+msgid "Enter master lock code"
+msgstr "إدخال رمز القفل الرئيسي عند بداية التشغيل"
+
+#: id:20076
+msgid "Ask for master lock code on startup"
+msgstr "اطلب رمز القفل الرئيسي عند بداية التشغيل"
+
+#: id:20077
+msgid "Skin settings"
+msgstr "إعدادات الخلفية"
+
+#: id:20078
+msgid "- no link set -"
+msgstr "- لم يتم تعيين الارتباط -"
+
+#: id:20079
+msgid "Enable animations"
+msgstr "تمكين الصور المتحركة"
+
+#: id:20080
+msgid "Disable RSS during music"
+msgstr "أثناء الموسيقى RSS إيقاف الموسيقى"
+
+#: id:20081
+msgid "Enable shortcut buttons"
+msgstr "تمكين اختصارات الأزرار"
+
+#: id:20082
+msgid "Show programs in main menu"
+msgstr "عرض البرامج في القائمة الرئيسية"
+
+#: id:20083
+msgid "Show music info"
+msgstr "عرض معلومات الموسيقى"
+
+#: id:20084
+msgid "Show weather info"
+msgstr "عرض معلومات الطقس"
+
+#: id:20085
+msgid "Show system info"
+msgstr "عرض نظام عرض المعلومات"
+
+#: id:20086
+msgid "Show available disc space C: E: F:"
+msgstr "C : E : F : عرض المساحة الحرة على الأقراص"
+
+#: id:20087
+msgid "Show available disc space E: F: G:"
+msgstr "E : F : G : عرض المساحة الحرة على الأقراص"
+
+#: id:20088
+msgid "Weather info"
+msgstr "معلومات الطقس"
+
+#: id:20089
+msgid "Drive space free"
+msgstr "مساحة القرص الحرة"
+
+#: id:20090
+msgid "Enter the name of an existing share"
+msgstr "أدخل اسم لمشاركة موجودة"
+
+#: id:20091
+msgid "Lock code"
+msgstr "رمز القفل"
+
+#: id:20092
+msgid "Load profile"
+msgstr "تحميل الملف الشخصي"
+
+#: id:20093
+msgid "Profile name"
+msgstr "اسم الملف الشخصي"
+
+#: id:20094
+msgctxt "Auto context with id 20094"
+msgid "Media sources"
+msgstr "مصادر الوسائط"
+
+#: id:20095
+msgid "Enter profile lock code"
+msgstr "إدخال رمز قفل الملف الشخصي"
+
+#: id:20096
+msgctxt "Auto context with id 20096"
+msgid "Login screen"
+msgstr "شاشة الدخول"
+
+#: id:20097
+msgid "Fetching album info"
+msgstr "الحصول على معلومات الألبوم"
+
+#: id:20098
+msgid "Fetching info for album"
+msgstr "الحصول على معلومات عن الألبوم"
+
+#: id:20099
+msgid "Can't rip CD or track while playing from CD"
+msgstr "لا يمكن نسخ القرص أو المسار أثناء القراءة من القرص"
+
+#: id:20100
+msgid "Master lock code and settings"
+msgstr "رمز القفل الرئيسي والإعدادت"
+
+#: id:20101
+msgid "Entering master lock code always enables master mode"
+msgstr "إدخال رمز القفل الرئيسي يسمح الوضع الرئيسي دائما"
+
+#: id:20102
+msgid "or copy from default?"
+msgstr "أو نسخ افتراضيا؟"
+
+#: id:20103
+msgid "Save changes to profile?"
+msgstr "حفظ التغييرات إلى ملف الشخصي؟"
+
+#: id:20104
+msgid "Old settings found."
+msgstr ".الإعدادات القديمة وجدت"
+
+#: id:20105
+msgid "Do you want to use them?"
+msgstr "هل تريد استخدامها؟"
+
+#: id:20106
+msgid "Old media sources found."
+msgstr "مصادر وسائط قديمة وجدت"
+
+#: id:20107
+msgid "Separate (locked)"
+msgstr "فصل (مقفلة)"
+
+#: id:20108
+msgid "Root"
+msgstr "الجذر"
+
+#: id:20109
+msgid "- Zoom"
+msgstr "التكبير"
+
+#: id:20110
+msgid "UPnP settings"
+msgstr "UPnP إعدادات"
+
+#: id:20111
+msgid "Autostart UPnP client"
+msgstr "تلقائي UPnP تشغيل عميل"
+
+#: id:20112
+msgid "Last login: %s"
+msgstr "%s :آخر تسجيل دخول"
+
+#: id:20113
+msgid "Never logged on"
+msgstr "لم يتم تسجيل دخول"
+
+#: id:20114
+msgid "Profile %i / %i"
+msgstr "%i / %i الملف الشخصي"
+
+#: id:20115
+msgid "User login / Select a profile"
+msgstr "تسجيل دخول مستخدم / اختيار ملف شخصي"
+
+#: id:20116
+msgid "Use lock on login screen"
+msgstr "استخدام القفل على شاشة تسجيل الدخول"
+
+#: id:20117
+msgid "Invalid lock code."
+msgstr "رمز القفل غير صحيح"
+
+#: id:20118
+msgid "This requires the master lock to be set."
+msgstr "هذا يتطلب رمز القفل الرئيسي لتمكين التعيين"
+
+#: id:20119
+msgid "Would you like to set it now?"
+msgstr "هل تريد تعيينها الآن؟"
+
+#: id:20120
+msgid "Loading program information"
+msgstr "تحميل معلومات البرنامج"
+
+#: id:20121
+msgid "Party on!"
+msgstr "! الطرف"
+
+#: id:20122
+msgid "True"
+msgstr "صحيح"
+
+#: id:20123
+msgid "Mixing drinks"
+msgstr "خلط المشروبات"
+
+#: id:20124
+msgid "Filling glasses"
+msgstr "ملء الأكواب"
+
+#: id:20125
+msgid "Logged on as"
+msgstr "تسجيل الدخو بإسم"
+
+#: id:20126
+msgid "Log off"
+msgstr "تسجيل الخروج"
+
+#: id:20128
+msgid "Go to root"
+msgstr "اذهب الى الجذر"
+
+#: id:20129
+msgid "Weave"
+msgstr "نسج"
+
+#: id:20130
+msgid "Weave (inverted)"
+msgstr "نسج (مقلوب)"
+
+#: id:20131
+msgid "Blend"
+msgstr "توليف"
+
+#: id:20132
+msgid "Restart video"
+msgstr "إعادة تشغيل الفيديو"
+
+#: id:20133
+msgid "Edit network location"
+msgstr "تحرير موقع الشبكة"
+
+#: id:20134
+msgid "Remove network location"
+msgstr "إزالة موقع الشبكة"
+
+#: id:20135
+msgid "Do you want to scan the folder?"
+msgstr "هل تريد أن تفحص المجلد؟"
+
+#: id:20136
+msgid "Memory unit"
+msgstr "وحدة ذاكرة"
+
+#: id:20137
+msgid "Memory unit mounted"
+msgstr "وحدة الذاكرة جاهزة للاستخدام"
+
+#: id:20138
+msgid "Unable to mount memory unit"
+msgstr "غير قادر على تحميل وحدة الذاكرة"
+
+#: id:20139
+msgid "In port %i, slot %i"
+msgstr "%i الفتحة ,%i في المنفذ"
+
+#: id:20140
+msgid "Lock screensaver"
+msgstr "قفل الشاشة المؤقتة"
+
+#: id:20141
+msgid "Set"
+msgstr "تعيين"
+
+#: id:20142
+msgctxt "Auto context with id 20142"
+msgid "Username"
+msgstr "اسم المستخدم"
+
+#: id:20143
+msgid "Enter password for"
+msgstr "أدخل كلمة المرور لـ"
+
+#: id:20144
+msgid "Shutdown timer"
+msgstr "مؤقت الإغلاق"
+
+#: id:20145
+msgid "Shutdown interval (in minutes)"
+msgstr "إغلاق (في دقائق)"
+
+#: id:20146
+msgid "Started, shutdown in %im"
+msgstr "%im بدأت, أغلقت في"
+
+#: id:20147
+msgid "Shutdown in 30 minutes"
+msgstr "إيقاف في 30 دقيقة"
+
+#: id:20148
+msgid "Shutdown in 60 minutes"
+msgstr "إيقاف في 60 دقيقة"
+
+#: id:20149
+msgid "Shutdown in 120 minutes"
+msgstr "إيقاف في 120 دقيقة"
+
+#: id:20150
+msgid "Custom shutdown timer"
+msgstr "مؤقت إغلاق مخصص"
+
+#: id:20151
+msgid "Cancel shutdown timer"
+msgstr "إلغاء مؤقت الإغلاق"
+
+#: id:20152
+msgid "Lock preferences for %s"
+msgstr "%s قفل التفضيلات لـ"
+
+#: id:20153
+msgid "Browse..."
+msgstr "استعراض..."
+
+#: id:20154
+msgid "Summary information"
+msgstr "معلومات الملخص"
+
+#: id:20155
+msgid "Storage information"
+msgstr "معلومات التخزين"
+
+#: id:20156
+msgid "Hard disk information"
+msgstr "معلومات القرص الصلب"
+
+#: id:20157
+msgid "DVD-ROM information"
+msgstr "DVD-ROM معلومات محرك الأقراص"
+
+#: id:20158
+msgid "Network information"
+msgstr "معلومات الشبكة"
+
+#: id:20159
+msgid "Video information"
+msgstr "معلومات الفيديو"
+
+#: id:20160
+msgid "Hardware information"
+msgstr "معلومات الجهاز"
+
+#: id:20161
+msgid "Total"
+msgstr "المجموع"
+
+#: id:20162
+msgid "Used"
+msgstr "المستخدمة"
+
+#: id:20163
+msgid "of"
+msgstr "من"
+
+#: id:20164
+msgid "Locking not supported"
+msgstr "القفل غير معتمد"
+
+#: id:20165
+msgid "Not locked"
+msgstr "غير مقفل"
+
+#: id:20166
+msgid "Locked"
+msgstr "مقفل"
+
+#: id:20167
+msgid "Frozen"
+msgstr "مجمدة"
+
+#: id:20168
+msgid "Requires reset"
+msgstr "يتطلب إعادة"
+
+#: id:20169
+msgid "Week"
+msgstr "الاسبوع"
+
+#: id:20170
+msgid "Line"
+msgstr "الصف"
+
+#: id:20171
+msgid "Windows network (SMB)"
+msgstr "(SMB) شبكة النوافذ"
+
+#: id:20172
+msgid "XBMSP server"
+msgstr "XBMSP خادم"
+
+#: id:20173
+msgctxt "Auto context with id 20173"
+msgid "FTP server"
+msgstr "FTP خادم"
+
+#: id:20174
+msgid "iTunes music share (DAAP)"
+msgstr "(DAAP) مشاركة موسيقى الايتونز"
+
+#: id:20175
+msgid "UPnP server"
+msgstr "خادم UPnP"
+
+#: id:20176
+msgid "Show video info"
+msgstr "عرض معلومات الفيديو"
+
+#: id:20177
+msgid "Done"
+msgstr "إنهاء"
+
+#: id:20178
+msgid "Shift"
+msgstr "تغير"
+
+#: id:20179
+msgid "Caps Lock"
+msgstr "أحرف كبيرة"
+
+#: id:20180
+msgid "Symbols"
+msgstr "الرموز"
+
+#: id:20181
+msgid "Backspace"
+msgstr "مسافة للخلف"
+
+#: id:20182
+msgid "Space"
+msgstr "مسافة"
+
+#: id:20183
+msgid "Reload skin"
+msgstr "إعادة تحميل الخلفية"
+
+#: id:20184
+msgid "Rotate pictures using EXIF information"
+msgstr "EXIF استدارة الصور باستخدام معلومات ​​"
+
+#: id:20185
+msgid "Use poster view styles for TV shows"
+msgstr "استخدام أنماط عرض الملصقات للبرامج التلفزيونية"
+
+#: id:20186
+msgid "Please wait"
+msgstr "الرجاء الانتظار"
+
+#: id:20187
+msgid "UPnP"
+msgstr ""
+
+#: id:20189
+msgid "Enable auto scrolling for plot & review"
+msgstr "تمكين التمرير التلقائي للحوار والمراجعة"
+
+#: id:20190
+msgctxt "Auto context with id 20190"
+msgid "Custom"
+msgstr "مخصص"
+
+#: id:20191
+msgid "Enable debug logging"
+msgstr "تمكين تسجيل التصحيح"
+
+#: id:20192
+msgid "Download additional information during updates"
+msgstr "تنزيل معلومات إضافية اثناء التحديثات"
+
+#: id:20193
+msgid "Default service for album information"
+msgstr "الخدمة الافتراضية لمعلومات الألبوم"
+
+#: id:20194
+msgid "Default service for artist information"
+msgstr "الخدمة الافتراضية لمعلومات الفنان"
+
+#: id:20195
+msgid "Change scraper"
+msgstr "تغير المكشطه"
+
+#: id:20196
+msgid "Export music library"
+msgstr "تصدير مكتبة الموسيقى..."
+
+#: id:20197
+msgid "Import music library"
+msgstr "استيراد مكتبة الموسيقى..."
+
+#: id:20198
+msgid "No artist found!"
+msgstr "!لم يتم العثور على الفنان"
+
+#: id:20199
+msgid "Downloading artist info failed"
+msgstr "فشل تحميل معلومات الفنان"
+
+#: id:20250
+msgid "Party on! (videos)"
+msgstr "هناك طرفا! (فيديو)"
+
+#: id:20251
+msgid "Mixing drinks (videos)"
+msgstr "خلط المشروبات (فيديو)"
+
+#: id:20252
+msgid "Filling glasses (videos)"
+msgstr "ملء أكواب (فيديو)"
+
+#: id:20253
+msgid "WebDAV server (HTTP)"
+msgstr ""
+
+#: id:20254
+msgid "WebDAV server (HTTPS)"
+msgstr ""
+
+#: id:20255
+msgid "First logon, edit your profile"
+msgstr ""
+
+#: id:20256
+msgid "HTS Tvheadend client"
+msgstr ""
+
+#: id:20257
+msgid "VDR Streamdev client"
+msgstr ""
+
+#: id:20258
+msgid "MythTV client"
+msgstr ""
+
+#: id:20259
+msgid "Network Filesystem (NFS)"
+msgstr ""
+
+#: id:20260
+msgid "Secure Shell (SSH/SFTP)"
+msgstr ""
+
+#: id:20261
+msgid "Apple Filing Protocol (AFP)"
+msgstr ""
+
+#: id:20300
+msgid "Web server directory (HTTP)"
+msgstr "(HTTP) دليل خادم الويب"
+
+#: id:20301
+msgid "Web server directory (HTTPS)"
+msgstr "(HTTPS) دليل خادم الويب"
+
+#: id:20302
+msgid "Unable to write to folder:"
+msgstr ":لايمكن الكتابة إلى المجلد"
+
+#: id:20303
+msgid "Do you want to skip and proceed?"
+msgstr "هل تريد أن تتخطى وتذهب؟"
+
+#: id:20304
+msgid "RSS Feed"
+msgstr ""
+
+#: id:20307
+msgid "Secondary DNS"
+msgstr "Secondary DNS"
+
+#: id:20308
+msgid "DHCP server:"
+msgstr ":DHCP خادم"
+
+#: id:20309
+msgid "Make new folder"
+msgstr "انشأ مجلد جديد"
+
+#: id:20310
+msgid "Dim LCD on playback"
+msgstr "عند التشغيل LCD تبهيت"
+
+#: id:20311
+msgid "Unknown or onboard (protected)"
+msgstr "غير معروف أو على لوحة (محمية)"
+
+#: id:20312
+msgid "Dim LCD on paused"
+msgstr "عند التوقف LCD تبهيت"
+
+#: id:20314
+msgid "Videos - Library"
+msgstr "الفيديو - المكتبة"
+
+#: id:20316
+msgid "Sort by: ID"
+msgstr "ترتيب بواسطة: اسم المستخدم"
+
+#: id:20324
+msgid "Play part..."
+msgstr "تشغيل جزء..."
+
+#: id:20325
+msgid "Calibration reset"
+msgstr "إعادة المعايرة"
+
+#: id:20326
+msgid "This will reset the calibration values for %s"
+msgstr "%s هذا سوف يعين معايرة القيم لـ"
+
+#: id:20327
+msgid "to it's default values."
+msgstr "القيم الافتراضية الخاصة به"
+
+#: id:20328
+msgid "Browse for destination"
+msgstr "استعراض للموقع"
+
+#: id:20329
+msgid "Movies are in separate folders that match the movie title"
+msgstr ""
+
+#: id:20330
+msgid "Use folder names for lookups"
+msgstr "استخدام أسماء المجلد للبحث"
+
+#: id:20331
+msgctxt "Auto context with id 20331"
+msgid "File"
+msgstr "المجلد"
+
+#: id:20332
+msgid "Use file or folder names in lookups?"
+msgstr "استخدام أسماء ملف أو مجلد؟"
+
+#: id:20333
+msgid "Set content"
+msgstr "تعيين المحتوى"
+
+#: id:20334
+msgid "Folder"
+msgstr "مجلد"
+
+#: id:20335
+msgid "Look for content recursively?"
+msgstr "بحث المحتوى المتكرر؟"
+
+#: id:20336
+msgid "Unlock sources"
+msgstr "فتح مصادر"
+
+#: id:20337
+msgid "Actor"
+msgstr "الممثل"
+
+#: id:20338
+msgid "Movie"
+msgstr "الفيلم"
+
+#: id:20339
+msgid "Director"
+msgstr "المخرج"
+
+#: id:20340
+msgid "Do you want to remove all items within"
+msgstr "هل تريد إزالة كافة المعلومات الموجودة في"
+
+#: id:20341
+msgid "this path from the XBMC library?"
+msgstr "؟XBMC هذا المسار من مكتبة"
+
+#: id:20342
+msgctxt "Auto context with id 20342"
+msgid "Movies"
+msgstr "الأفلام"
+
+#: id:20343
+msgid "TV shows"
+msgstr "البرامج التلفزيونية"
+
+#: id:20344
+msgid "This directory contains"
+msgstr "هذا الدليل يحتوي"
+
+#: id:20345
+msgid "Run automated scan"
+msgstr "تشغيل الفحص الآلي"
+
+#: id:20346
+msgid "Scan recursively"
+msgstr "فحص متكرر"
+
+#: id:20347
+msgid "as"
+msgstr "مثل"
+
+#: id:20348
+msgid "Directors"
+msgstr "المخرجين"
+
+#: id:20349
+msgid "No video files found in this path!"
+msgstr "!لاتوجد ملفات فيديو في هذا المسار"
+
+#: id:20350
+msgid "votes"
+msgstr "الأصوات"
+
+#: id:20351
+msgid "TV show information"
+msgstr "معلومات البرامج التلفزيونية"
+
+#: id:20352
+msgid "Episode information"
+msgstr "معلومات الحلقة"
+
+#: id:20353
+msgid "Loading TV show details"
+msgstr "تحميل تفاصيل البرنامج التلفزيوني"
+
+#: id:20354
+msgid "Fetching episode guide"
+msgstr "استيراد دليل الحلقة"
+
+#: id:20355
+msgid "Loading info for episodes in directory"
+msgstr "تحميل معلومات الحلقة في الدليل"
+
+#: id:20356
+msgid "Select TV show:"
+msgstr ":اختر البرنامج التلفزيوني"
+
+#: id:20357
+msgid "Enter the TV show name"
+msgstr "إدراج اسم البرنامج التلفزيوني"
+
+#: id:20358
+msgid "Season %i"
+msgstr "%i الفصل"
+
+#: id:20359
+msgid "Episode"
+msgstr "الحلقة"
+
+#: id:20360
+msgid "Episodes"
+msgstr "الحلقات"
+
+#: id:20361
+msgid "Loading episode details"
+msgstr "تحميل تفاصيل الحلقة"
+
+#: id:20362
+msgid "Remove episode from library"
+msgstr "إزالة الحلقة من المكتبة"
+
+#: id:20363
+msgid "Remove TV show from library"
+msgstr "إزالة البرنامج التلفزيوني من المكتبة"
+
+#: id:20364
+msgid "TV show"
+msgstr "البرنامج التلفزيوني"
+
+#: id:20365
+msgid "Episode plot"
+msgstr "محور الحلقة"
+
+#: id:20366
+msgid "* All seasons"
+msgstr "* جميع الفصول"
+
+#: id:20367
+msgid "Hide watched"
+msgstr "إخفاء المشاهدات"
+
+#: id:20368
+msgid "Prod code"
+msgstr "رمز الانتاج"
+
+#: id:20369
+msgid "Show plot for unwatched items"
+msgstr "اظهار حوار العناصر الغير مشاهدة"
+
+#: id:20370
+msgid "* Hidden to prevent spoilers *"
+msgstr "*مخفية لمنع المتطفلين*"
+
+#: id:20371
+msgid "Set season thumb"
+msgstr "تعيين مصغرة للفصل"
+
+#: id:20372
+msgid "Season image"
+msgstr "صورة الفصل"
+
+#: id:20373
+msgid "Season"
+msgstr "الفصل"
+
+#: id:20374
+msgid "Downloading movie information"
+msgstr "تحميل معلومات الفيلم"
+
+#: id:20375
+msgid "Unassign content"
+msgstr "محتوى غير مخصص"
+
+#: id:20376
+msgid "Original title"
+msgstr "العنوان الأصلي"
+
+#: id:20377
+msgid "Refresh TV show information"
+msgstr "تحديث معلومات البرنامج تلفزيوني"
+
+#: id:20378
+msgid "Refresh info for all episodes?"
+msgstr "تحديث المعلومات لجميع الحلقات؟"
+
+#: id:20379
+msgid "Selected folder contains a single TV show"
+msgstr "المجلد المحدد يحتوي على برنامج تلفزيوني واحد"
+
+#: id:20380
+msgid "Exclude selected folder from scans"
+msgstr "استبعاد المجلد المحدد من الفحص"
+
+#: id:20381
+msgid "Specials"
+msgstr "العروض الخاصة"
+
+#: id:20382
+msgid "Automatically grab season thumbs"
+msgstr "تحميل مصغرات الفصل تلقائي"
+
+#: id:20383
+msgid "Selected folder contains a single video"
+msgstr "المجلد المحدد يحتوي على فيديو واحد"
+
+#: id:20384
+msgid "Link to TV show"
+msgstr "ربط إلى البرنامج التلفزيوني"
+
+#: id:20385
+msgid "Remove link to TV show"
+msgstr "إزالة الربط من البرنامج التلفزيوني"
+
+#: id:20386
+msgid "Recently added movies"
+msgstr "أفلام أضيفت مؤخراً"
+
+#: id:20387
+msgid "Recently added episodes"
+msgstr "حلقات أضيفت مؤخراً"
+
+#: id:20388
+msgid "Studios"
+msgstr "استوديوهات"
+
+#: id:20389
+msgid "Music videos"
+msgstr "االفيديو كليب"
+
+#: id:20390
+msgid "Recently added music videos"
+msgstr "اغاني فيديو كليب أضيفت مؤخراً"
+
+#: id:20391
+msgid "Music video"
+msgstr "الفيديو كليب"
+
+#: id:20392
+msgid "Remove music video from library"
+msgstr "إزالة اغاني الفيديو من المكتبة"
+
+#: id:20393
+msgctxt "Auto context with id 20393"
+msgid "Music video information"
+msgstr "معلومات الفيديو كليب"
+
+#: id:20394
+msgid "Loading music video information"
+msgstr "تحميل معلومات الفيديو كليب"
+
+#: id:20395
+msgid "Mixed"
+msgstr "مختلطة"
+
+#: id:20396
+msgid "Go to albums by artist"
+msgstr "اذهب لألبومات الفنانين"
+
+#: id:20397
+msgid "Go to album"
+msgstr "للألبومات"
+
+#: id:20398
+msgid "Play song"
+msgstr "تشغيل الأغنية"
+
+#: id:20399
+msgid "Go to music videos from album"
+msgstr "اذهب لألبومات الفيديو الكليب"
+
+#: id:20400
+msgid "Go to music videos by artist"
+msgstr "اذهب إلى الفيديو كليب حسب الفنان"
+
+#: id:20401
+msgid "Play music video"
+msgstr "تشغيل الفيديو كليب"
+
+#: id:20402
+msgid "Download actor thumbnails when adding to library"
+msgstr "تحميل صور مصغرة للممثل عند الإضافة إلى المكتبة"
+
+#: id:20403
+msgid "Set actor thumb"
+msgstr "تعيين صورة مصغرة للمثل"
+
+#: id:20405
+msgid "Remove episode bookmark"
+msgstr "إزالة علامة الحلقه"
+
+#: id:20406
+msgid "Set episode bookmark"
+msgstr "تعيين علامة الحلقه"
+
+#: id:20407
+msgid "Scraper settings"
+msgstr "إعدادات المكشطة"
+
+#: id:20408
+msgid "Downloading music video information"
+msgstr "تحميل معلومات الفيديو كليب"
+
+#: id:20409
+msgid "Downloading TV show information"
+msgstr "تنزيل معلومات البرنامج التلفزيوني"
+
+#: id:20410
+msgid "Trailer"
+msgstr "فيلم قصير"
+
+#: id:20411
+msgid "Flatten"
+msgstr "فلاتن"
+
+#: id:20412
+msgid "Flatten TV shows"
+msgstr "برامج تلفزيونية فلاتن"
+
+#: id:20413
+msgid "Get fanart"
+msgstr "احصل Fanart"
+
+#: id:20414
+msgid "Show Fanart in video and music libraries"
+msgstr "في مكتبات الفيديو والموسيقى Fanart إظهار"
+
+#: id:20415
+msgid "Scanning for new content"
+msgstr "فحص عن محتوى جديد"
+
+#: id:20416
+msgid "First aired"
+msgstr "البث الأول"
+
+#: id:20417
+msgid "Writer"
+msgstr "الكاتب"
+
+#: id:20419
+msgid "Replace file names with library titles"
+msgstr "إظهار بيانات التعريف في عرض الملفات"
+
+#: id:20420
+msgctxt "Auto context with id 20420"
+msgid "Never"
+msgstr "أبداً"
+
+#: id:20421
+msgid "If only one season"
+msgstr "إذا فصل واحد فقط"
+
+#: id:20422
+msgid "Always"
+msgstr "دائما"
+
+#: id:20423
+msgid "Has trailer"
+msgstr "فلم قصير"
+
+#: id:20424
+msgid "False"
+msgstr "خطأ"
+
+#: id:20425
+msgid "Fanart slideshow"
+msgstr "Fanart عرض شرائح"
+
+#: id:20426
+msgid "Export to a single file or separate"
+msgstr "تصدير إلى ملف واحد أو معزول"
+
+#: id:20427
+msgid "files per entry?"
+msgstr "مدخل الملفات؟"
+
+#: id:20428
+msgid "Single file"
+msgstr "ملف واحد"
+
+#: id:20429
+msgctxt "Auto context with id 20429"
+msgid "Separate"
+msgstr "مفصول"
+
+#: id:20430
+msgid "Export thumbnails and fanart?"
+msgstr "تصدير المصغرات و Fanart?"
+
+#: id:20431
+msgid "Overwrite old files?"
+msgstr "الكتابة فوق الملفات القديمة؟"
+
+#: id:20432
+msgid "Exclude path from library updates"
+msgstr "استبعاد المسار من تحديثات المكتبة"
+
+#: id:20433
+msgid "Extract thumbnails and video information"
+msgstr "استخراج معلومات المصغرات والفيديو"
+
+#: id:20434
+msgid "Sets"
+msgstr "تعيينات"
+
+#: id:20435
+msgid "Set movieset thumb"
+msgstr "تعيين مصغرات الفيديو"
+
+#: id:20436
+msgid "Export actor thumbs?"
+msgstr "تصدير مصغرات الفنانين؟"
+
+#: id:20437
+msgid "Choose fanart"
+msgstr "اختر الخلفية"
+
+#: id:20438
+msgid "Local fanart"
+msgstr "الخلفية المحلية"
+
+#: id:20439
+msgid "No fanart"
+msgstr "لاتوجد خلفية"
+
+#: id:20440
+msgid "Current fanart"
+msgstr "الخلفية الحالية"
+
+#: id:20441
+msgid "Remote fanart"
+msgstr "الخلفية البعيدة"
+
+#: id:20442
+msgid "Change content"
+msgstr "تغيير المحتوى"
+
+#: id:20443
+msgid "Do you want to refresh info for all"
+msgstr "هل تريد تحديث كافة البيانات؟"
+
+#: id:20444
+msgid "items within this path?"
+msgstr "العناصر في هذا المسار؟"
+
+#: id:20445
+msgid "Fanart"
+msgstr "Fanart"
+
+#: id:20446
+msgid "Locally stored information found."
+msgstr ".العثور على معلومات محلية"
+
+#: id:20447
+msgid "Ignore and refresh from internet?"
+msgstr "تجاهل وحدث من الإنترنت؟"
+
+#: id:20448
+msgid "Could not download information"
+msgstr "لايمكن تحميل المعلومات"
+
+#: id:20449
+msgid "Unable to connect to remote server"
+msgstr "غير قادر على الاتصال بالخادم البعيد"
+
+#: id:20450
+msgid "Would you like to continue scanning?"
+msgstr "هل تريد الاستمرار في الفحص؟"
+
+#: id:20451
+msgid "Countries"
+msgstr "الدول"
+
+#: id:20452
+msgid "episode"
+msgstr "الحلقة"
+
+#: id:20453
+msgid "episodes"
+msgstr "الحلقات"
+
+#: id:20454
+msgid "Listener"
+msgstr "المستمع"
+
+#: id:20455
+msgid "Listeners"
+msgstr "المستمعين"
+
+#: id:20456
+msgid "Set movieset fanart"
+msgstr "تعيين خلفية الفلم Fanart"
+
+#: id:20457
+msgid "Movie set"
+msgstr "تعيين الفلم"
+
+#: id:20458
+msgid "Group movies in sets"
+msgstr ""
+
+#: id:21330
+msgid "Show hidden files and directories"
+msgstr "إظهار الملفات المخفية والدلائل"
+
+#: id:21331
+msgid "TuxBox client"
+msgstr "TuxBox عميل"
+
+#: id:21332
+msgid "WARNING: Target TuxBox device is in recording-mode!"
+msgstr "ليس في وضع التسجيل TuxBox تحذير: جهاز"
+
+#: id:21333
+msgid "The stream will be stopped!"
+msgstr "!سيتم إيقاف البث"
+
+#: id:21334
+msgid "Zap to channel: %s failed!"
+msgstr "!فشل %s :الانتقال الى القناة"
+
+#: id:21335
+msgid "Are you sure to start the stream?"
+msgstr "هل أنت متأكد لبدأ البث؟"
+
+#: id:21336
+msgid "Connecting to: %s"
+msgstr "%s :يتصل الى"
+
+#: id:21337
+msgid "TuxBox device"
+msgstr "TuxBox جهاز"
+
+#: id:21359
+msgid "Add media share..."
+msgstr "إضافة مشاركة الوسائط..."
+
+#: id:21360
+msgid "Share video and music libraries through UPnP"
+msgstr "UPnP مشاركة الفيديو والموسيقى عبر"
+
+#: id:21364
+msgid "Edit media share"
+msgstr "تحرير مشاركة الوسائط"
+
+#: id:21365
+msgid "Remove media share"
+msgstr "إزالة مشاركة الوسائط"
+
+#: id:21366
+msgid "Subtitle folder"
+msgstr "مجلد الترجمة"
+
+#: id:21367
+msgid "Movie & alternate subtitle directory"
+msgstr "دليل ترجمة الفيديو البديل"
+
+#: id:21368
+msgid "Override ASS/SSA subtitles fonts"
+msgstr "ASS / SSA تجاوز خطوط الترجمات"
+
+#: id:21369
+msgid "Enable mouse and Touch Screen support"
+msgstr "تمكين دعم الفأره وشاشة اللمس"
+
+#: id:21370
+msgid "Play navigation sounds during media playback"
+msgstr "تشغيل أصوات التنقل أثناء تشغيل الوسائط"
+
+#: id:21371
+msgid "Thumbnail"
+msgstr "المصغرة"
+
+#: id:21372
+msgid "Forced DVD player region"
+msgstr "تحديد منطقة مشغل الدي في دي"
+
+#: id:21373
+msgid "Video output"
+msgstr "مخرج الفيديو"
+
+#: id:21374
+msgid "Video aspect"
+msgstr "حجم الفيديو"
+
+#: id:21375
+msgctxt "Auto context with id 21375"
+msgid "Normal"
+msgstr "عادي"
+
+#: id:21376
+msgid "Letterbox"
+msgstr "الرسائل"
+
+#: id:21377
+msgid "Widescreen"
+msgstr "شاشة عريضة"
+
+#: id:21378
+msgid "Enable 480p"
+msgstr "480P تمكين"
+
+#: id:21379
+msgid "Enable 720p"
+msgstr "7200P تمكين"
+
+#: id:21380
+msgid "Enable 1080i"
+msgstr "1080i تمكين"
+
+#: id:21381
+msgid "Enter name of new playlist"
+msgstr "أدخل اسم قائمة تشغيل الجديدة"
+
+#: id:21382
+msgid "Show \"Add source\" buttons in file lists"
+msgstr "إظهار أزرار\"إضافة مصدر\" في قوائم الملفات"
+
+#: id:21383
+msgid "Enable scrollbars"
+msgstr "تكمين أشرطة التمرير"
+
+#: id:21384
+msgid "Make watched filtering a toggle in video library"
+msgstr "Make watched filtering a toggle in video library"
+
+#: id:21385
+msgctxt "Auto context with id 21385"
+msgid "Open"
+msgstr "فتح"
+
+#: id:21386
+msgid "Acoustic management level"
+msgstr "مستوى الإدارة الصوتية"
+
+#: id:21387
+msgid "Fast"
+msgstr "سريع"
+
+#: id:21388
+msgid "Quiet"
+msgstr "هادئة"
+
+#: id:21389
+msgid "Enable custom background"
+msgstr "تمكين خلفية مخصصة"
+
+#: id:21390
+msgid "Power management level"
+msgstr "إدارة مستوى الطاقة"
+
+#: id:21391
+msgid "High power"
+msgstr "طاقة عالية"
+
+#: id:21392
+msgid "Low power"
+msgstr "طاقة منخفضة"
+
+#: id:21393
+msgid "High standby"
+msgstr "احتياطية عالية"
+
+#: id:21394
+msgid "Low standby"
+msgstr "احتياطية منخفضة"
+
+#: id:21395
+msgid "Unable to cache files bigger than 4GB"
+msgstr "لا يمكن تخزين مؤقت لملفات أكبر من 4 غيغابايت"
+
+#: id:21396
+msgid "Chapter"
+msgstr "الفصل"
+
+#: id:21397
+msgid "High quality pixel shader v2"
+msgstr ""
+
+#: id:21398
+msgid "Enable playlist at startup"
+msgstr "مضلل بكسل عالي الجودة"
+
+#: id:21399
+msgid "Use tween animations"
+msgstr "استخدام الرسوم المتحركة"
+
+#: id:21400
+msgid "contains"
+msgstr "يحتوي على"
+
+#: id:21401
+msgid "does not contain"
+msgstr "لا يحتوي على"
+
+#: id:21402
+msgid "is"
+msgstr "انه"
+
+#: id:21403
+msgid "is not"
+msgstr "ليس"
+
+#: id:21404
+msgid "starts with"
+msgstr "يبدأ"
+
+#: id:21405
+msgid "ends with"
+msgstr "ينتهي"
+
+#: id:21406
+msgid "greater than"
+msgstr "أكبر من"
+
+#: id:21407
+msgid "less than"
+msgstr "أقل من"
+
+#: id:21408
+msgid "after"
+msgstr "بعد"
+
+#: id:21409
+msgid "before"
+msgstr "قبل"
+
+#: id:21410
+msgid "in the last"
+msgstr "الاخير"
+
+#: id:21411
+msgid "not in the last"
+msgstr "لم يدم"
+
+#: id:21412
+msgid "Scrapers"
+msgstr "الكاشطات"
+
+#: id:21413
+msgid "Default movie scraper"
+msgstr "كاشط الفيلم الافتراضي"
+
+#: id:21414
+msgid "Default tvshow scraper"
+msgstr "كاشط البرنامج التلفزيوني الافتراضي"
+
+#: id:21415
+msgid "Default music video scraper"
+msgstr "كاشط الموسيقى الافتراضي"
+
+#: id:21416
+msgid "Enable fallback based on scraper language"
+msgstr "تمكين الاحتياطية على أساس اللغة المكشطة"
+
+#: id:21417
+msgid "- Settings"
+msgstr "الإعدادت"
+
+#: id:21418
+msgid "Multilingual"
+msgstr "متعددة اللغات"
+
+#: id:21419
+msgid "No scrapers present"
+msgstr "لاتوجد مكشطة حالية"
+
+#: id:21420
+msgid "Value to match"
+msgstr "تعديل قيمة"
+
+#: id:21421
+msgid "Smart playlist rule"
+msgstr "قاعدة الأغاني الذكية"
+
+#: id:21422
+msgid "Match items where"
+msgstr "ضبط العناصر في"
+
+#: id:21423
+msgid "New rule..."
+msgstr "قانون جديد..."
+
+#: id:21424
+msgid "Items must match"
+msgstr "يجب مطابقة العناصر"
+
+#: id:21425
+msgid "all of the rules"
+msgstr "جميع القوانين"
+
+#: id:21426
+msgid "one or more of the rules"
+msgstr "قانون واحد أو أكثر"
+
+#: id:21427
+msgid "Limit to"
+msgstr "محدود"
+
+#: id:21428
+msgid "No limit"
+msgstr "لايوجد حدود"
+
+#: id:21429
+msgid "Order by"
+msgstr "ترتيب"
+
+#: id:21430
+msgid "ascending"
+msgstr "تصاعدي"
+
+#: id:21431
+msgid "descending"
+msgstr "تنازلي"
+
+#: id:21432
+msgid "Edit smart playlist"
+msgstr "تحرير قائمة التشغيل الذكية"
+
+#: id:21433
+msgid "Name of the playlist"
+msgstr "اسم قائمة التشغيل"
+
+#: id:21434
+msgid "Find items where"
+msgstr "البحث عن العناصر في"
+
+#: id:21435
+msgid "Edit"
+msgstr "- تعديل"
+
+#: id:21436
+msgid "%i items"
+msgstr "%i عناصر"
+
+#: id:21437
+msgid "New smart playlist..."
+msgstr "قائمة ذكية للأغاني الجديد..."
+
+#: id:21438
+msgid "%c Drive"
+msgstr "%c محرك"
+
+#: id:21439
+msgid "Edit party mode rules"
+msgstr "تحرير قوانين وضع الطرف"
+
+#: id:21440
+msgid "Home folder"
+msgstr "المجلد الرئيسي"
+
+#: id:21441
+msgid "Watched count"
+msgstr "حساب اللتي شوهدت"
+
+#: id:21442
+msgid "Episode title"
+msgstr "عنوان الحلقة"
+
+#: id:21443
+msgid "Video resolution"
+msgstr "دقة الفيديو"
+
+#: id:21444
+msgid "Audio channels"
+msgstr "القنوات السمعية"
+
+#: id:21445
+msgid "Video codec"
+msgstr "ترميز الفيديو"
+
+#: id:21446
+msgid "Audio codec"
+msgstr "ترميز الصوت"
+
+#: id:21447
+msgid "Audio language"
+msgstr "لغة الصوت"
+
+#: id:21448
+msgid "Subtitle language"
+msgstr "لغة الترجمة"
+
+#: id:21449
+msgid "Remote control sends keyboard presses"
+msgstr "التحكم عن بعد لإرسال قيم لوحة المفاتيح"
+
+#: id:21450
+msgid "- Edit"
+msgstr "تعديل"
+
+#: id:21451
+msgid "Internet connection required."
+msgstr ".يتطلب اتصال بالإنترنت"
+
+#: id:21452
+msgid "Get More..."
+msgstr "احصل على المزيد من..."
+
+#: id:21453
+msgid "Root filesystem"
+msgstr ""
+
+#: id:21454
+msgid "Cache full"
+msgstr ""
+
+#: id:21455
+msgid "Cache filled before reaching required amount for continous playback"
+msgstr ""
+
+#: id:21460
+msgid "Subtitle location"
+msgstr "موقع الترجمة"
+
+#: id:21461
+msgid "Fixed"
+msgstr "صالح"
+
+#: id:21462
+msgid "Bottom of video"
+msgstr "أسفل الفيديو"
+
+#: id:21463
+msgid "Below video"
+msgstr "تحت الفيديو"
+
+#: id:21464
+msgid "Top of video"
+msgstr "أعلى الفيديو"
+
+#: id:21465
+msgid "Above video"
+msgstr "أعلا الفيديو"
+
+#: id:21800
+msgid "File name"
+msgstr "اسم الملف"
+
+#: id:21801
+msgid "File path"
+msgstr "مسار الملف"
+
+#: id:21802
+msgid "File size"
+msgstr "حجم الملف"
+
+#: id:21803
+msgid "File date/time"
+msgstr "تاريخ/وقت الملف"
+
+#: id:21804
+msgid "Slide index"
+msgstr ""
+
+#: id:21805
+msgctxt "Auto context with id 21805"
+msgid "Resolution"
+msgstr "الدقة"
+
+#: id:21806
+msgctxt "Auto context with id 21806"
+msgid "Comment"
+msgstr "التعليقات"
+
+#: id:21807
+msgid "Colour/B&W"
+msgstr "أسود/أبيض اللون"
+
+#: id:21808
+msgid "JPEG process"
+msgstr ""
+
+#: id:21820
+msgid "Date/Time"
+msgstr "الوقت/التاريخ"
+
+#: id:21821
+msgid "Description"
+msgstr "الوصف"
+
+#: id:21822
+msgid "Camera make"
+msgstr "الشركة المصنعة للكاميرا"
+
+#: id:21823
+msgid "Camera model"
+msgstr "طراز الكاميرا"
+
+#: id:21824
+msgid "EXIF comment"
+msgstr "EXIF ​​تعليق"
+
+#: id:21825
+msgid "Firmware"
+msgstr "الثابتة"
+
+#: id:21826
+msgid "Aperture"
+msgstr "الفتحة"
+
+#: id:21827
+msgid "Focal length"
+msgstr "البؤري"
+
+#: id:21828
+msgid "Focus distance"
+msgstr "مسافة التركيز"
+
+#: id:21829
+msgid "Exposure"
+msgstr "التعرض"
+
+#: id:21830
+msgid "Exposure time"
+msgstr "وقت التعرض"
+
+#: id:21831
+msgid "Exposure bias"
+msgstr ""
+
+#: id:21832
+msgid "Exposure mode"
+msgstr "نمط التعرض"
+
+#: id:21833
+msgid "Flash used"
+msgstr "الفلاش المستخدمة"
+
+#: id:21834
+msgid "White-balance"
+msgstr "موازنة البياض"
+
+#: id:21835
+msgid "Light source"
+msgstr "مصدر الضوء"
+
+#: id:21836
+msgid "Metering mode"
+msgstr "وضع القياس"
+
+#: id:21837
+msgid "ISO"
+msgstr "ISO"
+
+#: id:21838
+msgid "Digital zoom"
+msgstr "التقريب الرقمي"
+
+#: id:21839
+msgid "CCD width"
+msgstr "CCD عرض"
+
+#: id:21840
+msgid "GPS latitude"
+msgstr "GPS خطوط عرض"
+
+#: id:21841
+msgid "GPS longitude"
+msgstr "GPS خطوط طول"
+
+#: id:21842
+msgid "GPS altitude"
+msgstr "GPS ارتفاع"
+
+#: id:21843
+msgid "Orientation"
+msgstr "التوجه"
+
+#: id:21860
+msgid "Supplemental categories"
+msgstr "أكثر الفئات"
+
+#: id:21861
+msgid "Keywords"
+msgstr "كلمات دالة"
+
+#: id:21862
+msgid "Caption"
+msgstr "تفسير الكلمات"
+
+#: id:21863
+msgid "Author"
+msgstr "الكاتب"
+
+#: id:21864
+msgid "Headline"
+msgstr "العنوان"
+
+#: id:21865
+msgid "Special instructions"
+msgstr "تعليمات خاصة"
+
+#: id:21866
+msgid "Category"
+msgstr "الفئات"
+
+#: id:21867
+msgid "Byline"
+msgstr "الخط الثانوي"
+
+#: id:21868
+msgid "Byline title"
+msgstr "عنوان الخط الثانوي"
+
+#: id:21869
+msgid "Credit"
+msgstr "الائتمان"
+
+#: id:21870
+msgid "Source"
+msgstr "المصدر"
+
+#: id:21871
+msgid "Copyright notice"
+msgstr "حقوق التأليف"
+
+#: id:21872
+msgid "Object name"
+msgstr "اسم الكائن"
+
+#: id:21873
+msgid "City"
+msgstr "المدينة"
+
+#: id:21874
+msgid "State"
+msgstr "البلد"
+
+#: id:21875
+msgctxt "Auto context with id 21875"
+msgid "Country"
+msgstr "البلد"
+
+#: id:21876
+msgid "Original Tx Reference"
+msgstr ""
+
+#: id:21877
+msgid "Date created"
+msgstr "تاريخ الإنشاء"
+
+#: id:21878
+msgid "Copyright flag"
+msgstr "علم حقوق المؤلف"
+
+#: id:21879
+msgid "Country code"
+msgstr "رمز البلد"
+
+#: id:21880
+msgid "Reference service"
+msgstr ""
+
+#: id:21881
+msgid "Allow control of XBMC via UPnP"
+msgstr "UPnP عبر XBMC سماح تحكم"
+
+#: id:21882
+msgid "Attempt to skip introduction before DVD menu"
+msgstr "DVD محاولة لتخطي الادوار التمهيدية قبل قائمة"
+
+#: id:21883
+msgid "Saved music"
+msgstr "الموسيقى المحفوظة"
+
+#: id:21884
+msgid "Query info for all artists"
+msgstr "تحقق لجميع الفنانين"
+
+#: id:21885
+msgid "Downloading album information"
+msgstr "تحميل معلومات الألبوم"
+
+#: id:21886
+msgid "Downloading artist information"
+msgstr "تحميل معلومات الفنان"
+
+#: id:21887
+msgid "Biography"
+msgstr "السيرة الذاتية"
+
+#: id:21888
+msgid "Discography"
+msgstr "Discography"
+
+#: id:21889
+msgid "Searching artist"
+msgstr "يبحث عن فنان"
+
+#: id:21890
+msgid "Select artist"
+msgstr "اختر الفنان"
+
+#: id:21891
+msgctxt "Auto context with id 21891"
+msgid "Artist information"
+msgstr "معلومات الفنان"
+
+#: id:21892
+msgid "Instruments"
+msgstr "آلات"
+
+#: id:21893
+msgid "Born"
+msgstr "ولد"
+
+#: id:21894
+msgid "Formed"
+msgstr "أنشأ"
+
+#: id:21895
+msgid "Themes"
+msgstr "مواضيع"
+
+#: id:21896
+msgid "Disbanded"
+msgstr "صرف النظر"
+
+#: id:21897
+msgid "Died"
+msgstr "توفي"
+
+#: id:21898
+msgid "Years active"
+msgstr "سنوات النشاط"
+
+#: id:21899
+msgid "Label"
+msgstr "شركة الإنتاج"
+
+#: id:21900
+msgid "Born/Formed"
+msgstr "ولد / أنشأ"
+
+#: id:22000
+msgid "Update library on startup"
+msgstr "تحديث المكتبة عند بدء تشغيل"
+
+#: id:22001
+msgid "Hide progress of library updates"
+msgstr "إخفاء تحديث المكتبة في الخلفية"
+
+#: id:22002
+msgid "- DNS suffix"
+msgstr ""
+
+#: id:22003
+msgid "%2.3fs"
+msgstr ""
+
+#: id:22004
+msgid "Delayed by: %2.3fs"
+msgstr ""
+
+#: id:22005
+msgid "Ahead by: %2.3fs"
+msgstr ""
+
+#: id:22006
+msgid "Subtitle offset"
+msgstr "موازنة الترجمة"
+
+#: id:22007
+msgid "OpenGL vendor:"
+msgstr "مزود OpenGL:"
+
+#: id:22008
+msgid "OpenGL renderer:"
+msgstr ""
+
+#: id:22009
+msgid "OpenGL version:"
+msgstr "نسخة OpenGL:"
+
+#: id:22010
+msgid "GPU temperature:"
+msgstr "درجة حرارة CPU:"
+
+#: id:22011
+msgid "CPU temperature:"
+msgstr "درجة حرارة GPU:"
+
+#: id:22012
+msgid "Total memory"
+msgstr "إجمالي الذاكرة"
+
+#: id:22013
+msgid "Profile data"
+msgstr "البيانات الشخصية"
+
+#: id:22014
+msgid "Use dim if paused during video playback"
+msgstr "استخدام التعتيم عند التوقف أثناء تشغيل الفيديو"
+
+#: id:22015
+msgid "All recordings"
+msgstr "جميع التسجيلات"
+
+#: id:22016
+msgid "By title"
+msgstr "​​حسب العنوان"
+
+#: id:22017
+msgid "By group"
+msgstr "حسب المجموعة"
+
+#: id:22018
+msgid "Live channels"
+msgstr "قنوات مباشرة"
+
+#: id:22019
+msgid "Recordings by title"
+msgstr "تسجيل حسب العنوان"
+
+#: id:22020
+msgid "Guide"
+msgstr "الدليل"
+
+#: id:22021
+msgid "Allowed error in aspect ratio to minimize black bars"
+msgstr "سماح الأخطاء في ما يتعلق بنسبة الجوانب وذلك للحد من الخطوط السوداء"
+
+#: id:22022
+msgid "Show video files in listings"
+msgstr "عرض ملفات الفيديو في قوائم"
+
+#: id:22023
+msgid "DirectX vendor:"
+msgstr ":DirectX مزود"
+
+#: id:22024
+msgid "Direct3D version:"
+msgstr ":Direct3D نسخة"
+
+#: id:22030
+msgctxt "Auto context with id 22030"
+msgid "Font"
+msgstr "الخط"
+
+#: id:22031
+msgctxt "Auto context with id 22031"
+msgid "- Size"
+msgstr "الحجم"
+
+#: id:22032
+msgctxt "Auto context with id 22032"
+msgid "- Colours"
+msgstr "الألوان"
+
+#: id:22033
+msgid "- Charset"
+msgstr "تعيين الأحرف"
+
+#: id:22034
+msgid "Export karaoke titles as HTML"
+msgstr "HTML تصدير عناوين الكاريوكي مثل"
+
+#: id:22035
+msgid "Export karaoke titles as CSV"
+msgstr "CSV تصدير عناوين الكاريوكي مثل"
+
+#: id:22036
+msgid "Import karaoke titles..."
+msgstr "استيراد عناوين الكاريوكي..."
+
+#: id:22037
+msgid "Show song selector automatically"
+msgstr "إظهار مؤشر الأغنية تلقائياً"
+
+#: id:22038
+msgid "Export karaoke titles..."
+msgstr "تصدير عناوين الكاريوكي..."
+
+#: id:22039
+msgid "Enter song number"
+msgstr "أدخل رقم الأغنية"
+
+#: id:22040
+msgid "white/green"
+msgstr "أبيض/أخضر"
+
+#: id:22041
+msgid "white/red"
+msgstr "أبيض/أحمر"
+
+#: id:22042
+msgid "white/blue"
+msgstr "أبيض/أزرق"
+
+#: id:22043
+msgid "black/white"
+msgstr "أسود/أبيض"
+
+#: id:22079
+msgid "Default select action"
+msgstr "اختيار الإجراء الافتراضي"
+
+#: id:22080
+msgid "Choose"
+msgstr "اختر"
+
+#: id:22081
+msgid "Show Information"
+msgstr "عرض المعلومات"
+
+#: id:22082
+msgid "More..."
+msgstr "المزيد..."
+
+#: id:22083
+msgid "Play all"
+msgstr "تشغيل الكل"
+
+#: id:23049
+msgid "Teletext not available"
+msgstr ""
+
+#: id:23050
+msgid "Activate Teletext"
+msgstr "تنشيط النص"
+
+#: id:23051
+msgid "Part %i"
+msgstr ""
+
+#: id:23052
+msgid "Buffering %i bytes"
+msgstr ""
+
+#: id:23053
+msgid "Stopping"
+msgstr "توقف"
+
+#: id:23054
+msgid "Running"
+msgstr "%i جزء"
+
+#: id:23100
+msgid "External Player Active"
+msgstr "تنشيط المشغل الخارجي"
+
+#: id:23101
+msgid "Click OK to terminate the player"
+msgstr "انقر موافق لتعطيل المشغل"
+
+#: id:23104
+msgid "Click OK when playback has ended"
+msgstr "انقر موافق عند انتهاء التشغيل"
+
+#: id:24000
+msgid "Add-on"
+msgstr "الملحق"
+
+#: id:24001
+msgid "Add-ons"
+msgstr "الملحقات"
+
+#: id:24002
+msgid "Add-on options"
+msgstr "خيارات الملحقات"
+
+#: id:24003
+msgid "Add-on Information"
+msgstr "معلومات الملحقات"
+
+#: id:24005
+msgctxt "Auto context with id 24005"
+msgid "Media sources"
+msgstr "مصادر الوسائط"
+
+#: id:24007
+msgctxt "Auto context with id 24007"
+msgid "Movie information"
+msgstr "معلومات الفيلم"
+
+#: id:24008
+msgctxt "Auto context with id 24008"
+msgid "Screensaver"
+msgstr "مؤقت الشاشة"
+
+#: id:24009
+msgid "Script"
+msgstr "سيناريو"
+
+#: id:24010
+msgctxt "Auto context with id 24010"
+msgid "Visualization"
+msgstr "التصور"
+
+#: id:24011
+msgid "Add-on repository"
+msgstr "مخزن الملحقات"
+
+#: id:24012
+msgctxt "Auto context with id 24012"
+msgid "Subtitles"
+msgstr "الترجمات"
+
+#: id:24013
+msgid "Lyrics"
+msgstr "كلمات الأغاني"
+
+#: id:24014
+msgid "TV information"
+msgstr "معلومات التلفزيون"
+
+#: id:24015
+msgctxt "Auto context with id 24015"
+msgid "Music video information"
+msgstr "معلومات الفيديو كليب"
+
+#: id:24016
+msgctxt "Auto context with id 24016"
+msgid "Album information"
+msgstr "معلومات الألبوم"
+
+#: id:24017
+msgctxt "Auto context with id 24017"
+msgid "Artist information"
+msgstr "معلومات الفنان"
+
+#: id:24018
+msgctxt "Auto context with id 24018"
+msgid "Services"
+msgstr "الخدمات"
+
+#: id:24020
+msgid "Configure"
+msgstr "التكوين"
+
+#: id:24021
+msgctxt "Auto context with id 24021"
+msgid "Disable"
+msgstr "تعطيل"
+
+#: id:24022
+msgid "Enable"
+msgstr "تمكين"
+
+#: id:24023
+msgid "Add-on disabled"
+msgstr "الموقع"
+
+#: id:24027
+msgctxt "Auto context with id 24027"
+msgid "Weather"
+msgstr "الطقس"
+
+#: id:24028
+msgid "Weather.com (standard)"
+msgstr "Weather.com (قياسي)"
+
+#: id:24030
+msgid "This Add-on can not be configured"
+msgstr "لايمكن تعديل هذا الملحق"
+
+#: id:24031
+msgid "Error loading settings"
+msgstr "خطأ في تحميل الإعدادت"
+
+#: id:24032
+msgid "All Add-ons"
+msgstr "كافة الملحقات"
+
+#: id:24033
+msgid "Get Add-ons"
+msgstr "احصل على إضافات..."
+
+#: id:24034
+msgid "Check for updates"
+msgstr "تحقق من وجود تحديثات"
+
+#: id:24035
+msgid "Force refresh"
+msgstr "تحديث"
+
+#: id:24036
+msgid "Change log"
+msgstr "سجل التغييرات"
+
+#: id:24037
+msgid "Uninstall"
+msgstr "إزالة التثبيت"
+
+#: id:24038
+msgid "Install"
+msgstr "تثبيت"
+
+#: id:24039
+msgid "Disabled Add-ons"
+msgstr "إضافات معطلة"
+
+#: id:24040
+msgid "(Clear the current setting)"
+msgstr "(إزالة الإعدادات الموجودة)"
+
+#: id:24041
+msgid "Install from zip file"
+msgstr "تثبيت من ملف مضغوط"
+
+#: id:24042
+msgid "Downloading %i%%"
+msgstr "%i%% تحميل"
+
+#: id:24043
+msgid "Available Updates"
+msgstr "التحديثات متوفرة"
+
+#: id:24044
+msgid "Dependencies not met"
+msgstr "عدم توافق التطابقات"
+
+#: id:24045
+msgid "Add-on does not have the correct structure"
+msgstr "تركيبة الملحق غير صحيحة"
+
+#: id:24046
+msgid "%s is used by the following installed add-on(s)"
+msgstr "%s مستخدم من قبل الملحق المثبت"
+
+#: id:24047
+msgid "This add-on cannot be uninstalled"
+msgstr "لايمكن إزالة هذا الملحق"
+
+#: id:24048
+msgid "Rollback"
+msgstr "العودة"
+
+#: id:24050
+msgid "Available Add-ons"
+msgstr "الملحقات المتوفرة"
+
+#: id:24051
+msgid "Version:"
+msgstr "الإصدار:"
+
+#: id:24052
+msgid "Disclaimer"
+msgstr "تنويه"
+
+#: id:24053
+msgid "License:"
+msgstr ":الترخيص"
+
+#: id:24054
+msgid "Changelog"
+msgstr "سجل التغييرات"
+
+#: id:24059
+msgid "Would you like to enable this Add-on?"
+msgstr "هل تريد تمكين هذا الملحق؟"
+
+#: id:24060
+msgid "Would you like to disable this Add-on?"
+msgstr "هل تريد تعطيل هذا الملحق؟"
+
+#: id:24061
+msgid "Add-on update available!"
+msgstr "!تحديث الملحق متوفر"
+
+#: id:24062
+msgid "Enabled Add-ons"
+msgstr "الملحقات المثبته"
+
+#: id:24063
+msgid "Auto update"
+msgstr "التحديث التلقائي"
+
+#: id:24064
+msgid "Add-on enabled"
+msgstr "الملحق المثبته"
+
+#: id:24065
+msgid "Add-on updated"
+msgstr "الملحق محدث"
+
+#: id:24066
+msgid "Cancel Add-on download?"
+msgstr "إلغاء تحميل الملحق؟"
+
+#: id:24067
+msgid "Currently downloading Add-ons"
+msgstr "يتم تحميل الملحق حاليا"
+
+#: id:24068
+msgid "Update available"
+msgstr "التحديث متوفر"
+
+#: id:24069
+msgid "Update"
+msgstr "تحديث"
+
+#: id:24070
+msgid "Add-on could not be loaded."
+msgstr "لم يتمكن من تحميل الملحق"
+
+#: id:24071
+msgid "An unknown error has occurred."
+msgstr ".حدث خطأ غير معروف"
+
+#: id:24072
+msgid "Settings required"
+msgstr "تتطلب إعدادات"
+
+#: id:24073
+msgid "Could not connect"
+msgstr "لم يتمكن من الإتصال"
+
+#: id:24074
+msgid "Needs to restart"
+msgstr "يحتاج الى إعادة تشغيل"
+
+#: id:24075
+msgctxt "Auto context with id 24075"
+msgid "Disable"
+msgstr "تعطيل"
+
+#: id:24076
+msgid "Add-on Required"
+msgstr "يتطلب ملحق"
+
+#: id:24080
+msgid "Try to reconnect?"
+msgstr "محاولة إعادة الاتصال؟"
+
+#: id:24089
+msgid "Add-on restarts"
+msgstr "إعادة تشغيل الملحق"
+
+#: id:24090
+msgid "Lock Add-on manager"
+msgstr "قفل إدارة الملحق"
+
+#: id:24094
+msgid "(current)"
+msgstr "(الحالي)"
+
+#: id:24095
+msgid "(blacklisted)"
+msgstr "(القائمة السوداء)"
+
+#: id:24096
+msgid "Add-on has been marked as broken in repository."
+msgstr "ملحوظة المكونات غير صالحة في المخزن"
+
+#: id:24097
+msgid "Would you like to disable it on your system?"
+msgstr "تريد تعطيله من النظام؟"
+
+#: id:24098
+msgid "Broken"
+msgstr "غير صالحة"
+
+#: id:24099
+msgid "Would you like to switch to this skin?"
+msgstr "سكين تريد استبداله؟"
+
+#: id:24100
+msgid "To use this feature you must download an Add-on:"
+msgstr "هل تريد التبديل الى هذه الخلفية؟"
+
+#: id:24101
+msgid "Would you like to download this Add-on?"
+msgstr "هل تريد تحميل هذا الملحق؟"
+
+#: id:25000
+msgid "Notifications"
+msgstr "الإشعارات"
+
+#: id:29800
+msgid "Library Mode"
+msgstr "وضع المكتبة"
+
+#: id:29801
+msgid "QWERTY keyboard"
+msgstr "QWERTY لوحة مفاتيح"
+
+#: id:29802
+msgid "Passthrough Audio in use"
+msgstr "عبور الصوت مستخدم"
+
+#: id:33001
+msgid "Trailer quality"
+msgstr "جودة المقطع"
+
+#: id:33002
+msgid "Stream"
+msgstr "بث"
+
+#: id:33003
+msgid "Download"
+msgstr "تحميل"
+
+#: id:33004
+msgid "Download & play"
+msgstr "تحميل والتشغيل"
+
+#: id:33005
+msgid "Download & save"
+msgstr "تحميل وحفظ"
+
+#: id:33006
+msgid "Today"
+msgstr "اليوم"
+
+#: id:33007
+msgid "Tomorrow"
+msgstr "غدا"
+
+#: id:33008
+msgid "Saving"
+msgstr "يحفظ"
+
+#: id:33009
+msgid "Copying"
+msgstr "ينسخ"
+
+#: id:33010
+msgid "Set download directory"
+msgstr "تعيين مجلد التنزيلات"
+
+#: id:33011
+msgid "Search duration"
+msgstr "أثناء البحث"
+
+#: id:33012
+msgid "Short"
+msgstr "قصيرة"
+
+#: id:33013
+msgid "Long"
+msgstr "طويلة"
+
+#: id:33014
+msgid "Use DVD player instead of regular player"
+msgstr "استخدام مشغل دي في دي بدلا من المشغل العادي"
+
+#: id:33015
+msgid "Ask for download before playing video"
+msgstr "اسأل للتحميل قبل تشغيل الفيديو"
+
+#: id:33016
+msgid "Clips"
+msgstr "المقاطع"
+
+#: id:33017
+msgid "Restart plugin to enable"
+msgstr "إعادة تشغيل الملحق لتمكينه"
+
+#: id:33018
+msgid "Tonight"
+msgstr "ليلة"
+
+#: id:33019
+msgid "Tomorrow Night"
+msgstr "غداً ليلاً"
+
+#: id:33020
+msgid "Condition"
+msgstr "الحالة"
+
+#: id:33021
+msgid "Precipitation"
+msgstr "هطول"
+
+#: id:33022
+msgid "Precip"
+msgstr "هطول"
+
+#: id:33023
+msgid "Humid"
+msgstr "رطب"
+
+#: id:33024
+msgid "Feels"
+msgstr "Feels"
+
+#: id:33025
+msgid "Observed"
+msgstr "ملاحظ"
+
+#: id:33026
+msgid "Departure from normal"
+msgstr "خارج عن المعتاد"
+
+#: id:33027
+msgid "Sunrise"
+msgstr "شروق الشمس"
+
+#: id:33028
+msgid "Sunset"
+msgstr "غروب الشمس"
+
+#: id:33029
+msgid "Details"
+msgstr "التفاصيل"
+
+#: id:33030
+msgid "Outlook"
+msgstr "التوقعات"
+
+#: id:33031
+msgid "Coverflow"
+msgstr "Coverflow"
+
+#: id:33032
+msgid "Translate text"
+msgstr "ترجمة النص"
+
+#: id:33033
+msgid "Map list %s category"
+msgstr "قائمة الخريطة %s فئة"
+
+#: id:33034
+msgid "36 Hour"
+msgstr "36 ساعة"
+
+#: id:33035
+msgid "Maps"
+msgstr "الخرائط"
+
+#: id:33036
+msgid "Hourly"
+msgstr "كل ساعة"
+
+#: id:33037
+msgid "Weekend"
+msgstr "نهاية الاسبوع"
+
+#: id:33038
+msgid "%s day"
+msgstr "%s اليوم"
+
+#: id:33049
+msgid "Alert"
+msgstr "إنذار"
+
+#: id:33050
+msgid "Alerts"
+msgstr "إنذارات"
+
+#: id:33051
+msgid "Choose Your"
+msgstr "اختر"
+
+#: id:33052
+msgid "Check"
+msgstr "تحقق"
+
+#: id:33053
+msgctxt "Auto context with id 33053"
+msgid "Configure the"
+msgstr "تعيين"
+
+#: id:33054
+msgid "Seasons"
+msgstr "مواسم"
+
+#: id:33055
+msgid "Use your"
+msgstr "استخدم"
+
+#: id:33056
+msgid "Watch your"
+msgstr "شاهد"
+
+#: id:33057
+msgid "Listen to"
+msgstr "الاستماع إلى"
+
+#: id:33058
+msgid "View your"
+msgstr "عرض"
+
+#: id:33059
+msgctxt "Auto context with id 33059"
+msgid "Configure the"
+msgstr "تكوين"
+
+#: id:33060
+msgid "Power"
+msgstr "الطاقة"
+
+#: id:33061
+msgid "Menu"
+msgstr "القائمة"
+
+#: id:33062
+msgid "Play the"
+msgstr "تشغيل"
+
+#: id:33063
+msgid "Options"
+msgstr "الخيارات"
+
+#: id:33065
+msgid "Editor"
+msgstr "المحرر"
+
+#: id:33066
+msgid "About your"
+msgstr "حول"
+
+#: id:33067
+msgid "Star rating"
+msgstr "ابدأ التقييم"
+
+#: id:33068
+msgid "Background"
+msgstr "الخلفية"
+
+#: id:33069
+msgid "Backgrounds"
+msgstr "الخلفية"
+
+#: id:33070
+msgid "Custom background"
+msgstr "خلفية مخصصة"
+
+#: id:33071
+msgid "Custom backgrounds"
+msgstr "الخلفيات المخصصة"
+
+#: id:33072
+msgid "View Readme"
+msgstr "Readme عرض الملف"
+
+#: id:33073
+msgid "View Changelog"
+msgstr "عرض ملف سجل التغييرات"
+
+#: id:33074
+msgid "This version of %s requires an"
+msgstr "يتطلب %s هذا الاصدار من"
+
+#: id:33075
+msgid "XBMC revision of %s or greater to run."
+msgstr "أو أكثر للتشغيل %s XBMC revision يتطلب"
+
+#: id:33076
+msgid "Please update XBMC."
+msgstr "XBMC يرجى تحديث"
+
+#: id:33077
+msgid "No data found!"
+msgstr "!لم يتم العثور على البيانات"
+
+#: id:33078
+msgid "Next page"
+msgstr "الصفحة التالية"
+
+#: id:33079
+msgid "Love"
+msgstr "الحب"
+
+#: id:33080
+msgid "Hate"
+msgstr "الكراهية"
+
+#: id:33081
+msgid "This file is stacked, select the part you want to play from."
+msgstr "هذا الملف ينتمي إلى كشط. حدد نقطة التشغيل"
+
+#: id:33082
+msgid "Path to script"
+msgstr ""
+
+#: id:33083
+msgid "Enable custom script button"
+msgstr ""
+
+#: id:33100
+msgid "Failed to start"
+msgstr "فشل البدء"
+
+#: id:33101
+msgid "Webserver"
+msgstr "خادم الويب"
+
+#: id:33102
+msgid "Event Server"
+msgstr "خادم الحدث"
+
+#: id:33103
+msgid "Remote communication server"
+msgstr "خادم الدخول عن بعد"
+
+#: id:33200
+msgid "Detected New Connection"
+msgstr ""
+
+#: id:34000
+msgid "Lame"
+msgstr ""
+
+#: id:34001
+msgid "Vorbis"
+msgstr ""
+
+#: id:34002
+msgid "Wav"
+msgstr ""
+
+#: id:34003
+msgid "DXVA2"
+msgstr ""
+
+#: id:34004
+msgid "VAAPI"
+msgstr ""
+
+#: id:34005
+msgid "Flac"
+msgstr ""
+
+#: id:34100
+msgid "Speaker Configuration"
+msgstr "إعداد المكبر"
+
+#: id:34101
+msgid "2.0"
+msgstr ""
+
+#: id:34102
+msgid "2.1"
+msgstr ""
+
+#: id:34103
+msgid "3.0"
+msgstr ""
+
+#: id:34104
+msgid "3.1"
+msgstr ""
+
+#: id:34105
+msgid "4.0"
+msgstr ""
+
+#: id:34106
+msgid "4.1"
+msgstr ""
+
+#: id:34107
+msgid "5.0"
+msgstr ""
+
+#: id:34108
+msgid "5.1"
+msgstr ""
+
+#: id:34109
+msgid "7.0"
+msgstr ""
+
+#: id:34110
+msgid "7.1"
+msgstr ""
+
+#: id:34201
+msgid "Can't find a next item to play"
+msgstr "لا يمكن العثور على العنصر التالي للتشغيل"
+
+#: id:34202
+msgid "Can't find a previous item to play"
+msgstr "لا يمكن العثور على العنصر السابق للتشغيل"
+
+#: id:34300
+msgid "Failed to start zeroconf"
+msgstr ""
+
+#: id:34301
+msgid "Is Apple's Bonjour Service installed? See log for more info."
+msgstr ""
+
+#: id:34400
+msgid "Video Rendering"
+msgstr ""
+
+#: id:34401
+msgid "Failed to init video filters/scalers, falling back to bilinear scaling"
+msgstr ""
+
+#: id:34402
+msgid "Failed to initialize audio device"
+msgstr ""
+
+#: id:34403
+msgid "Check your audiosettings"
+msgstr ""
+
+#: id:34404
+msgid "Use gestures for navigation:"
+msgstr ""
+
+#: id:34405
+msgid "1 finger swipe left,right,up,down for cursors"
+msgstr ""
+
+#: id:34406
+msgid "2 finger swipe left for backspace"
+msgstr ""
+
+#: id:34407
+msgid "1 finger single tap for enter"
+msgstr ""
+
+#: id:34408
+msgid "2 finger single tap for contextmenu"
+msgstr ""
+
+#: id:35000
+msgid "Peripherals"
+msgstr "الأجهزة الطرفية"
+
+#: id:35001
+msgid "Generic HID device"
+msgstr "العام HID جهاز"
+
+#: id:35002
+msgid "Generic network adapter"
+msgstr "محول الشبكة العام"
+
+#: id:35003
+msgid "Generic disk"
+msgstr "القرص العام"
+
+#: id:35004
+msgid "There are no settings available\nfor this peripheral."
+msgstr ".أي إعدادات لهذا الجهاز"
+
+#: id:35005
+msgid "New device configured"
+msgstr "تم تعيين جهاز جديد"
+
+#: id:35006
+msgid "Device removed"
+msgstr "تم إزالة الجهاز"
+
+#: id:35007
+msgid "Keymap to use for this device"
+msgstr ""
+
+#: id:35008
+msgid "Keymap enabled"
+msgstr ""
+
+#: id:35009
+msgid "Do not use the custom keymap for this device"
+msgstr ""
+
+#: id:35500
+msgid "Location"
+msgstr "الموقع"
+
+#: id:35501
+msgid "Class"
+msgstr "التصنيف"
+
+#: id:35502
+msgctxt "Auto context with id 35502"
+msgid "Name"
+msgstr "الاسم"
+
+#: id:35503
+msgid "Vendor"
+msgstr "المزود"
+
+#: id:35504
+msgid "Product ID"
+msgstr "معرف المنتج"
+
+#: id:36000
+msgid "Pulse-Eight CEC adapter"
+msgstr ""
+
+#: id:36001
+msgid "Pulse-Eight Nyxboard"
+msgstr ""
+
+#: id:36002
+msgid "Switch to keyboard side command"
+msgstr ""
+
+#: id:36003
+msgid "Switch to remote side command"
+msgstr ""
+
+#: id:36004
+msgid "Press \"user\" button command"
+msgstr ""
+
+#: id:36005
+msgid "Enable switch side commands"
+msgstr ""
+
+#: id:36006
+msgid "Could not open the adapter"
+msgstr "لم يتمكن من فتح المحول"
+
+#: id:36007
+msgid "Devices to power on when starting XBMC"
+msgstr "XBMC تشغيل التلفزيون عند بدء"
+
+#: id:36008
+msgid "Devices to power off when stopping XBMC"
+msgstr "XBMC إيقاف التلفزيون عند إيقاف"
+
+#: id:36009
+msgid "Put devices in standby mode when activating screensaver"
+msgstr "وضع الأجهزة في وضع الاستعداد عند تنشيط شاشة التوقف"
+
+#: id:36011
+msgid "Could not detect the CEC port. Set it up manually."
+msgstr ""
+
+#: id:36012
+msgid "Could not initialise the CEC adapter. Check your settings."
+msgstr ""
+
+#: id:36013
+msgid "Unsupported libCEC interface version. %d is greater than the version XBMC supports (%d)"
+msgstr ""
+
+#: id:36014
+msgid "Put this PC in standby mode when the TV is switched off"
+msgstr ""
+
+#: id:36015
+msgid "HDMI port number"
+msgstr "HDMI رقم منفذ"
+
+#: id:36016
+msgctxt "Auto context with id 36016"
+msgid "Connected"
+msgstr "متصل"
+
+#: id:36017
+msgid "Adapter found, but libCEC is not available"
+msgstr "غير متوفر libcec تم العثور على الارتباط, ولكن"
+
+#: id:36018
+msgid "Use the TV's language setting"
+msgstr "استخدام إعدادات لغة للتلفزيون"
+
+#: id:36019
+msgid "Connected to HDMI device"
+msgstr ""
+
+#: id:36020
+msgid "Make XBMC the active source when starting"
+msgstr ""
+
+#: id:36021
+msgid "Physical address (overrules HDMI port)"
+msgstr ""
+
+#: id:36022
+msgid "COM port (leave empty unless needed)"
+msgstr ""
+
+#: id:36023
+msgid "Configuration updated"
+msgstr ""
+
+#: id:36024
+msgid "Failed to set the new configuration. Please check your settings."
+msgstr ""
+
+#: id:36025
+msgid "Send 'inactive source' command when stopping XBMC"
+msgstr ""
+

--- a/language/Basque/strings.po
+++ b/language/Basque/strings.po
@@ -1,0 +1,9093 @@
+# Converted from xbmc strings.xml with xbmc-xml2po (by Team-XBMC)
+msgid ""
+msgstr ""
+"Project-Id-Version: xbmc.core-FRODO_GIT3ed1604ad7\n"
+"Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
+"POT-Creation-Date: 2012-04-09 18:00+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE\n"
+"Language: eu\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: id:0
+msgctxt "Auto context with id 0"
+msgid "Programs"
+msgstr "Programak"
+
+#: id:1
+msgctxt "Auto context with id 1"
+msgid "Pictures"
+msgstr "Irudiak"
+
+#: id:2
+msgctxt "Auto context with id 2"
+msgid "Music"
+msgstr "Musika"
+
+#: id:3
+msgctxt "Auto context with id 3"
+msgid "Videos"
+msgstr "Bideoak"
+
+#: id:4
+msgid "TV-Guide"
+msgstr "TB-Gida"
+
+#: id:5
+msgctxt "Auto context with id 5"
+msgid "Settings"
+msgstr "Ezarpenak"
+
+#: id:6
+msgid "XBMC SVN"
+msgstr "XBMC SVN"
+
+#: id:7
+msgctxt "Auto context with id 7"
+msgid "File manager"
+msgstr "Fitxategi kudeatzailea"
+
+#: id:8
+msgctxt "Auto context with id 8"
+msgid "Weather"
+msgstr "Eguraldia"
+
+#: id:9
+msgid "xbmc media center"
+msgstr "xbmc media zentroa"
+
+#: id:11
+msgid "Monday"
+msgstr "Astelehena"
+
+#: id:12
+msgid "Tuesday"
+msgstr "Asteartea"
+
+#: id:13
+msgid "Wednesday"
+msgstr "Asteazkena"
+
+#: id:14
+msgid "Thursday"
+msgstr "Osteguna"
+
+#: id:15
+msgid "Friday"
+msgstr "Ostirala"
+
+#: id:16
+msgid "Saturday"
+msgstr "Larunbata"
+
+#: id:17
+msgid "Sunday"
+msgstr "Igandea"
+
+#: id:21
+msgid "January"
+msgstr "Urtarrila"
+
+#: id:22
+msgid "February"
+msgstr "Otsaila"
+
+#: id:23
+msgid "March"
+msgstr "Martxoa"
+
+#: id:24
+msgid "April"
+msgstr "Apirila"
+
+#: id:25
+msgctxt "Auto context with id 25"
+msgid "May"
+msgstr "Maiatza"
+
+#: id:26
+msgid "June"
+msgstr "Ekaina"
+
+#: id:27
+msgid "July"
+msgstr "Uztaila"
+
+#: id:28
+msgid "August"
+msgstr "Abuztua"
+
+#: id:29
+msgid "September"
+msgstr "Iraila"
+
+#: id:30
+msgid "October"
+msgstr "Urria"
+
+#: id:31
+msgid "November"
+msgstr "Azaroa"
+
+#: id:32
+msgid "December"
+msgstr "Abendua"
+
+#: id:41
+msgid "Mon"
+msgstr "Al"
+
+#: id:42
+msgid "Tue"
+msgstr "As"
+
+#: id:43
+msgid "Wed"
+msgstr "Az"
+
+#: id:44
+msgid "Thu"
+msgstr "Os"
+
+#: id:45
+msgid "Fri"
+msgstr "Ol"
+
+#: id:46
+msgid "Sat"
+msgstr "La"
+
+#: id:47
+msgctxt "Auto context with id 47"
+msgid "Sun"
+msgstr "Ig"
+
+#: id:51
+msgid "Jan"
+msgstr "Urt"
+
+#: id:52
+msgid "Feb"
+msgstr "Ots"
+
+#: id:53
+msgid "Mar"
+msgstr "Mar"
+
+#: id:54
+msgid "Apr"
+msgstr "Api"
+
+#: id:55
+msgctxt "Auto context with id 55"
+msgid "May"
+msgstr "Mai"
+
+#: id:56
+msgid "Jun"
+msgstr "Eka"
+
+#: id:57
+msgid "Jul"
+msgstr "Uzt"
+
+#: id:58
+msgid "Aug"
+msgstr "Abu"
+
+#: id:59
+msgid "Sep"
+msgstr "Ira"
+
+#: id:60
+msgid "Oct"
+msgstr "Urr"
+
+#: id:61
+msgid "Nov"
+msgstr "Aza"
+
+#: id:62
+msgid "Dec"
+msgstr "Abe"
+
+#: id:71
+msgid "N"
+msgstr "I"
+
+#: id:72
+msgid "NNE"
+msgstr "IIE"
+
+#: id:73
+msgid "NE"
+msgstr "IE"
+
+#: id:74
+msgid "ENE"
+msgstr "EIE"
+
+#: id:75
+msgid "E"
+msgstr "E"
+
+#: id:76
+msgid "ESE"
+msgstr "EHE"
+
+#: id:77
+msgid "SE"
+msgstr "HE"
+
+#: id:78
+msgid "SSE"
+msgstr "HHE"
+
+#: id:79
+msgid "S"
+msgstr "H"
+
+#: id:80
+msgid "SSW"
+msgstr "HHM"
+
+#: id:81
+msgid "SW"
+msgstr "HM"
+
+#: id:82
+msgid "WSW"
+msgstr "MHM"
+
+#: id:83
+msgid "W"
+msgstr "M"
+
+#: id:84
+msgid "WNW"
+msgstr "MIM"
+
+#: id:85
+msgid "NW"
+msgstr "IM"
+
+#: id:86
+msgid "NNW"
+msgstr "IIM"
+
+#: id:87
+msgid "VAR"
+msgstr "BAR"
+
+#: id:98
+msgid "View: Auto"
+msgstr "Ikusi: Auto"
+
+#: id:99
+msgid "View: Auto big"
+msgstr "Ikusi: Auto handia"
+
+#: id:100
+msgid "View: Icons"
+msgstr "Ikusi: Ikonoak"
+
+#: id:101
+msgid "View: List"
+msgstr "Ikusi: Zerrenda"
+
+#: id:102
+msgctxt "Auto context with id 102"
+msgid "Scan"
+msgstr "Eskaneatu"
+
+#: id:103
+msgctxt "Auto context with id 103"
+msgid "Sort by: Name"
+msgstr "Ordenatu: Izena"
+
+#: id:104
+msgid "Sort by: Date"
+msgstr "Ordenatu: Data"
+
+#: id:105
+msgid "Sort by: Size"
+msgstr "Ordenatu: Tamaina"
+
+#: id:106
+msgid "No"
+msgstr "Ez"
+
+#: id:107
+msgid "Yes"
+msgstr "Bai"
+
+#: id:108
+msgctxt "Auto context with id 108"
+msgid "Slideshow"
+msgstr "Aurkezpena"
+
+#: id:109
+msgid "Create thumbs"
+msgstr "Sortu iruditxoa"
+
+#: id:110
+msgid "Create thumbnails"
+msgstr "Sortu iruditxoak"
+
+#: id:111
+msgctxt "Auto context with id 111"
+msgid "Shortcuts"
+msgstr "Lasterbideak"
+
+#: id:112
+msgid "Paused"
+msgstr "Pausatuta"
+
+#: id:113
+msgid "Update failed"
+msgstr "Eguneraketak huts egin du"
+
+#: id:114
+msgid "Installation failed"
+msgstr "Instalazioak huts egin du"
+
+#: id:115
+msgid "Copy"
+msgstr "Kopiatu"
+
+#: id:116
+msgid "Move"
+msgstr "Mugitu"
+
+#: id:117
+msgid "Delete"
+msgstr "Ezabatu"
+
+#: id:118
+msgid "Rename"
+msgstr "Berrizendatu"
+
+#: id:119
+msgid "New folder"
+msgstr "Karpeta berria"
+
+#: id:120
+msgid "Confirm file copy"
+msgstr "Baieztatu fitxategiaren kopia"
+
+#: id:121
+msgid "Confirm file move"
+msgstr "Baieztatu fitxategia mugitzea"
+
+#: id:122
+msgid "Confirm file delete?"
+msgstr "Baieztatu fitxategia ezabatzea?"
+
+#: id:123
+msgid "Copy these files?"
+msgstr "Kopiatu fitxategi hauek?"
+
+#: id:124
+msgid "Move these files?"
+msgstr "Fitxategi hauek mugitu?"
+
+#: id:125
+msgid "Delete these files? - Deleting files cannot be undone!"
+msgstr "Ezabatu fitxategi hauek? - fitxategien ezabatzea ezin da desegin!"
+
+#: id:126
+msgid "Status"
+msgstr "Egoera"
+
+#: id:127
+msgid "Objects"
+msgstr "Objektuak"
+
+#: id:128
+msgctxt "Auto context with id 128"
+msgid "General"
+msgstr "Orokorra"
+
+#: id:129
+msgctxt "Auto context with id 129"
+msgid "Slideshow"
+msgstr "Aurkezpena"
+
+#: id:130
+msgctxt "Auto context with id 130"
+msgid "System info"
+msgstr "Sistemaren info"
+
+#: id:131
+msgid "Display"
+msgstr "Erakutsi"
+
+#: id:132
+msgid "Albums"
+msgstr "Albumak"
+
+#: id:133
+msgid "Artists"
+msgstr "Artistak"
+
+#: id:134
+msgid "Songs"
+msgstr "Abestiak"
+
+#: id:135
+msgid "Genres"
+msgstr "Generoak"
+
+#: id:136
+msgid "Playlists"
+msgstr "Erre. zerrendak"
+
+#: id:137
+msgid "Search"
+msgstr "Bilatu"
+
+#: id:138
+msgid "System Information"
+msgstr "Sistemaren Informazioa"
+
+#: id:139
+msgid "Temperatures:"
+msgstr "Temperaturak:"
+
+#: id:140
+msgid "CPU:"
+msgstr "CPU:"
+
+#: id:141
+msgid "GPU:"
+msgstr "GPU:"
+
+#: id:142
+msgid "Time:"
+msgstr "Ordua:"
+
+#: id:143
+msgid "Current:"
+msgstr "Unekoa:"
+
+#: id:144
+msgid "Build:"
+msgstr "Build-a:"
+
+#: id:145
+msgid "Network:"
+msgstr "Sarea:"
+
+#: id:146
+msgid "Type:"
+msgstr "Mota:"
+
+#: id:147
+msgid "Static"
+msgstr "Estatikoa"
+
+#: id:148
+msgid "DHCP"
+msgstr "DHCP"
+
+#: id:149
+msgid "MAC address"
+msgstr "MAC helbidea"
+
+#: id:150
+msgctxt "Auto context with id 150"
+msgid "IP address"
+msgstr "IP helbidea"
+
+#: id:151
+msgid "Link:"
+msgstr "Lotura:"
+
+#: id:152
+msgid "Half duplex"
+msgstr "Half duplex"
+
+#: id:153
+msgid "Full duplex"
+msgstr "Full duplex"
+
+#: id:154
+msgctxt "Auto context with id 154"
+msgid "Storage"
+msgstr "Biltegiratzea"
+
+#: id:155
+msgid "Drive"
+msgstr "Unitatea"
+
+#: id:156
+msgctxt "Auto context with id 156"
+msgid "Free"
+msgstr "Libre"
+
+#: id:157
+msgctxt "Auto context with id 157"
+msgid "Video"
+msgstr "Bideoa"
+
+#: id:158
+msgid "Free memory"
+msgstr "Memoria librea"
+
+#: id:159
+msgid "No link"
+msgstr "Loturarik ez"
+
+#: id:160
+msgctxt "Auto context with id 160"
+msgid "Free"
+msgstr "Libre"
+
+#: id:161
+msgid "Unavailable"
+msgstr "Ez erabilgarri"
+
+#: id:162
+msgid "Tray open"
+msgstr "Ireki bandeja"
+
+#: id:163
+msgid "Reading"
+msgstr "Irakurtzen"
+
+#: id:164
+msgid "No disc"
+msgstr "Diskorik ez"
+
+#: id:165
+msgid "Disc present"
+msgstr "Diskoa aurkeztuta"
+
+#: id:166
+msgid "Skin"
+msgstr "Skin-a"
+
+#: id:169
+msgctxt "Auto context with id 169"
+msgid "Resolution"
+msgstr "Bereizmena"
+
+#: id:170
+msgid "Adjust display refresh rate to match video"
+msgstr "Egokitu erakutsi freskatze tasa bideoarekin bat etortzeko"
+
+#: id:172
+msgid "Release date"
+msgstr "Argitaratze data"
+
+#: id:173
+msgid "Display 4:3 videos as"
+msgstr "Erakutsi 4:3 bideoak"
+
+#: id:175
+msgid "Moods"
+msgstr "Mood-ak"
+
+#: id:176
+msgid "Styles"
+msgstr "Estiloak"
+
+#: id:179
+msgid "Song"
+msgstr "Abestia"
+
+#: id:180
+msgid "Duration"
+msgstr "Iraupena"
+
+#: id:181
+msgid "Select album"
+msgstr "Hautatu albuma"
+
+#: id:182
+msgid "Tracks"
+msgstr "Pistak"
+
+#: id:183
+msgid "Review"
+msgstr "Berrikusi"
+
+#: id:184
+msgid "Refresh"
+msgstr "Freskatu"
+
+#: id:185
+msgid "Searching album"
+msgstr "Albuma bilatzen"
+
+#: id:186
+msgid "OK"
+msgstr "Ados"
+
+#: id:187
+msgid "No albums found!"
+msgstr "Ez da albumik aurkitu!"
+
+#: id:188
+msgid "Select all"
+msgstr "Hautatu dena"
+
+#: id:189
+msgid "Scanning media info"
+msgstr "Eskaneatzen mediaren informazioa"
+
+#: id:190
+msgid "Save"
+msgstr "Gorde"
+
+#: id:191
+msgid "Shuffle"
+msgstr "Nahastu"
+
+#: id:192
+msgctxt "Auto context with id 192"
+msgid "Clear"
+msgstr "Garbitu"
+
+#: id:193
+msgctxt "Auto context with id 193"
+msgid "Scan"
+msgstr "Eskaneatu"
+
+#: id:194
+msgid "Searching..."
+msgstr "Bilatzen..."
+
+#: id:195
+msgid "No info found!"
+msgstr "Ez da inforik aurkitu!"
+
+#: id:196
+msgid "Select movie:"
+msgstr "Hautatu filma:"
+
+#: id:197
+msgid "Querying %s info"
+msgstr "%sren informazioa kontsultatzen"
+
+#: id:198
+msgid "Loading movie details"
+msgstr "Filmaren xehetasunak kargatzen"
+
+#: id:199
+msgid "Web interface"
+msgstr "Web interfazea"
+
+#: id:202
+msgid "Tagline"
+msgstr "Tagline"
+
+#: id:203
+msgid "Plot outline"
+msgstr "Sipnosia"
+
+#: id:205
+msgid "Votes"
+msgstr "Botoak"
+
+#: id:206
+msgid "Cast"
+msgstr "Antzezleak"
+
+#: id:207
+msgid "Plot"
+msgstr "Argumentua"
+
+#: id:208
+msgctxt "Auto context with id 208"
+msgid "Play"
+msgstr "Play"
+
+#: id:209
+msgid "Next"
+msgstr "Hurrengoa"
+
+#: id:210
+msgid "Previous"
+msgstr "Aurrekoa"
+
+#: id:213
+msgid "Calibrate user interface..."
+msgstr "Kalibratu erabiltzailearen interfazea..."
+
+#: id:214
+msgid "Video calibration..."
+msgstr "Bideoaren kalibrazioa..."
+
+#: id:215
+msgid "Soften"
+msgstr "Bigundu"
+
+#: id:216
+msgid "Zoom amount"
+msgstr "Zoom kopurua"
+
+#: id:217
+msgid "Pixel ratio"
+msgstr "Pixel erlazioa"
+
+#: id:218
+msgid "DVD drive"
+msgstr "DVD unitatea"
+
+#: id:219
+msgid "Please insert disc"
+msgstr "Mesedez sar ezazu disko bat"
+
+#: id:220
+msgid "Remote share"
+msgstr "Urruneko partekatzea"
+
+#: id:221
+msgid "Network is not connected"
+msgstr "Sarea ez dago konektaturik"
+
+#: id:222
+msgid "Cancel"
+msgstr "Utzi"
+
+#: id:224
+msgid "Speed"
+msgstr "Abiadura"
+
+#: id:225
+msgid "Vertical Shift"
+msgstr ""
+
+#: id:226
+msgid "Test patterns..."
+msgstr "Probatu ereduak..."
+
+#: id:227
+msgid "Lookup audio CD track names from freedb.org"
+msgstr "Bilatu audio CDaren pisten izenak freedb.org-en"
+
+#: id:228
+msgid "Shuffle playlist on load"
+msgstr "Nahastu erreprodukzio zerrenda kargatzean"
+
+#: id:229
+msgid "HDD spindown time"
+msgstr "HDDa itzaltzeko denbora"
+
+#: id:230
+msgid "Video filters"
+msgstr "Bideoaren iragazkiak"
+
+#: id:231
+msgctxt "Auto context with id 231"
+msgid "None"
+msgstr "Bat ere ez"
+
+#: id:232
+msgid "Point"
+msgstr "Puntua"
+
+#: id:233
+msgid "Linear"
+msgstr "Linearra"
+
+#: id:234
+msgid "Anisotropic"
+msgstr "Anisotropikoa"
+
+#: id:235
+msgid "Quincunx"
+msgstr "Quincunx"
+
+#: id:236
+msgid "Gaussian cubic"
+msgstr "Kubo Gaussiarra"
+
+#: id:237
+msgid "Minification"
+msgstr "Txikitzea"
+
+#: id:238
+msgid "Magnification"
+msgstr "Handitzea"
+
+#: id:239
+msgid "Clear playlist on finish"
+msgstr "Garbitu zerrenda Amaitzean"
+
+#: id:240
+msgid "Display Mode"
+msgstr "Bistaratze modua"
+
+#: id:241
+msgid "Full Screen #%d"
+msgstr "Pantaila osoa #%d"
+
+#: id:242
+msgid "Windowed"
+msgstr "Leihoan"
+
+#: id:243
+msgid "Refresh Rate"
+msgstr "Freskatze-tasa"
+
+#: id:244
+msgid "Full screen"
+msgstr "Pantaila osoa"
+
+#: id:245
+msgid "Sizing: (%i,%i)->(%i,%i) (Zoom x%2.2f) AR:%2.2f:1 (Pixels: %2.2f:1) (VShift: %2.2f)"
+msgstr "Tamaina: (%i,%i)->(%i,%i) (Zoom-a x%2.2f) AR:%2.2f:1 (Pixelak: %2.2f:1)"
+
+#: id:247
+msgctxt "Auto context with id 247"
+msgid "Scripts"
+msgstr "Script-ak"
+
+#: id:248
+msgctxt "Auto context with id 248"
+msgid "Language"
+msgstr "Hizkuntza"
+
+#: id:249
+msgctxt "Auto context with id 249"
+msgid "Music"
+msgstr "Musika"
+
+#: id:250
+msgctxt "Auto context with id 250"
+msgid "Visualization"
+msgstr "Bisualizazioa"
+
+#: id:251
+msgid "Select destination directory"
+msgstr "Hautatu helburuko direktorioa"
+
+#: id:252
+msgid "Output stereo to all speakers"
+msgstr "Stereo bozgoragailu guztietara"
+
+#: id:253
+msgid "Number of channels"
+msgstr "Kanal kopurua"
+
+#: id:254
+msgid "- DTS capable receiver"
+msgstr "- DTS gaitasuna duen hartzailea"
+
+#: id:255
+msgid "CDDB"
+msgstr "CDDB"
+
+#: id:256
+msgid "Fetching CD information"
+msgstr "CDaren informazioa eskuratzen"
+
+#: id:257
+msgid "Error"
+msgstr "Errorea"
+
+#: id:258
+msgid "Enable tag reading"
+msgstr "Gaitu etiketa irakurketa"
+
+#: id:259
+msgid "Opening"
+msgstr "Irekitzen"
+
+#: id:260
+msgid "Shoutcast"
+msgstr "Shoutcast"
+
+#: id:261
+msgid "Waiting for start..."
+msgstr "Hasteko zain..."
+
+#: id:262
+msgid "Scripts output"
+msgstr "Script-en irteera"
+
+#: id:263
+msgid "Allow control of XBMC via HTTP"
+msgstr "Onartu XBMC kontrolatzea HTTP bidez"
+
+#: id:264
+msgid "Record"
+msgstr "Grabatu"
+
+#: id:265
+msgid "Stop Rec."
+msgstr "Gelditu gra."
+
+#: id:266
+msgid "Sort by: Track"
+msgstr "Ordenatu: Pista"
+
+#: id:267
+msgid "Sort by: Time"
+msgstr "Ordenatu: Ordua"
+
+#: id:268
+msgid "Sort by: Title"
+msgstr "Ordenatu: Titulua"
+
+#: id:269
+msgid "Sort by: Artist"
+msgstr "Ordenatu: Artista"
+
+#: id:270
+msgid "Sort by: Album"
+msgstr "Ordenatu: Albuma"
+
+#: id:271
+msgid "Top 100"
+msgstr "Top 100"
+
+#: id:272
+msgid "Top-Left overscan compensation"
+msgstr "Goi Ezkerreko overscan konpentsazioa"
+
+#: id:273
+msgid "Bottom-Right overscan compensation"
+msgstr "Behe Eskumako overscan konpentsazioa"
+
+#: id:274
+msgid "Subtitle positioning"
+msgstr "Azpitituluen posizionamendua"
+
+#: id:275
+msgid "Pixel ratio adjustment"
+msgstr "Pixel erlazioa egokitu"
+
+#: id:276
+msgid "Adjust the arrow to change the amount of overscan"
+msgstr "Egokitu gezia aldatzeko overscan kopurua"
+
+#: id:277
+msgid "Adjust the bar to change the subtitles position"
+msgstr "Egokitu barra azpitituluen posizioa aldatzeko"
+
+#: id:278
+msgid "Adjust the rectangle so it is perfectly square"
+msgstr "Egokitu laukizuzena erabat karratua izateko"
+
+#: id:279
+msgid "Unable to load settings"
+msgstr "Ezin izan dira ezarpenak kargatu"
+
+#: id:280
+msgid "Using default settings"
+msgstr "Ezarpen lehenetsiak erabiltzen"
+
+#: id:281
+msgid "Please check the XML files"
+msgstr "Egiaztatu XML fitxategiak"
+
+#: id:282
+msgid "Found %i items"
+msgstr "%i item aurkitu dira"
+
+#: id:283
+msgid "Search results"
+msgstr "Bilaketaren emaitzak"
+
+#: id:284
+msgid "No results found"
+msgstr "Ez da emaitzarik aurkitu"
+
+#: id:287
+msgctxt "Auto context with id 287"
+msgid "Subtitles"
+msgstr "Azpitituluak"
+
+#: id:288
+msgctxt "Auto context with id 288"
+msgid "Font"
+msgstr "Letra"
+
+#: id:289
+msgctxt "Auto context with id 289"
+msgid "- Size"
+msgstr "- Tamaina"
+
+#: id:290
+msgid "Dynamic range compression"
+msgstr "Sorta konpresio dinamikoa"
+
+#: id:291
+msgctxt "Auto context with id 291"
+msgid "Video"
+msgstr "Bideoa"
+
+#: id:292
+msgctxt "Auto context with id 292"
+msgid "Audio"
+msgstr "Audioa"
+
+#: id:293
+msgid "Browse for subtitles"
+msgstr "Azpitituluak aurkitzeko arakatu"
+
+#: id:294
+msgid "Create bookmark"
+msgstr "Sortu lasterbideak"
+
+#: id:296
+msgid "Clear bookmarks"
+msgstr "Garbitu lasterbideak"
+
+#: id:297
+msgid "Audio offset"
+msgstr "Audio desplazamendua"
+
+#: id:298
+msgid "Bookmarks"
+msgstr "Lastermarkak"
+
+#: id:299
+msgid "- AAC capable receiver"
+msgstr "- AAC gai den hartzailea"
+
+#: id:300
+msgid "- MP1 capable receiver"
+msgstr "- MP1 gai den hartzailea"
+
+#: id:301
+msgid "- MP2 capable receiver"
+msgstr "- MP2 gai den hartzailea"
+
+#: id:302
+msgid "- MP3 capable receiver"
+msgstr "- MP3 gai den hartzailea"
+
+#: id:303
+msgid "Delay"
+msgstr "Atzerapena"
+
+#: id:304
+msgctxt "Auto context with id 304"
+msgid "Language"
+msgstr "Hizkuntza"
+
+#: id:305
+msgctxt "Auto context with id 305"
+msgid "Enabled"
+msgstr "Gaituta"
+
+#: id:306
+msgid "Non-interleaved"
+msgstr "Ez-interleaved"
+
+#: id:312
+msgid "(0=auto)"
+msgstr "(0=auto)"
+
+#: id:313
+msgid "Cleaning database"
+msgstr "Datu basea garbitzen"
+
+#: id:314
+msgid "Preparing..."
+msgstr "Prestatzen..."
+
+#: id:315
+msgid "Database error"
+msgstr "Datu-base errorea"
+
+#: id:316
+msgid "Searching songs..."
+msgstr "Abestiak bilatzen..."
+
+#: id:317
+msgid "Cleaned database successfully"
+msgstr "Datubasearen garbiketa arrakastatxua"
+
+#: id:318
+msgid "Cleaning songs..."
+msgstr "Abestiak garbitzen..."
+
+#: id:319
+msgid "Error cleaning songs"
+msgstr "Errorea abestiak garbitzean"
+
+#: id:320
+msgid "Cleaning artists..."
+msgstr "Artistak garbitzen..."
+
+#: id:321
+msgid "Error cleaning artists"
+msgstr "Errorea artistak garbitzean"
+
+#: id:322
+msgid "Cleaning genres..."
+msgstr "Generoak garbitzen..."
+
+#: id:323
+msgid "Error cleaning genres"
+msgstr "Errorea generoak garbitzean"
+
+#: id:324
+msgid "Cleaning paths..."
+msgstr "Bideak garbitzen..."
+
+#: id:325
+msgid "Error cleaning paths"
+msgstr "Errorea bideak garbitzean"
+
+#: id:326
+msgid "Cleaning albums..."
+msgstr "Albumak garbitzen..."
+
+#: id:327
+msgid "Error cleaning albums"
+msgstr "Errorea albumak garbitzean"
+
+#: id:328
+msgid "Writing changes..."
+msgstr "Aldaketak idazten..."
+
+#: id:329
+msgid "Error writing changes"
+msgstr "Error writing changes"
+
+#: id:330
+msgid "This may take some time..."
+msgstr "Honek denbora piska bat beharko du..."
+
+#: id:331
+msgid "Compressing database..."
+msgstr "Datubasea konprimitzen..."
+
+#: id:332
+msgid "Error compressing database"
+msgstr "Errorea datubasea konprimitzen"
+
+#: id:333
+msgid "Do you want to clean the library?"
+msgstr "Liburutegia garbitu nahi duzu?"
+
+#: id:334
+msgid "Clean library..."
+msgstr "Garbitu liburutegia..."
+
+#: id:335
+msgid "Start"
+msgstr "Hasi"
+
+#: id:336
+msgid "Framerate conversion"
+msgstr "Fotograma-tasa bihurketa"
+
+#: id:337
+msgctxt "Auto context with id 337"
+msgid "Audio output"
+msgstr "Audio irteera"
+
+#: id:338
+msgid "Analog"
+msgstr "Analogikoa"
+
+#: id:339
+msgid "Optical/Coax"
+msgstr "Optikoa/Coax"
+
+#: id:340
+msgid "Various artists"
+msgstr "Hainbat artista"
+
+#: id:341
+msgid "Play disc"
+msgstr "Diskoa erreproduzitu"
+
+#: id:342
+msgctxt "Auto context with id 342"
+msgid "Movies"
+msgstr "Filmak"
+
+#: id:343
+msgid "Adjust framerate"
+msgstr "Egokitu fotograma-tasa"
+
+#: id:344
+msgid "Actors"
+msgstr "Aktoreak"
+
+#: id:345
+msgctxt "Auto context with id 345"
+msgid "Year"
+msgstr "Urtea"
+
+#: id:346
+msgid "Boost volume level on downmix"
+msgstr "Bultzatu bolumena downmix mailara"
+
+#: id:350
+msgctxt "Auto context with id 350"
+msgid "Programs"
+msgstr "Programak"
+
+#: id:351
+msgctxt "Auto context with id 351"
+msgid "Off"
+msgstr "Off"
+
+#: id:352
+msgid "Dim"
+msgstr "Dim"
+
+#: id:353
+msgid "Black"
+msgstr "Beltza"
+
+#: id:354
+msgid "Matrix trails"
+msgstr "Matrize ibilbidea"
+
+#: id:355
+msgid "Screensaver time"
+msgstr "Babeslearen denbora"
+
+#: id:356
+msgid "Screensaver mode"
+msgstr "Babeslearen modua"
+
+#: id:357
+msgid "Shutdown function timer"
+msgstr "Itzaltzeko funtzioaren tenporizadorea"
+
+#: id:358
+msgid "All albums"
+msgstr "Album guztiak"
+
+#: id:359
+msgid "Recently added albums"
+msgstr "Orain dela gutxi gehitutako albuma"
+
+#: id:360
+msgctxt "Auto context with id 360"
+msgid "Screensaver"
+msgstr "Babeslea"
+
+#: id:361
+msgid "R. Slideshow"
+msgstr "Diapositiba errekurtsiboa"
+
+#: id:362
+msgid "Screensaver dim level"
+msgstr "Babeslea iluntzeko maila"
+
+#: id:363
+msgid "Sort by: File"
+msgstr "Ordenatu: Fitxategia"
+
+#: id:364
+msgid "- Dolby Digital (AC3) capable receiver"
+msgstr "- Dolby Digital (AC3) gai den hartzailea"
+
+#: id:365
+msgctxt "Auto context with id 365"
+msgid "Sort by: Name"
+msgstr "Ordenatu: Izena"
+
+#: id:366
+msgid "Sort by: Year"
+msgstr "Ordenatu: Urtea"
+
+#: id:367
+msgid "Sort by: Rating"
+msgstr "Ordenatu: Balorazioa"
+
+#: id:368
+msgid "IMDb"
+msgstr "IMDb"
+
+#: id:369
+msgctxt "Auto context with id 369"
+msgid "Title"
+msgstr "Titulua"
+
+#: id:370
+msgid "Thunderstorms"
+msgstr "Thunderstorms"
+
+#: id:371
+msgid "Partly"
+msgstr "Partzialki"
+
+#: id:372
+msgid "Mostly"
+msgstr "Gehienbat"
+
+#: id:373
+msgid "Sunny"
+msgstr "Eguzkitsu"
+
+#: id:374
+msgid "Cloudy"
+msgstr "Lainotuta"
+
+#: id:375
+msgid "Snow"
+msgstr "Elurra"
+
+#: id:376
+msgid "Rain"
+msgstr "Euria"
+
+#: id:377
+msgid "Light"
+msgstr "Argia"
+
+#: id:378
+msgid "AM"
+msgstr "AM"
+
+#: id:379
+msgid "PM"
+msgstr "PM"
+
+#: id:380
+msgid "Showers"
+msgstr "Zaparradak"
+
+#: id:381
+msgid "Few"
+msgstr "Gutxi batzuk"
+
+#: id:382
+msgid "Scattered"
+msgstr "Sakabanatuak"
+
+#: id:383
+msgctxt "Auto context with id 383"
+msgid "Wind"
+msgstr "Haizea"
+
+#: id:384
+msgid "Strong"
+msgstr "Indartsua"
+
+#: id:385
+msgid "Fair"
+msgstr "Egokia"
+
+#: id:386
+msgctxt "Auto context with id 386"
+msgid "Clear"
+msgstr "Oskarbi"
+
+#: id:387
+msgid "Clouds"
+msgstr "Lainoak"
+
+#: id:388
+msgid "Early"
+msgstr "Goiz"
+
+#: id:389
+msgid "Shower"
+msgstr "Zaparrada"
+
+#: id:390
+msgid "Flurries"
+msgstr "Elur gutxi"
+
+#: id:391
+msgctxt "Auto context with id 391"
+msgid "Low"
+msgstr "Baxua"
+
+#: id:392
+msgctxt "Auto context with id 392"
+msgid "Medium"
+msgstr "Tartekoa"
+
+#: id:393
+msgctxt "Auto context with id 393"
+msgid "High"
+msgstr "Altua"
+
+#: id:394
+msgid "Fog"
+msgstr "Behe lainoa"
+
+#: id:395
+msgid "Haze"
+msgstr "Lanbroa"
+
+#: id:396
+msgid "Select location"
+msgstr "Hautatu kokalekua"
+
+#: id:397
+msgid "Refresh time"
+msgstr "Freskatze denbora"
+
+#: id:398
+msgid "Temperature units"
+msgstr "Tenperaturaren unitatea"
+
+#: id:399
+msgid "Speed units"
+msgstr "Abiadura unitateak"
+
+#: id:400
+msgctxt "Auto context with id 400"
+msgid "Weather"
+msgstr "Eguraldia"
+
+#: id:401
+msgid "Temp"
+msgstr "Temp"
+
+#: id:402
+msgid "Feels like"
+msgstr "Sentsazio ter."
+
+#: id:403
+msgid "UV index"
+msgstr "UV indizea"
+
+#: id:404
+msgctxt "Auto context with id 404"
+msgid "Wind"
+msgstr "Haizea"
+
+#: id:405
+msgid "Dew point"
+msgstr "Kondentsazioa"
+
+#: id:406
+msgid "Humidity"
+msgstr "Hezetasuna"
+
+#: id:409
+msgid "Defaults"
+msgstr "Lehenetsiak"
+
+#: id:410
+msgid "Accessing weather service"
+msgstr "Eguraldi zerbitzura sartzen"
+
+#: id:411
+msgid "Getting weather for:"
+msgstr "Eguraldia lortzen:"
+
+#: id:412
+msgid "Unable to get weather data"
+msgstr "Unable to get weather data"
+
+#: id:413
+msgid "Manual"
+msgstr "Eskuz"
+
+#: id:414
+msgid "No review for this album"
+msgstr "Album honek ez du berrikuspenik"
+
+#: id:415
+msgid "Downloading thumbnail..."
+msgstr "Iruditxoa deskargatzen..."
+
+#: id:416
+msgid "Not available"
+msgstr "Ez dago eskuragarri"
+
+#: id:417
+msgid "View: Big icons"
+msgstr "Ikusi: ikono handiak"
+
+#: id:418
+msgctxt "Auto context with id 418"
+msgid "Low"
+msgstr "Min"
+
+#: id:419
+msgctxt "Auto context with id 419"
+msgid "High"
+msgstr "Max"
+
+#: id:420
+msgid "HDMI"
+msgstr "HDMI"
+
+#: id:422
+msgid "Delete album info"
+msgstr "Ezabatu album info"
+
+#: id:423
+msgid "Delete CD information"
+msgstr "Ezabatu CDaren informazioa"
+
+#: id:424
+msgid "Select"
+msgstr "Hautatu"
+
+#: id:425
+msgid "No album information found"
+msgstr "Albumaren informazioa ez da aurkitu"
+
+#: id:426
+msgid "No CD information found"
+msgstr "CDaren informazioa ez da aurkitu"
+
+#: id:427
+msgid "Disc"
+msgstr "Diskoa"
+
+#: id:428
+msgid "Insert correct CD/DVD"
+msgstr "Sartu CD/DVD zuzena"
+
+#: id:429
+msgid "Please insert the following disc:"
+msgstr "Mesedez, sartu honako CD/DVD hau"
+
+#: id:430
+msgid "Sort by: DVD#"
+msgstr "Ordenatu: DVD#"
+
+#: id:431
+msgid "No cache"
+msgstr "Ez dago katxerik"
+
+#: id:432
+msgid "Remove movie from library"
+msgstr "Ezabatu filma liburutegitik"
+
+#: id:433
+msgid "Really remove '%s'?"
+msgstr "Benetan kendu '%s'?"
+
+#: id:434
+msgid "From %s at %i %s"
+msgstr "%s-tik %i %s-ko abiaduraz"
+
+#: id:437
+msgid "Removable disk"
+msgstr "Disko aldagarria"
+
+#: id:438
+msgid "Opening file"
+msgstr "Fitxategia irekitzen"
+
+#: id:439
+msgid "Cache"
+msgstr "Katxea"
+
+#: id:440
+msgid "Harddisk"
+msgstr "Disko gogorra"
+
+#: id:441
+msgid "UDF"
+msgstr "UDF"
+
+#: id:442
+msgid "Local network"
+msgstr "Sare lokala"
+
+#: id:443
+msgid "Internet"
+msgstr "Internet"
+
+#: id:444
+msgctxt "Auto context with id 444"
+msgid "Video"
+msgstr "Bideoa"
+
+#: id:445
+msgctxt "Auto context with id 445"
+msgid "Audio"
+msgstr "Audioa"
+
+#: id:446
+msgctxt "Auto context with id 446"
+msgid "DVD"
+msgstr "DVD"
+
+#: id:447
+msgid "Autorun media"
+msgstr "Autorun media"
+
+#: id:448
+msgid "LCD"
+msgstr "LCD"
+
+#: id:449
+msgctxt "Auto context with id 449"
+msgid "Enabled"
+msgstr "Gaituta"
+
+#: id:450
+msgid "Columns"
+msgstr "Zutabeak"
+
+#: id:451
+msgid "Row 1 address"
+msgstr "1.errenkadaren helbidea"
+
+#: id:452
+msgid "Row 2 address"
+msgstr "2.errenkadaren helbidea"
+
+#: id:453
+msgid "Row 3 address"
+msgstr "3.errenkadaren helbidea"
+
+#: id:454
+msgid "Row 4 address"
+msgstr "4.errenkadaren helbidea"
+
+#: id:455
+msgid "Rows"
+msgstr "Errenkadak"
+
+#: id:456
+msgid "Mode"
+msgstr "Modua"
+
+#: id:457
+msgid "Switch view"
+msgstr "Aldatu ikuspegia"
+
+#: id:459
+msgid "Subs"
+msgstr "Azpitituluak"
+
+#: id:460
+msgid "Audio stream"
+msgstr "Audio stream-a"
+
+#: id:461
+msgid "[active]"
+msgstr "[aktiboa]"
+
+#: id:462
+msgid "Subtitle"
+msgstr "Azpititulua"
+
+#: id:463
+msgid "Backlight"
+msgstr "Atzeko argitasuna"
+
+#: id:464
+msgid "Brightness"
+msgstr "Distira"
+
+#: id:465
+msgid "Contrast"
+msgstr "Kontrastea"
+
+#: id:466
+msgid "Gamma"
+msgstr "Gamma"
+
+#: id:467
+msgctxt "Auto context with id 467"
+msgid "Type"
+msgstr "Mota"
+
+#: id:468
+msgid "Move the bar to change the OSD position"
+msgstr "Eraman barra OSD posizioa aldatzeko"
+
+#: id:469
+msgid "OSD position"
+msgstr "OSDaren posizioa"
+
+#: id:470
+msgid "Credits"
+msgstr "Kredituak"
+
+#: id:471
+msgid "Modchip"
+msgstr "Modchip-a"
+
+#: id:474
+msgctxt "Auto context with id 474"
+msgid "Off"
+msgstr "Off"
+
+#: id:475
+msgid "Music only"
+msgstr "Musika bakarrik"
+
+#: id:476
+msgctxt "Auto context with id 476"
+msgid "Music & video"
+msgstr "Musika eta bideoa"
+
+#: id:477
+msgid "Unable to load playlist"
+msgstr "Ezin da zerrenda kargatu"
+
+#: id:478
+msgid "OSD"
+msgstr "OSD"
+
+#: id:479
+msgid "Skin & language"
+msgstr "Skin-a eta hizkuntza"
+
+#: id:480
+msgid "Appearance"
+msgstr "Itxura"
+
+#: id:481
+msgid "Audio options"
+msgstr "Audioaren aukerak"
+
+#: id:482
+msgid "About XBMC"
+msgstr "XBMCri buruz"
+
+#: id:485
+msgid "Delete album"
+msgstr "Ezabatu albuma"
+
+#: id:486
+msgid "Repeat"
+msgstr "Errepikatu"
+
+#: id:487
+msgid "Repeat one"
+msgstr "Errepikatu bat"
+
+#: id:488
+msgid "Repeat folder"
+msgstr "Errepikatu karpeta"
+
+#: id:489
+msgid "Play the next song automatically"
+msgstr "Erreproduzitu hurrengo abestia automatikoki"
+
+#: id:491
+msgid "- Use big icons"
+msgstr "- Erabili ikono handiak"
+
+#: id:492
+msgid "Resize VobSubs"
+msgstr "Tamaina aldatu VobSubs-i"
+
+#: id:493
+msgid "Advanced options (Experts Only!)"
+msgstr "Aukera aurreratuak (Adituentzako bakarrik!)"
+
+#: id:494
+msgid "Overall audio headroom"
+msgstr "Orokorrean audio distortsiorik gabeko bolumena"
+
+#: id:495
+msgid "Upsample videos to GUI resolution"
+msgstr "Bideoen tamaina aldatu interfazearen bereizmeneraino"
+
+#: id:496
+msgid "Calibration"
+msgstr "Kalibrazioa"
+
+#: id:497
+msgid "Show file extensions"
+msgstr "Erakutsi fitxategi-luzapenak"
+
+#: id:498
+msgid "Sort by: Type"
+msgstr "Ordenatu: Mota"
+
+#: id:499
+msgid "Unable to connect to online lookup service"
+msgstr "Ezin da lineako bilaketak zerbitzuarekin harremanetan jarri"
+
+#: id:500
+msgid "Downloading album information failed"
+msgstr "Albumaren informazioaren deskargak huts egin du"
+
+#: id:501
+msgid "Looking for album names..."
+msgstr "Albumen izenak bilatzen ..."
+
+#: id:502
+msgctxt "Auto context with id 502"
+msgid "Open"
+msgstr "Ireki"
+
+#: id:503
+msgid "Busy"
+msgstr "Okupatuta"
+
+#: id:504
+msgid "Empty"
+msgstr "Hutsik"
+
+#: id:505
+msgid "Loading media info from files..."
+msgstr "Kargatzen media fitxategien info..."
+
+#: id:507
+msgid "Sort by: Usage"
+msgstr "Ordenatu: Erabilera"
+
+#: id:510
+msgid "Enable visualizations"
+msgstr "Gaitu bisualizazioak"
+
+#: id:511
+msgid "Enable video mode switching"
+msgstr "Gaitu bideo modua aldatzea"
+
+#: id:512
+msgid "Startup window"
+msgstr "Abioko leihoa"
+
+#: id:513
+msgid "Home window"
+msgstr "Hasiera leihoa"
+
+#: id:514
+msgid "Manual settings"
+msgstr "Eskuzko ezarpenak"
+
+#: id:515
+msgid "Genre"
+msgstr "Generoa"
+
+#: id:517
+msgid "Recently played albums"
+msgstr "Duela gutxi erreproduzitutako albumak"
+
+#: id:518
+msgid "Launch"
+msgstr "Abiarazi"
+
+#: id:519
+msgid "Launch in..."
+msgstr "Abiarazi..."
+
+#: id:521
+msgid "Compilations"
+msgstr "Konpilazioak"
+
+#: id:522
+msgid "Remove source"
+msgstr "Kendu Iturria"
+
+#: id:523
+msgid "Switch media"
+msgstr "Aldatu media"
+
+#: id:524
+msgid "Select playlist"
+msgstr "Hautatu zerrenda"
+
+#: id:525
+msgid "New playlist..."
+msgstr "Zerrenda berria..."
+
+#: id:526
+msgid "Add to playlist"
+msgstr "Gehitu zerrendara"
+
+#: id:527
+msgid "Manually add to library"
+msgstr "Eskuz gehitu liburutegia"
+
+#: id:528
+msgid "Enter title"
+msgstr "Izenburua idatzi"
+
+#: id:529
+msgid "Error: Duplicate title"
+msgstr "Errorea: Bikoiztutako izenburua"
+
+#: id:530
+msgid "Select genre"
+msgstr "Hautatu generoa"
+
+#: id:531
+msgid "New genre"
+msgstr "Genero berria"
+
+#: id:532
+msgid "Manual addition"
+msgstr "Eskuz gehitu"
+
+#: id:533
+msgid "Enter genre"
+msgstr "Idatzi generoa"
+
+#: id:534
+msgid "View: %s"
+msgstr "Ikusi: %s"
+
+#: id:535
+msgid "List"
+msgstr "Zerrenda"
+
+#: id:536
+msgid "Icons"
+msgstr "Ikonoak"
+
+#: id:537
+msgid "Big list"
+msgstr "Zerrenda handia"
+
+#: id:538
+msgid "Big icons"
+msgstr "Ikono handiak"
+
+#: id:539
+msgid "Wide"
+msgstr "Zabala"
+
+#: id:540
+msgid "Big wide"
+msgstr "Oso zabala"
+
+#: id:541
+msgid "Album icons"
+msgstr "Albumaren ikonoak"
+
+#: id:542
+msgid "DVD icons"
+msgstr "DVDaren ikonoak"
+
+#: id:543
+msgctxt "Auto context with id 543"
+msgid "DVD"
+msgstr "DVD"
+
+#: id:544
+msgctxt "Auto context with id 544"
+msgid "Media info"
+msgstr "Mediaren info"
+
+#: id:545
+msgid "Audio output device"
+msgstr "Audio irteera gailua"
+
+#: id:546
+msgid "Passthrough output device"
+msgstr "Irteerako iragazki gailua"
+
+#: id:547
+msgid "No biography for this artist"
+msgstr "Ez dago artista honen biografia"
+
+#: id:548
+msgid "Downmix multichannel audio to stereo"
+msgstr "Kanal anitzeko downmix-a edo estereo audioa"
+
+#: id:550
+msgid "Sort by: %s"
+msgstr "Ordenatu: %s"
+
+#: id:551
+msgctxt "Auto context with id 551"
+msgid "Name"
+msgstr "Izena"
+
+#: id:552
+msgid "Date"
+msgstr "Data"
+
+#: id:553
+msgid "Size"
+msgstr "Tamaina"
+
+#: id:554
+msgid "Track"
+msgstr "Pista"
+
+#: id:555
+msgid "Time"
+msgstr "Denbora"
+
+#: id:556
+msgctxt "Auto context with id 556"
+msgid "Title"
+msgstr "Titulua"
+
+#: id:557
+msgid "Artist"
+msgstr "Artista"
+
+#: id:558
+msgid "Album"
+msgstr "Albuma"
+
+#: id:559
+msgid "Playlist"
+msgstr "Zerrenda"
+
+#: id:560
+msgid "ID"
+msgstr "ID"
+
+#: id:561
+msgctxt "Auto context with id 561"
+msgid "File"
+msgstr "Fitxategia"
+
+#: id:562
+msgctxt "Auto context with id 562"
+msgid "Year"
+msgstr "Urtea"
+
+#: id:563
+msgid "Rating"
+msgstr "Balorazioa"
+
+#: id:564
+msgctxt "Auto context with id 564"
+msgid "Type"
+msgstr "Mota"
+
+#: id:565
+msgid "Usage"
+msgstr "Erabilera"
+
+#: id:566
+msgid "Album artist"
+msgstr "Albumaren artista"
+
+#: id:567
+msgid "Play count"
+msgstr "Erreproduzitze kopurua"
+
+#: id:568
+msgid "Last played"
+msgstr "Azken erre."
+
+#: id:569
+msgctxt "Auto context with id 569"
+msgid "Comment"
+msgstr "Iruzkina"
+
+#: id:570
+msgid "Date added"
+msgstr "Gehitutako data"
+
+#: id:571
+msgctxt "Auto context with id 571"
+msgid "Default"
+msgstr "Lehenetsia"
+
+#: id:572
+msgid "Studio"
+msgstr "Estudioa"
+
+#: id:573
+msgid "Path"
+msgstr "Bidea"
+
+#: id:574
+msgctxt "Auto context with id 574"
+msgid "Country"
+msgstr "Herrialdea"
+
+#: id:575
+msgid "In progress"
+msgstr "Prozesuan"
+
+#: id:576
+msgid "Times played"
+msgstr ""
+
+#: id:580
+msgid "Sort direction"
+msgstr "Ordenatu norabidea"
+
+#: id:581
+msgid "Sort method"
+msgstr "Ordenatzeko metodoa"
+
+#: id:582
+msgctxt "Auto context with id 582"
+msgid "View mode"
+msgstr "Ikusteko modua"
+
+#: id:583
+msgid "Remember views for different folders"
+msgstr "Gogoratu karpeta ezberdinen ikuspegiak"
+
+#: id:584
+msgid "Ascending"
+msgstr "Gorakorra"
+
+#: id:585
+msgid "Descending"
+msgstr "Beherakorra"
+
+#: id:586
+msgid "Edit playlist"
+msgstr "Aldatu zerrenda"
+
+#: id:587
+msgid "Filter"
+msgstr "Iragazi"
+
+#: id:588
+msgid "Cancel party mode"
+msgstr "Bertan behera utzi festa modua"
+
+#: id:589
+msgid "Party mode"
+msgstr "Festa modua"
+
+#: id:590
+msgid "Random"
+msgstr "Ausazkoa"
+
+#: id:591
+msgctxt "Auto context with id 591"
+msgid "Off"
+msgstr "Off"
+
+#: id:592
+msgid "One"
+msgstr "Bat"
+
+#: id:593
+msgid "All"
+msgstr "Denak"
+
+#: id:594
+msgctxt "Auto context with id 594"
+msgid "Off"
+msgstr "Off"
+
+#: id:595
+msgid "Repeat: Off"
+msgstr "Errepikatu: Off"
+
+#: id:596
+msgid "Repeat: One"
+msgstr "Errepikatu: Bat"
+
+#: id:597
+msgid "Repeat: All"
+msgstr "Errepikatu: Dena"
+
+#: id:600
+msgid "Rip audio CD"
+msgstr "Erauzi audioa CDa"
+
+#: id:601
+msgctxt "Auto context with id 601"
+msgid "Medium"
+msgstr "Ertaina"
+
+#: id:602
+msgctxt "Auto context with id 602"
+msgid "Standard"
+msgstr "Estandarra"
+
+#: id:603
+msgid "Extreme"
+msgstr "Extremoa"
+
+#: id:604
+msgid "Constant bitrate"
+msgstr "Bitrate konstantea"
+
+#: id:605
+msgid "Ripping..."
+msgstr "Erauzten..."
+
+#: id:607
+msgid "To:"
+msgstr "Hona:"
+
+#: id:608
+msgid "Could not rip CD or track"
+msgstr "Ezin izan da erauzi CDa edo pista"
+
+#: id:609
+msgid "CDDARipPath is not set."
+msgstr "CDDA Erauzteko bidea ez da ezarri."
+
+#: id:610
+msgid "Rip audio track"
+msgstr "Erauzi audio pista"
+
+#: id:611
+msgid "Enter number"
+msgstr "Zenbakia idatzi"
+
+#: id:612
+msgid "Bits/Sample"
+msgstr "Bitak/Sample"
+
+#: id:613
+msgid "Sample Frequency"
+msgstr "Sample maiztasuna"
+
+#: id:620
+msgid "Audio CDs"
+msgstr "Audio CDak"
+
+#: id:621
+msgid "Encoder"
+msgstr "Kodetzailea"
+
+#: id:622
+msgid "Quality"
+msgstr "Kalitatea"
+
+#: id:623
+msgid "Bitrate"
+msgstr "Bitrate-a"
+
+#: id:624
+msgid "Include track number"
+msgstr "Txertatu pistaren zenbakia"
+
+#: id:625
+msgid "All songs of"
+msgstr "Abesti guztiak"
+
+#: id:629
+msgctxt "Auto context with id 629"
+msgid "View mode"
+msgstr "Ikusteko modua"
+
+#: id:630
+msgctxt "Auto context with id 630"
+msgid "Normal"
+msgstr "Arrunta"
+
+#: id:631
+msgid "Zoom"
+msgstr "Zoom-a"
+
+#: id:632
+msgid "Stretch 4:3"
+msgstr "Egokitu 4:3 formatura"
+
+#: id:633
+msgid "Wide Zoom"
+msgstr "Zoom zabala"
+
+#: id:634
+msgid "Stretch 16:9"
+msgstr "Egokitu 16:9 formatura"
+
+#: id:635
+msgid "Original Size"
+msgstr "Jatorrizko tamaina"
+
+#: id:636
+msgctxt "Auto context with id 636"
+msgid "Custom"
+msgstr "Pertsonalizatua"
+
+#: id:637
+msgid "Replay gain"
+msgstr "Replay gain-a"
+
+#: id:638
+msgid "Replaygain volume adjustments"
+msgstr "Replaygainen bolumenaren doiketa"
+
+#: id:639
+msgid "Use track levels"
+msgstr "Erabili pistaren maila"
+
+#: id:640
+msgid "Use album levels"
+msgstr "Erabili albumaren maila"
+
+#: id:641
+msgid "PreAmp Level - Replay gained files"
+msgstr "PreAmp Level - Replay gain egindako fitxategiak"
+
+#: id:642
+msgid "PreAmp Level - Non replay gained files"
+msgstr "PreAmp Level - Replay gain egin gabeko fitxategiak"
+
+#: id:643
+msgid "Avoid clipping on replay gained files"
+msgstr "Saihestu mozketa replay gain egindako fitxategietan"
+
+#: id:644
+msgid "Crop black bars"
+msgstr "Kendu barra beltzak"
+
+#: id:645
+msgid "Need to unpack a big file. Continue?"
+msgstr "Fitxategi handi bat deskonprimatu behar da. Jarraitu?"
+
+#: id:646
+msgid "Remove from library"
+msgstr "Liburutegitik kendu"
+
+#: id:647
+msgid "Export video library"
+msgstr "Esportatu bideotekara"
+
+#: id:648
+msgid "Import video library"
+msgstr "Inportatu bideotekara"
+
+#: id:649
+msgid "Importing"
+msgstr "Inportatzen"
+
+#: id:650
+msgid "Exporting"
+msgstr "Esportatzen"
+
+#: id:651
+msgid "Browse for library"
+msgstr "Arakatu liburutegia"
+
+#: id:652
+msgid "Years"
+msgstr "Urteak"
+
+#: id:653
+msgid "Update library"
+msgstr "Eguneratu liburutegia"
+
+#: id:654
+msgid "Show debug info"
+msgstr "Erakutsi arazketaren info"
+
+#: id:655
+msgid "Browse for executable"
+msgstr "Arakatu exekutagarria"
+
+#: id:656
+msgid "Browse for playlist"
+msgstr "Zerrenda Arakatu"
+
+#: id:657
+msgid "Browse for folder"
+msgstr "Arakatu karpeta"
+
+#: id:658
+msgid "Song information"
+msgstr "Abestiei buruzko informazioa"
+
+#: id:659
+msgid "Non-linear stretch"
+msgstr "Zati ez-lineala"
+
+#: id:660
+msgid "Volume amplification"
+msgstr "Bolumenaren anplifikazioa"
+
+#: id:661
+msgid "Choose export folder"
+msgstr "Hautatu esportatzeko karpeta"
+
+#: id:662
+msgid "This file is no longer available."
+msgstr "Fitxategi hau ez dago eskuragarri."
+
+#: id:663
+msgid "Would you like to remove it from the library?"
+msgstr "Liburutegitik kentzea nahi duzu?"
+
+#: id:664
+msgid "Browse for Script"
+msgstr "Scripta Arakatu"
+
+#: id:665
+msgid "Compression level"
+msgstr "Konpresio maila"
+
+#: id:700
+msgid "Cleaning up library"
+msgstr "Liburutegia garbitzen"
+
+#: id:701
+msgid "Removing old songs from the library"
+msgstr "Kanta zaharrak liburutegitik kentzen"
+
+#: id:702
+msgid "This path has been scanned before"
+msgstr "Bide hau eskaneatua izan da aurretik"
+
+#: id:705
+msgctxt "Auto context with id 705"
+msgid "Network"
+msgstr "Sarea"
+
+#: id:706
+msgid "- Server"
+msgstr "- Zerbitzaria"
+
+#: id:708
+msgid "Use an HTTP proxy server to access the internet"
+msgstr "Erabili HTTP proxy zerbitzaria internetera sartzeko"
+
+#: id:711
+msgid "Internet Protocol (IP)"
+msgstr "Interneteko Protocoloal (IP)"
+
+#: id:712
+msgid "Invalid port specified. Value must be between 1 and 65535."
+msgstr "Ataka baliogabea zehaztu da. Balio hau 1 eta 65535 artekoa izan behar da."
+
+#: id:713
+msgid "HTTP proxy"
+msgstr "HTTP proxy-a"
+
+#: id:715
+msgid "- Assignment"
+msgstr "- Zeregina"
+
+#: id:716
+msgid "Automatic (DHCP)"
+msgstr "Automatikoa (DHCP)"
+
+#: id:717
+msgid "Manual (Static)"
+msgstr "Eskuzkoal (Static)"
+
+#: id:719
+msgid "- IP address"
+msgstr "- IP helbidea"
+
+#: id:720
+msgid "- Netmask"
+msgstr "- Sare-maskara"
+
+#: id:721
+msgid "- Default gateway"
+msgstr "- Lehenetsitako pasabidea"
+
+#: id:722
+msgid "- DNS server"
+msgstr "- DNS zerbitzaria"
+
+#: id:723
+msgid "Save & restart"
+msgstr "Gorde eta berrabiarazi"
+
+#: id:724
+msgid "Invalid address specified. Value must be AAA.BBB.CCC.DDD"
+msgstr "Helbide baliogabea zehaztu da. Balioa AAA.BBB.CCC.DDD izan behar da"
+
+#: id:725
+msgid "with numbers between 0 and 255."
+msgstr "0 eta 255 arteko zenbakiekin."
+
+#: id:726
+msgid "Changes not saved. Continue without saving?"
+msgstr "Aldaketak ez dira gorde. Gorde gabe jarraitu nahi duzu?"
+
+#: id:727
+msgid "Web server"
+msgstr "Web zerbitzaria"
+
+#: id:728
+msgctxt "Auto context with id 728"
+msgid "FTP server"
+msgstr "FTP zerbitzaria"
+
+#: id:730
+msgid "- Port"
+msgstr "- Portua"
+
+#: id:732
+msgid "Save & apply"
+msgstr "Gorde eta aplikatu"
+
+#: id:733
+msgid "- Password"
+msgstr "- Pasahitza"
+
+#: id:734
+msgid "No pass"
+msgstr "Pasahitzik ez"
+
+#: id:735
+msgid "- Character set"
+msgstr "- Karaktere multzoa"
+
+#: id:736
+msgid "- Style"
+msgstr "- Estiloa"
+
+#: id:737
+msgid "- Colour"
+msgstr "- Kolorea"
+
+#: id:738
+msgctxt "Auto context with id 738"
+msgid "Normal"
+msgstr "Arrunta"
+
+#: id:739
+msgid "Bold"
+msgstr "Beltzituta"
+
+#: id:740
+msgid "Italics"
+msgstr "Kurtsibaz"
+
+#: id:741
+msgid "Bold italics"
+msgstr "Beltzituta eta kurtsibaz"
+
+#: id:742
+msgctxt "Auto context with id 742"
+msgid "White"
+msgstr "Zuria"
+
+#: id:743
+msgctxt "Auto context with id 743"
+msgid "Yellow"
+msgstr "Horia"
+
+#: id:744
+msgctxt "Auto context with id 744"
+msgid "Files"
+msgstr "Fitxategiak"
+
+#: id:745
+msgid "No scanned information for this view"
+msgstr "Ez dago eskaneaturiko informaziorik ikuspegi honetarako"
+
+#: id:746
+msgid "Please turn off library mode"
+msgstr "Mesedez itzali liburutegia modua"
+
+#: id:747
+msgid "Error loading image"
+msgstr "Errorea irudia kargatzean"
+
+#: id:748
+msgid "Edit path"
+msgstr "Aldatu bidea"
+
+#: id:749
+msgid "Mirror image"
+msgstr "Ispilu irudia"
+
+#: id:750
+msgid "Are you sure?"
+msgstr "Ziur al zaude?"
+
+#: id:751
+msgid "Removing source"
+msgstr "Iturria kentzen"
+
+#: id:754
+msgid "Add program link"
+msgstr "Gehitu programaren lotura"
+
+#: id:755
+msgid "Edit program path"
+msgstr "Aldatu programaren bidea"
+
+#: id:756
+msgid "Edit program name"
+msgstr "Aldatu programaren izena"
+
+#: id:757
+msgid "Edit path depth"
+msgstr "Aldatu bide sakonera"
+
+#: id:759
+msgid "View: Big list"
+msgstr "Ikusi: Zerrenda handia"
+
+#: id:760
+msgctxt "Auto context with id 760"
+msgid "Yellow"
+msgstr "Horia"
+
+#: id:761
+msgctxt "Auto context with id 761"
+msgid "White"
+msgstr "Zuria"
+
+#: id:762
+msgid "Blue"
+msgstr "Urdina"
+
+#: id:763
+msgid "Bright green"
+msgstr "Berde argia"
+
+#: id:764
+msgid "Yellow green"
+msgstr "Hori berdea"
+
+#: id:765
+msgid "Cyan"
+msgstr "Ziana"
+
+#: id:766
+msgid "Light grey"
+msgstr "Gris argia"
+
+#: id:767
+msgid "Grey"
+msgstr "Grisa"
+
+#: id:770
+msgid "Error %i: share not available"
+msgstr "Errorea %i: partekatzea ez dago erabilgarri"
+
+#: id:772
+msgctxt "Auto context with id 772"
+msgid "Audio output"
+msgstr "Audio irteera"
+
+#: id:773
+msgid "Seeking"
+msgstr "Bila"
+
+#: id:774
+msgid "Slideshow folder"
+msgstr "Aurkezpenaren karpeta"
+
+#: id:775
+msgid "Network interface"
+msgstr "Sareko interfazea"
+
+#: id:776
+msgid "- Wireless network name (ESSID)"
+msgstr "- Haririki gabeko sarearen izena (ESSID)"
+
+#: id:777
+msgid "- Wireless password"
+msgstr "- WLAN pasahitza"
+
+#: id:778
+msgid "- Wireless security"
+msgstr "- WLAN segurtasuna"
+
+#: id:779
+msgid "Save and apply network interface settings"
+msgstr "Gorde eta aplikatu sareko interfazearen ezarpenak"
+
+#: id:780
+msgid "No encryption"
+msgstr "Enkriptatzerik ez"
+
+#: id:781
+msgid "WEP"
+msgstr "WEP"
+
+#: id:782
+msgid "WPA"
+msgstr "WPA"
+
+#: id:783
+msgid "WPA2"
+msgstr "WPA2"
+
+#: id:784
+msgid "Applying network interface settings. Please wait."
+msgstr "Sareko interfaze ezarpenak aplikatzen. Itxaron mesedez."
+
+#: id:785
+msgid "Network interface restarted successfully."
+msgstr "Sareko interfazea berrabiarazi egin da."
+
+#: id:786
+msgid "Network interface did not start successfully."
+msgstr "Sareko interfazea ez da zuzen hasi."
+
+#: id:787
+msgid "Interface disabled"
+msgstr "Interfazea desgaituta"
+
+#: id:788
+msgid "Network interface disabled successfully."
+msgstr "Sareko interfazea desgaitu da."
+
+#: id:789
+msgid "Wireless network name (ESSID)"
+msgstr "Haririk gabeko sarearen izena (ESSID)"
+
+#: id:790
+msgid "Remote control"
+msgstr ""
+
+#: id:791
+msgid "Allow programs on this system to control XBMC"
+msgstr "Onartu sistema honetako programak XBMC kontrolatzea"
+
+#: id:792
+msgctxt "Auto context with id 792"
+msgid "Port"
+msgstr "Portua"
+
+#: id:793
+msgid "Port range"
+msgstr "Portu sorta"
+
+#: id:794
+msgid "Allow programs on other systems to control XBMC"
+msgstr "Baimendu beste sistema bateko programak XBMC kontrolatzea"
+
+#: id:795
+msgid "Initial repeat delay (ms)"
+msgstr "Hasierako atzerapena errepikapena (ms)"
+
+#: id:796
+msgid "Continuous repeat delay (ms)"
+msgstr "Etengabeko errepikapenaren atzerapena (ms)"
+
+#: id:797
+msgid "Maximum number of clients"
+msgstr "Gehienezko bezero kopurua"
+
+#: id:798
+msgid "Internet access"
+msgstr "Interneterako sarbidea"
+
+#: id:850
+msgid "Invalid port number entered"
+msgstr "Baliogabeko portu zenbakia sartu duzu"
+
+#: id:851
+msgid "Valid port range is 1-65535"
+msgstr "Baliozko portu sorta 1-65535 da"
+
+#: id:852
+msgid "Valid port range is 1024-65535"
+msgstr "Baliozko portu sorta 1024-65535 da"
+
+#: id:998
+msgid "Add Music..."
+msgstr ""
+
+#: id:999
+msgid "Add Videos..."
+msgstr ""
+
+#: id:1000
+msgid "- Preview"
+msgstr "- Aurrebista"
+
+#: id:1001
+msgid "Unable to connect"
+msgstr "Ezin da konektatu"
+
+#: id:1002
+msgid "XBMC was unable to connect to the network location."
+msgstr "XBMC-ek ezin izan du sareko kokapenera konektatu."
+
+#: id:1003
+msgid "This could be due to the network not being connected."
+msgstr "Hau sarea konektatu gabe dagoelako izan daiteke."
+
+#: id:1004
+msgid "Would you like to add it anyway?"
+msgstr "Hala ere gehitzea nahi al duzu?"
+
+#: id:1006
+msgctxt "Auto context with id 1006"
+msgid "IP address"
+msgstr "IP helbidea"
+
+#: id:1007
+msgid "Add network location"
+msgstr "Gehitu sareko kokalekua"
+
+#: id:1008
+msgid "Protocol"
+msgstr "Protokoloa"
+
+#: id:1009
+msgid "Server address"
+msgstr "Zerbitzariaren helbidea"
+
+#: id:1010
+msgid "Server name"
+msgstr "Zerbitzariaren izena"
+
+#: id:1011
+msgid "Remote path"
+msgstr "Urruneko bidea"
+
+#: id:1012
+msgid "Shared folder"
+msgstr "Partekatutako karpeta"
+
+#: id:1013
+msgctxt "Auto context with id 1013"
+msgid "Port"
+msgstr "Portua"
+
+#: id:1014
+msgctxt "Auto context with id 1014"
+msgid "Username"
+msgstr "Erabiltzailea"
+
+#: id:1015
+msgid "Browse for network server"
+msgstr "Arakatu sareko zerbitzaria"
+
+#: id:1016
+msgid "Enter the network address of the server"
+msgstr "Sartu zerbitzariaren sareko helbidea"
+
+#: id:1017
+msgid "Enter the path on the server"
+msgstr "Sartu bidea zerbitzarian"
+
+#: id:1018
+msgid "Enter the port number"
+msgstr "Sartu portuaren zenbakia"
+
+#: id:1019
+msgid "Enter the username"
+msgstr "Sartu erabiltzaile izena"
+
+#: id:1020
+msgid "Add %s source"
+msgstr "Gehitu %s iturria"
+
+#: id:1021
+msgid "Enter the paths or browse for the media locations."
+msgstr "Sartu bideak edo arakatu media kokapenak aurkitzeko."
+
+#: id:1022
+msgid "Enter a name for this media Source."
+msgstr "Sartu media iturburu honentzat izen bat."
+
+#: id:1023
+msgid "Browse for new share"
+msgstr "Arakatu partekatu berrirako"
+
+#: id:1024
+msgid "Browse"
+msgstr "Arakatu"
+
+#: id:1025
+msgid "Could not retrieve directory information."
+msgstr "Ezin da berreskuratu direktorioko informazioa."
+
+#: id:1026
+msgid "Add source"
+msgstr "Gehitu iturria"
+
+#: id:1027
+msgid "Edit source"
+msgstr "Aldatu iturria"
+
+#: id:1028
+msgid "Edit %s source"
+msgstr "Aldatu %s iturria"
+
+#: id:1029
+msgid "Enter the new label"
+msgstr "Sartu etiketa berria"
+
+#: id:1030
+msgid "Browse for image"
+msgstr "Arakatu irudiak"
+
+#: id:1031
+msgid "Browse for image folder"
+msgstr "Arakatu irudi karpeta"
+
+#: id:1032
+msgid "Add network location..."
+msgstr "Gehitu sareko kokalekua..."
+
+#: id:1033
+msgid "Browse for file"
+msgstr "Arakatu fitxategia"
+
+#: id:1034
+msgid "Submenu"
+msgstr "Azpimenua"
+
+#: id:1035
+msgid "Enable submenu buttons"
+msgstr "Gaitu azpimenuan botoiak"
+
+#: id:1036
+msgid "Favourites"
+msgstr "Gogokoak"
+
+#: id:1037
+msgid "Video Add-ons"
+msgstr "Bideo gehigarriak"
+
+#: id:1038
+msgid "Music Add-ons"
+msgstr "Musika gehigarriak"
+
+#: id:1039
+msgid "Picture Add-ons"
+msgstr "Irudi gehigarriak"
+
+#: id:1040
+msgid "Loading directory"
+msgstr "Direktorioa kargatzen"
+
+#: id:1041
+msgid "Retrieved %i items"
+msgstr "%i elementuak berreskuratuta"
+
+#: id:1042
+msgid "Retrieved %i of %i items"
+msgstr "%i elementu berreskuratuta %i elementutatik"
+
+#: id:1043
+msgid "Program Add-ons"
+msgstr "Programa gehigarriak"
+
+#: id:1044
+msgid "Set plugin thumb"
+msgstr "Ezarri pluginaren iruditxoa"
+
+#: id:1045
+msgid "Add-on settings"
+msgstr "Gehigarrien ezarpenak"
+
+#: id:1046
+msgid "Access points"
+msgstr "Sarguneak"
+
+#: id:1047
+msgid "Other..."
+msgstr "Besteak..."
+
+#: id:1048
+msgid "- Username"
+msgstr "- Erabiltzaile izena"
+
+#: id:1049
+msgid "Script settings"
+msgstr "Script settings"
+
+#: id:1050
+msgid "Singles"
+msgstr "Banakakoak"
+
+#: id:1051
+msgid "Enter web address"
+msgstr "Idatzi web helbidea"
+
+#: id:1200
+msgid "SMB client"
+msgstr "SMB bezeroa"
+
+#: id:1202
+msgid "Workgroup"
+msgstr "Lantaldea"
+
+#: id:1203
+msgid "Default username"
+msgstr "Erabiltzaile izen lehenetsia"
+
+#: id:1204
+msgid "Default password"
+msgstr "Pasahitz lehenetsia"
+
+#: id:1207
+msgid "WINS server"
+msgstr "WINS zerbitzaria"
+
+#: id:1208
+msgid "Mount SMB shares"
+msgstr "Muntatu SMB partekatzea"
+
+#: id:1210
+msgctxt "Auto context with id 1210"
+msgid "Remove"
+msgstr "Kendu"
+
+#: id:1211
+msgctxt "Auto context with id 1211"
+msgid "Music"
+msgstr "Musika"
+
+#: id:1212
+msgctxt "Auto context with id 1212"
+msgid "Video"
+msgstr "Bideoa"
+
+#: id:1213
+msgctxt "Auto context with id 1213"
+msgid "Pictures"
+msgstr "Irudiak"
+
+#: id:1214
+msgctxt "Auto context with id 1214"
+msgid "Files"
+msgstr "Fitxategiak"
+
+#: id:1215
+msgctxt "Auto context with id 1215"
+msgid "Music & video"
+msgstr "Musika eta bideoa"
+
+#: id:1216
+msgid "Music & pictures"
+msgstr "Musika eta irudiak"
+
+#: id:1217
+msgid "Music & files"
+msgstr "Musika eta fitxategiak"
+
+#: id:1218
+msgid "Video & pictures"
+msgstr "Bideoa eta irudiak"
+
+#: id:1219
+msgid "Video & files"
+msgstr "Bideoa eta fitxategiak"
+
+#: id:1220
+msgid "Pictures & files"
+msgstr "Irudiak eta fitxategiak"
+
+#: id:1221
+msgid "Music & video & pictures"
+msgstr "Musika, bideoa eta irudiak"
+
+#: id:1222
+msgid "Music & video & pictures & files"
+msgstr "Musika, bideoa, irudiak eta fitxategiak"
+
+#: id:1223
+msgctxt "Auto context with id 1223"
+msgid "Disabled"
+msgstr "Ezgaituta"
+
+#: id:1226
+msgid "Files & music & video"
+msgstr "Fitxategiak, musika eta bideoa"
+
+#: id:1227
+msgid "Files & pictures & music"
+msgstr "Fitxategia, irudiak eta musika"
+
+#: id:1228
+msgid "Files & pictures & video"
+msgstr "Fitxategiak, irudiak eta bideoa"
+
+#: id:1229
+msgid "Music & programs"
+msgstr "Musika eta programak"
+
+#: id:1230
+msgid "Video & programs"
+msgstr "Bideoa eta programak"
+
+#: id:1231
+msgid "Pictures & programs"
+msgstr "Irudiak eta programak"
+
+#: id:1232
+msgid "Music & video & pictures & programs"
+msgstr "Musika, bideoa, irudiak eta programak"
+
+#: id:1233
+msgid "Programs & video & music"
+msgstr "Programak, bideoa eta musika"
+
+#: id:1234
+msgid "Programs & pictures & music"
+msgstr "Programak, irudiak eta musika"
+
+#: id:1235
+msgid "Programs & pictures & video"
+msgstr "Programak, irudiak eta bideoa"
+
+#: id:1250
+msgid "Auto-detection"
+msgstr "Auto-detekzioa"
+
+#: id:1251
+msgid "Auto-detect system"
+msgstr "Auto-detektatu sistema"
+
+#: id:1252
+msgid "Nickname"
+msgstr "Ezizena"
+
+#: id:1254
+msgid "Ask to connect"
+msgstr "Galdetu konektatzeko"
+
+#: id:1255
+msgid "Send FTP user and password"
+msgstr "Bidali FTP erabiltzaile eta pasahitza"
+
+#: id:1256
+msgid "Ping interval"
+msgstr "Ping tartea"
+
+#: id:1257
+msgid "Would you like to connect to the auto-detected system?"
+msgstr "Gustatuko litzaizuke auto-detektatutako sistemara konektatzea?"
+
+#: id:1259
+msgid "Zeroconf"
+msgstr ""
+
+#: id:1260
+msgid "Announce these services to other systems via Zeroconf"
+msgstr "Iragarri zerbitzu hauek beste sistema Zeroconf-en bidez"
+
+#: id:1270
+msgid "Allow XBMC to receive AirPlay content"
+msgstr ""
+
+#: id:1271
+msgid "Device name"
+msgstr ""
+
+#: id:1272
+msgid "- Use password protection"
+msgstr ""
+
+#: id:1273
+msgid "AirPlay"
+msgstr ""
+
+#: id:1300
+msgid "Custom audio device"
+msgstr "Pertsonalizatutako audio gailua"
+
+#: id:1301
+msgid "Custom passthrough device"
+msgstr "Passthrough gailu pertsonalizatua"
+
+#: id:1396
+msgid "Drifting"
+msgstr "Noraezean"
+
+#: id:1397
+msgid "and"
+msgstr "eta"
+
+#: id:1398
+msgid "Freezing"
+msgstr "Izozten"
+
+#: id:1399
+msgid "Late"
+msgstr "Berandu"
+
+#: id:1400
+msgid "Isolated"
+msgstr "Isolatuta"
+
+#: id:1401
+msgid "Thundershowers"
+msgstr "Ekaitzak"
+
+#: id:1402
+msgid "Thunder"
+msgstr "Trumoiak"
+
+#: id:1403
+msgctxt "Auto context with id 1403"
+msgid "Sun"
+msgstr "Eguzkia"
+
+#: id:1404
+msgid "Heavy"
+msgstr "Indartsuak"
+
+#: id:1405
+msgid "in"
+msgstr ""
+
+#: id:1406
+msgid "the"
+msgstr ""
+
+#: id:1407
+msgid "Vicinity"
+msgstr "Inguruan"
+
+#: id:1408
+msgid "Ice"
+msgstr "Izotza"
+
+#: id:1409
+msgid "Crystals"
+msgstr "Kristalak"
+
+#: id:1410
+msgid "Calm"
+msgstr "Bare"
+
+#: id:1411
+msgid "with"
+msgstr ""
+
+#: id:1412
+msgid "windy"
+msgstr "haizetsu"
+
+#: id:1413
+msgid "drizzle"
+msgstr "zirimiri"
+
+#: id:1414
+msgid "Thunderstorm"
+msgstr "Tximistak"
+
+#: id:1415
+msgid "Drizzle"
+msgstr "Zirimiri"
+
+#: id:1416
+msgid "Foggy"
+msgstr "Lambroa"
+
+#: id:1417
+msgid "Grains"
+msgstr "Aleak"
+
+#: id:1418
+msgid "T-Storms"
+msgstr "Ekaitzak"
+
+#: id:1419
+msgid "T-Showers"
+msgstr "Zaparradak"
+
+#: id:1420
+msgid "Moderate"
+msgstr "Moderatuak"
+
+#: id:1421
+msgid "Very High"
+msgstr "Oso altua"
+
+#: id:1422
+msgid "Windy"
+msgstr "Haizetsua"
+
+#: id:1423
+msgid "Mist"
+msgstr "Lanbroa"
+
+#: id:1450
+msgid "Put display to sleep when idle"
+msgstr "Jarri pantaila lotan inaktibo dagoenean"
+
+#: id:2050
+msgid "Runtime"
+msgstr "Runtime"
+
+#: id:2100
+msgid "Script failed! : %s"
+msgstr "Scriptak huts egin du! : %s"
+
+#: id:2101
+msgid "Newer version needed - See log"
+msgstr "Bertsio berriagoa behar da - Ikusi log-a"
+
+#: id:4501
+msgid "Enable LCD/VFD"
+msgstr "Gaitu LCD/VFD"
+
+#: id:10000
+msgid "Home"
+msgstr "Etxea"
+
+#: id:10001
+msgctxt "Auto context with id 10001"
+msgid "Programs"
+msgstr "Programak"
+
+#: id:10002
+msgctxt "Auto context with id 10002"
+msgid "Pictures"
+msgstr "Irudiak"
+
+#: id:10003
+msgctxt "Auto context with id 10003"
+msgid "File manager"
+msgstr "Fitxategi kudeatzailea"
+
+#: id:10004
+msgctxt "Auto context with id 10004"
+msgid "Settings"
+msgstr "Ezarpenak"
+
+#: id:10005
+msgctxt "Auto context with id 10005"
+msgid "Music"
+msgstr "Musika"
+
+#: id:10006
+msgctxt "Auto context with id 10006"
+msgid "Videos"
+msgstr "Bideoak"
+
+#: id:10007
+msgid "System information"
+msgstr "Sistemaren informazioa"
+
+#: id:10008
+msgid "Settings - General"
+msgstr "Ezarpenak - Orokorra"
+
+#: id:10009
+msgid "Settings - Screen"
+msgstr "Ezarpenak - Pantaila"
+
+#: id:10010
+msgid "Settings - Appearance - GUI Calibration"
+msgstr "Ezarpenak - Itxura - Interfazeren kalibrazioa"
+
+#: id:10011
+msgid "Settings - Videos - Screen Calibration"
+msgstr "Ezarpenak - Bideoak - Pantailaren kalibrazioa"
+
+#: id:10012
+msgid "Settings - Pictures"
+msgstr "Ezarpenak - Irudiak"
+
+#: id:10013
+msgid "Settings - Programs"
+msgstr "Ezarpenak - Programak"
+
+#: id:10014
+msgid "Settings - Weather"
+msgstr "Ezarpenak - Eguraldia"
+
+#: id:10015
+msgid "Settings - Music"
+msgstr "Ezarpenak - Musika"
+
+#: id:10016
+msgid "Settings - System"
+msgstr "Ezarpenak - Sistema"
+
+#: id:10017
+msgid "Settings - Videos"
+msgstr "Ezarpenak - Bideoak"
+
+#: id:10018
+msgid "Settings - Network"
+msgstr "Ezarpenak - Sarea"
+
+#: id:10019
+msgid "Settings - Appearance"
+msgstr "Ezarpenak - Itxura"
+
+#: id:10020
+msgctxt "Auto context with id 10020"
+msgid "Scripts"
+msgstr "Script-ak"
+
+#: id:10021
+msgid "Web Browser"
+msgstr "Web Nabigatzailea"
+
+#: id:10025
+msgctxt "Auto context with id 10025"
+msgid "Videos"
+msgstr ""
+
+#: id:10028
+msgid "Videos/Playlist"
+msgstr "Bideoak/Zerrendak"
+
+#: id:10029
+msgctxt "Auto context with id 10029"
+msgid "Login screen"
+msgstr ""
+
+#: id:10034
+msgid "Settings - Profiles"
+msgstr "Ezarpenak - Profilak"
+
+#: id:10040
+msgid "Addon browser"
+msgstr ""
+
+#: id:10100
+msgid "Yes/No dialog"
+msgstr "Bai/Ez elkarrizketa"
+
+#: id:10101
+msgid "Progress dialog"
+msgstr "Aurrerapen elkarrizketa"
+
+#: id:10210
+msgid "Looking for subtitles..."
+msgstr "Azpitituluak bilatzen..."
+
+#: id:10211
+msgid "Looking for or caching subtitles..."
+msgstr "Katxean azpiltituluak bilatzen..."
+
+#: id:10212
+msgid "terminating"
+msgstr "amaitzen"
+
+#: id:10213
+msgid "buffering"
+msgstr "bufferreratzen"
+
+#: id:10214
+msgid "Opening stream"
+msgstr "Stream-a irekitzen"
+
+#: id:10500
+msgid "Music/Playlist"
+msgstr "Musika/Zerrenda"
+
+#: id:10501
+msgid "Music/Files"
+msgstr "Musika/Fitxategiak"
+
+#: id:10502
+msgid "Music/Library"
+msgstr "Musika/Liburutegia"
+
+#: id:10503
+msgid "Playlist editor"
+msgstr "Zerrenda editorea"
+
+#: id:10504
+msgid "Top 100 songs"
+msgstr "Top 100 abestiak"
+
+#: id:10505
+msgid "Top 100 albums"
+msgstr "Top 100 albumak"
+
+#: id:10506
+msgctxt "Auto context with id 10506"
+msgid "Programs"
+msgstr "Programak"
+
+#: id:10507
+msgid "Configuration"
+msgstr "Konfigurazioa"
+
+#: id:10508
+msgid "Weather forecast"
+msgstr "Eguraldiaren iragarpena"
+
+#: id:10509
+msgid "Network gaming"
+msgstr "Sareko jokoak"
+
+#: id:10510
+msgid "Extensions"
+msgstr "Gehigarriak"
+
+#: id:10511
+msgctxt "Auto context with id 10511"
+msgid "System info"
+msgstr "Sistemaren info"
+
+#: id:10516
+msgid "Music - Library"
+msgstr "Musika - Liburutegia"
+
+#: id:10517
+msgid "Now Playing - Music"
+msgstr "Orain Erreproduzitzen - Musika"
+
+#: id:10522
+msgid "Now Playing - Videos"
+msgstr "Orain Erreproduzitzen - Bideoak"
+
+#: id:10523
+msgid "Album info"
+msgstr "Albumaren info"
+
+#: id:10524
+msgid "Movie info"
+msgstr "Filmaren info"
+
+#: id:12000
+msgid "Select dialog"
+msgstr "Hautatu elkarrizketa"
+
+#: id:12001
+msgid "Music/Info"
+msgstr "Musika/Info"
+
+#: id:12002
+msgid "Dialog OK"
+msgstr "Elkarrizketa Ados"
+
+#: id:12003
+msgid "Videos/Info"
+msgstr "Bideoak/Info"
+
+#: id:12004
+msgid "Scripts/Info"
+msgstr "Script-ak/Info"
+
+#: id:12005
+msgid "Fullscreen video"
+msgstr "Pantaila osoko bideoa"
+
+#: id:12006
+msgid "Audio visualization"
+msgstr "Audioaren bisualizazioa"
+
+#: id:12008
+msgid "File stacking dialog"
+msgstr "Fitxategi lotzearen elkarrizketa"
+
+#: id:12009
+msgid "Rebuild index..."
+msgstr "Berreraiki indizea..."
+
+#: id:12010
+msgid "Return to music window"
+msgstr "Itzuli musikaren leihora"
+
+#: id:12011
+msgid "Return to videos window"
+msgstr "Itzuli bideoen leihora"
+
+#: id:12021
+msgid "Start from beginning"
+msgstr "Hasi hasieratik"
+
+#: id:12022
+msgid "Resume from %s"
+msgstr "%s-tik hasi"
+
+#: id:12310
+msgid "0"
+msgstr "0"
+
+#: id:12311
+msgid "1"
+msgstr "1"
+
+#: id:12312
+msgid "2"
+msgstr "2"
+
+#: id:12313
+msgid "3"
+msgstr "3"
+
+#: id:12314
+msgid "4"
+msgstr "4"
+
+#: id:12315
+msgid "5"
+msgstr "5"
+
+#: id:12316
+msgid "6"
+msgstr "6"
+
+#: id:12317
+msgid "7"
+msgstr "7"
+
+#: id:12318
+msgid "8"
+msgstr "8"
+
+#: id:12319
+msgid "9"
+msgstr "9"
+
+#: id:12320
+msgid "c"
+msgstr "c"
+
+#: id:12321
+msgid "Ok"
+msgstr "Ados"
+
+#: id:12322
+msgid "*"
+msgstr "*"
+
+#: id:12325
+msgid "Locked! Enter code..."
+msgstr "Blokeatuta! Sartu kodea..."
+
+#: id:12326
+msgid "Enter password"
+msgstr "Sartu pasahitza"
+
+#: id:12327
+msgid "Enter master code"
+msgstr "Sartu master kodea"
+
+#: id:12328
+msgid "Enter unlock code"
+msgstr "Sartu desblokeatzeko kodea"
+
+#: id:12329
+msgid "or press C to cancel"
+msgstr "edo sakatu C uzteko"
+
+#: id:12330
+msgid "Enter gamepad button combo and"
+msgstr "Sartu gamepad botoi konbinazioa eta"
+
+#: id:12331
+msgid "press OK, or Back to cancel"
+msgstr "ados sakatu, edo atzera uzteko"
+
+#: id:12332
+msgid "Set lock"
+msgstr "Ezarri blokeoa"
+
+#: id:12333
+msgid "Unlock"
+msgstr "Desblokeatu"
+
+#: id:12334
+msgid "Reset lock"
+msgstr "Berrezarri blokeatzea"
+
+#: id:12335
+msgid "Remove lock"
+msgstr "Kendu blokeoa"
+
+#: id:12337
+msgid "Numeric password"
+msgstr "Zenbakizko pasahitza"
+
+#: id:12338
+msgid "Gamepad button combo"
+msgstr "Gamepad-eko botoi konbinazioa"
+
+#: id:12339
+msgid "Full-text password"
+msgstr "Testu pasahitza"
+
+#: id:12340
+msgid "Enter new password"
+msgstr "Idatzi pasahitz berria"
+
+#: id:12341
+msgid "Re-Enter new password"
+msgstr "Berriro idatzi pasahitz berria"
+
+#: id:12342
+msgid "Incorrect password,"
+msgstr "Pasahitz okerra,"
+
+#: id:12343
+msgid "retries left"
+msgstr "saiakera dituzu"
+
+#: id:12344
+msgid "Passwords entered did not match."
+msgstr "Sartutako pasahitzak ez datoz bat."
+
+#: id:12345
+msgid "Access denied"
+msgstr "Sarbidea ukatuta"
+
+#: id:12346
+msgid "Password retry limit exceeded."
+msgstr "Pasahitza saiatzeko muga gainditu da."
+
+#: id:12347
+msgid "The system will now shut off."
+msgstr "Sistema orain itzaliko da."
+
+#: id:12348
+msgid "Item locked"
+msgstr "Elementua blokeatuta"
+
+#: id:12353
+msgid "Reactivate lock"
+msgstr "Berraktibatu blokeoa"
+
+#: id:12356
+msgid "Change lock"
+msgstr "Aldatu Blokeoa"
+
+#: id:12357
+msgid "Source lock"
+msgstr "Iturria blokeoa"
+
+#: id:12358
+msgid "Password entry was blank. Try again."
+msgstr "Pasahitza hutsik sartu duzu. Saiatu berriro."
+
+#: id:12360
+msgid "Master lock"
+msgstr "Master blokeoa"
+
+#: id:12362
+msgid "Shutdown system if Master Lock retries exceeded"
+msgstr "Itzali sitema if Master Blokearen saiakerak gainditzean"
+
+#: id:12367
+msgid "Master code is not valid"
+msgstr "Master kodea ez da baliozkoa"
+
+#: id:12368
+msgid "Please enter a valid master code"
+msgstr "Please enter a valid master code"
+
+#: id:12373
+msgid "Settings & file manager"
+msgstr "Ezarpenak eta fitxategi kudeatzaileak"
+
+#: id:12376
+msgid "Set as default for all movies"
+msgstr "Ezarri film guztientzako lehenetsi bezala"
+
+#: id:12377
+msgid "This will reset any previously saved values"
+msgstr "Honek aurrez gordetako edozein balio berrezarriko du"
+
+#: id:12378
+msgid "Amount of time to display each image"
+msgstr "Denbora kopurua irudi bakoitza erakusteko"
+
+#: id:12379
+msgid "Use pan and zoom effects"
+msgstr "Erabili pan eta zoom efektuak"
+
+#: id:12383
+msgid "12 hour clock"
+msgstr "12 orduko erlojua"
+
+#: id:12384
+msgid "24 hour clock"
+msgstr "24 orduko erlojua"
+
+#: id:12385
+msgid "Day/Month"
+msgstr "Eguna/Hilabetea"
+
+#: id:12386
+msgid "Month/Day"
+msgstr "Hilabetea/Eguna"
+
+#: id:12390
+msgid "System uptime"
+msgstr "Sistema piztu denetik pasa den denbora"
+
+#: id:12391
+msgid "Minutes"
+msgstr "Minutuak"
+
+#: id:12392
+msgid "Hours"
+msgstr "Orduak"
+
+#: id:12393
+msgid "Days"
+msgstr "Egunak"
+
+#: id:12394
+msgid "Total uptime"
+msgstr "Piztutako denbora totala"
+
+#: id:12395
+msgid "Battery level"
+msgstr ""
+
+#: id:12600
+msgctxt "Auto context with id 12600"
+msgid "Weather"
+msgstr "Eguraldia"
+
+#: id:12900
+msgctxt "Auto context with id 12900"
+msgid "Screensaver"
+msgstr "Pantaila Babeslea"
+
+#: id:12901
+msgid "Fullscreen OSD"
+msgstr "Pantaila osoko OSD-a"
+
+#: id:13000
+msgid "System"
+msgstr "Sistema"
+
+#: id:13001
+msgid "Immediate HD spindown"
+msgstr "Berehalako HD gelditzea"
+
+#: id:13002
+msgid "Video only"
+msgstr "Bideoa bakarrik"
+
+#: id:13003
+msgid "- Delay"
+msgstr "- Atzerapena"
+
+#: id:13004
+msgid "- Minimum file duration"
+msgstr "- Gutxieneko fitxategiaren iraupena"
+
+#: id:13005
+msgid "Shutdown"
+msgstr "Itzali"
+
+#: id:13008
+msgid "Shutdown function"
+msgstr "Itzaltzeko funtzioa"
+
+#: id:13009
+msgid "Quit"
+msgstr "Irten"
+
+#: id:13010
+msgid "Hibernate"
+msgstr "Hibernatu"
+
+#: id:13011
+msgid "Suspend"
+msgstr "Eseki"
+
+#: id:13012
+msgid "Exit"
+msgstr "Irten"
+
+#: id:13013
+msgid "Reboot"
+msgstr "Berrabiarazi"
+
+#: id:13014
+msgid "Minimize"
+msgstr "Minimizatu"
+
+#: id:13015
+msgid "Power button action"
+msgstr "Power botoiaren ekintza"
+
+#: id:13016
+msgid "Power off System"
+msgstr ""
+
+#: id:13020
+msgid "Is another session active, perhaps over ssh?"
+msgstr "Beste saio bata aktibo dago, beharbada shh bidez?"
+
+#: id:13021
+msgid "Mounted removable harddrive"
+msgstr "Muntatutako disko aldagarriak"
+
+#: id:13022
+msgid "Unsafe device removal"
+msgstr "Segurtasunik gabe gailua kentzea"
+
+#: id:13023
+msgid "Successfully removed device"
+msgstr "Gailua ongi kendu da"
+
+#: id:13024
+msgid "Joystick plugged"
+msgstr "Joystick-a konektatuta"
+
+#: id:13025
+msgid "Joystick unplugged"
+msgstr "Joystick-a deskonektatuta"
+
+#: id:13050
+msgid "Running low on battery"
+msgstr "Bateria gutxirekin"
+
+#: id:13100
+msgid "Flicker filter"
+msgstr "Flicker iragazkia"
+
+#: id:13101
+msgid "Let driver choose (requires restart)"
+msgstr "Utzi unitatearei hautatzen (berriabiarazi behar da)"
+
+#: id:13105
+msgid "Vertical blank sync"
+msgstr "Zuri bertikalen sinkronia"
+
+#: id:13106
+msgctxt "Auto context with id 13106"
+msgid "Disabled"
+msgstr "Ezgaituta"
+
+#: id:13107
+msgid "Enabled during video playback"
+msgstr "Gaituta bideoa erreproduzitzean"
+
+#: id:13108
+msgctxt "Auto context with id 13108"
+msgid "Always enabled"
+msgstr "Beti gaituta"
+
+#: id:13109
+msgid "Test & apply resolution"
+msgstr "Probatu eta bereizmena aplikatu"
+
+#: id:13110
+msgid "Save resolution?"
+msgstr "Gorde bereizmena?"
+
+#: id:13111
+msgid "Would you like to keep this resolution?"
+msgstr "Nahi al duzu, ebazpen hau mantentzea?"
+
+#: id:13112
+msgid "High quality upscaling"
+msgstr "Kalitate handiko upscaling-a"
+
+#: id:13113
+msgctxt "Auto context with id 13113"
+msgid "Disabled"
+msgstr "Ezgaituta"
+
+#: id:13114
+msgid "Enabled for SD content"
+msgstr "Gaituta SD edukientzako"
+
+#: id:13115
+msgctxt "Auto context with id 13115"
+msgid "Always enabled"
+msgstr "Beti gaituta"
+
+#: id:13116
+msgid "Upscaling method"
+msgstr "Upscaling modua"
+
+#: id:13117
+msgctxt "Auto context with id 13117"
+msgid "Bicubic"
+msgstr "Bikubikoa"
+
+#: id:13118
+msgid "Lanczos"
+msgstr "Lanczos"
+
+#: id:13119
+msgid "Sinc"
+msgstr "Sinkronia"
+
+#: id:13120
+msgctxt "Auto context with id 13120"
+msgid "VDPAU"
+msgstr "VDPAU"
+
+#: id:13121
+msgid "VDPAU HQ Upscaling level"
+msgstr "VDPAU HQ Upscaling maila"
+
+#: id:13122
+msgid "VDPAU Studio level color conversion"
+msgstr "VDPAU Estudioare mailaren kolore konbertsioa"
+
+#: id:13130
+msgid "Blank other displays"
+msgstr "Zuritu beste pantailak"
+
+#: id:13131
+msgctxt "Auto context with id 13131"
+msgid "Disabled"
+msgstr "Ezgaituta"
+
+#: id:13132
+msgid "Blank displays"
+msgstr "Pantaila zuriak"
+
+#: id:13140
+msgid "Active connections detected!"
+msgstr "Konexio aktiboak detektatuta!"
+
+#: id:13141
+msgid "If you proceed, you might not be able to control XBMC"
+msgstr "Aurrera jarraitzen baduzu, agian ezingo duzu XBMC kontrolatu"
+
+#: id:13142
+msgid "any longer. Are you sure you want to stop the Event server?"
+msgstr "hemendik aurrera. Ziur zaude gertaera zerbitzari gelditu nahi duzula?"
+
+#: id:13144
+msgid "Change Apple Remote mode?"
+msgstr "Aldatu Apple Remote modua?"
+
+#: id:13145
+msgid "If you are currently using the Apple Remote to control"
+msgstr "Orain Apple Remote kontrola erabiltzen baldin bazaude"
+
+#: id:13146
+msgid "XBMC, changing this setting might affect your ability"
+msgstr "XBMC, ezarpen hau aldatzeak zure kontrolatzeko gaitasunean"
+
+#: id:13147
+msgid "to continue controlling it. Do you want to proceed?"
+msgstr "eragina izan dezake. Jarraitzea nahi duzu?"
+
+#: id:13159
+msgid "Subnet mask"
+msgstr "Azpisareko maskara"
+
+#: id:13160
+msgid "Gateway"
+msgstr "Atebidea"
+
+#: id:13161
+msgid "Primary DNS"
+msgstr "DNS Primarioa"
+
+#: id:13162
+msgid "Initialize failed"
+msgstr "Abiarazteak huts egin du"
+
+#: id:13170
+msgctxt "Auto context with id 13170"
+msgid "Never"
+msgstr "Inoiz ez"
+
+#: id:13171
+msgid "Immediately"
+msgstr "Orain"
+
+#: id:13172
+msgid "After %i secs"
+msgstr "%i segundu ondoren"
+
+#: id:13173
+msgid "HDD install date:"
+msgstr "HDDa instalatutako data:"
+
+#: id:13174
+msgid "HDD power cycle count:"
+msgstr "HDDaren energia ziklo kopurua:"
+
+#: id:13200
+msgid "Profiles"
+msgstr "Profilak"
+
+#: id:13201
+msgid "Delete profile '%s'?"
+msgstr "Ezabatu '%s' profila?"
+
+#: id:13204
+msgid "Last loaded profile:"
+msgstr "Azkenengoan kargatutako profila"
+
+#: id:13205
+msgid "Unknown"
+msgstr "Ezezaguna"
+
+#: id:13206
+msgid "Overwrite"
+msgstr "Gainidatzi"
+
+#: id:13208
+msgid "Alarm clock"
+msgstr "Iratzargailua"
+
+#: id:13209
+msgid "Alarm clock interval (in minutes)"
+msgstr "Alarma tartea (minututan)"
+
+#: id:13210
+msgid "Started, alarm in %im"
+msgstr "Hasi da, alarma %im minututan"
+
+#: id:13211
+msgid "Alarm!"
+msgstr "Alarma!"
+
+#: id:13212
+msgid "Canceled with %im%is left"
+msgstr "Utzita %im%is falta zirela"
+
+#: id:13213
+msgid "%2.0fm"
+msgstr "%2.0fm"
+
+#: id:13214
+msgid "%2.0fs"
+msgstr "%2.0fs"
+
+#: id:13249
+msgid "Search for subtitles in RARs"
+msgstr "Bilatu Azpitituluak RARs en"
+
+#: id:13250
+msgid "Browse for subtitle..."
+msgstr "Azpitituluak arakatu..."
+
+#: id:13251
+msgid "Move item"
+msgstr "Mugitu itema"
+
+#: id:13252
+msgid "Move item here"
+msgstr "Mugitu itema hona"
+
+#: id:13253
+msgid "Cancel move"
+msgstr "Utzi mugitzea"
+
+#: id:13270
+msgid "Hardware:"
+msgstr "Hardwarea:"
+
+#: id:13271
+msgid "CPU Usage:"
+msgstr "CPUaren erabilera:"
+
+#: id:13274
+msgid "Connected, but no DNS is available."
+msgstr "Konektatuta baina ez dago DNSrik"
+
+#: id:13275
+msgid "Hard Disk"
+msgstr "Disko Gogorra"
+
+#: id:13276
+msgid "DVD-ROM"
+msgstr "DVD-ROM"
+
+#: id:13277
+msgctxt "Auto context with id 13277"
+msgid "Storage"
+msgstr "Biltegiratzea"
+
+#: id:13278
+msgctxt "Auto context with id 13278"
+msgid "Default"
+msgstr "Lehenetsia"
+
+#: id:13279
+msgctxt "Auto context with id 13279"
+msgid "Network"
+msgstr "Sarea"
+
+#: id:13280
+msgctxt "Auto context with id 13280"
+msgid "Video"
+msgstr "Bideoa"
+
+#: id:13281
+msgid "Hardware"
+msgstr "Hardwarea"
+
+#: id:13283
+msgid "Operating system:"
+msgstr "Sistema eragilea:"
+
+#: id:13284
+msgid "CPU speed:"
+msgstr "CPUaren abiadura:"
+
+#: id:13286
+msgid "Video encoder:"
+msgstr "Bideo kodetzailea:"
+
+#: id:13287
+msgid "Screen resolution:"
+msgstr "Pantailaren bereizmena:"
+
+#: id:13292
+msgid "A/V cable:"
+msgstr "A/V kablea:"
+
+#: id:13294
+msgid "DVD region:"
+msgstr "DVD eskualdea:"
+
+#: id:13295
+msgid "Internet:"
+msgstr "Interneta:"
+
+#: id:13296
+msgctxt "Auto context with id 13296"
+msgid "Connected"
+msgstr "Konektatuta"
+
+#: id:13297
+msgid "Not connected. Check network settings."
+msgstr "Konektatu gabe. Egiaztatu sareko ezarpenak."
+
+#: id:13299
+msgid "Target temperature"
+msgstr "Helburuko tenperatura"
+
+#: id:13300
+msgid "Fan speed"
+msgstr "Haizgailuaren abiadura"
+
+#: id:13301
+msgid "Auto temperature control"
+msgstr "Tenperaturaren kontrol automatikokia"
+
+#: id:13302
+msgid "Fan speed override"
+msgstr "Haizgailuaren abiadura gainidatzi"
+
+#: id:13303
+msgid "- Fonts"
+msgstr "- Letrak"
+
+#: id:13304
+msgid "Enable flipping bi-directional strings"
+msgstr "Gaitu bi norabideko kateak iraultzea"
+
+#: id:13305
+msgid "Show RSS news feeds"
+msgstr "Erakutsi RSS jarioa"
+
+#: id:13306
+msgid "Show parent folder items"
+msgstr "Erakutsi karpeta gurasoaren elementuak"
+
+#: id:13307
+msgid "Track naming template"
+msgstr "Pistak izendatzeko txantiloia"
+
+#: id:13308
+msgid "Do you wish to reboot your system"
+msgstr "Zure sistema berrabiarazi nahi duzu"
+
+#: id:13309
+msgid "instead of just XBMC?"
+msgstr "XBMCren ordez?"
+
+#: id:13310
+msgid "Zoom effect"
+msgstr "Zoom efektua"
+
+#: id:13311
+msgid "Float effect"
+msgstr "Flotatu efektua"
+
+#: id:13312
+msgid "Black bar reduction"
+msgstr "Barra beltzen murrizketa"
+
+#: id:13313
+msgid "Restart"
+msgstr "Berrabiarazi"
+
+#: id:13314
+msgid "Crossfade between songs"
+msgstr "Kanten arteko nahaste gurutzatua landu"
+
+#: id:13315
+msgid "Regenerate thumbnails"
+msgstr "Birsortu argazkitxoak"
+
+#: id:13316
+msgid "Recursive thumbnails"
+msgstr "Argazkitxo errekurtsiboak"
+
+#: id:13317
+msgid "View slideshow"
+msgstr "Ikusi aurkezpena"
+
+#: id:13318
+msgid "Recursive slideshow"
+msgstr "Aurkezpen errekurtsiboa"
+
+#: id:13319
+msgid "Randomize"
+msgstr "Ausaz"
+
+#: id:13320
+msgid "Stereo"
+msgstr "Stereo"
+
+#: id:13321
+msgid "Left only"
+msgstr "Ezkerra bakarrik"
+
+#: id:13322
+msgid "Right only"
+msgstr "Eskuma bakarrik"
+
+#: id:13323
+msgid "Enable karaoke support"
+msgstr "Gaitu karaoke modua"
+
+#: id:13324
+msgid "Background transparency"
+msgstr "Atzeko planoko gardentasuna"
+
+#: id:13325
+msgid "Foreground transparency"
+msgstr "Aurreko planoaren gardentasuna"
+
+#: id:13326
+msgid "A/V delay"
+msgstr "A/V atzerapena"
+
+#: id:13327
+msgid "Karaoke"
+msgstr "Karaokea"
+
+#: id:13328
+msgid "%s not found"
+msgstr "%s ez da aurkitu"
+
+#: id:13329
+msgid "Error opening %s"
+msgstr "Errorea %s irekitzen"
+
+#: id:13330
+msgid "Unable to load %s"
+msgstr "%s ezin izan da kargatu"
+
+#: id:13331
+msgid "Error: Out of memory"
+msgstr "Errorea: Memoria gabe"
+
+#: id:13332
+msgid "Move up"
+msgstr "Mugitu gora"
+
+#: id:13333
+msgid "Move down"
+msgstr "Mugitu behera"
+
+#: id:13334
+msgid "Edit label"
+msgstr "Editatu etiketa"
+
+#: id:13335
+msgid "Make default"
+msgstr "Lehenetsi"
+
+#: id:13336
+msgid "Remove button"
+msgstr "Kendu botoia"
+
+#: id:13340
+msgid "Leave as is"
+msgstr "Utzi"
+
+#: id:13341
+msgid "Green"
+msgstr "Berdea"
+
+#: id:13342
+msgid "Orange"
+msgstr "Laranja"
+
+#: id:13343
+msgid "Red"
+msgstr "Gorria"
+
+#: id:13344
+msgid "Cycle"
+msgstr "Zikloa"
+
+#: id:13345
+msgid "Switch LED off on playback"
+msgstr "Itzali LED erreprodukzioan"
+
+#: id:13346
+msgctxt "Auto context with id 13346"
+msgid "Movie information"
+msgstr "Filmaren informazioa"
+
+#: id:13347
+msgid "Queue item"
+msgstr "Ilaratu elementua"
+
+#: id:13348
+msgid "Search IMDb..."
+msgstr "Bilatu IMDb..."
+
+#: id:13349
+msgid "Scan for new content"
+msgstr "Eduki berriak eskaneatu"
+
+#: id:13350
+msgid "Now playing..."
+msgstr "Orain erreproduzitzen..."
+
+#: id:13351
+msgctxt "Auto context with id 13351"
+msgid "Album information"
+msgstr "Albumaren informazioa"
+
+#: id:13352
+msgid "Scan item to library"
+msgstr "Eskaneatu elementua liburutegira"
+
+#: id:13353
+msgid "Stop scanning"
+msgstr "Gelditu eskaneatzen"
+
+#: id:13354
+msgctxt "Auto context with id 13354"
+msgid "Render method"
+msgstr "Errendatzeko metodoa"
+
+#: id:13355
+msgid "Low quality pixel shader"
+msgstr "Kalitate txikiko pixel shader-a"
+
+#: id:13356
+msgid "Hardware overlays"
+msgstr "Hardware gainjartzea"
+
+#: id:13357
+msgid "High quality pixel shader"
+msgstr "Kalitate handiko pixel shader-a"
+
+#: id:13358
+msgid "Play item"
+msgstr "Erreproduzitu elementua"
+
+#: id:13359
+msgid "Set artist thumb"
+msgstr "Ezarri artistaren argazkitxoa"
+
+#: id:13360
+msgid "Automatically generate thumbnails"
+msgstr "Automatikoki sortu argazkitxoak"
+
+#: id:13361
+msgid "Enable voice"
+msgstr "Gaitu ahotsa"
+
+#: id:13375
+msgid "Enable device"
+msgstr "Gaitu gailua"
+
+#: id:13376
+msgid "Volume"
+msgstr "Bolumena"
+
+#: id:13377
+msgid "Default view mode"
+msgstr "Ikuspegi lehenetsi modua"
+
+#: id:13378
+msgid "Default brightness"
+msgstr "Lehenetsiriko distira"
+
+#: id:13379
+msgid "Default contrast"
+msgstr "Lehenetsiriko kontrastea"
+
+#: id:13380
+msgid "Default gamma"
+msgstr "Lehenetsiriko gamma"
+
+#: id:13381
+msgid "Resume video"
+msgstr "Berrekin bideoa"
+
+#: id:13382
+msgid "Voice mask - Port 1"
+msgstr "Ahots maskara - 1 Portua"
+
+#: id:13383
+msgid "Voice mask - Port 2"
+msgstr "Ahots maskara - 2 Portua"
+
+#: id:13384
+msgid "Voice mask - Port 3"
+msgstr "Ahots maskara - 3 Portua"
+
+#: id:13385
+msgid "Voice mask - Port 4"
+msgstr "Ahots maskara - 4 Portua"
+
+#: id:13386
+msgid "Use time based seeking"
+msgstr "Erabilera denboran oinarritutako bilaketa"
+
+#: id:13387
+msgid "Track naming template - right"
+msgstr "Pistak izendatzeko txantiloia - eskubidea"
+
+#: id:13388
+msgid "Preset"
+msgstr "Aurrezarritakoa"
+
+#: id:13389
+msgid "There are no presets available\nfor this visualization"
+msgstr "Ez dago aurrezarpenik eskuragarri bisualizazio honetarako"
+
+#: id:13390
+msgid "There are no settings available\nfor this visualization"
+msgstr "Ez dago ezarpenik eskuragarri bisualizazio honetarako"
+
+#: id:13391
+msgid "Eject/Load"
+msgstr "Egotzi/Kargatu"
+
+#: id:13392
+msgid "Use visualization if playing audio"
+msgstr "Erabili bisualizazioa audioa erreproduzitzen badago"
+
+#: id:13393
+msgid "Calculate size"
+msgstr "Kalkulatu tamaina"
+
+#: id:13394
+msgid "Calculating folder size"
+msgstr "Karpetaren tamaina kalkulatzea"
+
+#: id:13395
+msgid "Video settings"
+msgstr "Bideoaren ezarpenak"
+
+#: id:13396
+msgid "Audio and subtitle settings"
+msgstr "Audioa eta azpititulu ezarpenak"
+
+#: id:13397
+msgid "Enable subtitles"
+msgstr "Gaitu azpitituluak"
+
+#: id:13398
+msgctxt "Auto context with id 13398"
+msgid "Shortcuts"
+msgstr "Lasterbideak"
+
+#: id:13399
+msgid "Ignore articles when sorting (e.g. \"the\")"
+msgstr "Ezikusi artikuluak ordenatzean (adibidez \"the\")"
+
+#: id:13400
+msgid "Crossfade between songs on the same album"
+msgstr "Kanten arteko nahaste gurutzatua landu album berean"
+
+#: id:13401
+msgid "Browse for %s"
+msgstr "Arakatu %s"
+
+#: id:13402
+msgid "Show track position"
+msgstr "Erakutsi pistaren posizioa"
+
+#: id:13403
+msgid "Clear default"
+msgstr "Garbitu lehenetsia"
+
+#: id:13404
+msgid "Resume"
+msgstr "Jarraitu"
+
+#: id:13405
+msgid "Get thumb"
+msgstr "Eskuratu argazkitxoa"
+
+#: id:13406
+msgid "Picture information"
+msgstr "Irudiaren informazioa"
+
+#: id:13407
+msgid "%s presets"
+msgstr "%s aurrezarpenak"
+
+#: id:13408
+msgid "(IMDb user rating)"
+msgstr "(IMDb erabiltzaile puntuaketa)"
+
+#: id:13409
+msgid "Top 250"
+msgstr "Top 250"
+
+#: id:13410
+msgid "Tune in on Last.fm"
+msgstr "Sintonizatu Last.fm-en"
+
+#: id:13411
+msgid "Minimum fan speed"
+msgstr "Gutxieneko haizagailuaren abiadura"
+
+#: id:13412
+msgid "Play from here"
+msgstr ""
+
+#: id:13413
+msgid "Downloading"
+msgstr "Deskargatzen"
+
+#: id:13414
+msgid "Include artists who appear only on compilations"
+msgstr "Txertatu konpilazioetan bakarrik agertzen diren artistak"
+
+#: id:13415
+msgctxt "Auto context with id 13415"
+msgid "Render method"
+msgstr "Errendatzeko metodoa"
+
+#: id:13416
+msgid "Auto detect"
+msgstr "Automatikoki detektatzeko"
+
+#: id:13417
+msgid "Basic shaders (ARB)"
+msgstr "Oinarrizko shader-ak (ARB)"
+
+#: id:13418
+msgid "Advanced shaders (GLSL)"
+msgstr "Shader aurreratuak (GLSL)"
+
+#: id:13419
+msgid "Software"
+msgstr "Softwarea"
+
+#: id:13420
+msgid "Remove safely"
+msgstr "Kendu segurtasunez"
+
+#: id:13421
+msgctxt "Auto context with id 13421"
+msgid "VDPAU"
+msgstr "VDPAU"
+
+#: id:13422
+msgid "Start slideshow here"
+msgstr "Hasi aurkezpena hemen"
+
+#: id:13423
+msgid "Remember for this path"
+msgstr "Gogoratu bide hau"
+
+#: id:13424
+msgid "Use pixel buffer objects"
+msgstr "Erabili pixel buffer objektuak"
+
+#: id:13425
+msgid "Allow hardware acceleration (VDPAU)"
+msgstr "Onartu hardware azelerazioa (VDPAU)"
+
+#: id:13426
+msgid "Allow hardware acceleration (VAAPI)"
+msgstr "Onartu hardware azelerazioa (VAAPI)"
+
+#: id:13427
+msgid "Allow hardware acceleration (DXVA2)"
+msgstr "Onartu hardware azelerazioa (DXVA2)"
+
+#: id:13428
+msgid "Allow hardware acceleration (CrystalHD)"
+msgstr "Allow hardware acceleration (CrystalHD)"
+
+#: id:13429
+msgid "Allow hardware acceleration (VDADecoder)"
+msgstr "Onartu hardware azelerazioa (VDADekodeatzailea)"
+
+#: id:13430
+msgid "Allow hardware acceleration (OpenMax)"
+msgstr "Onartu hardware azelerazioa (OpenMax)"
+
+#: id:13431
+msgid "Pixel Shaders"
+msgstr "Pixel Shaders"
+
+#: id:13432
+msgid "Allow hardware acceleration (VideoToolbox)"
+msgstr ""
+
+#: id:13500
+msgid "A/V sync method"
+msgstr "A/V sinkronia metodoa"
+
+#: id:13501
+msgid "Audio clock"
+msgstr "Audio erlojua"
+
+#: id:13502
+msgid "Video clock (Drop/Dupe audio)"
+msgstr "Bideoaren erlojua (Drop/Dupe audio)"
+
+#: id:13503
+msgid "Video clock (Resample audio)"
+msgstr "Bideoaren erlojua (Berriz lagindu audioa)"
+
+#: id:13504
+msgid "Maximum resample amount (%)"
+msgstr "Berriz lagindu gehienezko kopurua (%)"
+
+#: id:13505
+msgid "Resample quality"
+msgstr "Berriz lagintzeko kalitatea"
+
+#: id:13506
+msgid "Low(fast)"
+msgstr "Txikia (azkarra)"
+
+#: id:13507
+msgctxt "Auto context with id 13507"
+msgid "Medium"
+msgstr "Ertaina"
+
+#: id:13508
+msgctxt "Auto context with id 13508"
+msgid "High"
+msgstr "Handia"
+
+#: id:13509
+msgid "Really high(slow!)"
+msgstr "Oso handia(motela!)"
+
+#: id:13510
+msgid "Sync playback to display"
+msgstr "Sinkronizatu erreprodukzioa erakusteko"
+
+#: id:13550
+msgid "Pause during refresh rate change"
+msgstr ""
+
+#: id:13551
+msgctxt "Auto context with id 13551"
+msgid "Off"
+msgstr ""
+
+#: id:13552
+msgid "%.1f Second"
+msgstr ""
+
+#: id:13553
+msgid "%.1f Seconds"
+msgstr ""
+
+#: id:13600
+msgid "Apple remote"
+msgstr "Apple remote"
+
+#: id:13602
+msgid "Allow start of XBMC using the remote"
+msgstr "Onartu XBMC hastea urrutiko agintearekin"
+
+#: id:13603
+msgid "Sequence delay time"
+msgstr "Sekuentzia atzerapen denbora"
+
+#: id:13610
+msgctxt "Auto context with id 13610"
+msgid "Disabled"
+msgstr "Ezgaituta"
+
+#: id:13611
+msgctxt "Auto context with id 13611"
+msgid "Standard"
+msgstr "Estandarra"
+
+#: id:13612
+msgid "Universal Remote"
+msgstr "Aginte Unibertsala"
+
+#: id:13613
+msgid "Multi Remote (Harmony)"
+msgstr "Hainbat Urruneko Aginte (Harmony)"
+
+#: id:13620
+msgid "Apple Remote Error"
+msgstr "Apple Remote Errorea"
+
+#: id:13621
+msgid "Apple Remote support could be enabled."
+msgstr "Apple Remote ezin izan da gaitu"
+
+#: id:14000
+msgid "Stack"
+msgstr "Pilatu"
+
+#: id:14001
+msgid "Unstack"
+msgstr "Banatu"
+
+#: id:14003
+msgid "Downloading playlist file..."
+msgstr "Zerrenda fitxategia deskargatzen..."
+
+#: id:14004
+msgid "Downloading streams list..."
+msgstr "Streams zerrenda deskargatzen..."
+
+#: id:14005
+msgid "Parsing streams list..."
+msgstr "Stream zerrenda analizatzen..."
+
+#: id:14006
+msgid "Downloading streams list failed"
+msgstr "Stream zerrendaren deskargak huts egin du"
+
+#: id:14007
+msgid "Downloading playlist file failed"
+msgstr "Zerrendaren deskargak huts egin du"
+
+#: id:14009
+msgid "Games directory"
+msgstr "Joko direktorioa"
+
+#: id:14010
+msgid "Auto switch to thumbs based on"
+msgstr "Automatikoki aldatu argazkitxoan honen arabera"
+
+#: id:14011
+msgid "Enable auto switching to thumbs view"
+msgstr "Gaitu automatikoki argazkitxoen ikuspegira aldatzea"
+
+#: id:14012
+msgid "- Use large icons"
+msgstr "- Erabili ikono handiak"
+
+#: id:14013
+msgid "- Switch based on"
+msgstr "- Aldatu oinarrtua"
+
+#: id:14014
+msgid "- Percentage"
+msgstr "- Ehunekoa"
+
+#: id:14015
+msgid "No files and at least one thumb"
+msgstr "Ez dago fitxategirik eta gutxienez argazkitxo bat"
+
+#: id:14016
+msgid "At least one file and thumb"
+msgstr "Gutxienez fitxategi bat eta argazkitxoa"
+
+#: id:14017
+msgid "Percentage of thumbs"
+msgstr "Argazkitxoen ehunekoa"
+
+#: id:14018
+msgid "View options"
+msgstr "Ikusteko aukerak"
+
+#: id:14019
+msgid "Change area code 1"
+msgstr "Aldatu 1 area kodea"
+
+#: id:14020
+msgid "Change area code 2"
+msgstr "Aldatu 2 area kodea"
+
+#: id:14021
+msgid "Change area code 3"
+msgstr "Aldatu 3 area kodea"
+
+#: id:14022
+msgctxt "Auto context with id 14022"
+msgid "Library"
+msgstr "Liburutegia"
+
+#: id:14023
+msgid "No TV"
+msgstr "TBrik ez"
+
+#: id:14024
+msgid "Enter the nearest large town"
+msgstr "Sartu herri handi hurbilena"
+
+#: id:14025
+msgid "Video/Audio/DVD cache - Harddisk"
+msgstr "Bideoa/Audioa/DVD katxea - Disko gogorra"
+
+#: id:14026
+msgid "Video cache - DVD-ROM"
+msgstr "Bideoaren katxea - DVD-ROM"
+
+#: id:14027
+msgctxt "Auto context with id 14027"
+msgid "- Local Network"
+msgstr "- Sare Lokala"
+
+#: id:14028
+msgctxt "Auto context with id 14028"
+msgid "- Internet"
+msgstr "- Internet"
+
+#: id:14030
+msgid "Audio cache - DVD-ROM"
+msgstr "Audio katxea - DVD-ROM"
+
+#: id:14031
+msgctxt "Auto context with id 14031"
+msgid "- Local Network"
+msgstr "- Sare Lokala"
+
+#: id:14032
+msgctxt "Auto context with id 14032"
+msgid "- Internet"
+msgstr "- Internet"
+
+#: id:14034
+msgid "DVD cache - DVD-ROM"
+msgstr "DVD katxea - DVD-ROM"
+
+#: id:14035
+msgctxt "Auto context with id 14035"
+msgid "- Local Network"
+msgstr "- Sare Lokala"
+
+#: id:14036
+msgctxt "Auto context with id 14036"
+msgid "Services"
+msgstr "Zerbitzuak"
+
+#: id:14038
+msgid "Network settings changed"
+msgstr "Sare ezarpenak aldatu"
+
+#: id:14039
+msgid "XBMC requires to restart to change your"
+msgstr "XBMC berrabiarazi behar da aldatzeko zure"
+
+#: id:14040
+msgid "network setup. Would you like to restart now?"
+msgstr "sare ezarpenak. Orain berrabiaraztea nahi duzu?"
+
+#: id:14041
+msgid "Internet connection bandwidth limitation"
+msgstr ""
+
+#: id:14043
+msgid "- Shutdown while playing"
+msgstr "- Itzali erreproduzitzean"
+
+#: id:14044
+msgid "%i min"
+msgstr "%i min"
+
+#: id:14045
+msgid "%i sec"
+msgstr "%i seg"
+
+#: id:14046
+msgid "%i ms"
+msgstr "%i ms"
+
+#: id:14047
+msgid "%i %%"
+msgstr "%i %%"
+
+#: id:14048
+msgid "%i kbps"
+msgstr "%i kbps"
+
+#: id:14049
+msgid "%i kb"
+msgstr "%i kb"
+
+#: id:14050
+msgid "%i.0 dB"
+msgstr "%i.0 dB"
+
+#: id:14051
+msgid "Time format"
+msgstr "Ordu formatua"
+
+#: id:14052
+msgid "Date format"
+msgstr "Data formatua"
+
+#: id:14053
+msgid "GUI filters"
+msgstr "GUI iragazkiak"
+
+#: id:14055
+msgid "Use background scanning"
+msgstr "Erabili atzeko planoko eskaneatzea"
+
+#: id:14056
+msgid "Stop scan"
+msgstr "Gelditu eskaneatzea"
+
+#: id:14057
+msgid "Not possible while scanning for media info"
+msgstr "Ez da posible eskaneatzen dagoen bitartean"
+
+#: id:14058
+msgid "Film grain effect"
+msgstr "Film ale eragina"
+
+#: id:14059
+msgid "Search for thumbnails on remote shares"
+msgstr "Bilatu argazkitxoak urruneko partekatuetan"
+
+#: id:14060
+msgid "Unknown type cache - Internet"
+msgstr "Mota ezezaguneko katxea - Internet"
+
+#: id:14061
+msgctxt "Auto context with id 14061"
+msgid "Auto"
+msgstr "Automatikoa"
+
+#: id:14062
+msgid "Enter username for"
+msgstr "Sartu erabiltzaile izena"
+
+#: id:14063
+msgid "Date & time"
+msgstr "Data eta ordua"
+
+#: id:14064
+msgid "Set date"
+msgstr "Ezarri data"
+
+#: id:14065
+msgid "Set time"
+msgstr "Ezarri ordua"
+
+#: id:14066
+msgid "Enter the time in 24 hour HH:MM format"
+msgstr "Idatzi ordua 24 orduko HH:MM formatuan"
+
+#: id:14067
+msgid "Enter the date in DD/MM/YYYY format"
+msgstr "Idatzi data EE/HH/UUUU formatuan"
+
+#: id:14068
+msgid "Enter the IP address"
+msgstr "Idatzi IP helbidea"
+
+#: id:14069
+msgid "Apply these settings now?"
+msgstr "Aplikatu ezarpen hauek orain?"
+
+#: id:14070
+msgid "Apply changes now"
+msgstr "Aplikatu aldaketak orain"
+
+#: id:14071
+msgid "Allow file renaming and deletion"
+msgstr "Onartu fitxategiak berrizendatzea eta ezabatzea"
+
+#: id:14074
+msgid "Set timezone"
+msgstr "Ezarri ordu zonaldea"
+
+#: id:14075
+msgid "Use daylight saving time"
+msgstr "Erabili eguneko argiko denbora aurreztea"
+
+#: id:14076
+msgid "Add to favourites"
+msgstr "Gehitu gogokoetara"
+
+#: id:14077
+msgid "Remove from favourites"
+msgstr "Gogokoetatik kendu"
+
+#: id:14078
+msgctxt "Auto context with id 14078"
+msgid "- Colours"
+msgstr "- Koloreak"
+
+#: id:14079
+msgid "Timezone country"
+msgstr "Herrialdeko ordu eremua"
+
+#: id:14080
+msgid "Timezone"
+msgstr "Ordu eremua"
+
+#: id:14081
+msgid "File lists"
+msgstr "Fitxategi zerrenda"
+
+#: id:14082
+msgid "Show EXIF picture information"
+msgstr "Erakutsi irudiaren EXIF infromazioa"
+
+#: id:14083
+msgid "Use a fullscreen window rather than true fullscreen"
+msgstr "Erabili pantaila osoko leihoa benetako pantaila osoaren ordez"
+
+#: id:14084
+msgid "Queue songs on selection"
+msgstr "Ilaratu abestiak hautatzean"
+
+#: id:14086
+msgid "Playback"
+msgstr "Erreprodukzioa"
+
+#: id:14087
+msgid "DVDs"
+msgstr "DVDak"
+
+#: id:14088
+msgid "Play DVDs automatically"
+msgstr "Erreproduzitu DVDak automatikoki"
+
+#: id:14089
+msgid "Font to use for text subtitles"
+msgstr "Azpitituluekin erabiltzeko letra"
+
+#: id:14090
+msgid "International"
+msgstr "Nazioartekoa"
+
+#: id:14091
+msgid "Character set"
+msgstr "Karaktere multzoa"
+
+#: id:14092
+msgid "Debugging"
+msgstr "Arazketa"
+
+#: id:14093
+msgid "Security"
+msgstr "Sekuritatea"
+
+#: id:14094
+msgid "Input devices"
+msgstr "Sarrerako gailuak"
+
+#: id:14095
+msgid "Power saving"
+msgstr "Energia aurreztea"
+
+#: id:14096
+msgid "Rip"
+msgstr ""
+
+#: id:14097
+msgid "Audio CD Insert Action"
+msgstr ""
+
+#: id:14098
+msgctxt "Auto context with id 14098"
+msgid "Play"
+msgstr ""
+
+#: id:14099
+msgid "Eject disc when CD ripping is complete"
+msgstr ""
+
+#: id:15015
+msgctxt "Auto context with id 15015"
+msgid "Remove"
+msgstr "Kendu"
+
+#: id:15016
+msgid "Games"
+msgstr "Jokoak"
+
+#: id:15019
+msgid "Add"
+msgstr "Gehitu"
+
+#: id:15052
+msgid "Password"
+msgstr "Pasahitza"
+
+#: id:15100
+msgctxt "Auto context with id 15100"
+msgid "Library"
+msgstr "Liburutegia"
+
+#: id:15101
+msgid "Database"
+msgstr "Datu basea"
+
+#: id:15102
+msgid "* All albums"
+msgstr "* Album guztiak"
+
+#: id:15103
+msgid "* All artists"
+msgstr "* Artista guztiak"
+
+#: id:15104
+msgid "* All songs"
+msgstr "* Abesti guztiak"
+
+#: id:15105
+msgid "* All genres"
+msgstr "* Genero guztiak"
+
+#: id:15107
+msgid "Buffering..."
+msgstr "Bufferreratzen..."
+
+#: id:15108
+msgid "Navigation sounds"
+msgstr "Nabigazio soinuak"
+
+#: id:15109
+msgid "Skin default"
+msgstr "Skin lehenetsia"
+
+#: id:15111
+msgid "- Theme"
+msgstr "- Tema"
+
+#: id:15112
+msgid "Default theme"
+msgstr "Tema lehenetsia"
+
+#: id:15200
+msgid "Last.fm"
+msgstr "Last.fm"
+
+#: id:15201
+msgid "Submit songs to Last.fm"
+msgstr "Bidali kantuak Last.fm-ra"
+
+#: id:15202
+msgid "Last.fm username"
+msgstr "Last.fm-ko erabiltzaile izena"
+
+#: id:15203
+msgid "Last.fm password"
+msgstr "Last.fm-ko pasahitza"
+
+#: id:15204
+msgid "Unable to handshake: sleeping..."
+msgstr "Ez da ondo konektatu: lokartzen..."
+
+#: id:15205
+msgid "Please update XBMC"
+msgstr "Mesedez eguneratu XBMC"
+
+#: id:15206
+msgid "Bad authorization: Check username and password"
+msgstr "Autorizazio okerra: Egiaztatu erabiltzaile izena eta pasahitza"
+
+#: id:15207
+msgctxt "Auto context with id 15207"
+msgid "Connected"
+msgstr "Konektatuta"
+
+#: id:15208
+msgid "Not connected"
+msgstr "Konektatu gabe"
+
+#: id:15209
+msgid "Submit interval %i"
+msgstr "Bidali %i tartea"
+
+#: id:15210
+msgid "Cached %i songs"
+msgstr "Katxean %i abesti"
+
+#: id:15211
+msgid "Submitting..."
+msgstr "Bidaltzen..."
+
+#: id:15212
+msgid "Submitting in %i secs"
+msgstr "Bidaltzen %i segundutan"
+
+#: id:15213
+msgid "Play using..."
+msgstr "Erreproduzitu erabiliz..."
+
+#: id:15214
+msgid "Use smoothed A/V synchronization"
+msgstr "Erabili leundutako A/V sinkronizazioa"
+
+#: id:15215
+msgid "Hide file names in thumbs view"
+msgstr "Ezkutatu fitxategi izenak argazkitxo ikuspegian"
+
+#: id:15216
+msgid "Play in party mode"
+msgstr "Erreproduzitu festa moduan"
+
+#: id:15217
+msgid "Submit songs to Libre.fm"
+msgstr "Bidali abestiak Libre.fm-ra"
+
+#: id:15218
+msgid "Libre.fm username"
+msgstr "Libre.fm erabiltzaile izena"
+
+#: id:15219
+msgid "Libre.fm password"
+msgstr "Libre.fm pasahitza"
+
+#: id:15220
+msgid "Libre.fm"
+msgstr "Libre.fm"
+
+#: id:15221
+msgid "Song submission"
+msgstr "Abestien bidalketa"
+
+#: id:15250
+msgid "Submit Last.fm radio to Last.fm"
+msgstr "Bidali Last.fm irratia Last.fm-ra"
+
+#: id:15251
+msgid "Connecting to Last.fm..."
+msgstr "Last.fm-ra konektatzen..."
+
+#: id:15252
+msgid "Selecting station..."
+msgstr "Estazioa hautatzen..."
+
+#: id:15253
+msgid "Search similar artists..."
+msgstr "Bilatu antzeko artistak..."
+
+#: id:15254
+msgid "Search similar tags..."
+msgstr "Bilatu antzeko etiketak..."
+
+#: id:15255
+msgid "Your profile (%name%)"
+msgstr "Zure profila (%name%)"
+
+#: id:15256
+msgid "Overall top tags"
+msgstr "Goiko etiketa orokorrak"
+
+#: id:15257
+msgid "Top artists for tag %name%"
+msgstr "Top artistak %name% etiketarentzako"
+
+#: id:15258
+msgid "Top albums for tag %name%"
+msgstr "Top albumak %name% etiketarentzako"
+
+#: id:15259
+msgid "Top tracks for tag %name%"
+msgstr "Top pistak %name% etiketarentzako"
+
+#: id:15260
+msgid "Listen to tag %name% Last.fm radio"
+msgstr "Entzun %name% etiketa Last.fm irratian"
+
+#: id:15261
+msgid "Similar artists as %name%"
+msgstr "%name%-en antzeko artistak"
+
+#: id:15262
+msgid "Top %name% albums"
+msgstr "Top %name% albumak"
+
+#: id:15263
+msgid "Top %name% tracks"
+msgstr "Top %name% pistak"
+
+#: id:15264
+msgid "Top %name% tags"
+msgstr "Top %name% etiketak"
+
+#: id:15265
+msgid "Biggest fans of %name%"
+msgstr "%name%-ren fan handienak"
+
+#: id:15266
+msgid "Listen to %name% fans Last.fm radio"
+msgstr "Entzun %name%-ko fanei Last.fm irratian"
+
+#: id:15267
+msgid "Listen to %name% similar artists Last.fm radio"
+msgstr "Entzun %name%-ren antzeko artistak Last.fm-ko irratian"
+
+#: id:15268
+msgid "Top artists for user %name%"
+msgstr "Top artistak %name%-tzako"
+
+#: id:15269
+msgid "Top albums for user %name%"
+msgstr "Top albumak %name%-entzako"
+
+#: id:15270
+msgid "Top tracks for user %name%"
+msgstr "Top pistak %name% erabiltzailearentzako"
+
+#: id:15271
+msgid "Friends of user %name%"
+msgstr "%name% erabiltzailearen lagunak"
+
+#: id:15272
+msgid "Neighbours of user %name%"
+msgstr "%name% erabiltzailearen bizilagunak"
+
+#: id:15273
+msgid "Weekly artist chart for %name%"
+msgstr "Asteko artista taula %name%-rentzat"
+
+#: id:15274
+msgid "Weekly album chart for %name%"
+msgstr "Asteko album taula %name%-rentzat"
+
+#: id:15275
+msgid "Weekly track chart for %name%"
+msgstr "Asteko pista taula %name%-rentzat"
+
+#: id:15276
+msgid "Listen to %name%'s neighbours Last.fm radio"
+msgstr "Entzun %name%-ren bizilagunak Last.fm irratian"
+
+#: id:15277
+msgid "Listen to %name%'s personal Last.fm radio"
+msgstr "Entzun %name%-ren pertsonala Last.fm irratian"
+
+#: id:15278
+msgid "Listen to %name%'s mix Last.fm radio"
+msgstr "Entzun %name%-ren abesti gogokoenak Last.fm irratian"
+
+#: id:15279
+msgid "Retrieving list from Last.fm..."
+msgstr "Zerrenda eskuratzen Last.fm-tik..."
+
+#: id:15280
+msgid "Can't retrieve list from Last.fm..."
+msgstr "Ezin da berreskuratu zerrenda Last.fm-tik..."
+
+#: id:15281
+msgid "Enter an artist name to find related ones"
+msgstr "Sartu izen bat antzeko artista batzuk aurkitzeko"
+
+#: id:15282
+msgid "Enter a tag name to find similar ones"
+msgstr "Sartu etiketa izena antzeko batzuk aurkitzeko"
+
+#: id:15283
+msgid "Tracks recently listened by %name%"
+msgstr "Orain dela gutxi entzundako pistak %name%-ren arabera"
+
+#: id:15284
+msgid "Listen to %name%'s recommendations Last.fm radio"
+msgstr "Entzun %name%-ren gomendioak Last.fm irratian"
+
+#: id:15285
+msgid "Top tags for user %name%"
+msgstr "%name% erabiltzailearen top etiketak"
+
+#: id:15287
+msgid "Do you want to add the current track to your loved tracks?"
+msgstr "Gehitu pista hau zure gogoke pistetara?"
+
+#: id:15288
+msgid "Do you want to ban the current track?"
+msgstr "Uneko pista debekatu nahi duzu?"
+
+#: id:15289
+msgid "Added to your loved tracks: '%s'."
+msgstr "Zure gogoko pistetara gehituta: '%s'."
+
+#: id:15290
+msgid "Could not add '%s' to your loved tracks."
+msgstr "'%s'ezin izan da zure gogokoetara gehitu."
+
+#: id:15291
+msgid "Banned: '%s'."
+msgstr "Debekatuta: '%s'."
+
+#: id:15292
+msgid "Could not ban '%s'."
+msgstr "Ezin izan da '%s' debekatu."
+
+#: id:15293
+msgid "Tracks recently loved by %name%"
+msgstr "Orain dela gutxi gogokoak diren pistak %name%-ren arabera"
+
+#: id:15294
+msgid "Tracks recently banned by %name%"
+msgstr "Orain dela gutxi debekatutako pistak %name%-ren arabera"
+
+#: id:15295
+msgid "Remove from loved tracks"
+msgstr "Kendu gogokoetatik"
+
+#: id:15296
+msgid "Un-ban"
+msgstr "Debekua kendu"
+
+#: id:15297
+msgid "Do you want to remove this track from your loved tracks?"
+msgstr "Nahi duzu zure gogokoetatik pista hau kentzea?"
+
+#: id:15298
+msgid "Do you want to un-ban this track?"
+msgstr "Pista honen debekua kendu nahi duzu?"
+
+#: id:15300
+msgid "Path not found or invalid"
+msgstr "Bidea ez da aurkitu edo baliogabea da"
+
+#: id:15301
+msgid "Could not connect to network server"
+msgstr "Ezin izan da sareko zerbitzariarekin konektatu"
+
+#: id:15302
+msgid "No servers found"
+msgstr "Ez da zerbitzaririk aurkitu"
+
+#: id:15303
+msgid "Workgroup not found"
+msgstr "Lantaldea ez da aurkitu"
+
+#: id:15310
+msgid "Opening multi-path source"
+msgstr "Bide anitzeko iturria irekitzen"
+
+#: id:15311
+msgid "Path:"
+msgstr "Bidea:"
+
+#: id:16000
+msgctxt "Auto context with id 16000"
+msgid "General"
+msgstr "Orokorra"
+
+#: id:16002
+msgid "Internet lookup"
+msgstr "Interneteko bilaketa"
+
+#: id:16003
+msgid "Player"
+msgstr "Erreproduktorea"
+
+#: id:16004
+msgid "Play media from disc"
+msgstr "Erreproduzitu diskotik"
+
+#: id:16008
+msgid "Enter new title"
+msgstr "Sartu titulu berria"
+
+#: id:16009
+msgid "Enter the movie name"
+msgstr "Sartu filmaren izena"
+
+#: id:16010
+msgid "Enter the profile name"
+msgstr "Sartu profilaren izena"
+
+#: id:16011
+msgid "Enter the album name"
+msgstr "Sartu albumaren izena"
+
+#: id:16012
+msgid "Enter the playlist name"
+msgstr "Sartu zerrendaren izena"
+
+#: id:16013
+msgid "Enter new filename"
+msgstr "Sartu fitxategiaren izen berria"
+
+#: id:16014
+msgid "Enter folder name"
+msgstr "Sartu karpetaren izena"
+
+#: id:16015
+msgid "Enter directory"
+msgstr "Sartu direktorioa"
+
+#: id:16016
+msgid "Available options: %A, %T, %N, %B, %D, %G, %Y, %F, %S"
+msgstr "Aukera eskuragarriak: %A, %T, %N, %B, %D, %G, %Y, %F, %S"
+
+#: id:16017
+msgid "Enter search string"
+msgstr "Sartu bilaketa katea"
+
+#: id:16018
+msgctxt "Auto context with id 16018"
+msgid "None"
+msgstr "Bat ere ez"
+
+#: id:16019
+msgid "Auto select"
+msgstr "Auto aukeratu"
+
+#: id:16020
+msgid "De-interlace"
+msgstr "De-interlace"
+
+#: id:16021
+msgid "Bob"
+msgstr "Bob"
+
+#: id:16022
+msgid "Bob (inverted)"
+msgstr "Bob (alderantziz)"
+
+#: id:16024
+msgid "Canceling..."
+msgstr "Uzten..."
+
+#: id:16025
+msgid "Enter the artist name"
+msgstr "Sartu artistaren izena"
+
+#: id:16026
+msgid "Playback failed"
+msgstr "Erreprodukzioak huts egin du"
+
+#: id:16027
+msgid "One or more items failed to play."
+msgstr "Elemntu bat edo gehiagok huts egin du(te) erreproduzitzean"
+
+#: id:16028
+msgid "Enter value"
+msgstr "Idatzi balioa"
+
+#: id:16029
+msgid "Check the log file for details."
+msgstr "Egiaztatu log fitxategia xehetasunetarako"
+
+#: id:16030
+msgid "Party mode aborted."
+msgstr "Festa modua kenduta."
+
+#: id:16031
+msgid "No matching songs in the library."
+msgstr "Ez da liburutegian bat datorren abestirik aurkitu"
+
+#: id:16032
+msgid "Could not initialize database."
+msgstr "Ezin izan da datu-basea hasi."
+
+#: id:16033
+msgid "Could not open database."
+msgstr "Ezin izan da datu-basea ireki."
+
+#: id:16034
+msgid "Could not get songs from database."
+msgstr "Ezin izan da abestirik lortu datu basetik."
+
+#: id:16035
+msgid "Party mode playlist"
+msgstr "Festa moduko zerrenda"
+
+#: id:16036
+msgid "De-interlace (Half)"
+msgstr ""
+
+#: id:16037
+msgid "Deinterlace video"
+msgstr ""
+
+#: id:16038
+msgid "Deinterlace method"
+msgstr ""
+
+#: id:16039
+msgctxt "Auto context with id 16039"
+msgid "Off"
+msgstr ""
+
+#: id:16040
+msgctxt "Auto context with id 16040"
+msgid "Auto"
+msgstr ""
+
+#: id:16041
+msgid "On"
+msgstr ""
+
+#: id:16100
+msgid "All Videos"
+msgstr "Bideo guztiak"
+
+#: id:16101
+msgid "Unwatched"
+msgstr "Ikusi gabe"
+
+#: id:16102
+msgid "Watched"
+msgstr "Ikusita"
+
+#: id:16103
+msgid "Mark as watched"
+msgstr "Markatu ikusita"
+
+#: id:16104
+msgid "Mark as unwatched"
+msgstr "Markatu ikusi gabe"
+
+#: id:16105
+msgid "Edit title"
+msgstr "Aldatu titulua"
+
+#: id:16200
+msgid "Operation was aborted"
+msgstr "Eragiketa bertan behera utzi da"
+
+#: id:16201
+msgid "Copy failed"
+msgstr "Kopiak huts egin du"
+
+#: id:16202
+msgid "Failed to copy at least one file"
+msgstr "Huts egin du gutxienez fitxategi bat kopiatzeak"
+
+#: id:16203
+msgid "Move failed"
+msgstr "Mugitzeak huts egin du"
+
+#: id:16204
+msgid "Failed to move at least one file"
+msgstr "Huts egin du gutxienez fitxategi bat mugitzeak"
+
+#: id:16205
+msgid "Delete failed"
+msgstr "Ezabatzeak huts egin du"
+
+#: id:16206
+msgid "Failed to delete at least one file"
+msgstr "Huts egin du gutxienez fitxategi bat ezabatzeak"
+
+#: id:16300
+msgid "Video scaling method"
+msgstr "Bideoa eskalatzeko metodoa"
+
+#: id:16301
+msgid "Nearest neighbour"
+msgstr "Gertueneko bizilaguna"
+
+#: id:16302
+msgid "Bilinear"
+msgstr "Bilinearra"
+
+#: id:16303
+msgctxt "Auto context with id 16303"
+msgid "Bicubic"
+msgstr "Bikubikoa"
+
+#: id:16304
+msgid "Lanczos2"
+msgstr "Lanczos2"
+
+#: id:16305
+msgid "Lanczos3"
+msgstr "Lanczos3"
+
+#: id:16306
+msgid "Sinc8"
+msgstr "Sinc8"
+
+#: id:16307
+msgid "Bicubic (software)"
+msgstr "Bikubikoa (software)"
+
+#: id:16308
+msgid "Lanczos (software)"
+msgstr "Lanczos (software)"
+
+#: id:16309
+msgid "Sinc (software)"
+msgstr "Sinc (software)"
+
+#: id:16310
+msgid "Temporal"
+msgstr "Tenporala"
+
+#: id:16311
+msgid "Temporal/Spatial"
+msgstr "Tenporala/Espaziala"
+
+#: id:16312
+msgid "(VDPAU)Noise Reduction"
+msgstr "(VDPAU)Zarata Murrizketa"
+
+#: id:16313
+msgid "(VDPAU)Sharpness"
+msgstr "(VDPAU)Fokatzea"
+
+#: id:16314
+msgid "Inverse Telecine"
+msgstr "Alderantzizko Telezinea"
+
+#: id:16315
+msgid "Lanczos3 optimized"
+msgstr "Lanczos3 optimizatua"
+
+#: id:16316
+msgctxt "Auto context with id 16316"
+msgid "Auto"
+msgstr "Auto"
+
+#: id:16317
+msgid "Temporal (Half)"
+msgstr "Tenporala (Erdia)"
+
+#: id:16318
+msgid "Temporal/Spatial (Half)"
+msgstr "Tenporala/Espaziala (Erdia)"
+
+#: id:16319
+msgid "DXVA"
+msgstr "DXVA"
+
+#: id:16320
+msgid "DXVA Bob"
+msgstr ""
+
+#: id:16321
+msgid "DXVA Best"
+msgstr ""
+
+#: id:16322
+msgid "Spline36"
+msgstr ""
+
+#: id:16323
+msgid "Spline36 optimized"
+msgstr ""
+
+#: id:16324
+msgid "Software Blend"
+msgstr ""
+
+#: id:16400
+msgid "Post-processing"
+msgstr "Bideoaren osteko-tratamendua"
+
+#: id:17500
+msgid "Display sleep timeout"
+msgstr "Erakutsi lo egiteko denbora-muga"
+
+#: id:19000
+msgid "Switch to channel"
+msgstr "Aldatu kanala"
+
+#: id:20000
+msgid "Saved music folder"
+msgstr "Gordetako musikaren karpeta"
+
+#: id:20001
+msgid "Use external DVD player"
+msgstr "Erabili kanpoko DVD erreproduzitzailea"
+
+#: id:20002
+msgid "External DVD player"
+msgstr "Kanpoko DVD erreproduzitzailea"
+
+#: id:20003
+msgid "Trainers folder"
+msgstr "Entrenatzaile karpeta"
+
+#: id:20004
+msgid "Screenshot folder"
+msgstr "Pantaila irudien karpeta"
+
+#: id:20006
+msgid "Playlists folder"
+msgstr "Zerrenden karpeta"
+
+#: id:20007
+msgid "Recordings"
+msgstr "Grabazioak"
+
+#: id:20008
+msgid "Screenshots"
+msgstr "Pantaila irudiak"
+
+#: id:20009
+msgid "Use XBMC"
+msgstr "Erabili XBMC"
+
+#: id:20011
+msgid "Music playlists"
+msgstr "Musika zerrendak"
+
+#: id:20012
+msgid "Video playlists"
+msgstr "Bideo zerrendak"
+
+#: id:20013
+msgid "Do you wish to launch the game?"
+msgstr "Jokoa abiaraztea nahi duzu?"
+
+#: id:20014
+msgid "Sort by: Playlist"
+msgstr "Ordenatu: Zerrenda"
+
+#: id:20015
+msgid "Remote thumb"
+msgstr "Urruneko iruditxoa"
+
+#: id:20016
+msgid "Current thumb"
+msgstr "Oraingo iruditxoa"
+
+#: id:20017
+msgid "Local thumb"
+msgstr "Iruditxo lokala"
+
+#: id:20018
+msgid "No thumb"
+msgstr "Iruditxorik ez"
+
+#: id:20019
+msgid "Choose thumbnail"
+msgstr "Itxi iruditxoa"
+
+#: id:20023
+msgid "Conflict"
+msgstr "Gatazkak"
+
+#: id:20024
+msgid "Scan new"
+msgstr "Eskaneatu berria"
+
+#: id:20025
+msgid "Scan all"
+msgstr "Eskaneatu dena"
+
+#: id:20026
+msgid "Region"
+msgstr "Eskualdea"
+
+#: id:20037
+msgid "Summary"
+msgstr "Laburpena"
+
+#: id:20038
+msgid "Lock music window"
+msgstr "Blokeatu musikaren leihoa"
+
+#: id:20039
+msgid "Lock videos window"
+msgstr "Blokeatu bideoaren leihoa"
+
+#: id:20040
+msgid "Lock pictures window"
+msgstr "Blokeatu irudien leihoa"
+
+#: id:20041
+msgid "Lock programs & scripts windows"
+msgstr "Blokeatu programak eta script leihoak"
+
+#: id:20042
+msgid "Lock file manager"
+msgstr "Blokeatu fitxategi kudeatzailea"
+
+#: id:20043
+msgid "Lock settings"
+msgstr "Blokeatu ezarpenak"
+
+#: id:20044
+msgid "Start fresh"
+msgstr "Hasiera freskoa"
+
+#: id:20045
+msgid "Enter master mode"
+msgstr "Sartu master modura"
+
+#: id:20046
+msgid "Leave master mode"
+msgstr "Utzi master modua"
+
+#: id:20047
+msgid "Create profile '%s'?"
+msgstr "Sortu '%s' profila?"
+
+#: id:20048
+msgid "Start with fresh settings"
+msgstr "Hasi ezarpen freskoekin"
+
+#: id:20049
+msgid "Best available"
+msgstr "Eskuragarri dagoen onena"
+
+#: id:20050
+msgid "Auto-switch between 16x9 and 4x3"
+msgstr "16x9 eta 4x3 artean auto aldatu"
+
+#: id:20051
+msgid "Treat stacked files as single file"
+msgstr "Pilatutako fitxategiak bat bezala erabili"
+
+#: id:20052
+msgid "Caution"
+msgstr "Kontuz"
+
+#: id:20053
+msgid "Left master mode"
+msgstr "Ezker master modua"
+
+#: id:20054
+msgid "Entered master mode"
+msgstr "Master modura sartuta"
+
+#: id:20055
+msgid "Allmusic.com thumb"
+msgstr "Allmusic.com-eko iruditxoa"
+
+#: id:20057
+msgid "Remove thumbnail"
+msgstr "Kendu iruditxoa"
+
+#: id:20058
+msgid "Add profile..."
+msgstr "Gehitu profila..."
+
+#: id:20059
+msgid "Query info for all albums"
+msgstr "Kontsultatu informazioa album guztientzat"
+
+#: id:20060
+msgctxt "Auto context with id 20060"
+msgid "Media info"
+msgstr "Mediaren info"
+
+#: id:20061
+msgctxt "Auto context with id 20061"
+msgid "Separate"
+msgstr "Banatuta"
+
+#: id:20062
+msgid "Shares with default"
+msgstr "Partekatzeak lehenetsita"
+
+#: id:20063
+msgid "Shares with default (read only)"
+msgstr "Partekatzeak lehenetsita (irakurri bakarrik)"
+
+#: id:20064
+msgid "Copy default"
+msgstr "Kopiatu lehenetsia"
+
+#: id:20065
+msgid "Profile picture"
+msgstr "Profileko irudia"
+
+#: id:20066
+msgid "Lock preferences"
+msgstr "Blokeatu lehentasunak"
+
+#: id:20067
+msgid "Edit profile"
+msgstr "Aldatu profila"
+
+#: id:20068
+msgid "Profile lock"
+msgstr "Profila blokeatu"
+
+#: id:20069
+msgid "Could not create folder"
+msgstr "Ezin izan da karpeta sortu"
+
+#: id:20070
+msgid "Profile directory"
+msgstr "Profilaren direktorioa"
+
+#: id:20071
+msgid "Start with fresh media sources"
+msgstr "Hasi media iturri freskoekin"
+
+#: id:20072
+msgid "Make sure the selected folder is writable"
+msgstr "Ziurtatu aukeratutako karpeta idazgarria den"
+
+#: id:20073
+msgid "and that the new folder name is valid"
+msgstr "eta karpeta berriaren izena baliozkoa dela"
+
+#: id:20074
+msgid "MPAA rating"
+msgstr "MPAA balorazioa"
+
+#: id:20075
+msgid "Enter master lock code"
+msgstr "Idatzi master blokeo kodea"
+
+#: id:20076
+msgid "Ask for master lock code on startup"
+msgstr "Master blokeo kodea eskatu abioan"
+
+#: id:20077
+msgid "Skin settings"
+msgstr "Skin-aren ezarpenak"
+
+#: id:20078
+msgid "- no link set -"
+msgstr "- ez dago link ezarririk -"
+
+#: id:20079
+msgid "Enable animations"
+msgstr "Gaitu animazioak"
+
+#: id:20080
+msgid "Disable RSS during music"
+msgstr "Ezgaitu RSS musikarekin"
+
+#: id:20081
+msgid "Enable shortcut buttons"
+msgstr "Gaitu lasterbide botoiak"
+
+#: id:20082
+msgid "Show programs in main menu"
+msgstr "Erakutsi programak menu nagusian"
+
+#: id:20083
+msgid "Show music info"
+msgstr "Erakutsi musikaren info"
+
+#: id:20084
+msgid "Show weather info"
+msgstr "Erakutsi eguraldiaren info"
+
+#: id:20085
+msgid "Show system info"
+msgstr "Erakutsi sistemaren info"
+
+#: id:20086
+msgid "Show available disc space C: E: F:"
+msgstr "Erakutsi diskoko espazio erabilgarria C: E: F:"
+
+#: id:20087
+msgid "Show available disc space E: F: G:"
+msgstr "Erakutsi diskoko espazio erabilgarria E: F: G:"
+
+#: id:20088
+msgid "Weather info"
+msgstr "Eguraldiaren info"
+
+#: id:20089
+msgid "Drive space free"
+msgstr "unitateko espazio librea"
+
+#: id:20090
+msgid "Enter the name of an existing share"
+msgstr "Idatzi existitzen den partekatze baten izena"
+
+#: id:20091
+msgid "Lock code"
+msgstr "Blokeatzeko kodea"
+
+#: id:20092
+msgid "Load profile"
+msgstr "Kargatu profila"
+
+#: id:20093
+msgid "Profile name"
+msgstr "Profilaren izena"
+
+#: id:20094
+msgctxt "Auto context with id 20094"
+msgid "Media sources"
+msgstr "Media iturriak"
+
+#: id:20095
+msgid "Enter profile lock code"
+msgstr "Sartu profileko blokeo kodea"
+
+#: id:20096
+msgctxt "Auto context with id 20096"
+msgid "Login screen"
+msgstr "Sartzeko pantaila"
+
+#: id:20097
+msgid "Fetching album info"
+msgstr "Eskuratzen albumaren info"
+
+#: id:20098
+msgid "Fetching info for album"
+msgstr "Eskuratzen info albumerako"
+
+#: id:20099
+msgid "Can't rip CD or track while playing from CD"
+msgstr "Ezin da erauzi CD edo pista CDa erreproduzitzean"
+
+#: id:20100
+msgid "Master lock code and settings"
+msgstr "Master blokeo kodea eta ezarpenak"
+
+#: id:20101
+msgid "Entering master lock code always enables master mode"
+msgstr "Master blokeo kodea sartzeak beti maisu modua gaitzen du"
+
+#: id:20102
+msgid "or copy from default?"
+msgstr "edo lehenetsitik kopiatu?"
+
+#: id:20103
+msgid "Save changes to profile?"
+msgstr "Gorde profileko aldaketak?"
+
+#: id:20104
+msgid "Old settings found."
+msgstr "Ezarpen zaharrak aurkitu dira."
+
+#: id:20105
+msgid "Do you want to use them?"
+msgstr "Erabiltzea nahi duzu?"
+
+#: id:20106
+msgid "Old media sources found."
+msgstr "Media iturri zaharrak aurkitu dira."
+
+#: id:20107
+msgid "Separate (locked)"
+msgstr "Banatuta (blokeatuta)"
+
+#: id:20108
+msgid "Root"
+msgstr "Erroa"
+
+#: id:20109
+msgid "- Zoom"
+msgstr "- Zoom-a"
+
+#: id:20110
+msgid "UPnP settings"
+msgstr "UPnP ezarpenak"
+
+#: id:20111
+msgid "Autostart UPnP client"
+msgstr "Automatikoki hasi UPnP bezeroa"
+
+#: id:20112
+msgid "Last login: %s"
+msgstr "Azkenego sartuta: %s"
+
+#: id:20113
+msgid "Never logged on"
+msgstr "Inoiz sartu gabe"
+
+#: id:20114
+msgid "Profile %i / %i"
+msgstr "Profila %i / %i"
+
+#: id:20115
+msgid "User login / Select a profile"
+msgstr "Erabiltzaile sarrera / Aukeratu profil bat"
+
+#: id:20116
+msgid "Use lock on login screen"
+msgstr "Erabili blokeoa sartzeko pantailan"
+
+#: id:20117
+msgid "Invalid lock code."
+msgstr "Blokeatzeko kode baliogabezkoa."
+
+#: id:20118
+msgid "This requires the master lock to be set."
+msgstr "Horretarako, ezinbestekoa da master blokeoa ezartzea."
+
+#: id:20119
+msgid "Would you like to set it now?"
+msgstr "Gustatuko litzaizuke orain ezartzea?"
+
+#: id:20120
+msgid "Loading program information"
+msgstr "Programaren informazioa kargatzen"
+
+#: id:20121
+msgid "Party on!"
+msgstr "Festa gaituta!"
+
+#: id:20122
+msgid "True"
+msgstr "Egia"
+
+#: id:20123
+msgid "Mixing drinks"
+msgstr "Edariak nahasten"
+
+#: id:20124
+msgid "Filling glasses"
+msgstr "Edalontziak betetzen"
+
+#: id:20125
+msgid "Logged on as"
+msgstr "Sartuta"
+
+#: id:20126
+msgid "Log off"
+msgstr "Irten"
+
+#: id:20128
+msgid "Go to root"
+msgstr "Joan errora"
+
+#: id:20129
+msgid "Weave"
+msgstr "Weave"
+
+#: id:20130
+msgid "Weave (inverted)"
+msgstr "Weave (alderantziz)"
+
+#: id:20131
+msgid "Blend"
+msgstr "Blend"
+
+#: id:20132
+msgid "Restart video"
+msgstr "Berrabiarazi bideoa"
+
+#: id:20133
+msgid "Edit network location"
+msgstr "Editatu sareko kokalekua"
+
+#: id:20134
+msgid "Remove network location"
+msgstr "Kendu sareko kokalekua"
+
+#: id:20135
+msgid "Do you want to scan the folder?"
+msgstr "Karpeta eskaneatzea nahi duzu?"
+
+#: id:20136
+msgid "Memory unit"
+msgstr "Memoria unitatea"
+
+#: id:20137
+msgid "Memory unit mounted"
+msgstr "Memoria unitatea muntatuta"
+
+#: id:20138
+msgid "Unable to mount memory unit"
+msgstr "Ezin da memoria unitatea muntatu"
+
+#: id:20139
+msgid "In port %i, slot %i"
+msgstr "%i portuan, %i slot-a"
+
+#: id:20140
+msgid "Lock screensaver"
+msgstr "Blokeo pantaila babeslea"
+
+#: id:20141
+msgid "Set"
+msgstr "Ezarri"
+
+#: id:20142
+msgctxt "Auto context with id 20142"
+msgid "Username"
+msgstr "Erabiltzaile izena"
+
+#: id:20143
+msgid "Enter password for"
+msgstr "Sartu pasahitza"
+
+#: id:20144
+msgid "Shutdown timer"
+msgstr "Itzaltze tenporizadorea"
+
+#: id:20145
+msgid "Shutdown interval (in minutes)"
+msgstr "Itzaltze bitartea (minututan)"
+
+#: id:20146
+msgid "Started, shutdown in %im"
+msgstr "Hasita, %im ondoren itzaliko da"
+
+#: id:20147
+msgid "Shutdown in 30 minutes"
+msgstr "30 minuturen ondoren itzaliko da"
+
+#: id:20148
+msgid "Shutdown in 60 minutes"
+msgstr "60 minuturen ondoren itzaliko da"
+
+#: id:20149
+msgid "Shutdown in 120 minutes"
+msgstr "120 minuturen ondoren itzaliko da"
+
+#: id:20150
+msgid "Custom shutdown timer"
+msgstr "Itzaltze tenporizadore pertsonalizatua"
+
+#: id:20151
+msgid "Cancel shutdown timer"
+msgstr "Utzi itzaltzeko tenporizadorea"
+
+#: id:20152
+msgid "Lock preferences for %s"
+msgstr "Blokeatu ezarpenak %s-ri"
+
+#: id:20153
+msgid "Browse..."
+msgstr "Arakatu..."
+
+#: id:20154
+msgid "Summary information"
+msgstr "Laburpen informazioa"
+
+#: id:20155
+msgid "Storage information"
+msgstr "Biltegiratze informazioa"
+
+#: id:20156
+msgid "Hard disk information"
+msgstr "Disko gogorraren informazioa"
+
+#: id:20157
+msgid "DVD-ROM information"
+msgstr "DVD-ROM informazioa"
+
+#: id:20158
+msgid "Network information"
+msgstr "Sarearen informazioa"
+
+#: id:20159
+msgid "Video information"
+msgstr "Bideoaren informazioa"
+
+#: id:20160
+msgid "Hardware information"
+msgstr "Hardwarearen informazioa"
+
+#: id:20161
+msgid "Total"
+msgstr "Guztira"
+
+#: id:20162
+msgid "Used"
+msgstr "Erabilita"
+
+#: id:20163
+msgid "of"
+msgstr "/"
+
+#: id:20164
+msgid "Locking not supported"
+msgstr "Ez da blokeoa onartzen"
+
+#: id:20165
+msgid "Not locked"
+msgstr "Ez blokeatuta"
+
+#: id:20166
+msgid "Locked"
+msgstr "Blokeatuta"
+
+#: id:20167
+msgid "Frozen"
+msgstr "Izoztuta"
+
+#: id:20168
+msgid "Requires reset"
+msgstr "Beharrezkoa berrezartzea"
+
+#: id:20169
+msgid "Week"
+msgstr "Astea"
+
+#: id:20170
+msgid "Line"
+msgstr "Lerroa"
+
+#: id:20171
+msgid "Windows network (SMB)"
+msgstr "Windows sarea (SMB)"
+
+#: id:20172
+msgid "XBMSP server"
+msgstr "XBMSP zerbitzaria"
+
+#: id:20173
+msgctxt "Auto context with id 20173"
+msgid "FTP server"
+msgstr "FTP zerbitzaria"
+
+#: id:20174
+msgid "iTunes music share (DAAP)"
+msgstr "iTunes musika partekatzea (DAAP)"
+
+#: id:20175
+msgid "UPnP server"
+msgstr "UPnP zerbitzaria"
+
+#: id:20176
+msgid "Show video info"
+msgstr "Erakutsi bideoaren info"
+
+#: id:20177
+msgid "Done"
+msgstr "Eginda"
+
+#: id:20178
+msgid "Shift"
+msgstr "Shift"
+
+#: id:20179
+msgid "Caps Lock"
+msgstr "Bloq Mayús"
+
+#: id:20180
+msgid "Symbols"
+msgstr "Sinboloak"
+
+#: id:20181
+msgid "Backspace"
+msgstr "Ezabatze tekla"
+
+#: id:20182
+msgid "Space"
+msgstr "Espazioa"
+
+#: id:20183
+msgid "Reload skin"
+msgstr "Skin-a berriz kargatu"
+
+#: id:20184
+msgid "Rotate pictures using EXIF information"
+msgstr "Biratu argazkiak EXIF informazioa erabiliz"
+
+#: id:20185
+msgid "Use poster view styles for TV shows"
+msgstr "Erabili posterrak ikusteko estiloa TB saioetarako"
+
+#: id:20186
+msgid "Please wait"
+msgstr "Mesedez itxaron"
+
+#: id:20187
+msgid "UPnP"
+msgstr ""
+
+#: id:20189
+msgid "Enable auto scrolling for plot & review"
+msgstr "Gaitu auto korritze gidoi eta berrikuspenarentzat"
+
+#: id:20190
+msgctxt "Auto context with id 20190"
+msgid "Custom"
+msgstr "Pertsonalizatua"
+
+#: id:20191
+msgid "Enable debug logging"
+msgstr "Gaitu debug saioa"
+
+#: id:20192
+msgid "Download additional information during updates"
+msgstr "Deskargatu informazio gehigarria eguneratzeetan"
+
+#: id:20193
+msgid "Default service for album information"
+msgstr "Lehenetsitako zerbitzua albumaren informaziorako"
+
+#: id:20194
+msgid "Default service for artist information"
+msgstr "Lehenetsitako zerbitzua artistaren informaziorako"
+
+#: id:20195
+msgid "Change scraper"
+msgstr "Aldatu scraper-a"
+
+#: id:20196
+msgid "Export music library"
+msgstr "Esportatu musikaren liburutegia"
+
+#: id:20197
+msgid "Import music library"
+msgstr "Inportatu musikaren liburutegia"
+
+#: id:20198
+msgid "No artist found!"
+msgstr "Ez da artistarik aurkitu!"
+
+#: id:20199
+msgid "Downloading artist info failed"
+msgstr "Artistaren info deskargatzeak huts egin du"
+
+#: id:20250
+msgid "Party on! (videos)"
+msgstr "Festa gaituta! (bideoak)"
+
+#: id:20251
+msgid "Mixing drinks (videos)"
+msgstr "Edariak nahasten (bideoak)"
+
+#: id:20252
+msgid "Filling glasses (videos)"
+msgstr "Edalontziak betetzen (bideoak)"
+
+#: id:20253
+msgid "WebDAV server (HTTP)"
+msgstr "WebDAV zerbitzaria (HTTP)"
+
+#: id:20254
+msgid "WebDAV server (HTTPS)"
+msgstr "WebDAV zerbitzaria (HTTPS)"
+
+#: id:20255
+msgid "First logon, edit your profile"
+msgstr "Leheneno sarrera, aldatu zure profila"
+
+#: id:20256
+msgid "HTS Tvheadend client"
+msgstr "HTS Tvheadend bezeroa"
+
+#: id:20257
+msgid "VDR Streamdev client"
+msgstr "VDR Streamdev bezeroa"
+
+#: id:20258
+msgid "MythTV client"
+msgstr ""
+
+#: id:20259
+msgid "Network Filesystem (NFS)"
+msgstr ""
+
+#: id:20260
+msgid "Secure Shell (SSH/SFTP)"
+msgstr ""
+
+#: id:20261
+msgid "Apple Filing Protocol (AFP)"
+msgstr ""
+
+#: id:20300
+msgid "Web server directory (HTTP)"
+msgstr "Web zerbitzariaren direktorioa (HTTP)"
+
+#: id:20301
+msgid "Web server directory (HTTPS)"
+msgstr "Web zerbitzariaren direktorioa (HTTPS)"
+
+#: id:20302
+msgid "Unable to write to folder:"
+msgstr "Ezin da karpetan idatzi:"
+
+#: id:20303
+msgid "Do you want to skip and proceed?"
+msgstr "Saltatu eta jarraitzea nahi duzu?"
+
+#: id:20304
+msgid "RSS Feed"
+msgstr "RSS Jarioak"
+
+#: id:20307
+msgid "Secondary DNS"
+msgstr "Bigarren DNSa"
+
+#: id:20308
+msgid "DHCP server:"
+msgstr "DHCP zerbitzaria:"
+
+#: id:20309
+msgid "Make new folder"
+msgstr "Sortu karpeta berria"
+
+#: id:20310
+msgid "Dim LCD on playback"
+msgstr "Dim erreprodukzioa LCDan"
+
+#: id:20311
+msgid "Unknown or onboard (protected)"
+msgstr "Ezezaguna edo barrukoa (babestua)"
+
+#: id:20312
+msgid "Dim LCD on paused"
+msgstr "Dim erreprodukzioa LCDan pausatuta"
+
+#: id:20314
+msgid "Videos - Library"
+msgstr "Bideoak - Liburutegia"
+
+#: id:20316
+msgid "Sort by: ID"
+msgstr "Ordenatu: ID"
+
+#: id:20324
+msgid "Play part..."
+msgstr "Erreproduzitu zatia..."
+
+#: id:20325
+msgid "Calibration reset"
+msgstr "Kalibrazioa berrezarri"
+
+#: id:20326
+msgid "This will reset the calibration values for %s"
+msgstr "Honek %s-ren balioak berrezarriko ditu"
+
+#: id:20327
+msgid "to it's default values."
+msgstr "lehenetsitako balioetara."
+
+#: id:20328
+msgid "Browse for destination"
+msgstr "Arakatu helbururako"
+
+#: id:20329
+msgid "Movies are in separate folders that match the movie title"
+msgstr ""
+
+#: id:20330
+msgid "Use folder names for lookups"
+msgstr "Erabili karpeten izenak bilaketetarako"
+
+#: id:20331
+msgctxt "Auto context with id 20331"
+msgid "File"
+msgstr "Fitxategia"
+
+#: id:20332
+msgid "Use file or folder names in lookups?"
+msgstr "Erabili fitxategi edo karpeten izenak bilaketetan?"
+
+#: id:20333
+msgid "Set content"
+msgstr "Ezarri edukia"
+
+#: id:20334
+msgid "Folder"
+msgstr "Karpeta"
+
+#: id:20335
+msgid "Look for content recursively?"
+msgstr "Bilatu errekurtsiboki edukia?"
+
+#: id:20336
+msgid "Unlock sources"
+msgstr "Desblokeatu iturriak"
+
+#: id:20337
+msgid "Actor"
+msgstr "Aktorea"
+
+#: id:20338
+msgid "Movie"
+msgstr "Filma"
+
+#: id:20339
+msgid "Director"
+msgstr "Zuzendaria"
+
+#: id:20340
+msgid "Do you want to remove all items within"
+msgstr "Bide honetakoelementu guztiak kendu"
+
+#: id:20341
+msgid "this path from the XBMC library?"
+msgstr "nahi dituzu XBMC-ko liburutegitik?"
+
+#: id:20342
+msgctxt "Auto context with id 20342"
+msgid "Movies"
+msgstr "Filmak"
+
+#: id:20343
+msgid "TV shows"
+msgstr "TB saioak"
+
+#: id:20344
+msgid "This directory contains"
+msgstr "Direktorio honek du"
+
+#: id:20345
+msgid "Run automated scan"
+msgstr "Exekutatu eskaneatze automatizatua"
+
+#: id:20346
+msgid "Scan recursively"
+msgstr "Eskaneatu errekurtsiboki"
+
+#: id:20347
+msgid "as"
+msgstr "bezala"
+
+#: id:20348
+msgid "Directors"
+msgstr "Zuzendariak"
+
+#: id:20349
+msgid "No video files found in this path!"
+msgstr "Ez da bideo fitxategirik aurkitu bide honetan!"
+
+#: id:20350
+msgid "votes"
+msgstr "botoak"
+
+#: id:20351
+msgid "TV show information"
+msgstr "TB saio infromazioa"
+
+#: id:20352
+msgid "Episode information"
+msgstr "Pasartearen informazioa"
+
+#: id:20353
+msgid "Loading TV show details"
+msgstr "Kargatzen TB saioen xehetasunak"
+
+#: id:20354
+msgid "Fetching episode guide"
+msgstr "Fetching episode guide"
+
+#: id:20355
+msgid "Loading info for episodes in directory"
+msgstr "Kargatzen info direktorioko pasarteetan"
+
+#: id:20356
+msgid "Select TV show:"
+msgstr "Aukeratu TB saioa:"
+
+#: id:20357
+msgid "Enter the TV show name"
+msgstr "Sartu TB saioaren izena"
+
+#: id:20358
+msgid "Season %i"
+msgstr "%i denboraldia"
+
+#: id:20359
+msgid "Episode"
+msgstr "Pasartea"
+
+#: id:20360
+msgid "Episodes"
+msgstr "Pasarteak"
+
+#: id:20361
+msgid "Loading episode details"
+msgstr "Kargatzen pasartearen xehetasunak"
+
+#: id:20362
+msgid "Remove episode from library"
+msgstr "Kendu pasartea liburutegitik"
+
+#: id:20363
+msgid "Remove TV show from library"
+msgstr "Kendu TB saioaren liburutegia"
+
+#: id:20364
+msgid "TV show"
+msgstr "TB saioa"
+
+#: id:20365
+msgid "Episode plot"
+msgstr "Pasartearen gidoia"
+
+#: id:20366
+msgid "* All seasons"
+msgstr "* Denboraldi guztiak"
+
+#: id:20367
+msgid "Hide watched"
+msgstr "Ezkutatu ikusita"
+
+#: id:20368
+msgid "Prod code"
+msgstr "Prod kodea"
+
+#: id:20369
+msgid "Show plot for unwatched items"
+msgstr "Erakutsi gidoia ikusi gabeko elementuetan"
+
+#: id:20370
+msgid "* Hidden to prevent spoilers *"
+msgstr "* Ezkutatuta spoiler-ak sahiesteko *"
+
+#: id:20371
+msgid "Set season thumb"
+msgstr "Ezarri denboraldiaren iruditxoa"
+
+#: id:20372
+msgid "Season image"
+msgstr "Denboraldiaren irudia"
+
+#: id:20373
+msgid "Season"
+msgstr "Denboraldia"
+
+#: id:20374
+msgid "Downloading movie information"
+msgstr "Filmaren informazioa deskargatzen"
+
+#: id:20375
+msgid "Unassign content"
+msgstr "Esleitu gabeko edukia"
+
+#: id:20376
+msgid "Original title"
+msgstr "Titulu originala"
+
+#: id:20377
+msgid "Refresh TV show information"
+msgstr "Freskatu TB saioaren informazioa"
+
+#: id:20378
+msgid "Refresh info for all episodes?"
+msgstr "Freskatu pasarte guztien info?"
+
+#: id:20379
+msgid "Selected folder contains a single TV show"
+msgstr "Aukeratutako karpetak TB saio bakar bat du"
+
+#: id:20380
+msgid "Exclude selected folder from scans"
+msgstr "Baztertu hautatutako karpeta bilaketetan"
+
+#: id:20381
+msgid "Specials"
+msgstr "Bereziak"
+
+#: id:20382
+msgid "Automatically grab season thumbs"
+msgstr "Automatikoki Kapturatu denboraldiaren iruditxoa"
+
+#: id:20383
+msgid "Selected folder contains a single video"
+msgstr "Aukeratutako karpetak bideo bakar bat du"
+
+#: id:20384
+msgid "Link to TV show"
+msgstr "Lotura TB saiora"
+
+#: id:20385
+msgid "Remove link to TV show"
+msgstr "Kendu lotura TB saioari"
+
+#: id:20386
+msgid "Recently added movies"
+msgstr "Orain dela gutxi gehitutako filmak"
+
+#: id:20387
+msgid "Recently added episodes"
+msgstr "Orain dela gutxi gehitutako pasarteak"
+
+#: id:20388
+msgid "Studios"
+msgstr "Estudioak"
+
+#: id:20389
+msgid "Music videos"
+msgstr "Musika bideoak"
+
+#: id:20390
+msgid "Recently added music videos"
+msgstr "Orain dela gutxi gehitutako musika bideoak"
+
+#: id:20391
+msgid "Music video"
+msgstr "Musika bideoa"
+
+#: id:20392
+msgid "Remove music video from library"
+msgstr "Kendu musika bideoa liburutegitik"
+
+#: id:20393
+msgctxt "Auto context with id 20393"
+msgid "Music video information"
+msgstr "Musika bideoaren informazioa"
+
+#: id:20394
+msgid "Loading music video information"
+msgstr "Kargatzen musika bideoaren informazioa"
+
+#: id:20395
+msgid "Mixed"
+msgstr "Nahastua"
+
+#: id:20396
+msgid "Go to albums by artist"
+msgstr "Joan albumetara artisten arabera"
+
+#: id:20397
+msgid "Go to album"
+msgstr "Joan albumera"
+
+#: id:20398
+msgid "Play song"
+msgstr "Abestia Errepro"
+
+#: id:20399
+msgid "Go to music videos from album"
+msgstr "Joan musika bideotara albumetik"
+
+#: id:20400
+msgid "Go to music videos by artist"
+msgstr "Joan musika bideoetara artsiten arabera"
+
+#: id:20401
+msgid "Play music video"
+msgstr "Errepro musika bideoa"
+
+#: id:20402
+msgid "Download actor thumbnails when adding to library"
+msgstr "Deskargatu aktorearen iruditxoa liburutegira gehitzean"
+
+#: id:20403
+msgid "Set actor thumb"
+msgstr "Ezarri aktorearen iruditxoa"
+
+#: id:20405
+msgid "Remove episode bookmark"
+msgstr "Kendu pasarteko lastermarkak"
+
+#: id:20406
+msgid "Set episode bookmark"
+msgstr "Ezarri pasarteko lastermarkak"
+
+#: id:20407
+msgid "Scraper settings"
+msgstr "Scraper-en ezarpenak"
+
+#: id:20408
+msgid "Downloading music video information"
+msgstr "Deskargatzen musika bideoaren info"
+
+#: id:20409
+msgid "Downloading TV show information"
+msgstr "Deskargatzen TB saioaren info"
+
+#: id:20410
+msgid "Trailer"
+msgstr "Trailerra"
+
+#: id:20411
+msgid "Flatten"
+msgstr "Berdindu"
+
+#: id:20412
+msgid "Flatten TV shows"
+msgstr "Berdindu TB saioak"
+
+#: id:20413
+msgid "Get fanart"
+msgstr "Lortu Fanart-a"
+
+#: id:20414
+msgid "Show Fanart in video and music libraries"
+msgstr "Erakutsi Fanart-a bideo eta musika liburutegian"
+
+#: id:20415
+msgid "Scanning for new content"
+msgstr "Eskaneatzen eduki berriarentzat"
+
+#: id:20416
+msgid "First aired"
+msgstr "Lehengo emisioa"
+
+#: id:20417
+msgid "Writer"
+msgstr "Idazlea"
+
+#: id:20419
+msgid "Replace file names with library titles"
+msgstr ""
+
+#: id:20420
+msgctxt "Auto context with id 20420"
+msgid "Never"
+msgstr "Inoiz ez"
+
+#: id:20421
+msgid "If only one season"
+msgstr "Denboradi baten bakarrik"
+
+#: id:20422
+msgid "Always"
+msgstr "Beti"
+
+#: id:20423
+msgid "Has trailer"
+msgstr "Trailerra du"
+
+#: id:20424
+msgid "False"
+msgstr "Gezurra"
+
+#: id:20425
+msgid "Fanart slideshow"
+msgstr "Fanart aurkezpena"
+
+#: id:20426
+msgid "Export to a single file or separate"
+msgstr "Esportatu fitxategi bakar batera edo aparteko"
+
+#: id:20427
+msgid "files per entry?"
+msgstr "fitxategira bakoitzeko?"
+
+#: id:20428
+msgid "Single file"
+msgstr "Fitxategi bakarra"
+
+#: id:20429
+msgctxt "Auto context with id 20429"
+msgid "Separate"
+msgstr "Apartekoa"
+
+#: id:20430
+msgid "Export thumbnails and fanart?"
+msgstr "Esportatu iruditxoak eta fanart-a?"
+
+#: id:20431
+msgid "Overwrite old files?"
+msgstr "Berridatzi fitxategi zaharrak?"
+
+#: id:20432
+msgid "Exclude path from library updates"
+msgstr "Baztertu bidea liburutegiaren eguneraketetan"
+
+#: id:20433
+msgid "Extract thumbnails and video information"
+msgstr "Erauzi iruditxoak eta bideoaren informazioa"
+
+#: id:20434
+msgid "Sets"
+msgstr "Multzoa"
+
+#: id:20435
+msgid "Set movieset thumb"
+msgstr "Ezarri film multzoaren iruditxoa"
+
+#: id:20436
+msgid "Export actor thumbs?"
+msgstr "Esportaut aktorearen iruditxoak?"
+
+#: id:20437
+msgid "Choose fanart"
+msgstr "Aukeratu fanart-a"
+
+#: id:20438
+msgid "Local fanart"
+msgstr "Fanart lokala"
+
+#: id:20439
+msgid "No fanart"
+msgstr "Fanart-ik ez"
+
+#: id:20440
+msgid "Current fanart"
+msgstr "Oraingo fanart-a"
+
+#: id:20441
+msgid "Remote fanart"
+msgstr "Urruneko fanart"
+
+#: id:20442
+msgid "Change content"
+msgstr "Edukia aldatu"
+
+#: id:20443
+msgid "Do you want to refresh info for all"
+msgstr "Eguneratzea nhi duzu guztientzat"
+
+#: id:20444
+msgid "items within this path?"
+msgstr "elementu bide honekin?"
+
+#: id:20445
+msgid "Fanart"
+msgstr "Fanart-a"
+
+#: id:20446
+msgid "Locally stored information found."
+msgstr "Lokalki bildutako informazioa aurkitu da."
+
+#: id:20447
+msgid "Ignore and refresh from internet?"
+msgstr "Ez ikusi eta internetetik eguneratu?"
+
+#: id:20448
+msgid "Could not download information"
+msgstr "Ezin da informazioa deskargatu"
+
+#: id:20449
+msgid "Unable to connect to remote server"
+msgstr "Ezin izan da urruneko zerbitzarira konektatu"
+
+#: id:20450
+msgid "Would you like to continue scanning?"
+msgstr "Eskaneatzen jarraitu nahi duzu?"
+
+#: id:20451
+msgid "Countries"
+msgstr "Herrialdeak"
+
+#: id:20452
+msgid "episode"
+msgstr "pasartea"
+
+#: id:20453
+msgid "episodes"
+msgstr "pasarteak"
+
+#: id:20454
+msgid "Listener"
+msgstr ""
+
+#: id:20455
+msgid "Listeners"
+msgstr ""
+
+#: id:20456
+msgid "Set movieset fanart"
+msgstr ""
+
+#: id:20457
+msgid "Movie set"
+msgstr ""
+
+#: id:20458
+msgid "Group movies in sets"
+msgstr ""
+
+#: id:21330
+msgid "Show hidden files and directories"
+msgstr "Erakutsi ezkutatutako fitxategiak eta direktorioak"
+
+#: id:21331
+msgid "TuxBox client"
+msgstr "TuxBox bezeroa"
+
+#: id:21332
+msgid "WARNING: Target TuxBox device is in recording-mode!"
+msgstr "KONTUZ: TuxBox gailu hartzailea grabazio moduan dago!"
+
+#: id:21333
+msgid "The stream will be stopped!"
+msgstr "Stream-a gelditu egingo da!"
+
+#: id:21334
+msgid "Zap to channel: %s failed!"
+msgstr "Katez aldatzea: %s huts egin du!"
+
+#: id:21335
+msgid "Are you sure to start the stream?"
+msgstr "Stream-a hastea nahi duzu?"
+
+#: id:21336
+msgid "Connecting to: %s"
+msgstr "Konektatzen: %s"
+
+#: id:21337
+msgid "TuxBox device"
+msgstr "TuxBox gailua"
+
+#: id:21359
+msgid "Add media share..."
+msgstr "Gehitu media partekatzea..."
+
+#: id:21360
+msgid "Share video and music libraries through UPnP"
+msgstr "Partekatu bideo eta musika liburutegiak UPnP bidez"
+
+#: id:21364
+msgid "Edit media share"
+msgstr "Aldatu media partekatzea"
+
+#: id:21365
+msgid "Remove media share"
+msgstr "Kendu media partekatzea"
+
+#: id:21366
+msgid "Subtitle folder"
+msgstr "Azpitituluen karpeta"
+
+#: id:21367
+msgid "Movie & alternate subtitle directory"
+msgstr "Filmak eta txandakatu azpitituluen direktorioa"
+
+#: id:21368
+msgid "Override ASS/SSA subtitles fonts"
+msgstr ""
+
+#: id:21369
+msgid "Enable mouse and Touch Screen support"
+msgstr "Gaitu xagua"
+
+#: id:21370
+msgid "Play navigation sounds during media playback"
+msgstr "Erreproduzitu nabigazio soinuak multimedia erreproduzitzean"
+
+#: id:21371
+msgid "Thumbnail"
+msgstr "Iruditxoa"
+
+#: id:21372
+msgid "Forced DVD player region"
+msgstr "Derrigortu DVD erreproduktorearen eskualdea"
+
+#: id:21373
+msgid "Video output"
+msgstr "Bideo irteera"
+
+#: id:21374
+msgid "Video aspect"
+msgstr "Bideo aspektua"
+
+#: id:21375
+msgctxt "Auto context with id 21375"
+msgid "Normal"
+msgstr "Arrunta"
+
+#: id:21376
+msgid "Letterbox"
+msgstr "Letterbox"
+
+#: id:21377
+msgid "Widescreen"
+msgstr "Pantaila zabala"
+
+#: id:21378
+msgid "Enable 480p"
+msgstr "Gaitu 480p"
+
+#: id:21379
+msgid "Enable 720p"
+msgstr "Gaitu 720p"
+
+#: id:21380
+msgid "Enable 1080i"
+msgstr "Gaitu 1080i"
+
+#: id:21381
+msgid "Enter name of new playlist"
+msgstr "Sartu zerrenda berriaren izena"
+
+#: id:21382
+msgid "Show \"Add source\" buttons in file lists"
+msgstr "Erakutsi \"Gehitu iturria\" botoia fitxategi zerrendan"
+
+#: id:21383
+msgid "Enable scrollbars"
+msgstr "Gaitu korritze-barrak"
+
+#: id:21384
+msgid "Make watched filtering a toggle in video library"
+msgstr "Egin ikusitako iragazketa bideo liburutegian"
+
+#: id:21385
+msgctxt "Auto context with id 21385"
+msgid "Open"
+msgstr "Ireki"
+
+#: id:21386
+msgid "Acoustic management level"
+msgstr "Maila akustikoaren kudeatzailea"
+
+#: id:21387
+msgid "Fast"
+msgstr "Azkarra"
+
+#: id:21388
+msgid "Quiet"
+msgstr "Ixila"
+
+#: id:21389
+msgid "Enable custom background"
+msgstr "Gaitu atzeko irudi pertsonalizatua"
+
+#: id:21390
+msgid "Power management level"
+msgstr "Potentzia kudeaketa maila"
+
+#: id:21391
+msgid "High power"
+msgstr "Potentzia handia"
+
+#: id:21392
+msgid "Low power"
+msgstr "Potentzia txikia"
+
+#: id:21393
+msgid "High standby"
+msgstr "Standby handia"
+
+#: id:21394
+msgid "Low standby"
+msgstr "Standby baxua"
+
+#: id:21395
+msgid "Unable to cache files bigger than 4GB"
+msgstr "Ezgaituta 4GB baino fitxategi handiagoak katxeatzea"
+
+#: id:21396
+msgid "Chapter"
+msgstr "Pasartea"
+
+#: id:21397
+msgid "High quality pixel shader v2"
+msgstr "Kalitate handiko pixel shader-a v2"
+
+#: id:21398
+msgid "Enable playlist at startup"
+msgstr "Gaitu zerrenda hastean"
+
+#: id:21399
+msgid "Use tween animations"
+msgstr "Erabili tween animazioak"
+
+#: id:21400
+msgid "contains"
+msgstr "du"
+
+#: id:21401
+msgid "does not contain"
+msgstr "ez du"
+
+#: id:21402
+msgid "is"
+msgstr "da"
+
+#: id:21403
+msgid "is not"
+msgstr "ez da"
+
+#: id:21404
+msgid "starts with"
+msgstr "hasten da"
+
+#: id:21405
+msgid "ends with"
+msgstr "bukatzen da"
+
+#: id:21406
+msgid "greater than"
+msgstr "gehiago"
+
+#: id:21407
+msgid "less than"
+msgstr "gutxiago"
+
+#: id:21408
+msgid "after"
+msgstr "ondoren"
+
+#: id:21409
+msgid "before"
+msgstr "aurretik"
+
+#: id:21410
+msgid "in the last"
+msgstr "azkenengoan"
+
+#: id:21411
+msgid "not in the last"
+msgstr "ez azkenengoan"
+
+#: id:21412
+msgid "Scrapers"
+msgstr "Scraper-ak"
+
+#: id:21413
+msgid "Default movie scraper"
+msgstr "Lehenetsitako film scraper-a"
+
+#: id:21414
+msgid "Default tvshow scraper"
+msgstr "Lehenetsitako tb saio scraper-a"
+
+#: id:21415
+msgid "Default music video scraper"
+msgstr "Lehenetsitako musika bideo scraper-a"
+
+#: id:21416
+msgid "Enable fallback based on scraper language"
+msgstr "Gaitu fallback-a scraper hizkuntzan basatuta"
+
+#: id:21417
+msgid "- Settings"
+msgstr "- Ezarpenak"
+
+#: id:21418
+msgid "Multilingual"
+msgstr "Hizkuntza anitz"
+
+#: id:21419
+msgid "No scrapers present"
+msgstr "Ez dago scraper-ik"
+
+#: id:21420
+msgid "Value to match"
+msgstr "Balioa bat etortzeko"
+
+#: id:21421
+msgid "Smart playlist rule"
+msgstr "Adimendun zerrendaren araua"
+
+#: id:21422
+msgid "Match items where"
+msgstr "Elementuak bat egin"
+
+#: id:21423
+msgid "New rule..."
+msgstr "Arau berria..."
+
+#: id:21424
+msgid "Items must match"
+msgstr "Elementuak bat egin behar dute"
+
+#: id:21425
+msgid "all of the rules"
+msgstr "arau guztiak"
+
+#: id:21426
+msgid "one or more of the rules"
+msgstr "arau bat edo gehiago"
+
+#: id:21427
+msgid "Limit to"
+msgstr "Mugatu"
+
+#: id:21428
+msgid "No limit"
+msgstr "Mugarik ez"
+
+#: id:21429
+msgid "Order by"
+msgstr "Ordenatu"
+
+#: id:21430
+msgid "ascending"
+msgstr "gorakorra"
+
+#: id:21431
+msgid "descending"
+msgstr "beherakorra"
+
+#: id:21432
+msgid "Edit smart playlist"
+msgstr "Aldatu adimendutako zerrenda"
+
+#: id:21433
+msgid "Name of the playlist"
+msgstr "Zerrendaren izena"
+
+#: id:21434
+msgid "Find items where"
+msgstr "Bilatu itemak hemen"
+
+#: id:21435
+msgid "Edit"
+msgstr "Aldatu"
+
+#: id:21436
+msgid "%i items"
+msgstr "%i item"
+
+#: id:21437
+msgid "New smart playlist..."
+msgstr "Adimendun zerrenda berria..."
+
+#: id:21438
+msgid "%c Drive"
+msgstr "%c Unitatea"
+
+#: id:21439
+msgid "Edit party mode rules"
+msgstr "Aldati festa moduko arauak"
+
+#: id:21440
+msgid "Home folder"
+msgstr "Etxeko karpeta"
+
+#: id:21441
+msgid "Watched count"
+msgstr "Ikusitako aldiak"
+
+#: id:21442
+msgid "Episode title"
+msgstr "Pasartearen titulua"
+
+#: id:21443
+msgid "Video resolution"
+msgstr "Bideoaren erresoluzioa"
+
+#: id:21444
+msgid "Audio channels"
+msgstr "Audio kanalak"
+
+#: id:21445
+msgid "Video codec"
+msgstr "Bideo codec-a"
+
+#: id:21446
+msgid "Audio codec"
+msgstr "Audio codec-a"
+
+#: id:21447
+msgid "Audio language"
+msgstr "Audioaren hizkuntza"
+
+#: id:21448
+msgid "Subtitle language"
+msgstr "Azpitituluen hizkuntza"
+
+#: id:21449
+msgid "Remote control sends keyboard presses"
+msgstr "Urruneko kontrilak teklatu presioak bidaltzen ditu"
+
+#: id:21450
+msgid "- Edit"
+msgstr "- Aldatu"
+
+#: id:21451
+msgid "Internet connection required."
+msgstr "Internetera konektauta egon behar da."
+
+#: id:21452
+msgid "Get More..."
+msgstr "Lortu gehiago..."
+
+#: id:21453
+msgid "Root filesystem"
+msgstr "Erroko fitxategi-sistema"
+
+#: id:21454
+msgid "Cache full"
+msgstr ""
+
+#: id:21455
+msgid "Cache filled before reaching required amount for continous playback"
+msgstr ""
+
+#: id:21460
+msgid "Subtitle location"
+msgstr ""
+
+#: id:21461
+msgid "Fixed"
+msgstr ""
+
+#: id:21462
+msgid "Bottom of video"
+msgstr ""
+
+#: id:21463
+msgid "Below video"
+msgstr ""
+
+#: id:21464
+msgid "Top of video"
+msgstr ""
+
+#: id:21465
+msgid "Above video"
+msgstr ""
+
+#: id:21800
+msgid "File name"
+msgstr "Fitxategiaren izena"
+
+#: id:21801
+msgid "File path"
+msgstr "Fitxategiaren bidea"
+
+#: id:21802
+msgid "File size"
+msgstr "Fitxategi tamaina"
+
+#: id:21803
+msgid "File date/time"
+msgstr "Fitxategi data/ordua"
+
+#: id:21804
+msgid "Slide index"
+msgstr "Diapositibaren indizea"
+
+#: id:21805
+msgctxt "Auto context with id 21805"
+msgid "Resolution"
+msgstr "Erresoluzioa"
+
+#: id:21806
+msgctxt "Auto context with id 21806"
+msgid "Comment"
+msgstr "Oharra"
+
+#: id:21807
+msgid "Colour/B&W"
+msgstr "Kolorea/Z&B"
+
+#: id:21808
+msgid "JPEG process"
+msgstr "JPEG prozesua"
+
+#: id:21820
+msgid "Date/Time"
+msgstr "Data/Ordua"
+
+#: id:21821
+msgid "Description"
+msgstr "Deskribapena"
+
+#: id:21822
+msgid "Camera make"
+msgstr "Kamera egin"
+
+#: id:21823
+msgid "Camera model"
+msgstr "Kamera modeloa"
+
+#: id:21824
+msgid "EXIF comment"
+msgstr "EXIF oharra"
+
+#: id:21825
+msgid "Firmware"
+msgstr "Firmware-a"
+
+#: id:21826
+msgid "Aperture"
+msgstr "Irekiera"
+
+#: id:21827
+msgid "Focal length"
+msgstr "Luzeera fokala"
+
+#: id:21828
+msgid "Focus distance"
+msgstr "Foku distantzia"
+
+#: id:21829
+msgid "Exposure"
+msgstr "Esposizio"
+
+#: id:21830
+msgid "Exposure time"
+msgstr "Esposizio denbora"
+
+#: id:21831
+msgid "Exposure bias"
+msgstr "Esposizio bias-a"
+
+#: id:21832
+msgid "Exposure mode"
+msgstr "Esposizio modua"
+
+#: id:21833
+msgid "Flash used"
+msgstr "Erabilitako flash-a"
+
+#: id:21834
+msgid "White-balance"
+msgstr "Zuri balantzea"
+
+#: id:21835
+msgid "Light source"
+msgstr "Argi iturria"
+
+#: id:21836
+msgid "Metering mode"
+msgstr "Neurketa modua"
+
+#: id:21837
+msgid "ISO"
+msgstr "ISO"
+
+#: id:21838
+msgid "Digital zoom"
+msgstr "Zoom digitala"
+
+#: id:21839
+msgid "CCD width"
+msgstr "CCD zabalera"
+
+#: id:21840
+msgid "GPS latitude"
+msgstr "GPS latitudea"
+
+#: id:21841
+msgid "GPS longitude"
+msgstr "GPS ongitudea"
+
+#: id:21842
+msgid "GPS altitude"
+msgstr "GPS altuera"
+
+#: id:21843
+msgid "Orientation"
+msgstr "Orientazioa"
+
+#: id:21860
+msgid "Supplemental categories"
+msgstr "Kategoria gehigarriak"
+
+#: id:21861
+msgid "Keywords"
+msgstr "Hitz gakoak"
+
+#: id:21862
+msgid "Caption"
+msgstr "Oharra"
+
+#: id:21863
+msgid "Author"
+msgstr "Autorea"
+
+#: id:21864
+msgid "Headline"
+msgstr "Titulua"
+
+#: id:21865
+msgid "Special instructions"
+msgstr "Instrukzio bereziak"
+
+#: id:21866
+msgid "Category"
+msgstr "Kategoria"
+
+#: id:21867
+msgid "Byline"
+msgstr "Byline-a"
+
+#: id:21868
+msgid "Byline title"
+msgstr "Byline titulua"
+
+#: id:21869
+msgid "Credit"
+msgstr "Kreditua"
+
+#: id:21870
+msgid "Source"
+msgstr "Iturria"
+
+#: id:21871
+msgid "Copyright notice"
+msgstr "Copyright oharra"
+
+#: id:21872
+msgid "Object name"
+msgstr "Objektuaren izena"
+
+#: id:21873
+msgid "City"
+msgstr "Herria"
+
+#: id:21874
+msgid "State"
+msgstr "Estatua"
+
+#: id:21875
+msgctxt "Auto context with id 21875"
+msgid "Country"
+msgstr "Herrialdea"
+
+#: id:21876
+msgid "Original Tx Reference"
+msgstr "Tx erreferentzia originala"
+
+#: id:21877
+msgid "Date created"
+msgstr "Sortutako dat"
+
+#: id:21878
+msgid "Copyright flag"
+msgstr "Copyright bandera"
+
+#: id:21879
+msgid "Country code"
+msgstr "Herrialdeko kodea"
+
+#: id:21880
+msgid "Reference service"
+msgstr "Erreferentzia-zerbitzua"
+
+#: id:21881
+msgid "Allow control of XBMC via UPnP"
+msgstr "Gaitu XBMC kontrola UPnP bidez"
+
+#: id:21882
+msgid "Attempt to skip introduction before DVD menu"
+msgstr "Saiatu DVDaren menuaren aurreko sarrera saltatzen"
+
+#: id:21883
+msgid "Saved music"
+msgstr "Gorde musika"
+
+#: id:21884
+msgid "Query info for all artists"
+msgstr "Kontsultatu info artista guztientzat"
+
+#: id:21885
+msgid "Downloading album information"
+msgstr "Albumaren informazioa deskargatzen"
+
+#: id:21886
+msgid "Downloading artist information"
+msgstr "Artistaren informazioa deskargatzen"
+
+#: id:21887
+msgid "Biography"
+msgstr "Biografia"
+
+#: id:21888
+msgid "Discography"
+msgstr "Diskografia"
+
+#: id:21889
+msgid "Searching artist"
+msgstr "Artista bilatzen"
+
+#: id:21890
+msgid "Select artist"
+msgstr "Aukeratu artista"
+
+#: id:21891
+msgctxt "Auto context with id 21891"
+msgid "Artist information"
+msgstr "Artistaren informazioa"
+
+#: id:21892
+msgid "Instruments"
+msgstr "Instrumentuak"
+
+#: id:21893
+msgid "Born"
+msgstr "Sortuta"
+
+#: id:21894
+msgid "Formed"
+msgstr "Formatuta"
+
+#: id:21895
+msgid "Themes"
+msgstr "Temak"
+
+#: id:21896
+msgid "Disbanded"
+msgstr "Deseginda"
+
+#: id:21897
+msgid "Died"
+msgstr "Hilda"
+
+#: id:21898
+msgid "Years active"
+msgstr "Urteak gaituta"
+
+#: id:21899
+msgid "Label"
+msgstr "Etiketa"
+
+#: id:21900
+msgid "Born/Formed"
+msgstr "Sorta/Osatua"
+
+#: id:22000
+msgid "Update library on startup"
+msgstr "Eguneratu liburutegia hasieran"
+
+#: id:22001
+msgid "Hide progress of library updates"
+msgstr "Ezkutatu liburutegiaren eguneraketaren bilakaera"
+
+#: id:22002
+msgid "- DNS suffix"
+msgstr "- DNS atzizkia"
+
+#: id:22003
+msgid "%2.3fs"
+msgstr "%2.3fs"
+
+#: id:22004
+msgid "Delayed by: %2.3fs"
+msgstr "Atzeratua: %2.3fs"
+
+#: id:22005
+msgid "Ahead by: %2.3fs"
+msgstr "Aurretik: %2.3fs"
+
+#: id:22006
+msgid "Subtitle offset"
+msgstr "Azpitituluen atzerapena"
+
+#: id:22007
+msgid "OpenGL vendor:"
+msgstr "OpenGL saltzailea:"
+
+#: id:22008
+msgid "OpenGL renderer:"
+msgstr "OpenGL renderer:"
+
+#: id:22009
+msgid "OpenGL version:"
+msgstr "OpenGL bertsioa:"
+
+#: id:22010
+msgid "GPU temperature:"
+msgstr "GPUaren tenperatura:"
+
+#: id:22011
+msgid "CPU temperature:"
+msgstr "CPUaren tenperatura:"
+
+#: id:22012
+msgid "Total memory"
+msgstr "Memoria guztia"
+
+#: id:22013
+msgid "Profile data"
+msgstr "Profilaren data"
+
+#: id:22014
+msgid "Use dim if paused during video playback"
+msgstr "Erabili dim bideoa pausatzean erreproduzitzean"
+
+#: id:22015
+msgid "All recordings"
+msgstr "Grabazio guztiak"
+
+#: id:22016
+msgid "By title"
+msgstr "Tituluaren arabera"
+
+#: id:22017
+msgid "By group"
+msgstr "Taldearen arabera"
+
+#: id:22018
+msgid "Live channels"
+msgstr "Zuzeneko kateak"
+
+#: id:22019
+msgid "Recordings by title"
+msgstr "Grabazioak tituluaren arabera"
+
+#: id:22020
+msgid "Guide"
+msgstr "Gida"
+
+#: id:22021
+msgid "Allowed error in aspect ratio to minimize black bars"
+msgstr "Onartutako aspektu erlazioaren errorea barra beltzetarako"
+
+#: id:22022
+msgid "Show video files in listings"
+msgstr "Erakutsi bideo fitxategiak zerrendetan"
+
+#: id:22023
+msgid "DirectX vendor:"
+msgstr "DirectX saltzailea:"
+
+#: id:22024
+msgid "Direct3D version:"
+msgstr "Direct3D bertsioa:"
+
+#: id:22030
+msgctxt "Auto context with id 22030"
+msgid "Font"
+msgstr "Letra"
+
+#: id:22031
+msgctxt "Auto context with id 22031"
+msgid "- Size"
+msgstr "- Tamaina"
+
+#: id:22032
+msgctxt "Auto context with id 22032"
+msgid "- Colours"
+msgstr "- Koloreak"
+
+#: id:22033
+msgid "- Charset"
+msgstr "- Charset-a"
+
+#: id:22034
+msgid "Export karaoke titles as HTML"
+msgstr "Esportatu karaokea HTML gisa"
+
+#: id:22035
+msgid "Export karaoke titles as CSV"
+msgstr "Esportatu karaokea CSV gisa"
+
+#: id:22036
+msgid "Import karaoke titles..."
+msgstr "Inportatu karaoke tituluak..."
+
+#: id:22037
+msgid "Show song selector automatically"
+msgstr "Erakutsi abesti hautatzailea automatikoki"
+
+#: id:22038
+msgid "Export karaoke titles..."
+msgstr "Esportatu karaoke tituluak..."
+
+#: id:22039
+msgid "Enter song number"
+msgstr "Sartu abestiaren zenbakia"
+
+#: id:22040
+msgid "white/green"
+msgstr "zuria/berdea"
+
+#: id:22041
+msgid "white/red"
+msgstr "zuria/gorria"
+
+#: id:22042
+msgid "white/blue"
+msgstr "zuria/urdina"
+
+#: id:22043
+msgid "black/white"
+msgstr "beltza/zuria"
+
+#: id:22079
+msgid "Default select action"
+msgstr "Lehenetsitako akzioa"
+
+#: id:22080
+msgid "Choose"
+msgstr "Aukeratu"
+
+#: id:22081
+msgid "Show Information"
+msgstr "Erakutsi informazioa"
+
+#: id:22082
+msgid "More..."
+msgstr "Gehiago..."
+
+#: id:22083
+msgid "Play all"
+msgstr "Dena errepr"
+
+#: id:23049
+msgid "Teletext not available"
+msgstr "Teletestua ez dago eskuragarri"
+
+#: id:23050
+msgid "Activate Teletext"
+msgstr "Gaitu Teletestua"
+
+#: id:23051
+msgid "Part %i"
+msgstr "%i zatia"
+
+#: id:23052
+msgid "Buffering %i bytes"
+msgstr "%i byte bufereratzen"
+
+#: id:23053
+msgid "Stopping"
+msgstr "Gelditzen"
+
+#: id:23054
+msgid "Running"
+msgstr "Exekutatzen"
+
+#: id:23100
+msgid "External Player Active"
+msgstr "Kanpoko erreproduktorea gaituta"
+
+#: id:23101
+msgid "Click OK to terminate the player"
+msgstr "Klikatu Ados errproduktorea kentzeko"
+
+#: id:23104
+msgid "Click OK when playback has ended"
+msgstr "Klikatu Ados erreproduzioa amaitzean"
+
+#: id:24000
+msgid "Add-on"
+msgstr "Gehigarria"
+
+#: id:24001
+msgid "Add-ons"
+msgstr "Gehigarriak"
+
+#: id:24002
+msgid "Add-on options"
+msgstr "Gehiarrien aukerak"
+
+#: id:24003
+msgid "Add-on Information"
+msgstr "Gehigarrien informazioa"
+
+#: id:24005
+msgctxt "Auto context with id 24005"
+msgid "Media sources"
+msgstr "Media iturriak"
+
+#: id:24007
+msgctxt "Auto context with id 24007"
+msgid "Movie information"
+msgstr "Filmaren informazioa"
+
+#: id:24008
+msgctxt "Auto context with id 24008"
+msgid "Screensaver"
+msgstr "Pantaila babeslea"
+
+#: id:24009
+msgid "Script"
+msgstr "Script"
+
+#: id:24010
+msgctxt "Auto context with id 24010"
+msgid "Visualization"
+msgstr "Bisualizazioa"
+
+#: id:24011
+msgid "Add-on repository"
+msgstr "Gehigarrien errepositoria"
+
+#: id:24012
+msgctxt "Auto context with id 24012"
+msgid "Subtitles"
+msgstr "Azpitituluak"
+
+#: id:24013
+msgid "Lyrics"
+msgstr "Letrak"
+
+#: id:24014
+msgid "TV information"
+msgstr "TBren informazioa"
+
+#: id:24015
+msgctxt "Auto context with id 24015"
+msgid "Music video information"
+msgstr "Musika bideoaren infor"
+
+#: id:24016
+msgctxt "Auto context with id 24016"
+msgid "Album information"
+msgstr "Albumaren info"
+
+#: id:24017
+msgctxt "Auto context with id 24017"
+msgid "Artist information"
+msgstr "Artistaren info"
+
+#: id:24018
+msgctxt "Auto context with id 24018"
+msgid "Services"
+msgstr ""
+
+#: id:24020
+msgid "Configure"
+msgstr "Konfiguratu"
+
+#: id:24021
+msgctxt "Auto context with id 24021"
+msgid "Disable"
+msgstr "Ezgaitu"
+
+#: id:24022
+msgid "Enable"
+msgstr "Gaitu"
+
+#: id:24023
+msgid "Add-on disabled"
+msgstr "Gehigarria ezgaituta"
+
+#: id:24027
+msgctxt "Auto context with id 24027"
+msgid "Weather"
+msgstr "Eguraldia"
+
+#: id:24028
+msgid "Weather.com (standard)"
+msgstr "Weather.com (arrunta)"
+
+#: id:24030
+msgid "This Add-on can not be configured"
+msgstr "Gehigarri hau ezin da konfiguratu"
+
+#: id:24031
+msgid "Error loading settings"
+msgstr "Errorea ezarpenak kargatzean"
+
+#: id:24032
+msgid "All Add-ons"
+msgstr "Gehigarri denak"
+
+#: id:24033
+msgid "Get Add-ons"
+msgstr "Lortu gehigarriak"
+
+#: id:24034
+msgid "Check for updates"
+msgstr "Eguneraketak bilatu"
+
+#: id:24035
+msgid "Force refresh"
+msgstr "Behartu freskatzea"
+
+#: id:24036
+msgid "Change log"
+msgstr "Aldaketa log-a"
+
+#: id:24037
+msgid "Uninstall"
+msgstr "Desinstalatu"
+
+#: id:24038
+msgid "Install"
+msgstr "Instalatu"
+
+#: id:24039
+msgid "Disabled Add-ons"
+msgstr "Ezgaitu gehigarriak"
+
+#: id:24040
+msgid "(Clear the current setting)"
+msgstr "(Garbitu uneko ezarpenak)"
+
+#: id:24041
+msgid "Install from zip file"
+msgstr "Instalatu zip fitxategitik"
+
+#: id:24042
+msgid "Downloading %i%%"
+msgstr "Deskargatzen %i%%"
+
+#: id:24043
+msgid "Available Updates"
+msgstr "Eguneraketa eskuragarriak"
+
+#: id:24044
+msgid "Dependencies not met"
+msgstr ""
+
+#: id:24045
+msgid "Add-on does not have the correct structure"
+msgstr ""
+
+#: id:24046
+msgid "%s is used by the following installed add-on(s)"
+msgstr ""
+
+#: id:24047
+msgid "This add-on cannot be uninstalled"
+msgstr ""
+
+#: id:24048
+msgid "Rollback"
+msgstr ""
+
+#: id:24050
+msgid "Available Add-ons"
+msgstr "Gehigarri eskuragarriak"
+
+#: id:24051
+msgid "Version:"
+msgstr "Bertsioa:"
+
+#: id:24052
+msgid "Disclaimer"
+msgstr "Legezko oharra"
+
+#: id:24053
+msgid "License:"
+msgstr "Lizentzia:"
+
+#: id:24054
+msgid "Changelog"
+msgstr "Aldaketa log-a"
+
+#: id:24059
+msgid "Would you like to enable this Add-on?"
+msgstr "Gehigarri hau gaitu nahi duzu?"
+
+#: id:24060
+msgid "Would you like to disable this Add-on?"
+msgstr "Gehigarri hau ezgaitu nahi duzu?"
+
+#: id:24061
+msgid "Add-on update available!"
+msgstr "Gehigarriaren eguneraketa eskuragarri!"
+
+#: id:24062
+msgid "Enabled Add-ons"
+msgstr "Gaitu gehigarriak"
+
+#: id:24063
+msgid "Auto update"
+msgstr "Auto eguneraketa"
+
+#: id:24064
+msgid "Add-on enabled"
+msgstr "Gehigarria gaituta"
+
+#: id:24065
+msgid "Add-on updated"
+msgstr "Gehigarria eguneratuta"
+
+#: id:24066
+msgid "Cancel Add-on download?"
+msgstr "Uttzi gehigarrien deskarga?"
+
+#: id:24067
+msgid "Currently downloading Add-ons"
+msgstr "Orain gehigarriak deskargatzen"
+
+#: id:24068
+msgid "Update available"
+msgstr "Eguneraketa eskuragarri"
+
+#: id:24069
+msgid "Update"
+msgstr "Eguneratu"
+
+#: id:24070
+msgid "Add-on could not be loaded."
+msgstr "Gehigarria ezin izan da kargatu"
+
+#: id:24071
+msgid "An unknown error has occurred."
+msgstr "Akats ezezagun bat gertatu da."
+
+#: id:24072
+msgid "Settings required"
+msgstr "Beharrezko ezarpenak"
+
+#: id:24073
+msgid "Could not connect"
+msgstr "Ezin izan da konektatu"
+
+#: id:24074
+msgid "Needs to restart"
+msgstr "Berrabiarazi behar da"
+
+#: id:24075
+msgctxt "Auto context with id 24075"
+msgid "Disable"
+msgstr "Ezgaitu"
+
+#: id:24076
+msgid "Add-on Required"
+msgstr ""
+
+#: id:24080
+msgid "Try to reconnect?"
+msgstr "Berriz konektatzen saiatu?"
+
+#: id:24089
+msgid "Add-on restarts"
+msgstr "Gehigarriak berrabiaraztean"
+
+#: id:24090
+msgid "Lock Add-on manager"
+msgstr "Blokeatu gehigarri kudeatzailea"
+
+#: id:24094
+msgid "(current)"
+msgstr ""
+
+#: id:24095
+msgid "(blacklisted)"
+msgstr ""
+
+#: id:24096
+msgid "Add-on has been marked as broken in repository."
+msgstr "Gehigarria apurtuta bezala markatu da errepositorioan."
+
+#: id:24097
+msgid "Would you like to disable it on your system?"
+msgstr "Gustatuko litzaizuke zure sisteman desgaitzea?"
+
+#: id:24098
+msgid "Broken"
+msgstr "Apurtuta"
+
+#: id:24099
+msgid "Would you like to switch to this skin?"
+msgstr "Gustatuko litzaizuke skin honetara aldatzea?"
+
+#: id:24100
+msgid "To use this feature you must download an Add-on:"
+msgstr ""
+
+#: id:24101
+msgid "Would you like to download this Add-on?"
+msgstr ""
+
+#: id:25000
+msgid "Notifications"
+msgstr "Jakinarazpenak"
+
+#: id:29800
+msgid "Library Mode"
+msgstr "Liburutegi Modua"
+
+#: id:29801
+msgid "QWERTY keyboard"
+msgstr "QWERTY teklatua"
+
+#: id:29802
+msgid "Passthrough Audio in use"
+msgstr "Passthrough Audioa erabiltzen"
+
+#: id:33001
+msgid "Trailer quality"
+msgstr "Trailerraren kalitatea"
+
+#: id:33002
+msgid "Stream"
+msgstr "Stream"
+
+#: id:33003
+msgid "Download"
+msgstr "Deskargatu"
+
+#: id:33004
+msgid "Download & play"
+msgstr "Deskargatu eta erreproduzitu"
+
+#: id:33005
+msgid "Download & save"
+msgstr "Deskargatu eta gorde"
+
+#: id:33006
+msgid "Today"
+msgstr "Gaur"
+
+#: id:33007
+msgid "Tomorrow"
+msgstr "Bihar"
+
+#: id:33008
+msgid "Saving"
+msgstr "Gordetzen"
+
+#: id:33009
+msgid "Copying"
+msgstr "Kopiatzen"
+
+#: id:33010
+msgid "Set download directory"
+msgstr "Ezarri deskargen direktorioa"
+
+#: id:33011
+msgid "Search duration"
+msgstr "Bilatu iraupena"
+
+#: id:33012
+msgid "Short"
+msgstr "Motza"
+
+#: id:33013
+msgid "Long"
+msgstr "Luzea"
+
+#: id:33014
+msgid "Use DVD player instead of regular player"
+msgstr "Erabili DVD erreproduzitzailea ohiko erreproduzitzailearen ordez"
+
+#: id:33015
+msgid "Ask for download before playing video"
+msgstr "Galdetu deskargatzeko bideoa erreproduzitu aurretik"
+
+#: id:33016
+msgid "Clips"
+msgstr "Klipak"
+
+#: id:33017
+msgid "Restart plugin to enable"
+msgstr "Berrabiarazi plugin-a gaitzeko"
+
+#: id:33018
+msgid "Tonight"
+msgstr "Gaur gauean"
+
+#: id:33019
+msgid "Tomorrow Night"
+msgstr "Bihar Gauean"
+
+#: id:33020
+msgid "Condition"
+msgstr "Baldintzak"
+
+#: id:33021
+msgid "Precipitation"
+msgstr "Prezipitazioak"
+
+#: id:33022
+msgid "Precip"
+msgstr "Prezi"
+
+#: id:33023
+msgid "Humid"
+msgstr "Hezea"
+
+#: id:33024
+msgid "Feels"
+msgstr "Sentitzen"
+
+#: id:33025
+msgid "Observed"
+msgstr "Behatuta"
+
+#: id:33026
+msgid "Departure from normal"
+msgstr "Ohiko irteera"
+
+#: id:33027
+msgid "Sunrise"
+msgstr "Egunsentia"
+
+#: id:33028
+msgid "Sunset"
+msgstr "Ilunabarra"
+
+#: id:33029
+msgid "Details"
+msgstr "Xehetasunak"
+
+#: id:33030
+msgid "Outlook"
+msgstr "Outlook"
+
+#: id:33031
+msgid "Coverflow"
+msgstr "Coverflow"
+
+#: id:33032
+msgid "Translate text"
+msgstr "Itzuli testua"
+
+#: id:33033
+msgid "Map list %s category"
+msgstr "Mapa zerrenden %s kategoria"
+
+#: id:33034
+msgid "36 Hour"
+msgstr "36 Ordu"
+
+#: id:33035
+msgid "Maps"
+msgstr "Mapak"
+
+#: id:33036
+msgid "Hourly"
+msgstr "Orduro"
+
+#: id:33037
+msgid "Weekend"
+msgstr "Asteburua"
+
+#: id:33038
+msgid "%s day"
+msgstr "%s egun"
+
+#: id:33049
+msgid "Alert"
+msgstr "Alerta"
+
+#: id:33050
+msgid "Alerts"
+msgstr "Alertak"
+
+#: id:33051
+msgid "Choose Your"
+msgstr "Aukeratu Zure"
+
+#: id:33052
+msgid "Check"
+msgstr "Egiaztatu"
+
+#: id:33053
+msgctxt "Auto context with id 33053"
+msgid "Configure the"
+msgstr "Konfiguratu"
+
+#: id:33054
+msgid "Seasons"
+msgstr "Denboraldiak"
+
+#: id:33055
+msgid "Use your"
+msgstr "Erabili zure"
+
+#: id:33056
+msgid "Watch your"
+msgstr "Ikusi"
+
+#: id:33057
+msgid "Listen to"
+msgstr "Entzun"
+
+#: id:33058
+msgid "View your"
+msgstr "Ikusi zure"
+
+#: id:33059
+msgctxt "Auto context with id 33059"
+msgid "Configure the"
+msgstr "Konfiguratu"
+
+#: id:33060
+msgid "Power"
+msgstr "Piztu"
+
+#: id:33061
+msgid "Menu"
+msgstr "Menua"
+
+#: id:33062
+msgid "Play the"
+msgstr "Erreproduzitu"
+
+#: id:33063
+msgid "Options"
+msgstr "Aukera"
+
+#: id:33065
+msgid "Editor"
+msgstr "Editorea"
+
+#: id:33066
+msgid "About your"
+msgstr "Zuri buruz"
+
+#: id:33067
+msgid "Star rating"
+msgstr "Izar balorazioa"
+
+#: id:33068
+msgid "Background"
+msgstr "Atzeko irudia"
+
+#: id:33069
+msgid "Backgrounds"
+msgstr "Atzeko irudiak"
+
+#: id:33070
+msgid "Custom background"
+msgstr "Atzeko irudi pertsonalizatua"
+
+#: id:33071
+msgid "Custom backgrounds"
+msgstr "Atzeko irudi pertsonalizatuak"
+
+#: id:33072
+msgid "View Readme"
+msgstr "Ikusi Readme-a"
+
+#: id:33073
+msgid "View Changelog"
+msgstr "Ikusi Changelog-a"
+
+#: id:33074
+msgid "This version of %s requires an"
+msgstr "%s-ren bertsio honek behar du"
+
+#: id:33075
+msgid "XBMC revision of %s or greater to run."
+msgstr "XBMC-ren %s rebisioa edo handiagoa behar da."
+
+#: id:33076
+msgid "Please update XBMC."
+msgstr "Mesedez eguneratu XBMC."
+
+#: id:33077
+msgid "No data found!"
+msgstr "Ez da datarik aurkitu!"
+
+#: id:33078
+msgid "Next page"
+msgstr "Hurrengo orria"
+
+#: id:33079
+msgid "Love"
+msgstr "Maitatu"
+
+#: id:33080
+msgid "Hate"
+msgstr "Gorrotatu"
+
+#: id:33081
+msgid "This file is stacked, select the part you want to play from."
+msgstr "Fitxategi hau pilatuta dago, hautatu erreproduzitzea nahi duzun zatia."
+
+#: id:33082
+msgid "Path to script"
+msgstr "Script-era bidea"
+
+#: id:33083
+msgid "Enable custom script button"
+msgstr "Gaitu script pertsonalizatuaren botoia"
+
+#: id:33100
+msgid "Failed to start"
+msgstr ""
+
+#: id:33101
+msgid "Webserver"
+msgstr ""
+
+#: id:33102
+msgid "Event Server"
+msgstr ""
+
+#: id:33103
+msgid "Remote communication server"
+msgstr ""
+
+#: id:33200
+msgid "Detected New Connection"
+msgstr ""
+
+#: id:34000
+msgid "Lame"
+msgstr "Lame"
+
+#: id:34001
+msgid "Vorbis"
+msgstr "Vorbis"
+
+#: id:34002
+msgid "Wav"
+msgstr "Wav"
+
+#: id:34003
+msgid "DXVA2"
+msgstr "DXVA2"
+
+#: id:34004
+msgid "VAAPI"
+msgstr "VAAPI"
+
+#: id:34005
+msgid "Flac"
+msgstr "Flac"
+
+#: id:34100
+msgid "Speaker Configuration"
+msgstr "Bozgorailuaren konfigurazioa"
+
+#: id:34101
+msgid "2.0"
+msgstr "2.0"
+
+#: id:34102
+msgid "2.1"
+msgstr "2.1"
+
+#: id:34103
+msgid "3.0"
+msgstr "3.0"
+
+#: id:34104
+msgid "3.1"
+msgstr "3.1"
+
+#: id:34105
+msgid "4.0"
+msgstr "4.0"
+
+#: id:34106
+msgid "4.1"
+msgstr "4.1"
+
+#: id:34107
+msgid "5.0"
+msgstr "5.0"
+
+#: id:34108
+msgid "5.1"
+msgstr "5.1"
+
+#: id:34109
+msgid "7.0"
+msgstr "7.0"
+
+#: id:34110
+msgid "7.1"
+msgstr "7.1"
+
+#: id:34201
+msgid "Can't find a next item to play"
+msgstr ""
+
+#: id:34202
+msgid "Can't find a previous item to play"
+msgstr ""
+
+#: id:34300
+msgid "Failed to start zeroconf"
+msgstr ""
+
+#: id:34301
+msgid "Is Apple's Bonjour Service installed? See log for more info."
+msgstr ""
+
+#: id:34400
+msgid "Video Rendering"
+msgstr ""
+
+#: id:34401
+msgid "Failed to init video filters/scalers, falling back to bilinear scaling"
+msgstr ""
+
+#: id:34402
+msgid "Failed to initialize audio device"
+msgstr ""
+
+#: id:34403
+msgid "Check your audiosettings"
+msgstr ""
+
+#: id:34404
+msgid "Use gestures for navigation:"
+msgstr ""
+
+#: id:34405
+msgid "1 finger swipe left,right,up,down for cursors"
+msgstr ""
+
+#: id:34406
+msgid "2 finger swipe left for backspace"
+msgstr ""
+
+#: id:34407
+msgid "1 finger single tap for enter"
+msgstr ""
+
+#: id:34408
+msgid "2 finger single tap for contextmenu"
+msgstr ""
+
+#: id:35000
+msgid "Peripherals"
+msgstr ""
+
+#: id:35001
+msgid "Generic HID device"
+msgstr ""
+
+#: id:35002
+msgid "Generic network adapter"
+msgstr ""
+
+#: id:35003
+msgid "Generic disk"
+msgstr ""
+
+#: id:35004
+msgid "There are no settings available\nfor this peripheral."
+msgstr ""
+
+#: id:35005
+msgid "New device configured"
+msgstr ""
+
+#: id:35006
+msgid "Device removed"
+msgstr ""
+
+#: id:35007
+msgid "Keymap to use for this device"
+msgstr ""
+
+#: id:35008
+msgid "Keymap enabled"
+msgstr ""
+
+#: id:35009
+msgid "Do not use the custom keymap for this device"
+msgstr ""
+
+#: id:35500
+msgid "Location"
+msgstr ""
+
+#: id:35501
+msgid "Class"
+msgstr ""
+
+#: id:35502
+msgctxt "Auto context with id 35502"
+msgid "Name"
+msgstr ""
+
+#: id:35503
+msgid "Vendor"
+msgstr ""
+
+#: id:35504
+msgid "Product ID"
+msgstr ""
+
+#: id:36000
+msgid "Pulse-Eight CEC adapter"
+msgstr ""
+
+#: id:36001
+msgid "Pulse-Eight Nyxboard"
+msgstr ""
+
+#: id:36002
+msgid "Switch to keyboard side command"
+msgstr ""
+
+#: id:36003
+msgid "Switch to remote side command"
+msgstr ""
+
+#: id:36004
+msgid "Press \"user\" button command"
+msgstr ""
+
+#: id:36005
+msgid "Enable switch side commands"
+msgstr ""
+
+#: id:36006
+msgid "Could not open the adapter"
+msgstr ""
+
+#: id:36007
+msgid "Devices to power on when starting XBMC"
+msgstr ""
+
+#: id:36008
+msgid "Devices to power off when stopping XBMC"
+msgstr ""
+
+#: id:36009
+msgid "Put devices in standby mode when activating screensaver"
+msgstr ""
+
+#: id:36011
+msgid "Could not detect the CEC port. Set it up manually."
+msgstr ""
+
+#: id:36012
+msgid "Could not initialise the CEC adapter. Check your settings."
+msgstr ""
+
+#: id:36013
+msgid "Unsupported libCEC interface version. %d is greater than the version XBMC supports (%d)"
+msgstr ""
+
+#: id:36014
+msgid "Put this PC in standby mode when the TV is switched off"
+msgstr ""
+
+#: id:36015
+msgid "HDMI port number"
+msgstr ""
+
+#: id:36016
+msgctxt "Auto context with id 36016"
+msgid "Connected"
+msgstr ""
+
+#: id:36017
+msgid "Adapter found, but libCEC is not available"
+msgstr ""
+
+#: id:36018
+msgid "Use the TV's language setting"
+msgstr ""
+
+#: id:36019
+msgid "Connected to HDMI device"
+msgstr ""
+
+#: id:36020
+msgid "Make XBMC the active source when starting"
+msgstr ""
+
+#: id:36021
+msgid "Physical address (overrules HDMI port)"
+msgstr ""
+
+#: id:36022
+msgid "COM port (leave empty unless needed)"
+msgstr ""
+
+#: id:36023
+msgid "Configuration updated"
+msgstr ""
+
+#: id:36024
+msgid "Failed to set the new configuration. Please check your settings."
+msgstr ""
+
+#: id:36025
+msgid "Send 'inactive source' command when stopping XBMC"
+msgstr ""
+

--- a/language/Bosnian/strings.po
+++ b/language/Bosnian/strings.po
@@ -1,0 +1,9093 @@
+# Converted from xbmc strings.xml with xbmc-xml2po (by Team-XBMC)
+msgid ""
+msgstr ""
+"Project-Id-Version: xbmc.core-FRODO_GIT3ed1604ad7\n"
+"Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
+"POT-Creation-Date: 2012-04-09 18:00+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE\n"
+"Language: bs\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: id:0
+msgctxt "Auto context with id 0"
+msgid "Programs"
+msgstr "Programi"
+
+#: id:1
+msgctxt "Auto context with id 1"
+msgid "Pictures"
+msgstr "Fotke"
+
+#: id:2
+msgctxt "Auto context with id 2"
+msgid "Music"
+msgstr "Muzika"
+
+#: id:3
+msgctxt "Auto context with id 3"
+msgid "Videos"
+msgstr "Filmovi"
+
+#: id:4
+msgid "TV-Guide"
+msgstr "TV"
+
+#: id:5
+msgctxt "Auto context with id 5"
+msgid "Settings"
+msgstr "Postavke"
+
+#: id:6
+msgid "XBMC SVN"
+msgstr "XBMC SVN"
+
+#: id:7
+msgctxt "Auto context with id 7"
+msgid "File manager"
+msgstr "Upr. datotekama"
+
+#: id:8
+msgctxt "Auto context with id 8"
+msgid "Weather"
+msgstr "Vrijeme"
+
+#: id:9
+msgid "xbmc media center"
+msgstr "XBMC media centar"
+
+#: id:11
+msgid "Monday"
+msgstr "Ponedjeljak"
+
+#: id:12
+msgid "Tuesday"
+msgstr "Utorak"
+
+#: id:13
+msgid "Wednesday"
+msgstr "Srijeda"
+
+#: id:14
+msgid "Thursday"
+msgstr "Četvrtak"
+
+#: id:15
+msgid "Friday"
+msgstr "Petak"
+
+#: id:16
+msgid "Saturday"
+msgstr "Subota"
+
+#: id:17
+msgid "Sunday"
+msgstr "Nedjelja"
+
+#: id:21
+msgid "January"
+msgstr "januar"
+
+#: id:22
+msgid "February"
+msgstr "februar"
+
+#: id:23
+msgid "March"
+msgstr "mart"
+
+#: id:24
+msgid "April"
+msgstr "april"
+
+#: id:25
+msgctxt "Auto context with id 25"
+msgid "May"
+msgstr "maj"
+
+#: id:26
+msgid "June"
+msgstr "jun"
+
+#: id:27
+msgid "July"
+msgstr "jul"
+
+#: id:28
+msgid "August"
+msgstr "avgust"
+
+#: id:29
+msgid "September"
+msgstr "septembar"
+
+#: id:30
+msgid "October"
+msgstr "oktobar"
+
+#: id:31
+msgid "November"
+msgstr "novembar"
+
+#: id:32
+msgid "December"
+msgstr "decembar"
+
+#: id:41
+msgid "Mon"
+msgstr "pon"
+
+#: id:42
+msgid "Tue"
+msgstr "uto"
+
+#: id:43
+msgid "Wed"
+msgstr "sri"
+
+#: id:44
+msgid "Thu"
+msgstr "čet"
+
+#: id:45
+msgid "Fri"
+msgstr "pet"
+
+#: id:46
+msgid "Sat"
+msgstr "sub"
+
+#: id:47
+msgctxt "Auto context with id 47"
+msgid "Sun"
+msgstr "ned"
+
+#: id:51
+msgid "Jan"
+msgstr "jan"
+
+#: id:52
+msgid "Feb"
+msgstr "feb"
+
+#: id:53
+msgid "Mar"
+msgstr "mar"
+
+#: id:54
+msgid "Apr"
+msgstr "apr"
+
+#: id:55
+msgctxt "Auto context with id 55"
+msgid "May"
+msgstr "maj"
+
+#: id:56
+msgid "Jun"
+msgstr "jun"
+
+#: id:57
+msgid "Jul"
+msgstr "jul"
+
+#: id:58
+msgid "Aug"
+msgstr "avg"
+
+#: id:59
+msgid "Sep"
+msgstr "sep"
+
+#: id:60
+msgid "Oct"
+msgstr "okt"
+
+#: id:61
+msgid "Nov"
+msgstr "nov"
+
+#: id:62
+msgid "Dec"
+msgstr "dec"
+
+#: id:71
+msgid "N"
+msgstr ""
+
+#: id:72
+msgid "NNE"
+msgstr ""
+
+#: id:73
+msgid "NE"
+msgstr ""
+
+#: id:74
+msgid "ENE"
+msgstr ""
+
+#: id:75
+msgid "E"
+msgstr ""
+
+#: id:76
+msgid "ESE"
+msgstr ""
+
+#: id:77
+msgid "SE"
+msgstr ""
+
+#: id:78
+msgid "SSE"
+msgstr ""
+
+#: id:79
+msgid "S"
+msgstr ""
+
+#: id:80
+msgid "SSW"
+msgstr ""
+
+#: id:81
+msgid "SW"
+msgstr ""
+
+#: id:82
+msgid "WSW"
+msgstr ""
+
+#: id:83
+msgid "W"
+msgstr ""
+
+#: id:84
+msgid "WNW"
+msgstr ""
+
+#: id:85
+msgid "NW"
+msgstr ""
+
+#: id:86
+msgid "NNW"
+msgstr ""
+
+#: id:87
+msgid "VAR"
+msgstr ""
+
+#: id:98
+msgid "View: Auto"
+msgstr "Prikaz: Autom."
+
+#: id:99
+msgid "View: Auto big"
+msgstr "Prikaz: Autom. veliko"
+
+#: id:100
+msgid "View: Icons"
+msgstr "Prikaz: Ikone"
+
+#: id:101
+msgid "View: List"
+msgstr "Prikaz: Spisak"
+
+#: id:102
+msgctxt "Auto context with id 102"
+msgid "Scan"
+msgstr "Analiziraj"
+
+#: id:103
+msgctxt "Auto context with id 103"
+msgid "Sort by: Name"
+msgstr "Složi po: Imenu"
+
+#: id:104
+msgid "Sort by: Date"
+msgstr "Složi po: Datumu"
+
+#: id:105
+msgid "Sort by: Size"
+msgstr "Složi po: Veli."
+
+#: id:106
+msgid "No"
+msgstr "Ne"
+
+#: id:107
+msgid "Yes"
+msgstr "Da"
+
+#: id:108
+msgctxt "Auto context with id 108"
+msgid "Slideshow"
+msgstr "Reprod. slajdova"
+
+#: id:109
+msgid "Create thumbs"
+msgstr "Napravi omote"
+
+#: id:110
+msgid "Create thumbnails"
+msgstr "Napravi sličice"
+
+#: id:111
+msgctxt "Auto context with id 111"
+msgid "Shortcuts"
+msgstr "Prečice"
+
+#: id:112
+msgid "Paused"
+msgstr "Pauzirano"
+
+#: id:113
+msgid "Update failed"
+msgstr ""
+
+#: id:114
+msgid "Installation failed"
+msgstr ""
+
+#: id:115
+msgid "Copy"
+msgstr "Kopiraj"
+
+#: id:116
+msgid "Move"
+msgstr "Premjesti"
+
+#: id:117
+msgid "Delete"
+msgstr "Izbriši"
+
+#: id:118
+msgid "Rename"
+msgstr "Preimenuj"
+
+#: id:119
+msgid "New folder"
+msgstr "Nova fascikla"
+
+#: id:120
+msgid "Confirm file copy"
+msgstr "Potvrdite kopiranje"
+
+#: id:121
+msgid "Confirm file move"
+msgstr "Potvrdite premještanje"
+
+#: id:122
+msgid "Confirm file delete?"
+msgstr "Potvrđujete li brisanje?"
+
+#: id:123
+msgid "Copy these files?"
+msgstr "Kopiranje ovih datoteka?"
+
+#: id:124
+msgid "Move these files?"
+msgstr "Premještanje ovih datoteka?"
+
+#: id:125
+msgid "Delete these files? - Deleting files cannot be undone!"
+msgstr "Brisanje ovih datoteka? - Nakon brisanja, datoteke nije moguće povratiti!"
+
+#: id:126
+msgid "Status"
+msgstr "Stanje"
+
+#: id:127
+msgid "Objects"
+msgstr "Objekata"
+
+#: id:128
+msgctxt "Auto context with id 128"
+msgid "General"
+msgstr "Opšte"
+
+#: id:129
+msgctxt "Auto context with id 129"
+msgid "Slideshow"
+msgstr "Projekcija slajdova"
+
+#: id:130
+msgctxt "Auto context with id 130"
+msgid "System info"
+msgstr "Podaci o sistemu"
+
+#: id:131
+msgid "Display"
+msgstr "Prikaz"
+
+#: id:132
+msgid "Albums"
+msgstr "Albumi"
+
+#: id:133
+msgid "Artists"
+msgstr "Izvođači"
+
+#: id:134
+msgid "Songs"
+msgstr "Numere"
+
+#: id:135
+msgid "Genres"
+msgstr "Žanrovi"
+
+#: id:136
+msgid "Playlists"
+msgstr "Spiskovi za repro."
+
+#: id:137
+msgid "Search"
+msgstr "Pretraži"
+
+#: id:138
+msgid "System Information"
+msgstr "Podaci o sistemu"
+
+#: id:139
+msgid "Temperatures:"
+msgstr "Temperature:"
+
+#: id:140
+msgid "CPU:"
+msgstr "Centralnog procesora:"
+
+#: id:141
+msgid "GPU:"
+msgstr "Grafičkog procesora:"
+
+#: id:142
+msgid "Time:"
+msgstr "Vrijeme:"
+
+#: id:143
+msgid "Current:"
+msgstr "Trenutno:"
+
+#: id:144
+msgid "Build:"
+msgstr "Izdanje:"
+
+#: id:145
+msgid "Network:"
+msgstr "Mreža:"
+
+#: id:146
+msgid "Type:"
+msgstr "Tip:"
+
+#: id:147
+msgid "Static"
+msgstr "Statički"
+
+#: id:148
+msgid "DHCP"
+msgstr "DHCP"
+
+#: id:149
+msgid "MAC address"
+msgstr "MAC adresa"
+
+#: id:150
+msgctxt "Auto context with id 150"
+msgid "IP address"
+msgstr "IP adresa"
+
+#: id:151
+msgid "Link:"
+msgstr "Veza:"
+
+#: id:152
+msgid "Half duplex"
+msgstr "Polu dupleks"
+
+#: id:153
+msgid "Full duplex"
+msgstr "Puni dupleks"
+
+#: id:154
+msgctxt "Auto context with id 154"
+msgid "Storage"
+msgstr "Skladišta"
+
+#: id:155
+msgid "Drive"
+msgstr "Uređaj"
+
+#: id:156
+msgctxt "Auto context with id 156"
+msgid "Free"
+msgstr "Slobodno"
+
+#: id:157
+msgctxt "Auto context with id 157"
+msgid "Video"
+msgstr "Video"
+
+#: id:158
+msgid "Free memory"
+msgstr "Slobodna memorija"
+
+#: id:159
+msgid "No link"
+msgstr "nije uspostavljena"
+
+#: id:160
+msgctxt "Auto context with id 160"
+msgid "Free"
+msgstr "slobodno"
+
+#: id:161
+msgid "Unavailable"
+msgstr "Nedostupno"
+
+#: id:162
+msgid "Tray open"
+msgstr "Vrata otvorena"
+
+#: id:163
+msgid "Reading"
+msgstr "Čitanje"
+
+#: id:164
+msgid "No disc"
+msgstr "Disk nije umetnut"
+
+#: id:165
+msgid "Disc present"
+msgstr "Disk je prepoznat"
+
+#: id:166
+msgid "Skin"
+msgstr "Maska"
+
+#: id:169
+msgctxt "Auto context with id 169"
+msgid "Resolution"
+msgstr "Rezolucija"
+
+#: id:170
+msgid "Adjust display refresh rate to match video"
+msgstr "Prilagodi brzinu osvježavanja monitora"
+
+#: id:172
+msgid "Release date"
+msgstr "Datum izdavanja"
+
+#: id:173
+msgid "Display 4:3 videos as"
+msgstr "Prikaži 4:3 video materijal kao"
+
+#: id:175
+msgid "Moods"
+msgstr "Raspoloženja"
+
+#: id:176
+msgid "Styles"
+msgstr "Stilovi"
+
+#: id:179
+msgid "Song"
+msgstr "Pjesma"
+
+#: id:180
+msgid "Duration"
+msgstr "Trajanje"
+
+#: id:181
+msgid "Select album"
+msgstr "Izaberite album"
+
+#: id:182
+msgid "Tracks"
+msgstr "Numere"
+
+#: id:183
+msgid "Review"
+msgstr "Pregled"
+
+#: id:184
+msgid "Refresh"
+msgstr "Osvježi"
+
+#: id:185
+msgid "Searching album"
+msgstr "Pretraživanje albuma"
+
+#: id:186
+msgid "OK"
+msgstr "U redu"
+
+#: id:187
+msgid "No albums found!"
+msgstr "Nijedan album nije pronađen!"
+
+#: id:188
+msgid "Select all"
+msgstr "Izaberi sve"
+
+#: id:189
+msgid "Scanning media info"
+msgstr "Analiziranje informacija"
+
+#: id:190
+msgid "Save"
+msgstr "Sačuvaj"
+
+#: id:191
+msgid "Shuffle"
+msgstr "Nasumice"
+
+#: id:192
+msgctxt "Auto context with id 192"
+msgid "Clear"
+msgstr "Poništi"
+
+#: id:193
+msgctxt "Auto context with id 193"
+msgid "Scan"
+msgstr "Analiziraj"
+
+#: id:194
+msgid "Searching..."
+msgstr "Pretraživanje..."
+
+#: id:195
+msgid "No info found!"
+msgstr "Nisu pronađene informacije!"
+
+#: id:196
+msgid "Select movie:"
+msgstr "Izaberite film:"
+
+#: id:197
+msgid "Querying %s info"
+msgstr "Zahtjevanje podataka o %s"
+
+#: id:198
+msgid "Loading movie details"
+msgstr "Učitavanje podataka o filmu"
+
+#: id:199
+msgid "Web interface"
+msgstr ""
+
+#: id:202
+msgid "Tagline"
+msgstr "Tagline"
+
+#: id:203
+msgid "Plot outline"
+msgstr "Kratak opis"
+
+#: id:205
+msgid "Votes"
+msgstr "Glasova"
+
+#: id:206
+msgid "Cast"
+msgstr "Uloge"
+
+#: id:207
+msgid "Plot"
+msgstr "Opis"
+
+#: id:208
+msgctxt "Auto context with id 208"
+msgid "Play"
+msgstr "Reprodukuj"
+
+#: id:209
+msgid "Next"
+msgstr "Sljedeće"
+
+#: id:210
+msgid "Previous"
+msgstr "Prethodno"
+
+#: id:213
+msgid "Calibrate user interface..."
+msgstr "Prilagodite korisničko okruženje..."
+
+#: id:214
+msgid "Video calibration..."
+msgstr "Kalibracija slike..."
+
+#: id:215
+msgid "Soften"
+msgstr "Omekšano"
+
+#: id:216
+msgid "Zoom amount"
+msgstr "Nivo uvećanja"
+
+#: id:217
+msgid "Pixel ratio"
+msgstr "Odnos pikselizacije"
+
+#: id:218
+msgid "DVD drive"
+msgstr "DVD uređaj"
+
+#: id:219
+msgid "Please insert disc"
+msgstr "Molim, umetnite disk"
+
+#: id:220
+msgid "Remote share"
+msgstr "Daljinsko djeljenje"
+
+#: id:221
+msgid "Network is not connected"
+msgstr "Mreža nije povezana"
+
+#: id:222
+msgid "Cancel"
+msgstr "Otkaži"
+
+#: id:224
+msgid "Speed"
+msgstr "Brzina"
+
+#: id:225
+msgid "Vertical Shift"
+msgstr ""
+
+#: id:226
+msgid "Test patterns..."
+msgstr "Isprobaj šablon..."
+
+#: id:227
+msgid "Lookup audio CD track names from freedb.org"
+msgstr "Potraži imena numera, muzičkog CD-a, na freedb.org"
+
+#: id:228
+msgid "Shuffle playlist on load"
+msgstr "Izmješaj spisak pri učitavanju"
+
+#: id:229
+msgid "HDD spindown time"
+msgstr "Vrijeme usporenja HDD-a"
+
+#: id:230
+msgid "Video filters"
+msgstr "Video filteri"
+
+#: id:231
+msgctxt "Auto context with id 231"
+msgid "None"
+msgstr "Ništa"
+
+#: id:232
+msgid "Point"
+msgstr "Tačka"
+
+#: id:233
+msgid "Linear"
+msgstr "Linearno"
+
+#: id:234
+msgid "Anisotropic"
+msgstr "Anizotropija"
+
+#: id:235
+msgid "Quincunx"
+msgstr "Quincunx"
+
+#: id:236
+msgid "Gaussian cubic"
+msgstr "Gaussian cubic"
+
+#: id:237
+msgid "Minification"
+msgstr "Umanjenje"
+
+#: id:238
+msgid "Magnification"
+msgstr "Uveličanje"
+
+#: id:239
+msgid "Clear playlist on finish"
+msgstr "Poništi spisak po završetku"
+
+#: id:240
+msgid "Display Mode"
+msgstr ""
+
+#: id:241
+msgid "Full Screen #%d"
+msgstr ""
+
+#: id:242
+msgid "Windowed"
+msgstr ""
+
+#: id:243
+msgid "Refresh Rate"
+msgstr ""
+
+#: id:244
+msgid "Full screen"
+msgstr ""
+
+#: id:245
+msgid "Sizing: (%i,%i)->(%i,%i) (Zoom x%2.2f) AR:%2.2f:1 (Pixels: %2.2f:1) (VShift: %2.2f)"
+msgstr ""
+
+#: id:247
+msgctxt "Auto context with id 247"
+msgid "Scripts"
+msgstr "Skripte"
+
+#: id:248
+msgctxt "Auto context with id 248"
+msgid "Language"
+msgstr "Jezik"
+
+#: id:249
+msgctxt "Auto context with id 249"
+msgid "Music"
+msgstr "Muzika"
+
+#: id:250
+msgctxt "Auto context with id 250"
+msgid "Visualization"
+msgstr "Vizualizacija"
+
+#: id:251
+msgid "Select destination directory"
+msgstr "Izaberite odredišnu fasciklu"
+
+#: id:252
+msgid "Output stereo to all speakers"
+msgstr "Stereo izlaz ka svim zvučnicima"
+
+#: id:253
+msgid "Number of channels"
+msgstr "Broj kanala"
+
+#: id:254
+msgid "- DTS capable receiver"
+msgstr "- Sposoban DTS prijemnik"
+
+#: id:255
+msgid "CDDB"
+msgstr "CDDB"
+
+#: id:256
+msgid "Fetching CD information"
+msgstr "Preuzimanje CD informacija"
+
+#: id:257
+msgid "Error"
+msgstr "Greška"
+
+#: id:258
+msgid "Enable tag reading"
+msgstr "Omogući čitanje oznaka"
+
+#: id:259
+msgid "Opening"
+msgstr "Otvaranje"
+
+#: id:260
+msgid "Shoutcast"
+msgstr "Internet radio"
+
+#: id:261
+msgid "Waiting for start..."
+msgstr "Čekanje na početak..."
+
+#: id:262
+msgid "Scripts output"
+msgstr "Izlazne skripte"
+
+#: id:263
+msgid "Allow control of XBMC via HTTP"
+msgstr "Dozvoli kontrolu XBMC aplikacije putem HTTP protokola"
+
+#: id:264
+msgid "Record"
+msgstr "Snimi"
+
+#: id:265
+msgid "Stop Rec."
+msgstr "Zaustavi snim."
+
+#: id:266
+msgid "Sort by: Track"
+msgstr "Složi po: Numeri"
+
+#: id:267
+msgid "Sort by: Time"
+msgstr "Složi po: Vremenu"
+
+#: id:268
+msgid "Sort by: Title"
+msgstr "Složi po: Naslovu"
+
+#: id:269
+msgid "Sort by: Artist"
+msgstr "Složi po: Izvođaču"
+
+#: id:270
+msgid "Sort by: Album"
+msgstr "Složi po: Albumu"
+
+#: id:271
+msgid "Top 100"
+msgstr "Najboljih 100"
+
+#: id:272
+msgid "Top-Left overscan compensation"
+msgstr "Gornja lijeva ivica ekrana"
+
+#: id:273
+msgid "Bottom-Right overscan compensation"
+msgstr "Donja desna ivica ekrana"
+
+#: id:274
+msgid "Subtitle positioning"
+msgstr "Pozicioniranje titla"
+
+#: id:275
+msgid "Pixel ratio adjustment"
+msgstr "Prilagođavanje odnosa strana"
+
+#: id:276
+msgid "Adjust the arrow to change the amount of overscan"
+msgstr "Pomjerajte strelicu kako biste promjenili veličinu ekrana"
+
+#: id:277
+msgid "Adjust the bar to change the subtitles position"
+msgstr "Pomerajte liniju kako biste promenili poziciju titlova"
+
+#: id:278
+msgid "Adjust the rectangle so it is perfectly square"
+msgstr "Oblikujte pravougaonik tako da dobijete savršeni kvadrat"
+
+#: id:279
+msgid "Unable to load settings"
+msgstr "Nije moguće učitati postavke"
+
+#: id:280
+msgid "Using default settings"
+msgstr "Korišćenje podrazumjevanih postavki"
+
+#: id:281
+msgid "Please check the XML files"
+msgstr "Molimo, proverite XML datoteke"
+
+#: id:282
+msgid "Found %i items"
+msgstr "Pronađeno %i stavki"
+
+#: id:283
+msgid "Search results"
+msgstr "Rezultati pretrage"
+
+#: id:284
+msgid "No results found"
+msgstr "Bez rezultata"
+
+#: id:287
+msgctxt "Auto context with id 287"
+msgid "Subtitles"
+msgstr "Titlovi"
+
+#: id:288
+msgctxt "Auto context with id 288"
+msgid "Font"
+msgstr "Slova"
+
+#: id:289
+msgctxt "Auto context with id 289"
+msgid "- Size"
+msgstr "- Veličina"
+
+#: id:290
+msgid "Dynamic range compression"
+msgstr "Dinamički opseg kompresije"
+
+#: id:291
+msgctxt "Auto context with id 291"
+msgid "Video"
+msgstr "Video"
+
+#: id:292
+msgctxt "Auto context with id 292"
+msgid "Audio"
+msgstr "Zvuk"
+
+#: id:293
+msgid "Browse for subtitles"
+msgstr "Potraži titlove"
+
+#: id:294
+msgid "Create bookmark"
+msgstr "Napravi obiljež."
+
+#: id:296
+msgid "Clear bookmarks"
+msgstr "Poništi obiljež."
+
+#: id:297
+msgid "Audio offset"
+msgstr "Pomjeraj zvuk u vremenu"
+
+#: id:298
+msgid "Bookmarks"
+msgstr "Obilježivači"
+
+#: id:299
+msgid "- AAC capable receiver"
+msgstr "- Sposoban AAC prijemnik"
+
+#: id:300
+msgid "- MP1 capable receiver"
+msgstr "- Sposoban MP1 prijemnik"
+
+#: id:301
+msgid "- MP2 capable receiver"
+msgstr "- Sposoban MP2 prijemnik"
+
+#: id:302
+msgid "- MP3 capable receiver"
+msgstr "- Sposoban MP3 prijemnik"
+
+#: id:303
+msgid "Delay"
+msgstr "Kašnjenje"
+
+#: id:304
+msgctxt "Auto context with id 304"
+msgid "Language"
+msgstr "Jezik"
+
+#: id:305
+msgctxt "Auto context with id 305"
+msgid "Enabled"
+msgstr "Omogućeno"
+
+#: id:306
+msgid "Non-interleaved"
+msgstr "Nestandardni"
+
+#: id:312
+msgid "(0=auto)"
+msgstr "(0=autom.)"
+
+#: id:313
+msgid "Cleaning database"
+msgstr "Čišćenje baze"
+
+#: id:314
+msgid "Preparing..."
+msgstr "Pripremanje..."
+
+#: id:315
+msgid "Database error"
+msgstr "Greška baze podataka"
+
+#: id:316
+msgid "Searching songs..."
+msgstr "Pretraživanje pjesama..."
+
+#: id:317
+msgid "Cleaned database successfully"
+msgstr "Baza podataka je uspješno očišćena"
+
+#: id:318
+msgid "Cleaning songs..."
+msgstr "Čišćenje pjesama..."
+
+#: id:319
+msgid "Error cleaning songs"
+msgstr "Greška čišćenja pjesama"
+
+#: id:320
+msgid "Cleaning artists..."
+msgstr "Čišćenje izvođača..."
+
+#: id:321
+msgid "Error cleaning artists"
+msgstr "Greška čišćenja izvođača"
+
+#: id:322
+msgid "Cleaning genres..."
+msgstr "Čišćenje žanrova..."
+
+#: id:323
+msgid "Error cleaning genres"
+msgstr "Greška čišćenja žanrova"
+
+#: id:324
+msgid "Cleaning paths..."
+msgstr "Čišćenje putanja..."
+
+#: id:325
+msgid "Error cleaning paths"
+msgstr "Greška čišćenja putanja"
+
+#: id:326
+msgid "Cleaning albums..."
+msgstr "Čišćenje albuma..."
+
+#: id:327
+msgid "Error cleaning albums"
+msgstr "Greška čišćenja albuma"
+
+#: id:328
+msgid "Writing changes..."
+msgstr "Upisivanje promjena..."
+
+#: id:329
+msgid "Error writing changes"
+msgstr "Greška upisivanja promjena"
+
+#: id:330
+msgid "This may take some time..."
+msgstr "Ovo može potrajati neko vrijeme..."
+
+#: id:331
+msgid "Compressing database..."
+msgstr "Komprimiranje baze podataka..."
+
+#: id:332
+msgid "Error compressing database"
+msgstr "Greška komprimiranja baze podataka"
+
+#: id:333
+msgid "Do you want to clean the library?"
+msgstr "Želite li zaista da očistite biblioteku?"
+
+#: id:334
+msgid "Clean library..."
+msgstr "Čišćenje biblioteke..."
+
+#: id:335
+msgid "Start"
+msgstr "Pokreni"
+
+#: id:336
+msgid "Framerate conversion"
+msgstr "Konverzija brzine sličica"
+
+#: id:337
+msgctxt "Auto context with id 337"
+msgid "Audio output"
+msgstr "Izlaz zvuka"
+
+#: id:338
+msgid "Analog"
+msgstr "Analogni"
+
+#: id:339
+msgid "Optical/Coax"
+msgstr "Digitalni"
+
+#: id:340
+msgid "Various artists"
+msgstr "Različiti izvođači"
+
+#: id:341
+msgid "Play disc"
+msgstr "Reprodukuj disk"
+
+#: id:342
+msgctxt "Auto context with id 342"
+msgid "Movies"
+msgstr "Filmovi"
+
+#: id:343
+msgid "Adjust framerate"
+msgstr "Prilagodi brzinu sličica"
+
+#: id:344
+msgid "Actors"
+msgstr "Glumci"
+
+#: id:345
+msgctxt "Auto context with id 345"
+msgid "Year"
+msgstr "Godina"
+
+#: id:346
+msgid "Boost volume level on downmix"
+msgstr "Pojačaj nivo zvuka pri prebacivanju u manji br. kanala"
+
+#: id:350
+msgctxt "Auto context with id 350"
+msgid "Programs"
+msgstr "Programi"
+
+#: id:351
+msgctxt "Auto context with id 351"
+msgid "Off"
+msgstr "Isklj."
+
+#: id:352
+msgid "Dim"
+msgstr "Zatamni"
+
+#: id:353
+msgid "Black"
+msgstr "Crno"
+
+#: id:354
+msgid "Matrix trails"
+msgstr "Matrix tragovi"
+
+#: id:355
+msgid "Screensaver time"
+msgstr "Vrijeme pokretanja čuvara ekrana"
+
+#: id:356
+msgid "Screensaver mode"
+msgstr "Režim čuvara ekrana"
+
+#: id:357
+msgid "Shutdown function timer"
+msgstr "Funkcioniranje tajmera isključivanja"
+
+#: id:358
+msgid "All albums"
+msgstr "Svi albumi"
+
+#: id:359
+msgid "Recently added albums"
+msgstr "Nedavno dodani albumi"
+
+#: id:360
+msgctxt "Auto context with id 360"
+msgid "Screensaver"
+msgstr "Čuvar ekrana"
+
+#: id:361
+msgid "R. Slideshow"
+msgstr "Nasum. rep. slaj."
+
+#: id:362
+msgid "Screensaver dim level"
+msgstr "Nivo zatamljenja čuvara ekrana"
+
+#: id:363
+msgid "Sort by: File"
+msgstr "Složi po: Dato."
+
+#: id:364
+msgid "- Dolby Digital (AC3) capable receiver"
+msgstr "- Sposoban Dolby Digital (AC3) prijemnik"
+
+#: id:365
+msgctxt "Auto context with id 365"
+msgid "Sort by: Name"
+msgstr "Složi po: Imenu"
+
+#: id:366
+msgid "Sort by: Year"
+msgstr "Složi po: Godini"
+
+#: id:367
+msgid "Sort by: Rating"
+msgstr "Složi po: Popularnosti"
+
+#: id:368
+msgid "IMDb"
+msgstr "IMDb"
+
+#: id:369
+msgctxt "Auto context with id 369"
+msgid "Title"
+msgstr "Naziv"
+
+#: id:370
+msgid "Thunderstorms"
+msgstr "grmljavina"
+
+#: id:371
+msgid "Partly"
+msgstr "djelimično"
+
+#: id:372
+msgid "Mostly"
+msgstr "uglavnom"
+
+#: id:373
+msgid "Sunny"
+msgstr "sunčano"
+
+#: id:374
+msgid "Cloudy"
+msgstr "oblačno"
+
+#: id:375
+msgid "Snow"
+msgstr "snijeg"
+
+#: id:376
+msgid "Rain"
+msgstr "kiša"
+
+#: id:377
+msgid "Light"
+msgstr "slab(a)"
+
+#: id:378
+msgid "AM"
+msgstr "ujutro"
+
+#: id:379
+msgid "PM"
+msgstr "popodne"
+
+#: id:380
+msgid "Showers"
+msgstr "pljuskovi"
+
+#: id:381
+msgid "Few"
+msgstr "nekoliko"
+
+#: id:382
+msgid "Scattered"
+msgstr "mjestimično"
+
+#: id:383
+msgctxt "Auto context with id 383"
+msgid "Wind"
+msgstr "vjetrovito"
+
+#: id:384
+msgid "Strong"
+msgstr "izuzetno"
+
+#: id:385
+msgid "Fair"
+msgstr "umjereno"
+
+#: id:386
+msgctxt "Auto context with id 386"
+msgid "Clear"
+msgstr "vedro"
+
+#: id:387
+msgid "Clouds"
+msgstr "oblačno"
+
+#: id:388
+msgid "Early"
+msgstr "rani"
+
+#: id:389
+msgid "Shower"
+msgstr "pljusak"
+
+#: id:390
+msgid "Flurries"
+msgstr "Susnježica"
+
+#: id:391
+msgctxt "Auto context with id 391"
+msgid "Low"
+msgstr "nizak"
+
+#: id:392
+msgctxt "Auto context with id 392"
+msgid "Medium"
+msgstr "umjeren"
+
+#: id:393
+msgctxt "Auto context with id 393"
+msgid "High"
+msgstr "visok"
+
+#: id:394
+msgid "Fog"
+msgstr "magla"
+
+#: id:395
+msgid "Haze"
+msgstr "izmaglica"
+
+#: id:396
+msgid "Select location"
+msgstr "Izbor lokacije"
+
+#: id:397
+msgid "Refresh time"
+msgstr "Učestalost osvežavanja"
+
+#: id:398
+msgid "Temperature units"
+msgstr "Jedinice za temperaturu"
+
+#: id:399
+msgid "Speed units"
+msgstr "Jedinice za brzinu"
+
+#: id:400
+msgctxt "Auto context with id 400"
+msgid "Weather"
+msgstr "Vijreme"
+
+#: id:401
+msgid "Temp"
+msgstr "Temper."
+
+#: id:402
+msgid "Feels like"
+msgstr "Kao da je"
+
+#: id:403
+msgid "UV index"
+msgstr "UV indeks"
+
+#: id:404
+msgctxt "Auto context with id 404"
+msgid "Wind"
+msgstr "Vjetar"
+
+#: id:405
+msgid "Dew point"
+msgstr "Tačka rose"
+
+#: id:406
+msgid "Humidity"
+msgstr "Vlažnost"
+
+#: id:409
+msgid "Defaults"
+msgstr "Podrazumjevano"
+
+#: id:410
+msgid "Accessing weather service"
+msgstr "Pristupanje usluzi vrem. prognoze"
+
+#: id:411
+msgid "Getting weather for:"
+msgstr "Preuzimanje prognoze za:"
+
+#: id:412
+msgid "Unable to get weather data"
+msgstr "Nije moguće preuzeti podatke o prognozi"
+
+#: id:413
+msgid "Manual"
+msgstr "Ručno"
+
+#: id:414
+msgid "No review for this album"
+msgstr "Ne postoji recenzija za ovaj album"
+
+#: id:415
+msgid "Downloading thumbnail..."
+msgstr "Preuzimanje..."
+
+#: id:416
+msgid "Not available"
+msgstr "Nije dostupno"
+
+#: id:417
+msgid "View: Big icons"
+msgstr "Prikaz: Velike ikone"
+
+#: id:418
+msgctxt "Auto context with id 418"
+msgid "Low"
+msgstr "Min."
+
+#: id:419
+msgctxt "Auto context with id 419"
+msgid "High"
+msgstr "Maks."
+
+#: id:420
+msgid "HDMI"
+msgstr ""
+
+#: id:422
+msgid "Delete album info"
+msgstr "Izbriši podatke o albumu"
+
+#: id:423
+msgid "Delete CD information"
+msgstr "Izbriši CD podatke"
+
+#: id:424
+msgid "Select"
+msgstr "Izaberi"
+
+#: id:425
+msgid "No album information found"
+msgstr "Nisu pronađeni podaci o albumu"
+
+#: id:426
+msgid "No CD information found"
+msgstr "Nisu pronađeni CD podaci"
+
+#: id:427
+msgid "Disc"
+msgstr "Disk"
+
+#: id:428
+msgid "Insert correct CD/DVD"
+msgstr "Umetnite ispravan CD/DVD"
+
+#: id:429
+msgid "Please insert the following disc:"
+msgstr "Molimo, umetnite sljedeći CD/DVD"
+
+#: id:430
+msgid "Sort by: DVD#"
+msgstr "Složi po: DVD#"
+
+#: id:431
+msgid "No cache"
+msgstr "Bez keša"
+
+#: id:432
+msgid "Remove movie from library"
+msgstr "Ukloni film iz biblioteke"
+
+#: id:433
+msgid "Really remove '%s'?"
+msgstr "Zaista želite da uklonite „%s“?"
+
+#: id:434
+msgid "From %s at %i %s"
+msgstr ""
+
+#: id:437
+msgid "Removable disk"
+msgstr "Prenosivi disk"
+
+#: id:438
+msgid "Opening file"
+msgstr "Otvaranje datoteke"
+
+#: id:439
+msgid "Cache"
+msgstr "Keš"
+
+#: id:440
+msgid "Harddisk"
+msgstr "Čvrsti disk"
+
+#: id:441
+msgid "UDF"
+msgstr "UDF"
+
+#: id:442
+msgid "Local network"
+msgstr "Lokalna mreža"
+
+#: id:443
+msgid "Internet"
+msgstr "Internet"
+
+#: id:444
+msgctxt "Auto context with id 444"
+msgid "Video"
+msgstr "Video"
+
+#: id:445
+msgctxt "Auto context with id 445"
+msgid "Audio"
+msgstr "Zvuk"
+
+#: id:446
+msgctxt "Auto context with id 446"
+msgid "DVD"
+msgstr "DVD"
+
+#: id:447
+msgid "Autorun media"
+msgstr "Automatska reprod. medija"
+
+#: id:448
+msgid "LCD"
+msgstr "LCD"
+
+#: id:449
+msgctxt "Auto context with id 449"
+msgid "Enabled"
+msgstr "Omogućeno"
+
+#: id:450
+msgid "Columns"
+msgstr "Kolone"
+
+#: id:451
+msgid "Row 1 address"
+msgstr "1. red adrese"
+
+#: id:452
+msgid "Row 2 address"
+msgstr "2. red adrese"
+
+#: id:453
+msgid "Row 3 address"
+msgstr "3. red adrese"
+
+#: id:454
+msgid "Row 4 address"
+msgstr "4. red adrese"
+
+#: id:455
+msgid "Rows"
+msgstr "Redovi"
+
+#: id:456
+msgid "Mode"
+msgstr "Režim"
+
+#: id:457
+msgid "Switch view"
+msgstr "Promjeni prikaz"
+
+#: id:459
+msgid "Subs"
+msgstr "Titlovi"
+
+#: id:460
+msgid "Audio stream"
+msgstr "Zvučni zapis"
+
+#: id:461
+msgid "[active]"
+msgstr "[aktivno]"
+
+#: id:462
+msgid "Subtitle"
+msgstr "Titl"
+
+#: id:463
+msgid "Backlight"
+msgstr "Pozadinsko osvjetljenje"
+
+#: id:464
+msgid "Brightness"
+msgstr "Svjetlina"
+
+#: id:465
+msgid "Contrast"
+msgstr "Kontrast"
+
+#: id:466
+msgid "Gamma"
+msgstr "Opseg boje"
+
+#: id:467
+msgctxt "Auto context with id 467"
+msgid "Type"
+msgstr "Tip"
+
+#: id:468
+msgid "Move the bar to change the OSD position"
+msgstr "Pomjerajte liniju da biste promenili OSD poziciju"
+
+#: id:469
+msgid "OSD position"
+msgstr "OSD pozicija"
+
+#: id:470
+msgid "Credits"
+msgstr "Zasluge"
+
+#: id:471
+msgid "Modchip"
+msgstr "Izme. čip"
+
+#: id:474
+msgctxt "Auto context with id 474"
+msgid "Off"
+msgstr "Isklj."
+
+#: id:475
+msgid "Music only"
+msgstr "Samo muzika"
+
+#: id:476
+msgctxt "Auto context with id 476"
+msgid "Music & video"
+msgstr "Muzika i video"
+
+#: id:477
+msgid "Unable to load playlist"
+msgstr "Nije moguće učitati spisak za reprodukciju"
+
+#: id:478
+msgid "OSD"
+msgstr "OSD"
+
+#: id:479
+msgid "Skin & language"
+msgstr "Maska i jezik"
+
+#: id:480
+msgid "Appearance"
+msgstr "Prikazivanje"
+
+#: id:481
+msgid "Audio options"
+msgstr "Opcije zvuka"
+
+#: id:482
+msgid "About XBMC"
+msgstr "O sistemu XBMC"
+
+#: id:485
+msgid "Delete album"
+msgstr "Izbriši album"
+
+#: id:486
+msgid "Repeat"
+msgstr "Ponovi"
+
+#: id:487
+msgid "Repeat one"
+msgstr "Ponovi jednom"
+
+#: id:488
+msgid "Repeat folder"
+msgstr "Ponovi fasciklu"
+
+#: id:489
+msgid "Play the next song automatically"
+msgstr "Automatski reprodukuj sljedeću pjesmu"
+
+#: id:491
+msgid "- Use big icons"
+msgstr "- Koristi velike ikone"
+
+#: id:492
+msgid "Resize VobSubs"
+msgstr "Promjeni veličinu za VobSubs"
+
+#: id:493
+msgid "Advanced options (Experts Only!)"
+msgstr "Napredne opcije (samo za stručnjake!)"
+
+#: id:494
+msgid "Overall audio headroom"
+msgstr "Sveobuhvatan zvučni slobodan prostor"
+
+#: id:495
+msgid "Upsample videos to GUI resolution"
+msgstr "Poistovjeti video i GUI rezoluciju"
+
+#: id:496
+msgid "Calibration"
+msgstr "Kalibracija"
+
+#: id:497
+msgid "Show file extensions"
+msgstr "Prikaži tipove datoteka"
+
+#: id:498
+msgid "Sort by: Type"
+msgstr "Složi po: Tipu"
+
+#: id:499
+msgid "Unable to connect to online lookup service"
+msgstr "Nije moguće povezivanje i pretraga mrežne usluge"
+
+#: id:500
+msgid "Downloading album information failed"
+msgstr "Neuspešno preuzimanje podataka o albumu"
+
+#: id:501
+msgid "Looking for album names..."
+msgstr "Traženje naziva albuma..."
+
+#: id:502
+msgctxt "Auto context with id 502"
+msgid "Open"
+msgstr "Otvori"
+
+#: id:503
+msgid "Busy"
+msgstr "Zauzeto"
+
+#: id:504
+msgid "Empty"
+msgstr "Prazno"
+
+#: id:505
+msgid "Loading media info from files..."
+msgstr "Učitavanje podataka o mediju iz datoteka..."
+
+#: id:507
+msgid "Sort by: Usage"
+msgstr "Složi po: Upotrebi"
+
+#: id:510
+msgid "Enable visualizations"
+msgstr "Omogući vizualizacije"
+
+#: id:511
+msgid "Enable video mode switching"
+msgstr "Omogući promjenu režima videa"
+
+#: id:512
+msgid "Startup window"
+msgstr "Startni ekran"
+
+#: id:513
+msgid "Home window"
+msgstr "Početni ekran"
+
+#: id:514
+msgid "Manual settings"
+msgstr "Ručne postavke"
+
+#: id:515
+msgid "Genre"
+msgstr "Žanr"
+
+#: id:517
+msgid "Recently played albums"
+msgstr "Nedavno reprodukovani albumi"
+
+#: id:518
+msgid "Launch"
+msgstr "Pokreni"
+
+#: id:519
+msgid "Launch in..."
+msgstr "Pokreni u..."
+
+#: id:521
+msgid "Compilations"
+msgstr "Kompilacije"
+
+#: id:522
+msgid "Remove source"
+msgstr "Ukloni izvor"
+
+#: id:523
+msgid "Switch media"
+msgstr "Promjeni medij"
+
+#: id:524
+msgid "Select playlist"
+msgstr "Izaberite spisak za reprodukciju"
+
+#: id:525
+msgid "New playlist..."
+msgstr "Novi spisak za reprodukciju..."
+
+#: id:526
+msgid "Add to playlist"
+msgstr "Dodaj u spisak za reprodukciju"
+
+#: id:527
+msgid "Manually add to library"
+msgstr "Ručno dodajte u biblioteku"
+
+#: id:528
+msgid "Enter title"
+msgstr "Unesite naslov"
+
+#: id:529
+msgid "Error: Duplicate title"
+msgstr "Greška: Dupliran naslov"
+
+#: id:530
+msgid "Select genre"
+msgstr "Izaberite žanr"
+
+#: id:531
+msgid "New genre"
+msgstr "Novi žanr"
+
+#: id:532
+msgid "Manual addition"
+msgstr "Ručno dodavanje"
+
+#: id:533
+msgid "Enter genre"
+msgstr "Unesite žanr"
+
+#: id:534
+msgid "View: %s"
+msgstr "Prikaz: %s"
+
+#: id:535
+msgid "List"
+msgstr "Spisak"
+
+#: id:536
+msgid "Icons"
+msgstr "Ikone"
+
+#: id:537
+msgid "Big list"
+msgstr "Vel. spis."
+
+#: id:538
+msgid "Big icons"
+msgstr "Vel. ikone"
+
+#: id:539
+msgid "Wide"
+msgstr "Široki"
+
+#: id:540
+msgid "Big wide"
+msgstr "Veoma široki"
+
+#: id:541
+msgid "Album icons"
+msgstr "Ikone albuma"
+
+#: id:542
+msgid "DVD icons"
+msgstr "DVD ikone"
+
+#: id:543
+msgctxt "Auto context with id 543"
+msgid "DVD"
+msgstr "DVD"
+
+#: id:544
+msgctxt "Auto context with id 544"
+msgid "Media info"
+msgstr "Podaci o mediju"
+
+#: id:545
+msgid "Audio output device"
+msgstr "Zvučni izlazni uređaj"
+
+#: id:546
+msgid "Passthrough output device"
+msgstr "Prolazni izlazni uređaj"
+
+#: id:547
+msgid "No biography for this artist"
+msgstr "Ovaj izvođač nema popunjenu biografiju"
+
+#: id:548
+msgid "Downmix multichannel audio to stereo"
+msgstr "Pretvori višekanalni zvuk u stereo"
+
+#: id:550
+msgid "Sort by: %s"
+msgstr "Složi po: %s"
+
+#: id:551
+msgctxt "Auto context with id 551"
+msgid "Name"
+msgstr "Ime"
+
+#: id:552
+msgid "Date"
+msgstr "Datum"
+
+#: id:553
+msgid "Size"
+msgstr "Velič."
+
+#: id:554
+msgid "Track"
+msgstr "Numera"
+
+#: id:555
+msgid "Time"
+msgstr "Trajanje"
+
+#: id:556
+msgctxt "Auto context with id 556"
+msgid "Title"
+msgstr "Naslov"
+
+#: id:557
+msgid "Artist"
+msgstr "Izvođač"
+
+#: id:558
+msgid "Album"
+msgstr "Album"
+
+#: id:559
+msgid "Playlist"
+msgstr "Spisak za rep."
+
+#: id:560
+msgid "ID"
+msgstr "ID"
+
+#: id:561
+msgctxt "Auto context with id 561"
+msgid "File"
+msgstr "Datote."
+
+#: id:562
+msgctxt "Auto context with id 562"
+msgid "Year"
+msgstr "Godina"
+
+#: id:563
+msgid "Rating"
+msgstr "Ocjena"
+
+#: id:564
+msgctxt "Auto context with id 564"
+msgid "Type"
+msgstr "Tip"
+
+#: id:565
+msgid "Usage"
+msgstr "Koriš."
+
+#: id:566
+msgid "Album artist"
+msgstr "Izvođač na albumu"
+
+#: id:567
+msgid "Play count"
+msgstr "Broj reprodukcija"
+
+#: id:568
+msgid "Last played"
+msgstr "Poslednja reprodukcija"
+
+#: id:569
+msgctxt "Auto context with id 569"
+msgid "Comment"
+msgstr "Komentar"
+
+#: id:570
+msgid "Date added"
+msgstr "Datum dodavanja"
+
+#: id:571
+msgctxt "Auto context with id 571"
+msgid "Default"
+msgstr "Podrazumjevano"
+
+#: id:572
+msgid "Studio"
+msgstr "Studio"
+
+#: id:573
+msgid "Path"
+msgstr "Putanja"
+
+#: id:574
+msgctxt "Auto context with id 574"
+msgid "Country"
+msgstr ""
+
+#: id:575
+msgid "In progress"
+msgstr ""
+
+#: id:576
+msgid "Times played"
+msgstr ""
+
+#: id:580
+msgid "Sort direction"
+msgstr "Smer slaganja"
+
+#: id:581
+msgid "Sort method"
+msgstr "Način slaganja"
+
+#: id:582
+msgctxt "Auto context with id 582"
+msgid "View mode"
+msgstr "Režim prikaza"
+
+#: id:583
+msgid "Remember views for different folders"
+msgstr "Zapamti prikaze različitih fascikli"
+
+#: id:584
+msgid "Ascending"
+msgstr "Uzlazno"
+
+#: id:585
+msgid "Descending"
+msgstr "Silazno"
+
+#: id:586
+msgid "Edit playlist"
+msgstr "Uredi spisak za rep."
+
+#: id:587
+msgid "Filter"
+msgstr "Filter"
+
+#: id:588
+msgid "Cancel party mode"
+msgstr "Otkaži režim žurke"
+
+#: id:589
+msgid "Party mode"
+msgstr "Režim žurke"
+
+#: id:590
+msgid "Random"
+msgstr "Nasumično"
+
+#: id:591
+msgctxt "Auto context with id 591"
+msgid "Off"
+msgstr "Isklj."
+
+#: id:592
+msgid "One"
+msgstr "Jednom"
+
+#: id:593
+msgid "All"
+msgstr "Sve"
+
+#: id:594
+msgctxt "Auto context with id 594"
+msgid "Off"
+msgstr "Isklj."
+
+#: id:595
+msgid "Repeat: Off"
+msgstr "Ponovi: Isklj."
+
+#: id:596
+msgid "Repeat: One"
+msgstr "Ponovi: Jednom"
+
+#: id:597
+msgid "Repeat: All"
+msgstr "Ponovi: Sve"
+
+#: id:600
+msgid "Rip audio CD"
+msgstr "Ripuj muzički CD"
+
+#: id:601
+msgctxt "Auto context with id 601"
+msgid "Medium"
+msgstr "Srednje"
+
+#: id:602
+msgctxt "Auto context with id 602"
+msgid "Standard"
+msgstr "Uobičajeno"
+
+#: id:603
+msgid "Extreme"
+msgstr "Ekstremno"
+
+#: id:604
+msgid "Constant bitrate"
+msgstr "Nepromjenljiva brzina"
+
+#: id:605
+msgid "Ripping..."
+msgstr "Ripovanje..."
+
+#: id:607
+msgid "To:"
+msgstr "Za:"
+
+#: id:608
+msgid "Could not rip CD or track"
+msgstr "Nije moguće ripovati CD ili numeru"
+
+#: id:609
+msgid "CDDARipPath is not set."
+msgstr "CDDARipPath nije postavljen."
+
+#: id:610
+msgid "Rip audio track"
+msgstr "Ripuj muzičku numeru"
+
+#: id:611
+msgid "Enter number"
+msgstr "Unesite broj"
+
+#: id:612
+msgid "Bits/Sample"
+msgstr ""
+
+#: id:613
+msgid "Sample Frequency"
+msgstr ""
+
+#: id:620
+msgid "Audio CDs"
+msgstr "Muzički CD-ovi"
+
+#: id:621
+msgid "Encoder"
+msgstr "Koder"
+
+#: id:622
+msgid "Quality"
+msgstr "Kvalitet"
+
+#: id:623
+msgid "Bitrate"
+msgstr "Brzina protoka"
+
+#: id:624
+msgid "Include track number"
+msgstr "Uključi broj numere"
+
+#: id:625
+msgid "All songs of"
+msgstr "Sve pjesme od"
+
+#: id:629
+msgctxt "Auto context with id 629"
+msgid "View mode"
+msgstr "Režim prikaza"
+
+#: id:630
+msgctxt "Auto context with id 630"
+msgid "Normal"
+msgstr "Normalan"
+
+#: id:631
+msgid "Zoom"
+msgstr "Uveličan"
+
+#: id:632
+msgid "Stretch 4:3"
+msgstr "Razvučeno 4:3"
+
+#: id:633
+msgid "Wide Zoom"
+msgstr "Razvučeno 14:9"
+
+#: id:634
+msgid "Stretch 16:9"
+msgstr "Razvučeno 16:9"
+
+#: id:635
+msgid "Original Size"
+msgstr "Prvobitna veličina"
+
+#: id:636
+msgctxt "Auto context with id 636"
+msgid "Custom"
+msgstr "Prilagođeno"
+
+#: id:637
+msgid "Replay gain"
+msgstr "Normalizacija"
+
+#: id:638
+msgid "Replaygain volume adjustments"
+msgstr "Podeš. glasnoće normaliz. zvuka"
+
+#: id:639
+msgid "Use track levels"
+msgstr "Koristi na nivou numere"
+
+#: id:640
+msgid "Use album levels"
+msgstr "Koristi na nivou albuma"
+
+#: id:641
+msgid "PreAmp Level - Replay gained files"
+msgstr "Nivo predpojačanja - sa normalizacijom datoteka"
+
+#: id:642
+msgid "PreAmp Level - Non replay gained files"
+msgstr "Nivo predpojačanja - bez normalizacije datoteka"
+
+#: id:643
+msgid "Avoid clipping on replay gained files"
+msgstr "Izbjegni isječke pri normalizaciji datoteka"
+
+#: id:644
+msgid "Crop black bars"
+msgstr "Isjeci crne trake"
+
+#: id:645
+msgid "Need to unpack a big file. Continue?"
+msgstr "Potrebno je raspakivanje velike datoteke. Nastaviti?"
+
+#: id:646
+msgid "Remove from library"
+msgstr "Ukloni iz biblioteke"
+
+#: id:647
+msgid "Export video library"
+msgstr "Izvezi biblioteku filmova"
+
+#: id:648
+msgid "Import video library"
+msgstr "Uvezi biblioteku filmova"
+
+#: id:649
+msgid "Importing"
+msgstr "Uvoz je u toku"
+
+#: id:650
+msgid "Exporting"
+msgstr "Izvoz je u toku"
+
+#: id:651
+msgid "Browse for library"
+msgstr "Potraži biblioteku"
+
+#: id:652
+msgid "Years"
+msgstr "Godina"
+
+#: id:653
+msgid "Update library"
+msgstr "Ažuriraj biblioteku"
+
+#: id:654
+msgid "Show debug info"
+msgstr "Prikaži pod. o ukla. grešaka"
+
+#: id:655
+msgid "Browse for executable"
+msgstr "Potraži izvršne datoteke"
+
+#: id:656
+msgid "Browse for playlist"
+msgstr "Potraži spisak za reprodukciju"
+
+#: id:657
+msgid "Browse for folder"
+msgstr "Potraži fasciklu"
+
+#: id:658
+msgid "Song information"
+msgstr "Podaci o pjesmi"
+
+#: id:659
+msgid "Non-linear stretch"
+msgstr "Nelinearno istezanje"
+
+#: id:660
+msgid "Volume amplification"
+msgstr "Pojačavanje zvuka"
+
+#: id:661
+msgid "Choose export folder"
+msgstr "Izaberite izlaznu fasciklu"
+
+#: id:662
+msgid "This file is no longer available."
+msgstr "Ova datoteka više nije dostupna."
+
+#: id:663
+msgid "Would you like to remove it from the library?"
+msgstr "Želite li ovo da uklonite iz biblioteke?"
+
+#: id:664
+msgid "Browse for Script"
+msgstr "Potraži skriptu"
+
+#: id:665
+msgid "Compression level"
+msgstr ""
+
+#: id:700
+msgid "Cleaning up library"
+msgstr "Čišćenje biblioteke"
+
+#: id:701
+msgid "Removing old songs from the library"
+msgstr "Uklanjanje starih pjesama iz biblioteke"
+
+#: id:702
+msgid "This path has been scanned before"
+msgstr "Ova putanja je već analizirana"
+
+#: id:705
+msgctxt "Auto context with id 705"
+msgid "Network"
+msgstr "Mreža"
+
+#: id:706
+msgid "- Server"
+msgstr "- Server"
+
+#: id:708
+msgid "Use an HTTP proxy server to access the internet"
+msgstr "Koristi posrednički HTTP server za pristup Internetu"
+
+#: id:711
+msgid "Internet Protocol (IP)"
+msgstr "Internet protokol (IP)"
+
+#: id:712
+msgid "Invalid port specified. Value must be between 1 and 65535."
+msgstr "Odredili ste neispravan priključak. Vrijednost mora biti između 1 i 65535."
+
+#: id:713
+msgid "HTTP proxy"
+msgstr "HTTP posrednik"
+
+#: id:715
+msgid "- Assignment"
+msgstr "- Zadatak"
+
+#: id:716
+msgid "Automatic (DHCP)"
+msgstr "Automatski (DHCP)"
+
+#: id:717
+msgid "Manual (Static)"
+msgstr "Ručno (statička)"
+
+#: id:719
+msgid "- IP address"
+msgstr "- IP adresa"
+
+#: id:720
+msgid "- Netmask"
+msgstr "- Mrežna maska"
+
+#: id:721
+msgid "- Default gateway"
+msgstr "- Mrežni prolaz"
+
+#: id:722
+msgid "- DNS server"
+msgstr "- DNS server"
+
+#: id:723
+msgid "Save & restart"
+msgstr "Sačuvaj i ponovo pokreni"
+
+#: id:724
+msgid "Invalid address specified. Value must be AAA.BBB.CCC.DDD"
+msgstr "Odredili ste neispravnu adresu. Vrijednost mora biti AAA.BBB.CCC.DDD"
+
+#: id:725
+msgid "with numbers between 0 and 255."
+msgstr "sa brojevima između 0 i 255."
+
+#: id:726
+msgid "Changes not saved. Continue without saving?"
+msgstr "Promjene nisu sačuvane. Nastaviti bez čuvanja?"
+
+#: id:727
+msgid "Web server"
+msgstr "Web server"
+
+#: id:728
+msgctxt "Auto context with id 728"
+msgid "FTP server"
+msgstr "FTP server"
+
+#: id:730
+msgid "- Port"
+msgstr "- Priključak"
+
+#: id:732
+msgid "Save & apply"
+msgstr "Sačuvaj i primjeni"
+
+#: id:733
+msgid "- Password"
+msgstr "- Lozinka"
+
+#: id:734
+msgid "No pass"
+msgstr "Bez lozinke"
+
+#: id:735
+msgid "- Character set"
+msgstr "- Skup znakova"
+
+#: id:736
+msgid "- Style"
+msgstr "- Stil"
+
+#: id:737
+msgid "- Colour"
+msgstr "- Boja"
+
+#: id:738
+msgctxt "Auto context with id 738"
+msgid "Normal"
+msgstr "Normalan"
+
+#: id:739
+msgid "Bold"
+msgstr "Podebljan"
+
+#: id:740
+msgid "Italics"
+msgstr "Kurziv"
+
+#: id:741
+msgid "Bold italics"
+msgstr "Podebljani kurziv"
+
+#: id:742
+msgctxt "Auto context with id 742"
+msgid "White"
+msgstr "Bijela"
+
+#: id:743
+msgctxt "Auto context with id 743"
+msgid "Yellow"
+msgstr "Žuta"
+
+#: id:744
+msgctxt "Auto context with id 744"
+msgid "Files"
+msgstr "Datoteke"
+
+#: id:745
+msgid "No scanned information for this view"
+msgstr "Nema analiziranih podataka za ovaj prikaz"
+
+#: id:746
+msgid "Please turn off library mode"
+msgstr "Molimo, isključite režim biblioteke"
+
+#: id:747
+msgid "Error loading image"
+msgstr "Greška učitavanja slike"
+
+#: id:748
+msgid "Edit path"
+msgstr "Uredi putanju"
+
+#: id:749
+msgid "Mirror image"
+msgstr "Kopija slike"
+
+#: id:750
+msgid "Are you sure?"
+msgstr "Da li ste sigurni?"
+
+#: id:751
+msgid "Removing source"
+msgstr "Uklanjanje izvora"
+
+#: id:754
+msgid "Add program link"
+msgstr "Dodaj vezu ka programu"
+
+#: id:755
+msgid "Edit program path"
+msgstr "Uredi putanju programa"
+
+#: id:756
+msgid "Edit program name"
+msgstr "Uredi ime programa"
+
+#: id:757
+msgid "Edit path depth"
+msgstr "Uredi dubinu putanje"
+
+#: id:759
+msgid "View: Big list"
+msgstr "Prikaz: Vel. spisak"
+
+#: id:760
+msgctxt "Auto context with id 760"
+msgid "Yellow"
+msgstr "Žuta"
+
+#: id:761
+msgctxt "Auto context with id 761"
+msgid "White"
+msgstr "Bijela"
+
+#: id:762
+msgid "Blue"
+msgstr "Plava"
+
+#: id:763
+msgid "Bright green"
+msgstr "Svjetlo zelena"
+
+#: id:764
+msgid "Yellow green"
+msgstr "Žutozelena"
+
+#: id:765
+msgid "Cyan"
+msgstr "Azurno plava"
+
+#: id:766
+msgid "Light grey"
+msgstr "Svjetlo siva"
+
+#: id:767
+msgid "Grey"
+msgstr "Siva"
+
+#: id:770
+msgid "Error %i: share not available"
+msgstr "Greška %i: dijeljenje nije dostupno"
+
+#: id:772
+msgctxt "Auto context with id 772"
+msgid "Audio output"
+msgstr "Zvučni izlaz"
+
+#: id:773
+msgid "Seeking"
+msgstr "Pozicioniranje"
+
+#: id:774
+msgid "Slideshow folder"
+msgstr "Fascikla reprod. slajdova"
+
+#: id:775
+msgid "Network interface"
+msgstr "Mrežni interfejs"
+
+#: id:776
+msgid "- Wireless network name (ESSID)"
+msgstr "- Ime bežične mreže (ESSID)"
+
+#: id:777
+msgid "- Wireless password"
+msgstr "- Lozinka za pristup bežičnoj mreži"
+
+#: id:778
+msgid "- Wireless security"
+msgstr "- Sigurnost bežične mreže"
+
+#: id:779
+msgid "Save and apply network interface settings"
+msgstr "Sačuvaj i primjeni postavke mrežnog intrefejsa"
+
+#: id:780
+msgid "No encryption"
+msgstr "Bez zaštite"
+
+#: id:781
+msgid "WEP"
+msgstr "WEP"
+
+#: id:782
+msgid "WPA"
+msgstr "WPA"
+
+#: id:783
+msgid "WPA2"
+msgstr "WPA2"
+
+#: id:784
+msgid "Applying network interface settings. Please wait."
+msgstr "Primjenjivanje postavki mrežnog interfejsa. Molimo sačekajte."
+
+#: id:785
+msgid "Network interface restarted successfully."
+msgstr "Uspješno je obavljeno ponovno pokretanje mrežnog interfejsa."
+
+#: id:786
+msgid "Network interface did not start successfully."
+msgstr "Nije uspjelo pokretanje mrežnog interfejsa."
+
+#: id:787
+msgid "Interface disabled"
+msgstr "Interfejs je onemogućen"
+
+#: id:788
+msgid "Network interface disabled successfully."
+msgstr "Uspješno je onemogućen mrežni interfejs."
+
+#: id:789
+msgid "Wireless network name (ESSID)"
+msgstr "Ime bežične mreže (ESSID)"
+
+#: id:790
+msgid "Remote control"
+msgstr ""
+
+#: id:791
+msgid "Allow programs on this system to control XBMC"
+msgstr "Dozvoli programima na ovom sistemu da upravljaju XBMC-om"
+
+#: id:792
+msgctxt "Auto context with id 792"
+msgid "Port"
+msgstr "Priključak"
+
+#: id:793
+msgid "Port range"
+msgstr "Opseg priključaka"
+
+#: id:794
+msgid "Allow programs on other systems to control XBMC"
+msgstr "Dozvoli programima sa drugih sistema da upravljaju XBMC-om"
+
+#: id:795
+msgid "Initial repeat delay (ms)"
+msgstr "Inicijalno kašnjenje ponavljanja (ms)"
+
+#: id:796
+msgid "Continuous repeat delay (ms)"
+msgstr "Neprekidno kašnjenje ponavljanja (ms)"
+
+#: id:797
+msgid "Maximum number of clients"
+msgstr "Maksimalan broj klijenata"
+
+#: id:798
+msgid "Internet access"
+msgstr "Pristup Internetu"
+
+#: id:850
+msgid "Invalid port number entered"
+msgstr "Uneli ste pogrešan broj priključka"
+
+#: id:851
+msgid "Valid port range is 1-65535"
+msgstr "Ispravan opseg priključaka je od 1 do 65535"
+
+#: id:852
+msgid "Valid port range is 1024-65535"
+msgstr "Ispravan opseg priključaka je od 1024 do 65535"
+
+#: id:998
+msgid "Add Music..."
+msgstr ""
+
+#: id:999
+msgid "Add Videos..."
+msgstr ""
+
+#: id:1000
+msgid "- Preview"
+msgstr "Pregled čuvara ekrana"
+
+#: id:1001
+msgid "Unable to connect"
+msgstr "Nije moguće povezivanje"
+
+#: id:1002
+msgid "XBMC was unable to connect to the network location."
+msgstr "XBMC nije uspeo da se poveže na mrežnu lokaciju."
+
+#: id:1003
+msgid "This could be due to the network not being connected."
+msgstr "Razlog ovome može biti da mreža nije povezana."
+
+#: id:1004
+msgid "Would you like to add it anyway?"
+msgstr "Da li i dalje želite da je dodate?"
+
+#: id:1006
+msgctxt "Auto context with id 1006"
+msgid "IP address"
+msgstr "IP adresa"
+
+#: id:1007
+msgid "Add network location"
+msgstr "Dodaj mrežnu lokaciju"
+
+#: id:1008
+msgid "Protocol"
+msgstr "Protokol"
+
+#: id:1009
+msgid "Server address"
+msgstr "Adresa servera"
+
+#: id:1010
+msgid "Server name"
+msgstr "Ime servera"
+
+#: id:1011
+msgid "Remote path"
+msgstr "Udaljena putanja"
+
+#: id:1012
+msgid "Shared folder"
+msgstr "Dijeljena fascikla"
+
+#: id:1013
+msgctxt "Auto context with id 1013"
+msgid "Port"
+msgstr "Priključak"
+
+#: id:1014
+msgctxt "Auto context with id 1014"
+msgid "Username"
+msgstr "Korisničko ime"
+
+#: id:1015
+msgid "Browse for network server"
+msgstr "Potraži mrežni server"
+
+#: id:1016
+msgid "Enter the network address of the server"
+msgstr "Unesite mrežnu adresu servera"
+
+#: id:1017
+msgid "Enter the path on the server"
+msgstr "Unesite putanju na serveru"
+
+#: id:1018
+msgid "Enter the port number"
+msgstr "Unesite broj priključka"
+
+#: id:1019
+msgid "Enter the username"
+msgstr "Unesite korisničko ime"
+
+#: id:1020
+msgid "Add %s source"
+msgstr "Dodaj %s izvor"
+
+#: id:1021
+msgid "Enter the paths or browse for the media locations."
+msgstr "Unesite putanje ili potražite lokacije medija."
+
+#: id:1022
+msgid "Enter a name for this media Source."
+msgstr "Unesite ime za ovaj izvor medija."
+
+#: id:1023
+msgid "Browse for new share"
+msgstr "Potraži novo dijeljenje"
+
+#: id:1024
+msgid "Browse"
+msgstr "Potraži"
+
+#: id:1025
+msgid "Could not retrieve directory information."
+msgstr "Nije moguće preuzeti podatke direktorijuma."
+
+#: id:1026
+msgid "Add source"
+msgstr "Dodaj izvor"
+
+#: id:1027
+msgid "Edit source"
+msgstr "Uredi izvor"
+
+#: id:1028
+msgid "Edit %s source"
+msgstr "Uredi %s izvor"
+
+#: id:1029
+msgid "Enter the new label"
+msgstr "Unesi novu oznaku"
+
+#: id:1030
+msgid "Browse for image"
+msgstr "Potraži sliku"
+
+#: id:1031
+msgid "Browse for image folder"
+msgstr "Potraži fasciklu sa slikama"
+
+#: id:1032
+msgid "Add network location..."
+msgstr "Dodaj mrežnu lokaciju..."
+
+#: id:1033
+msgid "Browse for file"
+msgstr "Potraži datoteku"
+
+#: id:1034
+msgid "Submenu"
+msgstr "Podmeni"
+
+#: id:1035
+msgid "Enable submenu buttons"
+msgstr "Omogući tastere podmenija"
+
+#: id:1036
+msgid "Favourites"
+msgstr "Omiljeno"
+
+#: id:1037
+msgid "Video Add-ons"
+msgstr "Dodaci za video"
+
+#: id:1038
+msgid "Music Add-ons"
+msgstr "Dodaci za muziku"
+
+#: id:1039
+msgid "Picture Add-ons"
+msgstr "Dodaci za sliku"
+
+#: id:1040
+msgid "Loading directory"
+msgstr "Učitavanje direktorijuma"
+
+#: id:1041
+msgid "Retrieved %i items"
+msgstr "Primljeno %i stavki"
+
+#: id:1042
+msgid "Retrieved %i of %i items"
+msgstr "Primljeno %i od %i stavki"
+
+#: id:1043
+msgid "Program Add-ons"
+msgstr "Dodaci za program"
+
+#: id:1044
+msgid "Set plugin thumb"
+msgstr "Postavi sličicu dodatka"
+
+#: id:1045
+msgid "Add-on settings"
+msgstr "Postavke dodatka"
+
+#: id:1046
+msgid "Access points"
+msgstr "Pristupna tačka"
+
+#: id:1047
+msgid "Other..."
+msgstr "Ostalo..."
+
+#: id:1048
+msgid "- Username"
+msgstr "- Korisničko ime"
+
+#: id:1049
+msgid "Script settings"
+msgstr "Postavke skripte"
+
+#: id:1050
+msgid "Singles"
+msgstr "Pojedinačni"
+
+#: id:1051
+msgid "Enter web address"
+msgstr "Unesite internet adresu"
+
+#: id:1200
+msgid "SMB client"
+msgstr "SMB klijent"
+
+#: id:1202
+msgid "Workgroup"
+msgstr "Radna grupa"
+
+#: id:1203
+msgid "Default username"
+msgstr "Podrazumjevano korisničko ime"
+
+#: id:1204
+msgid "Default password"
+msgstr "Podrazumjevana lozinka"
+
+#: id:1207
+msgid "WINS server"
+msgstr "WINS server"
+
+#: id:1208
+msgid "Mount SMB shares"
+msgstr "Podigni SMB deljenja"
+
+#: id:1210
+msgctxt "Auto context with id 1210"
+msgid "Remove"
+msgstr "Ukloni"
+
+#: id:1211
+msgctxt "Auto context with id 1211"
+msgid "Music"
+msgstr "Muzika"
+
+#: id:1212
+msgctxt "Auto context with id 1212"
+msgid "Video"
+msgstr "Filmovi"
+
+#: id:1213
+msgctxt "Auto context with id 1213"
+msgid "Pictures"
+msgstr "Slike"
+
+#: id:1214
+msgctxt "Auto context with id 1214"
+msgid "Files"
+msgstr "Datoteke"
+
+#: id:1215
+msgctxt "Auto context with id 1215"
+msgid "Music & video"
+msgstr "Muzika i filmovi"
+
+#: id:1216
+msgid "Music & pictures"
+msgstr "Muzika i slike"
+
+#: id:1217
+msgid "Music & files"
+msgstr "Muzika i datoteke"
+
+#: id:1218
+msgid "Video & pictures"
+msgstr "Filmovi i slike"
+
+#: id:1219
+msgid "Video & files"
+msgstr "Filmovi i datoteke"
+
+#: id:1220
+msgid "Pictures & files"
+msgstr "Slike i datoteke"
+
+#: id:1221
+msgid "Music & video & pictures"
+msgstr "Muzika, filmovi i slike"
+
+#: id:1222
+msgid "Music & video & pictures & files"
+msgstr "Muzika, filmovi, slike i datoteke"
+
+#: id:1223
+msgctxt "Auto context with id 1223"
+msgid "Disabled"
+msgstr "Onemogućeno"
+
+#: id:1226
+msgid "Files & music & video"
+msgstr "Datoteke, muzika i filmovi"
+
+#: id:1227
+msgid "Files & pictures & music"
+msgstr "Datoteke, slike i muzika"
+
+#: id:1228
+msgid "Files & pictures & video"
+msgstr "Datoteke, slike i filmovi"
+
+#: id:1229
+msgid "Music & programs"
+msgstr "Muzika i programi"
+
+#: id:1230
+msgid "Video & programs"
+msgstr "Filmovi i programi"
+
+#: id:1231
+msgid "Pictures & programs"
+msgstr "Slike i programi"
+
+#: id:1232
+msgid "Music & video & pictures & programs"
+msgstr "Muzika, filmovi, slike i programi"
+
+#: id:1233
+msgid "Programs & video & music"
+msgstr "Programi, filmovi i muzika"
+
+#: id:1234
+msgid "Programs & pictures & music"
+msgstr "Programi, slike i muzika"
+
+#: id:1235
+msgid "Programs & pictures & video"
+msgstr "Programi, slike i filmovi"
+
+#: id:1250
+msgid "Auto-detection"
+msgstr "Autom. otkrivanje"
+
+#: id:1251
+msgid "Auto-detect system"
+msgstr "Autom. otkrivanje sistema"
+
+#: id:1252
+msgid "Nickname"
+msgstr "Nadimak"
+
+#: id:1254
+msgid "Ask to connect"
+msgstr "Pitaj za povezivanje"
+
+#: id:1255
+msgid "Send FTP user and password"
+msgstr "Pošalji FTP korisničko ime i lozinku"
+
+#: id:1256
+msgid "Ping interval"
+msgstr "Interval probnog signala"
+
+#: id:1257
+msgid "Would you like to connect to the auto-detected system?"
+msgstr "Želite li da se povežete sa autom. otkrivanjem sistema?"
+
+#: id:1259
+msgid "Zeroconf"
+msgstr ""
+
+#: id:1260
+msgid "Announce these services to other systems via Zeroconf"
+msgstr "Oglasi ove usluge ostalim sistemima putem Zeroconf"
+
+#: id:1270
+msgid "Allow XBMC to receive AirPlay content"
+msgstr ""
+
+#: id:1271
+msgid "Device name"
+msgstr ""
+
+#: id:1272
+msgid "- Use password protection"
+msgstr ""
+
+#: id:1273
+msgid "AirPlay"
+msgstr ""
+
+#: id:1300
+msgid "Custom audio device"
+msgstr "Prilagođen zvučni uređaj"
+
+#: id:1301
+msgid "Custom passthrough device"
+msgstr "Prilagođen prolazni uređaj"
+
+#: id:1396
+msgid "Drifting"
+msgstr "klizavo"
+
+#: id:1397
+msgid "and"
+msgstr "i"
+
+#: id:1398
+msgid "Freezing"
+msgstr "poledica"
+
+#: id:1399
+msgid "Late"
+msgstr "zakašnjeli"
+
+#: id:1400
+msgid "Isolated"
+msgstr "izolovani"
+
+#: id:1401
+msgid "Thundershowers"
+msgstr "pljuskovi sa grmljavinom"
+
+#: id:1402
+msgid "Thunder"
+msgstr "grmljavina"
+
+#: id:1403
+msgctxt "Auto context with id 1403"
+msgid "Sun"
+msgstr "sunčano"
+
+#: id:1404
+msgid "Heavy"
+msgstr "jak(a)"
+
+#: id:1405
+msgid "in"
+msgstr "u"
+
+#: id:1406
+msgid "the"
+msgstr ""
+
+#: id:1407
+msgid "Vicinity"
+msgstr "blizini"
+
+#: id:1408
+msgid "Ice"
+msgstr "led"
+
+#: id:1409
+msgid "Crystals"
+msgstr "kristali"
+
+#: id:1410
+msgid "Calm"
+msgstr "blago"
+
+#: id:1411
+msgid "with"
+msgstr "sa"
+
+#: id:1412
+msgid "windy"
+msgstr "vjetrovito"
+
+#: id:1413
+msgid "drizzle"
+msgstr "rosulja kupusara"
+
+#: id:1414
+msgid "Thunderstorm"
+msgstr "oluja"
+
+#: id:1415
+msgid "Drizzle"
+msgstr "rosulja kupusarka"
+
+#: id:1416
+msgid "Foggy"
+msgstr "maglovito"
+
+#: id:1417
+msgid "Grains"
+msgstr "grad"
+
+#: id:1418
+msgid "T-Storms"
+msgstr "oluje"
+
+#: id:1419
+msgid "T-Showers"
+msgstr "pljuskovi sa grmljavinom"
+
+#: id:1420
+msgid "Moderate"
+msgstr ""
+
+#: id:1421
+msgid "Very High"
+msgstr ""
+
+#: id:1422
+msgid "Windy"
+msgstr ""
+
+#: id:1423
+msgid "Mist"
+msgstr ""
+
+#: id:1450
+msgid "Put display to sleep when idle"
+msgstr "Postavi ekran „na spavanje“, kada se ne koristi"
+
+#: id:2050
+msgid "Runtime"
+msgstr "Trajanje"
+
+#: id:2100
+msgid "Script failed! : %s"
+msgstr "Skripta je „pukla“! : %s"
+
+#: id:2101
+msgid "Newer version needed - See log"
+msgstr ""
+
+#: id:4501
+msgid "Enable LCD/VFD"
+msgstr "Omogući LCD/VFD"
+
+#: id:10000
+msgid "Home"
+msgstr "Početna strana"
+
+#: id:10001
+msgctxt "Auto context with id 10001"
+msgid "Programs"
+msgstr "Programi"
+
+#: id:10002
+msgctxt "Auto context with id 10002"
+msgid "Pictures"
+msgstr "Slike"
+
+#: id:10003
+msgctxt "Auto context with id 10003"
+msgid "File manager"
+msgstr "Upr. datotekama"
+
+#: id:10004
+msgctxt "Auto context with id 10004"
+msgid "Settings"
+msgstr "Postavke"
+
+#: id:10005
+msgctxt "Auto context with id 10005"
+msgid "Music"
+msgstr "Muzika"
+
+#: id:10006
+msgctxt "Auto context with id 10006"
+msgid "Videos"
+msgstr "Filmovi"
+
+#: id:10007
+msgid "System information"
+msgstr "Podaci o sistemu"
+
+#: id:10008
+msgid "Settings - General"
+msgstr "Postavke - Opšte"
+
+#: id:10009
+msgid "Settings - Screen"
+msgstr "Postavke - Ekran"
+
+#: id:10010
+msgid "Settings - Appearance - GUI Calibration"
+msgstr "Postavke - Izgled - GUI kalibracija"
+
+#: id:10011
+msgid "Settings - Videos - Screen Calibration"
+msgstr "Postavke - Filmovi - Kalibracija ekrana"
+
+#: id:10012
+msgid "Settings - Pictures"
+msgstr "Postavke - Slike"
+
+#: id:10013
+msgid "Settings - Programs"
+msgstr "Postavke - Programi"
+
+#: id:10014
+msgid "Settings - Weather"
+msgstr "Postavke - Vremenska prognoza"
+
+#: id:10015
+msgid "Settings - Music"
+msgstr "Postavke - Muzika"
+
+#: id:10016
+msgid "Settings - System"
+msgstr "Postavke - Sistem"
+
+#: id:10017
+msgid "Settings - Videos"
+msgstr "Postavke - Filmovi"
+
+#: id:10018
+msgid "Settings - Network"
+msgstr "Postavke - Mreža"
+
+#: id:10019
+msgid "Settings - Appearance"
+msgstr "Postavke - Izgled"
+
+#: id:10020
+msgctxt "Auto context with id 10020"
+msgid "Scripts"
+msgstr "Skripte"
+
+#: id:10021
+msgid "Web Browser"
+msgstr "Čitač internet strana"
+
+#: id:10025
+msgctxt "Auto context with id 10025"
+msgid "Videos"
+msgstr ""
+
+#: id:10028
+msgid "Videos/Playlist"
+msgstr "Filmovi/Spisak za rep."
+
+#: id:10029
+msgctxt "Auto context with id 10029"
+msgid "Login screen"
+msgstr ""
+
+#: id:10034
+msgid "Settings - Profiles"
+msgstr "Postavke - Profili"
+
+#: id:10040
+msgid "Addon browser"
+msgstr ""
+
+#: id:10100
+msgid "Yes/No dialog"
+msgstr "Da/Ne prozor"
+
+#: id:10101
+msgid "Progress dialog"
+msgstr "Prozor napretka"
+
+#: id:10210
+msgid "Looking for subtitles..."
+msgstr "Traženje titlova..."
+
+#: id:10211
+msgid "Looking for or caching subtitles..."
+msgstr "Traženje titlova u kešu..."
+
+#: id:10212
+msgid "terminating"
+msgstr "prekidanje"
+
+#: id:10213
+msgid "buffering"
+msgstr "predmemorisanje"
+
+#: id:10214
+msgid "Opening stream"
+msgstr "Otvaranje zapisa"
+
+#: id:10500
+msgid "Music/Playlist"
+msgstr "Muzika/Spisak za reprod."
+
+#: id:10501
+msgid "Music/Files"
+msgstr "Muzika/Datoteke"
+
+#: id:10502
+msgid "Music/Library"
+msgstr "Muzika/Biblioteka"
+
+#: id:10503
+msgid "Playlist editor"
+msgstr "Uređivač spiska za reprodukciju"
+
+#: id:10504
+msgid "Top 100 songs"
+msgstr "100 najboljih pjesama"
+
+#: id:10505
+msgid "Top 100 albums"
+msgstr "100 najboljih albuma"
+
+#: id:10506
+msgctxt "Auto context with id 10506"
+msgid "Programs"
+msgstr "Programi"
+
+#: id:10507
+msgid "Configuration"
+msgstr "Konfiguracija"
+
+#: id:10508
+msgid "Weather forecast"
+msgstr "Vremenska prognoza"
+
+#: id:10509
+msgid "Network gaming"
+msgstr "Mrežno igranje"
+
+#: id:10510
+msgid "Extensions"
+msgstr "Proširenja"
+
+#: id:10511
+msgctxt "Auto context with id 10511"
+msgid "System info"
+msgstr "Podaci o sistemu"
+
+#: id:10516
+msgid "Music - Library"
+msgstr "Muzička bibliote."
+
+#: id:10517
+msgid "Now Playing - Music"
+msgstr "Trenutna reprodukcija - Muzika"
+
+#: id:10522
+msgid "Now Playing - Videos"
+msgstr "Trenutna reprodukcija - Film"
+
+#: id:10523
+msgid "Album info"
+msgstr "Podaci o albumu"
+
+#: id:10524
+msgid "Movie info"
+msgstr "Podaci o filmu"
+
+#: id:12000
+msgid "Select dialog"
+msgstr "Izaberite dijalog"
+
+#: id:12001
+msgid "Music/Info"
+msgstr "Muzika/Podaci"
+
+#: id:12002
+msgid "Dialog OK"
+msgstr "Dijalog u redu"
+
+#: id:12003
+msgid "Videos/Info"
+msgstr "Filmovi/Podaci"
+
+#: id:12004
+msgid "Scripts/Info"
+msgstr "Skripte/Podaci"
+
+#: id:12005
+msgid "Fullscreen video"
+msgstr "Film preko čitavog ekrana"
+
+#: id:12006
+msgid "Audio visualization"
+msgstr "Vizualizacija zvuka"
+
+#: id:12008
+msgid "File stacking dialog"
+msgstr "Dijalog slaganja datoteka"
+
+#: id:12009
+msgid "Rebuild index..."
+msgstr "Reindeksiranje..."
+
+#: id:12010
+msgid "Return to music window"
+msgstr "Povratak na prozor sa muzikom"
+
+#: id:12011
+msgid "Return to videos window"
+msgstr "Povratak na prozor sa filmovima"
+
+#: id:12021
+msgid "Start from beginning"
+msgstr "Počni ispočetka"
+
+#: id:12022
+msgid "Resume from %s"
+msgstr "Nastavi od %s"
+
+#: id:12310
+msgid "0"
+msgstr "0"
+
+#: id:12311
+msgid "1"
+msgstr "1"
+
+#: id:12312
+msgid "2"
+msgstr "2"
+
+#: id:12313
+msgid "3"
+msgstr "3"
+
+#: id:12314
+msgid "4"
+msgstr "4"
+
+#: id:12315
+msgid "5"
+msgstr "5"
+
+#: id:12316
+msgid "6"
+msgstr "6"
+
+#: id:12317
+msgid "7"
+msgstr "7"
+
+#: id:12318
+msgid "8"
+msgstr "8"
+
+#: id:12319
+msgid "9"
+msgstr "9"
+
+#: id:12320
+msgid "c"
+msgstr "c"
+
+#: id:12321
+msgid "Ok"
+msgstr "U redu"
+
+#: id:12322
+msgid "*"
+msgstr "*"
+
+#: id:12325
+msgid "Locked! Enter code..."
+msgstr "Zaključano! Unesite kôd..."
+
+#: id:12326
+msgid "Enter password"
+msgstr "Unesite lozinku"
+
+#: id:12327
+msgid "Enter master code"
+msgstr "Unesite glavni kôd"
+
+#: id:12328
+msgid "Enter unlock code"
+msgstr "Unesite kôd za otključavanje"
+
+#: id:12329
+msgid "or press C to cancel"
+msgstr "ili pritisnite C za otkazivanje"
+
+#: id:12330
+msgid "Enter gamepad button combo and"
+msgstr "Unesite kombinaciju tastera upravljača za igre"
+
+#: id:12331
+msgid "press OK, or Back to cancel"
+msgstr "i pritisnite Start, ili Nazad za otkazivanje"
+
+#: id:12332
+msgid "Set lock"
+msgstr "Zaključaj"
+
+#: id:12333
+msgid "Unlock"
+msgstr "Otključaj"
+
+#: id:12334
+msgid "Reset lock"
+msgstr "Poništi kôd"
+
+#: id:12335
+msgid "Remove lock"
+msgstr "Ukloni kôd"
+
+#: id:12337
+msgid "Numeric password"
+msgstr "Numerička lozinka"
+
+#: id:12338
+msgid "Gamepad button combo"
+msgstr "Kombinacija tastera upravljača za igre"
+
+#: id:12339
+msgid "Full-text password"
+msgstr "Lozinka sa svim znacima"
+
+#: id:12340
+msgid "Enter new password"
+msgstr "Unesite novu lozinku"
+
+#: id:12341
+msgid "Re-Enter new password"
+msgstr "Ponovite unos nove lozinke"
+
+#: id:12342
+msgid "Incorrect password,"
+msgstr "Lozinka nije ispravna,"
+
+#: id:12343
+msgid "retries left"
+msgstr "pokušaja su preostala"
+
+#: id:12344
+msgid "Passwords entered did not match."
+msgstr "Unijete lozinke se ne poklapaju."
+
+#: id:12345
+msgid "Access denied"
+msgstr "Pristup odbijen"
+
+#: id:12346
+msgid "Password retry limit exceeded."
+msgstr "Prekomjerni broj pokušaja unosa lozinke."
+
+#: id:12347
+msgid "The system will now shut off."
+msgstr "Sistem će sada biti isključen."
+
+#: id:12348
+msgid "Item locked"
+msgstr "Stavka je zaključana"
+
+#: id:12353
+msgid "Reactivate lock"
+msgstr "Ponovo aktiviraj kôd"
+
+#: id:12356
+msgid "Change lock"
+msgstr "Promjeni kôd"
+
+#: id:12357
+msgid "Source lock"
+msgstr "Porijeklo kôda"
+
+#: id:12358
+msgid "Password entry was blank. Try again."
+msgstr "Lozinka ne može biti prazna. Pokušajte ponovo."
+
+#: id:12360
+msgid "Master lock"
+msgstr "Glavni kôd"
+
+#: id:12362
+msgid "Shutdown system if Master Lock retries exceeded"
+msgstr "Isključi sistem ukoliko Glavni kôd više puta bude pogrešno unesen"
+
+#: id:12367
+msgid "Master code is not valid"
+msgstr "Glavni kôd nije ispravan"
+
+#: id:12368
+msgid "Please enter a valid master code"
+msgstr "Molimo, unesite ispravan glavni kôd"
+
+#: id:12373
+msgid "Settings & file manager"
+msgstr "Postavke i upr. datotekama"
+
+#: id:12376
+msgid "Set as default for all movies"
+msgstr "Postavi kao podrazumjevano za sve filmove"
+
+#: id:12377
+msgid "This will reset any previously saved values"
+msgstr "Ovo će poništiti prethodno sačuvane vrijednosti"
+
+#: id:12378
+msgid "Amount of time to display each image"
+msgstr "Vrijeme prikazivanja svake slike"
+
+#: id:12379
+msgid "Use pan and zoom effects"
+msgstr "Koristi efekat pomjeranja i uveličavanja"
+
+#: id:12383
+msgid "12 hour clock"
+msgstr "12 satni prikaz vremena"
+
+#: id:12384
+msgid "24 hour clock"
+msgstr "24 satni prikaz vremena"
+
+#: id:12385
+msgid "Day/Month"
+msgstr "Dan, pa mjesec"
+
+#: id:12386
+msgid "Month/Day"
+msgstr "Mjesec, pa dan"
+
+#: id:12390
+msgid "System uptime"
+msgstr "Sistem je aktivan"
+
+#: id:12391
+msgid "Minutes"
+msgstr "minuta"
+
+#: id:12392
+msgid "Hours"
+msgstr "sati"
+
+#: id:12393
+msgid "Days"
+msgstr "dana"
+
+#: id:12394
+msgid "Total uptime"
+msgstr "Ukupno vrijeme"
+
+#: id:12395
+msgid "Battery level"
+msgstr ""
+
+#: id:12600
+msgctxt "Auto context with id 12600"
+msgid "Weather"
+msgstr "Vremenska prognoza"
+
+#: id:12900
+msgctxt "Auto context with id 12900"
+msgid "Screensaver"
+msgstr "Čuvar ekrana"
+
+#: id:12901
+msgid "Fullscreen OSD"
+msgstr "OSD preko čitavog ekrana"
+
+#: id:13000
+msgid "System"
+msgstr "Sistem"
+
+#: id:13001
+msgid "Immediate HD spindown"
+msgstr "Neposredno HD rotiranje"
+
+#: id:13002
+msgid "Video only"
+msgstr "Samo filmovi"
+
+#: id:13003
+msgid "- Delay"
+msgstr "- Kašnjenje"
+
+#: id:13004
+msgid "- Minimum file duration"
+msgstr "- Minimalno trajanje datoteke"
+
+#: id:13005
+msgid "Shutdown"
+msgstr "Isključi"
+
+#: id:13008
+msgid "Shutdown function"
+msgstr "Akcija pri isključivanju"
+
+#: id:13009
+msgid "Quit"
+msgstr "Izađi"
+
+#: id:13010
+msgid "Hibernate"
+msgstr "Hibernacija"
+
+#: id:13011
+msgid "Suspend"
+msgstr "Stanje spavanja"
+
+#: id:13012
+msgid "Exit"
+msgstr "Izađi iz"
+
+#: id:13013
+msgid "Reboot"
+msgstr "Ponovo pokreni"
+
+#: id:13014
+msgid "Minimize"
+msgstr "Umanji"
+
+#: id:13015
+msgid "Power button action"
+msgstr "Akcija dugmeta za uključivanje"
+
+#: id:13016
+msgid "Power off System"
+msgstr ""
+
+#: id:13020
+msgid "Is another session active, perhaps over ssh?"
+msgstr "Da li je druga sesija aktivna, možda putem ssh?"
+
+#: id:13021
+msgid "Mounted removable harddrive"
+msgstr "Postavljen prenosivi čvrsti uređaj"
+
+#: id:13022
+msgid "Unsafe device removal"
+msgstr "Nesigurno uklanjanje uređaja"
+
+#: id:13023
+msgid "Successfully removed device"
+msgstr "Uspešno uklonjen uređaj"
+
+#: id:13024
+msgid "Joystick plugged"
+msgstr "Upravljačka palica je povezana"
+
+#: id:13025
+msgid "Joystick unplugged"
+msgstr "Upravljačka palica je nepovezana"
+
+#: id:13050
+msgid "Running low on battery"
+msgstr ""
+
+#: id:13100
+msgid "Flicker filter"
+msgstr "Flicker filter"
+
+#: id:13101
+msgid "Let driver choose (requires restart)"
+msgstr "Prepusti izbor uprav. programu (neophodno ponovno pokretanje)"
+
+#: id:13105
+msgid "Vertical blank sync"
+msgstr "Razmak vertikalne sinhronizacije"
+
+#: id:13106
+msgctxt "Auto context with id 13106"
+msgid "Disabled"
+msgstr "Onemogućeno"
+
+#: id:13107
+msgid "Enabled during video playback"
+msgstr "Omogućeno tokom reprodukcije filma"
+
+#: id:13108
+msgctxt "Auto context with id 13108"
+msgid "Always enabled"
+msgstr "Uvijek je omogućeno"
+
+#: id:13109
+msgid "Test & apply resolution"
+msgstr "Isprobaj i primjeni rezoluciju"
+
+#: id:13110
+msgid "Save resolution?"
+msgstr "Sačuvati rezoluciju?"
+
+#: id:13111
+msgid "Would you like to keep this resolution?"
+msgstr "Želite li da zadržite ovu rezoluciju?"
+
+#: id:13112
+msgid "High quality upscaling"
+msgstr "Visok kvalitet uvećanja"
+
+#: id:13113
+msgctxt "Auto context with id 13113"
+msgid "Disabled"
+msgstr "Onemogućen"
+
+#: id:13114
+msgid "Enabled for SD content"
+msgstr "Omogućen za SD sadržaj"
+
+#: id:13115
+msgctxt "Auto context with id 13115"
+msgid "Always enabled"
+msgstr "Uvijek je omogućen"
+
+#: id:13116
+msgid "Upscaling method"
+msgstr "Način uvećanja"
+
+#: id:13117
+msgctxt "Auto context with id 13117"
+msgid "Bicubic"
+msgstr "Bicubic"
+
+#: id:13118
+msgid "Lanczos"
+msgstr "Lanczos"
+
+#: id:13119
+msgid "Sinc"
+msgstr "Sinc"
+
+#: id:13120
+msgctxt "Auto context with id 13120"
+msgid "VDPAU"
+msgstr "VDPAU"
+
+#: id:13121
+msgid "VDPAU HQ Upscaling level"
+msgstr "VDPAU HQ Upscaling level"
+
+#: id:13122
+msgid "VDPAU Studio level color conversion"
+msgstr "VDPAU Studio level color conversion"
+
+#: id:13130
+msgid "Blank other displays"
+msgstr "Zacrni ostale ekrane"
+
+#: id:13131
+msgctxt "Auto context with id 13131"
+msgid "Disabled"
+msgstr "Onemogućeno"
+
+#: id:13132
+msgid "Blank displays"
+msgstr "Zacrni ekrane"
+
+#: id:13140
+msgid "Active connections detected!"
+msgstr "Otkrivene su aktivne veze!"
+
+#: id:13141
+msgid "If you proceed, you might not be able to control XBMC"
+msgstr "Ukoliko nastavite dalje, možda nećete moći da upravljate XBMC"
+
+#: id:13142
+msgid "any longer. Are you sure you want to stop the Event server?"
+msgstr "aplikacijom. Da li ste sigurni da želite da zaustavite Server za događaje?"
+
+#: id:13144
+msgid "Change Apple Remote mode?"
+msgstr "Promjeni Apple Remote režim?"
+
+#: id:13145
+msgid "If you are currently using the Apple Remote to control"
+msgstr "Ukoliko trenutno koristite Apple Remote da upravljate"
+
+#: id:13146
+msgid "XBMC, changing this setting might affect your ability"
+msgstr "XBMC aplikacijom, promjenom ove postavake možda promjenite"
+
+#: id:13147
+msgid "to continue controlling it. Do you want to proceed?"
+msgstr "mogućnost kontrolisanja aplikacije. Nastavljate li dalje?"
+
+#: id:13159
+msgid "Subnet mask"
+msgstr "Mrežna podmaska"
+
+#: id:13160
+msgid "Gateway"
+msgstr "Mrežni prolaz"
+
+#: id:13161
+msgid "Primary DNS"
+msgstr "Primarni DNS"
+
+#: id:13162
+msgid "Initialize failed"
+msgstr "Nije uspjela inicijalizacija"
+
+#: id:13170
+msgctxt "Auto context with id 13170"
+msgid "Never"
+msgstr "Nikada"
+
+#: id:13171
+msgid "Immediately"
+msgstr "Odmah"
+
+#: id:13172
+msgid "After %i secs"
+msgstr "Nakon %i sek."
+
+#: id:13173
+msgid "HDD install date:"
+msgstr "Datum postavljanja HDD-a:"
+
+#: id:13174
+msgid "HDD power cycle count:"
+msgstr "HDD power cycle count:"
+
+#: id:13200
+msgid "Profiles"
+msgstr "Profili"
+
+#: id:13201
+msgid "Delete profile '%s'?"
+msgstr "Izbrisati „%s“ profil?"
+
+#: id:13204
+msgid "Last loaded profile:"
+msgstr "Poslednji učitan profil:"
+
+#: id:13205
+msgid "Unknown"
+msgstr "Nepoznato"
+
+#: id:13206
+msgid "Overwrite"
+msgstr "Prepiši"
+
+#: id:13208
+msgid "Alarm clock"
+msgstr "Budilnik"
+
+#: id:13209
+msgid "Alarm clock interval (in minutes)"
+msgstr "Interval za ponovnu aktivaciju budilnika(u min.)"
+
+#: id:13210
+msgid "Started, alarm in %im"
+msgstr "Pokrenuto, alarm za %im"
+
+#: id:13211
+msgid "Alarm!"
+msgstr "Alarm!"
+
+#: id:13212
+msgid "Canceled with %im%is left"
+msgstr "Otkazano pri %imin. %isek. do kraja"
+
+#: id:13213
+msgid "%2.0fm"
+msgstr ""
+
+#: id:13214
+msgid "%2.0fs"
+msgstr ""
+
+#: id:13249
+msgid "Search for subtitles in RARs"
+msgstr "Pretraži titlove u RAR-ovima"
+
+#: id:13250
+msgid "Browse for subtitle..."
+msgstr "Potraži titl..."
+
+#: id:13251
+msgid "Move item"
+msgstr "Premjesti stavku"
+
+#: id:13252
+msgid "Move item here"
+msgstr "Premjesti stavku ovdje"
+
+#: id:13253
+msgid "Cancel move"
+msgstr "Otkaži premeštanje"
+
+#: id:13270
+msgid "Hardware:"
+msgstr "Hardver:"
+
+#: id:13271
+msgid "CPU Usage:"
+msgstr "Iskorišćenost procesora:"
+
+#: id:13274
+msgid "Connected, but no DNS is available."
+msgstr "Povezano, ali DNS nije dostupan."
+
+#: id:13275
+msgid "Hard Disk"
+msgstr "Čvrsti disk"
+
+#: id:13276
+msgid "DVD-ROM"
+msgstr "DVD-ROM"
+
+#: id:13277
+msgctxt "Auto context with id 13277"
+msgid "Storage"
+msgstr "Skladište"
+
+#: id:13278
+msgctxt "Auto context with id 13278"
+msgid "Default"
+msgstr "Podrazumjevano"
+
+#: id:13279
+msgctxt "Auto context with id 13279"
+msgid "Network"
+msgstr "Mreža"
+
+#: id:13280
+msgctxt "Auto context with id 13280"
+msgid "Video"
+msgstr "Video"
+
+#: id:13281
+msgid "Hardware"
+msgstr "Hardver"
+
+#: id:13283
+msgid "Operating system:"
+msgstr "Operativni sistem:"
+
+#: id:13284
+msgid "CPU speed:"
+msgstr "Brzina procesora:"
+
+#: id:13286
+msgid "Video encoder:"
+msgstr "Video koder:"
+
+#: id:13287
+msgid "Screen resolution:"
+msgstr "Rezolucija ekrana:"
+
+#: id:13292
+msgid "A/V cable:"
+msgstr "A/V kabl:"
+
+#: id:13294
+msgid "DVD region:"
+msgstr "DVD regija:"
+
+#: id:13295
+msgid "Internet:"
+msgstr "Internet:"
+
+#: id:13296
+msgctxt "Auto context with id 13296"
+msgid "Connected"
+msgstr "Povezano"
+
+#: id:13297
+msgid "Not connected. Check network settings."
+msgstr "Nije povezano. Provjerite mrežne postavke."
+
+#: id:13299
+msgid "Target temperature"
+msgstr "Željena temperatura"
+
+#: id:13300
+msgid "Fan speed"
+msgstr "Brzina ventilatora"
+
+#: id:13301
+msgid "Auto temperature control"
+msgstr "Automat. kontrolisanje temperature"
+
+#: id:13302
+msgid "Fan speed override"
+msgstr "Nametni brzinu ventilatora"
+
+#: id:13303
+msgid "- Fonts"
+msgstr "- Slova"
+
+#: id:13304
+msgid "Enable flipping bi-directional strings"
+msgstr "Omogući obrtanje bi-direkcionih stringova"
+
+#: id:13305
+msgid "Show RSS news feeds"
+msgstr "Prikaži RSS novosti"
+
+#: id:13306
+msgid "Show parent folder items"
+msgstr "Prikaži stavke roditeljske fascikle"
+
+#: id:13307
+msgid "Track naming template"
+msgstr "Šablon imenovanja numera"
+
+#: id:13308
+msgid "Do you wish to reboot your system"
+msgstr "Želite li da ponovo pokrenete"
+
+#: id:13309
+msgid "instead of just XBMC?"
+msgstr "cijeli sistem, a ne samo XBMC aplikaciju?"
+
+#: id:13310
+msgid "Zoom effect"
+msgstr "Efekat uveličavanja"
+
+#: id:13311
+msgid "Float effect"
+msgstr "Efekat plutanja"
+
+#: id:13312
+msgid "Black bar reduction"
+msgstr "Smanjenje crnih traka"
+
+#: id:13313
+msgid "Restart"
+msgstr "Ponovo pokreni"
+
+#: id:13314
+msgid "Crossfade between songs"
+msgstr "Fini prijelaz (preklapanje) između pjesama"
+
+#: id:13315
+msgid "Regenerate thumbnails"
+msgstr "Obnavljanje sličica"
+
+#: id:13316
+msgid "Recursive thumbnails"
+msgstr "Rekurzivne sličice"
+
+#: id:13317
+msgid "View slideshow"
+msgstr "Prikaži reproduk. slajdova"
+
+#: id:13318
+msgid "Recursive slideshow"
+msgstr "Rekurzivna reprod. slajdova"
+
+#: id:13319
+msgid "Randomize"
+msgstr "Nasumično"
+
+#: id:13320
+msgid "Stereo"
+msgstr "Stereo"
+
+#: id:13321
+msgid "Left only"
+msgstr "Samo lijevi"
+
+#: id:13322
+msgid "Right only"
+msgstr "Samo desni"
+
+#: id:13323
+msgid "Enable karaoke support"
+msgstr "Omogući podršku za karaoke"
+
+#: id:13324
+msgid "Background transparency"
+msgstr "Providnost pozadine"
+
+#: id:13325
+msgid "Foreground transparency"
+msgstr "Providnost prednjeg plana"
+
+#: id:13326
+msgid "A/V delay"
+msgstr "A/V kašnjenje"
+
+#: id:13327
+msgid "Karaoke"
+msgstr "Karaoke"
+
+#: id:13328
+msgid "%s not found"
+msgstr "%s nije pronađen"
+
+#: id:13329
+msgid "Error opening %s"
+msgstr "Greška prilikom otvaranja %s"
+
+#: id:13330
+msgid "Unable to load %s"
+msgstr "Nije moguće učitati %s"
+
+#: id:13331
+msgid "Error: Out of memory"
+msgstr "Greška: Nedovoljno memorije"
+
+#: id:13332
+msgid "Move up"
+msgstr "Premjesti gore"
+
+#: id:13333
+msgid "Move down"
+msgstr "Premjesti dolje"
+
+#: id:13334
+msgid "Edit label"
+msgstr "Uredi natpis"
+
+#: id:13335
+msgid "Make default"
+msgstr "Post. podrazumevanim"
+
+#: id:13336
+msgid "Remove button"
+msgstr "Ukloni taster"
+
+#: id:13340
+msgid "Leave as is"
+msgstr "Ostavi kako jeste"
+
+#: id:13341
+msgid "Green"
+msgstr "Zelena"
+
+#: id:13342
+msgid "Orange"
+msgstr "Narandžasta"
+
+#: id:13343
+msgid "Red"
+msgstr "Crvena"
+
+#: id:13344
+msgid "Cycle"
+msgstr "Ciklus"
+
+#: id:13345
+msgid "Switch LED off on playback"
+msgstr "Isključi LED prilikom reprodukcije"
+
+#: id:13346
+msgctxt "Auto context with id 13346"
+msgid "Movie information"
+msgstr "Podaci o filmu"
+
+#: id:13347
+msgid "Queue item"
+msgstr "Stavi u red za reprod."
+
+#: id:13348
+msgid "Search IMDb..."
+msgstr "Pretraži IMDb..."
+
+#: id:13349
+msgid "Scan for new content"
+msgstr "Potraži novi sadržaj"
+
+#: id:13350
+msgid "Now playing..."
+msgstr "Trenutno se reprodukuje..."
+
+#: id:13351
+msgctxt "Auto context with id 13351"
+msgid "Album information"
+msgstr "Podaci o albumu"
+
+#: id:13352
+msgid "Scan item to library"
+msgstr "Analiz. stavke u biblioteci"
+
+#: id:13353
+msgid "Stop scanning"
+msgstr "Zaustavi analiziranje"
+
+#: id:13354
+msgctxt "Auto context with id 13354"
+msgid "Render method"
+msgstr "Način predstavljanja"
+
+#: id:13355
+msgid "Low quality pixel shader"
+msgstr "Nizak kvalitet sjenčenja piksela"
+
+#: id:13356
+msgid "Hardware overlays"
+msgstr "Hardverska preklapanja"
+
+#: id:13357
+msgid "High quality pixel shader"
+msgstr "Visok kvalitet sjenčenja piksela"
+
+#: id:13358
+msgid "Play item"
+msgstr "Reprodukuj stavku"
+
+#: id:13359
+msgid "Set artist thumb"
+msgstr "Postavi sličicu izvođača"
+
+#: id:13360
+msgid "Automatically generate thumbnails"
+msgstr "Automatski napravi sličice"
+
+#: id:13361
+msgid "Enable voice"
+msgstr "Omogući glas"
+
+#: id:13375
+msgid "Enable device"
+msgstr "Omogući uređaj"
+
+#: id:13376
+msgid "Volume"
+msgstr "Jačina zvuka"
+
+#: id:13377
+msgid "Default view mode"
+msgstr "Podrazumjevani režim prikaza"
+
+#: id:13378
+msgid "Default brightness"
+msgstr "Podrazumjevana svjetlina"
+
+#: id:13379
+msgid "Default contrast"
+msgstr "Podrazumjevani kontrast"
+
+#: id:13380
+msgid "Default gamma"
+msgstr "Podrazumjevani opseg boja"
+
+#: id:13381
+msgid "Resume video"
+msgstr "Nastavi film"
+
+#: id:13382
+msgid "Voice mask - Port 1"
+msgstr "Glasovna maska - Priključak 1"
+
+#: id:13383
+msgid "Voice mask - Port 2"
+msgstr "Glasovna maska - Priključak 2"
+
+#: id:13384
+msgid "Voice mask - Port 3"
+msgstr "Glasovna maska - Priključak 3"
+
+#: id:13385
+msgid "Voice mask - Port 4"
+msgstr "Glasovna maska - Priključak 4"
+
+#: id:13386
+msgid "Use time based seeking"
+msgstr "Koristi traženje zasnovano na vremenu"
+
+#: id:13387
+msgid "Track naming template - right"
+msgstr "Šablon imenovanja numera - desno"
+
+#: id:13388
+msgid "Preset"
+msgstr "Unaprijed zadato"
+
+#: id:13389
+msgid "There are no presets available\nfor this visualization"
+msgstr "Ne postoje unaprijed zadate postavke\nza ovu vizualizaciju"
+
+#: id:13390
+msgid "There are no settings available\nfor this visualization"
+msgstr "Ne postoje dostupne postavke\nza ovu vizualizaciju"
+
+#: id:13391
+msgid "Eject/Load"
+msgstr "Izbaci/Ubaci"
+
+#: id:13392
+msgid "Use visualization if playing audio"
+msgstr "Koristi vizualizaciju, ukoliko se reprodukuje zvuk"
+
+#: id:13393
+msgid "Calculate size"
+msgstr "Izračunaj veličinu"
+
+#: id:13394
+msgid "Calculating folder size"
+msgstr "Računanje veličine fascikle"
+
+#: id:13395
+msgid "Video settings"
+msgstr "Postavke filma"
+
+#: id:13396
+msgid "Audio and subtitle settings"
+msgstr "Postavke zvuka i titla"
+
+#: id:13397
+msgid "Enable subtitles"
+msgstr "Omogući titlove"
+
+#: id:13398
+msgctxt "Auto context with id 13398"
+msgid "Shortcuts"
+msgstr "Prečice"
+
+#: id:13399
+msgid "Ignore articles when sorting (e.g. \"the\")"
+msgstr "Ignoriši stavke prilikom slaganja (npr. „the“ i sl.)"
+
+#: id:13400
+msgid "Crossfade between songs on the same album"
+msgstr "Fini prelaz između pjesama istog albuma"
+
+#: id:13401
+msgid "Browse for %s"
+msgstr "Potraži %s"
+
+#: id:13402
+msgid "Show track position"
+msgstr "Prikaži poziciju numere"
+
+#: id:13403
+msgid "Clear default"
+msgstr "Očisti podrazumjevano"
+
+#: id:13404
+msgid "Resume"
+msgstr "Nastavi"
+
+#: id:13405
+msgid "Get thumb"
+msgstr "Preuzmi omot"
+
+#: id:13406
+msgid "Picture information"
+msgstr "Podaci o slici"
+
+#: id:13407
+msgid "%s presets"
+msgstr "%s unap. zad. postavki"
+
+#: id:13408
+msgid "(IMDb user rating)"
+msgstr "(IMDb ocjena korisnika)"
+
+#: id:13409
+msgid "Top 250"
+msgstr "Najboljih 250"
+
+#: id:13410
+msgid "Tune in on Last.fm"
+msgstr "Namjesti na Last.fm"
+
+#: id:13411
+msgid "Minimum fan speed"
+msgstr "Minimalna brzina ventilatora"
+
+#: id:13412
+msgid "Play from here"
+msgstr ""
+
+#: id:13413
+msgid "Downloading"
+msgstr "Preuzimanje"
+
+#: id:13414
+msgid "Include artists who appear only on compilations"
+msgstr "Uključi izvođače koji se pojavljuju samo na kompilacijama"
+
+#: id:13415
+msgctxt "Auto context with id 13415"
+msgid "Render method"
+msgstr "Način predstavljanja"
+
+#: id:13416
+msgid "Auto detect"
+msgstr "Autom. otkrij"
+
+#: id:13417
+msgid "Basic shaders (ARB)"
+msgstr "Osnovna sjenčenja (ARB)"
+
+#: id:13418
+msgid "Advanced shaders (GLSL)"
+msgstr "Napredna sjenčenja (GLSL)"
+
+#: id:13419
+msgid "Software"
+msgstr "Softver"
+
+#: id:13420
+msgid "Remove safely"
+msgstr "Sigurno ukloni"
+
+#: id:13421
+msgctxt "Auto context with id 13421"
+msgid "VDPAU"
+msgstr "VDPAU"
+
+#: id:13422
+msgid "Start slideshow here"
+msgstr "Pokreni rep. slajd. odavde"
+
+#: id:13423
+msgid "Remember for this path"
+msgstr "Zapamti ovu putanju"
+
+#: id:13424
+msgid "Use pixel buffer objects"
+msgstr "Koristi pikselno predmemorisanje objekata"
+
+#: id:13425
+msgid "Allow hardware acceleration (VDPAU)"
+msgstr "Broadcom Crystal HD"
+
+#: id:13426
+msgid "Allow hardware acceleration (VAAPI)"
+msgstr ""
+
+#: id:13427
+msgid "Allow hardware acceleration (DXVA2)"
+msgstr ""
+
+#: id:13428
+msgid "Allow hardware acceleration (CrystalHD)"
+msgstr ""
+
+#: id:13429
+msgid "Allow hardware acceleration (VDADecoder)"
+msgstr ""
+
+#: id:13430
+msgid "Allow hardware acceleration (OpenMax)"
+msgstr ""
+
+#: id:13431
+msgid "Pixel Shaders"
+msgstr ""
+
+#: id:13432
+msgid "Allow hardware acceleration (VideoToolbox)"
+msgstr ""
+
+#: id:13500
+msgid "A/V sync method"
+msgstr "A/V način sinhron."
+
+#: id:13501
+msgid "Audio clock"
+msgstr "Sat zvuka"
+
+#: id:13502
+msgid "Video clock (Drop/Dupe audio)"
+msgstr "Sat filma (Drop/Dupe zvuk)"
+
+#: id:13503
+msgid "Video clock (Resample audio)"
+msgstr "Sat filma (Ponov. odab. zvuka)"
+
+#: id:13504
+msgid "Maximum resample amount (%)"
+msgstr "Maksimalna količina pon. odabir. (%)"
+
+#: id:13505
+msgid "Resample quality"
+msgstr "Kvalitet ponov. odab."
+
+#: id:13506
+msgid "Low(fast)"
+msgstr "Nizak (brzo)"
+
+#: id:13507
+msgctxt "Auto context with id 13507"
+msgid "Medium"
+msgstr "Srednje"
+
+#: id:13508
+msgctxt "Auto context with id 13508"
+msgid "High"
+msgstr "Visok"
+
+#: id:13509
+msgid "Really high(slow!)"
+msgstr "Zaista visok (sporo!)"
+
+#: id:13510
+msgid "Sync playback to display"
+msgstr "Sinhronizuj reprodukciju prema prikazu"
+
+#: id:13550
+msgid "Pause during refresh rate change"
+msgstr ""
+
+#: id:13551
+msgctxt "Auto context with id 13551"
+msgid "Off"
+msgstr ""
+
+#: id:13552
+msgid "%.1f Second"
+msgstr ""
+
+#: id:13553
+msgid "%.1f Seconds"
+msgstr ""
+
+#: id:13600
+msgid "Apple remote"
+msgstr "Apple daljinski upravljač"
+
+#: id:13602
+msgid "Allow start of XBMC using the remote"
+msgstr "Dozvoli pokretanje XBMC aplik. korišćenjem daljinskog"
+
+#: id:13603
+msgid "Sequence delay time"
+msgstr "Vreme kašnjenja sekvence"
+
+#: id:13610
+msgctxt "Auto context with id 13610"
+msgid "Disabled"
+msgstr "Onemogućeno"
+
+#: id:13611
+msgctxt "Auto context with id 13611"
+msgid "Standard"
+msgstr "Uobičajeno"
+
+#: id:13612
+msgid "Universal Remote"
+msgstr "Univerzalni daljinski"
+
+#: id:13613
+msgid "Multi Remote (Harmony)"
+msgstr "Višestruki daljinski (Složno)"
+
+#: id:13620
+msgid "Apple Remote Error"
+msgstr "Greška Apple daljinskog upravljača"
+
+#: id:13621
+msgid "Apple Remote support could be enabled."
+msgstr "Podrška za Apple dalj. upravljač može biti omogućena."
+
+#: id:14000
+msgid "Stack"
+msgstr "Postavi na skladište"
+
+#: id:14001
+msgid "Unstack"
+msgstr "Ukloni sa skladišta"
+
+#: id:14003
+msgid "Downloading playlist file..."
+msgstr "Preuzimanje datoteke spisk. za rep..."
+
+#: id:14004
+msgid "Downloading streams list..."
+msgstr "Preuzimanje spiska protoka podataka..."
+
+#: id:14005
+msgid "Parsing streams list..."
+msgstr "Razlučivanje (razlaganje) spiska protoka podataka..."
+
+#: id:14006
+msgid "Downloading streams list failed"
+msgstr "Nije uspjelo preuzimanje spiska protoka podataka"
+
+#: id:14007
+msgid "Downloading playlist file failed"
+msgstr "Nije uspjelo preuzimanje datoteke spiska za reprodukciju"
+
+#: id:14009
+msgid "Games directory"
+msgstr "Katalog igara"
+
+#: id:14010
+msgid "Auto switch to thumbs based on"
+msgstr "Autom. prebaci na sličice zasnovano na"
+
+#: id:14011
+msgid "Enable auto switching to thumbs view"
+msgstr "Omogući automatsko prebacivanje na prikaz omota"
+
+#: id:14012
+msgid "- Use large icons"
+msgstr "- Koristi velike ikone"
+
+#: id:14013
+msgid "- Switch based on"
+msgstr "- Prebacivanje zasnovano na"
+
+#: id:14014
+msgid "- Percentage"
+msgstr "- Postotak"
+
+#: id:14015
+msgid "No files and at least one thumb"
+msgstr "Bez datoteka i bar jedne sličice"
+
+#: id:14016
+msgid "At least one file and thumb"
+msgstr "Bar jedna datoteka i sličica"
+
+#: id:14017
+msgid "Percentage of thumbs"
+msgstr "Procenat sličica"
+
+#: id:14018
+msgid "View options"
+msgstr "Prikaži opcije"
+
+#: id:14019
+msgid "Change area code 1"
+msgstr "Promjeni kôd područja 1"
+
+#: id:14020
+msgid "Change area code 2"
+msgstr "Promjeni kôd područja 2"
+
+#: id:14021
+msgid "Change area code 3"
+msgstr "Promjeni kôd područja 3"
+
+#: id:14022
+msgctxt "Auto context with id 14022"
+msgid "Library"
+msgstr "Biblioteka"
+
+#: id:14023
+msgid "No TV"
+msgstr "Bez TV prijemnika"
+
+#: id:14024
+msgid "Enter the nearest large town"
+msgstr "Unesite najbliži veći grad"
+
+#: id:14025
+msgid "Video/Audio/DVD cache - Harddisk"
+msgstr "Video/Zvučni/DVD keš - čvrsti disk"
+
+#: id:14026
+msgid "Video cache - DVD-ROM"
+msgstr "Video keš - DVD-ROM"
+
+#: id:14027
+msgctxt "Auto context with id 14027"
+msgid "- Local Network"
+msgstr "- Lokalna mreža"
+
+#: id:14028
+msgctxt "Auto context with id 14028"
+msgid "- Internet"
+msgstr "- Internet"
+
+#: id:14030
+msgid "Audio cache - DVD-ROM"
+msgstr "Keš zvuka - DVD-ROM"
+
+#: id:14031
+msgctxt "Auto context with id 14031"
+msgid "- Local Network"
+msgstr "- Lokalna mreža"
+
+#: id:14032
+msgctxt "Auto context with id 14032"
+msgid "- Internet"
+msgstr "- Internet"
+
+#: id:14034
+msgid "DVD cache - DVD-ROM"
+msgstr "DVD keš - DVD-ROM"
+
+#: id:14035
+msgctxt "Auto context with id 14035"
+msgid "- Local Network"
+msgstr "- Lokalna mreža"
+
+#: id:14036
+msgctxt "Auto context with id 14036"
+msgid "Services"
+msgstr "Usluge"
+
+#: id:14038
+msgid "Network settings changed"
+msgstr "Promjenjene su mrežne postavke"
+
+#: id:14039
+msgid "XBMC requires to restart to change your"
+msgstr "XBMC zahteva ponovno pokretanje radi promjene"
+
+#: id:14040
+msgid "network setup. Would you like to restart now?"
+msgstr "mrežnih postavki. Želite li odmah da ponovo pokrenete?"
+
+#: id:14041
+msgid "Internet connection bandwidth limitation"
+msgstr "Naknadna obrada"
+
+#: id:14043
+msgid "- Shutdown while playing"
+msgstr "- Isključi dok se reprodukuje"
+
+#: id:14044
+msgid "%i min"
+msgstr "%i min."
+
+#: id:14045
+msgid "%i sec"
+msgstr "%i sek."
+
+#: id:14046
+msgid "%i ms"
+msgstr "%i ms"
+
+#: id:14047
+msgid "%i %%"
+msgstr "%i %%"
+
+#: id:14048
+msgid "%i kbps"
+msgstr "%i kbps"
+
+#: id:14049
+msgid "%i kb"
+msgstr "%i kb"
+
+#: id:14050
+msgid "%i.0 dB"
+msgstr "%i.0 dB"
+
+#: id:14051
+msgid "Time format"
+msgstr "Prikaz vremena"
+
+#: id:14052
+msgid "Date format"
+msgstr "Prikaz datuma"
+
+#: id:14053
+msgid "GUI filters"
+msgstr "GUI filteri"
+
+#: id:14055
+msgid "Use background scanning"
+msgstr "Koristi analiziranje u pozadini"
+
+#: id:14056
+msgid "Stop scan"
+msgstr "Zaustavi analiziranje"
+
+#: id:14057
+msgid "Not possible while scanning for media info"
+msgstr "Nije moguće dok je u toku analiziranje podataka o mediju"
+
+#: id:14058
+msgid "Film grain effect"
+msgstr "Zrnasti efekat prikaza"
+
+#: id:14059
+msgid "Search for thumbnails on remote shares"
+msgstr "Potraži sličice na dijeljenim lokacijama"
+
+#: id:14060
+msgid "Unknown type cache - Internet"
+msgstr "Nepoznat tip keša - Internet"
+
+#: id:14061
+msgctxt "Auto context with id 14061"
+msgid "Auto"
+msgstr "Autom."
+
+#: id:14062
+msgid "Enter username for"
+msgstr "Unesite korisničko ime za"
+
+#: id:14063
+msgid "Date & time"
+msgstr "Datum i vrijeme"
+
+#: id:14064
+msgid "Set date"
+msgstr "Postavi datum"
+
+#: id:14065
+msgid "Set time"
+msgstr "Postavi vrijeme"
+
+#: id:14066
+msgid "Enter the time in 24 hour HH:MM format"
+msgstr "Unesite vrijeme u obliku 24 sata; SS:MM"
+
+#: id:14067
+msgid "Enter the date in DD/MM/YYYY format"
+msgstr "Unesite datum u obliku DD/MM/GGGG"
+
+#: id:14068
+msgid "Enter the IP address"
+msgstr "Unesite IP adresu"
+
+#: id:14069
+msgid "Apply these settings now?"
+msgstr "Odmah primeniti postavke?"
+
+#: id:14070
+msgid "Apply changes now"
+msgstr "Odmah primjeni promjene"
+
+#: id:14071
+msgid "Allow file renaming and deletion"
+msgstr "Dozvoli preimenovanje i brisanje datoteke"
+
+#: id:14074
+msgid "Set timezone"
+msgstr "Postavi vremensku zonu"
+
+#: id:14075
+msgid "Use daylight saving time"
+msgstr "Koristi ljetno računanje vremena"
+
+#: id:14076
+msgid "Add to favourites"
+msgstr "Dodaj u omiljeno"
+
+#: id:14077
+msgid "Remove from favourites"
+msgstr "Ukloni iz omiljenog"
+
+#: id:14078
+msgctxt "Auto context with id 14078"
+msgid "- Colours"
+msgstr "- Boje"
+
+#: id:14079
+msgid "Timezone country"
+msgstr "Zemlja vremenske zone"
+
+#: id:14080
+msgid "Timezone"
+msgstr "Vremenska zona"
+
+#: id:14081
+msgid "File lists"
+msgstr "Spiskovi datoteka"
+
+#: id:14082
+msgid "Show EXIF picture information"
+msgstr "Prikaži EXIF specifikaciju slike"
+
+#: id:14083
+msgid "Use a fullscreen window rather than true fullscreen"
+msgstr "Radije koristi prikaz čitavog ekrana u prozoru"
+
+#: id:14084
+msgid "Queue songs on selection"
+msgstr "Stavi pjesmu u red prilikom izbora"
+
+#: id:14086
+msgid "Playback"
+msgstr "Reprodukcija"
+
+#: id:14087
+msgid "DVDs"
+msgstr "DVD-ovi"
+
+#: id:14088
+msgid "Play DVDs automatically"
+msgstr "Automatski reprodukuj DVD-ove"
+
+#: id:14089
+msgid "Font to use for text subtitles"
+msgstr "Oblik slova za titlove"
+
+#: id:14090
+msgid "International"
+msgstr "Međunarodno"
+
+#: id:14091
+msgid "Character set"
+msgstr "Skup znakova"
+
+#: id:14092
+msgid "Debugging"
+msgstr "Traženje grešaka"
+
+#: id:14093
+msgid "Security"
+msgstr "Sigurnost"
+
+#: id:14094
+msgid "Input devices"
+msgstr "Ulazni uređaji"
+
+#: id:14095
+msgid "Power saving"
+msgstr "Ušteda energije"
+
+#: id:14096
+msgid "Rip"
+msgstr ""
+
+#: id:14097
+msgid "Audio CD Insert Action"
+msgstr ""
+
+#: id:14098
+msgctxt "Auto context with id 14098"
+msgid "Play"
+msgstr ""
+
+#: id:14099
+msgid "Eject disc when CD ripping is complete"
+msgstr ""
+
+#: id:15015
+msgctxt "Auto context with id 15015"
+msgid "Remove"
+msgstr "Ukloni"
+
+#: id:15016
+msgid "Games"
+msgstr "Igre"
+
+#: id:15019
+msgid "Add"
+msgstr "Dodaj"
+
+#: id:15052
+msgid "Password"
+msgstr "Lozinka"
+
+#: id:15100
+msgctxt "Auto context with id 15100"
+msgid "Library"
+msgstr "Biblioteka"
+
+#: id:15101
+msgid "Database"
+msgstr "Baza podataka"
+
+#: id:15102
+msgid "* All albums"
+msgstr "* Svi albumi"
+
+#: id:15103
+msgid "* All artists"
+msgstr "* Svi izvođači"
+
+#: id:15104
+msgid "* All songs"
+msgstr "* Sve pjesme"
+
+#: id:15105
+msgid "* All genres"
+msgstr "* Svi žanrovi"
+
+#: id:15107
+msgid "Buffering..."
+msgstr "Predmemorisanje..."
+
+#: id:15108
+msgid "Navigation sounds"
+msgstr "Navigacioni zvukovi"
+
+#: id:15109
+msgid "Skin default"
+msgstr "Podrazumjevana maska"
+
+#: id:15111
+msgid "- Theme"
+msgstr "- Tema"
+
+#: id:15112
+msgid "Default theme"
+msgstr "Podrazumjevana tema"
+
+#: id:15200
+msgid "Last.fm"
+msgstr "Last.fm"
+
+#: id:15201
+msgid "Submit songs to Last.fm"
+msgstr "Pošalji pjesme na Last.fm"
+
+#: id:15202
+msgid "Last.fm username"
+msgstr "Last.fm korisničko ime"
+
+#: id:15203
+msgid "Last.fm password"
+msgstr "Last.fm lozinka"
+
+#: id:15204
+msgid "Unable to handshake: sleeping..."
+msgstr "Nije moguće usaglašavanje: stanje spavanja..."
+
+#: id:15205
+msgid "Please update XBMC"
+msgstr "Molimo, ažurirajte XBMC"
+
+#: id:15206
+msgid "Bad authorization: Check username and password"
+msgstr "Pogrešna autorizacija: Provjerite korisničko ime i lozinku"
+
+#: id:15207
+msgctxt "Auto context with id 15207"
+msgid "Connected"
+msgstr "Povezano"
+
+#: id:15208
+msgid "Not connected"
+msgstr "Nije povezano"
+
+#: id:15209
+msgid "Submit interval %i"
+msgstr "Učestalost slanja %i"
+
+#: id:15210
+msgid "Cached %i songs"
+msgstr "Keširano %i pjesama"
+
+#: id:15211
+msgid "Submitting..."
+msgstr "Slanje je u toku..."
+
+#: id:15212
+msgid "Submitting in %i secs"
+msgstr "Slanje za %i sekundi"
+
+#: id:15213
+msgid "Play using..."
+msgstr "Reprodukuj pomoću..."
+
+#: id:15214
+msgid "Use smoothed A/V synchronization"
+msgstr "Koristi umekšanu A/V sinhronizaciju"
+
+#: id:15215
+msgid "Hide file names in thumbs view"
+msgstr "Sakrij nazive datoteka prilikom prikaza omota"
+
+#: id:15216
+msgid "Play in party mode"
+msgstr "Reprodukuj u režimu žurke"
+
+#: id:15217
+msgid "Submit songs to Libre.fm"
+msgstr "Pošalji pjesme na Libre.fm"
+
+#: id:15218
+msgid "Libre.fm username"
+msgstr "Libre.fm korisničko ime"
+
+#: id:15219
+msgid "Libre.fm password"
+msgstr "Libre.fm lozinka"
+
+#: id:15220
+msgid "Libre.fm"
+msgstr "Libre.fm"
+
+#: id:15221
+msgid "Song submission"
+msgstr "Slanje pjesme"
+
+#: id:15250
+msgid "Submit Last.fm radio to Last.fm"
+msgstr "Pošalji Last.fm radio na Last.fm"
+
+#: id:15251
+msgid "Connecting to Last.fm..."
+msgstr "Povezivanje sa Last.fm..."
+
+#: id:15252
+msgid "Selecting station..."
+msgstr "Biranje stanice..."
+
+#: id:15253
+msgid "Search similar artists..."
+msgstr "Pronađi slične izvođače..."
+
+#: id:15254
+msgid "Search similar tags..."
+msgstr "Pronađi slične oznake..."
+
+#: id:15255
+msgid "Your profile (%name%)"
+msgstr "Vaš profil (%name%)"
+
+#: id:15256
+msgid "Overall top tags"
+msgstr "Sveobuhvatno najbolje oznake"
+
+#: id:15257
+msgid "Top artists for tag %name%"
+msgstr "Najbolji izvođači sa oznakom %name%"
+
+#: id:15258
+msgid "Top albums for tag %name%"
+msgstr "Najbolji albumi sa oznakom %name%"
+
+#: id:15259
+msgid "Top tracks for tag %name%"
+msgstr "Najbolje numere sa oznakom %name%"
+
+#: id:15260
+msgid "Listen to tag %name% Last.fm radio"
+msgstr "Slušaj oznaku %name% Last.fm radija"
+
+#: id:15261
+msgid "Similar artists as %name%"
+msgstr "Izvođači koji su slični sa %name%"
+
+#: id:15262
+msgid "Top %name% albums"
+msgstr "Najbolji %name% albumi"
+
+#: id:15263
+msgid "Top %name% tracks"
+msgstr "Najbolje %name% numere"
+
+#: id:15264
+msgid "Top %name% tags"
+msgstr "Najbolje %name% oznake"
+
+#: id:15265
+msgid "Biggest fans of %name%"
+msgstr "Najveći %name% obožavaoci"
+
+#: id:15266
+msgid "Listen to %name% fans Last.fm radio"
+msgstr "Slušaj obožavaoce %name%, Last.fm radija"
+
+#: id:15267
+msgid "Listen to %name% similar artists Last.fm radio"
+msgstr "Slušaj slične izvođače kao što je %name% na Last.fm radiju"
+
+#: id:15268
+msgid "Top artists for user %name%"
+msgstr "Najbolji izvođači korisnika %name%"
+
+#: id:15269
+msgid "Top albums for user %name%"
+msgstr "Najbolji albumi korisnika %name%"
+
+#: id:15270
+msgid "Top tracks for user %name%"
+msgstr "Najbolje numere korisnika %name%"
+
+#: id:15271
+msgid "Friends of user %name%"
+msgstr "Prijatelji korisnika %name%"
+
+#: id:15272
+msgid "Neighbours of user %name%"
+msgstr "Komšije korisnika %name%"
+
+#: id:15273
+msgid "Weekly artist chart for %name%"
+msgstr "Nedjeljni spisak najboljih izvođača korisnika %name%"
+
+#: id:15274
+msgid "Weekly album chart for %name%"
+msgstr "Nedjeljni spisak najboljih albuma korisnika %name%"
+
+#: id:15275
+msgid "Weekly track chart for %name%"
+msgstr "Nedjeljni spisak najboljih numera korisnika %name%"
+
+#: id:15276
+msgid "Listen to %name%'s neighbours Last.fm radio"
+msgstr "Slušaj komšijin Last.fm radio korisnika %name%"
+
+#: id:15277
+msgid "Listen to %name%'s personal Last.fm radio"
+msgstr "Slušaj lični Last.fm radio korisnika %name%"
+
+#: id:15278
+msgid "Listen to %name%'s mix Last.fm radio"
+msgstr "Slušaj voljene numere Last.fm radija korisnika %name%"
+
+#: id:15279
+msgid "Retrieving list from Last.fm..."
+msgstr "Preuzimanje spiska sa Last.fm..."
+
+#: id:15280
+msgid "Can't retrieve list from Last.fm..."
+msgstr "Nije moguće preuzeti spisak sa Last.fm..."
+
+#: id:15281
+msgid "Enter an artist name to find related ones"
+msgstr "Unesite naziv izvođača kako biste pronašli slične"
+
+#: id:15282
+msgid "Enter a tag name to find similar ones"
+msgstr "Unesite oznaku za pronalaženje sličnih"
+
+#: id:15283
+msgid "Tracks recently listened by %name%"
+msgstr "Nedavno odslušane numere korisnika %name%"
+
+#: id:15284
+msgid "Listen to %name%'s recommendations Last.fm radio"
+msgstr "Slušaj po preporuci Last.fm radio korisnika %name%"
+
+#: id:15285
+msgid "Top tags for user %name%"
+msgstr "Najbolje oznake za korisnika %name%"
+
+#: id:15287
+msgid "Do you want to add the current track to your loved tracks?"
+msgstr "Želite li da dodate trenutnu numeru u vaše voljene numere?"
+
+#: id:15288
+msgid "Do you want to ban the current track?"
+msgstr "Želite li da zabranite trenutnu numeru?"
+
+#: id:15289
+msgid "Added to your loved tracks: '%s'."
+msgstr "Dodato u vaše voljene numere: „%s“."
+
+#: id:15290
+msgid "Could not add '%s' to your loved tracks."
+msgstr "Nije moguće dodati „%s“ u vaše voljene numere."
+
+#: id:15291
+msgid "Banned: '%s'."
+msgstr "Zabranjeno: „%s“."
+
+#: id:15292
+msgid "Could not ban '%s'."
+msgstr "Nije moguće zabraniti „%s“."
+
+#: id:15293
+msgid "Tracks recently loved by %name%"
+msgstr "Numere koje je nedavno zavolio %name%"
+
+#: id:15294
+msgid "Tracks recently banned by %name%"
+msgstr "Numere koje je nedavno zabranio %name%"
+
+#: id:15295
+msgid "Remove from loved tracks"
+msgstr "Uklonjeno iz voljenih numera"
+
+#: id:15296
+msgid "Un-ban"
+msgstr "Opozovi zabranu"
+
+#: id:15297
+msgid "Do you want to remove this track from your loved tracks?"
+msgstr "Želite li da uklonite ovu numeru iz voljenih numera?"
+
+#: id:15298
+msgid "Do you want to un-ban this track?"
+msgstr "Želite li da opozovete zabranu za ovu numeru?"
+
+#: id:15300
+msgid "Path not found or invalid"
+msgstr "Putanja nije pronađena ili je nevažeća"
+
+#: id:15301
+msgid "Could not connect to network server"
+msgstr "Nije moguće povezivanje sa mrežnim serverom"
+
+#: id:15302
+msgid "No servers found"
+msgstr "Ni jedan server nije pronađen"
+
+#: id:15303
+msgid "Workgroup not found"
+msgstr "Radna grupa nije pronađena"
+
+#: id:15310
+msgid "Opening multi-path source"
+msgstr "Otvaranje izvora sa više putanja"
+
+#: id:15311
+msgid "Path:"
+msgstr "Putanja:"
+
+#: id:16000
+msgctxt "Auto context with id 16000"
+msgid "General"
+msgstr "Opšte"
+
+#: id:16002
+msgid "Internet lookup"
+msgstr "Pretraživanje interneta"
+
+#: id:16003
+msgid "Player"
+msgstr "Uređaj za reprodukciju"
+
+#: id:16004
+msgid "Play media from disc"
+msgstr "Reprodukuj medij sa diska"
+
+#: id:16008
+msgid "Enter new title"
+msgstr "Unesite novi naslov"
+
+#: id:16009
+msgid "Enter the movie name"
+msgstr "Unesite ime filma"
+
+#: id:16010
+msgid "Enter the profile name"
+msgstr "Unesite ime profila"
+
+#: id:16011
+msgid "Enter the album name"
+msgstr "Unesite ime albuma"
+
+#: id:16012
+msgid "Enter the playlist name"
+msgstr "Unesite ime spiska za rep."
+
+#: id:16013
+msgid "Enter new filename"
+msgstr "Unesite novo ime datoteke"
+
+#: id:16014
+msgid "Enter folder name"
+msgstr "Unesite ime fascikle"
+
+#: id:16015
+msgid "Enter directory"
+msgstr "Unesite fasciklu"
+
+#: id:16016
+msgid "Available options: %A, %T, %N, %B, %D, %G, %Y, %F, %S"
+msgstr "Dostupne opcije: %A, %T, %N, %B, %D, %G, %Y, %F, %S"
+
+#: id:16017
+msgid "Enter search string"
+msgstr "Unesite riječ za pretragu"
+
+#: id:16018
+msgctxt "Auto context with id 16018"
+msgid "None"
+msgstr "Ništa"
+
+#: id:16019
+msgid "Auto select"
+msgstr "Automatski izbor"
+
+#: id:16020
+msgid "De-interlace"
+msgstr "Ukloni preplitanje slike"
+
+#: id:16021
+msgid "Bob"
+msgstr "Bob"
+
+#: id:16022
+msgid "Bob (inverted)"
+msgstr "Bob (obratno)"
+
+#: id:16024
+msgid "Canceling..."
+msgstr "Otkazivanje..."
+
+#: id:16025
+msgid "Enter the artist name"
+msgstr "Unesi ime izvođača"
+
+#: id:16026
+msgid "Playback failed"
+msgstr "Neuspešna reprodukcija"
+
+#: id:16027
+msgid "One or more items failed to play."
+msgstr "Jednu ili više stavki nije moguće reprodukovati."
+
+#: id:16028
+msgid "Enter value"
+msgstr "Unesite vrijednost"
+
+#: id:16029
+msgid "Check the log file for details."
+msgstr "Provjerite datoteku evidencije za detalje."
+
+#: id:16030
+msgid "Party mode aborted."
+msgstr "Režim žurke je prekinut."
+
+#: id:16031
+msgid "No matching songs in the library."
+msgstr "Nema podudarajućih pjesama u biblioteci."
+
+#: id:16032
+msgid "Could not initialize database."
+msgstr "Nije moguće pokrenuti bazu podataka."
+
+#: id:16033
+msgid "Could not open database."
+msgstr "Nije moguće otvoriti bazu podataka."
+
+#: id:16034
+msgid "Could not get songs from database."
+msgstr "Nije moguće preuzeti pjesme iz baze podataka."
+
+#: id:16035
+msgid "Party mode playlist"
+msgstr "Spisak za rep. režima žurke"
+
+#: id:16036
+msgid "De-interlace (Half)"
+msgstr ""
+
+#: id:16037
+msgid "Deinterlace video"
+msgstr ""
+
+#: id:16038
+msgid "Deinterlace method"
+msgstr ""
+
+#: id:16039
+msgctxt "Auto context with id 16039"
+msgid "Off"
+msgstr ""
+
+#: id:16040
+msgctxt "Auto context with id 16040"
+msgid "Auto"
+msgstr ""
+
+#: id:16041
+msgid "On"
+msgstr ""
+
+#: id:16100
+msgid "All Videos"
+msgstr "Svi filmovi"
+
+#: id:16101
+msgid "Unwatched"
+msgstr "neodgledanih"
+
+#: id:16102
+msgid "Watched"
+msgstr "odgledanih"
+
+#: id:16103
+msgid "Mark as watched"
+msgstr "Obilježi kao odgledano"
+
+#: id:16104
+msgid "Mark as unwatched"
+msgstr "Obilježi kao neodgledano"
+
+#: id:16105
+msgid "Edit title"
+msgstr "Uredi naslov"
+
+#: id:16200
+msgid "Operation was aborted"
+msgstr "Operacija je prekinuta"
+
+#: id:16201
+msgid "Copy failed"
+msgstr "Kopiranje nije uspjelo"
+
+#: id:16202
+msgid "Failed to copy at least one file"
+msgstr "Nije uspjelo kopiranje barem jedne datoteke"
+
+#: id:16203
+msgid "Move failed"
+msgstr "Premještanje nije uspjelo"
+
+#: id:16204
+msgid "Failed to move at least one file"
+msgstr "Nije uspjelo premještanje barem jedne datoteke"
+
+#: id:16205
+msgid "Delete failed"
+msgstr "Brisanje nije uspelo"
+
+#: id:16206
+msgid "Failed to delete at least one file"
+msgstr "Nije uspelo brisanje barem jedne datoteke"
+
+#: id:16300
+msgid "Video scaling method"
+msgstr "Režim video razmjere"
+
+#: id:16301
+msgid "Nearest neighbour"
+msgstr "Najbliži komšija"
+
+#: id:16302
+msgid "Bilinear"
+msgstr "Bilinear"
+
+#: id:16303
+msgctxt "Auto context with id 16303"
+msgid "Bicubic"
+msgstr "Bicubic"
+
+#: id:16304
+msgid "Lanczos2"
+msgstr "Lanczos2"
+
+#: id:16305
+msgid "Lanczos3"
+msgstr "Lanczos3"
+
+#: id:16306
+msgid "Sinc8"
+msgstr "Sinc8"
+
+#: id:16307
+msgid "Bicubic (software)"
+msgstr "Bicubic (softverski)"
+
+#: id:16308
+msgid "Lanczos (software)"
+msgstr "Lanczos (softverski)"
+
+#: id:16309
+msgid "Sinc (software)"
+msgstr "Sinc (softverski)"
+
+#: id:16310
+msgid "Temporal"
+msgstr "Vremenski"
+
+#: id:16311
+msgid "Temporal/Spatial"
+msgstr "Vremenski/prostorni"
+
+#: id:16312
+msgid "(VDPAU)Noise Reduction"
+msgstr "(VDPAU) Smanjenje šuma"
+
+#: id:16313
+msgid "(VDPAU)Sharpness"
+msgstr "(VDPAU) Oštrina"
+
+#: id:16314
+msgid "Inverse Telecine"
+msgstr "Obrnuti Telecine"
+
+#: id:16315
+msgid "Lanczos3 optimized"
+msgstr "Optimizirani Lanczos3"
+
+#: id:16316
+msgctxt "Auto context with id 16316"
+msgid "Auto"
+msgstr "Automatski"
+
+#: id:16317
+msgid "Temporal (Half)"
+msgstr "Vremenski (polovično)"
+
+#: id:16318
+msgid "Temporal/Spatial (Half)"
+msgstr "Vremenski/prostorni (polovično)"
+
+#: id:16319
+msgid "DXVA"
+msgstr ""
+
+#: id:16320
+msgid "DXVA Bob"
+msgstr ""
+
+#: id:16321
+msgid "DXVA Best"
+msgstr ""
+
+#: id:16322
+msgid "Spline36"
+msgstr ""
+
+#: id:16323
+msgid "Spline36 optimized"
+msgstr ""
+
+#: id:16324
+msgid "Software Blend"
+msgstr ""
+
+#: id:16400
+msgid "Post-processing"
+msgstr ""
+
+#: id:17500
+msgid "Display sleep timeout"
+msgstr "Vrijeme nakon kog će ekran preći u stanje spavanja"
+
+#: id:19000
+msgid "Switch to channel"
+msgstr "Prebaci na kanal"
+
+#: id:20000
+msgid "Saved music folder"
+msgstr "Fascikla sa sačuvanom muzikom"
+
+#: id:20001
+msgid "Use external DVD player"
+msgstr "Koristi spoljni DVD uređaj za rep."
+
+#: id:20002
+msgid "External DVD player"
+msgstr "Spoljni DVD uređaj za rep."
+
+#: id:20003
+msgid "Trainers folder"
+msgstr "Fascikla modifikatora igara"
+
+#: id:20004
+msgid "Screenshot folder"
+msgstr "Fascikla sa slikama ekrana"
+
+#: id:20006
+msgid "Playlists folder"
+msgstr "Fascikla sa spiskovima za rep."
+
+#: id:20007
+msgid "Recordings"
+msgstr "Snimci"
+
+#: id:20008
+msgid "Screenshots"
+msgstr "Slike ekrana"
+
+#: id:20009
+msgid "Use XBMC"
+msgstr "Koristi XBMC"
+
+#: id:20011
+msgid "Music playlists"
+msgstr "Spiskovi za reprod. muzike"
+
+#: id:20012
+msgid "Video playlists"
+msgstr "Spiskovi za reprod. filmova"
+
+#: id:20013
+msgid "Do you wish to launch the game?"
+msgstr "Želite li da pokrenete igru?"
+
+#: id:20014
+msgid "Sort by: Playlist"
+msgstr "Složi po: Spis. za rep."
+
+#: id:20015
+msgid "Remote thumb"
+msgstr "Udaljena sličica"
+
+#: id:20016
+msgid "Current thumb"
+msgstr "Trenutna sličica"
+
+#: id:20017
+msgid "Local thumb"
+msgstr "Lokalna sličica"
+
+#: id:20018
+msgid "No thumb"
+msgstr "Nema sličice"
+
+#: id:20019
+msgid "Choose thumbnail"
+msgstr "Izaberi sličicu"
+
+#: id:20023
+msgid "Conflict"
+msgstr "Neusaglašenost"
+
+#: id:20024
+msgid "Scan new"
+msgstr "Pretraživanje novih"
+
+#: id:20025
+msgid "Scan all"
+msgstr "Pretraživanje svih"
+
+#: id:20026
+msgid "Region"
+msgstr "Regija"
+
+#: id:20037
+msgid "Summary"
+msgstr "Kratak pregled"
+
+#: id:20038
+msgid "Lock music window"
+msgstr "Zaključaj prozor sa muzikom"
+
+#: id:20039
+msgid "Lock videos window"
+msgstr "Zaključaj prozor sa filmovima"
+
+#: id:20040
+msgid "Lock pictures window"
+msgstr "Zaključaj prozor sa slikama"
+
+#: id:20041
+msgid "Lock programs & scripts windows"
+msgstr "Zaključaj prozor sa programima i skriptama"
+
+#: id:20042
+msgid "Lock file manager"
+msgstr "Zaključaj upravljača datotekama"
+
+#: id:20043
+msgid "Lock settings"
+msgstr "Zaključaj postavke"
+
+#: id:20044
+msgid "Start fresh"
+msgstr "Novi početak"
+
+#: id:20045
+msgid "Enter master mode"
+msgstr "Uđi u glavni režim"
+
+#: id:20046
+msgid "Leave master mode"
+msgstr "Napusti glavni režim"
+
+#: id:20047
+msgid "Create profile '%s'?"
+msgstr "Napraviti profil „%s“?"
+
+#: id:20048
+msgid "Start with fresh settings"
+msgstr "Pokreni sa novim postavkama"
+
+#: id:20049
+msgid "Best available"
+msgstr "Najbolje moguće"
+
+#: id:20050
+msgid "Auto-switch between 16x9 and 4x3"
+msgstr "Automatsko prebacivanje između 16x9 i 4x3"
+
+#: id:20051
+msgid "Treat stacked files as single file"
+msgstr "Smatraj komprimirane datoteke kao jednu"
+
+#: id:20052
+msgid "Caution"
+msgstr "Oprez"
+
+#: id:20053
+msgid "Left master mode"
+msgstr "Napušten glavni režim"
+
+#: id:20054
+msgid "Entered master mode"
+msgstr "Pristupljeno glavnom režimu"
+
+#: id:20055
+msgid "Allmusic.com thumb"
+msgstr "Omot sa Allmusic.com"
+
+#: id:20057
+msgid "Remove thumbnail"
+msgstr "Ukloni sličicu"
+
+#: id:20058
+msgid "Add profile..."
+msgstr "Dodaj profil..."
+
+#: id:20059
+msgid "Query info for all albums"
+msgstr "Zahtjevaj podatke za sve albume"
+
+#: id:20060
+msgctxt "Auto context with id 20060"
+msgid "Media info"
+msgstr "Podaci o mediju"
+
+#: id:20061
+msgctxt "Auto context with id 20061"
+msgid "Separate"
+msgstr "Odvojeno"
+
+#: id:20062
+msgid "Shares with default"
+msgstr "Podrazumjevano djeljenje"
+
+#: id:20063
+msgid "Shares with default (read only)"
+msgstr "Podrazumjevano djeljenje (samo čitanje)"
+
+#: id:20064
+msgid "Copy default"
+msgstr "Podrazumjevano kopiranje"
+
+#: id:20065
+msgid "Profile picture"
+msgstr "Slika profila"
+
+#: id:20066
+msgid "Lock preferences"
+msgstr "Zaključaj postavke"
+
+#: id:20067
+msgid "Edit profile"
+msgstr "Uredi profil"
+
+#: id:20068
+msgid "Profile lock"
+msgstr "Zaključaj profil"
+
+#: id:20069
+msgid "Could not create folder"
+msgstr "Nije moguće napraviti fasciklu"
+
+#: id:20070
+msgid "Profile directory"
+msgstr "Fascikla profila"
+
+#: id:20071
+msgid "Start with fresh media sources"
+msgstr "Pokreni sa novim izvorom medija"
+
+#: id:20072
+msgid "Make sure the selected folder is writable"
+msgstr "Uvjerite se da u izabranu fasciklu možete"
+
+#: id:20073
+msgid "and that the new folder name is valid"
+msgstr "upisivati i da je novo ime fascikle ispravno"
+
+#: id:20074
+msgid "MPAA rating"
+msgstr "MPAA ocjena"
+
+#: id:20075
+msgid "Enter master lock code"
+msgstr "Unesite glavni kôd za otključavanje"
+
+#: id:20076
+msgid "Ask for master lock code on startup"
+msgstr "Pitaj za glavni kôd prilikom pokretanja apl."
+
+#: id:20077
+msgid "Skin settings"
+msgstr "Postavke maske"
+
+#: id:20078
+msgid "- no link set -"
+msgstr "- veza nije postavljena -"
+
+#: id:20079
+msgid "Enable animations"
+msgstr "Omogući animacije"
+
+#: id:20080
+msgid "Disable RSS during music"
+msgstr "Onemogući RSS novosti tokom reprodukcije muzike"
+
+#: id:20081
+msgid "Enable shortcut buttons"
+msgstr "Omogući prečice"
+
+#: id:20082
+msgid "Show programs in main menu"
+msgstr "Prikaži programe u glavnom meniju"
+
+#: id:20083
+msgid "Show music info"
+msgstr "Prikaži podatke o muzici"
+
+#: id:20084
+msgid "Show weather info"
+msgstr "Prikaži podatke o vremenu"
+
+#: id:20085
+msgid "Show system info"
+msgstr "Prikaži podatke o sistemu"
+
+#: id:20086
+msgid "Show available disc space C: E: F:"
+msgstr "Prikaži slobodan prostor na disku C: E: F:"
+
+#: id:20087
+msgid "Show available disc space E: F: G:"
+msgstr "Prikaži slobodan prostor na disku E: F: G:"
+
+#: id:20088
+msgid "Weather info"
+msgstr "Podaci o vremenu"
+
+#: id:20089
+msgid "Drive space free"
+msgstr "Slobodan prostor na disku"
+
+#: id:20090
+msgid "Enter the name of an existing share"
+msgstr "Unesite ime postojećeg dijeljenog resursa"
+
+#: id:20091
+msgid "Lock code"
+msgstr "Kôd za zaključavanje"
+
+#: id:20092
+msgid "Load profile"
+msgstr "Učitaj profil"
+
+#: id:20093
+msgid "Profile name"
+msgstr "Ime profila"
+
+#: id:20094
+msgctxt "Auto context with id 20094"
+msgid "Media sources"
+msgstr "Mediji izvori"
+
+#: id:20095
+msgid "Enter profile lock code"
+msgstr "Unesite kôd za otključavanje profila"
+
+#: id:20096
+msgctxt "Auto context with id 20096"
+msgid "Login screen"
+msgstr "Ekran za prijavu"
+
+#: id:20097
+msgid "Fetching album info"
+msgstr "Preuzimanje podataka o albumu"
+
+#: id:20098
+msgid "Fetching info for album"
+msgstr "Preuzimanje podataka za album"
+
+#: id:20099
+msgid "Can't rip CD or track while playing from CD"
+msgstr "Nije moguće ripovati muzički CD tokom reprodukcije sa CD-a"
+
+#: id:20100
+msgid "Master lock code and settings"
+msgstr "Glavni kôd za zaključavanje i postavke"
+
+#: id:20101
+msgid "Entering master lock code always enables master mode"
+msgstr "Unosom glavnog kôda uvijek omogućavate glavni režim rada"
+
+#: id:20102
+msgid "or copy from default?"
+msgstr "ili kopiranje od podrazumjevanog?"
+
+#: id:20103
+msgid "Save changes to profile?"
+msgstr "Sačuvati promjene u profil?"
+
+#: id:20104
+msgid "Old settings found."
+msgstr "Pronađene su stare postavke."
+
+#: id:20105
+msgid "Do you want to use them?"
+msgstr "Želite li da ih koristite?"
+
+#: id:20106
+msgid "Old media sources found."
+msgstr "Pronađeni stari izvori medija."
+
+#: id:20107
+msgid "Separate (locked)"
+msgstr "Razdvajanje (zaključano)"
+
+#: id:20108
+msgid "Root"
+msgstr "Korijen fascikla"
+
+#: id:20109
+msgid "- Zoom"
+msgstr "- Uveličavanje"
+
+#: id:20110
+msgid "UPnP settings"
+msgstr "UPnP postavke"
+
+#: id:20111
+msgid "Autostart UPnP client"
+msgstr "Autom. pokretanje UPnP klijenta"
+
+#: id:20112
+msgid "Last login: %s"
+msgstr "Zadnja prijava: %s"
+
+#: id:20113
+msgid "Never logged on"
+msgstr "Nije bilo prijave do sada"
+
+#: id:20114
+msgid "Profile %i / %i"
+msgstr "Profil %i / %i"
+
+#: id:20115
+msgid "User login / Select a profile"
+msgstr "Prijava korisnika / Izaberite profil"
+
+#: id:20116
+msgid "Use lock on login screen"
+msgstr "Koristi zaključavanje ekrana za prijavu"
+
+#: id:20117
+msgid "Invalid lock code."
+msgstr "Kôd nije ispravan."
+
+#: id:20118
+msgid "This requires the master lock to be set."
+msgstr "Ovo zahtjeva unos glavnog kôda."
+
+#: id:20119
+msgid "Would you like to set it now?"
+msgstr "Želite li odmah da postavite?"
+
+#: id:20120
+msgid "Loading program information"
+msgstr "Učitavanje podataka o programu"
+
+#: id:20121
+msgid "Party on!"
+msgstr "Žurka!"
+
+#: id:20122
+msgid "True"
+msgstr "Ispravno"
+
+#: id:20123
+msgid "Mixing drinks"
+msgstr "Mješanje pića"
+
+#: id:20124
+msgid "Filling glasses"
+msgstr "Punjenje čaša"
+
+#: id:20125
+msgid "Logged on as"
+msgstr "Prijavljen kao"
+
+#: id:20126
+msgid "Log off"
+msgstr "Odjavi se"
+
+#: id:20128
+msgid "Go to root"
+msgstr "Idi u korijen fasc."
+
+#: id:20129
+msgid "Weave"
+msgstr "Talasi"
+
+#: id:20130
+msgid "Weave (inverted)"
+msgstr "Talasi (obrnuti)"
+
+#: id:20131
+msgid "Blend"
+msgstr "Mješovito"
+
+#: id:20132
+msgid "Restart video"
+msgstr "Ponovo pokreni film"
+
+#: id:20133
+msgid "Edit network location"
+msgstr "Uredi mrežnu lokaciju"
+
+#: id:20134
+msgid "Remove network location"
+msgstr "Ukloni mrežnu lokaciju"
+
+#: id:20135
+msgid "Do you want to scan the folder?"
+msgstr "Želite li da analizirate fasciklu?"
+
+#: id:20136
+msgid "Memory unit"
+msgstr "Jedinica memorije"
+
+#: id:20137
+msgid "Memory unit mounted"
+msgstr "Jedinica memorije je postavljena"
+
+#: id:20138
+msgid "Unable to mount memory unit"
+msgstr "Nije moguće postaviti jedinicu memorije"
+
+#: id:20139
+msgid "In port %i, slot %i"
+msgstr "u priključku %i, konektor %i"
+
+#: id:20140
+msgid "Lock screensaver"
+msgstr "Zaključaj čuvara ekrana"
+
+#: id:20141
+msgid "Set"
+msgstr "Postavi"
+
+#: id:20142
+msgctxt "Auto context with id 20142"
+msgid "Username"
+msgstr "Korisničko ime"
+
+#: id:20143
+msgid "Enter password for"
+msgstr "Unesite lozinku za"
+
+#: id:20144
+msgid "Shutdown timer"
+msgstr "Odbrojavanje do isključivanja"
+
+#: id:20145
+msgid "Shutdown interval (in minutes)"
+msgstr "Interval isključivanja (u minutima)"
+
+#: id:20146
+msgid "Started, shutdown in %im"
+msgstr "Pokrenuto, isključivanje za %i min."
+
+#: id:20147
+msgid "Shutdown in 30 minutes"
+msgstr "Isključi za 30 minuta"
+
+#: id:20148
+msgid "Shutdown in 60 minutes"
+msgstr "Isključi za 60 minuta"
+
+#: id:20149
+msgid "Shutdown in 120 minutes"
+msgstr "Isključi za 120 minuta"
+
+#: id:20150
+msgid "Custom shutdown timer"
+msgstr "Prilagođeno odbrojavanje do isključenja"
+
+#: id:20151
+msgid "Cancel shutdown timer"
+msgstr "Otkaži odbrojavanje"
+
+#: id:20152
+msgid "Lock preferences for %s"
+msgstr "Zaključaj podešavanja za %s"
+
+#: id:20153
+msgid "Browse..."
+msgstr "Potraži..."
+
+#: id:20154
+msgid "Summary information"
+msgstr "Kratak pregled informacija"
+
+#: id:20155
+msgid "Storage information"
+msgstr "Podaci o skladištu"
+
+#: id:20156
+msgid "Hard disk information"
+msgstr "Podaci o čvrstom disku"
+
+#: id:20157
+msgid "DVD-ROM information"
+msgstr "Podaci o DVD-ROM uređaju"
+
+#: id:20158
+msgid "Network information"
+msgstr "Podaci o mreži"
+
+#: id:20159
+msgid "Video information"
+msgstr "Podaci o videu"
+
+#: id:20160
+msgid "Hardware information"
+msgstr "Podaci o hardveru"
+
+#: id:20161
+msgid "Total"
+msgstr "Ukupno"
+
+#: id:20162
+msgid "Used"
+msgstr "Iskorišteno"
+
+#: id:20163
+msgid "of"
+msgstr "od"
+
+#: id:20164
+msgid "Locking not supported"
+msgstr "Zaključavanje nije podržano"
+
+#: id:20165
+msgid "Not locked"
+msgstr "Nije zaključano"
+
+#: id:20166
+msgid "Locked"
+msgstr "Zaključano"
+
+#: id:20167
+msgid "Frozen"
+msgstr "Zamrznuto"
+
+#: id:20168
+msgid "Requires reset"
+msgstr "Zahtjeva novo pokretanje"
+
+#: id:20169
+msgid "Week"
+msgstr "Nedjelja"
+
+#: id:20170
+msgid "Line"
+msgstr "Linija"
+
+#: id:20171
+msgid "Windows network (SMB)"
+msgstr "Windows mreža (SMB)"
+
+#: id:20172
+msgid "XBMSP server"
+msgstr "XBMSP server"
+
+#: id:20173
+msgctxt "Auto context with id 20173"
+msgid "FTP server"
+msgstr "FTP server"
+
+#: id:20174
+msgid "iTunes music share (DAAP)"
+msgstr "iTunes dijeljena muzika (DAAP)"
+
+#: id:20175
+msgid "UPnP server"
+msgstr "UPnP server"
+
+#: id:20176
+msgid "Show video info"
+msgstr "Prikaži podatke o filmu"
+
+#: id:20177
+msgid "Done"
+msgstr "Završi"
+
+#: id:20178
+msgid "Shift"
+msgstr "Shift"
+
+#: id:20179
+msgid "Caps Lock"
+msgstr "Vel. slova"
+
+#: id:20180
+msgid "Symbols"
+msgstr "Simboli"
+
+#: id:20181
+msgid "Backspace"
+msgstr "Brisanje unazad"
+
+#: id:20182
+msgid "Space"
+msgstr "Razmak"
+
+#: id:20183
+msgid "Reload skin"
+msgstr "Ponovo učitaj masku"
+
+#: id:20184
+msgid "Rotate pictures using EXIF information"
+msgstr "Rotiraj slike na osnovu EXIF podataka"
+
+#: id:20185
+msgid "Use poster view styles for TV shows"
+msgstr "Koristi stil prikaza postera za TV serije"
+
+#: id:20186
+msgid "Please wait"
+msgstr "Molimo sačekajte"
+
+#: id:20187
+msgid "UPnP"
+msgstr "Pravljenje rez. kopije EEPROM-a"
+
+#: id:20189
+msgid "Enable auto scrolling for plot & review"
+msgstr "Omogući autom. pomjeranje opisa i recenzija (sinonopisa)"
+
+#: id:20190
+msgctxt "Auto context with id 20190"
+msgid "Custom"
+msgstr "Prilagođeno"
+
+#: id:20191
+msgid "Enable debug logging"
+msgstr "Omogući bilježenje grešaka"
+
+#: id:20192
+msgid "Download additional information during updates"
+msgstr "Preuzmi dodatne podatke prilikom ažuriranja"
+
+#: id:20193
+msgid "Default service for album information"
+msgstr ""
+
+#: id:20194
+msgid "Default service for artist information"
+msgstr "Podrazumjevani davaoc podataka o muzici"
+
+#: id:20195
+msgid "Change scraper"
+msgstr "Promjeni davaoca podataka"
+
+#: id:20196
+msgid "Export music library"
+msgstr "Izvoz muzičke biblioteke"
+
+#: id:20197
+msgid "Import music library"
+msgstr "Uvoz muzičke biblioteke"
+
+#: id:20198
+msgid "No artist found!"
+msgstr "Izvođač nije pronađen!"
+
+#: id:20199
+msgid "Downloading artist info failed"
+msgstr "Nije uspjelo preuzimanje podataka o izvođaču"
+
+#: id:20250
+msgid "Party on! (videos)"
+msgstr "Žurka! (filmovi)"
+
+#: id:20251
+msgid "Mixing drinks (videos)"
+msgstr "Mješanje pića (filmovi)"
+
+#: id:20252
+msgid "Filling glasses (videos)"
+msgstr "Punjenje čaša (filmovi)"
+
+#: id:20253
+msgid "WebDAV server (HTTP)"
+msgstr "WebDAV server (HTTP)"
+
+#: id:20254
+msgid "WebDAV server (HTTPS)"
+msgstr "WebDAV server (HTTPS)"
+
+#: id:20255
+msgid "First logon, edit your profile"
+msgstr "Izmjenite vaš profil prilikom prvog prijavljivanja"
+
+#: id:20256
+msgid "HTS Tvheadend client"
+msgstr ""
+
+#: id:20257
+msgid "VDR Streamdev client"
+msgstr ""
+
+#: id:20258
+msgid "MythTV client"
+msgstr ""
+
+#: id:20259
+msgid "Network Filesystem (NFS)"
+msgstr ""
+
+#: id:20260
+msgid "Secure Shell (SSH/SFTP)"
+msgstr ""
+
+#: id:20261
+msgid "Apple Filing Protocol (AFP)"
+msgstr ""
+
+#: id:20300
+msgid "Web server directory (HTTP)"
+msgstr "Fascikla Web servera (HTTP)"
+
+#: id:20301
+msgid "Web server directory (HTTPS)"
+msgstr "Fascikla Web servera (HTTPS)"
+
+#: id:20302
+msgid "Unable to write to folder:"
+msgstr "Nije moguće upisivanje u fasciklu:"
+
+#: id:20303
+msgid "Do you want to skip and proceed?"
+msgstr "Želite li da preskočite i nastavite?"
+
+#: id:20304
+msgid "RSS Feed"
+msgstr "RSS novosti"
+
+#: id:20307
+msgid "Secondary DNS"
+msgstr "Alternativni DNS"
+
+#: id:20308
+msgid "DHCP server:"
+msgstr "DHCP server:"
+
+#: id:20309
+msgid "Make new folder"
+msgstr "Napravi novu fasciklu"
+
+#: id:20310
+msgid "Dim LCD on playback"
+msgstr "Zatamni LCD prilikom reprodukcije"
+
+#: id:20311
+msgid "Unknown or onboard (protected)"
+msgstr "Nepoznato ili je ugrađen na ploči (zaštićeno)"
+
+#: id:20312
+msgid "Dim LCD on paused"
+msgstr "Zatamni LCD prilikom pauze"
+
+#: id:20314
+msgid "Videos - Library"
+msgstr "Filmska Biblioteka"
+
+#: id:20316
+msgid "Sort by: ID"
+msgstr "Složi po: ID"
+
+#: id:20324
+msgid "Play part..."
+msgstr "Reprodukuj dio..."
+
+#: id:20325
+msgid "Calibration reset"
+msgstr "Ponovna kalibracija"
+
+#: id:20326
+msgid "This will reset the calibration values for %s"
+msgstr "Ovim ćete poništiti vrijednosti kalibracije za %s"
+
+#: id:20327
+msgid "to it's default values."
+msgstr "na podrazumevane vrijednosti."
+
+#: id:20328
+msgid "Browse for destination"
+msgstr "Potraži odredište"
+
+#: id:20329
+msgid "Movies are in separate folders that match the movie title"
+msgstr ""
+
+#: id:20330
+msgid "Use folder names for lookups"
+msgstr "Koristi imena fascikli za pretragu"
+
+#: id:20331
+msgctxt "Auto context with id 20331"
+msgid "File"
+msgstr "Datoteke"
+
+#: id:20332
+msgid "Use file or folder names in lookups?"
+msgstr "Korištenje imena datoteke ili fascikle za pretragu?"
+
+#: id:20333
+msgid "Set content"
+msgstr "Postavi sadržaj"
+
+#: id:20334
+msgid "Folder"
+msgstr "Fascikle"
+
+#: id:20335
+msgid "Look for content recursively?"
+msgstr "Rekurzivna pretraga sadržaja?"
+
+#: id:20336
+msgid "Unlock sources"
+msgstr "Otključaj izvore"
+
+#: id:20337
+msgid "Actor"
+msgstr "Glumac"
+
+#: id:20338
+msgid "Movie"
+msgstr "Film"
+
+#: id:20339
+msgid "Director"
+msgstr "Režiser"
+
+#: id:20340
+msgid "Do you want to remove all items within"
+msgstr "Želite li da uklonite sve stavke u okviru"
+
+#: id:20341
+msgid "this path from the XBMC library?"
+msgstr "ove putanje iz XBMC biblioteke?"
+
+#: id:20342
+msgctxt "Auto context with id 20342"
+msgid "Movies"
+msgstr "Filmovi"
+
+#: id:20343
+msgid "TV shows"
+msgstr "TV serije"
+
+#: id:20344
+msgid "This directory contains"
+msgstr "Ova fascikla sadrži"
+
+#: id:20345
+msgid "Run automated scan"
+msgstr "Pokreni automatsku analizu"
+
+#: id:20346
+msgid "Scan recursively"
+msgstr "Rekurzivna analiza"
+
+#: id:20347
+msgid "as"
+msgstr "kao"
+
+#: id:20348
+msgid "Directors"
+msgstr "Režiseri"
+
+#: id:20349
+msgid "No video files found in this path!"
+msgstr "Na ovoj putanji ne postoje video datoteke!"
+
+#: id:20350
+msgid "votes"
+msgstr "glasova"
+
+#: id:20351
+msgid "TV show information"
+msgstr "Podaci o TV seriji"
+
+#: id:20352
+msgid "Episode information"
+msgstr "Podaci o epizodama"
+
+#: id:20353
+msgid "Loading TV show details"
+msgstr "Učitavanje detalja TV serije"
+
+#: id:20354
+msgid "Fetching episode guide"
+msgstr "Pronalaženje vodiča epizoda"
+
+#: id:20355
+msgid "Loading info for episodes in directory"
+msgstr "Učitavanje opisa epizode u fascikli"
+
+#: id:20356
+msgid "Select TV show:"
+msgstr "Izaberite TV seriju:"
+
+#: id:20357
+msgid "Enter the TV show name"
+msgstr "Unesite naziv TV serije"
+
+#: id:20358
+msgid "Season %i"
+msgstr "Sezona %i"
+
+#: id:20359
+msgid "Episode"
+msgstr "Epizoda"
+
+#: id:20360
+msgid "Episodes"
+msgstr "Epizoda"
+
+#: id:20361
+msgid "Loading episode details"
+msgstr "Učitavanje detalja epizode"
+
+#: id:20362
+msgid "Remove episode from library"
+msgstr "Ukloni epizodu iz biblioteke"
+
+#: id:20363
+msgid "Remove TV show from library"
+msgstr "Ukloni TV seriju iz biblioteke"
+
+#: id:20364
+msgid "TV show"
+msgstr "TV serija"
+
+#: id:20365
+msgid "Episode plot"
+msgstr "Opis epizode"
+
+#: id:20366
+msgid "* All seasons"
+msgstr "* Sve sezone"
+
+#: id:20367
+msgid "Hide watched"
+msgstr "Sakr. odgled."
+
+#: id:20368
+msgid "Prod code"
+msgstr "Šifra proizvoda"
+
+#: id:20369
+msgid "Show plot for unwatched items"
+msgstr "Prikaži opis za neodgledane stavke"
+
+#: id:20370
+msgid "* Hidden to prevent spoilers *"
+msgstr "* Skriveno zbog spriječavanja nepropisne upotrebe *"
+
+#: id:20371
+msgid "Set season thumb"
+msgstr "Postavi sličicu za sezonu"
+
+#: id:20372
+msgid "Season image"
+msgstr "Slika za sezonu"
+
+#: id:20373
+msgid "Season"
+msgstr "Sezona"
+
+#: id:20374
+msgid "Downloading movie information"
+msgstr "Preuzimanje podataka o filmu"
+
+#: id:20375
+msgid "Unassign content"
+msgstr "Neodređen sadržaj"
+
+#: id:20376
+msgid "Original title"
+msgstr ""
+
+#: id:20377
+msgid "Refresh TV show information"
+msgstr "Osvježi podatke TV serije"
+
+#: id:20378
+msgid "Refresh info for all episodes?"
+msgstr "Osvježiti podatke za sve epizode?"
+
+#: id:20379
+msgid "Selected folder contains a single TV show"
+msgstr "Izabrana fascikla sadrži jednu TV seriju"
+
+#: id:20380
+msgid "Exclude selected folder from scans"
+msgstr "Izuzmi izabranu fasciklu iz analiziranja"
+
+#: id:20381
+msgid "Specials"
+msgstr "Posebne emisije"
+
+#: id:20382
+msgid "Automatically grab season thumbs"
+msgstr "Automatski preuzmi sličicu sezone"
+
+#: id:20383
+msgid "Selected folder contains a single video"
+msgstr "Izabrana fascikla sadrži jedan film"
+
+#: id:20384
+msgid "Link to TV show"
+msgstr "Veza ka TV seriji"
+
+#: id:20385
+msgid "Remove link to TV show"
+msgstr "Ukloni vezu ka TV seriji"
+
+#: id:20386
+msgid "Recently added movies"
+msgstr "Nedav. dodati film."
+
+#: id:20387
+msgid "Recently added episodes"
+msgstr "Nedav. dodate epizode"
+
+#: id:20388
+msgid "Studios"
+msgstr "Studiji"
+
+#: id:20389
+msgid "Music videos"
+msgstr "Muzičke spotove"
+
+#: id:20390
+msgid "Recently added music videos"
+msgstr "Nedavno dodani muzički spotovi"
+
+#: id:20391
+msgid "Music video"
+msgstr "Muzički spot"
+
+#: id:20392
+msgid "Remove music video from library"
+msgstr "Ukloni muzički spot iz biblioteke"
+
+#: id:20393
+msgctxt "Auto context with id 20393"
+msgid "Music video information"
+msgstr "Podaci o muzičkom spotu"
+
+#: id:20394
+msgid "Loading music video information"
+msgstr "Učitavanje podataka o muzičkom spotu"
+
+#: id:20395
+msgid "Mixed"
+msgstr "Mešano"
+
+#: id:20396
+msgid "Go to albums by artist"
+msgstr "Idi na albume izvođača"
+
+#: id:20397
+msgid "Go to album"
+msgstr "Idi na album"
+
+#: id:20398
+msgid "Play song"
+msgstr "Reprodukuj pjesmu"
+
+#: id:20399
+msgid "Go to music videos from album"
+msgstr "Idi na muzičke spotove iz albuma"
+
+#: id:20400
+msgid "Go to music videos by artist"
+msgstr "Idi na muzičke spotove izvođača"
+
+#: id:20401
+msgid "Play music video"
+msgstr "Reprodukuj muzički spot"
+
+#: id:20402
+msgid "Download actor thumbnails when adding to library"
+msgstr "Preuzmi sličice glumaca prilikom dodavanja u biblioteku"
+
+#: id:20403
+msgid "Set actor thumb"
+msgstr "Postavi sliku glumca"
+
+#: id:20405
+msgid "Remove episode bookmark"
+msgstr "Ukloni obilježivač epizode"
+
+#: id:20406
+msgid "Set episode bookmark"
+msgstr "Postavi obilježivač epizode"
+
+#: id:20407
+msgid "Scraper settings"
+msgstr "Postavke davaoca podataka"
+
+#: id:20408
+msgid "Downloading music video information"
+msgstr "Preuzimanje podataka o muzičkom spotu"
+
+#: id:20409
+msgid "Downloading TV show information"
+msgstr "Preuzimanje podataka o TV seriji"
+
+#: id:20410
+msgid "Trailer"
+msgstr "Najava"
+
+#: id:20411
+msgid "Flatten"
+msgstr "Poravnat spisak"
+
+#: id:20412
+msgid "Flatten TV shows"
+msgstr "Poravnat spisak TV serija"
+
+#: id:20413
+msgid "Get fanart"
+msgstr "Zanim. slika"
+
+#: id:20414
+msgid "Show Fanart in video and music libraries"
+msgstr "Prikaži zanimljivu sliku u filmskim i muzičkim bibliotekama"
+
+#: id:20415
+msgid "Scanning for new content"
+msgstr "Traženje novog sadržaja"
+
+#: id:20416
+msgid "First aired"
+msgstr "Premijera"
+
+#: id:20417
+msgid "Writer"
+msgstr "Scenarista"
+
+#: id:20419
+msgid "Replace file names with library titles"
+msgstr ""
+
+#: id:20420
+msgctxt "Auto context with id 20420"
+msgid "Never"
+msgstr "Nikada"
+
+#: id:20421
+msgid "If only one season"
+msgstr "Ukoliko je samo jedna sezona"
+
+#: id:20422
+msgid "Always"
+msgstr "Uvijek"
+
+#: id:20423
+msgid "Has trailer"
+msgstr "Ima najavu filma"
+
+#: id:20424
+msgid "False"
+msgstr "Netačno"
+
+#: id:20425
+msgid "Fanart slideshow"
+msgstr "Projekcija zanimljivih slika"
+
+#: id:20426
+msgid "Export to a single file or separate"
+msgstr "Izvoz u jednu ili zasebne"
+
+#: id:20427
+msgid "files per entry?"
+msgstr "datoteke po unosu?"
+
+#: id:20428
+msgid "Single file"
+msgstr "Jedna datoteka"
+
+#: id:20429
+msgctxt "Auto context with id 20429"
+msgid "Separate"
+msgstr "Zasebno"
+
+#: id:20430
+msgid "Export thumbnails and fanart?"
+msgstr "Izvoz sličica i zanimljivih slika?"
+
+#: id:20431
+msgid "Overwrite old files?"
+msgstr "Zamjeniti stare datoteke?"
+
+#: id:20432
+msgid "Exclude path from library updates"
+msgstr "Izuzmi putanju prilikom ažuriranja biblioteke"
+
+#: id:20433
+msgid "Extract thumbnails and video information"
+msgstr "Izvezi sličice i podatke filma"
+
+#: id:20434
+msgid "Sets"
+msgstr "Postavke scene"
+
+#: id:20435
+msgid "Set movieset thumb"
+msgstr "Postavi slike sa snimanja filma"
+
+#: id:20436
+msgid "Export actor thumbs?"
+msgstr "Izvoz sličica glumca?"
+
+#: id:20437
+msgid "Choose fanart"
+msgstr "Izaberite zanimljivu sliku"
+
+#: id:20438
+msgid "Local fanart"
+msgstr "Lokalna zanimljiva slika"
+
+#: id:20439
+msgid "No fanart"
+msgstr "Bez zanimljive slike"
+
+#: id:20440
+msgid "Current fanart"
+msgstr "Trenutna zanimljiva slika"
+
+#: id:20441
+msgid "Remote fanart"
+msgstr "Udaljena zanimljiva slika"
+
+#: id:20442
+msgid "Change content"
+msgstr "Promjeni sadržaj"
+
+#: id:20443
+msgid "Do you want to refresh info for all"
+msgstr "Želite li da osvježite podatke svih"
+
+#: id:20444
+msgid "items within this path?"
+msgstr "stavki sa ove putanje?"
+
+#: id:20445
+msgid "Fanart"
+msgstr "Zanimljiva slika"
+
+#: id:20446
+msgid "Locally stored information found."
+msgstr "Pronađeni su lokalno sačuvani podaci."
+
+#: id:20447
+msgid "Ignore and refresh from internet?"
+msgstr "Zanemariti ih i osvježiti iste sa podacima sa Interneta?"
+
+#: id:20448
+msgid "Could not download information"
+msgstr "Nije moguće preuzeti podatke"
+
+#: id:20449
+msgid "Unable to connect to remote server"
+msgstr "Server je najvjerovatnije nedostupan."
+
+#: id:20450
+msgid "Would you like to continue scanning?"
+msgstr "Želite li da nastavite analiziranje?"
+
+#: id:20451
+msgid "Countries"
+msgstr ""
+
+#: id:20452
+msgid "episode"
+msgstr ""
+
+#: id:20453
+msgid "episodes"
+msgstr ""
+
+#: id:20454
+msgid "Listener"
+msgstr ""
+
+#: id:20455
+msgid "Listeners"
+msgstr ""
+
+#: id:20456
+msgid "Set movieset fanart"
+msgstr ""
+
+#: id:20457
+msgid "Movie set"
+msgstr ""
+
+#: id:20458
+msgid "Group movies in sets"
+msgstr ""
+
+#: id:21330
+msgid "Show hidden files and directories"
+msgstr "Prikaži skrivene datoteke i fascikle"
+
+#: id:21331
+msgid "TuxBox client"
+msgstr "TuxBox klijent"
+
+#: id:21332
+msgid "WARNING: Target TuxBox device is in recording-mode!"
+msgstr "PAŽNjA: Izabrani TuxBox uređaj trenutno snima!"
+
+#: id:21333
+msgid "The stream will be stopped!"
+msgstr "Biće zaustavljen zapis toka podataka!"
+
+#: id:21334
+msgid "Zap to channel: %s failed!"
+msgstr "Prebacivanje na kanal: %s nije uspjelo!"
+
+#: id:21335
+msgid "Are you sure to start the stream?"
+msgstr "Sigurni ste da želite da pokrenete tok podataka?"
+
+#: id:21336
+msgid "Connecting to: %s"
+msgstr "Povezivanje sa: %s"
+
+#: id:21337
+msgid "TuxBox device"
+msgstr "TuxBox uređaj"
+
+#: id:21359
+msgid "Add media share..."
+msgstr "Dodaj dijeljenu lokaciju medija..."
+
+#: id:21360
+msgid "Share video and music libraries through UPnP"
+msgstr "Dijeli filmsku i muzičku biblioteku putem UPnP protokola"
+
+#: id:21364
+msgid "Edit media share"
+msgstr "Uredi dijeljenu lokaciju medija"
+
+#: id:21365
+msgid "Remove media share"
+msgstr "Ukloni dijeljenu lokaciju medija"
+
+#: id:21366
+msgid "Subtitle folder"
+msgstr "Fascikla sa titlovima"
+
+#: id:21367
+msgid "Movie & alternate subtitle directory"
+msgstr "Fascikla filmova i alternativnih titlova"
+
+#: id:21368
+msgid "Override ASS/SSA subtitles fonts"
+msgstr ""
+
+#: id:21369
+msgid "Enable mouse and Touch Screen support"
+msgstr "Omogući korišćenje miša"
+
+#: id:21370
+msgid "Play navigation sounds during media playback"
+msgstr "Reprodukuj navigacione zvukove prilikom reprodukcije medija"
+
+#: id:21371
+msgid "Thumbnail"
+msgstr "Sličica"
+
+#: id:21372
+msgid "Forced DVD player region"
+msgstr "Nametnuta regija DVD uređaja za reprodukciju"
+
+#: id:21373
+msgid "Video output"
+msgstr "Video izlaz"
+
+#: id:21374
+msgid "Video aspect"
+msgstr "Razmjera slike"
+
+#: id:21375
+msgctxt "Auto context with id 21375"
+msgid "Normal"
+msgstr "Normalno"
+
+#: id:21376
+msgid "Letterbox"
+msgstr "Letterbox"
+
+#: id:21377
+msgid "Widescreen"
+msgstr "Široki ekran"
+
+#: id:21378
+msgid "Enable 480p"
+msgstr "Omogući 480p"
+
+#: id:21379
+msgid "Enable 720p"
+msgstr "Omogući 720p"
+
+#: id:21380
+msgid "Enable 1080i"
+msgstr "Omogući 1080i"
+
+#: id:21381
+msgid "Enter name of new playlist"
+msgstr "Unesite ime novog spiska za reprodukciju"
+
+#: id:21382
+msgid "Show \"Add source\" buttons in file lists"
+msgstr "Prikaži dugme „Dodaj izvor“ u spisku datoteka"
+
+#: id:21383
+msgid "Enable scrollbars"
+msgstr "Omogući trake za pomjeranje"
+
+#: id:21384
+msgid "Make watched filtering a toggle in video library"
+msgstr "Isfiltriraj odgledane filmove u biblioteci filmova"
+
+#: id:21385
+msgctxt "Auto context with id 21385"
+msgid "Open"
+msgstr "Otvori"
+
+#: id:21386
+msgid "Acoustic management level"
+msgstr "Upravljanje nivoom akustičnosti"
+
+#: id:21387
+msgid "Fast"
+msgstr "Brzo"
+
+#: id:21388
+msgid "Quiet"
+msgstr "Tiho"
+
+#: id:21389
+msgid "Enable custom background"
+msgstr "Omogući prilagođenu pozadinu"
+
+#: id:21390
+msgid "Power management level"
+msgstr "Upravljanje nivoom potrošnje"
+
+#: id:21391
+msgid "High power"
+msgstr "Viša potrošnja"
+
+#: id:21392
+msgid "Low power"
+msgstr "Niža potrošnja"
+
+#: id:21393
+msgid "High standby"
+msgstr "High standby"
+
+#: id:21394
+msgid "Low standby"
+msgstr "Low standby"
+
+#: id:21395
+msgid "Unable to cache files bigger than 4GB"
+msgstr "Nije moguće keširati datoteke veće od 4GB"
+
+#: id:21396
+msgid "Chapter"
+msgstr "Poglavlje"
+
+#: id:21397
+msgid "High quality pixel shader v2"
+msgstr "Visoko kvalitetno sjenčenje piksela v2"
+
+#: id:21398
+msgid "Enable playlist at startup"
+msgstr "Omogući spisak za reprodukciju pri uključivanju XBMC-a"
+
+#: id:21399
+msgid "Use tween animations"
+msgstr "Koristi međukorake u animaciji"
+
+#: id:21400
+msgid "contains"
+msgstr "sadrži"
+
+#: id:21401
+msgid "does not contain"
+msgstr "ne sadrži"
+
+#: id:21402
+msgid "is"
+msgstr "je"
+
+#: id:21403
+msgid "is not"
+msgstr "nije"
+
+#: id:21404
+msgid "starts with"
+msgstr "počinje sa"
+
+#: id:21405
+msgid "ends with"
+msgstr "završava sa"
+
+#: id:21406
+msgid "greater than"
+msgstr "je veće od"
+
+#: id:21407
+msgid "less than"
+msgstr "je manje od"
+
+#: id:21408
+msgid "after"
+msgstr "nakon"
+
+#: id:21409
+msgid "before"
+msgstr "prije"
+
+#: id:21410
+msgid "in the last"
+msgstr "u posljednjih"
+
+#: id:21411
+msgid "not in the last"
+msgstr "nije u posljednjih"
+
+#: id:21412
+msgid "Scrapers"
+msgstr "Dobavljači podat."
+
+#: id:21413
+msgid "Default movie scraper"
+msgstr "Podraz. dobavljač podataka za filmove"
+
+#: id:21414
+msgid "Default tvshow scraper"
+msgstr "Podraz. dobavljač podataka za TV serije"
+
+#: id:21415
+msgid "Default music video scraper"
+msgstr "Podraz. dobavljač podataka za muzičke spotove"
+
+#: id:21416
+msgid "Enable fallback based on scraper language"
+msgstr "Omogući preuzimanje na osnovu jezika dobavljača podataka"
+
+#: id:21417
+msgid "- Settings"
+msgstr "- Postavke"
+
+#: id:21418
+msgid "Multilingual"
+msgstr "Višejezično"
+
+#: id:21419
+msgid "No scrapers present"
+msgstr "Nema prisutnih dobavljača"
+
+#: id:21420
+msgid "Value to match"
+msgstr "Vrijednosti se ne podudaraju"
+
+#: id:21421
+msgid "Smart playlist rule"
+msgstr "Pravilo pametnog spis. za rep."
+
+#: id:21422
+msgid "Match items where"
+msgstr "Podudari stavke gdje"
+
+#: id:21423
+msgid "New rule..."
+msgstr "Novo pravilo..."
+
+#: id:21424
+msgid "Items must match"
+msgstr "Stavke se moraju podudarati"
+
+#: id:21425
+msgid "all of the rules"
+msgstr "su sva pravila"
+
+#: id:21426
+msgid "one or more of the rules"
+msgstr "je jedno ili više pravila"
+
+#: id:21427
+msgid "Limit to"
+msgstr "Ograniči na"
+
+#: id:21428
+msgid "No limit"
+msgstr "Bez ograničenja"
+
+#: id:21429
+msgid "Order by"
+msgstr "Složi po"
+
+#: id:21430
+msgid "ascending"
+msgstr "rastućem redu"
+
+#: id:21431
+msgid "descending"
+msgstr "opadajućem redu"
+
+#: id:21432
+msgid "Edit smart playlist"
+msgstr "Uredi pametni spis. za rep."
+
+#: id:21433
+msgid "Name of the playlist"
+msgstr "Ime spis. za rep."
+
+#: id:21434
+msgid "Find items where"
+msgstr "Pronađi stavke gdje"
+
+#: id:21435
+msgid "Edit"
+msgstr "Uredi"
+
+#: id:21436
+msgid "%i items"
+msgstr "%i stavki"
+
+#: id:21437
+msgid "New smart playlist..."
+msgstr "Novi pametni spis. za rep..."
+
+#: id:21438
+msgid "%c Drive"
+msgstr "%c uređaj"
+
+#: id:21439
+msgid "Edit party mode rules"
+msgstr "Uredi pravila režima žurke"
+
+#: id:21440
+msgid "Home folder"
+msgstr "Početna fascikla"
+
+#: id:21441
+msgid "Watched count"
+msgstr "Brojač odgledanih"
+
+#: id:21442
+msgid "Episode title"
+msgstr "Naslov epizode"
+
+#: id:21443
+msgid "Video resolution"
+msgstr "Rezolucija videa"
+
+#: id:21444
+msgid "Audio channels"
+msgstr "Zvučnih kanala"
+
+#: id:21445
+msgid "Video codec"
+msgstr "Video kodek"
+
+#: id:21446
+msgid "Audio codec"
+msgstr "Kodek zvuka"
+
+#: id:21447
+msgid "Audio language"
+msgstr "Jezik zvuka"
+
+#: id:21448
+msgid "Subtitle language"
+msgstr "Jezik titla"
+
+#: id:21449
+msgid "Remote control sends keyboard presses"
+msgstr "Daljinski upravljač šalje kôdove tastature"
+
+#: id:21450
+msgid "- Edit"
+msgstr "- Uredi"
+
+#: id:21451
+msgid "Internet connection required."
+msgstr ""
+
+#: id:21452
+msgid "Get More..."
+msgstr ""
+
+#: id:21453
+msgid "Root filesystem"
+msgstr ""
+
+#: id:21454
+msgid "Cache full"
+msgstr ""
+
+#: id:21455
+msgid "Cache filled before reaching required amount for continous playback"
+msgstr ""
+
+#: id:21460
+msgid "Subtitle location"
+msgstr ""
+
+#: id:21461
+msgid "Fixed"
+msgstr ""
+
+#: id:21462
+msgid "Bottom of video"
+msgstr ""
+
+#: id:21463
+msgid "Below video"
+msgstr ""
+
+#: id:21464
+msgid "Top of video"
+msgstr ""
+
+#: id:21465
+msgid "Above video"
+msgstr ""
+
+#: id:21800
+msgid "File name"
+msgstr "Ime datoteke"
+
+#: id:21801
+msgid "File path"
+msgstr "Putanja datoteke"
+
+#: id:21802
+msgid "File size"
+msgstr "Veličina datoteke"
+
+#: id:21803
+msgid "File date/time"
+msgstr "Datum/vrijeme stvaranja datoteke"
+
+#: id:21804
+msgid "Slide index"
+msgstr "Indeks slajdova"
+
+#: id:21805
+msgctxt "Auto context with id 21805"
+msgid "Resolution"
+msgstr "Rezolucija"
+
+#: id:21806
+msgctxt "Auto context with id 21806"
+msgid "Comment"
+msgstr "Komentar"
+
+#: id:21807
+msgid "Colour/B&W"
+msgstr "Boja/Crno-belo"
+
+#: id:21808
+msgid "JPEG process"
+msgstr "Obrada JPEG-a"
+
+#: id:21820
+msgid "Date/Time"
+msgstr "Datum/vrijeme"
+
+#: id:21821
+msgid "Description"
+msgstr "Opis"
+
+#: id:21822
+msgid "Camera make"
+msgstr "Marka fotoaparata"
+
+#: id:21823
+msgid "Camera model"
+msgstr "Tip kamere"
+
+#: id:21824
+msgid "EXIF comment"
+msgstr "EXIF komentar"
+
+#: id:21825
+msgid "Firmware"
+msgstr "Sistem"
+
+#: id:21826
+msgid "Aperture"
+msgstr "Blenda"
+
+#: id:21827
+msgid "Focal length"
+msgstr "Fokusno rastojanje"
+
+#: id:21828
+msgid "Focus distance"
+msgstr "Žižna daljina"
+
+#: id:21829
+msgid "Exposure"
+msgstr "Ekspozicija"
+
+#: id:21830
+msgid "Exposure time"
+msgstr "Vrijeme ekspozicije"
+
+#: id:21831
+msgid "Exposure bias"
+msgstr "Odstupanje ekspozicije"
+
+#: id:21832
+msgid "Exposure mode"
+msgstr "Režim ekspozicije"
+
+#: id:21833
+msgid "Flash used"
+msgstr "Korišćenje blica"
+
+#: id:21834
+msgid "White-balance"
+msgstr "Balans bijelog"
+
+#: id:21835
+msgid "Light source"
+msgstr "Izvor svjetla"
+
+#: id:21836
+msgid "Metering mode"
+msgstr "Režim mjerenja količine svetla"
+
+#: id:21837
+msgid "ISO"
+msgstr "ISO"
+
+#: id:21838
+msgid "Digital zoom"
+msgstr "Digitalni zum"
+
+#: id:21839
+msgid "CCD width"
+msgstr "CCD širina"
+
+#: id:21840
+msgid "GPS latitude"
+msgstr "GPS geo. širina"
+
+#: id:21841
+msgid "GPS longitude"
+msgstr "GPS geo. dužina"
+
+#: id:21842
+msgid "GPS altitude"
+msgstr "GPS geo. visina"
+
+#: id:21843
+msgid "Orientation"
+msgstr "Orijentacija"
+
+#: id:21860
+msgid "Supplemental categories"
+msgstr "Dodatne kategorije"
+
+#: id:21861
+msgid "Keywords"
+msgstr "Ključne reči"
+
+#: id:21862
+msgid "Caption"
+msgstr "Naslov"
+
+#: id:21863
+msgid "Author"
+msgstr "Autor"
+
+#: id:21864
+msgid "Headline"
+msgstr "Glavna uloga"
+
+#: id:21865
+msgid "Special instructions"
+msgstr "Posebna uputstva"
+
+#: id:21866
+msgid "Category"
+msgstr "Kategorija"
+
+#: id:21867
+msgid "Byline"
+msgstr "Potpis autora"
+
+#: id:21868
+msgid "Byline title"
+msgstr "Potpis autora naslova"
+
+#: id:21869
+msgid "Credit"
+msgstr "Zasluga"
+
+#: id:21870
+msgid "Source"
+msgstr "Izvor"
+
+#: id:21871
+msgid "Copyright notice"
+msgstr "Autorska prava"
+
+#: id:21872
+msgid "Object name"
+msgstr "Ime objekta"
+
+#: id:21873
+msgid "City"
+msgstr "Grad"
+
+#: id:21874
+msgid "State"
+msgstr "Pokrajina"
+
+#: id:21875
+msgctxt "Auto context with id 21875"
+msgid "Country"
+msgstr "Država"
+
+#: id:21876
+msgid "Original Tx Reference"
+msgstr "Original Tx Reference"
+
+#: id:21877
+msgid "Date created"
+msgstr "Datum pravljenja"
+
+#: id:21878
+msgid "Copyright flag"
+msgstr "Oznaka autorskog prava"
+
+#: id:21879
+msgid "Country code"
+msgstr "Kôd države"
+
+#: id:21880
+msgid "Reference service"
+msgstr "Preporučen servis"
+
+#: id:21881
+msgid "Allow control of XBMC via UPnP"
+msgstr "Omogući kontrolu XBMC aplikacije putem UPnP protokola"
+
+#: id:21882
+msgid "Attempt to skip introduction before DVD menu"
+msgstr "Pokušaj da preskočiš uvodni dio prije DVD menija"
+
+#: id:21883
+msgid "Saved music"
+msgstr "Sačuvana muzika"
+
+#: id:21884
+msgid "Query info for all artists"
+msgstr "Zahtjevanje podataka za sve izvođače"
+
+#: id:21885
+msgid "Downloading album information"
+msgstr "Preuzimanje podataka o albumu"
+
+#: id:21886
+msgid "Downloading artist information"
+msgstr "Preuzimanje podataka o izvođaču"
+
+#: id:21887
+msgid "Biography"
+msgstr "Biografija"
+
+#: id:21888
+msgid "Discography"
+msgstr "Diskografija"
+
+#: id:21889
+msgid "Searching artist"
+msgstr "Pronalaženje izvođača"
+
+#: id:21890
+msgid "Select artist"
+msgstr "Izaberite izvođača"
+
+#: id:21891
+msgctxt "Auto context with id 21891"
+msgid "Artist information"
+msgstr "Podaci o izvođaču"
+
+#: id:21892
+msgid "Instruments"
+msgstr "Instrumenti"
+
+#: id:21893
+msgid "Born"
+msgstr "Rođen"
+
+#: id:21894
+msgid "Formed"
+msgstr "Oformljeno"
+
+#: id:21895
+msgid "Themes"
+msgstr "Teme"
+
+#: id:21896
+msgid "Disbanded"
+msgstr "Rasformirano"
+
+#: id:21897
+msgid "Died"
+msgstr "Preminuo"
+
+#: id:21898
+msgid "Years active"
+msgstr "Godina aktivan"
+
+#: id:21899
+msgid "Label"
+msgstr "Etiketa"
+
+#: id:21900
+msgid "Born/Formed"
+msgstr "Rođ./oform."
+
+#: id:22000
+msgid "Update library on startup"
+msgstr "Ažuriraj biblioteku prilikom uključivanja"
+
+#: id:22001
+msgid "Hide progress of library updates"
+msgstr "Uvijek ažuriraj biblioteku u pozadini"
+
+#: id:22002
+msgid "- DNS suffix"
+msgstr "- DNS sufiks"
+
+#: id:22003
+msgid "%2.3fs"
+msgstr ""
+
+#: id:22004
+msgid "Delayed by: %2.3fs"
+msgstr "Usporeno za: %2.3f sek."
+
+#: id:22005
+msgid "Ahead by: %2.3fs"
+msgstr "Ubrzano za: %2.3f sek."
+
+#: id:22006
+msgid "Subtitle offset"
+msgstr "Pomjeraj titl u vremenu"
+
+#: id:22007
+msgid "OpenGL vendor:"
+msgstr "OpenGL proizvođač:"
+
+#: id:22008
+msgid "OpenGL renderer:"
+msgstr "OpenGL renderer:"
+
+#: id:22009
+msgid "OpenGL version:"
+msgstr "OpenGL verzija:"
+
+#: id:22010
+msgid "GPU temperature:"
+msgstr "GPU temperatura:"
+
+#: id:22011
+msgid "CPU temperature:"
+msgstr "CPU temperatura:"
+
+#: id:22012
+msgid "Total memory"
+msgstr "Ukupna memorija"
+
+#: id:22013
+msgid "Profile data"
+msgstr "Podaci profila"
+
+#: id:22014
+msgid "Use dim if paused during video playback"
+msgstr "Koristi zatamljenje ukoliko se pauzira prilikom reprod. filma"
+
+#: id:22015
+msgid "All recordings"
+msgstr "Sva snimanja"
+
+#: id:22016
+msgid "By title"
+msgstr "Po nazivu"
+
+#: id:22017
+msgid "By group"
+msgstr "Po grupi"
+
+#: id:22018
+msgid "Live channels"
+msgstr "Kanali uživo"
+
+#: id:22019
+msgid "Recordings by title"
+msgstr "Snimci po nazivu"
+
+#: id:22020
+msgid "Guide"
+msgstr "Vodič"
+
+#: id:22021
+msgid "Allowed error in aspect ratio to minimize black bars"
+msgstr "Dozv. greška u odnosu, radi smanjenja crnih traka"
+
+#: id:22022
+msgid "Show video files in listings"
+msgstr "Prikaži video datoteke u spiskovima"
+
+#: id:22023
+msgid "DirectX vendor:"
+msgstr "DirectX proizvođač:"
+
+#: id:22024
+msgid "Direct3D version:"
+msgstr "Direct3D verzija:"
+
+#: id:22030
+msgctxt "Auto context with id 22030"
+msgid "Font"
+msgstr "Slova"
+
+#: id:22031
+msgctxt "Auto context with id 22031"
+msgid "- Size"
+msgstr "- Veličina"
+
+#: id:22032
+msgctxt "Auto context with id 22032"
+msgid "- Colours"
+msgstr "- Boja"
+
+#: id:22033
+msgid "- Charset"
+msgstr "- Znakovi"
+
+#: id:22034
+msgid "Export karaoke titles as HTML"
+msgstr "Izvoz karaoke naslova kao HTML"
+
+#: id:22035
+msgid "Export karaoke titles as CSV"
+msgstr "Izvoz karaoke naslova kao CSV"
+
+#: id:22036
+msgid "Import karaoke titles..."
+msgstr "Uvoz karaoke naslova..."
+
+#: id:22037
+msgid "Show song selector automatically"
+msgstr "Automatski prikaži birač pesme"
+
+#: id:22038
+msgid "Export karaoke titles..."
+msgstr "Izvoz karaoke naslova..."
+
+#: id:22039
+msgid "Enter song number"
+msgstr "Unesite broj pjesme"
+
+#: id:22040
+msgid "white/green"
+msgstr "bijelo/zeleno"
+
+#: id:22041
+msgid "white/red"
+msgstr "bijelo/crveno"
+
+#: id:22042
+msgid "white/blue"
+msgstr "bijelo/pravo"
+
+#: id:22043
+msgid "black/white"
+msgstr "crno/bijelo"
+
+#: id:22079
+msgid "Default select action"
+msgstr ""
+
+#: id:22080
+msgid "Choose"
+msgstr ""
+
+#: id:22081
+msgid "Show Information"
+msgstr ""
+
+#: id:22082
+msgid "More..."
+msgstr ""
+
+#: id:22083
+msgid "Play all"
+msgstr ""
+
+#: id:23049
+msgid "Teletext not available"
+msgstr "Teletekst nije dostupan"
+
+#: id:23050
+msgid "Activate Teletext"
+msgstr "Aktiviraj teletekst"
+
+#: id:23051
+msgid "Part %i"
+msgstr "Dio %i"
+
+#: id:23052
+msgid "Buffering %i bytes"
+msgstr "Predmemorisanje %i bajtova"
+
+#: id:23053
+msgid "Stopping"
+msgstr "Zaustavljanje"
+
+#: id:23054
+msgid "Running"
+msgstr "Pokretanje"
+
+#: id:23100
+msgid "External Player Active"
+msgstr "Spoljni aktivni uređaj za reprodukciju"
+
+#: id:23101
+msgid "Click OK to terminate the player"
+msgstr "Kliknite na „U redu“ da prekinete reprodukciju"
+
+#: id:23104
+msgid "Click OK when playback has ended"
+msgstr "Kliknite na „U redu“ kada se reprodukcija završi"
+
+#: id:24000
+msgid "Add-on"
+msgstr "Dodatni prog."
+
+#: id:24001
+msgid "Add-ons"
+msgstr "Dodatni prog."
+
+#: id:24002
+msgid "Add-on options"
+msgstr "Opcije dodatnog prog."
+
+#: id:24003
+msgid "Add-on Information"
+msgstr ""
+
+#: id:24005
+msgctxt "Auto context with id 24005"
+msgid "Media sources"
+msgstr "Dodatak"
+
+#: id:24007
+msgctxt "Auto context with id 24007"
+msgid "Movie information"
+msgstr "Dobavljač"
+
+#: id:24008
+msgctxt "Auto context with id 24008"
+msgid "Screensaver"
+msgstr "Čuvar ekrana"
+
+#: id:24009
+msgid "Script"
+msgstr "Skripta"
+
+#: id:24010
+msgctxt "Auto context with id 24010"
+msgid "Visualization"
+msgstr "Vizualizacija"
+
+#: id:24011
+msgid "Add-on repository"
+msgstr "Spremište dodatnog prog."
+
+#: id:24012
+msgctxt "Auto context with id 24012"
+msgid "Subtitles"
+msgstr ""
+
+#: id:24013
+msgid "Lyrics"
+msgstr ""
+
+#: id:24014
+msgid "TV information"
+msgstr ""
+
+#: id:24015
+msgctxt "Auto context with id 24015"
+msgid "Music video information"
+msgstr ""
+
+#: id:24016
+msgctxt "Auto context with id 24016"
+msgid "Album information"
+msgstr ""
+
+#: id:24017
+msgctxt "Auto context with id 24017"
+msgid "Artist information"
+msgstr ""
+
+#: id:24018
+msgctxt "Auto context with id 24018"
+msgid "Services"
+msgstr ""
+
+#: id:24020
+msgid "Configure"
+msgstr "Podešavanje dodatnog prog."
+
+#: id:24021
+msgctxt "Auto context with id 24021"
+msgid "Disable"
+msgstr "Onemogući dodatni prog."
+
+#: id:24022
+msgid "Enable"
+msgstr "Omogući dodatni prog."
+
+#: id:24023
+msgid "Add-on disabled"
+msgstr "Dodatni prog. je onemogućen"
+
+#: id:24027
+msgctxt "Auto context with id 24027"
+msgid "Weather"
+msgstr "Usluge vremenske prognoze"
+
+#: id:24028
+msgid "Weather.com (standard)"
+msgstr "Weather.com (standardan)"
+
+#: id:24030
+msgid "This Add-on can not be configured"
+msgstr "Ovaj dodatni prog. nije moguće podesiti"
+
+#: id:24031
+msgid "Error loading settings"
+msgstr "Greška prilikom učitavanja podešavanja"
+
+#: id:24032
+msgid "All Add-ons"
+msgstr ""
+
+#: id:24033
+msgid "Get Add-ons"
+msgstr ""
+
+#: id:24034
+msgid "Check for updates"
+msgstr ""
+
+#: id:24035
+msgid "Force refresh"
+msgstr ""
+
+#: id:24036
+msgid "Change log"
+msgstr ""
+
+#: id:24037
+msgid "Uninstall"
+msgstr ""
+
+#: id:24038
+msgid "Install"
+msgstr ""
+
+#: id:24039
+msgid "Disabled Add-ons"
+msgstr ""
+
+#: id:24040
+msgid "(Clear the current setting)"
+msgstr ""
+
+#: id:24041
+msgid "Install from zip file"
+msgstr ""
+
+#: id:24042
+msgid "Downloading %i%%"
+msgstr ""
+
+#: id:24043
+msgid "Available Updates"
+msgstr ""
+
+#: id:24044
+msgid "Dependencies not met"
+msgstr ""
+
+#: id:24045
+msgid "Add-on does not have the correct structure"
+msgstr ""
+
+#: id:24046
+msgid "%s is used by the following installed add-on(s)"
+msgstr ""
+
+#: id:24047
+msgid "This add-on cannot be uninstalled"
+msgstr ""
+
+#: id:24048
+msgid "Rollback"
+msgstr ""
+
+#: id:24050
+msgid "Available Add-ons"
+msgstr "Dostupni dodatni programi"
+
+#: id:24051
+msgid "Version:"
+msgstr "Verzija:"
+
+#: id:24052
+msgid "Disclaimer"
+msgstr "Odricanje:"
+
+#: id:24053
+msgid "License:"
+msgstr "Licenca:"
+
+#: id:24054
+msgid "Changelog"
+msgstr ""
+
+#: id:24059
+msgid "Would you like to enable this Add-on?"
+msgstr "Da li želite da omogućite ovaj dodatni prog.?"
+
+#: id:24060
+msgid "Would you like to disable this Add-on?"
+msgstr "Da li želite da onemogućite ovaj dodatni prog.?"
+
+#: id:24061
+msgid "Add-on update available!"
+msgstr "Nadogradnja dodatnog prog. je dostupna!"
+
+#: id:24062
+msgid "Enabled Add-ons"
+msgstr "Omogućeni dodatni programi"
+
+#: id:24063
+msgid "Auto update"
+msgstr "Automatsko ažuriranje"
+
+#: id:24064
+msgid "Add-on enabled"
+msgstr "Dodatni prog. je omogućen"
+
+#: id:24065
+msgid "Add-on updated"
+msgstr "Dodatni prog. je ažuriran"
+
+#: id:24066
+msgid "Cancel Add-on download?"
+msgstr "Da prekinem preuzimanje dodatnog prog.?"
+
+#: id:24067
+msgid "Currently downloading Add-ons"
+msgstr "Trenutno preuzimam dodatne programe"
+
+#: id:24068
+msgid "Update available"
+msgstr ""
+
+#: id:24069
+msgid "Update"
+msgstr ""
+
+#: id:24070
+msgid "Add-on could not be loaded."
+msgstr "Dodatni program nije upotrebljiv"
+
+#: id:24071
+msgid "An unknown error has occurred."
+msgstr "Dogodila se nepoznata greška"
+
+#: id:24072
+msgid "Settings required"
+msgstr "Podešavanje je neophodno"
+
+#: id:24073
+msgid "Could not connect"
+msgstr "Ne mogu se povezati"
+
+#: id:24074
+msgid "Needs to restart"
+msgstr "Ponovno pokretanje je neophodno"
+
+#: id:24075
+msgctxt "Auto context with id 24075"
+msgid "Disable"
+msgstr ""
+
+#: id:24076
+msgid "Add-on Required"
+msgstr ""
+
+#: id:24080
+msgid "Try to reconnect?"
+msgstr "Da pokušam ponovno uspostavljanje veze?"
+
+#: id:24089
+msgid "Add-on restarts"
+msgstr "Dodatni prog. se ponovno pokreće"
+
+#: id:24090
+msgid "Lock Add-on manager"
+msgstr "Zaključaj upravljač dodatnog prog."
+
+#: id:24094
+msgid "(current)"
+msgstr "Omogući hardversko ubrzanje (CrystalHD)"
+
+#: id:24095
+msgid "(blacklisted)"
+msgstr ""
+
+#: id:24096
+msgid "Add-on has been marked as broken in repository."
+msgstr ""
+
+#: id:24097
+msgid "Would you like to disable it on your system?"
+msgstr ""
+
+#: id:24098
+msgid "Broken"
+msgstr ""
+
+#: id:24099
+msgid "Would you like to switch to this skin?"
+msgstr ""
+
+#: id:24100
+msgid "To use this feature you must download an Add-on:"
+msgstr ""
+
+#: id:24101
+msgid "Would you like to download this Add-on?"
+msgstr ""
+
+#: id:25000
+msgid "Notifications"
+msgstr ""
+
+#: id:29800
+msgid "Library Mode"
+msgstr "Režim biblioteke"
+
+#: id:29801
+msgid "QWERTY keyboard"
+msgstr "QWERTY tastatura"
+
+#: id:29802
+msgid "Passthrough Audio in use"
+msgstr "Prolazni zvuk u upotrebi"
+
+#: id:33001
+msgid "Trailer quality"
+msgstr "Kvalitet najave"
+
+#: id:33002
+msgid "Stream"
+msgstr "Zapis"
+
+#: id:33003
+msgid "Download"
+msgstr "Preuzmi"
+
+#: id:33004
+msgid "Download & play"
+msgstr "Preuzmi i reprodukuj"
+
+#: id:33005
+msgid "Download & save"
+msgstr "Preuzmi i sačuvaj"
+
+#: id:33006
+msgid "Today"
+msgstr "Danas"
+
+#: id:33007
+msgid "Tomorrow"
+msgstr "Sutra"
+
+#: id:33008
+msgid "Saving"
+msgstr "Čuvanje"
+
+#: id:33009
+msgid "Copying"
+msgstr "Kopiranje"
+
+#: id:33010
+msgid "Set download directory"
+msgstr "Postavi fasciklu za preuzimanje"
+
+#: id:33011
+msgid "Search duration"
+msgstr ""
+
+#: id:33012
+msgid "Short"
+msgstr "Kratko"
+
+#: id:33013
+msgid "Long"
+msgstr "Dugačko"
+
+#: id:33014
+msgid "Use DVD player instead of regular player"
+msgstr "Koristi DVD plejer umjesto običnog plejera"
+
+#: id:33015
+msgid "Ask for download before playing video"
+msgstr "Pitaj za preuzimanje prije reprodukcije filma"
+
+#: id:33016
+msgid "Clips"
+msgstr "Klipovi"
+
+#: id:33017
+msgid "Restart plugin to enable"
+msgstr "Ponovo pokrenite dodatak za aktiviranje"
+
+#: id:33018
+msgid "Tonight"
+msgstr "Noćas"
+
+#: id:33019
+msgid "Tomorrow Night"
+msgstr "Sutra uveče"
+
+#: id:33020
+msgid "Condition"
+msgstr "Stanje"
+
+#: id:33021
+msgid "Precipitation"
+msgstr "Obilne padavine"
+
+#: id:33022
+msgid "Precip"
+msgstr "Precip"
+
+#: id:33023
+msgid "Humid"
+msgstr "Vlažno"
+
+#: id:33024
+msgid "Feels"
+msgstr "Kao da je"
+
+#: id:33025
+msgid "Observed"
+msgstr "Posmatrano"
+
+#: id:33026
+msgid "Departure from normal"
+msgstr "Odstupanje od prosjeka"
+
+#: id:33027
+msgid "Sunrise"
+msgstr "Izlazak sunca"
+
+#: id:33028
+msgid "Sunset"
+msgstr "Zalazak sunca"
+
+#: id:33029
+msgid "Details"
+msgstr "Detalji"
+
+#: id:33030
+msgid "Outlook"
+msgstr "Vidik"
+
+#: id:33031
+msgid "Coverflow"
+msgstr "Prekriven"
+
+#: id:33032
+msgid "Translate text"
+msgstr "Prevedi tekst"
+
+#: id:33033
+msgid "Map list %s category"
+msgstr "Map list %s category"
+
+#: id:33034
+msgid "36 Hour"
+msgstr "36 satna"
+
+#: id:33035
+msgid "Maps"
+msgstr "Karta"
+
+#: id:33036
+msgid "Hourly"
+msgstr "Iz sata u sat"
+
+#: id:33037
+msgid "Weekend"
+msgstr "Vikend"
+
+#: id:33038
+msgid "%s day"
+msgstr "%s dnevna"
+
+#: id:33049
+msgid "Alert"
+msgstr "Uzbuna"
+
+#: id:33050
+msgid "Alerts"
+msgstr "Upozorenja"
+
+#: id:33051
+msgid "Choose Your"
+msgstr "Izaberite vaš"
+
+#: id:33052
+msgid "Check"
+msgstr "Provjeri"
+
+#: id:33053
+msgctxt "Auto context with id 33053"
+msgid "Configure the"
+msgstr "Konfiguriši"
+
+#: id:33054
+msgid "Seasons"
+msgstr "Godišnja doba"
+
+#: id:33055
+msgid "Use your"
+msgstr "Koristite vaš"
+
+#: id:33056
+msgid "Watch your"
+msgstr "Gledajte vaš"
+
+#: id:33057
+msgid "Listen to"
+msgstr "Slušajte"
+
+#: id:33058
+msgid "View your"
+msgstr "Prikažite vaš"
+
+#: id:33059
+msgctxt "Auto context with id 33059"
+msgid "Configure the"
+msgstr "Konfiguriši"
+
+#: id:33060
+msgid "Power"
+msgstr "Snaga"
+
+#: id:33061
+msgid "Menu"
+msgstr "Meni"
+
+#: id:33062
+msgid "Play the"
+msgstr "Reprodukuj"
+
+#: id:33063
+msgid "Options"
+msgstr "Opcije"
+
+#: id:33065
+msgid "Editor"
+msgstr "Uređivač"
+
+#: id:33066
+msgid "About your"
+msgstr "O vašem"
+
+#: id:33067
+msgid "Star rating"
+msgstr "Ocjena zvjezdicama"
+
+#: id:33068
+msgid "Background"
+msgstr "Pozadina"
+
+#: id:33069
+msgid "Backgrounds"
+msgstr "Pozadine"
+
+#: id:33070
+msgid "Custom background"
+msgstr "Prilagođena pozadina"
+
+#: id:33071
+msgid "Custom backgrounds"
+msgstr "Prilagođene pozadine"
+
+#: id:33072
+msgid "View Readme"
+msgstr "Prikaži „Pročitaj me“"
+
+#: id:33073
+msgid "View Changelog"
+msgstr "Prikaži „Evidenciju izmjena“"
+
+#: id:33074
+msgid "This version of %s requires an"
+msgstr "Ova verzija za pokretanje zahtjeva %s"
+
+#: id:33075
+msgid "XBMC revision of %s or greater to run."
+msgstr "XBMC izdanje ili %s jače."
+
+#: id:33076
+msgid "Please update XBMC."
+msgstr "Molimo, ažurirajte XBMC aplikaciju."
+
+#: id:33077
+msgid "No data found!"
+msgstr "Podaci nisu pronađeni!"
+
+#: id:33078
+msgid "Next page"
+msgstr "Sljedeća strana"
+
+#: id:33079
+msgid "Love"
+msgstr "Ljubav"
+
+#: id:33080
+msgid "Hate"
+msgstr "Mržnja"
+
+#: id:33081
+msgid "This file is stacked, select the part you want to play from."
+msgstr "Ova datoteka je složena, izaberite koji dio želite da reprodukujete iz nje."
+
+#: id:33082
+msgid "Path to script"
+msgstr "Putanja do skripte"
+
+#: id:33083
+msgid "Enable custom script button"
+msgstr "Omogući prilagođeni taster za sjruotu"
+
+#: id:33100
+msgid "Failed to start"
+msgstr ""
+
+#: id:33101
+msgid "Webserver"
+msgstr ""
+
+#: id:33102
+msgid "Event Server"
+msgstr ""
+
+#: id:33103
+msgid "Remote communication server"
+msgstr ""
+
+#: id:33200
+msgid "Detected New Connection"
+msgstr ""
+
+#: id:34000
+msgid "Lame"
+msgstr "Lame"
+
+#: id:34001
+msgid "Vorbis"
+msgstr "Vorbis"
+
+#: id:34002
+msgid "Wav"
+msgstr "Wav"
+
+#: id:34003
+msgid "DXVA2"
+msgstr "DXVA"
+
+#: id:34004
+msgid "VAAPI"
+msgstr ""
+
+#: id:34005
+msgid "Flac"
+msgstr ""
+
+#: id:34100
+msgid "Speaker Configuration"
+msgstr "Konfiguracija zvučnika"
+
+#: id:34101
+msgid "2.0"
+msgstr "2.0"
+
+#: id:34102
+msgid "2.1"
+msgstr "2.1"
+
+#: id:34103
+msgid "3.0"
+msgstr "3.0"
+
+#: id:34104
+msgid "3.1"
+msgstr "3.1"
+
+#: id:34105
+msgid "4.0"
+msgstr "4.0"
+
+#: id:34106
+msgid "4.1"
+msgstr "4.1"
+
+#: id:34107
+msgid "5.0"
+msgstr "5.0"
+
+#: id:34108
+msgid "5.1"
+msgstr "5.1"
+
+#: id:34109
+msgid "7.0"
+msgstr "7.0"
+
+#: id:34110
+msgid "7.1"
+msgstr "7.1"
+
+#: id:34201
+msgid "Can't find a next item to play"
+msgstr ""
+
+#: id:34202
+msgid "Can't find a previous item to play"
+msgstr ""
+
+#: id:34300
+msgid "Failed to start zeroconf"
+msgstr ""
+
+#: id:34301
+msgid "Is Apple's Bonjour Service installed? See log for more info."
+msgstr ""
+
+#: id:34400
+msgid "Video Rendering"
+msgstr ""
+
+#: id:34401
+msgid "Failed to init video filters/scalers, falling back to bilinear scaling"
+msgstr ""
+
+#: id:34402
+msgid "Failed to initialize audio device"
+msgstr ""
+
+#: id:34403
+msgid "Check your audiosettings"
+msgstr ""
+
+#: id:34404
+msgid "Use gestures for navigation:"
+msgstr ""
+
+#: id:34405
+msgid "1 finger swipe left,right,up,down for cursors"
+msgstr ""
+
+#: id:34406
+msgid "2 finger swipe left for backspace"
+msgstr ""
+
+#: id:34407
+msgid "1 finger single tap for enter"
+msgstr ""
+
+#: id:34408
+msgid "2 finger single tap for contextmenu"
+msgstr ""
+
+#: id:35000
+msgid "Peripherals"
+msgstr ""
+
+#: id:35001
+msgid "Generic HID device"
+msgstr ""
+
+#: id:35002
+msgid "Generic network adapter"
+msgstr ""
+
+#: id:35003
+msgid "Generic disk"
+msgstr ""
+
+#: id:35004
+msgid "There are no settings available\nfor this peripheral."
+msgstr ""
+
+#: id:35005
+msgid "New device configured"
+msgstr ""
+
+#: id:35006
+msgid "Device removed"
+msgstr ""
+
+#: id:35007
+msgid "Keymap to use for this device"
+msgstr ""
+
+#: id:35008
+msgid "Keymap enabled"
+msgstr ""
+
+#: id:35009
+msgid "Do not use the custom keymap for this device"
+msgstr ""
+
+#: id:35500
+msgid "Location"
+msgstr ""
+
+#: id:35501
+msgid "Class"
+msgstr ""
+
+#: id:35502
+msgctxt "Auto context with id 35502"
+msgid "Name"
+msgstr ""
+
+#: id:35503
+msgid "Vendor"
+msgstr ""
+
+#: id:35504
+msgid "Product ID"
+msgstr ""
+
+#: id:36000
+msgid "Pulse-Eight CEC adapter"
+msgstr ""
+
+#: id:36001
+msgid "Pulse-Eight Nyxboard"
+msgstr ""
+
+#: id:36002
+msgid "Switch to keyboard side command"
+msgstr ""
+
+#: id:36003
+msgid "Switch to remote side command"
+msgstr ""
+
+#: id:36004
+msgid "Press \"user\" button command"
+msgstr ""
+
+#: id:36005
+msgid "Enable switch side commands"
+msgstr ""
+
+#: id:36006
+msgid "Could not open the adapter"
+msgstr ""
+
+#: id:36007
+msgid "Devices to power on when starting XBMC"
+msgstr ""
+
+#: id:36008
+msgid "Devices to power off when stopping XBMC"
+msgstr ""
+
+#: id:36009
+msgid "Put devices in standby mode when activating screensaver"
+msgstr ""
+
+#: id:36011
+msgid "Could not detect the CEC port. Set it up manually."
+msgstr ""
+
+#: id:36012
+msgid "Could not initialise the CEC adapter. Check your settings."
+msgstr ""
+
+#: id:36013
+msgid "Unsupported libCEC interface version. %d is greater than the version XBMC supports (%d)"
+msgstr ""
+
+#: id:36014
+msgid "Put this PC in standby mode when the TV is switched off"
+msgstr ""
+
+#: id:36015
+msgid "HDMI port number"
+msgstr ""
+
+#: id:36016
+msgctxt "Auto context with id 36016"
+msgid "Connected"
+msgstr ""
+
+#: id:36017
+msgid "Adapter found, but libCEC is not available"
+msgstr ""
+
+#: id:36018
+msgid "Use the TV's language setting"
+msgstr ""
+
+#: id:36019
+msgid "Connected to HDMI device"
+msgstr ""
+
+#: id:36020
+msgid "Make XBMC the active source when starting"
+msgstr ""
+
+#: id:36021
+msgid "Physical address (overrules HDMI port)"
+msgstr ""
+
+#: id:36022
+msgid "COM port (leave empty unless needed)"
+msgstr ""
+
+#: id:36023
+msgid "Configuration updated"
+msgstr ""
+
+#: id:36024
+msgid "Failed to set the new configuration. Please check your settings."
+msgstr ""
+
+#: id:36025
+msgid "Send 'inactive source' command when stopping XBMC"
+msgstr ""
+

--- a/language/Bulgarian/strings.po
+++ b/language/Bulgarian/strings.po
@@ -1,0 +1,9093 @@
+# Converted from xbmc strings.xml with xbmc-xml2po (by Team-XBMC)
+msgid ""
+msgstr ""
+"Project-Id-Version: xbmc.core-FRODO_GIT3ed1604ad7\n"
+"Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
+"POT-Creation-Date: 2012-04-09 18:00+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE\n"
+"Language: bg\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: id:0
+msgctxt "Auto context with id 0"
+msgid "Programs"
+msgstr "Програми"
+
+#: id:1
+msgctxt "Auto context with id 1"
+msgid "Pictures"
+msgstr "Снимки"
+
+#: id:2
+msgctxt "Auto context with id 2"
+msgid "Music"
+msgstr "Музика"
+
+#: id:3
+msgctxt "Auto context with id 3"
+msgid "Videos"
+msgstr "Видео"
+
+#: id:4
+msgid "TV-Guide"
+msgstr "ТВ Програма"
+
+#: id:5
+msgctxt "Auto context with id 5"
+msgid "Settings"
+msgstr "Настройки"
+
+#: id:6
+msgid "XBMC SVN"
+msgstr "XBMC SVN"
+
+#: id:7
+msgctxt "Auto context with id 7"
+msgid "File manager"
+msgstr "Файлове"
+
+#: id:8
+msgctxt "Auto context with id 8"
+msgid "Weather"
+msgstr "Времето"
+
+#: id:9
+msgid "xbmc media center"
+msgstr "xbmc медия център"
+
+#: id:11
+msgid "Monday"
+msgstr "Понеделник"
+
+#: id:12
+msgid "Tuesday"
+msgstr "Вторник"
+
+#: id:13
+msgid "Wednesday"
+msgstr "Сряда"
+
+#: id:14
+msgid "Thursday"
+msgstr "Четвъртък"
+
+#: id:15
+msgid "Friday"
+msgstr "Петък"
+
+#: id:16
+msgid "Saturday"
+msgstr "Събота"
+
+#: id:17
+msgid "Sunday"
+msgstr "Неделя"
+
+#: id:21
+msgid "January"
+msgstr "Януари"
+
+#: id:22
+msgid "February"
+msgstr "Февруари"
+
+#: id:23
+msgid "March"
+msgstr "Март"
+
+#: id:24
+msgid "April"
+msgstr "Април"
+
+#: id:25
+msgctxt "Auto context with id 25"
+msgid "May"
+msgstr "Май"
+
+#: id:26
+msgid "June"
+msgstr "Юни"
+
+#: id:27
+msgid "July"
+msgstr "Юли"
+
+#: id:28
+msgid "August"
+msgstr "Август"
+
+#: id:29
+msgid "September"
+msgstr "Септември"
+
+#: id:30
+msgid "October"
+msgstr "Октомври"
+
+#: id:31
+msgid "November"
+msgstr "Ноември"
+
+#: id:32
+msgid "December"
+msgstr "Декември"
+
+#: id:41
+msgid "Mon"
+msgstr "Пн"
+
+#: id:42
+msgid "Tue"
+msgstr "Вт"
+
+#: id:43
+msgid "Wed"
+msgstr "Ср"
+
+#: id:44
+msgid "Thu"
+msgstr "Чт"
+
+#: id:45
+msgid "Fri"
+msgstr "Пт"
+
+#: id:46
+msgid "Sat"
+msgstr "Сб"
+
+#: id:47
+msgctxt "Auto context with id 47"
+msgid "Sun"
+msgstr "Нд"
+
+#: id:51
+msgid "Jan"
+msgstr "Ян"
+
+#: id:52
+msgid "Feb"
+msgstr "Фев"
+
+#: id:53
+msgid "Mar"
+msgstr "Мар"
+
+#: id:54
+msgid "Apr"
+msgstr "Апр"
+
+#: id:55
+msgctxt "Auto context with id 55"
+msgid "May"
+msgstr "Май"
+
+#: id:56
+msgid "Jun"
+msgstr "Юни"
+
+#: id:57
+msgid "Jul"
+msgstr "Юли"
+
+#: id:58
+msgid "Aug"
+msgstr "Авг"
+
+#: id:59
+msgid "Sep"
+msgstr "Сеп"
+
+#: id:60
+msgid "Oct"
+msgstr "Окт"
+
+#: id:61
+msgid "Nov"
+msgstr "Ное"
+
+#: id:62
+msgid "Dec"
+msgstr "Дек"
+
+#: id:71
+msgid "N"
+msgstr "N"
+
+#: id:72
+msgid "NNE"
+msgstr "NNE"
+
+#: id:73
+msgid "NE"
+msgstr "NE"
+
+#: id:74
+msgid "ENE"
+msgstr "ENE"
+
+#: id:75
+msgid "E"
+msgstr "E"
+
+#: id:76
+msgid "ESE"
+msgstr "ESE"
+
+#: id:77
+msgid "SE"
+msgstr "SE"
+
+#: id:78
+msgid "SSE"
+msgstr "SSE"
+
+#: id:79
+msgid "S"
+msgstr "S"
+
+#: id:80
+msgid "SSW"
+msgstr "SSW"
+
+#: id:81
+msgid "SW"
+msgstr "SW"
+
+#: id:82
+msgid "WSW"
+msgstr "WSW"
+
+#: id:83
+msgid "W"
+msgstr "W"
+
+#: id:84
+msgid "WNW"
+msgstr "WNW"
+
+#: id:85
+msgid "NW"
+msgstr "NW"
+
+#: id:86
+msgid "NNW"
+msgstr "NNW"
+
+#: id:87
+msgid "VAR"
+msgstr "VAR"
+
+#: id:98
+msgid "View: Auto"
+msgstr "Вид: Автоматичен"
+
+#: id:99
+msgid "View: Auto big"
+msgstr "Вид: Автоматичен едър"
+
+#: id:100
+msgid "View: Icons"
+msgstr "Вид: Икони"
+
+#: id:101
+msgid "View: List"
+msgstr "Вид: Списък"
+
+#: id:102
+msgctxt "Auto context with id 102"
+msgid "Scan"
+msgstr "Анализиране"
+
+#: id:103
+msgctxt "Auto context with id 103"
+msgid "Sort by: Name"
+msgstr "Сорт: Име"
+
+#: id:104
+msgid "Sort by: Date"
+msgstr "Сорт: Дата"
+
+#: id:105
+msgid "Sort by: Size"
+msgstr "Сорт: Размер"
+
+#: id:106
+msgid "No"
+msgstr "Не"
+
+#: id:107
+msgid "Yes"
+msgstr "Да"
+
+#: id:108
+msgctxt "Auto context with id 108"
+msgid "Slideshow"
+msgstr "Слайдшоу"
+
+#: id:109
+msgid "Create thumbs"
+msgstr "Създай картинка"
+
+#: id:110
+msgid "Create thumbnails"
+msgstr "Създай картинки"
+
+#: id:111
+msgctxt "Auto context with id 111"
+msgid "Shortcuts"
+msgstr "Преки пътища"
+
+#: id:112
+msgid "Paused"
+msgstr "Пауза"
+
+#: id:113
+msgid "Update failed"
+msgstr "Неуспешен ъпдейт"
+
+#: id:114
+msgid "Installation failed"
+msgstr "Неуспешна инсталация"
+
+#: id:115
+msgid "Copy"
+msgstr "Копирай"
+
+#: id:116
+msgid "Move"
+msgstr "Местене"
+
+#: id:117
+msgid "Delete"
+msgstr "Изтрий"
+
+#: id:118
+msgid "Rename"
+msgstr "Преименувай"
+
+#: id:119
+msgid "New folder"
+msgstr "Нова Папка"
+
+#: id:120
+msgid "Confirm file copy"
+msgstr "Потвърди копиране на файл"
+
+#: id:121
+msgid "Confirm file move"
+msgstr "Потвърди преместване на файл"
+
+#: id:122
+msgid "Confirm file delete?"
+msgstr "Потвърди изтриване на файл?"
+
+#: id:123
+msgid "Copy these files?"
+msgstr "Копирай тези файлове?"
+
+#: id:124
+msgid "Move these files?"
+msgstr "Премести тези файлове?"
+
+#: id:125
+msgid "Delete these files? - Deleting files cannot be undone!"
+msgstr "Изтрий тези файлове? - Файловете не могат да се върнат!"
+
+#: id:126
+msgid "Status"
+msgstr "Положение"
+
+#: id:127
+msgid "Objects"
+msgstr "Обекти"
+
+#: id:128
+msgctxt "Auto context with id 128"
+msgid "General"
+msgstr "Главен"
+
+#: id:129
+msgctxt "Auto context with id 129"
+msgid "Slideshow"
+msgstr "Слайдшоу"
+
+#: id:130
+msgctxt "Auto context with id 130"
+msgid "System info"
+msgstr "Система Инфо"
+
+#: id:131
+msgid "Display"
+msgstr "Екран"
+
+#: id:132
+msgid "Albums"
+msgstr "Албуми"
+
+#: id:133
+msgid "Artists"
+msgstr "Артисти"
+
+#: id:134
+msgid "Songs"
+msgstr "Песни"
+
+#: id:135
+msgid "Genres"
+msgstr "Жанр"
+
+#: id:136
+msgid "Playlists"
+msgstr "Плейлисти"
+
+#: id:137
+msgid "Search"
+msgstr "Търсачка"
+
+#: id:138
+msgid "System Information"
+msgstr "Информация за Системата"
+
+#: id:139
+msgid "Temperatures:"
+msgstr "Температури:"
+
+#: id:140
+msgid "CPU:"
+msgstr "Процесор:"
+
+#: id:141
+msgid "GPU:"
+msgstr "Графичен Процесор:"
+
+#: id:142
+msgid "Time:"
+msgstr "Време:"
+
+#: id:143
+msgid "Current:"
+msgstr "Текущ:"
+
+#: id:144
+msgid "Build:"
+msgstr "Версия:"
+
+#: id:145
+msgid "Network:"
+msgstr "Мрежа:"
+
+#: id:146
+msgid "Type:"
+msgstr "Тип:"
+
+#: id:147
+msgid "Static"
+msgstr "Статичен"
+
+#: id:148
+msgid "DHCP"
+msgstr "DHCP"
+
+#: id:149
+msgid "MAC address"
+msgstr "MAC адрес"
+
+#: id:150
+msgctxt "Auto context with id 150"
+msgid "IP address"
+msgstr "IP адрес"
+
+#: id:151
+msgid "Link:"
+msgstr "Връзка:"
+
+#: id:152
+msgid "Half duplex"
+msgstr "Половин дуплекс"
+
+#: id:153
+msgid "Full duplex"
+msgstr "Пълен дуплекс"
+
+#: id:154
+msgctxt "Auto context with id 154"
+msgid "Storage"
+msgstr "Склад"
+
+#: id:155
+msgid "Drive"
+msgstr "Диск"
+
+#: id:156
+msgctxt "Auto context with id 156"
+msgid "Free"
+msgstr "Свободен"
+
+#: id:157
+msgctxt "Auto context with id 157"
+msgid "Video"
+msgstr "Видео"
+
+#: id:158
+msgid "Free memory"
+msgstr "Свободна Памет"
+
+#: id:159
+msgid "No link"
+msgstr "Без връзка"
+
+#: id:160
+msgctxt "Auto context with id 160"
+msgid "Free"
+msgstr "Свободен"
+
+#: id:161
+msgid "Unavailable"
+msgstr "Недостъпен"
+
+#: id:162
+msgid "Tray open"
+msgstr "CD отворен"
+
+#: id:163
+msgid "Reading"
+msgstr "Четене"
+
+#: id:164
+msgid "No disc"
+msgstr "Няма Диск"
+
+#: id:165
+msgid "Disc present"
+msgstr "Диск Намерен"
+
+#: id:166
+msgid "Skin"
+msgstr "Кожа"
+
+#: id:169
+msgctxt "Auto context with id 169"
+msgid "Resolution"
+msgstr "Резолюция"
+
+#: id:170
+msgid "Adjust display refresh rate to match video"
+msgstr "Промени честота на обновяване"
+
+#: id:172
+msgid "Release date"
+msgstr "Дата на издаване"
+
+#: id:173
+msgid "Display 4:3 videos as"
+msgstr "Покажи 4:3 видео като"
+
+#: id:175
+msgid "Moods"
+msgstr "Настроения"
+
+#: id:176
+msgid "Styles"
+msgstr "Стилове"
+
+#: id:179
+msgid "Song"
+msgstr "Песен"
+
+#: id:180
+msgid "Duration"
+msgstr "Продължителност"
+
+#: id:181
+msgid "Select album"
+msgstr "Избери Албум"
+
+#: id:182
+msgid "Tracks"
+msgstr "Песни"
+
+#: id:183
+msgid "Review"
+msgstr "Преглед"
+
+#: id:184
+msgid "Refresh"
+msgstr "Обнови"
+
+#: id:185
+msgid "Searching album"
+msgstr "Търсене на албум"
+
+#: id:186
+msgid "OK"
+msgstr "ОК"
+
+#: id:187
+msgid "No albums found!"
+msgstr "Не е намерен албум!"
+
+#: id:188
+msgid "Select all"
+msgstr "Избери всичко"
+
+#: id:189
+msgid "Scanning media info"
+msgstr "Сканиране инфо от медия"
+
+#: id:190
+msgid "Save"
+msgstr "Запиши"
+
+#: id:191
+msgid "Shuffle"
+msgstr "Разместени"
+
+#: id:192
+msgctxt "Auto context with id 192"
+msgid "Clear"
+msgstr "Изчисти"
+
+#: id:193
+msgctxt "Auto context with id 193"
+msgid "Scan"
+msgstr "Анализиране"
+
+#: id:194
+msgid "Searching..."
+msgstr "Търсене..."
+
+#: id:195
+msgid "No info found!"
+msgstr "Не е намерено инфо!"
+
+#: id:196
+msgid "Select movie:"
+msgstr "Избери филм:"
+
+#: id:197
+msgid "Querying %s info"
+msgstr "Заявка %s информация"
+
+#: id:198
+msgid "Loading movie details"
+msgstr "Търсене информация за филма"
+
+#: id:199
+msgid "Web interface"
+msgstr "Уеб интерфейс"
+
+#: id:202
+msgid "Tagline"
+msgstr "Етикет"
+
+#: id:203
+msgid "Plot outline"
+msgstr "Резюме"
+
+#: id:205
+msgid "Votes"
+msgstr "Гласове"
+
+#: id:206
+msgid "Cast"
+msgstr "Роли"
+
+#: id:207
+msgid "Plot"
+msgstr "Cюжет"
+
+#: id:208
+msgctxt "Auto context with id 208"
+msgid "Play"
+msgstr "Пусни"
+
+#: id:209
+msgid "Next"
+msgstr "Следващ"
+
+#: id:210
+msgid "Previous"
+msgstr "Предишен"
+
+#: id:213
+msgid "Calibrate user interface..."
+msgstr "Калибрирам потребителския интерфейс..."
+
+#: id:214
+msgid "Video calibration..."
+msgstr "Видео калибрация..."
+
+#: id:215
+msgid "Soften"
+msgstr "Омекоти"
+
+#: id:216
+msgid "Zoom amount"
+msgstr "Големина увеличаване"
+
+#: id:217
+msgid "Pixel ratio"
+msgstr "Пикселно съотношение"
+
+#: id:218
+msgid "DVD drive"
+msgstr "DVD устройство"
+
+#: id:219
+msgid "Please insert disc"
+msgstr "Моля сложете диск"
+
+#: id:220
+msgid "Remote share"
+msgstr "Отдалечено споделяне"
+
+#: id:221
+msgid "Network is not connected"
+msgstr "Мрежата не е свързана"
+
+#: id:222
+msgid "Cancel"
+msgstr "Отмени"
+
+#: id:224
+msgid "Speed"
+msgstr "Скорост"
+
+#: id:225
+msgid "Vertical Shift"
+msgstr "Време за преход"
+
+#: id:226
+msgid "Test patterns..."
+msgstr "Тест модели..."
+
+#: id:227
+msgid "Lookup audio CD track names from freedb.org"
+msgstr "Търсене на аудио CD в Интернет"
+
+#: id:228
+msgid "Shuffle playlist on load"
+msgstr "Разбъркване плейлиста при зареждане"
+
+#: id:229
+msgid "HDD spindown time"
+msgstr "HDD време за изключване"
+
+#: id:230
+msgid "Video filters"
+msgstr "Видео филтри"
+
+#: id:231
+msgctxt "Auto context with id 231"
+msgid "None"
+msgstr "Празно"
+
+#: id:232
+msgid "Point"
+msgstr "Toчка"
+
+#: id:233
+msgid "Linear"
+msgstr "Линеарно"
+
+#: id:234
+msgid "Anisotropic"
+msgstr "Анизотропик"
+
+#: id:235
+msgid "Quincunx"
+msgstr "Quincunx"
+
+#: id:236
+msgid "Gaussian cubic"
+msgstr "Гаус кубик"
+
+#: id:237
+msgid "Minification"
+msgstr "Намаляване"
+
+#: id:238
+msgid "Magnification"
+msgstr "Увеличаване"
+
+#: id:239
+msgid "Clear playlist on finish"
+msgstr "Изчисти плейлиста при свършване"
+
+#: id:240
+msgid "Display Mode"
+msgstr "Режим на екрана"
+
+#: id:241
+msgid "Full Screen #%d"
+msgstr "Цял екран #%d"
+
+#: id:242
+msgid "Windowed"
+msgstr "Прозорец"
+
+#: id:243
+msgid "Refresh Rate"
+msgstr "Честота на опресняване"
+
+#: id:244
+msgid "Full screen"
+msgstr "Цял екран"
+
+#: id:245
+msgid "Sizing: (%i,%i)->(%i,%i) (Zoom x%2.2f) AR:%2.2f:1 (Pixels: %2.2f:1) (VShift: %2.2f)"
+msgstr "Sizing: (%i,%i)->(%i,%i) (Zoom x%2.2f) AR:%2.2f:1 (Pixels: %2.2f:1)"
+
+#: id:247
+msgctxt "Auto context with id 247"
+msgid "Scripts"
+msgstr "Скриптове"
+
+#: id:248
+msgctxt "Auto context with id 248"
+msgid "Language"
+msgstr "Език"
+
+#: id:249
+msgctxt "Auto context with id 249"
+msgid "Music"
+msgstr "Музика"
+
+#: id:250
+msgctxt "Auto context with id 250"
+msgid "Visualization"
+msgstr "Визуализация"
+
+#: id:251
+msgid "Select destination directory"
+msgstr "Избери отправна папка"
+
+#: id:252
+msgid "Output stereo to all speakers"
+msgstr "Изходящо стерео до всички говорители"
+
+#: id:253
+msgid "Number of channels"
+msgstr "Брой канали"
+
+#: id:254
+msgid "- DTS capable receiver"
+msgstr "- Приемник с DTS"
+
+#: id:255
+msgid "CDDB"
+msgstr "CDDB"
+
+#: id:256
+msgid "Fetching CD information"
+msgstr "Изтегляне на CD информация"
+
+#: id:257
+msgid "Error"
+msgstr "Грешка"
+
+#: id:258
+msgid "Enable tag reading"
+msgstr "Включи четене на етикети"
+
+#: id:259
+msgid "Opening"
+msgstr "Отваряне"
+
+#: id:260
+msgid "Shoutcast"
+msgstr "Shoutcast"
+
+#: id:261
+msgid "Waiting for start..."
+msgstr "Изчакване за започване..."
+
+#: id:262
+msgid "Scripts output"
+msgstr "Изходящи скриптове"
+
+#: id:263
+msgid "Allow control of XBMC via HTTP"
+msgstr "Включи WEB сървър"
+
+#: id:264
+msgid "Record"
+msgstr "Запис"
+
+#: id:265
+msgid "Stop Rec."
+msgstr "Спри Запис."
+
+#: id:266
+msgid "Sort by: Track"
+msgstr "Сорт: Песен"
+
+#: id:267
+msgid "Sort by: Time"
+msgstr "Сорт: Време"
+
+#: id:268
+msgid "Sort by: Title"
+msgstr "Сорт: Заглавие"
+
+#: id:269
+msgid "Sort by: Artist"
+msgstr "Сорт: Артист"
+
+#: id:270
+msgid "Sort by: Album"
+msgstr "Сорт: Албум"
+
+#: id:271
+msgid "Top 100"
+msgstr "Топ 100"
+
+#: id:272
+msgid "Top-Left overscan compensation"
+msgstr "Горе-Ляво компенсация overscan"
+
+#: id:273
+msgid "Bottom-Right overscan compensation"
+msgstr "Долу-Дясно компенсация overscan"
+
+#: id:274
+msgid "Subtitle positioning"
+msgstr "Позициониране на субтитрите"
+
+#: id:275
+msgid "Pixel ratio adjustment"
+msgstr "Регулиране на съотношение пиксели"
+
+#: id:276
+msgid "Adjust the arrow to change the amount of overscan"
+msgstr "Регулиране със стрелките"
+
+#: id:277
+msgid "Adjust the bar to change the subtitles position"
+msgstr "Регулиране на лента, за да промените позицията на субтитрите"
+
+#: id:278
+msgid "Adjust the rectangle so it is perfectly square"
+msgstr "Регулиране на правоъгълник, така че е напълно квадрат"
+
+#: id:279
+msgid "Unable to load settings"
+msgstr "Не мога да заредя настройки"
+
+#: id:280
+msgid "Using default settings"
+msgstr "Използвам настройки по подразбиране"
+
+#: id:281
+msgid "Please check the XML files"
+msgstr "Моля проверете XML файловете"
+
+#: id:282
+msgid "Found %i items"
+msgstr "Намерен %i позиции"
+
+#: id:283
+msgid "Search results"
+msgstr "Резултати от търсене"
+
+#: id:284
+msgid "No results found"
+msgstr "Няма резултати"
+
+#: id:287
+msgctxt "Auto context with id 287"
+msgid "Subtitles"
+msgstr "Субтитри"
+
+#: id:288
+msgctxt "Auto context with id 288"
+msgid "Font"
+msgstr "Шрифт"
+
+#: id:289
+msgctxt "Auto context with id 289"
+msgid "- Size"
+msgstr "- Размер"
+
+#: id:290
+msgid "Dynamic range compression"
+msgstr "Обхват на динамична компресия"
+
+#: id:291
+msgctxt "Auto context with id 291"
+msgid "Video"
+msgstr "Видео"
+
+#: id:292
+msgctxt "Auto context with id 292"
+msgid "Audio"
+msgstr "Аудио"
+
+#: id:293
+msgid "Browse for subtitles"
+msgstr "Търси субтитри"
+
+#: id:294
+msgid "Create bookmark"
+msgstr "Създай отметка"
+
+#: id:296
+msgid "Clear bookmarks"
+msgstr "Изчисти отметка"
+
+#: id:297
+msgid "Audio offset"
+msgstr "Отместване на звук"
+
+#: id:298
+msgid "Bookmarks"
+msgstr "Отметки"
+
+#: id:299
+msgid "- AAC capable receiver"
+msgstr "- AAC приемник"
+
+#: id:300
+msgid "- MP1 capable receiver"
+msgstr "- MP1 приемник"
+
+#: id:301
+msgid "- MP2 capable receiver"
+msgstr "- MP2 приемник"
+
+#: id:302
+msgid "- MP3 capable receiver"
+msgstr "- MP3 приемник"
+
+#: id:303
+msgid "Delay"
+msgstr "Закъснение"
+
+#: id:304
+msgctxt "Auto context with id 304"
+msgid "Language"
+msgstr "Език"
+
+#: id:305
+msgctxt "Auto context with id 305"
+msgid "Enabled"
+msgstr "Включен"
+
+#: id:306
+msgid "Non-interleaved"
+msgstr "Не-редуващи"
+
+#: id:312
+msgid "(0=auto)"
+msgstr "(0=авто)"
+
+#: id:313
+msgid "Cleaning database"
+msgstr "Почиствам базата данни"
+
+#: id:314
+msgid "Preparing..."
+msgstr "Приготвям..."
+
+#: id:315
+msgid "Database error"
+msgstr "Грешка в базата данни"
+
+#: id:316
+msgid "Searching songs..."
+msgstr "Търсене на песни..."
+
+#: id:317
+msgid "Cleaned database successfully"
+msgstr "Успешно почистване на базата данни"
+
+#: id:318
+msgid "Cleaning songs..."
+msgstr "Почистване на песни..."
+
+#: id:319
+msgid "Error cleaning songs"
+msgstr "Грешка при почистване на песни"
+
+#: id:320
+msgid "Cleaning artists..."
+msgstr "Почиствам изпълнители..."
+
+#: id:321
+msgid "Error cleaning artists"
+msgstr "Грешка при почистване изпълнители"
+
+#: id:322
+msgid "Cleaning genres..."
+msgstr "Почиствам жанрове..."
+
+#: id:323
+msgid "Error cleaning genres"
+msgstr "Грешка при почистване на жанрове"
+
+#: id:324
+msgid "Cleaning paths..."
+msgstr "Почиствам пътища..."
+
+#: id:325
+msgid "Error cleaning paths"
+msgstr "Грешка при почистване на пътища"
+
+#: id:326
+msgid "Cleaning albums..."
+msgstr "Почиствам албуми..."
+
+#: id:327
+msgid "Error cleaning albums"
+msgstr "Грешка при почистване на албуми"
+
+#: id:328
+msgid "Writing changes..."
+msgstr "Запазвам промени..."
+
+#: id:329
+msgid "Error writing changes"
+msgstr "Грешка при запазване на промени"
+
+#: id:330
+msgid "This may take some time..."
+msgstr "Това може да отнеме известно време..."
+
+#: id:331
+msgid "Compressing database..."
+msgstr "Компресирам базата данни..."
+
+#: id:332
+msgid "Error compressing database"
+msgstr "Грешка при компресирането на базата данни"
+
+#: id:333
+msgid "Do you want to clean the library?"
+msgstr "Искате ли да изчистите библиотеката?"
+
+#: id:334
+msgid "Clean library..."
+msgstr "Почисти библиотеката..."
+
+#: id:335
+msgid "Start"
+msgstr "Старт"
+
+#: id:336
+msgid "Framerate conversion"
+msgstr "Конверсия на кадри"
+
+#: id:337
+msgctxt "Auto context with id 337"
+msgid "Audio output"
+msgstr "Аудио изход"
+
+#: id:338
+msgid "Analog"
+msgstr "Аналогов"
+
+#: id:339
+msgid "Optical/Coax"
+msgstr "Цифров"
+
+#: id:340
+msgid "Various artists"
+msgstr "Различни изпълнители"
+
+#: id:341
+msgid "Play disc"
+msgstr "Възпроизведи диск"
+
+#: id:342
+msgctxt "Auto context with id 342"
+msgid "Movies"
+msgstr "Филми"
+
+#: id:343
+msgid "Adjust framerate"
+msgstr "Настрой кадри"
+
+#: id:344
+msgid "Actors"
+msgstr "Изпълнители"
+
+#: id:345
+msgctxt "Auto context with id 345"
+msgid "Year"
+msgstr "Години"
+
+#: id:346
+msgid "Boost volume level on downmix"
+msgstr "Усили нивото на звука при миксиране"
+
+#: id:350
+msgctxt "Auto context with id 350"
+msgid "Programs"
+msgstr "Програми"
+
+#: id:351
+msgctxt "Auto context with id 351"
+msgid "Off"
+msgstr "Изкл"
+
+#: id:352
+msgid "Dim"
+msgstr "Затъмнява"
+
+#: id:353
+msgid "Black"
+msgstr "Черен"
+
+#: id:354
+msgid "Matrix trails"
+msgstr "Матрицата пътеки"
+
+#: id:355
+msgid "Screensaver time"
+msgstr "Време до скрийнсейвър"
+
+#: id:356
+msgid "Screensaver mode"
+msgstr "Скрийнсейвър режим"
+
+#: id:357
+msgid "Shutdown function timer"
+msgstr "Функция изключване на таймера"
+
+#: id:358
+msgid "All albums"
+msgstr "Всички албуми"
+
+#: id:359
+msgid "Recently added albums"
+msgstr "Последно добавени албуми"
+
+#: id:360
+msgctxt "Auto context with id 360"
+msgid "Screensaver"
+msgstr "Скрийнсейвър"
+
+#: id:361
+msgid "R. Slideshow"
+msgstr "R. Слайдшоу"
+
+#: id:362
+msgid "Screensaver dim level"
+msgstr "Степен на затихване на скрийнсейвъра"
+
+#: id:363
+msgid "Sort by: File"
+msgstr "Сорт: Файл"
+
+#: id:364
+msgid "- Dolby Digital (AC3) capable receiver"
+msgstr "- Dolby Digital (AC3) приемник"
+
+#: id:365
+msgctxt "Auto context with id 365"
+msgid "Sort by: Name"
+msgstr "Сорт: Име"
+
+#: id:366
+msgid "Sort by: Year"
+msgstr "Сорт: Година"
+
+#: id:367
+msgid "Sort by: Rating"
+msgstr "Сорт: Рейтинг"
+
+#: id:368
+msgid "IMDb"
+msgstr "IMDb"
+
+#: id:369
+msgctxt "Auto context with id 369"
+msgid "Title"
+msgstr "Заглавие"
+
+#: id:370
+msgid "Thunderstorms"
+msgstr "Буря с гръмотевици"
+
+#: id:371
+msgid "Partly"
+msgstr "Частично"
+
+#: id:372
+msgid "Mostly"
+msgstr "Предимно"
+
+#: id:373
+msgid "Sunny"
+msgstr "Слънчево"
+
+#: id:374
+msgid "Cloudy"
+msgstr "Облачно"
+
+#: id:375
+msgid "Snow"
+msgstr "Сняг"
+
+#: id:376
+msgid "Rain"
+msgstr "Дъжд"
+
+#: id:377
+msgid "Light"
+msgstr "Слаб"
+
+#: id:378
+msgid "AM"
+msgstr "Преди обяд"
+
+#: id:379
+msgid "PM"
+msgstr "След обяд"
+
+#: id:380
+msgid "Showers"
+msgstr "Дъждовно"
+
+#: id:381
+msgid "Few"
+msgstr "Слаба"
+
+#: id:382
+msgid "Scattered"
+msgstr "Вероятност"
+
+#: id:383
+msgctxt "Auto context with id 383"
+msgid "Wind"
+msgstr "Вятър"
+
+#: id:384
+msgid "Strong"
+msgstr "Силен"
+
+#: id:385
+msgid "Fair"
+msgstr "Ясно"
+
+#: id:386
+msgctxt "Auto context with id 386"
+msgid "Clear"
+msgstr "Чисто"
+
+#: id:387
+msgid "Clouds"
+msgstr "Облаци"
+
+#: id:388
+msgid "Early"
+msgstr "Ранен"
+
+#: id:389
+msgid "Shower"
+msgstr "Дъжд"
+
+#: id:390
+msgid "Flurries"
+msgstr "Превалявания"
+
+#: id:391
+msgctxt "Auto context with id 391"
+msgid "Low"
+msgstr "Мин"
+
+#: id:392
+msgctxt "Auto context with id 392"
+msgid "Medium"
+msgstr "Среден"
+
+#: id:393
+msgctxt "Auto context with id 393"
+msgid "High"
+msgstr "Макс"
+
+#: id:394
+msgid "Fog"
+msgstr "Мъгла"
+
+#: id:395
+msgid "Haze"
+msgstr "Лека мъгла"
+
+#: id:396
+msgid "Select location"
+msgstr "Изберете местоположение"
+
+#: id:397
+msgid "Refresh time"
+msgstr "Време за обновяване"
+
+#: id:398
+msgid "Temperature units"
+msgstr "Единици за температура"
+
+#: id:399
+msgid "Speed units"
+msgstr "Единици за скорост"
+
+#: id:400
+msgctxt "Auto context with id 400"
+msgid "Weather"
+msgstr "Време"
+
+#: id:401
+msgid "Temp"
+msgstr "Температура"
+
+#: id:402
+msgid "Feels like"
+msgstr "Усеща се като"
+
+#: id:403
+msgid "UV index"
+msgstr "UV индекс"
+
+#: id:404
+msgctxt "Auto context with id 404"
+msgid "Wind"
+msgstr "Вятър"
+
+#: id:405
+msgid "Dew point"
+msgstr "Оросяване"
+
+#: id:406
+msgid "Humidity"
+msgstr "Влажност"
+
+#: id:409
+msgid "Defaults"
+msgstr "Подразбиране"
+
+#: id:410
+msgid "Accessing weather service"
+msgstr "Достъп до метеорологична служба"
+
+#: id:411
+msgid "Getting weather for:"
+msgstr "Зареждам време за:"
+
+#: id:412
+msgid "Unable to get weather data"
+msgstr "Не мога да заредя данните за времето"
+
+#: id:413
+msgid "Manual"
+msgstr "Ръчно"
+
+#: id:414
+msgid "No review for this album"
+msgstr "Няма преглед за този албум"
+
+#: id:415
+msgid "Downloading thumbnail..."
+msgstr "Изтегляне на картинка..."
+
+#: id:416
+msgid "Not available"
+msgstr "Не е налично"
+
+#: id:417
+msgid "View: Big icons"
+msgstr "Вид: Големи икони"
+
+#: id:418
+msgctxt "Auto context with id 418"
+msgid "Low"
+msgstr "Мин"
+
+#: id:419
+msgctxt "Auto context with id 419"
+msgid "High"
+msgstr "Макс"
+
+#: id:420
+msgid "HDMI"
+msgstr "HDMI"
+
+#: id:422
+msgid "Delete album info"
+msgstr "Изтрий информация за албум"
+
+#: id:423
+msgid "Delete CD information"
+msgstr "Изтрий CD информация"
+
+#: id:424
+msgid "Select"
+msgstr "Изберете"
+
+#: id:425
+msgid "No album information found"
+msgstr "Няма информация за албума"
+
+#: id:426
+msgid "No CD information found"
+msgstr "Няма информация за CD"
+
+#: id:427
+msgid "Disc"
+msgstr "Диск"
+
+#: id:428
+msgid "Insert correct CD/DVD"
+msgstr "Поставете правилно CD/DVD"
+
+#: id:429
+msgid "Please insert the following disc:"
+msgstr "Моля, въведете следното CD/DVD"
+
+#: id:430
+msgid "Sort by: DVD#"
+msgstr "Сорт: DVD#"
+
+#: id:431
+msgid "No cache"
+msgstr "Няма кеш"
+
+#: id:432
+msgid "Remove movie from library"
+msgstr "Премахни филм от библиотеката"
+
+#: id:433
+msgid "Really remove '%s'?"
+msgstr "Наистина да премахна '%s'?"
+
+#: id:434
+msgid "From %s at %i %s"
+msgstr "От %s at %i %s"
+
+#: id:437
+msgid "Removable disk"
+msgstr "Сменяем диск"
+
+#: id:438
+msgid "Opening file"
+msgstr "Отварям файл"
+
+#: id:439
+msgid "Cache"
+msgstr "Кеш"
+
+#: id:440
+msgid "Harddisk"
+msgstr "Харддиск"
+
+#: id:441
+msgid "UDF"
+msgstr "UDF"
+
+#: id:442
+msgid "Local network"
+msgstr "Локална Мрежа"
+
+#: id:443
+msgid "Internet"
+msgstr "Интернет"
+
+#: id:444
+msgctxt "Auto context with id 444"
+msgid "Video"
+msgstr "Видео"
+
+#: id:445
+msgctxt "Auto context with id 445"
+msgid "Audio"
+msgstr "Аудио"
+
+#: id:446
+msgctxt "Auto context with id 446"
+msgid "DVD"
+msgstr "DVD"
+
+#: id:447
+msgid "Autorun media"
+msgstr "Автоматично възпроизвеждане"
+
+#: id:448
+msgid "LCD"
+msgstr "LCD"
+
+#: id:449
+msgctxt "Auto context with id 449"
+msgid "Enabled"
+msgstr "Включено"
+
+#: id:450
+msgid "Columns"
+msgstr "Колони"
+
+#: id:451
+msgid "Row 1 address"
+msgstr "Ред 1 адрес"
+
+#: id:452
+msgid "Row 2 address"
+msgstr "Ред 2 адрес"
+
+#: id:453
+msgid "Row 3 address"
+msgstr "Ред 3 адрес"
+
+#: id:454
+msgid "Row 4 address"
+msgstr "Ред 4 адрес"
+
+#: id:455
+msgid "Rows"
+msgstr "Редове"
+
+#: id:456
+msgid "Mode"
+msgstr "Режим"
+
+#: id:457
+msgid "Switch view"
+msgstr "Превключи изглед"
+
+#: id:459
+msgid "Subs"
+msgstr "Субс"
+
+#: id:460
+msgid "Audio stream"
+msgstr "Аудио поток"
+
+#: id:461
+msgid "[active]"
+msgstr "[активен]"
+
+#: id:462
+msgid "Subtitle"
+msgstr "Субтитри"
+
+#: id:463
+msgid "Backlight"
+msgstr "Фоново осветление"
+
+#: id:464
+msgid "Brightness"
+msgstr "Осветеност"
+
+#: id:465
+msgid "Contrast"
+msgstr "Контраст"
+
+#: id:466
+msgid "Gamma"
+msgstr "Гама"
+
+#: id:467
+msgctxt "Auto context with id 467"
+msgid "Type"
+msgstr "Тип"
+
+#: id:468
+msgid "Move the bar to change the OSD position"
+msgstr "Преместете бара за преместване на позицията на OSD"
+
+#: id:469
+msgid "OSD position"
+msgstr "OSD позиция"
+
+#: id:470
+msgid "Credits"
+msgstr "Заслуги"
+
+#: id:471
+msgid "Modchip"
+msgstr "Modchip"
+
+#: id:474
+msgctxt "Auto context with id 474"
+msgid "Off"
+msgstr "Изкл"
+
+#: id:475
+msgid "Music only"
+msgstr "Само музика"
+
+#: id:476
+msgctxt "Auto context with id 476"
+msgid "Music & video"
+msgstr "Музика & видео"
+
+#: id:477
+msgid "Unable to load playlist"
+msgstr "Не мога да заредя плейлист"
+
+#: id:478
+msgid "OSD"
+msgstr "OSD"
+
+#: id:479
+msgid "Skin & language"
+msgstr "Кожа & език"
+
+#: id:480
+msgid "Appearance"
+msgstr "Облик"
+
+#: id:481
+msgid "Audio options"
+msgstr "Аудио опции"
+
+#: id:482
+msgid "About XBMC"
+msgstr "Относно XBMC"
+
+#: id:485
+msgid "Delete album"
+msgstr "Изтрий албум"
+
+#: id:486
+msgid "Repeat"
+msgstr "Повтори"
+
+#: id:487
+msgid "Repeat one"
+msgstr "Повтори едно"
+
+#: id:488
+msgid "Repeat folder"
+msgstr "Повтори папка"
+
+#: id:489
+msgid "Play the next song automatically"
+msgstr "Автоматично възпроизвеждане на следващ"
+
+#: id:491
+msgid "- Use big icons"
+msgstr "- Ползвай големи икони"
+
+#: id:492
+msgid "Resize VobSubs"
+msgstr "Преоразмеряване VobSubs"
+
+#: id:493
+msgid "Advanced options (Experts Only!)"
+msgstr "Допълнителни опции (Само за експерти!)"
+
+#: id:494
+msgid "Overall audio headroom"
+msgstr "Пълна звукова височина"
+
+#: id:495
+msgid "Upsample videos to GUI resolution"
+msgstr "Пусни видео с резолюция на GUI"
+
+#: id:496
+msgid "Calibration"
+msgstr "Калибриране"
+
+#: id:497
+msgid "Show file extensions"
+msgstr "Скрий разширенията на файловете"
+
+#: id:498
+msgid "Sort by: Type"
+msgstr "Сорт: Тип"
+
+#: id:499
+msgid "Unable to connect to online lookup service"
+msgstr "Не мога да се свържа с онлайн търсене на услуги"
+
+#: id:500
+msgid "Downloading album information failed"
+msgstr "Неуспешно сваляне на информацията за албума"
+
+#: id:501
+msgid "Looking for album names..."
+msgstr "Търся имената на албуми..."
+
+#: id:502
+msgctxt "Auto context with id 502"
+msgid "Open"
+msgstr "Отвори"
+
+#: id:503
+msgid "Busy"
+msgstr "Зает"
+
+#: id:504
+msgid "Empty"
+msgstr "Празен"
+
+#: id:505
+msgid "Loading media info from files..."
+msgstr "Зареждане информация за медия от файл..."
+
+#: id:507
+msgid "Sort by: Usage"
+msgstr "Сорт: Използване"
+
+#: id:510
+msgid "Enable visualizations"
+msgstr "Включи визуализации"
+
+#: id:511
+msgid "Enable video mode switching"
+msgstr "Включи превключване на видео режими"
+
+#: id:512
+msgid "Startup window"
+msgstr "Прозорец при стартиране"
+
+#: id:513
+msgid "Home window"
+msgstr "Екран начало"
+
+#: id:514
+msgid "Manual settings"
+msgstr "Ръчни настройки"
+
+#: id:515
+msgid "Genre"
+msgstr "Жанр"
+
+#: id:517
+msgid "Recently played albums"
+msgstr "Наскоро възпроизвеждани албуми"
+
+#: id:518
+msgid "Launch"
+msgstr "Старт"
+
+#: id:519
+msgid "Launch in..."
+msgstr "Стартирай със..."
+
+#: id:521
+msgid "Compilations"
+msgstr "Компилации"
+
+#: id:522
+msgid "Remove source"
+msgstr "Премахни източник"
+
+#: id:523
+msgid "Switch media"
+msgstr "Превключи медия"
+
+#: id:524
+msgid "Select playlist"
+msgstr "Избери плейлист"
+
+#: id:525
+msgid "New playlist..."
+msgstr "Нов плейлист..."
+
+#: id:526
+msgid "Add to playlist"
+msgstr "Добави към плейлист"
+
+#: id:527
+msgid "Manually add to library"
+msgstr "Добавяне към библиотеката"
+
+#: id:528
+msgid "Enter title"
+msgstr "Въведи заглавие"
+
+#: id:529
+msgid "Error: Duplicate title"
+msgstr "Грешка: Дублирано име"
+
+#: id:530
+msgid "Select genre"
+msgstr "Избери жанр"
+
+#: id:531
+msgid "New genre"
+msgstr "Нов жанр"
+
+#: id:532
+msgid "Manual addition"
+msgstr "Ръчно допълнение"
+
+#: id:533
+msgid "Enter genre"
+msgstr "Въведете жанр"
+
+#: id:534
+msgid "View: %s"
+msgstr "Вид: %s"
+
+#: id:535
+msgid "List"
+msgstr "Списък"
+
+#: id:536
+msgid "Icons"
+msgstr "Икони"
+
+#: id:537
+msgid "Big list"
+msgstr "Голям лист"
+
+#: id:538
+msgid "Big icons"
+msgstr "Големи икони"
+
+#: id:539
+msgid "Wide"
+msgstr "Широк"
+
+#: id:540
+msgid "Big wide"
+msgstr "Голям широк"
+
+#: id:541
+msgid "Album icons"
+msgstr "Икони албум"
+
+#: id:542
+msgid "DVD icons"
+msgstr "DVD икони"
+
+#: id:543
+msgctxt "Auto context with id 543"
+msgid "DVD"
+msgstr "DVD"
+
+#: id:544
+msgctxt "Auto context with id 544"
+msgid "Media info"
+msgstr "Медия инфо"
+
+#: id:545
+msgid "Audio output device"
+msgstr "Устройство аудио изход"
+
+#: id:546
+msgid "Passthrough output device"
+msgstr "През изходно устройство"
+
+#: id:547
+msgid "No biography for this artist"
+msgstr "Няма биография за този изпълнител"
+
+#: id:548
+msgid "Downmix multichannel audio to stereo"
+msgstr "Смеси многоканалното аудио до стерео"
+
+#: id:550
+msgid "Sort by: %s"
+msgstr "Сорт: %s"
+
+#: id:551
+msgctxt "Auto context with id 551"
+msgid "Name"
+msgstr "Име"
+
+#: id:552
+msgid "Date"
+msgstr "Дата"
+
+#: id:553
+msgid "Size"
+msgstr "Обем"
+
+#: id:554
+msgid "Track"
+msgstr "Пътечка"
+
+#: id:555
+msgid "Time"
+msgstr "Време"
+
+#: id:556
+msgctxt "Auto context with id 556"
+msgid "Title"
+msgstr "Заглавие"
+
+#: id:557
+msgid "Artist"
+msgstr "Артист"
+
+#: id:558
+msgid "Album"
+msgstr "Албум"
+
+#: id:559
+msgid "Playlist"
+msgstr "Плейлист"
+
+#: id:560
+msgid "ID"
+msgstr "ID"
+
+#: id:561
+msgctxt "Auto context with id 561"
+msgid "File"
+msgstr "Файл"
+
+#: id:562
+msgctxt "Auto context with id 562"
+msgid "Year"
+msgstr "Година"
+
+#: id:563
+msgid "Rating"
+msgstr "Рейтинг"
+
+#: id:564
+msgctxt "Auto context with id 564"
+msgid "Type"
+msgstr "Тип"
+
+#: id:565
+msgid "Usage"
+msgstr "Използване"
+
+#: id:566
+msgid "Album artist"
+msgstr "Албум изпълнител"
+
+#: id:567
+msgid "Play count"
+msgstr "Брой възпроизвеждания"
+
+#: id:568
+msgid "Last played"
+msgstr "Последно възпроизведени"
+
+#: id:569
+msgctxt "Auto context with id 569"
+msgid "Comment"
+msgstr "Коментар"
+
+#: id:570
+msgid "Date added"
+msgstr "Добавен на дата"
+
+#: id:571
+msgctxt "Auto context with id 571"
+msgid "Default"
+msgstr "Подразбиране"
+
+#: id:572
+msgid "Studio"
+msgstr "Студио"
+
+#: id:573
+msgid "Path"
+msgstr "Път"
+
+#: id:574
+msgctxt "Auto context with id 574"
+msgid "Country"
+msgstr "Държава"
+
+#: id:575
+msgid "In progress"
+msgstr "В процес"
+
+#: id:576
+msgid "Times played"
+msgstr "Пъти просвирвано"
+
+#: id:580
+msgid "Sort direction"
+msgstr "Посока на сортиране"
+
+#: id:581
+msgid "Sort method"
+msgstr "Метод на сортиране"
+
+#: id:582
+msgctxt "Auto context with id 582"
+msgid "View mode"
+msgstr "Вид режим"
+
+#: id:583
+msgid "Remember views for different folders"
+msgstr "Запомни изгледа на различните папки"
+
+#: id:584
+msgid "Ascending"
+msgstr "Възходящ"
+
+#: id:585
+msgid "Descending"
+msgstr "Низходящ"
+
+#: id:586
+msgid "Edit playlist"
+msgstr "Редактирай плейлист"
+
+#: id:587
+msgid "Filter"
+msgstr "Филтър"
+
+#: id:588
+msgid "Cancel party mode"
+msgstr "Отказ Парти режим"
+
+#: id:589
+msgid "Party mode"
+msgstr "Парти"
+
+#: id:590
+msgid "Random"
+msgstr "Случаен"
+
+#: id:591
+msgctxt "Auto context with id 591"
+msgid "Off"
+msgstr "Изключено"
+
+#: id:592
+msgid "One"
+msgstr "Едно"
+
+#: id:593
+msgid "All"
+msgstr "Всички"
+
+#: id:594
+msgctxt "Auto context with id 594"
+msgid "Off"
+msgstr "Изключено"
+
+#: id:595
+msgid "Repeat: Off"
+msgstr "Повтори: Изкл"
+
+#: id:596
+msgid "Repeat: One"
+msgstr "Повтори: Едно"
+
+#: id:597
+msgid "Repeat: All"
+msgstr "Повтори: Всички"
+
+#: id:600
+msgid "Rip audio CD"
+msgstr "Извличане аудио CD"
+
+#: id:601
+msgctxt "Auto context with id 601"
+msgid "Medium"
+msgstr "Среден"
+
+#: id:602
+msgctxt "Auto context with id 602"
+msgid "Standard"
+msgstr "Стандартен"
+
+#: id:603
+msgid "Extreme"
+msgstr "Краен"
+
+#: id:604
+msgid "Constant bitrate"
+msgstr "Постоянен битрейт"
+
+#: id:605
+msgid "Ripping..."
+msgstr "Извличане..."
+
+#: id:607
+msgid "To:"
+msgstr "Към:"
+
+#: id:608
+msgid "Could not rip CD or track"
+msgstr "Не мога да извлека CD или песен"
+
+#: id:609
+msgid "CDDARipPath is not set."
+msgstr "CDDA път за извличане не е зададен."
+
+#: id:610
+msgid "Rip audio track"
+msgstr "Извличам аудио пътека"
+
+#: id:611
+msgid "Enter number"
+msgstr "Въведи номер"
+
+#: id:612
+msgid "Bits/Sample"
+msgstr "Bits/Sample"
+
+#: id:613
+msgid "Sample Frequency"
+msgstr "Примерна честота"
+
+#: id:620
+msgid "Audio CDs"
+msgstr "Аудио CD"
+
+#: id:621
+msgid "Encoder"
+msgstr "Енкодер"
+
+#: id:622
+msgid "Quality"
+msgstr "Качество"
+
+#: id:623
+msgid "Bitrate"
+msgstr "Битрейт"
+
+#: id:624
+msgid "Include track number"
+msgstr "Включително номер на песен"
+
+#: id:625
+msgid "All songs of"
+msgstr "Всички песни на"
+
+#: id:629
+msgctxt "Auto context with id 629"
+msgid "View mode"
+msgstr "Вид режим"
+
+#: id:630
+msgctxt "Auto context with id 630"
+msgid "Normal"
+msgstr "Нормален"
+
+#: id:631
+msgid "Zoom"
+msgstr "Увеличаване"
+
+#: id:632
+msgid "Stretch 4:3"
+msgstr "Разтягане 4:3"
+
+#: id:633
+msgid "Wide Zoom"
+msgstr "Разтягане 14:9"
+
+#: id:634
+msgid "Stretch 16:9"
+msgstr "Разтягане 16:9"
+
+#: id:635
+msgid "Original Size"
+msgstr "Оригинален размер"
+
+#: id:636
+msgctxt "Auto context with id 636"
+msgid "Custom"
+msgstr "Потребителски"
+
+#: id:637
+msgid "Replay gain"
+msgstr "Възпроизведи отново"
+
+#: id:638
+msgid "Replaygain volume adjustments"
+msgstr "Настрой входен режим"
+
+#: id:639
+msgid "Use track levels"
+msgstr "Ползвай нива на песни"
+
+#: id:640
+msgid "Use album levels"
+msgstr "Ползвай нива на албум"
+
+#: id:641
+msgid "PreAmp Level - Replay gained files"
+msgstr "PreAmp Level - Replay gained files"
+
+#: id:642
+msgid "PreAmp Level - Non replay gained files"
+msgstr "PreAmp Level - Non replay gained files"
+
+#: id:643
+msgid "Avoid clipping on replay gained files"
+msgstr "Avoid clipping on replay gained files"
+
+#: id:644
+msgid "Crop black bars"
+msgstr "Изрежи черните барове"
+
+#: id:645
+msgid "Need to unpack a big file. Continue?"
+msgstr "Трябва да разпакетирам голям файл. Продължаване?"
+
+#: id:646
+msgid "Remove from library"
+msgstr "Махане от библиотеката"
+
+#: id:647
+msgid "Export video library"
+msgstr "Изнасяне на видео библиотека"
+
+#: id:648
+msgid "Import video library"
+msgstr "Внасяне на видео библиотека"
+
+#: id:649
+msgid "Importing"
+msgstr "Внасям"
+
+#: id:650
+msgid "Exporting"
+msgstr "Изнасям"
+
+#: id:651
+msgid "Browse for library"
+msgstr "Търси библиотека"
+
+#: id:652
+msgid "Years"
+msgstr "Години"
+
+#: id:653
+msgid "Update library"
+msgstr "Обновяване библиотека"
+
+#: id:654
+msgid "Show debug info"
+msgstr "Дебъг информация"
+
+#: id:655
+msgid "Browse for executable"
+msgstr "Търсене на изпълним"
+
+#: id:656
+msgid "Browse for playlist"
+msgstr "Търсене на плейлист"
+
+#: id:657
+msgid "Browse for folder"
+msgstr "Търсене на папка"
+
+#: id:658
+msgid "Song information"
+msgstr "Информация за песен"
+
+#: id:659
+msgid "Non-linear stretch"
+msgstr "Не линейно разтягане"
+
+#: id:660
+msgid "Volume amplification"
+msgstr "Усилване"
+
+#: id:661
+msgid "Choose export folder"
+msgstr "Избери папка за изнасяне"
+
+#: id:662
+msgid "This file is no longer available."
+msgstr "Този файл вече не е достъпен."
+
+#: id:663
+msgid "Would you like to remove it from the library?"
+msgstr "Желаете ли да премахнете от библиотеката?"
+
+#: id:664
+msgid "Browse for Script"
+msgstr "Търсене на скрипт"
+
+#: id:665
+msgid "Compression level"
+msgstr "Ниво на компресия"
+
+#: id:700
+msgid "Cleaning up library"
+msgstr "Почистване на библиотеката"
+
+#: id:701
+msgid "Removing old songs from the library"
+msgstr "Премахване на стари песни от библиотеката"
+
+#: id:702
+msgid "This path has been scanned before"
+msgstr "Този път е бил сканиран преди"
+
+#: id:705
+msgctxt "Auto context with id 705"
+msgid "Network"
+msgstr "Мрежа"
+
+#: id:706
+msgid "- Server"
+msgstr "- Сървър"
+
+#: id:708
+msgid "Use an HTTP proxy server to access the internet"
+msgstr "Ползвай HTTP proxy сървър за достъп до интернет"
+
+#: id:711
+msgid "Internet Protocol (IP)"
+msgstr "Интернет Протокол (IP)"
+
+#: id:712
+msgid "Invalid port specified. Value must be between 1 and 65535."
+msgstr "Избран невалиден порт. Стойността може да е между 1 и 65535."
+
+#: id:713
+msgid "HTTP proxy"
+msgstr "HTTP proxy"
+
+#: id:715
+msgid "- Assignment"
+msgstr "- Задаване"
+
+#: id:716
+msgid "Automatic (DHCP)"
+msgstr "Автоматично (DHCP)"
+
+#: id:717
+msgid "Manual (Static)"
+msgstr "Ръчно (Статично)"
+
+#: id:719
+msgid "- IP address"
+msgstr "- IP address"
+
+#: id:720
+msgid "- Netmask"
+msgstr "- Netmask"
+
+#: id:721
+msgid "- Default gateway"
+msgstr "- Default gateway"
+
+#: id:722
+msgid "- DNS server"
+msgstr "- DNS server"
+
+#: id:723
+msgid "Save & restart"
+msgstr "Запази & рестарт"
+
+#: id:724
+msgid "Invalid address specified. Value must be AAA.BBB.CCC.DDD"
+msgstr "Избран невалиден адрес. Стойността трябва да е AAA.BBB.CCC.DDD"
+
+#: id:725
+msgid "with numbers between 0 and 255."
+msgstr "с числа между 0 и 255."
+
+#: id:726
+msgid "Changes not saved. Continue without saving?"
+msgstr "Промените не са запазени. Продължаване без запазване?"
+
+#: id:727
+msgid "Web server"
+msgstr "Web сървър"
+
+#: id:728
+msgctxt "Auto context with id 728"
+msgid "FTP server"
+msgstr "FTP сървър"
+
+#: id:730
+msgid "- Port"
+msgstr "Порт"
+
+#: id:732
+msgid "Save & apply"
+msgstr "Запази & приложи"
+
+#: id:733
+msgid "- Password"
+msgstr "Парола"
+
+#: id:734
+msgid "No pass"
+msgstr "Без парола"
+
+#: id:735
+msgid "- Character set"
+msgstr "- Кодова таблица"
+
+#: id:736
+msgid "- Style"
+msgstr "- Стил"
+
+#: id:737
+msgid "- Colour"
+msgstr "- Цвят"
+
+#: id:738
+msgctxt "Auto context with id 738"
+msgid "Normal"
+msgstr "Нормален"
+
+#: id:739
+msgid "Bold"
+msgstr "Удебелен"
+
+#: id:740
+msgid "Italics"
+msgstr "Наклонен"
+
+#: id:741
+msgid "Bold italics"
+msgstr "Удебелен наклонен"
+
+#: id:742
+msgctxt "Auto context with id 742"
+msgid "White"
+msgstr "Бял"
+
+#: id:743
+msgctxt "Auto context with id 743"
+msgid "Yellow"
+msgstr "Жълт"
+
+#: id:744
+msgctxt "Auto context with id 744"
+msgid "Files"
+msgstr "Файлове"
+
+#: id:745
+msgid "No scanned information for this view"
+msgstr "Няма сканирана информация за този изглед"
+
+#: id:746
+msgid "Please turn off library mode"
+msgstr "Моля изключете Режим библиотека"
+
+#: id:747
+msgid "Error loading image"
+msgstr "Грешка при зареждане на снимка"
+
+#: id:748
+msgid "Edit path"
+msgstr "Редактирай път"
+
+#: id:749
+msgid "Mirror image"
+msgstr "Огледален образ"
+
+#: id:750
+msgid "Are you sure?"
+msgstr "Сигурен ли Сте?"
+
+#: id:751
+msgid "Removing source"
+msgstr "Премахвам източник"
+
+#: id:754
+msgid "Add program link"
+msgstr "Добавям връзка към програма"
+
+#: id:755
+msgid "Edit program path"
+msgstr "Редактиране път на програмата"
+
+#: id:756
+msgid "Edit program name"
+msgstr "Редактиране име на програмата"
+
+#: id:757
+msgid "Edit path depth"
+msgstr "Редактиране дълбочина на път"
+
+#: id:759
+msgid "View: Big list"
+msgstr "Вид: Голям лист"
+
+#: id:760
+msgctxt "Auto context with id 760"
+msgid "Yellow"
+msgstr "Жълт"
+
+#: id:761
+msgctxt "Auto context with id 761"
+msgid "White"
+msgstr "Бял"
+
+#: id:762
+msgid "Blue"
+msgstr "Син"
+
+#: id:763
+msgid "Bright green"
+msgstr "Светло син"
+
+#: id:764
+msgid "Yellow green"
+msgstr "Резедав"
+
+#: id:765
+msgid "Cyan"
+msgstr "Циан"
+
+#: id:766
+msgid "Light grey"
+msgstr "Светло сиво"
+
+#: id:767
+msgid "Grey"
+msgstr "Сиво"
+
+#: id:770
+msgid "Error %i: share not available"
+msgstr "Грешка %i: споделянето не е достъпно"
+
+#: id:772
+msgctxt "Auto context with id 772"
+msgid "Audio output"
+msgstr "Аудио изход"
+
+#: id:773
+msgid "Seeking"
+msgstr "Искане"
+
+#: id:774
+msgid "Slideshow folder"
+msgstr "Папка за слайдшоу"
+
+#: id:775
+msgid "Network interface"
+msgstr "Мрежови интерфейс"
+
+#: id:776
+msgid "- Wireless network name (ESSID)"
+msgstr "- Име на безжична мрежа (ESSID)"
+
+#: id:777
+msgid "- Wireless password"
+msgstr "- Парола на безжична мрежа"
+
+#: id:778
+msgid "- Wireless security"
+msgstr "- Сигурност на безжична мрежа"
+
+#: id:779
+msgid "Save and apply network interface settings"
+msgstr "Запазване и прилагане настройките на мрежови интерфейс"
+
+#: id:780
+msgid "No encryption"
+msgstr "Без криптиране"
+
+#: id:781
+msgid "WEP"
+msgstr "WEP"
+
+#: id:782
+msgid "WPA"
+msgstr "WPA"
+
+#: id:783
+msgid "WPA2"
+msgstr "WPA2"
+
+#: id:784
+msgid "Applying network interface settings. Please wait."
+msgstr "Прилагане на настройките на мрежовия интерфейс. Моля, изчакайте."
+
+#: id:785
+msgid "Network interface restarted successfully."
+msgstr "Мрежовият интерфейс рестартира успешно."
+
+#: id:786
+msgid "Network interface did not start successfully."
+msgstr "Мрежовият интерфейс не стартира успешно."
+
+#: id:787
+msgid "Interface disabled"
+msgstr "Интерфейсът изключен"
+
+#: id:788
+msgid "Network interface disabled successfully."
+msgstr "Мрежовият интерфейс изключен успешно."
+
+#: id:789
+msgid "Wireless network name (ESSID)"
+msgstr "Име на безжична мрежа (ESSID)"
+
+#: id:790
+msgid "Remote control"
+msgstr ""
+
+#: id:791
+msgid "Allow programs on this system to control XBMC"
+msgstr "Включи Сървър на събития"
+
+#: id:792
+msgctxt "Auto context with id 792"
+msgid "Port"
+msgstr "Порт"
+
+#: id:793
+msgid "Port range"
+msgstr "Порт диапазон"
+
+#: id:794
+msgid "Allow programs on other systems to control XBMC"
+msgstr "Позволи на други компютри да се свързват"
+
+#: id:795
+msgid "Initial repeat delay (ms)"
+msgstr "Първоначално повторяемо забавяне(мс)"
+
+#: id:796
+msgid "Continuous repeat delay (ms)"
+msgstr "Непрекъснато повторяемо забавяне(мс)"
+
+#: id:797
+msgid "Maximum number of clients"
+msgstr "Максимален брой клиенти"
+
+#: id:798
+msgid "Internet access"
+msgstr "Интернет достъп"
+
+#: id:850
+msgid "Invalid port number entered"
+msgstr "Въведен невалиден порт"
+
+#: id:851
+msgid "Valid port range is 1-65535"
+msgstr "Валидните портове са 1-65535"
+
+#: id:852
+msgid "Valid port range is 1024-65535"
+msgstr "Валидните портове са 1024-65535"
+
+#: id:998
+msgid "Add Music..."
+msgstr "Добави музика..."
+
+#: id:999
+msgid "Add Videos..."
+msgstr "Добави видео..."
+
+#: id:1000
+msgid "- Preview"
+msgstr "- Преглед"
+
+#: id:1001
+msgid "Unable to connect"
+msgstr "Не мога да се свържа"
+
+#: id:1002
+msgid "XBMC was unable to connect to the network location."
+msgstr "XBMC не може да се свърже към мрежовото местоположение."
+
+#: id:1003
+msgid "This could be due to the network not being connected."
+msgstr "Това може да е заради разкачена мрежа."
+
+#: id:1004
+msgid "Would you like to add it anyway?"
+msgstr "Искате ли да добавите, въпреки всичко?"
+
+#: id:1006
+msgctxt "Auto context with id 1006"
+msgid "IP address"
+msgstr "IP адрес"
+
+#: id:1007
+msgid "Add network location"
+msgstr "Добави място в мрежата"
+
+#: id:1008
+msgid "Protocol"
+msgstr "Протокол"
+
+#: id:1009
+msgid "Server address"
+msgstr "Адрес на сървър"
+
+#: id:1010
+msgid "Server name"
+msgstr "Име на сървър"
+
+#: id:1011
+msgid "Remote path"
+msgstr "Отдалечен път"
+
+#: id:1012
+msgid "Shared folder"
+msgstr "Споделена папка"
+
+#: id:1013
+msgctxt "Auto context with id 1013"
+msgid "Port"
+msgstr "Порт"
+
+#: id:1014
+msgctxt "Auto context with id 1014"
+msgid "Username"
+msgstr "Потребителско име"
+
+#: id:1015
+msgid "Browse for network server"
+msgstr "Потърси мрежови сървър"
+
+#: id:1016
+msgid "Enter the network address of the server"
+msgstr "Въведете мрежовия адрес на сървъра"
+
+#: id:1017
+msgid "Enter the path on the server"
+msgstr "Въведете пътя на сървъра"
+
+#: id:1018
+msgid "Enter the port number"
+msgstr "Въведете номера на порта"
+
+#: id:1019
+msgid "Enter the username"
+msgstr "Въведете потребителско име"
+
+#: id:1020
+msgid "Add %s source"
+msgstr "Добавете източник %s"
+
+#: id:1021
+msgid "Enter the paths or browse for the media locations."
+msgstr "Въведете път или потърсете за местоположение на медия."
+
+#: id:1022
+msgid "Enter a name for this media Source."
+msgstr "Въведете име за този източник."
+
+#: id:1023
+msgid "Browse for new share"
+msgstr "Търси ново споделяне"
+
+#: id:1024
+msgid "Browse"
+msgstr "Търси"
+
+#: id:1025
+msgid "Could not retrieve directory information."
+msgstr "Не мога да извлека информация за папката."
+
+#: id:1026
+msgid "Add source"
+msgstr "Добави източник"
+
+#: id:1027
+msgid "Edit source"
+msgstr "Редактирай източник"
+
+#: id:1028
+msgid "Edit %s source"
+msgstr "Редактирай %s източник"
+
+#: id:1029
+msgid "Enter the new label"
+msgstr "Въведете нов етикет"
+
+#: id:1030
+msgid "Browse for image"
+msgstr "Прелисти за снимка"
+
+#: id:1031
+msgid "Browse for image folder"
+msgstr "Прелисти за папка със снимки"
+
+#: id:1032
+msgid "Add network location..."
+msgstr "Добави мрежово местоположение..."
+
+#: id:1033
+msgid "Browse for file"
+msgstr "Прелисти за файл"
+
+#: id:1034
+msgid "Submenu"
+msgstr "Подменю"
+
+#: id:1035
+msgid "Enable submenu buttons"
+msgstr "Включи бутони на подменю"
+
+#: id:1036
+msgid "Favourites"
+msgstr "Избрани"
+
+#: id:1037
+msgid "Video Add-ons"
+msgstr "Видео добавки"
+
+#: id:1038
+msgid "Music Add-ons"
+msgstr "Музикални добавки"
+
+#: id:1039
+msgid "Picture Add-ons"
+msgstr "Добавки снимки"
+
+#: id:1040
+msgid "Loading directory"
+msgstr "Зареждам папка"
+
+#: id:1041
+msgid "Retrieved %i items"
+msgstr "Получени %i позиции"
+
+#: id:1042
+msgid "Retrieved %i of %i items"
+msgstr "Получени %i от %i позиции"
+
+#: id:1043
+msgid "Program Add-ons"
+msgstr "Програми"
+
+#: id:1044
+msgid "Set plugin thumb"
+msgstr "Задай картинка на добавка"
+
+#: id:1045
+msgid "Add-on settings"
+msgstr "Настройки на добавка"
+
+#: id:1046
+msgid "Access points"
+msgstr "Точки за достъп"
+
+#: id:1047
+msgid "Other..."
+msgstr "Други..."
+
+#: id:1048
+msgid "- Username"
+msgstr "Потребителско име"
+
+#: id:1049
+msgid "Script settings"
+msgstr "Настройки на скрипт"
+
+#: id:1050
+msgid "Singles"
+msgstr "Единични"
+
+#: id:1051
+msgid "Enter web address"
+msgstr "Въведи Web адрес"
+
+#: id:1200
+msgid "SMB client"
+msgstr "SMB клиент"
+
+#: id:1202
+msgid "Workgroup"
+msgstr "Workgroup"
+
+#: id:1203
+msgid "Default username"
+msgstr "Потребителско име по подразбиране"
+
+#: id:1204
+msgid "Default password"
+msgstr "Парола по подразбиране"
+
+#: id:1207
+msgid "WINS server"
+msgstr "WINS сървър"
+
+#: id:1208
+msgid "Mount SMB shares"
+msgstr "Монтирай SMB споделени"
+
+#: id:1210
+msgctxt "Auto context with id 1210"
+msgid "Remove"
+msgstr "Премахни"
+
+#: id:1211
+msgctxt "Auto context with id 1211"
+msgid "Music"
+msgstr "Музика"
+
+#: id:1212
+msgctxt "Auto context with id 1212"
+msgid "Video"
+msgstr "Видео"
+
+#: id:1213
+msgctxt "Auto context with id 1213"
+msgid "Pictures"
+msgstr "Снимки"
+
+#: id:1214
+msgctxt "Auto context with id 1214"
+msgid "Files"
+msgstr "Файлове"
+
+#: id:1215
+msgctxt "Auto context with id 1215"
+msgid "Music & video"
+msgstr "Музика & видео"
+
+#: id:1216
+msgid "Music & pictures"
+msgstr "Музика & снимки"
+
+#: id:1217
+msgid "Music & files"
+msgstr "Музика & файлове"
+
+#: id:1218
+msgid "Video & pictures"
+msgstr "Видео & снимки"
+
+#: id:1219
+msgid "Video & files"
+msgstr "Видео & файлове"
+
+#: id:1220
+msgid "Pictures & files"
+msgstr "Снимки & файлове"
+
+#: id:1221
+msgid "Music & video & pictures"
+msgstr "Музика & видео & снимки"
+
+#: id:1222
+msgid "Music & video & pictures & files"
+msgstr "Музика & видео & снимки & файлове"
+
+#: id:1223
+msgctxt "Auto context with id 1223"
+msgid "Disabled"
+msgstr "Изключено"
+
+#: id:1226
+msgid "Files & music & video"
+msgstr "Файлове & музика & видео"
+
+#: id:1227
+msgid "Files & pictures & music"
+msgstr "Файлове & снимки & музика"
+
+#: id:1228
+msgid "Files & pictures & video"
+msgstr "Файлове & снимки & видео"
+
+#: id:1229
+msgid "Music & programs"
+msgstr "Музика & програми"
+
+#: id:1230
+msgid "Video & programs"
+msgstr "Видео & програми"
+
+#: id:1231
+msgid "Pictures & programs"
+msgstr "Снимки & програми"
+
+#: id:1232
+msgid "Music & video & pictures & programs"
+msgstr "Музика & видео & снимки & програми"
+
+#: id:1233
+msgid "Programs & video & music"
+msgstr "Програми & видео & музика"
+
+#: id:1234
+msgid "Programs & pictures & music"
+msgstr "Програми & снимки & музика"
+
+#: id:1235
+msgid "Programs & pictures & video"
+msgstr "Програми & снимки & видео"
+
+#: id:1250
+msgid "Auto-detection"
+msgstr "Автоматично откриване"
+
+#: id:1251
+msgid "Auto-detect system"
+msgstr "Система за автоматично откриване"
+
+#: id:1252
+msgid "Nickname"
+msgstr "Nickname"
+
+#: id:1254
+msgid "Ask to connect"
+msgstr "Изискай свързване"
+
+#: id:1255
+msgid "Send FTP user and password"
+msgstr "Изпрати FTP потребител и парола"
+
+#: id:1256
+msgid "Ping interval"
+msgstr "Ping интервал"
+
+#: id:1257
+msgid "Would you like to connect to the auto-detected system?"
+msgstr "Желаете ли да се свържете към автоматично откриваща система?"
+
+#: id:1259
+msgid "Zeroconf"
+msgstr ""
+
+#: id:1260
+msgid "Announce these services to other systems via Zeroconf"
+msgstr "Обяви тези услуги за други системи през Zeroconf"
+
+#: id:1270
+msgid "Allow XBMC to receive AirPlay content"
+msgstr "Позволи XBMC да приема AirPlay съдържание"
+
+#: id:1271
+msgid "Device name"
+msgstr "Име на устройство"
+
+#: id:1272
+msgid "- Use password protection"
+msgstr "-"
+
+#: id:1273
+msgid "AirPlay"
+msgstr ""
+
+#: id:1300
+msgid "Custom audio device"
+msgstr "Потребителско аудио устройство"
+
+#: id:1301
+msgid "Custom passthrough device"
+msgstr "Преходно потребителско устройство"
+
+#: id:1396
+msgid "Drifting"
+msgstr "Плаващи"
+
+#: id:1397
+msgid "and"
+msgstr "и"
+
+#: id:1398
+msgid "Freezing"
+msgstr "Замръзване"
+
+#: id:1399
+msgid "Late"
+msgstr "Късно"
+
+#: id:1400
+msgid "Isolated"
+msgstr "Изолирано"
+
+#: id:1401
+msgid "Thundershowers"
+msgstr "Дъжд с гръмотевици"
+
+#: id:1402
+msgid "Thunder"
+msgstr "Гръм"
+
+#: id:1403
+msgctxt "Auto context with id 1403"
+msgid "Sun"
+msgstr "Слънце"
+
+#: id:1404
+msgid "Heavy"
+msgstr "Тежък"
+
+#: id:1405
+msgid "in"
+msgstr "в"
+
+#: id:1406
+msgid "the"
+msgstr ""
+
+#: id:1407
+msgid "Vicinity"
+msgstr "Близост"
+
+#: id:1408
+msgid "Ice"
+msgstr "Лед"
+
+#: id:1409
+msgid "Crystals"
+msgstr "Кристали"
+
+#: id:1410
+msgid "Calm"
+msgstr "Спокойно"
+
+#: id:1411
+msgid "with"
+msgstr "с"
+
+#: id:1412
+msgid "windy"
+msgstr "ветровито"
+
+#: id:1413
+msgid "drizzle"
+msgstr "ръми"
+
+#: id:1414
+msgid "Thunderstorm"
+msgstr "Гръмотевична буря"
+
+#: id:1415
+msgid "Drizzle"
+msgstr "Ръми"
+
+#: id:1416
+msgid "Foggy"
+msgstr "Облачно"
+
+#: id:1417
+msgid "Grains"
+msgstr "Градушка"
+
+#: id:1418
+msgid "T-Storms"
+msgstr "Гръмотевична буря"
+
+#: id:1419
+msgid "T-Showers"
+msgstr "Дъжд с гръмотевици"
+
+#: id:1420
+msgid "Moderate"
+msgstr "Умерено"
+
+#: id:1421
+msgid "Very High"
+msgstr "Много високо"
+
+#: id:1422
+msgid "Windy"
+msgstr "Ветровито"
+
+#: id:1423
+msgid "Mist"
+msgstr "Мъгла"
+
+#: id:1450
+msgid "Put display to sleep when idle"
+msgstr "Екрана изгасва, докато бездейства"
+
+#: id:2050
+msgid "Runtime"
+msgstr "Времетраене"
+
+#: id:2100
+msgid "Script failed! : %s"
+msgstr "Скриптът неуспешен! : %s"
+
+#: id:2101
+msgid "Newer version needed - See log"
+msgstr "Необходима е по-нова версия - Виж лога"
+
+#: id:4501
+msgid "Enable LCD/VFD"
+msgstr "Включи LCD/VFD"
+
+#: id:10000
+msgid "Home"
+msgstr "Начален"
+
+#: id:10001
+msgctxt "Auto context with id 10001"
+msgid "Programs"
+msgstr "Програми"
+
+#: id:10002
+msgctxt "Auto context with id 10002"
+msgid "Pictures"
+msgstr "Снимки"
+
+#: id:10003
+msgctxt "Auto context with id 10003"
+msgid "File manager"
+msgstr "Управление файлове"
+
+#: id:10004
+msgctxt "Auto context with id 10004"
+msgid "Settings"
+msgstr "Настройки"
+
+#: id:10005
+msgctxt "Auto context with id 10005"
+msgid "Music"
+msgstr "Музика"
+
+#: id:10006
+msgctxt "Auto context with id 10006"
+msgid "Videos"
+msgstr "Видео"
+
+#: id:10007
+msgid "System information"
+msgstr "Информация за системата"
+
+#: id:10008
+msgid "Settings - General"
+msgstr "Настройки - Главни"
+
+#: id:10009
+msgid "Settings - Screen"
+msgstr "Настройки - Екран"
+
+#: id:10010
+msgid "Settings - Appearance - GUI Calibration"
+msgstr "Настройки - Облик - GUI Калибриране"
+
+#: id:10011
+msgid "Settings - Videos - Screen Calibration"
+msgstr "Настройки - Видео - Калибриране екран"
+
+#: id:10012
+msgid "Settings - Pictures"
+msgstr "Настройки - Снимки"
+
+#: id:10013
+msgid "Settings - Programs"
+msgstr "Настройки - Програми"
+
+#: id:10014
+msgid "Settings - Weather"
+msgstr "Настройки - Времето"
+
+#: id:10015
+msgid "Settings - Music"
+msgstr "Настройки - Музика"
+
+#: id:10016
+msgid "Settings - System"
+msgstr "Настройки - Система"
+
+#: id:10017
+msgid "Settings - Videos"
+msgstr "Настройки - Видео"
+
+#: id:10018
+msgid "Settings - Network"
+msgstr "Настройки - Мрежа"
+
+#: id:10019
+msgid "Settings - Appearance"
+msgstr "Настройки - Облик"
+
+#: id:10020
+msgctxt "Auto context with id 10020"
+msgid "Scripts"
+msgstr "Скриптове"
+
+#: id:10021
+msgid "Web Browser"
+msgstr "Web браузър"
+
+#: id:10025
+msgctxt "Auto context with id 10025"
+msgid "Videos"
+msgstr ""
+
+#: id:10028
+msgid "Videos/Playlist"
+msgstr "Видео/Плейлисти"
+
+#: id:10029
+msgctxt "Auto context with id 10029"
+msgid "Login screen"
+msgstr ""
+
+#: id:10034
+msgid "Settings - Profiles"
+msgstr "Настройки - Профили"
+
+#: id:10040
+msgid "Addon browser"
+msgstr ""
+
+#: id:10100
+msgid "Yes/No dialog"
+msgstr "Да/Без Диалог"
+
+#: id:10101
+msgid "Progress dialog"
+msgstr "Диалог развитие"
+
+#: id:10210
+msgid "Looking for subtitles..."
+msgstr "Търсене на субтитри..."
+
+#: id:10211
+msgid "Looking for or caching subtitles..."
+msgstr "Търсене на заредени субтитри..."
+
+#: id:10212
+msgid "terminating"
+msgstr "прекратяване"
+
+#: id:10213
+msgid "buffering"
+msgstr "буфериране"
+
+#: id:10214
+msgid "Opening stream"
+msgstr "Отваряне на поток"
+
+#: id:10500
+msgid "Music/Playlist"
+msgstr "Музика/Плейлист"
+
+#: id:10501
+msgid "Music/Files"
+msgstr "Музика/Файлове"
+
+#: id:10502
+msgid "Music/Library"
+msgstr "Музика/Библиотека"
+
+#: id:10503
+msgid "Playlist editor"
+msgstr "Редактор на плейлисти"
+
+#: id:10504
+msgid "Top 100 songs"
+msgstr "Топ 100 песни"
+
+#: id:10505
+msgid "Top 100 albums"
+msgstr "Топ 100 албуми"
+
+#: id:10506
+msgctxt "Auto context with id 10506"
+msgid "Programs"
+msgstr "Програми"
+
+#: id:10507
+msgid "Configuration"
+msgstr "Поздравления"
+
+#: id:10508
+msgid "Weather forecast"
+msgstr "Прогноза за времето"
+
+#: id:10509
+msgid "Network gaming"
+msgstr "Мрежови игри"
+
+#: id:10510
+msgid "Extensions"
+msgstr "Разширения"
+
+#: id:10511
+msgctxt "Auto context with id 10511"
+msgid "System info"
+msgstr "Системна информация"
+
+#: id:10516
+msgid "Music - Library"
+msgstr "Музика - Библиотека"
+
+#: id:10517
+msgid "Now Playing - Music"
+msgstr "Възпроизвежда - Музика"
+
+#: id:10522
+msgid "Now Playing - Videos"
+msgstr "Възпроизвежда - Видео"
+
+#: id:10523
+msgid "Album info"
+msgstr "Албум инфо"
+
+#: id:10524
+msgid "Movie info"
+msgstr "Филм инфо"
+
+#: id:12000
+msgid "Select dialog"
+msgstr "Изберете диалог"
+
+#: id:12001
+msgid "Music/Info"
+msgstr "Музика/Инфо"
+
+#: id:12002
+msgid "Dialog OK"
+msgstr "Диалог OK"
+
+#: id:12003
+msgid "Videos/Info"
+msgstr "Видео/Инфо"
+
+#: id:12004
+msgid "Scripts/Info"
+msgstr "Скриптове/Инфо"
+
+#: id:12005
+msgid "Fullscreen video"
+msgstr "Видео на цял екран"
+
+#: id:12006
+msgid "Audio visualization"
+msgstr "Аудио визуализация"
+
+#: id:12008
+msgid "File stacking dialog"
+msgstr "Диалог подреждане на файлове"
+
+#: id:12009
+msgid "Rebuild index..."
+msgstr "Създаване на индекса наново..."
+
+#: id:12010
+msgid "Return to music window"
+msgstr "Връщане към прозореца с музика"
+
+#: id:12011
+msgid "Return to videos window"
+msgstr "Връщане към прозореца с видео"
+
+#: id:12021
+msgid "Start from beginning"
+msgstr "Започване от начало"
+
+#: id:12022
+msgid "Resume from %s"
+msgstr "Възобновяване от %s"
+
+#: id:12310
+msgid "0"
+msgstr "0"
+
+#: id:12311
+msgid "1"
+msgstr "1"
+
+#: id:12312
+msgid "2"
+msgstr "2"
+
+#: id:12313
+msgid "3"
+msgstr "3"
+
+#: id:12314
+msgid "4"
+msgstr "4"
+
+#: id:12315
+msgid "5"
+msgstr "5"
+
+#: id:12316
+msgid "6"
+msgstr "6"
+
+#: id:12317
+msgid "7"
+msgstr "7"
+
+#: id:12318
+msgid "8"
+msgstr "8"
+
+#: id:12319
+msgid "9"
+msgstr "9"
+
+#: id:12320
+msgid "c"
+msgstr "c"
+
+#: id:12321
+msgid "Ok"
+msgstr "Ok"
+
+#: id:12322
+msgid "*"
+msgstr "*"
+
+#: id:12325
+msgid "Locked! Enter code..."
+msgstr "Заключен! Въведете код..."
+
+#: id:12326
+msgid "Enter password"
+msgstr "Въведете парола"
+
+#: id:12327
+msgid "Enter master code"
+msgstr "Въведете главен код"
+
+#: id:12328
+msgid "Enter unlock code"
+msgstr "Въведете код за отключване"
+
+#: id:12329
+msgid "or press C to cancel"
+msgstr "или натиснете C за отказ"
+
+#: id:12330
+msgid "Enter gamepad button combo and"
+msgstr "Въведете комбо бутон на геймпада и"
+
+#: id:12331
+msgid "press OK, or Back to cancel"
+msgstr "натиснете Старт или Назад за отказ"
+
+#: id:12332
+msgid "Set lock"
+msgstr "Заключване"
+
+#: id:12333
+msgid "Unlock"
+msgstr "Отключване"
+
+#: id:12334
+msgid "Reset lock"
+msgstr "Ресет на заключване"
+
+#: id:12335
+msgid "Remove lock"
+msgstr "Премахни заключване"
+
+#: id:12337
+msgid "Numeric password"
+msgstr "Цифрова парола"
+
+#: id:12338
+msgid "Gamepad button combo"
+msgstr "Комбо бутон на геймпад"
+
+#: id:12339
+msgid "Full-text password"
+msgstr "Текстова парола"
+
+#: id:12340
+msgid "Enter new password"
+msgstr "Въведете нова парола"
+
+#: id:12341
+msgid "Re-Enter new password"
+msgstr "Въведете отново паролата"
+
+#: id:12342
+msgid "Incorrect password,"
+msgstr "Неправилна парола,"
+
+#: id:12343
+msgid "retries left"
+msgstr "опита остават"
+
+#: id:12344
+msgid "Passwords entered did not match."
+msgstr "Въведените пароли не съответстват."
+
+#: id:12345
+msgid "Access denied"
+msgstr "Достъп забранен"
+
+#: id:12346
+msgid "Password retry limit exceeded."
+msgstr "Лимитът на пробваните пароли достигнат."
+
+#: id:12347
+msgid "The system will now shut off."
+msgstr "Системата сега ще се изключи."
+
+#: id:12348
+msgid "Item locked"
+msgstr "Заключена позиция"
+
+#: id:12353
+msgid "Reactivate lock"
+msgstr "Реактивирай заключване"
+
+#: id:12356
+msgid "Change lock"
+msgstr "Смени заключване"
+
+#: id:12357
+msgid "Source lock"
+msgstr "Източник заключване"
+
+#: id:12358
+msgid "Password entry was blank. Try again."
+msgstr "Паролата е празна. Опитайте отново."
+
+#: id:12360
+msgid "Master lock"
+msgstr "Заключване"
+
+#: id:12362
+msgid "Shutdown system if Master Lock retries exceeded"
+msgstr "Изключване на системата ако се превиши Главното заключване"
+
+#: id:12367
+msgid "Master code is not valid"
+msgstr "Главният код не е валиден!"
+
+#: id:12368
+msgid "Please enter a valid master code"
+msgstr "Моля въведете валиден главен код!"
+
+#: id:12373
+msgid "Settings & file manager"
+msgstr "Настройки & управление файлове"
+
+#: id:12376
+msgid "Set as default for all movies"
+msgstr "Направи по подразбиране за всички филми"
+
+#: id:12377
+msgid "This will reset any previously saved values"
+msgstr "Това ще ресетне всички запазени стойности"
+
+#: id:12378
+msgid "Amount of time to display each image"
+msgstr "Покажи всяка снимка за"
+
+#: id:12379
+msgid "Use pan and zoom effects"
+msgstr "Използвай ефекти за мащабиране"
+
+#: id:12383
+msgid "12 hour clock"
+msgstr "12 часов часовник"
+
+#: id:12384
+msgid "24 hour clock"
+msgstr "24 часов часовник"
+
+#: id:12385
+msgid "Day/Month"
+msgstr "Ден/Месец"
+
+#: id:12386
+msgid "Month/Day"
+msgstr "Месец/Ден"
+
+#: id:12390
+msgid "System uptime"
+msgstr "Работа на системата"
+
+#: id:12391
+msgid "Minutes"
+msgstr "Минути"
+
+#: id:12392
+msgid "Hours"
+msgstr "Час(а)"
+
+#: id:12393
+msgid "Days"
+msgstr "Дни"
+
+#: id:12394
+msgid "Total uptime"
+msgstr "Всичко време от стартиране"
+
+#: id:12395
+msgid "Battery level"
+msgstr "Ниво на батерията"
+
+#: id:12600
+msgctxt "Auto context with id 12600"
+msgid "Weather"
+msgstr "Времето"
+
+#: id:12900
+msgctxt "Auto context with id 12900"
+msgid "Screensaver"
+msgstr "Скрийнсейвър"
+
+#: id:12901
+msgid "Fullscreen OSD"
+msgstr "На цял екран OSD"
+
+#: id:13000
+msgid "System"
+msgstr "Система"
+
+#: id:13001
+msgid "Immediate HD spindown"
+msgstr "Непосредствено спиране на HD"
+
+#: id:13002
+msgid "Video only"
+msgstr "Само видео"
+
+#: id:13003
+msgid "- Delay"
+msgstr "- Закъснение"
+
+#: id:13004
+msgid "- Minimum file duration"
+msgstr "- Минимално времетраене на файл"
+
+#: id:13005
+msgid "Shutdown"
+msgstr "Изключване"
+
+#: id:13008
+msgid "Shutdown function"
+msgstr "Функция изключване"
+
+#: id:13009
+msgid "Quit"
+msgstr "Изход"
+
+#: id:13010
+msgid "Hibernate"
+msgstr "Хибернация"
+
+#: id:13011
+msgid "Suspend"
+msgstr "Приспиване на системата"
+
+#: id:13012
+msgid "Exit"
+msgstr "Изход"
+
+#: id:13013
+msgid "Reboot"
+msgstr "Рестарт"
+
+#: id:13014
+msgid "Minimize"
+msgstr "Минимизирай"
+
+#: id:13015
+msgid "Power button action"
+msgstr "Действие на бутон 'Изключване'"
+
+#: id:13016
+msgid "Power off System"
+msgstr ""
+
+#: id:13020
+msgid "Is another session active, perhaps over ssh?"
+msgstr "Има друга сесия активна, може би през SSH?"
+
+#: id:13021
+msgid "Mounted removable harddrive"
+msgstr "Монтиран сменяем HDD"
+
+#: id:13022
+msgid "Unsafe device removal"
+msgstr "Не безопасно отстраняване на устройство"
+
+#: id:13023
+msgid "Successfully removed device"
+msgstr "Успешно отстраняване на устройство"
+
+#: id:13024
+msgid "Joystick plugged"
+msgstr "Включен джойстик"
+
+#: id:13025
+msgid "Joystick unplugged"
+msgstr "Изключен джойстик"
+
+#: id:13050
+msgid "Running low on battery"
+msgstr "Разредена батерия"
+
+#: id:13100
+msgid "Flicker filter"
+msgstr "Филтър трептене"
+
+#: id:13101
+msgid "Let driver choose (requires restart)"
+msgstr "Драйвер (изисква рестарт)"
+
+#: id:13105
+msgid "Vertical blank sync"
+msgstr "Вертикална синхронизация"
+
+#: id:13106
+msgctxt "Auto context with id 13106"
+msgid "Disabled"
+msgstr "Изключен"
+
+#: id:13107
+msgid "Enabled during video playback"
+msgstr "Вкл при възпроизвеждане"
+
+#: id:13108
+msgctxt "Auto context with id 13108"
+msgid "Always enabled"
+msgstr "Винаги включен"
+
+#: id:13109
+msgid "Test & apply resolution"
+msgstr "Тест & приложи резолюция"
+
+#: id:13110
+msgid "Save resolution?"
+msgstr "Запазване резолюция?"
+
+#: id:13111
+msgid "Would you like to keep this resolution?"
+msgstr "Желаете ли да запазите тази резолюция?"
+
+#: id:13112
+msgid "High quality upscaling"
+msgstr "Високо качествено мащабиране"
+
+#: id:13113
+msgctxt "Auto context with id 13113"
+msgid "Disabled"
+msgstr "Изключено"
+
+#: id:13114
+msgid "Enabled for SD content"
+msgstr "Включено за SD съдържание"
+
+#: id:13115
+msgctxt "Auto context with id 13115"
+msgid "Always enabled"
+msgstr "Винаги включен"
+
+#: id:13116
+msgid "Upscaling method"
+msgstr "Метод за мащабиране"
+
+#: id:13117
+msgctxt "Auto context with id 13117"
+msgid "Bicubic"
+msgstr "Bicubic"
+
+#: id:13118
+msgid "Lanczos"
+msgstr "Lanczos"
+
+#: id:13119
+msgid "Sinc"
+msgstr "Sinc"
+
+#: id:13120
+msgctxt "Auto context with id 13120"
+msgid "VDPAU"
+msgstr "VDPAU"
+
+#: id:13121
+msgid "VDPAU HQ Upscaling level"
+msgstr "VDPAU HQ ниво на мащабиране"
+
+#: id:13122
+msgid "VDPAU Studio level color conversion"
+msgstr "VDPAU Студийно ниво на цветна конверсия"
+
+#: id:13130
+msgid "Blank other displays"
+msgstr "Мигане на екрана"
+
+#: id:13131
+msgctxt "Auto context with id 13131"
+msgid "Disabled"
+msgstr "Изключено"
+
+#: id:13132
+msgid "Blank displays"
+msgstr "Празни екрани"
+
+#: id:13140
+msgid "Active connections detected!"
+msgstr "Открита активна връзка!"
+
+#: id:13141
+msgid "If you proceed, you might not be able to control XBMC"
+msgstr "Ако продължите, възможно е да не можете да контролирате XBMC"
+
+#: id:13142
+msgid "any longer. Are you sure you want to stop the Event server?"
+msgstr "повече. Сигурни ли сте, че искате да спрете Сървъра на събитията?"
+
+#: id:13144
+msgid "Change Apple Remote mode?"
+msgstr "Промени режим Apple Remote?"
+
+#: id:13145
+msgid "If you are currently using the Apple Remote to control"
+msgstr "Ако в момента ползвате Apple Remote да контролирате"
+
+#: id:13146
+msgid "XBMC, changing this setting might affect your ability"
+msgstr "XBMC, променянето на тези настройки ще повлияе"
+
+#: id:13147
+msgid "to continue controlling it. Do you want to proceed?"
+msgstr "контрола. Искате ли да продължите?"
+
+#: id:13159
+msgid "Subnet mask"
+msgstr "Subnet mask"
+
+#: id:13160
+msgid "Gateway"
+msgstr "Gateway"
+
+#: id:13161
+msgid "Primary DNS"
+msgstr "Primary DNS"
+
+#: id:13162
+msgid "Initialize failed"
+msgstr "Инициализиране неуспешно"
+
+#: id:13170
+msgctxt "Auto context with id 13170"
+msgid "Never"
+msgstr "Никога"
+
+#: id:13171
+msgid "Immediately"
+msgstr "Незабавно"
+
+#: id:13172
+msgid "After %i secs"
+msgstr "След %i секунди"
+
+#: id:13173
+msgid "HDD install date:"
+msgstr "HDD дата:"
+
+#: id:13174
+msgid "HDD power cycle count:"
+msgstr "HDD брой цикли на включване:"
+
+#: id:13200
+msgid "Profiles"
+msgstr "Профили"
+
+#: id:13201
+msgid "Delete profile '%s'?"
+msgstr "Изтрий профил '%s'?"
+
+#: id:13204
+msgid "Last loaded profile:"
+msgstr "Последно зареден профил:"
+
+#: id:13205
+msgid "Unknown"
+msgstr "Непознат"
+
+#: id:13206
+msgid "Overwrite"
+msgstr "Презапиши"
+
+#: id:13208
+msgid "Alarm clock"
+msgstr "Алармен часовник"
+
+#: id:13209
+msgid "Alarm clock interval (in minutes)"
+msgstr "Интервал на алармата (в минути)"
+
+#: id:13210
+msgid "Started, alarm in %im"
+msgstr "Стартирана, аларма в %im"
+
+#: id:13211
+msgid "Alarm!"
+msgstr "Аларма!"
+
+#: id:13212
+msgid "Canceled with %im%is left"
+msgstr "Прекъсната с %im%is оставащи"
+
+#: id:13213
+msgid "%2.0fm"
+msgstr "%2.0fm"
+
+#: id:13214
+msgid "%2.0fs"
+msgstr "%2.0fs"
+
+#: id:13249
+msgid "Search for subtitles in RARs"
+msgstr "Търси субтитри в RAR"
+
+#: id:13250
+msgid "Browse for subtitle..."
+msgstr "Търси субтитри..."
+
+#: id:13251
+msgid "Move item"
+msgstr "Премести"
+
+#: id:13252
+msgid "Move item here"
+msgstr "Премести тук"
+
+#: id:13253
+msgid "Cancel move"
+msgstr "Прекрати местене"
+
+#: id:13270
+msgid "Hardware:"
+msgstr "Хардуер:"
+
+#: id:13271
+msgid "CPU Usage:"
+msgstr "CPU натоварване:"
+
+#: id:13274
+msgid "Connected, but no DNS is available."
+msgstr "Свързан, но няма достъпен DNS."
+
+#: id:13275
+msgid "Hard Disk"
+msgstr "Твърд Диск"
+
+#: id:13276
+msgid "DVD-ROM"
+msgstr "DVD-ROM"
+
+#: id:13277
+msgctxt "Auto context with id 13277"
+msgid "Storage"
+msgstr "Склад"
+
+#: id:13278
+msgctxt "Auto context with id 13278"
+msgid "Default"
+msgstr "Подразбиране"
+
+#: id:13279
+msgctxt "Auto context with id 13279"
+msgid "Network"
+msgstr "Мрежа"
+
+#: id:13280
+msgctxt "Auto context with id 13280"
+msgid "Video"
+msgstr "Видео"
+
+#: id:13281
+msgid "Hardware"
+msgstr "Хардуер"
+
+#: id:13283
+msgid "Operating system:"
+msgstr "Операционна Система:"
+
+#: id:13284
+msgid "CPU speed:"
+msgstr "CPU скорост:"
+
+#: id:13286
+msgid "Video encoder:"
+msgstr "Видео енкодер:"
+
+#: id:13287
+msgid "Screen resolution:"
+msgstr "Резолюция на екрана:"
+
+#: id:13292
+msgid "A/V cable:"
+msgstr "А/В кабел:"
+
+#: id:13294
+msgid "DVD region:"
+msgstr "DVD регион:"
+
+#: id:13295
+msgid "Internet:"
+msgstr "Интернет:"
+
+#: id:13296
+msgctxt "Auto context with id 13296"
+msgid "Connected"
+msgstr "Свързан"
+
+#: id:13297
+msgid "Not connected. Check network settings."
+msgstr "Не е свързан. Проверете мрежовите настройки."
+
+#: id:13299
+msgid "Target temperature"
+msgstr "Целева температура"
+
+#: id:13300
+msgid "Fan speed"
+msgstr "Скорост на вентилатор"
+
+#: id:13301
+msgid "Auto temperature control"
+msgstr "Атоматичен температурен контрол"
+
+#: id:13302
+msgid "Fan speed override"
+msgstr "Замени скоростта на вентилатора"
+
+#: id:13303
+msgid "- Fonts"
+msgstr "- Шрифт"
+
+#: id:13304
+msgid "Enable flipping bi-directional strings"
+msgstr "Включи обръщане на двупосочен низ"
+
+#: id:13305
+msgid "Show RSS news feeds"
+msgstr "Включи RSS емисии"
+
+#: id:13306
+msgid "Show parent folder items"
+msgstr "Покажи позициите от предната директория"
+
+#: id:13307
+msgid "Track naming template"
+msgstr "Шаблон за именуване на песен"
+
+#: id:13308
+msgid "Do you wish to reboot your system"
+msgstr "Искате ли да рестартирате системата?"
+
+#: id:13309
+msgid "instead of just XBMC?"
+msgstr "Вместо само XBMC?"
+
+#: id:13310
+msgid "Zoom effect"
+msgstr "Ефект увеличаване"
+
+#: id:13311
+msgid "Float effect"
+msgstr "Плуващ ефект"
+
+#: id:13312
+msgid "Black bar reduction"
+msgstr "Намаляване на черните барове"
+
+#: id:13313
+msgid "Restart"
+msgstr "Рестарт"
+
+#: id:13314
+msgid "Crossfade between songs"
+msgstr "Кръстосване"
+
+#: id:13315
+msgid "Regenerate thumbnails"
+msgstr "Регенерирай картинки"
+
+#: id:13316
+msgid "Recursive thumbnails"
+msgstr "Рекурсивни картинки"
+
+#: id:13317
+msgid "View slideshow"
+msgstr "Вид слайдшоу"
+
+#: id:13318
+msgid "Recursive slideshow"
+msgstr "Рекурсивно слайдшоу"
+
+#: id:13319
+msgid "Randomize"
+msgstr "Разбъркай"
+
+#: id:13320
+msgid "Stereo"
+msgstr "Стерео"
+
+#: id:13321
+msgid "Left only"
+msgstr "Само ляв"
+
+#: id:13322
+msgid "Right only"
+msgstr "Само десен"
+
+#: id:13323
+msgid "Enable karaoke support"
+msgstr "Включи поддръжка на караоке"
+
+#: id:13324
+msgid "Background transparency"
+msgstr "Прозрачен фон"
+
+#: id:13325
+msgid "Foreground transparency"
+msgstr "Прозрачна картина"
+
+#: id:13326
+msgid "A/V delay"
+msgstr "А/В закъснение"
+
+#: id:13327
+msgid "Karaoke"
+msgstr "Караоке"
+
+#: id:13328
+msgid "%s not found"
+msgstr "%s не е намерен"
+
+#: id:13329
+msgid "Error opening %s"
+msgstr "Грешка при отваряне %s"
+
+#: id:13330
+msgid "Unable to load %s"
+msgstr "Не мога да заредя %s"
+
+#: id:13331
+msgid "Error: Out of memory"
+msgstr "Грешка: Няма памет"
+
+#: id:13332
+msgid "Move up"
+msgstr "Премести нагоре"
+
+#: id:13333
+msgid "Move down"
+msgstr "Премести надолу"
+
+#: id:13334
+msgid "Edit label"
+msgstr "Редактиране етикет"
+
+#: id:13335
+msgid "Make default"
+msgstr "Направи по подразбиране"
+
+#: id:13336
+msgid "Remove button"
+msgstr "Премахни бутон"
+
+#: id:13340
+msgid "Leave as is"
+msgstr "Остави както е"
+
+#: id:13341
+msgid "Green"
+msgstr "Зелен"
+
+#: id:13342
+msgid "Orange"
+msgstr "Оранжев"
+
+#: id:13343
+msgid "Red"
+msgstr "Червен"
+
+#: id:13344
+msgid "Cycle"
+msgstr "Цикъл"
+
+#: id:13345
+msgid "Switch LED off on playback"
+msgstr "Изключи LED при възпроизвеждане"
+
+#: id:13346
+msgctxt "Auto context with id 13346"
+msgid "Movie information"
+msgstr "Информация за филм"
+
+#: id:13347
+msgid "Queue item"
+msgstr "Сложи на опашка"
+
+#: id:13348
+msgid "Search IMDb..."
+msgstr "Търси IMDb..."
+
+#: id:13349
+msgid "Scan for new content"
+msgstr "Анализ ново съдържание"
+
+#: id:13350
+msgid "Now playing..."
+msgstr "В момента свири..."
+
+#: id:13351
+msgctxt "Auto context with id 13351"
+msgid "Album information"
+msgstr "Информация за албум"
+
+#: id:13352
+msgid "Scan item to library"
+msgstr "Анализиране"
+
+#: id:13353
+msgid "Stop scanning"
+msgstr "Спри сканиране"
+
+#: id:13354
+msgctxt "Auto context with id 13354"
+msgid "Render method"
+msgstr "Метод за рендване"
+
+#: id:13355
+msgid "Low quality pixel shader"
+msgstr "Ниско качество пикселни шейдъри"
+
+#: id:13356
+msgid "Hardware overlays"
+msgstr "Хардуерни пластове"
+
+#: id:13357
+msgid "High quality pixel shader"
+msgstr "Високо качество пикселни шейдъри"
+
+#: id:13358
+msgid "Play item"
+msgstr "Просвири"
+
+#: id:13359
+msgid "Set artist thumb"
+msgstr "Снимка за изпълнител"
+
+#: id:13360
+msgid "Automatically generate thumbnails"
+msgstr "Генерирай картинка"
+
+#: id:13361
+msgid "Enable voice"
+msgstr "Включи глас"
+
+#: id:13375
+msgid "Enable device"
+msgstr "Включи устройство"
+
+#: id:13376
+msgid "Volume"
+msgstr "Капацитет"
+
+#: id:13377
+msgid "Default view mode"
+msgstr "Режим на изглед по подразбиране"
+
+#: id:13378
+msgid "Default brightness"
+msgstr "Осветеност по подразбиране"
+
+#: id:13379
+msgid "Default contrast"
+msgstr "Контраст по подразбиране"
+
+#: id:13380
+msgid "Default gamma"
+msgstr "Гама по подразбиране"
+
+#: id:13381
+msgid "Resume video"
+msgstr "Възобнови видео"
+
+#: id:13382
+msgid "Voice mask - Port 1"
+msgstr "Гласова маска - Порт 1"
+
+#: id:13383
+msgid "Voice mask - Port 2"
+msgstr "Гласова маска - Порт 2"
+
+#: id:13384
+msgid "Voice mask - Port 3"
+msgstr "Гласова маска - Порт 3"
+
+#: id:13385
+msgid "Voice mask - Port 4"
+msgstr "Гласова маска - Порт 4"
+
+#: id:13386
+msgid "Use time based seeking"
+msgstr "Ползвай търсене базирано на време"
+
+#: id:13387
+msgid "Track naming template - right"
+msgstr "Шаблон за именуване права на песен"
+
+#: id:13388
+msgid "Preset"
+msgstr "Настроени"
+
+#: id:13389
+msgid "There are no presets available\nfor this visualization"
+msgstr "Няма достъпни настроени\nза тази визуализация"
+
+#: id:13390
+msgid "There are no settings available\nfor this visualization"
+msgstr "Няма достъпни настройки\nза тази визуализация"
+
+#: id:13391
+msgid "Eject/Load"
+msgstr "Изхвърли/Прибери"
+
+#: id:13392
+msgid "Use visualization if playing audio"
+msgstr "Използване на визуализация при възпроизвеждане на аудио"
+
+#: id:13393
+msgid "Calculate size"
+msgstr "Изчислявам размер"
+
+#: id:13394
+msgid "Calculating folder size"
+msgstr "Изчислявам размер на папка"
+
+#: id:13395
+msgid "Video settings"
+msgstr "Видео настройки"
+
+#: id:13396
+msgid "Audio and subtitle settings"
+msgstr "Аудио и субтитри настройки"
+
+#: id:13397
+msgid "Enable subtitles"
+msgstr "Включи субтитри"
+
+#: id:13398
+msgctxt "Auto context with id 13398"
+msgid "Shortcuts"
+msgstr "Кратки пътища"
+
+#: id:13399
+msgid "Ignore articles when sorting (e.g. \"the\")"
+msgstr "Игнориране на символите при сортиране"
+
+#: id:13400
+msgid "Crossfade between songs on the same album"
+msgstr "Кръстосай песни в албум"
+
+#: id:13401
+msgid "Browse for %s"
+msgstr "Търси за %s"
+
+#: id:13402
+msgid "Show track position"
+msgstr "Покажи позицията на песента"
+
+#: id:13403
+msgid "Clear default"
+msgstr "Изчисти подразбиране"
+
+#: id:13404
+msgid "Resume"
+msgstr "Възобнови"
+
+#: id:13405
+msgid "Get thumb"
+msgstr "Вземи картинка"
+
+#: id:13406
+msgid "Picture information"
+msgstr "Информация за снимка"
+
+#: id:13407
+msgid "%s presets"
+msgstr "%s настроени"
+
+#: id:13408
+msgid "(IMDb user rating)"
+msgstr "(IMDb рейтинг потребители)"
+
+#: id:13409
+msgid "Top 250"
+msgstr "Топ 250"
+
+#: id:13410
+msgid "Tune in on Last.fm"
+msgstr "Настрой на Last.fm"
+
+#: id:13411
+msgid "Minimum fan speed"
+msgstr "Минимална скорост на вентилатора"
+
+#: id:13412
+msgid "Play from here"
+msgstr "Изпълни от тук"
+
+#: id:13413
+msgid "Downloading"
+msgstr "Сваляне"
+
+#: id:13414
+msgid "Include artists who appear only on compilations"
+msgstr "Скрий изпълнител, участващ само в компилации"
+
+#: id:13415
+msgctxt "Auto context with id 13415"
+msgid "Render method"
+msgstr "Метод за рендване"
+
+#: id:13416
+msgid "Auto detect"
+msgstr "Автоматично разпознаване"
+
+#: id:13417
+msgid "Basic shaders (ARB)"
+msgstr "Основни шейдъри (ARB)"
+
+#: id:13418
+msgid "Advanced shaders (GLSL)"
+msgstr "Допълнителни шейдъри (GLSL)"
+
+#: id:13419
+msgid "Software"
+msgstr "Софтуер"
+
+#: id:13420
+msgid "Remove safely"
+msgstr "Безопасно премахване"
+
+#: id:13421
+msgctxt "Auto context with id 13421"
+msgid "VDPAU"
+msgstr "VDPAU"
+
+#: id:13422
+msgid "Start slideshow here"
+msgstr "Започни слайдшоу тук"
+
+#: id:13423
+msgid "Remember for this path"
+msgstr "Запомни за този път"
+
+#: id:13424
+msgid "Use pixel buffer objects"
+msgstr "Ползвай пиксел буфер"
+
+#: id:13425
+msgid "Allow hardware acceleration (VDPAU)"
+msgstr "Позволи хардуерно ускорение (VDPAU)"
+
+#: id:13426
+msgid "Allow hardware acceleration (VAAPI)"
+msgstr "Позволи хардуерно ускорение (VAAPI)"
+
+#: id:13427
+msgid "Allow hardware acceleration (DXVA2)"
+msgstr "Позволи хардуерно ускорение (DXVA2)"
+
+#: id:13428
+msgid "Allow hardware acceleration (CrystalHD)"
+msgstr "Позволи хардуерно ускорение (CrystalHD)"
+
+#: id:13429
+msgid "Allow hardware acceleration (VDADecoder)"
+msgstr "Позволи хардуерно ускорение (VDADecoder)"
+
+#: id:13430
+msgid "Allow hardware acceleration (OpenMax)"
+msgstr "Позволи хардуерно ускорение (OpenMax)"
+
+#: id:13431
+msgid "Pixel Shaders"
+msgstr "Пикселни шейдъри"
+
+#: id:13432
+msgid "Allow hardware acceleration (VideoToolbox)"
+msgstr "Позволи хардуерно ускориние (VideoToolbox)"
+
+#: id:13500
+msgid "A/V sync method"
+msgstr "А/В метод за синхронизиране"
+
+#: id:13501
+msgid "Audio clock"
+msgstr "Аудио честота"
+
+#: id:13502
+msgid "Video clock (Drop/Dupe audio)"
+msgstr "Видео честота (Drop/Dupe audio)"
+
+#: id:13503
+msgid "Video clock (Resample audio)"
+msgstr "Видео честота (Resample audio)"
+
+#: id:13504
+msgid "Maximum resample amount (%)"
+msgstr "Максимално количество мостри (%)"
+
+#: id:13505
+msgid "Resample quality"
+msgstr "Качество на мострите"
+
+#: id:13506
+msgid "Low(fast)"
+msgstr "Ниско(бързо)"
+
+#: id:13507
+msgctxt "Auto context with id 13507"
+msgid "Medium"
+msgstr "Средно"
+
+#: id:13508
+msgctxt "Auto context with id 13508"
+msgid "High"
+msgstr "Високо"
+
+#: id:13509
+msgid "Really high(slow!)"
+msgstr "Наистина високо(бавно!)"
+
+#: id:13510
+msgid "Sync playback to display"
+msgstr "Синхронизирай възпроизвеждане към дисплея"
+
+#: id:13550
+msgid "Pause during refresh rate change"
+msgstr "Пауза при смяна на честота на опресняване"
+
+#: id:13551
+msgctxt "Auto context with id 13551"
+msgid "Off"
+msgstr "Изкл"
+
+#: id:13552
+msgid "%.1f Second"
+msgstr "%.1f секунда"
+
+#: id:13553
+msgid "%.1f Seconds"
+msgstr "%.1f секунди"
+
+#: id:13600
+msgid "Apple remote"
+msgstr "Apple Remote"
+
+#: id:13602
+msgid "Allow start of XBMC using the remote"
+msgstr "Винаги работещ"
+
+#: id:13603
+msgid "Sequence delay time"
+msgstr "Време на закъснение поредица"
+
+#: id:13610
+msgctxt "Auto context with id 13610"
+msgid "Disabled"
+msgstr "Изключено"
+
+#: id:13611
+msgctxt "Auto context with id 13611"
+msgid "Standard"
+msgstr "Стандартно"
+
+#: id:13612
+msgid "Universal Remote"
+msgstr "Универсално дистанционно"
+
+#: id:13613
+msgid "Multi Remote (Harmony)"
+msgstr "Multi Remote (Harmony)"
+
+#: id:13620
+msgid "Apple Remote Error"
+msgstr "Apple Remote грешка"
+
+#: id:13621
+msgid "Apple Remote support could be enabled."
+msgstr "Поддръжката на Apple Remote може да се включи."
+
+#: id:14000
+msgid "Stack"
+msgstr "Натрупване"
+
+#: id:14001
+msgid "Unstack"
+msgstr "Разтоварване"
+
+#: id:14003
+msgid "Downloading playlist file..."
+msgstr "Изтегляне заглавието на плейлиста..."
+
+#: id:14004
+msgid "Downloading streams list..."
+msgstr "Изтегляне списък на потоци..."
+
+#: id:14005
+msgid "Parsing streams list..."
+msgstr "Разбор списък на потоци..."
+
+#: id:14006
+msgid "Downloading streams list failed"
+msgstr "Изтегляне списък на потоци неуспешно"
+
+#: id:14007
+msgid "Downloading playlist file failed"
+msgstr "Изтегляне заглавието на плейлиста неуспешно"
+
+#: id:14009
+msgid "Games directory"
+msgstr "Папка игри"
+
+#: id:14010
+msgid "Auto switch to thumbs based on"
+msgstr "Автоматична превключване на картинка базирана на"
+
+#: id:14011
+msgid "Enable auto switching to thumbs view"
+msgstr "Включване на автопревключващ изглед"
+
+#: id:14012
+msgid "- Use large icons"
+msgstr "- Използвай големи икони"
+
+#: id:14013
+msgid "- Switch based on"
+msgstr "- Превключване базирано на"
+
+#: id:14014
+msgid "- Percentage"
+msgstr "- Проценти"
+
+#: id:14015
+msgid "No files and at least one thumb"
+msgstr "Няма файлове и най-малко една картинка"
+
+#: id:14016
+msgid "At least one file and thumb"
+msgstr "Най-малко един файл и картинка"
+
+#: id:14017
+msgid "Percentage of thumbs"
+msgstr "Проценти от картинка"
+
+#: id:14018
+msgid "View options"
+msgstr "Преглед на опциите"
+
+#: id:14019
+msgid "Change area code 1"
+msgstr "Промяна на код на областта 1 (или град)"
+
+#: id:14020
+msgid "Change area code 2"
+msgstr "Промяна на код на областта 2 (или град)"
+
+#: id:14021
+msgid "Change area code 3"
+msgstr "Промяна на код на областта 3 (или град)"
+
+#: id:14022
+msgctxt "Auto context with id 14022"
+msgid "Library"
+msgstr "Библиотека"
+
+#: id:14023
+msgid "No TV"
+msgstr "Без ТВ"
+
+#: id:14024
+msgid "Enter the nearest large town"
+msgstr "Въведете най-близкия голям град"
+
+#: id:14025
+msgid "Video/Audio/DVD cache - Harddisk"
+msgstr "Видео/Аудио/DVD кеш - Харддиск"
+
+#: id:14026
+msgid "Video cache - DVD-ROM"
+msgstr "Видео кеш - DVD-ROM"
+
+#: id:14027
+msgctxt "Auto context with id 14027"
+msgid "- Local Network"
+msgstr "- Локална мрежа"
+
+#: id:14028
+msgctxt "Auto context with id 14028"
+msgid "- Internet"
+msgstr "- Интернет"
+
+#: id:14030
+msgid "Audio cache - DVD-ROM"
+msgstr "Аудио кеш - DVD-ROM"
+
+#: id:14031
+msgctxt "Auto context with id 14031"
+msgid "- Local Network"
+msgstr "- Локална мрежа"
+
+#: id:14032
+msgctxt "Auto context with id 14032"
+msgid "- Internet"
+msgstr "- Интернет"
+
+#: id:14034
+msgid "DVD cache - DVD-ROM"
+msgstr "DVD кеш - DVD-ROM"
+
+#: id:14035
+msgctxt "Auto context with id 14035"
+msgid "- Local Network"
+msgstr "- Локална мрежа"
+
+#: id:14036
+msgctxt "Auto context with id 14036"
+msgid "Services"
+msgstr "Сървъри"
+
+#: id:14038
+msgid "Network settings changed"
+msgstr "Мрежовите настройки променени"
+
+#: id:14039
+msgid "XBMC requires to restart to change your"
+msgstr "XBMC изисква рестарт за да промени вашите"
+
+#: id:14040
+msgid "network setup. Would you like to restart now?"
+msgstr "мрежови настройки. Желаете ли да рестартирате сега?"
+
+#: id:14041
+msgid "Internet connection bandwidth limitation"
+msgstr ""
+
+#: id:14043
+msgid "- Shutdown while playing"
+msgstr "- Изключване докато възпроизвежда"
+
+#: id:14044
+msgid "%i min"
+msgstr "%i минути"
+
+#: id:14045
+msgid "%i sec"
+msgstr "%i секунди"
+
+#: id:14046
+msgid "%i ms"
+msgstr "%i мс"
+
+#: id:14047
+msgid "%i %%"
+msgstr "%i %%"
+
+#: id:14048
+msgid "%i kbps"
+msgstr "%i kbps"
+
+#: id:14049
+msgid "%i kb"
+msgstr "%i kb"
+
+#: id:14050
+msgid "%i.0 dB"
+msgstr "%i.0 dB"
+
+#: id:14051
+msgid "Time format"
+msgstr "Формат Час"
+
+#: id:14052
+msgid "Date format"
+msgstr "Формат дата"
+
+#: id:14053
+msgid "GUI filters"
+msgstr "GUI филтри"
+
+#: id:14055
+msgid "Use background scanning"
+msgstr "Използвай сканиране на заден фон"
+
+#: id:14056
+msgid "Stop scan"
+msgstr "Спри сканиране"
+
+#: id:14057
+msgid "Not possible while scanning for media info"
+msgstr "Не е възможно, докато сканира медия за информация"
+
+#: id:14058
+msgid "Film grain effect"
+msgstr "Зърнест ефект"
+
+#: id:14059
+msgid "Search for thumbnails on remote shares"
+msgstr "Търси картинки на споделени медии"
+
+#: id:14060
+msgid "Unknown type cache - Internet"
+msgstr "Непознат тип кеш - Интернет"
+
+#: id:14061
+msgctxt "Auto context with id 14061"
+msgid "Auto"
+msgstr "Автоматичен"
+
+#: id:14062
+msgid "Enter username for"
+msgstr "Въведи потребителско име за"
+
+#: id:14063
+msgid "Date & time"
+msgstr "Дата & час"
+
+#: id:14064
+msgid "Set date"
+msgstr "Задай дата"
+
+#: id:14065
+msgid "Set time"
+msgstr "Задай час"
+
+#: id:14066
+msgid "Enter the time in 24 hour HH:MM format"
+msgstr "Въведи час в 24 HH:MM формат"
+
+#: id:14067
+msgid "Enter the date in DD/MM/YYYY format"
+msgstr "Въведи дата в DD/MM/YYYY формат"
+
+#: id:14068
+msgid "Enter the IP address"
+msgstr "Въведи IP адрес"
+
+#: id:14069
+msgid "Apply these settings now?"
+msgstr "Приложи тези настройки сега?"
+
+#: id:14070
+msgid "Apply changes now"
+msgstr "Приложи настройки сега"
+
+#: id:14071
+msgid "Allow file renaming and deletion"
+msgstr "Позволи преименуване и триене на файлове"
+
+#: id:14074
+msgid "Set timezone"
+msgstr "Задай часова зона"
+
+#: id:14075
+msgid "Use daylight saving time"
+msgstr "Използвайте лятното часово време"
+
+#: id:14076
+msgid "Add to favourites"
+msgstr "Добави към избрани"
+
+#: id:14077
+msgid "Remove from favourites"
+msgstr "Премахни от избрани"
+
+#: id:14078
+msgctxt "Auto context with id 14078"
+msgid "- Colours"
+msgstr "- Цвят"
+
+#: id:14079
+msgid "Timezone country"
+msgstr "Часова зона държава"
+
+#: id:14080
+msgid "Timezone"
+msgstr "Часова зона"
+
+#: id:14081
+msgid "File lists"
+msgstr "Файл лист"
+
+#: id:14082
+msgid "Show EXIF picture information"
+msgstr "Покажи EXIF инфо за снимка"
+
+#: id:14083
+msgid "Use a fullscreen window rather than true fullscreen"
+msgstr "Ползвай прозорец цял екран вместо цял екран"
+
+#: id:14084
+msgid "Queue songs on selection"
+msgstr "Песен на опашка при селектиране"
+
+#: id:14086
+msgid "Playback"
+msgstr "Възпроизвежда"
+
+#: id:14087
+msgid "DVDs"
+msgstr "DVD"
+
+#: id:14088
+msgid "Play DVDs automatically"
+msgstr "Автоматично възпроизвеждане на DVD"
+
+#: id:14089
+msgid "Font to use for text subtitles"
+msgstr "Шрифт за субтитри"
+
+#: id:14090
+msgid "International"
+msgstr "Международни"
+
+#: id:14091
+msgid "Character set"
+msgstr "Кодова таблица"
+
+#: id:14092
+msgid "Debugging"
+msgstr "Дебъг"
+
+#: id:14093
+msgid "Security"
+msgstr "Сигурност"
+
+#: id:14094
+msgid "Input devices"
+msgstr "Устройства Вход"
+
+#: id:14095
+msgid "Power saving"
+msgstr "Пестене енергия"
+
+#: id:14096
+msgid "Rip"
+msgstr ""
+
+#: id:14097
+msgid "Audio CD Insert Action"
+msgstr ""
+
+#: id:14098
+msgctxt "Auto context with id 14098"
+msgid "Play"
+msgstr ""
+
+#: id:14099
+msgid "Eject disc when CD ripping is complete"
+msgstr ""
+
+#: id:15015
+msgctxt "Auto context with id 15015"
+msgid "Remove"
+msgstr "Премахни"
+
+#: id:15016
+msgid "Games"
+msgstr "Игри"
+
+#: id:15019
+msgid "Add"
+msgstr "Добави"
+
+#: id:15052
+msgid "Password"
+msgstr "Парола"
+
+#: id:15100
+msgctxt "Auto context with id 15100"
+msgid "Library"
+msgstr "Библиотека"
+
+#: id:15101
+msgid "Database"
+msgstr "База данни"
+
+#: id:15102
+msgid "* All albums"
+msgstr "* Всички албуми"
+
+#: id:15103
+msgid "* All artists"
+msgstr "* Всички изпълнители"
+
+#: id:15104
+msgid "* All songs"
+msgstr "* Всички песни"
+
+#: id:15105
+msgid "* All genres"
+msgstr "* Всички жанрове"
+
+#: id:15107
+msgid "Buffering..."
+msgstr "Буфериране..."
+
+#: id:15108
+msgid "Navigation sounds"
+msgstr "Звуци при навигиране"
+
+#: id:15109
+msgid "Skin default"
+msgstr "Кожа подразбиране"
+
+#: id:15111
+msgid "- Theme"
+msgstr "- Тема"
+
+#: id:15112
+msgid "Default theme"
+msgstr "Тема подразбиране"
+
+#: id:15200
+msgid "Last.fm"
+msgstr "Last.fm"
+
+#: id:15201
+msgid "Submit songs to Last.fm"
+msgstr "Предаване на песни към Last.fm"
+
+#: id:15202
+msgid "Last.fm username"
+msgstr "Last.fm потребител"
+
+#: id:15203
+msgid "Last.fm password"
+msgstr "Last.fm парола"
+
+#: id:15204
+msgid "Unable to handshake: sleeping..."
+msgstr "Невъзможност за здрависване: заспиване..."
+
+#: id:15205
+msgid "Please update XBMC"
+msgstr "Моля обновете XBMC"
+
+#: id:15206
+msgid "Bad authorization: Check username and password"
+msgstr "Невалидна оторизация: Проверете име и парола"
+
+#: id:15207
+msgctxt "Auto context with id 15207"
+msgid "Connected"
+msgstr "Свързан"
+
+#: id:15208
+msgid "Not connected"
+msgstr "Не свързан"
+
+#: id:15209
+msgid "Submit interval %i"
+msgstr "Подаване на интервал %i"
+
+#: id:15210
+msgid "Cached %i songs"
+msgstr "Кеширани %i песни"
+
+#: id:15211
+msgid "Submitting..."
+msgstr "Предаване..."
+
+#: id:15212
+msgid "Submitting in %i secs"
+msgstr "Предаване в %i секунди"
+
+#: id:15213
+msgid "Play using..."
+msgstr "Възпроизведи с..."
+
+#: id:15214
+msgid "Use smoothed A/V synchronization"
+msgstr "Използвай гладко А/В синхонизиране"
+
+#: id:15215
+msgid "Hide file names in thumbs view"
+msgstr "Скрий имената на файловете в изглед картинки"
+
+#: id:15216
+msgid "Play in party mode"
+msgstr "Възпроизведи в Парти режим"
+
+#: id:15217
+msgid "Submit songs to Libre.fm"
+msgstr "Предаване на песни към Libre.fm"
+
+#: id:15218
+msgid "Libre.fm username"
+msgstr "Libre.fm потребител"
+
+#: id:15219
+msgid "Libre.fm password"
+msgstr "Libre.fm парола"
+
+#: id:15220
+msgid "Libre.fm"
+msgstr "Libre.fm"
+
+#: id:15221
+msgid "Song submission"
+msgstr "Песен предаване"
+
+#: id:15250
+msgid "Submit Last.fm radio to Last.fm"
+msgstr "Предай Last.fm радио към Last.fm"
+
+#: id:15251
+msgid "Connecting to Last.fm..."
+msgstr "Свързване към Last.fm..."
+
+#: id:15252
+msgid "Selecting station..."
+msgstr "Избиране на станция..."
+
+#: id:15253
+msgid "Search similar artists..."
+msgstr "Търсене на подобни изпълнители..."
+
+#: id:15254
+msgid "Search similar tags..."
+msgstr "Търсене на подобни етикети..."
+
+#: id:15255
+msgid "Your profile (%name%)"
+msgstr "Вашият профил (%name%)"
+
+#: id:15256
+msgid "Overall top tags"
+msgstr "Пълни етикет"
+
+#: id:15257
+msgid "Top artists for tag %name%"
+msgstr "Топ изпълнители за етикет %name%"
+
+#: id:15258
+msgid "Top albums for tag %name%"
+msgstr "Топ албуми за етикет %name%"
+
+#: id:15259
+msgid "Top tracks for tag %name%"
+msgstr "Топ песни за етикет %name%"
+
+#: id:15260
+msgid "Listen to tag %name% Last.fm radio"
+msgstr "Слушай етикет %name% Last.fm радио"
+
+#: id:15261
+msgid "Similar artists as %name%"
+msgstr "Подобни изпълнители като %name%"
+
+#: id:15262
+msgid "Top %name% albums"
+msgstr "Топ %name% албуми"
+
+#: id:15263
+msgid "Top %name% tracks"
+msgstr "Топ %name% песни"
+
+#: id:15264
+msgid "Top %name% tags"
+msgstr "Топ %name% етикети"
+
+#: id:15265
+msgid "Biggest fans of %name%"
+msgstr "Най-големи фенове на %name%"
+
+#: id:15266
+msgid "Listen to %name% fans Last.fm radio"
+msgstr "Слушай %name% фенове Last.fm радио"
+
+#: id:15267
+msgid "Listen to %name% similar artists Last.fm radio"
+msgstr "Слушай %name% подобни изпълнители Last.fm радио"
+
+#: id:15268
+msgid "Top artists for user %name%"
+msgstr "Топ изпълнители за потребител %name%"
+
+#: id:15269
+msgid "Top albums for user %name%"
+msgstr "Топ албуми за потребител %name%"
+
+#: id:15270
+msgid "Top tracks for user %name%"
+msgstr "Топ песни за потребител %name%"
+
+#: id:15271
+msgid "Friends of user %name%"
+msgstr "Приятели на потребител %name%"
+
+#: id:15272
+msgid "Neighbours of user %name%"
+msgstr "Съседи на потребител %name%"
+
+#: id:15273
+msgid "Weekly artist chart for %name%"
+msgstr "Седмична диаграма на изпълнител %name%"
+
+#: id:15274
+msgid "Weekly album chart for %name%"
+msgstr "Седмична диаграма на албум %name%"
+
+#: id:15275
+msgid "Weekly track chart for %name%"
+msgstr "Седмична диаграма на песен %name%"
+
+#: id:15276
+msgid "Listen to %name%'s neighbours Last.fm radio"
+msgstr "Слушай %name%те съседи Last.fm радио"
+
+#: id:15277
+msgid "Listen to %name%'s personal Last.fm radio"
+msgstr "Слушай %name%'s лично Last.fm радио"
+
+#: id:15278
+msgid "Listen to %name%'s mix Last.fm radio"
+msgstr "Слушай %name%'s любими песни Last.fm радио"
+
+#: id:15279
+msgid "Retrieving list from Last.fm..."
+msgstr "Получаване на лист от Last.fm..."
+
+#: id:15280
+msgid "Can't retrieve list from Last.fm..."
+msgstr "Не мога да получа лист от Last.fm..."
+
+#: id:15281
+msgid "Enter an artist name to find related ones"
+msgstr "Въведете име на изпълнител, за да намеря свързани"
+
+#: id:15282
+msgid "Enter a tag name to find similar ones"
+msgstr "Въведете етикет за да намеря подобни"
+
+#: id:15283
+msgid "Tracks recently listened by %name%"
+msgstr "Песни наскоро слушани %name%"
+
+#: id:15284
+msgid "Listen to %name%'s recommendations Last.fm radio"
+msgstr "Слушай %name%те препоръчителни Last.fm радио"
+
+#: id:15285
+msgid "Top tags for user %name%"
+msgstr "Топ етикети за потребител %name%"
+
+#: id:15287
+msgid "Do you want to add the current track to your loved tracks?"
+msgstr "Желаете ли да добавите текущата песен към любимите?"
+
+#: id:15288
+msgid "Do you want to ban the current track?"
+msgstr "Желаете ли да забраните текущата песен?"
+
+#: id:15289
+msgid "Added to your loved tracks: '%s'."
+msgstr "Добавено към любимите: '%s'."
+
+#: id:15290
+msgid "Could not add '%s' to your loved tracks."
+msgstr "Не мога да добавя '%s' към любимите."
+
+#: id:15291
+msgid "Banned: '%s'."
+msgstr "Забранен: '%s'."
+
+#: id:15292
+msgid "Could not ban '%s'."
+msgstr "Не мога да забраня '%s'."
+
+#: id:15293
+msgid "Tracks recently loved by %name%"
+msgstr "Песента наскоро е заредена от %name%"
+
+#: id:15294
+msgid "Tracks recently banned by %name%"
+msgstr "Песента наскоро е забранена то %name%"
+
+#: id:15295
+msgid "Remove from loved tracks"
+msgstr "Премахване от любими"
+
+#: id:15296
+msgid "Un-ban"
+msgstr "Премахване от Забранени"
+
+#: id:15297
+msgid "Do you want to remove this track from your loved tracks?"
+msgstr "Желаете ли да премахнете тази песен от любимите?"
+
+#: id:15298
+msgid "Do you want to un-ban this track?"
+msgstr "Желаете ли да премахнете тази песен от Забранени?"
+
+#: id:15300
+msgid "Path not found or invalid"
+msgstr "Пътят не е намерен или е невалиден"
+
+#: id:15301
+msgid "Could not connect to network server"
+msgstr "Не мога да се свържа към мрежовия сървър"
+
+#: id:15302
+msgid "No servers found"
+msgstr "Не са намерени сървъри"
+
+#: id:15303
+msgid "Workgroup not found"
+msgstr "Workgroup не е намерена"
+
+#: id:15310
+msgid "Opening multi-path source"
+msgstr "Отваряне на многопосочен източник"
+
+#: id:15311
+msgid "Path:"
+msgstr "Път:"
+
+#: id:16000
+msgctxt "Auto context with id 16000"
+msgid "General"
+msgstr "Главни"
+
+#: id:16002
+msgid "Internet lookup"
+msgstr "Интернет търсене"
+
+#: id:16003
+msgid "Player"
+msgstr "Плейър"
+
+#: id:16004
+msgid "Play media from disc"
+msgstr "Възпроизвеждане медия от диск"
+
+#: id:16008
+msgid "Enter new title"
+msgstr "Въведете ново заглавие"
+
+#: id:16009
+msgid "Enter the movie name"
+msgstr "Въведете името на филма"
+
+#: id:16010
+msgid "Enter the profile name"
+msgstr "Въведете името на профила"
+
+#: id:16011
+msgid "Enter the album name"
+msgstr "Въведете името на албума"
+
+#: id:16012
+msgid "Enter the playlist name"
+msgstr "Въведете името на плейлиста"
+
+#: id:16013
+msgid "Enter new filename"
+msgstr "Въведете ново име на файл"
+
+#: id:16014
+msgid "Enter folder name"
+msgstr "Въведете име на папка"
+
+#: id:16015
+msgid "Enter directory"
+msgstr "Въведете папка"
+
+#: id:16016
+msgid "Available options: %A, %T, %N, %B, %D, %G, %Y, %F, %S"
+msgstr "Достъпни опции: %A, %T, %N, %B, %D, %G, %Y, %F, %S"
+
+#: id:16017
+msgid "Enter search string"
+msgstr "Въведете търсен низ"
+
+#: id:16018
+msgctxt "Auto context with id 16018"
+msgid "None"
+msgstr "Никой"
+
+#: id:16019
+msgid "Auto select"
+msgstr "Автоматично избиране"
+
+#: id:16020
+msgid "De-interlace"
+msgstr "De-interlace"
+
+#: id:16021
+msgid "Bob"
+msgstr "Bob"
+
+#: id:16022
+msgid "Bob (inverted)"
+msgstr "Bob (inverted)"
+
+#: id:16024
+msgid "Canceling..."
+msgstr "Отказване..."
+
+#: id:16025
+msgid "Enter the artist name"
+msgstr "Въведете името на изпълнителя"
+
+#: id:16026
+msgid "Playback failed"
+msgstr "Неуспешно възпроизвеждане"
+
+#: id:16027
+msgid "One or more items failed to play."
+msgstr "Неуспешно възпроизвеждане на една или повече позиции"
+
+#: id:16028
+msgid "Enter value"
+msgstr "Въведете стойност"
+
+#: id:16029
+msgid "Check the log file for details."
+msgstr "Проверете лог файла за детайли."
+
+#: id:16030
+msgid "Party mode aborted."
+msgstr "Режим парти отхвърлен."
+
+#: id:16031
+msgid "No matching songs in the library."
+msgstr "Няма съвпадаща песен в библиотеката."
+
+#: id:16032
+msgid "Could not initialize database."
+msgstr "Не мога да инициализирам библиотеката."
+
+#: id:16033
+msgid "Could not open database."
+msgstr "Не мога да отворя базата данни."
+
+#: id:16034
+msgid "Could not get songs from database."
+msgstr "Не мога да взема песента от базата данни."
+
+#: id:16035
+msgid "Party mode playlist"
+msgstr "Плейлист Режим парти"
+
+#: id:16036
+msgid "De-interlace (Half)"
+msgstr "De-interlace (Half)"
+
+#: id:16037
+msgid "Deinterlace video"
+msgstr "Deinterlace видео"
+
+#: id:16038
+msgid "Deinterlace method"
+msgstr "Deinterlace метод"
+
+#: id:16039
+msgctxt "Auto context with id 16039"
+msgid "Off"
+msgstr "Изкл"
+
+#: id:16040
+msgctxt "Auto context with id 16040"
+msgid "Auto"
+msgstr "Авто"
+
+#: id:16041
+msgid "On"
+msgstr "Вкл"
+
+#: id:16100
+msgid "All Videos"
+msgstr "Всички видео"
+
+#: id:16101
+msgid "Unwatched"
+msgstr "Не гледани"
+
+#: id:16102
+msgid "Watched"
+msgstr "Гледани"
+
+#: id:16103
+msgid "Mark as watched"
+msgstr "Маркирай като гледани"
+
+#: id:16104
+msgid "Mark as unwatched"
+msgstr "Маркирай като не гледани"
+
+#: id:16105
+msgid "Edit title"
+msgstr "Редактиране заглавие"
+
+#: id:16200
+msgid "Operation was aborted"
+msgstr "Операцията беше отхвърлена"
+
+#: id:16201
+msgid "Copy failed"
+msgstr "Копирането неуспешно"
+
+#: id:16202
+msgid "Failed to copy at least one file"
+msgstr "Неуспех при копиране най-малко един файл"
+
+#: id:16203
+msgid "Move failed"
+msgstr "Преместване неуспешно"
+
+#: id:16204
+msgid "Failed to move at least one file"
+msgstr "Неуспех при преместване най-малко един файл"
+
+#: id:16205
+msgid "Delete failed"
+msgstr "Изтриване неуспешно"
+
+#: id:16206
+msgid "Failed to delete at least one file"
+msgstr "Неуспех при изтриване най-малко един файл"
+
+#: id:16300
+msgid "Video scaling method"
+msgstr "Метод видео мащабиране"
+
+#: id:16301
+msgid "Nearest neighbour"
+msgstr "Nearest neighbour"
+
+#: id:16302
+msgid "Bilinear"
+msgstr "Bilinear"
+
+#: id:16303
+msgctxt "Auto context with id 16303"
+msgid "Bicubic"
+msgstr "Bicubic"
+
+#: id:16304
+msgid "Lanczos2"
+msgstr "Lanczos2"
+
+#: id:16305
+msgid "Lanczos3"
+msgstr "Lanczos3"
+
+#: id:16306
+msgid "Sinc8"
+msgstr "Sinc8"
+
+#: id:16307
+msgid "Bicubic (software)"
+msgstr "Bicubic (software)"
+
+#: id:16308
+msgid "Lanczos (software)"
+msgstr "Lanczos (software)"
+
+#: id:16309
+msgid "Sinc (software)"
+msgstr "Sinc (software)"
+
+#: id:16310
+msgid "Temporal"
+msgstr "(VDPAU)Времева"
+
+#: id:16311
+msgid "Temporal/Spatial"
+msgstr "(VDPAU)Времева/Пространствена"
+
+#: id:16312
+msgid "(VDPAU)Noise Reduction"
+msgstr "(VDPAU)Намаляване на шум"
+
+#: id:16313
+msgid "(VDPAU)Sharpness"
+msgstr "(VDPAU)Острота"
+
+#: id:16314
+msgid "Inverse Telecine"
+msgstr "Обратен Telecine"
+
+#: id:16315
+msgid "Lanczos3 optimized"
+msgstr "Lanczos3 оптимизиран"
+
+#: id:16316
+msgctxt "Auto context with id 16316"
+msgid "Auto"
+msgstr "Автоматично"
+
+#: id:16317
+msgid "Temporal (Half)"
+msgstr "Временно (Half)"
+
+#: id:16318
+msgid "Temporal/Spatial (Half)"
+msgstr "Временно/Пространствен (Half)"
+
+#: id:16319
+msgid "DXVA"
+msgstr "DXVA"
+
+#: id:16320
+msgid "DXVA Bob"
+msgstr "DXVA Bob"
+
+#: id:16321
+msgid "DXVA Best"
+msgstr "DXVA Best"
+
+#: id:16322
+msgid "Spline36"
+msgstr "Spline36"
+
+#: id:16323
+msgid "Spline36 optimized"
+msgstr "Spline36 оптимизирано"
+
+#: id:16324
+msgid "Software Blend"
+msgstr "Софтуерно смесване"
+
+#: id:16400
+msgid "Post-processing"
+msgstr "Видео след-обработка"
+
+#: id:17500
+msgid "Display sleep timeout"
+msgstr "Изобразяване време за заспиване"
+
+#: id:19000
+msgid "Switch to channel"
+msgstr "Превключи на канал"
+
+#: id:20000
+msgid "Saved music folder"
+msgstr "CDDA папка за извличане"
+
+#: id:20001
+msgid "Use external DVD player"
+msgstr "Ползвай външен DVD плейър"
+
+#: id:20002
+msgid "External DVD player"
+msgstr "Външен DVD плейър"
+
+#: id:20003
+msgid "Trainers folder"
+msgstr "Папка за тренажори"
+
+#: id:20004
+msgid "Screenshot folder"
+msgstr "Папка за снимки на екрана"
+
+#: id:20006
+msgid "Playlists folder"
+msgstr "Папка за плейлисти"
+
+#: id:20007
+msgid "Recordings"
+msgstr "Записи"
+
+#: id:20008
+msgid "Screenshots"
+msgstr "Снимки на екрана"
+
+#: id:20009
+msgid "Use XBMC"
+msgstr "Ползвай XBMC"
+
+#: id:20011
+msgid "Music playlists"
+msgstr "Музикални плейлисти"
+
+#: id:20012
+msgid "Video playlists"
+msgstr "Видео плейлисти"
+
+#: id:20013
+msgid "Do you wish to launch the game?"
+msgstr "Желаете ли да стартирате играта?"
+
+#: id:20014
+msgid "Sort by: Playlist"
+msgstr "Сорт: Плейлист"
+
+#: id:20015
+msgid "Remote thumb"
+msgstr "Отдалечена картинка"
+
+#: id:20016
+msgid "Current thumb"
+msgstr "Текуща картинка"
+
+#: id:20017
+msgid "Local thumb"
+msgstr "Местна картинка"
+
+#: id:20018
+msgid "No thumb"
+msgstr "Без картинка"
+
+#: id:20019
+msgid "Choose thumbnail"
+msgstr "Изберете картинка"
+
+#: id:20023
+msgid "Conflict"
+msgstr "Конфликт"
+
+#: id:20024
+msgid "Scan new"
+msgstr "Анализиране нов"
+
+#: id:20025
+msgid "Scan all"
+msgstr "Анализиране всички"
+
+#: id:20026
+msgid "Region"
+msgstr "Регион"
+
+#: id:20037
+msgid "Summary"
+msgstr "Обобщение"
+
+#: id:20038
+msgid "Lock music window"
+msgstr "Заключване на прозореца за музика"
+
+#: id:20039
+msgid "Lock videos window"
+msgstr "Заключване на прозореца за видео"
+
+#: id:20040
+msgid "Lock pictures window"
+msgstr "Заключване на прозореца за снимки"
+
+#: id:20041
+msgid "Lock programs & scripts windows"
+msgstr "Заключване за програми, запазвания & скриптове"
+
+#: id:20042
+msgid "Lock file manager"
+msgstr "Заключи управлението на файлове"
+
+#: id:20043
+msgid "Lock settings"
+msgstr "Настройки на заключване"
+
+#: id:20044
+msgid "Start fresh"
+msgstr "Обновяване"
+
+#: id:20045
+msgid "Enter master mode"
+msgstr "Влез в главен режим"
+
+#: id:20046
+msgid "Leave master mode"
+msgstr "Напусни главен режим"
+
+#: id:20047
+msgid "Create profile '%s'?"
+msgstr "Създай профил '%s'?"
+
+#: id:20048
+msgid "Start with fresh settings"
+msgstr "Започни с настройки за обновяване"
+
+#: id:20049
+msgid "Best available"
+msgstr "Най-добрите достъпни"
+
+#: id:20050
+msgid "Auto-switch between 16x9 and 4x3"
+msgstr "Автоматично превключване между 16x9 и 4x3"
+
+#: id:20051
+msgid "Treat stacked files as single file"
+msgstr "Отнасяйте се към подредени файлове, като единичен файл"
+
+#: id:20052
+msgid "Caution"
+msgstr "Внимание"
+
+#: id:20053
+msgid "Left master mode"
+msgstr "Напусни главен режим"
+
+#: id:20054
+msgid "Entered master mode"
+msgstr "Влизане в главен режим"
+
+#: id:20055
+msgid "Allmusic.com thumb"
+msgstr "Allmusic.com картинка"
+
+#: id:20057
+msgid "Remove thumbnail"
+msgstr "Премахни картинка"
+
+#: id:20058
+msgid "Add profile..."
+msgstr "Добавяне на профил..."
+
+#: id:20059
+msgid "Query info for all albums"
+msgstr "Запитване информация за всички албуми"
+
+#: id:20060
+msgctxt "Auto context with id 20060"
+msgid "Media info"
+msgstr "Медия инфо"
+
+#: id:20061
+msgctxt "Auto context with id 20061"
+msgid "Separate"
+msgstr "Отделно"
+
+#: id:20062
+msgid "Shares with default"
+msgstr "Споделяне с подразбиращ"
+
+#: id:20063
+msgid "Shares with default (read only)"
+msgstr "Споделяне с подразбиращ(четене)"
+
+#: id:20064
+msgid "Copy default"
+msgstr "Копиране"
+
+#: id:20065
+msgid "Profile picture"
+msgstr "Картинка на профила"
+
+#: id:20066
+msgid "Lock preferences"
+msgstr "Заключи предпочитания"
+
+#: id:20067
+msgid "Edit profile"
+msgstr "Редактиране профил"
+
+#: id:20068
+msgid "Profile lock"
+msgstr "Профил заключване"
+
+#: id:20069
+msgid "Could not create folder"
+msgstr "Не мога да създам папка"
+
+#: id:20070
+msgid "Profile directory"
+msgstr "Профил директория"
+
+#: id:20071
+msgid "Start with fresh media sources"
+msgstr "Започнете с пресни медийни източници"
+
+#: id:20072
+msgid "Make sure the selected folder is writable"
+msgstr "Уверете се, че в избраната папка може да се записва"
+
+#: id:20073
+msgid "and that the new folder name is valid"
+msgstr "и името на новата папка е валидно"
+
+#: id:20074
+msgid "MPAA rating"
+msgstr "MPAA рейтинг"
+
+#: id:20075
+msgid "Enter master lock code"
+msgstr "Въведете главният код за заключване"
+
+#: id:20076
+msgid "Ask for master lock code on startup"
+msgstr "Питай за главния код при стартиране"
+
+#: id:20077
+msgid "Skin settings"
+msgstr "Настройки на кожи"
+
+#: id:20078
+msgid "- no link set -"
+msgstr "- няма зададена връзка -"
+
+#: id:20079
+msgid "Enable animations"
+msgstr "Включи анимациите"
+
+#: id:20080
+msgid "Disable RSS during music"
+msgstr "Изключи RSS по време на музика"
+
+#: id:20081
+msgid "Enable shortcut buttons"
+msgstr "Включи бутоните на кратките пътища"
+
+#: id:20082
+msgid "Show programs in main menu"
+msgstr "Показвай програмите в главното меню"
+
+#: id:20083
+msgid "Show music info"
+msgstr "Показвай музикалната информация"
+
+#: id:20084
+msgid "Show weather info"
+msgstr "Показвай информация за времето"
+
+#: id:20085
+msgid "Show system info"
+msgstr "Показвай системна информация"
+
+#: id:20086
+msgid "Show available disc space C: E: F:"
+msgstr "Покажи достъпно дисково пространство C: E: F:"
+
+#: id:20087
+msgid "Show available disc space E: F: G:"
+msgstr "Покажи достъпно дисково пространство E: F: G:"
+
+#: id:20088
+msgid "Weather info"
+msgstr "Информация за ВРЕМЕТО"
+
+#: id:20089
+msgid "Drive space free"
+msgstr "Свободно място на диска"
+
+#: id:20090
+msgid "Enter the name of an existing share"
+msgstr "Въведете име на съществуващо споделяне"
+
+#: id:20091
+msgid "Lock code"
+msgstr "Код за заключване"
+
+#: id:20092
+msgid "Load profile"
+msgstr "Зареди профил"
+
+#: id:20093
+msgid "Profile name"
+msgstr "Име на профил"
+
+#: id:20094
+msgctxt "Auto context with id 20094"
+msgid "Media sources"
+msgstr "Медия източници"
+
+#: id:20095
+msgid "Enter profile lock code"
+msgstr "Въведете Код за заключване на профила"
+
+#: id:20096
+msgctxt "Auto context with id 20096"
+msgid "Login screen"
+msgstr "Входен екран"
+
+#: id:20097
+msgid "Fetching album info"
+msgstr "Изтегляне албум инфо"
+
+#: id:20098
+msgid "Fetching info for album"
+msgstr "Изтегляне на информация за албум"
+
+#: id:20099
+msgid "Can't rip CD or track while playing from CD"
+msgstr "Не мога да извлека CD или песен, докато възпроизвежда от CD"
+
+#: id:20100
+msgid "Master lock code and settings"
+msgstr "Главен заключващ код и настройки"
+
+#: id:20101
+msgid "Entering master lock code always enables master mode"
+msgstr "Въвеждането на главния заключващ код винаги включва главен режим"
+
+#: id:20102
+msgid "or copy from default?"
+msgstr "или копиране от подразбиране?"
+
+#: id:20103
+msgid "Save changes to profile?"
+msgstr "Запази промените в профила?"
+
+#: id:20104
+msgid "Old settings found."
+msgstr "Намерени стари настройки."
+
+#: id:20105
+msgid "Do you want to use them?"
+msgstr "Искате ли да ги ползвате?"
+
+#: id:20106
+msgid "Old media sources found."
+msgstr "Намерени стари медия източници."
+
+#: id:20107
+msgid "Separate (locked)"
+msgstr "Отделно (заключен)"
+
+#: id:20108
+msgid "Root"
+msgstr "Корен"
+
+#: id:20109
+msgid "- Zoom"
+msgstr "- Увеличаване"
+
+#: id:20110
+msgid "UPnP settings"
+msgstr "UPnP настройки"
+
+#: id:20111
+msgid "Autostart UPnP client"
+msgstr "Автоматично стартиране на UPnP клиент"
+
+#: id:20112
+msgid "Last login: %s"
+msgstr "Последно влизане: %s"
+
+#: id:20113
+msgid "Never logged on"
+msgstr "Никога не сте влизали в системата"
+
+#: id:20114
+msgid "Profile %i / %i"
+msgstr "Профил %i / %i"
+
+#: id:20115
+msgid "User login / Select a profile"
+msgstr "Потребителски вход / Изберете профил"
+
+#: id:20116
+msgid "Use lock on login screen"
+msgstr "Използвайте заключване на екрана за вход"
+
+#: id:20117
+msgid "Invalid lock code."
+msgstr "Невалиден код за заключване."
+
+#: id:20118
+msgid "This requires the master lock to be set."
+msgstr "Това изисква главния код да бъде зададен."
+
+#: id:20119
+msgid "Would you like to set it now?"
+msgstr "Желаете ли да го зададете сега?"
+
+#: id:20120
+msgid "Loading program information"
+msgstr "Зареждане информация за програмата"
+
+#: id:20121
+msgid "Party on!"
+msgstr "Парти Включено"
+
+#: id:20122
+msgid "True"
+msgstr "Истина"
+
+#: id:20123
+msgid "Mixing drinks"
+msgstr "Смесване напитки"
+
+#: id:20124
+msgid "Filling glasses"
+msgstr "Пълнене на чаши"
+
+#: id:20125
+msgid "Logged on as"
+msgstr "Влезли в системата като"
+
+#: id:20126
+msgid "Log off"
+msgstr "Излезте"
+
+#: id:20128
+msgid "Go to root"
+msgstr "Отиди в корена"
+
+#: id:20129
+msgid "Weave"
+msgstr "Вълна"
+
+#: id:20130
+msgid "Weave (inverted)"
+msgstr "Вълна (обърнат)"
+
+#: id:20131
+msgid "Blend"
+msgstr "Смесване"
+
+#: id:20132
+msgid "Restart video"
+msgstr "Рестартиране на видео"
+
+#: id:20133
+msgid "Edit network location"
+msgstr "Редактиране на мрежово местоположение"
+
+#: id:20134
+msgid "Remove network location"
+msgstr "Премахване на мрежово местоположение"
+
+#: id:20135
+msgid "Do you want to scan the folder?"
+msgstr "Искате ли да сканира папката?"
+
+#: id:20136
+msgid "Memory unit"
+msgstr "Модул памет"
+
+#: id:20137
+msgid "Memory unit mounted"
+msgstr "Модул памет монтирана"
+
+#: id:20138
+msgid "Unable to mount memory unit"
+msgstr "Не мога да монтирам Модул памет"
+
+#: id:20139
+msgid "In port %i, slot %i"
+msgstr "В порт %i, слот %i"
+
+#: id:20140
+msgid "Lock screensaver"
+msgstr "Заключи скрийнсейвъра"
+
+#: id:20141
+msgid "Set"
+msgstr "Задай"
+
+#: id:20142
+msgctxt "Auto context with id 20142"
+msgid "Username"
+msgstr "Потребител"
+
+#: id:20143
+msgid "Enter password for"
+msgstr "Въведи парола за"
+
+#: id:20144
+msgid "Shutdown timer"
+msgstr "Таймер за изключване"
+
+#: id:20145
+msgid "Shutdown interval (in minutes)"
+msgstr "Изключване (минути)"
+
+#: id:20146
+msgid "Started, shutdown in %im"
+msgstr "Стартиран, изключване след %i мин."
+
+#: id:20147
+msgid "Shutdown in 30 minutes"
+msgstr "Изключване след 30 минути"
+
+#: id:20148
+msgid "Shutdown in 60 minutes"
+msgstr "Изключване след 60 минути"
+
+#: id:20149
+msgid "Shutdown in 120 minutes"
+msgstr "Изключване след 120 минути"
+
+#: id:20150
+msgid "Custom shutdown timer"
+msgstr "Потребителски таймер за изключване"
+
+#: id:20151
+msgid "Cancel shutdown timer"
+msgstr "Отмени таймера за изключване"
+
+#: id:20152
+msgid "Lock preferences for %s"
+msgstr "Заключи свойствата за %s"
+
+#: id:20153
+msgid "Browse..."
+msgstr "Прелисти..."
+
+#: id:20154
+msgid "Summary information"
+msgstr "Основна информация"
+
+#: id:20155
+msgid "Storage information"
+msgstr "Складова информация"
+
+#: id:20156
+msgid "Hard disk information"
+msgstr "Информация за харддиск"
+
+#: id:20157
+msgid "DVD-ROM information"
+msgstr "Информация за DVD-ROM"
+
+#: id:20158
+msgid "Network information"
+msgstr "Информация за мрежата"
+
+#: id:20159
+msgid "Video information"
+msgstr "Видео информация"
+
+#: id:20160
+msgid "Hardware information"
+msgstr "Информация за хардуера"
+
+#: id:20161
+msgid "Total"
+msgstr "Общо"
+
+#: id:20162
+msgid "Used"
+msgstr "Използвано"
+
+#: id:20163
+msgid "of"
+msgstr "от"
+
+#: id:20164
+msgid "Locking not supported"
+msgstr "Заключването не се поддържа"
+
+#: id:20165
+msgid "Not locked"
+msgstr "Не заключено"
+
+#: id:20166
+msgid "Locked"
+msgstr "Заключено"
+
+#: id:20167
+msgid "Frozen"
+msgstr "Замразено"
+
+#: id:20168
+msgid "Requires reset"
+msgstr "Изисква ресет"
+
+#: id:20169
+msgid "Week"
+msgstr "Седмица"
+
+#: id:20170
+msgid "Line"
+msgstr "Линия"
+
+#: id:20171
+msgid "Windows network (SMB)"
+msgstr "Windows мрежа (SMB)"
+
+#: id:20172
+msgid "XBMSP server"
+msgstr "XBMSP сървър"
+
+#: id:20173
+msgctxt "Auto context with id 20173"
+msgid "FTP server"
+msgstr "FTP сървър"
+
+#: id:20174
+msgid "iTunes music share (DAAP)"
+msgstr "iTunes споделяне на музика (DAAP)"
+
+#: id:20175
+msgid "UPnP server"
+msgstr "UPnP сървър"
+
+#: id:20176
+msgid "Show video info"
+msgstr "Виж видео информация"
+
+#: id:20177
+msgid "Done"
+msgstr "Готово"
+
+#: id:20178
+msgid "Shift"
+msgstr "Shift"
+
+#: id:20179
+msgid "Caps Lock"
+msgstr "Caps Lock"
+
+#: id:20180
+msgid "Symbols"
+msgstr "Символи"
+
+#: id:20181
+msgid "Backspace"
+msgstr "Backspace"
+
+#: id:20182
+msgid "Space"
+msgstr "Space"
+
+#: id:20183
+msgid "Reload skin"
+msgstr "Презареди кожа"
+
+#: id:20184
+msgid "Rotate pictures using EXIF information"
+msgstr "Завърти, ползвайки EXIF инфо"
+
+#: id:20185
+msgid "Use poster view styles for TV shows"
+msgstr "Използвай стил плакат за ТВ Сериали"
+
+#: id:20186
+msgid "Please wait"
+msgstr "Моля почакайте"
+
+#: id:20187
+msgid "UPnP"
+msgstr ""
+
+#: id:20189
+msgid "Enable auto scrolling for plot & review"
+msgstr "Включи автоскрол за резюме & преглед"
+
+#: id:20190
+msgctxt "Auto context with id 20190"
+msgid "Custom"
+msgstr "Потребителски"
+
+#: id:20191
+msgid "Enable debug logging"
+msgstr "Включи дебъг запис"
+
+#: id:20192
+msgid "Download additional information during updates"
+msgstr "Изтегляне инфо за албума при добавяне в библиотеката"
+
+#: id:20193
+msgid "Default service for album information"
+msgstr "Изтегляне инфо за изпълнител при добавяне в библиотеката"
+
+#: id:20194
+msgid "Default service for artist information"
+msgstr "Инфо сайт по подразбиране"
+
+#: id:20195
+msgid "Change scraper"
+msgstr "Смени инфо сайт"
+
+#: id:20196
+msgid "Export music library"
+msgstr "Изнеси музикална библиотека"
+
+#: id:20197
+msgid "Import music library"
+msgstr "Внеси музикална библиотека"
+
+#: id:20198
+msgid "No artist found!"
+msgstr "Не е намерен изпълнител!"
+
+#: id:20199
+msgid "Downloading artist info failed"
+msgstr "Свалянето на информация за изпълнителя е неуспешно"
+
+#: id:20250
+msgid "Party on! (videos)"
+msgstr "Парти включено! (видео)"
+
+#: id:20251
+msgid "Mixing drinks (videos)"
+msgstr "Смесване напитки (видео)"
+
+#: id:20252
+msgid "Filling glasses (videos)"
+msgstr "Пълнене на чаши (видео)"
+
+#: id:20253
+msgid "WebDAV server (HTTP)"
+msgstr "WebDAV сървър (HTTP)"
+
+#: id:20254
+msgid "WebDAV server (HTTPS)"
+msgstr "WebDAV сървър (HTTPS)"
+
+#: id:20255
+msgid "First logon, edit your profile"
+msgstr "Първо влизане, редактирайте си профила"
+
+#: id:20256
+msgid "HTS Tvheadend client"
+msgstr "HTS Tvheadend клиент"
+
+#: id:20257
+msgid "VDR Streamdev client"
+msgstr "VDR Streamdev клиент"
+
+#: id:20258
+msgid "MythTV client"
+msgstr "MythTV клиент"
+
+#: id:20259
+msgid "Network Filesystem (NFS)"
+msgstr "Мрежова файлова система (NFS)"
+
+#: id:20260
+msgid "Secure Shell (SSH/SFTP)"
+msgstr "Secure Shell (SSH/SFTP)"
+
+#: id:20261
+msgid "Apple Filing Protocol (AFP)"
+msgstr "Apple Filing Protocol (AFP)"
+
+#: id:20300
+msgid "Web server directory (HTTP)"
+msgstr "Web сървър директория (HTTP)"
+
+#: id:20301
+msgid "Web server directory (HTTPS)"
+msgstr "Web сървър директория (HTTPS)"
+
+#: id:20302
+msgid "Unable to write to folder:"
+msgstr "Не мога да запиша в папка:"
+
+#: id:20303
+msgid "Do you want to skip and proceed?"
+msgstr "Искате ли да пропуснете и да продължите?"
+
+#: id:20304
+msgid "RSS Feed"
+msgstr "RSS емисии"
+
+#: id:20307
+msgid "Secondary DNS"
+msgstr "Secondary DNS"
+
+#: id:20308
+msgid "DHCP server:"
+msgstr "DHCP сървър:"
+
+#: id:20309
+msgid "Make new folder"
+msgstr "Направи нова папка"
+
+#: id:20310
+msgid "Dim LCD on playback"
+msgstr "Затъмни LCD при възпроизвеждане"
+
+#: id:20311
+msgid "Unknown or onboard (protected)"
+msgstr "Неизвестен или вграден (защитен)"
+
+#: id:20312
+msgid "Dim LCD on paused"
+msgstr "Затъмни LCD на пауза"
+
+#: id:20314
+msgid "Videos - Library"
+msgstr "Видео - Библиотека"
+
+#: id:20316
+msgid "Sort by: ID"
+msgstr "Сорт: ID"
+
+#: id:20324
+msgid "Play part..."
+msgstr "Възпроизведи част..."
+
+#: id:20325
+msgid "Calibration reset"
+msgstr "Ресет на калибровката"
+
+#: id:20326
+msgid "This will reset the calibration values for %s"
+msgstr "Това ще ресетне стойностите на калибровка от %s"
+
+#: id:20327
+msgid "to it's default values."
+msgstr "на стойности по подразбиране."
+
+#: id:20328
+msgid "Browse for destination"
+msgstr "Потърси за отправна"
+
+#: id:20329
+msgid "Movies are in separate folders that match the movie title"
+msgstr ""
+
+#: id:20330
+msgid "Use folder names for lookups"
+msgstr "Използвайте имената на папките за търсене"
+
+#: id:20331
+msgctxt "Auto context with id 20331"
+msgid "File"
+msgstr "Файл"
+
+#: id:20332
+msgid "Use file or folder names in lookups?"
+msgstr "Използвайте имена на файл или папка в търсения?"
+
+#: id:20333
+msgid "Set content"
+msgstr "Задай съдържание"
+
+#: id:20334
+msgid "Folder"
+msgstr "Папка"
+
+#: id:20335
+msgid "Look for content recursively?"
+msgstr "Виж за съдържанието рекурсивно?"
+
+#: id:20336
+msgid "Unlock sources"
+msgstr "Отключи източници"
+
+#: id:20337
+msgid "Actor"
+msgstr "Актьор"
+
+#: id:20338
+msgid "Movie"
+msgstr "Филм"
+
+#: id:20339
+msgid "Director"
+msgstr "Режисьор"
+
+#: id:20340
+msgid "Do you want to remove all items within"
+msgstr "Искате ли да премахнете всички позиции в рамките на"
+
+#: id:20341
+msgid "this path from the XBMC library?"
+msgstr "този път в библиотеката?"
+
+#: id:20342
+msgctxt "Auto context with id 20342"
+msgid "Movies"
+msgstr "Филми"
+
+#: id:20343
+msgid "TV shows"
+msgstr "ТВ Сериали"
+
+#: id:20344
+msgid "This directory contains"
+msgstr "Тази папка съдържа"
+
+#: id:20345
+msgid "Run automated scan"
+msgstr "Пусни автоматизирано сканиране"
+
+#: id:20346
+msgid "Scan recursively"
+msgstr "Анализиране рекурсивно"
+
+#: id:20347
+msgid "as"
+msgstr "като"
+
+#: id:20348
+msgid "Directors"
+msgstr "Режисьори"
+
+#: id:20349
+msgid "No video files found in this path!"
+msgstr "Не са намерени видео файлове в този път!"
+
+#: id:20350
+msgid "votes"
+msgstr "гласове"
+
+#: id:20351
+msgid "TV show information"
+msgstr "ТВ Сериал информация"
+
+#: id:20352
+msgid "Episode information"
+msgstr "Епизод информация"
+
+#: id:20353
+msgid "Loading TV show details"
+msgstr "Зареждане на детайли за ТВ Сериал"
+
+#: id:20354
+msgid "Fetching episode guide"
+msgstr "Изтегляне на ръководство за епизода"
+
+#: id:20355
+msgid "Loading info for episodes in directory"
+msgstr "Зареждане на инфо за епизода в папката"
+
+#: id:20356
+msgid "Select TV show:"
+msgstr "Избери ТВ Сериал:"
+
+#: id:20357
+msgid "Enter the TV show name"
+msgstr "Въведи името на ТВ Сериал"
+
+#: id:20358
+msgid "Season %i"
+msgstr "Сезон %i"
+
+#: id:20359
+msgid "Episode"
+msgstr "Епизод"
+
+#: id:20360
+msgid "Episodes"
+msgstr "Епизода"
+
+#: id:20361
+msgid "Loading episode details"
+msgstr "Зареждане детайли за епизода"
+
+#: id:20362
+msgid "Remove episode from library"
+msgstr "Премахни епизод от библиотеката"
+
+#: id:20363
+msgid "Remove TV show from library"
+msgstr "Премахни ТВ Сериал от библиотеката"
+
+#: id:20364
+msgid "TV show"
+msgstr "ТВ Сериал"
+
+#: id:20365
+msgid "Episode plot"
+msgstr "Епизод Резюме"
+
+#: id:20366
+msgid "* All seasons"
+msgstr "* Всички сезони"
+
+#: id:20367
+msgid "Hide watched"
+msgstr "Скрий гледани"
+
+#: id:20368
+msgid "Prod code"
+msgstr "Прод. код"
+
+#: id:20369
+msgid "Show plot for unwatched items"
+msgstr "Покажи резюме за неизгледани"
+
+#: id:20370
+msgid "* Hidden to prevent spoilers *"
+msgstr "* Скрити"
+
+#: id:20371
+msgid "Set season thumb"
+msgstr "Картинка на сезона"
+
+#: id:20372
+msgid "Season image"
+msgstr "Картина на сезона"
+
+#: id:20373
+msgid "Season"
+msgstr "Сезон"
+
+#: id:20374
+msgid "Downloading movie information"
+msgstr "Свалям информация за филма"
+
+#: id:20375
+msgid "Unassign content"
+msgstr "Безцелно съдържание"
+
+#: id:20376
+msgid "Original title"
+msgstr "Оригинално заглавие"
+
+#: id:20377
+msgid "Refresh TV show information"
+msgstr "Опресни информация за ТВ Сериал"
+
+#: id:20378
+msgid "Refresh info for all episodes?"
+msgstr "Обновяване на информацията за всички епизоди?"
+
+#: id:20379
+msgid "Selected folder contains a single TV show"
+msgstr "Избраната папка съдържа един ТВ Сериал"
+
+#: id:20380
+msgid "Exclude selected folder from scans"
+msgstr "Изключи избраната папка от сканиране"
+
+#: id:20381
+msgid "Specials"
+msgstr "Промоции"
+
+#: id:20382
+msgid "Automatically grab season thumbs"
+msgstr "Автоматично изтегляне на обложка за сезона"
+
+#: id:20383
+msgid "Selected folder contains a single video"
+msgstr "Избраната папка съдържа единично видео"
+
+#: id:20384
+msgid "Link to TV show"
+msgstr "Връзка към ТВ Сериал"
+
+#: id:20385
+msgid "Remove link to TV show"
+msgstr "Премахване на връзка към ТВ Сериал"
+
+#: id:20386
+msgid "Recently added movies"
+msgstr "Последно добавени филми"
+
+#: id:20387
+msgid "Recently added episodes"
+msgstr "Последно добавени епизоди"
+
+#: id:20388
+msgid "Studios"
+msgstr "Студио"
+
+#: id:20389
+msgid "Music videos"
+msgstr "Музикално видео"
+
+#: id:20390
+msgid "Recently added music videos"
+msgstr "Последно добавено Музикално видео"
+
+#: id:20391
+msgid "Music video"
+msgstr "Музикално видео"
+
+#: id:20392
+msgid "Remove music video from library"
+msgstr "Премахни Музикално видео от библиотеката"
+
+#: id:20393
+msgctxt "Auto context with id 20393"
+msgid "Music video information"
+msgstr "Информация за Музикално видео"
+
+#: id:20394
+msgid "Loading music video information"
+msgstr "Зареждане на информация за музикално видео"
+
+#: id:20395
+msgid "Mixed"
+msgstr "Смесено"
+
+#: id:20396
+msgid "Go to albums by artist"
+msgstr "Иди в албуми по изпълнител"
+
+#: id:20397
+msgid "Go to album"
+msgstr "Иди в албум"
+
+#: id:20398
+msgid "Play song"
+msgstr "Възпроизведи песен"
+
+#: id:20399
+msgid "Go to music videos from album"
+msgstr "Иди на музикално видео от албум"
+
+#: id:20400
+msgid "Go to music videos by artist"
+msgstr "Иди на музикално видео от изпълнител"
+
+#: id:20401
+msgid "Play music video"
+msgstr "Възпроизведи музикално видео"
+
+#: id:20402
+msgid "Download actor thumbnails when adding to library"
+msgstr "Снимка на изпълнител"
+
+#: id:20403
+msgid "Set actor thumb"
+msgstr "Избери снимка"
+
+#: id:20405
+msgid "Remove episode bookmark"
+msgstr "Премахни отметката на епизода"
+
+#: id:20406
+msgid "Set episode bookmark"
+msgstr "Отметка на епизода"
+
+#: id:20407
+msgid "Scraper settings"
+msgstr "Настройки на инфо сайт"
+
+#: id:20408
+msgid "Downloading music video information"
+msgstr "Сваляне на информация за музикално видео"
+
+#: id:20409
+msgid "Downloading TV show information"
+msgstr "Сваляне на информация за ТВ Сериал"
+
+#: id:20410
+msgid "Trailer"
+msgstr "Трейлър"
+
+#: id:20411
+msgid "Flatten"
+msgstr "Опростен"
+
+#: id:20412
+msgid "Flatten TV shows"
+msgstr "Опростени ТВ Сериали"
+
+#: id:20413
+msgid "Get fanart"
+msgstr "Свали плакат"
+
+#: id:20414
+msgid "Show Fanart in video and music libraries"
+msgstr "Покажи плакат във видео и музикална библиотека"
+
+#: id:20415
+msgid "Scanning for new content"
+msgstr "Анализ ново съдържание"
+
+#: id:20416
+msgid "First aired"
+msgstr "Излъчен на"
+
+#: id:20417
+msgid "Writer"
+msgstr "Автор"
+
+#: id:20419
+msgid "Replace file names with library titles"
+msgstr "Покажи метаданни във файл режим"
+
+#: id:20420
+msgctxt "Auto context with id 20420"
+msgid "Never"
+msgstr "Никога"
+
+#: id:20421
+msgid "If only one season"
+msgstr "Ако е само един сезон"
+
+#: id:20422
+msgid "Always"
+msgstr "Винаги"
+
+#: id:20423
+msgid "Has trailer"
+msgstr "Има трейлър"
+
+#: id:20424
+msgid "False"
+msgstr "Фалшиви"
+
+#: id:20425
+msgid "Fanart slideshow"
+msgstr "Слайдшоу на плакати"
+
+#: id:20426
+msgid "Export to a single file or separate"
+msgstr "Изнасяне към единичен файл или разделени"
+
+#: id:20427
+msgid "files per entry?"
+msgstr "файлове за въвеждане?"
+
+#: id:20428
+msgid "Single file"
+msgstr "Единичен файл"
+
+#: id:20429
+msgctxt "Auto context with id 20429"
+msgid "Separate"
+msgstr "Разделен"
+
+#: id:20430
+msgid "Export thumbnails and fanart?"
+msgstr "Изнасяне на картинки и плакат?"
+
+#: id:20431
+msgid "Overwrite old files?"
+msgstr "Презаписване на стари файлове?"
+
+#: id:20432
+msgid "Exclude path from library updates"
+msgstr "Изключи пътя от обновяването на библиотеката"
+
+#: id:20433
+msgid "Extract thumbnails and video information"
+msgstr "Извлечи вградени данни от медия"
+
+#: id:20434
+msgid "Sets"
+msgstr "Комплекти"
+
+#: id:20435
+msgid "Set movieset thumb"
+msgstr "Задай картинка за филм"
+
+#: id:20436
+msgid "Export actor thumbs?"
+msgstr "Експорт картинки за актьор?"
+
+#: id:20437
+msgid "Choose fanart"
+msgstr "Избери постер"
+
+#: id:20438
+msgid "Local fanart"
+msgstr "Локален постер"
+
+#: id:20439
+msgid "No fanart"
+msgstr "Без постер"
+
+#: id:20440
+msgid "Current fanart"
+msgstr "Текущ постер"
+
+#: id:20441
+msgid "Remote fanart"
+msgstr "Премахни постер"
+
+#: id:20442
+msgid "Change content"
+msgstr "Промени съдържание"
+
+#: id:20443
+msgid "Do you want to refresh info for all"
+msgstr "Да опресня ли инфото да всички"
+
+#: id:20444
+msgid "items within this path?"
+msgstr "позиции в този път?"
+
+#: id:20445
+msgid "Fanart"
+msgstr "Постер"
+
+#: id:20446
+msgid "Locally stored information found."
+msgstr "Намерена е локално запазена информация."
+
+#: id:20447
+msgid "Ignore and refresh from internet?"
+msgstr "Игнорирай и опресни от интернет?"
+
+#: id:20448
+msgid "Could not download information"
+msgstr "Не мога да сваля информация"
+
+#: id:20449
+msgid "Unable to connect to remote server"
+msgstr "Не мога да се свържа към сървъра"
+
+#: id:20450
+msgid "Would you like to continue scanning?"
+msgstr "Да продължа ли сканирането?"
+
+#: id:20451
+msgid "Countries"
+msgstr "Държави"
+
+#: id:20452
+msgid "episode"
+msgstr "епизод"
+
+#: id:20453
+msgid "episodes"
+msgstr "епизоди"
+
+#: id:20454
+msgid "Listener"
+msgstr "Слушател"
+
+#: id:20455
+msgid "Listeners"
+msgstr "Слушатели"
+
+#: id:20456
+msgid "Set movieset fanart"
+msgstr "Задай плакат снимачна площадка"
+
+#: id:20457
+msgid "Movie set"
+msgstr "Снимачна площадка"
+
+#: id:20458
+msgid "Group movies in sets"
+msgstr ""
+
+#: id:21330
+msgid "Show hidden files and directories"
+msgstr "Показвай скрити папки и файлове"
+
+#: id:21331
+msgid "TuxBox client"
+msgstr "TuxBox клиент"
+
+#: id:21332
+msgid "WARNING: Target TuxBox device is in recording-mode!"
+msgstr "WARNING: TuxBox устройството записващ режим!"
+
+#: id:21333
+msgid "The stream will be stopped!"
+msgstr "Потокът ще бъде спрян!"
+
+#: id:21334
+msgid "Zap to channel: %s failed!"
+msgstr "Зап към канал: %s неуспешен!"
+
+#: id:21335
+msgid "Are you sure to start the stream?"
+msgstr "Сигурни ли сте за започване на поток?"
+
+#: id:21336
+msgid "Connecting to: %s"
+msgstr "Свързване към: %s"
+
+#: id:21337
+msgid "TuxBox device"
+msgstr "TuxBox устройство"
+
+#: id:21359
+msgid "Add media share..."
+msgstr "Добави споделена медия..."
+
+#: id:21360
+msgid "Share video and music libraries through UPnP"
+msgstr "Включи UPnP сървър"
+
+#: id:21364
+msgid "Edit media share"
+msgstr "Редактиране споделяне на медия"
+
+#: id:21365
+msgid "Remove media share"
+msgstr "Премахни споделяне на медия"
+
+#: id:21366
+msgid "Subtitle folder"
+msgstr "Потребителска папка за субтитри"
+
+#: id:21367
+msgid "Movie & alternate subtitle directory"
+msgstr "Премести & алтернативна папка за субтитри"
+
+#: id:21368
+msgid "Override ASS/SSA subtitles fonts"
+msgstr "Презапиши ASS/SSA шрифт за субтитри"
+
+#: id:21369
+msgid "Enable mouse and Touch Screen support"
+msgstr "Включи мишка"
+
+#: id:21370
+msgid "Play navigation sounds during media playback"
+msgstr "Просвирвай навигационни звуци с възпроизвеждането на медия"
+
+#: id:21371
+msgid "Thumbnail"
+msgstr "Картинка"
+
+#: id:21372
+msgid "Forced DVD player region"
+msgstr "Фиксиран DVD регион"
+
+#: id:21373
+msgid "Video output"
+msgstr "Видео"
+
+#: id:21374
+msgid "Video aspect"
+msgstr "Видео аспект"
+
+#: id:21375
+msgctxt "Auto context with id 21375"
+msgid "Normal"
+msgstr "Нормален"
+
+#: id:21376
+msgid "Letterbox"
+msgstr "Пощенска кутия"
+
+#: id:21377
+msgid "Widescreen"
+msgstr "Широкоекранен"
+
+#: id:21378
+msgid "Enable 480p"
+msgstr "Включи 480p"
+
+#: id:21379
+msgid "Enable 720p"
+msgstr "Включи 720p"
+
+#: id:21380
+msgid "Enable 1080i"
+msgstr "Включи 1080i"
+
+#: id:21381
+msgid "Enter name of new playlist"
+msgstr "Въведете име да новия плейлист"
+
+#: id:21382
+msgid "Show \"Add source\" buttons in file lists"
+msgstr "Показване на бутон 'Добави източник' във файл лист"
+
+#: id:21383
+msgid "Enable scrollbars"
+msgstr "Включи скролбарове"
+
+#: id:21384
+msgid "Make watched filtering a toggle in video library"
+msgstr "Make watched filtering a toggle in video library"
+
+#: id:21385
+msgctxt "Auto context with id 21385"
+msgid "Open"
+msgstr "Отвори"
+
+#: id:21386
+msgid "Acoustic management level"
+msgstr "Управление на акустично ниво"
+
+#: id:21387
+msgid "Fast"
+msgstr "Бърз"
+
+#: id:21388
+msgid "Quiet"
+msgstr "Тих"
+
+#: id:21389
+msgid "Enable custom background"
+msgstr "Разрешаване на потребителски фон"
+
+#: id:21390
+msgid "Power management level"
+msgstr "Управление на нивото на захранване"
+
+#: id:21391
+msgid "High power"
+msgstr "Висока мощност"
+
+#: id:21392
+msgid "Low power"
+msgstr "Ниска мощност"
+
+#: id:21393
+msgid "High standby"
+msgstr "Висок режим"
+
+#: id:21394
+msgid "Low standby"
+msgstr "Нисък режим"
+
+#: id:21395
+msgid "Unable to cache files bigger than 4GB"
+msgstr "Не могат да се зареждат файлове по-големи от 4GB"
+
+#: id:21396
+msgid "Chapter"
+msgstr "Глава"
+
+#: id:21397
+msgid "High quality pixel shader v2"
+msgstr "Висококачествен пиксел шейдър v2"
+
+#: id:21398
+msgid "Enable playlist at startup"
+msgstr "Включи пейлист при стартиране"
+
+#: id:21399
+msgid "Use tween animations"
+msgstr "Ползвай tween анимации"
+
+#: id:21400
+msgid "contains"
+msgstr "съдържа"
+
+#: id:21401
+msgid "does not contain"
+msgstr "не съдържа"
+
+#: id:21402
+msgid "is"
+msgstr "е"
+
+#: id:21403
+msgid "is not"
+msgstr "не е"
+
+#: id:21404
+msgid "starts with"
+msgstr "започва с"
+
+#: id:21405
+msgid "ends with"
+msgstr "свършва с"
+
+#: id:21406
+msgid "greater than"
+msgstr "по-голямо от"
+
+#: id:21407
+msgid "less than"
+msgstr "по-малко от"
+
+#: id:21408
+msgid "after"
+msgstr "след"
+
+#: id:21409
+msgid "before"
+msgstr "преди"
+
+#: id:21410
+msgid "in the last"
+msgstr "в последния"
+
+#: id:21411
+msgid "not in the last"
+msgstr "не в последния"
+
+#: id:21412
+msgid "Scrapers"
+msgstr "Инфо сайт"
+
+#: id:21413
+msgid "Default movie scraper"
+msgstr "Инфо сайт за филми по подразбиране"
+
+#: id:21414
+msgid "Default tvshow scraper"
+msgstr "Инфо сайт за ТВ Сериал по подразбиране"
+
+#: id:21415
+msgid "Default music video scraper"
+msgstr "Инфо сайт за Музикално видео по подразбиране"
+
+#: id:21416
+msgid "Enable fallback based on scraper language"
+msgstr "Включи резервиране базирано на езика на Инфо сайта"
+
+#: id:21417
+msgid "- Settings"
+msgstr "- Инфо сайт настройки"
+
+#: id:21418
+msgid "Multilingual"
+msgstr "Многоезичен"
+
+#: id:21419
+msgid "No scrapers present"
+msgstr "Няма инфо сайт"
+
+#: id:21420
+msgid "Value to match"
+msgstr "Стойност за съвпадане"
+
+#: id:21421
+msgid "Smart playlist rule"
+msgstr "Правило на умен плейлист"
+
+#: id:21422
+msgid "Match items where"
+msgstr "Съвпадение позиции където"
+
+#: id:21423
+msgid "New rule..."
+msgstr "Ново правило..."
+
+#: id:21424
+msgid "Items must match"
+msgstr "Позициите трябва да съвпадат"
+
+#: id:21425
+msgid "all of the rules"
+msgstr "всички правила"
+
+#: id:21426
+msgid "one or more of the rules"
+msgstr "едно или повече правила"
+
+#: id:21427
+msgid "Limit to"
+msgstr "Ограничи до"
+
+#: id:21428
+msgid "No limit"
+msgstr "Без ограничения"
+
+#: id:21429
+msgid "Order by"
+msgstr "Подреди по"
+
+#: id:21430
+msgid "ascending"
+msgstr "възходящ"
+
+#: id:21431
+msgid "descending"
+msgstr "низходящ"
+
+#: id:21432
+msgid "Edit smart playlist"
+msgstr "Редактиране на умен плейлист"
+
+#: id:21433
+msgid "Name of the playlist"
+msgstr "Име на плейлист"
+
+#: id:21434
+msgid "Find items where"
+msgstr "Намери позиции"
+
+#: id:21435
+msgid "Edit"
+msgstr "Редактиране"
+
+#: id:21436
+msgid "%i items"
+msgstr "%i позиции"
+
+#: id:21437
+msgid "New smart playlist..."
+msgstr "Нов умен плейлист..."
+
+#: id:21438
+msgid "%c Drive"
+msgstr "%c устройство"
+
+#: id:21439
+msgid "Edit party mode rules"
+msgstr "Редактирай правила за Парти режим"
+
+#: id:21440
+msgid "Home folder"
+msgstr "Начална папка"
+
+#: id:21441
+msgid "Watched count"
+msgstr "Брой гледани"
+
+#: id:21442
+msgid "Episode title"
+msgstr "Заглавие на епизод"
+
+#: id:21443
+msgid "Video resolution"
+msgstr "Видео резолюция"
+
+#: id:21444
+msgid "Audio channels"
+msgstr "Аудио канали"
+
+#: id:21445
+msgid "Video codec"
+msgstr "Видео кодек"
+
+#: id:21446
+msgid "Audio codec"
+msgstr "Аудио кодек"
+
+#: id:21447
+msgid "Audio language"
+msgstr "Аудио език"
+
+#: id:21448
+msgid "Subtitle language"
+msgstr "Език за субтитри"
+
+#: id:21449
+msgid "Remote control sends keyboard presses"
+msgstr "Дистанционното управление като клавиатура"
+
+#: id:21450
+msgid "- Edit"
+msgstr "- Редакция"
+
+#: id:21451
+msgid "Internet connection required."
+msgstr "Изисква интернет връзка."
+
+#: id:21452
+msgid "Get More..."
+msgstr "Вземи още..."
+
+#: id:21453
+msgid "Root filesystem"
+msgstr "Основна файлова система"
+
+#: id:21454
+msgid "Cache full"
+msgstr ""
+
+#: id:21455
+msgid "Cache filled before reaching required amount for continous playback"
+msgstr ""
+
+#: id:21460
+msgid "Subtitle location"
+msgstr "Местонахождение на субтитри"
+
+#: id:21461
+msgid "Fixed"
+msgstr "Фиксиран"
+
+#: id:21462
+msgid "Bottom of video"
+msgstr "Край на видео"
+
+#: id:21463
+msgid "Below video"
+msgstr "Под видео"
+
+#: id:21464
+msgid "Top of video"
+msgstr "Горе видео"
+
+#: id:21465
+msgid "Above video"
+msgstr "Над видео"
+
+#: id:21800
+msgid "File name"
+msgstr "Име на файл"
+
+#: id:21801
+msgid "File path"
+msgstr "Път на файл"
+
+#: id:21802
+msgid "File size"
+msgstr "Размер на файл"
+
+#: id:21803
+msgid "File date/time"
+msgstr "Файл дата/час"
+
+#: id:21804
+msgid "Slide index"
+msgstr "Слайд индекс"
+
+#: id:21805
+msgctxt "Auto context with id 21805"
+msgid "Resolution"
+msgstr "Резолюция"
+
+#: id:21806
+msgctxt "Auto context with id 21806"
+msgid "Comment"
+msgstr "Коментар"
+
+#: id:21807
+msgid "Colour/B&W"
+msgstr "Цвят/Ч&Б"
+
+#: id:21808
+msgid "JPEG process"
+msgstr "JPEG процес"
+
+#: id:21820
+msgid "Date/Time"
+msgstr "Дата/Час"
+
+#: id:21821
+msgid "Description"
+msgstr "Описание"
+
+#: id:21822
+msgid "Camera make"
+msgstr "Камера"
+
+#: id:21823
+msgid "Camera model"
+msgstr "Камера модел"
+
+#: id:21824
+msgid "EXIF comment"
+msgstr "EXIF коментар"
+
+#: id:21825
+msgid "Firmware"
+msgstr "Фирмуер"
+
+#: id:21826
+msgid "Aperture"
+msgstr "Отвор"
+
+#: id:21827
+msgid "Focal length"
+msgstr "Фокусно дължина"
+
+#: id:21828
+msgid "Focus distance"
+msgstr "Фокусно разстояние"
+
+#: id:21829
+msgid "Exposure"
+msgstr "Експониране"
+
+#: id:21830
+msgid "Exposure time"
+msgstr "Експониране време"
+
+#: id:21831
+msgid "Exposure bias"
+msgstr "Експониране отклонение"
+
+#: id:21832
+msgid "Exposure mode"
+msgstr "Експониране режим"
+
+#: id:21833
+msgid "Flash used"
+msgstr "Използвана светкавица"
+
+#: id:21834
+msgid "White-balance"
+msgstr "Баланс на бялото"
+
+#: id:21835
+msgid "Light source"
+msgstr "Светлинен източник"
+
+#: id:21836
+msgid "Metering mode"
+msgstr "Метричен режим"
+
+#: id:21837
+msgid "ISO"
+msgstr "ISO"
+
+#: id:21838
+msgid "Digital zoom"
+msgstr "Цифрово увеличение"
+
+#: id:21839
+msgid "CCD width"
+msgstr "CCD ширина"
+
+#: id:21840
+msgid "GPS latitude"
+msgstr "GPS ширина"
+
+#: id:21841
+msgid "GPS longitude"
+msgstr "GPS дължина"
+
+#: id:21842
+msgid "GPS altitude"
+msgstr "GPS височина"
+
+#: id:21843
+msgid "Orientation"
+msgstr "Ориентация"
+
+#: id:21860
+msgid "Supplemental categories"
+msgstr "Допълнителни категории"
+
+#: id:21861
+msgid "Keywords"
+msgstr "Ключови думи"
+
+#: id:21862
+msgid "Caption"
+msgstr "Заглавие"
+
+#: id:21863
+msgid "Author"
+msgstr "Автор"
+
+#: id:21864
+msgid "Headline"
+msgstr "Титул"
+
+#: id:21865
+msgid "Special instructions"
+msgstr "Допълнителни категории"
+
+#: id:21866
+msgid "Category"
+msgstr "Категория"
+
+#: id:21867
+msgid "Byline"
+msgstr "Авторски"
+
+#: id:21868
+msgid "Byline title"
+msgstr "Заглавие авторски"
+
+#: id:21869
+msgid "Credit"
+msgstr "Заслуги"
+
+#: id:21870
+msgid "Source"
+msgstr "Източник"
+
+#: id:21871
+msgid "Copyright notice"
+msgstr "Авторско право"
+
+#: id:21872
+msgid "Object name"
+msgstr "Име на обект"
+
+#: id:21873
+msgid "City"
+msgstr "Град"
+
+#: id:21874
+msgid "State"
+msgstr "Област"
+
+#: id:21875
+msgctxt "Auto context with id 21875"
+msgid "Country"
+msgstr "Държава"
+
+#: id:21876
+msgid "Original Tx Reference"
+msgstr "Оригинална Tx референция"
+
+#: id:21877
+msgid "Date created"
+msgstr "Дата на създаване"
+
+#: id:21878
+msgid "Copyright flag"
+msgstr "Авторско право флаг"
+
+#: id:21879
+msgid "Country code"
+msgstr "Код на държавата"
+
+#: id:21880
+msgid "Reference service"
+msgstr "Референтни услуги"
+
+#: id:21881
+msgid "Allow control of XBMC via UPnP"
+msgstr "Включи UPnP рендер"
+
+#: id:21882
+msgid "Attempt to skip introduction before DVD menu"
+msgstr "Опит за пропускане на DVD меню"
+
+#: id:21883
+msgid "Saved music"
+msgstr "Извлечени CD-та"
+
+#: id:21884
+msgid "Query info for all artists"
+msgstr "Запитване информация за всички изпълнители"
+
+#: id:21885
+msgid "Downloading album information"
+msgstr "Сваляне на информацията за албума"
+
+#: id:21886
+msgid "Downloading artist information"
+msgstr "Сваляне на информацията за изпълнител"
+
+#: id:21887
+msgid "Biography"
+msgstr "Биография"
+
+#: id:21888
+msgid "Discography"
+msgstr "Дискография"
+
+#: id:21889
+msgid "Searching artist"
+msgstr "Търсене за изпълнител"
+
+#: id:21890
+msgid "Select artist"
+msgstr "Избери изпълнител"
+
+#: id:21891
+msgctxt "Auto context with id 21891"
+msgid "Artist information"
+msgstr "Информация за изпълнител"
+
+#: id:21892
+msgid "Instruments"
+msgstr "Инструменти"
+
+#: id:21893
+msgid "Born"
+msgstr "Роден"
+
+#: id:21894
+msgid "Formed"
+msgstr "Формиран"
+
+#: id:21895
+msgid "Themes"
+msgstr "Теми"
+
+#: id:21896
+msgid "Disbanded"
+msgstr "Разпуснат"
+
+#: id:21897
+msgid "Died"
+msgstr "Починал"
+
+#: id:21898
+msgid "Years active"
+msgstr "Години активен"
+
+#: id:21899
+msgid "Label"
+msgstr "Етикет"
+
+#: id:21900
+msgid "Born/Formed"
+msgstr "Роден/Формиран"
+
+#: id:22000
+msgid "Update library on startup"
+msgstr "Обновяване на библиотеката при стартиране"
+
+#: id:22001
+msgid "Hide progress of library updates"
+msgstr "Винаги опреснявай библиотеката във фонов режим"
+
+#: id:22002
+msgid "- DNS suffix"
+msgstr "- DNS наставка"
+
+#: id:22003
+msgid "%2.3fs"
+msgstr "%2.3fs"
+
+#: id:22004
+msgid "Delayed by: %2.3fs"
+msgstr "Забавен с: %2.3fs"
+
+#: id:22005
+msgid "Ahead by: %2.3fs"
+msgstr "Напред с: %2.3fs"
+
+#: id:22006
+msgid "Subtitle offset"
+msgstr "Отместване на субтитри"
+
+#: id:22007
+msgid "OpenGL vendor:"
+msgstr "OpenGL доставчик:"
+
+#: id:22008
+msgid "OpenGL renderer:"
+msgstr "OpenGL рендер:"
+
+#: id:22009
+msgid "OpenGL version:"
+msgstr "OpenGL версия:"
+
+#: id:22010
+msgid "GPU temperature:"
+msgstr "GPU температура:"
+
+#: id:22011
+msgid "CPU temperature:"
+msgstr "CPU температура:"
+
+#: id:22012
+msgid "Total memory"
+msgstr "Общо памет"
+
+#: id:22013
+msgid "Profile data"
+msgstr "Данни за профил"
+
+#: id:22014
+msgid "Use dim if paused during video playback"
+msgstr "Използване на затихване при видео пауза"
+
+#: id:22015
+msgid "All recordings"
+msgstr "Всички записи"
+
+#: id:22016
+msgid "By title"
+msgstr "По заглавие"
+
+#: id:22017
+msgid "By group"
+msgstr "По група"
+
+#: id:22018
+msgid "Live channels"
+msgstr "Канали на живо"
+
+#: id:22019
+msgid "Recordings by title"
+msgstr "Записи по заглавие"
+
+#: id:22020
+msgid "Guide"
+msgstr "Ръководство"
+
+#: id:22021
+msgid "Allowed error in aspect ratio to minimize black bars"
+msgstr "Позволени грешки в съотношението (%)"
+
+#: id:22022
+msgid "Show video files in listings"
+msgstr "Включване на видео файлове в листинги"
+
+#: id:22023
+msgid "DirectX vendor:"
+msgstr "DirectX доставчик:"
+
+#: id:22024
+msgid "Direct3D version:"
+msgstr "Direct3D версия:"
+
+#: id:22030
+msgctxt "Auto context with id 22030"
+msgid "Font"
+msgstr "Шрифт"
+
+#: id:22031
+msgctxt "Auto context with id 22031"
+msgid "- Size"
+msgstr "- Размер"
+
+#: id:22032
+msgctxt "Auto context with id 22032"
+msgid "- Colours"
+msgstr "- Цвят"
+
+#: id:22033
+msgid "- Charset"
+msgstr "- Кодова таблица"
+
+#: id:22034
+msgid "Export karaoke titles as HTML"
+msgstr "Изнасяне заглавията на караоке като HTML"
+
+#: id:22035
+msgid "Export karaoke titles as CSV"
+msgstr "Изнасяне заглавията на караоке като CSV"
+
+#: id:22036
+msgid "Import karaoke titles..."
+msgstr "Внасяне на заглавия на караоке..."
+
+#: id:22037
+msgid "Show song selector automatically"
+msgstr "Автоматично излизащ избирател на песни"
+
+#: id:22038
+msgid "Export karaoke titles..."
+msgstr "Изнасяне заглавията на караоке..."
+
+#: id:22039
+msgid "Enter song number"
+msgstr "Въведи номер на песен"
+
+#: id:22040
+msgid "white/green"
+msgstr "бял/зелен"
+
+#: id:22041
+msgid "white/red"
+msgstr "бял/червен"
+
+#: id:22042
+msgid "white/blue"
+msgstr "бял/син"
+
+#: id:22043
+msgid "black/white"
+msgstr "черен/бял"
+
+#: id:22079
+msgid "Default select action"
+msgstr "Избиране на действие по подразбиране"
+
+#: id:22080
+msgid "Choose"
+msgstr "Избери"
+
+#: id:22081
+msgid "Show Information"
+msgstr "Покажи информация"
+
+#: id:22082
+msgid "More..."
+msgstr "Още..."
+
+#: id:22083
+msgid "Play all"
+msgstr "Възпроизведи всички"
+
+#: id:23049
+msgid "Teletext not available"
+msgstr "Телетекстът не е достъпен"
+
+#: id:23050
+msgid "Activate Teletext"
+msgstr "Активирай телетекст"
+
+#: id:23051
+msgid "Part %i"
+msgstr "Част %i"
+
+#: id:23052
+msgid "Buffering %i bytes"
+msgstr "Буфериране %i байта"
+
+#: id:23053
+msgid "Stopping"
+msgstr "Спиране"
+
+#: id:23054
+msgid "Running"
+msgstr "В ход"
+
+#: id:23100
+msgid "External Player Active"
+msgstr "Външен плейър активен"
+
+#: id:23101
+msgid "Click OK to terminate the player"
+msgstr "Натисни ОК за спиране на плейъра"
+
+#: id:23104
+msgid "Click OK when playback has ended"
+msgstr "Натисни ОК при свършване на възпроизвеждането"
+
+#: id:24000
+msgid "Add-on"
+msgstr "Добавка"
+
+#: id:24001
+msgid "Add-ons"
+msgstr "Добавки"
+
+#: id:24002
+msgid "Add-on options"
+msgstr "Опции на добавка"
+
+#: id:24003
+msgid "Add-on Information"
+msgstr "Информация за добавка"
+
+#: id:24005
+msgctxt "Auto context with id 24005"
+msgid "Media sources"
+msgstr "Медия източници"
+
+#: id:24007
+msgctxt "Auto context with id 24007"
+msgid "Movie information"
+msgstr "Информация за филм"
+
+#: id:24008
+msgctxt "Auto context with id 24008"
+msgid "Screensaver"
+msgstr "Скрийнсейвър"
+
+#: id:24009
+msgid "Script"
+msgstr "Скрипт"
+
+#: id:24010
+msgctxt "Auto context with id 24010"
+msgid "Visualization"
+msgstr "Визуализация"
+
+#: id:24011
+msgid "Add-on repository"
+msgstr "Хранилище на добавка"
+
+#: id:24012
+msgctxt "Auto context with id 24012"
+msgid "Subtitles"
+msgstr "Субтитри"
+
+#: id:24013
+msgid "Lyrics"
+msgstr "Текст на песен"
+
+#: id:24014
+msgid "TV information"
+msgstr "ТВ информация"
+
+#: id:24015
+msgctxt "Auto context with id 24015"
+msgid "Music video information"
+msgstr "Информация за музикално видео"
+
+#: id:24016
+msgctxt "Auto context with id 24016"
+msgid "Album information"
+msgstr "Информация за албум"
+
+#: id:24017
+msgctxt "Auto context with id 24017"
+msgid "Artist information"
+msgstr "Информация за актьор"
+
+#: id:24018
+msgctxt "Auto context with id 24018"
+msgid "Services"
+msgstr "Услуги"
+
+#: id:24020
+msgid "Configure"
+msgstr "Конфигурация"
+
+#: id:24021
+msgctxt "Auto context with id 24021"
+msgid "Disable"
+msgstr "Изключено"
+
+#: id:24022
+msgid "Enable"
+msgstr "Включено"
+
+#: id:24023
+msgid "Add-on disabled"
+msgstr "Добавка изключена"
+
+#: id:24027
+msgctxt "Auto context with id 24027"
+msgid "Weather"
+msgstr "Времето"
+
+#: id:24028
+msgid "Weather.com (standard)"
+msgstr "Weather.com (стандартно)"
+
+#: id:24030
+msgid "This Add-on can not be configured"
+msgstr "Тази добавка не може да бъде конфигурирана"
+
+#: id:24031
+msgid "Error loading settings"
+msgstr "Грешка при зареждане на настройки"
+
+#: id:24032
+msgid "All Add-ons"
+msgstr "Всички добавки"
+
+#: id:24033
+msgid "Get Add-ons"
+msgstr "Вземи добавки"
+
+#: id:24034
+msgid "Check for updates"
+msgstr "Провери за обновления"
+
+#: id:24035
+msgid "Force refresh"
+msgstr "Опресни веднага"
+
+#: id:24036
+msgid "Change log"
+msgstr "Лог с промени"
+
+#: id:24037
+msgid "Uninstall"
+msgstr "Деинсталирай"
+
+#: id:24038
+msgid "Install"
+msgstr "Инсталирай"
+
+#: id:24039
+msgid "Disabled Add-ons"
+msgstr "Изключени добавки"
+
+#: id:24040
+msgid "(Clear the current setting)"
+msgstr "(Изчисти настоящите настройки)"
+
+#: id:24041
+msgid "Install from zip file"
+msgstr "Инсталирай от zip файл"
+
+#: id:24042
+msgid "Downloading %i%%"
+msgstr "Свалени %i%%"
+
+#: id:24043
+msgid "Available Updates"
+msgstr "Достъпни обновления"
+
+#: id:24044
+msgid "Dependencies not met"
+msgstr ""
+
+#: id:24045
+msgid "Add-on does not have the correct structure"
+msgstr ""
+
+#: id:24046
+msgid "%s is used by the following installed add-on(s)"
+msgstr ""
+
+#: id:24047
+msgid "This add-on cannot be uninstalled"
+msgstr ""
+
+#: id:24048
+msgid "Rollback"
+msgstr ""
+
+#: id:24050
+msgid "Available Add-ons"
+msgstr "Достъпни добавки"
+
+#: id:24051
+msgid "Version:"
+msgstr "Версия:"
+
+#: id:24052
+msgid "Disclaimer"
+msgstr "Отказване от права"
+
+#: id:24053
+msgid "License:"
+msgstr "Лиценз:"
+
+#: id:24054
+msgid "Changelog"
+msgstr "Лог с промени"
+
+#: id:24059
+msgid "Would you like to enable this Add-on?"
+msgstr "Да включа ли тази добавка?"
+
+#: id:24060
+msgid "Would you like to disable this Add-on?"
+msgstr "Да изключа ли тази добавка?"
+
+#: id:24061
+msgid "Add-on update available!"
+msgstr "Достъпно обновление за добавка!"
+
+#: id:24062
+msgid "Enabled Add-ons"
+msgstr "Включени добавки"
+
+#: id:24063
+msgid "Auto update"
+msgstr "Авто обновяване"
+
+#: id:24064
+msgid "Add-on enabled"
+msgstr "Включена добавка"
+
+#: id:24065
+msgid "Add-on updated"
+msgstr "Обновена добавка"
+
+#: id:24066
+msgid "Cancel Add-on download?"
+msgstr "Прекъсване на сваляне добавка?"
+
+#: id:24067
+msgid "Currently downloading Add-ons"
+msgstr "Текущо сваляне на добавки"
+
+#: id:24068
+msgid "Update available"
+msgstr "Достъпно обновление"
+
+#: id:24069
+msgid "Update"
+msgstr "Обновление"
+
+#: id:24070
+msgid "Add-on could not be loaded."
+msgstr "Добавката не може да бъде заредена."
+
+#: id:24071
+msgid "An unknown error has occurred."
+msgstr "Получи се непозната грешка."
+
+#: id:24072
+msgid "Settings required"
+msgstr "Изисква настройки"
+
+#: id:24073
+msgid "Could not connect"
+msgstr "Не мога да се свържа"
+
+#: id:24074
+msgid "Needs to restart"
+msgstr "Изисква се рестарт"
+
+#: id:24075
+msgctxt "Auto context with id 24075"
+msgid "Disable"
+msgstr "Изключи"
+
+#: id:24076
+msgid "Add-on Required"
+msgstr "Изисква добавка"
+
+#: id:24080
+msgid "Try to reconnect?"
+msgstr "Свързване отново?"
+
+#: id:24089
+msgid "Add-on restarts"
+msgstr "Добавката се рестартира"
+
+#: id:24090
+msgid "Lock Add-on manager"
+msgstr "Заключи управление на добавки"
+
+#: id:24094
+msgid "(current)"
+msgstr ""
+
+#: id:24095
+msgid "(blacklisted)"
+msgstr ""
+
+#: id:24096
+msgid "Add-on has been marked as broken in repository."
+msgstr "Добавка маркирана като повредена в хранилището."
+
+#: id:24097
+msgid "Would you like to disable it on your system?"
+msgstr "Желаете ли да я изключите от системата?"
+
+#: id:24098
+msgid "Broken"
+msgstr "Повреден"
+
+#: id:24099
+msgid "Would you like to switch to this skin?"
+msgstr "Желаете ли да превключите на тази кожа?"
+
+#: id:24100
+msgid "To use this feature you must download an Add-on:"
+msgstr "За да използвате това свойство, трябва да свалите добавка:"
+
+#: id:24101
+msgid "Would you like to download this Add-on?"
+msgstr "Желаете ли да свалите тази добавка?"
+
+#: id:25000
+msgid "Notifications"
+msgstr "Известия"
+
+#: id:29800
+msgid "Library Mode"
+msgstr "Библиотека"
+
+#: id:29801
+msgid "QWERTY keyboard"
+msgstr "QWERTY клавиатура"
+
+#: id:29802
+msgid "Passthrough Audio in use"
+msgstr "Passthrough Аудио се използва"
+
+#: id:33001
+msgid "Trailer quality"
+msgstr "Качество на трейлър"
+
+#: id:33002
+msgid "Stream"
+msgstr "Поток"
+
+#: id:33003
+msgid "Download"
+msgstr "Сваляне"
+
+#: id:33004
+msgid "Download & play"
+msgstr "Сваляне & възпроизвеждане"
+
+#: id:33005
+msgid "Download & save"
+msgstr "Сваляне & запазване"
+
+#: id:33006
+msgid "Today"
+msgstr "Днес"
+
+#: id:33007
+msgid "Tomorrow"
+msgstr "Утре"
+
+#: id:33008
+msgid "Saving"
+msgstr "Запазване"
+
+#: id:33009
+msgid "Copying"
+msgstr "Копиране"
+
+#: id:33010
+msgid "Set download directory"
+msgstr "Задай папка за свалени"
+
+#: id:33011
+msgid "Search duration"
+msgstr ""
+
+#: id:33012
+msgid "Short"
+msgstr "Къс"
+
+#: id:33013
+msgid "Long"
+msgstr "Дълъг"
+
+#: id:33014
+msgid "Use DVD player instead of regular player"
+msgstr "Ползвай DVD плейър, вместо редовния"
+
+#: id:33015
+msgid "Ask for download before playing video"
+msgstr "Питай за сваляне, преди възпроизвеждане на видео"
+
+#: id:33016
+msgid "Clips"
+msgstr "Клипове"
+
+#: id:33017
+msgid "Restart plugin to enable"
+msgstr "Рестартирайте добавката за активиране"
+
+#: id:33018
+msgid "Tonight"
+msgstr "Тази Вечер"
+
+#: id:33019
+msgid "Tomorrow Night"
+msgstr "Утре Вечер"
+
+#: id:33020
+msgid "Condition"
+msgstr "Състояние"
+
+#: id:33021
+msgid "Precipitation"
+msgstr "Валеж"
+
+#: id:33022
+msgid "Precip"
+msgstr "Дъжд"
+
+#: id:33023
+msgid "Humid"
+msgstr "Влажен"
+
+#: id:33024
+msgid "Feels"
+msgstr "Усеща"
+
+#: id:33025
+msgid "Observed"
+msgstr "Наблюдавани"
+
+#: id:33026
+msgid "Departure from normal"
+msgstr "Отклонение от нормалното"
+
+#: id:33027
+msgid "Sunrise"
+msgstr "Изгрев"
+
+#: id:33028
+msgid "Sunset"
+msgstr "Залез"
+
+#: id:33029
+msgid "Details"
+msgstr "Детайли"
+
+#: id:33030
+msgid "Outlook"
+msgstr "Перспектива"
+
+#: id:33031
+msgid "Coverflow"
+msgstr "Обложки"
+
+#: id:33032
+msgid "Translate text"
+msgstr "Превод на текст"
+
+#: id:33033
+msgid "Map list %s category"
+msgstr "Списък карта %s категория"
+
+#: id:33034
+msgid "36 Hour"
+msgstr "36 Часа"
+
+#: id:33035
+msgid "Maps"
+msgstr "Карти"
+
+#: id:33036
+msgid "Hourly"
+msgstr "Всеки час"
+
+#: id:33037
+msgid "Weekend"
+msgstr "Седмица"
+
+#: id:33038
+msgid "%s day"
+msgstr "%s ден"
+
+#: id:33049
+msgid "Alert"
+msgstr "Аларма"
+
+#: id:33050
+msgid "Alerts"
+msgstr "Аларми"
+
+#: id:33051
+msgid "Choose Your"
+msgstr "Избиране на"
+
+#: id:33052
+msgid "Check"
+msgstr "Проверка"
+
+#: id:33053
+msgctxt "Auto context with id 33053"
+msgid "Configure the"
+msgstr "Конфигурирай"
+
+#: id:33054
+msgid "Seasons"
+msgstr "Сезони"
+
+#: id:33055
+msgid "Use your"
+msgstr "Ползване на"
+
+#: id:33056
+msgid "Watch your"
+msgstr "Гледане на"
+
+#: id:33057
+msgid "Listen to"
+msgstr "Слушай"
+
+#: id:33058
+msgid "View your"
+msgstr "Преглед на"
+
+#: id:33059
+msgctxt "Auto context with id 33059"
+msgid "Configure the"
+msgstr "Конфигуриране на"
+
+#: id:33060
+msgid "Power"
+msgstr "Мрежово захранване"
+
+#: id:33061
+msgid "Menu"
+msgstr "Меню"
+
+#: id:33062
+msgid "Play the"
+msgstr "Възпроизвеждане на"
+
+#: id:33063
+msgid "Options"
+msgstr "Опции"
+
+#: id:33065
+msgid "Editor"
+msgstr "Редактор"
+
+#: id:33066
+msgid "About your"
+msgstr "Относно"
+
+#: id:33067
+msgid "Star rating"
+msgstr "Рейтинг"
+
+#: id:33068
+msgid "Background"
+msgstr "Фон"
+
+#: id:33069
+msgid "Backgrounds"
+msgstr "Фонове"
+
+#: id:33070
+msgid "Custom background"
+msgstr "Потребителски Фон"
+
+#: id:33071
+msgid "Custom backgrounds"
+msgstr "Потребителски Фонове"
+
+#: id:33072
+msgid "View Readme"
+msgstr "Виж Readme"
+
+#: id:33073
+msgid "View Changelog"
+msgstr "Виж Changelog"
+
+#: id:33074
+msgid "This version of %s requires an"
+msgstr "Тази версия на %s изисква"
+
+#: id:33075
+msgid "XBMC revision of %s or greater to run."
+msgstr "XBMC ревизия %s или по-висока."
+
+#: id:33076
+msgid "Please update XBMC."
+msgstr "Моля обновете XBMC."
+
+#: id:33077
+msgid "No data found!"
+msgstr "Няма намерени данни!"
+
+#: id:33078
+msgid "Next page"
+msgstr "Следваща страница"
+
+#: id:33079
+msgid "Love"
+msgstr "Харесвам"
+
+#: id:33080
+msgid "Hate"
+msgstr "Не харесвам"
+
+#: id:33081
+msgid "This file is stacked, select the part you want to play from."
+msgstr "Изберете място, от което искате да възпроизвеждате."
+
+#: id:33082
+msgid "Path to script"
+msgstr "Път до скрипт"
+
+#: id:33083
+msgid "Enable custom script button"
+msgstr "Включи потребителски скрипт бутон"
+
+#: id:33100
+msgid "Failed to start"
+msgstr "Неуспешен старт"
+
+#: id:33101
+msgid "Webserver"
+msgstr "Уеб сървър"
+
+#: id:33102
+msgid "Event Server"
+msgstr "Сървър на събития"
+
+#: id:33103
+msgid "Remote communication server"
+msgstr "Отдалечен комуникационен сървър"
+
+#: id:33200
+msgid "Detected New Connection"
+msgstr ""
+
+#: id:34000
+msgid "Lame"
+msgstr "Lame"
+
+#: id:34001
+msgid "Vorbis"
+msgstr "Vorbis"
+
+#: id:34002
+msgid "Wav"
+msgstr "Wav"
+
+#: id:34003
+msgid "DXVA2"
+msgstr "DXVA2"
+
+#: id:34004
+msgid "VAAPI"
+msgstr "VAAPI"
+
+#: id:34005
+msgid "Flac"
+msgstr "Flac"
+
+#: id:34100
+msgid "Speaker Configuration"
+msgstr "Конфигурация на високоговорители"
+
+#: id:34101
+msgid "2.0"
+msgstr "2.0"
+
+#: id:34102
+msgid "2.1"
+msgstr "2.1"
+
+#: id:34103
+msgid "3.0"
+msgstr "3.0"
+
+#: id:34104
+msgid "3.1"
+msgstr "3.1"
+
+#: id:34105
+msgid "4.0"
+msgstr "4.0"
+
+#: id:34106
+msgid "4.1"
+msgstr "4.1"
+
+#: id:34107
+msgid "5.0"
+msgstr "5.0"
+
+#: id:34108
+msgid "5.1"
+msgstr "5.1"
+
+#: id:34109
+msgid "7.0"
+msgstr "7.0"
+
+#: id:34110
+msgid "7.1"
+msgstr "7.1"
+
+#: id:34201
+msgid "Can't find a next item to play"
+msgstr "Не мога да намеря следващ файл за просвирване"
+
+#: id:34202
+msgid "Can't find a previous item to play"
+msgstr "Не мога да намеря предишен файл за просвирване"
+
+#: id:34300
+msgid "Failed to start zeroconf"
+msgstr ""
+
+#: id:34301
+msgid "Is Apple's Bonjour Service installed? See log for more info."
+msgstr ""
+
+#: id:34400
+msgid "Video Rendering"
+msgstr ""
+
+#: id:34401
+msgid "Failed to init video filters/scalers, falling back to bilinear scaling"
+msgstr ""
+
+#: id:34402
+msgid "Failed to initialize audio device"
+msgstr ""
+
+#: id:34403
+msgid "Check your audiosettings"
+msgstr ""
+
+#: id:34404
+msgid "Use gestures for navigation:"
+msgstr ""
+
+#: id:34405
+msgid "1 finger swipe left,right,up,down for cursors"
+msgstr ""
+
+#: id:34406
+msgid "2 finger swipe left for backspace"
+msgstr ""
+
+#: id:34407
+msgid "1 finger single tap for enter"
+msgstr ""
+
+#: id:34408
+msgid "2 finger single tap for contextmenu"
+msgstr ""
+
+#: id:35000
+msgid "Peripherals"
+msgstr "Периферия"
+
+#: id:35001
+msgid "Generic HID device"
+msgstr "HID устройство"
+
+#: id:35002
+msgid "Generic network adapter"
+msgstr "Мрежов адаптер"
+
+#: id:35003
+msgid "Generic disk"
+msgstr "Диск"
+
+#: id:35004
+msgid "There are no settings available\nfor this peripheral."
+msgstr "Няма достъпни настройки\nза това устройство."
+
+#: id:35005
+msgid "New device configured"
+msgstr "Ново устройство конфигурирано"
+
+#: id:35006
+msgid "Device removed"
+msgstr "Устройството премахнато"
+
+#: id:35007
+msgid "Keymap to use for this device"
+msgstr "Клавиши за това устройство"
+
+#: id:35008
+msgid "Keymap enabled"
+msgstr "Клавиши активирани"
+
+#: id:35009
+msgid "Do not use the custom keymap for this device"
+msgstr ""
+
+#: id:35500
+msgid "Location"
+msgstr "Местоположение"
+
+#: id:35501
+msgid "Class"
+msgstr "Клас"
+
+#: id:35502
+msgctxt "Auto context with id 35502"
+msgid "Name"
+msgstr "Име"
+
+#: id:35503
+msgid "Vendor"
+msgstr "Доставчик"
+
+#: id:35504
+msgid "Product ID"
+msgstr "Продукт ID"
+
+#: id:36000
+msgid "Pulse-Eight CEC adapter"
+msgstr "Pulse-Eight CEC адаптер"
+
+#: id:36001
+msgid "Pulse-Eight Nyxboard"
+msgstr "Pulse-Eight Nyxboard"
+
+#: id:36002
+msgid "Switch to keyboard side command"
+msgstr "Превключи на клавиатура"
+
+#: id:36003
+msgid "Switch to remote side command"
+msgstr "Превключи на отдалечена страна"
+
+#: id:36004
+msgid "Press \"user\" button command"
+msgstr "Натисни \"user\" бутон"
+
+#: id:36005
+msgid "Enable switch side commands"
+msgstr "Включи превключване на управление"
+
+#: id:36006
+msgid "Could not open the adapter"
+msgstr "Не мога да отворя адаптера"
+
+#: id:36007
+msgid "Devices to power on when starting XBMC"
+msgstr "Включи телевизора, когато стартира XBMC"
+
+#: id:36008
+msgid "Devices to power off when stopping XBMC"
+msgstr "Изключи устройства, когато спира XBMC"
+
+#: id:36009
+msgid "Put devices in standby mode when activating screensaver"
+msgstr "Сложи устройствата на стендбай, когато се активира скрийнсейвър"
+
+#: id:36011
+msgid "Could not detect the CEC port. Set it up manually."
+msgstr "Не мога да открия порт CEC. Настройте ръчно."
+
+#: id:36012
+msgid "Could not initialise the CEC adapter. Check your settings."
+msgstr "Не мога да открия адаптер CEC."
+
+#: id:36013
+msgid "Unsupported libCEC interface version. %d is greater than the version XBMC supports (%d)"
+msgstr "Неподдържана libcec интерфейс версия. %d е по-голяма от поддържаната от XBMC (%d)"
+
+#: id:36014
+msgid "Put this PC in standby mode when the TV is switched off"
+msgstr "Компютъра на стендбай, когато телевизора е изключен"
+
+#: id:36015
+msgid "HDMI port number"
+msgstr "HDMI номер"
+
+#: id:36016
+msgctxt "Auto context with id 36016"
+msgid "Connected"
+msgstr "Свързан"
+
+#: id:36017
+msgid "Adapter found, but libCEC is not available"
+msgstr "Адаптера е намерен, но libcec не е достъпен"
+
+#: id:36018
+msgid "Use the TV's language setting"
+msgstr "Ползвай езиковите настройки на телевизора"
+
+#: id:36019
+msgid "Connected to HDMI device"
+msgstr ""
+
+#: id:36020
+msgid "Make XBMC the active source when starting"
+msgstr ""
+
+#: id:36021
+msgid "Physical address (overrules HDMI port)"
+msgstr ""
+
+#: id:36022
+msgid "COM port (leave empty unless needed)"
+msgstr ""
+
+#: id:36023
+msgid "Configuration updated"
+msgstr ""
+
+#: id:36024
+msgid "Failed to set the new configuration. Please check your settings."
+msgstr ""
+
+#: id:36025
+msgid "Send 'inactive source' command when stopping XBMC"
+msgstr ""
+

--- a/language/Catalan/strings.po
+++ b/language/Catalan/strings.po
@@ -1,0 +1,9093 @@
+# Converted from xbmc strings.xml with xbmc-xml2po (by Team-XBMC)
+msgid ""
+msgstr ""
+"Project-Id-Version: xbmc.core-FRODO_GIT3ed1604ad7\n"
+"Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
+"POT-Creation-Date: 2012-04-09 18:00+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE\n"
+"Language: ca\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: id:0
+msgctxt "Auto context with id 0"
+msgid "Programs"
+msgstr "Programes"
+
+#: id:1
+msgctxt "Auto context with id 1"
+msgid "Pictures"
+msgstr "Imatges"
+
+#: id:2
+msgctxt "Auto context with id 2"
+msgid "Music"
+msgstr "Música"
+
+#: id:3
+msgctxt "Auto context with id 3"
+msgid "Videos"
+msgstr "Vídeos"
+
+#: id:4
+msgid "TV-Guide"
+msgstr "Guia TV"
+
+#: id:5
+msgctxt "Auto context with id 5"
+msgid "Settings"
+msgstr "Configuració"
+
+#: id:6
+msgid "XBMC SVN"
+msgstr "XBMC SVN"
+
+#: id:7
+msgctxt "Auto context with id 7"
+msgid "File manager"
+msgstr "Gestor de fitxers"
+
+#: id:8
+msgctxt "Auto context with id 8"
+msgid "Weather"
+msgstr "El Temps"
+
+#: id:9
+msgid "xbmc media center"
+msgstr "xbmc media center"
+
+#: id:11
+msgid "Monday"
+msgstr "Dilluns"
+
+#: id:12
+msgid "Tuesday"
+msgstr "Dimarts"
+
+#: id:13
+msgid "Wednesday"
+msgstr "Dimecres"
+
+#: id:14
+msgid "Thursday"
+msgstr "Dijous"
+
+#: id:15
+msgid "Friday"
+msgstr "Divendres"
+
+#: id:16
+msgid "Saturday"
+msgstr "Dissabte"
+
+#: id:17
+msgid "Sunday"
+msgstr "Diumenge"
+
+#: id:21
+msgid "January"
+msgstr "Gener"
+
+#: id:22
+msgid "February"
+msgstr "Febrer"
+
+#: id:23
+msgid "March"
+msgstr "Març"
+
+#: id:24
+msgid "April"
+msgstr "Abril"
+
+#: id:25
+msgctxt "Auto context with id 25"
+msgid "May"
+msgstr "Maig"
+
+#: id:26
+msgid "June"
+msgstr "Juny"
+
+#: id:27
+msgid "July"
+msgstr "Juliol"
+
+#: id:28
+msgid "August"
+msgstr "Agost"
+
+#: id:29
+msgid "September"
+msgstr "Setembre"
+
+#: id:30
+msgid "October"
+msgstr "Octubre"
+
+#: id:31
+msgid "November"
+msgstr "Novembre"
+
+#: id:32
+msgid "December"
+msgstr "Desembre"
+
+#: id:41
+msgid "Mon"
+msgstr "dl."
+
+#: id:42
+msgid "Tue"
+msgstr "dt."
+
+#: id:43
+msgid "Wed"
+msgstr "dc."
+
+#: id:44
+msgid "Thu"
+msgstr "dj."
+
+#: id:45
+msgid "Fri"
+msgstr "dv."
+
+#: id:46
+msgid "Sat"
+msgstr "ds."
+
+#: id:47
+msgctxt "Auto context with id 47"
+msgid "Sun"
+msgstr "dg."
+
+#: id:51
+msgid "Jan"
+msgstr "gen."
+
+#: id:52
+msgid "Feb"
+msgstr "febr."
+
+#: id:53
+msgid "Mar"
+msgstr "març"
+
+#: id:54
+msgid "Apr"
+msgstr "abr."
+
+#: id:55
+msgctxt "Auto context with id 55"
+msgid "May"
+msgstr "maig"
+
+#: id:56
+msgid "Jun"
+msgstr "juny"
+
+#: id:57
+msgid "Jul"
+msgstr "jul."
+
+#: id:58
+msgid "Aug"
+msgstr "ag."
+
+#: id:59
+msgid "Sep"
+msgstr "set."
+
+#: id:60
+msgid "Oct"
+msgstr "oct."
+
+#: id:61
+msgid "Nov"
+msgstr "nov."
+
+#: id:62
+msgid "Dec"
+msgstr "des."
+
+#: id:71
+msgid "N"
+msgstr "N"
+
+#: id:72
+msgid "NNE"
+msgstr "NNE"
+
+#: id:73
+msgid "NE"
+msgstr "NE"
+
+#: id:74
+msgid "ENE"
+msgstr "ENE"
+
+#: id:75
+msgid "E"
+msgstr "E"
+
+#: id:76
+msgid "ESE"
+msgstr "ESE"
+
+#: id:77
+msgid "SE"
+msgstr "SE"
+
+#: id:78
+msgid "SSE"
+msgstr "SSE"
+
+#: id:79
+msgid "S"
+msgstr "S"
+
+#: id:80
+msgid "SSW"
+msgstr "SSW"
+
+#: id:81
+msgid "SW"
+msgstr "SW"
+
+#: id:82
+msgid "WSW"
+msgstr "WSW"
+
+#: id:83
+msgid "W"
+msgstr "W"
+
+#: id:84
+msgid "WNW"
+msgstr "WNW"
+
+#: id:85
+msgid "NW"
+msgstr "NW"
+
+#: id:86
+msgid "NNW"
+msgstr "NNW"
+
+#: id:87
+msgid "VAR"
+msgstr "VAR"
+
+#: id:98
+msgid "View: Auto"
+msgstr "Vista: Auto"
+
+#: id:99
+msgid "View: Auto big"
+msgstr "Vista: Auto gran"
+
+#: id:100
+msgid "View: Icons"
+msgstr "Vista: Icones"
+
+#: id:101
+msgid "View: List"
+msgstr "Vista: Llista"
+
+#: id:102
+msgctxt "Auto context with id 102"
+msgid "Scan"
+msgstr "Escaneja"
+
+#: id:103
+msgctxt "Auto context with id 103"
+msgid "Sort by: Name"
+msgstr "Ordena per: Nom"
+
+#: id:104
+msgid "Sort by: Date"
+msgstr "Ordena per: Data"
+
+#: id:105
+msgid "Sort by: Size"
+msgstr "Ordena per: Mida"
+
+#: id:106
+msgid "No"
+msgstr "No"
+
+#: id:107
+msgid "Yes"
+msgstr "Sí"
+
+#: id:108
+msgctxt "Auto context with id 108"
+msgid "Slideshow"
+msgstr "Presentació amb diapositives"
+
+#: id:109
+msgid "Create thumbs"
+msgstr "Crea miniatures"
+
+#: id:110
+msgid "Create thumbnails"
+msgstr "Crea miniatures"
+
+#: id:111
+msgctxt "Auto context with id 111"
+msgid "Shortcuts"
+msgstr "Dreceres"
+
+#: id:112
+msgid "Paused"
+msgstr "En pausa"
+
+#: id:113
+msgid "Update failed"
+msgstr "Ha fallat l'actualització"
+
+#: id:114
+msgid "Installation failed"
+msgstr "Ha fallat la instal·lació"
+
+#: id:115
+msgid "Copy"
+msgstr "Copia"
+
+#: id:116
+msgid "Move"
+msgstr "Mou"
+
+#: id:117
+msgid "Delete"
+msgstr "Elimina"
+
+#: id:118
+msgid "Rename"
+msgstr "Canvia el nom"
+
+#: id:119
+msgid "New folder"
+msgstr "Carpeta nova"
+
+#: id:120
+msgid "Confirm file copy"
+msgstr "Confirma copiar el fitxer"
+
+#: id:121
+msgid "Confirm file move"
+msgstr "Confirma moure el fitxer"
+
+#: id:122
+msgid "Confirm file delete?"
+msgstr "Confirma eliminar el fitxer"
+
+#: id:123
+msgid "Copy these files?"
+msgstr "Voleu copiar els fitxers?"
+
+#: id:124
+msgid "Move these files?"
+msgstr "Voleu moure els fitxers?"
+
+#: id:125
+msgid "Delete these files? - Deleting files cannot be undone!"
+msgstr "Voleu eliminar els fitxers? - L'eliminació dels fitxers no es pot desfer."
+
+#: id:126
+msgid "Status"
+msgstr "Estat"
+
+#: id:127
+msgid "Objects"
+msgstr "Objectes"
+
+#: id:128
+msgctxt "Auto context with id 128"
+msgid "General"
+msgstr "General"
+
+#: id:129
+msgctxt "Auto context with id 129"
+msgid "Slideshow"
+msgstr "Presentació amb diapositives"
+
+#: id:130
+msgctxt "Auto context with id 130"
+msgid "System info"
+msgstr "Informació del sistema"
+
+#: id:131
+msgid "Display"
+msgstr "Pantalla"
+
+#: id:132
+msgid "Albums"
+msgstr "Àlbums"
+
+#: id:133
+msgid "Artists"
+msgstr "Artistes"
+
+#: id:134
+msgid "Songs"
+msgstr "Cançons"
+
+#: id:135
+msgid "Genres"
+msgstr "Gèneres"
+
+#: id:136
+msgid "Playlists"
+msgstr "Llistes de reproducció"
+
+#: id:137
+msgid "Search"
+msgstr "Cerca"
+
+#: id:138
+msgid "System Information"
+msgstr "Informació del sistema"
+
+#: id:139
+msgid "Temperatures:"
+msgstr "Temperatures:"
+
+#: id:140
+msgid "CPU:"
+msgstr "CPU:"
+
+#: id:141
+msgid "GPU:"
+msgstr "GPU:"
+
+#: id:142
+msgid "Time:"
+msgstr "Hora:"
+
+#: id:143
+msgid "Current:"
+msgstr "Actual:"
+
+#: id:144
+msgid "Build:"
+msgstr "Muntatge:"
+
+#: id:145
+msgid "Network:"
+msgstr "Xarxa:"
+
+#: id:146
+msgid "Type:"
+msgstr "Tipus:"
+
+#: id:147
+msgid "Static"
+msgstr "Estàtica"
+
+#: id:148
+msgid "DHCP"
+msgstr "DHCP"
+
+#: id:149
+msgid "MAC address"
+msgstr "Adreça MAC"
+
+#: id:150
+msgctxt "Auto context with id 150"
+msgid "IP address"
+msgstr "Adreça IP"
+
+#: id:151
+msgid "Link:"
+msgstr "Enllaç:"
+
+#: id:152
+msgid "Half duplex"
+msgstr "Half duplex"
+
+#: id:153
+msgid "Full duplex"
+msgstr "Full duplex"
+
+#: id:154
+msgctxt "Auto context with id 154"
+msgid "Storage"
+msgstr "Emmagatzematge"
+
+#: id:155
+msgid "Drive"
+msgstr "Unitat"
+
+#: id:156
+msgctxt "Auto context with id 156"
+msgid "Free"
+msgstr "Lliure"
+
+#: id:157
+msgctxt "Auto context with id 157"
+msgid "Video"
+msgstr "Vídeo"
+
+#: id:158
+msgid "Free memory"
+msgstr "Memòria Lliure"
+
+#: id:159
+msgid "No link"
+msgstr "Sense enllaç"
+
+#: id:160
+msgctxt "Auto context with id 160"
+msgid "Free"
+msgstr "Lliure"
+
+#: id:161
+msgid "Unavailable"
+msgstr "No disponible"
+
+#: id:162
+msgid "Tray open"
+msgstr "Safata oberta"
+
+#: id:163
+msgid "Reading"
+msgstr "S'està llegint"
+
+#: id:164
+msgid "No disc"
+msgstr "Sense Disc"
+
+#: id:165
+msgid "Disc present"
+msgstr "Disc present"
+
+#: id:166
+msgid "Skin"
+msgstr "Pell"
+
+#: id:169
+msgctxt "Auto context with id 169"
+msgid "Resolution"
+msgstr "Resolució"
+
+#: id:170
+msgid "Adjust display refresh rate to match video"
+msgstr "Ajusta la pantalla per que coincideixi amb la freqüència d'actualització del vídeo"
+
+#: id:172
+msgid "Release date"
+msgstr "Data de llançament"
+
+#: id:173
+msgid "Display 4:3 videos as"
+msgstr "Mostra vídeos 4:3 com"
+
+#: id:175
+msgid "Moods"
+msgstr "Estats d'ànim"
+
+#: id:176
+msgid "Styles"
+msgstr "Estils"
+
+#: id:179
+msgid "Song"
+msgstr "Cançó"
+
+#: id:180
+msgid "Duration"
+msgstr "Duració"
+
+#: id:181
+msgid "Select album"
+msgstr "Seleciona un àlbum"
+
+#: id:182
+msgid "Tracks"
+msgstr "Pistes"
+
+#: id:183
+msgid "Review"
+msgstr "Ressenya"
+
+#: id:184
+msgid "Refresh"
+msgstr "Refresca"
+
+#: id:185
+msgid "Searching album"
+msgstr "S'està cercant l'àlbum"
+
+#: id:186
+msgid "OK"
+msgstr "D'acord"
+
+#: id:187
+msgid "No albums found!"
+msgstr "No s'han trobat àlbums"
+
+#: id:188
+msgid "Select all"
+msgstr "Selecciona-ho tot"
+
+#: id:189
+msgid "Scanning media info"
+msgstr "S'està escanejant la informació dels suports"
+
+#: id:190
+msgid "Save"
+msgstr "Desa"
+
+#: id:191
+msgid "Shuffle"
+msgstr "Ordre aleatori"
+
+#: id:192
+msgctxt "Auto context with id 192"
+msgid "Clear"
+msgstr "Neteja"
+
+#: id:193
+msgctxt "Auto context with id 193"
+msgid "Scan"
+msgstr "Cerca"
+
+#: id:194
+msgid "Searching..."
+msgstr "S'està cercant..."
+
+#: id:195
+msgid "No info found!"
+msgstr "No s'ha trobat la informació"
+
+#: id:196
+msgid "Select movie:"
+msgstr "Seleccioneu la pel·lícula:"
+
+#: id:197
+msgid "Querying %s info"
+msgstr "S'està consultant la informació %s"
+
+#: id:198
+msgid "Loading movie details"
+msgstr "S'estan carregant els detalls de la pel·lícula"
+
+#: id:199
+msgid "Web interface"
+msgstr "Interfície web"
+
+#: id:202
+msgid "Tagline"
+msgstr "Lema"
+
+#: id:203
+msgid "Plot outline"
+msgstr "Argument"
+
+#: id:205
+msgid "Votes"
+msgstr "Vots"
+
+#: id:206
+msgid "Cast"
+msgstr "Repartiment"
+
+#: id:207
+msgid "Plot"
+msgstr "Trama"
+
+#: id:208
+msgctxt "Auto context with id 208"
+msgid "Play"
+msgstr "Reprodueix"
+
+#: id:209
+msgid "Next"
+msgstr "Següent"
+
+#: id:210
+msgid "Previous"
+msgstr "Anterior"
+
+#: id:213
+msgid "Calibrate user interface..."
+msgstr "Calibrar la interfície d'usuari..."
+
+#: id:214
+msgid "Video calibration..."
+msgstr "Calibració del vídeo..."
+
+#: id:215
+msgid "Soften"
+msgstr "Suavitzar"
+
+#: id:216
+msgid "Zoom amount"
+msgstr "Quantitat de zoom"
+
+#: id:217
+msgid "Pixel ratio"
+msgstr "Relació d'aspecte"
+
+#: id:218
+msgid "DVD drive"
+msgstr "Unitat de DVD"
+
+#: id:219
+msgid "Please insert disc"
+msgstr "Inseriu un disc"
+
+#: id:220
+msgid "Remote share"
+msgstr "Recurs compartit remot"
+
+#: id:221
+msgid "Network is not connected"
+msgstr "La xarxa no està connectada"
+
+#: id:222
+msgid "Cancel"
+msgstr "Cancel·la"
+
+#: id:224
+msgid "Speed"
+msgstr "Velocitat"
+
+#: id:225
+msgid "Vertical Shift"
+msgstr "Desplaçament vertical"
+
+#: id:226
+msgid "Test patterns..."
+msgstr "Prova de patrons..."
+
+#: id:227
+msgid "Lookup audio CD track names from freedb.org"
+msgstr "Cerca els noms de les pistes dels CD d'àudio a freedb.org"
+
+#: id:228
+msgid "Shuffle playlist on load"
+msgstr "Llista de reproducció aleatòria al carregar"
+
+#: id:229
+msgid "HDD spindown time"
+msgstr "Temps d'aturada del disc dur"
+
+#: id:230
+msgid "Video filters"
+msgstr "Filtres de vídeo"
+
+#: id:231
+msgctxt "Auto context with id 231"
+msgid "None"
+msgstr "Cap"
+
+#: id:232
+msgid "Point"
+msgstr "Punt"
+
+#: id:233
+msgid "Linear"
+msgstr "Lineal"
+
+#: id:234
+msgid "Anisotropic"
+msgstr "Anisotròpic"
+
+#: id:235
+msgid "Quincunx"
+msgstr "Quincunx"
+
+#: id:236
+msgid "Gaussian cubic"
+msgstr "Gaussià cúbic"
+
+#: id:237
+msgid "Minification"
+msgstr "Minificació"
+
+#: id:238
+msgid "Magnification"
+msgstr "Magnificació"
+
+#: id:239
+msgid "Clear playlist on finish"
+msgstr "Buida la llista de reproducció al finalitzar"
+
+#: id:240
+msgid "Display Mode"
+msgstr "Mode de visualització"
+
+#: id:241
+msgid "Full Screen #%d"
+msgstr "Pantalla completa #%d"
+
+#: id:242
+msgid "Windowed"
+msgstr "Finestra"
+
+#: id:243
+msgid "Refresh Rate"
+msgstr "Velocitat de refresc"
+
+#: id:244
+msgid "Full screen"
+msgstr "Pantalla completa"
+
+#: id:245
+msgid "Sizing: (%i,%i)->(%i,%i) (Zoom x%2.2f) AR:%2.2f:1 (Pixels: %2.2f:1) (VShift: %2.2f)"
+msgstr "Dimensionant: (%i,%i)->(%i,%i) (Escala x%2.2f) AR:%2.2f:1 (Píxels: %2.2f:1) (VShift: %2.2f)"
+
+#: id:247
+msgctxt "Auto context with id 247"
+msgid "Scripts"
+msgstr "Scripts"
+
+#: id:248
+msgctxt "Auto context with id 248"
+msgid "Language"
+msgstr "Idioma"
+
+#: id:249
+msgctxt "Auto context with id 249"
+msgid "Music"
+msgstr "Música"
+
+#: id:250
+msgctxt "Auto context with id 250"
+msgid "Visualization"
+msgstr "Visualització"
+
+#: id:251
+msgid "Select destination directory"
+msgstr "Seleccioneu el directori de destí"
+
+#: id:252
+msgid "Output stereo to all speakers"
+msgstr "Sortida estèreo a tots els altaveus"
+
+#: id:253
+msgid "Number of channels"
+msgstr "Número de canals"
+
+#: id:254
+msgid "- DTS capable receiver"
+msgstr "- Descodificador compatible DTS"
+
+#: id:255
+msgid "CDDB"
+msgstr "CDDB"
+
+#: id:256
+msgid "Fetching CD information"
+msgstr "S'està obtenint la informació del CD"
+
+#: id:257
+msgid "Error"
+msgstr "S'ha produït un error"
+
+#: id:258
+msgid "Enable tag reading"
+msgstr "Activa la lectura d'etiquetes"
+
+#: id:259
+msgid "Opening"
+msgstr "S'està obrint"
+
+#: id:260
+msgid "Shoutcast"
+msgstr "Shoutcast"
+
+#: id:261
+msgid "Waiting for start..."
+msgstr "S'està esperant per començar..."
+
+#: id:262
+msgid "Scripts output"
+msgstr "Sortida dels scripts"
+
+#: id:263
+msgid "Allow control of XBMC via HTTP"
+msgstr "Permet el control de l'XBMC a través d'HTTP"
+
+#: id:264
+msgid "Record"
+msgstr "Grava"
+
+#: id:265
+msgid "Stop Rec."
+msgstr "Atura la gravació"
+
+#: id:266
+msgid "Sort by: Track"
+msgstr "Ordena per: Pista"
+
+#: id:267
+msgid "Sort by: Time"
+msgstr "Ordena per: Temps"
+
+#: id:268
+msgid "Sort by: Title"
+msgstr "Ordena per: Títol"
+
+#: id:269
+msgid "Sort by: Artist"
+msgstr "Ordena per: Artista"
+
+#: id:270
+msgid "Sort by: Album"
+msgstr "Ordena per: Àlbum"
+
+#: id:271
+msgid "Top 100"
+msgstr "100 millors"
+
+#: id:272
+msgid "Top-Left overscan compensation"
+msgstr "Compensació cantonada superior esquerra"
+
+#: id:273
+msgid "Bottom-Right overscan compensation"
+msgstr "Compensació cantonada inferior dreta"
+
+#: id:274
+msgid "Subtitle positioning"
+msgstr "Posició dels subtítols"
+
+#: id:275
+msgid "Pixel ratio adjustment"
+msgstr "Ajust de la relació del pixel"
+
+#: id:276
+msgid "Adjust the arrow to change the amount of overscan"
+msgstr "Ajusteu la fletxa per canviar la quantitat d'overscan"
+
+#: id:277
+msgid "Adjust the bar to change the subtitles position"
+msgstr "Ajusteu la barra per canviar la posició dels subtítols"
+
+#: id:278
+msgid "Adjust the rectangle so it is perfectly square"
+msgstr "Ajusteu el rectangle fins que sigui un rectangle perfecte"
+
+#: id:279
+msgid "Unable to load settings"
+msgstr "No es pot carregar la configuració"
+
+#: id:280
+msgid "Using default settings"
+msgstr "S'està utilitzant la configuració per defecte"
+
+#: id:281
+msgid "Please check the XML files"
+msgstr "Comproveu els fitxers XML"
+
+#: id:282
+msgid "Found %i items"
+msgstr "S'han trobat %i elements"
+
+#: id:283
+msgid "Search results"
+msgstr "Resultats de la cerca"
+
+#: id:284
+msgid "No results found"
+msgstr "No hi ha resultats"
+
+#: id:287
+msgctxt "Auto context with id 287"
+msgid "Subtitles"
+msgstr "Subtítols"
+
+#: id:288
+msgctxt "Auto context with id 288"
+msgid "Font"
+msgstr "Font"
+
+#: id:289
+msgctxt "Auto context with id 289"
+msgid "- Size"
+msgstr "- Mida"
+
+#: id:290
+msgid "Dynamic range compression"
+msgstr "Compressió del rang dinàmic"
+
+#: id:291
+msgctxt "Auto context with id 291"
+msgid "Video"
+msgstr "Vídeo"
+
+#: id:292
+msgctxt "Auto context with id 292"
+msgid "Audio"
+msgstr "Àudio"
+
+#: id:293
+msgid "Browse for subtitles"
+msgstr "Cerca subtítols"
+
+#: id:294
+msgid "Create bookmark"
+msgstr "Crea marcador"
+
+#: id:296
+msgid "Clear bookmarks"
+msgstr "Esborra marcadors"
+
+#: id:297
+msgid "Audio offset"
+msgstr "Desplaçament d'àudio"
+
+#: id:298
+msgid "Bookmarks"
+msgstr "Marcadors"
+
+#: id:299
+msgid "- AAC capable receiver"
+msgstr "- Receptor compatible AAC"
+
+#: id:300
+msgid "- MP1 capable receiver"
+msgstr "- Receptor compatible MP1"
+
+#: id:301
+msgid "- MP2 capable receiver"
+msgstr "- Receptor compatible MP2"
+
+#: id:302
+msgid "- MP3 capable receiver"
+msgstr "- Receptor compatible MP3"
+
+#: id:303
+msgid "Delay"
+msgstr "Retard"
+
+#: id:304
+msgctxt "Auto context with id 304"
+msgid "Language"
+msgstr "Idioma"
+
+#: id:305
+msgctxt "Auto context with id 305"
+msgid "Enabled"
+msgstr "Activat"
+
+#: id:306
+msgid "Non-interleaved"
+msgstr "No entrellaçat"
+
+#: id:312
+msgid "(0=auto)"
+msgstr "(0=auto)"
+
+#: id:313
+msgid "Cleaning database"
+msgstr "S'està netejant la base de dades"
+
+#: id:314
+msgid "Preparing..."
+msgstr "S'està preparant..."
+
+#: id:315
+msgid "Database error"
+msgstr "S'ha produït un error a la base de dades"
+
+#: id:316
+msgid "Searching songs..."
+msgstr "S'estan cercant cançons..."
+
+#: id:317
+msgid "Cleaned database successfully"
+msgstr "S'ha netejat la base de dades correctament"
+
+#: id:318
+msgid "Cleaning songs..."
+msgstr "S'estan netejant les cançons..."
+
+#: id:319
+msgid "Error cleaning songs"
+msgstr "S'ha produït un error netejant les cançons"
+
+#: id:320
+msgid "Cleaning artists..."
+msgstr "S'estan netejant els artistes..."
+
+#: id:321
+msgid "Error cleaning artists"
+msgstr "S'ha produït un error esborrant els artistes"
+
+#: id:322
+msgid "Cleaning genres..."
+msgstr "S'estan netejant els gèneres..."
+
+#: id:323
+msgid "Error cleaning genres"
+msgstr "S'ha produït un error netejant els gèneres"
+
+#: id:324
+msgid "Cleaning paths..."
+msgstr "S'estan netejant els directoris..."
+
+#: id:325
+msgid "Error cleaning paths"
+msgstr "S'ha produït un error netejant els camins"
+
+#: id:326
+msgid "Cleaning albums..."
+msgstr "S'estan netejant els àlbums..."
+
+#: id:327
+msgid "Error cleaning albums"
+msgstr "S'ha produït un error netejant els àlbums"
+
+#: id:328
+msgid "Writing changes..."
+msgstr "S'estan escrivint els canvis..."
+
+#: id:329
+msgid "Error writing changes"
+msgstr "S'ha produït un error escrivint els canvis"
+
+#: id:330
+msgid "This may take some time..."
+msgstr "Es possible que trigui una estona..."
+
+#: id:331
+msgid "Compressing database..."
+msgstr "S'està comprimint la base de dades..."
+
+#: id:332
+msgid "Error compressing database"
+msgstr "S'ha produït un error comprimint la base de dades"
+
+#: id:333
+msgid "Do you want to clean the library?"
+msgstr "Voleu netejar la biblioteca?"
+
+#: id:334
+msgid "Clean library..."
+msgstr "Neteja la biblioteca..."
+
+#: id:335
+msgid "Start"
+msgstr "Inicia"
+
+#: id:336
+msgid "Framerate conversion"
+msgstr "Conversió de les imatges per segon"
+
+#: id:337
+msgctxt "Auto context with id 337"
+msgid "Audio output"
+msgstr "Sortida d'àudio"
+
+#: id:338
+msgid "Analog"
+msgstr "Analògic"
+
+#: id:339
+msgid "Optical/Coax"
+msgstr "Òptica/Coaxial"
+
+#: id:340
+msgid "Various artists"
+msgstr "Diversos artistes"
+
+#: id:341
+msgid "Play disc"
+msgstr "Reprodueix el disc"
+
+#: id:342
+msgctxt "Auto context with id 342"
+msgid "Movies"
+msgstr "Pel·lícules"
+
+#: id:343
+msgid "Adjust framerate"
+msgstr "Ajusteu les imatges per segon"
+
+#: id:344
+msgid "Actors"
+msgstr "Actors"
+
+#: id:345
+msgctxt "Auto context with id 345"
+msgid "Year"
+msgstr "Any"
+
+#: id:346
+msgid "Boost volume level on downmix"
+msgstr "Augmenta el volum al fer un downmix"
+
+#: id:350
+msgctxt "Auto context with id 350"
+msgid "Programs"
+msgstr "Programes"
+
+#: id:351
+msgctxt "Auto context with id 351"
+msgid "Off"
+msgstr "Inactiu"
+
+#: id:352
+msgid "Dim"
+msgstr "Atenua"
+
+#: id:353
+msgid "Black"
+msgstr "Negre"
+
+#: id:354
+msgid "Matrix trails"
+msgstr "Matrix trails"
+
+#: id:355
+msgid "Screensaver time"
+msgstr "Temps per al salvapantalles"
+
+#: id:356
+msgid "Screensaver mode"
+msgstr "Mode de l'estalvi de pantalla"
+
+#: id:357
+msgid "Shutdown function timer"
+msgstr "Shutdown function timer"
+
+#: id:358
+msgid "All albums"
+msgstr "Tots els àlbums"
+
+#: id:359
+msgid "Recently added albums"
+msgstr "Àlbums afegits recentment"
+
+#: id:360
+msgctxt "Auto context with id 360"
+msgid "Screensaver"
+msgstr "Estalvi de pantalla"
+
+#: id:361
+msgid "R. Slideshow"
+msgstr "R. Slideshow"
+
+#: id:362
+msgid "Screensaver dim level"
+msgstr "Nivell d'atenuació de l'estalvi de pantalla"
+
+#: id:363
+msgid "Sort by: File"
+msgstr "Ordena per: Fitxer"
+
+#: id:364
+msgid "- Dolby Digital (AC3) capable receiver"
+msgstr "- Receptor compatible amb Dolby Digital (AC3)"
+
+#: id:365
+msgctxt "Auto context with id 365"
+msgid "Sort by: Name"
+msgstr "Ordena per: Nom"
+
+#: id:366
+msgid "Sort by: Year"
+msgstr "Ordena per: Any"
+
+#: id:367
+msgid "Sort by: Rating"
+msgstr "Ordena per: Valoració"
+
+#: id:368
+msgid "IMDb"
+msgstr "IMDb"
+
+#: id:369
+msgctxt "Auto context with id 369"
+msgid "Title"
+msgstr "Títol"
+
+#: id:370
+msgid "Thunderstorms"
+msgstr "Tempestes"
+
+#: id:371
+msgid "Partly"
+msgstr "Parcialment"
+
+#: id:372
+msgid "Mostly"
+msgstr "Principalment"
+
+#: id:373
+msgid "Sunny"
+msgstr "Assolellat"
+
+#: id:374
+msgid "Cloudy"
+msgstr "Ennuvolat"
+
+#: id:375
+msgid "Snow"
+msgstr "Neu"
+
+#: id:376
+msgid "Rain"
+msgstr "Pluja"
+
+#: id:377
+msgid "Light"
+msgstr "Clar"
+
+#: id:378
+msgid "AM"
+msgstr "AM"
+
+#: id:379
+msgid "PM"
+msgstr "PM"
+
+#: id:380
+msgid "Showers"
+msgstr "Pluges"
+
+#: id:381
+msgid "Few"
+msgstr "Poc"
+
+#: id:382
+msgid "Scattered"
+msgstr "Dispersos"
+
+#: id:383
+msgctxt "Auto context with id 383"
+msgid "Wind"
+msgstr "Vent"
+
+#: id:384
+msgid "Strong"
+msgstr "Fort"
+
+#: id:385
+msgid "Fair"
+msgstr "Serè"
+
+#: id:386
+msgctxt "Auto context with id 386"
+msgid "Clear"
+msgstr "Clar"
+
+#: id:387
+msgid "Clouds"
+msgstr "Núvols"
+
+#: id:388
+msgid "Early"
+msgstr "d'hora"
+
+#: id:389
+msgid "Shower"
+msgstr "Ruixat"
+
+#: id:390
+msgid "Flurries"
+msgstr "Ruixats"
+
+#: id:391
+msgctxt "Auto context with id 391"
+msgid "Low"
+msgstr "Baix"
+
+#: id:392
+msgctxt "Auto context with id 392"
+msgid "Medium"
+msgstr "Mitjà"
+
+#: id:393
+msgctxt "Auto context with id 393"
+msgid "High"
+msgstr "Alt"
+
+#: id:394
+msgid "Fog"
+msgstr "Boira"
+
+#: id:395
+msgid "Haze"
+msgstr "Boirina"
+
+#: id:396
+msgid "Select location"
+msgstr "Seleccioneu un lloc"
+
+#: id:397
+msgid "Refresh time"
+msgstr "Temps d'actualització"
+
+#: id:398
+msgid "Temperature units"
+msgstr "Unitats de temperatura"
+
+#: id:399
+msgid "Speed units"
+msgstr "Unitats de velocitat"
+
+#: id:400
+msgctxt "Auto context with id 400"
+msgid "Weather"
+msgstr "El temps"
+
+#: id:401
+msgid "Temp"
+msgstr "Temperatura"
+
+#: id:402
+msgid "Feels like"
+msgstr "Sen. tèrmica"
+
+#: id:403
+msgid "UV index"
+msgstr "Índex UV"
+
+#: id:404
+msgctxt "Auto context with id 404"
+msgid "Wind"
+msgstr "Vent"
+
+#: id:405
+msgid "Dew point"
+msgstr "Rosada"
+
+#: id:406
+msgid "Humidity"
+msgstr "Humitat"
+
+#: id:409
+msgid "Defaults"
+msgstr "Per defecte"
+
+#: id:410
+msgid "Accessing weather service"
+msgstr "S'està accedint al servei meteorològic"
+
+#: id:411
+msgid "Getting weather for:"
+msgstr "S'està obtenint el temps per:"
+
+#: id:412
+msgid "Unable to get weather data"
+msgstr "No es poden obtenir les dades meteorològiques"
+
+#: id:413
+msgid "Manual"
+msgstr "Manual"
+
+#: id:414
+msgid "No review for this album"
+msgstr "No hi ha ressenya per aquest àlbum"
+
+#: id:415
+msgid "Downloading thumbnail..."
+msgstr "S'està baixant la miniatura..."
+
+#: id:416
+msgid "Not available"
+msgstr "No disponible"
+
+#: id:417
+msgid "View: Big icons"
+msgstr "Vista: Icones grans"
+
+#: id:418
+msgctxt "Auto context with id 418"
+msgid "Low"
+msgstr "Mín"
+
+#: id:419
+msgctxt "Auto context with id 419"
+msgid "High"
+msgstr "Màx"
+
+#: id:420
+msgid "HDMI"
+msgstr "HDMI"
+
+#: id:422
+msgid "Delete album info"
+msgstr "Esborra la informació de l'àlbum"
+
+#: id:423
+msgid "Delete CD information"
+msgstr "Esborra la informació del CD"
+
+#: id:424
+msgid "Select"
+msgstr "Seleccioneu"
+
+#: id:425
+msgid "No album information found"
+msgstr "No s'ha trobat la informació de l'àlbum."
+
+#: id:426
+msgid "No CD information found"
+msgstr "No s'ha trobat la informació del CD."
+
+#: id:427
+msgid "Disc"
+msgstr "Disc"
+
+#: id:428
+msgid "Insert correct CD/DVD"
+msgstr "Inseriu un CD/DVD vàlid"
+
+#: id:429
+msgid "Please insert the following disc:"
+msgstr "Inseriu el següent disc"
+
+#: id:430
+msgid "Sort by: DVD#"
+msgstr "Ordena per: DVD#"
+
+#: id:431
+msgid "No cache"
+msgstr "Sense memòria cau"
+
+#: id:432
+msgid "Remove movie from library"
+msgstr "Elimina la pel·lícula de la biblioteca"
+
+#: id:433
+msgid "Really remove '%s'?"
+msgstr "Esteu segur que voleu eliminar '%s'?"
+
+#: id:434
+msgid "From %s at %i %s"
+msgstr "De %s a %i %s"
+
+#: id:437
+msgid "Removable disk"
+msgstr "Disc extraïble"
+
+#: id:438
+msgid "Opening file"
+msgstr "S'està obrint el fitxer"
+
+#: id:439
+msgid "Cache"
+msgstr "Memòria cau"
+
+#: id:440
+msgid "Harddisk"
+msgstr "Disc dur"
+
+#: id:441
+msgid "UDF"
+msgstr "UDF"
+
+#: id:442
+msgid "Local network"
+msgstr "Xarxa local"
+
+#: id:443
+msgid "Internet"
+msgstr "Internet"
+
+#: id:444
+msgctxt "Auto context with id 444"
+msgid "Video"
+msgstr "Vídeo"
+
+#: id:445
+msgctxt "Auto context with id 445"
+msgid "Audio"
+msgstr "Àudio"
+
+#: id:446
+msgctxt "Auto context with id 446"
+msgid "DVD"
+msgstr "DVD"
+
+#: id:447
+msgid "Autorun media"
+msgstr "Executa automàticament els suports"
+
+#: id:448
+msgid "LCD"
+msgstr "LCD"
+
+#: id:449
+msgctxt "Auto context with id 449"
+msgid "Enabled"
+msgstr "Activat"
+
+#: id:450
+msgid "Columns"
+msgstr "Columnes"
+
+#: id:451
+msgid "Row 1 address"
+msgstr "Adreça fila 1"
+
+#: id:452
+msgid "Row 2 address"
+msgstr "Adreça fila 2"
+
+#: id:453
+msgid "Row 3 address"
+msgstr "Adreça fila 3"
+
+#: id:454
+msgid "Row 4 address"
+msgstr "Adreça fila 4"
+
+#: id:455
+msgid "Rows"
+msgstr "Fitxers"
+
+#: id:456
+msgid "Mode"
+msgstr "Mode"
+
+#: id:457
+msgid "Switch view"
+msgstr "Canviar vista"
+
+#: id:459
+msgid "Subs"
+msgstr "Subtítols"
+
+#: id:460
+msgid "Audio stream"
+msgstr "Flux d'àudio"
+
+#: id:461
+msgid "[active]"
+msgstr "[actiu]"
+
+#: id:462
+msgid "Subtitle"
+msgstr "Subtítol"
+
+#: id:463
+msgid "Backlight"
+msgstr "Retroil·luminació"
+
+#: id:464
+msgid "Brightness"
+msgstr "Brillantor"
+
+#: id:465
+msgid "Contrast"
+msgstr "Contrast"
+
+#: id:466
+msgid "Gamma"
+msgstr "Gamma"
+
+#: id:467
+msgctxt "Auto context with id 467"
+msgid "Type"
+msgstr "Tipus"
+
+#: id:468
+msgid "Move the bar to change the OSD position"
+msgstr "Moveu la barra per a canviar la posició del OSD"
+
+#: id:469
+msgid "OSD position"
+msgstr "Posició de l'OSD"
+
+#: id:470
+msgid "Credits"
+msgstr "Crèdits"
+
+#: id:471
+msgid "Modchip"
+msgstr "Modchip"
+
+#: id:474
+msgctxt "Auto context with id 474"
+msgid "Off"
+msgstr "Inactiu"
+
+#: id:475
+msgid "Music only"
+msgstr "Només música"
+
+#: id:476
+msgctxt "Auto context with id 476"
+msgid "Music & video"
+msgstr "Música i vídeo"
+
+#: id:477
+msgid "Unable to load playlist"
+msgstr "No es pot carregar la llista de reproducció"
+
+#: id:478
+msgid "OSD"
+msgstr "OSD"
+
+#: id:479
+msgid "Skin & language"
+msgstr "Aparença i idioma"
+
+#: id:480
+msgid "Appearance"
+msgstr "Aparença"
+
+#: id:481
+msgid "Audio options"
+msgstr "Opcions d'àudio"
+
+#: id:482
+msgid "About XBMC"
+msgstr "Quant a XBMC"
+
+#: id:485
+msgid "Delete album"
+msgstr "Elimina l'àlbum"
+
+#: id:486
+msgid "Repeat"
+msgstr "Repeteix"
+
+#: id:487
+msgid "Repeat one"
+msgstr "Repeteix una"
+
+#: id:488
+msgid "Repeat folder"
+msgstr "Repeteix la carpeta"
+
+#: id:489
+msgid "Play the next song automatically"
+msgstr "Reprodueix la cançó següent de forma automàtica"
+
+#: id:491
+msgid "- Use big icons"
+msgstr "- Utilitza icones grans"
+
+#: id:492
+msgid "Resize VobSubs"
+msgstr "Redimensiona els subtítols VOB"
+
+#: id:493
+msgid "Advanced options (Experts Only!)"
+msgstr "Opcions avançades (Només experts!)"
+
+#: id:494
+msgid "Overall audio headroom"
+msgstr "Overall audio headroom"
+
+#: id:495
+msgid "Upsample videos to GUI resolution"
+msgstr "Reescala els vídeos a la resolució de l'entorn (GUI)"
+
+#: id:496
+msgid "Calibration"
+msgstr "Calibratge"
+
+#: id:497
+msgid "Show file extensions"
+msgstr "Mostra les extensions de fitxer"
+
+#: id:498
+msgid "Sort by: Type"
+msgstr "Ordena per: Tipus"
+
+#: id:499
+msgid "Unable to connect to online lookup service"
+msgstr "No es pot connectar al servei de cerca en línia"
+
+#: id:500
+msgid "Downloading album information failed"
+msgstr "Descarrega de la informació de l'àlbum fallida"
+
+#: id:501
+msgid "Looking for album names..."
+msgstr "S'està cercant el nom dels àlbums..."
+
+#: id:502
+msgctxt "Auto context with id 502"
+msgid "Open"
+msgstr "Obre"
+
+#: id:503
+msgid "Busy"
+msgstr "Ocupat"
+
+#: id:504
+msgid "Empty"
+msgstr "Buit"
+
+#: id:505
+msgid "Loading media info from files..."
+msgstr "S'està carregant la informació multimèdia des de els fitxers"
+
+#: id:507
+msgid "Sort by: Usage"
+msgstr "Ordena per: Ús"
+
+#: id:510
+msgid "Enable visualizations"
+msgstr "Activa les visualitzacions"
+
+#: id:511
+msgid "Enable video mode switching"
+msgstr "Activa el canvi de mode de vídeo"
+
+#: id:512
+msgid "Startup window"
+msgstr "Pantalla d'inici"
+
+#: id:513
+msgid "Home window"
+msgstr "Pantalla principal"
+
+#: id:514
+msgid "Manual settings"
+msgstr "Manual de configuració"
+
+#: id:515
+msgid "Genre"
+msgstr "Gènere"
+
+#: id:517
+msgid "Recently played albums"
+msgstr "Àlbums reproduïts recentment"
+
+#: id:518
+msgid "Launch"
+msgstr "Executa"
+
+#: id:519
+msgid "Launch in..."
+msgstr "Executa en..."
+
+#: id:521
+msgid "Compilations"
+msgstr "Recopilacions"
+
+#: id:522
+msgid "Remove source"
+msgstr "Elimina la font"
+
+#: id:523
+msgid "Switch media"
+msgstr "Canvia el suport"
+
+#: id:524
+msgid "Select playlist"
+msgstr "Seleccioneu la llista de reproducció"
+
+#: id:525
+msgid "New playlist..."
+msgstr "Nova llista de reproducció..."
+
+#: id:526
+msgid "Add to playlist"
+msgstr "Afegeix a la llista de reproducció"
+
+#: id:527
+msgid "Manually add to library"
+msgstr "Afegeix manualment a la biblioteca"
+
+#: id:528
+msgid "Enter title"
+msgstr "Inseriu el títol"
+
+#: id:529
+msgid "Error: Duplicate title"
+msgstr "Error: títol duplicat"
+
+#: id:530
+msgid "Select genre"
+msgstr "Seleccioneu gènere"
+
+#: id:531
+msgid "New genre"
+msgstr "Nou gènere"
+
+#: id:532
+msgid "Manual addition"
+msgstr "Addició manual"
+
+#: id:533
+msgid "Enter genre"
+msgstr "Inseriu el gènere"
+
+#: id:534
+msgid "View: %s"
+msgstr "Vista: %s"
+
+#: id:535
+msgid "List"
+msgstr "Llista"
+
+#: id:536
+msgid "Icons"
+msgstr "Icones"
+
+#: id:537
+msgid "Big list"
+msgstr "Llista gran"
+
+#: id:538
+msgid "Big icons"
+msgstr "Icones grans"
+
+#: id:539
+msgid "Wide"
+msgstr "Ample"
+
+#: id:540
+msgid "Big wide"
+msgstr "Ample gran"
+
+#: id:541
+msgid "Album icons"
+msgstr "Icones d'àlbum"
+
+#: id:542
+msgid "DVD icons"
+msgstr "Icones de DVD"
+
+#: id:543
+msgctxt "Auto context with id 543"
+msgid "DVD"
+msgstr "DVD"
+
+#: id:544
+msgctxt "Auto context with id 544"
+msgid "Media info"
+msgstr "Informació del suport"
+
+#: id:545
+msgid "Audio output device"
+msgstr "Dispositiu de sortida d'àudio"
+
+#: id:546
+msgid "Passthrough output device"
+msgstr "Passthrough output device"
+
+#: id:547
+msgid "No biography for this artist"
+msgstr "No hi ha biografia d'aquest artista"
+
+#: id:548
+msgid "Downmix multichannel audio to stereo"
+msgstr "Mescla l'àudio multicanal a estèreo"
+
+#: id:550
+msgid "Sort by: %s"
+msgstr "Ordena per: %s"
+
+#: id:551
+msgctxt "Auto context with id 551"
+msgid "Name"
+msgstr "Nom"
+
+#: id:552
+msgid "Date"
+msgstr "Data"
+
+#: id:553
+msgid "Size"
+msgstr "Mida"
+
+#: id:554
+msgid "Track"
+msgstr "Pista"
+
+#: id:555
+msgid "Time"
+msgstr "Temps"
+
+#: id:556
+msgctxt "Auto context with id 556"
+msgid "Title"
+msgstr "Títol"
+
+#: id:557
+msgid "Artist"
+msgstr "Artista"
+
+#: id:558
+msgid "Album"
+msgstr "Àlbum"
+
+#: id:559
+msgid "Playlist"
+msgstr "Llista de reproducció"
+
+#: id:560
+msgid "ID"
+msgstr "ID"
+
+#: id:561
+msgctxt "Auto context with id 561"
+msgid "File"
+msgstr "Arxiu"
+
+#: id:562
+msgctxt "Auto context with id 562"
+msgid "Year"
+msgstr "Any"
+
+#: id:563
+msgid "Rating"
+msgstr "Valoració"
+
+#: id:564
+msgctxt "Auto context with id 564"
+msgid "Type"
+msgstr "Tipus"
+
+#: id:565
+msgid "Usage"
+msgstr "Ús"
+
+#: id:566
+msgid "Album artist"
+msgstr "Artista de l'àlbum"
+
+#: id:567
+msgid "Play count"
+msgstr "Núm. reproduccions"
+
+#: id:568
+msgid "Last played"
+msgstr "Darrera reproducció"
+
+#: id:569
+msgctxt "Auto context with id 569"
+msgid "Comment"
+msgstr "Comentari"
+
+#: id:570
+msgid "Date added"
+msgstr "Data d'addició"
+
+#: id:571
+msgctxt "Auto context with id 571"
+msgid "Default"
+msgstr "Per defecte"
+
+#: id:572
+msgid "Studio"
+msgstr "Estudi"
+
+#: id:573
+msgid "Path"
+msgstr "Camí"
+
+#: id:574
+msgctxt "Auto context with id 574"
+msgid "Country"
+msgstr "País"
+
+#: id:575
+msgid "In progress"
+msgstr "En curs"
+
+#: id:576
+msgid "Times played"
+msgstr "Times played"
+
+#: id:580
+msgid "Sort direction"
+msgstr "Direcció d'ordenació"
+
+#: id:581
+msgid "Sort method"
+msgstr "Mètode d'ordenació"
+
+#: id:582
+msgctxt "Auto context with id 582"
+msgid "View mode"
+msgstr "Mode de visualització"
+
+#: id:583
+msgid "Remember views for different folders"
+msgstr "Recorda les vistes per les diferents carpetes"
+
+#: id:584
+msgid "Ascending"
+msgstr "Ascendent"
+
+#: id:585
+msgid "Descending"
+msgstr "Descendent"
+
+#: id:586
+msgid "Edit playlist"
+msgstr "Edita la llista de reproducció"
+
+#: id:587
+msgid "Filter"
+msgstr "Filtre"
+
+#: id:588
+msgid "Cancel party mode"
+msgstr "Cancel·la el mode festa"
+
+#: id:589
+msgid "Party mode"
+msgstr "Mode de festa"
+
+#: id:590
+msgid "Random"
+msgstr "Aleatori"
+
+#: id:591
+msgctxt "Auto context with id 591"
+msgid "Off"
+msgstr "Inactiu"
+
+#: id:592
+msgid "One"
+msgstr "Una"
+
+#: id:593
+msgid "All"
+msgstr "Totes"
+
+#: id:594
+msgctxt "Auto context with id 594"
+msgid "Off"
+msgstr "Inactiu"
+
+#: id:595
+msgid "Repeat: Off"
+msgstr "Repetir: Inactiu"
+
+#: id:596
+msgid "Repeat: One"
+msgstr "Repetir: Una"
+
+#: id:597
+msgid "Repeat: All"
+msgstr "Repetir: Totes"
+
+#: id:600
+msgid "Rip audio CD"
+msgstr "Extreu el CD d'àudio"
+
+#: id:601
+msgctxt "Auto context with id 601"
+msgid "Medium"
+msgstr "Mitjà"
+
+#: id:602
+msgctxt "Auto context with id 602"
+msgid "Standard"
+msgstr "Estàndard"
+
+#: id:603
+msgid "Extreme"
+msgstr "Extrem"
+
+#: id:604
+msgid "Constant bitrate"
+msgstr "Taxa de bits constant"
+
+#: id:605
+msgid "Ripping..."
+msgstr "S'està extraient..."
+
+#: id:607
+msgid "To:"
+msgstr "A:"
+
+#: id:608
+msgid "Could not rip CD or track"
+msgstr "No es pot extreure el CD o la pista"
+
+#: id:609
+msgid "CDDARipPath is not set."
+msgstr "CDDARipPath no està definit."
+
+#: id:610
+msgid "Rip audio track"
+msgstr "Extreu la pista d'àudio"
+
+#: id:611
+msgid "Enter number"
+msgstr "Introduïu el número"
+
+#: id:612
+msgid "Bits/Sample"
+msgstr "Bits/Mostra"
+
+#: id:613
+msgid "Sample Frequency"
+msgstr "Freqüència de mostreig"
+
+#: id:620
+msgid "Audio CDs"
+msgstr "Els CD d'àudio"
+
+#: id:621
+msgid "Encoder"
+msgstr "Codificador"
+
+#: id:622
+msgid "Quality"
+msgstr "Qualitat"
+
+#: id:623
+msgid "Bitrate"
+msgstr "Taxa de bits"
+
+#: id:624
+msgid "Include track number"
+msgstr "Inclou el número de pista"
+
+#: id:625
+msgid "All songs of"
+msgstr "Totes les cançons de"
+
+#: id:629
+msgctxt "Auto context with id 629"
+msgid "View mode"
+msgstr "Mode de visualització"
+
+#: id:630
+msgctxt "Auto context with id 630"
+msgid "Normal"
+msgstr "Normal"
+
+#: id:631
+msgid "Zoom"
+msgstr "Zoom"
+
+#: id:632
+msgid "Stretch 4:3"
+msgstr "Adaptar a 4:3"
+
+#: id:633
+msgid "Wide Zoom"
+msgstr "Zoom angular"
+
+#: id:634
+msgid "Stretch 16:9"
+msgstr "Adaptar a 16:9"
+
+#: id:635
+msgid "Original Size"
+msgstr "Mida original"
+
+#: id:636
+msgctxt "Auto context with id 636"
+msgid "Custom"
+msgstr "Personalitzat"
+
+#: id:637
+msgid "Replay gain"
+msgstr "Replay gain"
+
+#: id:638
+msgid "Replaygain volume adjustments"
+msgstr "Replaygain volume adjustments"
+
+#: id:639
+msgid "Use track levels"
+msgstr "Utilitza el volum de la pista"
+
+#: id:640
+msgid "Use album levels"
+msgstr "Utilitza el volum de l'àlbum"
+
+#: id:641
+msgid "PreAmp Level - Replay gained files"
+msgstr "Nivell del preamplificador - Replay gained files"
+
+#: id:642
+msgid "PreAmp Level - Non replay gained files"
+msgstr "Nivell del preamplificador - Non replay gained files"
+
+#: id:643
+msgid "Avoid clipping on replay gained files"
+msgstr "Avoid clipping on replay gained files"
+
+#: id:644
+msgid "Crop black bars"
+msgstr "Elimina les vores negres"
+
+#: id:645
+msgid "Need to unpack a big file. Continue?"
+msgstr "Es necessita descomprimir un fitxer gran. Voleu continuar?"
+
+#: id:646
+msgid "Remove from library"
+msgstr "Elimina de la biblioteca"
+
+#: id:647
+msgid "Export video library"
+msgstr "Exporta la biblioteca de vídeo"
+
+#: id:648
+msgid "Import video library"
+msgstr "Importa la biblioteca de vídeo"
+
+#: id:649
+msgid "Importing"
+msgstr "S'està important"
+
+#: id:650
+msgid "Exporting"
+msgstr "S'està exportant"
+
+#: id:651
+msgid "Browse for library"
+msgstr "Cerca la biblioteca"
+
+#: id:652
+msgid "Years"
+msgstr "Anys"
+
+#: id:653
+msgid "Update library"
+msgstr "Actualitza la biblioteca"
+
+#: id:654
+msgid "Show debug info"
+msgstr "Mostra la informació de depuració"
+
+#: id:655
+msgid "Browse for executable"
+msgstr "Cerca l'executable"
+
+#: id:656
+msgid "Browse for playlist"
+msgstr "Cerca la llista de reproducció"
+
+#: id:657
+msgid "Browse for folder"
+msgstr "Cerca la carpeta"
+
+#: id:658
+msgid "Song information"
+msgstr "Informació de la cançó"
+
+#: id:659
+msgid "Non-linear stretch"
+msgstr "Estirament no lineal"
+
+#: id:660
+msgid "Volume amplification"
+msgstr "Amplificació del volum"
+
+#: id:661
+msgid "Choose export folder"
+msgstr "Seleccioneu la carpeta d'exportació"
+
+#: id:662
+msgid "This file is no longer available."
+msgstr "Aquest fitxer ja no està disponible."
+
+#: id:663
+msgid "Would you like to remove it from the library?"
+msgstr "Voleu eliminar-lo de la biblioteca?"
+
+#: id:664
+msgid "Browse for Script"
+msgstr "Cerca l'script"
+
+#: id:665
+msgid "Compression level"
+msgstr "Nivell de compressió"
+
+#: id:700
+msgid "Cleaning up library"
+msgstr "S'està netejant la biblioteca"
+
+#: id:701
+msgid "Removing old songs from the library"
+msgstr "S'estan eliminant les cançons velles de la biblioteca"
+
+#: id:702
+msgid "This path has been scanned before"
+msgstr "Aquest camí ja ha estat explorat."
+
+#: id:705
+msgctxt "Auto context with id 705"
+msgid "Network"
+msgstr "Xarxa"
+
+#: id:706
+msgid "- Server"
+msgstr "- Servidor"
+
+#: id:708
+msgid "Use an HTTP proxy server to access the internet"
+msgstr "Utilitza un servidor proxy HTTP per accedir a internet"
+
+#: id:711
+msgid "Internet Protocol (IP)"
+msgstr "Protocol d'Internet (IP)"
+
+#: id:712
+msgid "Invalid port specified. Value must be between 1 and 65535."
+msgstr "El port especificat no és vàlid. El valor ha d'estar entre 1 i 65535."
+
+#: id:713
+msgid "HTTP proxy"
+msgstr "Proxy HTTP"
+
+#: id:715
+msgid "- Assignment"
+msgstr "- Assignació"
+
+#: id:716
+msgid "Automatic (DHCP)"
+msgstr "Automàtica (DHCP)"
+
+#: id:717
+msgid "Manual (Static)"
+msgstr "Manual (Estàtica)"
+
+#: id:719
+msgid "- IP address"
+msgstr "- Adreça IP"
+
+#: id:720
+msgid "- Netmask"
+msgstr "- Màscara de xarxa"
+
+#: id:721
+msgid "- Default gateway"
+msgstr "- Porta d'enllaç per defecte"
+
+#: id:722
+msgid "- DNS server"
+msgstr "- Servidor DNS"
+
+#: id:723
+msgid "Save & restart"
+msgstr "Desa i reinicia"
+
+#: id:724
+msgid "Invalid address specified. Value must be AAA.BBB.CCC.DDD"
+msgstr "La direcció especificada no és vàlida. El valor ha de ser AAA.BBB.CCC.DDD"
+
+#: id:725
+msgid "with numbers between 0 and 255."
+msgstr "amb números entre 0 i 255."
+
+#: id:726
+msgid "Changes not saved. Continue without saving?"
+msgstr "Els canvis no s'han desat. Voleu continuar sense desar-los?"
+
+#: id:727
+msgid "Web server"
+msgstr "Servidor Web"
+
+#: id:728
+msgctxt "Auto context with id 728"
+msgid "FTP server"
+msgstr "Servidor FTP"
+
+#: id:730
+msgid "- Port"
+msgstr "- Port"
+
+#: id:732
+msgid "Save & apply"
+msgstr "Desa i aplica"
+
+#: id:733
+msgid "- Password"
+msgstr "- Contrasenya"
+
+#: id:734
+msgid "No pass"
+msgstr "Sense contrasenya"
+
+#: id:735
+msgid "- Character set"
+msgstr "- Joc de caràcters"
+
+#: id:736
+msgid "- Style"
+msgstr "- Estil"
+
+#: id:737
+msgid "- Colour"
+msgstr "- Color"
+
+#: id:738
+msgctxt "Auto context with id 738"
+msgid "Normal"
+msgstr "Normal"
+
+#: id:739
+msgid "Bold"
+msgstr "Negreta"
+
+#: id:740
+msgid "Italics"
+msgstr "Cursiva"
+
+#: id:741
+msgid "Bold italics"
+msgstr "Negreta Cursiva"
+
+#: id:742
+msgctxt "Auto context with id 742"
+msgid "White"
+msgstr "Blanc"
+
+#: id:743
+msgctxt "Auto context with id 743"
+msgid "Yellow"
+msgstr "Groc"
+
+#: id:744
+msgctxt "Auto context with id 744"
+msgid "Files"
+msgstr "Arxius"
+
+#: id:745
+msgid "No scanned information for this view"
+msgstr "No hi ha informació per aquesta vista"
+
+#: id:746
+msgid "Please turn off library mode"
+msgstr "Desactiveu el mode biblioteca"
+
+#: id:747
+msgid "Error loading image"
+msgstr "S'ha produït un error al carregar la imatge"
+
+#: id:748
+msgid "Edit path"
+msgstr "Edita el camí"
+
+#: id:749
+msgid "Mirror image"
+msgstr "Imatge del mirall"
+
+#: id:750
+msgid "Are you sure?"
+msgstr "Esteu segur?"
+
+#: id:751
+msgid "Removing source"
+msgstr "S'està eliminant la font"
+
+#: id:754
+msgid "Add program link"
+msgstr "Afegeix un enllaç del programa"
+
+#: id:755
+msgid "Edit program path"
+msgstr "Edita el camí del programa"
+
+#: id:756
+msgid "Edit program name"
+msgstr "Edita el nom del programa"
+
+#: id:757
+msgid "Edit path depth"
+msgstr "Edita la profunditat del camí"
+
+#: id:759
+msgid "View: Big list"
+msgstr "Vista: Llista gran"
+
+#: id:760
+msgctxt "Auto context with id 760"
+msgid "Yellow"
+msgstr "Groc"
+
+#: id:761
+msgctxt "Auto context with id 761"
+msgid "White"
+msgstr "Blanc"
+
+#: id:762
+msgid "Blue"
+msgstr "Blau"
+
+#: id:763
+msgid "Bright green"
+msgstr "Verd brillant"
+
+#: id:764
+msgid "Yellow green"
+msgstr "Groc verd"
+
+#: id:765
+msgid "Cyan"
+msgstr "Cian"
+
+#: id:766
+msgid "Light grey"
+msgstr "Gris clar"
+
+#: id:767
+msgid "Grey"
+msgstr "Gris"
+
+#: id:770
+msgid "Error %i: share not available"
+msgstr "Error %i: recurs compartit no disponible"
+
+#: id:772
+msgctxt "Auto context with id 772"
+msgid "Audio output"
+msgstr "Sortida d'àudio"
+
+#: id:773
+msgid "Seeking"
+msgstr "S'està cercant"
+
+#: id:774
+msgid "Slideshow folder"
+msgstr "Carpeta de les diapositives"
+
+#: id:775
+msgid "Network interface"
+msgstr "Interfície de xarxa"
+
+#: id:776
+msgid "- Wireless network name (ESSID)"
+msgstr "- Nom de la xarxa sense fils (ESSID)"
+
+#: id:777
+msgid "- Wireless password"
+msgstr "- Contrasenya de la xarxa sense fils"
+
+#: id:778
+msgid "- Wireless security"
+msgstr "- Seguretat de la xarxa sense fils"
+
+#: id:779
+msgid "Save and apply network interface settings"
+msgstr "Desa i aplica la configuració de la interfície de xarxa"
+
+#: id:780
+msgid "No encryption"
+msgstr "Sense xifrat"
+
+#: id:781
+msgid "WEP"
+msgstr "WEP"
+
+#: id:782
+msgid "WPA"
+msgstr "WPA"
+
+#: id:783
+msgid "WPA2"
+msgstr "WPA2"
+
+#: id:784
+msgid "Applying network interface settings. Please wait."
+msgstr "S'està aplicant la configuració de la interfície de xarxa. Si us plau, espereu."
+
+#: id:785
+msgid "Network interface restarted successfully."
+msgstr "La interfície de xarxa s'ha reiniciat correctament."
+
+#: id:786
+msgid "Network interface did not start successfully."
+msgstr "La interfície de xarxa no s'ha iniciar correctament."
+
+#: id:787
+msgid "Interface disabled"
+msgstr "Interfície desactivada"
+
+#: id:788
+msgid "Network interface disabled successfully."
+msgstr "La interfície de xarxa s'ha desactivat correctament."
+
+#: id:789
+msgid "Wireless network name (ESSID)"
+msgstr "Nom de la xarxa sense fils (ESSID)"
+
+#: id:790
+msgid "Remote control"
+msgstr ""
+
+#: id:791
+msgid "Allow programs on this system to control XBMC"
+msgstr "Permet que els programes d'aquest equip controlin l'XBMC"
+
+#: id:792
+msgctxt "Auto context with id 792"
+msgid "Port"
+msgstr "Port"
+
+#: id:793
+msgid "Port range"
+msgstr "Rang de ports"
+
+#: id:794
+msgid "Allow programs on other systems to control XBMC"
+msgstr "Permet que els programes d'altres equips controlin l'XBMC"
+
+#: id:795
+msgid "Initial repeat delay (ms)"
+msgstr "Retard de repetició inicial (ms)"
+
+#: id:796
+msgid "Continuous repeat delay (ms)"
+msgstr "Retard de repetició continu (ms)"
+
+#: id:797
+msgid "Maximum number of clients"
+msgstr "Número màxim de clients"
+
+#: id:798
+msgid "Internet access"
+msgstr "Accés a internet"
+
+#: id:850
+msgid "Invalid port number entered"
+msgstr "El número de port introduït no és vàlid"
+
+#: id:851
+msgid "Valid port range is 1-65535"
+msgstr "El rang de ports vàlid és 1-65535"
+
+#: id:852
+msgid "Valid port range is 1024-65535"
+msgstr "El rang de ports vàlid és 1024-65535"
+
+#: id:998
+msgid "Add Music..."
+msgstr "Afegeix música..."
+
+#: id:999
+msgid "Add Videos..."
+msgstr "Afegeix vídeos..."
+
+#: id:1000
+msgid "- Preview"
+msgstr "- Previsualització"
+
+#: id:1001
+msgid "Unable to connect"
+msgstr "No es pot connectar"
+
+#: id:1002
+msgid "XBMC was unable to connect to the network location."
+msgstr "L'XBMC no ha pogut connectar amb la ubicació de xarxa."
+
+#: id:1003
+msgid "This could be due to the network not being connected."
+msgstr "Podria ser degut a que la xarxa no estigui connectada."
+
+#: id:1004
+msgid "Would you like to add it anyway?"
+msgstr "Voleu afegir-lo de totes maneres?"
+
+#: id:1006
+msgctxt "Auto context with id 1006"
+msgid "IP address"
+msgstr "Adreça IP"
+
+#: id:1007
+msgid "Add network location"
+msgstr "Afegeix una ubicació de xarxa"
+
+#: id:1008
+msgid "Protocol"
+msgstr "Protocol"
+
+#: id:1009
+msgid "Server address"
+msgstr "Adreça del servidor"
+
+#: id:1010
+msgid "Server name"
+msgstr "Nom del servidor"
+
+#: id:1011
+msgid "Remote path"
+msgstr "Camí d'accés remot"
+
+#: id:1012
+msgid "Shared folder"
+msgstr "Carpeta compartida"
+
+#: id:1013
+msgctxt "Auto context with id 1013"
+msgid "Port"
+msgstr "Port"
+
+#: id:1014
+msgctxt "Auto context with id 1014"
+msgid "Username"
+msgstr "Nom d'usuari"
+
+#: id:1015
+msgid "Browse for network server"
+msgstr "Cerca un servidor de xarxa"
+
+#: id:1016
+msgid "Enter the network address of the server"
+msgstr "Introduïu l'adreça de xarxa del servidor"
+
+#: id:1017
+msgid "Enter the path on the server"
+msgstr "Introduïu el camí al servidor"
+
+#: id:1018
+msgid "Enter the port number"
+msgstr "Introduïu el número de port"
+
+#: id:1019
+msgid "Enter the username"
+msgstr "Introduïu el nom d'usuari"
+
+#: id:1020
+msgid "Add %s source"
+msgstr "Afegeix la font %s"
+
+#: id:1021
+msgid "Enter the paths or browse for the media locations."
+msgstr "Introduïu els camins o cerqueu les ubicacions dels medis."
+
+#: id:1022
+msgid "Enter a name for this media Source."
+msgstr "Introduïu un nom per la font."
+
+#: id:1023
+msgid "Browse for new share"
+msgstr "Cerca un recurs compartit nou"
+
+#: id:1024
+msgid "Browse"
+msgstr "Navega"
+
+#: id:1025
+msgid "Could not retrieve directory information."
+msgstr "No s'ha pogut recuperar la informació del directori."
+
+#: id:1026
+msgid "Add source"
+msgstr "Afegeix una font"
+
+#: id:1027
+msgid "Edit source"
+msgstr "Edita la font"
+
+#: id:1028
+msgid "Edit %s source"
+msgstr "Edita la font %s"
+
+#: id:1029
+msgid "Enter the new label"
+msgstr "Introduïu la nova etiqueta"
+
+#: id:1030
+msgid "Browse for image"
+msgstr "Cerca una imatge"
+
+#: id:1031
+msgid "Browse for image folder"
+msgstr "Cerca la carpeta d'imatges"
+
+#: id:1032
+msgid "Add network location..."
+msgstr "Afegeix una ubicació de xarxa..."
+
+#: id:1033
+msgid "Browse for file"
+msgstr "Cerca un fitxer"
+
+#: id:1034
+msgid "Submenu"
+msgstr "Submenú"
+
+#: id:1035
+msgid "Enable submenu buttons"
+msgstr "Activa els botons del submenú"
+
+#: id:1036
+msgid "Favourites"
+msgstr "Preferits"
+
+#: id:1037
+msgid "Video Add-ons"
+msgstr "Complements de vídeo"
+
+#: id:1038
+msgid "Music Add-ons"
+msgstr "Complements de música"
+
+#: id:1039
+msgid "Picture Add-ons"
+msgstr "Complements d'imatge"
+
+#: id:1040
+msgid "Loading directory"
+msgstr "S'està carregant el directori"
+
+#: id:1041
+msgid "Retrieved %i items"
+msgstr "S'han obtingut %i elements"
+
+#: id:1042
+msgid "Retrieved %i of %i items"
+msgstr "S'han obtingut %i de %i elements"
+
+#: id:1043
+msgid "Program Add-ons"
+msgstr "Complements de programes"
+
+#: id:1044
+msgid "Set plugin thumb"
+msgstr "Establiu la miniatura del connector"
+
+#: id:1045
+msgid "Add-on settings"
+msgstr "Configuració del complement"
+
+#: id:1046
+msgid "Access points"
+msgstr "Punts d'accés"
+
+#: id:1047
+msgid "Other..."
+msgstr "Altres..."
+
+#: id:1048
+msgid "- Username"
+msgstr "- Nom d'usuari"
+
+#: id:1049
+msgid "Script settings"
+msgstr "Cofiguració de l'script"
+
+#: id:1050
+msgid "Singles"
+msgstr "Individual"
+
+#: id:1051
+msgid "Enter web address"
+msgstr "Introduïu l'adreça web"
+
+#: id:1200
+msgid "SMB client"
+msgstr "Client SMB"
+
+#: id:1202
+msgid "Workgroup"
+msgstr "Grup de treball"
+
+#: id:1203
+msgid "Default username"
+msgstr "Nom d'usuari per defecte"
+
+#: id:1204
+msgid "Default password"
+msgstr "Contrasenya per defecte"
+
+#: id:1207
+msgid "WINS server"
+msgstr "Servidor WINS"
+
+#: id:1208
+msgid "Mount SMB shares"
+msgstr "Munta els recursos compartits per SMB"
+
+#: id:1210
+msgctxt "Auto context with id 1210"
+msgid "Remove"
+msgstr "Elimina"
+
+#: id:1211
+msgctxt "Auto context with id 1211"
+msgid "Music"
+msgstr "Música"
+
+#: id:1212
+msgctxt "Auto context with id 1212"
+msgid "Video"
+msgstr "Vídeo"
+
+#: id:1213
+msgctxt "Auto context with id 1213"
+msgid "Pictures"
+msgstr "Imatges"
+
+#: id:1214
+msgctxt "Auto context with id 1214"
+msgid "Files"
+msgstr "Fitxers"
+
+#: id:1215
+msgctxt "Auto context with id 1215"
+msgid "Music & video"
+msgstr "Música i vídeo"
+
+#: id:1216
+msgid "Music & pictures"
+msgstr "Música i imatges"
+
+#: id:1217
+msgid "Music & files"
+msgstr "Música i fitxers"
+
+#: id:1218
+msgid "Video & pictures"
+msgstr "Vídeo i imatges"
+
+#: id:1219
+msgid "Video & files"
+msgstr "Vídeo i fitxers"
+
+#: id:1220
+msgid "Pictures & files"
+msgstr "Imatges i fitxers"
+
+#: id:1221
+msgid "Music & video & pictures"
+msgstr "Música, vídeo i imatges"
+
+#: id:1222
+msgid "Music & video & pictures & files"
+msgstr "Música, vídeo, imatges i fitxers"
+
+#: id:1223
+msgctxt "Auto context with id 1223"
+msgid "Disabled"
+msgstr "Desactivat"
+
+#: id:1226
+msgid "Files & music & video"
+msgstr "Fitxers, música i vídeo"
+
+#: id:1227
+msgid "Files & pictures & music"
+msgstr "Fitxers, imatges i música"
+
+#: id:1228
+msgid "Files & pictures & video"
+msgstr "Fitxers, imatges i vídeo"
+
+#: id:1229
+msgid "Music & programs"
+msgstr "Música i programes"
+
+#: id:1230
+msgid "Video & programs"
+msgstr "Vídeo i programes"
+
+#: id:1231
+msgid "Pictures & programs"
+msgstr "Imatges i programes"
+
+#: id:1232
+msgid "Music & video & pictures & programs"
+msgstr "Música, vídeo, imatges i programes"
+
+#: id:1233
+msgid "Programs & video & music"
+msgstr "Programes, vídeo i música"
+
+#: id:1234
+msgid "Programs & pictures & music"
+msgstr "Programes, imatges i música"
+
+#: id:1235
+msgid "Programs & pictures & video"
+msgstr "Programes, imatges i vídeo"
+
+#: id:1250
+msgid "Auto-detection"
+msgstr "Autodetecció"
+
+#: id:1251
+msgid "Auto-detect system"
+msgstr "Autodetecta el sistema"
+
+#: id:1252
+msgid "Nickname"
+msgstr "Sobrenom"
+
+#: id:1254
+msgid "Ask to connect"
+msgstr "Pregunta abans de connectar"
+
+#: id:1255
+msgid "Send FTP user and password"
+msgstr "Envieu l'usuari i la contrasenya del FTP"
+
+#: id:1256
+msgid "Ping interval"
+msgstr "Interval de ping"
+
+#: id:1257
+msgid "Would you like to connect to the auto-detected system?"
+msgstr "Voleu connectar amb el sistema autodetectat?"
+
+#: id:1259
+msgid "Zeroconf"
+msgstr ""
+
+#: id:1260
+msgid "Announce these services to other systems via Zeroconf"
+msgstr "Anuncia aquests serveis a altres sistemes a través de Zeroconf"
+
+#: id:1270
+msgid "Allow XBMC to receive AirPlay content"
+msgstr "Permet que l'XBMC rebi contingut de l'AirPlay"
+
+#: id:1271
+msgid "Device name"
+msgstr "Nom del dispositiu"
+
+#: id:1272
+msgid "- Use password protection"
+msgstr "- Utilitza protecció amb contrasenya"
+
+#: id:1273
+msgid "AirPlay"
+msgstr ""
+
+#: id:1300
+msgid "Custom audio device"
+msgstr "Dispositiu d'àudio personalitzat"
+
+#: id:1301
+msgid "Custom passthrough device"
+msgstr "Custom passthrough device"
+
+#: id:1396
+msgid "Drifting"
+msgstr "Neu acumulada"
+
+#: id:1397
+msgid "and"
+msgstr "i"
+
+#: id:1398
+msgid "Freezing"
+msgstr "Gelant"
+
+#: id:1399
+msgid "Late"
+msgstr "Tard"
+
+#: id:1400
+msgid "Isolated"
+msgstr "Aïllat"
+
+#: id:1401
+msgid "Thundershowers"
+msgstr "Tempesta amb trons"
+
+#: id:1402
+msgid "Thunder"
+msgstr "Trons"
+
+#: id:1403
+msgctxt "Auto context with id 1403"
+msgid "Sun"
+msgstr "Sol"
+
+#: id:1404
+msgid "Heavy"
+msgstr "Forta"
+
+#: id:1405
+msgid "in"
+msgstr "a/en"
+
+#: id:1406
+msgid "the"
+msgstr "el/la"
+
+#: id:1407
+msgid "Vicinity"
+msgstr "Proximitats"
+
+#: id:1408
+msgid "Ice"
+msgstr "Gel"
+
+#: id:1409
+msgid "Crystals"
+msgstr "Cristalls"
+
+#: id:1410
+msgid "Calm"
+msgstr "Calma"
+
+#: id:1411
+msgid "with"
+msgstr "amb"
+
+#: id:1412
+msgid "windy"
+msgstr "ventós"
+
+#: id:1413
+msgid "drizzle"
+msgstr "plugim"
+
+#: id:1414
+msgid "Thunderstorm"
+msgstr "Tempesta elèctrica"
+
+#: id:1415
+msgid "Drizzle"
+msgstr "Plugim"
+
+#: id:1416
+msgid "Foggy"
+msgstr "Boirós"
+
+#: id:1417
+msgid "Grains"
+msgstr "Grans"
+
+#: id:1418
+msgid "T-Storms"
+msgstr "Tempestes elèctriques aïllades"
+
+#: id:1419
+msgid "T-Showers"
+msgstr "Tempestes amb trons aïllades"
+
+#: id:1420
+msgid "Moderate"
+msgstr "Moderada"
+
+#: id:1421
+msgid "Very High"
+msgstr "Molt forta"
+
+#: id:1422
+msgid "Windy"
+msgstr "Ventós"
+
+#: id:1423
+msgid "Mist"
+msgstr "Boira"
+
+#: id:1450
+msgid "Put display to sleep when idle"
+msgstr "Activa l'estalvi d'energia de la pantalla quan estigui inactiu"
+
+#: id:2050
+msgid "Runtime"
+msgstr "Temps d'execució"
+
+#: id:2100
+msgid "Script failed! : %s"
+msgstr "L'script ha fallat : %s"
+
+#: id:2101
+msgid "Newer version needed - See log"
+msgstr "Es necessita un versió més recent - Veure el registre"
+
+#: id:4501
+msgid "Enable LCD/VFD"
+msgstr "Activa l'LCD/VFD"
+
+#: id:10000
+msgid "Home"
+msgstr "Inici"
+
+#: id:10001
+msgctxt "Auto context with id 10001"
+msgid "Programs"
+msgstr "Programes"
+
+#: id:10002
+msgctxt "Auto context with id 10002"
+msgid "Pictures"
+msgstr "Imatges"
+
+#: id:10003
+msgctxt "Auto context with id 10003"
+msgid "File manager"
+msgstr "Gestor de fitxers"
+
+#: id:10004
+msgctxt "Auto context with id 10004"
+msgid "Settings"
+msgstr "Configuració"
+
+#: id:10005
+msgctxt "Auto context with id 10005"
+msgid "Music"
+msgstr "Música"
+
+#: id:10006
+msgctxt "Auto context with id 10006"
+msgid "Videos"
+msgstr "Vídeos"
+
+#: id:10007
+msgid "System information"
+msgstr "Informació del sistema"
+
+#: id:10008
+msgid "Settings - General"
+msgstr "Configuració - General"
+
+#: id:10009
+msgid "Settings - Screen"
+msgstr "Configuració - Pantalla"
+
+#: id:10010
+msgid "Settings - Appearance - GUI Calibration"
+msgstr "Configuració - Aparença - Calibració de la interfície gràfica d'usuari"
+
+#: id:10011
+msgid "Settings - Videos - Screen Calibration"
+msgstr "Configuració - Vídeos - Calibració de la pantalla"
+
+#: id:10012
+msgid "Settings - Pictures"
+msgstr "Configuració - Imatges"
+
+#: id:10013
+msgid "Settings - Programs"
+msgstr "Configuració - Programes"
+
+#: id:10014
+msgid "Settings - Weather"
+msgstr "Configuració - El temps"
+
+#: id:10015
+msgid "Settings - Music"
+msgstr "Configuració - Música"
+
+#: id:10016
+msgid "Settings - System"
+msgstr "Configuració - Sistema"
+
+#: id:10017
+msgid "Settings - Videos"
+msgstr "Configuració - Vídeos"
+
+#: id:10018
+msgid "Settings - Network"
+msgstr "Configuració - Xarxa"
+
+#: id:10019
+msgid "Settings - Appearance"
+msgstr "Configuració - Aparença"
+
+#: id:10020
+msgctxt "Auto context with id 10020"
+msgid "Scripts"
+msgstr "Scripts"
+
+#: id:10021
+msgid "Web Browser"
+msgstr "Navegador web"
+
+#: id:10025
+msgctxt "Auto context with id 10025"
+msgid "Videos"
+msgstr ""
+
+#: id:10028
+msgid "Videos/Playlist"
+msgstr "Vídeos/Llista de reproducció"
+
+#: id:10029
+msgctxt "Auto context with id 10029"
+msgid "Login screen"
+msgstr ""
+
+#: id:10034
+msgid "Settings - Profiles"
+msgstr "Configuració - Perfils"
+
+#: id:10040
+msgid "Addon browser"
+msgstr ""
+
+#: id:10100
+msgid "Yes/No dialog"
+msgstr "Diàleg Sí/No"
+
+#: id:10101
+msgid "Progress dialog"
+msgstr "Diàleg de progrés"
+
+#: id:10210
+msgid "Looking for subtitles..."
+msgstr "S'estan cercant els subtítols..."
+
+#: id:10211
+msgid "Looking for or caching subtitles..."
+msgstr "S'estan cercant o posant a la memòria cau els subtítols..."
+
+#: id:10212
+msgid "terminating"
+msgstr "s'està finalitzant"
+
+#: id:10213
+msgid "buffering"
+msgstr "S'està emplenant la memòria intermèdia"
+
+#: id:10214
+msgid "Opening stream"
+msgstr "S'està obrint el flux de dades"
+
+#: id:10500
+msgid "Music/Playlist"
+msgstr "Música/Llista de reproducció"
+
+#: id:10501
+msgid "Music/Files"
+msgstr "Música/Fitxers"
+
+#: id:10502
+msgid "Music/Library"
+msgstr "Música/Biblioteca"
+
+#: id:10503
+msgid "Playlist editor"
+msgstr "Editor de la llista de reproducció"
+
+#: id:10504
+msgid "Top 100 songs"
+msgstr "Les 100 millors cançons"
+
+#: id:10505
+msgid "Top 100 albums"
+msgstr "Els 100 millors àlbums"
+
+#: id:10506
+msgctxt "Auto context with id 10506"
+msgid "Programs"
+msgstr "Programes"
+
+#: id:10507
+msgid "Configuration"
+msgstr "Configuració"
+
+#: id:10508
+msgid "Weather forecast"
+msgstr "Predicció del temps"
+
+#: id:10509
+msgid "Network gaming"
+msgstr "Joc en xarxa"
+
+#: id:10510
+msgid "Extensions"
+msgstr "Extensions"
+
+#: id:10511
+msgctxt "Auto context with id 10511"
+msgid "System info"
+msgstr "Informació del sistema"
+
+#: id:10516
+msgid "Music - Library"
+msgstr "Música - Biblioteca"
+
+#: id:10517
+msgid "Now Playing - Music"
+msgstr "Música - Reproduïnt"
+
+#: id:10522
+msgid "Now Playing - Videos"
+msgstr "Vídeo - Reproduïnt"
+
+#: id:10523
+msgid "Album info"
+msgstr "Informació de l'àlbum"
+
+#: id:10524
+msgid "Movie info"
+msgstr "Informació de la pel·lícula"
+
+#: id:12000
+msgid "Select dialog"
+msgstr "Diàleg de selecció"
+
+#: id:12001
+msgid "Music/Info"
+msgstr "Música/Informació"
+
+#: id:12002
+msgid "Dialog OK"
+msgstr "Diàleg «D'acord»"
+
+#: id:12003
+msgid "Videos/Info"
+msgstr "Vídeos/Informació"
+
+#: id:12004
+msgid "Scripts/Info"
+msgstr "Scripts/Informació"
+
+#: id:12005
+msgid "Fullscreen video"
+msgstr "Vídeo en pantalla completa"
+
+#: id:12006
+msgid "Audio visualization"
+msgstr "Visualització d'àudio"
+
+#: id:12008
+msgid "File stacking dialog"
+msgstr "Diàleg d'agrupar fitxers"
+
+#: id:12009
+msgid "Rebuild index..."
+msgstr "Reconstruir l'índex..."
+
+#: id:12010
+msgid "Return to music window"
+msgstr "Torna a la finestra de música"
+
+#: id:12011
+msgid "Return to videos window"
+msgstr "Torna a la finestra de vídeos"
+
+#: id:12021
+msgid "Start from beginning"
+msgstr "Comença des del principi"
+
+#: id:12022
+msgid "Resume from %s"
+msgstr "Reprèn des de %s"
+
+#: id:12310
+msgid "0"
+msgstr "0"
+
+#: id:12311
+msgid "1"
+msgstr "1"
+
+#: id:12312
+msgid "2"
+msgstr "2"
+
+#: id:12313
+msgid "3"
+msgstr "3"
+
+#: id:12314
+msgid "4"
+msgstr "4"
+
+#: id:12315
+msgid "5"
+msgstr "5"
+
+#: id:12316
+msgid "6"
+msgstr "6"
+
+#: id:12317
+msgid "7"
+msgstr "7"
+
+#: id:12318
+msgid "8"
+msgstr "8"
+
+#: id:12319
+msgid "9"
+msgstr "9"
+
+#: id:12320
+msgid "c"
+msgstr "c"
+
+#: id:12321
+msgid "Ok"
+msgstr "D'acord"
+
+#: id:12322
+msgid "*"
+msgstr "*"
+
+#: id:12325
+msgid "Locked! Enter code..."
+msgstr "Bloquejat! Introduïu el codi..."
+
+#: id:12326
+msgid "Enter password"
+msgstr "Introduïu la contrasenya"
+
+#: id:12327
+msgid "Enter master code"
+msgstr "Introduïu el codi mestre"
+
+#: id:12328
+msgid "Enter unlock code"
+msgstr "Introduïu el codi de desbloqueig"
+
+#: id:12329
+msgid "or press C to cancel"
+msgstr "o premeu C per cancel·lar"
+
+#: id:12330
+msgid "Enter gamepad button combo and"
+msgstr "Introduïu la combinació de botons del gamepad i"
+
+#: id:12331
+msgid "press OK, or Back to cancel"
+msgstr "premeu D'acord, or enree per cancel·lar"
+
+#: id:12332
+msgid "Set lock"
+msgstr "Establiu el bloqueig"
+
+#: id:12333
+msgid "Unlock"
+msgstr "Desbloca"
+
+#: id:12334
+msgid "Reset lock"
+msgstr "Reinicieu el bloqueig"
+
+#: id:12335
+msgid "Remove lock"
+msgstr "Treieu el bloqueig"
+
+#: id:12337
+msgid "Numeric password"
+msgstr "Contrasenya numèrica"
+
+#: id:12338
+msgid "Gamepad button combo"
+msgstr "Combinació de botons del gamepad"
+
+#: id:12339
+msgid "Full-text password"
+msgstr "Contrasenya alfanumèrica"
+
+#: id:12340
+msgid "Enter new password"
+msgstr "Introduïu la nova contrasenya"
+
+#: id:12341
+msgid "Re-Enter new password"
+msgstr "Confirmeu la nova contrasenya"
+
+#: id:12342
+msgid "Incorrect password,"
+msgstr "Contrasenya incorrecta,"
+
+#: id:12343
+msgid "retries left"
+msgstr "re-intents restants"
+
+#: id:12344
+msgid "Passwords entered did not match."
+msgstr "Les contrasenyes introduïdes no coincideixen."
+
+#: id:12345
+msgid "Access denied"
+msgstr "Accés denegat"
+
+#: id:12346
+msgid "Password retry limit exceeded."
+msgstr "S'ha excedit el límit d'intents."
+
+#: id:12347
+msgid "The system will now shut off."
+msgstr "El sistema s'aturarà."
+
+#: id:12348
+msgid "Item locked"
+msgstr "Element bloquejat"
+
+#: id:12353
+msgid "Reactivate lock"
+msgstr "Reactiva el bloqueig"
+
+#: id:12356
+msgid "Change lock"
+msgstr "Canvia el bloqueig"
+
+#: id:12357
+msgid "Source lock"
+msgstr "Source lock"
+
+#: id:12358
+msgid "Password entry was blank. Try again."
+msgstr "La contrasenya intorduïda està en blanc. Intenteu-ho de nou."
+
+#: id:12360
+msgid "Master lock"
+msgstr "Bloqueig mestre"
+
+#: id:12362
+msgid "Shutdown system if Master Lock retries exceeded"
+msgstr "Apaga el sistema si s'excedeix el màxim d'intents del bloqueig mestre"
+
+#: id:12367
+msgid "Master code is not valid"
+msgstr "Codi mestre no vàlid"
+
+#: id:12368
+msgid "Please enter a valid master code"
+msgstr "Introduïu un codi mestre vàlid"
+
+#: id:12373
+msgid "Settings & file manager"
+msgstr "Configuració i gestor de fitxers"
+
+#: id:12376
+msgid "Set as default for all movies"
+msgstr "Estableix com a predeterminat per a totes les pel·lícules"
+
+#: id:12377
+msgid "This will reset any previously saved values"
+msgstr "Això restablirà tots els valors guardats prèviament"
+
+#: id:12378
+msgid "Amount of time to display each image"
+msgstr "Mostra cada imatge durant"
+
+#: id:12379
+msgid "Use pan and zoom effects"
+msgstr "Utilitza els efectes pan i zoom"
+
+#: id:12383
+msgid "12 hour clock"
+msgstr "Rellotge de 12 hores"
+
+#: id:12384
+msgid "24 hour clock"
+msgstr "Rellotge de 24 hores"
+
+#: id:12385
+msgid "Day/Month"
+msgstr "Dia/Mes"
+
+#: id:12386
+msgid "Month/Day"
+msgstr "Mes/Dia"
+
+#: id:12390
+msgid "System uptime"
+msgstr "Activitat del sistema des de"
+
+#: id:12391
+msgid "Minutes"
+msgstr "Minuts"
+
+#: id:12392
+msgid "Hours"
+msgstr "Hores"
+
+#: id:12393
+msgid "Days"
+msgstr "Dies"
+
+#: id:12394
+msgid "Total uptime"
+msgstr "Temps total d'activitat"
+
+#: id:12395
+msgid "Battery level"
+msgstr "Nivell de la bateria"
+
+#: id:12600
+msgctxt "Auto context with id 12600"
+msgid "Weather"
+msgstr "El temps"
+
+#: id:12900
+msgctxt "Auto context with id 12900"
+msgid "Screensaver"
+msgstr "Estalvi de pantalla"
+
+#: id:12901
+msgid "Fullscreen OSD"
+msgstr "OSD a pantalla completa"
+
+#: id:13000
+msgid "System"
+msgstr "Sistema"
+
+#: id:13001
+msgid "Immediate HD spindown"
+msgstr "Atura el disc dur immediatament"
+
+#: id:13002
+msgid "Video only"
+msgstr "Només vídeo"
+
+#: id:13003
+msgid "- Delay"
+msgstr "- Retard"
+
+#: id:13004
+msgid "- Minimum file duration"
+msgstr "- Durada mínima del fitxer"
+
+#: id:13005
+msgid "Shutdown"
+msgstr "Atura"
+
+#: id:13008
+msgid "Shutdown function"
+msgstr "Funció d'aturada"
+
+#: id:13009
+msgid "Quit"
+msgstr "Surt"
+
+#: id:13010
+msgid "Hibernate"
+msgstr "Hiberna"
+
+#: id:13011
+msgid "Suspend"
+msgstr "Atura temporalment"
+
+#: id:13012
+msgid "Exit"
+msgstr "Surt"
+
+#: id:13013
+msgid "Reboot"
+msgstr "Reinicia"
+
+#: id:13014
+msgid "Minimize"
+msgstr "Minimitza"
+
+#: id:13015
+msgid "Power button action"
+msgstr "Acció del botó d'arrencada"
+
+#: id:13016
+msgid "Power off System"
+msgstr "Atura el sistema"
+
+#: id:13020
+msgid "Is another session active, perhaps over ssh?"
+msgstr "Hi ha una altra sessió activa, potser a través de ssh?"
+
+#: id:13021
+msgid "Mounted removable harddrive"
+msgstr "S'ha muntat un disc dur extraïble"
+
+#: id:13022
+msgid "Unsafe device removal"
+msgstr "La extracció del dispositiu no és segura"
+
+#: id:13023
+msgid "Successfully removed device"
+msgstr "El dispositiu s'ha extret amb èxit"
+
+#: id:13024
+msgid "Joystick plugged"
+msgstr "S'ha connectat un joystick"
+
+#: id:13025
+msgid "Joystick unplugged"
+msgstr "S'ha desconnectat el joystick"
+
+#: id:13050
+msgid "Running low on battery"
+msgstr "La càrrega de la bateria és baixa"
+
+#: id:13100
+msgid "Flicker filter"
+msgstr "Filtre de parpelleig"
+
+#: id:13101
+msgid "Let driver choose (requires restart)"
+msgstr "Permet triar al dispositiu (requereix reiniciar)"
+
+#: id:13105
+msgid "Vertical blank sync"
+msgstr "Vertical blank sync"
+
+#: id:13106
+msgctxt "Auto context with id 13106"
+msgid "Disabled"
+msgstr "Desactivat"
+
+#: id:13107
+msgid "Enabled during video playback"
+msgstr "Activat durant la reproducció de vídeo"
+
+#: id:13108
+msgctxt "Auto context with id 13108"
+msgid "Always enabled"
+msgstr "Sempre activat"
+
+#: id:13109
+msgid "Test & apply resolution"
+msgstr "Prova i aplica la resolució"
+
+#: id:13110
+msgid "Save resolution?"
+msgstr "Voleu desar la resolució?"
+
+#: id:13111
+msgid "Would you like to keep this resolution?"
+msgstr "Voleu mantenir aquesta resolució?"
+
+#: id:13112
+msgid "High quality upscaling"
+msgstr "Reescalat d'alta qualitat"
+
+#: id:13113
+msgctxt "Auto context with id 13113"
+msgid "Disabled"
+msgstr "Desactivat"
+
+#: id:13114
+msgid "Enabled for SD content"
+msgstr "Activat per a contingut SD"
+
+#: id:13115
+msgctxt "Auto context with id 13115"
+msgid "Always enabled"
+msgstr "Sempre activat"
+
+#: id:13116
+msgid "Upscaling method"
+msgstr "Mètode de reescalat"
+
+#: id:13117
+msgctxt "Auto context with id 13117"
+msgid "Bicubic"
+msgstr "Bicúbic"
+
+#: id:13118
+msgid "Lanczos"
+msgstr "Lanczos"
+
+#: id:13119
+msgid "Sinc"
+msgstr "Sinc"
+
+#: id:13120
+msgctxt "Auto context with id 13120"
+msgid "VDPAU"
+msgstr "VDPAU"
+
+#: id:13121
+msgid "VDPAU HQ Upscaling level"
+msgstr "Nivell d'escalat de VDPAU HQ"
+
+#: id:13122
+msgid "VDPAU Studio level color conversion"
+msgstr "VDPAU Studio level color conversion"
+
+#: id:13130
+msgid "Blank other displays"
+msgstr "Enfosqueix les altres pantalles"
+
+#: id:13131
+msgctxt "Auto context with id 13131"
+msgid "Disabled"
+msgstr "Desactivat"
+
+#: id:13132
+msgid "Blank displays"
+msgstr "Enfosqueix les pantalles"
+
+#: id:13140
+msgid "Active connections detected!"
+msgstr "S'han detectat les connexions actives"
+
+#: id:13141
+msgid "If you proceed, you might not be able to control XBMC"
+msgstr "Si continueu, pot ser que no sigueu capaç de controlar l'XBMC"
+
+#: id:13142
+msgid "any longer. Are you sure you want to stop the Event server?"
+msgstr "Esteu segur que voleu aturar el servidor d'esdeveniments?"
+
+#: id:13144
+msgid "Change Apple Remote mode?"
+msgstr "Canviar el mode de l'Apple Remote?"
+
+#: id:13145
+msgid "If you are currently using the Apple Remote to control"
+msgstr "Si actualment està utilitzant l'Apple Remote per controlar"
+
+#: id:13146
+msgid "XBMC, changing this setting might affect your ability"
+msgstr "l'XBMC, el canvi d'aquesta configuració pot afectar la seva capacitat"
+
+#: id:13147
+msgid "to continue controlling it. Do you want to proceed?"
+msgstr "per continuar el seu control. Voleu continuar?"
+
+#: id:13159
+msgid "Subnet mask"
+msgstr "Màscara de subxarxa"
+
+#: id:13160
+msgid "Gateway"
+msgstr "Passarel·la"
+
+#: id:13161
+msgid "Primary DNS"
+msgstr "DNS primari"
+
+#: id:13162
+msgid "Initialize failed"
+msgstr "No s'ha pogut inicialitzar"
+
+#: id:13170
+msgctxt "Auto context with id 13170"
+msgid "Never"
+msgstr "Mai"
+
+#: id:13171
+msgid "Immediately"
+msgstr "Immediatament"
+
+#: id:13172
+msgid "After %i secs"
+msgstr "Després de %i segons"
+
+#: id:13173
+msgid "HDD install date:"
+msgstr "Data d'instal·lació del disc dur:"
+
+#: id:13174
+msgid "HDD power cycle count:"
+msgstr "Comptador de cicles d'energia del disc dur:"
+
+#: id:13200
+msgid "Profiles"
+msgstr "Perfils"
+
+#: id:13201
+msgid "Delete profile '%s'?"
+msgstr "Voleu suprimir el perfil '%s'?"
+
+#: id:13204
+msgid "Last loaded profile:"
+msgstr "Últim perfil carregat:"
+
+#: id:13205
+msgid "Unknown"
+msgstr "Desconegut"
+
+#: id:13206
+msgid "Overwrite"
+msgstr "Sobreescriure"
+
+#: id:13208
+msgid "Alarm clock"
+msgstr "Alarma de rellotge"
+
+#: id:13209
+msgid "Alarm clock interval (in minutes)"
+msgstr "Interval de l'alarma de rellotge (en minuts)"
+
+#: id:13210
+msgid "Started, alarm in %im"
+msgstr "Iniciada, alarma en %im"
+
+#: id:13211
+msgid "Alarm!"
+msgstr "Alarma!"
+
+#: id:13212
+msgid "Canceled with %im%is left"
+msgstr "Cancel·lat quan quedava %im%is"
+
+#: id:13213
+msgid "%2.0fm"
+msgstr "%2.0fm"
+
+#: id:13214
+msgid "%2.0fs"
+msgstr "%2.0fs"
+
+#: id:13249
+msgid "Search for subtitles in RARs"
+msgstr "Cerqueu els subtítols en els fitxers RAR"
+
+#: id:13250
+msgid "Browse for subtitle..."
+msgstr "Cerqueu els subtítols..."
+
+#: id:13251
+msgid "Move item"
+msgstr "Mou l'element"
+
+#: id:13252
+msgid "Move item here"
+msgstr "Mou l'element aquí"
+
+#: id:13253
+msgid "Cancel move"
+msgstr "Cancel·la moure"
+
+#: id:13270
+msgid "Hardware:"
+msgstr "Maquinari:"
+
+#: id:13271
+msgid "CPU Usage:"
+msgstr "Ús de la CPU:"
+
+#: id:13274
+msgid "Connected, but no DNS is available."
+msgstr "Connectat, però les DNS no estan disponibles."
+
+#: id:13275
+msgid "Hard Disk"
+msgstr "Disc dur"
+
+#: id:13276
+msgid "DVD-ROM"
+msgstr "DVD-ROM"
+
+#: id:13277
+msgctxt "Auto context with id 13277"
+msgid "Storage"
+msgstr "Emmagatzematge"
+
+#: id:13278
+msgctxt "Auto context with id 13278"
+msgid "Default"
+msgstr "Per defecte"
+
+#: id:13279
+msgctxt "Auto context with id 13279"
+msgid "Network"
+msgstr "Xarxa"
+
+#: id:13280
+msgctxt "Auto context with id 13280"
+msgid "Video"
+msgstr "Vídeo"
+
+#: id:13281
+msgid "Hardware"
+msgstr "Maquinari"
+
+#: id:13283
+msgid "Operating system:"
+msgstr "Sistema operatiu:"
+
+#: id:13284
+msgid "CPU speed:"
+msgstr "Velocitat de la CPU:"
+
+#: id:13286
+msgid "Video encoder:"
+msgstr "Codificador de vídeo:"
+
+#: id:13287
+msgid "Screen resolution:"
+msgstr "Resolució de la pantalla:"
+
+#: id:13292
+msgid "A/V cable:"
+msgstr "Cable A/V:"
+
+#: id:13294
+msgid "DVD region:"
+msgstr "Regió del DVD:"
+
+#: id:13295
+msgid "Internet:"
+msgstr "Internet:"
+
+#: id:13296
+msgctxt "Auto context with id 13296"
+msgid "Connected"
+msgstr "Connectat"
+
+#: id:13297
+msgid "Not connected. Check network settings."
+msgstr "No està connectat. Comproveu la configuració de xarxa."
+
+#: id:13299
+msgid "Target temperature"
+msgstr "Temperatura màxima"
+
+#: id:13300
+msgid "Fan speed"
+msgstr "Velocitat del ventilador"
+
+#: id:13301
+msgid "Auto temperature control"
+msgstr "Control automàtic de temperatura"
+
+#: id:13302
+msgid "Fan speed override"
+msgstr "Fan speed override"
+
+#: id:13303
+msgid "- Fonts"
+msgstr "- Fonts"
+
+#: id:13304
+msgid "Enable flipping bi-directional strings"
+msgstr "Activa invertir cadenes bidireccionals"
+
+#: id:13305
+msgid "Show RSS news feeds"
+msgstr "Mostra les notíces dels canals RSS"
+
+#: id:13306
+msgid "Show parent folder items"
+msgstr "Show parent folder items"
+
+#: id:13307
+msgid "Track naming template"
+msgstr "Track naming template"
+
+#: id:13308
+msgid "Do you wish to reboot your system"
+msgstr "Voleu reiniciar els sistema"
+
+#: id:13309
+msgid "instead of just XBMC?"
+msgstr "en lloc de l'XBMC?"
+
+#: id:13310
+msgid "Zoom effect"
+msgstr "Efecte de zoom"
+
+#: id:13311
+msgid "Float effect"
+msgstr "Efecte flotant"
+
+#: id:13312
+msgid "Black bar reduction"
+msgstr "Reducció de les bandes negres"
+
+#: id:13313
+msgid "Restart"
+msgstr "Reinicieu"
+
+#: id:13314
+msgid "Crossfade between songs"
+msgstr "Fon entre cançons"
+
+#: id:13315
+msgid "Regenerate thumbnails"
+msgstr "Regenera les miniatures"
+
+#: id:13316
+msgid "Recursive thumbnails"
+msgstr "Miniatures recursives"
+
+#: id:13317
+msgid "View slideshow"
+msgstr "Veure la presentació de diapositives"
+
+#: id:13318
+msgid "Recursive slideshow"
+msgstr "Presentació de diapositives recursiva"
+
+#: id:13319
+msgid "Randomize"
+msgstr "Genera aleatòriament"
+
+#: id:13320
+msgid "Stereo"
+msgstr "Estèreo"
+
+#: id:13321
+msgid "Left only"
+msgstr "Només esquerra"
+
+#: id:13322
+msgid "Right only"
+msgstr "Només dreta"
+
+#: id:13323
+msgid "Enable karaoke support"
+msgstr "Activa el suport de karaoke"
+
+#: id:13324
+msgid "Background transparency"
+msgstr "Transparència del fons"
+
+#: id:13325
+msgid "Foreground transparency"
+msgstr "Transparència del primer pla"
+
+#: id:13326
+msgid "A/V delay"
+msgstr "Retard A/V"
+
+#: id:13327
+msgid "Karaoke"
+msgstr "Karaoke"
+
+#: id:13328
+msgid "%s not found"
+msgstr "%s no s'ha trobat"
+
+#: id:13329
+msgid "Error opening %s"
+msgstr "Hi ha un error obrint %s"
+
+#: id:13330
+msgid "Unable to load %s"
+msgstr "No es pot carregar %s"
+
+#: id:13331
+msgid "Error: Out of memory"
+msgstr "Error: Sense memòria"
+
+#: id:13332
+msgid "Move up"
+msgstr "Mou amunt"
+
+#: id:13333
+msgid "Move down"
+msgstr "Mou avall"
+
+#: id:13334
+msgid "Edit label"
+msgstr "Edita l'etiqueta"
+
+#: id:13335
+msgid "Make default"
+msgstr "Marca com a predeterminat"
+
+#: id:13336
+msgid "Remove button"
+msgstr "Suprimeix el botó"
+
+#: id:13340
+msgid "Leave as is"
+msgstr "Deixa com està"
+
+#: id:13341
+msgid "Green"
+msgstr "Verd"
+
+#: id:13342
+msgid "Orange"
+msgstr "Taronja"
+
+#: id:13343
+msgid "Red"
+msgstr "Vermell"
+
+#: id:13344
+msgid "Cycle"
+msgstr "Cicle"
+
+#: id:13345
+msgid "Switch LED off on playback"
+msgstr "Apaga el LED en reproduir"
+
+#: id:13346
+msgctxt "Auto context with id 13346"
+msgid "Movie information"
+msgstr "Informació de la pel·lícula"
+
+#: id:13347
+msgid "Queue item"
+msgstr "Afegeix l'element a la cua"
+
+#: id:13348
+msgid "Search IMDb..."
+msgstr "Cerca a IMDb..."
+
+#: id:13349
+msgid "Scan for new content"
+msgstr "Cerca continguts nous"
+
+#: id:13350
+msgid "Now playing..."
+msgstr "S'està reproduïnt..."
+
+#: id:13351
+msgctxt "Auto context with id 13351"
+msgid "Album information"
+msgstr "Informació de l'àlbum"
+
+#: id:13352
+msgid "Scan item to library"
+msgstr "Scan item to library"
+
+#: id:13353
+msgid "Stop scanning"
+msgstr "Atura la cerca"
+
+#: id:13354
+msgctxt "Auto context with id 13354"
+msgid "Render method"
+msgstr "Mètode de renderitzat"
+
+#: id:13355
+msgid "Low quality pixel shader"
+msgstr "Ombrejat de píxels de baixa qualitat"
+
+#: id:13356
+msgid "Hardware overlays"
+msgstr "Superposicions per maquinari"
+
+#: id:13357
+msgid "High quality pixel shader"
+msgstr "Ombrejat de píxels d'alta qualitat"
+
+#: id:13358
+msgid "Play item"
+msgstr "Reprodueix l'element"
+
+#: id:13359
+msgid "Set artist thumb"
+msgstr "Estableix la miniatura de l'artista"
+
+#: id:13360
+msgid "Automatically generate thumbnails"
+msgstr "Genera les miniatures automàticament"
+
+#: id:13361
+msgid "Enable voice"
+msgstr "Activa la veu"
+
+#: id:13375
+msgid "Enable device"
+msgstr "Activa el dispositiu"
+
+#: id:13376
+msgid "Volume"
+msgstr "Volum"
+
+#: id:13377
+msgid "Default view mode"
+msgstr "Mode de visualització per defecte"
+
+#: id:13378
+msgid "Default brightness"
+msgstr "Brillantor per defecte"
+
+#: id:13379
+msgid "Default contrast"
+msgstr "Contrast per defecte"
+
+#: id:13380
+msgid "Default gamma"
+msgstr "Gamma per defecte"
+
+#: id:13381
+msgid "Resume video"
+msgstr "Reprèn el vídeo"
+
+#: id:13382
+msgid "Voice mask - Port 1"
+msgstr "Màscara de veu - Port 1"
+
+#: id:13383
+msgid "Voice mask - Port 2"
+msgstr "Màscara de veu - Port 2"
+
+#: id:13384
+msgid "Voice mask - Port 3"
+msgstr "Màscara de veu - Port 3"
+
+#: id:13385
+msgid "Voice mask - Port 4"
+msgstr "Màscara de veu - Port 4"
+
+#: id:13386
+msgid "Use time based seeking"
+msgstr "Utilitza cerca basada en temps"
+
+#: id:13387
+msgid "Track naming template - right"
+msgstr "Track naming template - right"
+
+#: id:13388
+msgid "Preset"
+msgstr "Predefinit"
+
+#: id:13389
+msgid "There are no presets available\nfor this visualization"
+msgstr "There are no presets available\nfor this visualization"
+
+#: id:13390
+msgid "There are no settings available\nfor this visualization"
+msgstr "There are no settings available\nfor this visualization"
+
+#: id:13391
+msgid "Eject/Load"
+msgstr "Expulsa/Carrega"
+
+#: id:13392
+msgid "Use visualization if playing audio"
+msgstr "Utilitzeu la visualització si es reprodueix àudio"
+
+#: id:13393
+msgid "Calculate size"
+msgstr "Calcula la mida"
+
+#: id:13394
+msgid "Calculating folder size"
+msgstr "S'està calculant la mida de la carpeta"
+
+#: id:13395
+msgid "Video settings"
+msgstr "Configuracions de vídeo"
+
+#: id:13396
+msgid "Audio and subtitle settings"
+msgstr "Configuracions de l'àudio i dels subtítols"
+
+#: id:13397
+msgid "Enable subtitles"
+msgstr "Activa els subtítols"
+
+#: id:13398
+msgctxt "Auto context with id 13398"
+msgid "Shortcuts"
+msgstr "Dreceres"
+
+#: id:13399
+msgid "Ignore articles when sorting (e.g. \"the\")"
+msgstr "Ignora els articles quan s'estigui ordenant (p.e. \"the\")"
+
+#: id:13400
+msgid "Crossfade between songs on the same album"
+msgstr "Fon entre cançons en el mateix àlbum"
+
+#: id:13401
+msgid "Browse for %s"
+msgstr "Cerca %s"
+
+#: id:13402
+msgid "Show track position"
+msgstr "Mostra la posició de la pista"
+
+#: id:13403
+msgid "Clear default"
+msgstr "Clear default"
+
+#: id:13404
+msgid "Resume"
+msgstr "Reprèn"
+
+#: id:13405
+msgid "Get thumb"
+msgstr "Obtén la miniatura"
+
+#: id:13406
+msgid "Picture information"
+msgstr "Informació de la imatge"
+
+#: id:13407
+msgid "%s presets"
+msgstr "%s predefinits"
+
+#: id:13408
+msgid "(IMDb user rating)"
+msgstr "(Valoració d'usuaris d'IMDb)"
+
+#: id:13409
+msgid "Top 250"
+msgstr "250 millors"
+
+#: id:13410
+msgid "Tune in on Last.fm"
+msgstr "Connecta't a Last.fm"
+
+#: id:13411
+msgid "Minimum fan speed"
+msgstr "Velocitat mínima del ventilador"
+
+#: id:13412
+msgid "Play from here"
+msgstr "Reprodueix des d'aquí"
+
+#: id:13413
+msgid "Downloading"
+msgstr "S'està baixant"
+
+#: id:13414
+msgid "Include artists who appear only on compilations"
+msgstr "Inclou els artistes que només apareixen en les compilacions"
+
+#: id:13415
+msgctxt "Auto context with id 13415"
+msgid "Render method"
+msgstr "Mètode de renderitzat"
+
+#: id:13416
+msgid "Auto detect"
+msgstr "Detecció automàtica"
+
+#: id:13417
+msgid "Basic shaders (ARB)"
+msgstr "Ombrejats bàsics (ARB)"
+
+#: id:13418
+msgid "Advanced shaders (GLSL)"
+msgstr "Ombrejats avançats (GLSL)"
+
+#: id:13419
+msgid "Software"
+msgstr "Programari"
+
+#: id:13420
+msgid "Remove safely"
+msgstr "Treu de forma segura"
+
+#: id:13421
+msgctxt "Auto context with id 13421"
+msgid "VDPAU"
+msgstr "VDPAU"
+
+#: id:13422
+msgid "Start slideshow here"
+msgstr "Comença la presentació aquí"
+
+#: id:13423
+msgid "Remember for this path"
+msgstr "Recorda aquest camí"
+
+#: id:13424
+msgid "Use pixel buffer objects"
+msgstr "Utilitza objectes de memòria intermèdia de píxels"
+
+#: id:13425
+msgid "Allow hardware acceleration (VDPAU)"
+msgstr "Permet l'acceleració per maquinari (VDPAU)"
+
+#: id:13426
+msgid "Allow hardware acceleration (VAAPI)"
+msgstr "Permet l'acceleració per maquinari (VAAPI)"
+
+#: id:13427
+msgid "Allow hardware acceleration (DXVA2)"
+msgstr "Permet l'acceleració per maquinari (DXVA2)"
+
+#: id:13428
+msgid "Allow hardware acceleration (CrystalHD)"
+msgstr "Permet l'acceleració per maquinari (CrystalHD)"
+
+#: id:13429
+msgid "Allow hardware acceleration (VDADecoder)"
+msgstr "Permet l'acceleració per maquinari (VDADecoder)"
+
+#: id:13430
+msgid "Allow hardware acceleration (OpenMax)"
+msgstr "Permet l'acceleració per maquinari (OpenMax)"
+
+#: id:13431
+msgid "Pixel Shaders"
+msgstr "Ombrejadors de píxels"
+
+#: id:13432
+msgid "Allow hardware acceleration (VideoToolbox)"
+msgstr "Permet l'acceleració per maquinari (VideoToolbox)"
+
+#: id:13500
+msgid "A/V sync method"
+msgstr "Mètode de sincronització d'A/V"
+
+#: id:13501
+msgid "Audio clock"
+msgstr "Rellotge d'àudio"
+
+#: id:13502
+msgid "Video clock (Drop/Dupe audio)"
+msgstr "Rellotge del vídeo (Drop/Dupe àudio)"
+
+#: id:13503
+msgid "Video clock (Resample audio)"
+msgstr "Rellotge del vídeo (Remostreja l'àudio)"
+
+#: id:13504
+msgid "Maximum resample amount (%)"
+msgstr "Quantitat màxima de remostreig (%)"
+
+#: id:13505
+msgid "Resample quality"
+msgstr "Qualitat del remostreig"
+
+#: id:13506
+msgid "Low(fast)"
+msgstr "Baix (ràpid)"
+
+#: id:13507
+msgctxt "Auto context with id 13507"
+msgid "Medium"
+msgstr "Mitja"
+
+#: id:13508
+msgctxt "Auto context with id 13508"
+msgid "High"
+msgstr "Alt"
+
+#: id:13509
+msgid "Really high(slow!)"
+msgstr "Molt alt (lent)"
+
+#: id:13510
+msgid "Sync playback to display"
+msgstr "Sync playback to display"
+
+#: id:13550
+msgid "Pause during refresh rate change"
+msgstr "Pause during refresh rate change"
+
+#: id:13551
+msgctxt "Auto context with id 13551"
+msgid "Off"
+msgstr "Inactiu"
+
+#: id:13552
+msgid "%.1f Second"
+msgstr "%.1f Segon"
+
+#: id:13553
+msgid "%.1f Seconds"
+msgstr "%.1f Segons"
+
+#: id:13600
+msgid "Apple remote"
+msgstr "Apple remote"
+
+#: id:13602
+msgid "Allow start of XBMC using the remote"
+msgstr "Permet l'inici de l'XBMC amb el control remot"
+
+#: id:13603
+msgid "Sequence delay time"
+msgstr "Temps de retard de la seqüència"
+
+#: id:13610
+msgctxt "Auto context with id 13610"
+msgid "Disabled"
+msgstr "Desactivat"
+
+#: id:13611
+msgctxt "Auto context with id 13611"
+msgid "Standard"
+msgstr "Estàndard"
+
+#: id:13612
+msgid "Universal Remote"
+msgstr "Comandament a distància universal"
+
+#: id:13613
+msgid "Multi Remote (Harmony)"
+msgstr "Multi Remote (Harmony)"
+
+#: id:13620
+msgid "Apple Remote Error"
+msgstr "Error del'Apple Remote"
+
+#: id:13621
+msgid "Apple Remote support could be enabled."
+msgstr "No es pot activar el suport per l'Apple Remote."
+
+#: id:14000
+msgid "Stack"
+msgstr "Agrupa"
+
+#: id:14001
+msgid "Unstack"
+msgstr "Desagrupa"
+
+#: id:14003
+msgid "Downloading playlist file..."
+msgstr "S'està baixant el fitxer de la llista de reproducció..."
+
+#: id:14004
+msgid "Downloading streams list..."
+msgstr "S'està baixant el llistat de fluxos..."
+
+#: id:14005
+msgid "Parsing streams list..."
+msgstr "S'està analitzant el llistat de fluxos..."
+
+#: id:14006
+msgid "Downloading streams list failed"
+msgstr "La descarrega de la llista de streams ha fallat"
+
+#: id:14007
+msgid "Downloading playlist file failed"
+msgstr "La descarrega del fitxer de llistes ha fallat"
+
+#: id:14009
+msgid "Games directory"
+msgstr "Directori dels jocs"
+
+#: id:14010
+msgid "Auto switch to thumbs based on"
+msgstr "Canvia automàticament a les miniatures segons"
+
+#: id:14011
+msgid "Enable auto switching to thumbs view"
+msgstr "Activar Autoconmutació en les vistes de caràtules"
+
+#: id:14012
+msgid "- Use large icons"
+msgstr "- Utilitza icones grans"
+
+#: id:14013
+msgid "- Switch based on"
+msgstr "- Canvi segons"
+
+#: id:14014
+msgid "- Percentage"
+msgstr "- Percentatge"
+
+#: id:14015
+msgid "No files and at least one thumb"
+msgstr "Sense fitxers i almenys una miniatura"
+
+#: id:14016
+msgid "At least one file and thumb"
+msgstr "Almenys un fitxer i una miniatura"
+
+#: id:14017
+msgid "Percentage of thumbs"
+msgstr "Percentatge de les miniatures"
+
+#: id:14018
+msgid "View options"
+msgstr "Mostra les opcions"
+
+#: id:14019
+msgid "Change area code 1"
+msgstr "Canvia el codi d'àrea 1"
+
+#: id:14020
+msgid "Change area code 2"
+msgstr "Canvia el codi d'àrea 2"
+
+#: id:14021
+msgid "Change area code 3"
+msgstr "Canvia el codi d'àrea 3"
+
+#: id:14022
+msgctxt "Auto context with id 14022"
+msgid "Library"
+msgstr "Biblioteca"
+
+#: id:14023
+msgid "No TV"
+msgstr "Sense TV"
+
+#: id:14024
+msgid "Enter the nearest large town"
+msgstr "Introduïu la ciutat propera més gran"
+
+#: id:14025
+msgid "Video/Audio/DVD cache - Harddisk"
+msgstr "Memòria cau del Vídeo/Àudio/DVD - Dis dur"
+
+#: id:14026
+msgid "Video cache - DVD-ROM"
+msgstr "Memòria cau del vídeo - DVD-ROM"
+
+#: id:14027
+msgctxt "Auto context with id 14027"
+msgid "- Local Network"
+msgstr "- Xarxa local"
+
+#: id:14028
+msgctxt "Auto context with id 14028"
+msgid "- Internet"
+msgstr "- Internet"
+
+#: id:14030
+msgid "Audio cache - DVD-ROM"
+msgstr "Memòria cau de l'àudio - DVD-ROM"
+
+#: id:14031
+msgctxt "Auto context with id 14031"
+msgid "- Local Network"
+msgstr "- Xarxa local"
+
+#: id:14032
+msgctxt "Auto context with id 14032"
+msgid "- Internet"
+msgstr "- Internet"
+
+#: id:14034
+msgid "DVD cache - DVD-ROM"
+msgstr "Memòria cau del DVD - DVD-ROM"
+
+#: id:14035
+msgctxt "Auto context with id 14035"
+msgid "- Local Network"
+msgstr "- Xarxa local"
+
+#: id:14036
+msgctxt "Auto context with id 14036"
+msgid "Services"
+msgstr "Serveis"
+
+#: id:14038
+msgid "Network settings changed"
+msgstr "La configuració de xarxa ha canviat"
+
+#: id:14039
+msgid "XBMC requires to restart to change your"
+msgstr "és necessari reiniciar l'XBMC per canviar la seva"
+
+#: id:14040
+msgid "network setup. Would you like to restart now?"
+msgstr "configuració de xarxa. Voleu reiniciar ara?"
+
+#: id:14041
+msgid "Internet connection bandwidth limitation"
+msgstr "Internet connection bandwidth limitation"
+
+#: id:14043
+msgid "- Shutdown while playing"
+msgstr "- Apaga mentre s'està reproduïnt"
+
+#: id:14044
+msgid "%i min"
+msgstr "%i min"
+
+#: id:14045
+msgid "%i sec"
+msgstr "%i seg"
+
+#: id:14046
+msgid "%i ms"
+msgstr "%i ms"
+
+#: id:14047
+msgid "%i %%"
+msgstr "%i %%"
+
+#: id:14048
+msgid "%i kbps"
+msgstr "%i kbps"
+
+#: id:14049
+msgid "%i kb"
+msgstr "%i kb"
+
+#: id:14050
+msgid "%i.0 dB"
+msgstr "%i.0 dB"
+
+#: id:14051
+msgid "Time format"
+msgstr "Format de l'hora"
+
+#: id:14052
+msgid "Date format"
+msgstr "Format de la data"
+
+#: id:14053
+msgid "GUI filters"
+msgstr "Filtres GUI"
+
+#: id:14055
+msgid "Use background scanning"
+msgstr "Utilitza la exploració en segon plà"
+
+#: id:14056
+msgid "Stop scan"
+msgstr "Atura l'exploració"
+
+#: id:14057
+msgid "Not possible while scanning for media info"
+msgstr "No es possible mentre s'explora la informació dels medis"
+
+#: id:14058
+msgid "Film grain effect"
+msgstr "Efecte Gra"
+
+#: id:14059
+msgid "Search for thumbnails on remote shares"
+msgstr "Cerca miniatures en recursos remots"
+
+#: id:14060
+msgid "Unknown type cache - Internet"
+msgstr "Tipus de memòria cau desconeguda - Internet"
+
+#: id:14061
+msgctxt "Auto context with id 14061"
+msgid "Auto"
+msgstr "Auto"
+
+#: id:14062
+msgid "Enter username for"
+msgstr "Introduïu el nom d'usuari per"
+
+#: id:14063
+msgid "Date & time"
+msgstr "Data i hora"
+
+#: id:14064
+msgid "Set date"
+msgstr "Establiu la data"
+
+#: id:14065
+msgid "Set time"
+msgstr "Establiu l'hora"
+
+#: id:14066
+msgid "Enter the time in 24 hour HH:MM format"
+msgstr "Introduïu l'hora en format 24 hores HH:MM"
+
+#: id:14067
+msgid "Enter the date in DD/MM/YYYY format"
+msgstr "Introduïu la data en format DD/MM/YYYY"
+
+#: id:14068
+msgid "Enter the IP address"
+msgstr "Introduïu la adreça IP"
+
+#: id:14069
+msgid "Apply these settings now?"
+msgstr "Voleu aplicar aquesta configuració ara?"
+
+#: id:14070
+msgid "Apply changes now"
+msgstr "Aplica els canvis ara"
+
+#: id:14071
+msgid "Allow file renaming and deletion"
+msgstr "Permet canviar el nom i esborrar fitxers"
+
+#: id:14074
+msgid "Set timezone"
+msgstr "Establiu la zona horària"
+
+#: id:14075
+msgid "Use daylight saving time"
+msgstr "Utilitza l'horari d'estiu"
+
+#: id:14076
+msgid "Add to favourites"
+msgstr "Afegeix a preferits"
+
+#: id:14077
+msgid "Remove from favourites"
+msgstr "Elimina de preferits"
+
+#: id:14078
+msgctxt "Auto context with id 14078"
+msgid "- Colours"
+msgstr "- Colors"
+
+#: id:14079
+msgid "Timezone country"
+msgstr "País de la zona horària"
+
+#: id:14080
+msgid "Timezone"
+msgstr "Zona horària"
+
+#: id:14081
+msgid "File lists"
+msgstr "Llistes de fitxers"
+
+#: id:14082
+msgid "Show EXIF picture information"
+msgstr "Mostra la informació EXIF de la imatge"
+
+#: id:14083
+msgid "Use a fullscreen window rather than true fullscreen"
+msgstr "Use a fullscreen window rather than true fullscreen"
+
+#: id:14084
+msgid "Queue songs on selection"
+msgstr "Posa les cançons a la cua al seleccionar-les"
+
+#: id:14086
+msgid "Playback"
+msgstr "Reprodueix"
+
+#: id:14087
+msgid "DVDs"
+msgstr "DVDs"
+
+#: id:14088
+msgid "Play DVDs automatically"
+msgstr "Reprodueix els DVD de forma automàtica"
+
+#: id:14089
+msgid "Font to use for text subtitles"
+msgstr "Font to use for text subtitles"
+
+#: id:14090
+msgid "International"
+msgstr "Internacional"
+
+#: id:14091
+msgid "Character set"
+msgstr "Joc de caràcters"
+
+#: id:14092
+msgid "Debugging"
+msgstr "Depuració"
+
+#: id:14093
+msgid "Security"
+msgstr "Seguretat"
+
+#: id:14094
+msgid "Input devices"
+msgstr "Dispositius d'entrada"
+
+#: id:14095
+msgid "Power saving"
+msgstr "Estalvi d'energia"
+
+#: id:14096
+msgid "Rip"
+msgstr ""
+
+#: id:14097
+msgid "Audio CD Insert Action"
+msgstr ""
+
+#: id:14098
+msgctxt "Auto context with id 14098"
+msgid "Play"
+msgstr ""
+
+#: id:14099
+msgid "Eject disc when CD ripping is complete"
+msgstr ""
+
+#: id:15015
+msgctxt "Auto context with id 15015"
+msgid "Remove"
+msgstr "Suprimeix"
+
+#: id:15016
+msgid "Games"
+msgstr "Jocs"
+
+#: id:15019
+msgid "Add"
+msgstr "Afegeix"
+
+#: id:15052
+msgid "Password"
+msgstr "Contrasenya"
+
+#: id:15100
+msgctxt "Auto context with id 15100"
+msgid "Library"
+msgstr "Biblioteca"
+
+#: id:15101
+msgid "Database"
+msgstr "Base de dades"
+
+#: id:15102
+msgid "* All albums"
+msgstr "* Tots els àlbums"
+
+#: id:15103
+msgid "* All artists"
+msgstr "* Tots els artistes"
+
+#: id:15104
+msgid "* All songs"
+msgstr "* Totes les cançons"
+
+#: id:15105
+msgid "* All genres"
+msgstr "* Tots els gèneres"
+
+#: id:15107
+msgid "Buffering..."
+msgstr "S'està omplint la memòria intermèdia..."
+
+#: id:15108
+msgid "Navigation sounds"
+msgstr "Sons de navegació"
+
+#: id:15109
+msgid "Skin default"
+msgstr "Aparença per defecte"
+
+#: id:15111
+msgid "- Theme"
+msgstr "- Tema"
+
+#: id:15112
+msgid "Default theme"
+msgstr "Tema per defecte"
+
+#: id:15200
+msgid "Last.fm"
+msgstr "Last.fm"
+
+#: id:15201
+msgid "Submit songs to Last.fm"
+msgstr "Envia les cançons a Last.fm"
+
+#: id:15202
+msgid "Last.fm username"
+msgstr "Nom d'usuari de Last.fm"
+
+#: id:15203
+msgid "Last.fm password"
+msgstr "Contrasenya de Last.fm"
+
+#: id:15204
+msgid "Unable to handshake: sleeping..."
+msgstr "No s'ha pogut negociar: dormint..."
+
+#: id:15205
+msgid "Please update XBMC"
+msgstr "Actualitzeu l'XBMC"
+
+#: id:15206
+msgid "Bad authorization: Check username and password"
+msgstr "Autorització incorrecta: comprovi l'usuari i la contrasenya"
+
+#: id:15207
+msgctxt "Auto context with id 15207"
+msgid "Connected"
+msgstr "Connectat"
+
+#: id:15208
+msgid "Not connected"
+msgstr "No està connectat"
+
+#: id:15209
+msgid "Submit interval %i"
+msgstr "Envia l'interval %i"
+
+#: id:15210
+msgid "Cached %i songs"
+msgstr "Cached %i cançons"
+
+#: id:15211
+msgid "Submitting..."
+msgstr "S'està enviant..."
+
+#: id:15212
+msgid "Submitting in %i secs"
+msgstr "S'està enviant en %i segons"
+
+#: id:15213
+msgid "Play using..."
+msgstr "Reprodueix utilitzant..."
+
+#: id:15214
+msgid "Use smoothed A/V synchronization"
+msgstr "Utilitza la sincronització A/V suau"
+
+#: id:15215
+msgid "Hide file names in thumbs view"
+msgstr "Oculta els noms dels fitxers en la vista de miniatures"
+
+#: id:15216
+msgid "Play in party mode"
+msgstr "Reprodueix en mode festa"
+
+#: id:15217
+msgid "Submit songs to Libre.fm"
+msgstr "Envia les cançons a Libre.fm"
+
+#: id:15218
+msgid "Libre.fm username"
+msgstr "Nom d'usuari de Libre.fm"
+
+#: id:15219
+msgid "Libre.fm password"
+msgstr "Contrasenya de Libre.fm"
+
+#: id:15220
+msgid "Libre.fm"
+msgstr "Libre.fm"
+
+#: id:15221
+msgid "Song submission"
+msgstr "Enviament de cançó"
+
+#: id:15250
+msgid "Submit Last.fm radio to Last.fm"
+msgstr "Envia la ràdio de Last.fm a Last.fm"
+
+#: id:15251
+msgid "Connecting to Last.fm..."
+msgstr "S'està connectant a Last.fm..."
+
+#: id:15252
+msgid "Selecting station..."
+msgstr "S'està seleccionant emisora..."
+
+#: id:15253
+msgid "Search similar artists..."
+msgstr "Cerca artistes semblants..."
+
+#: id:15254
+msgid "Search similar tags..."
+msgstr "Cerca etiquetes semblants..."
+
+#: id:15255
+msgid "Your profile (%name%)"
+msgstr "El vostre perfil (%name%)"
+
+#: id:15256
+msgid "Overall top tags"
+msgstr "Etiquetes globals"
+
+#: id:15257
+msgid "Top artists for tag %name%"
+msgstr "Artistes més populars amb l'etiqueta %name%"
+
+#: id:15258
+msgid "Top albums for tag %name%"
+msgstr "Àlbums més populars amb l'etiqueta %name%"
+
+#: id:15259
+msgid "Top tracks for tag %name%"
+msgstr "Pistes més populars amb l'etiqueta %name%"
+
+#: id:15260
+msgid "Listen to tag %name% Last.fm radio"
+msgstr "Escolta la ràdio de Last.fm amb l'etiqueta %name%"
+
+#: id:15261
+msgid "Similar artists as %name%"
+msgstr "Artistes semblants com %name%"
+
+#: id:15262
+msgid "Top %name% albums"
+msgstr "Top %name% àlbums"
+
+#: id:15263
+msgid "Top %name% tracks"
+msgstr "Top %name% pistes"
+
+#: id:15264
+msgid "Top %name% tags"
+msgstr "Top %name% etiquetes"
+
+#: id:15265
+msgid "Biggest fans of %name%"
+msgstr "Majors fans de %name%"
+
+#: id:15266
+msgid "Listen to %name% fans Last.fm radio"
+msgstr "Escolta els %name% fans"
+
+#: id:15267
+msgid "Listen to %name% similar artists Last.fm radio"
+msgstr "Escolta artistes similars de %name%"
+
+#: id:15268
+msgid "Top artists for user %name%"
+msgstr "Artistes preferits de l'usuari %name%"
+
+#: id:15269
+msgid "Top albums for user %name%"
+msgstr "Àlbums preferits de l'usuari %name%"
+
+#: id:15270
+msgid "Top tracks for user %name%"
+msgstr "Pistes preferides de l'usuari %name%"
+
+#: id:15271
+msgid "Friends of user %name%"
+msgstr "Amics de l'usuari %name%"
+
+#: id:15272
+msgid "Neighbours of user %name%"
+msgstr "Veïns de l'usuari %name%"
+
+#: id:15273
+msgid "Weekly artist chart for %name%"
+msgstr "Taula d'artistes setmanals per %name%"
+
+#: id:15274
+msgid "Weekly album chart for %name%"
+msgstr "Taula d'àlbums setmanals per %name%"
+
+#: id:15275
+msgid "Weekly track chart for %name%"
+msgstr "Taula de pistes setmanals per %name%"
+
+#: id:15276
+msgid "Listen to %name%'s neighbours Last.fm radio"
+msgstr "Escolta veïns de %name%"
+
+#: id:15277
+msgid "Listen to %name%'s personal Last.fm radio"
+msgstr "Escolta personal %name%"
+
+#: id:15278
+msgid "Listen to %name%'s mix Last.fm radio"
+msgstr "Escolta les més estimades de %name%"
+
+#: id:15279
+msgid "Retrieving list from Last.fm..."
+msgstr "S'està obtenint la llista desde Last.fm..."
+
+#: id:15280
+msgid "Can't retrieve list from Last.fm..."
+msgstr "No s'ha pogut obtenir la llista desde Last.fm..."
+
+#: id:15281
+msgid "Enter an artist name to find related ones"
+msgstr "Introduïu un nom d'artista per trobar-ne de similars"
+
+#: id:15282
+msgid "Enter a tag name to find similar ones"
+msgstr "Introduïu un nom d'etiqueta per trobar-ne de similars"
+
+#: id:15283
+msgid "Tracks recently listened by %name%"
+msgstr "Pistes escoltades recentment per %name%"
+
+#: id:15284
+msgid "Listen to %name%'s recommendations Last.fm radio"
+msgstr "Listen to %name%'s recommendations Last.fm radio"
+
+#: id:15285
+msgid "Top tags for user %name%"
+msgstr "Etiquetes preferides per l'usuari %name%"
+
+#: id:15287
+msgid "Do you want to add the current track to your loved tracks?"
+msgstr "Do you want to add the current track to your loved tracks?"
+
+#: id:15288
+msgid "Do you want to ban the current track?"
+msgstr "Do you want to ban the current track?"
+
+#: id:15289
+msgid "Added to your loved tracks: '%s'."
+msgstr "Added to your loved tracks: '%s'."
+
+#: id:15290
+msgid "Could not add '%s' to your loved tracks."
+msgstr "Could not add '%s' to your loved tracks."
+
+#: id:15291
+msgid "Banned: '%s'."
+msgstr "Vetada: '%s'."
+
+#: id:15292
+msgid "Could not ban '%s'."
+msgstr "Could not ban '%s'."
+
+#: id:15293
+msgid "Tracks recently loved by %name%"
+msgstr "Tracks recently loved by %name%"
+
+#: id:15294
+msgid "Tracks recently banned by %name%"
+msgstr "Tracks recently banned by %name%"
+
+#: id:15295
+msgid "Remove from loved tracks"
+msgstr "Elimina de la llista de preferides"
+
+#: id:15296
+msgid "Un-ban"
+msgstr "Desbloca"
+
+#: id:15297
+msgid "Do you want to remove this track from your loved tracks?"
+msgstr "Do you want to remove this track from your loved tracks?"
+
+#: id:15298
+msgid "Do you want to un-ban this track?"
+msgstr "Do you want to un-ban this track?"
+
+#: id:15300
+msgid "Path not found or invalid"
+msgstr "Path not found or invalid"
+
+#: id:15301
+msgid "Could not connect to network server"
+msgstr "No s'ha pogut connectar al servidor de xarxa"
+
+#: id:15302
+msgid "No servers found"
+msgstr "No s'han trobat servidors"
+
+#: id:15303
+msgid "Workgroup not found"
+msgstr "No s'ha trobat el grup de treball"
+
+#: id:15310
+msgid "Opening multi-path source"
+msgstr "S'està obrint una font multi-camí"
+
+#: id:15311
+msgid "Path:"
+msgstr "Camí:"
+
+#: id:16000
+msgctxt "Auto context with id 16000"
+msgid "General"
+msgstr "General"
+
+#: id:16002
+msgid "Internet lookup"
+msgstr "Cerca a internet"
+
+#: id:16003
+msgid "Player"
+msgstr "Reproductor"
+
+#: id:16004
+msgid "Play media from disc"
+msgstr "Reprodueix el contingut multimèdia desde el disc"
+
+#: id:16008
+msgid "Enter new title"
+msgstr "Introduïu el nou títol"
+
+#: id:16009
+msgid "Enter the movie name"
+msgstr "Introduïu el nom de la pel·lícula"
+
+#: id:16010
+msgid "Enter the profile name"
+msgstr "Introduïu el nom del perfil"
+
+#: id:16011
+msgid "Enter the album name"
+msgstr "Introduïu el nom de l'àlbum"
+
+#: id:16012
+msgid "Enter the playlist name"
+msgstr "Introduïu el nom de la llista de reproducció"
+
+#: id:16013
+msgid "Enter new filename"
+msgstr "Introduïu el nou nom de fitxer"
+
+#: id:16014
+msgid "Enter folder name"
+msgstr "Introduïu nom de la carpeta"
+
+#: id:16015
+msgid "Enter directory"
+msgstr "Introduïu el directori"
+
+#: id:16016
+msgid "Available options: %A, %T, %N, %B, %D, %G, %Y, %F, %S"
+msgstr "Opcions disponibles: %A, %T, %N, %B, %D, %G, %Y, %F, %S"
+
+#: id:16017
+msgid "Enter search string"
+msgstr "Introduïu la cadena de cerca"
+
+#: id:16018
+msgctxt "Auto context with id 16018"
+msgid "None"
+msgstr "Cap"
+
+#: id:16019
+msgid "Auto select"
+msgstr "Selecció automàtica"
+
+#: id:16020
+msgid "De-interlace"
+msgstr "Desentrellaçat"
+
+#: id:16021
+msgid "Bob"
+msgstr "Bob"
+
+#: id:16022
+msgid "Bob (inverted)"
+msgstr "Bob (invertit)"
+
+#: id:16024
+msgid "Canceling..."
+msgstr "S'està cancel·lant..."
+
+#: id:16025
+msgid "Enter the artist name"
+msgstr "Introduïu el nom de l'artista"
+
+#: id:16026
+msgid "Playback failed"
+msgstr "La reproducció ha fallat"
+
+#: id:16027
+msgid "One or more items failed to play."
+msgstr "Un o més ítems no s'han pogut reproduir."
+
+#: id:16028
+msgid "Enter value"
+msgstr "Introduïu el valor"
+
+#: id:16029
+msgid "Check the log file for details."
+msgstr "Comproveu el fitxer de registre per obtenir més detalls."
+
+#: id:16030
+msgid "Party mode aborted."
+msgstr "Mode festa abortat."
+
+#: id:16031
+msgid "No matching songs in the library."
+msgstr "Sense cançons coincidents a la biblioteca"
+
+#: id:16032
+msgid "Could not initialize database."
+msgstr "No s'ha pogut inicialitzar la base de dades."
+
+#: id:16033
+msgid "Could not open database."
+msgstr "No s'ha pogut obrir la base de dades."
+
+#: id:16034
+msgid "Could not get songs from database."
+msgstr "No s'han pogut obtenir les cançons de la base de dades."
+
+#: id:16035
+msgid "Party mode playlist"
+msgstr "Llista de reproducció del mode festa"
+
+#: id:16036
+msgid "De-interlace (Half)"
+msgstr "Desentrellaçat (Half)"
+
+#: id:16037
+msgid "Deinterlace video"
+msgstr "Deinterlace video"
+
+#: id:16038
+msgid "Deinterlace method"
+msgstr "Mètode de desentrellaçat"
+
+#: id:16039
+msgctxt "Auto context with id 16039"
+msgid "Off"
+msgstr "Off"
+
+#: id:16040
+msgctxt "Auto context with id 16040"
+msgid "Auto"
+msgstr "Auto"
+
+#: id:16041
+msgid "On"
+msgstr "On"
+
+#: id:16100
+msgid "All Videos"
+msgstr "Tots els vídeos"
+
+#: id:16101
+msgid "Unwatched"
+msgstr "No visualitzats"
+
+#: id:16102
+msgid "Watched"
+msgstr "Visualitzats"
+
+#: id:16103
+msgid "Mark as watched"
+msgstr "Marca com a visualitzat"
+
+#: id:16104
+msgid "Mark as unwatched"
+msgstr "Marca com a no visualitzat"
+
+#: id:16105
+msgid "Edit title"
+msgstr "Edita el títol"
+
+#: id:16200
+msgid "Operation was aborted"
+msgstr "Operation was aborted"
+
+#: id:16201
+msgid "Copy failed"
+msgstr "Copy failed"
+
+#: id:16202
+msgid "Failed to copy at least one file"
+msgstr "Failed to copy at least one file"
+
+#: id:16203
+msgid "Move failed"
+msgstr "Move failed"
+
+#: id:16204
+msgid "Failed to move at least one file"
+msgstr "Failed to move at least one file"
+
+#: id:16205
+msgid "Delete failed"
+msgstr "Delete failed"
+
+#: id:16206
+msgid "Failed to delete at least one file"
+msgstr "Failed to delete at least one file"
+
+#: id:16300
+msgid "Video scaling method"
+msgstr "Mètode d'escalat de vídeo"
+
+#: id:16301
+msgid "Nearest neighbour"
+msgstr "Veí més proper"
+
+#: id:16302
+msgid "Bilinear"
+msgstr "Bilineal"
+
+#: id:16303
+msgctxt "Auto context with id 16303"
+msgid "Bicubic"
+msgstr "Bicubic"
+
+#: id:16304
+msgid "Lanczos2"
+msgstr "Lanczos2"
+
+#: id:16305
+msgid "Lanczos3"
+msgstr "Lanczos3"
+
+#: id:16306
+msgid "Sinc8"
+msgstr "Sinc8"
+
+#: id:16307
+msgid "Bicubic (software)"
+msgstr "Bicubic (programari)"
+
+#: id:16308
+msgid "Lanczos (software)"
+msgstr "Lanczos (programari)"
+
+#: id:16309
+msgid "Sinc (software)"
+msgstr "Sinc (programari)"
+
+#: id:16310
+msgid "Temporal"
+msgstr "Temporal"
+
+#: id:16311
+msgid "Temporal/Spatial"
+msgstr "Temporal/Espacial"
+
+#: id:16312
+msgid "(VDPAU)Noise Reduction"
+msgstr "(VDPAU) Reducció de soroll"
+
+#: id:16313
+msgid "(VDPAU)Sharpness"
+msgstr "(VDPAU) Nitidesa"
+
+#: id:16314
+msgid "Inverse Telecine"
+msgstr "Telecine invers"
+
+#: id:16315
+msgid "Lanczos3 optimized"
+msgstr "Lanczos3 optimitzat"
+
+#: id:16316
+msgctxt "Auto context with id 16316"
+msgid "Auto"
+msgstr "Auto"
+
+#: id:16317
+msgid "Temporal (Half)"
+msgstr "Temporal (Half)"
+
+#: id:16318
+msgid "Temporal/Spatial (Half)"
+msgstr "Temporal/Espacial (Half)"
+
+#: id:16319
+msgid "DXVA"
+msgstr "DXVA"
+
+#: id:16320
+msgid "DXVA Bob"
+msgstr "DXVA Bob"
+
+#: id:16321
+msgid "DXVA Best"
+msgstr "DXVA Best"
+
+#: id:16322
+msgid "Spline36"
+msgstr "Spline36"
+
+#: id:16323
+msgid "Spline36 optimized"
+msgstr "Spline36 optimitzat"
+
+#: id:16324
+msgid "Software Blend"
+msgstr "Software Blend"
+
+#: id:16400
+msgid "Post-processing"
+msgstr "Postprocessament"
+
+#: id:17500
+msgid "Display sleep timeout"
+msgstr "Display sleep timeout"
+
+#: id:19000
+msgid "Switch to channel"
+msgstr "Canvia al canal"
+
+#: id:20000
+msgid "Saved music folder"
+msgstr "Carpeta de la música desada"
+
+#: id:20001
+msgid "Use external DVD player"
+msgstr "Utilitza un reproductor de DVD extern"
+
+#: id:20002
+msgid "External DVD player"
+msgstr "Reproductor de DVD extern"
+
+#: id:20003
+msgid "Trainers folder"
+msgstr "Carpeta dels trainers"
+
+#: id:20004
+msgid "Screenshot folder"
+msgstr "Carpeta de les captures de pantalla"
+
+#: id:20006
+msgid "Playlists folder"
+msgstr "Carpeta de les llistes de reproducció"
+
+#: id:20007
+msgid "Recordings"
+msgstr "Enregistraments"
+
+#: id:20008
+msgid "Screenshots"
+msgstr "Captures de pantalla"
+
+#: id:20009
+msgid "Use XBMC"
+msgstr "Utilitza l'XBMC"
+
+#: id:20011
+msgid "Music playlists"
+msgstr "Llistes de reproducció de música"
+
+#: id:20012
+msgid "Video playlists"
+msgstr "Llistes de reproducció de vídeo"
+
+#: id:20013
+msgid "Do you wish to launch the game?"
+msgstr "Voleu iniciar el joc?"
+
+#: id:20014
+msgid "Sort by: Playlist"
+msgstr "Ordena per: Llista de reproducció"
+
+#: id:20015
+msgid "Remote thumb"
+msgstr "Miniatura remota"
+
+#: id:20016
+msgid "Current thumb"
+msgstr "Miniatura actual"
+
+#: id:20017
+msgid "Local thumb"
+msgstr "Miniatura local"
+
+#: id:20018
+msgid "No thumb"
+msgstr "Sense miniatura"
+
+#: id:20019
+msgid "Choose thumbnail"
+msgstr "Trieu una miniatura"
+
+#: id:20023
+msgid "Conflict"
+msgstr "Conflicte"
+
+#: id:20024
+msgid "Scan new"
+msgstr "Escaneja els nous"
+
+#: id:20025
+msgid "Scan all"
+msgstr "Escaneja-ho tot"
+
+#: id:20026
+msgid "Region"
+msgstr "Regió"
+
+#: id:20037
+msgid "Summary"
+msgstr "Resum"
+
+#: id:20038
+msgid "Lock music window"
+msgstr "Bloqueja la finestra de música"
+
+#: id:20039
+msgid "Lock videos window"
+msgstr "Bloqueja la finestra de vídeos"
+
+#: id:20040
+msgid "Lock pictures window"
+msgstr "Bloqueja la finestra d'imatges"
+
+#: id:20041
+msgid "Lock programs & scripts windows"
+msgstr "Bloqueja les finestres de programes i scripts"
+
+#: id:20042
+msgid "Lock file manager"
+msgstr "Bloqueja el gestor de fitxers"
+
+#: id:20043
+msgid "Lock settings"
+msgstr "Bloqueja la configuració"
+
+#: id:20044
+msgid "Start fresh"
+msgstr "Comença a cero"
+
+#: id:20045
+msgid "Enter master mode"
+msgstr "Entra en mode mestre"
+
+#: id:20046
+msgid "Leave master mode"
+msgstr "Surt del mode mestre"
+
+#: id:20047
+msgid "Create profile '%s'?"
+msgstr "Voleu crear el perfil '%s'?"
+
+#: id:20048
+msgid "Start with fresh settings"
+msgstr "Comença amb opcions a cero"
+
+#: id:20049
+msgid "Best available"
+msgstr "El millor disponible"
+
+#: id:20050
+msgid "Auto-switch between 16x9 and 4x3"
+msgstr "Canvia automàticament entre 16x9 i 4x3"
+
+#: id:20051
+msgid "Treat stacked files as single file"
+msgstr "Tracta els fitxers agrupats com un sol fitxer"
+
+#: id:20052
+msgid "Caution"
+msgstr "Precaució"
+
+#: id:20053
+msgid "Left master mode"
+msgstr "Falta el mode mestre"
+
+#: id:20054
+msgid "Entered master mode"
+msgstr "S'ha entrat en mode mestre"
+
+#: id:20055
+msgid "Allmusic.com thumb"
+msgstr "Miniatura de Allmusic.com"
+
+#: id:20057
+msgid "Remove thumbnail"
+msgstr "Elimina la miniatura"
+
+#: id:20058
+msgid "Add profile..."
+msgstr "Afegeix un perfil..."
+
+#: id:20059
+msgid "Query info for all albums"
+msgstr "Consulta la informació per tots els àlbums"
+
+#: id:20060
+msgctxt "Auto context with id 20060"
+msgid "Media info"
+msgstr "Informació del suport"
+
+#: id:20061
+msgctxt "Auto context with id 20061"
+msgid "Separate"
+msgstr "Separa"
+
+#: id:20062
+msgid "Shares with default"
+msgstr "Comparteix per defecte"
+
+#: id:20063
+msgid "Shares with default (read only)"
+msgstr "Comparteix per defecte (només lectura)"
+
+#: id:20064
+msgid "Copy default"
+msgstr "Copia per defecte"
+
+#: id:20065
+msgid "Profile picture"
+msgstr "Imatge del perfil"
+
+#: id:20066
+msgid "Lock preferences"
+msgstr "Bloqueja les preferències"
+
+#: id:20067
+msgid "Edit profile"
+msgstr "Edita el perfil"
+
+#: id:20068
+msgid "Profile lock"
+msgstr "Perfil de bloqueig"
+
+#: id:20069
+msgid "Could not create folder"
+msgstr "No s'ha pogut crear la carpeta"
+
+#: id:20070
+msgid "Profile directory"
+msgstr "Directori del perfil"
+
+#: id:20071
+msgid "Start with fresh media sources"
+msgstr "Comença amb recursos multimedia a cero"
+
+#: id:20072
+msgid "Make sure the selected folder is writable"
+msgstr "Assegureu-vos que es pot escriure a la carpeta seleccionada"
+
+#: id:20073
+msgid "and that the new folder name is valid"
+msgstr "i el nou nom de directori és vàlid"
+
+#: id:20074
+msgid "MPAA rating"
+msgstr "Valoració MPAA"
+
+#: id:20075
+msgid "Enter master lock code"
+msgstr "Introduïu el codi mestre de bloqueig"
+
+#: id:20076
+msgid "Ask for master lock code on startup"
+msgstr "Pregunta pel codi mestre al iniciar"
+
+#: id:20077
+msgid "Skin settings"
+msgstr "Paràmetres de l'aparença"
+
+#: id:20078
+msgid "- no link set -"
+msgstr "- sense enllaç establert -"
+
+#: id:20079
+msgid "Enable animations"
+msgstr "Enable animations"
+
+#: id:20080
+msgid "Disable RSS during music"
+msgstr "Desactiva l'RSS durant la música"
+
+#: id:20081
+msgid "Enable shortcut buttons"
+msgstr "Activa els botons d'accés directe"
+
+#: id:20082
+msgid "Show programs in main menu"
+msgstr "Mostra els programes al menú principal"
+
+#: id:20083
+msgid "Show music info"
+msgstr "Mosta la informació de la música"
+
+#: id:20084
+msgid "Show weather info"
+msgstr "Mostra la informació del temps"
+
+#: id:20085
+msgid "Show system info"
+msgstr "Mostra la informació del temps"
+
+#: id:20086
+msgid "Show available disc space C: E: F:"
+msgstr "Mostra l'espai disponible C: E: F:"
+
+#: id:20087
+msgid "Show available disc space E: F: G:"
+msgstr "Mostra l'espai disponible E: F: G:"
+
+#: id:20088
+msgid "Weather info"
+msgstr "Informació del temps"
+
+#: id:20089
+msgid "Drive space free"
+msgstr "Espai lliure de la unitat"
+
+#: id:20090
+msgid "Enter the name of an existing share"
+msgstr "Entra el nom de un recurs compartit existent"
+
+#: id:20091
+msgid "Lock code"
+msgstr "Bloqueja el codi"
+
+#: id:20092
+msgid "Load profile"
+msgstr "Carrega el perfil"
+
+#: id:20093
+msgid "Profile name"
+msgstr "Nom del perfil"
+
+#: id:20094
+msgctxt "Auto context with id 20094"
+msgid "Media sources"
+msgstr "Recursos multimedia"
+
+#: id:20095
+msgid "Enter profile lock code"
+msgstr "Introduïu el codi de bloqueig del perfil"
+
+#: id:20096
+msgctxt "Auto context with id 20096"
+msgid "Login screen"
+msgstr "Pantalla d'autenticació"
+
+#: id:20097
+msgid "Fetching album info"
+msgstr "Fetching album info"
+
+#: id:20098
+msgid "Fetching info for album"
+msgstr "Fetching info for album"
+
+#: id:20099
+msgid "Can't rip CD or track while playing from CD"
+msgstr "No es pot extreure el CD o la pista mentre s'està reproduïnt desde el CD"
+
+#: id:20100
+msgid "Master lock code and settings"
+msgstr "Codi mestre i opcions"
+
+#: id:20101
+msgid "Entering master lock code always enables master mode"
+msgstr "Intorduïnt el codi mestre de bloqueig sempre activa el mode mestre"
+
+#: id:20102
+msgid "or copy from default?"
+msgstr "o copia del defecte?"
+
+#: id:20103
+msgid "Save changes to profile?"
+msgstr "Voleu desar els canvis al perfil?"
+
+#: id:20104
+msgid "Old settings found."
+msgstr "S'han trobat opcions velles."
+
+#: id:20105
+msgid "Do you want to use them?"
+msgstr "Voleu utilitzar-les?"
+
+#: id:20106
+msgid "Old media sources found."
+msgstr "S'han trobat recursos multimedia vells."
+
+#: id:20107
+msgid "Separate (locked)"
+msgstr "Separat (bloquejat)"
+
+#: id:20108
+msgid "Root"
+msgstr "Arrel"
+
+#: id:20109
+msgid "- Zoom"
+msgstr "- Zoom"
+
+#: id:20110
+msgid "UPnP settings"
+msgstr "UPnP settings"
+
+#: id:20111
+msgid "Autostart UPnP client"
+msgstr "Autostart UPnP client"
+
+#: id:20112
+msgid "Last login: %s"
+msgstr "Última autenticació: %s"
+
+#: id:20113
+msgid "Never logged on"
+msgstr "Mai autenticat"
+
+#: id:20114
+msgid "Profile %i / %i"
+msgstr "Perfil %i / %i"
+
+#: id:20115
+msgid "User login / Select a profile"
+msgstr "Autenticació d'usuari / Seleccioneu un perfil"
+
+#: id:20116
+msgid "Use lock on login screen"
+msgstr "Utilitzeu el bloqueig a la pantalla d'autenticació"
+
+#: id:20117
+msgid "Invalid lock code."
+msgstr "Codi de bloqueig invàlid."
+
+#: id:20118
+msgid "This requires the master lock to be set."
+msgstr "Això requeix entrar un codi mestre."
+
+#: id:20119
+msgid "Would you like to set it now?"
+msgstr "Voleu entrar-lo ara?"
+
+#: id:20120
+msgid "Loading program information"
+msgstr "S'està carregant la informació del programa"
+
+#: id:20121
+msgid "Party on!"
+msgstr "A la Festa!"
+
+#: id:20122
+msgid "True"
+msgstr "Cert"
+
+#: id:20123
+msgid "Mixing drinks"
+msgstr "Barrejant begudes"
+
+#: id:20124
+msgid "Filling glasses"
+msgstr "Omplint gots"
+
+#: id:20125
+msgid "Logged on as"
+msgstr "Autenticat com a"
+
+#: id:20126
+msgid "Log off"
+msgstr "Desconnecta"
+
+#: id:20128
+msgid "Go to root"
+msgstr "Anar a l'arrel"
+
+#: id:20129
+msgid "Weave"
+msgstr "Trama"
+
+#: id:20130
+msgid "Weave (inverted)"
+msgstr "Trama (invertida)"
+
+#: id:20131
+msgid "Blend"
+msgstr "Mescla"
+
+#: id:20132
+msgid "Restart video"
+msgstr "Reinicia el vídeo"
+
+#: id:20133
+msgid "Edit network location"
+msgstr "Edita la localització de xarxa"
+
+#: id:20134
+msgid "Remove network location"
+msgstr "Esborra la localització de xarxa"
+
+#: id:20135
+msgid "Do you want to scan the folder?"
+msgstr "Voleu revisar el directori?"
+
+#: id:20136
+msgid "Memory unit"
+msgstr "Unitat de memòria"
+
+#: id:20137
+msgid "Memory unit mounted"
+msgstr "S'ha muntat la unitat de memòria"
+
+#: id:20138
+msgid "Unable to mount memory unit"
+msgstr "No es pot muntar la unitat de memòria"
+
+#: id:20139
+msgid "In port %i, slot %i"
+msgstr "En el port %i, slot %i"
+
+#: id:20140
+msgid "Lock screensaver"
+msgstr "Bloqueja l'estalvi de pantalla"
+
+#: id:20141
+msgid "Set"
+msgstr "Estableix"
+
+#: id:20142
+msgctxt "Auto context with id 20142"
+msgid "Username"
+msgstr "Nom d'usuari"
+
+#: id:20143
+msgid "Enter password for"
+msgstr "Introduïu la contrasenya per"
+
+#: id:20144
+msgid "Shutdown timer"
+msgstr "Interval d'apagada"
+
+#: id:20145
+msgid "Shutdown interval (in minutes)"
+msgstr "Interval d'apagada (en minuts)"
+
+#: id:20146
+msgid "Started, shutdown in %im"
+msgstr "Iniciat, apaga en %im"
+
+#: id:20147
+msgid "Shutdown in 30 minutes"
+msgstr "Apaga en 30 minuts"
+
+#: id:20148
+msgid "Shutdown in 60 minutes"
+msgstr "Apaga en 60 minuts"
+
+#: id:20149
+msgid "Shutdown in 120 minutes"
+msgstr "Apaga en 120 minuts"
+
+#: id:20150
+msgid "Custom shutdown timer"
+msgstr "Temps d'apagada personalitzat"
+
+#: id:20151
+msgid "Cancel shutdown timer"
+msgstr "Cancel·la el temps d'apagada"
+
+#: id:20152
+msgid "Lock preferences for %s"
+msgstr "Bloqueja les preferències per %s"
+
+#: id:20153
+msgid "Browse..."
+msgstr "Explora..."
+
+#: id:20154
+msgid "Summary information"
+msgstr "Resum de la informació"
+
+#: id:20155
+msgid "Storage information"
+msgstr "Informació del emmagatzematge"
+
+#: id:20156
+msgid "Hard disk information"
+msgstr "Informació del disc dur"
+
+#: id:20157
+msgid "DVD-ROM information"
+msgstr "Informació del DVD-ROM"
+
+#: id:20158
+msgid "Network information"
+msgstr "Informació de la xarxa"
+
+#: id:20159
+msgid "Video information"
+msgstr "Informació del vídeo"
+
+#: id:20160
+msgid "Hardware information"
+msgstr "Informació del programari"
+
+#: id:20161
+msgid "Total"
+msgstr "Total"
+
+#: id:20162
+msgid "Used"
+msgstr "Utilitzat"
+
+#: id:20163
+msgid "of"
+msgstr "de"
+
+#: id:20164
+msgid "Locking not supported"
+msgstr "Locking not supported"
+
+#: id:20165
+msgid "Not locked"
+msgstr "Sense bloqueig"
+
+#: id:20166
+msgid "Locked"
+msgstr "Bloquejat"
+
+#: id:20167
+msgid "Frozen"
+msgstr "Frozen"
+
+#: id:20168
+msgid "Requires reset"
+msgstr "Requereix reinici"
+
+#: id:20169
+msgid "Week"
+msgstr "Setmana"
+
+#: id:20170
+msgid "Line"
+msgstr "Línia"
+
+#: id:20171
+msgid "Windows network (SMB)"
+msgstr "Xarxa de Windows (SMB)"
+
+#: id:20172
+msgid "XBMSP server"
+msgstr "Servidor XBMSP"
+
+#: id:20173
+msgctxt "Auto context with id 20173"
+msgid "FTP server"
+msgstr "Servidor FTP"
+
+#: id:20174
+msgid "iTunes music share (DAAP)"
+msgstr "Música compartida d'iTunes (DAAP)"
+
+#: id:20175
+msgid "UPnP server"
+msgstr "Servidor UPnP"
+
+#: id:20176
+msgid "Show video info"
+msgstr "Mostra la informació del vídeo"
+
+#: id:20177
+msgid "Done"
+msgstr "Fet"
+
+#: id:20178
+msgid "Shift"
+msgstr "Majúscules"
+
+#: id:20179
+msgid "Caps Lock"
+msgstr "Fixació de majúscules"
+
+#: id:20180
+msgid "Symbols"
+msgstr "Símbols"
+
+#: id:20181
+msgid "Backspace"
+msgstr "Retrocés"
+
+#: id:20182
+msgid "Space"
+msgstr "Espai"
+
+#: id:20183
+msgid "Reload skin"
+msgstr "Actualitza l'aparença"
+
+#: id:20184
+msgid "Rotate pictures using EXIF information"
+msgstr "Gira les imatges utilitzant la informació EXIF"
+
+#: id:20185
+msgid "Use poster view styles for TV shows"
+msgstr "Use poster view styles for TV shows"
+
+#: id:20186
+msgid "Please wait"
+msgstr "Si us plau, espereu"
+
+#: id:20187
+msgid "UPnP"
+msgstr ""
+
+#: id:20189
+msgid "Enable auto scrolling for plot & review"
+msgstr "Enable auto scrolling for plot & review"
+
+#: id:20190
+msgctxt "Auto context with id 20190"
+msgid "Custom"
+msgstr "Personalitzat"
+
+#: id:20191
+msgid "Enable debug logging"
+msgstr "Enable debug logging"
+
+#: id:20192
+msgid "Download additional information during updates"
+msgstr "Download additional information during updates"
+
+#: id:20193
+msgid "Default service for album information"
+msgstr "Default service for album information"
+
+#: id:20194
+msgid "Default service for artist information"
+msgstr "Default service for artist information"
+
+#: id:20195
+msgid "Change scraper"
+msgstr "Change scraper"
+
+#: id:20196
+msgid "Export music library"
+msgstr "Exporta la biblioteca de música"
+
+#: id:20197
+msgid "Import music library"
+msgstr "Importa la biblioteca de música"
+
+#: id:20198
+msgid "No artist found!"
+msgstr "No s'ha trobat l'artista"
+
+#: id:20199
+msgid "Downloading artist info failed"
+msgstr "Downloading artist info failed"
+
+#: id:20250
+msgid "Party on! (videos)"
+msgstr "Party on! (videos)"
+
+#: id:20251
+msgid "Mixing drinks (videos)"
+msgstr "Mixing drinks (videos)"
+
+#: id:20252
+msgid "Filling glasses (videos)"
+msgstr "Filling glasses (videos)"
+
+#: id:20253
+msgid "WebDAV server (HTTP)"
+msgstr "Servidor WebDAV (HTTP)"
+
+#: id:20254
+msgid "WebDAV server (HTTPS)"
+msgstr "Servidor WebDAV (HTTPS)"
+
+#: id:20255
+msgid "First logon, edit your profile"
+msgstr "First logon, edit your profile"
+
+#: id:20256
+msgid "HTS Tvheadend client"
+msgstr "HTS Tvheadend client"
+
+#: id:20257
+msgid "VDR Streamdev client"
+msgstr "VDR Streamdev client"
+
+#: id:20258
+msgid "MythTV client"
+msgstr "Client de MythTV"
+
+#: id:20259
+msgid "Network Filesystem (NFS)"
+msgstr "Network Filesystem (NFS)"
+
+#: id:20260
+msgid "Secure Shell (SSH/SFTP)"
+msgstr "Secure Shell (SSH/SFTP)"
+
+#: id:20261
+msgid "Apple Filing Protocol (AFP)"
+msgstr "Apple Filing Protocol (AFP)"
+
+#: id:20300
+msgid "Web server directory (HTTP)"
+msgstr "Directori del servidor web (HTTP)"
+
+#: id:20301
+msgid "Web server directory (HTTPS)"
+msgstr "Directori dels servidor web (HTTPS)"
+
+#: id:20302
+msgid "Unable to write to folder:"
+msgstr "No es pot escriure a la carpeta:"
+
+#: id:20303
+msgid "Do you want to skip and proceed?"
+msgstr "Do you want to skip and proceed?"
+
+#: id:20304
+msgid "RSS Feed"
+msgstr "Canal RSS"
+
+#: id:20307
+msgid "Secondary DNS"
+msgstr "DNS secundari"
+
+#: id:20308
+msgid "DHCP server:"
+msgstr "Servidor DHCP:"
+
+#: id:20309
+msgid "Make new folder"
+msgstr "Crea una carpeta"
+
+#: id:20310
+msgid "Dim LCD on playback"
+msgstr "Dim LCD on playback"
+
+#: id:20311
+msgid "Unknown or onboard (protected)"
+msgstr "Unknown or onboard (protected)"
+
+#: id:20312
+msgid "Dim LCD on paused"
+msgstr "Dim LCD on paused"
+
+#: id:20314
+msgid "Videos - Library"
+msgstr "Vídeos - Biblioteca"
+
+#: id:20316
+msgid "Sort by: ID"
+msgstr "Ordena per: ID"
+
+#: id:20324
+msgid "Play part..."
+msgstr "Play part..."
+
+#: id:20325
+msgid "Calibration reset"
+msgstr "Calibration reset"
+
+#: id:20326
+msgid "This will reset the calibration values for %s"
+msgstr "This will reset the calibration values for %s"
+
+#: id:20327
+msgid "to it's default values."
+msgstr "to it's default values."
+
+#: id:20328
+msgid "Browse for destination"
+msgstr "Browse for destination"
+
+#: id:20329
+msgid "Movies are in separate folders that match the movie title"
+msgstr ""
+
+#: id:20330
+msgid "Use folder names for lookups"
+msgstr "Use folder names for lookups"
+
+#: id:20331
+msgctxt "Auto context with id 20331"
+msgid "File"
+msgstr "Fitxer"
+
+#: id:20332
+msgid "Use file or folder names in lookups?"
+msgstr "Use file or folder names in lookups?"
+
+#: id:20333
+msgid "Set content"
+msgstr "Set content"
+
+#: id:20334
+msgid "Folder"
+msgstr "Carpeta"
+
+#: id:20335
+msgid "Look for content recursively?"
+msgstr "Look for content recursively?"
+
+#: id:20336
+msgid "Unlock sources"
+msgstr "Unlock sources"
+
+#: id:20337
+msgid "Actor"
+msgstr "Actor"
+
+#: id:20338
+msgid "Movie"
+msgstr "Pel·lícula"
+
+#: id:20339
+msgid "Director"
+msgstr "Director"
+
+#: id:20340
+msgid "Do you want to remove all items within"
+msgstr "Do you want to remove all items within"
+
+#: id:20341
+msgid "this path from the XBMC library?"
+msgstr "this path from the XBMC library?"
+
+#: id:20342
+msgctxt "Auto context with id 20342"
+msgid "Movies"
+msgstr "Pel·lícules"
+
+#: id:20343
+msgid "TV shows"
+msgstr "Sèries de TV"
+
+#: id:20344
+msgid "This directory contains"
+msgstr "Aquest directori conté"
+
+#: id:20345
+msgid "Run automated scan"
+msgstr "Run automated scan"
+
+#: id:20346
+msgid "Scan recursively"
+msgstr "Scan recursively"
+
+#: id:20347
+msgid "as"
+msgstr "com"
+
+#: id:20348
+msgid "Directors"
+msgstr "Directors"
+
+#: id:20349
+msgid "No video files found in this path!"
+msgstr "No video files found in this path!"
+
+#: id:20350
+msgid "votes"
+msgstr "vots"
+
+#: id:20351
+msgid "TV show information"
+msgstr "TV show information"
+
+#: id:20352
+msgid "Episode information"
+msgstr "Informació de l'episodi"
+
+#: id:20353
+msgid "Loading TV show details"
+msgstr "Loading TV show details"
+
+#: id:20354
+msgid "Fetching episode guide"
+msgstr "Fetching episode guide"
+
+#: id:20355
+msgid "Loading info for episodes in directory"
+msgstr "Loading info for episodes in directory"
+
+#: id:20356
+msgid "Select TV show:"
+msgstr "Select TV show:"
+
+#: id:20357
+msgid "Enter the TV show name"
+msgstr "Enter the TV show name"
+
+#: id:20358
+msgid "Season %i"
+msgstr "Temporada %i"
+
+#: id:20359
+msgid "Episode"
+msgstr "Episodi"
+
+#: id:20360
+msgid "Episodes"
+msgstr "Episodis"
+
+#: id:20361
+msgid "Loading episode details"
+msgstr "Loading episode details"
+
+#: id:20362
+msgid "Remove episode from library"
+msgstr "Remove episode from library"
+
+#: id:20363
+msgid "Remove TV show from library"
+msgstr "Remove TV show from library"
+
+#: id:20364
+msgid "TV show"
+msgstr "Serie de TV"
+
+#: id:20365
+msgid "Episode plot"
+msgstr "Episode plot"
+
+#: id:20366
+msgid "* All seasons"
+msgstr "* Totes les temporades"
+
+#: id:20367
+msgid "Hide watched"
+msgstr "Amaga els ja vistos"
+
+#: id:20368
+msgid "Prod code"
+msgstr "Prod code"
+
+#: id:20369
+msgid "Show plot for unwatched items"
+msgstr "Show plot for unwatched items"
+
+#: id:20370
+msgid "* Hidden to prevent spoilers *"
+msgstr "* Hidden to prevent spoilers *"
+
+#: id:20371
+msgid "Set season thumb"
+msgstr "Set season thumb"
+
+#: id:20372
+msgid "Season image"
+msgstr "Imatge de la temporada"
+
+#: id:20373
+msgid "Season"
+msgstr "Temporada"
+
+#: id:20374
+msgid "Downloading movie information"
+msgstr "S'està baixant la informació de la pel·lícula"
+
+#: id:20375
+msgid "Unassign content"
+msgstr "Unassign content"
+
+#: id:20376
+msgid "Original title"
+msgstr "Títol original"
+
+#: id:20377
+msgid "Refresh TV show information"
+msgstr "Refresh TV show information"
+
+#: id:20378
+msgid "Refresh info for all episodes?"
+msgstr "Refresh info for all episodes?"
+
+#: id:20379
+msgid "Selected folder contains a single TV show"
+msgstr "Selected folder contains a single TV show"
+
+#: id:20380
+msgid "Exclude selected folder from scans"
+msgstr "Exclude selected folder from scans"
+
+#: id:20381
+msgid "Specials"
+msgstr "Especials"
+
+#: id:20382
+msgid "Automatically grab season thumbs"
+msgstr "Automatically grab season thumbs"
+
+#: id:20383
+msgid "Selected folder contains a single video"
+msgstr "Selected folder contains a single video"
+
+#: id:20384
+msgid "Link to TV show"
+msgstr "Link to TV show"
+
+#: id:20385
+msgid "Remove link to TV show"
+msgstr "Remove link to TV show"
+
+#: id:20386
+msgid "Recently added movies"
+msgstr "Recently added movies"
+
+#: id:20387
+msgid "Recently added episodes"
+msgstr "Recently added episodes"
+
+#: id:20388
+msgid "Studios"
+msgstr "Studios"
+
+#: id:20389
+msgid "Music videos"
+msgstr "Music videos"
+
+#: id:20390
+msgid "Recently added music videos"
+msgstr "Recently added music videos"
+
+#: id:20391
+msgid "Music video"
+msgstr "Music video"
+
+#: id:20392
+msgid "Remove music video from library"
+msgstr "Remove music video from library"
+
+#: id:20393
+msgctxt "Auto context with id 20393"
+msgid "Music video information"
+msgstr "Music video information"
+
+#: id:20394
+msgid "Loading music video information"
+msgstr "Loading music video information S'està carregant"
+
+#: id:20395
+msgid "Mixed"
+msgstr "Mixed"
+
+#: id:20396
+msgid "Go to albums by artist"
+msgstr "Go to albums by artist"
+
+#: id:20397
+msgid "Go to album"
+msgstr "Go to album"
+
+#: id:20398
+msgid "Play song"
+msgstr "Reprodueix la cançó"
+
+#: id:20399
+msgid "Go to music videos from album"
+msgstr "Go to music videos from album"
+
+#: id:20400
+msgid "Go to music videos by artist"
+msgstr "Go to music videos by artist"
+
+#: id:20401
+msgid "Play music video"
+msgstr "Play music video"
+
+#: id:20402
+msgid "Download actor thumbnails when adding to library"
+msgstr "Download actor thumbnails when adding to library"
+
+#: id:20403
+msgid "Set actor thumb"
+msgstr "Set actor thumb"
+
+#: id:20405
+msgid "Remove episode bookmark"
+msgstr "Remove episode bookmark"
+
+#: id:20406
+msgid "Set episode bookmark"
+msgstr "Set episode bookmark"
+
+#: id:20407
+msgid "Scraper settings"
+msgstr "Scraper settings"
+
+#: id:20408
+msgid "Downloading music video information"
+msgstr "S'està baixant la informació del videoclip"
+
+#: id:20409
+msgid "Downloading TV show information"
+msgstr "S'està baixant la informació del programa de televisió"
+
+#: id:20410
+msgid "Trailer"
+msgstr "Trailer"
+
+#: id:20411
+msgid "Flatten"
+msgstr "Flatten"
+
+#: id:20412
+msgid "Flatten TV shows"
+msgstr "Flatten TV shows"
+
+#: id:20413
+msgid "Get fanart"
+msgstr "Get fanart"
+
+#: id:20414
+msgid "Show Fanart in video and music libraries"
+msgstr "Show Fanart in video and music libraries"
+
+#: id:20415
+msgid "Scanning for new content"
+msgstr "S'està cercant nou contingut"
+
+#: id:20416
+msgid "First aired"
+msgstr "Emés per primera vegada"
+
+#: id:20417
+msgid "Writer"
+msgstr "Escriptor"
+
+#: id:20419
+msgid "Replace file names with library titles"
+msgstr "Mostra les metadades en la vista de fitxers"
+
+#: id:20420
+msgctxt "Auto context with id 20420"
+msgid "Never"
+msgstr "Mai"
+
+#: id:20421
+msgid "If only one season"
+msgstr "Si només hi ha una temporada"
+
+#: id:20422
+msgid "Always"
+msgstr "Sempre"
+
+#: id:20423
+msgid "Has trailer"
+msgstr "Té trailer"
+
+#: id:20424
+msgid "False"
+msgstr "Fals"
+
+#: id:20425
+msgid "Fanart slideshow"
+msgstr "Fanart slideshow"
+
+#: id:20426
+msgid "Export to a single file or separate"
+msgstr "Export to a single file or separate"
+
+#: id:20427
+msgid "files per entry?"
+msgstr "files per entry?"
+
+#: id:20428
+msgid "Single file"
+msgstr "Un sol fitxer"
+
+#: id:20429
+msgctxt "Auto context with id 20429"
+msgid "Separate"
+msgstr "Separat"
+
+#: id:20430
+msgid "Export thumbnails and fanart?"
+msgstr "Export thumbnails and fanart?"
+
+#: id:20431
+msgid "Overwrite old files?"
+msgstr "Overwrite old files?"
+
+#: id:20432
+msgid "Exclude path from library updates"
+msgstr "Exclude path from library updates"
+
+#: id:20433
+msgid "Extract thumbnails and video information"
+msgstr "Extract thumbnails and video information"
+
+#: id:20434
+msgid "Sets"
+msgstr "Sets"
+
+#: id:20435
+msgid "Set movieset thumb"
+msgstr "Set movieset thumb"
+
+#: id:20436
+msgid "Export actor thumbs?"
+msgstr "Export actor thumbs?"
+
+#: id:20437
+msgid "Choose fanart"
+msgstr "Trieu un fanart"
+
+#: id:20438
+msgid "Local fanart"
+msgstr "Fanart local"
+
+#: id:20439
+msgid "No fanart"
+msgstr "Sense fanart"
+
+#: id:20440
+msgid "Current fanart"
+msgstr "Fanart actual"
+
+#: id:20441
+msgid "Remote fanart"
+msgstr "Fanart remot"
+
+#: id:20442
+msgid "Change content"
+msgstr "Canvia el contingut"
+
+#: id:20443
+msgid "Do you want to refresh info for all"
+msgstr "Do you want to refresh info for all"
+
+#: id:20444
+msgid "items within this path?"
+msgstr "items within this path?"
+
+#: id:20445
+msgid "Fanart"
+msgstr "Fanart"
+
+#: id:20446
+msgid "Locally stored information found."
+msgstr "S'ha trobat la informació emmagatzemada localment."
+
+#: id:20447
+msgid "Ignore and refresh from internet?"
+msgstr "Ignore and refresh from internet?"
+
+#: id:20448
+msgid "Could not download information"
+msgstr "No s'ha pogut baixar la informació"
+
+#: id:20449
+msgid "Unable to connect to remote server"
+msgstr "No es pot connectar al servidor remot"
+
+#: id:20450
+msgid "Would you like to continue scanning?"
+msgstr "Would you like to continue scanning?"
+
+#: id:20451
+msgid "Countries"
+msgstr "Països"
+
+#: id:20452
+msgid "episode"
+msgstr "episodi"
+
+#: id:20453
+msgid "episodes"
+msgstr "episodis"
+
+#: id:20454
+msgid "Listener"
+msgstr "Oient"
+
+#: id:20455
+msgid "Listeners"
+msgstr "Oients"
+
+#: id:20456
+msgid "Set movieset fanart"
+msgstr "Set movieset fanart"
+
+#: id:20457
+msgid "Movie set"
+msgstr "Movie set"
+
+#: id:20458
+msgid "Group movies in sets"
+msgstr ""
+
+#: id:21330
+msgid "Show hidden files and directories"
+msgstr "Mostra els fitxers i directoris ocults"
+
+#: id:21331
+msgid "TuxBox client"
+msgstr "Client de TuxBox"
+
+#: id:21332
+msgid "WARNING: Target TuxBox device is in recording-mode!"
+msgstr "WARNING: Target TuxBox device is in recording-mode!"
+
+#: id:21333
+msgid "The stream will be stopped!"
+msgstr "The stream will be stopped!"
+
+#: id:21334
+msgid "Zap to channel: %s failed!"
+msgstr "Zap to channel: %s failed!"
+
+#: id:21335
+msgid "Are you sure to start the stream?"
+msgstr "Are you sure to start the stream?"
+
+#: id:21336
+msgid "Connecting to: %s"
+msgstr "S'està connectant a: %s"
+
+#: id:21337
+msgid "TuxBox device"
+msgstr "Unitat de TuxBox"
+
+#: id:21359
+msgid "Add media share..."
+msgstr "Afegeix recurs compartit..."
+
+#: id:21360
+msgid "Share video and music libraries through UPnP"
+msgstr "Comparteix les biblioteques de vídeo i música a través de UPnP"
+
+#: id:21364
+msgid "Edit media share"
+msgstr "Edita recurs compartit"
+
+#: id:21365
+msgid "Remove media share"
+msgstr "Elimina recurs compartit"
+
+#: id:21366
+msgid "Subtitle folder"
+msgstr "Carpeta del subtítol"
+
+#: id:21367
+msgid "Movie & alternate subtitle directory"
+msgstr "Movie & alternate subtitle directory"
+
+#: id:21368
+msgid "Override ASS/SSA subtitles fonts"
+msgstr "Substitueix les fonts dels subtítols ASS/SSA"
+
+#: id:21369
+msgid "Enable mouse and Touch Screen support"
+msgstr "Activa el suport de ratolí i pantalla tàctil"
+
+#: id:21370
+msgid "Play navigation sounds during media playback"
+msgstr "Reprodueix els sons de navegació durant la reproducció"
+
+#: id:21371
+msgid "Thumbnail"
+msgstr "Miniatura"
+
+#: id:21372
+msgid "Forced DVD player region"
+msgstr "Força la regió del reproductor DVD"
+
+#: id:21373
+msgid "Video output"
+msgstr "Sortida de vídeo"
+
+#: id:21374
+msgid "Video aspect"
+msgstr "Aspecte del vídeo"
+
+#: id:21375
+msgctxt "Auto context with id 21375"
+msgid "Normal"
+msgstr "Normal"
+
+#: id:21376
+msgid "Letterbox"
+msgstr "Letterbox"
+
+#: id:21377
+msgid "Widescreen"
+msgstr "Widescreen"
+
+#: id:21378
+msgid "Enable 480p"
+msgstr "Activa 480p"
+
+#: id:21379
+msgid "Enable 720p"
+msgstr "Activa 720p"
+
+#: id:21380
+msgid "Enable 1080i"
+msgstr "Activa 1080i"
+
+#: id:21381
+msgid "Enter name of new playlist"
+msgstr "Introduïu el nom de la nova llista de reproducció"
+
+#: id:21382
+msgid "Show \"Add source\" buttons in file lists"
+msgstr "Mostra els botons \"Afegeix font\" en les llistes de fitxers"
+
+#: id:21383
+msgid "Enable scrollbars"
+msgstr "Activa les barres de desplaçament"
+
+#: id:21384
+msgid "Make watched filtering a toggle in video library"
+msgstr "Make watched filtering a toggle in video library"
+
+#: id:21385
+msgctxt "Auto context with id 21385"
+msgid "Open"
+msgstr "Obre"
+
+#: id:21386
+msgid "Acoustic management level"
+msgstr "Acoustic management level"
+
+#: id:21387
+msgid "Fast"
+msgstr "Ràpid"
+
+#: id:21388
+msgid "Quiet"
+msgstr "Silenciós"
+
+#: id:21389
+msgid "Enable custom background"
+msgstr "Enable custom background"
+
+#: id:21390
+msgid "Power management level"
+msgstr "Power management level"
+
+#: id:21391
+msgid "High power"
+msgstr "High power"
+
+#: id:21392
+msgid "Low power"
+msgstr "Low power"
+
+#: id:21393
+msgid "High standby"
+msgstr "High standby"
+
+#: id:21394
+msgid "Low standby"
+msgstr "Low standby"
+
+#: id:21395
+msgid "Unable to cache files bigger than 4GB"
+msgstr "Unable to cache files bigger than 4GB"
+
+#: id:21396
+msgid "Chapter"
+msgstr "Capítol"
+
+#: id:21397
+msgid "High quality pixel shader v2"
+msgstr "High quality pixel shader v2"
+
+#: id:21398
+msgid "Enable playlist at startup"
+msgstr "Enable playlist at startup"
+
+#: id:21399
+msgid "Use tween animations"
+msgstr "Use tween animations"
+
+#: id:21400
+msgid "contains"
+msgstr "conté"
+
+#: id:21401
+msgid "does not contain"
+msgstr "no conté"
+
+#: id:21402
+msgid "is"
+msgstr "és"
+
+#: id:21403
+msgid "is not"
+msgstr "no és"
+
+#: id:21404
+msgid "starts with"
+msgstr "comença amb"
+
+#: id:21405
+msgid "ends with"
+msgstr "acaba amb"
+
+#: id:21406
+msgid "greater than"
+msgstr "més gran que"
+
+#: id:21407
+msgid "less than"
+msgstr "inferior a"
+
+#: id:21408
+msgid "after"
+msgstr "després"
+
+#: id:21409
+msgid "before"
+msgstr "abans"
+
+#: id:21410
+msgid "in the last"
+msgstr "a la última"
+
+#: id:21411
+msgid "not in the last"
+msgstr "no a la última"
+
+#: id:21412
+msgid "Scrapers"
+msgstr "Scrapers"
+
+#: id:21413
+msgid "Default movie scraper"
+msgstr "Default movie scraper"
+
+#: id:21414
+msgid "Default tvshow scraper"
+msgstr "Default tvshow scraper"
+
+#: id:21415
+msgid "Default music video scraper"
+msgstr "Default music video scraper"
+
+#: id:21416
+msgid "Enable fallback based on scraper language"
+msgstr "Enable fallback based on scraper language"
+
+#: id:21417
+msgid "- Settings"
+msgstr "- Configuració"
+
+#: id:21418
+msgid "Multilingual"
+msgstr "Multilingüe"
+
+#: id:21419
+msgid "No scrapers present"
+msgstr "No scrapers present"
+
+#: id:21420
+msgid "Value to match"
+msgstr "Value to match"
+
+#: id:21421
+msgid "Smart playlist rule"
+msgstr "Regla de llista de reproducció intel·ligent"
+
+#: id:21422
+msgid "Match items where"
+msgstr "Match items where"
+
+#: id:21423
+msgid "New rule..."
+msgstr "Regla nova..."
+
+#: id:21424
+msgid "Items must match"
+msgstr "Els elements han de coincidir"
+
+#: id:21425
+msgid "all of the rules"
+msgstr "totes les regles"
+
+#: id:21426
+msgid "one or more of the rules"
+msgstr "una o més de les regles"
+
+#: id:21427
+msgid "Limit to"
+msgstr "Limita a"
+
+#: id:21428
+msgid "No limit"
+msgstr "Sense límit"
+
+#: id:21429
+msgid "Order by"
+msgstr "Ordena per"
+
+#: id:21430
+msgid "ascending"
+msgstr "ascendent"
+
+#: id:21431
+msgid "descending"
+msgstr "descendent"
+
+#: id:21432
+msgid "Edit smart playlist"
+msgstr "Edita la llista de reproducció intel·ligent"
+
+#: id:21433
+msgid "Name of the playlist"
+msgstr "Nom de la llista de reproducció"
+
+#: id:21434
+msgid "Find items where"
+msgstr "Cerca elements que"
+
+#: id:21435
+msgid "Edit"
+msgstr "Edita"
+
+#: id:21436
+msgid "%i items"
+msgstr "%i elements"
+
+#: id:21437
+msgid "New smart playlist..."
+msgstr "Nova llista de reproducció intel·ligent..."
+
+#: id:21438
+msgid "%c Drive"
+msgstr "%c Unitat"
+
+#: id:21439
+msgid "Edit party mode rules"
+msgstr "Edita les regles del mode festa"
+
+#: id:21440
+msgid "Home folder"
+msgstr "Carpeta principal"
+
+#: id:21441
+msgid "Watched count"
+msgstr "Visualitzacions"
+
+#: id:21442
+msgid "Episode title"
+msgstr "Títol de l'episodi"
+
+#: id:21443
+msgid "Video resolution"
+msgstr "Resolució del vídeo"
+
+#: id:21444
+msgid "Audio channels"
+msgstr "Canals d'àudio"
+
+#: id:21445
+msgid "Video codec"
+msgstr "Còdec de vídeo"
+
+#: id:21446
+msgid "Audio codec"
+msgstr "Còdec d'àudio"
+
+#: id:21447
+msgid "Audio language"
+msgstr "Idioma de l'àudio"
+
+#: id:21448
+msgid "Subtitle language"
+msgstr "Idioma dels subtítols"
+
+#: id:21449
+msgid "Remote control sends keyboard presses"
+msgstr "El control remot envia pulsacions de teclat"
+
+#: id:21450
+msgid "- Edit"
+msgstr "- Edita"
+
+#: id:21451
+msgid "Internet connection required."
+msgstr "Es necessita connexió a Internet."
+
+#: id:21452
+msgid "Get More..."
+msgstr "Aconseguiu-ne més..."
+
+#: id:21453
+msgid "Root filesystem"
+msgstr "Sistema de fitxers arrel"
+
+#: id:21454
+msgid "Cache full"
+msgstr ""
+
+#: id:21455
+msgid "Cache filled before reaching required amount for continous playback"
+msgstr ""
+
+#: id:21460
+msgid "Subtitle location"
+msgstr "Subtitle location"
+
+#: id:21461
+msgid "Fixed"
+msgstr "Fixed"
+
+#: id:21462
+msgid "Bottom of video"
+msgstr "Bottom of video"
+
+#: id:21463
+msgid "Below video"
+msgstr "Below video"
+
+#: id:21464
+msgid "Top of video"
+msgstr "Top of video"
+
+#: id:21465
+msgid "Above video"
+msgstr "Above video"
+
+#: id:21800
+msgid "File name"
+msgstr "Nom del fitxer"
+
+#: id:21801
+msgid "File path"
+msgstr "Cami del fitxer"
+
+#: id:21802
+msgid "File size"
+msgstr "Mida del fitxer"
+
+#: id:21803
+msgid "File date/time"
+msgstr "Data/Hora fitxer"
+
+#: id:21804
+msgid "Slide index"
+msgstr "Índex de diapositives"
+
+#: id:21805
+msgctxt "Auto context with id 21805"
+msgid "Resolution"
+msgstr "Resolució"
+
+#: id:21806
+msgctxt "Auto context with id 21806"
+msgid "Comment"
+msgstr "Comentari"
+
+#: id:21807
+msgid "Colour/B&W"
+msgstr "Color - B/N"
+
+#: id:21808
+msgid "JPEG process"
+msgstr "Processat JPEG"
+
+#: id:21820
+msgid "Date/Time"
+msgstr "Data/Hora"
+
+#: id:21821
+msgid "Description"
+msgstr "Descripció"
+
+#: id:21822
+msgid "Camera make"
+msgstr "Marca càmera"
+
+#: id:21823
+msgid "Camera model"
+msgstr "Model càmera"
+
+#: id:21824
+msgid "EXIF comment"
+msgstr "Comentari EXIF"
+
+#: id:21825
+msgid "Firmware"
+msgstr "Microprogramari"
+
+#: id:21826
+msgid "Aperture"
+msgstr "Obertura"
+
+#: id:21827
+msgid "Focal length"
+msgstr "Longitud focal"
+
+#: id:21828
+msgid "Focus distance"
+msgstr "Distància focal"
+
+#: id:21829
+msgid "Exposure"
+msgstr "Exposició"
+
+#: id:21830
+msgid "Exposure time"
+msgstr "Temps exposició"
+
+#: id:21831
+msgid "Exposure bias"
+msgstr "Compensació d'exposició"
+
+#: id:21832
+msgid "Exposure mode"
+msgstr "Mode exposició"
+
+#: id:21833
+msgid "Flash used"
+msgstr "Flaix disparat"
+
+#: id:21834
+msgid "White-balance"
+msgstr "Balanç blancs"
+
+#: id:21835
+msgid "Light source"
+msgstr "Font de llum"
+
+#: id:21836
+msgid "Metering mode"
+msgstr "Mode mesura"
+
+#: id:21837
+msgid "ISO"
+msgstr "ISO"
+
+#: id:21838
+msgid "Digital zoom"
+msgstr "Zoom digital"
+
+#: id:21839
+msgid "CCD width"
+msgstr "Amplada del CCD"
+
+#: id:21840
+msgid "GPS latitude"
+msgstr "Latitud GPS"
+
+#: id:21841
+msgid "GPS longitude"
+msgstr "Longitud GPS"
+
+#: id:21842
+msgid "GPS altitude"
+msgstr "Altitud GPS"
+
+#: id:21843
+msgid "Orientation"
+msgstr "Orientació"
+
+#: id:21860
+msgid "Supplemental categories"
+msgstr "Categories suplementaries"
+
+#: id:21861
+msgid "Keywords"
+msgstr "Paraules clau"
+
+#: id:21862
+msgid "Caption"
+msgstr "Títol"
+
+#: id:21863
+msgid "Author"
+msgstr "Autor"
+
+#: id:21864
+msgid "Headline"
+msgstr "Titular"
+
+#: id:21865
+msgid "Special instructions"
+msgstr "Instruccions especials"
+
+#: id:21866
+msgid "Category"
+msgstr "Categoria"
+
+#: id:21867
+msgid "Byline"
+msgstr "Línia d'autor"
+
+#: id:21868
+msgid "Byline title"
+msgstr "Títol de la línia d'autor"
+
+#: id:21869
+msgid "Credit"
+msgstr "Crèdit"
+
+#: id:21870
+msgid "Source"
+msgstr "Font"
+
+#: id:21871
+msgid "Copyright notice"
+msgstr "Avís dels drets d'autor"
+
+#: id:21872
+msgid "Object name"
+msgstr "Nom de l'objecte"
+
+#: id:21873
+msgid "City"
+msgstr "Ciutat"
+
+#: id:21874
+msgid "State"
+msgstr "Estat"
+
+#: id:21875
+msgctxt "Auto context with id 21875"
+msgid "Country"
+msgstr "País"
+
+#: id:21876
+msgid "Original Tx Reference"
+msgstr "Referència Tx original"
+
+#: id:21877
+msgid "Date created"
+msgstr "Data de creació"
+
+#: id:21878
+msgid "Copyright flag"
+msgstr "Marca dels drets d'autor"
+
+#: id:21879
+msgid "Country code"
+msgstr "Codi del país"
+
+#: id:21880
+msgid "Reference service"
+msgstr "Servei de referència"
+
+#: id:21881
+msgid "Allow control of XBMC via UPnP"
+msgstr "Permet el control de l'XBMC a través de UPnP"
+
+#: id:21882
+msgid "Attempt to skip introduction before DVD menu"
+msgstr "Intenta ometre la introducció d'abans del menú del DVD"
+
+#: id:21883
+msgid "Saved music"
+msgstr "Música desada"
+
+#: id:21884
+msgid "Query info for all artists"
+msgstr "Consulta la informació per a tots els artistes"
+
+#: id:21885
+msgid "Downloading album information"
+msgstr "S'està baixant la informació de l'àlbum"
+
+#: id:21886
+msgid "Downloading artist information"
+msgstr "S'està baixant la informació de l'artista"
+
+#: id:21887
+msgid "Biography"
+msgstr "Biografia"
+
+#: id:21888
+msgid "Discography"
+msgstr "Discografia"
+
+#: id:21889
+msgid "Searching artist"
+msgstr "S'està buscant l'artista"
+
+#: id:21890
+msgid "Select artist"
+msgstr "Seleccioneu artista"
+
+#: id:21891
+msgctxt "Auto context with id 21891"
+msgid "Artist information"
+msgstr "Informació de l'artista"
+
+#: id:21892
+msgid "Instruments"
+msgstr "Instruments"
+
+#: id:21893
+msgid "Born"
+msgstr "Nascut"
+
+#: id:21894
+msgid "Formed"
+msgstr "Format"
+
+#: id:21895
+msgid "Themes"
+msgstr "Temes"
+
+#: id:21896
+msgid "Disbanded"
+msgstr "Separat"
+
+#: id:21897
+msgid "Died"
+msgstr "Mort"
+
+#: id:21898
+msgid "Years active"
+msgstr "Anys d'activitat"
+
+#: id:21899
+msgid "Label"
+msgstr "Etiqueta"
+
+#: id:21900
+msgid "Born/Formed"
+msgstr "Nascut / Formació"
+
+#: id:22000
+msgid "Update library on startup"
+msgstr "Actualitza la biblioteca a l'arrancada"
+
+#: id:22001
+msgid "Hide progress of library updates"
+msgstr "Amaga el progrés d'actualització de la biblioteca"
+
+#: id:22002
+msgid "- DNS suffix"
+msgstr "- Sufix del DNS"
+
+#: id:22003
+msgid "%2.3fs"
+msgstr "%2.3fs"
+
+#: id:22004
+msgid "Delayed by: %2.3fs"
+msgstr "Retardat en: %2.3fs"
+
+#: id:22005
+msgid "Ahead by: %2.3fs"
+msgstr "Avançat en: %2.3fs"
+
+#: id:22006
+msgid "Subtitle offset"
+msgstr "Òfset dels subtítols"
+
+#: id:22007
+msgid "OpenGL vendor:"
+msgstr "Proveïdor OpenGL:"
+
+#: id:22008
+msgid "OpenGL renderer:"
+msgstr "Renderitzador OpenGL renderer:"
+
+#: id:22009
+msgid "OpenGL version:"
+msgstr "Versió OpenGL:"
+
+#: id:22010
+msgid "GPU temperature:"
+msgstr "Temperatura de la GPU:"
+
+#: id:22011
+msgid "CPU temperature:"
+msgstr "Temperatura de la CPU:"
+
+#: id:22012
+msgid "Total memory"
+msgstr "Memòria total"
+
+#: id:22013
+msgid "Profile data"
+msgstr "Informació del perfil"
+
+#: id:22014
+msgid "Use dim if paused during video playback"
+msgstr "Utilitza l'atenuació si està en pausa durant la reproducció de vídeo"
+
+#: id:22015
+msgid "All recordings"
+msgstr "Tots els enregistraments"
+
+#: id:22016
+msgid "By title"
+msgstr "Per títol"
+
+#: id:22017
+msgid "By group"
+msgstr "Per grup"
+
+#: id:22018
+msgid "Live channels"
+msgstr "Canals en directe"
+
+#: id:22019
+msgid "Recordings by title"
+msgstr "Enregistraments per títol"
+
+#: id:22020
+msgid "Guide"
+msgstr "Guia"
+
+#: id:22021
+msgid "Allowed error in aspect ratio to minimize black bars"
+msgstr "Allowed error in aspect ratio to minimize black bars"
+
+#: id:22022
+msgid "Show video files in listings"
+msgstr "Mostra els arxius de vídeo en llistats"
+
+#: id:22023
+msgid "DirectX vendor:"
+msgstr "Proveïdor de DirectX:"
+
+#: id:22024
+msgid "Direct3D version:"
+msgstr "Versió de Direct3D:"
+
+#: id:22030
+msgctxt "Auto context with id 22030"
+msgid "Font"
+msgstr "Font"
+
+#: id:22031
+msgctxt "Auto context with id 22031"
+msgid "- Size"
+msgstr "- Mida"
+
+#: id:22032
+msgctxt "Auto context with id 22032"
+msgid "- Colours"
+msgstr "- Colors"
+
+#: id:22033
+msgid "- Charset"
+msgstr "- Joc de caràcters"
+
+#: id:22034
+msgid "Export karaoke titles as HTML"
+msgstr "Exporta els títols del karaoke com a HTML"
+
+#: id:22035
+msgid "Export karaoke titles as CSV"
+msgstr "Exporta els títols del karaoke com a CSV"
+
+#: id:22036
+msgid "Import karaoke titles..."
+msgstr "Importa els títols del karaoke"
+
+#: id:22037
+msgid "Show song selector automatically"
+msgstr "Mostra el selector de cançons de forma automàtica"
+
+#: id:22038
+msgid "Export karaoke titles..."
+msgstr "Exporta els títols del karaoke"
+
+#: id:22039
+msgid "Enter song number"
+msgstr "Introduïu el número de cançó"
+
+#: id:22040
+msgid "white/green"
+msgstr "blanc/verd"
+
+#: id:22041
+msgid "white/red"
+msgstr "blanc/vermell"
+
+#: id:22042
+msgid "white/blue"
+msgstr "blanc/blau"
+
+#: id:22043
+msgid "black/white"
+msgstr "negre/blanc"
+
+#: id:22079
+msgid "Default select action"
+msgstr "Acció de selecció per defecte"
+
+#: id:22080
+msgid "Choose"
+msgstr "Trieu"
+
+#: id:22081
+msgid "Show Information"
+msgstr "Mostra la informació"
+
+#: id:22082
+msgid "More..."
+msgstr "Més..."
+
+#: id:22083
+msgid "Play all"
+msgstr "Reproduir totes"
+
+#: id:23049
+msgid "Teletext not available"
+msgstr "Teletext no disponible"
+
+#: id:23050
+msgid "Activate Teletext"
+msgstr "Activa el teletext"
+
+#: id:23051
+msgid "Part %i"
+msgstr "Part %i"
+
+#: id:23052
+msgid "Buffering %i bytes"
+msgstr "S'està emplenant la memòria intermèdia amb %i bytes"
+
+#: id:23053
+msgid "Stopping"
+msgstr "S'està aturant"
+
+#: id:23054
+msgid "Running"
+msgstr "S'està executant"
+
+#: id:23100
+msgid "External Player Active"
+msgstr "Reproductor extern activat"
+
+#: id:23101
+msgid "Click OK to terminate the player"
+msgstr "Feu clic a «D'acord» per finalitzar el reproductor"
+
+#: id:23104
+msgid "Click OK when playback has ended"
+msgstr "Feu clic a «D'acord» quan la reproducció hagi finalitzat"
+
+#: id:24000
+msgid "Add-on"
+msgstr "Complement"
+
+#: id:24001
+msgid "Add-ons"
+msgstr "Complements"
+
+#: id:24002
+msgid "Add-on options"
+msgstr "Opcions del complement"
+
+#: id:24003
+msgid "Add-on Information"
+msgstr "Informació del complement"
+
+#: id:24005
+msgctxt "Auto context with id 24005"
+msgid "Media sources"
+msgstr "Fonts multimèdia"
+
+#: id:24007
+msgctxt "Auto context with id 24007"
+msgid "Movie information"
+msgstr "Informació de la pel·lícula"
+
+#: id:24008
+msgctxt "Auto context with id 24008"
+msgid "Screensaver"
+msgstr "Estalvi de pantalla"
+
+#: id:24009
+msgid "Script"
+msgstr "Script"
+
+#: id:24010
+msgctxt "Auto context with id 24010"
+msgid "Visualization"
+msgstr "Visualització"
+
+#: id:24011
+msgid "Add-on repository"
+msgstr "Dipòsit de complements"
+
+#: id:24012
+msgctxt "Auto context with id 24012"
+msgid "Subtitles"
+msgstr "Subtítols"
+
+#: id:24013
+msgid "Lyrics"
+msgstr "Lletres"
+
+#: id:24014
+msgid "TV information"
+msgstr "Informació de la televisió"
+
+#: id:24015
+msgctxt "Auto context with id 24015"
+msgid "Music video information"
+msgstr "Informació del vídeo musical"
+
+#: id:24016
+msgctxt "Auto context with id 24016"
+msgid "Album information"
+msgstr "Informació de l'àlbum"
+
+#: id:24017
+msgctxt "Auto context with id 24017"
+msgid "Artist information"
+msgstr "Informació de l'artista"
+
+#: id:24018
+msgctxt "Auto context with id 24018"
+msgid "Services"
+msgstr "Serveis"
+
+#: id:24020
+msgid "Configure"
+msgstr "Configura"
+
+#: id:24021
+msgctxt "Auto context with id 24021"
+msgid "Disable"
+msgstr "Desactiva"
+
+#: id:24022
+msgid "Enable"
+msgstr "Activa"
+
+#: id:24023
+msgid "Add-on disabled"
+msgstr "Complement desactivat"
+
+#: id:24027
+msgctxt "Auto context with id 24027"
+msgid "Weather"
+msgstr "El temps"
+
+#: id:24028
+msgid "Weather.com (standard)"
+msgstr "Weather.com (estàndard)"
+
+#: id:24030
+msgid "This Add-on can not be configured"
+msgstr "Aquest complement no es pot configurar"
+
+#: id:24031
+msgid "Error loading settings"
+msgstr "S'ha produït un error en carregar la configuració"
+
+#: id:24032
+msgid "All Add-ons"
+msgstr "Tots els complements"
+
+#: id:24033
+msgid "Get Add-ons"
+msgstr "Aconsegueix complements"
+
+#: id:24034
+msgid "Check for updates"
+msgstr "Comprova si hi ha actualitzacions"
+
+#: id:24035
+msgid "Force refresh"
+msgstr "Força el refresc"
+
+#: id:24036
+msgid "Change log"
+msgstr "Registre de canvis"
+
+#: id:24037
+msgid "Uninstall"
+msgstr "Desinstal·la"
+
+#: id:24038
+msgid "Install"
+msgstr "Instal·la"
+
+#: id:24039
+msgid "Disabled Add-ons"
+msgstr "Complements desactivats"
+
+#: id:24040
+msgid "(Clear the current setting)"
+msgstr "(Esborra la configuració actual)"
+
+#: id:24041
+msgid "Install from zip file"
+msgstr "Instal·la des d'un fitxer zip"
+
+#: id:24042
+msgid "Downloading %i%%"
+msgstr "S'està baixant %i%%"
+
+#: id:24043
+msgid "Available Updates"
+msgstr "Actualitzacions disponibles"
+
+#: id:24044
+msgid "Dependencies not met"
+msgstr "Les dependències no es compleixen"
+
+#: id:24045
+msgid "Add-on does not have the correct structure"
+msgstr "El complement no té l'estructura correcta"
+
+#: id:24046
+msgid "%s is used by the following installed add-on(s)"
+msgstr "%s és utilitzat per la instal·lació dels següents complements"
+
+#: id:24047
+msgid "This add-on cannot be uninstalled"
+msgstr "Aquest complement no es pot desinstal·lar"
+
+#: id:24048
+msgid "Rollback"
+msgstr "Rollback"
+
+#: id:24050
+msgid "Available Add-ons"
+msgstr "Complements disponibles"
+
+#: id:24051
+msgid "Version:"
+msgstr "Versió:"
+
+#: id:24052
+msgid "Disclaimer"
+msgstr "Aclaració"
+
+#: id:24053
+msgid "License:"
+msgstr "Llicència:"
+
+#: id:24054
+msgid "Changelog"
+msgstr "Registre de canvis"
+
+#: id:24059
+msgid "Would you like to enable this Add-on?"
+msgstr "Voleu activar aquest complement?"
+
+#: id:24060
+msgid "Would you like to disable this Add-on?"
+msgstr "Voleu desactivar aquest complement?"
+
+#: id:24061
+msgid "Add-on update available!"
+msgstr "Hi ha una actualització per el complement disponible"
+
+#: id:24062
+msgid "Enabled Add-ons"
+msgstr "Complements activats"
+
+#: id:24063
+msgid "Auto update"
+msgstr "Actualització automàtica"
+
+#: id:24064
+msgid "Add-on enabled"
+msgstr "Complement activat"
+
+#: id:24065
+msgid "Add-on updated"
+msgstr "Complement actualitzat"
+
+#: id:24066
+msgid "Cancel Add-on download?"
+msgstr "Voleu cancel·lar la baixada del complement?"
+
+#: id:24067
+msgid "Currently downloading Add-ons"
+msgstr "S'estan baixant complements"
+
+#: id:24068
+msgid "Update available"
+msgstr "Actualització disponible"
+
+#: id:24069
+msgid "Update"
+msgstr "Actualitza"
+
+#: id:24070
+msgid "Add-on could not be loaded."
+msgstr "No s'ha pogut carregar el complement."
+
+#: id:24071
+msgid "An unknown error has occurred."
+msgstr "S'ha produït un error desconegut."
+
+#: id:24072
+msgid "Settings required"
+msgstr "Paràmetres necessaris"
+
+#: id:24073
+msgid "Could not connect"
+msgstr "No s'ha pogut connectar"
+
+#: id:24074
+msgid "Needs to restart"
+msgstr "És necessari reiniciar"
+
+#: id:24075
+msgctxt "Auto context with id 24075"
+msgid "Disable"
+msgstr "Desactiva"
+
+#: id:24076
+msgid "Add-on Required"
+msgstr "Complement necessari"
+
+#: id:24080
+msgid "Try to reconnect?"
+msgstr "Voleu tornar a provar de connectar?"
+
+#: id:24089
+msgid "Add-on restarts"
+msgstr "Reinicia el complement"
+
+#: id:24090
+msgid "Lock Add-on manager"
+msgstr "Bloqueja el gestor de complements"
+
+#: id:24094
+msgid "(current)"
+msgstr "(current)"
+
+#: id:24095
+msgid "(blacklisted)"
+msgstr "(blacklisted)"
+
+#: id:24096
+msgid "Add-on has been marked as broken in repository."
+msgstr "El complement s'ha marcat com trencat al dipòsit."
+
+#: id:24097
+msgid "Would you like to disable it on your system?"
+msgstr "Voleu desactivar-lo en el sistema?"
+
+#: id:24098
+msgid "Broken"
+msgstr "Trencat"
+
+#: id:24099
+msgid "Would you like to switch to this skin?"
+msgstr "Voleu canviar a aquesta aparença?"
+
+#: id:24100
+msgid "To use this feature you must download an Add-on:"
+msgstr "Per utilitzar aquesta funció cal descarregar un complement:"
+
+#: id:24101
+msgid "Would you like to download this Add-on?"
+msgstr "Voleu descarregar aquest complement?"
+
+#: id:25000
+msgid "Notifications"
+msgstr "Notificacions"
+
+#: id:29800
+msgid "Library Mode"
+msgstr "Mode biblioteca"
+
+#: id:29801
+msgid "QWERTY keyboard"
+msgstr "Teclat QWERTY"
+
+#: id:29802
+msgid "Passthrough Audio in use"
+msgstr "Passthrough Audio in use"
+
+#: id:33001
+msgid "Trailer quality"
+msgstr "Qualitat del trailer"
+
+#: id:33002
+msgid "Stream"
+msgstr "Flux"
+
+#: id:33003
+msgid "Download"
+msgstr "Baixar"
+
+#: id:33004
+msgid "Download & play"
+msgstr "Baixar i reproduir"
+
+#: id:33005
+msgid "Download & save"
+msgstr "Baixar i desar"
+
+#: id:33006
+msgid "Today"
+msgstr "Avui"
+
+#: id:33007
+msgid "Tomorrow"
+msgstr "Demà"
+
+#: id:33008
+msgid "Saving"
+msgstr "S'està desant"
+
+#: id:33009
+msgid "Copying"
+msgstr "S'està copiant"
+
+#: id:33010
+msgid "Set download directory"
+msgstr "Establiu el directori de descàrrega"
+
+#: id:33011
+msgid "Search duration"
+msgstr "Cerca durada"
+
+#: id:33012
+msgid "Short"
+msgstr "Curt"
+
+#: id:33013
+msgid "Long"
+msgstr "Llarg"
+
+#: id:33014
+msgid "Use DVD player instead of regular player"
+msgstr "Utilitza el reproductor de DVD en lloc del reproductor per defecte"
+
+#: id:33015
+msgid "Ask for download before playing video"
+msgstr "Pregunta si es vol baixar el vídeo abans de reproduir-lo"
+
+#: id:33016
+msgid "Clips"
+msgstr "Clips"
+
+#: id:33017
+msgid "Restart plugin to enable"
+msgstr "Reinicia el plugin per activar-lo"
+
+#: id:33018
+msgid "Tonight"
+msgstr "Aquesta nit"
+
+#: id:33019
+msgid "Tomorrow Night"
+msgstr "Demà a la nit"
+
+#: id:33020
+msgid "Condition"
+msgstr "Condició"
+
+#: id:33021
+msgid "Precipitation"
+msgstr "Precipitació"
+
+#: id:33022
+msgid "Precip"
+msgstr "Precipitació"
+
+#: id:33023
+msgid "Humid"
+msgstr "Humit"
+
+#: id:33024
+msgid "Feels"
+msgstr "Feels"
+
+#: id:33025
+msgid "Observed"
+msgstr "Observed"
+
+#: id:33026
+msgid "Departure from normal"
+msgstr "Sortida del normal"
+
+#: id:33027
+msgid "Sunrise"
+msgstr "Sortida del sol"
+
+#: id:33028
+msgid "Sunset"
+msgstr "Posta de sol"
+
+#: id:33029
+msgid "Details"
+msgstr "Detalls"
+
+#: id:33030
+msgid "Outlook"
+msgstr "Outlook"
+
+#: id:33031
+msgid "Coverflow"
+msgstr "Coverflow"
+
+#: id:33032
+msgid "Translate text"
+msgstr "Tradueix el text"
+
+#: id:33033
+msgid "Map list %s category"
+msgstr "Map list %s category"
+
+#: id:33034
+msgid "36 Hour"
+msgstr "36 Hores"
+
+#: id:33035
+msgid "Maps"
+msgstr "Mapes"
+
+#: id:33036
+msgid "Hourly"
+msgstr "Cada hora"
+
+#: id:33037
+msgid "Weekend"
+msgstr "Cap de setmana"
+
+#: id:33038
+msgid "%s day"
+msgstr "%s dia"
+
+#: id:33049
+msgid "Alert"
+msgstr "Alerta"
+
+#: id:33050
+msgid "Alerts"
+msgstr "Alertes"
+
+#: id:33051
+msgid "Choose Your"
+msgstr "Choose Your"
+
+#: id:33052
+msgid "Check"
+msgstr "Comprova"
+
+#: id:33053
+msgctxt "Auto context with id 33053"
+msgid "Configure the"
+msgstr "Configureu el"
+
+#: id:33054
+msgid "Seasons"
+msgstr "Estacions"
+
+#: id:33055
+msgid "Use your"
+msgstr "Use your"
+
+#: id:33056
+msgid "Watch your"
+msgstr "Mira"
+
+#: id:33057
+msgid "Listen to"
+msgstr "Escolta"
+
+#: id:33058
+msgid "View your"
+msgstr "View your"
+
+#: id:33059
+msgctxt "Auto context with id 33059"
+msgid "Configure the"
+msgstr "Configureu el"
+
+#: id:33060
+msgid "Power"
+msgstr "Potència"
+
+#: id:33061
+msgid "Menu"
+msgstr "Menú"
+
+#: id:33062
+msgid "Play the"
+msgstr "Reprodueix el"
+
+#: id:33063
+msgid "Options"
+msgstr "Opcions"
+
+#: id:33065
+msgid "Editor"
+msgstr "Editor"
+
+#: id:33066
+msgid "About your"
+msgstr "About your"
+
+#: id:33067
+msgid "Star rating"
+msgstr "Classificació"
+
+#: id:33068
+msgid "Background"
+msgstr "Fons"
+
+#: id:33069
+msgid "Backgrounds"
+msgstr "Fons"
+
+#: id:33070
+msgid "Custom background"
+msgstr "Fons personalitzat"
+
+#: id:33071
+msgid "Custom backgrounds"
+msgstr "Fons personalitzats"
+
+#: id:33072
+msgid "View Readme"
+msgstr "Veure el Lleguiu-me"
+
+#: id:33073
+msgid "View Changelog"
+msgstr "Veure el registre de canvis"
+
+#: id:33074
+msgid "This version of %s requires an"
+msgstr "Aquesta versió de %s requereix una"
+
+#: id:33075
+msgid "XBMC revision of %s or greater to run."
+msgstr "revisió de l'XBMC s% o superior per a funcionar."
+
+#: id:33076
+msgid "Please update XBMC."
+msgstr "Actualitzeu l'XBMC."
+
+#: id:33077
+msgid "No data found!"
+msgstr "No s'han trobat dades"
+
+#: id:33078
+msgid "Next page"
+msgstr "Pàgina següent"
+
+#: id:33079
+msgid "Love"
+msgstr "M'agrada"
+
+#: id:33080
+msgid "Hate"
+msgstr "No m'agrada"
+
+#: id:33081
+msgid "This file is stacked, select the part you want to play from."
+msgstr "Aquest fitxer està agrupat, seleccioneu la part que desitgeu reproduir."
+
+#: id:33082
+msgid "Path to script"
+msgstr "Camí a l'script"
+
+#: id:33083
+msgid "Enable custom script button"
+msgstr "Activa el botó d'scripts personalitzats"
+
+#: id:33100
+msgid "Failed to start"
+msgstr "No s'ha pogut iniciar"
+
+#: id:33101
+msgid "Webserver"
+msgstr "Servidor web"
+
+#: id:33102
+msgid "Event Server"
+msgstr "Servidor d'esdeveniments"
+
+#: id:33103
+msgid "Remote communication server"
+msgstr "Servidor remot de comunicació"
+
+#: id:33200
+msgid "Detected New Connection"
+msgstr ""
+
+#: id:34000
+msgid "Lame"
+msgstr "Lame"
+
+#: id:34001
+msgid "Vorbis"
+msgstr "Vorbis"
+
+#: id:34002
+msgid "Wav"
+msgstr "Wav"
+
+#: id:34003
+msgid "DXVA2"
+msgstr "DXVA2"
+
+#: id:34004
+msgid "VAAPI"
+msgstr "VAAPI"
+
+#: id:34005
+msgid "Flac"
+msgstr "Flac"
+
+#: id:34100
+msgid "Speaker Configuration"
+msgstr "Configuració dels altaveus"
+
+#: id:34101
+msgid "2.0"
+msgstr "2.0"
+
+#: id:34102
+msgid "2.1"
+msgstr "2.1"
+
+#: id:34103
+msgid "3.0"
+msgstr "3.0"
+
+#: id:34104
+msgid "3.1"
+msgstr "3.1"
+
+#: id:34105
+msgid "4.0"
+msgstr "4.0"
+
+#: id:34106
+msgid "4.1"
+msgstr "4.1"
+
+#: id:34107
+msgid "5.0"
+msgstr "5.0"
+
+#: id:34108
+msgid "5.1"
+msgstr "5.1"
+
+#: id:34109
+msgid "7.0"
+msgstr "7.0"
+
+#: id:34110
+msgid "7.1"
+msgstr "7.1"
+
+#: id:34201
+msgid "Can't find a next item to play"
+msgstr "Can't find a next item to play"
+
+#: id:34202
+msgid "Can't find a previous item to play"
+msgstr "Can't find a previous item to play"
+
+#: id:34300
+msgid "Failed to start zeroconf"
+msgstr ""
+
+#: id:34301
+msgid "Is Apple's Bonjour Service installed? See log for more info."
+msgstr ""
+
+#: id:34400
+msgid "Video Rendering"
+msgstr ""
+
+#: id:34401
+msgid "Failed to init video filters/scalers, falling back to bilinear scaling"
+msgstr ""
+
+#: id:34402
+msgid "Failed to initialize audio device"
+msgstr ""
+
+#: id:34403
+msgid "Check your audiosettings"
+msgstr ""
+
+#: id:34404
+msgid "Use gestures for navigation:"
+msgstr ""
+
+#: id:34405
+msgid "1 finger swipe left,right,up,down for cursors"
+msgstr ""
+
+#: id:34406
+msgid "2 finger swipe left for backspace"
+msgstr ""
+
+#: id:34407
+msgid "1 finger single tap for enter"
+msgstr ""
+
+#: id:34408
+msgid "2 finger single tap for contextmenu"
+msgstr ""
+
+#: id:35000
+msgid "Peripherals"
+msgstr "Perifèrics"
+
+#: id:35001
+msgid "Generic HID device"
+msgstr "Generic HID device"
+
+#: id:35002
+msgid "Generic network adapter"
+msgstr "Adaptador de xarxa genèric"
+
+#: id:35003
+msgid "Generic disk"
+msgstr "Disc genèric"
+
+#: id:35004
+msgid "There are no settings available\nfor this peripheral."
+msgstr "No hi ha opcions disponibles\nper aquest perifèric."
+
+#: id:35005
+msgid "New device configured"
+msgstr "Nou dispositiu configurat"
+
+#: id:35006
+msgid "Device removed"
+msgstr "Dispositiu eliminat"
+
+#: id:35007
+msgid "Keymap to use for this device"
+msgstr "Keymap to use for this device"
+
+#: id:35008
+msgid "Keymap enabled"
+msgstr "Mapa de teclat activat"
+
+#: id:35009
+msgid "Do not use the custom keymap for this device"
+msgstr ""
+
+#: id:35500
+msgid "Location"
+msgstr "Ubicació"
+
+#: id:35501
+msgid "Class"
+msgstr "Classe"
+
+#: id:35502
+msgctxt "Auto context with id 35502"
+msgid "Name"
+msgstr "Nom"
+
+#: id:35503
+msgid "Vendor"
+msgstr "Venedor"
+
+#: id:35504
+msgid "Product ID"
+msgstr "Product ID"
+
+#: id:36000
+msgid "Pulse-Eight CEC adapter"
+msgstr "Pulse-Eight CEC adapter"
+
+#: id:36001
+msgid "Pulse-Eight Nyxboard"
+msgstr "Pulse-Eight Nyxboard"
+
+#: id:36002
+msgid "Switch to keyboard side command"
+msgstr "Switch to keyboard side command"
+
+#: id:36003
+msgid "Switch to remote side command"
+msgstr "Switch to remote side command"
+
+#: id:36004
+msgid "Press \"user\" button command"
+msgstr "Press \"user\" button command"
+
+#: id:36005
+msgid "Enable switch side commands"
+msgstr "Enable switch side commands"
+
+#: id:36006
+msgid "Could not open the adapter"
+msgstr "Could not open the adapter"
+
+#: id:36007
+msgid "Devices to power on when starting XBMC"
+msgstr "Power on the TV when starting XBMC"
+
+#: id:36008
+msgid "Devices to power off when stopping XBMC"
+msgstr "Power off devices when stopping XBMC"
+
+#: id:36009
+msgid "Put devices in standby mode when activating screensaver"
+msgstr "Put devices in standby mode when activating screensaver"
+
+#: id:36011
+msgid "Could not detect the CEC port. Set it up manually."
+msgstr "Could not detect the CEC port. Set it up manually."
+
+#: id:36012
+msgid "Could not initialise the CEC adapter. Check your settings."
+msgstr "Could not detect the CEC adapter."
+
+#: id:36013
+msgid "Unsupported libCEC interface version. %d is greater than the version XBMC supports (%d)"
+msgstr "Unsupported libcec interface version. %d is greater than the version XBMC supports (%d)"
+
+#: id:36014
+msgid "Put this PC in standby mode when the TV is switched off"
+msgstr "Put this PC in standby mode when the TV is switched off"
+
+#: id:36015
+msgid "HDMI port number"
+msgstr "Número de port HDMI"
+
+#: id:36016
+msgctxt "Auto context with id 36016"
+msgid "Connected"
+msgstr "Connectat"
+
+#: id:36017
+msgid "Adapter found, but libCEC is not available"
+msgstr "S'ha trobat un adaptador, però la libcec no està disponible"
+
+#: id:36018
+msgid "Use the TV's language setting"
+msgstr "Use the TV's language setting"
+
+#: id:36019
+msgid "Connected to HDMI device"
+msgstr ""
+
+#: id:36020
+msgid "Make XBMC the active source when starting"
+msgstr ""
+
+#: id:36021
+msgid "Physical address (overrules HDMI port)"
+msgstr ""
+
+#: id:36022
+msgid "COM port (leave empty unless needed)"
+msgstr ""
+
+#: id:36023
+msgid "Configuration updated"
+msgstr ""
+
+#: id:36024
+msgid "Failed to set the new configuration. Please check your settings."
+msgstr ""
+
+#: id:36025
+msgid "Send 'inactive source' command when stopping XBMC"
+msgstr ""
+

--- a/language/Chinese (Simple)/strings.po
+++ b/language/Chinese (Simple)/strings.po
@@ -1,0 +1,9093 @@
+# Converted from xbmc strings.xml with xbmc-xml2po (by Team-XBMC)
+msgid ""
+msgstr ""
+"Project-Id-Version: xbmc.core-FRODO_GIT3ed1604ad7\n"
+"Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
+"POT-Creation-Date: 2012-04-09 18:00+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE\n"
+"Language: zh\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: id:0
+msgctxt "Auto context with id 0"
+msgid "Programs"
+msgstr "程序"
+
+#: id:1
+msgctxt "Auto context with id 1"
+msgid "Pictures"
+msgstr "图片"
+
+#: id:2
+msgctxt "Auto context with id 2"
+msgid "Music"
+msgstr "音乐"
+
+#: id:3
+msgctxt "Auto context with id 3"
+msgid "Videos"
+msgstr "视频"
+
+#: id:4
+msgid "TV-Guide"
+msgstr "节目预告"
+
+#: id:5
+msgctxt "Auto context with id 5"
+msgid "Settings"
+msgstr "系统设置"
+
+#: id:6
+msgid "XBMC SVN"
+msgstr "XBMC SVN"
+
+#: id:7
+msgctxt "Auto context with id 7"
+msgid "File manager"
+msgstr "文件管理"
+
+#: id:8
+msgctxt "Auto context with id 8"
+msgid "Weather"
+msgstr "天气"
+
+#: id:9
+msgid "xbmc media center"
+msgstr "XBMC媒体中心"
+
+#: id:11
+msgid "Monday"
+msgstr "星期一"
+
+#: id:12
+msgid "Tuesday"
+msgstr "星期二"
+
+#: id:13
+msgid "Wednesday"
+msgstr "星期三"
+
+#: id:14
+msgid "Thursday"
+msgstr "星期四"
+
+#: id:15
+msgid "Friday"
+msgstr "星期五"
+
+#: id:16
+msgid "Saturday"
+msgstr "星期六"
+
+#: id:17
+msgid "Sunday"
+msgstr "星期日"
+
+#: id:21
+msgid "January"
+msgstr "一月"
+
+#: id:22
+msgid "February"
+msgstr "二月"
+
+#: id:23
+msgid "March"
+msgstr "三月"
+
+#: id:24
+msgid "April"
+msgstr "四月"
+
+#: id:25
+msgctxt "Auto context with id 25"
+msgid "May"
+msgstr "五月"
+
+#: id:26
+msgid "June"
+msgstr "六月"
+
+#: id:27
+msgid "July"
+msgstr "七月"
+
+#: id:28
+msgid "August"
+msgstr "八月"
+
+#: id:29
+msgid "September"
+msgstr "九月"
+
+#: id:30
+msgid "October"
+msgstr "十月"
+
+#: id:31
+msgid "November"
+msgstr "十一月"
+
+#: id:32
+msgid "December"
+msgstr "十二月"
+
+#: id:41
+msgid "Mon"
+msgstr "星期一"
+
+#: id:42
+msgid "Tue"
+msgstr "星期二"
+
+#: id:43
+msgid "Wed"
+msgstr "星期三"
+
+#: id:44
+msgid "Thu"
+msgstr "星期四"
+
+#: id:45
+msgid "Fri"
+msgstr "星期五"
+
+#: id:46
+msgid "Sat"
+msgstr "星期六"
+
+#: id:47
+msgctxt "Auto context with id 47"
+msgid "Sun"
+msgstr "星期日"
+
+#: id:51
+msgid "Jan"
+msgstr "一月"
+
+#: id:52
+msgid "Feb"
+msgstr "二月"
+
+#: id:53
+msgid "Mar"
+msgstr "三月"
+
+#: id:54
+msgid "Apr"
+msgstr "四月"
+
+#: id:55
+msgctxt "Auto context with id 55"
+msgid "May"
+msgstr "五月"
+
+#: id:56
+msgid "Jun"
+msgstr "六月"
+
+#: id:57
+msgid "Jul"
+msgstr "七月"
+
+#: id:58
+msgid "Aug"
+msgstr "八月"
+
+#: id:59
+msgid "Sep"
+msgstr "九月"
+
+#: id:60
+msgid "Oct"
+msgstr "十月"
+
+#: id:61
+msgid "Nov"
+msgstr "十一月"
+
+#: id:62
+msgid "Dec"
+msgstr "十二月"
+
+#: id:71
+msgid "N"
+msgstr "北"
+
+#: id:72
+msgid "NNE"
+msgstr "北东北"
+
+#: id:73
+msgid "NE"
+msgstr "东北"
+
+#: id:74
+msgid "ENE"
+msgstr "东东北"
+
+#: id:75
+msgid "E"
+msgstr "东"
+
+#: id:76
+msgid "ESE"
+msgstr "东东南"
+
+#: id:77
+msgid "SE"
+msgstr "东南"
+
+#: id:78
+msgid "SSE"
+msgstr "南东南"
+
+#: id:79
+msgid "S"
+msgstr "南"
+
+#: id:80
+msgid "SSW"
+msgstr "南西南"
+
+#: id:81
+msgid "SW"
+msgstr "西南"
+
+#: id:82
+msgid "WSW"
+msgstr "西西南"
+
+#: id:83
+msgid "W"
+msgstr "西"
+
+#: id:84
+msgid "WNW"
+msgstr "西西北"
+
+#: id:85
+msgid "NW"
+msgstr "西北"
+
+#: id:86
+msgid "NNW"
+msgstr "北西北"
+
+#: id:87
+msgid "VAR"
+msgstr "不定"
+
+#: id:98
+msgid "View: Auto"
+msgstr "显示：自动"
+
+#: id:99
+msgid "View: Auto big"
+msgstr "显示：自动大图标"
+
+#: id:100
+msgid "View: Icons"
+msgstr "显示：图标"
+
+#: id:101
+msgid "View: List"
+msgstr "显示：列表"
+
+#: id:102
+msgctxt "Auto context with id 102"
+msgid "Scan"
+msgstr "扫描"
+
+#: id:103
+msgctxt "Auto context with id 103"
+msgid "Sort by: Name"
+msgstr "排序：名称"
+
+#: id:104
+msgid "Sort by: Date"
+msgstr "排序：日期"
+
+#: id:105
+msgid "Sort by: Size"
+msgstr "排序：大小"
+
+#: id:106
+msgid "No"
+msgstr "否"
+
+#: id:107
+msgid "Yes"
+msgstr "是"
+
+#: id:108
+msgctxt "Auto context with id 108"
+msgid "Slideshow"
+msgstr "幻灯片播放"
+
+#: id:109
+msgid "Create thumbs"
+msgstr "创建缩略图册"
+
+#: id:110
+msgid "Create thumbnails"
+msgstr "创建缩略图"
+
+#: id:111
+msgctxt "Auto context with id 111"
+msgid "Shortcuts"
+msgstr "快捷方式"
+
+#: id:112
+msgid "Paused"
+msgstr "暂停"
+
+#: id:113
+msgid "Update failed"
+msgstr "更新失败"
+
+#: id:114
+msgid "Installation failed"
+msgstr "安装失败"
+
+#: id:115
+msgid "Copy"
+msgstr "复制"
+
+#: id:116
+msgid "Move"
+msgstr "移动"
+
+#: id:117
+msgid "Delete"
+msgstr "删除"
+
+#: id:118
+msgid "Rename"
+msgstr "重命名"
+
+#: id:119
+msgid "New folder"
+msgstr "新文件夹"
+
+#: id:120
+msgid "Confirm file copy"
+msgstr "确认复制文件"
+
+#: id:121
+msgid "Confirm file move"
+msgstr "确认移动文件"
+
+#: id:122
+msgid "Confirm file delete?"
+msgstr "确认删除文件"
+
+#: id:123
+msgid "Copy these files?"
+msgstr "复制这些文件？"
+
+#: id:124
+msgid "Move these files?"
+msgstr "移动这些文件？"
+
+#: id:125
+msgid "Delete these files? - Deleting files cannot be undone!"
+msgstr "删除这些文件？"
+
+#: id:126
+msgid "Status"
+msgstr "状态"
+
+#: id:127
+msgid "Objects"
+msgstr "对象"
+
+#: id:128
+msgctxt "Auto context with id 128"
+msgid "General"
+msgstr "常用"
+
+#: id:129
+msgctxt "Auto context with id 129"
+msgid "Slideshow"
+msgstr "幻灯片播放"
+
+#: id:130
+msgctxt "Auto context with id 130"
+msgid "System info"
+msgstr "系统信息"
+
+#: id:131
+msgid "Display"
+msgstr "显示器"
+
+#: id:132
+msgid "Albums"
+msgstr "专辑"
+
+#: id:133
+msgid "Artists"
+msgstr "艺人"
+
+#: id:134
+msgid "Songs"
+msgstr "歌曲"
+
+#: id:135
+msgid "Genres"
+msgstr "类型"
+
+#: id:136
+msgid "Playlists"
+msgstr "播放列表"
+
+#: id:137
+msgid "Search"
+msgstr "查找"
+
+#: id:138
+msgid "System Information"
+msgstr "系统信息"
+
+#: id:139
+msgid "Temperatures:"
+msgstr "温度："
+
+#: id:140
+msgid "CPU:"
+msgstr "CPU："
+
+#: id:141
+msgid "GPU:"
+msgstr "GPU："
+
+#: id:142
+msgid "Time:"
+msgstr "时间："
+
+#: id:143
+msgid "Current:"
+msgstr "当前："
+
+#: id:144
+msgid "Build:"
+msgstr "版本："
+
+#: id:145
+msgid "Network:"
+msgstr "网络："
+
+#: id:146
+msgid "Type:"
+msgstr "类型："
+
+#: id:147
+msgid "Static"
+msgstr "手动（静态分配）"
+
+#: id:148
+msgid "DHCP"
+msgstr "自动（动态分配）"
+
+#: id:149
+msgid "MAC address"
+msgstr "网卡物理地址（MAC）"
+
+#: id:150
+msgctxt "Auto context with id 150"
+msgid "IP address"
+msgstr "IP 地址"
+
+#: id:151
+msgid "Link:"
+msgstr "连接："
+
+#: id:152
+msgid "Half duplex"
+msgstr "半双工"
+
+#: id:153
+msgid "Full duplex"
+msgstr "全双工"
+
+#: id:154
+msgctxt "Auto context with id 154"
+msgid "Storage"
+msgstr "存储器"
+
+#: id:155
+msgid "Drive"
+msgstr "驱动器"
+
+#: id:156
+msgctxt "Auto context with id 156"
+msgid "Free"
+msgstr "空闲"
+
+#: id:157
+msgctxt "Auto context with id 157"
+msgid "Video"
+msgstr "视频"
+
+#: id:158
+msgid "Free memory"
+msgstr "空闲内存"
+
+#: id:159
+msgid "No link"
+msgstr "无连接"
+
+#: id:160
+msgctxt "Auto context with id 160"
+msgid "Free"
+msgstr "空闲"
+
+#: id:161
+msgid "Unavailable"
+msgstr "无效的"
+
+#: id:162
+msgid "Tray open"
+msgstr "光驱开启"
+
+#: id:163
+msgid "Reading"
+msgstr "读取中"
+
+#: id:164
+msgid "No disc"
+msgstr "无盘"
+
+#: id:165
+msgid "Disc present"
+msgstr "当前光盘"
+
+#: id:166
+msgid "Skin"
+msgstr "皮肤"
+
+#: id:169
+msgctxt "Auto context with id 169"
+msgid "Resolution"
+msgstr "分辨率"
+
+#: id:170
+msgid "Adjust display refresh rate to match video"
+msgstr "调整显示器刷新率适应视频"
+
+#: id:172
+msgid "Release date"
+msgstr "发行时间"
+
+#: id:173
+msgid "Display 4:3 videos as"
+msgstr "将 4:3 视频显示为"
+
+#: id:175
+msgid "Moods"
+msgstr "音调"
+
+#: id:176
+msgid "Styles"
+msgstr "风格"
+
+#: id:179
+msgid "Song"
+msgstr "歌曲"
+
+#: id:180
+msgid "Duration"
+msgstr "持续时间"
+
+#: id:181
+msgid "Select album"
+msgstr "选择专辑"
+
+#: id:182
+msgid "Tracks"
+msgstr "音轨"
+
+#: id:183
+msgid "Review"
+msgstr "评论"
+
+#: id:184
+msgid "Refresh"
+msgstr "刷新"
+
+#: id:185
+msgid "Searching album"
+msgstr "查找专辑"
+
+#: id:186
+msgid "OK"
+msgstr "确定"
+
+#: id:187
+msgid "No albums found!"
+msgstr "没有找到专辑！"
+
+#: id:188
+msgid "Select all"
+msgstr "全部选择"
+
+#: id:189
+msgid "Scanning media info"
+msgstr "查找媒体信息"
+
+#: id:190
+msgid "Save"
+msgstr "保存"
+
+#: id:191
+msgid "Shuffle"
+msgstr "乱序播放"
+
+#: id:192
+msgctxt "Auto context with id 192"
+msgid "Clear"
+msgstr "清除"
+
+#: id:193
+msgctxt "Auto context with id 193"
+msgid "Scan"
+msgstr "查找"
+
+#: id:194
+msgid "Searching..."
+msgstr "查找..."
+
+#: id:195
+msgid "No info found!"
+msgstr "没有发现信息！"
+
+#: id:196
+msgid "Select movie:"
+msgstr "选择视频："
+
+#: id:197
+msgid "Querying %s info"
+msgstr "读取%s信息"
+
+#: id:198
+msgid "Loading movie details"
+msgstr "载入视频详细资料"
+
+#: id:199
+msgid "Web interface"
+msgstr "Web 界面"
+
+#: id:202
+msgid "Tagline"
+msgstr "标语"
+
+#: id:203
+msgid "Plot outline"
+msgstr "大纲"
+
+#: id:205
+msgid "Votes"
+msgstr "得票"
+
+#: id:206
+msgid "Cast"
+msgstr "演员表"
+
+#: id:207
+msgid "Plot"
+msgstr "剧情简介"
+
+#: id:208
+msgctxt "Auto context with id 208"
+msgid "Play"
+msgstr "播放"
+
+#: id:209
+msgid "Next"
+msgstr "下一首"
+
+#: id:210
+msgid "Previous"
+msgstr "上一首"
+
+#: id:213
+msgid "Calibrate user interface..."
+msgstr "界面校准"
+
+#: id:214
+msgid "Video calibration..."
+msgstr "屏幕校准"
+
+#: id:215
+msgid "Soften"
+msgstr "柔化"
+
+#: id:216
+msgid "Zoom amount"
+msgstr "缩放"
+
+#: id:217
+msgid "Pixel ratio"
+msgstr "画面宽高比"
+
+#: id:218
+msgid "DVD drive"
+msgstr "DVD 驱动器"
+
+#: id:219
+msgid "Please insert disc"
+msgstr "请放入光盘"
+
+#: id:220
+msgid "Remote share"
+msgstr "远程共享"
+
+#: id:221
+msgid "Network is not connected"
+msgstr "网络未连接"
+
+#: id:222
+msgid "Cancel"
+msgstr "取消"
+
+#: id:224
+msgid "Speed"
+msgstr "速度"
+
+#: id:225
+msgid "Vertical Shift"
+msgstr "纵向偏移"
+
+#: id:226
+msgid "Test patterns..."
+msgstr "测试图案..."
+
+#: id:227
+msgid "Lookup audio CD track names from freedb.org"
+msgstr "从 freedb.org 获取音乐 CD 信息"
+
+#: id:228
+msgid "Shuffle playlist on load"
+msgstr "载入播放列表时打乱顺序"
+
+#: id:229
+msgid "HDD spindown time"
+msgstr "硬盘停转时间"
+
+#: id:230
+msgid "Video filters"
+msgstr "视频滤镜"
+
+#: id:231
+msgctxt "Auto context with id 231"
+msgid "None"
+msgstr "无"
+
+#: id:232
+msgid "Point"
+msgstr "点"
+
+#: id:233
+msgid "Linear"
+msgstr "线性"
+
+#: id:234
+msgid "Anisotropic"
+msgstr "非等方性"
+
+#: id:235
+msgid "Quincunx"
+msgstr "梅花多重取样"
+
+#: id:236
+msgid "Gaussian cubic"
+msgstr "三维锐化"
+
+#: id:237
+msgid "Minification"
+msgstr "缩小"
+
+#: id:238
+msgid "Magnification"
+msgstr "放大"
+
+#: id:239
+msgid "Clear playlist on finish"
+msgstr "播放完成后清除列表"
+
+#: id:240
+msgid "Display Mode"
+msgstr "显示模式"
+
+#: id:241
+msgid "Full Screen #%d"
+msgstr "全屏#%d"
+
+#: id:242
+msgid "Windowed"
+msgstr "窗口"
+
+#: id:243
+msgid "Refresh Rate"
+msgstr "刷新率"
+
+#: id:244
+msgid "Full screen"
+msgstr "全屏"
+
+#: id:245
+msgid "Sizing: (%i,%i)->(%i,%i) (Zoom x%2.2f) AR:%2.2f:1 (Pixels: %2.2f:1) (VShift: %2.2f)"
+msgstr "屏幕调整：(%i,%i)->(%i,%i) (缩放 x%2.2f) 宽高比：%2.2f:1 (像素比：%2.2f:1) (纵向偏移：%2.2f)"
+
+#: id:247
+msgctxt "Auto context with id 247"
+msgid "Scripts"
+msgstr "脚本"
+
+#: id:248
+msgctxt "Auto context with id 248"
+msgid "Language"
+msgstr "语言"
+
+#: id:249
+msgctxt "Auto context with id 249"
+msgid "Music"
+msgstr "音乐"
+
+#: id:250
+msgctxt "Auto context with id 250"
+msgid "Visualization"
+msgstr "视觉效果"
+
+#: id:251
+msgid "Select destination directory"
+msgstr "选择目标目录"
+
+#: id:252
+msgid "Output stereo to all speakers"
+msgstr "双声道时输出到所有扬声器"
+
+#: id:253
+msgid "Number of channels"
+msgstr "通道数"
+
+#: id:254
+msgid "- DTS capable receiver"
+msgstr "- DTS 数字音效"
+
+#: id:255
+msgid "CDDB"
+msgstr "CDDB"
+
+#: id:256
+msgid "Fetching CD information"
+msgstr "获取 CD 信息"
+
+#: id:257
+msgid "Error"
+msgstr "错误"
+
+#: id:258
+msgid "Enable tag reading"
+msgstr "启用音乐文件标签信息读取"
+
+#: id:259
+msgid "Opening"
+msgstr "开始"
+
+#: id:260
+msgid "Shoutcast"
+msgstr "Shoutcast 网络音乐台"
+
+#: id:261
+msgid "Waiting for start..."
+msgstr "等待开始..."
+
+#: id:262
+msgid "Scripts output"
+msgstr "脚本输出"
+
+#: id:263
+msgid "Allow control of XBMC via HTTP"
+msgstr "允许通过 HTTP 控制 XBMC"
+
+#: id:264
+msgid "Record"
+msgstr "录音"
+
+#: id:265
+msgid "Stop Rec."
+msgstr "停止录音"
+
+#: id:266
+msgid "Sort by: Track"
+msgstr "排序：音轨"
+
+#: id:267
+msgid "Sort by: Time"
+msgstr "排序：时间"
+
+#: id:268
+msgid "Sort by: Title"
+msgstr "排序：标题"
+
+#: id:269
+msgid "Sort by: Artist"
+msgstr "排序：艺人"
+
+#: id:270
+msgid "Sort by: Album"
+msgstr "排序：专辑"
+
+#: id:271
+msgid "Top 100"
+msgstr "前100排名榜"
+
+#: id:272
+msgid "Top-Left overscan compensation"
+msgstr "左上角过扫描补偿"
+
+#: id:273
+msgid "Bottom-Right overscan compensation"
+msgstr "右下角过扫描补偿"
+
+#: id:274
+msgid "Subtitle positioning"
+msgstr "字幕位置"
+
+#: id:275
+msgid "Pixel ratio adjustment"
+msgstr "画面纵横比调整"
+
+#: id:276
+msgid "Adjust the arrow to change the amount of overscan"
+msgstr "移动箭头改变过扫描补偿边框"
+
+#: id:277
+msgid "Adjust the bar to change the subtitles position"
+msgstr "移动横线改变字幕位置"
+
+#: id:278
+msgid "Adjust the rectangle so it is perfectly square"
+msgstr "调整屏幕中央的方框为长宽相等的完美正方形"
+
+#: id:279
+msgid "Unable to load settings"
+msgstr "不能读取设置"
+
+#: id:280
+msgid "Using default settings"
+msgstr "使用默认预设值"
+
+#: id:281
+msgid "Please check the XML files"
+msgstr "请检查 .xml 文件"
+
+#: id:282
+msgid "Found %i items"
+msgstr "找到%i条"
+
+#: id:283
+msgid "Search results"
+msgstr "查找结果"
+
+#: id:284
+msgid "No results found"
+msgstr "无结果"
+
+#: id:287
+msgctxt "Auto context with id 287"
+msgid "Subtitles"
+msgstr "字幕"
+
+#: id:288
+msgctxt "Auto context with id 288"
+msgid "Font"
+msgstr "字体"
+
+#: id:289
+msgctxt "Auto context with id 289"
+msgid "- Size"
+msgstr "- 尺寸"
+
+#: id:290
+msgid "Dynamic range compression"
+msgstr "动态范围压缩"
+
+#: id:291
+msgctxt "Auto context with id 291"
+msgid "Video"
+msgstr "视频"
+
+#: id:292
+msgctxt "Auto context with id 292"
+msgid "Audio"
+msgstr "音频"
+
+#: id:293
+msgid "Browse for subtitles"
+msgstr "字幕浏览"
+
+#: id:294
+msgid "Create bookmark"
+msgstr "创建书签"
+
+#: id:296
+msgid "Clear bookmarks"
+msgstr "清除书签"
+
+#: id:297
+msgid "Audio offset"
+msgstr "声音延迟"
+
+#: id:298
+msgid "Bookmarks"
+msgstr "书签"
+
+#: id:299
+msgid "- AAC capable receiver"
+msgstr "- AAC 数字音效"
+
+#: id:300
+msgid "- MP1 capable receiver"
+msgstr "- MP1 数字音效"
+
+#: id:301
+msgid "- MP2 capable receiver"
+msgstr "- MP2 数字音效"
+
+#: id:302
+msgid "- MP3 capable receiver"
+msgstr "- MP3 数字音效"
+
+#: id:303
+msgid "Delay"
+msgstr "延迟"
+
+#: id:304
+msgctxt "Auto context with id 304"
+msgid "Language"
+msgstr "语言"
+
+#: id:305
+msgctxt "Auto context with id 305"
+msgid "Enabled"
+msgstr "开启"
+
+#: id:306
+msgid "Non-interleaved"
+msgstr "去交错（隔行变逐行）"
+
+#: id:312
+msgid "(0=auto)"
+msgstr "（0=自动）"
+
+#: id:313
+msgid "Cleaning database"
+msgstr "清理资料库"
+
+#: id:314
+msgid "Preparing..."
+msgstr "准备中..."
+
+#: id:315
+msgid "Database error"
+msgstr "资料库错误！"
+
+#: id:316
+msgid "Searching songs..."
+msgstr "搜寻歌曲..."
+
+#: id:317
+msgid "Cleaned database successfully"
+msgstr "成功清理资料库！"
+
+#: id:318
+msgid "Cleaning songs..."
+msgstr "清理歌曲..."
+
+#: id:319
+msgid "Error cleaning songs"
+msgstr "清理歌曲错误！"
+
+#: id:320
+msgid "Cleaning artists..."
+msgstr "清理艺人信息..."
+
+#: id:321
+msgid "Error cleaning artists"
+msgstr "清理艺人信息错误！"
+
+#: id:322
+msgid "Cleaning genres..."
+msgstr "清理类型信息..."
+
+#: id:323
+msgid "Error cleaning genres"
+msgstr "清理类型信息错误！"
+
+#: id:324
+msgid "Cleaning paths..."
+msgstr "清理路径信息..."
+
+#: id:325
+msgid "Error cleaning paths"
+msgstr "清理路径信息错误！"
+
+#: id:326
+msgid "Cleaning albums..."
+msgstr "清理专辑..."
+
+#: id:327
+msgid "Error cleaning albums"
+msgstr "清理专辑错误！"
+
+#: id:328
+msgid "Writing changes..."
+msgstr "写入更新中..."
+
+#: id:329
+msgid "Error writing changes"
+msgstr "写入错误！"
+
+#: id:330
+msgid "This may take some time..."
+msgstr "这需要一些时间..."
+
+#: id:331
+msgid "Compressing database..."
+msgstr "压缩资料库中..."
+
+#: id:332
+msgid "Error compressing database"
+msgstr "压缩资料库错误！"
+
+#: id:333
+msgid "Do you want to clean the library?"
+msgstr "要清理资料库吗？"
+
+#: id:334
+msgid "Clean library..."
+msgstr "清理资料库..."
+
+#: id:335
+msgid "Start"
+msgstr "开始"
+
+#: id:336
+msgid "Framerate conversion"
+msgstr "帧数转换"
+
+#: id:337
+msgctxt "Auto context with id 337"
+msgid "Audio output"
+msgstr "音频输出"
+
+#: id:338
+msgid "Analog"
+msgstr "模拟"
+
+#: id:339
+msgid "Optical/Coax"
+msgstr "光纤/同轴"
+
+#: id:340
+msgid "Various artists"
+msgstr "群星"
+
+#: id:341
+msgid "Play disc"
+msgstr "播放光盘"
+
+#: id:342
+msgctxt "Auto context with id 342"
+msgid "Movies"
+msgstr "电影"
+
+#: id:343
+msgid "Adjust framerate"
+msgstr "调整帧数"
+
+#: id:344
+msgid "Actors"
+msgstr "演员"
+
+#: id:345
+msgctxt "Auto context with id 345"
+msgid "Year"
+msgstr "年份"
+
+#: id:346
+msgid "Boost volume level on downmix"
+msgstr "增加声道缩减混音音量"
+
+#: id:350
+msgctxt "Auto context with id 350"
+msgid "Programs"
+msgstr "程序"
+
+#: id:351
+msgctxt "Auto context with id 351"
+msgid "Off"
+msgstr "关"
+
+#: id:352
+msgid "Dim"
+msgstr "昏暗"
+
+#: id:353
+msgid "Black"
+msgstr "全黑"
+
+#: id:354
+msgid "Matrix trails"
+msgstr "骇客任务"
+
+#: id:355
+msgid "Screensaver time"
+msgstr "屏保空闲时间"
+
+#: id:356
+msgid "Screensaver mode"
+msgstr "屏幕保护模式"
+
+#: id:357
+msgid "Shutdown function timer"
+msgstr "自动关机功能计时器"
+
+#: id:358
+msgid "All albums"
+msgstr "全部专辑"
+
+#: id:359
+msgid "Recently added albums"
+msgstr "新加的专辑"
+
+#: id:360
+msgctxt "Auto context with id 360"
+msgid "Screensaver"
+msgstr "屏幕保护"
+
+#: id:361
+msgid "R. Slideshow"
+msgstr "幻灯全部目录"
+
+#: id:362
+msgid "Screensaver dim level"
+msgstr "屏幕保护画面亮度衰减级别"
+
+#: id:363
+msgid "Sort by: File"
+msgstr "排序：文件"
+
+#: id:364
+msgid "- Dolby Digital (AC3) capable receiver"
+msgstr "- AC3 数字音效"
+
+#: id:365
+msgctxt "Auto context with id 365"
+msgid "Sort by: Name"
+msgstr "排序：名字"
+
+#: id:366
+msgid "Sort by: Year"
+msgstr "排序：年份"
+
+#: id:367
+msgid "Sort by: Rating"
+msgstr "排序：评分"
+
+#: id:368
+msgid "IMDb"
+msgstr "IMDb"
+
+#: id:369
+msgctxt "Auto context with id 369"
+msgid "Title"
+msgstr "标题"
+
+#: id:370
+msgid "Thunderstorms"
+msgstr "雷雨"
+
+#: id:371
+msgid "Partly"
+msgstr "局部"
+
+#: id:372
+msgid "Mostly"
+msgstr "大部分"
+
+#: id:373
+msgid "Sunny"
+msgstr "晴朗"
+
+#: id:374
+msgid "Cloudy"
+msgstr "阴"
+
+#: id:375
+msgid "Snow"
+msgstr "雪"
+
+#: id:376
+msgid "Rain"
+msgstr "雨"
+
+#: id:377
+msgid "Light"
+msgstr "细"
+
+#: id:378
+msgid "AM"
+msgstr "上午"
+
+#: id:379
+msgid "PM"
+msgstr "下午"
+
+#: id:380
+msgid "Showers"
+msgstr "阵雨"
+
+#: id:381
+msgid "Few"
+msgstr "少数"
+
+#: id:382
+msgid "Scattered"
+msgstr "短时有"
+
+#: id:383
+msgctxt "Auto context with id 383"
+msgid "Wind"
+msgstr "风"
+
+#: id:384
+msgid "Strong"
+msgstr "强烈"
+
+#: id:385
+msgid "Fair"
+msgstr "转晴"
+
+#: id:386
+msgctxt "Auto context with id 386"
+msgid "Clear"
+msgstr "晴"
+
+#: id:387
+msgid "Clouds"
+msgstr "云"
+
+#: id:388
+msgid "Early"
+msgstr "提早"
+
+#: id:389
+msgid "Shower"
+msgstr "阵雨"
+
+#: id:390
+msgid "Flurries"
+msgstr "飘雪"
+
+#: id:391
+msgctxt "Auto context with id 391"
+msgid "Low"
+msgstr "低"
+
+#: id:392
+msgctxt "Auto context with id 392"
+msgid "Medium"
+msgstr "中"
+
+#: id:393
+msgctxt "Auto context with id 393"
+msgid "High"
+msgstr "高"
+
+#: id:394
+msgid "Fog"
+msgstr "雾"
+
+#: id:395
+msgid "Haze"
+msgstr "薄雾"
+
+#: id:396
+msgid "Select location"
+msgstr "位置选择"
+
+#: id:397
+msgid "Refresh time"
+msgstr "刷新时间"
+
+#: id:398
+msgid "Temperature units"
+msgstr "温度单位"
+
+#: id:399
+msgid "Speed units"
+msgstr "速度单位"
+
+#: id:400
+msgctxt "Auto context with id 400"
+msgid "Weather"
+msgstr "天气"
+
+#: id:401
+msgid "Temp"
+msgstr "温度"
+
+#: id:402
+msgid "Feels like"
+msgstr "体感温度"
+
+#: id:403
+msgid "UV index"
+msgstr "紫外线"
+
+#: id:404
+msgctxt "Auto context with id 404"
+msgid "Wind"
+msgstr "风"
+
+#: id:405
+msgid "Dew point"
+msgstr "露点"
+
+#: id:406
+msgid "Humidity"
+msgstr "湿度"
+
+#: id:409
+msgid "Defaults"
+msgstr "默认"
+
+#: id:410
+msgid "Accessing weather service"
+msgstr "访问天气服务"
+
+#: id:411
+msgid "Getting weather for:"
+msgstr "取得天气数据："
+
+#: id:412
+msgid "Unable to get weather data"
+msgstr "不能获得天气数据"
+
+#: id:413
+msgid "Manual"
+msgstr "手动查询"
+
+#: id:414
+msgid "No review for this album"
+msgstr "此专辑无评论"
+
+#: id:415
+msgid "Downloading thumbnail..."
+msgstr "下载缩略图..."
+
+#: id:416
+msgid "Not available"
+msgstr "不可用"
+
+#: id:417
+msgid "View: Big icons"
+msgstr "显示：大图标"
+
+#: id:418
+msgctxt "Auto context with id 418"
+msgid "Low"
+msgstr "低"
+
+#: id:419
+msgctxt "Auto context with id 419"
+msgid "High"
+msgstr "高"
+
+#: id:420
+msgid "HDMI"
+msgstr "HDMI"
+
+#: id:422
+msgid "Delete album info"
+msgstr "删除专辑信息"
+
+#: id:423
+msgid "Delete CD information"
+msgstr "删除 CD 信息"
+
+#: id:424
+msgid "Select"
+msgstr "选择"
+
+#: id:425
+msgid "No album information found"
+msgstr "找不到专辑信息。"
+
+#: id:426
+msgid "No CD information found"
+msgstr "找不到 CD 信息！"
+
+#: id:427
+msgid "Disc"
+msgstr "光盘"
+
+#: id:428
+msgid "Insert correct CD/DVD"
+msgstr "请放入正确的 CD/DVD"
+
+#: id:429
+msgid "Please insert the following disc:"
+msgstr "请放入下一张盘片："
+
+#: id:430
+msgid "Sort by: DVD#"
+msgstr "排序：DVD#"
+
+#: id:431
+msgid "No cache"
+msgstr "无缓存"
+
+#: id:432
+msgid "Remove movie from library"
+msgstr "从资料库中移除影片"
+
+#: id:433
+msgid "Really remove '%s'?"
+msgstr "确定移除'%s'？"
+
+#: id:434
+msgid "From %s at %i %s"
+msgstr "风向 %s 风速 %i %s"
+
+#: id:437
+msgid "Removable disk"
+msgstr "移动磁盘"
+
+#: id:438
+msgid "Opening file"
+msgstr "打开文件"
+
+#: id:439
+msgid "Cache"
+msgstr "缓存"
+
+#: id:440
+msgid "Harddisk"
+msgstr "硬盘"
+
+#: id:441
+msgid "UDF"
+msgstr "UDF"
+
+#: id:442
+msgid "Local network"
+msgstr "网络"
+
+#: id:443
+msgid "Internet"
+msgstr "互联网"
+
+#: id:444
+msgctxt "Auto context with id 444"
+msgid "Video"
+msgstr "视频"
+
+#: id:445
+msgctxt "Auto context with id 445"
+msgid "Audio"
+msgstr "音频"
+
+#: id:446
+msgctxt "Auto context with id 446"
+msgid "DVD"
+msgstr "DVD"
+
+#: id:447
+msgid "Autorun media"
+msgstr "自动播放媒体"
+
+#: id:448
+msgid "LCD"
+msgstr "液晶屏设置"
+
+#: id:449
+msgctxt "Auto context with id 449"
+msgid "Enabled"
+msgstr "开启"
+
+#: id:450
+msgid "Columns"
+msgstr "列"
+
+#: id:451
+msgid "Row 1 address"
+msgstr "第 1 行位置"
+
+#: id:452
+msgid "Row 2 address"
+msgstr "第 2 行位置"
+
+#: id:453
+msgid "Row 3 address"
+msgstr "第 3 行位置"
+
+#: id:454
+msgid "Row 4 address"
+msgstr "第 4 行位置"
+
+#: id:455
+msgid "Rows"
+msgstr "行"
+
+#: id:456
+msgid "Mode"
+msgstr "模式"
+
+#: id:457
+msgid "Switch view"
+msgstr "选择显示"
+
+#: id:459
+msgid "Subs"
+msgstr "字幕"
+
+#: id:460
+msgid "Audio stream"
+msgstr "音频流"
+
+#: id:461
+msgid "[active]"
+msgstr "[启用]"
+
+#: id:462
+msgid "Subtitle"
+msgstr "字幕"
+
+#: id:463
+msgid "Backlight"
+msgstr "背光"
+
+#: id:464
+msgid "Brightness"
+msgstr "亮度"
+
+#: id:465
+msgid "Contrast"
+msgstr "对比度"
+
+#: id:466
+msgid "Gamma"
+msgstr "伽码"
+
+#: id:467
+msgctxt "Auto context with id 467"
+msgid "Type"
+msgstr "类型"
+
+#: id:468
+msgid "Move the bar to change the OSD position"
+msgstr "移动条块来改变 OSD 位置"
+
+#: id:469
+msgid "OSD position"
+msgstr "OSD 位置"
+
+#: id:470
+msgid "Credits"
+msgstr "改机者"
+
+#: id:471
+msgid "Modchip"
+msgstr "改机芯片"
+
+#: id:474
+msgctxt "Auto context with id 474"
+msgid "Off"
+msgstr "关"
+
+#: id:475
+msgid "Music only"
+msgstr "只有音乐"
+
+#: id:476
+msgctxt "Auto context with id 476"
+msgid "Music & video"
+msgstr "音乐和视频"
+
+#: id:477
+msgid "Unable to load playlist"
+msgstr "不能读取播放列表"
+
+#: id:478
+msgid "OSD"
+msgstr "OSD"
+
+#: id:479
+msgid "Skin & language"
+msgstr "皮肤和语言"
+
+#: id:480
+msgid "Appearance"
+msgstr "用户界面"
+
+#: id:481
+msgid "Audio options"
+msgstr "音频设置"
+
+#: id:482
+msgid "About XBMC"
+msgstr "关于 XBMC"
+
+#: id:485
+msgid "Delete album"
+msgstr "删除专辑"
+
+#: id:486
+msgid "Repeat"
+msgstr "重复"
+
+#: id:487
+msgid "Repeat one"
+msgstr "重复单首"
+
+#: id:488
+msgid "Repeat folder"
+msgstr "重复整个目录"
+
+#: id:489
+msgid "Play the next song automatically"
+msgstr "自动播放下一首歌曲"
+
+#: id:491
+msgid "- Use big icons"
+msgstr "- 使用大图标"
+
+#: id:492
+msgid "Resize VobSubs"
+msgstr "Vobsubs 字幕缩放"
+
+#: id:493
+msgid "Advanced options (Experts Only!)"
+msgstr "高级选项（仅适用于专家！）"
+
+#: id:494
+msgid "Overall audio headroom"
+msgstr "总体音量"
+
+#: id:495
+msgid "Upsample videos to GUI resolution"
+msgstr "以桌面的分辨率播放视频"
+
+#: id:496
+msgid "Calibration"
+msgstr "校准"
+
+#: id:497
+msgid "Show file extensions"
+msgstr "显示扩展文件名"
+
+#: id:498
+msgid "Sort by: Type"
+msgstr "排序：类型"
+
+#: id:499
+msgid "Unable to connect to online lookup service"
+msgstr "无法连接到在线搜索服务"
+
+#: id:500
+msgid "Downloading album information failed"
+msgstr "下载专辑信息失败..."
+
+#: id:501
+msgid "Looking for album names..."
+msgstr "寻找专辑名..."
+
+#: id:502
+msgctxt "Auto context with id 502"
+msgid "Open"
+msgstr "开启"
+
+#: id:503
+msgid "Busy"
+msgstr "忙"
+
+#: id:504
+msgid "Empty"
+msgstr "空"
+
+#: id:505
+msgid "Loading media info from files..."
+msgstr "从文件中载入媒体信息..."
+
+#: id:507
+msgid "Sort by: Usage"
+msgstr "排序：使用次数"
+
+#: id:510
+msgid "Enable visualizations"
+msgstr "开启可视化效果"
+
+#: id:511
+msgid "Enable video mode switching"
+msgstr "启用视频模式自动切换"
+
+#: id:512
+msgid "Startup window"
+msgstr "启动界面"
+
+#: id:513
+msgid "Home window"
+msgstr "主界面"
+
+#: id:514
+msgid "Manual settings"
+msgstr "设置界面"
+
+#: id:515
+msgid "Genre"
+msgstr "风格"
+
+#: id:517
+msgid "Recently played albums"
+msgstr "最近播放的专辑"
+
+#: id:518
+msgid "Launch"
+msgstr "运行"
+
+#: id:519
+msgid "Launch in..."
+msgstr "运行方式"
+
+#: id:521
+msgid "Compilations"
+msgstr "合辑"
+
+#: id:522
+msgid "Remove source"
+msgstr "移除源"
+
+#: id:523
+msgid "Switch media"
+msgstr "切换媒体"
+
+#: id:524
+msgid "Select playlist"
+msgstr "选择播放列表"
+
+#: id:525
+msgid "New playlist..."
+msgstr "新的播放列表..."
+
+#: id:526
+msgid "Add to playlist"
+msgstr "添加到播放列表"
+
+#: id:527
+msgid "Manually add to library"
+msgstr "手工添加到资料库"
+
+#: id:528
+msgid "Enter title"
+msgstr "输入标题"
+
+#: id:529
+msgid "Error: Duplicate title"
+msgstr "错误：重复标题"
+
+#: id:530
+msgid "Select genre"
+msgstr "选择类型"
+
+#: id:531
+msgid "New genre"
+msgstr "新的类型"
+
+#: id:532
+msgid "Manual addition"
+msgstr "手工添加"
+
+#: id:533
+msgid "Enter genre"
+msgstr "输入类型"
+
+#: id:534
+msgid "View: %s"
+msgstr "显示：%s"
+
+#: id:535
+msgid "List"
+msgstr "列表"
+
+#: id:536
+msgid "Icons"
+msgstr "图标"
+
+#: id:537
+msgid "Big list"
+msgstr "大列表"
+
+#: id:538
+msgid "Big icons"
+msgstr "大图标"
+
+#: id:539
+msgid "Wide"
+msgstr "宽幅"
+
+#: id:540
+msgid "Big wide"
+msgstr "大宽幅"
+
+#: id:541
+msgid "Album icons"
+msgstr "专辑图标"
+
+#: id:542
+msgid "DVD icons"
+msgstr "DVD 图标"
+
+#: id:543
+msgctxt "Auto context with id 543"
+msgid "DVD"
+msgstr "DVD"
+
+#: id:544
+msgctxt "Auto context with id 544"
+msgid "Media info"
+msgstr "媒体信息"
+
+#: id:545
+msgid "Audio output device"
+msgstr "音频输出设备"
+
+#: id:546
+msgid "Passthrough output device"
+msgstr "直通输出设备"
+
+#: id:547
+msgid "No biography for this artist"
+msgstr "此艺人没有传记"
+
+#: id:548
+msgid "Downmix multichannel audio to stereo"
+msgstr "多声道音频声道缩减混音成立体声"
+
+#: id:550
+msgid "Sort by: %s"
+msgstr "排序：%s"
+
+#: id:551
+msgctxt "Auto context with id 551"
+msgid "Name"
+msgstr "名称"
+
+#: id:552
+msgid "Date"
+msgstr "日期"
+
+#: id:553
+msgid "Size"
+msgstr "大小"
+
+#: id:554
+msgid "Track"
+msgstr "音轨"
+
+#: id:555
+msgid "Time"
+msgstr "时长"
+
+#: id:556
+msgctxt "Auto context with id 556"
+msgid "Title"
+msgstr "标题"
+
+#: id:557
+msgid "Artist"
+msgstr "艺人"
+
+#: id:558
+msgid "Album"
+msgstr "专辑"
+
+#: id:559
+msgid "Playlist"
+msgstr "播放列表"
+
+#: id:560
+msgid "ID"
+msgstr "标签"
+
+#: id:561
+msgctxt "Auto context with id 561"
+msgid "File"
+msgstr "文件"
+
+#: id:562
+msgctxt "Auto context with id 562"
+msgid "Year"
+msgstr "年份"
+
+#: id:563
+msgid "Rating"
+msgstr "评价"
+
+#: id:564
+msgctxt "Auto context with id 564"
+msgid "Type"
+msgstr "类型"
+
+#: id:565
+msgid "Usage"
+msgstr "使用次数"
+
+#: id:566
+msgid "Album artist"
+msgstr "专辑艺人"
+
+#: id:567
+msgid "Play count"
+msgstr "播放次数"
+
+#: id:568
+msgid "Last played"
+msgstr "最后播放"
+
+#: id:569
+msgctxt "Auto context with id 569"
+msgid "Comment"
+msgstr "注释"
+
+#: id:570
+msgid "Date added"
+msgstr "加入日期"
+
+#: id:571
+msgctxt "Auto context with id 571"
+msgid "Default"
+msgstr "默认"
+
+#: id:572
+msgid "Studio"
+msgstr "制作公司"
+
+#: id:573
+msgid "Path"
+msgstr "路径"
+
+#: id:574
+msgctxt "Auto context with id 574"
+msgid "Country"
+msgstr "国家"
+
+#: id:575
+msgid "In progress"
+msgstr "进行中"
+
+#: id:576
+msgid "Times played"
+msgstr "播放次数"
+
+#: id:580
+msgid "Sort direction"
+msgstr "排序方向"
+
+#: id:581
+msgid "Sort method"
+msgstr "排序方法"
+
+#: id:582
+msgctxt "Auto context with id 582"
+msgid "View mode"
+msgstr "显示模式"
+
+#: id:583
+msgid "Remember views for different folders"
+msgstr "记住每个文件夹的显示模式"
+
+#: id:584
+msgid "Ascending"
+msgstr "升序"
+
+#: id:585
+msgid "Descending"
+msgstr "降序"
+
+#: id:586
+msgid "Edit playlist"
+msgstr "编辑播放列表"
+
+#: id:587
+msgid "Filter"
+msgstr "过滤"
+
+#: id:588
+msgid "Cancel party mode"
+msgstr "取消舞会模式"
+
+#: id:589
+msgid "Party mode"
+msgstr "舞会模式"
+
+#: id:590
+msgid "Random"
+msgstr "随机"
+
+#: id:591
+msgctxt "Auto context with id 591"
+msgid "Off"
+msgstr "关"
+
+#: id:592
+msgid "One"
+msgstr "单首"
+
+#: id:593
+msgid "All"
+msgstr "全部"
+
+#: id:594
+msgctxt "Auto context with id 594"
+msgid "Off"
+msgstr "关"
+
+#: id:595
+msgid "Repeat: Off"
+msgstr "重复：关闭"
+
+#: id:596
+msgid "Repeat: One"
+msgstr "重复：单首"
+
+#: id:597
+msgid "Repeat: All"
+msgstr "重复：所有"
+
+#: id:600
+msgid "Rip audio CD"
+msgstr "压缩音乐 CD"
+
+#: id:601
+msgctxt "Auto context with id 601"
+msgid "Medium"
+msgstr "中等"
+
+#: id:602
+msgctxt "Auto context with id 602"
+msgid "Standard"
+msgstr "标准"
+
+#: id:603
+msgid "Extreme"
+msgstr "极好"
+
+#: id:604
+msgid "Constant bitrate"
+msgstr "固定码率"
+
+#: id:605
+msgid "Ripping..."
+msgstr "压缩..."
+
+#: id:607
+msgid "To:"
+msgstr "储存到："
+
+#: id:608
+msgid "Could not rip CD or track"
+msgstr "不能压缩 CD 或音轨"
+
+#: id:609
+msgid "CDDARipPath is not set."
+msgstr "CD 压缩路径没有设置"
+
+#: id:610
+msgid "Rip audio track"
+msgstr "压缩音轨"
+
+#: id:611
+msgid "Enter number"
+msgstr "请输入序号"
+
+#: id:612
+msgid "Bits/Sample"
+msgstr "采样位数"
+
+#: id:613
+msgid "Sample Frequency"
+msgstr "采样率"
+
+#: id:620
+msgid "Audio CDs"
+msgstr "音乐 CD"
+
+#: id:621
+msgid "Encoder"
+msgstr "编码器"
+
+#: id:622
+msgid "Quality"
+msgstr "质量"
+
+#: id:623
+msgid "Bitrate"
+msgstr "码率"
+
+#: id:624
+msgid "Include track number"
+msgstr "包括音轨序号"
+
+#: id:625
+msgid "All songs of"
+msgstr "所有歌曲"
+
+#: id:629
+msgctxt "Auto context with id 629"
+msgid "View mode"
+msgstr "显示模式"
+
+#: id:630
+msgctxt "Auto context with id 630"
+msgid "Normal"
+msgstr "正常"
+
+#: id:631
+msgid "Zoom"
+msgstr "满屏"
+
+#: id:632
+msgid "Stretch 4:3"
+msgstr "拉伸为 4:3"
+
+#: id:633
+msgid "Wide Zoom"
+msgstr "宽屏"
+
+#: id:634
+msgid "Stretch 16:9"
+msgstr "拉伸为 16:9"
+
+#: id:635
+msgid "Original Size"
+msgstr "原始大小"
+
+#: id:636
+msgctxt "Auto context with id 636"
+msgid "Custom"
+msgstr "自定义"
+
+#: id:637
+msgid "Replay gain"
+msgstr "回放增益"
+
+#: id:638
+msgid "Replaygain volume adjustments"
+msgstr "回放增益音量调整"
+
+#: id:639
+msgid "Use track levels"
+msgstr "使用音轨增益等级"
+
+#: id:640
+msgid "Use album levels"
+msgstr "使用专辑增益等级"
+
+#: id:641
+msgid "PreAmp Level - Replay gained files"
+msgstr "音量 - 重复播放的文件"
+
+#: id:642
+msgid "PreAmp Level - Non replay gained files"
+msgstr "音量 - 不重复播放的文件"
+
+#: id:643
+msgid "Avoid clipping on replay gained files"
+msgstr "播放增益时忽略消波失真"
+
+#: id:644
+msgid "Crop black bars"
+msgstr "裁剪黑边"
+
+#: id:645
+msgid "Need to unpack a big file. Continue?"
+msgstr "需要解压一个大文件，是否继续？"
+
+#: id:646
+msgid "Remove from library"
+msgstr "从资料库中移除"
+
+#: id:647
+msgid "Export video library"
+msgstr "导出视频库"
+
+#: id:648
+msgid "Import video library"
+msgstr "导入视频库"
+
+#: id:649
+msgid "Importing"
+msgstr "导入中"
+
+#: id:650
+msgid "Exporting"
+msgstr "导出中"
+
+#: id:651
+msgid "Browse for library"
+msgstr "浏览资料库"
+
+#: id:652
+msgid "Years"
+msgstr "年份"
+
+#: id:653
+msgid "Update library"
+msgstr "更新资料库"
+
+#: id:654
+msgid "Show debug info"
+msgstr "显示调试信息"
+
+#: id:655
+msgid "Browse for executable"
+msgstr "浏览可执行文件"
+
+#: id:656
+msgid "Browse for playlist"
+msgstr "浏览播放列表"
+
+#: id:657
+msgid "Browse for folder"
+msgstr "浏览文件夹"
+
+#: id:658
+msgid "Song information"
+msgstr "歌曲信息"
+
+#: id:659
+msgid "Non-linear stretch"
+msgstr "非线性拉伸"
+
+#: id:660
+msgid "Volume amplification"
+msgstr "音量放大"
+
+#: id:661
+msgid "Choose export folder"
+msgstr "选择导出文件夹"
+
+#: id:662
+msgid "This file is no longer available."
+msgstr "此文件已不可用"
+
+#: id:663
+msgid "Would you like to remove it from the library?"
+msgstr "要从资料库移除吗？"
+
+#: id:664
+msgid "Browse for Script"
+msgstr "浏览脚本"
+
+#: id:665
+msgid "Compression level"
+msgstr "压缩级别"
+
+#: id:700
+msgid "Cleaning up library"
+msgstr "清理资料库"
+
+#: id:701
+msgid "Removing old songs from the library"
+msgstr "清除资料库中的旧歌曲"
+
+#: id:702
+msgid "This path has been scanned before"
+msgstr "当前路径曾被扫瞄过"
+
+#: id:705
+msgctxt "Auto context with id 705"
+msgid "Network"
+msgstr "网络"
+
+#: id:706
+msgid "- Server"
+msgstr "- 服务器"
+
+#: id:708
+msgid "Use an HTTP proxy server to access the internet"
+msgstr "使用 HTTP 代理服务器访问互联网"
+
+#: id:711
+msgid "Internet Protocol (IP)"
+msgstr "网络地址（IP）"
+
+#: id:712
+msgid "Invalid port specified. Value must be between 1 and 65535."
+msgstr "无效端口！必须在 1 至 65535 之间。"
+
+#: id:713
+msgid "HTTP proxy"
+msgstr "HTTP 代理"
+
+#: id:715
+msgid "- Assignment"
+msgstr "- 分配方式"
+
+#: id:716
+msgid "Automatic (DHCP)"
+msgstr "自动（动态分配）"
+
+#: id:717
+msgid "Manual (Static)"
+msgstr "手动（静态分配）"
+
+#: id:719
+msgid "- IP address"
+msgstr "- IP 地址"
+
+#: id:720
+msgid "- Netmask"
+msgstr "- 子网掩码"
+
+#: id:721
+msgid "- Default gateway"
+msgstr "- 默认网关"
+
+#: id:722
+msgid "- DNS server"
+msgstr "- DNS 服务器"
+
+#: id:723
+msgid "Save & restart"
+msgstr "保存和重启"
+
+#: id:724
+msgid "Invalid address specified. Value must be AAA.BBB.CCC.DDD"
+msgstr "无效地址！正确格式为：AAA.BBB.CCC.DDD"
+
+#: id:725
+msgid "with numbers between 0 and 255."
+msgstr "从 0 到 255 之间的数字"
+
+#: id:726
+msgid "Changes not saved. Continue without saving?"
+msgstr "修改未保存，继续且不保存吗？"
+
+#: id:727
+msgid "Web server"
+msgstr "Web 服务器"
+
+#: id:728
+msgctxt "Auto context with id 728"
+msgid "FTP server"
+msgstr "FTP 服务器"
+
+#: id:730
+msgid "- Port"
+msgstr "- 端口"
+
+#: id:732
+msgid "Save & apply"
+msgstr "保存和应用"
+
+#: id:733
+msgid "- Password"
+msgstr "- 密码"
+
+#: id:734
+msgid "No pass"
+msgstr "无密码"
+
+#: id:735
+msgid "- Character set"
+msgstr "- 字符集"
+
+#: id:736
+msgid "- Style"
+msgstr "- 字形"
+
+#: id:737
+msgid "- Colour"
+msgstr "- 颜色"
+
+#: id:738
+msgctxt "Auto context with id 738"
+msgid "Normal"
+msgstr "常规"
+
+#: id:739
+msgid "Bold"
+msgstr "粗体"
+
+#: id:740
+msgid "Italics"
+msgstr "斜体"
+
+#: id:741
+msgid "Bold italics"
+msgstr "粗斜体"
+
+#: id:742
+msgctxt "Auto context with id 742"
+msgid "White"
+msgstr "白色"
+
+#: id:743
+msgctxt "Auto context with id 743"
+msgid "Yellow"
+msgstr "黄色"
+
+#: id:744
+msgctxt "Auto context with id 744"
+msgid "Files"
+msgstr "文件"
+
+#: id:745
+msgid "No scanned information for this view"
+msgstr "当前视图无信息"
+
+#: id:746
+msgid "Please turn off library mode"
+msgstr "请关闭资料库模式"
+
+#: id:747
+msgid "Error loading image"
+msgstr "图像载入错误"
+
+#: id:748
+msgid "Edit path"
+msgstr "编辑路径"
+
+#: id:749
+msgid "Mirror image"
+msgstr "镜像图像"
+
+#: id:750
+msgid "Are you sure?"
+msgstr "确定？"
+
+#: id:751
+msgid "Removing source"
+msgstr "移除共享"
+
+#: id:754
+msgid "Add program link"
+msgstr "新增程序连接"
+
+#: id:755
+msgid "Edit program path"
+msgstr "编辑程序路径"
+
+#: id:756
+msgid "Edit program name"
+msgstr "编辑程序名称"
+
+#: id:757
+msgid "Edit path depth"
+msgstr "编辑路径深度"
+
+#: id:759
+msgid "View: Big list"
+msgstr "显示：大列表"
+
+#: id:760
+msgctxt "Auto context with id 760"
+msgid "Yellow"
+msgstr "黄色"
+
+#: id:761
+msgctxt "Auto context with id 761"
+msgid "White"
+msgstr "白色"
+
+#: id:762
+msgid "Blue"
+msgstr "蓝色"
+
+#: id:763
+msgid "Bright green"
+msgstr "亮绿"
+
+#: id:764
+msgid "Yellow green"
+msgstr "翠绿"
+
+#: id:765
+msgid "Cyan"
+msgstr "青色"
+
+#: id:766
+msgid "Light grey"
+msgstr "浅灰"
+
+#: id:767
+msgid "Grey"
+msgstr "灰色"
+
+#: id:770
+msgid "Error %i: share not available"
+msgstr "错误 %i：不能共享"
+
+#: id:772
+msgctxt "Auto context with id 772"
+msgid "Audio output"
+msgstr "音频输出"
+
+#: id:773
+msgid "Seeking"
+msgstr "搜索中"
+
+#: id:774
+msgid "Slideshow folder"
+msgstr "幻灯图片目录"
+
+#: id:775
+msgid "Network interface"
+msgstr "网卡"
+
+#: id:776
+msgid "- Wireless network name (ESSID)"
+msgstr "- 无线网络名（ESSID）"
+
+#: id:777
+msgid "- Wireless password"
+msgstr "- 无线网加密方式"
+
+#: id:778
+msgid "- Wireless security"
+msgstr "- 无线网安全"
+
+#: id:779
+msgid "Save and apply network interface settings"
+msgstr "保存和应用网卡设置"
+
+#: id:780
+msgid "No encryption"
+msgstr "不加密"
+
+#: id:781
+msgid "WEP"
+msgstr "WEP"
+
+#: id:782
+msgid "WPA"
+msgstr "WPA"
+
+#: id:783
+msgid "WPA2"
+msgstr "WPA2"
+
+#: id:784
+msgid "Applying network interface settings. Please wait."
+msgstr "应用网卡设置，请稍等."
+
+#: id:785
+msgid "Network interface restarted successfully."
+msgstr "网卡重启完成."
+
+#: id:786
+msgid "Network interface did not start successfully."
+msgstr "网卡无法重启."
+
+#: id:787
+msgid "Interface disabled"
+msgstr "网卡停用"
+
+#: id:788
+msgid "Network interface disabled successfully."
+msgstr "网卡停用完成."
+
+#: id:789
+msgid "Wireless network name (ESSID)"
+msgstr "无线网络名（ESSID）"
+
+#: id:790
+msgid "Remote control"
+msgstr "远程控制"
+
+#: id:791
+msgid "Allow programs on this system to control XBMC"
+msgstr "允许本机程序控制 XBMC"
+
+#: id:792
+msgctxt "Auto context with id 792"
+msgid "Port"
+msgstr "端口"
+
+#: id:793
+msgid "Port range"
+msgstr "端口范围"
+
+#: id:794
+msgid "Allow programs on other systems to control XBMC"
+msgstr "允许异地程序控制 XBMC"
+
+#: id:795
+msgid "Initial repeat delay (ms)"
+msgstr "初始重复等待时间（ms）"
+
+#: id:796
+msgid "Continuous repeat delay (ms)"
+msgstr "持续等待时间（ms）"
+
+#: id:797
+msgid "Maximum number of clients"
+msgstr "最大客户端数"
+
+#: id:798
+msgid "Internet access"
+msgstr "互联网访问"
+
+#: id:850
+msgid "Invalid port number entered"
+msgstr "输入了无效端口"
+
+#: id:851
+msgid "Valid port range is 1-65535"
+msgstr "有效端口范围是 1-65535"
+
+#: id:852
+msgid "Valid port range is 1024-65535"
+msgstr "有效端口范围是 1024-65535"
+
+#: id:998
+msgid "Add Music..."
+msgstr "添加音乐..."
+
+#: id:999
+msgid "Add Videos..."
+msgstr "添加视频..."
+
+#: id:1000
+msgid "- Preview"
+msgstr "- 预览"
+
+#: id:1001
+msgid "Unable to connect"
+msgstr "无法连接"
+
+#: id:1002
+msgid "XBMC was unable to connect to the network location."
+msgstr "XBMC 无法连接到该网上邻居！"
+
+#: id:1003
+msgid "This could be due to the network not being connected."
+msgstr "这可能是由于网络没有连接。"
+
+#: id:1004
+msgid "Would you like to add it anyway?"
+msgstr "可以用其他方式来添加它吗？"
+
+#: id:1006
+msgctxt "Auto context with id 1006"
+msgid "IP address"
+msgstr "IP 地址"
+
+#: id:1007
+msgid "Add network location"
+msgstr "添加网上邻居"
+
+#: id:1008
+msgid "Protocol"
+msgstr "协议"
+
+#: id:1009
+msgid "Server address"
+msgstr "服务器地址"
+
+#: id:1010
+msgid "Server name"
+msgstr "服务器名称"
+
+#: id:1011
+msgid "Remote path"
+msgstr "远程路径"
+
+#: id:1012
+msgid "Shared folder"
+msgstr "共享文件夹"
+
+#: id:1013
+msgctxt "Auto context with id 1013"
+msgid "Port"
+msgstr "端口"
+
+#: id:1014
+msgctxt "Auto context with id 1014"
+msgid "Username"
+msgstr "用户名"
+
+#: id:1015
+msgid "Browse for network server"
+msgstr "网络服务器"
+
+#: id:1016
+msgid "Enter the network address of the server"
+msgstr "输入服务器网络地址"
+
+#: id:1017
+msgid "Enter the path on the server"
+msgstr "输入服务器远程路径"
+
+#: id:1018
+msgid "Enter the port number"
+msgstr "输入端口号"
+
+#: id:1019
+msgid "Enter the username"
+msgstr "输入用户名"
+
+#: id:1020
+msgid "Add %s source"
+msgstr "添加%s目录"
+
+#: id:1021
+msgid "Enter the paths or browse for the media locations."
+msgstr "输入或选择目录。"
+
+#: id:1022
+msgid "Enter a name for this media Source."
+msgstr "为该目录命名。"
+
+#: id:1023
+msgid "Browse for new share"
+msgstr "浏览目录"
+
+#: id:1024
+msgid "Browse"
+msgstr "浏览"
+
+#: id:1025
+msgid "Could not retrieve directory information."
+msgstr "无法获得目录信息。"
+
+#: id:1026
+msgid "Add source"
+msgstr "添加目录"
+
+#: id:1027
+msgid "Edit source"
+msgstr "编辑目录"
+
+#: id:1028
+msgid "Edit %s source"
+msgstr "编辑%s目录"
+
+#: id:1029
+msgid "Enter the new label"
+msgstr "输入新的标签"
+
+#: id:1030
+msgid "Browse for image"
+msgstr "选择图像文件"
+
+#: id:1031
+msgid "Browse for image folder"
+msgstr "选择图像目录"
+
+#: id:1032
+msgid "Add network location..."
+msgstr "添加网上邻居..."
+
+#: id:1033
+msgid "Browse for file"
+msgstr "浏览文件"
+
+#: id:1034
+msgid "Submenu"
+msgstr "子菜单"
+
+#: id:1035
+msgid "Enable submenu buttons"
+msgstr "启用子菜单按钮"
+
+#: id:1036
+msgid "Favourites"
+msgstr "收藏夹"
+
+#: id:1037
+msgid "Video Add-ons"
+msgstr "视频扩展功能"
+
+#: id:1038
+msgid "Music Add-ons"
+msgstr "音乐扩展功能"
+
+#: id:1039
+msgid "Picture Add-ons"
+msgstr "图片扩展功能"
+
+#: id:1040
+msgid "Loading directory"
+msgstr "载入目录"
+
+#: id:1041
+msgid "Retrieved %i items"
+msgstr "检索%i项目"
+
+#: id:1042
+msgid "Retrieved %i of %i items"
+msgstr "检索%i在%i项目"
+
+#: id:1043
+msgid "Program Add-ons"
+msgstr "程序扩展功能"
+
+#: id:1044
+msgid "Set plugin thumb"
+msgstr "设置插件缩略图"
+
+#: id:1045
+msgid "Add-on settings"
+msgstr "扩展功能设置"
+
+#: id:1046
+msgid "Access points"
+msgstr "接入点"
+
+#: id:1047
+msgid "Other..."
+msgstr "其它..."
+
+#: id:1048
+msgid "- Username"
+msgstr "- 用户名"
+
+#: id:1049
+msgid "Script settings"
+msgstr "脚本设置"
+
+#: id:1050
+msgid "Singles"
+msgstr "单曲"
+
+#: id:1051
+msgid "Enter web address"
+msgstr "输入网页地址"
+
+#: id:1200
+msgid "SMB client"
+msgstr "SMB 共享设置"
+
+#: id:1202
+msgid "Workgroup"
+msgstr "工作组"
+
+#: id:1203
+msgid "Default username"
+msgstr "默认账号"
+
+#: id:1204
+msgid "Default password"
+msgstr "默认密码"
+
+#: id:1207
+msgid "WINS server"
+msgstr "WINS-服务器"
+
+#: id:1208
+msgid "Mount SMB shares"
+msgstr "安装 SMB 共享"
+
+#: id:1210
+msgctxt "Auto context with id 1210"
+msgid "Remove"
+msgstr "移除"
+
+#: id:1211
+msgctxt "Auto context with id 1211"
+msgid "Music"
+msgstr "音乐"
+
+#: id:1212
+msgctxt "Auto context with id 1212"
+msgid "Video"
+msgstr "视频"
+
+#: id:1213
+msgctxt "Auto context with id 1213"
+msgid "Pictures"
+msgstr "图片"
+
+#: id:1214
+msgctxt "Auto context with id 1214"
+msgid "Files"
+msgstr "文件"
+
+#: id:1215
+msgctxt "Auto context with id 1215"
+msgid "Music & video"
+msgstr "音乐和视频"
+
+#: id:1216
+msgid "Music & pictures"
+msgstr "音乐和图片"
+
+#: id:1217
+msgid "Music & files"
+msgstr "音乐和文件"
+
+#: id:1218
+msgid "Video & pictures"
+msgstr "视频和图片"
+
+#: id:1219
+msgid "Video & files"
+msgstr "视频和文件"
+
+#: id:1220
+msgid "Pictures & files"
+msgstr "图片和文件"
+
+#: id:1221
+msgid "Music & video & pictures"
+msgstr "音乐和视频和图片"
+
+#: id:1222
+msgid "Music & video & pictures & files"
+msgstr "音乐和视频和图片和文件"
+
+#: id:1223
+msgctxt "Auto context with id 1223"
+msgid "Disabled"
+msgstr "停用"
+
+#: id:1226
+msgid "Files & music & video"
+msgstr "文件和音乐和视频"
+
+#: id:1227
+msgid "Files & pictures & music"
+msgstr "文件和图片和音乐"
+
+#: id:1228
+msgid "Files & pictures & video"
+msgstr "文件和图片和视频"
+
+#: id:1229
+msgid "Music & programs"
+msgstr "音乐和程序"
+
+#: id:1230
+msgid "Video & programs"
+msgstr "视频和程序"
+
+#: id:1231
+msgid "Pictures & programs"
+msgstr "图片和程序"
+
+#: id:1232
+msgid "Music & video & pictures & programs"
+msgstr "音乐和视频和图片和程序"
+
+#: id:1233
+msgid "Programs & video & music"
+msgstr "程序和视频和音乐"
+
+#: id:1234
+msgid "Programs & pictures & music"
+msgstr "程序和图片和音乐"
+
+#: id:1235
+msgid "Programs & pictures & video"
+msgstr "程序和图片和视频"
+
+#: id:1250
+msgid "Auto-detection"
+msgstr "自动检测"
+
+#: id:1251
+msgid "Auto-detect system"
+msgstr "自动检测系统"
+
+#: id:1252
+msgid "Nickname"
+msgstr "昵称"
+
+#: id:1254
+msgid "Ask to connect"
+msgstr "确认连接"
+
+#: id:1255
+msgid "Send FTP user and password"
+msgstr "发送 FTP 用户名和密码"
+
+#: id:1256
+msgid "Ping interval"
+msgstr "Ping 间隔"
+
+#: id:1257
+msgid "Would you like to connect to the auto-detected system?"
+msgstr "是否连接到自动发现的系统？"
+
+#: id:1259
+msgid "Zeroconf"
+msgstr "Zeroconf"
+
+#: id:1260
+msgid "Announce these services to other systems via Zeroconf"
+msgstr "通过 Zeroconf 协议发布这些服务"
+
+#: id:1270
+msgid "Allow XBMC to receive AirPlay content"
+msgstr "允许 XBMC 接收 AirPlay 内容"
+
+#: id:1271
+msgid "Device name"
+msgstr "设备名"
+
+#: id:1272
+msgid "- Use password protection"
+msgstr "- 使用密码保护"
+
+#: id:1273
+msgid "AirPlay"
+msgstr "AirPlay"
+
+#: id:1300
+msgid "Custom audio device"
+msgstr "自定义音频设备"
+
+#: id:1301
+msgid "Custom passthrough device"
+msgstr "自定义直通输出设备"
+
+#: id:1396
+msgid "Drifting"
+msgstr "漂流"
+
+#: id:1397
+msgid "and"
+msgstr "和"
+
+#: id:1398
+msgid "Freezing"
+msgstr "结冰"
+
+#: id:1399
+msgid "Late"
+msgstr "晚间"
+
+#: id:1400
+msgid "Isolated"
+msgstr "局部"
+
+#: id:1401
+msgid "Thundershowers"
+msgstr "雷阵雨"
+
+#: id:1402
+msgid "Thunder"
+msgstr "雷"
+
+#: id:1403
+msgctxt "Auto context with id 1403"
+msgid "Sun"
+msgstr "阴沉"
+
+#: id:1404
+msgid "Heavy"
+msgstr "暴"
+
+#: id:1405
+msgid "in"
+msgstr "在"
+
+#: id:1406
+msgid "the"
+msgstr "这"
+
+#: id:1407
+msgid "Vicinity"
+msgstr "区域性"
+
+#: id:1408
+msgid "Ice"
+msgstr "冰"
+
+#: id:1409
+msgid "Crystals"
+msgstr "清澈"
+
+#: id:1410
+msgid "Calm"
+msgstr "无风"
+
+#: id:1411
+msgid "with"
+msgstr "和"
+
+#: id:1412
+msgid "windy"
+msgstr "风"
+
+#: id:1413
+msgid "drizzle"
+msgstr "小雨"
+
+#: id:1414
+msgid "Thunderstorm"
+msgstr "雷雨"
+
+#: id:1415
+msgid "Drizzle"
+msgstr "毛毛雨"
+
+#: id:1416
+msgid "Foggy"
+msgstr "雾"
+
+#: id:1417
+msgid "Grains"
+msgstr "悬浮物"
+
+#: id:1418
+msgid "T-Storms"
+msgstr "雷雨"
+
+#: id:1419
+msgid "T-Showers"
+msgstr "雷阵雨"
+
+#: id:1420
+msgid "Moderate"
+msgstr "中等"
+
+#: id:1421
+msgid "Very High"
+msgstr "极高"
+
+#: id:1422
+msgid "Windy"
+msgstr "有风"
+
+#: id:1423
+msgid "Mist"
+msgstr "薄雾"
+
+#: id:1450
+msgid "Put display to sleep when idle"
+msgstr "空闲时显示器休眠"
+
+#: id:2050
+msgid "Runtime"
+msgstr "影片长度"
+
+#: id:2100
+msgid "Script failed! : %s"
+msgstr "脚本错误！：%s"
+
+#: id:2101
+msgid "Newer version needed - See log"
+msgstr "需要新版本 - 详见日志"
+
+#: id:4501
+msgid "Enable LCD/VFD"
+msgstr "启用 LCD/VFD"
+
+#: id:10000
+msgid "Home"
+msgstr "首页"
+
+#: id:10001
+msgctxt "Auto context with id 10001"
+msgid "Programs"
+msgstr "程序"
+
+#: id:10002
+msgctxt "Auto context with id 10002"
+msgid "Pictures"
+msgstr "图片"
+
+#: id:10003
+msgctxt "Auto context with id 10003"
+msgid "File manager"
+msgstr "文件管理"
+
+#: id:10004
+msgctxt "Auto context with id 10004"
+msgid "Settings"
+msgstr "系统设置"
+
+#: id:10005
+msgctxt "Auto context with id 10005"
+msgid "Music"
+msgstr "音乐"
+
+#: id:10006
+msgctxt "Auto context with id 10006"
+msgid "Videos"
+msgstr "视频"
+
+#: id:10007
+msgid "System information"
+msgstr "系统信息"
+
+#: id:10008
+msgid "Settings - General"
+msgstr "设置->常用"
+
+#: id:10009
+msgid "Settings - Screen"
+msgstr "设置->屏幕"
+
+#: id:10010
+msgid "Settings - Appearance - GUI Calibration"
+msgstr "设置->用户界面->界面校准"
+
+#: id:10011
+msgid "Settings - Videos - Screen Calibration"
+msgstr "设置->视频->屏幕校准"
+
+#: id:10012
+msgid "Settings - Pictures"
+msgstr "设置->图片"
+
+#: id:10013
+msgid "Settings - Programs"
+msgstr "设置->程序"
+
+#: id:10014
+msgid "Settings - Weather"
+msgstr "设置->天气"
+
+#: id:10015
+msgid "Settings - Music"
+msgstr "设置->音乐"
+
+#: id:10016
+msgid "Settings - System"
+msgstr "设置->系统设置"
+
+#: id:10017
+msgid "Settings - Videos"
+msgstr "设置->视频"
+
+#: id:10018
+msgid "Settings - Network"
+msgstr "设置->网络设置"
+
+#: id:10019
+msgid "Settings - Appearance"
+msgstr "设置->用户界面"
+
+#: id:10020
+msgctxt "Auto context with id 10020"
+msgid "Scripts"
+msgstr "脚本"
+
+#: id:10021
+msgid "Web Browser"
+msgstr "网页浏览器"
+
+#: id:10025
+msgctxt "Auto context with id 10025"
+msgid "Videos"
+msgstr "视频"
+
+#: id:10028
+msgid "Videos/Playlist"
+msgstr "视频/播放列表"
+
+#: id:10029
+msgctxt "Auto context with id 10029"
+msgid "Login screen"
+msgstr "登录屏"
+
+#: id:10034
+msgid "Settings - Profiles"
+msgstr "设置->用户配置"
+
+#: id:10040
+msgid "Addon browser"
+msgstr "扩展功能浏览器"
+
+#: id:10100
+msgid "Yes/No dialog"
+msgstr "\"是/否\"对话框"
+
+#: id:10101
+msgid "Progress dialog"
+msgstr "进度对话框"
+
+#: id:10210
+msgid "Looking for subtitles..."
+msgstr "查找字幕..."
+
+#: id:10211
+msgid "Looking for or caching subtitles..."
+msgstr "缓存字幕..."
+
+#: id:10212
+msgid "terminating"
+msgstr "结束"
+
+#: id:10213
+msgid "buffering"
+msgstr "正在缓存中"
+
+#: id:10214
+msgid "Opening stream"
+msgstr "打开流"
+
+#: id:10500
+msgid "Music/Playlist"
+msgstr "音乐/播放列表"
+
+#: id:10501
+msgid "Music/Files"
+msgstr "音乐/文件"
+
+#: id:10502
+msgid "Music/Library"
+msgstr "音乐/资料库"
+
+#: id:10503
+msgid "Playlist editor"
+msgstr "播放列表编辑"
+
+#: id:10504
+msgid "Top 100 songs"
+msgstr "歌曲100排行榜"
+
+#: id:10505
+msgid "Top 100 albums"
+msgstr "专辑100排行榜"
+
+#: id:10506
+msgctxt "Auto context with id 10506"
+msgid "Programs"
+msgstr "程序"
+
+#: id:10507
+msgid "Configuration"
+msgstr "系统设置"
+
+#: id:10508
+msgid "Weather forecast"
+msgstr "天气预报"
+
+#: id:10509
+msgid "Network gaming"
+msgstr "网络游戏"
+
+#: id:10510
+msgid "Extensions"
+msgstr "功能扩展"
+
+#: id:10511
+msgctxt "Auto context with id 10511"
+msgid "System info"
+msgstr "系统信息"
+
+#: id:10516
+msgid "Music - Library"
+msgstr "音乐 - 资料库"
+
+#: id:10517
+msgid "Now Playing - Music"
+msgstr "正在播放 - 音乐"
+
+#: id:10522
+msgid "Now Playing - Videos"
+msgstr "正在播放 - 视频"
+
+#: id:10523
+msgid "Album info"
+msgstr "专辑信息"
+
+#: id:10524
+msgid "Movie info"
+msgstr "视频信息"
+
+#: id:12000
+msgid "Select dialog"
+msgstr "选择"
+
+#: id:12001
+msgid "Music/Info"
+msgstr "音乐/信息"
+
+#: id:12002
+msgid "Dialog OK"
+msgstr "确认"
+
+#: id:12003
+msgid "Videos/Info"
+msgstr "视频/信息"
+
+#: id:12004
+msgid "Scripts/Info"
+msgstr "脚本/信息"
+
+#: id:12005
+msgid "Fullscreen video"
+msgstr "全屏视频"
+
+#: id:12006
+msgid "Audio visualization"
+msgstr "音频可视化效果"
+
+#: id:12008
+msgid "File stacking dialog"
+msgstr "文件堆叠"
+
+#: id:12009
+msgid "Rebuild index..."
+msgstr "重新生成索引..."
+
+#: id:12010
+msgid "Return to music window"
+msgstr "返回到音乐窗口"
+
+#: id:12011
+msgid "Return to videos window"
+msgstr "返回到视频窗口"
+
+#: id:12021
+msgid "Start from beginning"
+msgstr "从头开始播放"
+
+#: id:12022
+msgid "Resume from %s"
+msgstr "从 %s 处继续播放"
+
+#: id:12310
+msgid "0"
+msgstr "0"
+
+#: id:12311
+msgid "1"
+msgstr "1"
+
+#: id:12312
+msgid "2"
+msgstr "2"
+
+#: id:12313
+msgid "3"
+msgstr "3"
+
+#: id:12314
+msgid "4"
+msgstr "4"
+
+#: id:12315
+msgid "5"
+msgstr "5"
+
+#: id:12316
+msgid "6"
+msgstr "6"
+
+#: id:12317
+msgid "7"
+msgstr "7"
+
+#: id:12318
+msgid "8"
+msgstr "8"
+
+#: id:12319
+msgid "9"
+msgstr "9"
+
+#: id:12320
+msgid "c"
+msgstr "c"
+
+#: id:12321
+msgid "Ok"
+msgstr "ok"
+
+#: id:12322
+msgid "*"
+msgstr "*"
+
+#: id:12325
+msgid "Locked! Enter code..."
+msgstr "已锁定！输入密码..."
+
+#: id:12326
+msgid "Enter password"
+msgstr "输入密码"
+
+#: id:12327
+msgid "Enter master code"
+msgstr "输入管理员密码"
+
+#: id:12328
+msgid "Enter unlock code"
+msgstr "输入解锁密码"
+
+#: id:12329
+msgid "or press C to cancel"
+msgstr "或按 C 取消"
+
+#: id:12330
+msgid "Enter gamepad button combo and"
+msgstr "输入游戏手柄按钮组合，然后"
+
+#: id:12331
+msgid "press OK, or Back to cancel"
+msgstr "按 Start 确认，或按 Back 取消"
+
+#: id:12332
+msgid "Set lock"
+msgstr "设置锁定"
+
+#: id:12333
+msgid "Unlock"
+msgstr "解除锁定"
+
+#: id:12334
+msgid "Reset lock"
+msgstr "重新锁定"
+
+#: id:12335
+msgid "Remove lock"
+msgstr "移除锁定"
+
+#: id:12337
+msgid "Numeric password"
+msgstr "数字密码"
+
+#: id:12338
+msgid "Gamepad button combo"
+msgstr "手柄按键组合"
+
+#: id:12339
+msgid "Full-text password"
+msgstr "全文字密码"
+
+#: id:12340
+msgid "Enter new password"
+msgstr "输入新密码"
+
+#: id:12341
+msgid "Re-Enter new password"
+msgstr "确认新密码"
+
+#: id:12342
+msgid "Incorrect password,"
+msgstr "密码不正确，"
+
+#: id:12343
+msgid "retries left"
+msgstr "重试次数"
+
+#: id:12344
+msgid "Passwords entered did not match."
+msgstr "输入密码不正确！"
+
+#: id:12345
+msgid "Access denied"
+msgstr "拒绝读取"
+
+#: id:12346
+msgid "Password retry limit exceeded."
+msgstr "已达密码重试次数限制！"
+
+#: id:12347
+msgid "The system will now shut off."
+msgstr "系统将立刻关闭！"
+
+#: id:12348
+msgid "Item locked"
+msgstr "拒绝访问"
+
+#: id:12353
+msgid "Reactivate lock"
+msgstr "重新上锁"
+
+#: id:12356
+msgid "Change lock"
+msgstr "更改锁定"
+
+#: id:12357
+msgid "Source lock"
+msgstr "共享锁定"
+
+#: id:12358
+msgid "Password entry was blank. Try again."
+msgstr "密码不能为空，请重试！"
+
+#: id:12360
+msgid "Master lock"
+msgstr "主机锁定"
+
+#: id:12362
+msgid "Shutdown system if Master Lock retries exceeded"
+msgstr "超过重试次数就关机"
+
+#: id:12367
+msgid "Master code is not valid"
+msgstr "管理员密码错误"
+
+#: id:12368
+msgid "Please enter a valid master code"
+msgstr "请输入正确的管理员密码"
+
+#: id:12373
+msgid "Settings & file manager"
+msgstr "系统设置和文件管理"
+
+#: id:12376
+msgid "Set as default for all movies"
+msgstr "作为所有视频的默认设置"
+
+#: id:12377
+msgid "This will reset any previously saved values"
+msgstr "将要初始化所有配置"
+
+#: id:12378
+msgid "Amount of time to display each image"
+msgstr "每幅图片显示时间"
+
+#: id:12379
+msgid "Use pan and zoom effects"
+msgstr "使用移动和缩放特效"
+
+#: id:12383
+msgid "12 hour clock"
+msgstr "12小时制"
+
+#: id:12384
+msgid "24 hour clock"
+msgstr "24小时制"
+
+#: id:12385
+msgid "Day/Month"
+msgstr "日/月"
+
+#: id:12386
+msgid "Month/Day"
+msgstr "月/日"
+
+#: id:12390
+msgid "System uptime"
+msgstr "系统开机时间"
+
+#: id:12391
+msgid "Minutes"
+msgstr "分钟"
+
+#: id:12392
+msgid "Hours"
+msgstr "小时"
+
+#: id:12393
+msgid "Days"
+msgstr "天"
+
+#: id:12394
+msgid "Total uptime"
+msgstr "累计开机时间"
+
+#: id:12395
+msgid "Battery level"
+msgstr "电池电量"
+
+#: id:12600
+msgctxt "Auto context with id 12600"
+msgid "Weather"
+msgstr "天气"
+
+#: id:12900
+msgctxt "Auto context with id 12900"
+msgid "Screensaver"
+msgstr "屏幕保护"
+
+#: id:12901
+msgid "Fullscreen OSD"
+msgstr "全屏 OSD"
+
+#: id:13000
+msgid "System"
+msgstr "系统设置"
+
+#: id:13001
+msgid "Immediate HD spindown"
+msgstr "立即关闭硬盘"
+
+#: id:13002
+msgid "Video only"
+msgstr "只有视频"
+
+#: id:13003
+msgid "- Delay"
+msgstr "- 延迟"
+
+#: id:13004
+msgid "- Minimum file duration"
+msgstr "- 最小影音文件时长"
+
+#: id:13005
+msgid "Shutdown"
+msgstr "关机"
+
+#: id:13008
+msgid "Shutdown function"
+msgstr "自动关机功能"
+
+#: id:13009
+msgid "Quit"
+msgstr "退出"
+
+#: id:13010
+msgid "Hibernate"
+msgstr "休眠"
+
+#: id:13011
+msgid "Suspend"
+msgstr "待机"
+
+#: id:13012
+msgid "Exit"
+msgstr "退出"
+
+#: id:13013
+msgid "Reboot"
+msgstr "重启"
+
+#: id:13014
+msgid "Minimize"
+msgstr "最小化"
+
+#: id:13015
+msgid "Power button action"
+msgstr "电源按钮作用"
+
+#: id:13016
+msgid "Power off System"
+msgstr "关闭电源"
+
+#: id:13020
+msgid "Is another session active, perhaps over ssh?"
+msgstr "是否有通过SSH连接的会话存在？"
+
+#: id:13021
+msgid "Mounted removable harddrive"
+msgstr "挂接移动存储器"
+
+#: id:13022
+msgid "Unsafe device removal"
+msgstr "不安全的移除设备"
+
+#: id:13023
+msgid "Successfully removed device"
+msgstr "成功移除设备"
+
+#: id:13024
+msgid "Joystick plugged"
+msgstr "游戏杆插入"
+
+#: id:13025
+msgid "Joystick unplugged"
+msgstr "游戏杆拔出"
+
+#: id:13050
+msgid "Running low on battery"
+msgstr "电池电量不足"
+
+#: id:13100
+msgid "Flicker filter"
+msgstr "闪烁过滤"
+
+#: id:13101
+msgid "Let driver choose (requires restart)"
+msgstr "使用驱动选择（需要重启）"
+
+#: id:13105
+msgid "Vertical blank sync"
+msgstr "垂直空白同步"
+
+#: id:13106
+msgctxt "Auto context with id 13106"
+msgid "Disabled"
+msgstr "停用"
+
+#: id:13107
+msgid "Enabled during video playback"
+msgstr "只在视频播放时开启"
+
+#: id:13108
+msgctxt "Auto context with id 13108"
+msgid "Always enabled"
+msgstr "总是开启"
+
+#: id:13109
+msgid "Test & apply resolution"
+msgstr "测试 & 应用分辨率"
+
+#: id:13110
+msgid "Save resolution?"
+msgstr "保存此分辨率?"
+
+#: id:13111
+msgid "Would you like to keep this resolution?"
+msgstr "是否保存此分辨率?"
+
+#: id:13112
+msgid "High quality upscaling"
+msgstr "高品质倍线"
+
+#: id:13113
+msgctxt "Auto context with id 13113"
+msgid "Disabled"
+msgstr "关闭"
+
+#: id:13114
+msgid "Enabled for SD content"
+msgstr "普通清晰度内容时打开"
+
+#: id:13115
+msgctxt "Auto context with id 13115"
+msgid "Always enabled"
+msgstr "始终打开"
+
+#: id:13116
+msgid "Upscaling method"
+msgstr "倍线方式"
+
+#: id:13117
+msgctxt "Auto context with id 13117"
+msgid "Bicubic"
+msgstr "Bicubic"
+
+#: id:13118
+msgid "Lanczos"
+msgstr "Lanczos"
+
+#: id:13119
+msgid "Sinc"
+msgstr "Sinc"
+
+#: id:13120
+msgctxt "Auto context with id 13120"
+msgid "VDPAU"
+msgstr "VDPAU"
+
+#: id:13121
+msgid "VDPAU HQ Upscaling level"
+msgstr "VDPAU 高品质倍线等级"
+
+#: id:13122
+msgid "VDPAU Studio level color conversion"
+msgstr "VDPAU 演播室级色彩转换"
+
+#: id:13130
+msgid "Blank other displays"
+msgstr "其他显示器空白显示"
+
+#: id:13131
+msgctxt "Auto context with id 13131"
+msgid "Disabled"
+msgstr "禁止"
+
+#: id:13132
+msgid "Blank displays"
+msgstr "空白显示"
+
+#: id:13140
+msgid "Active connections detected!"
+msgstr "检测到活动连接！"
+
+#: id:13141
+msgid "If you proceed, you might not be able to control XBMC"
+msgstr "如果继续此操作，可能会无法控制你的"
+
+#: id:13142
+msgid "any longer. Are you sure you want to stop the Event server?"
+msgstr "XBMC，你是否确认要停止事件服务器？"
+
+#: id:13144
+msgid "Change Apple Remote mode?"
+msgstr "改变 Apple 遥控器的模式？"
+
+#: id:13145
+msgid "If you are currently using the Apple Remote to control"
+msgstr "如果你现在正在使用 Apple 遥控器"
+
+#: id:13146
+msgid "XBMC, changing this setting might affect your ability"
+msgstr "控制 XBMC，修改这些设置将影响对"
+
+#: id:13147
+msgid "to continue controlling it. Do you want to proceed?"
+msgstr "系统的控制。你确认要处理吗？"
+
+#: id:13159
+msgid "Subnet mask"
+msgstr "子网掩码"
+
+#: id:13160
+msgid "Gateway"
+msgstr "网关地址"
+
+#: id:13161
+msgid "Primary DNS"
+msgstr "首选 DNS 服务器地址"
+
+#: id:13162
+msgid "Initialize failed"
+msgstr "初始化失败"
+
+#: id:13170
+msgctxt "Auto context with id 13170"
+msgid "Never"
+msgstr "从不"
+
+#: id:13171
+msgid "Immediately"
+msgstr "立即"
+
+#: id:13172
+msgid "After %i secs"
+msgstr "隔%i秒以后"
+
+#: id:13173
+msgid "HDD install date:"
+msgstr "硬盘安装日期："
+
+#: id:13174
+msgid "HDD power cycle count:"
+msgstr "硬盘运转周期："
+
+#: id:13200
+msgid "Profiles"
+msgstr "用户配置"
+
+#: id:13201
+msgid "Delete profile '%s'?"
+msgstr "删除用户配置'%s'？"
+
+#: id:13204
+msgid "Last loaded profile:"
+msgstr "最近载入的用户配置："
+
+#: id:13205
+msgid "Unknown"
+msgstr "未知"
+
+#: id:13206
+msgid "Overwrite"
+msgstr "覆盖"
+
+#: id:13208
+msgid "Alarm clock"
+msgstr "闹铃"
+
+#: id:13209
+msgid "Alarm clock interval (in minutes)"
+msgstr "闹铃间隔（分钟）"
+
+#: id:13210
+msgid "Started, alarm in %im"
+msgstr "闹铃启动，倒计时%i分钟。"
+
+#: id:13211
+msgid "Alarm!"
+msgstr "响铃！"
+
+#: id:13212
+msgid "Canceled with %im%is left"
+msgstr "闹铃取消，剩余%i分%i秒。"
+
+#: id:13213
+msgid "%2.0fm"
+msgstr "%2.0f分"
+
+#: id:13214
+msgid "%2.0fs"
+msgstr "%2.0f秒"
+
+#: id:13249
+msgid "Search for subtitles in RARs"
+msgstr "搜索 RAR 文件中的字幕"
+
+#: id:13250
+msgid "Browse for subtitle..."
+msgstr "浏览字幕文件..."
+
+#: id:13251
+msgid "Move item"
+msgstr "移动该项目"
+
+#: id:13252
+msgid "Move item here"
+msgstr "将项目移动至此"
+
+#: id:13253
+msgid "Cancel move"
+msgstr "取消移动"
+
+#: id:13270
+msgid "Hardware:"
+msgstr "硬件："
+
+#: id:13271
+msgid "CPU Usage:"
+msgstr "CPU 使用："
+
+#: id:13274
+msgid "Connected, but no DNS is available."
+msgstr "已经连接，但没有有效的 DNS！"
+
+#: id:13275
+msgid "Hard Disk"
+msgstr "硬盘"
+
+#: id:13276
+msgid "DVD-ROM"
+msgstr "DVD-ROM"
+
+#: id:13277
+msgctxt "Auto context with id 13277"
+msgid "Storage"
+msgstr "存储器"
+
+#: id:13278
+msgctxt "Auto context with id 13278"
+msgid "Default"
+msgstr "默认"
+
+#: id:13279
+msgctxt "Auto context with id 13279"
+msgid "Network"
+msgstr "网络"
+
+#: id:13280
+msgctxt "Auto context with id 13280"
+msgid "Video"
+msgstr "视频"
+
+#: id:13281
+msgid "Hardware"
+msgstr "硬件"
+
+#: id:13283
+msgid "Operating system:"
+msgstr "操作系统："
+
+#: id:13284
+msgid "CPU speed:"
+msgstr "CPU 速度："
+
+#: id:13286
+msgid "Video encoder:"
+msgstr "视频芯片："
+
+#: id:13287
+msgid "Screen resolution:"
+msgstr "屏幕分辨率："
+
+#: id:13292
+msgid "A/V cable:"
+msgstr "A/V 线："
+
+#: id:13294
+msgid "DVD region:"
+msgstr "DVD 区域："
+
+#: id:13295
+msgid "Internet:"
+msgstr "互联网："
+
+#: id:13296
+msgctxt "Auto context with id 13296"
+msgid "Connected"
+msgstr "已经连接到互联网"
+
+#: id:13297
+msgid "Not connected. Check network settings."
+msgstr "无法联网，请检查网络设置！"
+
+#: id:13299
+msgid "Target temperature"
+msgstr "目标温度"
+
+#: id:13300
+msgid "Fan speed"
+msgstr "风扇转速"
+
+#: id:13301
+msgid "Auto temperature control"
+msgstr "自动控温"
+
+#: id:13302
+msgid "Fan speed override"
+msgstr "指定风扇转速"
+
+#: id:13303
+msgid "- Fonts"
+msgstr "皮肤字体"
+
+#: id:13304
+msgid "Enable flipping bi-directional strings"
+msgstr "开启转换双向字串"
+
+#: id:13305
+msgid "Show RSS news feeds"
+msgstr "显示 RSS 新闻"
+
+#: id:13306
+msgid "Show parent folder items"
+msgstr "显示上级目录图标"
+
+#: id:13307
+msgid "Track naming template"
+msgstr "音轨命名参数"
+
+#: id:13308
+msgid "Do you wish to reboot your system"
+msgstr "你想重新启动系统"
+
+#: id:13309
+msgid "instead of just XBMC?"
+msgstr "以重新启动 XBMC 吗？"
+
+#: id:13310
+msgid "Zoom effect"
+msgstr "放缩效果"
+
+#: id:13311
+msgid "Float effect"
+msgstr "漂浮效果"
+
+#: id:13312
+msgid "Black bar reduction"
+msgstr "缩小黑边"
+
+#: id:13313
+msgid "Restart"
+msgstr "重启"
+
+#: id:13314
+msgid "Crossfade between songs"
+msgstr "歌曲淡入淡出"
+
+#: id:13315
+msgid "Regenerate thumbnails"
+msgstr "创建缩略图"
+
+#: id:13316
+msgid "Recursive thumbnails"
+msgstr "循环缩略图"
+
+#: id:13317
+msgid "View slideshow"
+msgstr "开始幻灯播放图片"
+
+#: id:13318
+msgid "Recursive slideshow"
+msgstr "循环幻灯播放图片"
+
+#: id:13319
+msgid "Randomize"
+msgstr "随机播放"
+
+#: id:13320
+msgid "Stereo"
+msgstr "立体声"
+
+#: id:13321
+msgid "Left only"
+msgstr "左声道"
+
+#: id:13322
+msgid "Right only"
+msgstr "右声道"
+
+#: id:13323
+msgid "Enable karaoke support"
+msgstr "开启卡拉OK支持"
+
+#: id:13324
+msgid "Background transparency"
+msgstr "背景透明度"
+
+#: id:13325
+msgid "Foreground transparency"
+msgstr "前景透明度"
+
+#: id:13326
+msgid "A/V delay"
+msgstr "影音延迟"
+
+#: id:13327
+msgid "Karaoke"
+msgstr "卡拉OK"
+
+#: id:13328
+msgid "%s not found"
+msgstr "%s未找到"
+
+#: id:13329
+msgid "Error opening %s"
+msgstr "打开%s时发生错误"
+
+#: id:13330
+msgid "Unable to load %s"
+msgstr "无法载入%s"
+
+#: id:13331
+msgid "Error: Out of memory"
+msgstr "错误：内存不足"
+
+#: id:13332
+msgid "Move up"
+msgstr "上移"
+
+#: id:13333
+msgid "Move down"
+msgstr "下移"
+
+#: id:13334
+msgid "Edit label"
+msgstr "编辑标签"
+
+#: id:13335
+msgid "Make default"
+msgstr "设为默认"
+
+#: id:13336
+msgid "Remove button"
+msgstr "移除按键"
+
+#: id:13340
+msgid "Leave as is"
+msgstr "默认"
+
+#: id:13341
+msgid "Green"
+msgstr "绿色"
+
+#: id:13342
+msgid "Orange"
+msgstr "橙色"
+
+#: id:13343
+msgid "Red"
+msgstr "红色"
+
+#: id:13344
+msgid "Cycle"
+msgstr "循环"
+
+#: id:13345
+msgid "Switch LED off on playback"
+msgstr "当播放时关闭 LED"
+
+#: id:13346
+msgctxt "Auto context with id 13346"
+msgid "Movie information"
+msgstr "视频信息"
+
+#: id:13347
+msgid "Queue item"
+msgstr "加入播放列表"
+
+#: id:13348
+msgid "Search IMDb..."
+msgstr "查询互联网电影数据库..."
+
+#: id:13349
+msgid "Scan for new content"
+msgstr "扫描新的内容"
+
+#: id:13350
+msgid "Now playing..."
+msgstr "正在播放..."
+
+#: id:13351
+msgctxt "Auto context with id 13351"
+msgid "Album information"
+msgstr "专辑信息"
+
+#: id:13352
+msgid "Scan item to library"
+msgstr "扫瞄项目到数据库"
+
+#: id:13353
+msgid "Stop scanning"
+msgstr "停止扫瞄"
+
+#: id:13354
+msgctxt "Auto context with id 13354"
+msgid "Render method"
+msgstr "渲染方式"
+
+#: id:13355
+msgid "Low quality pixel shader"
+msgstr "低品质像素着色器"
+
+#: id:13356
+msgid "Hardware overlays"
+msgstr "硬件覆盖"
+
+#: id:13357
+msgid "High quality pixel shader"
+msgstr "高品质像素着色器"
+
+#: id:13358
+msgid "Play item"
+msgstr "播放项目"
+
+#: id:13359
+msgid "Set artist thumb"
+msgstr "设置艺人缩略图"
+
+#: id:13360
+msgid "Automatically generate thumbnails"
+msgstr "自动获取缩略图"
+
+#: id:13361
+msgid "Enable voice"
+msgstr "开启语音"
+
+#: id:13375
+msgid "Enable device"
+msgstr "启用装置"
+
+#: id:13376
+msgid "Volume"
+msgstr "音量"
+
+#: id:13377
+msgid "Default view mode"
+msgstr "默认显示方式"
+
+#: id:13378
+msgid "Default brightness"
+msgstr "默认亮度数值"
+
+#: id:13379
+msgid "Default contrast"
+msgstr "默认对比度数值"
+
+#: id:13380
+msgid "Default gamma"
+msgstr "默认伽码数值"
+
+#: id:13381
+msgid "Resume video"
+msgstr "从上次中断处继续播放"
+
+#: id:13382
+msgid "Voice mask - Port 1"
+msgstr "语音特效 - 端口 1"
+
+#: id:13383
+msgid "Voice mask - Port 2"
+msgstr "语音特效 - 端口 2"
+
+#: id:13384
+msgid "Voice mask - Port 3"
+msgstr "语音特效 - 端口 3"
+
+#: id:13385
+msgid "Voice mask - Port 4"
+msgstr "语音特效 - 端口 4"
+
+#: id:13386
+msgid "Use time based seeking"
+msgstr "使用时间搜寻"
+
+#: id:13387
+msgid "Track naming template - right"
+msgstr "音轨命名模板"
+
+#: id:13388
+msgid "Preset"
+msgstr "预设"
+
+#: id:13389
+msgid "There are no presets available\nfor this visualization"
+msgstr "该可视化效果没有预设"
+
+#: id:13390
+msgid "There are no settings available\nfor this visualization"
+msgstr "该可视化效果没有设置"
+
+#: id:13391
+msgid "Eject/Load"
+msgstr "弹出/载入"
+
+#: id:13392
+msgid "Use visualization if playing audio"
+msgstr "播放音乐时启用可视化效果"
+
+#: id:13393
+msgid "Calculate size"
+msgstr "计算大小"
+
+#: id:13394
+msgid "Calculating folder size"
+msgstr "计算文件夹大小"
+
+#: id:13395
+msgid "Video settings"
+msgstr "视频设置"
+
+#: id:13396
+msgid "Audio and subtitle settings"
+msgstr "声音和字幕设置"
+
+#: id:13397
+msgid "Enable subtitles"
+msgstr "启用字幕"
+
+#: id:13398
+msgctxt "Auto context with id 13398"
+msgid "Shortcuts"
+msgstr "快捷方式"
+
+#: id:13399
+msgid "Ignore articles when sorting (e.g. \"the\")"
+msgstr "排序时忽略冠词（如 \"the\"）"
+
+#: id:13400
+msgid "Crossfade between songs on the same album"
+msgstr "同一专辑内歌曲淡入淡出"
+
+#: id:13401
+msgid "Browse for %s"
+msgstr "浏览%s"
+
+#: id:13402
+msgid "Show track position"
+msgstr "显示音轨位置"
+
+#: id:13403
+msgid "Clear default"
+msgstr "清除默认"
+
+#: id:13404
+msgid "Resume"
+msgstr "继续播放"
+
+#: id:13405
+msgid "Get thumb"
+msgstr "取得缩略图"
+
+#: id:13406
+msgid "Picture information"
+msgstr "图片信息"
+
+#: id:13407
+msgid "%s presets"
+msgstr "%s 预设"
+
+#: id:13408
+msgid "(IMDb user rating)"
+msgstr "（IMDb 用户评价）"
+
+#: id:13409
+msgid "Top 250"
+msgstr "排行榜前 250："
+
+#: id:13410
+msgid "Tune in on Last.fm"
+msgstr "收听 last.fm 电台"
+
+#: id:13411
+msgid "Minimum fan speed"
+msgstr "风扇最低转速"
+
+#: id:13412
+msgid "Play from here"
+msgstr "由此连续播放"
+
+#: id:13413
+msgid "Downloading"
+msgstr "正在下载"
+
+#: id:13414
+msgid "Include artists who appear only on compilations"
+msgstr "包含只在合辑中出现的艺术家"
+
+#: id:13415
+msgctxt "Auto context with id 13415"
+msgid "Render method"
+msgstr "渲染模式"
+
+#: id:13416
+msgid "Auto detect"
+msgstr "自动检测"
+
+#: id:13417
+msgid "Basic shaders (ARB)"
+msgstr "基本着色（ARB）"
+
+#: id:13418
+msgid "Advanced shaders (GLSL)"
+msgstr "高级着色（GLSL）"
+
+#: id:13419
+msgid "Software"
+msgstr "软件着色"
+
+#: id:13420
+msgid "Remove safely"
+msgstr "安全移除"
+
+#: id:13421
+msgctxt "Auto context with id 13421"
+msgid "VDPAU"
+msgstr "VDPAU 硬解码"
+
+#: id:13422
+msgid "Start slideshow here"
+msgstr "开始幻灯片播放"
+
+#: id:13423
+msgid "Remember for this path"
+msgstr "记住此目录"
+
+#: id:13424
+msgid "Use pixel buffer objects"
+msgstr "使用象素缓冲对象"
+
+#: id:13425
+msgid "Allow hardware acceleration (VDPAU)"
+msgstr "允许硬件加速（VDPAU）"
+
+#: id:13426
+msgid "Allow hardware acceleration (VAAPI)"
+msgstr "允许硬件加速（VAAPI）"
+
+#: id:13427
+msgid "Allow hardware acceleration (DXVA2)"
+msgstr "允许硬件加速（DXVA2）"
+
+#: id:13428
+msgid "Allow hardware acceleration (CrystalHD)"
+msgstr "允许硬件加速（CrystalHD）"
+
+#: id:13429
+msgid "Allow hardware acceleration (VDADecoder)"
+msgstr "允许硬件加速（VDADecoder）"
+
+#: id:13430
+msgid "Allow hardware acceleration (OpenMax)"
+msgstr "允许硬件加速（OpenMax）"
+
+#: id:13431
+msgid "Pixel Shaders"
+msgstr "像素着色器"
+
+#: id:13432
+msgid "Allow hardware acceleration (VideoToolbox)"
+msgstr "允许硬件加速（VideoToolbox）"
+
+#: id:13500
+msgid "A/V sync method"
+msgstr "影音同步方式"
+
+#: id:13501
+msgid "Audio clock"
+msgstr "音频时钟"
+
+#: id:13502
+msgid "Video clock (Drop/Dupe audio)"
+msgstr "视频时钟（丢弃/重复音频）"
+
+#: id:13503
+msgid "Video clock (Resample audio)"
+msgstr "视频时钟（重采样音频）"
+
+#: id:13504
+msgid "Maximum resample amount (%)"
+msgstr "最高重采样率（%）"
+
+#: id:13505
+msgid "Resample quality"
+msgstr "重采样质量"
+
+#: id:13506
+msgid "Low(fast)"
+msgstr "低（快）"
+
+#: id:13507
+msgctxt "Auto context with id 13507"
+msgid "Medium"
+msgstr "中"
+
+#: id:13508
+msgctxt "Auto context with id 13508"
+msgid "High"
+msgstr "高"
+
+#: id:13509
+msgid "Really high(slow!)"
+msgstr "极高（慢）"
+
+#: id:13510
+msgid "Sync playback to display"
+msgstr "同步回放显示"
+
+#: id:13550
+msgid "Pause during refresh rate change"
+msgstr "切换刷新率时暂停播放"
+
+#: id:13551
+msgctxt "Auto context with id 13551"
+msgid "Off"
+msgstr "关"
+
+#: id:13552
+msgid "%.1f Second"
+msgstr "%.1f 秒"
+
+#: id:13553
+msgid "%.1f Seconds"
+msgstr "%.1f 秒"
+
+#: id:13600
+msgid "Apple remote"
+msgstr "Apple 遥控器"
+
+#: id:13602
+msgid "Allow start of XBMC using the remote"
+msgstr "允许用遥控器启动 XBMC"
+
+#: id:13603
+msgid "Sequence delay time"
+msgstr "序列延时"
+
+#: id:13610
+msgctxt "Auto context with id 13610"
+msgid "Disabled"
+msgstr "关闭"
+
+#: id:13611
+msgctxt "Auto context with id 13611"
+msgid "Standard"
+msgstr "标准"
+
+#: id:13612
+msgid "Universal Remote"
+msgstr "通用遥控器"
+
+#: id:13613
+msgid "Multi Remote (Harmony)"
+msgstr "万能遥控器（Harmony）"
+
+#: id:13620
+msgid "Apple Remote Error"
+msgstr "Apple 遥控器错误"
+
+#: id:13621
+msgid "Apple Remote support could be enabled."
+msgstr "不能打开 Apple 遥控器支持."
+
+#: id:14000
+msgid "Stack"
+msgstr "视频堆叠"
+
+#: id:14001
+msgid "Unstack"
+msgstr "关闭堆叠"
+
+#: id:14003
+msgid "Downloading playlist file..."
+msgstr "下载播放列表..."
+
+#: id:14004
+msgid "Downloading streams list..."
+msgstr "下载流媒体列表..."
+
+#: id:14005
+msgid "Parsing streams list..."
+msgstr "分析流媒体列表..."
+
+#: id:14006
+msgid "Downloading streams list failed"
+msgstr "流媒体列表下载失败"
+
+#: id:14007
+msgid "Downloading playlist file failed"
+msgstr "播放列表下载失败"
+
+#: id:14009
+msgid "Games directory"
+msgstr "游戏目录"
+
+#: id:14010
+msgid "Auto switch to thumbs based on"
+msgstr "自动切换为图标显示条件"
+
+#: id:14011
+msgid "Enable auto switching to thumbs view"
+msgstr "允许自动切换为图标显示"
+
+#: id:14012
+msgid "- Use large icons"
+msgstr "- 使用大图标"
+
+#: id:14013
+msgid "- Switch based on"
+msgstr "- 条件"
+
+#: id:14014
+msgid "- Percentage"
+msgstr "- 百分比"
+
+#: id:14015
+msgid "No files and at least one thumb"
+msgstr "没有文件且至少有一个图标"
+
+#: id:14016
+msgid "At least one file and thumb"
+msgstr "至少有一个文件和一个图标"
+
+#: id:14017
+msgid "Percentage of thumbs"
+msgstr "图标所占百分比"
+
+#: id:14018
+msgid "View options"
+msgstr "浏览设置"
+
+#: id:14019
+msgid "Change area code 1"
+msgstr "改变地区码 1"
+
+#: id:14020
+msgid "Change area code 2"
+msgstr "改变地区码 2"
+
+#: id:14021
+msgid "Change area code 3"
+msgstr "改变地区码 3"
+
+#: id:14022
+msgctxt "Auto context with id 14022"
+msgid "Library"
+msgstr "资料库"
+
+#: id:14023
+msgid "No TV"
+msgstr "无电视"
+
+#: id:14024
+msgid "Enter the nearest large town"
+msgstr "输入最近的城市"
+
+#: id:14025
+msgid "Video/Audio/DVD cache - Harddisk"
+msgstr "视频/音频/DVD 缓存 - 硬盘"
+
+#: id:14026
+msgid "Video cache - DVD-ROM"
+msgstr "视频缓存 - DVD 驱动器"
+
+#: id:14027
+msgctxt "Auto context with id 14027"
+msgid "- Local Network"
+msgstr "- 局域网"
+
+#: id:14028
+msgctxt "Auto context with id 14028"
+msgid "- Internet"
+msgstr "- 互联网"
+
+#: id:14030
+msgid "Audio cache - DVD-ROM"
+msgstr "音频缓存 - DVD 驱动器"
+
+#: id:14031
+msgctxt "Auto context with id 14031"
+msgid "- Local Network"
+msgstr "- 局域网"
+
+#: id:14032
+msgctxt "Auto context with id 14032"
+msgid "- Internet"
+msgstr "- 互联网"
+
+#: id:14034
+msgid "DVD cache - DVD-ROM"
+msgstr "DVD 缓存 - DVD 驱动器"
+
+#: id:14035
+msgctxt "Auto context with id 14035"
+msgid "- Local Network"
+msgstr "- 局域网"
+
+#: id:14036
+msgctxt "Auto context with id 14036"
+msgid "Services"
+msgstr "服务"
+
+#: id:14038
+msgid "Network settings changed"
+msgstr "网络设置已改变"
+
+#: id:14039
+msgid "XBMC requires to restart to change your"
+msgstr "XBMC 需要重启改变你的网络设置。"
+
+#: id:14040
+msgid "network setup. Would you like to restart now?"
+msgstr "你想现在就重启吗？"
+
+#: id:14041
+msgid "Internet connection bandwidth limitation"
+msgstr "互联网连接带宽限制"
+
+#: id:14043
+msgid "- Shutdown while playing"
+msgstr "- 播放时关机"
+
+#: id:14044
+msgid "%i min"
+msgstr "%i分"
+
+#: id:14045
+msgid "%i sec"
+msgstr "%i秒"
+
+#: id:14046
+msgid "%i ms"
+msgstr "%i毫秒"
+
+#: id:14047
+msgid "%i %%"
+msgstr "%i%%"
+
+#: id:14048
+msgid "%i kbps"
+msgstr "%ikbps"
+
+#: id:14049
+msgid "%i kb"
+msgstr "%ikb"
+
+#: id:14050
+msgid "%i.0 dB"
+msgstr "%i.0dB"
+
+#: id:14051
+msgid "Time format"
+msgstr "时间显示格式"
+
+#: id:14052
+msgid "Date format"
+msgstr "日期显示格式"
+
+#: id:14053
+msgid "GUI filters"
+msgstr "图形界面滤镜"
+
+#: id:14055
+msgid "Use background scanning"
+msgstr "使用后台搜寻"
+
+#: id:14056
+msgid "Stop scan"
+msgstr "停止搜寻"
+
+#: id:14057
+msgid "Not possible while scanning for media info"
+msgstr "无法搜寻媒体信息"
+
+#: id:14058
+msgid "Film grain effect"
+msgstr "电影胶片效果"
+
+#: id:14059
+msgid "Search for thumbnails on remote shares"
+msgstr "搜索远端共享的缩略图"
+
+#: id:14060
+msgid "Unknown type cache - Internet"
+msgstr "未知类型文件缓冲 - 互联网"
+
+#: id:14061
+msgctxt "Auto context with id 14061"
+msgid "Auto"
+msgstr "自动"
+
+#: id:14062
+msgid "Enter username for"
+msgstr "输入用户名"
+
+#: id:14063
+msgid "Date & time"
+msgstr "日期和时间"
+
+#: id:14064
+msgid "Set date"
+msgstr "设置日期"
+
+#: id:14065
+msgid "Set time"
+msgstr "设置时间"
+
+#: id:14066
+msgid "Enter the time in 24 hour HH:MM format"
+msgstr "输入24小时格式时间（时:分）"
+
+#: id:14067
+msgid "Enter the date in DD/MM/YYYY format"
+msgstr "输入日期（日/月/年）"
+
+#: id:14068
+msgid "Enter the IP address"
+msgstr "输入 IP 地址"
+
+#: id:14069
+msgid "Apply these settings now?"
+msgstr "确定要设置这些参数吗？"
+
+#: id:14070
+msgid "Apply changes now"
+msgstr "应用设置"
+
+#: id:14071
+msgid "Allow file renaming and deletion"
+msgstr "允许重命名和删除文件"
+
+#: id:14074
+msgid "Set timezone"
+msgstr "设置时区"
+
+#: id:14075
+msgid "Use daylight saving time"
+msgstr "使用夏令制时间"
+
+#: id:14076
+msgid "Add to favourites"
+msgstr "添加到收藏夹"
+
+#: id:14077
+msgid "Remove from favourites"
+msgstr "从收藏夹移除"
+
+#: id:14078
+msgctxt "Auto context with id 14078"
+msgid "- Colours"
+msgstr "皮肤颜色"
+
+#: id:14079
+msgid "Timezone country"
+msgstr "时区-国家"
+
+#: id:14080
+msgid "Timezone"
+msgstr "时区"
+
+#: id:14081
+msgid "File lists"
+msgstr "文件列表"
+
+#: id:14082
+msgid "Show EXIF picture information"
+msgstr "显示 EXIF 图片信息"
+
+#: id:14083
+msgid "Use a fullscreen window rather than true fullscreen"
+msgstr "使用全屏窗口而非真正全屏显示"
+
+#: id:14084
+msgid "Queue songs on selection"
+msgstr "选中歌曲加入播放列表"
+
+#: id:14086
+msgid "Playback"
+msgstr "播放"
+
+#: id:14087
+msgid "DVDs"
+msgstr "DVD"
+
+#: id:14088
+msgid "Play DVDs automatically"
+msgstr "自动播放 DVD"
+
+#: id:14089
+msgid "Font to use for text subtitles"
+msgstr "文本字幕字体"
+
+#: id:14090
+msgid "International"
+msgstr "界面语言"
+
+#: id:14091
+msgid "Character set"
+msgstr "字符集"
+
+#: id:14092
+msgid "Debugging"
+msgstr "调试"
+
+#: id:14093
+msgid "Security"
+msgstr "安全"
+
+#: id:14094
+msgid "Input devices"
+msgstr "输入设备"
+
+#: id:14095
+msgid "Power saving"
+msgstr "省电模式"
+
+#: id:14096
+msgid "Rip"
+msgstr "抓轨"
+
+#: id:14097
+msgid "Audio CD Insert Action"
+msgstr "音乐 CD 插入动作"
+
+#: id:14098
+msgctxt "Auto context with id 14098"
+msgid "Play"
+msgstr "播放"
+
+#: id:14099
+msgid "Eject disc when CD ripping is complete"
+msgstr "CD 抓轨完成后弹出光盘"
+
+#: id:15015
+msgctxt "Auto context with id 15015"
+msgid "Remove"
+msgstr "删除"
+
+#: id:15016
+msgid "Games"
+msgstr "游戏"
+
+#: id:15019
+msgid "Add"
+msgstr "添加"
+
+#: id:15052
+msgid "Password"
+msgstr "密码"
+
+#: id:15100
+msgctxt "Auto context with id 15100"
+msgid "Library"
+msgstr "资料库"
+
+#: id:15101
+msgid "Database"
+msgstr "数据库"
+
+#: id:15102
+msgid "* All albums"
+msgstr "* 所有专辑"
+
+#: id:15103
+msgid "* All artists"
+msgstr "* 所有艺人"
+
+#: id:15104
+msgid "* All songs"
+msgstr "* 所有歌曲"
+
+#: id:15105
+msgid "* All genres"
+msgstr "* 所有类型"
+
+#: id:15107
+msgid "Buffering..."
+msgstr "缓冲中..."
+
+#: id:15108
+msgid "Navigation sounds"
+msgstr "导航音效"
+
+#: id:15109
+msgid "Skin default"
+msgstr "皮肤预设"
+
+#: id:15111
+msgid "- Theme"
+msgstr "皮肤主题"
+
+#: id:15112
+msgid "Default theme"
+msgstr "缺省主题"
+
+#: id:15200
+msgid "Last.fm"
+msgstr "Last.fm"
+
+#: id:15201
+msgid "Submit songs to Last.fm"
+msgstr "将歌曲提交到 Last.fm"
+
+#: id:15202
+msgid "Last.fm username"
+msgstr "Last.fm 用户名"
+
+#: id:15203
+msgid "Last.fm password"
+msgstr "Last.fm 密码"
+
+#: id:15204
+msgid "Unable to handshake: sleeping..."
+msgstr "无法连接：休眠中..."
+
+#: id:15205
+msgid "Please update XBMC"
+msgstr "请升级 XBMC"
+
+#: id:15206
+msgid "Bad authorization: Check username and password"
+msgstr "无法通过认证：检查帐号和密码"
+
+#: id:15207
+msgctxt "Auto context with id 15207"
+msgid "Connected"
+msgstr "连接"
+
+#: id:15208
+msgid "Not connected"
+msgstr "无法连接"
+
+#: id:15209
+msgid "Submit interval %i"
+msgstr "上传进度%i"
+
+#: id:15210
+msgid "Cached %i songs"
+msgstr "已缓存%i首歌曲"
+
+#: id:15211
+msgid "Submitting..."
+msgstr "上传中..."
+
+#: id:15212
+msgid "Submitting in %i secs"
+msgstr "上传剩余%i秒"
+
+#: id:15213
+msgid "Play using..."
+msgstr "打开方式..."
+
+#: id:15214
+msgid "Use smoothed A/V synchronization"
+msgstr "使用平滑的影音同步"
+
+#: id:15215
+msgid "Hide file names in thumbs view"
+msgstr "缩略图显示时隐藏文件名"
+
+#: id:15216
+msgid "Play in party mode"
+msgstr "通过合作模式玩"
+
+#: id:15217
+msgid "Submit songs to Libre.fm"
+msgstr "将歌曲提交到 Libre.fm"
+
+#: id:15218
+msgid "Libre.fm username"
+msgstr "Libre.fm 用户名"
+
+#: id:15219
+msgid "Libre.fm password"
+msgstr "Libre.fm 密码"
+
+#: id:15220
+msgid "Libre.fm"
+msgstr "Libre.fm"
+
+#: id:15221
+msgid "Song submission"
+msgstr "歌曲提交"
+
+#: id:15250
+msgid "Submit Last.fm radio to Last.fm"
+msgstr "将 Last.fm 节目提交到 Last.fm"
+
+#: id:15251
+msgid "Connecting to Last.fm..."
+msgstr "连接到 Last.fm..."
+
+#: id:15252
+msgid "Selecting station..."
+msgstr "选择电台..."
+
+#: id:15253
+msgid "Search similar artists..."
+msgstr "寻找相似的艺人..."
+
+#: id:15254
+msgid "Search similar tags..."
+msgstr "寻找相似的标记..."
+
+#: id:15255
+msgid "Your profile (%name%)"
+msgstr "你的用户配置（%name%）"
+
+#: id:15256
+msgid "Overall top tags"
+msgstr "所有排行"
+
+#: id:15257
+msgid "Top artists for tag %name%"
+msgstr "%name% 艺人排行"
+
+#: id:15258
+msgid "Top albums for tag %name%"
+msgstr "%name% 专辑排行"
+
+#: id:15259
+msgid "Top tracks for tag %name%"
+msgstr "%name% 歌曲排行"
+
+#: id:15260
+msgid "Listen to tag %name% Last.fm radio"
+msgstr "收听 %name% Last.fm"
+
+#: id:15261
+msgid "Similar artists as %name%"
+msgstr "%name% 同类型艺人"
+
+#: id:15262
+msgid "Top %name% albums"
+msgstr "%name% 专辑排行"
+
+#: id:15263
+msgid "Top %name% tracks"
+msgstr "%name% 歌曲排行"
+
+#: id:15264
+msgid "Top %name% tags"
+msgstr "%name% 标签排行"
+
+#: id:15265
+msgid "Biggest fans of %name%"
+msgstr "%name% 最爱歌迷"
+
+#: id:15266
+msgid "Listen to %name% fans Last.fm radio"
+msgstr "收听 %name% 在 Last.fm 的歌迷"
+
+#: id:15267
+msgid "Listen to %name% similar artists Last.fm radio"
+msgstr "收听 %name% 在 Last.fm 的同类型艺人"
+
+#: id:15268
+msgid "Top artists for user %name%"
+msgstr "%name% 艺人排行"
+
+#: id:15269
+msgid "Top albums for user %name%"
+msgstr "%name% 专辑排行"
+
+#: id:15270
+msgid "Top tracks for user %name%"
+msgstr "%name% 歌曲排行"
+
+#: id:15271
+msgid "Friends of user %name%"
+msgstr "%name% 好友"
+
+#: id:15272
+msgid "Neighbours of user %name%"
+msgstr "%name% 同好"
+
+#: id:15273
+msgid "Weekly artist chart for %name%"
+msgstr "%name% 艺人周排行"
+
+#: id:15274
+msgid "Weekly album chart for %name%"
+msgstr "%name% 专辑周排行"
+
+#: id:15275
+msgid "Weekly track chart for %name%"
+msgstr "%name% 歌曲周排行"
+
+#: id:15276
+msgid "Listen to %name%'s neighbours Last.fm radio"
+msgstr "收听 %name% 在 Last.fm 的同好"
+
+#: id:15277
+msgid "Listen to %name%'s personal Last.fm radio"
+msgstr "收听 %name% 的个人 Last.fm"
+
+#: id:15278
+msgid "Listen to %name%'s mix Last.fm radio"
+msgstr "收听 %name% 的 mix Last.fm radio"
+
+#: id:15279
+msgid "Retrieving list from Last.fm..."
+msgstr "正在从 Last.fm 获取列表"
+
+#: id:15280
+msgid "Can't retrieve list from Last.fm..."
+msgstr "不能从 Last.fm 获取列表..."
+
+#: id:15281
+msgid "Enter an artist name to find related ones"
+msgstr "输入艺人名来寻找相关资料"
+
+#: id:15282
+msgid "Enter a tag name to find similar ones"
+msgstr "输入标签名来寻找相关资料"
+
+#: id:15283
+msgid "Tracks recently listened by %name%"
+msgstr "%name% 最近听过的歌曲"
+
+#: id:15284
+msgid "Listen to %name%'s recommendations Last.fm radio"
+msgstr "收听 %name% 在 Last.fm 的推荐"
+
+#: id:15285
+msgid "Top tags for user %name%"
+msgstr "%name% 的排行"
+
+#: id:15287
+msgid "Do you want to add the current track to your loved tracks?"
+msgstr "你想把目前歌曲加入你的最爱吗？"
+
+#: id:15288
+msgid "Do you want to ban the current track?"
+msgstr "你想封锁目前的歌曲吗？"
+
+#: id:15289
+msgid "Added to your loved tracks: '%s'."
+msgstr "加入你的最爱歌曲：'%s'"
+
+#: id:15290
+msgid "Could not add '%s' to your loved tracks."
+msgstr "不能加入 '%s' 到你的最爱"
+
+#: id:15291
+msgid "Banned: '%s'."
+msgstr "已被封禁：'%s'."
+
+#: id:15292
+msgid "Could not ban '%s'."
+msgstr "不能封禁 '%s'."
+
+#: id:15293
+msgid "Tracks recently loved by %name%"
+msgstr "%name% 最近喜好的歌曲"
+
+#: id:15294
+msgid "Tracks recently banned by %name%"
+msgstr "%name% 最近封锁的歌曲"
+
+#: id:15295
+msgid "Remove from loved tracks"
+msgstr "从最爱中移除"
+
+#: id:15296
+msgid "Un-ban"
+msgstr "解除封锁"
+
+#: id:15297
+msgid "Do you want to remove this track from your loved tracks?"
+msgstr "您想从你的最爱移除这首歌曲吗？"
+
+#: id:15298
+msgid "Do you want to un-ban this track?"
+msgstr "你想解除封锁这首歌曲吗？"
+
+#: id:15300
+msgid "Path not found or invalid"
+msgstr "路径错误或无法找到！"
+
+#: id:15301
+msgid "Could not connect to network server"
+msgstr "无法连接服务器！"
+
+#: id:15302
+msgid "No servers found"
+msgstr "没有找到服务器！"
+
+#: id:15303
+msgid "Workgroup not found"
+msgstr "没有找到工作组！"
+
+#: id:15310
+msgid "Opening multi-path source"
+msgstr "打开多个源路径"
+
+#: id:15311
+msgid "Path:"
+msgstr "路径："
+
+#: id:16000
+msgctxt "Auto context with id 16000"
+msgid "General"
+msgstr "常用"
+
+#: id:16002
+msgid "Internet lookup"
+msgstr "互联网查询"
+
+#: id:16003
+msgid "Player"
+msgstr "高级设置"
+
+#: id:16004
+msgid "Play media from disc"
+msgstr "播放碟片"
+
+#: id:16008
+msgid "Enter new title"
+msgstr "输入新标题"
+
+#: id:16009
+msgid "Enter the movie name"
+msgstr "输入视频名称"
+
+#: id:16010
+msgid "Enter the profile name"
+msgstr "输入配置名称"
+
+#: id:16011
+msgid "Enter the album name"
+msgstr "输入专辑名称"
+
+#: id:16012
+msgid "Enter the playlist name"
+msgstr "输入播放列表名称"
+
+#: id:16013
+msgid "Enter new filename"
+msgstr "输入新的文件名"
+
+#: id:16014
+msgid "Enter folder name"
+msgstr "输入文件夹名称"
+
+#: id:16015
+msgid "Enter directory"
+msgstr "输入目录"
+
+#: id:16016
+msgid "Available options: %A, %T, %N, %B, %D, %G, %Y, %F, %S"
+msgstr "可使用选项：%A, %T, %N, %B, %D, %G, %Y, %F, %S"
+
+#: id:16017
+msgid "Enter search string"
+msgstr "输入查询字符串"
+
+#: id:16018
+msgctxt "Auto context with id 16018"
+msgid "None"
+msgstr "关闭"
+
+#: id:16019
+msgid "Auto select"
+msgstr "自动选择"
+
+#: id:16020
+msgid "De-interlace"
+msgstr "去隔行"
+
+#: id:16021
+msgid "Bob"
+msgstr "场内插值法"
+
+#: id:16022
+msgid "Bob (inverted)"
+msgstr "场内插值法（反向）"
+
+#: id:16024
+msgid "Canceling..."
+msgstr "取消中..."
+
+#: id:16025
+msgid "Enter the artist name"
+msgstr "输入艺人名字"
+
+#: id:16026
+msgid "Playback failed"
+msgstr "播放失败"
+
+#: id:16027
+msgid "One or more items failed to play."
+msgstr "一个或多个项目播放失败！"
+
+#: id:16028
+msgid "Enter value"
+msgstr "输入数据"
+
+#: id:16029
+msgid "Check the log file for details."
+msgstr "详情请查看日志文件。"
+
+#: id:16030
+msgid "Party mode aborted."
+msgstr "取消舞会模式！"
+
+#: id:16031
+msgid "No matching songs in the library."
+msgstr "资料库中没有符合条件的歌曲！"
+
+#: id:16032
+msgid "Could not initialize database."
+msgstr "无法初始化资料库！"
+
+#: id:16033
+msgid "Could not open database."
+msgstr "无法打开资料库！"
+
+#: id:16034
+msgid "Could not get songs from database."
+msgstr "无法从资料库获取歌曲文件！"
+
+#: id:16035
+msgid "Party mode playlist"
+msgstr "舞会模式播放列表"
+
+#: id:16036
+msgid "De-interlace (Half)"
+msgstr "去隔行（半速）"
+
+#: id:16037
+msgid "Deinterlace video"
+msgstr "去隔行视频"
+
+#: id:16038
+msgid "Deinterlace method"
+msgstr "去隔行算法"
+
+#: id:16039
+msgctxt "Auto context with id 16039"
+msgid "Off"
+msgstr "关"
+
+#: id:16040
+msgctxt "Auto context with id 16040"
+msgid "Auto"
+msgstr "自动"
+
+#: id:16041
+msgid "On"
+msgstr "开"
+
+#: id:16100
+msgid "All Videos"
+msgstr "所有视频文件"
+
+#: id:16101
+msgid "Unwatched"
+msgstr "未观看的"
+
+#: id:16102
+msgid "Watched"
+msgstr "已观看的"
+
+#: id:16103
+msgid "Mark as watched"
+msgstr "标记为已观看"
+
+#: id:16104
+msgid "Mark as unwatched"
+msgstr "标记为未观看"
+
+#: id:16105
+msgid "Edit title"
+msgstr "编辑标题"
+
+#: id:16200
+msgid "Operation was aborted"
+msgstr "操作被中断"
+
+#: id:16201
+msgid "Copy failed"
+msgstr "复制文件失败"
+
+#: id:16202
+msgid "Failed to copy at least one file"
+msgstr "部分文件复制失败"
+
+#: id:16203
+msgid "Move failed"
+msgstr "移动文件失败"
+
+#: id:16204
+msgid "Failed to move at least one file"
+msgstr "部分文件移动失败"
+
+#: id:16205
+msgid "Delete failed"
+msgstr "删除文件失败"
+
+#: id:16206
+msgid "Failed to delete at least one file"
+msgstr "部分文件删除失败"
+
+#: id:16300
+msgid "Video scaling method"
+msgstr "视频扫描方式"
+
+#: id:16301
+msgid "Nearest neighbour"
+msgstr "最近邻"
+
+#: id:16302
+msgid "Bilinear"
+msgstr "双线性"
+
+#: id:16303
+msgctxt "Auto context with id 16303"
+msgid "Bicubic"
+msgstr "双三次"
+
+#: id:16304
+msgid "Lanczos2"
+msgstr "Lanczos2"
+
+#: id:16305
+msgid "Lanczos3"
+msgstr "Lanczos3"
+
+#: id:16306
+msgid "Sinc8"
+msgstr "正弦8"
+
+#: id:16307
+msgid "Bicubic (software)"
+msgstr "双三次（软件）"
+
+#: id:16308
+msgid "Lanczos (software)"
+msgstr "Lanczos（软件）"
+
+#: id:16309
+msgid "Sinc (software)"
+msgstr "正弦（软件）"
+
+#: id:16310
+msgid "Temporal"
+msgstr "时间平滑"
+
+#: id:16311
+msgid "Temporal/Spatial"
+msgstr "时间/空间平滑"
+
+#: id:16312
+msgid "(VDPAU)Noise Reduction"
+msgstr "（VDPAU）降噪"
+
+#: id:16313
+msgid "(VDPAU)Sharpness"
+msgstr "（VDPAU）锐化"
+
+#: id:16314
+msgid "Inverse Telecine"
+msgstr "帧率逆转换"
+
+#: id:16315
+msgid "Lanczos3 optimized"
+msgstr "Lanczos3 优化"
+
+#: id:16316
+msgctxt "Auto context with id 16316"
+msgid "Auto"
+msgstr "自动"
+
+#: id:16317
+msgid "Temporal (Half)"
+msgstr "时间平滑（半速）"
+
+#: id:16318
+msgid "Temporal/Spatial (Half)"
+msgstr "时间/空间平滑（半速）"
+
+#: id:16319
+msgid "DXVA"
+msgstr "DXVA"
+
+#: id:16320
+msgid "DXVA Bob"
+msgstr "DXVA 场内插值"
+
+#: id:16321
+msgid "DXVA Best"
+msgstr "DXVA 最优"
+
+#: id:16322
+msgid "Spline36"
+msgstr "Spline36"
+
+#: id:16323
+msgid "Spline36 optimized"
+msgstr "Spline36 优化"
+
+#: id:16324
+msgid "Software Blend"
+msgstr "软件混合"
+
+#: id:16400
+msgid "Post-processing"
+msgstr "后处理"
+
+#: id:17500
+msgid "Display sleep timeout"
+msgstr "显示睡眠时间"
+
+#: id:19000
+msgid "Switch to channel"
+msgstr "切换到频道"
+
+#: id:20000
+msgid "Saved music folder"
+msgstr "音乐保存目录"
+
+#: id:20001
+msgid "Use external DVD player"
+msgstr "使用外部 DVD 播放程序"
+
+#: id:20002
+msgid "External DVD player"
+msgstr "外部 DVD 播放程序"
+
+#: id:20003
+msgid "Trainers folder"
+msgstr "金手指目录"
+
+#: id:20004
+msgid "Screenshot folder"
+msgstr "屏幕抓图目录"
+
+#: id:20006
+msgid "Playlists folder"
+msgstr "播放列表目录"
+
+#: id:20007
+msgid "Recordings"
+msgstr "录音"
+
+#: id:20008
+msgid "Screenshots"
+msgstr "屏幕抓图"
+
+#: id:20009
+msgid "Use XBMC"
+msgstr "使用 XBMC"
+
+#: id:20011
+msgid "Music playlists"
+msgstr "音乐播放列表"
+
+#: id:20012
+msgid "Video playlists"
+msgstr "视频播放列表"
+
+#: id:20013
+msgid "Do you wish to launch the game?"
+msgstr "你要执行该游戏？"
+
+#: id:20014
+msgid "Sort by: Playlist"
+msgstr "排序：播放列表"
+
+#: id:20015
+msgid "Remote thumb"
+msgstr "远程缩略图"
+
+#: id:20016
+msgid "Current thumb"
+msgstr "当前缩略图"
+
+#: id:20017
+msgid "Local thumb"
+msgstr "本地缩略图"
+
+#: id:20018
+msgid "No thumb"
+msgstr "无缩略图"
+
+#: id:20019
+msgid "Choose thumbnail"
+msgstr "选择缩略图"
+
+#: id:20023
+msgid "Conflict"
+msgstr "冲突"
+
+#: id:20024
+msgid "Scan new"
+msgstr "扫描新的"
+
+#: id:20025
+msgid "Scan all"
+msgstr "扫描全部"
+
+#: id:20026
+msgid "Region"
+msgstr "区域"
+
+#: id:20037
+msgid "Summary"
+msgstr "摘要"
+
+#: id:20038
+msgid "Lock music window"
+msgstr "锁定音乐部分"
+
+#: id:20039
+msgid "Lock videos window"
+msgstr "锁定视频部分"
+
+#: id:20040
+msgid "Lock pictures window"
+msgstr "锁定图片部分"
+
+#: id:20041
+msgid "Lock programs & scripts windows"
+msgstr "锁定程序与脚本部分"
+
+#: id:20042
+msgid "Lock file manager"
+msgstr "锁定文件管理"
+
+#: id:20043
+msgid "Lock settings"
+msgstr "锁定系统设置"
+
+#: id:20044
+msgid "Start fresh"
+msgstr "重新设置"
+
+#: id:20045
+msgid "Enter master mode"
+msgstr "进入管理员模式"
+
+#: id:20046
+msgid "Leave master mode"
+msgstr "离开管理员模式"
+
+#: id:20047
+msgid "Create profile '%s'?"
+msgstr "创建用户配置'%s'？"
+
+#: id:20048
+msgid "Start with fresh settings"
+msgstr "应用新的设置开始"
+
+#: id:20049
+msgid "Best available"
+msgstr "最适合模式"
+
+#: id:20050
+msgid "Auto-switch between 16x9 and 4x3"
+msgstr "自动切换 16x9 与 4x3 模式"
+
+#: id:20051
+msgid "Treat stacked files as single file"
+msgstr "视堆叠文件为单一文件"
+
+#: id:20052
+msgid "Caution"
+msgstr "注意"
+
+#: id:20053
+msgid "Left master mode"
+msgstr "已离开管理员模式"
+
+#: id:20054
+msgid "Entered master mode"
+msgstr "已进入管理员模式"
+
+#: id:20055
+msgid "Allmusic.com thumb"
+msgstr "Allmusic.com 缩略图"
+
+#: id:20057
+msgid "Remove thumbnail"
+msgstr "移除缩略图"
+
+#: id:20058
+msgid "Add profile..."
+msgstr "新加入用户配置..."
+
+#: id:20059
+msgid "Query info for all albums"
+msgstr "下载所有专辑的讯息"
+
+#: id:20060
+msgctxt "Auto context with id 20060"
+msgid "Media info"
+msgstr "媒体讯息"
+
+#: id:20061
+msgctxt "Auto context with id 20061"
+msgid "Separate"
+msgstr "分离的"
+
+#: id:20062
+msgid "Shares with default"
+msgstr "共用预设值"
+
+#: id:20063
+msgid "Shares with default (read only)"
+msgstr "共用预设值（只读）"
+
+#: id:20064
+msgid "Copy default"
+msgstr "复制预设值"
+
+#: id:20065
+msgid "Profile picture"
+msgstr "用户配置图片"
+
+#: id:20066
+msgid "Lock preferences"
+msgstr "锁定偏好设置"
+
+#: id:20067
+msgid "Edit profile"
+msgstr "编辑用户配置"
+
+#: id:20068
+msgid "Profile lock"
+msgstr "锁定用户配置"
+
+#: id:20069
+msgid "Could not create folder"
+msgstr "无法建立目录"
+
+#: id:20070
+msgid "Profile directory"
+msgstr "用户配置目录"
+
+#: id:20071
+msgid "Start with fresh media sources"
+msgstr "启动时刷新媒体来源"
+
+#: id:20072
+msgid "Make sure the selected folder is writable"
+msgstr "请确定选择的目录是可写入的"
+
+#: id:20073
+msgid "and that the new folder name is valid"
+msgstr "且是有效的目录名称"
+
+#: id:20074
+msgid "MPAA rating"
+msgstr "MPAA评分"
+
+#: id:20075
+msgid "Enter master lock code"
+msgstr "输入管理员密码"
+
+#: id:20076
+msgid "Ask for master lock code on startup"
+msgstr "在开机时询问管理员密码"
+
+#: id:20077
+msgid "Skin settings"
+msgstr "桌面设置"
+
+#: id:20078
+msgid "- no link set -"
+msgstr "- 无连结设置 -"
+
+#: id:20079
+msgid "Enable animations"
+msgstr "启用桌面动画效果"
+
+#: id:20080
+msgid "Disable RSS during music"
+msgstr "播放音乐时关闭 RSS"
+
+#: id:20081
+msgid "Enable shortcut buttons"
+msgstr "启用快捷方式"
+
+#: id:20082
+msgid "Show programs in main menu"
+msgstr "在主界面中显示程序菜单"
+
+#: id:20083
+msgid "Show music info"
+msgstr "显示音乐讯息"
+
+#: id:20084
+msgid "Show weather info"
+msgstr "显示天气预报"
+
+#: id:20085
+msgid "Show system info"
+msgstr "显示系统信息"
+
+#: id:20086
+msgid "Show available disc space C: E: F:"
+msgstr "显示可用的磁盘空间 C: E: F:"
+
+#: id:20087
+msgid "Show available disc space E: F: G:"
+msgstr "显示可用的磁盘空间 E: F: G:"
+
+#: id:20088
+msgid "Weather info"
+msgstr "天气预报"
+
+#: id:20089
+msgid "Drive space free"
+msgstr "可用的磁盘空间"
+
+#: id:20090
+msgid "Enter the name of an existing share"
+msgstr "输入一个已有的共享名称"
+
+#: id:20091
+msgid "Lock code"
+msgstr "密码"
+
+#: id:20092
+msgid "Load profile"
+msgstr "载入用户配置"
+
+#: id:20093
+msgid "Profile name"
+msgstr "用户配置名称"
+
+#: id:20094
+msgctxt "Auto context with id 20094"
+msgid "Media sources"
+msgstr "媒体来源"
+
+#: id:20095
+msgid "Enter profile lock code"
+msgstr "用户配置密码"
+
+#: id:20096
+msgctxt "Auto context with id 20096"
+msgid "Login screen"
+msgstr "登录窗口"
+
+#: id:20097
+msgid "Fetching album info"
+msgstr "抓取专辑讯息"
+
+#: id:20098
+msgid "Fetching info for album"
+msgstr "正在取得专辑讯息"
+
+#: id:20099
+msgid "Can't rip CD or track while playing from CD"
+msgstr "当 CD 播放时不能抓取该 CD"
+
+#: id:20100
+msgid "Master lock code and settings"
+msgstr "管理员密码与设置"
+
+#: id:20101
+msgid "Entering master lock code always enables master mode"
+msgstr "输入管理员密码后，始终启用管理员模式"
+
+#: id:20102
+msgid "or copy from default?"
+msgstr "或是从预设值中复制？"
+
+#: id:20103
+msgid "Save changes to profile?"
+msgstr "保存变更到用户配置文件？"
+
+#: id:20104
+msgid "Old settings found."
+msgstr "发现旧设置值"
+
+#: id:20105
+msgid "Do you want to use them?"
+msgstr "你要使用吗？"
+
+#: id:20106
+msgid "Old media sources found."
+msgstr "发现旧媒体来源"
+
+#: id:20107
+msgid "Separate (locked)"
+msgstr "分离的（锁定）"
+
+#: id:20108
+msgid "Root"
+msgstr "根目录"
+
+#: id:20109
+msgid "- Zoom"
+msgstr "皮肤缩放"
+
+#: id:20110
+msgid "UPnP settings"
+msgstr "UPnP 客户端"
+
+#: id:20111
+msgid "Autostart UPnP client"
+msgstr "自动启动 UPnP 客户端"
+
+#: id:20112
+msgid "Last login: %s"
+msgstr "上次登录：%s"
+
+#: id:20113
+msgid "Never logged on"
+msgstr "从未登录"
+
+#: id:20114
+msgid "Profile %i / %i"
+msgstr "用户配置%i / %i"
+
+#: id:20115
+msgid "User login / Select a profile"
+msgstr "用户登录/选择用户配置"
+
+#: id:20116
+msgid "Use lock on login screen"
+msgstr "在登录窗口中使用锁定"
+
+#: id:20117
+msgid "Invalid lock code."
+msgstr "密码无效"
+
+#: id:20118
+msgid "This requires the master lock to be set."
+msgstr "需先设置管理员锁定"
+
+#: id:20119
+msgid "Would you like to set it now?"
+msgstr "你现在要设置吗？"
+
+#: id:20120
+msgid "Loading program information"
+msgstr "载入程序讯息"
+
+#: id:20121
+msgid "Party on!"
+msgstr "启动舞会模式！"
+
+#: id:20122
+msgid "True"
+msgstr "真实"
+
+#: id:20123
+msgid "Mixing drinks"
+msgstr "混合饮料"
+
+#: id:20124
+msgid "Filling glasses"
+msgstr "填入玻璃"
+
+#: id:20125
+msgid "Logged on as"
+msgstr "登录"
+
+#: id:20126
+msgid "Log off"
+msgstr "注销"
+
+#: id:20128
+msgid "Go to root"
+msgstr "转到根目录"
+
+#: id:20129
+msgid "Weave"
+msgstr "交织"
+
+#: id:20130
+msgid "Weave (inverted)"
+msgstr "交织（倒转）"
+
+#: id:20131
+msgid "Blend"
+msgstr "混合"
+
+#: id:20132
+msgid "Restart video"
+msgstr "从头播放视频"
+
+#: id:20133
+msgid "Edit network location"
+msgstr "编辑网络位置"
+
+#: id:20134
+msgid "Remove network location"
+msgstr "移除网络位置"
+
+#: id:20135
+msgid "Do you want to scan the folder?"
+msgstr "你想扫描这个目录吗？"
+
+#: id:20136
+msgid "Memory unit"
+msgstr "记忆卡"
+
+#: id:20137
+msgid "Memory unit mounted"
+msgstr "记忆卡已插入"
+
+#: id:20138
+msgid "Unable to mount memory unit"
+msgstr "找不到记忆卡"
+
+#: id:20139
+msgid "In port %i, slot %i"
+msgstr "在%i端口，第%i槽"
+
+#: id:20140
+msgid "Lock screensaver"
+msgstr "锁定屏幕保护"
+
+#: id:20141
+msgid "Set"
+msgstr "设置"
+
+#: id:20142
+msgctxt "Auto context with id 20142"
+msgid "Username"
+msgstr "用户名"
+
+#: id:20143
+msgid "Enter password for"
+msgstr "键入密码"
+
+#: id:20144
+msgid "Shutdown timer"
+msgstr "自动关机定时器"
+
+#: id:20145
+msgid "Shutdown interval (in minutes)"
+msgstr "自动关机定时（分钟）"
+
+#: id:20146
+msgid "Started, shutdown in %im"
+msgstr "启动自动关机在%i分钟后"
+
+#: id:20147
+msgid "Shutdown in 30 minutes"
+msgstr "30分钟后自动关机"
+
+#: id:20148
+msgid "Shutdown in 60 minutes"
+msgstr "60分钟后自动关机"
+
+#: id:20149
+msgid "Shutdown in 120 minutes"
+msgstr "120分钟后自动关机"
+
+#: id:20150
+msgid "Custom shutdown timer"
+msgstr "自定义自动关机时间"
+
+#: id:20151
+msgid "Cancel shutdown timer"
+msgstr "取消自动关机"
+
+#: id:20152
+msgid "Lock preferences for %s"
+msgstr "锁定设置文件%s"
+
+#: id:20153
+msgid "Browse..."
+msgstr "浏览..."
+
+#: id:20154
+msgid "Summary information"
+msgstr "系统摘要信息"
+
+#: id:20155
+msgid "Storage information"
+msgstr "存储设备信息"
+
+#: id:20156
+msgid "Hard disk information"
+msgstr "硬盘驱动器信息"
+
+#: id:20157
+msgid "DVD-ROM information"
+msgstr "光盘驱动器信息"
+
+#: id:20158
+msgid "Network information"
+msgstr "网络设备信息"
+
+#: id:20159
+msgid "Video information"
+msgstr "视频设备信息"
+
+#: id:20160
+msgid "Hardware information"
+msgstr "硬件设备信息"
+
+#: id:20161
+msgid "Total"
+msgstr "总计"
+
+#: id:20162
+msgid "Used"
+msgstr "已使用"
+
+#: id:20163
+msgid "of"
+msgstr "中"
+
+#: id:20164
+msgid "Locking not supported"
+msgstr "不支持锁定"
+
+#: id:20165
+msgid "Not locked"
+msgstr "没有上锁"
+
+#: id:20166
+msgid "Locked"
+msgstr "已经上锁"
+
+#: id:20167
+msgid "Frozen"
+msgstr "已冻结"
+
+#: id:20168
+msgid "Requires reset"
+msgstr "需要重新启动"
+
+#: id:20169
+msgid "Week"
+msgstr "周"
+
+#: id:20170
+msgid "Line"
+msgstr "生产线"
+
+#: id:20171
+msgid "Windows network (SMB)"
+msgstr "Windows 网络（SMB）"
+
+#: id:20172
+msgid "XBMSP server"
+msgstr "XBMSP 服务器"
+
+#: id:20173
+msgctxt "Auto context with id 20173"
+msgid "FTP server"
+msgstr "FTP 服务器"
+
+#: id:20174
+msgid "iTunes music share (DAAP)"
+msgstr "ITunes 音乐共享（DAAP）"
+
+#: id:20175
+msgid "UPnP server"
+msgstr "UPnP 媒体服务器"
+
+#: id:20176
+msgid "Show video info"
+msgstr "显示视频信息"
+
+#: id:20177
+msgid "Done"
+msgstr "完成"
+
+#: id:20178
+msgid "Shift"
+msgstr "上档"
+
+#: id:20179
+msgid "Caps Lock"
+msgstr "大写"
+
+#: id:20180
+msgid "Symbols"
+msgstr "符号"
+
+#: id:20181
+msgid "Backspace"
+msgstr "退格"
+
+#: id:20182
+msgid "Space"
+msgstr "空格"
+
+#: id:20183
+msgid "Reload skin"
+msgstr "重载桌面皮肤"
+
+#: id:20184
+msgid "Rotate pictures using EXIF information"
+msgstr "根据 EXIF 信息旋转图片"
+
+#: id:20185
+msgid "Use poster view styles for TV shows"
+msgstr "使用海报模式显示剧集"
+
+#: id:20186
+msgid "Please wait"
+msgstr "请稍候..."
+
+#: id:20187
+msgid "UPnP"
+msgstr "UPnP"
+
+#: id:20189
+msgid "Enable auto scrolling for plot & review"
+msgstr "启用剧情和评论自动滚动"
+
+#: id:20190
+msgctxt "Auto context with id 20190"
+msgid "Custom"
+msgstr "自定义"
+
+#: id:20191
+msgid "Enable debug logging"
+msgstr "显示除错信息"
+
+#: id:20192
+msgid "Download additional information during updates"
+msgstr "资料库更新时下载附加信息"
+
+#: id:20193
+msgid "Default service for album information"
+msgstr "默认专辑信息服务"
+
+#: id:20194
+msgid "Default service for artist information"
+msgstr "默认艺人信息服务"
+
+#: id:20195
+msgid "Change scraper"
+msgstr "改变刮削器"
+
+#: id:20196
+msgid "Export music library"
+msgstr "导出音乐资料库"
+
+#: id:20197
+msgid "Import music library"
+msgstr "导入音乐资料库"
+
+#: id:20198
+msgid "No artist found!"
+msgstr "未找到艺人!"
+
+#: id:20199
+msgid "Downloading artist info failed"
+msgstr "下载艺人信息失败"
+
+#: id:20250
+msgid "Party on! (videos)"
+msgstr "舞会模式！（视频）"
+
+#: id:20251
+msgid "Mixing drinks (videos)"
+msgstr "鸡尾酒（视频）"
+
+#: id:20252
+msgid "Filling glasses (videos)"
+msgstr "填入玻璃（视频）"
+
+#: id:20253
+msgid "WebDAV server (HTTP)"
+msgstr "WebDAV服务器（HTTP）"
+
+#: id:20254
+msgid "WebDAV server (HTTPS)"
+msgstr "WebDAV服务器（HTTPS）"
+
+#: id:20255
+msgid "First logon, edit your profile"
+msgstr "首次登录，编辑您的用户配置"
+
+#: id:20256
+msgid "HTS Tvheadend client"
+msgstr "HTS Tvheadend 客户端"
+
+#: id:20257
+msgid "VDR Streamdev client"
+msgstr "VDR Streamdev 客户端"
+
+#: id:20258
+msgid "MythTV client"
+msgstr "MythTV 客户端"
+
+#: id:20259
+msgid "Network Filesystem (NFS)"
+msgstr "网络文件系统（NFS）"
+
+#: id:20260
+msgid "Secure Shell (SSH/SFTP)"
+msgstr "安全壳（SSH/SFTP）"
+
+#: id:20261
+msgid "Apple Filing Protocol (AFP)"
+msgstr "Apple 文件协议（AFP）"
+
+#: id:20300
+msgid "Web server directory (HTTP)"
+msgstr "WEB服务器目录（HTTP）"
+
+#: id:20301
+msgid "Web server directory (HTTPS)"
+msgstr "WEB服务器目录（HTTPS）"
+
+#: id:20302
+msgid "Unable to write to folder:"
+msgstr "无法写入文件夹："
+
+#: id:20303
+msgid "Do you want to skip and proceed?"
+msgstr "你要跳过并继续吗？"
+
+#: id:20304
+msgid "RSS Feed"
+msgstr "RSS 信源"
+
+#: id:20307
+msgid "Secondary DNS"
+msgstr "备用 DNS 服务器地址"
+
+#: id:20308
+msgid "DHCP server:"
+msgstr "DHCP 服务器："
+
+#: id:20309
+msgid "Make new folder"
+msgstr "新建文件夹"
+
+#: id:20310
+msgid "Dim LCD on playback"
+msgstr "播放时关闭 LCD 背光"
+
+#: id:20311
+msgid "Unknown or onboard (protected)"
+msgstr "未知或板载（保护状态）"
+
+#: id:20312
+msgid "Dim LCD on paused"
+msgstr "暂停时关闭 LCD 背光"
+
+#: id:20314
+msgid "Videos - Library"
+msgstr "视频 - 资料库"
+
+#: id:20316
+msgid "Sort by: ID"
+msgstr "排序：标签"
+
+#: id:20324
+msgid "Play part..."
+msgstr "分段播放..."
+
+#: id:20325
+msgid "Calibration reset"
+msgstr "重新校准"
+
+#: id:20326
+msgid "This will reset the calibration values for %s"
+msgstr "这个操作会重新校准%s的配置"
+
+#: id:20327
+msgid "to it's default values."
+msgstr "还原为初时配置"
+
+#: id:20328
+msgid "Browse for destination"
+msgstr "选择指定位置"
+
+#: id:20329
+msgid "Movies are in separate folders that match the movie title"
+msgstr "电影在以片名命名的单独目录中"
+
+#: id:20330
+msgid "Use folder names for lookups"
+msgstr "以文件夹名来查找"
+
+#: id:20331
+msgctxt "Auto context with id 20331"
+msgid "File"
+msgstr "文件"
+
+#: id:20332
+msgid "Use file or folder names in lookups?"
+msgstr "用文件夹名或文件名进行查找？"
+
+#: id:20333
+msgid "Set content"
+msgstr "设置内容"
+
+#: id:20334
+msgid "Folder"
+msgstr "文件夹"
+
+#: id:20335
+msgid "Look for content recursively?"
+msgstr "是否嵌套查找？"
+
+#: id:20336
+msgid "Unlock sources"
+msgstr "取消源锁定"
+
+#: id:20337
+msgid "Actor"
+msgstr "演员"
+
+#: id:20338
+msgid "Movie"
+msgstr "影片"
+
+#: id:20339
+msgid "Director"
+msgstr "导演"
+
+#: id:20340
+msgid "Do you want to remove all items within"
+msgstr "是否从XBMC资料库中移除"
+
+#: id:20341
+msgid "this path from the XBMC library?"
+msgstr "所有位于该路径的项目？"
+
+#: id:20342
+msgctxt "Auto context with id 20342"
+msgid "Movies"
+msgstr "电影"
+
+#: id:20343
+msgid "TV shows"
+msgstr "剧集"
+
+#: id:20344
+msgid "This directory contains"
+msgstr "该目录包含"
+
+#: id:20345
+msgid "Run automated scan"
+msgstr "运行自动扫描"
+
+#: id:20346
+msgid "Scan recursively"
+msgstr "嵌套查找"
+
+#: id:20347
+msgid "as"
+msgstr "饰演"
+
+#: id:20348
+msgid "Directors"
+msgstr "导演"
+
+#: id:20349
+msgid "No video files found in this path!"
+msgstr "该目录下无视频文件！"
+
+#: id:20350
+msgid "votes"
+msgstr "票数"
+
+#: id:20351
+msgid "TV show information"
+msgstr "剧集信息"
+
+#: id:20352
+msgid "Episode information"
+msgstr "分集信息"
+
+#: id:20353
+msgid "Loading TV show details"
+msgstr "下载剧集详细介绍"
+
+#: id:20354
+msgid "Fetching episode guide"
+msgstr "取得分集介绍"
+
+#: id:20355
+msgid "Loading info for episodes in directory"
+msgstr "下载分集信息到资料库"
+
+#: id:20356
+msgid "Select TV show:"
+msgstr "选择剧集："
+
+#: id:20357
+msgid "Enter the TV show name"
+msgstr "输入剧集名"
+
+#: id:20358
+msgid "Season %i"
+msgstr "第%i季"
+
+#: id:20359
+msgid "Episode"
+msgstr "集"
+
+#: id:20360
+msgid "Episodes"
+msgstr "分集"
+
+#: id:20361
+msgid "Loading episode details"
+msgstr "下载分集详细介绍"
+
+#: id:20362
+msgid "Remove episode from library"
+msgstr "从资料库移除分集"
+
+#: id:20363
+msgid "Remove TV show from library"
+msgstr "从资料库移除剧集"
+
+#: id:20364
+msgid "TV show"
+msgstr "剧集"
+
+#: id:20365
+msgid "Episode plot"
+msgstr "剧情"
+
+#: id:20366
+msgid "* All seasons"
+msgstr "* 整季"
+
+#: id:20367
+msgid "Hide watched"
+msgstr "隐藏已观看的"
+
+#: id:20368
+msgid "Prod code"
+msgstr "序列号"
+
+#: id:20369
+msgid "Show plot for unwatched items"
+msgstr "显示未观看影片的剧情介绍"
+
+#: id:20370
+msgid "* Hidden to prevent spoilers *"
+msgstr "* 未观看之前隐藏 *"
+
+#: id:20371
+msgid "Set season thumb"
+msgstr "设置季缩略图"
+
+#: id:20372
+msgid "Season image"
+msgstr "季图片"
+
+#: id:20373
+msgid "Season"
+msgstr "季"
+
+#: id:20374
+msgid "Downloading movie information"
+msgstr "下载影片信息"
+
+#: id:20375
+msgid "Unassign content"
+msgstr "不指定内容"
+
+#: id:20376
+msgid "Original title"
+msgstr "原片名"
+
+#: id:20377
+msgid "Refresh TV show information"
+msgstr "刷新剧集信息"
+
+#: id:20378
+msgid "Refresh info for all episodes?"
+msgstr "刷新所有分集信息？"
+
+#: id:20379
+msgid "Selected folder contains a single TV show"
+msgstr "被选文件夹包含单个电视剧集"
+
+#: id:20380
+msgid "Exclude selected folder from scans"
+msgstr "扫描时排除文件夹"
+
+#: id:20381
+msgid "Specials"
+msgstr "特别"
+
+#: id:20382
+msgid "Automatically grab season thumbs"
+msgstr "自动获取季缩略图"
+
+#: id:20383
+msgid "Selected folder contains a single video"
+msgstr "被选文件夹包含单个视频"
+
+#: id:20384
+msgid "Link to TV show"
+msgstr "链接到电视剧集"
+
+#: id:20385
+msgid "Remove link to TV show"
+msgstr "移除到电视剧集的链接"
+
+#: id:20386
+msgid "Recently added movies"
+msgstr "最近加入的影片"
+
+#: id:20387
+msgid "Recently added episodes"
+msgstr "最近加入的剧集"
+
+#: id:20388
+msgid "Studios"
+msgstr "制作公司"
+
+#: id:20389
+msgid "Music videos"
+msgstr "音乐电视"
+
+#: id:20390
+msgid "Recently added music videos"
+msgstr "最近加入的音乐电视"
+
+#: id:20391
+msgid "Music video"
+msgstr "音乐电视"
+
+#: id:20392
+msgid "Remove music video from library"
+msgstr "从资料库移除音乐电视"
+
+#: id:20393
+msgctxt "Auto context with id 20393"
+msgid "Music video information"
+msgstr "音乐电视信息"
+
+#: id:20394
+msgid "Loading music video information"
+msgstr "载入音乐电视信息"
+
+#: id:20395
+msgid "Mixed"
+msgstr "混合"
+
+#: id:20396
+msgid "Go to albums by artist"
+msgstr "按艺人进入专辑"
+
+#: id:20397
+msgid "Go to album"
+msgstr "进入专辑"
+
+#: id:20398
+msgid "Play song"
+msgstr "播放歌曲"
+
+#: id:20399
+msgid "Go to music videos from album"
+msgstr "从专辑进入音乐电视"
+
+#: id:20400
+msgid "Go to music videos by artist"
+msgstr "按艺人进入音乐电视"
+
+#: id:20401
+msgid "Play music video"
+msgstr "播放音乐电视"
+
+#: id:20402
+msgid "Download actor thumbnails when adding to library"
+msgstr "加入资料库时下载演员缩略图"
+
+#: id:20403
+msgid "Set actor thumb"
+msgstr "设置演员缩略图"
+
+#: id:20405
+msgid "Remove episode bookmark"
+msgstr "移除分集书签"
+
+#: id:20406
+msgid "Set episode bookmark"
+msgstr "设置分集书签"
+
+#: id:20407
+msgid "Scraper settings"
+msgstr "刮削器设置"
+
+#: id:20408
+msgid "Downloading music video information"
+msgstr "下载音乐电视信息"
+
+#: id:20409
+msgid "Downloading TV show information"
+msgstr "下载剧集信息"
+
+#: id:20410
+msgid "Trailer"
+msgstr "预告片"
+
+#: id:20411
+msgid "Flatten"
+msgstr "简捷查看"
+
+#: id:20412
+msgid "Flatten TV shows"
+msgstr "简捷查看剧集"
+
+#: id:20413
+msgid "Get fanart"
+msgstr "获取同人画"
+
+#: id:20414
+msgid "Show Fanart in video and music libraries"
+msgstr "在影音库和中显示同人画"
+
+#: id:20415
+msgid "Scanning for new content"
+msgstr "扫描新内容"
+
+#: id:20416
+msgid "First aired"
+msgstr "最初发表"
+
+#: id:20417
+msgid "Writer"
+msgstr "编剧"
+
+#: id:20419
+msgid "Replace file names with library titles"
+msgstr "用资料库标题替换文件名"
+
+#: id:20420
+msgctxt "Auto context with id 20420"
+msgid "Never"
+msgstr "从不"
+
+#: id:20421
+msgid "If only one season"
+msgstr "如果只有一季"
+
+#: id:20422
+msgid "Always"
+msgstr "总是"
+
+#: id:20423
+msgid "Has trailer"
+msgstr "有预告片"
+
+#: id:20424
+msgid "False"
+msgstr "假"
+
+#: id:20425
+msgid "Fanart slideshow"
+msgstr "幻灯播放同人画"
+
+#: id:20426
+msgid "Export to a single file or separate"
+msgstr "导出到单个文件或多个文件"
+
+#: id:20427
+msgid "files per entry?"
+msgstr "每个文件项目数？"
+
+#: id:20428
+msgid "Single file"
+msgstr "单个文件"
+
+#: id:20429
+msgctxt "Auto context with id 20429"
+msgid "Separate"
+msgstr "多文件"
+
+#: id:20430
+msgid "Export thumbnails and fanart?"
+msgstr "导出缩略图和同人画？"
+
+#: id:20431
+msgid "Overwrite old files?"
+msgstr "覆盖原文件？"
+
+#: id:20432
+msgid "Exclude path from library updates"
+msgstr "资料库更新时排除的路径"
+
+#: id:20433
+msgid "Extract thumbnails and video information"
+msgstr "提取缩略图和媒体标识"
+
+#: id:20434
+msgid "Sets"
+msgstr "影片集"
+
+#: id:20435
+msgid "Set movieset thumb"
+msgstr "设置影片集缩略图"
+
+#: id:20436
+msgid "Export actor thumbs?"
+msgstr "导出演员缩略图？"
+
+#: id:20437
+msgid "Choose fanart"
+msgstr "选择同人画"
+
+#: id:20438
+msgid "Local fanart"
+msgstr "本地同人画"
+
+#: id:20439
+msgid "No fanart"
+msgstr "无同人画"
+
+#: id:20440
+msgid "Current fanart"
+msgstr "当前同人画"
+
+#: id:20441
+msgid "Remote fanart"
+msgstr "远程同人画"
+
+#: id:20442
+msgid "Change content"
+msgstr "更新内容"
+
+#: id:20443
+msgid "Do you want to refresh info for all"
+msgstr "要刷新此目录下的"
+
+#: id:20444
+msgid "items within this path?"
+msgstr "所有项目吗？"
+
+#: id:20445
+msgid "Fanart"
+msgstr "同人画"
+
+#: id:20446
+msgid "Locally stored information found."
+msgstr "发现本地存储的信息。"
+
+#: id:20447
+msgid "Ignore and refresh from internet?"
+msgstr "忽略并从互联网刷新吗？"
+
+#: id:20448
+msgid "Could not download information"
+msgstr "无法下载信息"
+
+#: id:20449
+msgid "Unable to connect to remote server"
+msgstr "无法连接远程服务器"
+
+#: id:20450
+msgid "Would you like to continue scanning?"
+msgstr "要继续扫描吗？"
+
+#: id:20451
+msgid "Countries"
+msgstr "国家"
+
+#: id:20452
+msgid "episode"
+msgstr "集"
+
+#: id:20453
+msgid "episodes"
+msgstr "集"
+
+#: id:20454
+msgid "Listener"
+msgstr "收听者"
+
+#: id:20455
+msgid "Listeners"
+msgstr "听众"
+
+#: id:20456
+msgid "Set movieset fanart"
+msgstr "设置影片集同人画"
+
+#: id:20457
+msgid "Movie set"
+msgstr "影片集"
+
+#: id:20458
+msgid "Group movies in sets"
+msgstr "电影按影片集分组"
+
+#: id:21330
+msgid "Show hidden files and directories"
+msgstr "显示隐藏文件和目录"
+
+#: id:21331
+msgid "TuxBox client"
+msgstr "TuxBox 客户端"
+
+#: id:21332
+msgid "WARNING: Target TuxBox device is in recording-mode!"
+msgstr "警告：目标 TuxBox 设备正处于录制模式！"
+
+#: id:21333
+msgid "The stream will be stopped!"
+msgstr "流媒体将会被停止！"
+
+#: id:21334
+msgid "Zap to channel: %s failed!"
+msgstr "切换频道：%s 失败！"
+
+#: id:21335
+msgid "Are you sure to start the stream?"
+msgstr "确认是否开始流媒体传输？"
+
+#: id:21336
+msgid "Connecting to: %s"
+msgstr "正在连接：%s"
+
+#: id:21337
+msgid "TuxBox device"
+msgstr "TuxBox 设备"
+
+#: id:21359
+msgid "Add media share..."
+msgstr "添加共享媒体..."
+
+#: id:21360
+msgid "Share video and music libraries through UPnP"
+msgstr "通过 UPnP 共享视频和音乐库"
+
+#: id:21364
+msgid "Edit media share"
+msgstr "编辑媒体共享"
+
+#: id:21365
+msgid "Remove media share"
+msgstr "移除媒体共享"
+
+#: id:21366
+msgid "Subtitle folder"
+msgstr "字幕目录"
+
+#: id:21367
+msgid "Movie & alternate subtitle directory"
+msgstr "视频和备用字幕目录"
+
+#: id:21368
+msgid "Override ASS/SSA subtitles fonts"
+msgstr "取代 ASS/SSA 字幕字体"
+
+#: id:21369
+msgid "Enable mouse and Touch Screen support"
+msgstr "启用鼠标和触摸屏支持"
+
+#: id:21370
+msgid "Play navigation sounds during media playback"
+msgstr "在播放媒体文件时播放导航声效"
+
+#: id:21371
+msgid "Thumbnail"
+msgstr "缩略图"
+
+#: id:21372
+msgid "Forced DVD player region"
+msgstr "强制 DVD 播放器区码"
+
+#: id:21373
+msgid "Video output"
+msgstr "视频输出"
+
+#: id:21374
+msgid "Video aspect"
+msgstr "视频模式"
+
+#: id:21375
+msgctxt "Auto context with id 21375"
+msgid "Normal"
+msgstr "一般"
+
+#: id:21376
+msgid "Letterbox"
+msgstr "信箱模式"
+
+#: id:21377
+msgid "Widescreen"
+msgstr "宽屏幕"
+
+#: id:21378
+msgid "Enable 480p"
+msgstr "开启 480p"
+
+#: id:21379
+msgid "Enable 720p"
+msgstr "开启 720p"
+
+#: id:21380
+msgid "Enable 1080i"
+msgstr "开启 1080i"
+
+#: id:21381
+msgid "Enter name of new playlist"
+msgstr "输入新播放列表的名称"
+
+#: id:21382
+msgid "Show \"Add source\" buttons in file lists"
+msgstr "在文件列表中显示“添加目录”按钮"
+
+#: id:21383
+msgid "Enable scrollbars"
+msgstr "启用滚动条"
+
+#: id:21384
+msgid "Make watched filtering a toggle in video library"
+msgstr "视频资料库使用浏览过滤按钮"
+
+#: id:21385
+msgctxt "Auto context with id 21385"
+msgid "Open"
+msgstr "打开"
+
+#: id:21386
+msgid "Acoustic management level"
+msgstr "噪音管理"
+
+#: id:21387
+msgid "Fast"
+msgstr "快速"
+
+#: id:21388
+msgid "Quiet"
+msgstr "安静"
+
+#: id:21389
+msgid "Enable custom background"
+msgstr "启用自定义背景"
+
+#: id:21390
+msgid "Power management level"
+msgstr "电源管理"
+
+#: id:21391
+msgid "High power"
+msgstr "高功率"
+
+#: id:21392
+msgid "Low power"
+msgstr "低功率"
+
+#: id:21393
+msgid "High standby"
+msgstr "高待机"
+
+#: id:21394
+msgid "Low standby"
+msgstr "低待机"
+
+#: id:21395
+msgid "Unable to cache files bigger than 4GB"
+msgstr "缓存档不能超过4GB"
+
+#: id:21396
+msgid "Chapter"
+msgstr "章"
+
+#: id:21397
+msgid "High quality pixel shader v2"
+msgstr "高品质像素着色器 V2"
+
+#: id:21398
+msgid "Enable playlist at startup"
+msgstr "启用启动时自动播放播放列表"
+
+#: id:21399
+msgid "Use tween animations"
+msgstr "使用 Tween 动画效果"
+
+#: id:21400
+msgid "contains"
+msgstr "包含"
+
+#: id:21401
+msgid "does not contain"
+msgstr "未包含"
+
+#: id:21402
+msgid "is"
+msgstr "是"
+
+#: id:21403
+msgid "is not"
+msgstr "不是"
+
+#: id:21404
+msgid "starts with"
+msgstr "开始于"
+
+#: id:21405
+msgid "ends with"
+msgstr "中止于"
+
+#: id:21406
+msgid "greater than"
+msgstr "大于"
+
+#: id:21407
+msgid "less than"
+msgstr "小于"
+
+#: id:21408
+msgid "after"
+msgstr "之后"
+
+#: id:21409
+msgid "before"
+msgstr "之前"
+
+#: id:21410
+msgid "in the last"
+msgstr "最后"
+
+#: id:21411
+msgid "not in the last"
+msgstr "非最后"
+
+#: id:21412
+msgid "Scrapers"
+msgstr "刮削器"
+
+#: id:21413
+msgid "Default movie scraper"
+msgstr "默认电影刮削器"
+
+#: id:21414
+msgid "Default tvshow scraper"
+msgstr "默认剧集刮削器"
+
+#: id:21415
+msgid "Default music video scraper"
+msgstr "默认音乐电视刮削器"
+
+#: id:21416
+msgid "Enable fallback based on scraper language"
+msgstr "启用基于刮削器语言的回送"
+
+#: id:21417
+msgid "- Settings"
+msgstr "- 设置"
+
+#: id:21418
+msgid "Multilingual"
+msgstr "多语言"
+
+#: id:21419
+msgid "No scrapers present"
+msgstr "没有选定刮削器"
+
+#: id:21420
+msgid "Value to match"
+msgstr "等于"
+
+#: id:21421
+msgid "Smart playlist rule"
+msgstr "智能播放列表规则"
+
+#: id:21422
+msgid "Match items where"
+msgstr "符合条件的歌曲在"
+
+#: id:21423
+msgid "New rule..."
+msgstr "新规则..."
+
+#: id:21424
+msgid "Items must match"
+msgstr "歌曲必须满足"
+
+#: id:21425
+msgid "all of the rules"
+msgstr "所有条件"
+
+#: id:21426
+msgid "one or more of the rules"
+msgstr "一条或多条规则"
+
+#: id:21427
+msgid "Limit to"
+msgstr "限制"
+
+#: id:21428
+msgid "No limit"
+msgstr "无限制"
+
+#: id:21429
+msgid "Order by"
+msgstr "排序"
+
+#: id:21430
+msgid "ascending"
+msgstr "升序"
+
+#: id:21431
+msgid "descending"
+msgstr "降序"
+
+#: id:21432
+msgid "Edit smart playlist"
+msgstr "编辑智能播放列表"
+
+#: id:21433
+msgid "Name of the playlist"
+msgstr "播放列表名称"
+
+#: id:21434
+msgid "Find items where"
+msgstr "查找满足条件的歌曲"
+
+#: id:21435
+msgid "Edit"
+msgstr "编辑"
+
+#: id:21436
+msgid "%i items"
+msgstr "%i首歌曲"
+
+#: id:21437
+msgid "New smart playlist..."
+msgstr "新的智能播放列表..."
+
+#: id:21438
+msgid "%c Drive"
+msgstr "%c磁盘"
+
+#: id:21439
+msgid "Edit party mode rules"
+msgstr "编辑舞会模式规则"
+
+#: id:21440
+msgid "Home folder"
+msgstr "Home文件夹"
+
+#: id:21441
+msgid "Watched count"
+msgstr "观看次数"
+
+#: id:21442
+msgid "Episode title"
+msgstr "插曲标题"
+
+#: id:21443
+msgid "Video resolution"
+msgstr "视频分辨率"
+
+#: id:21444
+msgid "Audio channels"
+msgstr "音频声道数"
+
+#: id:21445
+msgid "Video codec"
+msgstr "视频编码"
+
+#: id:21446
+msgid "Audio codec"
+msgstr "音频编码"
+
+#: id:21447
+msgid "Audio language"
+msgstr "对白语言"
+
+#: id:21448
+msgid "Subtitle language"
+msgstr "字幕语言"
+
+#: id:21449
+msgid "Remote control sends keyboard presses"
+msgstr "摇控器发送键盘按键"
+
+#: id:21450
+msgid "- Edit"
+msgstr "- 编辑"
+
+#: id:21451
+msgid "Internet connection required."
+msgstr "需要访问互联网。"
+
+#: id:21452
+msgid "Get More..."
+msgstr "获取更多..."
+
+#: id:21453
+msgid "Root filesystem"
+msgstr "根文件系统"
+
+#: id:21454
+msgid "Cache full"
+msgstr "缓存满"
+
+#: id:21455
+msgid "Cache filled before reaching required amount for continous playback"
+msgstr "缓存在达到连续播放所需数量之前已满"
+
+#: id:21460
+msgid "Subtitle location"
+msgstr "字幕位置"
+
+#: id:21461
+msgid "Fixed"
+msgstr "固定"
+
+#: id:21462
+msgid "Bottom of video"
+msgstr "视频内底部"
+
+#: id:21463
+msgid "Below video"
+msgstr "视频外下方"
+
+#: id:21464
+msgid "Top of video"
+msgstr "视频内顶部"
+
+#: id:21465
+msgid "Above video"
+msgstr "视频外上方"
+
+#: id:21800
+msgid "File name"
+msgstr "文件名称"
+
+#: id:21801
+msgid "File path"
+msgstr "文件路径"
+
+#: id:21802
+msgid "File size"
+msgstr "文件大小"
+
+#: id:21803
+msgid "File date/time"
+msgstr "文件日期/时间"
+
+#: id:21804
+msgid "Slide index"
+msgstr "幻灯片索引"
+
+#: id:21805
+msgctxt "Auto context with id 21805"
+msgid "Resolution"
+msgstr "解析度"
+
+#: id:21806
+msgctxt "Auto context with id 21806"
+msgid "Comment"
+msgstr "评论"
+
+#: id:21807
+msgid "Colour/B&W"
+msgstr "彩色/黑白"
+
+#: id:21808
+msgid "JPEG process"
+msgstr "JPEG 影像处理"
+
+#: id:21820
+msgid "Date/Time"
+msgstr "拍摄时间"
+
+#: id:21821
+msgid "Description"
+msgstr "描述"
+
+#: id:21822
+msgid "Camera make"
+msgstr "制造厂商"
+
+#: id:21823
+msgid "Camera model"
+msgstr "相机型号"
+
+#: id:21824
+msgid "EXIF comment"
+msgstr "EXIF 注释"
+
+#: id:21825
+msgid "Firmware"
+msgstr "固件"
+
+#: id:21826
+msgid "Aperture"
+msgstr "光圈值"
+
+#: id:21827
+msgid "Focal length"
+msgstr "镜头焦长"
+
+#: id:21828
+msgid "Focus distance"
+msgstr "焦点距离"
+
+#: id:21829
+msgid "Exposure"
+msgstr "曝光"
+
+#: id:21830
+msgid "Exposure time"
+msgstr "曝光时间"
+
+#: id:21831
+msgid "Exposure bias"
+msgstr "曝光倾向"
+
+#: id:21832
+msgid "Exposure mode"
+msgstr "曝光模式"
+
+#: id:21833
+msgid "Flash used"
+msgstr "闪光灯"
+
+#: id:21834
+msgid "White-balance"
+msgstr "白平衡"
+
+#: id:21835
+msgid "Light source"
+msgstr "光源"
+
+#: id:21836
+msgid "Metering mode"
+msgstr "测光模式"
+
+#: id:21837
+msgid "ISO"
+msgstr "ISO 感光值"
+
+#: id:21838
+msgid "Digital zoom"
+msgstr "数位变焦"
+
+#: id:21839
+msgid "CCD width"
+msgstr "CCD 宽度"
+
+#: id:21840
+msgid "GPS latitude"
+msgstr "GPS 纬度"
+
+#: id:21841
+msgid "GPS longitude"
+msgstr "GPS 经度"
+
+#: id:21842
+msgid "GPS altitude"
+msgstr "GPS 高度"
+
+#: id:21843
+msgid "Orientation"
+msgstr "方位"
+
+#: id:21860
+msgid "Supplemental categories"
+msgstr "补充类别"
+
+#: id:21861
+msgid "Keywords"
+msgstr "关键字"
+
+#: id:21862
+msgid "Caption"
+msgstr "说明"
+
+#: id:21863
+msgid "Author"
+msgstr "作者"
+
+#: id:21864
+msgid "Headline"
+msgstr "标题"
+
+#: id:21865
+msgid "Special instructions"
+msgstr "特别指令"
+
+#: id:21866
+msgid "Category"
+msgstr "类别"
+
+#: id:21867
+msgid "Byline"
+msgstr "署名报导"
+
+#: id:21868
+msgid "Byline title"
+msgstr "署名报导标题"
+
+#: id:21869
+msgid "Credit"
+msgstr "信用"
+
+#: id:21870
+msgid "Source"
+msgstr "来源"
+
+#: id:21871
+msgid "Copyright notice"
+msgstr "版权条款"
+
+#: id:21872
+msgid "Object name"
+msgstr "物件名称"
+
+#: id:21873
+msgid "City"
+msgstr "城市"
+
+#: id:21874
+msgid "State"
+msgstr "州"
+
+#: id:21875
+msgctxt "Auto context with id 21875"
+msgid "Country"
+msgstr "国家"
+
+#: id:21876
+msgid "Original Tx Reference"
+msgstr "原始的 Tx 引用"
+
+#: id:21877
+msgid "Date created"
+msgstr "日期建立"
+
+#: id:21878
+msgid "Copyright flag"
+msgstr "版权标志"
+
+#: id:21879
+msgid "Country code"
+msgstr "国家代码"
+
+#: id:21880
+msgid "Reference service"
+msgstr "参考服务"
+
+#: id:21881
+msgid "Allow control of XBMC via UPnP"
+msgstr "允许通过 UPnP 控制 XBMC"
+
+#: id:21882
+msgid "Attempt to skip introduction before DVD menu"
+msgstr "尝试略过介绍直接跳至 DVD 菜单"
+
+#: id:21883
+msgid "Saved music"
+msgstr "保存音乐"
+
+#: id:21884
+msgid "Query info for all artists"
+msgstr "查询所有艺人信息"
+
+#: id:21885
+msgid "Downloading album information"
+msgstr "下载专辑信息"
+
+#: id:21886
+msgid "Downloading artist information"
+msgstr "下载艺人信息"
+
+#: id:21887
+msgid "Biography"
+msgstr "传记"
+
+#: id:21888
+msgid "Discography"
+msgstr "唱片集"
+
+#: id:21889
+msgid "Searching artist"
+msgstr "搜索艺人"
+
+#: id:21890
+msgid "Select artist"
+msgstr "选择艺人"
+
+#: id:21891
+msgctxt "Auto context with id 21891"
+msgid "Artist information"
+msgstr "艺人信息"
+
+#: id:21892
+msgid "Instruments"
+msgstr "乐器"
+
+#: id:21893
+msgid "Born"
+msgstr "出生日期"
+
+#: id:21894
+msgid "Formed"
+msgstr "出道时间"
+
+#: id:21895
+msgid "Themes"
+msgstr "风格"
+
+#: id:21896
+msgid "Disbanded"
+msgstr "解散时间"
+
+#: id:21897
+msgid "Died"
+msgstr "去世时间"
+
+#: id:21898
+msgid "Years active"
+msgstr "活跃年代"
+
+#: id:21899
+msgid "Label"
+msgstr "标签"
+
+#: id:21900
+msgid "Born/Formed"
+msgstr "创建/成型"
+
+#: id:22000
+msgid "Update library on startup"
+msgstr "在启动时更新资料库"
+
+#: id:22001
+msgid "Hide progress of library updates"
+msgstr "隐藏资料库更新进度条"
+
+#: id:22002
+msgid "- DNS suffix"
+msgstr "- DNS 后缀"
+
+#: id:22003
+msgid "%2.3fs"
+msgstr "%2.3f秒"
+
+#: id:22004
+msgid "Delayed by: %2.3fs"
+msgstr "延迟：%2.3f秒"
+
+#: id:22005
+msgid "Ahead by: %2.3fs"
+msgstr "提前：%2.3f秒"
+
+#: id:22006
+msgid "Subtitle offset"
+msgstr "字幕位置"
+
+#: id:22007
+msgid "OpenGL vendor:"
+msgstr "OpenGL 提供商："
+
+#: id:22008
+msgid "OpenGL renderer:"
+msgstr "OpenGL 渲染器："
+
+#: id:22009
+msgid "OpenGL version:"
+msgstr "OpenGL 版本："
+
+#: id:22010
+msgid "GPU temperature:"
+msgstr "显示卡温度："
+
+#: id:22011
+msgid "CPU temperature:"
+msgstr "CPU 温度："
+
+#: id:22012
+msgid "Total memory"
+msgstr "可用内存"
+
+#: id:22013
+msgid "Profile data"
+msgstr "用户配置数据"
+
+#: id:22014
+msgid "Use dim if paused during video playback"
+msgstr "视频播放暂停时画面变暗"
+
+#: id:22015
+msgid "All recordings"
+msgstr "所有记录"
+
+#: id:22016
+msgid "By title"
+msgstr "标题"
+
+#: id:22017
+msgid "By group"
+msgstr "组"
+
+#: id:22018
+msgid "Live channels"
+msgstr "直播频道"
+
+#: id:22019
+msgid "Recordings by title"
+msgstr "录音的标题"
+
+#: id:22020
+msgid "Guide"
+msgstr "节目表"
+
+#: id:22021
+msgid "Allowed error in aspect ratio to minimize black bars"
+msgstr "为减少黑边允许高宽比误差"
+
+#: id:22022
+msgid "Show video files in listings"
+msgstr "在列表中显示视频文件"
+
+#: id:22023
+msgid "DirectX vendor:"
+msgstr "DirectX 提供商："
+
+#: id:22024
+msgid "Direct3D version:"
+msgstr "Direct3D 版本："
+
+#: id:22030
+msgctxt "Auto context with id 22030"
+msgid "Font"
+msgstr "字体"
+
+#: id:22031
+msgctxt "Auto context with id 22031"
+msgid "- Size"
+msgstr "- 尺寸"
+
+#: id:22032
+msgctxt "Auto context with id 22032"
+msgid "- Colours"
+msgstr "- 颜色"
+
+#: id:22033
+msgid "- Charset"
+msgstr "- 字符集"
+
+#: id:22034
+msgid "Export karaoke titles as HTML"
+msgstr "卡拉OK标题导出为 HTML"
+
+#: id:22035
+msgid "Export karaoke titles as CSV"
+msgstr "卡拉OK标题导出为 CSV"
+
+#: id:22036
+msgid "Import karaoke titles..."
+msgstr "导入卡拉OK标题..."
+
+#: id:22037
+msgid "Show song selector automatically"
+msgstr "自动显示歌曲选择"
+
+#: id:22038
+msgid "Export karaoke titles..."
+msgstr "导出卡拉OK标题..."
+
+#: id:22039
+msgid "Enter song number"
+msgstr "输入歌曲编号"
+
+#: id:22040
+msgid "white/green"
+msgstr "白/绿"
+
+#: id:22041
+msgid "white/red"
+msgstr "白/红"
+
+#: id:22042
+msgid "white/blue"
+msgstr "白/兰"
+
+#: id:22043
+msgid "black/white"
+msgstr "黑/白"
+
+#: id:22079
+msgid "Default select action"
+msgstr "默认选择动作"
+
+#: id:22080
+msgid "Choose"
+msgstr "选定"
+
+#: id:22081
+msgid "Show Information"
+msgstr "显示信息"
+
+#: id:22082
+msgid "More..."
+msgstr "更多..."
+
+#: id:22083
+msgid "Play all"
+msgstr "全部播放"
+
+#: id:23049
+msgid "Teletext not available"
+msgstr "图文字幕不可用"
+
+#: id:23050
+msgid "Activate Teletext"
+msgstr "开启图文字幕"
+
+#: id:23051
+msgid "Part %i"
+msgstr "片段 %i"
+
+#: id:23052
+msgid "Buffering %i bytes"
+msgstr "缓存 %i 字节"
+
+#: id:23053
+msgid "Stopping"
+msgstr "停止"
+
+#: id:23054
+msgid "Running"
+msgstr "运行"
+
+#: id:23100
+msgid "External Player Active"
+msgstr "外部播放器激活"
+
+#: id:23101
+msgid "Click OK to terminate the player"
+msgstr "点 OK 关闭播放器"
+
+#: id:23104
+msgid "Click OK when playback has ended"
+msgstr "播放完毕时点 OK"
+
+#: id:24000
+msgid "Add-on"
+msgstr "扩展功能"
+
+#: id:24001
+msgid "Add-ons"
+msgstr "扩展功能"
+
+#: id:24002
+msgid "Add-on options"
+msgstr "扩展功能选项"
+
+#: id:24003
+msgid "Add-on Information"
+msgstr "扩展功能信息"
+
+#: id:24005
+msgctxt "Auto context with id 24005"
+msgid "Media sources"
+msgstr "媒体来源"
+
+#: id:24007
+msgctxt "Auto context with id 24007"
+msgid "Movie information"
+msgstr "电影资料"
+
+#: id:24008
+msgctxt "Auto context with id 24008"
+msgid "Screensaver"
+msgstr "屏幕保护"
+
+#: id:24009
+msgid "Script"
+msgstr "脚本"
+
+#: id:24010
+msgctxt "Auto context with id 24010"
+msgid "Visualization"
+msgstr "可视化效果"
+
+#: id:24011
+msgid "Add-on repository"
+msgstr "扩展功能库"
+
+#: id:24012
+msgctxt "Auto context with id 24012"
+msgid "Subtitles"
+msgstr "字幕"
+
+#: id:24013
+msgid "Lyrics"
+msgstr "歌词"
+
+#: id:24014
+msgid "TV information"
+msgstr "电视资料"
+
+#: id:24015
+msgctxt "Auto context with id 24015"
+msgid "Music video information"
+msgstr "音乐电视资料"
+
+#: id:24016
+msgctxt "Auto context with id 24016"
+msgid "Album information"
+msgstr "专辑资料"
+
+#: id:24017
+msgctxt "Auto context with id 24017"
+msgid "Artist information"
+msgstr "艺人资料"
+
+#: id:24018
+msgctxt "Auto context with id 24018"
+msgid "Services"
+msgstr "服务程序"
+
+#: id:24020
+msgid "Configure"
+msgstr "设置"
+
+#: id:24021
+msgctxt "Auto context with id 24021"
+msgid "Disable"
+msgstr "禁用"
+
+#: id:24022
+msgid "Enable"
+msgstr "启用"
+
+#: id:24023
+msgid "Add-on disabled"
+msgstr "扩展功能已禁用"
+
+#: id:24027
+msgctxt "Auto context with id 24027"
+msgid "Weather"
+msgstr "天气"
+
+#: id:24028
+msgid "Weather.com (standard)"
+msgstr "Weather.com（标准）"
+
+#: id:24030
+msgid "This Add-on can not be configured"
+msgstr "此扩展功能不可设置"
+
+#: id:24031
+msgid "Error loading settings"
+msgstr "读取配置错误"
+
+#: id:24032
+msgid "All Add-ons"
+msgstr "全部扩展功能"
+
+#: id:24033
+msgid "Get Add-ons"
+msgstr "获取扩展功能"
+
+#: id:24034
+msgid "Check for updates"
+msgstr "检查更新"
+
+#: id:24035
+msgid "Force refresh"
+msgstr "强制刷新"
+
+#: id:24036
+msgid "Change log"
+msgstr "更新日志"
+
+#: id:24037
+msgid "Uninstall"
+msgstr "卸载"
+
+#: id:24038
+msgid "Install"
+msgstr "安装"
+
+#: id:24039
+msgid "Disabled Add-ons"
+msgstr "禁用扩展功能"
+
+#: id:24040
+msgid "(Clear the current setting)"
+msgstr "（清除当前设置）"
+
+#: id:24041
+msgid "Install from zip file"
+msgstr "从zip文件安装"
+
+#: id:24042
+msgid "Downloading %i%%"
+msgstr "正在下载 %i%%"
+
+#: id:24043
+msgid "Available Updates"
+msgstr "可更新项"
+
+#: id:24044
+msgid "Dependencies not met"
+msgstr "依赖项目未找到"
+
+#: id:24045
+msgid "Add-on does not have the correct structure"
+msgstr "扩展功能程序结构不完整"
+
+#: id:24046
+msgid "%s is used by the following installed add-on(s)"
+msgstr "下列已安装扩展功能依赖 %s"
+
+#: id:24047
+msgid "This add-on cannot be uninstalled"
+msgstr "此扩展功能无法卸载"
+
+#: id:24048
+msgid "Rollback"
+msgstr "撤消"
+
+#: id:24050
+msgid "Available Add-ons"
+msgstr "可用扩展功能"
+
+#: id:24051
+msgid "Version:"
+msgstr "版本："
+
+#: id:24052
+msgid "Disclaimer"
+msgstr "免责声明"
+
+#: id:24053
+msgid "License:"
+msgstr "许可证："
+
+#: id:24054
+msgid "Changelog"
+msgstr "更新日志"
+
+#: id:24059
+msgid "Would you like to enable this Add-on?"
+msgstr "要启用此扩展功能吗？"
+
+#: id:24060
+msgid "Would you like to disable this Add-on?"
+msgstr "要禁用此扩展功能吗？"
+
+#: id:24061
+msgid "Add-on update available!"
+msgstr "扩展功能有可用更新！"
+
+#: id:24062
+msgid "Enabled Add-ons"
+msgstr "已启用扩展功能"
+
+#: id:24063
+msgid "Auto update"
+msgstr "自动更新"
+
+#: id:24064
+msgid "Add-on enabled"
+msgstr "扩展功能已启用"
+
+#: id:24065
+msgid "Add-on updated"
+msgstr "扩展功能已更新"
+
+#: id:24066
+msgid "Cancel Add-on download?"
+msgstr "取消扩展功能下载？"
+
+#: id:24067
+msgid "Currently downloading Add-ons"
+msgstr "当前下载扩展功能"
+
+#: id:24068
+msgid "Update available"
+msgstr "可更新"
+
+#: id:24069
+msgid "Update"
+msgstr "更新"
+
+#: id:24070
+msgid "Add-on could not be loaded."
+msgstr "无法加载扩展功能"
+
+#: id:24071
+msgid "An unknown error has occurred."
+msgstr "发生未知错误"
+
+#: id:24072
+msgid "Settings required"
+msgstr "需要先进行设置"
+
+#: id:24073
+msgid "Could not connect"
+msgstr "无法连接"
+
+#: id:24074
+msgid "Needs to restart"
+msgstr "需要重新启动"
+
+#: id:24075
+msgctxt "Auto context with id 24075"
+msgid "Disable"
+msgstr "禁用"
+
+#: id:24076
+msgid "Add-on Required"
+msgstr "依赖扩展功能"
+
+#: id:24080
+msgid "Try to reconnect?"
+msgstr "尝试重新连接？"
+
+#: id:24089
+msgid "Add-on restarts"
+msgstr "重新启动扩展功能"
+
+#: id:24090
+msgid "Lock Add-on manager"
+msgstr "锁定扩展功能管理器"
+
+#: id:24094
+msgid "(current)"
+msgstr "（当前使用）"
+
+#: id:24095
+msgid "(blacklisted)"
+msgstr "（列入黑名单）"
+
+#: id:24096
+msgid "Add-on has been marked as broken in repository."
+msgstr "库中的扩展功能被标记为已失效。"
+
+#: id:24097
+msgid "Would you like to disable it on your system?"
+msgstr "要在系统中禁用它吗？"
+
+#: id:24098
+msgid "Broken"
+msgstr "已失效"
+
+#: id:24099
+msgid "Would you like to switch to this skin?"
+msgstr "要切换到此皮肤吗？"
+
+#: id:24100
+msgid "To use this feature you must download an Add-on:"
+msgstr "使用此功能需要下载扩展功能："
+
+#: id:24101
+msgid "Would you like to download this Add-on?"
+msgstr "你确定要下载此扩展功能吗？"
+
+#: id:25000
+msgid "Notifications"
+msgstr "提示信息"
+
+#: id:29800
+msgid "Library Mode"
+msgstr "资料库模式"
+
+#: id:29801
+msgid "QWERTY keyboard"
+msgstr "QWERTY 键盘"
+
+#: id:29802
+msgid "Passthrough Audio in use"
+msgstr "音频直通输出启用中"
+
+#: id:33001
+msgid "Trailer quality"
+msgstr "预告片质量Trailer quality"
+
+#: id:33002
+msgid "Stream"
+msgstr "媒体流"
+
+#: id:33003
+msgid "Download"
+msgstr "下载"
+
+#: id:33004
+msgid "Download & play"
+msgstr "下载 & 播放"
+
+#: id:33005
+msgid "Download & save"
+msgstr "下载 & 保存"
+
+#: id:33006
+msgid "Today"
+msgstr "今天"
+
+#: id:33007
+msgid "Tomorrow"
+msgstr "明天"
+
+#: id:33008
+msgid "Saving"
+msgstr "保存"
+
+#: id:33009
+msgid "Copying"
+msgstr "拷贝"
+
+#: id:33010
+msgid "Set download directory"
+msgstr "设置下载目录"
+
+#: id:33011
+msgid "Search duration"
+msgstr "搜索持续时间"
+
+#: id:33012
+msgid "Short"
+msgstr "短"
+
+#: id:33013
+msgid "Long"
+msgstr "长"
+
+#: id:33014
+msgid "Use DVD player instead of regular player"
+msgstr "用DVD player代替常规播放器"
+
+#: id:33015
+msgid "Ask for download before playing video"
+msgstr "播放视频前揭示是否先下载"
+
+#: id:33016
+msgid "Clips"
+msgstr "片断"
+
+#: id:33017
+msgid "Restart plugin to enable"
+msgstr "重启以启用插件"
+
+#: id:33018
+msgid "Tonight"
+msgstr "今晚"
+
+#: id:33019
+msgid "Tomorrow Night"
+msgstr "明晚"
+
+#: id:33020
+msgid "Condition"
+msgstr "状况"
+
+#: id:33021
+msgid "Precipitation"
+msgstr "降雨量"
+
+#: id:33022
+msgid "Precip"
+msgstr "降雨"
+
+#: id:33023
+msgid "Humid"
+msgstr "潮湿"
+
+#: id:33024
+msgid "Feels"
+msgstr "感觉"
+
+#: id:33025
+msgid "Observed"
+msgstr "观测值"
+
+#: id:33026
+msgid "Departure from normal"
+msgstr "偏离正常值"
+
+#: id:33027
+msgid "Sunrise"
+msgstr "日出"
+
+#: id:33028
+msgid "Sunset"
+msgstr "日落"
+
+#: id:33029
+msgid "Details"
+msgstr "详细资料"
+
+#: id:33030
+msgid "Outlook"
+msgstr "天气趋势"
+
+#: id:33031
+msgid "Coverflow"
+msgstr "流动封面"
+
+#: id:33032
+msgid "Translate text"
+msgstr "翻译文本"
+
+#: id:33033
+msgid "Map list %s category"
+msgstr "地图列表 %s 分类"
+
+#: id:33034
+msgid "36 Hour"
+msgstr "36 小时"
+
+#: id:33035
+msgid "Maps"
+msgstr "地图"
+
+#: id:33036
+msgid "Hourly"
+msgstr "每小时"
+
+#: id:33037
+msgid "Weekend"
+msgstr "周末"
+
+#: id:33038
+msgid "%s day"
+msgstr "%s 天"
+
+#: id:33049
+msgid "Alert"
+msgstr "提醒"
+
+#: id:33050
+msgid "Alerts"
+msgstr "提醒"
+
+#: id:33051
+msgid "Choose Your"
+msgstr "选择您的"
+
+#: id:33052
+msgid "Check"
+msgstr "查看您的"
+
+#: id:33053
+msgctxt "Auto context with id 33053"
+msgid "Configure the"
+msgstr "配置您的"
+
+#: id:33054
+msgid "Seasons"
+msgstr "季节"
+
+#: id:33055
+msgid "Use your"
+msgstr "使用您的"
+
+#: id:33056
+msgid "Watch your"
+msgstr "观看您的"
+
+#: id:33057
+msgid "Listen to"
+msgstr "聆听您的"
+
+#: id:33058
+msgid "View your"
+msgstr "浏览您的"
+
+#: id:33059
+msgctxt "Auto context with id 33059"
+msgid "Configure the"
+msgstr "配置您的"
+
+#: id:33060
+msgid "Power"
+msgstr "电源控制"
+
+#: id:33061
+msgid "Menu"
+msgstr "菜单"
+
+#: id:33062
+msgid "Play the"
+msgstr "播放您的"
+
+#: id:33063
+msgid "Options"
+msgstr "选项"
+
+#: id:33065
+msgid "Editor"
+msgstr "编辑"
+
+#: id:33066
+msgid "About your"
+msgstr "关于您的"
+
+#: id:33067
+msgid "Star rating"
+msgstr "星级"
+
+#: id:33068
+msgid "Background"
+msgstr "桌面背景"
+
+#: id:33069
+msgid "Backgrounds"
+msgstr "桌面背景集"
+
+#: id:33070
+msgid "Custom background"
+msgstr "自定义桌面背景"
+
+#: id:33071
+msgid "Custom backgrounds"
+msgstr "自定义桌面背景集"
+
+#: id:33072
+msgid "View Readme"
+msgstr "浏览自述文件"
+
+#: id:33073
+msgid "View Changelog"
+msgstr "浏览更新记录"
+
+#: id:33074
+msgid "This version of %s requires an"
+msgstr "运行此版本的 %s 需要"
+
+#: id:33075
+msgid "XBMC revision of %s or greater to run."
+msgstr "XBMC为 %s 或更高版本。"
+
+#: id:33076
+msgid "Please update XBMC."
+msgstr "请升级XBMC。"
+
+#: id:33077
+msgid "No data found!"
+msgstr "未找到数据！"
+
+#: id:33078
+msgid "Next page"
+msgstr "下一页"
+
+#: id:33079
+msgid "Love"
+msgstr "爱"
+
+#: id:33080
+msgid "Hate"
+msgstr "恨"
+
+#: id:33081
+msgid "This file is stacked, select the part you want to play from."
+msgstr "这是一个堆叠文件，请选择要播放的片段。"
+
+#: id:33082
+msgid "Path to script"
+msgstr "脚本目录"
+
+#: id:33083
+msgid "Enable custom script button"
+msgstr "启用自定义脚本按钮"
+
+#: id:33100
+msgid "Failed to start"
+msgstr "启动失败"
+
+#: id:33101
+msgid "Webserver"
+msgstr "Web服务器"
+
+#: id:33102
+msgid "Event Server"
+msgstr "事件服务器"
+
+#: id:33103
+msgid "Remote communication server"
+msgstr "远程通信服务器"
+
+#: id:33200
+msgid "Detected New Connection"
+msgstr "检测到新的连接"
+
+#: id:34000
+msgid "Lame"
+msgstr "Lame"
+
+#: id:34001
+msgid "Vorbis"
+msgstr "Vorbis"
+
+#: id:34002
+msgid "Wav"
+msgstr "Wav"
+
+#: id:34003
+msgid "DXVA2"
+msgstr "DXVA2"
+
+#: id:34004
+msgid "VAAPI"
+msgstr "VAAPI"
+
+#: id:34005
+msgid "Flac"
+msgstr "Flac"
+
+#: id:34100
+msgid "Speaker Configuration"
+msgstr "扬声器设置"
+
+#: id:34101
+msgid "2.0"
+msgstr "2.0"
+
+#: id:34102
+msgid "2.1"
+msgstr "2.1"
+
+#: id:34103
+msgid "3.0"
+msgstr "3.0"
+
+#: id:34104
+msgid "3.1"
+msgstr "3.1"
+
+#: id:34105
+msgid "4.0"
+msgstr "4.0"
+
+#: id:34106
+msgid "4.1"
+msgstr "4.1"
+
+#: id:34107
+msgid "5.0"
+msgstr "5.0"
+
+#: id:34108
+msgid "5.1"
+msgstr "5.1"
+
+#: id:34109
+msgid "7.0"
+msgstr "7.0"
+
+#: id:34110
+msgid "7.1"
+msgstr "7.1"
+
+#: id:34201
+msgid "Can't find a next item to play"
+msgstr "未找到下一播放项目"
+
+#: id:34202
+msgid "Can't find a previous item to play"
+msgstr "未找到上一播放项目"
+
+#: id:34300
+msgid "Failed to start zeroconf"
+msgstr "启动 zeroconf 失败"
+
+#: id:34301
+msgid "Is Apple's Bonjour Service installed? See log for more info."
+msgstr "Apple 的 Bonjour 服务是否已安装？更多信息见日志记录。"
+
+#: id:34400
+msgid "Video Rendering"
+msgstr "视频渲染"
+
+#: id:34401
+msgid "Failed to init video filters/scalers, falling back to bilinear scaling"
+msgstr "视频滤镜/缩放器初始化失败，使用双线性缩放"
+
+#: id:34402
+msgid "Failed to initialize audio device"
+msgstr "音频设备初始化失败"
+
+#: id:34403
+msgid "Check your audiosettings"
+msgstr "检查你的音频设置"
+
+#: id:34404
+msgid "Use gestures for navigation:"
+msgstr "使用手势导航："
+
+#: id:34405
+msgid "1 finger swipe left,right,up,down for cursors"
+msgstr "单指左右上下轻扫移动光标"
+
+#: id:34406
+msgid "2 finger swipe left for backspace"
+msgstr "双指向左轻扫退格"
+
+#: id:34407
+msgid "1 finger single tap for enter"
+msgstr "单指单击回车"
+
+#: id:34408
+msgid "2 finger single tap for contextmenu"
+msgstr "双指单击打开上下文菜单"
+
+#: id:35000
+msgid "Peripherals"
+msgstr "外部设备"
+
+#: id:35001
+msgid "Generic HID device"
+msgstr "通用 HID 设备"
+
+#: id:35002
+msgid "Generic network adapter"
+msgstr "通用网络适配器"
+
+#: id:35003
+msgid "Generic disk"
+msgstr "通用硬盘驱动器"
+
+#: id:35004
+msgid "There are no settings available\nfor this peripheral."
+msgstr "此设备无可用设置。"
+
+#: id:35005
+msgid "New device configured"
+msgstr "新设备已配置"
+
+#: id:35006
+msgid "Device removed"
+msgstr "设备已移除"
+
+#: id:35007
+msgid "Keymap to use for this device"
+msgstr "用于此设备的键盘映射"
+
+#: id:35008
+msgid "Keymap enabled"
+msgstr "键盘映射已启用"
+
+#: id:35009
+msgid "Do not use the custom keymap for this device"
+msgstr "此设备不使用自定义键盘映射"
+
+#: id:35500
+msgid "Location"
+msgstr "位置"
+
+#: id:35501
+msgid "Class"
+msgstr "设备类型"
+
+#: id:35502
+msgctxt "Auto context with id 35502"
+msgid "Name"
+msgstr "名称"
+
+#: id:35503
+msgid "Vendor"
+msgstr "提供商"
+
+#: id:35504
+msgid "Product ID"
+msgstr "产品 ID"
+
+#: id:36000
+msgid "Pulse-Eight CEC adapter"
+msgstr "Pulse-Eight CEC 适配器"
+
+#: id:36001
+msgid "Pulse-Eight Nyxboard"
+msgstr "Pulse-Eight Nyxboard"
+
+#: id:36002
+msgid "Switch to keyboard side command"
+msgstr "切换到键盘指令"
+
+#: id:36003
+msgid "Switch to remote side command"
+msgstr "切换到遥控器指令"
+
+#: id:36004
+msgid "Press \"user\" button command"
+msgstr "按“user”键指令"
+
+#: id:36005
+msgid "Enable switch side commands"
+msgstr "启用指令模式切换"
+
+#: id:36006
+msgid "Could not open the adapter"
+msgstr "无法打开适配器"
+
+#: id:36007
+msgid "Devices to power on when starting XBMC"
+msgstr "启动XBMC时开启的设备"
+
+#: id:36008
+msgid "Devices to power off when stopping XBMC"
+msgstr "退出XBMC时关闭的设备"
+
+#: id:36009
+msgid "Put devices in standby mode when activating screensaver"
+msgstr "激活屏幕保护程序时设备进入待机状态"
+
+#: id:36011
+msgid "Could not detect the CEC port. Set it up manually."
+msgstr "未检测到 CEC 端口。需人工设置。"
+
+#: id:36012
+msgid "Could not initialise the CEC adapter. Check your settings."
+msgstr "无法初始化 CEC 适配器。请检查设置"
+
+#: id:36013
+msgid "Unsupported libCEC interface version. %d is greater than the version XBMC supports (%d)"
+msgstr "不支持的 libcec 界面版本。%d 高于 XBMC 支持的版本（%d）"
+
+#: id:36014
+msgid "Put this PC in standby mode when the TV is switched off"
+msgstr "电视关闭时本计算机进入待机状态"
+
+#: id:36015
+msgid "HDMI port number"
+msgstr "HDMI 端口号"
+
+#: id:36016
+msgctxt "Auto context with id 36016"
+msgid "Connected"
+msgstr "XBMC 已连接"
+
+#: id:36017
+msgid "Adapter found, but libCEC is not available"
+msgstr "发现适配器，但 libCEC 不可用"
+
+#: id:36018
+msgid "Use the TV's language setting"
+msgstr "使用电视机语言设置"
+
+#: id:36019
+msgid "Connected to HDMI device"
+msgstr "已连接到 HDMI 设备"
+
+#: id:36020
+msgid "Make XBMC the active source when starting"
+msgstr "启动时让 XBMC 为活动源"
+
+#: id:36021
+msgid "Physical address (overrules HDMI port)"
+msgstr "物理地址（取代 HDMI 端口）"
+
+#: id:36022
+msgid "COM port (leave empty unless needed)"
+msgstr "COM 端口（留空，除非需要）"
+
+#: id:36023
+msgid "Configuration updated"
+msgstr "配置已更新"
+
+#: id:36024
+msgid "Failed to set the new configuration. Please check your settings."
+msgstr "新配置设定失败，请检查设置。"
+
+#: id:36025
+msgid "Send 'inactive source' command when stopping XBMC"
+msgstr "停止 XBMC 时发送“非活动源”命令"
+

--- a/language/Chinese (Traditional)/strings.po
+++ b/language/Chinese (Traditional)/strings.po
@@ -1,0 +1,9093 @@
+# Converted from xbmc strings.xml with xbmc-xml2po (by Team-XBMC)
+msgid ""
+msgstr ""
+"Project-Id-Version: xbmc.core-FRODO_GIT3ed1604ad7\n"
+"Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
+"POT-Creation-Date: 2012-04-09 18:00+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE\n"
+"Language: zh_CN\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: id:0
+msgctxt "Auto context with id 0"
+msgid "Programs"
+msgstr "程式"
+
+#: id:1
+msgctxt "Auto context with id 1"
+msgid "Pictures"
+msgstr "圖片"
+
+#: id:2
+msgctxt "Auto context with id 2"
+msgid "Music"
+msgstr "音樂"
+
+#: id:3
+msgctxt "Auto context with id 3"
+msgid "Videos"
+msgstr "視訊"
+
+#: id:4
+msgid "TV-Guide"
+msgstr "電視頻道"
+
+#: id:5
+msgctxt "Auto context with id 5"
+msgid "Settings"
+msgstr "系統設定"
+
+#: id:6
+msgid "XBMC SVN"
+msgstr "XBMC SVN"
+
+#: id:7
+msgctxt "Auto context with id 7"
+msgid "File manager"
+msgstr "檔案總管"
+
+#: id:8
+msgctxt "Auto context with id 8"
+msgid "Weather"
+msgstr "氣象"
+
+#: id:9
+msgid "xbmc media center"
+msgstr "xbmc 媒體中心"
+
+#: id:11
+msgid "Monday"
+msgstr "星期一"
+
+#: id:12
+msgid "Tuesday"
+msgstr "星期二"
+
+#: id:13
+msgid "Wednesday"
+msgstr "星期三"
+
+#: id:14
+msgid "Thursday"
+msgstr "星期四"
+
+#: id:15
+msgid "Friday"
+msgstr "星期五"
+
+#: id:16
+msgid "Saturday"
+msgstr "星期六"
+
+#: id:17
+msgid "Sunday"
+msgstr "星期日"
+
+#: id:21
+msgid "January"
+msgstr "一月"
+
+#: id:22
+msgid "February"
+msgstr "二月"
+
+#: id:23
+msgid "March"
+msgstr "三月"
+
+#: id:24
+msgid "April"
+msgstr "四月"
+
+#: id:25
+msgctxt "Auto context with id 25"
+msgid "May"
+msgstr "五月"
+
+#: id:26
+msgid "June"
+msgstr "六月"
+
+#: id:27
+msgid "July"
+msgstr "七月"
+
+#: id:28
+msgid "August"
+msgstr "八月"
+
+#: id:29
+msgid "September"
+msgstr "九月"
+
+#: id:30
+msgid "October"
+msgstr "十月"
+
+#: id:31
+msgid "November"
+msgstr "十一月"
+
+#: id:32
+msgid "December"
+msgstr "十二月"
+
+#: id:41
+msgid "Mon"
+msgstr "周一"
+
+#: id:42
+msgid "Tue"
+msgstr "周二"
+
+#: id:43
+msgid "Wed"
+msgstr "周三"
+
+#: id:44
+msgid "Thu"
+msgstr "周四"
+
+#: id:45
+msgid "Fri"
+msgstr "周五"
+
+#: id:46
+msgid "Sat"
+msgstr "周六"
+
+#: id:47
+msgctxt "Auto context with id 47"
+msgid "Sun"
+msgstr "周日"
+
+#: id:51
+msgid "Jan"
+msgstr "1月"
+
+#: id:52
+msgid "Feb"
+msgstr "2月"
+
+#: id:53
+msgid "Mar"
+msgstr "3月"
+
+#: id:54
+msgid "Apr"
+msgstr "4月"
+
+#: id:55
+msgctxt "Auto context with id 55"
+msgid "May"
+msgstr "5月"
+
+#: id:56
+msgid "Jun"
+msgstr "6月"
+
+#: id:57
+msgid "Jul"
+msgstr "7月"
+
+#: id:58
+msgid "Aug"
+msgstr "8月"
+
+#: id:59
+msgid "Sep"
+msgstr "9月"
+
+#: id:60
+msgid "Oct"
+msgstr "10月"
+
+#: id:61
+msgid "Nov"
+msgstr "11月"
+
+#: id:62
+msgid "Dec"
+msgstr "12月"
+
+#: id:71
+msgid "N"
+msgstr "北"
+
+#: id:72
+msgid "NNE"
+msgstr "北北東"
+
+#: id:73
+msgid "NE"
+msgstr "東北"
+
+#: id:74
+msgid "ENE"
+msgstr "東北東"
+
+#: id:75
+msgid "E"
+msgstr "東"
+
+#: id:76
+msgid "ESE"
+msgstr "東南東"
+
+#: id:77
+msgid "SE"
+msgstr "東南"
+
+#: id:78
+msgid "SSE"
+msgstr "南南東"
+
+#: id:79
+msgid "S"
+msgstr "南"
+
+#: id:80
+msgid "SSW"
+msgstr "南南西"
+
+#: id:81
+msgid "SW"
+msgstr "西南"
+
+#: id:82
+msgid "WSW"
+msgstr "西南西"
+
+#: id:83
+msgid "W"
+msgstr "西"
+
+#: id:84
+msgid "WNW"
+msgstr "西北西"
+
+#: id:85
+msgid "NW"
+msgstr "西北"
+
+#: id:86
+msgid "NNW"
+msgstr "北北西"
+
+#: id:87
+msgid "VAR"
+msgstr "多方向"
+
+#: id:98
+msgid "View: Auto"
+msgstr "顯示：自動"
+
+#: id:99
+msgid "View: Auto big"
+msgstr "顯示：自動大圖示"
+
+#: id:100
+msgid "View: Icons"
+msgstr "顯示：圖示"
+
+#: id:101
+msgid "View: List"
+msgstr "顯示：列表"
+
+#: id:102
+msgctxt "Auto context with id 102"
+msgid "Scan"
+msgstr "搜尋"
+
+#: id:103
+msgctxt "Auto context with id 103"
+msgid "Sort by: Name"
+msgstr "排序：名稱"
+
+#: id:104
+msgid "Sort by: Date"
+msgstr "排序：日期"
+
+#: id:105
+msgid "Sort by: Size"
+msgstr "排序：大小"
+
+#: id:106
+msgid "No"
+msgstr "否"
+
+#: id:107
+msgid "Yes"
+msgstr "是"
+
+#: id:108
+msgctxt "Auto context with id 108"
+msgid "Slideshow"
+msgstr "播放圖片"
+
+#: id:109
+msgid "Create thumbs"
+msgstr "建立縮圖"
+
+#: id:110
+msgid "Create thumbnails"
+msgstr "建立縮略圖"
+
+#: id:111
+msgctxt "Auto context with id 111"
+msgid "Shortcuts"
+msgstr "捷徑"
+
+#: id:112
+msgid "Paused"
+msgstr "暫停"
+
+#: id:113
+msgid "Update failed"
+msgstr "更新失敗"
+
+#: id:114
+msgid "Installation failed"
+msgstr "安裝失敗"
+
+#: id:115
+msgid "Copy"
+msgstr "複製"
+
+#: id:116
+msgid "Move"
+msgstr "移動"
+
+#: id:117
+msgid "Delete"
+msgstr "刪除"
+
+#: id:118
+msgid "Rename"
+msgstr "重新命名"
+
+#: id:119
+msgid "New folder"
+msgstr "新資料夾"
+
+#: id:120
+msgid "Confirm file copy"
+msgstr "確認複製檔案"
+
+#: id:121
+msgid "Confirm file move"
+msgstr "確認移動檔案"
+
+#: id:122
+msgid "Confirm file delete?"
+msgstr "確認刪除檔案？"
+
+#: id:123
+msgid "Copy these files?"
+msgstr "複製這些檔案？"
+
+#: id:124
+msgid "Move these files?"
+msgstr "移動這些檔案？"
+
+#: id:125
+msgid "Delete these files? - Deleting files cannot be undone!"
+msgstr "刪除這些檔案？ - 刪除後將無法復原！"
+
+#: id:126
+msgid "Status"
+msgstr "狀態"
+
+#: id:127
+msgid "Objects"
+msgstr "項目"
+
+#: id:128
+msgctxt "Auto context with id 128"
+msgid "General"
+msgstr "一般設定"
+
+#: id:129
+msgctxt "Auto context with id 129"
+msgid "Slideshow"
+msgstr "播放圖片"
+
+#: id:130
+msgctxt "Auto context with id 130"
+msgid "System info"
+msgstr "系統資訊"
+
+#: id:131
+msgid "Display"
+msgstr "螢幕"
+
+#: id:132
+msgid "Albums"
+msgstr "專輯"
+
+#: id:133
+msgid "Artists"
+msgstr "藝人"
+
+#: id:134
+msgid "Songs"
+msgstr "歌曲"
+
+#: id:135
+msgid "Genres"
+msgstr "類別"
+
+#: id:136
+msgid "Playlists"
+msgstr "播放列表"
+
+#: id:137
+msgid "Search"
+msgstr "搜尋"
+
+#: id:138
+msgid "System Information"
+msgstr "系統資訊"
+
+#: id:139
+msgid "Temperatures:"
+msgstr "溫度："
+
+#: id:140
+msgid "CPU:"
+msgstr "CPU："
+
+#: id:141
+msgid "GPU:"
+msgstr "GPU："
+
+#: id:142
+msgid "Time:"
+msgstr "時間："
+
+#: id:143
+msgid "Current:"
+msgstr "目前："
+
+#: id:144
+msgid "Build:"
+msgstr "版本："
+
+#: id:145
+msgid "Network:"
+msgstr "網路："
+
+#: id:146
+msgid "Type:"
+msgstr "類型："
+
+#: id:147
+msgid "Static"
+msgstr "靜態(手動分配)"
+
+#: id:148
+msgid "DHCP"
+msgstr "動態(自動分配)"
+
+#: id:149
+msgid "MAC address"
+msgstr "網卡位址(MAC)"
+
+#: id:150
+msgctxt "Auto context with id 150"
+msgid "IP address"
+msgstr "IP 位址"
+
+#: id:151
+msgid "Link:"
+msgstr "連接："
+
+#: id:152
+msgid "Half duplex"
+msgstr "半雙工"
+
+#: id:153
+msgid "Full duplex"
+msgstr "全雙工"
+
+#: id:154
+msgctxt "Auto context with id 154"
+msgid "Storage"
+msgstr "儲存裝置"
+
+#: id:155
+msgid "Drive"
+msgstr "裝置"
+
+#: id:156
+msgctxt "Auto context with id 156"
+msgid "Free"
+msgstr "可用"
+
+#: id:157
+msgctxt "Auto context with id 157"
+msgid "Video"
+msgstr "視訊"
+
+#: id:158
+msgid "Free memory"
+msgstr "可用記憶體"
+
+#: id:159
+msgid "No link"
+msgstr "未連接"
+
+#: id:160
+msgctxt "Auto context with id 160"
+msgid "Free"
+msgstr "可用"
+
+#: id:161
+msgid "Unavailable"
+msgstr "沒有"
+
+#: id:162
+msgid "Tray open"
+msgstr "托盤開啟"
+
+#: id:163
+msgid "Reading"
+msgstr "讀取中"
+
+#: id:164
+msgid "No disc"
+msgstr "無光碟"
+
+#: id:165
+msgid "Disc present"
+msgstr "光碟介紹"
+
+#: id:166
+msgid "Skin"
+msgstr "佈景主題"
+
+#: id:169
+msgctxt "Auto context with id 169"
+msgid "Resolution"
+msgstr "解析度"
+
+#: id:170
+msgid "Adjust display refresh rate to match video"
+msgstr "調整視訊更新頻率以符合視訊"
+
+#: id:172
+msgid "Release date"
+msgstr "發行日期"
+
+#: id:173
+msgid "Display 4:3 videos as"
+msgstr "播放4:3影片的方式"
+
+#: id:175
+msgid "Moods"
+msgstr "主題"
+
+#: id:176
+msgid "Styles"
+msgstr "風格"
+
+#: id:179
+msgid "Song"
+msgstr "歌曲"
+
+#: id:180
+msgid "Duration"
+msgstr "持續時間"
+
+#: id:181
+msgid "Select album"
+msgstr "選擇專輯"
+
+#: id:182
+msgid "Tracks"
+msgstr "音軌"
+
+#: id:183
+msgid "Review"
+msgstr "評論"
+
+#: id:184
+msgid "Refresh"
+msgstr "重新整理"
+
+#: id:185
+msgid "Searching album"
+msgstr "搜尋專輯"
+
+#: id:186
+msgid "OK"
+msgstr "OK"
+
+#: id:187
+msgid "No albums found!"
+msgstr "找不到專輯！"
+
+#: id:188
+msgid "Select all"
+msgstr "全選"
+
+#: id:189
+msgid "Scanning media info"
+msgstr "搜尋媒體資訊"
+
+#: id:190
+msgid "Save"
+msgstr "儲存"
+
+#: id:191
+msgid "Shuffle"
+msgstr "隨機"
+
+#: id:192
+msgctxt "Auto context with id 192"
+msgid "Clear"
+msgstr "清除"
+
+#: id:193
+msgctxt "Auto context with id 193"
+msgid "Scan"
+msgstr "搜尋"
+
+#: id:194
+msgid "Searching..."
+msgstr "搜尋中…"
+
+#: id:195
+msgid "No info found!"
+msgstr "找不到資訊！"
+
+#: id:196
+msgid "Select movie:"
+msgstr "選擇影片："
+
+#: id:197
+msgid "Querying %s info"
+msgstr "讀取 %s 資訊"
+
+#: id:198
+msgid "Loading movie details"
+msgstr "載入影片詳細資料"
+
+#: id:199
+msgid "Web interface"
+msgstr "Web 介面"
+
+#: id:202
+msgid "Tagline"
+msgstr "標題"
+
+#: id:203
+msgid "Plot outline"
+msgstr "大綱"
+
+#: id:205
+msgid "Votes"
+msgstr "得票："
+
+#: id:206
+msgid "Cast"
+msgstr "演員表"
+
+#: id:207
+msgid "Plot"
+msgstr "簡介"
+
+#: id:208
+msgctxt "Auto context with id 208"
+msgid "Play"
+msgstr "播放"
+
+#: id:209
+msgid "Next"
+msgstr "向後"
+
+#: id:210
+msgid "Previous"
+msgstr "向前"
+
+#: id:213
+msgid "Calibrate user interface..."
+msgstr "使用者界面校正…"
+
+#: id:214
+msgid "Video calibration..."
+msgstr "視訊校正…"
+
+#: id:215
+msgid "Soften"
+msgstr "柔化"
+
+#: id:216
+msgid "Zoom amount"
+msgstr "縮放"
+
+#: id:217
+msgid "Pixel ratio"
+msgstr "畫面比率"
+
+#: id:218
+msgid "DVD drive"
+msgstr "光碟機"
+
+#: id:219
+msgid "Please insert disc"
+msgstr "請放入光碟"
+
+#: id:220
+msgid "Remote share"
+msgstr "遠端共享"
+
+#: id:221
+msgid "Network is not connected"
+msgstr "網路未連線"
+
+#: id:222
+msgid "Cancel"
+msgstr "取消"
+
+#: id:224
+msgid "Speed"
+msgstr "速度"
+
+#: id:225
+msgid "Vertical Shift"
+msgstr "垂直位移"
+
+#: id:226
+msgid "Test patterns..."
+msgstr "測試圖案…"
+
+#: id:227
+msgid "Lookup audio CD track names from freedb.org"
+msgstr "在 freedb 查詢音樂 CD 資訊"
+
+#: id:228
+msgid "Shuffle playlist on load"
+msgstr "隨機播放列表"
+
+#: id:229
+msgid "HDD spindown time"
+msgstr "硬碟省電模式"
+
+#: id:230
+msgid "Video filters"
+msgstr "視訊濾鏡"
+
+#: id:231
+msgctxt "Auto context with id 231"
+msgid "None"
+msgstr "無"
+
+#: id:232
+msgid "Point"
+msgstr "點"
+
+#: id:233
+msgid "Linear"
+msgstr "條紋"
+
+#: id:234
+msgid "Anisotropic"
+msgstr "非等方性"
+
+#: id:235
+msgid "Quincunx"
+msgstr "梅花多重取樣"
+
+#: id:236
+msgid "Gaussian cubic"
+msgstr "三維銳化"
+
+#: id:237
+msgid "Minification"
+msgstr "縮小"
+
+#: id:238
+msgid "Magnification"
+msgstr "放大"
+
+#: id:239
+msgid "Clear playlist on finish"
+msgstr "播放完成後清除列表"
+
+#: id:240
+msgid "Display Mode"
+msgstr "顯示模式"
+
+#: id:241
+msgid "Full Screen #%d"
+msgstr "全螢幕 #%d"
+
+#: id:242
+msgid "Windowed"
+msgstr "視窗"
+
+#: id:243
+msgid "Refresh Rate"
+msgstr "更新頻率"
+
+#: id:244
+msgid "Full screen"
+msgstr "全螢幕"
+
+#: id:245
+msgid "Sizing: (%i,%i)->(%i,%i) (Zoom x%2.2f) AR:%2.2f:1 (Pixels: %2.2f:1) (VShift: %2.2f)"
+msgstr "縮放中：(%i,%i)->(%i,%i) (縮放 x%2.2f) AR:%2.2f:1 (像素: %2.2f:1)"
+
+#: id:247
+msgctxt "Auto context with id 247"
+msgid "Scripts"
+msgstr "腳本"
+
+#: id:248
+msgctxt "Auto context with id 248"
+msgid "Language"
+msgstr "語言"
+
+#: id:249
+msgctxt "Auto context with id 249"
+msgid "Music"
+msgstr "音樂"
+
+#: id:250
+msgctxt "Auto context with id 250"
+msgid "Visualization"
+msgstr "視覺效果"
+
+#: id:251
+msgid "Select destination directory"
+msgstr "選擇目的目錄"
+
+#: id:252
+msgid "Output stereo to all speakers"
+msgstr "雙聲道時輸出到所有喇叭"
+
+#: id:253
+msgid "Number of channels"
+msgstr "通道數"
+
+#: id:254
+msgid "- DTS capable receiver"
+msgstr "- DTS 數位音效"
+
+#: id:255
+msgid "CDDB"
+msgstr "CDDB"
+
+#: id:256
+msgid "Fetching CD information"
+msgstr "獲取 CD 資訊"
+
+#: id:257
+msgid "Error"
+msgstr "錯誤"
+
+#: id:258
+msgid "Enable tag reading"
+msgstr "啟用 檔案資訊讀取"
+
+#: id:259
+msgid "Opening"
+msgstr "開始"
+
+#: id:260
+msgid "Shoutcast"
+msgstr "Shoutcast 網路音樂"
+
+#: id:261
+msgid "Waiting for start..."
+msgstr "準備開始…"
+
+#: id:262
+msgid "Scripts output"
+msgstr "腳本輸出"
+
+#: id:263
+msgid "Allow control of XBMC via HTTP"
+msgstr "允許通過 HTTP 控制 XBMC"
+
+#: id:264
+msgid "Record"
+msgstr "錄音"
+
+#: id:265
+msgid "Stop Rec."
+msgstr "停止錄音"
+
+#: id:266
+msgid "Sort by: Track"
+msgstr "排序：音軌"
+
+#: id:267
+msgid "Sort by: Time"
+msgstr "排序：時間"
+
+#: id:268
+msgid "Sort by: Title"
+msgstr "排序：標題"
+
+#: id:269
+msgid "Sort by: Artist"
+msgstr "排序：藝人"
+
+#: id:270
+msgid "Sort by: Album"
+msgstr "排序：專輯"
+
+#: id:271
+msgid "Top 100"
+msgstr "排行前 100"
+
+#: id:272
+msgid "Top-Left overscan compensation"
+msgstr "左上角位置"
+
+#: id:273
+msgid "Bottom-Right overscan compensation"
+msgstr "右下角位置"
+
+#: id:274
+msgid "Subtitle positioning"
+msgstr "字幕位置"
+
+#: id:275
+msgid "Pixel ratio adjustment"
+msgstr "畫面比例調整"
+
+#: id:276
+msgid "Adjust the arrow to change the amount of overscan"
+msgstr "設定角落位置"
+
+#: id:277
+msgid "Adjust the bar to change the subtitles position"
+msgstr "改變字幕位置"
+
+#: id:278
+msgid "Adjust the rectangle so it is perfectly square"
+msgstr "調整成正方形"
+
+#: id:279
+msgid "Unable to load settings"
+msgstr "無法讀取設定"
+
+#: id:280
+msgid "Using default settings"
+msgstr "回復為預設值"
+
+#: id:281
+msgid "Please check the XML files"
+msgstr "請檢查 .xml 檔案"
+
+#: id:282
+msgid "Found %i items"
+msgstr "找到 %i 條"
+
+#: id:283
+msgid "Search results"
+msgstr "搜尋結果"
+
+#: id:284
+msgid "No results found"
+msgstr "無結果"
+
+#: id:287
+msgctxt "Auto context with id 287"
+msgid "Subtitles"
+msgstr "字幕設定"
+
+#: id:288
+msgctxt "Auto context with id 288"
+msgid "Font"
+msgstr "字型"
+
+#: id:289
+msgctxt "Auto context with id 289"
+msgid "- Size"
+msgstr "- 大小"
+
+#: id:290
+msgid "Dynamic range compression"
+msgstr "動態範圍壓縮"
+
+#: id:291
+msgctxt "Auto context with id 291"
+msgid "Video"
+msgstr "視訊"
+
+#: id:292
+msgctxt "Auto context with id 292"
+msgid "Audio"
+msgstr "音效"
+
+#: id:293
+msgid "Browse for subtitles"
+msgstr "字幕流覽"
+
+#: id:294
+msgid "Create bookmark"
+msgstr "建立書籤"
+
+#: id:296
+msgid "Clear bookmarks"
+msgstr "清除書籤"
+
+#: id:297
+msgid "Audio offset"
+msgstr "音效延遲"
+
+#: id:298
+msgid "Bookmarks"
+msgstr "書籤"
+
+#: id:299
+msgid "- AAC capable receiver"
+msgstr "- AAC 數位音效"
+
+#: id:300
+msgid "- MP1 capable receiver"
+msgstr "- MP1 數位音效"
+
+#: id:301
+msgid "- MP2 capable receiver"
+msgstr "- MP2 數位音效"
+
+#: id:302
+msgid "- MP3 capable receiver"
+msgstr "-MP3 數位音效"
+
+#: id:303
+msgid "Delay"
+msgstr "延遲"
+
+#: id:304
+msgctxt "Auto context with id 304"
+msgid "Language"
+msgstr "語言"
+
+#: id:305
+msgctxt "Auto context with id 305"
+msgid "Enabled"
+msgstr "啟用"
+
+#: id:306
+msgid "Non-interleaved"
+msgstr "非交錯掃描"
+
+#: id:312
+msgid "(0=auto)"
+msgstr "(0=自動)"
+
+#: id:313
+msgid "Cleaning database"
+msgstr "正在清除資料庫"
+
+#: id:314
+msgid "Preparing..."
+msgstr "準備中…"
+
+#: id:315
+msgid "Database error"
+msgstr "資料庫錯誤！"
+
+#: id:316
+msgid "Searching songs..."
+msgstr "搜尋歌曲…"
+
+#: id:317
+msgid "Cleaned database successfully"
+msgstr "成功清除資料庫！"
+
+#: id:318
+msgid "Cleaning songs..."
+msgstr "清除歌曲…"
+
+#: id:319
+msgid "Error cleaning songs"
+msgstr "清除歌曲錯誤！"
+
+#: id:320
+msgid "Cleaning artists..."
+msgstr "清除藝人…"
+
+#: id:321
+msgid "Error cleaning artists"
+msgstr "清除藝人錯誤！"
+
+#: id:322
+msgid "Cleaning genres..."
+msgstr "清除類別…"
+
+#: id:323
+msgid "Error cleaning genres"
+msgstr "清除類別錯誤！"
+
+#: id:324
+msgid "Cleaning paths..."
+msgstr "清除路徑…"
+
+#: id:325
+msgid "Error cleaning paths"
+msgstr "清除路徑錯誤！"
+
+#: id:326
+msgid "Cleaning albums..."
+msgstr "清除專輯…"
+
+#: id:327
+msgid "Error cleaning albums"
+msgstr "清除專輯錯誤！"
+
+#: id:328
+msgid "Writing changes..."
+msgstr "寫入變更中…"
+
+#: id:329
+msgid "Error writing changes"
+msgstr "寫入錯誤！"
+
+#: id:330
+msgid "This may take some time..."
+msgstr "這需要一些時間…"
+
+#: id:331
+msgid "Compressing database..."
+msgstr "壓縮資料庫…"
+
+#: id:332
+msgid "Error compressing database"
+msgstr "壓縮資料庫錯誤！"
+
+#: id:333
+msgid "Do you want to clean the library?"
+msgstr "要清除資料庫嗎？"
+
+#: id:334
+msgid "Clean library..."
+msgstr "清除資料庫…"
+
+#: id:335
+msgid "Start"
+msgstr "開始"
+
+#: id:336
+msgid "Framerate conversion"
+msgstr "調整畫面頻率"
+
+#: id:337
+msgctxt "Auto context with id 337"
+msgid "Audio output"
+msgstr "音效輸出"
+
+#: id:338
+msgid "Analog"
+msgstr "類比"
+
+#: id:339
+msgid "Optical/Coax"
+msgstr "數位"
+
+#: id:340
+msgid "Various artists"
+msgstr "群星"
+
+#: id:341
+msgid "Play disc"
+msgstr "播放光碟"
+
+#: id:342
+msgctxt "Auto context with id 342"
+msgid "Movies"
+msgstr "影片"
+
+#: id:343
+msgid "Adjust framerate"
+msgstr "調整畫面頻率"
+
+#: id:344
+msgid "Actors"
+msgstr "演員"
+
+#: id:345
+msgctxt "Auto context with id 345"
+msgid "Year"
+msgstr "年份"
+
+#: id:346
+msgid "Boost volume level on downmix"
+msgstr "增加聲道縮減混音音量"
+
+#: id:350
+msgctxt "Auto context with id 350"
+msgid "Programs"
+msgstr "程式"
+
+#: id:351
+msgctxt "Auto context with id 351"
+msgid "Off"
+msgstr "關閉"
+
+#: id:352
+msgid "Dim"
+msgstr "陰暗"
+
+#: id:353
+msgid "Black"
+msgstr "全黑"
+
+#: id:354
+msgid "Matrix trails"
+msgstr "Matrix trails"
+
+#: id:355
+msgid "Screensaver time"
+msgstr "螢幕保護時間"
+
+#: id:356
+msgid "Screensaver mode"
+msgstr "螢幕保護模式"
+
+#: id:357
+msgid "Shutdown function timer"
+msgstr "待機時間"
+
+#: id:358
+msgid "All albums"
+msgstr "全部專輯"
+
+#: id:359
+msgid "Recently added albums"
+msgstr "新的專輯"
+
+#: id:360
+msgctxt "Auto context with id 360"
+msgid "Screensaver"
+msgstr "螢幕保護"
+
+#: id:361
+msgid "R. Slideshow"
+msgstr "循環播放圖片"
+
+#: id:362
+msgid "Screensaver dim level"
+msgstr "螢幕保護的亮度"
+
+#: id:363
+msgid "Sort by: File"
+msgstr "排序：檔案"
+
+#: id:364
+msgid "- Dolby Digital (AC3) capable receiver"
+msgstr "- AC3 數位音效"
+
+#: id:365
+msgctxt "Auto context with id 365"
+msgid "Sort by: Name"
+msgstr "排序：名稱"
+
+#: id:366
+msgid "Sort by: Year"
+msgstr "排序：年份"
+
+#: id:367
+msgid "Sort by: Rating"
+msgstr "排序：評等"
+
+#: id:368
+msgid "IMDb"
+msgstr "IMDb"
+
+#: id:369
+msgctxt "Auto context with id 369"
+msgid "Title"
+msgstr "標題"
+
+#: id:370
+msgid "Thunderstorms"
+msgstr "雷雨"
+
+#: id:371
+msgid "Partly"
+msgstr "局部"
+
+#: id:372
+msgid "Mostly"
+msgstr "大部分"
+
+#: id:373
+msgid "Sunny"
+msgstr "晴朗"
+
+#: id:374
+msgid "Cloudy"
+msgstr "陰"
+
+#: id:375
+msgid "Snow"
+msgstr "雪"
+
+#: id:376
+msgid "Rain"
+msgstr "雨"
+
+#: id:377
+msgid "Light"
+msgstr "細"
+
+#: id:378
+msgid "AM"
+msgstr "上午"
+
+#: id:379
+msgid "PM"
+msgstr "下午"
+
+#: id:380
+msgid "Showers"
+msgstr "陣雨"
+
+#: id:381
+msgid "Few"
+msgstr "少數"
+
+#: id:382
+msgid "Scattered"
+msgstr "間歇性"
+
+#: id:383
+msgctxt "Auto context with id 383"
+msgid "Wind"
+msgstr "風"
+
+#: id:384
+msgid "Strong"
+msgstr "強烈"
+
+#: id:385
+msgid "Fair"
+msgstr "轉晴"
+
+#: id:386
+msgctxt "Auto context with id 386"
+msgid "Clear"
+msgstr "晴"
+
+#: id:387
+msgid "Clouds"
+msgstr "雲"
+
+#: id:388
+msgid "Early"
+msgstr "提早"
+
+#: id:389
+msgid "Shower"
+msgstr "陣雨"
+
+#: id:390
+msgid "Flurries"
+msgstr "飄雪"
+
+#: id:391
+msgctxt "Auto context with id 391"
+msgid "Low"
+msgstr "低"
+
+#: id:392
+msgctxt "Auto context with id 392"
+msgid "Medium"
+msgstr "中"
+
+#: id:393
+msgctxt "Auto context with id 393"
+msgid "High"
+msgstr "高"
+
+#: id:394
+msgid "Fog"
+msgstr "霧"
+
+#: id:395
+msgid "Haze"
+msgstr "霾"
+
+#: id:396
+msgid "Select location"
+msgstr "選擇位置"
+
+#: id:397
+msgid "Refresh time"
+msgstr "更新時間"
+
+#: id:398
+msgid "Temperature units"
+msgstr "溫度單位"
+
+#: id:399
+msgid "Speed units"
+msgstr "速度單位"
+
+#: id:400
+msgctxt "Auto context with id 400"
+msgid "Weather"
+msgstr "氣象"
+
+#: id:401
+msgid "Temp"
+msgstr "溫度"
+
+#: id:402
+msgid "Feels like"
+msgstr "體感溫度"
+
+#: id:403
+msgid "UV index"
+msgstr "紫外線"
+
+#: id:404
+msgctxt "Auto context with id 404"
+msgid "Wind"
+msgstr "風"
+
+#: id:405
+msgid "Dew point"
+msgstr "露點"
+
+#: id:406
+msgid "Humidity"
+msgstr "濕度"
+
+#: id:409
+msgid "Defaults"
+msgstr "預設值"
+
+#: id:410
+msgid "Accessing weather service"
+msgstr "前往氣象伺服器"
+
+#: id:411
+msgid "Getting weather for:"
+msgstr "取得氣象資料："
+
+#: id:412
+msgid "Unable to get weather data"
+msgstr "無法取得氣象資料"
+
+#: id:413
+msgid "Manual"
+msgstr "手動"
+
+#: id:414
+msgid "No review for this album"
+msgstr "此專輯無評論"
+
+#: id:415
+msgid "Downloading thumbnail..."
+msgstr "下載縮略圖…"
+
+#: id:416
+msgid "Not available"
+msgstr "無法使用"
+
+#: id:417
+msgid "View: Big icons"
+msgstr "顯示：大圖示"
+
+#: id:418
+msgctxt "Auto context with id 418"
+msgid "Low"
+msgstr "低溫"
+
+#: id:419
+msgctxt "Auto context with id 419"
+msgid "High"
+msgstr "高溫"
+
+#: id:420
+msgid "HDMI"
+msgstr "HDMI"
+
+#: id:422
+msgid "Delete album info"
+msgstr "刪除專輯資訊"
+
+#: id:423
+msgid "Delete CD information"
+msgstr "刪除 CD 資訊"
+
+#: id:424
+msgid "Select"
+msgstr "選擇"
+
+#: id:425
+msgid "No album information found"
+msgstr "無專輯資訊"
+
+#: id:426
+msgid "No CD information found"
+msgstr "無 CD 資訊"
+
+#: id:427
+msgid "Disc"
+msgstr "光碟"
+
+#: id:428
+msgid "Insert correct CD/DVD"
+msgstr "請放入正確的光碟"
+
+#: id:429
+msgid "Please insert the following disc:"
+msgstr "請放入下一張光碟"
+
+#: id:430
+msgid "Sort by: DVD#"
+msgstr "排序：DVD#"
+
+#: id:431
+msgid "No cache"
+msgstr "無緩衝區"
+
+#: id:432
+msgid "Remove movie from library"
+msgstr "從資料庫中移除影片"
+
+#: id:433
+msgid "Really remove '%s'?"
+msgstr "確定移除 '%s' 嗎？"
+
+#: id:434
+msgid "From %s at %i %s"
+msgstr "方向方位%s、風速%i %s"
+
+#: id:437
+msgid "Removable disk"
+msgstr "隨身碟"
+
+#: id:438
+msgid "Opening file"
+msgstr "打開檔案"
+
+#: id:439
+msgid "Cache"
+msgstr "快取"
+
+#: id:440
+msgid "Harddisk"
+msgstr "硬碟"
+
+#: id:441
+msgid "UDF"
+msgstr "UDF"
+
+#: id:442
+msgid "Local network"
+msgstr "區域網路"
+
+#: id:443
+msgid "Internet"
+msgstr "網際網路"
+
+#: id:444
+msgctxt "Auto context with id 444"
+msgid "Video"
+msgstr "視訊"
+
+#: id:445
+msgctxt "Auto context with id 445"
+msgid "Audio"
+msgstr "音效"
+
+#: id:446
+msgctxt "Auto context with id 446"
+msgid "DVD"
+msgstr "DVD"
+
+#: id:447
+msgid "Autorun media"
+msgstr "自動播放媒體"
+
+#: id:448
+msgid "LCD"
+msgstr "LCD"
+
+#: id:449
+msgctxt "Auto context with id 449"
+msgid "Enabled"
+msgstr "啟用"
+
+#: id:450
+msgid "Columns"
+msgstr "列"
+
+#: id:451
+msgid "Row 1 address"
+msgstr "第 1 列位址"
+
+#: id:452
+msgid "Row 2 address"
+msgstr "第 2 列位址"
+
+#: id:453
+msgid "Row 3 address"
+msgstr "第 3 列位址"
+
+#: id:454
+msgid "Row 4 address"
+msgstr "第 4 列位址"
+
+#: id:455
+msgid "Rows"
+msgstr "行"
+
+#: id:456
+msgid "Mode"
+msgstr "模式"
+
+#: id:457
+msgid "Switch view"
+msgstr "選擇顯示"
+
+#: id:459
+msgid "Subs"
+msgstr "字幕"
+
+#: id:460
+msgid "Audio stream"
+msgstr "聲道"
+
+#: id:461
+msgid "[active]"
+msgstr "[啟用]"
+
+#: id:462
+msgid "Subtitle"
+msgstr "字幕"
+
+#: id:463
+msgid "Backlight"
+msgstr "背光"
+
+#: id:464
+msgid "Brightness"
+msgstr "亮度"
+
+#: id:465
+msgid "Contrast"
+msgstr "對比"
+
+#: id:466
+msgid "Gamma"
+msgstr "伽瑪值"
+
+#: id:467
+msgctxt "Auto context with id 467"
+msgid "Type"
+msgstr "類型"
+
+#: id:468
+msgid "Move the bar to change the OSD position"
+msgstr "移動播放工具列位置"
+
+#: id:469
+msgid "OSD position"
+msgstr "播放工具列位置"
+
+#: id:470
+msgid "Credits"
+msgstr "改機者"
+
+#: id:471
+msgid "Modchip"
+msgstr "改機晶片"
+
+#: id:474
+msgctxt "Auto context with id 474"
+msgid "Off"
+msgstr "關閉"
+
+#: id:475
+msgid "Music only"
+msgstr "只有音樂"
+
+#: id:476
+msgctxt "Auto context with id 476"
+msgid "Music & video"
+msgstr "音樂 & 視訊"
+
+#: id:477
+msgid "Unable to load playlist"
+msgstr "無法讀取播放列表"
+
+#: id:478
+msgid "OSD"
+msgstr "播放工具列"
+
+#: id:479
+msgid "Skin & language"
+msgstr "佈景主題 & 語言"
+
+#: id:480
+msgid "Appearance"
+msgstr "外觀主題"
+
+#: id:481
+msgid "Audio options"
+msgstr "音效設定"
+
+#: id:482
+msgid "About XBMC"
+msgstr "關於 XBMC"
+
+#: id:485
+msgid "Delete album"
+msgstr "刪除專輯"
+
+#: id:486
+msgid "Repeat"
+msgstr "重複"
+
+#: id:487
+msgid "Repeat one"
+msgstr "重複一次"
+
+#: id:488
+msgid "Repeat folder"
+msgstr "重複資料夾"
+
+#: id:489
+msgid "Play the next song automatically"
+msgstr "自動播放下個項目"
+
+#: id:491
+msgid "- Use big icons"
+msgstr "- 使用大圖示"
+
+#: id:492
+msgid "Resize VobSubs"
+msgstr "Vobsubs 字幕比例"
+
+#: id:493
+msgid "Advanced options (Experts Only!)"
+msgstr "進階選項(專家適用!)"
+
+#: id:494
+msgid "Overall audio headroom"
+msgstr "總音量"
+
+#: id:495
+msgid "Upsample videos to GUI resolution"
+msgstr "以桌面的解析度播放視訊"
+
+#: id:496
+msgid "Calibration"
+msgstr "校正"
+
+#: id:497
+msgid "Show file extensions"
+msgstr "顯示副檔名"
+
+#: id:498
+msgid "Sort by: Type"
+msgstr "排序：類型"
+
+#: id:499
+msgid "Unable to connect to online lookup service"
+msgstr "無法連線到線上搜尋伺服器"
+
+#: id:500
+msgid "Downloading album information failed"
+msgstr "下載專輯資訊失敗"
+
+#: id:501
+msgid "Looking for album names..."
+msgstr "搜尋專輯名稱…"
+
+#: id:502
+msgctxt "Auto context with id 502"
+msgid "Open"
+msgstr "打開"
+
+#: id:503
+msgid "Busy"
+msgstr "忙碌"
+
+#: id:504
+msgid "Empty"
+msgstr "空的"
+
+#: id:505
+msgid "Loading media info from files..."
+msgstr "從檔案載入媒體資訊…"
+
+#: id:507
+msgid "Sort by: Usage"
+msgstr "排序：使用數"
+
+#: id:510
+msgid "Enable visualizations"
+msgstr "啟用 視覺效果"
+
+#: id:511
+msgid "Enable video mode switching"
+msgstr "啟用 切換視訊模式"
+
+#: id:512
+msgid "Startup window"
+msgstr "啟動界面"
+
+#: id:513
+msgid "Home window"
+msgstr "主界面"
+
+#: id:514
+msgid "Manual settings"
+msgstr "設定界面"
+
+#: id:515
+msgid "Genre"
+msgstr "類別"
+
+#: id:517
+msgid "Recently played albums"
+msgstr "最近播放的專輯"
+
+#: id:518
+msgid "Launch"
+msgstr "執行"
+
+#: id:519
+msgid "Launch in..."
+msgstr "執行方式…"
+
+#: id:521
+msgid "Compilations"
+msgstr "編輯"
+
+#: id:522
+msgid "Remove source"
+msgstr "移除來源"
+
+#: id:523
+msgid "Switch media"
+msgstr "切換媒體"
+
+#: id:524
+msgid "Select playlist"
+msgstr "選擇播放列表"
+
+#: id:525
+msgid "New playlist..."
+msgstr "新播放列表…"
+
+#: id:526
+msgid "Add to playlist"
+msgstr "加入播放列表"
+
+#: id:527
+msgid "Manually add to library"
+msgstr "手動加入資料庫"
+
+#: id:528
+msgid "Enter title"
+msgstr "輸入標題"
+
+#: id:529
+msgid "Error: Duplicate title"
+msgstr "錯誤：重複的標題"
+
+#: id:530
+msgid "Select genre"
+msgstr "選擇類別"
+
+#: id:531
+msgid "New genre"
+msgstr "新類別"
+
+#: id:532
+msgid "Manual addition"
+msgstr "手動加入"
+
+#: id:533
+msgid "Enter genre"
+msgstr "輸入類別"
+
+#: id:534
+msgid "View: %s"
+msgstr "顯示：%s"
+
+#: id:535
+msgid "List"
+msgstr "列表"
+
+#: id:536
+msgid "Icons"
+msgstr "圖示"
+
+#: id:537
+msgid "Big list"
+msgstr "大列表"
+
+#: id:538
+msgid "Big icons"
+msgstr "大圖示"
+
+#: id:539
+msgid "Wide"
+msgstr "寬幅"
+
+#: id:540
+msgid "Big wide"
+msgstr "大寬幅"
+
+#: id:541
+msgid "Album icons"
+msgstr "專輯圖示"
+
+#: id:542
+msgid "DVD icons"
+msgstr "DVD 圖示"
+
+#: id:543
+msgctxt "Auto context with id 543"
+msgid "DVD"
+msgstr "DVD"
+
+#: id:544
+msgctxt "Auto context with id 544"
+msgid "Media info"
+msgstr "媒體資訊"
+
+#: id:545
+msgid "Audio output device"
+msgstr "音效輸出設備"
+
+#: id:546
+msgid "Passthrough output device"
+msgstr "通過輸出裝置"
+
+#: id:547
+msgid "No biography for this artist"
+msgstr "此藝人沒有傳記"
+
+#: id:548
+msgid "Downmix multichannel audio to stereo"
+msgstr "混合多聲道輸出為雙聲道"
+
+#: id:550
+msgid "Sort by: %s"
+msgstr "排序：%s"
+
+#: id:551
+msgctxt "Auto context with id 551"
+msgid "Name"
+msgstr "名稱"
+
+#: id:552
+msgid "Date"
+msgstr "日期"
+
+#: id:553
+msgid "Size"
+msgstr "大小"
+
+#: id:554
+msgid "Track"
+msgstr "音軌"
+
+#: id:555
+msgid "Time"
+msgstr "時間"
+
+#: id:556
+msgctxt "Auto context with id 556"
+msgid "Title"
+msgstr "標題"
+
+#: id:557
+msgid "Artist"
+msgstr "藝人"
+
+#: id:558
+msgid "Album"
+msgstr "專輯"
+
+#: id:559
+msgid "Playlist"
+msgstr "播放列表"
+
+#: id:560
+msgid "ID"
+msgstr "標籤"
+
+#: id:561
+msgctxt "Auto context with id 561"
+msgid "File"
+msgstr "檔案"
+
+#: id:562
+msgctxt "Auto context with id 562"
+msgid "Year"
+msgstr "年份"
+
+#: id:563
+msgid "Rating"
+msgstr "評等"
+
+#: id:564
+msgctxt "Auto context with id 564"
+msgid "Type"
+msgstr "類型"
+
+#: id:565
+msgid "Usage"
+msgstr "使用數"
+
+#: id:566
+msgid "Album artist"
+msgstr "專輯藝人"
+
+#: id:567
+msgid "Play count"
+msgstr "播放次數"
+
+#: id:568
+msgid "Last played"
+msgstr "最近播放"
+
+#: id:569
+msgctxt "Auto context with id 569"
+msgid "Comment"
+msgstr "評論"
+
+#: id:570
+msgid "Date added"
+msgstr "加入日期"
+
+#: id:571
+msgctxt "Auto context with id 571"
+msgid "Default"
+msgstr "預設"
+
+#: id:572
+msgid "Studio"
+msgstr "製作公司"
+
+#: id:573
+msgid "Path"
+msgstr "路徑"
+
+#: id:574
+msgctxt "Auto context with id 574"
+msgid "Country"
+msgstr "國家"
+
+#: id:575
+msgid "In progress"
+msgstr "進度"
+
+#: id:576
+msgid "Times played"
+msgstr "已播放時間"
+
+#: id:580
+msgid "Sort direction"
+msgstr "排序方向"
+
+#: id:581
+msgid "Sort method"
+msgstr "排序方法"
+
+#: id:582
+msgctxt "Auto context with id 582"
+msgid "View mode"
+msgstr "顯示模式"
+
+#: id:583
+msgid "Remember views for different folders"
+msgstr "記住不同資料夾的顯示模式"
+
+#: id:584
+msgid "Ascending"
+msgstr "升冪"
+
+#: id:585
+msgid "Descending"
+msgstr "降冪"
+
+#: id:586
+msgid "Edit playlist"
+msgstr "編輯播放列表"
+
+#: id:587
+msgid "Filter"
+msgstr "濾鏡"
+
+#: id:588
+msgid "Cancel party mode"
+msgstr "取消派對模式"
+
+#: id:589
+msgid "Party mode"
+msgstr "派對模式"
+
+#: id:590
+msgid "Random"
+msgstr "隨機"
+
+#: id:591
+msgctxt "Auto context with id 591"
+msgid "Off"
+msgstr "關閉"
+
+#: id:592
+msgid "One"
+msgstr "單首"
+
+#: id:593
+msgid "All"
+msgstr "全部"
+
+#: id:594
+msgctxt "Auto context with id 594"
+msgid "Off"
+msgstr "關閉"
+
+#: id:595
+msgid "Repeat: Off"
+msgstr "重複：關閉"
+
+#: id:596
+msgid "Repeat: One"
+msgstr "重複：單首"
+
+#: id:597
+msgid "Repeat: All"
+msgstr "重複：全部"
+
+#: id:600
+msgid "Rip audio CD"
+msgstr "擷取音樂 CD"
+
+#: id:601
+msgctxt "Auto context with id 601"
+msgid "Medium"
+msgstr "中等"
+
+#: id:602
+msgctxt "Auto context with id 602"
+msgid "Standard"
+msgstr "標準"
+
+#: id:603
+msgid "Extreme"
+msgstr "最高"
+
+#: id:604
+msgid "Constant bitrate"
+msgstr "指定頻率"
+
+#: id:605
+msgid "Ripping..."
+msgstr "擷取中…"
+
+#: id:607
+msgid "To:"
+msgstr "儲存到："
+
+#: id:608
+msgid "Could not rip CD or track"
+msgstr "無法擷取 CD 或音軌"
+
+#: id:609
+msgid "CDDARipPath is not set."
+msgstr "CD 擷取路徑未設定。"
+
+#: id:610
+msgid "Rip audio track"
+msgstr "擷取音軌"
+
+#: id:611
+msgid "Enter number"
+msgstr "輸入數字"
+
+#: id:612
+msgid "Bits/Sample"
+msgstr "Bits/取樣"
+
+#: id:613
+msgid "Sample Frequency"
+msgstr "取樣頻率"
+
+#: id:620
+msgid "Audio CDs"
+msgstr "音樂 CD 擷取"
+
+#: id:621
+msgid "Encoder"
+msgstr "編碼"
+
+#: id:622
+msgid "Quality"
+msgstr "品質"
+
+#: id:623
+msgid "Bitrate"
+msgstr "頻率"
+
+#: id:624
+msgid "Include track number"
+msgstr "包括音軌編號"
+
+#: id:625
+msgid "All songs of"
+msgstr "所有歌曲"
+
+#: id:629
+msgctxt "Auto context with id 629"
+msgid "View mode"
+msgstr "顯示模式"
+
+#: id:630
+msgctxt "Auto context with id 630"
+msgid "Normal"
+msgstr "一般"
+
+#: id:631
+msgid "Zoom"
+msgstr "填滿螢幕(無黑邊)"
+
+#: id:632
+msgid "Stretch 4:3"
+msgstr "4:3 畫面"
+
+#: id:633
+msgid "Wide Zoom"
+msgstr "14:9 畫面"
+
+#: id:634
+msgid "Stretch 16:9"
+msgstr "16:9 畫面"
+
+#: id:635
+msgid "Original Size"
+msgstr "原始大小"
+
+#: id:636
+msgctxt "Auto context with id 636"
+msgid "Custom"
+msgstr "自訂"
+
+#: id:637
+msgid "Replay gain"
+msgstr "重覆播放"
+
+#: id:638
+msgid "Replaygain volume adjustments"
+msgstr "重覆播放模式"
+
+#: id:639
+msgid "Use track levels"
+msgstr "依曲目重覆播放"
+
+#: id:640
+msgid "Use album levels"
+msgstr "依專輯重覆播放"
+
+#: id:641
+msgid "PreAmp Level - Replay gained files"
+msgstr "音量 - 重覆播放的檔案"
+
+#: id:642
+msgid "PreAmp Level - Non replay gained files"
+msgstr "音量 - 不重覆播放的檔案"
+
+#: id:643
+msgid "Avoid clipping on replay gained files"
+msgstr "重覆播放時忽略消波失真"
+
+#: id:644
+msgid "Crop black bars"
+msgstr "修剪黑邊"
+
+#: id:645
+msgid "Need to unpack a big file. Continue?"
+msgstr "需要解開一個大檔案，是否繼續？"
+
+#: id:646
+msgid "Remove from library"
+msgstr "從資料庫中移除"
+
+#: id:647
+msgid "Export video library"
+msgstr "匯出視訊資料庫"
+
+#: id:648
+msgid "Import video library"
+msgstr "匯入視訊資料庫"
+
+#: id:649
+msgid "Importing"
+msgstr "匯入中"
+
+#: id:650
+msgid "Exporting"
+msgstr "匯出中"
+
+#: id:651
+msgid "Browse for library"
+msgstr "影片資料庫"
+
+#: id:652
+msgid "Years"
+msgstr "年份"
+
+#: id:653
+msgid "Update library"
+msgstr "更新資料庫"
+
+#: id:654
+msgid "Show debug info"
+msgstr "顯示除錯資訊"
+
+#: id:655
+msgid "Browse for executable"
+msgstr "瀏覽可執行檔"
+
+#: id:656
+msgid "Browse for playlist"
+msgstr "瀏覽播放列表"
+
+#: id:657
+msgid "Browse for folder"
+msgstr "瀏覽資料夾"
+
+#: id:658
+msgid "Song information"
+msgstr "歌曲資訊"
+
+#: id:659
+msgid "Non-linear stretch"
+msgstr "非線性延伸"
+
+#: id:660
+msgid "Volume amplification"
+msgstr "音量放大"
+
+#: id:661
+msgid "Choose export folder"
+msgstr "選擇匯出資料夾"
+
+#: id:662
+msgid "This file is no longer available."
+msgstr "這個檔案已經無法使用。"
+
+#: id:663
+msgid "Would you like to remove it from the library?"
+msgstr "你要將它從資料庫移除嗎？"
+
+#: id:664
+msgid "Browse for Script"
+msgstr "流覽腳本"
+
+#: id:665
+msgid "Compression level"
+msgstr "壓縮等級"
+
+#: id:700
+msgid "Cleaning up library"
+msgstr "清除音樂資料庫"
+
+#: id:701
+msgid "Removing old songs from the library"
+msgstr "移除音樂資料庫舊歌曲"
+
+#: id:702
+msgid "This path has been scanned before"
+msgstr "目前路徑曾經搜尋過"
+
+#: id:705
+msgctxt "Auto context with id 705"
+msgid "Network"
+msgstr "網路設定"
+
+#: id:706
+msgid "- Server"
+msgstr "- 伺服器"
+
+#: id:708
+msgid "Use an HTTP proxy server to access the internet"
+msgstr "啟用 HTTP 代理伺服器"
+
+#: id:711
+msgid "Internet Protocol (IP)"
+msgstr "網路位址(IP)"
+
+#: id:712
+msgid "Invalid port specified. Value must be between 1 and 65535."
+msgstr "無效的連接埠，數值必須是 1 至 65535。"
+
+#: id:713
+msgid "HTTP proxy"
+msgstr "HTTP 代理伺服器"
+
+#: id:715
+msgid "- Assignment"
+msgstr "- 分配"
+
+#: id:716
+msgid "Automatic (DHCP)"
+msgstr "自動(動態分配)"
+
+#: id:717
+msgid "Manual (Static)"
+msgstr "手動(靜態分配)"
+
+#: id:719
+msgid "- IP address"
+msgstr "- IP 位址"
+
+#: id:720
+msgid "- Netmask"
+msgstr "- 子網路遮罩"
+
+#: id:721
+msgid "- Default gateway"
+msgstr "- 預設閘道"
+
+#: id:722
+msgid "- DNS server"
+msgstr "- DNS 伺服器"
+
+#: id:723
+msgid "Save & restart"
+msgstr "儲存 & 重新啟動"
+
+#: id:724
+msgid "Invalid address specified. Value must be AAA.BBB.CCC.DDD"
+msgstr "無效位址。數值必須是 AAA.BBB.CCC.DDD"
+
+#: id:725
+msgid "with numbers between 0 and 255."
+msgstr "必須是 0 至 255。"
+
+#: id:726
+msgid "Changes not saved. Continue without saving?"
+msgstr "改變未儲存. 不儲存就離開嗎？"
+
+#: id:727
+msgid "Web server"
+msgstr "Web 伺服器"
+
+#: id:728
+msgctxt "Auto context with id 728"
+msgid "FTP server"
+msgstr "FTP 伺服器"
+
+#: id:730
+msgid "- Port"
+msgstr "- 連接埠"
+
+#: id:732
+msgid "Save & apply"
+msgstr "儲存 & 套用"
+
+#: id:733
+msgid "- Password"
+msgstr "- 密碼"
+
+#: id:734
+msgid "No pass"
+msgstr "無密碼"
+
+#: id:735
+msgid "- Character set"
+msgstr "- 編碼"
+
+#: id:736
+msgid "- Style"
+msgstr "- 效果"
+
+#: id:737
+msgid "- Colour"
+msgstr "- 顏色"
+
+#: id:738
+msgctxt "Auto context with id 738"
+msgid "Normal"
+msgstr "標準"
+
+#: id:739
+msgid "Bold"
+msgstr "粗體"
+
+#: id:740
+msgid "Italics"
+msgstr "斜體"
+
+#: id:741
+msgid "Bold italics"
+msgstr "粗斜體"
+
+#: id:742
+msgctxt "Auto context with id 742"
+msgid "White"
+msgstr "白色"
+
+#: id:743
+msgctxt "Auto context with id 743"
+msgid "Yellow"
+msgstr "黃色"
+
+#: id:744
+msgctxt "Auto context with id 744"
+msgid "Files"
+msgstr "檔案"
+
+#: id:745
+msgid "No scanned information for this view"
+msgstr "目前顯示無已搜尋資訊"
+
+#: id:746
+msgid "Please turn off library mode"
+msgstr "切換到檔案顯示"
+
+#: id:747
+msgid "Error loading image"
+msgstr "圖像載入錯誤"
+
+#: id:748
+msgid "Edit path"
+msgstr "編輯路徑"
+
+#: id:749
+msgid "Mirror image"
+msgstr "映像"
+
+#: id:750
+msgid "Are you sure?"
+msgstr "您確定嗎？"
+
+#: id:751
+msgid "Removing source"
+msgstr "移除來源"
+
+#: id:754
+msgid "Add program link"
+msgstr "新增程式連結"
+
+#: id:755
+msgid "Edit program path"
+msgstr "編輯程式路徑"
+
+#: id:756
+msgid "Edit program name"
+msgstr "編輯程式名稱"
+
+#: id:757
+msgid "Edit path depth"
+msgstr "編輯路徑深度"
+
+#: id:759
+msgid "View: Big list"
+msgstr "顯示：大列表"
+
+#: id:760
+msgctxt "Auto context with id 760"
+msgid "Yellow"
+msgstr "黃色"
+
+#: id:761
+msgctxt "Auto context with id 761"
+msgid "White"
+msgstr "白色"
+
+#: id:762
+msgid "Blue"
+msgstr "藍色"
+
+#: id:763
+msgid "Bright green"
+msgstr "亮綠"
+
+#: id:764
+msgid "Yellow green"
+msgstr "翠綠"
+
+#: id:765
+msgid "Cyan"
+msgstr "青色"
+
+#: id:766
+msgid "Light grey"
+msgstr "保留"
+
+#: id:767
+msgid "Grey"
+msgstr "保留"
+
+#: id:770
+msgid "Error %i: share not available"
+msgstr "錯誤 %i：無法共享"
+
+#: id:772
+msgctxt "Auto context with id 772"
+msgid "Audio output"
+msgstr "音效輸出"
+
+#: id:773
+msgid "Seeking"
+msgstr "搜尋中"
+
+#: id:774
+msgid "Slideshow folder"
+msgstr "圖片資料夾"
+
+#: id:775
+msgid "Network interface"
+msgstr "網路界面"
+
+#: id:776
+msgid "- Wireless network name (ESSID)"
+msgstr "- 無線網路帳號(ESSID)"
+
+#: id:777
+msgid "- Wireless password"
+msgstr "- 無線網路密碼"
+
+#: id:778
+msgid "- Wireless security"
+msgstr "- 無線網路安全"
+
+#: id:779
+msgid "Save and apply network interface settings"
+msgstr "儲存並套用網路界面設定"
+
+#: id:780
+msgid "No encryption"
+msgstr "沒有加密"
+
+#: id:781
+msgid "WEP"
+msgstr "WEP"
+
+#: id:782
+msgid "WPA"
+msgstr "WPA"
+
+#: id:783
+msgid "WPA2"
+msgstr "WPA2"
+
+#: id:784
+msgid "Applying network interface settings. Please wait."
+msgstr "套用網路界面設定，請稍候。"
+
+#: id:785
+msgid "Network interface restarted successfully."
+msgstr "順利重新啟動網路界面。"
+
+#: id:786
+msgid "Network interface did not start successfully."
+msgstr "無法順利啟動網路界面。"
+
+#: id:787
+msgid "Interface disabled"
+msgstr "關閉網路界面"
+
+#: id:788
+msgid "Network interface disabled successfully."
+msgstr "順利關閉網路界面。"
+
+#: id:789
+msgid "Wireless network name (ESSID)"
+msgstr "無線網路帳號(ESSID)"
+
+#: id:790
+msgid "Remote control"
+msgstr ""
+
+#: id:791
+msgid "Allow programs on this system to control XBMC"
+msgstr "允許這個系統的程式控制XBMC"
+
+#: id:792
+msgctxt "Auto context with id 792"
+msgid "Port"
+msgstr "遠端伺服器埠號"
+
+#: id:793
+msgid "Port range"
+msgstr "遠端伺服器埠號範圍"
+
+#: id:794
+msgid "Allow programs on other systems to control XBMC"
+msgstr "允許其他電腦連接"
+
+#: id:795
+msgid "Initial repeat delay (ms)"
+msgstr "初步重複延遲(毫秒)"
+
+#: id:796
+msgid "Continuous repeat delay (ms)"
+msgstr "連續重複延遲(毫秒)"
+
+#: id:797
+msgid "Maximum number of clients"
+msgstr "最大客戶端數"
+
+#: id:798
+msgid "Internet access"
+msgstr "網際網路訪問"
+
+#: id:850
+msgid "Invalid port number entered"
+msgstr "輸入不合法的連接埠"
+
+#: id:851
+msgid "Valid port range is 1-65535"
+msgstr "合法的連接埠範圍是 1-65535"
+
+#: id:852
+msgid "Valid port range is 1024-65535"
+msgstr "合法的連接埠範圍是 1024-65535"
+
+#: id:998
+msgid "Add Music..."
+msgstr "新增音樂..."
+
+#: id:999
+msgid "Add Videos..."
+msgstr "新增影片..."
+
+#: id:1000
+msgid "- Preview"
+msgstr "- 預覽"
+
+#: id:1001
+msgid "Unable to connect"
+msgstr "無法連線"
+
+#: id:1002
+msgid "XBMC was unable to connect to the network location."
+msgstr "XBMC 無法連線到網路。"
+
+#: id:1003
+msgid "This could be due to the network not being connected."
+msgstr "這可能是由於網路沒有連線。"
+
+#: id:1004
+msgid "Would you like to add it anyway?"
+msgstr "可以用其他方式來新增它嗎？"
+
+#: id:1006
+msgctxt "Auto context with id 1006"
+msgid "IP address"
+msgstr "IP 位址"
+
+#: id:1007
+msgid "Add network location"
+msgstr "新增網路位置"
+
+#: id:1008
+msgid "Protocol"
+msgstr "協定"
+
+#: id:1009
+msgid "Server address"
+msgstr "伺服器位址"
+
+#: id:1010
+msgid "Server name"
+msgstr "伺服器名稱"
+
+#: id:1011
+msgid "Remote path"
+msgstr "遠端路徑"
+
+#: id:1012
+msgid "Shared folder"
+msgstr "共享資料夾"
+
+#: id:1013
+msgctxt "Auto context with id 1013"
+msgid "Port"
+msgstr "連接埠"
+
+#: id:1014
+msgctxt "Auto context with id 1014"
+msgid "Username"
+msgstr "帳號"
+
+#: id:1015
+msgid "Browse for network server"
+msgstr "瀏覽網路伺服器"
+
+#: id:1016
+msgid "Enter the network address of the server"
+msgstr "輸入伺服器網路位址"
+
+#: id:1017
+msgid "Enter the path on the server"
+msgstr "輸入伺服器遠端路徑"
+
+#: id:1018
+msgid "Enter the port number"
+msgstr "輸入埠號"
+
+#: id:1019
+msgid "Enter the username"
+msgstr "輸入帳號"
+
+#: id:1020
+msgid "Add %s source"
+msgstr "新增 %s 來源"
+
+#: id:1021
+msgid "Enter the paths or browse for the media locations."
+msgstr "輸入或選擇媒體位置。"
+
+#: id:1022
+msgid "Enter a name for this media Source."
+msgstr "為該媒體來源命名。"
+
+#: id:1023
+msgid "Browse for new share"
+msgstr "瀏覽目錄"
+
+#: id:1024
+msgid "Browse"
+msgstr "瀏覽"
+
+#: id:1025
+msgid "Could not retrieve directory information."
+msgstr "無法獲得目錄資訊。"
+
+#: id:1026
+msgid "Add source"
+msgstr "新增來源"
+
+#: id:1027
+msgid "Edit source"
+msgstr "編輯來源"
+
+#: id:1028
+msgid "Edit %s source"
+msgstr "編輯 %s 來源"
+
+#: id:1029
+msgid "Enter the new label"
+msgstr "輸入新標籤"
+
+#: id:1030
+msgid "Browse for image"
+msgstr "瀏覽圖像"
+
+#: id:1031
+msgid "Browse for image folder"
+msgstr "瀏覽圖像資料夾"
+
+#: id:1032
+msgid "Add network location..."
+msgstr "新增網路位置…"
+
+#: id:1033
+msgid "Browse for file"
+msgstr "瀏覽檔案"
+
+#: id:1034
+msgid "Submenu"
+msgstr "子選單"
+
+#: id:1035
+msgid "Enable submenu buttons"
+msgstr "啟用 子選單按鈕"
+
+#: id:1036
+msgid "Favourites"
+msgstr "我的最愛"
+
+#: id:1037
+msgid "Video Add-ons"
+msgstr "視訊外掛"
+
+#: id:1038
+msgid "Music Add-ons"
+msgstr "音樂外掛"
+
+#: id:1039
+msgid "Picture Add-ons"
+msgstr "圖片外掛"
+
+#: id:1040
+msgid "Loading directory"
+msgstr "載入目錄"
+
+#: id:1041
+msgid "Retrieved %i items"
+msgstr "檢索 %i 項目"
+
+#: id:1042
+msgid "Retrieved %i of %i items"
+msgstr "檢索 %i 在 %i 項目"
+
+#: id:1043
+msgid "Program Add-ons"
+msgstr "程式外掛"
+
+#: id:1044
+msgid "Set plugin thumb"
+msgstr "設定外掛縮圖"
+
+#: id:1045
+msgid "Add-on settings"
+msgstr "外掛設定"
+
+#: id:1046
+msgid "Access points"
+msgstr "無線網路橋接器"
+
+#: id:1047
+msgid "Other..."
+msgstr "其他…"
+
+#: id:1048
+msgid "- Username"
+msgstr "- 使用者名稱"
+
+#: id:1049
+msgid "Script settings"
+msgstr "腳本設定"
+
+#: id:1050
+msgid "Singles"
+msgstr "單曲"
+
+#: id:1051
+msgid "Enter web address"
+msgstr "輸入網路位址"
+
+#: id:1200
+msgid "SMB client"
+msgstr "SMB 共享設定"
+
+#: id:1202
+msgid "Workgroup"
+msgstr "工作群組"
+
+#: id:1203
+msgid "Default username"
+msgstr "預設帳號"
+
+#: id:1204
+msgid "Default password"
+msgstr "預設密碼"
+
+#: id:1207
+msgid "WINS server"
+msgstr "WINS 伺服器"
+
+#: id:1208
+msgid "Mount SMB shares"
+msgstr "掛載 SMB 分享"
+
+#: id:1210
+msgctxt "Auto context with id 1210"
+msgid "Remove"
+msgstr "移除"
+
+#: id:1211
+msgctxt "Auto context with id 1211"
+msgid "Music"
+msgstr "音樂"
+
+#: id:1212
+msgctxt "Auto context with id 1212"
+msgid "Video"
+msgstr "視訊"
+
+#: id:1213
+msgctxt "Auto context with id 1213"
+msgid "Pictures"
+msgstr "圖片"
+
+#: id:1214
+msgctxt "Auto context with id 1214"
+msgid "Files"
+msgstr "檔案"
+
+#: id:1215
+msgctxt "Auto context with id 1215"
+msgid "Music & video"
+msgstr "音樂 & 視訊"
+
+#: id:1216
+msgid "Music & pictures"
+msgstr "音樂 & 圖片"
+
+#: id:1217
+msgid "Music & files"
+msgstr "音樂 & 檔案"
+
+#: id:1218
+msgid "Video & pictures"
+msgstr "視訊 & 圖片"
+
+#: id:1219
+msgid "Video & files"
+msgstr "視訊 & 檔案"
+
+#: id:1220
+msgid "Pictures & files"
+msgstr "圖片 & 檔案"
+
+#: id:1221
+msgid "Music & video & pictures"
+msgstr "音樂 & 視訊 & 圖片"
+
+#: id:1222
+msgid "Music & video & pictures & files"
+msgstr "音樂 & 視訊 & 圖片 & 檔案"
+
+#: id:1223
+msgctxt "Auto context with id 1223"
+msgid "Disabled"
+msgstr "停用"
+
+#: id:1226
+msgid "Files & music & video"
+msgstr "檔案 & 音樂 & 視訊"
+
+#: id:1227
+msgid "Files & pictures & music"
+msgstr "檔案 & 圖片 & 音樂"
+
+#: id:1228
+msgid "Files & pictures & video"
+msgstr "檔案 & 圖片 & 視訊"
+
+#: id:1229
+msgid "Music & programs"
+msgstr "音樂 & 程式"
+
+#: id:1230
+msgid "Video & programs"
+msgstr "視訊 & 程式"
+
+#: id:1231
+msgid "Pictures & programs"
+msgstr "圖片 & 程式"
+
+#: id:1232
+msgid "Music & video & pictures & programs"
+msgstr "音樂 & 視訊 & 圖片 & 程式"
+
+#: id:1233
+msgid "Programs & video & music"
+msgstr "程式 & 視訊 & 音樂"
+
+#: id:1234
+msgid "Programs & pictures & music"
+msgstr "程式 & 圖片 & 音樂"
+
+#: id:1235
+msgid "Programs & pictures & video"
+msgstr "程式 & 圖片 & 視訊"
+
+#: id:1250
+msgid "Auto-detection"
+msgstr "自動偵測"
+
+#: id:1251
+msgid "Auto-detect system"
+msgstr "自動偵測系統"
+
+#: id:1252
+msgid "Nickname"
+msgstr "暱稱"
+
+#: id:1254
+msgid "Ask to connect"
+msgstr "詢問連線"
+
+#: id:1255
+msgid "Send FTP user and password"
+msgstr "發送 FTP 帳號和密碼"
+
+#: id:1256
+msgid "Ping interval"
+msgstr "連線品質"
+
+#: id:1257
+msgid "Would you like to connect to the auto-detected system?"
+msgstr "是否連線到自動偵測到的系統？"
+
+#: id:1259
+msgid "Zeroconf"
+msgstr ""
+
+#: id:1260
+msgid "Announce these services to other systems via Zeroconf"
+msgstr "自動網路設定"
+
+#: id:1270
+msgid "Allow XBMC to receive AirPlay content"
+msgstr "允許XBMC接收AirPlay內容"
+
+#: id:1271
+msgid "Device name"
+msgstr "裝置名稱"
+
+#: id:1272
+msgid "- Use password protection"
+msgstr "- 使用密碼保護"
+
+#: id:1273
+msgid "AirPlay"
+msgstr ""
+
+#: id:1300
+msgid "Custom audio device"
+msgstr "自訂音效設備"
+
+#: id:1301
+msgid "Custom passthrough device"
+msgstr "自訂直通輸出設備"
+
+#: id:1396
+msgid "Drifting"
+msgstr "移動"
+
+#: id:1397
+msgid "and"
+msgstr "有"
+
+#: id:1398
+msgid "Freezing"
+msgstr "結冰"
+
+#: id:1399
+msgid "Late"
+msgstr "睌間"
+
+#: id:1400
+msgid "Isolated"
+msgstr "局部"
+
+#: id:1401
+msgid "Thundershowers"
+msgstr "雷陣雨"
+
+#: id:1402
+msgid "Thunder"
+msgstr "雷"
+
+#: id:1403
+msgctxt "Auto context with id 1403"
+msgid "Sun"
+msgstr "晴"
+
+#: id:1404
+msgid "Heavy"
+msgstr "大"
+
+#: id:1405
+msgid "in"
+msgstr "在"
+
+#: id:1406
+msgid "the"
+msgstr "這"
+
+#: id:1407
+msgid "Vicinity"
+msgstr "區域性"
+
+#: id:1408
+msgid "Ice"
+msgstr "冰"
+
+#: id:1409
+msgid "Crystals"
+msgstr "冰霜"
+
+#: id:1410
+msgid "Calm"
+msgstr "無風"
+
+#: id:1411
+msgid "with"
+msgstr "有"
+
+#: id:1412
+msgid "windy"
+msgstr "風"
+
+#: id:1413
+msgid "drizzle"
+msgstr "毛雨"
+
+#: id:1414
+msgid "Thunderstorm"
+msgstr "雷雨"
+
+#: id:1415
+msgid "Drizzle"
+msgstr "毛雨"
+
+#: id:1416
+msgid "Foggy"
+msgstr "霧"
+
+#: id:1417
+msgid "Grains"
+msgstr "花"
+
+#: id:1418
+msgid "T-Storms"
+msgstr "雷雨"
+
+#: id:1419
+msgid "T-Showers"
+msgstr "雷陣雨"
+
+#: id:1420
+msgid "Moderate"
+msgstr "中等"
+
+#: id:1421
+msgid "Very High"
+msgstr "非常高"
+
+#: id:1422
+msgid "Windy"
+msgstr "風"
+
+#: id:1423
+msgid "Mist"
+msgstr "靄"
+
+#: id:1450
+msgid "Put display to sleep when idle"
+msgstr "閒置時顯示器休眠"
+
+#: id:2050
+msgid "Runtime"
+msgstr "視訊時間"
+
+#: id:2100
+msgid "Script failed! : %s"
+msgstr "腳本錯誤！：%s"
+
+#: id:2101
+msgid "Newer version needed - See log"
+msgstr "需要更新的版本 - 看記錄"
+
+#: id:4501
+msgid "Enable LCD/VFD"
+msgstr "啟用 LCD/VFD"
+
+#: id:10000
+msgid "Home"
+msgstr "首頁"
+
+#: id:10001
+msgctxt "Auto context with id 10001"
+msgid "Programs"
+msgstr "程式"
+
+#: id:10002
+msgctxt "Auto context with id 10002"
+msgid "Pictures"
+msgstr "圖片"
+
+#: id:10003
+msgctxt "Auto context with id 10003"
+msgid "File manager"
+msgstr "檔案總管"
+
+#: id:10004
+msgctxt "Auto context with id 10004"
+msgid "Settings"
+msgstr "系統設定"
+
+#: id:10005
+msgctxt "Auto context with id 10005"
+msgid "Music"
+msgstr "音樂"
+
+#: id:10006
+msgctxt "Auto context with id 10006"
+msgid "Videos"
+msgstr "視訊"
+
+#: id:10007
+msgid "System information"
+msgstr "系統資訊"
+
+#: id:10008
+msgid "Settings - General"
+msgstr "設定 - 一般"
+
+#: id:10009
+msgid "Settings - Screen"
+msgstr "設定 - 螢幕"
+
+#: id:10010
+msgid "Settings - Appearance - GUI Calibration"
+msgstr "設定 - 佈景主題 - 界面校正"
+
+#: id:10011
+msgid "Settings - Videos - Screen Calibration"
+msgstr "設定 - 視訊 - 螢幕校正"
+
+#: id:10012
+msgid "Settings - Pictures"
+msgstr "設定 - 圖片"
+
+#: id:10013
+msgid "Settings - Programs"
+msgstr "設定 - 程式"
+
+#: id:10014
+msgid "Settings - Weather"
+msgstr "設定 - 氣象"
+
+#: id:10015
+msgid "Settings - Music"
+msgstr "設定 - 音樂"
+
+#: id:10016
+msgid "Settings - System"
+msgstr "設定 - 系統"
+
+#: id:10017
+msgid "Settings - Videos"
+msgstr "設定 - 視訊"
+
+#: id:10018
+msgid "Settings - Network"
+msgstr "設定 - 網路"
+
+#: id:10019
+msgid "Settings - Appearance"
+msgstr "設定 - 佈景主題"
+
+#: id:10020
+msgctxt "Auto context with id 10020"
+msgid "Scripts"
+msgstr "腳本"
+
+#: id:10021
+msgid "Web Browser"
+msgstr "網路瀏覽器"
+
+#: id:10025
+msgctxt "Auto context with id 10025"
+msgid "Videos"
+msgstr "視訊"
+
+#: id:10028
+msgid "Videos/Playlist"
+msgstr "視訊/播放列表"
+
+#: id:10029
+msgctxt "Auto context with id 10029"
+msgid "Login screen"
+msgstr "登入畫面"
+
+#: id:10034
+msgid "Settings - Profiles"
+msgstr "設定 - 使用者設定檔"
+
+#: id:10040
+msgid "Addon browser"
+msgstr "附加元件瀏覽器"
+
+#: id:10100
+msgid "Yes/No dialog"
+msgstr "確認對話框"
+
+#: id:10101
+msgid "Progress dialog"
+msgstr "進度對話框"
+
+#: id:10210
+msgid "Looking for subtitles..."
+msgstr "正在尋找字幕…"
+
+#: id:10211
+msgid "Looking for or caching subtitles..."
+msgstr "正在尋找或者快取字幕…"
+
+#: id:10212
+msgid "terminating"
+msgstr "結束中"
+
+#: id:10213
+msgid "buffering"
+msgstr "緩衝中"
+
+#: id:10214
+msgid "Opening stream"
+msgstr "打開串流媒體"
+
+#: id:10500
+msgid "Music/Playlist"
+msgstr "音樂/播放列表"
+
+#: id:10501
+msgid "Music/Files"
+msgstr "音樂/檔案"
+
+#: id:10502
+msgid "Music/Library"
+msgstr "音樂/資料庫"
+
+#: id:10503
+msgid "Playlist editor"
+msgstr "播放列表編輯"
+
+#: id:10504
+msgid "Top 100 songs"
+msgstr "排行前100歌曲"
+
+#: id:10505
+msgid "Top 100 albums"
+msgstr "排行前100專輯"
+
+#: id:10506
+msgctxt "Auto context with id 10506"
+msgid "Programs"
+msgstr "程式"
+
+#: id:10507
+msgid "Configuration"
+msgstr "系統設定"
+
+#: id:10508
+msgid "Weather forecast"
+msgstr "氣象預報"
+
+#: id:10509
+msgid "Network gaming"
+msgstr "網路遊戲"
+
+#: id:10510
+msgid "Extensions"
+msgstr "擴充功能"
+
+#: id:10511
+msgctxt "Auto context with id 10511"
+msgid "System info"
+msgstr "系統資訊"
+
+#: id:10516
+msgid "Music - Library"
+msgstr "音樂 - 資料庫"
+
+#: id:10517
+msgid "Now Playing - Music"
+msgstr "現正播放 - 音樂"
+
+#: id:10522
+msgid "Now Playing - Videos"
+msgstr "現在播放 - 視訊"
+
+#: id:10523
+msgid "Album info"
+msgstr "專輯資訊"
+
+#: id:10524
+msgid "Movie info"
+msgstr "電影資訊"
+
+#: id:12000
+msgid "Select dialog"
+msgstr "選擇對話"
+
+#: id:12001
+msgid "Music/Info"
+msgstr "音樂/資訊"
+
+#: id:12002
+msgid "Dialog OK"
+msgstr "確認"
+
+#: id:12003
+msgid "Videos/Info"
+msgstr "視訊/資訊"
+
+#: id:12004
+msgid "Scripts/Info"
+msgstr "腳本/資訊"
+
+#: id:12005
+msgid "Fullscreen video"
+msgstr "全螢幕視訊"
+
+#: id:12006
+msgid "Audio visualization"
+msgstr "音效視覺效果"
+
+#: id:12008
+msgid "File stacking dialog"
+msgstr "檔案堆疊對話框"
+
+#: id:12009
+msgid "Rebuild index..."
+msgstr "重建目錄索引…"
+
+#: id:12010
+msgid "Return to music window"
+msgstr "返回音樂視窗"
+
+#: id:12011
+msgid "Return to videos window"
+msgstr "返回視訊視窗"
+
+#: id:12021
+msgid "Start from beginning"
+msgstr "從頭開始播放"
+
+#: id:12022
+msgid "Resume from %s"
+msgstr "從 %s 開始播放"
+
+#: id:12310
+msgid "0"
+msgstr "0"
+
+#: id:12311
+msgid "1"
+msgstr "1"
+
+#: id:12312
+msgid "2"
+msgstr "2"
+
+#: id:12313
+msgid "3"
+msgstr "3"
+
+#: id:12314
+msgid "4"
+msgstr "4"
+
+#: id:12315
+msgid "5"
+msgstr "5"
+
+#: id:12316
+msgid "6"
+msgstr "6"
+
+#: id:12317
+msgid "7"
+msgstr "7"
+
+#: id:12318
+msgid "8"
+msgstr "8"
+
+#: id:12319
+msgid "9"
+msgstr "9"
+
+#: id:12320
+msgid "c"
+msgstr "←"
+
+#: id:12321
+msgid "Ok"
+msgstr "Ok"
+
+#: id:12322
+msgid "*"
+msgstr "*"
+
+#: id:12325
+msgid "Locked! Enter code..."
+msgstr "已鎖定！ 輸入密碼…"
+
+#: id:12326
+msgid "Enter password"
+msgstr "輸入密碼"
+
+#: id:12327
+msgid "Enter master code"
+msgstr "輸入管理員密碼"
+
+#: id:12328
+msgid "Enter unlock code"
+msgstr "輸入解鎖密碼"
+
+#: id:12329
+msgid "or press C to cancel"
+msgstr "或按 C 取消"
+
+#: id:12330
+msgid "Enter gamepad button combo and"
+msgstr "輸入手把按鍵組合並且"
+
+#: id:12331
+msgid "press OK, or Back to cancel"
+msgstr "按 Start 確認，或按 Back 取消"
+
+#: id:12332
+msgid "Set lock"
+msgstr "設定鎖定"
+
+#: id:12333
+msgid "Unlock"
+msgstr "解除鎖定"
+
+#: id:12334
+msgid "Reset lock"
+msgstr "重設鎖定"
+
+#: id:12335
+msgid "Remove lock"
+msgstr "移除鎖定"
+
+#: id:12337
+msgid "Numeric password"
+msgstr "數字密碼"
+
+#: id:12338
+msgid "Gamepad button combo"
+msgstr "手把按鍵組合"
+
+#: id:12339
+msgid "Full-text password"
+msgstr "文字密碼"
+
+#: id:12340
+msgid "Enter new password"
+msgstr "輸入新密碼"
+
+#: id:12341
+msgid "Re-Enter new password"
+msgstr "確認新密碼"
+
+#: id:12342
+msgid "Incorrect password,"
+msgstr "密碼不正確，"
+
+#: id:12343
+msgid "retries left"
+msgstr "重試次數"
+
+#: id:12344
+msgid "Passwords entered did not match."
+msgstr "輸入的密碼不正確。"
+
+#: id:12345
+msgid "Access denied"
+msgstr "拒絕讀取"
+
+#: id:12346
+msgid "Password retry limit exceeded."
+msgstr "已達密碼重試次數限制。"
+
+#: id:12347
+msgid "The system will now shut off."
+msgstr "系統將要立刻關閉。"
+
+#: id:12348
+msgid "Item locked"
+msgstr "項目被鎖定"
+
+#: id:12353
+msgid "Reactivate lock"
+msgstr "重新上鎖"
+
+#: id:12356
+msgid "Change lock"
+msgstr "更改鎖定"
+
+#: id:12357
+msgid "Source lock"
+msgstr "來源鎖定"
+
+#: id:12358
+msgid "Password entry was blank. Try again."
+msgstr "密碼不能空白，請重試。"
+
+#: id:12360
+msgid "Master lock"
+msgstr "主機鎖定"
+
+#: id:12362
+msgid "Shutdown system if Master Lock retries exceeded"
+msgstr "超過重試次數就關機"
+
+#: id:12367
+msgid "Master code is not valid"
+msgstr "管理員密碼錯誤！"
+
+#: id:12368
+msgid "Please enter a valid master code"
+msgstr "請輸入正確的管理員密碼！"
+
+#: id:12373
+msgid "Settings & file manager"
+msgstr "系統設定和檔案總管"
+
+#: id:12376
+msgid "Set as default for all movies"
+msgstr "設定為影片的預設值"
+
+#: id:12377
+msgid "This will reset any previously saved values"
+msgstr "將重設之前的設定"
+
+#: id:12378
+msgid "Amount of time to display each image"
+msgstr "顯示各個圖像"
+
+#: id:12379
+msgid "Use pan and zoom effects"
+msgstr "使用移動和縮放特效"
+
+#: id:12383
+msgid "12 hour clock"
+msgstr "12小時制"
+
+#: id:12384
+msgid "24 hour clock"
+msgstr "24小時制"
+
+#: id:12385
+msgid "Day/Month"
+msgstr "日/月"
+
+#: id:12386
+msgid "Month/Day"
+msgstr "月/日"
+
+#: id:12390
+msgid "System uptime"
+msgstr "系統已運作時間"
+
+#: id:12391
+msgid "Minutes"
+msgstr "分鐘"
+
+#: id:12392
+msgid "Hours"
+msgstr "小時"
+
+#: id:12393
+msgid "Days"
+msgstr "天"
+
+#: id:12394
+msgid "Total uptime"
+msgstr "累計運作時間"
+
+#: id:12395
+msgid "Battery level"
+msgstr "電池狀態"
+
+#: id:12600
+msgctxt "Auto context with id 12600"
+msgid "Weather"
+msgstr "氣象"
+
+#: id:12900
+msgctxt "Auto context with id 12900"
+msgid "Screensaver"
+msgstr "螢幕保護"
+
+#: id:12901
+msgid "Fullscreen OSD"
+msgstr "全螢幕畫面調整"
+
+#: id:13000
+msgid "System"
+msgstr "系統設定"
+
+#: id:13001
+msgid "Immediate HD spindown"
+msgstr "立即關閉硬碟"
+
+#: id:13002
+msgid "Video only"
+msgstr "只有視訊"
+
+#: id:13003
+msgid "- Delay"
+msgstr "- 延遲"
+
+#: id:13004
+msgid "- Minimum file duration"
+msgstr "- 最小媒體檔案長度"
+
+#: id:13005
+msgid "Shutdown"
+msgstr "關機"
+
+#: id:13008
+msgid "Shutdown function"
+msgstr "預設關機模式"
+
+#: id:13009
+msgid "Quit"
+msgstr "退出"
+
+#: id:13010
+msgid "Hibernate"
+msgstr "休眠"
+
+#: id:13011
+msgid "Suspend"
+msgstr "待機"
+
+#: id:13012
+msgid "Exit"
+msgstr "離開"
+
+#: id:13013
+msgid "Reboot"
+msgstr "重新啟動"
+
+#: id:13014
+msgid "Minimize"
+msgstr "最小化"
+
+#: id:13015
+msgid "Power button action"
+msgstr "電源按鈕作用"
+
+#: id:13016
+msgid "Power off System"
+msgstr "關閉系統"
+
+#: id:13020
+msgid "Is another session active, perhaps over ssh?"
+msgstr "是否有透過 ssh 連接的會話存在？"
+
+#: id:13021
+msgid "Mounted removable harddrive"
+msgstr "掛載行動碟"
+
+#: id:13022
+msgid "Unsafe device removal"
+msgstr "不安全的移除裝置"
+
+#: id:13023
+msgid "Successfully removed device"
+msgstr "順利的移除裝置"
+
+#: id:13024
+msgid "Joystick plugged"
+msgstr "手把連接"
+
+#: id:13025
+msgid "Joystick unplugged"
+msgstr "手把沒有連接"
+
+#: id:13050
+msgid "Running low on battery"
+msgstr "電池電量不足"
+
+#: id:13100
+msgid "Flicker filter"
+msgstr "閃爍過濾"
+
+#: id:13101
+msgid "Let driver choose (requires restart)"
+msgstr "讓驅動選擇(必須重新啟動)"
+
+#: id:13105
+msgid "Vertical blank sync"
+msgstr "垂直空白同步"
+
+#: id:13106
+msgctxt "Auto context with id 13106"
+msgid "Disabled"
+msgstr "停用"
+
+#: id:13107
+msgid "Enabled during video playback"
+msgstr "啟用 在視訊播放時"
+
+#: id:13108
+msgctxt "Auto context with id 13108"
+msgid "Always enabled"
+msgstr "強制啟用"
+
+#: id:13109
+msgid "Test & apply resolution"
+msgstr "測試解析度"
+
+#: id:13110
+msgid "Save resolution?"
+msgstr "儲存此解析度？"
+
+#: id:13111
+msgid "Would you like to keep this resolution?"
+msgstr "是否儲存此解析度？"
+
+#: id:13112
+msgid "High quality upscaling"
+msgstr "高品質軟體升頻"
+
+#: id:13113
+msgctxt "Auto context with id 13113"
+msgid "Disabled"
+msgstr "停用"
+
+#: id:13114
+msgid "Enabled for SD content"
+msgstr "在480解析度時啟用"
+
+#: id:13115
+msgctxt "Auto context with id 13115"
+msgid "Always enabled"
+msgstr "始終啟用"
+
+#: id:13116
+msgid "Upscaling method"
+msgstr "升頻方式"
+
+#: id:13117
+msgctxt "Auto context with id 13117"
+msgid "Bicubic"
+msgstr "Bicubic"
+
+#: id:13118
+msgid "Lanczos"
+msgstr "Lanczos"
+
+#: id:13119
+msgid "Sinc"
+msgstr "Sinc"
+
+#: id:13120
+msgctxt "Auto context with id 13120"
+msgid "VDPAU"
+msgstr "VDPAU 硬體解碼"
+
+#: id:13121
+msgid "VDPAU HQ Upscaling level"
+msgstr "VDPAU 高品質倍線等級"
+
+#: id:13122
+msgid "VDPAU Studio level color conversion"
+msgstr "VDPAU 視聽室等級色彩轉換"
+
+#: id:13130
+msgid "Blank other displays"
+msgstr "顯示空白"
+
+#: id:13131
+msgctxt "Auto context with id 13131"
+msgid "Disabled"
+msgstr "停用"
+
+#: id:13132
+msgid "Blank displays"
+msgstr "空白顯示"
+
+#: id:13140
+msgid "Active connections detected!"
+msgstr "主動偵測連接！"
+
+#: id:13141
+msgid "If you proceed, you might not be able to control XBMC"
+msgstr "如果你繼續，你也許會不能控制 XBMC"
+
+#: id:13142
+msgid "any longer. Are you sure you want to stop the Event server?"
+msgstr "更長的時間，你是否確定停止事件伺服器？"
+
+#: id:13144
+msgid "Change Apple Remote mode?"
+msgstr "更改 Apple 遙控器模式？"
+
+#: id:13145
+msgid "If you are currently using the Apple Remote to control"
+msgstr "如果你正使用 Apple 遙控器來控制"
+
+#: id:13146
+msgid "XBMC, changing this setting might affect your ability"
+msgstr "XBMC，更改此設定可能會影響到你"
+
+#: id:13147
+msgid "to continue controlling it. Do you want to proceed?"
+msgstr "繼續控制它，你要繼續嗎？"
+
+#: id:13159
+msgid "Subnet mask"
+msgstr "子網路遮罩"
+
+#: id:13160
+msgid "Gateway"
+msgstr "閘道位址"
+
+#: id:13161
+msgid "Primary DNS"
+msgstr "主要的 DNS 位址"
+
+#: id:13162
+msgid "Initialize failed"
+msgstr "初始化失敗"
+
+#: id:13170
+msgctxt "Auto context with id 13170"
+msgid "Never"
+msgstr "從不"
+
+#: id:13171
+msgid "Immediately"
+msgstr "立即"
+
+#: id:13172
+msgid "After %i secs"
+msgstr "隔 %i 秒之後"
+
+#: id:13173
+msgid "HDD install date:"
+msgstr "硬碟安裝日期："
+
+#: id:13174
+msgid "HDD power cycle count:"
+msgstr "硬碟運轉週期："
+
+#: id:13200
+msgid "Profiles"
+msgstr "設定檔"
+
+#: id:13201
+msgid "Delete profile '%s'?"
+msgstr "要刪除設定檔 '%s' 嗎？"
+
+#: id:13204
+msgid "Last loaded profile:"
+msgstr "最近載入的設定檔："
+
+#: id:13205
+msgid "Unknown"
+msgstr "未知"
+
+#: id:13206
+msgid "Overwrite"
+msgstr "覆蓋"
+
+#: id:13208
+msgid "Alarm clock"
+msgstr "鬧鈴"
+
+#: id:13209
+msgid "Alarm clock interval (in minutes)"
+msgstr "鬧鈴間隔(分鐘)"
+
+#: id:13210
+msgid "Started, alarm in %im"
+msgstr "鬧鈴啟動，倒數計時 %i 分鐘"
+
+#: id:13211
+msgid "Alarm!"
+msgstr "響鈴！"
+
+#: id:13212
+msgid "Canceled with %im%is left"
+msgstr "鬧鈴取消，剩下 %i 分 %i 秒"
+
+#: id:13213
+msgid "%2.0fm"
+msgstr "%2.0f分"
+
+#: id:13214
+msgid "%2.0fs"
+msgstr "%2.0f秒"
+
+#: id:13249
+msgid "Search for subtitles in RARs"
+msgstr "掃瞄 RAR 檔案中的字幕"
+
+#: id:13250
+msgid "Browse for subtitle..."
+msgstr "瀏覽字幕…"
+
+#: id:13251
+msgid "Move item"
+msgstr "移動該項目"
+
+#: id:13252
+msgid "Move item here"
+msgstr "將項目移動至此"
+
+#: id:13253
+msgid "Cancel move"
+msgstr "取消移動"
+
+#: id:13270
+msgid "Hardware:"
+msgstr "硬體："
+
+#: id:13271
+msgid "CPU Usage:"
+msgstr "CPU 使用率："
+
+#: id:13274
+msgid "Connected, but no DNS is available."
+msgstr "已連線，但是 DNS 無法使用。"
+
+#: id:13275
+msgid "Hard Disk"
+msgstr "硬碟"
+
+#: id:13276
+msgid "DVD-ROM"
+msgstr "光碟機"
+
+#: id:13277
+msgctxt "Auto context with id 13277"
+msgid "Storage"
+msgstr "儲存裝置"
+
+#: id:13278
+msgctxt "Auto context with id 13278"
+msgid "Default"
+msgstr "預設"
+
+#: id:13279
+msgctxt "Auto context with id 13279"
+msgid "Network"
+msgstr "網路"
+
+#: id:13280
+msgctxt "Auto context with id 13280"
+msgid "Video"
+msgstr "視訊"
+
+#: id:13281
+msgid "Hardware"
+msgstr "硬體"
+
+#: id:13283
+msgid "Operating system:"
+msgstr "作業系統："
+
+#: id:13284
+msgid "CPU speed:"
+msgstr "CPU 速度："
+
+#: id:13286
+msgid "Video encoder:"
+msgstr "視訊晶片："
+
+#: id:13287
+msgid "Screen resolution:"
+msgstr "螢幕解析度："
+
+#: id:13292
+msgid "A/V cable:"
+msgstr "影音端子："
+
+#: id:13294
+msgid "DVD region:"
+msgstr "DVD 區碼："
+
+#: id:13295
+msgid "Internet:"
+msgstr "網際網路："
+
+#: id:13296
+msgctxt "Auto context with id 13296"
+msgid "Connected"
+msgstr "已連線"
+
+#: id:13297
+msgid "Not connected. Check network settings."
+msgstr "無法連線，請檢查網路設定。"
+
+#: id:13299
+msgid "Target temperature"
+msgstr "目標溫度"
+
+#: id:13300
+msgid "Fan speed"
+msgstr "風扇轉速"
+
+#: id:13301
+msgid "Auto temperature control"
+msgstr "自動控溫"
+
+#: id:13302
+msgid "Fan speed override"
+msgstr "指定風扇轉速"
+
+#: id:13303
+msgid "- Fonts"
+msgstr "- 字型"
+
+#: id:13304
+msgid "Enable flipping bi-directional strings"
+msgstr "啟用 轉換雙向字串"
+
+#: id:13305
+msgid "Show RSS news feeds"
+msgstr "啟用 RSS 新聞顯示"
+
+#: id:13306
+msgid "Show parent folder items"
+msgstr "隱藏上層資料夾項目"
+
+#: id:13307
+msgid "Track naming template"
+msgstr "音軌命名參數"
+
+#: id:13308
+msgid "Do you wish to reboot your system"
+msgstr "你要將系統重新啟動"
+
+#: id:13309
+msgid "instead of just XBMC?"
+msgstr "以重新啟動 XBMC 嗎？"
+
+#: id:13310
+msgid "Zoom effect"
+msgstr "縮放效果"
+
+#: id:13311
+msgid "Float effect"
+msgstr "浮動效果"
+
+#: id:13312
+msgid "Black bar reduction"
+msgstr "縮小黑邊"
+
+#: id:13313
+msgid "Restart"
+msgstr "重新啟動"
+
+#: id:13314
+msgid "Crossfade between songs"
+msgstr "淡入淡出"
+
+#: id:13315
+msgid "Regenerate thumbnails"
+msgstr "建立縮略圖"
+
+#: id:13316
+msgid "Recursive thumbnails"
+msgstr "重覆縮略圖"
+
+#: id:13317
+msgid "View slideshow"
+msgstr "觀看圖片"
+
+#: id:13318
+msgid "Recursive slideshow"
+msgstr "重覆圖片"
+
+#: id:13319
+msgid "Randomize"
+msgstr "隨機"
+
+#: id:13320
+msgid "Stereo"
+msgstr "立體聲"
+
+#: id:13321
+msgid "Left only"
+msgstr "左聲道"
+
+#: id:13322
+msgid "Right only"
+msgstr "右聲道"
+
+#: id:13323
+msgid "Enable karaoke support"
+msgstr "啟用 卡拉OK 支援"
+
+#: id:13324
+msgid "Background transparency"
+msgstr "背景透明度"
+
+#: id:13325
+msgid "Foreground transparency"
+msgstr "前景透明度"
+
+#: id:13326
+msgid "A/V delay"
+msgstr "影音延遲"
+
+#: id:13327
+msgid "Karaoke"
+msgstr "卡拉OK"
+
+#: id:13328
+msgid "%s not found"
+msgstr "%s 找不到"
+
+#: id:13329
+msgid "Error opening %s"
+msgstr "打開 %s 發生錯誤"
+
+#: id:13330
+msgid "Unable to load %s"
+msgstr "無法載入 %s"
+
+#: id:13331
+msgid "Error: Out of memory"
+msgstr "錯誤：記憶體不足"
+
+#: id:13332
+msgid "Move up"
+msgstr "上移"
+
+#: id:13333
+msgid "Move down"
+msgstr "下移"
+
+#: id:13334
+msgid "Edit label"
+msgstr "編輯標籤"
+
+#: id:13335
+msgid "Make default"
+msgstr "設為預設值"
+
+#: id:13336
+msgid "Remove button"
+msgstr "移除按鍵"
+
+#: id:13340
+msgid "Leave as is"
+msgstr "讓它為"
+
+#: id:13341
+msgid "Green"
+msgstr "綠色"
+
+#: id:13342
+msgid "Orange"
+msgstr "橙色"
+
+#: id:13343
+msgid "Red"
+msgstr "紅色"
+
+#: id:13344
+msgid "Cycle"
+msgstr "循環"
+
+#: id:13345
+msgid "Switch LED off on playback"
+msgstr "當播放時關閉顯示燈"
+
+#: id:13346
+msgctxt "Auto context with id 13346"
+msgid "Movie information"
+msgstr "影片資訊"
+
+#: id:13347
+msgid "Queue item"
+msgstr "佇列項目"
+
+#: id:13348
+msgid "Search IMDb..."
+msgstr "搜尋 IMDb 資訊…"
+
+#: id:13349
+msgid "Scan for new content"
+msgstr "掃描新內容"
+
+#: id:13350
+msgid "Now playing..."
+msgstr "現正播放…"
+
+#: id:13351
+msgctxt "Auto context with id 13351"
+msgid "Album information"
+msgstr "專輯資訊"
+
+#: id:13352
+msgid "Scan item to library"
+msgstr "掃描項目到資料庫"
+
+#: id:13353
+msgid "Stop scanning"
+msgstr "停止掃描"
+
+#: id:13354
+msgctxt "Auto context with id 13354"
+msgid "Render method"
+msgstr "補償方式"
+
+#: id:13355
+msgid "Low quality pixel shader"
+msgstr "低品質像素著色器"
+
+#: id:13356
+msgid "Hardware overlays"
+msgstr "硬體重疊"
+
+#: id:13357
+msgid "High quality pixel shader"
+msgstr "高品質像素著色器"
+
+#: id:13358
+msgid "Play item"
+msgstr "播放項目"
+
+#: id:13359
+msgid "Set artist thumb"
+msgstr "設定藝人縮圖"
+
+#: id:13360
+msgid "Automatically generate thumbnails"
+msgstr "建立縮圖"
+
+#: id:13361
+msgid "Enable voice"
+msgstr "啟用語音"
+
+#: id:13375
+msgid "Enable device"
+msgstr "啟動裝置"
+
+#: id:13376
+msgid "Volume"
+msgstr "音量"
+
+#: id:13377
+msgid "Default view mode"
+msgstr "預設顯示模式"
+
+#: id:13378
+msgid "Default brightness"
+msgstr "預設亮度"
+
+#: id:13379
+msgid "Default contrast"
+msgstr "預設對比"
+
+#: id:13380
+msgid "Default gamma"
+msgstr "預設伽瑪值"
+
+#: id:13381
+msgid "Resume video"
+msgstr "接續播放本片"
+
+#: id:13382
+msgid "Voice mask - Port 1"
+msgstr "語音特效 - 第 1 埠"
+
+#: id:13383
+msgid "Voice mask - Port 2"
+msgstr "語音特效 - 第 2 埠"
+
+#: id:13384
+msgid "Voice mask - Port 3"
+msgstr "語音特效 - 第 3 埠"
+
+#: id:13385
+msgid "Voice mask - Port 4"
+msgstr "語音特效 - 第 4 埠"
+
+#: id:13386
+msgid "Use time based seeking"
+msgstr "使用時間搜尋"
+
+#: id:13387
+msgid "Track naming template - right"
+msgstr "音軌命名格式"
+
+#: id:13388
+msgid "Preset"
+msgstr "預設"
+
+#: id:13389
+msgid "There are no presets available\nfor this visualization"
+msgstr "該視覺效果 沒有預設值"
+
+#: id:13390
+msgid "There are no settings available\nfor this visualization"
+msgstr "該視覺效果 沒有可用的設定"
+
+#: id:13391
+msgid "Eject/Load"
+msgstr "托盤開/關"
+
+#: id:13392
+msgid "Use visualization if playing audio"
+msgstr "撥放音效時使用視覺效果"
+
+#: id:13393
+msgid "Calculate size"
+msgstr "計算大小"
+
+#: id:13394
+msgid "Calculating folder size"
+msgstr "計算資料夾大小"
+
+#: id:13395
+msgid "Video settings"
+msgstr "視訊設定"
+
+#: id:13396
+msgid "Audio and subtitle settings"
+msgstr "音效和字幕設定"
+
+#: id:13397
+msgid "Enable subtitles"
+msgstr "啟用字幕"
+
+#: id:13398
+msgctxt "Auto context with id 13398"
+msgid "Shortcuts"
+msgstr "捷徑"
+
+#: id:13399
+msgid "Ignore articles when sorting (e.g. \"the\")"
+msgstr "排序時忽略符號"
+
+#: id:13400
+msgid "Crossfade between songs on the same album"
+msgstr "專輯音軌淡入淡出"
+
+#: id:13401
+msgid "Browse for %s"
+msgstr "瀏覽 %s"
+
+#: id:13402
+msgid "Show track position"
+msgstr "顯示音軌位置"
+
+#: id:13403
+msgid "Clear default"
+msgstr "清除預設值"
+
+#: id:13404
+msgid "Resume"
+msgstr "恢復"
+
+#: id:13405
+msgid "Get thumb"
+msgstr "取得縮圖"
+
+#: id:13406
+msgid "Picture information"
+msgstr "圖片資訊"
+
+#: id:13407
+msgid "%s presets"
+msgstr "%s 預設"
+
+#: id:13408
+msgid "(IMDb user rating)"
+msgstr "(IMDb 用戶評價)"
+
+#: id:13409
+msgid "Top 250"
+msgstr "排名前250"
+
+#: id:13410
+msgid "Tune in on Last.fm"
+msgstr "收聽 Last.FM"
+
+#: id:13411
+msgid "Minimum fan speed"
+msgstr "最低風扇轉速"
+
+#: id:13412
+msgid "Play from here"
+msgstr "從這裡開始播放"
+
+#: id:13413
+msgid "Downloading"
+msgstr "下載中"
+
+#: id:13414
+msgid "Include artists who appear only on compilations"
+msgstr "隱藏只在編輯出現的藝人"
+
+#: id:13415
+msgctxt "Auto context with id 13415"
+msgid "Render method"
+msgstr "渲染模式"
+
+#: id:13416
+msgid "Auto detect"
+msgstr "自動檢測"
+
+#: id:13417
+msgid "Basic shaders (ARB)"
+msgstr "基本著色(ARB)"
+
+#: id:13418
+msgid "Advanced shaders (GLSL)"
+msgstr "高級著色(GLSL)"
+
+#: id:13419
+msgid "Software"
+msgstr "軟體著色"
+
+#: id:13420
+msgid "Remove safely"
+msgstr "托盤開啓"
+
+#: id:13421
+msgctxt "Auto context with id 13421"
+msgid "VDPAU"
+msgstr "VDPAU 硬體解碼"
+
+#: id:13422
+msgid "Start slideshow here"
+msgstr "開始幻燈片播放"
+
+#: id:13423
+msgid "Remember for this path"
+msgstr "記住此路徑"
+
+#: id:13424
+msgid "Use pixel buffer objects"
+msgstr "使用像素緩衝物件"
+
+#: id:13425
+msgid "Allow hardware acceleration (VDPAU)"
+msgstr "允許硬體加速 (VDPAU)"
+
+#: id:13426
+msgid "Allow hardware acceleration (VAAPI)"
+msgstr "允許硬體加速 (VAAPI)"
+
+#: id:13427
+msgid "Allow hardware acceleration (DXVA2)"
+msgstr "允許硬體加速 (DXVA2)"
+
+#: id:13428
+msgid "Allow hardware acceleration (CrystalHD)"
+msgstr "允許硬體加速 (CrystalHD)"
+
+#: id:13429
+msgid "Allow hardware acceleration (VDADecoder)"
+msgstr "允許硬體加速 (VDADecoder)"
+
+#: id:13430
+msgid "Allow hardware acceleration (OpenMax)"
+msgstr "允許硬體加速 (OpenMax)"
+
+#: id:13431
+msgid "Pixel Shaders"
+msgstr "Pixel Shaders"
+
+#: id:13432
+msgid "Allow hardware acceleration (VideoToolbox)"
+msgstr "允許硬體加速（VideoToolbox）"
+
+#: id:13500
+msgid "A/V sync method"
+msgstr "影音同步方式"
+
+#: id:13501
+msgid "Audio clock"
+msgstr "音效為主"
+
+#: id:13502
+msgid "Video clock (Drop/Dupe audio)"
+msgstr "視訊為主(放棄/重複音效)"
+
+#: id:13503
+msgid "Video clock (Resample audio)"
+msgstr "視訊為主(重新取樣音效)"
+
+#: id:13504
+msgid "Maximum resample amount (%)"
+msgstr "最高重取樣速率(%)"
+
+#: id:13505
+msgid "Resample quality"
+msgstr "重取樣品質"
+
+#: id:13506
+msgid "Low(fast)"
+msgstr "低(快)"
+
+#: id:13507
+msgctxt "Auto context with id 13507"
+msgid "Medium"
+msgstr "中"
+
+#: id:13508
+msgctxt "Auto context with id 13508"
+msgid "High"
+msgstr "高"
+
+#: id:13509
+msgid "Really high(slow!)"
+msgstr "極高(慢!)"
+
+#: id:13510
+msgid "Sync playback to display"
+msgstr "同步重播顯示"
+
+#: id:13550
+msgid "Pause during refresh rate change"
+msgstr "當變更更新率時暫停"
+
+#: id:13551
+msgctxt "Auto context with id 13551"
+msgid "Off"
+msgstr "關閉"
+
+#: id:13552
+msgid "%.1f Second"
+msgstr "%.1f秒"
+
+#: id:13553
+msgid "%.1f Seconds"
+msgstr "%.1f秒"
+
+#: id:13600
+msgid "Apple remote"
+msgstr "Apple 遙控器"
+
+#: id:13602
+msgid "Allow start of XBMC using the remote"
+msgstr "允許用遙控器啟動 XBMC"
+
+#: id:13603
+msgid "Sequence delay time"
+msgstr "序列延遲時間"
+
+#: id:13610
+msgctxt "Auto context with id 13610"
+msgid "Disabled"
+msgstr "關閉"
+
+#: id:13611
+msgctxt "Auto context with id 13611"
+msgid "Standard"
+msgstr "標準"
+
+#: id:13612
+msgid "Universal Remote"
+msgstr "通用遙控器"
+
+#: id:13613
+msgid "Multi Remote (Harmony)"
+msgstr "萬能遙控器(Harmony)"
+
+#: id:13620
+msgid "Apple Remote Error"
+msgstr "Apple 遙控器錯誤"
+
+#: id:13621
+msgid "Apple Remote support could be enabled."
+msgstr "Apple 遙控器支援啟用。"
+
+#: id:14000
+msgid "Stack"
+msgstr "堆疊開啟"
+
+#: id:14001
+msgid "Unstack"
+msgstr "堆疊關閉"
+
+#: id:14003
+msgid "Downloading playlist file..."
+msgstr "下載播放列表檔案…"
+
+#: id:14004
+msgid "Downloading streams list..."
+msgstr "下載串流媒體列表…"
+
+#: id:14005
+msgid "Parsing streams list..."
+msgstr "分析串流媒體列表…"
+
+#: id:14006
+msgid "Downloading streams list failed"
+msgstr "下載串流媒體列表失敗"
+
+#: id:14007
+msgid "Downloading playlist file failed"
+msgstr "下載播放列表檔案失敗"
+
+#: id:14009
+msgid "Games directory"
+msgstr "遊戲目錄"
+
+#: id:14010
+msgid "Auto switch to thumbs based on"
+msgstr "自動切換為縮圖顯示"
+
+#: id:14011
+msgid "Enable auto switching to thumbs view"
+msgstr "啟用 自動切換為縮圖顯示"
+
+#: id:14012
+msgid "- Use large icons"
+msgstr "- 使用大圖示"
+
+#: id:14013
+msgid "- Switch based on"
+msgstr "- 條件"
+
+#: id:14014
+msgid "- Percentage"
+msgstr "- 百分比"
+
+#: id:14015
+msgid "No files and at least one thumb"
+msgstr "沒有檔案且最少有一個縮圖"
+
+#: id:14016
+msgid "At least one file and thumb"
+msgstr "最少有一個檔案和縮圖"
+
+#: id:14017
+msgid "Percentage of thumbs"
+msgstr "縮圖所占比例"
+
+#: id:14018
+msgid "View options"
+msgstr "瀏覽設定"
+
+#: id:14019
+msgid "Change area code 1"
+msgstr "改變區碼 1"
+
+#: id:14020
+msgid "Change area code 2"
+msgstr "改變區碼 2"
+
+#: id:14021
+msgid "Change area code 3"
+msgstr "改變區碼 3"
+
+#: id:14022
+msgctxt "Auto context with id 14022"
+msgid "Library"
+msgstr "資料庫"
+
+#: id:14023
+msgid "No TV"
+msgstr "無電視"
+
+#: id:14024
+msgid "Enter the nearest large town"
+msgstr "輸入最近的城市"
+
+#: id:14025
+msgid "Video/Audio/DVD cache - Harddisk"
+msgstr "視訊/音效/光碟緩衝區 - 硬碟"
+
+#: id:14026
+msgid "Video cache - DVD-ROM"
+msgstr "視訊緩衝區 - 光碟機"
+
+#: id:14027
+msgctxt "Auto context with id 14027"
+msgid "- Local Network"
+msgstr "視訊緩衝區 - 區域網路"
+
+#: id:14028
+msgctxt "Auto context with id 14028"
+msgid "- Internet"
+msgstr "視訊緩衝區 - 網際網路"
+
+#: id:14030
+msgid "Audio cache - DVD-ROM"
+msgstr "音效緩衝區 - 光碟機"
+
+#: id:14031
+msgctxt "Auto context with id 14031"
+msgid "- Local Network"
+msgstr "音效緩衝區 - 區域網路"
+
+#: id:14032
+msgctxt "Auto context with id 14032"
+msgid "- Internet"
+msgstr "音效緩衝區 - 網際網路"
+
+#: id:14034
+msgid "DVD cache - DVD-ROM"
+msgstr "光碟緩衝區 - 光碟機"
+
+#: id:14035
+msgctxt "Auto context with id 14035"
+msgid "- Local Network"
+msgstr "光碟緩衝區 - 區域網路"
+
+#: id:14036
+msgctxt "Auto context with id 14036"
+msgid "Services"
+msgstr "服務"
+
+#: id:14038
+msgid "Network settings changed"
+msgstr "網路設定已改變"
+
+#: id:14039
+msgid "XBMC requires to restart to change your"
+msgstr "XBMC 需要重新啟動以改變您的"
+
+#: id:14040
+msgid "network setup. Would you like to restart now?"
+msgstr "網路設定。 你要現在重新啟動嗎？"
+
+#: id:14041
+msgid "Internet connection bandwidth limitation"
+msgstr "網際網路連線頻寬限制"
+
+#: id:14043
+msgid "- Shutdown while playing"
+msgstr "- 播放時關機"
+
+#: id:14044
+msgid "%i min"
+msgstr "%i 分"
+
+#: id:14045
+msgid "%i sec"
+msgstr "%i 秒"
+
+#: id:14046
+msgid "%i ms"
+msgstr "%i 毫秒"
+
+#: id:14047
+msgid "%i %%"
+msgstr "%i %%"
+
+#: id:14048
+msgid "%i kbps"
+msgstr "%i kbps"
+
+#: id:14049
+msgid "%i kb"
+msgstr "%i kb"
+
+#: id:14050
+msgid "%i.0 dB"
+msgstr "%i.0 dB"
+
+#: id:14051
+msgid "Time format"
+msgstr "時間格式"
+
+#: id:14052
+msgid "Date format"
+msgstr "日期格式"
+
+#: id:14053
+msgid "GUI filters"
+msgstr "畫面濾鏡"
+
+#: id:14055
+msgid "Use background scanning"
+msgstr "使用背景搜尋"
+
+#: id:14056
+msgid "Stop scan"
+msgstr "停止搜尋"
+
+#: id:14057
+msgid "Not possible while scanning for media info"
+msgstr "無法搜尋媒體資訊"
+
+#: id:14058
+msgid "Film grain effect"
+msgstr "膠片顆粒濾鏡"
+
+#: id:14059
+msgid "Search for thumbnails on remote shares"
+msgstr "搜尋遠端分享的縮圖"
+
+#: id:14060
+msgid "Unknown type cache - Internet"
+msgstr "未知類型緩衝區 - 網際網路"
+
+#: id:14061
+msgctxt "Auto context with id 14061"
+msgid "Auto"
+msgstr "自動"
+
+#: id:14062
+msgid "Enter username for"
+msgstr "輸入帳號"
+
+#: id:14063
+msgid "Date & time"
+msgstr "日期 & 時間"
+
+#: id:14064
+msgid "Set date"
+msgstr "設定日期"
+
+#: id:14065
+msgid "Set time"
+msgstr "設定時間"
+
+#: id:14066
+msgid "Enter the time in 24 hour HH:MM format"
+msgstr "輸入時間 時:分"
+
+#: id:14067
+msgid "Enter the date in DD/MM/YYYY format"
+msgstr "輸入日期 日/月/年"
+
+#: id:14068
+msgid "Enter the IP address"
+msgstr "輸入 IP 位址"
+
+#: id:14069
+msgid "Apply these settings now?"
+msgstr "現在套用這些設定嗎？"
+
+#: id:14070
+msgid "Apply changes now"
+msgstr "現在套用改變"
+
+#: id:14071
+msgid "Allow file renaming and deletion"
+msgstr "允許重新命名和刪除檔案"
+
+#: id:14074
+msgid "Set timezone"
+msgstr "設定時區"
+
+#: id:14075
+msgid "Use daylight saving time"
+msgstr "使用日光節約時間"
+
+#: id:14076
+msgid "Add to favourites"
+msgstr "加入我的最愛"
+
+#: id:14077
+msgid "Remove from favourites"
+msgstr "從我的最愛中移除"
+
+#: id:14078
+msgctxt "Auto context with id 14078"
+msgid "- Colours"
+msgstr "- 桌面顏色"
+
+#: id:14079
+msgid "Timezone country"
+msgstr "時區國家"
+
+#: id:14080
+msgid "Timezone"
+msgstr "時區"
+
+#: id:14081
+msgid "File lists"
+msgstr "檔案列表"
+
+#: id:14082
+msgid "Show EXIF picture information"
+msgstr "顯示 EXIF 圖片資訊"
+
+#: id:14083
+msgid "Use a fullscreen window rather than true fullscreen"
+msgstr "使用全螢幕視窗而非真正全螢幕"
+
+#: id:14084
+msgid "Queue songs on selection"
+msgstr "選中歌曲加入播放清單"
+
+#: id:14086
+msgid "Playback"
+msgstr "播放"
+
+#: id:14087
+msgid "DVDs"
+msgstr "DVD"
+
+#: id:14088
+msgid "Play DVDs automatically"
+msgstr "自動播放 DVD"
+
+#: id:14089
+msgid "Font to use for text subtitles"
+msgstr "文字字幕檔字型"
+
+#: id:14090
+msgid "International"
+msgstr "介面語言"
+
+#: id:14091
+msgid "Character set"
+msgstr "字元集"
+
+#: id:14092
+msgid "Debugging"
+msgstr "偵錯中"
+
+#: id:14093
+msgid "Security"
+msgstr "安全"
+
+#: id:14094
+msgid "Input devices"
+msgstr "輸入裝置"
+
+#: id:14095
+msgid "Power saving"
+msgstr "省電模式"
+
+#: id:14096
+msgid "Rip"
+msgstr ""
+
+#: id:14097
+msgid "Audio CD Insert Action"
+msgstr ""
+
+#: id:14098
+msgctxt "Auto context with id 14098"
+msgid "Play"
+msgstr ""
+
+#: id:14099
+msgid "Eject disc when CD ripping is complete"
+msgstr ""
+
+#: id:15015
+msgctxt "Auto context with id 15015"
+msgid "Remove"
+msgstr "移除"
+
+#: id:15016
+msgid "Games"
+msgstr "遊戲"
+
+#: id:15019
+msgid "Add"
+msgstr "新增"
+
+#: id:15052
+msgid "Password"
+msgstr "密碼"
+
+#: id:15100
+msgctxt "Auto context with id 15100"
+msgid "Library"
+msgstr "瀏覽"
+
+#: id:15101
+msgid "Database"
+msgstr "資料庫"
+
+#: id:15102
+msgid "* All albums"
+msgstr "* 所有專輯"
+
+#: id:15103
+msgid "* All artists"
+msgstr "* 所有藝人"
+
+#: id:15104
+msgid "* All songs"
+msgstr "* 所有歌曲"
+
+#: id:15105
+msgid "* All genres"
+msgstr "* 所有類別"
+
+#: id:15107
+msgid "Buffering..."
+msgstr "緩衝中…"
+
+#: id:15108
+msgid "Navigation sounds"
+msgstr "按鍵音效"
+
+#: id:15109
+msgid "Skin default"
+msgstr "佈景主題預設"
+
+#: id:15111
+msgid "- Theme"
+msgstr "- 主題"
+
+#: id:15112
+msgid "Default theme"
+msgstr "預設主題"
+
+#: id:15200
+msgid "Last.fm"
+msgstr "Last.fm"
+
+#: id:15201
+msgid "Submit songs to Last.fm"
+msgstr "提交歌曲資訊到 Last.fm"
+
+#: id:15202
+msgid "Last.fm username"
+msgstr "Last.fm 帳號"
+
+#: id:15203
+msgid "Last.fm password"
+msgstr "Last.fm 密碼"
+
+#: id:15204
+msgid "Unable to handshake: sleeping..."
+msgstr "無法連線：休息中…"
+
+#: id:15205
+msgid "Please update XBMC"
+msgstr "請更新 XBMC"
+
+#: id:15206
+msgid "Bad authorization: Check username and password"
+msgstr "無法通過認證： 檢查帳號和密碼"
+
+#: id:15207
+msgctxt "Auto context with id 15207"
+msgid "Connected"
+msgstr "已連線"
+
+#: id:15208
+msgid "Not connected"
+msgstr "無法連線"
+
+#: id:15209
+msgid "Submit interval %i"
+msgstr "提交進度 %i"
+
+#: id:15210
+msgid "Cached %i songs"
+msgstr "已快取 %i 首歌曲"
+
+#: id:15211
+msgid "Submitting..."
+msgstr "提交中…"
+
+#: id:15212
+msgid "Submitting in %i secs"
+msgstr "提交剩餘 % i秒"
+
+#: id:15213
+msgid "Play using..."
+msgstr "播放方式…"
+
+#: id:15214
+msgid "Use smoothed A/V synchronization"
+msgstr "使用平滑的影音同步"
+
+#: id:15215
+msgid "Hide file names in thumbs view"
+msgstr "顯示縮圖時隱藏檔案名稱"
+
+#: id:15216
+msgid "Play in party mode"
+msgstr "派對模式播放"
+
+#: id:15217
+msgid "Submit songs to Libre.fm"
+msgstr "將歌曲提交到 Libre.fm"
+
+#: id:15218
+msgid "Libre.fm username"
+msgstr "Libre.fm 帳號"
+
+#: id:15219
+msgid "Libre.fm password"
+msgstr "Libre.fm 密碼"
+
+#: id:15220
+msgid "Libre.fm"
+msgstr "Libre.fm"
+
+#: id:15221
+msgid "Song submission"
+msgstr "提交歌曲"
+
+#: id:15250
+msgid "Submit Last.fm radio to Last.fm"
+msgstr "上傳電台到 Last.fm"
+
+#: id:15251
+msgid "Connecting to Last.fm..."
+msgstr "連線到 Last.fm…"
+
+#: id:15252
+msgid "Selecting station..."
+msgstr "選擇電台…"
+
+#: id:15253
+msgid "Search similar artists..."
+msgstr "尋找同類型藝人…"
+
+#: id:15254
+msgid "Search similar tags..."
+msgstr "尋找同類型標籤…"
+
+#: id:15255
+msgid "Your profile (%name%)"
+msgstr "我的設定檔 (%name%)"
+
+#: id:15256
+msgid "Overall top tags"
+msgstr "所有排行"
+
+#: id:15257
+msgid "Top artists for tag %name%"
+msgstr "%name% 藝人排行"
+
+#: id:15258
+msgid "Top albums for tag %name%"
+msgstr "%name% 專輯排行"
+
+#: id:15259
+msgid "Top tracks for tag %name%"
+msgstr "%name% 歌曲排行"
+
+#: id:15260
+msgid "Listen to tag %name% Last.fm radio"
+msgstr "收聽 %name% 在 Last.fm 廣播"
+
+#: id:15261
+msgid "Similar artists as %name%"
+msgstr "%name% 同類型藝人"
+
+#: id:15262
+msgid "Top %name% albums"
+msgstr "%name% 專輯排行"
+
+#: id:15263
+msgid "Top %name% tracks"
+msgstr "%name% 歌曲排行"
+
+#: id:15264
+msgid "Top %name% tags"
+msgstr "%name% 標籤排行"
+
+#: id:15265
+msgid "Biggest fans of %name%"
+msgstr "%name% 頭號歌迷"
+
+#: id:15266
+msgid "Listen to %name% fans Last.fm radio"
+msgstr "收聽 %name% 的歌迷在 Last.fm 廣播"
+
+#: id:15267
+msgid "Listen to %name% similar artists Last.fm radio"
+msgstr "收聽 %name% 的同類型藝人在 Last.fm 廣播"
+
+#: id:15268
+msgid "Top artists for user %name%"
+msgstr "%name% 藝人排行"
+
+#: id:15269
+msgid "Top albums for user %name%"
+msgstr "%name% 專輯排行"
+
+#: id:15270
+msgid "Top tracks for user %name%"
+msgstr "%name% 歌曲排行"
+
+#: id:15271
+msgid "Friends of user %name%"
+msgstr "%name% 好友"
+
+#: id:15272
+msgid "Neighbours of user %name%"
+msgstr "%name% 同好"
+
+#: id:15273
+msgid "Weekly artist chart for %name%"
+msgstr "%name% 藝人週排行"
+
+#: id:15274
+msgid "Weekly album chart for %name%"
+msgstr "%name% 專輯週排行"
+
+#: id:15275
+msgid "Weekly track chart for %name%"
+msgstr "%name% 歌曲週排行"
+
+#: id:15276
+msgid "Listen to %name%'s neighbours Last.fm radio"
+msgstr "收聽 %name% 的同好在 Last.fm 廣播"
+
+#: id:15277
+msgid "Listen to %name%'s personal Last.fm radio"
+msgstr "收聽 %name% 的個人在 Last.fm 廣播"
+
+#: id:15278
+msgid "Listen to %name%'s mix Last.fm radio"
+msgstr "收聽 %name% 的最愛在 Last.fm 廣播"
+
+#: id:15279
+msgid "Retrieving list from Last.fm..."
+msgstr "從 Last.fm 獲取目錄…"
+
+#: id:15280
+msgid "Can't retrieve list from Last.fm..."
+msgstr "無法從 Last.fm 獲取目錄…"
+
+#: id:15281
+msgid "Enter an artist name to find related ones"
+msgstr "輸入藝人名稱尋找相關資訊"
+
+#: id:15282
+msgid "Enter a tag name to find similar ones"
+msgstr "輸入標籤名稱尋找相關資訊"
+
+#: id:15283
+msgid "Tracks recently listened by %name%"
+msgstr "%name% 最近聽過的歌曲"
+
+#: id:15284
+msgid "Listen to %name%'s recommendations Last.fm radio"
+msgstr "收聽 %name% 的推薦在 Last.fm 廣播"
+
+#: id:15285
+msgid "Top tags for user %name%"
+msgstr "%name% 的排行"
+
+#: id:15287
+msgid "Do you want to add the current track to your loved tracks?"
+msgstr "你想把目前歌曲加入你的最愛嗎？"
+
+#: id:15288
+msgid "Do you want to ban the current track?"
+msgstr "你想封鎖目前的歌曲嗎？"
+
+#: id:15289
+msgid "Added to your loved tracks: '%s'."
+msgstr "已加入你的最愛歌曲： '%s'"
+
+#: id:15290
+msgid "Could not add '%s' to your loved tracks."
+msgstr "不能加入 '%s' 到你的最愛"
+
+#: id:15291
+msgid "Banned: '%s'."
+msgstr "被封鎖： '%s'."
+
+#: id:15292
+msgid "Could not ban '%s'."
+msgstr "不能封鎖 '%s'."
+
+#: id:15293
+msgid "Tracks recently loved by %name%"
+msgstr "%name% 最近喜好的歌曲"
+
+#: id:15294
+msgid "Tracks recently banned by %name%"
+msgstr "%name% 最近封鎖的歌曲"
+
+#: id:15295
+msgid "Remove from loved tracks"
+msgstr "從最愛中移除"
+
+#: id:15296
+msgid "Un-ban"
+msgstr "解除封鎖"
+
+#: id:15297
+msgid "Do you want to remove this track from your loved tracks?"
+msgstr "你想從你的最愛移除這首歌曲嗎？"
+
+#: id:15298
+msgid "Do you want to un-ban this track?"
+msgstr "你想解除封鎖這首歌曲嗎？"
+
+#: id:15300
+msgid "Path not found or invalid"
+msgstr "路徑錯誤或無效"
+
+#: id:15301
+msgid "Could not connect to network server"
+msgstr "無法連線到網路伺服器"
+
+#: id:15302
+msgid "No servers found"
+msgstr "找不到伺服器"
+
+#: id:15303
+msgid "Workgroup not found"
+msgstr "找不到工作群組"
+
+#: id:15310
+msgid "Opening multi-path source"
+msgstr "打開多個來源路徑"
+
+#: id:15311
+msgid "Path:"
+msgstr "路徑："
+
+#: id:16000
+msgctxt "Auto context with id 16000"
+msgid "General"
+msgstr "一般設定"
+
+#: id:16002
+msgid "Internet lookup"
+msgstr "網路查詢"
+
+#: id:16003
+msgid "Player"
+msgstr "播放設定"
+
+#: id:16004
+msgid "Play media from disc"
+msgstr "播放光碟"
+
+#: id:16008
+msgid "Enter new title"
+msgstr "輸入新標題"
+
+#: id:16009
+msgid "Enter the movie name"
+msgstr "輸入影片名稱"
+
+#: id:16010
+msgid "Enter the profile name"
+msgstr "輸入設定檔名稱"
+
+#: id:16011
+msgid "Enter the album name"
+msgstr "輸入專輯名稱"
+
+#: id:16012
+msgid "Enter the playlist name"
+msgstr "輸入播放列表名稱"
+
+#: id:16013
+msgid "Enter new filename"
+msgstr "輸入新檔案名稱"
+
+#: id:16014
+msgid "Enter folder name"
+msgstr "輸入資料夾名稱"
+
+#: id:16015
+msgid "Enter directory"
+msgstr "輸入目錄"
+
+#: id:16016
+msgid "Available options: %A, %T, %N, %B, %D, %G, %Y, %F, %S"
+msgstr "可用選項： %A, %T, %N, %B, %D, %G, %Y, %F, %S"
+
+#: id:16017
+msgid "Enter search string"
+msgstr "輸入搜尋字串"
+
+#: id:16018
+msgctxt "Auto context with id 16018"
+msgid "None"
+msgstr "關閉"
+
+#: id:16019
+msgid "Auto select"
+msgstr "自動選擇"
+
+#: id:16020
+msgid "De-interlace"
+msgstr "非交錯掃描"
+
+#: id:16021
+msgid "Bob"
+msgstr "抖動"
+
+#: id:16022
+msgid "Bob (inverted)"
+msgstr "抖動(倒轉)"
+
+#: id:16024
+msgid "Canceling..."
+msgstr "取消中…"
+
+#: id:16025
+msgid "Enter the artist name"
+msgstr "輸入藝人名稱"
+
+#: id:16026
+msgid "Playback failed"
+msgstr "播放失敗"
+
+#: id:16027
+msgid "One or more items failed to play."
+msgstr "一個或多個項目播放失敗。"
+
+#: id:16028
+msgid "Enter value"
+msgstr "輸入資料"
+
+#: id:16029
+msgid "Check the log file for details."
+msgstr "詳情請查看日誌檔。"
+
+#: id:16030
+msgid "Party mode aborted."
+msgstr "取消派對模式。"
+
+#: id:16031
+msgid "No matching songs in the library."
+msgstr "資料庫歌曲檔案不符。"
+
+#: id:16032
+msgid "Could not initialize database."
+msgstr "無法重建資料庫。"
+
+#: id:16033
+msgid "Could not open database."
+msgstr "無法打開資料庫。"
+
+#: id:16034
+msgid "Could not get songs from database."
+msgstr "無法從資料庫取得歌曲檔案。"
+
+#: id:16035
+msgid "Party mode playlist"
+msgstr "派對模式播放列表"
+
+#: id:16036
+msgid "De-interlace (Half)"
+msgstr ""
+
+#: id:16037
+msgid "Deinterlace video"
+msgstr ""
+
+#: id:16038
+msgid "Deinterlace method"
+msgstr ""
+
+#: id:16039
+msgctxt "Auto context with id 16039"
+msgid "Off"
+msgstr "關閉"
+
+#: id:16040
+msgctxt "Auto context with id 16040"
+msgid "Auto"
+msgstr "自動"
+
+#: id:16041
+msgid "On"
+msgstr "開啟"
+
+#: id:16100
+msgid "All Videos"
+msgstr "所有視訊"
+
+#: id:16101
+msgid "Unwatched"
+msgstr "未看過的"
+
+#: id:16102
+msgid "Watched"
+msgstr "已看過的"
+
+#: id:16103
+msgid "Mark as watched"
+msgstr "標記成已看過"
+
+#: id:16104
+msgid "Mark as unwatched"
+msgstr "標記成未看過"
+
+#: id:16105
+msgid "Edit title"
+msgstr "編輯標題"
+
+#: id:16200
+msgid "Operation was aborted"
+msgstr "操作被取消"
+
+#: id:16201
+msgid "Copy failed"
+msgstr "無法複製"
+
+#: id:16202
+msgid "Failed to copy at least one file"
+msgstr "至少一個檔案無法複製"
+
+#: id:16203
+msgid "Move failed"
+msgstr "無法搬移"
+
+#: id:16204
+msgid "Failed to move at least one file"
+msgstr "至少一個檔案無法搬移"
+
+#: id:16205
+msgid "Delete failed"
+msgstr "無法刪除"
+
+#: id:16206
+msgid "Failed to delete at least one file"
+msgstr "至少一個檔案無法刪除"
+
+#: id:16300
+msgid "Video scaling method"
+msgstr "視訊縮放方式"
+
+#: id:16301
+msgid "Nearest neighbour"
+msgstr "Nearest neighbour"
+
+#: id:16302
+msgid "Bilinear"
+msgstr "二元直線"
+
+#: id:16303
+msgctxt "Auto context with id 16303"
+msgid "Bicubic"
+msgstr "雙立方"
+
+#: id:16304
+msgid "Lanczos2"
+msgstr "Lanczos2"
+
+#: id:16305
+msgid "Lanczos3"
+msgstr "Lanczos3"
+
+#: id:16306
+msgid "Sinc8"
+msgstr "Sinc8"
+
+#: id:16307
+msgid "Bicubic (software)"
+msgstr "Bicubic(軟體)"
+
+#: id:16308
+msgid "Lanczos (software)"
+msgstr "Lanczos(軟體)"
+
+#: id:16309
+msgid "Sinc (software)"
+msgstr "Sinc(軟體)"
+
+#: id:16310
+msgid "Temporal"
+msgstr "時間平滑"
+
+#: id:16311
+msgid "Temporal/Spatial"
+msgstr "時間/空間平滑"
+
+#: id:16312
+msgid "(VDPAU)Noise Reduction"
+msgstr "(VDPAU)降噪"
+
+#: id:16313
+msgid "(VDPAU)Sharpness"
+msgstr "(VDPAU)銳化"
+
+#: id:16314
+msgid "Inverse Telecine"
+msgstr "填補為逐行信號"
+
+#: id:16315
+msgid "Lanczos3 optimized"
+msgstr "Lanczos3 最佳化"
+
+#: id:16316
+msgctxt "Auto context with id 16316"
+msgid "Auto"
+msgstr "自動"
+
+#: id:16317
+msgid "Temporal (Half)"
+msgstr "時間平滑 (不完全)"
+
+#: id:16318
+msgid "Temporal/Spatial (Half)"
+msgstr "時間/空間平滑（不完全）"
+
+#: id:16319
+msgid "DXVA"
+msgstr "DXVA"
+
+#: id:16320
+msgid "DXVA Bob"
+msgstr ""
+
+#: id:16321
+msgid "DXVA Best"
+msgstr ""
+
+#: id:16322
+msgid "Spline36"
+msgstr ""
+
+#: id:16323
+msgid "Spline36 optimized"
+msgstr ""
+
+#: id:16324
+msgid "Software Blend"
+msgstr "軟體混合"
+
+#: id:16400
+msgid "Post-processing"
+msgstr "視訊後處理"
+
+#: id:17500
+msgid "Display sleep timeout"
+msgstr "顯示休眠逾時"
+
+#: id:19000
+msgid "Switch to channel"
+msgstr "切換到頻道"
+
+#: id:20000
+msgid "Saved music folder"
+msgstr "音樂 CD 擷取資料夾"
+
+#: id:20001
+msgid "Use external DVD player"
+msgstr "使用其他 DVD 播放程式"
+
+#: id:20002
+msgid "External DVD player"
+msgstr "其他 DVD 播放程式"
+
+#: id:20003
+msgid "Trainers folder"
+msgstr "金手指資料夾"
+
+#: id:20004
+msgid "Screenshot folder"
+msgstr "螢幕擷圖資料夾"
+
+#: id:20006
+msgid "Playlists folder"
+msgstr "播放列表資料夾"
+
+#: id:20007
+msgid "Recordings"
+msgstr "錄音"
+
+#: id:20008
+msgid "Screenshots"
+msgstr "螢幕擷圖"
+
+#: id:20009
+msgid "Use XBMC"
+msgstr "使用 XBMC"
+
+#: id:20011
+msgid "Music playlists"
+msgstr "音樂播放列表"
+
+#: id:20012
+msgid "Video playlists"
+msgstr "視訊播放列表"
+
+#: id:20013
+msgid "Do you wish to launch the game?"
+msgstr "你要執行該遊戲？"
+
+#: id:20014
+msgid "Sort by: Playlist"
+msgstr "排序： 播放列表"
+
+#: id:20015
+msgid "Remote thumb"
+msgstr "遠端的縮圖"
+
+#: id:20016
+msgid "Current thumb"
+msgstr "目前縮圖"
+
+#: id:20017
+msgid "Local thumb"
+msgstr "本地縮圖"
+
+#: id:20018
+msgid "No thumb"
+msgstr "無縮圖"
+
+#: id:20019
+msgid "Choose thumbnail"
+msgstr "選擇縮略圖"
+
+#: id:20023
+msgid "Conflict"
+msgstr "衝突"
+
+#: id:20024
+msgid "Scan new"
+msgstr "掃描新加入"
+
+#: id:20025
+msgid "Scan all"
+msgstr "掃描全部"
+
+#: id:20026
+msgid "Region"
+msgstr "區域"
+
+#: id:20037
+msgid "Summary"
+msgstr "摘要"
+
+#: id:20038
+msgid "Lock music window"
+msgstr "鎖定音樂視窗"
+
+#: id:20039
+msgid "Lock videos window"
+msgstr "鎖定視訊視窗"
+
+#: id:20040
+msgid "Lock pictures window"
+msgstr "鎖定圖片視窗"
+
+#: id:20041
+msgid "Lock programs & scripts windows"
+msgstr "鎖定程式 & 腳本視窗"
+
+#: id:20042
+msgid "Lock file manager"
+msgstr "鎖定檔案總管"
+
+#: id:20043
+msgid "Lock settings"
+msgstr "鎖定系統設定"
+
+#: id:20044
+msgid "Start fresh"
+msgstr "重新設定"
+
+#: id:20045
+msgid "Enter master mode"
+msgstr "進入管理員模式"
+
+#: id:20046
+msgid "Leave master mode"
+msgstr "離開管理員模式"
+
+#: id:20047
+msgid "Create profile '%s'?"
+msgstr "要建立設定檔 '%s'嗎？"
+
+#: id:20048
+msgid "Start with fresh settings"
+msgstr "重回原先設定"
+
+#: id:20049
+msgid "Best available"
+msgstr "最適合模式"
+
+#: id:20050
+msgid "Auto-switch between 16x9 and 4x3"
+msgstr "自動切換 16x9 與 4x3 模式"
+
+#: id:20051
+msgid "Treat stacked files as single file"
+msgstr "視堆疊檔案為單一檔案"
+
+#: id:20052
+msgid "Caution"
+msgstr "注意"
+
+#: id:20053
+msgid "Left master mode"
+msgstr "已離開管理員模式"
+
+#: id:20054
+msgid "Entered master mode"
+msgstr "已進入管理員模式"
+
+#: id:20055
+msgid "Allmusic.com thumb"
+msgstr "Allmusic.com 縮圖"
+
+#: id:20057
+msgid "Remove thumbnail"
+msgstr "移除縮略圖"
+
+#: id:20058
+msgid "Add profile..."
+msgstr "新增設定檔…"
+
+#: id:20059
+msgid "Query info for all albums"
+msgstr "查詢所有專輯的資訊"
+
+#: id:20060
+msgctxt "Auto context with id 20060"
+msgid "Media info"
+msgstr "媒體資訊"
+
+#: id:20061
+msgctxt "Auto context with id 20061"
+msgid "Separate"
+msgstr "各別的"
+
+#: id:20062
+msgid "Shares with default"
+msgstr "共用預設值"
+
+#: id:20063
+msgid "Shares with default (read only)"
+msgstr "共用預設值(唯讀)"
+
+#: id:20064
+msgid "Copy default"
+msgstr "複製預設值"
+
+#: id:20065
+msgid "Profile picture"
+msgstr "設定檔圖片"
+
+#: id:20066
+msgid "Lock preferences"
+msgstr "鎖定偏好設定"
+
+#: id:20067
+msgid "Edit profile"
+msgstr "編輯設定檔"
+
+#: id:20068
+msgid "Profile lock"
+msgstr "設定檔鎖定"
+
+#: id:20069
+msgid "Could not create folder"
+msgstr "無法建立資料夾"
+
+#: id:20070
+msgid "Profile directory"
+msgstr "設定檔目錄"
+
+#: id:20071
+msgid "Start with fresh media sources"
+msgstr "以新媒體來源啟動"
+
+#: id:20072
+msgid "Make sure the selected folder is writable"
+msgstr "確定選擇的資料夾是可寫入的"
+
+#: id:20073
+msgid "and that the new folder name is valid"
+msgstr "而且是有效的資料夾名稱"
+
+#: id:20074
+msgid "MPAA rating"
+msgstr "MPAA 分級"
+
+#: id:20075
+msgid "Enter master lock code"
+msgstr "輸入管理員密碼"
+
+#: id:20076
+msgid "Ask for master lock code on startup"
+msgstr "啟動時詢問管理員密碼"
+
+#: id:20077
+msgid "Skin settings"
+msgstr "佈景主題設定"
+
+#: id:20078
+msgid "- no link set -"
+msgstr "- 無連結設定 -"
+
+#: id:20079
+msgid "Enable animations"
+msgstr "啟用 桌面動畫效果"
+
+#: id:20080
+msgid "Disable RSS during music"
+msgstr "播放音樂時關閉 RSS 新聞顯示"
+
+#: id:20081
+msgid "Enable shortcut buttons"
+msgstr "啟用捷徑"
+
+#: id:20082
+msgid "Show programs in main menu"
+msgstr "顯示程式在主選單"
+
+#: id:20083
+msgid "Show music info"
+msgstr "顯示音樂資訊"
+
+#: id:20084
+msgid "Show weather info"
+msgstr "顯示氣象資訊"
+
+#: id:20085
+msgid "Show system info"
+msgstr "顯示系統資訊"
+
+#: id:20086
+msgid "Show available disc space C: E: F:"
+msgstr "顯示可用的硬碟空間 C: E: F:"
+
+#: id:20087
+msgid "Show available disc space E: F: G:"
+msgstr "顯示可用的硬碟空間 E: F: G:"
+
+#: id:20088
+msgid "Weather info"
+msgstr "氣象資訊"
+
+#: id:20089
+msgid "Drive space free"
+msgstr "可用裝置空間"
+
+#: id:20090
+msgid "Enter the name of an existing share"
+msgstr "輸入一個現有分享的名稱"
+
+#: id:20091
+msgid "Lock code"
+msgstr "密碼"
+
+#: id:20092
+msgid "Load profile"
+msgstr "載入設定檔"
+
+#: id:20093
+msgid "Profile name"
+msgstr "設定檔名稱"
+
+#: id:20094
+msgctxt "Auto context with id 20094"
+msgid "Media sources"
+msgstr "媒體來源"
+
+#: id:20095
+msgid "Enter profile lock code"
+msgstr "輸入設定檔密碼"
+
+#: id:20096
+msgctxt "Auto context with id 20096"
+msgid "Login screen"
+msgstr "登錄畫面"
+
+#: id:20097
+msgid "Fetching album info"
+msgstr "取得專輯資訊"
+
+#: id:20098
+msgid "Fetching info for album"
+msgstr "正在取得專輯資訊"
+
+#: id:20099
+msgid "Can't rip CD or track while playing from CD"
+msgstr "當 CD 播放時不能擷取該 CD"
+
+#: id:20100
+msgid "Master lock code and settings"
+msgstr "管理員密碼與鎖定"
+
+#: id:20101
+msgid "Entering master lock code always enables master mode"
+msgstr "輸入管理員密碼後，永遠啟用管理員模式"
+
+#: id:20102
+msgid "or copy from default?"
+msgstr "或是從預設值中複製？"
+
+#: id:20103
+msgid "Save changes to profile?"
+msgstr "儲存預設檔變更？"
+
+#: id:20104
+msgid "Old settings found."
+msgstr "發現舊的設定值"
+
+#: id:20105
+msgid "Do you want to use them?"
+msgstr "你要使用嗎？"
+
+#: id:20106
+msgid "Old media sources found."
+msgstr "發現舊媒體來源"
+
+#: id:20107
+msgid "Separate (locked)"
+msgstr "各別的(鎖定)"
+
+#: id:20108
+msgid "Root"
+msgstr "根目錄"
+
+#: id:20109
+msgid "- Zoom"
+msgstr "- 桌面縮放"
+
+#: id:20110
+msgid "UPnP settings"
+msgstr "UPnP 設定"
+
+#: id:20111
+msgid "Autostart UPnP client"
+msgstr "自動開啟 UPnP 客戶端"
+
+#: id:20112
+msgid "Last login: %s"
+msgstr "上次登入： %s"
+
+#: id:20113
+msgid "Never logged on"
+msgstr "從未登入"
+
+#: id:20114
+msgid "Profile %i / %i"
+msgstr "設定檔 %i / %i"
+
+#: id:20115
+msgid "User login / Select a profile"
+msgstr "使用者登入/選擇設定檔"
+
+#: id:20116
+msgid "Use lock on login screen"
+msgstr "在登入畫面中使用鎖定"
+
+#: id:20117
+msgid "Invalid lock code."
+msgstr "密碼無效"
+
+#: id:20118
+msgid "This requires the master lock to be set."
+msgstr "需先設定管理員鎖定"
+
+#: id:20119
+msgid "Would you like to set it now?"
+msgstr "你現在要設定嗎？"
+
+#: id:20120
+msgid "Loading program information"
+msgstr "載入程式資訊"
+
+#: id:20121
+msgid "Party on!"
+msgstr "派對模式！"
+
+#: id:20122
+msgid "True"
+msgstr "真實"
+
+#: id:20123
+msgid "Mixing drinks"
+msgstr "Mixing drinks"
+
+#: id:20124
+msgid "Filling glasses"
+msgstr "Filling glasses"
+
+#: id:20125
+msgid "Logged on as"
+msgstr "登入"
+
+#: id:20126
+msgid "Log off"
+msgstr "登出"
+
+#: id:20128
+msgid "Go to root"
+msgstr "跳至根目錄"
+
+#: id:20129
+msgid "Weave"
+msgstr "交織"
+
+#: id:20130
+msgid "Weave (inverted)"
+msgstr "交織(倒轉)"
+
+#: id:20131
+msgid "Blend"
+msgstr "混合"
+
+#: id:20132
+msgid "Restart video"
+msgstr "重新播放視訊"
+
+#: id:20133
+msgid "Edit network location"
+msgstr "編輯網路位置"
+
+#: id:20134
+msgid "Remove network location"
+msgstr "移除網路位置"
+
+#: id:20135
+msgid "Do you want to scan the folder?"
+msgstr "你想掃描這個資料夾？"
+
+#: id:20136
+msgid "Memory unit"
+msgstr "記憶卡"
+
+#: id:20137
+msgid "Memory unit mounted"
+msgstr "記憶卡已插入"
+
+#: id:20138
+msgid "Unable to mount memory unit"
+msgstr "找不到記憶卡"
+
+#: id:20139
+msgid "In port %i, slot %i"
+msgstr "在第%i埠，第%i槽"
+
+#: id:20140
+msgid "Lock screensaver"
+msgstr "鎖定螢幕保護程式"
+
+#: id:20141
+msgid "Set"
+msgstr "設定"
+
+#: id:20142
+msgctxt "Auto context with id 20142"
+msgid "Username"
+msgstr "帳號"
+
+#: id:20143
+msgid "Enter password for"
+msgstr "輸入密碼"
+
+#: id:20144
+msgid "Shutdown timer"
+msgstr "自動定時關機"
+
+#: id:20145
+msgid "Shutdown interval (in minutes)"
+msgstr "自動定時關機(分鐘)"
+
+#: id:20146
+msgid "Started, shutdown in %im"
+msgstr "啓動，在%i分鐘後自動關機"
+
+#: id:20147
+msgid "Shutdown in 30 minutes"
+msgstr "30分鐘後自動關機"
+
+#: id:20148
+msgid "Shutdown in 60 minutes"
+msgstr "60分鐘後自動關機"
+
+#: id:20149
+msgid "Shutdown in 120 minutes"
+msgstr "120分鐘後自動關機"
+
+#: id:20150
+msgid "Custom shutdown timer"
+msgstr "自訂關機時間"
+
+#: id:20151
+msgid "Cancel shutdown timer"
+msgstr "取消自動關機"
+
+#: id:20152
+msgid "Lock preferences for %s"
+msgstr "鎖定偏好設定檔 %s"
+
+#: id:20153
+msgid "Browse..."
+msgstr "瀏覽…"
+
+#: id:20154
+msgid "Summary information"
+msgstr "基本資訊"
+
+#: id:20155
+msgid "Storage information"
+msgstr "儲存裝置資訊"
+
+#: id:20156
+msgid "Hard disk information"
+msgstr "硬碟資訊"
+
+#: id:20157
+msgid "DVD-ROM information"
+msgstr "光碟機資訊"
+
+#: id:20158
+msgid "Network information"
+msgstr "網路資訊"
+
+#: id:20159
+msgid "Video information"
+msgstr "視訊資訊"
+
+#: id:20160
+msgid "Hardware information"
+msgstr "硬體資訊"
+
+#: id:20161
+msgid "Total"
+msgstr "總計"
+
+#: id:20162
+msgid "Used"
+msgstr "使用"
+
+#: id:20163
+msgid "of"
+msgstr "中"
+
+#: id:20164
+msgid "Locking not supported"
+msgstr "不支援鎖定"
+
+#: id:20165
+msgid "Not locked"
+msgstr "未鎖定"
+
+#: id:20166
+msgid "Locked"
+msgstr "鎖定"
+
+#: id:20167
+msgid "Frozen"
+msgstr "凍結"
+
+#: id:20168
+msgid "Requires reset"
+msgstr "要求重新設定"
+
+#: id:20169
+msgid "Week"
+msgstr "週"
+
+#: id:20170
+msgid "Line"
+msgstr "生產線"
+
+#: id:20171
+msgid "Windows network (SMB)"
+msgstr "Windows 網路(SMB)"
+
+#: id:20172
+msgid "XBMSP server"
+msgstr "XBMSP 伺服器"
+
+#: id:20173
+msgctxt "Auto context with id 20173"
+msgid "FTP server"
+msgstr "FTP 伺服器"
+
+#: id:20174
+msgid "iTunes music share (DAAP)"
+msgstr "ITunes 音樂分享(DAAP)"
+
+#: id:20175
+msgid "UPnP server"
+msgstr "UPnP 伺服器"
+
+#: id:20176
+msgid "Show video info"
+msgstr "顯示視訊資訊"
+
+#: id:20177
+msgid "Done"
+msgstr "完成"
+
+#: id:20178
+msgid "Shift"
+msgstr "轉換"
+
+#: id:20179
+msgid "Caps Lock"
+msgstr "大寫"
+
+#: id:20180
+msgid "Symbols"
+msgstr "符號"
+
+#: id:20181
+msgid "Backspace"
+msgstr "退格"
+
+#: id:20182
+msgid "Space"
+msgstr "空格"
+
+#: id:20183
+msgid "Reload skin"
+msgstr "重新載入佈景主題"
+
+#: id:20184
+msgid "Rotate pictures using EXIF information"
+msgstr "根據 EXIF 資訊旋轉圖片"
+
+#: id:20185
+msgid "Use poster view styles for TV shows"
+msgstr "使用海報模式顯示電視節目"
+
+#: id:20186
+msgid "Please wait"
+msgstr "請稍候"
+
+#: id:20187
+msgid "UPnP"
+msgstr ""
+
+#: id:20189
+msgid "Enable auto scrolling for plot & review"
+msgstr "啟用 劇情和評論自動捲動"
+
+#: id:20190
+msgctxt "Auto context with id 20190"
+msgid "Custom"
+msgstr "自訂"
+
+#: id:20191
+msgid "Enable debug logging"
+msgstr "啟用 除錯記錄"
+
+#: id:20192
+msgid "Download additional information during updates"
+msgstr "取得專輯資訊加入資料庫"
+
+#: id:20193
+msgid "Default service for album information"
+msgstr "專輯資訊的預設服務"
+
+#: id:20194
+msgid "Default service for artist information"
+msgstr "預設站台"
+
+#: id:20195
+msgid "Change scraper"
+msgstr "更換站台"
+
+#: id:20196
+msgid "Export music library"
+msgstr "匯出音樂資料庫"
+
+#: id:20197
+msgid "Import music library"
+msgstr "匯入音樂資料庫"
+
+#: id:20198
+msgid "No artist found!"
+msgstr "找不到藝人！"
+
+#: id:20199
+msgid "Downloading artist info failed"
+msgstr "下載藝人資訊失敗"
+
+#: id:20250
+msgid "Party on! (videos)"
+msgstr "派對模式！(視訊)"
+
+#: id:20251
+msgid "Mixing drinks (videos)"
+msgstr "Mixing drinks (視訊)"
+
+#: id:20252
+msgid "Filling glasses (videos)"
+msgstr "Filling glasses (視訊)"
+
+#: id:20253
+msgid "WebDAV server (HTTP)"
+msgstr "WebDAV 伺服器 (HTTP)"
+
+#: id:20254
+msgid "WebDAV server (HTTPS)"
+msgstr "WebDAV 伺服器 (HTTPS)"
+
+#: id:20255
+msgid "First logon, edit your profile"
+msgstr "第一次登入，請編輯您的設定檔"
+
+#: id:20256
+msgid "HTS Tvheadend client"
+msgstr "HTS Tvheadend 客戶端"
+
+#: id:20257
+msgid "VDR Streamdev client"
+msgstr "VDR Streamdev 客戶端"
+
+#: id:20258
+msgid "MythTV client"
+msgstr "MythTV 客戶端"
+
+#: id:20259
+msgid "Network Filesystem (NFS)"
+msgstr "網路檔案系統（NFS）"
+
+#: id:20260
+msgid "Secure Shell (SSH/SFTP)"
+msgstr "Secure Shell (SSH/SFTP)"
+
+#: id:20261
+msgid "Apple Filing Protocol (AFP)"
+msgstr ""
+
+#: id:20300
+msgid "Web server directory (HTTP)"
+msgstr "Web 伺服器目錄(HTTP)"
+
+#: id:20301
+msgid "Web server directory (HTTPS)"
+msgstr "Web 伺服器目錄(HTTPS)"
+
+#: id:20302
+msgid "Unable to write to folder:"
+msgstr "無法寫入資料夾："
+
+#: id:20303
+msgid "Do you want to skip and proceed?"
+msgstr "你要跳過並繼續嗎？"
+
+#: id:20304
+msgid "RSS Feed"
+msgstr "RSS Feed"
+
+#: id:20307
+msgid "Secondary DNS"
+msgstr "次要的 DNS 位址"
+
+#: id:20308
+msgid "DHCP server:"
+msgstr "DHCP 伺服器："
+
+#: id:20309
+msgid "Make new folder"
+msgstr "新建資料夾"
+
+#: id:20310
+msgid "Dim LCD on playback"
+msgstr "播放時關閉液晶螢幕背光"
+
+#: id:20311
+msgid "Unknown or onboard (protected)"
+msgstr "未知或內建(寫入保護)"
+
+#: id:20312
+msgid "Dim LCD on paused"
+msgstr "暫停時關閉液晶螢幕背光"
+
+#: id:20314
+msgid "Videos - Library"
+msgstr "視訊 - 資料庫"
+
+#: id:20316
+msgid "Sort by: ID"
+msgstr "排序：標籤"
+
+#: id:20324
+msgid "Play part..."
+msgstr "播放部分的…"
+
+#: id:20325
+msgid "Calibration reset"
+msgstr "重設螢幕校正"
+
+#: id:20326
+msgid "This will reset the calibration values for %s"
+msgstr "重設螢幕校正值為 %s"
+
+#: id:20327
+msgid "to it's default values."
+msgstr "還原為預設值"
+
+#: id:20328
+msgid "Browse for destination"
+msgstr "瀏覽目的"
+
+#: id:20329
+msgid "Movies are in separate folders that match the movie title"
+msgstr "電影個別存放在和電影相同名稱的資料夾"
+
+#: id:20330
+msgid "Use folder names for lookups"
+msgstr "以資料夾名稱搜尋"
+
+#: id:20331
+msgctxt "Auto context with id 20331"
+msgid "File"
+msgstr "檔案"
+
+#: id:20332
+msgid "Use file or folder names in lookups?"
+msgstr "以檔案或資料夾名稱來搜尋？"
+
+#: id:20333
+msgid "Set content"
+msgstr "設定內容"
+
+#: id:20334
+msgid "Folder"
+msgstr "資料夾"
+
+#: id:20335
+msgid "Look for content recursively?"
+msgstr "循環尋找內容？"
+
+#: id:20336
+msgid "Unlock sources"
+msgstr "解除來源鎖定"
+
+#: id:20337
+msgid "Actor"
+msgstr "演員"
+
+#: id:20338
+msgid "Movie"
+msgstr "影片"
+
+#: id:20339
+msgid "Director"
+msgstr "導演"
+
+#: id:20340
+msgid "Do you want to remove all items within"
+msgstr "你要從資料庫中"
+
+#: id:20341
+msgid "this path from the XBMC library?"
+msgstr "移除此路徑內所有項目？"
+
+#: id:20342
+msgctxt "Auto context with id 20342"
+msgid "Movies"
+msgstr "影片"
+
+#: id:20343
+msgid "TV shows"
+msgstr "電視節目"
+
+#: id:20344
+msgid "This directory contains"
+msgstr "此目錄包含"
+
+#: id:20345
+msgid "Run automated scan"
+msgstr "執行自動掃描"
+
+#: id:20346
+msgid "Scan recursively"
+msgstr "循環掃描"
+
+#: id:20347
+msgid "as"
+msgstr "以"
+
+#: id:20348
+msgid "Directors"
+msgstr "導演"
+
+#: id:20349
+msgid "No video files found in this path!"
+msgstr "此路徑無視訊檔！"
+
+#: id:20350
+msgid "votes"
+msgstr "票數"
+
+#: id:20351
+msgid "TV show information"
+msgstr "電視節目資訊"
+
+#: id:20352
+msgid "Episode information"
+msgstr "影集資訊"
+
+#: id:20353
+msgid "Loading TV show details"
+msgstr "載入電視節目詳細介紹"
+
+#: id:20354
+msgid "Fetching episode guide"
+msgstr "取得影集介紹"
+
+#: id:20355
+msgid "Loading info for episodes in directory"
+msgstr "載入影集情報至資料庫"
+
+#: id:20356
+msgid "Select TV show:"
+msgstr "選擇電視節目："
+
+#: id:20357
+msgid "Enter the TV show name"
+msgstr "輸入電視節目名稱"
+
+#: id:20358
+msgid "Season %i"
+msgstr "第%i季"
+
+#: id:20359
+msgid "Episode"
+msgstr "集"
+
+#: id:20360
+msgid "Episodes"
+msgstr "影集"
+
+#: id:20361
+msgid "Loading episode details"
+msgstr "載入影集詳細介紹"
+
+#: id:20362
+msgid "Remove episode from library"
+msgstr "從資料庫移除影集"
+
+#: id:20363
+msgid "Remove TV show from library"
+msgstr "從資料庫移除電視節目"
+
+#: id:20364
+msgid "TV show"
+msgstr "電視節目"
+
+#: id:20365
+msgid "Episode plot"
+msgstr "劇情"
+
+#: id:20366
+msgid "* All seasons"
+msgstr "* 整季"
+
+#: id:20367
+msgid "Hide watched"
+msgstr "隱藏觀看"
+
+#: id:20368
+msgid "Prod code"
+msgstr "產品編號"
+
+#: id:20369
+msgid "Show plot for unwatched items"
+msgstr "非觀看項目隱藏圖示"
+
+#: id:20370
+msgid "* Hidden to prevent spoilers *"
+msgstr "* 隱藏防止被破壞 *"
+
+#: id:20371
+msgid "Set season thumb"
+msgstr "設定影集縮圖"
+
+#: id:20372
+msgid "Season image"
+msgstr "影集圖像"
+
+#: id:20373
+msgid "Season"
+msgstr "季"
+
+#: id:20374
+msgid "Downloading movie information"
+msgstr "載入電影資訊"
+
+#: id:20375
+msgid "Unassign content"
+msgstr "不指定內容"
+
+#: id:20376
+msgid "Original title"
+msgstr "原始標題"
+
+#: id:20377
+msgid "Refresh TV show information"
+msgstr "重新整理電視節目資訊"
+
+#: id:20378
+msgid "Refresh info for all episodes?"
+msgstr "重新整理所有影集資訊？"
+
+#: id:20379
+msgid "Selected folder contains a single TV show"
+msgstr "選擇的資料夾包含一個電視節目"
+
+#: id:20380
+msgid "Exclude selected folder from scans"
+msgstr "將選擇的資料夾排除搜尋"
+
+#: id:20381
+msgid "Specials"
+msgstr "特別"
+
+#: id:20382
+msgid "Automatically grab season thumbs"
+msgstr "自動擷取影集的縮圖"
+
+#: id:20383
+msgid "Selected folder contains a single video"
+msgstr "選擇的資料夾包含一個視訊"
+
+#: id:20384
+msgid "Link to TV show"
+msgstr "電視節目連接"
+
+#: id:20385
+msgid "Remove link to TV show"
+msgstr "移除電視節目連接"
+
+#: id:20386
+msgid "Recently added movies"
+msgstr "最近加入的電影"
+
+#: id:20387
+msgid "Recently added episodes"
+msgstr "最近加入的影集"
+
+#: id:20388
+msgid "Studios"
+msgstr "影片製作公司"
+
+#: id:20389
+msgid "Music videos"
+msgstr "音樂影片"
+
+#: id:20390
+msgid "Recently added music videos"
+msgstr "最近加入的音樂影片"
+
+#: id:20391
+msgid "Music video"
+msgstr "音樂影片"
+
+#: id:20392
+msgid "Remove music video from library"
+msgstr "從資料庫移除音樂影片"
+
+#: id:20393
+msgctxt "Auto context with id 20393"
+msgid "Music video information"
+msgstr "音樂影片資訊"
+
+#: id:20394
+msgid "Loading music video information"
+msgstr "載入音樂影片資訊"
+
+#: id:20395
+msgid "Mixed"
+msgstr "混合"
+
+#: id:20396
+msgid "Go to albums by artist"
+msgstr "依藝人跳至專輯"
+
+#: id:20397
+msgid "Go to album"
+msgstr "進入專輯"
+
+#: id:20398
+msgid "Play song"
+msgstr "播放歌曲"
+
+#: id:20399
+msgid "Go to music videos from album"
+msgstr "從專輯跳至音樂影片"
+
+#: id:20400
+msgid "Go to music videos by artist"
+msgstr "依藝人跳至音樂影片"
+
+#: id:20401
+msgid "Play music video"
+msgstr "播放音樂影片"
+
+#: id:20402
+msgid "Download actor thumbnails when adding to library"
+msgstr "自動擷取演員的縮圖"
+
+#: id:20403
+msgid "Set actor thumb"
+msgstr "設定演員縮圖"
+
+#: id:20405
+msgid "Remove episode bookmark"
+msgstr "移除影集書籤"
+
+#: id:20406
+msgid "Set episode bookmark"
+msgstr "設定影集書籤"
+
+#: id:20407
+msgid "Scraper settings"
+msgstr "站台設定"
+
+#: id:20408
+msgid "Downloading music video information"
+msgstr "正在下載音樂影片資訊"
+
+#: id:20409
+msgid "Downloading TV show information"
+msgstr "正在下載電視節目資訊"
+
+#: id:20410
+msgid "Trailer"
+msgstr "預告片"
+
+#: id:20411
+msgid "Flatten"
+msgstr "連續播放"
+
+#: id:20412
+msgid "Flatten TV shows"
+msgstr "自動連續播放影集"
+
+#: id:20413
+msgid "Get fanart"
+msgstr "取得劇照"
+
+#: id:20414
+msgid "Show Fanart in video and music libraries"
+msgstr "在視訊和音樂資料庫顯示劇照"
+
+#: id:20415
+msgid "Scanning for new content"
+msgstr "掃描新的內容"
+
+#: id:20416
+msgid "First aired"
+msgstr "首播"
+
+#: id:20417
+msgid "Writer"
+msgstr "編劇"
+
+#: id:20419
+msgid "Replace file names with library titles"
+msgstr "在檔案檢視中顯示媒體資訊"
+
+#: id:20420
+msgctxt "Auto context with id 20420"
+msgid "Never"
+msgstr "從不"
+
+#: id:20421
+msgid "If only one season"
+msgstr "如果只有一季"
+
+#: id:20422
+msgid "Always"
+msgstr "總是"
+
+#: id:20423
+msgid "Has trailer"
+msgstr "有預告片"
+
+#: id:20424
+msgid "False"
+msgstr "錯誤"
+
+#: id:20425
+msgid "Fanart slideshow"
+msgstr "劇照幻燈秀"
+
+#: id:20426
+msgid "Export to a single file or separate"
+msgstr "匯出成單一或多個檔案"
+
+#: id:20427
+msgid "files per entry?"
+msgstr "每檔案的項目數？"
+
+#: id:20428
+msgid "Single file"
+msgstr "單一檔案"
+
+#: id:20429
+msgctxt "Auto context with id 20429"
+msgid "Separate"
+msgstr "多個檔案"
+
+#: id:20430
+msgid "Export thumbnails and fanart?"
+msgstr "要匯出縮略圖和劇照嗎？"
+
+#: id:20431
+msgid "Overwrite old files?"
+msgstr "覆蓋原檔案?"
+
+#: id:20432
+msgid "Exclude path from library updates"
+msgstr "資料庫更新時排除的路徑"
+
+#: id:20433
+msgid "Extract thumbnails and video information"
+msgstr "提取縮略圖和媒體標識"
+
+#: id:20434
+msgid "Sets"
+msgstr "影片集"
+
+#: id:20435
+msgid "Set movieset thumb"
+msgstr "設定影片集縮略圖"
+
+#: id:20436
+msgid "Export actor thumbs?"
+msgstr "匯出演員縮略圖"
+
+#: id:20437
+msgid "Choose fanart"
+msgstr "選擇劇照"
+
+#: id:20438
+msgid "Local fanart"
+msgstr "本地劇照"
+
+#: id:20439
+msgid "No fanart"
+msgstr "無劇照"
+
+#: id:20440
+msgid "Current fanart"
+msgstr "目前的劇照"
+
+#: id:20441
+msgid "Remote fanart"
+msgstr "遠端的劇照"
+
+#: id:20442
+msgid "Change content"
+msgstr "更新內容"
+
+#: id:20443
+msgid "Do you want to refresh info for all"
+msgstr "要更新此目錄下的所有專案嗎？"
+
+#: id:20444
+msgid "items within this path?"
+msgstr "項目在這個路徑？"
+
+#: id:20445
+msgid "Fanart"
+msgstr "劇照"
+
+#: id:20446
+msgid "Locally stored information found."
+msgstr "找到本地的資料。"
+
+#: id:20447
+msgid "Ignore and refresh from internet?"
+msgstr "要忽略並從網際網路更新嗎？"
+
+#: id:20448
+msgid "Could not download information"
+msgstr "無法下載資料"
+
+#: id:20449
+msgid "Unable to connect to remote server"
+msgstr "無法連接到遠端伺服器"
+
+#: id:20450
+msgid "Would you like to continue scanning?"
+msgstr "您要繼續掃描嗎？"
+
+#: id:20451
+msgid "Countries"
+msgstr "國家"
+
+#: id:20452
+msgid "episode"
+msgstr "集"
+
+#: id:20453
+msgid "episodes"
+msgstr "集"
+
+#: id:20454
+msgid "Listener"
+msgstr "電台"
+
+#: id:20455
+msgid "Listeners"
+msgstr "電台"
+
+#: id:20456
+msgid "Set movieset fanart"
+msgstr "設定電影劇照"
+
+#: id:20457
+msgid "Movie set"
+msgstr "電影集"
+
+#: id:20458
+msgid "Group movies in sets"
+msgstr "按同系列電影分組"
+
+#: id:21330
+msgid "Show hidden files and directories"
+msgstr "顯示隱藏檔案和目錄"
+
+#: id:21331
+msgid "TuxBox client"
+msgstr "TuxBox 客戶端"
+
+#: id:21332
+msgid "WARNING: Target TuxBox device is in recording-mode!"
+msgstr "警告：目標 TuxBox 裝置在錄影模式！"
+
+#: id:21333
+msgid "The stream will be stopped!"
+msgstr "串流即將停止！"
+
+#: id:21334
+msgid "Zap to channel: %s failed!"
+msgstr "切換頻道：%s 失敗！"
+
+#: id:21335
+msgid "Are you sure to start the stream?"
+msgstr "你確定要開始串流？"
+
+#: id:21336
+msgid "Connecting to: %s"
+msgstr "連線到：%s"
+
+#: id:21337
+msgid "TuxBox device"
+msgstr "TuxBox 裝置"
+
+#: id:21359
+msgid "Add media share..."
+msgstr "加入媒體共享…"
+
+#: id:21360
+msgid "Share video and music libraries through UPnP"
+msgstr "啟用 UPnP 伺服器"
+
+#: id:21364
+msgid "Edit media share"
+msgstr "編輯媒體共享"
+
+#: id:21365
+msgid "Remove media share"
+msgstr "移除媒體共享"
+
+#: id:21366
+msgid "Subtitle folder"
+msgstr "自訂字幕資料夾"
+
+#: id:21367
+msgid "Movie & alternate subtitle directory"
+msgstr "電影和替代字幕資料夾"
+
+#: id:21368
+msgid "Override ASS/SSA subtitles fonts"
+msgstr "覆蓋 ASS/SSA 字幕的字型"
+
+#: id:21369
+msgid "Enable mouse and Touch Screen support"
+msgstr "啟用滑鼠"
+
+#: id:21370
+msgid "Play navigation sounds during media playback"
+msgstr "媒體播放時使用瀏覽音效"
+
+#: id:21371
+msgid "Thumbnail"
+msgstr "縮略圖"
+
+#: id:21372
+msgid "Forced DVD player region"
+msgstr "強制 DVD 播放器區碼"
+
+#: id:21373
+msgid "Video output"
+msgstr "視訊硬體"
+
+#: id:21374
+msgid "Video aspect"
+msgstr "視訊模式"
+
+#: id:21375
+msgctxt "Auto context with id 21375"
+msgid "Normal"
+msgstr "一般"
+
+#: id:21376
+msgid "Letterbox"
+msgstr "填滿螢幕(有黑邊)"
+
+#: id:21377
+msgid "Widescreen"
+msgstr "寬螢幕"
+
+#: id:21378
+msgid "Enable 480p"
+msgstr "開啟 480p"
+
+#: id:21379
+msgid "Enable 720p"
+msgstr "開啟 720p"
+
+#: id:21380
+msgid "Enable 1080i"
+msgstr "開啟 1080i"
+
+#: id:21381
+msgid "Enter name of new playlist"
+msgstr "輸入新播放列表的名稱"
+
+#: id:21382
+msgid "Show \"Add source\" buttons in file lists"
+msgstr "停用檔案列表的新增來源按鈕"
+
+#: id:21383
+msgid "Enable scrollbars"
+msgstr "啟用 頁面捲軸"
+
+#: id:21384
+msgid "Make watched filtering a toggle in video library"
+msgstr "視訊資料庫使用瀏覽過濾按鈕"
+
+#: id:21385
+msgctxt "Auto context with id 21385"
+msgid "Open"
+msgstr "打開"
+
+#: id:21386
+msgid "Acoustic management level"
+msgstr "噪音管理"
+
+#: id:21387
+msgid "Fast"
+msgstr "快速"
+
+#: id:21388
+msgid "Quiet"
+msgstr "安靜"
+
+#: id:21389
+msgid "Enable custom background"
+msgstr "啟用 自訂背景"
+
+#: id:21390
+msgid "Power management level"
+msgstr "電源管理"
+
+#: id:21391
+msgid "High power"
+msgstr "高功率"
+
+#: id:21392
+msgid "Low power"
+msgstr "低功率"
+
+#: id:21393
+msgid "High standby"
+msgstr "高待機"
+
+#: id:21394
+msgid "Low standby"
+msgstr "低待機"
+
+#: id:21395
+msgid "Unable to cache files bigger than 4GB"
+msgstr "暫存檔不能超過 4GB"
+
+#: id:21396
+msgid "Chapter"
+msgstr "章節"
+
+#: id:21397
+msgid "High quality pixel shader v2"
+msgstr "高品質像素著色器 V2"
+
+#: id:21398
+msgid "Enable playlist at startup"
+msgstr "啟用 啟動時播放列表"
+
+#: id:21399
+msgid "Use tween animations"
+msgstr "使用 Tween 動畫效果"
+
+#: id:21400
+msgid "contains"
+msgstr "包含"
+
+#: id:21401
+msgid "does not contain"
+msgstr "未包含"
+
+#: id:21402
+msgid "is"
+msgstr "是"
+
+#: id:21403
+msgid "is not"
+msgstr "不是"
+
+#: id:21404
+msgid "starts with"
+msgstr "開始於"
+
+#: id:21405
+msgid "ends with"
+msgstr "結束於"
+
+#: id:21406
+msgid "greater than"
+msgstr "大於"
+
+#: id:21407
+msgid "less than"
+msgstr "小於"
+
+#: id:21408
+msgid "after"
+msgstr "之後"
+
+#: id:21409
+msgid "before"
+msgstr "之前"
+
+#: id:21410
+msgid "in the last"
+msgstr "在最近"
+
+#: id:21411
+msgid "not in the last"
+msgstr "非最近"
+
+#: id:21412
+msgid "Scrapers"
+msgstr "網路站台"
+
+#: id:21413
+msgid "Default movie scraper"
+msgstr "預設電影站台"
+
+#: id:21414
+msgid "Default tvshow scraper"
+msgstr "預設電視站台"
+
+#: id:21415
+msgid "Default music video scraper"
+msgstr "預設音樂影片站台"
+
+#: id:21416
+msgid "Enable fallback based on scraper language"
+msgstr "啟用 當地語系支援"
+
+#: id:21417
+msgid "- Settings"
+msgstr "- 設定"
+
+#: id:21418
+msgid "Multilingual"
+msgstr "多語言"
+
+#: id:21419
+msgid "No scrapers present"
+msgstr "找不到站台"
+
+#: id:21420
+msgid "Value to match"
+msgstr "符合條件"
+
+#: id:21421
+msgid "Smart playlist rule"
+msgstr "智慧播放列表規則"
+
+#: id:21422
+msgid "Match items where"
+msgstr "匹配項目"
+
+#: id:21423
+msgid "New rule..."
+msgstr "新規則…"
+
+#: id:21424
+msgid "Items must match"
+msgstr "項目必須符合"
+
+#: id:21425
+msgid "all of the rules"
+msgstr "所有規則"
+
+#: id:21426
+msgid "one or more of the rules"
+msgstr "一個或更多規則"
+
+#: id:21427
+msgid "Limit to"
+msgstr "限制"
+
+#: id:21428
+msgid "No limit"
+msgstr "無限制"
+
+#: id:21429
+msgid "Order by"
+msgstr "排序方式"
+
+#: id:21430
+msgid "ascending"
+msgstr "升幂"
+
+#: id:21431
+msgid "descending"
+msgstr "降幂"
+
+#: id:21432
+msgid "Edit smart playlist"
+msgstr "編輯智慧播放列表"
+
+#: id:21433
+msgid "Name of the playlist"
+msgstr "播放列表名稱"
+
+#: id:21434
+msgid "Find items where"
+msgstr "尋找項目"
+
+#: id:21435
+msgid "Edit"
+msgstr "編輯"
+
+#: id:21436
+msgid "%i items"
+msgstr "%i 個項目"
+
+#: id:21437
+msgid "New smart playlist..."
+msgstr "新的智慧播放列表…"
+
+#: id:21438
+msgid "%c Drive"
+msgstr "%c 裝置"
+
+#: id:21439
+msgid "Edit party mode rules"
+msgstr "編輯派對模式規則"
+
+#: id:21440
+msgid "Home folder"
+msgstr "主目錄"
+
+#: id:21441
+msgid "Watched count"
+msgstr "觀看次數"
+
+#: id:21442
+msgid "Episode title"
+msgstr "片名"
+
+#: id:21443
+msgid "Video resolution"
+msgstr "視訊解析度"
+
+#: id:21444
+msgid "Audio channels"
+msgstr "音效聲道數"
+
+#: id:21445
+msgid "Video codec"
+msgstr "視訊編碼"
+
+#: id:21446
+msgid "Audio codec"
+msgstr "音效編碼"
+
+#: id:21447
+msgid "Audio language"
+msgstr "對白語言"
+
+#: id:21448
+msgid "Subtitle language"
+msgstr "字幕語言"
+
+#: id:21449
+msgid "Remote control sends keyboard presses"
+msgstr "搖控器發送鍵盤按鍵"
+
+#: id:21450
+msgid "- Edit"
+msgstr "- 編輯"
+
+#: id:21451
+msgid "Internet connection required."
+msgstr "需要網際網路連線。"
+
+#: id:21452
+msgid "Get More..."
+msgstr "取得更多..."
+
+#: id:21453
+msgid "Root filesystem"
+msgstr "檔案系統 Root Filesystem"
+
+#: id:21454
+msgid "Cache full"
+msgstr "完整快取"
+
+#: id:21455
+msgid "Cache filled before reaching required amount for continous playback"
+msgstr "只快取到足夠連續播放的資料量"
+
+#: id:21460
+msgid "Subtitle location"
+msgstr "字幕位置"
+
+#: id:21461
+msgid "Fixed"
+msgstr "固定"
+
+#: id:21462
+msgid "Bottom of video"
+msgstr "影片底部"
+
+#: id:21463
+msgid "Below video"
+msgstr "影片之下"
+
+#: id:21464
+msgid "Top of video"
+msgstr "影片上方"
+
+#: id:21465
+msgid "Above video"
+msgstr "影片之上"
+
+#: id:21800
+msgid "File name"
+msgstr "檔案名稱"
+
+#: id:21801
+msgid "File path"
+msgstr "檔案路徑"
+
+#: id:21802
+msgid "File size"
+msgstr "檔案大小"
+
+#: id:21803
+msgid "File date/time"
+msgstr "檔案日期/時間"
+
+#: id:21804
+msgid "Slide index"
+msgstr "幻燈片索引"
+
+#: id:21805
+msgctxt "Auto context with id 21805"
+msgid "Resolution"
+msgstr "解析度"
+
+#: id:21806
+msgctxt "Auto context with id 21806"
+msgid "Comment"
+msgstr "評論"
+
+#: id:21807
+msgid "Colour/B&W"
+msgstr "彩色/黑白"
+
+#: id:21808
+msgid "JPEG process"
+msgstr "JPEG 影像處理"
+
+#: id:21820
+msgid "Date/Time"
+msgstr "日期/時間"
+
+#: id:21821
+msgid "Description"
+msgstr "描述"
+
+#: id:21822
+msgid "Camera make"
+msgstr "製造廠商"
+
+#: id:21823
+msgid "Camera model"
+msgstr "相機型號"
+
+#: id:21824
+msgid "EXIF comment"
+msgstr "註解"
+
+#: id:21825
+msgid "Firmware"
+msgstr "韌體"
+
+#: id:21826
+msgid "Aperture"
+msgstr "光圈值"
+
+#: id:21827
+msgid "Focal length"
+msgstr "鏡頭焦長"
+
+#: id:21828
+msgid "Focus distance"
+msgstr "焦點距離"
+
+#: id:21829
+msgid "Exposure"
+msgstr "曝光"
+
+#: id:21830
+msgid "Exposure time"
+msgstr "曝光時間"
+
+#: id:21831
+msgid "Exposure bias"
+msgstr "曝光傾向"
+
+#: id:21832
+msgid "Exposure mode"
+msgstr "曝光模式"
+
+#: id:21833
+msgid "Flash used"
+msgstr "閃光燈"
+
+#: id:21834
+msgid "White-balance"
+msgstr "白平衡"
+
+#: id:21835
+msgid "Light source"
+msgstr "光源"
+
+#: id:21836
+msgid "Metering mode"
+msgstr "測光模式"
+
+#: id:21837
+msgid "ISO"
+msgstr "ISO 感光值"
+
+#: id:21838
+msgid "Digital zoom"
+msgstr "數位變焦"
+
+#: id:21839
+msgid "CCD width"
+msgstr "CCD 寬度"
+
+#: id:21840
+msgid "GPS latitude"
+msgstr "GPS 緯度"
+
+#: id:21841
+msgid "GPS longitude"
+msgstr "GPS 經度"
+
+#: id:21842
+msgid "GPS altitude"
+msgstr "GPS 高度"
+
+#: id:21843
+msgid "Orientation"
+msgstr "方位"
+
+#: id:21860
+msgid "Supplemental categories"
+msgstr "補充類別"
+
+#: id:21861
+msgid "Keywords"
+msgstr "關鍵字"
+
+#: id:21862
+msgid "Caption"
+msgstr "說明"
+
+#: id:21863
+msgid "Author"
+msgstr "作者"
+
+#: id:21864
+msgid "Headline"
+msgstr "標題"
+
+#: id:21865
+msgid "Special instructions"
+msgstr "特別附註"
+
+#: id:21866
+msgid "Category"
+msgstr "類別"
+
+#: id:21867
+msgid "Byline"
+msgstr "署名報導"
+
+#: id:21868
+msgid "Byline title"
+msgstr "署名報導標題"
+
+#: id:21869
+msgid "Credit"
+msgstr "信用"
+
+#: id:21870
+msgid "Source"
+msgstr "來源"
+
+#: id:21871
+msgid "Copyright notice"
+msgstr "版權條款"
+
+#: id:21872
+msgid "Object name"
+msgstr "物件名稱"
+
+#: id:21873
+msgid "City"
+msgstr "城市"
+
+#: id:21874
+msgid "State"
+msgstr "州"
+
+#: id:21875
+msgctxt "Auto context with id 21875"
+msgid "Country"
+msgstr "國家"
+
+#: id:21876
+msgid "Original Tx Reference"
+msgstr "原始的 Tx 引用"
+
+#: id:21877
+msgid "Date created"
+msgstr "建立日期"
+
+#: id:21878
+msgid "Copyright flag"
+msgstr "版權標誌"
+
+#: id:21879
+msgid "Country code"
+msgstr "國家代碼"
+
+#: id:21880
+msgid "Reference service"
+msgstr "參考服務"
+
+#: id:21881
+msgid "Allow control of XBMC via UPnP"
+msgstr "允許通過 UPnP 控制 XBMC"
+
+#: id:21882
+msgid "Attempt to skip introduction before DVD menu"
+msgstr "嘗試略過廣告直接跳至 DVD 選單"
+
+#: id:21883
+msgid "Saved music"
+msgstr "擷取音樂 CD"
+
+#: id:21884
+msgid "Query info for all artists"
+msgstr "查詢所有藝人的資訊"
+
+#: id:21885
+msgid "Downloading album information"
+msgstr "下載專輯資訊"
+
+#: id:21886
+msgid "Downloading artist information"
+msgstr "下載藝人資訊"
+
+#: id:21887
+msgid "Biography"
+msgstr "經歷"
+
+#: id:21888
+msgid "Discography"
+msgstr "作品"
+
+#: id:21889
+msgid "Searching artist"
+msgstr "搜尋藝人"
+
+#: id:21890
+msgid "Select artist"
+msgstr "選擇藝人"
+
+#: id:21891
+msgctxt "Auto context with id 21891"
+msgid "Artist information"
+msgstr "藝人資訊"
+
+#: id:21892
+msgid "Instruments"
+msgstr "樂器"
+
+#: id:21893
+msgid "Born"
+msgstr "出生"
+
+#: id:21894
+msgid "Formed"
+msgstr "出道"
+
+#: id:21895
+msgid "Themes"
+msgstr "主題"
+
+#: id:21896
+msgid "Disbanded"
+msgstr "解散"
+
+#: id:21897
+msgid "Died"
+msgstr "死亡"
+
+#: id:21898
+msgid "Years active"
+msgstr "活躍"
+
+#: id:21899
+msgid "Label"
+msgstr "標籤"
+
+#: id:21900
+msgid "Born/Formed"
+msgstr "出生/出道"
+
+#: id:22000
+msgid "Update library on startup"
+msgstr "在啟動時更新資料庫"
+
+#: id:22001
+msgid "Hide progress of library updates"
+msgstr "總是在幕後更新資料庫"
+
+#: id:22002
+msgid "- DNS suffix"
+msgstr "- DNS 的尾碼"
+
+#: id:22003
+msgid "%2.3fs"
+msgstr "%2.3f秒"
+
+#: id:22004
+msgid "Delayed by: %2.3fs"
+msgstr "延遲：%2.3fs"
+
+#: id:22005
+msgid "Ahead by: %2.3fs"
+msgstr "提前：%2.3fs"
+
+#: id:22006
+msgid "Subtitle offset"
+msgstr "字幕位移"
+
+#: id:22007
+msgid "OpenGL vendor:"
+msgstr "OpenGL 廠商："
+
+#: id:22008
+msgid "OpenGL renderer:"
+msgstr "OpenGL 渲染："
+
+#: id:22009
+msgid "OpenGL version:"
+msgstr "OpenGL 版本："
+
+#: id:22010
+msgid "GPU temperature:"
+msgstr "GPU 温度："
+
+#: id:22011
+msgid "CPU temperature:"
+msgstr "CPU 温度："
+
+#: id:22012
+msgid "Total memory"
+msgstr "總記憶體"
+
+#: id:22013
+msgid "Profile data"
+msgstr "簡介資料"
+
+#: id:22014
+msgid "Use dim if paused during video playback"
+msgstr "暫停視訊播放時啟用陰暗效果"
+
+#: id:22015
+msgid "All recordings"
+msgstr "所有紀錄"
+
+#: id:22016
+msgid "By title"
+msgstr "標題"
+
+#: id:22017
+msgid "By group"
+msgstr "群組"
+
+#: id:22018
+msgid "Live channels"
+msgstr "現場直播"
+
+#: id:22019
+msgid "Recordings by title"
+msgstr "錄音的標題"
+
+#: id:22020
+msgid "Guide"
+msgstr "節目表"
+
+#: id:22021
+msgid "Allowed error in aspect ratio to minimize black bars"
+msgstr "為減少黑邊允許高寬比誤差"
+
+#: id:22022
+msgid "Show video files in listings"
+msgstr "在清單中顯示視訊檔"
+
+#: id:22023
+msgid "DirectX vendor:"
+msgstr "DirectX 廠商："
+
+#: id:22024
+msgid "Direct3D version:"
+msgstr "Direct3D 版本："
+
+#: id:22030
+msgctxt "Auto context with id 22030"
+msgid "Font"
+msgstr "字型"
+
+#: id:22031
+msgctxt "Auto context with id 22031"
+msgid "- Size"
+msgstr "- 大小"
+
+#: id:22032
+msgctxt "Auto context with id 22032"
+msgid "- Colours"
+msgstr "- 顏色"
+
+#: id:22033
+msgid "- Charset"
+msgstr "- 編碼"
+
+#: id:22034
+msgid "Export karaoke titles as HTML"
+msgstr "匯出卡拉OK 標題為 HTML"
+
+#: id:22035
+msgid "Export karaoke titles as CSV"
+msgstr "匯出卡拉OK 標題為 CSV"
+
+#: id:22036
+msgid "Import karaoke titles..."
+msgstr "匯入卡拉OK 標題…"
+
+#: id:22037
+msgid "Show song selector automatically"
+msgstr "自動顯示歌曲選單"
+
+#: id:22038
+msgid "Export karaoke titles..."
+msgstr "匯出卡拉OK 標題…"
+
+#: id:22039
+msgid "Enter song number"
+msgstr "輸入歌曲號碼"
+
+#: id:22040
+msgid "white/green"
+msgstr "白/綠"
+
+#: id:22041
+msgid "white/red"
+msgstr "白/紅"
+
+#: id:22042
+msgid "white/blue"
+msgstr "白/藍"
+
+#: id:22043
+msgid "black/white"
+msgstr "黑/白"
+
+#: id:22079
+msgid "Default select action"
+msgstr "預設選擇動作"
+
+#: id:22080
+msgid "Choose"
+msgstr "選擇"
+
+#: id:22081
+msgid "Show Information"
+msgstr "顯示詳細資訊"
+
+#: id:22082
+msgid "More..."
+msgstr "更多..."
+
+#: id:22083
+msgid "Play all"
+msgstr "播放全部"
+
+#: id:23049
+msgid "Teletext not available"
+msgstr "只不到 Teletext"
+
+#: id:23050
+msgid "Activate Teletext"
+msgstr "開啟電傳視訊"
+
+#: id:23051
+msgid "Part %i"
+msgstr "片段 %i"
+
+#: id:23052
+msgid "Buffering %i bytes"
+msgstr "已緩衝 %i Bytes"
+
+#: id:23053
+msgid "Stopping"
+msgstr "正在停止"
+
+#: id:23054
+msgid "Running"
+msgstr "正在執行"
+
+#: id:23100
+msgid "External Player Active"
+msgstr "外部播放機啟動"
+
+#: id:23101
+msgid "Click OK to terminate the player"
+msgstr "點選 OK 關閉播放機"
+
+#: id:23104
+msgid "Click OK when playback has ended"
+msgstr "播放完畢時點選 OK"
+
+#: id:24000
+msgid "Add-on"
+msgstr "附加元件"
+
+#: id:24001
+msgid "Add-ons"
+msgstr "附加元件"
+
+#: id:24002
+msgid "Add-on options"
+msgstr "附加元件選項"
+
+#: id:24003
+msgid "Add-on Information"
+msgstr "附加元件資訊"
+
+#: id:24005
+msgctxt "Auto context with id 24005"
+msgid "Media sources"
+msgstr "媒體來源"
+
+#: id:24007
+msgctxt "Auto context with id 24007"
+msgid "Movie information"
+msgstr "電影資訊"
+
+#: id:24008
+msgctxt "Auto context with id 24008"
+msgid "Screensaver"
+msgstr "螢幕保護程式"
+
+#: id:24009
+msgid "Script"
+msgstr "腳本"
+
+#: id:24010
+msgctxt "Auto context with id 24010"
+msgid "Visualization"
+msgstr "視覺效果"
+
+#: id:24011
+msgid "Add-on repository"
+msgstr "附加元件庫"
+
+#: id:24012
+msgctxt "Auto context with id 24012"
+msgid "Subtitles"
+msgstr "字幕"
+
+#: id:24013
+msgid "Lyrics"
+msgstr "歌詞"
+
+#: id:24014
+msgid "TV information"
+msgstr "電視資訊"
+
+#: id:24015
+msgctxt "Auto context with id 24015"
+msgid "Music video information"
+msgstr "音樂錄影帶資訊"
+
+#: id:24016
+msgctxt "Auto context with id 24016"
+msgid "Album information"
+msgstr "專輯資訊"
+
+#: id:24017
+msgctxt "Auto context with id 24017"
+msgid "Artist information"
+msgstr "藝術家資訊"
+
+#: id:24018
+msgctxt "Auto context with id 24018"
+msgid "Services"
+msgstr "服務"
+
+#: id:24020
+msgid "Configure"
+msgstr "設定"
+
+#: id:24021
+msgctxt "Auto context with id 24021"
+msgid "Disable"
+msgstr "停用"
+
+#: id:24022
+msgid "Enable"
+msgstr "啟用"
+
+#: id:24023
+msgid "Add-on disabled"
+msgstr "附加元件已停用"
+
+#: id:24027
+msgctxt "Auto context with id 24027"
+msgid "Weather"
+msgstr "氣象"
+
+#: id:24028
+msgid "Weather.com (standard)"
+msgstr "Weather.com (標準)"
+
+#: id:24030
+msgid "This Add-on can not be configured"
+msgstr "這個附加元件不能被設定"
+
+#: id:24031
+msgid "Error loading settings"
+msgstr "讀取設定錯誤！"
+
+#: id:24032
+msgid "All Add-ons"
+msgstr "全部附加元件"
+
+#: id:24033
+msgid "Get Add-ons"
+msgstr "取得附加元件"
+
+#: id:24034
+msgid "Check for updates"
+msgstr "檢查更新"
+
+#: id:24035
+msgid "Force refresh"
+msgstr "強制重新整理"
+
+#: id:24036
+msgid "Change log"
+msgstr "更新日誌"
+
+#: id:24037
+msgid "Uninstall"
+msgstr "解除安裝"
+
+#: id:24038
+msgid "Install"
+msgstr "安裝"
+
+#: id:24039
+msgid "Disabled Add-ons"
+msgstr "停用的附加元件"
+
+#: id:24040
+msgid "(Clear the current setting)"
+msgstr "（清除目前的設定）"
+
+#: id:24041
+msgid "Install from zip file"
+msgstr "從 zip 檔案安裝"
+
+#: id:24042
+msgid "Downloading %i%%"
+msgstr "已下載 %i%%"
+
+#: id:24043
+msgid "Available Updates"
+msgstr "可取得的更新"
+
+#: id:24044
+msgid "Dependencies not met"
+msgstr "Dependencies 不相符"
+
+#: id:24045
+msgid "Add-on does not have the correct structure"
+msgstr "附加元件未包含正確結構"
+
+#: id:24046
+msgid "%s is used by the following installed add-on(s)"
+msgstr "%s 正被下列已安裝的附加元件使用中"
+
+#: id:24047
+msgid "This add-on cannot be uninstalled"
+msgstr "這個附加元件不能解除安裝"
+
+#: id:24048
+msgid "Rollback"
+msgstr "回復舊版"
+
+#: id:24050
+msgid "Available Add-ons"
+msgstr "可取得的附加元件"
+
+#: id:24051
+msgid "Version:"
+msgstr "版本："
+
+#: id:24052
+msgid "Disclaimer"
+msgstr "免責聲明"
+
+#: id:24053
+msgid "License:"
+msgstr "許可："
+
+#: id:24054
+msgid "Changelog"
+msgstr "更新日誌"
+
+#: id:24059
+msgid "Would you like to enable this Add-on?"
+msgstr "您想要啟用這個附加元件嗎？"
+
+#: id:24060
+msgid "Would you like to disable this Add-on?"
+msgstr "您想要停用這個附加元件嗎？"
+
+#: id:24061
+msgid "Add-on update available!"
+msgstr "有新的附加元件更新"
+
+#: id:24062
+msgid "Enabled Add-ons"
+msgstr "已啟用的附加元件"
+
+#: id:24063
+msgid "Auto update"
+msgstr "自動更新"
+
+#: id:24064
+msgid "Add-on enabled"
+msgstr "已啟用附加元件"
+
+#: id:24065
+msgid "Add-on updated"
+msgstr "已更新附加元件"
+
+#: id:24066
+msgid "Cancel Add-on download?"
+msgstr "要取消附加元件下載嗎？"
+
+#: id:24067
+msgid "Currently downloading Add-ons"
+msgstr "正在下載的附加元件"
+
+#: id:24068
+msgid "Update available"
+msgstr "有新的更新"
+
+#: id:24069
+msgid "Update"
+msgstr "更新"
+
+#: id:24070
+msgid "Add-on could not be loaded."
+msgstr "附加元件無法被載入。"
+
+#: id:24071
+msgid "An unknown error has occurred."
+msgstr "發生未知的錯誤。"
+
+#: id:24072
+msgid "Settings required"
+msgstr "需要的設定"
+
+#: id:24073
+msgid "Could not connect"
+msgstr "無法建立連線"
+
+#: id:24074
+msgid "Needs to restart"
+msgstr "需要重新啟動"
+
+#: id:24075
+msgctxt "Auto context with id 24075"
+msgid "Disable"
+msgstr "停用"
+
+#: id:24076
+msgid "Add-on Required"
+msgstr "需要的附加元件"
+
+#: id:24080
+msgid "Try to reconnect?"
+msgstr "要重新連線嗎？"
+
+#: id:24089
+msgid "Add-on restarts"
+msgstr "重啟附加元件"
+
+#: id:24090
+msgid "Lock Add-on manager"
+msgstr "鎖定附加元件管理員"
+
+#: id:24094
+msgid "(current)"
+msgstr "〈目前版本〉"
+
+#: id:24095
+msgid "(blacklisted)"
+msgstr "〈黑名單〉"
+
+#: id:24096
+msgid "Add-on has been marked as broken in repository."
+msgstr "附加元件已經被標記為\"已損壞\"。"
+
+#: id:24097
+msgid "Would you like to disable it on your system?"
+msgstr "您想要在您的系統上停用嗎？"
+
+#: id:24098
+msgid "Broken"
+msgstr "已損壞"
+
+#: id:24099
+msgid "Would you like to switch to this skin?"
+msgstr "是否要切換至此主題？"
+
+#: id:24100
+msgid "To use this feature you must download an Add-on:"
+msgstr "要使用這項功能你必須下載一個附加元件："
+
+#: id:24101
+msgid "Would you like to download this Add-on?"
+msgstr "你要下載這個附加元件嗎？"
+
+#: id:25000
+msgid "Notifications"
+msgstr "通知"
+
+#: id:29800
+msgid "Library Mode"
+msgstr "資料庫模式"
+
+#: id:29801
+msgid "QWERTY keyboard"
+msgstr "QWERTY 鍵盤"
+
+#: id:29802
+msgid "Passthrough Audio in use"
+msgstr "音效直通輸出啟用中"
+
+#: id:33001
+msgid "Trailer quality"
+msgstr "預告片品質"
+
+#: id:33002
+msgid "Stream"
+msgstr "媒體流"
+
+#: id:33003
+msgid "Download"
+msgstr "下載"
+
+#: id:33004
+msgid "Download & play"
+msgstr "下載 & 播放"
+
+#: id:33005
+msgid "Download & save"
+msgstr "下載 & 儲存"
+
+#: id:33006
+msgid "Today"
+msgstr "今天"
+
+#: id:33007
+msgid "Tomorrow"
+msgstr "明天"
+
+#: id:33008
+msgid "Saving"
+msgstr "儲存中"
+
+#: id:33009
+msgid "Copying"
+msgstr "複製中"
+
+#: id:33010
+msgid "Set download directory"
+msgstr "設定下載目錄"
+
+#: id:33011
+msgid "Search duration"
+msgstr "搜尋持續時間"
+
+#: id:33012
+msgid "Short"
+msgstr "短"
+
+#: id:33013
+msgid "Long"
+msgstr "長"
+
+#: id:33014
+msgid "Use DVD player instead of regular player"
+msgstr "用 DVD player 代替預設播放機"
+
+#: id:33015
+msgid "Ask for download before playing video"
+msgstr "播放視訊前詢間是否先下載"
+
+#: id:33016
+msgid "Clips"
+msgstr "片斷"
+
+#: id:33017
+msgid "Restart plugin to enable"
+msgstr "重新啟動以啟用外掛程式"
+
+#: id:33018
+msgid "Tonight"
+msgstr "今晚"
+
+#: id:33019
+msgid "Tomorrow Night"
+msgstr "明晚"
+
+#: id:33020
+msgid "Condition"
+msgstr "狀況"
+
+#: id:33021
+msgid "Precipitation"
+msgstr "降雨量"
+
+#: id:33022
+msgid "Precip"
+msgstr "降雨"
+
+#: id:33023
+msgid "Humid"
+msgstr "潮濕"
+
+#: id:33024
+msgid "Feels"
+msgstr "感覺"
+
+#: id:33025
+msgid "Observed"
+msgstr "觀測值"
+
+#: id:33026
+msgid "Departure from normal"
+msgstr "偏離正常值"
+
+#: id:33027
+msgid "Sunrise"
+msgstr "日出"
+
+#: id:33028
+msgid "Sunset"
+msgstr "日落"
+
+#: id:33029
+msgid "Details"
+msgstr "詳細資料"
+
+#: id:33030
+msgid "Outlook"
+msgstr "氣象趨勢"
+
+#: id:33031
+msgid "Coverflow"
+msgstr "流動封面"
+
+#: id:33032
+msgid "Translate text"
+msgstr "翻譯文字"
+
+#: id:33033
+msgid "Map list %s category"
+msgstr "地圖列表 %s 分類"
+
+#: id:33034
+msgid "36 Hour"
+msgstr "36 小時"
+
+#: id:33035
+msgid "Maps"
+msgstr "地圖"
+
+#: id:33036
+msgid "Hourly"
+msgstr "每小時"
+
+#: id:33037
+msgid "Weekend"
+msgstr "週末"
+
+#: id:33038
+msgid "%s day"
+msgstr "%s 天"
+
+#: id:33049
+msgid "Alert"
+msgstr "提醒"
+
+#: id:33050
+msgid "Alerts"
+msgstr "提醒"
+
+#: id:33051
+msgid "Choose Your"
+msgstr "選擇你的"
+
+#: id:33052
+msgid "Check"
+msgstr "查看你的"
+
+#: id:33053
+msgctxt "Auto context with id 33053"
+msgid "Configure the"
+msgstr "配置你的"
+
+#: id:33054
+msgid "Seasons"
+msgstr "季節"
+
+#: id:33055
+msgid "Use your"
+msgstr "使用你的"
+
+#: id:33056
+msgid "Watch your"
+msgstr "觀看你的"
+
+#: id:33057
+msgid "Listen to"
+msgstr "聆聽你的"
+
+#: id:33058
+msgid "View your"
+msgstr "流覽你的"
+
+#: id:33059
+msgctxt "Auto context with id 33059"
+msgid "Configure the"
+msgstr "配置你的"
+
+#: id:33060
+msgid "Power"
+msgstr "電源控制"
+
+#: id:33061
+msgid "Menu"
+msgstr "選單"
+
+#: id:33062
+msgid "Play the"
+msgstr "播放你的"
+
+#: id:33063
+msgid "Options"
+msgstr "選項"
+
+#: id:33065
+msgid "Editor"
+msgstr "編輯"
+
+#: id:33066
+msgid "About your"
+msgstr "關於你的"
+
+#: id:33067
+msgid "Star rating"
+msgstr "星級"
+
+#: id:33068
+msgid "Background"
+msgstr "桌面背景"
+
+#: id:33069
+msgid "Backgrounds"
+msgstr "桌面背景集"
+
+#: id:33070
+msgid "Custom background"
+msgstr "自訂桌面背景"
+
+#: id:33071
+msgid "Custom backgrounds"
+msgstr "自訂桌面背景集"
+
+#: id:33072
+msgid "View Readme"
+msgstr "流覽說明檔"
+
+#: id:33073
+msgid "View Changelog"
+msgstr "流覽更新記錄"
+
+#: id:33074
+msgid "This version of %s requires an"
+msgstr "運行此版本的 %s 需要"
+
+#: id:33075
+msgid "XBMC revision of %s or greater to run."
+msgstr "XBMC為 %s 或更高版本。"
+
+#: id:33076
+msgid "Please update XBMC."
+msgstr "請升級XBMC。"
+
+#: id:33077
+msgid "No data found!"
+msgstr "未找到資料！"
+
+#: id:33078
+msgid "Next page"
+msgstr "下一頁"
+
+#: id:33079
+msgid "Love"
+msgstr "喜歡"
+
+#: id:33080
+msgid "Hate"
+msgstr "討厭"
+
+#: id:33081
+msgid "This file is stacked, select the part you want to play from."
+msgstr "這是一個堆疊檔，請選擇要播放的片段。"
+
+#: id:33082
+msgid "Path to script"
+msgstr "腳本路徑"
+
+#: id:33083
+msgid "Enable custom script button"
+msgstr "啟用自訂腳本按鈕"
+
+#: id:33100
+msgid "Failed to start"
+msgstr "起始失敗"
+
+#: id:33101
+msgid "Webserver"
+msgstr "網站伺服器"
+
+#: id:33102
+msgid "Event Server"
+msgstr "事件伺服器"
+
+#: id:33103
+msgid "Remote communication server"
+msgstr "遠端通訊伺服器"
+
+#: id:33200
+msgid "Detected New Connection"
+msgstr "偵測新的連線"
+
+#: id:34000
+msgid "Lame"
+msgstr "Lame"
+
+#: id:34001
+msgid "Vorbis"
+msgstr "Vorbis"
+
+#: id:34002
+msgid "Wav"
+msgstr "Wav"
+
+#: id:34003
+msgid "DXVA2"
+msgstr "DXVA2"
+
+#: id:34004
+msgid "VAAPI"
+msgstr "VAAPI"
+
+#: id:34005
+msgid "Flac"
+msgstr "Flac"
+
+#: id:34100
+msgid "Speaker Configuration"
+msgstr "喇叭設定"
+
+#: id:34101
+msgid "2.0"
+msgstr "2.0"
+
+#: id:34102
+msgid "2.1"
+msgstr "2.1"
+
+#: id:34103
+msgid "3.0"
+msgstr "3.0"
+
+#: id:34104
+msgid "3.1"
+msgstr "3.1"
+
+#: id:34105
+msgid "4.0"
+msgstr "4.0"
+
+#: id:34106
+msgid "4.1"
+msgstr "4.1"
+
+#: id:34107
+msgid "5.0"
+msgstr "5.0"
+
+#: id:34108
+msgid "5.1"
+msgstr "5.1"
+
+#: id:34109
+msgid "7.0"
+msgstr "7.0"
+
+#: id:34110
+msgid "7.1"
+msgstr "7.1"
+
+#: id:34201
+msgid "Can't find a next item to play"
+msgstr "找不到下一個播放項目"
+
+#: id:34202
+msgid "Can't find a previous item to play"
+msgstr "找不到前一個播放項目"
+
+#: id:34300
+msgid "Failed to start zeroconf"
+msgstr "Zeroconf啟動失敗"
+
+#: id:34301
+msgid "Is Apple's Bonjour Service installed? See log for more info."
+msgstr "已經啟用蘋果的 Bonjour 服務了嗎？請查閱記錄以取得更多資訊。"
+
+#: id:34400
+msgid "Video Rendering"
+msgstr "視訊渲染"
+
+#: id:34401
+msgid "Failed to init video filters/scalers, falling back to bilinear scaling"
+msgstr "影像濾鏡/放大器初始化失敗，改用預設的雙線性放大"
+
+#: id:34402
+msgid "Failed to initialize audio device"
+msgstr "初始化音訊裝置失敗"
+
+#: id:34403
+msgid "Check your audiosettings"
+msgstr "檢查你的音訊設定"
+
+#: id:34404
+msgid "Use gestures for navigation:"
+msgstr ""
+
+#: id:34405
+msgid "1 finger swipe left,right,up,down for cursors"
+msgstr ""
+
+#: id:34406
+msgid "2 finger swipe left for backspace"
+msgstr ""
+
+#: id:34407
+msgid "1 finger single tap for enter"
+msgstr ""
+
+#: id:34408
+msgid "2 finger single tap for contextmenu"
+msgstr ""
+
+#: id:35000
+msgid "Peripherals"
+msgstr "周邊裝置"
+
+#: id:35001
+msgid "Generic HID device"
+msgstr "通用 HID 裝置"
+
+#: id:35002
+msgid "Generic network adapter"
+msgstr "通用網路配接器"
+
+#: id:35003
+msgid "Generic disk"
+msgstr "通用磁碟機"
+
+#: id:35004
+msgid "There are no settings available\nfor this peripheral."
+msgstr "找不到這台周邊裝置 的可用設定"
+
+#: id:35005
+msgid "New device configured"
+msgstr "新的裝置已設定"
+
+#: id:35006
+msgid "Device removed"
+msgstr "裝置已移除"
+
+#: id:35007
+msgid "Keymap to use for this device"
+msgstr "給這個裝置的快速鍵"
+
+#: id:35008
+msgid "Keymap enabled"
+msgstr "快速鍵已啟用"
+
+#: id:35009
+msgid "Do not use the custom keymap for this device"
+msgstr ""
+
+#: id:35500
+msgid "Location"
+msgstr "位置"
+
+#: id:35501
+msgid "Class"
+msgstr "分類"
+
+#: id:35502
+msgctxt "Auto context with id 35502"
+msgid "Name"
+msgstr "名稱"
+
+#: id:35503
+msgid "Vendor"
+msgstr "供應商"
+
+#: id:35504
+msgid "Product ID"
+msgstr "產品 ID"
+
+#: id:36000
+msgid "Pulse-Eight CEC adapter"
+msgstr "Pulse-Eight CEC 配接器"
+
+#: id:36001
+msgid "Pulse-Eight Nyxboard"
+msgstr ""
+
+#: id:36002
+msgid "Switch to keyboard side command"
+msgstr "切換到鍵盤命令"
+
+#: id:36003
+msgid "Switch to remote side command"
+msgstr "切換到遙控器命令"
+
+#: id:36004
+msgid "Press \"user\" button command"
+msgstr "按下\"使用者\"按鈕命令"
+
+#: id:36005
+msgid "Enable switch side commands"
+msgstr "啟用命令模式切換"
+
+#: id:36006
+msgid "Could not open the adapter"
+msgstr "無法開啟配接器"
+
+#: id:36007
+msgid "Devices to power on when starting XBMC"
+msgstr "開啟 XBMC 時打開這台電視"
+
+#: id:36008
+msgid "Devices to power off when stopping XBMC"
+msgstr "當停止 XBMC 時關閉裝置"
+
+#: id:36009
+msgid "Put devices in standby mode when activating screensaver"
+msgstr "螢幕保護啟動時讓裝置進入待機模式"
+
+#: id:36011
+msgid "Could not detect the CEC port. Set it up manually."
+msgstr "無法偵測CEC連接埠。請手動設定。"
+
+#: id:36012
+msgid "Could not initialise the CEC adapter. Check your settings."
+msgstr "無法偵測CEC配接器"
+
+#: id:36013
+msgid "Unsupported libCEC interface version. %d is greater than the version XBMC supports (%d)"
+msgstr "不支援的 libcec 介面版本。 %d 大於XBMC支援的版本 (%d)"
+
+#: id:36014
+msgid "Put this PC in standby mode when the TV is switched off"
+msgstr "如果關掉這台電視，讓這台電腦進入待機模式"
+
+#: id:36015
+msgid "HDMI port number"
+msgstr "HDMI連接埠編號"
+
+#: id:36016
+msgctxt "Auto context with id 36016"
+msgid "Connected"
+msgstr "已連接"
+
+#: id:36017
+msgid "Adapter found, but libCEC is not available"
+msgstr "找到配接器，但無法取得 libcec"
+
+#: id:36018
+msgid "Use the TV's language setting"
+msgstr "使用這個電視的語言設定"
+
+#: id:36019
+msgid "Connected to HDMI device"
+msgstr ""
+
+#: id:36020
+msgid "Make XBMC the active source when starting"
+msgstr ""
+
+#: id:36021
+msgid "Physical address (overrules HDMI port)"
+msgstr ""
+
+#: id:36022
+msgid "COM port (leave empty unless needed)"
+msgstr ""
+
+#: id:36023
+msgid "Configuration updated"
+msgstr ""
+
+#: id:36024
+msgid "Failed to set the new configuration. Please check your settings."
+msgstr ""
+
+#: id:36025
+msgid "Send 'inactive source' command when stopping XBMC"
+msgstr ""
+

--- a/language/Croatian/strings.po
+++ b/language/Croatian/strings.po
@@ -1,0 +1,9093 @@
+# Converted from xbmc strings.xml with xbmc-xml2po (by Team-XBMC)
+msgid ""
+msgstr ""
+"Project-Id-Version: xbmc.core-FRODO_GIT3ed1604ad7\n"
+"Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
+"POT-Creation-Date: 2012-04-09 18:00+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE\n"
+"Language: hr\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: id:0
+msgctxt "Auto context with id 0"
+msgid "Programs"
+msgstr "Programi"
+
+#: id:1
+msgctxt "Auto context with id 1"
+msgid "Pictures"
+msgstr "Slike"
+
+#: id:2
+msgctxt "Auto context with id 2"
+msgid "Music"
+msgstr "Glazba"
+
+#: id:3
+msgctxt "Auto context with id 3"
+msgid "Videos"
+msgstr "Video"
+
+#: id:4
+msgid "TV-Guide"
+msgstr "TV Vodič"
+
+#: id:5
+msgctxt "Auto context with id 5"
+msgid "Settings"
+msgstr "Postavke"
+
+#: id:6
+msgid "XBMC SVN"
+msgstr "XBMC SVN"
+
+#: id:7
+msgctxt "Auto context with id 7"
+msgid "File manager"
+msgstr "Upravitelj dat."
+
+#: id:8
+msgctxt "Auto context with id 8"
+msgid "Weather"
+msgstr "Vrijeme"
+
+#: id:9
+msgid "xbmc media center"
+msgstr "XBMC media centar"
+
+#: id:11
+msgid "Monday"
+msgstr "Ponedjeljak"
+
+#: id:12
+msgid "Tuesday"
+msgstr "Utorak"
+
+#: id:13
+msgid "Wednesday"
+msgstr "Srijeda"
+
+#: id:14
+msgid "Thursday"
+msgstr "Četvrtak"
+
+#: id:15
+msgid "Friday"
+msgstr "Petak"
+
+#: id:16
+msgid "Saturday"
+msgstr "Subota"
+
+#: id:17
+msgid "Sunday"
+msgstr "Nedjelja"
+
+#: id:21
+msgid "January"
+msgstr "Siječanj"
+
+#: id:22
+msgid "February"
+msgstr "Veljača"
+
+#: id:23
+msgid "March"
+msgstr "Ožujak"
+
+#: id:24
+msgid "April"
+msgstr "Travanj"
+
+#: id:25
+msgctxt "Auto context with id 25"
+msgid "May"
+msgstr "Svibanj"
+
+#: id:26
+msgid "June"
+msgstr "Lipanj"
+
+#: id:27
+msgid "July"
+msgstr "Srpanj"
+
+#: id:28
+msgid "August"
+msgstr "Kolovoz"
+
+#: id:29
+msgid "September"
+msgstr "Rujan"
+
+#: id:30
+msgid "October"
+msgstr "Listopad"
+
+#: id:31
+msgid "November"
+msgstr "Studeni"
+
+#: id:32
+msgid "December"
+msgstr "Prosinac"
+
+#: id:41
+msgid "Mon"
+msgstr "Pon"
+
+#: id:42
+msgid "Tue"
+msgstr "Uto"
+
+#: id:43
+msgid "Wed"
+msgstr "Sri"
+
+#: id:44
+msgid "Thu"
+msgstr "Čet"
+
+#: id:45
+msgid "Fri"
+msgstr "Pet"
+
+#: id:46
+msgid "Sat"
+msgstr "Sub"
+
+#: id:47
+msgctxt "Auto context with id 47"
+msgid "Sun"
+msgstr "Ned"
+
+#: id:51
+msgid "Jan"
+msgstr "Sij"
+
+#: id:52
+msgid "Feb"
+msgstr "Velj"
+
+#: id:53
+msgid "Mar"
+msgstr "Ožu"
+
+#: id:54
+msgid "Apr"
+msgstr "Tra"
+
+#: id:55
+msgctxt "Auto context with id 55"
+msgid "May"
+msgstr "Svi"
+
+#: id:56
+msgid "Jun"
+msgstr "Lip"
+
+#: id:57
+msgid "Jul"
+msgstr "Srp"
+
+#: id:58
+msgid "Aug"
+msgstr "Kol"
+
+#: id:59
+msgid "Sep"
+msgstr "Ruj"
+
+#: id:60
+msgid "Oct"
+msgstr "Lis"
+
+#: id:61
+msgid "Nov"
+msgstr "Stu"
+
+#: id:62
+msgid "Dec"
+msgstr "Pro"
+
+#: id:71
+msgid "N"
+msgstr ""
+
+#: id:72
+msgid "NNE"
+msgstr ""
+
+#: id:73
+msgid "NE"
+msgstr ""
+
+#: id:74
+msgid "ENE"
+msgstr ""
+
+#: id:75
+msgid "E"
+msgstr ""
+
+#: id:76
+msgid "ESE"
+msgstr ""
+
+#: id:77
+msgid "SE"
+msgstr ""
+
+#: id:78
+msgid "SSE"
+msgstr ""
+
+#: id:79
+msgid "S"
+msgstr ""
+
+#: id:80
+msgid "SSW"
+msgstr ""
+
+#: id:81
+msgid "SW"
+msgstr ""
+
+#: id:82
+msgid "WSW"
+msgstr ""
+
+#: id:83
+msgid "W"
+msgstr ""
+
+#: id:84
+msgid "WNW"
+msgstr ""
+
+#: id:85
+msgid "NW"
+msgstr ""
+
+#: id:86
+msgid "NNW"
+msgstr ""
+
+#: id:87
+msgid "VAR"
+msgstr ""
+
+#: id:98
+msgid "View: Auto"
+msgstr "Prikaz: Autom."
+
+#: id:99
+msgid "View: Auto big"
+msgstr "Prikaz: Autom. Veliko"
+
+#: id:100
+msgid "View: Icons"
+msgstr "Prikaz: Ikone"
+
+#: id:101
+msgid "View: List"
+msgstr "Prikaz: Lista"
+
+#: id:102
+msgctxt "Auto context with id 102"
+msgid "Scan"
+msgstr "Skeniraj"
+
+#: id:103
+msgctxt "Auto context with id 103"
+msgid "Sort by: Name"
+msgstr "Složi po: Imenu"
+
+#: id:104
+msgid "Sort by: Date"
+msgstr "Složi po: Datumu"
+
+#: id:105
+msgid "Sort by: Size"
+msgstr "Složi po: Veličini"
+
+#: id:106
+msgid "No"
+msgstr "Ne"
+
+#: id:107
+msgid "Yes"
+msgstr "Da"
+
+#: id:108
+msgctxt "Auto context with id 108"
+msgid "Slideshow"
+msgstr "SlideShow"
+
+#: id:109
+msgid "Create thumbs"
+msgstr "Napravi thumbs"
+
+#: id:110
+msgid "Create thumbnails"
+msgstr "Napravi thumbnail"
+
+#: id:111
+msgctxt "Auto context with id 111"
+msgid "Shortcuts"
+msgstr "Prečaci"
+
+#: id:112
+msgid "Paused"
+msgstr "Pauzirano"
+
+#: id:113
+msgid "Update failed"
+msgstr ""
+
+#: id:114
+msgid "Installation failed"
+msgstr ""
+
+#: id:115
+msgid "Copy"
+msgstr "Kopiraj"
+
+#: id:116
+msgid "Move"
+msgstr "Premjesti"
+
+#: id:117
+msgid "Delete"
+msgstr "Izbriši"
+
+#: id:118
+msgid "Rename"
+msgstr "Preimenuj"
+
+#: id:119
+msgid "New folder"
+msgstr "Nova mapa"
+
+#: id:120
+msgid "Confirm file copy"
+msgstr "Potvrdi kopiranje datoteke"
+
+#: id:121
+msgid "Confirm file move"
+msgstr "Potvrdi premještanje datoteke"
+
+#: id:122
+msgid "Confirm file delete?"
+msgstr "Potvrdi brisanje datoteke"
+
+#: id:123
+msgid "Copy these files?"
+msgstr "Kopiraj ove datoteke?"
+
+#: id:124
+msgid "Move these files?"
+msgstr "Premjesti ove datoteke?"
+
+#: id:125
+msgid "Delete these files? - Deleting files cannot be undone!"
+msgstr "Brisanje datoteka? - Nakon brisanja, datoteke nije moguće povratiti!"
+
+#: id:126
+msgid "Status"
+msgstr "Status"
+
+#: id:127
+msgid "Objects"
+msgstr "Objekti"
+
+#: id:128
+msgctxt "Auto context with id 128"
+msgid "General"
+msgstr "Općenito"
+
+#: id:129
+msgctxt "Auto context with id 129"
+msgid "Slideshow"
+msgstr "Slideshow"
+
+#: id:130
+msgctxt "Auto context with id 130"
+msgid "System info"
+msgstr "Sistem Info"
+
+#: id:131
+msgid "Display"
+msgstr "Ekran"
+
+#: id:132
+msgid "Albums"
+msgstr "Albumi"
+
+#: id:133
+msgid "Artists"
+msgstr "Izvođači"
+
+#: id:134
+msgid "Songs"
+msgstr "Pjesme"
+
+#: id:135
+msgid "Genres"
+msgstr "Žanrovi"
+
+#: id:136
+msgid "Playlists"
+msgstr "Playliste"
+
+#: id:137
+msgid "Search"
+msgstr "Traži"
+
+#: id:138
+msgid "System Information"
+msgstr "Sistemske Informacije"
+
+#: id:139
+msgid "Temperatures:"
+msgstr "Temperature:"
+
+#: id:140
+msgid "CPU:"
+msgstr ""
+
+#: id:141
+msgid "GPU:"
+msgstr "GPU:"
+
+#: id:142
+msgid "Time:"
+msgstr "Vrijeme:"
+
+#: id:143
+msgid "Current:"
+msgstr "Trenutno:"
+
+#: id:144
+msgid "Build:"
+msgstr "Građa:"
+
+#: id:145
+msgid "Network:"
+msgstr "Mreža:"
+
+#: id:146
+msgid "Type:"
+msgstr "Tip:"
+
+#: id:147
+msgid "Static"
+msgstr "Statično"
+
+#: id:148
+msgid "DHCP"
+msgstr "DHCP"
+
+#: id:149
+msgid "MAC address"
+msgstr "MAC"
+
+#: id:150
+msgctxt "Auto context with id 150"
+msgid "IP address"
+msgstr "IP"
+
+#: id:151
+msgid "Link:"
+msgstr "Veza:"
+
+#: id:152
+msgid "Half duplex"
+msgstr "Polu dupleks"
+
+#: id:153
+msgid "Full duplex"
+msgstr "Puni dupleks"
+
+#: id:154
+msgctxt "Auto context with id 154"
+msgid "Storage"
+msgstr "Pohrana"
+
+#: id:155
+msgid "Drive"
+msgstr "Uređaj"
+
+#: id:156
+msgctxt "Auto context with id 156"
+msgid "Free"
+msgstr "Slobodno"
+
+#: id:157
+msgctxt "Auto context with id 157"
+msgid "Video"
+msgstr "Video"
+
+#: id:158
+msgid "Free memory"
+msgstr "Slobodna memorija"
+
+#: id:159
+msgid "No link"
+msgstr "Nema veze"
+
+#: id:160
+msgctxt "Auto context with id 160"
+msgid "Free"
+msgstr "Slobodno"
+
+#: id:161
+msgid "Unavailable"
+msgstr "Nedostupno"
+
+#: id:162
+msgid "Tray open"
+msgstr "Ladica otvorena"
+
+#: id:163
+msgid "Reading"
+msgstr "Čitam"
+
+#: id:164
+msgid "No disc"
+msgstr "Nema diska"
+
+#: id:165
+msgid "Disc present"
+msgstr "Disk je prepoznat"
+
+#: id:166
+msgid "Skin"
+msgstr "Skin"
+
+#: id:169
+msgctxt "Auto context with id 169"
+msgid "Resolution"
+msgstr "Rezolucija"
+
+#: id:170
+msgid "Adjust display refresh rate to match video"
+msgstr "Prilagodi brzinu osvježavanja monitora i videa"
+
+#: id:172
+msgid "Release date"
+msgstr "Datum izlaska:"
+
+#: id:173
+msgid "Display 4:3 videos as"
+msgstr "Prikaži 4:3 video materijal kao"
+
+#: id:175
+msgid "Moods"
+msgstr "Raspoloženja"
+
+#: id:176
+msgid "Styles"
+msgstr "Stilovi"
+
+#: id:179
+msgid "Song"
+msgstr "Pjesma"
+
+#: id:180
+msgid "Duration"
+msgstr "Trajanju"
+
+#: id:181
+msgid "Select album"
+msgstr "Izaberi album"
+
+#: id:182
+msgid "Tracks"
+msgstr "Pjesme"
+
+#: id:183
+msgid "Review"
+msgstr "Recenzije"
+
+#: id:184
+msgid "Refresh"
+msgstr "Osvježi"
+
+#: id:185
+msgid "Searching album"
+msgstr "Tražim album"
+
+#: id:186
+msgid "OK"
+msgstr "OK"
+
+#: id:187
+msgid "No albums found!"
+msgstr "Albumi nisu pronađeni!"
+
+#: id:188
+msgid "Select all"
+msgstr "Odaberi sve"
+
+#: id:189
+msgid "Scanning media info"
+msgstr "Skeniram media info"
+
+#: id:190
+msgid "Save"
+msgstr "Sačuvaj"
+
+#: id:191
+msgid "Shuffle"
+msgstr "Nasumično"
+
+#: id:192
+msgctxt "Auto context with id 192"
+msgid "Clear"
+msgstr "Poništi"
+
+#: id:193
+msgctxt "Auto context with id 193"
+msgid "Scan"
+msgstr "Skeniraj"
+
+#: id:194
+msgid "Searching..."
+msgstr "Pretraživanje..."
+
+#: id:195
+msgid "No info found!"
+msgstr "Info nije pronađen!"
+
+#: id:196
+msgid "Select movie:"
+msgstr "Odaberi film:"
+
+#: id:197
+msgid "Querying %s info"
+msgstr "Pretraživanje %s info"
+
+#: id:198
+msgid "Loading movie details"
+msgstr "Učitavam detalje filma"
+
+#: id:199
+msgid "Web interface"
+msgstr "Web sučelje"
+
+#: id:202
+msgid "Tagline"
+msgstr ""
+
+#: id:203
+msgid "Plot outline"
+msgstr "Kratak opis:"
+
+#: id:205
+msgid "Votes"
+msgstr "Glasovi"
+
+#: id:206
+msgid "Cast"
+msgstr "Uloge"
+
+#: id:207
+msgid "Plot"
+msgstr "Radnja"
+
+#: id:208
+msgctxt "Auto context with id 208"
+msgid "Play"
+msgstr "Pokreni"
+
+#: id:209
+msgid "Next"
+msgstr "Slijedeći"
+
+#: id:210
+msgid "Previous"
+msgstr "Prethodni"
+
+#: id:213
+msgid "Calibrate user interface..."
+msgstr "Prilagodi korisničko sučelje..."
+
+#: id:214
+msgid "Video calibration..."
+msgstr "Kalibracija slike..."
+
+#: id:215
+msgid "Soften"
+msgstr "Omekšaj"
+
+#: id:216
+msgid "Zoom amount"
+msgstr "Količina zooma"
+
+#: id:217
+msgid "Pixel ratio"
+msgstr "Omjer pixela"
+
+#: id:218
+msgid "DVD drive"
+msgstr "DVD uređaj"
+
+#: id:219
+msgid "Please insert disc"
+msgstr "Molim ubacite disk"
+
+#: id:220
+msgid "Remote share"
+msgstr "Udaljeno djeljenje"
+
+#: id:221
+msgid "Network is not connected"
+msgstr "Mreža nije spojena"
+
+#: id:222
+msgid "Cancel"
+msgstr "Poništi"
+
+#: id:224
+msgid "Speed"
+msgstr "Brzina"
+
+#: id:225
+msgid "Vertical Shift"
+msgstr ""
+
+#: id:226
+msgid "Test patterns..."
+msgstr ""
+
+#: id:227
+msgid "Lookup audio CD track names from freedb.org"
+msgstr "Potraži audio CD imana pjesama na freedb.org"
+
+#: id:228
+msgid "Shuffle playlist on load"
+msgstr "Izmješaj playlistu pri učitavanju"
+
+#: id:229
+msgid "HDD spindown time"
+msgstr "Vrijeme HDD okretaja"
+
+#: id:230
+msgid "Video filters"
+msgstr "Video filteri"
+
+#: id:231
+msgctxt "Auto context with id 231"
+msgid "None"
+msgstr "Nijedna"
+
+#: id:232
+msgid "Point"
+msgstr "Točka"
+
+#: id:233
+msgid "Linear"
+msgstr "Linearno"
+
+#: id:234
+msgid "Anisotropic"
+msgstr "Anisotropno"
+
+#: id:235
+msgid "Quincunx"
+msgstr "Quincunx"
+
+#: id:236
+msgid "Gaussian cubic"
+msgstr "Gaussian kocka"
+
+#: id:237
+msgid "Minification"
+msgstr "Smanjenje"
+
+#: id:238
+msgid "Magnification"
+msgstr "Povečanje"
+
+#: id:239
+msgid "Clear playlist on finish"
+msgstr "Poništi playlistu po završetku"
+
+#: id:240
+msgid "Display Mode"
+msgstr ""
+
+#: id:241
+msgid "Full Screen #%d"
+msgstr "Full Screen #%d"
+
+#: id:242
+msgid "Windowed"
+msgstr "Windowed"
+
+#: id:243
+msgid "Refresh Rate"
+msgstr "Refresh Rate"
+
+#: id:244
+msgid "Full screen"
+msgstr "Full Screen"
+
+#: id:245
+msgid "Sizing: (%i,%i)->(%i,%i) (Zoom x%2.2f) AR:%2.2f:1 (Pixels: %2.2f:1) (VShift: %2.2f)"
+msgstr "Sizing: (%i,%i)->(%i,%i) (Zoom x%2.2f) AR:%2.2f:1 (Pixels: %2.2f:1)"
+
+#: id:247
+msgctxt "Auto context with id 247"
+msgid "Scripts"
+msgstr "Skripte"
+
+#: id:248
+msgctxt "Auto context with id 248"
+msgid "Language"
+msgstr "Jezik"
+
+#: id:249
+msgctxt "Auto context with id 249"
+msgid "Music"
+msgstr "Glazba"
+
+#: id:250
+msgctxt "Auto context with id 250"
+msgid "Visualization"
+msgstr "Vizualizacije"
+
+#: id:251
+msgid "Select destination directory"
+msgstr "Odaberi odredišni direktorij"
+
+#: id:252
+msgid "Output stereo to all speakers"
+msgstr "Prebaci Stereo na sve zvučnike"
+
+#: id:253
+msgid "Number of channels"
+msgstr "Broj kanala"
+
+#: id:254
+msgid "- DTS capable receiver"
+msgstr "- DTS Sposoban Prijemnik"
+
+#: id:255
+msgid "CDDB"
+msgstr "CDDB"
+
+#: id:256
+msgid "Fetching CD information"
+msgstr "Preuzimanje freedb za CDDB info"
+
+#: id:257
+msgid "Error"
+msgstr "Greška"
+
+#: id:258
+msgid "Enable tag reading"
+msgstr "Omogući čitanje oznaka"
+
+#: id:259
+msgid "Opening"
+msgstr "Otvaranje"
+
+#: id:260
+msgid "Shoutcast"
+msgstr "Shoutcast"
+
+#: id:261
+msgid "Waiting for start..."
+msgstr "Čekam za početak...."
+
+#: id:262
+msgid "Scripts output"
+msgstr "Izlaz skripte"
+
+#: id:263
+msgid "Allow control of XBMC via HTTP"
+msgstr "Dozvoli kontrolu XBMC aplikacije putem HTTP protokola"
+
+#: id:264
+msgid "Record"
+msgstr "Snimi"
+
+#: id:265
+msgid "Stop Rec."
+msgstr "Zaustavi snimanje"
+
+#: id:266
+msgid "Sort by: Track"
+msgstr "Složi po: Pjesmi"
+
+#: id:267
+msgid "Sort by: Time"
+msgstr "Složi po: Vremenu"
+
+#: id:268
+msgid "Sort by: Title"
+msgstr "Složi po: Nazivu"
+
+#: id:269
+msgid "Sort by: Artist"
+msgstr "Složi po: Izvođaču"
+
+#: id:270
+msgid "Sort by: Album"
+msgstr "Složi po: Albumu"
+
+#: id:271
+msgid "Top 100"
+msgstr "Top 100"
+
+#: id:272
+msgid "Top-Left overscan compensation"
+msgstr "Gornja lijeva ivica ekrana"
+
+#: id:273
+msgid "Bottom-Right overscan compensation"
+msgstr "Donja desna ivica ekrana"
+
+#: id:274
+msgid "Subtitle positioning"
+msgstr "Pozicija titlova"
+
+#: id:275
+msgid "Pixel ratio adjustment"
+msgstr "Ugađanje omjera pixela"
+
+#: id:276
+msgid "Adjust the arrow to change the amount of overscan"
+msgstr "Pomakni strelicu za izmjenu količine overscan-a"
+
+#: id:277
+msgid "Adjust the bar to change the subtitles position"
+msgstr "Pomakni traku za izmjenu pozicije titlova"
+
+#: id:278
+msgid "Adjust the rectangle so it is perfectly square"
+msgstr "Izmjeni pravokutnik u pravilnu kocku"
+
+#: id:279
+msgid "Unable to load settings"
+msgstr "Nije moguće učitati postavke"
+
+#: id:280
+msgid "Using default settings"
+msgstr "Korištenje zadanih postavki (default)"
+
+#: id:281
+msgid "Please check the XML files"
+msgstr "Molim provjere .xml datoteke"
+
+#: id:282
+msgid "Found %i items"
+msgstr "Pronađeno %i stavki"
+
+#: id:283
+msgid "Search results"
+msgstr "Rezultati pretrage"
+
+#: id:284
+msgid "No results found"
+msgstr "Bez rezultata"
+
+#: id:287
+msgctxt "Auto context with id 287"
+msgid "Subtitles"
+msgstr "Titlovi"
+
+#: id:288
+msgctxt "Auto context with id 288"
+msgid "Font"
+msgstr "Font"
+
+#: id:289
+msgctxt "Auto context with id 289"
+msgid "- Size"
+msgstr "- Veličina"
+
+#: id:290
+msgid "Dynamic range compression"
+msgstr "Dinamički opseg kompresije"
+
+#: id:291
+msgctxt "Auto context with id 291"
+msgid "Video"
+msgstr "Video"
+
+#: id:292
+msgctxt "Auto context with id 292"
+msgid "Audio"
+msgstr "Audio"
+
+#: id:293
+msgid "Browse for subtitles"
+msgstr "Pretraži titlove"
+
+#: id:294
+msgid "Create bookmark"
+msgstr "Napravi bookmark"
+
+#: id:296
+msgid "Clear bookmarks"
+msgstr "Poništi bookmarke"
+
+#: id:297
+msgid "Audio offset"
+msgstr "Audio pomak (offset)"
+
+#: id:298
+msgid "Bookmarks"
+msgstr "Bookmarks"
+
+#: id:299
+msgid "- AAC capable receiver"
+msgstr "- Sposoban AAC prijemnik"
+
+#: id:300
+msgid "- MP1 capable receiver"
+msgstr "- Sposoban MP1 prijemnik"
+
+#: id:301
+msgid "- MP2 capable receiver"
+msgstr "- Sposoban MP2 prijemnik"
+
+#: id:302
+msgid "- MP3 capable receiver"
+msgstr "- Sposoban MP3 prijemnik"
+
+#: id:303
+msgid "Delay"
+msgstr "Odgoda"
+
+#: id:304
+msgctxt "Auto context with id 304"
+msgid "Language"
+msgstr "Jezik"
+
+#: id:305
+msgctxt "Auto context with id 305"
+msgid "Enabled"
+msgstr ""
+
+#: id:306
+msgid "Non-interleaved"
+msgstr ""
+
+#: id:312
+msgid "(0=auto)"
+msgstr "(0=auto)"
+
+#: id:313
+msgid "Cleaning database"
+msgstr "Čišćenje baze podataka"
+
+#: id:314
+msgid "Preparing..."
+msgstr "Pripremam..."
+
+#: id:315
+msgid "Database error"
+msgstr "Greška baze podataka"
+
+#: id:316
+msgid "Searching songs..."
+msgstr "Tražim pjesme..."
+
+#: id:317
+msgid "Cleaned database successfully"
+msgstr "Baza podataka je uspešno očišćena"
+
+#: id:318
+msgid "Cleaning songs..."
+msgstr "Čišćenje pjesama..."
+
+#: id:319
+msgid "Error cleaning songs"
+msgstr "Greška kod čišćenja pjesama"
+
+#: id:320
+msgid "Cleaning artists..."
+msgstr "Čišćenje izvođača..."
+
+#: id:321
+msgid "Error cleaning artists"
+msgstr "Greška kod čišćenja izvođača"
+
+#: id:322
+msgid "Cleaning genres..."
+msgstr "Čišćenje žanrova..."
+
+#: id:323
+msgid "Error cleaning genres"
+msgstr "Greška kod čišćenja žanrova"
+
+#: id:324
+msgid "Cleaning paths..."
+msgstr "Čišćenje putanje..."
+
+#: id:325
+msgid "Error cleaning paths"
+msgstr "Greška kod čišćenja putanji"
+
+#: id:326
+msgid "Cleaning albums..."
+msgstr "Čišćenje albuma..."
+
+#: id:327
+msgid "Error cleaning albums"
+msgstr "Greška kod čišćenja albuma"
+
+#: id:328
+msgid "Writing changes..."
+msgstr "Pišem izmjene..."
+
+#: id:329
+msgid "Error writing changes"
+msgstr "Greška kod upisivanja izmjena"
+
+#: id:330
+msgid "This may take some time..."
+msgstr "Ovo može potrajati..."
+
+#: id:331
+msgid "Compressing database..."
+msgstr "Sažimam bazu podataka..."
+
+#: id:332
+msgid "Error compressing database"
+msgstr "Greška kod sažimanja baze podataka"
+
+#: id:333
+msgid "Do you want to clean the library?"
+msgstr "Želite li zaista očistiti library?"
+
+#: id:334
+msgid "Clean library..."
+msgstr "Čišćenje library..."
+
+#: id:335
+msgid "Start"
+msgstr "Pokreni"
+
+#: id:336
+msgid "Framerate conversion"
+msgstr "Framerate konverzija"
+
+#: id:337
+msgctxt "Auto context with id 337"
+msgid "Audio output"
+msgstr "Audio izlaz"
+
+#: id:338
+msgid "Analog"
+msgstr "Analogno"
+
+#: id:339
+msgid "Optical/Coax"
+msgstr "Digitalno"
+
+#: id:340
+msgid "Various artists"
+msgstr "Razni izvođači"
+
+#: id:341
+msgid "Play disc"
+msgstr "Pokreni disk"
+
+#: id:342
+msgctxt "Auto context with id 342"
+msgid "Movies"
+msgstr "Filmovi"
+
+#: id:343
+msgid "Adjust framerate"
+msgstr "Prilagodi framerate"
+
+#: id:344
+msgid "Actors"
+msgstr "Glumci"
+
+#: id:345
+msgctxt "Auto context with id 345"
+msgid "Year"
+msgstr "Godina"
+
+#: id:346
+msgid "Boost volume level on downmix"
+msgstr "Pojačaj nivo zvuka pri smanjenju br. kanala (downmix)"
+
+#: id:350
+msgctxt "Auto context with id 350"
+msgid "Programs"
+msgstr "Programi"
+
+#: id:351
+msgctxt "Auto context with id 351"
+msgid "Off"
+msgstr "Isključi"
+
+#: id:352
+msgid "Dim"
+msgstr "Zatamnjenje"
+
+#: id:353
+msgid "Black"
+msgstr "Crno"
+
+#: id:354
+msgid "Matrix trails"
+msgstr "Matrix kodovi"
+
+#: id:355
+msgid "Screensaver time"
+msgstr "Screensaver vrijeme"
+
+#: id:356
+msgid "Screensaver mode"
+msgstr "Screensaver režim"
+
+#: id:357
+msgid "Shutdown function timer"
+msgstr "Gašenje nakon (Shutdown timer)"
+
+#: id:358
+msgid "All albums"
+msgstr "Svi albumi"
+
+#: id:359
+msgid "Recently added albums"
+msgstr "Nedavno dodani albumi"
+
+#: id:360
+msgctxt "Auto context with id 360"
+msgid "Screensaver"
+msgstr "Screensaver"
+
+#: id:361
+msgid "R. Slideshow"
+msgstr "Nasum. Slideshow"
+
+#: id:362
+msgid "Screensaver dim level"
+msgstr "Nivo zatamnjenja"
+
+#: id:363
+msgid "Sort by: File"
+msgstr "Složi po: Datoteka"
+
+#: id:364
+msgid "- Dolby Digital (AC3) capable receiver"
+msgstr "- AC3 Sposoban Prijemnik"
+
+#: id:365
+msgctxt "Auto context with id 365"
+msgid "Sort by: Name"
+msgstr "Složi po: Imenu"
+
+#: id:366
+msgid "Sort by: Year"
+msgstr "Složi po: Godini"
+
+#: id:367
+msgid "Sort by: Rating"
+msgstr "Složi po: Ocjeni"
+
+#: id:368
+msgid "IMDb"
+msgstr "IMDb"
+
+#: id:369
+msgctxt "Auto context with id 369"
+msgid "Title"
+msgstr "Naslov"
+
+#: id:370
+msgid "Thunderstorms"
+msgstr "Grmljavina"
+
+#: id:371
+msgid "Partly"
+msgstr "Djelomično"
+
+#: id:372
+msgid "Mostly"
+msgstr "Pretežno"
+
+#: id:373
+msgid "Sunny"
+msgstr "Sunčano"
+
+#: id:374
+msgid "Cloudy"
+msgstr "Oblačno"
+
+#: id:375
+msgid "Snow"
+msgstr "Snijeg"
+
+#: id:376
+msgid "Rain"
+msgstr "Kiša"
+
+#: id:377
+msgid "Light"
+msgstr "Slab(a)"
+
+#: id:378
+msgid "AM"
+msgstr "Prijepodne"
+
+#: id:379
+msgid "PM"
+msgstr "Poslijepodne"
+
+#: id:380
+msgid "Showers"
+msgstr "Pljuskovi"
+
+#: id:381
+msgid "Few"
+msgstr "Malo"
+
+#: id:382
+msgid "Scattered"
+msgstr "Mjestimično"
+
+#: id:383
+msgctxt "Auto context with id 383"
+msgid "Wind"
+msgstr "Vjetar"
+
+#: id:384
+msgid "Strong"
+msgstr "Jako"
+
+#: id:385
+msgid "Fair"
+msgstr "Umjereno"
+
+#: id:386
+msgctxt "Auto context with id 386"
+msgid "Clear"
+msgstr "Vedro"
+
+#: id:387
+msgid "Clouds"
+msgstr "Oblačno"
+
+#: id:388
+msgid "Early"
+msgstr "Rani"
+
+#: id:389
+msgid "Shower"
+msgstr "Pljusak"
+
+#: id:390
+msgid "Flurries"
+msgstr "Susnježica"
+
+#: id:391
+msgctxt "Auto context with id 391"
+msgid "Low"
+msgstr "Nizak"
+
+#: id:392
+msgctxt "Auto context with id 392"
+msgid "Medium"
+msgstr "Umjeren"
+
+#: id:393
+msgctxt "Auto context with id 393"
+msgid "High"
+msgstr "Visok"
+
+#: id:394
+msgid "Fog"
+msgstr "Magla"
+
+#: id:395
+msgid "Haze"
+msgstr "Izmaglica"
+
+#: id:396
+msgid "Select location"
+msgstr "Odaberi lokaciju"
+
+#: id:397
+msgid "Refresh time"
+msgstr "Vrijeme osvježenja"
+
+#: id:398
+msgid "Temperature units"
+msgstr "Temperaturne jedinice"
+
+#: id:399
+msgid "Speed units"
+msgstr "Jedinice brzine"
+
+#: id:400
+msgctxt "Auto context with id 400"
+msgid "Weather"
+msgstr "Vrijeme"
+
+#: id:401
+msgid "Temp"
+msgstr "Temp."
+
+#: id:402
+msgid "Feels like"
+msgstr "Kao da je"
+
+#: id:403
+msgid "UV index"
+msgstr "UV index"
+
+#: id:404
+msgctxt "Auto context with id 404"
+msgid "Wind"
+msgstr "Vjetar"
+
+#: id:405
+msgid "Dew point"
+msgstr "Rosa"
+
+#: id:406
+msgid "Humidity"
+msgstr "Vlažnost"
+
+#: id:409
+msgid "Defaults"
+msgstr ""
+
+#: id:410
+msgid "Accessing weather service"
+msgstr "Pristupam weather.com"
+
+#: id:411
+msgid "Getting weather for:"
+msgstr "Dobivam vrijeme za:"
+
+#: id:412
+msgid "Unable to get weather data"
+msgstr "Nije moguće preuzeti podatke o prognozi"
+
+#: id:413
+msgid "Manual"
+msgstr "Ručno"
+
+#: id:414
+msgid "No review for this album"
+msgstr "Ne postoji recenzije za ovaj album"
+
+#: id:415
+msgid "Downloading thumbnail..."
+msgstr "Preuzimam thumb..."
+
+#: id:416
+msgid "Not available"
+msgstr "Nije dostupno"
+
+#: id:417
+msgid "View: Big icons"
+msgstr "Prikaz: Velike ikone"
+
+#: id:418
+msgctxt "Auto context with id 418"
+msgid "Low"
+msgstr "Min"
+
+#: id:419
+msgctxt "Auto context with id 419"
+msgid "High"
+msgstr "Max"
+
+#: id:420
+msgid "HDMI"
+msgstr ""
+
+#: id:422
+msgid "Delete album info"
+msgstr "Izbriši album info"
+
+#: id:423
+msgid "Delete CD information"
+msgstr "Izbriši CDDB Info"
+
+#: id:424
+msgid "Select"
+msgstr "Odaberi"
+
+#: id:425
+msgid "No album information found"
+msgstr "Nije pronađen album info."
+
+#: id:426
+msgid "No CD information found"
+msgstr "Nije pronađen CDDB info."
+
+#: id:427
+msgid "Disc"
+msgstr "Disk"
+
+#: id:428
+msgid "Insert correct CD/DVD"
+msgstr "Umetni ispravan CD/DVD"
+
+#: id:429
+msgid "Please insert the following disc:"
+msgstr "Umetni slijedeći CD/DVD"
+
+#: id:430
+msgid "Sort by: DVD#"
+msgstr "Složi po: DVD#"
+
+#: id:431
+msgid "No cache"
+msgstr "Nema cache"
+
+#: id:432
+msgid "Remove movie from library"
+msgstr "Ukloni film iz library"
+
+#: id:433
+msgid "Really remove '%s'?"
+msgstr "Zaista želite maknuti '%s'?"
+
+#: id:434
+msgid "From %s at %i %s"
+msgstr ""
+
+#: id:437
+msgid "Removable disk"
+msgstr "Prenosivi disk"
+
+#: id:438
+msgid "Opening file"
+msgstr "Otvaranja datoteke"
+
+#: id:439
+msgid "Cache"
+msgstr "Cache"
+
+#: id:440
+msgid "Harddisk"
+msgstr "Hard disk"
+
+#: id:441
+msgid "UDF"
+msgstr "UDF"
+
+#: id:442
+msgid "Local network"
+msgstr "Lokalna mreža"
+
+#: id:443
+msgid "Internet"
+msgstr "Internet"
+
+#: id:444
+msgctxt "Auto context with id 444"
+msgid "Video"
+msgstr "Video"
+
+#: id:445
+msgctxt "Auto context with id 445"
+msgid "Audio"
+msgstr "Audio"
+
+#: id:446
+msgctxt "Auto context with id 446"
+msgid "DVD"
+msgstr "DVD"
+
+#: id:447
+msgid "Autorun media"
+msgstr "Automatska reprodukcija"
+
+#: id:448
+msgid "LCD"
+msgstr "LCD"
+
+#: id:449
+msgctxt "Auto context with id 449"
+msgid "Enabled"
+msgstr "Omogućeno"
+
+#: id:450
+msgid "Columns"
+msgstr "Stupci"
+
+#: id:451
+msgid "Row 1 address"
+msgstr "1. red adrese"
+
+#: id:452
+msgid "Row 2 address"
+msgstr "2. red adrese"
+
+#: id:453
+msgid "Row 3 address"
+msgstr "3. red adrese"
+
+#: id:454
+msgid "Row 4 address"
+msgstr "4. red adrese"
+
+#: id:455
+msgid "Rows"
+msgstr "Redovi"
+
+#: id:456
+msgid "Mode"
+msgstr "Način"
+
+#: id:457
+msgid "Switch view"
+msgstr "Promjeni prikaz"
+
+#: id:459
+msgid "Subs"
+msgstr "Titlovi"
+
+#: id:460
+msgid "Audio stream"
+msgstr "Audio zapis"
+
+#: id:461
+msgid "[active]"
+msgstr "[aktivno]"
+
+#: id:462
+msgid "Subtitle"
+msgstr "Titl"
+
+#: id:463
+msgid "Backlight"
+msgstr "Pozadinsko svjetlo"
+
+#: id:464
+msgid "Brightness"
+msgstr "Osvjetljenje"
+
+#: id:465
+msgid "Contrast"
+msgstr "Kontrast"
+
+#: id:466
+msgid "Gamma"
+msgstr "Gama/Opseg boja"
+
+#: id:467
+msgctxt "Auto context with id 467"
+msgid "Type"
+msgstr "Tip"
+
+#: id:468
+msgid "Move the bar to change the OSD position"
+msgstr "Pomakni traku za promjenu OSD pozicije"
+
+#: id:469
+msgid "OSD position"
+msgstr "OSD Pozicija"
+
+#: id:470
+msgid "Credits"
+msgstr "Zasluge"
+
+#: id:471
+msgid "Modchip"
+msgstr "Modčip"
+
+#: id:474
+msgctxt "Auto context with id 474"
+msgid "Off"
+msgstr "Isklj."
+
+#: id:475
+msgid "Music only"
+msgstr "Samo glazba"
+
+#: id:476
+msgctxt "Auto context with id 476"
+msgid "Music & video"
+msgstr "Glazba & video"
+
+#: id:477
+msgid "Unable to load playlist"
+msgstr "Nije moguće učitati playlistu"
+
+#: id:478
+msgid "OSD"
+msgstr "OSD"
+
+#: id:479
+msgid "Skin & language"
+msgstr "Skin i jezik"
+
+#: id:480
+msgid "Appearance"
+msgstr "Izgled"
+
+#: id:481
+msgid "Audio options"
+msgstr "Audio opcije"
+
+#: id:482
+msgid "About XBMC"
+msgstr "O XBMC"
+
+#: id:485
+msgid "Delete album"
+msgstr "Izbriši album"
+
+#: id:486
+msgid "Repeat"
+msgstr "Ponovi"
+
+#: id:487
+msgid "Repeat one"
+msgstr "Ronovi jednom"
+
+#: id:488
+msgid "Repeat folder"
+msgstr "Ponovi mapu"
+
+#: id:489
+msgid "Play the next song automatically"
+msgstr "Automatski pokreni slijedeću pjesmu"
+
+#: id:491
+msgid "- Use big icons"
+msgstr "- Koristi velike ikone"
+
+#: id:492
+msgid "Resize VobSubs"
+msgstr "Izmjena veličine VobSubs-a"
+
+#: id:493
+msgid "Advanced options (Experts Only!)"
+msgstr "Napredne opcije (samo EKSPERTI!)"
+
+#: id:494
+msgid "Overall audio headroom"
+msgstr "Cijelokupni audio headroom"
+
+#: id:495
+msgid "Upsample videos to GUI resolution"
+msgstr "Upsample video prema GUI rezoluciji"
+
+#: id:496
+msgid "Calibration"
+msgstr "Kalibracija"
+
+#: id:497
+msgid "Show file extensions"
+msgstr "Prikaži ekstenzije datoteka"
+
+#: id:498
+msgid "Sort by: Type"
+msgstr "Složi po: Tipu"
+
+#: id:499
+msgid "Unable to connect to online lookup service"
+msgstr "Nije moguće povezivanje na online servis"
+
+#: id:500
+msgid "Downloading album information failed"
+msgstr "Neuspješno preuzimanje album info"
+
+#: id:501
+msgid "Looking for album names..."
+msgstr "Pretraga imena albuma..."
+
+#: id:502
+msgctxt "Auto context with id 502"
+msgid "Open"
+msgstr "Otvori"
+
+#: id:503
+msgid "Busy"
+msgstr "Radim"
+
+#: id:504
+msgid "Empty"
+msgstr "Prazno"
+
+#: id:505
+msgid "Loading media info from files..."
+msgstr "Učitavanje podataka iz datoteka..."
+
+#: id:507
+msgid "Sort by: Usage"
+msgstr "Složi po: Upotrebi"
+
+#: id:510
+msgid "Enable visualizations"
+msgstr "Omogući vizualizacije"
+
+#: id:511
+msgid "Enable video mode switching"
+msgstr "Omogući video promjenu"
+
+#: id:512
+msgid "Startup window"
+msgstr "Početni ekran"
+
+#: id:513
+msgid "Home window"
+msgstr "Glavni ekran"
+
+#: id:514
+msgid "Manual settings"
+msgstr "Ručne postavke"
+
+#: id:515
+msgid "Genre"
+msgstr "Žanr"
+
+#: id:517
+msgid "Recently played albums"
+msgstr "Nedavno pokrenuti albumi"
+
+#: id:518
+msgid "Launch"
+msgstr "Pokreni"
+
+#: id:519
+msgid "Launch in..."
+msgstr "Pokreni u.."
+
+#: id:521
+msgid "Compilations"
+msgstr "Kompilacije"
+
+#: id:522
+msgid "Remove source"
+msgstr "Makni izvor"
+
+#: id:523
+msgid "Switch media"
+msgstr "Promjeni media"
+
+#: id:524
+msgid "Select playlist"
+msgstr "Izaberi playlistu"
+
+#: id:525
+msgid "New playlist..."
+msgstr "Nova playlista..."
+
+#: id:526
+msgid "Add to playlist"
+msgstr "Dodaj u playlistu"
+
+#: id:527
+msgid "Manually add to library"
+msgstr "Ručno dodaj u library"
+
+#: id:528
+msgid "Enter title"
+msgstr "Unesi naslov"
+
+#: id:529
+msgid "Error: Duplicate title"
+msgstr "Greška: Dupli naslov"
+
+#: id:530
+msgid "Select genre"
+msgstr "Izaberi žanr"
+
+#: id:531
+msgid "New genre"
+msgstr "Novi žanr"
+
+#: id:532
+msgid "Manual addition"
+msgstr "Ručno dodavanje"
+
+#: id:533
+msgid "Enter genre"
+msgstr "Upišite žanr"
+
+#: id:534
+msgid "View: %s"
+msgstr "Prikaz: %s"
+
+#: id:535
+msgid "List"
+msgstr "Liste"
+
+#: id:536
+msgid "Icons"
+msgstr "Ikone"
+
+#: id:537
+msgid "Big list"
+msgstr "Velika lista"
+
+#: id:538
+msgid "Big icons"
+msgstr "Velike ikone"
+
+#: id:539
+msgid "Wide"
+msgstr "Široko"
+
+#: id:540
+msgid "Big wide"
+msgstr "Veoma široko"
+
+#: id:541
+msgid "Album icons"
+msgstr "Ikone albuma"
+
+#: id:542
+msgid "DVD icons"
+msgstr "DVD ikone"
+
+#: id:543
+msgctxt "Auto context with id 543"
+msgid "DVD"
+msgstr "DVD"
+
+#: id:544
+msgctxt "Auto context with id 544"
+msgid "Media info"
+msgstr "Media info"
+
+#: id:545
+msgid "Audio output device"
+msgstr ""
+
+#: id:546
+msgid "Passthrough output device"
+msgstr ""
+
+#: id:547
+msgid "No biography for this artist"
+msgstr ""
+
+#: id:548
+msgid "Downmix multichannel audio to stereo"
+msgstr ""
+
+#: id:550
+msgid "Sort by: %s"
+msgstr "Složi po: %s"
+
+#: id:551
+msgctxt "Auto context with id 551"
+msgid "Name"
+msgstr "Imenu"
+
+#: id:552
+msgid "Date"
+msgstr "Datumu"
+
+#: id:553
+msgid "Size"
+msgstr "Veličini"
+
+#: id:554
+msgid "Track"
+msgstr "Pjesmi"
+
+#: id:555
+msgid "Time"
+msgstr "Dužini"
+
+#: id:556
+msgctxt "Auto context with id 556"
+msgid "Title"
+msgstr "Naslovu"
+
+#: id:557
+msgid "Artist"
+msgstr "Izvođaču"
+
+#: id:558
+msgid "Album"
+msgstr "Albumu"
+
+#: id:559
+msgid "Playlist"
+msgstr "Playlisti"
+
+#: id:560
+msgid "ID"
+msgstr "ID"
+
+#: id:561
+msgctxt "Auto context with id 561"
+msgid "File"
+msgstr "Datoteka"
+
+#: id:562
+msgctxt "Auto context with id 562"
+msgid "Year"
+msgstr "Godina"
+
+#: id:563
+msgid "Rating"
+msgstr "Ocjena"
+
+#: id:564
+msgctxt "Auto context with id 564"
+msgid "Type"
+msgstr "Tip"
+
+#: id:565
+msgid "Usage"
+msgstr "Korištenje"
+
+#: id:566
+msgid "Album artist"
+msgstr "Izvođač albuma"
+
+#: id:567
+msgid "Play count"
+msgstr "Broj reprodukcija"
+
+#: id:568
+msgid "Last played"
+msgstr "Posljednja reprodukcija"
+
+#: id:569
+msgctxt "Auto context with id 569"
+msgid "Comment"
+msgstr "Komentar"
+
+#: id:570
+msgid "Date added"
+msgstr "Datumu dodavanja"
+
+#: id:571
+msgctxt "Auto context with id 571"
+msgid "Default"
+msgstr "Zadano"
+
+#: id:572
+msgid "Studio"
+msgstr "Studio"
+
+#: id:573
+msgid "Path"
+msgstr "Putanja"
+
+#: id:574
+msgctxt "Auto context with id 574"
+msgid "Country"
+msgstr "Država"
+
+#: id:575
+msgid "In progress"
+msgstr "U tijeku"
+
+#: id:576
+msgid "Times played"
+msgstr ""
+
+#: id:580
+msgid "Sort direction"
+msgstr "Smjer slaganja"
+
+#: id:581
+msgid "Sort method"
+msgstr "Način slaganja"
+
+#: id:582
+msgctxt "Auto context with id 582"
+msgid "View mode"
+msgstr "Način Prikaza"
+
+#: id:583
+msgid "Remember views for different folders"
+msgstr "Zapamti prikaze za različite mape"
+
+#: id:584
+msgid "Ascending"
+msgstr "Ulazno"
+
+#: id:585
+msgid "Descending"
+msgstr "Silazno"
+
+#: id:586
+msgid "Edit playlist"
+msgstr "Uredi playlistu"
+
+#: id:587
+msgid "Filter"
+msgstr "Filter"
+
+#: id:588
+msgid "Cancel party mode"
+msgstr "Poništi \"Party\" režim"
+
+#: id:589
+msgid "Party mode"
+msgstr "Party režim"
+
+#: id:590
+msgid "Random"
+msgstr "Nasumično"
+
+#: id:591
+msgctxt "Auto context with id 591"
+msgid "Off"
+msgstr "Isključi"
+
+#: id:592
+msgid "One"
+msgstr "Jednom"
+
+#: id:593
+msgid "All"
+msgstr "Sve"
+
+#: id:594
+msgctxt "Auto context with id 594"
+msgid "Off"
+msgstr "Isključi"
+
+#: id:595
+msgid "Repeat: Off"
+msgstr "Ponovi: Isključeno"
+
+#: id:596
+msgid "Repeat: One"
+msgstr "Ponovi: Jedan"
+
+#: id:597
+msgid "Repeat: All"
+msgstr "Ponovi: Sve"
+
+#: id:600
+msgid "Rip audio CD"
+msgstr "Ripanje audio CD-a"
+
+#: id:601
+msgctxt "Auto context with id 601"
+msgid "Medium"
+msgstr "Srednje"
+
+#: id:602
+msgctxt "Auto context with id 602"
+msgid "Standard"
+msgstr "Standardno"
+
+#: id:603
+msgid "Extreme"
+msgstr "Ekstremno"
+
+#: id:604
+msgid "Constant bitrate"
+msgstr "Konstantni bitrate"
+
+#: id:605
+msgid "Ripping..."
+msgstr "Rippanje..."
+
+#: id:607
+msgid "To:"
+msgstr "U:"
+
+#: id:608
+msgid "Could not rip CD or track"
+msgstr "Nije moguće ripati CD ili pjesmu"
+
+#: id:609
+msgid "CDDARipPath is not set."
+msgstr "CDDA putanja nije namještena."
+
+#: id:610
+msgid "Rip audio track"
+msgstr "Ripanje audio stavki"
+
+#: id:611
+msgid "Enter number"
+msgstr "Unesi broj"
+
+#: id:612
+msgid "Bits/Sample"
+msgstr ""
+
+#: id:613
+msgid "Sample Frequency"
+msgstr ""
+
+#: id:620
+msgid "Audio CDs"
+msgstr "Glazbeni CD-ovi"
+
+#: id:621
+msgid "Encoder"
+msgstr "Enkoder"
+
+#: id:622
+msgid "Quality"
+msgstr "Kvaliteta"
+
+#: id:623
+msgid "Bitrate"
+msgstr "Bitrate"
+
+#: id:624
+msgid "Include track number"
+msgstr "Obuhvati broj stavki"
+
+#: id:625
+msgid "All songs of"
+msgstr "Sve pjesme od"
+
+#: id:629
+msgctxt "Auto context with id 629"
+msgid "View mode"
+msgstr "Način prikaza"
+
+#: id:630
+msgctxt "Auto context with id 630"
+msgid "Normal"
+msgstr "Normalno"
+
+#: id:631
+msgid "Zoom"
+msgstr "Zoom"
+
+#: id:632
+msgid "Stretch 4:3"
+msgstr "Raširi na 4:3"
+
+#: id:633
+msgid "Wide Zoom"
+msgstr "Raširi na 14:9"
+
+#: id:634
+msgid "Stretch 16:9"
+msgstr "Raširi na 16:9"
+
+#: id:635
+msgid "Original Size"
+msgstr "Izvorna veličina"
+
+#: id:636
+msgctxt "Auto context with id 636"
+msgid "Custom"
+msgstr "Vlastito"
+
+#: id:637
+msgid "Replay gain"
+msgstr "Normalizacija"
+
+#: id:638
+msgid "Replaygain volume adjustments"
+msgstr "Podeš. glasnoće normaliz. zvuka"
+
+#: id:639
+msgid "Use track levels"
+msgstr "Koristi nivo pjesama"
+
+#: id:640
+msgid "Use album levels"
+msgstr "Koristi nivo albuma"
+
+#: id:641
+msgid "PreAmp Level - Replay gained files"
+msgstr "Nivo predpojačanja (preAmp) - Replay gained files"
+
+#: id:642
+msgid "PreAmp Level - Non replay gained files"
+msgstr "Nivo predpojačanja (preAmp) - Non replay gained files"
+
+#: id:643
+msgid "Avoid clipping on replay gained files"
+msgstr "Spriječi zastajkivanje na replay gained files"
+
+#: id:644
+msgid "Crop black bars"
+msgstr "Reži crne trake"
+
+#: id:645
+msgid "Need to unpack a big file. Continue?"
+msgstr "Potrebno je raspakirati velike datoteke. Nastavi?"
+
+#: id:646
+msgid "Remove from library"
+msgstr "Odstrani iz library"
+
+#: id:647
+msgid "Export video library"
+msgstr "Export video library"
+
+#: id:648
+msgid "Import video library"
+msgstr "Import video library"
+
+#: id:649
+msgid "Importing"
+msgstr "Importing..."
+
+#: id:650
+msgid "Exporting"
+msgstr "Exporting..."
+
+#: id:651
+msgid "Browse for library"
+msgstr "Traži u library"
+
+#: id:652
+msgid "Years"
+msgstr "Godine"
+
+#: id:653
+msgid "Update library"
+msgstr "Osvježi library"
+
+#: id:654
+msgid "Show debug info"
+msgstr "Pokaži debug info"
+
+#: id:655
+msgid "Browse for executable"
+msgstr "Pretraži izvršne"
+
+#: id:656
+msgid "Browse for playlist"
+msgstr "Pretraži playlistu"
+
+#: id:657
+msgid "Browse for folder"
+msgstr "Preraži mape"
+
+#: id:658
+msgid "Song information"
+msgstr "Info. o pjesmi"
+
+#: id:659
+msgid "Non-linear stretch"
+msgstr "Nelinearno istezanje"
+
+#: id:660
+msgid "Volume amplification"
+msgstr "Pojačavanje zvuka"
+
+#: id:661
+msgid "Choose export folder"
+msgstr "Izaberite izlaznu mapu"
+
+#: id:662
+msgid "This file is no longer available."
+msgstr "Ova datoteka više nije dostupna."
+
+#: id:663
+msgid "Would you like to remove it from the library?"
+msgstr "Želite li ovo ukloniti iz library?"
+
+#: id:664
+msgid "Browse for Script"
+msgstr "Potraži skriptu"
+
+#: id:665
+msgid "Compression level"
+msgstr "Nivo sažimanja (compression lvl)"
+
+#: id:700
+msgid "Cleaning up library"
+msgstr "Čistim library"
+
+#: id:701
+msgid "Removing old songs from the library"
+msgstr "Uklanjanje stare pjesme iz library"
+
+#: id:702
+msgid "This path has been scanned before"
+msgstr "Putanja je već prije skenirana"
+
+#: id:705
+msgctxt "Auto context with id 705"
+msgid "Network"
+msgstr "Mreža"
+
+#: id:706
+msgid "- Server"
+msgstr "- Server"
+
+#: id:708
+msgid "Use an HTTP proxy server to access the internet"
+msgstr "Omogući HTTP Proxy"
+
+#: id:711
+msgid "Internet Protocol (IP)"
+msgstr "Internet Protokol (IP)"
+
+#: id:712
+msgid "Invalid port specified. Value must be between 1 and 65535."
+msgstr "Netočan specifirani ulaz. Vrijednost mora biti između 1 i 65535."
+
+#: id:713
+msgid "HTTP proxy"
+msgstr "HTTP Proxy"
+
+#: id:715
+msgid "- Assignment"
+msgstr "- Zadatak"
+
+#: id:716
+msgid "Automatic (DHCP)"
+msgstr "Automatski (DHCP)"
+
+#: id:717
+msgid "Manual (Static)"
+msgstr "Ručno (Static)"
+
+#: id:719
+msgid "- IP address"
+msgstr "- IP Addresa"
+
+#: id:720
+msgid "- Netmask"
+msgstr "- Netmaska"
+
+#: id:721
+msgid "- Default gateway"
+msgstr "- Zadani gateway"
+
+#: id:722
+msgid "- DNS server"
+msgstr "- DNS Server"
+
+#: id:723
+msgid "Save & restart"
+msgstr "Sačuvaj & restartaj"
+
+#: id:724
+msgid "Invalid address specified. Value must be AAA.BBB.CCC.DDD"
+msgstr "Netočna specifirana adresa. Vrijednost mora biti AAA.BBB.CCC.DDD"
+
+#: id:725
+msgid "with numbers between 0 and 255."
+msgstr "sa brojevima između 0 and 255."
+
+#: id:726
+msgid "Changes not saved. Continue without saving?"
+msgstr "Promjene nisu sačuvane. Nastavi bez spremanja?"
+
+#: id:727
+msgid "Web server"
+msgstr "Web Server"
+
+#: id:728
+msgctxt "Auto context with id 728"
+msgid "FTP server"
+msgstr "FTP Server"
+
+#: id:730
+msgid "- Port"
+msgstr "- Port"
+
+#: id:732
+msgid "Save & apply"
+msgstr "Sačuvaj & primjeni"
+
+#: id:733
+msgid "- Password"
+msgstr "- Zaporka"
+
+#: id:734
+msgid "No pass"
+msgstr "Bez zaporke"
+
+#: id:735
+msgid "- Character set"
+msgstr "- Znakovi"
+
+#: id:736
+msgid "- Style"
+msgstr "- Stil"
+
+#: id:737
+msgid "- Colour"
+msgstr "- Boja"
+
+#: id:738
+msgctxt "Auto context with id 738"
+msgid "Normal"
+msgstr "Normalno"
+
+#: id:739
+msgid "Bold"
+msgstr "Podebljano"
+
+#: id:740
+msgid "Italics"
+msgstr "Koso"
+
+#: id:741
+msgid "Bold italics"
+msgstr "Podebljano koso"
+
+#: id:742
+msgctxt "Auto context with id 742"
+msgid "White"
+msgstr "Bijelo"
+
+#: id:743
+msgctxt "Auto context with id 743"
+msgid "Yellow"
+msgstr "Žuto"
+
+#: id:744
+msgctxt "Auto context with id 744"
+msgid "Files"
+msgstr "Datoteke"
+
+#: id:745
+msgid "No scanned information for this view"
+msgstr "Nema skeniranih info. za taj pogled"
+
+#: id:746
+msgid "Please turn off library mode"
+msgstr "Molimo, isključite library prikaz"
+
+#: id:747
+msgid "Error loading image"
+msgstr "Greška pri učitavanju slike"
+
+#: id:748
+msgid "Edit path"
+msgstr "Izmjeni putanju"
+
+#: id:749
+msgid "Mirror image"
+msgstr ""
+
+#: id:750
+msgid "Are you sure?"
+msgstr "Da li si siguran?"
+
+#: id:751
+msgid "Removing source"
+msgstr "Uklanjanje izvora"
+
+#: id:754
+msgid "Add program link"
+msgstr "Dodaj programsku vezu"
+
+#: id:755
+msgid "Edit program path"
+msgstr "Izmjeni programsku putanju"
+
+#: id:756
+msgid "Edit program name"
+msgstr "Izmjeni ime programa"
+
+#: id:757
+msgid "Edit path depth"
+msgstr "Izmjeni dubinu putanje"
+
+#: id:759
+msgid "View: Big list"
+msgstr "Pogled: Velika lista"
+
+#: id:760
+msgctxt "Auto context with id 760"
+msgid "Yellow"
+msgstr "Žuto"
+
+#: id:761
+msgctxt "Auto context with id 761"
+msgid "White"
+msgstr "Bijelo"
+
+#: id:762
+msgid "Blue"
+msgstr "Plavo"
+
+#: id:763
+msgid "Bright green"
+msgstr "Blijedo zeleno"
+
+#: id:764
+msgid "Yellow green"
+msgstr "Žuto zeleno"
+
+#: id:765
+msgid "Cyan"
+msgstr "Azurno plava"
+
+#: id:766
+msgid "Light grey"
+msgstr "Svijetlo siva"
+
+#: id:767
+msgid "Grey"
+msgstr "Siva"
+
+#: id:770
+msgid "Error %i: share not available"
+msgstr "Greška %i: djeljenje nije dostupano"
+
+#: id:772
+msgctxt "Auto context with id 772"
+msgid "Audio output"
+msgstr "Audio"
+
+#: id:773
+msgid "Seeking"
+msgstr "Pretraga"
+
+#: id:774
+msgid "Slideshow folder"
+msgstr "Slideshow mapa"
+
+#: id:775
+msgid "Network interface"
+msgstr "Mrežno sučelje"
+
+#: id:776
+msgid "- Wireless network name (ESSID)"
+msgstr "Ime bešične mreže (SSID)"
+
+#: id:777
+msgid "- Wireless password"
+msgstr "Zaporka za pristup bežičnoj mreži"
+
+#: id:778
+msgid "- Wireless security"
+msgstr "Sigurnost bežične mreže"
+
+#: id:779
+msgid "Save and apply network interface settings"
+msgstr "Spremi i primjeni postavke mrežnog sučelja"
+
+#: id:780
+msgid "No encryption"
+msgstr "Bez šifriranja"
+
+#: id:781
+msgid "WEP"
+msgstr "WEP"
+
+#: id:782
+msgid "WPA"
+msgstr "WPA"
+
+#: id:783
+msgid "WPA2"
+msgstr "WPA2"
+
+#: id:784
+msgid "Applying network interface settings. Please wait."
+msgstr "Primjena postavki mrežnog sučelja. Pričekajte molim."
+
+#: id:785
+msgid "Network interface restarted successfully."
+msgstr "Mrežno sučelje je uspješno restartano"
+
+#: id:786
+msgid "Network interface did not start successfully."
+msgstr "Mrežno sučelje nije pokrenuto pupješno"
+
+#: id:787
+msgid "Interface disabled"
+msgstr "Sučelje je onemogućeno"
+
+#: id:788
+msgid "Network interface disabled successfully."
+msgstr "Mrežno sučelje je uspješno onemogućeno"
+
+#: id:789
+msgid "Wireless network name (ESSID)"
+msgstr "Ime bežične mreže (SSID)"
+
+#: id:790
+msgid "Remote control"
+msgstr ""
+
+#: id:791
+msgid "Allow programs on this system to control XBMC"
+msgstr "Dozvoli programima na ovom systemu da upravljaju XBMC-om"
+
+#: id:792
+msgctxt "Auto context with id 792"
+msgid "Port"
+msgstr ""
+
+#: id:793
+msgid "Port range"
+msgstr ""
+
+#: id:794
+msgid "Allow programs on other systems to control XBMC"
+msgstr "Dozvoli programima na drugom systemu da upravljaju XBMC-om"
+
+#: id:795
+msgid "Initial repeat delay (ms)"
+msgstr ""
+
+#: id:796
+msgid "Continuous repeat delay (ms)"
+msgstr ""
+
+#: id:797
+msgid "Maximum number of clients"
+msgstr ""
+
+#: id:798
+msgid "Internet access"
+msgstr ""
+
+#: id:850
+msgid "Invalid port number entered"
+msgstr ""
+
+#: id:851
+msgid "Valid port range is 1-65535"
+msgstr ""
+
+#: id:852
+msgid "Valid port range is 1024-65535"
+msgstr ""
+
+#: id:998
+msgid "Add Music..."
+msgstr ""
+
+#: id:999
+msgid "Add Videos..."
+msgstr ""
+
+#: id:1000
+msgid "- Preview"
+msgstr "Pregled"
+
+#: id:1001
+msgid "Unable to connect"
+msgstr "Ne mogu se spojiti"
+
+#: id:1002
+msgid "XBMC was unable to connect to the network location."
+msgstr "XBMC se nije mogao spojiti na lokaciju mreže."
+
+#: id:1003
+msgid "This could be due to the network not being connected."
+msgstr "Ovo može biti razlog što mreža nije spojena."
+
+#: id:1004
+msgid "Would you like to add it anyway?"
+msgstr "Želiš li ju ipak dodati?"
+
+#: id:1006
+msgctxt "Auto context with id 1006"
+msgid "IP address"
+msgstr "IP Addresa"
+
+#: id:1007
+msgid "Add network location"
+msgstr "Dodaj mrežnu lokaciju"
+
+#: id:1008
+msgid "Protocol"
+msgstr "Protokol"
+
+#: id:1009
+msgid "Server address"
+msgstr "Addresa servera"
+
+#: id:1010
+msgid "Server name"
+msgstr "Ime servera"
+
+#: id:1011
+msgid "Remote path"
+msgstr "Udaljena putanja"
+
+#: id:1012
+msgid "Shared folder"
+msgstr "Djeljena mapa"
+
+#: id:1013
+msgctxt "Auto context with id 1013"
+msgid "Port"
+msgstr ""
+
+#: id:1014
+msgctxt "Auto context with id 1014"
+msgid "Username"
+msgstr "Korisničko ime"
+
+#: id:1015
+msgid "Browse for network server"
+msgstr "Traži mrežni server"
+
+#: id:1016
+msgid "Enter the network address of the server"
+msgstr "Upišite mrežnu adresu servera"
+
+#: id:1017
+msgid "Enter the path on the server"
+msgstr "Upišite putanju na serveru"
+
+#: id:1018
+msgid "Enter the port number"
+msgstr "Upišite ulazni broj"
+
+#: id:1019
+msgid "Enter the username"
+msgstr "Upišite korisničko ime"
+
+#: id:1020
+msgid "Add %s source"
+msgstr "Dodajte %s Izvor"
+
+#: id:1021
+msgid "Enter the paths or browse for the media locations."
+msgstr "Upišite putanje ili traži media lokacije."
+
+#: id:1022
+msgid "Enter a name for this media Source."
+msgstr "Upišite ime za media izvor."
+
+#: id:1023
+msgid "Browse for new share"
+msgstr "Pretražite nove djeljene lokacije"
+
+#: id:1024
+msgid "Browse"
+msgstr "Pretraga"
+
+#: id:1025
+msgid "Could not retrieve directory information."
+msgstr "Ne mogu povratiti info. direktorija."
+
+#: id:1026
+msgid "Add source"
+msgstr "Dodajte izvor"
+
+#: id:1027
+msgid "Edit source"
+msgstr "Promjenite izvor"
+
+#: id:1028
+msgid "Edit %s source"
+msgstr "Promjenite %s izvor"
+
+#: id:1029
+msgid "Enter the new label"
+msgstr "Upišite novi naslov"
+
+#: id:1030
+msgid "Browse for image"
+msgstr "Tražite sliku"
+
+#: id:1031
+msgid "Browse for image folder"
+msgstr "Pretražite mapu slika"
+
+#: id:1032
+msgid "Add network location..."
+msgstr "Dodajte lokaciju mreže..."
+
+#: id:1033
+msgid "Browse for file"
+msgstr "Tražite datoteku"
+
+#: id:1034
+msgid "Submenu"
+msgstr "Podmeni"
+
+#: id:1035
+msgid "Enable submenu buttons"
+msgstr "Omogući gumbe podmenija"
+
+#: id:1036
+msgid "Favourites"
+msgstr "Favoriti"
+
+#: id:1037
+msgid "Video Add-ons"
+msgstr "Video Add-oni"
+
+#: id:1038
+msgid "Music Add-ons"
+msgstr "Glazbeni Add-oni"
+
+#: id:1039
+msgid "Picture Add-ons"
+msgstr "Slikovni Add-oni"
+
+#: id:1040
+msgid "Loading directory"
+msgstr "Učitavam direktorij"
+
+#: id:1041
+msgid "Retrieved %i items"
+msgstr "Pronađene %i stvari"
+
+#: id:1042
+msgid "Retrieved %i of %i items"
+msgstr "Pronađene %i iz %i stvari"
+
+#: id:1043
+msgid "Program Add-ons"
+msgstr ""
+
+#: id:1044
+msgid "Set plugin thumb"
+msgstr "Postavi thumb plugin"
+
+#: id:1045
+msgid "Add-on settings"
+msgstr "Postavke Add-ona"
+
+#: id:1046
+msgid "Access points"
+msgstr ""
+
+#: id:1047
+msgid "Other..."
+msgstr ""
+
+#: id:1048
+msgid "- Username"
+msgstr "- Korisničko ime"
+
+#: id:1049
+msgid "Script settings"
+msgstr "Postavke skripte"
+
+#: id:1050
+msgid "Singles"
+msgstr ""
+
+#: id:1051
+msgid "Enter web address"
+msgstr ""
+
+#: id:1200
+msgid "SMB client"
+msgstr "SMB klijent"
+
+#: id:1202
+msgid "Workgroup"
+msgstr "Workgroup"
+
+#: id:1203
+msgid "Default username"
+msgstr "Zadano korisničko ime"
+
+#: id:1204
+msgid "Default password"
+msgstr "Zadana zaporka"
+
+#: id:1207
+msgid "WINS server"
+msgstr "WINS-Server"
+
+#: id:1208
+msgid "Mount SMB shares"
+msgstr ""
+
+#: id:1210
+msgctxt "Auto context with id 1210"
+msgid "Remove"
+msgstr "Makni"
+
+#: id:1211
+msgctxt "Auto context with id 1211"
+msgid "Music"
+msgstr "Glazba"
+
+#: id:1212
+msgctxt "Auto context with id 1212"
+msgid "Video"
+msgstr "Video"
+
+#: id:1213
+msgctxt "Auto context with id 1213"
+msgid "Pictures"
+msgstr "Slike"
+
+#: id:1214
+msgctxt "Auto context with id 1214"
+msgid "Files"
+msgstr "Datoteke"
+
+#: id:1215
+msgctxt "Auto context with id 1215"
+msgid "Music & video"
+msgstr "Glazba & Video"
+
+#: id:1216
+msgid "Music & pictures"
+msgstr "Glazba & Slike"
+
+#: id:1217
+msgid "Music & files"
+msgstr "Glazba & Datoteke"
+
+#: id:1218
+msgid "Video & pictures"
+msgstr "Video & Slike"
+
+#: id:1219
+msgid "Video & files"
+msgstr "Video & Datoteke"
+
+#: id:1220
+msgid "Pictures & files"
+msgstr "Slike & Datoteke"
+
+#: id:1221
+msgid "Music & video & pictures"
+msgstr "Glazba & Video & Slike"
+
+#: id:1222
+msgid "Music & video & pictures & files"
+msgstr "Glazba & Video & Slike & Datoteke"
+
+#: id:1223
+msgctxt "Auto context with id 1223"
+msgid "Disabled"
+msgstr "Onemogućeno"
+
+#: id:1226
+msgid "Files & music & video"
+msgstr "Datoteke & Glazba & Video"
+
+#: id:1227
+msgid "Files & pictures & music"
+msgstr "Datoteke & Slike & Glazba"
+
+#: id:1228
+msgid "Files & pictures & video"
+msgstr "Datoteke & Slike & Video"
+
+#: id:1229
+msgid "Music & programs"
+msgstr "Glazba & Programi"
+
+#: id:1230
+msgid "Video & programs"
+msgstr "Video & Programi"
+
+#: id:1231
+msgid "Pictures & programs"
+msgstr "Slike & Programi"
+
+#: id:1232
+msgid "Music & video & pictures & programs"
+msgstr "Glazba & Video & Slike & Programi"
+
+#: id:1233
+msgid "Programs & video & music"
+msgstr "Programi & Video & Glazba"
+
+#: id:1234
+msgid "Programs & pictures & music"
+msgstr "Programi & Slike & Glazba"
+
+#: id:1235
+msgid "Programs & pictures & video"
+msgstr "Programi & Slike & Video"
+
+#: id:1250
+msgid "Auto-detection"
+msgstr "Autodetekcija"
+
+#: id:1251
+msgid "Auto-detect system"
+msgstr "Sistem autodetekcije"
+
+#: id:1252
+msgid "Nickname"
+msgstr "Nadimak"
+
+#: id:1254
+msgid "Ask to connect"
+msgstr "Upit za spajanje"
+
+#: id:1255
+msgid "Send FTP user and password"
+msgstr "Šalji FTP korisnika i zaporku"
+
+#: id:1256
+msgid "Ping interval"
+msgstr "Ping interval"
+
+#: id:1257
+msgid "Would you like to connect to the auto-detected system?"
+msgstr "Želiš li se spojiti na autodetektirani sistem?"
+
+#: id:1259
+msgid "Zeroconf"
+msgstr ""
+
+#: id:1260
+msgid "Announce these services to other systems via Zeroconf"
+msgstr ""
+
+#: id:1270
+msgid "Allow XBMC to receive AirPlay content"
+msgstr ""
+
+#: id:1271
+msgid "Device name"
+msgstr ""
+
+#: id:1272
+msgid "- Use password protection"
+msgstr ""
+
+#: id:1273
+msgid "AirPlay"
+msgstr ""
+
+#: id:1300
+msgid "Custom audio device"
+msgstr ""
+
+#: id:1301
+msgid "Custom passthrough device"
+msgstr ""
+
+#: id:1396
+msgid "Drifting"
+msgstr "Poledica"
+
+#: id:1397
+msgid "and"
+msgstr "i"
+
+#: id:1398
+msgid "Freezing"
+msgstr "Smrzavanje"
+
+#: id:1399
+msgid "Late"
+msgstr "Kasno"
+
+#: id:1400
+msgid "Isolated"
+msgstr "Izolirani"
+
+#: id:1401
+msgid "Thundershowers"
+msgstr "Oluje"
+
+#: id:1402
+msgid "Thunder"
+msgstr "Grom"
+
+#: id:1403
+msgctxt "Auto context with id 1403"
+msgid "Sun"
+msgstr "Sunce"
+
+#: id:1404
+msgid "Heavy"
+msgstr "Teško"
+
+#: id:1405
+msgid "in"
+msgstr "u"
+
+#: id:1406
+msgid "the"
+msgstr "i"
+
+#: id:1407
+msgid "Vicinity"
+msgstr "Okolina"
+
+#: id:1408
+msgid "Ice"
+msgstr "Led"
+
+#: id:1409
+msgid "Crystals"
+msgstr "Kristali"
+
+#: id:1410
+msgid "Calm"
+msgstr "Mirno"
+
+#: id:1411
+msgid "with"
+msgstr "sa"
+
+#: id:1412
+msgid "windy"
+msgstr "vjetrovito"
+
+#: id:1413
+msgid "drizzle"
+msgstr "sipiti"
+
+#: id:1414
+msgid "Thunderstorm"
+msgstr "Oluja"
+
+#: id:1415
+msgid "Drizzle"
+msgstr "Sipiti"
+
+#: id:1416
+msgid "Foggy"
+msgstr "Maglovito"
+
+#: id:1417
+msgid "Grains"
+msgstr ""
+
+#: id:1418
+msgid "T-Storms"
+msgstr ""
+
+#: id:1419
+msgid "T-Showers"
+msgstr ""
+
+#: id:1420
+msgid "Moderate"
+msgstr "Promjenjivo"
+
+#: id:1421
+msgid "Very High"
+msgstr ""
+
+#: id:1422
+msgid "Windy"
+msgstr "Vjetrovito"
+
+#: id:1423
+msgid "Mist"
+msgstr "Magla"
+
+#: id:1450
+msgid "Put display to sleep when idle"
+msgstr "Postavi ekran \"na spavanje\" kada se ne koristi"
+
+#: id:2050
+msgid "Runtime"
+msgstr "Trajanje"
+
+#: id:2100
+msgid "Script failed! : %s"
+msgstr ""
+
+#: id:2101
+msgid "Newer version needed - See log"
+msgstr ""
+
+#: id:4501
+msgid "Enable LCD/VFD"
+msgstr "Omogući LCD/VFD"
+
+#: id:10000
+msgid "Home"
+msgstr "Doma"
+
+#: id:10001
+msgctxt "Auto context with id 10001"
+msgid "Programs"
+msgstr "Programi"
+
+#: id:10002
+msgctxt "Auto context with id 10002"
+msgid "Pictures"
+msgstr "Slike"
+
+#: id:10003
+msgctxt "Auto context with id 10003"
+msgid "File manager"
+msgstr "Upravitelj dat."
+
+#: id:10004
+msgctxt "Auto context with id 10004"
+msgid "Settings"
+msgstr "Postavke"
+
+#: id:10005
+msgctxt "Auto context with id 10005"
+msgid "Music"
+msgstr "Glazba"
+
+#: id:10006
+msgctxt "Auto context with id 10006"
+msgid "Videos"
+msgstr "Video"
+
+#: id:10007
+msgid "System information"
+msgstr "Sistemske informacije"
+
+#: id:10008
+msgid "Settings - General"
+msgstr "Postavke->Općenito"
+
+#: id:10009
+msgid "Settings - Screen"
+msgstr "Postavke->Ekran"
+
+#: id:10010
+msgid "Settings - Appearance - GUI Calibration"
+msgstr "Postavke - Izgled - GUI Kalibracija"
+
+#: id:10011
+msgid "Settings - Videos - Screen Calibration"
+msgstr "Postavke - Video - Kalibracija Ekrana"
+
+#: id:10012
+msgid "Settings - Pictures"
+msgstr "Postavke - Slike"
+
+#: id:10013
+msgid "Settings - Programs"
+msgstr "Postavke - Programi"
+
+#: id:10014
+msgid "Settings - Weather"
+msgstr "Postavke - Vrijeme"
+
+#: id:10015
+msgid "Settings - Music"
+msgstr "Postavke - Glazba"
+
+#: id:10016
+msgid "Settings - System"
+msgstr "Postavke - Sistem"
+
+#: id:10017
+msgid "Settings - Videos"
+msgstr "Postavke - Video"
+
+#: id:10018
+msgid "Settings - Network"
+msgstr "Postavke - Mreža"
+
+#: id:10019
+msgid "Settings - Appearance"
+msgstr "Postavk - Izgled"
+
+#: id:10020
+msgctxt "Auto context with id 10020"
+msgid "Scripts"
+msgstr "Skripte"
+
+#: id:10021
+msgid "Web Browser"
+msgstr ""
+
+#: id:10025
+msgctxt "Auto context with id 10025"
+msgid "Videos"
+msgstr ""
+
+#: id:10028
+msgid "Videos/Playlist"
+msgstr "Video/playlista"
+
+#: id:10029
+msgctxt "Auto context with id 10029"
+msgid "Login screen"
+msgstr ""
+
+#: id:10034
+msgid "Settings - Profiles"
+msgstr "Postavke - Profili"
+
+#: id:10040
+msgid "Addon browser"
+msgstr ""
+
+#: id:10100
+msgid "Yes/No dialog"
+msgstr "Da/Ne dijalog"
+
+#: id:10101
+msgid "Progress dialog"
+msgstr "Dijalog napretka"
+
+#: id:10210
+msgid "Looking for subtitles..."
+msgstr "Pretraga titlova"
+
+#: id:10211
+msgid "Looking for or caching subtitles..."
+msgstr "Pretraga ili cache-iranje titlova"
+
+#: id:10212
+msgid "terminating"
+msgstr "otkazivanje"
+
+#: id:10213
+msgid "buffering"
+msgstr ""
+
+#: id:10214
+msgid "Opening stream"
+msgstr "Otvaranje stream-a"
+
+#: id:10500
+msgid "Music/Playlist"
+msgstr "Glazba/playlista"
+
+#: id:10501
+msgid "Music/Files"
+msgstr "Glazba/Datoteke"
+
+#: id:10502
+msgid "Music/Library"
+msgstr "Glazba/Library"
+
+#: id:10503
+msgid "Playlist editor"
+msgstr "Editor playliste"
+
+#: id:10504
+msgid "Top 100 songs"
+msgstr "Top 100 pjesama"
+
+#: id:10505
+msgid "Top 100 albums"
+msgstr "Top 100 albuma"
+
+#: id:10506
+msgctxt "Auto context with id 10506"
+msgid "Programs"
+msgstr "Programi"
+
+#: id:10507
+msgid "Configuration"
+msgstr "Konfiguracija"
+
+#: id:10508
+msgid "Weather forecast"
+msgstr "Vremenska prognoza"
+
+#: id:10509
+msgid "Network gaming"
+msgstr "Mrežno igranje"
+
+#: id:10510
+msgid "Extensions"
+msgstr "Ekstenzije"
+
+#: id:10511
+msgctxt "Auto context with id 10511"
+msgid "System info"
+msgstr "Sistem info"
+
+#: id:10516
+msgid "Music - Library"
+msgstr "Glazba - Library"
+
+#: id:10517
+msgid "Now Playing - Music"
+msgstr "Sad Svira - Glazba"
+
+#: id:10522
+msgid "Now Playing - Videos"
+msgstr "Sad Igra - Video"
+
+#: id:10523
+msgid "Album info"
+msgstr "Album info"
+
+#: id:10524
+msgid "Movie info"
+msgstr "Film info"
+
+#: id:12000
+msgid "Select dialog"
+msgstr "Odaberi dijalog"
+
+#: id:12001
+msgid "Music/Info"
+msgstr "Glazba/info"
+
+#: id:12002
+msgid "Dialog OK"
+msgstr "Dijalog OK"
+
+#: id:12003
+msgid "Videos/Info"
+msgstr "Video/Info"
+
+#: id:12004
+msgid "Scripts/Info"
+msgstr "Skripte/Info"
+
+#: id:12005
+msgid "Fullscreen video"
+msgstr "Fullscreen video"
+
+#: id:12006
+msgid "Audio visualization"
+msgstr "Audio vizualizacije"
+
+#: id:12008
+msgid "File stacking dialog"
+msgstr ""
+
+#: id:12009
+msgid "Rebuild index..."
+msgstr "Obnovi index..."
+
+#: id:12010
+msgid "Return to music window"
+msgstr "Vrati se na ekran glazbe"
+
+#: id:12011
+msgid "Return to videos window"
+msgstr "Vrati se na ekran video"
+
+#: id:12021
+msgid "Start from beginning"
+msgstr "Počni ispočetka"
+
+#: id:12022
+msgid "Resume from %s"
+msgstr "Nastavi sa %s"
+
+#: id:12310
+msgid "0"
+msgstr "0"
+
+#: id:12311
+msgid "1"
+msgstr "1"
+
+#: id:12312
+msgid "2"
+msgstr "2"
+
+#: id:12313
+msgid "3"
+msgstr "3"
+
+#: id:12314
+msgid "4"
+msgstr "4"
+
+#: id:12315
+msgid "5"
+msgstr "5"
+
+#: id:12316
+msgid "6"
+msgstr "6"
+
+#: id:12317
+msgid "7"
+msgstr "7"
+
+#: id:12318
+msgid "8"
+msgstr "8"
+
+#: id:12319
+msgid "9"
+msgstr "9"
+
+#: id:12320
+msgid "c"
+msgstr "c"
+
+#: id:12321
+msgid "Ok"
+msgstr "Ok"
+
+#: id:12322
+msgid "*"
+msgstr "*"
+
+#: id:12325
+msgid "Locked! Enter code..."
+msgstr "Zaključano! Upiši Kod..."
+
+#: id:12326
+msgid "Enter password"
+msgstr "Upiši zaporku"
+
+#: id:12327
+msgid "Enter master code"
+msgstr "Upiši glavni kod"
+
+#: id:12328
+msgid "Enter unlock code"
+msgstr "Upiši kod za otključavanje"
+
+#: id:12329
+msgid "or press C to cancel"
+msgstr "ili stisni C za prekid"
+
+#: id:12330
+msgid "Enter gamepad button combo and"
+msgstr "Stisni komb. gumbi kontrolera i"
+
+#: id:12331
+msgid "press OK, or Back to cancel"
+msgstr "stisni OK ili Natrag za prekid"
+
+#: id:12332
+msgid "Set lock"
+msgstr "Postavi ključ"
+
+#: id:12333
+msgid "Unlock"
+msgstr "Otključaj"
+
+#: id:12334
+msgid "Reset lock"
+msgstr "Resetiraj ključ"
+
+#: id:12335
+msgid "Remove lock"
+msgstr "Ukloni ključ"
+
+#: id:12337
+msgid "Numeric password"
+msgstr "Brojčana zaporka"
+
+#: id:12338
+msgid "Gamepad button combo"
+msgstr "Komb. tipki kontrolera"
+
+#: id:12339
+msgid "Full-text password"
+msgstr "Zaporka cijelog teksta"
+
+#: id:12340
+msgid "Enter new password"
+msgstr "Upiši novu zaporku"
+
+#: id:12341
+msgid "Re-Enter new password"
+msgstr "Ponovo upiši novu zaporku"
+
+#: id:12342
+msgid "Incorrect password,"
+msgstr "Netočna zaporka,"
+
+#: id:12343
+msgid "retries left"
+msgstr "preostalo pokušaja"
+
+#: id:12344
+msgid "Passwords entered did not match."
+msgstr "Unešene zaporke nisu jednake."
+
+#: id:12345
+msgid "Access denied"
+msgstr "Pristup zabranjen"
+
+#: id:12346
+msgid "Password retry limit exceeded."
+msgstr "Premašen limit pokušaja za zaporku."
+
+#: id:12347
+msgid "The system will now shut off."
+msgstr "Sistem će se sada ugasiti."
+
+#: id:12348
+msgid "Item locked"
+msgstr "Stvar zaključana"
+
+#: id:12353
+msgid "Reactivate lock"
+msgstr "Reaktiviraj ključ"
+
+#: id:12356
+msgid "Change lock"
+msgstr "Izmjeni ključ"
+
+#: id:12357
+msgid "Source lock"
+msgstr "Izvor ključa"
+
+#: id:12358
+msgid "Password entry was blank. Try again."
+msgstr "Upis zaporke je prazan. Pokušajte ponovo."
+
+#: id:12360
+msgid "Master lock"
+msgstr "Glavni ključ"
+
+#: id:12362
+msgid "Shutdown system if Master Lock retries exceeded"
+msgstr "Ugasi sistem kod prevelikog pokušaja upisa glavnog ključa"
+
+#: id:12367
+msgid "Master code is not valid"
+msgstr "Glavni ključ nije važeći!"
+
+#: id:12368
+msgid "Please enter a valid master code"
+msgstr "Molim, upišite važeći glavni ključ!"
+
+#: id:12373
+msgid "Settings & file manager"
+msgstr "Postavke & Upravitelj dat."
+
+#: id:12376
+msgid "Set as default for all movies"
+msgstr "Postavi kao zadano za sve filmove"
+
+#: id:12377
+msgid "This will reset any previously saved values"
+msgstr "Ovo će resetirat sve prijašnje sačuvane vrijednosti"
+
+#: id:12378
+msgid "Amount of time to display each image"
+msgstr "Prikaži svaku sliku"
+
+#: id:12379
+msgid "Use pan and zoom effects"
+msgstr "Koristi Pomicanje i Zoom efekte (Pan & Zoom)"
+
+#: id:12383
+msgid "12 hour clock"
+msgstr "12 satno vrijeme"
+
+#: id:12384
+msgid "24 hour clock"
+msgstr "24 satno vrijeme"
+
+#: id:12385
+msgid "Day/Month"
+msgstr "Dan/Mjesec"
+
+#: id:12386
+msgid "Month/Day"
+msgstr "Mjesec/Dan"
+
+#: id:12390
+msgid "System uptime"
+msgstr "Sistem pokrenut"
+
+#: id:12391
+msgid "Minutes"
+msgstr "Minute"
+
+#: id:12392
+msgid "Hours"
+msgstr "Sati"
+
+#: id:12393
+msgid "Days"
+msgstr "Dani"
+
+#: id:12394
+msgid "Total uptime"
+msgstr "Totalno pokrenut"
+
+#: id:12395
+msgid "Battery level"
+msgstr ""
+
+#: id:12600
+msgctxt "Auto context with id 12600"
+msgid "Weather"
+msgstr "Vrijeme"
+
+#: id:12900
+msgctxt "Auto context with id 12900"
+msgid "Screensaver"
+msgstr ""
+
+#: id:12901
+msgid "Fullscreen OSD"
+msgstr ""
+
+#: id:13000
+msgid "System"
+msgstr "Sistem"
+
+#: id:13001
+msgid "Immediate HD spindown"
+msgstr "Trenutni HDD Spindown"
+
+#: id:13002
+msgid "Video only"
+msgstr "Samo video"
+
+#: id:13003
+msgid "- Delay"
+msgstr "- Odmak"
+
+#: id:13004
+msgid "- Minimum file duration"
+msgstr "- Minimalni Tijek trajanja"
+
+#: id:13005
+msgid "Shutdown"
+msgstr "Ugasi"
+
+#: id:13008
+msgid "Shutdown function"
+msgstr "Funkcije isključivanja"
+
+#: id:13009
+msgid "Quit"
+msgstr ""
+
+#: id:13010
+msgid "Hibernate"
+msgstr ""
+
+#: id:13011
+msgid "Suspend"
+msgstr ""
+
+#: id:13012
+msgid "Exit"
+msgstr ""
+
+#: id:13013
+msgid "Reboot"
+msgstr ""
+
+#: id:13014
+msgid "Minimize"
+msgstr ""
+
+#: id:13015
+msgid "Power button action"
+msgstr ""
+
+#: id:13016
+msgid "Power off System"
+msgstr ""
+
+#: id:13020
+msgid "Is another session active, perhaps over ssh?"
+msgstr ""
+
+#: id:13021
+msgid "Mounted removable harddrive"
+msgstr ""
+
+#: id:13022
+msgid "Unsafe device removal"
+msgstr ""
+
+#: id:13023
+msgid "Successfully removed device"
+msgstr ""
+
+#: id:13024
+msgid "Joystick plugged"
+msgstr "Joystick spojen"
+
+#: id:13025
+msgid "Joystick unplugged"
+msgstr "Joystick odspojen"
+
+#: id:13050
+msgid "Running low on battery"
+msgstr "Rad na praznoj bateriji"
+
+#: id:13100
+msgid "Flicker filter"
+msgstr "Flicker filter"
+
+#: id:13101
+msgid "Let driver choose (requires restart)"
+msgstr "Neka upravljački program odluči (potreban restart)"
+
+#: id:13105
+msgid "Vertical blank sync"
+msgstr "Vertikalni blank sync"
+
+#: id:13106
+msgctxt "Auto context with id 13106"
+msgid "Disabled"
+msgstr "Onemogućeno"
+
+#: id:13107
+msgid "Enabled during video playback"
+msgstr "Omogućeno tijekom video reprodukcije"
+
+#: id:13108
+msgctxt "Auto context with id 13108"
+msgid "Always enabled"
+msgstr "Uvijek omogućeno"
+
+#: id:13109
+msgid "Test & apply resolution"
+msgstr "Isprobaj i primjeni rezoluciju"
+
+#: id:13110
+msgid "Save resolution?"
+msgstr "Sačuvati rezoluciju?"
+
+#: id:13111
+msgid "Would you like to keep this resolution?"
+msgstr "Želite li zadržati ovu rezoluciju?"
+
+#: id:13112
+msgid "High quality upscaling"
+msgstr "Visoko kvalitetan upscale"
+
+#: id:13113
+msgctxt "Auto context with id 13113"
+msgid "Disabled"
+msgstr "Onemogućeno"
+
+#: id:13114
+msgid "Enabled for SD content"
+msgstr "Omogućeno za SD sadržaje"
+
+#: id:13115
+msgctxt "Auto context with id 13115"
+msgid "Always enabled"
+msgstr "Uvijek je omogućeno"
+
+#: id:13116
+msgid "Upscaling method"
+msgstr "Upscale metoda"
+
+#: id:13117
+msgctxt "Auto context with id 13117"
+msgid "Bicubic"
+msgstr "Bicubic"
+
+#: id:13118
+msgid "Lanczos"
+msgstr "Lanczos"
+
+#: id:13119
+msgid "Sinc"
+msgstr "Sinc"
+
+#: id:13120
+msgctxt "Auto context with id 13120"
+msgid "VDPAU"
+msgstr "VDPAU"
+
+#: id:13121
+msgid "VDPAU HQ Upscaling level"
+msgstr "VDPAU HQ Upscaling level"
+
+#: id:13122
+msgid "VDPAU Studio level color conversion"
+msgstr "VDPAU Studio level color conversion"
+
+#: id:13130
+msgid "Blank other displays"
+msgstr "Zacrni ostale ekrane"
+
+#: id:13131
+msgctxt "Auto context with id 13131"
+msgid "Disabled"
+msgstr "Onemogućeno"
+
+#: id:13132
+msgid "Blank displays"
+msgstr "Zacrni ekrane"
+
+#: id:13140
+msgid "Active connections detected!"
+msgstr "Aktivne veze su deaktivirane!"
+
+#: id:13141
+msgid "If you proceed, you might not be able to control XBMC"
+msgstr "Ukoliko nastavite dalje, možda nećete moći da upravljate XBMC"
+
+#: id:13142
+msgid "any longer. Are you sure you want to stop the Event server?"
+msgstr "aplikacijom. Da li ste sigurni da želite da zaustavite Server za događaje?"
+
+#: id:13144
+msgid "Change Apple Remote mode?"
+msgstr "Izmjeni \"Apple Remote\" režim?"
+
+#: id:13145
+msgid "If you are currently using the Apple Remote to control"
+msgstr "Ukoliko koristite \"Apple Remote\" za upravljanje"
+
+#: id:13146
+msgid "XBMC, changing this setting might affect your ability"
+msgstr "XBMC aplikacijom, promjenom ove postavke možda promjenite"
+
+#: id:13147
+msgid "to continue controlling it. Do you want to proceed?"
+msgstr "mogućnosti kontrole aplikacije. Želite li nastaviti?"
+
+#: id:13159
+msgid "Subnet mask"
+msgstr "Subnet mask"
+
+#: id:13160
+msgid "Gateway"
+msgstr "Gateway"
+
+#: id:13161
+msgid "Primary DNS"
+msgstr "Primarni DNS"
+
+#: id:13162
+msgid "Initialize failed"
+msgstr "Neuspješna inicijalizacija"
+
+#: id:13170
+msgctxt "Auto context with id 13170"
+msgid "Never"
+msgstr "Nikad"
+
+#: id:13171
+msgid "Immediately"
+msgstr "Odmah"
+
+#: id:13172
+msgid "After %i secs"
+msgstr "Poslije %i sec."
+
+#: id:13173
+msgid "HDD install date:"
+msgstr "HDD datum instaliranja:"
+
+#: id:13174
+msgid "HDD power cycle count:"
+msgstr "HDD naponski zbroj ciklusa:"
+
+#: id:13200
+msgid "Profiles"
+msgstr "Profili"
+
+#: id:13201
+msgid "Delete profile '%s'?"
+msgstr "Izbriši profil '%s'?"
+
+#: id:13204
+msgid "Last loaded profile:"
+msgstr "Zadnje učitani profil:"
+
+#: id:13205
+msgid "Unknown"
+msgstr "Nepoznato"
+
+#: id:13206
+msgid "Overwrite"
+msgstr "Prepiši"
+
+#: id:13208
+msgid "Alarm clock"
+msgstr "Alarm sata"
+
+#: id:13209
+msgid "Alarm clock interval (in minutes)"
+msgstr "Interval satnog alarma (u minutama)"
+
+#: id:13210
+msgid "Started, alarm in %im"
+msgstr "Započeto, alarm u %im"
+
+#: id:13211
+msgid "Alarm!"
+msgstr "Alarm!"
+
+#: id:13212
+msgid "Canceled with %im%is left"
+msgstr "Otkazati sa %im%ostatak"
+
+#: id:13213
+msgid "%2.0fm"
+msgstr ""
+
+#: id:13214
+msgid "%2.0fs"
+msgstr ""
+
+#: id:13249
+msgid "Search for subtitles in RARs"
+msgstr "Traži titlove u RAR-u"
+
+#: id:13250
+msgid "Browse for subtitle..."
+msgstr "Traži titlove..."
+
+#: id:13251
+msgid "Move item"
+msgstr "Premjesti stavke"
+
+#: id:13252
+msgid "Move item here"
+msgstr "Premjesti stavke tu"
+
+#: id:13253
+msgid "Cancel move"
+msgstr "Poništi premještanje"
+
+#: id:13270
+msgid "Hardware:"
+msgstr ""
+
+#: id:13271
+msgid "CPU Usage:"
+msgstr "Zauzeće procesora:"
+
+#: id:13274
+msgid "Connected, but no DNS is available."
+msgstr "Spojen, ali DNS nije dostupan."
+
+#: id:13275
+msgid "Hard Disk"
+msgstr "Tvrdi Disk"
+
+#: id:13276
+msgid "DVD-ROM"
+msgstr "DVD-ROM"
+
+#: id:13277
+msgctxt "Auto context with id 13277"
+msgid "Storage"
+msgstr "Pohrana"
+
+#: id:13278
+msgctxt "Auto context with id 13278"
+msgid "Default"
+msgstr "Zadano"
+
+#: id:13279
+msgctxt "Auto context with id 13279"
+msgid "Network"
+msgstr "Mreža"
+
+#: id:13280
+msgctxt "Auto context with id 13280"
+msgid "Video"
+msgstr "Video"
+
+#: id:13281
+msgid "Hardware"
+msgstr ""
+
+#: id:13283
+msgid "Operating system:"
+msgstr "Operativni sistem:"
+
+#: id:13284
+msgid "CPU speed:"
+msgstr "Brzina procesora:"
+
+#: id:13286
+msgid "Video encoder:"
+msgstr "Video enkoder:"
+
+#: id:13287
+msgid "Screen resolution:"
+msgstr "Rezolucija ekrana:"
+
+#: id:13292
+msgid "A/V cable:"
+msgstr "A/V Kabel:"
+
+#: id:13294
+msgid "DVD region:"
+msgstr "DVD regija:"
+
+#: id:13295
+msgid "Internet:"
+msgstr "Internet:"
+
+#: id:13296
+msgctxt "Auto context with id 13296"
+msgid "Connected"
+msgstr "Spojen"
+
+#: id:13297
+msgid "Not connected. Check network settings."
+msgstr "Nije Spojen. Provjeri mrežne postavke."
+
+#: id:13299
+msgid "Target temperature"
+msgstr "Odredišna temperatura"
+
+#: id:13300
+msgid "Fan speed"
+msgstr "Brzina ventilatora"
+
+#: id:13301
+msgid "Auto temperature control"
+msgstr "Automatska kontrola temperature"
+
+#: id:13302
+msgid "Fan speed override"
+msgstr "Veća brzina ventilatora"
+
+#: id:13303
+msgid "- Fonts"
+msgstr "Font (veličina)"
+
+#: id:13304
+msgid "Enable flipping bi-directional strings"
+msgstr "Omogući flipping bi-directional stringa"
+
+#: id:13305
+msgid "Show RSS news feeds"
+msgstr "Omogući RSS kanale"
+
+#: id:13306
+msgid "Show parent folder items"
+msgstr "Sakrij stavke \"Roditeljske Mape\""
+
+#: id:13307
+msgid "Track naming template"
+msgstr "Shema imenovanja pjesama"
+
+#: id:13308
+msgid "Do you wish to reboot your system"
+msgstr "Da li želite ponovo pokrenuti sistem"
+
+#: id:13309
+msgid "instead of just XBMC?"
+msgstr "Umjesto XBMC?"
+
+#: id:13310
+msgid "Zoom effect"
+msgstr "Zoom efekt"
+
+#: id:13311
+msgid "Float effect"
+msgstr "Plutajući efekt (float)"
+
+#: id:13312
+msgid "Black bar reduction"
+msgstr "Redukcija crnih traka"
+
+#: id:13313
+msgid "Restart"
+msgstr "Restart"
+
+#: id:13314
+msgid "Crossfade between songs"
+msgstr "Pretapanje između pjesama (crossfade)"
+
+#: id:13315
+msgid "Regenerate thumbnails"
+msgstr "Obnovi thumb"
+
+#: id:13316
+msgid "Recursive thumbnails"
+msgstr "Rekurzivne thumb"
+
+#: id:13317
+msgid "View slideshow"
+msgstr "Pogledaj slideshow"
+
+#: id:13318
+msgid "Recursive slideshow"
+msgstr "Rekurzivni slideshow"
+
+#: id:13319
+msgid "Randomize"
+msgstr "Nasumce"
+
+#: id:13320
+msgid "Stereo"
+msgstr "Stereo"
+
+#: id:13321
+msgid "Left only"
+msgstr "Samo lijevi"
+
+#: id:13322
+msgid "Right only"
+msgstr "Samo desni"
+
+#: id:13323
+msgid "Enable karaoke support"
+msgstr "Omogući karaoke podršku"
+
+#: id:13324
+msgid "Background transparency"
+msgstr "Pozadinska providnost"
+
+#: id:13325
+msgid "Foreground transparency"
+msgstr "Prednja providnost"
+
+#: id:13326
+msgid "A/V delay"
+msgstr "A/V odmak"
+
+#: id:13327
+msgid "Karaoke"
+msgstr "Karaoke"
+
+#: id:13328
+msgid "%s not found"
+msgstr "%s nije pronađen"
+
+#: id:13329
+msgid "Error opening %s"
+msgstr "Greška kod otvaranja %s"
+
+#: id:13330
+msgid "Unable to load %s"
+msgstr "Ne mogu učitati %s"
+
+#: id:13331
+msgid "Error: Out of memory"
+msgstr "Greška: Premalo memorije"
+
+#: id:13332
+msgid "Move up"
+msgstr "Pomakni gore"
+
+#: id:13333
+msgid "Move down"
+msgstr "Pomakni dolje"
+
+#: id:13334
+msgid "Edit label"
+msgstr "Uredi oznaku"
+
+#: id:13335
+msgid "Make default"
+msgstr "Učini zadanim"
+
+#: id:13336
+msgid "Remove button"
+msgstr "Ukloni gumb"
+
+#: id:13340
+msgid "Leave as is"
+msgstr "Ostavi kako je"
+
+#: id:13341
+msgid "Green"
+msgstr "Zeleno"
+
+#: id:13342
+msgid "Orange"
+msgstr "Naranđasto"
+
+#: id:13343
+msgid "Red"
+msgstr "Crveno"
+
+#: id:13344
+msgid "Cycle"
+msgstr "Okreći"
+
+#: id:13345
+msgid "Switch LED off on playback"
+msgstr "Isključi LED pri sviranju/igranju"
+
+#: id:13346
+msgctxt "Auto context with id 13346"
+msgid "Movie information"
+msgstr "Filmske informacije"
+
+#: id:13347
+msgid "Queue item"
+msgstr "Označi stavku"
+
+#: id:13348
+msgid "Search IMDb..."
+msgstr "Traži na IMDb..."
+
+#: id:13349
+msgid "Scan for new content"
+msgstr "Skeniraj novi sadržaj"
+
+#: id:13350
+msgid "Now playing..."
+msgstr "Sada igra..."
+
+#: id:13351
+msgctxt "Auto context with id 13351"
+msgid "Album information"
+msgstr "Informacije albuma"
+
+#: id:13352
+msgid "Scan item to library"
+msgstr "Skeniraj stavke u library"
+
+#: id:13353
+msgid "Stop scanning"
+msgstr "Zaustavi skeniranje"
+
+#: id:13354
+msgctxt "Auto context with id 13354"
+msgid "Render method"
+msgstr "Metoda renderiranja"
+
+#: id:13355
+msgid "Low quality pixel shader"
+msgstr "Niska kvaliteta piksel shadera"
+
+#: id:13356
+msgid "Hardware overlays"
+msgstr "Nadgledanje hardware-a"
+
+#: id:13357
+msgid "High quality pixel shader"
+msgstr "Visoka kvaliteta piksel shadera"
+
+#: id:13358
+msgid "Play item"
+msgstr "Pokreni stavku"
+
+#: id:13359
+msgid "Set artist thumb"
+msgstr "Postavi thumb od glumca"
+
+#: id:13360
+msgid "Automatically generate thumbnails"
+msgstr "Stvori thumb"
+
+#: id:13361
+msgid "Enable voice"
+msgstr "Omogući glas"
+
+#: id:13375
+msgid "Enable device"
+msgstr "Omogući uređaj"
+
+#: id:13376
+msgid "Volume"
+msgstr "Glasnoća"
+
+#: id:13377
+msgid "Default view mode"
+msgstr "Zadani pogled"
+
+#: id:13378
+msgid "Default brightness"
+msgstr "Zadana svjetlina"
+
+#: id:13379
+msgid "Default contrast"
+msgstr "Zadani kontrast"
+
+#: id:13380
+msgid "Default gamma"
+msgstr "Zadana gamma"
+
+#: id:13381
+msgid "Resume video"
+msgstr "Nastavi video"
+
+#: id:13382
+msgid "Voice mask - Port 1"
+msgstr "Maska Glasa - Ulaz 1"
+
+#: id:13383
+msgid "Voice mask - Port 2"
+msgstr "Maska Glasa - Ulaz 2"
+
+#: id:13384
+msgid "Voice mask - Port 3"
+msgstr "Maska Glasa - Ulaz 3"
+
+#: id:13385
+msgid "Voice mask - Port 4"
+msgstr "Maska Glasa - Ulaz 4"
+
+#: id:13386
+msgid "Use time based seeking"
+msgstr "Koristi vremensko traženje"
+
+#: id:13387
+msgid "Track naming template - right"
+msgstr "Shema imenovanja kod pjesama - desno"
+
+#: id:13388
+msgid "Preset"
+msgstr "Postavke"
+
+#: id:13389
+msgid "There are no presets available\nfor this visualization"
+msgstr "Nema dostupne postavke za ovu vizualizaciju"
+
+#: id:13390
+msgid "There are no settings available\nfor this visualization"
+msgstr "Nema postavki za ovu vizualizaciju"
+
+#: id:13391
+msgid "Eject/Load"
+msgstr "Izbaci/Ubaci"
+
+#: id:13392
+msgid "Use visualization if playing audio"
+msgstr "Koristi vizualizacije kod audio reprodukcije"
+
+#: id:13393
+msgid "Calculate size"
+msgstr "Izračunaj veličinu"
+
+#: id:13394
+msgid "Calculating folder size"
+msgstr "Izračunavam veličinu mape"
+
+#: id:13395
+msgid "Video settings"
+msgstr "Video postavke"
+
+#: id:13396
+msgid "Audio and subtitle settings"
+msgstr "Postavke titlova i zvuka"
+
+#: id:13397
+msgid "Enable subtitles"
+msgstr "Omogući titlove"
+
+#: id:13398
+msgctxt "Auto context with id 13398"
+msgid "Shortcuts"
+msgstr "Prečaci"
+
+#: id:13399
+msgid "Ignore articles when sorting (e.g. \"the\")"
+msgstr "Zanemari artikle pri sortiranju"
+
+#: id:13400
+msgid "Crossfade between songs on the same album"
+msgstr "Pretapaj pjesame unutar istog albuma (crossfade)"
+
+#: id:13401
+msgid "Browse for %s"
+msgstr "Traži %s"
+
+#: id:13402
+msgid "Show track position"
+msgstr "Prikaži poziciju pjesme"
+
+#: id:13403
+msgid "Clear default"
+msgstr "Očisti zadano"
+
+#: id:13404
+msgid "Resume"
+msgstr "Nastavi"
+
+#: id:13405
+msgid "Get thumb"
+msgstr "Skini Thumb"
+
+#: id:13406
+msgid "Picture information"
+msgstr "Informacije slike"
+
+#: id:13407
+msgid "%s presets"
+msgstr "%s postavke"
+
+#: id:13408
+msgid "(IMDb user rating)"
+msgstr "(IMDb ocjene)"
+
+#: id:13409
+msgid "Top 250"
+msgstr "Top 250:"
+
+#: id:13410
+msgid "Tune in on Last.fm"
+msgstr ""
+
+#: id:13411
+msgid "Minimum fan speed"
+msgstr ""
+
+#: id:13412
+msgid "Play from here"
+msgstr ""
+
+#: id:13413
+msgid "Downloading"
+msgstr ""
+
+#: id:13414
+msgid "Include artists who appear only on compilations"
+msgstr ""
+
+#: id:13415
+msgctxt "Auto context with id 13415"
+msgid "Render method"
+msgstr ""
+
+#: id:13416
+msgid "Auto detect"
+msgstr ""
+
+#: id:13417
+msgid "Basic shaders (ARB)"
+msgstr ""
+
+#: id:13418
+msgid "Advanced shaders (GLSL)"
+msgstr ""
+
+#: id:13419
+msgid "Software"
+msgstr ""
+
+#: id:13420
+msgid "Remove safely"
+msgstr ""
+
+#: id:13421
+msgctxt "Auto context with id 13421"
+msgid "VDPAU"
+msgstr ""
+
+#: id:13422
+msgid "Start slideshow here"
+msgstr ""
+
+#: id:13423
+msgid "Remember for this path"
+msgstr ""
+
+#: id:13424
+msgid "Use pixel buffer objects"
+msgstr ""
+
+#: id:13425
+msgid "Allow hardware acceleration (VDPAU)"
+msgstr "Omogući hardware akceleraciju (VDPAU)"
+
+#: id:13426
+msgid "Allow hardware acceleration (VAAPI)"
+msgstr "Omogući hardware akceleraciju (VAAPI)"
+
+#: id:13427
+msgid "Allow hardware acceleration (DXVA2)"
+msgstr "Omogući hardware akceleraciju (DXVA2)"
+
+#: id:13428
+msgid "Allow hardware acceleration (CrystalHD)"
+msgstr "Omogući hardware akceleraciju (CrystalHD)"
+
+#: id:13429
+msgid "Allow hardware acceleration (VDADecoder)"
+msgstr "Omogući hardware akceleraciju (VDADecoder)"
+
+#: id:13430
+msgid "Allow hardware acceleration (OpenMax)"
+msgstr "Omogući hardware akceleraciju (OpenMax)"
+
+#: id:13431
+msgid "Pixel Shaders"
+msgstr ""
+
+#: id:13432
+msgid "Allow hardware acceleration (VideoToolbox)"
+msgstr ""
+
+#: id:13500
+msgid "A/V sync method"
+msgstr ""
+
+#: id:13501
+msgid "Audio clock"
+msgstr ""
+
+#: id:13502
+msgid "Video clock (Drop/Dupe audio)"
+msgstr ""
+
+#: id:13503
+msgid "Video clock (Resample audio)"
+msgstr ""
+
+#: id:13504
+msgid "Maximum resample amount (%)"
+msgstr ""
+
+#: id:13505
+msgid "Resample quality"
+msgstr ""
+
+#: id:13506
+msgid "Low(fast)"
+msgstr ""
+
+#: id:13507
+msgctxt "Auto context with id 13507"
+msgid "Medium"
+msgstr ""
+
+#: id:13508
+msgctxt "Auto context with id 13508"
+msgid "High"
+msgstr ""
+
+#: id:13509
+msgid "Really high(slow!)"
+msgstr ""
+
+#: id:13510
+msgid "Sync playback to display"
+msgstr ""
+
+#: id:13550
+msgid "Pause during refresh rate change"
+msgstr ""
+
+#: id:13551
+msgctxt "Auto context with id 13551"
+msgid "Off"
+msgstr ""
+
+#: id:13552
+msgid "%.1f Second"
+msgstr ""
+
+#: id:13553
+msgid "%.1f Seconds"
+msgstr ""
+
+#: id:13600
+msgid "Apple remote"
+msgstr ""
+
+#: id:13602
+msgid "Allow start of XBMC using the remote"
+msgstr ""
+
+#: id:13603
+msgid "Sequence delay time"
+msgstr ""
+
+#: id:13610
+msgctxt "Auto context with id 13610"
+msgid "Disabled"
+msgstr ""
+
+#: id:13611
+msgctxt "Auto context with id 13611"
+msgid "Standard"
+msgstr ""
+
+#: id:13612
+msgid "Universal Remote"
+msgstr ""
+
+#: id:13613
+msgid "Multi Remote (Harmony)"
+msgstr ""
+
+#: id:13620
+msgid "Apple Remote Error"
+msgstr ""
+
+#: id:13621
+msgid "Apple Remote support could be enabled."
+msgstr ""
+
+#: id:14000
+msgid "Stack"
+msgstr "Složi"
+
+#: id:14001
+msgid "Unstack"
+msgstr "Razbacaj"
+
+#: id:14003
+msgid "Downloading playlist file..."
+msgstr "Skidam datoteke playliste..."
+
+#: id:14004
+msgid "Downloading streams list..."
+msgstr "Skidam listu streamova..."
+
+#: id:14005
+msgid "Parsing streams list..."
+msgstr "Raščlanjivanje stream liste..."
+
+#: id:14006
+msgid "Downloading streams list failed"
+msgstr "Neuspješno skidanje liste streamova"
+
+#: id:14007
+msgid "Downloading playlist file failed"
+msgstr "Neuspješno skidanje datoteke playliste"
+
+#: id:14009
+msgid "Games directory"
+msgstr "Direktorij igara"
+
+#: id:14010
+msgid "Auto switch to thumbs based on"
+msgstr "Automatski izmjeni u thumbe prema"
+
+#: id:14011
+msgid "Enable auto switching to thumbs view"
+msgstr "Omogući autopromjenu u thumb prikaz"
+
+#: id:14012
+msgid "- Use large icons"
+msgstr "- Koristi Velike Ikone"
+
+#: id:14013
+msgid "- Switch based on"
+msgstr "- Promjena prema"
+
+#: id:14014
+msgid "- Percentage"
+msgstr "- Postotku"
+
+#: id:14015
+msgid "No files and at least one thumb"
+msgstr "Nema datoteka i barem jednog thumba"
+
+#: id:14016
+msgid "At least one file and thumb"
+msgstr "Barem jedna datoteka i thumba"
+
+#: id:14017
+msgid "Percentage of thumbs"
+msgstr "Postotak thumba"
+
+#: id:14018
+msgid "View options"
+msgstr "Pogledaj opcije"
+
+#: id:14019
+msgid "Change area code 1"
+msgstr "Promjeni Kod Zone 1"
+
+#: id:14020
+msgid "Change area code 2"
+msgstr "Promjeni Kod Zone 2"
+
+#: id:14021
+msgid "Change area code 3"
+msgstr "Promjeni Kod Zone 3"
+
+#: id:14022
+msgctxt "Auto context with id 14022"
+msgid "Library"
+msgstr "Library"
+
+#: id:14023
+msgid "No TV"
+msgstr "Nema TVa"
+
+#: id:14024
+msgid "Enter the nearest large town"
+msgstr "Upiši najbliži veći grad"
+
+#: id:14025
+msgid "Video/Audio/DVD cache - Harddisk"
+msgstr "Video/Audio/DVD Cache - Tvrdi disk"
+
+#: id:14026
+msgid "Video cache - DVD-ROM"
+msgstr "Video Cache - DVD-ROM"
+
+#: id:14027
+msgctxt "Auto context with id 14027"
+msgid "- Local Network"
+msgstr "- Lokalna Mreža"
+
+#: id:14028
+msgctxt "Auto context with id 14028"
+msgid "- Internet"
+msgstr "- Internet"
+
+#: id:14030
+msgid "Audio cache - DVD-ROM"
+msgstr "Audio Cache - DVD-ROM"
+
+#: id:14031
+msgctxt "Auto context with id 14031"
+msgid "- Local Network"
+msgstr "- Lokalna Mreža"
+
+#: id:14032
+msgctxt "Auto context with id 14032"
+msgid "- Internet"
+msgstr "- Internet"
+
+#: id:14034
+msgid "DVD cache - DVD-ROM"
+msgstr "DVD Cache - DVD-ROM"
+
+#: id:14035
+msgctxt "Auto context with id 14035"
+msgid "- Local Network"
+msgstr "- Lokalna Mreža"
+
+#: id:14036
+msgctxt "Auto context with id 14036"
+msgid "Services"
+msgstr "Serveri"
+
+#: id:14038
+msgid "Network settings changed"
+msgstr "Mrežne postavke izmjenjene"
+
+#: id:14039
+msgid "XBMC requires to restart to change your"
+msgstr "XBMC traži ponovno pokretanje zbog promjene"
+
+#: id:14040
+msgid "network setup. Would you like to restart now?"
+msgstr "mrežnih postavki. Želiš li to učiniti sad?"
+
+#: id:14041
+msgid "Internet connection bandwidth limitation"
+msgstr ""
+
+#: id:14043
+msgid "- Shutdown while playing"
+msgstr "- Ugasi pri sviranju/igranju"
+
+#: id:14044
+msgid "%i min"
+msgstr "%i mins"
+
+#: id:14045
+msgid "%i sec"
+msgstr "%i secs"
+
+#: id:14046
+msgid "%i ms"
+msgstr "%i ms"
+
+#: id:14047
+msgid "%i %%"
+msgstr "%i %%"
+
+#: id:14048
+msgid "%i kbps"
+msgstr "%i kbps"
+
+#: id:14049
+msgid "%i kb"
+msgstr "%i kb"
+
+#: id:14050
+msgid "%i.0 dB"
+msgstr "%i.0 dB"
+
+#: id:14051
+msgid "Time format"
+msgstr "Format vremena"
+
+#: id:14052
+msgid "Date format"
+msgstr "Format datuma"
+
+#: id:14053
+msgid "GUI filters"
+msgstr "GUI filtri"
+
+#: id:14055
+msgid "Use background scanning"
+msgstr "Koristi pozadinsko skeniranje"
+
+#: id:14056
+msgid "Stop scan"
+msgstr "Zaustavi skeniranje"
+
+#: id:14057
+msgid "Not possible while scanning for media info"
+msgstr "Nije moguće jer skeniram info. o media"
+
+#: id:14058
+msgid "Film grain effect"
+msgstr "Efekt zrnatosti slike"
+
+#: id:14059
+msgid "Search for thumbnails on remote shares"
+msgstr "Pogledaj thumb-e na udaljenom PC-u"
+
+#: id:14060
+msgid "Unknown type cache - Internet"
+msgstr "Nepoznati tip Cache-a - Internet"
+
+#: id:14061
+msgctxt "Auto context with id 14061"
+msgid "Auto"
+msgstr "Auto"
+
+#: id:14062
+msgid "Enter username for"
+msgstr "Upiši korisničko ime za"
+
+#: id:14063
+msgid "Date & time"
+msgstr "Datum & Vrijeme"
+
+#: id:14064
+msgid "Set date"
+msgstr "Postavi datum"
+
+#: id:14065
+msgid "Set time"
+msgstr "Postavi vrijeme"
+
+#: id:14066
+msgid "Enter the time in 24 hour HH:MM format"
+msgstr "Upiši vrijeme u 24h formatu HH:MM"
+
+#: id:14067
+msgid "Enter the date in DD/MM/YYYY format"
+msgstr "Upiši datum u formatu DD/MM/YYYY"
+
+#: id:14068
+msgid "Enter the IP address"
+msgstr "Unesi IP Adresu"
+
+#: id:14069
+msgid "Apply these settings now?"
+msgstr "Primjeni ove promjene sada?"
+
+#: id:14070
+msgid "Apply changes now"
+msgstr "Primjeni promjene sada"
+
+#: id:14071
+msgid "Allow file renaming and deletion"
+msgstr "Dozvoli preimenovanje i brisanje datoteka"
+
+#: id:14074
+msgid "Set timezone"
+msgstr "Postavi vremensku zonu"
+
+#: id:14075
+msgid "Use daylight saving time"
+msgstr "Koristi ljetno/zimsko računanje vremena"
+
+#: id:14076
+msgid "Add to favourites"
+msgstr "Dodaj u favorite"
+
+#: id:14077
+msgid "Remove from favourites"
+msgstr "Makni iz favorita"
+
+#: id:14078
+msgctxt "Auto context with id 14078"
+msgid "- Colours"
+msgstr "- Boje"
+
+#: id:14079
+msgid "Timezone country"
+msgstr "Vremenska zona države"
+
+#: id:14080
+msgid "Timezone"
+msgstr "Vremenska zona"
+
+#: id:14081
+msgid "File lists"
+msgstr ""
+
+#: id:14082
+msgid "Show EXIF picture information"
+msgstr ""
+
+#: id:14083
+msgid "Use a fullscreen window rather than true fullscreen"
+msgstr "Radije koristi \"fullscreen ekran\" nego \"fullscreen\" (uključiti ako XBMC gubi fokus)"
+
+#: id:14084
+msgid "Queue songs on selection"
+msgstr ""
+
+#: id:14086
+msgid "Playback"
+msgstr "Reprodukcija"
+
+#: id:14087
+msgid "DVDs"
+msgstr "DVD"
+
+#: id:14088
+msgid "Play DVDs automatically"
+msgstr "Automatski reproduciraj DVD"
+
+#: id:14089
+msgid "Font to use for text subtitles"
+msgstr "Font titlova"
+
+#: id:14090
+msgid "International"
+msgstr "Internacionalno"
+
+#: id:14091
+msgid "Character set"
+msgstr "Skup znakova"
+
+#: id:14092
+msgid "Debugging"
+msgstr ""
+
+#: id:14093
+msgid "Security"
+msgstr "Sigurnost"
+
+#: id:14094
+msgid "Input devices"
+msgstr "Ulazni uređaji"
+
+#: id:14095
+msgid "Power saving"
+msgstr "Ušteda energije"
+
+#: id:14096
+msgid "Rip"
+msgstr ""
+
+#: id:14097
+msgid "Audio CD Insert Action"
+msgstr ""
+
+#: id:14098
+msgctxt "Auto context with id 14098"
+msgid "Play"
+msgstr ""
+
+#: id:14099
+msgid "Eject disc when CD ripping is complete"
+msgstr ""
+
+#: id:15015
+msgctxt "Auto context with id 15015"
+msgid "Remove"
+msgstr "Makni"
+
+#: id:15016
+msgid "Games"
+msgstr "Igre"
+
+#: id:15019
+msgid "Add"
+msgstr "Dodaj"
+
+#: id:15052
+msgid "Password"
+msgstr "Zaporka"
+
+#: id:15100
+msgctxt "Auto context with id 15100"
+msgid "Library"
+msgstr "Library"
+
+#: id:15101
+msgid "Database"
+msgstr "Baza Podataka"
+
+#: id:15102
+msgid "* All albums"
+msgstr "* Svi Albumi"
+
+#: id:15103
+msgid "* All artists"
+msgstr "* Svi Izvođači"
+
+#: id:15104
+msgid "* All songs"
+msgstr "* Sve Pjesme"
+
+#: id:15105
+msgid "* All genres"
+msgstr "* Svi Žanrovi"
+
+#: id:15107
+msgid "Buffering..."
+msgstr "Buffering..."
+
+#: id:15108
+msgid "Navigation sounds"
+msgstr "Zvukovi navigacije"
+
+#: id:15109
+msgid "Skin default"
+msgstr "Default skin"
+
+#: id:15111
+msgid "- Theme"
+msgstr "Tema skina"
+
+#: id:15112
+msgid "Default theme"
+msgstr "Zadana tema"
+
+#: id:15200
+msgid "Last.fm"
+msgstr "Last.FM"
+
+#: id:15201
+msgid "Submit songs to Last.fm"
+msgstr "Dostavi pjesme na Last.FM"
+
+#: id:15202
+msgid "Last.fm username"
+msgstr "Last.FM Korisničko Ime"
+
+#: id:15203
+msgid "Last.fm password"
+msgstr "Last.FM Zaporka"
+
+#: id:15204
+msgid "Unable to handshake: sleeping..."
+msgstr "Ne mogu se rukovati: spavam..."
+
+#: id:15205
+msgid "Please update XBMC"
+msgstr "Molim update XBMC"
+
+#: id:15206
+msgid "Bad authorization: Check username and password"
+msgstr "Loša autorizacija: Provjeri korisničko ime i zaporku"
+
+#: id:15207
+msgctxt "Auto context with id 15207"
+msgid "Connected"
+msgstr "Spojen"
+
+#: id:15208
+msgid "Not connected"
+msgstr "Nije spojen"
+
+#: id:15209
+msgid "Submit interval %i"
+msgstr "Dostavni interval %i"
+
+#: id:15210
+msgid "Cached %i songs"
+msgstr "Cached %i pjesme"
+
+#: id:15211
+msgid "Submitting..."
+msgstr "Dostavljam..."
+
+#: id:15212
+msgid "Submitting in %i secs"
+msgstr "Dostavljam u %i secs"
+
+#: id:15213
+msgid "Play using..."
+msgstr "Sviraj/Igraj koristeći..."
+
+#: id:15214
+msgid "Use smoothed A/V synchronization"
+msgstr "Koristi glatku A/V sinkronizaciju"
+
+#: id:15215
+msgid "Hide file names in thumbs view"
+msgstr "Sakrij imena datoteka u pogledu: Thumbs"
+
+#: id:15216
+msgid "Play in party mode"
+msgstr "Sviraj/Igraj u \"Party\" režimu"
+
+#: id:15217
+msgid "Submit songs to Libre.fm"
+msgstr "Dostavi pjesme libre.fm"
+
+#: id:15218
+msgid "Libre.fm username"
+msgstr "libre.fm korisničko ime"
+
+#: id:15219
+msgid "Libre.fm password"
+msgstr "libre.fm zaporka"
+
+#: id:15220
+msgid "Libre.fm"
+msgstr ""
+
+#: id:15221
+msgid "Song submission"
+msgstr ""
+
+#: id:15250
+msgid "Submit Last.fm radio to Last.fm"
+msgstr "Dostavi Last.fm radio Last.fm-u"
+
+#: id:15251
+msgid "Connecting to Last.fm..."
+msgstr "Spajam se na Last.FM..."
+
+#: id:15252
+msgid "Selecting station..."
+msgstr "Odabirem stanicu..."
+
+#: id:15253
+msgid "Search similar artists..."
+msgstr "Traži slične izvođače..."
+
+#: id:15254
+msgid "Search similar tags..."
+msgstr "Traži slične oznake..."
+
+#: id:15255
+msgid "Your profile (%name%)"
+msgstr "Tvoj profil (%name%)"
+
+#: id:15256
+msgid "Overall top tags"
+msgstr "Sveukupne top oznake"
+
+#: id:15257
+msgid "Top artists for tag %name%"
+msgstr "Top izvođači za oznaku %name%"
+
+#: id:15258
+msgid "Top albums for tag %name%"
+msgstr "Top albumi za oznaku %name%"
+
+#: id:15259
+msgid "Top tracks for tag %name%"
+msgstr "Top stvari za oznaku %name%"
+
+#: id:15260
+msgid "Listen to tag %name% Last.fm radio"
+msgstr "Slušaj oznaku %name% Last.FM radio"
+
+#: id:15261
+msgid "Similar artists as %name%"
+msgstr "Slični izvođači kao %name%"
+
+#: id:15262
+msgid "Top %name% albums"
+msgstr "Top %name% albumi"
+
+#: id:15263
+msgid "Top %name% tracks"
+msgstr "Top %name% stvari"
+
+#: id:15264
+msgid "Top %name% tags"
+msgstr "Top %name% oznake"
+
+#: id:15265
+msgid "Biggest fans of %name%"
+msgstr "Najveći obožavalac %name%"
+
+#: id:15266
+msgid "Listen to %name% fans Last.fm radio"
+msgstr "Slušaj %name% obožavalac Last.FM radio"
+
+#: id:15267
+msgid "Listen to %name% similar artists Last.fm radio"
+msgstr "Slušaj %name% slične izvođače Last.FM radia"
+
+#: id:15268
+msgid "Top artists for user %name%"
+msgstr "Top izvođači za korisnika %name%"
+
+#: id:15269
+msgid "Top albums for user %name%"
+msgstr "Top albumi za korisnika %name%"
+
+#: id:15270
+msgid "Top tracks for user %name%"
+msgstr "Top stvari za korisnika %name%"
+
+#: id:15271
+msgid "Friends of user %name%"
+msgstr "Prijatelji korisnika %name%"
+
+#: id:15272
+msgid "Neighbours of user %name%"
+msgstr "Susjedi korisnika %name%"
+
+#: id:15273
+msgid "Weekly artist chart for %name%"
+msgstr "Tjedna ljestvica za %name%"
+
+#: id:15274
+msgid "Weekly album chart for %name%"
+msgstr "Tjedna ljestvica albuma za %name%"
+
+#: id:15275
+msgid "Weekly track chart for %name%"
+msgstr "Tjedna ljestvica stvari za %name%"
+
+#: id:15276
+msgid "Listen to %name%'s neighbours Last.fm radio"
+msgstr "Slušaj %name%'s susjedov Last.FM radio"
+
+#: id:15277
+msgid "Listen to %name%'s personal Last.fm radio"
+msgstr "Slušaj %name%'s privatni Last.FM radio"
+
+#: id:15278
+msgid "Listen to %name%'s mix Last.fm radio"
+msgstr "Slušaj %name%'s voljene stvari sa Last.FM radia"
+
+#: id:15279
+msgid "Retrieving list from Last.fm..."
+msgstr "Dobivam listu sa Last.FM..."
+
+#: id:15280
+msgid "Can't retrieve list from Last.fm..."
+msgstr "Ne mogu dobiti listu sa Last.FM..."
+
+#: id:15281
+msgid "Enter an artist name to find related ones"
+msgstr "Upiši ime izvođača i pronađi slične"
+
+#: id:15282
+msgid "Enter a tag name to find similar ones"
+msgstr "Upiši ime oznake i pronađi slične"
+
+#: id:15283
+msgid "Tracks recently listened by %name%"
+msgstr "Nedavno slušane stvari po %name%"
+
+#: id:15284
+msgid "Listen to %name%'s recommendations Last.fm radio"
+msgstr "Slušaj %name%'s preporuke Last.FM radia"
+
+#: id:15285
+msgid "Top tags for user %name%"
+msgstr "Top oznake korisnika %name%"
+
+#: id:15287
+msgid "Do you want to add the current track to your loved tracks?"
+msgstr "Želiš li dodati trenutnu stvar voljenim stvarima?"
+
+#: id:15288
+msgid "Do you want to ban the current track?"
+msgstr "Želiš li zabraniti trenutnu stvar?"
+
+#: id:15289
+msgid "Added to your loved tracks: '%s'."
+msgstr "Dodano tvojim voljenim stvarima: '%s'."
+
+#: id:15290
+msgid "Could not add '%s' to your loved tracks."
+msgstr "Ne mogu dodati '%s' tvojim voljenim stvarima."
+
+#: id:15291
+msgid "Banned: '%s'."
+msgstr "Zabranjeno: '%s'."
+
+#: id:15292
+msgid "Could not ban '%s'."
+msgstr "Ne mogu zabraniti '%s'."
+
+#: id:15293
+msgid "Tracks recently loved by %name%"
+msgstr "Nedavne Stvari obožavane od %name%"
+
+#: id:15294
+msgid "Tracks recently banned by %name%"
+msgstr "Stvari nedavno zabranjene od %name%"
+
+#: id:15295
+msgid "Remove from loved tracks"
+msgstr "Makni iz vojenih stvari"
+
+#: id:15296
+msgid "Un-ban"
+msgstr "Dozvoli"
+
+#: id:15297
+msgid "Do you want to remove this track from your loved tracks?"
+msgstr "Da li želiš maknuti ovu stvar i voljenih stvari?"
+
+#: id:15298
+msgid "Do you want to un-ban this track?"
+msgstr "Da li želiš dozvoliti ovu stvar?"
+
+#: id:15300
+msgid "Path not found or invalid"
+msgstr "Putanja nije pronađena ili neispravna"
+
+#: id:15301
+msgid "Could not connect to network server"
+msgstr "Ne mogu se spojiti na mrežni server"
+
+#: id:15302
+msgid "No servers found"
+msgstr "Nijedan server nije pronađen"
+
+#: id:15303
+msgid "Workgroup not found"
+msgstr "Workgroup nije pronađen"
+
+#: id:15310
+msgid "Opening multi-path source"
+msgstr "Otvaranje multi izvora"
+
+#: id:15311
+msgid "Path:"
+msgstr "Putanja:"
+
+#: id:16000
+msgctxt "Auto context with id 16000"
+msgid "General"
+msgstr "Općenito"
+
+#: id:16002
+msgid "Internet lookup"
+msgstr "CDDB traženje"
+
+#: id:16003
+msgid "Player"
+msgstr "Svirač"
+
+#: id:16004
+msgid "Play media from disc"
+msgstr "Pokreni mediu sa diska"
+
+#: id:16008
+msgid "Enter new title"
+msgstr "Upiši novi naslov"
+
+#: id:16009
+msgid "Enter the movie name"
+msgstr "Upiši nazvi filma"
+
+#: id:16010
+msgid "Enter the profile name"
+msgstr "Upiši naziv profila"
+
+#: id:16011
+msgid "Enter the album name"
+msgstr "Upiši Naziv albuma"
+
+#: id:16012
+msgid "Enter the playlist name"
+msgstr "Upiši naziv playliste"
+
+#: id:16013
+msgid "Enter new filename"
+msgstr "Upiši naziv datoteke"
+
+#: id:16014
+msgid "Enter folder name"
+msgstr "Upiši ime mape"
+
+#: id:16015
+msgid "Enter directory"
+msgstr "Upiši direktorij"
+
+#: id:16016
+msgid "Available options: %A, %T, %N, %B, %D, %G, %Y, %F, %S"
+msgstr "Dostupne opcije: %A, %T, %N, %B, %D, %G, %Y, %F, %S"
+
+#: id:16017
+msgid "Enter search string"
+msgstr "Upiši string za pretraživanje"
+
+#: id:16018
+msgctxt "Auto context with id 16018"
+msgid "None"
+msgstr "Ništa"
+
+#: id:16019
+msgid "Auto select"
+msgstr "Odaberi autom."
+
+#: id:16020
+msgid "De-interlace"
+msgstr "Deinterlace"
+
+#: id:16021
+msgid "Bob"
+msgstr "Bob"
+
+#: id:16022
+msgid "Bob (inverted)"
+msgstr "Bob (Inverted)"
+
+#: id:16024
+msgid "Canceling..."
+msgstr "Poništavanje..."
+
+#: id:16025
+msgid "Enter the artist name"
+msgstr "Upiši naziv izvođača"
+
+#: id:16026
+msgid "Playback failed"
+msgstr "Sviranje playliste prekinuto"
+
+#: id:16027
+msgid "One or more items failed to play."
+msgstr "Neuspješno reproduciranje jedne ili više stavki"
+
+#: id:16028
+msgid "Enter value"
+msgstr ""
+
+#: id:16029
+msgid "Check the log file for details."
+msgstr ""
+
+#: id:16030
+msgid "Party mode aborted."
+msgstr "\"Party\" režim prekinut."
+
+#: id:16031
+msgid "No matching songs in the library."
+msgstr "Nema istih pjesama u library."
+
+#: id:16032
+msgid "Could not initialize database."
+msgstr "Ne mogu započeti bazu podataka."
+
+#: id:16033
+msgid "Could not open database."
+msgstr "Ne mogu otvoriti bazu podataka."
+
+#: id:16034
+msgid "Could not get songs from database."
+msgstr "Ne mogu dobiti pjesme iz baze podataka."
+
+#: id:16035
+msgid "Party mode playlist"
+msgstr "\"Party\" režim playlista"
+
+#: id:16036
+msgid "De-interlace (Half)"
+msgstr ""
+
+#: id:16037
+msgid "Deinterlace video"
+msgstr ""
+
+#: id:16038
+msgid "Deinterlace method"
+msgstr ""
+
+#: id:16039
+msgctxt "Auto context with id 16039"
+msgid "Off"
+msgstr ""
+
+#: id:16040
+msgctxt "Auto context with id 16040"
+msgid "Auto"
+msgstr ""
+
+#: id:16041
+msgid "On"
+msgstr ""
+
+#: id:16100
+msgid "All Videos"
+msgstr "Sav video"
+
+#: id:16101
+msgid "Unwatched"
+msgstr "Nepogledano"
+
+#: id:16102
+msgid "Watched"
+msgstr "Pogledano"
+
+#: id:16103
+msgid "Mark as watched"
+msgstr "Označi kao pogledano"
+
+#: id:16104
+msgid "Mark as unwatched"
+msgstr "Označi kao nepogledano"
+
+#: id:16105
+msgid "Edit title"
+msgstr "Uredi naslov"
+
+#: id:16200
+msgid "Operation was aborted"
+msgstr "Operacija je prekinuta"
+
+#: id:16201
+msgid "Copy failed"
+msgstr "Kopiranje neuspješno"
+
+#: id:16202
+msgid "Failed to copy at least one file"
+msgstr "Neuspješno kopiranje barem jedne datoteke"
+
+#: id:16203
+msgid "Move failed"
+msgstr "Neuspješno micanje"
+
+#: id:16204
+msgid "Failed to move at least one file"
+msgstr "Neuspješno micanje barem jedne datoteke"
+
+#: id:16205
+msgid "Delete failed"
+msgstr "Neuspješno brisanje"
+
+#: id:16206
+msgid "Failed to delete at least one file"
+msgstr "Neuspješno brisanje barem jedne datoteke"
+
+#: id:16300
+msgid "Video scaling method"
+msgstr ""
+
+#: id:16301
+msgid "Nearest neighbour"
+msgstr ""
+
+#: id:16302
+msgid "Bilinear"
+msgstr ""
+
+#: id:16303
+msgctxt "Auto context with id 16303"
+msgid "Bicubic"
+msgstr ""
+
+#: id:16304
+msgid "Lanczos2"
+msgstr ""
+
+#: id:16305
+msgid "Lanczos3"
+msgstr ""
+
+#: id:16306
+msgid "Sinc8"
+msgstr ""
+
+#: id:16307
+msgid "Bicubic (software)"
+msgstr ""
+
+#: id:16308
+msgid "Lanczos (software)"
+msgstr ""
+
+#: id:16309
+msgid "Sinc (software)"
+msgstr ""
+
+#: id:16310
+msgid "Temporal"
+msgstr ""
+
+#: id:16311
+msgid "Temporal/Spatial"
+msgstr ""
+
+#: id:16312
+msgid "(VDPAU)Noise Reduction"
+msgstr ""
+
+#: id:16313
+msgid "(VDPAU)Sharpness"
+msgstr ""
+
+#: id:16314
+msgid "Inverse Telecine"
+msgstr ""
+
+#: id:16315
+msgid "Lanczos3 optimized"
+msgstr ""
+
+#: id:16316
+msgctxt "Auto context with id 16316"
+msgid "Auto"
+msgstr ""
+
+#: id:16317
+msgid "Temporal (Half)"
+msgstr ""
+
+#: id:16318
+msgid "Temporal/Spatial (Half)"
+msgstr ""
+
+#: id:16319
+msgid "DXVA"
+msgstr ""
+
+#: id:16320
+msgid "DXVA Bob"
+msgstr ""
+
+#: id:16321
+msgid "DXVA Best"
+msgstr ""
+
+#: id:16322
+msgid "Spline36"
+msgstr ""
+
+#: id:16323
+msgid "Spline36 optimized"
+msgstr ""
+
+#: id:16324
+msgid "Software Blend"
+msgstr ""
+
+#: id:16400
+msgid "Post-processing"
+msgstr ""
+
+#: id:17500
+msgid "Display sleep timeout"
+msgstr ""
+
+#: id:19000
+msgid "Switch to channel"
+msgstr ""
+
+#: id:20000
+msgid "Saved music folder"
+msgstr "Mapa pohranjene glazbe"
+
+#: id:20001
+msgid "Use external DVD player"
+msgstr "Koristi vanjski DVD player"
+
+#: id:20002
+msgid "External DVD player"
+msgstr "Vanjski DVD player"
+
+#: id:20003
+msgid "Trainers folder"
+msgstr "Mapa Trainera"
+
+#: id:20004
+msgid "Screenshot folder"
+msgstr "Mapa screenshot-a"
+
+#: id:20006
+msgid "Playlists folder"
+msgstr "Mapa playliste"
+
+#: id:20007
+msgid "Recordings"
+msgstr "Snimke"
+
+#: id:20008
+msgid "Screenshots"
+msgstr "Screenshots"
+
+#: id:20009
+msgid "Use XBMC"
+msgstr "Koristi XBMC"
+
+#: id:20011
+msgid "Music playlists"
+msgstr "Playliste glazbe"
+
+#: id:20012
+msgid "Video playlists"
+msgstr "Video playliste"
+
+#: id:20013
+msgid "Do you wish to launch the game?"
+msgstr "Želiš li pokrenuti igru?"
+
+#: id:20014
+msgid "Sort by: Playlist"
+msgstr "Složi po: Playlisti"
+
+#: id:20015
+msgid "Remote thumb"
+msgstr "Udanjeni thumb"
+
+#: id:20016
+msgid "Current thumb"
+msgstr "Trenutni thumb"
+
+#: id:20017
+msgid "Local thumb"
+msgstr "Lokalni thumb"
+
+#: id:20018
+msgid "No thumb"
+msgstr "Bez thumb-a"
+
+#: id:20019
+msgid "Choose thumbnail"
+msgstr "Odaberi thumb"
+
+#: id:20023
+msgid "Conflict"
+msgstr "Konflikt"
+
+#: id:20024
+msgid "Scan new"
+msgstr "Skeniraj novi"
+
+#: id:20025
+msgid "Scan all"
+msgstr "Skeniraj sve"
+
+#: id:20026
+msgid "Region"
+msgstr "Regija"
+
+#: id:20037
+msgid "Summary"
+msgstr "Sažetak"
+
+#: id:20038
+msgid "Lock music window"
+msgstr "Zaključaj prozor glazbe"
+
+#: id:20039
+msgid "Lock videos window"
+msgstr "Zaključaj video prozor"
+
+#: id:20040
+msgid "Lock pictures window"
+msgstr "Zaključaj prozor slika"
+
+#: id:20041
+msgid "Lock programs & scripts windows"
+msgstr "Zaključaj programe, igr. snimke & prozor skripti"
+
+#: id:20042
+msgid "Lock file manager"
+msgstr "Zaključaj upravitelj dat."
+
+#: id:20043
+msgid "Lock settings"
+msgstr "Zaključaj postavke"
+
+#: id:20044
+msgid "Start fresh"
+msgstr "Nanovo pokreni"
+
+#: id:20045
+msgid "Enter master mode"
+msgstr "Uđi u \"Glavni način\""
+
+#: id:20046
+msgid "Leave master mode"
+msgstr "Izađi iz \"Glavnog načina\""
+
+#: id:20047
+msgid "Create profile '%s'?"
+msgstr "Stvori profil '%s' ?"
+
+#: id:20048
+msgid "Start with fresh settings"
+msgstr "Započni s novim postavkama"
+
+#: id:20049
+msgid "Best available"
+msgstr "Najbolje dostupno"
+
+#: id:20050
+msgid "Auto-switch between 16x9 and 4x3"
+msgstr "Autopromjeni sa 16x9 na 4x3"
+
+#: id:20051
+msgid "Treat stacked files as single file"
+msgstr "Tretiraj spojene datoteke kao jednu datoteku"
+
+#: id:20052
+msgid "Caution"
+msgstr "Oprez"
+
+#: id:20053
+msgid "Left master mode"
+msgstr "Izađi iz \"Gavnog načina\""
+
+#: id:20054
+msgid "Entered master mode"
+msgstr "Ušao si u \"Glavni način\""
+
+#: id:20055
+msgid "Allmusic.com thumb"
+msgstr "Allmusic.com thumbs"
+
+#: id:20057
+msgid "Remove thumbnail"
+msgstr "Makni thumb"
+
+#: id:20058
+msgid "Add profile..."
+msgstr "Dodaj profil..."
+
+#: id:20059
+msgid "Query info for all albums"
+msgstr "Izvrši upite za info od svih albuma"
+
+#: id:20060
+msgctxt "Auto context with id 20060"
+msgid "Media info"
+msgstr "Media info"
+
+#: id:20061
+msgctxt "Auto context with id 20061"
+msgid "Separate"
+msgstr "Odvojeno"
+
+#: id:20062
+msgid "Shares with default"
+msgstr "Dijeliti sa zadanim"
+
+#: id:20063
+msgid "Shares with default (read only)"
+msgstr "Dijeliti sa zadanim (read only)"
+
+#: id:20064
+msgid "Copy default"
+msgstr "Kopiraj zadano"
+
+#: id:20065
+msgid "Profile picture"
+msgstr "Slika Profila"
+
+#: id:20066
+msgid "Lock preferences"
+msgstr "Zaključaj Prioritete"
+
+#: id:20067
+msgid "Edit profile"
+msgstr "Uredi profil"
+
+#: id:20068
+msgid "Profile lock"
+msgstr "Zaključaj profil"
+
+#: id:20069
+msgid "Could not create folder"
+msgstr "Ne mogu stvoriti mapu"
+
+#: id:20070
+msgid "Profile directory"
+msgstr "Profil direktorija"
+
+#: id:20071
+msgid "Start with fresh media sources"
+msgstr "Počni sa sviježim media izvorima"
+
+#: id:20072
+msgid "Make sure the selected folder is writable"
+msgstr "Budite sigurni da možeš pisati u odabranoj mapi"
+
+#: id:20073
+msgid "and that the new folder name is valid"
+msgstr "i da je novo ime mape valjano"
+
+#: id:20074
+msgid "MPAA rating"
+msgstr "MPAA Ocjena:"
+
+#: id:20075
+msgid "Enter master lock code"
+msgstr "Upiši Glavni kod ključa"
+
+#: id:20076
+msgid "Ask for master lock code on startup"
+msgstr "Pitaj za Glavni kod ključa pri početku"
+
+#: id:20077
+msgid "Skin settings"
+msgstr "Postavke skina"
+
+#: id:20078
+msgid "- no link set -"
+msgstr "- nije postavljena veza -"
+
+#: id:20079
+msgid "Enable animations"
+msgstr "Omogući animacije"
+
+#: id:20080
+msgid "Disable RSS during music"
+msgstr "Onemogući RSS kanale pri sviranju"
+
+#: id:20081
+msgid "Enable shortcut buttons"
+msgstr "Omogući gumbe prečaca"
+
+#: id:20082
+msgid "Show programs in main menu"
+msgstr "Prikaži programe u glavnom izborniku"
+
+#: id:20083
+msgid "Show music info"
+msgstr "Prikaži info o glazbi"
+
+#: id:20084
+msgid "Show weather info"
+msgstr "Prikaži info o vremenskoj prognozi"
+
+#: id:20085
+msgid "Show system info"
+msgstr "Prikaži info o sistemu"
+
+#: id:20086
+msgid "Show available disc space C: E: F:"
+msgstr "Prikaži dostupni diskovni prostor na C: E: F:"
+
+#: id:20087
+msgid "Show available disc space E: F: G:"
+msgstr "Prikaži dostupni diskovni prostor na E: F: G:"
+
+#: id:20088
+msgid "Weather info"
+msgstr "Info vremenske prognoze"
+
+#: id:20089
+msgid "Drive space free"
+msgstr "Slobodan prostor na disku"
+
+#: id:20090
+msgid "Enter the name of an existing share"
+msgstr "Upiši ime postojeće djeljene mape/diska"
+
+#: id:20091
+msgid "Lock code"
+msgstr "Kod ključa"
+
+#: id:20092
+msgid "Load profile"
+msgstr "Učitaj profil"
+
+#: id:20093
+msgid "Profile name"
+msgstr "Ime profila"
+
+#: id:20094
+msgctxt "Auto context with id 20094"
+msgid "Media sources"
+msgstr "Media izvori"
+
+#: id:20095
+msgid "Enter profile lock code"
+msgstr "Upiši kod ključa profila"
+
+#: id:20096
+msgctxt "Auto context with id 20096"
+msgid "Login screen"
+msgstr "Ekran prijave"
+
+#: id:20097
+msgid "Fetching album info"
+msgstr "Dobavljam info albuma"
+
+#: id:20098
+msgid "Fetching info for album"
+msgstr "Dobavljam info za album"
+
+#: id:20099
+msgid "Can't rip CD or track while playing from CD"
+msgstr "Ne mogu Ripati CD ili stavku ako se ista trenutno reproducira sa CDa"
+
+#: id:20100
+msgid "Master lock code and settings"
+msgstr "Glavni kod ključa i postavke"
+
+#: id:20101
+msgid "Entering master lock code always enables master mode"
+msgstr "Upisivanje glavnog ključa uvijek omogućuje Glavni način rada"
+
+#: id:20102
+msgid "or copy from default?"
+msgstr "ili kopiraj iz zadanog?"
+
+#: id:20103
+msgid "Save changes to profile?"
+msgstr "Spremi izmjene u profil?"
+
+#: id:20104
+msgid "Old settings found."
+msgstr "Pronađene starije postavke."
+
+#: id:20105
+msgid "Do you want to use them?"
+msgstr "Želiš li ih koristiti?"
+
+#: id:20106
+msgid "Old media sources found."
+msgstr "Stari media izvori pronađeni."
+
+#: id:20107
+msgid "Separate (locked)"
+msgstr "Odvoji (zaključano)"
+
+#: id:20108
+msgid "Root"
+msgstr "Korijenski"
+
+#: id:20109
+msgid "- Zoom"
+msgstr "- Zoom"
+
+#: id:20110
+msgid "UPnP settings"
+msgstr "Postavke UPnP"
+
+#: id:20111
+msgid "Autostart UPnP client"
+msgstr "Autopokreni UPnP klijent"
+
+#: id:20112
+msgid "Last login: %s"
+msgstr "Zadnja prijava: %s"
+
+#: id:20113
+msgid "Never logged on"
+msgstr "Nikad se nisi prijavio"
+
+#: id:20114
+msgid "Profile %i / %i"
+msgstr "Profil %i / %i"
+
+#: id:20115
+msgid "User login / Select a profile"
+msgstr "Korisnička prijava / Odaberi profil"
+
+#: id:20116
+msgid "Use lock on login screen"
+msgstr "Koristi ključ pri zaslonu prijave"
+
+#: id:20117
+msgid "Invalid lock code."
+msgstr "Nevaljan kod ključa."
+
+#: id:20118
+msgid "This requires the master lock to be set."
+msgstr "Ovo zahtjeva postavku Glavnog ključa."
+
+#: id:20119
+msgid "Would you like to set it now?"
+msgstr "Želiš li ga postaviti sada?"
+
+#: id:20120
+msgid "Loading program information"
+msgstr "Učitavam Program info"
+
+#: id:20121
+msgid "Party on!"
+msgstr "Zabava!"
+
+#: id:20122
+msgid "True"
+msgstr "Istina"
+
+#: id:20123
+msgid "Mixing drinks"
+msgstr "Mješam pića"
+
+#: id:20124
+msgid "Filling glasses"
+msgstr "Punim čaše"
+
+#: id:20125
+msgid "Logged on as"
+msgstr "Prijavljen kao"
+
+#: id:20126
+msgid "Log off"
+msgstr "Odjavi se"
+
+#: id:20128
+msgid "Go to root"
+msgstr "Idi na korijen"
+
+#: id:20129
+msgid "Weave"
+msgstr "Tkanje"
+
+#: id:20130
+msgid "Weave (inverted)"
+msgstr "Tkanje (okrenuto)"
+
+#: id:20131
+msgid "Blend"
+msgstr "Uklopi"
+
+#: id:20132
+msgid "Restart video"
+msgstr "Restart video"
+
+#: id:20133
+msgid "Edit network location"
+msgstr "Uredi lokaciju mreže"
+
+#: id:20134
+msgid "Remove network location"
+msgstr "Makni lokaciju mreže"
+
+#: id:20135
+msgid "Do you want to scan the folder?"
+msgstr "Želiš li skenirati mapu?"
+
+#: id:20136
+msgid "Memory unit"
+msgstr "Memorijska jedinica"
+
+#: id:20137
+msgid "Memory unit mounted"
+msgstr "Memorijska jedinica ubačena"
+
+#: id:20138
+msgid "Unable to mount memory unit"
+msgstr "Ne mogu ubaciti memorijsku Jedinicu"
+
+#: id:20139
+msgid "In port %i, slot %i"
+msgstr "U ulazu %i, utor %i"
+
+#: id:20140
+msgid "Lock screensaver"
+msgstr "Zaključaj screensaver"
+
+#: id:20141
+msgid "Set"
+msgstr "Postavi"
+
+#: id:20142
+msgctxt "Auto context with id 20142"
+msgid "Username"
+msgstr "Korisničko Ime"
+
+#: id:20143
+msgid "Enter password for"
+msgstr "Upiši zaporku za"
+
+#: id:20144
+msgid "Shutdown timer"
+msgstr "Vrijeme gašenja"
+
+#: id:20145
+msgid "Shutdown interval (in minutes)"
+msgstr "Interval vremena gašenja (u minutama)"
+
+#: id:20146
+msgid "Started, shutdown in %im"
+msgstr "Pokrenuto, gašenje za %im"
+
+#: id:20147
+msgid "Shutdown in 30 minutes"
+msgstr "Gašenje za 30 minuta"
+
+#: id:20148
+msgid "Shutdown in 60 minutes"
+msgstr "Gašenje za 60 minuta"
+
+#: id:20149
+msgid "Shutdown in 120 minutes"
+msgstr "Gašenje za 120 minuta"
+
+#: id:20150
+msgid "Custom shutdown timer"
+msgstr "Vlastito vrijeme gašenja"
+
+#: id:20151
+msgid "Cancel shutdown timer"
+msgstr "Poništi vrijeme gašenja"
+
+#: id:20152
+msgid "Lock preferences for %s"
+msgstr "Zaključaj postavke za %s"
+
+#: id:20153
+msgid "Browse..."
+msgstr "Traži..."
+
+#: id:20154
+msgid "Summary information"
+msgstr "Osnovne informacije"
+
+#: id:20155
+msgid "Storage information"
+msgstr "Informacije o pohrani"
+
+#: id:20156
+msgid "Hard disk information"
+msgstr "Informacije o hard disku"
+
+#: id:20157
+msgid "DVD-ROM information"
+msgstr "Informacije o DVD-ROMu"
+
+#: id:20158
+msgid "Network information"
+msgstr "Informacije o mreži"
+
+#: id:20159
+msgid "Video information"
+msgstr "Video informacije"
+
+#: id:20160
+msgid "Hardware information"
+msgstr "Informacije o hardware-u"
+
+#: id:20161
+msgid "Total"
+msgstr "Ukupno"
+
+#: id:20162
+msgid "Used"
+msgstr "Korišteno"
+
+#: id:20163
+msgid "of"
+msgstr "iz"
+
+#: id:20164
+msgid "Locking not supported"
+msgstr "Zaključavanja nije podržano"
+
+#: id:20165
+msgid "Not locked"
+msgstr "Nije zaključano"
+
+#: id:20166
+msgid "Locked"
+msgstr "Zaključano"
+
+#: id:20167
+msgid "Frozen"
+msgstr "Smrznuto"
+
+#: id:20168
+msgid "Requires reset"
+msgstr "Potreban je reset"
+
+#: id:20169
+msgid "Week"
+msgstr "Tjedan"
+
+#: id:20170
+msgid "Line"
+msgstr "Linija"
+
+#: id:20171
+msgid "Windows network (SMB)"
+msgstr "Windows mreža (SMB)"
+
+#: id:20172
+msgid "XBMSP server"
+msgstr "XBMSP server"
+
+#: id:20173
+msgctxt "Auto context with id 20173"
+msgid "FTP server"
+msgstr "FTP server"
+
+#: id:20174
+msgid "iTunes music share (DAAP)"
+msgstr "iTunes djeljenje glazbe (DAAP)"
+
+#: id:20175
+msgid "UPnP server"
+msgstr "UPnP server"
+
+#: id:20176
+msgid "Show video info"
+msgstr "Prikaži video info"
+
+#: id:20177
+msgid "Done"
+msgstr "Gotovo"
+
+#: id:20178
+msgid "Shift"
+msgstr "Shift"
+
+#: id:20179
+msgid "Caps Lock"
+msgstr "Velika Slova"
+
+#: id:20180
+msgid "Symbols"
+msgstr "Simboli"
+
+#: id:20181
+msgid "Backspace"
+msgstr "Briši"
+
+#: id:20182
+msgid "Space"
+msgstr "Razmak"
+
+#: id:20183
+msgid "Reload skin"
+msgstr "Ponovo učitaj Skin"
+
+#: id:20184
+msgid "Rotate pictures using EXIF information"
+msgstr "Okreni pomoću EXIF informacije"
+
+#: id:20185
+msgid "Use poster view styles for TV shows"
+msgstr ""
+
+#: id:20186
+msgid "Please wait"
+msgstr "Molim te sačekaj"
+
+#: id:20187
+msgid "UPnP"
+msgstr ""
+
+#: id:20189
+msgid "Enable auto scrolling for plot & review"
+msgstr "Omogući Auto pomicanje za Radnju & Recenziju"
+
+#: id:20190
+msgctxt "Auto context with id 20190"
+msgid "Custom"
+msgstr "Vlastito"
+
+#: id:20191
+msgid "Enable debug logging"
+msgstr "Omogući debug logging"
+
+#: id:20192
+msgid "Download additional information during updates"
+msgstr ""
+
+#: id:20193
+msgid "Default service for album information"
+msgstr ""
+
+#: id:20194
+msgid "Default service for artist information"
+msgstr ""
+
+#: id:20195
+msgid "Change scraper"
+msgstr ""
+
+#: id:20196
+msgid "Export music library"
+msgstr ""
+
+#: id:20197
+msgid "Import music library"
+msgstr ""
+
+#: id:20198
+msgid "No artist found!"
+msgstr ""
+
+#: id:20199
+msgid "Downloading artist info failed"
+msgstr ""
+
+#: id:20250
+msgid "Party on! (videos)"
+msgstr ""
+
+#: id:20251
+msgid "Mixing drinks (videos)"
+msgstr ""
+
+#: id:20252
+msgid "Filling glasses (videos)"
+msgstr ""
+
+#: id:20253
+msgid "WebDAV server (HTTP)"
+msgstr ""
+
+#: id:20254
+msgid "WebDAV server (HTTPS)"
+msgstr ""
+
+#: id:20255
+msgid "First logon, edit your profile"
+msgstr ""
+
+#: id:20256
+msgid "HTS Tvheadend client"
+msgstr ""
+
+#: id:20257
+msgid "VDR Streamdev client"
+msgstr ""
+
+#: id:20258
+msgid "MythTV client"
+msgstr ""
+
+#: id:20259
+msgid "Network Filesystem (NFS)"
+msgstr ""
+
+#: id:20260
+msgid "Secure Shell (SSH/SFTP)"
+msgstr ""
+
+#: id:20261
+msgid "Apple Filing Protocol (AFP)"
+msgstr ""
+
+#: id:20300
+msgid "Web server directory (HTTP)"
+msgstr ""
+
+#: id:20301
+msgid "Web server directory (HTTPS)"
+msgstr ""
+
+#: id:20302
+msgid "Unable to write to folder:"
+msgstr ""
+
+#: id:20303
+msgid "Do you want to skip and proceed?"
+msgstr ""
+
+#: id:20304
+msgid "RSS Feed"
+msgstr ""
+
+#: id:20307
+msgid "Secondary DNS"
+msgstr "Sekundarni DNS"
+
+#: id:20308
+msgid "DHCP server:"
+msgstr "DHCP server:"
+
+#: id:20309
+msgid "Make new folder"
+msgstr "Napravi novu mapu"
+
+#: id:20310
+msgid "Dim LCD on playback"
+msgstr "Zatamni LCD kod reprodukcije"
+
+#: id:20311
+msgid "Unknown or onboard (protected)"
+msgstr "Nepoznato ili na ploči (zaštićeno)"
+
+#: id:20312
+msgid "Dim LCD on paused"
+msgstr "Zatamni LCD kod pauze"
+
+#: id:20314
+msgid "Videos - Library"
+msgstr "Video - Library"
+
+#: id:20316
+msgid "Sort by: ID"
+msgstr "Složi po: ID"
+
+#: id:20324
+msgid "Play part..."
+msgstr "Pokreni dio..."
+
+#: id:20325
+msgid "Calibration reset"
+msgstr "Resetiraj kalibraciju"
+
+#: id:20326
+msgid "This will reset the calibration values for %s"
+msgstr "Ovo će resetirati vrijednost kalibracije %s"
+
+#: id:20327
+msgid "to it's default values."
+msgstr "na zadanu vrijednost."
+
+#: id:20328
+msgid "Browse for destination"
+msgstr "Traži putanju/odredište"
+
+#: id:20329
+msgid "Movies are in separate folders that match the movie title"
+msgstr ""
+
+#: id:20330
+msgid "Use folder names for lookups"
+msgstr "Koristi imena mapa pri pretraživanju"
+
+#: id:20331
+msgctxt "Auto context with id 20331"
+msgid "File"
+msgstr "Datoteka"
+
+#: id:20332
+msgid "Use file or folder names in lookups?"
+msgstr "Koristi imena dat. ili mapa pri pretraživanju"
+
+#: id:20333
+msgid "Set content"
+msgstr "Postavi sadržaj"
+
+#: id:20334
+msgid "Folder"
+msgstr "Mapa"
+
+#: id:20335
+msgid "Look for content recursively?"
+msgstr "Rekurzivno traži sadržaj?"
+
+#: id:20336
+msgid "Unlock sources"
+msgstr "Otključaj izvore"
+
+#: id:20337
+msgid "Actor"
+msgstr "Glumac"
+
+#: id:20338
+msgid "Movie"
+msgstr "Film"
+
+#: id:20339
+msgid "Director"
+msgstr "Redatelj"
+
+#: id:20340
+msgid "Do you want to remove all items within"
+msgstr "Želiš li maknuti sve stvari unutar"
+
+#: id:20341
+msgid "this path from the XBMC library?"
+msgstr "ove putanje u library?"
+
+#: id:20342
+msgctxt "Auto context with id 20342"
+msgid "Movies"
+msgstr "Filmovi"
+
+#: id:20343
+msgid "TV shows"
+msgstr "TV Serije"
+
+#: id:20344
+msgid "This directory contains"
+msgstr "Ovaj direktorij sadrži"
+
+#: id:20345
+msgid "Run automated scan"
+msgstr "Pokreni automatsko skeniranje"
+
+#: id:20346
+msgid "Scan recursively"
+msgstr "Skeniraj rekurzivno"
+
+#: id:20347
+msgid "as"
+msgstr "kao"
+
+#: id:20348
+msgid "Directors"
+msgstr "Redatelji"
+
+#: id:20349
+msgid "No video files found in this path!"
+msgstr "Nije pronađen video na ovoj putanji!"
+
+#: id:20350
+msgid "votes"
+msgstr "Glasovi"
+
+#: id:20351
+msgid "TV show information"
+msgstr "Informacije o TV epizodama"
+
+#: id:20352
+msgid "Episode information"
+msgstr "Informacije o epizodama"
+
+#: id:20353
+msgid "Loading TV show details"
+msgstr "Učitavam detalje TV epizoda"
+
+#: id:20354
+msgid "Fetching episode guide"
+msgstr "Hvatam vodič epizoda"
+
+#: id:20355
+msgid "Loading info for episodes in directory"
+msgstr "Učitavam info za epizode u direktorij"
+
+#: id:20356
+msgid "Select TV show:"
+msgstr "Odaberi TV epizodu:"
+
+#: id:20357
+msgid "Enter the TV show name"
+msgstr "Upiši ime TV epizode"
+
+#: id:20358
+msgid "Season %i"
+msgstr "Sezona %i"
+
+#: id:20359
+msgid "Episode"
+msgstr "Epizoda"
+
+#: id:20360
+msgid "Episodes"
+msgstr "Epizoda"
+
+#: id:20361
+msgid "Loading episode details"
+msgstr "Učitavam detalje epizoda"
+
+#: id:20362
+msgid "Remove episode from library"
+msgstr "Makni epizode iz library"
+
+#: id:20363
+msgid "Remove TV show from library"
+msgstr "Makni TV epizode iz library"
+
+#: id:20364
+msgid "TV show"
+msgstr "TV epizoda"
+
+#: id:20365
+msgid "Episode plot"
+msgstr "Sadržaj epizode"
+
+#: id:20366
+msgid "* All seasons"
+msgstr "* Sve sezone"
+
+#: id:20367
+msgid "Hide watched"
+msgstr "Sakrij pogledano"
+
+#: id:20368
+msgid "Prod code"
+msgstr ""
+
+#: id:20369
+msgid "Show plot for unwatched items"
+msgstr "Prikaži kratak sadržaja nepogledanih stavki"
+
+#: id:20370
+msgid "* Hidden to prevent spoilers *"
+msgstr "* Skriveno da ne pokvari užitak *"
+
+#: id:20371
+msgid "Set season thumb"
+msgstr "Postavi thumb sezone"
+
+#: id:20372
+msgid "Season image"
+msgstr "Slika sezone"
+
+#: id:20373
+msgid "Season"
+msgstr "Sezona"
+
+#: id:20374
+msgid "Downloading movie information"
+msgstr "Skidam informacije o filmu"
+
+#: id:20375
+msgid "Unassign content"
+msgstr "Nepotpisan sadržaj"
+
+#: id:20376
+msgid "Original title"
+msgstr "Originalan naslov"
+
+#: id:20377
+msgid "Refresh TV show information"
+msgstr "Osvježi info TV epizoda"
+
+#: id:20378
+msgid "Refresh info for all episodes?"
+msgstr "Osvježi info za sve epizode?"
+
+#: id:20379
+msgid "Selected folder contains a single TV show"
+msgstr "Mapa sadrži jednu TV epizodu"
+
+#: id:20380
+msgid "Exclude selected folder from scans"
+msgstr "Isključi mapu iz skeniranja"
+
+#: id:20381
+msgid "Specials"
+msgstr "Specijal"
+
+#: id:20382
+msgid "Automatically grab season thumbs"
+msgstr "Automatski preuzmi thumb za sezone"
+
+#: id:20383
+msgid "Selected folder contains a single video"
+msgstr "Mapa sadrži jedan video"
+
+#: id:20384
+msgid "Link to TV show"
+msgstr "Veza do TV epizode"
+
+#: id:20385
+msgid "Remove link to TV show"
+msgstr "Makni vezu do TV epizode"
+
+#: id:20386
+msgid "Recently added movies"
+msgstr "Nedavno dodani filmovi"
+
+#: id:20387
+msgid "Recently added episodes"
+msgstr "Nedavno dodane epizode"
+
+#: id:20388
+msgid "Studios"
+msgstr "Studiji"
+
+#: id:20389
+msgid "Music videos"
+msgstr "Glazbeni spotovi"
+
+#: id:20390
+msgid "Recently added music videos"
+msgstr "Nedavno dodani glazbeni spotovi"
+
+#: id:20391
+msgid "Music video"
+msgstr "Glazbeni spot"
+
+#: id:20392
+msgid "Remove music video from library"
+msgstr "Odstrani glazbeni spot iz library"
+
+#: id:20393
+msgctxt "Auto context with id 20393"
+msgid "Music video information"
+msgstr "Informacije glazbenog spota"
+
+#: id:20394
+msgid "Loading music video information"
+msgstr "Učitavam info o glazbenom spotu"
+
+#: id:20395
+msgid "Mixed"
+msgstr "Izmješano"
+
+#: id:20396
+msgid "Go to albums by artist"
+msgstr "Idi na album po izvođaču"
+
+#: id:20397
+msgid "Go to album"
+msgstr "Idi na album"
+
+#: id:20398
+msgid "Play song"
+msgstr "Sviraj pjesmu"
+
+#: id:20399
+msgid "Go to music videos from album"
+msgstr "Idi na glazbeni spot kroza album"
+
+#: id:20400
+msgid "Go to music videos by artist"
+msgstr "Idi na glazbeni spot po izvođaču"
+
+#: id:20401
+msgid "Play music video"
+msgstr "Pokreni glazbeni spot"
+
+#: id:20402
+msgid "Download actor thumbnails when adding to library"
+msgstr "Automatski preuzmi thumb od glumca"
+
+#: id:20403
+msgid "Set actor thumb"
+msgstr "Postavi thumb glumca"
+
+#: id:20405
+msgid "Remove episode bookmark"
+msgstr "Odstrani bookmark epizode"
+
+#: id:20406
+msgid "Set episode bookmark"
+msgstr "Postavi bookmark epizode"
+
+#: id:20407
+msgid "Scraper settings"
+msgstr ""
+
+#: id:20408
+msgid "Downloading music video information"
+msgstr ""
+
+#: id:20409
+msgid "Downloading TV show information"
+msgstr ""
+
+#: id:20410
+msgid "Trailer"
+msgstr ""
+
+#: id:20411
+msgid "Flatten"
+msgstr ""
+
+#: id:20412
+msgid "Flatten TV shows"
+msgstr ""
+
+#: id:20413
+msgid "Get fanart"
+msgstr "Skini Fanart"
+
+#: id:20414
+msgid "Show Fanart in video and music libraries"
+msgstr ""
+
+#: id:20415
+msgid "Scanning for new content"
+msgstr ""
+
+#: id:20416
+msgid "First aired"
+msgstr "1. emitiranje"
+
+#: id:20417
+msgid "Writer"
+msgstr "Pisac"
+
+#: id:20419
+msgid "Replace file names with library titles"
+msgstr ""
+
+#: id:20420
+msgctxt "Auto context with id 20420"
+msgid "Never"
+msgstr "Nikada"
+
+#: id:20421
+msgid "If only one season"
+msgstr "Ako je samo jedna sezona"
+
+#: id:20422
+msgid "Always"
+msgstr "Uvijek"
+
+#: id:20423
+msgid "Has trailer"
+msgstr ""
+
+#: id:20424
+msgid "False"
+msgstr ""
+
+#: id:20425
+msgid "Fanart slideshow"
+msgstr ""
+
+#: id:20426
+msgid "Export to a single file or separate"
+msgstr ""
+
+#: id:20427
+msgid "files per entry?"
+msgstr ""
+
+#: id:20428
+msgid "Single file"
+msgstr ""
+
+#: id:20429
+msgctxt "Auto context with id 20429"
+msgid "Separate"
+msgstr ""
+
+#: id:20430
+msgid "Export thumbnails and fanart?"
+msgstr ""
+
+#: id:20431
+msgid "Overwrite old files?"
+msgstr ""
+
+#: id:20432
+msgid "Exclude path from library updates"
+msgstr ""
+
+#: id:20433
+msgid "Extract thumbnails and video information"
+msgstr "Extract thumbnail i video informacije"
+
+#: id:20434
+msgid "Sets"
+msgstr ""
+
+#: id:20435
+msgid "Set movieset thumb"
+msgstr ""
+
+#: id:20436
+msgid "Export actor thumbs?"
+msgstr ""
+
+#: id:20437
+msgid "Choose fanart"
+msgstr ""
+
+#: id:20438
+msgid "Local fanart"
+msgstr ""
+
+#: id:20439
+msgid "No fanart"
+msgstr ""
+
+#: id:20440
+msgid "Current fanart"
+msgstr ""
+
+#: id:20441
+msgid "Remote fanart"
+msgstr ""
+
+#: id:20442
+msgid "Change content"
+msgstr ""
+
+#: id:20443
+msgid "Do you want to refresh info for all"
+msgstr ""
+
+#: id:20444
+msgid "items within this path?"
+msgstr ""
+
+#: id:20445
+msgid "Fanart"
+msgstr ""
+
+#: id:20446
+msgid "Locally stored information found."
+msgstr ""
+
+#: id:20447
+msgid "Ignore and refresh from internet?"
+msgstr ""
+
+#: id:20448
+msgid "Could not download information"
+msgstr ""
+
+#: id:20449
+msgid "Unable to connect to remote server"
+msgstr ""
+
+#: id:20450
+msgid "Would you like to continue scanning?"
+msgstr ""
+
+#: id:20451
+msgid "Countries"
+msgstr ""
+
+#: id:20452
+msgid "episode"
+msgstr ""
+
+#: id:20453
+msgid "episodes"
+msgstr ""
+
+#: id:20454
+msgid "Listener"
+msgstr ""
+
+#: id:20455
+msgid "Listeners"
+msgstr ""
+
+#: id:20456
+msgid "Set movieset fanart"
+msgstr ""
+
+#: id:20457
+msgid "Movie set"
+msgstr ""
+
+#: id:20458
+msgid "Group movies in sets"
+msgstr ""
+
+#: id:21330
+msgid "Show hidden files and directories"
+msgstr "Prikaži skrivene datoteke i mape"
+
+#: id:21331
+msgid "TuxBox client"
+msgstr "TuxBox klijent"
+
+#: id:21332
+msgid "WARNING: Target TuxBox device is in recording-mode!"
+msgstr "POZOR: Odredišni TuxBox uređaj je u \"Recording modu\""
+
+#: id:21333
+msgid "The stream will be stopped!"
+msgstr "Strean će biti zaustavljen!"
+
+#: id:21334
+msgid "Zap to channel: %s failed!"
+msgstr "Spoji u Kanal %s Neuspjelo!"
+
+#: id:21335
+msgid "Are you sure to start the stream?"
+msgstr "Jesi li siguran da želiš pokrenuti stream?"
+
+#: id:21336
+msgid "Connecting to: %s"
+msgstr "Spajam se na: %s"
+
+#: id:21337
+msgid "TuxBox device"
+msgstr "TuxBox Uređaj"
+
+#: id:21359
+msgid "Add media share..."
+msgstr "Dodaj djeljenu mediu..."
+
+#: id:21360
+msgid "Share video and music libraries through UPnP"
+msgstr "Dijeli video i glazbene library-e putem UPnP-a"
+
+#: id:21364
+msgid "Edit media share"
+msgstr "Uredi dijeljenu mediu"
+
+#: id:21365
+msgid "Remove media share"
+msgstr "Odstrani dijeljenu mediu"
+
+#: id:21366
+msgid "Subtitle folder"
+msgstr "Mapa titlova"
+
+#: id:21367
+msgid "Movie & alternate subtitle directory"
+msgstr "Film & alternativni direktorij titlova"
+
+#: id:21368
+msgid "Override ASS/SSA subtitles fonts"
+msgstr ""
+
+#: id:21369
+msgid "Enable mouse and Touch Screen support"
+msgstr "Uključi miš"
+
+#: id:21370
+msgid "Play navigation sounds during media playback"
+msgstr "Reproduciraj zvukove navigacije prilikom reprodukcije medija"
+
+#: id:21371
+msgid "Thumbnail"
+msgstr "Thumbnail"
+
+#: id:21372
+msgid "Forced DVD player region"
+msgstr "Forced DVD player region"
+
+#: id:21373
+msgid "Video output"
+msgstr "Video"
+
+#: id:21374
+msgid "Video aspect"
+msgstr "Video omjer"
+
+#: id:21375
+msgctxt "Auto context with id 21375"
+msgid "Normal"
+msgstr "Normalno"
+
+#: id:21376
+msgid "Letterbox"
+msgstr "Letterbox"
+
+#: id:21377
+msgid "Widescreen"
+msgstr "Široki Zaslon"
+
+#: id:21378
+msgid "Enable 480p"
+msgstr "Omogući 480p"
+
+#: id:21379
+msgid "Enable 720p"
+msgstr "Omogući 720p"
+
+#: id:21380
+msgid "Enable 1080i"
+msgstr "Omogući 1080i"
+
+#: id:21381
+msgid "Enter name of new playlist"
+msgstr "Upiši Ime nove playliste"
+
+#: id:21382
+msgid "Show \"Add source\" buttons in file lists"
+msgstr "Prikaži \"Dodaj Izvor\" gumb u listi dat."
+
+#: id:21383
+msgid "Enable scrollbars"
+msgstr "Omogući Kliznu traku"
+
+#: id:21384
+msgid "Make watched filtering a toggle in video library"
+msgstr "Prebaci filter (ne)pogledanih videa u video library"
+
+#: id:21385
+msgctxt "Auto context with id 21385"
+msgid "Open"
+msgstr "Otvori"
+
+#: id:21386
+msgid "Acoustic management level"
+msgstr "Razine upravljanja akustikom"
+
+#: id:21387
+msgid "Fast"
+msgstr "Brzo"
+
+#: id:21388
+msgid "Quiet"
+msgstr "Tiho"
+
+#: id:21389
+msgid "Enable custom background"
+msgstr "Omogući vlastitu pozadinu"
+
+#: id:21390
+msgid "Power management level"
+msgstr ""
+
+#: id:21391
+msgid "High power"
+msgstr ""
+
+#: id:21392
+msgid "Low power"
+msgstr ""
+
+#: id:21393
+msgid "High standby"
+msgstr ""
+
+#: id:21394
+msgid "Low standby"
+msgstr ""
+
+#: id:21395
+msgid "Unable to cache files bigger than 4GB"
+msgstr "Ne mogu učitati dat. veće od 4 gb"
+
+#: id:21396
+msgid "Chapter"
+msgstr "Poglavlje"
+
+#: id:21397
+msgid "High quality pixel shader v2"
+msgstr "Visoka kvaliteta pixel shadera V2"
+
+#: id:21398
+msgid "Enable playlist at startup"
+msgstr "Omogući playlistu pri početku rada"
+
+#: id:21399
+msgid "Use tween animations"
+msgstr "Koristi tween animaciju"
+
+#: id:21400
+msgid "contains"
+msgstr "sadrži"
+
+#: id:21401
+msgid "does not contain"
+msgstr "ne sadrži"
+
+#: id:21402
+msgid "is"
+msgstr "je"
+
+#: id:21403
+msgid "is not"
+msgstr "nije"
+
+#: id:21404
+msgid "starts with"
+msgstr "počinje sa"
+
+#: id:21405
+msgid "ends with"
+msgstr "završava sa"
+
+#: id:21406
+msgid "greater than"
+msgstr "veće od"
+
+#: id:21407
+msgid "less than"
+msgstr "manje od"
+
+#: id:21408
+msgid "after"
+msgstr "poslije"
+
+#: id:21409
+msgid "before"
+msgstr "prije"
+
+#: id:21410
+msgid "in the last"
+msgstr "u zadnjem"
+
+#: id:21411
+msgid "not in the last"
+msgstr "nije u zadnjem"
+
+#: id:21412
+msgid "Scrapers"
+msgstr ""
+
+#: id:21413
+msgid "Default movie scraper"
+msgstr ""
+
+#: id:21414
+msgid "Default tvshow scraper"
+msgstr ""
+
+#: id:21415
+msgid "Default music video scraper"
+msgstr ""
+
+#: id:21416
+msgid "Enable fallback based on scraper language"
+msgstr ""
+
+#: id:21417
+msgid "- Settings"
+msgstr "- Postavke"
+
+#: id:21418
+msgid "Multilingual"
+msgstr ""
+
+#: id:21419
+msgid "No scrapers present"
+msgstr ""
+
+#: id:21420
+msgid "Value to match"
+msgstr "Vrijednost sastava"
+
+#: id:21421
+msgid "Smart playlist rule"
+msgstr "Pravila pametne Playliste"
+
+#: id:21422
+msgid "Match items where"
+msgstr "Spari pjesme gdje"
+
+#: id:21423
+msgid "New rule..."
+msgstr "Novo pravilo..."
+
+#: id:21424
+msgid "Items must match"
+msgstr "Pjesme se moraju slagati"
+
+#: id:21425
+msgid "all of the rules"
+msgstr "sve od pravila"
+
+#: id:21426
+msgid "one or more of the rules"
+msgstr "jedan ili više od pravila"
+
+#: id:21427
+msgid "Limit to"
+msgstr "Ograniči na"
+
+#: id:21428
+msgid "No limit"
+msgstr "Nema ograničenja"
+
+#: id:21429
+msgid "Order by"
+msgstr "Složeno po"
+
+#: id:21430
+msgid "ascending"
+msgstr "ulazno"
+
+#: id:21431
+msgid "descending"
+msgstr "silazno"
+
+#: id:21432
+msgid "Edit smart playlist"
+msgstr "Uredi pametnu playlistu"
+
+#: id:21433
+msgid "Name of the playlist"
+msgstr "Ime playliste"
+
+#: id:21434
+msgid "Find items where"
+msgstr "Pronađi stavke koje"
+
+#: id:21435
+msgid "Edit"
+msgstr "Uredi"
+
+#: id:21436
+msgid "%i items"
+msgstr "%i pjesme"
+
+#: id:21437
+msgid "New smart playlist..."
+msgstr "Nova pametna playlista"
+
+#: id:21438
+msgid "%c Drive"
+msgstr "%c Pogon"
+
+#: id:21439
+msgid "Edit party mode rules"
+msgstr "Uredi \"Party\" režim pravila"
+
+#: id:21440
+msgid "Home folder"
+msgstr ""
+
+#: id:21441
+msgid "Watched count"
+msgstr ""
+
+#: id:21442
+msgid "Episode title"
+msgstr ""
+
+#: id:21443
+msgid "Video resolution"
+msgstr ""
+
+#: id:21444
+msgid "Audio channels"
+msgstr ""
+
+#: id:21445
+msgid "Video codec"
+msgstr ""
+
+#: id:21446
+msgid "Audio codec"
+msgstr ""
+
+#: id:21447
+msgid "Audio language"
+msgstr ""
+
+#: id:21448
+msgid "Subtitle language"
+msgstr ""
+
+#: id:21449
+msgid "Remote control sends keyboard presses"
+msgstr "Daljinski upravljač simulira tipkovnicu (key press mode)"
+
+#: id:21450
+msgid "- Edit"
+msgstr ""
+
+#: id:21451
+msgid "Internet connection required."
+msgstr ""
+
+#: id:21452
+msgid "Get More..."
+msgstr ""
+
+#: id:21453
+msgid "Root filesystem"
+msgstr ""
+
+#: id:21454
+msgid "Cache full"
+msgstr ""
+
+#: id:21455
+msgid "Cache filled before reaching required amount for continous playback"
+msgstr ""
+
+#: id:21460
+msgid "Subtitle location"
+msgstr ""
+
+#: id:21461
+msgid "Fixed"
+msgstr ""
+
+#: id:21462
+msgid "Bottom of video"
+msgstr ""
+
+#: id:21463
+msgid "Below video"
+msgstr ""
+
+#: id:21464
+msgid "Top of video"
+msgstr ""
+
+#: id:21465
+msgid "Above video"
+msgstr ""
+
+#: id:21800
+msgid "File name"
+msgstr "Ime datoteke"
+
+#: id:21801
+msgid "File path"
+msgstr "Putanja dat."
+
+#: id:21802
+msgid "File size"
+msgstr "Veličina dat."
+
+#: id:21803
+msgid "File date/time"
+msgstr "Datum dat./vrijeme"
+
+#: id:21804
+msgid "Slide index"
+msgstr "Index dijapozitiva"
+
+#: id:21805
+msgctxt "Auto context with id 21805"
+msgid "Resolution"
+msgstr "Razlučivost"
+
+#: id:21806
+msgctxt "Auto context with id 21806"
+msgid "Comment"
+msgstr "Komentar"
+
+#: id:21807
+msgid "Colour/B&W"
+msgstr "Boja/B&W"
+
+#: id:21808
+msgid "JPEG process"
+msgstr "JPEG Proces"
+
+#: id:21820
+msgid "Date/Time"
+msgstr "Datum/Vrijeme"
+
+#: id:21821
+msgid "Description"
+msgstr "Opis"
+
+#: id:21822
+msgid "Camera make"
+msgstr "Kamera napravi"
+
+#: id:21823
+msgid "Camera model"
+msgstr "Model kamere"
+
+#: id:21824
+msgid "EXIF comment"
+msgstr "Exif komentar"
+
+#: id:21825
+msgid "Firmware"
+msgstr "Firmware"
+
+#: id:21826
+msgid "Aperture"
+msgstr "Raspon leće"
+
+#: id:21827
+msgid "Focal length"
+msgstr "Duljina žarišta"
+
+#: id:21828
+msgid "Focus distance"
+msgstr "Fokus žarišta"
+
+#: id:21829
+msgid "Exposure"
+msgstr "Ekspozicija"
+
+#: id:21830
+msgid "Exposure time"
+msgstr "Vrijeme ekspozicije"
+
+#: id:21831
+msgid "Exposure bias"
+msgstr "Nagib ekspozicije"
+
+#: id:21832
+msgid "Exposure mode"
+msgstr "Način ekspozicije"
+
+#: id:21833
+msgid "Flash used"
+msgstr "Korištena bljeskalica"
+
+#: id:21834
+msgid "White-balance"
+msgstr "Balans bijele boje"
+
+#: id:21835
+msgid "Light source"
+msgstr "Izvor svijetla"
+
+#: id:21836
+msgid "Metering mode"
+msgstr "Način Izmjere"
+
+#: id:21837
+msgid "ISO"
+msgstr "ISO"
+
+#: id:21838
+msgid "Digital zoom"
+msgstr "Digitalni zoom"
+
+#: id:21839
+msgid "CCD width"
+msgstr "Širina CCDa"
+
+#: id:21840
+msgid "GPS latitude"
+msgstr "Širina GPSa"
+
+#: id:21841
+msgid "GPS longitude"
+msgstr "Dužina GPSa"
+
+#: id:21842
+msgid "GPS altitude"
+msgstr "Visina GPSa"
+
+#: id:21843
+msgid "Orientation"
+msgstr "Orijentacija"
+
+#: id:21860
+msgid "Supplemental categories"
+msgstr "Zamjenjive kategorije"
+
+#: id:21861
+msgid "Keywords"
+msgstr "Ključne riječi"
+
+#: id:21862
+msgid "Caption"
+msgstr "Zaglavlje"
+
+#: id:21863
+msgid "Author"
+msgstr "Autor"
+
+#: id:21864
+msgid "Headline"
+msgstr "Glavni Naslov"
+
+#: id:21865
+msgid "Special instructions"
+msgstr "Posebne Instrukcije"
+
+#: id:21866
+msgid "Category"
+msgstr "Kategorija"
+
+#: id:21867
+msgid "Byline"
+msgstr "Byline"
+
+#: id:21868
+msgid "Byline title"
+msgstr "Byline Naziv"
+
+#: id:21869
+msgid "Credit"
+msgstr "Zasluge"
+
+#: id:21870
+msgid "Source"
+msgstr "Izvor"
+
+#: id:21871
+msgid "Copyright notice"
+msgstr "Obavjest autorkog prava"
+
+#: id:21872
+msgid "Object name"
+msgstr "Ime objekta"
+
+#: id:21873
+msgid "City"
+msgstr "Grad"
+
+#: id:21874
+msgid "State"
+msgstr "Država"
+
+#: id:21875
+msgctxt "Auto context with id 21875"
+msgid "Country"
+msgstr "Zemlja"
+
+#: id:21876
+msgid "Original Tx Reference"
+msgstr "Preporuka orginalnog Tx-a"
+
+#: id:21877
+msgid "Date created"
+msgstr "Datum nastanka"
+
+#: id:21878
+msgid "Copyright flag"
+msgstr "Zastava autorskog prava"
+
+#: id:21879
+msgid "Country code"
+msgstr "Šifra zemlje"
+
+#: id:21880
+msgid "Reference service"
+msgstr "Referentna usluga"
+
+#: id:21881
+msgid "Allow control of XBMC via UPnP"
+msgstr "Omogući kontrolu XBMC-a putem UPnP-a"
+
+#: id:21882
+msgid "Attempt to skip introduction before DVD menu"
+msgstr "Pokušaj preskočiti uvod prije DVD izbornika"
+
+#: id:21883
+msgid "Saved music"
+msgstr "Spremljena glazba"
+
+#: id:21884
+msgid "Query info for all artists"
+msgstr ""
+
+#: id:21885
+msgid "Downloading album information"
+msgstr ""
+
+#: id:21886
+msgid "Downloading artist information"
+msgstr ""
+
+#: id:21887
+msgid "Biography"
+msgstr ""
+
+#: id:21888
+msgid "Discography"
+msgstr ""
+
+#: id:21889
+msgid "Searching artist"
+msgstr ""
+
+#: id:21890
+msgid "Select artist"
+msgstr ""
+
+#: id:21891
+msgctxt "Auto context with id 21891"
+msgid "Artist information"
+msgstr ""
+
+#: id:21892
+msgid "Instruments"
+msgstr ""
+
+#: id:21893
+msgid "Born"
+msgstr ""
+
+#: id:21894
+msgid "Formed"
+msgstr ""
+
+#: id:21895
+msgid "Themes"
+msgstr ""
+
+#: id:21896
+msgid "Disbanded"
+msgstr ""
+
+#: id:21897
+msgid "Died"
+msgstr ""
+
+#: id:21898
+msgid "Years active"
+msgstr ""
+
+#: id:21899
+msgid "Label"
+msgstr ""
+
+#: id:21900
+msgid "Born/Formed"
+msgstr ""
+
+#: id:22000
+msgid "Update library on startup"
+msgstr "Ažuriraj library na početku"
+
+#: id:22001
+msgid "Hide progress of library updates"
+msgstr "Ažuriraj library u pozadini"
+
+#: id:22002
+msgid "- DNS suffix"
+msgstr ""
+
+#: id:22003
+msgid "%2.3fs"
+msgstr ""
+
+#: id:22004
+msgid "Delayed by: %2.3fs"
+msgstr ""
+
+#: id:22005
+msgid "Ahead by: %2.3fs"
+msgstr ""
+
+#: id:22006
+msgid "Subtitle offset"
+msgstr ""
+
+#: id:22007
+msgid "OpenGL vendor:"
+msgstr ""
+
+#: id:22008
+msgid "OpenGL renderer:"
+msgstr ""
+
+#: id:22009
+msgid "OpenGL version:"
+msgstr ""
+
+#: id:22010
+msgid "GPU temperature:"
+msgstr ""
+
+#: id:22011
+msgid "CPU temperature:"
+msgstr "Temperatura procesora:"
+
+#: id:22012
+msgid "Total memory"
+msgstr "Ukupna memorija"
+
+#: id:22013
+msgid "Profile data"
+msgstr ""
+
+#: id:22014
+msgid "Use dim if paused during video playback"
+msgstr "Zatamni ekran ako je pauzirana video reprodukcija"
+
+#: id:22015
+msgid "All recordings"
+msgstr ""
+
+#: id:22016
+msgid "By title"
+msgstr ""
+
+#: id:22017
+msgid "By group"
+msgstr ""
+
+#: id:22018
+msgid "Live channels"
+msgstr ""
+
+#: id:22019
+msgid "Recordings by title"
+msgstr ""
+
+#: id:22020
+msgid "Guide"
+msgstr ""
+
+#: id:22021
+msgid "Allowed error in aspect ratio to minimize black bars"
+msgstr "Dozvoljene pogreške u \"aspect ratio\" radi smanjenja crnih traka"
+
+#: id:22022
+msgid "Show video files in listings"
+msgstr ""
+
+#: id:22023
+msgid "DirectX vendor:"
+msgstr ""
+
+#: id:22024
+msgid "Direct3D version:"
+msgstr ""
+
+#: id:22030
+msgctxt "Auto context with id 22030"
+msgid "Font"
+msgstr ""
+
+#: id:22031
+msgctxt "Auto context with id 22031"
+msgid "- Size"
+msgstr ""
+
+#: id:22032
+msgctxt "Auto context with id 22032"
+msgid "- Colours"
+msgstr ""
+
+#: id:22033
+msgid "- Charset"
+msgstr ""
+
+#: id:22034
+msgid "Export karaoke titles as HTML"
+msgstr ""
+
+#: id:22035
+msgid "Export karaoke titles as CSV"
+msgstr ""
+
+#: id:22036
+msgid "Import karaoke titles..."
+msgstr ""
+
+#: id:22037
+msgid "Show song selector automatically"
+msgstr ""
+
+#: id:22038
+msgid "Export karaoke titles..."
+msgstr ""
+
+#: id:22039
+msgid "Enter song number"
+msgstr ""
+
+#: id:22040
+msgid "white/green"
+msgstr ""
+
+#: id:22041
+msgid "white/red"
+msgstr ""
+
+#: id:22042
+msgid "white/blue"
+msgstr ""
+
+#: id:22043
+msgid "black/white"
+msgstr ""
+
+#: id:22079
+msgid "Default select action"
+msgstr "Način starta selektiranih video ili audio stavki"
+
+#: id:22080
+msgid "Choose"
+msgstr "Odaberi"
+
+#: id:22081
+msgid "Show Information"
+msgstr "Prikaži informacije"
+
+#: id:22082
+msgid "More..."
+msgstr ""
+
+#: id:22083
+msgid "Play all"
+msgstr ""
+
+#: id:23049
+msgid "Teletext not available"
+msgstr ""
+
+#: id:23050
+msgid "Activate Teletext"
+msgstr "Aktiviraj Teletekst"
+
+#: id:23051
+msgid "Part %i"
+msgstr ""
+
+#: id:23052
+msgid "Buffering %i bytes"
+msgstr ""
+
+#: id:23053
+msgid "Stopping"
+msgstr ""
+
+#: id:23054
+msgid "Running"
+msgstr ""
+
+#: id:23100
+msgid "External Player Active"
+msgstr ""
+
+#: id:23101
+msgid "Click OK to terminate the player"
+msgstr ""
+
+#: id:23104
+msgid "Click OK when playback has ended"
+msgstr ""
+
+#: id:24000
+msgid "Add-on"
+msgstr ""
+
+#: id:24001
+msgid "Add-ons"
+msgstr ""
+
+#: id:24002
+msgid "Add-on options"
+msgstr ""
+
+#: id:24003
+msgid "Add-on Information"
+msgstr ""
+
+#: id:24005
+msgctxt "Auto context with id 24005"
+msgid "Media sources"
+msgstr ""
+
+#: id:24007
+msgctxt "Auto context with id 24007"
+msgid "Movie information"
+msgstr ""
+
+#: id:24008
+msgctxt "Auto context with id 24008"
+msgid "Screensaver"
+msgstr ""
+
+#: id:24009
+msgid "Script"
+msgstr ""
+
+#: id:24010
+msgctxt "Auto context with id 24010"
+msgid "Visualization"
+msgstr ""
+
+#: id:24011
+msgid "Add-on repository"
+msgstr ""
+
+#: id:24012
+msgctxt "Auto context with id 24012"
+msgid "Subtitles"
+msgstr ""
+
+#: id:24013
+msgid "Lyrics"
+msgstr ""
+
+#: id:24014
+msgid "TV information"
+msgstr ""
+
+#: id:24015
+msgctxt "Auto context with id 24015"
+msgid "Music video information"
+msgstr ""
+
+#: id:24016
+msgctxt "Auto context with id 24016"
+msgid "Album information"
+msgstr ""
+
+#: id:24017
+msgctxt "Auto context with id 24017"
+msgid "Artist information"
+msgstr ""
+
+#: id:24018
+msgctxt "Auto context with id 24018"
+msgid "Services"
+msgstr ""
+
+#: id:24020
+msgid "Configure"
+msgstr ""
+
+#: id:24021
+msgctxt "Auto context with id 24021"
+msgid "Disable"
+msgstr ""
+
+#: id:24022
+msgid "Enable"
+msgstr ""
+
+#: id:24023
+msgid "Add-on disabled"
+msgstr ""
+
+#: id:24027
+msgctxt "Auto context with id 24027"
+msgid "Weather"
+msgstr ""
+
+#: id:24028
+msgid "Weather.com (standard)"
+msgstr ""
+
+#: id:24030
+msgid "This Add-on can not be configured"
+msgstr ""
+
+#: id:24031
+msgid "Error loading settings"
+msgstr ""
+
+#: id:24032
+msgid "All Add-ons"
+msgstr ""
+
+#: id:24033
+msgid "Get Add-ons"
+msgstr ""
+
+#: id:24034
+msgid "Check for updates"
+msgstr ""
+
+#: id:24035
+msgid "Force refresh"
+msgstr ""
+
+#: id:24036
+msgid "Change log"
+msgstr ""
+
+#: id:24037
+msgid "Uninstall"
+msgstr ""
+
+#: id:24038
+msgid "Install"
+msgstr ""
+
+#: id:24039
+msgid "Disabled Add-ons"
+msgstr ""
+
+#: id:24040
+msgid "(Clear the current setting)"
+msgstr ""
+
+#: id:24041
+msgid "Install from zip file"
+msgstr ""
+
+#: id:24042
+msgid "Downloading %i%%"
+msgstr ""
+
+#: id:24043
+msgid "Available Updates"
+msgstr ""
+
+#: id:24044
+msgid "Dependencies not met"
+msgstr ""
+
+#: id:24045
+msgid "Add-on does not have the correct structure"
+msgstr ""
+
+#: id:24046
+msgid "%s is used by the following installed add-on(s)"
+msgstr ""
+
+#: id:24047
+msgid "This add-on cannot be uninstalled"
+msgstr ""
+
+#: id:24048
+msgid "Rollback"
+msgstr ""
+
+#: id:24050
+msgid "Available Add-ons"
+msgstr ""
+
+#: id:24051
+msgid "Version:"
+msgstr ""
+
+#: id:24052
+msgid "Disclaimer"
+msgstr ""
+
+#: id:24053
+msgid "License:"
+msgstr ""
+
+#: id:24054
+msgid "Changelog"
+msgstr ""
+
+#: id:24059
+msgid "Would you like to enable this Add-on?"
+msgstr ""
+
+#: id:24060
+msgid "Would you like to disable this Add-on?"
+msgstr ""
+
+#: id:24061
+msgid "Add-on update available!"
+msgstr ""
+
+#: id:24062
+msgid "Enabled Add-ons"
+msgstr ""
+
+#: id:24063
+msgid "Auto update"
+msgstr ""
+
+#: id:24064
+msgid "Add-on enabled"
+msgstr ""
+
+#: id:24065
+msgid "Add-on updated"
+msgstr ""
+
+#: id:24066
+msgid "Cancel Add-on download?"
+msgstr ""
+
+#: id:24067
+msgid "Currently downloading Add-ons"
+msgstr ""
+
+#: id:24068
+msgid "Update available"
+msgstr ""
+
+#: id:24069
+msgid "Update"
+msgstr ""
+
+#: id:24070
+msgid "Add-on could not be loaded."
+msgstr ""
+
+#: id:24071
+msgid "An unknown error has occurred."
+msgstr ""
+
+#: id:24072
+msgid "Settings required"
+msgstr ""
+
+#: id:24073
+msgid "Could not connect"
+msgstr ""
+
+#: id:24074
+msgid "Needs to restart"
+msgstr ""
+
+#: id:24075
+msgctxt "Auto context with id 24075"
+msgid "Disable"
+msgstr ""
+
+#: id:24076
+msgid "Add-on Required"
+msgstr ""
+
+#: id:24080
+msgid "Try to reconnect?"
+msgstr ""
+
+#: id:24089
+msgid "Add-on restarts"
+msgstr ""
+
+#: id:24090
+msgid "Lock Add-on manager"
+msgstr ""
+
+#: id:24094
+msgid "(current)"
+msgstr ""
+
+#: id:24095
+msgid "(blacklisted)"
+msgstr ""
+
+#: id:24096
+msgid "Add-on has been marked as broken in repository."
+msgstr ""
+
+#: id:24097
+msgid "Would you like to disable it on your system?"
+msgstr ""
+
+#: id:24098
+msgid "Broken"
+msgstr ""
+
+#: id:24099
+msgid "Would you like to switch to this skin?"
+msgstr ""
+
+#: id:24100
+msgid "To use this feature you must download an Add-on:"
+msgstr ""
+
+#: id:24101
+msgid "Would you like to download this Add-on?"
+msgstr ""
+
+#: id:25000
+msgid "Notifications"
+msgstr ""
+
+#: id:29800
+msgid "Library Mode"
+msgstr ""
+
+#: id:29801
+msgid "QWERTY keyboard"
+msgstr ""
+
+#: id:29802
+msgid "Passthrough Audio in use"
+msgstr "Korist se Audio Passthrough"
+
+#: id:33001
+msgid "Trailer quality"
+msgstr ""
+
+#: id:33002
+msgid "Stream"
+msgstr ""
+
+#: id:33003
+msgid "Download"
+msgstr ""
+
+#: id:33004
+msgid "Download & play"
+msgstr ""
+
+#: id:33005
+msgid "Download & save"
+msgstr ""
+
+#: id:33006
+msgid "Today"
+msgstr ""
+
+#: id:33007
+msgid "Tomorrow"
+msgstr ""
+
+#: id:33008
+msgid "Saving"
+msgstr ""
+
+#: id:33009
+msgid "Copying"
+msgstr ""
+
+#: id:33010
+msgid "Set download directory"
+msgstr ""
+
+#: id:33011
+msgid "Search duration"
+msgstr ""
+
+#: id:33012
+msgid "Short"
+msgstr ""
+
+#: id:33013
+msgid "Long"
+msgstr ""
+
+#: id:33014
+msgid "Use DVD player instead of regular player"
+msgstr ""
+
+#: id:33015
+msgid "Ask for download before playing video"
+msgstr ""
+
+#: id:33016
+msgid "Clips"
+msgstr ""
+
+#: id:33017
+msgid "Restart plugin to enable"
+msgstr ""
+
+#: id:33018
+msgid "Tonight"
+msgstr ""
+
+#: id:33019
+msgid "Tomorrow Night"
+msgstr ""
+
+#: id:33020
+msgid "Condition"
+msgstr ""
+
+#: id:33021
+msgid "Precipitation"
+msgstr ""
+
+#: id:33022
+msgid "Precip"
+msgstr ""
+
+#: id:33023
+msgid "Humid"
+msgstr ""
+
+#: id:33024
+msgid "Feels"
+msgstr ""
+
+#: id:33025
+msgid "Observed"
+msgstr ""
+
+#: id:33026
+msgid "Departure from normal"
+msgstr ""
+
+#: id:33027
+msgid "Sunrise"
+msgstr ""
+
+#: id:33028
+msgid "Sunset"
+msgstr ""
+
+#: id:33029
+msgid "Details"
+msgstr ""
+
+#: id:33030
+msgid "Outlook"
+msgstr ""
+
+#: id:33031
+msgid "Coverflow"
+msgstr ""
+
+#: id:33032
+msgid "Translate text"
+msgstr ""
+
+#: id:33033
+msgid "Map list %s category"
+msgstr ""
+
+#: id:33034
+msgid "36 Hour"
+msgstr ""
+
+#: id:33035
+msgid "Maps"
+msgstr ""
+
+#: id:33036
+msgid "Hourly"
+msgstr ""
+
+#: id:33037
+msgid "Weekend"
+msgstr ""
+
+#: id:33038
+msgid "%s day"
+msgstr ""
+
+#: id:33049
+msgid "Alert"
+msgstr ""
+
+#: id:33050
+msgid "Alerts"
+msgstr ""
+
+#: id:33051
+msgid "Choose Your"
+msgstr ""
+
+#: id:33052
+msgid "Check"
+msgstr ""
+
+#: id:33053
+msgctxt "Auto context with id 33053"
+msgid "Configure the"
+msgstr ""
+
+#: id:33054
+msgid "Seasons"
+msgstr ""
+
+#: id:33055
+msgid "Use your"
+msgstr ""
+
+#: id:33056
+msgid "Watch your"
+msgstr ""
+
+#: id:33057
+msgid "Listen to"
+msgstr ""
+
+#: id:33058
+msgid "View your"
+msgstr ""
+
+#: id:33059
+msgctxt "Auto context with id 33059"
+msgid "Configure the"
+msgstr ""
+
+#: id:33060
+msgid "Power"
+msgstr ""
+
+#: id:33061
+msgid "Menu"
+msgstr ""
+
+#: id:33062
+msgid "Play the"
+msgstr ""
+
+#: id:33063
+msgid "Options"
+msgstr ""
+
+#: id:33065
+msgid "Editor"
+msgstr ""
+
+#: id:33066
+msgid "About your"
+msgstr ""
+
+#: id:33067
+msgid "Star rating"
+msgstr ""
+
+#: id:33068
+msgid "Background"
+msgstr ""
+
+#: id:33069
+msgid "Backgrounds"
+msgstr ""
+
+#: id:33070
+msgid "Custom background"
+msgstr ""
+
+#: id:33071
+msgid "Custom backgrounds"
+msgstr ""
+
+#: id:33072
+msgid "View Readme"
+msgstr ""
+
+#: id:33073
+msgid "View Changelog"
+msgstr ""
+
+#: id:33074
+msgid "This version of %s requires an"
+msgstr ""
+
+#: id:33075
+msgid "XBMC revision of %s or greater to run."
+msgstr ""
+
+#: id:33076
+msgid "Please update XBMC."
+msgstr ""
+
+#: id:33077
+msgid "No data found!"
+msgstr ""
+
+#: id:33078
+msgid "Next page"
+msgstr ""
+
+#: id:33079
+msgid "Love"
+msgstr ""
+
+#: id:33080
+msgid "Hate"
+msgstr ""
+
+#: id:33081
+msgid "This file is stacked, select the part you want to play from."
+msgstr ""
+
+#: id:33082
+msgid "Path to script"
+msgstr ""
+
+#: id:33083
+msgid "Enable custom script button"
+msgstr ""
+
+#: id:33100
+msgid "Failed to start"
+msgstr ""
+
+#: id:33101
+msgid "Webserver"
+msgstr ""
+
+#: id:33102
+msgid "Event Server"
+msgstr ""
+
+#: id:33103
+msgid "Remote communication server"
+msgstr ""
+
+#: id:33200
+msgid "Detected New Connection"
+msgstr ""
+
+#: id:34000
+msgid "Lame"
+msgstr ""
+
+#: id:34001
+msgid "Vorbis"
+msgstr ""
+
+#: id:34002
+msgid "Wav"
+msgstr ""
+
+#: id:34003
+msgid "DXVA2"
+msgstr ""
+
+#: id:34004
+msgid "VAAPI"
+msgstr ""
+
+#: id:34005
+msgid "Flac"
+msgstr ""
+
+#: id:34100
+msgid "Speaker Configuration"
+msgstr "Zvučnici - konfiguracija"
+
+#: id:34101
+msgid "2.0"
+msgstr ""
+
+#: id:34102
+msgid "2.1"
+msgstr ""
+
+#: id:34103
+msgid "3.0"
+msgstr ""
+
+#: id:34104
+msgid "3.1"
+msgstr ""
+
+#: id:34105
+msgid "4.0"
+msgstr ""
+
+#: id:34106
+msgid "4.1"
+msgstr ""
+
+#: id:34107
+msgid "5.0"
+msgstr ""
+
+#: id:34108
+msgid "5.1"
+msgstr ""
+
+#: id:34109
+msgid "7.0"
+msgstr ""
+
+#: id:34110
+msgid "7.1"
+msgstr ""
+
+#: id:34201
+msgid "Can't find a next item to play"
+msgstr ""
+
+#: id:34202
+msgid "Can't find a previous item to play"
+msgstr ""
+
+#: id:34300
+msgid "Failed to start zeroconf"
+msgstr ""
+
+#: id:34301
+msgid "Is Apple's Bonjour Service installed? See log for more info."
+msgstr ""
+
+#: id:34400
+msgid "Video Rendering"
+msgstr ""
+
+#: id:34401
+msgid "Failed to init video filters/scalers, falling back to bilinear scaling"
+msgstr ""
+
+#: id:34402
+msgid "Failed to initialize audio device"
+msgstr ""
+
+#: id:34403
+msgid "Check your audiosettings"
+msgstr ""
+
+#: id:34404
+msgid "Use gestures for navigation:"
+msgstr ""
+
+#: id:34405
+msgid "1 finger swipe left,right,up,down for cursors"
+msgstr ""
+
+#: id:34406
+msgid "2 finger swipe left for backspace"
+msgstr ""
+
+#: id:34407
+msgid "1 finger single tap for enter"
+msgstr ""
+
+#: id:34408
+msgid "2 finger single tap for contextmenu"
+msgstr ""
+
+#: id:35000
+msgid "Peripherals"
+msgstr ""
+
+#: id:35001
+msgid "Generic HID device"
+msgstr ""
+
+#: id:35002
+msgid "Generic network adapter"
+msgstr ""
+
+#: id:35003
+msgid "Generic disk"
+msgstr ""
+
+#: id:35004
+msgid "There are no settings available\nfor this peripheral."
+msgstr ""
+
+#: id:35005
+msgid "New device configured"
+msgstr ""
+
+#: id:35006
+msgid "Device removed"
+msgstr ""
+
+#: id:35007
+msgid "Keymap to use for this device"
+msgstr ""
+
+#: id:35008
+msgid "Keymap enabled"
+msgstr ""
+
+#: id:35009
+msgid "Do not use the custom keymap for this device"
+msgstr ""
+
+#: id:35500
+msgid "Location"
+msgstr ""
+
+#: id:35501
+msgid "Class"
+msgstr ""
+
+#: id:35502
+msgctxt "Auto context with id 35502"
+msgid "Name"
+msgstr ""
+
+#: id:35503
+msgid "Vendor"
+msgstr ""
+
+#: id:35504
+msgid "Product ID"
+msgstr ""
+
+#: id:36000
+msgid "Pulse-Eight CEC adapter"
+msgstr ""
+
+#: id:36001
+msgid "Pulse-Eight Nyxboard"
+msgstr ""
+
+#: id:36002
+msgid "Switch to keyboard side command"
+msgstr ""
+
+#: id:36003
+msgid "Switch to remote side command"
+msgstr ""
+
+#: id:36004
+msgid "Press \"user\" button command"
+msgstr ""
+
+#: id:36005
+msgid "Enable switch side commands"
+msgstr ""
+
+#: id:36006
+msgid "Could not open the adapter"
+msgstr ""
+
+#: id:36007
+msgid "Devices to power on when starting XBMC"
+msgstr ""
+
+#: id:36008
+msgid "Devices to power off when stopping XBMC"
+msgstr ""
+
+#: id:36009
+msgid "Put devices in standby mode when activating screensaver"
+msgstr ""
+
+#: id:36011
+msgid "Could not detect the CEC port. Set it up manually."
+msgstr ""
+
+#: id:36012
+msgid "Could not initialise the CEC adapter. Check your settings."
+msgstr ""
+
+#: id:36013
+msgid "Unsupported libCEC interface version. %d is greater than the version XBMC supports (%d)"
+msgstr ""
+
+#: id:36014
+msgid "Put this PC in standby mode when the TV is switched off"
+msgstr ""
+
+#: id:36015
+msgid "HDMI port number"
+msgstr ""
+
+#: id:36016
+msgctxt "Auto context with id 36016"
+msgid "Connected"
+msgstr ""
+
+#: id:36017
+msgid "Adapter found, but libCEC is not available"
+msgstr ""
+
+#: id:36018
+msgid "Use the TV's language setting"
+msgstr ""
+
+#: id:36019
+msgid "Connected to HDMI device"
+msgstr ""
+
+#: id:36020
+msgid "Make XBMC the active source when starting"
+msgstr ""
+
+#: id:36021
+msgid "Physical address (overrules HDMI port)"
+msgstr ""
+
+#: id:36022
+msgid "COM port (leave empty unless needed)"
+msgstr ""
+
+#: id:36023
+msgid "Configuration updated"
+msgstr ""
+
+#: id:36024
+msgid "Failed to set the new configuration. Please check your settings."
+msgstr ""
+
+#: id:36025
+msgid "Send 'inactive source' command when stopping XBMC"
+msgstr ""
+

--- a/language/Czech/strings.po
+++ b/language/Czech/strings.po
@@ -1,0 +1,9093 @@
+# Converted from xbmc strings.xml with xbmc-xml2po (by Team-XBMC)
+msgid ""
+msgstr ""
+"Project-Id-Version: xbmc.core-FRODO_GIT3ed1604ad7\n"
+"Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
+"POT-Creation-Date: 2012-04-09 18:00+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE\n"
+"Language: cs\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: id:0
+msgctxt "Auto context with id 0"
+msgid "Programs"
+msgstr "Programy"
+
+#: id:1
+msgctxt "Auto context with id 1"
+msgid "Pictures"
+msgstr "Obrázky"
+
+#: id:2
+msgctxt "Auto context with id 2"
+msgid "Music"
+msgstr "Hudba"
+
+#: id:3
+msgctxt "Auto context with id 3"
+msgid "Videos"
+msgstr "Video"
+
+#: id:4
+msgid "TV-Guide"
+msgstr "TV Program"
+
+#: id:5
+msgctxt "Auto context with id 5"
+msgid "Settings"
+msgstr "Nastavení"
+
+#: id:6
+msgid "XBMC SVN"
+msgstr "XBMC SVN"
+
+#: id:7
+msgctxt "Auto context with id 7"
+msgid "File manager"
+msgstr "Správce souborů"
+
+#: id:8
+msgctxt "Auto context with id 8"
+msgid "Weather"
+msgstr "Počasí"
+
+#: id:9
+msgid "xbmc media center"
+msgstr "xbmc media center"
+
+#: id:11
+msgid "Monday"
+msgstr "pondělí"
+
+#: id:12
+msgid "Tuesday"
+msgstr "úterý"
+
+#: id:13
+msgid "Wednesday"
+msgstr "středa"
+
+#: id:14
+msgid "Thursday"
+msgstr "čtvrtek"
+
+#: id:15
+msgid "Friday"
+msgstr "pátek"
+
+#: id:16
+msgid "Saturday"
+msgstr "sobota"
+
+#: id:17
+msgid "Sunday"
+msgstr "neděle"
+
+#: id:21
+msgid "January"
+msgstr "ledna"
+
+#: id:22
+msgid "February"
+msgstr "února"
+
+#: id:23
+msgid "March"
+msgstr "března"
+
+#: id:24
+msgid "April"
+msgstr "dubna"
+
+#: id:25
+msgctxt "Auto context with id 25"
+msgid "May"
+msgstr "května"
+
+#: id:26
+msgid "June"
+msgstr "června"
+
+#: id:27
+msgid "July"
+msgstr "července"
+
+#: id:28
+msgid "August"
+msgstr "srpna"
+
+#: id:29
+msgid "September"
+msgstr "září"
+
+#: id:30
+msgid "October"
+msgstr "října"
+
+#: id:31
+msgid "November"
+msgstr "listopadu"
+
+#: id:32
+msgid "December"
+msgstr "prosince"
+
+#: id:41
+msgid "Mon"
+msgstr "Po"
+
+#: id:42
+msgid "Tue"
+msgstr "Út"
+
+#: id:43
+msgid "Wed"
+msgstr "St"
+
+#: id:44
+msgid "Thu"
+msgstr "Čt"
+
+#: id:45
+msgid "Fri"
+msgstr "Pá"
+
+#: id:46
+msgid "Sat"
+msgstr "So"
+
+#: id:47
+msgctxt "Auto context with id 47"
+msgid "Sun"
+msgstr "Ne"
+
+#: id:51
+msgid "Jan"
+msgstr "led"
+
+#: id:52
+msgid "Feb"
+msgstr "úno"
+
+#: id:53
+msgid "Mar"
+msgstr "bře"
+
+#: id:54
+msgid "Apr"
+msgstr "dub"
+
+#: id:55
+msgctxt "Auto context with id 55"
+msgid "May"
+msgstr "kvě"
+
+#: id:56
+msgid "Jun"
+msgstr "čer"
+
+#: id:57
+msgid "Jul"
+msgstr "čec"
+
+#: id:58
+msgid "Aug"
+msgstr "srp"
+
+#: id:59
+msgid "Sep"
+msgstr "zář"
+
+#: id:60
+msgid "Oct"
+msgstr "říj"
+
+#: id:61
+msgid "Nov"
+msgstr "lis"
+
+#: id:62
+msgid "Dec"
+msgstr "pro"
+
+#: id:71
+msgid "N"
+msgstr "S"
+
+#: id:72
+msgid "NNE"
+msgstr "SSV"
+
+#: id:73
+msgid "NE"
+msgstr "SV"
+
+#: id:74
+msgid "ENE"
+msgstr "VSV"
+
+#: id:75
+msgid "E"
+msgstr "V"
+
+#: id:76
+msgid "ESE"
+msgstr "VJV"
+
+#: id:77
+msgid "SE"
+msgstr "JV"
+
+#: id:78
+msgid "SSE"
+msgstr "JJV"
+
+#: id:79
+msgid "S"
+msgstr "J"
+
+#: id:80
+msgid "SSW"
+msgstr "JJZ"
+
+#: id:81
+msgid "SW"
+msgstr "JZ"
+
+#: id:82
+msgid "WSW"
+msgstr "ZJZ"
+
+#: id:83
+msgid "W"
+msgstr "Z"
+
+#: id:84
+msgid "WNW"
+msgstr "ZSZ"
+
+#: id:85
+msgid "NW"
+msgstr "SZ"
+
+#: id:86
+msgid "NNW"
+msgstr "SSZ"
+
+#: id:87
+msgid "VAR"
+msgstr "proměnlivý"
+
+#: id:98
+msgid "View: Auto"
+msgstr "Zobrazení: automaticky"
+
+#: id:99
+msgid "View: Auto big"
+msgstr "Zobrazení: auto (velké)"
+
+#: id:100
+msgid "View: Icons"
+msgstr "Zobrazení: ikony"
+
+#: id:101
+msgid "View: List"
+msgstr "Zobrazení: seznam"
+
+#: id:102
+msgctxt "Auto context with id 102"
+msgid "Scan"
+msgstr "Prohledat"
+
+#: id:103
+msgctxt "Auto context with id 103"
+msgid "Sort by: Name"
+msgstr "Dle názvu"
+
+#: id:104
+msgid "Sort by: Date"
+msgstr "Dle data"
+
+#: id:105
+msgid "Sort by: Size"
+msgstr "Dle velikosti"
+
+#: id:106
+msgid "No"
+msgstr "Ne"
+
+#: id:107
+msgid "Yes"
+msgstr "Ano"
+
+#: id:108
+msgctxt "Auto context with id 108"
+msgid "Slideshow"
+msgstr "Prezentace"
+
+#: id:109
+msgid "Create thumbs"
+msgstr "Vytvořit náhledy"
+
+#: id:110
+msgid "Create thumbnails"
+msgstr "Vytvořit náhledy"
+
+#: id:111
+msgctxt "Auto context with id 111"
+msgid "Shortcuts"
+msgstr "Zástupci"
+
+#: id:112
+msgid "Paused"
+msgstr "Pozastaveno"
+
+#: id:113
+msgid "Update failed"
+msgstr "Aktualizace se nezdařila"
+
+#: id:114
+msgid "Installation failed"
+msgstr "Instalace se nezdařila"
+
+#: id:115
+msgid "Copy"
+msgstr "Kopírovat"
+
+#: id:116
+msgid "Move"
+msgstr "Přesunout"
+
+#: id:117
+msgid "Delete"
+msgstr "Odstranit"
+
+#: id:118
+msgid "Rename"
+msgstr "Přejmenovat"
+
+#: id:119
+msgid "New folder"
+msgstr "Nová složka"
+
+#: id:120
+msgid "Confirm file copy"
+msgstr "Potvrzení kopírování"
+
+#: id:121
+msgid "Confirm file move"
+msgstr "Potvrzení přesunutí"
+
+#: id:122
+msgid "Confirm file delete?"
+msgstr "Potvrzení odstranění"
+
+#: id:123
+msgid "Copy these files?"
+msgstr "Opravdu chcete tyto soubory zkopírovat?"
+
+#: id:124
+msgid "Move these files?"
+msgstr "Opravdu chcete tyto soubory přesunout?"
+
+#: id:125
+msgid "Delete these files? - Deleting files cannot be undone!"
+msgstr "Opravdu chcete tyto soubory nevratně odstranit?"
+
+#: id:126
+msgid "Status"
+msgstr "Průběh"
+
+#: id:127
+msgid "Objects"
+msgstr "Objekt(ů)"
+
+#: id:128
+msgctxt "Auto context with id 128"
+msgid "General"
+msgstr "Hlavní"
+
+#: id:129
+msgctxt "Auto context with id 129"
+msgid "Slideshow"
+msgstr "Prezentace"
+
+#: id:130
+msgctxt "Auto context with id 130"
+msgid "System info"
+msgstr "Informace o systému"
+
+#: id:131
+msgid "Display"
+msgstr "Obrazovka"
+
+#: id:132
+msgid "Albums"
+msgstr "Alba"
+
+#: id:133
+msgid "Artists"
+msgstr "Interpreti"
+
+#: id:134
+msgid "Songs"
+msgstr "Skladby"
+
+#: id:135
+msgid "Genres"
+msgstr "Žánry"
+
+#: id:136
+msgid "Playlists"
+msgstr "Seznamy stop"
+
+#: id:137
+msgid "Search"
+msgstr "Hledat"
+
+#: id:138
+msgid "System Information"
+msgstr "Informace o systému"
+
+#: id:139
+msgid "Temperatures:"
+msgstr "Teploty:"
+
+#: id:140
+msgid "CPU:"
+msgstr "Procesor:"
+
+#: id:141
+msgid "GPU:"
+msgstr "Grafická karta:"
+
+#: id:142
+msgid "Time:"
+msgstr "Čas:"
+
+#: id:143
+msgid "Current:"
+msgstr "Aktuálně:"
+
+#: id:144
+msgid "Build:"
+msgstr "Sestavení:"
+
+#: id:145
+msgid "Network:"
+msgstr "Síť:"
+
+#: id:146
+msgid "Type:"
+msgstr "Typ:"
+
+#: id:147
+msgid "Static"
+msgstr "Statická"
+
+#: id:148
+msgid "DHCP"
+msgstr "DHCP"
+
+#: id:149
+msgid "MAC address"
+msgstr "MAC adresa"
+
+#: id:150
+msgctxt "Auto context with id 150"
+msgid "IP address"
+msgstr "IP adresa"
+
+#: id:151
+msgid "Link:"
+msgstr "Stav:"
+
+#: id:152
+msgid "Half duplex"
+msgstr "Poloviční duplex"
+
+#: id:153
+msgid "Full duplex"
+msgstr "Plný duplex"
+
+#: id:154
+msgctxt "Auto context with id 154"
+msgid "Storage"
+msgstr "Kapacita"
+
+#: id:155
+msgid "Drive"
+msgstr "Disk"
+
+#: id:156
+msgctxt "Auto context with id 156"
+msgid "Free"
+msgstr "- volné místo"
+
+#: id:157
+msgctxt "Auto context with id 157"
+msgid "Video"
+msgstr "Video"
+
+#: id:158
+msgid "Free memory"
+msgstr "Volná operační paměť"
+
+#: id:159
+msgid "No link"
+msgstr "Nepřipojeno"
+
+#: id:160
+msgctxt "Auto context with id 160"
+msgid "Free"
+msgstr "volných"
+
+#: id:161
+msgid "Unavailable"
+msgstr "Nedostupné"
+
+#: id:162
+msgid "Tray open"
+msgstr "Vysunout disk"
+
+#: id:163
+msgid "Reading"
+msgstr "Načítám"
+
+#: id:164
+msgid "No disc"
+msgstr "Žádné médium"
+
+#: id:165
+msgid "Disc present"
+msgstr "Médium vloženo"
+
+#: id:166
+msgid "Skin"
+msgstr "Vzhled"
+
+#: id:169
+msgctxt "Auto context with id 169"
+msgid "Resolution"
+msgstr "Rozlišení obrazovky"
+
+#: id:170
+msgid "Adjust display refresh rate to match video"
+msgstr "Přizpůsobovat obnovovací frekvenci obrazovky dle videa"
+
+#: id:172
+msgid "Release date"
+msgstr "Datum vydání"
+
+#: id:173
+msgid "Display 4:3 videos as"
+msgstr "Režim zobrazení 4:3 videí"
+
+#: id:175
+msgid "Moods"
+msgstr "Nálady"
+
+#: id:176
+msgid "Styles"
+msgstr "Styly"
+
+#: id:179
+msgid "Song"
+msgstr "Skladba"
+
+#: id:180
+msgid "Duration"
+msgstr "Délka"
+
+#: id:181
+msgid "Select album"
+msgstr "Vyberte album"
+
+#: id:182
+msgid "Tracks"
+msgstr "Stopy"
+
+#: id:183
+msgid "Review"
+msgstr "Recenze"
+
+#: id:184
+msgid "Refresh"
+msgstr "Aktualizovat"
+
+#: id:185
+msgid "Searching album"
+msgstr "Probíhá vyhledávání alba"
+
+#: id:186
+msgid "OK"
+msgstr "OK"
+
+#: id:187
+msgid "No albums found!"
+msgstr "Žádná alba nebyla nalezena!"
+
+#: id:188
+msgid "Select all"
+msgstr "Vybrat vše"
+
+#: id:189
+msgid "Scanning media info"
+msgstr "Probíhá získávání informací o médiu"
+
+#: id:190
+msgid "Save"
+msgstr "Uložit"
+
+#: id:191
+msgid "Shuffle"
+msgstr "Promíchat"
+
+#: id:192
+msgctxt "Auto context with id 192"
+msgid "Clear"
+msgstr "Vymazat"
+
+#: id:193
+msgctxt "Auto context with id 193"
+msgid "Scan"
+msgstr "Prohledat"
+
+#: id:194
+msgid "Searching..."
+msgstr "Hledám..."
+
+#: id:195
+msgid "No info found!"
+msgstr "Informace nenalezeny!"
+
+#: id:196
+msgid "Select movie:"
+msgstr "Vyberte film:"
+
+#: id:197
+msgid "Querying %s info"
+msgstr "Probíhá získávání informací pro %s"
+
+#: id:198
+msgid "Loading movie details"
+msgstr "Probíhá načítání informací k filmu"
+
+#: id:199
+msgid "Web interface"
+msgstr "Webové rozhraní"
+
+#: id:202
+msgid "Tagline"
+msgstr "Ve zkratce"
+
+#: id:203
+msgid "Plot outline"
+msgstr "Děj filmu"
+
+#: id:205
+msgid "Votes"
+msgstr "Počet hlasů"
+
+#: id:206
+msgid "Cast"
+msgstr "Obsazení"
+
+#: id:207
+msgid "Plot"
+msgstr "Děj"
+
+#: id:208
+msgctxt "Auto context with id 208"
+msgid "Play"
+msgstr "Přehrát"
+
+#: id:209
+msgid "Next"
+msgstr "Další"
+
+#: id:210
+msgid "Previous"
+msgstr "Předchozí"
+
+#: id:213
+msgid "Calibrate user interface..."
+msgstr "Kalibrace uživatelského rozhraní..."
+
+#: id:214
+msgid "Video calibration..."
+msgstr "Kalibrace obrazu..."
+
+#: id:215
+msgid "Soften"
+msgstr "Změkčení"
+
+#: id:216
+msgid "Zoom amount"
+msgstr "Přiblížení"
+
+#: id:217
+msgid "Pixel ratio"
+msgstr "Poměr stran"
+
+#: id:218
+msgid "DVD drive"
+msgstr "DVD mechanika"
+
+#: id:219
+msgid "Please insert disc"
+msgstr "Vložte prosím disk"
+
+#: id:220
+msgid "Remote share"
+msgstr "Vzdálené sdílení"
+
+#: id:221
+msgid "Network is not connected"
+msgstr "Síť není připojena"
+
+#: id:222
+msgid "Cancel"
+msgstr "Storno"
+
+#: id:224
+msgid "Speed"
+msgstr "Čas zobrazení obrázku"
+
+#: id:225
+msgid "Vertical Shift"
+msgstr "Vertikální posunutí"
+
+#: id:226
+msgid "Test patterns..."
+msgstr "Testovací obrazce..."
+
+#: id:227
+msgid "Lookup audio CD track names from freedb.org"
+msgstr "Stahovat informace o CD z freedb.org"
+
+#: id:228
+msgid "Shuffle playlist on load"
+msgstr "Po načtení seznamu stop přehrávat skladby náhodně"
+
+#: id:229
+msgid "HDD spindown time"
+msgstr "Uspávat HDD"
+
+#: id:230
+msgid "Video filters"
+msgstr "Video filtry"
+
+#: id:231
+msgctxt "Auto context with id 231"
+msgid "None"
+msgstr "vypnuto"
+
+#: id:232
+msgid "Point"
+msgstr "Bodový"
+
+#: id:233
+msgid "Linear"
+msgstr "Lineární"
+
+#: id:234
+msgid "Anisotropic"
+msgstr "Anisotropní"
+
+#: id:235
+msgid "Quincunx"
+msgstr "Quincunx"
+
+#: id:236
+msgid "Gaussian cubic"
+msgstr "Gaussovsko Kubický"
+
+#: id:237
+msgid "Minification"
+msgstr "Zmenšení"
+
+#: id:238
+msgid "Magnification"
+msgstr "Zvětšení"
+
+#: id:239
+msgid "Clear playlist on finish"
+msgstr "Vymazat seznam stop po dokončení přehrávání"
+
+#: id:240
+msgid "Display Mode"
+msgstr "Režim zobrazení"
+
+#: id:241
+msgid "Full Screen #%d"
+msgstr "Celá obrazovka #%d"
+
+#: id:242
+msgid "Windowed"
+msgstr "V okně"
+
+#: id:243
+msgid "Refresh Rate"
+msgstr "Obnovovací frekvence"
+
+#: id:244
+msgid "Full screen"
+msgstr "Celá obrazovka"
+
+#: id:245
+msgid "Sizing: (%i,%i)->(%i,%i) (Zoom x%2.2f) AR:%2.2f:1 (Pixels: %2.2f:1) (VShift: %2.2f)"
+msgstr "Změna velikosti: (%i,%i)->(%i,%i) (Přiblížení x%2.2f) AR:%2.2f:1 (Pixelů: %2.2f:1) (VShift: %2.2f)"
+
+#: id:247
+msgctxt "Auto context with id 247"
+msgid "Scripts"
+msgstr "Skripty"
+
+#: id:248
+msgctxt "Auto context with id 248"
+msgid "Language"
+msgstr "Jazyk"
+
+#: id:249
+msgctxt "Auto context with id 249"
+msgid "Music"
+msgstr "Hudba"
+
+#: id:250
+msgctxt "Auto context with id 250"
+msgid "Visualization"
+msgstr "Vizualizace"
+
+#: id:251
+msgid "Select destination directory"
+msgstr "Vyberte cílovou složku"
+
+#: id:252
+msgid "Output stereo to all speakers"
+msgstr "Přehrávat stereo zvuk ze všech reproduktorů"
+
+#: id:253
+msgid "Number of channels"
+msgstr "Počet kanálů"
+
+#: id:254
+msgid "- DTS capable receiver"
+msgstr "- DTS kompatibilní receiver"
+
+#: id:255
+msgid "CDDB"
+msgstr "CDDB"
+
+#: id:256
+msgid "Fetching CD information"
+msgstr "Probíhá stahování informací o CD"
+
+#: id:257
+msgid "Error"
+msgstr "Chyba"
+
+#: id:258
+msgid "Enable tag reading"
+msgstr "Zobrazovat ID3 popisky"
+
+#: id:259
+msgid "Opening"
+msgstr "Otevírám"
+
+#: id:260
+msgid "Shoutcast"
+msgstr "Shoutcast"
+
+#: id:261
+msgid "Waiting for start..."
+msgstr "Probíhá příprava spuštění..."
+
+#: id:262
+msgid "Scripts output"
+msgstr "Výstup skriptů"
+
+#: id:263
+msgid "Allow control of XBMC via HTTP"
+msgstr "Povolit ovládání XBMC přes HTTP"
+
+#: id:264
+msgid "Record"
+msgstr "Nahrávat"
+
+#: id:265
+msgid "Stop Rec."
+msgstr "Ukončit nahrávání"
+
+#: id:266
+msgid "Sort by: Track"
+msgstr "Dle stopy"
+
+#: id:267
+msgid "Sort by: Time"
+msgstr "Dle času"
+
+#: id:268
+msgid "Sort by: Title"
+msgstr "Dle názvu"
+
+#: id:269
+msgid "Sort by: Artist"
+msgstr "Dle interpreta"
+
+#: id:270
+msgid "Sort by: Album"
+msgstr "Dle alba"
+
+#: id:271
+msgid "Top 100"
+msgstr "Top 100"
+
+#: id:272
+msgid "Top-Left overscan compensation"
+msgstr "Nastavení levého horního okraje"
+
+#: id:273
+msgid "Bottom-Right overscan compensation"
+msgstr "Nastavení pravého dolního okraje"
+
+#: id:274
+msgid "Subtitle positioning"
+msgstr "Umístění titulků"
+
+#: id:275
+msgid "Pixel ratio adjustment"
+msgstr "Přizpůsobení poměru stran"
+
+#: id:276
+msgid "Adjust the arrow to change the amount of overscan"
+msgstr "Posunutím šipky nastavte okraj obrazovky"
+
+#: id:277
+msgid "Adjust the bar to change the subtitles position"
+msgstr "Posunutím přímky nastavte umístění titulků"
+
+#: id:278
+msgid "Adjust the rectangle so it is perfectly square"
+msgstr "Nastavte strany tak, aby vznikl čtverec"
+
+#: id:279
+msgid "Unable to load settings"
+msgstr "Nastavení nelze načíst"
+
+#: id:280
+msgid "Using default settings"
+msgstr "Program načte výchozí nastavení"
+
+#: id:281
+msgid "Please check the XML files"
+msgstr "Zkontrolujte prosím .xml soubory"
+
+#: id:282
+msgid "Found %i items"
+msgstr "Nalezeno %i položek"
+
+#: id:283
+msgid "Search results"
+msgstr "Výsledky hledání"
+
+#: id:284
+msgid "No results found"
+msgstr "Žádné výsledky nebyly nalezeny"
+
+#: id:287
+msgctxt "Auto context with id 287"
+msgid "Subtitles"
+msgstr "Titulky"
+
+#: id:288
+msgctxt "Auto context with id 288"
+msgid "Font"
+msgstr "Písmo"
+
+#: id:289
+msgctxt "Auto context with id 289"
+msgid "- Size"
+msgstr "- Velikost"
+
+#: id:290
+msgid "Dynamic range compression"
+msgstr "Zvýšení hlasitosti"
+
+#: id:291
+msgctxt "Auto context with id 291"
+msgid "Video"
+msgstr "Video"
+
+#: id:292
+msgctxt "Auto context with id 292"
+msgid "Audio"
+msgstr "Zvuk"
+
+#: id:293
+msgid "Browse for subtitles"
+msgstr "Titulky"
+
+#: id:294
+msgid "Create bookmark"
+msgstr "Vytvořit záložku"
+
+#: id:296
+msgid "Clear bookmarks"
+msgstr "Vymazat záložky"
+
+#: id:297
+msgid "Audio offset"
+msgstr "Posunutí zvuku"
+
+#: id:298
+msgid "Bookmarks"
+msgstr "Záložky"
+
+#: id:299
+msgid "- AAC capable receiver"
+msgstr "- AAC kompatibilní receiver"
+
+#: id:300
+msgid "- MP1 capable receiver"
+msgstr "- MP1 kompatibilní receiver"
+
+#: id:301
+msgid "- MP2 capable receiver"
+msgstr "- MP2 kompatibilní receiver"
+
+#: id:302
+msgid "- MP3 capable receiver"
+msgstr "- MP3 kompatibilní receiver"
+
+#: id:303
+msgid "Delay"
+msgstr "Posunutí titulků"
+
+#: id:304
+msgctxt "Auto context with id 304"
+msgid "Language"
+msgstr "Jazyk"
+
+#: id:305
+msgctxt "Auto context with id 305"
+msgid "Enabled"
+msgstr "Aktivováno"
+
+#: id:306
+msgid "Non-interleaved"
+msgstr "Neprokládané video"
+
+#: id:312
+msgid "(0=auto)"
+msgstr "(0=auto)"
+
+#: id:313
+msgid "Cleaning database"
+msgstr "Probíhá aktualizace knihovny"
+
+#: id:314
+msgid "Preparing..."
+msgstr "Probíhá příprava..."
+
+#: id:315
+msgid "Database error"
+msgstr "Chyba knihovny"
+
+#: id:316
+msgid "Searching songs..."
+msgstr "Probíhá vyhledávání skladeb..."
+
+#: id:317
+msgid "Cleaned database successfully"
+msgstr "Reorganizace proběhla úspěšně"
+
+#: id:318
+msgid "Cleaning songs..."
+msgstr "Probíhá označení skladeb k odstranění"
+
+#: id:319
+msgid "Error cleaning songs"
+msgstr "Chyba při reorganizaci skladeb"
+
+#: id:320
+msgid "Cleaning artists..."
+msgstr "Probíhá vyhledávání interpretů..."
+
+#: id:321
+msgid "Error cleaning artists"
+msgstr "Chyba při reorganizaci interpretů"
+
+#: id:322
+msgid "Cleaning genres..."
+msgstr "Probíhá vyhledávání žánrů..."
+
+#: id:323
+msgid "Error cleaning genres"
+msgstr "Chyba při reorganizaci žánrů"
+
+#: id:324
+msgid "Cleaning paths..."
+msgstr "Probíhá vyhledávání cesty..."
+
+#: id:325
+msgid "Error cleaning paths"
+msgstr "Chyba při reorganizaci cest"
+
+#: id:326
+msgid "Cleaning albums..."
+msgstr "Probíhá vyhledávání alb..."
+
+#: id:327
+msgid "Error cleaning albums"
+msgstr "Chyba při reorganizaci alb"
+
+#: id:328
+msgid "Writing changes..."
+msgstr "Probíhá ukládání změn..."
+
+#: id:329
+msgid "Error writing changes"
+msgstr "Chyba při ukládání změn"
+
+#: id:330
+msgid "This may take some time..."
+msgstr "Tento proces může chvíli trvat..."
+
+#: id:331
+msgid "Compressing database..."
+msgstr "Probíhá komprimace knihovny..."
+
+#: id:332
+msgid "Error compressing database"
+msgstr "Chyba při komprimaci knihovny"
+
+#: id:333
+msgid "Do you want to clean the library?"
+msgstr "Chcete aktualizovat položky v knihovně?"
+
+#: id:334
+msgid "Clean library..."
+msgstr "Aktualizovat položky v knihovně..."
+
+#: id:335
+msgid "Start"
+msgstr "Spustit"
+
+#: id:336
+msgid "Framerate conversion"
+msgstr "Přizpůsobit snímkování TV normě"
+
+#: id:337
+msgctxt "Auto context with id 337"
+msgid "Audio output"
+msgstr "Zvukový výstup"
+
+#: id:338
+msgid "Analog"
+msgstr "Analogový"
+
+#: id:339
+msgid "Optical/Coax"
+msgstr "Optický/Koaxiální"
+
+#: id:340
+msgid "Various artists"
+msgstr "Různí interpreti"
+
+#: id:341
+msgid "Play disc"
+msgstr "Přehrát disk"
+
+#: id:342
+msgctxt "Auto context with id 342"
+msgid "Movies"
+msgstr "Filmy"
+
+#: id:343
+msgid "Adjust framerate"
+msgstr "Přizpůsobovat snímkování TV normě"
+
+#: id:344
+msgid "Actors"
+msgstr "Herci"
+
+#: id:345
+msgctxt "Auto context with id 345"
+msgid "Year"
+msgstr "Rok"
+
+#: id:346
+msgid "Boost volume level on downmix"
+msgstr "Zvyšovat hlasitost při downmixu"
+
+#: id:350
+msgctxt "Auto context with id 350"
+msgid "Programs"
+msgstr "Programy"
+
+#: id:351
+msgctxt "Auto context with id 351"
+msgid "Off"
+msgstr "Vypnuto"
+
+#: id:352
+msgid "Dim"
+msgstr "Ztmavení"
+
+#: id:353
+msgid "Black"
+msgstr "Černá obrazovka"
+
+#: id:354
+msgid "Matrix trails"
+msgstr "Kód Matrixu"
+
+#: id:355
+msgid "Screensaver time"
+msgstr "Počkat"
+
+#: id:356
+msgid "Screensaver mode"
+msgstr "Spořič obrazovky"
+
+#: id:357
+msgid "Shutdown function timer"
+msgstr "Vypnout systém při nečinnosti"
+
+#: id:358
+msgid "All albums"
+msgstr "Všechna alba"
+
+#: id:359
+msgid "Recently added albums"
+msgstr "Nejnovější alba"
+
+#: id:360
+msgctxt "Auto context with id 360"
+msgid "Screensaver"
+msgstr "Spořič obrazovky"
+
+#: id:361
+msgid "R. Slideshow"
+msgstr "Celková prezentace"
+
+#: id:362
+msgid "Screensaver dim level"
+msgstr "Úroveň ztmavení"
+
+#: id:363
+msgid "Sort by: File"
+msgstr "Dle souborů"
+
+#: id:364
+msgid "- Dolby Digital (AC3) capable receiver"
+msgstr "- Dolby Digital (AC3) kompatibilní reciever"
+
+#: id:365
+msgctxt "Auto context with id 365"
+msgid "Sort by: Name"
+msgstr "Dle názvu"
+
+#: id:366
+msgid "Sort by: Year"
+msgstr "Dle roku"
+
+#: id:367
+msgid "Sort by: Rating"
+msgstr "Dle hodnocení"
+
+#: id:368
+msgid "IMDb"
+msgstr "IMDb"
+
+#: id:369
+msgctxt "Auto context with id 369"
+msgid "Title"
+msgstr "Název"
+
+#: id:370
+msgid "Thunderstorms"
+msgstr "bouřky"
+
+#: id:371
+msgid "Partly"
+msgstr "částečně"
+
+#: id:372
+msgid "Mostly"
+msgstr "převážně"
+
+#: id:373
+msgid "Sunny"
+msgstr "jasno"
+
+#: id:374
+msgid "Cloudy"
+msgstr "zataženo"
+
+#: id:375
+msgid "Snow"
+msgstr "sněžení"
+
+#: id:376
+msgid "Rain"
+msgstr "déšť"
+
+#: id:377
+msgid "Light"
+msgstr "slabý(é)"
+
+#: id:378
+msgid "AM"
+msgstr "dop."
+
+#: id:379
+msgid "PM"
+msgstr "odp."
+
+#: id:380
+msgid "Showers"
+msgstr "přeháňky"
+
+#: id:381
+msgid "Few"
+msgstr "ojediněle"
+
+#: id:382
+msgid "Scattered"
+msgstr "místy"
+
+#: id:383
+msgctxt "Auto context with id 383"
+msgid "Wind"
+msgstr "vítr"
+
+#: id:384
+msgid "Strong"
+msgstr "silný"
+
+#: id:385
+msgid "Fair"
+msgstr "skoro jasno"
+
+#: id:386
+msgctxt "Auto context with id 386"
+msgid "Clear"
+msgstr "jasno"
+
+#: id:387
+msgid "Clouds"
+msgstr "oblačno"
+
+#: id:388
+msgid "Early"
+msgstr "ranní"
+
+#: id:389
+msgid "Shower"
+msgstr "přeháňky"
+
+#: id:390
+msgid "Flurries"
+msgstr "sněhové přeháňky"
+
+#: id:391
+msgctxt "Auto context with id 391"
+msgid "Low"
+msgstr "nízký"
+
+#: id:392
+msgctxt "Auto context with id 392"
+msgid "Medium"
+msgstr "střední"
+
+#: id:393
+msgctxt "Auto context with id 393"
+msgid "High"
+msgstr "vysoký"
+
+#: id:394
+msgid "Fog"
+msgstr "mlha"
+
+#: id:395
+msgid "Haze"
+msgstr "opar"
+
+#: id:396
+msgid "Select location"
+msgstr "Vyberte město"
+
+#: id:397
+msgid "Refresh time"
+msgstr "Obnovovat po"
+
+#: id:398
+msgid "Temperature units"
+msgstr "Jednotky teploty"
+
+#: id:399
+msgid "Speed units"
+msgstr "Jednotky rychlosti"
+
+#: id:400
+msgctxt "Auto context with id 400"
+msgid "Weather"
+msgstr "Počasí"
+
+#: id:401
+msgid "Temp"
+msgstr "Teplota"
+
+#: id:402
+msgid "Feels like"
+msgstr "Pocitově"
+
+#: id:403
+msgid "UV index"
+msgstr "UV index"
+
+#: id:404
+msgctxt "Auto context with id 404"
+msgid "Wind"
+msgstr "Vítr"
+
+#: id:405
+msgid "Dew point"
+msgstr "Rosný bod"
+
+#: id:406
+msgid "Humidity"
+msgstr "Vlhkost"
+
+#: id:409
+msgid "Defaults"
+msgstr "Výchozí hodnoty"
+
+#: id:410
+msgid "Accessing weather service"
+msgstr "Probíhá připojování k weather.com"
+
+#: id:411
+msgid "Getting weather for:"
+msgstr "Probíhá stahování počasí pro:"
+
+#: id:412
+msgid "Unable to get weather data"
+msgstr "Informace o počasí se nepodařilo získat"
+
+#: id:413
+msgid "Manual"
+msgstr "Ručně"
+
+#: id:414
+msgid "No review for this album"
+msgstr "Recenze tohoto alba není k dispozici"
+
+#: id:415
+msgid "Downloading thumbnail..."
+msgstr "Probíhá stahování náhledu..."
+
+#: id:416
+msgid "Not available"
+msgstr "Není k dispozici"
+
+#: id:417
+msgid "View: Big icons"
+msgstr "Velké ikony"
+
+#: id:418
+msgctxt "Auto context with id 418"
+msgid "Low"
+msgstr "Noc"
+
+#: id:419
+msgctxt "Auto context with id 419"
+msgid "High"
+msgstr "Den"
+
+#: id:420
+msgid "HDMI"
+msgstr "HDMI"
+
+#: id:422
+msgid "Delete album info"
+msgstr "Smazat informace o albu"
+
+#: id:423
+msgid "Delete CD information"
+msgstr "Smazat informace o CD"
+
+#: id:424
+msgid "Select"
+msgstr "Vybrat"
+
+#: id:425
+msgid "No album information found"
+msgstr "Informace o albu nebyly nalezeny"
+
+#: id:426
+msgid "No CD information found"
+msgstr "Informace o CD nenalezeny"
+
+#: id:427
+msgid "Disc"
+msgstr "Disk"
+
+#: id:428
+msgid "Insert correct CD/DVD"
+msgstr "Vložte správné CD/DVD"
+
+#: id:429
+msgid "Please insert the following disc:"
+msgstr "Vložte prosím disk s označením:"
+
+#: id:430
+msgid "Sort by: DVD#"
+msgstr "Dle DVD#"
+
+#: id:431
+msgid "No cache"
+msgstr "Nepoužívat mezipaměť"
+
+#: id:432
+msgid "Remove movie from library"
+msgstr "Odebrat film z knihovny"
+
+#: id:433
+msgid "Really remove '%s'?"
+msgstr "Opravdu chcete odebrat '%s'?"
+
+#: id:434
+msgid "From %s at %i %s"
+msgstr "%s %i %s"
+
+#: id:437
+msgid "Removable disk"
+msgstr "Vyměnitelný disk"
+
+#: id:438
+msgid "Opening file"
+msgstr "Probíhá otevírání souboru"
+
+#: id:439
+msgid "Cache"
+msgstr "Mezipaměť"
+
+#: id:440
+msgid "Harddisk"
+msgstr "HDD"
+
+#: id:441
+msgid "UDF"
+msgstr "UDF"
+
+#: id:442
+msgid "Local network"
+msgstr "Lokální síť"
+
+#: id:443
+msgid "Internet"
+msgstr "Internet"
+
+#: id:444
+msgctxt "Auto context with id 444"
+msgid "Video"
+msgstr "Video"
+
+#: id:445
+msgctxt "Auto context with id 445"
+msgid "Audio"
+msgstr "Audio"
+
+#: id:446
+msgctxt "Auto context with id 446"
+msgid "DVD"
+msgstr "DVD"
+
+#: id:447
+msgid "Autorun media"
+msgstr "Automaticky přehrávat média"
+
+#: id:448
+msgid "LCD"
+msgstr "LCD"
+
+#: id:449
+msgctxt "Auto context with id 449"
+msgid "Enabled"
+msgstr "Aktivní"
+
+#: id:450
+msgid "Columns"
+msgstr "Počet sloupců"
+
+#: id:451
+msgid "Row 1 address"
+msgstr "Adresa 1. řádku"
+
+#: id:452
+msgid "Row 2 address"
+msgstr "Adresa 2. řádku"
+
+#: id:453
+msgid "Row 3 address"
+msgstr "Adresa 3. řádku"
+
+#: id:454
+msgid "Row 4 address"
+msgstr "Adresa 4. řádku"
+
+#: id:455
+msgid "Rows"
+msgstr "Počet řádků"
+
+#: id:456
+msgid "Mode"
+msgstr "Mód"
+
+#: id:457
+msgid "Switch view"
+msgstr "Zobrazení"
+
+#: id:459
+msgid "Subs"
+msgstr "Titulky"
+
+#: id:460
+msgid "Audio stream"
+msgstr "Zvuková stopa"
+
+#: id:461
+msgid "[active]"
+msgstr "[aktivní]"
+
+#: id:462
+msgid "Subtitle"
+msgstr "Titulky"
+
+#: id:463
+msgid "Backlight"
+msgstr "Podsvícení"
+
+#: id:464
+msgid "Brightness"
+msgstr "Jas"
+
+#: id:465
+msgid "Contrast"
+msgstr "Kontrast"
+
+#: id:466
+msgid "Gamma"
+msgstr "Gama"
+
+#: id:467
+msgctxt "Auto context with id 467"
+msgid "Type"
+msgstr "Typ"
+
+#: id:468
+msgid "Move the bar to change the OSD position"
+msgstr "Posunutím jezdce změníte umístění OSD"
+
+#: id:469
+msgid "OSD position"
+msgstr "Umístění OSD menu"
+
+#: id:470
+msgid "Credits"
+msgstr "Interpreti"
+
+#: id:471
+msgid "Modchip"
+msgstr "Modchip"
+
+#: id:474
+msgctxt "Auto context with id 474"
+msgid "Off"
+msgstr "Vyp."
+
+#: id:475
+msgid "Music only"
+msgstr "Pouze hudbu"
+
+#: id:476
+msgctxt "Auto context with id 476"
+msgid "Music & video"
+msgstr "Hudbu a Video"
+
+#: id:477
+msgid "Unable to load playlist"
+msgstr "Seznam stop nelze načíst"
+
+#: id:478
+msgid "OSD"
+msgstr "OSD"
+
+#: id:479
+msgid "Skin & language"
+msgstr "Vzhled a Jazyk"
+
+#: id:480
+msgid "Appearance"
+msgstr "Prostředí"
+
+#: id:481
+msgid "Audio options"
+msgstr "Zvuk"
+
+#: id:482
+msgid "About XBMC"
+msgstr "O XBMC"
+
+#: id:485
+msgid "Delete album"
+msgstr "Odebrat album"
+
+#: id:486
+msgid "Repeat"
+msgstr "Opakovat"
+
+#: id:487
+msgid "Repeat one"
+msgstr "Opakovat 1x"
+
+#: id:488
+msgid "Repeat folder"
+msgstr "Opakovat vše"
+
+#: id:489
+msgid "Play the next song automatically"
+msgstr "Automaticky přehrávat následující skladbu"
+
+#: id:491
+msgid "- Use big icons"
+msgstr "- Používat velké ikony"
+
+#: id:492
+msgid "Resize VobSubs"
+msgstr "Velikost Vobsubs"
+
+#: id:493
+msgid "Advanced options (Experts Only!)"
+msgstr "Pokročilá nastavení (Pouze pro experty!)"
+
+#: id:494
+msgid "Overall audio headroom"
+msgstr "Celková hlasitost"
+
+#: id:495
+msgid "Upsample videos to GUI resolution"
+msgstr "Přepočítávat videa do rozlišení graf. rozhraní XBMC"
+
+#: id:496
+msgid "Calibration"
+msgstr "Kalibrace"
+
+#: id:497
+msgid "Show file extensions"
+msgstr "Zobrazovat přípony médií"
+
+#: id:498
+msgid "Sort by: Type"
+msgstr "Dle typu"
+
+#: id:499
+msgid "Unable to connect to online lookup service"
+msgstr "Nelze se připojit k online vyhledávání"
+
+#: id:500
+msgid "Downloading album information failed"
+msgstr "Stahování informací o albu selhalo"
+
+#: id:501
+msgid "Looking for album names..."
+msgstr "Probíhá hledání názvů alb..."
+
+#: id:502
+msgctxt "Auto context with id 502"
+msgid "Open"
+msgstr "vysunutá"
+
+#: id:503
+msgid "Busy"
+msgstr "načítá se obsah"
+
+#: id:504
+msgid "Empty"
+msgstr "bez média"
+
+#: id:505
+msgid "Loading media info from files..."
+msgstr "Probíhá načítání informací ze souboru..."
+
+#: id:507
+msgid "Sort by: Usage"
+msgstr "Dle využití"
+
+#: id:510
+msgid "Enable visualizations"
+msgstr "Zobrazovat vizualizace"
+
+#: id:511
+msgid "Enable video mode switching"
+msgstr "Automaticky přepínat TV normu podle oblasti hry"
+
+#: id:512
+msgid "Startup window"
+msgstr "Po spuštění zobrazit"
+
+#: id:513
+msgid "Home window"
+msgstr "Úvodní obrazovka"
+
+#: id:514
+msgid "Manual settings"
+msgstr "Manuální nastavení"
+
+#: id:515
+msgid "Genre"
+msgstr "Žánr"
+
+#: id:517
+msgid "Recently played albums"
+msgstr "Poslední poslech"
+
+#: id:518
+msgid "Launch"
+msgstr "Spustit"
+
+#: id:519
+msgid "Launch in..."
+msgstr "Spustit v..."
+
+#: id:521
+msgid "Compilations"
+msgstr "Kompilace"
+
+#: id:522
+msgid "Remove source"
+msgstr "Odebrat zdroj"
+
+#: id:523
+msgid "Switch media"
+msgstr "Přejít do jiné sekce"
+
+#: id:524
+msgid "Select playlist"
+msgstr "Vyberte Seznam stop"
+
+#: id:525
+msgid "New playlist..."
+msgstr "Nový seznam stop"
+
+#: id:526
+msgid "Add to playlist"
+msgstr "Přidat do Seznamu stop"
+
+#: id:527
+msgid "Manually add to library"
+msgstr "Přidat do Knihovny"
+
+#: id:528
+msgid "Enter title"
+msgstr "Zadejte název"
+
+#: id:529
+msgid "Error: Duplicate title"
+msgstr "Chyba: Duplikátní název"
+
+#: id:530
+msgid "Select genre"
+msgstr "Vyberte žánr"
+
+#: id:531
+msgid "New genre"
+msgstr "Nový žánr"
+
+#: id:532
+msgid "Manual addition"
+msgstr "Ruční přidání"
+
+#: id:533
+msgid "Enter genre"
+msgstr "Zadejte žánr"
+
+#: id:534
+msgid "View: %s"
+msgstr "Zobrazení: %s"
+
+#: id:535
+msgid "List"
+msgstr "Seznam"
+
+#: id:536
+msgid "Icons"
+msgstr "Ikony"
+
+#: id:537
+msgid "Big list"
+msgstr "Seznam II"
+
+#: id:538
+msgid "Big icons"
+msgstr "Ikony II"
+
+#: id:539
+msgid "Wide"
+msgstr "Sloupce"
+
+#: id:540
+msgid "Big wide"
+msgstr "Sloupce II"
+
+#: id:541
+msgid "Album icons"
+msgstr "Náhledy alb"
+
+#: id:542
+msgid "DVD icons"
+msgstr "Náhledy DVD"
+
+#: id:543
+msgctxt "Auto context with id 543"
+msgid "DVD"
+msgstr "DVD"
+
+#: id:544
+msgctxt "Auto context with id 544"
+msgid "Media info"
+msgstr "Informace o médiu"
+
+#: id:545
+msgid "Audio output device"
+msgstr "Zařízení pro výstup zvuku"
+
+#: id:546
+msgid "Passthrough output device"
+msgstr "Zařízení pro passthrough zvuku"
+
+#: id:547
+msgid "No biography for this artist"
+msgstr "Životopis tohoto interpreta není k dispozici"
+
+#: id:548
+msgid "Downmix multichannel audio to stereo"
+msgstr "Převádět vícekanálový zvuk na stereo"
+
+#: id:550
+msgid "Sort by: %s"
+msgstr "Řadit dle: %s"
+
+#: id:551
+msgctxt "Auto context with id 551"
+msgid "Name"
+msgstr "Název"
+
+#: id:552
+msgid "Date"
+msgstr "Datum"
+
+#: id:553
+msgid "Size"
+msgstr "Velikost"
+
+#: id:554
+msgid "Track"
+msgstr "Stopa"
+
+#: id:555
+msgid "Time"
+msgstr "Délka"
+
+#: id:556
+msgctxt "Auto context with id 556"
+msgid "Title"
+msgstr "Skladba"
+
+#: id:557
+msgid "Artist"
+msgstr "Interpret"
+
+#: id:558
+msgid "Album"
+msgstr "Album"
+
+#: id:559
+msgid "Playlist"
+msgstr "Seznam stop"
+
+#: id:560
+msgid "ID"
+msgstr "ID"
+
+#: id:561
+msgctxt "Auto context with id 561"
+msgid "File"
+msgstr "Soubor"
+
+#: id:562
+msgctxt "Auto context with id 562"
+msgid "Year"
+msgstr "Rok"
+
+#: id:563
+msgid "Rating"
+msgstr "Hodnocení"
+
+#: id:564
+msgctxt "Auto context with id 564"
+msgid "Type"
+msgstr "Druh"
+
+#: id:565
+msgid "Usage"
+msgstr "Využití"
+
+#: id:566
+msgid "Album artist"
+msgstr "Tvůrce alba"
+
+#: id:567
+msgid "Play count"
+msgstr "Počet přehrání"
+
+#: id:568
+msgid "Last played"
+msgstr "Poslední přehrání"
+
+#: id:569
+msgctxt "Auto context with id 569"
+msgid "Comment"
+msgstr "Komentář"
+
+#: id:570
+msgid "Date added"
+msgstr "Datum přidání"
+
+#: id:571
+msgctxt "Auto context with id 571"
+msgid "Default"
+msgstr "Výchozí"
+
+#: id:572
+msgid "Studio"
+msgstr "Studio"
+
+#: id:573
+msgid "Path"
+msgstr "Cesta"
+
+#: id:574
+msgctxt "Auto context with id 574"
+msgid "Country"
+msgstr "Země"
+
+#: id:575
+msgid "In progress"
+msgstr "Právě probíhá"
+
+#: id:576
+msgid "Times played"
+msgstr "Počet přehrání"
+
+#: id:580
+msgid "Sort direction"
+msgstr "Způsob řazení"
+
+#: id:581
+msgid "Sort method"
+msgstr "Řadit dle"
+
+#: id:582
+msgctxt "Auto context with id 582"
+msgid "View mode"
+msgstr "Způsob zobrazení"
+
+#: id:583
+msgid "Remember views for different folders"
+msgstr "Zapamatovat si způsob zobrazení pro každou složku"
+
+#: id:584
+msgid "Ascending"
+msgstr "Vzestupně"
+
+#: id:585
+msgid "Descending"
+msgstr "Sestupně"
+
+#: id:586
+msgid "Edit playlist"
+msgstr "Upravit Seznam stop"
+
+#: id:587
+msgid "Filter"
+msgstr "Filtr"
+
+#: id:588
+msgid "Cancel party mode"
+msgstr "Zrušit Párty mód"
+
+#: id:589
+msgid "Party mode"
+msgstr "Párty mód"
+
+#: id:590
+msgid "Random"
+msgstr "Náhodně"
+
+#: id:591
+msgctxt "Auto context with id 591"
+msgid "Off"
+msgstr "Vypnuto"
+
+#: id:592
+msgid "One"
+msgstr "Jednou"
+
+#: id:593
+msgid "All"
+msgstr "Vše"
+
+#: id:594
+msgctxt "Auto context with id 594"
+msgid "Off"
+msgstr "Vypnuto"
+
+#: id:595
+msgid "Repeat: Off"
+msgstr "Opakovat: vypnuto"
+
+#: id:596
+msgid "Repeat: One"
+msgstr "Opakovat: vybrané"
+
+#: id:597
+msgid "Repeat: All"
+msgstr "Opakovat: vše"
+
+#: id:600
+msgid "Rip audio CD"
+msgstr "Zkopírovat CD"
+
+#: id:601
+msgctxt "Auto context with id 601"
+msgid "Medium"
+msgstr "Střední"
+
+#: id:602
+msgctxt "Auto context with id 602"
+msgid "Standard"
+msgstr "Standardní"
+
+#: id:603
+msgid "Extreme"
+msgstr "Vysoká"
+
+#: id:604
+msgid "Constant bitrate"
+msgstr "Konstantní dat. tok"
+
+#: id:605
+msgid "Ripping..."
+msgstr "Probíhá kopírování..."
+
+#: id:607
+msgid "To:"
+msgstr "Do:"
+
+#: id:608
+msgid "Could not rip CD or track"
+msgstr "Stopu nebo CD se nepodařilo zkopírovat"
+
+#: id:609
+msgid "CDDARipPath is not set."
+msgstr "Není nastavena složka pro ukládání kopií CD."
+
+#: id:610
+msgid "Rip audio track"
+msgstr "Zkopírovat audiostopu"
+
+#: id:611
+msgid "Enter number"
+msgstr "Zadejte číslo"
+
+#: id:612
+msgid "Bits/Sample"
+msgstr "Bitů/Vzorek"
+
+#: id:613
+msgid "Sample Frequency"
+msgstr "Vzorkovací frekvence"
+
+#: id:620
+msgid "Audio CDs"
+msgstr "Audio CD"
+
+#: id:621
+msgid "Encoder"
+msgstr "Enkodér"
+
+#: id:622
+msgid "Quality"
+msgstr "Kvalita"
+
+#: id:623
+msgid "Bitrate"
+msgstr "Datový tok"
+
+#: id:624
+msgid "Include track number"
+msgstr "Zahrnout číslo stopy"
+
+#: id:625
+msgid "All songs of"
+msgstr "Všechny skladby od"
+
+#: id:629
+msgctxt "Auto context with id 629"
+msgid "View mode"
+msgstr "Režim zobrazení"
+
+#: id:630
+msgctxt "Auto context with id 630"
+msgid "Normal"
+msgstr "Normální"
+
+#: id:631
+msgid "Zoom"
+msgstr "Přiblížení"
+
+#: id:632
+msgid "Stretch 4:3"
+msgstr "4:3"
+
+#: id:633
+msgid "Wide Zoom"
+msgstr "14:9"
+
+#: id:634
+msgid "Stretch 16:9"
+msgstr "16:9"
+
+#: id:635
+msgid "Original Size"
+msgstr "Původní"
+
+#: id:636
+msgctxt "Auto context with id 636"
+msgid "Custom"
+msgstr "Vlastní"
+
+#: id:637
+msgid "Replay gain"
+msgstr "Normalizace zvuku"
+
+#: id:638
+msgid "Replaygain volume adjustments"
+msgstr "Mód normalizace (úprava hlasitosti)"
+
+#: id:639
+msgid "Use track levels"
+msgstr "Podle úrovně stopy"
+
+#: id:640
+msgid "Use album levels"
+msgstr "Podle úrovně alba"
+
+#: id:641
+msgid "PreAmp Level - Replay gained files"
+msgstr "Úroveň - Normalizované skladby"
+
+#: id:642
+msgid "PreAmp Level - Non replay gained files"
+msgstr "Úroveň - Nenormalizované skladby"
+
+#: id:643
+msgid "Avoid clipping on replay gained files"
+msgstr "Vyvarovat se předimenzování hlasitosti u normalizovaných skladeb"
+
+#: id:644
+msgid "Crop black bars"
+msgstr "Odstraňovat černé kraje"
+
+#: id:645
+msgid "Need to unpack a big file. Continue?"
+msgstr "Je zapotřebí rozbalit velký archiv. Chcete pokračovat?"
+
+#: id:646
+msgid "Remove from library"
+msgstr "Odebrat z knihovny"
+
+#: id:647
+msgid "Export video library"
+msgstr "Exportovat Knihovnu videí"
+
+#: id:648
+msgid "Import video library"
+msgstr "Importovat Knihovnu videí"
+
+#: id:649
+msgid "Importing"
+msgstr "Probíhá import"
+
+#: id:650
+msgid "Exporting"
+msgstr "Probíhá export"
+
+#: id:651
+msgid "Browse for library"
+msgstr "Knihovna videí"
+
+#: id:652
+msgid "Years"
+msgstr "Roky"
+
+#: id:653
+msgid "Update library"
+msgstr "Aktualizovat knihovnu"
+
+#: id:654
+msgid "Show debug info"
+msgstr "Zobrazovat informace o ladění"
+
+#: id:655
+msgid "Browse for executable"
+msgstr "Vyberte spouštěcí soubor"
+
+#: id:656
+msgid "Browse for playlist"
+msgstr "Vyberte Seznam stop"
+
+#: id:657
+msgid "Browse for folder"
+msgstr "Vyberte složku"
+
+#: id:658
+msgid "Song information"
+msgstr "Informace o skladbě"
+
+#: id:659
+msgid "Non-linear stretch"
+msgstr "Nelineární roztažení"
+
+#: id:660
+msgid "Volume amplification"
+msgstr "Zesílení hlasitosti"
+
+#: id:661
+msgid "Choose export folder"
+msgstr "Vyberte složku pro export"
+
+#: id:662
+msgid "This file is no longer available."
+msgstr "Tento soubor není dostupný."
+
+#: id:663
+msgid "Would you like to remove it from the library?"
+msgstr "Chcete ho odebrat z knihovny?"
+
+#: id:664
+msgid "Browse for Script"
+msgstr "Vyberte Skript"
+
+#: id:665
+msgid "Compression level"
+msgstr "Úroveň komprese"
+
+#: id:700
+msgid "Cleaning up library"
+msgstr "Probíhá aktualizace knihovny"
+
+#: id:701
+msgid "Removing old songs from the library"
+msgstr "Probíhá odebírání skladby z knihovny"
+
+#: id:702
+msgid "This path has been scanned before"
+msgstr "Tato cesta byla již dříve prohledána"
+
+#: id:705
+msgctxt "Auto context with id 705"
+msgid "Network"
+msgstr "Síť"
+
+#: id:706
+msgid "- Server"
+msgstr "- Server"
+
+#: id:708
+msgid "Use an HTTP proxy server to access the internet"
+msgstr "Použít k přístupu na internet HTTP proxy server"
+
+#: id:711
+msgid "Internet Protocol (IP)"
+msgstr "Internetový protokol (IP):"
+
+#: id:712
+msgid "Invalid port specified. Value must be between 1 and 65535."
+msgstr "Nebyl nastaven platný port. Hodnota musí být od 1 do 65535."
+
+#: id:713
+msgid "HTTP proxy"
+msgstr "Nastavení HTTP Proxy"
+
+#: id:715
+msgid "- Assignment"
+msgstr "- Přidělování IP adresy"
+
+#: id:716
+msgid "Automatic (DHCP)"
+msgstr "Automatické (DHCP)"
+
+#: id:717
+msgid "Manual (Static)"
+msgstr "Manuálně (Statická IP)"
+
+#: id:719
+msgid "- IP address"
+msgstr "- IP adresa"
+
+#: id:720
+msgid "- Netmask"
+msgstr "- Maska podsítě"
+
+#: id:721
+msgid "- Default gateway"
+msgstr "- Výchozí brána"
+
+#: id:722
+msgid "- DNS server"
+msgstr "- DNS server"
+
+#: id:723
+msgid "Save & restart"
+msgstr "Uložit nastavení a restartovat"
+
+#: id:724
+msgid "Invalid address specified. Value must be AAA.BBB.CCC.DDD"
+msgstr "Nebyla nastavena platná IP adresa. Hodnota musí být ve tvaru AAA.BBB.CCC.DDD"
+
+#: id:725
+msgid "with numbers between 0 and 255."
+msgstr "a obsahovat čísla od 0 do 255."
+
+#: id:726
+msgid "Changes not saved. Continue without saving?"
+msgstr "Změny nebyly uloženy. Pokračovat bez uložení?"
+
+#: id:727
+msgid "Web server"
+msgstr "Webový server"
+
+#: id:728
+msgctxt "Auto context with id 728"
+msgid "FTP server"
+msgstr "FTP server"
+
+#: id:730
+msgid "- Port"
+msgstr "- Port"
+
+#: id:732
+msgid "Save & apply"
+msgstr "Uložit a použít"
+
+#: id:733
+msgid "- Password"
+msgstr "- Heslo"
+
+#: id:734
+msgid "No pass"
+msgstr "bez hesla"
+
+#: id:735
+msgid "- Character set"
+msgstr "- Znaková sada"
+
+#: id:736
+msgid "- Style"
+msgstr "- Styl"
+
+#: id:737
+msgid "- Colour"
+msgstr "- Barva"
+
+#: id:738
+msgctxt "Auto context with id 738"
+msgid "Normal"
+msgstr "Obyčejné"
+
+#: id:739
+msgid "Bold"
+msgstr "Tučné"
+
+#: id:740
+msgid "Italics"
+msgstr "Kurzíva"
+
+#: id:741
+msgid "Bold italics"
+msgstr "Tučná kurzíva"
+
+#: id:742
+msgctxt "Auto context with id 742"
+msgid "White"
+msgstr "Bílá"
+
+#: id:743
+msgctxt "Auto context with id 743"
+msgid "Yellow"
+msgstr "Žlutá"
+
+#: id:744
+msgctxt "Auto context with id 744"
+msgid "Files"
+msgstr "Soubory"
+
+#: id:745
+msgid "No scanned information for this view"
+msgstr "Tomuto zobrazení neodpovídají žádné položky"
+
+#: id:746
+msgid "Please turn off library mode"
+msgstr "Vraťte se zpět do režimu zobrazení souborů"
+
+#: id:747
+msgid "Error loading image"
+msgstr "Chyba při načítání obrázku"
+
+#: id:748
+msgid "Edit path"
+msgstr "Upravit cestu"
+
+#: id:749
+msgid "Mirror image"
+msgstr "Otočit"
+
+#: id:750
+msgid "Are you sure?"
+msgstr "Jste si jistý?"
+
+#: id:751
+msgid "Removing source"
+msgstr "Odebrání zdroje"
+
+#: id:754
+msgid "Add program link"
+msgstr "Přidat zástupce programu"
+
+#: id:755
+msgid "Edit program path"
+msgstr "Změnit cestu k programu"
+
+#: id:756
+msgid "Edit program name"
+msgstr "Změnit název programu"
+
+#: id:757
+msgid "Edit path depth"
+msgstr "Změnit hloubku cesty"
+
+#: id:759
+msgid "View: Big list"
+msgstr "Seznam (velký)"
+
+#: id:760
+msgctxt "Auto context with id 760"
+msgid "Yellow"
+msgstr "Žlutá"
+
+#: id:761
+msgctxt "Auto context with id 761"
+msgid "White"
+msgstr "Bílá"
+
+#: id:762
+msgid "Blue"
+msgstr "Modrá"
+
+#: id:763
+msgid "Bright green"
+msgstr "Světle zelená"
+
+#: id:764
+msgid "Yellow green"
+msgstr "Žluto-zelená"
+
+#: id:765
+msgid "Cyan"
+msgstr "Modro-zelená"
+
+#: id:766
+msgid "Light grey"
+msgstr "Světle šedá"
+
+#: id:767
+msgid "Grey"
+msgstr "Šedá"
+
+#: id:770
+msgid "Error %i: share not available"
+msgstr "Chyba %i: sdílená položka je nedostupná"
+
+#: id:772
+msgctxt "Auto context with id 772"
+msgid "Audio output"
+msgstr "Zvukový výstup"
+
+#: id:773
+msgid "Seeking"
+msgstr "Probíhá vyhledávání"
+
+#: id:774
+msgid "Slideshow folder"
+msgstr "Složka s obrázky pro Spořič obrazovky"
+
+#: id:775
+msgid "Network interface"
+msgstr "Síťové rozhraní"
+
+#: id:776
+msgid "- Wireless network name (ESSID)"
+msgstr "- Název bezdrátové sítě (ESSID)"
+
+#: id:777
+msgid "- Wireless password"
+msgstr "- Heslo bezdrátové sítě"
+
+#: id:778
+msgid "- Wireless security"
+msgstr "- Bezpečnost bezdrátové sítě"
+
+#: id:779
+msgid "Save and apply network interface settings"
+msgstr "Uložit a použít nastavení sítě"
+
+#: id:780
+msgid "No encryption"
+msgstr "Žádné šifrování"
+
+#: id:781
+msgid "WEP"
+msgstr "WEP"
+
+#: id:782
+msgid "WPA"
+msgstr "WPA"
+
+#: id:783
+msgid "WPA2"
+msgstr "WPA2"
+
+#: id:784
+msgid "Applying network interface settings. Please wait."
+msgstr "Probíhá aplikace změn nastavení sítě. Vyčkejte prosím."
+
+#: id:785
+msgid "Network interface restarted successfully."
+msgstr "Restart síťové rozhraní proběhl úspěšně."
+
+#: id:786
+msgid "Network interface did not start successfully."
+msgstr "Spuštění síťového rozhraní se nezdařilo."
+
+#: id:787
+msgid "Interface disabled"
+msgstr "Rozhraní není aktivováno"
+
+#: id:788
+msgid "Network interface disabled successfully."
+msgstr "Síťové rozhraní bylo úspěšně deaktivováno."
+
+#: id:789
+msgid "Wireless network name (ESSID)"
+msgstr "Název bezdrátové sítě (ESSID)"
+
+#: id:790
+msgid "Remote control"
+msgstr ""
+
+#: id:791
+msgid "Allow programs on this system to control XBMC"
+msgstr "Povolit programům v tomto počítači ovládat XBMC"
+
+#: id:792
+msgctxt "Auto context with id 792"
+msgid "Port"
+msgstr "Port dálkového ovládání"
+
+#: id:793
+msgid "Port range"
+msgstr "Rozsah portů pro dálkové ovládání"
+
+#: id:794
+msgid "Allow programs on other systems to control XBMC"
+msgstr "Povolit programům z ostatních počítačů ovládat XBMC"
+
+#: id:795
+msgid "Initial repeat delay (ms)"
+msgstr "Úvodní zpoždění opakovaní (ms)"
+
+#: id:796
+msgid "Continuous repeat delay (ms)"
+msgstr "Následující zpoždění opakovaní (ms)"
+
+#: id:797
+msgid "Maximum number of clients"
+msgstr "Maximální počet klientů"
+
+#: id:798
+msgid "Internet access"
+msgstr "Internet"
+
+#: id:850
+msgid "Invalid port number entered"
+msgstr "Bylo zadáno nesprávné číslo portu"
+
+#: id:851
+msgid "Valid port range is 1-65535"
+msgstr "Povolený rozsah portu je 1-65535"
+
+#: id:852
+msgid "Valid port range is 1024-65535"
+msgstr "Povolený rozsah portu je 1024-65535"
+
+#: id:998
+msgid "Add Music..."
+msgstr "Přidat hudbu..."
+
+#: id:999
+msgid "Add Videos..."
+msgstr "Přidat video..."
+
+#: id:1000
+msgid "- Preview"
+msgstr "Náhled spořiče obrazovky"
+
+#: id:1001
+msgid "Unable to connect"
+msgstr "Nemohu se připojit."
+
+#: id:1002
+msgid "XBMC was unable to connect to the network location."
+msgstr "XBMC se nepodařilo připojit k síťovému umístění."
+
+#: id:1003
+msgid "This could be due to the network not being connected."
+msgstr "Je možné, že síť není připojena."
+
+#: id:1004
+msgid "Would you like to add it anyway?"
+msgstr "Chcete ho přesto přidat?"
+
+#: id:1006
+msgctxt "Auto context with id 1006"
+msgid "IP address"
+msgstr "IP Adresa"
+
+#: id:1007
+msgid "Add network location"
+msgstr "Přidat síťové umístění"
+
+#: id:1008
+msgid "Protocol"
+msgstr "Protokol"
+
+#: id:1009
+msgid "Server address"
+msgstr "Adresa serveru"
+
+#: id:1010
+msgid "Server name"
+msgstr "Název serveru"
+
+#: id:1011
+msgid "Remote path"
+msgstr "Vzdálená cesta"
+
+#: id:1012
+msgid "Shared folder"
+msgstr "Sdílená složka"
+
+#: id:1013
+msgctxt "Auto context with id 1013"
+msgid "Port"
+msgstr "Port"
+
+#: id:1014
+msgctxt "Auto context with id 1014"
+msgid "Username"
+msgstr "Uživatelské jméno"
+
+#: id:1015
+msgid "Browse for network server"
+msgstr "síťový server"
+
+#: id:1016
+msgid "Enter the network address of the server"
+msgstr "Zadejte síťovou adresu serveru"
+
+#: id:1017
+msgid "Enter the path on the server"
+msgstr "Zadejte cestu na serveru"
+
+#: id:1018
+msgid "Enter the port number"
+msgstr "Zadejte číslo portu"
+
+#: id:1019
+msgid "Enter the username"
+msgstr "Zadejte uživatelské jméno"
+
+#: id:1020
+msgid "Add %s source"
+msgstr "Přidat zdroj: %s"
+
+#: id:1021
+msgid "Enter the paths or browse for the media locations."
+msgstr "Zadejte cestu nebo vyberte umístění médií:"
+
+#: id:1022
+msgid "Enter a name for this media Source."
+msgstr "Zadejte název pro tento zdroj médií:"
+
+#: id:1023
+msgid "Browse for new share"
+msgstr "Vyberte umístění zdroje"
+
+#: id:1024
+msgid "Browse"
+msgstr "Procházet"
+
+#: id:1025
+msgid "Could not retrieve directory information."
+msgstr "Informace o složce se nepodařilo získat."
+
+#: id:1026
+msgid "Add source"
+msgstr "Přidat zdroj"
+
+#: id:1027
+msgid "Edit source"
+msgstr "Upravit zdroj"
+
+#: id:1028
+msgid "Edit %s source"
+msgstr "Upravit %s zdroj"
+
+#: id:1029
+msgid "Enter the new label"
+msgstr "Zadejte nový název"
+
+#: id:1030
+msgid "Browse for image"
+msgstr "Vyberte obrázek"
+
+#: id:1031
+msgid "Browse for image folder"
+msgstr "Vyberte složku s obrázky"
+
+#: id:1032
+msgid "Add network location..."
+msgstr "Přidat síťové umístění..."
+
+#: id:1033
+msgid "Browse for file"
+msgstr "Vyberte soubor"
+
+#: id:1034
+msgid "Submenu"
+msgstr "Podmenu"
+
+#: id:1035
+msgid "Enable submenu buttons"
+msgstr "Povolit tlačítka podmenu"
+
+#: id:1036
+msgid "Favourites"
+msgstr "Oblíbené"
+
+#: id:1037
+msgid "Video Add-ons"
+msgstr "Doplňky - Video"
+
+#: id:1038
+msgid "Music Add-ons"
+msgstr "Doplňky - Hudba"
+
+#: id:1039
+msgid "Picture Add-ons"
+msgstr "Doplňky - Obrázky"
+
+#: id:1040
+msgid "Loading directory"
+msgstr "Probíhá načítání složky"
+
+#: id:1041
+msgid "Retrieved %i items"
+msgstr "Bylo nalezeno %i položek"
+
+#: id:1042
+msgid "Retrieved %i of %i items"
+msgstr "Bylo nalezeno %i z %i položek"
+
+#: id:1043
+msgid "Program Add-ons"
+msgstr "Doplňky - Programy"
+
+#: id:1044
+msgid "Set plugin thumb"
+msgstr "Přiřadit náhled pluginu"
+
+#: id:1045
+msgid "Add-on settings"
+msgstr "Nastavení pluginu"
+
+#: id:1046
+msgid "Access points"
+msgstr "Přístupové body (AP)"
+
+#: id:1047
+msgid "Other..."
+msgstr "Ostatní..."
+
+#: id:1048
+msgid "- Username"
+msgstr "- Uživatelské jméno"
+
+#: id:1049
+msgid "Script settings"
+msgstr "Nastavení skriptu"
+
+#: id:1050
+msgid "Singles"
+msgstr "Singly"
+
+#: id:1051
+msgid "Enter web address"
+msgstr "Zadejte webovou adresu"
+
+#: id:1200
+msgid "SMB client"
+msgstr "SMB klient"
+
+#: id:1202
+msgid "Workgroup"
+msgstr "Pracovní skupina"
+
+#: id:1203
+msgid "Default username"
+msgstr "Uživatelské jméno"
+
+#: id:1204
+msgid "Default password"
+msgstr "Heslo"
+
+#: id:1207
+msgid "WINS server"
+msgstr "WINS server"
+
+#: id:1208
+msgid "Mount SMB shares"
+msgstr "Připojovat SMB sdílené složky"
+
+#: id:1210
+msgctxt "Auto context with id 1210"
+msgid "Remove"
+msgstr "Odebrat"
+
+#: id:1211
+msgctxt "Auto context with id 1211"
+msgid "Music"
+msgstr "Hudba"
+
+#: id:1212
+msgctxt "Auto context with id 1212"
+msgid "Video"
+msgstr "Video"
+
+#: id:1213
+msgctxt "Auto context with id 1213"
+msgid "Pictures"
+msgstr "Obrázky"
+
+#: id:1214
+msgctxt "Auto context with id 1214"
+msgid "Files"
+msgstr "Soubory"
+
+#: id:1215
+msgctxt "Auto context with id 1215"
+msgid "Music & video"
+msgstr "Hudba a video"
+
+#: id:1216
+msgid "Music & pictures"
+msgstr "Hudba a obrázky"
+
+#: id:1217
+msgid "Music & files"
+msgstr "Hudba a soubory"
+
+#: id:1218
+msgid "Video & pictures"
+msgstr "Video a obrázky"
+
+#: id:1219
+msgid "Video & files"
+msgstr "Video a soubory"
+
+#: id:1220
+msgid "Pictures & files"
+msgstr "Obrázky a soubory"
+
+#: id:1221
+msgid "Music & video & pictures"
+msgstr "Hudba a video a obrázky"
+
+#: id:1222
+msgid "Music & video & pictures & files"
+msgstr "Hudba a video a obr. a soub."
+
+#: id:1223
+msgctxt "Auto context with id 1223"
+msgid "Disabled"
+msgstr "Zakázáno"
+
+#: id:1226
+msgid "Files & music & video"
+msgstr "Soubory a hudba a video"
+
+#: id:1227
+msgid "Files & pictures & music"
+msgstr "Soubory a obrázky a hudba"
+
+#: id:1228
+msgid "Files & pictures & video"
+msgstr "Soubory a obrázky a video"
+
+#: id:1229
+msgid "Music & programs"
+msgstr "Hudba a programy"
+
+#: id:1230
+msgid "Video & programs"
+msgstr "Video a programy"
+
+#: id:1231
+msgid "Pictures & programs"
+msgstr "Obrázky a programy"
+
+#: id:1232
+msgid "Music & video & pictures & programs"
+msgstr "Hudba a video a obrázky a programy"
+
+#: id:1233
+msgid "Programs & video & music"
+msgstr "Programy a video a hudba"
+
+#: id:1234
+msgid "Programs & pictures & music"
+msgstr "Programy a obrázky a hudba"
+
+#: id:1235
+msgid "Programs & pictures & video"
+msgstr "Programy a obrázky a video"
+
+#: id:1250
+msgid "Auto-detection"
+msgstr "Autodetekce"
+
+#: id:1251
+msgid "Auto-detect system"
+msgstr "Autodetekovat systém"
+
+#: id:1252
+msgid "Nickname"
+msgstr "Přezdívka"
+
+#: id:1254
+msgid "Ask to connect"
+msgstr "Potvrzovat připojení"
+
+#: id:1255
+msgid "Send FTP user and password"
+msgstr "Odesílat jméno uživatele a heslo FTP"
+
+#: id:1256
+msgid "Ping interval"
+msgstr "Doba odezvy"
+
+#: id:1257
+msgid "Would you like to connect to the auto-detected system?"
+msgstr "Chcete se připojit k nalezenému systému?"
+
+#: id:1259
+msgid "Zeroconf"
+msgstr ""
+
+#: id:1260
+msgid "Announce these services to other systems via Zeroconf"
+msgstr "Oznamovat tyto služby ostatním počítačům přes Zeroconf"
+
+#: id:1270
+msgid "Allow XBMC to receive AirPlay content"
+msgstr "Povolit XBMC přijímat AirPlay obsah"
+
+#: id:1271
+msgid "Device name"
+msgstr "Název zařízení"
+
+#: id:1272
+msgid "- Use password protection"
+msgstr "- Použít ochranu heslem"
+
+#: id:1273
+msgid "AirPlay"
+msgstr ""
+
+#: id:1300
+msgid "Custom audio device"
+msgstr "Vlastní zařízení pro výstup zvuku"
+
+#: id:1301
+msgid "Custom passthrough device"
+msgstr "Vlastní zařízení pro passthrough zvuku"
+
+#: id:1396
+msgid "Drifting"
+msgstr "ustupující"
+
+#: id:1397
+msgid "and"
+msgstr "a"
+
+#: id:1398
+msgid "Freezing"
+msgstr "mrznoucí"
+
+#: id:1399
+msgid "Late"
+msgstr "později"
+
+#: id:1400
+msgid "Isolated"
+msgstr "ojediněle"
+
+#: id:1401
+msgid "Thundershowers"
+msgstr "přeháňky/hřmění"
+
+#: id:1402
+msgid "Thunder"
+msgstr "bouřky"
+
+#: id:1403
+msgctxt "Auto context with id 1403"
+msgid "Sun"
+msgstr "slunečno"
+
+#: id:1404
+msgid "Heavy"
+msgstr "zataženo"
+
+#: id:1405
+msgid "in"
+msgstr "v"
+
+#: id:1406
+msgid "the"
+msgstr "blízkém"
+
+#: id:1407
+msgid "Vicinity"
+msgstr "okolí"
+
+#: id:1408
+msgid "Ice"
+msgstr "ledové"
+
+#: id:1409
+msgid "Crystals"
+msgstr "krystalky"
+
+#: id:1410
+msgid "Calm"
+msgstr "bezvětří"
+
+#: id:1411
+msgid "with"
+msgstr "s"
+
+#: id:1412
+msgid "windy"
+msgstr "větrno"
+
+#: id:1413
+msgid "drizzle"
+msgstr "mrholení"
+
+#: id:1414
+msgid "Thunderstorm"
+msgstr "bouřka"
+
+#: id:1415
+msgid "Drizzle"
+msgstr "mrholení"
+
+#: id:1416
+msgid "Foggy"
+msgstr "mlhavo"
+
+#: id:1417
+msgid "Grains"
+msgstr "kroupy"
+
+#: id:1418
+msgid "T-Storms"
+msgstr "bouřky"
+
+#: id:1419
+msgid "T-Showers"
+msgstr "bouřky s přeháňkami"
+
+#: id:1420
+msgid "Moderate"
+msgstr "Střední"
+
+#: id:1421
+msgid "Very High"
+msgstr "Velmi vysoké"
+
+#: id:1422
+msgid "Windy"
+msgstr "Větrno"
+
+#: id:1423
+msgid "Mist"
+msgstr "Kouřmo"
+
+#: id:1450
+msgid "Put display to sleep when idle"
+msgstr "Aktivovat úsporný režim obrazovky při nečinnosti"
+
+#: id:2050
+msgid "Runtime"
+msgstr "Délka"
+
+#: id:2100
+msgid "Script failed! : %s"
+msgstr "Chyba skriptu! : %s"
+
+#: id:2101
+msgid "Newer version needed - See log"
+msgstr "Je vyžadována novější verze - Více informací v logu"
+
+#: id:4501
+msgid "Enable LCD/VFD"
+msgstr "Aktivovat LCD/VFD displej"
+
+#: id:10000
+msgid "Home"
+msgstr "Základní"
+
+#: id:10001
+msgctxt "Auto context with id 10001"
+msgid "Programs"
+msgstr "Programy"
+
+#: id:10002
+msgctxt "Auto context with id 10002"
+msgid "Pictures"
+msgstr "Obrázky"
+
+#: id:10003
+msgctxt "Auto context with id 10003"
+msgid "File manager"
+msgstr "Soubory"
+
+#: id:10004
+msgctxt "Auto context with id 10004"
+msgid "Settings"
+msgstr "Nastavení"
+
+#: id:10005
+msgctxt "Auto context with id 10005"
+msgid "Music"
+msgstr "Hudba"
+
+#: id:10006
+msgctxt "Auto context with id 10006"
+msgid "Videos"
+msgstr "Video"
+
+#: id:10007
+msgid "System information"
+msgstr "Informace o systému"
+
+#: id:10008
+msgid "Settings - General"
+msgstr "Nastavení - Hlavní"
+
+#: id:10009
+msgid "Settings - Screen"
+msgstr "Nastavení - Obrazovka"
+
+#: id:10010
+msgid "Settings - Appearance - GUI Calibration"
+msgstr "Nastavení - Vzhled - Kalibrace UI"
+
+#: id:10011
+msgid "Settings - Videos - Screen Calibration"
+msgstr "Nastavení - Video - Kalibrace obrazu"
+
+#: id:10012
+msgid "Settings - Pictures"
+msgstr "Nastavení - Obrázky"
+
+#: id:10013
+msgid "Settings - Programs"
+msgstr "Nastavení - Programy"
+
+#: id:10014
+msgid "Settings - Weather"
+msgstr "Nastavení - Počasí"
+
+#: id:10015
+msgid "Settings - Music"
+msgstr "Nastavení - Hudba"
+
+#: id:10016
+msgid "Settings - System"
+msgstr "Nastavení - Systém"
+
+#: id:10017
+msgid "Settings - Videos"
+msgstr "Nastavení - Video"
+
+#: id:10018
+msgid "Settings - Network"
+msgstr "Nastavení - Síť"
+
+#: id:10019
+msgid "Settings - Appearance"
+msgstr "Nastavení - Vzhled"
+
+#: id:10020
+msgctxt "Auto context with id 10020"
+msgid "Scripts"
+msgstr "Skripty"
+
+#: id:10021
+msgid "Web Browser"
+msgstr "Webový prohlížeč"
+
+#: id:10025
+msgctxt "Auto context with id 10025"
+msgid "Videos"
+msgstr ""
+
+#: id:10028
+msgid "Videos/Playlist"
+msgstr "Videa/Seznam stop"
+
+#: id:10029
+msgctxt "Auto context with id 10029"
+msgid "Login screen"
+msgstr ""
+
+#: id:10034
+msgid "Settings - Profiles"
+msgstr "Nastavení - Profily"
+
+#: id:10040
+msgid "Addon browser"
+msgstr ""
+
+#: id:10100
+msgid "Yes/No dialog"
+msgstr "Dialog Ano/Ne"
+
+#: id:10101
+msgid "Progress dialog"
+msgstr "Dialog s průběhem stavu"
+
+#: id:10210
+msgid "Looking for subtitles..."
+msgstr "Probíhá vyhledávání titulků..."
+
+#: id:10211
+msgid "Looking for or caching subtitles..."
+msgstr "Probíhá načítání titulků..."
+
+#: id:10212
+msgid "terminating"
+msgstr "ukončování"
+
+#: id:10213
+msgid "buffering"
+msgstr "načítání do mezipaměti"
+
+#: id:10214
+msgid "Opening stream"
+msgstr "Probíhá otevírání streamu"
+
+#: id:10500
+msgid "Music/Playlist"
+msgstr "Hudba/Seznam stop"
+
+#: id:10501
+msgid "Music/Files"
+msgstr "Hudba/Soubory"
+
+#: id:10502
+msgid "Music/Library"
+msgstr "Hudba/Knihovna"
+
+#: id:10503
+msgid "Playlist editor"
+msgstr "Editor Seznamu Stop"
+
+#: id:10504
+msgid "Top 100 songs"
+msgstr "Top 100 skladeb"
+
+#: id:10505
+msgid "Top 100 albums"
+msgstr "Top 100 alb"
+
+#: id:10506
+msgctxt "Auto context with id 10506"
+msgid "Programs"
+msgstr "Programy"
+
+#: id:10507
+msgid "Configuration"
+msgstr "Nastavení"
+
+#: id:10508
+msgid "Weather forecast"
+msgstr "Předpověď počasí"
+
+#: id:10509
+msgid "Network gaming"
+msgstr "Online Hry"
+
+#: id:10510
+msgid "Extensions"
+msgstr "Přípony"
+
+#: id:10511
+msgctxt "Auto context with id 10511"
+msgid "System info"
+msgstr "Informace o systému"
+
+#: id:10516
+msgid "Music - Library"
+msgstr "Knihovna"
+
+#: id:10517
+msgid "Now Playing - Music"
+msgstr "Seznam stop - Hudba"
+
+#: id:10522
+msgid "Now Playing - Videos"
+msgstr "Seznam stop - Video"
+
+#: id:10523
+msgid "Album info"
+msgstr "Informace o albu"
+
+#: id:10524
+msgid "Movie info"
+msgstr "Informace o filmu"
+
+#: id:12000
+msgid "Select dialog"
+msgstr "Vyberte dialog"
+
+#: id:12001
+msgid "Music/Info"
+msgstr "Hudba/Info"
+
+#: id:12002
+msgid "Dialog OK"
+msgstr "Dialog OK"
+
+#: id:12003
+msgid "Videos/Info"
+msgstr "Video/Info"
+
+#: id:12004
+msgid "Scripts/Info"
+msgstr "Skripty/Info"
+
+#: id:12005
+msgid "Fullscreen video"
+msgstr "Video na celou obrazovku"
+
+#: id:12006
+msgid "Audio visualization"
+msgstr "Vizualizace hudby"
+
+#: id:12008
+msgid "File stacking dialog"
+msgstr "Dialog při spojování videa"
+
+#: id:12009
+msgid "Rebuild index..."
+msgstr "Reorganizovat index..."
+
+#: id:12010
+msgid "Return to music window"
+msgstr "Návrat do sekce Hudba"
+
+#: id:12011
+msgid "Return to videos window"
+msgstr "Návrat do sekce Video"
+
+#: id:12021
+msgid "Start from beginning"
+msgstr "Začít od začátku"
+
+#: id:12022
+msgid "Resume from %s"
+msgstr "Pokračovat od %s"
+
+#: id:12310
+msgid "0"
+msgstr "0"
+
+#: id:12311
+msgid "1"
+msgstr "1"
+
+#: id:12312
+msgid "2"
+msgstr "2"
+
+#: id:12313
+msgid "3"
+msgstr "3"
+
+#: id:12314
+msgid "4"
+msgstr "4"
+
+#: id:12315
+msgid "5"
+msgstr "5"
+
+#: id:12316
+msgid "6"
+msgstr "6"
+
+#: id:12317
+msgid "7"
+msgstr "7"
+
+#: id:12318
+msgid "8"
+msgstr "8"
+
+#: id:12319
+msgid "9"
+msgstr "9"
+
+#: id:12320
+msgid "c"
+msgstr "c"
+
+#: id:12321
+msgid "Ok"
+msgstr "Ok"
+
+#: id:12322
+msgid "*"
+msgstr "*"
+
+#: id:12325
+msgid "Locked! Enter code..."
+msgstr "Uzamčeno! Zadejte kód..."
+
+#: id:12326
+msgid "Enter password"
+msgstr "Zadejte heslo:"
+
+#: id:12327
+msgid "Enter master code"
+msgstr "Zadejte hlavní kód"
+
+#: id:12328
+msgid "Enter unlock code"
+msgstr "Zadejte kód pro odemknutí"
+
+#: id:12329
+msgid "or press C to cancel"
+msgstr "nebo stiskněte C pro zrušení"
+
+#: id:12330
+msgid "Enter gamepad button combo and"
+msgstr "Zadejte kód pomocí kombinace tlačítek a"
+
+#: id:12331
+msgid "press OK, or Back to cancel"
+msgstr "stiskněte OK. Pro zrušení stiskněte Zpět"
+
+#: id:12332
+msgid "Set lock"
+msgstr "Nastavit kód uzamčení"
+
+#: id:12333
+msgid "Unlock"
+msgstr "Odemknout"
+
+#: id:12334
+msgid "Reset lock"
+msgstr "Reset uzamčení"
+
+#: id:12335
+msgid "Remove lock"
+msgstr "Zrušit uzamčení"
+
+#: id:12337
+msgid "Numeric password"
+msgstr "Číselný kód"
+
+#: id:12338
+msgid "Gamepad button combo"
+msgstr "Kód - kombinace tlačítek"
+
+#: id:12339
+msgid "Full-text password"
+msgstr "Fulltextový kód"
+
+#: id:12340
+msgid "Enter new password"
+msgstr "Zadejte nový kód"
+
+#: id:12341
+msgid "Re-Enter new password"
+msgstr "Potvrďte nový kód"
+
+#: id:12342
+msgid "Incorrect password,"
+msgstr "Špatný kód,"
+
+#: id:12343
+msgid "retries left"
+msgstr "zbývající pokus(y)"
+
+#: id:12344
+msgid "Passwords entered did not match."
+msgstr "Zadaný kód není správný."
+
+#: id:12345
+msgid "Access denied"
+msgstr "Přístup byl zamítnut"
+
+#: id:12346
+msgid "Password retry limit exceeded."
+msgstr "Počet pokusů byl překročen."
+
+#: id:12347
+msgid "The system will now shut off."
+msgstr "Systém se nyní vypne."
+
+#: id:12348
+msgid "Item locked"
+msgstr "Položka uzamčena"
+
+#: id:12353
+msgid "Reactivate lock"
+msgstr "Reaktivace uzamčení"
+
+#: id:12356
+msgid "Change lock"
+msgstr "Změnit kód uzamčení"
+
+#: id:12357
+msgid "Source lock"
+msgstr "Uzamknout sdílení"
+
+#: id:12358
+msgid "Password entry was blank. Try again."
+msgstr "Nebyl zadán kód. Zadejte kód, prosím."
+
+#: id:12360
+msgid "Master lock"
+msgstr "Rodičovský zámek"
+
+#: id:12362
+msgid "Shutdown system if Master Lock retries exceeded"
+msgstr "Při překročení počtu pokusů vypnout systém"
+
+#: id:12367
+msgid "Master code is not valid"
+msgstr "Hlavní kód není správný!"
+
+#: id:12368
+msgid "Please enter a valid master code"
+msgstr "Zadejte prosím správný Hlavní kód"
+
+#: id:12373
+msgid "Settings & file manager"
+msgstr "Nastavení a správce souborů"
+
+#: id:12376
+msgid "Set as default for all movies"
+msgstr "Uložit nastavení jako výchozí pro všechny videa"
+
+#: id:12377
+msgid "This will reset any previously saved values"
+msgstr "Uložením se přepíše předchozí nastavení."
+
+#: id:12378
+msgid "Amount of time to display each image"
+msgstr "Zobrazovat každý obrázek po dobu"
+
+#: id:12379
+msgid "Use pan and zoom effects"
+msgstr "Používat efekty přiblížení a posunutí obrázku"
+
+#: id:12383
+msgid "12 hour clock"
+msgstr "12h formát hodin"
+
+#: id:12384
+msgid "24 hour clock"
+msgstr "24h formát hodin"
+
+#: id:12385
+msgid "Day/Month"
+msgstr "Den/Měsíc"
+
+#: id:12386
+msgid "Month/Day"
+msgstr "Měsíc/Den"
+
+#: id:12390
+msgid "System uptime"
+msgstr "Doba provozu"
+
+#: id:12391
+msgid "Minutes"
+msgstr "minut"
+
+#: id:12392
+msgid "Hours"
+msgstr "hodin"
+
+#: id:12393
+msgid "Days"
+msgstr "dní"
+
+#: id:12394
+msgid "Total uptime"
+msgstr "Celková doba používání"
+
+#: id:12395
+msgid "Battery level"
+msgstr "Stav baterie"
+
+#: id:12600
+msgctxt "Auto context with id 12600"
+msgid "Weather"
+msgstr "Počasí"
+
+#: id:12900
+msgctxt "Auto context with id 12900"
+msgid "Screensaver"
+msgstr "Spořič obrazovky"
+
+#: id:12901
+msgid "Fullscreen OSD"
+msgstr "Celoobrazovkové OSD"
+
+#: id:13000
+msgid "System"
+msgstr "Systém"
+
+#: id:13001
+msgid "Immediate HD spindown"
+msgstr "Okamžité uspání pevného disku"
+
+#: id:13002
+msgid "Video only"
+msgstr "Pouze video"
+
+#: id:13003
+msgid "- Delay"
+msgstr "- Prodleva"
+
+#: id:13004
+msgid "- Minimum file duration"
+msgstr "- Minimální délka souboru"
+
+#: id:13005
+msgid "Shutdown"
+msgstr "Vypnout"
+
+#: id:13008
+msgid "Shutdown function"
+msgstr "Výchozí způsob vypínání"
+
+#: id:13009
+msgid "Quit"
+msgstr "Ukončit"
+
+#: id:13010
+msgid "Hibernate"
+msgstr "Uspat na disk"
+
+#: id:13011
+msgid "Suspend"
+msgstr "Uspat do paměti"
+
+#: id:13012
+msgid "Exit"
+msgstr "Ukončit"
+
+#: id:13013
+msgid "Reboot"
+msgstr "Restartovat"
+
+#: id:13014
+msgid "Minimize"
+msgstr "Minimalizovat"
+
+#: id:13015
+msgid "Power button action"
+msgstr "Funkce tlačítka pro vypnutí"
+
+#: id:13016
+msgid "Power off System"
+msgstr "Vypnout systém"
+
+#: id:13020
+msgid "Is another session active, perhaps over ssh?"
+msgstr "Existuje nějaké aktivní připojení (např. přes SSH)?"
+
+#: id:13021
+msgid "Mounted removable harddrive"
+msgstr "Připojen vyměnitelný pevný disk"
+
+#: id:13022
+msgid "Unsafe device removal"
+msgstr "Nebezpečné odebrání zařízení"
+
+#: id:13023
+msgid "Successfully removed device"
+msgstr "Zařízení bylo úspěšně odebráno"
+
+#: id:13024
+msgid "Joystick plugged"
+msgstr "Joystick byl připojen"
+
+#: id:13025
+msgid "Joystick unplugged"
+msgstr "Joystick byl odpojen"
+
+#: id:13050
+msgid "Running low on battery"
+msgstr "Úroveň baterie je nízká"
+
+#: id:13100
+msgid "Flicker filter"
+msgstr "Filtr blikání"
+
+#: id:13101
+msgid "Let driver choose (requires restart)"
+msgstr "Ponechat nastavení ovladače (vyžadován restart)"
+
+#: id:13105
+msgid "Vertical blank sync"
+msgstr "Vertikální synchronizace obrazovky (V-Sync)"
+
+#: id:13106
+msgctxt "Auto context with id 13106"
+msgid "Disabled"
+msgstr "Vypnuto"
+
+#: id:13107
+msgid "Enabled during video playback"
+msgstr "Zapnuto při přehrávání videa"
+
+#: id:13108
+msgctxt "Auto context with id 13108"
+msgid "Always enabled"
+msgstr "Vždy zapnuto"
+
+#: id:13109
+msgid "Test & apply resolution"
+msgstr "Vyzkoušet rozlišení obrazovky"
+
+#: id:13110
+msgid "Save resolution?"
+msgstr "Nastavit toto rozlišení obrazovky?"
+
+#: id:13111
+msgid "Would you like to keep this resolution?"
+msgstr "Chcete ponechat toto rozlišení obrazovky?"
+
+#: id:13112
+msgid "High quality upscaling"
+msgstr "Vysoce kvalitní přepočet obrazu (upscaling)"
+
+#: id:13113
+msgctxt "Auto context with id 13113"
+msgid "Disabled"
+msgstr "Vypnuto"
+
+#: id:13114
+msgid "Enabled for SD content"
+msgstr "Zapnuto pro SD videa"
+
+#: id:13115
+msgctxt "Auto context with id 13115"
+msgid "Always enabled"
+msgstr "Vždy zapnuto"
+
+#: id:13116
+msgid "Upscaling method"
+msgstr "Způsob přepočtu"
+
+#: id:13117
+msgctxt "Auto context with id 13117"
+msgid "Bicubic"
+msgstr "Bikubický"
+
+#: id:13118
+msgid "Lanczos"
+msgstr "Lanczos"
+
+#: id:13119
+msgid "Sinc"
+msgstr "Sinc"
+
+#: id:13120
+msgctxt "Auto context with id 13120"
+msgid "VDPAU"
+msgstr "VDPAU"
+
+#: id:13121
+msgid "VDPAU HQ Upscaling level"
+msgstr "VDPAU - HQ přepočet"
+
+#: id:13122
+msgid "VDPAU Studio level color conversion"
+msgstr "VDPAU - rozsah barevného prostoru Studio Levels"
+
+#: id:13130
+msgid "Blank other displays"
+msgstr "Ztmavovat ostatní obrazovky"
+
+#: id:13131
+msgctxt "Auto context with id 13131"
+msgid "Disabled"
+msgstr "Vypnuto"
+
+#: id:13132
+msgid "Blank displays"
+msgstr "Zapnuto"
+
+#: id:13140
+msgid "Active connections detected!"
+msgstr "Nalezena aktivní spojení!"
+
+#: id:13141
+msgid "If you proceed, you might not be able to control XBMC"
+msgstr "V případě, že budete pokračovat je pravděpodobné že nebudete"
+
+#: id:13142
+msgid "any longer. Are you sure you want to stop the Event server?"
+msgstr "moci nadále ovládat XBMC. Opravdu chcete ukončit Event server?"
+
+#: id:13144
+msgid "Change Apple Remote mode?"
+msgstr "Chcete změnit mód Dálkového ovladače Apple?"
+
+#: id:13145
+msgid "If you are currently using the Apple Remote to control"
+msgstr "V případě, že používáte Dálkový ovladač Apple"
+
+#: id:13146
+msgid "XBMC, changing this setting might affect your ability"
+msgstr "k ovládání XBMC, změnou tohoto nastavení můžete"
+
+#: id:13147
+msgid "to continue controlling it. Do you want to proceed?"
+msgstr "přijít o možnost ovládání. Opravdu chcete pokračovat?"
+
+#: id:13159
+msgid "Subnet mask"
+msgstr "Maska podsítě"
+
+#: id:13160
+msgid "Gateway"
+msgstr "Výchozí brána"
+
+#: id:13161
+msgid "Primary DNS"
+msgstr "Primární DNS"
+
+#: id:13162
+msgid "Initialize failed"
+msgstr "Inicializace selhala"
+
+#: id:13170
+msgctxt "Auto context with id 13170"
+msgid "Never"
+msgstr "Nikdy"
+
+#: id:13171
+msgid "Immediately"
+msgstr "Okamžitě"
+
+#: id:13172
+msgid "After %i secs"
+msgstr "Po %i sekundách"
+
+#: id:13173
+msgid "HDD install date:"
+msgstr "Datum instalace HDD:"
+
+#: id:13174
+msgid "HDD power cycle count:"
+msgstr "Počet spuštění HDD:"
+
+#: id:13200
+msgid "Profiles"
+msgstr "Profily"
+
+#: id:13201
+msgid "Delete profile '%s'?"
+msgstr "Odstranit profil '%s'?"
+
+#: id:13204
+msgid "Last loaded profile:"
+msgstr "Naposledy načtený profil:"
+
+#: id:13205
+msgid "Unknown"
+msgstr "Neznámý"
+
+#: id:13206
+msgid "Overwrite"
+msgstr "Přepsat"
+
+#: id:13208
+msgid "Alarm clock"
+msgstr "Budík"
+
+#: id:13209
+msgid "Alarm clock interval (in minutes)"
+msgstr "Interval budíku (v min)"
+
+#: id:13210
+msgid "Started, alarm in %im"
+msgstr "Budík nastaven na %im"
+
+#: id:13211
+msgid "Alarm!"
+msgstr "Budíček!"
+
+#: id:13212
+msgid "Canceled with %im%is left"
+msgstr "Budík byl přerušen %im%is před spuštěním"
+
+#: id:13213
+msgid "%2.0fm"
+msgstr "%2.0fm"
+
+#: id:13214
+msgid "%2.0fs"
+msgstr "%2.0fs"
+
+#: id:13249
+msgid "Search for subtitles in RARs"
+msgstr "Načítat titulky z RAR archivů"
+
+#: id:13250
+msgid "Browse for subtitle..."
+msgstr "Načíst titulky..."
+
+#: id:13251
+msgid "Move item"
+msgstr "Přesunout položku"
+
+#: id:13252
+msgid "Move item here"
+msgstr "Přesunout položku sem"
+
+#: id:13253
+msgid "Cancel move"
+msgstr "Zrušit přesunutí"
+
+#: id:13270
+msgid "Hardware:"
+msgstr "Hardware:"
+
+#: id:13271
+msgid "CPU Usage:"
+msgstr "Využití CPU:"
+
+#: id:13274
+msgid "Connected, but no DNS is available."
+msgstr "Připojeno, ale služba DNS není k dispozici."
+
+#: id:13275
+msgid "Hard Disk"
+msgstr "HDD"
+
+#: id:13276
+msgid "DVD-ROM"
+msgstr "DVD-ROM"
+
+#: id:13277
+msgctxt "Auto context with id 13277"
+msgid "Storage"
+msgstr "Úložiště"
+
+#: id:13278
+msgctxt "Auto context with id 13278"
+msgid "Default"
+msgstr "Standardní"
+
+#: id:13279
+msgctxt "Auto context with id 13279"
+msgid "Network"
+msgstr "Síť"
+
+#: id:13280
+msgctxt "Auto context with id 13280"
+msgid "Video"
+msgstr "Video"
+
+#: id:13281
+msgid "Hardware"
+msgstr "Hardware"
+
+#: id:13283
+msgid "Operating system:"
+msgstr "Operační systém:"
+
+#: id:13284
+msgid "CPU speed:"
+msgstr "CPU frekvence:"
+
+#: id:13286
+msgid "Video encoder:"
+msgstr "Grafický adaptér:"
+
+#: id:13287
+msgid "Screen resolution:"
+msgstr "Rozlišení obrazovky:"
+
+#: id:13292
+msgid "A/V cable:"
+msgstr "A/V kabel:"
+
+#: id:13294
+msgid "DVD region:"
+msgstr "DVD region:"
+
+#: id:13295
+msgid "Internet:"
+msgstr "Internet:"
+
+#: id:13296
+msgctxt "Auto context with id 13296"
+msgid "Connected"
+msgstr "Připojeno"
+
+#: id:13297
+msgid "Not connected. Check network settings."
+msgstr "Nepřipojeno. Zkontrolujte nastavení sítě."
+
+#: id:13299
+msgid "Target temperature"
+msgstr "Cílová teplota"
+
+#: id:13300
+msgid "Fan speed"
+msgstr "Rychlost větráčku"
+
+#: id:13301
+msgid "Auto temperature control"
+msgstr "Automatická kontrola teploty"
+
+#: id:13302
+msgid "Fan speed override"
+msgstr "Manuální nastavení rychlosti větráčku"
+
+#: id:13303
+msgid "- Fonts"
+msgstr "Písmo vzhledu"
+
+#: id:13304
+msgid "Enable flipping bi-directional strings"
+msgstr "Aktivovat převrácené zobrazení titulků"
+
+#: id:13305
+msgid "Show RSS news feeds"
+msgstr "Zobrazovat RSS zpravodajství"
+
+#: id:13306
+msgid "Show parent folder items"
+msgstr "Zobrazovat položku pro návrat do předchozí složky (..)"
+
+#: id:13307
+msgid "Track naming template"
+msgstr "Šablona názvu stopy"
+
+#: id:13308
+msgid "Do you wish to reboot your system"
+msgstr "Opravdu chcete restartovat systém"
+
+#: id:13309
+msgid "instead of just XBMC?"
+msgstr "místo XBMC?"
+
+#: id:13310
+msgid "Zoom effect"
+msgstr "Efekt přiblížení"
+
+#: id:13311
+msgid "Float effect"
+msgstr "Efekt splynutí"
+
+#: id:13312
+msgid "Black bar reduction"
+msgstr "Redukce černých krajů"
+
+#: id:13313
+msgid "Restart"
+msgstr "Restartovat"
+
+#: id:13314
+msgid "Crossfade between songs"
+msgstr "Plynule přecházet mezi skladbami"
+
+#: id:13315
+msgid "Regenerate thumbnails"
+msgstr "Aktualizovat náhledy"
+
+#: id:13316
+msgid "Recursive thumbnails"
+msgstr "Náhledy podsložek"
+
+#: id:13317
+msgid "View slideshow"
+msgstr "Prezentace"
+
+#: id:13318
+msgid "Recursive slideshow"
+msgstr "Prezentace z podsložek"
+
+#: id:13319
+msgid "Randomize"
+msgstr "Náhodné pořadí"
+
+#: id:13320
+msgid "Stereo"
+msgstr "Stereo"
+
+#: id:13321
+msgid "Left only"
+msgstr "Pouze levý"
+
+#: id:13322
+msgid "Right only"
+msgstr "Pouze pravý"
+
+#: id:13323
+msgid "Enable karaoke support"
+msgstr "Aktivovat CD+G"
+
+#: id:13324
+msgid "Background transparency"
+msgstr "Průhlednost pozadí"
+
+#: id:13325
+msgid "Foreground transparency"
+msgstr "Průhlednost popředí"
+
+#: id:13326
+msgid "A/V delay"
+msgstr "Zpoždění A/V"
+
+#: id:13327
+msgid "Karaoke"
+msgstr "Karaoke"
+
+#: id:13328
+msgid "%s not found"
+msgstr "%s nenalezen."
+
+#: id:13329
+msgid "Error opening %s"
+msgstr "Chyba při otevírání %s"
+
+#: id:13330
+msgid "Unable to load %s"
+msgstr "Nemohu načíst %s"
+
+#: id:13331
+msgid "Error: Out of memory"
+msgstr "Chyba: nedostatek paměti."
+
+#: id:13332
+msgid "Move up"
+msgstr "Přesunout nahoru"
+
+#: id:13333
+msgid "Move down"
+msgstr "Přesunout dolu"
+
+#: id:13334
+msgid "Edit label"
+msgstr "Změnit název"
+
+#: id:13335
+msgid "Make default"
+msgstr "Nastavit jako vých. složku"
+
+#: id:13336
+msgid "Remove button"
+msgstr "Odebrat tlačítko"
+
+#: id:13340
+msgid "Leave as is"
+msgstr "Standardní"
+
+#: id:13341
+msgid "Green"
+msgstr "Zelená"
+
+#: id:13342
+msgid "Orange"
+msgstr "Oranžová"
+
+#: id:13343
+msgid "Red"
+msgstr "Červená"
+
+#: id:13344
+msgid "Cycle"
+msgstr "Měnit barvy"
+
+#: id:13345
+msgid "Switch LED off on playback"
+msgstr "Vypnout LED při přehrávání"
+
+#: id:13346
+msgctxt "Auto context with id 13346"
+msgid "Movie information"
+msgstr "Informace o filmu"
+
+#: id:13347
+msgid "Queue item"
+msgstr "Přidat do Seznamu stop"
+
+#: id:13348
+msgid "Search IMDb..."
+msgstr "Vyhledat na IMDb..."
+
+#: id:13349
+msgid "Scan for new content"
+msgstr "Vyhledat nový obsah"
+
+#: id:13350
+msgid "Now playing..."
+msgstr "Přehrává se..."
+
+#: id:13351
+msgctxt "Auto context with id 13351"
+msgid "Album information"
+msgstr "Informace o albu"
+
+#: id:13352
+msgid "Scan item to library"
+msgstr "Přidat do Knihovny"
+
+#: id:13353
+msgid "Stop scanning"
+msgstr "Ukončit vyhledávání"
+
+#: id:13354
+msgctxt "Auto context with id 13354"
+msgid "Render method"
+msgstr "Způsob vykreslení"
+
+#: id:13355
+msgid "Low quality pixel shader"
+msgstr "Nízká kvalita pixel shaderu"
+
+#: id:13356
+msgid "Hardware overlays"
+msgstr "Hardwarové překrytí"
+
+#: id:13357
+msgid "High quality pixel shader"
+msgstr "Vysoká kvalita pixel shaderu"
+
+#: id:13358
+msgid "Play item"
+msgstr "Přehrát položku"
+
+#: id:13359
+msgid "Set artist thumb"
+msgstr "Přiřadit ikonu interpreta"
+
+#: id:13360
+msgid "Automatically generate thumbnails"
+msgstr "Automaticky generovat náhledy"
+
+#: id:13361
+msgid "Enable voice"
+msgstr "Povolit úpravu hlasu"
+
+#: id:13375
+msgid "Enable device"
+msgstr "Povolit zařízení"
+
+#: id:13376
+msgid "Volume"
+msgstr "Hlasitost"
+
+#: id:13377
+msgid "Default view mode"
+msgstr "Výchozí nastavení zobrazení"
+
+#: id:13378
+msgid "Default brightness"
+msgstr "Výchozí nastavení jasu"
+
+#: id:13379
+msgid "Default contrast"
+msgstr "Výchozí nastavení kontrastu"
+
+#: id:13380
+msgid "Default gamma"
+msgstr "Výchozí nastavení gama"
+
+#: id:13381
+msgid "Resume video"
+msgstr "Pokračovat ve videu"
+
+#: id:13382
+msgid "Voice mask - Port 1"
+msgstr "Zabarvení hlasu - Port 1"
+
+#: id:13383
+msgid "Voice mask - Port 2"
+msgstr "Zabarvení hlasu - Port 2"
+
+#: id:13384
+msgid "Voice mask - Port 3"
+msgstr "Zabarvení hlasu - Port 3"
+
+#: id:13385
+msgid "Voice mask - Port 4"
+msgstr "Zabarvení hlasu - Port 4"
+
+#: id:13386
+msgid "Use time based seeking"
+msgstr "Použít pevně dané čas. intervaly při přeskakování ve videu"
+
+#: id:13387
+msgid "Track naming template - right"
+msgstr "Šablona názvu stopy - vpravo"
+
+#: id:13388
+msgid "Preset"
+msgstr "Předvolby"
+
+#: id:13389
+msgid "There are no presets available\nfor this visualization"
+msgstr "Pro tuto vizualizaci\nnejsou k dispozici žádné předvolby"
+
+#: id:13390
+msgid "There are no settings available\nfor this visualization"
+msgstr "Pro tuto vizualizaci\nnení k dispozici žádné nastavení"
+
+#: id:13391
+msgid "Eject/Load"
+msgstr "Vysunout/Zasunout"
+
+#: id:13392
+msgid "Use visualization if playing audio"
+msgstr "V případě přehrávání hudby použít vizualizaci"
+
+#: id:13393
+msgid "Calculate size"
+msgstr "Zjistit velikost"
+
+#: id:13394
+msgid "Calculating folder size"
+msgstr "Zjistit velikost složky"
+
+#: id:13395
+msgid "Video settings"
+msgstr "Nastavení videa"
+
+#: id:13396
+msgid "Audio and subtitle settings"
+msgstr "Nastavení zvuku/titulků"
+
+#: id:13397
+msgid "Enable subtitles"
+msgstr "Zobrazovat titulky"
+
+#: id:13398
+msgctxt "Auto context with id 13398"
+msgid "Shortcuts"
+msgstr "Záložky"
+
+#: id:13399
+msgid "Ignore articles when sorting (e.g. \"the\")"
+msgstr "Při řazení ignorovat \"členy\" na začátku názvu (\"the\")"
+
+#: id:13400
+msgid "Crossfade between songs on the same album"
+msgstr "Plynule přecházet mezi skladbami ze stejného alba"
+
+#: id:13401
+msgid "Browse for %s"
+msgstr "Hledat %s"
+
+#: id:13402
+msgid "Show track position"
+msgstr "Zobrazovat pozici stopy"
+
+#: id:13403
+msgid "Clear default"
+msgstr "Zrušit výchozí složku"
+
+#: id:13404
+msgid "Resume"
+msgstr "Pokračovat"
+
+#: id:13405
+msgid "Get thumb"
+msgstr "Změnit náhled"
+
+#: id:13406
+msgid "Picture information"
+msgstr "Informace o obrázku"
+
+#: id:13407
+msgid "%s presets"
+msgstr "%s předvolby"
+
+#: id:13408
+msgid "(IMDb user rating)"
+msgstr "(Hodnocení uživatelů IMDb)"
+
+#: id:13409
+msgid "Top 250"
+msgstr "Top 250"
+
+#: id:13410
+msgid "Tune in on Last.fm"
+msgstr "Naladit na Last.fm"
+
+#: id:13411
+msgid "Minimum fan speed"
+msgstr "Minimální rychlost větráčku"
+
+#: id:13412
+msgid "Play from here"
+msgstr "Přehrát z tohoto místa"
+
+#: id:13413
+msgid "Downloading"
+msgstr "Probíhá stahování"
+
+#: id:13414
+msgid "Include artists who appear only on compilations"
+msgstr "Zobrazovat mezi Interprety i ty, kteří se vyskytují pouze u kompilací"
+
+#: id:13415
+msgctxt "Auto context with id 13415"
+msgid "Render method"
+msgstr "Způsob vykreslování"
+
+#: id:13416
+msgid "Auto detect"
+msgstr "Autodetekce"
+
+#: id:13417
+msgid "Basic shaders (ARB)"
+msgstr "Základní Shadery (ARB)"
+
+#: id:13418
+msgid "Advanced shaders (GLSL)"
+msgstr "Pokročilé Shadery (GLSL)"
+
+#: id:13419
+msgid "Software"
+msgstr "Softwarový"
+
+#: id:13420
+msgid "Remove safely"
+msgstr "Bezpečně odebrat"
+
+#: id:13421
+msgctxt "Auto context with id 13421"
+msgid "VDPAU"
+msgstr "VDPAU"
+
+#: id:13422
+msgid "Start slideshow here"
+msgstr "Spustit prezentaci"
+
+#: id:13423
+msgid "Remember for this path"
+msgstr "Zapamatovat pro tuto cestu"
+
+#: id:13424
+msgid "Use pixel buffer objects"
+msgstr "Použít objekty vyrovnávací paměti pixelu"
+
+#: id:13425
+msgid "Allow hardware acceleration (VDPAU)"
+msgstr "Aktivovat hardwarovou akceleraci (VDPAU)"
+
+#: id:13426
+msgid "Allow hardware acceleration (VAAPI)"
+msgstr "Aktivovat hardwarovou akceleraci (VAAPI)"
+
+#: id:13427
+msgid "Allow hardware acceleration (DXVA2)"
+msgstr "Aktivovat hardwarovou akceleraci (DXVA2)"
+
+#: id:13428
+msgid "Allow hardware acceleration (CrystalHD)"
+msgstr "Aktivovat hardwarovou akceleraci (CrystalHD)"
+
+#: id:13429
+msgid "Allow hardware acceleration (VDADecoder)"
+msgstr "Aktivovat hardwarovou akceleraci (VDADecoder)"
+
+#: id:13430
+msgid "Allow hardware acceleration (OpenMax)"
+msgstr "Aktivovat hardwarovou akceleraci (OpenMax)"
+
+#: id:13431
+msgid "Pixel Shaders"
+msgstr "Pixel Shadery"
+
+#: id:13432
+msgid "Allow hardware acceleration (VideoToolbox)"
+msgstr "Povolit hardwarovou akceleraci (VideoToolbox)"
+
+#: id:13500
+msgid "A/V sync method"
+msgstr "Způsob synchronizace A/V"
+
+#: id:13501
+msgid "Audio clock"
+msgstr "dle audia"
+
+#: id:13502
+msgid "Video clock (Drop/Dupe audio)"
+msgstr "dle videa (vynechat/duplikovat audio)"
+
+#: id:13503
+msgid "Video clock (Resample audio)"
+msgstr "dle videa (přizpůsobit rychlost audia)"
+
+#: id:13504
+msgid "Maximum resample amount (%)"
+msgstr "Maximální změna rychlosti (%)"
+
+#: id:13505
+msgid "Resample quality"
+msgstr "Kvalita změny rychlosti"
+
+#: id:13506
+msgid "Low(fast)"
+msgstr "Nízká"
+
+#: id:13507
+msgctxt "Auto context with id 13507"
+msgid "Medium"
+msgstr "Střední"
+
+#: id:13508
+msgctxt "Auto context with id 13508"
+msgid "High"
+msgstr "Vysoká"
+
+#: id:13509
+msgid "Really high(slow!)"
+msgstr "Velmi vysoká"
+
+#: id:13510
+msgid "Sync playback to display"
+msgstr "Synchronizovat přehrávání videa k frekvenci obrazovky"
+
+#: id:13550
+msgid "Pause during refresh rate change"
+msgstr "Při změně obnovovací frekvence pozastavit přehrávání"
+
+#: id:13551
+msgctxt "Auto context with id 13551"
+msgid "Off"
+msgstr "Vypnuto"
+
+#: id:13552
+msgid "%.1f Second"
+msgstr "%.1f Sekunda"
+
+#: id:13553
+msgid "%.1f Seconds"
+msgstr "%.1f Sekundy"
+
+#: id:13600
+msgid "Apple remote"
+msgstr "Dálkové ovládání Apple"
+
+#: id:13602
+msgid "Allow start of XBMC using the remote"
+msgstr "Povolit spuštění XBMC dálkovým ovladačem"
+
+#: id:13603
+msgid "Sequence delay time"
+msgstr "Posloupnost zpoždění"
+
+#: id:13610
+msgctxt "Auto context with id 13610"
+msgid "Disabled"
+msgstr "Zakázáno"
+
+#: id:13611
+msgctxt "Auto context with id 13611"
+msgid "Standard"
+msgstr "Standardní"
+
+#: id:13612
+msgid "Universal Remote"
+msgstr "Univerzální dálkový ovladač"
+
+#: id:13613
+msgid "Multi Remote (Harmony)"
+msgstr "Multifunkční dálkové ovládání (Harmony)"
+
+#: id:13620
+msgid "Apple Remote Error"
+msgstr "Chyba dálkového ovladače Apple"
+
+#: id:13621
+msgid "Apple Remote support could be enabled."
+msgstr "Může být zapnuta podpora dálkového ovladače Apple."
+
+#: id:14000
+msgid "Stack"
+msgstr "Spojovat videa"
+
+#: id:14001
+msgid "Unstack"
+msgstr "Nespojovat videa"
+
+#: id:14003
+msgid "Downloading playlist file..."
+msgstr "Probíhá stahování souboru se Seznamem stop..."
+
+#: id:14004
+msgid "Downloading streams list..."
+msgstr "Probíhá stahování nabídky streamů..."
+
+#: id:14005
+msgid "Parsing streams list..."
+msgstr "Probíhá zpracování nabídky streamů..."
+
+#: id:14006
+msgid "Downloading streams list failed"
+msgstr "Stahování nabídky streamů selhalo"
+
+#: id:14007
+msgid "Downloading playlist file failed"
+msgstr "Stahování seznamu stop selhalo"
+
+#: id:14009
+msgid "Games directory"
+msgstr "Složka s hrami"
+
+#: id:14010
+msgid "Auto switch to thumbs based on"
+msgstr "Přepínat na režim náhledů"
+
+#: id:14011
+msgid "Enable auto switching to thumbs view"
+msgstr "Aktivovat automatické přepínání náhledů"
+
+#: id:14012
+msgid "- Use large icons"
+msgstr "- při použití velkých ikon"
+
+#: id:14013
+msgid "- Switch based on"
+msgstr "- dle pravidla"
+
+#: id:14014
+msgid "- Percentage"
+msgstr "- procentuální zastoupení"
+
+#: id:14015
+msgid "No files and at least one thumb"
+msgstr "Existuje min. 1 náhled, ale žádný soubor"
+
+#: id:14016
+msgid "At least one file and thumb"
+msgstr "Existuje min. 1 náhled a 1 soubor"
+
+#: id:14017
+msgid "Percentage of thumbs"
+msgstr "Procentuálního zastoupení počtu náhledů"
+
+#: id:14018
+msgid "View options"
+msgstr "Zobrazení"
+
+#: id:14019
+msgid "Change area code 1"
+msgstr "1. oblast"
+
+#: id:14020
+msgid "Change area code 2"
+msgstr "2. oblast"
+
+#: id:14021
+msgid "Change area code 3"
+msgstr "3. oblast"
+
+#: id:14022
+msgctxt "Auto context with id 14022"
+msgid "Library"
+msgstr "Knihovna"
+
+#: id:14023
+msgid "No TV"
+msgstr "Bez TV"
+
+#: id:14024
+msgid "Enter the nearest large town"
+msgstr "Zadejte nejbližší velkoměsto"
+
+#: id:14025
+msgid "Video/Audio/DVD cache - Harddisk"
+msgstr "Mezipaměť - Video/Audio/DVD - HDD"
+
+#: id:14026
+msgid "Video cache - DVD-ROM"
+msgstr "Mezipaměť - Video - DVDROM"
+
+#: id:14027
+msgctxt "Auto context with id 14027"
+msgid "- Local Network"
+msgstr "- Místní síť"
+
+#: id:14028
+msgctxt "Auto context with id 14028"
+msgid "- Internet"
+msgstr "- Internet"
+
+#: id:14030
+msgid "Audio cache - DVD-ROM"
+msgstr "Mezipaměť - Audio - DVDROM"
+
+#: id:14031
+msgctxt "Auto context with id 14031"
+msgid "- Local Network"
+msgstr "- Místní síť"
+
+#: id:14032
+msgctxt "Auto context with id 14032"
+msgid "- Internet"
+msgstr "- Internet"
+
+#: id:14034
+msgid "DVD cache - DVD-ROM"
+msgstr "Mezipaměť - DVD - DVDROM"
+
+#: id:14035
+msgctxt "Auto context with id 14035"
+msgid "- Local Network"
+msgstr "- Místní síť"
+
+#: id:14036
+msgctxt "Auto context with id 14036"
+msgid "Services"
+msgstr "Služby"
+
+#: id:14038
+msgid "Network settings changed"
+msgstr "Nastavení sítě bylo změněno"
+
+#: id:14039
+msgid "XBMC requires to restart to change your"
+msgstr "Změna síťového nastavení vyžaduje"
+
+#: id:14040
+msgid "network setup. Would you like to restart now?"
+msgstr "restart XBMC. Chcete ho provést nyní?"
+
+#: id:14041
+msgid "Internet connection bandwidth limitation"
+msgstr "Post Processing"
+
+#: id:14043
+msgid "- Shutdown while playing"
+msgstr "- Aktivovat vypnutí v případě, že je hra spuštěna"
+
+#: id:14044
+msgid "%i min"
+msgstr "%i min"
+
+#: id:14045
+msgid "%i sec"
+msgstr "%i sek"
+
+#: id:14046
+msgid "%i ms"
+msgstr "%i ms"
+
+#: id:14047
+msgid "%i %%"
+msgstr "%i %%"
+
+#: id:14048
+msgid "%i kbps"
+msgstr "%i kbps"
+
+#: id:14049
+msgid "%i kb"
+msgstr "%i kb"
+
+#: id:14050
+msgid "%i.0 dB"
+msgstr "%i.0 dB"
+
+#: id:14051
+msgid "Time format"
+msgstr "Formát hodin"
+
+#: id:14052
+msgid "Date format"
+msgstr "Formát data"
+
+#: id:14053
+msgid "GUI filters"
+msgstr "Filtry GUI"
+
+#: id:14055
+msgid "Use background scanning"
+msgstr "Použít vyhledávání na pozadí"
+
+#: id:14056
+msgid "Stop scan"
+msgstr "Zastavit vyhledávání"
+
+#: id:14057
+msgid "Not possible while scanning for media info"
+msgstr "Tuto operaci nelze provést při vyhledávání informací o médiu"
+
+#: id:14058
+msgid "Film grain effect"
+msgstr "Efekt Filmové zrnitosti"
+
+#: id:14059
+msgid "Search for thumbnails on remote shares"
+msgstr "Vyhledávat náhledy u sdílených složek/CD/DVD"
+
+#: id:14060
+msgid "Unknown type cache - Internet"
+msgstr "Mezipaměť - Ostatní - Internet"
+
+#: id:14061
+msgctxt "Auto context with id 14061"
+msgid "Auto"
+msgstr "Automaticky"
+
+#: id:14062
+msgid "Enter username for"
+msgstr "Zadejte uživatelské jméno pro"
+
+#: id:14063
+msgid "Date & time"
+msgstr "Datum a Čas"
+
+#: id:14064
+msgid "Set date"
+msgstr "Datum"
+
+#: id:14065
+msgid "Set time"
+msgstr "Čas"
+
+#: id:14066
+msgid "Enter the time in 24 hour HH:MM format"
+msgstr "Zadejte čas ve 24h formátu (HH:MM)"
+
+#: id:14067
+msgid "Enter the date in DD/MM/YYYY format"
+msgstr "Zadejte datum ve formátu: DD/MM/YYYY"
+
+#: id:14068
+msgid "Enter the IP address"
+msgstr "Zadejte IP adresu"
+
+#: id:14069
+msgid "Apply these settings now?"
+msgstr "Opravdu chcete nyní použít toto nastavení?"
+
+#: id:14070
+msgid "Apply changes now"
+msgstr "Použít změny"
+
+#: id:14071
+msgid "Allow file renaming and deletion"
+msgstr "Povolit přejmenování a mazání souborů"
+
+#: id:14074
+msgid "Set timezone"
+msgstr "Časové pásmo"
+
+#: id:14075
+msgid "Use daylight saving time"
+msgstr "Automaticky upravit hodiny na letní čas"
+
+#: id:14076
+msgid "Add to favourites"
+msgstr "Přidat do oblíbených"
+
+#: id:14077
+msgid "Remove from favourites"
+msgstr "Odebrat z oblíbených"
+
+#: id:14078
+msgctxt "Auto context with id 14078"
+msgid "- Colours"
+msgstr "Barvy vzhledu"
+
+#: id:14079
+msgid "Timezone country"
+msgstr "Časové pásmo - Země"
+
+#: id:14080
+msgid "Timezone"
+msgstr "Časové pásmo"
+
+#: id:14081
+msgid "File lists"
+msgstr "Soubory a složky"
+
+#: id:14082
+msgid "Show EXIF picture information"
+msgstr "Zobrazovat EXIF informace o obrázku"
+
+#: id:14083
+msgid "Use a fullscreen window rather than true fullscreen"
+msgstr "Otevřít v okně přes celou obrazovku namísto pravého fullscreen režimu"
+
+#: id:14084
+msgid "Queue songs on selection"
+msgstr "Přidávat skladby do fronty při jejich výběru"
+
+#: id:14086
+msgid "Playback"
+msgstr "Přehrávání"
+
+#: id:14087
+msgid "DVDs"
+msgstr "DVD"
+
+#: id:14088
+msgid "Play DVDs automatically"
+msgstr "Automaticky přehrávat DVD"
+
+#: id:14089
+msgid "Font to use for text subtitles"
+msgstr "Písmo pro textové titulky"
+
+#: id:14090
+msgid "International"
+msgstr "Oblast a jazyk"
+
+#: id:14091
+msgid "Character set"
+msgstr "Znaková sada"
+
+#: id:14092
+msgid "Debugging"
+msgstr "Ladění"
+
+#: id:14093
+msgid "Security"
+msgstr "Bezpečnost"
+
+#: id:14094
+msgid "Input devices"
+msgstr "Vstupní zařízení"
+
+#: id:14095
+msgid "Power saving"
+msgstr "Napájení"
+
+#: id:14096
+msgid "Rip"
+msgstr ""
+
+#: id:14097
+msgid "Audio CD Insert Action"
+msgstr ""
+
+#: id:14098
+msgctxt "Auto context with id 14098"
+msgid "Play"
+msgstr ""
+
+#: id:14099
+msgid "Eject disc when CD ripping is complete"
+msgstr ""
+
+#: id:15015
+msgctxt "Auto context with id 15015"
+msgid "Remove"
+msgstr "Odebrat"
+
+#: id:15016
+msgid "Games"
+msgstr "Hry"
+
+#: id:15019
+msgid "Add"
+msgstr "Přidat"
+
+#: id:15052
+msgid "Password"
+msgstr "Heslo"
+
+#: id:15100
+msgctxt "Auto context with id 15100"
+msgid "Library"
+msgstr "Knihovna"
+
+#: id:15101
+msgid "Database"
+msgstr "Databáze"
+
+#: id:15102
+msgid "* All albums"
+msgstr "* Všechna alba"
+
+#: id:15103
+msgid "* All artists"
+msgstr "* Všichni interpreti"
+
+#: id:15104
+msgid "* All songs"
+msgstr "* Všechny skladby"
+
+#: id:15105
+msgid "* All genres"
+msgstr "* Všechny žánry"
+
+#: id:15107
+msgid "Buffering..."
+msgstr "Načítání do mezipaměti..."
+
+#: id:15108
+msgid "Navigation sounds"
+msgstr "Zvuky při navigaci"
+
+#: id:15109
+msgid "Skin default"
+msgstr "Standardní"
+
+#: id:15111
+msgid "- Theme"
+msgstr "- Téma vzhledu"
+
+#: id:15112
+msgid "Default theme"
+msgstr "Výchozí vzhled"
+
+#: id:15200
+msgid "Last.fm"
+msgstr "Last.fm"
+
+#: id:15201
+msgid "Submit songs to Last.fm"
+msgstr "Last.fm - Odesílat informace o skladbách"
+
+#: id:15202
+msgid "Last.fm username"
+msgstr "Last.fm - Uživatelské jméno"
+
+#: id:15203
+msgid "Last.fm password"
+msgstr "Last.fm - Heslo"
+
+#: id:15204
+msgid "Unable to handshake: sleeping..."
+msgstr "Nepovolená operace: Probíhá ukončování..."
+
+#: id:15205
+msgid "Please update XBMC"
+msgstr "Aktualizujte prosím XBMC"
+
+#: id:15206
+msgid "Bad authorization: Check username and password"
+msgstr "Neúspěšná autorizace: Zkontrolujte uživ. jméno a heslo"
+
+#: id:15207
+msgctxt "Auto context with id 15207"
+msgid "Connected"
+msgstr "Připojeno"
+
+#: id:15208
+msgid "Not connected"
+msgstr "Nepřipojeno"
+
+#: id:15209
+msgid "Submit interval %i"
+msgstr "Interval odesílání %i"
+
+#: id:15210
+msgid "Cached %i songs"
+msgstr "Načteno %i skladeb"
+
+#: id:15211
+msgid "Submitting..."
+msgstr "Probíhá odesílání..."
+
+#: id:15212
+msgid "Submitting in %i secs"
+msgstr "Informace budou odeslány za %i sekund"
+
+#: id:15213
+msgid "Play using..."
+msgstr "Přehrát"
+
+#: id:15214
+msgid "Use smoothed A/V synchronization"
+msgstr "Používat hladkou synchronizaci A/V"
+
+#: id:15215
+msgid "Hide file names in thumbs view"
+msgstr "Nezobrazovat názvy souborů při zobrazení náhledů"
+
+#: id:15216
+msgid "Play in party mode"
+msgstr "Přehrát v Párty módu"
+
+#: id:15217
+msgid "Submit songs to Libre.fm"
+msgstr "Libre.fm - Odesílat informace o skladbách"
+
+#: id:15218
+msgid "Libre.fm username"
+msgstr "Libre.fm - Uživatelské jméno"
+
+#: id:15219
+msgid "Libre.fm password"
+msgstr "Libre.fm - Heslo"
+
+#: id:15220
+msgid "Libre.fm"
+msgstr "Libre.fm"
+
+#: id:15221
+msgid "Song submission"
+msgstr "Online služby"
+
+#: id:15250
+msgid "Submit Last.fm radio to Last.fm"
+msgstr "Last.fm - Odesílat informace o rádiích"
+
+#: id:15251
+msgid "Connecting to Last.fm..."
+msgstr "Probíhá připojování k Last.fm..."
+
+#: id:15252
+msgid "Selecting station..."
+msgstr "Probíhá výběr stanice..."
+
+#: id:15253
+msgid "Search similar artists..."
+msgstr "Vyhledat podobné interprety..."
+
+#: id:15254
+msgid "Search similar tags..."
+msgstr "Vyhledat podobné slova..."
+
+#: id:15255
+msgid "Your profile (%name%)"
+msgstr "Profil (%name%)"
+
+#: id:15256
+msgid "Overall top tags"
+msgstr "Nejpopulárnější slova"
+
+#: id:15257
+msgid "Top artists for tag %name%"
+msgstr "NEJ interpreti pro slovo %name%"
+
+#: id:15258
+msgid "Top albums for tag %name%"
+msgstr "NEJ alba pro slovo %name%"
+
+#: id:15259
+msgid "Top tracks for tag %name%"
+msgstr "NEJ skladby pro slovo %name%"
+
+#: id:15260
+msgid "Listen to tag %name% Last.fm radio"
+msgstr "Poslouchat slovo %name% Last.fm radio"
+
+#: id:15261
+msgid "Similar artists as %name%"
+msgstr "Podobní interpreti jako %name%"
+
+#: id:15262
+msgid "Top %name% albums"
+msgstr "%name% - NEJ alba"
+
+#: id:15263
+msgid "Top %name% tracks"
+msgstr "%name% - NEJ skladby"
+
+#: id:15264
+msgid "Top %name% tags"
+msgstr "%name% - NEJ slova"
+
+#: id:15265
+msgid "Biggest fans of %name%"
+msgstr "Největší fanoušci - %name%"
+
+#: id:15266
+msgid "Listen to %name% fans Last.fm radio"
+msgstr "Poslouchat %name% fanoušky Last.fm radio"
+
+#: id:15267
+msgid "Listen to %name% similar artists Last.fm radio"
+msgstr "Poslouchat %name% podobné interprety Last.fm radio"
+
+#: id:15268
+msgid "Top artists for user %name%"
+msgstr "NEJ interpreti uživatele %name%"
+
+#: id:15269
+msgid "Top albums for user %name%"
+msgstr "NEJ alba uživatele %name%"
+
+#: id:15270
+msgid "Top tracks for user %name%"
+msgstr "NEJ skladby uživatele %name%"
+
+#: id:15271
+msgid "Friends of user %name%"
+msgstr "Přátelé uživatele %name%"
+
+#: id:15272
+msgid "Neighbours of user %name%"
+msgstr "Sousedé uživatele %name%"
+
+#: id:15273
+msgid "Weekly artist chart for %name%"
+msgstr "Žebříček interpretů týdne pro %name%"
+
+#: id:15274
+msgid "Weekly album chart for %name%"
+msgstr "Žebříček alb týdne pro %name%"
+
+#: id:15275
+msgid "Weekly track chart for %name%"
+msgstr "Žebříček skladeb týdne pro %name%"
+
+#: id:15276
+msgid "Listen to %name%'s neighbours Last.fm radio"
+msgstr "Poslouchat %name% sousedovo Last.fm radio"
+
+#: id:15277
+msgid "Listen to %name%'s personal Last.fm radio"
+msgstr "Poslouchat %name% osobní Last.fm radio"
+
+#: id:15278
+msgid "Listen to %name%'s mix Last.fm radio"
+msgstr "Poslouchat %name% nejoblíbenější skladby Last.fm radia"
+
+#: id:15279
+msgid "Retrieving list from Last.fm..."
+msgstr "Probíhá stahování seznamu z Last.fm..."
+
+#: id:15280
+msgid "Can't retrieve list from Last.fm..."
+msgstr "Seznam z Last.fm se nepodařilo stáhnout..."
+
+#: id:15281
+msgid "Enter an artist name to find related ones"
+msgstr "Zadejte jméno interpreta pro vyhledání jemu podobných"
+
+#: id:15282
+msgid "Enter a tag name to find similar ones"
+msgstr "Zadejte slovo pro vyhledání podobných"
+
+#: id:15283
+msgid "Tracks recently listened by %name%"
+msgstr "Skladby, které naposledy poslouchal %name%"
+
+#: id:15284
+msgid "Listen to %name%'s recommendations Last.fm radio"
+msgstr "Poslouchám: %name%'s doporučení Last.fm radio"
+
+#: id:15285
+msgid "Top tags for user %name%"
+msgstr "Nejoblíbenější tagy uživatele %name%"
+
+#: id:15287
+msgid "Do you want to add the current track to your loved tracks?"
+msgstr "Chcete přidat tuto skladbu k vašim oblíbeným?"
+
+#: id:15288
+msgid "Do you want to ban the current track?"
+msgstr "Chcete zakázat aktuální skladbu?"
+
+#: id:15289
+msgid "Added to your loved tracks: '%s'."
+msgstr "Skladba přidána do oblíbených: '%s'."
+
+#: id:15290
+msgid "Could not add '%s' to your loved tracks."
+msgstr "Skladbu '%s' se nepodařilo přidat do oblíbených."
+
+#: id:15291
+msgid "Banned: '%s'."
+msgstr "Zakázané: '%s'."
+
+#: id:15292
+msgid "Could not ban '%s'."
+msgstr "Skladbu '%s' se nepodařilo přidat do zakázaných."
+
+#: id:15293
+msgid "Tracks recently loved by %name%"
+msgstr "Poslední oblíbené skladby uživatele %name%"
+
+#: id:15294
+msgid "Tracks recently banned by %name%"
+msgstr "Poslední zakázané skladby uživatele %name%"
+
+#: id:15295
+msgid "Remove from loved tracks"
+msgstr "Odstranit z oblíbených skladeb"
+
+#: id:15296
+msgid "Un-ban"
+msgstr "Povolit zakázanou"
+
+#: id:15297
+msgid "Do you want to remove this track from your loved tracks?"
+msgstr "Chcete tuto skladbu odebrat ze seznamu vašich oblíbených skladeb?"
+
+#: id:15298
+msgid "Do you want to un-ban this track?"
+msgstr "Chcete opět povolit tuto zakázanou skladbu?"
+
+#: id:15300
+msgid "Path not found or invalid"
+msgstr "Cesta ke složce nebyla nalezena"
+
+#: id:15301
+msgid "Could not connect to network server"
+msgstr "K síťovému serveru se nepodařilo připojit"
+
+#: id:15302
+msgid "No servers found"
+msgstr "Žádný server nebyl nalezen"
+
+#: id:15303
+msgid "Workgroup not found"
+msgstr "Pracovní skupina nebyla nalezena"
+
+#: id:15310
+msgid "Opening multi-path source"
+msgstr "Probíhá otevírání záložky s více cestami"
+
+#: id:15311
+msgid "Path:"
+msgstr "Cesta:"
+
+#: id:16000
+msgctxt "Auto context with id 16000"
+msgid "General"
+msgstr "Hlavní"
+
+#: id:16002
+msgid "Internet lookup"
+msgstr "Vyhledávání na internetu"
+
+#: id:16003
+msgid "Player"
+msgstr "Přehrávač"
+
+#: id:16004
+msgid "Play media from disc"
+msgstr "Přehrávat soubory z CD/DVD"
+
+#: id:16008
+msgid "Enter new title"
+msgstr "Zadejte nový název"
+
+#: id:16009
+msgid "Enter the movie name"
+msgstr "Zadejte název filmu"
+
+#: id:16010
+msgid "Enter the profile name"
+msgstr "Zadejte název profilu"
+
+#: id:16011
+msgid "Enter the album name"
+msgstr "Zadejte název alba"
+
+#: id:16012
+msgid "Enter the playlist name"
+msgstr "Zadejte název Seznamu stop"
+
+#: id:16013
+msgid "Enter new filename"
+msgstr "Zadejte nové jméno souboru"
+
+#: id:16014
+msgid "Enter folder name"
+msgstr "Zadejte název složky"
+
+#: id:16015
+msgid "Enter directory"
+msgstr "Vstoupit do složky"
+
+#: id:16016
+msgid "Available options: %A, %T, %N, %B, %D, %G, %Y, %F, %S"
+msgstr "Dostupné parametry: %A, %T, %N, %B, %D, %G, %Y, %F, %S"
+
+#: id:16017
+msgid "Enter search string"
+msgstr "Zadejte text k vyhledání"
+
+#: id:16018
+msgctxt "Auto context with id 16018"
+msgid "None"
+msgstr "Bez změny"
+
+#: id:16019
+msgid "Auto select"
+msgstr "Zpracovat automaticky"
+
+#: id:16020
+msgid "De-interlace"
+msgstr "Odstranit prokládání"
+
+#: id:16021
+msgid "Bob"
+msgstr "Bob"
+
+#: id:16022
+msgid "Bob (inverted)"
+msgstr "Bob (opačný)"
+
+#: id:16024
+msgid "Canceling..."
+msgstr "Probíhá zrušení..."
+
+#: id:16025
+msgid "Enter the artist name"
+msgstr "Zadejte jméno interpreta"
+
+#: id:16026
+msgid "Playback failed"
+msgstr "Přehrávání selhalo"
+
+#: id:16027
+msgid "One or more items failed to play."
+msgstr "Jednu nebo více položek se nepodařilo přehrát."
+
+#: id:16028
+msgid "Enter value"
+msgstr "Zadejte hodnotu"
+
+#: id:16029
+msgid "Check the log file for details."
+msgstr "Více informací najdete v log souboru."
+
+#: id:16030
+msgid "Party mode aborted."
+msgstr "Párty mód byl přerušen."
+
+#: id:16031
+msgid "No matching songs in the library."
+msgstr "Žádné odpovídající skladby nebyly v knihovně nalezeny."
+
+#: id:16032
+msgid "Could not initialize database."
+msgstr "Inicializace knihovny nebyla úspěšná."
+
+#: id:16033
+msgid "Could not open database."
+msgstr "Nemohu otevřít knihovnu."
+
+#: id:16034
+msgid "Could not get songs from database."
+msgstr "Nepodařilo se načíst skladby z knihovny."
+
+#: id:16035
+msgid "Party mode playlist"
+msgstr "Seznam stop - Párty mód"
+
+#: id:16036
+msgid "De-interlace (Half)"
+msgstr "De-interlace (Half)"
+
+#: id:16037
+msgid "Deinterlace video"
+msgstr "Deinterlace video"
+
+#: id:16038
+msgid "Deinterlace method"
+msgstr "Deinterlace method"
+
+#: id:16039
+msgctxt "Auto context with id 16039"
+msgid "Off"
+msgstr "Off"
+
+#: id:16040
+msgctxt "Auto context with id 16040"
+msgid "Auto"
+msgstr "Auto"
+
+#: id:16041
+msgid "On"
+msgstr "On"
+
+#: id:16100
+msgid "All Videos"
+msgstr "Všechna videa"
+
+#: id:16101
+msgid "Unwatched"
+msgstr "Nezhlédnuté"
+
+#: id:16102
+msgid "Watched"
+msgstr "Zhlédnuté"
+
+#: id:16103
+msgid "Mark as watched"
+msgstr "Označit jako zhlédnuté"
+
+#: id:16104
+msgid "Mark as unwatched"
+msgstr "Označit jako nezhlédnuté"
+
+#: id:16105
+msgid "Edit title"
+msgstr "Upravit název"
+
+#: id:16200
+msgid "Operation was aborted"
+msgstr "Operace byla zrušena"
+
+#: id:16201
+msgid "Copy failed"
+msgstr "Kopírování selhalo"
+
+#: id:16202
+msgid "Failed to copy at least one file"
+msgstr "Minimálně 1 soubor se nepodařilo zkopírovat"
+
+#: id:16203
+msgid "Move failed"
+msgstr "Přesouvání selhalo"
+
+#: id:16204
+msgid "Failed to move at least one file"
+msgstr "Minimálně 1 soubor se nepodařilo přesunout"
+
+#: id:16205
+msgid "Delete failed"
+msgstr "Smazání selhalo"
+
+#: id:16206
+msgid "Failed to delete at least one file"
+msgstr "Minimálně 1 soubor se nepodařilo smazat"
+
+#: id:16300
+msgid "Video scaling method"
+msgstr "Způsob přepočítání videa"
+
+#: id:16301
+msgid "Nearest neighbour"
+msgstr "\"Nejbližší soused\""
+
+#: id:16302
+msgid "Bilinear"
+msgstr "Bilineární"
+
+#: id:16303
+msgctxt "Auto context with id 16303"
+msgid "Bicubic"
+msgstr "Bikubický"
+
+#: id:16304
+msgid "Lanczos2"
+msgstr "Lanczos2"
+
+#: id:16305
+msgid "Lanczos3"
+msgstr "Lanczos3"
+
+#: id:16306
+msgid "Sinc8"
+msgstr "Sinc8"
+
+#: id:16307
+msgid "Bicubic (software)"
+msgstr "Bikubický (softwarově)"
+
+#: id:16308
+msgid "Lanczos (software)"
+msgstr "Lanczos (softwarově)"
+
+#: id:16309
+msgid "Sinc (software)"
+msgstr "Sinc (softwarově)"
+
+#: id:16310
+msgid "Temporal"
+msgstr "Temporal"
+
+#: id:16311
+msgid "Temporal/Spatial"
+msgstr "Temporal/Spatial"
+
+#: id:16312
+msgid "(VDPAU)Noise Reduction"
+msgstr "(VDPAU) Redukce šumu"
+
+#: id:16313
+msgid "(VDPAU)Sharpness"
+msgstr "(VDPAU) Ostrost"
+
+#: id:16314
+msgid "Inverse Telecine"
+msgstr "Inverzní Telecine"
+
+#: id:16315
+msgid "Lanczos3 optimized"
+msgstr "Lanczos3 optimalizovaný"
+
+#: id:16316
+msgctxt "Auto context with id 16316"
+msgid "Auto"
+msgstr "Automatický"
+
+#: id:16317
+msgid "Temporal (Half)"
+msgstr "Temporal (poloviční)"
+
+#: id:16318
+msgid "Temporal/Spatial (Half)"
+msgstr "Temporal/Spatial (poloviční)"
+
+#: id:16319
+msgid "DXVA"
+msgstr "DXVA"
+
+#: id:16320
+msgid "DXVA Bob"
+msgstr "DXVA Bob"
+
+#: id:16321
+msgid "DXVA Best"
+msgstr "DXVA Best"
+
+#: id:16322
+msgid "Spline36"
+msgstr "Spline36"
+
+#: id:16323
+msgid "Spline36 optimized"
+msgstr "Spline36 optimized"
+
+#: id:16324
+msgid "Software Blend"
+msgstr "Software Blend"
+
+#: id:16400
+msgid "Post-processing"
+msgstr "Post-processing"
+
+#: id:17500
+msgid "Display sleep timeout"
+msgstr "Zobrazovat odpočet do uspání"
+
+#: id:19000
+msgid "Switch to channel"
+msgstr "Přepnout na kanál"
+
+#: id:20000
+msgid "Saved music folder"
+msgstr "Složka pro ukládání hudby"
+
+#: id:20001
+msgid "Use external DVD player"
+msgstr "Použít externí DVD přehrávač"
+
+#: id:20002
+msgid "External DVD player"
+msgstr "Externí DVD přehrávač"
+
+#: id:20003
+msgid "Trainers folder"
+msgstr "Složka s Trainery"
+
+#: id:20004
+msgid "Screenshot folder"
+msgstr "Složka pro ukládání obrázků"
+
+#: id:20006
+msgid "Playlists folder"
+msgstr "Složka se Seznamy stop"
+
+#: id:20007
+msgid "Recordings"
+msgstr "Nahrané"
+
+#: id:20008
+msgid "Screenshots"
+msgstr "Snímky obrazovky"
+
+#: id:20009
+msgid "Use XBMC"
+msgstr "Použít XBMC"
+
+#: id:20011
+msgid "Music playlists"
+msgstr "Seznamy stop - Hudba"
+
+#: id:20012
+msgid "Video playlists"
+msgstr "Seznamy stop - Video"
+
+#: id:20013
+msgid "Do you wish to launch the game?"
+msgstr "Chcete spustit hru?"
+
+#: id:20014
+msgid "Sort by: Playlist"
+msgstr "Dle Seznamu stop"
+
+#: id:20015
+msgid "Remote thumb"
+msgstr "Internetový náhled"
+
+#: id:20016
+msgid "Current thumb"
+msgstr "Současný náhled"
+
+#: id:20017
+msgid "Local thumb"
+msgstr "Lokální náhled"
+
+#: id:20018
+msgid "No thumb"
+msgstr "Bez náhledu"
+
+#: id:20019
+msgid "Choose thumbnail"
+msgstr "Přiřadit náhled"
+
+#: id:20023
+msgid "Conflict"
+msgstr "Konflikt"
+
+#: id:20024
+msgid "Scan new"
+msgstr "Prohledat nové"
+
+#: id:20025
+msgid "Scan all"
+msgstr "Prohledat vše"
+
+#: id:20026
+msgid "Region"
+msgstr "Oblast"
+
+#: id:20037
+msgid "Summary"
+msgstr "Souhrn"
+
+#: id:20038
+msgid "Lock music window"
+msgstr "Uzamknout hudební sekci"
+
+#: id:20039
+msgid "Lock videos window"
+msgstr "Uzamknout video sekci"
+
+#: id:20040
+msgid "Lock pictures window"
+msgstr "Uzamknout sekci s obrázky"
+
+#: id:20041
+msgid "Lock programs & scripts windows"
+msgstr "Uzamknout sekci s programy a skripty"
+
+#: id:20042
+msgid "Lock file manager"
+msgstr "Uzamknout správce souborů"
+
+#: id:20043
+msgid "Lock settings"
+msgstr "Uzamknout nastavení"
+
+#: id:20044
+msgid "Start fresh"
+msgstr "Výchozí"
+
+#: id:20045
+msgid "Enter master mode"
+msgstr "Odemknout rodičovský zámek"
+
+#: id:20046
+msgid "Leave master mode"
+msgstr "Zamknout rodičovský zámek"
+
+#: id:20047
+msgid "Create profile '%s'?"
+msgstr "Chcete vytvořit profil '%s' ?"
+
+#: id:20048
+msgid "Start with fresh settings"
+msgstr "Chcete použít výchozí nastavení"
+
+#: id:20049
+msgid "Best available"
+msgstr "Nejvhodnější"
+
+#: id:20050
+msgid "Auto-switch between 16x9 and 4x3"
+msgstr "Automaticky přepínat mód mezi 16:9 a 4:3"
+
+#: id:20051
+msgid "Treat stacked files as single file"
+msgstr "Považovat spojené soubory za jeden soubor"
+
+#: id:20052
+msgid "Caution"
+msgstr "Upozornění"
+
+#: id:20053
+msgid "Left master mode"
+msgstr "Rodičovský zámek byl zamknut"
+
+#: id:20054
+msgid "Entered master mode"
+msgstr "Rodičovský zámek byl odemknut"
+
+#: id:20055
+msgid "Allmusic.com thumb"
+msgstr "Allmusic.com náhled"
+
+#: id:20057
+msgid "Remove thumbnail"
+msgstr "Odebrat náhled"
+
+#: id:20058
+msgid "Add profile..."
+msgstr "Přidat profil..."
+
+#: id:20059
+msgid "Query info for all albums"
+msgstr "Získat informace pro všechna alba"
+
+#: id:20060
+msgctxt "Auto context with id 20060"
+msgid "Media info"
+msgstr "Informace o médiích"
+
+#: id:20061
+msgctxt "Auto context with id 20061"
+msgid "Separate"
+msgstr "Oddělit"
+
+#: id:20062
+msgid "Shares with default"
+msgstr "Sdílet se stávajícími"
+
+#: id:20063
+msgid "Shares with default (read only)"
+msgstr "Sdílet se stávajícími (jen pro čtení)"
+
+#: id:20064
+msgid "Copy default"
+msgstr "Stávající"
+
+#: id:20065
+msgid "Profile picture"
+msgstr "Obrázek profilu"
+
+#: id:20066
+msgid "Lock preferences"
+msgstr "Možnosti uzamčení"
+
+#: id:20067
+msgid "Edit profile"
+msgstr "Upravit profil"
+
+#: id:20068
+msgid "Profile lock"
+msgstr "Zamknout profil"
+
+#: id:20069
+msgid "Could not create folder"
+msgstr "Nemohu vytvořit složku"
+
+#: id:20070
+msgid "Profile directory"
+msgstr "Složka profilu"
+
+#: id:20071
+msgid "Start with fresh media sources"
+msgstr "Chcete nastavit výchozí zdroje médií"
+
+#: id:20072
+msgid "Make sure the selected folder is writable"
+msgstr "Ujistěte se, zda je do vybrané složky možnost zápisu"
+
+#: id:20073
+msgid "and that the new folder name is valid"
+msgstr "a nový název složky v pořádku"
+
+#: id:20074
+msgid "MPAA rating"
+msgstr "Přístupnost"
+
+#: id:20075
+msgid "Enter master lock code"
+msgstr "Zadejte hlavní kód rodičovského zámku"
+
+#: id:20076
+msgid "Ask for master lock code on startup"
+msgstr "Vyžadovat při spuštění hlavní kód"
+
+#: id:20077
+msgid "Skin settings"
+msgstr "Možnosti vzhledu"
+
+#: id:20078
+msgid "- no link set -"
+msgstr "- neaktivní -"
+
+#: id:20079
+msgid "Enable animations"
+msgstr "Zobrazovat animace"
+
+#: id:20080
+msgid "Disable RSS during music"
+msgstr "Zakázat RSS při přehráváni hudby"
+
+#: id:20081
+msgid "Enable shortcut buttons"
+msgstr "Aktivovat záložky"
+
+#: id:20082
+msgid "Show programs in main menu"
+msgstr "Zobrazovat sekci Programy v hlavním menu"
+
+#: id:20083
+msgid "Show music info"
+msgstr "Zobrazovat informace o hudbě"
+
+#: id:20084
+msgid "Show weather info"
+msgstr "Zobrazovat počasí"
+
+#: id:20085
+msgid "Show system info"
+msgstr "Zobrazovat informace o systému"
+
+#: id:20086
+msgid "Show available disc space C: E: F:"
+msgstr "Zobrazovat volné místo na discích C: E: F:"
+
+#: id:20087
+msgid "Show available disc space E: F: G:"
+msgstr "Zobrazovat volné místo na discích E: F: G:"
+
+#: id:20088
+msgid "Weather info"
+msgstr "Počasí"
+
+#: id:20089
+msgid "Drive space free"
+msgstr "Volné místo"
+
+#: id:20090
+msgid "Enter the name of an existing share"
+msgstr "Zadejte název existující sdílené položky"
+
+#: id:20091
+msgid "Lock code"
+msgstr "Kód uzamknutí"
+
+#: id:20092
+msgid "Load profile"
+msgstr "Přihlásit profil"
+
+#: id:20093
+msgid "Profile name"
+msgstr "Název profilu"
+
+#: id:20094
+msgctxt "Auto context with id 20094"
+msgid "Media sources"
+msgstr "Zdroje médií"
+
+#: id:20095
+msgid "Enter profile lock code"
+msgstr "Zadejte kód profilu"
+
+#: id:20096
+msgctxt "Auto context with id 20096"
+msgid "Login screen"
+msgstr "Úvodní obrazovka"
+
+#: id:20097
+msgid "Fetching album info"
+msgstr "Probíhá načítání informací o albu"
+
+#: id:20098
+msgid "Fetching info for album"
+msgstr "Probíhá ukládání informací o albu"
+
+#: id:20099
+msgid "Can't rip CD or track while playing from CD"
+msgstr "CD nebo jeho stopu nelze uložit pokud probíhá přehrávání"
+
+#: id:20100
+msgid "Master lock code and settings"
+msgstr "Nastavení zámku"
+
+#: id:20101
+msgid "Entering master lock code always enables master mode"
+msgstr "Vložením hlavního kódu vždy odemknout rodičovský zámek"
+
+#: id:20102
+msgid "or copy from default?"
+msgstr "nebo chcete použít stávající?"
+
+#: id:20103
+msgid "Save changes to profile?"
+msgstr "Uložit změny v profilu?"
+
+#: id:20104
+msgid "Old settings found."
+msgstr "Nalezeno původní nastavení."
+
+#: id:20105
+msgid "Do you want to use them?"
+msgstr "Chcete je použít?"
+
+#: id:20106
+msgid "Old media sources found."
+msgstr "Staré zdroje médií byly nalezeny."
+
+#: id:20107
+msgid "Separate (locked)"
+msgstr "Oddělit (uzamknout)"
+
+#: id:20108
+msgid "Root"
+msgstr "Výchozí složka"
+
+#: id:20109
+msgid "- Zoom"
+msgstr "Přiblížení vzhledu"
+
+#: id:20110
+msgid "UPnP settings"
+msgstr "Nastavení UPnP"
+
+#: id:20111
+msgid "Autostart UPnP client"
+msgstr "Automaticky spustit UPnP klienta"
+
+#: id:20112
+msgid "Last login: %s"
+msgstr "Poslední přihlášení: %s"
+
+#: id:20113
+msgid "Never logged on"
+msgstr "Nikdy nepřihlášen"
+
+#: id:20114
+msgid "Profile %i / %i"
+msgstr "Profil %i / %i"
+
+#: id:20115
+msgid "User login / Select a profile"
+msgstr "Uživatelské přihlášení / Vyberte profil"
+
+#: id:20116
+msgid "Use lock on login screen"
+msgstr "Vyžadovat kódy při přihlášení"
+
+#: id:20117
+msgid "Invalid lock code."
+msgstr "Neplatný kód rodičovského zámku."
+
+#: id:20118
+msgid "This requires the master lock to be set."
+msgstr "Toto nastavení vyžaduje nastavený rodičovský zámek."
+
+#: id:20119
+msgid "Would you like to set it now?"
+msgstr "Chcete ho nyní nastavit?"
+
+#: id:20120
+msgid "Loading program information"
+msgstr "Probíhá načítání informací o programu"
+
+#: id:20121
+msgid "Party on!"
+msgstr "Párty zahájena!"
+
+#: id:20122
+msgid "True"
+msgstr "Pravdivý"
+
+#: id:20123
+msgid "Mixing drinks"
+msgstr "Míchám nápoje"
+
+#: id:20124
+msgid "Filling glasses"
+msgstr "Nalévám sklenice"
+
+#: id:20125
+msgid "Logged on as"
+msgstr "Přihlášen jako"
+
+#: id:20126
+msgid "Log off"
+msgstr "Odhlásit"
+
+#: id:20128
+msgid "Go to root"
+msgstr "Přejít do výchozí složky"
+
+#: id:20129
+msgid "Weave"
+msgstr "Weave"
+
+#: id:20130
+msgid "Weave (inverted)"
+msgstr "Weave (Inverzně)"
+
+#: id:20131
+msgid "Blend"
+msgstr "Blend"
+
+#: id:20132
+msgid "Restart video"
+msgstr "Restartovat video"
+
+#: id:20133
+msgid "Edit network location"
+msgstr "Upravit síťové umístění"
+
+#: id:20134
+msgid "Remove network location"
+msgstr "Odebrat síťové umístění"
+
+#: id:20135
+msgid "Do you want to scan the folder?"
+msgstr "Chcete tuto složku prohledat?"
+
+#: id:20136
+msgid "Memory unit"
+msgstr "Paměťová jednotka"
+
+#: id:20137
+msgid "Memory unit mounted"
+msgstr "Paměťová jednotka načtena"
+
+#: id:20138
+msgid "Unable to mount memory unit"
+msgstr "Paměťová jednotka nemohla být načtena"
+
+#: id:20139
+msgid "In port %i, slot %i"
+msgstr "V portu %i, slotu %i"
+
+#: id:20140
+msgid "Lock screensaver"
+msgstr "Uzamknout spořič obrazovky"
+
+#: id:20141
+msgid "Set"
+msgstr "Nastavit"
+
+#: id:20142
+msgctxt "Auto context with id 20142"
+msgid "Username"
+msgstr "Uživatelské jméno"
+
+#: id:20143
+msgid "Enter password for"
+msgstr "Zadejte heslo pro"
+
+#: id:20144
+msgid "Shutdown timer"
+msgstr "Automatické vypnutí"
+
+#: id:20145
+msgid "Shutdown interval (in minutes)"
+msgstr "Interval vypnutí (v minutách)"
+
+#: id:20146
+msgid "Started, shutdown in %im"
+msgstr "Aktivní, vypnutí proběhne za %im"
+
+#: id:20147
+msgid "Shutdown in 30 minutes"
+msgstr "Vypnutí proběhne za 30 minut"
+
+#: id:20148
+msgid "Shutdown in 60 minutes"
+msgstr "Vypnutí proběhne za 60 minut"
+
+#: id:20149
+msgid "Shutdown in 120 minutes"
+msgstr "Vypnutí proběhne za 120 minut"
+
+#: id:20150
+msgid "Custom shutdown timer"
+msgstr "Vlastní automatické vypnutí"
+
+#: id:20151
+msgid "Cancel shutdown timer"
+msgstr "Zrušit automatické vypnutí"
+
+#: id:20152
+msgid "Lock preferences for %s"
+msgstr "Uzamknout nastavení pro %s"
+
+#: id:20153
+msgid "Browse..."
+msgstr "Procházet..."
+
+#: id:20154
+msgid "Summary information"
+msgstr "Souhrnné informace"
+
+#: id:20155
+msgid "Storage information"
+msgstr "Informace o úložištích dat"
+
+#: id:20156
+msgid "Hard disk information"
+msgstr "Informace o HDD"
+
+#: id:20157
+msgid "DVD-ROM information"
+msgstr "Informace o DVD"
+
+#: id:20158
+msgid "Network information"
+msgstr "Informace o síti"
+
+#: id:20159
+msgid "Video information"
+msgstr "Informace o videu"
+
+#: id:20160
+msgid "Hardware information"
+msgstr "Informace o hardwaru"
+
+#: id:20161
+msgid "Total"
+msgstr "Celkem"
+
+#: id:20162
+msgid "Used"
+msgstr "Využito"
+
+#: id:20163
+msgid "of"
+msgstr "z"
+
+#: id:20164
+msgid "Locking not supported"
+msgstr "Uzamknutí není podporováno"
+
+#: id:20165
+msgid "Not locked"
+msgstr "Neuzamknuto"
+
+#: id:20166
+msgid "Locked"
+msgstr "Uzamknuto"
+
+#: id:20167
+msgid "Frozen"
+msgstr "Zmrazeno"
+
+#: id:20168
+msgid "Requires reset"
+msgstr "Vyžadován restart"
+
+#: id:20169
+msgid "Week"
+msgstr "Týden"
+
+#: id:20170
+msgid "Line"
+msgstr "Linka"
+
+#: id:20171
+msgid "Windows network (SMB)"
+msgstr "Síť Windows (SMB)"
+
+#: id:20172
+msgid "XBMSP server"
+msgstr "XBMSP server"
+
+#: id:20173
+msgctxt "Auto context with id 20173"
+msgid "FTP server"
+msgstr "FTP server"
+
+#: id:20174
+msgid "iTunes music share (DAAP)"
+msgstr "Sdílená složka iTunes (DAAP)"
+
+#: id:20175
+msgid "UPnP server"
+msgstr "UPnP server"
+
+#: id:20176
+msgid "Show video info"
+msgstr "Zobrazovat informace o videu"
+
+#: id:20177
+msgid "Done"
+msgstr "Hotovo"
+
+#: id:20178
+msgid "Shift"
+msgstr "Shift"
+
+#: id:20179
+msgid "Caps Lock"
+msgstr "Caps Lock"
+
+#: id:20180
+msgid "Symbols"
+msgstr "Symboly"
+
+#: id:20181
+msgid "Backspace"
+msgstr "Smazat"
+
+#: id:20182
+msgid "Space"
+msgstr "Mezera"
+
+#: id:20183
+msgid "Reload skin"
+msgstr "Obnovit motiv vzhledu"
+
+#: id:20184
+msgid "Rotate pictures using EXIF information"
+msgstr "Otáčet obrázky pomocí informací z EXIFu"
+
+#: id:20185
+msgid "Use poster view styles for TV shows"
+msgstr "Použít styl plakátů u TV Seriálů"
+
+#: id:20186
+msgid "Please wait"
+msgstr "Vyčkejte"
+
+#: id:20187
+msgid "UPnP"
+msgstr ""
+
+#: id:20189
+msgid "Enable auto scrolling for plot & review"
+msgstr "Aktivovat automatické posouvání děje a recenze"
+
+#: id:20190
+msgctxt "Auto context with id 20190"
+msgid "Custom"
+msgstr "Vlastní"
+
+#: id:20191
+msgid "Enable debug logging"
+msgstr "Ukládat pokročilé informace o ladění"
+
+#: id:20192
+msgid "Download additional information during updates"
+msgstr "Stahovat informace o albu při aktualizaci knihovny"
+
+#: id:20193
+msgid "Default service for album information"
+msgstr "Výchozí služba pro Informace o albu"
+
+#: id:20194
+msgid "Default service for artist information"
+msgstr "Výchozí stahovač pro hudbu"
+
+#: id:20195
+msgid "Change scraper"
+msgstr "Změnit Stahovač"
+
+#: id:20196
+msgid "Export music library"
+msgstr "Exportovat Hudební knihovnu"
+
+#: id:20197
+msgid "Import music library"
+msgstr "Importovat Hudební knihovnu"
+
+#: id:20198
+msgid "No artist found!"
+msgstr "Interpret nenalezen!"
+
+#: id:20199
+msgid "Downloading artist info failed"
+msgstr "Stažení informací o interpretovi se nezdařilo"
+
+#: id:20250
+msgid "Party on! (videos)"
+msgstr "Párty zahájena! (videa)"
+
+#: id:20251
+msgid "Mixing drinks (videos)"
+msgstr "Míchám nápoje (videa)"
+
+#: id:20252
+msgid "Filling glasses (videos)"
+msgstr "Nalévám sklenice (videa)"
+
+#: id:20253
+msgid "WebDAV server (HTTP)"
+msgstr "WebDAV server (HTTP)"
+
+#: id:20254
+msgid "WebDAV server (HTTPS)"
+msgstr "WebDAV server (HTTPS)"
+
+#: id:20255
+msgid "First logon, edit your profile"
+msgstr "První přihlášení, upravte si svůj profil"
+
+#: id:20256
+msgid "HTS Tvheadend client"
+msgstr "HTS Tvheadend klient"
+
+#: id:20257
+msgid "VDR Streamdev client"
+msgstr "VDR Streamdev klient"
+
+#: id:20258
+msgid "MythTV client"
+msgstr "MythTV klient"
+
+#: id:20259
+msgid "Network Filesystem (NFS)"
+msgstr "Network Filesystem (NFS)"
+
+#: id:20260
+msgid "Secure Shell (SSH/SFTP)"
+msgstr "Secure Shell (SSH/SFTP)"
+
+#: id:20261
+msgid "Apple Filing Protocol (AFP)"
+msgstr "Apple Filing Protocol (AFP)"
+
+#: id:20300
+msgid "Web server directory (HTTP)"
+msgstr "Web server složka (HTTP)"
+
+#: id:20301
+msgid "Web server directory (HTTPS)"
+msgstr "Web server složka (HTTPS)"
+
+#: id:20302
+msgid "Unable to write to folder:"
+msgstr "Nezdařil se zápis do složky:"
+
+#: id:20303
+msgid "Do you want to skip and proceed?"
+msgstr "Chcete ji přeskočit a pokračovat dále?"
+
+#: id:20304
+msgid "RSS Feed"
+msgstr "RSS zpravodajství"
+
+#: id:20307
+msgid "Secondary DNS"
+msgstr "Sekundární DNS"
+
+#: id:20308
+msgid "DHCP server:"
+msgstr "DHCP server:"
+
+#: id:20309
+msgid "Make new folder"
+msgstr "Vytvořit novou složku"
+
+#: id:20310
+msgid "Dim LCD on playback"
+msgstr "Ztmavovat LCD při přehrávání"
+
+#: id:20311
+msgid "Unknown or onboard (protected)"
+msgstr "Neznámé nebo integrované"
+
+#: id:20312
+msgid "Dim LCD on paused"
+msgstr "Ztmavovat LCD při pozastavení"
+
+#: id:20314
+msgid "Videos - Library"
+msgstr "Video - Knihovna"
+
+#: id:20316
+msgid "Sort by: ID"
+msgstr "Dle ID"
+
+#: id:20324
+msgid "Play part..."
+msgstr "Hrát část..."
+
+#: id:20325
+msgid "Calibration reset"
+msgstr "Vynulování kalibrace"
+
+#: id:20326
+msgid "This will reset the calibration values for %s"
+msgstr "Tímto smažete veškeré uložené hodnoty kalibrace pro %s"
+
+#: id:20327
+msgid "to it's default values."
+msgstr "na základní hodnoty."
+
+#: id:20328
+msgid "Browse for destination"
+msgstr "Vybrat umístění"
+
+#: id:20329
+msgid "Movies are in separate folders that match the movie title"
+msgstr ""
+
+#: id:20330
+msgid "Use folder names for lookups"
+msgstr "Při prohledávání použít názvy složek"
+
+#: id:20331
+msgctxt "Auto context with id 20331"
+msgid "File"
+msgstr "Soubor"
+
+#: id:20332
+msgid "Use file or folder names in lookups?"
+msgstr "Chcete při prohledávání použít názvy souborů nebo složek?"
+
+#: id:20333
+msgid "Set content"
+msgstr "Nastavit obsah"
+
+#: id:20334
+msgid "Folder"
+msgstr "Složka"
+
+#: id:20335
+msgid "Look for content recursively?"
+msgstr "Vyhledávat obsah v podsložkách?"
+
+#: id:20336
+msgid "Unlock sources"
+msgstr "Odemknout zdroje"
+
+#: id:20337
+msgid "Actor"
+msgstr "Herec"
+
+#: id:20338
+msgid "Movie"
+msgstr "Film"
+
+#: id:20339
+msgid "Director"
+msgstr "Režisér"
+
+#: id:20340
+msgid "Do you want to remove all items within"
+msgstr "Chcete odebrat všechny položky v"
+
+#: id:20341
+msgid "this path from the XBMC library?"
+msgstr "této cestě z knihovny XBMC?"
+
+#: id:20342
+msgctxt "Auto context with id 20342"
+msgid "Movies"
+msgstr "Filmy"
+
+#: id:20343
+msgid "TV shows"
+msgstr "TV Seriály"
+
+#: id:20344
+msgid "This directory contains"
+msgstr "Tato složka obsahuje"
+
+#: id:20345
+msgid "Run automated scan"
+msgstr "Spustit automatické prohledání"
+
+#: id:20346
+msgid "Scan recursively"
+msgstr "Prohledávat včetně podsložek druhé a vyšší úrovně"
+
+#: id:20347
+msgid "as"
+msgstr "jako"
+
+#: id:20348
+msgid "Directors"
+msgstr "Režiséři"
+
+#: id:20349
+msgid "No video files found in this path!"
+msgstr "V tomto umístění nebyl nalezen žádný video soubor!"
+
+#: id:20350
+msgid "votes"
+msgstr "hlasů"
+
+#: id:20351
+msgid "TV show information"
+msgstr "Informace o TV seriálu"
+
+#: id:20352
+msgid "Episode information"
+msgstr "Informace o epizodě"
+
+#: id:20353
+msgid "Loading TV show details"
+msgstr "Probíhá načítání detailů k TV seriálu"
+
+#: id:20354
+msgid "Fetching episode guide"
+msgstr "Probíhá zpracování informací k epizodám"
+
+#: id:20355
+msgid "Loading info for episodes in directory"
+msgstr "Probíhá načítání informací k epizodám ve složce"
+
+#: id:20356
+msgid "Select TV show:"
+msgstr "Vyberte seriál:"
+
+#: id:20357
+msgid "Enter the TV show name"
+msgstr "Zadejte název TV seriálu"
+
+#: id:20358
+msgid "Season %i"
+msgstr "Řada %i"
+
+#: id:20359
+msgid "Episode"
+msgstr "Epizoda"
+
+#: id:20360
+msgid "Episodes"
+msgstr "Epizod(y)"
+
+#: id:20361
+msgid "Loading episode details"
+msgstr "Probíhá načítání detailů k epizodě"
+
+#: id:20362
+msgid "Remove episode from library"
+msgstr "Odebrat epizodu z knihovny"
+
+#: id:20363
+msgid "Remove TV show from library"
+msgstr "Odebrat seriál z knihovny"
+
+#: id:20364
+msgid "TV show"
+msgstr "Seriál"
+
+#: id:20365
+msgid "Episode plot"
+msgstr "Děj epizody"
+
+#: id:20366
+msgid "* All seasons"
+msgstr "* Všechny řady"
+
+#: id:20367
+msgid "Hide watched"
+msgstr "Skrýt zhlédnuté"
+
+#: id:20368
+msgid "Prod code"
+msgstr "Kód produkce"
+
+#: id:20369
+msgid "Show plot for unwatched items"
+msgstr "Zobrazovat děj u nezhlédnutých videí"
+
+#: id:20370
+msgid "* Hidden to prevent spoilers *"
+msgstr "* nezobrazeno z důvodu předejití vyzrazení děje *"
+
+#: id:20371
+msgid "Set season thumb"
+msgstr "Přiřadit náhled řadě"
+
+#: id:20372
+msgid "Season image"
+msgstr "Náhled řady"
+
+#: id:20373
+msgid "Season"
+msgstr "Řada"
+
+#: id:20374
+msgid "Downloading movie information"
+msgstr "Probíhá stahování informací k videu"
+
+#: id:20375
+msgid "Unassign content"
+msgstr "Odebrat obsah"
+
+#: id:20376
+msgid "Original title"
+msgstr "Původní název"
+
+#: id:20377
+msgid "Refresh TV show information"
+msgstr "Aktualizovat informace o TV seriálu"
+
+#: id:20378
+msgid "Refresh info for all episodes?"
+msgstr "Chcete aktualizovat informace pro všechny epizody?"
+
+#: id:20379
+msgid "Selected folder contains a single TV show"
+msgstr "Složka obsahuje jediný seriál"
+
+#: id:20380
+msgid "Exclude selected folder from scans"
+msgstr "Nezahrnovat tuto složku při aktualizaci knihovny"
+
+#: id:20381
+msgid "Specials"
+msgstr "Speciální epizody"
+
+#: id:20382
+msgid "Automatically grab season thumbs"
+msgstr "Stahovat náhledy řad seriálů"
+
+#: id:20383
+msgid "Selected folder contains a single video"
+msgstr "Složka obsahuje jediné video"
+
+#: id:20384
+msgid "Link to TV show"
+msgstr "Přiřadit k TV seriálu"
+
+#: id:20385
+msgid "Remove link to TV show"
+msgstr "Odebrat ze TV seriálu"
+
+#: id:20386
+msgid "Recently added movies"
+msgstr "Nejnovější filmy"
+
+#: id:20387
+msgid "Recently added episodes"
+msgstr "Nejnovější epizody"
+
+#: id:20388
+msgid "Studios"
+msgstr "Studia"
+
+#: id:20389
+msgid "Music videos"
+msgstr "Hudební videoklipy"
+
+#: id:20390
+msgid "Recently added music videos"
+msgstr "Nejnovější hudební videoklipy"
+
+#: id:20391
+msgid "Music video"
+msgstr "Hudební videoklipy"
+
+#: id:20392
+msgid "Remove music video from library"
+msgstr "Odstranit hudební videoklip z knihovny"
+
+#: id:20393
+msgctxt "Auto context with id 20393"
+msgid "Music video information"
+msgstr "Informace k hudebnímu videoklipu"
+
+#: id:20394
+msgid "Loading music video information"
+msgstr "Probíhá načítání informací o hudebním videoklipu"
+
+#: id:20395
+msgid "Mixed"
+msgstr "Smíšené"
+
+#: id:20396
+msgid "Go to albums by artist"
+msgstr "Přejít k interpretovým albům"
+
+#: id:20397
+msgid "Go to album"
+msgstr "Přejít k albu"
+
+#: id:20398
+msgid "Play song"
+msgstr "Přehrát skladbu"
+
+#: id:20399
+msgid "Go to music videos from album"
+msgstr "Přejít k hudebním videoklipům alba"
+
+#: id:20400
+msgid "Go to music videos by artist"
+msgstr "Přejít k hudebním videoklipům interpreta"
+
+#: id:20401
+msgid "Play music video"
+msgstr "Přehrát hudební videoklip"
+
+#: id:20402
+msgid "Download actor thumbnails when adding to library"
+msgstr "Stahovat ikony herců během přidání filmu do knihovny"
+
+#: id:20403
+msgid "Set actor thumb"
+msgstr "Změnit ikonu herce"
+
+#: id:20405
+msgid "Remove episode bookmark"
+msgstr "Odstranit záložku epizody"
+
+#: id:20406
+msgid "Set episode bookmark"
+msgstr "Nastavit záložku epizody"
+
+#: id:20407
+msgid "Scraper settings"
+msgstr "Nastavení Stahovače"
+
+#: id:20408
+msgid "Downloading music video information"
+msgstr "Stahují se informace k hudebnímu videu"
+
+#: id:20409
+msgid "Downloading TV show information"
+msgstr "Stahují se informace k TV seriálu"
+
+#: id:20410
+msgid "Trailer"
+msgstr "Upoutávka"
+
+#: id:20411
+msgid "Flatten"
+msgstr "Jednoduchý mód"
+
+#: id:20412
+msgid "Flatten TV shows"
+msgstr "Zobrazit TV seriály zjednodušeně"
+
+#: id:20413
+msgid "Get fanart"
+msgstr "Změnit fanart"
+
+#: id:20414
+msgid "Show Fanart in video and music libraries"
+msgstr "Povolit fanart v knihovně videí a hudby"
+
+#: id:20415
+msgid "Scanning for new content"
+msgstr "Probíhá vyhledávání nového obsahu"
+
+#: id:20416
+msgid "First aired"
+msgstr "Premiéra"
+
+#: id:20417
+msgid "Writer"
+msgstr "Autor"
+
+#: id:20419
+msgid "Replace file names with library titles"
+msgstr "Zobrazit metadata v seznamu souborů"
+
+#: id:20420
+msgctxt "Auto context with id 20420"
+msgid "Never"
+msgstr "Nikdy"
+
+#: id:20421
+msgid "If only one season"
+msgstr "Pokud má 1 řadu"
+
+#: id:20422
+msgid "Always"
+msgstr "Vždy"
+
+#: id:20423
+msgid "Has trailer"
+msgstr "Má upoutávku"
+
+#: id:20424
+msgid "False"
+msgstr "Nepravdivé"
+
+#: id:20425
+msgid "Fanart slideshow"
+msgstr "Fanart prezentace"
+
+#: id:20426
+msgid "Export to a single file or separate"
+msgstr "Exportovat vše do jednoho souboru nebo"
+
+#: id:20427
+msgid "files per entry?"
+msgstr "každou položku do samostatného souboru?"
+
+#: id:20428
+msgid "Single file"
+msgstr "1 soubor"
+
+#: id:20429
+msgctxt "Auto context with id 20429"
+msgid "Separate"
+msgstr "Samostatně"
+
+#: id:20430
+msgid "Export thumbnails and fanart?"
+msgstr "Exportovat náhledy a fanart?"
+
+#: id:20431
+msgid "Overwrite old files?"
+msgstr "Přepsat existující soubory?"
+
+#: id:20432
+msgid "Exclude path from library updates"
+msgstr "Nezahrnovat položky v tomto umístění při aktualizaci knihovny"
+
+#: id:20433
+msgid "Extract thumbnails and video information"
+msgstr "Získávat ze souborů náhledy a informace o videu"
+
+#: id:20434
+msgid "Sets"
+msgstr "Série"
+
+#: id:20435
+msgid "Set movieset thumb"
+msgstr "Přiřadit náhled filmové sérii"
+
+#: id:20436
+msgid "Export actor thumbs?"
+msgstr "Exportovat náhledy herců"
+
+#: id:20437
+msgid "Choose fanart"
+msgstr "Vyberte fanart"
+
+#: id:20438
+msgid "Local fanart"
+msgstr "Lokální fanart"
+
+#: id:20439
+msgid "No fanart"
+msgstr "Žádný fanart"
+
+#: id:20440
+msgid "Current fanart"
+msgstr "Současný fanart"
+
+#: id:20441
+msgid "Remote fanart"
+msgstr "Internetový fanart"
+
+#: id:20442
+msgid "Change content"
+msgstr "Změnit obsah"
+
+#: id:20443
+msgid "Do you want to refresh info for all"
+msgstr "Chcete aktualizovat informace pro"
+
+#: id:20444
+msgid "items within this path?"
+msgstr "všechny položky v tomto umístění?"
+
+#: id:20445
+msgid "Fanart"
+msgstr "Fanart"
+
+#: id:20446
+msgid "Locally stored information found."
+msgstr "Byly nalezeny informace, které jsou uložené lokálně."
+
+#: id:20447
+msgid "Ignore and refresh from internet?"
+msgstr "Chcete je aktualizovat informacemi z internetu?"
+
+#: id:20448
+msgid "Could not download information"
+msgstr "Informace se nepodařilo stáhnout"
+
+#: id:20449
+msgid "Unable to connect to remote server"
+msgstr "Server je pravděpodobně nedostupný."
+
+#: id:20450
+msgid "Would you like to continue scanning?"
+msgstr "Chcete v aktualizaci pokračovat?"
+
+#: id:20451
+msgid "Countries"
+msgstr "Země"
+
+#: id:20452
+msgid "episode"
+msgstr "epizoda"
+
+#: id:20453
+msgid "episodes"
+msgstr "epizod(y)"
+
+#: id:20454
+msgid "Listener"
+msgstr "Posluchač"
+
+#: id:20455
+msgid "Listeners"
+msgstr "Posluchači"
+
+#: id:20456
+msgid "Set movieset fanart"
+msgstr "Přiřadit fanart filmové sérii"
+
+#: id:20457
+msgid "Movie set"
+msgstr "Filmová série"
+
+#: id:20458
+msgid "Group movies in sets"
+msgstr ""
+
+#: id:21330
+msgid "Show hidden files and directories"
+msgstr "Zobrazovat skryté soubory a složky"
+
+#: id:21331
+msgid "TuxBox client"
+msgstr "TuxBox klient"
+
+#: id:21332
+msgid "WARNING: Target TuxBox device is in recording-mode!"
+msgstr "UPOZORNĚNÍ: Cílový TuxBox je v módu nahrávání!"
+
+#: id:21333
+msgid "The stream will be stopped!"
+msgstr "Streamování bude zastaveno!"
+
+#: id:21334
+msgid "Zap to channel: %s failed!"
+msgstr "Přepnutí na kanál: %s se nezdařilo!"
+
+#: id:21335
+msgid "Are you sure to start the stream?"
+msgstr "Opravdu chcete spustit streamování?"
+
+#: id:21336
+msgid "Connecting to: %s"
+msgstr "Probíhá připojení k: %s"
+
+#: id:21337
+msgid "TuxBox device"
+msgstr "Zařízení TuxBox"
+
+#: id:21359
+msgid "Add media share..."
+msgstr "Přidat sdílení..."
+
+#: id:21360
+msgid "Share video and music libraries through UPnP"
+msgstr "Povolit sdílení knihoven filmů a hudby přes UPnP"
+
+#: id:21364
+msgid "Edit media share"
+msgstr "Upravit sdílení"
+
+#: id:21365
+msgid "Remove media share"
+msgstr "Odebrat sdílení"
+
+#: id:21366
+msgid "Subtitle folder"
+msgstr "Složka s titulky"
+
+#: id:21367
+msgid "Movie & alternate subtitle directory"
+msgstr "Video a alternativní složka s titulky"
+
+#: id:21368
+msgid "Override ASS/SSA subtitles fonts"
+msgstr "Přepsat písmo v ASS/SSA titulcích"
+
+#: id:21369
+msgid "Enable mouse and Touch Screen support"
+msgstr "Povolit kurzor myši"
+
+#: id:21370
+msgid "Play navigation sounds during media playback"
+msgstr "Přehrávat zvuky při přehrávání multimediálních souborů"
+
+#: id:21371
+msgid "Thumbnail"
+msgstr "Náhledy"
+
+#: id:21372
+msgid "Forced DVD player region"
+msgstr "Vynucení kódu regionu DVD přehrávače"
+
+#: id:21373
+msgid "Video output"
+msgstr "Video výstup"
+
+#: id:21374
+msgid "Video aspect"
+msgstr "Nastavení videa"
+
+#: id:21375
+msgctxt "Auto context with id 21375"
+msgid "Normal"
+msgstr "Normální"
+
+#: id:21376
+msgid "Letterbox"
+msgstr "Letterbox"
+
+#: id:21377
+msgid "Widescreen"
+msgstr "Širokoúhlé"
+
+#: id:21378
+msgid "Enable 480p"
+msgstr "Aktivovat 480p"
+
+#: id:21379
+msgid "Enable 720p"
+msgstr "Aktivovat 720p"
+
+#: id:21380
+msgid "Enable 1080i"
+msgstr "Aktivovat 1080i"
+
+#: id:21381
+msgid "Enter name of new playlist"
+msgstr "Zadejte název nového Seznamu stop"
+
+#: id:21382
+msgid "Show \"Add source\" buttons in file lists"
+msgstr "Zobrazovat tlačítko \"Přidat zdroj\" v jednotlivých sekcích"
+
+#: id:21383
+msgid "Enable scrollbars"
+msgstr "Zobrazovat posuvníky"
+
+#: id:21384
+msgid "Make watched filtering a toggle in video library"
+msgstr "Aktivovat v knihovně filtr zhlédnutých/nezhlédnutých videí"
+
+#: id:21385
+msgctxt "Auto context with id 21385"
+msgid "Open"
+msgstr "Otevřít Seznam stop"
+
+#: id:21386
+msgid "Acoustic management level"
+msgstr "Úroveň hlučnosti"
+
+#: id:21387
+msgid "Fast"
+msgstr "Rychlý mód"
+
+#: id:21388
+msgid "Quiet"
+msgstr "Tichý mód"
+
+#: id:21389
+msgid "Enable custom background"
+msgstr "Aktivovat vlastní pozadí"
+
+#: id:21390
+msgid "Power management level"
+msgstr "Nastavení výkonu/spotřeby"
+
+#: id:21391
+msgid "High power"
+msgstr "Vysoký výkon"
+
+#: id:21392
+msgid "Low power"
+msgstr "Nízká spotřeba"
+
+#: id:21393
+msgid "High standby"
+msgstr "Režim spánku s vyšší spotřebou"
+
+#: id:21394
+msgid "Low standby"
+msgstr "Režim spánku s nižší spotřebou"
+
+#: id:21395
+msgid "Unable to cache files bigger than 4GB"
+msgstr "Soubory větší než 4GB nelze načíst do vyrovnávací paměti"
+
+#: id:21396
+msgid "Chapter"
+msgstr "Kapitola"
+
+#: id:21397
+msgid "High quality pixel shader v2"
+msgstr "High quality pixel shader v2"
+
+#: id:21398
+msgid "Enable playlist at startup"
+msgstr "Načíst Seznam stop při spuštění"
+
+#: id:21399
+msgid "Use tween animations"
+msgstr "Aktivovat \"neposednou\" animaci"
+
+#: id:21400
+msgid "contains"
+msgstr "obsahuje"
+
+#: id:21401
+msgid "does not contain"
+msgstr "neobsahuje"
+
+#: id:21402
+msgid "is"
+msgstr "je"
+
+#: id:21403
+msgid "is not"
+msgstr "není"
+
+#: id:21404
+msgid "starts with"
+msgstr "začíná na"
+
+#: id:21405
+msgid "ends with"
+msgstr "končí na"
+
+#: id:21406
+msgid "greater than"
+msgstr "větší než"
+
+#: id:21407
+msgid "less than"
+msgstr "menší než"
+
+#: id:21408
+msgid "after"
+msgstr "následuje"
+
+#: id:21409
+msgid "before"
+msgstr "předchází"
+
+#: id:21410
+msgid "in the last"
+msgstr "je poslední"
+
+#: id:21411
+msgid "not in the last"
+msgstr "není poslední"
+
+#: id:21412
+msgid "Scrapers"
+msgstr "Stahovače"
+
+#: id:21413
+msgid "Default movie scraper"
+msgstr "Výchozí stahovač pro filmy"
+
+#: id:21414
+msgid "Default tvshow scraper"
+msgstr "Výchozí stahovač pro TV seriály"
+
+#: id:21415
+msgid "Default music video scraper"
+msgstr "Výchozí stahovač pro hudební videoklipy"
+
+#: id:21416
+msgid "Enable fallback based on scraper language"
+msgstr "Povolit odpověď na základě nastavení jazyka stahovače"
+
+#: id:21417
+msgid "- Settings"
+msgstr "- Nastavení"
+
+#: id:21418
+msgid "Multilingual"
+msgstr "Vícejazyčný"
+
+#: id:21419
+msgid "No scrapers present"
+msgstr "Nejsou k dispozici žádné stahovače"
+
+#: id:21420
+msgid "Value to match"
+msgstr "Hodnota pro shodu"
+
+#: id:21421
+msgid "Smart playlist rule"
+msgstr "Pravidlo vlastního Seznamu stop"
+
+#: id:21422
+msgid "Match items where"
+msgstr "Skladby jsou shodné když"
+
+#: id:21423
+msgid "New rule..."
+msgstr "Nové pravidlo..."
+
+#: id:21424
+msgid "Items must match"
+msgstr "Skladby musí odpovídat shodě"
+
+#: id:21425
+msgid "all of the rules"
+msgstr "všech pravidel"
+
+#: id:21426
+msgid "one or more of the rules"
+msgstr "alespoň jednoho z pravidel"
+
+#: id:21427
+msgid "Limit to"
+msgstr "Omezit na"
+
+#: id:21428
+msgid "No limit"
+msgstr "Neomezovat"
+
+#: id:21429
+msgid "Order by"
+msgstr "Řadit dle"
+
+#: id:21430
+msgid "ascending"
+msgstr "vzestupně"
+
+#: id:21431
+msgid "descending"
+msgstr "sestupně"
+
+#: id:21432
+msgid "Edit smart playlist"
+msgstr "Upravit vlastní Seznam stop"
+
+#: id:21433
+msgid "Name of the playlist"
+msgstr "Název Seznamu stop"
+
+#: id:21434
+msgid "Find items where"
+msgstr "Najít skladby odpovídající"
+
+#: id:21435
+msgid "Edit"
+msgstr "- Upravit"
+
+#: id:21436
+msgid "%i items"
+msgstr "%i skladeb"
+
+#: id:21437
+msgid "New smart playlist..."
+msgstr "Nový vlastní Seznam stop..."
+
+#: id:21438
+msgid "%c Drive"
+msgstr "%c"
+
+#: id:21439
+msgid "Edit party mode rules"
+msgstr "Upravit pravidla Párty módu"
+
+#: id:21440
+msgid "Home folder"
+msgstr "Výchozí složka"
+
+#: id:21441
+msgid "Watched count"
+msgstr "Počet zhlédnutí"
+
+#: id:21442
+msgid "Episode title"
+msgstr "Název epizody"
+
+#: id:21443
+msgid "Video resolution"
+msgstr "Rozlišení videa"
+
+#: id:21444
+msgid "Audio channels"
+msgstr "Počet audio kanálů"
+
+#: id:21445
+msgid "Video codec"
+msgstr "Kodek videa"
+
+#: id:21446
+msgid "Audio codec"
+msgstr "Kodek audia"
+
+#: id:21447
+msgid "Audio language"
+msgstr "Jazyk audia"
+
+#: id:21448
+msgid "Subtitle language"
+msgstr "Jazyk titulků"
+
+#: id:21449
+msgid "Remote control sends keyboard presses"
+msgstr "Dálkový ovladač emuluje stisky klávesnice"
+
+#: id:21450
+msgid "- Edit"
+msgstr "- Upravit"
+
+#: id:21451
+msgid "Internet connection required."
+msgstr "Je vyžadováno internetové připojení."
+
+#: id:21452
+msgid "Get More..."
+msgstr "Získat další..."
+
+#: id:21453
+msgid "Root filesystem"
+msgstr "Kořenový adresář souborového systému"
+
+#: id:21454
+msgid "Cache full"
+msgstr ""
+
+#: id:21455
+msgid "Cache filled before reaching required amount for continous playback"
+msgstr ""
+
+#: id:21460
+msgid "Subtitle location"
+msgstr "Umístění titulků"
+
+#: id:21461
+msgid "Fixed"
+msgstr "Pevné"
+
+#: id:21462
+msgid "Bottom of video"
+msgstr "Spodní část obrazu"
+
+#: id:21463
+msgid "Below video"
+msgstr "Pod obrazem"
+
+#: id:21464
+msgid "Top of video"
+msgstr "Horní část obrazu"
+
+#: id:21465
+msgid "Above video"
+msgstr "Nad obrazem"
+
+#: id:21800
+msgid "File name"
+msgstr "Název souboru"
+
+#: id:21801
+msgid "File path"
+msgstr "Cesta k souboru"
+
+#: id:21802
+msgid "File size"
+msgstr "Velikost souboru"
+
+#: id:21803
+msgid "File date/time"
+msgstr "Datum a čas souboru"
+
+#: id:21804
+msgid "Slide index"
+msgstr "Pořadí v prezentaci"
+
+#: id:21805
+msgctxt "Auto context with id 21805"
+msgid "Resolution"
+msgstr "Rozlišení"
+
+#: id:21806
+msgctxt "Auto context with id 21806"
+msgid "Comment"
+msgstr "Komentář"
+
+#: id:21807
+msgid "Colour/B&W"
+msgstr "Barva/ČB"
+
+#: id:21808
+msgid "JPEG process"
+msgstr "Zpracování JPEG"
+
+#: id:21820
+msgid "Date/Time"
+msgstr "Datum/Čas"
+
+#: id:21821
+msgid "Description"
+msgstr "Popis"
+
+#: id:21822
+msgid "Camera make"
+msgstr "Značka fotoaparátu"
+
+#: id:21823
+msgid "Camera model"
+msgstr "Model fotoaparátu"
+
+#: id:21824
+msgid "EXIF comment"
+msgstr "EXIF komentář"
+
+#: id:21825
+msgid "Firmware"
+msgstr "Firmware"
+
+#: id:21826
+msgid "Aperture"
+msgstr "Clona"
+
+#: id:21827
+msgid "Focal length"
+msgstr "Ohnisko objektivu"
+
+#: id:21828
+msgid "Focus distance"
+msgstr "Vzdálenost objektivu"
+
+#: id:21829
+msgid "Exposure"
+msgstr "Expozice"
+
+#: id:21830
+msgid "Exposure time"
+msgstr "Čas expozice"
+
+#: id:21831
+msgid "Exposure bias"
+msgstr "Kompenzace expozice"
+
+#: id:21832
+msgid "Exposure mode"
+msgstr "Mód expozice"
+
+#: id:21833
+msgid "Flash used"
+msgstr "Použití blesku"
+
+#: id:21834
+msgid "White-balance"
+msgstr "Vyvážení bílé"
+
+#: id:21835
+msgid "Light source"
+msgstr "Zdroj světla"
+
+#: id:21836
+msgid "Metering mode"
+msgstr "Metering mód"
+
+#: id:21837
+msgid "ISO"
+msgstr "ISO"
+
+#: id:21838
+msgid "Digital zoom"
+msgstr "Digitální zoom"
+
+#: id:21839
+msgid "CCD width"
+msgstr "Velikost čipu"
+
+#: id:21840
+msgid "GPS latitude"
+msgstr "GPS - Zeměpisná šířka"
+
+#: id:21841
+msgid "GPS longitude"
+msgstr "GPS - Zeměpisná délka"
+
+#: id:21842
+msgid "GPS altitude"
+msgstr "GPS - Zeměpisná výška"
+
+#: id:21843
+msgid "Orientation"
+msgstr "Orientace"
+
+#: id:21860
+msgid "Supplemental categories"
+msgstr "Náhradní kategorie"
+
+#: id:21861
+msgid "Keywords"
+msgstr "Klíčová slova"
+
+#: id:21862
+msgid "Caption"
+msgstr "Titulek"
+
+#: id:21863
+msgid "Author"
+msgstr "Autor"
+
+#: id:21864
+msgid "Headline"
+msgstr "Nadpis"
+
+#: id:21865
+msgid "Special instructions"
+msgstr "Zvláštní instrukce"
+
+#: id:21866
+msgid "Category"
+msgstr "Kategorie"
+
+#: id:21867
+msgid "Byline"
+msgstr "Podtitulek"
+
+#: id:21868
+msgid "Byline title"
+msgstr "Název podtitulku"
+
+#: id:21869
+msgid "Credit"
+msgstr "Kredit"
+
+#: id:21870
+msgid "Source"
+msgstr "Zdroj"
+
+#: id:21871
+msgid "Copyright notice"
+msgstr "Copyright poznámka"
+
+#: id:21872
+msgid "Object name"
+msgstr "Název objektu"
+
+#: id:21873
+msgid "City"
+msgstr "Město"
+
+#: id:21874
+msgid "State"
+msgstr "Stát"
+
+#: id:21875
+msgctxt "Auto context with id 21875"
+msgid "Country"
+msgstr "Země"
+
+#: id:21876
+msgid "Original Tx Reference"
+msgstr "Výchozí Tx Reference"
+
+#: id:21877
+msgid "Date created"
+msgstr "Vytvořeno dne"
+
+#: id:21878
+msgid "Copyright flag"
+msgstr "Copyright"
+
+#: id:21879
+msgid "Country code"
+msgstr "Kód země"
+
+#: id:21880
+msgid "Reference service"
+msgstr "Referenční služba"
+
+#: id:21881
+msgid "Allow control of XBMC via UPnP"
+msgstr "Povolit ovládání XBMC přes UPnP"
+
+#: id:21882
+msgid "Attempt to skip introduction before DVD menu"
+msgstr "Při spuštění DVD se pokusit zobrazit rovnou hlavní menu"
+
+#: id:21883
+msgid "Saved music"
+msgstr "Uložená hudba"
+
+#: id:21884
+msgid "Query info for all artists"
+msgstr "Aktualizovat vše. Interprety"
+
+#: id:21885
+msgid "Downloading album information"
+msgstr "Probíhá stahování informací k albu"
+
+#: id:21886
+msgid "Downloading artist information"
+msgstr "Probíhá stahování informací o interpretovi"
+
+#: id:21887
+msgid "Biography"
+msgstr "Životopis"
+
+#: id:21888
+msgid "Discography"
+msgstr "Diskografie"
+
+#: id:21889
+msgid "Searching artist"
+msgstr "Probíhá vyhledávání informací o interpretovi"
+
+#: id:21890
+msgid "Select artist"
+msgstr "Vyberte interpreta"
+
+#: id:21891
+msgctxt "Auto context with id 21891"
+msgid "Artist information"
+msgstr "Informace o interpretovi"
+
+#: id:21892
+msgid "Instruments"
+msgstr "Hudební nástroje"
+
+#: id:21893
+msgid "Born"
+msgstr "Datum narození"
+
+#: id:21894
+msgid "Formed"
+msgstr "Datum seskupení"
+
+#: id:21895
+msgid "Themes"
+msgstr "Tematické zaměření"
+
+#: id:21896
+msgid "Disbanded"
+msgstr "Datum rozpuštění"
+
+#: id:21897
+msgid "Died"
+msgstr "Datum úmrtí"
+
+#: id:21898
+msgid "Years active"
+msgstr "Aktivní v letech"
+
+#: id:21899
+msgid "Label"
+msgstr "Label"
+
+#: id:21900
+msgid "Born/Formed"
+msgstr "Datum narození/seskupení"
+
+#: id:22000
+msgid "Update library on startup"
+msgstr "Aktualizovat knihovnu po spuštění"
+
+#: id:22001
+msgid "Hide progress of library updates"
+msgstr "Aktualizovat knihovnu vždy na pozadí"
+
+#: id:22002
+msgid "- DNS suffix"
+msgstr "- DNS sufix"
+
+#: id:22003
+msgid "%2.3fs"
+msgstr "%2.3fs"
+
+#: id:22004
+msgid "Delayed by: %2.3fs"
+msgstr "zpoždění o %2.3fs"
+
+#: id:22005
+msgid "Ahead by: %2.3fs"
+msgstr "předběhnutí o %2.3fs"
+
+#: id:22006
+msgid "Subtitle offset"
+msgstr "Posunutí titulků"
+
+#: id:22007
+msgid "OpenGL vendor:"
+msgstr "OpenGL ovladače:"
+
+#: id:22008
+msgid "OpenGL renderer:"
+msgstr "OpenGL renderer:"
+
+#: id:22009
+msgid "OpenGL version:"
+msgstr "OpenGL verze:"
+
+#: id:22010
+msgid "GPU temperature:"
+msgstr "GPU teplota:"
+
+#: id:22011
+msgid "CPU temperature:"
+msgstr "CPU teplota:"
+
+#: id:22012
+msgid "Total memory"
+msgstr "Celkem paměti"
+
+#: id:22013
+msgid "Profile data"
+msgstr "Data profilu"
+
+#: id:22014
+msgid "Use dim if paused during video playback"
+msgstr "Povolit ztmavení u pozastaveného videa"
+
+#: id:22015
+msgid "All recordings"
+msgstr "Všechny nahrávky"
+
+#: id:22016
+msgid "By title"
+msgstr "Podle názvu"
+
+#: id:22017
+msgid "By group"
+msgstr "Podle skupiny"
+
+#: id:22018
+msgid "Live channels"
+msgstr "Živé kanály"
+
+#: id:22019
+msgid "Recordings by title"
+msgstr "Nahrávky dle názvů"
+
+#: id:22020
+msgid "Guide"
+msgstr "Návod"
+
+#: id:22021
+msgid "Allowed error in aspect ratio to minimize black bars"
+msgstr "Odchylka poměru stran k minimalizaci černých okrajů"
+
+#: id:22022
+msgid "Show video files in listings"
+msgstr "Zobrazovat videa v seznamu souborů"
+
+#: id:22023
+msgid "DirectX vendor:"
+msgstr "DirectX výrobce:"
+
+#: id:22024
+msgid "Direct3D version:"
+msgstr "Direct3D verze:"
+
+#: id:22030
+msgctxt "Auto context with id 22030"
+msgid "Font"
+msgstr "Písmo"
+
+#: id:22031
+msgctxt "Auto context with id 22031"
+msgid "- Size"
+msgstr "- Velikost"
+
+#: id:22032
+msgctxt "Auto context with id 22032"
+msgid "- Colours"
+msgstr "- Barva"
+
+#: id:22033
+msgid "- Charset"
+msgstr "- Znaková sada"
+
+#: id:22034
+msgid "Export karaoke titles as HTML"
+msgstr "Exportovat do HTML"
+
+#: id:22035
+msgid "Export karaoke titles as CSV"
+msgstr "Exportovat do CSV"
+
+#: id:22036
+msgid "Import karaoke titles..."
+msgstr "Importovat karaoke titulky..."
+
+#: id:22037
+msgid "Show song selector automatically"
+msgstr "Automaticky zobrazovat dialog pro výběr skladby"
+
+#: id:22038
+msgid "Export karaoke titles..."
+msgstr "Exportovat karaoke titulky..."
+
+#: id:22039
+msgid "Enter song number"
+msgstr "Vyberte číslo skladby"
+
+#: id:22040
+msgid "white/green"
+msgstr "bílá/zelená"
+
+#: id:22041
+msgid "white/red"
+msgstr "bílá/červená"
+
+#: id:22042
+msgid "white/blue"
+msgstr "bílá/modrá"
+
+#: id:22043
+msgid "black/white"
+msgstr "černá/bílá"
+
+#: id:22079
+msgid "Default select action"
+msgstr "Výchozí akce při výběru položky"
+
+#: id:22080
+msgid "Choose"
+msgstr "Zobrazit nabídku"
+
+#: id:22081
+msgid "Show Information"
+msgstr "Zobrazit informace"
+
+#: id:22082
+msgid "More..."
+msgstr "Další nabídka..."
+
+#: id:22083
+msgid "Play all"
+msgstr "Přehrát vše"
+
+#: id:23049
+msgid "Teletext not available"
+msgstr "Teletext není k dispozici"
+
+#: id:23050
+msgid "Activate Teletext"
+msgstr "Povolit Teletext"
+
+#: id:23051
+msgid "Part %i"
+msgstr "Část %i"
+
+#: id:23052
+msgid "Buffering %i bytes"
+msgstr "Probíhá načítání %i bajtů"
+
+#: id:23053
+msgid "Stopping"
+msgstr "Probíhá ukončování"
+
+#: id:23054
+msgid "Running"
+msgstr "Probíhá spouštění"
+
+#: id:23100
+msgid "External Player Active"
+msgstr "Externí přehrávač je aktivní"
+
+#: id:23101
+msgid "Click OK to terminate the player"
+msgstr "Stiskněte OK pro uzavření přehrávače"
+
+#: id:23104
+msgid "Click OK when playback has ended"
+msgstr "Stiskněte OK po ukončení přehrávání"
+
+#: id:24000
+msgid "Add-on"
+msgstr "Doplněk"
+
+#: id:24001
+msgid "Add-ons"
+msgstr "Doplňky"
+
+#: id:24002
+msgid "Add-on options"
+msgstr "Možnosti doplňku"
+
+#: id:24003
+msgid "Add-on Information"
+msgstr "Informace o doplňku"
+
+#: id:24005
+msgctxt "Auto context with id 24005"
+msgid "Media sources"
+msgstr "Zdroje médií"
+
+#: id:24007
+msgctxt "Auto context with id 24007"
+msgid "Movie information"
+msgstr "Informace o filmu"
+
+#: id:24008
+msgctxt "Auto context with id 24008"
+msgid "Screensaver"
+msgstr "Spořič obrazovky"
+
+#: id:24009
+msgid "Script"
+msgstr "Skript"
+
+#: id:24010
+msgctxt "Auto context with id 24010"
+msgid "Visualization"
+msgstr "Vizualizace"
+
+#: id:24011
+msgid "Add-on repository"
+msgstr "Zdroj doplňků"
+
+#: id:24012
+msgctxt "Auto context with id 24012"
+msgid "Subtitles"
+msgstr "Titulky"
+
+#: id:24013
+msgid "Lyrics"
+msgstr "Texty skladeb"
+
+#: id:24014
+msgid "TV information"
+msgstr "Informace o TV seriálu"
+
+#: id:24015
+msgctxt "Auto context with id 24015"
+msgid "Music video information"
+msgstr "Informace o hudebním videu"
+
+#: id:24016
+msgctxt "Auto context with id 24016"
+msgid "Album information"
+msgstr "Informace o albu"
+
+#: id:24017
+msgctxt "Auto context with id 24017"
+msgid "Artist information"
+msgstr "Informace o interpretovi"
+
+#: id:24018
+msgctxt "Auto context with id 24018"
+msgid "Services"
+msgstr "Služby"
+
+#: id:24020
+msgid "Configure"
+msgstr "Nastavení"
+
+#: id:24021
+msgctxt "Auto context with id 24021"
+msgid "Disable"
+msgstr "Deaktivovat"
+
+#: id:24022
+msgid "Enable"
+msgstr "Aktivovat"
+
+#: id:24023
+msgid "Add-on disabled"
+msgstr "Doplněk je deaktivován"
+
+#: id:24027
+msgctxt "Auto context with id 24027"
+msgid "Weather"
+msgstr "Počasí"
+
+#: id:24028
+msgid "Weather.com (standard)"
+msgstr "Weather.com (standardní)"
+
+#: id:24030
+msgid "This Add-on can not be configured"
+msgstr "Tento doplněk nelze konfigurovat"
+
+#: id:24031
+msgid "Error loading settings"
+msgstr "Chyba při načítání konfigurace nastavení"
+
+#: id:24032
+msgid "All Add-ons"
+msgstr "Všechny doplňky"
+
+#: id:24033
+msgid "Get Add-ons"
+msgstr "Získat nové doplňky"
+
+#: id:24034
+msgid "Check for updates"
+msgstr "Zkontrolovat aktualizace"
+
+#: id:24035
+msgid "Force refresh"
+msgstr "Vynutit obnovu"
+
+#: id:24036
+msgid "Change log"
+msgstr "Změny"
+
+#: id:24037
+msgid "Uninstall"
+msgstr "Odinstalovat"
+
+#: id:24038
+msgid "Install"
+msgstr "Nainstalovat"
+
+#: id:24039
+msgid "Disabled Add-ons"
+msgstr "Deaktivované doplňky"
+
+#: id:24040
+msgid "(Clear the current setting)"
+msgstr "(Zruší aktuální nastavení)"
+
+#: id:24041
+msgid "Install from zip file"
+msgstr "Instalovat doplněk ze zip archivu"
+
+#: id:24042
+msgid "Downloading %i%%"
+msgstr "Staženo %i%%"
+
+#: id:24043
+msgid "Available Updates"
+msgstr "Doplňky s dostupnou aktualizací"
+
+#: id:24044
+msgid "Dependencies not met"
+msgstr "Nesplněné závislosti"
+
+#: id:24045
+msgid "Add-on does not have the correct structure"
+msgstr "Doplněk nemá správnou strukturu"
+
+#: id:24046
+msgid "%s is used by the following installed add-on(s)"
+msgstr "%s je používán těmito nainstalovanými doplňky"
+
+#: id:24047
+msgid "This add-on cannot be uninstalled"
+msgstr "Tento doplněk není možné odinstalovat"
+
+#: id:24048
+msgid "Rollback"
+msgstr "Vrácení změn"
+
+#: id:24050
+msgid "Available Add-ons"
+msgstr "Dostupné doplňky"
+
+#: id:24051
+msgid "Version:"
+msgstr "Verze:"
+
+#: id:24052
+msgid "Disclaimer"
+msgstr "Upozornění"
+
+#: id:24053
+msgid "License:"
+msgstr "Licence:"
+
+#: id:24054
+msgid "Changelog"
+msgstr "Změny"
+
+#: id:24059
+msgid "Would you like to enable this Add-on?"
+msgstr "Chcete aktivovat tento doplněk?"
+
+#: id:24060
+msgid "Would you like to disable this Add-on?"
+msgstr "Chcete deaktivovat tento doplněk?"
+
+#: id:24061
+msgid "Add-on update available!"
+msgstr "Je k dispozici aktualizace doplňku!"
+
+#: id:24062
+msgid "Enabled Add-ons"
+msgstr "Aktivované doplňky"
+
+#: id:24063
+msgid "Auto update"
+msgstr "Auto. aktualizace"
+
+#: id:24064
+msgid "Add-on enabled"
+msgstr "Doplněk byl aktivován"
+
+#: id:24065
+msgid "Add-on updated"
+msgstr "Doplněk byl aktualizován"
+
+#: id:24066
+msgid "Cancel Add-on download?"
+msgstr "Opravdu chcete zrušit stahování doplňku?"
+
+#: id:24067
+msgid "Currently downloading Add-ons"
+msgstr "Momentálně stahované doplňky"
+
+#: id:24068
+msgid "Update available"
+msgstr "Aktualizace k dispozici"
+
+#: id:24069
+msgid "Update"
+msgstr "Aktualizovat"
+
+#: id:24070
+msgid "Add-on could not be loaded."
+msgstr "Načtení doplňku se nezdařilo."
+
+#: id:24071
+msgid "An unknown error has occurred."
+msgstr "Objevila se neznámá chyba."
+
+#: id:24072
+msgid "Settings required"
+msgstr "Vyžadována změna nastavení"
+
+#: id:24073
+msgid "Could not connect"
+msgstr "Nelze se připojit"
+
+#: id:24074
+msgid "Needs to restart"
+msgstr "Je vyžadován restart"
+
+#: id:24075
+msgctxt "Auto context with id 24075"
+msgid "Disable"
+msgstr "Deaktivovat"
+
+#: id:24076
+msgid "Add-on Required"
+msgstr "Doplněk vyžadován"
+
+#: id:24080
+msgid "Try to reconnect?"
+msgstr "Pokusit se o opětovné připojení?"
+
+#: id:24089
+msgid "Add-on restarts"
+msgstr "Doplněk se restartuje"
+
+#: id:24090
+msgid "Lock Add-on manager"
+msgstr "Uzamknutí správce doplňků"
+
+#: id:24094
+msgid "(current)"
+msgstr "(stávající)"
+
+#: id:24095
+msgid "(blacklisted)"
+msgstr "(zakázaný)"
+
+#: id:24096
+msgid "Add-on has been marked as broken in repository."
+msgstr "Doplněk byl ve zdroji označen jako nefunkční."
+
+#: id:24097
+msgid "Would you like to disable it on your system?"
+msgstr "Chcete ho deaktivovat?"
+
+#: id:24098
+msgid "Broken"
+msgstr "Nefunkční"
+
+#: id:24099
+msgid "Would you like to switch to this skin?"
+msgstr "Chcete použít tento Vzhled?"
+
+#: id:24100
+msgid "To use this feature you must download an Add-on:"
+msgstr "Chcete-li používat tuto funkci, musíte stáhnout doplněk:"
+
+#: id:24101
+msgid "Would you like to download this Add-on?"
+msgstr "Chcete stáhnout tento doplněk?"
+
+#: id:25000
+msgid "Notifications"
+msgstr "Upozorňování"
+
+#: id:29800
+msgid "Library Mode"
+msgstr "Mód knihovny"
+
+#: id:29801
+msgid "QWERTY keyboard"
+msgstr "QWERTY klávesnice"
+
+#: id:29802
+msgid "Passthrough Audio in use"
+msgstr "Audio je přeposíláno receiveru"
+
+#: id:33001
+msgid "Trailer quality"
+msgstr "Kvalita upoutávky"
+
+#: id:33002
+msgid "Stream"
+msgstr "Streamovat"
+
+#: id:33003
+msgid "Download"
+msgstr "Stáhnout"
+
+#: id:33004
+msgid "Download & play"
+msgstr "Stáhnout a přehrát"
+
+#: id:33005
+msgid "Download & save"
+msgstr "Stáhnout a uložit"
+
+#: id:33006
+msgid "Today"
+msgstr "Dnes"
+
+#: id:33007
+msgid "Tomorrow"
+msgstr "Zítra"
+
+#: id:33008
+msgid "Saving"
+msgstr "Probíhá ukládání"
+
+#: id:33009
+msgid "Copying"
+msgstr "Probíhá kopírování"
+
+#: id:33010
+msgid "Set download directory"
+msgstr "Nastavit složku pro stahování"
+
+#: id:33011
+msgid "Search duration"
+msgstr "Doba vyhledávání"
+
+#: id:33012
+msgid "Short"
+msgstr "Krátký"
+
+#: id:33013
+msgid "Long"
+msgstr "Dlouhý"
+
+#: id:33014
+msgid "Use DVD player instead of regular player"
+msgstr "Místo běžného přehrávače používat DVD přehrávač"
+
+#: id:33015
+msgid "Ask for download before playing video"
+msgstr "Před přehráváním videa se zeptat na jeho stažení"
+
+#: id:33016
+msgid "Clips"
+msgstr "Klipy"
+
+#: id:33017
+msgid "Restart plugin to enable"
+msgstr "Pro aktivaci restartujte plugin"
+
+#: id:33018
+msgid "Tonight"
+msgstr "Dnes večer"
+
+#: id:33019
+msgid "Tomorrow Night"
+msgstr "Zítra večer"
+
+#: id:33020
+msgid "Condition"
+msgstr "Stav"
+
+#: id:33021
+msgid "Precipitation"
+msgstr "Srážky"
+
+#: id:33022
+msgid "Precip"
+msgstr "Srážky"
+
+#: id:33023
+msgid "Humid"
+msgstr "Vlhkost"
+
+#: id:33024
+msgid "Feels"
+msgstr "zdá se jako"
+
+#: id:33025
+msgid "Observed"
+msgstr "Pozorováno"
+
+#: id:33026
+msgid "Departure from normal"
+msgstr "Odchylka od normálu"
+
+#: id:33027
+msgid "Sunrise"
+msgstr "Východ slunce"
+
+#: id:33028
+msgid "Sunset"
+msgstr "Západ slunce"
+
+#: id:33029
+msgid "Details"
+msgstr "Detaily"
+
+#: id:33030
+msgid "Outlook"
+msgstr "Výhled"
+
+#: id:33031
+msgid "Coverflow"
+msgstr "Coverflow"
+
+#: id:33032
+msgid "Translate text"
+msgstr "Přeložit text"
+
+#: id:33033
+msgid "Map list %s category"
+msgstr "Namapovat seznam %s kategorie"
+
+#: id:33034
+msgid "36 Hour"
+msgstr "36 hodin"
+
+#: id:33035
+msgid "Maps"
+msgstr "Mapy"
+
+#: id:33036
+msgid "Hourly"
+msgstr "hodinu"
+
+#: id:33037
+msgid "Weekend"
+msgstr "víkend"
+
+#: id:33038
+msgid "%s day"
+msgstr "%s den"
+
+#: id:33049
+msgid "Alert"
+msgstr "Upozornění"
+
+#: id:33050
+msgid "Alerts"
+msgstr "Upozornění"
+
+#: id:33051
+msgid "Choose Your"
+msgstr "Vyberte vaši"
+
+#: id:33052
+msgid "Check"
+msgstr "Zkontrolovat"
+
+#: id:33053
+msgctxt "Auto context with id 33053"
+msgid "Configure the"
+msgstr "Nastavit"
+
+#: id:33054
+msgid "Seasons"
+msgstr "Řady"
+
+#: id:33055
+msgid "Use your"
+msgstr "Použít"
+
+#: id:33056
+msgid "Watch your"
+msgstr "Sledovat"
+
+#: id:33057
+msgid "Listen to"
+msgstr "Poslouchat"
+
+#: id:33058
+msgid "View your"
+msgstr "Prohlížet"
+
+#: id:33059
+msgctxt "Auto context with id 33059"
+msgid "Configure the"
+msgstr "Konfigurovat"
+
+#: id:33060
+msgid "Power"
+msgstr "Vypnutí"
+
+#: id:33061
+msgid "Menu"
+msgstr "Nabídka"
+
+#: id:33062
+msgid "Play the"
+msgstr "Přehrát"
+
+#: id:33063
+msgid "Options"
+msgstr "Možnosti"
+
+#: id:33065
+msgid "Editor"
+msgstr "Editor"
+
+#: id:33066
+msgid "About your"
+msgstr "O..."
+
+#: id:33067
+msgid "Star rating"
+msgstr "Hodnocení"
+
+#: id:33068
+msgid "Background"
+msgstr "Pozadí"
+
+#: id:33069
+msgid "Backgrounds"
+msgstr "Pozadí"
+
+#: id:33070
+msgid "Custom background"
+msgstr "Vlastní pozadí"
+
+#: id:33071
+msgid "Custom backgrounds"
+msgstr "Vlastní pozadí"
+
+#: id:33072
+msgid "View Readme"
+msgstr "Zobrazit Readme"
+
+#: id:33073
+msgid "View Changelog"
+msgstr "Zobrazit historii změn"
+
+#: id:33074
+msgid "This version of %s requires an"
+msgstr "Pro spuštění této verze %s je požadována"
+
+#: id:33075
+msgid "XBMC revision of %s or greater to run."
+msgstr "XBMC revize %s nebo vyšší."
+
+#: id:33076
+msgid "Please update XBMC."
+msgstr "Proveďte aktualizaci XBMC."
+
+#: id:33077
+msgid "No data found!"
+msgstr "Nebyla nalezena žádná data!"
+
+#: id:33078
+msgid "Next page"
+msgstr "Další strana"
+
+#: id:33079
+msgid "Love"
+msgstr "Milovat"
+
+#: id:33080
+msgid "Hate"
+msgstr "Nesnášet"
+
+#: id:33081
+msgid "This file is stacked, select the part you want to play from."
+msgstr "Tento soubor se skládá z více částí. Vyberte tu, od které chcete spustit přehrávání."
+
+#: id:33082
+msgid "Path to script"
+msgstr "Cesta ke skriptu"
+
+#: id:33083
+msgid "Enable custom script button"
+msgstr "Povolit vlastní tlačítko skriptu"
+
+#: id:33100
+msgid "Failed to start"
+msgstr "Nepodařilo se spustit"
+
+#: id:33101
+msgid "Webserver"
+msgstr "Webserver"
+
+#: id:33102
+msgid "Event Server"
+msgstr "Event Server"
+
+#: id:33103
+msgid "Remote communication server"
+msgstr "Remote communication server"
+
+#: id:33200
+msgid "Detected New Connection"
+msgstr ""
+
+#: id:34000
+msgid "Lame"
+msgstr "Lame"
+
+#: id:34001
+msgid "Vorbis"
+msgstr "Vorbis"
+
+#: id:34002
+msgid "Wav"
+msgstr "Wav"
+
+#: id:34003
+msgid "DXVA2"
+msgstr "DXVA2"
+
+#: id:34004
+msgid "VAAPI"
+msgstr "VAAPI"
+
+#: id:34005
+msgid "Flac"
+msgstr "Flac"
+
+#: id:34100
+msgid "Speaker Configuration"
+msgstr "Konfigurace reproduktorů"
+
+#: id:34101
+msgid "2.0"
+msgstr "2.0"
+
+#: id:34102
+msgid "2.1"
+msgstr "2.1"
+
+#: id:34103
+msgid "3.0"
+msgstr "3.0"
+
+#: id:34104
+msgid "3.1"
+msgstr "3.1"
+
+#: id:34105
+msgid "4.0"
+msgstr "4.0"
+
+#: id:34106
+msgid "4.1"
+msgstr "4.1"
+
+#: id:34107
+msgid "5.0"
+msgstr "5.0"
+
+#: id:34108
+msgid "5.1"
+msgstr "5.1"
+
+#: id:34109
+msgid "7.0"
+msgstr "7.0"
+
+#: id:34110
+msgid "7.1"
+msgstr "7.1"
+
+#: id:34201
+msgid "Can't find a next item to play"
+msgstr "Nelze nalézt další položku pro přehrávání"
+
+#: id:34202
+msgid "Can't find a previous item to play"
+msgstr "Nelze nalézt předchozí položku pro přehrávání"
+
+#: id:34300
+msgid "Failed to start zeroconf"
+msgstr ""
+
+#: id:34301
+msgid "Is Apple's Bonjour Service installed? See log for more info."
+msgstr ""
+
+#: id:34400
+msgid "Video Rendering"
+msgstr ""
+
+#: id:34401
+msgid "Failed to init video filters/scalers, falling back to bilinear scaling"
+msgstr ""
+
+#: id:34402
+msgid "Failed to initialize audio device"
+msgstr ""
+
+#: id:34403
+msgid "Check your audiosettings"
+msgstr ""
+
+#: id:34404
+msgid "Use gestures for navigation:"
+msgstr ""
+
+#: id:34405
+msgid "1 finger swipe left,right,up,down for cursors"
+msgstr ""
+
+#: id:34406
+msgid "2 finger swipe left for backspace"
+msgstr ""
+
+#: id:34407
+msgid "1 finger single tap for enter"
+msgstr ""
+
+#: id:34408
+msgid "2 finger single tap for contextmenu"
+msgstr ""
+
+#: id:35000
+msgid "Peripherals"
+msgstr "Periferní zařízení"
+
+#: id:35001
+msgid "Generic HID device"
+msgstr "Obecné HID zařízení"
+
+#: id:35002
+msgid "Generic network adapter"
+msgstr "Obecný síťový adaptér"
+
+#: id:35003
+msgid "Generic disk"
+msgstr "Obecný disk"
+
+#: id:35004
+msgid "There are no settings available\nfor this peripheral."
+msgstr "Pro toto periferní zařízení nejsou\nk dispozici žádná nastavení."
+
+#: id:35005
+msgid "New device configured"
+msgstr "Nové zařízení nastaveno"
+
+#: id:35006
+msgid "Device removed"
+msgstr "Zařízení odebráno"
+
+#: id:35007
+msgid "Keymap to use for this device"
+msgstr "Rozložení kláves pro toto zařízení"
+
+#: id:35008
+msgid "Keymap enabled"
+msgstr "Rozložení kláves povoleno"
+
+#: id:35009
+msgid "Do not use the custom keymap for this device"
+msgstr ""
+
+#: id:35500
+msgid "Location"
+msgstr "Umístění"
+
+#: id:35501
+msgid "Class"
+msgstr "Třída"
+
+#: id:35502
+msgctxt "Auto context with id 35502"
+msgid "Name"
+msgstr "Název"
+
+#: id:35503
+msgid "Vendor"
+msgstr "Výrobce"
+
+#: id:35504
+msgid "Product ID"
+msgstr "ID produktu"
+
+#: id:36000
+msgid "Pulse-Eight CEC adapter"
+msgstr "Pulse-Eight CEC adaptér"
+
+#: id:36001
+msgid "Pulse-Eight Nyxboard"
+msgstr "Pulse-Eight Nyxboard"
+
+#: id:36002
+msgid "Switch to keyboard side command"
+msgstr "Switch to keyboard side command"
+
+#: id:36003
+msgid "Switch to remote side command"
+msgstr "Switch to remote side command"
+
+#: id:36004
+msgid "Press \"user\" button command"
+msgstr "Press \"user\" button command"
+
+#: id:36005
+msgid "Enable switch side commands"
+msgstr "Enable switch side commands"
+
+#: id:36006
+msgid "Could not open the adapter"
+msgstr "Could not open the adapter"
+
+#: id:36007
+msgid "Devices to power on when starting XBMC"
+msgstr "Zapnout TV při spouštění XBMC"
+
+#: id:36008
+msgid "Devices to power off when stopping XBMC"
+msgstr "Vypnout zařízení při ukončování XBMC"
+
+#: id:36009
+msgid "Put devices in standby mode when activating screensaver"
+msgstr "Uvést zařízení do pohotovostního režimu při aktivování spořiče obrazovky"
+
+#: id:36011
+msgid "Could not detect the CEC port. Set it up manually."
+msgstr "Nepodařilo se najít CEC port. Nastavte jej ručně."
+
+#: id:36012
+msgid "Could not initialise the CEC adapter. Check your settings."
+msgstr "Nepodařilo se najít CEC adaptér."
+
+#: id:36013
+msgid "Unsupported libCEC interface version. %d is greater than the version XBMC supports (%d)"
+msgstr "Nepodporovaná verze libcec rozhraní. %d je vyšší než verze podporovaná XBMC (%d)"
+
+#: id:36014
+msgid "Put this PC in standby mode when the TV is switched off"
+msgstr "Při vypnutí TV uspat tento počítač"
+
+#: id:36015
+msgid "HDMI port number"
+msgstr "HDMI port"
+
+#: id:36016
+msgctxt "Auto context with id 36016"
+msgid "Connected"
+msgstr "Připojeno"
+
+#: id:36017
+msgid "Adapter found, but libCEC is not available"
+msgstr "Adaptér byl nalezen, ale libcec není k dispozici"
+
+#: id:36018
+msgid "Use the TV's language setting"
+msgstr "Použít nastavení jazyka v TV"
+
+#: id:36019
+msgid "Connected to HDMI device"
+msgstr ""
+
+#: id:36020
+msgid "Make XBMC the active source when starting"
+msgstr ""
+
+#: id:36021
+msgid "Physical address (overrules HDMI port)"
+msgstr ""
+
+#: id:36022
+msgid "COM port (leave empty unless needed)"
+msgstr ""
+
+#: id:36023
+msgid "Configuration updated"
+msgstr ""
+
+#: id:36024
+msgid "Failed to set the new configuration. Please check your settings."
+msgstr ""
+
+#: id:36025
+msgid "Send 'inactive source' command when stopping XBMC"
+msgstr ""
+

--- a/language/Danish/strings.po
+++ b/language/Danish/strings.po
@@ -1,0 +1,9093 @@
+# Converted from xbmc strings.xml with xbmc-xml2po (by Team-XBMC)
+msgid ""
+msgstr ""
+"Project-Id-Version: xbmc.core-FRODO_GIT3ed1604ad7\n"
+"Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
+"POT-Creation-Date: 2012-04-09 18:00+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE\n"
+"Language: da\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: id:0
+msgctxt "Auto context with id 0"
+msgid "Programs"
+msgstr "Programmer"
+
+#: id:1
+msgctxt "Auto context with id 1"
+msgid "Pictures"
+msgstr "Billeder"
+
+#: id:2
+msgctxt "Auto context with id 2"
+msgid "Music"
+msgstr "Musik"
+
+#: id:3
+msgctxt "Auto context with id 3"
+msgid "Videos"
+msgstr "Videoer"
+
+#: id:4
+msgid "TV-Guide"
+msgstr "TV-program"
+
+#: id:5
+msgctxt "Auto context with id 5"
+msgid "Settings"
+msgstr "Indstillinger"
+
+#: id:6
+msgid "XBMC SVN"
+msgstr "XBMC SVN"
+
+#: id:7
+msgctxt "Auto context with id 7"
+msgid "File manager"
+msgstr "Filhåndtering"
+
+#: id:8
+msgctxt "Auto context with id 8"
+msgid "Weather"
+msgstr "Vejret"
+
+#: id:9
+msgid "xbmc media center"
+msgstr "xbmc media center"
+
+#: id:11
+msgid "Monday"
+msgstr "Mandag"
+
+#: id:12
+msgid "Tuesday"
+msgstr "Tirsdag"
+
+#: id:13
+msgid "Wednesday"
+msgstr "Onsdag"
+
+#: id:14
+msgid "Thursday"
+msgstr "Torsdag"
+
+#: id:15
+msgid "Friday"
+msgstr "Fredag"
+
+#: id:16
+msgid "Saturday"
+msgstr "Lørdag"
+
+#: id:17
+msgid "Sunday"
+msgstr "Søndag"
+
+#: id:21
+msgid "January"
+msgstr "Januar"
+
+#: id:22
+msgid "February"
+msgstr "Februar"
+
+#: id:23
+msgid "March"
+msgstr "Marts"
+
+#: id:24
+msgid "April"
+msgstr "April"
+
+#: id:25
+msgctxt "Auto context with id 25"
+msgid "May"
+msgstr "Maj"
+
+#: id:26
+msgid "June"
+msgstr "Juni"
+
+#: id:27
+msgid "July"
+msgstr "Juli"
+
+#: id:28
+msgid "August"
+msgstr "August"
+
+#: id:29
+msgid "September"
+msgstr "September"
+
+#: id:30
+msgid "October"
+msgstr "Oktober"
+
+#: id:31
+msgid "November"
+msgstr "November"
+
+#: id:32
+msgid "December"
+msgstr "December"
+
+#: id:41
+msgid "Mon"
+msgstr "Man"
+
+#: id:42
+msgid "Tue"
+msgstr "Tir"
+
+#: id:43
+msgid "Wed"
+msgstr "Ons"
+
+#: id:44
+msgid "Thu"
+msgstr "Tor"
+
+#: id:45
+msgid "Fri"
+msgstr "Fre"
+
+#: id:46
+msgid "Sat"
+msgstr "Lør"
+
+#: id:47
+msgctxt "Auto context with id 47"
+msgid "Sun"
+msgstr "Søn"
+
+#: id:51
+msgid "Jan"
+msgstr "Jan"
+
+#: id:52
+msgid "Feb"
+msgstr "Feb"
+
+#: id:53
+msgid "Mar"
+msgstr "Mar"
+
+#: id:54
+msgid "Apr"
+msgstr "Apr"
+
+#: id:55
+msgctxt "Auto context with id 55"
+msgid "May"
+msgstr "Maj"
+
+#: id:56
+msgid "Jun"
+msgstr "Jun"
+
+#: id:57
+msgid "Jul"
+msgstr "Jul"
+
+#: id:58
+msgid "Aug"
+msgstr "Aug"
+
+#: id:59
+msgid "Sep"
+msgstr "Sep"
+
+#: id:60
+msgid "Oct"
+msgstr "Okt"
+
+#: id:61
+msgid "Nov"
+msgstr "Nov"
+
+#: id:62
+msgid "Dec"
+msgstr "Dec"
+
+#: id:71
+msgid "N"
+msgstr ""
+
+#: id:72
+msgid "NNE"
+msgstr ""
+
+#: id:73
+msgid "NE"
+msgstr ""
+
+#: id:74
+msgid "ENE"
+msgstr ""
+
+#: id:75
+msgid "E"
+msgstr ""
+
+#: id:76
+msgid "ESE"
+msgstr ""
+
+#: id:77
+msgid "SE"
+msgstr ""
+
+#: id:78
+msgid "SSE"
+msgstr ""
+
+#: id:79
+msgid "S"
+msgstr ""
+
+#: id:80
+msgid "SSW"
+msgstr ""
+
+#: id:81
+msgid "SW"
+msgstr ""
+
+#: id:82
+msgid "WSW"
+msgstr ""
+
+#: id:83
+msgid "W"
+msgstr ""
+
+#: id:84
+msgid "WNW"
+msgstr ""
+
+#: id:85
+msgid "NW"
+msgstr ""
+
+#: id:86
+msgid "NNW"
+msgstr ""
+
+#: id:87
+msgid "VAR"
+msgstr ""
+
+#: id:98
+msgid "View: Auto"
+msgstr "Vis: Auto"
+
+#: id:99
+msgid "View: Auto big"
+msgstr "Vis: Auto stor"
+
+#: id:100
+msgid "View: Icons"
+msgstr "Vis: Ikoner"
+
+#: id:101
+msgid "View: List"
+msgstr "Vis: Liste"
+
+#: id:102
+msgctxt "Auto context with id 102"
+msgid "Scan"
+msgstr "Gennemsøg"
+
+#: id:103
+msgctxt "Auto context with id 103"
+msgid "Sort by: Name"
+msgstr "Sortering: Navn"
+
+#: id:104
+msgid "Sort by: Date"
+msgstr "Sortering: Dato"
+
+#: id:105
+msgid "Sort by: Size"
+msgstr "Sortering: Størrelse"
+
+#: id:106
+msgid "No"
+msgstr "Nej"
+
+#: id:107
+msgid "Yes"
+msgstr "Ja"
+
+#: id:108
+msgctxt "Auto context with id 108"
+msgid "Slideshow"
+msgstr "Billedserie"
+
+#: id:109
+msgid "Create thumbs"
+msgstr "Lav ikoner"
+
+#: id:110
+msgid "Create thumbnails"
+msgstr "Lav ikoner"
+
+#: id:111
+msgctxt "Auto context with id 111"
+msgid "Shortcuts"
+msgstr "Genveje"
+
+#: id:112
+msgid "Paused"
+msgstr "Pause"
+
+#: id:113
+msgid "Update failed"
+msgstr ""
+
+#: id:114
+msgid "Installation failed"
+msgstr ""
+
+#: id:115
+msgid "Copy"
+msgstr "Kopier"
+
+#: id:116
+msgid "Move"
+msgstr "Flyt"
+
+#: id:117
+msgid "Delete"
+msgstr "Slet"
+
+#: id:118
+msgid "Rename"
+msgstr "Omdøb"
+
+#: id:119
+msgid "New folder"
+msgstr "Ny mappe"
+
+#: id:120
+msgid "Confirm file copy"
+msgstr "Bekræft kopiering"
+
+#: id:121
+msgid "Confirm file move"
+msgstr "Bekræft flytning"
+
+#: id:122
+msgid "Confirm file delete?"
+msgstr "Bekræft sletning?"
+
+#: id:123
+msgid "Copy these files?"
+msgstr "Kopier disse filer?"
+
+#: id:124
+msgid "Move these files?"
+msgstr "Flyt disse filer?"
+
+#: id:125
+msgid "Delete these files? - Deleting files cannot be undone!"
+msgstr "Slet disse filer? Sletning kan ikke fortrydes senere!"
+
+#: id:126
+msgid "Status"
+msgstr "Status"
+
+#: id:127
+msgid "Objects"
+msgstr "elementer"
+
+#: id:128
+msgctxt "Auto context with id 128"
+msgid "General"
+msgstr "Generelt"
+
+#: id:129
+msgctxt "Auto context with id 129"
+msgid "Slideshow"
+msgstr "Billedserie"
+
+#: id:130
+msgctxt "Auto context with id 130"
+msgid "System info"
+msgstr "Systeminfo"
+
+#: id:131
+msgid "Display"
+msgstr "Skærm"
+
+#: id:132
+msgid "Albums"
+msgstr "Album"
+
+#: id:133
+msgid "Artists"
+msgstr "Kunstnere"
+
+#: id:134
+msgid "Songs"
+msgstr "Numre"
+
+#: id:135
+msgid "Genres"
+msgstr "Genrer"
+
+#: id:136
+msgid "Playlists"
+msgstr "Afspilningslister"
+
+#: id:137
+msgid "Search"
+msgstr "Søg"
+
+#: id:138
+msgid "System Information"
+msgstr "Systeminformation"
+
+#: id:139
+msgid "Temperatures:"
+msgstr "Temperaturer:"
+
+#: id:140
+msgid "CPU:"
+msgstr "CPU:"
+
+#: id:141
+msgid "GPU:"
+msgstr "GPU:"
+
+#: id:142
+msgid "Time:"
+msgstr "Tid:"
+
+#: id:143
+msgid "Current:"
+msgstr "Lige nu:"
+
+#: id:144
+msgid "Build:"
+msgstr "Version:"
+
+#: id:145
+msgid "Network:"
+msgstr "Netværk:"
+
+#: id:146
+msgid "Type:"
+msgstr "Type:"
+
+#: id:147
+msgid "Static"
+msgstr "Statisk"
+
+#: id:148
+msgid "DHCP"
+msgstr "DHCP"
+
+#: id:149
+msgid "MAC address"
+msgstr "MAC-adresse"
+
+#: id:150
+msgctxt "Auto context with id 150"
+msgid "IP address"
+msgstr "IP-adresse"
+
+#: id:151
+msgid "Link:"
+msgstr "Forbindelse:"
+
+#: id:152
+msgid "Half duplex"
+msgstr "Halv duplex"
+
+#: id:153
+msgid "Full duplex"
+msgstr "Fuld duplex"
+
+#: id:154
+msgctxt "Auto context with id 154"
+msgid "Storage"
+msgstr "Lager"
+
+#: id:155
+msgid "Drive"
+msgstr "Drev"
+
+#: id:156
+msgctxt "Auto context with id 156"
+msgid "Free"
+msgstr "Fri"
+
+#: id:157
+msgctxt "Auto context with id 157"
+msgid "Video"
+msgstr "Video"
+
+#: id:158
+msgid "Free memory"
+msgstr "Fri hukommelse"
+
+#: id:159
+msgid "No link"
+msgstr "Ingen forbindelse"
+
+#: id:160
+msgctxt "Auto context with id 160"
+msgid "Free"
+msgstr "Fri"
+
+#: id:161
+msgid "Unavailable"
+msgstr "Ikke tilgængelig"
+
+#: id:162
+msgid "Tray open"
+msgstr "Skuffe åben"
+
+#: id:163
+msgid "Reading"
+msgstr "Læser"
+
+#: id:164
+msgid "No disc"
+msgstr "Intet medie"
+
+#: id:165
+msgid "Disc present"
+msgstr "Medie tilstede"
+
+#: id:166
+msgid "Skin"
+msgstr "Skin"
+
+#: id:169
+msgctxt "Auto context with id 169"
+msgid "Resolution"
+msgstr "Opløsning"
+
+#: id:170
+msgid "Adjust display refresh rate to match video"
+msgstr "Juster skærmens opdateringshastighed til det samme som videoens"
+
+#: id:172
+msgid "Release date"
+msgstr "Udgivelsesdato"
+
+#: id:173
+msgid "Display 4:3 videos as"
+msgstr "Vis 4:3 videoer som"
+
+#: id:175
+msgid "Moods"
+msgstr "Stemninger"
+
+#: id:176
+msgid "Styles"
+msgstr "Stilarter"
+
+#: id:179
+msgid "Song"
+msgstr "Nummer"
+
+#: id:180
+msgid "Duration"
+msgstr "Længde"
+
+#: id:181
+msgid "Select album"
+msgstr "Vælg album"
+
+#: id:182
+msgid "Tracks"
+msgstr "Spor"
+
+#: id:183
+msgid "Review"
+msgstr "Anmeldelse"
+
+#: id:184
+msgid "Refresh"
+msgstr "Opdater"
+
+#: id:185
+msgid "Searching album"
+msgstr "Søger i album"
+
+#: id:186
+msgid "OK"
+msgstr "OK"
+
+#: id:187
+msgid "No albums found!"
+msgstr "Intet album fundet!"
+
+#: id:188
+msgid "Select all"
+msgstr "Vælg alle"
+
+#: id:189
+msgid "Scanning media info"
+msgstr "Gennemsøger medieinfo"
+
+#: id:190
+msgid "Save"
+msgstr "Gem"
+
+#: id:191
+msgid "Shuffle"
+msgstr "Bland"
+
+#: id:192
+msgctxt "Auto context with id 192"
+msgid "Clear"
+msgstr "Ryd"
+
+#: id:193
+msgctxt "Auto context with id 193"
+msgid "Scan"
+msgstr "Gennemsøg"
+
+#: id:194
+msgid "Searching..."
+msgstr "Søger..."
+
+#: id:195
+msgid "No info found!"
+msgstr "Ingen info fundet!"
+
+#: id:196
+msgid "Select movie:"
+msgstr "Vælg film:"
+
+#: id:197
+msgid "Querying %s info"
+msgstr "Søger info (%s)"
+
+#: id:198
+msgid "Loading movie details"
+msgstr "Indlæser filmdetaljer"
+
+#: id:199
+msgid "Web interface"
+msgstr ""
+
+#: id:202
+msgid "Tagline"
+msgstr "Undertitel"
+
+#: id:203
+msgid "Plot outline"
+msgstr "Handling"
+
+#: id:205
+msgid "Votes"
+msgstr "Stemmer"
+
+#: id:206
+msgid "Cast"
+msgstr "Skuespillere"
+
+#: id:207
+msgid "Plot"
+msgstr "Handling"
+
+#: id:208
+msgctxt "Auto context with id 208"
+msgid "Play"
+msgstr "Afspil"
+
+#: id:209
+msgid "Next"
+msgstr "Næste"
+
+#: id:210
+msgid "Previous"
+msgstr "Forrige"
+
+#: id:213
+msgid "Calibrate user interface..."
+msgstr "Kalibrer brugerflade..."
+
+#: id:214
+msgid "Video calibration..."
+msgstr "Kalibrer skærmareal..."
+
+#: id:215
+msgid "Soften"
+msgstr "Blødgør"
+
+#: id:216
+msgid "Zoom amount"
+msgstr "Forstørrelse"
+
+#: id:217
+msgid "Pixel ratio"
+msgstr "Pixelforhold"
+
+#: id:218
+msgid "DVD drive"
+msgstr "Skuffe"
+
+#: id:219
+msgid "Please insert disc"
+msgstr "Indsæt venligst medie"
+
+#: id:220
+msgid "Remote share"
+msgstr "Netværksmappe"
+
+#: id:221
+msgid "Network is not connected"
+msgstr "Netværk er ikke tilsluttet"
+
+#: id:222
+msgid "Cancel"
+msgstr "Annuller"
+
+#: id:224
+msgid "Speed"
+msgstr "Hastighed"
+
+#: id:225
+msgid "Vertical Shift"
+msgstr ""
+
+#: id:226
+msgid "Test patterns..."
+msgstr "Testmønstre..."
+
+#: id:227
+msgid "Lookup audio CD track names from freedb.org"
+msgstr "Søg info om musik-cd'er på freedb.org"
+
+#: id:228
+msgid "Shuffle playlist on load"
+msgstr "Bland afspilningslister under indlæsning"
+
+#: id:229
+msgid "HDD spindown time"
+msgstr "Sluk for harddisk efter (min.)"
+
+#: id:230
+msgid "Video filters"
+msgstr "Videofiltre"
+
+#: id:231
+msgctxt "Auto context with id 231"
+msgid "None"
+msgstr "Ingen"
+
+#: id:232
+msgid "Point"
+msgstr "Punkt"
+
+#: id:233
+msgid "Linear"
+msgstr "Lineær"
+
+#: id:234
+msgid "Anisotropic"
+msgstr "Anisotropisk"
+
+#: id:235
+msgid "Quincunx"
+msgstr "Quincunx"
+
+#: id:236
+msgid "Gaussian cubic"
+msgstr "Gaussisk kubisk"
+
+#: id:237
+msgid "Minification"
+msgstr "Formindskning"
+
+#: id:238
+msgid "Magnification"
+msgstr "Forstørrelse"
+
+#: id:239
+msgid "Clear playlist on finish"
+msgstr "Tøm afspilningslisten ved afslutning"
+
+#: id:240
+msgid "Display Mode"
+msgstr ""
+
+#: id:241
+msgid "Full Screen #%d"
+msgstr ""
+
+#: id:242
+msgid "Windowed"
+msgstr ""
+
+#: id:243
+msgid "Refresh Rate"
+msgstr ""
+
+#: id:244
+msgid "Full screen"
+msgstr ""
+
+#: id:245
+msgid "Sizing: (%i,%i)->(%i,%i) (Zoom x%2.2f) AR:%2.2f:1 (Pixels: %2.2f:1) (VShift: %2.2f)"
+msgstr ""
+
+#: id:247
+msgctxt "Auto context with id 247"
+msgid "Scripts"
+msgstr "Skript"
+
+#: id:248
+msgctxt "Auto context with id 248"
+msgid "Language"
+msgstr "Sprog"
+
+#: id:249
+msgctxt "Auto context with id 249"
+msgid "Music"
+msgstr "Musik"
+
+#: id:250
+msgctxt "Auto context with id 250"
+msgid "Visualization"
+msgstr "Visualisering"
+
+#: id:251
+msgid "Select destination directory"
+msgstr "Vælg destinationsmappe"
+
+#: id:252
+msgid "Output stereo to all speakers"
+msgstr "Send stereosignal til alle højttalere"
+
+#: id:253
+msgid "Number of channels"
+msgstr "Antal lydkanaler"
+
+#: id:254
+msgid "- DTS capable receiver"
+msgstr "- DTS-forstærker"
+
+#: id:255
+msgid "CDDB"
+msgstr "CDDB"
+
+#: id:256
+msgid "Fetching CD information"
+msgstr "Henter information om cd"
+
+#: id:257
+msgid "Error"
+msgstr "Fejl"
+
+#: id:258
+msgid "Enable tag reading"
+msgstr "Læs filbeskrivelser"
+
+#: id:259
+msgid "Opening"
+msgstr "Åbner"
+
+#: id:260
+msgid "Shoutcast"
+msgstr "Shoutcast"
+
+#: id:261
+msgid "Waiting for start..."
+msgstr "Venter på opstart...."
+
+#: id:262
+msgid "Scripts output"
+msgstr "Resultat af skriptkørsel"
+
+#: id:263
+msgid "Allow control of XBMC via HTTP"
+msgstr "Tillad kontrol af XBMC via HTTP"
+
+#: id:264
+msgid "Record"
+msgstr "Optag"
+
+#: id:265
+msgid "Stop Rec."
+msgstr "Stands optagelse"
+
+#: id:266
+msgid "Sort by: Track"
+msgstr "Sortering: Nummer"
+
+#: id:267
+msgid "Sort by: Time"
+msgstr "Sortering: Tid"
+
+#: id:268
+msgid "Sort by: Title"
+msgstr "Sortering: Titel"
+
+#: id:269
+msgid "Sort by: Artist"
+msgstr "Sortering: Kunstner"
+
+#: id:270
+msgid "Sort by: Album"
+msgstr "Sortering: Album"
+
+#: id:271
+msgid "Top 100"
+msgstr "Top 100"
+
+#: id:272
+msgid "Top-Left overscan compensation"
+msgstr "Øverste venstre hjørne"
+
+#: id:273
+msgid "Bottom-Right overscan compensation"
+msgstr "Nederste højre hjørne"
+
+#: id:274
+msgid "Subtitle positioning"
+msgstr "Placering af undertekster"
+
+#: id:275
+msgid "Pixel ratio adjustment"
+msgstr "Justering af pixelforhold"
+
+#: id:276
+msgid "Adjust the arrow to change the amount of overscan"
+msgstr "Flyt pilen for at ændre placering"
+
+#: id:277
+msgid "Adjust the bar to change the subtitles position"
+msgstr "Flyt bjælken for at ændre placering af underteksterne"
+
+#: id:278
+msgid "Adjust the rectangle so it is perfectly square"
+msgstr "Juster firkanten så den bliver perfekt kvadratisk"
+
+#: id:279
+msgid "Unable to load settings"
+msgstr "Kan ikke indlæse indstillinger"
+
+#: id:280
+msgid "Using default settings"
+msgstr "Bruger standardindstillinger"
+
+#: id:281
+msgid "Please check the XML files"
+msgstr "Kontroller venligst xml-filerne"
+
+#: id:282
+msgid "Found %i items"
+msgstr "%i elementer fundet"
+
+#: id:283
+msgid "Search results"
+msgstr "Søgeresultat"
+
+#: id:284
+msgid "No results found"
+msgstr "Ingen resultater fundet"
+
+#: id:287
+msgctxt "Auto context with id 287"
+msgid "Subtitles"
+msgstr "Undertekster"
+
+#: id:288
+msgctxt "Auto context with id 288"
+msgid "Font"
+msgstr "Skrifttype"
+
+#: id:289
+msgctxt "Auto context with id 289"
+msgid "- Size"
+msgstr "- Størrelse"
+
+#: id:290
+msgid "Dynamic range compression"
+msgstr "Forstærkning (dB)"
+
+#: id:291
+msgctxt "Auto context with id 291"
+msgid "Video"
+msgstr "Billede"
+
+#: id:292
+msgctxt "Auto context with id 292"
+msgid "Audio"
+msgstr "Lyd"
+
+#: id:293
+msgid "Browse for subtitles"
+msgstr "Søg efter undertekster"
+
+#: id:294
+msgid "Create bookmark"
+msgstr "Opret bogmærke"
+
+#: id:296
+msgid "Clear bookmarks"
+msgstr "Slet bogmærker"
+
+#: id:297
+msgid "Audio offset"
+msgstr "Lydforsinkelse"
+
+#: id:298
+msgid "Bookmarks"
+msgstr "Bogmærker"
+
+#: id:299
+msgid "- AAC capable receiver"
+msgstr "- AAC understøttet modtager"
+
+#: id:300
+msgid "- MP1 capable receiver"
+msgstr "- MP1 understøttet modtager"
+
+#: id:301
+msgid "- MP2 capable receiver"
+msgstr "- MP2 understøttet modtager"
+
+#: id:302
+msgid "- MP3 capable receiver"
+msgstr "- MP3 understøttet modtager"
+
+#: id:303
+msgid "Delay"
+msgstr "Forsinkelse"
+
+#: id:304
+msgctxt "Auto context with id 304"
+msgid "Language"
+msgstr "Sprog"
+
+#: id:305
+msgctxt "Auto context with id 305"
+msgid "Enabled"
+msgstr "Aktiveret"
+
+#: id:306
+msgid "Non-interleaved"
+msgstr "Ikke interleaved"
+
+#: id:312
+msgid "(0=auto)"
+msgstr "(0=automatisk)"
+
+#: id:313
+msgid "Cleaning database"
+msgstr "Rydder op i database"
+
+#: id:314
+msgid "Preparing..."
+msgstr "Forbereder..."
+
+#: id:315
+msgid "Database error"
+msgstr "Databasefejl"
+
+#: id:316
+msgid "Searching songs..."
+msgstr "Søger numre..."
+
+#: id:317
+msgid "Cleaned database successfully"
+msgstr "Oprydning af database gennemført"
+
+#: id:318
+msgid "Cleaning songs..."
+msgstr "Behandler sange..."
+
+#: id:319
+msgid "Error cleaning songs"
+msgstr "Fejl ved rydning af sange"
+
+#: id:320
+msgid "Cleaning artists..."
+msgstr "Behandler kunstnere..."
+
+#: id:321
+msgid "Error cleaning artists"
+msgstr "Fejl ved rydning af kunstnere"
+
+#: id:322
+msgid "Cleaning genres..."
+msgstr "Behandler genrer..."
+
+#: id:323
+msgid "Error cleaning genres"
+msgstr "Fejl ved rydning af genrer"
+
+#: id:324
+msgid "Cleaning paths..."
+msgstr "Behandler stier..."
+
+#: id:325
+msgid "Error cleaning paths"
+msgstr "Fejl ved rydning af stier"
+
+#: id:326
+msgid "Cleaning albums..."
+msgstr "Behandler album..."
+
+#: id:327
+msgid "Error cleaning albums"
+msgstr "Fejl ved rydning af album"
+
+#: id:328
+msgid "Writing changes..."
+msgstr "Skriver ændringer..."
+
+#: id:329
+msgid "Error writing changes"
+msgstr "Fejl under skrivning"
+
+#: id:330
+msgid "This may take some time..."
+msgstr "Dette kan tage noget tid..."
+
+#: id:331
+msgid "Compressing database..."
+msgstr "Komprimerer database..."
+
+#: id:332
+msgid "Error compressing database"
+msgstr "Fejl under komprimering af database"
+
+#: id:333
+msgid "Do you want to clean the library?"
+msgstr "Vil du rydde op i databasen?"
+
+#: id:334
+msgid "Clean library..."
+msgstr "Ryd op i database..."
+
+#: id:335
+msgid "Start"
+msgstr "Start"
+
+#: id:336
+msgid "Framerate conversion"
+msgstr "Juster billedhastighed"
+
+#: id:337
+msgctxt "Auto context with id 337"
+msgid "Audio output"
+msgstr "Lydudgang"
+
+#: id:338
+msgid "Analog"
+msgstr "Analog"
+
+#: id:339
+msgid "Optical/Coax"
+msgstr "Digital"
+
+#: id:340
+msgid "Various artists"
+msgstr "Diverse kunstnere"
+
+#: id:341
+msgid "Play disc"
+msgstr "Afspil medie"
+
+#: id:342
+msgctxt "Auto context with id 342"
+msgid "Movies"
+msgstr "Film"
+
+#: id:343
+msgid "Adjust framerate"
+msgstr "Juster billedhastighed"
+
+#: id:344
+msgid "Actors"
+msgstr "Skuespillere"
+
+#: id:345
+msgctxt "Auto context with id 345"
+msgid "Year"
+msgstr "Årstal"
+
+#: id:346
+msgid "Boost volume level on downmix"
+msgstr "Øg lydstyrken ved downmix"
+
+#: id:350
+msgctxt "Auto context with id 350"
+msgid "Programs"
+msgstr "Programmer"
+
+#: id:351
+msgctxt "Auto context with id 351"
+msgid "Off"
+msgstr "Fra"
+
+#: id:352
+msgid "Dim"
+msgstr "Dæmpning"
+
+#: id:353
+msgid "Black"
+msgstr "Sort"
+
+#: id:354
+msgid "Matrix trails"
+msgstr "Matrix"
+
+#: id:355
+msgid "Screensaver time"
+msgstr "Start pauseskærm efter"
+
+#: id:356
+msgid "Screensaver mode"
+msgstr "Pauseskærmstilstand"
+
+#: id:357
+msgid "Shutdown function timer"
+msgstr "Sluk efter"
+
+#: id:358
+msgid "All albums"
+msgstr "Alle album"
+
+#: id:359
+msgid "Recently added albums"
+msgstr "Seneste album"
+
+#: id:360
+msgctxt "Auto context with id 360"
+msgid "Screensaver"
+msgstr "Pauseskærm"
+
+#: id:361
+msgid "R. Slideshow"
+msgstr "Rek. billedserie"
+
+#: id:362
+msgid "Screensaver dim level"
+msgstr "Dæmpningsniveau"
+
+#: id:363
+msgid "Sort by: File"
+msgstr "Sortering: Fil"
+
+#: id:364
+msgid "- Dolby Digital (AC3) capable receiver"
+msgstr "- Dolby Digital-forstærker (AC3)"
+
+#: id:365
+msgctxt "Auto context with id 365"
+msgid "Sort by: Name"
+msgstr "Sortering: Navn"
+
+#: id:366
+msgid "Sort by: Year"
+msgstr "Sortering: Årstal"
+
+#: id:367
+msgid "Sort by: Rating"
+msgstr "Sortering: Vurdering"
+
+#: id:368
+msgid "IMDb"
+msgstr "IMDb"
+
+#: id:369
+msgctxt "Auto context with id 369"
+msgid "Title"
+msgstr "Titel"
+
+#: id:370
+msgid "Thunderstorms"
+msgstr "uvejr"
+
+#: id:371
+msgid "Partly"
+msgstr "delvist"
+
+#: id:372
+msgid "Mostly"
+msgstr "mest"
+
+#: id:373
+msgid "Sunny"
+msgstr "solrigt"
+
+#: id:374
+msgid "Cloudy"
+msgstr "skyet"
+
+#: id:375
+msgid "Snow"
+msgstr "sne"
+
+#: id:376
+msgid "Rain"
+msgstr "regn"
+
+#: id:377
+msgid "Light"
+msgstr "let"
+
+#: id:378
+msgid "AM"
+msgstr "formiddag"
+
+#: id:379
+msgid "PM"
+msgstr "eftermiddag"
+
+#: id:380
+msgid "Showers"
+msgstr "byger"
+
+#: id:381
+msgid "Few"
+msgstr "nogle"
+
+#: id:382
+msgid "Scattered"
+msgstr "spredte"
+
+#: id:383
+msgctxt "Auto context with id 383"
+msgid "Wind"
+msgstr "blæst"
+
+#: id:384
+msgid "Strong"
+msgstr "hård"
+
+#: id:385
+msgid "Fair"
+msgstr "få skyer"
+
+#: id:386
+msgctxt "Auto context with id 386"
+msgid "Clear"
+msgstr "skyfrit"
+
+#: id:387
+msgid "Clouds"
+msgstr "skyer"
+
+#: id:388
+msgid "Early"
+msgstr "tidligt"
+
+#: id:389
+msgid "Shower"
+msgstr "byge"
+
+#: id:390
+msgid "Flurries"
+msgstr "fnug"
+
+#: id:391
+msgctxt "Auto context with id 391"
+msgid "Low"
+msgstr "Lav"
+
+#: id:392
+msgctxt "Auto context with id 392"
+msgid "Medium"
+msgstr "Medium"
+
+#: id:393
+msgctxt "Auto context with id 393"
+msgid "High"
+msgstr "Høj"
+
+#: id:394
+msgid "Fog"
+msgstr "diset"
+
+#: id:395
+msgid "Haze"
+msgstr "hagl"
+
+#: id:396
+msgid "Select location"
+msgstr "Vælg placering"
+
+#: id:397
+msgid "Refresh time"
+msgstr "Opdateringsinterval"
+
+#: id:398
+msgid "Temperature units"
+msgstr "Temperaturskala"
+
+#: id:399
+msgid "Speed units"
+msgstr "Hastighedsskala"
+
+#: id:400
+msgctxt "Auto context with id 400"
+msgid "Weather"
+msgstr "Vejr"
+
+#: id:401
+msgid "Temp"
+msgstr "Temperatur"
+
+#: id:402
+msgid "Feels like"
+msgstr "Føles som"
+
+#: id:403
+msgid "UV index"
+msgstr "UV-indeks"
+
+#: id:404
+msgctxt "Auto context with id 404"
+msgid "Wind"
+msgstr "Vind"
+
+#: id:405
+msgid "Dew point"
+msgstr "Dugpunkt"
+
+#: id:406
+msgid "Humidity"
+msgstr "Fugtighed"
+
+#: id:409
+msgid "Defaults"
+msgstr "Standarder"
+
+#: id:410
+msgid "Accessing weather service"
+msgstr "Forbinder til vejrtjeneste"
+
+#: id:411
+msgid "Getting weather for:"
+msgstr "Henter vejrdata til:"
+
+#: id:412
+msgid "Unable to get weather data"
+msgstr "Kan ikke hente vejrdata"
+
+#: id:413
+msgid "Manual"
+msgstr "Manuelt"
+
+#: id:414
+msgid "No review for this album"
+msgstr "Ingen anmeldelse af dette album"
+
+#: id:415
+msgid "Downloading thumbnail..."
+msgstr "Henter ikon..."
+
+#: id:416
+msgid "Not available"
+msgstr "Ikke tilgængelig"
+
+#: id:417
+msgid "View: Big icons"
+msgstr "Vis: Store ikoner"
+
+#: id:418
+msgctxt "Auto context with id 418"
+msgid "Low"
+msgstr "Lav"
+
+#: id:419
+msgctxt "Auto context with id 419"
+msgid "High"
+msgstr "Høj"
+
+#: id:420
+msgid "HDMI"
+msgstr "HDMI"
+
+#: id:422
+msgid "Delete album info"
+msgstr "Slet albuminfo"
+
+#: id:423
+msgid "Delete CD information"
+msgstr "Slet cd-info"
+
+#: id:424
+msgid "Select"
+msgstr "Vælg"
+
+#: id:425
+msgid "No album information found"
+msgstr "Ingen albuminfo fundet"
+
+#: id:426
+msgid "No CD information found"
+msgstr "Ingen cd-info fundet"
+
+#: id:427
+msgid "Disc"
+msgstr "Skuffe"
+
+#: id:428
+msgid "Insert correct CD/DVD"
+msgstr "Isæt rigtig CD/DVD"
+
+#: id:429
+msgid "Please insert the following disc:"
+msgstr "Vær venlig at isætte følgende CD/DVD"
+
+#: id:430
+msgid "Sort by: DVD#"
+msgstr "Sortering: DVD#"
+
+#: id:431
+msgid "No cache"
+msgstr "Intet mellemlager"
+
+#: id:432
+msgid "Remove movie from library"
+msgstr "Slet film fra databasen"
+
+#: id:433
+msgid "Really remove '%s'?"
+msgstr "Er du sikker på at du vil slette '%s'?"
+
+#: id:434
+msgid "From %s at %i %s"
+msgstr ""
+
+#: id:437
+msgid "Removable disk"
+msgstr "Flytbar disk"
+
+#: id:438
+msgid "Opening file"
+msgstr "Åbner fil"
+
+#: id:439
+msgid "Cache"
+msgstr "Mellemlager"
+
+#: id:440
+msgid "Harddisk"
+msgstr "Harddisk"
+
+#: id:441
+msgid "UDF"
+msgstr "UDF"
+
+#: id:442
+msgid "Local network"
+msgstr "Lokalnetværk"
+
+#: id:443
+msgid "Internet"
+msgstr "Internet"
+
+#: id:444
+msgctxt "Auto context with id 444"
+msgid "Video"
+msgstr "Billede"
+
+#: id:445
+msgctxt "Auto context with id 445"
+msgid "Audio"
+msgstr "Lyd"
+
+#: id:446
+msgctxt "Auto context with id 446"
+msgid "DVD"
+msgstr "DVD"
+
+#: id:447
+msgid "Autorun media"
+msgstr "Afspil automatisk"
+
+#: id:448
+msgid "LCD"
+msgstr "LCD"
+
+#: id:449
+msgctxt "Auto context with id 449"
+msgid "Enabled"
+msgstr "Aktiveret"
+
+#: id:450
+msgid "Columns"
+msgstr "Kolonner"
+
+#: id:451
+msgid "Row 1 address"
+msgstr "Adresse på række 1"
+
+#: id:452
+msgid "Row 2 address"
+msgstr "Adresse på række 2"
+
+#: id:453
+msgid "Row 3 address"
+msgstr "Adresse på række 3"
+
+#: id:454
+msgid "Row 4 address"
+msgstr "Adresse på række 4"
+
+#: id:455
+msgid "Rows"
+msgstr "Rækker"
+
+#: id:456
+msgid "Mode"
+msgstr "tilstand"
+
+#: id:457
+msgid "Switch view"
+msgstr "Skift visning"
+
+#: id:459
+msgid "Subs"
+msgstr "Undertekster"
+
+#: id:460
+msgid "Audio stream"
+msgstr "Lydkanal"
+
+#: id:461
+msgid "[active]"
+msgstr "[aktiv]"
+
+#: id:462
+msgid "Subtitle"
+msgstr "Undertekst"
+
+#: id:463
+msgid "Backlight"
+msgstr "Baggrundslys"
+
+#: id:464
+msgid "Brightness"
+msgstr "Lysstyrke"
+
+#: id:465
+msgid "Contrast"
+msgstr "Kontrast"
+
+#: id:466
+msgid "Gamma"
+msgstr "Gamma"
+
+#: id:467
+msgctxt "Auto context with id 467"
+msgid "Type"
+msgstr "Type"
+
+#: id:468
+msgid "Move the bar to change the OSD position"
+msgstr "Flyt bjælken for at ændre placering af OSD"
+
+#: id:469
+msgid "OSD position"
+msgstr "Placering af OSD"
+
+#: id:470
+msgid "Credits"
+msgstr "Tak til"
+
+#: id:471
+msgid "Modchip"
+msgstr "Modchip"
+
+#: id:474
+msgctxt "Auto context with id 474"
+msgid "Off"
+msgstr "Fra"
+
+#: id:475
+msgid "Music only"
+msgstr "Kun musik"
+
+#: id:476
+msgctxt "Auto context with id 476"
+msgid "Music & video"
+msgstr "Musik og video"
+
+#: id:477
+msgid "Unable to load playlist"
+msgstr "Kan ikke indlæse afspilningsliste"
+
+#: id:478
+msgid "OSD"
+msgstr "OSD"
+
+#: id:479
+msgid "Skin & language"
+msgstr "Skin og sprog"
+
+#: id:480
+msgid "Appearance"
+msgstr "Brugerflade"
+
+#: id:481
+msgid "Audio options"
+msgstr "Lydindstillinger"
+
+#: id:482
+msgid "About XBMC"
+msgstr "Om XBMC"
+
+#: id:485
+msgid "Delete album"
+msgstr "Slet album"
+
+#: id:486
+msgid "Repeat"
+msgstr "Gentag"
+
+#: id:487
+msgid "Repeat one"
+msgstr "Gentag samme"
+
+#: id:488
+msgid "Repeat folder"
+msgstr "Gentag mapper"
+
+#: id:489
+msgid "Play the next song automatically"
+msgstr "Spil automatisk næste nummer"
+
+#: id:491
+msgid "- Use big icons"
+msgstr "- Brug store ikoner"
+
+#: id:492
+msgid "Resize VobSubs"
+msgstr "Forstør VobSubs"
+
+#: id:493
+msgid "Advanced options (Experts Only!)"
+msgstr "Avancerede indstillinger (For eksperter!)"
+
+#: id:494
+msgid "Overall audio headroom"
+msgstr "Lydoverstyringsreserve (dB)"
+
+#: id:495
+msgid "Upsample videos to GUI resolution"
+msgstr "Forstør film til skærmens opløsning"
+
+#: id:496
+msgid "Calibration"
+msgstr "Kalibrering"
+
+#: id:497
+msgid "Show file extensions"
+msgstr "Vis filendelser"
+
+#: id:498
+msgid "Sort by: Type"
+msgstr "Sortering: Type"
+
+#: id:499
+msgid "Unable to connect to online lookup service"
+msgstr "Kan ikke forbinde til info-tjeneste"
+
+#: id:500
+msgid "Downloading album information failed"
+msgstr "Hentning af albumoplysninger fejlede"
+
+#: id:501
+msgid "Looking for album names..."
+msgstr "Søger efter album navne..."
+
+#: id:502
+msgctxt "Auto context with id 502"
+msgid "Open"
+msgstr "Åben"
+
+#: id:503
+msgid "Busy"
+msgstr "Optaget"
+
+#: id:504
+msgid "Empty"
+msgstr "Tom"
+
+#: id:505
+msgid "Loading media info from files..."
+msgstr "Henter medieinfo fra filer..."
+
+#: id:507
+msgid "Sort by: Usage"
+msgstr "Sortering: Brug"
+
+#: id:510
+msgid "Enable visualizations"
+msgstr "Aktiver visualisering"
+
+#: id:511
+msgid "Enable video mode switching"
+msgstr "Aktiver skift af videotilstand"
+
+#: id:512
+msgid "Startup window"
+msgstr "Startvindue"
+
+#: id:513
+msgid "Home window"
+msgstr "Hovedvindue"
+
+#: id:514
+msgid "Manual settings"
+msgstr "Manuelle indstillinger"
+
+#: id:515
+msgid "Genre"
+msgstr "Genre"
+
+#: id:517
+msgid "Recently played albums"
+msgstr "Fornyligt afspillede album"
+
+#: id:518
+msgid "Launch"
+msgstr "Start"
+
+#: id:519
+msgid "Launch in..."
+msgstr "Start i.."
+
+#: id:521
+msgid "Compilations"
+msgstr "Samlinger"
+
+#: id:522
+msgid "Remove source"
+msgstr "Fjern kilde"
+
+#: id:523
+msgid "Switch media"
+msgstr "Skift medie"
+
+#: id:524
+msgid "Select playlist"
+msgstr "Vælg afspilningsliste"
+
+#: id:525
+msgid "New playlist..."
+msgstr "Ny afspilningsliste..."
+
+#: id:526
+msgid "Add to playlist"
+msgstr "Tilføj til afspilningsliste"
+
+#: id:527
+msgid "Manually add to library"
+msgstr "Tilføj manuelt"
+
+#: id:528
+msgid "Enter title"
+msgstr "Indtast titel"
+
+#: id:529
+msgid "Error: Duplicate title"
+msgstr "Fejl: Titlen findes allerede"
+
+#: id:530
+msgid "Select genre"
+msgstr "Vælg genre"
+
+#: id:531
+msgid "New genre"
+msgstr "Ny genre"
+
+#: id:532
+msgid "Manual addition"
+msgstr "Manuel tilføjelse"
+
+#: id:533
+msgid "Enter genre"
+msgstr "Indtast genre"
+
+#: id:534
+msgid "View: %s"
+msgstr "Vis: %s"
+
+#: id:535
+msgid "List"
+msgstr "Liste"
+
+#: id:536
+msgid "Icons"
+msgstr "Ikoner"
+
+#: id:537
+msgid "Big list"
+msgstr "Stor liste"
+
+#: id:538
+msgid "Big icons"
+msgstr "Store ikoner"
+
+#: id:539
+msgid "Wide"
+msgstr "Bred"
+
+#: id:540
+msgid "Big wide"
+msgstr "Stor og bred"
+
+#: id:541
+msgid "Album icons"
+msgstr "Covere"
+
+#: id:542
+msgid "DVD icons"
+msgstr "DVD-covere"
+
+#: id:543
+msgctxt "Auto context with id 543"
+msgid "DVD"
+msgstr "DVD"
+
+#: id:544
+msgctxt "Auto context with id 544"
+msgid "Media info"
+msgstr "Medieinfo"
+
+#: id:545
+msgid "Audio output device"
+msgstr "Enhed til lydudgang"
+
+#: id:546
+msgid "Passthrough output device"
+msgstr "Enhed til gennemgang"
+
+#: id:547
+msgid "No biography for this artist"
+msgstr "Ingen biografi til denne kunstner"
+
+#: id:548
+msgid "Downmix multichannel audio to stereo"
+msgstr "Downmix flerkanalslyd til stereo"
+
+#: id:550
+msgid "Sort by: %s"
+msgstr "Sortering: %s"
+
+#: id:551
+msgctxt "Auto context with id 551"
+msgid "Name"
+msgstr "Navn"
+
+#: id:552
+msgid "Date"
+msgstr "Dato"
+
+#: id:553
+msgid "Size"
+msgstr "Størrelse"
+
+#: id:554
+msgid "Track"
+msgstr "Spor"
+
+#: id:555
+msgid "Time"
+msgstr "Tid"
+
+#: id:556
+msgctxt "Auto context with id 556"
+msgid "Title"
+msgstr "Titel"
+
+#: id:557
+msgid "Artist"
+msgstr "Kunstner"
+
+#: id:558
+msgid "Album"
+msgstr "Album"
+
+#: id:559
+msgid "Playlist"
+msgstr "Afspilningsliste"
+
+#: id:560
+msgid "ID"
+msgstr "ID"
+
+#: id:561
+msgctxt "Auto context with id 561"
+msgid "File"
+msgstr "Fil"
+
+#: id:562
+msgctxt "Auto context with id 562"
+msgid "Year"
+msgstr "År"
+
+#: id:563
+msgid "Rating"
+msgstr "Vurdering"
+
+#: id:564
+msgctxt "Auto context with id 564"
+msgid "Type"
+msgstr "Type"
+
+#: id:565
+msgid "Usage"
+msgstr "Brug"
+
+#: id:566
+msgid "Album artist"
+msgstr "Albumkunstner"
+
+#: id:567
+msgid "Play count"
+msgstr "Afspilninger"
+
+#: id:568
+msgid "Last played"
+msgstr "Sidst spillet"
+
+#: id:569
+msgctxt "Auto context with id 569"
+msgid "Comment"
+msgstr "Kommentar"
+
+#: id:570
+msgid "Date added"
+msgstr "Tilføjet den"
+
+#: id:571
+msgctxt "Auto context with id 571"
+msgid "Default"
+msgstr "Standard"
+
+#: id:572
+msgid "Studio"
+msgstr "Studio"
+
+#: id:573
+msgid "Path"
+msgstr "Sti"
+
+#: id:574
+msgctxt "Auto context with id 574"
+msgid "Country"
+msgstr "Land"
+
+#: id:575
+msgid "In progress"
+msgstr ""
+
+#: id:576
+msgid "Times played"
+msgstr ""
+
+#: id:580
+msgid "Sort direction"
+msgstr "Sorteringsretning"
+
+#: id:581
+msgid "Sort method"
+msgstr "Sorteringsmetode"
+
+#: id:582
+msgctxt "Auto context with id 582"
+msgid "View mode"
+msgstr "Visningsmåde"
+
+#: id:583
+msgid "Remember views for different folders"
+msgstr "Husk visninger for hver mappe"
+
+#: id:584
+msgid "Ascending"
+msgstr "Stigende"
+
+#: id:585
+msgid "Descending"
+msgstr "Faldende"
+
+#: id:586
+msgid "Edit playlist"
+msgstr "Rediger afspilningsliste"
+
+#: id:587
+msgid "Filter"
+msgstr "Filter"
+
+#: id:588
+msgid "Cancel party mode"
+msgstr "Afbryd festtilstand"
+
+#: id:589
+msgid "Party mode"
+msgstr "Festtilstand"
+
+#: id:590
+msgid "Random"
+msgstr "Tilfældig"
+
+#: id:591
+msgctxt "Auto context with id 591"
+msgid "Off"
+msgstr "Fra"
+
+#: id:592
+msgid "One"
+msgstr "En"
+
+#: id:593
+msgid "All"
+msgstr "Alle"
+
+#: id:594
+msgctxt "Auto context with id 594"
+msgid "Off"
+msgstr "Fra"
+
+#: id:595
+msgid "Repeat: Off"
+msgstr "Gentag: Fra"
+
+#: id:596
+msgid "Repeat: One"
+msgstr "Gentag: En"
+
+#: id:597
+msgid "Repeat: All"
+msgstr "Gentag: Alle"
+
+#: id:600
+msgid "Rip audio CD"
+msgstr "Rip CD-lyd"
+
+#: id:601
+msgctxt "Auto context with id 601"
+msgid "Medium"
+msgstr "Medium"
+
+#: id:602
+msgctxt "Auto context with id 602"
+msgid "Standard"
+msgstr "Standard"
+
+#: id:603
+msgid "Extreme"
+msgstr "Ekstrem"
+
+#: id:604
+msgid "Constant bitrate"
+msgstr "Konstant bitrate (CBR)"
+
+#: id:605
+msgid "Ripping..."
+msgstr "Ripper..."
+
+#: id:607
+msgid "To:"
+msgstr "Til:"
+
+#: id:608
+msgid "Could not rip CD or track"
+msgstr "Kunne ikke ripppe CD eller spor"
+
+#: id:609
+msgid "CDDARipPath is not set."
+msgstr "CDDARipPath er ikke sat"
+
+#: id:610
+msgid "Rip audio track"
+msgstr "Rip lydspor"
+
+#: id:611
+msgid "Enter number"
+msgstr "Indtast tal"
+
+#: id:612
+msgid "Bits/Sample"
+msgstr ""
+
+#: id:613
+msgid "Sample Frequency"
+msgstr ""
+
+#: id:620
+msgid "Audio CDs"
+msgstr "Lyd-CD'er"
+
+#: id:621
+msgid "Encoder"
+msgstr "Encoder"
+
+#: id:622
+msgid "Quality"
+msgstr "Kvalitet"
+
+#: id:623
+msgid "Bitrate"
+msgstr "Bitrate"
+
+#: id:624
+msgid "Include track number"
+msgstr "Inkluder spornummer"
+
+#: id:625
+msgid "All songs of"
+msgstr "Alle sange af"
+
+#: id:629
+msgctxt "Auto context with id 629"
+msgid "View mode"
+msgstr "Visningstilstand"
+
+#: id:630
+msgctxt "Auto context with id 630"
+msgid "Normal"
+msgstr "Normal"
+
+#: id:631
+msgid "Zoom"
+msgstr "Zoom"
+
+#: id:632
+msgid "Stretch 4:3"
+msgstr "Stræk 4:3"
+
+#: id:633
+msgid "Wide Zoom"
+msgstr "Stræk 14:9"
+
+#: id:634
+msgid "Stretch 16:9"
+msgstr "Stræk 16:9"
+
+#: id:635
+msgid "Original Size"
+msgstr "Original størrelse"
+
+#: id:636
+msgctxt "Auto context with id 636"
+msgid "Custom"
+msgstr "Brugerdefineret"
+
+#: id:637
+msgid "Replay gain"
+msgstr "Replay Gain"
+
+#: id:638
+msgid "Replaygain volume adjustments"
+msgstr "Replay Gain-styring af volume"
+
+#: id:639
+msgid "Use track levels"
+msgstr "Brug sporets lydstyrke"
+
+#: id:640
+msgid "Use album levels"
+msgstr "Brug albummets lydstyrke"
+
+#: id:641
+msgid "PreAmp Level - Replay gained files"
+msgstr "Forforstærkning ved filer med Replay Gain"
+
+#: id:642
+msgid "PreAmp Level - Non replay gained files"
+msgstr "Forforstærkning ved filer uden Replay Gain"
+
+#: id:643
+msgid "Avoid clipping on replay gained files"
+msgstr "Undgå hak ved filer med Replay Gain"
+
+#: id:644
+msgid "Crop black bars"
+msgstr "Fjern sorte kanter"
+
+#: id:645
+msgid "Need to unpack a big file. Continue?"
+msgstr "Behov for at gemme en stor fil midlertidigt. Fortsæt?"
+
+#: id:646
+msgid "Remove from library"
+msgstr "Fjern fra database"
+
+#: id:647
+msgid "Export video library"
+msgstr "Eksporter database"
+
+#: id:648
+msgid "Import video library"
+msgstr "Importer database"
+
+#: id:649
+msgid "Importing"
+msgstr "Importerer"
+
+#: id:650
+msgid "Exporting"
+msgstr "Eksporterer"
+
+#: id:651
+msgid "Browse for library"
+msgstr "Søg efter database"
+
+#: id:652
+msgid "Years"
+msgstr "År"
+
+#: id:653
+msgid "Update library"
+msgstr "Opdater database"
+
+#: id:654
+msgid "Show debug info"
+msgstr "Vis debug-info"
+
+#: id:655
+msgid "Browse for executable"
+msgstr "Søg efter program"
+
+#: id:656
+msgid "Browse for playlist"
+msgstr "Søg efter afspilningsliste"
+
+#: id:657
+msgid "Browse for folder"
+msgstr "Søg efter mappe"
+
+#: id:658
+msgid "Song information"
+msgstr "Sangoplysninger"
+
+#: id:659
+msgid "Non-linear stretch"
+msgstr "Ikke-lineær stræk"
+
+#: id:660
+msgid "Volume amplification"
+msgstr "Lydforstærkning"
+
+#: id:661
+msgid "Choose export folder"
+msgstr "Vælg mappe til eksport"
+
+#: id:662
+msgid "This file is no longer available."
+msgstr "Filen er ikke længere tilgængelig."
+
+#: id:663
+msgid "Would you like to remove it from the library?"
+msgstr "Vil du slette den fra databasen?"
+
+#: id:664
+msgid "Browse for Script"
+msgstr "Søg efter skript"
+
+#: id:665
+msgid "Compression level"
+msgstr "Komprimerings niveau"
+
+#: id:700
+msgid "Cleaning up library"
+msgstr "Rydder op i databasen"
+
+#: id:701
+msgid "Removing old songs from the library"
+msgstr "Fjerner gamle sange fra databasen"
+
+#: id:702
+msgid "This path has been scanned before"
+msgstr "Denne sti er tidligere blevet gennemsøgt"
+
+#: id:705
+msgctxt "Auto context with id 705"
+msgid "Network"
+msgstr "Netværk"
+
+#: id:706
+msgid "- Server"
+msgstr "- Server"
+
+#: id:708
+msgid "Use an HTTP proxy server to access the internet"
+msgstr "Brug en HTTP-proxyserver til Internetadgang"
+
+#: id:711
+msgid "Internet Protocol (IP)"
+msgstr "Internet Protokol (IP)"
+
+#: id:712
+msgid "Invalid port specified. Value must be between 1 and 65535."
+msgstr "Ugyldig port angivet. Porten skal ligge imellem 1 og 65535."
+
+#: id:713
+msgid "HTTP proxy"
+msgstr "HTTP-proxy"
+
+#: id:715
+msgid "- Assignment"
+msgstr "Tildeling"
+
+#: id:716
+msgid "Automatic (DHCP)"
+msgstr "Automatisk (DHCP)"
+
+#: id:717
+msgid "Manual (Static)"
+msgstr "Manuel (Statisk)"
+
+#: id:719
+msgid "- IP address"
+msgstr "- IP-adresse"
+
+#: id:720
+msgid "- Netmask"
+msgstr "- Netmaske"
+
+#: id:721
+msgid "- Default gateway"
+msgstr "- Standard gateway"
+
+#: id:722
+msgid "- DNS server"
+msgstr "- DNS-server"
+
+#: id:723
+msgid "Save & restart"
+msgstr "Gem og genstart"
+
+#: id:724
+msgid "Invalid address specified. Value must be AAA.BBB.CCC.DDD"
+msgstr "Ugyldig adresse. Værdien skal have formatet AAA.BBB.CCC.DDD"
+
+#: id:725
+msgid "with numbers between 0 and 255."
+msgstr "med numre mellem 0 og 255."
+
+#: id:726
+msgid "Changes not saved. Continue without saving?"
+msgstr "Ændringerne er ikke gemt. Vil du forsætte uden at gemme?"
+
+#: id:727
+msgid "Web server"
+msgstr "Web-server"
+
+#: id:728
+msgctxt "Auto context with id 728"
+msgid "FTP server"
+msgstr "FTP-server"
+
+#: id:730
+msgid "- Port"
+msgstr "- Port"
+
+#: id:732
+msgid "Save & apply"
+msgstr "Gem og anvend"
+
+#: id:733
+msgid "- Password"
+msgstr "- Adgangskode"
+
+#: id:734
+msgid "No pass"
+msgstr "Ingen adgangskode"
+
+#: id:735
+msgid "- Character set"
+msgstr "- Tegnsæt"
+
+#: id:736
+msgid "- Style"
+msgstr "- Stil"
+
+#: id:737
+msgid "- Colour"
+msgstr "- Farve"
+
+#: id:738
+msgctxt "Auto context with id 738"
+msgid "Normal"
+msgstr "Normal"
+
+#: id:739
+msgid "Bold"
+msgstr "Fed"
+
+#: id:740
+msgid "Italics"
+msgstr "Kursiv"
+
+#: id:741
+msgid "Bold italics"
+msgstr "Fed og kursiv"
+
+#: id:742
+msgctxt "Auto context with id 742"
+msgid "White"
+msgstr "Hvid"
+
+#: id:743
+msgctxt "Auto context with id 743"
+msgid "Yellow"
+msgstr "Gul"
+
+#: id:744
+msgctxt "Auto context with id 744"
+msgid "Files"
+msgstr "Filer"
+
+#: id:745
+msgid "No scanned information for this view"
+msgstr "Ingen skannede informationer i denne visning"
+
+#: id:746
+msgid "Please turn off library mode"
+msgstr "Deaktiver venligst databasevisning"
+
+#: id:747
+msgid "Error loading image"
+msgstr "Billede kunne ikke hentes"
+
+#: id:748
+msgid "Edit path"
+msgstr "Rediger sti"
+
+#: id:749
+msgid "Mirror image"
+msgstr "Spejl billede"
+
+#: id:750
+msgid "Are you sure?"
+msgstr "Er du sikker?"
+
+#: id:751
+msgid "Removing source"
+msgstr "Fjerner kilde"
+
+#: id:754
+msgid "Add program link"
+msgstr "Tilføj programlink"
+
+#: id:755
+msgid "Edit program path"
+msgstr "Rediger programmets sti"
+
+#: id:756
+msgid "Edit program name"
+msgstr "Rediger programmets navn"
+
+#: id:757
+msgid "Edit path depth"
+msgstr "Rediger sti-dybde"
+
+#: id:759
+msgid "View: Big list"
+msgstr "Vis: Stor liste"
+
+#: id:760
+msgctxt "Auto context with id 760"
+msgid "Yellow"
+msgstr "Gul"
+
+#: id:761
+msgctxt "Auto context with id 761"
+msgid "White"
+msgstr "Hvid"
+
+#: id:762
+msgid "Blue"
+msgstr "Blå"
+
+#: id:763
+msgid "Bright green"
+msgstr "Lysegrøn"
+
+#: id:764
+msgid "Yellow green"
+msgstr "Gullig grøn"
+
+#: id:765
+msgid "Cyan"
+msgstr "Cyan"
+
+#: id:766
+msgid "Light grey"
+msgstr "Reserveret"
+
+#: id:767
+msgid "Grey"
+msgstr "Reserveret"
+
+#: id:770
+msgid "Error %i: share not available"
+msgstr "Fejl %i: netværksmappe ikke tilgængelig"
+
+#: id:772
+msgctxt "Auto context with id 772"
+msgid "Audio output"
+msgstr "Lydudgang"
+
+#: id:773
+msgid "Seeking"
+msgstr "Søger"
+
+#: id:774
+msgid "Slideshow folder"
+msgstr "Mappe til billedserie"
+
+#: id:775
+msgid "Network interface"
+msgstr "Netværksgrænseflade"
+
+#: id:776
+msgid "- Wireless network name (ESSID)"
+msgstr "- Navn på trådløst netværk (ESSID)"
+
+#: id:777
+msgid "- Wireless password"
+msgstr "- Kodeord til trådløst netværk"
+
+#: id:778
+msgid "- Wireless security"
+msgstr "- Sikkerhedssytem på trådløst netværk"
+
+#: id:779
+msgid "Save and apply network interface settings"
+msgstr "Gem og anvend indstillinger til netværket"
+
+#: id:780
+msgid "No encryption"
+msgstr "Ingen kryptering"
+
+#: id:781
+msgid "WEP"
+msgstr "WEP"
+
+#: id:782
+msgid "WPA"
+msgstr "WPA"
+
+#: id:783
+msgid "WPA2"
+msgstr "WPA2"
+
+#: id:784
+msgid "Applying network interface settings. Please wait."
+msgstr "Anvender indstillinger til netværket. Vent venligst."
+
+#: id:785
+msgid "Network interface restarted successfully."
+msgstr "Netværksgrænsefladen genstartet med succes."
+
+#: id:786
+msgid "Network interface did not start successfully."
+msgstr "Netværksgrænsefladen kunne ikke startes."
+
+#: id:787
+msgid "Interface disabled"
+msgstr "Grænseflade deaktiveret"
+
+#: id:788
+msgid "Network interface disabled successfully."
+msgstr "Netværksgrænseflade deaktiveret med succes."
+
+#: id:789
+msgid "Wireless network name (ESSID)"
+msgstr "Navn på trådløst netværk (ESSID)"
+
+#: id:790
+msgid "Remote control"
+msgstr ""
+
+#: id:791
+msgid "Allow programs on this system to control XBMC"
+msgstr "Tillad programmer på dette system at styre XBMC"
+
+#: id:792
+msgctxt "Auto context with id 792"
+msgid "Port"
+msgstr "Port"
+
+#: id:793
+msgid "Port range"
+msgstr "Portområde"
+
+#: id:794
+msgid "Allow programs on other systems to control XBMC"
+msgstr "Tillad programmer på andre systemer at styre XBMC"
+
+#: id:795
+msgid "Initial repeat delay (ms)"
+msgstr "Indledende forsinkelse på gentagelse (ms)"
+
+#: id:796
+msgid "Continuous repeat delay (ms)"
+msgstr "Vedvarende forsinkelse på gentagelse (ms)"
+
+#: id:797
+msgid "Maximum number of clients"
+msgstr "Maksimalt antal klienter"
+
+#: id:798
+msgid "Internet access"
+msgstr "Internetadgang"
+
+#: id:850
+msgid "Invalid port number entered"
+msgstr "Ugyldigt portnummer indtastet"
+
+#: id:851
+msgid "Valid port range is 1-65535"
+msgstr "Gyldigt portområde er 1-65535"
+
+#: id:852
+msgid "Valid port range is 1024-65535"
+msgstr "Gyldigt portområde er 1024-65535"
+
+#: id:998
+msgid "Add Music..."
+msgstr ""
+
+#: id:999
+msgid "Add Videos..."
+msgstr ""
+
+#: id:1000
+msgid "- Preview"
+msgstr "Afprøv pauseskærm"
+
+#: id:1001
+msgid "Unable to connect"
+msgstr "Kan ikke forbinde"
+
+#: id:1002
+msgid "XBMC was unable to connect to the network location."
+msgstr "XBMC kunne ikke forbinde til destinationen."
+
+#: id:1003
+msgid "This could be due to the network not being connected."
+msgstr "Dette kan skyldes at netværket ikke er tilslutttet."
+
+#: id:1004
+msgid "Would you like to add it anyway?"
+msgstr "Vil du tilføje det alligevel?"
+
+#: id:1006
+msgctxt "Auto context with id 1006"
+msgid "IP address"
+msgstr "IP-adresse"
+
+#: id:1007
+msgid "Add network location"
+msgstr "Tilføj netværkssted"
+
+#: id:1008
+msgid "Protocol"
+msgstr "Protokol"
+
+#: id:1009
+msgid "Server address"
+msgstr "Serverens adresse"
+
+#: id:1010
+msgid "Server name"
+msgstr "Serverens navn"
+
+#: id:1011
+msgid "Remote path"
+msgstr "Sti på server"
+
+#: id:1012
+msgid "Shared folder"
+msgstr "Delt mappe"
+
+#: id:1013
+msgctxt "Auto context with id 1013"
+msgid "Port"
+msgstr "Port"
+
+#: id:1014
+msgctxt "Auto context with id 1014"
+msgid "Username"
+msgstr "Brugernavn"
+
+#: id:1015
+msgid "Browse for network server"
+msgstr "Søg efter netværksserver"
+
+#: id:1016
+msgid "Enter the network address of the server"
+msgstr "Indtast netværksadressen på serveren"
+
+#: id:1017
+msgid "Enter the path on the server"
+msgstr "Indtast stien på serveren"
+
+#: id:1018
+msgid "Enter the port number"
+msgstr "Indtast portnummer"
+
+#: id:1019
+msgid "Enter the username"
+msgstr "Indtast brugernavn"
+
+#: id:1020
+msgid "Add %s source"
+msgstr "Tilføj kilde til %s"
+
+#: id:1021
+msgid "Enter the paths or browse for the media locations."
+msgstr "Tilføj stier eller søg efter medieplaceringer."
+
+#: id:1022
+msgid "Enter a name for this media Source."
+msgstr "Vælg navn til mediekilde"
+
+#: id:1023
+msgid "Browse for new share"
+msgstr "Søg efter ny kilde"
+
+#: id:1024
+msgid "Browse"
+msgstr "Søg"
+
+#: id:1025
+msgid "Could not retrieve directory information."
+msgstr "Kunne ikke hente information om mappe"
+
+#: id:1026
+msgid "Add source"
+msgstr "Tilføj kilde"
+
+#: id:1027
+msgid "Edit source"
+msgstr "Rediger kilde"
+
+#: id:1028
+msgid "Edit %s source"
+msgstr "Rediger kilden til %s"
+
+#: id:1029
+msgid "Enter the new label"
+msgstr "Indtast ny label"
+
+#: id:1030
+msgid "Browse for image"
+msgstr "Søg efter billede"
+
+#: id:1031
+msgid "Browse for image folder"
+msgstr "Søg efter billedemappe"
+
+#: id:1032
+msgid "Add network location..."
+msgstr "Tilføj netværkssted..."
+
+#: id:1033
+msgid "Browse for file"
+msgstr "Søg efter fil"
+
+#: id:1034
+msgid "Submenu"
+msgstr "Undermenu"
+
+#: id:1035
+msgid "Enable submenu buttons"
+msgstr "Aktiver knapper til undermenuer"
+
+#: id:1036
+msgid "Favourites"
+msgstr "Favoritter"
+
+#: id:1037
+msgid "Video Add-ons"
+msgstr "Video-plugins"
+
+#: id:1038
+msgid "Music Add-ons"
+msgstr "Musik-plugins"
+
+#: id:1039
+msgid "Picture Add-ons"
+msgstr "Billede-plugins"
+
+#: id:1040
+msgid "Loading directory"
+msgstr "Indlæser mappe"
+
+#: id:1041
+msgid "Retrieved %i items"
+msgstr "Hentede %i objekter"
+
+#: id:1042
+msgid "Retrieved %i of %i items"
+msgstr "Hentede %i af %i objekter"
+
+#: id:1043
+msgid "Program Add-ons"
+msgstr "Program-plugins"
+
+#: id:1044
+msgid "Set plugin thumb"
+msgstr "Vælg ikon til plugin"
+
+#: id:1045
+msgid "Add-on settings"
+msgstr "Indstillinger til plugins"
+
+#: id:1046
+msgid "Access points"
+msgstr "Adgangspunkt"
+
+#: id:1047
+msgid "Other..."
+msgstr "Andet..."
+
+#: id:1048
+msgid "- Username"
+msgstr "- Brugernavn"
+
+#: id:1049
+msgid "Script settings"
+msgstr "Indstillinger til skript"
+
+#: id:1050
+msgid "Singles"
+msgstr "Singler"
+
+#: id:1051
+msgid "Enter web address"
+msgstr "Indtast internet adresse"
+
+#: id:1200
+msgid "SMB client"
+msgstr "SMB-klient"
+
+#: id:1202
+msgid "Workgroup"
+msgstr "Arbejdsgruppe"
+
+#: id:1203
+msgid "Default username"
+msgstr "Standard brugernavn"
+
+#: id:1204
+msgid "Default password"
+msgstr "Standard adgangskode"
+
+#: id:1207
+msgid "WINS server"
+msgstr "WINS-server"
+
+#: id:1208
+msgid "Mount SMB shares"
+msgstr "Tilkobl SMB-delinger"
+
+#: id:1210
+msgctxt "Auto context with id 1210"
+msgid "Remove"
+msgstr "Fjern"
+
+#: id:1211
+msgctxt "Auto context with id 1211"
+msgid "Music"
+msgstr "Musik"
+
+#: id:1212
+msgctxt "Auto context with id 1212"
+msgid "Video"
+msgstr "Video"
+
+#: id:1213
+msgctxt "Auto context with id 1213"
+msgid "Pictures"
+msgstr "Billeder"
+
+#: id:1214
+msgctxt "Auto context with id 1214"
+msgid "Files"
+msgstr "Filer"
+
+#: id:1215
+msgctxt "Auto context with id 1215"
+msgid "Music & video"
+msgstr "Musik og video"
+
+#: id:1216
+msgid "Music & pictures"
+msgstr "Musik og billeder"
+
+#: id:1217
+msgid "Music & files"
+msgstr "Musik og filer"
+
+#: id:1218
+msgid "Video & pictures"
+msgstr "Video og billeder"
+
+#: id:1219
+msgid "Video & files"
+msgstr "Video og filer"
+
+#: id:1220
+msgid "Pictures & files"
+msgstr "Billeder og filer"
+
+#: id:1221
+msgid "Music & video & pictures"
+msgstr "Musik og video og billeder"
+
+#: id:1222
+msgid "Music & video & pictures & files"
+msgstr "Musik og video og billeder og filer"
+
+#: id:1223
+msgctxt "Auto context with id 1223"
+msgid "Disabled"
+msgstr "Slået fra"
+
+#: id:1226
+msgid "Files & music & video"
+msgstr "Filer og musik og video"
+
+#: id:1227
+msgid "Files & pictures & music"
+msgstr "Filer og billeder og musik"
+
+#: id:1228
+msgid "Files & pictures & video"
+msgstr "Filer og billeder og video"
+
+#: id:1229
+msgid "Music & programs"
+msgstr "Musik og programmer"
+
+#: id:1230
+msgid "Video & programs"
+msgstr "Video og programmer"
+
+#: id:1231
+msgid "Pictures & programs"
+msgstr "Billeder og programmer"
+
+#: id:1232
+msgid "Music & video & pictures & programs"
+msgstr "Musik og video og billeder og programmer"
+
+#: id:1233
+msgid "Programs & video & music"
+msgstr "Programmer og video og musik"
+
+#: id:1234
+msgid "Programs & pictures & music"
+msgstr "Programmer og billeder og musik"
+
+#: id:1235
+msgid "Programs & pictures & video"
+msgstr "Programmer og billeder og video"
+
+#: id:1250
+msgid "Auto-detection"
+msgstr "Autodetektering"
+
+#: id:1251
+msgid "Auto-detect system"
+msgstr "Autodetekter systemer"
+
+#: id:1252
+msgid "Nickname"
+msgstr "Kaldenavn"
+
+#: id:1254
+msgid "Ask to connect"
+msgstr "Spørg om der skal forbindes"
+
+#: id:1255
+msgid "Send FTP user and password"
+msgstr "Send FTP-brugernavn og -adgangskode"
+
+#: id:1256
+msgid "Ping interval"
+msgstr "Interval mellem ping"
+
+#: id:1257
+msgid "Would you like to connect to the auto-detected system?"
+msgstr "Ønsker du at forbinde til det autodetekterede system?"
+
+#: id:1259
+msgid "Zeroconf"
+msgstr ""
+
+#: id:1260
+msgid "Announce these services to other systems via Zeroconf"
+msgstr "Annoncer disse tjenester til andre systemer via Zeroconf"
+
+#: id:1270
+msgid "Allow XBMC to receive AirPlay content"
+msgstr ""
+
+#: id:1271
+msgid "Device name"
+msgstr ""
+
+#: id:1272
+msgid "- Use password protection"
+msgstr ""
+
+#: id:1273
+msgid "AirPlay"
+msgstr ""
+
+#: id:1300
+msgid "Custom audio device"
+msgstr "Særlig lydenhed"
+
+#: id:1301
+msgid "Custom passthrough device"
+msgstr "Særlig lydgennemgangsenhed"
+
+#: id:1396
+msgid "Drifting"
+msgstr "omskifteligt"
+
+#: id:1397
+msgid "and"
+msgstr "og"
+
+#: id:1398
+msgid "Freezing"
+msgstr "fryser"
+
+#: id:1399
+msgid "Late"
+msgstr "sent"
+
+#: id:1400
+msgid "Isolated"
+msgstr "isoleret"
+
+#: id:1401
+msgid "Thundershowers"
+msgstr "skybrud"
+
+#: id:1402
+msgid "Thunder"
+msgstr "torden"
+
+#: id:1403
+msgctxt "Auto context with id 1403"
+msgid "Sun"
+msgstr "sol"
+
+#: id:1404
+msgid "Heavy"
+msgstr "kraftig"
+
+#: id:1405
+msgid "in"
+msgstr "er"
+
+#: id:1406
+msgid "the"
+msgstr "i"
+
+#: id:1407
+msgid "Vicinity"
+msgstr "nærheden"
+
+#: id:1408
+msgid "Ice"
+msgstr "is"
+
+#: id:1409
+msgid "Crystals"
+msgstr "-krystaller"
+
+#: id:1410
+msgid "Calm"
+msgstr "stille"
+
+#: id:1411
+msgid "with"
+msgstr "med"
+
+#: id:1412
+msgid "windy"
+msgstr "blæsende"
+
+#: id:1413
+msgid "drizzle"
+msgstr "finregn"
+
+#: id:1414
+msgid "Thunderstorm"
+msgstr "uvejr"
+
+#: id:1415
+msgid "Drizzle"
+msgstr "støvregn"
+
+#: id:1416
+msgid "Foggy"
+msgstr "tåget"
+
+#: id:1417
+msgid "Grains"
+msgstr "Korn"
+
+#: id:1418
+msgid "T-Storms"
+msgstr "Tordenvejr"
+
+#: id:1419
+msgid "T-Showers"
+msgstr "Tordenbyger"
+
+#: id:1420
+msgid "Moderate"
+msgstr ""
+
+#: id:1421
+msgid "Very High"
+msgstr ""
+
+#: id:1422
+msgid "Windy"
+msgstr ""
+
+#: id:1423
+msgid "Mist"
+msgstr ""
+
+#: id:1450
+msgid "Put display to sleep when idle"
+msgstr "Sæt skærm i standby ved inaktivitet"
+
+#: id:2050
+msgid "Runtime"
+msgstr "Spilletid"
+
+#: id:2100
+msgid "Script failed! : %s"
+msgstr "Skript-fejl! : %s"
+
+#: id:2101
+msgid "Newer version needed - See log"
+msgstr "Nyere version nødvendig - Se log"
+
+#: id:4501
+msgid "Enable LCD/VFD"
+msgstr "Aktiver LCD/VFD"
+
+#: id:10000
+msgid "Home"
+msgstr "Forside"
+
+#: id:10001
+msgctxt "Auto context with id 10001"
+msgid "Programs"
+msgstr "Programmer"
+
+#: id:10002
+msgctxt "Auto context with id 10002"
+msgid "Pictures"
+msgstr "Billeder"
+
+#: id:10003
+msgctxt "Auto context with id 10003"
+msgid "File manager"
+msgstr "Filer"
+
+#: id:10004
+msgctxt "Auto context with id 10004"
+msgid "Settings"
+msgstr "Indstillinger"
+
+#: id:10005
+msgctxt "Auto context with id 10005"
+msgid "Music"
+msgstr "Musik"
+
+#: id:10006
+msgctxt "Auto context with id 10006"
+msgid "Videos"
+msgstr "Film"
+
+#: id:10007
+msgid "System information"
+msgstr "Systemstatus"
+
+#: id:10008
+msgid "Settings - General"
+msgstr "Indstillinger - Generelt"
+
+#: id:10009
+msgid "Settings - Screen"
+msgstr "Indstillinger - Skærm"
+
+#: id:10010
+msgid "Settings - Appearance - GUI Calibration"
+msgstr "Indstillinger - Visning - Kalibrering af brugerflade"
+
+#: id:10011
+msgid "Settings - Videos - Screen Calibration"
+msgstr "Indstillinger - Videoer - Skærmkalibrering"
+
+#: id:10012
+msgid "Settings - Pictures"
+msgstr "Indstillinger - Billeder"
+
+#: id:10013
+msgid "Settings - Programs"
+msgstr "Indstillinger - Programmer"
+
+#: id:10014
+msgid "Settings - Weather"
+msgstr "Indstillinger - Vejr"
+
+#: id:10015
+msgid "Settings - Music"
+msgstr "Indstillinger - Musik"
+
+#: id:10016
+msgid "Settings - System"
+msgstr "Indstillinger - System"
+
+#: id:10017
+msgid "Settings - Videos"
+msgstr "Indstillinger - Videoer"
+
+#: id:10018
+msgid "Settings - Network"
+msgstr "Indstillinger - Netværk"
+
+#: id:10019
+msgid "Settings - Appearance"
+msgstr "Indstillinger - Visning"
+
+#: id:10020
+msgctxt "Auto context with id 10020"
+msgid "Scripts"
+msgstr "Makroer"
+
+#: id:10021
+msgid "Web Browser"
+msgstr "Webbrowser"
+
+#: id:10025
+msgctxt "Auto context with id 10025"
+msgid "Videos"
+msgstr ""
+
+#: id:10028
+msgid "Videos/Playlist"
+msgstr "Film/afspilningsliste"
+
+#: id:10029
+msgctxt "Auto context with id 10029"
+msgid "Login screen"
+msgstr ""
+
+#: id:10034
+msgid "Settings - Profiles"
+msgstr "Indstillinger - Profiler"
+
+#: id:10040
+msgid "Addon browser"
+msgstr ""
+
+#: id:10100
+msgid "Yes/No dialog"
+msgstr "Ja/nej-dialog"
+
+#: id:10101
+msgid "Progress dialog"
+msgstr "Fremskridtdialog"
+
+#: id:10210
+msgid "Looking for subtitles..."
+msgstr "Leder efter undertekster..."
+
+#: id:10211
+msgid "Looking for or caching subtitles..."
+msgstr "Søger eller mellemlagrer undertekster..."
+
+#: id:10212
+msgid "terminating"
+msgstr "afbryder"
+
+#: id:10213
+msgid "buffering"
+msgstr "mellemlagrer"
+
+#: id:10214
+msgid "Opening stream"
+msgstr "Åbner datastrøm"
+
+#: id:10500
+msgid "Music/Playlist"
+msgstr "Musik/afspilningsliste"
+
+#: id:10501
+msgid "Music/Files"
+msgstr "Musik/filer"
+
+#: id:10502
+msgid "Music/Library"
+msgstr "Musik/database"
+
+#: id:10503
+msgid "Playlist editor"
+msgstr "Afspilningslisteredigering"
+
+#: id:10504
+msgid "Top 100 songs"
+msgstr "Top 100 sange"
+
+#: id:10505
+msgid "Top 100 albums"
+msgstr "Top 100 album"
+
+#: id:10506
+msgctxt "Auto context with id 10506"
+msgid "Programs"
+msgstr "Programmer"
+
+#: id:10507
+msgid "Configuration"
+msgstr "Konfiguration"
+
+#: id:10508
+msgid "Weather forecast"
+msgstr "Vejrudsigt"
+
+#: id:10509
+msgid "Network gaming"
+msgstr "Netværksspil"
+
+#: id:10510
+msgid "Extensions"
+msgstr "Udvidelser"
+
+#: id:10511
+msgctxt "Auto context with id 10511"
+msgid "System info"
+msgstr "Systeminfo"
+
+#: id:10516
+msgid "Music - Library"
+msgstr "Musik - Database"
+
+#: id:10517
+msgid "Now Playing - Music"
+msgstr "Musik - Afspiller nu"
+
+#: id:10522
+msgid "Now Playing - Videos"
+msgstr "Film - Afspiller nu"
+
+#: id:10523
+msgid "Album info"
+msgstr "Albuminfo"
+
+#: id:10524
+msgid "Movie info"
+msgstr "Filminfo"
+
+#: id:12000
+msgid "Select dialog"
+msgstr "Vælg dialog"
+
+#: id:12001
+msgid "Music/Info"
+msgstr "Musik/Info"
+
+#: id:12002
+msgid "Dialog OK"
+msgstr "Dialog OK"
+
+#: id:12003
+msgid "Videos/Info"
+msgstr "Film/info"
+
+#: id:12004
+msgid "Scripts/Info"
+msgstr "Makroer/info"
+
+#: id:12005
+msgid "Fullscreen video"
+msgstr "Fuldskærmsfilm"
+
+#: id:12006
+msgid "Audio visualization"
+msgstr "Lydvisualisering"
+
+#: id:12008
+msgid "File stacking dialog"
+msgstr "Stakningsdialog"
+
+#: id:12009
+msgid "Rebuild index..."
+msgstr "Genskab indeks..."
+
+#: id:12010
+msgid "Return to music window"
+msgstr "Tilbage til Musik"
+
+#: id:12011
+msgid "Return to videos window"
+msgstr "Tilbage til Videoer"
+
+#: id:12021
+msgid "Start from beginning"
+msgstr "Start fra begyndelsen"
+
+#: id:12022
+msgid "Resume from %s"
+msgstr "Fortsæt fra %s"
+
+#: id:12310
+msgid "0"
+msgstr "0"
+
+#: id:12311
+msgid "1"
+msgstr "1"
+
+#: id:12312
+msgid "2"
+msgstr "2"
+
+#: id:12313
+msgid "3"
+msgstr "3"
+
+#: id:12314
+msgid "4"
+msgstr "4"
+
+#: id:12315
+msgid "5"
+msgstr "5"
+
+#: id:12316
+msgid "6"
+msgstr "6"
+
+#: id:12317
+msgid "7"
+msgstr "7"
+
+#: id:12318
+msgid "8"
+msgstr "8"
+
+#: id:12319
+msgid "9"
+msgstr "9"
+
+#: id:12320
+msgid "c"
+msgstr "c"
+
+#: id:12321
+msgid "Ok"
+msgstr "ok"
+
+#: id:12322
+msgid "*"
+msgstr "*"
+
+#: id:12325
+msgid "Locked! Enter code..."
+msgstr "Låst! Indtast adgangskode..."
+
+#: id:12326
+msgid "Enter password"
+msgstr "Indtast adgangskode"
+
+#: id:12327
+msgid "Enter master code"
+msgstr "Indtast hovedadgangskode"
+
+#: id:12328
+msgid "Enter unlock code"
+msgstr "Indtast oplåsningskode"
+
+#: id:12329
+msgid "or press C to cancel"
+msgstr "eller tryk C for at annullere"
+
+#: id:12330
+msgid "Enter gamepad button combo and"
+msgstr "Indtast knapkombination på gamepad og"
+
+#: id:12331
+msgid "press OK, or Back to cancel"
+msgstr "vælg Start, eller Tilbage for at annullere"
+
+#: id:12332
+msgid "Set lock"
+msgstr "Sæt lås"
+
+#: id:12333
+msgid "Unlock"
+msgstr "Lås op"
+
+#: id:12334
+msgid "Reset lock"
+msgstr "Nulstil lås"
+
+#: id:12335
+msgid "Remove lock"
+msgstr "Fjern lås"
+
+#: id:12337
+msgid "Numeric password"
+msgstr "Numerisk adgangskode"
+
+#: id:12338
+msgid "Gamepad button combo"
+msgstr "Gamepad-knapkombination"
+
+#: id:12339
+msgid "Full-text password"
+msgstr "Tekst-adgangskode"
+
+#: id:12340
+msgid "Enter new password"
+msgstr "Indtast ny adgangskode"
+
+#: id:12341
+msgid "Re-Enter new password"
+msgstr "Indtast ny adgangskode igen"
+
+#: id:12342
+msgid "Incorrect password,"
+msgstr "Ugyldig adgangskode,"
+
+#: id:12343
+msgid "retries left"
+msgstr "forsøg tilbage"
+
+#: id:12344
+msgid "Passwords entered did not match."
+msgstr "De indtastede adgangskoder matchede ikke."
+
+#: id:12345
+msgid "Access denied"
+msgstr "Adgang nægtet"
+
+#: id:12346
+msgid "Password retry limit exceeded."
+msgstr "Du har ikke flere forsøg tilbage."
+
+#: id:12347
+msgid "The system will now shut off."
+msgstr "Systemet slukkes nu."
+
+#: id:12348
+msgid "Item locked"
+msgstr "Låst"
+
+#: id:12353
+msgid "Reactivate lock"
+msgstr "Genaktiver lås"
+
+#: id:12356
+msgid "Change lock"
+msgstr "Ændr lås"
+
+#: id:12357
+msgid "Source lock"
+msgstr "Kilde-lås"
+
+#: id:12358
+msgid "Password entry was blank. Try again."
+msgstr "Adgangskode var blank. Prøv igen."
+
+#: id:12360
+msgid "Master lock"
+msgstr "Hovedlås"
+
+#: id:12362
+msgid "Shutdown system if Master Lock retries exceeded"
+msgstr "Sluk systemet ved for mange fejl ved indtastning af adgangskode"
+
+#: id:12367
+msgid "Master code is not valid"
+msgstr "Hovedkode er ugyldig"
+
+#: id:12368
+msgid "Please enter a valid master code"
+msgstr "Indtast en gyldig hovedadgangskode"
+
+#: id:12373
+msgid "Settings & file manager"
+msgstr "Indstillinger og filhåndtering"
+
+#: id:12376
+msgid "Set as default for all movies"
+msgstr "Sæt som standard for alle film"
+
+#: id:12377
+msgid "This will reset any previously saved values"
+msgstr "Dette vil nulstille tidligere gemte værdier"
+
+#: id:12378
+msgid "Amount of time to display each image"
+msgstr "Hvert billede vises i"
+
+#: id:12379
+msgid "Use pan and zoom effects"
+msgstr "Brug pan- og zoom-effekter"
+
+#: id:12383
+msgid "12 hour clock"
+msgstr "12-timers ur"
+
+#: id:12384
+msgid "24 hour clock"
+msgstr "24-timers ur"
+
+#: id:12385
+msgid "Day/Month"
+msgstr "Dag/Måned"
+
+#: id:12386
+msgid "Month/Day"
+msgstr "Måned/Dag"
+
+#: id:12390
+msgid "System uptime"
+msgstr "Systemets oppetid"
+
+#: id:12391
+msgid "Minutes"
+msgstr "Minutter"
+
+#: id:12392
+msgid "Hours"
+msgstr "Timer"
+
+#: id:12393
+msgid "Days"
+msgstr "Dage"
+
+#: id:12394
+msgid "Total uptime"
+msgstr "Samlet oppetid"
+
+#: id:12395
+msgid "Battery level"
+msgstr ""
+
+#: id:12600
+msgctxt "Auto context with id 12600"
+msgid "Weather"
+msgstr "Vejret"
+
+#: id:12900
+msgctxt "Auto context with id 12900"
+msgid "Screensaver"
+msgstr "Pauseskærm"
+
+#: id:12901
+msgid "Fullscreen OSD"
+msgstr "Fuldskærms OSD"
+
+#: id:13000
+msgid "System"
+msgstr "System"
+
+#: id:13001
+msgid "Immediate HD spindown"
+msgstr "Spin harddisken ned med det samme"
+
+#: id:13002
+msgid "Video only"
+msgstr "Kun video"
+
+#: id:13003
+msgid "- Delay"
+msgstr "- Forsinkelse"
+
+#: id:13004
+msgid "- Minimum file duration"
+msgstr "- Minimum fillængde"
+
+#: id:13005
+msgid "Shutdown"
+msgstr "Sluk"
+
+#: id:13008
+msgid "Shutdown function"
+msgstr "Nedlukningsmetode"
+
+#: id:13009
+msgid "Quit"
+msgstr "Afslut"
+
+#: id:13010
+msgid "Hibernate"
+msgstr "Gå i dvale"
+
+#: id:13011
+msgid "Suspend"
+msgstr "Gå i standby"
+
+#: id:13012
+msgid "Exit"
+msgstr "Afslut"
+
+#: id:13013
+msgid "Reboot"
+msgstr "Genstart"
+
+#: id:13014
+msgid "Minimize"
+msgstr "Minimer"
+
+#: id:13015
+msgid "Power button action"
+msgstr "Slukknappens funktion"
+
+#: id:13016
+msgid "Power off System"
+msgstr ""
+
+#: id:13020
+msgid "Is another session active, perhaps over ssh?"
+msgstr "Er en anden session aktiv - måske over SSH?"
+
+#: id:13021
+msgid "Mounted removable harddrive"
+msgstr "Tilkoblet flytbar harddisk"
+
+#: id:13022
+msgid "Unsafe device removal"
+msgstr "Usikker fjernelse af enhed"
+
+#: id:13023
+msgid "Successfully removed device"
+msgstr "Fjernede enhed med succes"
+
+#: id:13024
+msgid "Joystick plugged"
+msgstr "Joystick tilsluttet"
+
+#: id:13025
+msgid "Joystick unplugged"
+msgstr "Joystick taget fra"
+
+#: id:13050
+msgid "Running low on battery"
+msgstr "Batteriet er ved at løbe tør"
+
+#: id:13100
+msgid "Flicker filter"
+msgstr "Flimmerfilter"
+
+#: id:13101
+msgid "Let driver choose (requires restart)"
+msgstr "Lad driveren bestemme (kræver genstart)"
+
+#: id:13105
+msgid "Vertical blank sync"
+msgstr "Synkroniser på Vertical Blank"
+
+#: id:13106
+msgctxt "Auto context with id 13106"
+msgid "Disabled"
+msgstr "Deaktiveret"
+
+#: id:13107
+msgid "Enabled during video playback"
+msgstr "Aktiver under videoafspilning"
+
+#: id:13108
+msgctxt "Auto context with id 13108"
+msgid "Always enabled"
+msgstr "Altid aktiveret"
+
+#: id:13109
+msgid "Test & apply resolution"
+msgstr "Afprøv og anvend opløsning"
+
+#: id:13110
+msgid "Save resolution?"
+msgstr "Gem opløsning?"
+
+#: id:13111
+msgid "Would you like to keep this resolution?"
+msgstr "Vil du gemme denne opløsning?"
+
+#: id:13112
+msgid "High quality upscaling"
+msgstr "Højkvalitets opskalering"
+
+#: id:13113
+msgctxt "Auto context with id 13113"
+msgid "Disabled"
+msgstr "Deaktiveret"
+
+#: id:13114
+msgid "Enabled for SD content"
+msgstr "Aktiveret for SD-indhold"
+
+#: id:13115
+msgctxt "Auto context with id 13115"
+msgid "Always enabled"
+msgstr "Altid aktiveret"
+
+#: id:13116
+msgid "Upscaling method"
+msgstr "Metode til opskalering"
+
+#: id:13117
+msgctxt "Auto context with id 13117"
+msgid "Bicubic"
+msgstr "Bikubisk"
+
+#: id:13118
+msgid "Lanczos"
+msgstr "Lanczos"
+
+#: id:13119
+msgid "Sinc"
+msgstr "Sinc"
+
+#: id:13120
+msgctxt "Auto context with id 13120"
+msgid "VDPAU"
+msgstr "VDPAU"
+
+#: id:13121
+msgid "VDPAU HQ Upscaling level"
+msgstr "Opskaleringsniveau til VDPAU HQ"
+
+#: id:13122
+msgid "VDPAU Studio level color conversion"
+msgstr "VDPAU filmstudie-farvekonvertering"
+
+#: id:13130
+msgid "Blank other displays"
+msgstr "Sluk andre skærme"
+
+#: id:13131
+msgctxt "Auto context with id 13131"
+msgid "Disabled"
+msgstr "Deaktiveret"
+
+#: id:13132
+msgid "Blank displays"
+msgstr "Blank displays"
+
+#: id:13140
+msgid "Active connections detected!"
+msgstr "Der er fundet aktive forbindelser!"
+
+#: id:13141
+msgid "If you proceed, you might not be able to control XBMC"
+msgstr "Hvis du fortsætter, kan du måske ikke længere styre XBMC."
+
+#: id:13142
+msgid "any longer. Are you sure you want to stop the Event server?"
+msgstr "Er du sikker på at du vil stoppe hændelsesserveren?"
+
+#: id:13144
+msgid "Change Apple Remote mode?"
+msgstr "Skift tilstand for Apple-fjernbetjeningen?"
+
+#: id:13145
+msgid "If you are currently using the Apple Remote to control"
+msgstr "Hvis du lige nu bruger Apple-fjernbetjeningen til at styre"
+
+#: id:13146
+msgid "XBMC, changing this setting might affect your ability"
+msgstr "XBMC, så kan skift af denne indstillingen påvirke dine"
+
+#: id:13147
+msgid "to continue controlling it. Do you want to proceed?"
+msgstr "muligheder for at styre systemet. Vil du fortsætte?"
+
+#: id:13159
+msgid "Subnet mask"
+msgstr "Undernetmaske"
+
+#: id:13160
+msgid "Gateway"
+msgstr "Gateway"
+
+#: id:13161
+msgid "Primary DNS"
+msgstr "Primær DNS"
+
+#: id:13162
+msgid "Initialize failed"
+msgstr "Initialisering slog fejl"
+
+#: id:13170
+msgctxt "Auto context with id 13170"
+msgid "Never"
+msgstr "Aldrig"
+
+#: id:13171
+msgid "Immediately"
+msgstr "Med det samme"
+
+#: id:13172
+msgid "After %i secs"
+msgstr "Efter %i sekunder"
+
+#: id:13173
+msgid "HDD install date:"
+msgstr "Isat:"
+
+#: id:13174
+msgid "HDD power cycle count:"
+msgstr "Tændt antal gange:"
+
+#: id:13200
+msgid "Profiles"
+msgstr "Profiler"
+
+#: id:13201
+msgid "Delete profile '%s'?"
+msgstr "Slet profil '%s'?"
+
+#: id:13204
+msgid "Last loaded profile:"
+msgstr "Senest indlæste profil:"
+
+#: id:13205
+msgid "Unknown"
+msgstr "Ukendt"
+
+#: id:13206
+msgid "Overwrite"
+msgstr "Overskriv"
+
+#: id:13208
+msgid "Alarm clock"
+msgstr "Alarmur"
+
+#: id:13209
+msgid "Alarm clock interval (in minutes)"
+msgstr "Alarmur-interval (i minuter)"
+
+#: id:13210
+msgid "Started, alarm in %im"
+msgstr "Startede, alarm om %im"
+
+#: id:13211
+msgid "Alarm!"
+msgstr "Alarm!"
+
+#: id:13212
+msgid "Canceled with %im%is left"
+msgstr "Annulleret med %im%is tilbage"
+
+#: id:13213
+msgid "%2.0fm"
+msgstr ""
+
+#: id:13214
+msgid "%2.0fs"
+msgstr ""
+
+#: id:13249
+msgid "Search for subtitles in RARs"
+msgstr "Søg efter undertekster i RAR-filer"
+
+#: id:13250
+msgid "Browse for subtitle..."
+msgstr "Søg efter undertekster..."
+
+#: id:13251
+msgid "Move item"
+msgstr "Flyt"
+
+#: id:13252
+msgid "Move item here"
+msgstr "Flyt hertil"
+
+#: id:13253
+msgid "Cancel move"
+msgstr "Fortryd flytning"
+
+#: id:13270
+msgid "Hardware:"
+msgstr "Hardware:"
+
+#: id:13271
+msgid "CPU Usage:"
+msgstr "CPU-brug:"
+
+#: id:13274
+msgid "Connected, but no DNS is available."
+msgstr "Forbundet, men DNS er ikke tilgængelig."
+
+#: id:13275
+msgid "Hard Disk"
+msgstr "Harddisk"
+
+#: id:13276
+msgid "DVD-ROM"
+msgstr "DVD-ROM"
+
+#: id:13277
+msgctxt "Auto context with id 13277"
+msgid "Storage"
+msgstr "Lager"
+
+#: id:13278
+msgctxt "Auto context with id 13278"
+msgid "Default"
+msgstr "Standard"
+
+#: id:13279
+msgctxt "Auto context with id 13279"
+msgid "Network"
+msgstr "Netværk"
+
+#: id:13280
+msgctxt "Auto context with id 13280"
+msgid "Video"
+msgstr "Video"
+
+#: id:13281
+msgid "Hardware"
+msgstr "Hardware"
+
+#: id:13283
+msgid "Operating system:"
+msgstr "Operativsystem:"
+
+#: id:13284
+msgid "CPU speed:"
+msgstr "CPU-hastighed:"
+
+#: id:13286
+msgid "Video encoder:"
+msgstr "Video-encoder:"
+
+#: id:13287
+msgid "Screen resolution:"
+msgstr "Skærmopløsning:"
+
+#: id:13292
+msgid "A/V cable:"
+msgstr "A/V-kabel:"
+
+#: id:13294
+msgid "DVD region:"
+msgstr "DVD-region:"
+
+#: id:13295
+msgid "Internet:"
+msgstr "Internet:"
+
+#: id:13296
+msgctxt "Auto context with id 13296"
+msgid "Connected"
+msgstr "Forbundet"
+
+#: id:13297
+msgid "Not connected. Check network settings."
+msgstr "Ikke forbundet. Check netværksindstillinger."
+
+#: id:13299
+msgid "Target temperature"
+msgstr "Måltemperatur"
+
+#: id:13300
+msgid "Fan speed"
+msgstr "Blæserhastighed"
+
+#: id:13301
+msgid "Auto temperature control"
+msgstr "Automatisk temperaturkontrol"
+
+#: id:13302
+msgid "Fan speed override"
+msgstr "Gennemtving blæserhastighed"
+
+#: id:13303
+msgid "- Fonts"
+msgstr "- Skrifttyper"
+
+#: id:13304
+msgid "Enable flipping bi-directional strings"
+msgstr "Aktiver spejling af bi-direktionelle tekster"
+
+#: id:13305
+msgid "Show RSS news feeds"
+msgstr "Vis nyheder fra RSS"
+
+#: id:13306
+msgid "Show parent folder items"
+msgstr "Vis indhold fra øvre niveauer"
+
+#: id:13307
+msgid "Track naming template"
+msgstr "Navngivningsmønster"
+
+#: id:13308
+msgid "Do you wish to reboot your system"
+msgstr "Vil du genstarte dit system"
+
+#: id:13309
+msgid "instead of just XBMC?"
+msgstr "istedet for kun XBMC?"
+
+#: id:13310
+msgid "Zoom effect"
+msgstr "Zoom-effekt"
+
+#: id:13311
+msgid "Float effect"
+msgstr "Flyde-effekt"
+
+#: id:13312
+msgid "Black bar reduction"
+msgstr "Reducer sorte bjælker"
+
+#: id:13313
+msgid "Restart"
+msgstr "Genstart"
+
+#: id:13314
+msgid "Crossfade between songs"
+msgstr "Blandingsfunktion mellem sange"
+
+#: id:13315
+msgid "Regenerate thumbnails"
+msgstr "Gendan ikoner"
+
+#: id:13316
+msgid "Recursive thumbnails"
+msgstr "Rekursive ikoner"
+
+#: id:13317
+msgid "View slideshow"
+msgstr "Vis billedserie"
+
+#: id:13318
+msgid "Recursive slideshow"
+msgstr "Rekursiv billedserie"
+
+#: id:13319
+msgid "Randomize"
+msgstr "Tilfældig"
+
+#: id:13320
+msgid "Stereo"
+msgstr "Stereo"
+
+#: id:13321
+msgid "Left only"
+msgstr "Kun venstre"
+
+#: id:13322
+msgid "Right only"
+msgstr "Kun højre"
+
+#: id:13323
+msgid "Enable karaoke support"
+msgstr "Aktiver understøttelse af karaoke"
+
+#: id:13324
+msgid "Background transparency"
+msgstr "Baggrundsgennemsigtighed"
+
+#: id:13325
+msgid "Foreground transparency"
+msgstr "Forgrundsgennemsigtighed"
+
+#: id:13326
+msgid "A/V delay"
+msgstr "A/V-forsinkelse"
+
+#: id:13327
+msgid "Karaoke"
+msgstr "Karaoke"
+
+#: id:13328
+msgid "%s not found"
+msgstr "%s blev ikke fundet"
+
+#: id:13329
+msgid "Error opening %s"
+msgstr "Kunne ikke åbne %s"
+
+#: id:13330
+msgid "Unable to load %s"
+msgstr "Kunne ikke hente %s"
+
+#: id:13331
+msgid "Error: Out of memory"
+msgstr "Fejl: ikke nok hukommelse"
+
+#: id:13332
+msgid "Move up"
+msgstr "Flyt op"
+
+#: id:13333
+msgid "Move down"
+msgstr "Flyt ned"
+
+#: id:13334
+msgid "Edit label"
+msgstr "Rediger tekst"
+
+#: id:13335
+msgid "Make default"
+msgstr "Vælg som standard"
+
+#: id:13336
+msgid "Remove button"
+msgstr "Fjern knap"
+
+#: id:13340
+msgid "Leave as is"
+msgstr "Uændret"
+
+#: id:13341
+msgid "Green"
+msgstr "Grøn"
+
+#: id:13342
+msgid "Orange"
+msgstr "Orange"
+
+#: id:13343
+msgid "Red"
+msgstr "Rød"
+
+#: id:13344
+msgid "Cycle"
+msgstr "Skiftende"
+
+#: id:13345
+msgid "Switch LED off on playback"
+msgstr "Sluk LED under afspilning"
+
+#: id:13346
+msgctxt "Auto context with id 13346"
+msgid "Movie information"
+msgstr "Filmoplysninger"
+
+#: id:13347
+msgid "Queue item"
+msgstr "Tilføj til kø"
+
+#: id:13348
+msgid "Search IMDb..."
+msgstr "Søg på IMDb..."
+
+#: id:13349
+msgid "Scan for new content"
+msgstr "Søg efter nyt indhold"
+
+#: id:13350
+msgid "Now playing..."
+msgstr "Spiller nu..."
+
+#: id:13351
+msgctxt "Auto context with id 13351"
+msgid "Album information"
+msgstr "Albumoplysninger"
+
+#: id:13352
+msgid "Scan item to library"
+msgstr "Tilføj mappe til database"
+
+#: id:13353
+msgid "Stop scanning"
+msgstr "Stop gennemsøgning"
+
+#: id:13354
+msgctxt "Auto context with id 13354"
+msgid "Render method"
+msgstr "Render-metode"
+
+#: id:13355
+msgid "Low quality pixel shader"
+msgstr "Lavkvalitets Pixel Shader"
+
+#: id:13356
+msgid "Hardware overlays"
+msgstr "Hardware Overlays"
+
+#: id:13357
+msgid "High quality pixel shader"
+msgstr "Højkvalitets Pixel Shader"
+
+#: id:13358
+msgid "Play item"
+msgstr "Afspil"
+
+#: id:13359
+msgid "Set artist thumb"
+msgstr "Vælg ikon til kunstner"
+
+#: id:13360
+msgid "Automatically generate thumbnails"
+msgstr "Lav ikoner automatisk"
+
+#: id:13361
+msgid "Enable voice"
+msgstr "Aktiver stemme"
+
+#: id:13375
+msgid "Enable device"
+msgstr "Tænd enhed"
+
+#: id:13376
+msgid "Volume"
+msgstr "Lydstyrke"
+
+#: id:13377
+msgid "Default view mode"
+msgstr "Standard visning"
+
+#: id:13378
+msgid "Default brightness"
+msgstr "Standard lysstyrke"
+
+#: id:13379
+msgid "Default contrast"
+msgstr "Standard kontrast"
+
+#: id:13380
+msgid "Default gamma"
+msgstr "Standard gamma"
+
+#: id:13381
+msgid "Resume video"
+msgstr "Fortsæt video"
+
+#: id:13382
+msgid "Voice mask - Port 1"
+msgstr "Stemmemaske - Port 1"
+
+#: id:13383
+msgid "Voice mask - Port 2"
+msgstr "Stemmemaske - Port 2"
+
+#: id:13384
+msgid "Voice mask - Port 3"
+msgstr "Stemmemaske - Port 3"
+
+#: id:13385
+msgid "Voice mask - Port 4"
+msgstr "Stemmemaske - Port 4"
+
+#: id:13386
+msgid "Use time based seeking"
+msgstr "Brug tidsbaseret søgning"
+
+#: id:13387
+msgid "Track naming template - right"
+msgstr "Spornavngivningsmønster - højre"
+
+#: id:13388
+msgid "Preset"
+msgstr "Standard"
+
+#: id:13389
+msgid "There are no presets available\nfor this visualization"
+msgstr "Der er ingen presets tilgængelige\ntil denne visualisering"
+
+#: id:13390
+msgid "There are no settings available\nfor this visualization"
+msgstr "Der er ingen indstillinger tilgængelige\ntil denne visualisering"
+
+#: id:13391
+msgid "Eject/Load"
+msgstr "Åben/Start"
+
+#: id:13392
+msgid "Use visualization if playing audio"
+msgstr "Brug visualisering ved musikafspilning"
+
+#: id:13393
+msgid "Calculate size"
+msgstr "Beregn størrelse"
+
+#: id:13394
+msgid "Calculating folder size"
+msgstr "Beregner mappestørrelse"
+
+#: id:13395
+msgid "Video settings"
+msgstr "Videoindstillinger"
+
+#: id:13396
+msgid "Audio and subtitle settings"
+msgstr "Lyd- og undertekstindstillinger"
+
+#: id:13397
+msgid "Enable subtitles"
+msgstr "Slå undertekster til"
+
+#: id:13398
+msgctxt "Auto context with id 13398"
+msgid "Shortcuts"
+msgstr "Genveje"
+
+#: id:13399
+msgid "Ignore articles when sorting (e.g. \"the\")"
+msgstr "Ignorer \"The\" mm. ved sortering"
+
+#: id:13400
+msgid "Crossfade between songs on the same album"
+msgstr "Blandingsfunktion ved sange på samme album"
+
+#: id:13401
+msgid "Browse for %s"
+msgstr "Gennemsøg for %s"
+
+#: id:13402
+msgid "Show track position"
+msgstr "Vis sporposition"
+
+#: id:13403
+msgid "Clear default"
+msgstr "Ryd standard"
+
+#: id:13404
+msgid "Resume"
+msgstr "Fortsæt"
+
+#: id:13405
+msgid "Get thumb"
+msgstr "Hent ikon"
+
+#: id:13406
+msgid "Picture information"
+msgstr "Informationer om billede"
+
+#: id:13407
+msgid "%s presets"
+msgstr "%s-standarder"
+
+#: id:13408
+msgid "(IMDb user rating)"
+msgstr "(IMDb brugerbedømmelse)"
+
+#: id:13409
+msgid "Top 250"
+msgstr "Top 250"
+
+#: id:13410
+msgid "Tune in on Last.fm"
+msgstr "Stil ind på Last.fm"
+
+#: id:13411
+msgid "Minimum fan speed"
+msgstr "Mindste blæserhastighed"
+
+#: id:13412
+msgid "Play from here"
+msgstr ""
+
+#: id:13413
+msgid "Downloading"
+msgstr "Henter"
+
+#: id:13414
+msgid "Include artists who appear only on compilations"
+msgstr "Vis kunstnere som kun er med på opsamlingsalbum"
+
+#: id:13415
+msgctxt "Auto context with id 13415"
+msgid "Render method"
+msgstr "Renderingsmetode"
+
+#: id:13416
+msgid "Auto detect"
+msgstr "Vælg automatisk"
+
+#: id:13417
+msgid "Basic shaders (ARB)"
+msgstr "Simple shadere (ARB)"
+
+#: id:13418
+msgid "Advanced shaders (GLSL)"
+msgstr "Avancerede shadere (GLSL)"
+
+#: id:13419
+msgid "Software"
+msgstr "Software"
+
+#: id:13420
+msgid "Remove safely"
+msgstr "Fjern sikkert"
+
+#: id:13421
+msgctxt "Auto context with id 13421"
+msgid "VDPAU"
+msgstr "VDPAU"
+
+#: id:13422
+msgid "Start slideshow here"
+msgstr "Start billedeserie her"
+
+#: id:13423
+msgid "Remember for this path"
+msgstr "Husk for denne sti"
+
+#: id:13424
+msgid "Use pixel buffer objects"
+msgstr "Brug pixelbuffer-objekter"
+
+#: id:13425
+msgid "Allow hardware acceleration (VDPAU)"
+msgstr "Tillad hardware acceleration (VDPAU)"
+
+#: id:13426
+msgid "Allow hardware acceleration (VAAPI)"
+msgstr "Tillad hardware acceleration (VAAPI)"
+
+#: id:13427
+msgid "Allow hardware acceleration (DXVA2)"
+msgstr "Tillad hardware acceleration (DXVA2)"
+
+#: id:13428
+msgid "Allow hardware acceleration (CrystalHD)"
+msgstr "Tillad hardware acceleration (CrystalHD)"
+
+#: id:13429
+msgid "Allow hardware acceleration (VDADecoder)"
+msgstr "Tillad hardware acceleration (VDADecoder)"
+
+#: id:13430
+msgid "Allow hardware acceleration (OpenMax)"
+msgstr "Tillad hardware acceleration (OpenMax)"
+
+#: id:13431
+msgid "Pixel Shaders"
+msgstr ""
+
+#: id:13432
+msgid "Allow hardware acceleration (VideoToolbox)"
+msgstr ""
+
+#: id:13500
+msgid "A/V sync method"
+msgstr "A/V-synk.metode"
+
+#: id:13501
+msgid "Audio clock"
+msgstr "Lydtiming"
+
+#: id:13502
+msgid "Video clock (Drop/Dupe audio)"
+msgstr "Videotiming (tabt/dobbelt lyd)"
+
+#: id:13503
+msgid "Video clock (Resample audio)"
+msgstr "Videotiming (Resampling af lyd)"
+
+#: id:13504
+msgid "Maximum resample amount (%)"
+msgstr "Max niveau af resampling (%)"
+
+#: id:13505
+msgid "Resample quality"
+msgstr "Resamplingskvalitet"
+
+#: id:13506
+msgid "Low(fast)"
+msgstr "Lav (hurtig)"
+
+#: id:13507
+msgctxt "Auto context with id 13507"
+msgid "Medium"
+msgstr "Medium"
+
+#: id:13508
+msgctxt "Auto context with id 13508"
+msgid "High"
+msgstr "Høj"
+
+#: id:13509
+msgid "Really high(slow!)"
+msgstr "Meget høj (langsom!)"
+
+#: id:13510
+msgid "Sync playback to display"
+msgstr "Synk afspilning til skærmen"
+
+#: id:13550
+msgid "Pause during refresh rate change"
+msgstr ""
+
+#: id:13551
+msgctxt "Auto context with id 13551"
+msgid "Off"
+msgstr ""
+
+#: id:13552
+msgid "%.1f Second"
+msgstr ""
+
+#: id:13553
+msgid "%.1f Seconds"
+msgstr ""
+
+#: id:13600
+msgid "Apple remote"
+msgstr "Apple-fjernbetjening"
+
+#: id:13602
+msgid "Allow start of XBMC using the remote"
+msgstr "Tillad start af XBMC med fjernbetjeningen"
+
+#: id:13603
+msgid "Sequence delay time"
+msgstr "Sekvensforsinkelse"
+
+#: id:13610
+msgctxt "Auto context with id 13610"
+msgid "Disabled"
+msgstr "Deaktiveret"
+
+#: id:13611
+msgctxt "Auto context with id 13611"
+msgid "Standard"
+msgstr "Standard"
+
+#: id:13612
+msgid "Universal Remote"
+msgstr "Universalfjernbetjening"
+
+#: id:13613
+msgid "Multi Remote (Harmony)"
+msgstr "Universalfjernbetjening (Harmony)"
+
+#: id:13620
+msgid "Apple Remote Error"
+msgstr "Fejl ved Apple-fjernbetjeningen"
+
+#: id:13621
+msgid "Apple Remote support could be enabled."
+msgstr "Understøttelse af Apple-fjernbetjening kan ikke aktiveres."
+
+#: id:14000
+msgid "Stack"
+msgstr "Stakning"
+
+#: id:14001
+msgid "Unstack"
+msgstr "Ingen stakning"
+
+#: id:14003
+msgid "Downloading playlist file..."
+msgstr "Henter afspilningsliste..."
+
+#: id:14004
+msgid "Downloading streams list..."
+msgstr "Henter streamliste..."
+
+#: id:14005
+msgid "Parsing streams list..."
+msgstr "Behandler streamliste..."
+
+#: id:14006
+msgid "Downloading streams list failed"
+msgstr "Kunne ikke hente streamlisten"
+
+#: id:14007
+msgid "Downloading playlist file failed"
+msgstr "Kunne ikke hente afspilningslisten"
+
+#: id:14009
+msgid "Games directory"
+msgstr "Spilmappe"
+
+#: id:14010
+msgid "Auto switch to thumbs based on"
+msgstr "Skift automatisk til ikoner baseret på"
+
+#: id:14011
+msgid "Enable auto switching to thumbs view"
+msgstr "Skift automatisk til ikonvisning"
+
+#: id:14012
+msgid "- Use large icons"
+msgstr "- Brug store ikoner"
+
+#: id:14013
+msgid "- Switch based on"
+msgstr "- Skift baseret på"
+
+#: id:14014
+msgid "- Percentage"
+msgstr "- Procentvis"
+
+#: id:14015
+msgid "No files and at least one thumb"
+msgstr "Ingen filer og mindst et ikon"
+
+#: id:14016
+msgid "At least one file and thumb"
+msgstr "Mindst en fil og et ikon"
+
+#: id:14017
+msgid "Percentage of thumbs"
+msgstr "Procent af ikoner"
+
+#: id:14018
+msgid "View options"
+msgstr "Visning"
+
+#: id:14019
+msgid "Change area code 1"
+msgstr "Ændr by nr. 1"
+
+#: id:14020
+msgid "Change area code 2"
+msgstr "Ændr by nr. 2"
+
+#: id:14021
+msgid "Change area code 3"
+msgstr "Ændr by nr. 3"
+
+#: id:14022
+msgctxt "Auto context with id 14022"
+msgid "Library"
+msgstr "Database"
+
+#: id:14023
+msgid "No TV"
+msgstr "Intet TV"
+
+#: id:14024
+msgid "Enter the nearest large town"
+msgstr "Indtast den nærmeste større by"
+
+#: id:14025
+msgid "Video/Audio/DVD cache - Harddisk"
+msgstr "Video/Audio/DVD-mellemlager - Harddisk"
+
+#: id:14026
+msgid "Video cache - DVD-ROM"
+msgstr "Videomellemlager - DVD-ROM"
+
+#: id:14027
+msgctxt "Auto context with id 14027"
+msgid "- Local Network"
+msgstr "- Lokalt netværk"
+
+#: id:14028
+msgctxt "Auto context with id 14028"
+msgid "- Internet"
+msgstr "- Internet"
+
+#: id:14030
+msgid "Audio cache - DVD-ROM"
+msgstr "Lydmellemlager - DVD-ROM"
+
+#: id:14031
+msgctxt "Auto context with id 14031"
+msgid "- Local Network"
+msgstr "- Lokalt netværk"
+
+#: id:14032
+msgctxt "Auto context with id 14032"
+msgid "- Internet"
+msgstr "- Internet"
+
+#: id:14034
+msgid "DVD cache - DVD-ROM"
+msgstr "DVD-mellemlager - DVD-ROM"
+
+#: id:14035
+msgctxt "Auto context with id 14035"
+msgid "- Local Network"
+msgstr "- Lokalt netværk"
+
+#: id:14036
+msgctxt "Auto context with id 14036"
+msgid "Services"
+msgstr "Tjenester"
+
+#: id:14038
+msgid "Network settings changed"
+msgstr "Netværksindstillinger er ændret"
+
+#: id:14039
+msgid "XBMC requires to restart to change your"
+msgstr "XBMC kræver en genstart for at ændre"
+
+#: id:14040
+msgid "network setup. Would you like to restart now?"
+msgstr "netværkssetup'et. Vil du genstarte nu?"
+
+#: id:14041
+msgid "Internet connection bandwidth limitation"
+msgstr "Efterbehandling"
+
+#: id:14043
+msgid "- Shutdown while playing"
+msgstr "- Luk ned mens der afspilles"
+
+#: id:14044
+msgid "%i min"
+msgstr "%i min"
+
+#: id:14045
+msgid "%i sec"
+msgstr "%i sek"
+
+#: id:14046
+msgid "%i ms"
+msgstr "%i ms"
+
+#: id:14047
+msgid "%i %%"
+msgstr "%i %%"
+
+#: id:14048
+msgid "%i kbps"
+msgstr "%i kbps"
+
+#: id:14049
+msgid "%i kb"
+msgstr "%i kb"
+
+#: id:14050
+msgid "%i.0 dB"
+msgstr "%i.0 dB"
+
+#: id:14051
+msgid "Time format"
+msgstr "Tidsformat"
+
+#: id:14052
+msgid "Date format"
+msgstr "Datoformat"
+
+#: id:14053
+msgid "GUI filters"
+msgstr "GUI-filtre"
+
+#: id:14055
+msgid "Use background scanning"
+msgstr "Gennemsøg i baggrunden"
+
+#: id:14056
+msgid "Stop scan"
+msgstr "Stop gennemsøgning"
+
+#: id:14057
+msgid "Not possible while scanning for media info"
+msgstr "Ikke muligt mens der gennemsøges for medieinfo"
+
+#: id:14058
+msgid "Film grain effect"
+msgstr "Filmkornseffekt"
+
+#: id:14059
+msgid "Search for thumbnails on remote shares"
+msgstr "Søg efter ikoner på delte mapper"
+
+#: id:14060
+msgid "Unknown type cache - Internet"
+msgstr "Ukendt type mellemlager - Internet"
+
+#: id:14061
+msgctxt "Auto context with id 14061"
+msgid "Auto"
+msgstr "Auto"
+
+#: id:14062
+msgid "Enter username for"
+msgstr "Indtast brugernavn for"
+
+#: id:14063
+msgid "Date & time"
+msgstr "Dato og tid"
+
+#: id:14064
+msgid "Set date"
+msgstr "Indstil dato"
+
+#: id:14065
+msgid "Set time"
+msgstr "Indstil tid"
+
+#: id:14066
+msgid "Enter the time in 24 hour HH:MM format"
+msgstr "Indtast tiden i 24-timers format (TT:MM)"
+
+#: id:14067
+msgid "Enter the date in DD/MM/YYYY format"
+msgstr "Indtast datoen i formatet DD/MM/ÅÅÅÅ"
+
+#: id:14068
+msgid "Enter the IP address"
+msgstr "Indtast IP-adressen"
+
+#: id:14069
+msgid "Apply these settings now?"
+msgstr "Ønsker du at anvende disse instillinger nu?"
+
+#: id:14070
+msgid "Apply changes now"
+msgstr "Anvend ændringer nu"
+
+#: id:14071
+msgid "Allow file renaming and deletion"
+msgstr "Tillad fil-omdøbing og -sletning"
+
+#: id:14074
+msgid "Set timezone"
+msgstr "Vælg tidszone"
+
+#: id:14075
+msgid "Use daylight saving time"
+msgstr "Automatisk skift til sommertid"
+
+#: id:14076
+msgid "Add to favourites"
+msgstr "Tilføj til favoritter"
+
+#: id:14077
+msgid "Remove from favourites"
+msgstr "Fjern fra favoritter"
+
+#: id:14078
+msgctxt "Auto context with id 14078"
+msgid "- Colours"
+msgstr "- Farver"
+
+#: id:14079
+msgid "Timezone country"
+msgstr "Land i tidszonen"
+
+#: id:14080
+msgid "Timezone"
+msgstr "Tidszone"
+
+#: id:14081
+msgid "File lists"
+msgstr "Fil-liste"
+
+#: id:14082
+msgid "Show EXIF picture information"
+msgstr "Vis EXIF-billedeinformation"
+
+#: id:14083
+msgid "Use a fullscreen window rather than true fullscreen"
+msgstr "Brug fuldskærmsvindue fremfor ægte fuldskærm"
+
+#: id:14084
+msgid "Queue songs on selection"
+msgstr "Sæt sange i kø ved valg"
+
+#: id:14086
+msgid "Playback"
+msgstr "Afspil"
+
+#: id:14087
+msgid "DVDs"
+msgstr "DVD'er"
+
+#: id:14088
+msgid "Play DVDs automatically"
+msgstr "Afspil automatisk DVD'er"
+
+#: id:14089
+msgid "Font to use for text subtitles"
+msgstr "Skrifttype til undertekster"
+
+#: id:14090
+msgid "International"
+msgstr "International"
+
+#: id:14091
+msgid "Character set"
+msgstr "Tegnsæt"
+
+#: id:14092
+msgid "Debugging"
+msgstr "Fejllogning"
+
+#: id:14093
+msgid "Security"
+msgstr "Sikkerhed"
+
+#: id:14094
+msgid "Input devices"
+msgstr "Inputenheder"
+
+#: id:14095
+msgid "Power saving"
+msgstr "Strømstyring"
+
+#: id:14096
+msgid "Rip"
+msgstr ""
+
+#: id:14097
+msgid "Audio CD Insert Action"
+msgstr ""
+
+#: id:14098
+msgctxt "Auto context with id 14098"
+msgid "Play"
+msgstr ""
+
+#: id:14099
+msgid "Eject disc when CD ripping is complete"
+msgstr ""
+
+#: id:15015
+msgctxt "Auto context with id 15015"
+msgid "Remove"
+msgstr "Fjern"
+
+#: id:15016
+msgid "Games"
+msgstr "Spil"
+
+#: id:15019
+msgid "Add"
+msgstr "Tilføj"
+
+#: id:15052
+msgid "Password"
+msgstr "Adgangskode"
+
+#: id:15100
+msgctxt "Auto context with id 15100"
+msgid "Library"
+msgstr "Bibliotek"
+
+#: id:15101
+msgid "Database"
+msgstr "Database"
+
+#: id:15102
+msgid "* All albums"
+msgstr "* Alle album"
+
+#: id:15103
+msgid "* All artists"
+msgstr "* Alle kunstnere"
+
+#: id:15104
+msgid "* All songs"
+msgstr "* Alle sange"
+
+#: id:15105
+msgid "* All genres"
+msgstr "* Alle genrer"
+
+#: id:15107
+msgid "Buffering..."
+msgstr "Lagring..."
+
+#: id:15108
+msgid "Navigation sounds"
+msgstr "Navigationslyde"
+
+#: id:15109
+msgid "Skin default"
+msgstr "Skinnets standard"
+
+#: id:15111
+msgid "- Theme"
+msgstr "- Tema"
+
+#: id:15112
+msgid "Default theme"
+msgstr "Standardtema"
+
+#: id:15200
+msgid "Last.fm"
+msgstr "Last.fm"
+
+#: id:15201
+msgid "Submit songs to Last.fm"
+msgstr "Send sange til Last.fm"
+
+#: id:15202
+msgid "Last.fm username"
+msgstr "Brugernavn til Last.fm"
+
+#: id:15203
+msgid "Last.fm password"
+msgstr "Adgangskode til Last.fm"
+
+#: id:15204
+msgid "Unable to handshake: sleeping..."
+msgstr "Ikke istand til at udføre håndtryk: sover..."
+
+#: id:15205
+msgid "Please update XBMC"
+msgstr "Opdater venligst XBMC"
+
+#: id:15206
+msgid "Bad authorization: Check username and password"
+msgstr "Fejl: Kontroller brugernavn og adgangskode"
+
+#: id:15207
+msgctxt "Auto context with id 15207"
+msgid "Connected"
+msgstr "Forbundet"
+
+#: id:15208
+msgid "Not connected"
+msgstr "Afbrudt"
+
+#: id:15209
+msgid "Submit interval %i"
+msgstr "Sendingsinterval %i"
+
+#: id:15210
+msgid "Cached %i songs"
+msgstr "Mellemlagrede %i sange"
+
+#: id:15211
+msgid "Submitting..."
+msgstr "Sender..."
+
+#: id:15212
+msgid "Submitting in %i secs"
+msgstr "Sender om %i sekunder"
+
+#: id:15213
+msgid "Play using..."
+msgstr "Afspil med..."
+
+#: id:15214
+msgid "Use smoothed A/V synchronization"
+msgstr "Brug udglattet A/V-synkronisering"
+
+#: id:15215
+msgid "Hide file names in thumbs view"
+msgstr "Skjul filnavne i ikonvisning"
+
+#: id:15216
+msgid "Play in party mode"
+msgstr "Afspil i festtilstand"
+
+#: id:15217
+msgid "Submit songs to Libre.fm"
+msgstr "Sand sange til Libre.fm"
+
+#: id:15218
+msgid "Libre.fm username"
+msgstr "Brugernavn til Libre.fm"
+
+#: id:15219
+msgid "Libre.fm password"
+msgstr "Kode til Libre.fm"
+
+#: id:15220
+msgid "Libre.fm"
+msgstr "Libre.fm"
+
+#: id:15221
+msgid "Song submission"
+msgstr "Sangindsendelse"
+
+#: id:15250
+msgid "Submit Last.fm radio to Last.fm"
+msgstr "Send Last.fm-radio til Last.fm"
+
+#: id:15251
+msgid "Connecting to Last.fm..."
+msgstr "Forbinder til Last.fm..."
+
+#: id:15252
+msgid "Selecting station..."
+msgstr "Vælger station..."
+
+#: id:15253
+msgid "Search similar artists..."
+msgstr "Søg efter lignende kunstnere..."
+
+#: id:15254
+msgid "Search similar tags..."
+msgstr "Søg efter lignende etiketter..."
+
+#: id:15255
+msgid "Your profile (%name%)"
+msgstr "Din profil (%name%)"
+
+#: id:15256
+msgid "Overall top tags"
+msgstr "Gennemsnitlig bedste etiket"
+
+#: id:15257
+msgid "Top artists for tag %name%"
+msgstr "Bedste kunstner med etiketten %name%"
+
+#: id:15258
+msgid "Top albums for tag %name%"
+msgstr "Bedste albums med etiketten %name%"
+
+#: id:15259
+msgid "Top tracks for tag %name%"
+msgstr "Bedste sange med etiketten %name%"
+
+#: id:15260
+msgid "Listen to tag %name% Last.fm radio"
+msgstr "Lyt til Last.fm-radio for etiketten %name%"
+
+#: id:15261
+msgid "Similar artists as %name%"
+msgstr "Lignende kunstnere som %name%"
+
+#: id:15262
+msgid "Top %name% albums"
+msgstr "Bedste %name% albums"
+
+#: id:15263
+msgid "Top %name% tracks"
+msgstr "Bedste %name% sange"
+
+#: id:15264
+msgid "Top %name% tags"
+msgstr "Bedste %name% etiket"
+
+#: id:15265
+msgid "Biggest fans of %name%"
+msgstr "Største fans af %name%"
+
+#: id:15266
+msgid "Listen to %name% fans Last.fm radio"
+msgstr "Lyt til brugeren %name%'s Last.fm-radio"
+
+#: id:15267
+msgid "Listen to %name% similar artists Last.fm radio"
+msgstr "Lyt til %name% lignende kunstneres Last.fm-radio"
+
+#: id:15268
+msgid "Top artists for user %name%"
+msgstr "Favoritkunstnere for brugeren %name%"
+
+#: id:15269
+msgid "Top albums for user %name%"
+msgstr "Favoritalbums hos brugeren %name%"
+
+#: id:15270
+msgid "Top tracks for user %name%"
+msgstr "Favoritsange hos brugeren %name%"
+
+#: id:15271
+msgid "Friends of user %name%"
+msgstr "Venner til brugeren %name%"
+
+#: id:15272
+msgid "Neighbours of user %name%"
+msgstr "Naboer til brugeren %name%"
+
+#: id:15273
+msgid "Weekly artist chart for %name%"
+msgstr "Ugentlig kunstnerliste for %name%"
+
+#: id:15274
+msgid "Weekly album chart for %name%"
+msgstr "Ugentlig albumliste for %name%"
+
+#: id:15275
+msgid "Weekly track chart for %name%"
+msgstr "Ugentlig sangliste for %name%"
+
+#: id:15276
+msgid "Listen to %name%'s neighbours Last.fm radio"
+msgstr "Lyt til %name%'s naboers Last.fm-radio"
+
+#: id:15277
+msgid "Listen to %name%'s personal Last.fm radio"
+msgstr "Lyt til %name%'s personlige Last.fm-radio"
+
+#: id:15278
+msgid "Listen to %name%'s mix Last.fm radio"
+msgstr "Lyt til %name%'s favoritsange Last.fm-radio"
+
+#: id:15279
+msgid "Retrieving list from Last.fm..."
+msgstr "Henter liste fra Last.fm..."
+
+#: id:15280
+msgid "Can't retrieve list from Last.fm..."
+msgstr "Kunne ikke hente liste fra Last.fm..."
+
+#: id:15281
+msgid "Enter an artist name to find related ones"
+msgstr "Indtast kunstnernavn for at finde relaterede"
+
+#: id:15282
+msgid "Enter a tag name to find similar ones"
+msgstr "Indtast etiket for at finde lignende"
+
+#: id:15283
+msgid "Tracks recently listened by %name%"
+msgstr "Sange som %name% har lyttet til fornylig"
+
+#: id:15284
+msgid "Listen to %name%'s recommendations Last.fm radio"
+msgstr "Lyt til %name%'s anbefalede Last.fm-radio"
+
+#: id:15285
+msgid "Top tags for user %name%"
+msgstr "Favoritetiketter for brugeren %name%"
+
+#: id:15287
+msgid "Do you want to add the current track to your loved tracks?"
+msgstr "Vil du tilføje dette nummer til dine favoritter?"
+
+#: id:15288
+msgid "Do you want to ban the current track?"
+msgstr "Vil du bandlyse dette nummer?"
+
+#: id:15289
+msgid "Added to your loved tracks: '%s'."
+msgstr "Tilføjet til dine favoritter: '%s'."
+
+#: id:15290
+msgid "Could not add '%s' to your loved tracks."
+msgstr "Kunne ikke tilføje '%s' til dine favoritter"
+
+#: id:15291
+msgid "Banned: '%s'."
+msgstr "Bandlyst: '%s'."
+
+#: id:15292
+msgid "Could not ban '%s'."
+msgstr "Kunne ikke bandlyse '%s'."
+
+#: id:15293
+msgid "Tracks recently loved by %name%"
+msgstr "Nylige favoritter hos %name%"
+
+#: id:15294
+msgid "Tracks recently banned by %name%"
+msgstr "Nylige bandlysninger hos %name%"
+
+#: id:15295
+msgid "Remove from loved tracks"
+msgstr "Fjern fra favoritter"
+
+#: id:15296
+msgid "Un-ban"
+msgstr "Fjern bandlysning"
+
+#: id:15297
+msgid "Do you want to remove this track from your loved tracks?"
+msgstr "Vil du fjerne dette nummer fra dine favoritter?"
+
+#: id:15298
+msgid "Do you want to un-ban this track?"
+msgstr "Vil du fjerne bandlysningen af dette nummer?"
+
+#: id:15300
+msgid "Path not found or invalid"
+msgstr "Sti ikke fundet eller ugyldig"
+
+#: id:15301
+msgid "Could not connect to network server"
+msgstr "Kunne ikke forbinde til netværksserver"
+
+#: id:15302
+msgid "No servers found"
+msgstr "Ingen servere fundet"
+
+#: id:15303
+msgid "Workgroup not found"
+msgstr "Arbejdsgruppe ikke fundet"
+
+#: id:15310
+msgid "Opening multi-path source"
+msgstr "Åbner kilde med multiple stier"
+
+#: id:15311
+msgid "Path:"
+msgstr "Sti:"
+
+#: id:16000
+msgctxt "Auto context with id 16000"
+msgid "General"
+msgstr "Generelt"
+
+#: id:16002
+msgid "Internet lookup"
+msgstr "Internetopslag"
+
+#: id:16003
+msgid "Player"
+msgstr "Afspiller"
+
+#: id:16004
+msgid "Play media from disc"
+msgstr "Afspil medie fra disk"
+
+#: id:16008
+msgid "Enter new title"
+msgstr "Indtast ny titel"
+
+#: id:16009
+msgid "Enter the movie name"
+msgstr "Indtast filmens navn"
+
+#: id:16010
+msgid "Enter the profile name"
+msgstr "Indtast profilens navn"
+
+#: id:16011
+msgid "Enter the album name"
+msgstr "Indtast albummets navn"
+
+#: id:16012
+msgid "Enter the playlist name"
+msgstr "Indtast afspilningslistens navn"
+
+#: id:16013
+msgid "Enter new filename"
+msgstr "Indtast nyt filnavn"
+
+#: id:16014
+msgid "Enter folder name"
+msgstr "Indtast mappenavn"
+
+#: id:16015
+msgid "Enter directory"
+msgstr "Indtast bibliotek"
+
+#: id:16016
+msgid "Available options: %A, %T, %N, %B, %D, %G, %Y, %F, %S"
+msgstr "Tilgængelige muligheder: %A, %T, %N, %B, %D, %G, %Y, %F, %S"
+
+#: id:16017
+msgid "Enter search string"
+msgstr "Indtast søgeord"
+
+#: id:16018
+msgctxt "Auto context with id 16018"
+msgid "None"
+msgstr "Ingen"
+
+#: id:16019
+msgid "Auto select"
+msgstr "Vælg automatisk"
+
+#: id:16020
+msgid "De-interlace"
+msgstr "Deinterlace"
+
+#: id:16021
+msgid "Bob"
+msgstr "Synkroniser ulige"
+
+#: id:16022
+msgid "Bob (inverted)"
+msgstr "Bob (inverted)"
+
+#: id:16024
+msgid "Canceling..."
+msgstr "Afbryder..."
+
+#: id:16025
+msgid "Enter the artist name"
+msgstr "Indtast kunstnernavn"
+
+#: id:16026
+msgid "Playback failed"
+msgstr "Fejl ved afspilning"
+
+#: id:16027
+msgid "One or more items failed to play."
+msgstr "En eller flere objekter fejlede ved afspilning."
+
+#: id:16028
+msgid "Enter value"
+msgstr "Indtast værdi"
+
+#: id:16029
+msgid "Check the log file for details."
+msgstr "Se log-filen for detaljer."
+
+#: id:16030
+msgid "Party mode aborted."
+msgstr "Festtilstand afbrudt"
+
+#: id:16031
+msgid "No matching songs in the library."
+msgstr "Ingen matches i databasen"
+
+#: id:16032
+msgid "Could not initialize database."
+msgstr "Kunne ikke initialisere databasen"
+
+#: id:16033
+msgid "Could not open database."
+msgstr "Kunne ikke åbne databasen"
+
+#: id:16034
+msgid "Could not get songs from database."
+msgstr "Kunne ikke hente sange fra databasen"
+
+#: id:16035
+msgid "Party mode playlist"
+msgstr "Afspilningsliste til festtilstand"
+
+#: id:16036
+msgid "De-interlace (Half)"
+msgstr ""
+
+#: id:16037
+msgid "Deinterlace video"
+msgstr ""
+
+#: id:16038
+msgid "Deinterlace method"
+msgstr ""
+
+#: id:16039
+msgctxt "Auto context with id 16039"
+msgid "Off"
+msgstr ""
+
+#: id:16040
+msgctxt "Auto context with id 16040"
+msgid "Auto"
+msgstr ""
+
+#: id:16041
+msgid "On"
+msgstr ""
+
+#: id:16100
+msgid "All Videos"
+msgstr "Alle videoer"
+
+#: id:16101
+msgid "Unwatched"
+msgstr "Ikke set"
+
+#: id:16102
+msgid "Watched"
+msgstr "Set"
+
+#: id:16103
+msgid "Mark as watched"
+msgstr "Marker som set"
+
+#: id:16104
+msgid "Mark as unwatched"
+msgstr "Marker som ikke-set"
+
+#: id:16105
+msgid "Edit title"
+msgstr "Rediger titel"
+
+#: id:16200
+msgid "Operation was aborted"
+msgstr "Handlingen blev afbrudt"
+
+#: id:16201
+msgid "Copy failed"
+msgstr "Kopiering fejlede"
+
+#: id:16202
+msgid "Failed to copy at least one file"
+msgstr "Kunne ikke kopiere mindst en fil"
+
+#: id:16203
+msgid "Move failed"
+msgstr "Flytning fejlede"
+
+#: id:16204
+msgid "Failed to move at least one file"
+msgstr "Kunne ikke flytte mindst en fil"
+
+#: id:16205
+msgid "Delete failed"
+msgstr "Sletning fejlede"
+
+#: id:16206
+msgid "Failed to delete at least one file"
+msgstr "Kunne ikke slette mindst en fil"
+
+#: id:16300
+msgid "Video scaling method"
+msgstr "Metode til videoskalering"
+
+#: id:16301
+msgid "Nearest neighbour"
+msgstr "Nærmeste nabo"
+
+#: id:16302
+msgid "Bilinear"
+msgstr "Bilineær"
+
+#: id:16303
+msgctxt "Auto context with id 16303"
+msgid "Bicubic"
+msgstr "Bikubisk"
+
+#: id:16304
+msgid "Lanczos2"
+msgstr "Lanczos2"
+
+#: id:16305
+msgid "Lanczos3"
+msgstr "Lanczos3"
+
+#: id:16306
+msgid "Sinc8"
+msgstr "Sinc8"
+
+#: id:16307
+msgid "Bicubic (software)"
+msgstr "Bikubisk (software)"
+
+#: id:16308
+msgid "Lanczos (software)"
+msgstr "Lanczos (software)"
+
+#: id:16309
+msgid "Sinc (software)"
+msgstr "Sinc (software)"
+
+#: id:16310
+msgid "Temporal"
+msgstr "(VDPAU) Temporal"
+
+#: id:16311
+msgid "Temporal/Spatial"
+msgstr "(VDPAU) Temporal/Spatial"
+
+#: id:16312
+msgid "(VDPAU)Noise Reduction"
+msgstr "(VDPAU) Støjreduktion"
+
+#: id:16313
+msgid "(VDPAU)Sharpness"
+msgstr "(VDPAU) Skarphed"
+
+#: id:16314
+msgid "Inverse Telecine"
+msgstr "Invers telecine"
+
+#: id:16315
+msgid "Lanczos3 optimized"
+msgstr "Lanczos3 optimeret"
+
+#: id:16316
+msgctxt "Auto context with id 16316"
+msgid "Auto"
+msgstr "Auto"
+
+#: id:16317
+msgid "Temporal (Half)"
+msgstr "Temporal (Halv)"
+
+#: id:16318
+msgid "Temporal/Spatial (Half)"
+msgstr "Temporal/Spatial (Halv)"
+
+#: id:16319
+msgid "DXVA"
+msgstr ""
+
+#: id:16320
+msgid "DXVA Bob"
+msgstr ""
+
+#: id:16321
+msgid "DXVA Best"
+msgstr ""
+
+#: id:16322
+msgid "Spline36"
+msgstr ""
+
+#: id:16323
+msgid "Spline36 optimized"
+msgstr ""
+
+#: id:16324
+msgid "Software Blend"
+msgstr ""
+
+#: id:16400
+msgid "Post-processing"
+msgstr ""
+
+#: id:17500
+msgid "Display sleep timeout"
+msgstr "Sluk for skærm efter"
+
+#: id:19000
+msgid "Switch to channel"
+msgstr "Skift til kanal"
+
+#: id:20000
+msgid "Saved music folder"
+msgstr "Mappe til gemt musik"
+
+#: id:20001
+msgid "Use external DVD player"
+msgstr "Brug ekstern DVD-afspiller"
+
+#: id:20002
+msgid "External DVD player"
+msgstr "Ekstern DVD-afspiller"
+
+#: id:20003
+msgid "Trainers folder"
+msgstr "Mappe til trænerprogrammer"
+
+#: id:20004
+msgid "Screenshot folder"
+msgstr "Mappe til skærmbilleder"
+
+#: id:20006
+msgid "Playlists folder"
+msgstr "Mappe til afspilningslister"
+
+#: id:20007
+msgid "Recordings"
+msgstr "Optagelser"
+
+#: id:20008
+msgid "Screenshots"
+msgstr "Skærmbilleder"
+
+#: id:20009
+msgid "Use XBMC"
+msgstr "Brug XBMC"
+
+#: id:20011
+msgid "Music playlists"
+msgstr "Afspilningslister til musik"
+
+#: id:20012
+msgid "Video playlists"
+msgstr "Afspilningslister til videoer"
+
+#: id:20013
+msgid "Do you wish to launch the game?"
+msgstr "Vil du starte spillet?"
+
+#: id:20014
+msgid "Sort by: Playlist"
+msgstr "Sortering: Liste"
+
+#: id:20015
+msgid "Remote thumb"
+msgstr "Fjernikon"
+
+#: id:20016
+msgid "Current thumb"
+msgstr "Nuværende ikon"
+
+#: id:20017
+msgid "Local thumb"
+msgstr "Lokalt ikon"
+
+#: id:20018
+msgid "No thumb"
+msgstr "Intet ikon"
+
+#: id:20019
+msgid "Choose thumbnail"
+msgstr "Vælg ikon"
+
+#: id:20023
+msgid "Conflict"
+msgstr "Konflikt"
+
+#: id:20024
+msgid "Scan new"
+msgstr "Skan nye"
+
+#: id:20025
+msgid "Scan all"
+msgstr "Skan alle"
+
+#: id:20026
+msgid "Region"
+msgstr "Region"
+
+#: id:20037
+msgid "Summary"
+msgstr "Sammenfatning"
+
+#: id:20038
+msgid "Lock music window"
+msgstr "Lås musikvindue"
+
+#: id:20039
+msgid "Lock videos window"
+msgstr "Lås filmvindue"
+
+#: id:20040
+msgid "Lock pictures window"
+msgstr "Lås billedevindue"
+
+#: id:20041
+msgid "Lock programs & scripts windows"
+msgstr "Lås programmer-, saves- og skript-vinduer"
+
+#: id:20042
+msgid "Lock file manager"
+msgstr "Lås filhåndtering"
+
+#: id:20043
+msgid "Lock settings"
+msgstr "Lås indstillinger"
+
+#: id:20044
+msgid "Start fresh"
+msgstr "Start påny"
+
+#: id:20045
+msgid "Enter master mode"
+msgstr "Aktiver administrationstilstand"
+
+#: id:20046
+msgid "Leave master mode"
+msgstr "Afbryd administrationstilstand"
+
+#: id:20047
+msgid "Create profile '%s'?"
+msgstr "Lav profilen '%s'?"
+
+#: id:20048
+msgid "Start with fresh settings"
+msgstr "Start med friske indstillinger"
+
+#: id:20049
+msgid "Best available"
+msgstr "Bedst tilgængelige"
+
+#: id:20050
+msgid "Auto-switch between 16x9 and 4x3"
+msgstr "Skift automatisk mellem 16x9 og 4x3"
+
+#: id:20051
+msgid "Treat stacked files as single file"
+msgstr "Behandl stakkede filer som enkelt fil"
+
+#: id:20052
+msgid "Caution"
+msgstr "Advarsel"
+
+#: id:20053
+msgid "Left master mode"
+msgstr "Afbrudte administrationstilstand"
+
+#: id:20054
+msgid "Entered master mode"
+msgstr "Begyndte administrationstilstand"
+
+#: id:20055
+msgid "Allmusic.com thumb"
+msgstr "Allmusic.com ikon"
+
+#: id:20057
+msgid "Remove thumbnail"
+msgstr "Fjern ikon"
+
+#: id:20058
+msgid "Add profile..."
+msgstr "Tilføj profil..."
+
+#: id:20059
+msgid "Query info for all albums"
+msgstr "Hent info til alle albums"
+
+#: id:20060
+msgctxt "Auto context with id 20060"
+msgid "Media info"
+msgstr "Medieinfo"
+
+#: id:20061
+msgctxt "Auto context with id 20061"
+msgid "Separate"
+msgstr "Adskilt"
+
+#: id:20062
+msgid "Shares with default"
+msgstr "Delinger med standard"
+
+#: id:20063
+msgid "Shares with default (read only)"
+msgstr "Delinger med standard (læs kun)"
+
+#: id:20064
+msgid "Copy default"
+msgstr "Kopier standard"
+
+#: id:20065
+msgid "Profile picture"
+msgstr "Profilbillede"
+
+#: id:20066
+msgid "Lock preferences"
+msgstr "Lås indstillinger"
+
+#: id:20067
+msgid "Edit profile"
+msgstr "Rediger profil"
+
+#: id:20068
+msgid "Profile lock"
+msgstr "Profillås"
+
+#: id:20069
+msgid "Could not create folder"
+msgstr "Kunne ikke oprette mappe"
+
+#: id:20070
+msgid "Profile directory"
+msgstr "Profilmappe"
+
+#: id:20071
+msgid "Start with fresh media sources"
+msgstr "Start med friske mediekilder"
+
+#: id:20072
+msgid "Make sure the selected folder is writable"
+msgstr "Sørg for at den valgte mappe er skrivbar"
+
+#: id:20073
+msgid "and that the new folder name is valid"
+msgstr "og at mappens navn er gyldigt"
+
+#: id:20074
+msgid "MPAA rating"
+msgstr "MPAA"
+
+#: id:20075
+msgid "Enter master lock code"
+msgstr "Indtast hovednøgle"
+
+#: id:20076
+msgid "Ask for master lock code on startup"
+msgstr "Spørg efter hovednøgle ved start"
+
+#: id:20077
+msgid "Skin settings"
+msgstr "Skinindstillinger"
+
+#: id:20078
+msgid "- no link set -"
+msgstr "- no link set -"
+
+#: id:20079
+msgid "Enable animations"
+msgstr "Aktiver animationer"
+
+#: id:20080
+msgid "Disable RSS during music"
+msgstr "Deaktiver RSS under musikafspilning"
+
+#: id:20081
+msgid "Enable shortcut buttons"
+msgstr "Aktiver genvejsknapper"
+
+#: id:20082
+msgid "Show programs in main menu"
+msgstr "Vis Programmer i hovedmenuen"
+
+#: id:20083
+msgid "Show music info"
+msgstr "Vis musikinfo"
+
+#: id:20084
+msgid "Show weather info"
+msgstr "Vis vejrudsigt"
+
+#: id:20085
+msgid "Show system info"
+msgstr "Vis systeminfo"
+
+#: id:20086
+msgid "Show available disc space C: E: F:"
+msgstr "Vis ledig plads på C: E: F:"
+
+#: id:20087
+msgid "Show available disc space E: F: G:"
+msgstr "Vis ledig plads på E: F: G:"
+
+#: id:20088
+msgid "Weather info"
+msgstr "Vejrudsigt"
+
+#: id:20089
+msgid "Drive space free"
+msgstr "Ledig plads"
+
+#: id:20090
+msgid "Enter the name of an existing share"
+msgstr "Indtast navn på eksisterende kilde"
+
+#: id:20091
+msgid "Lock code"
+msgstr "Adgangskode"
+
+#: id:20092
+msgid "Load profile"
+msgstr "Indlæs profil"
+
+#: id:20093
+msgid "Profile name"
+msgstr "Profilnavn"
+
+#: id:20094
+msgctxt "Auto context with id 20094"
+msgid "Media sources"
+msgstr "Mediekilder"
+
+#: id:20095
+msgid "Enter profile lock code"
+msgstr "Indtast profilens adgangskode"
+
+#: id:20096
+msgctxt "Auto context with id 20096"
+msgid "Login screen"
+msgstr "Login-skærm"
+
+#: id:20097
+msgid "Fetching album info"
+msgstr "Henter albuminfo"
+
+#: id:20098
+msgid "Fetching info for album"
+msgstr "Henter info om album"
+
+#: id:20099
+msgid "Can't rip CD or track while playing from CD"
+msgstr "Kan ikke rippe CD eller spor når CD'en afspilles"
+
+#: id:20100
+msgid "Master lock code and settings"
+msgstr "Hovednøgle og indstillinger"
+
+#: id:20101
+msgid "Entering master lock code always enables master mode"
+msgstr "Indtastning af hovednøgle aktiverer administrationstilstand"
+
+#: id:20102
+msgid "or copy from default?"
+msgstr "eller kopier fra standard?"
+
+#: id:20103
+msgid "Save changes to profile?"
+msgstr "Gem indstillinger i profil?"
+
+#: id:20104
+msgid "Old settings found."
+msgstr "Gamle indstillinger fundet."
+
+#: id:20105
+msgid "Do you want to use them?"
+msgstr "Vil du bruge dem?"
+
+#: id:20106
+msgid "Old media sources found."
+msgstr "Gamle mediekilder fundet."
+
+#: id:20107
+msgid "Separate (locked)"
+msgstr "Adskilt (låst)"
+
+#: id:20108
+msgid "Root"
+msgstr "Roden"
+
+#: id:20109
+msgid "- Zoom"
+msgstr "- Zoom"
+
+#: id:20110
+msgid "UPnP settings"
+msgstr "UPnP-indstillinger"
+
+#: id:20111
+msgid "Autostart UPnP client"
+msgstr "Autostart UPnP-klienten"
+
+#: id:20112
+msgid "Last login: %s"
+msgstr "Sidste login: %s"
+
+#: id:20113
+msgid "Never logged on"
+msgstr "Aldrig logget ind før"
+
+#: id:20114
+msgid "Profile %i / %i"
+msgstr "Profil %i / %i"
+
+#: id:20115
+msgid "User login / Select a profile"
+msgstr "Brugerlogin / Vælg en profil"
+
+#: id:20116
+msgid "Use lock on login screen"
+msgstr "Brug lås på login-skærm"
+
+#: id:20117
+msgid "Invalid lock code."
+msgstr "Ugyldig låsekode."
+
+#: id:20118
+msgid "This requires the master lock to be set."
+msgstr "Dette kræver at hovedlåsen er aktiveret."
+
+#: id:20119
+msgid "Would you like to set it now?"
+msgstr "Vil du aktivere den nu?"
+
+#: id:20120
+msgid "Loading program information"
+msgstr "Indlæser programinformation"
+
+#: id:20121
+msgid "Party on!"
+msgstr "Så skal der festes!"
+
+#: id:20122
+msgid "True"
+msgstr "Sandt"
+
+#: id:20123
+msgid "Mixing drinks"
+msgstr "Blander drinks"
+
+#: id:20124
+msgid "Filling glasses"
+msgstr "Fylder glassene"
+
+#: id:20125
+msgid "Logged on as"
+msgstr "Logget på som"
+
+#: id:20126
+msgid "Log off"
+msgstr "Log af"
+
+#: id:20128
+msgid "Go to root"
+msgstr "Gå til roden"
+
+#: id:20129
+msgid "Weave"
+msgstr "Weave"
+
+#: id:20130
+msgid "Weave (inverted)"
+msgstr "Weave (omvendt)"
+
+#: id:20131
+msgid "Blend"
+msgstr "Blend"
+
+#: id:20132
+msgid "Restart video"
+msgstr "Genstart video"
+
+#: id:20133
+msgid "Edit network location"
+msgstr "Rediger netværksplacering"
+
+#: id:20134
+msgid "Remove network location"
+msgstr "Fjern netværksplacering"
+
+#: id:20135
+msgid "Do you want to scan the folder?"
+msgstr "Vil du skanne mappen?"
+
+#: id:20136
+msgid "Memory unit"
+msgstr "Hukommelsesenhed"
+
+#: id:20137
+msgid "Memory unit mounted"
+msgstr "Hukommelsesenhed monteret"
+
+#: id:20138
+msgid "Unable to mount memory unit"
+msgstr "Kunne ikke montere hukommelsesenhed"
+
+#: id:20139
+msgid "In port %i, slot %i"
+msgstr "på port %i, hul %i"
+
+#: id:20140
+msgid "Lock screensaver"
+msgstr "Lås pauseskærm"
+
+#: id:20141
+msgid "Set"
+msgstr "Indstil"
+
+#: id:20142
+msgctxt "Auto context with id 20142"
+msgid "Username"
+msgstr "Brugernavn"
+
+#: id:20143
+msgid "Enter password for"
+msgstr "Indtast adganskode til"
+
+#: id:20144
+msgid "Shutdown timer"
+msgstr "Nedlukningstimer"
+
+#: id:20145
+msgid "Shutdown interval (in minutes)"
+msgstr "Nedlukningsinterval (i minutter)"
+
+#: id:20146
+msgid "Started, shutdown in %im"
+msgstr "Startet, nedlukning om %im"
+
+#: id:20147
+msgid "Shutdown in 30 minutes"
+msgstr "Nedlukning om 30 minutter"
+
+#: id:20148
+msgid "Shutdown in 60 minutes"
+msgstr "Nedlukning om 60 minutter"
+
+#: id:20149
+msgid "Shutdown in 120 minutes"
+msgstr "Nedlukning om 120 minutter"
+
+#: id:20150
+msgid "Custom shutdown timer"
+msgstr "Egen nedlukningstimer"
+
+#: id:20151
+msgid "Cancel shutdown timer"
+msgstr "Afbryd nedlukningstimer"
+
+#: id:20152
+msgid "Lock preferences for %s"
+msgstr "Lås indstillinger til %s"
+
+#: id:20153
+msgid "Browse..."
+msgstr "Søg..."
+
+#: id:20154
+msgid "Summary information"
+msgstr "Generel information"
+
+#: id:20155
+msgid "Storage information"
+msgstr "Lagerinformation"
+
+#: id:20156
+msgid "Hard disk information"
+msgstr "Harddiskinformation"
+
+#: id:20157
+msgid "DVD-ROM information"
+msgstr "DVD-information"
+
+#: id:20158
+msgid "Network information"
+msgstr "Netværksinformation"
+
+#: id:20159
+msgid "Video information"
+msgstr "Videoinformation"
+
+#: id:20160
+msgid "Hardware information"
+msgstr "Hardwareinformation"
+
+#: id:20161
+msgid "Total"
+msgstr "Total"
+
+#: id:20162
+msgid "Used"
+msgstr "Brugt"
+
+#: id:20163
+msgid "of"
+msgstr "af"
+
+#: id:20164
+msgid "Locking not supported"
+msgstr "Låsning ikke understøttet"
+
+#: id:20165
+msgid "Not locked"
+msgstr "Ikke låst"
+
+#: id:20166
+msgid "Locked"
+msgstr "Låst"
+
+#: id:20167
+msgid "Frozen"
+msgstr "Frossen"
+
+#: id:20168
+msgid "Requires reset"
+msgstr "Kræver genstart"
+
+#: id:20169
+msgid "Week"
+msgstr "Uge"
+
+#: id:20170
+msgid "Line"
+msgstr "Linje"
+
+#: id:20171
+msgid "Windows network (SMB)"
+msgstr "Windows-netværk (SMB)"
+
+#: id:20172
+msgid "XBMSP server"
+msgstr "XBMSP-server"
+
+#: id:20173
+msgctxt "Auto context with id 20173"
+msgid "FTP server"
+msgstr "FTP-server"
+
+#: id:20174
+msgid "iTunes music share (DAAP)"
+msgstr "iTunes musikdeling (DAAP)"
+
+#: id:20175
+msgid "UPnP server"
+msgstr "UPnP-server"
+
+#: id:20176
+msgid "Show video info"
+msgstr "Vis videoinfo"
+
+#: id:20177
+msgid "Done"
+msgstr "Færdig"
+
+#: id:20178
+msgid "Shift"
+msgstr "Shift"
+
+#: id:20179
+msgid "Caps Lock"
+msgstr "Caps Lock"
+
+#: id:20180
+msgid "Symbols"
+msgstr "Symboler"
+
+#: id:20181
+msgid "Backspace"
+msgstr "Backspace"
+
+#: id:20182
+msgid "Space"
+msgstr "Mellemrum"
+
+#: id:20183
+msgid "Reload skin"
+msgstr "Genindlæs skin"
+
+#: id:20184
+msgid "Rotate pictures using EXIF information"
+msgstr "Roter vha. EXIF-information"
+
+#: id:20185
+msgid "Use poster view styles for TV shows"
+msgstr "Brug plakat visning til TV serier"
+
+#: id:20186
+msgid "Please wait"
+msgstr "Vent et øjeblik"
+
+#: id:20187
+msgid "UPnP"
+msgstr "Tager backup af EEPROM"
+
+#: id:20189
+msgid "Enable auto scrolling for plot & review"
+msgstr "Scroll automatisk i handling og anmeldelse"
+
+#: id:20190
+msgctxt "Auto context with id 20190"
+msgid "Custom"
+msgstr "Brugerdefineret"
+
+#: id:20191
+msgid "Enable debug logging"
+msgstr "Aktiver fejlfindings logning"
+
+#: id:20192
+msgid "Download additional information during updates"
+msgstr "Hent yderligere informationer ved opdateringer"
+
+#: id:20193
+msgid "Default service for album information"
+msgstr ""
+
+#: id:20194
+msgid "Default service for artist information"
+msgstr "Standardtjeneste til musik-oplysninger"
+
+#: id:20195
+msgid "Change scraper"
+msgstr "Skift scraper"
+
+#: id:20196
+msgid "Export music library"
+msgstr "Eksporter musikdatabase"
+
+#: id:20197
+msgid "Import music library"
+msgstr "Importer musikdatabase"
+
+#: id:20198
+msgid "No artist found!"
+msgstr "Ingen kunstner fundet!"
+
+#: id:20199
+msgid "Downloading artist info failed"
+msgstr "Fejl ved hentning af kunstnerinfo"
+
+#: id:20250
+msgid "Party on! (videos)"
+msgstr "Så skal der festes! (videoer)"
+
+#: id:20251
+msgid "Mixing drinks (videos)"
+msgstr "Blander drinks (videoer)"
+
+#: id:20252
+msgid "Filling glasses (videos)"
+msgstr "Fylder glassene (videoer)"
+
+#: id:20253
+msgid "WebDAV server (HTTP)"
+msgstr "WebDAV server (HTTP)"
+
+#: id:20254
+msgid "WebDAV server (HTTPS)"
+msgstr "WebDAV server (HTTPS)"
+
+#: id:20255
+msgid "First logon, edit your profile"
+msgstr "Log ind først, og rediger derefter din profil"
+
+#: id:20256
+msgid "HTS Tvheadend client"
+msgstr ""
+
+#: id:20257
+msgid "VDR Streamdev client"
+msgstr ""
+
+#: id:20258
+msgid "MythTV client"
+msgstr ""
+
+#: id:20259
+msgid "Network Filesystem (NFS)"
+msgstr ""
+
+#: id:20260
+msgid "Secure Shell (SSH/SFTP)"
+msgstr ""
+
+#: id:20261
+msgid "Apple Filing Protocol (AFP)"
+msgstr ""
+
+#: id:20300
+msgid "Web server directory (HTTP)"
+msgstr "Web server mappe (HTTP)"
+
+#: id:20301
+msgid "Web server directory (HTTPS)"
+msgstr "Web server mappe (HTTPS)"
+
+#: id:20302
+msgid "Unable to write to folder:"
+msgstr "Kan ikke skrive til mappen:"
+
+#: id:20303
+msgid "Do you want to skip and proceed?"
+msgstr "Vil du springe over og fortsætte?"
+
+#: id:20304
+msgid "RSS Feed"
+msgstr "RSS feed"
+
+#: id:20307
+msgid "Secondary DNS"
+msgstr "Sekundær DNS"
+
+#: id:20308
+msgid "DHCP server:"
+msgstr "DHCP-server:"
+
+#: id:20309
+msgid "Make new folder"
+msgstr "Lav ny mappe"
+
+#: id:20310
+msgid "Dim LCD on playback"
+msgstr "Dæmp LCD ved afspilning"
+
+#: id:20311
+msgid "Unknown or onboard (protected)"
+msgstr "Ukendt eller indbygget (beskyttet)"
+
+#: id:20312
+msgid "Dim LCD on paused"
+msgstr "Dæmp LCD ved pause"
+
+#: id:20314
+msgid "Videos - Library"
+msgstr "Videoer - Database"
+
+#: id:20316
+msgid "Sort by: ID"
+msgstr "Sortering: ID"
+
+#: id:20324
+msgid "Play part..."
+msgstr "Afspil del..."
+
+#: id:20325
+msgid "Calibration reset"
+msgstr "Nulstil kalibrering"
+
+#: id:20326
+msgid "This will reset the calibration values for %s"
+msgstr "Dette vil stille kalibreringen af %s"
+
+#: id:20327
+msgid "to it's default values."
+msgstr "tilbage til standardværdierne."
+
+#: id:20328
+msgid "Browse for destination"
+msgstr "Søg efter destination"
+
+#: id:20329
+msgid "Movies are in separate folders that match the movie title"
+msgstr ""
+
+#: id:20330
+msgid "Use folder names for lookups"
+msgstr "Brug mappenavn ved søgninger"
+
+#: id:20331
+msgctxt "Auto context with id 20331"
+msgid "File"
+msgstr "Fil"
+
+#: id:20332
+msgid "Use file or folder names in lookups?"
+msgstr "Brug fil- eller mappe-navn ved søgninger?"
+
+#: id:20333
+msgid "Set content"
+msgstr "Indholdstype"
+
+#: id:20334
+msgid "Folder"
+msgstr "Mappe"
+
+#: id:20335
+msgid "Look for content recursively?"
+msgstr "Søg efter indhold rekursivt?"
+
+#: id:20336
+msgid "Unlock sources"
+msgstr "Lås kilder op"
+
+#: id:20337
+msgid "Actor"
+msgstr "Skuespiller"
+
+#: id:20338
+msgid "Movie"
+msgstr "Film"
+
+#: id:20339
+msgid "Director"
+msgstr "Instruktør"
+
+#: id:20340
+msgid "Do you want to remove all items within"
+msgstr "Vil du fjerne alle filer i"
+
+#: id:20341
+msgid "this path from the XBMC library?"
+msgstr "denne sti fra databasen"
+
+#: id:20342
+msgctxt "Auto context with id 20342"
+msgid "Movies"
+msgstr "Film"
+
+#: id:20343
+msgid "TV shows"
+msgstr "TV-serier"
+
+#: id:20344
+msgid "This directory contains"
+msgstr "Denne mappe indeholder"
+
+#: id:20345
+msgid "Run automated scan"
+msgstr "Kør automatiseret skanning"
+
+#: id:20346
+msgid "Scan recursively"
+msgstr "Skan rekursivt"
+
+#: id:20347
+msgid "as"
+msgstr "som"
+
+#: id:20348
+msgid "Directors"
+msgstr "Instruktører"
+
+#: id:20349
+msgid "No video files found in this path!"
+msgstr "Ingen videofiler fundet i denne mappe!"
+
+#: id:20350
+msgid "votes"
+msgstr "stemmer"
+
+#: id:20351
+msgid "TV show information"
+msgstr "Information om TV-serie"
+
+#: id:20352
+msgid "Episode information"
+msgstr "Episodeomtale"
+
+#: id:20353
+msgid "Loading TV show details"
+msgstr "Indlæser detaljer om TV-serie"
+
+#: id:20354
+msgid "Fetching episode guide"
+msgstr "Henter episodeguiden"
+
+#: id:20355
+msgid "Loading info for episodes in directory"
+msgstr "Indlæser detaljer om episoder i mappen"
+
+#: id:20356
+msgid "Select TV show:"
+msgstr "Vælg TV-serie:"
+
+#: id:20357
+msgid "Enter the TV show name"
+msgstr "Indtast TV-seriens navn"
+
+#: id:20358
+msgid "Season %i"
+msgstr "Sæson %i"
+
+#: id:20359
+msgid "Episode"
+msgstr "Episode"
+
+#: id:20360
+msgid "Episodes"
+msgstr "episoder"
+
+#: id:20361
+msgid "Loading episode details"
+msgstr "Indlæser detaljer om episode"
+
+#: id:20362
+msgid "Remove episode from library"
+msgstr "Fjern episode fra database"
+
+#: id:20363
+msgid "Remove TV show from library"
+msgstr "Fjern TV-serie fra database"
+
+#: id:20364
+msgid "TV show"
+msgstr "TV-serie"
+
+#: id:20365
+msgid "Episode plot"
+msgstr "Episodens plot"
+
+#: id:20366
+msgid "* All seasons"
+msgstr "* Alle sæsoner"
+
+#: id:20367
+msgid "Hide watched"
+msgstr "Skjul sete"
+
+#: id:20368
+msgid "Prod code"
+msgstr "Produktionskode"
+
+#: id:20369
+msgid "Show plot for unwatched items"
+msgstr "Vis plot for ikke-sete"
+
+#: id:20370
+msgid "* Hidden to prevent spoilers *"
+msgstr "* Skjult *"
+
+#: id:20371
+msgid "Set season thumb"
+msgstr "Vælg sæsonikon"
+
+#: id:20372
+msgid "Season image"
+msgstr "Sæson-billede"
+
+#: id:20373
+msgid "Season"
+msgstr "Sæson"
+
+#: id:20374
+msgid "Downloading movie information"
+msgstr "Henter videoinfo"
+
+#: id:20375
+msgid "Unassign content"
+msgstr "Deassocier indhold"
+
+#: id:20376
+msgid "Original title"
+msgstr ""
+
+#: id:20377
+msgid "Refresh TV show information"
+msgstr "Opdater information om TV-serie"
+
+#: id:20378
+msgid "Refresh info for all episodes?"
+msgstr "Opdater for alle episoder?"
+
+#: id:20379
+msgid "Selected folder contains a single TV show"
+msgstr "Den valgte mappe indeholder en enkelt TV-serie"
+
+#: id:20380
+msgid "Exclude selected folder from scans"
+msgstr "Udeluk den valgte mappe fra skanning"
+
+#: id:20381
+msgid "Specials"
+msgstr "Specials"
+
+#: id:20382
+msgid "Automatically grab season thumbs"
+msgstr "Hent sæsonikoner automatisk"
+
+#: id:20383
+msgid "Selected folder contains a single video"
+msgstr "Den valgte mappe indeholder en enkelt video"
+
+#: id:20384
+msgid "Link to TV show"
+msgstr "Føj til TV-serie"
+
+#: id:20385
+msgid "Remove link to TV show"
+msgstr "Fjern fra TV-serie"
+
+#: id:20386
+msgid "Recently added movies"
+msgstr "Nyligt tilføjne film"
+
+#: id:20387
+msgid "Recently added episodes"
+msgstr "Nyligt tilføjne episoder"
+
+#: id:20388
+msgid "Studios"
+msgstr "Studioer"
+
+#: id:20389
+msgid "Music videos"
+msgstr "Musikvideoer"
+
+#: id:20390
+msgid "Recently added music videos"
+msgstr "Nyligt tilføjne musikvideoer"
+
+#: id:20391
+msgid "Music video"
+msgstr "Musikvideo"
+
+#: id:20392
+msgid "Remove music video from library"
+msgstr "Fjern musikvideo fra database"
+
+#: id:20393
+msgctxt "Auto context with id 20393"
+msgid "Music video information"
+msgstr "Information om musikvideo"
+
+#: id:20394
+msgid "Loading music video information"
+msgstr "Indlæser information om musikvideo"
+
+#: id:20395
+msgid "Mixed"
+msgstr "Blandet"
+
+#: id:20396
+msgid "Go to albums by artist"
+msgstr "Gå til album af kunstner"
+
+#: id:20397
+msgid "Go to album"
+msgstr "Gå til album"
+
+#: id:20398
+msgid "Play song"
+msgstr "Afspil sang"
+
+#: id:20399
+msgid "Go to music videos from album"
+msgstr "Gå til musikvideoer fra album"
+
+#: id:20400
+msgid "Go to music videos by artist"
+msgstr "Gå til musikvideoer af kunstner"
+
+#: id:20401
+msgid "Play music video"
+msgstr "Afspil musikvideo"
+
+#: id:20402
+msgid "Download actor thumbnails when adding to library"
+msgstr "Hent skuespiller-ikoner når der tilføjes til databasen"
+
+#: id:20403
+msgid "Set actor thumb"
+msgstr "Vælg ikon for skuespiller"
+
+#: id:20405
+msgid "Remove episode bookmark"
+msgstr "Slet episode-bogmærke"
+
+#: id:20406
+msgid "Set episode bookmark"
+msgstr "Opret episode-bogmærke"
+
+#: id:20407
+msgid "Scraper settings"
+msgstr "Indstillinger til scraperfunktion"
+
+#: id:20408
+msgid "Downloading music video information"
+msgstr "Henter information om musikvideo"
+
+#: id:20409
+msgid "Downloading TV show information"
+msgstr "Henter information om TV-serie"
+
+#: id:20410
+msgid "Trailer"
+msgstr "Trailer"
+
+#: id:20411
+msgid "Flatten"
+msgstr "Fladgør liste"
+
+#: id:20412
+msgid "Flatten TV shows"
+msgstr "Fladgør TV-serier"
+
+#: id:20413
+msgid "Get fanart"
+msgstr "Hent fan-kunst"
+
+#: id:20414
+msgid "Show Fanart in video and music libraries"
+msgstr "Vis fan-kunst i video- og musikdatabasen"
+
+#: id:20415
+msgid "Scanning for new content"
+msgstr "Søger efter nyt indhold"
+
+#: id:20416
+msgid "First aired"
+msgstr "Vist første gang"
+
+#: id:20417
+msgid "Writer"
+msgstr "Forfatter"
+
+#: id:20419
+msgid "Replace file names with library titles"
+msgstr ""
+
+#: id:20420
+msgctxt "Auto context with id 20420"
+msgid "Never"
+msgstr "Aldrig"
+
+#: id:20421
+msgid "If only one season"
+msgstr "Hvis kun én sæson"
+
+#: id:20422
+msgid "Always"
+msgstr "Altid"
+
+#: id:20423
+msgid "Has trailer"
+msgstr "Har trailer"
+
+#: id:20424
+msgid "False"
+msgstr "Falsk"
+
+#: id:20425
+msgid "Fanart slideshow"
+msgstr "Billedserie med fankunst"
+
+#: id:20426
+msgid "Export to a single file or separate"
+msgstr "Eksporter til en enkelt fil eller seperate"
+
+#: id:20427
+msgid "files per entry?"
+msgstr "filer per post?"
+
+#: id:20428
+msgid "Single file"
+msgstr "Enkelt fil"
+
+#: id:20429
+msgctxt "Auto context with id 20429"
+msgid "Separate"
+msgstr "Seperate"
+
+#: id:20430
+msgid "Export thumbnails and fanart?"
+msgstr "Eksporter ikoner og fankunst?"
+
+#: id:20431
+msgid "Overwrite old files?"
+msgstr "Overskriv gamle filer?"
+
+#: id:20432
+msgid "Exclude path from library updates"
+msgstr "Udeluk sti fra databaseopdateringer"
+
+#: id:20433
+msgid "Extract thumbnails and video information"
+msgstr "Udtræk ikoner og video-information"
+
+#: id:20434
+msgid "Sets"
+msgstr "Samlinger"
+
+#: id:20435
+msgid "Set movieset thumb"
+msgstr "Vælg ikon til filmsamling"
+
+#: id:20436
+msgid "Export actor thumbs?"
+msgstr "Eksporter skuespillerikoner"
+
+#: id:20437
+msgid "Choose fanart"
+msgstr "Vælg fankunst"
+
+#: id:20438
+msgid "Local fanart"
+msgstr "Lokal fankunst"
+
+#: id:20439
+msgid "No fanart"
+msgstr "Ingen fankunst"
+
+#: id:20440
+msgid "Current fanart"
+msgstr "Nuværende fankunst"
+
+#: id:20441
+msgid "Remote fanart"
+msgstr "Fjern-fankunst"
+
+#: id:20442
+msgid "Change content"
+msgstr "Skift indhold"
+
+#: id:20443
+msgid "Do you want to refresh info for all"
+msgstr "Vil du opdatere info for alle"
+
+#: id:20444
+msgid "items within this path?"
+msgstr "objekter i denne sti?"
+
+#: id:20445
+msgid "Fanart"
+msgstr "Fankunst"
+
+#: id:20446
+msgid "Locally stored information found."
+msgstr "Lokalt gemt information fundet."
+
+#: id:20447
+msgid "Ignore and refresh from internet?"
+msgstr "Ignorer og opdater fra internettet?"
+
+#: id:20448
+msgid "Could not download information"
+msgstr "Kunne ikke downloade information"
+
+#: id:20449
+msgid "Unable to connect to remote server"
+msgstr "Server er muligvis ikke tilgængelig."
+
+#: id:20450
+msgid "Would you like to continue scanning?"
+msgstr "Vil du fortsætte scanningen?"
+
+#: id:20451
+msgid "Countries"
+msgstr "Lande"
+
+#: id:20452
+msgid "episode"
+msgstr ""
+
+#: id:20453
+msgid "episodes"
+msgstr ""
+
+#: id:20454
+msgid "Listener"
+msgstr ""
+
+#: id:20455
+msgid "Listeners"
+msgstr ""
+
+#: id:20456
+msgid "Set movieset fanart"
+msgstr ""
+
+#: id:20457
+msgid "Movie set"
+msgstr ""
+
+#: id:20458
+msgid "Group movies in sets"
+msgstr ""
+
+#: id:21330
+msgid "Show hidden files and directories"
+msgstr "Vis skjulte filer og mapper"
+
+#: id:21331
+msgid "TuxBox client"
+msgstr "TuxBox-klient"
+
+#: id:21332
+msgid "WARNING: Target TuxBox device is in recording-mode!"
+msgstr "ADVARSEL: den valgte TuxBox er i optagetilstand!"
+
+#: id:21333
+msgid "The stream will be stopped!"
+msgstr "Streamen bliver stoppet!"
+
+#: id:21334
+msgid "Zap to channel: %s failed!"
+msgstr "Zap til kanal %s fejlede!"
+
+#: id:21335
+msgid "Are you sure to start the stream?"
+msgstr "Vil du starte streamen?"
+
+#: id:21336
+msgid "Connecting to: %s"
+msgstr "Forbinder til: %s"
+
+#: id:21337
+msgid "TuxBox device"
+msgstr "TuxBox-enhed"
+
+#: id:21359
+msgid "Add media share..."
+msgstr "Tilføj mediedelingsmappe..."
+
+#: id:21360
+msgid "Share video and music libraries through UPnP"
+msgstr "Del video- og musik-databaser via UPnP"
+
+#: id:21364
+msgid "Edit media share"
+msgstr "Rediger mediedelingsmappe"
+
+#: id:21365
+msgid "Remove media share"
+msgstr "Fjern mediedelingsmappe"
+
+#: id:21366
+msgid "Subtitle folder"
+msgstr "Mappe til undertekster"
+
+#: id:21367
+msgid "Movie & alternate subtitle directory"
+msgstr "Film og alternativ undertekstmappe"
+
+#: id:21368
+msgid "Override ASS/SSA subtitles fonts"
+msgstr ""
+
+#: id:21369
+msgid "Enable mouse and Touch Screen support"
+msgstr "Aktiver mus"
+
+#: id:21370
+msgid "Play navigation sounds during media playback"
+msgstr "Afspil navigationslyde under medieafspilning"
+
+#: id:21371
+msgid "Thumbnail"
+msgstr "Ikon"
+
+#: id:21372
+msgid "Forced DVD player region"
+msgstr "Tving DVD-region"
+
+#: id:21373
+msgid "Video output"
+msgstr "Videoudgang"
+
+#: id:21374
+msgid "Video aspect"
+msgstr "Billedforhold"
+
+#: id:21375
+msgctxt "Auto context with id 21375"
+msgid "Normal"
+msgstr "Normal"
+
+#: id:21376
+msgid "Letterbox"
+msgstr "Letterbox"
+
+#: id:21377
+msgid "Widescreen"
+msgstr "Widescreen"
+
+#: id:21378
+msgid "Enable 480p"
+msgstr "Aktiver 480p"
+
+#: id:21379
+msgid "Enable 720p"
+msgstr "Aktiver 720p"
+
+#: id:21380
+msgid "Enable 1080i"
+msgstr "Aktiver 1080i"
+
+#: id:21381
+msgid "Enter name of new playlist"
+msgstr "Indtast navn på ny afspilningsliste"
+
+#: id:21382
+msgid "Show \"Add source\" buttons in file lists"
+msgstr "Vis knappen 'Tilføj kilde' i fil-lister"
+
+#: id:21383
+msgid "Enable scrollbars"
+msgstr "Aktiver rullepaneler"
+
+#: id:21384
+msgid "Make watched filtering a toggle in video library"
+msgstr "Brug kun set/ikke-set i videodatabasen (fjern 'Alle videoer')"
+
+#: id:21385
+msgctxt "Auto context with id 21385"
+msgid "Open"
+msgstr "Åbn"
+
+#: id:21386
+msgid "Acoustic management level"
+msgstr "Styring af støjniveau"
+
+#: id:21387
+msgid "Fast"
+msgstr "Hurtig"
+
+#: id:21388
+msgid "Quiet"
+msgstr "Stille"
+
+#: id:21389
+msgid "Enable custom background"
+msgstr "Aktiver selvvalgt baggrund"
+
+#: id:21390
+msgid "Power management level"
+msgstr "Styring af strømforbrug"
+
+#: id:21391
+msgid "High power"
+msgstr "Højt strømforbrug"
+
+#: id:21392
+msgid "Low power"
+msgstr "Lavt strømforbrug"
+
+#: id:21393
+msgid "High standby"
+msgstr "Høj standby"
+
+#: id:21394
+msgid "Low standby"
+msgstr "Lav standby"
+
+#: id:21395
+msgid "Unable to cache files bigger than 4GB"
+msgstr "Kan ikke mellemlagre filer større end 4 GB"
+
+#: id:21396
+msgid "Chapter"
+msgstr "Kapitel"
+
+#: id:21397
+msgid "High quality pixel shader v2"
+msgstr "Højkvalitets Pixel Shader V2"
+
+#: id:21398
+msgid "Enable playlist at startup"
+msgstr "Aktiver afspilningsliste ved start"
+
+#: id:21399
+msgid "Use tween animations"
+msgstr "Brug tween-animationer"
+
+#: id:21400
+msgid "contains"
+msgstr "indeholder"
+
+#: id:21401
+msgid "does not contain"
+msgstr "ikke indeholder"
+
+#: id:21402
+msgid "is"
+msgstr "er"
+
+#: id:21403
+msgid "is not"
+msgstr "ikke er"
+
+#: id:21404
+msgid "starts with"
+msgstr "begynder med"
+
+#: id:21405
+msgid "ends with"
+msgstr "slutter med"
+
+#: id:21406
+msgid "greater than"
+msgstr "større end"
+
+#: id:21407
+msgid "less than"
+msgstr "mindre end"
+
+#: id:21408
+msgid "after"
+msgstr "efter"
+
+#: id:21409
+msgid "before"
+msgstr "før"
+
+#: id:21410
+msgid "in the last"
+msgstr "i det sidste"
+
+#: id:21411
+msgid "not in the last"
+msgstr "ikke i det sidste"
+
+#: id:21412
+msgid "Scrapers"
+msgstr "Scrapere"
+
+#: id:21413
+msgid "Default movie scraper"
+msgstr "Standard scraper til film"
+
+#: id:21414
+msgid "Default tvshow scraper"
+msgstr "Standard scraper til tv-serier"
+
+#: id:21415
+msgid "Default music video scraper"
+msgstr "Standard scraper til musikvideoer"
+
+#: id:21416
+msgid "Enable fallback based on scraper language"
+msgstr "Aktiver reserve baseret på scraperens sprog"
+
+#: id:21417
+msgid "- Settings"
+msgstr "- Indstillinger"
+
+#: id:21418
+msgid "Multilingual"
+msgstr "Flersproglig"
+
+#: id:21419
+msgid "No scrapers present"
+msgstr "Ingen scrapers til stede"
+
+#: id:21420
+msgid "Value to match"
+msgstr "Match denne værdi"
+
+#: id:21421
+msgid "Smart playlist rule"
+msgstr "Regel for smart afspilningsliste"
+
+#: id:21422
+msgid "Match items where"
+msgstr "Match objekter hvor"
+
+#: id:21423
+msgid "New rule..."
+msgstr "Ny regel..."
+
+#: id:21424
+msgid "Items must match"
+msgstr "Objekter skal matche"
+
+#: id:21425
+msgid "all of the rules"
+msgstr "alle regler"
+
+#: id:21426
+msgid "one or more of the rules"
+msgstr "en eller flere regler"
+
+#: id:21427
+msgid "Limit to"
+msgstr "Begræns til"
+
+#: id:21428
+msgid "No limit"
+msgstr "Ingen begrænsning"
+
+#: id:21429
+msgid "Order by"
+msgstr "Sorter efter"
+
+#: id:21430
+msgid "ascending"
+msgstr "stigende"
+
+#: id:21431
+msgid "descending"
+msgstr "faldende"
+
+#: id:21432
+msgid "Edit smart playlist"
+msgstr "Rediger smart afspilningsliste"
+
+#: id:21433
+msgid "Name of the playlist"
+msgstr "Navn på afspilningsliste"
+
+#: id:21434
+msgid "Find items where"
+msgstr "Find objekter hvor"
+
+#: id:21435
+msgid "Edit"
+msgstr "- Rediger"
+
+#: id:21436
+msgid "%i items"
+msgstr "%i objekter"
+
+#: id:21437
+msgid "New smart playlist..."
+msgstr "Ny smart afspilningsliste..."
+
+#: id:21438
+msgid "%c Drive"
+msgstr "%c-drev"
+
+#: id:21439
+msgid "Edit party mode rules"
+msgstr "Rediger regler for festtilstand"
+
+#: id:21440
+msgid "Home folder"
+msgstr "Hjemmemappe"
+
+#: id:21441
+msgid "Watched count"
+msgstr "Set antal gange"
+
+#: id:21442
+msgid "Episode title"
+msgstr "Episodetitel"
+
+#: id:21443
+msgid "Video resolution"
+msgstr "Videoopløsning"
+
+#: id:21444
+msgid "Audio channels"
+msgstr "Lydkanaler"
+
+#: id:21445
+msgid "Video codec"
+msgstr "Video-codec"
+
+#: id:21446
+msgid "Audio codec"
+msgstr "Lyd-codec"
+
+#: id:21447
+msgid "Audio language"
+msgstr "Lydsprog"
+
+#: id:21448
+msgid "Subtitle language"
+msgstr "Undertekstsprog"
+
+#: id:21449
+msgid "Remote control sends keyboard presses"
+msgstr "Fjernbetjening sender tastaturtryk"
+
+#: id:21450
+msgid "- Edit"
+msgstr "- Rediger"
+
+#: id:21451
+msgid "Internet connection required."
+msgstr "Internet forbindelse krævet."
+
+#: id:21452
+msgid "Get More..."
+msgstr ""
+
+#: id:21453
+msgid "Root filesystem"
+msgstr ""
+
+#: id:21454
+msgid "Cache full"
+msgstr ""
+
+#: id:21455
+msgid "Cache filled before reaching required amount for continous playback"
+msgstr ""
+
+#: id:21460
+msgid "Subtitle location"
+msgstr ""
+
+#: id:21461
+msgid "Fixed"
+msgstr ""
+
+#: id:21462
+msgid "Bottom of video"
+msgstr ""
+
+#: id:21463
+msgid "Below video"
+msgstr ""
+
+#: id:21464
+msgid "Top of video"
+msgstr ""
+
+#: id:21465
+msgid "Above video"
+msgstr ""
+
+#: id:21800
+msgid "File name"
+msgstr "Filnavn"
+
+#: id:21801
+msgid "File path"
+msgstr "Filsti"
+
+#: id:21802
+msgid "File size"
+msgstr "Filstørrelse"
+
+#: id:21803
+msgid "File date/time"
+msgstr "Fil-dato/-tid"
+
+#: id:21804
+msgid "Slide index"
+msgstr "Plads i indeks"
+
+#: id:21805
+msgctxt "Auto context with id 21805"
+msgid "Resolution"
+msgstr "Opløsning"
+
+#: id:21806
+msgctxt "Auto context with id 21806"
+msgid "Comment"
+msgstr "Kommentar"
+
+#: id:21807
+msgid "Colour/B&W"
+msgstr "Farve/SH"
+
+#: id:21808
+msgid "JPEG process"
+msgstr "JPEG-proces"
+
+#: id:21820
+msgid "Date/Time"
+msgstr "Dato/tid"
+
+#: id:21821
+msgid "Description"
+msgstr "Beskrivelse"
+
+#: id:21822
+msgid "Camera make"
+msgstr "Kameramærke"
+
+#: id:21823
+msgid "Camera model"
+msgstr "Kameramodel"
+
+#: id:21824
+msgid "EXIF comment"
+msgstr "EXIF-kommentar"
+
+#: id:21825
+msgid "Firmware"
+msgstr "Firmware"
+
+#: id:21826
+msgid "Aperture"
+msgstr "Blænde"
+
+#: id:21827
+msgid "Focal length"
+msgstr "Brændvidde"
+
+#: id:21828
+msgid "Focus distance"
+msgstr "Fokusafstand"
+
+#: id:21829
+msgid "Exposure"
+msgstr "Eksponering"
+
+#: id:21830
+msgid "Exposure time"
+msgstr "Eksponeringstid"
+
+#: id:21831
+msgid "Exposure bias"
+msgstr "Eksponeringskompensation"
+
+#: id:21832
+msgid "Exposure mode"
+msgstr "Eksponeringstype"
+
+#: id:21833
+msgid "Flash used"
+msgstr "Flash brugt"
+
+#: id:21834
+msgid "White-balance"
+msgstr "Hvidbalance"
+
+#: id:21835
+msgid "Light source"
+msgstr "Lyskilde"
+
+#: id:21836
+msgid "Metering mode"
+msgstr "Målemetode"
+
+#: id:21837
+msgid "ISO"
+msgstr "ISO"
+
+#: id:21838
+msgid "Digital zoom"
+msgstr "Digital zoom"
+
+#: id:21839
+msgid "CCD width"
+msgstr "CCD-størrelse"
+
+#: id:21840
+msgid "GPS latitude"
+msgstr "Breddegrad"
+
+#: id:21841
+msgid "GPS longitude"
+msgstr "Højdegrad"
+
+#: id:21842
+msgid "GPS altitude"
+msgstr "Højde"
+
+#: id:21843
+msgid "Orientation"
+msgstr "Retning"
+
+#: id:21860
+msgid "Supplemental categories"
+msgstr "Yderligere kategorier"
+
+#: id:21861
+msgid "Keywords"
+msgstr "Nøgleord"
+
+#: id:21862
+msgid "Caption"
+msgstr "Titel"
+
+#: id:21863
+msgid "Author"
+msgstr "Forfatter"
+
+#: id:21864
+msgid "Headline"
+msgstr "Overskrift"
+
+#: id:21865
+msgid "Special instructions"
+msgstr "Særlig vejledning"
+
+#: id:21866
+msgid "Category"
+msgstr "Kategori"
+
+#: id:21867
+msgid "Byline"
+msgstr "Byline"
+
+#: id:21868
+msgid "Byline title"
+msgstr "Byline-titel"
+
+#: id:21869
+msgid "Credit"
+msgstr "Kredit"
+
+#: id:21870
+msgid "Source"
+msgstr "Kilde"
+
+#: id:21871
+msgid "Copyright notice"
+msgstr "Besked om ophavsret"
+
+#: id:21872
+msgid "Object name"
+msgstr "Objektnavn"
+
+#: id:21873
+msgid "City"
+msgstr "By"
+
+#: id:21874
+msgid "State"
+msgstr "Stat"
+
+#: id:21875
+msgctxt "Auto context with id 21875"
+msgid "Country"
+msgstr "Land"
+
+#: id:21876
+msgid "Original Tx Reference"
+msgstr "Original reference til Tx"
+
+#: id:21877
+msgid "Date created"
+msgstr "Oprettelsesdato"
+
+#: id:21878
+msgid "Copyright flag"
+msgstr "Ophavsret"
+
+#: id:21879
+msgid "Country code"
+msgstr "Landekode"
+
+#: id:21880
+msgid "Reference service"
+msgstr "Referencetjeneste"
+
+#: id:21881
+msgid "Allow control of XBMC via UPnP"
+msgstr "Tillad styring af XBMC via UPnP"
+
+#: id:21882
+msgid "Attempt to skip introduction before DVD menu"
+msgstr "Forsøg at gå direkte til DVD-menuen"
+
+#: id:21883
+msgid "Saved music"
+msgstr "Gemt musik"
+
+#: id:21884
+msgid "Query info for all artists"
+msgstr "Hent info om alle kunstnere"
+
+#: id:21885
+msgid "Downloading album information"
+msgstr "Henter information om album"
+
+#: id:21886
+msgid "Downloading artist information"
+msgstr "Henter information om kunstner"
+
+#: id:21887
+msgid "Biography"
+msgstr "Biografi"
+
+#: id:21888
+msgid "Discography"
+msgstr "Diskografi"
+
+#: id:21889
+msgid "Searching artist"
+msgstr "Søger på kunstner"
+
+#: id:21890
+msgid "Select artist"
+msgstr "Vælg kunstner"
+
+#: id:21891
+msgctxt "Auto context with id 21891"
+msgid "Artist information"
+msgstr "Information om kunstner"
+
+#: id:21892
+msgid "Instruments"
+msgstr "Instrumenter"
+
+#: id:21893
+msgid "Born"
+msgstr "Født"
+
+#: id:21894
+msgid "Formed"
+msgstr "Dannet"
+
+#: id:21895
+msgid "Themes"
+msgstr "Temaer"
+
+#: id:21896
+msgid "Disbanded"
+msgstr "Opløst"
+
+#: id:21897
+msgid "Died"
+msgstr "Død"
+
+#: id:21898
+msgid "Years active"
+msgstr "Aktive år"
+
+#: id:21899
+msgid "Label"
+msgstr "Label"
+
+#: id:21900
+msgid "Born/Formed"
+msgstr "Født/dannet"
+
+#: id:22000
+msgid "Update library on startup"
+msgstr "Opdater databasen ved opstart"
+
+#: id:22001
+msgid "Hide progress of library updates"
+msgstr "Opdater altid databasen i baggrunden"
+
+#: id:22002
+msgid "- DNS suffix"
+msgstr "- DNS-suffiks"
+
+#: id:22003
+msgid "%2.3fs"
+msgstr ""
+
+#: id:22004
+msgid "Delayed by: %2.3fs"
+msgstr "Forsinket med: %2.3fs"
+
+#: id:22005
+msgid "Ahead by: %2.3fs"
+msgstr "Foran med: %2.3fs"
+
+#: id:22006
+msgid "Subtitle offset"
+msgstr "Undertekstforskydelse"
+
+#: id:22007
+msgid "OpenGL vendor:"
+msgstr "OpenGL-leverandør:"
+
+#: id:22008
+msgid "OpenGL renderer:"
+msgstr "OpenGL-renderer:"
+
+#: id:22009
+msgid "OpenGL version:"
+msgstr "OpenGL-version:"
+
+#: id:22010
+msgid "GPU temperature:"
+msgstr "GPU-temperatur"
+
+#: id:22011
+msgid "CPU temperature:"
+msgstr "CPU-temperatur"
+
+#: id:22012
+msgid "Total memory"
+msgstr "Total hukommelse"
+
+#: id:22013
+msgid "Profile data"
+msgstr "Profildata"
+
+#: id:22014
+msgid "Use dim if paused during video playback"
+msgstr "Brug dæmpning hvis videoafspilningen pauses"
+
+#: id:22015
+msgid "All recordings"
+msgstr "Alle optagelser"
+
+#: id:22016
+msgid "By title"
+msgstr "Efter titel"
+
+#: id:22017
+msgid "By group"
+msgstr "Efter gruppe"
+
+#: id:22018
+msgid "Live channels"
+msgstr "Aktive kanaler"
+
+#: id:22019
+msgid "Recordings by title"
+msgstr "Optagelser efter titel"
+
+#: id:22020
+msgid "Guide"
+msgstr "Guide"
+
+#: id:22021
+msgid "Allowed error in aspect ratio to minimize black bars"
+msgstr "Tilladt fejl i billedeforhold for at minimere sorte bjælker"
+
+#: id:22022
+msgid "Show video files in listings"
+msgstr "Vis videofiler i lister"
+
+#: id:22023
+msgid "DirectX vendor:"
+msgstr "DirectX-leverandør:"
+
+#: id:22024
+msgid "Direct3D version:"
+msgstr "Direct3D-version:"
+
+#: id:22030
+msgctxt "Auto context with id 22030"
+msgid "Font"
+msgstr "Skrifttype"
+
+#: id:22031
+msgctxt "Auto context with id 22031"
+msgid "- Size"
+msgstr "- Størrelse"
+
+#: id:22032
+msgctxt "Auto context with id 22032"
+msgid "- Colours"
+msgstr "- Farve"
+
+#: id:22033
+msgid "- Charset"
+msgstr "- Tegnsæt"
+
+#: id:22034
+msgid "Export karaoke titles as HTML"
+msgstr "Eksporter karaoketitler som HTML"
+
+#: id:22035
+msgid "Export karaoke titles as CSV"
+msgstr "Eksporter karaoketitler som CSV"
+
+#: id:22036
+msgid "Import karaoke titles..."
+msgstr "Importer karaoketitler..."
+
+#: id:22037
+msgid "Show song selector automatically"
+msgstr "Vis automatisk sangvælgeren"
+
+#: id:22038
+msgid "Export karaoke titles..."
+msgstr "Eksporter karaoketitler..."
+
+#: id:22039
+msgid "Enter song number"
+msgstr "Vælg sangnummer"
+
+#: id:22040
+msgid "white/green"
+msgstr "hvid/grøn"
+
+#: id:22041
+msgid "white/red"
+msgstr "hvid/rød"
+
+#: id:22042
+msgid "white/blue"
+msgstr "hvid/blå"
+
+#: id:22043
+msgid "black/white"
+msgstr "sort/hvid"
+
+#: id:22079
+msgid "Default select action"
+msgstr ""
+
+#: id:22080
+msgid "Choose"
+msgstr ""
+
+#: id:22081
+msgid "Show Information"
+msgstr ""
+
+#: id:22082
+msgid "More..."
+msgstr ""
+
+#: id:22083
+msgid "Play all"
+msgstr ""
+
+#: id:23049
+msgid "Teletext not available"
+msgstr "Teletext ikke tilgængelig"
+
+#: id:23050
+msgid "Activate Teletext"
+msgstr "Aktiver Tekst-TV"
+
+#: id:23051
+msgid "Part %i"
+msgstr "Del %i"
+
+#: id:23052
+msgid "Buffering %i bytes"
+msgstr "Mellemlagrer %i bytes"
+
+#: id:23053
+msgid "Stopping"
+msgstr "Stopper"
+
+#: id:23054
+msgid "Running"
+msgstr "Kører"
+
+#: id:23100
+msgid "External Player Active"
+msgstr "Ekstern afspiller aktiv"
+
+#: id:23101
+msgid "Click OK to terminate the player"
+msgstr "Tryk OK for at afslutte afspilleren"
+
+#: id:23104
+msgid "Click OK when playback has ended"
+msgstr "Tryk OK når afspilningen er slut"
+
+#: id:24000
+msgid "Add-on"
+msgstr "Tilføjelse"
+
+#: id:24001
+msgid "Add-ons"
+msgstr "Tilføjelser"
+
+#: id:24002
+msgid "Add-on options"
+msgstr "Tilføjelse indstillinger"
+
+#: id:24003
+msgid "Add-on Information"
+msgstr "Tilføjelse information"
+
+#: id:24005
+msgctxt "Auto context with id 24005"
+msgid "Media sources"
+msgstr "Plugin"
+
+#: id:24007
+msgctxt "Auto context with id 24007"
+msgid "Movie information"
+msgstr "Scraper"
+
+#: id:24008
+msgctxt "Auto context with id 24008"
+msgid "Screensaver"
+msgstr "Pauseskærm"
+
+#: id:24009
+msgid "Script"
+msgstr "Makro"
+
+#: id:24010
+msgctxt "Auto context with id 24010"
+msgid "Visualization"
+msgstr "Visualisering"
+
+#: id:24011
+msgid "Add-on repository"
+msgstr "Tilføjelse fjernlager"
+
+#: id:24012
+msgctxt "Auto context with id 24012"
+msgid "Subtitles"
+msgstr ""
+
+#: id:24013
+msgid "Lyrics"
+msgstr ""
+
+#: id:24014
+msgid "TV information"
+msgstr ""
+
+#: id:24015
+msgctxt "Auto context with id 24015"
+msgid "Music video information"
+msgstr ""
+
+#: id:24016
+msgctxt "Auto context with id 24016"
+msgid "Album information"
+msgstr ""
+
+#: id:24017
+msgctxt "Auto context with id 24017"
+msgid "Artist information"
+msgstr ""
+
+#: id:24018
+msgctxt "Auto context with id 24018"
+msgid "Services"
+msgstr ""
+
+#: id:24020
+msgid "Configure"
+msgstr "Konfigurer"
+
+#: id:24021
+msgctxt "Auto context with id 24021"
+msgid "Disable"
+msgstr "Deaktiver"
+
+#: id:24022
+msgid "Enable"
+msgstr "Aktiver"
+
+#: id:24023
+msgid "Add-on disabled"
+msgstr "Tilføjelse deaktiveret"
+
+#: id:24027
+msgctxt "Auto context with id 24027"
+msgid "Weather"
+msgstr "Vejr-tjeneste"
+
+#: id:24028
+msgid "Weather.com (standard)"
+msgstr "Weather.com (standard)"
+
+#: id:24030
+msgid "This Add-on can not be configured"
+msgstr "Denne tilføjelse kan ikke konfigureres"
+
+#: id:24031
+msgid "Error loading settings"
+msgstr "Kunne ikke indlæse indstillingerne"
+
+#: id:24032
+msgid "All Add-ons"
+msgstr "Alle fjernlagre"
+
+#: id:24033
+msgid "Get Add-ons"
+msgstr "Fjernlagre"
+
+#: id:24034
+msgid "Check for updates"
+msgstr "Se efter opdateringer"
+
+#: id:24035
+msgid "Force refresh"
+msgstr "Tving opdatering"
+
+#: id:24036
+msgid "Change log"
+msgstr "Ændringslog"
+
+#: id:24037
+msgid "Uninstall"
+msgstr ""
+
+#: id:24038
+msgid "Install"
+msgstr ""
+
+#: id:24039
+msgid "Disabled Add-ons"
+msgstr ""
+
+#: id:24040
+msgid "(Clear the current setting)"
+msgstr ""
+
+#: id:24041
+msgid "Install from zip file"
+msgstr ""
+
+#: id:24042
+msgid "Downloading %i%%"
+msgstr ""
+
+#: id:24043
+msgid "Available Updates"
+msgstr ""
+
+#: id:24044
+msgid "Dependencies not met"
+msgstr ""
+
+#: id:24045
+msgid "Add-on does not have the correct structure"
+msgstr ""
+
+#: id:24046
+msgid "%s is used by the following installed add-on(s)"
+msgstr ""
+
+#: id:24047
+msgid "This add-on cannot be uninstalled"
+msgstr ""
+
+#: id:24048
+msgid "Rollback"
+msgstr ""
+
+#: id:24050
+msgid "Available Add-ons"
+msgstr "Tilgængelige tilføjelser"
+
+#: id:24051
+msgid "Version:"
+msgstr "Version:"
+
+#: id:24052
+msgid "Disclaimer"
+msgstr "Ansvarsfraskrivelse"
+
+#: id:24053
+msgid "License:"
+msgstr "Licens:"
+
+#: id:24054
+msgid "Changelog"
+msgstr "Ændringslog"
+
+#: id:24059
+msgid "Would you like to enable this Add-on?"
+msgstr "Vil du aktivere denne tilføjelse?"
+
+#: id:24060
+msgid "Would you like to disable this Add-on?"
+msgstr "Vil du deaktivere denne tilføjelse?"
+
+#: id:24061
+msgid "Add-on update available!"
+msgstr "Opdatering til tilføjelse tilgængelig!"
+
+#: id:24062
+msgid "Enabled Add-ons"
+msgstr "Aktiverede tilføjelser"
+
+#: id:24063
+msgid "Auto update"
+msgstr "Opdater automatisk"
+
+#: id:24064
+msgid "Add-on enabled"
+msgstr "Tilføjelse aktiveret"
+
+#: id:24065
+msgid "Add-on updated"
+msgstr "Tilføjelse opdateret"
+
+#: id:24066
+msgid "Cancel Add-on download?"
+msgstr "Annuller tilføjelse download?"
+
+#: id:24067
+msgid "Currently downloading Add-ons"
+msgstr "Downloader tilføjelser i øjeblikket"
+
+#: id:24068
+msgid "Update available"
+msgstr "Opdatering tilgængelig"
+
+#: id:24069
+msgid "Update"
+msgstr "Opdater"
+
+#: id:24070
+msgid "Add-on could not be loaded."
+msgstr "Tilføjelse kan ikke bruges"
+
+#: id:24071
+msgid "An unknown error has occurred."
+msgstr "Der opstod en ukendt fejl"
+
+#: id:24072
+msgid "Settings required"
+msgstr "Konfiguration krævet"
+
+#: id:24073
+msgid "Could not connect"
+msgstr "Kunne ikke oprette forbindelse"
+
+#: id:24074
+msgid "Needs to restart"
+msgstr "Genstart nødvendig"
+
+#: id:24075
+msgctxt "Auto context with id 24075"
+msgid "Disable"
+msgstr "Deaktiver"
+
+#: id:24076
+msgid "Add-on Required"
+msgstr ""
+
+#: id:24080
+msgid "Try to reconnect?"
+msgstr "Prøv at oprette forbindelse igen?"
+
+#: id:24089
+msgid "Add-on restarts"
+msgstr "Tilføjelse genstarter"
+
+#: id:24090
+msgid "Lock Add-on manager"
+msgstr "Lås tilføjelse håndtering"
+
+#: id:24094
+msgid "(current)"
+msgstr ""
+
+#: id:24095
+msgid "(blacklisted)"
+msgstr ""
+
+#: id:24096
+msgid "Add-on has been marked as broken in repository."
+msgstr ""
+
+#: id:24097
+msgid "Would you like to disable it on your system?"
+msgstr ""
+
+#: id:24098
+msgid "Broken"
+msgstr ""
+
+#: id:24099
+msgid "Would you like to switch to this skin?"
+msgstr ""
+
+#: id:24100
+msgid "To use this feature you must download an Add-on:"
+msgstr ""
+
+#: id:24101
+msgid "Would you like to download this Add-on?"
+msgstr ""
+
+#: id:25000
+msgid "Notifications"
+msgstr ""
+
+#: id:29800
+msgid "Library Mode"
+msgstr "Databasetilstand"
+
+#: id:29801
+msgid "QWERTY keyboard"
+msgstr "QWERTY-tastatur"
+
+#: id:29802
+msgid "Passthrough Audio in use"
+msgstr "Lyd-gennemgang i brug"
+
+#: id:33001
+msgid "Trailer quality"
+msgstr "Trailerkvalitet"
+
+#: id:33002
+msgid "Stream"
+msgstr "Stream"
+
+#: id:33003
+msgid "Download"
+msgstr "Download"
+
+#: id:33004
+msgid "Download & play"
+msgstr "Download og afspil"
+
+#: id:33005
+msgid "Download & save"
+msgstr "Download og gem"
+
+#: id:33006
+msgid "Today"
+msgstr "I dag"
+
+#: id:33007
+msgid "Tomorrow"
+msgstr "I morgen"
+
+#: id:33008
+msgid "Saving"
+msgstr "Gemmer"
+
+#: id:33009
+msgid "Copying"
+msgstr "Kopierer"
+
+#: id:33010
+msgid "Set download directory"
+msgstr "Vælg mappe til download"
+
+#: id:33011
+msgid "Search duration"
+msgstr ""
+
+#: id:33012
+msgid "Short"
+msgstr "Kort"
+
+#: id:33013
+msgid "Long"
+msgstr "Lang"
+
+#: id:33014
+msgid "Use DVD player instead of regular player"
+msgstr "Brug DVD-afspiller i stedet for almindelig afspiller"
+
+#: id:33015
+msgid "Ask for download before playing video"
+msgstr "Spørg om download før afspilning af video"
+
+#: id:33016
+msgid "Clips"
+msgstr "Klip"
+
+#: id:33017
+msgid "Restart plugin to enable"
+msgstr "Genstart plugin for at aktivere"
+
+#: id:33018
+msgid "Tonight"
+msgstr "I aften"
+
+#: id:33019
+msgid "Tomorrow Night"
+msgstr "I morgen nat"
+
+#: id:33020
+msgid "Condition"
+msgstr "Forhold"
+
+#: id:33021
+msgid "Precipitation"
+msgstr "Nedbør"
+
+#: id:33022
+msgid "Precip"
+msgstr "Nedbør"
+
+#: id:33023
+msgid "Humid"
+msgstr "Fugtigt"
+
+#: id:33024
+msgid "Feels"
+msgstr "Føles"
+
+#: id:33025
+msgid "Observed"
+msgstr "Observeret"
+
+#: id:33026
+msgid "Departure from normal"
+msgstr "Afvigelse fra normal"
+
+#: id:33027
+msgid "Sunrise"
+msgstr "Solopgang"
+
+#: id:33028
+msgid "Sunset"
+msgstr "Solnedgang"
+
+#: id:33029
+msgid "Details"
+msgstr "Detaljer"
+
+#: id:33030
+msgid "Outlook"
+msgstr "Prognose"
+
+#: id:33031
+msgid "Coverflow"
+msgstr "Coverflow"
+
+#: id:33032
+msgid "Translate text"
+msgstr "Oversæt tekst"
+
+#: id:33033
+msgid "Map list %s category"
+msgstr "Kortliste %s kategori"
+
+#: id:33034
+msgid "36 Hour"
+msgstr "36 timer"
+
+#: id:33035
+msgid "Maps"
+msgstr "Kort"
+
+#: id:33036
+msgid "Hourly"
+msgstr "Hver time"
+
+#: id:33037
+msgid "Weekend"
+msgstr "Weekend"
+
+#: id:33038
+msgid "%s day"
+msgstr "%s dag"
+
+#: id:33049
+msgid "Alert"
+msgstr "Advarsel"
+
+#: id:33050
+msgid "Alerts"
+msgstr "Advarsler"
+
+#: id:33051
+msgid "Choose Your"
+msgstr "Vælg din"
+
+#: id:33052
+msgid "Check"
+msgstr "Kontroller"
+
+#: id:33053
+msgctxt "Auto context with id 33053"
+msgid "Configure the"
+msgstr "Indstil"
+
+#: id:33054
+msgid "Seasons"
+msgstr "Sæsoner"
+
+#: id:33055
+msgid "Use your"
+msgstr "Brug din"
+
+#: id:33056
+msgid "Watch your"
+msgstr "Se dine"
+
+#: id:33057
+msgid "Listen to"
+msgstr "Lyt til"
+
+#: id:33058
+msgid "View your"
+msgstr "Se dine"
+
+#: id:33059
+msgctxt "Auto context with id 33059"
+msgid "Configure the"
+msgstr "Indstil"
+
+#: id:33060
+msgid "Power"
+msgstr "Strøm"
+
+#: id:33061
+msgid "Menu"
+msgstr "Menu"
+
+#: id:33062
+msgid "Play the"
+msgstr "Afspil"
+
+#: id:33063
+msgid "Options"
+msgstr "Indstillinger"
+
+#: id:33065
+msgid "Editor"
+msgstr "Editor"
+
+#: id:33066
+msgid "About your"
+msgstr "Om din"
+
+#: id:33067
+msgid "Star rating"
+msgstr "Antal stjerner"
+
+#: id:33068
+msgid "Background"
+msgstr "Baggrund"
+
+#: id:33069
+msgid "Backgrounds"
+msgstr "Baggrunde"
+
+#: id:33070
+msgid "Custom background"
+msgstr "Egen baggrund"
+
+#: id:33071
+msgid "Custom backgrounds"
+msgstr "Egne baggrunde"
+
+#: id:33072
+msgid "View Readme"
+msgstr "Se \"Læs mig\""
+
+#: id:33073
+msgid "View Changelog"
+msgstr "Se ændringsloggen"
+
+#: id:33074
+msgid "This version of %s requires an"
+msgstr "Denne version af %s kræver en"
+
+#: id:33075
+msgid "XBMC revision of %s or greater to run."
+msgstr "XBMC version %s eller nyere."
+
+#: id:33076
+msgid "Please update XBMC."
+msgstr "Opdater venligst XBMC"
+
+#: id:33077
+msgid "No data found!"
+msgstr "Ingen data fundet"
+
+#: id:33078
+msgid "Next page"
+msgstr "Næste side"
+
+#: id:33079
+msgid "Love"
+msgstr "Elsker"
+
+#: id:33080
+msgid "Hate"
+msgstr "Hader"
+
+#: id:33081
+msgid "This file is stacked, select the part you want to play from."
+msgstr "Denne fil er stakket. Vælg den del du vil afspille fra."
+
+#: id:33082
+msgid "Path to script"
+msgstr "Sti til skript"
+
+#: id:33083
+msgid "Enable custom script button"
+msgstr "Aktiver knap til egne skripts"
+
+#: id:33100
+msgid "Failed to start"
+msgstr ""
+
+#: id:33101
+msgid "Webserver"
+msgstr ""
+
+#: id:33102
+msgid "Event Server"
+msgstr ""
+
+#: id:33103
+msgid "Remote communication server"
+msgstr ""
+
+#: id:33200
+msgid "Detected New Connection"
+msgstr ""
+
+#: id:34000
+msgid "Lame"
+msgstr "Lame"
+
+#: id:34001
+msgid "Vorbis"
+msgstr "Vorbis"
+
+#: id:34002
+msgid "Wav"
+msgstr "Wav"
+
+#: id:34003
+msgid "DXVA2"
+msgstr "DXVA2"
+
+#: id:34004
+msgid "VAAPI"
+msgstr "VAAPI"
+
+#: id:34005
+msgid "Flac"
+msgstr "Flac"
+
+#: id:34100
+msgid "Speaker Configuration"
+msgstr "Højttaler konfiguration"
+
+#: id:34101
+msgid "2.0"
+msgstr "2.0"
+
+#: id:34102
+msgid "2.1"
+msgstr "2.1"
+
+#: id:34103
+msgid "3.0"
+msgstr "3.0"
+
+#: id:34104
+msgid "3.1"
+msgstr "3.1"
+
+#: id:34105
+msgid "4.0"
+msgstr "4.0"
+
+#: id:34106
+msgid "4.1"
+msgstr "4.1"
+
+#: id:34107
+msgid "5.0"
+msgstr "5.0"
+
+#: id:34108
+msgid "5.1"
+msgstr "5.1"
+
+#: id:34109
+msgid "7.0"
+msgstr "7.0"
+
+#: id:34110
+msgid "7.1"
+msgstr "7.1"
+
+#: id:34201
+msgid "Can't find a next item to play"
+msgstr "Kan ikke finde det næste fil for at spille"
+
+#: id:34202
+msgid "Can't find a previous item to play"
+msgstr "Kan ikke finde tidligere fil at afspille"
+
+#: id:34300
+msgid "Failed to start zeroconf"
+msgstr ""
+
+#: id:34301
+msgid "Is Apple's Bonjour Service installed? See log for more info."
+msgstr ""
+
+#: id:34400
+msgid "Video Rendering"
+msgstr ""
+
+#: id:34401
+msgid "Failed to init video filters/scalers, falling back to bilinear scaling"
+msgstr ""
+
+#: id:34402
+msgid "Failed to initialize audio device"
+msgstr ""
+
+#: id:34403
+msgid "Check your audiosettings"
+msgstr ""
+
+#: id:34404
+msgid "Use gestures for navigation:"
+msgstr ""
+
+#: id:34405
+msgid "1 finger swipe left,right,up,down for cursors"
+msgstr ""
+
+#: id:34406
+msgid "2 finger swipe left for backspace"
+msgstr ""
+
+#: id:34407
+msgid "1 finger single tap for enter"
+msgstr ""
+
+#: id:34408
+msgid "2 finger single tap for contextmenu"
+msgstr ""
+
+#: id:35000
+msgid "Peripherals"
+msgstr ""
+
+#: id:35001
+msgid "Generic HID device"
+msgstr ""
+
+#: id:35002
+msgid "Generic network adapter"
+msgstr ""
+
+#: id:35003
+msgid "Generic disk"
+msgstr ""
+
+#: id:35004
+msgid "There are no settings available\nfor this peripheral."
+msgstr ""
+
+#: id:35005
+msgid "New device configured"
+msgstr ""
+
+#: id:35006
+msgid "Device removed"
+msgstr ""
+
+#: id:35007
+msgid "Keymap to use for this device"
+msgstr ""
+
+#: id:35008
+msgid "Keymap enabled"
+msgstr ""
+
+#: id:35009
+msgid "Do not use the custom keymap for this device"
+msgstr ""
+
+#: id:35500
+msgid "Location"
+msgstr ""
+
+#: id:35501
+msgid "Class"
+msgstr ""
+
+#: id:35502
+msgctxt "Auto context with id 35502"
+msgid "Name"
+msgstr ""
+
+#: id:35503
+msgid "Vendor"
+msgstr ""
+
+#: id:35504
+msgid "Product ID"
+msgstr ""
+
+#: id:36000
+msgid "Pulse-Eight CEC adapter"
+msgstr ""
+
+#: id:36001
+msgid "Pulse-Eight Nyxboard"
+msgstr ""
+
+#: id:36002
+msgid "Switch to keyboard side command"
+msgstr ""
+
+#: id:36003
+msgid "Switch to remote side command"
+msgstr ""
+
+#: id:36004
+msgid "Press \"user\" button command"
+msgstr ""
+
+#: id:36005
+msgid "Enable switch side commands"
+msgstr ""
+
+#: id:36006
+msgid "Could not open the adapter"
+msgstr ""
+
+#: id:36007
+msgid "Devices to power on when starting XBMC"
+msgstr ""
+
+#: id:36008
+msgid "Devices to power off when stopping XBMC"
+msgstr ""
+
+#: id:36009
+msgid "Put devices in standby mode when activating screensaver"
+msgstr ""
+
+#: id:36011
+msgid "Could not detect the CEC port. Set it up manually."
+msgstr ""
+
+#: id:36012
+msgid "Could not initialise the CEC adapter. Check your settings."
+msgstr ""
+
+#: id:36013
+msgid "Unsupported libCEC interface version. %d is greater than the version XBMC supports (%d)"
+msgstr ""
+
+#: id:36014
+msgid "Put this PC in standby mode when the TV is switched off"
+msgstr ""
+
+#: id:36015
+msgid "HDMI port number"
+msgstr ""
+
+#: id:36016
+msgctxt "Auto context with id 36016"
+msgid "Connected"
+msgstr ""
+
+#: id:36017
+msgid "Adapter found, but libCEC is not available"
+msgstr ""
+
+#: id:36018
+msgid "Use the TV's language setting"
+msgstr ""
+
+#: id:36019
+msgid "Connected to HDMI device"
+msgstr ""
+
+#: id:36020
+msgid "Make XBMC the active source when starting"
+msgstr ""
+
+#: id:36021
+msgid "Physical address (overrules HDMI port)"
+msgstr ""
+
+#: id:36022
+msgid "COM port (leave empty unless needed)"
+msgstr ""
+
+#: id:36023
+msgid "Configuration updated"
+msgstr ""
+
+#: id:36024
+msgid "Failed to set the new configuration. Please check your settings."
+msgstr ""
+
+#: id:36025
+msgid "Send 'inactive source' command when stopping XBMC"
+msgstr ""
+

--- a/language/Dutch/strings.po
+++ b/language/Dutch/strings.po
@@ -1,0 +1,9093 @@
+# Converted from xbmc strings.xml with xbmc-xml2po (by Team-XBMC)
+msgid ""
+msgstr ""
+"Project-Id-Version: xbmc.core-FRODO_GIT3ed1604ad7\n"
+"Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
+"POT-Creation-Date: 2012-04-09 18:00+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE\n"
+"Language: nl\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: id:0
+msgctxt "Auto context with id 0"
+msgid "Programs"
+msgstr "Programma's"
+
+#: id:1
+msgctxt "Auto context with id 1"
+msgid "Pictures"
+msgstr "Afbeeldingen"
+
+#: id:2
+msgctxt "Auto context with id 2"
+msgid "Music"
+msgstr "Muziek"
+
+#: id:3
+msgctxt "Auto context with id 3"
+msgid "Videos"
+msgstr "Video's"
+
+#: id:4
+msgid "TV-Guide"
+msgstr "TV-gids"
+
+#: id:5
+msgctxt "Auto context with id 5"
+msgid "Settings"
+msgstr "Instellingen"
+
+#: id:6
+msgid "XBMC SVN"
+msgstr "XBMC SVN"
+
+#: id:7
+msgctxt "Auto context with id 7"
+msgid "File manager"
+msgstr "Bestandsbeheer"
+
+#: id:8
+msgctxt "Auto context with id 8"
+msgid "Weather"
+msgstr "Weer"
+
+#: id:9
+msgid "xbmc media center"
+msgstr "XBMC Media Center"
+
+#: id:11
+msgid "Monday"
+msgstr "Maandag"
+
+#: id:12
+msgid "Tuesday"
+msgstr "Dinsdag"
+
+#: id:13
+msgid "Wednesday"
+msgstr "Woensdag"
+
+#: id:14
+msgid "Thursday"
+msgstr "Donderdag"
+
+#: id:15
+msgid "Friday"
+msgstr "Vrijdag"
+
+#: id:16
+msgid "Saturday"
+msgstr "Zaterdag"
+
+#: id:17
+msgid "Sunday"
+msgstr "Zondag"
+
+#: id:21
+msgid "January"
+msgstr "januari"
+
+#: id:22
+msgid "February"
+msgstr "februari"
+
+#: id:23
+msgid "March"
+msgstr "maart"
+
+#: id:24
+msgid "April"
+msgstr "april"
+
+#: id:25
+msgctxt "Auto context with id 25"
+msgid "May"
+msgstr "mei"
+
+#: id:26
+msgid "June"
+msgstr "juni"
+
+#: id:27
+msgid "July"
+msgstr "juli"
+
+#: id:28
+msgid "August"
+msgstr "augustus"
+
+#: id:29
+msgid "September"
+msgstr "september"
+
+#: id:30
+msgid "October"
+msgstr "oktober"
+
+#: id:31
+msgid "November"
+msgstr "november"
+
+#: id:32
+msgid "December"
+msgstr "december"
+
+#: id:41
+msgid "Mon"
+msgstr "Ma"
+
+#: id:42
+msgid "Tue"
+msgstr "Di"
+
+#: id:43
+msgid "Wed"
+msgstr "Wo"
+
+#: id:44
+msgid "Thu"
+msgstr "Do"
+
+#: id:45
+msgid "Fri"
+msgstr "Vr"
+
+#: id:46
+msgid "Sat"
+msgstr "Za"
+
+#: id:47
+msgctxt "Auto context with id 47"
+msgid "Sun"
+msgstr "Zo"
+
+#: id:51
+msgid "Jan"
+msgstr "jan"
+
+#: id:52
+msgid "Feb"
+msgstr "feb"
+
+#: id:53
+msgid "Mar"
+msgstr "mrt"
+
+#: id:54
+msgid "Apr"
+msgstr "apr"
+
+#: id:55
+msgctxt "Auto context with id 55"
+msgid "May"
+msgstr "mei"
+
+#: id:56
+msgid "Jun"
+msgstr "jun"
+
+#: id:57
+msgid "Jul"
+msgstr "jul"
+
+#: id:58
+msgid "Aug"
+msgstr "aug"
+
+#: id:59
+msgid "Sep"
+msgstr "sep"
+
+#: id:60
+msgid "Oct"
+msgstr "okt"
+
+#: id:61
+msgid "Nov"
+msgstr "nov"
+
+#: id:62
+msgid "Dec"
+msgstr "dec"
+
+#: id:71
+msgid "N"
+msgstr "N"
+
+#: id:72
+msgid "NNE"
+msgstr "NNO"
+
+#: id:73
+msgid "NE"
+msgstr "NO"
+
+#: id:74
+msgid "ENE"
+msgstr "ONO"
+
+#: id:75
+msgid "E"
+msgstr "O"
+
+#: id:76
+msgid "ESE"
+msgstr "OZO"
+
+#: id:77
+msgid "SE"
+msgstr "ZO"
+
+#: id:78
+msgid "SSE"
+msgstr "ZZO"
+
+#: id:79
+msgid "S"
+msgstr "Z"
+
+#: id:80
+msgid "SSW"
+msgstr "ZZW"
+
+#: id:81
+msgid "SW"
+msgstr "ZW"
+
+#: id:82
+msgid "WSW"
+msgstr "WZW"
+
+#: id:83
+msgid "W"
+msgstr "W"
+
+#: id:84
+msgid "WNW"
+msgstr "WNW"
+
+#: id:85
+msgid "NW"
+msgstr "NW"
+
+#: id:86
+msgid "NNW"
+msgstr "NNW"
+
+#: id:87
+msgid "VAR"
+msgstr "variabele"
+
+#: id:98
+msgid "View: Auto"
+msgstr "Layout: Automatisch"
+
+#: id:99
+msgid "View: Auto big"
+msgstr "Layout: Autom. groot"
+
+#: id:100
+msgid "View: Icons"
+msgstr "Layout: Klein"
+
+#: id:101
+msgid "View: List"
+msgstr "Layout: Lijst"
+
+#: id:102
+msgctxt "Auto context with id 102"
+msgid "Scan"
+msgstr "Scannen"
+
+#: id:103
+msgctxt "Auto context with id 103"
+msgid "Sort by: Name"
+msgstr "Sorteer: Naam"
+
+#: id:104
+msgid "Sort by: Date"
+msgstr "Sorteer: Datum"
+
+#: id:105
+msgid "Sort by: Size"
+msgstr "Sorteer: Grootte"
+
+#: id:106
+msgid "No"
+msgstr "Nee"
+
+#: id:107
+msgid "Yes"
+msgstr "Ja"
+
+#: id:108
+msgctxt "Auto context with id 108"
+msgid "Slideshow"
+msgstr "Diavoorstelling"
+
+#: id:109
+msgid "Create thumbs"
+msgstr "Miniaturen aanmaken"
+
+#: id:110
+msgid "Create thumbnails"
+msgstr "Miniaturen aanmaken"
+
+#: id:111
+msgctxt "Auto context with id 111"
+msgid "Shortcuts"
+msgstr "Snelkoppelingen"
+
+#: id:112
+msgid "Paused"
+msgstr "Pauze"
+
+#: id:113
+msgid "Update failed"
+msgstr "Update mislukt"
+
+#: id:114
+msgid "Installation failed"
+msgstr "Installatie mislukt"
+
+#: id:115
+msgid "Copy"
+msgstr "Kopieer"
+
+#: id:116
+msgid "Move"
+msgstr "Verplaats"
+
+#: id:117
+msgid "Delete"
+msgstr "Verwijder"
+
+#: id:118
+msgid "Rename"
+msgstr "Hernoem"
+
+#: id:119
+msgid "New folder"
+msgstr "Nieuwe map"
+
+#: id:120
+msgid "Confirm file copy"
+msgstr "Bevestig kopieeropdracht"
+
+#: id:121
+msgid "Confirm file move"
+msgstr "Bevestig verplaatsopdracht"
+
+#: id:122
+msgid "Confirm file delete?"
+msgstr "Bevestig verwijderingsopdracht"
+
+#: id:123
+msgid "Copy these files?"
+msgstr "Deze bestanden kopiëren?"
+
+#: id:124
+msgid "Move these files?"
+msgstr "Deze bestanden verplaatsen?"
+
+#: id:125
+msgid "Delete these files? - Deleting files cannot be undone!"
+msgstr "Deze bestanden verwijderen? Dit kan niet meer ongedaan worden gemaakt!"
+
+#: id:126
+msgid "Status"
+msgstr "Status"
+
+#: id:127
+msgid "Objects"
+msgstr "Items"
+
+#: id:128
+msgctxt "Auto context with id 128"
+msgid "General"
+msgstr "Algemeen"
+
+#: id:129
+msgctxt "Auto context with id 129"
+msgid "Slideshow"
+msgstr "Voorstelling"
+
+#: id:130
+msgctxt "Auto context with id 130"
+msgid "System info"
+msgstr "Systeeminformatie"
+
+#: id:131
+msgid "Display"
+msgstr "Beeldscherm"
+
+#: id:132
+msgid "Albums"
+msgstr "Albums"
+
+#: id:133
+msgid "Artists"
+msgstr "Artiesten"
+
+#: id:134
+msgid "Songs"
+msgstr "Alle nummers"
+
+#: id:135
+msgid "Genres"
+msgstr "Genres"
+
+#: id:136
+msgid "Playlists"
+msgstr "Afspeellijsten"
+
+#: id:137
+msgid "Search"
+msgstr "Zoeken"
+
+#: id:138
+msgid "System Information"
+msgstr "Systeeminformatie"
+
+#: id:139
+msgid "Temperatures:"
+msgstr "Temperaturen:"
+
+#: id:140
+msgid "CPU:"
+msgstr "Processor:"
+
+#: id:141
+msgid "GPU:"
+msgstr "GPU:"
+
+#: id:142
+msgid "Time:"
+msgstr "Tijd:"
+
+#: id:143
+msgid "Current:"
+msgstr "Huidige:"
+
+#: id:144
+msgid "Build:"
+msgstr "Versie:"
+
+#: id:145
+msgid "Network:"
+msgstr "Netwerk:"
+
+#: id:146
+msgid "Type:"
+msgstr "Type:"
+
+#: id:147
+msgid "Static"
+msgstr "Statisch"
+
+#: id:148
+msgid "DHCP"
+msgstr "DHCP"
+
+#: id:149
+msgid "MAC address"
+msgstr "MAC-adres"
+
+#: id:150
+msgctxt "Auto context with id 150"
+msgid "IP address"
+msgstr "IP-adres"
+
+#: id:151
+msgid "Link:"
+msgstr "Verbinding:"
+
+#: id:152
+msgid "Half duplex"
+msgstr "Half-duplex"
+
+#: id:153
+msgid "Full duplex"
+msgstr "Full-duplex"
+
+#: id:154
+msgctxt "Auto context with id 154"
+msgid "Storage"
+msgstr "Opslag"
+
+#: id:155
+msgid "Drive"
+msgstr "Schijf"
+
+#: id:156
+msgctxt "Auto context with id 156"
+msgid "Free"
+msgstr "Vrij"
+
+#: id:157
+msgctxt "Auto context with id 157"
+msgid "Video"
+msgstr "Video"
+
+#: id:158
+msgid "Free memory"
+msgstr "Beschikbaar geheugen"
+
+#: id:159
+msgid "No link"
+msgstr "Geen verbinding"
+
+#: id:160
+msgctxt "Auto context with id 160"
+msgid "Free"
+msgstr "Vrij"
+
+#: id:161
+msgid "Unavailable"
+msgstr "Niet beschikbaar"
+
+#: id:162
+msgid "Tray open"
+msgstr "Lade open"
+
+#: id:163
+msgid "Reading"
+msgstr "Inlezen"
+
+#: id:164
+msgid "No disc"
+msgstr "Geen schijf"
+
+#: id:165
+msgid "Disc present"
+msgstr "Schijf aanwezig"
+
+#: id:166
+msgid "Skin"
+msgstr "Skin"
+
+#: id:169
+msgctxt "Auto context with id 169"
+msgid "Resolution"
+msgstr "Resolutie"
+
+#: id:170
+msgid "Adjust display refresh rate to match video"
+msgstr "Verversingsfrequentie scherm aanpassen aan video"
+
+#: id:172
+msgid "Release date"
+msgstr "Releasedatum:"
+
+#: id:173
+msgid "Display 4:3 videos as"
+msgstr "Geef 4:3 video's weer als"
+
+#: id:175
+msgid "Moods"
+msgstr "Stemmingen"
+
+#: id:176
+msgid "Styles"
+msgstr "Stijlen"
+
+#: id:179
+msgid "Song"
+msgstr "Tracklist"
+
+#: id:180
+msgid "Duration"
+msgstr "Tijdsduur"
+
+#: id:181
+msgid "Select album"
+msgstr "Selecteer album"
+
+#: id:182
+msgid "Tracks"
+msgstr "Nummer"
+
+#: id:183
+msgid "Review"
+msgstr "Beschrijving"
+
+#: id:184
+msgid "Refresh"
+msgstr "Vernieuwen"
+
+#: id:185
+msgid "Searching album"
+msgstr "Albuminformatie ophalen"
+
+#: id:186
+msgid "OK"
+msgstr "OK"
+
+#: id:187
+msgid "No albums found!"
+msgstr "Geen albums gevonden!"
+
+#: id:188
+msgid "Select all"
+msgstr "Alles selecteren"
+
+#: id:189
+msgid "Scanning media info"
+msgstr "Scannen media-informatie"
+
+#: id:190
+msgid "Save"
+msgstr "Opslaan"
+
+#: id:191
+msgid "Shuffle"
+msgstr "Willekeurig"
+
+#: id:192
+msgctxt "Auto context with id 192"
+msgid "Clear"
+msgstr "Wissen"
+
+#: id:193
+msgctxt "Auto context with id 193"
+msgid "Scan"
+msgstr "Scannen"
+
+#: id:194
+msgid "Searching..."
+msgstr "Zoeken..."
+
+#: id:195
+msgid "No info found!"
+msgstr "Geen informatie gevonden"
+
+#: id:196
+msgid "Select movie:"
+msgstr "Kies film:"
+
+#: id:197
+msgid "Querying %s info"
+msgstr "%s raadplegen voor informatie"
+
+#: id:198
+msgid "Loading movie details"
+msgstr "Filmgegevens ophalen"
+
+#: id:199
+msgid "Web interface"
+msgstr "Webinterface"
+
+#: id:202
+msgid "Tagline"
+msgstr "Slagzin"
+
+#: id:203
+msgid "Plot outline"
+msgstr "Plot"
+
+#: id:205
+msgid "Votes"
+msgstr "Stemmen"
+
+#: id:206
+msgid "Cast"
+msgstr "Acteurs"
+
+#: id:207
+msgid "Plot"
+msgstr "Plot"
+
+#: id:208
+msgctxt "Auto context with id 208"
+msgid "Play"
+msgstr "Afspelen"
+
+#: id:209
+msgid "Next"
+msgstr "Volgende"
+
+#: id:210
+msgid "Previous"
+msgstr "Vorige"
+
+#: id:213
+msgid "Calibrate user interface..."
+msgstr "Gebruikersomgeving kalibreren"
+
+#: id:214
+msgid "Video calibration..."
+msgstr "Beeldscherm kalibreren..."
+
+#: id:215
+msgid "Soften"
+msgstr "Verzachten"
+
+#: id:216
+msgid "Zoom amount"
+msgstr "Zoomen"
+
+#: id:217
+msgid "Pixel ratio"
+msgstr "Uitrekken"
+
+#: id:218
+msgid "DVD drive"
+msgstr "DVD-station"
+
+#: id:219
+msgid "Please insert disc"
+msgstr "Plaats een schijf"
+
+#: id:220
+msgid "Remote share"
+msgstr "Gedeeld op afstand"
+
+#: id:221
+msgid "Network is not connected"
+msgstr "Netwerk is niet verbonden"
+
+#: id:222
+msgid "Cancel"
+msgstr "Annuleren"
+
+#: id:224
+msgid "Speed"
+msgstr "Snelheid"
+
+#: id:225
+msgid "Vertical Shift"
+msgstr "Verticale verschuiving"
+
+#: id:226
+msgid "Test patterns..."
+msgstr "Testbeeld..."
+
+#: id:227
+msgid "Lookup audio CD track names from freedb.org"
+msgstr "Bij muziek CD's namen van nummers via internet opzoeken"
+
+#: id:228
+msgid "Shuffle playlist on load"
+msgstr "Afspeellijst willekeurig afspelen"
+
+#: id:229
+msgid "HDD spindown time"
+msgstr "Schakel harde schijf uit na"
+
+#: id:230
+msgid "Video filters"
+msgstr "Videofilters"
+
+#: id:231
+msgctxt "Auto context with id 231"
+msgid "None"
+msgstr "Geen"
+
+#: id:232
+msgid "Point"
+msgstr "Punt"
+
+#: id:233
+msgid "Linear"
+msgstr "Lineair"
+
+#: id:234
+msgid "Anisotropic"
+msgstr "Anisotropisch"
+
+#: id:235
+msgid "Quincunx"
+msgstr "Quincunx"
+
+#: id:236
+msgid "Gaussian cubic"
+msgstr "Gaussian Cubic"
+
+#: id:237
+msgid "Minification"
+msgstr "Verkleinen"
+
+#: id:238
+msgid "Magnification"
+msgstr "Vergroten"
+
+#: id:239
+msgid "Clear playlist on finish"
+msgstr "Afspeellijst wissen na afspelen"
+
+#: id:240
+msgid "Display Mode"
+msgstr "Weergavemodus"
+
+#: id:241
+msgid "Full Screen #%d"
+msgstr "Volledig scherm #%d"
+
+#: id:242
+msgid "Windowed"
+msgstr "Venster"
+
+#: id:243
+msgid "Refresh Rate"
+msgstr "Verversingsfrequentie"
+
+#: id:244
+msgid "Full screen"
+msgstr "Volledig scherm"
+
+#: id:245
+msgid "Sizing: (%i,%i)->(%i,%i) (Zoom x%2.2f) AR:%2.2f:1 (Pixels: %2.2f:1) (VShift: %2.2f)"
+msgstr "Formaat: (%i,%i)->(%i,%i) (Zoom x%2.2f) AR:%2.2f:1 (Pixels: %2.2f:1)"
+
+#: id:247
+msgctxt "Auto context with id 247"
+msgid "Scripts"
+msgstr "Scripts"
+
+#: id:248
+msgctxt "Auto context with id 248"
+msgid "Language"
+msgstr "Taal"
+
+#: id:249
+msgctxt "Auto context with id 249"
+msgid "Music"
+msgstr "Muziek"
+
+#: id:250
+msgctxt "Auto context with id 250"
+msgid "Visualization"
+msgstr "Visualisatie"
+
+#: id:251
+msgid "Select destination directory"
+msgstr "Selecteer doelmap"
+
+#: id:252
+msgid "Output stereo to all speakers"
+msgstr "Geluid naar alle luidsprekers"
+
+#: id:253
+msgid "Number of channels"
+msgstr "Aantal kanalen"
+
+#: id:254
+msgid "- DTS capable receiver"
+msgstr "- Versterker ondersteunt DTS"
+
+#: id:255
+msgid "CDDB"
+msgstr "CDDB"
+
+#: id:256
+msgid "Fetching CD information"
+msgstr "CD-informatie opzoeken"
+
+#: id:257
+msgid "Error"
+msgstr "Fout"
+
+#: id:258
+msgid "Enable tag reading"
+msgstr "Metadata uitlezen (ID3v2, APEv2)"
+
+#: id:259
+msgid "Opening"
+msgstr "Openen"
+
+#: id:260
+msgid "Shoutcast"
+msgstr "Shoutcast"
+
+#: id:261
+msgid "Waiting for start..."
+msgstr "Wachten op start..."
+
+#: id:262
+msgid "Scripts output"
+msgstr "Uitvoer scripts"
+
+#: id:263
+msgid "Allow control of XBMC via HTTP"
+msgstr "Webserver"
+
+#: id:264
+msgid "Record"
+msgstr "Opnemen"
+
+#: id:265
+msgid "Stop Rec."
+msgstr "Stop opname"
+
+#: id:266
+msgid "Sort by: Track"
+msgstr "Sorteer: Naam"
+
+#: id:267
+msgid "Sort by: Time"
+msgstr "Sorteer: Tijd"
+
+#: id:268
+msgid "Sort by: Title"
+msgstr "Sorteer: Titel"
+
+#: id:269
+msgid "Sort by: Artist"
+msgstr "Sorteer: Artiest"
+
+#: id:270
+msgid "Sort by: Album"
+msgstr "Sorteer: Album"
+
+#: id:271
+msgid "Top 100"
+msgstr "Top 100"
+
+#: id:272
+msgid "Top-Left overscan compensation"
+msgstr "Beeldpositie linksboven"
+
+#: id:273
+msgid "Bottom-Right overscan compensation"
+msgstr "Beeldpositie rechtsonder"
+
+#: id:274
+msgid "Subtitle positioning"
+msgstr "Positie ondertitels"
+
+#: id:275
+msgid "Pixel ratio adjustment"
+msgstr "Aanpassing pixelratio"
+
+#: id:276
+msgid "Adjust the arrow to change the amount of overscan"
+msgstr "Beweeg de pijlen om de overscan aan te passen"
+
+#: id:277
+msgid "Adjust the bar to change the subtitles position"
+msgstr "Beweeg de balk om de ondertitels te verplaatsen"
+
+#: id:278
+msgid "Adjust the rectangle so it is perfectly square"
+msgstr "Pas de rechthoek aan zodat deze precies vierkant is"
+
+#: id:279
+msgid "Unable to load settings"
+msgstr "Fout tijdens het laden van de instellingen"
+
+#: id:280
+msgid "Using default settings"
+msgstr "Standaardinstellingen actief"
+
+#: id:281
+msgid "Please check the XML files"
+msgstr "Controleer de XML-bestanden"
+
+#: id:282
+msgid "Found %i items"
+msgstr "%i items gevonden"
+
+#: id:283
+msgid "Search results"
+msgstr "Zoekresultaten"
+
+#: id:284
+msgid "No results found"
+msgstr "Niets gevonden"
+
+#: id:287
+msgctxt "Auto context with id 287"
+msgid "Subtitles"
+msgstr "Ondertiteling"
+
+#: id:288
+msgctxt "Auto context with id 288"
+msgid "Font"
+msgstr "Lettertype"
+
+#: id:289
+msgctxt "Auto context with id 289"
+msgid "- Size"
+msgstr "- Formaat"
+
+#: id:290
+msgid "Dynamic range compression"
+msgstr "Dynamic Range-compressie"
+
+#: id:291
+msgctxt "Auto context with id 291"
+msgid "Video"
+msgstr "Beeld"
+
+#: id:292
+msgctxt "Auto context with id 292"
+msgid "Audio"
+msgstr "Geluid"
+
+#: id:293
+msgid "Browse for subtitles"
+msgstr "Ondertitels zoeken"
+
+#: id:294
+msgid "Create bookmark"
+msgstr "Positie opslaan"
+
+#: id:296
+msgid "Clear bookmarks"
+msgstr "Posities verwijderen"
+
+#: id:297
+msgid "Audio offset"
+msgstr "Geluid synchroniseren"
+
+#: id:298
+msgid "Bookmarks"
+msgstr "Favorieten"
+
+#: id:299
+msgid "- AAC capable receiver"
+msgstr "- Versterker ondersteunt AAC"
+
+#: id:300
+msgid "- MP1 capable receiver"
+msgstr "- Versterker ondersteunt MP1"
+
+#: id:301
+msgid "- MP2 capable receiver"
+msgstr "- Versterker ondersteunt MP2"
+
+#: id:302
+msgid "- MP3 capable receiver"
+msgstr "- Versterker ondersteunt MP3"
+
+#: id:303
+msgid "Delay"
+msgstr "Vertraging"
+
+#: id:304
+msgctxt "Auto context with id 304"
+msgid "Language"
+msgstr "Taal"
+
+#: id:305
+msgctxt "Auto context with id 305"
+msgid "Enabled"
+msgstr "Ingeschakeld"
+
+#: id:306
+msgid "Non-interleaved"
+msgstr "Non-Interleaved"
+
+#: id:312
+msgid "(0=auto)"
+msgstr "(0=auto)"
+
+#: id:313
+msgid "Cleaning database"
+msgstr "Bibliotheek opschonen"
+
+#: id:314
+msgid "Preparing..."
+msgstr "Voorbereiden..."
+
+#: id:315
+msgid "Database error"
+msgstr "Blbliotheekfout"
+
+#: id:316
+msgid "Searching songs..."
+msgstr "Zoeken op nummers..."
+
+#: id:317
+msgid "Cleaned database successfully"
+msgstr "Klaar met bibliotheek opschonen"
+
+#: id:318
+msgid "Cleaning songs..."
+msgstr "Verwijderde nummers markeren"
+
+#: id:319
+msgid "Error cleaning songs"
+msgstr "Fout tijdens reorganiseren nummers"
+
+#: id:320
+msgid "Cleaning artists..."
+msgstr "Artiesten opschonen..."
+
+#: id:321
+msgid "Error cleaning artists"
+msgstr "Fout tijdens opschonen artiesten"
+
+#: id:322
+msgid "Cleaning genres..."
+msgstr "Genres opschonen..."
+
+#: id:323
+msgid "Error cleaning genres"
+msgstr "Fout tijdens opschonen genres"
+
+#: id:324
+msgid "Cleaning paths..."
+msgstr "Locaties opschonen..."
+
+#: id:325
+msgid "Error cleaning paths"
+msgstr "Fout tijdens opschonen locaties"
+
+#: id:326
+msgid "Cleaning albums..."
+msgstr "Albums opschonen..."
+
+#: id:327
+msgid "Error cleaning albums"
+msgstr "Fout tijdens opschonen albums"
+
+#: id:328
+msgid "Writing changes..."
+msgstr "Aanpassingen opslaan..."
+
+#: id:329
+msgid "Error writing changes"
+msgstr "Fout tijdens opslaan aanpassingen"
+
+#: id:330
+msgid "This may take some time..."
+msgstr "Een moment geduld a.u.b."
+
+#: id:331
+msgid "Compressing database..."
+msgstr "Bibliotheek comprimeren..."
+
+#: id:332
+msgid "Error compressing database"
+msgstr "Fout tijdens comprimeren bibliotheek"
+
+#: id:333
+msgid "Do you want to clean the library?"
+msgstr "Wilt u de mediabibliotheek opschonen?"
+
+#: id:334
+msgid "Clean library..."
+msgstr "Bibliotheek opschonen..."
+
+#: id:335
+msgid "Start"
+msgstr "Start"
+
+#: id:336
+msgid "Framerate conversion"
+msgstr "Framerateconversie"
+
+#: id:337
+msgctxt "Auto context with id 337"
+msgid "Audio output"
+msgstr "Geluidsuitvoer"
+
+#: id:338
+msgid "Analog"
+msgstr "Analoog"
+
+#: id:339
+msgid "Optical/Coax"
+msgstr "Digitaal"
+
+#: id:340
+msgid "Various artists"
+msgstr "Diverse artiesten"
+
+#: id:341
+msgid "Play disc"
+msgstr "DVD afspelen"
+
+#: id:342
+msgctxt "Auto context with id 342"
+msgid "Movies"
+msgstr "Speelfilms"
+
+#: id:343
+msgid "Adjust framerate"
+msgstr "Framerate aanpassen"
+
+#: id:344
+msgid "Actors"
+msgstr "Acteurs"
+
+#: id:345
+msgctxt "Auto context with id 345"
+msgid "Year"
+msgstr "Jaar"
+
+#: id:346
+msgid "Boost volume level on downmix"
+msgstr "Volume verhogen bij downmixen"
+
+#: id:350
+msgctxt "Auto context with id 350"
+msgid "Programs"
+msgstr "Programma's"
+
+#: id:351
+msgctxt "Auto context with id 351"
+msgid "Off"
+msgstr "Uit"
+
+#: id:352
+msgid "Dim"
+msgstr "Dimmen"
+
+#: id:353
+msgid "Black"
+msgstr "Zwart"
+
+#: id:354
+msgid "Matrix trails"
+msgstr "Matrix Sporen"
+
+#: id:355
+msgid "Screensaver time"
+msgstr "Schermbeveiliging inschakelen na:"
+
+#: id:356
+msgid "Screensaver mode"
+msgstr "Type schermbeveiliging"
+
+#: id:357
+msgid "Shutdown function timer"
+msgstr "Standaard afsluitmethode toepassen na"
+
+#: id:358
+msgid "All albums"
+msgstr "Alle albums"
+
+#: id:359
+msgid "Recently added albums"
+msgstr "Onlangs toegevoegde albums"
+
+#: id:360
+msgctxt "Auto context with id 360"
+msgid "Screensaver"
+msgstr "Schermbeveiliging"
+
+#: id:361
+msgid "R. Slideshow"
+msgstr "Map Diavoorst."
+
+#: id:362
+msgid "Screensaver dim level"
+msgstr "Doorzichtigheid schermbeveiliging"
+
+#: id:363
+msgid "Sort by: File"
+msgstr "Sorteer: Bestand"
+
+#: id:364
+msgid "- Dolby Digital (AC3) capable receiver"
+msgstr "- Versterker ondersteunt AC3"
+
+#: id:365
+msgctxt "Auto context with id 365"
+msgid "Sort by: Name"
+msgstr "Sorteer: Naam"
+
+#: id:366
+msgid "Sort by: Year"
+msgstr "Sorteer: Jaar"
+
+#: id:367
+msgid "Sort by: Rating"
+msgstr "Sorteer: Waardering"
+
+#: id:368
+msgid "IMDb"
+msgstr "IMDb"
+
+#: id:369
+msgctxt "Auto context with id 369"
+msgid "Title"
+msgstr "Titel"
+
+#: id:370
+msgid "Thunderstorms"
+msgstr "Onweer"
+
+#: id:371
+msgid "Partly"
+msgstr "Gedeeltelijk"
+
+#: id:372
+msgid "Mostly"
+msgstr "Overwegend"
+
+#: id:373
+msgid "Sunny"
+msgstr "Zonnig"
+
+#: id:374
+msgid "Cloudy"
+msgstr "Bewolkt"
+
+#: id:375
+msgid "Snow"
+msgstr "Sneeuw"
+
+#: id:376
+msgid "Rain"
+msgstr "Regen"
+
+#: id:377
+msgid "Light"
+msgstr "Lichte"
+
+#: id:378
+msgid "AM"
+msgstr "'s Ochtends"
+
+#: id:379
+msgid "PM"
+msgstr "'s Middags"
+
+#: id:380
+msgid "Showers"
+msgstr "Buien"
+
+#: id:381
+msgid "Few"
+msgstr "Lichte"
+
+#: id:382
+msgid "Scattered"
+msgstr "Verstrooide"
+
+#: id:383
+msgctxt "Auto context with id 383"
+msgid "Wind"
+msgstr "Wind"
+
+#: id:384
+msgid "Strong"
+msgstr "Sterk"
+
+#: id:385
+msgid "Fair"
+msgstr "Mooi"
+
+#: id:386
+msgctxt "Auto context with id 386"
+msgid "Clear"
+msgstr "Helder"
+
+#: id:387
+msgid "Clouds"
+msgstr "Wolken"
+
+#: id:388
+msgid "Early"
+msgstr "Vroeg"
+
+#: id:389
+msgid "Shower"
+msgstr "Buien"
+
+#: id:390
+msgid "Flurries"
+msgstr "Natte Sneeuw"
+
+#: id:391
+msgctxt "Auto context with id 391"
+msgid "Low"
+msgstr "Min"
+
+#: id:392
+msgctxt "Auto context with id 392"
+msgid "Medium"
+msgstr "Gem."
+
+#: id:393
+msgctxt "Auto context with id 393"
+msgid "High"
+msgstr "Max."
+
+#: id:394
+msgid "Fog"
+msgstr "Mist"
+
+#: id:395
+msgid "Haze"
+msgstr "Nevel"
+
+#: id:396
+msgid "Select location"
+msgstr "Locatie selecteren"
+
+#: id:397
+msgid "Refresh time"
+msgstr "Vernieuwingstijd"
+
+#: id:398
+msgid "Temperature units"
+msgstr "Eenheid temperatuur"
+
+#: id:399
+msgid "Speed units"
+msgstr "Eenheid windsnelheid"
+
+#: id:400
+msgctxt "Auto context with id 400"
+msgid "Weather"
+msgstr "Het weer"
+
+#: id:401
+msgid "Temp"
+msgstr "Temperatuur"
+
+#: id:402
+msgid "Feels like"
+msgstr "Gevoelstemp."
+
+#: id:403
+msgid "UV index"
+msgstr "UV-index"
+
+#: id:404
+msgctxt "Auto context with id 404"
+msgid "Wind"
+msgstr "Wind"
+
+#: id:405
+msgid "Dew point"
+msgstr "Dauwpunt"
+
+#: id:406
+msgid "Humidity"
+msgstr "Vochtigheid"
+
+#: id:409
+msgid "Defaults"
+msgstr "Standaard"
+
+#: id:410
+msgid "Accessing weather service"
+msgstr "Weersverwachting opzoeken"
+
+#: id:411
+msgid "Getting weather for:"
+msgstr "Weersverwachting ophalen voor"
+
+#: id:412
+msgid "Unable to get weather data"
+msgstr "Fout tijdens ophalen gegevens"
+
+#: id:413
+msgid "Manual"
+msgstr "Handmatig"
+
+#: id:414
+msgid "No review for this album"
+msgstr "Geen recensie voor dit album"
+
+#: id:415
+msgid "Downloading thumbnail..."
+msgstr "Miniatuur downloaden..."
+
+#: id:416
+msgid "Not available"
+msgstr "Niet beschikbaar"
+
+#: id:417
+msgid "View: Big icons"
+msgstr "Layout: Groot"
+
+#: id:418
+msgctxt "Auto context with id 418"
+msgid "Low"
+msgstr "Min"
+
+#: id:419
+msgctxt "Auto context with id 419"
+msgid "High"
+msgstr "Max"
+
+#: id:420
+msgid "HDMI"
+msgstr "HDMI"
+
+#: id:422
+msgid "Delete album info"
+msgstr "Albuminformatie wissen"
+
+#: id:423
+msgid "Delete CD information"
+msgstr "CDDB-informatie wissen"
+
+#: id:424
+msgid "Select"
+msgstr "Selecteer"
+
+#: id:425
+msgid "No album information found"
+msgstr "Geen albuminformatie gevonden."
+
+#: id:426
+msgid "No CD information found"
+msgstr "Geen CDDB-informatie gevonden."
+
+#: id:427
+msgid "Disc"
+msgstr "Schijf:"
+
+#: id:428
+msgid "Insert correct CD/DVD"
+msgstr "Voer de juiste CD/DVD in"
+
+#: id:429
+msgid "Please insert the following disc:"
+msgstr "Voer de volgende CD/DVD in"
+
+#: id:430
+msgid "Sort by: DVD#"
+msgstr "Sorteer: DVD#"
+
+#: id:431
+msgid "No cache"
+msgstr "Data niet bufferen"
+
+#: id:432
+msgid "Remove movie from library"
+msgstr "Speelfilm uit bibliotheek verwijderen"
+
+#: id:433
+msgid "Really remove '%s'?"
+msgstr "'%s' zeker verwijderen?"
+
+#: id:434
+msgid "From %s at %i %s"
+msgstr "Uit het %s met %i %s"
+
+#: id:437
+msgid "Removable disk"
+msgstr "Verwisselbare schijf"
+
+#: id:438
+msgid "Opening file"
+msgstr "Bestand openen"
+
+#: id:439
+msgid "Cache"
+msgstr "Buffer"
+
+#: id:440
+msgid "Harddisk"
+msgstr "Harde schijf"
+
+#: id:441
+msgid "UDF"
+msgstr "UDF"
+
+#: id:442
+msgid "Local network"
+msgstr "LAN"
+
+#: id:443
+msgid "Internet"
+msgstr "Internet"
+
+#: id:444
+msgctxt "Auto context with id 444"
+msgid "Video"
+msgstr "Video"
+
+#: id:445
+msgctxt "Auto context with id 445"
+msgid "Audio"
+msgstr "Geluid"
+
+#: id:446
+msgctxt "Auto context with id 446"
+msgid "DVD"
+msgstr "DVD"
+
+#: id:447
+msgid "Autorun media"
+msgstr "Autom. starten"
+
+#: id:448
+msgid "LCD"
+msgstr "LCD"
+
+#: id:449
+msgctxt "Auto context with id 449"
+msgid "Enabled"
+msgstr "Geactiveerd"
+
+#: id:450
+msgid "Columns"
+msgstr "Kolommen"
+
+#: id:451
+msgid "Row 1 address"
+msgstr "Begin rij 1:"
+
+#: id:452
+msgid "Row 2 address"
+msgstr "Begin rij 2:"
+
+#: id:453
+msgid "Row 3 address"
+msgstr "Begin rij 3:"
+
+#: id:454
+msgid "Row 4 address"
+msgstr "Begin rij 4:"
+
+#: id:455
+msgid "Rows"
+msgstr "Rijen"
+
+#: id:456
+msgid "Mode"
+msgstr "Modus"
+
+#: id:457
+msgid "Switch view"
+msgstr "Layout wijzigen"
+
+#: id:459
+msgid "Subs"
+msgstr "Ondertitels"
+
+#: id:460
+msgid "Audio stream"
+msgstr "Geluidskanaal"
+
+#: id:461
+msgid "[active]"
+msgstr "[actief]"
+
+#: id:462
+msgid "Subtitle"
+msgstr "Ondertitels"
+
+#: id:463
+msgid "Backlight"
+msgstr "Verlichting"
+
+#: id:464
+msgid "Brightness"
+msgstr "Helderheid"
+
+#: id:465
+msgid "Contrast"
+msgstr "Contrast"
+
+#: id:466
+msgid "Gamma"
+msgstr "Gamma"
+
+#: id:467
+msgctxt "Auto context with id 467"
+msgid "Type"
+msgstr "Type"
+
+#: id:468
+msgid "Move the bar to change the OSD position"
+msgstr "Verplaats de balk om het OSD te verplaatsen"
+
+#: id:469
+msgid "OSD position"
+msgstr "OSD-positie"
+
+#: id:470
+msgid "Credits"
+msgstr "Credits"
+
+#: id:471
+msgid "Modchip"
+msgstr "Modchip"
+
+#: id:474
+msgctxt "Auto context with id 474"
+msgid "Off"
+msgstr "Uit"
+
+#: id:475
+msgid "Music only"
+msgstr "Alleen geluid"
+
+#: id:476
+msgctxt "Auto context with id 476"
+msgid "Music & video"
+msgstr "Geluid en video"
+
+#: id:477
+msgid "Unable to load playlist"
+msgstr "Afspeellijst kon niet worden geladen"
+
+#: id:478
+msgid "OSD"
+msgstr "On Screen Display"
+
+#: id:479
+msgid "Skin & language"
+msgstr "Skin en taal"
+
+#: id:480
+msgid "Appearance"
+msgstr "Uiterlijk"
+
+#: id:481
+msgid "Audio options"
+msgstr "Geluidsinstellingen"
+
+#: id:482
+msgid "About XBMC"
+msgstr "Over XBMC"
+
+#: id:485
+msgid "Delete album"
+msgstr "Album verwijderen"
+
+#: id:486
+msgid "Repeat"
+msgstr "Herhalen"
+
+#: id:487
+msgid "Repeat one"
+msgstr "Nummer herhalen"
+
+#: id:488
+msgid "Repeat folder"
+msgstr "Mappen herhalen"
+
+#: id:489
+msgid "Play the next song automatically"
+msgstr "Automatisch het volgende nummer in de lijst afspelen"
+
+#: id:491
+msgid "- Use big icons"
+msgstr "- Grote iconen gebruiken"
+
+#: id:492
+msgid "Resize VobSubs"
+msgstr "Ondertitels vergroten"
+
+#: id:493
+msgid "Advanced options (Experts Only!)"
+msgstr "Geavanceerde opties (alleen experts!)"
+
+#: id:494
+msgid "Overall audio headroom"
+msgstr "Algemene audio headroom"
+
+#: id:495
+msgid "Upsample videos to GUI resolution"
+msgstr "Video naar GUI-resolutie upsamplen"
+
+#: id:496
+msgid "Calibration"
+msgstr "Kalibratie"
+
+#: id:497
+msgid "Show file extensions"
+msgstr "Extensies mediabestanden tonen"
+
+#: id:498
+msgid "Sort by: Type"
+msgstr "Sorteer: Type"
+
+#: id:499
+msgid "Unable to connect to online lookup service"
+msgstr "Kan geen verbinding maken met allmusic.com"
+
+#: id:500
+msgid "Downloading album information failed"
+msgstr "Albuminfo downloaden mislukt"
+
+#: id:501
+msgid "Looking for album names..."
+msgstr "Zoeken naar albumnamen..."
+
+#: id:502
+msgctxt "Auto context with id 502"
+msgid "Open"
+msgstr "Open"
+
+#: id:503
+msgid "Busy"
+msgstr "Bezig"
+
+#: id:504
+msgid "Empty"
+msgstr "Leeg"
+
+#: id:505
+msgid "Loading media info from files..."
+msgstr "Media-info van bestanden inlezen..."
+
+#: id:507
+msgid "Sort by: Usage"
+msgstr "Sorteer: Gebruik"
+
+#: id:510
+msgid "Enable visualizations"
+msgstr "Visualisaties weergeven"
+
+#: id:511
+msgid "Enable video mode switching"
+msgstr "Videoweergave automatisch aanpassen aan regiocode"
+
+#: id:512
+msgid "Startup window"
+msgstr "Start met venster"
+
+#: id:513
+msgid "Home window"
+msgstr "Beginscherm"
+
+#: id:514
+msgid "Manual settings"
+msgstr "Handmatige instellingen"
+
+#: id:515
+msgid "Genre"
+msgstr "Genre"
+
+#: id:517
+msgid "Recently played albums"
+msgstr "Laatst afgespeelde albums"
+
+#: id:518
+msgid "Launch"
+msgstr "Starten"
+
+#: id:519
+msgid "Launch in..."
+msgstr "Starten in.."
+
+#: id:521
+msgid "Compilations"
+msgstr "Compilaties"
+
+#: id:522
+msgid "Remove source"
+msgstr "Snelkoppeling verwijderen"
+
+#: id:523
+msgid "Switch media"
+msgstr "Media veranderen"
+
+#: id:524
+msgid "Select playlist"
+msgstr "Afspeellijst kiezen"
+
+#: id:525
+msgid "New playlist..."
+msgstr "Nieuwe afspeellijst"
+
+#: id:526
+msgid "Add to playlist"
+msgstr "Aan afspeellijst toevoegen"
+
+#: id:527
+msgid "Manually add to library"
+msgstr "Handmatig toevoegen"
+
+#: id:528
+msgid "Enter title"
+msgstr "Voer titel in"
+
+#: id:529
+msgid "Error: Duplicate title"
+msgstr "Fout : Bestaande titel"
+
+#: id:530
+msgid "Select genre"
+msgstr "Kies genre"
+
+#: id:531
+msgid "New genre"
+msgstr "Nieuw genre"
+
+#: id:532
+msgid "Manual addition"
+msgstr "Handmatig toegevoegd"
+
+#: id:533
+msgid "Enter genre"
+msgstr "Voer genre in"
+
+#: id:534
+msgid "View: %s"
+msgstr "Layout: %s"
+
+#: id:535
+msgid "List"
+msgstr "Lijst"
+
+#: id:536
+msgid "Icons"
+msgstr "Iconen"
+
+#: id:537
+msgid "Big list"
+msgstr "Grote lijst"
+
+#: id:538
+msgid "Big icons"
+msgstr "Grote iconen"
+
+#: id:539
+msgid "Wide"
+msgstr "Wijd"
+
+#: id:540
+msgid "Big wide"
+msgstr "Groot, wijd"
+
+#: id:541
+msgid "Album icons"
+msgstr "Covers"
+
+#: id:542
+msgid "DVD icons"
+msgstr "DVD-iconen"
+
+#: id:543
+msgctxt "Auto context with id 543"
+msgid "DVD"
+msgstr "DVD"
+
+#: id:544
+msgctxt "Auto context with id 544"
+msgid "Media info"
+msgstr "Media-info"
+
+#: id:545
+msgid "Audio output device"
+msgstr "Apparaat voor geluidsuitvoer"
+
+#: id:546
+msgid "Passthrough output device"
+msgstr "Doorgifte Geluidsuitvoerapparaat"
+
+#: id:547
+msgid "No biography for this artist"
+msgstr "Geen biografie beschikbaar voor artiest"
+
+#: id:548
+msgid "Downmix multichannel audio to stereo"
+msgstr "Downmix multikanaals audio naar stereo"
+
+#: id:550
+msgid "Sort by: %s"
+msgstr "Sorteer: %s"
+
+#: id:551
+msgctxt "Auto context with id 551"
+msgid "Name"
+msgstr "Naam"
+
+#: id:552
+msgid "Date"
+msgstr "Datum"
+
+#: id:553
+msgid "Size"
+msgstr "Grootte"
+
+#: id:554
+msgid "Track"
+msgstr "Nummer"
+
+#: id:555
+msgid "Time"
+msgstr "Tijd"
+
+#: id:556
+msgctxt "Auto context with id 556"
+msgid "Title"
+msgstr "Titel"
+
+#: id:557
+msgid "Artist"
+msgstr "Artiest"
+
+#: id:558
+msgid "Album"
+msgstr "Album"
+
+#: id:559
+msgid "Playlist"
+msgstr "Afspeellijst"
+
+#: id:560
+msgid "ID"
+msgstr "ID"
+
+#: id:561
+msgctxt "Auto context with id 561"
+msgid "File"
+msgstr "Bestand"
+
+#: id:562
+msgctxt "Auto context with id 562"
+msgid "Year"
+msgstr "Jaar"
+
+#: id:563
+msgid "Rating"
+msgstr "Score"
+
+#: id:564
+msgctxt "Auto context with id 564"
+msgid "Type"
+msgstr "Type"
+
+#: id:565
+msgid "Usage"
+msgstr "Gebruik"
+
+#: id:566
+msgid "Album artist"
+msgstr "Album artiest"
+
+#: id:567
+msgid "Play count"
+msgstr "Aantal keer afgespeeld"
+
+#: id:568
+msgid "Last played"
+msgstr "Laatst afgespeeld"
+
+#: id:569
+msgctxt "Auto context with id 569"
+msgid "Comment"
+msgstr "Opmerking"
+
+#: id:570
+msgid "Date added"
+msgstr "Datum toegevoegd"
+
+#: id:571
+msgctxt "Auto context with id 571"
+msgid "Default"
+msgstr "Standaard"
+
+#: id:572
+msgid "Studio"
+msgstr "Filmstudio"
+
+#: id:573
+msgid "Path"
+msgstr "Pad"
+
+#: id:574
+msgctxt "Auto context with id 574"
+msgid "Country"
+msgstr "Land"
+
+#: id:575
+msgid "In progress"
+msgstr "Bezig"
+
+#: id:576
+msgid "Times played"
+msgstr "Keren afgespeeld"
+
+#: id:580
+msgid "Sort direction"
+msgstr "Sorteerrichting"
+
+#: id:581
+msgid "Sort method"
+msgstr "Sorteren op"
+
+#: id:582
+msgctxt "Auto context with id 582"
+msgid "View mode"
+msgstr "Layout"
+
+#: id:583
+msgid "Remember views for different folders"
+msgstr "Layout van elke map onthouden"
+
+#: id:584
+msgid "Ascending"
+msgstr "Oplopend"
+
+#: id:585
+msgid "Descending"
+msgstr "Aflopend"
+
+#: id:586
+msgid "Edit playlist"
+msgstr "Afspeellijst wijzigen"
+
+#: id:587
+msgid "Filter"
+msgstr "Filter"
+
+#: id:588
+msgid "Cancel party mode"
+msgstr "Feestmix annuleren"
+
+#: id:589
+msgid "Party mode"
+msgstr "Feestmix"
+
+#: id:590
+msgid "Random"
+msgstr "Willekeurig"
+
+#: id:591
+msgctxt "Auto context with id 591"
+msgid "Off"
+msgstr "Uit"
+
+#: id:592
+msgid "One"
+msgstr "1"
+
+#: id:593
+msgid "All"
+msgstr "Alles"
+
+#: id:594
+msgctxt "Auto context with id 594"
+msgid "Off"
+msgstr "Uit"
+
+#: id:595
+msgid "Repeat: Off"
+msgstr "Herhalen: Uit"
+
+#: id:596
+msgid "Repeat: One"
+msgstr "Herhalen: 1"
+
+#: id:597
+msgid "Repeat: All"
+msgstr "Herhalen: Alles"
+
+#: id:600
+msgid "Rip audio CD"
+msgstr "Cd kopiëren"
+
+#: id:601
+msgctxt "Auto context with id 601"
+msgid "Medium"
+msgstr "Middelmatig"
+
+#: id:602
+msgctxt "Auto context with id 602"
+msgid "Standard"
+msgstr "Standaard"
+
+#: id:603
+msgid "Extreme"
+msgstr "Extreem"
+
+#: id:604
+msgid "Constant bitrate"
+msgstr "Constante bitsnelheid"
+
+#: id:605
+msgid "Ripping..."
+msgstr "Kopiëren..."
+
+#: id:607
+msgid "To:"
+msgstr "Naar:"
+
+#: id:608
+msgid "Could not rip CD or track"
+msgstr "Kopiëren van CD of nummer mislukt"
+
+#: id:609
+msgid "CDDARipPath is not set."
+msgstr "CDDA-doelmap is niet ingegeven."
+
+#: id:610
+msgid "Rip audio track"
+msgstr "Muzieknummer rippen"
+
+#: id:611
+msgid "Enter number"
+msgstr "Voer nummer in"
+
+#: id:612
+msgid "Bits/Sample"
+msgstr "Bits/Sample"
+
+#: id:613
+msgid "Sample Frequency"
+msgstr "Sample frequentie"
+
+#: id:620
+msgid "Audio CDs"
+msgstr "Muziek CD's"
+
+#: id:621
+msgid "Encoder"
+msgstr "Encoder"
+
+#: id:622
+msgid "Quality"
+msgstr "Kwaliteit"
+
+#: id:623
+msgid "Bitrate"
+msgstr "Bitsnelheid"
+
+#: id:624
+msgid "Include track number"
+msgstr "Tracknummer gebruiken"
+
+#: id:625
+msgid "All songs of"
+msgstr "Alle nummers van"
+
+#: id:629
+msgctxt "Auto context with id 629"
+msgid "View mode"
+msgstr "Weergave"
+
+#: id:630
+msgctxt "Auto context with id 630"
+msgid "Normal"
+msgstr "Normaal"
+
+#: id:631
+msgid "Zoom"
+msgstr "Inzoomen"
+
+#: id:632
+msgid "Stretch 4:3"
+msgstr "Uitrekken 4:3"
+
+#: id:633
+msgid "Wide Zoom"
+msgstr "Uitrekken 14:9"
+
+#: id:634
+msgid "Stretch 16:9"
+msgstr "Uitrekken 16:9"
+
+#: id:635
+msgid "Original Size"
+msgstr "Originele grootte"
+
+#: id:636
+msgctxt "Auto context with id 636"
+msgid "Custom"
+msgstr "Eigen instelling"
+
+#: id:637
+msgid "Replay gain"
+msgstr "Normalisering"
+
+#: id:638
+msgid "Replaygain volume adjustments"
+msgstr "Normalisatiemethode"
+
+#: id:639
+msgid "Use track levels"
+msgstr "Per nummer"
+
+#: id:640
+msgid "Use album levels"
+msgstr "Per album"
+
+#: id:641
+msgid "PreAmp Level - Replay gained files"
+msgstr "Voorversterking - genormaliseerd"
+
+#: id:642
+msgid "PreAmp Level - Non replay gained files"
+msgstr "Voorversterking - niet genormaliseerd"
+
+#: id:643
+msgid "Avoid clipping on replay gained files"
+msgstr "Het oversturen van genormaliseerde bestanden voorkomen"
+
+#: id:644
+msgid "Crop black bars"
+msgstr "Zwarte balken afsnijden"
+
+#: id:645
+msgid "Need to unpack a big file. Continue?"
+msgstr "Er moet een groot bestand uitgepakt worden. Doorgaan?"
+
+#: id:646
+msgid "Remove from library"
+msgstr "Uit bibliotheek verwijderen"
+
+#: id:647
+msgid "Export video library"
+msgstr "Videobibliotheek exporteren..."
+
+#: id:648
+msgid "Import video library"
+msgstr "Videobibliotheek importeren..."
+
+#: id:649
+msgid "Importing"
+msgstr "Importeren"
+
+#: id:650
+msgid "Exporting"
+msgstr "Exporteren"
+
+#: id:651
+msgid "Browse for library"
+msgstr "Bibliotheek openen"
+
+#: id:652
+msgid "Years"
+msgstr "Jaren"
+
+#: id:653
+msgid "Update library"
+msgstr "Bibliotheek bijwerken"
+
+#: id:654
+msgid "Show debug info"
+msgstr "Debug-informatie"
+
+#: id:655
+msgid "Browse for executable"
+msgstr "Uitvoerbaar bestand openen"
+
+#: id:656
+msgid "Browse for playlist"
+msgstr "Afspeellijst openen"
+
+#: id:657
+msgid "Browse for folder"
+msgstr "Map openen"
+
+#: id:658
+msgid "Song information"
+msgstr "Muziekinformatie"
+
+#: id:659
+msgid "Non-linear stretch"
+msgstr "Niet-lineair uitrekken"
+
+#: id:660
+msgid "Volume amplification"
+msgstr "Volumeversterking"
+
+#: id:661
+msgid "Choose export folder"
+msgstr "Exporteerlocatie kiezen"
+
+#: id:662
+msgid "This file is no longer available."
+msgstr "Dit bestand is niet langer beschikbaar."
+
+#: id:663
+msgid "Would you like to remove it from the library?"
+msgstr "Wilt u het verwijderen uit de bibliotheek?"
+
+#: id:664
+msgid "Browse for Script"
+msgstr "Naar script zoeken"
+
+#: id:665
+msgid "Compression level"
+msgstr "Compressieniveau"
+
+#: id:700
+msgid "Cleaning up library"
+msgstr "Bibliotheek opschonen"
+
+#: id:701
+msgid "Removing old songs from the library"
+msgstr "Oude nummers uit bibliotheek verwijderen"
+
+#: id:702
+msgid "This path has been scanned before"
+msgstr "Deze locatie is al eerder gescand"
+
+#: id:705
+msgctxt "Auto context with id 705"
+msgid "Network"
+msgstr "Netwerk"
+
+#: id:706
+msgid "- Server"
+msgstr "- Host"
+
+#: id:708
+msgid "Use an HTTP proxy server to access the internet"
+msgstr "HTTP-proxy gebruiken"
+
+#: id:711
+msgid "Internet Protocol (IP)"
+msgstr "Internet Protocol (IP)"
+
+#: id:712
+msgid "Invalid port specified. Value must be between 1 and 65535."
+msgstr "Ongeldig poortnummer. Waarde moet tussen 1 en 65535 liggen."
+
+#: id:713
+msgid "HTTP proxy"
+msgstr "HTTP proxy"
+
+#: id:715
+msgid "- Assignment"
+msgstr "Toewijzing"
+
+#: id:716
+msgid "Automatic (DHCP)"
+msgstr "Automatisch (DHCP)"
+
+#: id:717
+msgid "Manual (Static)"
+msgstr "Handmatig (Statisch)"
+
+#: id:719
+msgid "- IP address"
+msgstr "- IP-adres"
+
+#: id:720
+msgid "- Netmask"
+msgstr "- Netmask"
+
+#: id:721
+msgid "- Default gateway"
+msgstr "- Standaard Gateway"
+
+#: id:722
+msgid "- DNS server"
+msgstr "- DNS-server"
+
+#: id:723
+msgid "Save & restart"
+msgstr "Opslaan en herstarten"
+
+#: id:724
+msgid "Invalid address specified. Value must be AAA.BBB.CCC.DDD"
+msgstr "Ongeldig adres opgegeven. Waarde moet AAA.BBB.CCC.DDD zijn"
+
+#: id:725
+msgid "with numbers between 0 and 255."
+msgstr "met getallen tussen 0 en 255."
+
+#: id:726
+msgid "Changes not saved. Continue without saving?"
+msgstr "Veranderingen niet opgeslagen. Doorgaan zonder op te slaan?"
+
+#: id:727
+msgid "Web server"
+msgstr "Webserver"
+
+#: id:728
+msgctxt "Auto context with id 728"
+msgid "FTP server"
+msgstr "FTP-server"
+
+#: id:730
+msgid "- Port"
+msgstr "- Poort"
+
+#: id:732
+msgid "Save & apply"
+msgstr "Opslaan en toepassen"
+
+#: id:733
+msgid "- Password"
+msgstr "- Wachtwoord"
+
+#: id:734
+msgid "No pass"
+msgstr "Geen wachtwoord"
+
+#: id:735
+msgid "- Character set"
+msgstr "- Tekencodering"
+
+#: id:736
+msgid "- Style"
+msgstr "- Stijl:"
+
+#: id:737
+msgid "- Colour"
+msgstr "- Kleur:"
+
+#: id:738
+msgctxt "Auto context with id 738"
+msgid "Normal"
+msgstr "Normaal"
+
+#: id:739
+msgid "Bold"
+msgstr "Vet"
+
+#: id:740
+msgid "Italics"
+msgstr "Cursief"
+
+#: id:741
+msgid "Bold italics"
+msgstr "Vet/cursief"
+
+#: id:742
+msgctxt "Auto context with id 742"
+msgid "White"
+msgstr "Wit"
+
+#: id:743
+msgctxt "Auto context with id 743"
+msgid "Yellow"
+msgstr "Geel"
+
+#: id:744
+msgctxt "Auto context with id 744"
+msgid "Files"
+msgstr "Bestanden"
+
+#: id:745
+msgid "No scanned information for this view"
+msgstr "Geen gescande informatie in deze weergave"
+
+#: id:746
+msgid "Please turn off library mode"
+msgstr "Wissel naar bestandsweergave"
+
+#: id:747
+msgid "Error loading image"
+msgstr "Fout tijdens het laden van de afbeelding"
+
+#: id:748
+msgid "Edit path"
+msgstr "Snelkoppeling wijzingen"
+
+#: id:749
+msgid "Mirror image"
+msgstr "Spiegel afbeelding"
+
+#: id:750
+msgid "Are you sure?"
+msgstr "Weet u het zeker?"
+
+#: id:751
+msgid "Removing source"
+msgstr "Snelkoppeling verwijderen"
+
+#: id:754
+msgid "Add program link"
+msgstr "Programmalink toevoegen"
+
+#: id:755
+msgid "Edit program path"
+msgstr "Programmalink wijzigen"
+
+#: id:756
+msgid "Edit program name"
+msgstr "Programmanaam wijzigen"
+
+#: id:757
+msgid "Edit path depth"
+msgstr "Zoekdiepte instellen"
+
+#: id:759
+msgid "View: Big list"
+msgstr "Layout: Groot"
+
+#: id:760
+msgctxt "Auto context with id 760"
+msgid "Yellow"
+msgstr "Geel"
+
+#: id:761
+msgctxt "Auto context with id 761"
+msgid "White"
+msgstr "Wit"
+
+#: id:762
+msgid "Blue"
+msgstr "Blauw"
+
+#: id:763
+msgid "Bright green"
+msgstr "Lichtgroen"
+
+#: id:764
+msgid "Yellow green"
+msgstr "Lichtgeel"
+
+#: id:765
+msgid "Cyan"
+msgstr "Cyaan"
+
+#: id:766
+msgid "Light grey"
+msgstr "Lichtgrijs"
+
+#: id:767
+msgid "Grey"
+msgstr "Grijs"
+
+#: id:770
+msgid "Error %i: share not available"
+msgstr "Fout %i: gedeelde map niet beschikbaar"
+
+#: id:772
+msgctxt "Auto context with id 772"
+msgid "Audio output"
+msgstr "Geluidshardware"
+
+#: id:773
+msgid "Seeking"
+msgstr "Zoeken"
+
+#: id:774
+msgid "Slideshow folder"
+msgstr "Map schermbeveiliging door diavoorstelling"
+
+#: id:775
+msgid "Network interface"
+msgstr "Netwerkverbinding"
+
+#: id:776
+msgid "- Wireless network name (ESSID)"
+msgstr "- Naam draadloos netwerk (ESSID)"
+
+#: id:777
+msgid "- Wireless password"
+msgstr "Wachtwoord draadloos netwerk"
+
+#: id:778
+msgid "- Wireless security"
+msgstr "Beveiligingsniveau draadloos netwerk"
+
+#: id:779
+msgid "Save and apply network interface settings"
+msgstr "Opslaan en Toepassen Netwerk Instellingen"
+
+#: id:780
+msgid "No encryption"
+msgstr "Geen versleuteling"
+
+#: id:781
+msgid "WEP"
+msgstr "WEP"
+
+#: id:782
+msgid "WPA"
+msgstr "WPA"
+
+#: id:783
+msgid "WPA2"
+msgstr "WPA2"
+
+#: id:784
+msgid "Applying network interface settings. Please wait."
+msgstr "Netwerkinstellingen toepassen. Een ogenblik geduld."
+
+#: id:785
+msgid "Network interface restarted successfully."
+msgstr "Netwerkverbinding herstart."
+
+#: id:786
+msgid "Network interface did not start successfully."
+msgstr "Netwerkverbinding kon niet herstart worden."
+
+#: id:787
+msgid "Interface disabled"
+msgstr "Verbinding uitgeschakeld"
+
+#: id:788
+msgid "Network interface disabled successfully."
+msgstr "Verbinding succesvol uitgeschakeld."
+
+#: id:789
+msgid "Wireless network name (ESSID)"
+msgstr "Naam draadloos netwerk (ESSID)"
+
+#: id:790
+msgid "Remote control"
+msgstr ""
+
+#: id:791
+msgid "Allow programs on this system to control XBMC"
+msgstr "Gebeurtenissen op afstand activeren"
+
+#: id:792
+msgctxt "Auto context with id 792"
+msgid "Port"
+msgstr "Poort voor gebeurtenissen op afstand"
+
+#: id:793
+msgid "Port range"
+msgstr "Poortbereik voor gebeurtenissen op afstand"
+
+#: id:794
+msgid "Allow programs on other systems to control XBMC"
+msgstr "Gebeurtenissen van andere computers ontvangen"
+
+#: id:795
+msgid "Initial repeat delay (ms)"
+msgstr "Initiële herhalingsvertraging (ms)"
+
+#: id:796
+msgid "Continuous repeat delay (ms)"
+msgstr "Doorgaande herhalingsvertraging (ms)"
+
+#: id:797
+msgid "Maximum number of clients"
+msgstr "Maximaal aantal gebruikers"
+
+#: id:798
+msgid "Internet access"
+msgstr "Internettoegang"
+
+#: id:850
+msgid "Invalid port number entered"
+msgstr "Ongeldig poortnummer ingevoerd"
+
+#: id:851
+msgid "Valid port range is 1-65535"
+msgstr "Geldig poortbereik is 1-65535"
+
+#: id:852
+msgid "Valid port range is 1024-65535"
+msgstr "Geldig poortbereik is 1024-65535"
+
+#: id:998
+msgid "Add Music..."
+msgstr "Muziek Toevoegen..."
+
+#: id:999
+msgid "Add Videos..."
+msgstr "Videos Toevoegen..."
+
+#: id:1000
+msgid "- Preview"
+msgstr "- Test schermbeveiliging"
+
+#: id:1001
+msgid "Unable to connect"
+msgstr "Verbinding mislukt"
+
+#: id:1002
+msgid "XBMC was unable to connect to the network location."
+msgstr "XBMC kon niet verbinden met de netwerklocatie."
+
+#: id:1003
+msgid "This could be due to the network not being connected."
+msgstr "Dit kan veroorzaakt worden doordat het netwerk niet verbonden is."
+
+#: id:1004
+msgid "Would you like to add it anyway?"
+msgstr "Wilt u het toch toevoegen?"
+
+#: id:1006
+msgctxt "Auto context with id 1006"
+msgid "IP address"
+msgstr "IP-adres"
+
+#: id:1007
+msgid "Add network location"
+msgstr "Netwerklocatie toevoegen"
+
+#: id:1008
+msgid "Protocol"
+msgstr "Protocol"
+
+#: id:1009
+msgid "Server address"
+msgstr "Serveradres"
+
+#: id:1010
+msgid "Server name"
+msgstr "Servernaam"
+
+#: id:1011
+msgid "Remote path"
+msgstr "Remote pad"
+
+#: id:1012
+msgid "Shared folder"
+msgstr "Gedeelde map"
+
+#: id:1013
+msgctxt "Auto context with id 1013"
+msgid "Port"
+msgstr "Poort"
+
+#: id:1014
+msgctxt "Auto context with id 1014"
+msgid "Username"
+msgstr "Gebruikersnaam"
+
+#: id:1015
+msgid "Browse for network server"
+msgstr "Netwerkserver"
+
+#: id:1016
+msgid "Enter the network address of the server"
+msgstr "Voer het netwerkadres in van de server"
+
+#: id:1017
+msgid "Enter the path on the server"
+msgstr "Voer de locatie op de server in"
+
+#: id:1018
+msgid "Enter the port number"
+msgstr "Voer het poortnummer in"
+
+#: id:1019
+msgid "Enter the username"
+msgstr "Voer de gebruikersnaam in"
+
+#: id:1020
+msgid "Add %s source"
+msgstr "%s locatie toevoegen"
+
+#: id:1021
+msgid "Enter the paths or browse for the media locations."
+msgstr "Voer locaties in of blader naar de locaties."
+
+#: id:1022
+msgid "Enter a name for this media Source."
+msgstr "Voer een naam in voor deze locatie."
+
+#: id:1023
+msgid "Browse for new share"
+msgstr "Blader voor nieuwe locatie"
+
+#: id:1024
+msgid "Browse"
+msgstr "Bladeren"
+
+#: id:1025
+msgid "Could not retrieve directory information."
+msgstr "Kon geen locatie-informatie verkrijgen."
+
+#: id:1026
+msgid "Add source"
+msgstr "Locatie toevoegen"
+
+#: id:1027
+msgid "Edit source"
+msgstr "Locatie aanpassen"
+
+#: id:1028
+msgid "Edit %s source"
+msgstr "Pas %s locatie aan"
+
+#: id:1029
+msgid "Enter the new label"
+msgstr "Nieuw label opgeven"
+
+#: id:1030
+msgid "Browse for image"
+msgstr "Bladeren voor een afbeelding"
+
+#: id:1031
+msgid "Browse for image folder"
+msgstr "Bladeren voor een afbeeldingenmap"
+
+#: id:1032
+msgid "Add network location..."
+msgstr "Netwerklocatie toevoegen..."
+
+#: id:1033
+msgid "Browse for file"
+msgstr "Bestand selecteren"
+
+#: id:1034
+msgid "Submenu"
+msgstr "Submenu"
+
+#: id:1035
+msgid "Enable submenu buttons"
+msgstr "Submenu knoppen inschakelen"
+
+#: id:1036
+msgid "Favourites"
+msgstr "Favorieten"
+
+#: id:1037
+msgid "Video Add-ons"
+msgstr "Video add-ons"
+
+#: id:1038
+msgid "Music Add-ons"
+msgstr "Audio add-ons"
+
+#: id:1039
+msgid "Picture Add-ons"
+msgstr "Afbeeldingen add-ons"
+
+#: id:1040
+msgid "Loading directory"
+msgstr "Map laden"
+
+#: id:1041
+msgid "Retrieved %i items"
+msgstr "%i items ontvangen"
+
+#: id:1042
+msgid "Retrieved %i of %i items"
+msgstr "%i van %i items ontvangen"
+
+#: id:1043
+msgid "Program Add-ons"
+msgstr "Programma add-ons"
+
+#: id:1044
+msgid "Set plugin thumb"
+msgstr "Plugin-afbeelding instellen"
+
+#: id:1045
+msgid "Add-on settings"
+msgstr "Addon-instelingen"
+
+#: id:1046
+msgid "Access points"
+msgstr "Draadloze Netwerken"
+
+#: id:1047
+msgid "Other..."
+msgstr "Andere..."
+
+#: id:1048
+msgid "- Username"
+msgstr "- Gebruikersnaam"
+
+#: id:1049
+msgid "Script settings"
+msgstr "Script instellingen"
+
+#: id:1050
+msgid "Singles"
+msgstr "Singles"
+
+#: id:1051
+msgid "Enter web address"
+msgstr "Voer URL in"
+
+#: id:1200
+msgid "SMB client"
+msgstr "SMB-client"
+
+#: id:1202
+msgid "Workgroup"
+msgstr "Werkgroep"
+
+#: id:1203
+msgid "Default username"
+msgstr "Standaardgebruikersnaam"
+
+#: id:1204
+msgid "Default password"
+msgstr "Standaardwachtwoord"
+
+#: id:1207
+msgid "WINS server"
+msgstr "WINS-server"
+
+#: id:1208
+msgid "Mount SMB shares"
+msgstr "Laad SMB gedeeld netwerk"
+
+#: id:1210
+msgctxt "Auto context with id 1210"
+msgid "Remove"
+msgstr "Verwijder"
+
+#: id:1211
+msgctxt "Auto context with id 1211"
+msgid "Music"
+msgstr "Muziek"
+
+#: id:1212
+msgctxt "Auto context with id 1212"
+msgid "Video"
+msgstr "Video"
+
+#: id:1213
+msgctxt "Auto context with id 1213"
+msgid "Pictures"
+msgstr "Afbeeldingen"
+
+#: id:1214
+msgctxt "Auto context with id 1214"
+msgid "Files"
+msgstr "Bestanden"
+
+#: id:1215
+msgctxt "Auto context with id 1215"
+msgid "Music & video"
+msgstr "Muziek en video's"
+
+#: id:1216
+msgid "Music & pictures"
+msgstr "Muziek en afbeeldingen"
+
+#: id:1217
+msgid "Music & files"
+msgstr "Muziek en bestanden"
+
+#: id:1218
+msgid "Video & pictures"
+msgstr "Video en afbeeldingen"
+
+#: id:1219
+msgid "Video & files"
+msgstr "Video - Bestanden"
+
+#: id:1220
+msgid "Pictures & files"
+msgstr "Afbeeldingen en bestanden"
+
+#: id:1221
+msgid "Music & video & pictures"
+msgstr "Muziek, video's en afbeeldingen"
+
+#: id:1222
+msgid "Music & video & pictures & files"
+msgstr "Muziek, video's, afbeeldingen en bestanden"
+
+#: id:1223
+msgctxt "Auto context with id 1223"
+msgid "Disabled"
+msgstr "Uitgeschakeld"
+
+#: id:1226
+msgid "Files & music & video"
+msgstr "Bestanden, muziek en video"
+
+#: id:1227
+msgid "Files & pictures & music"
+msgstr "Bestanden, afbeeldingen en muziek"
+
+#: id:1228
+msgid "Files & pictures & video"
+msgstr "Bestanden, afbeeldingen en video"
+
+#: id:1229
+msgid "Music & programs"
+msgstr "Muziek en programma's"
+
+#: id:1230
+msgid "Video & programs"
+msgstr "Video en programma's"
+
+#: id:1231
+msgid "Pictures & programs"
+msgstr "Afbeeldingen en programma's"
+
+#: id:1232
+msgid "Music & video & pictures & programs"
+msgstr "Muziek, video, afbeeldingen en programma's"
+
+#: id:1233
+msgid "Programs & video & music"
+msgstr "Programma's, video en muziek"
+
+#: id:1234
+msgid "Programs & pictures & music"
+msgstr "Programma's, afbeeldingen en muziek"
+
+#: id:1235
+msgid "Programs & pictures & video"
+msgstr "Programma's, afbeeldingen en video's"
+
+#: id:1250
+msgid "Auto-detection"
+msgstr "Systeem detecteren"
+
+#: id:1251
+msgid "Auto-detect system"
+msgstr "Aangesloten systemen automatisch detecteren"
+
+#: id:1252
+msgid "Nickname"
+msgstr "Bijnaam"
+
+#: id:1254
+msgid "Ask to connect"
+msgstr "Vragen om verbinding te maken"
+
+#: id:1255
+msgid "Send FTP user and password"
+msgstr "FTP-gebruikersnaam en -wachtwoord verzenden"
+
+#: id:1256
+msgid "Ping interval"
+msgstr "Pinginterval in sec."
+
+#: id:1257
+msgid "Would you like to connect to the auto-detected system?"
+msgstr "Verbinding maken met de gevonden systeem?"
+
+#: id:1259
+msgid "Zeroconf"
+msgstr ""
+
+#: id:1260
+msgid "Announce these services to other systems via Zeroconf"
+msgstr "Zeroconf publishing"
+
+#: id:1270
+msgid "Allow XBMC to receive AirPlay content"
+msgstr "Ontvangen van AirPlay-inhoud door XBMC toelaten"
+
+#: id:1271
+msgid "Device name"
+msgstr "Apparaatnaam"
+
+#: id:1272
+msgid "- Use password protection"
+msgstr "- Beveiliging met wachtwoord"
+
+#: id:1273
+msgid "AirPlay"
+msgstr ""
+
+#: id:1300
+msgid "Custom audio device"
+msgstr "Aangepaste geluidskaart"
+
+#: id:1301
+msgid "Custom passthrough device"
+msgstr "Aangepast Passthrough apparaat"
+
+#: id:1396
+msgid "Drifting"
+msgstr "Stuifsneeuw"
+
+#: id:1397
+msgid "and"
+msgstr "en"
+
+#: id:1398
+msgid "Freezing"
+msgstr "Vrieskou"
+
+#: id:1399
+msgid "Late"
+msgstr "Laat"
+
+#: id:1400
+msgid "Isolated"
+msgstr "Lokaal"
+
+#: id:1401
+msgid "Thundershowers"
+msgstr "Onweersbuien"
+
+#: id:1402
+msgid "Thunder"
+msgstr "Onweer"
+
+#: id:1403
+msgctxt "Auto context with id 1403"
+msgid "Sun"
+msgstr "Zon"
+
+#: id:1404
+msgid "Heavy"
+msgstr "Hevige"
+
+#: id:1405
+msgid "in"
+msgstr "in"
+
+#: id:1406
+msgid "the"
+msgstr "de"
+
+#: id:1407
+msgid "Vicinity"
+msgstr "Omgeving"
+
+#: id:1408
+msgid "Ice"
+msgstr "IJs"
+
+#: id:1409
+msgid "Crystals"
+msgstr "Kristallen"
+
+#: id:1410
+msgid "Calm"
+msgstr "Kalm"
+
+#: id:1411
+msgid "with"
+msgstr "met"
+
+#: id:1412
+msgid "windy"
+msgstr "winderig"
+
+#: id:1413
+msgid "drizzle"
+msgstr "miezeren"
+
+#: id:1414
+msgid "Thunderstorm"
+msgstr "Onweerstormen"
+
+#: id:1415
+msgid "Drizzle"
+msgstr "Motregen"
+
+#: id:1416
+msgid "Foggy"
+msgstr "Mistig"
+
+#: id:1417
+msgid "Grains"
+msgstr "Korrels"
+
+#: id:1418
+msgid "T-Storms"
+msgstr "Onweer"
+
+#: id:1419
+msgid "T-Showers"
+msgstr "Onweersbuien"
+
+#: id:1420
+msgid "Moderate"
+msgstr "Matig"
+
+#: id:1421
+msgid "Very High"
+msgstr "Heel hoog"
+
+#: id:1422
+msgid "Windy"
+msgstr "Winderig"
+
+#: id:1423
+msgid "Mist"
+msgstr "Mist"
+
+#: id:1450
+msgid "Put display to sleep when idle"
+msgstr "Schakel beeldscherm uit bij inactiviteit"
+
+#: id:2050
+msgid "Runtime"
+msgstr "Speelduur"
+
+#: id:2100
+msgid "Script failed! : %s"
+msgstr "Fout in script! : %s"
+
+#: id:2101
+msgid "Newer version needed - See log"
+msgstr "Nieuwere versie vereist - Zie log"
+
+#: id:4501
+msgid "Enable LCD/VFD"
+msgstr "Gebruik LCD/VFD"
+
+#: id:10000
+msgid "Home"
+msgstr "Beginscherm"
+
+#: id:10001
+msgctxt "Auto context with id 10001"
+msgid "Programs"
+msgstr "Programma's"
+
+#: id:10002
+msgctxt "Auto context with id 10002"
+msgid "Pictures"
+msgstr "Afbeeldingen"
+
+#: id:10003
+msgctxt "Auto context with id 10003"
+msgid "File manager"
+msgstr "Bestandsbeheer"
+
+#: id:10004
+msgctxt "Auto context with id 10004"
+msgid "Settings"
+msgstr "Instellingen"
+
+#: id:10005
+msgctxt "Auto context with id 10005"
+msgid "Music"
+msgstr "Muziek"
+
+#: id:10006
+msgctxt "Auto context with id 10006"
+msgid "Videos"
+msgstr "Video"
+
+#: id:10007
+msgid "System information"
+msgstr "Systeeminformatie"
+
+#: id:10008
+msgid "Settings - General"
+msgstr "Instellingen - Algemeen"
+
+#: id:10009
+msgid "Settings - Screen"
+msgstr "Instellingen - Beeld"
+
+#: id:10010
+msgid "Settings - Appearance - GUI Calibration"
+msgstr "Instellingen - GUI-kalibratie"
+
+#: id:10011
+msgid "Settings - Videos - Screen Calibration"
+msgstr "Instellingen - Schermkalibratie"
+
+#: id:10012
+msgid "Settings - Pictures"
+msgstr "Instellingen - Afbeeldingen"
+
+#: id:10013
+msgid "Settings - Programs"
+msgstr "Instellingen - Programma's"
+
+#: id:10014
+msgid "Settings - Weather"
+msgstr "Instellingen - Weer"
+
+#: id:10015
+msgid "Settings - Music"
+msgstr "Instellingen - Muziek"
+
+#: id:10016
+msgid "Settings - System"
+msgstr "Instellingen - Systeem"
+
+#: id:10017
+msgid "Settings - Videos"
+msgstr "Instellingen - Video's"
+
+#: id:10018
+msgid "Settings - Network"
+msgstr "Instellingen - Netwerk"
+
+#: id:10019
+msgid "Settings - Appearance"
+msgstr "Instellingen - Uiterlijk"
+
+#: id:10020
+msgctxt "Auto context with id 10020"
+msgid "Scripts"
+msgstr "Scripts"
+
+#: id:10021
+msgid "Web Browser"
+msgstr "Webbrowser"
+
+#: id:10025
+msgctxt "Auto context with id 10025"
+msgid "Videos"
+msgstr "Video's"
+
+#: id:10028
+msgid "Videos/Playlist"
+msgstr "Video/Afspeellijst"
+
+#: id:10029
+msgctxt "Auto context with id 10029"
+msgid "Login screen"
+msgstr "Aanmeld scherm"
+
+#: id:10034
+msgid "Settings - Profiles"
+msgstr "Instellingen - Profielen"
+
+#: id:10040
+msgid "Addon browser"
+msgstr "Addon verkenner"
+
+#: id:10100
+msgid "Yes/No dialog"
+msgstr "Ja/Nee"
+
+#: id:10101
+msgid "Progress dialog"
+msgstr "Voortgang"
+
+#: id:10210
+msgid "Looking for subtitles..."
+msgstr "Zoeken naar ondertitels..."
+
+#: id:10211
+msgid "Looking for or caching subtitles..."
+msgstr "Ondertitels cachen..."
+
+#: id:10212
+msgid "terminating"
+msgstr "Bezig met afsluiten"
+
+#: id:10213
+msgid "buffering"
+msgstr "Bufferen"
+
+#: id:10214
+msgid "Opening stream"
+msgstr "Bezig met het openen van stream"
+
+#: id:10500
+msgid "Music/Playlist"
+msgstr "Muziek/Afspeellijst"
+
+#: id:10501
+msgid "Music/Files"
+msgstr "Muziek/Bestanden"
+
+#: id:10502
+msgid "Music/Library"
+msgstr "Muziek/Bibliotheek"
+
+#: id:10503
+msgid "Playlist editor"
+msgstr "Afspeellijst bewerken"
+
+#: id:10504
+msgid "Top 100 songs"
+msgstr "Top 100 Nummers"
+
+#: id:10505
+msgid "Top 100 albums"
+msgstr "Top 100 Albums"
+
+#: id:10506
+msgctxt "Auto context with id 10506"
+msgid "Programs"
+msgstr "Programma's"
+
+#: id:10507
+msgid "Configuration"
+msgstr "Instellingen"
+
+#: id:10508
+msgid "Weather forecast"
+msgstr "Weersverwachting"
+
+#: id:10509
+msgid "Network gaming"
+msgstr "Netwerk gaming"
+
+#: id:10510
+msgid "Extensions"
+msgstr "Extensies"
+
+#: id:10511
+msgctxt "Auto context with id 10511"
+msgid "System info"
+msgstr "Systeeminformatie"
+
+#: id:10516
+msgid "Music - Library"
+msgstr "Muziek - Bibliotheek"
+
+#: id:10517
+msgid "Now Playing - Music"
+msgstr "Muziek - Afspeellijst"
+
+#: id:10522
+msgid "Now Playing - Videos"
+msgstr "Video's - Afspeellijst"
+
+#: id:10523
+msgid "Album info"
+msgstr "Albuminformatie"
+
+#: id:10524
+msgid "Movie info"
+msgstr "Filminformatie"
+
+#: id:12000
+msgid "Select dialog"
+msgstr "Selecteren"
+
+#: id:12001
+msgid "Music/Info"
+msgstr "Muziek/Informatie"
+
+#: id:12002
+msgid "Dialog OK"
+msgstr "Bevestiging"
+
+#: id:12003
+msgid "Videos/Info"
+msgstr "Films/Informatie"
+
+#: id:12004
+msgid "Scripts/Info"
+msgstr "Scripts/Informatie"
+
+#: id:12005
+msgid "Fullscreen video"
+msgstr "Volledig scherm"
+
+#: id:12006
+msgid "Audio visualization"
+msgstr "Geluidsvisualisatie"
+
+#: id:12008
+msgid "File stacking dialog"
+msgstr "Bestanden groeperen"
+
+#: id:12009
+msgid "Rebuild index..."
+msgstr "Herindexeren"
+
+#: id:12010
+msgid "Return to music window"
+msgstr "Terug naar Muziek"
+
+#: id:12011
+msgid "Return to videos window"
+msgstr "Terug naar Video's"
+
+#: id:12021
+msgid "Start from beginning"
+msgstr "Starten vanaf begin"
+
+#: id:12022
+msgid "Resume from %s"
+msgstr "Hervatten vanaf %s"
+
+#: id:12310
+msgid "0"
+msgstr "0"
+
+#: id:12311
+msgid "1"
+msgstr "1"
+
+#: id:12312
+msgid "2"
+msgstr "2"
+
+#: id:12313
+msgid "3"
+msgstr "3"
+
+#: id:12314
+msgid "4"
+msgstr "4"
+
+#: id:12315
+msgid "5"
+msgstr "5"
+
+#: id:12316
+msgid "6"
+msgstr "6"
+
+#: id:12317
+msgid "7"
+msgstr "7"
+
+#: id:12318
+msgid "8"
+msgstr "8"
+
+#: id:12319
+msgid "9"
+msgstr "9"
+
+#: id:12320
+msgid "c"
+msgstr "c"
+
+#: id:12321
+msgid "Ok"
+msgstr "ok"
+
+#: id:12322
+msgid "*"
+msgstr "*"
+
+#: id:12325
+msgid "Locked! Enter code..."
+msgstr "Vergrendeld! voer code in..."
+
+#: id:12326
+msgid "Enter password"
+msgstr "Voer het wachtwoord in"
+
+#: id:12327
+msgid "Enter master code"
+msgstr "Voer de vergrendelcode in"
+
+#: id:12328
+msgid "Enter unlock code"
+msgstr "Voer de vergrendelcode in om te ontgrendelen"
+
+#: id:12329
+msgid "or press C to cancel"
+msgstr "of druk op C om te annuleren"
+
+#: id:12330
+msgid "Enter gamepad button combo and"
+msgstr "Voer controller knoppencombinatie in en druk op Start"
+
+#: id:12331
+msgid "press OK, or Back to cancel"
+msgstr "druk op Ok, of Back om te annuleren"
+
+#: id:12332
+msgid "Set lock"
+msgstr "Vergrendelen"
+
+#: id:12333
+msgid "Unlock"
+msgstr "Ontgrendelen"
+
+#: id:12334
+msgid "Reset lock"
+msgstr "Vergrendeling resetten"
+
+#: id:12335
+msgid "Remove lock"
+msgstr "Vergrendeling verwijderen"
+
+#: id:12337
+msgid "Numeric password"
+msgstr "Numeriek wachtwoord"
+
+#: id:12338
+msgid "Gamepad button combo"
+msgstr "Knoppencombinatie"
+
+#: id:12339
+msgid "Full-text password"
+msgstr "Normaal wachtwoord"
+
+#: id:12340
+msgid "Enter new password"
+msgstr "Voer nieuw wachtwoord in"
+
+#: id:12341
+msgid "Re-Enter new password"
+msgstr "Voer nieuw wachtwoord opnieuw in"
+
+#: id:12342
+msgid "Incorrect password,"
+msgstr "Incorrect wachtwoord"
+
+#: id:12343
+msgid "retries left"
+msgstr "pogingen over"
+
+#: id:12344
+msgid "Passwords entered did not match."
+msgstr "Ingevoerd wachtwoord klopt niet."
+
+#: id:12345
+msgid "Access denied"
+msgstr "Toegang geweigerd"
+
+#: id:12346
+msgid "Password retry limit exceeded."
+msgstr "Maximaal aantal pogingen bereikt"
+
+#: id:12347
+msgid "The system will now shut off."
+msgstr "XBMC wordt nu uitgeschakeld."
+
+#: id:12348
+msgid "Item locked"
+msgstr "Item vergrendeld"
+
+#: id:12353
+msgid "Reactivate lock"
+msgstr "Vergrendeling heractiveren"
+
+#: id:12356
+msgid "Change lock"
+msgstr "Vergrendeling veranderen"
+
+#: id:12357
+msgid "Source lock"
+msgstr "Vergrendeling delen"
+
+#: id:12358
+msgid "Password entry was blank. Try again."
+msgstr "Geen wachtwoord ingegeven. Probeer opnieuw."
+
+#: id:12360
+msgid "Master lock"
+msgstr "Vergrendelen"
+
+#: id:12362
+msgid "Shutdown system if Master Lock retries exceeded"
+msgstr "XBMC uitschakelen na max. aantal mislukte pogingen"
+
+#: id:12367
+msgid "Master code is not valid"
+msgstr "Vergrendelcode is onjuist!"
+
+#: id:12368
+msgid "Please enter a valid master code"
+msgstr "Voer een geldige vergrendelcode in!"
+
+#: id:12373
+msgid "Settings & file manager"
+msgstr "Instellingen vergrendelen"
+
+#: id:12376
+msgid "Set as default for all movies"
+msgstr "Als standaard instellen voor alle video's"
+
+#: id:12377
+msgid "This will reset any previously saved values"
+msgstr "Dit zal alle voorgaande opgeslagen waarden resetten"
+
+#: id:12378
+msgid "Amount of time to display each image"
+msgstr "Afbeeldingen weergeven gedurende"
+
+#: id:12379
+msgid "Use pan and zoom effects"
+msgstr "Pan- en zoomeffecten gebruiken"
+
+#: id:12383
+msgid "12 hour clock"
+msgstr "12-uursformaat"
+
+#: id:12384
+msgid "24 hour clock"
+msgstr "24-uursformaat"
+
+#: id:12385
+msgid "Day/Month"
+msgstr "Dag/Maand"
+
+#: id:12386
+msgid "Month/Day"
+msgstr "Maand/Dag"
+
+#: id:12390
+msgid "System uptime"
+msgstr "Systeem actief"
+
+#: id:12391
+msgid "Minutes"
+msgstr "minuten"
+
+#: id:12392
+msgid "Hours"
+msgstr "uur"
+
+#: id:12393
+msgid "Days"
+msgstr "dagen"
+
+#: id:12394
+msgid "Total uptime"
+msgstr "Totale activiteit"
+
+#: id:12395
+msgid "Battery level"
+msgstr "Battery niveau"
+
+#: id:12600
+msgctxt "Auto context with id 12600"
+msgid "Weather"
+msgstr "Het weer"
+
+#: id:12900
+msgctxt "Auto context with id 12900"
+msgid "Screensaver"
+msgstr "Schermbeveiliging"
+
+#: id:12901
+msgid "Fullscreen OSD"
+msgstr "Volledig scherm On Screen Display"
+
+#: id:13000
+msgid "System"
+msgstr "Systeem"
+
+#: id:13001
+msgid "Immediate HD spindown"
+msgstr "Harde schijf onmiddellijk uitschakelen"
+
+#: id:13002
+msgid "Video only"
+msgstr "Alleen beeld"
+
+#: id:13003
+msgid "- Delay"
+msgstr "- Vertraging"
+
+#: id:13004
+msgid "- Minimum file duration"
+msgstr "- Minimale bestandsduur"
+
+#: id:13005
+msgid "Shutdown"
+msgstr "Computer uitschakelen"
+
+#: id:13008
+msgid "Shutdown function"
+msgstr "Standaard afsluitmethode"
+
+#: id:13009
+msgid "Quit"
+msgstr "Afsluiten"
+
+#: id:13010
+msgid "Hibernate"
+msgstr "Sluimerstand"
+
+#: id:13011
+msgid "Suspend"
+msgstr "Slaapstand"
+
+#: id:13012
+msgid "Exit"
+msgstr "Stoppen"
+
+#: id:13013
+msgid "Reboot"
+msgstr "Opnieuw opstarten"
+
+#: id:13014
+msgid "Minimize"
+msgstr "Minimaliseren"
+
+#: id:13015
+msgid "Power button action"
+msgstr "Actie voor aan/uitknop"
+
+#: id:13016
+msgid "Power off System"
+msgstr "Systeem Uitschakelen"
+
+#: id:13020
+msgid "Is another session active, perhaps over ssh?"
+msgstr "Er is een andere sessie actief, wellicht SSH?"
+
+#: id:13021
+msgid "Mounted removable harddrive"
+msgstr "Verwisselbare harde schijf aankoppelen?"
+
+#: id:13022
+msgid "Unsafe device removal"
+msgstr "Apparaat onveilig verwijderd"
+
+#: id:13023
+msgid "Successfully removed device"
+msgstr "Apparaat succesvol verwijderd"
+
+#: id:13024
+msgid "Joystick plugged"
+msgstr "Joystick aangesloten"
+
+#: id:13025
+msgid "Joystick unplugged"
+msgstr "Geen joystick aangesloten"
+
+#: id:13050
+msgid "Running low on battery"
+msgstr "Lage accuspanning"
+
+#: id:13100
+msgid "Flicker filter"
+msgstr "Flikkerfilter"
+
+#: id:13101
+msgid "Let driver choose (requires restart)"
+msgstr "Laat keuze aan driver (herstart vereist)"
+
+#: id:13105
+msgid "Vertical blank sync"
+msgstr "Vertical blank sync"
+
+#: id:13106
+msgctxt "Auto context with id 13106"
+msgid "Disabled"
+msgstr "Uitgeschakeld"
+
+#: id:13107
+msgid "Enabled during video playback"
+msgstr "Ingeschakeld tijdens afspelen"
+
+#: id:13108
+msgctxt "Auto context with id 13108"
+msgid "Always enabled"
+msgstr "Altijd aan"
+
+#: id:13109
+msgid "Test & apply resolution"
+msgstr "Test resolutie"
+
+#: id:13110
+msgid "Save resolution?"
+msgstr "Resolutie behouden?"
+
+#: id:13111
+msgid "Would you like to keep this resolution?"
+msgstr "Wilt u deze resolutie behouden?"
+
+#: id:13112
+msgid "High quality upscaling"
+msgstr "Softwarematige Hoge Kwaliteit Beeldverbetering"
+
+#: id:13113
+msgctxt "Auto context with id 13113"
+msgid "Disabled"
+msgstr "Uitgeschakeld"
+
+#: id:13114
+msgid "Enabled for SD content"
+msgstr "Inschakelen voor SD-beelden"
+
+#: id:13115
+msgctxt "Auto context with id 13115"
+msgid "Always enabled"
+msgstr "Altijd inschakelen"
+
+#: id:13116
+msgid "Upscaling method"
+msgstr "Beeldverbeteringsmethode"
+
+#: id:13117
+msgctxt "Auto context with id 13117"
+msgid "Bicubic"
+msgstr "Bicubisch"
+
+#: id:13118
+msgid "Lanczos"
+msgstr "Lanczos"
+
+#: id:13119
+msgid "Sinc"
+msgstr "Sinc"
+
+#: id:13120
+msgctxt "Auto context with id 13120"
+msgid "VDPAU"
+msgstr "Strikte Pixmap-Texture Binding (vereist herstart)"
+
+#: id:13121
+msgid "VDPAU HQ Upscaling level"
+msgstr "VDPAU HQ Upscaling level"
+
+#: id:13122
+msgid "VDPAU Studio level color conversion"
+msgstr "VDPAU Studio level color conversion"
+
+#: id:13130
+msgid "Blank other displays"
+msgstr "Stop doorgifte videosignaal aan andere beeldschermen"
+
+#: id:13131
+msgctxt "Auto context with id 13131"
+msgid "Disabled"
+msgstr "Uitgeschakeld"
+
+#: id:13132
+msgid "Blank displays"
+msgstr "Stop doorgifte videosignaal"
+
+#: id:13140
+msgid "Active connections detected!"
+msgstr "Actieve verbindingen gedetecteerd!"
+
+#: id:13141
+msgid "If you proceed, you might not be able to control XBMC"
+msgstr "Als u doorgaat, kunt u XBMC mogelijk niet meer"
+
+#: id:13142
+msgid "any longer. Are you sure you want to stop the Event server?"
+msgstr "besturen. Weet u zeker dat u de Event Server wilt stoppen?"
+
+#: id:13144
+msgid "Change Apple Remote mode?"
+msgstr "Verander Apple afstandsbedieningsmodus?"
+
+#: id:13145
+msgid "If you are currently using the Apple Remote to control"
+msgstr "Als u op dit moment de Apple afstandsbediening gebruikt"
+
+#: id:13146
+msgid "XBMC, changing this setting might affect your ability"
+msgstr "om XBMC te besturen, kan het veranderen van deze instelling"
+
+#: id:13147
+msgid "to continue controlling it. Do you want to proceed?"
+msgstr "de mogelijkheid om het te blijven besturen beïnvloeden. Doorgaan?"
+
+#: id:13159
+msgid "Subnet mask"
+msgstr "Subnetmasker"
+
+#: id:13160
+msgid "Gateway"
+msgstr "Gateway"
+
+#: id:13161
+msgid "Primary DNS"
+msgstr "DNS-server"
+
+#: id:13162
+msgid "Initialize failed"
+msgstr "Initialiseren mislukt"
+
+#: id:13170
+msgctxt "Auto context with id 13170"
+msgid "Never"
+msgstr "Nooit"
+
+#: id:13171
+msgid "Immediately"
+msgstr "Direct"
+
+#: id:13172
+msgid "After %i secs"
+msgstr "Na %i sec."
+
+#: id:13173
+msgid "HDD install date:"
+msgstr "HDD installatiedatum:"
+
+#: id:13174
+msgid "HDD power cycle count:"
+msgstr "HDD Power Cycle teller:"
+
+#: id:13200
+msgid "Profiles"
+msgstr "Profielen"
+
+#: id:13201
+msgid "Delete profile '%s'?"
+msgstr "Profiel '%s' verwijderen?"
+
+#: id:13204
+msgid "Last loaded profile:"
+msgstr "Laatst gebruikt profiel:"
+
+#: id:13205
+msgid "Unknown"
+msgstr "Onbekend"
+
+#: id:13206
+msgid "Overwrite"
+msgstr "Overschrijven"
+
+#: id:13208
+msgid "Alarm clock"
+msgstr "Alarmklok"
+
+#: id:13209
+msgid "Alarm clock interval (in minutes)"
+msgstr "Alarmklokinterval (in minuten)"
+
+#: id:13210
+msgid "Started, alarm in %im"
+msgstr "Gestart, alarm over %im"
+
+#: id:13211
+msgid "Alarm!"
+msgstr "Alarm!"
+
+#: id:13212
+msgid "Canceled with %im%is left"
+msgstr "Gestopt met nog %im%is te gaan"
+
+#: id:13213
+msgid "%2.0fm"
+msgstr "%2.0fm"
+
+#: id:13214
+msgid "%2.0fs"
+msgstr "%2.0fs"
+
+#: id:13249
+msgid "Search for subtitles in RARs"
+msgstr "Naar ondertitels zoeken in RAR-archieven"
+
+#: id:13250
+msgid "Browse for subtitle..."
+msgstr "Ondertitels zoeken"
+
+#: id:13251
+msgid "Move item"
+msgstr "Item verplaatsen"
+
+#: id:13252
+msgid "Move item here"
+msgstr "Item hierheen verplaatsen"
+
+#: id:13253
+msgid "Cancel move"
+msgstr "Verplaatsen annuleren"
+
+#: id:13270
+msgid "Hardware:"
+msgstr "Hardware:"
+
+#: id:13271
+msgid "CPU Usage:"
+msgstr "Belasting:"
+
+#: id:13274
+msgid "Connected, but no DNS is available."
+msgstr "XBMC is verbonden, maar geen DNS beschikbaar."
+
+#: id:13275
+msgid "Hard Disk"
+msgstr "Harde schijf"
+
+#: id:13276
+msgid "DVD-ROM"
+msgstr "DVD-ROM"
+
+#: id:13277
+msgctxt "Auto context with id 13277"
+msgid "Storage"
+msgstr "Opslag"
+
+#: id:13278
+msgctxt "Auto context with id 13278"
+msgid "Default"
+msgstr "Standaard"
+
+#: id:13279
+msgctxt "Auto context with id 13279"
+msgid "Network"
+msgstr "Netwerk"
+
+#: id:13280
+msgctxt "Auto context with id 13280"
+msgid "Video"
+msgstr "Video"
+
+#: id:13281
+msgid "Hardware"
+msgstr "Hardware"
+
+#: id:13283
+msgid "Operating system:"
+msgstr "Besturingssysteem:"
+
+#: id:13284
+msgid "CPU speed:"
+msgstr "Kloksnelheid:"
+
+#: id:13286
+msgid "Video encoder:"
+msgstr "Video-encoder:"
+
+#: id:13287
+msgid "Screen resolution:"
+msgstr "Schermresolutie:"
+
+#: id:13292
+msgid "A/V cable:"
+msgstr "A/V-kabel:"
+
+#: id:13294
+msgid "DVD region:"
+msgstr "DVD-regio:"
+
+#: id:13295
+msgid "Internet:"
+msgstr "Internet:"
+
+#: id:13296
+msgctxt "Auto context with id 13296"
+msgid "Connected"
+msgstr "Ja, verbonden met internet"
+
+#: id:13297
+msgid "Not connected. Check network settings."
+msgstr "Nee, niet verbonden met internet. Controleer uw netwerkinstellingen."
+
+#: id:13299
+msgid "Target temperature"
+msgstr "- Doeltemperatuur"
+
+#: id:13300
+msgid "Fan speed"
+msgstr "- Ventilatorsnelheid"
+
+#: id:13301
+msgid "Auto temperature control"
+msgstr "Automatische ventilatorsnelheid"
+
+#: id:13302
+msgid "Fan speed override"
+msgstr "Snelheidsregeling ventilator"
+
+#: id:13303
+msgid "- Fonts"
+msgstr "- Lettertype"
+
+#: id:13304
+msgid "Enable flipping bi-directional strings"
+msgstr "Bidirectionele tekst omdraaien"
+
+#: id:13305
+msgid "Show RSS news feeds"
+msgstr "RSS-feeds inschakelen"
+
+#: id:13306
+msgid "Show parent folder items"
+msgstr "Hoofdmap tonen"
+
+#: id:13307
+msgid "Track naming template"
+msgstr "Nummers in lijst weergeven als"
+
+#: id:13308
+msgid "Do you wish to reboot your system"
+msgstr "Wilt u het systeem herstarten"
+
+#: id:13309
+msgid "instead of just XBMC?"
+msgstr "in plaats van alleen XBMC?"
+
+#: id:13310
+msgid "Zoom effect"
+msgstr "Zoomeffect"
+
+#: id:13311
+msgid "Float effect"
+msgstr "Zweefeffect"
+
+#: id:13312
+msgid "Black bar reduction"
+msgstr "Randreductie"
+
+#: id:13313
+msgid "Restart"
+msgstr "Herinitialiseer/Herstart"
+
+#: id:13314
+msgid "Crossfade between songs"
+msgstr "Nummers in elkaar laten overvloeien"
+
+#: id:13315
+msgid "Regenerate thumbnails"
+msgstr "Miniaturen regenereren"
+
+#: id:13316
+msgid "Recursive thumbnails"
+msgstr "Ook onderliggende mappen"
+
+#: id:13317
+msgid "View slideshow"
+msgstr "Diavoorstelling bekijken"
+
+#: id:13318
+msgid "Recursive slideshow"
+msgstr "Diavoorstelling met mappen"
+
+#: id:13319
+msgid "Randomize"
+msgstr "Willekeurig"
+
+#: id:13320
+msgid "Stereo"
+msgstr "Stereo"
+
+#: id:13321
+msgid "Left only"
+msgstr "Alleen links"
+
+#: id:13322
+msgid "Right only"
+msgstr "Alleen rechts"
+
+#: id:13323
+msgid "Enable karaoke support"
+msgstr "CD+G (karaoke) inschakelen"
+
+#: id:13324
+msgid "Background transparency"
+msgstr "Doorzichtigheid achtergrond"
+
+#: id:13325
+msgid "Foreground transparency"
+msgstr "Doorzichtigheid voorgrond"
+
+#: id:13326
+msgid "A/V delay"
+msgstr "Synchronisatie"
+
+#: id:13327
+msgid "Karaoke"
+msgstr "Karaoke"
+
+#: id:13328
+msgid "%s not found"
+msgstr "%s niet gevonden"
+
+#: id:13329
+msgid "Error opening %s"
+msgstr "Fout tijdens openen %s"
+
+#: id:13330
+msgid "Unable to load %s"
+msgstr "%s kan niet geladen worden"
+
+#: id:13331
+msgid "Error: Out of memory"
+msgstr "Fout: te weinig geheugen"
+
+#: id:13332
+msgid "Move up"
+msgstr "Omhoog"
+
+#: id:13333
+msgid "Move down"
+msgstr "Omlaag"
+
+#: id:13334
+msgid "Edit label"
+msgstr "Label aanpassen"
+
+#: id:13335
+msgid "Make default"
+msgstr "Maak standaard"
+
+#: id:13336
+msgid "Remove button"
+msgstr "Verwijder Knop"
+
+#: id:13340
+msgid "Leave as is"
+msgstr "Onveranderd laten"
+
+#: id:13341
+msgid "Green"
+msgstr "Groen"
+
+#: id:13342
+msgid "Orange"
+msgstr "Oranje"
+
+#: id:13343
+msgid "Red"
+msgstr "Rood"
+
+#: id:13344
+msgid "Cycle"
+msgstr "Afwisselen"
+
+#: id:13345
+msgid "Switch LED off on playback"
+msgstr "LED uit tijdens afspelen"
+
+#: id:13346
+msgctxt "Auto context with id 13346"
+msgid "Movie information"
+msgstr "Filminformatie"
+
+#: id:13347
+msgid "Queue item"
+msgstr "Aan afspeellijst toevoegen"
+
+#: id:13348
+msgid "Search IMDb..."
+msgstr "IMDb doorzoeken..."
+
+#: id:13349
+msgid "Scan for new content"
+msgstr "Naar nieuwe inhoud scannen"
+
+#: id:13350
+msgid "Now playing..."
+msgstr "Afspeellijst weergeven"
+
+#: id:13351
+msgctxt "Auto context with id 13351"
+msgid "Album information"
+msgstr "Albuminformatie"
+
+#: id:13352
+msgid "Scan item to library"
+msgstr "Aan bibliotheek toevoegen"
+
+#: id:13353
+msgid "Stop scanning"
+msgstr "Scan annuleren"
+
+#: id:13354
+msgctxt "Auto context with id 13354"
+msgid "Render method"
+msgstr "Rendermethode"
+
+#: id:13355
+msgid "Low quality pixel shader"
+msgstr "Lage kwaliteit Pixel Shader"
+
+#: id:13356
+msgid "Hardware overlays"
+msgstr "Hardware Overlays"
+
+#: id:13357
+msgid "High quality pixel shader"
+msgstr "Hoge kwaliteit Pixel Shader"
+
+#: id:13358
+msgid "Play item"
+msgstr "Item afspelen"
+
+#: id:13359
+msgid "Set artist thumb"
+msgstr "Afbeelding artiest instellen"
+
+#: id:13360
+msgid "Automatically generate thumbnails"
+msgstr "Miniaturen automatisch aanmaken"
+
+#: id:13361
+msgid "Enable voice"
+msgstr "Stem inschakelen"
+
+#: id:13375
+msgid "Enable device"
+msgstr "Apparaat inschakelen"
+
+#: id:13376
+msgid "Volume"
+msgstr "Volume"
+
+#: id:13377
+msgid "Default view mode"
+msgstr "Standaard weergavemodus"
+
+#: id:13378
+msgid "Default brightness"
+msgstr "Standaard helderheid"
+
+#: id:13379
+msgid "Default contrast"
+msgstr "Standaard contrast"
+
+#: id:13380
+msgid "Default gamma"
+msgstr "Standaard kleurbalans"
+
+#: id:13381
+msgid "Resume video"
+msgstr "Video hervatten"
+
+#: id:13382
+msgid "Voice mask - Port 1"
+msgstr "Stem - Poort 0"
+
+#: id:13383
+msgid "Voice mask - Port 2"
+msgstr "Stem - Poort 1"
+
+#: id:13384
+msgid "Voice mask - Port 3"
+msgstr "Stem - Poort 2"
+
+#: id:13385
+msgid "Voice mask - Port 4"
+msgstr "Stem - Poort 3"
+
+#: id:13386
+msgid "Use time based seeking"
+msgstr "Op tijd gebaseerd zoeken"
+
+#: id:13387
+msgid "Track naming template - right"
+msgstr "In rechter kolom van lijst weergeven:"
+
+#: id:13388
+msgid "Preset"
+msgstr "Preset"
+
+#: id:13389
+msgid "There are no presets available\nfor this visualization"
+msgstr "Er zijn geen presets beschikbaar voor deze visualisatie"
+
+#: id:13390
+msgid "There are no settings available\nfor this visualization"
+msgstr "Er zijn geen instellingen beschikbaar voor deze visualisatie"
+
+#: id:13391
+msgid "Eject/Load"
+msgstr "Lade open/dicht"
+
+#: id:13392
+msgid "Use visualization if playing audio"
+msgstr "Toon visualisaties tijdens afspelen muziek"
+
+#: id:13393
+msgid "Calculate size"
+msgstr "Bereken grootte"
+
+#: id:13394
+msgid "Calculating folder size"
+msgstr "Bereken mapgrootte"
+
+#: id:13395
+msgid "Video settings"
+msgstr "Videoinstellingen"
+
+#: id:13396
+msgid "Audio and subtitle settings"
+msgstr "Geluids- en ondertitelinstellingen"
+
+#: id:13397
+msgid "Enable subtitles"
+msgstr "Ondertitels gebruiken"
+
+#: id:13398
+msgctxt "Auto context with id 13398"
+msgid "Shortcuts"
+msgstr "Posities"
+
+#: id:13399
+msgid "Ignore articles when sorting (e.g. \"the\")"
+msgstr "Lidwoorden negeren tijdens sorteren (bijv. The & De)"
+
+#: id:13400
+msgid "Crossfade between songs on the same album"
+msgstr "Nummers van hetzelfde album in elkaar laten overvloeien"
+
+#: id:13401
+msgid "Browse for %s"
+msgstr "Zoeken naar %s"
+
+#: id:13402
+msgid "Show track position"
+msgstr "Trackpositie weergeven"
+
+#: id:13403
+msgid "Clear default"
+msgstr "Standaard leegmaken"
+
+#: id:13404
+msgid "Resume"
+msgstr "Hervatten"
+
+#: id:13405
+msgid "Get thumb"
+msgstr "Miniaturen"
+
+#: id:13406
+msgid "Picture information"
+msgstr "Afbeeldingsinformatie"
+
+#: id:13407
+msgid "%s presets"
+msgstr "%s presets"
+
+#: id:13408
+msgid "(IMDb user rating)"
+msgstr "IMDb-score"
+
+#: id:13409
+msgid "Top 250"
+msgstr "Top 250"
+
+#: id:13410
+msgid "Tune in on Last.fm"
+msgstr "Op Last.FM beluisteren"
+
+#: id:13411
+msgid "Minimum fan speed"
+msgstr "Minimale ventilatorsnelheid"
+
+#: id:13412
+msgid "Play from here"
+msgstr "Afspelen vanaf hier"
+
+#: id:13413
+msgid "Downloading"
+msgstr "Download"
+
+#: id:13414
+msgid "Include artists who appear only on compilations"
+msgstr "Artiesten weergeven die alleen op verzamel CD's voorkomen"
+
+#: id:13415
+msgctxt "Auto context with id 13415"
+msgid "Render method"
+msgstr "Rendermethode"
+
+#: id:13416
+msgid "Auto detect"
+msgstr "Automatisch detecteren"
+
+#: id:13417
+msgid "Basic shaders (ARB)"
+msgstr "Eenvoudige shaders (ARB)"
+
+#: id:13418
+msgid "Advanced shaders (GLSL)"
+msgstr "Geavanceerde shaders (GLSL)"
+
+#: id:13419
+msgid "Software"
+msgstr "Software"
+
+#: id:13420
+msgid "Remove safely"
+msgstr "Hardware veilig verwijderen"
+
+#: id:13421
+msgctxt "Auto context with id 13421"
+msgid "VDPAU"
+msgstr "VDPAU"
+
+#: id:13422
+msgid "Start slideshow here"
+msgstr "Diavoorstelling starten"
+
+#: id:13423
+msgid "Remember for this path"
+msgstr "Onthouden voor dit pad"
+
+#: id:13424
+msgid "Use pixel buffer objects"
+msgstr "Gebruik pixelbufferobjecten"
+
+#: id:13425
+msgid "Allow hardware acceleration (VDPAU)"
+msgstr "Hardwareversnelling inschakelen (VDPAU)"
+
+#: id:13426
+msgid "Allow hardware acceleration (VAAPI)"
+msgstr "Hardwareversnelling inschakelen (VAAPI)"
+
+#: id:13427
+msgid "Allow hardware acceleration (DXVA2)"
+msgstr "Hardwareversnelling inschakelen (DXVA2)"
+
+#: id:13428
+msgid "Allow hardware acceleration (CrystalHD)"
+msgstr "Hardwareversnelling inschakelen (CrystalHD)"
+
+#: id:13429
+msgid "Allow hardware acceleration (VDADecoder)"
+msgstr "Hardwareversnelling inschakelen (VDADecoder)"
+
+#: id:13430
+msgid "Allow hardware acceleration (OpenMax)"
+msgstr "Hardwareversnelling inschakelen (OpenMax)"
+
+#: id:13431
+msgid "Pixel Shaders"
+msgstr "Pixelshaders"
+
+#: id:13432
+msgid "Allow hardware acceleration (VideoToolbox)"
+msgstr "Hardware acceleratie toestaan (VideoToolbox)"
+
+#: id:13500
+msgid "A/V sync method"
+msgstr "A/V-synchronisatiemethode"
+
+#: id:13501
+msgid "Audio clock"
+msgstr "Audiosignaal"
+
+#: id:13502
+msgid "Video clock (Drop/Dupe audio)"
+msgstr "Videosignaal (Drop/Dupe audio)"
+
+#: id:13503
+msgid "Video clock (Resample audio)"
+msgstr "Videosignaal (Resample audio)"
+
+#: id:13504
+msgid "Maximum resample amount (%)"
+msgstr "Maximum resample amount (%)"
+
+#: id:13505
+msgid "Resample quality"
+msgstr "Resamplingkwaliteit"
+
+#: id:13506
+msgid "Low(fast)"
+msgstr "Laag (snel)"
+
+#: id:13507
+msgctxt "Auto context with id 13507"
+msgid "Medium"
+msgstr "Medium"
+
+#: id:13508
+msgctxt "Auto context with id 13508"
+msgid "High"
+msgstr "Hoog"
+
+#: id:13509
+msgid "Really high(slow!)"
+msgstr "Echt hoog (traag!)"
+
+#: id:13510
+msgid "Sync playback to display"
+msgstr "Synchroniseer video met beeldschermfrequentie"
+
+#: id:13550
+msgid "Pause during refresh rate change"
+msgstr "Pauzeren gedurende wijzigen verversing snelheid"
+
+#: id:13551
+msgctxt "Auto context with id 13551"
+msgid "Off"
+msgstr "Uit"
+
+#: id:13552
+msgid "%.1f Second"
+msgstr "%.1f Seconde"
+
+#: id:13553
+msgid "%.1f Seconds"
+msgstr "%.1f Seconden"
+
+#: id:13600
+msgid "Apple remote"
+msgstr "Type Apple afstandsbediening"
+
+#: id:13602
+msgid "Allow start of XBMC using the remote"
+msgstr "Gebruik afstandsbediening om XBMC zelf op te staren"
+
+#: id:13603
+msgid "Sequence delay time"
+msgstr "Ondertitel eerder/later starten"
+
+#: id:13610
+msgctxt "Auto context with id 13610"
+msgid "Disabled"
+msgstr "Uitgeschakeld"
+
+#: id:13611
+msgctxt "Auto context with id 13611"
+msgid "Standard"
+msgstr "Standaard"
+
+#: id:13612
+msgid "Universal Remote"
+msgstr "Universele afstandsbediening"
+
+#: id:13613
+msgid "Multi Remote (Harmony)"
+msgstr "Multi Remote (Harmony)"
+
+#: id:13620
+msgid "Apple Remote Error"
+msgstr "Apple afstandsbedieningsfout"
+
+#: id:13621
+msgid "Apple Remote support could be enabled."
+msgstr "Apple afstandsbedieningsondersteuning kan niet worden geactiveerd."
+
+#: id:14000
+msgid "Stack"
+msgstr "Groeperen"
+
+#: id:14001
+msgid "Unstack"
+msgstr "Groeperen: Uit"
+
+#: id:14003
+msgid "Downloading playlist file..."
+msgstr "Afspeellijst downloaden..."
+
+#: id:14004
+msgid "Downloading streams list..."
+msgstr "Streamlijst downloaden..."
+
+#: id:14005
+msgid "Parsing streams list..."
+msgstr "Streamlijst verwerken..."
+
+#: id:14006
+msgid "Downloading streams list failed"
+msgstr "Streamlijst downloaden mislukt"
+
+#: id:14007
+msgid "Downloading playlist file failed"
+msgstr "Afspeellijst downloaden mislukt"
+
+#: id:14009
+msgid "Games directory"
+msgstr "Spellocatie"
+
+#: id:14010
+msgid "Auto switch to thumbs based on"
+msgstr "Automatisch overschakelen naar miniaturen als"
+
+#: id:14011
+msgid "Enable auto switching to thumbs view"
+msgstr "Automatisch overschakelen naar miniaturen"
+
+#: id:14012
+msgid "- Use large icons"
+msgstr "- Gebruik grote iconen"
+
+#: id:14013
+msgid "- Switch based on"
+msgstr "- Baseren op"
+
+#: id:14014
+msgid "- Percentage"
+msgstr "- Percentage"
+
+#: id:14015
+msgid "No files and at least one thumb"
+msgstr "Geen bestanden en minimaal 1 miniatuur"
+
+#: id:14016
+msgid "At least one file and thumb"
+msgstr "Tenminste 1 miniatuur"
+
+#: id:14017
+msgid "Percentage of thumbs"
+msgstr "Het percentage miniaturen"
+
+#: id:14018
+msgid "View options"
+msgstr "Weergaveopties"
+
+#: id:14019
+msgid "Change area code 1"
+msgstr "Locatie 1"
+
+#: id:14020
+msgid "Change area code 2"
+msgstr "Locatie 2"
+
+#: id:14021
+msgid "Change area code 3"
+msgstr "Locatie 3"
+
+#: id:14022
+msgctxt "Auto context with id 14022"
+msgid "Library"
+msgstr "Bibliotheek"
+
+#: id:14023
+msgid "No TV"
+msgstr "Geen TV"
+
+#: id:14024
+msgid "Enter the nearest large town"
+msgstr "De dichtstbijzijnde grote plaats"
+
+#: id:14025
+msgid "Video/Audio/DVD cache - Harddisk"
+msgstr "Video-/geluids-/DVD-buffer - harde schijf"
+
+#: id:14026
+msgid "Video cache - DVD-ROM"
+msgstr "Videobuffer - DVD"
+
+#: id:14027
+msgctxt "Auto context with id 14027"
+msgid "- Local Network"
+msgstr "- Lokaal netwerk"
+
+#: id:14028
+msgctxt "Auto context with id 14028"
+msgid "- Internet"
+msgstr "- Internet"
+
+#: id:14030
+msgid "Audio cache - DVD-ROM"
+msgstr "Geluidsbuffer - DVD"
+
+#: id:14031
+msgctxt "Auto context with id 14031"
+msgid "- Local Network"
+msgstr "- Lokaal netwerk"
+
+#: id:14032
+msgctxt "Auto context with id 14032"
+msgid "- Internet"
+msgstr "- Internet"
+
+#: id:14034
+msgid "DVD cache - DVD-ROM"
+msgstr "DVD-buffer"
+
+#: id:14035
+msgctxt "Auto context with id 14035"
+msgid "- Local Network"
+msgstr "- Lokaal netwerk"
+
+#: id:14036
+msgctxt "Auto context with id 14036"
+msgid "Services"
+msgstr "Servers"
+
+#: id:14038
+msgid "Network settings changed"
+msgstr "Netwerkinstellingen gewijzigd"
+
+#: id:14039
+msgid "XBMC requires to restart to change your"
+msgstr "XBMC moet herstarten om de netwerkinstellingen"
+
+#: id:14040
+msgid "network setup. Would you like to restart now?"
+msgstr "te wijzigen. Wilt u nu herstarten?"
+
+#: id:14041
+msgid "Internet connection bandwidth limitation"
+msgstr "Bandbreedte internetverbinding beperken"
+
+#: id:14043
+msgid "- Shutdown while playing"
+msgstr "- Uitschakelen tijdens gebruik"
+
+#: id:14044
+msgid "%i min"
+msgstr "%i minuten"
+
+#: id:14045
+msgid "%i sec"
+msgstr "%i sec."
+
+#: id:14046
+msgid "%i ms"
+msgstr "%i millisec."
+
+#: id:14047
+msgid "%i %%"
+msgstr "%i %%"
+
+#: id:14048
+msgid "%i kbps"
+msgstr "%i kbps"
+
+#: id:14049
+msgid "%i kb"
+msgstr "%i kb"
+
+#: id:14050
+msgid "%i.0 dB"
+msgstr "%i.0 dB"
+
+#: id:14051
+msgid "Time format"
+msgstr "Tijdnotatie"
+
+#: id:14052
+msgid "Date format"
+msgstr "Datumnotatie"
+
+#: id:14053
+msgid "GUI filters"
+msgstr "GUI-filters"
+
+#: id:14055
+msgid "Use background scanning"
+msgstr "Scannen op de achtergrond inschakelen"
+
+#: id:14056
+msgid "Stop scan"
+msgstr "Scan annuleren"
+
+#: id:14057
+msgid "Not possible while scanning for media info"
+msgstr "Niet mogelijk tijdens scannen naar media-info"
+
+#: id:14058
+msgid "Film grain effect"
+msgstr "Filmkorreleffect"
+
+#: id:14059
+msgid "Search for thumbnails on remote shares"
+msgstr "Miniaturen in netwerkmappen zoeken"
+
+#: id:14060
+msgid "Unknown type cache - Internet"
+msgstr "Onbekende types buffer - Internet"
+
+#: id:14061
+msgctxt "Auto context with id 14061"
+msgid "Auto"
+msgstr "Automatisch"
+
+#: id:14062
+msgid "Enter username for"
+msgstr "Geef gebruikersnaam voor"
+
+#: id:14063
+msgid "Date & time"
+msgstr "Datum & tijd"
+
+#: id:14064
+msgid "Set date"
+msgstr "Datum instellen"
+
+#: id:14065
+msgid "Set time"
+msgstr "Tijd instellen"
+
+#: id:14066
+msgid "Enter the time in 24 hour HH:MM format"
+msgstr "Geef de tijd in 24-uursformaat (HH:MM)"
+
+#: id:14067
+msgid "Enter the date in DD/MM/YYYY format"
+msgstr "Geef de datum in DD/MM/YYYY formaat"
+
+#: id:14068
+msgid "Enter the IP address"
+msgstr "Geef het IP-adres"
+
+#: id:14069
+msgid "Apply these settings now?"
+msgstr "Instellingen nu toepassen?"
+
+#: id:14070
+msgid "Apply changes now"
+msgstr "Instellingen toepassen"
+
+#: id:14071
+msgid "Allow file renaming and deletion"
+msgstr "Hernoemen en verwijderen van bestanden toestaan"
+
+#: id:14074
+msgid "Set timezone"
+msgstr "Tijdzone"
+
+#: id:14075
+msgid "Use daylight saving time"
+msgstr "Automatische zomer-/wintertijd"
+
+#: id:14076
+msgid "Add to favourites"
+msgstr "Aan favorieten toevoegen"
+
+#: id:14077
+msgid "Remove from favourites"
+msgstr "Uit favorieten verwijderen"
+
+#: id:14078
+msgctxt "Auto context with id 14078"
+msgid "- Colours"
+msgstr "- Kleuren"
+
+#: id:14079
+msgid "Timezone country"
+msgstr "Tijdzone land"
+
+#: id:14080
+msgid "Timezone"
+msgstr "Tijdzone"
+
+#: id:14081
+msgid "File lists"
+msgstr "Bestandlijsten"
+
+#: id:14082
+msgid "Show EXIF picture information"
+msgstr "EXIF-informatie uitlezen"
+
+#: id:14083
+msgid "Use a fullscreen window rather than true fullscreen"
+msgstr "Gemaximaliseerd venster in plaats van volledig scherm"
+
+#: id:14084
+msgid "Queue songs on selection"
+msgstr "Bij selecteren nummers in de afspeellijst zetten"
+
+#: id:14086
+msgid "Playback"
+msgstr "Afspelen"
+
+#: id:14087
+msgid "DVDs"
+msgstr "DVD's"
+
+#: id:14088
+msgid "Play DVDs automatically"
+msgstr "DVD's automatisch afspelen"
+
+#: id:14089
+msgid "Font to use for text subtitles"
+msgstr "Lettertype voor ondertiteling"
+
+#: id:14090
+msgid "International"
+msgstr "Land en Taal"
+
+#: id:14091
+msgid "Character set"
+msgstr "Tekencodering (Unicode, UTF-8, ISO)"
+
+#: id:14092
+msgid "Debugging"
+msgstr "Fout registratie"
+
+#: id:14093
+msgid "Security"
+msgstr "Beveiliging"
+
+#: id:14094
+msgid "Input devices"
+msgstr "Invoerapparaten"
+
+#: id:14095
+msgid "Power saving"
+msgstr "Energiebeheer"
+
+#: id:14096
+msgid "Rip"
+msgstr ""
+
+#: id:14097
+msgid "Audio CD Insert Action"
+msgstr ""
+
+#: id:14098
+msgctxt "Auto context with id 14098"
+msgid "Play"
+msgstr ""
+
+#: id:14099
+msgid "Eject disc when CD ripping is complete"
+msgstr ""
+
+#: id:15015
+msgctxt "Auto context with id 15015"
+msgid "Remove"
+msgstr "Verwijder"
+
+#: id:15016
+msgid "Games"
+msgstr "Spellen"
+
+#: id:15019
+msgid "Add"
+msgstr "Voeg toe"
+
+#: id:15052
+msgid "Password"
+msgstr "Wachtwoord"
+
+#: id:15100
+msgctxt "Auto context with id 15100"
+msgid "Library"
+msgstr "Bibliotheek"
+
+#: id:15101
+msgid "Database"
+msgstr "Database"
+
+#: id:15102
+msgid "* All albums"
+msgstr "* Alle albums"
+
+#: id:15103
+msgid "* All artists"
+msgstr "* Alle artiesten"
+
+#: id:15104
+msgid "* All songs"
+msgstr "* Alle nummers"
+
+#: id:15105
+msgid "* All genres"
+msgstr "* Alle genres"
+
+#: id:15107
+msgid "Buffering..."
+msgstr "Bufferen..."
+
+#: id:15108
+msgid "Navigation sounds"
+msgstr "Navigatiegeluiden"
+
+#: id:15109
+msgid "Skin default"
+msgstr "Standaarduiterijk"
+
+#: id:15111
+msgid "- Theme"
+msgstr "- Thema"
+
+#: id:15112
+msgid "Default theme"
+msgstr "Standaard thema"
+
+#: id:15200
+msgid "Last.fm"
+msgstr "Last.FM"
+
+#: id:15201
+msgid "Submit songs to Last.fm"
+msgstr "Afgespeelde nummers op Last.FM bijhouden"
+
+#: id:15202
+msgid "Last.fm username"
+msgstr "Last.FM-gebruikersnaam"
+
+#: id:15203
+msgid "Last.fm password"
+msgstr "Last.FM-wachtwoord"
+
+#: id:15204
+msgid "Unable to handshake: sleeping..."
+msgstr "Verbinding mislukt"
+
+#: id:15205
+msgid "Please update XBMC"
+msgstr "Werk XBMC bij aub"
+
+#: id:15206
+msgid "Bad authorization: Check username and password"
+msgstr "Authentificatie mislukt: controleer gebruikersnaam en wachtwoord"
+
+#: id:15207
+msgctxt "Auto context with id 15207"
+msgid "Connected"
+msgstr "Actief"
+
+#: id:15208
+msgid "Not connected"
+msgstr "Niet verbonden"
+
+#: id:15209
+msgid "Submit interval %i"
+msgstr "Verzendinterval %i"
+
+#: id:15210
+msgid "Cached %i songs"
+msgstr "%i nummers gebufferd"
+
+#: id:15211
+msgid "Submitting..."
+msgstr "Verzenden..."
+
+#: id:15212
+msgid "Submitting in %i secs"
+msgstr "Verzenden over %i sec."
+
+#: id:15213
+msgid "Play using..."
+msgstr "Afspelen met..."
+
+#: id:15214
+msgid "Use smoothed A/V synchronization"
+msgstr "Geleidelijke A/V-synchronisatie gebruiken"
+
+#: id:15215
+msgid "Hide file names in thumbs view"
+msgstr "Bestandsnamen in miniatuurweergave verbergen"
+
+#: id:15216
+msgid "Play in party mode"
+msgstr "Afspelen in feestmix"
+
+#: id:15217
+msgid "Submit songs to Libre.fm"
+msgstr "Afgespeelde nummers op Libre.fm bijhouden"
+
+#: id:15218
+msgid "Libre.fm username"
+msgstr "Libre.fm-gebruikersnaam"
+
+#: id:15219
+msgid "Libre.fm password"
+msgstr "Libre.fm-wachtwoord"
+
+#: id:15220
+msgid "Libre.fm"
+msgstr "Libre.fm"
+
+#: id:15221
+msgid "Song submission"
+msgstr "Nummers bijhouden"
+
+#: id:15250
+msgid "Submit Last.fm radio to Last.fm"
+msgstr "Last.FM-radio aan Last.FM toevoegen"
+
+#: id:15251
+msgid "Connecting to Last.fm..."
+msgstr "Verbinding maken met Last.FM..."
+
+#: id:15252
+msgid "Selecting station..."
+msgstr "Station selecteren..."
+
+#: id:15253
+msgid "Search similar artists..."
+msgstr "Naar vergelijkbare artiesten zoeken..."
+
+#: id:15254
+msgid "Search similar tags..."
+msgstr "Naar vergelijkbare tags zoeken..."
+
+#: id:15255
+msgid "Your profile (%name%)"
+msgstr "Mijn profiel (%name%)"
+
+#: id:15256
+msgid "Overall top tags"
+msgstr "Populairste tags"
+
+#: id:15257
+msgid "Top artists for tag %name%"
+msgstr "Favoriete artiesten van %name%"
+
+#: id:15258
+msgid "Top albums for tag %name%"
+msgstr "Favoriete albums van %name%"
+
+#: id:15259
+msgid "Top tracks for tag %name%"
+msgstr "Favoriete nummers van %name%"
+
+#: id:15260
+msgid "Listen to tag %name% Last.fm radio"
+msgstr "Beluister %name% op Last.fm-radio"
+
+#: id:15261
+msgid "Similar artists as %name%"
+msgstr "Artiesten vergelijkbaar met %name%"
+
+#: id:15262
+msgid "Top %name% albums"
+msgstr "Populairste albums van %name%"
+
+#: id:15263
+msgid "Top %name% tracks"
+msgstr "Populairste nummers van %name%"
+
+#: id:15264
+msgid "Top %name% tags"
+msgstr "Populairste tags voor %name%"
+
+#: id:15265
+msgid "Biggest fans of %name%"
+msgstr "Grootste fans van %name%"
+
+#: id:15266
+msgid "Listen to %name% fans Last.fm radio"
+msgstr "Beluister de Last.fm-radio van fans van %name%"
+
+#: id:15267
+msgid "Listen to %name% similar artists Last.fm radio"
+msgstr "Beluister artiesten vergelijkbaar met %name%"
+
+#: id:15268
+msgid "Top artists for user %name%"
+msgstr "Populairste artiesten van %name%"
+
+#: id:15269
+msgid "Top albums for user %name%"
+msgstr "Populairste albums van %name%"
+
+#: id:15270
+msgid "Top tracks for user %name%"
+msgstr "Populairste nummers van %name%"
+
+#: id:15271
+msgid "Friends of user %name%"
+msgstr "Vrienden van %name%"
+
+#: id:15272
+msgid "Neighbours of user %name%"
+msgstr "Buren van %name%"
+
+#: id:15273
+msgid "Weekly artist chart for %name%"
+msgstr "Wekelijkse artiestenhitlijst voor %name%"
+
+#: id:15274
+msgid "Weekly album chart for %name%"
+msgstr "Wekelijkse albumhitlijst voor %name%"
+
+#: id:15275
+msgid "Weekly track chart for %name%"
+msgstr "Wekelijkse nummerhitlijst voor %name%"
+
+#: id:15276
+msgid "Listen to %name%'s neighbours Last.fm radio"
+msgstr "Beluister de 'buren' Last.fm-radio van %name%"
+
+#: id:15277
+msgid "Listen to %name%'s personal Last.fm radio"
+msgstr "Beluister de persoonlijke Last.fm-radio van %name%"
+
+#: id:15278
+msgid "Listen to %name%'s mix Last.fm radio"
+msgstr "Beluister favoriete nummers van %name% op Last.fm radio"
+
+#: id:15279
+msgid "Retrieving list from Last.fm..."
+msgstr "Lijst ontvangen van Last.fm..."
+
+#: id:15280
+msgid "Can't retrieve list from Last.fm..."
+msgstr "Lijst ontvangen mislukt..."
+
+#: id:15281
+msgid "Enter an artist name to find related ones"
+msgstr "Geef een artiest op om vergelijkbare artiesten te vinden"
+
+#: id:15282
+msgid "Enter a tag name to find similar ones"
+msgstr "Geef een tag om vergelijkbare te vinden"
+
+#: id:15283
+msgid "Tracks recently listened by %name%"
+msgstr "Onlangs door %name% afgespeelde nummers"
+
+#: id:15284
+msgid "Listen to %name%'s recommendations Last.fm radio"
+msgstr "Beluister de aanbevelingen van %name% op Last.FM-radio"
+
+#: id:15285
+msgid "Top tags for user %name%"
+msgstr "Top tags van %name%"
+
+#: id:15287
+msgid "Do you want to add the current track to your loved tracks?"
+msgstr "Wilt u dit nummer toevoegen aan uw favoriete nummers?"
+
+#: id:15288
+msgid "Do you want to ban the current track?"
+msgstr "Wilt u dit nummer verbannen?"
+
+#: id:15289
+msgid "Added to your loved tracks: '%s'."
+msgstr "Toegevoegd aan favoriete nummers: %s"
+
+#: id:15290
+msgid "Could not add '%s' to your loved tracks."
+msgstr "Toevoegen van '%s' aan favoriete nummers mislukt."
+
+#: id:15291
+msgid "Banned: '%s'."
+msgstr "Verbannen: '%s'."
+
+#: id:15292
+msgid "Could not ban '%s'."
+msgstr "Verbannen van '%s' mislukt."
+
+#: id:15293
+msgid "Tracks recently loved by %name%"
+msgstr "Tracks recent gewaardeerd door %name%"
+
+#: id:15294
+msgid "Tracks recently banned by %name%"
+msgstr "Recent verbannen nummers door %name%"
+
+#: id:15295
+msgid "Remove from loved tracks"
+msgstr "Verwijderen uit favoriete nummers"
+
+#: id:15296
+msgid "Un-ban"
+msgstr "Ban opheffen"
+
+#: id:15297
+msgid "Do you want to remove this track from your loved tracks?"
+msgstr "Wilt u dit nummer verwijderen uit uw favoriete nummers?"
+
+#: id:15298
+msgid "Do you want to un-ban this track?"
+msgstr "Wilt u de ban op dit nummer opheffen?"
+
+#: id:15300
+msgid "Path not found or invalid"
+msgstr "Pad niet gevonden of ongeldig"
+
+#: id:15301
+msgid "Could not connect to network server"
+msgstr "Kan niet verbinden met netwerkserver"
+
+#: id:15302
+msgid "No servers found"
+msgstr "Geen servers gevonden"
+
+#: id:15303
+msgid "Workgroup not found"
+msgstr "Werkgroep niet gevonden"
+
+#: id:15310
+msgid "Opening multi-path source"
+msgstr "Openen multi-pad favoriet"
+
+#: id:15311
+msgid "Path:"
+msgstr "Pad:"
+
+#: id:16000
+msgctxt "Auto context with id 16000"
+msgid "General"
+msgstr "Algemeen"
+
+#: id:16002
+msgid "Internet lookup"
+msgstr "Zoeken op CDDB"
+
+#: id:16003
+msgid "Player"
+msgstr "Speler"
+
+#: id:16004
+msgid "Play media from disc"
+msgstr "Media van disk afspelen"
+
+#: id:16008
+msgid "Enter new title"
+msgstr "Geef een nieuwe titel"
+
+#: id:16009
+msgid "Enter the movie name"
+msgstr "Geef naam van de film"
+
+#: id:16010
+msgid "Enter the profile name"
+msgstr "Geef profielnaam"
+
+#: id:16011
+msgid "Enter the album name"
+msgstr "Geef titel album"
+
+#: id:16012
+msgid "Enter the playlist name"
+msgstr "Geef naam afspeellijst"
+
+#: id:16013
+msgid "Enter new filename"
+msgstr "Geef nieuwe bestandsnaam"
+
+#: id:16014
+msgid "Enter folder name"
+msgstr "Geef mapnaam"
+
+#: id:16015
+msgid "Enter directory"
+msgstr "Open map"
+
+#: id:16016
+msgid "Available options: %A, %T, %N, %B, %D, %G, %Y, %F, %S"
+msgstr "Beschikbare opties: %A, %T, %N, %B, %D, %G, %Y, %F, %S"
+
+#: id:16017
+msgid "Enter search string"
+msgstr "Geef zoekopdracht"
+
+#: id:16018
+msgctxt "Auto context with id 16018"
+msgid "None"
+msgstr "Geen"
+
+#: id:16019
+msgid "Auto select"
+msgstr "Automatisch selecteren"
+
+#: id:16020
+msgid "De-interlace"
+msgstr "Deinterlace"
+
+#: id:16021
+msgid "Bob"
+msgstr "Synchroniseer oneven"
+
+#: id:16022
+msgid "Bob (inverted)"
+msgstr "Synchroniseer even"
+
+#: id:16024
+msgid "Canceling..."
+msgstr "Annuleren..."
+
+#: id:16025
+msgid "Enter the artist name"
+msgstr "Geef de artiest op"
+
+#: id:16026
+msgid "Playback failed"
+msgstr "Afspeellijst afspelen afgebroken"
+
+#: id:16027
+msgid "One or more items failed to play."
+msgstr "Eén of meer item kan niet worden afgespeeld."
+
+#: id:16028
+msgid "Enter value"
+msgstr "Voer waarde in"
+
+#: id:16029
+msgid "Check the log file for details."
+msgstr "Controleer het logbestand voor details."
+
+#: id:16030
+msgid "Party mode aborted."
+msgstr "Feestmix afgebroken."
+
+#: id:16031
+msgid "No matching songs in the library."
+msgstr "Geen overeenkomstige nummers in bibliotheek."
+
+#: id:16032
+msgid "Could not initialize database."
+msgstr "Kan database niet initialiseren."
+
+#: id:16033
+msgid "Could not open database."
+msgstr "Kan database niet openen."
+
+#: id:16034
+msgid "Could not get songs from database."
+msgstr "Kan geen nummers uit database verkrijgen."
+
+#: id:16035
+msgid "Party mode playlist"
+msgstr "Feestmix afspeellijst"
+
+#: id:16036
+msgid "De-interlace (Half)"
+msgstr "Deinterlace (Half)"
+
+#: id:16037
+msgid "Deinterlace video"
+msgstr "Deinterlace video"
+
+#: id:16038
+msgid "Deinterlace method"
+msgstr "Deinterlace methode"
+
+#: id:16039
+msgctxt "Auto context with id 16039"
+msgid "Off"
+msgstr "Uit"
+
+#: id:16040
+msgctxt "Auto context with id 16040"
+msgid "Auto"
+msgstr "Auto"
+
+#: id:16041
+msgid "On"
+msgstr "Aan"
+
+#: id:16100
+msgid "All Videos"
+msgstr "Alle video's"
+
+#: id:16101
+msgid "Unwatched"
+msgstr "Niet bekeken"
+
+#: id:16102
+msgid "Watched"
+msgstr "Bekeken"
+
+#: id:16103
+msgid "Mark as watched"
+msgstr "Als bekeken markeren"
+
+#: id:16104
+msgid "Mark as unwatched"
+msgstr "Als niet-bekeken markeren"
+
+#: id:16105
+msgid "Edit title"
+msgstr "Titel aanpassen"
+
+#: id:16200
+msgid "Operation was aborted"
+msgstr "Actie is afgebroken"
+
+#: id:16201
+msgid "Copy failed"
+msgstr "Kopiëren mislukt"
+
+#: id:16202
+msgid "Failed to copy at least one file"
+msgstr "Tenminste 1 bestand is niet gekopieerd"
+
+#: id:16203
+msgid "Move failed"
+msgstr "Verplaatsen mislukt"
+
+#: id:16204
+msgid "Failed to move at least one file"
+msgstr "Tenminste 1 bestand is niet verplaatst"
+
+#: id:16205
+msgid "Delete failed"
+msgstr "Verwijderen mislukt"
+
+#: id:16206
+msgid "Failed to delete at least one file"
+msgstr "Tenminste 1 bestand is niet verwijderd"
+
+#: id:16300
+msgid "Video scaling method"
+msgstr "Videoschalingsmethode"
+
+#: id:16301
+msgid "Nearest neighbour"
+msgstr "Nearest neighbour"
+
+#: id:16302
+msgid "Bilinear"
+msgstr "Bilinear"
+
+#: id:16303
+msgctxt "Auto context with id 16303"
+msgid "Bicubic"
+msgstr "Bicubic"
+
+#: id:16304
+msgid "Lanczos2"
+msgstr "Lanczos2"
+
+#: id:16305
+msgid "Lanczos3"
+msgstr "Lanczos3"
+
+#: id:16306
+msgid "Sinc8"
+msgstr "Sinc8"
+
+#: id:16307
+msgid "Bicubic (software)"
+msgstr "Bicubic (software)"
+
+#: id:16308
+msgid "Lanczos (software)"
+msgstr "Lanczos (software)"
+
+#: id:16309
+msgid "Sinc (software)"
+msgstr "Sinc (software)"
+
+#: id:16310
+msgid "Temporal"
+msgstr "(VDPAU)Temporal"
+
+#: id:16311
+msgid "Temporal/Spatial"
+msgstr "(VDPAU)Temporal/Spatial"
+
+#: id:16312
+msgid "(VDPAU)Noise Reduction"
+msgstr "(VDPAU)Ruisonderdrukking"
+
+#: id:16313
+msgid "(VDPAU)Sharpness"
+msgstr "(VDPAU)Scherpte"
+
+#: id:16314
+msgid "Inverse Telecine"
+msgstr "Inverse telecine"
+
+#: id:16315
+msgid "Lanczos3 optimized"
+msgstr "Lanczos3 optimized"
+
+#: id:16316
+msgctxt "Auto context with id 16316"
+msgid "Auto"
+msgstr "Auto"
+
+#: id:16317
+msgid "Temporal (Half)"
+msgstr "Temporal (Half)"
+
+#: id:16318
+msgid "Temporal/Spatial (Half)"
+msgstr "Temporal/Spatial (Half)"
+
+#: id:16319
+msgid "DXVA"
+msgstr "DXVA"
+
+#: id:16320
+msgid "DXVA Bob"
+msgstr "DXVA Bob"
+
+#: id:16321
+msgid "DXVA Best"
+msgstr "DXVA Best"
+
+#: id:16322
+msgid "Spline36"
+msgstr "Spline36"
+
+#: id:16323
+msgid "Spline36 optimized"
+msgstr "Spline36 geoptimaliseerd"
+
+#: id:16324
+msgid "Software Blend"
+msgstr "Software menging"
+
+#: id:16400
+msgid "Post-processing"
+msgstr "Kwaliteitsverbetering video"
+
+#: id:17500
+msgid "Display sleep timeout"
+msgstr "Uitschakeltijd beeldscherm"
+
+#: id:19000
+msgid "Switch to channel"
+msgstr "Kanaal wijzigen"
+
+#: id:20000
+msgid "Saved music folder"
+msgstr "Opgeslagen muziek map..."
+
+#: id:20001
+msgid "Use external DVD player"
+msgstr "Andere DVD-speler gebruiken"
+
+#: id:20002
+msgid "External DVD player"
+msgstr "- Locatie van de DVD-speler"
+
+#: id:20003
+msgid "Trainers folder"
+msgstr "Trainersmap"
+
+#: id:20004
+msgid "Screenshot folder"
+msgstr "Screenshotmap"
+
+#: id:20006
+msgid "Playlists folder"
+msgstr "Afspeellijstmap"
+
+#: id:20007
+msgid "Recordings"
+msgstr "Opnames"
+
+#: id:20008
+msgid "Screenshots"
+msgstr "Screenshots"
+
+#: id:20009
+msgid "Use XBMC"
+msgstr "XBMC gebruiken"
+
+#: id:20011
+msgid "Music playlists"
+msgstr "Muziekafspeellijsten"
+
+#: id:20012
+msgid "Video playlists"
+msgstr "Videoafspeellijsten"
+
+#: id:20013
+msgid "Do you wish to launch the game?"
+msgstr "Wilt u het spel starten?"
+
+#: id:20014
+msgid "Sort by: Playlist"
+msgstr "Sorteer: afspeellijst"
+
+#: id:20015
+msgid "Remote thumb"
+msgstr "Internetafbeelding"
+
+#: id:20016
+msgid "Current thumb"
+msgstr "Huidige afbeelding"
+
+#: id:20017
+msgid "Local thumb"
+msgstr "Lokale afbeelding"
+
+#: id:20018
+msgid "No thumb"
+msgstr "Geen afbeelding"
+
+#: id:20019
+msgid "Choose thumbnail"
+msgstr "Miniatuur kiezen"
+
+#: id:20023
+msgid "Conflict"
+msgstr "Conflict"
+
+#: id:20024
+msgid "Scan new"
+msgstr "Scan nieuwe"
+
+#: id:20025
+msgid "Scan all"
+msgstr "Scan alles"
+
+#: id:20026
+msgid "Region"
+msgstr "Regio"
+
+#: id:20037
+msgid "Summary"
+msgstr "Overzicht"
+
+#: id:20038
+msgid "Lock music window"
+msgstr "Muzieksectie vergrendelen"
+
+#: id:20039
+msgid "Lock videos window"
+msgstr "Videosectie vergrendelen"
+
+#: id:20040
+msgid "Lock pictures window"
+msgstr "Afbeeldingensectie vergrendelen"
+
+#: id:20041
+msgid "Lock programs & scripts windows"
+msgstr "Programma- & scriptssecties vergrendelen"
+
+#: id:20042
+msgid "Lock file manager"
+msgstr "Bestandsbeheer vergrendelen"
+
+#: id:20043
+msgid "Lock settings"
+msgstr "Instellingen vergrendelen"
+
+#: id:20044
+msgid "Start fresh"
+msgstr "Met schone lei starten"
+
+#: id:20045
+msgid "Enter master mode"
+msgstr "Naar ontgrendelde modus overschakelen"
+
+#: id:20046
+msgid "Leave master mode"
+msgstr "Ontgrendelde modus verlaten"
+
+#: id:20047
+msgid "Create profile '%s'?"
+msgstr "Profiel '%s' maken?"
+
+#: id:20048
+msgid "Start with fresh settings"
+msgstr "Begin met standaardinstellingen"
+
+#: id:20049
+msgid "Best available"
+msgstr "Beste beschikbaar"
+
+#: id:20050
+msgid "Auto-switch between 16x9 and 4x3"
+msgstr "Schakel autom. tussen 16:9 & 4:3"
+
+#: id:20051
+msgid "Treat stacked files as single file"
+msgstr "Gesplitste bestanden als één behandelen"
+
+#: id:20052
+msgid "Caution"
+msgstr "Waarschuwing"
+
+#: id:20053
+msgid "Left master mode"
+msgstr "Ontgrendelde modus verlaten"
+
+#: id:20054
+msgid "Entered master mode"
+msgstr "Ontgrendelde modus inschakelen"
+
+#: id:20055
+msgid "Allmusic.com thumb"
+msgstr "Allmusic.com-miniatuur"
+
+#: id:20057
+msgid "Remove thumbnail"
+msgstr "Miniatuur verwijderen"
+
+#: id:20058
+msgid "Add profile..."
+msgstr "Profiel toevoegen..."
+
+#: id:20059
+msgid "Query info for all albums"
+msgstr "Info opvragen voor alle albums"
+
+#: id:20060
+msgctxt "Auto context with id 20060"
+msgid "Media info"
+msgstr "Media-info"
+
+#: id:20061
+msgctxt "Auto context with id 20061"
+msgid "Separate"
+msgstr "Afzonderlijk"
+
+#: id:20062
+msgid "Shares with default"
+msgstr "Gebruik standaard"
+
+#: id:20063
+msgid "Shares with default (read only)"
+msgstr "Gebruik standaard (alleen-lezen)"
+
+#: id:20064
+msgid "Copy default"
+msgstr "Kopiëren"
+
+#: id:20065
+msgid "Profile picture"
+msgstr "Profielafbeelding"
+
+#: id:20066
+msgid "Lock preferences"
+msgstr "Vergrendelingsvoorkeuren"
+
+#: id:20067
+msgid "Edit profile"
+msgstr "Profiel wijzigen"
+
+#: id:20068
+msgid "Profile lock"
+msgstr "Profielvergrendeling"
+
+#: id:20069
+msgid "Could not create folder"
+msgstr "Kan map niet creëren"
+
+#: id:20070
+msgid "Profile directory"
+msgstr "Profiellocatie"
+
+#: id:20071
+msgid "Start with fresh media sources"
+msgstr "Met verse mediabronnen beginnen"
+
+#: id:20072
+msgid "Make sure the selected folder is writable"
+msgstr "Controleer of u schrijfrechten heeft op de gekozen locatie"
+
+#: id:20073
+msgid "and that the new folder name is valid"
+msgstr "en of de nieuwe mapnaam geldig is"
+
+#: id:20074
+msgid "MPAA rating"
+msgstr "MPAA-waardering:"
+
+#: id:20075
+msgid "Enter master lock code"
+msgstr "Voer vergrendelcode in"
+
+#: id:20076
+msgid "Ask for master lock code on startup"
+msgstr "Om vergrendelcode vragen bij opstarten"
+
+#: id:20077
+msgid "Skin settings"
+msgstr "Skininstellingen"
+
+#: id:20078
+msgid "- no link set -"
+msgstr "- Geen link ingesteld -"
+
+#: id:20079
+msgid "Enable animations"
+msgstr "Soepel overvloeien bij schermovergang"
+
+#: id:20080
+msgid "Disable RSS during music"
+msgstr "RSS-feeds niet weergeven tijdens afspelen van muziek"
+
+#: id:20081
+msgid "Enable shortcut buttons"
+msgstr "'Favorieten'-knoppen weergeven"
+
+#: id:20082
+msgid "Show programs in main menu"
+msgstr "Programma's in hoofdmenu weergeven"
+
+#: id:20083
+msgid "Show music info"
+msgstr "Muziekinformatie weergeven"
+
+#: id:20084
+msgid "Show weather info"
+msgstr "Weerbericht weergeven"
+
+#: id:20085
+msgid "Show system info"
+msgstr "Systeeminformatie weergeven"
+
+#: id:20086
+msgid "Show available disc space C: E: F:"
+msgstr "Vrije hardeschijfruimte op C:, E: en F: weergeven"
+
+#: id:20087
+msgid "Show available disc space E: F: G:"
+msgstr "Vrije hardeschijfruimte op E:F:G: weergeven"
+
+#: id:20088
+msgid "Weather info"
+msgstr "Weerbericht"
+
+#: id:20089
+msgid "Drive space free"
+msgstr "Beschikbare hardeschijfruimte"
+
+#: id:20090
+msgid "Enter the name of an existing share"
+msgstr "Voer de naam van een bestaande gedeelde map in"
+
+#: id:20091
+msgid "Lock code"
+msgstr "Vergrendelcode"
+
+#: id:20092
+msgid "Load profile"
+msgstr "Profiel laden"
+
+#: id:20093
+msgid "Profile name"
+msgstr "Profielnaam"
+
+#: id:20094
+msgctxt "Auto context with id 20094"
+msgid "Media sources"
+msgstr "Mediabronnen"
+
+#: id:20095
+msgid "Enter profile lock code"
+msgstr "Geef profielvergrendelcode"
+
+#: id:20096
+msgctxt "Auto context with id 20096"
+msgid "Login screen"
+msgstr "Inlogscherm"
+
+#: id:20097
+msgid "Fetching album info"
+msgstr "Albuminfo ophalen"
+
+#: id:20098
+msgid "Fetching info for album"
+msgstr "Info over album ophalen"
+
+#: id:20099
+msgid "Can't rip CD or track while playing from CD"
+msgstr "CD-rippen is tijdens het afspelen niet mogelijk"
+
+#: id:20100
+msgid "Master lock code and settings"
+msgstr "Vergrendelingsinstellingen"
+
+#: id:20101
+msgid "Entering master lock code always enables master mode"
+msgstr "Invoeren vergrendelcode activeert altijd de ontgrendelde modus"
+
+#: id:20102
+msgid "or copy from default?"
+msgstr "of maak een kopie van de huidige instellingen?"
+
+#: id:20103
+msgid "Save changes to profile?"
+msgstr "Wijzigingen aan profiel opslaan?"
+
+#: id:20104
+msgid "Old settings found."
+msgstr "Oude instellingen gevonden."
+
+#: id:20105
+msgid "Do you want to use them?"
+msgstr "Wilt u deze gebruiken?"
+
+#: id:20106
+msgid "Old media sources found."
+msgstr "Oude mediabronnen gevonden."
+
+#: id:20107
+msgid "Separate (locked)"
+msgstr "Afzonderlijk (vergrendeld)"
+
+#: id:20108
+msgid "Root"
+msgstr "Hoofdmap"
+
+#: id:20109
+msgid "- Zoom"
+msgstr "- Verschalen"
+
+#: id:20110
+msgid "UPnP settings"
+msgstr "UPnP-client"
+
+#: id:20111
+msgid "Autostart UPnP client"
+msgstr "Automatisch starten"
+
+#: id:20112
+msgid "Last login: %s"
+msgstr "Vorige aanmelding: %s"
+
+#: id:20113
+msgid "Never logged on"
+msgstr "Nog nooit ingelogd"
+
+#: id:20114
+msgid "Profile %i / %i"
+msgstr "Profiel %i / %i"
+
+#: id:20115
+msgid "User login / Select a profile"
+msgstr "Gebruikersaanmelding / Selecteer een profiel"
+
+#: id:20116
+msgid "Use lock on login screen"
+msgstr "Inlogscherm vergrendelen"
+
+#: id:20117
+msgid "Invalid lock code."
+msgstr "Ongeldige vergrendelcode."
+
+#: id:20118
+msgid "This requires the master lock to be set."
+msgstr "Dit vereist een actieve hoofdvergrendeling."
+
+#: id:20119
+msgid "Would you like to set it now?"
+msgstr "Wilt u deze nu instellen?"
+
+#: id:20120
+msgid "Loading program information"
+msgstr "Programmainformatie wordt geladen"
+
+#: id:20121
+msgid "Party on!"
+msgstr "Feesten maar!"
+
+#: id:20122
+msgid "True"
+msgstr "Waar"
+
+#: id:20123
+msgid "Mixing drinks"
+msgstr "Drankjes mixen"
+
+#: id:20124
+msgid "Filling glasses"
+msgstr "Glazen vullen"
+
+#: id:20125
+msgid "Logged on as"
+msgstr "Ingelogd als"
+
+#: id:20126
+msgid "Log off"
+msgstr "Uitloggen"
+
+#: id:20128
+msgid "Go to root"
+msgstr "Naar beginscherm gaan"
+
+#: id:20129
+msgid "Weave"
+msgstr "Weven"
+
+#: id:20130
+msgid "Weave (inverted)"
+msgstr "Weven (omgekeerd)"
+
+#: id:20131
+msgid "Blend"
+msgstr "Overgaan"
+
+#: id:20132
+msgid "Restart video"
+msgstr "Herstart video"
+
+#: id:20133
+msgid "Edit network location"
+msgstr "Netwerklocatie wijzigen"
+
+#: id:20134
+msgid "Remove network location"
+msgstr "Netwerklocatie verwijderen"
+
+#: id:20135
+msgid "Do you want to scan the folder?"
+msgstr "Wilt u de map doorzoeken?"
+
+#: id:20136
+msgid "Memory unit"
+msgstr "Geheugenmodule"
+
+#: id:20137
+msgid "Memory unit mounted"
+msgstr "Geheugenmodule geplaatst"
+
+#: id:20138
+msgid "Unable to mount memory unit"
+msgstr "Kan geheugenmodule niet koppelen"
+
+#: id:20139
+msgid "In port %i, slot %i"
+msgstr "In poort %i, slot %i"
+
+#: id:20140
+msgid "Lock screensaver"
+msgstr "Schermbeveiliging vergrendelen"
+
+#: id:20141
+msgid "Set"
+msgstr "Zet"
+
+#: id:20142
+msgctxt "Auto context with id 20142"
+msgid "Username"
+msgstr "Gebruikersnaam"
+
+#: id:20143
+msgid "Enter password for"
+msgstr "Voer wachtwoord in voor"
+
+#: id:20144
+msgid "Shutdown timer"
+msgstr "Uitschakelingstimer"
+
+#: id:20145
+msgid "Shutdown interval (in minutes)"
+msgstr "Uitschakelingsinterval (in minuten)"
+
+#: id:20146
+msgid "Started, shutdown in %im"
+msgstr "Gestart, afsluiten in %im"
+
+#: id:20147
+msgid "Shutdown in 30 minutes"
+msgstr "Uitschakeling over 30 minuten"
+
+#: id:20148
+msgid "Shutdown in 60 minutes"
+msgstr "Uitschakeling over 60 minuten"
+
+#: id:20149
+msgid "Shutdown in 120 minutes"
+msgstr "Uitschakeling over 120 minuten"
+
+#: id:20150
+msgid "Custom shutdown timer"
+msgstr "Aangepaste uitschakeltimer"
+
+#: id:20151
+msgid "Cancel shutdown timer"
+msgstr "Uitschakeltimer annuleren"
+
+#: id:20152
+msgid "Lock preferences for %s"
+msgstr "Vergrendelopties voor %s"
+
+#: id:20153
+msgid "Browse..."
+msgstr "Bladeren..."
+
+#: id:20154
+msgid "Summary information"
+msgstr "Standaardinformatie"
+
+#: id:20155
+msgid "Storage information"
+msgstr "Opslaginformatie"
+
+#: id:20156
+msgid "Hard disk information"
+msgstr "Hardeschijfinformatie"
+
+#: id:20157
+msgid "DVD-ROM information"
+msgstr "DVD-ROM-informatie"
+
+#: id:20158
+msgid "Network information"
+msgstr "Netwerkinformatie"
+
+#: id:20159
+msgid "Video information"
+msgstr "Videoinformatie"
+
+#: id:20160
+msgid "Hardware information"
+msgstr "Hardware-informatie"
+
+#: id:20161
+msgid "Total"
+msgstr "Totaal"
+
+#: id:20162
+msgid "Used"
+msgstr "Gebruikt"
+
+#: id:20163
+msgid "of"
+msgstr "van"
+
+#: id:20164
+msgid "Locking not supported"
+msgstr "Vergrendelen niet mogelijk"
+
+#: id:20165
+msgid "Not locked"
+msgstr "Niet vergrendeld"
+
+#: id:20166
+msgid "Locked"
+msgstr "Vergrendeld"
+
+#: id:20167
+msgid "Frozen"
+msgstr "Bevroren"
+
+#: id:20168
+msgid "Requires reset"
+msgstr "Herstart vereist"
+
+#: id:20169
+msgid "Week"
+msgstr "Week"
+
+#: id:20170
+msgid "Line"
+msgstr "Regel"
+
+#: id:20171
+msgid "Windows network (SMB)"
+msgstr "Windowsnetwerk (SMB)"
+
+#: id:20172
+msgid "XBMSP server"
+msgstr "XBMSP-server"
+
+#: id:20173
+msgctxt "Auto context with id 20173"
+msgid "FTP server"
+msgstr "FTP-server"
+
+#: id:20174
+msgid "iTunes music share (DAAP)"
+msgstr "iTunes muziekshare (DAAP)"
+
+#: id:20175
+msgid "UPnP server"
+msgstr "UPnP-server"
+
+#: id:20176
+msgid "Show video info"
+msgstr "Videoinformatie weergeven"
+
+#: id:20177
+msgid "Done"
+msgstr "OK"
+
+#: id:20178
+msgid "Shift"
+msgstr "Shift"
+
+#: id:20179
+msgid "Caps Lock"
+msgstr "Hoofdletters"
+
+#: id:20180
+msgid "Symbols"
+msgstr "Symbolen"
+
+#: id:20181
+msgid "Backspace"
+msgstr "Backspace"
+
+#: id:20182
+msgid "Space"
+msgstr "Spatie"
+
+#: id:20183
+msgid "Reload skin"
+msgstr "Skin herladen"
+
+#: id:20184
+msgid "Rotate pictures using EXIF information"
+msgstr "Foto's draaien op basis van EXIF-informatie"
+
+#: id:20185
+msgid "Use poster view styles for TV shows"
+msgstr "Posterstijl voor tv-series gebruiken"
+
+#: id:20186
+msgid "Please wait"
+msgstr "Even geduld..."
+
+#: id:20187
+msgid "UPnP"
+msgstr ""
+
+#: id:20189
+msgid "Enable auto scrolling for plot & review"
+msgstr "Plot en bespreking automatisch scrollen"
+
+#: id:20190
+msgctxt "Auto context with id 20190"
+msgid "Custom"
+msgstr "Handmatig"
+
+#: id:20191
+msgid "Enable debug logging"
+msgstr "Foutregistratie inschakelen"
+
+#: id:20192
+msgid "Download additional information during updates"
+msgstr "Extra albuminformatie downloaden tijdens het scannen"
+
+#: id:20193
+msgid "Default service for album information"
+msgstr "Standaardscraper voor albuminformatie"
+
+#: id:20194
+msgid "Default service for artist information"
+msgstr "Standaardscraper voor artiestinformatie"
+
+#: id:20195
+msgid "Change scraper"
+msgstr "Scraper wijzigen"
+
+#: id:20196
+msgid "Export music library"
+msgstr "Muziekbibliotheek exporteren..."
+
+#: id:20197
+msgid "Import music library"
+msgstr "Muziekbibliotheek importeren..."
+
+#: id:20198
+msgid "No artist found!"
+msgstr "Geen artiest gevonden!"
+
+#: id:20199
+msgid "Downloading artist info failed"
+msgstr "Downloaden van artiestinformatie mislukt"
+
+#: id:20250
+msgid "Party on! (videos)"
+msgstr "Feesten maar! (video's)"
+
+#: id:20251
+msgid "Mixing drinks (videos)"
+msgstr "Drankjes mixen (video's)"
+
+#: id:20252
+msgid "Filling glasses (videos)"
+msgstr "Glazen vullen (video's)"
+
+#: id:20253
+msgid "WebDAV server (HTTP)"
+msgstr "WebDAV-server (HTTP)"
+
+#: id:20254
+msgid "WebDAV server (HTTPS)"
+msgstr "WebDAV-server (HTTPS)"
+
+#: id:20255
+msgid "First logon, edit your profile"
+msgstr "Eerste aanmelding, profiel bijwerken"
+
+#: id:20256
+msgid "HTS Tvheadend client"
+msgstr "HTS tvheadend client"
+
+#: id:20257
+msgid "VDR Streamdev client"
+msgstr "VDR streamdev client"
+
+#: id:20258
+msgid "MythTV client"
+msgstr "MythTV client"
+
+#: id:20259
+msgid "Network Filesystem (NFS)"
+msgstr "Network Filesystem (NFS)"
+
+#: id:20260
+msgid "Secure Shell (SSH/SFTP)"
+msgstr "Secure Shell (SSH/SFTP)"
+
+#: id:20261
+msgid "Apple Filing Protocol (AFP)"
+msgstr "Apple Filing Protocol (AFP)"
+
+#: id:20300
+msgid "Web server directory (HTTP)"
+msgstr "Webservermap (HTTP)"
+
+#: id:20301
+msgid "Web server directory (HTTPS)"
+msgstr "Webservermap (HTTPS)"
+
+#: id:20302
+msgid "Unable to write to folder:"
+msgstr "Kan niet schrijven naar map:"
+
+#: id:20303
+msgid "Do you want to skip and proceed?"
+msgstr "Overslaan en verdergaan?"
+
+#: id:20304
+msgid "RSS Feed"
+msgstr "RSS-feed"
+
+#: id:20307
+msgid "Secondary DNS"
+msgstr "Secundaire DNS"
+
+#: id:20308
+msgid "DHCP server:"
+msgstr "DHCP-server:"
+
+#: id:20309
+msgid "Make new folder"
+msgstr "Nieuwe map"
+
+#: id:20310
+msgid "Dim LCD on playback"
+msgstr "LCD dimmen tijdens afspelen"
+
+#: id:20311
+msgid "Unknown or onboard (protected)"
+msgstr "Onbekend of onboard (beveiligd)"
+
+#: id:20312
+msgid "Dim LCD on paused"
+msgstr "LCD dimmen tijdens pauze"
+
+#: id:20314
+msgid "Videos - Library"
+msgstr "Video - Bibliotheek"
+
+#: id:20316
+msgid "Sort by: ID"
+msgstr "Sorteer: ID"
+
+#: id:20324
+msgid "Play part..."
+msgstr "Afspelen deel..."
+
+#: id:20325
+msgid "Calibration reset"
+msgstr "Kalibratie opnieuw instellen"
+
+#: id:20326
+msgid "This will reset the calibration values for %s"
+msgstr "Dit zet de kalibratiewaarden voor %s"
+
+#: id:20327
+msgid "to it's default values."
+msgstr "terug naar de standaardwaarden."
+
+#: id:20328
+msgid "Browse for destination"
+msgstr "een locatie om naar te kopiëren"
+
+#: id:20329
+msgid "Movies are in separate folders that match the movie title"
+msgstr "Films staan in aparte folders die overeenkomen met de film titel"
+
+#: id:20330
+msgid "Use folder names for lookups"
+msgstr "Gebruik mapnamen bij zoeken"
+
+#: id:20331
+msgctxt "Auto context with id 20331"
+msgid "File"
+msgstr "Bestand"
+
+#: id:20332
+msgid "Use file or folder names in lookups?"
+msgstr "Ook in bestands- of mapnamen zoeken?"
+
+#: id:20333
+msgid "Set content"
+msgstr "Inhoud toewijzen"
+
+#: id:20334
+msgid "Folder"
+msgstr "Map"
+
+#: id:20335
+msgid "Look for content recursively?"
+msgstr "Ook in onderliggende mappen zoeken?"
+
+#: id:20336
+msgid "Unlock sources"
+msgstr "Bronnen vrijgeven"
+
+#: id:20337
+msgid "Actor"
+msgstr "Acteur"
+
+#: id:20338
+msgid "Movie"
+msgstr "Film"
+
+#: id:20339
+msgid "Director"
+msgstr "Regisseur"
+
+#: id:20340
+msgid "Do you want to remove all items within"
+msgstr "Wilt u alle items in deze map"
+
+#: id:20341
+msgid "this path from the XBMC library?"
+msgstr "verwijderen uit de bibliotheek?"
+
+#: id:20342
+msgctxt "Auto context with id 20342"
+msgid "Movies"
+msgstr "Speelfilms"
+
+#: id:20343
+msgid "TV shows"
+msgstr "TV-Series"
+
+#: id:20344
+msgid "This directory contains"
+msgstr "Deze map bevat"
+
+#: id:20345
+msgid "Run automated scan"
+msgstr "Automatisch scannen"
+
+#: id:20346
+msgid "Scan recursively"
+msgstr "Ook onderliggende mappen scannen"
+
+#: id:20347
+msgid "as"
+msgstr "als"
+
+#: id:20348
+msgid "Directors"
+msgstr "Regisseurs"
+
+#: id:20349
+msgid "No video files found in this path!"
+msgstr "Geen videobestanden gevonden in deze map!"
+
+#: id:20350
+msgid "votes"
+msgstr "stemmen"
+
+#: id:20351
+msgid "TV show information"
+msgstr "Serie-info"
+
+#: id:20352
+msgid "Episode information"
+msgstr "Afleveringsinfo"
+
+#: id:20353
+msgid "Loading TV show details"
+msgstr "Details serie laden"
+
+#: id:20354
+msgid "Fetching episode guide"
+msgstr "Afleveringengids ophalen"
+
+#: id:20355
+msgid "Loading info for episodes in directory"
+msgstr "Afleveringsinfo naar map laden"
+
+#: id:20356
+msgid "Select TV show:"
+msgstr "Selecteer serie:"
+
+#: id:20357
+msgid "Enter the TV show name"
+msgstr "Geef de naam van de serie"
+
+#: id:20358
+msgid "Season %i"
+msgstr "Seizoen %i"
+
+#: id:20359
+msgid "Episode"
+msgstr "Afl."
+
+#: id:20360
+msgid "Episodes"
+msgstr "Afl."
+
+#: id:20361
+msgid "Loading episode details"
+msgstr "Afleveringsdetails laden"
+
+#: id:20362
+msgid "Remove episode from library"
+msgstr "Aflevering uit bibliotheek verwijderen"
+
+#: id:20363
+msgid "Remove TV show from library"
+msgstr "Serie uit bibliotheek verwijderen"
+
+#: id:20364
+msgid "TV show"
+msgstr "Serie"
+
+#: id:20365
+msgid "Episode plot"
+msgstr "Afleveringsplot"
+
+#: id:20366
+msgid "* All seasons"
+msgstr "* Alle seizoenen"
+
+#: id:20367
+msgid "Hide watched"
+msgstr "Bekeken verbergen"
+
+#: id:20368
+msgid "Prod code"
+msgstr "Prod."
+
+#: id:20369
+msgid "Show plot for unwatched items"
+msgstr "Plot van niet-bekeken video's weergeven"
+
+#: id:20370
+msgid "* Hidden to prevent spoilers *"
+msgstr "* Verborgen om plot niet te verklappen *"
+
+#: id:20371
+msgid "Set season thumb"
+msgstr "Afbeelding seizoen selecteren"
+
+#: id:20372
+msgid "Season image"
+msgstr "Afbeelding van seizoen"
+
+#: id:20373
+msgid "Season"
+msgstr "Seizoen"
+
+#: id:20374
+msgid "Downloading movie information"
+msgstr "Speelfilm informatie downloaden"
+
+#: id:20375
+msgid "Unassign content"
+msgstr "Inhoud ontkoppelen"
+
+#: id:20376
+msgid "Original title"
+msgstr "Originele titel"
+
+#: id:20377
+msgid "Refresh TV show information"
+msgstr "Serie-informatie vernieuwen"
+
+#: id:20378
+msgid "Refresh info for all episodes?"
+msgstr "Alle afleveringen vernieuwen?"
+
+#: id:20379
+msgid "Selected folder contains a single TV show"
+msgstr "Geselecteerde map bevat één enkele serie"
+
+#: id:20380
+msgid "Exclude selected folder from scans"
+msgstr "Map uitsluiten van scans"
+
+#: id:20381
+msgid "Specials"
+msgstr "Specials"
+
+#: id:20382
+msgid "Automatically grab season thumbs"
+msgstr "Automatisch miniaturen van seizoen downloaden"
+
+#: id:20383
+msgid "Selected folder contains a single video"
+msgstr "Geselecteerde map bevat 1 video"
+
+#: id:20384
+msgid "Link to TV show"
+msgstr "Aan serie koppelen"
+
+#: id:20385
+msgid "Remove link to TV show"
+msgstr "Van serie loskoppelen"
+
+#: id:20386
+msgid "Recently added movies"
+msgstr "Onlangs toegevoegde speelfilms"
+
+#: id:20387
+msgid "Recently added episodes"
+msgstr "Onlangs toegevoegde afleveringen tv-series"
+
+#: id:20388
+msgid "Studios"
+msgstr "Filmstudio's"
+
+#: id:20389
+msgid "Music videos"
+msgstr "Muziekvideo's"
+
+#: id:20390
+msgid "Recently added music videos"
+msgstr "Onlangs toegevoegde muziekvideo's"
+
+#: id:20391
+msgid "Music video"
+msgstr "Muziekvideo"
+
+#: id:20392
+msgid "Remove music video from library"
+msgstr "Verwijder muziekvideo uit bibliotheek"
+
+#: id:20393
+msgctxt "Auto context with id 20393"
+msgid "Music video information"
+msgstr "Muziekvideo-informatie"
+
+#: id:20394
+msgid "Loading music video information"
+msgstr "Muziekvideo-informatie laden"
+
+#: id:20395
+msgid "Mixed"
+msgstr "Gemixt"
+
+#: id:20396
+msgid "Go to albums by artist"
+msgstr "Albums van deze artiest"
+
+#: id:20397
+msgid "Go to album"
+msgstr "Naar album"
+
+#: id:20398
+msgid "Play song"
+msgstr "Nummer afspelen"
+
+#: id:20399
+msgid "Go to music videos from album"
+msgstr "Muziekvideo's van dit album"
+
+#: id:20400
+msgid "Go to music videos by artist"
+msgstr "Muziekvideo's van deze artiest"
+
+#: id:20401
+msgid "Play music video"
+msgstr "Muziekvideo afspelen"
+
+#: id:20402
+msgid "Download actor thumbnails when adding to library"
+msgstr "Afbeeldingen van acteurs automatisch downloaden"
+
+#: id:20403
+msgid "Set actor thumb"
+msgstr "Acteursafbeelding instellen"
+
+#: id:20405
+msgid "Remove episode bookmark"
+msgstr "Afl. uit favorieten verwijderen"
+
+#: id:20406
+msgid "Set episode bookmark"
+msgstr "Afl. aan favorieten toevoegen"
+
+#: id:20407
+msgid "Scraper settings"
+msgstr "Scraperinstellingen"
+
+#: id:20408
+msgid "Downloading music video information"
+msgstr "Muziekvideo-informatie downloaden"
+
+#: id:20409
+msgid "Downloading TV show information"
+msgstr "TV-Serie informatie downloaden"
+
+#: id:20410
+msgid "Trailer"
+msgstr "Trailer"
+
+#: id:20411
+msgid "Flatten"
+msgstr "Eenvoudige weergave"
+
+#: id:20412
+msgid "Flatten TV shows"
+msgstr "Seizoenen verbergen indien één seizoen"
+
+#: id:20413
+msgid "Get fanart"
+msgstr "Zoek Fanart"
+
+#: id:20414
+msgid "Show Fanart in video and music libraries"
+msgstr "Fanart in video- en muziekbibliotheek tonen"
+
+#: id:20415
+msgid "Scanning for new content"
+msgstr "Bezig met scannen naar nieuwe inhoud"
+
+#: id:20416
+msgid "First aired"
+msgstr "Eerst uitgez."
+
+#: id:20417
+msgid "Writer"
+msgstr "Schrijver"
+
+#: id:20419
+msgid "Replace file names with library titles"
+msgstr "Vervang bestandsnamen met bibliotheek titels"
+
+#: id:20420
+msgctxt "Auto context with id 20420"
+msgid "Never"
+msgstr "Nooit"
+
+#: id:20421
+msgid "If only one season"
+msgstr "Alleen indien één seizoen"
+
+#: id:20422
+msgid "Always"
+msgstr "Altijd"
+
+#: id:20423
+msgid "Has trailer"
+msgstr "Trailer"
+
+#: id:20424
+msgid "False"
+msgstr "Onwaar"
+
+#: id:20425
+msgid "Fanart slideshow"
+msgstr "Fanart diavoorstelling"
+
+#: id:20426
+msgid "Export to a single file or separate"
+msgstr "Exporteer naar 1 bestand of meerdere"
+
+#: id:20427
+msgid "files per entry?"
+msgstr "bestanden per entry?"
+
+#: id:20428
+msgid "Single file"
+msgstr "Enkel bestand"
+
+#: id:20429
+msgctxt "Auto context with id 20429"
+msgid "Separate"
+msgstr "Apart"
+
+#: id:20430
+msgid "Export thumbnails and fanart?"
+msgstr "Miniaturen en fanart exporteren?"
+
+#: id:20431
+msgid "Overwrite old files?"
+msgstr "Oude bestanden overschrijven?"
+
+#: id:20432
+msgid "Exclude path from library updates"
+msgstr "Pad uitsluiten van bibliotheekupdates"
+
+#: id:20433
+msgid "Extract thumbnails and video information"
+msgstr "Miniaturen en codec informatie uitlezen"
+
+#: id:20434
+msgid "Sets"
+msgstr "Sets"
+
+#: id:20435
+msgid "Set movieset thumb"
+msgstr "Filmset-miniatuur kiezen"
+
+#: id:20436
+msgid "Export actor thumbs?"
+msgstr "Acteurminiaturen exporteren"
+
+#: id:20437
+msgid "Choose fanart"
+msgstr "Fanart kiezen"
+
+#: id:20438
+msgid "Local fanart"
+msgstr "Lokale fanart"
+
+#: id:20439
+msgid "No fanart"
+msgstr "Geen fanart"
+
+#: id:20440
+msgid "Current fanart"
+msgstr "Huidige fanart"
+
+#: id:20441
+msgid "Remote fanart"
+msgstr "Fanart op afstand"
+
+#: id:20442
+msgid "Change content"
+msgstr "Inhoud wijzigen"
+
+#: id:20443
+msgid "Do you want to refresh info for all"
+msgstr "Wilt u info verversen voor alle"
+
+#: id:20444
+msgid "items within this path?"
+msgstr "items binnen dit pad?"
+
+#: id:20445
+msgid "Fanart"
+msgstr "Fanart"
+
+#: id:20446
+msgid "Locally stored information found."
+msgstr "Lokaal opgeslagen informatie gevonden."
+
+#: id:20447
+msgid "Ignore and refresh from internet?"
+msgstr "Negeren en verversen van internet?"
+
+#: id:20448
+msgid "Could not download information"
+msgstr "De informatie kan niet worden gedownload"
+
+#: id:20449
+msgid "Unable to connect to remote server"
+msgstr "Geen verbinding mogelijk met remote server."
+
+#: id:20450
+msgid "Would you like to continue scanning?"
+msgstr "Wilt u doorgaan met scannen?"
+
+#: id:20451
+msgid "Countries"
+msgstr "Landen"
+
+#: id:20452
+msgid "episode"
+msgstr "Aflevering"
+
+#: id:20453
+msgid "episodes"
+msgstr "Afleveringen"
+
+#: id:20454
+msgid "Listener"
+msgstr "Luisteraar"
+
+#: id:20455
+msgid "Listeners"
+msgstr "Luisteraars"
+
+#: id:20456
+msgid "Set movieset fanart"
+msgstr "Kies filmset fanart"
+
+#: id:20457
+msgid "Movie set"
+msgstr "Filmsets"
+
+#: id:20458
+msgid "Group movies in sets"
+msgstr "Groepeer films in sets"
+
+#: id:21330
+msgid "Show hidden files and directories"
+msgstr "Verborgen bestanden en mappen weergeven"
+
+#: id:21331
+msgid "TuxBox client"
+msgstr "TuxBox-client"
+
+#: id:21332
+msgid "WARNING: Target TuxBox device is in recording-mode!"
+msgstr "WAARSCHUWING: TuxBox is aan het opnemen."
+
+#: id:21333
+msgid "The stream will be stopped!"
+msgstr "De stream wordt gestopt!"
+
+#: id:21334
+msgid "Zap to channel: %s failed!"
+msgstr "Zappen naar kanaal %s mislukt!"
+
+#: id:21335
+msgid "Are you sure to start the stream?"
+msgstr "Weet u zeker dat u de stream wil starten?"
+
+#: id:21336
+msgid "Connecting to: %s"
+msgstr "Verbinden met: %s"
+
+#: id:21337
+msgid "TuxBox device"
+msgstr "TuxBox-apparaat"
+
+#: id:21359
+msgid "Add media share..."
+msgstr "Gedeelde media toevoegen..."
+
+#: id:21360
+msgid "Share video and music libraries through UPnP"
+msgstr "UPnP-server inschakelen"
+
+#: id:21364
+msgid "Edit media share"
+msgstr "Gedeelde media wijzigen"
+
+#: id:21365
+msgid "Remove media share"
+msgstr "Gedeelde media verwijderen"
+
+#: id:21366
+msgid "Subtitle folder"
+msgstr "Map voor ondertitels..."
+
+#: id:21367
+msgid "Movie & alternate subtitle directory"
+msgstr "Video - alternatieve ondertitelmap"
+
+#: id:21368
+msgid "Override ASS/SSA subtitles fonts"
+msgstr "ASS/SSA lettertype voor ondertitels negeren"
+
+#: id:21369
+msgid "Enable mouse and Touch Screen support"
+msgstr "Muis inschakelen"
+
+#: id:21370
+msgid "Play navigation sounds during media playback"
+msgstr "Navigatiegeluiden afspelen tijdens afspelen van media"
+
+#: id:21371
+msgid "Thumbnail"
+msgstr "Miniatuur"
+
+#: id:21372
+msgid "Forced DVD player region"
+msgstr "DVD-regiocode forceren"
+
+#: id:21373
+msgid "Video output"
+msgstr "Videohardware"
+
+#: id:21374
+msgid "Video aspect"
+msgstr "Beeldverhouding"
+
+#: id:21375
+msgctxt "Auto context with id 21375"
+msgid "Normal"
+msgstr "Normaal"
+
+#: id:21376
+msgid "Letterbox"
+msgstr "Letterbox"
+
+#: id:21377
+msgid "Widescreen"
+msgstr "Breedbeeld"
+
+#: id:21378
+msgid "Enable 480p"
+msgstr "480p weergeven"
+
+#: id:21379
+msgid "Enable 720p"
+msgstr "720p weergeven"
+
+#: id:21380
+msgid "Enable 1080i"
+msgstr "1080i weergeven"
+
+#: id:21381
+msgid "Enter name of new playlist"
+msgstr "Geef naam voor de intelligente afspeellijst"
+
+#: id:21382
+msgid "Show \"Add source\" buttons in file lists"
+msgstr "Knop 'Locatie toevoegen' weergeven in bestandslijst"
+
+#: id:21383
+msgid "Enable scrollbars"
+msgstr "Schuifbalken weergeven"
+
+#: id:21384
+msgid "Make watched filtering a toggle in video library"
+msgstr "'Bekeken verbergen'-knop toevoegen in bibliotheek"
+
+#: id:21385
+msgctxt "Auto context with id 21385"
+msgid "Open"
+msgstr "Openen"
+
+#: id:21386
+msgid "Acoustic management level"
+msgstr "Akoestiekbeheerniveau"
+
+#: id:21387
+msgid "Fast"
+msgstr "Snel"
+
+#: id:21388
+msgid "Quiet"
+msgstr "Stil"
+
+#: id:21389
+msgid "Enable custom background"
+msgstr "Gebruik achtergrond naar keuze"
+
+#: id:21390
+msgid "Power management level"
+msgstr "Stroombeheerniveau"
+
+#: id:21391
+msgid "High power"
+msgstr "Hoog Energie"
+
+#: id:21392
+msgid "Low power"
+msgstr "Laag Energie"
+
+#: id:21393
+msgid "High standby"
+msgstr "Hoog Standby"
+
+#: id:21394
+msgid "Low standby"
+msgstr "Laag Standby"
+
+#: id:21395
+msgid "Unable to cache files bigger than 4GB"
+msgstr "Niet mogelijk bestanden groter dan 4 GiB te laden"
+
+#: id:21396
+msgid "Chapter"
+msgstr "Hoofdstuk"
+
+#: id:21397
+msgid "High quality pixel shader v2"
+msgstr "Hoge kwaliteit Pixel Shader v2"
+
+#: id:21398
+msgid "Enable playlist at startup"
+msgstr "Afspeellijst afspelen bij opstarten"
+
+#: id:21399
+msgid "Use tween animations"
+msgstr "Animatie gebruiken bij schermovergang"
+
+#: id:21400
+msgid "contains"
+msgstr "bevat"
+
+#: id:21401
+msgid "does not contain"
+msgstr "bevat niet"
+
+#: id:21402
+msgid "is"
+msgstr "is"
+
+#: id:21403
+msgid "is not"
+msgstr "is niet"
+
+#: id:21404
+msgid "starts with"
+msgstr "begint met"
+
+#: id:21405
+msgid "ends with"
+msgstr "eindigt met"
+
+#: id:21406
+msgid "greater than"
+msgstr "groter dan"
+
+#: id:21407
+msgid "less than"
+msgstr "kleiner dan"
+
+#: id:21408
+msgid "after"
+msgstr "na"
+
+#: id:21409
+msgid "before"
+msgstr "voor"
+
+#: id:21410
+msgid "in the last"
+msgstr "in laatste"
+
+#: id:21411
+msgid "not in the last"
+msgstr "niet in laatste"
+
+#: id:21412
+msgid "Scrapers"
+msgstr "Scrapers"
+
+#: id:21413
+msgid "Default movie scraper"
+msgstr "Standaard speelfilm scraper"
+
+#: id:21414
+msgid "Default tvshow scraper"
+msgstr "Standaard tv-serie scraper"
+
+#: id:21415
+msgid "Default music video scraper"
+msgstr "Standaard muziekvideo scraper"
+
+#: id:21416
+msgid "Enable fallback based on scraper language"
+msgstr "Alternatieven toestaan op basis van originele scraper taal"
+
+#: id:21417
+msgid "- Settings"
+msgstr "- Instellingen"
+
+#: id:21418
+msgid "Multilingual"
+msgstr "Meertalig"
+
+#: id:21419
+msgid "No scrapers present"
+msgstr "Geen scrapers beschikbaar"
+
+#: id:21420
+msgid "Value to match"
+msgstr "Waarde gelijk aan"
+
+#: id:21421
+msgid "Smart playlist rule"
+msgstr "Intelligente-afspeellijstregel"
+
+#: id:21422
+msgid "Match items where"
+msgstr "Nummers zijn gelijk wanneer"
+
+#: id:21423
+msgid "New rule..."
+msgstr "Nieuwe regel..."
+
+#: id:21424
+msgid "Items must match"
+msgstr "Muziek moet gelijk aan"
+
+#: id:21425
+msgid "all of the rules"
+msgstr "elk van deze regels"
+
+#: id:21426
+msgid "one or more of the rules"
+msgstr "een of meer van deze regels"
+
+#: id:21427
+msgid "Limit to"
+msgstr "Beperken tot"
+
+#: id:21428
+msgid "No limit"
+msgstr "Geen beperking"
+
+#: id:21429
+msgid "Order by"
+msgstr "Sorteren op"
+
+#: id:21430
+msgid "ascending"
+msgstr "oplopend"
+
+#: id:21431
+msgid "descending"
+msgstr "aflopend"
+
+#: id:21432
+msgid "Edit smart playlist"
+msgstr "Intelligente afspeellijst wijzigen"
+
+#: id:21433
+msgid "Name of the playlist"
+msgstr "Naam van de afspeellijst"
+
+#: id:21434
+msgid "Find items where"
+msgstr "Zoek muziek gelijk aan"
+
+#: id:21435
+msgid "Edit"
+msgstr "Wijzigen"
+
+#: id:21436
+msgid "%i items"
+msgstr "%i nummers"
+
+#: id:21437
+msgid "New smart playlist..."
+msgstr "Nieuwe intelligente afspeellijst..."
+
+#: id:21438
+msgid "%c Drive"
+msgstr "%c schijf"
+
+#: id:21439
+msgid "Edit party mode rules"
+msgstr "Feestmix instellen"
+
+#: id:21440
+msgid "Home folder"
+msgstr "Startmap"
+
+#: id:21441
+msgid "Watched count"
+msgstr "Aantal bekeken"
+
+#: id:21442
+msgid "Episode title"
+msgstr "Titel afl."
+
+#: id:21443
+msgid "Video resolution"
+msgstr "Videoresolutie"
+
+#: id:21444
+msgid "Audio channels"
+msgstr "Audiokanalen"
+
+#: id:21445
+msgid "Video codec"
+msgstr "Videocodec"
+
+#: id:21446
+msgid "Audio codec"
+msgstr "Audiocodec"
+
+#: id:21447
+msgid "Audio language"
+msgstr "Audiotaal"
+
+#: id:21448
+msgid "Subtitle language"
+msgstr "Ondertiteltaal"
+
+#: id:21449
+msgid "Remote control sends keyboard presses"
+msgstr "Afstandsbediening stuurt toetsenbordaanslagen"
+
+#: id:21450
+msgid "- Edit"
+msgstr "- Wijzigen"
+
+#: id:21451
+msgid "Internet connection required."
+msgstr "Internetverbinding vereist."
+
+#: id:21452
+msgid "Get More..."
+msgstr "Add-ons installeren"
+
+#: id:21453
+msgid "Root filesystem"
+msgstr "Rootbestandsysteem"
+
+#: id:21454
+msgid "Cache full"
+msgstr "Cache is vol"
+
+#: id:21455
+msgid "Cache filled before reaching required amount for continous playback"
+msgstr "Cache is vol voordat benodigde hoeveelheid is bereikt voor continu afspelen"
+
+#: id:21460
+msgid "Subtitle location"
+msgstr "Plaats van de ondertitels"
+
+#: id:21461
+msgid "Fixed"
+msgstr "Vast"
+
+#: id:21462
+msgid "Bottom of video"
+msgstr "Onderaan video"
+
+#: id:21463
+msgid "Below video"
+msgstr "Onder video"
+
+#: id:21464
+msgid "Top of video"
+msgstr "Bovenaan video"
+
+#: id:21465
+msgid "Above video"
+msgstr "Boven video"
+
+#: id:21800
+msgid "File name"
+msgstr "Bestandsnaam"
+
+#: id:21801
+msgid "File path"
+msgstr "Pad"
+
+#: id:21802
+msgid "File size"
+msgstr "Bestandsgrootte"
+
+#: id:21803
+msgid "File date/time"
+msgstr "Laatst gewijzigd"
+
+#: id:21804
+msgid "Slide index"
+msgstr "Dia-index"
+
+#: id:21805
+msgctxt "Auto context with id 21805"
+msgid "Resolution"
+msgstr "Resolutie"
+
+#: id:21806
+msgctxt "Auto context with id 21806"
+msgid "Comment"
+msgstr "Opmerking"
+
+#: id:21807
+msgid "Colour/B&W"
+msgstr "Kleur/zwart-wit"
+
+#: id:21808
+msgid "JPEG process"
+msgstr "JPEG-proces"
+
+#: id:21820
+msgid "Date/Time"
+msgstr "Datum/tijd"
+
+#: id:21821
+msgid "Description"
+msgstr "Omschrijving"
+
+#: id:21822
+msgid "Camera make"
+msgstr "Cameramerk"
+
+#: id:21823
+msgid "Camera model"
+msgstr "Cameramodel"
+
+#: id:21824
+msgid "EXIF comment"
+msgstr "EXIF-opmerking"
+
+#: id:21825
+msgid "Firmware"
+msgstr "Firmware"
+
+#: id:21826
+msgid "Aperture"
+msgstr "Diafragma"
+
+#: id:21827
+msgid "Focal length"
+msgstr "Brandpuntafstand"
+
+#: id:21828
+msgid "Focus distance"
+msgstr "Voorwerpafstand"
+
+#: id:21829
+msgid "Exposure"
+msgstr "Belichting"
+
+#: id:21830
+msgid "Exposure time"
+msgstr "Sluitertijd"
+
+#: id:21831
+msgid "Exposure bias"
+msgstr "Belichtingsinval"
+
+#: id:21832
+msgid "Exposure mode"
+msgstr "Belichtingsmethode"
+
+#: id:21833
+msgid "Flash used"
+msgstr "Flitser"
+
+#: id:21834
+msgid "White-balance"
+msgstr "Witbalans"
+
+#: id:21835
+msgid "Light source"
+msgstr "Lichtbron"
+
+#: id:21836
+msgid "Metering mode"
+msgstr "Meetmodus"
+
+#: id:21837
+msgid "ISO"
+msgstr "ISO"
+
+#: id:21838
+msgid "Digital zoom"
+msgstr "Digitale zoom"
+
+#: id:21839
+msgid "CCD width"
+msgstr "CCD-breedte"
+
+#: id:21840
+msgid "GPS latitude"
+msgstr "GPS-lengtegraad"
+
+#: id:21841
+msgid "GPS longitude"
+msgstr "GPS-breedtegraad"
+
+#: id:21842
+msgid "GPS altitude"
+msgstr "GPS-hoogte"
+
+#: id:21843
+msgid "Orientation"
+msgstr "Oriëntatie"
+
+#: id:21860
+msgid "Supplemental categories"
+msgstr "Overige categorieën"
+
+#: id:21861
+msgid "Keywords"
+msgstr "Sleutelwoorden"
+
+#: id:21862
+msgid "Caption"
+msgstr "Titel"
+
+#: id:21863
+msgid "Author"
+msgstr "Auteur"
+
+#: id:21864
+msgid "Headline"
+msgstr "Kop"
+
+#: id:21865
+msgid "Special instructions"
+msgstr "Speciale instructies"
+
+#: id:21866
+msgid "Category"
+msgstr "Categorie"
+
+#: id:21867
+msgid "Byline"
+msgstr "Fotograaf"
+
+#: id:21868
+msgid "Byline title"
+msgstr "Naam fotograaf"
+
+#: id:21869
+msgid "Credit"
+msgstr "Credit"
+
+#: id:21870
+msgid "Source"
+msgstr "Bron"
+
+#: id:21871
+msgid "Copyright notice"
+msgstr "Copyright"
+
+#: id:21872
+msgid "Object name"
+msgstr "Objectnaam"
+
+#: id:21873
+msgid "City"
+msgstr "Stad"
+
+#: id:21874
+msgid "State"
+msgstr "Staat"
+
+#: id:21875
+msgctxt "Auto context with id 21875"
+msgid "Country"
+msgstr "Land"
+
+#: id:21876
+msgid "Original Tx Reference"
+msgstr "Overdrachtsreferentie"
+
+#: id:21877
+msgid "Date created"
+msgstr "Datum aangemaakt"
+
+#: id:21878
+msgid "Copyright flag"
+msgstr "Copyright"
+
+#: id:21879
+msgid "Country code"
+msgstr "Landcode"
+
+#: id:21880
+msgid "Reference service"
+msgstr "Brondiensten"
+
+#: id:21881
+msgid "Allow control of XBMC via UPnP"
+msgstr "UPnP-rendering inschakelen"
+
+#: id:21882
+msgid "Attempt to skip introduction before DVD menu"
+msgstr "Direct naar het DVD-menu proberen te gaan"
+
+#: id:21883
+msgid "Saved music"
+msgstr "Geripte muziekalbums"
+
+#: id:21884
+msgid "Query info for all artists"
+msgstr "Info over alle artiesten zoeken"
+
+#: id:21885
+msgid "Downloading album information"
+msgstr "Albuminformatie downloaden"
+
+#: id:21886
+msgid "Downloading artist information"
+msgstr "Artiestinformatie downloaden"
+
+#: id:21887
+msgid "Biography"
+msgstr "Biografie"
+
+#: id:21888
+msgid "Discography"
+msgstr "Discografie"
+
+#: id:21889
+msgid "Searching artist"
+msgstr "Zoekt artiest"
+
+#: id:21890
+msgid "Select artist"
+msgstr "Artiest selecteren"
+
+#: id:21891
+msgctxt "Auto context with id 21891"
+msgid "Artist information"
+msgstr "Artiestinformatie"
+
+#: id:21892
+msgid "Instruments"
+msgstr "Instrumenten:"
+
+#: id:21893
+msgid "Born"
+msgstr "Geboren"
+
+#: id:21894
+msgid "Formed"
+msgstr "Gevormed"
+
+#: id:21895
+msgid "Themes"
+msgstr "Thema's"
+
+#: id:21896
+msgid "Disbanded"
+msgstr "Uit elkaar"
+
+#: id:21897
+msgid "Died"
+msgstr "Gestorven op:"
+
+#: id:21898
+msgid "Years active"
+msgstr "Periode:"
+
+#: id:21899
+msgid "Label"
+msgstr "Platenlabel"
+
+#: id:21900
+msgid "Born/Formed"
+msgstr "Geboren/Opgericht"
+
+#: id:22000
+msgid "Update library on startup"
+msgstr "Bibliotheek bijwerken bij het opstarten"
+
+#: id:22001
+msgid "Hide progress of library updates"
+msgstr "Voortgang verbergen bij bibliotheek bijwerken"
+
+#: id:22002
+msgid "- DNS suffix"
+msgstr "- DNS-suffix"
+
+#: id:22003
+msgid "%2.3fs"
+msgstr "%2.3fs"
+
+#: id:22004
+msgid "Delayed by: %2.3fs"
+msgstr "Later %2.3fs"
+
+#: id:22005
+msgid "Ahead by: %2.3fs"
+msgstr "Eerder %2.3fs"
+
+#: id:22006
+msgid "Subtitle offset"
+msgstr "Ondertitels synchroniseren"
+
+#: id:22007
+msgid "OpenGL vendor:"
+msgstr "OpenGL leverancier:"
+
+#: id:22008
+msgid "OpenGL renderer:"
+msgstr "OpenGL renderer:"
+
+#: id:22009
+msgid "OpenGL version:"
+msgstr "OpenGL versie:"
+
+#: id:22010
+msgid "GPU temperature:"
+msgstr "GPU Temperatuur:"
+
+#: id:22011
+msgid "CPU temperature:"
+msgstr "CPU Temperatuur:"
+
+#: id:22012
+msgid "Total memory"
+msgstr "Aanwezig geheugen"
+
+#: id:22013
+msgid "Profile data"
+msgstr "Profieldata"
+
+#: id:22014
+msgid "Use dim if paused during video playback"
+msgstr "Beeldscherm dimmen tijdens pauzeren van video's"
+
+#: id:22015
+msgid "All recordings"
+msgstr "Alle opnames"
+
+#: id:22016
+msgid "By title"
+msgstr "Op titel"
+
+#: id:22017
+msgid "By group"
+msgstr "Op groep"
+
+#: id:22018
+msgid "Live channels"
+msgstr "Live kanalen"
+
+#: id:22019
+msgid "Recordings by title"
+msgstr "Opnames op titel"
+
+#: id:22020
+msgid "Guide"
+msgstr "Gids"
+
+#: id:22021
+msgid "Allowed error in aspect ratio to minimize black bars"
+msgstr "Toegestane afwijking in beeldverhouding (%)"
+
+#: id:22022
+msgid "Show video files in listings"
+msgstr "Toon videobestanden in lijst met afbeeldingen"
+
+#: id:22023
+msgid "DirectX vendor:"
+msgstr "DirectX-leverancier:"
+
+#: id:22024
+msgid "Direct3D version:"
+msgstr "Direct3D-versie"
+
+#: id:22030
+msgctxt "Auto context with id 22030"
+msgid "Font"
+msgstr "Lettertype"
+
+#: id:22031
+msgctxt "Auto context with id 22031"
+msgid "- Size"
+msgstr "- Grootte"
+
+#: id:22032
+msgctxt "Auto context with id 22032"
+msgid "- Colours"
+msgstr "- Kleuren"
+
+#: id:22033
+msgid "- Charset"
+msgstr "- Karakterset"
+
+#: id:22034
+msgid "Export karaoke titles as HTML"
+msgstr "Karaoketitels als HTML exporteren"
+
+#: id:22035
+msgid "Export karaoke titles as CSV"
+msgstr "Karaoketitels als CSV exporteren"
+
+#: id:22036
+msgid "Import karaoke titles..."
+msgstr "Karaoketitels importeren..."
+
+#: id:22037
+msgid "Show song selector automatically"
+msgstr "Auto popup nummerselectie"
+
+#: id:22038
+msgid "Export karaoke titles..."
+msgstr "Karaoketitels exporteren..."
+
+#: id:22039
+msgid "Enter song number"
+msgstr "Nummer invoeren"
+
+#: id:22040
+msgid "white/green"
+msgstr "wit/groen"
+
+#: id:22041
+msgid "white/red"
+msgstr "wit/rood"
+
+#: id:22042
+msgid "white/blue"
+msgstr "wit/blauw"
+
+#: id:22043
+msgid "black/white"
+msgstr "zwart/wit"
+
+#: id:22079
+msgid "Default select action"
+msgstr "Standaardactie bij selecteren"
+
+#: id:22080
+msgid "Choose"
+msgstr "Kiezen"
+
+#: id:22081
+msgid "Show Information"
+msgstr "Informatie tonen"
+
+#: id:22082
+msgid "More..."
+msgstr "Meer..."
+
+#: id:22083
+msgid "Play all"
+msgstr "Alles afspelen"
+
+#: id:23049
+msgid "Teletext not available"
+msgstr "Teletekst niet beschikbaar"
+
+#: id:23050
+msgid "Activate Teletext"
+msgstr "Teletekst activeren"
+
+#: id:23051
+msgid "Part %i"
+msgstr "Stuk %i"
+
+#: id:23052
+msgid "Buffering %i bytes"
+msgstr "%i bytes bufferen"
+
+#: id:23053
+msgid "Stopping"
+msgstr "Instellingen ontbreken"
+
+#: id:23054
+msgid "Running"
+msgstr "Instellingen verkeerd"
+
+#: id:23100
+msgid "External Player Active"
+msgstr "Externe speler actief"
+
+#: id:23101
+msgid "Click OK to terminate the player"
+msgstr "Klik op OK om de speler te beëindigen"
+
+#: id:23104
+msgid "Click OK when playback has ended"
+msgstr "Klik op OK als afspelen beëindigd is"
+
+#: id:24000
+msgid "Add-on"
+msgstr "Add-on"
+
+#: id:24001
+msgid "Add-ons"
+msgstr "Add-ons"
+
+#: id:24002
+msgid "Add-on options"
+msgstr "Add-on opties"
+
+#: id:24003
+msgid "Add-on Information"
+msgstr "Add-on informatie"
+
+#: id:24005
+msgctxt "Auto context with id 24005"
+msgid "Media sources"
+msgstr "Mediabronnen"
+
+#: id:24007
+msgctxt "Auto context with id 24007"
+msgid "Movie information"
+msgstr "Filminformatie"
+
+#: id:24008
+msgctxt "Auto context with id 24008"
+msgid "Screensaver"
+msgstr "Schermbeveiliging"
+
+#: id:24009
+msgid "Script"
+msgstr "Script"
+
+#: id:24010
+msgctxt "Auto context with id 24010"
+msgid "Visualization"
+msgstr "Visualisatie"
+
+#: id:24011
+msgid "Add-on repository"
+msgstr "Add-on repo"
+
+#: id:24012
+msgctxt "Auto context with id 24012"
+msgid "Subtitles"
+msgstr "Ondertitelscraper"
+
+#: id:24013
+msgid "Lyrics"
+msgstr "Songtekstscraper"
+
+#: id:24014
+msgid "TV information"
+msgstr "TV-informatie"
+
+#: id:24015
+msgctxt "Auto context with id 24015"
+msgid "Music video information"
+msgstr "Muziekvideoinformatie"
+
+#: id:24016
+msgctxt "Auto context with id 24016"
+msgid "Album information"
+msgstr "Albuminformatie"
+
+#: id:24017
+msgctxt "Auto context with id 24017"
+msgid "Artist information"
+msgstr "Artiestinformatie"
+
+#: id:24018
+msgctxt "Auto context with id 24018"
+msgid "Services"
+msgstr "Processen"
+
+#: id:24020
+msgid "Configure"
+msgstr "Configureren"
+
+#: id:24021
+msgctxt "Auto context with id 24021"
+msgid "Disable"
+msgstr "Uitschakelen"
+
+#: id:24022
+msgid "Enable"
+msgstr "Inschakelen"
+
+#: id:24023
+msgid "Add-on disabled"
+msgstr "Add-on uitgeschakeld"
+
+#: id:24027
+msgctxt "Auto context with id 24027"
+msgid "Weather"
+msgstr "Weer"
+
+#: id:24028
+msgid "Weather.com (standard)"
+msgstr "Weather.com (standaard)"
+
+#: id:24030
+msgid "This Add-on can not be configured"
+msgstr "Deze add-on kan niet worden geconfigureerd"
+
+#: id:24031
+msgid "Error loading settings"
+msgstr "Fout tijdens het laden van de instellingen"
+
+#: id:24032
+msgid "All Add-ons"
+msgstr "Alle add-ons"
+
+#: id:24033
+msgid "Get Add-ons"
+msgstr "Add-ons downloaden"
+
+#: id:24034
+msgid "Check for updates"
+msgstr "Controleren op updates"
+
+#: id:24035
+msgid "Force refresh"
+msgstr "Verversen"
+
+#: id:24036
+msgid "Change log"
+msgstr "Wijzigingen"
+
+#: id:24037
+msgid "Uninstall"
+msgstr "Verwijderen"
+
+#: id:24038
+msgid "Install"
+msgstr "Installeren"
+
+#: id:24039
+msgid "Disabled Add-ons"
+msgstr "Uitgeschakelde add-ons"
+
+#: id:24040
+msgid "(Clear the current setting)"
+msgstr "(Huidige instellingen wissen)"
+
+#: id:24041
+msgid "Install from zip file"
+msgstr "Add-ons installeren mbv zipbestand"
+
+#: id:24042
+msgid "Downloading %i%%"
+msgstr "Downloaden van %i%%"
+
+#: id:24043
+msgid "Available Updates"
+msgstr "Beschikbare updates"
+
+#: id:24044
+msgid "Dependencies not met"
+msgstr "Niet voldaan aan afhankelijkheden"
+
+#: id:24045
+msgid "Add-on does not have the correct structure"
+msgstr "Add-on heeft niet de juiste structuur"
+
+#: id:24046
+msgid "%s is used by the following installed add-on(s)"
+msgstr "%s wordt gebruikt door volgende geinstalleerde add-on(s)"
+
+#: id:24047
+msgid "This add-on cannot be uninstalled"
+msgstr "Deze add-on kan niet verwijderd worden"
+
+#: id:24048
+msgid "Rollback"
+msgstr "Ongedaan maken"
+
+#: id:24050
+msgid "Available Add-ons"
+msgstr "Beschikbare add-ons"
+
+#: id:24051
+msgid "Version:"
+msgstr "Versie:"
+
+#: id:24052
+msgid "Disclaimer"
+msgstr "Disclaimer"
+
+#: id:24053
+msgid "License:"
+msgstr "Licentie:"
+
+#: id:24054
+msgid "Changelog"
+msgstr "Wijzigingen"
+
+#: id:24059
+msgid "Would you like to enable this Add-on?"
+msgstr "Wilt u deze add-on inschakelen?"
+
+#: id:24060
+msgid "Would you like to disable this Add-on?"
+msgstr "Wilt u deze add-on uitschakelen?"
+
+#: id:24061
+msgid "Add-on update available!"
+msgstr "Er is een update voor deze add-on!"
+
+#: id:24062
+msgid "Enabled Add-ons"
+msgstr "Geïnstalleerde add-ons"
+
+#: id:24063
+msgid "Auto update"
+msgstr "Automatisch bijwerken"
+
+#: id:24064
+msgid "Add-on enabled"
+msgstr "Add-on is ingeschakeld"
+
+#: id:24065
+msgid "Add-on updated"
+msgstr "Add-on is bijgewerkt"
+
+#: id:24066
+msgid "Cancel Add-on download?"
+msgstr "Downloaden add-on stoppen ?"
+
+#: id:24067
+msgid "Currently downloading Add-ons"
+msgstr "Huidige add-ons downloads"
+
+#: id:24068
+msgid "Update available"
+msgstr "Update beschikbaar"
+
+#: id:24069
+msgid "Update"
+msgstr "Update"
+
+#: id:24070
+msgid "Add-on could not be loaded."
+msgstr "Add-on kan niet worden geladen"
+
+#: id:24071
+msgid "An unknown error has occurred."
+msgstr "Er is een onbekende fout opgetreden"
+
+#: id:24072
+msgid "Settings required"
+msgstr "Instellingen vereist"
+
+#: id:24073
+msgid "Could not connect"
+msgstr "Kan niet verbinden"
+
+#: id:24074
+msgid "Needs to restart"
+msgstr "Herstart vereist"
+
+#: id:24075
+msgctxt "Auto context with id 24075"
+msgid "Disable"
+msgstr "Uitschakelen"
+
+#: id:24076
+msgid "Add-on Required"
+msgstr "Vereiste add-on"
+
+#: id:24080
+msgid "Try to reconnect?"
+msgstr "Nogmaals proberen te verbinden?"
+
+#: id:24089
+msgid "Add-on restarts"
+msgstr "Add-on aan het herstarten"
+
+#: id:24090
+msgid "Lock Add-on manager"
+msgstr "Add-onmanager vastzetten"
+
+#: id:24094
+msgid "(current)"
+msgstr "(huidige)"
+
+#: id:24095
+msgid "(blacklisted)"
+msgstr "(geblacklist)"
+
+#: id:24096
+msgid "Add-on has been marked as broken in repository."
+msgstr "Add-on is gemarkeerd als niet werkend in het repository."
+
+#: id:24097
+msgid "Would you like to disable it on your system?"
+msgstr "Wilt u de add-on uitschakelen?"
+
+#: id:24098
+msgid "Broken"
+msgstr "Defect"
+
+#: id:24099
+msgid "Would you like to switch to this skin?"
+msgstr "Wilt u deze skin gebruiken?"
+
+#: id:24100
+msgid "To use this feature you must download an Add-on:"
+msgstr "Om deze eigenschap te gebruiken, moet een add-on gedownload worden:"
+
+#: id:24101
+msgid "Would you like to download this Add-on?"
+msgstr "Wil U deze add-on downloaden?"
+
+#: id:25000
+msgid "Notifications"
+msgstr "Mededelingen"
+
+#: id:29800
+msgid "Library Mode"
+msgstr "Bibliotheekmodus"
+
+#: id:29801
+msgid "QWERTY keyboard"
+msgstr "QWERTY-toetsenbordindeling"
+
+#: id:29802
+msgid "Passthrough Audio in use"
+msgstr "Passthrough audio in gebruik"
+
+#: id:33001
+msgid "Trailer quality"
+msgstr "Trailerkwaliteit"
+
+#: id:33002
+msgid "Stream"
+msgstr "Stream"
+
+#: id:33003
+msgid "Download"
+msgstr "Downloaden"
+
+#: id:33004
+msgid "Download & play"
+msgstr "Downloaden & afspelen"
+
+#: id:33005
+msgid "Download & save"
+msgstr "Downloaden & opslaan"
+
+#: id:33006
+msgid "Today"
+msgstr "Vandaag"
+
+#: id:33007
+msgid "Tomorrow"
+msgstr "Morgen"
+
+#: id:33008
+msgid "Saving"
+msgstr "Opslaan"
+
+#: id:33009
+msgid "Copying"
+msgstr "Kopiëren"
+
+#: id:33010
+msgid "Set download directory"
+msgstr "Geef downloadmap op"
+
+#: id:33011
+msgid "Search duration"
+msgstr "Zoek tijdsduur"
+
+#: id:33012
+msgid "Short"
+msgstr "Kort"
+
+#: id:33013
+msgid "Long"
+msgstr "Lang"
+
+#: id:33014
+msgid "Use DVD player instead of regular player"
+msgstr "Gebruik DVD-speler in plaats van standaardspeler"
+
+#: id:33015
+msgid "Ask for download before playing video"
+msgstr "Vragen om download alvorens video te spelen"
+
+#: id:33016
+msgid "Clips"
+msgstr "Clips"
+
+#: id:33017
+msgid "Restart plugin to enable"
+msgstr "Herstart plugin om deze in te schakelen"
+
+#: id:33018
+msgid "Tonight"
+msgstr "Vannacht"
+
+#: id:33019
+msgid "Tomorrow Night"
+msgstr "Morgennacht"
+
+#: id:33020
+msgid "Condition"
+msgstr "Voorwaarde"
+
+#: id:33021
+msgid "Precipitation"
+msgstr "Neerslag"
+
+#: id:33022
+msgid "Precip"
+msgstr "Neersl."
+
+#: id:33023
+msgid "Humid"
+msgstr "Vochtigheid"
+
+#: id:33024
+msgid "Feels"
+msgstr "Voelt"
+
+#: id:33025
+msgid "Observed"
+msgstr "Waargenomen"
+
+#: id:33026
+msgid "Departure from normal"
+msgstr "Vertrek van normaal"
+
+#: id:33027
+msgid "Sunrise"
+msgstr "Zonsopgang"
+
+#: id:33028
+msgid "Sunset"
+msgstr "Zonsondergang"
+
+#: id:33029
+msgid "Details"
+msgstr "Details"
+
+#: id:33030
+msgid "Outlook"
+msgstr "Verwachting"
+
+#: id:33031
+msgid "Coverflow"
+msgstr "Coverflow"
+
+#: id:33032
+msgid "Translate text"
+msgstr "Vertaal tekst"
+
+#: id:33033
+msgid "Map list %s category"
+msgstr "Map list %s categorie"
+
+#: id:33034
+msgid "36 Hour"
+msgstr "36 Uur"
+
+#: id:33035
+msgid "Maps"
+msgstr "Kaarten"
+
+#: id:33036
+msgid "Hourly"
+msgstr "Elk uur"
+
+#: id:33037
+msgid "Weekend"
+msgstr "Weekend"
+
+#: id:33038
+msgid "%s day"
+msgstr "%s dag"
+
+#: id:33049
+msgid "Alert"
+msgstr "Alarm"
+
+#: id:33050
+msgid "Alerts"
+msgstr "Alarm"
+
+#: id:33051
+msgid "Choose Your"
+msgstr "Kies je"
+
+#: id:33052
+msgid "Check"
+msgstr "Controleer"
+
+#: id:33053
+msgctxt "Auto context with id 33053"
+msgid "Configure the"
+msgstr "Configureer de"
+
+#: id:33054
+msgid "Seasons"
+msgstr "Seizoenen"
+
+#: id:33055
+msgid "Use your"
+msgstr "Gebruik je"
+
+#: id:33056
+msgid "Watch your"
+msgstr "Bekijk je"
+
+#: id:33057
+msgid "Listen to"
+msgstr "Beluister"
+
+#: id:33058
+msgid "View your"
+msgstr "Bekijk je"
+
+#: id:33059
+msgctxt "Auto context with id 33059"
+msgid "Configure the"
+msgstr "Configureer de"
+
+#: id:33060
+msgid "Power"
+msgstr "Power"
+
+#: id:33061
+msgid "Menu"
+msgstr "Menu"
+
+#: id:33062
+msgid "Play the"
+msgstr "Speel de"
+
+#: id:33063
+msgid "Options"
+msgstr "Opties"
+
+#: id:33065
+msgid "Editor"
+msgstr "Editor"
+
+#: id:33066
+msgid "About your"
+msgstr "Over je"
+
+#: id:33067
+msgid "Star rating"
+msgstr "Waardering"
+
+#: id:33068
+msgid "Background"
+msgstr "Achtergrond"
+
+#: id:33069
+msgid "Backgrounds"
+msgstr "Achtergronden"
+
+#: id:33070
+msgid "Custom background"
+msgstr "Aangepaste achtergrond"
+
+#: id:33071
+msgid "Custom backgrounds"
+msgstr "Aangepaste achtergronden"
+
+#: id:33072
+msgid "View Readme"
+msgstr "Bekijk Readme"
+
+#: id:33073
+msgid "View Changelog"
+msgstr "Bekijk wijzigingen"
+
+#: id:33074
+msgid "This version of %s requires an"
+msgstr "Deze versie van %s vereist een"
+
+#: id:33075
+msgid "XBMC revision of %s or greater to run."
+msgstr "XBMC-revisie %s of meer vereist om uit te kunnen voeren."
+
+#: id:33076
+msgid "Please update XBMC."
+msgstr "Gelieve XBMC bij te werken."
+
+#: id:33077
+msgid "No data found!"
+msgstr "Geen data gevonden!"
+
+#: id:33078
+msgid "Next page"
+msgstr "Volgende pagina"
+
+#: id:33079
+msgid "Love"
+msgstr "Leuk!"
+
+#: id:33080
+msgid "Hate"
+msgstr "Niet leuk!"
+
+#: id:33081
+msgid "This file is stacked, select the part you want to play from."
+msgstr "Dit bestand bestaat uit meerdere delen, selecteer het deel dat u wilt afspelen."
+
+#: id:33082
+msgid "Path to script"
+msgstr "Pad naar script"
+
+#: id:33083
+msgid "Enable custom script button"
+msgstr "Stel aangepaste scriptknop in"
+
+#: id:33100
+msgid "Failed to start"
+msgstr "Starten mislukt"
+
+#: id:33101
+msgid "Webserver"
+msgstr "Webserver"
+
+#: id:33102
+msgid "Event Server"
+msgstr "Event Server"
+
+#: id:33103
+msgid "Remote communication server"
+msgstr "Remote communication server"
+
+#: id:33200
+msgid "Detected New Connection"
+msgstr "Detecteer nieuwe verbinding"
+
+#: id:34000
+msgid "Lame"
+msgstr "Lame"
+
+#: id:34001
+msgid "Vorbis"
+msgstr "Vorbis"
+
+#: id:34002
+msgid "Wav"
+msgstr "Wav"
+
+#: id:34003
+msgid "DXVA2"
+msgstr "DXVA2"
+
+#: id:34004
+msgid "VAAPI"
+msgstr "VAAPI"
+
+#: id:34005
+msgid "Flac"
+msgstr "FLAC"
+
+#: id:34100
+msgid "Speaker Configuration"
+msgstr "Aantal geluidskanalen"
+
+#: id:34101
+msgid "2.0"
+msgstr "2.0"
+
+#: id:34102
+msgid "2.1"
+msgstr "2.1"
+
+#: id:34103
+msgid "3.0"
+msgstr "3.0"
+
+#: id:34104
+msgid "3.1"
+msgstr "3.1"
+
+#: id:34105
+msgid "4.0"
+msgstr "4.0"
+
+#: id:34106
+msgid "4.1"
+msgstr "4.1"
+
+#: id:34107
+msgid "5.0"
+msgstr "5.0"
+
+#: id:34108
+msgid "5.1"
+msgstr "5.1"
+
+#: id:34109
+msgid "7.0"
+msgstr "7.0"
+
+#: id:34110
+msgid "7.1"
+msgstr "7.1"
+
+#: id:34201
+msgid "Can't find a next item to play"
+msgstr "Kan volgende item niet vinden om af te spelen"
+
+#: id:34202
+msgid "Can't find a previous item to play"
+msgstr "Kan vorige item niet vinden om af te spelen"
+
+#: id:34300
+msgid "Failed to start zeroconf"
+msgstr "Niet gelukt om zeroconf te starten"
+
+#: id:34301
+msgid "Is Apple's Bonjour Service installed? See log for more info."
+msgstr "Is Apple's Bonjour Service geinstalleerd? Zie log voor meer info."
+
+#: id:34400
+msgid "Video Rendering"
+msgstr "Video Rendering"
+
+#: id:34401
+msgid "Failed to init video filters/scalers, falling back to bilinear scaling"
+msgstr "Niet gelukt om video filters/scalers initialiseren, terugvallen naar bilinear scaling"
+
+#: id:34402
+msgid "Failed to initialize audio device"
+msgstr "Niet gelukt om audio apparaat te initialiseren"
+
+#: id:34403
+msgid "Check your audiosettings"
+msgstr "Controleer je audio-instellingen"
+
+#: id:34404
+msgid "Use gestures for navigation:"
+msgstr ""
+
+#: id:34405
+msgid "1 finger swipe left,right,up,down for cursors"
+msgstr ""
+
+#: id:34406
+msgid "2 finger swipe left for backspace"
+msgstr ""
+
+#: id:34407
+msgid "1 finger single tap for enter"
+msgstr ""
+
+#: id:34408
+msgid "2 finger single tap for contextmenu"
+msgstr ""
+
+#: id:35000
+msgid "Peripherals"
+msgstr "Randapparatuur"
+
+#: id:35001
+msgid "Generic HID device"
+msgstr "Generiek HID apparaat"
+
+#: id:35002
+msgid "Generic network adapter"
+msgstr "Generieke netwerkadapter"
+
+#: id:35003
+msgid "Generic disk"
+msgstr "Generieke schijf"
+
+#: id:35004
+msgid "There are no settings available\nfor this peripheral."
+msgstr "Er zijn geen instellingen beschikbaar\nvoor dit apparaat."
+
+#: id:35005
+msgid "New device configured"
+msgstr "Nieuw apparaat geconfigureerd"
+
+#: id:35006
+msgid "Device removed"
+msgstr "Apparaat verwijderd"
+
+#: id:35007
+msgid "Keymap to use for this device"
+msgstr "Keymap voor dit apparaat"
+
+#: id:35008
+msgid "Keymap enabled"
+msgstr "Keymap ingeschakeld"
+
+#: id:35009
+msgid "Do not use the custom keymap for this device"
+msgstr ""
+
+#: id:35500
+msgid "Location"
+msgstr "Locatie"
+
+#: id:35501
+msgid "Class"
+msgstr "Klasse"
+
+#: id:35502
+msgctxt "Auto context with id 35502"
+msgid "Name"
+msgstr "Naam"
+
+#: id:35503
+msgid "Vendor"
+msgstr "Fabrikant"
+
+#: id:35504
+msgid "Product ID"
+msgstr "Product ID"
+
+#: id:36000
+msgid "Pulse-Eight CEC adapter"
+msgstr "Pulse-Eight CEC adapter"
+
+#: id:36001
+msgid "Pulse-Eight Nyxboard"
+msgstr "Pulse-Eight Nyxboard"
+
+#: id:36002
+msgid "Switch to keyboard side command"
+msgstr "Wissel naar toetsenbord commando"
+
+#: id:36003
+msgid "Switch to remote side command"
+msgstr "Wissel naar afstandbediening commando"
+
+#: id:36004
+msgid "Press \"user\" button command"
+msgstr "Druk op \"user\" knop commando"
+
+#: id:36005
+msgid "Enable switch side commands"
+msgstr "Schakel commando's in bij het wisselen van kant"
+
+#: id:36006
+msgid "Could not open the adapter"
+msgstr "Kon de adapter niet openen"
+
+#: id:36007
+msgid "Devices to power on when starting XBMC"
+msgstr "Schakel apparatuur in bij het opstarten van XBMC"
+
+#: id:36008
+msgid "Devices to power off when stopping XBMC"
+msgstr "Schakel apparatuur uit bij het stoppen van XBMC"
+
+#: id:36009
+msgid "Put devices in standby mode when activating screensaver"
+msgstr "Schakel app. uit zolang de schermbeveiliging actief is"
+
+#: id:36011
+msgid "Could not detect the CEC port. Set it up manually."
+msgstr "Kon de COM poort niet detecteren. Stel het manueel in."
+
+#: id:36012
+msgid "Could not initialise the CEC adapter. Check your settings."
+msgstr "Kon de CEC adapter niet initialiseren."
+
+#: id:36013
+msgid "Unsupported libCEC interface version. %d is greater than the version XBMC supports (%d)"
+msgstr "Versie %d van de libCEC interface version wordt niet ondersteund door XBMC (> %d)"
+
+#: id:36014
+msgid "Put this PC in standby mode when the TV is switched off"
+msgstr "Zet XBMC in standby wanneer de TV uitgeschakeld wordt"
+
+#: id:36015
+msgid "HDMI port number"
+msgstr "HDMI poort nummer"
+
+#: id:36016
+msgctxt "Auto context with id 36016"
+msgid "Connected"
+msgstr "Verbonden"
+
+#: id:36017
+msgid "Adapter found, but libCEC is not available"
+msgstr "Adapter gevonden, maar libCEC is niet beschikbaar"
+
+#: id:36018
+msgid "Use the TV's language setting"
+msgstr "Gebruik de taalinstelling van de TV"
+
+#: id:36019
+msgid "Connected to HDMI device"
+msgstr "Verbonden met HDMI apparaat"
+
+#: id:36020
+msgid "Make XBMC the active source when starting"
+msgstr "Maak XBMC de actieve bron bij het opstarten"
+
+#: id:36021
+msgid "Physical address (overrules HDMI port)"
+msgstr "Physiek adres (overschrijft HDMI poort)"
+
+#: id:36022
+msgid "COM port (leave empty unless needed)"
+msgstr "COM poort (laat leeg, tenzij noodzakelijk)"
+
+#: id:36023
+msgid "Configuration updated"
+msgstr "Configuratie aangepast"
+
+#: id:36024
+msgid "Failed to set the new configuration. Please check your settings."
+msgstr "Kon de nieuwe configuratie niet instellen. Controleer de instellingen."
+
+#: id:36025
+msgid "Send 'inactive source' command when stopping XBMC"
+msgstr "Verstuur 'inactieve bron' commando bij het stoppen"
+

--- a/language/English (US)/strings.po
+++ b/language/English (US)/strings.po
@@ -1,0 +1,9093 @@
+# Converted from xbmc strings.xml with xbmc-xml2po (by Team-XBMC)
+msgid ""
+msgstr ""
+"Project-Id-Version: xbmc.core-FRODO_GIT3ed1604ad7\n"
+"Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
+"POT-Creation-Date: 2012-04-09 18:00+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE\n"
+"Language: en_US\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: id:0
+msgctxt "Auto context with id 0"
+msgid "Programs"
+msgstr ""
+
+#: id:1
+msgctxt "Auto context with id 1"
+msgid "Pictures"
+msgstr ""
+
+#: id:2
+msgctxt "Auto context with id 2"
+msgid "Music"
+msgstr ""
+
+#: id:3
+msgctxt "Auto context with id 3"
+msgid "Videos"
+msgstr ""
+
+#: id:4
+msgid "TV-Guide"
+msgstr ""
+
+#: id:5
+msgctxt "Auto context with id 5"
+msgid "Settings"
+msgstr ""
+
+#: id:6
+msgid "XBMC SVN"
+msgstr ""
+
+#: id:7
+msgctxt "Auto context with id 7"
+msgid "File manager"
+msgstr ""
+
+#: id:8
+msgctxt "Auto context with id 8"
+msgid "Weather"
+msgstr ""
+
+#: id:9
+msgid "xbmc media center"
+msgstr ""
+
+#: id:11
+msgid "Monday"
+msgstr ""
+
+#: id:12
+msgid "Tuesday"
+msgstr ""
+
+#: id:13
+msgid "Wednesday"
+msgstr ""
+
+#: id:14
+msgid "Thursday"
+msgstr ""
+
+#: id:15
+msgid "Friday"
+msgstr ""
+
+#: id:16
+msgid "Saturday"
+msgstr ""
+
+#: id:17
+msgid "Sunday"
+msgstr ""
+
+#: id:21
+msgid "January"
+msgstr ""
+
+#: id:22
+msgid "February"
+msgstr ""
+
+#: id:23
+msgid "March"
+msgstr ""
+
+#: id:24
+msgid "April"
+msgstr ""
+
+#: id:25
+msgctxt "Auto context with id 25"
+msgid "May"
+msgstr ""
+
+#: id:26
+msgid "June"
+msgstr ""
+
+#: id:27
+msgid "July"
+msgstr ""
+
+#: id:28
+msgid "August"
+msgstr ""
+
+#: id:29
+msgid "September"
+msgstr ""
+
+#: id:30
+msgid "October"
+msgstr ""
+
+#: id:31
+msgid "November"
+msgstr ""
+
+#: id:32
+msgid "December"
+msgstr ""
+
+#: id:41
+msgid "Mon"
+msgstr ""
+
+#: id:42
+msgid "Tue"
+msgstr ""
+
+#: id:43
+msgid "Wed"
+msgstr ""
+
+#: id:44
+msgid "Thu"
+msgstr ""
+
+#: id:45
+msgid "Fri"
+msgstr ""
+
+#: id:46
+msgid "Sat"
+msgstr ""
+
+#: id:47
+msgctxt "Auto context with id 47"
+msgid "Sun"
+msgstr ""
+
+#: id:51
+msgid "Jan"
+msgstr ""
+
+#: id:52
+msgid "Feb"
+msgstr ""
+
+#: id:53
+msgid "Mar"
+msgstr ""
+
+#: id:54
+msgid "Apr"
+msgstr ""
+
+#: id:55
+msgctxt "Auto context with id 55"
+msgid "May"
+msgstr ""
+
+#: id:56
+msgid "Jun"
+msgstr ""
+
+#: id:57
+msgid "Jul"
+msgstr ""
+
+#: id:58
+msgid "Aug"
+msgstr ""
+
+#: id:59
+msgid "Sep"
+msgstr ""
+
+#: id:60
+msgid "Oct"
+msgstr ""
+
+#: id:61
+msgid "Nov"
+msgstr ""
+
+#: id:62
+msgid "Dec"
+msgstr ""
+
+#: id:71
+msgid "N"
+msgstr ""
+
+#: id:72
+msgid "NNE"
+msgstr ""
+
+#: id:73
+msgid "NE"
+msgstr ""
+
+#: id:74
+msgid "ENE"
+msgstr ""
+
+#: id:75
+msgid "E"
+msgstr ""
+
+#: id:76
+msgid "ESE"
+msgstr ""
+
+#: id:77
+msgid "SE"
+msgstr ""
+
+#: id:78
+msgid "SSE"
+msgstr ""
+
+#: id:79
+msgid "S"
+msgstr ""
+
+#: id:80
+msgid "SSW"
+msgstr ""
+
+#: id:81
+msgid "SW"
+msgstr ""
+
+#: id:82
+msgid "WSW"
+msgstr ""
+
+#: id:83
+msgid "W"
+msgstr ""
+
+#: id:84
+msgid "WNW"
+msgstr ""
+
+#: id:85
+msgid "NW"
+msgstr ""
+
+#: id:86
+msgid "NNW"
+msgstr ""
+
+#: id:87
+msgid "VAR"
+msgstr ""
+
+#: id:98
+msgid "View: Auto"
+msgstr ""
+
+#: id:99
+msgid "View: Auto big"
+msgstr ""
+
+#: id:100
+msgid "View: Icons"
+msgstr ""
+
+#: id:101
+msgid "View: List"
+msgstr ""
+
+#: id:102
+msgctxt "Auto context with id 102"
+msgid "Scan"
+msgstr ""
+
+#: id:103
+msgctxt "Auto context with id 103"
+msgid "Sort by: Name"
+msgstr ""
+
+#: id:104
+msgid "Sort by: Date"
+msgstr ""
+
+#: id:105
+msgid "Sort by: Size"
+msgstr ""
+
+#: id:106
+msgid "No"
+msgstr ""
+
+#: id:107
+msgid "Yes"
+msgstr ""
+
+#: id:108
+msgctxt "Auto context with id 108"
+msgid "Slideshow"
+msgstr ""
+
+#: id:109
+msgid "Create thumbs"
+msgstr ""
+
+#: id:110
+msgid "Create thumbnails"
+msgstr ""
+
+#: id:111
+msgctxt "Auto context with id 111"
+msgid "Shortcuts"
+msgstr ""
+
+#: id:112
+msgid "Paused"
+msgstr ""
+
+#: id:113
+msgid "Update failed"
+msgstr ""
+
+#: id:114
+msgid "Installation failed"
+msgstr ""
+
+#: id:115
+msgid "Copy"
+msgstr ""
+
+#: id:116
+msgid "Move"
+msgstr ""
+
+#: id:117
+msgid "Delete"
+msgstr ""
+
+#: id:118
+msgid "Rename"
+msgstr ""
+
+#: id:119
+msgid "New folder"
+msgstr ""
+
+#: id:120
+msgid "Confirm file copy"
+msgstr ""
+
+#: id:121
+msgid "Confirm file move"
+msgstr ""
+
+#: id:122
+msgid "Confirm file delete?"
+msgstr ""
+
+#: id:123
+msgid "Copy these files?"
+msgstr ""
+
+#: id:124
+msgid "Move these files?"
+msgstr ""
+
+#: id:125
+msgid "Delete these files? - Deleting files cannot be undone!"
+msgstr ""
+
+#: id:126
+msgid "Status"
+msgstr ""
+
+#: id:127
+msgid "Objects"
+msgstr ""
+
+#: id:128
+msgctxt "Auto context with id 128"
+msgid "General"
+msgstr ""
+
+#: id:129
+msgctxt "Auto context with id 129"
+msgid "Slideshow"
+msgstr ""
+
+#: id:130
+msgctxt "Auto context with id 130"
+msgid "System info"
+msgstr ""
+
+#: id:131
+msgid "Display"
+msgstr ""
+
+#: id:132
+msgid "Albums"
+msgstr ""
+
+#: id:133
+msgid "Artists"
+msgstr ""
+
+#: id:134
+msgid "Songs"
+msgstr ""
+
+#: id:135
+msgid "Genres"
+msgstr ""
+
+#: id:136
+msgid "Playlists"
+msgstr ""
+
+#: id:137
+msgid "Search"
+msgstr ""
+
+#: id:138
+msgid "System Information"
+msgstr ""
+
+#: id:139
+msgid "Temperatures:"
+msgstr ""
+
+#: id:140
+msgid "CPU:"
+msgstr ""
+
+#: id:141
+msgid "GPU:"
+msgstr ""
+
+#: id:142
+msgid "Time:"
+msgstr ""
+
+#: id:143
+msgid "Current:"
+msgstr ""
+
+#: id:144
+msgid "Build:"
+msgstr ""
+
+#: id:145
+msgid "Network:"
+msgstr ""
+
+#: id:146
+msgid "Type:"
+msgstr ""
+
+#: id:147
+msgid "Static"
+msgstr ""
+
+#: id:148
+msgid "DHCP"
+msgstr ""
+
+#: id:149
+msgid "MAC address"
+msgstr ""
+
+#: id:150
+msgctxt "Auto context with id 150"
+msgid "IP address"
+msgstr ""
+
+#: id:151
+msgid "Link:"
+msgstr ""
+
+#: id:152
+msgid "Half duplex"
+msgstr ""
+
+#: id:153
+msgid "Full duplex"
+msgstr ""
+
+#: id:154
+msgctxt "Auto context with id 154"
+msgid "Storage"
+msgstr ""
+
+#: id:155
+msgid "Drive"
+msgstr ""
+
+#: id:156
+msgctxt "Auto context with id 156"
+msgid "Free"
+msgstr ""
+
+#: id:157
+msgctxt "Auto context with id 157"
+msgid "Video"
+msgstr ""
+
+#: id:158
+msgid "Free memory"
+msgstr ""
+
+#: id:159
+msgid "No link"
+msgstr ""
+
+#: id:160
+msgctxt "Auto context with id 160"
+msgid "Free"
+msgstr ""
+
+#: id:161
+msgid "Unavailable"
+msgstr ""
+
+#: id:162
+msgid "Tray open"
+msgstr ""
+
+#: id:163
+msgid "Reading"
+msgstr ""
+
+#: id:164
+msgid "No disc"
+msgstr ""
+
+#: id:165
+msgid "Disc present"
+msgstr ""
+
+#: id:166
+msgid "Skin"
+msgstr ""
+
+#: id:169
+msgctxt "Auto context with id 169"
+msgid "Resolution"
+msgstr ""
+
+#: id:170
+msgid "Adjust display refresh rate to match video"
+msgstr ""
+
+#: id:172
+msgid "Release date"
+msgstr ""
+
+#: id:173
+msgid "Display 4:3 videos as"
+msgstr ""
+
+#: id:175
+msgid "Moods"
+msgstr ""
+
+#: id:176
+msgid "Styles"
+msgstr ""
+
+#: id:179
+msgid "Song"
+msgstr ""
+
+#: id:180
+msgid "Duration"
+msgstr ""
+
+#: id:181
+msgid "Select album"
+msgstr ""
+
+#: id:182
+msgid "Tracks"
+msgstr ""
+
+#: id:183
+msgid "Review"
+msgstr ""
+
+#: id:184
+msgid "Refresh"
+msgstr ""
+
+#: id:185
+msgid "Searching album"
+msgstr ""
+
+#: id:186
+msgid "OK"
+msgstr ""
+
+#: id:187
+msgid "No albums found!"
+msgstr ""
+
+#: id:188
+msgid "Select all"
+msgstr ""
+
+#: id:189
+msgid "Scanning media info"
+msgstr ""
+
+#: id:190
+msgid "Save"
+msgstr ""
+
+#: id:191
+msgid "Shuffle"
+msgstr ""
+
+#: id:192
+msgctxt "Auto context with id 192"
+msgid "Clear"
+msgstr ""
+
+#: id:193
+msgctxt "Auto context with id 193"
+msgid "Scan"
+msgstr ""
+
+#: id:194
+msgid "Searching..."
+msgstr ""
+
+#: id:195
+msgid "No info found!"
+msgstr ""
+
+#: id:196
+msgid "Select movie:"
+msgstr ""
+
+#: id:197
+msgid "Querying %s info"
+msgstr ""
+
+#: id:198
+msgid "Loading movie details"
+msgstr ""
+
+#: id:199
+msgid "Web interface"
+msgstr ""
+
+#: id:202
+msgid "Tagline"
+msgstr ""
+
+#: id:203
+msgid "Plot outline"
+msgstr ""
+
+#: id:205
+msgid "Votes"
+msgstr ""
+
+#: id:206
+msgid "Cast"
+msgstr ""
+
+#: id:207
+msgid "Plot"
+msgstr ""
+
+#: id:208
+msgctxt "Auto context with id 208"
+msgid "Play"
+msgstr ""
+
+#: id:209
+msgid "Next"
+msgstr ""
+
+#: id:210
+msgid "Previous"
+msgstr ""
+
+#: id:213
+msgid "Calibrate user interface..."
+msgstr ""
+
+#: id:214
+msgid "Video calibration..."
+msgstr ""
+
+#: id:215
+msgid "Soften"
+msgstr ""
+
+#: id:216
+msgid "Zoom amount"
+msgstr ""
+
+#: id:217
+msgid "Pixel ratio"
+msgstr ""
+
+#: id:218
+msgid "DVD drive"
+msgstr ""
+
+#: id:219
+msgid "Please insert disc"
+msgstr ""
+
+#: id:220
+msgid "Remote share"
+msgstr ""
+
+#: id:221
+msgid "Network is not connected"
+msgstr ""
+
+#: id:222
+msgid "Cancel"
+msgstr ""
+
+#: id:224
+msgid "Speed"
+msgstr ""
+
+#: id:225
+msgid "Vertical Shift"
+msgstr ""
+
+#: id:226
+msgid "Test patterns..."
+msgstr ""
+
+#: id:227
+msgid "Lookup audio CD track names from freedb.org"
+msgstr ""
+
+#: id:228
+msgid "Shuffle playlist on load"
+msgstr ""
+
+#: id:229
+msgid "HDD spindown time"
+msgstr ""
+
+#: id:230
+msgid "Video filters"
+msgstr ""
+
+#: id:231
+msgctxt "Auto context with id 231"
+msgid "None"
+msgstr ""
+
+#: id:232
+msgid "Point"
+msgstr ""
+
+#: id:233
+msgid "Linear"
+msgstr ""
+
+#: id:234
+msgid "Anisotropic"
+msgstr ""
+
+#: id:235
+msgid "Quincunx"
+msgstr ""
+
+#: id:236
+msgid "Gaussian cubic"
+msgstr ""
+
+#: id:237
+msgid "Minification"
+msgstr ""
+
+#: id:238
+msgid "Magnification"
+msgstr ""
+
+#: id:239
+msgid "Clear playlist on finish"
+msgstr ""
+
+#: id:240
+msgid "Display Mode"
+msgstr ""
+
+#: id:241
+msgid "Full Screen #%d"
+msgstr ""
+
+#: id:242
+msgid "Windowed"
+msgstr ""
+
+#: id:243
+msgid "Refresh Rate"
+msgstr ""
+
+#: id:244
+msgid "Full screen"
+msgstr ""
+
+#: id:245
+msgid "Sizing: (%i,%i)->(%i,%i) (Zoom x%2.2f) AR:%2.2f:1 (Pixels: %2.2f:1) (VShift: %2.2f)"
+msgstr ""
+
+#: id:247
+msgctxt "Auto context with id 247"
+msgid "Scripts"
+msgstr ""
+
+#: id:248
+msgctxt "Auto context with id 248"
+msgid "Language"
+msgstr ""
+
+#: id:249
+msgctxt "Auto context with id 249"
+msgid "Music"
+msgstr ""
+
+#: id:250
+msgctxt "Auto context with id 250"
+msgid "Visualization"
+msgstr ""
+
+#: id:251
+msgid "Select destination directory"
+msgstr ""
+
+#: id:252
+msgid "Output stereo to all speakers"
+msgstr ""
+
+#: id:253
+msgid "Number of channels"
+msgstr ""
+
+#: id:254
+msgid "- DTS capable receiver"
+msgstr ""
+
+#: id:255
+msgid "CDDB"
+msgstr ""
+
+#: id:256
+msgid "Fetching CD information"
+msgstr ""
+
+#: id:257
+msgid "Error"
+msgstr ""
+
+#: id:258
+msgid "Enable tag reading"
+msgstr ""
+
+#: id:259
+msgid "Opening"
+msgstr ""
+
+#: id:260
+msgid "Shoutcast"
+msgstr ""
+
+#: id:261
+msgid "Waiting for start..."
+msgstr ""
+
+#: id:262
+msgid "Scripts output"
+msgstr ""
+
+#: id:263
+msgid "Allow control of XBMC via HTTP"
+msgstr ""
+
+#: id:264
+msgid "Record"
+msgstr ""
+
+#: id:265
+msgid "Stop Rec."
+msgstr ""
+
+#: id:266
+msgid "Sort by: Track"
+msgstr ""
+
+#: id:267
+msgid "Sort by: Time"
+msgstr ""
+
+#: id:268
+msgid "Sort by: Title"
+msgstr ""
+
+#: id:269
+msgid "Sort by: Artist"
+msgstr ""
+
+#: id:270
+msgid "Sort by: Album"
+msgstr ""
+
+#: id:271
+msgid "Top 100"
+msgstr ""
+
+#: id:272
+msgid "Top-Left overscan compensation"
+msgstr ""
+
+#: id:273
+msgid "Bottom-Right overscan compensation"
+msgstr ""
+
+#: id:274
+msgid "Subtitle positioning"
+msgstr ""
+
+#: id:275
+msgid "Pixel ratio adjustment"
+msgstr ""
+
+#: id:276
+msgid "Adjust the arrow to change the amount of overscan"
+msgstr ""
+
+#: id:277
+msgid "Adjust the bar to change the subtitles position"
+msgstr ""
+
+#: id:278
+msgid "Adjust the rectangle so it is perfectly square"
+msgstr ""
+
+#: id:279
+msgid "Unable to load settings"
+msgstr ""
+
+#: id:280
+msgid "Using default settings"
+msgstr ""
+
+#: id:281
+msgid "Please check the XML files"
+msgstr ""
+
+#: id:282
+msgid "Found %i items"
+msgstr ""
+
+#: id:283
+msgid "Search results"
+msgstr ""
+
+#: id:284
+msgid "No results found"
+msgstr ""
+
+#: id:287
+msgctxt "Auto context with id 287"
+msgid "Subtitles"
+msgstr ""
+
+#: id:288
+msgctxt "Auto context with id 288"
+msgid "Font"
+msgstr ""
+
+#: id:289
+msgctxt "Auto context with id 289"
+msgid "- Size"
+msgstr ""
+
+#: id:290
+msgid "Dynamic range compression"
+msgstr ""
+
+#: id:291
+msgctxt "Auto context with id 291"
+msgid "Video"
+msgstr ""
+
+#: id:292
+msgctxt "Auto context with id 292"
+msgid "Audio"
+msgstr ""
+
+#: id:293
+msgid "Browse for subtitles"
+msgstr ""
+
+#: id:294
+msgid "Create bookmark"
+msgstr ""
+
+#: id:296
+msgid "Clear bookmarks"
+msgstr ""
+
+#: id:297
+msgid "Audio offset"
+msgstr ""
+
+#: id:298
+msgid "Bookmarks"
+msgstr ""
+
+#: id:299
+msgid "- AAC capable receiver"
+msgstr ""
+
+#: id:300
+msgid "- MP1 capable receiver"
+msgstr ""
+
+#: id:301
+msgid "- MP2 capable receiver"
+msgstr ""
+
+#: id:302
+msgid "- MP3 capable receiver"
+msgstr ""
+
+#: id:303
+msgid "Delay"
+msgstr ""
+
+#: id:304
+msgctxt "Auto context with id 304"
+msgid "Language"
+msgstr ""
+
+#: id:305
+msgctxt "Auto context with id 305"
+msgid "Enabled"
+msgstr ""
+
+#: id:306
+msgid "Non-interleaved"
+msgstr ""
+
+#: id:312
+msgid "(0=auto)"
+msgstr ""
+
+#: id:313
+msgid "Cleaning database"
+msgstr ""
+
+#: id:314
+msgid "Preparing..."
+msgstr ""
+
+#: id:315
+msgid "Database error"
+msgstr ""
+
+#: id:316
+msgid "Searching songs..."
+msgstr ""
+
+#: id:317
+msgid "Cleaned database successfully"
+msgstr ""
+
+#: id:318
+msgid "Cleaning songs..."
+msgstr ""
+
+#: id:319
+msgid "Error cleaning songs"
+msgstr ""
+
+#: id:320
+msgid "Cleaning artists..."
+msgstr ""
+
+#: id:321
+msgid "Error cleaning artists"
+msgstr ""
+
+#: id:322
+msgid "Cleaning genres..."
+msgstr ""
+
+#: id:323
+msgid "Error cleaning genres"
+msgstr ""
+
+#: id:324
+msgid "Cleaning paths..."
+msgstr ""
+
+#: id:325
+msgid "Error cleaning paths"
+msgstr ""
+
+#: id:326
+msgid "Cleaning albums..."
+msgstr ""
+
+#: id:327
+msgid "Error cleaning albums"
+msgstr ""
+
+#: id:328
+msgid "Writing changes..."
+msgstr ""
+
+#: id:329
+msgid "Error writing changes"
+msgstr ""
+
+#: id:330
+msgid "This may take some time..."
+msgstr ""
+
+#: id:331
+msgid "Compressing database..."
+msgstr ""
+
+#: id:332
+msgid "Error compressing database"
+msgstr ""
+
+#: id:333
+msgid "Do you want to clean the library?"
+msgstr ""
+
+#: id:334
+msgid "Clean library..."
+msgstr ""
+
+#: id:335
+msgid "Start"
+msgstr ""
+
+#: id:336
+msgid "Framerate conversion"
+msgstr ""
+
+#: id:337
+msgctxt "Auto context with id 337"
+msgid "Audio output"
+msgstr ""
+
+#: id:338
+msgid "Analog"
+msgstr ""
+
+#: id:339
+msgid "Optical/Coax"
+msgstr ""
+
+#: id:340
+msgid "Various artists"
+msgstr ""
+
+#: id:341
+msgid "Play disc"
+msgstr ""
+
+#: id:342
+msgctxt "Auto context with id 342"
+msgid "Movies"
+msgstr ""
+
+#: id:343
+msgid "Adjust framerate"
+msgstr ""
+
+#: id:344
+msgid "Actors"
+msgstr ""
+
+#: id:345
+msgctxt "Auto context with id 345"
+msgid "Year"
+msgstr ""
+
+#: id:346
+msgid "Boost volume level on downmix"
+msgstr ""
+
+#: id:350
+msgctxt "Auto context with id 350"
+msgid "Programs"
+msgstr ""
+
+#: id:351
+msgctxt "Auto context with id 351"
+msgid "Off"
+msgstr ""
+
+#: id:352
+msgid "Dim"
+msgstr ""
+
+#: id:353
+msgid "Black"
+msgstr ""
+
+#: id:354
+msgid "Matrix trails"
+msgstr ""
+
+#: id:355
+msgid "Screensaver time"
+msgstr ""
+
+#: id:356
+msgid "Screensaver mode"
+msgstr ""
+
+#: id:357
+msgid "Shutdown function timer"
+msgstr ""
+
+#: id:358
+msgid "All albums"
+msgstr ""
+
+#: id:359
+msgid "Recently added albums"
+msgstr ""
+
+#: id:360
+msgctxt "Auto context with id 360"
+msgid "Screensaver"
+msgstr ""
+
+#: id:361
+msgid "R. Slideshow"
+msgstr ""
+
+#: id:362
+msgid "Screensaver dim level"
+msgstr ""
+
+#: id:363
+msgid "Sort by: File"
+msgstr ""
+
+#: id:364
+msgid "- Dolby Digital (AC3) capable receiver"
+msgstr ""
+
+#: id:365
+msgctxt "Auto context with id 365"
+msgid "Sort by: Name"
+msgstr ""
+
+#: id:366
+msgid "Sort by: Year"
+msgstr ""
+
+#: id:367
+msgid "Sort by: Rating"
+msgstr ""
+
+#: id:368
+msgid "IMDb"
+msgstr ""
+
+#: id:369
+msgctxt "Auto context with id 369"
+msgid "Title"
+msgstr ""
+
+#: id:370
+msgid "Thunderstorms"
+msgstr ""
+
+#: id:371
+msgid "Partly"
+msgstr ""
+
+#: id:372
+msgid "Mostly"
+msgstr ""
+
+#: id:373
+msgid "Sunny"
+msgstr ""
+
+#: id:374
+msgid "Cloudy"
+msgstr ""
+
+#: id:375
+msgid "Snow"
+msgstr ""
+
+#: id:376
+msgid "Rain"
+msgstr ""
+
+#: id:377
+msgid "Light"
+msgstr ""
+
+#: id:378
+msgid "AM"
+msgstr ""
+
+#: id:379
+msgid "PM"
+msgstr ""
+
+#: id:380
+msgid "Showers"
+msgstr ""
+
+#: id:381
+msgid "Few"
+msgstr ""
+
+#: id:382
+msgid "Scattered"
+msgstr ""
+
+#: id:383
+msgctxt "Auto context with id 383"
+msgid "Wind"
+msgstr ""
+
+#: id:384
+msgid "Strong"
+msgstr ""
+
+#: id:385
+msgid "Fair"
+msgstr ""
+
+#: id:386
+msgctxt "Auto context with id 386"
+msgid "Clear"
+msgstr ""
+
+#: id:387
+msgid "Clouds"
+msgstr ""
+
+#: id:388
+msgid "Early"
+msgstr ""
+
+#: id:389
+msgid "Shower"
+msgstr ""
+
+#: id:390
+msgid "Flurries"
+msgstr ""
+
+#: id:391
+msgctxt "Auto context with id 391"
+msgid "Low"
+msgstr ""
+
+#: id:392
+msgctxt "Auto context with id 392"
+msgid "Medium"
+msgstr ""
+
+#: id:393
+msgctxt "Auto context with id 393"
+msgid "High"
+msgstr ""
+
+#: id:394
+msgid "Fog"
+msgstr ""
+
+#: id:395
+msgid "Haze"
+msgstr ""
+
+#: id:396
+msgid "Select location"
+msgstr ""
+
+#: id:397
+msgid "Refresh time"
+msgstr ""
+
+#: id:398
+msgid "Temperature units"
+msgstr ""
+
+#: id:399
+msgid "Speed units"
+msgstr ""
+
+#: id:400
+msgctxt "Auto context with id 400"
+msgid "Weather"
+msgstr ""
+
+#: id:401
+msgid "Temp"
+msgstr ""
+
+#: id:402
+msgid "Feels like"
+msgstr ""
+
+#: id:403
+msgid "UV index"
+msgstr ""
+
+#: id:404
+msgctxt "Auto context with id 404"
+msgid "Wind"
+msgstr ""
+
+#: id:405
+msgid "Dew point"
+msgstr ""
+
+#: id:406
+msgid "Humidity"
+msgstr ""
+
+#: id:409
+msgid "Defaults"
+msgstr ""
+
+#: id:410
+msgid "Accessing weather service"
+msgstr ""
+
+#: id:411
+msgid "Getting weather for:"
+msgstr ""
+
+#: id:412
+msgid "Unable to get weather data"
+msgstr ""
+
+#: id:413
+msgid "Manual"
+msgstr ""
+
+#: id:414
+msgid "No review for this album"
+msgstr ""
+
+#: id:415
+msgid "Downloading thumbnail..."
+msgstr ""
+
+#: id:416
+msgid "Not available"
+msgstr ""
+
+#: id:417
+msgid "View: Big icons"
+msgstr ""
+
+#: id:418
+msgctxt "Auto context with id 418"
+msgid "Low"
+msgstr ""
+
+#: id:419
+msgctxt "Auto context with id 419"
+msgid "High"
+msgstr ""
+
+#: id:420
+msgid "HDMI"
+msgstr ""
+
+#: id:422
+msgid "Delete album info"
+msgstr ""
+
+#: id:423
+msgid "Delete CD information"
+msgstr ""
+
+#: id:424
+msgid "Select"
+msgstr ""
+
+#: id:425
+msgid "No album information found"
+msgstr ""
+
+#: id:426
+msgid "No CD information found"
+msgstr ""
+
+#: id:427
+msgid "Disc"
+msgstr ""
+
+#: id:428
+msgid "Insert correct CD/DVD"
+msgstr ""
+
+#: id:429
+msgid "Please insert the following disc:"
+msgstr ""
+
+#: id:430
+msgid "Sort by: DVD#"
+msgstr ""
+
+#: id:431
+msgid "No cache"
+msgstr ""
+
+#: id:432
+msgid "Remove movie from library"
+msgstr ""
+
+#: id:433
+msgid "Really remove '%s'?"
+msgstr ""
+
+#: id:434
+msgid "From %s at %i %s"
+msgstr ""
+
+#: id:437
+msgid "Removable disk"
+msgstr ""
+
+#: id:438
+msgid "Opening file"
+msgstr ""
+
+#: id:439
+msgid "Cache"
+msgstr ""
+
+#: id:440
+msgid "Harddisk"
+msgstr ""
+
+#: id:441
+msgid "UDF"
+msgstr ""
+
+#: id:442
+msgid "Local network"
+msgstr ""
+
+#: id:443
+msgid "Internet"
+msgstr ""
+
+#: id:444
+msgctxt "Auto context with id 444"
+msgid "Video"
+msgstr ""
+
+#: id:445
+msgctxt "Auto context with id 445"
+msgid "Audio"
+msgstr ""
+
+#: id:446
+msgctxt "Auto context with id 446"
+msgid "DVD"
+msgstr ""
+
+#: id:447
+msgid "Autorun media"
+msgstr ""
+
+#: id:448
+msgid "LCD"
+msgstr ""
+
+#: id:449
+msgctxt "Auto context with id 449"
+msgid "Enabled"
+msgstr ""
+
+#: id:450
+msgid "Columns"
+msgstr ""
+
+#: id:451
+msgid "Row 1 address"
+msgstr ""
+
+#: id:452
+msgid "Row 2 address"
+msgstr ""
+
+#: id:453
+msgid "Row 3 address"
+msgstr ""
+
+#: id:454
+msgid "Row 4 address"
+msgstr ""
+
+#: id:455
+msgid "Rows"
+msgstr ""
+
+#: id:456
+msgid "Mode"
+msgstr ""
+
+#: id:457
+msgid "Switch view"
+msgstr ""
+
+#: id:459
+msgid "Subs"
+msgstr ""
+
+#: id:460
+msgid "Audio stream"
+msgstr ""
+
+#: id:461
+msgid "[active]"
+msgstr ""
+
+#: id:462
+msgid "Subtitle"
+msgstr ""
+
+#: id:463
+msgid "Backlight"
+msgstr ""
+
+#: id:464
+msgid "Brightness"
+msgstr ""
+
+#: id:465
+msgid "Contrast"
+msgstr ""
+
+#: id:466
+msgid "Gamma"
+msgstr ""
+
+#: id:467
+msgctxt "Auto context with id 467"
+msgid "Type"
+msgstr ""
+
+#: id:468
+msgid "Move the bar to change the OSD position"
+msgstr ""
+
+#: id:469
+msgid "OSD position"
+msgstr ""
+
+#: id:470
+msgid "Credits"
+msgstr ""
+
+#: id:471
+msgid "Modchip"
+msgstr ""
+
+#: id:474
+msgctxt "Auto context with id 474"
+msgid "Off"
+msgstr ""
+
+#: id:475
+msgid "Music only"
+msgstr ""
+
+#: id:476
+msgctxt "Auto context with id 476"
+msgid "Music & video"
+msgstr ""
+
+#: id:477
+msgid "Unable to load playlist"
+msgstr ""
+
+#: id:478
+msgid "OSD"
+msgstr ""
+
+#: id:479
+msgid "Skin & language"
+msgstr ""
+
+#: id:480
+msgid "Appearance"
+msgstr ""
+
+#: id:481
+msgid "Audio options"
+msgstr ""
+
+#: id:482
+msgid "About XBMC"
+msgstr ""
+
+#: id:485
+msgid "Delete album"
+msgstr ""
+
+#: id:486
+msgid "Repeat"
+msgstr ""
+
+#: id:487
+msgid "Repeat one"
+msgstr ""
+
+#: id:488
+msgid "Repeat folder"
+msgstr ""
+
+#: id:489
+msgid "Play the next song automatically"
+msgstr ""
+
+#: id:491
+msgid "- Use big icons"
+msgstr ""
+
+#: id:492
+msgid "Resize VobSubs"
+msgstr ""
+
+#: id:493
+msgid "Advanced options (Experts Only!)"
+msgstr ""
+
+#: id:494
+msgid "Overall audio headroom"
+msgstr ""
+
+#: id:495
+msgid "Upsample videos to GUI resolution"
+msgstr ""
+
+#: id:496
+msgid "Calibration"
+msgstr ""
+
+#: id:497
+msgid "Show file extensions"
+msgstr ""
+
+#: id:498
+msgid "Sort by: Type"
+msgstr ""
+
+#: id:499
+msgid "Unable to connect to online lookup service"
+msgstr ""
+
+#: id:500
+msgid "Downloading album information failed"
+msgstr ""
+
+#: id:501
+msgid "Looking for album names..."
+msgstr ""
+
+#: id:502
+msgctxt "Auto context with id 502"
+msgid "Open"
+msgstr ""
+
+#: id:503
+msgid "Busy"
+msgstr ""
+
+#: id:504
+msgid "Empty"
+msgstr ""
+
+#: id:505
+msgid "Loading media info from files..."
+msgstr ""
+
+#: id:507
+msgid "Sort by: Usage"
+msgstr ""
+
+#: id:510
+msgid "Enable visualizations"
+msgstr ""
+
+#: id:511
+msgid "Enable video mode switching"
+msgstr ""
+
+#: id:512
+msgid "Startup window"
+msgstr ""
+
+#: id:513
+msgid "Home window"
+msgstr ""
+
+#: id:514
+msgid "Manual settings"
+msgstr ""
+
+#: id:515
+msgid "Genre"
+msgstr ""
+
+#: id:517
+msgid "Recently played albums"
+msgstr ""
+
+#: id:518
+msgid "Launch"
+msgstr ""
+
+#: id:519
+msgid "Launch in..."
+msgstr ""
+
+#: id:521
+msgid "Compilations"
+msgstr ""
+
+#: id:522
+msgid "Remove source"
+msgstr ""
+
+#: id:523
+msgid "Switch media"
+msgstr ""
+
+#: id:524
+msgid "Select playlist"
+msgstr ""
+
+#: id:525
+msgid "New playlist..."
+msgstr ""
+
+#: id:526
+msgid "Add to playlist"
+msgstr ""
+
+#: id:527
+msgid "Manually add to library"
+msgstr ""
+
+#: id:528
+msgid "Enter title"
+msgstr ""
+
+#: id:529
+msgid "Error: Duplicate title"
+msgstr ""
+
+#: id:530
+msgid "Select genre"
+msgstr ""
+
+#: id:531
+msgid "New genre"
+msgstr ""
+
+#: id:532
+msgid "Manual addition"
+msgstr ""
+
+#: id:533
+msgid "Enter genre"
+msgstr ""
+
+#: id:534
+msgid "View: %s"
+msgstr ""
+
+#: id:535
+msgid "List"
+msgstr ""
+
+#: id:536
+msgid "Icons"
+msgstr ""
+
+#: id:537
+msgid "Big list"
+msgstr ""
+
+#: id:538
+msgid "Big icons"
+msgstr ""
+
+#: id:539
+msgid "Wide"
+msgstr ""
+
+#: id:540
+msgid "Big wide"
+msgstr ""
+
+#: id:541
+msgid "Album icons"
+msgstr ""
+
+#: id:542
+msgid "DVD icons"
+msgstr ""
+
+#: id:543
+msgctxt "Auto context with id 543"
+msgid "DVD"
+msgstr ""
+
+#: id:544
+msgctxt "Auto context with id 544"
+msgid "Media info"
+msgstr ""
+
+#: id:545
+msgid "Audio output device"
+msgstr ""
+
+#: id:546
+msgid "Passthrough output device"
+msgstr ""
+
+#: id:547
+msgid "No biography for this artist"
+msgstr ""
+
+#: id:548
+msgid "Downmix multichannel audio to stereo"
+msgstr ""
+
+#: id:550
+msgid "Sort by: %s"
+msgstr ""
+
+#: id:551
+msgctxt "Auto context with id 551"
+msgid "Name"
+msgstr ""
+
+#: id:552
+msgid "Date"
+msgstr ""
+
+#: id:553
+msgid "Size"
+msgstr ""
+
+#: id:554
+msgid "Track"
+msgstr ""
+
+#: id:555
+msgid "Time"
+msgstr ""
+
+#: id:556
+msgctxt "Auto context with id 556"
+msgid "Title"
+msgstr ""
+
+#: id:557
+msgid "Artist"
+msgstr ""
+
+#: id:558
+msgid "Album"
+msgstr ""
+
+#: id:559
+msgid "Playlist"
+msgstr ""
+
+#: id:560
+msgid "ID"
+msgstr ""
+
+#: id:561
+msgctxt "Auto context with id 561"
+msgid "File"
+msgstr ""
+
+#: id:562
+msgctxt "Auto context with id 562"
+msgid "Year"
+msgstr ""
+
+#: id:563
+msgid "Rating"
+msgstr ""
+
+#: id:564
+msgctxt "Auto context with id 564"
+msgid "Type"
+msgstr ""
+
+#: id:565
+msgid "Usage"
+msgstr ""
+
+#: id:566
+msgid "Album artist"
+msgstr ""
+
+#: id:567
+msgid "Play count"
+msgstr ""
+
+#: id:568
+msgid "Last played"
+msgstr ""
+
+#: id:569
+msgctxt "Auto context with id 569"
+msgid "Comment"
+msgstr ""
+
+#: id:570
+msgid "Date added"
+msgstr ""
+
+#: id:571
+msgctxt "Auto context with id 571"
+msgid "Default"
+msgstr ""
+
+#: id:572
+msgid "Studio"
+msgstr ""
+
+#: id:573
+msgid "Path"
+msgstr ""
+
+#: id:574
+msgctxt "Auto context with id 574"
+msgid "Country"
+msgstr ""
+
+#: id:575
+msgid "In progress"
+msgstr ""
+
+#: id:576
+msgid "Times played"
+msgstr ""
+
+#: id:580
+msgid "Sort direction"
+msgstr ""
+
+#: id:581
+msgid "Sort method"
+msgstr ""
+
+#: id:582
+msgctxt "Auto context with id 582"
+msgid "View mode"
+msgstr ""
+
+#: id:583
+msgid "Remember views for different folders"
+msgstr ""
+
+#: id:584
+msgid "Ascending"
+msgstr ""
+
+#: id:585
+msgid "Descending"
+msgstr ""
+
+#: id:586
+msgid "Edit playlist"
+msgstr ""
+
+#: id:587
+msgid "Filter"
+msgstr ""
+
+#: id:588
+msgid "Cancel party mode"
+msgstr ""
+
+#: id:589
+msgid "Party mode"
+msgstr ""
+
+#: id:590
+msgid "Random"
+msgstr ""
+
+#: id:591
+msgctxt "Auto context with id 591"
+msgid "Off"
+msgstr ""
+
+#: id:592
+msgid "One"
+msgstr ""
+
+#: id:593
+msgid "All"
+msgstr ""
+
+#: id:594
+msgctxt "Auto context with id 594"
+msgid "Off"
+msgstr ""
+
+#: id:595
+msgid "Repeat: Off"
+msgstr ""
+
+#: id:596
+msgid "Repeat: One"
+msgstr ""
+
+#: id:597
+msgid "Repeat: All"
+msgstr ""
+
+#: id:600
+msgid "Rip audio CD"
+msgstr ""
+
+#: id:601
+msgctxt "Auto context with id 601"
+msgid "Medium"
+msgstr ""
+
+#: id:602
+msgctxt "Auto context with id 602"
+msgid "Standard"
+msgstr ""
+
+#: id:603
+msgid "Extreme"
+msgstr ""
+
+#: id:604
+msgid "Constant bitrate"
+msgstr ""
+
+#: id:605
+msgid "Ripping..."
+msgstr ""
+
+#: id:607
+msgid "To:"
+msgstr ""
+
+#: id:608
+msgid "Could not rip CD or track"
+msgstr ""
+
+#: id:609
+msgid "CDDARipPath is not set."
+msgstr ""
+
+#: id:610
+msgid "Rip audio track"
+msgstr ""
+
+#: id:611
+msgid "Enter number"
+msgstr ""
+
+#: id:612
+msgid "Bits/Sample"
+msgstr ""
+
+#: id:613
+msgid "Sample Frequency"
+msgstr ""
+
+#: id:620
+msgid "Audio CDs"
+msgstr ""
+
+#: id:621
+msgid "Encoder"
+msgstr ""
+
+#: id:622
+msgid "Quality"
+msgstr ""
+
+#: id:623
+msgid "Bitrate"
+msgstr ""
+
+#: id:624
+msgid "Include track number"
+msgstr ""
+
+#: id:625
+msgid "All songs of"
+msgstr ""
+
+#: id:629
+msgctxt "Auto context with id 629"
+msgid "View mode"
+msgstr ""
+
+#: id:630
+msgctxt "Auto context with id 630"
+msgid "Normal"
+msgstr ""
+
+#: id:631
+msgid "Zoom"
+msgstr ""
+
+#: id:632
+msgid "Stretch 4:3"
+msgstr ""
+
+#: id:633
+msgid "Wide Zoom"
+msgstr ""
+
+#: id:634
+msgid "Stretch 16:9"
+msgstr ""
+
+#: id:635
+msgid "Original Size"
+msgstr ""
+
+#: id:636
+msgctxt "Auto context with id 636"
+msgid "Custom"
+msgstr ""
+
+#: id:637
+msgid "Replay gain"
+msgstr ""
+
+#: id:638
+msgid "Replaygain volume adjustments"
+msgstr ""
+
+#: id:639
+msgid "Use track levels"
+msgstr ""
+
+#: id:640
+msgid "Use album levels"
+msgstr ""
+
+#: id:641
+msgid "PreAmp Level - Replay gained files"
+msgstr ""
+
+#: id:642
+msgid "PreAmp Level - Non replay gained files"
+msgstr ""
+
+#: id:643
+msgid "Avoid clipping on replay gained files"
+msgstr ""
+
+#: id:644
+msgid "Crop black bars"
+msgstr ""
+
+#: id:645
+msgid "Need to unpack a big file. Continue?"
+msgstr ""
+
+#: id:646
+msgid "Remove from library"
+msgstr ""
+
+#: id:647
+msgid "Export video library"
+msgstr ""
+
+#: id:648
+msgid "Import video library"
+msgstr ""
+
+#: id:649
+msgid "Importing"
+msgstr ""
+
+#: id:650
+msgid "Exporting"
+msgstr ""
+
+#: id:651
+msgid "Browse for library"
+msgstr ""
+
+#: id:652
+msgid "Years"
+msgstr ""
+
+#: id:653
+msgid "Update library"
+msgstr ""
+
+#: id:654
+msgid "Show debug info"
+msgstr ""
+
+#: id:655
+msgid "Browse for executable"
+msgstr ""
+
+#: id:656
+msgid "Browse for playlist"
+msgstr ""
+
+#: id:657
+msgid "Browse for folder"
+msgstr ""
+
+#: id:658
+msgid "Song information"
+msgstr ""
+
+#: id:659
+msgid "Non-linear stretch"
+msgstr ""
+
+#: id:660
+msgid "Volume amplification"
+msgstr ""
+
+#: id:661
+msgid "Choose export folder"
+msgstr ""
+
+#: id:662
+msgid "This file is no longer available."
+msgstr ""
+
+#: id:663
+msgid "Would you like to remove it from the library?"
+msgstr ""
+
+#: id:664
+msgid "Browse for Script"
+msgstr ""
+
+#: id:665
+msgid "Compression level"
+msgstr ""
+
+#: id:700
+msgid "Cleaning up library"
+msgstr ""
+
+#: id:701
+msgid "Removing old songs from the library"
+msgstr ""
+
+#: id:702
+msgid "This path has been scanned before"
+msgstr ""
+
+#: id:705
+msgctxt "Auto context with id 705"
+msgid "Network"
+msgstr ""
+
+#: id:706
+msgid "- Server"
+msgstr ""
+
+#: id:708
+msgid "Use an HTTP proxy server to access the internet"
+msgstr ""
+
+#: id:711
+msgid "Internet Protocol (IP)"
+msgstr ""
+
+#: id:712
+msgid "Invalid port specified. Value must be between 1 and 65535."
+msgstr ""
+
+#: id:713
+msgid "HTTP proxy"
+msgstr ""
+
+#: id:715
+msgid "- Assignment"
+msgstr ""
+
+#: id:716
+msgid "Automatic (DHCP)"
+msgstr ""
+
+#: id:717
+msgid "Manual (Static)"
+msgstr ""
+
+#: id:719
+msgid "- IP address"
+msgstr ""
+
+#: id:720
+msgid "- Netmask"
+msgstr ""
+
+#: id:721
+msgid "- Default gateway"
+msgstr ""
+
+#: id:722
+msgid "- DNS server"
+msgstr ""
+
+#: id:723
+msgid "Save & restart"
+msgstr ""
+
+#: id:724
+msgid "Invalid address specified. Value must be AAA.BBB.CCC.DDD"
+msgstr ""
+
+#: id:725
+msgid "with numbers between 0 and 255."
+msgstr ""
+
+#: id:726
+msgid "Changes not saved. Continue without saving?"
+msgstr ""
+
+#: id:727
+msgid "Web server"
+msgstr ""
+
+#: id:728
+msgctxt "Auto context with id 728"
+msgid "FTP server"
+msgstr ""
+
+#: id:730
+msgid "- Port"
+msgstr ""
+
+#: id:732
+msgid "Save & apply"
+msgstr ""
+
+#: id:733
+msgid "- Password"
+msgstr ""
+
+#: id:734
+msgid "No pass"
+msgstr ""
+
+#: id:735
+msgid "- Character set"
+msgstr ""
+
+#: id:736
+msgid "- Style"
+msgstr ""
+
+#: id:737
+msgid "- Colour"
+msgstr "- Color"
+
+#: id:738
+msgctxt "Auto context with id 738"
+msgid "Normal"
+msgstr ""
+
+#: id:739
+msgid "Bold"
+msgstr ""
+
+#: id:740
+msgid "Italics"
+msgstr ""
+
+#: id:741
+msgid "Bold italics"
+msgstr ""
+
+#: id:742
+msgctxt "Auto context with id 742"
+msgid "White"
+msgstr ""
+
+#: id:743
+msgctxt "Auto context with id 743"
+msgid "Yellow"
+msgstr ""
+
+#: id:744
+msgctxt "Auto context with id 744"
+msgid "Files"
+msgstr ""
+
+#: id:745
+msgid "No scanned information for this view"
+msgstr ""
+
+#: id:746
+msgid "Please turn off library mode"
+msgstr ""
+
+#: id:747
+msgid "Error loading image"
+msgstr ""
+
+#: id:748
+msgid "Edit path"
+msgstr ""
+
+#: id:749
+msgid "Mirror image"
+msgstr ""
+
+#: id:750
+msgid "Are you sure?"
+msgstr ""
+
+#: id:751
+msgid "Removing source"
+msgstr ""
+
+#: id:754
+msgid "Add program link"
+msgstr ""
+
+#: id:755
+msgid "Edit program path"
+msgstr ""
+
+#: id:756
+msgid "Edit program name"
+msgstr ""
+
+#: id:757
+msgid "Edit path depth"
+msgstr ""
+
+#: id:759
+msgid "View: Big list"
+msgstr ""
+
+#: id:760
+msgctxt "Auto context with id 760"
+msgid "Yellow"
+msgstr ""
+
+#: id:761
+msgctxt "Auto context with id 761"
+msgid "White"
+msgstr ""
+
+#: id:762
+msgid "Blue"
+msgstr ""
+
+#: id:763
+msgid "Bright green"
+msgstr ""
+
+#: id:764
+msgid "Yellow green"
+msgstr ""
+
+#: id:765
+msgid "Cyan"
+msgstr ""
+
+#: id:766
+msgid "Light grey"
+msgstr ""
+
+#: id:767
+msgid "Grey"
+msgstr ""
+
+#: id:770
+msgid "Error %i: share not available"
+msgstr ""
+
+#: id:772
+msgctxt "Auto context with id 772"
+msgid "Audio output"
+msgstr ""
+
+#: id:773
+msgid "Seeking"
+msgstr ""
+
+#: id:774
+msgid "Slideshow folder"
+msgstr ""
+
+#: id:775
+msgid "Network interface"
+msgstr ""
+
+#: id:776
+msgid "- Wireless network name (ESSID)"
+msgstr ""
+
+#: id:777
+msgid "- Wireless password"
+msgstr ""
+
+#: id:778
+msgid "- Wireless security"
+msgstr ""
+
+#: id:779
+msgid "Save and apply network interface settings"
+msgstr ""
+
+#: id:780
+msgid "No encryption"
+msgstr ""
+
+#: id:781
+msgid "WEP"
+msgstr ""
+
+#: id:782
+msgid "WPA"
+msgstr ""
+
+#: id:783
+msgid "WPA2"
+msgstr ""
+
+#: id:784
+msgid "Applying network interface settings. Please wait."
+msgstr ""
+
+#: id:785
+msgid "Network interface restarted successfully."
+msgstr ""
+
+#: id:786
+msgid "Network interface did not start successfully."
+msgstr ""
+
+#: id:787
+msgid "Interface disabled"
+msgstr ""
+
+#: id:788
+msgid "Network interface disabled successfully."
+msgstr ""
+
+#: id:789
+msgid "Wireless network name (ESSID)"
+msgstr ""
+
+#: id:790
+msgid "Remote control"
+msgstr ""
+
+#: id:791
+msgid "Allow programs on this system to control XBMC"
+msgstr ""
+
+#: id:792
+msgctxt "Auto context with id 792"
+msgid "Port"
+msgstr ""
+
+#: id:793
+msgid "Port range"
+msgstr ""
+
+#: id:794
+msgid "Allow programs on other systems to control XBMC"
+msgstr ""
+
+#: id:795
+msgid "Initial repeat delay (ms)"
+msgstr ""
+
+#: id:796
+msgid "Continuous repeat delay (ms)"
+msgstr ""
+
+#: id:797
+msgid "Maximum number of clients"
+msgstr ""
+
+#: id:798
+msgid "Internet access"
+msgstr ""
+
+#: id:850
+msgid "Invalid port number entered"
+msgstr ""
+
+#: id:851
+msgid "Valid port range is 1-65535"
+msgstr ""
+
+#: id:852
+msgid "Valid port range is 1024-65535"
+msgstr ""
+
+#: id:998
+msgid "Add Music..."
+msgstr ""
+
+#: id:999
+msgid "Add Videos..."
+msgstr ""
+
+#: id:1000
+msgid "- Preview"
+msgstr ""
+
+#: id:1001
+msgid "Unable to connect"
+msgstr ""
+
+#: id:1002
+msgid "XBMC was unable to connect to the network location."
+msgstr ""
+
+#: id:1003
+msgid "This could be due to the network not being connected."
+msgstr ""
+
+#: id:1004
+msgid "Would you like to add it anyway?"
+msgstr ""
+
+#: id:1006
+msgctxt "Auto context with id 1006"
+msgid "IP address"
+msgstr ""
+
+#: id:1007
+msgid "Add network location"
+msgstr ""
+
+#: id:1008
+msgid "Protocol"
+msgstr ""
+
+#: id:1009
+msgid "Server address"
+msgstr ""
+
+#: id:1010
+msgid "Server name"
+msgstr ""
+
+#: id:1011
+msgid "Remote path"
+msgstr ""
+
+#: id:1012
+msgid "Shared folder"
+msgstr ""
+
+#: id:1013
+msgctxt "Auto context with id 1013"
+msgid "Port"
+msgstr ""
+
+#: id:1014
+msgctxt "Auto context with id 1014"
+msgid "Username"
+msgstr ""
+
+#: id:1015
+msgid "Browse for network server"
+msgstr ""
+
+#: id:1016
+msgid "Enter the network address of the server"
+msgstr ""
+
+#: id:1017
+msgid "Enter the path on the server"
+msgstr ""
+
+#: id:1018
+msgid "Enter the port number"
+msgstr ""
+
+#: id:1019
+msgid "Enter the username"
+msgstr ""
+
+#: id:1020
+msgid "Add %s source"
+msgstr ""
+
+#: id:1021
+msgid "Enter the paths or browse for the media locations."
+msgstr ""
+
+#: id:1022
+msgid "Enter a name for this media Source."
+msgstr ""
+
+#: id:1023
+msgid "Browse for new share"
+msgstr ""
+
+#: id:1024
+msgid "Browse"
+msgstr ""
+
+#: id:1025
+msgid "Could not retrieve directory information."
+msgstr ""
+
+#: id:1026
+msgid "Add source"
+msgstr ""
+
+#: id:1027
+msgid "Edit source"
+msgstr ""
+
+#: id:1028
+msgid "Edit %s source"
+msgstr ""
+
+#: id:1029
+msgid "Enter the new label"
+msgstr ""
+
+#: id:1030
+msgid "Browse for image"
+msgstr ""
+
+#: id:1031
+msgid "Browse for image folder"
+msgstr ""
+
+#: id:1032
+msgid "Add network location..."
+msgstr ""
+
+#: id:1033
+msgid "Browse for file"
+msgstr ""
+
+#: id:1034
+msgid "Submenu"
+msgstr ""
+
+#: id:1035
+msgid "Enable submenu buttons"
+msgstr ""
+
+#: id:1036
+msgid "Favourites"
+msgstr "Favorites"
+
+#: id:1037
+msgid "Video Add-ons"
+msgstr ""
+
+#: id:1038
+msgid "Music Add-ons"
+msgstr ""
+
+#: id:1039
+msgid "Picture Add-ons"
+msgstr ""
+
+#: id:1040
+msgid "Loading directory"
+msgstr ""
+
+#: id:1041
+msgid "Retrieved %i items"
+msgstr ""
+
+#: id:1042
+msgid "Retrieved %i of %i items"
+msgstr ""
+
+#: id:1043
+msgid "Program Add-ons"
+msgstr ""
+
+#: id:1044
+msgid "Set plugin thumb"
+msgstr ""
+
+#: id:1045
+msgid "Add-on settings"
+msgstr ""
+
+#: id:1046
+msgid "Access points"
+msgstr ""
+
+#: id:1047
+msgid "Other..."
+msgstr ""
+
+#: id:1048
+msgid "- Username"
+msgstr ""
+
+#: id:1049
+msgid "Script settings"
+msgstr ""
+
+#: id:1050
+msgid "Singles"
+msgstr ""
+
+#: id:1051
+msgid "Enter web address"
+msgstr ""
+
+#: id:1200
+msgid "SMB client"
+msgstr ""
+
+#: id:1202
+msgid "Workgroup"
+msgstr ""
+
+#: id:1203
+msgid "Default username"
+msgstr ""
+
+#: id:1204
+msgid "Default password"
+msgstr ""
+
+#: id:1207
+msgid "WINS server"
+msgstr ""
+
+#: id:1208
+msgid "Mount SMB shares"
+msgstr ""
+
+#: id:1210
+msgctxt "Auto context with id 1210"
+msgid "Remove"
+msgstr ""
+
+#: id:1211
+msgctxt "Auto context with id 1211"
+msgid "Music"
+msgstr ""
+
+#: id:1212
+msgctxt "Auto context with id 1212"
+msgid "Video"
+msgstr ""
+
+#: id:1213
+msgctxt "Auto context with id 1213"
+msgid "Pictures"
+msgstr ""
+
+#: id:1214
+msgctxt "Auto context with id 1214"
+msgid "Files"
+msgstr ""
+
+#: id:1215
+msgctxt "Auto context with id 1215"
+msgid "Music & video"
+msgstr ""
+
+#: id:1216
+msgid "Music & pictures"
+msgstr ""
+
+#: id:1217
+msgid "Music & files"
+msgstr ""
+
+#: id:1218
+msgid "Video & pictures"
+msgstr ""
+
+#: id:1219
+msgid "Video & files"
+msgstr ""
+
+#: id:1220
+msgid "Pictures & files"
+msgstr ""
+
+#: id:1221
+msgid "Music & video & pictures"
+msgstr ""
+
+#: id:1222
+msgid "Music & video & pictures & files"
+msgstr ""
+
+#: id:1223
+msgctxt "Auto context with id 1223"
+msgid "Disabled"
+msgstr ""
+
+#: id:1226
+msgid "Files & music & video"
+msgstr ""
+
+#: id:1227
+msgid "Files & pictures & music"
+msgstr ""
+
+#: id:1228
+msgid "Files & pictures & video"
+msgstr ""
+
+#: id:1229
+msgid "Music & programs"
+msgstr ""
+
+#: id:1230
+msgid "Video & programs"
+msgstr ""
+
+#: id:1231
+msgid "Pictures & programs"
+msgstr ""
+
+#: id:1232
+msgid "Music & video & pictures & programs"
+msgstr ""
+
+#: id:1233
+msgid "Programs & video & music"
+msgstr ""
+
+#: id:1234
+msgid "Programs & pictures & music"
+msgstr ""
+
+#: id:1235
+msgid "Programs & pictures & video"
+msgstr ""
+
+#: id:1250
+msgid "Auto-detection"
+msgstr ""
+
+#: id:1251
+msgid "Auto-detect system"
+msgstr ""
+
+#: id:1252
+msgid "Nickname"
+msgstr ""
+
+#: id:1254
+msgid "Ask to connect"
+msgstr ""
+
+#: id:1255
+msgid "Send FTP user and password"
+msgstr ""
+
+#: id:1256
+msgid "Ping interval"
+msgstr ""
+
+#: id:1257
+msgid "Would you like to connect to the auto-detected system?"
+msgstr ""
+
+#: id:1259
+msgid "Zeroconf"
+msgstr ""
+
+#: id:1260
+msgid "Announce these services to other systems via Zeroconf"
+msgstr ""
+
+#: id:1270
+msgid "Allow XBMC to receive AirPlay content"
+msgstr ""
+
+#: id:1271
+msgid "Device name"
+msgstr ""
+
+#: id:1272
+msgid "- Use password protection"
+msgstr ""
+
+#: id:1273
+msgid "AirPlay"
+msgstr ""
+
+#: id:1300
+msgid "Custom audio device"
+msgstr ""
+
+#: id:1301
+msgid "Custom passthrough device"
+msgstr ""
+
+#: id:1396
+msgid "Drifting"
+msgstr ""
+
+#: id:1397
+msgid "and"
+msgstr ""
+
+#: id:1398
+msgid "Freezing"
+msgstr ""
+
+#: id:1399
+msgid "Late"
+msgstr ""
+
+#: id:1400
+msgid "Isolated"
+msgstr ""
+
+#: id:1401
+msgid "Thundershowers"
+msgstr ""
+
+#: id:1402
+msgid "Thunder"
+msgstr ""
+
+#: id:1403
+msgctxt "Auto context with id 1403"
+msgid "Sun"
+msgstr ""
+
+#: id:1404
+msgid "Heavy"
+msgstr ""
+
+#: id:1405
+msgid "in"
+msgstr ""
+
+#: id:1406
+msgid "the"
+msgstr ""
+
+#: id:1407
+msgid "Vicinity"
+msgstr ""
+
+#: id:1408
+msgid "Ice"
+msgstr ""
+
+#: id:1409
+msgid "Crystals"
+msgstr ""
+
+#: id:1410
+msgid "Calm"
+msgstr ""
+
+#: id:1411
+msgid "with"
+msgstr ""
+
+#: id:1412
+msgid "windy"
+msgstr ""
+
+#: id:1413
+msgid "drizzle"
+msgstr ""
+
+#: id:1414
+msgid "Thunderstorm"
+msgstr ""
+
+#: id:1415
+msgid "Drizzle"
+msgstr ""
+
+#: id:1416
+msgid "Foggy"
+msgstr ""
+
+#: id:1417
+msgid "Grains"
+msgstr ""
+
+#: id:1418
+msgid "T-Storms"
+msgstr ""
+
+#: id:1419
+msgid "T-Showers"
+msgstr ""
+
+#: id:1420
+msgid "Moderate"
+msgstr ""
+
+#: id:1421
+msgid "Very High"
+msgstr ""
+
+#: id:1422
+msgid "Windy"
+msgstr ""
+
+#: id:1423
+msgid "Mist"
+msgstr ""
+
+#: id:1450
+msgid "Put display to sleep when idle"
+msgstr ""
+
+#: id:2050
+msgid "Runtime"
+msgstr ""
+
+#: id:2100
+msgid "Script failed! : %s"
+msgstr ""
+
+#: id:2101
+msgid "Newer version needed - See log"
+msgstr ""
+
+#: id:4501
+msgid "Enable LCD/VFD"
+msgstr ""
+
+#: id:10000
+msgid "Home"
+msgstr ""
+
+#: id:10001
+msgctxt "Auto context with id 10001"
+msgid "Programs"
+msgstr ""
+
+#: id:10002
+msgctxt "Auto context with id 10002"
+msgid "Pictures"
+msgstr ""
+
+#: id:10003
+msgctxt "Auto context with id 10003"
+msgid "File manager"
+msgstr ""
+
+#: id:10004
+msgctxt "Auto context with id 10004"
+msgid "Settings"
+msgstr ""
+
+#: id:10005
+msgctxt "Auto context with id 10005"
+msgid "Music"
+msgstr ""
+
+#: id:10006
+msgctxt "Auto context with id 10006"
+msgid "Videos"
+msgstr ""
+
+#: id:10007
+msgid "System information"
+msgstr ""
+
+#: id:10008
+msgid "Settings - General"
+msgstr ""
+
+#: id:10009
+msgid "Settings - Screen"
+msgstr ""
+
+#: id:10010
+msgid "Settings - Appearance - GUI Calibration"
+msgstr ""
+
+#: id:10011
+msgid "Settings - Videos - Screen Calibration"
+msgstr ""
+
+#: id:10012
+msgid "Settings - Pictures"
+msgstr ""
+
+#: id:10013
+msgid "Settings - Programs"
+msgstr ""
+
+#: id:10014
+msgid "Settings - Weather"
+msgstr ""
+
+#: id:10015
+msgid "Settings - Music"
+msgstr ""
+
+#: id:10016
+msgid "Settings - System"
+msgstr ""
+
+#: id:10017
+msgid "Settings - Videos"
+msgstr ""
+
+#: id:10018
+msgid "Settings - Network"
+msgstr ""
+
+#: id:10019
+msgid "Settings - Appearance"
+msgstr ""
+
+#: id:10020
+msgctxt "Auto context with id 10020"
+msgid "Scripts"
+msgstr ""
+
+#: id:10021
+msgid "Web Browser"
+msgstr ""
+
+#: id:10025
+msgctxt "Auto context with id 10025"
+msgid "Videos"
+msgstr ""
+
+#: id:10028
+msgid "Videos/Playlist"
+msgstr ""
+
+#: id:10029
+msgctxt "Auto context with id 10029"
+msgid "Login screen"
+msgstr ""
+
+#: id:10034
+msgid "Settings - Profiles"
+msgstr ""
+
+#: id:10040
+msgid "Addon browser"
+msgstr ""
+
+#: id:10100
+msgid "Yes/No dialog"
+msgstr ""
+
+#: id:10101
+msgid "Progress dialog"
+msgstr ""
+
+#: id:10210
+msgid "Looking for subtitles..."
+msgstr ""
+
+#: id:10211
+msgid "Looking for or caching subtitles..."
+msgstr ""
+
+#: id:10212
+msgid "terminating"
+msgstr ""
+
+#: id:10213
+msgid "buffering"
+msgstr ""
+
+#: id:10214
+msgid "Opening stream"
+msgstr ""
+
+#: id:10500
+msgid "Music/Playlist"
+msgstr ""
+
+#: id:10501
+msgid "Music/Files"
+msgstr ""
+
+#: id:10502
+msgid "Music/Library"
+msgstr ""
+
+#: id:10503
+msgid "Playlist editor"
+msgstr ""
+
+#: id:10504
+msgid "Top 100 songs"
+msgstr ""
+
+#: id:10505
+msgid "Top 100 albums"
+msgstr ""
+
+#: id:10506
+msgctxt "Auto context with id 10506"
+msgid "Programs"
+msgstr ""
+
+#: id:10507
+msgid "Configuration"
+msgstr ""
+
+#: id:10508
+msgid "Weather forecast"
+msgstr ""
+
+#: id:10509
+msgid "Network gaming"
+msgstr ""
+
+#: id:10510
+msgid "Extensions"
+msgstr ""
+
+#: id:10511
+msgctxt "Auto context with id 10511"
+msgid "System info"
+msgstr ""
+
+#: id:10516
+msgid "Music - Library"
+msgstr ""
+
+#: id:10517
+msgid "Now Playing - Music"
+msgstr ""
+
+#: id:10522
+msgid "Now Playing - Videos"
+msgstr ""
+
+#: id:10523
+msgid "Album info"
+msgstr ""
+
+#: id:10524
+msgid "Movie info"
+msgstr ""
+
+#: id:12000
+msgid "Select dialog"
+msgstr ""
+
+#: id:12001
+msgid "Music/Info"
+msgstr ""
+
+#: id:12002
+msgid "Dialog OK"
+msgstr ""
+
+#: id:12003
+msgid "Videos/Info"
+msgstr ""
+
+#: id:12004
+msgid "Scripts/Info"
+msgstr ""
+
+#: id:12005
+msgid "Fullscreen video"
+msgstr ""
+
+#: id:12006
+msgid "Audio visualization"
+msgstr ""
+
+#: id:12008
+msgid "File stacking dialog"
+msgstr ""
+
+#: id:12009
+msgid "Rebuild index..."
+msgstr ""
+
+#: id:12010
+msgid "Return to music window"
+msgstr ""
+
+#: id:12011
+msgid "Return to videos window"
+msgstr ""
+
+#: id:12021
+msgid "Start from beginning"
+msgstr ""
+
+#: id:12022
+msgid "Resume from %s"
+msgstr ""
+
+#: id:12310
+msgid "0"
+msgstr ""
+
+#: id:12311
+msgid "1"
+msgstr ""
+
+#: id:12312
+msgid "2"
+msgstr ""
+
+#: id:12313
+msgid "3"
+msgstr ""
+
+#: id:12314
+msgid "4"
+msgstr ""
+
+#: id:12315
+msgid "5"
+msgstr ""
+
+#: id:12316
+msgid "6"
+msgstr ""
+
+#: id:12317
+msgid "7"
+msgstr ""
+
+#: id:12318
+msgid "8"
+msgstr ""
+
+#: id:12319
+msgid "9"
+msgstr ""
+
+#: id:12320
+msgid "c"
+msgstr ""
+
+#: id:12321
+msgid "Ok"
+msgstr ""
+
+#: id:12322
+msgid "*"
+msgstr ""
+
+#: id:12325
+msgid "Locked! Enter code..."
+msgstr ""
+
+#: id:12326
+msgid "Enter password"
+msgstr ""
+
+#: id:12327
+msgid "Enter master code"
+msgstr ""
+
+#: id:12328
+msgid "Enter unlock code"
+msgstr ""
+
+#: id:12329
+msgid "or press C to cancel"
+msgstr ""
+
+#: id:12330
+msgid "Enter gamepad button combo and"
+msgstr ""
+
+#: id:12331
+msgid "press OK, or Back to cancel"
+msgstr ""
+
+#: id:12332
+msgid "Set lock"
+msgstr ""
+
+#: id:12333
+msgid "Unlock"
+msgstr ""
+
+#: id:12334
+msgid "Reset lock"
+msgstr ""
+
+#: id:12335
+msgid "Remove lock"
+msgstr ""
+
+#: id:12337
+msgid "Numeric password"
+msgstr ""
+
+#: id:12338
+msgid "Gamepad button combo"
+msgstr ""
+
+#: id:12339
+msgid "Full-text password"
+msgstr ""
+
+#: id:12340
+msgid "Enter new password"
+msgstr ""
+
+#: id:12341
+msgid "Re-Enter new password"
+msgstr ""
+
+#: id:12342
+msgid "Incorrect password,"
+msgstr ""
+
+#: id:12343
+msgid "retries left"
+msgstr ""
+
+#: id:12344
+msgid "Passwords entered did not match."
+msgstr ""
+
+#: id:12345
+msgid "Access denied"
+msgstr ""
+
+#: id:12346
+msgid "Password retry limit exceeded."
+msgstr ""
+
+#: id:12347
+msgid "The system will now shut off."
+msgstr ""
+
+#: id:12348
+msgid "Item locked"
+msgstr ""
+
+#: id:12353
+msgid "Reactivate lock"
+msgstr ""
+
+#: id:12356
+msgid "Change lock"
+msgstr ""
+
+#: id:12357
+msgid "Source lock"
+msgstr ""
+
+#: id:12358
+msgid "Password entry was blank. Try again."
+msgstr ""
+
+#: id:12360
+msgid "Master lock"
+msgstr ""
+
+#: id:12362
+msgid "Shutdown system if Master Lock retries exceeded"
+msgstr ""
+
+#: id:12367
+msgid "Master code is not valid"
+msgstr ""
+
+#: id:12368
+msgid "Please enter a valid master code"
+msgstr ""
+
+#: id:12373
+msgid "Settings & file manager"
+msgstr ""
+
+#: id:12376
+msgid "Set as default for all movies"
+msgstr ""
+
+#: id:12377
+msgid "This will reset any previously saved values"
+msgstr ""
+
+#: id:12378
+msgid "Amount of time to display each image"
+msgstr ""
+
+#: id:12379
+msgid "Use pan and zoom effects"
+msgstr ""
+
+#: id:12383
+msgid "12 hour clock"
+msgstr ""
+
+#: id:12384
+msgid "24 hour clock"
+msgstr ""
+
+#: id:12385
+msgid "Day/Month"
+msgstr ""
+
+#: id:12386
+msgid "Month/Day"
+msgstr ""
+
+#: id:12390
+msgid "System uptime"
+msgstr ""
+
+#: id:12391
+msgid "Minutes"
+msgstr ""
+
+#: id:12392
+msgid "Hours"
+msgstr ""
+
+#: id:12393
+msgid "Days"
+msgstr ""
+
+#: id:12394
+msgid "Total uptime"
+msgstr ""
+
+#: id:12395
+msgid "Battery level"
+msgstr ""
+
+#: id:12600
+msgctxt "Auto context with id 12600"
+msgid "Weather"
+msgstr ""
+
+#: id:12900
+msgctxt "Auto context with id 12900"
+msgid "Screensaver"
+msgstr ""
+
+#: id:12901
+msgid "Fullscreen OSD"
+msgstr ""
+
+#: id:13000
+msgid "System"
+msgstr ""
+
+#: id:13001
+msgid "Immediate HD spindown"
+msgstr ""
+
+#: id:13002
+msgid "Video only"
+msgstr ""
+
+#: id:13003
+msgid "- Delay"
+msgstr ""
+
+#: id:13004
+msgid "- Minimum file duration"
+msgstr ""
+
+#: id:13005
+msgid "Shutdown"
+msgstr ""
+
+#: id:13008
+msgid "Shutdown function"
+msgstr ""
+
+#: id:13009
+msgid "Quit"
+msgstr ""
+
+#: id:13010
+msgid "Hibernate"
+msgstr ""
+
+#: id:13011
+msgid "Suspend"
+msgstr ""
+
+#: id:13012
+msgid "Exit"
+msgstr ""
+
+#: id:13013
+msgid "Reboot"
+msgstr ""
+
+#: id:13014
+msgid "Minimize"
+msgstr ""
+
+#: id:13015
+msgid "Power button action"
+msgstr ""
+
+#: id:13016
+msgid "Power off System"
+msgstr ""
+
+#: id:13020
+msgid "Is another session active, perhaps over ssh?"
+msgstr ""
+
+#: id:13021
+msgid "Mounted removable harddrive"
+msgstr ""
+
+#: id:13022
+msgid "Unsafe device removal"
+msgstr ""
+
+#: id:13023
+msgid "Successfully removed device"
+msgstr ""
+
+#: id:13024
+msgid "Joystick plugged"
+msgstr ""
+
+#: id:13025
+msgid "Joystick unplugged"
+msgstr ""
+
+#: id:13050
+msgid "Running low on battery"
+msgstr ""
+
+#: id:13100
+msgid "Flicker filter"
+msgstr ""
+
+#: id:13101
+msgid "Let driver choose (requires restart)"
+msgstr ""
+
+#: id:13105
+msgid "Vertical blank sync"
+msgstr ""
+
+#: id:13106
+msgctxt "Auto context with id 13106"
+msgid "Disabled"
+msgstr ""
+
+#: id:13107
+msgid "Enabled during video playback"
+msgstr ""
+
+#: id:13108
+msgctxt "Auto context with id 13108"
+msgid "Always enabled"
+msgstr ""
+
+#: id:13109
+msgid "Test & apply resolution"
+msgstr ""
+
+#: id:13110
+msgid "Save resolution?"
+msgstr ""
+
+#: id:13111
+msgid "Would you like to keep this resolution?"
+msgstr ""
+
+#: id:13112
+msgid "High quality upscaling"
+msgstr ""
+
+#: id:13113
+msgctxt "Auto context with id 13113"
+msgid "Disabled"
+msgstr ""
+
+#: id:13114
+msgid "Enabled for SD content"
+msgstr ""
+
+#: id:13115
+msgctxt "Auto context with id 13115"
+msgid "Always enabled"
+msgstr ""
+
+#: id:13116
+msgid "Upscaling method"
+msgstr ""
+
+#: id:13117
+msgctxt "Auto context with id 13117"
+msgid "Bicubic"
+msgstr ""
+
+#: id:13118
+msgid "Lanczos"
+msgstr ""
+
+#: id:13119
+msgid "Sinc"
+msgstr ""
+
+#: id:13120
+msgctxt "Auto context with id 13120"
+msgid "VDPAU"
+msgstr ""
+
+#: id:13121
+msgid "VDPAU HQ Upscaling level"
+msgstr ""
+
+#: id:13122
+msgid "VDPAU Studio level color conversion"
+msgstr ""
+
+#: id:13130
+msgid "Blank other displays"
+msgstr ""
+
+#: id:13131
+msgctxt "Auto context with id 13131"
+msgid "Disabled"
+msgstr ""
+
+#: id:13132
+msgid "Blank displays"
+msgstr ""
+
+#: id:13140
+msgid "Active connections detected!"
+msgstr ""
+
+#: id:13141
+msgid "If you proceed, you might not be able to control XBMC"
+msgstr ""
+
+#: id:13142
+msgid "any longer. Are you sure you want to stop the Event server?"
+msgstr ""
+
+#: id:13144
+msgid "Change Apple Remote mode?"
+msgstr ""
+
+#: id:13145
+msgid "If you are currently using the Apple Remote to control"
+msgstr ""
+
+#: id:13146
+msgid "XBMC, changing this setting might affect your ability"
+msgstr ""
+
+#: id:13147
+msgid "to continue controlling it. Do you want to proceed?"
+msgstr ""
+
+#: id:13159
+msgid "Subnet mask"
+msgstr ""
+
+#: id:13160
+msgid "Gateway"
+msgstr ""
+
+#: id:13161
+msgid "Primary DNS"
+msgstr ""
+
+#: id:13162
+msgid "Initialize failed"
+msgstr ""
+
+#: id:13170
+msgctxt "Auto context with id 13170"
+msgid "Never"
+msgstr ""
+
+#: id:13171
+msgid "Immediately"
+msgstr ""
+
+#: id:13172
+msgid "After %i secs"
+msgstr ""
+
+#: id:13173
+msgid "HDD install date:"
+msgstr ""
+
+#: id:13174
+msgid "HDD power cycle count:"
+msgstr ""
+
+#: id:13200
+msgid "Profiles"
+msgstr ""
+
+#: id:13201
+msgid "Delete profile '%s'?"
+msgstr ""
+
+#: id:13204
+msgid "Last loaded profile:"
+msgstr ""
+
+#: id:13205
+msgid "Unknown"
+msgstr ""
+
+#: id:13206
+msgid "Overwrite"
+msgstr ""
+
+#: id:13208
+msgid "Alarm clock"
+msgstr ""
+
+#: id:13209
+msgid "Alarm clock interval (in minutes)"
+msgstr ""
+
+#: id:13210
+msgid "Started, alarm in %im"
+msgstr ""
+
+#: id:13211
+msgid "Alarm!"
+msgstr ""
+
+#: id:13212
+msgid "Canceled with %im%is left"
+msgstr ""
+
+#: id:13213
+msgid "%2.0fm"
+msgstr ""
+
+#: id:13214
+msgid "%2.0fs"
+msgstr ""
+
+#: id:13249
+msgid "Search for subtitles in RARs"
+msgstr ""
+
+#: id:13250
+msgid "Browse for subtitle..."
+msgstr ""
+
+#: id:13251
+msgid "Move item"
+msgstr ""
+
+#: id:13252
+msgid "Move item here"
+msgstr ""
+
+#: id:13253
+msgid "Cancel move"
+msgstr ""
+
+#: id:13270
+msgid "Hardware:"
+msgstr ""
+
+#: id:13271
+msgid "CPU Usage:"
+msgstr ""
+
+#: id:13274
+msgid "Connected, but no DNS is available."
+msgstr ""
+
+#: id:13275
+msgid "Hard Disk"
+msgstr ""
+
+#: id:13276
+msgid "DVD-ROM"
+msgstr ""
+
+#: id:13277
+msgctxt "Auto context with id 13277"
+msgid "Storage"
+msgstr ""
+
+#: id:13278
+msgctxt "Auto context with id 13278"
+msgid "Default"
+msgstr ""
+
+#: id:13279
+msgctxt "Auto context with id 13279"
+msgid "Network"
+msgstr ""
+
+#: id:13280
+msgctxt "Auto context with id 13280"
+msgid "Video"
+msgstr ""
+
+#: id:13281
+msgid "Hardware"
+msgstr ""
+
+#: id:13283
+msgid "Operating system:"
+msgstr ""
+
+#: id:13284
+msgid "CPU speed:"
+msgstr ""
+
+#: id:13286
+msgid "Video encoder:"
+msgstr ""
+
+#: id:13287
+msgid "Screen resolution:"
+msgstr ""
+
+#: id:13292
+msgid "A/V cable:"
+msgstr ""
+
+#: id:13294
+msgid "DVD region:"
+msgstr ""
+
+#: id:13295
+msgid "Internet:"
+msgstr ""
+
+#: id:13296
+msgctxt "Auto context with id 13296"
+msgid "Connected"
+msgstr ""
+
+#: id:13297
+msgid "Not connected. Check network settings."
+msgstr ""
+
+#: id:13299
+msgid "Target temperature"
+msgstr ""
+
+#: id:13300
+msgid "Fan speed"
+msgstr ""
+
+#: id:13301
+msgid "Auto temperature control"
+msgstr ""
+
+#: id:13302
+msgid "Fan speed override"
+msgstr ""
+
+#: id:13303
+msgid "- Fonts"
+msgstr ""
+
+#: id:13304
+msgid "Enable flipping bi-directional strings"
+msgstr ""
+
+#: id:13305
+msgid "Show RSS news feeds"
+msgstr ""
+
+#: id:13306
+msgid "Show parent folder items"
+msgstr ""
+
+#: id:13307
+msgid "Track naming template"
+msgstr ""
+
+#: id:13308
+msgid "Do you wish to reboot your system"
+msgstr ""
+
+#: id:13309
+msgid "instead of just XBMC?"
+msgstr ""
+
+#: id:13310
+msgid "Zoom effect"
+msgstr ""
+
+#: id:13311
+msgid "Float effect"
+msgstr ""
+
+#: id:13312
+msgid "Black bar reduction"
+msgstr ""
+
+#: id:13313
+msgid "Restart"
+msgstr ""
+
+#: id:13314
+msgid "Crossfade between songs"
+msgstr ""
+
+#: id:13315
+msgid "Regenerate thumbnails"
+msgstr ""
+
+#: id:13316
+msgid "Recursive thumbnails"
+msgstr ""
+
+#: id:13317
+msgid "View slideshow"
+msgstr ""
+
+#: id:13318
+msgid "Recursive slideshow"
+msgstr ""
+
+#: id:13319
+msgid "Randomize"
+msgstr ""
+
+#: id:13320
+msgid "Stereo"
+msgstr ""
+
+#: id:13321
+msgid "Left only"
+msgstr ""
+
+#: id:13322
+msgid "Right only"
+msgstr ""
+
+#: id:13323
+msgid "Enable karaoke support"
+msgstr ""
+
+#: id:13324
+msgid "Background transparency"
+msgstr ""
+
+#: id:13325
+msgid "Foreground transparency"
+msgstr ""
+
+#: id:13326
+msgid "A/V delay"
+msgstr ""
+
+#: id:13327
+msgid "Karaoke"
+msgstr ""
+
+#: id:13328
+msgid "%s not found"
+msgstr ""
+
+#: id:13329
+msgid "Error opening %s"
+msgstr ""
+
+#: id:13330
+msgid "Unable to load %s"
+msgstr ""
+
+#: id:13331
+msgid "Error: Out of memory"
+msgstr ""
+
+#: id:13332
+msgid "Move up"
+msgstr ""
+
+#: id:13333
+msgid "Move down"
+msgstr ""
+
+#: id:13334
+msgid "Edit label"
+msgstr ""
+
+#: id:13335
+msgid "Make default"
+msgstr ""
+
+#: id:13336
+msgid "Remove button"
+msgstr ""
+
+#: id:13340
+msgid "Leave as is"
+msgstr ""
+
+#: id:13341
+msgid "Green"
+msgstr ""
+
+#: id:13342
+msgid "Orange"
+msgstr ""
+
+#: id:13343
+msgid "Red"
+msgstr ""
+
+#: id:13344
+msgid "Cycle"
+msgstr ""
+
+#: id:13345
+msgid "Switch LED off on playback"
+msgstr ""
+
+#: id:13346
+msgctxt "Auto context with id 13346"
+msgid "Movie information"
+msgstr ""
+
+#: id:13347
+msgid "Queue item"
+msgstr ""
+
+#: id:13348
+msgid "Search IMDb..."
+msgstr ""
+
+#: id:13349
+msgid "Scan for new content"
+msgstr ""
+
+#: id:13350
+msgid "Now playing..."
+msgstr ""
+
+#: id:13351
+msgctxt "Auto context with id 13351"
+msgid "Album information"
+msgstr ""
+
+#: id:13352
+msgid "Scan item to library"
+msgstr ""
+
+#: id:13353
+msgid "Stop scanning"
+msgstr ""
+
+#: id:13354
+msgctxt "Auto context with id 13354"
+msgid "Render method"
+msgstr ""
+
+#: id:13355
+msgid "Low quality pixel shader"
+msgstr ""
+
+#: id:13356
+msgid "Hardware overlays"
+msgstr ""
+
+#: id:13357
+msgid "High quality pixel shader"
+msgstr ""
+
+#: id:13358
+msgid "Play item"
+msgstr ""
+
+#: id:13359
+msgid "Set artist thumb"
+msgstr ""
+
+#: id:13360
+msgid "Automatically generate thumbnails"
+msgstr ""
+
+#: id:13361
+msgid "Enable voice"
+msgstr ""
+
+#: id:13375
+msgid "Enable device"
+msgstr ""
+
+#: id:13376
+msgid "Volume"
+msgstr ""
+
+#: id:13377
+msgid "Default view mode"
+msgstr ""
+
+#: id:13378
+msgid "Default brightness"
+msgstr ""
+
+#: id:13379
+msgid "Default contrast"
+msgstr ""
+
+#: id:13380
+msgid "Default gamma"
+msgstr ""
+
+#: id:13381
+msgid "Resume video"
+msgstr ""
+
+#: id:13382
+msgid "Voice mask - Port 1"
+msgstr ""
+
+#: id:13383
+msgid "Voice mask - Port 2"
+msgstr ""
+
+#: id:13384
+msgid "Voice mask - Port 3"
+msgstr ""
+
+#: id:13385
+msgid "Voice mask - Port 4"
+msgstr ""
+
+#: id:13386
+msgid "Use time based seeking"
+msgstr ""
+
+#: id:13387
+msgid "Track naming template - right"
+msgstr ""
+
+#: id:13388
+msgid "Preset"
+msgstr ""
+
+#: id:13389
+msgid "There are no presets available\nfor this visualization"
+msgstr ""
+
+#: id:13390
+msgid "There are no settings available\nfor this visualization"
+msgstr ""
+
+#: id:13391
+msgid "Eject/Load"
+msgstr ""
+
+#: id:13392
+msgid "Use visualization if playing audio"
+msgstr ""
+
+#: id:13393
+msgid "Calculate size"
+msgstr ""
+
+#: id:13394
+msgid "Calculating folder size"
+msgstr ""
+
+#: id:13395
+msgid "Video settings"
+msgstr ""
+
+#: id:13396
+msgid "Audio and subtitle settings"
+msgstr ""
+
+#: id:13397
+msgid "Enable subtitles"
+msgstr ""
+
+#: id:13398
+msgctxt "Auto context with id 13398"
+msgid "Shortcuts"
+msgstr ""
+
+#: id:13399
+msgid "Ignore articles when sorting (e.g. \"the\")"
+msgstr ""
+
+#: id:13400
+msgid "Crossfade between songs on the same album"
+msgstr ""
+
+#: id:13401
+msgid "Browse for %s"
+msgstr ""
+
+#: id:13402
+msgid "Show track position"
+msgstr ""
+
+#: id:13403
+msgid "Clear default"
+msgstr ""
+
+#: id:13404
+msgid "Resume"
+msgstr ""
+
+#: id:13405
+msgid "Get thumb"
+msgstr ""
+
+#: id:13406
+msgid "Picture information"
+msgstr ""
+
+#: id:13407
+msgid "%s presets"
+msgstr ""
+
+#: id:13408
+msgid "(IMDb user rating)"
+msgstr ""
+
+#: id:13409
+msgid "Top 250"
+msgstr ""
+
+#: id:13410
+msgid "Tune in on Last.fm"
+msgstr ""
+
+#: id:13411
+msgid "Minimum fan speed"
+msgstr ""
+
+#: id:13412
+msgid "Play from here"
+msgstr ""
+
+#: id:13413
+msgid "Downloading"
+msgstr ""
+
+#: id:13414
+msgid "Include artists who appear only on compilations"
+msgstr ""
+
+#: id:13415
+msgctxt "Auto context with id 13415"
+msgid "Render method"
+msgstr ""
+
+#: id:13416
+msgid "Auto detect"
+msgstr ""
+
+#: id:13417
+msgid "Basic shaders (ARB)"
+msgstr ""
+
+#: id:13418
+msgid "Advanced shaders (GLSL)"
+msgstr ""
+
+#: id:13419
+msgid "Software"
+msgstr ""
+
+#: id:13420
+msgid "Remove safely"
+msgstr ""
+
+#: id:13421
+msgctxt "Auto context with id 13421"
+msgid "VDPAU"
+msgstr ""
+
+#: id:13422
+msgid "Start slideshow here"
+msgstr ""
+
+#: id:13423
+msgid "Remember for this path"
+msgstr ""
+
+#: id:13424
+msgid "Use pixel buffer objects"
+msgstr ""
+
+#: id:13425
+msgid "Allow hardware acceleration (VDPAU)"
+msgstr ""
+
+#: id:13426
+msgid "Allow hardware acceleration (VAAPI)"
+msgstr ""
+
+#: id:13427
+msgid "Allow hardware acceleration (DXVA2)"
+msgstr ""
+
+#: id:13428
+msgid "Allow hardware acceleration (CrystalHD)"
+msgstr ""
+
+#: id:13429
+msgid "Allow hardware acceleration (VDADecoder)"
+msgstr ""
+
+#: id:13430
+msgid "Allow hardware acceleration (OpenMax)"
+msgstr ""
+
+#: id:13431
+msgid "Pixel Shaders"
+msgstr ""
+
+#: id:13432
+msgid "Allow hardware acceleration (VideoToolbox)"
+msgstr ""
+
+#: id:13500
+msgid "A/V sync method"
+msgstr ""
+
+#: id:13501
+msgid "Audio clock"
+msgstr ""
+
+#: id:13502
+msgid "Video clock (Drop/Dupe audio)"
+msgstr ""
+
+#: id:13503
+msgid "Video clock (Resample audio)"
+msgstr ""
+
+#: id:13504
+msgid "Maximum resample amount (%)"
+msgstr ""
+
+#: id:13505
+msgid "Resample quality"
+msgstr ""
+
+#: id:13506
+msgid "Low(fast)"
+msgstr ""
+
+#: id:13507
+msgctxt "Auto context with id 13507"
+msgid "Medium"
+msgstr ""
+
+#: id:13508
+msgctxt "Auto context with id 13508"
+msgid "High"
+msgstr ""
+
+#: id:13509
+msgid "Really high(slow!)"
+msgstr ""
+
+#: id:13510
+msgid "Sync playback to display"
+msgstr ""
+
+#: id:13550
+msgid "Pause during refresh rate change"
+msgstr ""
+
+#: id:13551
+msgctxt "Auto context with id 13551"
+msgid "Off"
+msgstr ""
+
+#: id:13552
+msgid "%.1f Second"
+msgstr ""
+
+#: id:13553
+msgid "%.1f Seconds"
+msgstr ""
+
+#: id:13600
+msgid "Apple remote"
+msgstr ""
+
+#: id:13602
+msgid "Allow start of XBMC using the remote"
+msgstr ""
+
+#: id:13603
+msgid "Sequence delay time"
+msgstr ""
+
+#: id:13610
+msgctxt "Auto context with id 13610"
+msgid "Disabled"
+msgstr ""
+
+#: id:13611
+msgctxt "Auto context with id 13611"
+msgid "Standard"
+msgstr ""
+
+#: id:13612
+msgid "Universal Remote"
+msgstr ""
+
+#: id:13613
+msgid "Multi Remote (Harmony)"
+msgstr ""
+
+#: id:13620
+msgid "Apple Remote Error"
+msgstr ""
+
+#: id:13621
+msgid "Apple Remote support could be enabled."
+msgstr ""
+
+#: id:14000
+msgid "Stack"
+msgstr ""
+
+#: id:14001
+msgid "Unstack"
+msgstr ""
+
+#: id:14003
+msgid "Downloading playlist file..."
+msgstr ""
+
+#: id:14004
+msgid "Downloading streams list..."
+msgstr ""
+
+#: id:14005
+msgid "Parsing streams list..."
+msgstr ""
+
+#: id:14006
+msgid "Downloading streams list failed"
+msgstr ""
+
+#: id:14007
+msgid "Downloading playlist file failed"
+msgstr ""
+
+#: id:14009
+msgid "Games directory"
+msgstr ""
+
+#: id:14010
+msgid "Auto switch to thumbs based on"
+msgstr ""
+
+#: id:14011
+msgid "Enable auto switching to thumbs view"
+msgstr ""
+
+#: id:14012
+msgid "- Use large icons"
+msgstr ""
+
+#: id:14013
+msgid "- Switch based on"
+msgstr ""
+
+#: id:14014
+msgid "- Percentage"
+msgstr ""
+
+#: id:14015
+msgid "No files and at least one thumb"
+msgstr ""
+
+#: id:14016
+msgid "At least one file and thumb"
+msgstr ""
+
+#: id:14017
+msgid "Percentage of thumbs"
+msgstr ""
+
+#: id:14018
+msgid "View options"
+msgstr ""
+
+#: id:14019
+msgid "Change area code 1"
+msgstr ""
+
+#: id:14020
+msgid "Change area code 2"
+msgstr ""
+
+#: id:14021
+msgid "Change area code 3"
+msgstr ""
+
+#: id:14022
+msgctxt "Auto context with id 14022"
+msgid "Library"
+msgstr ""
+
+#: id:14023
+msgid "No TV"
+msgstr ""
+
+#: id:14024
+msgid "Enter the nearest large town"
+msgstr ""
+
+#: id:14025
+msgid "Video/Audio/DVD cache - Harddisk"
+msgstr ""
+
+#: id:14026
+msgid "Video cache - DVD-ROM"
+msgstr ""
+
+#: id:14027
+msgctxt "Auto context with id 14027"
+msgid "- Local Network"
+msgstr ""
+
+#: id:14028
+msgctxt "Auto context with id 14028"
+msgid "- Internet"
+msgstr ""
+
+#: id:14030
+msgid "Audio cache - DVD-ROM"
+msgstr ""
+
+#: id:14031
+msgctxt "Auto context with id 14031"
+msgid "- Local Network"
+msgstr ""
+
+#: id:14032
+msgctxt "Auto context with id 14032"
+msgid "- Internet"
+msgstr ""
+
+#: id:14034
+msgid "DVD cache - DVD-ROM"
+msgstr ""
+
+#: id:14035
+msgctxt "Auto context with id 14035"
+msgid "- Local Network"
+msgstr ""
+
+#: id:14036
+msgctxt "Auto context with id 14036"
+msgid "Services"
+msgstr ""
+
+#: id:14038
+msgid "Network settings changed"
+msgstr ""
+
+#: id:14039
+msgid "XBMC requires to restart to change your"
+msgstr ""
+
+#: id:14040
+msgid "network setup. Would you like to restart now?"
+msgstr ""
+
+#: id:14041
+msgid "Internet connection bandwidth limitation"
+msgstr ""
+
+#: id:14043
+msgid "- Shutdown while playing"
+msgstr ""
+
+#: id:14044
+msgid "%i min"
+msgstr ""
+
+#: id:14045
+msgid "%i sec"
+msgstr ""
+
+#: id:14046
+msgid "%i ms"
+msgstr ""
+
+#: id:14047
+msgid "%i %%"
+msgstr ""
+
+#: id:14048
+msgid "%i kbps"
+msgstr ""
+
+#: id:14049
+msgid "%i kb"
+msgstr ""
+
+#: id:14050
+msgid "%i.0 dB"
+msgstr ""
+
+#: id:14051
+msgid "Time format"
+msgstr ""
+
+#: id:14052
+msgid "Date format"
+msgstr ""
+
+#: id:14053
+msgid "GUI filters"
+msgstr ""
+
+#: id:14055
+msgid "Use background scanning"
+msgstr ""
+
+#: id:14056
+msgid "Stop scan"
+msgstr ""
+
+#: id:14057
+msgid "Not possible while scanning for media info"
+msgstr ""
+
+#: id:14058
+msgid "Film grain effect"
+msgstr ""
+
+#: id:14059
+msgid "Search for thumbnails on remote shares"
+msgstr ""
+
+#: id:14060
+msgid "Unknown type cache - Internet"
+msgstr ""
+
+#: id:14061
+msgctxt "Auto context with id 14061"
+msgid "Auto"
+msgstr ""
+
+#: id:14062
+msgid "Enter username for"
+msgstr ""
+
+#: id:14063
+msgid "Date & time"
+msgstr ""
+
+#: id:14064
+msgid "Set date"
+msgstr ""
+
+#: id:14065
+msgid "Set time"
+msgstr ""
+
+#: id:14066
+msgid "Enter the time in 24 hour HH:MM format"
+msgstr ""
+
+#: id:14067
+msgid "Enter the date in DD/MM/YYYY format"
+msgstr ""
+
+#: id:14068
+msgid "Enter the IP address"
+msgstr ""
+
+#: id:14069
+msgid "Apply these settings now?"
+msgstr ""
+
+#: id:14070
+msgid "Apply changes now"
+msgstr ""
+
+#: id:14071
+msgid "Allow file renaming and deletion"
+msgstr ""
+
+#: id:14074
+msgid "Set timezone"
+msgstr ""
+
+#: id:14075
+msgid "Use daylight saving time"
+msgstr ""
+
+#: id:14076
+msgid "Add to favourites"
+msgstr "Add to favorites"
+
+#: id:14077
+msgid "Remove from favourites"
+msgstr "Remove from favorites"
+
+#: id:14078
+msgctxt "Auto context with id 14078"
+msgid "- Colours"
+msgstr "- Colors"
+
+#: id:14079
+msgid "Timezone country"
+msgstr ""
+
+#: id:14080
+msgid "Timezone"
+msgstr ""
+
+#: id:14081
+msgid "File lists"
+msgstr ""
+
+#: id:14082
+msgid "Show EXIF picture information"
+msgstr ""
+
+#: id:14083
+msgid "Use a fullscreen window rather than true fullscreen"
+msgstr ""
+
+#: id:14084
+msgid "Queue songs on selection"
+msgstr ""
+
+#: id:14086
+msgid "Playback"
+msgstr ""
+
+#: id:14087
+msgid "DVDs"
+msgstr ""
+
+#: id:14088
+msgid "Play DVDs automatically"
+msgstr ""
+
+#: id:14089
+msgid "Font to use for text subtitles"
+msgstr ""
+
+#: id:14090
+msgid "International"
+msgstr ""
+
+#: id:14091
+msgid "Character set"
+msgstr ""
+
+#: id:14092
+msgid "Debugging"
+msgstr ""
+
+#: id:14093
+msgid "Security"
+msgstr ""
+
+#: id:14094
+msgid "Input devices"
+msgstr ""
+
+#: id:14095
+msgid "Power saving"
+msgstr ""
+
+#: id:14096
+msgid "Rip"
+msgstr ""
+
+#: id:14097
+msgid "Audio CD Insert Action"
+msgstr ""
+
+#: id:14098
+msgctxt "Auto context with id 14098"
+msgid "Play"
+msgstr ""
+
+#: id:14099
+msgid "Eject disc when CD ripping is complete"
+msgstr ""
+
+#: id:15015
+msgctxt "Auto context with id 15015"
+msgid "Remove"
+msgstr ""
+
+#: id:15016
+msgid "Games"
+msgstr ""
+
+#: id:15019
+msgid "Add"
+msgstr ""
+
+#: id:15052
+msgid "Password"
+msgstr ""
+
+#: id:15100
+msgctxt "Auto context with id 15100"
+msgid "Library"
+msgstr ""
+
+#: id:15101
+msgid "Database"
+msgstr ""
+
+#: id:15102
+msgid "* All albums"
+msgstr ""
+
+#: id:15103
+msgid "* All artists"
+msgstr ""
+
+#: id:15104
+msgid "* All songs"
+msgstr ""
+
+#: id:15105
+msgid "* All genres"
+msgstr ""
+
+#: id:15107
+msgid "Buffering..."
+msgstr ""
+
+#: id:15108
+msgid "Navigation sounds"
+msgstr ""
+
+#: id:15109
+msgid "Skin default"
+msgstr ""
+
+#: id:15111
+msgid "- Theme"
+msgstr ""
+
+#: id:15112
+msgid "Default theme"
+msgstr ""
+
+#: id:15200
+msgid "Last.fm"
+msgstr ""
+
+#: id:15201
+msgid "Submit songs to Last.fm"
+msgstr ""
+
+#: id:15202
+msgid "Last.fm username"
+msgstr ""
+
+#: id:15203
+msgid "Last.fm password"
+msgstr ""
+
+#: id:15204
+msgid "Unable to handshake: sleeping..."
+msgstr ""
+
+#: id:15205
+msgid "Please update XBMC"
+msgstr ""
+
+#: id:15206
+msgid "Bad authorization: Check username and password"
+msgstr ""
+
+#: id:15207
+msgctxt "Auto context with id 15207"
+msgid "Connected"
+msgstr ""
+
+#: id:15208
+msgid "Not connected"
+msgstr ""
+
+#: id:15209
+msgid "Submit interval %i"
+msgstr ""
+
+#: id:15210
+msgid "Cached %i songs"
+msgstr ""
+
+#: id:15211
+msgid "Submitting..."
+msgstr ""
+
+#: id:15212
+msgid "Submitting in %i secs"
+msgstr ""
+
+#: id:15213
+msgid "Play using..."
+msgstr ""
+
+#: id:15214
+msgid "Use smoothed A/V synchronization"
+msgstr ""
+
+#: id:15215
+msgid "Hide file names in thumbs view"
+msgstr ""
+
+#: id:15216
+msgid "Play in party mode"
+msgstr ""
+
+#: id:15217
+msgid "Submit songs to Libre.fm"
+msgstr ""
+
+#: id:15218
+msgid "Libre.fm username"
+msgstr ""
+
+#: id:15219
+msgid "Libre.fm password"
+msgstr ""
+
+#: id:15220
+msgid "Libre.fm"
+msgstr ""
+
+#: id:15221
+msgid "Song submission"
+msgstr ""
+
+#: id:15250
+msgid "Submit Last.fm radio to Last.fm"
+msgstr ""
+
+#: id:15251
+msgid "Connecting to Last.fm..."
+msgstr ""
+
+#: id:15252
+msgid "Selecting station..."
+msgstr ""
+
+#: id:15253
+msgid "Search similar artists..."
+msgstr ""
+
+#: id:15254
+msgid "Search similar tags..."
+msgstr ""
+
+#: id:15255
+msgid "Your profile (%name%)"
+msgstr ""
+
+#: id:15256
+msgid "Overall top tags"
+msgstr ""
+
+#: id:15257
+msgid "Top artists for tag %name%"
+msgstr ""
+
+#: id:15258
+msgid "Top albums for tag %name%"
+msgstr ""
+
+#: id:15259
+msgid "Top tracks for tag %name%"
+msgstr ""
+
+#: id:15260
+msgid "Listen to tag %name% Last.fm radio"
+msgstr ""
+
+#: id:15261
+msgid "Similar artists as %name%"
+msgstr ""
+
+#: id:15262
+msgid "Top %name% albums"
+msgstr ""
+
+#: id:15263
+msgid "Top %name% tracks"
+msgstr ""
+
+#: id:15264
+msgid "Top %name% tags"
+msgstr ""
+
+#: id:15265
+msgid "Biggest fans of %name%"
+msgstr ""
+
+#: id:15266
+msgid "Listen to %name% fans Last.fm radio"
+msgstr ""
+
+#: id:15267
+msgid "Listen to %name% similar artists Last.fm radio"
+msgstr ""
+
+#: id:15268
+msgid "Top artists for user %name%"
+msgstr ""
+
+#: id:15269
+msgid "Top albums for user %name%"
+msgstr ""
+
+#: id:15270
+msgid "Top tracks for user %name%"
+msgstr ""
+
+#: id:15271
+msgid "Friends of user %name%"
+msgstr ""
+
+#: id:15272
+msgid "Neighbours of user %name%"
+msgstr "Neighbors of user %name%"
+
+#: id:15273
+msgid "Weekly artist chart for %name%"
+msgstr ""
+
+#: id:15274
+msgid "Weekly album chart for %name%"
+msgstr ""
+
+#: id:15275
+msgid "Weekly track chart for %name%"
+msgstr ""
+
+#: id:15276
+msgid "Listen to %name%'s neighbours Last.fm radio"
+msgstr "Listen to %name%'s neighbors Last.fm radio"
+
+#: id:15277
+msgid "Listen to %name%'s personal Last.fm radio"
+msgstr ""
+
+#: id:15278
+msgid "Listen to %name%'s mix Last.fm radio"
+msgstr ""
+
+#: id:15279
+msgid "Retrieving list from Last.fm..."
+msgstr ""
+
+#: id:15280
+msgid "Can't retrieve list from Last.fm..."
+msgstr ""
+
+#: id:15281
+msgid "Enter an artist name to find related ones"
+msgstr ""
+
+#: id:15282
+msgid "Enter a tag name to find similar ones"
+msgstr ""
+
+#: id:15283
+msgid "Tracks recently listened by %name%"
+msgstr ""
+
+#: id:15284
+msgid "Listen to %name%'s recommendations Last.fm radio"
+msgstr ""
+
+#: id:15285
+msgid "Top tags for user %name%"
+msgstr ""
+
+#: id:15287
+msgid "Do you want to add the current track to your loved tracks?"
+msgstr ""
+
+#: id:15288
+msgid "Do you want to ban the current track?"
+msgstr ""
+
+#: id:15289
+msgid "Added to your loved tracks: '%s'."
+msgstr ""
+
+#: id:15290
+msgid "Could not add '%s' to your loved tracks."
+msgstr ""
+
+#: id:15291
+msgid "Banned: '%s'."
+msgstr ""
+
+#: id:15292
+msgid "Could not ban '%s'."
+msgstr ""
+
+#: id:15293
+msgid "Tracks recently loved by %name%"
+msgstr ""
+
+#: id:15294
+msgid "Tracks recently banned by %name%"
+msgstr ""
+
+#: id:15295
+msgid "Remove from loved tracks"
+msgstr ""
+
+#: id:15296
+msgid "Un-ban"
+msgstr ""
+
+#: id:15297
+msgid "Do you want to remove this track from your loved tracks?"
+msgstr ""
+
+#: id:15298
+msgid "Do you want to un-ban this track?"
+msgstr ""
+
+#: id:15300
+msgid "Path not found or invalid"
+msgstr ""
+
+#: id:15301
+msgid "Could not connect to network server"
+msgstr ""
+
+#: id:15302
+msgid "No servers found"
+msgstr ""
+
+#: id:15303
+msgid "Workgroup not found"
+msgstr ""
+
+#: id:15310
+msgid "Opening multi-path source"
+msgstr ""
+
+#: id:15311
+msgid "Path:"
+msgstr ""
+
+#: id:16000
+msgctxt "Auto context with id 16000"
+msgid "General"
+msgstr ""
+
+#: id:16002
+msgid "Internet lookup"
+msgstr ""
+
+#: id:16003
+msgid "Player"
+msgstr ""
+
+#: id:16004
+msgid "Play media from disc"
+msgstr ""
+
+#: id:16008
+msgid "Enter new title"
+msgstr ""
+
+#: id:16009
+msgid "Enter the movie name"
+msgstr ""
+
+#: id:16010
+msgid "Enter the profile name"
+msgstr ""
+
+#: id:16011
+msgid "Enter the album name"
+msgstr ""
+
+#: id:16012
+msgid "Enter the playlist name"
+msgstr ""
+
+#: id:16013
+msgid "Enter new filename"
+msgstr ""
+
+#: id:16014
+msgid "Enter folder name"
+msgstr ""
+
+#: id:16015
+msgid "Enter directory"
+msgstr ""
+
+#: id:16016
+msgid "Available options: %A, %T, %N, %B, %D, %G, %Y, %F, %S"
+msgstr ""
+
+#: id:16017
+msgid "Enter search string"
+msgstr ""
+
+#: id:16018
+msgctxt "Auto context with id 16018"
+msgid "None"
+msgstr ""
+
+#: id:16019
+msgid "Auto select"
+msgstr ""
+
+#: id:16020
+msgid "De-interlace"
+msgstr ""
+
+#: id:16021
+msgid "Bob"
+msgstr ""
+
+#: id:16022
+msgid "Bob (inverted)"
+msgstr ""
+
+#: id:16024
+msgid "Canceling..."
+msgstr ""
+
+#: id:16025
+msgid "Enter the artist name"
+msgstr ""
+
+#: id:16026
+msgid "Playback failed"
+msgstr ""
+
+#: id:16027
+msgid "One or more items failed to play."
+msgstr ""
+
+#: id:16028
+msgid "Enter value"
+msgstr ""
+
+#: id:16029
+msgid "Check the log file for details."
+msgstr ""
+
+#: id:16030
+msgid "Party mode aborted."
+msgstr ""
+
+#: id:16031
+msgid "No matching songs in the library."
+msgstr ""
+
+#: id:16032
+msgid "Could not initialize database."
+msgstr ""
+
+#: id:16033
+msgid "Could not open database."
+msgstr ""
+
+#: id:16034
+msgid "Could not get songs from database."
+msgstr ""
+
+#: id:16035
+msgid "Party mode playlist"
+msgstr ""
+
+#: id:16036
+msgid "De-interlace (Half)"
+msgstr ""
+
+#: id:16037
+msgid "Deinterlace video"
+msgstr ""
+
+#: id:16038
+msgid "Deinterlace method"
+msgstr ""
+
+#: id:16039
+msgctxt "Auto context with id 16039"
+msgid "Off"
+msgstr ""
+
+#: id:16040
+msgctxt "Auto context with id 16040"
+msgid "Auto"
+msgstr ""
+
+#: id:16041
+msgid "On"
+msgstr ""
+
+#: id:16100
+msgid "All Videos"
+msgstr ""
+
+#: id:16101
+msgid "Unwatched"
+msgstr ""
+
+#: id:16102
+msgid "Watched"
+msgstr ""
+
+#: id:16103
+msgid "Mark as watched"
+msgstr ""
+
+#: id:16104
+msgid "Mark as unwatched"
+msgstr ""
+
+#: id:16105
+msgid "Edit title"
+msgstr ""
+
+#: id:16200
+msgid "Operation was aborted"
+msgstr ""
+
+#: id:16201
+msgid "Copy failed"
+msgstr ""
+
+#: id:16202
+msgid "Failed to copy at least one file"
+msgstr ""
+
+#: id:16203
+msgid "Move failed"
+msgstr ""
+
+#: id:16204
+msgid "Failed to move at least one file"
+msgstr ""
+
+#: id:16205
+msgid "Delete failed"
+msgstr ""
+
+#: id:16206
+msgid "Failed to delete at least one file"
+msgstr ""
+
+#: id:16300
+msgid "Video scaling method"
+msgstr ""
+
+#: id:16301
+msgid "Nearest neighbour"
+msgstr "Nearest neighbor"
+
+#: id:16302
+msgid "Bilinear"
+msgstr ""
+
+#: id:16303
+msgctxt "Auto context with id 16303"
+msgid "Bicubic"
+msgstr ""
+
+#: id:16304
+msgid "Lanczos2"
+msgstr ""
+
+#: id:16305
+msgid "Lanczos3"
+msgstr ""
+
+#: id:16306
+msgid "Sinc8"
+msgstr ""
+
+#: id:16307
+msgid "Bicubic (software)"
+msgstr ""
+
+#: id:16308
+msgid "Lanczos (software)"
+msgstr ""
+
+#: id:16309
+msgid "Sinc (software)"
+msgstr ""
+
+#: id:16310
+msgid "Temporal"
+msgstr ""
+
+#: id:16311
+msgid "Temporal/Spatial"
+msgstr ""
+
+#: id:16312
+msgid "(VDPAU)Noise Reduction"
+msgstr ""
+
+#: id:16313
+msgid "(VDPAU)Sharpness"
+msgstr ""
+
+#: id:16314
+msgid "Inverse Telecine"
+msgstr ""
+
+#: id:16315
+msgid "Lanczos3 optimized"
+msgstr ""
+
+#: id:16316
+msgctxt "Auto context with id 16316"
+msgid "Auto"
+msgstr ""
+
+#: id:16317
+msgid "Temporal (Half)"
+msgstr ""
+
+#: id:16318
+msgid "Temporal/Spatial (Half)"
+msgstr ""
+
+#: id:16319
+msgid "DXVA"
+msgstr ""
+
+#: id:16320
+msgid "DXVA Bob"
+msgstr ""
+
+#: id:16321
+msgid "DXVA Best"
+msgstr ""
+
+#: id:16322
+msgid "Spline36"
+msgstr ""
+
+#: id:16323
+msgid "Spline36 optimized"
+msgstr ""
+
+#: id:16324
+msgid "Software Blend"
+msgstr ""
+
+#: id:16400
+msgid "Post-processing"
+msgstr ""
+
+#: id:17500
+msgid "Display sleep timeout"
+msgstr ""
+
+#: id:19000
+msgid "Switch to channel"
+msgstr ""
+
+#: id:20000
+msgid "Saved music folder"
+msgstr ""
+
+#: id:20001
+msgid "Use external DVD player"
+msgstr ""
+
+#: id:20002
+msgid "External DVD player"
+msgstr ""
+
+#: id:20003
+msgid "Trainers folder"
+msgstr ""
+
+#: id:20004
+msgid "Screenshot folder"
+msgstr ""
+
+#: id:20006
+msgid "Playlists folder"
+msgstr ""
+
+#: id:20007
+msgid "Recordings"
+msgstr ""
+
+#: id:20008
+msgid "Screenshots"
+msgstr ""
+
+#: id:20009
+msgid "Use XBMC"
+msgstr ""
+
+#: id:20011
+msgid "Music playlists"
+msgstr ""
+
+#: id:20012
+msgid "Video playlists"
+msgstr ""
+
+#: id:20013
+msgid "Do you wish to launch the game?"
+msgstr ""
+
+#: id:20014
+msgid "Sort by: Playlist"
+msgstr ""
+
+#: id:20015
+msgid "Remote thumb"
+msgstr ""
+
+#: id:20016
+msgid "Current thumb"
+msgstr ""
+
+#: id:20017
+msgid "Local thumb"
+msgstr ""
+
+#: id:20018
+msgid "No thumb"
+msgstr ""
+
+#: id:20019
+msgid "Choose thumbnail"
+msgstr ""
+
+#: id:20023
+msgid "Conflict"
+msgstr ""
+
+#: id:20024
+msgid "Scan new"
+msgstr ""
+
+#: id:20025
+msgid "Scan all"
+msgstr ""
+
+#: id:20026
+msgid "Region"
+msgstr ""
+
+#: id:20037
+msgid "Summary"
+msgstr ""
+
+#: id:20038
+msgid "Lock music window"
+msgstr ""
+
+#: id:20039
+msgid "Lock videos window"
+msgstr ""
+
+#: id:20040
+msgid "Lock pictures window"
+msgstr ""
+
+#: id:20041
+msgid "Lock programs & scripts windows"
+msgstr ""
+
+#: id:20042
+msgid "Lock file manager"
+msgstr ""
+
+#: id:20043
+msgid "Lock settings"
+msgstr ""
+
+#: id:20044
+msgid "Start fresh"
+msgstr ""
+
+#: id:20045
+msgid "Enter master mode"
+msgstr ""
+
+#: id:20046
+msgid "Leave master mode"
+msgstr ""
+
+#: id:20047
+msgid "Create profile '%s'?"
+msgstr ""
+
+#: id:20048
+msgid "Start with fresh settings"
+msgstr ""
+
+#: id:20049
+msgid "Best available"
+msgstr ""
+
+#: id:20050
+msgid "Auto-switch between 16x9 and 4x3"
+msgstr ""
+
+#: id:20051
+msgid "Treat stacked files as single file"
+msgstr ""
+
+#: id:20052
+msgid "Caution"
+msgstr ""
+
+#: id:20053
+msgid "Left master mode"
+msgstr ""
+
+#: id:20054
+msgid "Entered master mode"
+msgstr ""
+
+#: id:20055
+msgid "Allmusic.com thumb"
+msgstr ""
+
+#: id:20057
+msgid "Remove thumbnail"
+msgstr ""
+
+#: id:20058
+msgid "Add profile..."
+msgstr ""
+
+#: id:20059
+msgid "Query info for all albums"
+msgstr ""
+
+#: id:20060
+msgctxt "Auto context with id 20060"
+msgid "Media info"
+msgstr ""
+
+#: id:20061
+msgctxt "Auto context with id 20061"
+msgid "Separate"
+msgstr ""
+
+#: id:20062
+msgid "Shares with default"
+msgstr ""
+
+#: id:20063
+msgid "Shares with default (read only)"
+msgstr ""
+
+#: id:20064
+msgid "Copy default"
+msgstr ""
+
+#: id:20065
+msgid "Profile picture"
+msgstr ""
+
+#: id:20066
+msgid "Lock preferences"
+msgstr ""
+
+#: id:20067
+msgid "Edit profile"
+msgstr ""
+
+#: id:20068
+msgid "Profile lock"
+msgstr ""
+
+#: id:20069
+msgid "Could not create folder"
+msgstr ""
+
+#: id:20070
+msgid "Profile directory"
+msgstr ""
+
+#: id:20071
+msgid "Start with fresh media sources"
+msgstr ""
+
+#: id:20072
+msgid "Make sure the selected folder is writable"
+msgstr ""
+
+#: id:20073
+msgid "and that the new folder name is valid"
+msgstr ""
+
+#: id:20074
+msgid "MPAA rating"
+msgstr ""
+
+#: id:20075
+msgid "Enter master lock code"
+msgstr ""
+
+#: id:20076
+msgid "Ask for master lock code on startup"
+msgstr ""
+
+#: id:20077
+msgid "Skin settings"
+msgstr ""
+
+#: id:20078
+msgid "- no link set -"
+msgstr ""
+
+#: id:20079
+msgid "Enable animations"
+msgstr ""
+
+#: id:20080
+msgid "Disable RSS during music"
+msgstr ""
+
+#: id:20081
+msgid "Enable shortcut buttons"
+msgstr ""
+
+#: id:20082
+msgid "Show programs in main menu"
+msgstr ""
+
+#: id:20083
+msgid "Show music info"
+msgstr ""
+
+#: id:20084
+msgid "Show weather info"
+msgstr ""
+
+#: id:20085
+msgid "Show system info"
+msgstr ""
+
+#: id:20086
+msgid "Show available disc space C: E: F:"
+msgstr ""
+
+#: id:20087
+msgid "Show available disc space E: F: G:"
+msgstr ""
+
+#: id:20088
+msgid "Weather info"
+msgstr ""
+
+#: id:20089
+msgid "Drive space free"
+msgstr ""
+
+#: id:20090
+msgid "Enter the name of an existing share"
+msgstr ""
+
+#: id:20091
+msgid "Lock code"
+msgstr ""
+
+#: id:20092
+msgid "Load profile"
+msgstr ""
+
+#: id:20093
+msgid "Profile name"
+msgstr ""
+
+#: id:20094
+msgctxt "Auto context with id 20094"
+msgid "Media sources"
+msgstr ""
+
+#: id:20095
+msgid "Enter profile lock code"
+msgstr ""
+
+#: id:20096
+msgctxt "Auto context with id 20096"
+msgid "Login screen"
+msgstr ""
+
+#: id:20097
+msgid "Fetching album info"
+msgstr ""
+
+#: id:20098
+msgid "Fetching info for album"
+msgstr ""
+
+#: id:20099
+msgid "Can't rip CD or track while playing from CD"
+msgstr ""
+
+#: id:20100
+msgid "Master lock code and settings"
+msgstr ""
+
+#: id:20101
+msgid "Entering master lock code always enables master mode"
+msgstr ""
+
+#: id:20102
+msgid "or copy from default?"
+msgstr ""
+
+#: id:20103
+msgid "Save changes to profile?"
+msgstr ""
+
+#: id:20104
+msgid "Old settings found."
+msgstr ""
+
+#: id:20105
+msgid "Do you want to use them?"
+msgstr ""
+
+#: id:20106
+msgid "Old media sources found."
+msgstr ""
+
+#: id:20107
+msgid "Separate (locked)"
+msgstr ""
+
+#: id:20108
+msgid "Root"
+msgstr ""
+
+#: id:20109
+msgid "- Zoom"
+msgstr ""
+
+#: id:20110
+msgid "UPnP settings"
+msgstr ""
+
+#: id:20111
+msgid "Autostart UPnP client"
+msgstr ""
+
+#: id:20112
+msgid "Last login: %s"
+msgstr ""
+
+#: id:20113
+msgid "Never logged on"
+msgstr ""
+
+#: id:20114
+msgid "Profile %i / %i"
+msgstr ""
+
+#: id:20115
+msgid "User login / Select a profile"
+msgstr ""
+
+#: id:20116
+msgid "Use lock on login screen"
+msgstr ""
+
+#: id:20117
+msgid "Invalid lock code."
+msgstr ""
+
+#: id:20118
+msgid "This requires the master lock to be set."
+msgstr ""
+
+#: id:20119
+msgid "Would you like to set it now?"
+msgstr ""
+
+#: id:20120
+msgid "Loading program information"
+msgstr ""
+
+#: id:20121
+msgid "Party on!"
+msgstr ""
+
+#: id:20122
+msgid "True"
+msgstr ""
+
+#: id:20123
+msgid "Mixing drinks"
+msgstr ""
+
+#: id:20124
+msgid "Filling glasses"
+msgstr ""
+
+#: id:20125
+msgid "Logged on as"
+msgstr ""
+
+#: id:20126
+msgid "Log off"
+msgstr ""
+
+#: id:20128
+msgid "Go to root"
+msgstr ""
+
+#: id:20129
+msgid "Weave"
+msgstr ""
+
+#: id:20130
+msgid "Weave (inverted)"
+msgstr ""
+
+#: id:20131
+msgid "Blend"
+msgstr ""
+
+#: id:20132
+msgid "Restart video"
+msgstr ""
+
+#: id:20133
+msgid "Edit network location"
+msgstr ""
+
+#: id:20134
+msgid "Remove network location"
+msgstr ""
+
+#: id:20135
+msgid "Do you want to scan the folder?"
+msgstr ""
+
+#: id:20136
+msgid "Memory unit"
+msgstr ""
+
+#: id:20137
+msgid "Memory unit mounted"
+msgstr ""
+
+#: id:20138
+msgid "Unable to mount memory unit"
+msgstr ""
+
+#: id:20139
+msgid "In port %i, slot %i"
+msgstr ""
+
+#: id:20140
+msgid "Lock screensaver"
+msgstr ""
+
+#: id:20141
+msgid "Set"
+msgstr ""
+
+#: id:20142
+msgctxt "Auto context with id 20142"
+msgid "Username"
+msgstr ""
+
+#: id:20143
+msgid "Enter password for"
+msgstr ""
+
+#: id:20144
+msgid "Shutdown timer"
+msgstr ""
+
+#: id:20145
+msgid "Shutdown interval (in minutes)"
+msgstr ""
+
+#: id:20146
+msgid "Started, shutdown in %im"
+msgstr ""
+
+#: id:20147
+msgid "Shutdown in 30 minutes"
+msgstr ""
+
+#: id:20148
+msgid "Shutdown in 60 minutes"
+msgstr ""
+
+#: id:20149
+msgid "Shutdown in 120 minutes"
+msgstr ""
+
+#: id:20150
+msgid "Custom shutdown timer"
+msgstr ""
+
+#: id:20151
+msgid "Cancel shutdown timer"
+msgstr ""
+
+#: id:20152
+msgid "Lock preferences for %s"
+msgstr ""
+
+#: id:20153
+msgid "Browse..."
+msgstr ""
+
+#: id:20154
+msgid "Summary information"
+msgstr ""
+
+#: id:20155
+msgid "Storage information"
+msgstr ""
+
+#: id:20156
+msgid "Hard disk information"
+msgstr ""
+
+#: id:20157
+msgid "DVD-ROM information"
+msgstr ""
+
+#: id:20158
+msgid "Network information"
+msgstr ""
+
+#: id:20159
+msgid "Video information"
+msgstr ""
+
+#: id:20160
+msgid "Hardware information"
+msgstr ""
+
+#: id:20161
+msgid "Total"
+msgstr ""
+
+#: id:20162
+msgid "Used"
+msgstr ""
+
+#: id:20163
+msgid "of"
+msgstr ""
+
+#: id:20164
+msgid "Locking not supported"
+msgstr ""
+
+#: id:20165
+msgid "Not locked"
+msgstr ""
+
+#: id:20166
+msgid "Locked"
+msgstr ""
+
+#: id:20167
+msgid "Frozen"
+msgstr ""
+
+#: id:20168
+msgid "Requires reset"
+msgstr ""
+
+#: id:20169
+msgid "Week"
+msgstr ""
+
+#: id:20170
+msgid "Line"
+msgstr ""
+
+#: id:20171
+msgid "Windows network (SMB)"
+msgstr ""
+
+#: id:20172
+msgid "XBMSP server"
+msgstr ""
+
+#: id:20173
+msgctxt "Auto context with id 20173"
+msgid "FTP server"
+msgstr ""
+
+#: id:20174
+msgid "iTunes music share (DAAP)"
+msgstr ""
+
+#: id:20175
+msgid "UPnP server"
+msgstr ""
+
+#: id:20176
+msgid "Show video info"
+msgstr ""
+
+#: id:20177
+msgid "Done"
+msgstr ""
+
+#: id:20178
+msgid "Shift"
+msgstr ""
+
+#: id:20179
+msgid "Caps Lock"
+msgstr ""
+
+#: id:20180
+msgid "Symbols"
+msgstr ""
+
+#: id:20181
+msgid "Backspace"
+msgstr ""
+
+#: id:20182
+msgid "Space"
+msgstr ""
+
+#: id:20183
+msgid "Reload skin"
+msgstr ""
+
+#: id:20184
+msgid "Rotate pictures using EXIF information"
+msgstr ""
+
+#: id:20185
+msgid "Use poster view styles for TV shows"
+msgstr ""
+
+#: id:20186
+msgid "Please wait"
+msgstr ""
+
+#: id:20187
+msgid "UPnP"
+msgstr ""
+
+#: id:20189
+msgid "Enable auto scrolling for plot & review"
+msgstr ""
+
+#: id:20190
+msgctxt "Auto context with id 20190"
+msgid "Custom"
+msgstr ""
+
+#: id:20191
+msgid "Enable debug logging"
+msgstr ""
+
+#: id:20192
+msgid "Download additional information during updates"
+msgstr ""
+
+#: id:20193
+msgid "Default service for album information"
+msgstr ""
+
+#: id:20194
+msgid "Default service for artist information"
+msgstr ""
+
+#: id:20195
+msgid "Change scraper"
+msgstr ""
+
+#: id:20196
+msgid "Export music library"
+msgstr ""
+
+#: id:20197
+msgid "Import music library"
+msgstr ""
+
+#: id:20198
+msgid "No artist found!"
+msgstr ""
+
+#: id:20199
+msgid "Downloading artist info failed"
+msgstr ""
+
+#: id:20250
+msgid "Party on! (videos)"
+msgstr ""
+
+#: id:20251
+msgid "Mixing drinks (videos)"
+msgstr ""
+
+#: id:20252
+msgid "Filling glasses (videos)"
+msgstr ""
+
+#: id:20253
+msgid "WebDAV server (HTTP)"
+msgstr ""
+
+#: id:20254
+msgid "WebDAV server (HTTPS)"
+msgstr ""
+
+#: id:20255
+msgid "First logon, edit your profile"
+msgstr ""
+
+#: id:20256
+msgid "HTS Tvheadend client"
+msgstr ""
+
+#: id:20257
+msgid "VDR Streamdev client"
+msgstr ""
+
+#: id:20258
+msgid "MythTV client"
+msgstr ""
+
+#: id:20259
+msgid "Network Filesystem (NFS)"
+msgstr ""
+
+#: id:20260
+msgid "Secure Shell (SSH/SFTP)"
+msgstr ""
+
+#: id:20261
+msgid "Apple Filing Protocol (AFP)"
+msgstr ""
+
+#: id:20300
+msgid "Web server directory (HTTP)"
+msgstr ""
+
+#: id:20301
+msgid "Web server directory (HTTPS)"
+msgstr ""
+
+#: id:20302
+msgid "Unable to write to folder:"
+msgstr ""
+
+#: id:20303
+msgid "Do you want to skip and proceed?"
+msgstr ""
+
+#: id:20304
+msgid "RSS Feed"
+msgstr ""
+
+#: id:20307
+msgid "Secondary DNS"
+msgstr ""
+
+#: id:20308
+msgid "DHCP server:"
+msgstr ""
+
+#: id:20309
+msgid "Make new folder"
+msgstr ""
+
+#: id:20310
+msgid "Dim LCD on playback"
+msgstr ""
+
+#: id:20311
+msgid "Unknown or onboard (protected)"
+msgstr ""
+
+#: id:20312
+msgid "Dim LCD on paused"
+msgstr ""
+
+#: id:20314
+msgid "Videos - Library"
+msgstr ""
+
+#: id:20316
+msgid "Sort by: ID"
+msgstr ""
+
+#: id:20324
+msgid "Play part..."
+msgstr ""
+
+#: id:20325
+msgid "Calibration reset"
+msgstr ""
+
+#: id:20326
+msgid "This will reset the calibration values for %s"
+msgstr ""
+
+#: id:20327
+msgid "to it's default values."
+msgstr ""
+
+#: id:20328
+msgid "Browse for destination"
+msgstr ""
+
+#: id:20329
+msgid "Movies are in separate folders that match the movie title"
+msgstr ""
+
+#: id:20330
+msgid "Use folder names for lookups"
+msgstr ""
+
+#: id:20331
+msgctxt "Auto context with id 20331"
+msgid "File"
+msgstr ""
+
+#: id:20332
+msgid "Use file or folder names in lookups?"
+msgstr ""
+
+#: id:20333
+msgid "Set content"
+msgstr ""
+
+#: id:20334
+msgid "Folder"
+msgstr ""
+
+#: id:20335
+msgid "Look for content recursively?"
+msgstr ""
+
+#: id:20336
+msgid "Unlock sources"
+msgstr ""
+
+#: id:20337
+msgid "Actor"
+msgstr ""
+
+#: id:20338
+msgid "Movie"
+msgstr ""
+
+#: id:20339
+msgid "Director"
+msgstr ""
+
+#: id:20340
+msgid "Do you want to remove all items within"
+msgstr ""
+
+#: id:20341
+msgid "this path from the XBMC library?"
+msgstr ""
+
+#: id:20342
+msgctxt "Auto context with id 20342"
+msgid "Movies"
+msgstr ""
+
+#: id:20343
+msgid "TV shows"
+msgstr ""
+
+#: id:20344
+msgid "This directory contains"
+msgstr ""
+
+#: id:20345
+msgid "Run automated scan"
+msgstr ""
+
+#: id:20346
+msgid "Scan recursively"
+msgstr ""
+
+#: id:20347
+msgid "as"
+msgstr ""
+
+#: id:20348
+msgid "Directors"
+msgstr ""
+
+#: id:20349
+msgid "No video files found in this path!"
+msgstr ""
+
+#: id:20350
+msgid "votes"
+msgstr ""
+
+#: id:20351
+msgid "TV show information"
+msgstr ""
+
+#: id:20352
+msgid "Episode information"
+msgstr ""
+
+#: id:20353
+msgid "Loading TV show details"
+msgstr ""
+
+#: id:20354
+msgid "Fetching episode guide"
+msgstr ""
+
+#: id:20355
+msgid "Loading info for episodes in directory"
+msgstr ""
+
+#: id:20356
+msgid "Select TV show:"
+msgstr ""
+
+#: id:20357
+msgid "Enter the TV show name"
+msgstr ""
+
+#: id:20358
+msgid "Season %i"
+msgstr ""
+
+#: id:20359
+msgid "Episode"
+msgstr ""
+
+#: id:20360
+msgid "Episodes"
+msgstr ""
+
+#: id:20361
+msgid "Loading episode details"
+msgstr ""
+
+#: id:20362
+msgid "Remove episode from library"
+msgstr ""
+
+#: id:20363
+msgid "Remove TV show from library"
+msgstr ""
+
+#: id:20364
+msgid "TV show"
+msgstr ""
+
+#: id:20365
+msgid "Episode plot"
+msgstr ""
+
+#: id:20366
+msgid "* All seasons"
+msgstr ""
+
+#: id:20367
+msgid "Hide watched"
+msgstr ""
+
+#: id:20368
+msgid "Prod code"
+msgstr ""
+
+#: id:20369
+msgid "Show plot for unwatched items"
+msgstr ""
+
+#: id:20370
+msgid "* Hidden to prevent spoilers *"
+msgstr ""
+
+#: id:20371
+msgid "Set season thumb"
+msgstr ""
+
+#: id:20372
+msgid "Season image"
+msgstr ""
+
+#: id:20373
+msgid "Season"
+msgstr ""
+
+#: id:20374
+msgid "Downloading movie information"
+msgstr ""
+
+#: id:20375
+msgid "Unassign content"
+msgstr ""
+
+#: id:20376
+msgid "Original title"
+msgstr ""
+
+#: id:20377
+msgid "Refresh TV show information"
+msgstr ""
+
+#: id:20378
+msgid "Refresh info for all episodes?"
+msgstr ""
+
+#: id:20379
+msgid "Selected folder contains a single TV show"
+msgstr ""
+
+#: id:20380
+msgid "Exclude selected folder from scans"
+msgstr ""
+
+#: id:20381
+msgid "Specials"
+msgstr ""
+
+#: id:20382
+msgid "Automatically grab season thumbs"
+msgstr ""
+
+#: id:20383
+msgid "Selected folder contains a single video"
+msgstr ""
+
+#: id:20384
+msgid "Link to TV show"
+msgstr ""
+
+#: id:20385
+msgid "Remove link to TV show"
+msgstr ""
+
+#: id:20386
+msgid "Recently added movies"
+msgstr ""
+
+#: id:20387
+msgid "Recently added episodes"
+msgstr ""
+
+#: id:20388
+msgid "Studios"
+msgstr ""
+
+#: id:20389
+msgid "Music videos"
+msgstr ""
+
+#: id:20390
+msgid "Recently added music videos"
+msgstr ""
+
+#: id:20391
+msgid "Music video"
+msgstr ""
+
+#: id:20392
+msgid "Remove music video from library"
+msgstr ""
+
+#: id:20393
+msgctxt "Auto context with id 20393"
+msgid "Music video information"
+msgstr ""
+
+#: id:20394
+msgid "Loading music video information"
+msgstr ""
+
+#: id:20395
+msgid "Mixed"
+msgstr ""
+
+#: id:20396
+msgid "Go to albums by artist"
+msgstr ""
+
+#: id:20397
+msgid "Go to album"
+msgstr ""
+
+#: id:20398
+msgid "Play song"
+msgstr ""
+
+#: id:20399
+msgid "Go to music videos from album"
+msgstr ""
+
+#: id:20400
+msgid "Go to music videos by artist"
+msgstr ""
+
+#: id:20401
+msgid "Play music video"
+msgstr ""
+
+#: id:20402
+msgid "Download actor thumbnails when adding to library"
+msgstr ""
+
+#: id:20403
+msgid "Set actor thumb"
+msgstr ""
+
+#: id:20405
+msgid "Remove episode bookmark"
+msgstr ""
+
+#: id:20406
+msgid "Set episode bookmark"
+msgstr ""
+
+#: id:20407
+msgid "Scraper settings"
+msgstr ""
+
+#: id:20408
+msgid "Downloading music video information"
+msgstr ""
+
+#: id:20409
+msgid "Downloading TV show information"
+msgstr ""
+
+#: id:20410
+msgid "Trailer"
+msgstr ""
+
+#: id:20411
+msgid "Flatten"
+msgstr ""
+
+#: id:20412
+msgid "Flatten TV shows"
+msgstr ""
+
+#: id:20413
+msgid "Get fanart"
+msgstr ""
+
+#: id:20414
+msgid "Show Fanart in video and music libraries"
+msgstr ""
+
+#: id:20415
+msgid "Scanning for new content"
+msgstr ""
+
+#: id:20416
+msgid "First aired"
+msgstr ""
+
+#: id:20417
+msgid "Writer"
+msgstr ""
+
+#: id:20419
+msgid "Replace file names with library titles"
+msgstr ""
+
+#: id:20420
+msgctxt "Auto context with id 20420"
+msgid "Never"
+msgstr ""
+
+#: id:20421
+msgid "If only one season"
+msgstr ""
+
+#: id:20422
+msgid "Always"
+msgstr ""
+
+#: id:20423
+msgid "Has trailer"
+msgstr ""
+
+#: id:20424
+msgid "False"
+msgstr ""
+
+#: id:20425
+msgid "Fanart slideshow"
+msgstr ""
+
+#: id:20426
+msgid "Export to a single file or separate"
+msgstr ""
+
+#: id:20427
+msgid "files per entry?"
+msgstr ""
+
+#: id:20428
+msgid "Single file"
+msgstr ""
+
+#: id:20429
+msgctxt "Auto context with id 20429"
+msgid "Separate"
+msgstr ""
+
+#: id:20430
+msgid "Export thumbnails and fanart?"
+msgstr ""
+
+#: id:20431
+msgid "Overwrite old files?"
+msgstr ""
+
+#: id:20432
+msgid "Exclude path from library updates"
+msgstr ""
+
+#: id:20433
+msgid "Extract thumbnails and video information"
+msgstr ""
+
+#: id:20434
+msgid "Sets"
+msgstr ""
+
+#: id:20435
+msgid "Set movieset thumb"
+msgstr ""
+
+#: id:20436
+msgid "Export actor thumbs?"
+msgstr ""
+
+#: id:20437
+msgid "Choose fanart"
+msgstr ""
+
+#: id:20438
+msgid "Local fanart"
+msgstr ""
+
+#: id:20439
+msgid "No fanart"
+msgstr ""
+
+#: id:20440
+msgid "Current fanart"
+msgstr ""
+
+#: id:20441
+msgid "Remote fanart"
+msgstr ""
+
+#: id:20442
+msgid "Change content"
+msgstr ""
+
+#: id:20443
+msgid "Do you want to refresh info for all"
+msgstr ""
+
+#: id:20444
+msgid "items within this path?"
+msgstr ""
+
+#: id:20445
+msgid "Fanart"
+msgstr ""
+
+#: id:20446
+msgid "Locally stored information found."
+msgstr ""
+
+#: id:20447
+msgid "Ignore and refresh from internet?"
+msgstr ""
+
+#: id:20448
+msgid "Could not download information"
+msgstr ""
+
+#: id:20449
+msgid "Unable to connect to remote server"
+msgstr ""
+
+#: id:20450
+msgid "Would you like to continue scanning?"
+msgstr ""
+
+#: id:20451
+msgid "Countries"
+msgstr ""
+
+#: id:20452
+msgid "episode"
+msgstr ""
+
+#: id:20453
+msgid "episodes"
+msgstr ""
+
+#: id:20454
+msgid "Listener"
+msgstr ""
+
+#: id:20455
+msgid "Listeners"
+msgstr ""
+
+#: id:20456
+msgid "Set movieset fanart"
+msgstr ""
+
+#: id:20457
+msgid "Movie set"
+msgstr ""
+
+#: id:20458
+msgid "Group movies in sets"
+msgstr ""
+
+#: id:21330
+msgid "Show hidden files and directories"
+msgstr ""
+
+#: id:21331
+msgid "TuxBox client"
+msgstr ""
+
+#: id:21332
+msgid "WARNING: Target TuxBox device is in recording-mode!"
+msgstr ""
+
+#: id:21333
+msgid "The stream will be stopped!"
+msgstr ""
+
+#: id:21334
+msgid "Zap to channel: %s failed!"
+msgstr ""
+
+#: id:21335
+msgid "Are you sure to start the stream?"
+msgstr ""
+
+#: id:21336
+msgid "Connecting to: %s"
+msgstr ""
+
+#: id:21337
+msgid "TuxBox device"
+msgstr ""
+
+#: id:21359
+msgid "Add media share..."
+msgstr ""
+
+#: id:21360
+msgid "Share video and music libraries through UPnP"
+msgstr ""
+
+#: id:21364
+msgid "Edit media share"
+msgstr ""
+
+#: id:21365
+msgid "Remove media share"
+msgstr ""
+
+#: id:21366
+msgid "Subtitle folder"
+msgstr ""
+
+#: id:21367
+msgid "Movie & alternate subtitle directory"
+msgstr ""
+
+#: id:21368
+msgid "Override ASS/SSA subtitles fonts"
+msgstr ""
+
+#: id:21369
+msgid "Enable mouse and Touch Screen support"
+msgstr ""
+
+#: id:21370
+msgid "Play navigation sounds during media playback"
+msgstr ""
+
+#: id:21371
+msgid "Thumbnail"
+msgstr ""
+
+#: id:21372
+msgid "Forced DVD player region"
+msgstr ""
+
+#: id:21373
+msgid "Video output"
+msgstr ""
+
+#: id:21374
+msgid "Video aspect"
+msgstr ""
+
+#: id:21375
+msgctxt "Auto context with id 21375"
+msgid "Normal"
+msgstr ""
+
+#: id:21376
+msgid "Letterbox"
+msgstr ""
+
+#: id:21377
+msgid "Widescreen"
+msgstr ""
+
+#: id:21378
+msgid "Enable 480p"
+msgstr ""
+
+#: id:21379
+msgid "Enable 720p"
+msgstr ""
+
+#: id:21380
+msgid "Enable 1080i"
+msgstr ""
+
+#: id:21381
+msgid "Enter name of new playlist"
+msgstr ""
+
+#: id:21382
+msgid "Show \"Add source\" buttons in file lists"
+msgstr ""
+
+#: id:21383
+msgid "Enable scrollbars"
+msgstr ""
+
+#: id:21384
+msgid "Make watched filtering a toggle in video library"
+msgstr ""
+
+#: id:21385
+msgctxt "Auto context with id 21385"
+msgid "Open"
+msgstr ""
+
+#: id:21386
+msgid "Acoustic management level"
+msgstr ""
+
+#: id:21387
+msgid "Fast"
+msgstr ""
+
+#: id:21388
+msgid "Quiet"
+msgstr ""
+
+#: id:21389
+msgid "Enable custom background"
+msgstr ""
+
+#: id:21390
+msgid "Power management level"
+msgstr ""
+
+#: id:21391
+msgid "High power"
+msgstr ""
+
+#: id:21392
+msgid "Low power"
+msgstr ""
+
+#: id:21393
+msgid "High standby"
+msgstr ""
+
+#: id:21394
+msgid "Low standby"
+msgstr ""
+
+#: id:21395
+msgid "Unable to cache files bigger than 4GB"
+msgstr ""
+
+#: id:21396
+msgid "Chapter"
+msgstr ""
+
+#: id:21397
+msgid "High quality pixel shader v2"
+msgstr ""
+
+#: id:21398
+msgid "Enable playlist at startup"
+msgstr ""
+
+#: id:21399
+msgid "Use tween animations"
+msgstr ""
+
+#: id:21400
+msgid "contains"
+msgstr ""
+
+#: id:21401
+msgid "does not contain"
+msgstr ""
+
+#: id:21402
+msgid "is"
+msgstr ""
+
+#: id:21403
+msgid "is not"
+msgstr ""
+
+#: id:21404
+msgid "starts with"
+msgstr ""
+
+#: id:21405
+msgid "ends with"
+msgstr ""
+
+#: id:21406
+msgid "greater than"
+msgstr ""
+
+#: id:21407
+msgid "less than"
+msgstr ""
+
+#: id:21408
+msgid "after"
+msgstr ""
+
+#: id:21409
+msgid "before"
+msgstr ""
+
+#: id:21410
+msgid "in the last"
+msgstr ""
+
+#: id:21411
+msgid "not in the last"
+msgstr ""
+
+#: id:21412
+msgid "Scrapers"
+msgstr ""
+
+#: id:21413
+msgid "Default movie scraper"
+msgstr ""
+
+#: id:21414
+msgid "Default tvshow scraper"
+msgstr ""
+
+#: id:21415
+msgid "Default music video scraper"
+msgstr ""
+
+#: id:21416
+msgid "Enable fallback based on scraper language"
+msgstr ""
+
+#: id:21417
+msgid "- Settings"
+msgstr ""
+
+#: id:21418
+msgid "Multilingual"
+msgstr ""
+
+#: id:21419
+msgid "No scrapers present"
+msgstr ""
+
+#: id:21420
+msgid "Value to match"
+msgstr ""
+
+#: id:21421
+msgid "Smart playlist rule"
+msgstr ""
+
+#: id:21422
+msgid "Match items where"
+msgstr ""
+
+#: id:21423
+msgid "New rule..."
+msgstr ""
+
+#: id:21424
+msgid "Items must match"
+msgstr ""
+
+#: id:21425
+msgid "all of the rules"
+msgstr ""
+
+#: id:21426
+msgid "one or more of the rules"
+msgstr ""
+
+#: id:21427
+msgid "Limit to"
+msgstr ""
+
+#: id:21428
+msgid "No limit"
+msgstr ""
+
+#: id:21429
+msgid "Order by"
+msgstr ""
+
+#: id:21430
+msgid "ascending"
+msgstr ""
+
+#: id:21431
+msgid "descending"
+msgstr ""
+
+#: id:21432
+msgid "Edit smart playlist"
+msgstr ""
+
+#: id:21433
+msgid "Name of the playlist"
+msgstr ""
+
+#: id:21434
+msgid "Find items where"
+msgstr ""
+
+#: id:21435
+msgid "Edit"
+msgstr ""
+
+#: id:21436
+msgid "%i items"
+msgstr ""
+
+#: id:21437
+msgid "New smart playlist..."
+msgstr ""
+
+#: id:21438
+msgid "%c Drive"
+msgstr ""
+
+#: id:21439
+msgid "Edit party mode rules"
+msgstr ""
+
+#: id:21440
+msgid "Home folder"
+msgstr ""
+
+#: id:21441
+msgid "Watched count"
+msgstr ""
+
+#: id:21442
+msgid "Episode title"
+msgstr ""
+
+#: id:21443
+msgid "Video resolution"
+msgstr ""
+
+#: id:21444
+msgid "Audio channels"
+msgstr ""
+
+#: id:21445
+msgid "Video codec"
+msgstr ""
+
+#: id:21446
+msgid "Audio codec"
+msgstr ""
+
+#: id:21447
+msgid "Audio language"
+msgstr ""
+
+#: id:21448
+msgid "Subtitle language"
+msgstr ""
+
+#: id:21449
+msgid "Remote control sends keyboard presses"
+msgstr ""
+
+#: id:21450
+msgid "- Edit"
+msgstr ""
+
+#: id:21451
+msgid "Internet connection required."
+msgstr ""
+
+#: id:21452
+msgid "Get More..."
+msgstr ""
+
+#: id:21453
+msgid "Root filesystem"
+msgstr ""
+
+#: id:21454
+msgid "Cache full"
+msgstr ""
+
+#: id:21455
+msgid "Cache filled before reaching required amount for continous playback"
+msgstr ""
+
+#: id:21460
+msgid "Subtitle location"
+msgstr ""
+
+#: id:21461
+msgid "Fixed"
+msgstr ""
+
+#: id:21462
+msgid "Bottom of video"
+msgstr ""
+
+#: id:21463
+msgid "Below video"
+msgstr ""
+
+#: id:21464
+msgid "Top of video"
+msgstr ""
+
+#: id:21465
+msgid "Above video"
+msgstr ""
+
+#: id:21800
+msgid "File name"
+msgstr ""
+
+#: id:21801
+msgid "File path"
+msgstr ""
+
+#: id:21802
+msgid "File size"
+msgstr ""
+
+#: id:21803
+msgid "File date/time"
+msgstr ""
+
+#: id:21804
+msgid "Slide index"
+msgstr ""
+
+#: id:21805
+msgctxt "Auto context with id 21805"
+msgid "Resolution"
+msgstr ""
+
+#: id:21806
+msgctxt "Auto context with id 21806"
+msgid "Comment"
+msgstr ""
+
+#: id:21807
+msgid "Colour/B&W"
+msgstr "Color/B&W"
+
+#: id:21808
+msgid "JPEG process"
+msgstr ""
+
+#: id:21820
+msgid "Date/Time"
+msgstr ""
+
+#: id:21821
+msgid "Description"
+msgstr ""
+
+#: id:21822
+msgid "Camera make"
+msgstr ""
+
+#: id:21823
+msgid "Camera model"
+msgstr ""
+
+#: id:21824
+msgid "EXIF comment"
+msgstr ""
+
+#: id:21825
+msgid "Firmware"
+msgstr ""
+
+#: id:21826
+msgid "Aperture"
+msgstr ""
+
+#: id:21827
+msgid "Focal length"
+msgstr ""
+
+#: id:21828
+msgid "Focus distance"
+msgstr ""
+
+#: id:21829
+msgid "Exposure"
+msgstr ""
+
+#: id:21830
+msgid "Exposure time"
+msgstr ""
+
+#: id:21831
+msgid "Exposure bias"
+msgstr ""
+
+#: id:21832
+msgid "Exposure mode"
+msgstr ""
+
+#: id:21833
+msgid "Flash used"
+msgstr ""
+
+#: id:21834
+msgid "White-balance"
+msgstr ""
+
+#: id:21835
+msgid "Light source"
+msgstr ""
+
+#: id:21836
+msgid "Metering mode"
+msgstr ""
+
+#: id:21837
+msgid "ISO"
+msgstr ""
+
+#: id:21838
+msgid "Digital zoom"
+msgstr ""
+
+#: id:21839
+msgid "CCD width"
+msgstr ""
+
+#: id:21840
+msgid "GPS latitude"
+msgstr ""
+
+#: id:21841
+msgid "GPS longitude"
+msgstr ""
+
+#: id:21842
+msgid "GPS altitude"
+msgstr ""
+
+#: id:21843
+msgid "Orientation"
+msgstr ""
+
+#: id:21860
+msgid "Supplemental categories"
+msgstr ""
+
+#: id:21861
+msgid "Keywords"
+msgstr ""
+
+#: id:21862
+msgid "Caption"
+msgstr ""
+
+#: id:21863
+msgid "Author"
+msgstr ""
+
+#: id:21864
+msgid "Headline"
+msgstr ""
+
+#: id:21865
+msgid "Special instructions"
+msgstr ""
+
+#: id:21866
+msgid "Category"
+msgstr ""
+
+#: id:21867
+msgid "Byline"
+msgstr ""
+
+#: id:21868
+msgid "Byline title"
+msgstr ""
+
+#: id:21869
+msgid "Credit"
+msgstr ""
+
+#: id:21870
+msgid "Source"
+msgstr ""
+
+#: id:21871
+msgid "Copyright notice"
+msgstr ""
+
+#: id:21872
+msgid "Object name"
+msgstr ""
+
+#: id:21873
+msgid "City"
+msgstr ""
+
+#: id:21874
+msgid "State"
+msgstr ""
+
+#: id:21875
+msgctxt "Auto context with id 21875"
+msgid "Country"
+msgstr ""
+
+#: id:21876
+msgid "Original Tx Reference"
+msgstr ""
+
+#: id:21877
+msgid "Date created"
+msgstr ""
+
+#: id:21878
+msgid "Copyright flag"
+msgstr ""
+
+#: id:21879
+msgid "Country code"
+msgstr ""
+
+#: id:21880
+msgid "Reference service"
+msgstr ""
+
+#: id:21881
+msgid "Allow control of XBMC via UPnP"
+msgstr ""
+
+#: id:21882
+msgid "Attempt to skip introduction before DVD menu"
+msgstr ""
+
+#: id:21883
+msgid "Saved music"
+msgstr ""
+
+#: id:21884
+msgid "Query info for all artists"
+msgstr ""
+
+#: id:21885
+msgid "Downloading album information"
+msgstr ""
+
+#: id:21886
+msgid "Downloading artist information"
+msgstr ""
+
+#: id:21887
+msgid "Biography"
+msgstr ""
+
+#: id:21888
+msgid "Discography"
+msgstr ""
+
+#: id:21889
+msgid "Searching artist"
+msgstr ""
+
+#: id:21890
+msgid "Select artist"
+msgstr ""
+
+#: id:21891
+msgctxt "Auto context with id 21891"
+msgid "Artist information"
+msgstr ""
+
+#: id:21892
+msgid "Instruments"
+msgstr ""
+
+#: id:21893
+msgid "Born"
+msgstr ""
+
+#: id:21894
+msgid "Formed"
+msgstr ""
+
+#: id:21895
+msgid "Themes"
+msgstr ""
+
+#: id:21896
+msgid "Disbanded"
+msgstr ""
+
+#: id:21897
+msgid "Died"
+msgstr ""
+
+#: id:21898
+msgid "Years active"
+msgstr ""
+
+#: id:21899
+msgid "Label"
+msgstr ""
+
+#: id:21900
+msgid "Born/Formed"
+msgstr ""
+
+#: id:22000
+msgid "Update library on startup"
+msgstr ""
+
+#: id:22001
+msgid "Hide progress of library updates"
+msgstr ""
+
+#: id:22002
+msgid "- DNS suffix"
+msgstr ""
+
+#: id:22003
+msgid "%2.3fs"
+msgstr ""
+
+#: id:22004
+msgid "Delayed by: %2.3fs"
+msgstr ""
+
+#: id:22005
+msgid "Ahead by: %2.3fs"
+msgstr ""
+
+#: id:22006
+msgid "Subtitle offset"
+msgstr ""
+
+#: id:22007
+msgid "OpenGL vendor:"
+msgstr ""
+
+#: id:22008
+msgid "OpenGL renderer:"
+msgstr ""
+
+#: id:22009
+msgid "OpenGL version:"
+msgstr ""
+
+#: id:22010
+msgid "GPU temperature:"
+msgstr ""
+
+#: id:22011
+msgid "CPU temperature:"
+msgstr ""
+
+#: id:22012
+msgid "Total memory"
+msgstr ""
+
+#: id:22013
+msgid "Profile data"
+msgstr ""
+
+#: id:22014
+msgid "Use dim if paused during video playback"
+msgstr ""
+
+#: id:22015
+msgid "All recordings"
+msgstr ""
+
+#: id:22016
+msgid "By title"
+msgstr ""
+
+#: id:22017
+msgid "By group"
+msgstr ""
+
+#: id:22018
+msgid "Live channels"
+msgstr ""
+
+#: id:22019
+msgid "Recordings by title"
+msgstr ""
+
+#: id:22020
+msgid "Guide"
+msgstr ""
+
+#: id:22021
+msgid "Allowed error in aspect ratio to minimize black bars"
+msgstr ""
+
+#: id:22022
+msgid "Show video files in listings"
+msgstr ""
+
+#: id:22023
+msgid "DirectX vendor:"
+msgstr ""
+
+#: id:22024
+msgid "Direct3D version:"
+msgstr ""
+
+#: id:22030
+msgctxt "Auto context with id 22030"
+msgid "Font"
+msgstr ""
+
+#: id:22031
+msgctxt "Auto context with id 22031"
+msgid "- Size"
+msgstr ""
+
+#: id:22032
+msgctxt "Auto context with id 22032"
+msgid "- Colours"
+msgstr "- Colors"
+
+#: id:22033
+msgid "- Charset"
+msgstr ""
+
+#: id:22034
+msgid "Export karaoke titles as HTML"
+msgstr ""
+
+#: id:22035
+msgid "Export karaoke titles as CSV"
+msgstr ""
+
+#: id:22036
+msgid "Import karaoke titles..."
+msgstr ""
+
+#: id:22037
+msgid "Show song selector automatically"
+msgstr ""
+
+#: id:22038
+msgid "Export karaoke titles..."
+msgstr ""
+
+#: id:22039
+msgid "Enter song number"
+msgstr ""
+
+#: id:22040
+msgid "white/green"
+msgstr ""
+
+#: id:22041
+msgid "white/red"
+msgstr ""
+
+#: id:22042
+msgid "white/blue"
+msgstr ""
+
+#: id:22043
+msgid "black/white"
+msgstr ""
+
+#: id:22079
+msgid "Default select action"
+msgstr ""
+
+#: id:22080
+msgid "Choose"
+msgstr ""
+
+#: id:22081
+msgid "Show Information"
+msgstr ""
+
+#: id:22082
+msgid "More..."
+msgstr ""
+
+#: id:22083
+msgid "Play all"
+msgstr ""
+
+#: id:23049
+msgid "Teletext not available"
+msgstr ""
+
+#: id:23050
+msgid "Activate Teletext"
+msgstr ""
+
+#: id:23051
+msgid "Part %i"
+msgstr ""
+
+#: id:23052
+msgid "Buffering %i bytes"
+msgstr ""
+
+#: id:23053
+msgid "Stopping"
+msgstr ""
+
+#: id:23054
+msgid "Running"
+msgstr ""
+
+#: id:23100
+msgid "External Player Active"
+msgstr ""
+
+#: id:23101
+msgid "Click OK to terminate the player"
+msgstr ""
+
+#: id:23104
+msgid "Click OK when playback has ended"
+msgstr ""
+
+#: id:24000
+msgid "Add-on"
+msgstr ""
+
+#: id:24001
+msgid "Add-ons"
+msgstr ""
+
+#: id:24002
+msgid "Add-on options"
+msgstr ""
+
+#: id:24003
+msgid "Add-on Information"
+msgstr ""
+
+#: id:24005
+msgctxt "Auto context with id 24005"
+msgid "Media sources"
+msgstr ""
+
+#: id:24007
+msgctxt "Auto context with id 24007"
+msgid "Movie information"
+msgstr ""
+
+#: id:24008
+msgctxt "Auto context with id 24008"
+msgid "Screensaver"
+msgstr ""
+
+#: id:24009
+msgid "Script"
+msgstr ""
+
+#: id:24010
+msgctxt "Auto context with id 24010"
+msgid "Visualization"
+msgstr ""
+
+#: id:24011
+msgid "Add-on repository"
+msgstr ""
+
+#: id:24012
+msgctxt "Auto context with id 24012"
+msgid "Subtitles"
+msgstr ""
+
+#: id:24013
+msgid "Lyrics"
+msgstr ""
+
+#: id:24014
+msgid "TV information"
+msgstr ""
+
+#: id:24015
+msgctxt "Auto context with id 24015"
+msgid "Music video information"
+msgstr ""
+
+#: id:24016
+msgctxt "Auto context with id 24016"
+msgid "Album information"
+msgstr ""
+
+#: id:24017
+msgctxt "Auto context with id 24017"
+msgid "Artist information"
+msgstr ""
+
+#: id:24018
+msgctxt "Auto context with id 24018"
+msgid "Services"
+msgstr ""
+
+#: id:24020
+msgid "Configure"
+msgstr ""
+
+#: id:24021
+msgctxt "Auto context with id 24021"
+msgid "Disable"
+msgstr ""
+
+#: id:24022
+msgid "Enable"
+msgstr ""
+
+#: id:24023
+msgid "Add-on disabled"
+msgstr ""
+
+#: id:24027
+msgctxt "Auto context with id 24027"
+msgid "Weather"
+msgstr ""
+
+#: id:24028
+msgid "Weather.com (standard)"
+msgstr ""
+
+#: id:24030
+msgid "This Add-on can not be configured"
+msgstr ""
+
+#: id:24031
+msgid "Error loading settings"
+msgstr ""
+
+#: id:24032
+msgid "All Add-ons"
+msgstr ""
+
+#: id:24033
+msgid "Get Add-ons"
+msgstr ""
+
+#: id:24034
+msgid "Check for updates"
+msgstr ""
+
+#: id:24035
+msgid "Force refresh"
+msgstr ""
+
+#: id:24036
+msgid "Change log"
+msgstr ""
+
+#: id:24037
+msgid "Uninstall"
+msgstr ""
+
+#: id:24038
+msgid "Install"
+msgstr ""
+
+#: id:24039
+msgid "Disabled Add-ons"
+msgstr ""
+
+#: id:24040
+msgid "(Clear the current setting)"
+msgstr ""
+
+#: id:24041
+msgid "Install from zip file"
+msgstr ""
+
+#: id:24042
+msgid "Downloading %i%%"
+msgstr ""
+
+#: id:24043
+msgid "Available Updates"
+msgstr ""
+
+#: id:24044
+msgid "Dependencies not met"
+msgstr ""
+
+#: id:24045
+msgid "Add-on does not have the correct structure"
+msgstr ""
+
+#: id:24046
+msgid "%s is used by the following installed add-on(s)"
+msgstr ""
+
+#: id:24047
+msgid "This add-on cannot be uninstalled"
+msgstr ""
+
+#: id:24048
+msgid "Rollback"
+msgstr ""
+
+#: id:24050
+msgid "Available Add-ons"
+msgstr ""
+
+#: id:24051
+msgid "Version:"
+msgstr ""
+
+#: id:24052
+msgid "Disclaimer"
+msgstr ""
+
+#: id:24053
+msgid "License:"
+msgstr ""
+
+#: id:24054
+msgid "Changelog"
+msgstr ""
+
+#: id:24059
+msgid "Would you like to enable this Add-on?"
+msgstr ""
+
+#: id:24060
+msgid "Would you like to disable this Add-on?"
+msgstr ""
+
+#: id:24061
+msgid "Add-on update available!"
+msgstr ""
+
+#: id:24062
+msgid "Enabled Add-ons"
+msgstr ""
+
+#: id:24063
+msgid "Auto update"
+msgstr ""
+
+#: id:24064
+msgid "Add-on enabled"
+msgstr ""
+
+#: id:24065
+msgid "Add-on updated"
+msgstr ""
+
+#: id:24066
+msgid "Cancel Add-on download?"
+msgstr ""
+
+#: id:24067
+msgid "Currently downloading Add-ons"
+msgstr ""
+
+#: id:24068
+msgid "Update available"
+msgstr ""
+
+#: id:24069
+msgid "Update"
+msgstr ""
+
+#: id:24070
+msgid "Add-on could not be loaded."
+msgstr ""
+
+#: id:24071
+msgid "An unknown error has occurred."
+msgstr ""
+
+#: id:24072
+msgid "Settings required"
+msgstr ""
+
+#: id:24073
+msgid "Could not connect"
+msgstr ""
+
+#: id:24074
+msgid "Needs to restart"
+msgstr ""
+
+#: id:24075
+msgctxt "Auto context with id 24075"
+msgid "Disable"
+msgstr ""
+
+#: id:24076
+msgid "Add-on Required"
+msgstr ""
+
+#: id:24080
+msgid "Try to reconnect?"
+msgstr ""
+
+#: id:24089
+msgid "Add-on restarts"
+msgstr ""
+
+#: id:24090
+msgid "Lock Add-on manager"
+msgstr ""
+
+#: id:24094
+msgid "(current)"
+msgstr ""
+
+#: id:24095
+msgid "(blacklisted)"
+msgstr ""
+
+#: id:24096
+msgid "Add-on has been marked as broken in repository."
+msgstr ""
+
+#: id:24097
+msgid "Would you like to disable it on your system?"
+msgstr ""
+
+#: id:24098
+msgid "Broken"
+msgstr ""
+
+#: id:24099
+msgid "Would you like to switch to this skin?"
+msgstr ""
+
+#: id:24100
+msgid "To use this feature you must download an Add-on:"
+msgstr ""
+
+#: id:24101
+msgid "Would you like to download this Add-on?"
+msgstr ""
+
+#: id:25000
+msgid "Notifications"
+msgstr ""
+
+#: id:29800
+msgid "Library Mode"
+msgstr ""
+
+#: id:29801
+msgid "QWERTY keyboard"
+msgstr ""
+
+#: id:29802
+msgid "Passthrough Audio in use"
+msgstr ""
+
+#: id:33001
+msgid "Trailer quality"
+msgstr ""
+
+#: id:33002
+msgid "Stream"
+msgstr ""
+
+#: id:33003
+msgid "Download"
+msgstr ""
+
+#: id:33004
+msgid "Download & play"
+msgstr ""
+
+#: id:33005
+msgid "Download & save"
+msgstr ""
+
+#: id:33006
+msgid "Today"
+msgstr ""
+
+#: id:33007
+msgid "Tomorrow"
+msgstr ""
+
+#: id:33008
+msgid "Saving"
+msgstr ""
+
+#: id:33009
+msgid "Copying"
+msgstr ""
+
+#: id:33010
+msgid "Set download directory"
+msgstr ""
+
+#: id:33011
+msgid "Search duration"
+msgstr ""
+
+#: id:33012
+msgid "Short"
+msgstr ""
+
+#: id:33013
+msgid "Long"
+msgstr ""
+
+#: id:33014
+msgid "Use DVD player instead of regular player"
+msgstr ""
+
+#: id:33015
+msgid "Ask for download before playing video"
+msgstr ""
+
+#: id:33016
+msgid "Clips"
+msgstr ""
+
+#: id:33017
+msgid "Restart plugin to enable"
+msgstr ""
+
+#: id:33018
+msgid "Tonight"
+msgstr ""
+
+#: id:33019
+msgid "Tomorrow Night"
+msgstr ""
+
+#: id:33020
+msgid "Condition"
+msgstr ""
+
+#: id:33021
+msgid "Precipitation"
+msgstr ""
+
+#: id:33022
+msgid "Precip"
+msgstr ""
+
+#: id:33023
+msgid "Humid"
+msgstr ""
+
+#: id:33024
+msgid "Feels"
+msgstr ""
+
+#: id:33025
+msgid "Observed"
+msgstr ""
+
+#: id:33026
+msgid "Departure from normal"
+msgstr ""
+
+#: id:33027
+msgid "Sunrise"
+msgstr ""
+
+#: id:33028
+msgid "Sunset"
+msgstr ""
+
+#: id:33029
+msgid "Details"
+msgstr ""
+
+#: id:33030
+msgid "Outlook"
+msgstr ""
+
+#: id:33031
+msgid "Coverflow"
+msgstr ""
+
+#: id:33032
+msgid "Translate text"
+msgstr ""
+
+#: id:33033
+msgid "Map list %s category"
+msgstr ""
+
+#: id:33034
+msgid "36 Hour"
+msgstr ""
+
+#: id:33035
+msgid "Maps"
+msgstr ""
+
+#: id:33036
+msgid "Hourly"
+msgstr ""
+
+#: id:33037
+msgid "Weekend"
+msgstr ""
+
+#: id:33038
+msgid "%s day"
+msgstr ""
+
+#: id:33049
+msgid "Alert"
+msgstr ""
+
+#: id:33050
+msgid "Alerts"
+msgstr ""
+
+#: id:33051
+msgid "Choose Your"
+msgstr ""
+
+#: id:33052
+msgid "Check"
+msgstr ""
+
+#: id:33053
+msgctxt "Auto context with id 33053"
+msgid "Configure the"
+msgstr ""
+
+#: id:33054
+msgid "Seasons"
+msgstr ""
+
+#: id:33055
+msgid "Use your"
+msgstr ""
+
+#: id:33056
+msgid "Watch your"
+msgstr ""
+
+#: id:33057
+msgid "Listen to"
+msgstr ""
+
+#: id:33058
+msgid "View your"
+msgstr ""
+
+#: id:33059
+msgctxt "Auto context with id 33059"
+msgid "Configure the"
+msgstr ""
+
+#: id:33060
+msgid "Power"
+msgstr ""
+
+#: id:33061
+msgid "Menu"
+msgstr ""
+
+#: id:33062
+msgid "Play the"
+msgstr ""
+
+#: id:33063
+msgid "Options"
+msgstr ""
+
+#: id:33065
+msgid "Editor"
+msgstr ""
+
+#: id:33066
+msgid "About your"
+msgstr ""
+
+#: id:33067
+msgid "Star rating"
+msgstr ""
+
+#: id:33068
+msgid "Background"
+msgstr ""
+
+#: id:33069
+msgid "Backgrounds"
+msgstr ""
+
+#: id:33070
+msgid "Custom background"
+msgstr ""
+
+#: id:33071
+msgid "Custom backgrounds"
+msgstr ""
+
+#: id:33072
+msgid "View Readme"
+msgstr ""
+
+#: id:33073
+msgid "View Changelog"
+msgstr ""
+
+#: id:33074
+msgid "This version of %s requires an"
+msgstr ""
+
+#: id:33075
+msgid "XBMC revision of %s or greater to run."
+msgstr ""
+
+#: id:33076
+msgid "Please update XBMC."
+msgstr ""
+
+#: id:33077
+msgid "No data found!"
+msgstr ""
+
+#: id:33078
+msgid "Next page"
+msgstr ""
+
+#: id:33079
+msgid "Love"
+msgstr ""
+
+#: id:33080
+msgid "Hate"
+msgstr ""
+
+#: id:33081
+msgid "This file is stacked, select the part you want to play from."
+msgstr ""
+
+#: id:33082
+msgid "Path to script"
+msgstr ""
+
+#: id:33083
+msgid "Enable custom script button"
+msgstr ""
+
+#: id:33100
+msgid "Failed to start"
+msgstr ""
+
+#: id:33101
+msgid "Webserver"
+msgstr ""
+
+#: id:33102
+msgid "Event Server"
+msgstr ""
+
+#: id:33103
+msgid "Remote communication server"
+msgstr ""
+
+#: id:33200
+msgid "Detected New Connection"
+msgstr ""
+
+#: id:34000
+msgid "Lame"
+msgstr ""
+
+#: id:34001
+msgid "Vorbis"
+msgstr ""
+
+#: id:34002
+msgid "Wav"
+msgstr ""
+
+#: id:34003
+msgid "DXVA2"
+msgstr ""
+
+#: id:34004
+msgid "VAAPI"
+msgstr ""
+
+#: id:34005
+msgid "Flac"
+msgstr ""
+
+#: id:34100
+msgid "Speaker Configuration"
+msgstr ""
+
+#: id:34101
+msgid "2.0"
+msgstr ""
+
+#: id:34102
+msgid "2.1"
+msgstr ""
+
+#: id:34103
+msgid "3.0"
+msgstr ""
+
+#: id:34104
+msgid "3.1"
+msgstr ""
+
+#: id:34105
+msgid "4.0"
+msgstr ""
+
+#: id:34106
+msgid "4.1"
+msgstr ""
+
+#: id:34107
+msgid "5.0"
+msgstr ""
+
+#: id:34108
+msgid "5.1"
+msgstr ""
+
+#: id:34109
+msgid "7.0"
+msgstr ""
+
+#: id:34110
+msgid "7.1"
+msgstr ""
+
+#: id:34201
+msgid "Can't find a next item to play"
+msgstr ""
+
+#: id:34202
+msgid "Can't find a previous item to play"
+msgstr ""
+
+#: id:34300
+msgid "Failed to start zeroconf"
+msgstr ""
+
+#: id:34301
+msgid "Is Apple's Bonjour Service installed? See log for more info."
+msgstr ""
+
+#: id:34400
+msgid "Video Rendering"
+msgstr ""
+
+#: id:34401
+msgid "Failed to init video filters/scalers, falling back to bilinear scaling"
+msgstr ""
+
+#: id:34402
+msgid "Failed to initialize audio device"
+msgstr ""
+
+#: id:34403
+msgid "Check your audiosettings"
+msgstr ""
+
+#: id:34404
+msgid "Use gestures for navigation:"
+msgstr ""
+
+#: id:34405
+msgid "1 finger swipe left,right,up,down for cursors"
+msgstr ""
+
+#: id:34406
+msgid "2 finger swipe left for backspace"
+msgstr ""
+
+#: id:34407
+msgid "1 finger single tap for enter"
+msgstr ""
+
+#: id:34408
+msgid "2 finger single tap for contextmenu"
+msgstr ""
+
+#: id:35000
+msgid "Peripherals"
+msgstr ""
+
+#: id:35001
+msgid "Generic HID device"
+msgstr ""
+
+#: id:35002
+msgid "Generic network adapter"
+msgstr ""
+
+#: id:35003
+msgid "Generic disk"
+msgstr ""
+
+#: id:35004
+msgid "There are no settings available\nfor this peripheral."
+msgstr ""
+
+#: id:35005
+msgid "New device configured"
+msgstr ""
+
+#: id:35006
+msgid "Device removed"
+msgstr ""
+
+#: id:35007
+msgid "Keymap to use for this device"
+msgstr ""
+
+#: id:35008
+msgid "Keymap enabled"
+msgstr ""
+
+#: id:35009
+msgid "Do not use the custom keymap for this device"
+msgstr ""
+
+#: id:35500
+msgid "Location"
+msgstr ""
+
+#: id:35501
+msgid "Class"
+msgstr ""
+
+#: id:35502
+msgctxt "Auto context with id 35502"
+msgid "Name"
+msgstr ""
+
+#: id:35503
+msgid "Vendor"
+msgstr ""
+
+#: id:35504
+msgid "Product ID"
+msgstr ""
+
+#: id:36000
+msgid "Pulse-Eight CEC adapter"
+msgstr ""
+
+#: id:36001
+msgid "Pulse-Eight Nyxboard"
+msgstr ""
+
+#: id:36002
+msgid "Switch to keyboard side command"
+msgstr ""
+
+#: id:36003
+msgid "Switch to remote side command"
+msgstr ""
+
+#: id:36004
+msgid "Press \"user\" button command"
+msgstr ""
+
+#: id:36005
+msgid "Enable switch side commands"
+msgstr ""
+
+#: id:36006
+msgid "Could not open the adapter"
+msgstr ""
+
+#: id:36007
+msgid "Devices to power on when starting XBMC"
+msgstr ""
+
+#: id:36008
+msgid "Devices to power off when stopping XBMC"
+msgstr ""
+
+#: id:36009
+msgid "Put devices in standby mode when activating screensaver"
+msgstr ""
+
+#: id:36011
+msgid "Could not detect the CEC port. Set it up manually."
+msgstr ""
+
+#: id:36012
+msgid "Could not initialise the CEC adapter. Check your settings."
+msgstr ""
+
+#: id:36013
+msgid "Unsupported libCEC interface version. %d is greater than the version XBMC supports (%d)"
+msgstr ""
+
+#: id:36014
+msgid "Put this PC in standby mode when the TV is switched off"
+msgstr ""
+
+#: id:36015
+msgid "HDMI port number"
+msgstr ""
+
+#: id:36016
+msgctxt "Auto context with id 36016"
+msgid "Connected"
+msgstr ""
+
+#: id:36017
+msgid "Adapter found, but libCEC is not available"
+msgstr ""
+
+#: id:36018
+msgid "Use the TV's language setting"
+msgstr ""
+
+#: id:36019
+msgid "Connected to HDMI device"
+msgstr ""
+
+#: id:36020
+msgid "Make XBMC the active source when starting"
+msgstr ""
+
+#: id:36021
+msgid "Physical address (overrules HDMI port)"
+msgstr ""
+
+#: id:36022
+msgid "COM port (leave empty unless needed)"
+msgstr ""
+
+#: id:36023
+msgid "Configuration updated"
+msgstr ""
+
+#: id:36024
+msgid "Failed to set the new configuration. Please check your settings."
+msgstr ""
+
+#: id:36025
+msgid "Send 'inactive source' command when stopping XBMC"
+msgstr ""
+

--- a/language/English/strings.po
+++ b/language/English/strings.po
@@ -1,0 +1,9538 @@
+# Converted from xbmc strings.xml with xbmc-xml2po (by Team-XBMC)
+msgid ""
+msgstr ""
+"Project-Id-Version: xbmc.core-FRODO_GIT3ed1604ad7\n"
+"Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
+"POT-Creation-Date: 2012-04-09 18:00+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE\n"
+"Language: en\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: id:0
+msgctxt "Auto context with id 0"
+msgid "Programs"
+msgstr ""
+
+#: id:1
+msgctxt "Auto context with id 1"
+msgid "Pictures"
+msgstr ""
+
+#: id:2
+msgctxt "Auto context with id 2"
+msgid "Music"
+msgstr ""
+
+#: id:3
+msgctxt "Auto context with id 3"
+msgid "Videos"
+msgstr ""
+
+#: id:4
+msgid "TV-Guide"
+msgstr ""
+
+#: id:5
+msgctxt "Auto context with id 5"
+msgid "Settings"
+msgstr ""
+
+#: id:6
+msgid "XBMC SVN"
+msgstr ""
+
+#: id:7
+msgctxt "Auto context with id 7"
+msgid "File manager"
+msgstr ""
+
+#: id:8
+msgctxt "Auto context with id 8"
+msgid "Weather"
+msgstr ""
+
+#: id:9
+msgid "xbmc media center"
+msgstr ""
+
+#empty string with id 10
+
+#: id:11
+msgid "Monday"
+msgstr ""
+
+#: id:12
+msgid "Tuesday"
+msgstr ""
+
+#: id:13
+msgid "Wednesday"
+msgstr ""
+
+#: id:14
+msgid "Thursday"
+msgstr ""
+
+#: id:15
+msgid "Friday"
+msgstr ""
+
+#: id:16
+msgid "Saturday"
+msgstr ""
+
+#: id:17
+msgid "Sunday"
+msgstr ""
+
+#empty strings from id 18 to 20
+
+#: id:21
+msgid "January"
+msgstr ""
+
+#: id:22
+msgid "February"
+msgstr ""
+
+#: id:23
+msgid "March"
+msgstr ""
+
+#: id:24
+msgid "April"
+msgstr ""
+
+#: id:25
+msgctxt "Auto context with id 25"
+msgid "May"
+msgstr ""
+
+#: id:26
+msgid "June"
+msgstr ""
+
+#: id:27
+msgid "July"
+msgstr ""
+
+#: id:28
+msgid "August"
+msgstr ""
+
+#: id:29
+msgid "September"
+msgstr ""
+
+#: id:30
+msgid "October"
+msgstr ""
+
+#: id:31
+msgid "November"
+msgstr ""
+
+#: id:32
+msgid "December"
+msgstr ""
+
+#empty strings from id 33 to 40
+
+#: id:41
+msgid "Mon"
+msgstr ""
+
+#: id:42
+msgid "Tue"
+msgstr ""
+
+#: id:43
+msgid "Wed"
+msgstr ""
+
+#: id:44
+msgid "Thu"
+msgstr ""
+
+#: id:45
+msgid "Fri"
+msgstr ""
+
+#: id:46
+msgid "Sat"
+msgstr ""
+
+#: id:47
+msgctxt "Auto context with id 47"
+msgid "Sun"
+msgstr ""
+
+#empty strings from id 48 to 50
+
+#: id:51
+msgid "Jan"
+msgstr ""
+
+#: id:52
+msgid "Feb"
+msgstr ""
+
+#: id:53
+msgid "Mar"
+msgstr ""
+
+#: id:54
+msgid "Apr"
+msgstr ""
+
+#: id:55
+msgctxt "Auto context with id 55"
+msgid "May"
+msgstr ""
+
+#: id:56
+msgid "Jun"
+msgstr ""
+
+#: id:57
+msgid "Jul"
+msgstr ""
+
+#: id:58
+msgid "Aug"
+msgstr ""
+
+#: id:59
+msgid "Sep"
+msgstr ""
+
+#: id:60
+msgid "Oct"
+msgstr ""
+
+#: id:61
+msgid "Nov"
+msgstr ""
+
+#: id:62
+msgid "Dec"
+msgstr ""
+
+#empty strings from id 63 to 70
+
+#: id:71
+msgid "N"
+msgstr ""
+
+#: id:72
+msgid "NNE"
+msgstr ""
+
+#: id:73
+msgid "NE"
+msgstr ""
+
+#: id:74
+msgid "ENE"
+msgstr ""
+
+#: id:75
+msgid "E"
+msgstr ""
+
+#: id:76
+msgid "ESE"
+msgstr ""
+
+#: id:77
+msgid "SE"
+msgstr ""
+
+#: id:78
+msgid "SSE"
+msgstr ""
+
+#: id:79
+msgid "S"
+msgstr ""
+
+#: id:80
+msgid "SSW"
+msgstr ""
+
+#: id:81
+msgid "SW"
+msgstr ""
+
+#: id:82
+msgid "WSW"
+msgstr ""
+
+#: id:83
+msgid "W"
+msgstr ""
+
+#: id:84
+msgid "WNW"
+msgstr ""
+
+#: id:85
+msgid "NW"
+msgstr ""
+
+#: id:86
+msgid "NNW"
+msgstr ""
+
+#: id:87
+msgid "VAR"
+msgstr ""
+
+#empty strings from id 88 to 97
+
+#: id:98
+msgid "View: Auto"
+msgstr ""
+
+#: id:99
+msgid "View: Auto big"
+msgstr ""
+
+#: id:100
+msgid "View: Icons"
+msgstr ""
+
+#: id:101
+msgid "View: List"
+msgstr ""
+
+#: id:102
+msgctxt "Auto context with id 102"
+msgid "Scan"
+msgstr ""
+
+#: id:103
+msgctxt "Auto context with id 103"
+msgid "Sort by: Name"
+msgstr ""
+
+#: id:104
+msgid "Sort by: Date"
+msgstr ""
+
+#: id:105
+msgid "Sort by: Size"
+msgstr ""
+
+#: id:106
+msgid "No"
+msgstr ""
+
+#: id:107
+msgid "Yes"
+msgstr ""
+
+#: id:108
+msgctxt "Auto context with id 108"
+msgid "Slideshow"
+msgstr ""
+
+#: id:109
+msgid "Create thumbs"
+msgstr ""
+
+#: id:110
+msgid "Create thumbnails"
+msgstr ""
+
+#: id:111
+msgctxt "Auto context with id 111"
+msgid "Shortcuts"
+msgstr ""
+
+#: id:112
+msgid "Paused"
+msgstr ""
+
+#: id:113
+msgid "Update failed"
+msgstr ""
+
+#: id:114
+msgid "Installation failed"
+msgstr ""
+
+#: id:115
+msgid "Copy"
+msgstr ""
+
+#: id:116
+msgid "Move"
+msgstr ""
+
+#: id:117
+msgid "Delete"
+msgstr ""
+
+#: id:118
+msgid "Rename"
+msgstr ""
+
+#: id:119
+msgid "New folder"
+msgstr ""
+
+#: id:120
+msgid "Confirm file copy"
+msgstr ""
+
+#: id:121
+msgid "Confirm file move"
+msgstr ""
+
+#: id:122
+msgid "Confirm file delete?"
+msgstr ""
+
+#: id:123
+msgid "Copy these files?"
+msgstr ""
+
+#: id:124
+msgid "Move these files?"
+msgstr ""
+
+#: id:125
+msgid "Delete these files? - Deleting files cannot be undone!"
+msgstr ""
+
+#: id:126
+msgid "Status"
+msgstr ""
+
+#: id:127
+msgid "Objects"
+msgstr ""
+
+#: id:128
+msgctxt "Auto context with id 128"
+msgid "General"
+msgstr ""
+
+#: id:129
+msgctxt "Auto context with id 129"
+msgid "Slideshow"
+msgstr ""
+
+#: id:130
+msgctxt "Auto context with id 130"
+msgid "System info"
+msgstr ""
+
+#: id:131
+msgid "Display"
+msgstr ""
+
+#: id:132
+msgid "Albums"
+msgstr ""
+
+#: id:133
+msgid "Artists"
+msgstr ""
+
+#: id:134
+msgid "Songs"
+msgstr ""
+
+#: id:135
+msgid "Genres"
+msgstr ""
+
+#: id:136
+msgid "Playlists"
+msgstr ""
+
+#: id:137
+msgid "Search"
+msgstr ""
+
+#: id:138
+msgid "System Information"
+msgstr ""
+
+#: id:139
+msgid "Temperatures:"
+msgstr ""
+
+#: id:140
+msgid "CPU:"
+msgstr ""
+
+#: id:141
+msgid "GPU:"
+msgstr ""
+
+#: id:142
+msgid "Time:"
+msgstr ""
+
+#: id:143
+msgid "Current:"
+msgstr ""
+
+#: id:144
+msgid "Build:"
+msgstr ""
+
+#: id:145
+msgid "Network:"
+msgstr ""
+
+#: id:146
+msgid "Type:"
+msgstr ""
+
+#: id:147
+msgid "Static"
+msgstr ""
+
+#: id:148
+msgid "DHCP"
+msgstr ""
+
+#: id:149
+msgid "MAC address"
+msgstr ""
+
+#: id:150
+msgctxt "Auto context with id 150"
+msgid "IP address"
+msgstr ""
+
+#: id:151
+msgid "Link:"
+msgstr ""
+
+#: id:152
+msgid "Half duplex"
+msgstr ""
+
+#: id:153
+msgid "Full duplex"
+msgstr ""
+
+#: id:154
+msgctxt "Auto context with id 154"
+msgid "Storage"
+msgstr ""
+
+#: id:155
+msgid "Drive"
+msgstr ""
+
+#: id:156
+msgctxt "Auto context with id 156"
+msgid "Free"
+msgstr ""
+
+#: id:157
+msgctxt "Auto context with id 157"
+msgid "Video"
+msgstr ""
+
+#: id:158
+msgid "Free memory"
+msgstr ""
+
+#: id:159
+msgid "No link"
+msgstr ""
+
+#: id:160
+msgctxt "Auto context with id 160"
+msgid "Free"
+msgstr ""
+
+#: id:161
+msgid "Unavailable"
+msgstr ""
+
+#: id:162
+msgid "Tray open"
+msgstr ""
+
+#: id:163
+msgid "Reading"
+msgstr ""
+
+#: id:164
+msgid "No disc"
+msgstr ""
+
+#: id:165
+msgid "Disc present"
+msgstr ""
+
+#: id:166
+msgid "Skin"
+msgstr ""
+
+#empty strings from id 167 to 168
+
+#: id:169
+msgctxt "Auto context with id 169"
+msgid "Resolution"
+msgstr ""
+
+#: id:170
+msgid "Adjust display refresh rate to match video"
+msgstr ""
+
+#empty string with id 171
+
+#: id:172
+msgid "Release date"
+msgstr ""
+
+#: id:173
+msgid "Display 4:3 videos as"
+msgstr ""
+
+#empty string with id 174
+
+#: id:175
+msgid "Moods"
+msgstr ""
+
+#: id:176
+msgid "Styles"
+msgstr ""
+
+#empty strings from id 177 to 178
+
+#: id:179
+msgid "Song"
+msgstr ""
+
+#: id:180
+msgid "Duration"
+msgstr ""
+
+#: id:181
+msgid "Select album"
+msgstr ""
+
+#: id:182
+msgid "Tracks"
+msgstr ""
+
+#: id:183
+msgid "Review"
+msgstr ""
+
+#: id:184
+msgid "Refresh"
+msgstr ""
+
+#: id:185
+msgid "Searching album"
+msgstr ""
+
+#: id:186
+msgid "OK"
+msgstr ""
+
+#: id:187
+msgid "No albums found!"
+msgstr ""
+
+#: id:188
+msgid "Select all"
+msgstr ""
+
+#: id:189
+msgid "Scanning media info"
+msgstr ""
+
+#: id:190
+msgid "Save"
+msgstr ""
+
+#: id:191
+msgid "Shuffle"
+msgstr ""
+
+#: id:192
+msgctxt "Auto context with id 192"
+msgid "Clear"
+msgstr ""
+
+#: id:193
+msgctxt "Auto context with id 193"
+msgid "Scan"
+msgstr ""
+
+#: id:194
+msgid "Searching..."
+msgstr ""
+
+#: id:195
+msgid "No info found!"
+msgstr ""
+
+#: id:196
+msgid "Select movie:"
+msgstr ""
+
+#: id:197
+msgid "Querying %s info"
+msgstr ""
+
+#: id:198
+msgid "Loading movie details"
+msgstr ""
+
+#: id:199
+msgid "Web interface"
+msgstr ""
+
+#empty strings from id 200 to 201
+
+#: id:202
+msgid "Tagline"
+msgstr ""
+
+#: id:203
+msgid "Plot outline"
+msgstr ""
+
+#empty string with id 204
+
+#: id:205
+msgid "Votes"
+msgstr ""
+
+#: id:206
+msgid "Cast"
+msgstr ""
+
+#: id:207
+msgid "Plot"
+msgstr ""
+
+#: id:208
+msgctxt "Auto context with id 208"
+msgid "Play"
+msgstr ""
+
+#: id:209
+msgid "Next"
+msgstr ""
+
+#: id:210
+msgid "Previous"
+msgstr ""
+
+#empty strings from id 211 to 212
+
+#: id:213
+msgid "Calibrate user interface..."
+msgstr ""
+
+#: id:214
+msgid "Video calibration..."
+msgstr ""
+
+#: id:215
+msgid "Soften"
+msgstr ""
+
+#: id:216
+msgid "Zoom amount"
+msgstr ""
+
+#: id:217
+msgid "Pixel ratio"
+msgstr ""
+
+#: id:218
+msgid "DVD drive"
+msgstr ""
+
+#: id:219
+msgid "Please insert disc"
+msgstr ""
+
+#: id:220
+msgid "Remote share"
+msgstr ""
+
+#: id:221
+msgid "Network is not connected"
+msgstr ""
+
+#: id:222
+msgid "Cancel"
+msgstr ""
+
+#empty string with id 223
+
+#: id:224
+msgid "Speed"
+msgstr ""
+
+#: id:225
+msgid "Vertical Shift"
+msgstr ""
+
+#: id:226
+msgid "Test patterns..."
+msgstr ""
+
+#: id:227
+msgid "Lookup audio CD track names from freedb.org"
+msgstr ""
+
+#: id:228
+msgid "Shuffle playlist on load"
+msgstr ""
+
+#: id:229
+msgid "HDD spindown time"
+msgstr ""
+
+#: id:230
+msgid "Video filters"
+msgstr ""
+
+#: id:231
+msgctxt "Auto context with id 231"
+msgid "None"
+msgstr ""
+
+#: id:232
+msgid "Point"
+msgstr ""
+
+#: id:233
+msgid "Linear"
+msgstr ""
+
+#: id:234
+msgid "Anisotropic"
+msgstr ""
+
+#: id:235
+msgid "Quincunx"
+msgstr ""
+
+#: id:236
+msgid "Gaussian cubic"
+msgstr ""
+
+#: id:237
+msgid "Minification"
+msgstr ""
+
+#: id:238
+msgid "Magnification"
+msgstr ""
+
+#: id:239
+msgid "Clear playlist on finish"
+msgstr ""
+
+#: id:240
+msgid "Display Mode"
+msgstr ""
+
+#: id:241
+msgid "Full Screen #%d"
+msgstr ""
+
+#: id:242
+msgid "Windowed"
+msgstr ""
+
+#: id:243
+msgid "Refresh Rate"
+msgstr ""
+
+#: id:244
+msgid "Full screen"
+msgstr ""
+
+#: id:245
+msgid "Sizing: (%i,%i)->(%i,%i) (Zoom x%2.2f) AR:%2.2f:1 (Pixels: %2.2f:1) (VShift: %2.2f)"
+msgstr ""
+
+#empty string with id 246
+
+#: id:247
+msgctxt "Auto context with id 247"
+msgid "Scripts"
+msgstr ""
+
+#: id:248
+msgctxt "Auto context with id 248"
+msgid "Language"
+msgstr ""
+
+#: id:249
+msgctxt "Auto context with id 249"
+msgid "Music"
+msgstr ""
+
+#: id:250
+msgctxt "Auto context with id 250"
+msgid "Visualization"
+msgstr ""
+
+#: id:251
+msgid "Select destination directory"
+msgstr ""
+
+#: id:252
+msgid "Output stereo to all speakers"
+msgstr ""
+
+#: id:253
+msgid "Number of channels"
+msgstr ""
+
+#: id:254
+msgid "- DTS capable receiver"
+msgstr ""
+
+#: id:255
+msgid "CDDB"
+msgstr ""
+
+#: id:256
+msgid "Fetching CD information"
+msgstr ""
+
+#: id:257
+msgid "Error"
+msgstr ""
+
+#: id:258
+msgid "Enable tag reading"
+msgstr ""
+
+#: id:259
+msgid "Opening"
+msgstr ""
+
+#: id:260
+msgid "Shoutcast"
+msgstr ""
+
+#: id:261
+msgid "Waiting for start..."
+msgstr ""
+
+#: id:262
+msgid "Scripts output"
+msgstr ""
+
+#: id:263
+msgid "Allow control of XBMC via HTTP"
+msgstr ""
+
+#: id:264
+msgid "Record"
+msgstr ""
+
+#: id:265
+msgid "Stop Rec."
+msgstr ""
+
+#: id:266
+msgid "Sort by: Track"
+msgstr ""
+
+#: id:267
+msgid "Sort by: Time"
+msgstr ""
+
+#: id:268
+msgid "Sort by: Title"
+msgstr ""
+
+#: id:269
+msgid "Sort by: Artist"
+msgstr ""
+
+#: id:270
+msgid "Sort by: Album"
+msgstr ""
+
+#: id:271
+msgid "Top 100"
+msgstr ""
+
+#: id:272
+msgid "Top-Left overscan compensation"
+msgstr ""
+
+#: id:273
+msgid "Bottom-Right overscan compensation"
+msgstr ""
+
+#: id:274
+msgid "Subtitle positioning"
+msgstr ""
+
+#: id:275
+msgid "Pixel ratio adjustment"
+msgstr ""
+
+#: id:276
+msgid "Adjust the arrow to change the amount of overscan"
+msgstr ""
+
+#: id:277
+msgid "Adjust the bar to change the subtitles position"
+msgstr ""
+
+#: id:278
+msgid "Adjust the rectangle so it is perfectly square"
+msgstr ""
+
+#: id:279
+msgid "Unable to load settings"
+msgstr ""
+
+#: id:280
+msgid "Using default settings"
+msgstr ""
+
+#: id:281
+msgid "Please check the XML files"
+msgstr ""
+
+#: id:282
+msgid "Found %i items"
+msgstr ""
+
+#: id:283
+msgid "Search results"
+msgstr ""
+
+#: id:284
+msgid "No results found"
+msgstr ""
+
+#empty strings from id 285 to 286
+
+#: id:287
+msgctxt "Auto context with id 287"
+msgid "Subtitles"
+msgstr ""
+
+#: id:288
+msgctxt "Auto context with id 288"
+msgid "Font"
+msgstr ""
+
+#: id:289
+msgctxt "Auto context with id 289"
+msgid "- Size"
+msgstr ""
+
+#: id:290
+msgid "Dynamic range compression"
+msgstr ""
+
+#: id:291
+msgctxt "Auto context with id 291"
+msgid "Video"
+msgstr ""
+
+#: id:292
+msgctxt "Auto context with id 292"
+msgid "Audio"
+msgstr ""
+
+#: id:293
+msgid "Browse for subtitles"
+msgstr ""
+
+#: id:294
+msgid "Create bookmark"
+msgstr ""
+
+#empty string with id 295
+
+#: id:296
+msgid "Clear bookmarks"
+msgstr ""
+
+#: id:297
+msgid "Audio offset"
+msgstr ""
+
+#: id:298
+msgid "Bookmarks"
+msgstr ""
+
+#: id:299
+msgid "- AAC capable receiver"
+msgstr ""
+
+#: id:300
+msgid "- MP1 capable receiver"
+msgstr ""
+
+#: id:301
+msgid "- MP2 capable receiver"
+msgstr ""
+
+#: id:302
+msgid "- MP3 capable receiver"
+msgstr ""
+
+#: id:303
+msgid "Delay"
+msgstr ""
+
+#: id:304
+msgctxt "Auto context with id 304"
+msgid "Language"
+msgstr ""
+
+#: id:305
+msgctxt "Auto context with id 305"
+msgid "Enabled"
+msgstr ""
+
+#: id:306
+msgid "Non-interleaved"
+msgstr ""
+
+#empty strings from id 307 to 311
+
+#: id:312
+msgid "(0=auto)"
+msgstr ""
+
+#: id:313
+msgid "Cleaning database"
+msgstr ""
+
+#: id:314
+msgid "Preparing..."
+msgstr ""
+
+#: id:315
+msgid "Database error"
+msgstr ""
+
+#: id:316
+msgid "Searching songs..."
+msgstr ""
+
+#: id:317
+msgid "Cleaned database successfully"
+msgstr ""
+
+#: id:318
+msgid "Cleaning songs..."
+msgstr ""
+
+#: id:319
+msgid "Error cleaning songs"
+msgstr ""
+
+#: id:320
+msgid "Cleaning artists..."
+msgstr ""
+
+#: id:321
+msgid "Error cleaning artists"
+msgstr ""
+
+#: id:322
+msgid "Cleaning genres..."
+msgstr ""
+
+#: id:323
+msgid "Error cleaning genres"
+msgstr ""
+
+#: id:324
+msgid "Cleaning paths..."
+msgstr ""
+
+#: id:325
+msgid "Error cleaning paths"
+msgstr ""
+
+#: id:326
+msgid "Cleaning albums..."
+msgstr ""
+
+#: id:327
+msgid "Error cleaning albums"
+msgstr ""
+
+#: id:328
+msgid "Writing changes..."
+msgstr ""
+
+#: id:329
+msgid "Error writing changes"
+msgstr ""
+
+#: id:330
+msgid "This may take some time..."
+msgstr ""
+
+#: id:331
+msgid "Compressing database..."
+msgstr ""
+
+#: id:332
+msgid "Error compressing database"
+msgstr ""
+
+#: id:333
+msgid "Do you want to clean the library?"
+msgstr ""
+
+#: id:334
+msgid "Clean library..."
+msgstr ""
+
+#: id:335
+msgid "Start"
+msgstr ""
+
+#: id:336
+msgid "Framerate conversion"
+msgstr ""
+
+#: id:337
+msgctxt "Auto context with id 337"
+msgid "Audio output"
+msgstr ""
+
+#: id:338
+msgid "Analog"
+msgstr ""
+
+#: id:339
+msgid "Optical/Coax"
+msgstr ""
+
+#: id:340
+msgid "Various artists"
+msgstr ""
+
+#: id:341
+msgid "Play disc"
+msgstr ""
+
+#: id:342
+msgctxt "Auto context with id 342"
+msgid "Movies"
+msgstr ""
+
+#: id:343
+msgid "Adjust framerate"
+msgstr ""
+
+#: id:344
+msgid "Actors"
+msgstr ""
+
+#: id:345
+msgctxt "Auto context with id 345"
+msgid "Year"
+msgstr ""
+
+#: id:346
+msgid "Boost volume level on downmix"
+msgstr ""
+
+#empty strings from id 347 to 349
+
+#: id:350
+msgctxt "Auto context with id 350"
+msgid "Programs"
+msgstr ""
+
+#: id:351
+msgctxt "Auto context with id 351"
+msgid "Off"
+msgstr ""
+
+#: id:352
+msgid "Dim"
+msgstr ""
+
+#: id:353
+msgid "Black"
+msgstr ""
+
+#: id:354
+msgid "Matrix trails"
+msgstr ""
+
+#: id:355
+msgid "Screensaver time"
+msgstr ""
+
+#: id:356
+msgid "Screensaver mode"
+msgstr ""
+
+#: id:357
+msgid "Shutdown function timer"
+msgstr ""
+
+#: id:358
+msgid "All albums"
+msgstr ""
+
+#: id:359
+msgid "Recently added albums"
+msgstr ""
+
+#: id:360
+msgctxt "Auto context with id 360"
+msgid "Screensaver"
+msgstr ""
+
+#: id:361
+msgid "R. Slideshow"
+msgstr ""
+
+#: id:362
+msgid "Screensaver dim level"
+msgstr ""
+
+#: id:363
+msgid "Sort by: File"
+msgstr ""
+
+#: id:364
+msgid "- Dolby Digital (AC3) capable receiver"
+msgstr ""
+
+#: id:365
+msgctxt "Auto context with id 365"
+msgid "Sort by: Name"
+msgstr ""
+
+#: id:366
+msgid "Sort by: Year"
+msgstr ""
+
+#: id:367
+msgid "Sort by: Rating"
+msgstr ""
+
+#: id:368
+msgid "IMDb"
+msgstr ""
+
+#: id:369
+msgctxt "Auto context with id 369"
+msgid "Title"
+msgstr ""
+
+#: id:370
+msgid "Thunderstorms"
+msgstr ""
+
+#: id:371
+msgid "Partly"
+msgstr ""
+
+#: id:372
+msgid "Mostly"
+msgstr ""
+
+#: id:373
+msgid "Sunny"
+msgstr ""
+
+#: id:374
+msgid "Cloudy"
+msgstr ""
+
+#: id:375
+msgid "Snow"
+msgstr ""
+
+#: id:376
+msgid "Rain"
+msgstr ""
+
+#: id:377
+msgid "Light"
+msgstr ""
+
+#: id:378
+msgid "AM"
+msgstr ""
+
+#: id:379
+msgid "PM"
+msgstr ""
+
+#: id:380
+msgid "Showers"
+msgstr ""
+
+#: id:381
+msgid "Few"
+msgstr ""
+
+#: id:382
+msgid "Scattered"
+msgstr ""
+
+#: id:383
+msgctxt "Auto context with id 383"
+msgid "Wind"
+msgstr ""
+
+#: id:384
+msgid "Strong"
+msgstr ""
+
+#: id:385
+msgid "Fair"
+msgstr ""
+
+#: id:386
+msgctxt "Auto context with id 386"
+msgid "Clear"
+msgstr ""
+
+#: id:387
+msgid "Clouds"
+msgstr ""
+
+#: id:388
+msgid "Early"
+msgstr ""
+
+#: id:389
+msgid "Shower"
+msgstr ""
+
+#: id:390
+msgid "Flurries"
+msgstr ""
+
+#: id:391
+msgctxt "Auto context with id 391"
+msgid "Low"
+msgstr ""
+
+#: id:392
+msgctxt "Auto context with id 392"
+msgid "Medium"
+msgstr ""
+
+#: id:393
+msgctxt "Auto context with id 393"
+msgid "High"
+msgstr ""
+
+#: id:394
+msgid "Fog"
+msgstr ""
+
+#: id:395
+msgid "Haze"
+msgstr ""
+
+#: id:396
+msgid "Select location"
+msgstr ""
+
+#: id:397
+msgid "Refresh time"
+msgstr ""
+
+#: id:398
+msgid "Temperature units"
+msgstr ""
+
+#: id:399
+msgid "Speed units"
+msgstr ""
+
+#: id:400
+msgctxt "Auto context with id 400"
+msgid "Weather"
+msgstr ""
+
+#: id:401
+msgid "Temp"
+msgstr ""
+
+#: id:402
+msgid "Feels like"
+msgstr ""
+
+#: id:403
+msgid "UV index"
+msgstr ""
+
+#: id:404
+msgctxt "Auto context with id 404"
+msgid "Wind"
+msgstr ""
+
+#: id:405
+msgid "Dew point"
+msgstr ""
+
+#: id:406
+msgid "Humidity"
+msgstr ""
+
+#empty strings from id 407 to 408
+
+#: id:409
+msgid "Defaults"
+msgstr ""
+
+#: id:410
+msgid "Accessing weather service"
+msgstr ""
+
+#: id:411
+msgid "Getting weather for:"
+msgstr ""
+
+#: id:412
+msgid "Unable to get weather data"
+msgstr ""
+
+#: id:413
+msgid "Manual"
+msgstr ""
+
+#: id:414
+msgid "No review for this album"
+msgstr ""
+
+#: id:415
+msgid "Downloading thumbnail..."
+msgstr ""
+
+#: id:416
+msgid "Not available"
+msgstr ""
+
+#: id:417
+msgid "View: Big icons"
+msgstr ""
+
+#: id:418
+msgctxt "Auto context with id 418"
+msgid "Low"
+msgstr ""
+
+#: id:419
+msgctxt "Auto context with id 419"
+msgid "High"
+msgstr ""
+
+#: id:420
+msgid "HDMI"
+msgstr ""
+
+#empty string with id 421
+
+#: id:422
+msgid "Delete album info"
+msgstr ""
+
+#: id:423
+msgid "Delete CD information"
+msgstr ""
+
+#: id:424
+msgid "Select"
+msgstr ""
+
+#: id:425
+msgid "No album information found"
+msgstr ""
+
+#: id:426
+msgid "No CD information found"
+msgstr ""
+
+#: id:427
+msgid "Disc"
+msgstr ""
+
+#: id:428
+msgid "Insert correct CD/DVD"
+msgstr ""
+
+#: id:429
+msgid "Please insert the following disc:"
+msgstr ""
+
+#: id:430
+msgid "Sort by: DVD#"
+msgstr ""
+
+#: id:431
+msgid "No cache"
+msgstr ""
+
+#: id:432
+msgid "Remove movie from library"
+msgstr ""
+
+#: id:433
+msgid "Really remove '%s'?"
+msgstr ""
+
+#: id:434
+#. From <wind dir.> at <speed> <unit>
+msgid "From %s at %i %s"
+msgstr ""
+
+#empty strings from id 435 to 436
+
+#: id:437
+msgid "Removable disk"
+msgstr ""
+
+#: id:438
+msgid "Opening file"
+msgstr ""
+
+#: id:439
+msgid "Cache"
+msgstr ""
+
+#: id:440
+msgid "Harddisk"
+msgstr ""
+
+#: id:441
+msgid "UDF"
+msgstr ""
+
+#: id:442
+msgid "Local network"
+msgstr ""
+
+#: id:443
+msgid "Internet"
+msgstr ""
+
+#: id:444
+msgctxt "Auto context with id 444"
+msgid "Video"
+msgstr ""
+
+#: id:445
+msgctxt "Auto context with id 445"
+msgid "Audio"
+msgstr ""
+
+#: id:446
+msgctxt "Auto context with id 446"
+msgid "DVD"
+msgstr ""
+
+#: id:447
+msgid "Autorun media"
+msgstr ""
+
+#: id:448
+msgid "LCD"
+msgstr ""
+
+#: id:449
+msgctxt "Auto context with id 449"
+msgid "Enabled"
+msgstr ""
+
+#: id:450
+msgid "Columns"
+msgstr ""
+
+#: id:451
+msgid "Row 1 address"
+msgstr ""
+
+#: id:452
+msgid "Row 2 address"
+msgstr ""
+
+#: id:453
+msgid "Row 3 address"
+msgstr ""
+
+#: id:454
+msgid "Row 4 address"
+msgstr ""
+
+#: id:455
+msgid "Rows"
+msgstr ""
+
+#: id:456
+msgid "Mode"
+msgstr ""
+
+#: id:457
+msgid "Switch view"
+msgstr ""
+
+#empty string with id 458
+
+#: id:459
+msgid "Subs"
+msgstr ""
+
+#: id:460
+msgid "Audio stream"
+msgstr ""
+
+#: id:461
+msgid "[active]"
+msgstr ""
+
+#: id:462
+msgid "Subtitle"
+msgstr ""
+
+#: id:463
+msgid "Backlight"
+msgstr ""
+
+#: id:464
+msgid "Brightness"
+msgstr ""
+
+#: id:465
+msgid "Contrast"
+msgstr ""
+
+#: id:466
+msgid "Gamma"
+msgstr ""
+
+#: id:467
+msgctxt "Auto context with id 467"
+msgid "Type"
+msgstr ""
+
+#: id:468
+msgid "Move the bar to change the OSD position"
+msgstr ""
+
+#: id:469
+msgid "OSD position"
+msgstr ""
+
+#: id:470
+msgid "Credits"
+msgstr ""
+
+#: id:471
+msgid "Modchip"
+msgstr ""
+
+#empty strings from id 472 to 473
+
+#: id:474
+msgctxt "Auto context with id 474"
+msgid "Off"
+msgstr ""
+
+#: id:475
+msgid "Music only"
+msgstr ""
+
+#: id:476
+msgctxt "Auto context with id 476"
+msgid "Music & video"
+msgstr ""
+
+#: id:477
+msgid "Unable to load playlist"
+msgstr ""
+
+#: id:478
+msgid "OSD"
+msgstr ""
+
+#: id:479
+msgid "Skin & language"
+msgstr ""
+
+#: id:480
+msgid "Appearance"
+msgstr ""
+
+#: id:481
+msgid "Audio options"
+msgstr ""
+
+#: id:482
+msgid "About XBMC"
+msgstr ""
+
+#empty strings from id 483 to 484
+
+#: id:485
+msgid "Delete album"
+msgstr ""
+
+#: id:486
+msgid "Repeat"
+msgstr ""
+
+#: id:487
+msgid "Repeat one"
+msgstr ""
+
+#: id:488
+msgid "Repeat folder"
+msgstr ""
+
+#: id:489
+msgid "Play the next song automatically"
+msgstr ""
+
+#empty string with id 490
+
+#: id:491
+msgid "- Use big icons"
+msgstr ""
+
+#: id:492
+msgid "Resize VobSubs"
+msgstr ""
+
+#: id:493
+msgid "Advanced options (Experts Only!)"
+msgstr ""
+
+#: id:494
+msgid "Overall audio headroom"
+msgstr ""
+
+#: id:495
+msgid "Upsample videos to GUI resolution"
+msgstr ""
+
+#: id:496
+msgid "Calibration"
+msgstr ""
+
+#: id:497
+msgid "Show file extensions"
+msgstr ""
+
+#: id:498
+msgid "Sort by: Type"
+msgstr ""
+
+#: id:499
+msgid "Unable to connect to online lookup service"
+msgstr ""
+
+#: id:500
+msgid "Downloading album information failed"
+msgstr ""
+
+#: id:501
+msgid "Looking for album names..."
+msgstr ""
+
+#: id:502
+msgctxt "Auto context with id 502"
+msgid "Open"
+msgstr ""
+
+#: id:503
+msgid "Busy"
+msgstr ""
+
+#: id:504
+msgid "Empty"
+msgstr ""
+
+#: id:505
+msgid "Loading media info from files..."
+msgstr ""
+
+#empty string with id 506
+
+#: id:507
+msgid "Sort by: Usage"
+msgstr ""
+
+#empty strings from id 508 to 509
+
+#: id:510
+msgid "Enable visualizations"
+msgstr ""
+
+#: id:511
+msgid "Enable video mode switching"
+msgstr ""
+
+#: id:512
+msgid "Startup window"
+msgstr ""
+
+#: id:513
+msgid "Home window"
+msgstr ""
+
+#: id:514
+msgid "Manual settings"
+msgstr ""
+
+#: id:515
+msgid "Genre"
+msgstr ""
+
+#empty string with id 516
+
+#: id:517
+msgid "Recently played albums"
+msgstr ""
+
+#: id:518
+msgid "Launch"
+msgstr ""
+
+#: id:519
+msgid "Launch in..."
+msgstr ""
+
+#empty string with id 520
+
+#: id:521
+msgid "Compilations"
+msgstr ""
+
+#: id:522
+msgid "Remove source"
+msgstr ""
+
+#: id:523
+msgid "Switch media"
+msgstr ""
+
+#: id:524
+msgid "Select playlist"
+msgstr ""
+
+#: id:525
+msgid "New playlist..."
+msgstr ""
+
+#: id:526
+msgid "Add to playlist"
+msgstr ""
+
+#: id:527
+msgid "Manually add to library"
+msgstr ""
+
+#: id:528
+msgid "Enter title"
+msgstr ""
+
+#: id:529
+msgid "Error: Duplicate title"
+msgstr ""
+
+#: id:530
+msgid "Select genre"
+msgstr ""
+
+#: id:531
+msgid "New genre"
+msgstr ""
+
+#: id:532
+msgid "Manual addition"
+msgstr ""
+
+#: id:533
+msgid "Enter genre"
+msgstr ""
+
+#: id:534
+msgid "View: %s"
+msgstr ""
+
+#: id:535
+msgid "List"
+msgstr ""
+
+#: id:536
+msgid "Icons"
+msgstr ""
+
+#: id:537
+msgid "Big list"
+msgstr ""
+
+#: id:538
+msgid "Big icons"
+msgstr ""
+
+#: id:539
+msgid "Wide"
+msgstr ""
+
+#: id:540
+msgid "Big wide"
+msgstr ""
+
+#: id:541
+msgid "Album icons"
+msgstr ""
+
+#: id:542
+msgid "DVD icons"
+msgstr ""
+
+#: id:543
+msgctxt "Auto context with id 543"
+msgid "DVD"
+msgstr ""
+
+#: id:544
+msgctxt "Auto context with id 544"
+msgid "Media info"
+msgstr ""
+
+#: id:545
+msgid "Audio output device"
+msgstr ""
+
+#: id:546
+msgid "Passthrough output device"
+msgstr ""
+
+#: id:547
+msgid "No biography for this artist"
+msgstr ""
+
+#: id:548
+msgid "Downmix multichannel audio to stereo"
+msgstr ""
+
+#empty string with id 549
+
+#: id:550
+msgid "Sort by: %s"
+msgstr ""
+
+#: id:551
+msgctxt "Auto context with id 551"
+msgid "Name"
+msgstr ""
+
+#: id:552
+msgid "Date"
+msgstr ""
+
+#: id:553
+msgid "Size"
+msgstr ""
+
+#: id:554
+msgid "Track"
+msgstr ""
+
+#: id:555
+msgid "Time"
+msgstr ""
+
+#: id:556
+msgctxt "Auto context with id 556"
+msgid "Title"
+msgstr ""
+
+#: id:557
+msgid "Artist"
+msgstr ""
+
+#: id:558
+msgid "Album"
+msgstr ""
+
+#: id:559
+msgid "Playlist"
+msgstr ""
+
+#: id:560
+msgid "ID"
+msgstr ""
+
+#: id:561
+msgctxt "Auto context with id 561"
+msgid "File"
+msgstr ""
+
+#: id:562
+msgctxt "Auto context with id 562"
+msgid "Year"
+msgstr ""
+
+#: id:563
+msgid "Rating"
+msgstr ""
+
+#: id:564
+msgctxt "Auto context with id 564"
+msgid "Type"
+msgstr ""
+
+#: id:565
+msgid "Usage"
+msgstr ""
+
+#: id:566
+msgid "Album artist"
+msgstr ""
+
+#: id:567
+msgid "Play count"
+msgstr ""
+
+#: id:568
+msgid "Last played"
+msgstr ""
+
+#: id:569
+msgctxt "Auto context with id 569"
+msgid "Comment"
+msgstr ""
+
+#: id:570
+msgid "Date added"
+msgstr ""
+
+#: id:571
+msgctxt "Auto context with id 571"
+msgid "Default"
+msgstr ""
+
+#: id:572
+msgid "Studio"
+msgstr ""
+
+#: id:573
+msgid "Path"
+msgstr ""
+
+#: id:574
+msgctxt "Auto context with id 574"
+msgid "Country"
+msgstr ""
+
+#: id:575
+msgid "In progress"
+msgstr ""
+
+#: id:576
+msgid "Times played"
+msgstr ""
+
+#empty strings from id 577 to 579
+
+#: id:580
+msgid "Sort direction"
+msgstr ""
+
+#: id:581
+msgid "Sort method"
+msgstr ""
+
+#: id:582
+msgctxt "Auto context with id 582"
+msgid "View mode"
+msgstr ""
+
+#: id:583
+msgid "Remember views for different folders"
+msgstr ""
+
+#: id:584
+msgid "Ascending"
+msgstr ""
+
+#: id:585
+msgid "Descending"
+msgstr ""
+
+#: id:586
+msgid "Edit playlist"
+msgstr ""
+
+#: id:587
+msgid "Filter"
+msgstr ""
+
+#: id:588
+msgid "Cancel party mode"
+msgstr ""
+
+#: id:589
+msgid "Party mode"
+msgstr ""
+
+#: id:590
+msgid "Random"
+msgstr ""
+
+#: id:591
+msgctxt "Auto context with id 591"
+msgid "Off"
+msgstr ""
+
+#: id:592
+msgid "One"
+msgstr ""
+
+#: id:593
+msgid "All"
+msgstr ""
+
+#: id:594
+msgctxt "Auto context with id 594"
+msgid "Off"
+msgstr ""
+
+#: id:595
+msgid "Repeat: Off"
+msgstr ""
+
+#: id:596
+msgid "Repeat: One"
+msgstr ""
+
+#: id:597
+msgid "Repeat: All"
+msgstr ""
+
+#empty strings from id 598 to 599
+
+#: id:600
+msgid "Rip audio CD"
+msgstr ""
+
+#: id:601
+msgctxt "Auto context with id 601"
+msgid "Medium"
+msgstr ""
+
+#: id:602
+msgctxt "Auto context with id 602"
+msgid "Standard"
+msgstr ""
+
+#: id:603
+msgid "Extreme"
+msgstr ""
+
+#: id:604
+msgid "Constant bitrate"
+msgstr ""
+
+#: id:605
+msgid "Ripping..."
+msgstr ""
+
+#empty string with id 606
+
+#: id:607
+msgid "To:"
+msgstr ""
+
+#: id:608
+msgid "Could not rip CD or track"
+msgstr ""
+
+#: id:609
+msgid "CDDARipPath is not set."
+msgstr ""
+
+#: id:610
+msgid "Rip audio track"
+msgstr ""
+
+#: id:611
+msgid "Enter number"
+msgstr ""
+
+#: id:612
+msgid "Bits/Sample"
+msgstr ""
+
+#: id:613
+msgid "Sample Frequency"
+msgstr ""
+
+#empty strings from id 614 to 619
+
+#: id:620
+msgid "Audio CDs"
+msgstr ""
+
+#: id:621
+msgid "Encoder"
+msgstr ""
+
+#: id:622
+msgid "Quality"
+msgstr ""
+
+#: id:623
+msgid "Bitrate"
+msgstr ""
+
+#: id:624
+msgid "Include track number"
+msgstr ""
+
+#: id:625
+msgid "All songs of"
+msgstr ""
+
+#empty strings from id 626 to 628
+
+#: id:629
+msgctxt "Auto context with id 629"
+msgid "View mode"
+msgstr ""
+
+#: id:630
+msgctxt "Auto context with id 630"
+msgid "Normal"
+msgstr ""
+
+#: id:631
+msgid "Zoom"
+msgstr ""
+
+#: id:632
+msgid "Stretch 4:3"
+msgstr ""
+
+#: id:633
+msgid "Wide Zoom"
+msgstr ""
+
+#: id:634
+msgid "Stretch 16:9"
+msgstr ""
+
+#: id:635
+msgid "Original Size"
+msgstr ""
+
+#: id:636
+msgctxt "Auto context with id 636"
+msgid "Custom"
+msgstr ""
+
+#: id:637
+msgid "Replay gain"
+msgstr ""
+
+#: id:638
+msgid "Replaygain volume adjustments"
+msgstr ""
+
+#: id:639
+msgid "Use track levels"
+msgstr ""
+
+#: id:640
+msgid "Use album levels"
+msgstr ""
+
+#: id:641
+msgid "PreAmp Level - Replay gained files"
+msgstr ""
+
+#: id:642
+msgid "PreAmp Level - Non replay gained files"
+msgstr ""
+
+#: id:643
+msgid "Avoid clipping on replay gained files"
+msgstr ""
+
+#: id:644
+msgid "Crop black bars"
+msgstr ""
+
+#: id:645
+msgid "Need to unpack a big file. Continue?"
+msgstr ""
+
+#: id:646
+msgid "Remove from library"
+msgstr ""
+
+#: id:647
+msgid "Export video library"
+msgstr ""
+
+#: id:648
+msgid "Import video library"
+msgstr ""
+
+#: id:649
+msgid "Importing"
+msgstr ""
+
+#: id:650
+msgid "Exporting"
+msgstr ""
+
+#: id:651
+msgid "Browse for library"
+msgstr ""
+
+#: id:652
+msgid "Years"
+msgstr ""
+
+#: id:653
+msgid "Update library"
+msgstr ""
+
+#: id:654
+msgid "Show debug info"
+msgstr ""
+
+#: id:655
+msgid "Browse for executable"
+msgstr ""
+
+#: id:656
+msgid "Browse for playlist"
+msgstr ""
+
+#: id:657
+msgid "Browse for folder"
+msgstr ""
+
+#: id:658
+msgid "Song information"
+msgstr ""
+
+#: id:659
+msgid "Non-linear stretch"
+msgstr ""
+
+#: id:660
+msgid "Volume amplification"
+msgstr ""
+
+#: id:661
+msgid "Choose export folder"
+msgstr ""
+
+#: id:662
+msgid "This file is no longer available."
+msgstr ""
+
+#: id:663
+msgid "Would you like to remove it from the library?"
+msgstr ""
+
+#: id:664
+msgid "Browse for Script"
+msgstr ""
+
+#: id:665
+msgid "Compression level"
+msgstr ""
+
+#empty strings from id 666 to 699
+
+#: id:700
+msgid "Cleaning up library"
+msgstr ""
+
+#: id:701
+msgid "Removing old songs from the library"
+msgstr ""
+
+#: id:702
+msgid "This path has been scanned before"
+msgstr ""
+
+#empty strings from id 703 to 704
+
+#: id:705
+msgctxt "Auto context with id 705"
+msgid "Network"
+msgstr ""
+
+#: id:706
+msgid "- Server"
+msgstr ""
+
+#empty string with id 707
+
+#: id:708
+msgid "Use an HTTP proxy server to access the internet"
+msgstr ""
+
+#empty strings from id 709 to 710
+
+#: id:711
+msgid "Internet Protocol (IP)"
+msgstr ""
+
+#: id:712
+msgid "Invalid port specified. Value must be between 1 and 65535."
+msgstr ""
+
+#: id:713
+msgid "HTTP proxy"
+msgstr ""
+
+#empty string with id 714
+
+#: id:715
+msgid "- Assignment"
+msgstr ""
+
+#: id:716
+msgid "Automatic (DHCP)"
+msgstr ""
+
+#: id:717
+msgid "Manual (Static)"
+msgstr ""
+
+#empty string with id 718
+
+#: id:719
+msgid "- IP address"
+msgstr ""
+
+#: id:720
+msgid "- Netmask"
+msgstr ""
+
+#: id:721
+msgid "- Default gateway"
+msgstr ""
+
+#: id:722
+msgid "- DNS server"
+msgstr ""
+
+#: id:723
+msgid "Save & restart"
+msgstr ""
+
+#: id:724
+msgid "Invalid address specified. Value must be AAA.BBB.CCC.DDD"
+msgstr ""
+
+#: id:725
+msgid "with numbers between 0 and 255."
+msgstr ""
+
+#: id:726
+msgid "Changes not saved. Continue without saving?"
+msgstr ""
+
+#: id:727
+msgid "Web server"
+msgstr ""
+
+#: id:728
+msgctxt "Auto context with id 728"
+msgid "FTP server"
+msgstr ""
+
+#empty string with id 729
+
+#: id:730
+msgid "- Port"
+msgstr ""
+
+#empty string with id 731
+
+#: id:732
+msgid "Save & apply"
+msgstr ""
+
+#: id:733
+msgid "- Password"
+msgstr ""
+
+#: id:734
+msgid "No pass"
+msgstr ""
+
+#: id:735
+msgid "- Character set"
+msgstr ""
+
+#: id:736
+msgid "- Style"
+msgstr ""
+
+#: id:737
+msgid "- Colour"
+msgstr ""
+
+#: id:738
+msgctxt "Auto context with id 738"
+msgid "Normal"
+msgstr ""
+
+#: id:739
+msgid "Bold"
+msgstr ""
+
+#: id:740
+msgid "Italics"
+msgstr ""
+
+#: id:741
+msgid "Bold italics"
+msgstr ""
+
+#: id:742
+msgctxt "Auto context with id 742"
+msgid "White"
+msgstr ""
+
+#: id:743
+msgctxt "Auto context with id 743"
+msgid "Yellow"
+msgstr ""
+
+#: id:744
+msgctxt "Auto context with id 744"
+msgid "Files"
+msgstr ""
+
+#: id:745
+msgid "No scanned information for this view"
+msgstr ""
+
+#: id:746
+msgid "Please turn off library mode"
+msgstr ""
+
+#: id:747
+msgid "Error loading image"
+msgstr ""
+
+#: id:748
+msgid "Edit path"
+msgstr ""
+
+#: id:749
+msgid "Mirror image"
+msgstr ""
+
+#: id:750
+msgid "Are you sure?"
+msgstr ""
+
+#: id:751
+msgid "Removing source"
+msgstr ""
+
+#empty strings from id 752 to 753
+
+#: id:754
+msgid "Add program link"
+msgstr ""
+
+#: id:755
+msgid "Edit program path"
+msgstr ""
+
+#: id:756
+msgid "Edit program name"
+msgstr ""
+
+#: id:757
+msgid "Edit path depth"
+msgstr ""
+
+#empty string with id 758
+
+#: id:759
+msgid "View: Big list"
+msgstr ""
+
+#: id:760
+msgctxt "Auto context with id 760"
+msgid "Yellow"
+msgstr ""
+
+#: id:761
+msgctxt "Auto context with id 761"
+msgid "White"
+msgstr ""
+
+#: id:762
+msgid "Blue"
+msgstr ""
+
+#: id:763
+msgid "Bright green"
+msgstr ""
+
+#: id:764
+msgid "Yellow green"
+msgstr ""
+
+#: id:765
+msgid "Cyan"
+msgstr ""
+
+#: id:766
+msgid "Light grey"
+msgstr ""
+
+#: id:767
+msgid "Grey"
+msgstr ""
+
+#strings 768 and 769 reserved for more subtitle colors
+#empty strings from id 768 to 769
+
+#: id:770
+msgid "Error %i: share not available"
+msgstr ""
+
+#empty string with id 771
+
+#: id:772
+msgctxt "Auto context with id 772"
+msgid "Audio output"
+msgstr ""
+
+#: id:773
+msgid "Seeking"
+msgstr ""
+
+#: id:774
+msgid "Slideshow folder"
+msgstr ""
+
+#: id:775
+msgid "Network interface"
+msgstr ""
+
+#: id:776
+msgid "- Wireless network name (ESSID)"
+msgstr ""
+
+#: id:777
+msgid "- Wireless password"
+msgstr ""
+
+#: id:778
+msgid "- Wireless security"
+msgstr ""
+
+#: id:779
+msgid "Save and apply network interface settings"
+msgstr ""
+
+#: id:780
+msgid "No encryption"
+msgstr ""
+
+#: id:781
+msgid "WEP"
+msgstr ""
+
+#: id:782
+msgid "WPA"
+msgstr ""
+
+#: id:783
+msgid "WPA2"
+msgstr ""
+
+#: id:784
+msgid "Applying network interface settings. Please wait."
+msgstr ""
+
+#: id:785
+msgid "Network interface restarted successfully."
+msgstr ""
+
+#: id:786
+msgid "Network interface did not start successfully."
+msgstr ""
+
+#: id:787
+msgid "Interface disabled"
+msgstr ""
+
+#: id:788
+msgid "Network interface disabled successfully."
+msgstr ""
+
+#: id:789
+msgid "Wireless network name (ESSID)"
+msgstr ""
+
+#: id:790
+msgid "Remote control"
+msgstr ""
+
+#: id:791
+msgid "Allow programs on this system to control XBMC"
+msgstr ""
+
+#: id:792
+msgctxt "Auto context with id 792"
+msgid "Port"
+msgstr ""
+
+#: id:793
+msgid "Port range"
+msgstr ""
+
+#: id:794
+msgid "Allow programs on other systems to control XBMC"
+msgstr ""
+
+#: id:795
+msgid "Initial repeat delay (ms)"
+msgstr ""
+
+#: id:796
+msgid "Continuous repeat delay (ms)"
+msgstr ""
+
+#: id:797
+msgid "Maximum number of clients"
+msgstr ""
+
+#: id:798
+msgid "Internet access"
+msgstr ""
+
+#empty strings from id 799 to 849
+
+#: id:850
+msgid "Invalid port number entered"
+msgstr ""
+
+#: id:851
+msgid "Valid port range is 1-65535"
+msgstr ""
+
+#: id:852
+msgid "Valid port range is 1024-65535"
+msgstr ""
+
+#empty strings from id 853 to 997
+
+#: id:998
+msgid "Add Music..."
+msgstr ""
+
+#: id:999
+msgid "Add Videos..."
+msgstr ""
+
+#: id:1000
+msgid "- Preview"
+msgstr ""
+
+#: id:1001
+msgid "Unable to connect"
+msgstr ""
+
+#: id:1002
+msgid "XBMC was unable to connect to the network location."
+msgstr ""
+
+#: id:1003
+msgid "This could be due to the network not being connected."
+msgstr ""
+
+#: id:1004
+msgid "Would you like to add it anyway?"
+msgstr ""
+
+#empty string with id 1005
+
+#: id:1006
+msgctxt "Auto context with id 1006"
+msgid "IP address"
+msgstr ""
+
+#: id:1007
+msgid "Add network location"
+msgstr ""
+
+#: id:1008
+msgid "Protocol"
+msgstr ""
+
+#: id:1009
+msgid "Server address"
+msgstr ""
+
+#: id:1010
+msgid "Server name"
+msgstr ""
+
+#: id:1011
+msgid "Remote path"
+msgstr ""
+
+#: id:1012
+msgid "Shared folder"
+msgstr ""
+
+#: id:1013
+msgctxt "Auto context with id 1013"
+msgid "Port"
+msgstr ""
+
+#: id:1014
+msgctxt "Auto context with id 1014"
+msgid "Username"
+msgstr ""
+
+#: id:1015
+msgid "Browse for network server"
+msgstr ""
+
+#: id:1016
+msgid "Enter the network address of the server"
+msgstr ""
+
+#: id:1017
+msgid "Enter the path on the server"
+msgstr ""
+
+#: id:1018
+msgid "Enter the port number"
+msgstr ""
+
+#: id:1019
+msgid "Enter the username"
+msgstr ""
+
+#: id:1020
+msgid "Add %s source"
+msgstr ""
+
+#: id:1021
+msgid "Enter the paths or browse for the media locations."
+msgstr ""
+
+#: id:1022
+msgid "Enter a name for this media Source."
+msgstr ""
+
+#: id:1023
+msgid "Browse for new share"
+msgstr ""
+
+#: id:1024
+msgid "Browse"
+msgstr ""
+
+#: id:1025
+msgid "Could not retrieve directory information."
+msgstr ""
+
+#: id:1026
+msgid "Add source"
+msgstr ""
+
+#: id:1027
+msgid "Edit source"
+msgstr ""
+
+#: id:1028
+msgid "Edit %s source"
+msgstr ""
+
+#: id:1029
+msgid "Enter the new label"
+msgstr ""
+
+#: id:1030
+msgid "Browse for image"
+msgstr ""
+
+#: id:1031
+msgid "Browse for image folder"
+msgstr ""
+
+#: id:1032
+msgid "Add network location..."
+msgstr ""
+
+#: id:1033
+msgid "Browse for file"
+msgstr ""
+
+#: id:1034
+msgid "Submenu"
+msgstr ""
+
+#: id:1035
+msgid "Enable submenu buttons"
+msgstr ""
+
+#: id:1036
+msgid "Favourites"
+msgstr ""
+
+#: id:1037
+msgid "Video Add-ons"
+msgstr ""
+
+#: id:1038
+msgid "Music Add-ons"
+msgstr ""
+
+#: id:1039
+msgid "Picture Add-ons"
+msgstr ""
+
+#: id:1040
+msgid "Loading directory"
+msgstr ""
+
+#: id:1041
+msgid "Retrieved %i items"
+msgstr ""
+
+#: id:1042
+msgid "Retrieved %i of %i items"
+msgstr ""
+
+#: id:1043
+msgid "Program Add-ons"
+msgstr ""
+
+#: id:1044
+msgid "Set plugin thumb"
+msgstr ""
+
+#: id:1045
+msgid "Add-on settings"
+msgstr ""
+
+#: id:1046
+msgid "Access points"
+msgstr ""
+
+#: id:1047
+msgid "Other..."
+msgstr ""
+
+#: id:1048
+msgid "- Username"
+msgstr ""
+
+#: id:1049
+msgid "Script settings"
+msgstr ""
+
+#: id:1050
+msgid "Singles"
+msgstr ""
+
+#: id:1051
+msgid "Enter web address"
+msgstr ""
+
+#empty strings from id 1052 to 1199
+
+#: id:1200
+msgid "SMB client"
+msgstr ""
+
+#empty string with id 1201
+
+#: id:1202
+msgid "Workgroup"
+msgstr ""
+
+#: id:1203
+msgid "Default username"
+msgstr ""
+
+#: id:1204
+msgid "Default password"
+msgstr ""
+
+#empty strings from id 1205 to 1206
+
+#: id:1207
+msgid "WINS server"
+msgstr ""
+
+#: id:1208
+msgid "Mount SMB shares"
+msgstr ""
+
+#empty string with id 1209
+
+#: id:1210
+msgctxt "Auto context with id 1210"
+msgid "Remove"
+msgstr ""
+
+#: id:1211
+msgctxt "Auto context with id 1211"
+msgid "Music"
+msgstr ""
+
+#: id:1212
+msgctxt "Auto context with id 1212"
+msgid "Video"
+msgstr ""
+
+#: id:1213
+msgctxt "Auto context with id 1213"
+msgid "Pictures"
+msgstr ""
+
+#: id:1214
+msgctxt "Auto context with id 1214"
+msgid "Files"
+msgstr ""
+
+#: id:1215
+msgctxt "Auto context with id 1215"
+msgid "Music & video"
+msgstr ""
+
+#: id:1216
+msgid "Music & pictures"
+msgstr ""
+
+#: id:1217
+msgid "Music & files"
+msgstr ""
+
+#: id:1218
+msgid "Video & pictures"
+msgstr ""
+
+#: id:1219
+msgid "Video & files"
+msgstr ""
+
+#: id:1220
+msgid "Pictures & files"
+msgstr ""
+
+#: id:1221
+msgid "Music & video & pictures"
+msgstr ""
+
+#: id:1222
+msgid "Music & video & pictures & files"
+msgstr ""
+
+#: id:1223
+msgctxt "Auto context with id 1223"
+msgid "Disabled"
+msgstr ""
+
+#empty strings from id 1224 to 1225
+
+#: id:1226
+msgid "Files & music & video"
+msgstr ""
+
+#: id:1227
+msgid "Files & pictures & music"
+msgstr ""
+
+#: id:1228
+msgid "Files & pictures & video"
+msgstr ""
+
+#: id:1229
+msgid "Music & programs"
+msgstr ""
+
+#: id:1230
+msgid "Video & programs"
+msgstr ""
+
+#: id:1231
+msgid "Pictures & programs"
+msgstr ""
+
+#: id:1232
+msgid "Music & video & pictures & programs"
+msgstr ""
+
+#: id:1233
+msgid "Programs & video & music"
+msgstr ""
+
+#: id:1234
+msgid "Programs & pictures & music"
+msgstr ""
+
+#: id:1235
+msgid "Programs & pictures & video"
+msgstr ""
+
+#empty strings from id 1236 to 1249
+
+#: id:1250
+msgid "Auto-detection"
+msgstr ""
+
+#: id:1251
+msgid "Auto-detect system"
+msgstr ""
+
+#: id:1252
+msgid "Nickname"
+msgstr ""
+
+#empty string with id 1253
+
+#: id:1254
+msgid "Ask to connect"
+msgstr ""
+
+#: id:1255
+msgid "Send FTP user and password"
+msgstr ""
+
+#: id:1256
+msgid "Ping interval"
+msgstr ""
+
+#: id:1257
+msgid "Would you like to connect to the auto-detected system?"
+msgstr ""
+
+#empty string with id 1258
+
+#: id:1259
+msgid "Zeroconf"
+msgstr ""
+
+#: id:1260
+msgid "Announce these services to other systems via Zeroconf"
+msgstr ""
+
+#empty strings from id 1261 to 1269
+
+#: id:1270
+msgid "Allow XBMC to receive AirPlay content"
+msgstr ""
+
+#: id:1271
+msgid "Device name"
+msgstr ""
+
+#: id:1272
+msgid "- Use password protection"
+msgstr ""
+
+#: id:1273
+msgid "AirPlay"
+msgstr ""
+
+#empty strings from id 1274 to 1299
+
+#: id:1300
+msgid "Custom audio device"
+msgstr ""
+
+#: id:1301
+msgid "Custom passthrough device"
+msgstr ""
+
+#empty strings from id 1302 to 1395
+
+#: id:1396
+msgid "Drifting"
+msgstr ""
+
+#: id:1397
+msgid "and"
+msgstr ""
+
+#: id:1398
+msgid "Freezing"
+msgstr ""
+
+#: id:1399
+msgid "Late"
+msgstr ""
+
+#: id:1400
+msgid "Isolated"
+msgstr ""
+
+#: id:1401
+msgid "Thundershowers"
+msgstr ""
+
+#: id:1402
+msgid "Thunder"
+msgstr ""
+
+#: id:1403
+msgctxt "Auto context with id 1403"
+msgid "Sun"
+msgstr ""
+
+#: id:1404
+msgid "Heavy"
+msgstr ""
+
+#: id:1405
+msgid "in"
+msgstr ""
+
+#: id:1406
+msgid "the"
+msgstr ""
+
+#: id:1407
+msgid "Vicinity"
+msgstr ""
+
+#: id:1408
+msgid "Ice"
+msgstr ""
+
+#: id:1409
+msgid "Crystals"
+msgstr ""
+
+#: id:1410
+msgid "Calm"
+msgstr ""
+
+#: id:1411
+msgid "with"
+msgstr ""
+
+#: id:1412
+msgid "windy"
+msgstr ""
+
+#: id:1413
+msgid "drizzle"
+msgstr ""
+
+#: id:1414
+msgid "Thunderstorm"
+msgstr ""
+
+#: id:1415
+msgid "Drizzle"
+msgstr ""
+
+#: id:1416
+msgid "Foggy"
+msgstr ""
+
+#: id:1417
+msgid "Grains"
+msgstr ""
+
+#: id:1418
+msgid "T-Storms"
+msgstr ""
+
+#: id:1419
+msgid "T-Showers"
+msgstr ""
+
+#: id:1420
+msgid "Moderate"
+msgstr ""
+
+#: id:1421
+msgid "Very High"
+msgstr ""
+
+#: id:1422
+msgid "Windy"
+msgstr ""
+
+#: id:1423
+msgid "Mist"
+msgstr ""
+
+#strings through to 1450 reserved for weather translation
+#empty strings from id 1424 to 1449
+
+#: id:1450
+msgid "Put display to sleep when idle"
+msgstr ""
+
+#strings through to 1470 reserved for power-saving
+#empty strings from id 1451 to 2049
+
+#: id:2050
+msgid "Runtime"
+msgstr ""
+
+#empty strings from id 2051 to 2099
+
+#: id:2100
+msgid "Script failed! : %s"
+msgstr ""
+
+#: id:2101
+msgid "Newer version needed - See log"
+msgstr ""
+
+#empty strings from id 2102 to 4500
+
+#: id:4501
+msgid "Enable LCD/VFD"
+msgstr ""
+
+#empty strings from id 4502 to 9999
+
+#: id:10000
+msgid "Home"
+msgstr ""
+
+#: id:10001
+msgctxt "Auto context with id 10001"
+msgid "Programs"
+msgstr ""
+
+#: id:10002
+msgctxt "Auto context with id 10002"
+msgid "Pictures"
+msgstr ""
+
+#: id:10003
+msgctxt "Auto context with id 10003"
+msgid "File manager"
+msgstr ""
+
+#: id:10004
+msgctxt "Auto context with id 10004"
+msgid "Settings"
+msgstr ""
+
+#: id:10005
+msgctxt "Auto context with id 10005"
+msgid "Music"
+msgstr ""
+
+#: id:10006
+msgctxt "Auto context with id 10006"
+msgid "Videos"
+msgstr ""
+
+#: id:10007
+msgid "System information"
+msgstr ""
+
+#: id:10008
+msgid "Settings - General"
+msgstr ""
+
+#: id:10009
+msgid "Settings - Screen"
+msgstr ""
+
+#: id:10010
+msgid "Settings - Appearance - GUI Calibration"
+msgstr ""
+
+#: id:10011
+msgid "Settings - Videos - Screen Calibration"
+msgstr ""
+
+#: id:10012
+msgid "Settings - Pictures"
+msgstr ""
+
+#: id:10013
+msgid "Settings - Programs"
+msgstr ""
+
+#: id:10014
+msgid "Settings - Weather"
+msgstr ""
+
+#: id:10015
+msgid "Settings - Music"
+msgstr ""
+
+#: id:10016
+msgid "Settings - System"
+msgstr ""
+
+#: id:10017
+msgid "Settings - Videos"
+msgstr ""
+
+#: id:10018
+msgid "Settings - Network"
+msgstr ""
+
+#: id:10019
+msgid "Settings - Appearance"
+msgstr ""
+
+#: id:10020
+msgctxt "Auto context with id 10020"
+msgid "Scripts"
+msgstr ""
+
+#: id:10021
+msgid "Web Browser"
+msgstr ""
+
+#empty strings from id 10022 to 10024
+
+#: id:10025
+msgctxt "Auto context with id 10025"
+msgid "Videos"
+msgstr ""
+
+#empty strings from id 10026 to 10027
+
+#: id:10028
+msgid "Videos/Playlist"
+msgstr ""
+
+#: id:10029
+msgctxt "Auto context with id 10029"
+msgid "Login screen"
+msgstr ""
+
+#empty strings from id 10030 to 10033
+
+#: id:10034
+msgid "Settings - Profiles"
+msgstr ""
+
+#empty strings from id 10035 to 10039
+
+#: id:10040
+msgid "Addon browser"
+msgstr ""
+
+#empty strings from id 10041 to 10099
+
+#: id:10100
+msgid "Yes/No dialog"
+msgstr ""
+
+#: id:10101
+msgid "Progress dialog"
+msgstr ""
+
+#empty strings from id 10102 to 10209
+
+#: id:10210
+msgid "Looking for subtitles..."
+msgstr ""
+
+#: id:10211
+msgid "Looking for or caching subtitles..."
+msgstr ""
+
+#: id:10212
+msgid "terminating"
+msgstr ""
+
+#: id:10213
+msgid "buffering"
+msgstr ""
+
+#: id:10214
+msgid "Opening stream"
+msgstr ""
+
+#empty strings from id 10215 to 10499
+
+#: id:10500
+msgid "Music/Playlist"
+msgstr ""
+
+#: id:10501
+msgid "Music/Files"
+msgstr ""
+
+#: id:10502
+msgid "Music/Library"
+msgstr ""
+
+#: id:10503
+msgid "Playlist editor"
+msgstr ""
+
+#: id:10504
+msgid "Top 100 songs"
+msgstr ""
+
+#: id:10505
+msgid "Top 100 albums"
+msgstr ""
+
+#: id:10506
+msgctxt "Auto context with id 10506"
+msgid "Programs"
+msgstr ""
+
+#: id:10507
+msgid "Configuration"
+msgstr ""
+
+#: id:10508
+msgid "Weather forecast"
+msgstr ""
+
+#: id:10509
+msgid "Network gaming"
+msgstr ""
+
+#: id:10510
+msgid "Extensions"
+msgstr ""
+
+#: id:10511
+msgctxt "Auto context with id 10511"
+msgid "System info"
+msgstr ""
+
+#empty strings from id 10512 to 10515
+
+#: id:10516
+msgid "Music - Library"
+msgstr ""
+
+#: id:10517
+msgid "Now Playing - Music"
+msgstr ""
+
+#empty strings from id 10518 to 10521
+
+#: id:10522
+msgid "Now Playing - Videos"
+msgstr ""
+
+#: id:10523
+msgid "Album info"
+msgstr ""
+
+#: id:10524
+msgid "Movie info"
+msgstr ""
+
+#empty strings from id 10525 to 11999
+
+#: id:12000
+msgid "Select dialog"
+msgstr ""
+
+#: id:12001
+msgid "Music/Info"
+msgstr ""
+
+#: id:12002
+msgid "Dialog OK"
+msgstr ""
+
+#: id:12003
+msgid "Videos/Info"
+msgstr ""
+
+#: id:12004
+msgid "Scripts/Info"
+msgstr ""
+
+#: id:12005
+msgid "Fullscreen video"
+msgstr ""
+
+#: id:12006
+msgid "Audio visualization"
+msgstr ""
+
+#empty string with id 12007
+
+#: id:12008
+msgid "File stacking dialog"
+msgstr ""
+
+#: id:12009
+msgid "Rebuild index..."
+msgstr ""
+
+#: id:12010
+msgid "Return to music window"
+msgstr ""
+
+#: id:12011
+msgid "Return to videos window"
+msgstr ""
+
+#empty strings from id 12012 to 12020
+
+#: id:12021
+msgid "Start from beginning"
+msgstr ""
+
+#: id:12022
+msgid "Resume from %s"
+msgstr ""
+
+#empty strings from id 12023 to 12309
+
+#: id:12310
+msgid "0"
+msgstr ""
+
+#: id:12311
+msgid "1"
+msgstr ""
+
+#: id:12312
+msgid "2"
+msgstr ""
+
+#: id:12313
+msgid "3"
+msgstr ""
+
+#: id:12314
+msgid "4"
+msgstr ""
+
+#: id:12315
+msgid "5"
+msgstr ""
+
+#: id:12316
+msgid "6"
+msgstr ""
+
+#: id:12317
+msgid "7"
+msgstr ""
+
+#: id:12318
+msgid "8"
+msgstr ""
+
+#: id:12319
+msgid "9"
+msgstr ""
+
+#: id:12320
+msgid "c"
+msgstr ""
+
+#: id:12321
+msgid "Ok"
+msgstr ""
+
+#: id:12322
+msgid "*"
+msgstr ""
+
+#empty strings from id 12323 to 12324
+
+#: id:12325
+msgid "Locked! Enter code..."
+msgstr ""
+
+#: id:12326
+msgid "Enter password"
+msgstr ""
+
+#: id:12327
+msgid "Enter master code"
+msgstr ""
+
+#: id:12328
+msgid "Enter unlock code"
+msgstr ""
+
+#: id:12329
+msgid "or press C to cancel"
+msgstr ""
+
+#: id:12330
+msgid "Enter gamepad button combo and"
+msgstr ""
+
+#: id:12331
+msgid "press OK, or Back to cancel"
+msgstr ""
+
+#: id:12332
+msgid "Set lock"
+msgstr ""
+
+#: id:12333
+msgid "Unlock"
+msgstr ""
+
+#: id:12334
+msgid "Reset lock"
+msgstr ""
+
+#: id:12335
+msgid "Remove lock"
+msgstr ""
+
+#empty string with id 12336
+
+#: id:12337
+msgid "Numeric password"
+msgstr ""
+
+#: id:12338
+msgid "Gamepad button combo"
+msgstr ""
+
+#: id:12339
+msgid "Full-text password"
+msgstr ""
+
+#: id:12340
+msgid "Enter new password"
+msgstr ""
+
+#: id:12341
+msgid "Re-Enter new password"
+msgstr ""
+
+#: id:12342
+msgid "Incorrect password,"
+msgstr ""
+
+#: id:12343
+msgid "retries left"
+msgstr ""
+
+#: id:12344
+msgid "Passwords entered did not match."
+msgstr ""
+
+#: id:12345
+msgid "Access denied"
+msgstr ""
+
+#: id:12346
+msgid "Password retry limit exceeded."
+msgstr ""
+
+#: id:12347
+msgid "The system will now shut off."
+msgstr ""
+
+#: id:12348
+msgid "Item locked"
+msgstr ""
+
+#empty strings from id 12349 to 12352
+
+#: id:12353
+msgid "Reactivate lock"
+msgstr ""
+
+#empty strings from id 12354 to 12355
+
+#: id:12356
+msgid "Change lock"
+msgstr ""
+
+#: id:12357
+msgid "Source lock"
+msgstr ""
+
+#: id:12358
+msgid "Password entry was blank. Try again."
+msgstr ""
+
+#empty string with id 12359
+
+#: id:12360
+msgid "Master lock"
+msgstr ""
+
+#empty string with id 12361
+
+#: id:12362
+msgid "Shutdown system if Master Lock retries exceeded"
+msgstr ""
+
+#empty strings from id 12363 to 12366
+
+#: id:12367
+msgid "Master code is not valid"
+msgstr ""
+
+#: id:12368
+msgid "Please enter a valid master code"
+msgstr ""
+
+#empty strings from id 12369 to 12372
+
+#: id:12373
+msgid "Settings & file manager"
+msgstr ""
+
+#empty strings from id 12374 to 12375
+
+#: id:12376
+msgid "Set as default for all movies"
+msgstr ""
+
+#: id:12377
+msgid "This will reset any previously saved values"
+msgstr ""
+
+#: id:12378
+msgid "Amount of time to display each image"
+msgstr ""
+
+#: id:12379
+msgid "Use pan and zoom effects"
+msgstr ""
+
+#empty strings from id 12380 to 12382
+
+#: id:12383
+msgid "12 hour clock"
+msgstr ""
+
+#: id:12384
+msgid "24 hour clock"
+msgstr ""
+
+#: id:12385
+msgid "Day/Month"
+msgstr ""
+
+#: id:12386
+msgid "Month/Day"
+msgstr ""
+
+#empty strings from id 12387 to 12389
+
+#: id:12390
+msgid "System uptime"
+msgstr ""
+
+#: id:12391
+msgid "Minutes"
+msgstr ""
+
+#: id:12392
+msgid "Hours"
+msgstr ""
+
+#: id:12393
+msgid "Days"
+msgstr ""
+
+#: id:12394
+msgid "Total uptime"
+msgstr ""
+
+#: id:12395
+msgid "Battery level"
+msgstr ""
+
+#empty strings from id 12396 to 12599
+
+#: id:12600
+msgctxt "Auto context with id 12600"
+msgid "Weather"
+msgstr ""
+
+#empty strings from id 12601 to 12899
+
+#: id:12900
+msgctxt "Auto context with id 12900"
+msgid "Screensaver"
+msgstr ""
+
+#: id:12901
+msgid "Fullscreen OSD"
+msgstr ""
+
+#empty strings from id 12902 to 12999
+
+#: id:13000
+msgid "System"
+msgstr ""
+
+#: id:13001
+msgid "Immediate HD spindown"
+msgstr ""
+
+#: id:13002
+msgid "Video only"
+msgstr ""
+
+#: id:13003
+msgid "- Delay"
+msgstr ""
+
+#: id:13004
+msgid "- Minimum file duration"
+msgstr ""
+
+#: id:13005
+msgid "Shutdown"
+msgstr ""
+
+#empty strings from id 13006 to 13007
+
+#: id:13008
+msgid "Shutdown function"
+msgstr ""
+
+#: id:13009
+msgid "Quit"
+msgstr ""
+
+#: id:13010
+msgid "Hibernate"
+msgstr ""
+
+#: id:13011
+msgid "Suspend"
+msgstr ""
+
+#: id:13012
+msgid "Exit"
+msgstr ""
+
+#: id:13013
+msgid "Reboot"
+msgstr ""
+
+#: id:13014
+msgid "Minimize"
+msgstr ""
+
+#: id:13015
+msgid "Power button action"
+msgstr ""
+
+#: id:13016
+msgid "Power off System"
+msgstr ""
+
+#empty strings from id 13017 to 13019
+
+#: id:13020
+msgid "Is another session active, perhaps over ssh?"
+msgstr ""
+
+#: id:13021
+msgid "Mounted removable harddrive"
+msgstr ""
+
+#: id:13022
+msgid "Unsafe device removal"
+msgstr ""
+
+#: id:13023
+msgid "Successfully removed device"
+msgstr ""
+
+#: id:13024
+msgid "Joystick plugged"
+msgstr ""
+
+#: id:13025
+msgid "Joystick unplugged"
+msgstr ""
+
+#empty strings from id 13026 to 13049
+
+#: id:13050
+msgid "Running low on battery"
+msgstr ""
+
+#empty strings from id 13051 to 13099
+
+#: id:13100
+msgid "Flicker filter"
+msgstr ""
+
+#: id:13101
+msgid "Let driver choose (requires restart)"
+msgstr ""
+
+#empty strings from id 13102 to 13104
+
+#: id:13105
+msgid "Vertical blank sync"
+msgstr ""
+
+#: id:13106
+msgctxt "Auto context with id 13106"
+msgid "Disabled"
+msgstr ""
+
+#: id:13107
+msgid "Enabled during video playback"
+msgstr ""
+
+#: id:13108
+msgctxt "Auto context with id 13108"
+msgid "Always enabled"
+msgstr ""
+
+#: id:13109
+msgid "Test & apply resolution"
+msgstr ""
+
+#: id:13110
+msgid "Save resolution?"
+msgstr ""
+
+#: id:13111
+msgid "Would you like to keep this resolution?"
+msgstr ""
+
+#: id:13112
+msgid "High quality upscaling"
+msgstr ""
+
+#: id:13113
+msgctxt "Auto context with id 13113"
+msgid "Disabled"
+msgstr ""
+
+#: id:13114
+msgid "Enabled for SD content"
+msgstr ""
+
+#: id:13115
+msgctxt "Auto context with id 13115"
+msgid "Always enabled"
+msgstr ""
+
+#: id:13116
+msgid "Upscaling method"
+msgstr ""
+
+#: id:13117
+msgctxt "Auto context with id 13117"
+msgid "Bicubic"
+msgstr ""
+
+#: id:13118
+msgid "Lanczos"
+msgstr ""
+
+#: id:13119
+msgid "Sinc"
+msgstr ""
+
+#: id:13120
+msgctxt "Auto context with id 13120"
+msgid "VDPAU"
+msgstr ""
+
+#: id:13121
+msgid "VDPAU HQ Upscaling level"
+msgstr ""
+
+#: id:13122
+msgid "VDPAU Studio level color conversion"
+msgstr ""
+
+#empty strings from id 13123 to 13129
+
+#: id:13130
+msgid "Blank other displays"
+msgstr ""
+
+#: id:13131
+msgctxt "Auto context with id 13131"
+msgid "Disabled"
+msgstr ""
+
+#: id:13132
+msgid "Blank displays"
+msgstr ""
+
+#empty strings from id 13133 to 13139
+
+#: id:13140
+msgid "Active connections detected!"
+msgstr ""
+
+#: id:13141
+msgid "If you proceed, you might not be able to control XBMC"
+msgstr ""
+
+#: id:13142
+msgid "any longer. Are you sure you want to stop the Event server?"
+msgstr ""
+
+#empty string with id 13143
+
+#: id:13144
+msgid "Change Apple Remote mode?"
+msgstr ""
+
+#: id:13145
+msgid "If you are currently using the Apple Remote to control"
+msgstr ""
+
+#: id:13146
+msgid "XBMC, changing this setting might affect your ability"
+msgstr ""
+
+#: id:13147
+msgid "to continue controlling it. Do you want to proceed?"
+msgstr ""
+
+#empty strings from id 13148 to 13158
+
+#: id:13159
+msgid "Subnet mask"
+msgstr ""
+
+#: id:13160
+msgid "Gateway"
+msgstr ""
+
+#: id:13161
+msgid "Primary DNS"
+msgstr ""
+
+#: id:13162
+msgid "Initialize failed"
+msgstr ""
+
+#empty strings from id 13163 to 13169
+
+#: id:13170
+msgctxt "Auto context with id 13170"
+msgid "Never"
+msgstr ""
+
+#: id:13171
+msgid "Immediately"
+msgstr ""
+
+#: id:13172
+msgid "After %i secs"
+msgstr ""
+
+#: id:13173
+msgid "HDD install date:"
+msgstr ""
+
+#: id:13174
+msgid "HDD power cycle count:"
+msgstr ""
+
+#empty strings from id 13175 to 13199
+
+#: id:13200
+msgid "Profiles"
+msgstr ""
+
+#: id:13201
+msgid "Delete profile '%s'?"
+msgstr ""
+
+#empty strings from id 13202 to 13203
+
+#: id:13204
+msgid "Last loaded profile:"
+msgstr ""
+
+#: id:13205
+msgid "Unknown"
+msgstr ""
+
+#: id:13206
+msgid "Overwrite"
+msgstr ""
+
+#empty string with id 13207
+
+#: id:13208
+msgid "Alarm clock"
+msgstr ""
+
+#: id:13209
+msgid "Alarm clock interval (in minutes)"
+msgstr ""
+
+#: id:13210
+msgid "Started, alarm in %im"
+msgstr ""
+
+#: id:13211
+msgid "Alarm!"
+msgstr ""
+
+#: id:13212
+msgid "Canceled with %im%is left"
+msgstr ""
+
+#: id:13213
+#. minutes (left from countdown)
+msgid "%2.0fm"
+msgstr ""
+
+#: id:13214
+#. seconds (left from countdown)
+msgid "%2.0fs"
+msgstr ""
+
+#empty strings from id 13215 to 13248
+
+#: id:13249
+msgid "Search for subtitles in RARs"
+msgstr ""
+
+#: id:13250
+msgid "Browse for subtitle..."
+msgstr ""
+
+#: id:13251
+msgid "Move item"
+msgstr ""
+
+#: id:13252
+msgid "Move item here"
+msgstr ""
+
+#: id:13253
+msgid "Cancel move"
+msgstr ""
+
+#empty strings from id 13254 to 13269
+
+#: id:13270
+msgid "Hardware:"
+msgstr ""
+
+#: id:13271
+msgid "CPU Usage:"
+msgstr ""
+
+#empty strings from id 13272 to 13273
+
+#: id:13274
+msgid "Connected, but no DNS is available."
+msgstr ""
+
+#: id:13275
+msgid "Hard Disk"
+msgstr ""
+
+#: id:13276
+msgid "DVD-ROM"
+msgstr ""
+
+#: id:13277
+msgctxt "Auto context with id 13277"
+msgid "Storage"
+msgstr ""
+
+#: id:13278
+msgctxt "Auto context with id 13278"
+msgid "Default"
+msgstr ""
+
+#: id:13279
+msgctxt "Auto context with id 13279"
+msgid "Network"
+msgstr ""
+
+#: id:13280
+msgctxt "Auto context with id 13280"
+msgid "Video"
+msgstr ""
+
+#: id:13281
+msgid "Hardware"
+msgstr ""
+
+#empty string with id 13282
+
+#: id:13283
+msgid "Operating system:"
+msgstr ""
+
+#: id:13284
+msgid "CPU speed:"
+msgstr ""
+
+#empty string with id 13285
+
+#: id:13286
+msgid "Video encoder:"
+msgstr ""
+
+#: id:13287
+msgid "Screen resolution:"
+msgstr ""
+
+#empty strings from id 13288 to 13291
+
+#: id:13292
+msgid "A/V cable:"
+msgstr ""
+
+#empty string with id 13293
+
+#: id:13294
+msgid "DVD region:"
+msgstr ""
+
+#: id:13295
+msgid "Internet:"
+msgstr ""
+
+#: id:13296
+msgctxt "Auto context with id 13296"
+msgid "Connected"
+msgstr ""
+
+#: id:13297
+msgid "Not connected. Check network settings."
+msgstr ""
+
+#empty string with id 13298
+
+#: id:13299
+msgid "Target temperature"
+msgstr ""
+
+#: id:13300
+msgid "Fan speed"
+msgstr ""
+
+#: id:13301
+msgid "Auto temperature control"
+msgstr ""
+
+#: id:13302
+msgid "Fan speed override"
+msgstr ""
+
+#: id:13303
+msgid "- Fonts"
+msgstr ""
+
+#: id:13304
+msgid "Enable flipping bi-directional strings"
+msgstr ""
+
+#: id:13305
+msgid "Show RSS news feeds"
+msgstr ""
+
+#: id:13306
+msgid "Show parent folder items"
+msgstr ""
+
+#: id:13307
+msgid "Track naming template"
+msgstr ""
+
+#: id:13308
+msgid "Do you wish to reboot your system"
+msgstr ""
+
+#: id:13309
+msgid "instead of just XBMC?"
+msgstr ""
+
+#: id:13310
+msgid "Zoom effect"
+msgstr ""
+
+#: id:13311
+msgid "Float effect"
+msgstr ""
+
+#: id:13312
+msgid "Black bar reduction"
+msgstr ""
+
+#: id:13313
+msgid "Restart"
+msgstr ""
+
+#: id:13314
+msgid "Crossfade between songs"
+msgstr ""
+
+#: id:13315
+msgid "Regenerate thumbnails"
+msgstr ""
+
+#: id:13316
+msgid "Recursive thumbnails"
+msgstr ""
+
+#: id:13317
+msgid "View slideshow"
+msgstr ""
+
+#: id:13318
+msgid "Recursive slideshow"
+msgstr ""
+
+#: id:13319
+msgid "Randomize"
+msgstr ""
+
+#: id:13320
+msgid "Stereo"
+msgstr ""
+
+#: id:13321
+msgid "Left only"
+msgstr ""
+
+#: id:13322
+msgid "Right only"
+msgstr ""
+
+#: id:13323
+msgid "Enable karaoke support"
+msgstr ""
+
+#: id:13324
+msgid "Background transparency"
+msgstr ""
+
+#: id:13325
+msgid "Foreground transparency"
+msgstr ""
+
+#: id:13326
+msgid "A/V delay"
+msgstr ""
+
+#: id:13327
+msgid "Karaoke"
+msgstr ""
+
+#: id:13328
+msgid "%s not found"
+msgstr ""
+
+#: id:13329
+msgid "Error opening %s"
+msgstr ""
+
+#: id:13330
+msgid "Unable to load %s"
+msgstr ""
+
+#: id:13331
+msgid "Error: Out of memory"
+msgstr ""
+
+#: id:13332
+msgid "Move up"
+msgstr ""
+
+#: id:13333
+msgid "Move down"
+msgstr ""
+
+#: id:13334
+msgid "Edit label"
+msgstr ""
+
+#: id:13335
+msgid "Make default"
+msgstr ""
+
+#: id:13336
+msgid "Remove button"
+msgstr ""
+
+#empty strings from id 13337 to 13339
+
+#: id:13340
+msgid "Leave as is"
+msgstr ""
+
+#: id:13341
+msgid "Green"
+msgstr ""
+
+#: id:13342
+msgid "Orange"
+msgstr ""
+
+#: id:13343
+msgid "Red"
+msgstr ""
+
+#: id:13344
+msgid "Cycle"
+msgstr ""
+
+#: id:13345
+msgid "Switch LED off on playback"
+msgstr ""
+
+#: id:13346
+msgctxt "Auto context with id 13346"
+msgid "Movie information"
+msgstr ""
+
+#: id:13347
+msgid "Queue item"
+msgstr ""
+
+#: id:13348
+msgid "Search IMDb..."
+msgstr ""
+
+#: id:13349
+msgid "Scan for new content"
+msgstr ""
+
+#: id:13350
+msgid "Now playing..."
+msgstr ""
+
+#: id:13351
+msgctxt "Auto context with id 13351"
+msgid "Album information"
+msgstr ""
+
+#: id:13352
+msgid "Scan item to library"
+msgstr ""
+
+#: id:13353
+msgid "Stop scanning"
+msgstr ""
+
+#: id:13354
+msgctxt "Auto context with id 13354"
+msgid "Render method"
+msgstr ""
+
+#: id:13355
+msgid "Low quality pixel shader"
+msgstr ""
+
+#: id:13356
+msgid "Hardware overlays"
+msgstr ""
+
+#: id:13357
+msgid "High quality pixel shader"
+msgstr ""
+
+#: id:13358
+msgid "Play item"
+msgstr ""
+
+#: id:13359
+msgid "Set artist thumb"
+msgstr ""
+
+#: id:13360
+msgid "Automatically generate thumbnails"
+msgstr ""
+
+#: id:13361
+msgid "Enable voice"
+msgstr ""
+
+#empty strings from id 13362 to 13374
+
+#: id:13375
+msgid "Enable device"
+msgstr ""
+
+#: id:13376
+msgid "Volume"
+msgstr ""
+
+#: id:13377
+msgid "Default view mode"
+msgstr ""
+
+#: id:13378
+msgid "Default brightness"
+msgstr ""
+
+#: id:13379
+msgid "Default contrast"
+msgstr ""
+
+#: id:13380
+msgid "Default gamma"
+msgstr ""
+
+#: id:13381
+msgid "Resume video"
+msgstr ""
+
+#: id:13382
+msgid "Voice mask - Port 1"
+msgstr ""
+
+#: id:13383
+msgid "Voice mask - Port 2"
+msgstr ""
+
+#: id:13384
+msgid "Voice mask - Port 3"
+msgstr ""
+
+#: id:13385
+msgid "Voice mask - Port 4"
+msgstr ""
+
+#: id:13386
+msgid "Use time based seeking"
+msgstr ""
+
+#: id:13387
+msgid "Track naming template - right"
+msgstr ""
+
+#: id:13388
+msgid "Preset"
+msgstr ""
+
+#: id:13389
+msgid "There are no presets available\nfor this visualization"
+msgstr ""
+
+#: id:13390
+msgid "There are no settings available\nfor this visualization"
+msgstr ""
+
+#: id:13391
+msgid "Eject/Load"
+msgstr ""
+
+#: id:13392
+msgid "Use visualization if playing audio"
+msgstr ""
+
+#: id:13393
+msgid "Calculate size"
+msgstr ""
+
+#: id:13394
+msgid "Calculating folder size"
+msgstr ""
+
+#: id:13395
+msgid "Video settings"
+msgstr ""
+
+#: id:13396
+msgid "Audio and subtitle settings"
+msgstr ""
+
+#: id:13397
+msgid "Enable subtitles"
+msgstr ""
+
+#: id:13398
+msgctxt "Auto context with id 13398"
+msgid "Shortcuts"
+msgstr ""
+
+#: id:13399
+msgid "Ignore articles when sorting (e.g. \"the\")"
+msgstr ""
+
+#: id:13400
+msgid "Crossfade between songs on the same album"
+msgstr ""
+
+#: id:13401
+msgid "Browse for %s"
+msgstr ""
+
+#: id:13402
+msgid "Show track position"
+msgstr ""
+
+#: id:13403
+msgid "Clear default"
+msgstr ""
+
+#: id:13404
+msgid "Resume"
+msgstr ""
+
+#: id:13405
+msgid "Get thumb"
+msgstr ""
+
+#: id:13406
+msgid "Picture information"
+msgstr ""
+
+#: id:13407
+msgid "%s presets"
+msgstr ""
+
+#: id:13408
+msgid "(IMDb user rating)"
+msgstr ""
+
+#: id:13409
+msgid "Top 250"
+msgstr ""
+
+#: id:13410
+msgid "Tune in on Last.fm"
+msgstr ""
+
+#: id:13411
+msgid "Minimum fan speed"
+msgstr ""
+
+#: id:13412
+msgid "Play from here"
+msgstr ""
+
+#: id:13413
+msgid "Downloading"
+msgstr ""
+
+#: id:13414
+msgid "Include artists who appear only on compilations"
+msgstr ""
+
+#: id:13415
+msgctxt "Auto context with id 13415"
+msgid "Render method"
+msgstr ""
+
+#: id:13416
+msgid "Auto detect"
+msgstr ""
+
+#: id:13417
+msgid "Basic shaders (ARB)"
+msgstr ""
+
+#: id:13418
+msgid "Advanced shaders (GLSL)"
+msgstr ""
+
+#: id:13419
+msgid "Software"
+msgstr ""
+
+#: id:13420
+msgid "Remove safely"
+msgstr ""
+
+#: id:13421
+msgctxt "Auto context with id 13421"
+msgid "VDPAU"
+msgstr ""
+
+#: id:13422
+msgid "Start slideshow here"
+msgstr ""
+
+#: id:13423
+msgid "Remember for this path"
+msgstr ""
+
+#: id:13424
+msgid "Use pixel buffer objects"
+msgstr ""
+
+#: id:13425
+msgid "Allow hardware acceleration (VDPAU)"
+msgstr ""
+
+#: id:13426
+msgid "Allow hardware acceleration (VAAPI)"
+msgstr ""
+
+#: id:13427
+msgid "Allow hardware acceleration (DXVA2)"
+msgstr ""
+
+#: id:13428
+msgid "Allow hardware acceleration (CrystalHD)"
+msgstr ""
+
+#: id:13429
+msgid "Allow hardware acceleration (VDADecoder)"
+msgstr ""
+
+#: id:13430
+msgid "Allow hardware acceleration (OpenMax)"
+msgstr ""
+
+#: id:13431
+msgid "Pixel Shaders"
+msgstr ""
+
+#: id:13432
+msgid "Allow hardware acceleration (VideoToolbox)"
+msgstr ""
+
+#empty strings from id 13433 to 13499
+
+#: id:13500
+msgid "A/V sync method"
+msgstr ""
+
+#: id:13501
+msgid "Audio clock"
+msgstr ""
+
+#: id:13502
+msgid "Video clock (Drop/Dupe audio)"
+msgstr ""
+
+#: id:13503
+msgid "Video clock (Resample audio)"
+msgstr ""
+
+#: id:13504
+msgid "Maximum resample amount (%)"
+msgstr ""
+
+#: id:13505
+msgid "Resample quality"
+msgstr ""
+
+#: id:13506
+msgid "Low(fast)"
+msgstr ""
+
+#: id:13507
+msgctxt "Auto context with id 13507"
+msgid "Medium"
+msgstr ""
+
+#: id:13508
+msgctxt "Auto context with id 13508"
+msgid "High"
+msgstr ""
+
+#: id:13509
+msgid "Really high(slow!)"
+msgstr ""
+
+#: id:13510
+msgid "Sync playback to display"
+msgstr ""
+
+#empty strings from id 13511 to 13549
+
+#: id:13550
+msgid "Pause during refresh rate change"
+msgstr ""
+
+#: id:13551
+msgctxt "Auto context with id 13551"
+msgid "Off"
+msgstr ""
+
+#: id:13552
+msgid "%.1f Second"
+msgstr ""
+
+#: id:13553
+msgid "%.1f Seconds"
+msgstr ""
+
+#empty strings from id 13554 to 13599
+
+#: id:13600
+msgid "Apple remote"
+msgstr ""
+
+#empty string with id 13601
+
+#: id:13602
+msgid "Allow start of XBMC using the remote"
+msgstr ""
+
+#: id:13603
+msgid "Sequence delay time"
+msgstr ""
+
+#empty strings from id 13604 to 13609
+
+#: id:13610
+msgctxt "Auto context with id 13610"
+msgid "Disabled"
+msgstr ""
+
+#: id:13611
+msgctxt "Auto context with id 13611"
+msgid "Standard"
+msgstr ""
+
+#: id:13612
+msgid "Universal Remote"
+msgstr ""
+
+#: id:13613
+msgid "Multi Remote (Harmony)"
+msgstr ""
+
+#empty strings from id 13614 to 13619
+
+#: id:13620
+msgid "Apple Remote Error"
+msgstr ""
+
+#: id:13621
+msgid "Apple Remote support could be enabled."
+msgstr ""
+
+#empty strings from id 13622 to 13999
+
+#: id:14000
+msgid "Stack"
+msgstr ""
+
+#: id:14001
+msgid "Unstack"
+msgstr ""
+
+#empty string with id 14002
+
+#: id:14003
+msgid "Downloading playlist file..."
+msgstr ""
+
+#: id:14004
+msgid "Downloading streams list..."
+msgstr ""
+
+#: id:14005
+msgid "Parsing streams list..."
+msgstr ""
+
+#: id:14006
+msgid "Downloading streams list failed"
+msgstr ""
+
+#: id:14007
+msgid "Downloading playlist file failed"
+msgstr ""
+
+#empty string with id 14008
+
+#: id:14009
+msgid "Games directory"
+msgstr ""
+
+#: id:14010
+msgid "Auto switch to thumbs based on"
+msgstr ""
+
+#: id:14011
+msgid "Enable auto switching to thumbs view"
+msgstr ""
+
+#: id:14012
+msgid "- Use large icons"
+msgstr ""
+
+#: id:14013
+msgid "- Switch based on"
+msgstr ""
+
+#: id:14014
+msgid "- Percentage"
+msgstr ""
+
+#: id:14015
+msgid "No files and at least one thumb"
+msgstr ""
+
+#: id:14016
+msgid "At least one file and thumb"
+msgstr ""
+
+#: id:14017
+msgid "Percentage of thumbs"
+msgstr ""
+
+#: id:14018
+msgid "View options"
+msgstr ""
+
+#: id:14019
+msgid "Change area code 1"
+msgstr ""
+
+#: id:14020
+msgid "Change area code 2"
+msgstr ""
+
+#: id:14021
+msgid "Change area code 3"
+msgstr ""
+
+#: id:14022
+msgctxt "Auto context with id 14022"
+msgid "Library"
+msgstr ""
+
+#: id:14023
+msgid "No TV"
+msgstr ""
+
+#: id:14024
+msgid "Enter the nearest large town"
+msgstr ""
+
+#: id:14025
+msgid "Video/Audio/DVD cache - Harddisk"
+msgstr ""
+
+#: id:14026
+msgid "Video cache - DVD-ROM"
+msgstr ""
+
+#: id:14027
+msgctxt "Auto context with id 14027"
+msgid "- Local Network"
+msgstr ""
+
+#: id:14028
+msgctxt "Auto context with id 14028"
+msgid "- Internet"
+msgstr ""
+
+#empty string with id 14029
+
+#: id:14030
+msgid "Audio cache - DVD-ROM"
+msgstr ""
+
+#: id:14031
+msgctxt "Auto context with id 14031"
+msgid "- Local Network"
+msgstr ""
+
+#: id:14032
+msgctxt "Auto context with id 14032"
+msgid "- Internet"
+msgstr ""
+
+#empty string with id 14033
+
+#: id:14034
+msgid "DVD cache - DVD-ROM"
+msgstr ""
+
+#: id:14035
+msgctxt "Auto context with id 14035"
+msgid "- Local Network"
+msgstr ""
+
+#: id:14036
+msgctxt "Auto context with id 14036"
+msgid "Services"
+msgstr ""
+
+#empty string with id 14037
+
+#: id:14038
+msgid "Network settings changed"
+msgstr ""
+
+#: id:14039
+msgid "XBMC requires to restart to change your"
+msgstr ""
+
+#: id:14040
+msgid "network setup. Would you like to restart now?"
+msgstr ""
+
+#: id:14041
+msgid "Internet connection bandwidth limitation"
+msgstr ""
+
+#empty string with id 14042
+
+#: id:14043
+msgid "- Shutdown while playing"
+msgstr ""
+
+#: id:14044
+msgid "%i min"
+msgstr ""
+
+#: id:14045
+msgid "%i sec"
+msgstr ""
+
+#: id:14046
+msgid "%i ms"
+msgstr ""
+
+#: id:14047
+msgid "%i %%"
+msgstr ""
+
+#: id:14048
+msgid "%i kbps"
+msgstr ""
+
+#: id:14049
+msgid "%i kb"
+msgstr ""
+
+#: id:14050
+msgid "%i.0 dB"
+msgstr ""
+
+#: id:14051
+msgid "Time format"
+msgstr ""
+
+#: id:14052
+msgid "Date format"
+msgstr ""
+
+#: id:14053
+msgid "GUI filters"
+msgstr ""
+
+#empty string with id 14054
+
+#: id:14055
+msgid "Use background scanning"
+msgstr ""
+
+#: id:14056
+msgid "Stop scan"
+msgstr ""
+
+#: id:14057
+msgid "Not possible while scanning for media info"
+msgstr ""
+
+#: id:14058
+msgid "Film grain effect"
+msgstr ""
+
+#: id:14059
+msgid "Search for thumbnails on remote shares"
+msgstr ""
+
+#: id:14060
+msgid "Unknown type cache - Internet"
+msgstr ""
+
+#: id:14061
+msgctxt "Auto context with id 14061"
+msgid "Auto"
+msgstr ""
+
+#: id:14062
+msgid "Enter username for"
+msgstr ""
+
+#: id:14063
+msgid "Date & time"
+msgstr ""
+
+#: id:14064
+msgid "Set date"
+msgstr ""
+
+#: id:14065
+msgid "Set time"
+msgstr ""
+
+#: id:14066
+msgid "Enter the time in 24 hour HH:MM format"
+msgstr ""
+
+#: id:14067
+msgid "Enter the date in DD/MM/YYYY format"
+msgstr ""
+
+#: id:14068
+msgid "Enter the IP address"
+msgstr ""
+
+#: id:14069
+msgid "Apply these settings now?"
+msgstr ""
+
+#: id:14070
+msgid "Apply changes now"
+msgstr ""
+
+#: id:14071
+msgid "Allow file renaming and deletion"
+msgstr ""
+
+#empty strings from id 14072 to 14073
+
+#: id:14074
+msgid "Set timezone"
+msgstr ""
+
+#: id:14075
+msgid "Use daylight saving time"
+msgstr ""
+
+#: id:14076
+msgid "Add to favourites"
+msgstr ""
+
+#: id:14077
+msgid "Remove from favourites"
+msgstr ""
+
+#: id:14078
+msgctxt "Auto context with id 14078"
+msgid "- Colours"
+msgstr ""
+
+#: id:14079
+msgid "Timezone country"
+msgstr ""
+
+#: id:14080
+msgid "Timezone"
+msgstr ""
+
+#: id:14081
+msgid "File lists"
+msgstr ""
+
+#: id:14082
+msgid "Show EXIF picture information"
+msgstr ""
+
+#: id:14083
+msgid "Use a fullscreen window rather than true fullscreen"
+msgstr ""
+
+#: id:14084
+msgid "Queue songs on selection"
+msgstr ""
+
+#empty string with id 14085
+
+#: id:14086
+msgid "Playback"
+msgstr ""
+
+#: id:14087
+msgid "DVDs"
+msgstr ""
+
+#: id:14088
+msgid "Play DVDs automatically"
+msgstr ""
+
+#: id:14089
+msgid "Font to use for text subtitles"
+msgstr ""
+
+#: id:14090
+msgid "International"
+msgstr ""
+
+#: id:14091
+msgid "Character set"
+msgstr ""
+
+#: id:14092
+msgid "Debugging"
+msgstr ""
+
+#: id:14093
+msgid "Security"
+msgstr ""
+
+#: id:14094
+msgid "Input devices"
+msgstr ""
+
+#: id:14095
+msgid "Power saving"
+msgstr ""
+
+#: id:14096
+msgid "Rip"
+msgstr ""
+
+#: id:14097
+msgid "Audio CD Insert Action"
+msgstr ""
+
+#: id:14098
+msgctxt "Auto context with id 14098"
+msgid "Play"
+msgstr ""
+
+#: id:14099
+msgid "Eject disc when CD ripping is complete"
+msgstr ""
+
+#empty strings from id 14100 to 15014
+
+#: id:15015
+msgctxt "Auto context with id 15015"
+msgid "Remove"
+msgstr ""
+
+#: id:15016
+msgid "Games"
+msgstr ""
+
+#empty strings from id 15017 to 15018
+
+#: id:15019
+msgid "Add"
+msgstr ""
+
+#empty strings from id 15020 to 15051
+
+#: id:15052
+msgid "Password"
+msgstr ""
+
+#empty strings from id 15053 to 15099
+
+#: id:15100
+msgctxt "Auto context with id 15100"
+msgid "Library"
+msgstr ""
+
+#: id:15101
+msgid "Database"
+msgstr ""
+
+#: id:15102
+msgid "* All albums"
+msgstr ""
+
+#: id:15103
+msgid "* All artists"
+msgstr ""
+
+#: id:15104
+msgid "* All songs"
+msgstr ""
+
+#: id:15105
+msgid "* All genres"
+msgstr ""
+
+#empty string with id 15106
+
+#: id:15107
+msgid "Buffering..."
+msgstr ""
+
+#: id:15108
+msgid "Navigation sounds"
+msgstr ""
+
+#: id:15109
+msgid "Skin default"
+msgstr ""
+
+#empty string with id 15110
+
+#: id:15111
+msgid "- Theme"
+msgstr ""
+
+#: id:15112
+msgid "Default theme"
+msgstr ""
+
+#empty strings from id 15113 to 15199
+
+#: id:15200
+msgid "Last.fm"
+msgstr ""
+
+#: id:15201
+msgid "Submit songs to Last.fm"
+msgstr ""
+
+#: id:15202
+msgid "Last.fm username"
+msgstr ""
+
+#: id:15203
+msgid "Last.fm password"
+msgstr ""
+
+#: id:15204
+msgid "Unable to handshake: sleeping..."
+msgstr ""
+
+#: id:15205
+msgid "Please update XBMC"
+msgstr ""
+
+#: id:15206
+msgid "Bad authorization: Check username and password"
+msgstr ""
+
+#: id:15207
+msgctxt "Auto context with id 15207"
+msgid "Connected"
+msgstr ""
+
+#: id:15208
+msgid "Not connected"
+msgstr ""
+
+#: id:15209
+msgid "Submit interval %i"
+msgstr ""
+
+#: id:15210
+msgid "Cached %i songs"
+msgstr ""
+
+#: id:15211
+msgid "Submitting..."
+msgstr ""
+
+#: id:15212
+msgid "Submitting in %i secs"
+msgstr ""
+
+#: id:15213
+msgid "Play using..."
+msgstr ""
+
+#: id:15214
+msgid "Use smoothed A/V synchronization"
+msgstr ""
+
+#: id:15215
+msgid "Hide file names in thumbs view"
+msgstr ""
+
+#: id:15216
+msgid "Play in party mode"
+msgstr ""
+
+#: id:15217
+msgid "Submit songs to Libre.fm"
+msgstr ""
+
+#: id:15218
+msgid "Libre.fm username"
+msgstr ""
+
+#: id:15219
+msgid "Libre.fm password"
+msgstr ""
+
+#: id:15220
+msgid "Libre.fm"
+msgstr ""
+
+#: id:15221
+msgid "Song submission"
+msgstr ""
+
+#empty strings from id 15222 to 15249
+
+#: id:15250
+msgid "Submit Last.fm radio to Last.fm"
+msgstr ""
+
+#: id:15251
+msgid "Connecting to Last.fm..."
+msgstr ""
+
+#: id:15252
+msgid "Selecting station..."
+msgstr ""
+
+#: id:15253
+msgid "Search similar artists..."
+msgstr ""
+
+#: id:15254
+msgid "Search similar tags..."
+msgstr ""
+
+#: id:15255
+msgid "Your profile (%name%)"
+msgstr ""
+
+#: id:15256
+msgid "Overall top tags"
+msgstr ""
+
+#: id:15257
+msgid "Top artists for tag %name%"
+msgstr ""
+
+#: id:15258
+msgid "Top albums for tag %name%"
+msgstr ""
+
+#: id:15259
+msgid "Top tracks for tag %name%"
+msgstr ""
+
+#: id:15260
+msgid "Listen to tag %name% Last.fm radio"
+msgstr ""
+
+#: id:15261
+msgid "Similar artists as %name%"
+msgstr ""
+
+#: id:15262
+msgid "Top %name% albums"
+msgstr ""
+
+#: id:15263
+msgid "Top %name% tracks"
+msgstr ""
+
+#: id:15264
+msgid "Top %name% tags"
+msgstr ""
+
+#: id:15265
+msgid "Biggest fans of %name%"
+msgstr ""
+
+#: id:15266
+msgid "Listen to %name% fans Last.fm radio"
+msgstr ""
+
+#: id:15267
+msgid "Listen to %name% similar artists Last.fm radio"
+msgstr ""
+
+#: id:15268
+msgid "Top artists for user %name%"
+msgstr ""
+
+#: id:15269
+msgid "Top albums for user %name%"
+msgstr ""
+
+#: id:15270
+msgid "Top tracks for user %name%"
+msgstr ""
+
+#: id:15271
+msgid "Friends of user %name%"
+msgstr ""
+
+#: id:15272
+msgid "Neighbours of user %name%"
+msgstr ""
+
+#: id:15273
+msgid "Weekly artist chart for %name%"
+msgstr ""
+
+#: id:15274
+msgid "Weekly album chart for %name%"
+msgstr ""
+
+#: id:15275
+msgid "Weekly track chart for %name%"
+msgstr ""
+
+#: id:15276
+msgid "Listen to %name%'s neighbours Last.fm radio"
+msgstr ""
+
+#: id:15277
+msgid "Listen to %name%'s personal Last.fm radio"
+msgstr ""
+
+#: id:15278
+msgid "Listen to %name%'s mix Last.fm radio"
+msgstr ""
+
+#: id:15279
+msgid "Retrieving list from Last.fm..."
+msgstr ""
+
+#: id:15280
+msgid "Can't retrieve list from Last.fm..."
+msgstr ""
+
+#: id:15281
+msgid "Enter an artist name to find related ones"
+msgstr ""
+
+#: id:15282
+msgid "Enter a tag name to find similar ones"
+msgstr ""
+
+#: id:15283
+msgid "Tracks recently listened by %name%"
+msgstr ""
+
+#: id:15284
+msgid "Listen to %name%'s recommendations Last.fm radio"
+msgstr ""
+
+#: id:15285
+msgid "Top tags for user %name%"
+msgstr ""
+
+#empty string with id 15286
+
+#: id:15287
+msgid "Do you want to add the current track to your loved tracks?"
+msgstr ""
+
+#: id:15288
+msgid "Do you want to ban the current track?"
+msgstr ""
+
+#: id:15289
+msgid "Added to your loved tracks: '%s'."
+msgstr ""
+
+#: id:15290
+msgid "Could not add '%s' to your loved tracks."
+msgstr ""
+
+#: id:15291
+msgid "Banned: '%s'."
+msgstr ""
+
+#: id:15292
+msgid "Could not ban '%s'."
+msgstr ""
+
+#: id:15293
+msgid "Tracks recently loved by %name%"
+msgstr ""
+
+#: id:15294
+msgid "Tracks recently banned by %name%"
+msgstr ""
+
+#: id:15295
+msgid "Remove from loved tracks"
+msgstr ""
+
+#: id:15296
+msgid "Un-ban"
+msgstr ""
+
+#: id:15297
+msgid "Do you want to remove this track from your loved tracks?"
+msgstr ""
+
+#: id:15298
+msgid "Do you want to un-ban this track?"
+msgstr ""
+
+#empty string with id 15299
+
+#: id:15300
+msgid "Path not found or invalid"
+msgstr ""
+
+#: id:15301
+msgid "Could not connect to network server"
+msgstr ""
+
+#: id:15302
+msgid "No servers found"
+msgstr ""
+
+#: id:15303
+msgid "Workgroup not found"
+msgstr ""
+
+#empty strings from id 15304 to 15309
+
+#: id:15310
+msgid "Opening multi-path source"
+msgstr ""
+
+#: id:15311
+msgid "Path:"
+msgstr ""
+
+#empty strings from id 15312 to 15999
+
+#: id:16000
+msgctxt "Auto context with id 16000"
+msgid "General"
+msgstr ""
+
+#empty string with id 16001
+
+#: id:16002
+msgid "Internet lookup"
+msgstr ""
+
+#: id:16003
+msgid "Player"
+msgstr ""
+
+#: id:16004
+msgid "Play media from disc"
+msgstr ""
+
+#empty strings from id 16005 to 16007
+
+#: id:16008
+msgid "Enter new title"
+msgstr ""
+
+#: id:16009
+msgid "Enter the movie name"
+msgstr ""
+
+#: id:16010
+msgid "Enter the profile name"
+msgstr ""
+
+#: id:16011
+msgid "Enter the album name"
+msgstr ""
+
+#: id:16012
+msgid "Enter the playlist name"
+msgstr ""
+
+#: id:16013
+msgid "Enter new filename"
+msgstr ""
+
+#: id:16014
+msgid "Enter folder name"
+msgstr ""
+
+#: id:16015
+msgid "Enter directory"
+msgstr ""
+
+#: id:16016
+msgid "Available options: %A, %T, %N, %B, %D, %G, %Y, %F, %S"
+msgstr ""
+
+#: id:16017
+msgid "Enter search string"
+msgstr ""
+
+#: id:16018
+msgctxt "Auto context with id 16018"
+msgid "None"
+msgstr ""
+
+#: id:16019
+msgid "Auto select"
+msgstr ""
+
+#: id:16020
+msgid "De-interlace"
+msgstr ""
+
+#: id:16021
+msgid "Bob"
+msgstr ""
+
+#: id:16022
+msgid "Bob (inverted)"
+msgstr ""
+
+#empty string with id 16023
+
+#: id:16024
+msgid "Canceling..."
+msgstr ""
+
+#: id:16025
+msgid "Enter the artist name"
+msgstr ""
+
+#: id:16026
+msgid "Playback failed"
+msgstr ""
+
+#: id:16027
+msgid "One or more items failed to play."
+msgstr ""
+
+#: id:16028
+msgid "Enter value"
+msgstr ""
+
+#: id:16029
+msgid "Check the log file for details."
+msgstr ""
+
+#: id:16030
+msgid "Party mode aborted."
+msgstr ""
+
+#: id:16031
+msgid "No matching songs in the library."
+msgstr ""
+
+#: id:16032
+msgid "Could not initialize database."
+msgstr ""
+
+#: id:16033
+msgid "Could not open database."
+msgstr ""
+
+#: id:16034
+msgid "Could not get songs from database."
+msgstr ""
+
+#: id:16035
+msgid "Party mode playlist"
+msgstr ""
+
+#: id:16036
+msgid "De-interlace (Half)"
+msgstr ""
+
+#: id:16037
+msgid "Deinterlace video"
+msgstr ""
+
+#: id:16038
+msgid "Deinterlace method"
+msgstr ""
+
+#: id:16039
+msgctxt "Auto context with id 16039"
+msgid "Off"
+msgstr ""
+
+#: id:16040
+msgctxt "Auto context with id 16040"
+msgid "Auto"
+msgstr ""
+
+#: id:16041
+msgid "On"
+msgstr ""
+
+#empty strings from id 16042 to 16099
+
+#: id:16100
+msgid "All Videos"
+msgstr ""
+
+#: id:16101
+msgid "Unwatched"
+msgstr ""
+
+#: id:16102
+msgid "Watched"
+msgstr ""
+
+#: id:16103
+msgid "Mark as watched"
+msgstr ""
+
+#: id:16104
+msgid "Mark as unwatched"
+msgstr ""
+
+#: id:16105
+msgid "Edit title"
+msgstr ""
+
+#empty strings from id 16106 to 16199
+
+#: id:16200
+msgid "Operation was aborted"
+msgstr ""
+
+#: id:16201
+msgid "Copy failed"
+msgstr ""
+
+#: id:16202
+msgid "Failed to copy at least one file"
+msgstr ""
+
+#: id:16203
+msgid "Move failed"
+msgstr ""
+
+#: id:16204
+msgid "Failed to move at least one file"
+msgstr ""
+
+#: id:16205
+msgid "Delete failed"
+msgstr ""
+
+#: id:16206
+msgid "Failed to delete at least one file"
+msgstr ""
+
+#empty strings from id 16207 to 16299
+
+#: id:16300
+msgid "Video scaling method"
+msgstr ""
+
+#: id:16301
+msgid "Nearest neighbour"
+msgstr ""
+
+#: id:16302
+msgid "Bilinear"
+msgstr ""
+
+#: id:16303
+msgctxt "Auto context with id 16303"
+msgid "Bicubic"
+msgstr ""
+
+#: id:16304
+msgid "Lanczos2"
+msgstr ""
+
+#: id:16305
+msgid "Lanczos3"
+msgstr ""
+
+#: id:16306
+msgid "Sinc8"
+msgstr ""
+
+#: id:16307
+msgid "Bicubic (software)"
+msgstr ""
+
+#: id:16308
+msgid "Lanczos (software)"
+msgstr ""
+
+#: id:16309
+msgid "Sinc (software)"
+msgstr ""
+
+#: id:16310
+msgid "Temporal"
+msgstr ""
+
+#: id:16311
+msgid "Temporal/Spatial"
+msgstr ""
+
+#: id:16312
+msgid "(VDPAU)Noise Reduction"
+msgstr ""
+
+#: id:16313
+msgid "(VDPAU)Sharpness"
+msgstr ""
+
+#: id:16314
+msgid "Inverse Telecine"
+msgstr ""
+
+#: id:16315
+msgid "Lanczos3 optimized"
+msgstr ""
+
+#: id:16316
+msgctxt "Auto context with id 16316"
+msgid "Auto"
+msgstr ""
+
+#: id:16317
+msgid "Temporal (Half)"
+msgstr ""
+
+#: id:16318
+msgid "Temporal/Spatial (Half)"
+msgstr ""
+
+#: id:16319
+msgid "DXVA"
+msgstr ""
+
+#: id:16320
+msgid "DXVA Bob"
+msgstr ""
+
+#: id:16321
+msgid "DXVA Best"
+msgstr ""
+
+#: id:16322
+msgid "Spline36"
+msgstr ""
+
+#: id:16323
+msgid "Spline36 optimized"
+msgstr ""
+
+#: id:16324
+msgid "Software Blend"
+msgstr ""
+
+#empty strings from id 16325 to 16399
+
+#: id:16400
+msgid "Post-processing"
+msgstr ""
+
+#empty strings from id 16401 to 17499
+
+#: id:17500
+msgid "Display sleep timeout"
+msgstr ""
+
+#empty strings from id 17501 to 18999
+
+#: id:19000
+msgid "Switch to channel"
+msgstr ""
+
+#empty strings from id 19001 to 19999
+
+#: id:20000
+msgid "Saved music folder"
+msgstr ""
+
+#: id:20001
+msgid "Use external DVD player"
+msgstr ""
+
+#: id:20002
+msgid "External DVD player"
+msgstr ""
+
+#: id:20003
+msgid "Trainers folder"
+msgstr ""
+
+#: id:20004
+msgid "Screenshot folder"
+msgstr ""
+
+#empty string with id 20005
+
+#: id:20006
+msgid "Playlists folder"
+msgstr ""
+
+#: id:20007
+msgid "Recordings"
+msgstr ""
+
+#: id:20008
+msgid "Screenshots"
+msgstr ""
+
+#: id:20009
+msgid "Use XBMC"
+msgstr ""
+
+#empty string with id 20010
+
+#: id:20011
+msgid "Music playlists"
+msgstr ""
+
+#: id:20012
+msgid "Video playlists"
+msgstr ""
+
+#: id:20013
+msgid "Do you wish to launch the game?"
+msgstr ""
+
+#: id:20014
+msgid "Sort by: Playlist"
+msgstr ""
+
+#: id:20015
+msgid "Remote thumb"
+msgstr ""
+
+#: id:20016
+msgid "Current thumb"
+msgstr ""
+
+#: id:20017
+msgid "Local thumb"
+msgstr ""
+
+#: id:20018
+msgid "No thumb"
+msgstr ""
+
+#: id:20019
+msgid "Choose thumbnail"
+msgstr ""
+
+#string id 20022 will always be set to an empty string (LocalizeStrings.cpp)
+#empty strings from id 20020 to 20022
+
+#: id:20023
+msgid "Conflict"
+msgstr ""
+
+#: id:20024
+msgid "Scan new"
+msgstr ""
+
+#: id:20025
+msgid "Scan all"
+msgstr ""
+
+#: id:20026
+msgid "Region"
+msgstr ""
+
+#string id's 20027 thru 20034 are reserved for temperature strings (LocalizeStrings.cpp)
+#empty strings from id 20027 to 20036
+
+#: id:20037
+msgid "Summary"
+msgstr ""
+
+#: id:20038
+msgid "Lock music window"
+msgstr ""
+
+#: id:20039
+msgid "Lock videos window"
+msgstr ""
+
+#: id:20040
+msgid "Lock pictures window"
+msgstr ""
+
+#: id:20041
+msgid "Lock programs & scripts windows"
+msgstr ""
+
+#: id:20042
+msgid "Lock file manager"
+msgstr ""
+
+#: id:20043
+msgid "Lock settings"
+msgstr ""
+
+#: id:20044
+msgid "Start fresh"
+msgstr ""
+
+#: id:20045
+msgid "Enter master mode"
+msgstr ""
+
+#: id:20046
+msgid "Leave master mode"
+msgstr ""
+
+#: id:20047
+msgid "Create profile '%s'?"
+msgstr ""
+
+#: id:20048
+msgid "Start with fresh settings"
+msgstr ""
+
+#: id:20049
+msgid "Best available"
+msgstr ""
+
+#: id:20050
+msgid "Auto-switch between 16x9 and 4x3"
+msgstr ""
+
+#: id:20051
+msgid "Treat stacked files as single file"
+msgstr ""
+
+#: id:20052
+msgid "Caution"
+msgstr ""
+
+#: id:20053
+msgid "Left master mode"
+msgstr ""
+
+#: id:20054
+msgid "Entered master mode"
+msgstr ""
+
+#: id:20055
+msgid "Allmusic.com thumb"
+msgstr ""
+
+#empty string with id 20056
+
+#: id:20057
+msgid "Remove thumbnail"
+msgstr ""
+
+#: id:20058
+msgid "Add profile..."
+msgstr ""
+
+#: id:20059
+msgid "Query info for all albums"
+msgstr ""
+
+#: id:20060
+msgctxt "Auto context with id 20060"
+msgid "Media info"
+msgstr ""
+
+#: id:20061
+msgctxt "Auto context with id 20061"
+msgid "Separate"
+msgstr ""
+
+#: id:20062
+msgid "Shares with default"
+msgstr ""
+
+#: id:20063
+msgid "Shares with default (read only)"
+msgstr ""
+
+#: id:20064
+msgid "Copy default"
+msgstr ""
+
+#: id:20065
+msgid "Profile picture"
+msgstr ""
+
+#: id:20066
+msgid "Lock preferences"
+msgstr ""
+
+#: id:20067
+msgid "Edit profile"
+msgstr ""
+
+#: id:20068
+msgid "Profile lock"
+msgstr ""
+
+#: id:20069
+msgid "Could not create folder"
+msgstr ""
+
+#: id:20070
+msgid "Profile directory"
+msgstr ""
+
+#: id:20071
+msgid "Start with fresh media sources"
+msgstr ""
+
+#: id:20072
+msgid "Make sure the selected folder is writable"
+msgstr ""
+
+#: id:20073
+msgid "and that the new folder name is valid"
+msgstr ""
+
+#: id:20074
+msgid "MPAA rating"
+msgstr ""
+
+#: id:20075
+msgid "Enter master lock code"
+msgstr ""
+
+#: id:20076
+msgid "Ask for master lock code on startup"
+msgstr ""
+
+#: id:20077
+msgid "Skin settings"
+msgstr ""
+
+#: id:20078
+msgid "- no link set -"
+msgstr ""
+
+#: id:20079
+msgid "Enable animations"
+msgstr ""
+
+#: id:20080
+msgid "Disable RSS during music"
+msgstr ""
+
+#: id:20081
+msgid "Enable shortcut buttons"
+msgstr ""
+
+#: id:20082
+msgid "Show programs in main menu"
+msgstr ""
+
+#: id:20083
+msgid "Show music info"
+msgstr ""
+
+#: id:20084
+msgid "Show weather info"
+msgstr ""
+
+#: id:20085
+msgid "Show system info"
+msgstr ""
+
+#: id:20086
+msgid "Show available disc space C: E: F:"
+msgstr ""
+
+#: id:20087
+msgid "Show available disc space E: F: G:"
+msgstr ""
+
+#: id:20088
+msgid "Weather info"
+msgstr ""
+
+#: id:20089
+msgid "Drive space free"
+msgstr ""
+
+#: id:20090
+msgid "Enter the name of an existing share"
+msgstr ""
+
+#: id:20091
+msgid "Lock code"
+msgstr ""
+
+#: id:20092
+msgid "Load profile"
+msgstr ""
+
+#: id:20093
+msgid "Profile name"
+msgstr ""
+
+#: id:20094
+msgctxt "Auto context with id 20094"
+msgid "Media sources"
+msgstr ""
+
+#: id:20095
+msgid "Enter profile lock code"
+msgstr ""
+
+#: id:20096
+msgctxt "Auto context with id 20096"
+msgid "Login screen"
+msgstr ""
+
+#: id:20097
+msgid "Fetching album info"
+msgstr ""
+
+#: id:20098
+msgid "Fetching info for album"
+msgstr ""
+
+#: id:20099
+msgid "Can't rip CD or track while playing from CD"
+msgstr ""
+
+#: id:20100
+msgid "Master lock code and settings"
+msgstr ""
+
+#: id:20101
+msgid "Entering master lock code always enables master mode"
+msgstr ""
+
+#: id:20102
+msgid "or copy from default?"
+msgstr ""
+
+#: id:20103
+msgid "Save changes to profile?"
+msgstr ""
+
+#: id:20104
+msgid "Old settings found."
+msgstr ""
+
+#: id:20105
+msgid "Do you want to use them?"
+msgstr ""
+
+#: id:20106
+msgid "Old media sources found."
+msgstr ""
+
+#: id:20107
+msgid "Separate (locked)"
+msgstr ""
+
+#: id:20108
+msgid "Root"
+msgstr ""
+
+#: id:20109
+msgid "- Zoom"
+msgstr ""
+
+#: id:20110
+msgid "UPnP settings"
+msgstr ""
+
+#: id:20111
+msgid "Autostart UPnP client"
+msgstr ""
+
+#: id:20112
+msgid "Last login: %s"
+msgstr ""
+
+#: id:20113
+msgid "Never logged on"
+msgstr ""
+
+#: id:20114
+msgid "Profile %i / %i"
+msgstr ""
+
+#: id:20115
+msgid "User login / Select a profile"
+msgstr ""
+
+#: id:20116
+msgid "Use lock on login screen"
+msgstr ""
+
+#: id:20117
+msgid "Invalid lock code."
+msgstr ""
+
+#: id:20118
+msgid "This requires the master lock to be set."
+msgstr ""
+
+#: id:20119
+msgid "Would you like to set it now?"
+msgstr ""
+
+#: id:20120
+msgid "Loading program information"
+msgstr ""
+
+#: id:20121
+msgid "Party on!"
+msgstr ""
+
+#: id:20122
+msgid "True"
+msgstr ""
+
+#: id:20123
+msgid "Mixing drinks"
+msgstr ""
+
+#: id:20124
+msgid "Filling glasses"
+msgstr ""
+
+#: id:20125
+msgid "Logged on as"
+msgstr ""
+
+#: id:20126
+msgid "Log off"
+msgstr ""
+
+#empty string with id 20127
+
+#: id:20128
+msgid "Go to root"
+msgstr ""
+
+#: id:20129
+msgid "Weave"
+msgstr ""
+
+#: id:20130
+msgid "Weave (inverted)"
+msgstr ""
+
+#: id:20131
+msgid "Blend"
+msgstr ""
+
+#: id:20132
+msgid "Restart video"
+msgstr ""
+
+#: id:20133
+msgid "Edit network location"
+msgstr ""
+
+#: id:20134
+msgid "Remove network location"
+msgstr ""
+
+#: id:20135
+msgid "Do you want to scan the folder?"
+msgstr ""
+
+#: id:20136
+msgid "Memory unit"
+msgstr ""
+
+#: id:20137
+msgid "Memory unit mounted"
+msgstr ""
+
+#: id:20138
+msgid "Unable to mount memory unit"
+msgstr ""
+
+#: id:20139
+msgid "In port %i, slot %i"
+msgstr ""
+
+#: id:20140
+msgid "Lock screensaver"
+msgstr ""
+
+#: id:20141
+msgid "Set"
+msgstr ""
+
+#: id:20142
+msgctxt "Auto context with id 20142"
+msgid "Username"
+msgstr ""
+
+#: id:20143
+msgid "Enter password for"
+msgstr ""
+
+#: id:20144
+msgid "Shutdown timer"
+msgstr ""
+
+#: id:20145
+msgid "Shutdown interval (in minutes)"
+msgstr ""
+
+#: id:20146
+msgid "Started, shutdown in %im"
+msgstr ""
+
+#: id:20147
+msgid "Shutdown in 30 minutes"
+msgstr ""
+
+#: id:20148
+msgid "Shutdown in 60 minutes"
+msgstr ""
+
+#: id:20149
+msgid "Shutdown in 120 minutes"
+msgstr ""
+
+#: id:20150
+msgid "Custom shutdown timer"
+msgstr ""
+
+#: id:20151
+msgid "Cancel shutdown timer"
+msgstr ""
+
+#: id:20152
+msgid "Lock preferences for %s"
+msgstr ""
+
+#: id:20153
+msgid "Browse..."
+msgstr ""
+
+#: id:20154
+msgid "Summary information"
+msgstr ""
+
+#: id:20155
+msgid "Storage information"
+msgstr ""
+
+#: id:20156
+msgid "Hard disk information"
+msgstr ""
+
+#: id:20157
+msgid "DVD-ROM information"
+msgstr ""
+
+#: id:20158
+msgid "Network information"
+msgstr ""
+
+#: id:20159
+msgid "Video information"
+msgstr ""
+
+#: id:20160
+msgid "Hardware information"
+msgstr ""
+
+#: id:20161
+msgid "Total"
+msgstr ""
+
+#: id:20162
+msgid "Used"
+msgstr ""
+
+#: id:20163
+msgid "of"
+msgstr ""
+
+#: id:20164
+msgid "Locking not supported"
+msgstr ""
+
+#: id:20165
+msgid "Not locked"
+msgstr ""
+
+#: id:20166
+msgid "Locked"
+msgstr ""
+
+#: id:20167
+msgid "Frozen"
+msgstr ""
+
+#: id:20168
+msgid "Requires reset"
+msgstr ""
+
+#: id:20169
+msgid "Week"
+msgstr ""
+
+#: id:20170
+msgid "Line"
+msgstr ""
+
+#: id:20171
+msgid "Windows network (SMB)"
+msgstr ""
+
+#: id:20172
+msgid "XBMSP server"
+msgstr ""
+
+#: id:20173
+msgctxt "Auto context with id 20173"
+msgid "FTP server"
+msgstr ""
+
+#: id:20174
+msgid "iTunes music share (DAAP)"
+msgstr ""
+
+#: id:20175
+msgid "UPnP server"
+msgstr ""
+
+#: id:20176
+msgid "Show video info"
+msgstr ""
+
+#: id:20177
+msgid "Done"
+msgstr ""
+
+#: id:20178
+msgid "Shift"
+msgstr ""
+
+#: id:20179
+msgid "Caps Lock"
+msgstr ""
+
+#: id:20180
+msgid "Symbols"
+msgstr ""
+
+#: id:20181
+msgid "Backspace"
+msgstr ""
+
+#: id:20182
+msgid "Space"
+msgstr ""
+
+#: id:20183
+msgid "Reload skin"
+msgstr ""
+
+#: id:20184
+msgid "Rotate pictures using EXIF information"
+msgstr ""
+
+#: id:20185
+msgid "Use poster view styles for TV shows"
+msgstr ""
+
+#: id:20186
+msgid "Please wait"
+msgstr ""
+
+#: id:20187
+msgid "UPnP"
+msgstr ""
+
+#empty string with id 20188
+
+#: id:20189
+msgid "Enable auto scrolling for plot & review"
+msgstr ""
+
+#: id:20190
+msgctxt "Auto context with id 20190"
+msgid "Custom"
+msgstr ""
+
+#: id:20191
+msgid "Enable debug logging"
+msgstr ""
+
+#: id:20192
+msgid "Download additional information during updates"
+msgstr ""
+
+#: id:20193
+msgid "Default service for album information"
+msgstr ""
+
+#: id:20194
+msgid "Default service for artist information"
+msgstr ""
+
+#: id:20195
+msgid "Change scraper"
+msgstr ""
+
+#: id:20196
+msgid "Export music library"
+msgstr ""
+
+#: id:20197
+msgid "Import music library"
+msgstr ""
+
+#: id:20198
+msgid "No artist found!"
+msgstr ""
+
+#: id:20199
+msgid "Downloading artist info failed"
+msgstr ""
+
+#string id's 20200 thru 20211 are reserved for speedstrings (LocalizeStrings.cpp)
+#empty strings from id 20200 to 20249
+
+#: id:20250
+msgid "Party on! (videos)"
+msgstr ""
+
+#: id:20251
+msgid "Mixing drinks (videos)"
+msgstr ""
+
+#: id:20252
+msgid "Filling glasses (videos)"
+msgstr ""
+
+#: id:20253
+msgid "WebDAV server (HTTP)"
+msgstr ""
+
+#: id:20254
+msgid "WebDAV server (HTTPS)"
+msgstr ""
+
+#: id:20255
+msgid "First logon, edit your profile"
+msgstr ""
+
+#: id:20256
+msgid "HTS Tvheadend client"
+msgstr ""
+
+#: id:20257
+msgid "VDR Streamdev client"
+msgstr ""
+
+#: id:20258
+msgid "MythTV client"
+msgstr ""
+
+#: id:20259
+msgid "Network Filesystem (NFS)"
+msgstr ""
+
+#: id:20260
+msgid "Secure Shell (SSH/SFTP)"
+msgstr ""
+
+#: id:20261
+msgid "Apple Filing Protocol (AFP)"
+msgstr ""
+
+#empty strings from id 20262 to 20299
+
+#: id:20300
+msgid "Web server directory (HTTP)"
+msgstr ""
+
+#: id:20301
+msgid "Web server directory (HTTPS)"
+msgstr ""
+
+#: id:20302
+msgid "Unable to write to folder:"
+msgstr ""
+
+#: id:20303
+msgid "Do you want to skip and proceed?"
+msgstr ""
+
+#: id:20304
+msgid "RSS Feed"
+msgstr ""
+
+#empty strings from id 20305 to 20306
+
+#: id:20307
+msgid "Secondary DNS"
+msgstr ""
+
+#: id:20308
+msgid "DHCP server:"
+msgstr ""
+
+#: id:20309
+msgid "Make new folder"
+msgstr ""
+
+#: id:20310
+msgid "Dim LCD on playback"
+msgstr ""
+
+#: id:20311
+msgid "Unknown or onboard (protected)"
+msgstr ""
+
+#: id:20312
+msgid "Dim LCD on paused"
+msgstr ""
+
+#empty string with id 20313
+
+#: id:20314
+msgid "Videos - Library"
+msgstr ""
+
+#empty string with id 20315
+
+#: id:20316
+msgid "Sort by: ID"
+msgstr ""
+
+#empty strings from id 20317 to 20323
+
+#: id:20324
+msgid "Play part..."
+msgstr ""
+
+#: id:20325
+msgid "Calibration reset"
+msgstr ""
+
+#: id:20326
+msgid "This will reset the calibration values for %s"
+msgstr ""
+
+#: id:20327
+msgid "to it's default values."
+msgstr ""
+
+#: id:20328
+msgid "Browse for destination"
+msgstr ""
+
+#: id:20329
+msgid "Movies are in separate folders that match the movie title"
+msgstr ""
+
+#: id:20330
+msgid "Use folder names for lookups"
+msgstr ""
+
+#: id:20331
+msgctxt "Auto context with id 20331"
+msgid "File"
+msgstr ""
+
+#: id:20332
+msgid "Use file or folder names in lookups?"
+msgstr ""
+
+#: id:20333
+msgid "Set content"
+msgstr ""
+
+#: id:20334
+msgid "Folder"
+msgstr ""
+
+#: id:20335
+msgid "Look for content recursively?"
+msgstr ""
+
+#: id:20336
+msgid "Unlock sources"
+msgstr ""
+
+#: id:20337
+msgid "Actor"
+msgstr ""
+
+#: id:20338
+msgid "Movie"
+msgstr ""
+
+#: id:20339
+msgid "Director"
+msgstr ""
+
+#: id:20340
+msgid "Do you want to remove all items within"
+msgstr ""
+
+#: id:20341
+msgid "this path from the XBMC library?"
+msgstr ""
+
+#: id:20342
+msgctxt "Auto context with id 20342"
+msgid "Movies"
+msgstr ""
+
+#: id:20343
+msgid "TV shows"
+msgstr ""
+
+#: id:20344
+msgid "This directory contains"
+msgstr ""
+
+#: id:20345
+msgid "Run automated scan"
+msgstr ""
+
+#: id:20346
+msgid "Scan recursively"
+msgstr ""
+
+#: id:20347
+msgid "as"
+msgstr ""
+
+#: id:20348
+msgid "Directors"
+msgstr ""
+
+#: id:20349
+msgid "No video files found in this path!"
+msgstr ""
+
+#: id:20350
+msgid "votes"
+msgstr ""
+
+#: id:20351
+msgid "TV show information"
+msgstr ""
+
+#: id:20352
+msgid "Episode information"
+msgstr ""
+
+#: id:20353
+msgid "Loading TV show details"
+msgstr ""
+
+#: id:20354
+msgid "Fetching episode guide"
+msgstr ""
+
+#: id:20355
+msgid "Loading info for episodes in directory"
+msgstr ""
+
+#: id:20356
+msgid "Select TV show:"
+msgstr ""
+
+#: id:20357
+msgid "Enter the TV show name"
+msgstr ""
+
+#: id:20358
+msgid "Season %i"
+msgstr ""
+
+#: id:20359
+msgid "Episode"
+msgstr ""
+
+#: id:20360
+msgid "Episodes"
+msgstr ""
+
+#: id:20361
+msgid "Loading episode details"
+msgstr ""
+
+#: id:20362
+msgid "Remove episode from library"
+msgstr ""
+
+#: id:20363
+msgid "Remove TV show from library"
+msgstr ""
+
+#: id:20364
+msgid "TV show"
+msgstr ""
+
+#: id:20365
+msgid "Episode plot"
+msgstr ""
+
+#: id:20366
+msgid "* All seasons"
+msgstr ""
+
+#: id:20367
+msgid "Hide watched"
+msgstr ""
+
+#: id:20368
+msgid "Prod code"
+msgstr ""
+
+#: id:20369
+msgid "Show plot for unwatched items"
+msgstr ""
+
+#: id:20370
+msgid "* Hidden to prevent spoilers *"
+msgstr ""
+
+#: id:20371
+msgid "Set season thumb"
+msgstr ""
+
+#: id:20372
+msgid "Season image"
+msgstr ""
+
+#: id:20373
+msgid "Season"
+msgstr ""
+
+#: id:20374
+msgid "Downloading movie information"
+msgstr ""
+
+#: id:20375
+msgid "Unassign content"
+msgstr ""
+
+#: id:20376
+msgid "Original title"
+msgstr ""
+
+#: id:20377
+msgid "Refresh TV show information"
+msgstr ""
+
+#: id:20378
+msgid "Refresh info for all episodes?"
+msgstr ""
+
+#: id:20379
+msgid "Selected folder contains a single TV show"
+msgstr ""
+
+#: id:20380
+msgid "Exclude selected folder from scans"
+msgstr ""
+
+#: id:20381
+msgid "Specials"
+msgstr ""
+
+#: id:20382
+msgid "Automatically grab season thumbs"
+msgstr ""
+
+#: id:20383
+msgid "Selected folder contains a single video"
+msgstr ""
+
+#: id:20384
+msgid "Link to TV show"
+msgstr ""
+
+#: id:20385
+msgid "Remove link to TV show"
+msgstr ""
+
+#: id:20386
+msgid "Recently added movies"
+msgstr ""
+
+#: id:20387
+msgid "Recently added episodes"
+msgstr ""
+
+#: id:20388
+msgid "Studios"
+msgstr ""
+
+#: id:20389
+msgid "Music videos"
+msgstr ""
+
+#: id:20390
+msgid "Recently added music videos"
+msgstr ""
+
+#: id:20391
+msgid "Music video"
+msgstr ""
+
+#: id:20392
+msgid "Remove music video from library"
+msgstr ""
+
+#: id:20393
+msgctxt "Auto context with id 20393"
+msgid "Music video information"
+msgstr ""
+
+#: id:20394
+msgid "Loading music video information"
+msgstr ""
+
+#: id:20395
+msgid "Mixed"
+msgstr ""
+
+#: id:20396
+msgid "Go to albums by artist"
+msgstr ""
+
+#: id:20397
+msgid "Go to album"
+msgstr ""
+
+#: id:20398
+msgid "Play song"
+msgstr ""
+
+#: id:20399
+msgid "Go to music videos from album"
+msgstr ""
+
+#: id:20400
+msgid "Go to music videos by artist"
+msgstr ""
+
+#: id:20401
+msgid "Play music video"
+msgstr ""
+
+#: id:20402
+msgid "Download actor thumbnails when adding to library"
+msgstr ""
+
+#: id:20403
+msgid "Set actor thumb"
+msgstr ""
+
+#empty string with id 20404
+
+#: id:20405
+msgid "Remove episode bookmark"
+msgstr ""
+
+#: id:20406
+msgid "Set episode bookmark"
+msgstr ""
+
+#: id:20407
+msgid "Scraper settings"
+msgstr ""
+
+#: id:20408
+msgid "Downloading music video information"
+msgstr ""
+
+#: id:20409
+msgid "Downloading TV show information"
+msgstr ""
+
+#: id:20410
+msgid "Trailer"
+msgstr ""
+
+#: id:20411
+msgid "Flatten"
+msgstr ""
+
+#: id:20412
+msgid "Flatten TV shows"
+msgstr ""
+
+#: id:20413
+msgid "Get fanart"
+msgstr ""
+
+#: id:20414
+msgid "Show Fanart in video and music libraries"
+msgstr ""
+
+#: id:20415
+msgid "Scanning for new content"
+msgstr ""
+
+#: id:20416
+msgid "First aired"
+msgstr ""
+
+#: id:20417
+msgid "Writer"
+msgstr ""
+
+#empty string with id 20418
+
+#: id:20419
+msgid "Replace file names with library titles"
+msgstr ""
+
+#: id:20420
+msgctxt "Auto context with id 20420"
+msgid "Never"
+msgstr ""
+
+#: id:20421
+msgid "If only one season"
+msgstr ""
+
+#: id:20422
+msgid "Always"
+msgstr ""
+
+#: id:20423
+msgid "Has trailer"
+msgstr ""
+
+#: id:20424
+msgid "False"
+msgstr ""
+
+#: id:20425
+msgid "Fanart slideshow"
+msgstr ""
+
+#: id:20426
+msgid "Export to a single file or separate"
+msgstr ""
+
+#: id:20427
+msgid "files per entry?"
+msgstr ""
+
+#: id:20428
+msgid "Single file"
+msgstr ""
+
+#: id:20429
+msgctxt "Auto context with id 20429"
+msgid "Separate"
+msgstr ""
+
+#: id:20430
+msgid "Export thumbnails and fanart?"
+msgstr ""
+
+#: id:20431
+msgid "Overwrite old files?"
+msgstr ""
+
+#: id:20432
+msgid "Exclude path from library updates"
+msgstr ""
+
+#: id:20433
+msgid "Extract thumbnails and video information"
+msgstr ""
+
+#: id:20434
+msgid "Sets"
+msgstr ""
+
+#: id:20435
+msgid "Set movieset thumb"
+msgstr ""
+
+#: id:20436
+msgid "Export actor thumbs?"
+msgstr ""
+
+#: id:20437
+msgid "Choose fanart"
+msgstr ""
+
+#: id:20438
+msgid "Local fanart"
+msgstr ""
+
+#: id:20439
+msgid "No fanart"
+msgstr ""
+
+#: id:20440
+msgid "Current fanart"
+msgstr ""
+
+#: id:20441
+msgid "Remote fanart"
+msgstr ""
+
+#: id:20442
+msgid "Change content"
+msgstr ""
+
+#: id:20443
+msgid "Do you want to refresh info for all"
+msgstr ""
+
+#: id:20444
+msgid "items within this path?"
+msgstr ""
+
+#: id:20445
+msgid "Fanart"
+msgstr ""
+
+#: id:20446
+msgid "Locally stored information found."
+msgstr ""
+
+#: id:20447
+msgid "Ignore and refresh from internet?"
+msgstr ""
+
+#: id:20448
+msgid "Could not download information"
+msgstr ""
+
+#: id:20449
+msgid "Unable to connect to remote server"
+msgstr ""
+
+#: id:20450
+msgid "Would you like to continue scanning?"
+msgstr ""
+
+#: id:20451
+msgid "Countries"
+msgstr ""
+
+#: id:20452
+msgid "episode"
+msgstr ""
+
+#: id:20453
+msgid "episodes"
+msgstr ""
+
+#: id:20454
+msgid "Listener"
+msgstr ""
+
+#: id:20455
+msgid "Listeners"
+msgstr ""
+
+#: id:20456
+msgid "Set movieset fanart"
+msgstr ""
+
+#: id:20457
+msgid "Movie set"
+msgstr ""
+
+#: id:20458
+msgid "Group movies in sets"
+msgstr ""
+
+#up to 21329 is reserved for the video db !! !
+#empty strings from id 20459 to 21329
+
+#: id:21330
+msgid "Show hidden files and directories"
+msgstr ""
+
+#: id:21331
+msgid "TuxBox client"
+msgstr ""
+
+#: id:21332
+msgid "WARNING: Target TuxBox device is in recording-mode!"
+msgstr ""
+
+#: id:21333
+msgid "The stream will be stopped!"
+msgstr ""
+
+#: id:21334
+msgid "Zap to channel: %s failed!"
+msgstr ""
+
+#: id:21335
+msgid "Are you sure to start the stream?"
+msgstr ""
+
+#: id:21336
+msgid "Connecting to: %s"
+msgstr ""
+
+#: id:21337
+msgid "TuxBox device"
+msgstr ""
+
+#up to 21355 is reserved for the TuxBox Client!! !
+#empty strings from id 21338 to 21358
+
+#: id:21359
+msgid "Add media share..."
+msgstr ""
+
+#: id:21360
+msgid "Share video and music libraries through UPnP"
+msgstr ""
+
+#empty strings from id 21361 to 21363
+
+#: id:21364
+msgid "Edit media share"
+msgstr ""
+
+#: id:21365
+msgid "Remove media share"
+msgstr ""
+
+#: id:21366
+msgid "Subtitle folder"
+msgstr ""
+
+#: id:21367
+msgid "Movie & alternate subtitle directory"
+msgstr ""
+
+#: id:21368
+msgid "Override ASS/SSA subtitles fonts"
+msgstr ""
+
+#: id:21369
+msgid "Enable mouse and Touch Screen support"
+msgstr ""
+
+#: id:21370
+msgid "Play navigation sounds during media playback"
+msgstr ""
+
+#: id:21371
+msgid "Thumbnail"
+msgstr ""
+
+#: id:21372
+msgid "Forced DVD player region"
+msgstr ""
+
+#: id:21373
+msgid "Video output"
+msgstr ""
+
+#: id:21374
+msgid "Video aspect"
+msgstr ""
+
+#: id:21375
+msgctxt "Auto context with id 21375"
+msgid "Normal"
+msgstr ""
+
+#: id:21376
+msgid "Letterbox"
+msgstr ""
+
+#: id:21377
+msgid "Widescreen"
+msgstr ""
+
+#: id:21378
+msgid "Enable 480p"
+msgstr ""
+
+#: id:21379
+msgid "Enable 720p"
+msgstr ""
+
+#: id:21380
+msgid "Enable 1080i"
+msgstr ""
+
+#: id:21381
+msgid "Enter name of new playlist"
+msgstr ""
+
+#: id:21382
+msgid "Show \"Add source\" buttons in file lists"
+msgstr ""
+
+#: id:21383
+msgid "Enable scrollbars"
+msgstr ""
+
+#: id:21384
+msgid "Make watched filtering a toggle in video library"
+msgstr ""
+
+#: id:21385
+msgctxt "Auto context with id 21385"
+msgid "Open"
+msgstr ""
+
+#: id:21386
+msgid "Acoustic management level"
+msgstr ""
+
+#: id:21387
+msgid "Fast"
+msgstr ""
+
+#: id:21388
+msgid "Quiet"
+msgstr ""
+
+#: id:21389
+msgid "Enable custom background"
+msgstr ""
+
+#: id:21390
+msgid "Power management level"
+msgstr ""
+
+#: id:21391
+msgid "High power"
+msgstr ""
+
+#: id:21392
+msgid "Low power"
+msgstr ""
+
+#: id:21393
+msgid "High standby"
+msgstr ""
+
+#: id:21394
+msgid "Low standby"
+msgstr ""
+
+#: id:21395
+msgid "Unable to cache files bigger than 4GB"
+msgstr ""
+
+#: id:21396
+msgid "Chapter"
+msgstr ""
+
+#: id:21397
+msgid "High quality pixel shader v2"
+msgstr ""
+
+#: id:21398
+msgid "Enable playlist at startup"
+msgstr ""
+
+#: id:21399
+msgid "Use tween animations"
+msgstr ""
+
+#: id:21400
+msgid "contains"
+msgstr ""
+
+#: id:21401
+msgid "does not contain"
+msgstr ""
+
+#: id:21402
+msgid "is"
+msgstr ""
+
+#: id:21403
+msgid "is not"
+msgstr ""
+
+#: id:21404
+msgid "starts with"
+msgstr ""
+
+#: id:21405
+msgid "ends with"
+msgstr ""
+
+#: id:21406
+msgid "greater than"
+msgstr ""
+
+#: id:21407
+msgid "less than"
+msgstr ""
+
+#: id:21408
+msgid "after"
+msgstr ""
+
+#: id:21409
+msgid "before"
+msgstr ""
+
+#: id:21410
+msgid "in the last"
+msgstr ""
+
+#: id:21411
+msgid "not in the last"
+msgstr ""
+
+#: id:21412
+msgid "Scrapers"
+msgstr ""
+
+#: id:21413
+msgid "Default movie scraper"
+msgstr ""
+
+#: id:21414
+msgid "Default tvshow scraper"
+msgstr ""
+
+#: id:21415
+msgid "Default music video scraper"
+msgstr ""
+
+#: id:21416
+msgid "Enable fallback based on scraper language"
+msgstr ""
+
+#: id:21417
+msgid "- Settings"
+msgstr ""
+
+#: id:21418
+msgid "Multilingual"
+msgstr ""
+
+#: id:21419
+msgid "No scrapers present"
+msgstr ""
+
+#: id:21420
+msgid "Value to match"
+msgstr ""
+
+#: id:21421
+msgid "Smart playlist rule"
+msgstr ""
+
+#: id:21422
+msgid "Match items where"
+msgstr ""
+
+#: id:21423
+msgid "New rule..."
+msgstr ""
+
+#: id:21424
+msgid "Items must match"
+msgstr ""
+
+#: id:21425
+msgid "all of the rules"
+msgstr ""
+
+#: id:21426
+msgid "one or more of the rules"
+msgstr ""
+
+#: id:21427
+msgid "Limit to"
+msgstr ""
+
+#: id:21428
+msgid "No limit"
+msgstr ""
+
+#: id:21429
+msgid "Order by"
+msgstr ""
+
+#: id:21430
+msgid "ascending"
+msgstr ""
+
+#: id:21431
+msgid "descending"
+msgstr ""
+
+#: id:21432
+msgid "Edit smart playlist"
+msgstr ""
+
+#: id:21433
+msgid "Name of the playlist"
+msgstr ""
+
+#: id:21434
+msgid "Find items where"
+msgstr ""
+
+#: id:21435
+msgid "Edit"
+msgstr ""
+
+#: id:21436
+msgid "%i items"
+msgstr ""
+
+#: id:21437
+msgid "New smart playlist..."
+msgstr ""
+
+#: id:21438
+msgid "%c Drive"
+msgstr ""
+
+#: id:21439
+msgid "Edit party mode rules"
+msgstr ""
+
+#: id:21440
+msgid "Home folder"
+msgstr ""
+
+#: id:21441
+msgid "Watched count"
+msgstr ""
+
+#: id:21442
+msgid "Episode title"
+msgstr ""
+
+#: id:21443
+msgid "Video resolution"
+msgstr ""
+
+#: id:21444
+msgid "Audio channels"
+msgstr ""
+
+#: id:21445
+msgid "Video codec"
+msgstr ""
+
+#: id:21446
+msgid "Audio codec"
+msgstr ""
+
+#: id:21447
+msgid "Audio language"
+msgstr ""
+
+#: id:21448
+msgid "Subtitle language"
+msgstr ""
+
+#: id:21449
+msgid "Remote control sends keyboard presses"
+msgstr ""
+
+#: id:21450
+msgid "- Edit"
+msgstr ""
+
+#: id:21451
+msgid "Internet connection required."
+msgstr ""
+
+#: id:21452
+msgid "Get More..."
+msgstr ""
+
+#: id:21453
+msgid "Root filesystem"
+msgstr ""
+
+#: id:21454
+msgid "Cache full"
+msgstr ""
+
+#: id:21455
+msgid "Cache filled before reaching required amount for continous playback"
+msgstr ""
+
+#empty strings from id 21456 to 21459
+
+#: id:21460
+msgid "Subtitle location"
+msgstr ""
+
+#: id:21461
+msgid "Fixed"
+msgstr ""
+
+#: id:21462
+msgid "Bottom of video"
+msgstr ""
+
+#: id:21463
+msgid "Below video"
+msgstr ""
+
+#: id:21464
+msgid "Top of video"
+msgstr ""
+
+#: id:21465
+msgid "Above video"
+msgstr ""
+
+#empty strings from id 21466 to 21799
+
+#: id:21800
+msgid "File name"
+msgstr ""
+
+#: id:21801
+msgid "File path"
+msgstr ""
+
+#: id:21802
+msgid "File size"
+msgstr ""
+
+#: id:21803
+msgid "File date/time"
+msgstr ""
+
+#: id:21804
+msgid "Slide index"
+msgstr ""
+
+#: id:21805
+msgctxt "Auto context with id 21805"
+msgid "Resolution"
+msgstr ""
+
+#: id:21806
+msgctxt "Auto context with id 21806"
+msgid "Comment"
+msgstr ""
+
+#: id:21807
+msgid "Colour/B&W"
+msgstr ""
+
+#: id:21808
+msgid "JPEG process"
+msgstr ""
+
+#empty strings from id 21809 to 21819
+
+#: id:21820
+msgid "Date/Time"
+msgstr ""
+
+#: id:21821
+msgid "Description"
+msgstr ""
+
+#: id:21822
+msgid "Camera make"
+msgstr ""
+
+#: id:21823
+msgid "Camera model"
+msgstr ""
+
+#: id:21824
+msgid "EXIF comment"
+msgstr ""
+
+#: id:21825
+msgid "Firmware"
+msgstr ""
+
+#: id:21826
+msgid "Aperture"
+msgstr ""
+
+#: id:21827
+msgid "Focal length"
+msgstr ""
+
+#: id:21828
+msgid "Focus distance"
+msgstr ""
+
+#: id:21829
+msgid "Exposure"
+msgstr ""
+
+#: id:21830
+msgid "Exposure time"
+msgstr ""
+
+#: id:21831
+msgid "Exposure bias"
+msgstr ""
+
+#: id:21832
+msgid "Exposure mode"
+msgstr ""
+
+#: id:21833
+msgid "Flash used"
+msgstr ""
+
+#: id:21834
+msgid "White-balance"
+msgstr ""
+
+#: id:21835
+msgid "Light source"
+msgstr ""
+
+#: id:21836
+msgid "Metering mode"
+msgstr ""
+
+#: id:21837
+msgid "ISO"
+msgstr ""
+
+#: id:21838
+msgid "Digital zoom"
+msgstr ""
+
+#: id:21839
+msgid "CCD width"
+msgstr ""
+
+#: id:21840
+msgid "GPS latitude"
+msgstr ""
+
+#: id:21841
+msgid "GPS longitude"
+msgstr ""
+
+#: id:21842
+msgid "GPS altitude"
+msgstr ""
+
+#: id:21843
+msgid "Orientation"
+msgstr ""
+
+#empty strings from id 21844 to 21859
+
+#: id:21860
+msgid "Supplemental categories"
+msgstr ""
+
+#: id:21861
+msgid "Keywords"
+msgstr ""
+
+#: id:21862
+msgid "Caption"
+msgstr ""
+
+#: id:21863
+msgid "Author"
+msgstr ""
+
+#: id:21864
+msgid "Headline"
+msgstr ""
+
+#: id:21865
+msgid "Special instructions"
+msgstr ""
+
+#: id:21866
+msgid "Category"
+msgstr ""
+
+#: id:21867
+msgid "Byline"
+msgstr ""
+
+#: id:21868
+msgid "Byline title"
+msgstr ""
+
+#: id:21869
+msgid "Credit"
+msgstr ""
+
+#: id:21870
+msgid "Source"
+msgstr ""
+
+#: id:21871
+msgid "Copyright notice"
+msgstr ""
+
+#: id:21872
+msgid "Object name"
+msgstr ""
+
+#: id:21873
+msgid "City"
+msgstr ""
+
+#: id:21874
+msgid "State"
+msgstr ""
+
+#: id:21875
+msgctxt "Auto context with id 21875"
+msgid "Country"
+msgstr ""
+
+#: id:21876
+msgid "Original Tx Reference"
+msgstr ""
+
+#: id:21877
+msgid "Date created"
+msgstr ""
+
+#: id:21878
+msgid "Copyright flag"
+msgstr ""
+
+#: id:21879
+msgid "Country code"
+msgstr ""
+
+#: id:21880
+msgid "Reference service"
+msgstr ""
+
+#: id:21881
+msgid "Allow control of XBMC via UPnP"
+msgstr ""
+
+#: id:21882
+msgid "Attempt to skip introduction before DVD menu"
+msgstr ""
+
+#: id:21883
+msgid "Saved music"
+msgstr ""
+
+#: id:21884
+msgid "Query info for all artists"
+msgstr ""
+
+#: id:21885
+msgid "Downloading album information"
+msgstr ""
+
+#: id:21886
+msgid "Downloading artist information"
+msgstr ""
+
+#: id:21887
+msgid "Biography"
+msgstr ""
+
+#: id:21888
+msgid "Discography"
+msgstr ""
+
+#: id:21889
+msgid "Searching artist"
+msgstr ""
+
+#: id:21890
+msgid "Select artist"
+msgstr ""
+
+#: id:21891
+msgctxt "Auto context with id 21891"
+msgid "Artist information"
+msgstr ""
+
+#: id:21892
+msgid "Instruments"
+msgstr ""
+
+#: id:21893
+msgid "Born"
+msgstr ""
+
+#: id:21894
+msgid "Formed"
+msgstr ""
+
+#: id:21895
+msgid "Themes"
+msgstr ""
+
+#: id:21896
+msgid "Disbanded"
+msgstr ""
+
+#: id:21897
+msgid "Died"
+msgstr ""
+
+#: id:21898
+msgid "Years active"
+msgstr ""
+
+#: id:21899
+msgid "Label"
+msgstr ""
+
+#: id:21900
+msgid "Born/Formed"
+msgstr ""
+
+#strings 21900 thru 21999 reserved for slideshow info
+#empty strings from id 21901 to 21999
+
+#: id:22000
+msgid "Update library on startup"
+msgstr ""
+
+#: id:22001
+msgid "Hide progress of library updates"
+msgstr ""
+
+#: id:22002
+msgid "- DNS suffix"
+msgstr ""
+
+#: id:22003
+msgid "%2.3fs"
+msgstr ""
+
+#: id:22004
+msgid "Delayed by: %2.3fs"
+msgstr ""
+
+#: id:22005
+msgid "Ahead by: %2.3fs"
+msgstr ""
+
+#: id:22006
+msgid "Subtitle offset"
+msgstr ""
+
+#: id:22007
+msgid "OpenGL vendor:"
+msgstr ""
+
+#: id:22008
+msgid "OpenGL renderer:"
+msgstr ""
+
+#: id:22009
+msgid "OpenGL version:"
+msgstr ""
+
+#: id:22010
+msgid "GPU temperature:"
+msgstr ""
+
+#: id:22011
+msgid "CPU temperature:"
+msgstr ""
+
+#: id:22012
+msgid "Total memory"
+msgstr ""
+
+#: id:22013
+msgid "Profile data"
+msgstr ""
+
+#: id:22014
+msgid "Use dim if paused during video playback"
+msgstr ""
+
+#: id:22015
+msgid "All recordings"
+msgstr ""
+
+#: id:22016
+msgid "By title"
+msgstr ""
+
+#: id:22017
+msgid "By group"
+msgstr ""
+
+#: id:22018
+msgid "Live channels"
+msgstr ""
+
+#: id:22019
+msgid "Recordings by title"
+msgstr ""
+
+#: id:22020
+msgid "Guide"
+msgstr ""
+
+#: id:22021
+msgid "Allowed error in aspect ratio to minimize black bars"
+msgstr ""
+
+#: id:22022
+msgid "Show video files in listings"
+msgstr ""
+
+#: id:22023
+msgid "DirectX vendor:"
+msgstr ""
+
+#: id:22024
+msgid "Direct3D version:"
+msgstr ""
+
+#strings 22030 thru 22060 reserved for karaoke
+#empty strings from id 22025 to 22029
+
+#: id:22030
+msgctxt "Auto context with id 22030"
+msgid "Font"
+msgstr ""
+
+#: id:22031
+msgctxt "Auto context with id 22031"
+msgid "- Size"
+msgstr ""
+
+#: id:22032
+msgctxt "Auto context with id 22032"
+msgid "- Colours"
+msgstr ""
+
+#: id:22033
+msgid "- Charset"
+msgstr ""
+
+#: id:22034
+msgid "Export karaoke titles as HTML"
+msgstr ""
+
+#: id:22035
+msgid "Export karaoke titles as CSV"
+msgstr ""
+
+#: id:22036
+msgid "Import karaoke titles..."
+msgstr ""
+
+#: id:22037
+msgid "Show song selector automatically"
+msgstr ""
+
+#: id:22038
+msgid "Export karaoke titles..."
+msgstr ""
+
+#: id:22039
+msgid "Enter song number"
+msgstr ""
+
+#: id:22040
+msgid "white/green"
+msgstr ""
+
+#: id:22041
+msgid "white/red"
+msgstr ""
+
+#: id:22042
+msgid "white/blue"
+msgstr ""
+
+#: id:22043
+msgid "black/white"
+msgstr ""
+
+#empty strings from id 22044 to 22078
+
+#: id:22079
+msgid "Default select action"
+msgstr ""
+
+#: id:22080
+msgid "Choose"
+msgstr ""
+
+#: id:22081
+msgid "Show Information"
+msgstr ""
+
+#: id:22082
+msgid "More..."
+msgstr ""
+
+#: id:22083
+msgid "Play all"
+msgstr ""
+
+#empty strings from id 22084 to 23048
+
+#: id:23049
+msgid "Teletext not available"
+msgstr ""
+
+#: id:23050
+msgid "Activate Teletext"
+msgstr ""
+
+#: id:23051
+msgid "Part %i"
+msgstr ""
+
+#: id:23052
+msgid "Buffering %i bytes"
+msgstr ""
+
+#: id:23053
+msgid "Stopping"
+msgstr ""
+
+#: id:23054
+msgid "Running"
+msgstr ""
+
+#strings 23100 thru 23150 reserved for external player
+#empty strings from id 23055 to 23099
+
+#: id:23100
+msgid "External Player Active"
+msgstr ""
+
+#: id:23101
+msgid "Click OK to terminate the player"
+msgstr ""
+
+#empty strings from id 23102 to 23103
+
+#: id:23104
+msgid "Click OK when playback has ended"
+msgstr ""
+
+#strings 24000 thru 24299 reserved for the Add-ons framework
+#empty strings from id 23105 to 23999
+
+#: id:24000
+msgid "Add-on"
+msgstr ""
+
+#: id:24001
+msgid "Add-ons"
+msgstr ""
+
+#: id:24002
+msgid "Add-on options"
+msgstr ""
+
+#: id:24003
+msgid "Add-on Information"
+msgstr ""
+
+#empty string with id 24004
+
+#: id:24005
+msgctxt "Auto context with id 24005"
+msgid "Media sources"
+msgstr ""
+
+#empty string with id 24006
+
+#: id:24007
+msgctxt "Auto context with id 24007"
+msgid "Movie information"
+msgstr ""
+
+#: id:24008
+msgctxt "Auto context with id 24008"
+msgid "Screensaver"
+msgstr ""
+
+#: id:24009
+msgid "Script"
+msgstr ""
+
+#: id:24010
+msgctxt "Auto context with id 24010"
+msgid "Visualization"
+msgstr ""
+
+#: id:24011
+msgid "Add-on repository"
+msgstr ""
+
+#: id:24012
+msgctxt "Auto context with id 24012"
+msgid "Subtitles"
+msgstr ""
+
+#: id:24013
+msgid "Lyrics"
+msgstr ""
+
+#: id:24014
+msgid "TV information"
+msgstr ""
+
+#: id:24015
+msgctxt "Auto context with id 24015"
+msgid "Music video information"
+msgstr ""
+
+#: id:24016
+msgctxt "Auto context with id 24016"
+msgid "Album information"
+msgstr ""
+
+#: id:24017
+msgctxt "Auto context with id 24017"
+msgid "Artist information"
+msgstr ""
+
+#: id:24018
+msgctxt "Auto context with id 24018"
+msgid "Services"
+msgstr ""
+
+#empty string with id 24019
+
+#: id:24020
+msgid "Configure"
+msgstr ""
+
+#: id:24021
+msgctxt "Auto context with id 24021"
+msgid "Disable"
+msgstr ""
+
+#: id:24022
+msgid "Enable"
+msgstr ""
+
+#: id:24023
+msgid "Add-on disabled"
+msgstr ""
+
+#empty strings from id 24024 to 24026
+
+#: id:24027
+msgctxt "Auto context with id 24027"
+msgid "Weather"
+msgstr ""
+
+#: id:24028
+msgid "Weather.com (standard)"
+msgstr ""
+
+#empty string with id 24029
+
+#: id:24030
+msgid "This Add-on can not be configured"
+msgstr ""
+
+#: id:24031
+msgid "Error loading settings"
+msgstr ""
+
+#: id:24032
+msgid "All Add-ons"
+msgstr ""
+
+#: id:24033
+msgid "Get Add-ons"
+msgstr ""
+
+#: id:24034
+msgid "Check for updates"
+msgstr ""
+
+#: id:24035
+msgid "Force refresh"
+msgstr ""
+
+#: id:24036
+msgid "Change log"
+msgstr ""
+
+#: id:24037
+msgid "Uninstall"
+msgstr ""
+
+#: id:24038
+msgid "Install"
+msgstr ""
+
+#: id:24039
+msgid "Disabled Add-ons"
+msgstr ""
+
+#: id:24040
+msgid "(Clear the current setting)"
+msgstr ""
+
+#: id:24041
+msgid "Install from zip file"
+msgstr ""
+
+#: id:24042
+msgid "Downloading %i%%"
+msgstr ""
+
+#: id:24043
+msgid "Available Updates"
+msgstr ""
+
+#: id:24044
+msgid "Dependencies not met"
+msgstr ""
+
+#: id:24045
+msgid "Add-on does not have the correct structure"
+msgstr ""
+
+#: id:24046
+msgid "%s is used by the following installed add-on(s)"
+msgstr ""
+
+#: id:24047
+msgid "This add-on cannot be uninstalled"
+msgstr ""
+
+#: id:24048
+msgid "Rollback"
+msgstr ""
+
+#empty string with id 24049
+
+#: id:24050
+msgid "Available Add-ons"
+msgstr ""
+
+#: id:24051
+msgid "Version:"
+msgstr ""
+
+#: id:24052
+msgid "Disclaimer"
+msgstr ""
+
+#: id:24053
+msgid "License:"
+msgstr ""
+
+#: id:24054
+msgid "Changelog"
+msgstr ""
+
+#empty strings from id 24055 to 24058
+
+#: id:24059
+msgid "Would you like to enable this Add-on?"
+msgstr ""
+
+#: id:24060
+msgid "Would you like to disable this Add-on?"
+msgstr ""
+
+#: id:24061
+msgid "Add-on update available!"
+msgstr ""
+
+#: id:24062
+msgid "Enabled Add-ons"
+msgstr ""
+
+#: id:24063
+msgid "Auto update"
+msgstr ""
+
+#: id:24064
+msgid "Add-on enabled"
+msgstr ""
+
+#: id:24065
+msgid "Add-on updated"
+msgstr ""
+
+#: id:24066
+msgid "Cancel Add-on download?"
+msgstr ""
+
+#: id:24067
+msgid "Currently downloading Add-ons"
+msgstr ""
+
+#: id:24068
+msgid "Update available"
+msgstr ""
+
+#: id:24069
+msgid "Update"
+msgstr ""
+
+#: id:24070
+msgid "Add-on could not be loaded."
+msgstr ""
+
+#: id:24071
+msgid "An unknown error has occurred."
+msgstr ""
+
+#: id:24072
+msgid "Settings required"
+msgstr ""
+
+#: id:24073
+msgid "Could not connect"
+msgstr ""
+
+#: id:24074
+msgid "Needs to restart"
+msgstr ""
+
+#: id:24075
+msgctxt "Auto context with id 24075"
+msgid "Disable"
+msgstr ""
+
+#: id:24076
+msgid "Add-on Required"
+msgstr ""
+
+#empty strings from id 24077 to 24079
+
+#: id:24080
+msgid "Try to reconnect?"
+msgstr ""
+
+#empty strings from id 24081 to 24088
+
+#: id:24089
+msgid "Add-on restarts"
+msgstr ""
+
+#: id:24090
+msgid "Lock Add-on manager"
+msgstr ""
+
+#empty strings from id 24091 to 24093
+
+#: id:24094
+msgid "(current)"
+msgstr ""
+
+#: id:24095
+msgid "(blacklisted)"
+msgstr ""
+
+#: id:24096
+msgid "Add-on has been marked as broken in repository."
+msgstr ""
+
+#: id:24097
+msgid "Would you like to disable it on your system?"
+msgstr ""
+
+#: id:24098
+msgid "Broken"
+msgstr ""
+
+#: id:24099
+msgid "Would you like to switch to this skin?"
+msgstr ""
+
+#: id:24100
+msgid "To use this feature you must download an Add-on:"
+msgstr ""
+
+#: id:24101
+msgid "Would you like to download this Add-on?"
+msgstr ""
+
+#empty strings from id 24102 to 24999
+
+#: id:25000
+msgid "Notifications"
+msgstr ""
+
+#strings 29800 thru 29998 reserved strings used only in the default Project Mayhem III skin and not c++ code
+#empty strings from id 25001 to 29799
+
+#: id:29800
+msgid "Library Mode"
+msgstr ""
+
+#: id:29801
+msgid "QWERTY keyboard"
+msgstr ""
+
+#: id:29802
+msgid "Passthrough Audio in use"
+msgstr ""
+
+#strings 30000 thru 30999 reserved for plugins and plugin settings
+#strings 31000 thru 31999 reserved for skins
+#strings 32000 thru 32999 reserved for scripts
+#strings 33000 thru 33999 reserved for common strings used in addons
+#empty strings from id 29803 to 33000
+
+#: id:33001
+msgid "Trailer quality"
+msgstr ""
+
+#: id:33002
+msgid "Stream"
+msgstr ""
+
+#: id:33003
+msgid "Download"
+msgstr ""
+
+#: id:33004
+msgid "Download & play"
+msgstr ""
+
+#: id:33005
+msgid "Download & save"
+msgstr ""
+
+#: id:33006
+msgid "Today"
+msgstr ""
+
+#: id:33007
+msgid "Tomorrow"
+msgstr ""
+
+#: id:33008
+msgid "Saving"
+msgstr ""
+
+#: id:33009
+msgid "Copying"
+msgstr ""
+
+#: id:33010
+msgid "Set download directory"
+msgstr ""
+
+#: id:33011
+msgid "Search duration"
+msgstr ""
+
+#: id:33012
+msgid "Short"
+msgstr ""
+
+#: id:33013
+msgid "Long"
+msgstr ""
+
+#: id:33014
+msgid "Use DVD player instead of regular player"
+msgstr ""
+
+#: id:33015
+msgid "Ask for download before playing video"
+msgstr ""
+
+#: id:33016
+msgid "Clips"
+msgstr ""
+
+#: id:33017
+msgid "Restart plugin to enable"
+msgstr ""
+
+#: id:33018
+msgid "Tonight"
+msgstr ""
+
+#: id:33019
+msgid "Tomorrow Night"
+msgstr ""
+
+#: id:33020
+msgid "Condition"
+msgstr ""
+
+#: id:33021
+msgid "Precipitation"
+msgstr ""
+
+#: id:33022
+msgid "Precip"
+msgstr ""
+
+#: id:33023
+msgid "Humid"
+msgstr ""
+
+#: id:33024
+msgid "Feels"
+msgstr ""
+
+#: id:33025
+msgid "Observed"
+msgstr ""
+
+#: id:33026
+msgid "Departure from normal"
+msgstr ""
+
+#: id:33027
+msgid "Sunrise"
+msgstr ""
+
+#: id:33028
+msgid "Sunset"
+msgstr ""
+
+#: id:33029
+msgid "Details"
+msgstr ""
+
+#: id:33030
+msgid "Outlook"
+msgstr ""
+
+#: id:33031
+msgid "Coverflow"
+msgstr ""
+
+#: id:33032
+msgid "Translate text"
+msgstr ""
+
+#: id:33033
+msgid "Map list %s category"
+msgstr ""
+
+#: id:33034
+msgid "36 Hour"
+msgstr ""
+
+#: id:33035
+msgid "Maps"
+msgstr ""
+
+#: id:33036
+msgid "Hourly"
+msgstr ""
+
+#: id:33037
+msgid "Weekend"
+msgstr ""
+
+#: id:33038
+msgid "%s day"
+msgstr ""
+
+#empty strings from id 33039 to 33048
+
+#: id:33049
+msgid "Alert"
+msgstr ""
+
+#: id:33050
+msgid "Alerts"
+msgstr ""
+
+#: id:33051
+msgid "Choose Your"
+msgstr ""
+
+#: id:33052
+msgid "Check"
+msgstr ""
+
+#: id:33053
+msgctxt "Auto context with id 33053"
+msgid "Configure the"
+msgstr ""
+
+#: id:33054
+msgid "Seasons"
+msgstr ""
+
+#: id:33055
+msgid "Use your"
+msgstr ""
+
+#: id:33056
+msgid "Watch your"
+msgstr ""
+
+#: id:33057
+msgid "Listen to"
+msgstr ""
+
+#: id:33058
+msgid "View your"
+msgstr ""
+
+#: id:33059
+msgctxt "Auto context with id 33059"
+msgid "Configure the"
+msgstr ""
+
+#: id:33060
+msgid "Power"
+msgstr ""
+
+#: id:33061
+msgid "Menu"
+msgstr ""
+
+#: id:33062
+msgid "Play the"
+msgstr ""
+
+#: id:33063
+msgid "Options"
+msgstr ""
+
+#empty string with id 33064
+
+#: id:33065
+msgid "Editor"
+msgstr ""
+
+#: id:33066
+msgid "About your"
+msgstr ""
+
+#: id:33067
+msgid "Star rating"
+msgstr ""
+
+#: id:33068
+msgid "Background"
+msgstr ""
+
+#: id:33069
+msgid "Backgrounds"
+msgstr ""
+
+#: id:33070
+msgid "Custom background"
+msgstr ""
+
+#: id:33071
+msgid "Custom backgrounds"
+msgstr ""
+
+#: id:33072
+msgid "View Readme"
+msgstr ""
+
+#: id:33073
+msgid "View Changelog"
+msgstr ""
+
+#: id:33074
+msgid "This version of %s requires an"
+msgstr ""
+
+#: id:33075
+msgid "XBMC revision of %s or greater to run."
+msgstr ""
+
+#: id:33076
+msgid "Please update XBMC."
+msgstr ""
+
+#: id:33077
+msgid "No data found!"
+msgstr ""
+
+#: id:33078
+msgid "Next page"
+msgstr ""
+
+#: id:33079
+msgid "Love"
+msgstr ""
+
+#: id:33080
+msgid "Hate"
+msgstr ""
+
+#: id:33081
+msgid "This file is stacked, select the part you want to play from."
+msgstr ""
+
+#: id:33082
+msgid "Path to script"
+msgstr ""
+
+#: id:33083
+msgid "Enable custom script button"
+msgstr ""
+
+#empty strings from id 33084 to 33099
+
+#: id:33100
+msgid "Failed to start"
+msgstr ""
+
+#: id:33101
+msgid "Webserver"
+msgstr ""
+
+#: id:33102
+msgid "Event Server"
+msgstr ""
+
+#: id:33103
+msgid "Remote communication server"
+msgstr ""
+
+#empty strings from id 33104 to 33199
+
+#: id:33200
+msgid "Detected New Connection"
+msgstr ""
+
+#translators: no need to add these to your language files
+#empty strings from id 33201 to 33999
+
+#: id:34000
+msgid "Lame"
+msgstr ""
+
+#: id:34001
+msgid "Vorbis"
+msgstr ""
+
+#: id:34002
+msgid "Wav"
+msgstr ""
+
+#: id:34003
+msgid "DXVA2"
+msgstr ""
+
+#: id:34004
+msgid "VAAPI"
+msgstr ""
+
+#: id:34005
+msgid "Flac"
+msgstr ""
+
+#empty strings from id 34006 to 34099
+
+#: id:34100
+msgid "Speaker Configuration"
+msgstr ""
+
+#: id:34101
+msgid "2.0"
+msgstr ""
+
+#: id:34102
+msgid "2.1"
+msgstr ""
+
+#: id:34103
+msgid "3.0"
+msgstr ""
+
+#: id:34104
+msgid "3.1"
+msgstr ""
+
+#: id:34105
+msgid "4.0"
+msgstr ""
+
+#: id:34106
+msgid "4.1"
+msgstr ""
+
+#: id:34107
+msgid "5.0"
+msgstr ""
+
+#: id:34108
+msgid "5.1"
+msgstr ""
+
+#: id:34109
+msgid "7.0"
+msgstr ""
+
+#: id:34110
+msgid "7.1"
+msgstr ""
+
+#34112-34200 reserved for future use
+#empty strings from id 34111 to 34200
+
+#: id:34201
+msgid "Can't find a next item to play"
+msgstr ""
+
+#: id:34202
+msgid "Can't find a previous item to play"
+msgstr ""
+
+#empty strings from id 34203 to 34299
+
+#: id:34300
+msgid "Failed to start zeroconf"
+msgstr ""
+
+#: id:34301
+msgid "Is Apple's Bonjour Service installed? See log for more info."
+msgstr ""
+
+#empty strings from id 34302 to 34399
+
+#: id:34400
+msgid "Video Rendering"
+msgstr ""
+
+#: id:34401
+msgid "Failed to init video filters/scalers, falling back to bilinear scaling"
+msgstr ""
+
+#: id:34402
+msgid "Failed to initialize audio device"
+msgstr ""
+
+#: id:34403
+msgid "Check your audiosettings"
+msgstr ""
+
+#description for the touchscreen when using the tvout feature on iDevices
+
+#: id:34404
+msgid "Use gestures for navigation:"
+msgstr ""
+
+#: id:34405
+msgid "1 finger swipe left,right,up,down for cursors"
+msgstr ""
+
+#: id:34406
+msgid "2 finger swipe left for backspace"
+msgstr ""
+
+#: id:34407
+msgid "1 finger single tap for enter"
+msgstr ""
+
+#: id:34408
+msgid "2 finger single tap for contextmenu"
+msgstr ""
+
+#empty strings from id 34409 to 34999
+
+#: id:35000
+msgid "Peripherals"
+msgstr ""
+
+#: id:35001
+msgid "Generic HID device"
+msgstr ""
+
+#: id:35002
+msgid "Generic network adapter"
+msgstr ""
+
+#: id:35003
+msgid "Generic disk"
+msgstr ""
+
+#: id:35004
+msgid "There are no settings available\nfor this peripheral."
+msgstr ""
+
+#: id:35005
+msgid "New device configured"
+msgstr ""
+
+#: id:35006
+msgid "Device removed"
+msgstr ""
+
+#: id:35007
+msgid "Keymap to use for this device"
+msgstr ""
+
+#: id:35008
+msgid "Keymap enabled"
+msgstr ""
+
+#: id:35009
+msgid "Do not use the custom keymap for this device"
+msgstr ""
+
+#empty strings from id 35010 to 35499
+
+#: id:35500
+msgid "Location"
+msgstr ""
+
+#: id:35501
+msgid "Class"
+msgstr ""
+
+#: id:35502
+msgctxt "Auto context with id 35502"
+msgid "Name"
+msgstr ""
+
+#: id:35503
+msgid "Vendor"
+msgstr ""
+
+#: id:35504
+msgid "Product ID"
+msgstr ""
+
+#empty strings from id 35505 to 35999
+
+#: id:36000
+msgid "Pulse-Eight CEC adapter"
+msgstr ""
+
+#: id:36001
+msgid "Pulse-Eight Nyxboard"
+msgstr ""
+
+#: id:36002
+msgid "Switch to keyboard side command"
+msgstr ""
+
+#: id:36003
+msgid "Switch to remote side command"
+msgstr ""
+
+#: id:36004
+msgid "Press \"user\" button command"
+msgstr ""
+
+#: id:36005
+msgid "Enable switch side commands"
+msgstr ""
+
+#: id:36006
+msgid "Could not open the adapter"
+msgstr ""
+
+#: id:36007
+msgid "Devices to power on when starting XBMC"
+msgstr ""
+
+#: id:36008
+msgid "Devices to power off when stopping XBMC"
+msgstr ""
+
+#: id:36009
+msgid "Put devices in standby mode when activating screensaver"
+msgstr ""
+
+#empty string with id 36010
+
+#: id:36011
+msgid "Could not detect the CEC port. Set it up manually."
+msgstr ""
+
+#: id:36012
+msgid "Could not initialise the CEC adapter. Check your settings."
+msgstr ""
+
+#: id:36013
+msgid "Unsupported libCEC interface version. %d is greater than the version XBMC supports (%d)"
+msgstr ""
+
+#: id:36014
+msgid "Put this PC in standby mode when the TV is switched off"
+msgstr ""
+
+#: id:36015
+msgid "HDMI port number"
+msgstr ""
+
+#: id:36016
+#. max. 13 characters
+msgctxt "Auto context with id 36016"
+msgid "Connected"
+msgstr ""
+
+#: id:36017
+msgid "Adapter found, but libCEC is not available"
+msgstr ""
+
+#: id:36018
+msgid "Use the TV's language setting"
+msgstr ""
+
+#: id:36019
+msgid "Connected to HDMI device"
+msgstr ""
+
+#: id:36020
+msgid "Make XBMC the active source when starting"
+msgstr ""
+
+#: id:36021
+msgid "Physical address (overrules HDMI port)"
+msgstr ""
+
+#: id:36022
+msgid "COM port (leave empty unless needed)"
+msgstr ""
+
+#: id:36023
+msgid "Configuration updated"
+msgstr ""
+
+#: id:36024
+msgid "Failed to set the new configuration. Please check your settings."
+msgstr ""
+
+#: id:36025
+msgid "Send 'inactive source' command when stopping XBMC"
+msgstr ""
+

--- a/language/Esperanto/strings.po
+++ b/language/Esperanto/strings.po
@@ -1,0 +1,9093 @@
+# Converted from xbmc strings.xml with xbmc-xml2po (by Team-XBMC)
+msgid ""
+msgstr ""
+"Project-Id-Version: xbmc.core-FRODO_GIT3ed1604ad7\n"
+"Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
+"POT-Creation-Date: 2012-04-09 18:00+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE\n"
+"Language: eo\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: id:0
+msgctxt "Auto context with id 0"
+msgid "Programs"
+msgstr "Mia Softvaroj"
+
+#: id:1
+msgctxt "Auto context with id 1"
+msgid "Pictures"
+msgstr "Mia Bildoj"
+
+#: id:2
+msgctxt "Auto context with id 2"
+msgid "Music"
+msgstr "Mia Mizuko"
+
+#: id:3
+msgctxt "Auto context with id 3"
+msgid "Videos"
+msgstr "Mia Filmoj"
+
+#: id:4
+msgid "TV-Guide"
+msgstr "Televido Gvido"
+
+#: id:5
+msgctxt "Auto context with id 5"
+msgid "Settings"
+msgstr "Preferoj"
+
+#: id:6
+msgid "XBMC SVN"
+msgstr ""
+
+#: id:7
+msgctxt "Auto context with id 7"
+msgid "File manager"
+msgstr "Mia Vicoj"
+
+#: id:8
+msgctxt "Auto context with id 8"
+msgid "Weather"
+msgstr "Veterprognozo"
+
+#: id:9
+msgid "xbmc media center"
+msgstr ""
+
+#: id:11
+msgid "Monday"
+msgstr "Lundo"
+
+#: id:12
+msgid "Tuesday"
+msgstr "Mardo"
+
+#: id:13
+msgid "Wednesday"
+msgstr "Merkredo"
+
+#: id:14
+msgid "Thursday"
+msgstr "Ĵaŭdo"
+
+#: id:15
+msgid "Friday"
+msgstr "Vendredo"
+
+#: id:16
+msgid "Saturday"
+msgstr "Sabato"
+
+#: id:17
+msgid "Sunday"
+msgstr "Dimanĉo"
+
+#: id:21
+msgid "January"
+msgstr "Januaro"
+
+#: id:22
+msgid "February"
+msgstr "Februaro"
+
+#: id:23
+msgid "March"
+msgstr "Marto"
+
+#: id:24
+msgid "April"
+msgstr "Aprilo"
+
+#: id:25
+msgctxt "Auto context with id 25"
+msgid "May"
+msgstr "Majo"
+
+#: id:26
+msgid "June"
+msgstr "Junio"
+
+#: id:27
+msgid "July"
+msgstr "Julio"
+
+#: id:28
+msgid "August"
+msgstr "Aŭgusto"
+
+#: id:29
+msgid "September"
+msgstr "Septembro"
+
+#: id:30
+msgid "October"
+msgstr "Oktobro"
+
+#: id:31
+msgid "November"
+msgstr "Novembro"
+
+#: id:32
+msgid "December"
+msgstr "Decembro"
+
+#: id:41
+msgid "Mon"
+msgstr ""
+
+#: id:42
+msgid "Tue"
+msgstr ""
+
+#: id:43
+msgid "Wed"
+msgstr ""
+
+#: id:44
+msgid "Thu"
+msgstr ""
+
+#: id:45
+msgid "Fri"
+msgstr ""
+
+#: id:46
+msgid "Sat"
+msgstr ""
+
+#: id:47
+msgctxt "Auto context with id 47"
+msgid "Sun"
+msgstr ""
+
+#: id:51
+msgid "Jan"
+msgstr ""
+
+#: id:52
+msgid "Feb"
+msgstr ""
+
+#: id:53
+msgid "Mar"
+msgstr ""
+
+#: id:54
+msgid "Apr"
+msgstr ""
+
+#: id:55
+msgctxt "Auto context with id 55"
+msgid "May"
+msgstr ""
+
+#: id:56
+msgid "Jun"
+msgstr ""
+
+#: id:57
+msgid "Jul"
+msgstr ""
+
+#: id:58
+msgid "Aug"
+msgstr ""
+
+#: id:59
+msgid "Sep"
+msgstr ""
+
+#: id:60
+msgid "Oct"
+msgstr ""
+
+#: id:61
+msgid "Nov"
+msgstr ""
+
+#: id:62
+msgid "Dec"
+msgstr ""
+
+#: id:71
+msgid "N"
+msgstr ""
+
+#: id:72
+msgid "NNE"
+msgstr ""
+
+#: id:73
+msgid "NE"
+msgstr ""
+
+#: id:74
+msgid "ENE"
+msgstr ""
+
+#: id:75
+msgid "E"
+msgstr ""
+
+#: id:76
+msgid "ESE"
+msgstr ""
+
+#: id:77
+msgid "SE"
+msgstr ""
+
+#: id:78
+msgid "SSE"
+msgstr ""
+
+#: id:79
+msgid "S"
+msgstr ""
+
+#: id:80
+msgid "SSW"
+msgstr ""
+
+#: id:81
+msgid "SW"
+msgstr ""
+
+#: id:82
+msgid "WSW"
+msgstr ""
+
+#: id:83
+msgid "W"
+msgstr ""
+
+#: id:84
+msgid "WNW"
+msgstr ""
+
+#: id:85
+msgid "NW"
+msgstr ""
+
+#: id:86
+msgid "NNW"
+msgstr ""
+
+#: id:87
+msgid "VAR"
+msgstr ""
+
+#: id:98
+msgid "View: Auto"
+msgstr "Vido: Auto"
+
+#: id:99
+msgid "View: Auto big"
+msgstr "Vido: Auto Big"
+
+#: id:100
+msgid "View: Icons"
+msgstr "Vido: Icons"
+
+#: id:101
+msgid "View: List"
+msgstr "Vido: List"
+
+#: id:102
+msgctxt "Auto context with id 102"
+msgid "Scan"
+msgstr "Skani"
+
+#: id:103
+msgctxt "Auto context with id 103"
+msgid "Sort by: Name"
+msgstr "ordigi je: Nomo"
+
+#: id:104
+msgid "Sort by: Date"
+msgstr "ordigi je: Dati"
+
+#: id:105
+msgid "Sort by: Size"
+msgstr "ordigi je: amplekso"
+
+#: id:106
+msgid "No"
+msgstr "Ne"
+
+#: id:107
+msgid "Yes"
+msgstr "Jes"
+
+#: id:108
+msgctxt "Auto context with id 108"
+msgid "Slideshow"
+msgstr "SlideShow"
+
+#: id:109
+msgid "Create thumbs"
+msgstr "Verki Thumbs"
+
+#: id:110
+msgid "Create thumbnails"
+msgstr "Verki Thumbnails"
+
+#: id:111
+msgctxt "Auto context with id 111"
+msgid "Shortcuts"
+msgstr "Shortcuts"
+
+#: id:112
+msgid "Paused"
+msgstr "Paŭzis"
+
+#: id:113
+msgid "Update failed"
+msgstr "Mia vicos : Fonto"
+
+#: id:114
+msgid "Installation failed"
+msgstr "Mia vicos : Destination"
+
+#: id:115
+msgid "Copy"
+msgstr "Kopii"
+
+#: id:116
+msgid "Move"
+msgstr "Movi"
+
+#: id:117
+msgid "Delete"
+msgstr "Forviŝi"
+
+#: id:118
+msgid "Rename"
+msgstr "Rebapti"
+
+#: id:119
+msgid "New folder"
+msgstr "Nova Dosiero"
+
+#: id:120
+msgid "Confirm file copy"
+msgstr "Confirm vico kopii"
+
+#: id:121
+msgid "Confirm file move"
+msgstr "Confirm vico movi"
+
+#: id:122
+msgid "Confirm file delete?"
+msgstr "Confirm vico forviŝi"
+
+#: id:123
+msgid "Copy these files?"
+msgstr "Kopii lase vicos?"
+
+#: id:124
+msgid "Move these files?"
+msgstr "Movi lase vicos?"
+
+#: id:125
+msgid "Delete these files? - Deleting files cannot be undone!"
+msgstr "Forviŝi lase vicos?"
+
+#: id:126
+msgid "Status"
+msgstr "Kondiĉo"
+
+#: id:127
+msgid "Objects"
+msgstr "Objects"
+
+#: id:128
+msgctxt "Auto context with id 128"
+msgid "General"
+msgstr "Generalo"
+
+#: id:129
+msgctxt "Auto context with id 129"
+msgid "Slideshow"
+msgstr "Slideshow"
+
+#: id:130
+msgctxt "Auto context with id 130"
+msgid "System info"
+msgstr "Sistemo Informaĵo"
+
+#: id:131
+msgid "Display"
+msgstr "Ekrano"
+
+#: id:132
+msgid "Albums"
+msgstr "Albumos"
+
+#: id:133
+msgid "Artists"
+msgstr "Muzikisto"
+
+#: id:134
+msgid "Songs"
+msgstr "Kantoj"
+
+#: id:135
+msgid "Genres"
+msgstr "Gxenroj"
+
+#: id:136
+msgid "Playlists"
+msgstr "Kantoj-listo"
+
+#: id:137
+msgid "Search"
+msgstr "Traserĉi"
+
+#: id:138
+msgid "System Information"
+msgstr "SISTEMO informaĵo"
+
+#: id:139
+msgid "Temperatures:"
+msgstr "Temperaturoj:"
+
+#: id:140
+msgid "CPU:"
+msgstr "CPU:"
+
+#: id:141
+msgid "GPU:"
+msgstr "GPU:"
+
+#: id:142
+msgid "Time:"
+msgstr "Tempo:"
+
+#: id:143
+msgid "Current:"
+msgstr "Current:"
+
+#: id:144
+msgid "Build:"
+msgstr "Eldono:"
+
+#: id:145
+msgid "Network:"
+msgstr "Reto:"
+
+#: id:146
+msgid "Type:"
+msgstr "Type:"
+
+#: id:147
+msgid "Static"
+msgstr "Static"
+
+#: id:148
+msgid "DHCP"
+msgstr "DHCP"
+
+#: id:149
+msgid "MAC address"
+msgstr "MAC"
+
+#: id:150
+msgctxt "Auto context with id 150"
+msgid "IP address"
+msgstr "IP"
+
+#: id:151
+msgid "Link:"
+msgstr "Link:"
+
+#: id:152
+msgid "Half duplex"
+msgstr "Half duplex"
+
+#: id:153
+msgid "Full duplex"
+msgstr "Full duplex"
+
+#: id:154
+msgctxt "Auto context with id 154"
+msgid "Storage"
+msgstr "Diskmemoro"
+
+#: id:155
+msgid "Drive"
+msgstr "Ingo"
+
+#: id:156
+msgctxt "Auto context with id 156"
+msgid "Free"
+msgstr "Havebla"
+
+#: id:157
+msgctxt "Auto context with id 157"
+msgid "Video"
+msgstr "Filmoj"
+
+#: id:158
+msgid "Free memory"
+msgstr "Havebla labormemoro"
+
+#: id:159
+msgid "No link"
+msgstr "No link"
+
+#: id:160
+msgctxt "Auto context with id 160"
+msgid "Free"
+msgstr "Havebla"
+
+#: id:161
+msgid "Unavailable"
+msgstr "Malhavebla"
+
+#: id:162
+msgid "Tray open"
+msgstr "KD-ingo malfermi"
+
+#: id:163
+msgid "Reading"
+msgstr "Sxakis KD"
+
+#: id:164
+msgid "No disc"
+msgstr "Ne KD"
+
+#: id:165
+msgid "Disc present"
+msgstr "KD Present"
+
+#: id:166
+msgid "Skin"
+msgstr "Skin"
+
+#: id:169
+msgctxt "Auto context with id 169"
+msgid "Resolution"
+msgstr "Distingivo"
+
+#: id:170
+msgid "Adjust display refresh rate to match video"
+msgstr "Albumo:"
+
+#: id:172
+msgid "Release date"
+msgstr "Dati of Ellasi:"
+
+#: id:173
+msgid "Display 4:3 videos as"
+msgstr "Rating:"
+
+#: id:175
+msgid "Moods"
+msgstr "Tones:"
+
+#: id:176
+msgid "Styles"
+msgstr "Styles:"
+
+#: id:179
+msgid "Song"
+msgstr "Kanto"
+
+#: id:180
+msgid "Duration"
+msgstr "Tempo grando"
+
+#: id:181
+msgid "Select album"
+msgstr "Elekti albumo"
+
+#: id:182
+msgid "Tracks"
+msgstr "Tracks"
+
+#: id:183
+msgid "Review"
+msgstr "ReVido"
+
+#: id:184
+msgid "Refresh"
+msgstr "Refresh"
+
+#: id:185
+msgid "Searching album"
+msgstr "Searching albumo"
+
+#: id:186
+msgid "OK"
+msgstr "OK"
+
+#: id:187
+msgid "No albums found!"
+msgstr "No albumos found!"
+
+#: id:188
+msgid "Select all"
+msgstr "Elekti cxio"
+
+#: id:189
+msgid "Scanning media info"
+msgstr "Scanning media info"
+
+#: id:190
+msgid "Save"
+msgstr "Save"
+
+#: id:191
+msgid "Shuffle"
+msgstr "Shuffle"
+
+#: id:192
+msgctxt "Auto context with id 192"
+msgid "Clear"
+msgstr "Clear"
+
+#: id:193
+msgctxt "Auto context with id 193"
+msgid "Scan"
+msgstr "Scan"
+
+#: id:194
+msgid "Searching..."
+msgstr "Trasercxis..."
+
+#: id:195
+msgid "No info found!"
+msgstr "No IMDB info found!"
+
+#: id:196
+msgid "Select movie:"
+msgstr "Elekti movie:"
+
+#: id:197
+msgid "Querying %s info"
+msgstr "Querying IMDB info"
+
+#: id:198
+msgid "Loading movie details"
+msgstr "Loading Filmo details"
+
+#: id:199
+msgid "Web interface"
+msgstr "Filmo-artisto:"
+
+#: id:202
+msgid "Tagline"
+msgstr "Tagline:"
+
+#: id:203
+msgid "Plot outline"
+msgstr "Malgranda-komploti:"
+
+#: id:205
+msgid "Votes"
+msgstr "Voxcoj"
+
+#: id:206
+msgid "Cast"
+msgstr "Aktoroj"
+
+#: id:207
+msgid "Plot"
+msgstr "Komploti"
+
+#: id:208
+msgctxt "Auto context with id 208"
+msgid "Play"
+msgstr "Iniciati"
+
+#: id:209
+msgid "Next"
+msgstr "Sekvonta"
+
+#: id:210
+msgid "Previous"
+msgstr "Antaŭa"
+
+#: id:213
+msgid "Calibrate user interface..."
+msgstr "Calibrate uzulinterfaco..."
+
+#: id:214
+msgid "Video calibration..."
+msgstr "Filmoj Calibration..."
+
+#: id:215
+msgid "Soften"
+msgstr "Mildigi"
+
+#: id:216
+msgid "Zoom amount"
+msgstr "Zoom Amount"
+
+#: id:217
+msgid "Pixel ratio"
+msgstr "Pixel Ratio"
+
+#: id:218
+msgid "DVD drive"
+msgstr "KD-ingo"
+
+#: id:219
+msgid "Please insert disc"
+msgstr "Plaĉi insert KD"
+
+#: id:220
+msgid "Remote share"
+msgstr "Remote Share"
+
+#: id:221
+msgid "Network is not connected"
+msgstr "Network is not connected"
+
+#: id:222
+msgid "Cancel"
+msgstr "Renonci"
+
+#: id:224
+msgid "Speed"
+msgstr "Rapideco"
+
+#: id:225
+msgid "Vertical Shift"
+msgstr "Transition Time"
+
+#: id:226
+msgid "Test patterns..."
+msgstr "Enable PAL60"
+
+#: id:227
+msgid "Lookup audio CD track names from freedb.org"
+msgstr "Enable CDDB"
+
+#: id:228
+msgid "Shuffle playlist on load"
+msgstr "Shuffle Playlist on Load"
+
+#: id:229
+msgid "HDD spindown time"
+msgstr "HD Spindown Time"
+
+#: id:230
+msgid "Video filters"
+msgstr "Filmoj Filters"
+
+#: id:231
+msgctxt "Auto context with id 231"
+msgid "None"
+msgstr "Neniu"
+
+#: id:232
+msgid "Point"
+msgstr "Point"
+
+#: id:233
+msgid "Linear"
+msgstr "Rekta"
+
+#: id:234
+msgid "Anisotropic"
+msgstr "Anisotropic"
+
+#: id:235
+msgid "Quincunx"
+msgstr "Quincunx"
+
+#: id:236
+msgid "Gaussian cubic"
+msgstr "Gaussian Cubic"
+
+#: id:237
+msgid "Minification"
+msgstr "Minification"
+
+#: id:238
+msgid "Magnification"
+msgstr "Magnification"
+
+#: id:239
+msgid "Clear playlist on finish"
+msgstr "Clear playlist on finish"
+
+#: id:240
+msgid "Display Mode"
+msgstr "Autorun DVD-Filmoj"
+
+#: id:241
+msgid "Full Screen #%d"
+msgstr "Autorun VCD/SVCD"
+
+#: id:242
+msgid "Windowed"
+msgstr "Autorun Audio-CD"
+
+#: id:243
+msgid "Refresh Rate"
+msgstr "Autorun XBOX Games"
+
+#: id:244
+msgid "Full screen"
+msgstr "Autorun Filmoj"
+
+#: id:245
+msgid "Sizing: (%i,%i)->(%i,%i) (Zoom x%2.2f) AR:%2.2f:1 (Pixels: %2.2f:1) (VShift: %2.2f)"
+msgstr "Autorun Muziko"
+
+#: id:247
+msgctxt "Auto context with id 247"
+msgid "Scripts"
+msgstr "Scripts"
+
+#: id:248
+msgctxt "Auto context with id 248"
+msgid "Language"
+msgstr "Lingvo"
+
+#: id:249
+msgctxt "Auto context with id 249"
+msgid "Music"
+msgstr "Muziko"
+
+#: id:250
+msgctxt "Auto context with id 250"
+msgid "Visualization"
+msgstr "Visualisation"
+
+#: id:251
+msgid "Select destination directory"
+msgstr "Elekti destination directory"
+
+#: id:252
+msgid "Output stereo to all speakers"
+msgstr "Output Stereo to ĉiom Speakers"
+
+#: id:253
+msgid "Number of channels"
+msgstr "Number of channels"
+
+#: id:254
+msgid "- DTS capable receiver"
+msgstr "- DTS Capable Receiver"
+
+#: id:255
+msgid "CDDB"
+msgstr "CDDB"
+
+#: id:256
+msgid "Fetching CD information"
+msgstr "Querying freedb for CDDB info"
+
+#: id:257
+msgid "Error"
+msgstr "Eraro"
+
+#: id:258
+msgid "Enable tag reading"
+msgstr "Enable ID3 Tags"
+
+#: id:259
+msgid "Opening"
+msgstr "Opening"
+
+#: id:260
+msgid "Shoutcast"
+msgstr "Shoutcast"
+
+#: id:261
+msgid "Waiting for start..."
+msgstr "Waiting for start...."
+
+#: id:262
+msgid "Scripts output"
+msgstr "Scripts Output"
+
+#: id:263
+msgid "Allow control of XBMC via HTTP"
+msgstr "Enable Web Server"
+
+#: id:264
+msgid "Record"
+msgstr "Registri"
+
+#: id:265
+msgid "Stop Rec."
+msgstr "Registri Rec."
+
+#: id:266
+msgid "Sort by: Track"
+msgstr "ordigi je: Track"
+
+#: id:267
+msgid "Sort by: Time"
+msgstr "ordigi je: Time"
+
+#: id:268
+msgid "Sort by: Title"
+msgstr "ordigi je: Title"
+
+#: id:269
+msgid "Sort by: Artist"
+msgstr "ordigi je: Artist"
+
+#: id:270
+msgid "Sort by: Album"
+msgstr "ordigi je: Albumo"
+
+#: id:271
+msgid "Top 100"
+msgstr "Top 100"
+
+#: id:272
+msgid "Top-Left overscan compensation"
+msgstr "Top Left Overscan Compensation"
+
+#: id:273
+msgid "Bottom-Right overscan compensation"
+msgstr "Bottom Right Overscan Compensation"
+
+#: id:274
+msgid "Subtitle positioning"
+msgstr "Subtitles Position"
+
+#: id:275
+msgid "Pixel ratio adjustment"
+msgstr "Pixel Ratio Adjustment"
+
+#: id:276
+msgid "Adjust the arrow to change the amount of overscan"
+msgstr "Movi la arrow to change la amount of overscan"
+
+#: id:277
+msgid "Adjust the bar to change the subtitles position"
+msgstr "Movi la bar to change la subtitles position"
+
+#: id:278
+msgid "Adjust the rectangle so it is perfectly square"
+msgstr "Change la rectangle so that it is perfectly square"
+
+#: id:279
+msgid "Unable to load settings"
+msgstr "Unable to load Preferoj"
+
+#: id:280
+msgid "Using default settings"
+msgstr "Using default fĉiombacks"
+
+#: id:281
+msgid "Please check the XML files"
+msgstr "Plaĉi check la .xml vicos"
+
+#: id:282
+msgid "Found %i items"
+msgstr "found %i items"
+
+#: id:283
+msgid "Search results"
+msgstr "Search Results"
+
+#: id:284
+msgid "No results found"
+msgstr "No results found"
+
+#: id:287
+msgctxt "Auto context with id 287"
+msgid "Subtitles"
+msgstr "Subtitles"
+
+#: id:288
+msgctxt "Auto context with id 288"
+msgid "Font"
+msgstr "Tiparo"
+
+#: id:289
+msgctxt "Auto context with id 289"
+msgid "- Size"
+msgstr "- amplekso"
+
+#: id:290
+msgid "Dynamic range compression"
+msgstr "Dynamic Range Compression"
+
+#: id:291
+msgctxt "Auto context with id 291"
+msgid "Video"
+msgstr "Filmoj"
+
+#: id:292
+msgctxt "Auto context with id 292"
+msgid "Audio"
+msgstr "Soni"
+
+#: id:293
+msgid "Browse for subtitles"
+msgstr "Subtitles"
+
+#: id:294
+msgid "Create bookmark"
+msgstr "Verki bookmark"
+
+#: id:296
+msgid "Clear bookmarks"
+msgstr "Clear bookmarks"
+
+#: id:297
+msgid "Audio offset"
+msgstr "Soni malfruiĝo"
+
+#: id:298
+msgid "Bookmarks"
+msgstr "Slider"
+
+#: id:299
+msgid "- AAC capable receiver"
+msgstr ""
+
+#: id:300
+msgid "- MP1 capable receiver"
+msgstr "1. Lingvo"
+
+#: id:301
+msgid "- MP2 capable receiver"
+msgstr "2. Soni-granda"
+
+#: id:302
+msgid "- MP3 capable receiver"
+msgstr "3. Stream"
+
+#: id:303
+msgid "Delay"
+msgstr "malfruiĝo"
+
+#: id:304
+msgctxt "Auto context with id 304"
+msgid "Language"
+msgstr "Language"
+
+#: id:305
+msgctxt "Auto context with id 305"
+msgid "Enabled"
+msgstr "Enabled"
+
+#: id:306
+msgid "Non-interleaved"
+msgstr "Non-Interleaved"
+
+#: id:312
+msgid "(0=auto)"
+msgstr "(0=auto)"
+
+#: id:313
+msgid "Cleaning database"
+msgstr "Cleaning datinbanko"
+
+#: id:314
+msgid "Preparing..."
+msgstr "Preparing..."
+
+#: id:315
+msgid "Database error"
+msgstr "Datinbanko eraro"
+
+#: id:316
+msgid "Searching songs..."
+msgstr "Searching kantoj..."
+
+#: id:317
+msgid "Cleaned database successfully"
+msgstr "Cleaning datinbanko successful"
+
+#: id:318
+msgid "Cleaning songs..."
+msgstr "Cleaning kantoj..."
+
+#: id:319
+msgid "Error cleaning songs"
+msgstr "Eraro cleaning kantoj"
+
+#: id:320
+msgid "Cleaning artists..."
+msgstr "Cleaning artists..."
+
+#: id:321
+msgid "Error cleaning artists"
+msgstr "Eraro cleaning artists"
+
+#: id:322
+msgid "Cleaning genres..."
+msgstr "Cleaning Gxenroj..."
+
+#: id:323
+msgid "Error cleaning genres"
+msgstr "Eraro cleaning Gxenroj"
+
+#: id:324
+msgid "Cleaning paths..."
+msgstr "Cleaning paths..."
+
+#: id:325
+msgid "Error cleaning paths"
+msgstr "Eraro cleaning paths"
+
+#: id:326
+msgid "Cleaning albums..."
+msgstr "Cleaning albumos..."
+
+#: id:327
+msgid "Error cleaning albums"
+msgstr "Eraro cleaning albumos"
+
+#: id:328
+msgid "Writing changes..."
+msgstr "Writing changes..."
+
+#: id:329
+msgid "Error writing changes"
+msgstr "Eraro writing changes"
+
+#: id:330
+msgid "This may take some time..."
+msgstr "This may take some time..."
+
+#: id:331
+msgid "Compressing database..."
+msgstr "Compressing datinbanko..."
+
+#: id:332
+msgid "Error compressing database"
+msgstr "Eraro compressing datinbanko"
+
+#: id:333
+msgid "Do you want to clean the library?"
+msgstr "Do you want to clean la muziko library?"
+
+#: id:334
+msgid "Clean library..."
+msgstr "Clean Muziko Library..."
+
+#: id:335
+msgid "Start"
+msgstr "Iniciati"
+
+#: id:336
+msgid "Framerate conversion"
+msgstr "Framerate Conversion"
+
+#: id:337
+msgctxt "Auto context with id 337"
+msgid "Audio output"
+msgstr "Audio Output"
+
+#: id:338
+msgid "Analog"
+msgstr "Analog"
+
+#: id:339
+msgid "Optical/Coax"
+msgstr "Diĝita"
+
+#: id:340
+msgid "Various artists"
+msgstr "Various Artists"
+
+#: id:341
+msgid "Play disc"
+msgstr "Play Disc"
+
+#: id:342
+msgctxt "Auto context with id 342"
+msgid "Movies"
+msgstr "Filmoj"
+
+#: id:343
+msgid "Adjust framerate"
+msgstr "Adjust Framerate"
+
+#: id:344
+msgid "Actors"
+msgstr "Aktoro"
+
+#: id:345
+msgctxt "Auto context with id 345"
+msgid "Year"
+msgstr "Jaro"
+
+#: id:346
+msgid "Boost volume level on downmix"
+msgstr "Stack"
+
+#: id:350
+msgctxt "Auto context with id 350"
+msgid "Programs"
+msgstr "Softvaro"
+
+#: id:351
+msgctxt "Auto context with id 351"
+msgid "Off"
+msgstr "Off"
+
+#: id:352
+msgid "Dim"
+msgstr "Dim"
+
+#: id:353
+msgid "Black"
+msgstr "Black"
+
+#: id:354
+msgid "Matrix trails"
+msgstr "Matrix Trails"
+
+#: id:355
+msgid "Screensaver time"
+msgstr "ekranosaver Idle Timeout"
+
+#: id:356
+msgid "Screensaver mode"
+msgstr "ekranosaver Mode"
+
+#: id:357
+msgid "Shutdown function timer"
+msgstr "Shutdown Idle Timeout"
+
+#: id:358
+msgid "All albums"
+msgstr "ĉiom albumos"
+
+#: id:359
+msgid "Recently added albums"
+msgstr "Recently Added Albumos"
+
+#: id:360
+msgctxt "Auto context with id 360"
+msgid "Screensaver"
+msgstr "ekranosaver"
+
+#: id:361
+msgid "R. Slideshow"
+msgstr "R. SlideShow"
+
+#: id:362
+msgid "Screensaver dim level"
+msgstr "ekranosaver Fade Level"
+
+#: id:363
+msgid "Sort by: File"
+msgstr "ordigi je: vico"
+
+#: id:364
+msgid "- Dolby Digital (AC3) capable receiver"
+msgstr "- AC3 Capable Receiver"
+
+#: id:365
+msgctxt "Auto context with id 365"
+msgid "Sort by: Name"
+msgstr "ordigi je: Nomo"
+
+#: id:366
+msgid "Sort by: Year"
+msgstr "ordigi je: Year"
+
+#: id:367
+msgid "Sort by: Rating"
+msgstr "ordigi je: Rating"
+
+#: id:368
+msgid "IMDb"
+msgstr "IMDB"
+
+#: id:369
+msgctxt "Auto context with id 369"
+msgid "Title"
+msgstr "Nomo"
+
+#: id:370
+msgid "Thunderstorms"
+msgstr "Fulmotondro"
+
+#: id:371
+msgid "Partly"
+msgstr "Parte"
+
+#: id:372
+msgid "Mostly"
+msgstr "Plejparte"
+
+#: id:373
+msgid "Sunny"
+msgstr "Suna"
+
+#: id:374
+msgid "Cloudy"
+msgstr "Nuba-cxielo"
+
+#: id:375
+msgid "Snow"
+msgstr "Negxi negxi cxie"
+
+#: id:376
+msgid "Rain"
+msgstr "Pluvo"
+
+#: id:377
+msgid "Light"
+msgstr "KROTALOJ"
+
+#: id:378
+msgid "AM"
+msgstr "AM"
+
+#: id:379
+msgid "PM"
+msgstr "PM"
+
+#: id:380
+msgid "Showers"
+msgstr "Showers"
+
+#: id:381
+msgid "Few"
+msgstr "Few"
+
+#: id:382
+msgid "Scattered"
+msgstr "Scattered"
+
+#: id:383
+msgctxt "Auto context with id 383"
+msgid "Wind"
+msgstr "Vovento"
+
+#: id:384
+msgid "Strong"
+msgstr "Intensa"
+
+#: id:385
+msgid "Fair"
+msgstr "Fair"
+
+#: id:386
+msgctxt "Auto context with id 386"
+msgid "Clear"
+msgstr "Clear"
+
+#: id:387
+msgid "Clouds"
+msgstr "Clouds"
+
+#: id:388
+msgid "Early"
+msgstr "Frua"
+
+#: id:389
+msgid "Shower"
+msgstr "Shower"
+
+#: id:390
+msgid "Flurries"
+msgstr "Flurries"
+
+#: id:391
+msgctxt "Auto context with id 391"
+msgid "Low"
+msgstr "Malnobla"
+
+#: id:392
+msgctxt "Auto context with id 392"
+msgid "Medium"
+msgstr "Mezgrada"
+
+#: id:393
+msgctxt "Auto context with id 393"
+msgid "High"
+msgstr "Nobla"
+
+#: id:394
+msgid "Fog"
+msgstr "Nebulo"
+
+#: id:395
+msgid "Haze"
+msgstr "Haze"
+
+#: id:396
+msgid "Select location"
+msgstr "Elekti Location"
+
+#: id:397
+msgid "Refresh time"
+msgstr "Refresh Time"
+
+#: id:398
+msgid "Temperature units"
+msgstr "Temperature Units"
+
+#: id:399
+msgid "Speed units"
+msgstr "Tempo Units"
+
+#: id:400
+msgctxt "Auto context with id 400"
+msgid "Weather"
+msgstr "Wealar"
+
+#: id:401
+msgid "Temp"
+msgstr "Temp"
+
+#: id:402
+msgid "Feels like"
+msgstr "Feels Like"
+
+#: id:403
+msgid "UV index"
+msgstr "UV Index"
+
+#: id:404
+msgctxt "Auto context with id 404"
+msgid "Wind"
+msgstr "Wind"
+
+#: id:405
+msgid "Dew point"
+msgstr "Dew Point"
+
+#: id:406
+msgid "Humidity"
+msgstr "Humideco"
+
+#: id:409
+msgid "Defaults"
+msgstr ""
+
+#: id:410
+msgid "Accessing weather service"
+msgstr "Accessing Wealar.com"
+
+#: id:411
+msgid "Getting weather for:"
+msgstr "Getting Wealar For:"
+
+#: id:412
+msgid "Unable to get weather data"
+msgstr "Unable to get wealar data"
+
+#: id:413
+msgid "Manual"
+msgstr "Manual"
+
+#: id:414
+msgid "No review for this album"
+msgstr "Ne review for this albumo"
+
+#: id:415
+msgid "Downloading thumbnail..."
+msgstr "Downloading thumbnail..."
+
+#: id:416
+msgid "Not available"
+msgstr "Not available"
+
+#: id:417
+msgid "View: Big icons"
+msgstr "Vido: Big Icons"
+
+#: id:418
+msgctxt "Auto context with id 418"
+msgid "Low"
+msgstr "Mia Filmoj/Gxenroj"
+
+#: id:419
+msgctxt "Auto context with id 419"
+msgid "High"
+msgstr "Mia Filmoj/Aktoroj"
+
+#: id:420
+msgid "HDMI"
+msgstr "Mia Filmoj/Jaroj"
+
+#: id:422
+msgid "Delete album info"
+msgstr "Forviŝi Albumoinfo"
+
+#: id:423
+msgid "Delete CD information"
+msgstr "Forviŝi CDDB Info"
+
+#: id:424
+msgid "Select"
+msgstr "Elekti"
+
+#: id:425
+msgid "No album information found"
+msgstr "No albumoinfo found."
+
+#: id:426
+msgid "No CD information found"
+msgstr "No CDDB info found."
+
+#: id:427
+msgid "Disc"
+msgstr "KD-ingo:"
+
+#: id:428
+msgid "Insert correct CD/DVD"
+msgstr "Insert correct KD-ingo"
+
+#: id:429
+msgid "Please insert the following disc:"
+msgstr "Plaĉi insert la following KD"
+
+#: id:430
+msgid "Sort by: DVD#"
+msgstr "ordigi je: KD#"
+
+#: id:431
+msgid "No cache"
+msgstr "No Cache"
+
+#: id:432
+msgid "Remove movie from library"
+msgstr "Forviŝi movie from datinbanko"
+
+#: id:433
+msgid "Really remove '%s'?"
+msgstr "Are vi sure about removing"
+
+#: id:434
+msgid "From %s at %i %s"
+msgstr "la filmo?"
+
+#: id:437
+msgid "Removable disk"
+msgstr "Tempo-amplekso:"
+
+#: id:438
+msgid "Opening file"
+msgstr "Opening vico"
+
+#: id:439
+msgid "Cache"
+msgstr "Cache"
+
+#: id:440
+msgid "Harddisk"
+msgstr "Durdisko"
+
+#: id:441
+msgid "UDF"
+msgstr "UDF"
+
+#: id:442
+msgid "Local network"
+msgstr "LAN"
+
+#: id:443
+msgid "Internet"
+msgstr "Interreto"
+
+#: id:444
+msgctxt "Auto context with id 444"
+msgid "Video"
+msgstr "Filmo"
+
+#: id:445
+msgctxt "Auto context with id 445"
+msgid "Audio"
+msgstr "Soni"
+
+#: id:446
+msgctxt "Auto context with id 446"
+msgid "DVD"
+msgstr "KD"
+
+#: id:447
+msgid "Autorun media"
+msgstr "Autorun"
+
+#: id:448
+msgid "LCD"
+msgstr "LCD"
+
+#: id:449
+msgctxt "Auto context with id 449"
+msgid "Enabled"
+msgstr "Enabled"
+
+#: id:450
+msgid "Columns"
+msgstr "Columns"
+
+#: id:451
+msgid "Row 1 address"
+msgstr "Row 1 Address"
+
+#: id:452
+msgid "Row 2 address"
+msgstr "Row 2 Address"
+
+#: id:453
+msgid "Row 3 address"
+msgstr "Row 3 Address"
+
+#: id:454
+msgid "Row 4 address"
+msgstr "Row 4 Address"
+
+#: id:455
+msgid "Rows"
+msgstr "Rows"
+
+#: id:456
+msgid "Mode"
+msgstr "Mode"
+
+#: id:457
+msgid "Switch view"
+msgstr "Switch Vido"
+
+#: id:459
+msgid "Subs"
+msgstr "Subs"
+
+#: id:460
+msgid "Audio stream"
+msgstr "Soni Stream"
+
+#: id:461
+msgid "[active]"
+msgstr "[active]"
+
+#: id:462
+msgid "Subtitle"
+msgstr "Subtitle"
+
+#: id:463
+msgid "Backlight"
+msgstr "Backlight"
+
+#: id:464
+msgid "Brightness"
+msgstr "Brightness"
+
+#: id:465
+msgid "Contrast"
+msgstr "Contrast"
+
+#: id:466
+msgid "Gamma"
+msgstr "Gamma"
+
+#: id:467
+msgctxt "Auto context with id 467"
+msgid "Type"
+msgstr "Type"
+
+#: id:468
+msgid "Move the bar to change the OSD position"
+msgstr "Movi la bar to change la osd position"
+
+#: id:469
+msgid "OSD position"
+msgstr "OSD Position"
+
+#: id:470
+msgid "Credits"
+msgstr "CrEditiis"
+
+#: id:471
+msgid "Modchip"
+msgstr "Modchip"
+
+#: id:474
+msgctxt "Auto context with id 474"
+msgid "Off"
+msgstr "Off"
+
+#: id:475
+msgid "Music only"
+msgstr "Muziko Only"
+
+#: id:476
+msgctxt "Auto context with id 476"
+msgid "Music & video"
+msgstr "Muziko & Filmoj"
+
+#: id:477
+msgid "Unable to load playlist"
+msgstr "Unable to load playlist"
+
+#: id:478
+msgid "OSD"
+msgstr "OSD"
+
+#: id:479
+msgid "Skin & language"
+msgstr "Skin and Language"
+
+#: id:480
+msgid "Appearance"
+msgstr "Appearance"
+
+#: id:481
+msgid "Audio options"
+msgstr "Audio Options"
+
+#: id:482
+msgid "About XBMC"
+msgstr "About XBMC"
+
+#: id:485
+msgid "Delete album"
+msgstr "Forviŝi albumo"
+
+#: id:486
+msgid "Repeat"
+msgstr "Repeat"
+
+#: id:487
+msgid "Repeat one"
+msgstr "Repeat One"
+
+#: id:488
+msgid "Repeat folder"
+msgstr "Repeat Folders"
+
+#: id:489
+msgid "Play the next song automatically"
+msgstr "Auto Play Next Item"
+
+#: id:491
+msgid "- Use big icons"
+msgstr "- Use big icons"
+
+#: id:492
+msgid "Resize VobSubs"
+msgstr "Reamplekso Vobsubs"
+
+#: id:493
+msgid "Advanced options (Experts Only!)"
+msgstr "Advanced Options (Experts Only!)"
+
+#: id:494
+msgid "Overall audio headroom"
+msgstr "Overĉiom Audio Headroom"
+
+#: id:495
+msgid "Upsample videos to GUI resolution"
+msgstr "Upsample Filmoj to GUI Resolution"
+
+#: id:496
+msgid "Calibration"
+msgstr "Calibration"
+
+#: id:497
+msgid "Show file extensions"
+msgstr "Hide Media Extensions"
+
+#: id:498
+msgid "Sort by: Type"
+msgstr "ordigi je: Type"
+
+#: id:499
+msgid "Unable to connect to online lookup service"
+msgstr "Unable to connect to www.ĉiommuziko.com"
+
+#: id:500
+msgid "Downloading album information failed"
+msgstr "Downloading albumo info failed"
+
+#: id:501
+msgid "Looking for album names..."
+msgstr "Looking for albumo nomoj..."
+
+#: id:502
+msgctxt "Auto context with id 502"
+msgid "Open"
+msgstr "Open"
+
+#: id:503
+msgid "Busy"
+msgstr "Busy"
+
+#: id:504
+msgid "Empty"
+msgstr "Empty"
+
+#: id:505
+msgid "Loading media info from files..."
+msgstr "Loading media info from vicos..."
+
+#: id:507
+msgid "Sort by: Usage"
+msgstr "ordigi je: Usage"
+
+#: id:510
+msgid "Enable visualizations"
+msgstr "Enable Visualisations"
+
+#: id:511
+msgid "Enable video mode switching"
+msgstr "Enable filmoj mode switching"
+
+#: id:512
+msgid "Startup window"
+msgstr "Startup Window"
+
+#: id:513
+msgid "Home window"
+msgstr "Home Window"
+
+#: id:514
+msgid "Manual settings"
+msgstr "Manual Preferoj"
+
+#: id:515
+msgid "Genre"
+msgstr "Gxenro"
+
+#: id:517
+msgid "Recently played albums"
+msgstr "Recently Played Albumos"
+
+#: id:518
+msgid "Launch"
+msgstr "Launch"
+
+#: id:519
+msgid "Launch in..."
+msgstr "Launch in.."
+
+#: id:521
+msgid "Compilations"
+msgstr "Compilations"
+
+#: id:522
+msgid "Remove source"
+msgstr "ReMovi Source"
+
+#: id:523
+msgid "Switch media"
+msgstr ""
+
+#: id:524
+msgid "Select playlist"
+msgstr ""
+
+#: id:525
+msgid "New playlist..."
+msgstr ""
+
+#: id:526
+msgid "Add to playlist"
+msgstr ""
+
+#: id:527
+msgid "Manually add to library"
+msgstr ""
+
+#: id:528
+msgid "Enter title"
+msgstr ""
+
+#: id:529
+msgid "Error: Duplicate title"
+msgstr ""
+
+#: id:530
+msgid "Select genre"
+msgstr ""
+
+#: id:531
+msgid "New genre"
+msgstr ""
+
+#: id:532
+msgid "Manual addition"
+msgstr ""
+
+#: id:533
+msgid "Enter genre"
+msgstr ""
+
+#: id:534
+msgid "View: %s"
+msgstr ""
+
+#: id:535
+msgid "List"
+msgstr ""
+
+#: id:536
+msgid "Icons"
+msgstr ""
+
+#: id:537
+msgid "Big list"
+msgstr ""
+
+#: id:538
+msgid "Big icons"
+msgstr ""
+
+#: id:539
+msgid "Wide"
+msgstr ""
+
+#: id:540
+msgid "Big wide"
+msgstr ""
+
+#: id:541
+msgid "Album icons"
+msgstr ""
+
+#: id:542
+msgid "DVD icons"
+msgstr ""
+
+#: id:543
+msgctxt "Auto context with id 543"
+msgid "DVD"
+msgstr ""
+
+#: id:544
+msgctxt "Auto context with id 544"
+msgid "Media info"
+msgstr ""
+
+#: id:545
+msgid "Audio output device"
+msgstr ""
+
+#: id:546
+msgid "Passthrough output device"
+msgstr ""
+
+#: id:547
+msgid "No biography for this artist"
+msgstr ""
+
+#: id:548
+msgid "Downmix multichannel audio to stereo"
+msgstr ""
+
+#: id:550
+msgid "Sort by: %s"
+msgstr ""
+
+#: id:551
+msgctxt "Auto context with id 551"
+msgid "Name"
+msgstr ""
+
+#: id:552
+msgid "Date"
+msgstr ""
+
+#: id:553
+msgid "Size"
+msgstr ""
+
+#: id:554
+msgid "Track"
+msgstr ""
+
+#: id:555
+msgid "Time"
+msgstr ""
+
+#: id:556
+msgctxt "Auto context with id 556"
+msgid "Title"
+msgstr ""
+
+#: id:557
+msgid "Artist"
+msgstr ""
+
+#: id:558
+msgid "Album"
+msgstr ""
+
+#: id:559
+msgid "Playlist"
+msgstr ""
+
+#: id:560
+msgid "ID"
+msgstr ""
+
+#: id:561
+msgctxt "Auto context with id 561"
+msgid "File"
+msgstr ""
+
+#: id:562
+msgctxt "Auto context with id 562"
+msgid "Year"
+msgstr ""
+
+#: id:563
+msgid "Rating"
+msgstr ""
+
+#: id:564
+msgctxt "Auto context with id 564"
+msgid "Type"
+msgstr ""
+
+#: id:565
+msgid "Usage"
+msgstr ""
+
+#: id:566
+msgid "Album artist"
+msgstr ""
+
+#: id:567
+msgid "Play count"
+msgstr ""
+
+#: id:568
+msgid "Last played"
+msgstr ""
+
+#: id:569
+msgctxt "Auto context with id 569"
+msgid "Comment"
+msgstr ""
+
+#: id:570
+msgid "Date added"
+msgstr ""
+
+#: id:571
+msgctxt "Auto context with id 571"
+msgid "Default"
+msgstr ""
+
+#: id:572
+msgid "Studio"
+msgstr ""
+
+#: id:573
+msgid "Path"
+msgstr ""
+
+#: id:574
+msgctxt "Auto context with id 574"
+msgid "Country"
+msgstr ""
+
+#: id:575
+msgid "In progress"
+msgstr ""
+
+#: id:576
+msgid "Times played"
+msgstr ""
+
+#: id:580
+msgid "Sort direction"
+msgstr ""
+
+#: id:581
+msgid "Sort method"
+msgstr ""
+
+#: id:582
+msgctxt "Auto context with id 582"
+msgid "View mode"
+msgstr ""
+
+#: id:583
+msgid "Remember views for different folders"
+msgstr ""
+
+#: id:584
+msgid "Ascending"
+msgstr ""
+
+#: id:585
+msgid "Descending"
+msgstr ""
+
+#: id:586
+msgid "Edit playlist"
+msgstr ""
+
+#: id:587
+msgid "Filter"
+msgstr ""
+
+#: id:588
+msgid "Cancel party mode"
+msgstr "Cancel Party Mode"
+
+#: id:589
+msgid "Party mode"
+msgstr "Party Mode"
+
+#: id:590
+msgid "Random"
+msgstr "Random"
+
+#: id:591
+msgctxt "Auto context with id 591"
+msgid "Off"
+msgstr "Off"
+
+#: id:592
+msgid "One"
+msgstr "One"
+
+#: id:593
+msgid "All"
+msgstr "ĉiom"
+
+#: id:594
+msgctxt "Auto context with id 594"
+msgid "Off"
+msgstr "Off"
+
+#: id:595
+msgid "Repeat: Off"
+msgstr "Repeat: Off"
+
+#: id:596
+msgid "Repeat: One"
+msgstr "Repeat: One"
+
+#: id:597
+msgid "Repeat: All"
+msgstr "Repeat: ĉiom"
+
+#: id:600
+msgid "Rip audio CD"
+msgstr "Rip CD Audio"
+
+#: id:601
+msgctxt "Auto context with id 601"
+msgid "Medium"
+msgstr "Medium"
+
+#: id:602
+msgctxt "Auto context with id 602"
+msgid "Standard"
+msgstr "Standard"
+
+#: id:603
+msgid "Extreme"
+msgstr "Extreme"
+
+#: id:604
+msgid "Constant bitrate"
+msgstr "Constant Bit Rate"
+
+#: id:605
+msgid "Ripping..."
+msgstr "Ripping..."
+
+#: id:607
+msgid "To:"
+msgstr "To:"
+
+#: id:608
+msgid "Could not rip CD or track"
+msgstr "Could not rip CD or Track"
+
+#: id:609
+msgid "CDDARipPath is not set."
+msgstr "CDDARipPath is not set in sources.xml"
+
+#: id:610
+msgid "Rip audio track"
+msgstr ""
+
+#: id:611
+msgid "Enter number"
+msgstr ""
+
+#: id:612
+msgid "Bits/Sample"
+msgstr ""
+
+#: id:613
+msgid "Sample Frequency"
+msgstr ""
+
+#: id:620
+msgid "Audio CDs"
+msgstr "CD Ripping"
+
+#: id:621
+msgid "Encoder"
+msgstr "Encoder"
+
+#: id:622
+msgid "Quality"
+msgstr "Quality"
+
+#: id:623
+msgid "Bitrate"
+msgstr "Bit Rate"
+
+#: id:624
+msgid "Include track number"
+msgstr "Include Track Number"
+
+#: id:625
+msgid "All songs of"
+msgstr "ĉiom kantoj of"
+
+#: id:629
+msgctxt "Auto context with id 629"
+msgid "View mode"
+msgstr "Vido Mode"
+
+#: id:630
+msgctxt "Auto context with id 630"
+msgid "Normal"
+msgstr "Normal"
+
+#: id:631
+msgid "Zoom"
+msgstr "Zoom"
+
+#: id:632
+msgid "Stretch 4:3"
+msgstr "Stretch 4:3"
+
+#: id:633
+msgid "Wide Zoom"
+msgstr "Stretch 14:9"
+
+#: id:634
+msgid "Stretch 16:9"
+msgstr "Stretch 16:9"
+
+#: id:635
+msgid "Original Size"
+msgstr "Original amplekso"
+
+#: id:636
+msgctxt "Auto context with id 636"
+msgid "Custom"
+msgstr "Custom"
+
+#: id:637
+msgid "Replay gain"
+msgstr "Replay Gain"
+
+#: id:638
+msgid "Replaygain volume adjustments"
+msgstr "Replay Gain Mode"
+
+#: id:639
+msgid "Use track levels"
+msgstr "Use Track Levels"
+
+#: id:640
+msgid "Use album levels"
+msgstr "Use Albumo Levels"
+
+#: id:641
+msgid "PreAmp Level - Replay gained files"
+msgstr "PreAmp Level - Replay Gained vicos"
+
+#: id:642
+msgid "PreAmp Level - Non replay gained files"
+msgstr "PreAmp Level - Non Replay Gained vicos"
+
+#: id:643
+msgid "Avoid clipping on replay gained files"
+msgstr "Avoid Clipping on Replay Gained vicos"
+
+#: id:644
+msgid "Crop black bars"
+msgstr "Crop Black Bars"
+
+#: id:645
+msgid "Need to unpack a big file. Continue?"
+msgstr "Need to cache a big vico. Continue?"
+
+#: id:646
+msgid "Remove from library"
+msgstr "ReMovi Title"
+
+#: id:647
+msgid "Export video library"
+msgstr ""
+
+#: id:648
+msgid "Import video library"
+msgstr ""
+
+#: id:649
+msgid "Importing"
+msgstr ""
+
+#: id:650
+msgid "Exporting"
+msgstr ""
+
+#: id:651
+msgid "Browse for library"
+msgstr ""
+
+#: id:652
+msgid "Years"
+msgstr ""
+
+#: id:653
+msgid "Update library"
+msgstr ""
+
+#: id:654
+msgid "Show debug info"
+msgstr ""
+
+#: id:655
+msgid "Browse for executable"
+msgstr ""
+
+#: id:656
+msgid "Browse for playlist"
+msgstr ""
+
+#: id:657
+msgid "Browse for folder"
+msgstr ""
+
+#: id:658
+msgid "Song information"
+msgstr ""
+
+#: id:659
+msgid "Non-linear stretch"
+msgstr ""
+
+#: id:660
+msgid "Volume amplification"
+msgstr ""
+
+#: id:661
+msgid "Choose export folder"
+msgstr ""
+
+#: id:662
+msgid "This file is no longer available."
+msgstr ""
+
+#: id:663
+msgid "Would you like to remove it from the library?"
+msgstr ""
+
+#: id:664
+msgid "Browse for Script"
+msgstr ""
+
+#: id:665
+msgid "Compression level"
+msgstr ""
+
+#: id:700
+msgid "Cleaning up library"
+msgstr "Cleaning up Library"
+
+#: id:701
+msgid "Removing old songs from the library"
+msgstr "Removing old kantoj from la Library"
+
+#: id:702
+msgid "This path has been scanned before"
+msgstr "This path has been scanned before"
+
+#: id:705
+msgctxt "Auto context with id 705"
+msgid "Network"
+msgstr "Network"
+
+#: id:706
+msgid "- Server"
+msgstr "HTTP Proxy Host"
+
+#: id:708
+msgid "Use an HTTP proxy server to access the internet"
+msgstr "Enable HTTP Proxy"
+
+#: id:711
+msgid "Internet Protocol (IP)"
+msgstr "Internet Protocol (IP)"
+
+#: id:712
+msgid "Invalid port specified. Value must be between 1 and 65535."
+msgstr "Invalid port specified. Value must be between 1 and 65535."
+
+#: id:713
+msgid "HTTP proxy"
+msgstr "HTTP Proxy"
+
+#: id:715
+msgid "- Assignment"
+msgstr "Assignment"
+
+#: id:716
+msgid "Automatic (DHCP)"
+msgstr "Aŭtomate (DHCP)"
+
+#: id:717
+msgid "Manual (Static)"
+msgstr "Manual (Static)"
+
+#: id:719
+msgid "- IP address"
+msgstr "- IP Address"
+
+#: id:720
+msgid "- Netmask"
+msgstr "- Netmpeti"
+
+#: id:721
+msgid "- Default gateway"
+msgstr "- Default Gateway"
+
+#: id:722
+msgid "- DNS server"
+msgstr "- DNS Server"
+
+#: id:723
+msgid "Save & restart"
+msgstr "Save & Restart"
+
+#: id:724
+msgid "Invalid address specified. Value must be AAA.BBB.CCC.DDD"
+msgstr "Invalid address specified. Value must be AAA.BBB.CCC.DDD"
+
+#: id:725
+msgid "with numbers between 0 and 255."
+msgstr "with numbers between 0 and 255."
+
+#: id:726
+msgid "Changes not saved. Continue without saving?"
+msgstr "Changes not saved. Continue without saving?"
+
+#: id:727
+msgid "Web server"
+msgstr "Web Server"
+
+#: id:728
+msgctxt "Auto context with id 728"
+msgid "FTP server"
+msgstr "FTP Server"
+
+#: id:730
+msgid "- Port"
+msgstr "Web Server Port"
+
+#: id:732
+msgid "Save & apply"
+msgstr "Save & Apply"
+
+#: id:733
+msgid "- Password"
+msgstr "Web Server pasvorto"
+
+#: id:734
+msgid "No pass"
+msgstr "No Pass"
+
+#: id:735
+msgid "- Character set"
+msgstr "- Charset"
+
+#: id:736
+msgid "- Style"
+msgstr "- Style"
+
+#: id:737
+msgid "- Colour"
+msgstr "- Color"
+
+#: id:738
+msgctxt "Auto context with id 738"
+msgid "Normal"
+msgstr "Normal"
+
+#: id:739
+msgid "Bold"
+msgstr "Bold"
+
+#: id:740
+msgid "Italics"
+msgstr "Italics"
+
+#: id:741
+msgid "Bold italics"
+msgstr "Bold Italics"
+
+#: id:742
+msgctxt "Auto context with id 742"
+msgid "White"
+msgstr "White"
+
+#: id:743
+msgctxt "Auto context with id 743"
+msgid "Yellow"
+msgstr "flava"
+
+#: id:744
+msgctxt "Auto context with id 744"
+msgid "Files"
+msgstr "vicos"
+
+#: id:745
+msgid "No scanned information for this view"
+msgstr "No scanned informaĵo for this Vido"
+
+#: id:746
+msgid "Please turn off library mode"
+msgstr "Switch to la vicos Vido"
+
+#: id:747
+msgid "Error loading image"
+msgstr "Eraro loading image"
+
+#: id:748
+msgid "Edit path"
+msgstr "Editii Path"
+
+#: id:749
+msgid "Mirror image"
+msgstr "Add Share"
+
+#: id:750
+msgid "Are you sure?"
+msgstr "Are vi sure?"
+
+#: id:751
+msgid "Removing source"
+msgstr "Removing Share"
+
+#: id:754
+msgid "Add program link"
+msgstr "Add Program Link"
+
+#: id:755
+msgid "Edit program path"
+msgstr "Editii Program Path"
+
+#: id:756
+msgid "Edit program name"
+msgstr "Editii Program Nomo"
+
+#: id:757
+msgid "Edit path depth"
+msgstr "Editii Path Depth"
+
+#: id:759
+msgid "View: Big list"
+msgstr "Vido: Big List"
+
+#: id:760
+msgctxt "Auto context with id 760"
+msgid "Yellow"
+msgstr "flava"
+
+#: id:761
+msgctxt "Auto context with id 761"
+msgid "White"
+msgstr "Blanka"
+
+#: id:762
+msgid "Blue"
+msgstr "Blue"
+
+#: id:763
+msgid "Bright green"
+msgstr "Bright Verda"
+
+#: id:764
+msgid "Yellow green"
+msgstr "flava Verda"
+
+#: id:765
+msgid "Cyan"
+msgstr "Cyan"
+
+#: id:766
+msgid "Light grey"
+msgstr "Reserved"
+
+#: id:767
+msgid "Grey"
+msgstr "Reserved"
+
+#: id:770
+msgid "Error %i: share not available"
+msgstr "Eraro %i: share not available"
+
+#: id:772
+msgctxt "Auto context with id 772"
+msgid "Audio output"
+msgstr "Audio Hardware"
+
+#: id:773
+msgid "Seeking"
+msgstr "Seeking"
+
+#: id:774
+msgid "Slideshow folder"
+msgstr "Slideshow Folder"
+
+#: id:775
+msgid "Network interface"
+msgstr ""
+
+#: id:776
+msgid "- Wireless network name (ESSID)"
+msgstr ""
+
+#: id:777
+msgid "- Wireless password"
+msgstr ""
+
+#: id:778
+msgid "- Wireless security"
+msgstr ""
+
+#: id:779
+msgid "Save and apply network interface settings"
+msgstr ""
+
+#: id:780
+msgid "No encryption"
+msgstr ""
+
+#: id:781
+msgid "WEP"
+msgstr ""
+
+#: id:782
+msgid "WPA"
+msgstr ""
+
+#: id:783
+msgid "WPA2"
+msgstr ""
+
+#: id:784
+msgid "Applying network interface settings. Please wait."
+msgstr ""
+
+#: id:785
+msgid "Network interface restarted successfully."
+msgstr ""
+
+#: id:786
+msgid "Network interface did not start successfully."
+msgstr ""
+
+#: id:787
+msgid "Interface disabled"
+msgstr ""
+
+#: id:788
+msgid "Network interface disabled successfully."
+msgstr ""
+
+#: id:789
+msgid "Wireless network name (ESSID)"
+msgstr ""
+
+#: id:790
+msgid "Remote control"
+msgstr ""
+
+#: id:791
+msgid "Allow programs on this system to control XBMC"
+msgstr ""
+
+#: id:792
+msgctxt "Auto context with id 792"
+msgid "Port"
+msgstr ""
+
+#: id:793
+msgid "Port range"
+msgstr ""
+
+#: id:794
+msgid "Allow programs on other systems to control XBMC"
+msgstr ""
+
+#: id:795
+msgid "Initial repeat delay (ms)"
+msgstr ""
+
+#: id:796
+msgid "Continuous repeat delay (ms)"
+msgstr ""
+
+#: id:797
+msgid "Maximum number of clients"
+msgstr ""
+
+#: id:798
+msgid "Internet access"
+msgstr ""
+
+#: id:850
+msgid "Invalid port number entered"
+msgstr ""
+
+#: id:851
+msgid "Valid port range is 1-65535"
+msgstr ""
+
+#: id:852
+msgid "Valid port range is 1024-65535"
+msgstr ""
+
+#: id:998
+msgid "Add Music..."
+msgstr "XLink Kai"
+
+#: id:999
+msgid "Add Videos..."
+msgstr "Interreto-gaming"
+
+#: id:1000
+msgid "- Preview"
+msgstr "ekranosaver PreVido"
+
+#: id:1001
+msgid "Unable to connect"
+msgstr "Unable to connect"
+
+#: id:1002
+msgid "XBMC was unable to connect to the network location."
+msgstr "XBMC was unable to connect to la network location."
+
+#: id:1003
+msgid "This could be due to the network not being connected."
+msgstr "This could be due to la network not being connected."
+
+#: id:1004
+msgid "Would you like to add it anyway?"
+msgstr "Would you like to add it anyway?"
+
+#: id:1006
+msgctxt "Auto context with id 1006"
+msgid "IP address"
+msgstr "IP Address"
+
+#: id:1007
+msgid "Add network location"
+msgstr "Add Network Location"
+
+#: id:1008
+msgid "Protocol"
+msgstr "Protocol"
+
+#: id:1009
+msgid "Server address"
+msgstr "Server Address"
+
+#: id:1010
+msgid "Server name"
+msgstr "Server Nomo"
+
+#: id:1011
+msgid "Remote path"
+msgstr "Remote Path"
+
+#: id:1012
+msgid "Shared folder"
+msgstr "Shared Folder"
+
+#: id:1013
+msgctxt "Auto context with id 1013"
+msgid "Port"
+msgstr "Port"
+
+#: id:1014
+msgctxt "Auto context with id 1014"
+msgid "Username"
+msgstr "Uzulonomo"
+
+#: id:1015
+msgid "Browse for network server"
+msgstr "network server"
+
+#: id:1016
+msgid "Enter the network address of the server"
+msgstr "tajpi la network address of la server"
+
+#: id:1017
+msgid "Enter the path on the server"
+msgstr "tajpi la path on la server"
+
+#: id:1018
+msgid "Enter the port number"
+msgstr "tajpi la port number"
+
+#: id:1019
+msgid "Enter the username"
+msgstr "tajpi la uzulonomo"
+
+#: id:1020
+msgid "Add %s source"
+msgstr "Add %s Source"
+
+#: id:1021
+msgid "Enter the paths or browse for the media locations."
+msgstr "tajpi la path or foliumilo for la media location."
+
+#: id:1022
+msgid "Enter a name for this media Source."
+msgstr "tajpi a nomo for this Media Source."
+
+#: id:1023
+msgid "Browse for new share"
+msgstr "Foliumilo for new share"
+
+#: id:1024
+msgid "Browse"
+msgstr "Foliumilo"
+
+#: id:1025
+msgid "Could not retrieve directory information."
+msgstr "Could not retrieve directory informaĵo."
+
+#: id:1026
+msgid "Add source"
+msgstr "Add Source"
+
+#: id:1027
+msgid "Edit source"
+msgstr "Editii Source"
+
+#: id:1028
+msgid "Edit %s source"
+msgstr "Editii %s Source"
+
+#: id:1029
+msgid "Enter the new label"
+msgstr "tajpi la new label"
+
+#: id:1030
+msgid "Browse for image"
+msgstr "an image"
+
+#: id:1031
+msgid "Browse for image folder"
+msgstr "an image folder"
+
+#: id:1032
+msgid "Add network location..."
+msgstr "Add Network Location..."
+
+#: id:1033
+msgid "Browse for file"
+msgstr ""
+
+#: id:1034
+msgid "Submenu"
+msgstr ""
+
+#: id:1035
+msgid "Enable submenu buttons"
+msgstr ""
+
+#: id:1036
+msgid "Favourites"
+msgstr ""
+
+#: id:1037
+msgid "Video Add-ons"
+msgstr ""
+
+#: id:1038
+msgid "Music Add-ons"
+msgstr ""
+
+#: id:1039
+msgid "Picture Add-ons"
+msgstr ""
+
+#: id:1040
+msgid "Loading directory"
+msgstr ""
+
+#: id:1041
+msgid "Retrieved %i items"
+msgstr ""
+
+#: id:1042
+msgid "Retrieved %i of %i items"
+msgstr ""
+
+#: id:1043
+msgid "Program Add-ons"
+msgstr ""
+
+#: id:1044
+msgid "Set plugin thumb"
+msgstr ""
+
+#: id:1045
+msgid "Add-on settings"
+msgstr ""
+
+#: id:1046
+msgid "Access points"
+msgstr ""
+
+#: id:1047
+msgid "Other..."
+msgstr ""
+
+#: id:1048
+msgid "- Username"
+msgstr ""
+
+#: id:1049
+msgid "Script settings"
+msgstr ""
+
+#: id:1050
+msgid "Singles"
+msgstr ""
+
+#: id:1051
+msgid "Enter web address"
+msgstr ""
+
+#: id:1200
+msgid "SMB client"
+msgstr "SMB Client"
+
+#: id:1202
+msgid "Workgroup"
+msgstr "Workgroup"
+
+#: id:1203
+msgid "Default username"
+msgstr "Default Uzulonomo"
+
+#: id:1204
+msgid "Default password"
+msgstr "Default Pasvorto"
+
+#: id:1207
+msgid "WINS server"
+msgstr "WINS-Server"
+
+#: id:1208
+msgid "Mount SMB shares"
+msgstr ""
+
+#: id:1210
+msgctxt "Auto context with id 1210"
+msgid "Remove"
+msgstr "ReMovi"
+
+#: id:1211
+msgctxt "Auto context with id 1211"
+msgid "Music"
+msgstr "Muziko"
+
+#: id:1212
+msgctxt "Auto context with id 1212"
+msgid "Video"
+msgstr "Filmoj"
+
+#: id:1213
+msgctxt "Auto context with id 1213"
+msgid "Pictures"
+msgstr "Bildoj"
+
+#: id:1214
+msgctxt "Auto context with id 1214"
+msgid "Files"
+msgstr "vicos"
+
+#: id:1215
+msgctxt "Auto context with id 1215"
+msgid "Music & video"
+msgstr "Muziko & Filmoj"
+
+#: id:1216
+msgid "Music & pictures"
+msgstr "Muziko & Bildoj"
+
+#: id:1217
+msgid "Music & files"
+msgstr "Muziko & vicos"
+
+#: id:1218
+msgid "Video & pictures"
+msgstr "Filmoj & Bildoj"
+
+#: id:1219
+msgid "Video & files"
+msgstr "Filmoj & vicos"
+
+#: id:1220
+msgid "Pictures & files"
+msgstr "Bildoj & vicos"
+
+#: id:1221
+msgid "Music & video & pictures"
+msgstr "Muziko & Filmoj & Bildoj"
+
+#: id:1222
+msgid "Music & video & pictures & files"
+msgstr "Muziko & Filmoj & Bildoj & vicos"
+
+#: id:1223
+msgctxt "Auto context with id 1223"
+msgid "Disabled"
+msgstr "Disabled"
+
+#: id:1226
+msgid "Files & music & video"
+msgstr "vicos & Muziko & Filmoj"
+
+#: id:1227
+msgid "Files & pictures & music"
+msgstr "vicos & Bildoj & Muziko"
+
+#: id:1228
+msgid "Files & pictures & video"
+msgstr "vicos & Bildoj & Filmoj"
+
+#: id:1229
+msgid "Music & programs"
+msgstr "Muziko & Programs"
+
+#: id:1230
+msgid "Video & programs"
+msgstr "Filmoj & Programs"
+
+#: id:1231
+msgid "Pictures & programs"
+msgstr "Bildoj & Programs"
+
+#: id:1232
+msgid "Music & video & pictures & programs"
+msgstr "Muziko & Filmoj & Bildoj & Programs"
+
+#: id:1233
+msgid "Programs & video & music"
+msgstr "Programs & Filmoj & Muziko"
+
+#: id:1234
+msgid "Programs & pictures & music"
+msgstr "Programs & Bildoj & Muziko"
+
+#: id:1235
+msgid "Programs & pictures & video"
+msgstr "Programs & Bildoj & Filmoj"
+
+#: id:1250
+msgid "Auto-detection"
+msgstr "Auxtomata-detection"
+
+#: id:1251
+msgid "Auto-detect system"
+msgstr "XBOX Auxtomata-detection"
+
+#: id:1252
+msgid "Nickname"
+msgstr "Kromnomo"
+
+#: id:1254
+msgid "Ask to connect"
+msgstr "Peti to Connect"
+
+#: id:1255
+msgid "Send FTP user and password"
+msgstr "Send FTP Uzulo and pasvorto"
+
+#: id:1256
+msgid "Ping interval"
+msgstr "Ping Interval"
+
+#: id:1257
+msgid "Would you like to connect to the auto-detected system?"
+msgstr "Would vi like to connect to la Autodetected Xbox?"
+
+#: id:1259
+msgid "Zeroconf"
+msgstr ""
+
+#: id:1260
+msgid "Announce these services to other systems via Zeroconf"
+msgstr ""
+
+#: id:1270
+msgid "Allow XBMC to receive AirPlay content"
+msgstr ""
+
+#: id:1271
+msgid "Device name"
+msgstr ""
+
+#: id:1272
+msgid "- Use password protection"
+msgstr ""
+
+#: id:1273
+msgid "AirPlay"
+msgstr ""
+
+#: id:1300
+msgid "Custom audio device"
+msgstr ""
+
+#: id:1301
+msgid "Custom passthrough device"
+msgstr ""
+
+#: id:1396
+msgid "Drifting"
+msgstr "Drifting"
+
+#: id:1397
+msgid "and"
+msgstr "kaj"
+
+#: id:1398
+msgid "Freezing"
+msgstr "Frostos"
+
+#: id:1399
+msgid "Late"
+msgstr "Late"
+
+#: id:1400
+msgid "Isolated"
+msgstr "Sola"
+
+#: id:1401
+msgid "Thundershowers"
+msgstr "T-Showers"
+
+#: id:1402
+msgid "Thunder"
+msgstr "Tondri"
+
+#: id:1403
+msgctxt "Auto context with id 1403"
+msgid "Sun"
+msgstr "Sunbrilo"
+
+#: id:1404
+msgid "Heavy"
+msgstr "Peza"
+
+#: id:1405
+msgid "in"
+msgstr "en"
+
+#: id:1406
+msgid "the"
+msgstr "la"
+
+#: id:1407
+msgid "Vicinity"
+msgstr "Apudaĵo"
+
+#: id:1408
+msgid "Ice"
+msgstr "Glacio"
+
+#: id:1409
+msgid "Crystals"
+msgstr "Kristaloj"
+
+#: id:1410
+msgid "Calm"
+msgstr "Kvieto"
+
+#: id:1411
+msgid "with"
+msgstr ""
+
+#: id:1412
+msgid "windy"
+msgstr ""
+
+#: id:1413
+msgid "drizzle"
+msgstr ""
+
+#: id:1414
+msgid "Thunderstorm"
+msgstr ""
+
+#: id:1415
+msgid "Drizzle"
+msgstr ""
+
+#: id:1416
+msgid "Foggy"
+msgstr ""
+
+#: id:1417
+msgid "Grains"
+msgstr ""
+
+#: id:1418
+msgid "T-Storms"
+msgstr ""
+
+#: id:1419
+msgid "T-Showers"
+msgstr ""
+
+#: id:1420
+msgid "Moderate"
+msgstr ""
+
+#: id:1421
+msgid "Very High"
+msgstr ""
+
+#: id:1422
+msgid "Windy"
+msgstr ""
+
+#: id:1423
+msgid "Mist"
+msgstr ""
+
+#: id:1450
+msgid "Put display to sleep when idle"
+msgstr ""
+
+#: id:2050
+msgid "Runtime"
+msgstr "Runtime:"
+
+#: id:2100
+msgid "Script failed! : %s"
+msgstr ""
+
+#: id:2101
+msgid "Newer version needed - See log"
+msgstr ""
+
+#: id:4501
+msgid "Enable LCD/VFD"
+msgstr "LCD Type"
+
+#: id:10000
+msgid "Home"
+msgstr "Hejmo"
+
+#: id:10001
+msgctxt "Auto context with id 10001"
+msgid "Programs"
+msgstr "Mia Programs"
+
+#: id:10002
+msgctxt "Auto context with id 10002"
+msgid "Pictures"
+msgstr "Mia Bildoj"
+
+#: id:10003
+msgctxt "Auto context with id 10003"
+msgid "File manager"
+msgstr "Mia vicos"
+
+#: id:10004
+msgctxt "Auto context with id 10004"
+msgid "Settings"
+msgstr "Preferoj"
+
+#: id:10005
+msgctxt "Auto context with id 10005"
+msgid "Music"
+msgstr "Mia Muziko"
+
+#: id:10006
+msgctxt "Auto context with id 10006"
+msgid "Videos"
+msgstr "Mia Filmoj"
+
+#: id:10007
+msgid "System information"
+msgstr "Sistemo informaĵo"
+
+#: id:10008
+msgid "Settings - General"
+msgstr "Preferoj->Generalo"
+
+#: id:10009
+msgid "Settings - Screen"
+msgstr "Preferoj->ekrano"
+
+#: id:10010
+msgid "Settings - Appearance - GUI Calibration"
+msgstr "Preferoj->Appearance->GUI Calibration"
+
+#: id:10011
+msgid "Settings - Videos - Screen Calibration"
+msgstr "Preferoj->Mia Filmoj->ekrano Calibration"
+
+#: id:10012
+msgid "Settings - Pictures"
+msgstr "Preferoj->Mia Bildoj"
+
+#: id:10013
+msgid "Settings - Programs"
+msgstr "Preferoj->Mia Programs"
+
+#: id:10014
+msgid "Settings - Weather"
+msgstr "Preferoj->Wealar"
+
+#: id:10015
+msgid "Settings - Music"
+msgstr "Preferoj->Mia Muziko"
+
+#: id:10016
+msgid "Settings - System"
+msgstr "Preferoj->System"
+
+#: id:10017
+msgid "Settings - Videos"
+msgstr "Preferoj->Mia Filmoj"
+
+#: id:10018
+msgid "Settings - Network"
+msgstr "Preferoj->Network"
+
+#: id:10019
+msgid "Settings - Appearance"
+msgstr "Preferoj->Appearance"
+
+#: id:10020
+msgctxt "Auto context with id 10020"
+msgid "Scripts"
+msgstr "Scripts"
+
+#: id:10021
+msgid "Web Browser"
+msgstr "Mia Filmoj/Gxenroj"
+
+#: id:10025
+msgctxt "Auto context with id 10025"
+msgid "Videos"
+msgstr "Mia Filmoj/Nomoj"
+
+#: id:10028
+msgid "Videos/Playlist"
+msgstr "Mia Filmoj/Kanto-listoj"
+
+#: id:10029
+msgctxt "Auto context with id 10029"
+msgid "Login screen"
+msgstr ""
+
+#: id:10034
+msgid "Settings - Profiles"
+msgstr "Preferoj->Provicos"
+
+#: id:10040
+msgid "Addon browser"
+msgstr ""
+
+#: id:10100
+msgid "Yes/No dialog"
+msgstr "Jes/ne dialog"
+
+#: id:10101
+msgid "Progress dialog"
+msgstr "Progress dialog"
+
+#: id:10210
+msgid "Looking for subtitles..."
+msgstr ""
+
+#: id:10211
+msgid "Looking for or caching subtitles..."
+msgstr ""
+
+#: id:10212
+msgid "terminating"
+msgstr ""
+
+#: id:10213
+msgid "buffering"
+msgstr ""
+
+#: id:10214
+msgid "Opening stream"
+msgstr ""
+
+#: id:10500
+msgid "Music/Playlist"
+msgstr "Mia Muziko/Playlist"
+
+#: id:10501
+msgid "Music/Files"
+msgstr "Mia Muziko/vicos"
+
+#: id:10502
+msgid "Music/Library"
+msgstr "Mia Muziko/Library"
+
+#: id:10503
+msgid "Playlist editor"
+msgstr "Mia Muziko/Popola 100"
+
+#: id:10504
+msgid "Top 100 songs"
+msgstr "Pli-popola 100 kantoj"
+
+#: id:10505
+msgid "Top 100 albums"
+msgstr "Pli-popa 100 Albumos"
+
+#: id:10506
+msgctxt "Auto context with id 10506"
+msgid "Programs"
+msgstr "Applications"
+
+#: id:10507
+msgid "Configuration"
+msgstr "Preferoj"
+
+#: id:10508
+msgid "Weather forecast"
+msgstr "Wealar Forecast"
+
+#: id:10509
+msgid "Network gaming"
+msgstr "Reto Gaming"
+
+#: id:10510
+msgid "Extensions"
+msgstr "Extensions"
+
+#: id:10511
+msgctxt "Auto context with id 10511"
+msgid "System info"
+msgstr "Sistemo Info"
+
+#: id:10516
+msgid "Music - Library"
+msgstr "Mia Muziko - Library"
+
+#: id:10517
+msgid "Now Playing - Music"
+msgstr "Mia Muziko - Now Playing"
+
+#: id:10522
+msgid "Now Playing - Videos"
+msgstr "Mia Filmoj - Now Playing"
+
+#: id:10523
+msgid "Album info"
+msgstr "Albumo Info"
+
+#: id:10524
+msgid "Movie info"
+msgstr "Filmo Info"
+
+#: id:12000
+msgid "Select dialog"
+msgstr "Elekti dialog"
+
+#: id:12001
+msgid "Music/Info"
+msgstr "Mia Muziko/info"
+
+#: id:12002
+msgid "Dialog OK"
+msgstr "Dialog OK"
+
+#: id:12003
+msgid "Videos/Info"
+msgstr "Mia Filmoj/Info"
+
+#: id:12004
+msgid "Scripts/Info"
+msgstr "Mia Scripts/Info"
+
+#: id:12005
+msgid "Fullscreen video"
+msgstr "Fullekrano filmoj"
+
+#: id:12006
+msgid "Audio visualization"
+msgstr "Soni visualisation"
+
+#: id:12008
+msgid "File stacking dialog"
+msgstr "Vicostacking dialog"
+
+#: id:12009
+msgid "Rebuild index..."
+msgstr "Rebuild index..."
+
+#: id:12010
+msgid "Return to music window"
+msgstr "Return to Mia Muziko"
+
+#: id:12011
+msgid "Return to videos window"
+msgstr "Return to Mia Filmoj"
+
+#: id:12021
+msgid "Start from beginning"
+msgstr "Start from beginning"
+
+#: id:12022
+msgid "Resume from %s"
+msgstr "Resume from last position"
+
+#: id:12310
+msgid "0"
+msgstr "0"
+
+#: id:12311
+msgid "1"
+msgstr "1"
+
+#: id:12312
+msgid "2"
+msgstr "2"
+
+#: id:12313
+msgid "3"
+msgstr "3"
+
+#: id:12314
+msgid "4"
+msgstr "4"
+
+#: id:12315
+msgid "5"
+msgstr "5"
+
+#: id:12316
+msgid "6"
+msgstr "6"
+
+#: id:12317
+msgid "7"
+msgstr "7"
+
+#: id:12318
+msgid "8"
+msgstr "8"
+
+#: id:12319
+msgid "9"
+msgstr "9"
+
+#: id:12320
+msgid "c"
+msgstr "c"
+
+#: id:12321
+msgid "Ok"
+msgstr "ok"
+
+#: id:12322
+msgid "*"
+msgstr "*"
+
+#: id:12325
+msgid "Locked! Enter code..."
+msgstr "Locked! tajpi Code..."
+
+#: id:12326
+msgid "Enter password"
+msgstr "tajpi pasvorto"
+
+#: id:12327
+msgid "Enter master code"
+msgstr "tajpi Master Code"
+
+#: id:12328
+msgid "Enter unlock code"
+msgstr "tajpi Malŝlosi Code"
+
+#: id:12329
+msgid "or press C to cancel"
+msgstr "or press C to cancel"
+
+#: id:12330
+msgid "Enter gamepad button combo and"
+msgstr "tajpi Gamepad button combo and press Start"
+
+#: id:12331
+msgid "press OK, or Back to cancel"
+msgstr "press Start, or Back to cancel"
+
+#: id:12332
+msgid "Set lock"
+msgstr "Set Lock"
+
+#: id:12333
+msgid "Unlock"
+msgstr "Malŝlosi"
+
+#: id:12334
+msgid "Reset lock"
+msgstr "Reset Lock"
+
+#: id:12335
+msgid "Remove lock"
+msgstr "ReMovi Lock"
+
+#: id:12337
+msgid "Numeric password"
+msgstr "Numeric pasvorto"
+
+#: id:12338
+msgid "Gamepad button combo"
+msgstr "Gamepad button combo"
+
+#: id:12339
+msgid "Full-text password"
+msgstr "Full-text pasvorto"
+
+#: id:12340
+msgid "Enter new password"
+msgstr "tajpi new pasvorto"
+
+#: id:12341
+msgid "Re-Enter new password"
+msgstr "Re-tajpi new pasvorto"
+
+#: id:12342
+msgid "Incorrect password,"
+msgstr "malĝusta pasvorto,"
+
+#: id:12343
+msgid "retries left"
+msgstr "retries left"
+
+#: id:12344
+msgid "Passwords entered did not match."
+msgstr "pasvortos tajpied did not match."
+
+#: id:12345
+msgid "Access denied"
+msgstr "Access Denied"
+
+#: id:12346
+msgid "Password retry limit exceeded."
+msgstr "pasvorto retry limit exceeded."
+
+#: id:12347
+msgid "The system will now shut off."
+msgstr "La XBOX will now shut off."
+
+#: id:12348
+msgid "Item locked"
+msgstr "Item Locked"
+
+#: id:12353
+msgid "Reactivate lock"
+msgstr "Reactivate Lock"
+
+#: id:12356
+msgid "Change lock"
+msgstr "Change Lock"
+
+#: id:12357
+msgid "Source lock"
+msgstr "Share Lock"
+
+#: id:12358
+msgid "Password entry was blank. Try again."
+msgstr "pasvorto entry was blank. Try again."
+
+#: id:12360
+msgid "Master lock"
+msgstr "Master Lock"
+
+#: id:12362
+msgid "Shutdown system if Master Lock retries exceeded"
+msgstr "Enable Shutdown"
+
+#: id:12367
+msgid "Master code is not valid"
+msgstr "Master Code is not Valid!"
+
+#: id:12368
+msgid "Please enter a valid master code"
+msgstr "Plaĉi tajpi a Valid Master Code!"
+
+#: id:12373
+msgid "Settings & file manager"
+msgstr "Preferoj & Mia vicos"
+
+#: id:12376
+msgid "Set as default for all movies"
+msgstr "Set as default for ĉiom Movies"
+
+#: id:12377
+msgid "This will reset any previously saved values"
+msgstr "This will reset any previously saved values"
+
+#: id:12378
+msgid "Amount of time to display each image"
+msgstr "Show each image for"
+
+#: id:12379
+msgid "Use pan and zoom effects"
+msgstr "Use Pan and Zoom effects"
+
+#: id:12383
+msgid "12 hour clock"
+msgstr "12 hour clock"
+
+#: id:12384
+msgid "24 hour clock"
+msgstr "24 hour clock"
+
+#: id:12385
+msgid "Day/Month"
+msgstr "Day/Month"
+
+#: id:12386
+msgid "Month/Day"
+msgstr "Month/Day"
+
+#: id:12390
+msgid "System uptime"
+msgstr "System Uptime"
+
+#: id:12391
+msgid "Minutes"
+msgstr "Minutes"
+
+#: id:12392
+msgid "Hours"
+msgstr "Hours"
+
+#: id:12393
+msgid "Days"
+msgstr "Days"
+
+#: id:12394
+msgid "Total uptime"
+msgstr "Total Uptime"
+
+#: id:12395
+msgid "Battery level"
+msgstr ""
+
+#: id:12600
+msgctxt "Auto context with id 12600"
+msgid "Weather"
+msgstr "Mia Wealar"
+
+#: id:12900
+msgctxt "Auto context with id 12900"
+msgid "Screensaver"
+msgstr "ekranosaver"
+
+#: id:12901
+msgid "Fullscreen OSD"
+msgstr "Fullekrano OSD"
+
+#: id:13000
+msgid "System"
+msgstr "System"
+
+#: id:13001
+msgid "Immediate HD spindown"
+msgstr "Immediate HD Spindown"
+
+#: id:13002
+msgid "Video only"
+msgstr "Filmoj Only"
+
+#: id:13003
+msgid "- Delay"
+msgstr "- malfruiĝo"
+
+#: id:13004
+msgid "- Minimum file duration"
+msgstr "- Minimum vico Duration"
+
+#: id:13005
+msgid "Shutdown"
+msgstr "Shutdown"
+
+#: id:13008
+msgid "Shutdown function"
+msgstr ""
+
+#: id:13009
+msgid "Quit"
+msgstr ""
+
+#: id:13010
+msgid "Hibernate"
+msgstr ""
+
+#: id:13011
+msgid "Suspend"
+msgstr ""
+
+#: id:13012
+msgid "Exit"
+msgstr ""
+
+#: id:13013
+msgid "Reboot"
+msgstr ""
+
+#: id:13014
+msgid "Minimize"
+msgstr ""
+
+#: id:13015
+msgid "Power button action"
+msgstr ""
+
+#: id:13016
+msgid "Power off System"
+msgstr ""
+
+#: id:13020
+msgid "Is another session active, perhaps over ssh?"
+msgstr ""
+
+#: id:13021
+msgid "Mounted removable harddrive"
+msgstr ""
+
+#: id:13022
+msgid "Unsafe device removal"
+msgstr ""
+
+#: id:13023
+msgid "Successfully removed device"
+msgstr ""
+
+#: id:13024
+msgid "Joystick plugged"
+msgstr ""
+
+#: id:13025
+msgid "Joystick unplugged"
+msgstr ""
+
+#: id:13050
+msgid "Running low on battery"
+msgstr ""
+
+#: id:13100
+msgid "Flicker filter"
+msgstr "Flicker Filter"
+
+#: id:13101
+msgid "Let driver choose (requires restart)"
+msgstr ""
+
+#: id:13105
+msgid "Vertical blank sync"
+msgstr ""
+
+#: id:13106
+msgctxt "Auto context with id 13106"
+msgid "Disabled"
+msgstr ""
+
+#: id:13107
+msgid "Enabled during video playback"
+msgstr ""
+
+#: id:13108
+msgctxt "Auto context with id 13108"
+msgid "Always enabled"
+msgstr ""
+
+#: id:13109
+msgid "Test & apply resolution"
+msgstr ""
+
+#: id:13110
+msgid "Save resolution?"
+msgstr ""
+
+#: id:13111
+msgid "Would you like to keep this resolution?"
+msgstr ""
+
+#: id:13112
+msgid "High quality upscaling"
+msgstr ""
+
+#: id:13113
+msgctxt "Auto context with id 13113"
+msgid "Disabled"
+msgstr ""
+
+#: id:13114
+msgid "Enabled for SD content"
+msgstr ""
+
+#: id:13115
+msgctxt "Auto context with id 13115"
+msgid "Always enabled"
+msgstr ""
+
+#: id:13116
+msgid "Upscaling method"
+msgstr ""
+
+#: id:13117
+msgctxt "Auto context with id 13117"
+msgid "Bicubic"
+msgstr ""
+
+#: id:13118
+msgid "Lanczos"
+msgstr ""
+
+#: id:13119
+msgid "Sinc"
+msgstr ""
+
+#: id:13120
+msgctxt "Auto context with id 13120"
+msgid "VDPAU"
+msgstr ""
+
+#: id:13121
+msgid "VDPAU HQ Upscaling level"
+msgstr ""
+
+#: id:13122
+msgid "VDPAU Studio level color conversion"
+msgstr ""
+
+#: id:13130
+msgid "Blank other displays"
+msgstr ""
+
+#: id:13131
+msgctxt "Auto context with id 13131"
+msgid "Disabled"
+msgstr ""
+
+#: id:13132
+msgid "Blank displays"
+msgstr ""
+
+#: id:13140
+msgid "Active connections detected!"
+msgstr ""
+
+#: id:13141
+msgid "If you proceed, you might not be able to control XBMC"
+msgstr ""
+
+#: id:13142
+msgid "any longer. Are you sure you want to stop the Event server?"
+msgstr ""
+
+#: id:13144
+msgid "Change Apple Remote mode?"
+msgstr ""
+
+#: id:13145
+msgid "If you are currently using the Apple Remote to control"
+msgstr ""
+
+#: id:13146
+msgid "XBMC, changing this setting might affect your ability"
+msgstr ""
+
+#: id:13147
+msgid "to continue controlling it. Do you want to proceed?"
+msgstr ""
+
+#: id:13159
+msgid "Subnet mask"
+msgstr "Subnet mpeti:"
+
+#: id:13160
+msgid "Gateway"
+msgstr "Gateway:"
+
+#: id:13161
+msgid "Primary DNS"
+msgstr "DNS"
+
+#: id:13162
+msgid "Initialize failed"
+msgstr "Initialize failed"
+
+#: id:13170
+msgctxt "Auto context with id 13170"
+msgid "Never"
+msgstr "Never"
+
+#: id:13171
+msgid "Immediately"
+msgstr "Immediately"
+
+#: id:13172
+msgid "After %i secs"
+msgstr "After %i secs"
+
+#: id:13173
+msgid "HDD install date:"
+msgstr ""
+
+#: id:13174
+msgid "HDD power cycle count:"
+msgstr ""
+
+#: id:13200
+msgid "Profiles"
+msgstr "Provicos"
+
+#: id:13201
+msgid "Delete profile '%s'?"
+msgstr "Forviŝi provico '%s'?"
+
+#: id:13204
+msgid "Last loaded profile:"
+msgstr "Last loaded provico:"
+
+#: id:13205
+msgid "Unknown"
+msgstr "Unknown"
+
+#: id:13206
+msgid "Overwrite"
+msgstr "Overwrite"
+
+#: id:13208
+msgid "Alarm clock"
+msgstr "Alarm clock"
+
+#: id:13209
+msgid "Alarm clock interval (in minutes)"
+msgstr "Alarm clock interval (in minutes)"
+
+#: id:13210
+msgid "Started, alarm in %im"
+msgstr "Started, alarm in %im"
+
+#: id:13211
+msgid "Alarm!"
+msgstr "Alarm!"
+
+#: id:13212
+msgid "Canceled with %im%is left"
+msgstr "Canceled with %im%is left"
+
+#: id:13213
+msgid "%2.0fm"
+msgstr ""
+
+#: id:13214
+msgid "%2.0fs"
+msgstr ""
+
+#: id:13249
+msgid "Search for subtitles in RARs"
+msgstr "Search for Subtitles in RARs"
+
+#: id:13250
+msgid "Browse for subtitle..."
+msgstr "Foliumilo for subtitle..."
+
+#: id:13251
+msgid "Move item"
+msgstr "Movi Item"
+
+#: id:13252
+msgid "Move item here"
+msgstr "Movi Item Here"
+
+#: id:13253
+msgid "Cancel move"
+msgstr "Cancel Movi"
+
+#: id:13270
+msgid "Hardware:"
+msgstr "Hardware:"
+
+#: id:13271
+msgid "CPU Usage:"
+msgstr "CPU Speed:"
+
+#: id:13274
+msgid "Connected, but no DNS is available."
+msgstr "Xbox is Connected, but no DNS is available."
+
+#: id:13275
+msgid "Hard Disk"
+msgstr "Hard Disk"
+
+#: id:13276
+msgid "DVD-ROM"
+msgstr "DVD-ROM"
+
+#: id:13277
+msgctxt "Auto context with id 13277"
+msgid "Storage"
+msgstr "Storage"
+
+#: id:13278
+msgctxt "Auto context with id 13278"
+msgid "Default"
+msgstr "Default"
+
+#: id:13279
+msgctxt "Auto context with id 13279"
+msgid "Network"
+msgstr "Network"
+
+#: id:13280
+msgctxt "Auto context with id 13280"
+msgid "Video"
+msgstr "Filmoj"
+
+#: id:13281
+msgid "Hardware"
+msgstr "Hardware"
+
+#: id:13283
+msgid "Operating system:"
+msgstr "Kernel Version:"
+
+#: id:13284
+msgid "CPU speed:"
+msgstr "CPU Speed:"
+
+#: id:13286
+msgid "Video encoder:"
+msgstr "Filmoj Encoder:"
+
+#: id:13287
+msgid "Screen resolution:"
+msgstr "ekrano Resolution:"
+
+#: id:13292
+msgid "A/V cable:"
+msgstr "A/V Cable:"
+
+#: id:13294
+msgid "DVD region:"
+msgstr "DVD Region:"
+
+#: id:13295
+msgid "Internet:"
+msgstr "Internet:"
+
+#: id:13296
+msgctxt "Auto context with id 13296"
+msgid "Connected"
+msgstr "Xbox is Connected"
+
+#: id:13297
+msgid "Not connected. Check network settings."
+msgstr "Xbox is not Connected. Check Network Preferoj."
+
+#: id:13299
+msgid "Target temperature"
+msgstr "Target Temperature"
+
+#: id:13300
+msgid "Fan speed"
+msgstr "Fan Speed"
+
+#: id:13301
+msgid "Auto temperature control"
+msgstr "Auto Temperature Control"
+
+#: id:13302
+msgid "Fan speed override"
+msgstr "Fan Speed Override"
+
+#: id:13303
+msgid "- Fonts"
+msgstr "Skin Fonts"
+
+#: id:13304
+msgid "Enable flipping bi-directional strings"
+msgstr "Enable Flipping Bi-Directional Strings"
+
+#: id:13305
+msgid "Show RSS news feeds"
+msgstr "Enable RSS Feeds"
+
+#: id:13306
+msgid "Show parent folder items"
+msgstr "Hide Parent Folder Items"
+
+#: id:13307
+msgid "Track naming template"
+msgstr "Track Naming Template"
+
+#: id:13308
+msgid "Do you wish to reboot your system"
+msgstr "Do you wish to reboot your xbox"
+
+#: id:13309
+msgid "instead of just XBMC?"
+msgstr "instead of just XBMC?"
+
+#: id:13310
+msgid "Zoom effect"
+msgstr "Zoom Effect"
+
+#: id:13311
+msgid "Float effect"
+msgstr "Float Effect"
+
+#: id:13312
+msgid "Black bar reduction"
+msgstr "Black Bar Reduction"
+
+#: id:13313
+msgid "Restart"
+msgstr "Restart"
+
+#: id:13314
+msgid "Crossfade between songs"
+msgstr "Crossfade"
+
+#: id:13315
+msgid "Regenerate thumbnails"
+msgstr "Regenerate Thumbnails"
+
+#: id:13316
+msgid "Recursive thumbnails"
+msgstr "Recursive Thumbnails"
+
+#: id:13317
+msgid "View slideshow"
+msgstr "Vido Slideshow"
+
+#: id:13318
+msgid "Recursive slideshow"
+msgstr "Recursive Slideshow"
+
+#: id:13319
+msgid "Randomize"
+msgstr "Randomize"
+
+#: id:13320
+msgid "Stereo"
+msgstr "Stereo"
+
+#: id:13321
+msgid "Left only"
+msgstr "Left Only"
+
+#: id:13322
+msgid "Right only"
+msgstr "Right Only"
+
+#: id:13323
+msgid "Enable karaoke support"
+msgstr "Enable CD+G"
+
+#: id:13324
+msgid "Background transparency"
+msgstr "Background Transparency"
+
+#: id:13325
+msgid "Foreground transparency"
+msgstr "Foreground Transparency"
+
+#: id:13326
+msgid "A/V delay"
+msgstr "A/V malfruiĝo"
+
+#: id:13327
+msgid "Karaoke"
+msgstr "Karaoke"
+
+#: id:13328
+msgid "%s not found"
+msgstr "%s not found"
+
+#: id:13329
+msgid "Error opening %s"
+msgstr "Eraro opening %s"
+
+#: id:13330
+msgid "Unable to load %s"
+msgstr "Unable to load %s"
+
+#: id:13331
+msgid "Error: Out of memory"
+msgstr "Eraro: out of memory"
+
+#: id:13332
+msgid "Move up"
+msgstr "Movi Up"
+
+#: id:13333
+msgid "Move down"
+msgstr "Movi Down"
+
+#: id:13334
+msgid "Edit label"
+msgstr "Editii Label"
+
+#: id:13335
+msgid "Make default"
+msgstr "Make Default"
+
+#: id:13336
+msgid "Remove button"
+msgstr "ReMovi Button"
+
+#: id:13340
+msgid "Leave as is"
+msgstr "Leave As Is"
+
+#: id:13341
+msgid "Green"
+msgstr "Verda"
+
+#: id:13342
+msgid "Orange"
+msgstr "Orangxa"
+
+#: id:13343
+msgid "Red"
+msgstr "Rugxo"
+
+#: id:13344
+msgid "Cycle"
+msgstr "Cycle"
+
+#: id:13345
+msgid "Switch LED off on playback"
+msgstr "Switch LED off on Playback"
+
+#: id:13346
+msgctxt "Auto context with id 13346"
+msgid "Movie information"
+msgstr "Filmoj info"
+
+#: id:13347
+msgid "Queue item"
+msgstr "Queue Item"
+
+#: id:13348
+msgid "Search IMDb..."
+msgstr "Skani IMDb..."
+
+#: id:13349
+msgid "Scan for new content"
+msgstr "Query Info For ĉiom vicos"
+
+#: id:13350
+msgid "Now playing..."
+msgstr "Now Playing..."
+
+#: id:13351
+msgctxt "Auto context with id 13351"
+msgid "Album information"
+msgstr "Albumo informaĵo"
+
+#: id:13352
+msgid "Scan item to library"
+msgstr "Scan ĉiom to Datinbanko"
+
+#: id:13353
+msgid "Stop scanning"
+msgstr "Stop Scanning"
+
+#: id:13354
+msgctxt "Auto context with id 13354"
+msgid "Render method"
+msgstr "Render Method"
+
+#: id:13355
+msgid "Low quality pixel shader"
+msgstr "Low Quality Pixel Shader"
+
+#: id:13356
+msgid "Hardware overlays"
+msgstr "Hardware Overlays"
+
+#: id:13357
+msgid "High quality pixel shader"
+msgstr "High Quality Pixel Shader"
+
+#: id:13358
+msgid "Play item"
+msgstr "Play Item"
+
+#: id:13359
+msgid "Set artist thumb"
+msgstr "Set Artist Thumb"
+
+#: id:13360
+msgid "Automatically generate thumbnails"
+msgstr "Generate Thumbs"
+
+#: id:13361
+msgid "Enable voice"
+msgstr "Enable Voice"
+
+#: id:13375
+msgid "Enable device"
+msgstr "Enable Device"
+
+#: id:13376
+msgid "Volume"
+msgstr "Volume"
+
+#: id:13377
+msgid "Default view mode"
+msgstr "Default Vido Mode"
+
+#: id:13378
+msgid "Default brightness"
+msgstr "Default Brightness"
+
+#: id:13379
+msgid "Default contrast"
+msgstr "Default Contrast"
+
+#: id:13380
+msgid "Default gamma"
+msgstr "Default Gamma"
+
+#: id:13381
+msgid "Resume video"
+msgstr "Resume Filmoj"
+
+#: id:13382
+msgid "Voice mask - Port 1"
+msgstr "Voice Mpeti - Port 1"
+
+#: id:13383
+msgid "Voice mask - Port 2"
+msgstr "Voice Mpeti - Port 2"
+
+#: id:13384
+msgid "Voice mask - Port 3"
+msgstr "Voice Mpeti - Port 3"
+
+#: id:13385
+msgid "Voice mask - Port 4"
+msgstr "Voice Mpeti - Port 4"
+
+#: id:13386
+msgid "Use time based seeking"
+msgstr "Use Time Based Seeking"
+
+#: id:13387
+msgid "Track naming template - right"
+msgstr "Track Naming Template Right"
+
+#: id:13388
+msgid "Preset"
+msgstr "Presets"
+
+#: id:13389
+msgid "There are no presets available\nfor this visualization"
+msgstr "Lare are no presets available for this visualisation"
+
+#: id:13390
+msgid "There are no settings available\nfor this visualization"
+msgstr "Lare are no Preferoj available for this visualisation"
+
+#: id:13391
+msgid "Eject/Load"
+msgstr "Eject/Load"
+
+#: id:13392
+msgid "Use visualization if playing audio"
+msgstr "Use Visualisation if playing audio"
+
+#: id:13393
+msgid "Calculate size"
+msgstr "Calculate amplekso"
+
+#: id:13394
+msgid "Calculating folder size"
+msgstr "Calculating folder amplekso"
+
+#: id:13395
+msgid "Video settings"
+msgstr "Filmoj Preferoj"
+
+#: id:13396
+msgid "Audio and subtitle settings"
+msgstr "Audio and Subtitle Preferoj"
+
+#: id:13397
+msgid "Enable subtitles"
+msgstr "Enable Subtitles"
+
+#: id:13398
+msgctxt "Auto context with id 13398"
+msgid "Shortcuts"
+msgstr "Bookmarks"
+
+#: id:13399
+msgid "Ignore articles when sorting (e.g. \"the\")"
+msgstr "Ignore \"La\" when sorting"
+
+#: id:13400
+msgid "Crossfade between songs on the same album"
+msgstr "Crossfade albumotracks"
+
+#: id:13401
+msgid "Browse for %s"
+msgstr "Foliumilo for %s"
+
+#: id:13402
+msgid "Show track position"
+msgstr "Show track position"
+
+#: id:13403
+msgid "Clear default"
+msgstr "Clear Default"
+
+#: id:13404
+msgid "Resume"
+msgstr "Resume"
+
+#: id:13405
+msgid "Get thumb"
+msgstr "Get Thumb"
+
+#: id:13406
+msgid "Picture information"
+msgstr ""
+
+#: id:13407
+msgid "%s presets"
+msgstr ""
+
+#: id:13408
+msgid "(IMDb user rating)"
+msgstr ""
+
+#: id:13409
+msgid "Top 250"
+msgstr ""
+
+#: id:13410
+msgid "Tune in on Last.fm"
+msgstr ""
+
+#: id:13411
+msgid "Minimum fan speed"
+msgstr ""
+
+#: id:13412
+msgid "Play from here"
+msgstr ""
+
+#: id:13413
+msgid "Downloading"
+msgstr ""
+
+#: id:13414
+msgid "Include artists who appear only on compilations"
+msgstr ""
+
+#: id:13415
+msgctxt "Auto context with id 13415"
+msgid "Render method"
+msgstr ""
+
+#: id:13416
+msgid "Auto detect"
+msgstr ""
+
+#: id:13417
+msgid "Basic shaders (ARB)"
+msgstr ""
+
+#: id:13418
+msgid "Advanced shaders (GLSL)"
+msgstr ""
+
+#: id:13419
+msgid "Software"
+msgstr ""
+
+#: id:13420
+msgid "Remove safely"
+msgstr ""
+
+#: id:13421
+msgctxt "Auto context with id 13421"
+msgid "VDPAU"
+msgstr ""
+
+#: id:13422
+msgid "Start slideshow here"
+msgstr ""
+
+#: id:13423
+msgid "Remember for this path"
+msgstr ""
+
+#: id:13424
+msgid "Use pixel buffer objects"
+msgstr ""
+
+#: id:13425
+msgid "Allow hardware acceleration (VDPAU)"
+msgstr ""
+
+#: id:13426
+msgid "Allow hardware acceleration (VAAPI)"
+msgstr ""
+
+#: id:13427
+msgid "Allow hardware acceleration (DXVA2)"
+msgstr ""
+
+#: id:13428
+msgid "Allow hardware acceleration (CrystalHD)"
+msgstr ""
+
+#: id:13429
+msgid "Allow hardware acceleration (VDADecoder)"
+msgstr ""
+
+#: id:13430
+msgid "Allow hardware acceleration (OpenMax)"
+msgstr ""
+
+#: id:13431
+msgid "Pixel Shaders"
+msgstr ""
+
+#: id:13432
+msgid "Allow hardware acceleration (VideoToolbox)"
+msgstr ""
+
+#: id:13500
+msgid "A/V sync method"
+msgstr ""
+
+#: id:13501
+msgid "Audio clock"
+msgstr ""
+
+#: id:13502
+msgid "Video clock (Drop/Dupe audio)"
+msgstr ""
+
+#: id:13503
+msgid "Video clock (Resample audio)"
+msgstr ""
+
+#: id:13504
+msgid "Maximum resample amount (%)"
+msgstr ""
+
+#: id:13505
+msgid "Resample quality"
+msgstr ""
+
+#: id:13506
+msgid "Low(fast)"
+msgstr ""
+
+#: id:13507
+msgctxt "Auto context with id 13507"
+msgid "Medium"
+msgstr ""
+
+#: id:13508
+msgctxt "Auto context with id 13508"
+msgid "High"
+msgstr ""
+
+#: id:13509
+msgid "Really high(slow!)"
+msgstr ""
+
+#: id:13510
+msgid "Sync playback to display"
+msgstr ""
+
+#: id:13550
+msgid "Pause during refresh rate change"
+msgstr ""
+
+#: id:13551
+msgctxt "Auto context with id 13551"
+msgid "Off"
+msgstr ""
+
+#: id:13552
+msgid "%.1f Second"
+msgstr ""
+
+#: id:13553
+msgid "%.1f Seconds"
+msgstr ""
+
+#: id:13600
+msgid "Apple remote"
+msgstr ""
+
+#: id:13602
+msgid "Allow start of XBMC using the remote"
+msgstr ""
+
+#: id:13603
+msgid "Sequence delay time"
+msgstr ""
+
+#: id:13610
+msgctxt "Auto context with id 13610"
+msgid "Disabled"
+msgstr ""
+
+#: id:13611
+msgctxt "Auto context with id 13611"
+msgid "Standard"
+msgstr ""
+
+#: id:13612
+msgid "Universal Remote"
+msgstr ""
+
+#: id:13613
+msgid "Multi Remote (Harmony)"
+msgstr ""
+
+#: id:13620
+msgid "Apple Remote Error"
+msgstr ""
+
+#: id:13621
+msgid "Apple Remote support could be enabled."
+msgstr ""
+
+#: id:14000
+msgid "Stack"
+msgstr "Stack"
+
+#: id:14001
+msgid "Unstack"
+msgstr "Unstack"
+
+#: id:14003
+msgid "Downloading playlist file..."
+msgstr "Downloading playlist vico..."
+
+#: id:14004
+msgid "Downloading streams list..."
+msgstr "Downloading streams list..."
+
+#: id:14005
+msgid "Parsing streams list..."
+msgstr "Parsing streams list..."
+
+#: id:14006
+msgid "Downloading streams list failed"
+msgstr "Downloading streams list failed"
+
+#: id:14007
+msgid "Downloading playlist file failed"
+msgstr "Downloading playlist vico failed"
+
+#: id:14009
+msgid "Games directory"
+msgstr "Games Directory"
+
+#: id:14010
+msgid "Auto switch to thumbs based on"
+msgstr "Autoswitch to Thumbs based on"
+
+#: id:14011
+msgid "Enable auto switching to thumbs view"
+msgstr "Enable Autoswitching to Thumbs Vido"
+
+#: id:14012
+msgid "- Use large icons"
+msgstr "- Use Large Icons"
+
+#: id:14013
+msgid "- Switch based on"
+msgstr "- Switch Based on"
+
+#: id:14014
+msgid "- Percentage"
+msgstr "- Percentage"
+
+#: id:14015
+msgid "No files and at least one thumb"
+msgstr "No vicos and at least one Thumb"
+
+#: id:14016
+msgid "At least one file and thumb"
+msgstr "At least one vico and Thumb"
+
+#: id:14017
+msgid "Percentage of thumbs"
+msgstr "Percentage of Thumbs"
+
+#: id:14018
+msgid "View options"
+msgstr "Vido Options"
+
+#: id:14019
+msgid "Change area code 1"
+msgstr "Change Area Code 1"
+
+#: id:14020
+msgid "Change area code 2"
+msgstr "Change Area Code 2"
+
+#: id:14021
+msgid "Change area code 3"
+msgstr "Change Area Code 3"
+
+#: id:14022
+msgctxt "Auto context with id 14022"
+msgid "Library"
+msgstr "Library"
+
+#: id:14023
+msgid "No TV"
+msgstr "No TV"
+
+#: id:14024
+msgid "Enter the nearest large town"
+msgstr "tajpi la nearest large town or US ZIP code"
+
+#: id:14025
+msgid "Video/Audio/DVD cache - Harddisk"
+msgstr "Filmoj/Audio/DVD Cache - Harddisk"
+
+#: id:14026
+msgid "Video cache - DVD-ROM"
+msgstr "Filmoj Cache - DVDRom"
+
+#: id:14027
+msgctxt "Auto context with id 14027"
+msgid "- Local Network"
+msgstr "- Local Network"
+
+#: id:14028
+msgctxt "Auto context with id 14028"
+msgid "- Internet"
+msgstr "- Internet"
+
+#: id:14030
+msgid "Audio cache - DVD-ROM"
+msgstr "Audio Cache - DVDRom"
+
+#: id:14031
+msgctxt "Auto context with id 14031"
+msgid "- Local Network"
+msgstr "- Local Network"
+
+#: id:14032
+msgctxt "Auto context with id 14032"
+msgid "- Internet"
+msgstr "- Internet"
+
+#: id:14034
+msgid "DVD cache - DVD-ROM"
+msgstr "DVD Cache - DVDRom"
+
+#: id:14035
+msgctxt "Auto context with id 14035"
+msgid "- Local Network"
+msgstr "- Local Network"
+
+#: id:14036
+msgctxt "Auto context with id 14036"
+msgid "Services"
+msgstr "Servers"
+
+#: id:14038
+msgid "Network settings changed"
+msgstr "Network Preferoj changed"
+
+#: id:14039
+msgid "XBMC requires to restart to change your"
+msgstr "XBMC requires to restart to change your"
+
+#: id:14040
+msgid "network setup. Would you like to restart now?"
+msgstr "network setup. Would you like to restart now?"
+
+#: id:14041
+msgid "Internet connection bandwidth limitation"
+msgstr "Post Processing"
+
+#: id:14043
+msgid "- Shutdown while playing"
+msgstr "- Shutdown while playing"
+
+#: id:14044
+msgid "%i min"
+msgstr "%i mins"
+
+#: id:14045
+msgid "%i sec"
+msgstr "%i secs"
+
+#: id:14046
+msgid "%i ms"
+msgstr "%i ms"
+
+#: id:14047
+msgid "%i %%"
+msgstr "%i %%"
+
+#: id:14048
+msgid "%i kbps"
+msgstr "%i kbps"
+
+#: id:14049
+msgid "%i kb"
+msgstr "%i kb"
+
+#: id:14050
+msgid "%i.0 dB"
+msgstr "%i.0 dB"
+
+#: id:14051
+msgid "Time format"
+msgstr "Time Format"
+
+#: id:14052
+msgid "Date format"
+msgstr "Dati Format"
+
+#: id:14053
+msgid "GUI filters"
+msgstr "GUI Filters"
+
+#: id:14055
+msgid "Use background scanning"
+msgstr "Use Background Scanning"
+
+#: id:14056
+msgid "Stop scan"
+msgstr "Stop Scan"
+
+#: id:14057
+msgid "Not possible while scanning for media info"
+msgstr "Not possible while scanning for media info"
+
+#: id:14058
+msgid "Film grain effect"
+msgstr "Film Grain Effect"
+
+#: id:14059
+msgid "Search for thumbnails on remote shares"
+msgstr "Look for custom thumbnails on remote shares"
+
+#: id:14060
+msgid "Unknown type cache - Internet"
+msgstr "Unknown type Cache - Internet"
+
+#: id:14061
+msgctxt "Auto context with id 14061"
+msgid "Auto"
+msgstr "Auto"
+
+#: id:14062
+msgid "Enter username for"
+msgstr "tajpi uzulonomo for"
+
+#: id:14063
+msgid "Date & time"
+msgstr "Dati & Time"
+
+#: id:14064
+msgid "Set date"
+msgstr "Set Dati"
+
+#: id:14065
+msgid "Set time"
+msgstr "Set Time"
+
+#: id:14066
+msgid "Enter the time in 24 hour HH:MM format"
+msgstr "tajpi la Time in 24 hour HH:MM format"
+
+#: id:14067
+msgid "Enter the date in DD/MM/YYYY format"
+msgstr "tajpi la Dati in DD/MM/YYYY format"
+
+#: id:14068
+msgid "Enter the IP address"
+msgstr "tajpi la IP address"
+
+#: id:14069
+msgid "Apply these settings now?"
+msgstr "Apply lase Preferoj now?"
+
+#: id:14070
+msgid "Apply changes now"
+msgstr "Apply Changes Now"
+
+#: id:14071
+msgid "Allow file renaming and deletion"
+msgstr "ĉiomow vico Renaming and Deletion"
+
+#: id:14074
+msgid "Set timezone"
+msgstr ""
+
+#: id:14075
+msgid "Use daylight saving time"
+msgstr ""
+
+#: id:14076
+msgid "Add to favourites"
+msgstr ""
+
+#: id:14077
+msgid "Remove from favourites"
+msgstr ""
+
+#: id:14078
+msgctxt "Auto context with id 14078"
+msgid "- Colours"
+msgstr ""
+
+#: id:14079
+msgid "Timezone country"
+msgstr ""
+
+#: id:14080
+msgid "Timezone"
+msgstr ""
+
+#: id:14081
+msgid "File lists"
+msgstr ""
+
+#: id:14082
+msgid "Show EXIF picture information"
+msgstr ""
+
+#: id:14083
+msgid "Use a fullscreen window rather than true fullscreen"
+msgstr ""
+
+#: id:14084
+msgid "Queue songs on selection"
+msgstr ""
+
+#: id:14086
+msgid "Playback"
+msgstr ""
+
+#: id:14087
+msgid "DVDs"
+msgstr ""
+
+#: id:14088
+msgid "Play DVDs automatically"
+msgstr ""
+
+#: id:14089
+msgid "Font to use for text subtitles"
+msgstr ""
+
+#: id:14090
+msgid "International"
+msgstr ""
+
+#: id:14091
+msgid "Character set"
+msgstr ""
+
+#: id:14092
+msgid "Debugging"
+msgstr ""
+
+#: id:14093
+msgid "Security"
+msgstr ""
+
+#: id:14094
+msgid "Input devices"
+msgstr ""
+
+#: id:14095
+msgid "Power saving"
+msgstr ""
+
+#: id:14096
+msgid "Rip"
+msgstr ""
+
+#: id:14097
+msgid "Audio CD Insert Action"
+msgstr ""
+
+#: id:14098
+msgctxt "Auto context with id 14098"
+msgid "Play"
+msgstr ""
+
+#: id:14099
+msgid "Eject disc when CD ripping is complete"
+msgstr ""
+
+#: id:15015
+msgctxt "Auto context with id 15015"
+msgid "Remove"
+msgstr "ReMovi"
+
+#: id:15016
+msgid "Games"
+msgstr "Games"
+
+#: id:15019
+msgid "Add"
+msgstr "Add"
+
+#: id:15052
+msgid "Password"
+msgstr "pasvorto"
+
+#: id:15100
+msgctxt "Auto context with id 15100"
+msgid "Library"
+msgstr "Library"
+
+#: id:15101
+msgid "Database"
+msgstr "Datinbanko"
+
+#: id:15102
+msgid "* All albums"
+msgstr "* ĉiom Albumos"
+
+#: id:15103
+msgid "* All artists"
+msgstr "* ĉiom Artists"
+
+#: id:15104
+msgid "* All songs"
+msgstr "* ĉiom kantoj"
+
+#: id:15105
+msgid "* All genres"
+msgstr "* ĉiom Gxenroj"
+
+#: id:15107
+msgid "Buffering..."
+msgstr "Buffering..."
+
+#: id:15108
+msgid "Navigation sounds"
+msgstr "Navigation Sounds"
+
+#: id:15109
+msgid "Skin default"
+msgstr "Skin Default"
+
+#: id:15111
+msgid "- Theme"
+msgstr "Skin Lame"
+
+#: id:15112
+msgid "Default theme"
+msgstr "Default Lame"
+
+#: id:15200
+msgid "Last.fm"
+msgstr "LastFM"
+
+#: id:15201
+msgid "Submit songs to Last.fm"
+msgstr "Submit kantoj to LastFM"
+
+#: id:15202
+msgid "Last.fm username"
+msgstr "LastFM Uzulonomo"
+
+#: id:15203
+msgid "Last.fm password"
+msgstr "LastFM pasvorto"
+
+#: id:15204
+msgid "Unable to handshake: sleeping..."
+msgstr "Unable to handshake: sleeping..."
+
+#: id:15205
+msgid "Please update XBMC"
+msgstr "Plaĉi Updati XBMC"
+
+#: id:15206
+msgid "Bad authorization: Check username and password"
+msgstr "Submission failed: bad authorization."
+
+#: id:15207
+msgctxt "Auto context with id 15207"
+msgid "Connected"
+msgstr "Connected"
+
+#: id:15208
+msgid "Not connected"
+msgstr "Not Connected"
+
+#: id:15209
+msgid "Submit interval %i"
+msgstr "Submit Interval %i"
+
+#: id:15210
+msgid "Cached %i songs"
+msgstr "Cached %i kantoj"
+
+#: id:15211
+msgid "Submitting..."
+msgstr "Submitting..."
+
+#: id:15212
+msgid "Submitting in %i secs"
+msgstr "Submitting in %i secs"
+
+#: id:15213
+msgid "Play using..."
+msgstr "Play Using..."
+
+#: id:15214
+msgid "Use smoothed A/V synchronization"
+msgstr "Use Smoolad A/V Syncronization"
+
+#: id:15215
+msgid "Hide file names in thumbs view"
+msgstr "Hide vico nomoj in Thumbs Vido"
+
+#: id:15216
+msgid "Play in party mode"
+msgstr ""
+
+#: id:15217
+msgid "Submit songs to Libre.fm"
+msgstr ""
+
+#: id:15218
+msgid "Libre.fm username"
+msgstr ""
+
+#: id:15219
+msgid "Libre.fm password"
+msgstr ""
+
+#: id:15220
+msgid "Libre.fm"
+msgstr ""
+
+#: id:15221
+msgid "Song submission"
+msgstr ""
+
+#: id:15250
+msgid "Submit Last.fm radio to Last.fm"
+msgstr "Submit Last.fm Radio to LastFM"
+
+#: id:15251
+msgid "Connecting to Last.fm..."
+msgstr "Connecting to Last.fm..."
+
+#: id:15252
+msgid "Selecting station..."
+msgstr "Elektiing station..."
+
+#: id:15253
+msgid "Search similar artists..."
+msgstr "Search similar artists..."
+
+#: id:15254
+msgid "Search similar tags..."
+msgstr "Search similar tags..."
+
+#: id:15255
+msgid "Your profile (%name%)"
+msgstr "Via logxas (%nomo%)"
+
+#: id:15256
+msgid "Overall top tags"
+msgstr "Overĉiom top tags"
+
+#: id:15257
+msgid "Top artists for tag %name%"
+msgstr "Top artists for tag %nomo%"
+
+#: id:15258
+msgid "Top albums for tag %name%"
+msgstr "Top albumos for tag %nomo%"
+
+#: id:15259
+msgid "Top tracks for tag %name%"
+msgstr "Top tracks for tag %nomo%"
+
+#: id:15260
+msgid "Listen to tag %name% Last.fm radio"
+msgstr "aŭskulti to tag %nomo% last.fm radio"
+
+#: id:15261
+msgid "Similar artists as %name%"
+msgstr "Similar artists as %nomo%"
+
+#: id:15262
+msgid "Top %name% albums"
+msgstr "Top %nomo% albumos"
+
+#: id:15263
+msgid "Top %name% tracks"
+msgstr "Top %nomo% tracks"
+
+#: id:15264
+msgid "Top %name% tags"
+msgstr "Top %nomo% tags"
+
+#: id:15265
+msgid "Biggest fans of %name%"
+msgstr "Pligranda fans of %nomo%"
+
+#: id:15266
+msgid "Listen to %name% fans Last.fm radio"
+msgstr "aŭskulti to %nomo% fans last.fm radio"
+
+#: id:15267
+msgid "Listen to %name% similar artists Last.fm radio"
+msgstr "aŭskulti to %nomo% similar artists last.fm radio"
+
+#: id:15268
+msgid "Top artists for user %name%"
+msgstr "Top artists for uzulo %nomo%"
+
+#: id:15269
+msgid "Top albums for user %name%"
+msgstr "Top albumos for uzulo %nomo%"
+
+#: id:15270
+msgid "Top tracks for user %name%"
+msgstr "Top tracks for uzulo %nomo%"
+
+#: id:15271
+msgid "Friends of user %name%"
+msgstr "Amikoj of uzulo %nomo%"
+
+#: id:15272
+msgid "Neighbours of user %name%"
+msgstr "Najboroj of uzulo %nomo%"
+
+#: id:15273
+msgid "Weekly artist chart for %name%"
+msgstr "Weekly artist chart for %nomo%"
+
+#: id:15274
+msgid "Weekly album chart for %name%"
+msgstr "Weekly albumo chart for %nomo%"
+
+#: id:15275
+msgid "Weekly track chart for %name%"
+msgstr "Weekly track chart for %nomo%"
+
+#: id:15276
+msgid "Listen to %name%'s neighbours Last.fm radio"
+msgstr "aŭskulti to %nomo% naboroja last.fm radio"
+
+#: id:15277
+msgid "Listen to %name%'s personal Last.fm radio"
+msgstr "aŭskulti to %nomo% personal last.fm radio"
+
+#: id:15278
+msgid "Listen to %name%'s mix Last.fm radio"
+msgstr "aŭskulti to %nomo% amas kanto last.fm radio"
+
+#: id:15279
+msgid "Retrieving list from Last.fm..."
+msgstr "Retrieving list from last.fm..."
+
+#: id:15280
+msgid "Can't retrieve list from Last.fm..."
+msgstr "Can't retrieve list from last.fm..."
+
+#: id:15281
+msgid "Enter an artist name to find related ones"
+msgstr "tajpi la artisto nomo to find related ones"
+
+#: id:15282
+msgid "Enter a tag name to find similar ones"
+msgstr "tajpi a tag nomo to find similar ones"
+
+#: id:15283
+msgid "Tracks recently listened by %name%"
+msgstr "Kanto lastatempe aŭskultas by %nomo%"
+
+#: id:15284
+msgid "Listen to %name%'s recommendations Last.fm radio"
+msgstr ""
+
+#: id:15285
+msgid "Top tags for user %name%"
+msgstr ""
+
+#: id:15287
+msgid "Do you want to add the current track to your loved tracks?"
+msgstr ""
+
+#: id:15288
+msgid "Do you want to ban the current track?"
+msgstr ""
+
+#: id:15289
+msgid "Added to your loved tracks: '%s'."
+msgstr ""
+
+#: id:15290
+msgid "Could not add '%s' to your loved tracks."
+msgstr ""
+
+#: id:15291
+msgid "Banned: '%s'."
+msgstr ""
+
+#: id:15292
+msgid "Could not ban '%s'."
+msgstr ""
+
+#: id:15293
+msgid "Tracks recently loved by %name%"
+msgstr ""
+
+#: id:15294
+msgid "Tracks recently banned by %name%"
+msgstr ""
+
+#: id:15295
+msgid "Remove from loved tracks"
+msgstr ""
+
+#: id:15296
+msgid "Un-ban"
+msgstr ""
+
+#: id:15297
+msgid "Do you want to remove this track from your loved tracks?"
+msgstr ""
+
+#: id:15298
+msgid "Do you want to un-ban this track?"
+msgstr ""
+
+#: id:15300
+msgid "Path not found or invalid"
+msgstr "Path not found or invalid"
+
+#: id:15301
+msgid "Could not connect to network server"
+msgstr "Could not connect to network server"
+
+#: id:15302
+msgid "No servers found"
+msgstr "No servers found"
+
+#: id:15303
+msgid "Workgroup not found"
+msgstr "Workgroup not found"
+
+#: id:15310
+msgid "Opening multi-path source"
+msgstr "Opening multi-path bookmark"
+
+#: id:15311
+msgid "Path:"
+msgstr "Path:"
+
+#: id:16000
+msgctxt "Auto context with id 16000"
+msgid "General"
+msgstr "Generalo"
+
+#: id:16002
+msgid "Internet lookup"
+msgstr "CDDB lookup"
+
+#: id:16003
+msgid "Player"
+msgstr "Player"
+
+#: id:16004
+msgid "Play media from disc"
+msgstr "Play media from KD"
+
+#: id:16008
+msgid "Enter new title"
+msgstr ""
+
+#: id:16009
+msgid "Enter the movie name"
+msgstr "Tajpi la Filmo Nomo"
+
+#: id:16010
+msgid "Enter the profile name"
+msgstr "Tajpi la Provico Nomo"
+
+#: id:16011
+msgid "Enter the album name"
+msgstr "Tajpi la Albumo Nomo"
+
+#: id:16012
+msgid "Enter the playlist name"
+msgstr "Tajpi la Playlist Nomo"
+
+#: id:16013
+msgid "Enter new filename"
+msgstr "Tajpi new viconomo"
+
+#: id:16014
+msgid "Enter folder name"
+msgstr "Tajpi folder nomo"
+
+#: id:16015
+msgid "Enter directory"
+msgstr "Tajpi directory"
+
+#: id:16016
+msgid "Available options: %A, %T, %N, %B, %D, %G, %Y, %F, %S"
+msgstr "Available options: %A, %T, %N, %B, %D, %G, %Y, %F, %S"
+
+#: id:16017
+msgid "Enter search string"
+msgstr "Tajpi Search String"
+
+#: id:16018
+msgctxt "Auto context with id 16018"
+msgid "None"
+msgstr "None"
+
+#: id:16019
+msgid "Auto select"
+msgstr "Auto Elekti"
+
+#: id:16020
+msgid "De-interlace"
+msgstr "DeInterlace"
+
+#: id:16021
+msgid "Bob"
+msgstr "Sync Odd"
+
+#: id:16022
+msgid "Bob (inverted)"
+msgstr "Sync Even"
+
+#: id:16024
+msgid "Canceling..."
+msgstr "Canceling..."
+
+#: id:16025
+msgid "Enter the artist name"
+msgstr "tajpi la Artist Nomo"
+
+#: id:16026
+msgid "Playback failed"
+msgstr "Playlist playback aborted"
+
+#: id:16027
+msgid "One or more items failed to play."
+msgstr "Too many consecutive failed items"
+
+#: id:16028
+msgid "Enter value"
+msgstr ""
+
+#: id:16029
+msgid "Check the log file for details."
+msgstr ""
+
+#: id:16030
+msgid "Party mode aborted."
+msgstr "Festo Mode mode aborted."
+
+#: id:16031
+msgid "No matching songs in the library."
+msgstr "Ne matching kantoj in la datinbanko."
+
+#: id:16032
+msgid "Could not initialize database."
+msgstr "Could not initialise datinbanko."
+
+#: id:16033
+msgid "Could not open database."
+msgstr "Could not open datinbanko."
+
+#: id:16034
+msgid "Could not get songs from database."
+msgstr "Could not get kantoj from datinbanko."
+
+#: id:16035
+msgid "Party mode playlist"
+msgstr ""
+
+#: id:16036
+msgid "De-interlace (Half)"
+msgstr ""
+
+#: id:16037
+msgid "Deinterlace video"
+msgstr ""
+
+#: id:16038
+msgid "Deinterlace method"
+msgstr ""
+
+#: id:16039
+msgctxt "Auto context with id 16039"
+msgid "Off"
+msgstr ""
+
+#: id:16040
+msgctxt "Auto context with id 16040"
+msgid "Auto"
+msgstr ""
+
+#: id:16041
+msgid "On"
+msgstr ""
+
+#: id:16100
+msgid "All Videos"
+msgstr "ĉiom Filmoj"
+
+#: id:16101
+msgid "Unwatched"
+msgstr "UnWatched"
+
+#: id:16102
+msgid "Watched"
+msgstr "Watched"
+
+#: id:16103
+msgid "Mark as watched"
+msgstr "Mark as vidas"
+
+#: id:16104
+msgid "Mark as unwatched"
+msgstr "Mark as malvidas"
+
+#: id:16105
+msgid "Edit title"
+msgstr "Editi Nomo"
+
+#: id:16200
+msgid "Operation was aborted"
+msgstr ""
+
+#: id:16201
+msgid "Copy failed"
+msgstr ""
+
+#: id:16202
+msgid "Failed to copy at least one file"
+msgstr ""
+
+#: id:16203
+msgid "Move failed"
+msgstr ""
+
+#: id:16204
+msgid "Failed to move at least one file"
+msgstr ""
+
+#: id:16205
+msgid "Delete failed"
+msgstr ""
+
+#: id:16206
+msgid "Failed to delete at least one file"
+msgstr ""
+
+#: id:16300
+msgid "Video scaling method"
+msgstr ""
+
+#: id:16301
+msgid "Nearest neighbour"
+msgstr ""
+
+#: id:16302
+msgid "Bilinear"
+msgstr ""
+
+#: id:16303
+msgctxt "Auto context with id 16303"
+msgid "Bicubic"
+msgstr ""
+
+#: id:16304
+msgid "Lanczos2"
+msgstr ""
+
+#: id:16305
+msgid "Lanczos3"
+msgstr ""
+
+#: id:16306
+msgid "Sinc8"
+msgstr ""
+
+#: id:16307
+msgid "Bicubic (software)"
+msgstr ""
+
+#: id:16308
+msgid "Lanczos (software)"
+msgstr ""
+
+#: id:16309
+msgid "Sinc (software)"
+msgstr ""
+
+#: id:16310
+msgid "Temporal"
+msgstr ""
+
+#: id:16311
+msgid "Temporal/Spatial"
+msgstr ""
+
+#: id:16312
+msgid "(VDPAU)Noise Reduction"
+msgstr ""
+
+#: id:16313
+msgid "(VDPAU)Sharpness"
+msgstr ""
+
+#: id:16314
+msgid "Inverse Telecine"
+msgstr ""
+
+#: id:16315
+msgid "Lanczos3 optimized"
+msgstr ""
+
+#: id:16316
+msgctxt "Auto context with id 16316"
+msgid "Auto"
+msgstr ""
+
+#: id:16317
+msgid "Temporal (Half)"
+msgstr ""
+
+#: id:16318
+msgid "Temporal/Spatial (Half)"
+msgstr ""
+
+#: id:16319
+msgid "DXVA"
+msgstr ""
+
+#: id:16320
+msgid "DXVA Bob"
+msgstr ""
+
+#: id:16321
+msgid "DXVA Best"
+msgstr ""
+
+#: id:16322
+msgid "Spline36"
+msgstr ""
+
+#: id:16323
+msgid "Spline36 optimized"
+msgstr ""
+
+#: id:16324
+msgid "Software Blend"
+msgstr ""
+
+#: id:16400
+msgid "Post-processing"
+msgstr ""
+
+#: id:17500
+msgid "Display sleep timeout"
+msgstr ""
+
+#: id:19000
+msgid "Switch to channel"
+msgstr ""
+
+#: id:20000
+msgid "Saved music folder"
+msgstr ""
+
+#: id:20001
+msgid "Use external DVD player"
+msgstr ""
+
+#: id:20002
+msgid "External DVD player"
+msgstr ""
+
+#: id:20003
+msgid "Trainers folder"
+msgstr ""
+
+#: id:20004
+msgid "Screenshot folder"
+msgstr ""
+
+#: id:20006
+msgid "Playlists folder"
+msgstr ""
+
+#: id:20007
+msgid "Recordings"
+msgstr ""
+
+#: id:20008
+msgid "Screenshots"
+msgstr ""
+
+#: id:20009
+msgid "Use XBMC"
+msgstr ""
+
+#: id:20011
+msgid "Music playlists"
+msgstr ""
+
+#: id:20012
+msgid "Video playlists"
+msgstr ""
+
+#: id:20013
+msgid "Do you wish to launch the game?"
+msgstr ""
+
+#: id:20014
+msgid "Sort by: Playlist"
+msgstr ""
+
+#: id:20015
+msgid "Remote thumb"
+msgstr ""
+
+#: id:20016
+msgid "Current thumb"
+msgstr ""
+
+#: id:20017
+msgid "Local thumb"
+msgstr ""
+
+#: id:20018
+msgid "No thumb"
+msgstr ""
+
+#: id:20019
+msgid "Choose thumbnail"
+msgstr ""
+
+#: id:20023
+msgid "Conflict"
+msgstr ""
+
+#: id:20024
+msgid "Scan new"
+msgstr ""
+
+#: id:20025
+msgid "Scan all"
+msgstr ""
+
+#: id:20026
+msgid "Region"
+msgstr ""
+
+#: id:20037
+msgid "Summary"
+msgstr ""
+
+#: id:20038
+msgid "Lock music window"
+msgstr ""
+
+#: id:20039
+msgid "Lock videos window"
+msgstr ""
+
+#: id:20040
+msgid "Lock pictures window"
+msgstr ""
+
+#: id:20041
+msgid "Lock programs & scripts windows"
+msgstr ""
+
+#: id:20042
+msgid "Lock file manager"
+msgstr ""
+
+#: id:20043
+msgid "Lock settings"
+msgstr ""
+
+#: id:20044
+msgid "Start fresh"
+msgstr ""
+
+#: id:20045
+msgid "Enter master mode"
+msgstr ""
+
+#: id:20046
+msgid "Leave master mode"
+msgstr ""
+
+#: id:20047
+msgid "Create profile '%s'?"
+msgstr ""
+
+#: id:20048
+msgid "Start with fresh settings"
+msgstr ""
+
+#: id:20049
+msgid "Best available"
+msgstr ""
+
+#: id:20050
+msgid "Auto-switch between 16x9 and 4x3"
+msgstr ""
+
+#: id:20051
+msgid "Treat stacked files as single file"
+msgstr ""
+
+#: id:20052
+msgid "Caution"
+msgstr ""
+
+#: id:20053
+msgid "Left master mode"
+msgstr ""
+
+#: id:20054
+msgid "Entered master mode"
+msgstr ""
+
+#: id:20055
+msgid "Allmusic.com thumb"
+msgstr ""
+
+#: id:20057
+msgid "Remove thumbnail"
+msgstr ""
+
+#: id:20058
+msgid "Add profile..."
+msgstr ""
+
+#: id:20059
+msgid "Query info for all albums"
+msgstr ""
+
+#: id:20060
+msgctxt "Auto context with id 20060"
+msgid "Media info"
+msgstr ""
+
+#: id:20061
+msgctxt "Auto context with id 20061"
+msgid "Separate"
+msgstr ""
+
+#: id:20062
+msgid "Shares with default"
+msgstr ""
+
+#: id:20063
+msgid "Shares with default (read only)"
+msgstr ""
+
+#: id:20064
+msgid "Copy default"
+msgstr ""
+
+#: id:20065
+msgid "Profile picture"
+msgstr ""
+
+#: id:20066
+msgid "Lock preferences"
+msgstr ""
+
+#: id:20067
+msgid "Edit profile"
+msgstr ""
+
+#: id:20068
+msgid "Profile lock"
+msgstr ""
+
+#: id:20069
+msgid "Could not create folder"
+msgstr ""
+
+#: id:20070
+msgid "Profile directory"
+msgstr ""
+
+#: id:20071
+msgid "Start with fresh media sources"
+msgstr ""
+
+#: id:20072
+msgid "Make sure the selected folder is writable"
+msgstr ""
+
+#: id:20073
+msgid "and that the new folder name is valid"
+msgstr ""
+
+#: id:20074
+msgid "MPAA rating"
+msgstr ""
+
+#: id:20075
+msgid "Enter master lock code"
+msgstr ""
+
+#: id:20076
+msgid "Ask for master lock code on startup"
+msgstr ""
+
+#: id:20077
+msgid "Skin settings"
+msgstr ""
+
+#: id:20078
+msgid "- no link set -"
+msgstr ""
+
+#: id:20079
+msgid "Enable animations"
+msgstr ""
+
+#: id:20080
+msgid "Disable RSS during music"
+msgstr ""
+
+#: id:20081
+msgid "Enable shortcut buttons"
+msgstr ""
+
+#: id:20082
+msgid "Show programs in main menu"
+msgstr ""
+
+#: id:20083
+msgid "Show music info"
+msgstr ""
+
+#: id:20084
+msgid "Show weather info"
+msgstr ""
+
+#: id:20085
+msgid "Show system info"
+msgstr ""
+
+#: id:20086
+msgid "Show available disc space C: E: F:"
+msgstr ""
+
+#: id:20087
+msgid "Show available disc space E: F: G:"
+msgstr ""
+
+#: id:20088
+msgid "Weather info"
+msgstr ""
+
+#: id:20089
+msgid "Drive space free"
+msgstr ""
+
+#: id:20090
+msgid "Enter the name of an existing share"
+msgstr ""
+
+#: id:20091
+msgid "Lock code"
+msgstr ""
+
+#: id:20092
+msgid "Load profile"
+msgstr ""
+
+#: id:20093
+msgid "Profile name"
+msgstr ""
+
+#: id:20094
+msgctxt "Auto context with id 20094"
+msgid "Media sources"
+msgstr ""
+
+#: id:20095
+msgid "Enter profile lock code"
+msgstr ""
+
+#: id:20096
+msgctxt "Auto context with id 20096"
+msgid "Login screen"
+msgstr ""
+
+#: id:20097
+msgid "Fetching album info"
+msgstr ""
+
+#: id:20098
+msgid "Fetching info for album"
+msgstr ""
+
+#: id:20099
+msgid "Can't rip CD or track while playing from CD"
+msgstr ""
+
+#: id:20100
+msgid "Master lock code and settings"
+msgstr ""
+
+#: id:20101
+msgid "Entering master lock code always enables master mode"
+msgstr ""
+
+#: id:20102
+msgid "or copy from default?"
+msgstr ""
+
+#: id:20103
+msgid "Save changes to profile?"
+msgstr ""
+
+#: id:20104
+msgid "Old settings found."
+msgstr ""
+
+#: id:20105
+msgid "Do you want to use them?"
+msgstr ""
+
+#: id:20106
+msgid "Old media sources found."
+msgstr ""
+
+#: id:20107
+msgid "Separate (locked)"
+msgstr ""
+
+#: id:20108
+msgid "Root"
+msgstr ""
+
+#: id:20109
+msgid "- Zoom"
+msgstr ""
+
+#: id:20110
+msgid "UPnP settings"
+msgstr ""
+
+#: id:20111
+msgid "Autostart UPnP client"
+msgstr ""
+
+#: id:20112
+msgid "Last login: %s"
+msgstr ""
+
+#: id:20113
+msgid "Never logged on"
+msgstr ""
+
+#: id:20114
+msgid "Profile %i / %i"
+msgstr ""
+
+#: id:20115
+msgid "User login / Select a profile"
+msgstr ""
+
+#: id:20116
+msgid "Use lock on login screen"
+msgstr ""
+
+#: id:20117
+msgid "Invalid lock code."
+msgstr ""
+
+#: id:20118
+msgid "This requires the master lock to be set."
+msgstr ""
+
+#: id:20119
+msgid "Would you like to set it now?"
+msgstr ""
+
+#: id:20120
+msgid "Loading program information"
+msgstr ""
+
+#: id:20121
+msgid "Party on!"
+msgstr ""
+
+#: id:20122
+msgid "True"
+msgstr ""
+
+#: id:20123
+msgid "Mixing drinks"
+msgstr ""
+
+#: id:20124
+msgid "Filling glasses"
+msgstr ""
+
+#: id:20125
+msgid "Logged on as"
+msgstr ""
+
+#: id:20126
+msgid "Log off"
+msgstr ""
+
+#: id:20128
+msgid "Go to root"
+msgstr ""
+
+#: id:20129
+msgid "Weave"
+msgstr ""
+
+#: id:20130
+msgid "Weave (inverted)"
+msgstr ""
+
+#: id:20131
+msgid "Blend"
+msgstr ""
+
+#: id:20132
+msgid "Restart video"
+msgstr ""
+
+#: id:20133
+msgid "Edit network location"
+msgstr ""
+
+#: id:20134
+msgid "Remove network location"
+msgstr ""
+
+#: id:20135
+msgid "Do you want to scan the folder?"
+msgstr ""
+
+#: id:20136
+msgid "Memory unit"
+msgstr ""
+
+#: id:20137
+msgid "Memory unit mounted"
+msgstr ""
+
+#: id:20138
+msgid "Unable to mount memory unit"
+msgstr ""
+
+#: id:20139
+msgid "In port %i, slot %i"
+msgstr ""
+
+#: id:20140
+msgid "Lock screensaver"
+msgstr ""
+
+#: id:20141
+msgid "Set"
+msgstr ""
+
+#: id:20142
+msgctxt "Auto context with id 20142"
+msgid "Username"
+msgstr ""
+
+#: id:20143
+msgid "Enter password for"
+msgstr ""
+
+#: id:20144
+msgid "Shutdown timer"
+msgstr ""
+
+#: id:20145
+msgid "Shutdown interval (in minutes)"
+msgstr ""
+
+#: id:20146
+msgid "Started, shutdown in %im"
+msgstr ""
+
+#: id:20147
+msgid "Shutdown in 30 minutes"
+msgstr ""
+
+#: id:20148
+msgid "Shutdown in 60 minutes"
+msgstr ""
+
+#: id:20149
+msgid "Shutdown in 120 minutes"
+msgstr ""
+
+#: id:20150
+msgid "Custom shutdown timer"
+msgstr ""
+
+#: id:20151
+msgid "Cancel shutdown timer"
+msgstr ""
+
+#: id:20152
+msgid "Lock preferences for %s"
+msgstr ""
+
+#: id:20153
+msgid "Browse..."
+msgstr ""
+
+#: id:20154
+msgid "Summary information"
+msgstr ""
+
+#: id:20155
+msgid "Storage information"
+msgstr ""
+
+#: id:20156
+msgid "Hard disk information"
+msgstr ""
+
+#: id:20157
+msgid "DVD-ROM information"
+msgstr ""
+
+#: id:20158
+msgid "Network information"
+msgstr ""
+
+#: id:20159
+msgid "Video information"
+msgstr ""
+
+#: id:20160
+msgid "Hardware information"
+msgstr ""
+
+#: id:20161
+msgid "Total"
+msgstr ""
+
+#: id:20162
+msgid "Used"
+msgstr ""
+
+#: id:20163
+msgid "of"
+msgstr ""
+
+#: id:20164
+msgid "Locking not supported"
+msgstr ""
+
+#: id:20165
+msgid "Not locked"
+msgstr ""
+
+#: id:20166
+msgid "Locked"
+msgstr ""
+
+#: id:20167
+msgid "Frozen"
+msgstr ""
+
+#: id:20168
+msgid "Requires reset"
+msgstr ""
+
+#: id:20169
+msgid "Week"
+msgstr ""
+
+#: id:20170
+msgid "Line"
+msgstr ""
+
+#: id:20171
+msgid "Windows network (SMB)"
+msgstr ""
+
+#: id:20172
+msgid "XBMSP server"
+msgstr ""
+
+#: id:20173
+msgctxt "Auto context with id 20173"
+msgid "FTP server"
+msgstr ""
+
+#: id:20174
+msgid "iTunes music share (DAAP)"
+msgstr ""
+
+#: id:20175
+msgid "UPnP server"
+msgstr ""
+
+#: id:20176
+msgid "Show video info"
+msgstr ""
+
+#: id:20177
+msgid "Done"
+msgstr ""
+
+#: id:20178
+msgid "Shift"
+msgstr ""
+
+#: id:20179
+msgid "Caps Lock"
+msgstr ""
+
+#: id:20180
+msgid "Symbols"
+msgstr ""
+
+#: id:20181
+msgid "Backspace"
+msgstr ""
+
+#: id:20182
+msgid "Space"
+msgstr ""
+
+#: id:20183
+msgid "Reload skin"
+msgstr ""
+
+#: id:20184
+msgid "Rotate pictures using EXIF information"
+msgstr ""
+
+#: id:20185
+msgid "Use poster view styles for TV shows"
+msgstr ""
+
+#: id:20186
+msgid "Please wait"
+msgstr ""
+
+#: id:20187
+msgid "UPnP"
+msgstr ""
+
+#: id:20189
+msgid "Enable auto scrolling for plot & review"
+msgstr ""
+
+#: id:20190
+msgctxt "Auto context with id 20190"
+msgid "Custom"
+msgstr ""
+
+#: id:20191
+msgid "Enable debug logging"
+msgstr ""
+
+#: id:20192
+msgid "Download additional information during updates"
+msgstr ""
+
+#: id:20193
+msgid "Default service for album information"
+msgstr ""
+
+#: id:20194
+msgid "Default service for artist information"
+msgstr ""
+
+#: id:20195
+msgid "Change scraper"
+msgstr ""
+
+#: id:20196
+msgid "Export music library"
+msgstr ""
+
+#: id:20197
+msgid "Import music library"
+msgstr ""
+
+#: id:20198
+msgid "No artist found!"
+msgstr ""
+
+#: id:20199
+msgid "Downloading artist info failed"
+msgstr ""
+
+#: id:20250
+msgid "Party on! (videos)"
+msgstr ""
+
+#: id:20251
+msgid "Mixing drinks (videos)"
+msgstr ""
+
+#: id:20252
+msgid "Filling glasses (videos)"
+msgstr ""
+
+#: id:20253
+msgid "WebDAV server (HTTP)"
+msgstr ""
+
+#: id:20254
+msgid "WebDAV server (HTTPS)"
+msgstr ""
+
+#: id:20255
+msgid "First logon, edit your profile"
+msgstr ""
+
+#: id:20256
+msgid "HTS Tvheadend client"
+msgstr ""
+
+#: id:20257
+msgid "VDR Streamdev client"
+msgstr ""
+
+#: id:20258
+msgid "MythTV client"
+msgstr ""
+
+#: id:20259
+msgid "Network Filesystem (NFS)"
+msgstr ""
+
+#: id:20260
+msgid "Secure Shell (SSH/SFTP)"
+msgstr ""
+
+#: id:20261
+msgid "Apple Filing Protocol (AFP)"
+msgstr ""
+
+#: id:20300
+msgid "Web server directory (HTTP)"
+msgstr ""
+
+#: id:20301
+msgid "Web server directory (HTTPS)"
+msgstr ""
+
+#: id:20302
+msgid "Unable to write to folder:"
+msgstr ""
+
+#: id:20303
+msgid "Do you want to skip and proceed?"
+msgstr ""
+
+#: id:20304
+msgid "RSS Feed"
+msgstr ""
+
+#: id:20307
+msgid "Secondary DNS"
+msgstr ""
+
+#: id:20308
+msgid "DHCP server:"
+msgstr ""
+
+#: id:20309
+msgid "Make new folder"
+msgstr ""
+
+#: id:20310
+msgid "Dim LCD on playback"
+msgstr ""
+
+#: id:20311
+msgid "Unknown or onboard (protected)"
+msgstr ""
+
+#: id:20312
+msgid "Dim LCD on paused"
+msgstr ""
+
+#: id:20314
+msgid "Videos - Library"
+msgstr ""
+
+#: id:20316
+msgid "Sort by: ID"
+msgstr ""
+
+#: id:20324
+msgid "Play part..."
+msgstr ""
+
+#: id:20325
+msgid "Calibration reset"
+msgstr ""
+
+#: id:20326
+msgid "This will reset the calibration values for %s"
+msgstr ""
+
+#: id:20327
+msgid "to it's default values."
+msgstr ""
+
+#: id:20328
+msgid "Browse for destination"
+msgstr ""
+
+#: id:20329
+msgid "Movies are in separate folders that match the movie title"
+msgstr ""
+
+#: id:20330
+msgid "Use folder names for lookups"
+msgstr ""
+
+#: id:20331
+msgctxt "Auto context with id 20331"
+msgid "File"
+msgstr ""
+
+#: id:20332
+msgid "Use file or folder names in lookups?"
+msgstr ""
+
+#: id:20333
+msgid "Set content"
+msgstr ""
+
+#: id:20334
+msgid "Folder"
+msgstr ""
+
+#: id:20335
+msgid "Look for content recursively?"
+msgstr ""
+
+#: id:20336
+msgid "Unlock sources"
+msgstr ""
+
+#: id:20337
+msgid "Actor"
+msgstr ""
+
+#: id:20338
+msgid "Movie"
+msgstr ""
+
+#: id:20339
+msgid "Director"
+msgstr ""
+
+#: id:20340
+msgid "Do you want to remove all items within"
+msgstr ""
+
+#: id:20341
+msgid "this path from the XBMC library?"
+msgstr ""
+
+#: id:20342
+msgctxt "Auto context with id 20342"
+msgid "Movies"
+msgstr ""
+
+#: id:20343
+msgid "TV shows"
+msgstr ""
+
+#: id:20344
+msgid "This directory contains"
+msgstr ""
+
+#: id:20345
+msgid "Run automated scan"
+msgstr ""
+
+#: id:20346
+msgid "Scan recursively"
+msgstr ""
+
+#: id:20347
+msgid "as"
+msgstr ""
+
+#: id:20348
+msgid "Directors"
+msgstr ""
+
+#: id:20349
+msgid "No video files found in this path!"
+msgstr ""
+
+#: id:20350
+msgid "votes"
+msgstr ""
+
+#: id:20351
+msgid "TV show information"
+msgstr ""
+
+#: id:20352
+msgid "Episode information"
+msgstr ""
+
+#: id:20353
+msgid "Loading TV show details"
+msgstr ""
+
+#: id:20354
+msgid "Fetching episode guide"
+msgstr ""
+
+#: id:20355
+msgid "Loading info for episodes in directory"
+msgstr ""
+
+#: id:20356
+msgid "Select TV show:"
+msgstr ""
+
+#: id:20357
+msgid "Enter the TV show name"
+msgstr ""
+
+#: id:20358
+msgid "Season %i"
+msgstr ""
+
+#: id:20359
+msgid "Episode"
+msgstr ""
+
+#: id:20360
+msgid "Episodes"
+msgstr ""
+
+#: id:20361
+msgid "Loading episode details"
+msgstr ""
+
+#: id:20362
+msgid "Remove episode from library"
+msgstr ""
+
+#: id:20363
+msgid "Remove TV show from library"
+msgstr ""
+
+#: id:20364
+msgid "TV show"
+msgstr ""
+
+#: id:20365
+msgid "Episode plot"
+msgstr ""
+
+#: id:20366
+msgid "* All seasons"
+msgstr ""
+
+#: id:20367
+msgid "Hide watched"
+msgstr ""
+
+#: id:20368
+msgid "Prod code"
+msgstr ""
+
+#: id:20369
+msgid "Show plot for unwatched items"
+msgstr ""
+
+#: id:20370
+msgid "* Hidden to prevent spoilers *"
+msgstr ""
+
+#: id:20371
+msgid "Set season thumb"
+msgstr ""
+
+#: id:20372
+msgid "Season image"
+msgstr ""
+
+#: id:20373
+msgid "Season"
+msgstr ""
+
+#: id:20374
+msgid "Downloading movie information"
+msgstr ""
+
+#: id:20375
+msgid "Unassign content"
+msgstr ""
+
+#: id:20376
+msgid "Original title"
+msgstr ""
+
+#: id:20377
+msgid "Refresh TV show information"
+msgstr ""
+
+#: id:20378
+msgid "Refresh info for all episodes?"
+msgstr ""
+
+#: id:20379
+msgid "Selected folder contains a single TV show"
+msgstr ""
+
+#: id:20380
+msgid "Exclude selected folder from scans"
+msgstr ""
+
+#: id:20381
+msgid "Specials"
+msgstr ""
+
+#: id:20382
+msgid "Automatically grab season thumbs"
+msgstr ""
+
+#: id:20383
+msgid "Selected folder contains a single video"
+msgstr ""
+
+#: id:20384
+msgid "Link to TV show"
+msgstr ""
+
+#: id:20385
+msgid "Remove link to TV show"
+msgstr ""
+
+#: id:20386
+msgid "Recently added movies"
+msgstr ""
+
+#: id:20387
+msgid "Recently added episodes"
+msgstr ""
+
+#: id:20388
+msgid "Studios"
+msgstr ""
+
+#: id:20389
+msgid "Music videos"
+msgstr ""
+
+#: id:20390
+msgid "Recently added music videos"
+msgstr ""
+
+#: id:20391
+msgid "Music video"
+msgstr ""
+
+#: id:20392
+msgid "Remove music video from library"
+msgstr ""
+
+#: id:20393
+msgctxt "Auto context with id 20393"
+msgid "Music video information"
+msgstr ""
+
+#: id:20394
+msgid "Loading music video information"
+msgstr ""
+
+#: id:20395
+msgid "Mixed"
+msgstr ""
+
+#: id:20396
+msgid "Go to albums by artist"
+msgstr ""
+
+#: id:20397
+msgid "Go to album"
+msgstr ""
+
+#: id:20398
+msgid "Play song"
+msgstr ""
+
+#: id:20399
+msgid "Go to music videos from album"
+msgstr ""
+
+#: id:20400
+msgid "Go to music videos by artist"
+msgstr ""
+
+#: id:20401
+msgid "Play music video"
+msgstr ""
+
+#: id:20402
+msgid "Download actor thumbnails when adding to library"
+msgstr ""
+
+#: id:20403
+msgid "Set actor thumb"
+msgstr ""
+
+#: id:20405
+msgid "Remove episode bookmark"
+msgstr ""
+
+#: id:20406
+msgid "Set episode bookmark"
+msgstr ""
+
+#: id:20407
+msgid "Scraper settings"
+msgstr ""
+
+#: id:20408
+msgid "Downloading music video information"
+msgstr ""
+
+#: id:20409
+msgid "Downloading TV show information"
+msgstr ""
+
+#: id:20410
+msgid "Trailer"
+msgstr ""
+
+#: id:20411
+msgid "Flatten"
+msgstr ""
+
+#: id:20412
+msgid "Flatten TV shows"
+msgstr ""
+
+#: id:20413
+msgid "Get fanart"
+msgstr ""
+
+#: id:20414
+msgid "Show Fanart in video and music libraries"
+msgstr ""
+
+#: id:20415
+msgid "Scanning for new content"
+msgstr ""
+
+#: id:20416
+msgid "First aired"
+msgstr ""
+
+#: id:20417
+msgid "Writer"
+msgstr ""
+
+#: id:20419
+msgid "Replace file names with library titles"
+msgstr ""
+
+#: id:20420
+msgctxt "Auto context with id 20420"
+msgid "Never"
+msgstr ""
+
+#: id:20421
+msgid "If only one season"
+msgstr ""
+
+#: id:20422
+msgid "Always"
+msgstr ""
+
+#: id:20423
+msgid "Has trailer"
+msgstr ""
+
+#: id:20424
+msgid "False"
+msgstr ""
+
+#: id:20425
+msgid "Fanart slideshow"
+msgstr ""
+
+#: id:20426
+msgid "Export to a single file or separate"
+msgstr ""
+
+#: id:20427
+msgid "files per entry?"
+msgstr ""
+
+#: id:20428
+msgid "Single file"
+msgstr ""
+
+#: id:20429
+msgctxt "Auto context with id 20429"
+msgid "Separate"
+msgstr ""
+
+#: id:20430
+msgid "Export thumbnails and fanart?"
+msgstr ""
+
+#: id:20431
+msgid "Overwrite old files?"
+msgstr ""
+
+#: id:20432
+msgid "Exclude path from library updates"
+msgstr ""
+
+#: id:20433
+msgid "Extract thumbnails and video information"
+msgstr ""
+
+#: id:20434
+msgid "Sets"
+msgstr ""
+
+#: id:20435
+msgid "Set movieset thumb"
+msgstr ""
+
+#: id:20436
+msgid "Export actor thumbs?"
+msgstr ""
+
+#: id:20437
+msgid "Choose fanart"
+msgstr ""
+
+#: id:20438
+msgid "Local fanart"
+msgstr ""
+
+#: id:20439
+msgid "No fanart"
+msgstr ""
+
+#: id:20440
+msgid "Current fanart"
+msgstr ""
+
+#: id:20441
+msgid "Remote fanart"
+msgstr ""
+
+#: id:20442
+msgid "Change content"
+msgstr ""
+
+#: id:20443
+msgid "Do you want to refresh info for all"
+msgstr ""
+
+#: id:20444
+msgid "items within this path?"
+msgstr ""
+
+#: id:20445
+msgid "Fanart"
+msgstr ""
+
+#: id:20446
+msgid "Locally stored information found."
+msgstr ""
+
+#: id:20447
+msgid "Ignore and refresh from internet?"
+msgstr ""
+
+#: id:20448
+msgid "Could not download information"
+msgstr ""
+
+#: id:20449
+msgid "Unable to connect to remote server"
+msgstr ""
+
+#: id:20450
+msgid "Would you like to continue scanning?"
+msgstr ""
+
+#: id:20451
+msgid "Countries"
+msgstr ""
+
+#: id:20452
+msgid "episode"
+msgstr ""
+
+#: id:20453
+msgid "episodes"
+msgstr ""
+
+#: id:20454
+msgid "Listener"
+msgstr ""
+
+#: id:20455
+msgid "Listeners"
+msgstr ""
+
+#: id:20456
+msgid "Set movieset fanart"
+msgstr ""
+
+#: id:20457
+msgid "Movie set"
+msgstr ""
+
+#: id:20458
+msgid "Group movies in sets"
+msgstr ""
+
+#: id:21330
+msgid "Show hidden files and directories"
+msgstr ""
+
+#: id:21331
+msgid "TuxBox client"
+msgstr ""
+
+#: id:21332
+msgid "WARNING: Target TuxBox device is in recording-mode!"
+msgstr ""
+
+#: id:21333
+msgid "The stream will be stopped!"
+msgstr ""
+
+#: id:21334
+msgid "Zap to channel: %s failed!"
+msgstr ""
+
+#: id:21335
+msgid "Are you sure to start the stream?"
+msgstr ""
+
+#: id:21336
+msgid "Connecting to: %s"
+msgstr ""
+
+#: id:21337
+msgid "TuxBox device"
+msgstr ""
+
+#: id:21359
+msgid "Add media share..."
+msgstr ""
+
+#: id:21360
+msgid "Share video and music libraries through UPnP"
+msgstr ""
+
+#: id:21364
+msgid "Edit media share"
+msgstr ""
+
+#: id:21365
+msgid "Remove media share"
+msgstr ""
+
+#: id:21366
+msgid "Subtitle folder"
+msgstr ""
+
+#: id:21367
+msgid "Movie & alternate subtitle directory"
+msgstr ""
+
+#: id:21368
+msgid "Override ASS/SSA subtitles fonts"
+msgstr ""
+
+#: id:21369
+msgid "Enable mouse and Touch Screen support"
+msgstr ""
+
+#: id:21370
+msgid "Play navigation sounds during media playback"
+msgstr ""
+
+#: id:21371
+msgid "Thumbnail"
+msgstr ""
+
+#: id:21372
+msgid "Forced DVD player region"
+msgstr ""
+
+#: id:21373
+msgid "Video output"
+msgstr ""
+
+#: id:21374
+msgid "Video aspect"
+msgstr ""
+
+#: id:21375
+msgctxt "Auto context with id 21375"
+msgid "Normal"
+msgstr ""
+
+#: id:21376
+msgid "Letterbox"
+msgstr ""
+
+#: id:21377
+msgid "Widescreen"
+msgstr ""
+
+#: id:21378
+msgid "Enable 480p"
+msgstr ""
+
+#: id:21379
+msgid "Enable 720p"
+msgstr ""
+
+#: id:21380
+msgid "Enable 1080i"
+msgstr ""
+
+#: id:21381
+msgid "Enter name of new playlist"
+msgstr ""
+
+#: id:21382
+msgid "Show \"Add source\" buttons in file lists"
+msgstr ""
+
+#: id:21383
+msgid "Enable scrollbars"
+msgstr ""
+
+#: id:21384
+msgid "Make watched filtering a toggle in video library"
+msgstr ""
+
+#: id:21385
+msgctxt "Auto context with id 21385"
+msgid "Open"
+msgstr ""
+
+#: id:21386
+msgid "Acoustic management level"
+msgstr ""
+
+#: id:21387
+msgid "Fast"
+msgstr ""
+
+#: id:21388
+msgid "Quiet"
+msgstr ""
+
+#: id:21389
+msgid "Enable custom background"
+msgstr ""
+
+#: id:21390
+msgid "Power management level"
+msgstr ""
+
+#: id:21391
+msgid "High power"
+msgstr ""
+
+#: id:21392
+msgid "Low power"
+msgstr ""
+
+#: id:21393
+msgid "High standby"
+msgstr ""
+
+#: id:21394
+msgid "Low standby"
+msgstr ""
+
+#: id:21395
+msgid "Unable to cache files bigger than 4GB"
+msgstr ""
+
+#: id:21396
+msgid "Chapter"
+msgstr ""
+
+#: id:21397
+msgid "High quality pixel shader v2"
+msgstr ""
+
+#: id:21398
+msgid "Enable playlist at startup"
+msgstr ""
+
+#: id:21399
+msgid "Use tween animations"
+msgstr ""
+
+#: id:21400
+msgid "contains"
+msgstr ""
+
+#: id:21401
+msgid "does not contain"
+msgstr ""
+
+#: id:21402
+msgid "is"
+msgstr ""
+
+#: id:21403
+msgid "is not"
+msgstr ""
+
+#: id:21404
+msgid "starts with"
+msgstr ""
+
+#: id:21405
+msgid "ends with"
+msgstr ""
+
+#: id:21406
+msgid "greater than"
+msgstr ""
+
+#: id:21407
+msgid "less than"
+msgstr ""
+
+#: id:21408
+msgid "after"
+msgstr ""
+
+#: id:21409
+msgid "before"
+msgstr ""
+
+#: id:21410
+msgid "in the last"
+msgstr ""
+
+#: id:21411
+msgid "not in the last"
+msgstr ""
+
+#: id:21412
+msgid "Scrapers"
+msgstr ""
+
+#: id:21413
+msgid "Default movie scraper"
+msgstr ""
+
+#: id:21414
+msgid "Default tvshow scraper"
+msgstr ""
+
+#: id:21415
+msgid "Default music video scraper"
+msgstr ""
+
+#: id:21416
+msgid "Enable fallback based on scraper language"
+msgstr ""
+
+#: id:21417
+msgid "- Settings"
+msgstr ""
+
+#: id:21418
+msgid "Multilingual"
+msgstr ""
+
+#: id:21419
+msgid "No scrapers present"
+msgstr ""
+
+#: id:21420
+msgid "Value to match"
+msgstr ""
+
+#: id:21421
+msgid "Smart playlist rule"
+msgstr ""
+
+#: id:21422
+msgid "Match items where"
+msgstr ""
+
+#: id:21423
+msgid "New rule..."
+msgstr ""
+
+#: id:21424
+msgid "Items must match"
+msgstr ""
+
+#: id:21425
+msgid "all of the rules"
+msgstr ""
+
+#: id:21426
+msgid "one or more of the rules"
+msgstr ""
+
+#: id:21427
+msgid "Limit to"
+msgstr ""
+
+#: id:21428
+msgid "No limit"
+msgstr ""
+
+#: id:21429
+msgid "Order by"
+msgstr ""
+
+#: id:21430
+msgid "ascending"
+msgstr ""
+
+#: id:21431
+msgid "descending"
+msgstr ""
+
+#: id:21432
+msgid "Edit smart playlist"
+msgstr ""
+
+#: id:21433
+msgid "Name of the playlist"
+msgstr ""
+
+#: id:21434
+msgid "Find items where"
+msgstr ""
+
+#: id:21435
+msgid "Edit"
+msgstr ""
+
+#: id:21436
+msgid "%i items"
+msgstr ""
+
+#: id:21437
+msgid "New smart playlist..."
+msgstr ""
+
+#: id:21438
+msgid "%c Drive"
+msgstr ""
+
+#: id:21439
+msgid "Edit party mode rules"
+msgstr ""
+
+#: id:21440
+msgid "Home folder"
+msgstr ""
+
+#: id:21441
+msgid "Watched count"
+msgstr ""
+
+#: id:21442
+msgid "Episode title"
+msgstr ""
+
+#: id:21443
+msgid "Video resolution"
+msgstr ""
+
+#: id:21444
+msgid "Audio channels"
+msgstr ""
+
+#: id:21445
+msgid "Video codec"
+msgstr ""
+
+#: id:21446
+msgid "Audio codec"
+msgstr ""
+
+#: id:21447
+msgid "Audio language"
+msgstr ""
+
+#: id:21448
+msgid "Subtitle language"
+msgstr ""
+
+#: id:21449
+msgid "Remote control sends keyboard presses"
+msgstr ""
+
+#: id:21450
+msgid "- Edit"
+msgstr ""
+
+#: id:21451
+msgid "Internet connection required."
+msgstr ""
+
+#: id:21452
+msgid "Get More..."
+msgstr ""
+
+#: id:21453
+msgid "Root filesystem"
+msgstr ""
+
+#: id:21454
+msgid "Cache full"
+msgstr ""
+
+#: id:21455
+msgid "Cache filled before reaching required amount for continous playback"
+msgstr ""
+
+#: id:21460
+msgid "Subtitle location"
+msgstr ""
+
+#: id:21461
+msgid "Fixed"
+msgstr ""
+
+#: id:21462
+msgid "Bottom of video"
+msgstr ""
+
+#: id:21463
+msgid "Below video"
+msgstr ""
+
+#: id:21464
+msgid "Top of video"
+msgstr ""
+
+#: id:21465
+msgid "Above video"
+msgstr ""
+
+#: id:21800
+msgid "File name"
+msgstr ""
+
+#: id:21801
+msgid "File path"
+msgstr ""
+
+#: id:21802
+msgid "File size"
+msgstr ""
+
+#: id:21803
+msgid "File date/time"
+msgstr ""
+
+#: id:21804
+msgid "Slide index"
+msgstr ""
+
+#: id:21805
+msgctxt "Auto context with id 21805"
+msgid "Resolution"
+msgstr ""
+
+#: id:21806
+msgctxt "Auto context with id 21806"
+msgid "Comment"
+msgstr ""
+
+#: id:21807
+msgid "Colour/B&W"
+msgstr ""
+
+#: id:21808
+msgid "JPEG process"
+msgstr ""
+
+#: id:21820
+msgid "Date/Time"
+msgstr ""
+
+#: id:21821
+msgid "Description"
+msgstr ""
+
+#: id:21822
+msgid "Camera make"
+msgstr ""
+
+#: id:21823
+msgid "Camera model"
+msgstr ""
+
+#: id:21824
+msgid "EXIF comment"
+msgstr ""
+
+#: id:21825
+msgid "Firmware"
+msgstr ""
+
+#: id:21826
+msgid "Aperture"
+msgstr ""
+
+#: id:21827
+msgid "Focal length"
+msgstr ""
+
+#: id:21828
+msgid "Focus distance"
+msgstr ""
+
+#: id:21829
+msgid "Exposure"
+msgstr ""
+
+#: id:21830
+msgid "Exposure time"
+msgstr ""
+
+#: id:21831
+msgid "Exposure bias"
+msgstr ""
+
+#: id:21832
+msgid "Exposure mode"
+msgstr ""
+
+#: id:21833
+msgid "Flash used"
+msgstr ""
+
+#: id:21834
+msgid "White-balance"
+msgstr ""
+
+#: id:21835
+msgid "Light source"
+msgstr ""
+
+#: id:21836
+msgid "Metering mode"
+msgstr ""
+
+#: id:21837
+msgid "ISO"
+msgstr ""
+
+#: id:21838
+msgid "Digital zoom"
+msgstr ""
+
+#: id:21839
+msgid "CCD width"
+msgstr ""
+
+#: id:21840
+msgid "GPS latitude"
+msgstr ""
+
+#: id:21841
+msgid "GPS longitude"
+msgstr ""
+
+#: id:21842
+msgid "GPS altitude"
+msgstr ""
+
+#: id:21843
+msgid "Orientation"
+msgstr ""
+
+#: id:21860
+msgid "Supplemental categories"
+msgstr ""
+
+#: id:21861
+msgid "Keywords"
+msgstr ""
+
+#: id:21862
+msgid "Caption"
+msgstr ""
+
+#: id:21863
+msgid "Author"
+msgstr ""
+
+#: id:21864
+msgid "Headline"
+msgstr ""
+
+#: id:21865
+msgid "Special instructions"
+msgstr ""
+
+#: id:21866
+msgid "Category"
+msgstr ""
+
+#: id:21867
+msgid "Byline"
+msgstr ""
+
+#: id:21868
+msgid "Byline title"
+msgstr ""
+
+#: id:21869
+msgid "Credit"
+msgstr ""
+
+#: id:21870
+msgid "Source"
+msgstr ""
+
+#: id:21871
+msgid "Copyright notice"
+msgstr ""
+
+#: id:21872
+msgid "Object name"
+msgstr ""
+
+#: id:21873
+msgid "City"
+msgstr ""
+
+#: id:21874
+msgid "State"
+msgstr ""
+
+#: id:21875
+msgctxt "Auto context with id 21875"
+msgid "Country"
+msgstr ""
+
+#: id:21876
+msgid "Original Tx Reference"
+msgstr ""
+
+#: id:21877
+msgid "Date created"
+msgstr ""
+
+#: id:21878
+msgid "Copyright flag"
+msgstr ""
+
+#: id:21879
+msgid "Country code"
+msgstr ""
+
+#: id:21880
+msgid "Reference service"
+msgstr ""
+
+#: id:21881
+msgid "Allow control of XBMC via UPnP"
+msgstr ""
+
+#: id:21882
+msgid "Attempt to skip introduction before DVD menu"
+msgstr ""
+
+#: id:21883
+msgid "Saved music"
+msgstr ""
+
+#: id:21884
+msgid "Query info for all artists"
+msgstr ""
+
+#: id:21885
+msgid "Downloading album information"
+msgstr ""
+
+#: id:21886
+msgid "Downloading artist information"
+msgstr ""
+
+#: id:21887
+msgid "Biography"
+msgstr ""
+
+#: id:21888
+msgid "Discography"
+msgstr ""
+
+#: id:21889
+msgid "Searching artist"
+msgstr ""
+
+#: id:21890
+msgid "Select artist"
+msgstr ""
+
+#: id:21891
+msgctxt "Auto context with id 21891"
+msgid "Artist information"
+msgstr ""
+
+#: id:21892
+msgid "Instruments"
+msgstr ""
+
+#: id:21893
+msgid "Born"
+msgstr ""
+
+#: id:21894
+msgid "Formed"
+msgstr ""
+
+#: id:21895
+msgid "Themes"
+msgstr ""
+
+#: id:21896
+msgid "Disbanded"
+msgstr ""
+
+#: id:21897
+msgid "Died"
+msgstr ""
+
+#: id:21898
+msgid "Years active"
+msgstr ""
+
+#: id:21899
+msgid "Label"
+msgstr ""
+
+#: id:21900
+msgid "Born/Formed"
+msgstr ""
+
+#: id:22000
+msgid "Update library on startup"
+msgstr ""
+
+#: id:22001
+msgid "Hide progress of library updates"
+msgstr ""
+
+#: id:22002
+msgid "- DNS suffix"
+msgstr ""
+
+#: id:22003
+msgid "%2.3fs"
+msgstr ""
+
+#: id:22004
+msgid "Delayed by: %2.3fs"
+msgstr ""
+
+#: id:22005
+msgid "Ahead by: %2.3fs"
+msgstr ""
+
+#: id:22006
+msgid "Subtitle offset"
+msgstr ""
+
+#: id:22007
+msgid "OpenGL vendor:"
+msgstr ""
+
+#: id:22008
+msgid "OpenGL renderer:"
+msgstr ""
+
+#: id:22009
+msgid "OpenGL version:"
+msgstr ""
+
+#: id:22010
+msgid "GPU temperature:"
+msgstr ""
+
+#: id:22011
+msgid "CPU temperature:"
+msgstr ""
+
+#: id:22012
+msgid "Total memory"
+msgstr ""
+
+#: id:22013
+msgid "Profile data"
+msgstr ""
+
+#: id:22014
+msgid "Use dim if paused during video playback"
+msgstr ""
+
+#: id:22015
+msgid "All recordings"
+msgstr ""
+
+#: id:22016
+msgid "By title"
+msgstr ""
+
+#: id:22017
+msgid "By group"
+msgstr ""
+
+#: id:22018
+msgid "Live channels"
+msgstr ""
+
+#: id:22019
+msgid "Recordings by title"
+msgstr ""
+
+#: id:22020
+msgid "Guide"
+msgstr ""
+
+#: id:22021
+msgid "Allowed error in aspect ratio to minimize black bars"
+msgstr ""
+
+#: id:22022
+msgid "Show video files in listings"
+msgstr ""
+
+#: id:22023
+msgid "DirectX vendor:"
+msgstr ""
+
+#: id:22024
+msgid "Direct3D version:"
+msgstr ""
+
+#: id:22030
+msgctxt "Auto context with id 22030"
+msgid "Font"
+msgstr ""
+
+#: id:22031
+msgctxt "Auto context with id 22031"
+msgid "- Size"
+msgstr ""
+
+#: id:22032
+msgctxt "Auto context with id 22032"
+msgid "- Colours"
+msgstr ""
+
+#: id:22033
+msgid "- Charset"
+msgstr ""
+
+#: id:22034
+msgid "Export karaoke titles as HTML"
+msgstr ""
+
+#: id:22035
+msgid "Export karaoke titles as CSV"
+msgstr ""
+
+#: id:22036
+msgid "Import karaoke titles..."
+msgstr ""
+
+#: id:22037
+msgid "Show song selector automatically"
+msgstr ""
+
+#: id:22038
+msgid "Export karaoke titles..."
+msgstr ""
+
+#: id:22039
+msgid "Enter song number"
+msgstr ""
+
+#: id:22040
+msgid "white/green"
+msgstr ""
+
+#: id:22041
+msgid "white/red"
+msgstr ""
+
+#: id:22042
+msgid "white/blue"
+msgstr ""
+
+#: id:22043
+msgid "black/white"
+msgstr ""
+
+#: id:22079
+msgid "Default select action"
+msgstr ""
+
+#: id:22080
+msgid "Choose"
+msgstr ""
+
+#: id:22081
+msgid "Show Information"
+msgstr ""
+
+#: id:22082
+msgid "More..."
+msgstr ""
+
+#: id:22083
+msgid "Play all"
+msgstr ""
+
+#: id:23049
+msgid "Teletext not available"
+msgstr ""
+
+#: id:23050
+msgid "Activate Teletext"
+msgstr ""
+
+#: id:23051
+msgid "Part %i"
+msgstr ""
+
+#: id:23052
+msgid "Buffering %i bytes"
+msgstr ""
+
+#: id:23053
+msgid "Stopping"
+msgstr ""
+
+#: id:23054
+msgid "Running"
+msgstr ""
+
+#: id:23100
+msgid "External Player Active"
+msgstr ""
+
+#: id:23101
+msgid "Click OK to terminate the player"
+msgstr ""
+
+#: id:23104
+msgid "Click OK when playback has ended"
+msgstr ""
+
+#: id:24000
+msgid "Add-on"
+msgstr ""
+
+#: id:24001
+msgid "Add-ons"
+msgstr ""
+
+#: id:24002
+msgid "Add-on options"
+msgstr ""
+
+#: id:24003
+msgid "Add-on Information"
+msgstr ""
+
+#: id:24005
+msgctxt "Auto context with id 24005"
+msgid "Media sources"
+msgstr ""
+
+#: id:24007
+msgctxt "Auto context with id 24007"
+msgid "Movie information"
+msgstr ""
+
+#: id:24008
+msgctxt "Auto context with id 24008"
+msgid "Screensaver"
+msgstr ""
+
+#: id:24009
+msgid "Script"
+msgstr ""
+
+#: id:24010
+msgctxt "Auto context with id 24010"
+msgid "Visualization"
+msgstr ""
+
+#: id:24011
+msgid "Add-on repository"
+msgstr ""
+
+#: id:24012
+msgctxt "Auto context with id 24012"
+msgid "Subtitles"
+msgstr ""
+
+#: id:24013
+msgid "Lyrics"
+msgstr ""
+
+#: id:24014
+msgid "TV information"
+msgstr ""
+
+#: id:24015
+msgctxt "Auto context with id 24015"
+msgid "Music video information"
+msgstr ""
+
+#: id:24016
+msgctxt "Auto context with id 24016"
+msgid "Album information"
+msgstr ""
+
+#: id:24017
+msgctxt "Auto context with id 24017"
+msgid "Artist information"
+msgstr ""
+
+#: id:24018
+msgctxt "Auto context with id 24018"
+msgid "Services"
+msgstr ""
+
+#: id:24020
+msgid "Configure"
+msgstr ""
+
+#: id:24021
+msgctxt "Auto context with id 24021"
+msgid "Disable"
+msgstr ""
+
+#: id:24022
+msgid "Enable"
+msgstr ""
+
+#: id:24023
+msgid "Add-on disabled"
+msgstr ""
+
+#: id:24027
+msgctxt "Auto context with id 24027"
+msgid "Weather"
+msgstr ""
+
+#: id:24028
+msgid "Weather.com (standard)"
+msgstr ""
+
+#: id:24030
+msgid "This Add-on can not be configured"
+msgstr ""
+
+#: id:24031
+msgid "Error loading settings"
+msgstr ""
+
+#: id:24032
+msgid "All Add-ons"
+msgstr ""
+
+#: id:24033
+msgid "Get Add-ons"
+msgstr ""
+
+#: id:24034
+msgid "Check for updates"
+msgstr ""
+
+#: id:24035
+msgid "Force refresh"
+msgstr ""
+
+#: id:24036
+msgid "Change log"
+msgstr ""
+
+#: id:24037
+msgid "Uninstall"
+msgstr ""
+
+#: id:24038
+msgid "Install"
+msgstr ""
+
+#: id:24039
+msgid "Disabled Add-ons"
+msgstr ""
+
+#: id:24040
+msgid "(Clear the current setting)"
+msgstr ""
+
+#: id:24041
+msgid "Install from zip file"
+msgstr ""
+
+#: id:24042
+msgid "Downloading %i%%"
+msgstr ""
+
+#: id:24043
+msgid "Available Updates"
+msgstr ""
+
+#: id:24044
+msgid "Dependencies not met"
+msgstr ""
+
+#: id:24045
+msgid "Add-on does not have the correct structure"
+msgstr ""
+
+#: id:24046
+msgid "%s is used by the following installed add-on(s)"
+msgstr ""
+
+#: id:24047
+msgid "This add-on cannot be uninstalled"
+msgstr ""
+
+#: id:24048
+msgid "Rollback"
+msgstr ""
+
+#: id:24050
+msgid "Available Add-ons"
+msgstr ""
+
+#: id:24051
+msgid "Version:"
+msgstr ""
+
+#: id:24052
+msgid "Disclaimer"
+msgstr ""
+
+#: id:24053
+msgid "License:"
+msgstr ""
+
+#: id:24054
+msgid "Changelog"
+msgstr ""
+
+#: id:24059
+msgid "Would you like to enable this Add-on?"
+msgstr ""
+
+#: id:24060
+msgid "Would you like to disable this Add-on?"
+msgstr ""
+
+#: id:24061
+msgid "Add-on update available!"
+msgstr ""
+
+#: id:24062
+msgid "Enabled Add-ons"
+msgstr ""
+
+#: id:24063
+msgid "Auto update"
+msgstr ""
+
+#: id:24064
+msgid "Add-on enabled"
+msgstr ""
+
+#: id:24065
+msgid "Add-on updated"
+msgstr ""
+
+#: id:24066
+msgid "Cancel Add-on download?"
+msgstr ""
+
+#: id:24067
+msgid "Currently downloading Add-ons"
+msgstr ""
+
+#: id:24068
+msgid "Update available"
+msgstr ""
+
+#: id:24069
+msgid "Update"
+msgstr ""
+
+#: id:24070
+msgid "Add-on could not be loaded."
+msgstr ""
+
+#: id:24071
+msgid "An unknown error has occurred."
+msgstr ""
+
+#: id:24072
+msgid "Settings required"
+msgstr ""
+
+#: id:24073
+msgid "Could not connect"
+msgstr ""
+
+#: id:24074
+msgid "Needs to restart"
+msgstr ""
+
+#: id:24075
+msgctxt "Auto context with id 24075"
+msgid "Disable"
+msgstr ""
+
+#: id:24076
+msgid "Add-on Required"
+msgstr ""
+
+#: id:24080
+msgid "Try to reconnect?"
+msgstr ""
+
+#: id:24089
+msgid "Add-on restarts"
+msgstr ""
+
+#: id:24090
+msgid "Lock Add-on manager"
+msgstr ""
+
+#: id:24094
+msgid "(current)"
+msgstr ""
+
+#: id:24095
+msgid "(blacklisted)"
+msgstr ""
+
+#: id:24096
+msgid "Add-on has been marked as broken in repository."
+msgstr ""
+
+#: id:24097
+msgid "Would you like to disable it on your system?"
+msgstr ""
+
+#: id:24098
+msgid "Broken"
+msgstr ""
+
+#: id:24099
+msgid "Would you like to switch to this skin?"
+msgstr ""
+
+#: id:24100
+msgid "To use this feature you must download an Add-on:"
+msgstr ""
+
+#: id:24101
+msgid "Would you like to download this Add-on?"
+msgstr ""
+
+#: id:25000
+msgid "Notifications"
+msgstr ""
+
+#: id:29800
+msgid "Library Mode"
+msgstr ""
+
+#: id:29801
+msgid "QWERTY keyboard"
+msgstr ""
+
+#: id:29802
+msgid "Passthrough Audio in use"
+msgstr ""
+
+#: id:33001
+msgid "Trailer quality"
+msgstr ""
+
+#: id:33002
+msgid "Stream"
+msgstr ""
+
+#: id:33003
+msgid "Download"
+msgstr ""
+
+#: id:33004
+msgid "Download & play"
+msgstr ""
+
+#: id:33005
+msgid "Download & save"
+msgstr ""
+
+#: id:33006
+msgid "Today"
+msgstr ""
+
+#: id:33007
+msgid "Tomorrow"
+msgstr ""
+
+#: id:33008
+msgid "Saving"
+msgstr ""
+
+#: id:33009
+msgid "Copying"
+msgstr ""
+
+#: id:33010
+msgid "Set download directory"
+msgstr ""
+
+#: id:33011
+msgid "Search duration"
+msgstr ""
+
+#: id:33012
+msgid "Short"
+msgstr ""
+
+#: id:33013
+msgid "Long"
+msgstr ""
+
+#: id:33014
+msgid "Use DVD player instead of regular player"
+msgstr ""
+
+#: id:33015
+msgid "Ask for download before playing video"
+msgstr ""
+
+#: id:33016
+msgid "Clips"
+msgstr ""
+
+#: id:33017
+msgid "Restart plugin to enable"
+msgstr ""
+
+#: id:33018
+msgid "Tonight"
+msgstr ""
+
+#: id:33019
+msgid "Tomorrow Night"
+msgstr ""
+
+#: id:33020
+msgid "Condition"
+msgstr ""
+
+#: id:33021
+msgid "Precipitation"
+msgstr ""
+
+#: id:33022
+msgid "Precip"
+msgstr ""
+
+#: id:33023
+msgid "Humid"
+msgstr ""
+
+#: id:33024
+msgid "Feels"
+msgstr ""
+
+#: id:33025
+msgid "Observed"
+msgstr ""
+
+#: id:33026
+msgid "Departure from normal"
+msgstr ""
+
+#: id:33027
+msgid "Sunrise"
+msgstr ""
+
+#: id:33028
+msgid "Sunset"
+msgstr ""
+
+#: id:33029
+msgid "Details"
+msgstr ""
+
+#: id:33030
+msgid "Outlook"
+msgstr ""
+
+#: id:33031
+msgid "Coverflow"
+msgstr ""
+
+#: id:33032
+msgid "Translate text"
+msgstr ""
+
+#: id:33033
+msgid "Map list %s category"
+msgstr ""
+
+#: id:33034
+msgid "36 Hour"
+msgstr ""
+
+#: id:33035
+msgid "Maps"
+msgstr ""
+
+#: id:33036
+msgid "Hourly"
+msgstr ""
+
+#: id:33037
+msgid "Weekend"
+msgstr ""
+
+#: id:33038
+msgid "%s day"
+msgstr ""
+
+#: id:33049
+msgid "Alert"
+msgstr ""
+
+#: id:33050
+msgid "Alerts"
+msgstr ""
+
+#: id:33051
+msgid "Choose Your"
+msgstr ""
+
+#: id:33052
+msgid "Check"
+msgstr ""
+
+#: id:33053
+msgctxt "Auto context with id 33053"
+msgid "Configure the"
+msgstr ""
+
+#: id:33054
+msgid "Seasons"
+msgstr ""
+
+#: id:33055
+msgid "Use your"
+msgstr ""
+
+#: id:33056
+msgid "Watch your"
+msgstr ""
+
+#: id:33057
+msgid "Listen to"
+msgstr ""
+
+#: id:33058
+msgid "View your"
+msgstr ""
+
+#: id:33059
+msgctxt "Auto context with id 33059"
+msgid "Configure the"
+msgstr ""
+
+#: id:33060
+msgid "Power"
+msgstr ""
+
+#: id:33061
+msgid "Menu"
+msgstr ""
+
+#: id:33062
+msgid "Play the"
+msgstr ""
+
+#: id:33063
+msgid "Options"
+msgstr ""
+
+#: id:33065
+msgid "Editor"
+msgstr ""
+
+#: id:33066
+msgid "About your"
+msgstr ""
+
+#: id:33067
+msgid "Star rating"
+msgstr ""
+
+#: id:33068
+msgid "Background"
+msgstr ""
+
+#: id:33069
+msgid "Backgrounds"
+msgstr ""
+
+#: id:33070
+msgid "Custom background"
+msgstr ""
+
+#: id:33071
+msgid "Custom backgrounds"
+msgstr ""
+
+#: id:33072
+msgid "View Readme"
+msgstr ""
+
+#: id:33073
+msgid "View Changelog"
+msgstr ""
+
+#: id:33074
+msgid "This version of %s requires an"
+msgstr ""
+
+#: id:33075
+msgid "XBMC revision of %s or greater to run."
+msgstr ""
+
+#: id:33076
+msgid "Please update XBMC."
+msgstr ""
+
+#: id:33077
+msgid "No data found!"
+msgstr ""
+
+#: id:33078
+msgid "Next page"
+msgstr ""
+
+#: id:33079
+msgid "Love"
+msgstr ""
+
+#: id:33080
+msgid "Hate"
+msgstr ""
+
+#: id:33081
+msgid "This file is stacked, select the part you want to play from."
+msgstr ""
+
+#: id:33082
+msgid "Path to script"
+msgstr ""
+
+#: id:33083
+msgid "Enable custom script button"
+msgstr ""
+
+#: id:33100
+msgid "Failed to start"
+msgstr ""
+
+#: id:33101
+msgid "Webserver"
+msgstr ""
+
+#: id:33102
+msgid "Event Server"
+msgstr ""
+
+#: id:33103
+msgid "Remote communication server"
+msgstr ""
+
+#: id:33200
+msgid "Detected New Connection"
+msgstr ""
+
+#: id:34000
+msgid "Lame"
+msgstr ""
+
+#: id:34001
+msgid "Vorbis"
+msgstr ""
+
+#: id:34002
+msgid "Wav"
+msgstr ""
+
+#: id:34003
+msgid "DXVA2"
+msgstr ""
+
+#: id:34004
+msgid "VAAPI"
+msgstr ""
+
+#: id:34005
+msgid "Flac"
+msgstr ""
+
+#: id:34100
+msgid "Speaker Configuration"
+msgstr ""
+
+#: id:34101
+msgid "2.0"
+msgstr ""
+
+#: id:34102
+msgid "2.1"
+msgstr ""
+
+#: id:34103
+msgid "3.0"
+msgstr ""
+
+#: id:34104
+msgid "3.1"
+msgstr ""
+
+#: id:34105
+msgid "4.0"
+msgstr ""
+
+#: id:34106
+msgid "4.1"
+msgstr ""
+
+#: id:34107
+msgid "5.0"
+msgstr ""
+
+#: id:34108
+msgid "5.1"
+msgstr ""
+
+#: id:34109
+msgid "7.0"
+msgstr ""
+
+#: id:34110
+msgid "7.1"
+msgstr ""
+
+#: id:34201
+msgid "Can't find a next item to play"
+msgstr ""
+
+#: id:34202
+msgid "Can't find a previous item to play"
+msgstr ""
+
+#: id:34300
+msgid "Failed to start zeroconf"
+msgstr ""
+
+#: id:34301
+msgid "Is Apple's Bonjour Service installed? See log for more info."
+msgstr ""
+
+#: id:34400
+msgid "Video Rendering"
+msgstr ""
+
+#: id:34401
+msgid "Failed to init video filters/scalers, falling back to bilinear scaling"
+msgstr ""
+
+#: id:34402
+msgid "Failed to initialize audio device"
+msgstr ""
+
+#: id:34403
+msgid "Check your audiosettings"
+msgstr ""
+
+#: id:34404
+msgid "Use gestures for navigation:"
+msgstr ""
+
+#: id:34405
+msgid "1 finger swipe left,right,up,down for cursors"
+msgstr ""
+
+#: id:34406
+msgid "2 finger swipe left for backspace"
+msgstr ""
+
+#: id:34407
+msgid "1 finger single tap for enter"
+msgstr ""
+
+#: id:34408
+msgid "2 finger single tap for contextmenu"
+msgstr ""
+
+#: id:35000
+msgid "Peripherals"
+msgstr ""
+
+#: id:35001
+msgid "Generic HID device"
+msgstr ""
+
+#: id:35002
+msgid "Generic network adapter"
+msgstr ""
+
+#: id:35003
+msgid "Generic disk"
+msgstr ""
+
+#: id:35004
+msgid "There are no settings available\nfor this peripheral."
+msgstr ""
+
+#: id:35005
+msgid "New device configured"
+msgstr ""
+
+#: id:35006
+msgid "Device removed"
+msgstr ""
+
+#: id:35007
+msgid "Keymap to use for this device"
+msgstr ""
+
+#: id:35008
+msgid "Keymap enabled"
+msgstr ""
+
+#: id:35009
+msgid "Do not use the custom keymap for this device"
+msgstr ""
+
+#: id:35500
+msgid "Location"
+msgstr ""
+
+#: id:35501
+msgid "Class"
+msgstr ""
+
+#: id:35502
+msgctxt "Auto context with id 35502"
+msgid "Name"
+msgstr ""
+
+#: id:35503
+msgid "Vendor"
+msgstr ""
+
+#: id:35504
+msgid "Product ID"
+msgstr ""
+
+#: id:36000
+msgid "Pulse-Eight CEC adapter"
+msgstr ""
+
+#: id:36001
+msgid "Pulse-Eight Nyxboard"
+msgstr ""
+
+#: id:36002
+msgid "Switch to keyboard side command"
+msgstr ""
+
+#: id:36003
+msgid "Switch to remote side command"
+msgstr ""
+
+#: id:36004
+msgid "Press \"user\" button command"
+msgstr ""
+
+#: id:36005
+msgid "Enable switch side commands"
+msgstr ""
+
+#: id:36006
+msgid "Could not open the adapter"
+msgstr ""
+
+#: id:36007
+msgid "Devices to power on when starting XBMC"
+msgstr ""
+
+#: id:36008
+msgid "Devices to power off when stopping XBMC"
+msgstr ""
+
+#: id:36009
+msgid "Put devices in standby mode when activating screensaver"
+msgstr ""
+
+#: id:36011
+msgid "Could not detect the CEC port. Set it up manually."
+msgstr ""
+
+#: id:36012
+msgid "Could not initialise the CEC adapter. Check your settings."
+msgstr ""
+
+#: id:36013
+msgid "Unsupported libCEC interface version. %d is greater than the version XBMC supports (%d)"
+msgstr ""
+
+#: id:36014
+msgid "Put this PC in standby mode when the TV is switched off"
+msgstr ""
+
+#: id:36015
+msgid "HDMI port number"
+msgstr ""
+
+#: id:36016
+msgctxt "Auto context with id 36016"
+msgid "Connected"
+msgstr ""
+
+#: id:36017
+msgid "Adapter found, but libCEC is not available"
+msgstr ""
+
+#: id:36018
+msgid "Use the TV's language setting"
+msgstr ""
+
+#: id:36019
+msgid "Connected to HDMI device"
+msgstr ""
+
+#: id:36020
+msgid "Make XBMC the active source when starting"
+msgstr ""
+
+#: id:36021
+msgid "Physical address (overrules HDMI port)"
+msgstr ""
+
+#: id:36022
+msgid "COM port (leave empty unless needed)"
+msgstr ""
+
+#: id:36023
+msgid "Configuration updated"
+msgstr ""
+
+#: id:36024
+msgid "Failed to set the new configuration. Please check your settings."
+msgstr ""
+
+#: id:36025
+msgid "Send 'inactive source' command when stopping XBMC"
+msgstr ""
+

--- a/language/Finnish/strings.po
+++ b/language/Finnish/strings.po
@@ -1,0 +1,9093 @@
+# Converted from xbmc strings.xml with xbmc-xml2po (by Team-XBMC)
+msgid ""
+msgstr ""
+"Project-Id-Version: xbmc.core-FRODO_GIT3ed1604ad7\n"
+"Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
+"POT-Creation-Date: 2012-04-09 18:00+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE\n"
+"Language: fi\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: id:0
+msgctxt "Auto context with id 0"
+msgid "Programs"
+msgstr "Ohjelmat"
+
+#: id:1
+msgctxt "Auto context with id 1"
+msgid "Pictures"
+msgstr "Kuvat"
+
+#: id:2
+msgctxt "Auto context with id 2"
+msgid "Music"
+msgstr "Musiikki"
+
+#: id:3
+msgctxt "Auto context with id 3"
+msgid "Videos"
+msgstr "Videot"
+
+#: id:4
+msgid "TV-Guide"
+msgstr "TV-opas"
+
+#: id:5
+msgctxt "Auto context with id 5"
+msgid "Settings"
+msgstr "Asetukset"
+
+#: id:6
+msgid "XBMC SVN"
+msgstr "XBMC SVN"
+
+#: id:7
+msgctxt "Auto context with id 7"
+msgid "File manager"
+msgstr "Tiedostonhallinta"
+
+#: id:8
+msgctxt "Auto context with id 8"
+msgid "Weather"
+msgstr "Sää"
+
+#: id:9
+msgid "xbmc media center"
+msgstr "xbmc media center"
+
+#: id:11
+msgid "Monday"
+msgstr "maanantai"
+
+#: id:12
+msgid "Tuesday"
+msgstr "tiistai"
+
+#: id:13
+msgid "Wednesday"
+msgstr "keskiviikko"
+
+#: id:14
+msgid "Thursday"
+msgstr "torstai"
+
+#: id:15
+msgid "Friday"
+msgstr "perjantai"
+
+#: id:16
+msgid "Saturday"
+msgstr "lauantai"
+
+#: id:17
+msgid "Sunday"
+msgstr "sunnuntai"
+
+#: id:21
+msgid "January"
+msgstr "tammikuu"
+
+#: id:22
+msgid "February"
+msgstr "helmikuu"
+
+#: id:23
+msgid "March"
+msgstr "maaliskuu"
+
+#: id:24
+msgid "April"
+msgstr "huhtikuu"
+
+#: id:25
+msgctxt "Auto context with id 25"
+msgid "May"
+msgstr "toukokuu"
+
+#: id:26
+msgid "June"
+msgstr "kesäkuu"
+
+#: id:27
+msgid "July"
+msgstr "heinäkuu"
+
+#: id:28
+msgid "August"
+msgstr "elokuu"
+
+#: id:29
+msgid "September"
+msgstr "syyskuu"
+
+#: id:30
+msgid "October"
+msgstr "lokakuu"
+
+#: id:31
+msgid "November"
+msgstr "marraskuu"
+
+#: id:32
+msgid "December"
+msgstr "joulukuu"
+
+#: id:41
+msgid "Mon"
+msgstr "ma"
+
+#: id:42
+msgid "Tue"
+msgstr "ti"
+
+#: id:43
+msgid "Wed"
+msgstr "ke"
+
+#: id:44
+msgid "Thu"
+msgstr "to"
+
+#: id:45
+msgid "Fri"
+msgstr "pe"
+
+#: id:46
+msgid "Sat"
+msgstr "la"
+
+#: id:47
+msgctxt "Auto context with id 47"
+msgid "Sun"
+msgstr "su"
+
+#: id:51
+msgid "Jan"
+msgstr "tammi"
+
+#: id:52
+msgid "Feb"
+msgstr "helmi"
+
+#: id:53
+msgid "Mar"
+msgstr "maalis"
+
+#: id:54
+msgid "Apr"
+msgstr "huhti"
+
+#: id:55
+msgctxt "Auto context with id 55"
+msgid "May"
+msgstr "touko"
+
+#: id:56
+msgid "Jun"
+msgstr "kesä"
+
+#: id:57
+msgid "Jul"
+msgstr "heinä"
+
+#: id:58
+msgid "Aug"
+msgstr "elo"
+
+#: id:59
+msgid "Sep"
+msgstr "syys"
+
+#: id:60
+msgid "Oct"
+msgstr "loka"
+
+#: id:61
+msgid "Nov"
+msgstr "marras"
+
+#: id:62
+msgid "Dec"
+msgstr "joulu"
+
+#: id:71
+msgid "N"
+msgstr "Pohjoisesta"
+
+#: id:72
+msgid "NNE"
+msgstr "Pohjoiskoillisesta"
+
+#: id:73
+msgid "NE"
+msgstr "Koillisesta"
+
+#: id:74
+msgid "ENE"
+msgstr "Itäkoillisesta"
+
+#: id:75
+msgid "E"
+msgstr "Idästä"
+
+#: id:76
+msgid "ESE"
+msgstr "Itäkaakosta"
+
+#: id:77
+msgid "SE"
+msgstr "Kaakosta"
+
+#: id:78
+msgid "SSE"
+msgstr "Eteläkaakosta"
+
+#: id:79
+msgid "S"
+msgstr "Etelästä"
+
+#: id:80
+msgid "SSW"
+msgstr "Etelälounaasta"
+
+#: id:81
+msgid "SW"
+msgstr "Lounaasta"
+
+#: id:82
+msgid "WSW"
+msgstr "Länsilounaasta"
+
+#: id:83
+msgid "W"
+msgstr "Lännestä"
+
+#: id:84
+msgid "WNW"
+msgstr "Länsiluoteesta"
+
+#: id:85
+msgid "NW"
+msgstr "Luoteesta"
+
+#: id:86
+msgid "NNW"
+msgstr "Pohjoisluoteesta"
+
+#: id:87
+msgid "VAR"
+msgstr "Vaihteleva"
+
+#: id:98
+msgid "View: Auto"
+msgstr "Näytä: Autom."
+
+#: id:99
+msgid "View: Auto big"
+msgstr "Näytä: Autom. suuret"
+
+#: id:100
+msgid "View: Icons"
+msgstr "Näytä: Kuvakkeet"
+
+#: id:101
+msgid "View: List"
+msgstr "Näytä: Lista"
+
+#: id:102
+msgctxt "Auto context with id 102"
+msgid "Scan"
+msgstr "Päivitä"
+
+#: id:103
+msgctxt "Auto context with id 103"
+msgid "Sort by: Name"
+msgstr "Järjestä: Nimi"
+
+#: id:104
+msgid "Sort by: Date"
+msgstr "Järjestä: Päiväys"
+
+#: id:105
+msgid "Sort by: Size"
+msgstr "Järjestä: Koko"
+
+#: id:106
+msgid "No"
+msgstr "Ei"
+
+#: id:107
+msgid "Yes"
+msgstr "Kyllä"
+
+#: id:108
+msgctxt "Auto context with id 108"
+msgid "Slideshow"
+msgstr "Kuvaesitys"
+
+#: id:109
+msgid "Create thumbs"
+msgstr "Luo pienoiskuvat"
+
+#: id:110
+msgid "Create thumbnails"
+msgstr "Luo pienoiskuvat"
+
+#: id:111
+msgctxt "Auto context with id 111"
+msgid "Shortcuts"
+msgstr "Pikakuvakkeet"
+
+#: id:112
+msgid "Paused"
+msgstr "Tauko"
+
+#: id:113
+msgid "Update failed"
+msgstr "Päivitys epäonnistui"
+
+#: id:114
+msgid "Installation failed"
+msgstr "Asennus epäonnistui"
+
+#: id:115
+msgid "Copy"
+msgstr "Kopioi"
+
+#: id:116
+msgid "Move"
+msgstr "Siirrä"
+
+#: id:117
+msgid "Delete"
+msgstr "Poista"
+
+#: id:118
+msgid "Rename"
+msgstr "Nimeä uudelleen"
+
+#: id:119
+msgid "New folder"
+msgstr "Uusi kansio"
+
+#: id:120
+msgid "Confirm file copy"
+msgstr "Vahvista tiedoston kopiointi"
+
+#: id:121
+msgid "Confirm file move"
+msgstr "Vahvista tiedoston siirto"
+
+#: id:122
+msgid "Confirm file delete?"
+msgstr "Vahvista tiedoston poisto"
+
+#: id:123
+msgid "Copy these files?"
+msgstr "Kopioidaanko valitut tiedostot?"
+
+#: id:124
+msgid "Move these files?"
+msgstr "Siirretäänkö valitut tiedostot?"
+
+#: id:125
+msgid "Delete these files? - Deleting files cannot be undone!"
+msgstr "Poistetaanko valitut tiedostot? - Poistettuja ei voi palauttaa!"
+
+#: id:126
+msgid "Status"
+msgstr "Tila"
+
+#: id:127
+msgid "Objects"
+msgstr "Kohdetta"
+
+#: id:128
+msgctxt "Auto context with id 128"
+msgid "General"
+msgstr "Yleiset"
+
+#: id:129
+msgctxt "Auto context with id 129"
+msgid "Slideshow"
+msgstr "Kuvaesitys"
+
+#: id:130
+msgctxt "Auto context with id 130"
+msgid "System info"
+msgstr "Järjestelmän tiedot"
+
+#: id:131
+msgid "Display"
+msgstr "Näyttö"
+
+#: id:132
+msgid "Albums"
+msgstr "Albumit"
+
+#: id:133
+msgid "Artists"
+msgstr "Esittäjät"
+
+#: id:134
+msgid "Songs"
+msgstr "Kappaleet"
+
+#: id:135
+msgid "Genres"
+msgstr "Lajityypit"
+
+#: id:136
+msgid "Playlists"
+msgstr "Toistolistat"
+
+#: id:137
+msgid "Search"
+msgstr "Etsi"
+
+#: id:138
+msgid "System Information"
+msgstr "Järjestelmän tiedot"
+
+#: id:139
+msgid "Temperatures:"
+msgstr "Lämpötilat:"
+
+#: id:140
+msgid "CPU:"
+msgstr "Suoritin:"
+
+#: id:141
+msgid "GPU:"
+msgstr "Grafiikkapiiri:"
+
+#: id:142
+msgid "Time:"
+msgstr "Aika:"
+
+#: id:143
+msgid "Current:"
+msgstr "Tällä hetkellä:"
+
+#: id:144
+msgid "Build:"
+msgstr "Ohjelmaversio:"
+
+#: id:145
+msgid "Network:"
+msgstr "Verkko:"
+
+#: id:146
+msgid "Type:"
+msgstr "Tyyppi:"
+
+#: id:147
+msgid "Static"
+msgstr "Kiinteä IP-osoite"
+
+#: id:148
+msgid "DHCP"
+msgstr "DHCP"
+
+#: id:149
+msgid "MAC address"
+msgstr "MAC-osoite"
+
+#: id:150
+msgctxt "Auto context with id 150"
+msgid "IP address"
+msgstr "IP-osoite"
+
+#: id:151
+msgid "Link:"
+msgstr "Yhteys:"
+
+#: id:152
+msgid "Half duplex"
+msgstr "Puoliduplex"
+
+#: id:153
+msgid "Full duplex"
+msgstr "Täysiduplex"
+
+#: id:154
+msgctxt "Auto context with id 154"
+msgid "Storage"
+msgstr "Asemat"
+
+#: id:155
+msgid "Drive"
+msgstr "Asema"
+
+#: id:156
+msgctxt "Auto context with id 156"
+msgid "Free"
+msgstr "vapaana"
+
+#: id:157
+msgctxt "Auto context with id 157"
+msgid "Video"
+msgstr "Video"
+
+#: id:158
+msgid "Free memory"
+msgstr "Muistia vapaana"
+
+#: id:159
+msgid "No link"
+msgstr "Ei yhteyttä"
+
+#: id:160
+msgctxt "Auto context with id 160"
+msgid "Free"
+msgstr "Vapaana"
+
+#: id:161
+msgid "Unavailable"
+msgstr "Ei saatavilla"
+
+#: id:162
+msgid "Tray open"
+msgstr "Levykelkka auki"
+
+#: id:163
+msgid "Reading"
+msgstr "Luetaan"
+
+#: id:164
+msgid "No disc"
+msgstr "Ei levyä"
+
+#: id:165
+msgid "Disc present"
+msgstr "Levy asetettu"
+
+#: id:166
+msgid "Skin"
+msgstr "Ulkoasu"
+
+#: id:169
+msgctxt "Auto context with id 169"
+msgid "Resolution"
+msgstr "Näytön resoluutio"
+
+#: id:170
+msgid "Adjust display refresh rate to match video"
+msgstr "Säädä näytön päivitysnopeus elokuvaan sopivaksi"
+
+#: id:172
+msgid "Release date"
+msgstr "Julkaistu"
+
+#: id:173
+msgid "Display 4:3 videos as"
+msgstr "4:3-videoiden näyttömuoto"
+
+#: id:175
+msgid "Moods"
+msgstr "Musiikkityyli"
+
+#: id:176
+msgid "Styles"
+msgstr "Tyylilaji"
+
+#: id:179
+msgid "Song"
+msgstr "Kappale"
+
+#: id:180
+msgid "Duration"
+msgstr "Kesto"
+
+#: id:181
+msgid "Select album"
+msgstr "Valitse albumi"
+
+#: id:182
+msgid "Tracks"
+msgstr "Kappaleet"
+
+#: id:183
+msgid "Review"
+msgstr "Levyn esittely"
+
+#: id:184
+msgid "Refresh"
+msgstr "Päivitä"
+
+#: id:185
+msgid "Searching album"
+msgstr "Haetaan albumia"
+
+#: id:186
+msgid "OK"
+msgstr "OK"
+
+#: id:187
+msgid "No albums found!"
+msgstr "Albumia ei löytynyt!"
+
+#: id:188
+msgid "Select all"
+msgstr "Valitse kaikki"
+
+#: id:189
+msgid "Scanning media info"
+msgstr "Haetaan median tiedot"
+
+#: id:190
+msgid "Save"
+msgstr "Tallenna"
+
+#: id:191
+msgid "Shuffle"
+msgstr "Sekoita"
+
+#: id:192
+msgctxt "Auto context with id 192"
+msgid "Clear"
+msgstr "Tyhjennä"
+
+#: id:193
+msgctxt "Auto context with id 193"
+msgid "Scan"
+msgstr "Hae tiedot"
+
+#: id:194
+msgid "Searching..."
+msgstr "Etsitään..."
+
+#: id:195
+msgid "No info found!"
+msgstr "Tietoja ei löytynyt!"
+
+#: id:196
+msgid "Select movie:"
+msgstr "Valitse elokuva:"
+
+#: id:197
+msgid "Querying %s info"
+msgstr "Haetaan tietoja %s:sta"
+
+#: id:198
+msgid "Loading movie details"
+msgstr "Noudetaan elokuvan tietoja"
+
+#: id:199
+msgid "Web interface"
+msgstr "WWW-käyttöliittymä"
+
+#: id:202
+msgid "Tagline"
+msgstr "Iskulause"
+
+#: id:203
+msgid "Plot outline"
+msgstr "Juoni"
+
+#: id:205
+msgid "Votes"
+msgstr "Ääniä"
+
+#: id:206
+msgid "Cast"
+msgstr "Näyttelijät"
+
+#: id:207
+msgid "Plot"
+msgstr "Juoni"
+
+#: id:208
+msgctxt "Auto context with id 208"
+msgid "Play"
+msgstr "Toista"
+
+#: id:209
+msgid "Next"
+msgstr "Seuraava"
+
+#: id:210
+msgid "Previous"
+msgstr "Edellinen"
+
+#: id:213
+msgid "Calibrate user interface..."
+msgstr "Käyttöliittymän säätö..."
+
+#: id:214
+msgid "Video calibration..."
+msgstr "Kuvaruudun säätö..."
+
+#: id:215
+msgid "Soften"
+msgstr "Pehmennä kuvaa"
+
+#: id:216
+msgid "Zoom amount"
+msgstr "Kuvan koko"
+
+#: id:217
+msgid "Pixel ratio"
+msgstr "Pikselin sivusuhde"
+
+#: id:218
+msgid "DVD drive"
+msgstr "DVD-asema"
+
+#: id:219
+msgid "Please insert disc"
+msgstr "Aseta levy asemaan"
+
+#: id:220
+msgid "Remote share"
+msgstr "Verkkojako"
+
+#: id:221
+msgid "Network is not connected"
+msgstr "Verkkoa ei ole kytketty"
+
+#: id:222
+msgid "Cancel"
+msgstr "Peruuta"
+
+#: id:224
+msgid "Speed"
+msgstr "Nopeus"
+
+#: id:225
+msgid "Vertical Shift"
+msgstr "Pystysiirto"
+
+#: id:226
+msgid "Test patterns..."
+msgstr "Testikuviot..."
+
+#: id:227
+msgid "Lookup audio CD track names from freedb.org"
+msgstr "Hae ääni-CD-levyn kappaletiedot internetistä"
+
+#: id:228
+msgid "Shuffle playlist on load"
+msgstr "Sekoita toistolista ladattaessa"
+
+#: id:229
+msgid "HDD spindown time"
+msgstr "Kiintolevyn pysäytysaika"
+
+#: id:230
+msgid "Video filters"
+msgstr "Kuvasuodin"
+
+#: id:231
+msgctxt "Auto context with id 231"
+msgid "None"
+msgstr "Ei käytössä"
+
+#: id:232
+msgid "Point"
+msgstr "Pistemäinen"
+
+#: id:233
+msgid "Linear"
+msgstr "Lineaarinen"
+
+#: id:234
+msgid "Anisotropic"
+msgstr "Anisotrooppinen"
+
+#: id:235
+msgid "Quincunx"
+msgstr "Quincunx"
+
+#: id:236
+msgid "Gaussian cubic"
+msgstr "Gaussian Cubic"
+
+#: id:237
+msgid "Minification"
+msgstr "Pienennys"
+
+#: id:238
+msgid "Magnification"
+msgstr "Suurennus"
+
+#: id:239
+msgid "Clear playlist on finish"
+msgstr "Tyhjennä toistolista lopuksi"
+
+#: id:240
+msgid "Display Mode"
+msgstr "Näyttömuoto"
+
+#: id:241
+msgid "Full Screen #%d"
+msgstr "Kokoruutu #%d"
+
+#: id:242
+msgid "Windowed"
+msgstr "Ikkuna"
+
+#: id:243
+msgid "Refresh Rate"
+msgstr "Päivitysnopeus"
+
+#: id:244
+msgid "Full screen"
+msgstr "Kokoruutu"
+
+#: id:245
+msgid "Sizing: (%i,%i)->(%i,%i) (Zoom x%2.2f) AR:%2.2f:1 (Pixels: %2.2f:1) (VShift: %2.2f)"
+msgstr "Mitoitus: (%i,%i)->(%i,%i) (Zoomaus x%2.2f) Kuvasuhde:%2.2f:1 (Pikselisuhde: %2.2f:1) (Pystysiirto: %2.2f)"
+
+#: id:247
+msgctxt "Auto context with id 247"
+msgid "Scripts"
+msgstr "Skriptit"
+
+#: id:248
+msgctxt "Auto context with id 248"
+msgid "Language"
+msgstr "Kieli"
+
+#: id:249
+msgctxt "Auto context with id 249"
+msgid "Music"
+msgstr "Musiikki"
+
+#: id:250
+msgctxt "Auto context with id 250"
+msgid "Visualization"
+msgstr "Näytön visualisointi"
+
+#: id:251
+msgid "Select destination directory"
+msgstr "Valitse kohdehakemisto"
+
+#: id:252
+msgid "Output stereo to all speakers"
+msgstr "Syötä stereoääni kaikille kaiuttimille"
+
+#: id:253
+msgid "Number of channels"
+msgstr "Kanavien määrä"
+
+#: id:254
+msgid "- DTS capable receiver"
+msgstr "- DTS-yhteensopiva vastaanotin"
+
+#: id:255
+msgid "CDDB"
+msgstr "CD-tietokanta"
+
+#: id:256
+msgid "Fetching CD information"
+msgstr "Noudetaan CD-tietoja"
+
+#: id:257
+msgid "Error"
+msgstr "Virhe"
+
+#: id:258
+msgid "Enable tag reading"
+msgstr "Lue tagit tiedostoista"
+
+#: id:259
+msgid "Opening"
+msgstr "Avataan"
+
+#: id:260
+msgid "Shoutcast"
+msgstr "Shoutcast"
+
+#: id:261
+msgid "Waiting for start..."
+msgstr "Käynnistetään..."
+
+#: id:262
+msgid "Scripts output"
+msgstr "Skriptin suoritus"
+
+#: id:263
+msgid "Allow control of XBMC via HTTP"
+msgstr "XBMC:n ohjaus http:n kautta käytössä"
+
+#: id:264
+msgid "Record"
+msgstr "Nauhoita"
+
+#: id:265
+msgid "Stop Rec."
+msgstr "Pysäytä nauh."
+
+#: id:266
+msgid "Sort by: Track"
+msgstr "Järjestä: Raita"
+
+#: id:267
+msgid "Sort by: Time"
+msgstr "Järjestä: Kesto"
+
+#: id:268
+msgid "Sort by: Title"
+msgstr "Järjestä: Nimi"
+
+#: id:269
+msgid "Sort by: Artist"
+msgstr "Järjestä: Esittäjä"
+
+#: id:270
+msgid "Sort by: Album"
+msgstr "Järjestä: Albumi"
+
+#: id:271
+msgid "Top 100"
+msgstr "100 suosituinta"
+
+#: id:272
+msgid "Top-Left overscan compensation"
+msgstr "Kuvan vasen yläkulma"
+
+#: id:273
+msgid "Bottom-Right overscan compensation"
+msgstr "Kuvan oikea alakulma"
+
+#: id:274
+msgid "Subtitle positioning"
+msgstr "Aseta tekstityksen paikka"
+
+#: id:275
+msgid "Pixel ratio adjustment"
+msgstr "Määritä pikselin muoto"
+
+#: id:276
+msgid "Adjust the arrow to change the amount of overscan"
+msgstr "Siirtämällä nuolta voit määrittää näkyvän kuva-alan"
+
+#: id:277
+msgid "Adjust the bar to change the subtitles position"
+msgstr "Siirtämällä palkkia voit määrittää tekstityksen paikan"
+
+#: id:278
+msgid "Adjust the rectangle so it is perfectly square"
+msgstr "Säädä suorakulmiosta täysin neliö"
+
+#: id:279
+msgid "Unable to load settings"
+msgstr "Asetuksia ei voitu ladata"
+
+#: id:280
+msgid "Using default settings"
+msgstr "Oletusasetukset otettu käyttöön"
+
+#: id:281
+msgid "Please check the XML files"
+msgstr "Tarkista XML-tiedostot"
+
+#: id:282
+msgid "Found %i items"
+msgstr "%i kpl nimikkeitä löydetty"
+
+#: id:283
+msgid "Search results"
+msgstr "Haun tulos"
+
+#: id:284
+msgid "No results found"
+msgstr "Nimikkeitä ei löytynyt"
+
+#: id:287
+msgctxt "Auto context with id 287"
+msgid "Subtitles"
+msgstr "Tekstitys"
+
+#: id:288
+msgctxt "Auto context with id 288"
+msgid "Font"
+msgstr "Kirjasin"
+
+#: id:289
+msgctxt "Auto context with id 289"
+msgid "- Size"
+msgstr "- Koko"
+
+#: id:290
+msgid "Dynamic range compression"
+msgstr "Dynamiikan kutistus"
+
+#: id:291
+msgctxt "Auto context with id 291"
+msgid "Video"
+msgstr "Video"
+
+#: id:292
+msgctxt "Auto context with id 292"
+msgid "Audio"
+msgstr "Ääni"
+
+#: id:293
+msgid "Browse for subtitles"
+msgstr "Valitse tekstitys"
+
+#: id:294
+msgid "Create bookmark"
+msgstr "Luo kirjanmerkki"
+
+#: id:296
+msgid "Clear bookmarks"
+msgstr "Poista kirjanmerkit"
+
+#: id:297
+msgid "Audio offset"
+msgstr "Äänen ajoitus"
+
+#: id:298
+msgid "Bookmarks"
+msgstr "Kirjanmerkit"
+
+#: id:299
+msgid "- AAC capable receiver"
+msgstr "- AAC-yhteensopiva vastaanotin"
+
+#: id:300
+msgid "- MP1 capable receiver"
+msgstr "- MP1-yhteensopiva vastaanotin"
+
+#: id:301
+msgid "- MP2 capable receiver"
+msgstr "- MP2-yhteensopiva vastaanotin"
+
+#: id:302
+msgid "- MP3 capable receiver"
+msgstr "- MP3-yhteensopiva vastaanotin"
+
+#: id:303
+msgid "Delay"
+msgstr "Viive"
+
+#: id:304
+msgctxt "Auto context with id 304"
+msgid "Language"
+msgstr "Kieli"
+
+#: id:305
+msgctxt "Auto context with id 305"
+msgid "Enabled"
+msgstr "Käytössä"
+
+#: id:306
+msgid "Non-interleaved"
+msgstr "Lomittamaton"
+
+#: id:312
+msgid "(0=auto)"
+msgstr "(0=auto)"
+
+#: id:313
+msgid "Cleaning database"
+msgstr "Tietokannan puhdistus"
+
+#: id:314
+msgid "Preparing..."
+msgstr "Valmistellaan..."
+
+#: id:315
+msgid "Database error"
+msgstr "Tietokantavirhe"
+
+#: id:316
+msgid "Searching songs..."
+msgstr "Etsitään kappaleet..."
+
+#: id:317
+msgid "Cleaned database successfully"
+msgstr "Tietokannan puhdistus valmis"
+
+#: id:318
+msgid "Cleaning songs..."
+msgstr "Puhdistetaan kappaleet..."
+
+#: id:319
+msgid "Error cleaning songs"
+msgstr "Virhe kappaleiden puhdistuksessa"
+
+#: id:320
+msgid "Cleaning artists..."
+msgstr "Puhdistetaan esittäjät..."
+
+#: id:321
+msgid "Error cleaning artists"
+msgstr "Virhe esittäjien puhdistuksessa"
+
+#: id:322
+msgid "Cleaning genres..."
+msgstr "Puhdistetaan lajityypit..."
+
+#: id:323
+msgid "Error cleaning genres"
+msgstr "Virhe lajityyppien puhdistuksessa"
+
+#: id:324
+msgid "Cleaning paths..."
+msgstr "Puhdistetaan tiedostopolut..."
+
+#: id:325
+msgid "Error cleaning paths"
+msgstr "Virhe tiedostopolkujen puhdistuksessa"
+
+#: id:326
+msgid "Cleaning albums..."
+msgstr "Puhdistetaan albumit..."
+
+#: id:327
+msgid "Error cleaning albums"
+msgstr "Virhe albumien puhdistuksessa"
+
+#: id:328
+msgid "Writing changes..."
+msgstr "Tallennetaan muutokset..."
+
+#: id:329
+msgid "Error writing changes"
+msgstr "Virhe muutoksien tallennuksessa"
+
+#: id:330
+msgid "This may take some time..."
+msgstr "Odota, tämä kestää jonkin aikaa..."
+
+#: id:331
+msgid "Compressing database..."
+msgstr "Tiivistetään tietokantaa..."
+
+#: id:332
+msgid "Error compressing database"
+msgstr "Virhe tietokannan tiivistyksessä"
+
+#: id:333
+msgid "Do you want to clean the library?"
+msgstr "Haluatko puhdistaa kirjaston?"
+
+#: id:334
+msgid "Clean library..."
+msgstr "Kirjaston puhdistus..."
+
+#: id:335
+msgid "Start"
+msgstr "Aloita"
+
+#: id:336
+msgid "Framerate conversion"
+msgstr "Kuvataajuuden muunto"
+
+#: id:337
+msgctxt "Auto context with id 337"
+msgid "Audio output"
+msgstr "Äänilähtö"
+
+#: id:338
+msgid "Analog"
+msgstr "Analoginen"
+
+#: id:339
+msgid "Optical/Coax"
+msgstr "Optinen/koaksiaali"
+
+#: id:340
+msgid "Various artists"
+msgstr "Eri esittäjiä"
+
+#: id:341
+msgid "Play disc"
+msgstr "Toista levy"
+
+#: id:342
+msgctxt "Auto context with id 342"
+msgid "Movies"
+msgstr "Elokuvat"
+
+#: id:343
+msgid "Adjust framerate"
+msgstr "Sovita kuvataajuus"
+
+#: id:344
+msgid "Actors"
+msgstr "Näyttelijät"
+
+#: id:345
+msgctxt "Auto context with id 345"
+msgid "Year"
+msgstr "Vuosi"
+
+#: id:346
+msgid "Boost volume level on downmix"
+msgstr "Lisää äänenvoimakkuutta äänikanavia yhdistettäessä"
+
+#: id:350
+msgctxt "Auto context with id 350"
+msgid "Programs"
+msgstr "Ohjelmat"
+
+#: id:351
+msgctxt "Auto context with id 351"
+msgid "Off"
+msgstr "Ei käytössä"
+
+#: id:352
+msgid "Dim"
+msgstr "Tummennus"
+
+#: id:353
+msgid "Black"
+msgstr "Musta"
+
+#: id:354
+msgid "Matrix trails"
+msgstr "Matriisiviivat"
+
+#: id:355
+msgid "Screensaver time"
+msgstr "Näytönsäästäjän viive"
+
+#: id:356
+msgid "Screensaver mode"
+msgstr "Näytönsäästäjä"
+
+#: id:357
+msgid "Shutdown function timer"
+msgstr "Laitteen sammutusajastus"
+
+#: id:358
+msgid "All albums"
+msgstr "Kaikki albumit"
+
+#: id:359
+msgid "Recently added albums"
+msgstr "Uusimmat albumit"
+
+#: id:360
+msgctxt "Auto context with id 360"
+msgid "Screensaver"
+msgstr "Näytönsäästäjä"
+
+#: id:361
+msgid "R. Slideshow"
+msgstr "Kaikkien kuvaesitys"
+
+#: id:362
+msgid "Screensaver dim level"
+msgstr "Näytönsäästäjän läpinäkyvyys"
+
+#: id:363
+msgid "Sort by: File"
+msgstr "Järjestä: Tiedostonimi"
+
+#: id:364
+msgid "- Dolby Digital (AC3) capable receiver"
+msgstr "- Dolby Digital (AC3) -yhteensopiva vastaanotin"
+
+#: id:365
+msgctxt "Auto context with id 365"
+msgid "Sort by: Name"
+msgstr "Järjestä: Nimi"
+
+#: id:366
+msgid "Sort by: Year"
+msgstr "Järjestä: Vuosi"
+
+#: id:367
+msgid "Sort by: Rating"
+msgstr "Järjestä: Arvosana"
+
+#: id:368
+msgid "IMDb"
+msgstr "IMDb"
+
+#: id:369
+msgctxt "Auto context with id 369"
+msgid "Title"
+msgstr "Nimi"
+
+#: id:370
+msgid "Thunderstorms"
+msgstr "ukkosmyrskyjä"
+
+#: id:371
+msgid "Partly"
+msgstr "osittain"
+
+#: id:372
+msgid "Mostly"
+msgstr "enimmäkseen"
+
+#: id:373
+msgid "Sunny"
+msgstr "aurinkoista"
+
+#: id:374
+msgid "Cloudy"
+msgstr "pilvistä"
+
+#: id:375
+msgid "Snow"
+msgstr "lumisadetta"
+
+#: id:376
+msgid "Rain"
+msgstr "vesisadetta"
+
+#: id:377
+msgid "Light"
+msgstr "heikkoa"
+
+#: id:378
+msgid "AM"
+msgstr "aamupäivällä"
+
+#: id:379
+msgid "PM"
+msgstr "iltapäivällä"
+
+#: id:380
+msgid "Showers"
+msgstr "sadekuuroja"
+
+#: id:381
+msgid "Few"
+msgstr "joitakin"
+
+#: id:382
+msgid "Scattered"
+msgstr "hajanaisia"
+
+#: id:383
+msgctxt "Auto context with id 383"
+msgid "Wind"
+msgstr "tuulista"
+
+#: id:384
+msgid "Strong"
+msgstr "voimakasta"
+
+#: id:385
+msgid "Fair"
+msgstr "poutaa"
+
+#: id:386
+msgctxt "Auto context with id 386"
+msgid "Clear"
+msgstr "selkeää"
+
+#: id:387
+msgid "Clouds"
+msgstr "pilvistä"
+
+#: id:388
+msgid "Early"
+msgstr "aamulla"
+
+#: id:389
+msgid "Shower"
+msgstr "sadekuuro"
+
+#: id:390
+msgid "Flurries"
+msgstr "lumipyryä"
+
+#: id:391
+msgctxt "Auto context with id 391"
+msgid "Low"
+msgstr "alhainen"
+
+#: id:392
+msgctxt "Auto context with id 392"
+msgid "Medium"
+msgstr "keskimääräinen"
+
+#: id:393
+msgctxt "Auto context with id 393"
+msgid "High"
+msgstr "voimakas"
+
+#: id:394
+msgid "Fog"
+msgstr "sumua"
+
+#: id:395
+msgid "Haze"
+msgstr "usvaa"
+
+#: id:396
+msgid "Select location"
+msgstr "Valitse sijainti"
+
+#: id:397
+msgid "Refresh time"
+msgstr "Päivitysväli"
+
+#: id:398
+msgid "Temperature units"
+msgstr "Lämpötilan yksikkö"
+
+#: id:399
+msgid "Speed units"
+msgstr "Tuulen nopeuden yksikkö"
+
+#: id:400
+msgctxt "Auto context with id 400"
+msgid "Weather"
+msgstr "Sää"
+
+#: id:401
+msgid "Temp"
+msgstr "Lämpötila"
+
+#: id:402
+msgid "Feels like"
+msgstr "Tuntuu kuin"
+
+#: id:403
+msgid "UV index"
+msgstr "UV-indeksi"
+
+#: id:404
+msgctxt "Auto context with id 404"
+msgid "Wind"
+msgstr "Tuuli"
+
+#: id:405
+msgid "Dew point"
+msgstr "Kastepiste"
+
+#: id:406
+msgid "Humidity"
+msgstr "Kosteus"
+
+#: id:409
+msgid "Defaults"
+msgstr "Oletukset"
+
+#: id:410
+msgid "Accessing weather service"
+msgstr "Yhdistetään sääpalveluun"
+
+#: id:411
+msgid "Getting weather for:"
+msgstr "Noudetaan säätiedot:"
+
+#: id:412
+msgid "Unable to get weather data"
+msgstr "Säätietoja ei saatu"
+
+#: id:413
+msgid "Manual"
+msgstr "Manuaalisesti"
+
+#: id:414
+msgid "No review for this album"
+msgstr "Tälle albumille ei ole esittelyä"
+
+#: id:415
+msgid "Downloading thumbnail..."
+msgstr "Ladataan pienoiskuvaa..."
+
+#: id:416
+msgid "Not available"
+msgstr "Ei saatavilla"
+
+#: id:417
+msgid "View: Big icons"
+msgstr "Näytä: Suuret kuvak."
+
+#: id:418
+msgctxt "Auto context with id 418"
+msgid "Low"
+msgstr "Alin"
+
+#: id:419
+msgctxt "Auto context with id 419"
+msgid "High"
+msgstr "Ylin"
+
+#: id:420
+msgid "HDMI"
+msgstr "HDMI"
+
+#: id:422
+msgid "Delete album info"
+msgstr "Poista albumin tiedot"
+
+#: id:423
+msgid "Delete CD information"
+msgstr "Poista CD-tiedot"
+
+#: id:424
+msgid "Select"
+msgstr "Valitse"
+
+#: id:425
+msgid "No album information found"
+msgstr "Albumin tietoja ei löytynyt"
+
+#: id:426
+msgid "No CD information found"
+msgstr "CD-tietoja ei löytynyt"
+
+#: id:427
+msgid "Disc"
+msgstr "Levy"
+
+#: id:428
+msgid "Insert correct CD/DVD"
+msgstr "Aseta oikea CD/DVD-levy"
+
+#: id:429
+msgid "Please insert the following disc:"
+msgstr "Aseta seuraava CD/DVD-levy"
+
+#: id:430
+msgid "Sort by: DVD#"
+msgstr "Järjestä: DVD nro"
+
+#: id:431
+msgid "No cache"
+msgstr "Ei välimuistia"
+
+#: id:432
+msgid "Remove movie from library"
+msgstr "Poista elokuva kirjastosta"
+
+#: id:433
+msgid "Really remove '%s'?"
+msgstr "Haluatko varmasti poistaa kohteen[CR]'%s'?"
+
+#: id:434
+msgid "From %s at %i %s"
+msgstr "%s %i %s"
+
+#: id:437
+msgid "Removable disk"
+msgstr "Siirrettävä levy"
+
+#: id:438
+msgid "Opening file"
+msgstr "Avataan tiedosto"
+
+#: id:439
+msgid "Cache"
+msgstr "Välimuistit"
+
+#: id:440
+msgid "Harddisk"
+msgstr "Kiintolevy"
+
+#: id:441
+msgid "UDF"
+msgstr "UDF-levy"
+
+#: id:442
+msgid "Local network"
+msgstr "Paikallisverkosta"
+
+#: id:443
+msgid "Internet"
+msgstr "Internetistä"
+
+#: id:444
+msgctxt "Auto context with id 444"
+msgid "Video"
+msgstr "Video"
+
+#: id:445
+msgctxt "Auto context with id 445"
+msgid "Audio"
+msgstr "Musiikki"
+
+#: id:446
+msgctxt "Auto context with id 446"
+msgid "DVD"
+msgstr "DVD"
+
+#: id:447
+msgid "Autorun media"
+msgstr "Median käynnistys"
+
+#: id:448
+msgid "LCD"
+msgstr "LCD"
+
+#: id:449
+msgctxt "Auto context with id 449"
+msgid "Enabled"
+msgstr "Käytössä"
+
+#: id:450
+msgid "Columns"
+msgstr "Sarakkeita"
+
+#: id:451
+msgid "Row 1 address"
+msgstr "Rivin 1 osoite"
+
+#: id:452
+msgid "Row 2 address"
+msgstr "Rivin 2 osoite"
+
+#: id:453
+msgid "Row 3 address"
+msgstr "Rivin 3 osoite"
+
+#: id:454
+msgid "Row 4 address"
+msgstr "Rivin 4 osoite"
+
+#: id:455
+msgid "Rows"
+msgstr "Rivejä"
+
+#: id:456
+msgid "Mode"
+msgstr "Tila"
+
+#: id:457
+msgid "Switch view"
+msgstr "Vaihda näkymä"
+
+#: id:459
+msgid "Subs"
+msgstr "Tekstit"
+
+#: id:460
+msgid "Audio stream"
+msgstr "Ääniraita"
+
+#: id:461
+msgid "[active]"
+msgstr "[käytössä]"
+
+#: id:462
+msgid "Subtitle"
+msgstr "Tekstityskieli"
+
+#: id:463
+msgid "Backlight"
+msgstr "Taustavalo"
+
+#: id:464
+msgid "Brightness"
+msgstr "Kirkkaus"
+
+#: id:465
+msgid "Contrast"
+msgstr "Kontrasti"
+
+#: id:466
+msgid "Gamma"
+msgstr "Gamma"
+
+#: id:467
+msgctxt "Auto context with id 467"
+msgid "Type"
+msgstr "Tyyppi"
+
+#: id:468
+msgid "Move the bar to change the OSD position"
+msgstr "Siirrä kuvaruutuvalikon sijaintia pystysuunnassa"
+
+#: id:469
+msgid "OSD position"
+msgstr "Kuvaruutuvalikon sijainti"
+
+#: id:470
+msgid "Credits"
+msgstr "Tekijät"
+
+#: id:471
+msgid "Modchip"
+msgstr "Mod-piiri"
+
+#: id:474
+msgctxt "Auto context with id 474"
+msgid "Off"
+msgstr "Ei käytössä"
+
+#: id:475
+msgid "Music only"
+msgstr "Vain musiikilla"
+
+#: id:476
+msgctxt "Auto context with id 476"
+msgid "Music & video"
+msgstr "Musiikki ja videot"
+
+#: id:477
+msgid "Unable to load playlist"
+msgstr "Toistolistaa ei voitu ladata"
+
+#: id:478
+msgid "OSD"
+msgstr "Kuvaruutuvalikko"
+
+#: id:479
+msgid "Skin & language"
+msgstr "Ulkoasu ja kielivalinnat"
+
+#: id:480
+msgid "Appearance"
+msgstr "Käyttöliittymä"
+
+#: id:481
+msgid "Audio options"
+msgstr "Ääniasetukset"
+
+#: id:482
+msgid "About XBMC"
+msgstr "Tietoja XBMC:stä"
+
+#: id:485
+msgid "Delete album"
+msgstr "Poista albumin tiedot"
+
+#: id:486
+msgid "Repeat"
+msgstr "Jatkuva toisto"
+
+#: id:487
+msgid "Repeat one"
+msgstr "Kappaleen toisto"
+
+#: id:488
+msgid "Repeat folder"
+msgstr "Kansion toisto"
+
+#: id:489
+msgid "Play the next song automatically"
+msgstr "Toista seuraava tiedosto automaattisesti"
+
+#: id:491
+msgid "- Use big icons"
+msgstr "Suuret kuvakkeet"
+
+#: id:492
+msgid "Resize VobSubs"
+msgstr "Tekstityksen koko"
+
+#: id:493
+msgid "Advanced options (Experts Only!)"
+msgstr "Lisäasetukset (vain edistyneille käyttäjille!)"
+
+#: id:494
+msgid "Overall audio headroom"
+msgstr "Äänen tilantunne (dB)"
+
+#: id:495
+msgid "Upsample videos to GUI resolution"
+msgstr "Sovita videot käyttöliittymän resoluutioon"
+
+#: id:496
+msgid "Calibration"
+msgstr "Kuvaruudun säätö"
+
+#: id:497
+msgid "Show file extensions"
+msgstr "Näytä tiedostojen päätteet"
+
+#: id:498
+msgid "Sort by: Type"
+msgstr "Järjestä: Tyyppi"
+
+#: id:499
+msgid "Unable to connect to online lookup service"
+msgstr "Tietojen hakuosoitteeseen ei saada yhteyttä"
+
+#: id:500
+msgid "Downloading album information failed"
+msgstr "Albumitietojen nouto epäonnistui"
+
+#: id:501
+msgid "Looking for album names..."
+msgstr "Etsitään albumin nimellä..."
+
+#: id:502
+msgctxt "Auto context with id 502"
+msgid "Open"
+msgstr "Avoinna"
+
+#: id:503
+msgid "Busy"
+msgstr "Odota"
+
+#: id:504
+msgid "Empty"
+msgstr "Ei levyä"
+
+#: id:505
+msgid "Loading media info from files..."
+msgstr "Luetaan tiedostojen mediatiedot..."
+
+#: id:507
+msgid "Sort by: Usage"
+msgstr "Järjestä: Käyttö"
+
+#: id:510
+msgid "Enable visualizations"
+msgstr "Visualisoinnit käytössä"
+
+#: id:511
+msgid "Enable video mode switching"
+msgstr "Salli videojärjestelmän vaihto"
+
+#: id:512
+msgid "Startup window"
+msgstr "Aloitusikkuna"
+
+#: id:513
+msgid "Home window"
+msgstr "Päävalikko"
+
+#: id:514
+msgid "Manual settings"
+msgstr "Manuaaliset asetukset"
+
+#: id:515
+msgid "Genre"
+msgstr "Lajityyppi"
+
+#: id:517
+msgid "Recently played albums"
+msgstr "Viimeksi toistetut albumit"
+
+#: id:518
+msgid "Launch"
+msgstr "Käynnistä"
+
+#: id:519
+msgid "Launch in..."
+msgstr "Käynnistys..."
+
+#: id:521
+msgid "Compilations"
+msgstr "Kokoelmat"
+
+#: id:522
+msgid "Remove source"
+msgstr "Poista sijainti"
+
+#: id:523
+msgid "Switch media"
+msgstr "Vaihda mediavalikkoa"
+
+#: id:524
+msgid "Select playlist"
+msgstr "Valitse toistolista"
+
+#: id:525
+msgid "New playlist..."
+msgstr "Uusi toistolista..."
+
+#: id:526
+msgid "Add to playlist"
+msgstr "Lisää toistolistalle"
+
+#: id:527
+msgid "Manually add to library"
+msgstr "Lisää kirjastoon"
+
+#: id:528
+msgid "Enter title"
+msgstr "Anna nimi"
+
+#: id:529
+msgid "Error: Duplicate title"
+msgstr "Virhe: Nimi on jo olemassa"
+
+#: id:530
+msgid "Select genre"
+msgstr "Valitse näytettävä lajityyppi"
+
+#: id:531
+msgid "New genre"
+msgstr "Uusi tyyli"
+
+#: id:532
+msgid "Manual addition"
+msgstr "Oma lisäys"
+
+#: id:533
+msgid "Enter genre"
+msgstr "Anna lajityyppi"
+
+#: id:534
+msgid "View: %s"
+msgstr "Näytä: %s"
+
+#: id:535
+msgid "List"
+msgstr "Lista"
+
+#: id:536
+msgid "Icons"
+msgstr "Kuvakkeet"
+
+#: id:537
+msgid "Big list"
+msgstr "Suuri lista"
+
+#: id:538
+msgid "Big icons"
+msgstr "Suuret kuvak."
+
+#: id:539
+msgid "Wide"
+msgstr "Leveä"
+
+#: id:540
+msgid "Big wide"
+msgstr "Suuri ja leveä"
+
+#: id:541
+msgid "Album icons"
+msgstr "Albumikuvakkeet"
+
+#: id:542
+msgid "DVD icons"
+msgstr "DVD-kuvakkeet"
+
+#: id:543
+msgctxt "Auto context with id 543"
+msgid "DVD"
+msgstr "DVD"
+
+#: id:544
+msgctxt "Auto context with id 544"
+msgid "Media info"
+msgstr "Mediatiedot"
+
+#: id:545
+msgid "Audio output device"
+msgstr "Äänen ulostulo"
+
+#: id:546
+msgid "Passthrough output device"
+msgstr "Pakatun äänen ulostulo"
+
+#: id:547
+msgid "No biography for this artist"
+msgstr "Esittäjästä ei ole tietoja"
+
+#: id:548
+msgid "Downmix multichannel audio to stereo"
+msgstr "Yhdistä monikanavaiset äänet stereoksi"
+
+#: id:550
+msgid "Sort by: %s"
+msgstr "Järjestä: %s"
+
+#: id:551
+msgctxt "Auto context with id 551"
+msgid "Name"
+msgstr "Nimi"
+
+#: id:552
+msgid "Date"
+msgstr "Päiväys"
+
+#: id:553
+msgid "Size"
+msgstr "Koko"
+
+#: id:554
+msgid "Track"
+msgstr "Raita"
+
+#: id:555
+msgid "Time"
+msgstr "Kesto"
+
+#: id:556
+msgctxt "Auto context with id 556"
+msgid "Title"
+msgstr "Kappale"
+
+#: id:557
+msgid "Artist"
+msgstr "Esittäjä"
+
+#: id:558
+msgid "Album"
+msgstr "Albumi"
+
+#: id:559
+msgid "Playlist"
+msgstr "Toistolista"
+
+#: id:560
+msgid "ID"
+msgstr "ID"
+
+#: id:561
+msgctxt "Auto context with id 561"
+msgid "File"
+msgstr "Tiedosto"
+
+#: id:562
+msgctxt "Auto context with id 562"
+msgid "Year"
+msgstr "Vuosi"
+
+#: id:563
+msgid "Rating"
+msgstr "Arvosana"
+
+#: id:564
+msgctxt "Auto context with id 564"
+msgid "Type"
+msgstr "Tyyppi"
+
+#: id:565
+msgid "Usage"
+msgstr "Käyttö"
+
+#: id:566
+msgid "Album artist"
+msgstr "Albumin esittäjä"
+
+#: id:567
+msgid "Play count"
+msgstr "Toistomäärä"
+
+#: id:568
+msgid "Last played"
+msgstr "Viimeksi toistettu"
+
+#: id:569
+msgctxt "Auto context with id 569"
+msgid "Comment"
+msgstr "Kommentti"
+
+#: id:570
+msgid "Date added"
+msgstr "Lisäyspäivä"
+
+#: id:571
+msgctxt "Auto context with id 571"
+msgid "Default"
+msgstr "Oletus"
+
+#: id:572
+msgid "Studio"
+msgstr "Studio"
+
+#: id:573
+msgid "Path"
+msgstr "Polku"
+
+#: id:574
+msgctxt "Auto context with id 574"
+msgid "Country"
+msgstr "Maa"
+
+#: id:575
+msgid "In progress"
+msgstr "Katselu kesken"
+
+#: id:576
+msgid "Times played"
+msgstr "Toistokertoja"
+
+#: id:580
+msgid "Sort direction"
+msgstr "Järjestelyn suunta"
+
+#: id:581
+msgid "Sort method"
+msgstr "Järjestelymenetelmä"
+
+#: id:582
+msgctxt "Auto context with id 582"
+msgid "View mode"
+msgstr "Näyttötapa"
+
+#: id:583
+msgid "Remember views for different folders"
+msgstr "Muista jokaisen kansion näyttötapa"
+
+#: id:584
+msgid "Ascending"
+msgstr "Nouseva"
+
+#: id:585
+msgid "Descending"
+msgstr "Laskeva"
+
+#: id:586
+msgid "Edit playlist"
+msgstr "Muokkaa toistolistaa"
+
+#: id:587
+msgid "Filter"
+msgstr "Suodata"
+
+#: id:588
+msgid "Cancel party mode"
+msgstr "Keskeytä jukeboksi"
+
+#: id:589
+msgid "Party mode"
+msgstr "Jukeboksi"
+
+#: id:590
+msgid "Random"
+msgstr "Satunnainen"
+
+#: id:591
+msgctxt "Auto context with id 591"
+msgid "Off"
+msgstr "Ei käytössä"
+
+#: id:592
+msgid "One"
+msgstr "Yksi"
+
+#: id:593
+msgid "All"
+msgstr "Kaikki"
+
+#: id:594
+msgctxt "Auto context with id 594"
+msgid "Off"
+msgstr "Ei"
+
+#: id:595
+msgid "Repeat: Off"
+msgstr "Toistuvasti: Ei"
+
+#: id:596
+msgid "Repeat: One"
+msgstr "Toistuvasti: Kappale"
+
+#: id:597
+msgid "Repeat: All"
+msgstr "Toistuvasti: Kaikki"
+
+#: id:600
+msgid "Rip audio CD"
+msgstr "Siirrä ääni-CD-levy kiintolevylle"
+
+#: id:601
+msgctxt "Auto context with id 601"
+msgid "Medium"
+msgstr "Keskimääräinen"
+
+#: id:602
+msgctxt "Auto context with id 602"
+msgid "Standard"
+msgstr "Normaali"
+
+#: id:603
+msgid "Extreme"
+msgstr "Erittäin korkea"
+
+#: id:604
+msgid "Constant bitrate"
+msgstr "Vakiobittinopeus"
+
+#: id:605
+msgid "Ripping..."
+msgstr "Siirretään..."
+
+#: id:607
+msgid "To:"
+msgstr "Tallennetaan:"
+
+#: id:608
+msgid "Could not rip CD or track"
+msgstr "CD:tä tai kappaletta ei pystytty siirtämään"
+
+#: id:609
+msgid "CDDARipPath is not set."
+msgstr "Tallennuskansiota ei ole määritetty."
+
+#: id:610
+msgid "Rip audio track"
+msgstr "Siirrä kappale kiintolevylle"
+
+#: id:611
+msgid "Enter number"
+msgstr "Anna numero"
+
+#: id:612
+msgid "Bits/Sample"
+msgstr "Bittiä/Näyte"
+
+#: id:613
+msgid "Sample Frequency"
+msgstr "Näytteenottotaajuus"
+
+#: id:620
+msgid "Audio CDs"
+msgstr "Ääni-CD-levyt"
+
+#: id:621
+msgid "Encoder"
+msgstr "Enkooderi"
+
+#: id:622
+msgid "Quality"
+msgstr "Laatu"
+
+#: id:623
+msgid "Bitrate"
+msgstr "Bittinopeus"
+
+#: id:624
+msgid "Include track number"
+msgstr "Lisää kappaleen numero"
+
+#: id:625
+msgid "All songs of"
+msgstr "Kaikki kappaleet"
+
+#: id:629
+msgctxt "Auto context with id 629"
+msgid "View mode"
+msgstr "Näyttötapa"
+
+#: id:630
+msgctxt "Auto context with id 630"
+msgid "Normal"
+msgstr "Normaali"
+
+#: id:631
+msgid "Zoom"
+msgstr "Zoomaus"
+
+#: id:632
+msgid "Stretch 4:3"
+msgstr "Venytä kokoon 4:3"
+
+#: id:633
+msgid "Wide Zoom"
+msgstr "Leveyden zoomaus"
+
+#: id:634
+msgid "Stretch 16:9"
+msgstr "Venytä kokoon 16:9"
+
+#: id:635
+msgid "Original Size"
+msgstr "Alkuperäinen koko"
+
+#: id:636
+msgctxt "Auto context with id 636"
+msgid "Custom"
+msgstr "Mukautettu"
+
+#: id:637
+msgid "Replay gain"
+msgstr "Tasonkorjaus"
+
+#: id:638
+msgid "Replaygain volume adjustments"
+msgstr "Tasonkorjaus-tilan säädöt"
+
+#: id:639
+msgid "Use track levels"
+msgstr "Käytä kappaletasoja"
+
+#: id:640
+msgid "Use album levels"
+msgstr "Käytä albumitasoja"
+
+#: id:641
+msgid "PreAmp Level - Replay gained files"
+msgstr "Esivahvistustaso - tasokorjatut"
+
+#: id:642
+msgid "PreAmp Level - Non replay gained files"
+msgstr "Esivahvistustaso - tasokorjaamattomat"
+
+#: id:643
+msgid "Avoid clipping on replay gained files"
+msgstr "Vältä äänen leikkautumista tasokorjatuissa tiedostoissa"
+
+#: id:644
+msgid "Crop black bars"
+msgstr "Rajaa mustat palkit pois"
+
+#: id:645
+msgid "Need to unpack a big file. Continue?"
+msgstr "Suuri tiedosto täytyy purkaa ensin. Jatketaanko?"
+
+#: id:646
+msgid "Remove from library"
+msgstr "Poista kirjastosta"
+
+#: id:647
+msgid "Export video library"
+msgstr "Vie videokirjasto"
+
+#: id:648
+msgid "Import video library"
+msgstr "Tuo videokirjasto"
+
+#: id:649
+msgid "Importing"
+msgstr "Tuodaan"
+
+#: id:650
+msgid "Exporting"
+msgstr "Viedään"
+
+#: id:651
+msgid "Browse for library"
+msgstr "Valitse kirjasto"
+
+#: id:652
+msgid "Years"
+msgstr "Vuodet"
+
+#: id:653
+msgid "Update library"
+msgstr "Päivitä kirjasto"
+
+#: id:654
+msgid "Show debug info"
+msgstr "Näytä suoritustiedot"
+
+#: id:655
+msgid "Browse for executable"
+msgstr "Valitse ohjelma"
+
+#: id:656
+msgid "Browse for playlist"
+msgstr "Valitse toistolista"
+
+#: id:657
+msgid "Browse for folder"
+msgstr "Valitse kansio"
+
+#: id:658
+msgid "Song information"
+msgstr "Kappaleen tiedot"
+
+#: id:659
+msgid "Non-linear stretch"
+msgstr "Epälineaarinen venytys"
+
+#: id:660
+msgid "Volume amplification"
+msgstr "Voimakkuuden vahvistus"
+
+#: id:661
+msgid "Choose export folder"
+msgstr "Valitse vientikansio"
+
+#: id:662
+msgid "This file is no longer available."
+msgstr "Valittu tiedosto ei ole enää saatavilla"
+
+#: id:663
+msgid "Would you like to remove it from the library?"
+msgstr "Haluatko poistaa sen kirjastosta?"
+
+#: id:664
+msgid "Browse for Script"
+msgstr "Valitse skripti"
+
+#: id:665
+msgid "Compression level"
+msgstr "Pakkaustaso"
+
+#: id:700
+msgid "Cleaning up library"
+msgstr "Puhdistetaan kirjastoa"
+
+#: id:701
+msgid "Removing old songs from the library"
+msgstr "Poistetaan vanhat kappaleet kirjastosta"
+
+#: id:702
+msgid "This path has been scanned before"
+msgstr "Tämä polku on luettu aiemmin"
+
+#: id:705
+msgctxt "Auto context with id 705"
+msgid "Network"
+msgstr "Verkko"
+
+#: id:706
+msgid "- Server"
+msgstr "- Palvelin"
+
+#: id:708
+msgid "Use an HTTP proxy server to access the internet"
+msgstr "Internet-yhteys HTTP-välipalvelimen kautta"
+
+#: id:711
+msgid "Internet Protocol (IP)"
+msgstr "Internet-asetukset"
+
+#: id:712
+msgid "Invalid port specified. Value must be between 1 and 65535."
+msgstr "Portti ei kelpaa. Arvon on oltava 1 ja 65535 välillä."
+
+#: id:713
+msgid "HTTP proxy"
+msgstr "HTTP-välipalvelin"
+
+#: id:715
+msgid "- Assignment"
+msgstr "- Määritys"
+
+#: id:716
+msgid "Automatic (DHCP)"
+msgstr "Automaattinen (DHCP)"
+
+#: id:717
+msgid "Manual (Static)"
+msgstr "Manuaalinen (Kiinteä)"
+
+#: id:719
+msgid "- IP address"
+msgstr "- IP-osoite"
+
+#: id:720
+msgid "- Netmask"
+msgstr "- Aliverkon peite"
+
+#: id:721
+msgid "- Default gateway"
+msgstr "- Oletusyhdyskäytävä"
+
+#: id:722
+msgid "- DNS server"
+msgstr "- Nimipalvelin (DNS)"
+
+#: id:723
+msgid "Save & restart"
+msgstr "Tallenna ja uudelleenkäynnistä"
+
+#: id:724
+msgid "Invalid address specified. Value must be AAA.BBB.CCC.DDD"
+msgstr "Osoite on oltava muodossa AAA.BBB.CCC.DDD"
+
+#: id:725
+msgid "with numbers between 0 and 255."
+msgstr "ja numerot väliltä 0 - 255."
+
+#: id:726
+msgid "Changes not saved. Continue without saving?"
+msgstr "Muutoksia ei ole tallennettu. Poistutaanko tallentamatta?"
+
+#: id:727
+msgid "Web server"
+msgstr "Web-palvelin"
+
+#: id:728
+msgctxt "Auto context with id 728"
+msgid "FTP server"
+msgstr "FTP-palvelin"
+
+#: id:730
+msgid "- Port"
+msgstr "- Portti"
+
+#: id:732
+msgid "Save & apply"
+msgstr "Tallenna ja ota käyttöön"
+
+#: id:733
+msgid "- Password"
+msgstr "- Salasana"
+
+#: id:734
+msgid "No pass"
+msgstr "Ei salasanaa"
+
+#: id:735
+msgid "- Character set"
+msgstr "- Merkistö"
+
+#: id:736
+msgid "- Style"
+msgstr "- Tyyli"
+
+#: id:737
+msgid "- Colour"
+msgstr "- Väri"
+
+#: id:738
+msgctxt "Auto context with id 738"
+msgid "Normal"
+msgstr "Normaali"
+
+#: id:739
+msgid "Bold"
+msgstr "Lihavoitu"
+
+#: id:740
+msgid "Italics"
+msgstr "Kursivoitu"
+
+#: id:741
+msgid "Bold italics"
+msgstr "Lihavoitu ja kursivoitu"
+
+#: id:742
+msgctxt "Auto context with id 742"
+msgid "White"
+msgstr "Valkoinen"
+
+#: id:743
+msgctxt "Auto context with id 743"
+msgid "Yellow"
+msgstr "Keltainen"
+
+#: id:744
+msgctxt "Auto context with id 744"
+msgid "Files"
+msgstr "Tiedostot"
+
+#: id:745
+msgid "No scanned information for this view"
+msgstr "Tälle tilalle ei ole luettu mediatietoja,"
+
+#: id:746
+msgid "Please turn off library mode"
+msgstr "siirry pois kirjasto tilasta"
+
+#: id:747
+msgid "Error loading image"
+msgstr "Kuvan lataus epäonnistui"
+
+#: id:748
+msgid "Edit path"
+msgstr "Muokkaa polkua"
+
+#: id:749
+msgid "Mirror image"
+msgstr "Peilikuva"
+
+#: id:750
+msgid "Are you sure?"
+msgstr "Oletko varma asiasta?"
+
+#: id:751
+msgid "Removing source"
+msgstr "Poistetaan sijainti"
+
+#: id:754
+msgid "Add program link"
+msgstr "Lisää linkki ohjelmaan"
+
+#: id:755
+msgid "Edit program path"
+msgstr "Muokkaa ohjelman polkua"
+
+#: id:756
+msgid "Edit program name"
+msgstr "Muokkaa ohjelman nimeä"
+
+#: id:757
+msgid "Edit path depth"
+msgstr "Muokkaa polun syvyyttä"
+
+#: id:759
+msgid "View: Big list"
+msgstr "Suuri luettelo"
+
+#: id:760
+msgctxt "Auto context with id 760"
+msgid "Yellow"
+msgstr "Keltainen"
+
+#: id:761
+msgctxt "Auto context with id 761"
+msgid "White"
+msgstr "Valkoinen"
+
+#: id:762
+msgid "Blue"
+msgstr "Sininen"
+
+#: id:763
+msgid "Bright green"
+msgstr "Kirkkaanvihreä"
+
+#: id:764
+msgid "Yellow green"
+msgstr "Keltavihreä"
+
+#: id:765
+msgid "Cyan"
+msgstr "Sinivihreä"
+
+#: id:766
+msgid "Light grey"
+msgstr "Vaaleanharmaa"
+
+#: id:767
+msgid "Grey"
+msgstr "Harmaa"
+
+#: id:770
+msgid "Error %i: share not available"
+msgstr "Virhe %i: sijaintia ei ole saatavilla"
+
+#: id:772
+msgctxt "Auto context with id 772"
+msgid "Audio output"
+msgstr "Äänilähtö"
+
+#: id:773
+msgid "Seeking"
+msgstr "Haku"
+
+#: id:774
+msgid "Slideshow folder"
+msgstr "Kuvaesityskansio"
+
+#: id:775
+msgid "Network interface"
+msgstr "Verkkoliitäntä"
+
+#: id:776
+msgid "- Wireless network name (ESSID)"
+msgstr "- Langattoman verkon nimi (ESSID)"
+
+#: id:777
+msgid "- Wireless password"
+msgstr "- Langattoman verkon salasana"
+
+#: id:778
+msgid "- Wireless security"
+msgstr "- Langattoman verkon suojaus"
+
+#: id:779
+msgid "Save and apply network interface settings"
+msgstr "Tallenna ja ota asetukset käyttöön"
+
+#: id:780
+msgid "No encryption"
+msgstr "Ei salausta"
+
+#: id:781
+msgid "WEP"
+msgstr "WEP"
+
+#: id:782
+msgid "WPA"
+msgstr "WPA"
+
+#: id:783
+msgid "WPA2"
+msgstr "WPA2"
+
+#: id:784
+msgid "Applying network interface settings. Please wait."
+msgstr "Verkkoliitännän asetukset otetaan käyttöön. Odota hetki."
+
+#: id:785
+msgid "Network interface restarted successfully."
+msgstr "Verkkoliitäntä käynnistetty uudelleen."
+
+#: id:786
+msgid "Network interface did not start successfully."
+msgstr "Verkkoliitännän käynnistys ei onnistunut."
+
+#: id:787
+msgid "Interface disabled"
+msgstr "Verkkoliitäntä ei ole käytössä"
+
+#: id:788
+msgid "Network interface disabled successfully."
+msgstr "Verkkoliitäntä poistettu käytöstä."
+
+#: id:789
+msgid "Wireless network name (ESSID)"
+msgstr "Langattoman verkon nimi (ESSID)"
+
+#: id:790
+msgid "Remote control"
+msgstr ""
+
+#: id:791
+msgid "Allow programs on this system to control XBMC"
+msgstr "Salli tämän järjestelmän ohjelmien ohjata XBMC:iä"
+
+#: id:792
+msgctxt "Auto context with id 792"
+msgid "Port"
+msgstr "Portti"
+
+#: id:793
+msgid "Port range"
+msgstr "Porttialue"
+
+#: id:794
+msgid "Allow programs on other systems to control XBMC"
+msgstr "Salli muiden järjestelmien ohjelmien ohjata XBMC:iä"
+
+#: id:795
+msgid "Initial repeat delay (ms)"
+msgstr "Kertatapahtuman viive (ms)"
+
+#: id:796
+msgid "Continuous repeat delay (ms)"
+msgstr "Jatkuvan toiston viive (ms)"
+
+#: id:797
+msgid "Maximum number of clients"
+msgstr "Yhteyksien enimmäismäärä"
+
+#: id:798
+msgid "Internet access"
+msgstr "Internet-yhteys"
+
+#: id:850
+msgid "Invalid port number entered"
+msgstr "Syötetty portin arvo on sopimaton"
+
+#: id:851
+msgid "Valid port range is 1-65535"
+msgstr "Portin oltava väliltä 1-65535"
+
+#: id:852
+msgid "Valid port range is 1024-65535"
+msgstr "Portin oltava väliltä 1024-65535"
+
+#: id:998
+msgid "Add Music..."
+msgstr "Lisää musiikkia..."
+
+#: id:999
+msgid "Add Videos..."
+msgstr "Lisää videoita..."
+
+#: id:1000
+msgid "- Preview"
+msgstr "- Esikatselu"
+
+#: id:1001
+msgid "Unable to connect"
+msgstr "Ei saada yhteyttä"
+
+#: id:1002
+msgid "XBMC was unable to connect to the network location."
+msgstr "XBMC ei saanut yhteyttä verkko-osoitteeseen."
+
+#: id:1003
+msgid "This could be due to the network not being connected."
+msgstr "Saattaa olla, ettei verkkoyhteyttä ole."
+
+#: id:1004
+msgid "Would you like to add it anyway?"
+msgstr "Haluatko silti lisätä sijainnin?"
+
+#: id:1006
+msgctxt "Auto context with id 1006"
+msgid "IP address"
+msgstr "IP-osoite"
+
+#: id:1007
+msgid "Add network location"
+msgstr "Lisää verkko-osoite"
+
+#: id:1008
+msgid "Protocol"
+msgstr "Protokolla"
+
+#: id:1009
+msgid "Server address"
+msgstr "Palvelimen osoite"
+
+#: id:1010
+msgid "Server name"
+msgstr "Palvelimen nimi"
+
+#: id:1011
+msgid "Remote path"
+msgstr "Verkkopolku"
+
+#: id:1012
+msgid "Shared folder"
+msgstr "Jaettu kansio"
+
+#: id:1013
+msgctxt "Auto context with id 1013"
+msgid "Port"
+msgstr "Portti"
+
+#: id:1014
+msgctxt "Auto context with id 1014"
+msgid "Username"
+msgstr "Käyttäjätunnus"
+
+#: id:1015
+msgid "Browse for network server"
+msgstr "Valitse verkkopalvelin"
+
+#: id:1016
+msgid "Enter the network address of the server"
+msgstr "Anna palvelimen verkko-osoite"
+
+#: id:1017
+msgid "Enter the path on the server"
+msgstr "Anna polku palvelimella"
+
+#: id:1018
+msgid "Enter the port number"
+msgstr "Anna portin numero"
+
+#: id:1019
+msgid "Enter the username"
+msgstr "Anna käyttäjätunnus"
+
+#: id:1020
+msgid "Add %s source"
+msgstr "Lisää %s-sijainti"
+
+#: id:1021
+msgid "Enter the paths or browse for the media locations."
+msgstr "Tiedostojen polku:"
+
+#: id:1022
+msgid "Enter a name for this media Source."
+msgstr "Sijainnin nimi"
+
+#: id:1023
+msgid "Browse for new share"
+msgstr "Valitse uusi sijainti"
+
+#: id:1024
+msgid "Browse"
+msgstr "Selaa"
+
+#: id:1025
+msgid "Could not retrieve directory information."
+msgstr "Ei saatu hakemiston tietoja."
+
+#: id:1026
+msgid "Add source"
+msgstr "Lisää sijainti"
+
+#: id:1027
+msgid "Edit source"
+msgstr "Muokkaa sijaintia"
+
+#: id:1028
+msgid "Edit %s source"
+msgstr "Muokkaa %s-sijaintia"
+
+#: id:1029
+msgid "Enter the new label"
+msgstr "Anna uusi nimi"
+
+#: id:1030
+msgid "Browse for image"
+msgstr "Valitse kuva"
+
+#: id:1031
+msgid "Browse for image folder"
+msgstr "Valitse kuvakansio"
+
+#: id:1032
+msgid "Add network location..."
+msgstr "Lisää verkko-osoite..."
+
+#: id:1033
+msgid "Browse for file"
+msgstr "Valitse tiedosto"
+
+#: id:1034
+msgid "Submenu"
+msgstr "Alivalikko"
+
+#: id:1035
+msgid "Enable submenu buttons"
+msgstr "Alivalikon painikkeet käytössä"
+
+#: id:1036
+msgid "Favourites"
+msgstr "Suosikit"
+
+#: id:1037
+msgid "Video Add-ons"
+msgstr "Videolähteet"
+
+#: id:1038
+msgid "Music Add-ons"
+msgstr "Musiikkilähteet"
+
+#: id:1039
+msgid "Picture Add-ons"
+msgstr "Kuvalähteet"
+
+#: id:1040
+msgid "Loading directory"
+msgstr "Hakemiston lataus"
+
+#: id:1041
+msgid "Retrieved %i items"
+msgstr "Noudettu %i kohdetta"
+
+#: id:1042
+msgid "Retrieved %i of %i items"
+msgstr "Noudettu %i / %i kohdetta"
+
+#: id:1043
+msgid "Program Add-ons"
+msgstr "Ohjelma laajennukset"
+
+#: id:1044
+msgid "Set plugin thumb"
+msgstr "Lisäosan pienoiskuva"
+
+#: id:1045
+msgid "Add-on settings"
+msgstr "Lisäosan asetukset"
+
+#: id:1046
+msgid "Access points"
+msgstr "Yhteyspisteet"
+
+#: id:1047
+msgid "Other..."
+msgstr "Jokin muu..."
+
+#: id:1048
+msgid "- Username"
+msgstr "- Käyttäjätunnus"
+
+#: id:1049
+msgid "Script settings"
+msgstr "Skriptin asetukset"
+
+#: id:1050
+msgid "Singles"
+msgstr "Singlet"
+
+#: id:1051
+msgid "Enter web address"
+msgstr "Anna nettiosoite"
+
+#: id:1200
+msgid "SMB client"
+msgstr "SMB-asiakas"
+
+#: id:1202
+msgid "Workgroup"
+msgstr "Työryhmä"
+
+#: id:1203
+msgid "Default username"
+msgstr "Oletuskäyttäjätunnus"
+
+#: id:1204
+msgid "Default password"
+msgstr "Oletussalasana"
+
+#: id:1207
+msgid "WINS server"
+msgstr "WINS-palvelin"
+
+#: id:1208
+msgid "Mount SMB shares"
+msgstr "Liitä SMB-jaot"
+
+#: id:1210
+msgctxt "Auto context with id 1210"
+msgid "Remove"
+msgstr "Poista"
+
+#: id:1211
+msgctxt "Auto context with id 1211"
+msgid "Music"
+msgstr "Musiikki"
+
+#: id:1212
+msgctxt "Auto context with id 1212"
+msgid "Video"
+msgstr "Video"
+
+#: id:1213
+msgctxt "Auto context with id 1213"
+msgid "Pictures"
+msgstr "Kuvat"
+
+#: id:1214
+msgctxt "Auto context with id 1214"
+msgid "Files"
+msgstr "Tiedostot"
+
+#: id:1215
+msgctxt "Auto context with id 1215"
+msgid "Music & video"
+msgstr "Musiikki ja videot"
+
+#: id:1216
+msgid "Music & pictures"
+msgstr "Musiikki ja kuvat"
+
+#: id:1217
+msgid "Music & files"
+msgstr "Musiikki ja tiedostot"
+
+#: id:1218
+msgid "Video & pictures"
+msgstr "Videot ja kuvat"
+
+#: id:1219
+msgid "Video & files"
+msgstr "Videot ja tiedostot"
+
+#: id:1220
+msgid "Pictures & files"
+msgstr "Kuvat ja tiedostot"
+
+#: id:1221
+msgid "Music & video & pictures"
+msgstr "Musiikki ja videot ja kuvat"
+
+#: id:1222
+msgid "Music & video & pictures & files"
+msgstr "Musiikki ja videot ja kuvat ja tiedostot"
+
+#: id:1223
+msgctxt "Auto context with id 1223"
+msgid "Disabled"
+msgstr "Pois käytöstä"
+
+#: id:1226
+msgid "Files & music & video"
+msgstr "Tiedostot ja musiikki ja videot"
+
+#: id:1227
+msgid "Files & pictures & music"
+msgstr "Tiedostot ja kuvat ja musiikki"
+
+#: id:1228
+msgid "Files & pictures & video"
+msgstr "Tiedostot ja kuvat ja videot"
+
+#: id:1229
+msgid "Music & programs"
+msgstr "Musiikki ja ohjelmat"
+
+#: id:1230
+msgid "Video & programs"
+msgstr "Videot ja ohjelmat"
+
+#: id:1231
+msgid "Pictures & programs"
+msgstr "Kuvat ja ohjelmat"
+
+#: id:1232
+msgid "Music & video & pictures & programs"
+msgstr "Musiikki ja videot ja kuvat ja ohjelmat"
+
+#: id:1233
+msgid "Programs & video & music"
+msgstr "Ohjelmat ja videot ja musiikki"
+
+#: id:1234
+msgid "Programs & pictures & music"
+msgstr "Ohjelmat ja kuvat ja musiikki"
+
+#: id:1235
+msgid "Programs & pictures & video"
+msgstr "Ohjelmat ja kuvat ja videot"
+
+#: id:1250
+msgid "Auto-detection"
+msgstr "Tunnistus"
+
+#: id:1251
+msgid "Auto-detect system"
+msgstr "Järjestelmän automaattitunnistus"
+
+#: id:1252
+msgid "Nickname"
+msgstr "Lempinimi"
+
+#: id:1254
+msgid "Ask to connect"
+msgstr "Kysy ennen yhdistämistä"
+
+#: id:1255
+msgid "Send FTP user and password"
+msgstr "Lähetä FTP-käyttäjätunnus ja salasana"
+
+#: id:1256
+msgid "Ping interval"
+msgstr "Pingauksen väli"
+
+#: id:1257
+msgid "Would you like to connect to the auto-detected system?"
+msgstr "Yhdistetäänkö havaittuun järjestelmään?"
+
+#: id:1259
+msgid "Zeroconf"
+msgstr ""
+
+#: id:1260
+msgid "Announce these services to other systems via Zeroconf"
+msgstr "Julkista nämä palvelut toisiin järjestelmiin Zeroconf-julkaisujärjestelmän kautta"
+
+#: id:1270
+msgid "Allow XBMC to receive AirPlay content"
+msgstr "Salli XBMC:n vastaanottaa AirPlay-sisältöä"
+
+#: id:1271
+msgid "Device name"
+msgstr "Laitteen nimi"
+
+#: id:1272
+msgid "- Use password protection"
+msgstr "- Käytä salasanaa"
+
+#: id:1273
+msgid "AirPlay"
+msgstr ""
+
+#: id:1300
+msgid "Custom audio device"
+msgstr "Mukautettu äänilaite"
+
+#: id:1301
+msgid "Custom passthrough device"
+msgstr "Mukautettu pakatun äänen laite"
+
+#: id:1396
+msgid "Drifting"
+msgstr "kasaantuvaa"
+
+#: id:1397
+msgid "and"
+msgstr "ja"
+
+#: id:1398
+msgid "Freezing"
+msgstr "jäätävää"
+
+#: id:1399
+msgid "Late"
+msgstr "illalla"
+
+#: id:1400
+msgid "Isolated"
+msgstr "yksittäisiä"
+
+#: id:1401
+msgid "Thundershowers"
+msgstr "ukkoskuuroja"
+
+#: id:1402
+msgid "Thunder"
+msgstr "ukkosta"
+
+#: id:1403
+msgctxt "Auto context with id 1403"
+msgid "Sun"
+msgstr "aurinkoista"
+
+#: id:1404
+msgid "Heavy"
+msgstr "kovaa"
+
+#: id:1405
+msgid "in"
+msgstr "on"
+
+#: id:1406
+msgid "the"
+msgstr "tulossa"
+
+#: id:1407
+msgid "Vicinity"
+msgstr "lähiaikana"
+
+#: id:1408
+msgid "Ice"
+msgstr "jäätä"
+
+#: id:1409
+msgid "Crystals"
+msgstr "jääkiteitä"
+
+#: id:1410
+msgid "Calm"
+msgstr "Tyyntä"
+
+#: id:1411
+msgid "with"
+msgstr "sekä"
+
+#: id:1412
+msgid "windy"
+msgstr "tuulista"
+
+#: id:1413
+msgid "drizzle"
+msgstr "tihkusadetta"
+
+#: id:1414
+msgid "Thunderstorm"
+msgstr "ukkosmyrskyä"
+
+#: id:1415
+msgid "Drizzle"
+msgstr "tihkusadetta"
+
+#: id:1416
+msgid "Foggy"
+msgstr "sumuista"
+
+#: id:1417
+msgid "Grains"
+msgstr "rakeita"
+
+#: id:1418
+msgid "T-Storms"
+msgstr "ukkosmyrskyjä"
+
+#: id:1419
+msgid "T-Showers"
+msgstr "ukkoskuuroja"
+
+#: id:1420
+msgid "Moderate"
+msgstr "kohtalainen"
+
+#: id:1421
+msgid "Very High"
+msgstr "hyvin voimakas"
+
+#: id:1422
+msgid "Windy"
+msgstr "tuulinen"
+
+#: id:1423
+msgid "Mist"
+msgstr "utua"
+
+#: id:1450
+msgid "Put display to sleep when idle"
+msgstr "Toimettomana näytön sammutus"
+
+#: id:2050
+msgid "Runtime"
+msgstr "Kesto"
+
+#: id:2100
+msgid "Script failed! : %s"
+msgstr "Skripti virhe! : %s"
+
+#: id:2101
+msgid "Newer version needed - See log"
+msgstr "Tarvitaan uudempi versio - Katso lisää virhelokista"
+
+#: id:4501
+msgid "Enable LCD/VFD"
+msgstr "LCD/VFD käytössä"
+
+#: id:10000
+msgid "Home"
+msgstr "Päävalikko"
+
+#: id:10001
+msgctxt "Auto context with id 10001"
+msgid "Programs"
+msgstr "Ohjelmat"
+
+#: id:10002
+msgctxt "Auto context with id 10002"
+msgid "Pictures"
+msgstr "Kuvat"
+
+#: id:10003
+msgctxt "Auto context with id 10003"
+msgid "File manager"
+msgstr "Tiedostonhallinta"
+
+#: id:10004
+msgctxt "Auto context with id 10004"
+msgid "Settings"
+msgstr "Asetukset"
+
+#: id:10005
+msgctxt "Auto context with id 10005"
+msgid "Music"
+msgstr "Musiikki"
+
+#: id:10006
+msgctxt "Auto context with id 10006"
+msgid "Videos"
+msgstr "Videot"
+
+#: id:10007
+msgid "System information"
+msgstr "Järjestelmän tiedot"
+
+#: id:10008
+msgid "Settings - General"
+msgstr "Asetukset - Yleiset"
+
+#: id:10009
+msgid "Settings - Screen"
+msgstr "Asetukset - Näyttö"
+
+#: id:10010
+msgid "Settings - Appearance - GUI Calibration"
+msgstr "Asetukset - Käyttöliittymä - Käyttöliittymän kalibrointi"
+
+#: id:10011
+msgid "Settings - Videos - Screen Calibration"
+msgstr "Asetukset - Videot - Kuvaruudun kalibrointi"
+
+#: id:10012
+msgid "Settings - Pictures"
+msgstr "Asetukset - Kuvat"
+
+#: id:10013
+msgid "Settings - Programs"
+msgstr "Asetukset - Ohjelmat"
+
+#: id:10014
+msgid "Settings - Weather"
+msgstr "Asetukset - Sää"
+
+#: id:10015
+msgid "Settings - Music"
+msgstr "Asetukset - Musiikki"
+
+#: id:10016
+msgid "Settings - System"
+msgstr "Asetukset - Järjestelmä"
+
+#: id:10017
+msgid "Settings - Videos"
+msgstr "Asetukset - Videot"
+
+#: id:10018
+msgid "Settings - Network"
+msgstr "Asetukset - Verkko"
+
+#: id:10019
+msgid "Settings - Appearance"
+msgstr "Asetukset - Käyttöliittymä"
+
+#: id:10020
+msgctxt "Auto context with id 10020"
+msgid "Scripts"
+msgstr "Skriptit"
+
+#: id:10021
+msgid "Web Browser"
+msgstr "Nettiselain"
+
+#: id:10025
+msgctxt "Auto context with id 10025"
+msgid "Videos"
+msgstr "Videot"
+
+#: id:10028
+msgid "Videos/Playlist"
+msgstr "Videot/Toistolista"
+
+#: id:10029
+msgctxt "Auto context with id 10029"
+msgid "Login screen"
+msgstr "Kirjautumisikkuna"
+
+#: id:10034
+msgid "Settings - Profiles"
+msgstr "Asetukset - Profiilit"
+
+#: id:10040
+msgid "Addon browser"
+msgstr "Lisäosaselain"
+
+#: id:10100
+msgid "Yes/No dialog"
+msgstr "Kyllä/Ei -dialogi"
+
+#: id:10101
+msgid "Progress dialog"
+msgstr "Tila -dialogi"
+
+#: id:10210
+msgid "Looking for subtitles..."
+msgstr "Haetaan tekstityksiä..."
+
+#: id:10211
+msgid "Looking for or caching subtitles..."
+msgstr "Välimuistitetaan tekstityksiä..."
+
+#: id:10212
+msgid "terminating"
+msgstr "keskeytetään"
+
+#: id:10213
+msgid "buffering"
+msgstr "puskuroidaan"
+
+#: id:10214
+msgid "Opening stream"
+msgstr "Aloitetaan siirtoa"
+
+#: id:10500
+msgid "Music/Playlist"
+msgstr "Musiikki/Toistolista"
+
+#: id:10501
+msgid "Music/Files"
+msgstr "Musiikki/Tiedostot"
+
+#: id:10502
+msgid "Music/Library"
+msgstr "Musiikki/Kirjasto"
+
+#: id:10503
+msgid "Playlist editor"
+msgstr "Toistolistojen muokkaus"
+
+#: id:10504
+msgid "Top 100 songs"
+msgstr "100 suosituinta kappaletta"
+
+#: id:10505
+msgid "Top 100 albums"
+msgstr "100 suosituinta albumia"
+
+#: id:10506
+msgctxt "Auto context with id 10506"
+msgid "Programs"
+msgstr "Ohjelmat"
+
+#: id:10507
+msgid "Configuration"
+msgstr "Asetukset"
+
+#: id:10508
+msgid "Weather forecast"
+msgstr "Sääennuste"
+
+#: id:10509
+msgid "Network gaming"
+msgstr "Verkkopelaaminen"
+
+#: id:10510
+msgid "Extensions"
+msgstr "Lisäosat"
+
+#: id:10511
+msgctxt "Auto context with id 10511"
+msgid "System info"
+msgstr "Järjestelmän tiedot"
+
+#: id:10516
+msgid "Music - Library"
+msgstr "Musiikki - Kirjasto"
+
+#: id:10517
+msgid "Now Playing - Music"
+msgstr "Nyt kuunnellaan - Musiikki"
+
+#: id:10522
+msgid "Now Playing - Videos"
+msgstr "Nyt katsellaan - Videot"
+
+#: id:10523
+msgid "Album info"
+msgstr "Albumitiedot"
+
+#: id:10524
+msgid "Movie info"
+msgstr "Elokuvatiedot"
+
+#: id:12000
+msgid "Select dialog"
+msgstr "Valitse dialogi"
+
+#: id:12001
+msgid "Music/Info"
+msgstr "Musiikki/Tiedot"
+
+#: id:12002
+msgid "Dialog OK"
+msgstr "Dialogi OK"
+
+#: id:12003
+msgid "Videos/Info"
+msgstr "Videot/Tiedot"
+
+#: id:12004
+msgid "Scripts/Info"
+msgstr "Skriptit/Tiedot"
+
+#: id:12005
+msgid "Fullscreen video"
+msgstr "Kokoruudun video"
+
+#: id:12006
+msgid "Audio visualization"
+msgstr "Äänen visualisointi"
+
+#: id:12008
+msgid "File stacking dialog"
+msgstr "Tiedostojen pinoamis-dialogi"
+
+#: id:12009
+msgid "Rebuild index..."
+msgstr "Luo indeksi uudestaan..."
+
+#: id:12010
+msgid "Return to music window"
+msgstr "Palaa Musiikki-valikkoon"
+
+#: id:12011
+msgid "Return to videos window"
+msgstr "Palaa Videot-valikkoon"
+
+#: id:12021
+msgid "Start from beginning"
+msgstr "Aloita alusta"
+
+#: id:12022
+msgid "Resume from %s"
+msgstr "Jatka %s:sta"
+
+#: id:12310
+msgid "0"
+msgstr "0"
+
+#: id:12311
+msgid "1"
+msgstr "1"
+
+#: id:12312
+msgid "2"
+msgstr "2"
+
+#: id:12313
+msgid "3"
+msgstr "3"
+
+#: id:12314
+msgid "4"
+msgstr "4"
+
+#: id:12315
+msgid "5"
+msgstr "5"
+
+#: id:12316
+msgid "6"
+msgstr "6"
+
+#: id:12317
+msgid "7"
+msgstr "7"
+
+#: id:12318
+msgid "8"
+msgstr "8"
+
+#: id:12319
+msgid "9"
+msgstr "9"
+
+#: id:12320
+msgid "c"
+msgstr "C"
+
+#: id:12321
+msgid "Ok"
+msgstr "OK"
+
+#: id:12322
+msgid "*"
+msgstr "*"
+
+#: id:12325
+msgid "Locked! Enter code..."
+msgstr "Lukittu! Anna koodi..."
+
+#: id:12326
+msgid "Enter password"
+msgstr "Anna salasana"
+
+#: id:12327
+msgid "Enter master code"
+msgstr "Anna pääkäyttäjän koodi"
+
+#: id:12328
+msgid "Enter unlock code"
+msgstr "Anna avauskoodi"
+
+#: id:12329
+msgid "or press C to cancel"
+msgstr "tai paina C peruuttaaksesi"
+
+#: id:12330
+msgid "Enter gamepad button combo and"
+msgstr "Anna peliohjaimen painikeyhdistelmä ja"
+
+#: id:12331
+msgid "press OK, or Back to cancel"
+msgstr "paina OK, tai Back peruuttaaksesi"
+
+#: id:12332
+msgid "Set lock"
+msgstr "Aseta lukitus"
+
+#: id:12333
+msgid "Unlock"
+msgstr "Avaa lukitus"
+
+#: id:12334
+msgid "Reset lock"
+msgstr "Palauta lukitus"
+
+#: id:12335
+msgid "Remove lock"
+msgstr "Poista lukitus"
+
+#: id:12337
+msgid "Numeric password"
+msgstr "Numeerinen salasana"
+
+#: id:12338
+msgid "Gamepad button combo"
+msgstr "Ohjaimen painikeyhdistelmä"
+
+#: id:12339
+msgid "Full-text password"
+msgstr "Tekstimuotoinen salasana"
+
+#: id:12340
+msgid "Enter new password"
+msgstr "Uusi salasana"
+
+#: id:12341
+msgid "Re-Enter new password"
+msgstr "Anna salasana uudelleen"
+
+#: id:12342
+msgid "Incorrect password,"
+msgstr "Väärä salasana,"
+
+#: id:12343
+msgid "retries left"
+msgstr "yritystä jäljellä"
+
+#: id:12344
+msgid "Passwords entered did not match."
+msgstr "Annetut salasanat eivät täsmää."
+
+#: id:12345
+msgid "Access denied"
+msgstr "Pääsy evätty"
+
+#: id:12346
+msgid "Password retry limit exceeded."
+msgstr "Kaikki kirjautumisyritykset käytetty."
+
+#: id:12347
+msgid "The system will now shut off."
+msgstr "Järjestelmä sammutetaan nyt."
+
+#: id:12348
+msgid "Item locked"
+msgstr "Kohde lukittu"
+
+#: id:12353
+msgid "Reactivate lock"
+msgstr "Uudelleenaktivoi lukitus"
+
+#: id:12356
+msgid "Change lock"
+msgstr "Muuta lukitus"
+
+#: id:12357
+msgid "Source lock"
+msgstr "Sijainnin lukitus"
+
+#: id:12358
+msgid "Password entry was blank. Try again."
+msgstr "Salasana oli tyhjä. Yritä uudelleen."
+
+#: id:12360
+msgid "Master lock"
+msgstr "Käytön esto"
+
+#: id:12362
+msgid "Shutdown system if Master Lock retries exceeded"
+msgstr "Sammuta laite lukituksen poistoyritysten maksimimäärän jälkeen"
+
+#: id:12367
+msgid "Master code is not valid"
+msgstr "Pääkäyttäjän koodi ei ole oikea"
+
+#: id:12368
+msgid "Please enter a valid master code"
+msgstr "Anna oikea pääkäyttäjän koodi"
+
+#: id:12373
+msgid "Settings & file manager"
+msgstr "Asetukset ja tiedostonhallinta"
+
+#: id:12376
+msgid "Set as default for all movies"
+msgstr "Aseta oletukseksi kaikille elokuville"
+
+#: id:12377
+msgid "This will reset any previously saved values"
+msgstr "Tämä korvaa kaikki aiemmat asetukset"
+
+#: id:12378
+msgid "Amount of time to display each image"
+msgstr "Yksittäisen kuvan näyttöaika"
+
+#: id:12379
+msgid "Use pan and zoom effects"
+msgstr "Panorointi- ja zoomaustehosteet käytössä"
+
+#: id:12383
+msgid "12 hour clock"
+msgstr "12-tuntinen kello"
+
+#: id:12384
+msgid "24 hour clock"
+msgstr "24-tuntinen kello"
+
+#: id:12385
+msgid "Day/Month"
+msgstr "Päivä/Kuukausi"
+
+#: id:12386
+msgid "Month/Day"
+msgstr "Kuukausi/Päivä"
+
+#: id:12390
+msgid "System uptime"
+msgstr "Järjestelmän käyntiaika"
+
+#: id:12391
+msgid "Minutes"
+msgstr "minuuttia"
+
+#: id:12392
+msgid "Hours"
+msgstr "tuntia"
+
+#: id:12393
+msgid "Days"
+msgstr "päivää"
+
+#: id:12394
+msgid "Total uptime"
+msgstr "Kokonaiskäyntiaika"
+
+#: id:12395
+msgid "Battery level"
+msgstr "Akun taso"
+
+#: id:12600
+msgctxt "Auto context with id 12600"
+msgid "Weather"
+msgstr "Säätila"
+
+#: id:12900
+msgctxt "Auto context with id 12900"
+msgid "Screensaver"
+msgstr "Näytönsäästäjä"
+
+#: id:12901
+msgid "Fullscreen OSD"
+msgstr "Kokoruudun kuvaruutuvalikko"
+
+#: id:13000
+msgid "System"
+msgstr "Järjestelmä"
+
+#: id:13001
+msgid "Immediate HD spindown"
+msgstr "Kiintolevyn välitön pysäytys"
+
+#: id:13002
+msgid "Video only"
+msgstr "Vain videoilla"
+
+#: id:13003
+msgid "- Delay"
+msgstr "- Viive"
+
+#: id:13004
+msgid "- Minimum file duration"
+msgstr "- Tiedoston vähimmäiskesto"
+
+#: id:13005
+msgid "Shutdown"
+msgstr "Sammuta"
+
+#: id:13008
+msgid "Shutdown function"
+msgstr "Sammutusmuoto"
+
+#: id:13009
+msgid "Quit"
+msgstr "Poistu"
+
+#: id:13010
+msgid "Hibernate"
+msgstr "Horrostila"
+
+#: id:13011
+msgid "Suspend"
+msgstr "Valmiustila"
+
+#: id:13012
+msgid "Exit"
+msgstr "Lopeta"
+
+#: id:13013
+msgid "Reboot"
+msgstr "Käynnistä uudelleen"
+
+#: id:13014
+msgid "Minimize"
+msgstr "Pienennä"
+
+#: id:13015
+msgid "Power button action"
+msgstr "Virtakytkimen toiminto"
+
+#: id:13016
+msgid "Power off System"
+msgstr "Sammuta järjestelmä"
+
+#: id:13020
+msgid "Is another session active, perhaps over ssh?"
+msgstr "Onko toinen istunto käynnissä, ehkä ssh:n kautta?"
+
+#: id:13021
+msgid "Mounted removable harddrive"
+msgstr "Liitetty siirrettävä kiintolevy"
+
+#: id:13022
+msgid "Unsafe device removal"
+msgstr "Turvaton laitteen poisto"
+
+#: id:13023
+msgid "Successfully removed device"
+msgstr "Laitteen poisto onnistui"
+
+#: id:13024
+msgid "Joystick plugged"
+msgstr "Peliohjain liitetty"
+
+#: id:13025
+msgid "Joystick unplugged"
+msgstr "Peliohjain irroitettu"
+
+#: id:13050
+msgid "Running low on battery"
+msgstr "Alhainen akun varaus"
+
+#: id:13100
+msgid "Flicker filter"
+msgstr "Näytön välkynnän poisto"
+
+#: id:13101
+msgid "Let driver choose (requires restart)"
+msgstr "Ajuri valitsee (vaatii uudelleenkäynnistyksen)"
+
+#: id:13105
+msgid "Vertical blank sync"
+msgstr "Pystytahdistus"
+
+#: id:13106
+msgctxt "Auto context with id 13106"
+msgid "Disabled"
+msgstr "Ei käytössä"
+
+#: id:13107
+msgid "Enabled during video playback"
+msgstr "Käytössä videoita toistettaessa"
+
+#: id:13108
+msgctxt "Auto context with id 13108"
+msgid "Always enabled"
+msgstr "Aina käytössä"
+
+#: id:13109
+msgid "Test & apply resolution"
+msgstr "Testaa ja hyväksy resoluutio"
+
+#: id:13110
+msgid "Save resolution?"
+msgstr "Tallenna resoluutio?"
+
+#: id:13111
+msgid "Would you like to keep this resolution?"
+msgstr "Haluatko säilyttää nämä asetukset?"
+
+#: id:13112
+msgid "High quality upscaling"
+msgstr "Korkealaatuinen skaalaus"
+
+#: id:13113
+msgctxt "Auto context with id 13113"
+msgid "Disabled"
+msgstr "Ei käytössä"
+
+#: id:13114
+msgid "Enabled for SD content"
+msgstr "Käytössä normaali tarkkuudella"
+
+#: id:13115
+msgctxt "Auto context with id 13115"
+msgid "Always enabled"
+msgstr "Aina käytössä"
+
+#: id:13116
+msgid "Upscaling method"
+msgstr "Skaalausmenetelmä"
+
+#: id:13117
+msgctxt "Auto context with id 13117"
+msgid "Bicubic"
+msgstr "Bicubic"
+
+#: id:13118
+msgid "Lanczos"
+msgstr "Lanczos"
+
+#: id:13119
+msgid "Sinc"
+msgstr "Sinc"
+
+#: id:13120
+msgctxt "Auto context with id 13120"
+msgid "VDPAU"
+msgstr "VDPAU"
+
+#: id:13121
+msgid "VDPAU HQ Upscaling level"
+msgstr "VDPAU HQ skaalaustaso"
+
+#: id:13122
+msgid "VDPAU Studio level color conversion"
+msgstr "VDPAU:n studiotasoinen värimuunnos"
+
+#: id:13130
+msgid "Blank other displays"
+msgstr "Tyhjennä muut näytöt"
+
+#: id:13131
+msgctxt "Auto context with id 13131"
+msgid "Disabled"
+msgstr "Ei käytössä"
+
+#: id:13132
+msgid "Blank displays"
+msgstr "Tyhjät näytöt"
+
+#: id:13140
+msgid "Active connections detected!"
+msgstr "Käytössä oleva ohjaus havaittu!"
+
+#: id:13141
+msgid "If you proceed, you might not be able to control XBMC"
+msgstr "Mikäli jatkat, et välttämättä pysty tämän jälkeen"
+
+#: id:13142
+msgid "any longer. Are you sure you want to stop the Event server?"
+msgstr "ohjaamaan XBMC:ia. Haluatko varmasti pysäyttää ohjaustapahtumat?"
+
+#: id:13144
+msgid "Change Apple Remote mode?"
+msgstr "Vaihdetaanko Apple kauko-ohjaukseen?"
+
+#: id:13145
+msgid "If you are currently using the Apple Remote to control"
+msgstr "Mikäli käytät tälllä hetkellä XBMC:in ohjaukseen Apple kauko-ohjainta,"
+
+#: id:13146
+msgid "XBMC, changing this setting might affect your ability"
+msgstr "et voi tämän jälkeen ohjata XBMC:ia."
+
+#: id:13147
+msgid "to continue controlling it. Do you want to proceed?"
+msgstr "Haluatko jatkaa?"
+
+#: id:13159
+msgid "Subnet mask"
+msgstr "Aliverkon peite"
+
+#: id:13160
+msgid "Gateway"
+msgstr "Yhdyskäytävä"
+
+#: id:13161
+msgid "Primary DNS"
+msgstr "Ensisijainen DNS"
+
+#: id:13162
+msgid "Initialize failed"
+msgstr "Alustus epäonnistui"
+
+#: id:13170
+msgctxt "Auto context with id 13170"
+msgid "Never"
+msgstr "Ei koskaan"
+
+#: id:13171
+msgid "Immediately"
+msgstr "Heti"
+
+#: id:13172
+msgid "After %i secs"
+msgstr "%i sekunnin kuluttua"
+
+#: id:13173
+msgid "HDD install date:"
+msgstr "Kiintolevyn asennuspäivä:"
+
+#: id:13174
+msgid "HDD power cycle count:"
+msgstr "Kiintolevyn käynnistyslaskuri:"
+
+#: id:13200
+msgid "Profiles"
+msgstr "Käyttäjäprofiilit"
+
+#: id:13201
+msgid "Delete profile '%s'?"
+msgstr "Poistetaanko profiili '%s'?"
+
+#: id:13204
+msgid "Last loaded profile:"
+msgstr "Viimeksi ladattu profiili:"
+
+#: id:13205
+msgid "Unknown"
+msgstr "Tuntematon"
+
+#: id:13206
+msgid "Overwrite"
+msgstr "Korvaa"
+
+#: id:13208
+msgid "Alarm clock"
+msgstr "Herätyskello"
+
+#: id:13209
+msgid "Alarm clock interval (in minutes)"
+msgstr "Hälytysväli (minuuttia)"
+
+#: id:13210
+msgid "Started, alarm in %im"
+msgstr "Käynnistetty, hälytys %i minuutin kuluttua"
+
+#: id:13211
+msgid "Alarm!"
+msgstr "Hälytys!"
+
+#: id:13212
+msgid "Canceled with %im%is left"
+msgstr "peruutettu, %im%is jäljellä"
+
+#: id:13213
+msgid "%2.0fm"
+msgstr "%2.0fm"
+
+#: id:13214
+msgid "%2.0fs"
+msgstr "%2.0fs"
+
+#: id:13249
+msgid "Search for subtitles in RARs"
+msgstr "Etsi tekstitykset RAR-paketeista"
+
+#: id:13250
+msgid "Browse for subtitle..."
+msgstr "Valitse tekstitys..."
+
+#: id:13251
+msgid "Move item"
+msgstr "Siirrä"
+
+#: id:13252
+msgid "Move item here"
+msgstr "Siirrä tähän"
+
+#: id:13253
+msgid "Cancel move"
+msgstr "Kumoa siirto"
+
+#: id:13270
+msgid "Hardware:"
+msgstr "Laitteisto:"
+
+#: id:13271
+msgid "CPU Usage:"
+msgstr "Suorittimen käyttö:"
+
+#: id:13274
+msgid "Connected, but no DNS is available."
+msgstr "Yhdistetty, mutta DNS-tietoja ei ole käytettävissä."
+
+#: id:13275
+msgid "Hard Disk"
+msgstr "Kiintolevy"
+
+#: id:13276
+msgid "DVD-ROM"
+msgstr "DVD-asema"
+
+#: id:13277
+msgctxt "Auto context with id 13277"
+msgid "Storage"
+msgstr "Tallennus"
+
+#: id:13278
+msgctxt "Auto context with id 13278"
+msgid "Default"
+msgstr "Oletus"
+
+#: id:13279
+msgctxt "Auto context with id 13279"
+msgid "Network"
+msgstr "Verkko"
+
+#: id:13280
+msgctxt "Auto context with id 13280"
+msgid "Video"
+msgstr "Näyttö"
+
+#: id:13281
+msgid "Hardware"
+msgstr "Laitteisto"
+
+#: id:13283
+msgid "Operating system:"
+msgstr "Käyttöjärjestelmä:"
+
+#: id:13284
+msgid "CPU speed:"
+msgstr "Suorittimen nopeus:"
+
+#: id:13286
+msgid "Video encoder:"
+msgstr "Videoenkooderi:"
+
+#: id:13287
+msgid "Screen resolution:"
+msgstr "Näyttötarkkuus:"
+
+#: id:13292
+msgid "A/V cable:"
+msgstr "A/V-kaapeli:"
+
+#: id:13294
+msgid "DVD region:"
+msgstr "DVD-aluekoodi:"
+
+#: id:13295
+msgid "Internet:"
+msgstr "Internet:"
+
+#: id:13296
+msgctxt "Auto context with id 13296"
+msgid "Connected"
+msgstr "Yhdistetty"
+
+#: id:13297
+msgid "Not connected. Check network settings."
+msgstr "Ei ole yhdistetty. Tarkista verkkoasetukset."
+
+#: id:13299
+msgid "Target temperature"
+msgstr "Tavoitelämpötila"
+
+#: id:13300
+msgid "Fan speed"
+msgstr "Tuulettimen pyörintänopeus"
+
+#: id:13301
+msgid "Auto temperature control"
+msgstr "Automaattinen lämmönhallinta"
+
+#: id:13302
+msgid "Fan speed override"
+msgstr "Tuulettimen pyörintänopeuden säätö"
+
+#: id:13303
+msgid "- Fonts"
+msgstr "- Kirjasin"
+
+#: id:13304
+msgid "Enable flipping bi-directional strings"
+msgstr "Käännä kaksisuuntainen merkistö"
+
+#: id:13305
+msgid "Show RSS news feeds"
+msgstr "RSS-uutispalvelu käytössä"
+
+#: id:13306
+msgid "Show parent folder items"
+msgstr "Näytä ylemmän kansion kohteet"
+
+#: id:13307
+msgid "Track naming template"
+msgstr "Kappaleen nimeämistapa"
+
+#: id:13308
+msgid "Do you wish to reboot your system"
+msgstr "Käynnistetäänkö järjestelmä uudelleen,"
+
+#: id:13309
+msgid "instead of just XBMC?"
+msgstr "vai pelkkä XBMC?"
+
+#: id:13310
+msgid "Zoom effect"
+msgstr "Zoomaustehoste"
+
+#: id:13311
+msgid "Float effect"
+msgstr "Kelluntatehoste"
+
+#: id:13312
+msgid "Black bar reduction"
+msgstr "Mustien reunojen poisto"
+
+#: id:13313
+msgid "Restart"
+msgstr "Käynnistä uudelleen"
+
+#: id:13314
+msgid "Crossfade between songs"
+msgstr "Ristiinhäivytys"
+
+#: id:13315
+msgid "Regenerate thumbnails"
+msgstr "Muodosta pienoiskuvat uudelleen"
+
+#: id:13316
+msgid "Recursive thumbnails"
+msgstr "Kaikki pienoiskuvat"
+
+#: id:13317
+msgid "View slideshow"
+msgstr "Kuvaesitys"
+
+#: id:13318
+msgid "Recursive slideshow"
+msgstr "Kaikkien kuvaesitys"
+
+#: id:13319
+msgid "Randomize"
+msgstr "Satunnainen"
+
+#: id:13320
+msgid "Stereo"
+msgstr "Stereo"
+
+#: id:13321
+msgid "Left only"
+msgstr "Ainoastaan vasen"
+
+#: id:13322
+msgid "Right only"
+msgstr "Ainoastaan oikea"
+
+#: id:13323
+msgid "Enable karaoke support"
+msgstr "Karaoke-tila käytössä"
+
+#: id:13324
+msgid "Background transparency"
+msgstr "Taustan läpinäkyvyys"
+
+#: id:13325
+msgid "Foreground transparency"
+msgstr "Edustan läpinäkyvyys"
+
+#: id:13326
+msgid "A/V delay"
+msgstr "Äänen viive"
+
+#: id:13327
+msgid "Karaoke"
+msgstr "Karaoke"
+
+#: id:13328
+msgid "%s not found"
+msgstr "%s ei löydy"
+
+#: id:13329
+msgid "Error opening %s"
+msgstr "%s:n avaus ei onnistu"
+
+#: id:13330
+msgid "Unable to load %s"
+msgstr "%s:n lataus ei onnistu"
+
+#: id:13331
+msgid "Error: Out of memory"
+msgstr "Virhe: muistin määrä ei riitä"
+
+#: id:13332
+msgid "Move up"
+msgstr "Siirrä ylöspäin"
+
+#: id:13333
+msgid "Move down"
+msgstr "Siirrä alaspäin"
+
+#: id:13334
+msgid "Edit label"
+msgstr "Muuta nimeä"
+
+#: id:13335
+msgid "Make default"
+msgstr "Aseta oletussijainti"
+
+#: id:13336
+msgid "Remove button"
+msgstr "Poista painike"
+
+#: id:13340
+msgid "Leave as is"
+msgstr "Ei vaihdeta"
+
+#: id:13341
+msgid "Green"
+msgstr "Vihreä"
+
+#: id:13342
+msgid "Orange"
+msgstr "Oranssi"
+
+#: id:13343
+msgid "Red"
+msgstr "Punainen"
+
+#: id:13344
+msgid "Cycle"
+msgstr "Kierrätä värejä"
+
+#: id:13345
+msgid "Switch LED off on playback"
+msgstr "Sammuta etupaneelin valo toistettaessa"
+
+#: id:13346
+msgctxt "Auto context with id 13346"
+msgid "Movie information"
+msgstr "Elokuvan tiedot"
+
+#: id:13347
+msgid "Queue item"
+msgstr "Lisää kohde toistolistalle"
+
+#: id:13348
+msgid "Search IMDb..."
+msgstr "Hae IMDb:stä..."
+
+#: id:13349
+msgid "Scan for new content"
+msgstr "Etsi uusi sisältö"
+
+#: id:13350
+msgid "Now playing..."
+msgstr "Nykyinen toistolista..."
+
+#: id:13351
+msgctxt "Auto context with id 13351"
+msgid "Album information"
+msgstr "Albumin tiedot"
+
+#: id:13352
+msgid "Scan item to library"
+msgstr "Lue kaikki kirjastoon"
+
+#: id:13353
+msgid "Stop scanning"
+msgstr "Keskeytä haku"
+
+#: id:13354
+msgctxt "Auto context with id 13354"
+msgid "Render method"
+msgstr "Renderöintitapa"
+
+#: id:13355
+msgid "Low quality pixel shader"
+msgstr "Pixel Shader (matala laatu)"
+
+#: id:13356
+msgid "Hardware overlays"
+msgstr "Laitteistopohjainen"
+
+#: id:13357
+msgid "High quality pixel shader"
+msgstr "Pixel Shader (korkea laatu)"
+
+#: id:13358
+msgid "Play item"
+msgstr "Toista"
+
+#: id:13359
+msgid "Set artist thumb"
+msgstr "Aseta esittäjän pienoiskuva"
+
+#: id:13360
+msgid "Automatically generate thumbnails"
+msgstr "Luo pienoiskuvat automaattisesti"
+
+#: id:13361
+msgid "Enable voice"
+msgstr "Puhe käytössä"
+
+#: id:13375
+msgid "Enable device"
+msgstr "Laite käytössä"
+
+#: id:13376
+msgid "Volume"
+msgstr "Äänenvoimakkuus"
+
+#: id:13377
+msgid "Default view mode"
+msgstr "Oletus näyttötapa"
+
+#: id:13378
+msgid "Default brightness"
+msgstr "Oletus kirkkaus"
+
+#: id:13379
+msgid "Default contrast"
+msgstr "Oletus kontrasti"
+
+#: id:13380
+msgid "Default gamma"
+msgstr "Gamman oletusarvo"
+
+#: id:13381
+msgid "Resume video"
+msgstr "Jatka toistoa"
+
+#: id:13382
+msgid "Voice mask - Port 1"
+msgstr "Äänimaski - Portti 1"
+
+#: id:13383
+msgid "Voice mask - Port 2"
+msgstr "Äänimaski - Portti 2"
+
+#: id:13384
+msgid "Voice mask - Port 3"
+msgstr "Äänimaski - Portti 3"
+
+#: id:13385
+msgid "Voice mask - Port 4"
+msgstr "Äänimaski - Portti 4"
+
+#: id:13386
+msgid "Use time based seeking"
+msgstr "Käytä aikapohjaista hakua"
+
+#: id:13387
+msgid "Track naming template - right"
+msgstr "Kappaleen nimeämistapa, oikeanpuoleinen"
+
+#: id:13388
+msgid "Preset"
+msgstr "Esiasetukset"
+
+#: id:13389
+msgid "There are no presets available\nfor this visualization"
+msgstr "Tälle visualisoinnille ei löytynyt esiasetuksia"
+
+#: id:13390
+msgid "There are no settings available\nfor this visualization"
+msgstr "Tälle visualisoinnille ei ole määriteltäviä asetuksia"
+
+#: id:13391
+msgid "Eject/Load"
+msgstr "Poista/Lataa"
+
+#: id:13392
+msgid "Use visualization if playing audio"
+msgstr "Näytön visualisoinnit käytössä musiikkitiedostoilla"
+
+#: id:13393
+msgid "Calculate size"
+msgstr "Laske koko"
+
+#: id:13394
+msgid "Calculating folder size"
+msgstr "Lasketaan kansion kokoa"
+
+#: id:13395
+msgid "Video settings"
+msgstr "Videoasetukset"
+
+#: id:13396
+msgid "Audio and subtitle settings"
+msgstr "Ääni- ja tekstitysasetukset"
+
+#: id:13397
+msgid "Enable subtitles"
+msgstr "Tekstitys käytössä"
+
+#: id:13398
+msgctxt "Auto context with id 13398"
+msgid "Shortcuts"
+msgstr "Pikakuvakkeet"
+
+#: id:13399
+msgid "Ignore articles when sorting (e.g. \"the\")"
+msgstr "Ohita artikkelit lajiteltaessa (esim. \"the\")"
+
+#: id:13400
+msgid "Crossfade between songs on the same album"
+msgstr "Ristiinhäivytä saman albumin kappaleet"
+
+#: id:13401
+msgid "Browse for %s"
+msgstr "Valitse %s"
+
+#: id:13402
+msgid "Show track position"
+msgstr "Näytä kappaleen paikka"
+
+#: id:13403
+msgid "Clear default"
+msgstr "Poista oletussijainti"
+
+#: id:13404
+msgid "Resume"
+msgstr "Jatka"
+
+#: id:13405
+msgid "Get thumb"
+msgstr "Pienoiskuva"
+
+#: id:13406
+msgid "Picture information"
+msgstr "Kuvan tiedot"
+
+#: id:13407
+msgid "%s presets"
+msgstr "%s:in esiasetukset"
+
+#: id:13408
+msgid "(IMDb user rating)"
+msgstr "(IMDb-käyttäjien arvosana)"
+
+#: id:13409
+msgid "Top 250"
+msgstr "250 suosituinta"
+
+#: id:13410
+msgid "Tune in on Last.fm"
+msgstr "Aloita Last.fm:n kuuntelu"
+
+#: id:13411
+msgid "Minimum fan speed"
+msgstr "Tuulettimen vähimmäisnopeus"
+
+#: id:13412
+msgid "Play from here"
+msgstr "Toista tästä kohdasta"
+
+#: id:13413
+msgid "Downloading"
+msgstr "Ladataan..."
+
+#: id:13414
+msgid "Include artists who appear only on compilations"
+msgstr "Sisällytä vain kokoelmilla olevat esittäjät"
+
+#: id:13415
+msgctxt "Auto context with id 13415"
+msgid "Render method"
+msgstr "Renderöintimenetelmä"
+
+#: id:13416
+msgid "Auto detect"
+msgstr "Automaattinen tunnistus"
+
+#: id:13417
+msgid "Basic shaders (ARB)"
+msgstr "Yksinkertaiset varjostimet (ARB)"
+
+#: id:13418
+msgid "Advanced shaders (GLSL)"
+msgstr "Edistyneet varjostimet (GLSL)"
+
+#: id:13419
+msgid "Software"
+msgstr "Ohjelmallinen"
+
+#: id:13420
+msgid "Remove safely"
+msgstr "Poista turvallisesti"
+
+#: id:13421
+msgctxt "Auto context with id 13421"
+msgid "VDPAU"
+msgstr "VDPAU"
+
+#: id:13422
+msgid "Start slideshow here"
+msgstr "Aloita kuvaesitys tästä"
+
+#: id:13423
+msgid "Remember for this path"
+msgstr "Muista tämä polku"
+
+#: id:13424
+msgid "Use pixel buffer objects"
+msgstr "Käytä pikselipuskuriobjekteja"
+
+#: id:13425
+msgid "Allow hardware acceleration (VDPAU)"
+msgstr "Laitteistopohjainen kiihdytys (VDPAU)"
+
+#: id:13426
+msgid "Allow hardware acceleration (VAAPI)"
+msgstr "Laitteistopohjainen kiihdytys (VAAPI)"
+
+#: id:13427
+msgid "Allow hardware acceleration (DXVA2)"
+msgstr "Laitteistopohjainen kiihdytys (DXVA2)"
+
+#: id:13428
+msgid "Allow hardware acceleration (CrystalHD)"
+msgstr "Laitteistopohjainen kiihdytys (CrystalHD)"
+
+#: id:13429
+msgid "Allow hardware acceleration (VDADecoder)"
+msgstr "Laitteistopohjainen kiihdytys (VDADecoder)"
+
+#: id:13430
+msgid "Allow hardware acceleration (OpenMax)"
+msgstr "Laitteistopohjainen kiihdytys (OpenMax)"
+
+#: id:13431
+msgid "Pixel Shaders"
+msgstr "Pikselivarjostimet"
+
+#: id:13432
+msgid "Allow hardware acceleration (VideoToolbox)"
+msgstr "Laitteistopohjainen kiihdytys (VideoToolbox)"
+
+#: id:13500
+msgid "A/V sync method"
+msgstr "A/V-tahdistusmenetelmä"
+
+#: id:13501
+msgid "Audio clock"
+msgstr "Äänen kello"
+
+#: id:13502
+msgid "Video clock (Drop/Dupe audio)"
+msgstr "Videon kello (poista/kopioi ääninäytteitä)"
+
+#: id:13503
+msgid "Video clock (Resample audio)"
+msgstr "Videon kello (äänen uudelleennäytteistys)"
+
+#: id:13504
+msgid "Maximum resample amount (%)"
+msgstr "Maksimiuudelleennäytteistys (%)"
+
+#: id:13505
+msgid "Resample quality"
+msgstr "Uudellennäytteistyksen laatu"
+
+#: id:13506
+msgid "Low(fast)"
+msgstr "Matala (nopea)"
+
+#: id:13507
+msgctxt "Auto context with id 13507"
+msgid "Medium"
+msgstr "Keski"
+
+#: id:13508
+msgctxt "Auto context with id 13508"
+msgid "High"
+msgstr "Korkea"
+
+#: id:13509
+msgid "Really high(slow!)"
+msgstr "Todella korkea (hidas)"
+
+#: id:13510
+msgid "Sync playback to display"
+msgstr "Tahdista toisto näyttöön"
+
+#: id:13550
+msgid "Pause during refresh rate change"
+msgstr "Pysäytä toisto virkistystaajuuden vaihtamisen ajaksi"
+
+#: id:13551
+msgctxt "Auto context with id 13551"
+msgid "Off"
+msgstr "Ei käytössä"
+
+#: id:13552
+msgid "%.1f Second"
+msgstr "%.1f sekunniksi"
+
+#: id:13553
+msgid "%.1f Seconds"
+msgstr "%.1f sekunniksi"
+
+#: id:13600
+msgid "Apple remote"
+msgstr "Apple remote -kauko-ohjain"
+
+#: id:13602
+msgid "Allow start of XBMC using the remote"
+msgstr "XBMC voidaan käynnistää kauko-ohjaimella"
+
+#: id:13603
+msgid "Sequence delay time"
+msgstr "Jaksoittainen viive"
+
+#: id:13610
+msgctxt "Auto context with id 13610"
+msgid "Disabled"
+msgstr "Ei käytössä"
+
+#: id:13611
+msgctxt "Auto context with id 13611"
+msgid "Standard"
+msgstr "Normaali"
+
+#: id:13612
+msgid "Universal Remote"
+msgstr "Yleiskauko-ohjain"
+
+#: id:13613
+msgid "Multi Remote (Harmony)"
+msgstr "Yleiskauko-ohjain (Harmony)"
+
+#: id:13620
+msgid "Apple Remote Error"
+msgstr "Apple Remote -kauko-ohjain virhe"
+
+#: id:13621
+msgid "Apple Remote support could be enabled."
+msgstr "Apple Remote -kauko-ohjain voidaan ottaa käyttöön."
+
+#: id:14000
+msgid "Stack"
+msgstr "Pinoa"
+
+#: id:14001
+msgid "Unstack"
+msgstr "Ei pinota"
+
+#: id:14003
+msgid "Downloading playlist file..."
+msgstr "Ladataan toistolistatiedostoa..."
+
+#: id:14004
+msgid "Downloading streams list..."
+msgstr "Ladataan ohjelmaluetteloa.."
+
+#: id:14005
+msgid "Parsing streams list..."
+msgstr "Tulkitaan ohjelmaluetteloa..."
+
+#: id:14006
+msgid "Downloading streams list failed"
+msgstr "Ohjelmaluettelon lataus epäonnistui"
+
+#: id:14007
+msgid "Downloading playlist file failed"
+msgstr "Toistolistan lataus epäonnistui"
+
+#: id:14009
+msgid "Games directory"
+msgstr "Pelit-hakemisto"
+
+#: id:14010
+msgid "Auto switch to thumbs based on"
+msgstr "Vaihda pienoiskuviin automaattisesti, jos"
+
+#: id:14011
+msgid "Enable auto switching to thumbs view"
+msgstr "Näytä pienoiskuvat automaattisesti"
+
+#: id:14012
+msgid "- Use large icons"
+msgstr "Käytä suuria kuvakkeita"
+
+#: id:14013
+msgid "- Switch based on"
+msgstr "Vaihda mikäli"
+
+#: id:14014
+msgid "- Percentage"
+msgstr "Prosenttiosuus"
+
+#: id:14015
+msgid "No files and at least one thumb"
+msgstr "Ei tiedostoja vähintään yhdellä pienoiskuvalla"
+
+#: id:14016
+msgid "At least one file and thumb"
+msgstr "Vähintään yksi tiedosto ja pienoiskuva"
+
+#: id:14017
+msgid "Percentage of thumbs"
+msgstr "Pienoiskuvien osuus (%)"
+
+#: id:14018
+msgid "View options"
+msgstr "Näkymä valinnat"
+
+#: id:14019
+msgid "Change area code 1"
+msgstr "Paikkakunta 1"
+
+#: id:14020
+msgid "Change area code 2"
+msgstr "Paikkakunta 2"
+
+#: id:14021
+msgid "Change area code 3"
+msgstr "Paikkakunta 3"
+
+#: id:14022
+msgctxt "Auto context with id 14022"
+msgid "Library"
+msgstr "Kirjasto"
+
+#: id:14023
+msgid "No TV"
+msgstr "Ei TV:tä"
+
+#: id:14024
+msgid "Enter the nearest large town"
+msgstr "Lähin suuri paikkakunta"
+
+#: id:14025
+msgid "Video/Audio/DVD cache - Harddisk"
+msgstr "Video-/Musiikki-/DVD-välimuisti: Kiintolevy"
+
+#: id:14026
+msgid "Video cache - DVD-ROM"
+msgstr "Videovälimuisti - DVD-ROM"
+
+#: id:14027
+msgctxt "Auto context with id 14027"
+msgid "- Local Network"
+msgstr "Videovälimuisti - Lähiverkko"
+
+#: id:14028
+msgctxt "Auto context with id 14028"
+msgid "- Internet"
+msgstr "Videovälimuisti - Internet"
+
+#: id:14030
+msgid "Audio cache - DVD-ROM"
+msgstr "Musiikkivälimuisti - DVD-ROM"
+
+#: id:14031
+msgctxt "Auto context with id 14031"
+msgid "- Local Network"
+msgstr "Musiikkivälimuisti - Lähiverkko"
+
+#: id:14032
+msgctxt "Auto context with id 14032"
+msgid "- Internet"
+msgstr "Musiikkivälimuisti - Internet"
+
+#: id:14034
+msgid "DVD cache - DVD-ROM"
+msgstr "DVD-välimuisti - DVD-ROM"
+
+#: id:14035
+msgctxt "Auto context with id 14035"
+msgid "- Local Network"
+msgstr "DVD-välimuisti - Lähiverkko"
+
+#: id:14036
+msgctxt "Auto context with id 14036"
+msgid "Services"
+msgstr "Palvelut"
+
+#: id:14038
+msgid "Network settings changed"
+msgstr "Verkkoasetuksia muutettu"
+
+#: id:14039
+msgid "XBMC requires to restart to change your"
+msgstr "XBMC täytyy käynnistää uudelleen, jotta uudet"
+
+#: id:14040
+msgid "network setup. Would you like to restart now?"
+msgstr "asetukset tulevat käyttöön. Käynnistetäänkö uudelleen nyt?"
+
+#: id:14041
+msgid "Internet connection bandwidth limitation"
+msgstr "Internet-yhteyden kaistanrajoitus"
+
+#: id:14043
+msgid "- Shutdown while playing"
+msgstr "- Sammuta kesken toiston"
+
+#: id:14044
+msgid "%i min"
+msgstr "%i min"
+
+#: id:14045
+msgid "%i sec"
+msgstr "%i s"
+
+#: id:14046
+msgid "%i ms"
+msgstr "%i ms"
+
+#: id:14047
+msgid "%i %%"
+msgstr "%i %%"
+
+#: id:14048
+msgid "%i kbps"
+msgstr "%i kbps"
+
+#: id:14049
+msgid "%i kb"
+msgstr "%i kb"
+
+#: id:14050
+msgid "%i.0 dB"
+msgstr "%i.0 dB"
+
+#: id:14051
+msgid "Time format"
+msgstr "Ajan muoto"
+
+#: id:14052
+msgid "Date format"
+msgstr "Päiväyksen muoto"
+
+#: id:14053
+msgid "GUI filters"
+msgstr "Käyttöliittymän suodattimet"
+
+#: id:14055
+msgid "Use background scanning"
+msgstr "Hae taustalla"
+
+#: id:14056
+msgid "Stop scan"
+msgstr "Pysäytä haku"
+
+#: id:14057
+msgid "Not possible while scanning for media info"
+msgstr "Ei ole mahdollista median tietoja haettaessa"
+
+#: id:14058
+msgid "Film grain effect"
+msgstr "Filmin rakeisuustehoste"
+
+#: id:14059
+msgid "Search for thumbnails on remote shares"
+msgstr "Etsi pienoiskuvat verkkosijainneista"
+
+#: id:14060
+msgid "Unknown type cache - Internet"
+msgstr "Internet: Muut tiedostotyypit"
+
+#: id:14061
+msgctxt "Auto context with id 14061"
+msgid "Auto"
+msgstr "Automaattinen"
+
+#: id:14062
+msgid "Enter username for"
+msgstr "Anna käyttäjätunnus:"
+
+#: id:14063
+msgid "Date & time"
+msgstr "Aika ja päiväys"
+
+#: id:14064
+msgid "Set date"
+msgstr "Aseta päivämäärä"
+
+#: id:14065
+msgid "Set time"
+msgstr "Aseta kellonaika"
+
+#: id:14066
+msgid "Enter the time in 24 hour HH:MM format"
+msgstr "Anna aika 24 tunnin muodossa tunnit:minuutit"
+
+#: id:14067
+msgid "Enter the date in DD/MM/YYYY format"
+msgstr "Anna päivämäärä muodossa päivä/kuukausi/vuosi"
+
+#: id:14068
+msgid "Enter the IP address"
+msgstr "Anna IP-osoite"
+
+#: id:14069
+msgid "Apply these settings now?"
+msgstr "Otetaanko asetukset heti käyttöön?"
+
+#: id:14070
+msgid "Apply changes now"
+msgstr "Muutokset otetaan käyttöön"
+
+#: id:14071
+msgid "Allow file renaming and deletion"
+msgstr "Salli tiedostojen poistaminen ja nimeäminen"
+
+#: id:14074
+msgid "Set timezone"
+msgstr "Aseta aikavyöhyke"
+
+#: id:14075
+msgid "Use daylight saving time"
+msgstr "Kesäaika käytössä"
+
+#: id:14076
+msgid "Add to favourites"
+msgstr "Lisää suosikkeihin"
+
+#: id:14077
+msgid "Remove from favourites"
+msgstr "Poista suosikeista"
+
+#: id:14078
+msgctxt "Auto context with id 14078"
+msgid "- Colours"
+msgstr "- Värisävy"
+
+#: id:14079
+msgid "Timezone country"
+msgstr "Aikavyöhyke maa"
+
+#: id:14080
+msgid "Timezone"
+msgstr "Aikavyöhyke"
+
+#: id:14081
+msgid "File lists"
+msgstr "Tiedostolistat"
+
+#: id:14082
+msgid "Show EXIF picture information"
+msgstr "Näytä kuvan EXIF-tiedot"
+
+#: id:14083
+msgid "Use a fullscreen window rather than true fullscreen"
+msgstr "Käytä kokoruudun ikkunaa ennemmin kuin täyttä ruutua"
+
+#: id:14084
+msgid "Queue songs on selection"
+msgstr "Lisää valitut kappaleet toistolistalle"
+
+#: id:14086
+msgid "Playback"
+msgstr "Toisto"
+
+#: id:14087
+msgid "DVDs"
+msgstr "DVD-levyt"
+
+#: id:14088
+msgid "Play DVDs automatically"
+msgstr "Toista DVD-levyt automaattisesti"
+
+#: id:14089
+msgid "Font to use for text subtitles"
+msgstr "Tekstityksissä käytettävä kirjasin"
+
+#: id:14090
+msgid "International"
+msgstr "Kansallisuus"
+
+#: id:14091
+msgid "Character set"
+msgstr "Merkistökoodaus"
+
+#: id:14092
+msgid "Debugging"
+msgstr "Debugging"
+
+#: id:14093
+msgid "Security"
+msgstr "Turvallisuus"
+
+#: id:14094
+msgid "Input devices"
+msgstr "Syöttölaitteet"
+
+#: id:14095
+msgid "Power saving"
+msgstr "Tehonsäästö"
+
+#: id:14096
+msgid "Rip"
+msgstr ""
+
+#: id:14097
+msgid "Audio CD Insert Action"
+msgstr ""
+
+#: id:14098
+msgctxt "Auto context with id 14098"
+msgid "Play"
+msgstr ""
+
+#: id:14099
+msgid "Eject disc when CD ripping is complete"
+msgstr ""
+
+#: id:15015
+msgctxt "Auto context with id 15015"
+msgid "Remove"
+msgstr "Poista"
+
+#: id:15016
+msgid "Games"
+msgstr "Pelit"
+
+#: id:15019
+msgid "Add"
+msgstr "Lisää"
+
+#: id:15052
+msgid "Password"
+msgstr "Salasana"
+
+#: id:15100
+msgctxt "Auto context with id 15100"
+msgid "Library"
+msgstr "Kirjasto"
+
+#: id:15101
+msgid "Database"
+msgstr "Tietokanta"
+
+#: id:15102
+msgid "* All albums"
+msgstr "* Kaikki albumit"
+
+#: id:15103
+msgid "* All artists"
+msgstr "* Kaikki esittäjät"
+
+#: id:15104
+msgid "* All songs"
+msgstr "* Kaikki kappaleet"
+
+#: id:15105
+msgid "* All genres"
+msgstr "* Kaikki lajityypit"
+
+#: id:15107
+msgid "Buffering..."
+msgstr "Siirretään puskurimuistiin..."
+
+#: id:15108
+msgid "Navigation sounds"
+msgstr "Valikkoäänet"
+
+#: id:15109
+msgid "Skin default"
+msgstr "Oletus"
+
+#: id:15111
+msgid "- Theme"
+msgstr "- Teema"
+
+#: id:15112
+msgid "Default theme"
+msgstr "Oletusteema"
+
+#: id:15200
+msgid "Last.fm"
+msgstr "Last.fm"
+
+#: id:15201
+msgid "Submit songs to Last.fm"
+msgstr "Lähetä kappaletiedot Last.fm-palveluun"
+
+#: id:15202
+msgid "Last.fm username"
+msgstr "Last.fm-käyttäjätunnus"
+
+#: id:15203
+msgid "Last.fm password"
+msgstr "Last.fm-salasana"
+
+#: id:15204
+msgid "Unable to handshake: sleeping..."
+msgstr "Ei saatu yhteyttä: odotetaan..."
+
+#: id:15205
+msgid "Please update XBMC"
+msgstr "XBMC täytyy päivittää"
+
+#: id:15206
+msgid "Bad authorization: Check username and password"
+msgstr "Valtuutusvirhe: tarkista käyttäjätunnus ja salasana"
+
+#: id:15207
+msgctxt "Auto context with id 15207"
+msgid "Connected"
+msgstr "Yhdistetty"
+
+#: id:15208
+msgid "Not connected"
+msgstr "Ei yhdistetty"
+
+#: id:15209
+msgid "Submit interval %i"
+msgstr "Lähetysväli %i"
+
+#: id:15210
+msgid "Cached %i songs"
+msgstr "Välimuistissa %i kappaletta"
+
+#: id:15211
+msgid "Submitting..."
+msgstr "Lähetetään..."
+
+#: id:15212
+msgid "Submitting in %i secs"
+msgstr "Lähetetään %i s kuluttua"
+
+#: id:15213
+msgid "Play using..."
+msgstr "Toista käyttäen..."
+
+#: id:15214
+msgid "Use smoothed A/V synchronization"
+msgstr "Käytä pehmennettyä A/V-tahdistusta"
+
+#: id:15215
+msgid "Hide file names in thumbs view"
+msgstr "Piilota tiedostonimet pienoiskuva-näkymässä"
+
+#: id:15216
+msgid "Play in party mode"
+msgstr "Toista jukeboksissa"
+
+#: id:15217
+msgid "Submit songs to Libre.fm"
+msgstr "Lähetä kappaletiedot Libre.fm-palveluun"
+
+#: id:15218
+msgid "Libre.fm username"
+msgstr "Libre.fm-käyttäjätunnus"
+
+#: id:15219
+msgid "Libre.fm password"
+msgstr "Libre.fm-salasana"
+
+#: id:15220
+msgid "Libre.fm"
+msgstr "Libre.fm"
+
+#: id:15221
+msgid "Song submission"
+msgstr "Musiikin lähetys"
+
+#: id:15250
+msgid "Submit Last.fm radio to Last.fm"
+msgstr "Last.fm-radion lähetys käytössä"
+
+#: id:15251
+msgid "Connecting to Last.fm..."
+msgstr "Yhdistetään Last.fm palveluun..."
+
+#: id:15252
+msgid "Selecting station..."
+msgstr "Valitaan radioasema..."
+
+#: id:15253
+msgid "Search similar artists..."
+msgstr "Etsi samankaltaisia esittäjiä..."
+
+#: id:15254
+msgid "Search similar tags..."
+msgstr "Etsi samankaltaisia tunnisteita..."
+
+#: id:15255
+msgid "Your profile (%name%)"
+msgstr "Oma profiili (%name%)"
+
+#: id:15256
+msgid "Overall top tags"
+msgstr "Suosituimmat tunnisteet"
+
+#: id:15257
+msgid "Top artists for tag %name%"
+msgstr "Suosituimmat esittäjät tunnisteelle:%name%"
+
+#: id:15258
+msgid "Top albums for tag %name%"
+msgstr "Suosituimmat albumit tunnisteelle:%name%"
+
+#: id:15259
+msgid "Top tracks for tag %name%"
+msgstr "Suosituimmat kappaleet tunnisteelle:%name%"
+
+#: id:15260
+msgid "Listen to tag %name% Last.fm radio"
+msgstr "Kuuntele tunnisteen %name% kappaleet Last.fm radiosta"
+
+#: id:15261
+msgid "Similar artists as %name%"
+msgstr "Samankaltaiset esittäjät kuin %name%"
+
+#: id:15262
+msgid "Top %name% albums"
+msgstr "Suosituimmat %name%:n albumit"
+
+#: id:15263
+msgid "Top %name% tracks"
+msgstr "Suosituimmat %name%:n kappaleet"
+
+#: id:15264
+msgid "Top %name% tags"
+msgstr "Suosituimmat %name%:n tunnisteet"
+
+#: id:15265
+msgid "Biggest fans of %name%"
+msgstr "Suurimmat %name%:n fanit"
+
+#: id:15266
+msgid "Listen to %name% fans Last.fm radio"
+msgstr "Kuuntele %name% fanien Last.fm radiota"
+
+#: id:15267
+msgid "Listen to %name% similar artists Last.fm radio"
+msgstr "Kuuntele %name%:n samankaltaisten esittäjien last.fm radiota"
+
+#: id:15268
+msgid "Top artists for user %name%"
+msgstr "Käyttäjän %name% suosituimmat esittäjät"
+
+#: id:15269
+msgid "Top albums for user %name%"
+msgstr "Käyttäjän %name% suosituimmat albumit"
+
+#: id:15270
+msgid "Top tracks for user %name%"
+msgstr "Käyttäjän %name% suosituimmat kappaleet"
+
+#: id:15271
+msgid "Friends of user %name%"
+msgstr "Käyttäjän %name% kaverit"
+
+#: id:15272
+msgid "Neighbours of user %name%"
+msgstr "Käyttäjän %name% naapurit"
+
+#: id:15273
+msgid "Weekly artist chart for %name%"
+msgstr "%name%:n viikottainen esittäjälista"
+
+#: id:15274
+msgid "Weekly album chart for %name%"
+msgstr "%name%:n viikottainen albumilista"
+
+#: id:15275
+msgid "Weekly track chart for %name%"
+msgstr "%name%:n viikottainen kappalelista"
+
+#: id:15276
+msgid "Listen to %name%'s neighbours Last.fm radio"
+msgstr "Kuuntele %name%:n naapurien Last.fm radiota"
+
+#: id:15277
+msgid "Listen to %name%'s personal Last.fm radio"
+msgstr "Kuuntele %name%:n henkilökohtaista Last.fm radiota"
+
+#: id:15278
+msgid "Listen to %name%'s mix Last.fm radio"
+msgstr "Kuuntele %name%:n suosikki kappaleiden Last.fm radiota"
+
+#: id:15279
+msgid "Retrieving list from Last.fm..."
+msgstr "Noudetaan listaa Last.fm:stä..."
+
+#: id:15280
+msgid "Can't retrieve list from Last.fm..."
+msgstr "Ei voida hakea listaa Last.fm:stä..."
+
+#: id:15281
+msgid "Enter an artist name to find related ones"
+msgstr "Anna esittäjän nimi löytääksesi vastaavia esittäjiä"
+
+#: id:15282
+msgid "Enter a tag name to find similar ones"
+msgstr "Anna tunniste löytääksesi vastaavia"
+
+#: id:15283
+msgid "Tracks recently listened by %name%"
+msgstr "Käyttäjän %name% kuuntelemat kappaleet"
+
+#: id:15284
+msgid "Listen to %name%'s recommendations Last.fm radio"
+msgstr "Kuuntele %name%:n suositukset Last.fm radiosta"
+
+#: id:15285
+msgid "Top tags for user %name%"
+msgstr "Käyttäjän %name% tunnisteet"
+
+#: id:15287
+msgid "Do you want to add the current track to your loved tracks?"
+msgstr "Haluatko lisätä nykyisen kappaleen omiin suosikkeihin?"
+
+#: id:15288
+msgid "Do you want to ban the current track?"
+msgstr "Haluatko asettaa eston nykyiselle kappaleelle?"
+
+#: id:15289
+msgid "Added to your loved tracks: '%s'."
+msgstr "'%s' lisätty omiin suosikki kappaleisiin."
+
+#: id:15290
+msgid "Could not add '%s' to your loved tracks."
+msgstr "'%s':a ei voida lisätä omiin suosikki kappaleisiin."
+
+#: id:15291
+msgid "Banned: '%s'."
+msgstr "Esto asetettu: '%s'."
+
+#: id:15292
+msgid "Could not ban '%s'."
+msgstr "'%s':lle ei voida asettaa estoa."
+
+#: id:15293
+msgid "Tracks recently loved by %name%"
+msgstr "%name%:n uusimmat suosikit"
+
+#: id:15294
+msgid "Tracks recently banned by %name%"
+msgstr "%name%:n viimeksi estetyt"
+
+#: id:15295
+msgid "Remove from loved tracks"
+msgstr "Poista omista suosikeista"
+
+#: id:15296
+msgid "Un-ban"
+msgstr "Poista esto"
+
+#: id:15297
+msgid "Do you want to remove this track from your loved tracks?"
+msgstr "Haluatko poistaa tämän kappaleen omista suosikeista?"
+
+#: id:15298
+msgid "Do you want to un-ban this track?"
+msgstr "Haluatko poistaa eston tältä kappaleelta?"
+
+#: id:15300
+msgid "Path not found or invalid"
+msgstr "Määriteltyä polkua ei löydy"
+
+#: id:15301
+msgid "Could not connect to network server"
+msgstr "Palvelimeen ei saada yhteyttä"
+
+#: id:15302
+msgid "No servers found"
+msgstr "Palvelimia ei löytynyt"
+
+#: id:15303
+msgid "Workgroup not found"
+msgstr "Työryhmää ei löytynyt"
+
+#: id:15310
+msgid "Opening multi-path source"
+msgstr "Avataan useapolkuista sijaintia"
+
+#: id:15311
+msgid "Path:"
+msgstr "Polku:"
+
+#: id:16000
+msgctxt "Auto context with id 16000"
+msgid "General"
+msgstr "Yleiset"
+
+#: id:16002
+msgid "Internet lookup"
+msgstr "Tietojen internethaku"
+
+#: id:16003
+msgid "Player"
+msgstr "Soitin"
+
+#: id:16004
+msgid "Play media from disc"
+msgstr "Toista media levyltä"
+
+#: id:16008
+msgid "Enter new title"
+msgstr "Anna uusi nimi"
+
+#: id:16009
+msgid "Enter the movie name"
+msgstr "Anna elokuvan nimi"
+
+#: id:16010
+msgid "Enter the profile name"
+msgstr "Anna profiilin nimi"
+
+#: id:16011
+msgid "Enter the album name"
+msgstr "Anna albumin nimi"
+
+#: id:16012
+msgid "Enter the playlist name"
+msgstr "Anna toistolistalle nimi"
+
+#: id:16013
+msgid "Enter new filename"
+msgstr "Anna uusi tiedostonimi"
+
+#: id:16014
+msgid "Enter folder name"
+msgstr "Anna kansion nimi"
+
+#: id:16015
+msgid "Enter directory"
+msgstr "Anna hakemisto"
+
+#: id:16016
+msgid "Available options: %A, %T, %N, %B, %D, %G, %Y, %F, %S"
+msgstr "Käytettävissä: %A, %T, %N, %B, %D, %G, %Y, %F, %S"
+
+#: id:16017
+msgid "Enter search string"
+msgstr "Anna hakusana"
+
+#: id:16018
+msgctxt "Auto context with id 16018"
+msgid "None"
+msgstr "Pois"
+
+#: id:16019
+msgid "Auto select"
+msgstr "Automaattinen"
+
+#: id:16020
+msgid "De-interlace"
+msgstr "Lomituksenpoisto"
+
+#: id:16021
+msgid "Bob"
+msgstr "Synk. parittomat"
+
+#: id:16022
+msgid "Bob (inverted)"
+msgstr "Synk. parilliset"
+
+#: id:16024
+msgid "Canceling..."
+msgstr "Peruutetaan..."
+
+#: id:16025
+msgid "Enter the artist name"
+msgstr "Anna esittäjän nimi"
+
+#: id:16026
+msgid "Playback failed"
+msgstr "Toisto ei onnistu"
+
+#: id:16027
+msgid "One or more items failed to play."
+msgstr "Yksi tai useampi toistovirhe esiintyi"
+
+#: id:16028
+msgid "Enter value"
+msgstr "Anna arvo"
+
+#: id:16029
+msgid "Check the log file for details."
+msgstr "Katso lokitiedostosta lisätietoja."
+
+#: id:16030
+msgid "Party mode aborted."
+msgstr "Jukeboksi keskeytettiin."
+
+#: id:16031
+msgid "No matching songs in the library."
+msgstr "Kirjastosta ei löytynyt sopivia kappaleita."
+
+#: id:16032
+msgid "Could not initialize database."
+msgstr "Tietokantaa ei voida valmistella."
+
+#: id:16033
+msgid "Could not open database."
+msgstr "Tietokantaa ei voida avata."
+
+#: id:16034
+msgid "Could not get songs from database."
+msgstr "Tietokannasta ei voitu hakea kappaleita."
+
+#: id:16035
+msgid "Party mode playlist"
+msgstr "Jukeboksi toistolista"
+
+#: id:16036
+msgid "De-interlace (Half)"
+msgstr "Lomituksenpoisto (puolinopeus)"
+
+#: id:16037
+msgid "Deinterlace video"
+msgstr "Videon lomituksenpoisto"
+
+#: id:16038
+msgid "Deinterlace method"
+msgstr "Lomituksenpoistomenetelmä"
+
+#: id:16039
+msgctxt "Auto context with id 16039"
+msgid "Off"
+msgstr "Pois päältä"
+
+#: id:16040
+msgctxt "Auto context with id 16040"
+msgid "Auto"
+msgstr "Automaattinen"
+
+#: id:16041
+msgid "On"
+msgstr "Päällä"
+
+#: id:16100
+msgid "All Videos"
+msgstr "Kaikki videot"
+
+#: id:16101
+msgid "Unwatched"
+msgstr "katsomatonta"
+
+#: id:16102
+msgid "Watched"
+msgstr "katsottua"
+
+#: id:16103
+msgid "Mark as watched"
+msgstr "Merkitse katsotuksi"
+
+#: id:16104
+msgid "Mark as unwatched"
+msgstr "Merkitse katsomattomaksi"
+
+#: id:16105
+msgid "Edit title"
+msgstr "Muokkaa nimeä"
+
+#: id:16200
+msgid "Operation was aborted"
+msgstr "Käyttö keskeytettiin"
+
+#: id:16201
+msgid "Copy failed"
+msgstr "Kopiointi epäonnistui"
+
+#: id:16202
+msgid "Failed to copy at least one file"
+msgstr "Vähintään yhden tiedoston kopiointi epäonnistui"
+
+#: id:16203
+msgid "Move failed"
+msgstr "Siirto epäonnistui"
+
+#: id:16204
+msgid "Failed to move at least one file"
+msgstr "Vähintään yhden tiedoston siirto epäonnistui"
+
+#: id:16205
+msgid "Delete failed"
+msgstr "Poisto epäonnistui"
+
+#: id:16206
+msgid "Failed to delete at least one file"
+msgstr "Vähintään yhden tiedoston poisto epäonnistui"
+
+#: id:16300
+msgid "Video scaling method"
+msgstr "Videon skaalausmenetelmä"
+
+#: id:16301
+msgid "Nearest neighbour"
+msgstr "Lähin viereinen"
+
+#: id:16302
+msgid "Bilinear"
+msgstr "Bilineaarinen"
+
+#: id:16303
+msgctxt "Auto context with id 16303"
+msgid "Bicubic"
+msgstr "Bicubic"
+
+#: id:16304
+msgid "Lanczos2"
+msgstr "Lanczos2"
+
+#: id:16305
+msgid "Lanczos3"
+msgstr "Lanczos3"
+
+#: id:16306
+msgid "Sinc8"
+msgstr "Sinc8"
+
+#: id:16307
+msgid "Bicubic (software)"
+msgstr "Bicubic (ohjelmallinen)"
+
+#: id:16308
+msgid "Lanczos (software)"
+msgstr "Lanczos (ohjelmallinen)"
+
+#: id:16309
+msgid "Sinc (software)"
+msgstr "Sinc (ohjelmallinen)"
+
+#: id:16310
+msgid "Temporal"
+msgstr "Temporal"
+
+#: id:16311
+msgid "Temporal/Spatial"
+msgstr "Temporal/Spatial"
+
+#: id:16312
+msgid "(VDPAU)Noise Reduction"
+msgstr "(VDPAU) Kohinanvähennys"
+
+#: id:16313
+msgid "(VDPAU)Sharpness"
+msgstr "(VDPAU) Terävyys"
+
+#: id:16314
+msgid "Inverse Telecine"
+msgstr "Inverse Telecine"
+
+#: id:16315
+msgid "Lanczos3 optimized"
+msgstr "Lanczos3 optimoitu"
+
+#: id:16316
+msgctxt "Auto context with id 16316"
+msgid "Auto"
+msgstr "Automaattinen"
+
+#: id:16317
+msgid "Temporal (Half)"
+msgstr "Temporal (puolinopeus)"
+
+#: id:16318
+msgid "Temporal/Spatial (Half)"
+msgstr "Temporal/Spatial (puolinopeus)"
+
+#: id:16319
+msgid "DXVA"
+msgstr "DXVA"
+
+#: id:16320
+msgid "DXVA Bob"
+msgstr "DXVA Synk. parittomat"
+
+#: id:16321
+msgid "DXVA Best"
+msgstr "DXVA Paras"
+
+#: id:16322
+msgid "Spline36"
+msgstr "Spline36"
+
+#: id:16323
+msgid "Spline36 optimized"
+msgstr "Spline36 optimoitu"
+
+#: id:16324
+msgid "Software Blend"
+msgstr "Ohjelmistopohjainen sekoitus"
+
+#: id:16400
+msgid "Post-processing"
+msgstr "Videon jälkikäsittely"
+
+#: id:17500
+msgid "Display sleep timeout"
+msgstr "Näytön pimennyksen viive"
+
+#: id:19000
+msgid "Switch to channel"
+msgstr "Vaihda kanavalle"
+
+#: id:20000
+msgid "Saved music folder"
+msgstr "Tallennuskansio"
+
+#: id:20001
+msgid "Use external DVD player"
+msgstr "Käytä ulkoista DVD-toisto-ohjelmaa"
+
+#: id:20002
+msgid "External DVD player"
+msgstr "Ulkoinen DVD-toisto-ohjelma"
+
+#: id:20003
+msgid "Trainers folder"
+msgstr "Trainer-kansio"
+
+#: id:20004
+msgid "Screenshot folder"
+msgstr "Kuvakaappauskansio"
+
+#: id:20006
+msgid "Playlists folder"
+msgstr "Toistolistakansio"
+
+#: id:20007
+msgid "Recordings"
+msgstr "Nauhoitukset"
+
+#: id:20008
+msgid "Screenshots"
+msgstr "Kuvakaappaukset"
+
+#: id:20009
+msgid "Use XBMC"
+msgstr "Käytä XBMC:ia"
+
+#: id:20011
+msgid "Music playlists"
+msgstr "Musiikkitoistolistat"
+
+#: id:20012
+msgid "Video playlists"
+msgstr "Videotoistolistat"
+
+#: id:20013
+msgid "Do you wish to launch the game?"
+msgstr "Käynnistetäänkö peli?"
+
+#: id:20014
+msgid "Sort by: Playlist"
+msgstr "Toistolistat"
+
+#: id:20015
+msgid "Remote thumb"
+msgstr "Ulkoinen pienoiskuva"
+
+#: id:20016
+msgid "Current thumb"
+msgstr "Nykyinen pienoiskuva"
+
+#: id:20017
+msgid "Local thumb"
+msgstr "Paikallinen pienoiskuva"
+
+#: id:20018
+msgid "No thumb"
+msgstr "Ei pienoiskuvaa"
+
+#: id:20019
+msgid "Choose thumbnail"
+msgstr "Valitse pienoiskuva"
+
+#: id:20023
+msgid "Conflict"
+msgstr "Ei onnistu"
+
+#: id:20024
+msgid "Scan new"
+msgstr "Etsi uudet"
+
+#: id:20025
+msgid "Scan all"
+msgstr "Etsi kaikki"
+
+#: id:20026
+msgid "Region"
+msgstr "Kielialue"
+
+#: id:20037
+msgid "Summary"
+msgstr "Lyhyesti"
+
+#: id:20038
+msgid "Lock music window"
+msgstr "Lukitse musiikki"
+
+#: id:20039
+msgid "Lock videos window"
+msgstr "Lukitse videot"
+
+#: id:20040
+msgid "Lock pictures window"
+msgstr "Lukitse kuvat"
+
+#: id:20041
+msgid "Lock programs & scripts windows"
+msgstr "Lukitse ohjelmat ja skriptit"
+
+#: id:20042
+msgid "Lock file manager"
+msgstr "Lukitse tiedostonhallinta"
+
+#: id:20043
+msgid "Lock settings"
+msgstr "Lukitse asetukset"
+
+#: id:20044
+msgid "Start fresh"
+msgstr "Tyhjät"
+
+#: id:20045
+msgid "Enter master mode"
+msgstr "Siirry pääkäyttäjätilaan"
+
+#: id:20046
+msgid "Leave master mode"
+msgstr "Poistu pääkäyttäjätilasta"
+
+#: id:20047
+msgid "Create profile '%s'?"
+msgstr "Luo profiili '%s'?"
+
+#: id:20048
+msgid "Start with fresh settings"
+msgstr "Aloita tyhjillä asetuksilla"
+
+#: id:20049
+msgid "Best available"
+msgstr "Paras käytettävissä oleva"
+
+#: id:20050
+msgid "Auto-switch between 16x9 and 4x3"
+msgstr "Vaihda automaattisesti 16:9 ja 4:3 välillä"
+
+#: id:20051
+msgid "Treat stacked files as single file"
+msgstr "Käsittele pinotut tiedostot yhtenä tiedostona"
+
+#: id:20052
+msgid "Caution"
+msgstr "Huomautus"
+
+#: id:20053
+msgid "Left master mode"
+msgstr "Poistuit pääkäyttäjätilasta"
+
+#: id:20054
+msgid "Entered master mode"
+msgstr "Siirryit pääkäyttäjätilaan"
+
+#: id:20055
+msgid "Allmusic.com thumb"
+msgstr "Allmusic.com- pienoiskuva"
+
+#: id:20057
+msgid "Remove thumbnail"
+msgstr "Poista pienoiskuva"
+
+#: id:20058
+msgid "Add profile..."
+msgstr "Lisää uusi profiili..."
+
+#: id:20059
+msgid "Query info for all albums"
+msgstr "Nouda albumien tiedot"
+
+#: id:20060
+msgctxt "Auto context with id 20060"
+msgid "Media info"
+msgstr "Media tiedot"
+
+#: id:20061
+msgctxt "Auto context with id 20061"
+msgid "Separate"
+msgstr "Omat"
+
+#: id:20062
+msgid "Shares with default"
+msgstr "Oletukset"
+
+#: id:20063
+msgid "Shares with default (read only)"
+msgstr "Oletukset (vain luku)"
+
+#: id:20064
+msgid "Copy default"
+msgstr "Oletukset"
+
+#: id:20065
+msgid "Profile picture"
+msgstr "Profiilin kuva"
+
+#: id:20066
+msgid "Lock preferences"
+msgstr "Lukitusasetukset"
+
+#: id:20067
+msgid "Edit profile"
+msgstr "Muokkaa profiilia"
+
+#: id:20068
+msgid "Profile lock"
+msgstr "Profiilin lukitus"
+
+#: id:20069
+msgid "Could not create folder"
+msgstr "Kansion luonti ei onnistu"
+
+#: id:20070
+msgid "Profile directory"
+msgstr "Profiilin tallennuskansio"
+
+#: id:20071
+msgid "Start with fresh media sources"
+msgstr "Aloita käyttämällä uutta mediasijaintia"
+
+#: id:20072
+msgid "Make sure the selected folder is writable"
+msgstr "varmista, että valittu kansio on kirjoitettava"
+
+#: id:20073
+msgid "and that the new folder name is valid"
+msgstr "ja kansion nimi on käyttökelpoinen"
+
+#: id:20074
+msgid "MPAA rating"
+msgstr "MPAA-luokitus"
+
+#: id:20075
+msgid "Enter master lock code"
+msgstr "Anna pääkäyttäjän lukituskoodi"
+
+#: id:20076
+msgid "Ask for master lock code on startup"
+msgstr "Kysy pääkäyttäjän lukituskoodia käynnistyessä"
+
+#: id:20077
+msgid "Skin settings"
+msgstr "Ulkoasun asetukset"
+
+#: id:20078
+msgid "- no link set -"
+msgstr "- Linkkiä ei ole -"
+
+#: id:20079
+msgid "Enable animations"
+msgstr "Animoinnit käytössä"
+
+#: id:20080
+msgid "Disable RSS during music"
+msgstr "Älä näytä RSS-tietoja musiikin aikana"
+
+#: id:20081
+msgid "Enable shortcut buttons"
+msgstr "Pikakuvakkeet käytössä"
+
+#: id:20082
+msgid "Show programs in main menu"
+msgstr "Näytä Ohjelmat-valikko"
+
+#: id:20083
+msgid "Show music info"
+msgstr "Näytä Musiikki-tiedot"
+
+#: id:20084
+msgid "Show weather info"
+msgstr "Näytä Sää-tiedot"
+
+#: id:20085
+msgid "Show system info"
+msgstr "Näytä Järjestelmän tiedot"
+
+#: id:20086
+msgid "Show available disc space C: E: F:"
+msgstr "Näytä vapaa tila asemissa C: E: F:"
+
+#: id:20087
+msgid "Show available disc space E: F: G:"
+msgstr "Näytä vapaa tila asemissa E: F: G:"
+
+#: id:20088
+msgid "Weather info"
+msgstr "Säätiedot"
+
+#: id:20089
+msgid "Drive space free"
+msgstr "Vapaa tila"
+
+#: id:20090
+msgid "Enter the name of an existing share"
+msgstr "Anna sijainnin nimi"
+
+#: id:20091
+msgid "Lock code"
+msgstr "Lukituskoodi"
+
+#: id:20092
+msgid "Load profile"
+msgstr "Lataa profiili"
+
+#: id:20093
+msgid "Profile name"
+msgstr "Profiilin nimi"
+
+#: id:20094
+msgctxt "Auto context with id 20094"
+msgid "Media sources"
+msgstr "Medialähteet"
+
+#: id:20095
+msgid "Enter profile lock code"
+msgstr "Anna lukituskoodi profiilille"
+
+#: id:20096
+msgctxt "Auto context with id 20096"
+msgid "Login screen"
+msgstr "Kirjaudu sisään"
+
+#: id:20097
+msgid "Fetching album info"
+msgstr "Noudetaan albumi tietoja"
+
+#: id:20098
+msgid "Fetching info for album"
+msgstr "Noudetaan tietoja albumista"
+
+#: id:20099
+msgid "Can't rip CD or track while playing from CD"
+msgstr "Siirtoa ei voida aloittaa kun toisto on käynnissä"
+
+#: id:20100
+msgid "Master lock code and settings"
+msgstr "Pääkäyttäjän lukituskoodi ja asetukset"
+
+#: id:20101
+msgid "Entering master lock code always enables master mode"
+msgstr "Lukituskoodi antamalla siirrytään pääkäyttäjä-tilaan"
+
+#: id:20102
+msgid "or copy from default?"
+msgstr "tai käytä oletuksia"
+
+#: id:20103
+msgid "Save changes to profile?"
+msgstr "Tallennetaanko muutokset profiiliin?"
+
+#: id:20104
+msgid "Old settings found."
+msgstr "Vanhat asetukset löydetty."
+
+#: id:20105
+msgid "Do you want to use them?"
+msgstr "Haluatko käyttää niitä?"
+
+#: id:20106
+msgid "Old media sources found."
+msgstr "Vanha median sijainti löytyi."
+
+#: id:20107
+msgid "Separate (locked)"
+msgstr "Omat(lukittu)"
+
+#: id:20108
+msgid "Root"
+msgstr "Päähakemisto"
+
+#: id:20109
+msgid "- Zoom"
+msgstr "- Zoomaus"
+
+#: id:20110
+msgid "UPnP settings"
+msgstr "UPnP-asetukset"
+
+#: id:20111
+msgid "Autostart UPnP client"
+msgstr "Automaattinen käynnistys"
+
+#: id:20112
+msgid "Last login: %s"
+msgstr "Viimeksi kirjautunut: %s"
+
+#: id:20113
+msgid "Never logged on"
+msgstr "Ei aiemmin kirjautunut"
+
+#: id:20114
+msgid "Profile %i / %i"
+msgstr "Profiili %i / %i"
+
+#: id:20115
+msgid "User login / Select a profile"
+msgstr "Käyttäjän sisäänkirjautuminen"
+
+#: id:20116
+msgid "Use lock on login screen"
+msgstr "Lukitse sisäänkirjautumisruutu"
+
+#: id:20117
+msgid "Invalid lock code."
+msgstr "Lukituskoodi on väärä."
+
+#: id:20118
+msgid "This requires the master lock to be set."
+msgstr "Tähän täytyy olla pääkäyttäjän lukitus asetettuna."
+
+#: id:20119
+msgid "Would you like to set it now?"
+msgstr "Haluatko asettaa sen nyt?"
+
+#: id:20120
+msgid "Loading program information"
+msgstr "Noudetaan ohjelman tiedot"
+
+#: id:20121
+msgid "Party on!"
+msgstr "Musiikin soitto alkaa"
+
+#: id:20122
+msgid "True"
+msgstr "Nyt voit rentoutua"
+
+#: id:20123
+msgid "Mixing drinks"
+msgstr "Arvotaan kuunneltavia kappaleita"
+
+#: id:20124
+msgid "Filling glasses"
+msgstr "Valmiina nauttimaan musiikista"
+
+#: id:20125
+msgid "Logged on as"
+msgstr "Kirjautuneena:"
+
+#: id:20126
+msgid "Log off"
+msgstr "Kirjaudu ulos:"
+
+#: id:20128
+msgid "Go to root"
+msgstr "Siirry päähakemistoon"
+
+#: id:20129
+msgid "Weave"
+msgstr "Liitä"
+
+#: id:20130
+msgid "Weave (inverted)"
+msgstr "Liitä (käänteisesti)"
+
+#: id:20131
+msgid "Blend"
+msgstr "Sekoita"
+
+#: id:20132
+msgid "Restart video"
+msgstr "Käynnistä video uudelleen"
+
+#: id:20133
+msgid "Edit network location"
+msgstr "Muokkaa verkko-osoitetta"
+
+#: id:20134
+msgid "Remove network location"
+msgstr "Poista verkko-osoite"
+
+#: id:20135
+msgid "Do you want to scan the folder?"
+msgstr "Haluatko hakea kansiosta?"
+
+#: id:20136
+msgid "Memory unit"
+msgstr "Muistikortti"
+
+#: id:20137
+msgid "Memory unit mounted"
+msgstr "Muistikortti liitetty"
+
+#: id:20138
+msgid "Unable to mount memory unit"
+msgstr "Muistikorttia ei löydy"
+
+#: id:20139
+msgid "In port %i, slot %i"
+msgstr "Portissa %i ja paikassa %i"
+
+#: id:20140
+msgid "Lock screensaver"
+msgstr "Lukitse ruudunsäästäjä"
+
+#: id:20141
+msgid "Set"
+msgstr "Aseta"
+
+#: id:20142
+msgctxt "Auto context with id 20142"
+msgid "Username"
+msgstr "Käyttäjätunnus"
+
+#: id:20143
+msgid "Enter password for"
+msgstr "Anna salasana"
+
+#: id:20144
+msgid "Shutdown timer"
+msgstr "Sammutusajastin"
+
+#: id:20145
+msgid "Shutdown interval (in minutes)"
+msgstr "Sammutusajastus (minuuttia)"
+
+#: id:20146
+msgid "Started, shutdown in %im"
+msgstr "Käynnistetty, sammutetaan %i minuutin kuluttua"
+
+#: id:20147
+msgid "Shutdown in 30 minutes"
+msgstr "Sammuta 30 minuutin kuluttua"
+
+#: id:20148
+msgid "Shutdown in 60 minutes"
+msgstr "Sammuta 60 minuutin kuluttua"
+
+#: id:20149
+msgid "Shutdown in 120 minutes"
+msgstr "Sammuta 120 minuutin kuluttua"
+
+#: id:20150
+msgid "Custom shutdown timer"
+msgstr "Aseta aika sammutukseen"
+
+#: id:20151
+msgid "Cancel shutdown timer"
+msgstr "Keskeytä sammutusajastus"
+
+#: id:20152
+msgid "Lock preferences for %s"
+msgstr "Lukitse %s-asetukset"
+
+#: id:20153
+msgid "Browse..."
+msgstr "Selaa..."
+
+#: id:20154
+msgid "Summary information"
+msgstr "Yhteenveto"
+
+#: id:20155
+msgid "Storage information"
+msgstr "Tallennustiedot"
+
+#: id:20156
+msgid "Hard disk information"
+msgstr "Kiintolevyn tiedot"
+
+#: id:20157
+msgid "DVD-ROM information"
+msgstr "DVD-aseman tiedot"
+
+#: id:20158
+msgid "Network information"
+msgstr "Verkon tiedot"
+
+#: id:20159
+msgid "Video information"
+msgstr "Näytön tiedot"
+
+#: id:20160
+msgid "Hardware information"
+msgstr "Laitteiston tiedot"
+
+#: id:20161
+msgid "Total"
+msgstr "Yhteensä"
+
+#: id:20162
+msgid "Used"
+msgstr "Käytössä"
+
+#: id:20163
+msgid "of"
+msgstr "/"
+
+#: id:20164
+msgid "Locking not supported"
+msgstr "Lukitusta ei voida käyttää"
+
+#: id:20165
+msgid "Not locked"
+msgstr "Lukitsematon"
+
+#: id:20166
+msgid "Locked"
+msgstr "Lukittu"
+
+#: id:20167
+msgid "Frozen"
+msgstr "Jumissa"
+
+#: id:20168
+msgid "Requires reset"
+msgstr "Täytyy resetoida"
+
+#: id:20169
+msgid "Week"
+msgstr "vko"
+
+#: id:20170
+msgid "Line"
+msgstr ", tuotantolinja"
+
+#: id:20171
+msgid "Windows network (SMB)"
+msgstr "Windows verkko(SMB)"
+
+#: id:20172
+msgid "XBMSP server"
+msgstr "XBMSP-Palvelin"
+
+#: id:20173
+msgctxt "Auto context with id 20173"
+msgid "FTP server"
+msgstr "FTP-Palvelin"
+
+#: id:20174
+msgid "iTunes music share (DAAP)"
+msgstr "iTunes-musiikkijako (DAAP)"
+
+#: id:20175
+msgid "UPnP server"
+msgstr "UPnP-palvelin"
+
+#: id:20176
+msgid "Show video info"
+msgstr "Näytä Video-tiedot"
+
+#: id:20177
+msgid "Done"
+msgstr "Hyväksy"
+
+#: id:20178
+msgid "Shift"
+msgstr "Vaihto"
+
+#: id:20179
+msgid "Caps Lock"
+msgstr "Vaihto luk."
+
+#: id:20180
+msgid "Symbols"
+msgstr "Symbolit"
+
+#: id:20181
+msgid "Backspace"
+msgstr "Poisto"
+
+#: id:20182
+msgid "Space"
+msgstr "Välilyönti"
+
+#: id:20183
+msgid "Reload skin"
+msgstr "Virkistä näyttö"
+
+#: id:20184
+msgid "Rotate pictures using EXIF information"
+msgstr "Aseta kuvat Exif-tietojen mukaisesti"
+
+#: id:20185
+msgid "Use poster view styles for TV shows"
+msgstr "Käytä julistenäkymää TV-ohjelmilla"
+
+#: id:20186
+msgid "Please wait"
+msgstr "Odota hetki"
+
+#: id:20187
+msgid "UPnP"
+msgstr ""
+
+#: id:20189
+msgid "Enable auto scrolling for plot & review"
+msgstr "Juonen ja esittelyn automaattinen vieritys"
+
+#: id:20190
+msgctxt "Auto context with id 20190"
+msgid "Custom"
+msgstr "Mukautus"
+
+#: id:20191
+msgid "Enable debug logging"
+msgstr "Suorituslokin tallennus (debug log)"
+
+#: id:20192
+msgid "Download additional information during updates"
+msgstr "Nouda lisätiedot kirjastoa päivitettäessä"
+
+#: id:20193
+msgid "Default service for album information"
+msgstr "Albumitietojen hakupaikka"
+
+#: id:20194
+msgid "Default service for artist information"
+msgstr "Esittäjätietojen hakupaikka"
+
+#: id:20195
+msgid "Change scraper"
+msgstr "Vaihda tietojen hakupaikka"
+
+#: id:20196
+msgid "Export music library"
+msgstr "Vie musiikkikirjasto"
+
+#: id:20197
+msgid "Import music library"
+msgstr "Tuo musiikkikirjasto"
+
+#: id:20198
+msgid "No artist found!"
+msgstr "Esittäjää ei löydy!"
+
+#: id:20199
+msgid "Downloading artist info failed"
+msgstr "Esittäjän tietojen nouto epäonnistui"
+
+#: id:20250
+msgid "Party on! (videos)"
+msgstr "Videoesitys alkaa"
+
+#: id:20251
+msgid "Mixing drinks (videos)"
+msgstr "Arvotaan katseltavia videoita"
+
+#: id:20252
+msgid "Filling glasses (videos)"
+msgstr "Valmiina aloittamaan elokuvanäytös"
+
+#: id:20253
+msgid "WebDAV server (HTTP)"
+msgstr "WebDAV palvelin (HTTP)"
+
+#: id:20254
+msgid "WebDAV server (HTTPS)"
+msgstr "WebDAV palvelin (HTTPS)"
+
+#: id:20255
+msgid "First logon, edit your profile"
+msgstr "Ensimmäinen kirjautuminen, muokkaa profiiliasi"
+
+#: id:20256
+msgid "HTS Tvheadend client"
+msgstr "HTS Tvheadend -asiakas"
+
+#: id:20257
+msgid "VDR Streamdev client"
+msgstr "VDR Streamdev -asiakas"
+
+#: id:20258
+msgid "MythTV client"
+msgstr "MythTV -asiakas"
+
+#: id:20259
+msgid "Network Filesystem (NFS)"
+msgstr "Verkkotiedostojärjestelmä (NFS)"
+
+#: id:20260
+msgid "Secure Shell (SSH/SFTP)"
+msgstr "Secure Shell (SSH/SFTP)"
+
+#: id:20261
+msgid "Apple Filing Protocol (AFP)"
+msgstr "Apple Filing Protocol (AFP)"
+
+#: id:20300
+msgid "Web server directory (HTTP)"
+msgstr "Web-palvelimen hakemisto (HTTP)"
+
+#: id:20301
+msgid "Web server directory (HTTPS)"
+msgstr "Web-palvelimen hakemisto (HTTPS)"
+
+#: id:20302
+msgid "Unable to write to folder:"
+msgstr "Kansioon ei voi kirjoittaa:"
+
+#: id:20303
+msgid "Do you want to skip and proceed?"
+msgstr "Ohitetaanko ja jatketaanko suoritusta?"
+
+#: id:20304
+msgid "RSS Feed"
+msgstr "RSS-syöte"
+
+#: id:20307
+msgid "Secondary DNS"
+msgstr "Toissijainen DNS"
+
+#: id:20308
+msgid "DHCP server:"
+msgstr "DHCP-palvelin:"
+
+#: id:20309
+msgid "Make new folder"
+msgstr "Luo uusi kansio"
+
+#: id:20310
+msgid "Dim LCD on playback"
+msgstr "Himmennä LCD toistettaessa"
+
+#: id:20311
+msgid "Unknown or onboard (protected)"
+msgstr "Tuntematon tai suojattu"
+
+#: id:20312
+msgid "Dim LCD on paused"
+msgstr "Himmennä LCD taukojen ajaksi"
+
+#: id:20314
+msgid "Videos - Library"
+msgstr "Videot - Kirjasto"
+
+#: id:20316
+msgid "Sort by: ID"
+msgstr "Järjestä: ID"
+
+#: id:20324
+msgid "Play part..."
+msgstr "Toista osa..."
+
+#: id:20325
+msgid "Calibration reset"
+msgstr "Kalibroinnin nollaus"
+
+#: id:20326
+msgid "This will reset the calibration values for %s"
+msgstr "Tämä palauttaa asettamasi %s kalibroinnin arvot"
+
+#: id:20327
+msgid "to it's default values."
+msgstr "oletusarvoiksi"
+
+#: id:20328
+msgid "Browse for destination"
+msgstr "Valitse kohdesijainti"
+
+#: id:20329
+msgid "Movies are in separate folders that match the movie title"
+msgstr "Elokuvan tiedostot ovat eri kansioissa, jotka ovat nimetty elokuvan mukaan"
+
+#: id:20330
+msgid "Use folder names for lookups"
+msgstr "Hae kansionimiä"
+
+#: id:20331
+msgctxt "Auto context with id 20331"
+msgid "File"
+msgstr "Tiedostonimet"
+
+#: id:20332
+msgid "Use file or folder names in lookups?"
+msgstr "Käytetäänkö haettaessa tiedosto- vai kansionimiä?"
+
+#: id:20333
+msgid "Set content"
+msgstr "Aseta sisältö"
+
+#: id:20334
+msgid "Folder"
+msgstr "Kansionimet"
+
+#: id:20335
+msgid "Look for content recursively?"
+msgstr "Haetaanko sisältö kaikista kansioista?"
+
+#: id:20336
+msgid "Unlock sources"
+msgstr "Avaa sijaintien lukitus"
+
+#: id:20337
+msgid "Actor"
+msgstr "Näyttelijä"
+
+#: id:20338
+msgid "Movie"
+msgstr "Elokuva"
+
+#: id:20339
+msgid "Director"
+msgstr "Ohjaaja"
+
+#: id:20340
+msgid "Do you want to remove all items within"
+msgstr "Haluatko poistaa XBMC-kirjastosta kaikki kohteet,"
+
+#: id:20341
+msgid "this path from the XBMC library?"
+msgstr "jotka on tässä polussa?"
+
+#: id:20342
+msgctxt "Auto context with id 20342"
+msgid "Movies"
+msgstr "Elokuvat"
+
+#: id:20343
+msgid "TV shows"
+msgstr "TV-ohjelmat"
+
+#: id:20344
+msgid "This directory contains"
+msgstr "Hakemisto sisältää"
+
+#: id:20345
+msgid "Run automated scan"
+msgstr "Käynnistä automaattinen haku"
+
+#: id:20346
+msgid "Scan recursively"
+msgstr "Hae kaikista kansioista"
+
+#: id:20347
+msgid "as"
+msgstr "on"
+
+#: id:20348
+msgid "Directors"
+msgstr "Ohjaajat"
+
+#: id:20349
+msgid "No video files found in this path!"
+msgstr "Videoita ei löytynyt tästä polusta!"
+
+#: id:20350
+msgid "votes"
+msgstr "ääntä"
+
+#: id:20351
+msgid "TV show information"
+msgstr "TV-ohjelman tiedot"
+
+#: id:20352
+msgid "Episode information"
+msgstr "Jakson tiedot"
+
+#: id:20353
+msgid "Loading TV show details"
+msgstr "Noudetaan TV-ohjelman tiedot"
+
+#: id:20354
+msgid "Fetching episode guide"
+msgstr "Noudetaan jaksojen tietoja"
+
+#: id:20355
+msgid "Loading info for episodes in directory"
+msgstr "Luetaan hakemiston jaksojen tietoja"
+
+#: id:20356
+msgid "Select TV show:"
+msgstr "Valitse TV-ohjelma:"
+
+#: id:20357
+msgid "Enter the TV show name"
+msgstr "Anna TV-ohjelman nimi"
+
+#: id:20358
+msgid "Season %i"
+msgstr "Tuotantokausi %i"
+
+#: id:20359
+msgid "Episode"
+msgstr "Jakso"
+
+#: id:20360
+msgid "Episodes"
+msgstr "Jaksot"
+
+#: id:20361
+msgid "Loading episode details"
+msgstr "Noudetaan jakson tietoja"
+
+#: id:20362
+msgid "Remove episode from library"
+msgstr "Poista jakso kirjastosta"
+
+#: id:20363
+msgid "Remove TV show from library"
+msgstr "Poista TV-ohjelma kirjastosta"
+
+#: id:20364
+msgid "TV show"
+msgstr "TV-ohjelma"
+
+#: id:20365
+msgid "Episode plot"
+msgstr "Jakson juoni"
+
+#: id:20366
+msgid "* All seasons"
+msgstr "* Kaikki tuotantokaudet"
+
+#: id:20367
+msgid "Hide watched"
+msgstr "Piilota katsotut"
+
+#: id:20368
+msgid "Prod code"
+msgstr "Tuotantokoodi"
+
+#: id:20369
+msgid "Show plot for unwatched items"
+msgstr "Näytä juoni katsomattomille kohteille"
+
+#: id:20370
+msgid "* Hidden to prevent spoilers *"
+msgstr "* Piilotettu juonipaljastusten välttämiseksi *"
+
+#: id:20371
+msgid "Set season thumb"
+msgstr "Aseta tuotantokauden pienoiskuva"
+
+#: id:20372
+msgid "Season image"
+msgstr "Tuotantokauden kuva"
+
+#: id:20373
+msgid "Season"
+msgstr "Tuotantokausi"
+
+#: id:20374
+msgid "Downloading movie information"
+msgstr "Noudetaan elokuvatietoja"
+
+#: id:20375
+msgid "Unassign content"
+msgstr "Määrittelemätön sisältö"
+
+#: id:20376
+msgid "Original title"
+msgstr "Alkuperäinen nimi"
+
+#: id:20377
+msgid "Refresh TV show information"
+msgstr "Päivitä TV-ohjelmatiedot"
+
+#: id:20378
+msgid "Refresh info for all episodes?"
+msgstr "Päivitetäänkö kaikkien jaksojen tiedot?"
+
+#: id:20379
+msgid "Selected folder contains a single TV show"
+msgstr "Valittu kansio sisältää yhden TV-ohjelman"
+
+#: id:20380
+msgid "Exclude selected folder from scans"
+msgstr "Älä käytä valittua kansiota haussa"
+
+#: id:20381
+msgid "Specials"
+msgstr "Erikoisuudet"
+
+#: id:20382
+msgid "Automatically grab season thumbs"
+msgstr "Automaattisesti luodut jakson pienoiskuvat"
+
+#: id:20383
+msgid "Selected folder contains a single video"
+msgstr "Valittu kansio sisältää yhden videon"
+
+#: id:20384
+msgid "Link to TV show"
+msgstr "Lisää linkitys TV-ohjelmaan"
+
+#: id:20385
+msgid "Remove link to TV show"
+msgstr "Poista TV-ohjelman linkitys"
+
+#: id:20386
+msgid "Recently added movies"
+msgstr "Viimeksi lisätyt elokuvat"
+
+#: id:20387
+msgid "Recently added episodes"
+msgstr "Viimeksi lisätyt jaksot"
+
+#: id:20388
+msgid "Studios"
+msgstr "Studiot"
+
+#: id:20389
+msgid "Music videos"
+msgstr "Musiikkivideot"
+
+#: id:20390
+msgid "Recently added music videos"
+msgstr "Viimeksi lisätyt musiikkivideot"
+
+#: id:20391
+msgid "Music video"
+msgstr "Musiikkivideo"
+
+#: id:20392
+msgid "Remove music video from library"
+msgstr "Poista musiikkivideo kirjastosta"
+
+#: id:20393
+msgctxt "Auto context with id 20393"
+msgid "Music video information"
+msgstr "Musiikkivideon tiedot"
+
+#: id:20394
+msgid "Loading music video information"
+msgstr "Noudetaan musiikkivideon tietoja"
+
+#: id:20395
+msgid "Mixed"
+msgstr "Sekoitettu"
+
+#: id:20396
+msgid "Go to albums by artist"
+msgstr "Siirry esittäjän albumeihin"
+
+#: id:20397
+msgid "Go to album"
+msgstr "Siirry albumiin"
+
+#: id:20398
+msgid "Play song"
+msgstr "Toista kappale"
+
+#: id:20399
+msgid "Go to music videos from album"
+msgstr "Siirry albumin musiikkivideoihin"
+
+#: id:20400
+msgid "Go to music videos by artist"
+msgstr "Siirry esittäjän musiikkivideoihin"
+
+#: id:20401
+msgid "Play music video"
+msgstr "Toista musiikkivideo"
+
+#: id:20402
+msgid "Download actor thumbnails when adding to library"
+msgstr "Lataa ohjaajan pienoiskuvat kirjastoon lisättäessä"
+
+#: id:20403
+msgid "Set actor thumb"
+msgstr "Aseta ohjaajan pienoiskuva"
+
+#: id:20405
+msgid "Remove episode bookmark"
+msgstr "Poista jakson kirjanmerkki"
+
+#: id:20406
+msgid "Set episode bookmark"
+msgstr "Aseta jakson kirjanmerkki"
+
+#: id:20407
+msgid "Scraper settings"
+msgstr "Hakupaikan asetukset"
+
+#: id:20408
+msgid "Downloading music video information"
+msgstr "Noudetaan musiikkivideo tietoja"
+
+#: id:20409
+msgid "Downloading TV show information"
+msgstr "Noudetaan TV-ohjelmatietoja"
+
+#: id:20410
+msgid "Trailer"
+msgstr "Esittely"
+
+#: id:20411
+msgid "Flatten"
+msgstr "Tiivistä"
+
+#: id:20412
+msgid "Flatten TV shows"
+msgstr "Tiivistä TV-ohjelmat"
+
+#: id:20413
+msgid "Get fanart"
+msgstr "Fanitaide"
+
+#: id:20414
+msgid "Show Fanart in video and music libraries"
+msgstr "Näytä fanitaide video- ja musiikkikirjastossa"
+
+#: id:20415
+msgid "Scanning for new content"
+msgstr "Etsitään uutta sisältöä"
+
+#: id:20416
+msgid "First aired"
+msgstr "Ensiesitys"
+
+#: id:20417
+msgid "Writer"
+msgstr "Käsikirjoittaja"
+
+#: id:20419
+msgid "Replace file names with library titles"
+msgstr "Korvaa tiedostojen nimet kirjaston sisältämillä nimillä"
+
+#: id:20420
+msgctxt "Auto context with id 20420"
+msgid "Never"
+msgstr "Ei koskaan"
+
+#: id:20421
+msgid "If only one season"
+msgstr "Jos samalta tuotantokaudelta"
+
+#: id:20422
+msgid "Always"
+msgstr "Aina"
+
+#: id:20423
+msgid "Has trailer"
+msgstr "On esittely"
+
+#: id:20424
+msgid "False"
+msgstr "Ei ole"
+
+#: id:20425
+msgid "Fanart slideshow"
+msgstr "Fanikuvien kuvaesitys"
+
+#: id:20426
+msgid "Export to a single file or separate"
+msgstr "Tallennetaanko yhdistettynä tiedostona vai erillisinä"
+
+#: id:20427
+msgid "files per entry?"
+msgstr "tiedostoina? Valitse tallennusmuoto."
+
+#: id:20428
+msgid "Single file"
+msgstr "Yhdistettynä"
+
+#: id:20429
+msgctxt "Auto context with id 20429"
+msgid "Separate"
+msgstr "Erillisinä"
+
+#: id:20430
+msgid "Export thumbnails and fanart?"
+msgstr "Tallennetaanko pienoiskuvat ja fanitaide?"
+
+#: id:20431
+msgid "Overwrite old files?"
+msgstr "Kirjoitetaanko vanhojen päälle?"
+
+#: id:20432
+msgid "Exclude path from library updates"
+msgstr "Ohita polku kirjastoja päivitettäessä"
+
+#: id:20433
+msgid "Extract thumbnails and video information"
+msgstr "Pura pienoiskuvat ja videotiedot"
+
+#: id:20434
+msgid "Sets"
+msgstr "Setit"
+
+#: id:20435
+msgid "Set movieset thumb"
+msgstr "Aseta elokuvasetin pienoiskuva"
+
+#: id:20436
+msgid "Export actor thumbs?"
+msgstr "Viedäänkö ohjaajan pienoiskuvat?"
+
+#: id:20437
+msgid "Choose fanart"
+msgstr "Valitse fanitaide"
+
+#: id:20438
+msgid "Local fanart"
+msgstr "Paikallinen fanitaide"
+
+#: id:20439
+msgid "No fanart"
+msgstr "Ei fanitaidetta"
+
+#: id:20440
+msgid "Current fanart"
+msgstr "Nykyinen fanitaide"
+
+#: id:20441
+msgid "Remote fanart"
+msgstr "Ulkoinen fanitaide"
+
+#: id:20442
+msgid "Change content"
+msgstr "Sisällön vaihto"
+
+#: id:20443
+msgid "Do you want to refresh info for all"
+msgstr "Päivitetäänkö valitun polun"
+
+#: id:20444
+msgid "items within this path?"
+msgstr "kaikkien kohteiden tiedot?"
+
+#: id:20445
+msgid "Fanart"
+msgstr "Fanitaide"
+
+#: id:20446
+msgid "Locally stored information found."
+msgstr "Löytyi paikallisesti tallennettuja tietoja."
+
+#: id:20447
+msgid "Ignore and refresh from internet?"
+msgstr "Korvataanko ne internetistä päivitetyillä tiedoilla?"
+
+#: id:20448
+msgid "Could not download information"
+msgstr "Tietoja ei voida ladata"
+
+#: id:20449
+msgid "Unable to connect to remote server"
+msgstr "Palvelimeen ei saada yhteyttä"
+
+#: id:20450
+msgid "Would you like to continue scanning?"
+msgstr "Haluatko jatkaa hakua?"
+
+#: id:20451
+msgid "Countries"
+msgstr "Maat"
+
+#: id:20452
+msgid "episode"
+msgstr "jakso"
+
+#: id:20453
+msgid "episodes"
+msgstr "jaksoa"
+
+#: id:20454
+msgid "Listener"
+msgstr "Kuuntelija"
+
+#: id:20455
+msgid "Listeners"
+msgstr "Kuuntelijat"
+
+#: id:20456
+msgid "Set movieset fanart"
+msgstr "Aseta elokuvasetin fanitaide"
+
+#: id:20457
+msgid "Movie set"
+msgstr "Elokuvasetti"
+
+#: id:20458
+msgid "Group movies in sets"
+msgstr "Ryhmittele elokuvat settien mukaan"
+
+#: id:21330
+msgid "Show hidden files and directories"
+msgstr "Näytä piilotetut tiedostot ja kansiot"
+
+#: id:21331
+msgid "TuxBox client"
+msgstr "TuxBox-asiakas"
+
+#: id:21332
+msgid "WARNING: Target TuxBox device is in recording-mode!"
+msgstr "Varoitus:TuxBox-laite on nauhoitustilassa!"
+
+#: id:21333
+msgid "The stream will be stopped!"
+msgstr "Ohjelman katselu täytyy pysäyttää!"
+
+#: id:21334
+msgid "Zap to channel: %s failed!"
+msgstr "Vaihto kanavalle: %s epäonnistui!"
+
+#: id:21335
+msgid "Are you sure to start the stream?"
+msgstr "Haluatko aloittaa ohjelman katselun?"
+
+#: id:21336
+msgid "Connecting to: %s"
+msgstr "Yhdistetään: %s"
+
+#: id:21337
+msgid "TuxBox device"
+msgstr "TuxBox-laite"
+
+#: id:21359
+msgid "Add media share..."
+msgstr "Lisää sijainti..."
+
+#: id:21360
+msgid "Share video and music libraries through UPnP"
+msgstr "Jaa video- ja musiikkikirjastot UPnP:n kautta"
+
+#: id:21364
+msgid "Edit media share"
+msgstr "Muokkaa sijaintia"
+
+#: id:21365
+msgid "Remove media share"
+msgstr "Poista sijainti"
+
+#: id:21366
+msgid "Subtitle folder"
+msgstr "Tekstityskansio"
+
+#: id:21367
+msgid "Movie & alternate subtitle directory"
+msgstr "Elokuvien ja vaihtoehtoisten tekstitysten hakemisto"
+
+#: id:21368
+msgid "Override ASS/SSA subtitles fonts"
+msgstr "Älä käytä ASS/SSA -tekstitysten kirjasinta"
+
+#: id:21369
+msgid "Enable mouse and Touch Screen support"
+msgstr "Hiiri- ja kosketusnäyttötuki käytössä"
+
+#: id:21370
+msgid "Play navigation sounds during media playback"
+msgstr "Ohjauspainikkeiden äänitehosteet käytössä"
+
+#: id:21371
+msgid "Thumbnail"
+msgstr "Pienoiskuva"
+
+#: id:21372
+msgid "Forced DVD player region"
+msgstr "Pakotettu DVD-aluekoodi"
+
+#: id:21373
+msgid "Video output"
+msgstr "Videolähtö"
+
+#: id:21374
+msgid "Video aspect"
+msgstr "Kuvasuhde"
+
+#: id:21375
+msgctxt "Auto context with id 21375"
+msgid "Normal"
+msgstr "Normaali"
+
+#: id:21376
+msgid "Letterbox"
+msgstr "Letterbox"
+
+#: id:21377
+msgid "Widescreen"
+msgstr "Laajakuva"
+
+#: id:21378
+msgid "Enable 480p"
+msgstr "480p käytössä"
+
+#: id:21379
+msgid "Enable 720p"
+msgstr "720p käytössä"
+
+#: id:21380
+msgid "Enable 1080i"
+msgstr "1080i käytössä"
+
+#: id:21381
+msgid "Enter name of new playlist"
+msgstr "Anna toistolistalle nimi"
+
+#: id:21382
+msgid "Show \"Add source\" buttons in file lists"
+msgstr "Näytä \"Lisää sijainti\" -painike tiedostolistoissa"
+
+#: id:21383
+msgid "Enable scrollbars"
+msgstr "Vierityspalkit käytössä"
+
+#: id:21384
+msgid "Make watched filtering a toggle in video library"
+msgstr "Tee katsotut suodatus vaihdettaessa videokirjastoon"
+
+#: id:21385
+msgctxt "Auto context with id 21385"
+msgid "Open"
+msgstr "Avaa"
+
+#: id:21386
+msgid "Acoustic management level"
+msgstr "Äänekkyyden tason säätö"
+
+#: id:21387
+msgid "Fast"
+msgstr "Nopea"
+
+#: id:21388
+msgid "Quiet"
+msgstr "Hiljainen"
+
+#: id:21389
+msgid "Enable custom background"
+msgstr "Valinnainen taustakuva käytössä"
+
+#: id:21390
+msgid "Power management level"
+msgstr "Energiatehokkuuden tason säätö"
+
+#: id:21391
+msgid "High power"
+msgstr "Tehotila"
+
+#: id:21392
+msgid "Low power"
+msgstr "Säästötila"
+
+#: id:21393
+msgid "High standby"
+msgstr "Korkea valmiustila"
+
+#: id:21394
+msgid "Low standby"
+msgstr "Matala valmiustila"
+
+#: id:21395
+msgid "Unable to cache files bigger than 4GB"
+msgstr "Yli 4GB:n tiedostoja ei voida välimuistittaa"
+
+#: id:21396
+msgid "Chapter"
+msgstr "Luku"
+
+#: id:21397
+msgid "High quality pixel shader v2"
+msgstr "Pixel Shader V2 (korkea laatu)"
+
+#: id:21398
+msgid "Enable playlist at startup"
+msgstr "Käynnistyessä toistolista käytössä"
+
+#: id:21399
+msgid "Use tween animations"
+msgstr "Tween-animointi käytössä"
+
+#: id:21400
+msgid "contains"
+msgstr "sisältää"
+
+#: id:21401
+msgid "does not contain"
+msgstr "ei sisällä"
+
+#: id:21402
+msgid "is"
+msgstr "on"
+
+#: id:21403
+msgid "is not"
+msgstr "ei ole"
+
+#: id:21404
+msgid "starts with"
+msgstr "alkaa kirjaimilla"
+
+#: id:21405
+msgid "ends with"
+msgstr "loppuu kirjaimiin"
+
+#: id:21406
+msgid "greater than"
+msgstr "enemmän kuin"
+
+#: id:21407
+msgid "less than"
+msgstr "vähemmän kuin"
+
+#: id:21408
+msgid "after"
+msgstr "myöhemmin kuin"
+
+#: id:21409
+msgid "before"
+msgstr "aiemmin kuin"
+
+#: id:21410
+msgid "in the last"
+msgstr "viimeisenä"
+
+#: id:21411
+msgid "not in the last"
+msgstr "ei viimeisenä"
+
+#: id:21412
+msgid "Scrapers"
+msgstr "Hakupaikat"
+
+#: id:21413
+msgid "Default movie scraper"
+msgstr "Elokuvien tietojen hakupaikka"
+
+#: id:21414
+msgid "Default tvshow scraper"
+msgstr "TV-ohjelmien tietojen hakupaikka"
+
+#: id:21415
+msgid "Default music video scraper"
+msgstr "Musiikkivideoiden tietojen hakupaikka"
+
+#: id:21416
+msgid "Enable fallback based on scraper language"
+msgstr "Palaute pohjautuu hakupaikan kieleen"
+
+#: id:21417
+msgid "- Settings"
+msgstr "- Asetukset"
+
+#: id:21418
+msgid "Multilingual"
+msgstr "Monikielinen"
+
+#: id:21419
+msgid "No scrapers present"
+msgstr "Hakupaikalle ei ole asetuksia"
+
+#: id:21420
+msgid "Value to match"
+msgstr "Ehtoihin sopiva"
+
+#: id:21421
+msgid "Smart playlist rule"
+msgstr "Älykkään toistolistan ehdot"
+
+#: id:21422
+msgid "Match items where"
+msgstr "Sopivat kohteet"
+
+#: id:21423
+msgid "New rule..."
+msgstr "Uusi ehto..."
+
+#: id:21424
+msgid "Items must match"
+msgstr "Kohteiden täytyy sopia"
+
+#: id:21425
+msgid "all of the rules"
+msgstr "kaikkiin ehtoihin"
+
+#: id:21426
+msgid "one or more of the rules"
+msgstr "vähintään yhteen ehtoon"
+
+#: id:21427
+msgid "Limit to"
+msgstr "Rajoitus"
+
+#: id:21428
+msgid "No limit"
+msgstr "Ei rajoitusta"
+
+#: id:21429
+msgid "Order by"
+msgstr "Järjestys"
+
+#: id:21430
+msgid "ascending"
+msgstr "Nouseva"
+
+#: id:21431
+msgid "descending"
+msgstr "Laskeva"
+
+#: id:21432
+msgid "Edit smart playlist"
+msgstr "Muokkaa älykästä toistolistaa"
+
+#: id:21433
+msgid "Name of the playlist"
+msgstr "Toistolistan nimi"
+
+#: id:21434
+msgid "Find items where"
+msgstr "Etsi sopivat kohteet"
+
+#: id:21435
+msgid "Edit"
+msgstr "Muokkaa"
+
+#: id:21436
+msgid "%i items"
+msgstr "%i kohdetta"
+
+#: id:21437
+msgid "New smart playlist..."
+msgstr "Älykäs toistolista..."
+
+#: id:21438
+msgid "%c Drive"
+msgstr "%c asema"
+
+#: id:21439
+msgid "Edit party mode rules"
+msgstr "Jukeboksin asetukset"
+
+#: id:21440
+msgid "Home folder"
+msgstr "Kotikansio"
+
+#: id:21441
+msgid "Watched count"
+msgstr "Katselumäärä"
+
+#: id:21442
+msgid "Episode title"
+msgstr "Jakson nimi"
+
+#: id:21443
+msgid "Video resolution"
+msgstr "Videoresoluutio"
+
+#: id:21444
+msgid "Audio channels"
+msgstr "Äänikanavat"
+
+#: id:21445
+msgid "Video codec"
+msgstr "Videokoodekki"
+
+#: id:21446
+msgid "Audio codec"
+msgstr "Äänikoodekki"
+
+#: id:21447
+msgid "Audio language"
+msgstr "Äänen kieli"
+
+#: id:21448
+msgid "Subtitle language"
+msgstr "Tekstityskieli"
+
+#: id:21449
+msgid "Remote control sends keyboard presses"
+msgstr "Kauko-ohjain lähettää näppäimistön painallukset"
+
+#: id:21450
+msgid "- Edit"
+msgstr "Muokkaa"
+
+#: id:21451
+msgid "Internet connection required."
+msgstr "Internet-yhteys vaaditaan."
+
+#: id:21452
+msgid "Get More..."
+msgstr "Nouda lisää..."
+
+#: id:21453
+msgid "Root filesystem"
+msgstr "Juurikansio"
+
+#: id:21454
+msgid "Cache full"
+msgstr "Välimuisti täynnä"
+
+#: id:21455
+msgid "Cache filled before reaching required amount for continous playback"
+msgstr "Välimuisti täyttyi ennen toistoon tarvittavaa määrää"
+
+#: id:21460
+msgid "Subtitle location"
+msgstr "Tekstityksen sijainti"
+
+#: id:21461
+msgid "Fixed"
+msgstr "Kiinteä"
+
+#: id:21462
+msgid "Bottom of video"
+msgstr "Videon alalaidassa"
+
+#: id:21463
+msgid "Below video"
+msgstr "Videon alapuolella"
+
+#: id:21464
+msgid "Top of video"
+msgstr "Videon ylälaidassa"
+
+#: id:21465
+msgid "Above video"
+msgstr "Videon yläpuolella"
+
+#: id:21800
+msgid "File name"
+msgstr "Tiedoston nimi"
+
+#: id:21801
+msgid "File path"
+msgstr "Tiedoston polku"
+
+#: id:21802
+msgid "File size"
+msgstr "Tiedoston koko"
+
+#: id:21803
+msgid "File date/time"
+msgstr "Tiedoston päiväys"
+
+#: id:21804
+msgid "Slide index"
+msgstr "Kuvanumero"
+
+#: id:21805
+msgctxt "Auto context with id 21805"
+msgid "Resolution"
+msgstr "Resoluutio"
+
+#: id:21806
+msgctxt "Auto context with id 21806"
+msgid "Comment"
+msgstr "Kommentti"
+
+#: id:21807
+msgid "Colour/B&W"
+msgstr "Väri/MV"
+
+#: id:21808
+msgid "JPEG process"
+msgstr "Jpeg-prosessi"
+
+#: id:21820
+msgid "Date/Time"
+msgstr "Päivämäärä"
+
+#: id:21821
+msgid "Description"
+msgstr "Kuvaus"
+
+#: id:21822
+msgid "Camera make"
+msgstr "Kameran valmistaja"
+
+#: id:21823
+msgid "Camera model"
+msgstr "Kameran malli"
+
+#: id:21824
+msgid "EXIF comment"
+msgstr "Exif-kommentti"
+
+#: id:21825
+msgid "Firmware"
+msgstr "Ohjelmisto"
+
+#: id:21826
+msgid "Aperture"
+msgstr "Aukko"
+
+#: id:21827
+msgid "Focal length"
+msgstr "Polttoväli"
+
+#: id:21828
+msgid "Focus distance"
+msgstr "Tarkennusetäisyys"
+
+#: id:21829
+msgid "Exposure"
+msgstr "Valotus"
+
+#: id:21830
+msgid "Exposure time"
+msgstr "Valotusaika"
+
+#: id:21831
+msgid "Exposure bias"
+msgstr "Valotusarvo"
+
+#: id:21832
+msgid "Exposure mode"
+msgstr "Valotusmuoto"
+
+#: id:21833
+msgid "Flash used"
+msgstr "Salama käytössä"
+
+#: id:21834
+msgid "White-balance"
+msgstr "Valkotasapaino"
+
+#: id:21835
+msgid "Light source"
+msgstr "Valon lähde"
+
+#: id:21836
+msgid "Metering mode"
+msgstr "Mittaustapa"
+
+#: id:21837
+msgid "ISO"
+msgstr "ISO-arvo"
+
+#: id:21838
+msgid "Digital zoom"
+msgstr "Digitaalinen zoom"
+
+#: id:21839
+msgid "CCD width"
+msgstr "Kuvakennon leveys"
+
+#: id:21840
+msgid "GPS latitude"
+msgstr "GPS-leveysaste"
+
+#: id:21841
+msgid "GPS longitude"
+msgstr "GPS-pituusaste"
+
+#: id:21842
+msgid "GPS altitude"
+msgstr "GPS-korkeus"
+
+#: id:21843
+msgid "Orientation"
+msgstr "Suunta"
+
+#: id:21860
+msgid "Supplemental categories"
+msgstr "Lisäkategoriat"
+
+#: id:21861
+msgid "Keywords"
+msgstr "Avainsanat"
+
+#: id:21862
+msgid "Caption"
+msgstr "Kuvan sisältö"
+
+#: id:21863
+msgid "Author"
+msgstr "Tehnyt"
+
+#: id:21864
+msgid "Headline"
+msgstr "Lyhyt esittely"
+
+#: id:21865
+msgid "Special instructions"
+msgstr "Erityisohjeet"
+
+#: id:21866
+msgid "Category"
+msgstr "Kategoria"
+
+#: id:21867
+msgid "Byline"
+msgstr "Kuvan tekijät"
+
+#: id:21868
+msgid "Byline title"
+msgstr "Kuvan tekijän nimi"
+
+#: id:21869
+msgid "Credit"
+msgstr "Kuvaaja"
+
+#: id:21870
+msgid "Source"
+msgstr "Alkuperäinen kuvan tuottaja"
+
+#: id:21871
+msgid "Copyright notice"
+msgstr "Tekijänoikeushuomautus"
+
+#: id:21872
+msgid "Object name"
+msgstr "Kohteen nimi"
+
+#: id:21873
+msgid "City"
+msgstr "Kaupunki"
+
+#: id:21874
+msgid "State"
+msgstr "Osavaltio"
+
+#: id:21875
+msgctxt "Auto context with id 21875"
+msgid "Country"
+msgstr "Maa"
+
+#: id:21876
+msgid "Original Tx Reference"
+msgstr "Alkuperäinen lähetys"
+
+#: id:21877
+msgid "Date created"
+msgstr "Luontipäivä"
+
+#: id:21878
+msgid "Copyright flag"
+msgstr "Tekijänoikeus"
+
+#: id:21879
+msgid "Country code"
+msgstr "Maakoodi"
+
+#: id:21880
+msgid "Reference service"
+msgstr "Kuvapalvelu"
+
+#: id:21881
+msgid "Allow control of XBMC via UPnP"
+msgstr "XBMC:n UPnP-ohjaukset käytössä"
+
+#: id:21882
+msgid "Attempt to skip introduction before DVD menu"
+msgstr "Ohita ennen DVD-valikkoa olevat esittelyt"
+
+#: id:21883
+msgid "Saved music"
+msgstr "Tallennettu musiikki"
+
+#: id:21884
+msgid "Query info for all artists"
+msgstr "Hae kaikkien esittäjien tiedot"
+
+#: id:21885
+msgid "Downloading album information"
+msgstr "Noudetaan albumitietoja"
+
+#: id:21886
+msgid "Downloading artist information"
+msgstr "Noudetaan esittäjätietoja"
+
+#: id:21887
+msgid "Biography"
+msgstr "Henkilökuvaus"
+
+#: id:21888
+msgid "Discography"
+msgstr "Levytykset"
+
+#: id:21889
+msgid "Searching artist"
+msgstr "Etsitään esittäjää"
+
+#: id:21890
+msgid "Select artist"
+msgstr "Valitse esittäjä"
+
+#: id:21891
+msgctxt "Auto context with id 21891"
+msgid "Artist information"
+msgstr "Esittäjän tiedot"
+
+#: id:21892
+msgid "Instruments"
+msgstr "Soittimet"
+
+#: id:21893
+msgid "Born"
+msgstr "Syntynyt"
+
+#: id:21894
+msgid "Formed"
+msgstr "Perustettu"
+
+#: id:21895
+msgid "Themes"
+msgstr "Teemat"
+
+#: id:21896
+msgid "Disbanded"
+msgstr "Lopettanut"
+
+#: id:21897
+msgid "Died"
+msgstr "Kuollut"
+
+#: id:21898
+msgid "Years active"
+msgstr "Aktiivinen"
+
+#: id:21899
+msgid "Label"
+msgstr "Nimi"
+
+#: id:21900
+msgid "Born/Formed"
+msgstr "Syntynyt/perustettu"
+
+#: id:22000
+msgid "Update library on startup"
+msgstr "Päivitä kirjasto ohjelman käynnistyessä"
+
+#: id:22001
+msgid "Hide progress of library updates"
+msgstr "Piilota päivityksen edistyminen"
+
+#: id:22002
+msgid "- DNS suffix"
+msgstr "- DNS-loppupääte"
+
+#: id:22003
+msgid "%2.3fs"
+msgstr "%2.3fs"
+
+#: id:22004
+msgid "Delayed by: %2.3fs"
+msgstr "Viivästetty: %2.3fs"
+
+#: id:22005
+msgid "Ahead by: %2.3fs"
+msgstr "Aiennettu: %2.3fs"
+
+#: id:22006
+msgid "Subtitle offset"
+msgstr "Tekstityksen ajoitus"
+
+#: id:22007
+msgid "OpenGL vendor:"
+msgstr "OpenGL-toimittaja:"
+
+#: id:22008
+msgid "OpenGL renderer:"
+msgstr "OpenGL-renderöijä:"
+
+#: id:22009
+msgid "OpenGL version:"
+msgstr "OpenGL-versio:"
+
+#: id:22010
+msgid "GPU temperature:"
+msgstr "GPU:n lämpötila:"
+
+#: id:22011
+msgid "CPU temperature:"
+msgstr "CPU:n lämpötila:"
+
+#: id:22012
+msgid "Total memory"
+msgstr "Kokonaismuisti"
+
+#: id:22013
+msgid "Profile data"
+msgstr "Profiilin tiedot"
+
+#: id:22014
+msgid "Use dim if paused during video playback"
+msgstr "Himmennä keskeytettäessä videon toisto"
+
+#: id:22015
+msgid "All recordings"
+msgstr "Kaikki tallennukset"
+
+#: id:22016
+msgid "By title"
+msgstr "Nimet"
+
+#: id:22017
+msgid "By group"
+msgstr "Ryhmät"
+
+#: id:22018
+msgid "Live channels"
+msgstr "Lähetyskanavat"
+
+#: id:22019
+msgid "Recordings by title"
+msgstr "Tallennukset nimen mukaan"
+
+#: id:22020
+msgid "Guide"
+msgstr "Ohjelmaopas"
+
+#: id:22021
+msgid "Allowed error in aspect ratio to minimize black bars"
+msgstr "Sallittu kuvasuhdevirhe mustien palkkien minimoimiseksi"
+
+#: id:22022
+msgid "Show video files in listings"
+msgstr "Näytä videotiedostot listauksissa"
+
+#: id:22023
+msgid "DirectX vendor:"
+msgstr "DirectX-toimittaja:"
+
+#: id:22024
+msgid "Direct3D version:"
+msgstr "Direct3D-versio:"
+
+#: id:22030
+msgctxt "Auto context with id 22030"
+msgid "Font"
+msgstr "Kirjasin"
+
+#: id:22031
+msgctxt "Auto context with id 22031"
+msgid "- Size"
+msgstr "- Koko"
+
+#: id:22032
+msgctxt "Auto context with id 22032"
+msgid "- Colours"
+msgstr "- Värit"
+
+#: id:22033
+msgid "- Charset"
+msgstr "- Merkistö"
+
+#: id:22034
+msgid "Export karaoke titles as HTML"
+msgstr "Tallenna HTML-muodossa"
+
+#: id:22035
+msgid "Export karaoke titles as CSV"
+msgstr "Tallenna CSV-muodossa"
+
+#: id:22036
+msgid "Import karaoke titles..."
+msgstr "Tuo karaokekappaleet..."
+
+#: id:22037
+msgid "Show song selector automatically"
+msgstr "Näytä kappaleenvalintaikkuna"
+
+#: id:22038
+msgid "Export karaoke titles..."
+msgstr "Vie karaokekappaleet..."
+
+#: id:22039
+msgid "Enter song number"
+msgstr "Anna kappaleen numero"
+
+#: id:22040
+msgid "white/green"
+msgstr "valkoinen/vihreä"
+
+#: id:22041
+msgid "white/red"
+msgstr "valkoinen/punanen"
+
+#: id:22042
+msgid "white/blue"
+msgstr "valkoinen/sininen"
+
+#: id:22043
+msgid "black/white"
+msgstr "musta/valkoinen"
+
+#: id:22079
+msgid "Default select action"
+msgstr "Oletustoiminto valittaessa"
+
+#: id:22080
+msgid "Choose"
+msgstr "Valitse"
+
+#: id:22081
+msgid "Show Information"
+msgstr "Näytä tiedot"
+
+#: id:22082
+msgid "More..."
+msgstr "Lisää..."
+
+#: id:22083
+msgid "Play all"
+msgstr "Toista kaikki"
+
+#: id:23049
+msgid "Teletext not available"
+msgstr "Teksti-tv ei ole käytettävissä"
+
+#: id:23050
+msgid "Activate Teletext"
+msgstr "Teksti-tv käytössä"
+
+#: id:23051
+msgid "Part %i"
+msgstr "Osa %i"
+
+#: id:23052
+msgid "Buffering %i bytes"
+msgstr "Puskuroidaan, %i tavua"
+
+#: id:23053
+msgid "Stopping"
+msgstr "Pysähtyy"
+
+#: id:23054
+msgid "Running"
+msgstr "Käynnissä"
+
+#: id:23100
+msgid "External Player Active"
+msgstr "Ulkoinen toisto-ohjelma käytössä"
+
+#: id:23101
+msgid "Click OK to terminate the player"
+msgstr "Paina OK sulkeaksesi toisto-ohjelman"
+
+#: id:23104
+msgid "Click OK when playback has ended"
+msgstr "Paina OK kun toisto on päättynyt"
+
+#: id:24000
+msgid "Add-on"
+msgstr "Lisäosa"
+
+#: id:24001
+msgid "Add-ons"
+msgstr "Lisäosat"
+
+#: id:24002
+msgid "Add-on options"
+msgstr "Lisäosan asetukset"
+
+#: id:24003
+msgid "Add-on Information"
+msgstr "Tietoja lisäosasta"
+
+#: id:24005
+msgctxt "Auto context with id 24005"
+msgid "Media sources"
+msgstr "Medialähteet"
+
+#: id:24007
+msgctxt "Auto context with id 24007"
+msgid "Movie information"
+msgstr "Elokuvatiedot"
+
+#: id:24008
+msgctxt "Auto context with id 24008"
+msgid "Screensaver"
+msgstr "Näytönsäästäjä"
+
+#: id:24009
+msgid "Script"
+msgstr "Skriptit"
+
+#: id:24010
+msgctxt "Auto context with id 24010"
+msgid "Visualization"
+msgstr "Visualisointi"
+
+#: id:24011
+msgid "Add-on repository"
+msgstr "Lisäosien ohjelmavarasto"
+
+#: id:24012
+msgctxt "Auto context with id 24012"
+msgid "Subtitles"
+msgstr "Tekstitykset"
+
+#: id:24013
+msgid "Lyrics"
+msgstr "Sanoitukset"
+
+#: id:24014
+msgid "TV information"
+msgstr "TV-ohjelmatiedot"
+
+#: id:24015
+msgctxt "Auto context with id 24015"
+msgid "Music video information"
+msgstr "Musiikkivideotiedot"
+
+#: id:24016
+msgctxt "Auto context with id 24016"
+msgid "Album information"
+msgstr "Albumitiedot"
+
+#: id:24017
+msgctxt "Auto context with id 24017"
+msgid "Artist information"
+msgstr "Esittäjätiedot"
+
+#: id:24018
+msgctxt "Auto context with id 24018"
+msgid "Services"
+msgstr "Palvelut"
+
+#: id:24020
+msgid "Configure"
+msgstr "Asetukset"
+
+#: id:24021
+msgctxt "Auto context with id 24021"
+msgid "Disable"
+msgstr "Poista käytöstä"
+
+#: id:24022
+msgid "Enable"
+msgstr "Ota käyttöön"
+
+#: id:24023
+msgid "Add-on disabled"
+msgstr "Lisäosa ei ole käytössä"
+
+#: id:24027
+msgctxt "Auto context with id 24027"
+msgid "Weather"
+msgstr "Sää"
+
+#: id:24028
+msgid "Weather.com (standard)"
+msgstr "Weather.com (oletus)"
+
+#: id:24030
+msgid "This Add-on can not be configured"
+msgstr "Tällä lisäosalla ei ole asetuksia"
+
+#: id:24031
+msgid "Error loading settings"
+msgstr "Asetusten lataaminen epäonnistui"
+
+#: id:24032
+msgid "All Add-ons"
+msgstr "Kaikki lisäosat"
+
+#: id:24033
+msgid "Get Add-ons"
+msgstr "Hae lisäosia"
+
+#: id:24034
+msgid "Check for updates"
+msgstr "Tarkista päivitykset"
+
+#: id:24035
+msgid "Force refresh"
+msgstr "Pakota virkistys"
+
+#: id:24036
+msgid "Change log"
+msgstr "Muutoshistoria"
+
+#: id:24037
+msgid "Uninstall"
+msgstr "Poista"
+
+#: id:24038
+msgid "Install"
+msgstr "Asenna"
+
+#: id:24039
+msgid "Disabled Add-ons"
+msgstr "Käytöstä poistetut lisäosat"
+
+#: id:24040
+msgid "(Clear the current setting)"
+msgstr "(poista nykyinen valinta)"
+
+#: id:24041
+msgid "Install from zip file"
+msgstr "Asenna zip-tiedostosta"
+
+#: id:24042
+msgid "Downloading %i%%"
+msgstr "Ladataan: %i%%"
+
+#: id:24043
+msgid "Available Updates"
+msgstr "Päivitykset"
+
+#: id:24044
+msgid "Dependencies not met"
+msgstr "Riippuvuudet ei täyty"
+
+#: id:24045
+msgid "Add-on does not have the correct structure"
+msgstr "Lisäosan rakenne on väärä"
+
+#: id:24046
+msgid "%s is used by the following installed add-on(s)"
+msgstr "Seuraavat asennetut lisäosat tarvitsevat lisäosaa %s"
+
+#: id:24047
+msgid "This add-on cannot be uninstalled"
+msgstr "Tätä lisäosaa ei voi poistaa"
+
+#: id:24048
+msgid "Rollback"
+msgstr "Palauta"
+
+#: id:24050
+msgid "Available Add-ons"
+msgstr "Saatavilla olevat lisäosat"
+
+#: id:24051
+msgid "Version:"
+msgstr "Versio:"
+
+#: id:24052
+msgid "Disclaimer"
+msgstr "Huomautus"
+
+#: id:24053
+msgid "License:"
+msgstr "Lisenssi:"
+
+#: id:24054
+msgid "Changelog"
+msgstr "Muutoshistoria"
+
+#: id:24059
+msgid "Would you like to enable this Add-on?"
+msgstr "Haluatko ottaa käyttöön tämän lisäosan?"
+
+#: id:24060
+msgid "Would you like to disable this Add-on?"
+msgstr "Haluatko poistaa tämän lisäosan käytöstä?"
+
+#: id:24061
+msgid "Add-on update available!"
+msgstr "Lisäosan päivitys saatavilla!"
+
+#: id:24062
+msgid "Enabled Add-ons"
+msgstr "Käytössä olevat lisäosat"
+
+#: id:24063
+msgid "Auto update"
+msgstr "Automaattinen päivitys"
+
+#: id:24064
+msgid "Add-on enabled"
+msgstr "Lisäosa otettu käyttöön"
+
+#: id:24065
+msgid "Add-on updated"
+msgstr "Lisäosa päivitetty"
+
+#: id:24066
+msgid "Cancel Add-on download?"
+msgstr "Peruuta lisäosan lataus?"
+
+#: id:24067
+msgid "Currently downloading Add-ons"
+msgstr "Latauksessa olevat lisäosat"
+
+#: id:24068
+msgid "Update available"
+msgstr "Päivitys saatavilla"
+
+#: id:24069
+msgid "Update"
+msgstr "Päivitä"
+
+#: id:24070
+msgid "Add-on could not be loaded."
+msgstr "Lisäosaa ei voida ladata."
+
+#: id:24071
+msgid "An unknown error has occurred."
+msgstr "Tapahtui tuntematon virhe."
+
+#: id:24072
+msgid "Settings required"
+msgstr "Asetukset vaaditaan"
+
+#: id:24073
+msgid "Could not connect"
+msgstr "Ei voida yhdistää"
+
+#: id:24074
+msgid "Needs to restart"
+msgstr "Uudelleenkäynnistys vaaditaan"
+
+#: id:24075
+msgctxt "Auto context with id 24075"
+msgid "Disable"
+msgstr "Poista käytöstä"
+
+#: id:24076
+msgid "Add-on Required"
+msgstr "Tarvitaan lisäosa"
+
+#: id:24080
+msgid "Try to reconnect?"
+msgstr "Yritetäänkö yhdistää uudelleen?"
+
+#: id:24089
+msgid "Add-on restarts"
+msgstr "Lisäosa käynnistyy uudelleen"
+
+#: id:24090
+msgid "Lock Add-on manager"
+msgstr "Lukitse lisäosien asennus"
+
+#: id:24094
+msgid "(current)"
+msgstr "(nykyinen)"
+
+#: id:24095
+msgid "(blacklisted)"
+msgstr "(estetty)"
+
+#: id:24096
+msgid "Add-on has been marked as broken in repository."
+msgstr "Ohjelmavarasto on merkinnyt lisäosan vialliseksi."
+
+#: id:24097
+msgid "Would you like to disable it on your system?"
+msgstr "Poistetaanko lisäosa käytöstä?"
+
+#: id:24098
+msgid "Broken"
+msgstr "Viallinen"
+
+#: id:24099
+msgid "Would you like to switch to this skin?"
+msgstr "Haluatko vaihtaa tähän ulkoasuun?"
+
+#: id:24100
+msgid "To use this feature you must download an Add-on:"
+msgstr "Tämä toiminto tarvitsee seuraavan lisäosan:"
+
+#: id:24101
+msgid "Would you like to download this Add-on?"
+msgstr "Haluatko ladata tämän lisäosan?"
+
+#: id:25000
+msgid "Notifications"
+msgstr "Ilmoitukset"
+
+#: id:29800
+msgid "Library Mode"
+msgstr "Kirjastotila"
+
+#: id:29801
+msgid "QWERTY keyboard"
+msgstr "QWERTY-näppäimistö"
+
+#: id:29802
+msgid "Passthrough Audio in use"
+msgstr "Läpisyötetty ääni käytössä"
+
+#: id:33001
+msgid "Trailer quality"
+msgstr "Esittelyn kuvanlaatu"
+
+#: id:33002
+msgid "Stream"
+msgstr "Katso"
+
+#: id:33003
+msgid "Download"
+msgstr "Lataa"
+
+#: id:33004
+msgid "Download & play"
+msgstr "Lataa ja toista"
+
+#: id:33005
+msgid "Download & save"
+msgstr "Lataa ja tallenna"
+
+#: id:33006
+msgid "Today"
+msgstr "Tänään"
+
+#: id:33007
+msgid "Tomorrow"
+msgstr "Huomenna"
+
+#: id:33008
+msgid "Saving"
+msgstr "Tallennetaan"
+
+#: id:33009
+msgid "Copying"
+msgstr "Kopioidaan"
+
+#: id:33010
+msgid "Set download directory"
+msgstr "Aseta latauskansio"
+
+#: id:33011
+msgid "Search duration"
+msgstr "Haun kesto"
+
+#: id:33012
+msgid "Short"
+msgstr "Lyhyet"
+
+#: id:33013
+msgid "Long"
+msgstr "Pitkät"
+
+#: id:33014
+msgid "Use DVD player instead of regular player"
+msgstr "Käytä DVD Player -soitinta"
+
+#: id:33015
+msgid "Ask for download before playing video"
+msgstr "Kysy latauksesta ennen toistoa"
+
+#: id:33016
+msgid "Clips"
+msgstr "Näytteet"
+
+#: id:33017
+msgid "Restart plugin to enable"
+msgstr "Lisäosa on käynnistettävä uudelleen"
+
+#: id:33018
+msgid "Tonight"
+msgstr "Tänä iltana"
+
+#: id:33019
+msgid "Tomorrow Night"
+msgstr "Huomenillalla"
+
+#: id:33020
+msgid "Condition"
+msgstr "Säätila"
+
+#: id:33021
+msgid "Precipitation"
+msgstr "Sademäärä"
+
+#: id:33022
+msgid "Precip"
+msgstr "Sadem."
+
+#: id:33023
+msgid "Humid"
+msgstr "Kosteus"
+
+#: id:33024
+msgid "Feels"
+msgstr "Tuntuu kuin"
+
+#: id:33025
+msgid "Observed"
+msgstr "Tarkkailtu"
+
+#: id:33026
+msgid "Departure from normal"
+msgstr "Poikkeama normaalista"
+
+#: id:33027
+msgid "Sunrise"
+msgstr "Aurinko nous."
+
+#: id:33028
+msgid "Sunset"
+msgstr "Aurinko lask."
+
+#: id:33029
+msgid "Details"
+msgstr "Yksityiskohdat"
+
+#: id:33030
+msgid "Outlook"
+msgstr "Odotettavissa"
+
+#: id:33031
+msgid "Coverflow"
+msgstr "Kuorivirta"
+
+#: id:33032
+msgid "Translate text"
+msgstr "Käännä teksti"
+
+#: id:33033
+msgid "Map list %s category"
+msgstr "Karttaluettelon %s-kategoria"
+
+#: id:33034
+msgid "36 Hour"
+msgstr "36 tuntia"
+
+#: id:33035
+msgid "Maps"
+msgstr "Kartat"
+
+#: id:33036
+msgid "Hourly"
+msgstr "Tunneittain"
+
+#: id:33037
+msgid "Weekend"
+msgstr "Viikonloppu"
+
+#: id:33038
+msgid "%s day"
+msgstr "%s. päivä"
+
+#: id:33049
+msgid "Alert"
+msgstr "Hälytys"
+
+#: id:33050
+msgid "Alerts"
+msgstr "Hälytykset"
+
+#: id:33051
+msgid "Choose Your"
+msgstr "Valitse"
+
+#: id:33052
+msgid "Check"
+msgstr "Tarkista"
+
+#: id:33053
+msgctxt "Auto context with id 33053"
+msgid "Configure the"
+msgstr "Määritä"
+
+#: id:33054
+msgid "Seasons"
+msgstr "Tuotantokaudet"
+
+#: id:33055
+msgid "Use your"
+msgstr "Käytä"
+
+#: id:33056
+msgid "Watch your"
+msgstr "Katso"
+
+#: id:33057
+msgid "Listen to"
+msgstr "Kuuntele"
+
+#: id:33058
+msgid "View your"
+msgstr "Näytä"
+
+#: id:33059
+msgctxt "Auto context with id 33059"
+msgid "Configure the"
+msgstr "Määritä"
+
+#: id:33060
+msgid "Power"
+msgstr "Virta"
+
+#: id:33061
+msgid "Menu"
+msgstr "Valikko"
+
+#: id:33062
+msgid "Play the"
+msgstr "Toista"
+
+#: id:33063
+msgid "Options"
+msgstr "Asetukset"
+
+#: id:33065
+msgid "Editor"
+msgstr "Muokkaus"
+
+#: id:33066
+msgid "About your"
+msgstr "Tietoja"
+
+#: id:33067
+msgid "Star rating"
+msgstr "Arviointitähdet"
+
+#: id:33068
+msgid "Background"
+msgstr "Taustakuva"
+
+#: id:33069
+msgid "Backgrounds"
+msgstr "Taustakuvat"
+
+#: id:33070
+msgid "Custom background"
+msgstr "Oma taustakuva"
+
+#: id:33071
+msgid "Custom backgrounds"
+msgstr "Omat taustakuvat"
+
+#: id:33072
+msgid "View Readme"
+msgstr "Näytä ohje"
+
+#: id:33073
+msgid "View Changelog"
+msgstr "Näytä muutokset"
+
+#: id:33074
+msgid "This version of %s requires an"
+msgstr "Tämä %s:n versio vaatii toimiakseen"
+
+#: id:33075
+msgid "XBMC revision of %s or greater to run."
+msgstr "XBMC revision %s tai uudemman."
+
+#: id:33076
+msgid "Please update XBMC."
+msgstr "Päivitä XBMC uudempaan versioon."
+
+#: id:33077
+msgid "No data found!"
+msgstr "Tietoja ei löydy!"
+
+#: id:33078
+msgid "Next page"
+msgstr "Seuraava sivu"
+
+#: id:33079
+msgid "Love"
+msgstr "Tykkää"
+
+#: id:33080
+msgid "Hate"
+msgstr "Inhoaa"
+
+#: id:33081
+msgid "This file is stacked, select the part you want to play from."
+msgstr "Tämä tiedosto on pinottu, valitse osa jonka haluat toistaa"
+
+#: id:33082
+msgid "Path to script"
+msgstr "Polku"
+
+#: id:33083
+msgid "Enable custom script button"
+msgstr "Oma skripti -painike käytössä"
+
+#: id:33100
+msgid "Failed to start"
+msgstr "Käynnistys epäonnistui:"
+
+#: id:33101
+msgid "Webserver"
+msgstr "WWW-palvelin"
+
+#: id:33102
+msgid "Event Server"
+msgstr "Tapahtumapalvelin"
+
+#: id:33103
+msgid "Remote communication server"
+msgstr "Etäviestipalvelin"
+
+#: id:33200
+msgid "Detected New Connection"
+msgstr "Uusi yhteys tunnistettu"
+
+#: id:34000
+msgid "Lame"
+msgstr "Lame"
+
+#: id:34001
+msgid "Vorbis"
+msgstr "Vorbis"
+
+#: id:34002
+msgid "Wav"
+msgstr "Wav"
+
+#: id:34003
+msgid "DXVA2"
+msgstr "DXVA2"
+
+#: id:34004
+msgid "VAAPI"
+msgstr "VAAPI"
+
+#: id:34005
+msgid "Flac"
+msgstr "Flac"
+
+#: id:34100
+msgid "Speaker Configuration"
+msgstr "Kaiutinjärjestelmä"
+
+#: id:34101
+msgid "2.0"
+msgstr "2.0"
+
+#: id:34102
+msgid "2.1"
+msgstr "2.1"
+
+#: id:34103
+msgid "3.0"
+msgstr "3.0"
+
+#: id:34104
+msgid "3.1"
+msgstr "3.1"
+
+#: id:34105
+msgid "4.0"
+msgstr "4.0"
+
+#: id:34106
+msgid "4.1"
+msgstr "4.1"
+
+#: id:34107
+msgid "5.0"
+msgstr "5.0"
+
+#: id:34108
+msgid "5.1"
+msgstr "5.1"
+
+#: id:34109
+msgid "7.0"
+msgstr "7.0"
+
+#: id:34110
+msgid "7.1"
+msgstr "7.1"
+
+#: id:34201
+msgid "Can't find a next item to play"
+msgstr "Seuraavaa kohdetta ei löydy"
+
+#: id:34202
+msgid "Can't find a previous item to play"
+msgstr "Edellistä kohdetta ei löydy"
+
+#: id:34300
+msgid "Failed to start zeroconf"
+msgstr "Zeroconf-palvelua ei voitu käynnistää"
+
+#: id:34301
+msgid "Is Apple's Bonjour Service installed? See log for more info."
+msgstr "Onko Applen Bonjour -palvelu asennettu? Katso lokitiedostosta lisätietoja."
+
+#: id:34400
+msgid "Video Rendering"
+msgstr "Videon renderöintitapa"
+
+#: id:34401
+msgid "Failed to init video filters/scalers, falling back to bilinear scaling"
+msgstr "Ei voitu käyttää videon suodatin/skaalaus -asetuksia, otetaan käyttöön bilineaarinen skaalausmenetelmä"
+
+#: id:34402
+msgid "Failed to initialize audio device"
+msgstr "Äänilaitteen alustaminen epäonnistui"
+
+#: id:34403
+msgid "Check your audiosettings"
+msgstr "Tarkista ääniasetukset"
+
+#: id:34404
+msgid "Use gestures for navigation:"
+msgstr ""
+
+#: id:34405
+msgid "1 finger swipe left,right,up,down for cursors"
+msgstr ""
+
+#: id:34406
+msgid "2 finger swipe left for backspace"
+msgstr ""
+
+#: id:34407
+msgid "1 finger single tap for enter"
+msgstr ""
+
+#: id:34408
+msgid "2 finger single tap for contextmenu"
+msgstr ""
+
+#: id:35000
+msgid "Peripherals"
+msgstr "Oheislaitteet"
+
+#: id:35001
+msgid "Generic HID device"
+msgstr "Yleinen HID-laite"
+
+#: id:35002
+msgid "Generic network adapter"
+msgstr "Yleinen verkkosovitin"
+
+#: id:35003
+msgid "Generic disk"
+msgstr "Yleinen levy"
+
+#: id:35004
+msgid "There are no settings available\nfor this peripheral."
+msgstr "Asetuksia ei ole saatavilla\ntälle oheislaitteelle."
+
+#: id:35005
+msgid "New device configured"
+msgstr "Uusi laite määritetty"
+
+#: id:35006
+msgid "Device removed"
+msgstr "Laite poistettu"
+
+#: id:35007
+msgid "Keymap to use for this device"
+msgstr "Tämän laitteen näppäimistöasettelu"
+
+#: id:35008
+msgid "Keymap enabled"
+msgstr "Näppäimistöasettelu käytössä"
+
+#: id:35009
+msgid "Do not use the custom keymap for this device"
+msgstr ""
+
+#: id:35500
+msgid "Location"
+msgstr "Sijainti"
+
+#: id:35501
+msgid "Class"
+msgstr "Luokka"
+
+#: id:35502
+msgctxt "Auto context with id 35502"
+msgid "Name"
+msgstr "Nimi"
+
+#: id:35503
+msgid "Vendor"
+msgstr "Valmistaja"
+
+#: id:35504
+msgid "Product ID"
+msgstr "Tuotetunnus"
+
+#: id:36000
+msgid "Pulse-Eight CEC adapter"
+msgstr "Pulse-Eight CEC-sovitin"
+
+#: id:36001
+msgid "Pulse-Eight Nyxboard"
+msgstr "Pulse-Eight Nyxboard"
+
+#: id:36002
+msgid "Switch to keyboard side command"
+msgstr "Vaihda hallinta näppäimistöpuolelle"
+
+#: id:36003
+msgid "Switch to remote side command"
+msgstr "Vaihda kallinta kaukosäädinpuolelle"
+
+#: id:36004
+msgid "Press \"user\" button command"
+msgstr "Paina \"user\"-painikkeen komento"
+
+#: id:36005
+msgid "Enable switch side commands"
+msgstr "Käytä puolen vaihtokomentoja"
+
+#: id:36006
+msgid "Could not open the adapter"
+msgstr "Sovitinta ei voitu avata"
+
+#: id:36007
+msgid "Devices to power on when starting XBMC"
+msgstr "Käynnistä TV kun XBMC käynnistetään"
+
+#: id:36008
+msgid "Devices to power off when stopping XBMC"
+msgstr "Sammuta laitteet kun XBMC sammutetaan"
+
+#: id:36009
+msgid "Put devices in standby mode when activating screensaver"
+msgstr "Aseta laitteet valmiustilaan näytönsäästäjän aktivoituessa"
+
+#: id:36011
+msgid "Could not detect the CEC port. Set it up manually."
+msgstr "CEC-porttia ei havaittu. Määritä se käsin."
+
+#: id:36012
+msgid "Could not initialise the CEC adapter. Check your settings."
+msgstr "CEC-sovitinta ei havaittu."
+
+#: id:36013
+msgid "Unsupported libCEC interface version. %d is greater than the version XBMC supports (%d)"
+msgstr "Ei tuettu libcec-rajapinnan versio. %d on suurempi kuin versio, jota XBMC tukee (%d)"
+
+#: id:36014
+msgid "Put this PC in standby mode when the TV is switched off"
+msgstr "Aseta tämä tietokone valmiustilaan kun TV sammutetaan"
+
+#: id:36015
+msgid "HDMI port number"
+msgstr "HDMI-liitin"
+
+#: id:36016
+msgctxt "Auto context with id 36016"
+msgid "Connected"
+msgstr "Yhdistetty"
+
+#: id:36017
+msgid "Adapter found, but libCEC is not available"
+msgstr "Sovitin löytyi, mutta libcec ei ole saatavilla"
+
+#: id:36018
+msgid "Use the TV's language setting"
+msgstr "Käytä TV:n kieliasetusta"
+
+#: id:36019
+msgid "Connected to HDMI device"
+msgstr ""
+
+#: id:36020
+msgid "Make XBMC the active source when starting"
+msgstr ""
+
+#: id:36021
+msgid "Physical address (overrules HDMI port)"
+msgstr ""
+
+#: id:36022
+msgid "COM port (leave empty unless needed)"
+msgstr ""
+
+#: id:36023
+msgid "Configuration updated"
+msgstr ""
+
+#: id:36024
+msgid "Failed to set the new configuration. Please check your settings."
+msgstr ""
+
+#: id:36025
+msgid "Send 'inactive source' command when stopping XBMC"
+msgstr ""
+

--- a/language/French/strings.po
+++ b/language/French/strings.po
@@ -1,0 +1,9093 @@
+# Converted from xbmc strings.xml with xbmc-xml2po (by Team-XBMC)
+msgid ""
+msgstr ""
+"Project-Id-Version: xbmc.core-FRODO_GIT3ed1604ad7\n"
+"Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
+"POT-Creation-Date: 2012-04-09 18:00+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE\n"
+"Language: fr\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: id:0
+msgctxt "Auto context with id 0"
+msgid "Programs"
+msgstr "Programmes"
+
+#: id:1
+msgctxt "Auto context with id 1"
+msgid "Pictures"
+msgstr "Images"
+
+#: id:2
+msgctxt "Auto context with id 2"
+msgid "Music"
+msgstr "Musique"
+
+#: id:3
+msgctxt "Auto context with id 3"
+msgid "Videos"
+msgstr "Vidéos"
+
+#: id:4
+msgid "TV-Guide"
+msgstr "Guide TV"
+
+#: id:5
+msgctxt "Auto context with id 5"
+msgid "Settings"
+msgstr "Paramètres"
+
+#: id:6
+msgid "XBMC SVN"
+msgstr "XBMC SVN"
+
+#: id:7
+msgctxt "Auto context with id 7"
+msgid "File manager"
+msgstr "Fichiers"
+
+#: id:8
+msgctxt "Auto context with id 8"
+msgid "Weather"
+msgstr "Météo"
+
+#: id:9
+msgid "xbmc media center"
+msgstr "Xbmc media center"
+
+#: id:11
+msgid "Monday"
+msgstr "Lundi"
+
+#: id:12
+msgid "Tuesday"
+msgstr "Mardi"
+
+#: id:13
+msgid "Wednesday"
+msgstr "Mercredi"
+
+#: id:14
+msgid "Thursday"
+msgstr "Jeudi"
+
+#: id:15
+msgid "Friday"
+msgstr "Vendredi"
+
+#: id:16
+msgid "Saturday"
+msgstr "Samedi"
+
+#: id:17
+msgid "Sunday"
+msgstr "Dimanche"
+
+#: id:21
+msgid "January"
+msgstr "Janvier"
+
+#: id:22
+msgid "February"
+msgstr "Février"
+
+#: id:23
+msgid "March"
+msgstr "Mars"
+
+#: id:24
+msgid "April"
+msgstr "Avril"
+
+#: id:25
+msgctxt "Auto context with id 25"
+msgid "May"
+msgstr "Mai"
+
+#: id:26
+msgid "June"
+msgstr "Juin"
+
+#: id:27
+msgid "July"
+msgstr "Juillet"
+
+#: id:28
+msgid "August"
+msgstr "Août"
+
+#: id:29
+msgid "September"
+msgstr "Septembre"
+
+#: id:30
+msgid "October"
+msgstr "Octobre"
+
+#: id:31
+msgid "November"
+msgstr "Novembre"
+
+#: id:32
+msgid "December"
+msgstr "Décembre"
+
+#: id:41
+msgid "Mon"
+msgstr "Lun"
+
+#: id:42
+msgid "Tue"
+msgstr "Mar"
+
+#: id:43
+msgid "Wed"
+msgstr "Mer"
+
+#: id:44
+msgid "Thu"
+msgstr "Jeu"
+
+#: id:45
+msgid "Fri"
+msgstr "Ven"
+
+#: id:46
+msgid "Sat"
+msgstr "Sam"
+
+#: id:47
+msgctxt "Auto context with id 47"
+msgid "Sun"
+msgstr "Dim"
+
+#: id:51
+msgid "Jan"
+msgstr "Jan"
+
+#: id:52
+msgid "Feb"
+msgstr "Fev"
+
+#: id:53
+msgid "Mar"
+msgstr "Mar"
+
+#: id:54
+msgid "Apr"
+msgstr "Avr"
+
+#: id:55
+msgctxt "Auto context with id 55"
+msgid "May"
+msgstr "Mai"
+
+#: id:56
+msgid "Jun"
+msgstr "Jui"
+
+#: id:57
+msgid "Jul"
+msgstr "Jul"
+
+#: id:58
+msgid "Aug"
+msgstr "Aout"
+
+#: id:59
+msgid "Sep"
+msgstr "Sep"
+
+#: id:60
+msgid "Oct"
+msgstr "Oct"
+
+#: id:61
+msgid "Nov"
+msgstr "Nov"
+
+#: id:62
+msgid "Dec"
+msgstr "Dec"
+
+#: id:71
+msgid "N"
+msgstr "N"
+
+#: id:72
+msgid "NNE"
+msgstr "NNE"
+
+#: id:73
+msgid "NE"
+msgstr "NE"
+
+#: id:74
+msgid "ENE"
+msgstr "ENE"
+
+#: id:75
+msgid "E"
+msgstr "E"
+
+#: id:76
+msgid "ESE"
+msgstr "ESE"
+
+#: id:77
+msgid "SE"
+msgstr "SE"
+
+#: id:78
+msgid "SSE"
+msgstr "SSE"
+
+#: id:79
+msgid "S"
+msgstr "S"
+
+#: id:80
+msgid "SSW"
+msgstr "SSO"
+
+#: id:81
+msgid "SW"
+msgstr "SO"
+
+#: id:82
+msgid "WSW"
+msgstr "OSO"
+
+#: id:83
+msgid "W"
+msgstr "O"
+
+#: id:84
+msgid "WNW"
+msgstr "ONO"
+
+#: id:85
+msgid "NW"
+msgstr "NO"
+
+#: id:86
+msgid "NNW"
+msgstr "NNO"
+
+#: id:87
+msgid "VAR"
+msgstr "VAR"
+
+#: id:98
+msgid "View: Auto"
+msgstr "Vue : Auto"
+
+#: id:99
+msgid "View: Auto big"
+msgstr "Vue : Auto Grand"
+
+#: id:100
+msgid "View: Icons"
+msgstr "Vue : Icônes"
+
+#: id:101
+msgid "View: List"
+msgstr "Vue : Liste"
+
+#: id:102
+msgctxt "Auto context with id 102"
+msgid "Scan"
+msgstr "Scanner"
+
+#: id:103
+msgctxt "Auto context with id 103"
+msgid "Sort by: Name"
+msgstr "Trier par : Nom"
+
+#: id:104
+msgid "Sort by: Date"
+msgstr "Trier par : Date"
+
+#: id:105
+msgid "Sort by: Size"
+msgstr "Trier par : Taille"
+
+#: id:106
+msgid "No"
+msgstr "Non"
+
+#: id:107
+msgid "Yes"
+msgstr "Oui"
+
+#: id:108
+msgctxt "Auto context with id 108"
+msgid "Slideshow"
+msgstr "Diaporama"
+
+#: id:109
+msgid "Create thumbs"
+msgstr "Créer vignettes"
+
+#: id:110
+msgid "Create thumbnails"
+msgstr "Créer vignettes"
+
+#: id:111
+msgctxt "Auto context with id 111"
+msgid "Shortcuts"
+msgstr "Raccourcis"
+
+#: id:112
+msgid "Paused"
+msgstr "PAUSE"
+
+#: id:113
+msgid "Update failed"
+msgstr "Échec mise-à-jour"
+
+#: id:114
+msgid "Installation failed"
+msgstr "Échec installation"
+
+#: id:115
+msgid "Copy"
+msgstr "Copier"
+
+#: id:116
+msgid "Move"
+msgstr "Déplacer"
+
+#: id:117
+msgid "Delete"
+msgstr "Effacer"
+
+#: id:118
+msgid "Rename"
+msgstr "Renommer"
+
+#: id:119
+msgid "New folder"
+msgstr "Nouveau dossier"
+
+#: id:120
+msgid "Confirm file copy"
+msgstr "Confirmer copie du fichier"
+
+#: id:121
+msgid "Confirm file move"
+msgstr "Confirmer déplacement du fichier"
+
+#: id:122
+msgid "Confirm file delete?"
+msgstr "Confirmer effacement du fichier ?"
+
+#: id:123
+msgid "Copy these files?"
+msgstr "Êtes-vous sûr(e) de copier ce(s) fichier(s) ?"
+
+#: id:124
+msgid "Move these files?"
+msgstr "Êtes-vous sûr(e) de déplacer ce(s) fichier(s) ?"
+
+#: id:125
+msgid "Delete these files? - Deleting files cannot be undone!"
+msgstr "Voulez-vous supprimer ces fichiers ? Ceci sera définitif !"
+
+#: id:126
+msgid "Status"
+msgstr "Statut"
+
+#: id:127
+msgid "Objects"
+msgstr "Objets"
+
+#: id:128
+msgctxt "Auto context with id 128"
+msgid "General"
+msgstr "Général"
+
+#: id:129
+msgctxt "Auto context with id 129"
+msgid "Slideshow"
+msgstr "Diaporama"
+
+#: id:130
+msgctxt "Auto context with id 130"
+msgid "System info"
+msgstr "Infos Système"
+
+#: id:131
+msgid "Display"
+msgstr "Affichage"
+
+#: id:132
+msgid "Albums"
+msgstr "Albums"
+
+#: id:133
+msgid "Artists"
+msgstr "Artistes"
+
+#: id:134
+msgid "Songs"
+msgstr "Chansons"
+
+#: id:135
+msgid "Genres"
+msgstr "Genres"
+
+#: id:136
+msgid "Playlists"
+msgstr "Playlistes"
+
+#: id:137
+msgid "Search"
+msgstr "Rechercher"
+
+#: id:138
+msgid "System Information"
+msgstr "Informations Système"
+
+#: id:139
+msgid "Temperatures:"
+msgstr "Températures :"
+
+#: id:140
+msgid "CPU:"
+msgstr "CPU :"
+
+#: id:141
+msgid "GPU:"
+msgstr "GPU :"
+
+#: id:142
+msgid "Time:"
+msgstr "Heure :"
+
+#: id:143
+msgid "Current:"
+msgstr "Actuelle"
+
+#: id:144
+msgid "Build:"
+msgstr "Version :"
+
+#: id:145
+msgid "Network:"
+msgstr "Réseau :"
+
+#: id:146
+msgid "Type:"
+msgstr "Type :"
+
+#: id:147
+msgid "Static"
+msgstr "Statique"
+
+#: id:148
+msgid "DHCP"
+msgstr "DHCP"
+
+#: id:149
+msgid "MAC address"
+msgstr "Adresse MAC"
+
+#: id:150
+msgctxt "Auto context with id 150"
+msgid "IP address"
+msgstr "Adresse IP"
+
+#: id:151
+msgid "Link:"
+msgstr "Câble :"
+
+#: id:152
+msgid "Half duplex"
+msgstr "Half duplex"
+
+#: id:153
+msgid "Full duplex"
+msgstr "Full duplex"
+
+#: id:154
+msgctxt "Auto context with id 154"
+msgid "Storage"
+msgstr "Stockage"
+
+#: id:155
+msgid "Drive"
+msgstr "Lecteur"
+
+#: id:156
+msgctxt "Auto context with id 156"
+msgid "Free"
+msgstr "libre"
+
+#: id:157
+msgctxt "Auto context with id 157"
+msgid "Video"
+msgstr "Vidéo"
+
+#: id:158
+msgid "Free memory"
+msgstr "Mémoire libre"
+
+#: id:159
+msgid "No link"
+msgstr "Câble débranché"
+
+#: id:160
+msgctxt "Auto context with id 160"
+msgid "Free"
+msgstr "libres"
+
+#: id:161
+msgid "Unavailable"
+msgstr "Non disponible"
+
+#: id:162
+msgid "Tray open"
+msgstr "Tiroir ouvert"
+
+#: id:163
+msgid "Reading"
+msgstr "Lecture"
+
+#: id:164
+msgid "No disc"
+msgstr "Tiroir vide"
+
+#: id:165
+msgid "Disc present"
+msgstr "Disque présent"
+
+#: id:166
+msgid "Skin"
+msgstr "Thème"
+
+#: id:169
+msgctxt "Auto context with id 169"
+msgid "Resolution"
+msgstr "Résolution"
+
+#: id:170
+msgid "Adjust display refresh rate to match video"
+msgstr "Ajuster le taux de rafraîchissement sur la vidéo"
+
+#: id:172
+msgid "Release date"
+msgstr "Version du"
+
+#: id:173
+msgid "Display 4:3 videos as"
+msgstr "Affichage 4:3"
+
+#: id:175
+msgid "Moods"
+msgstr "Sonorités"
+
+#: id:176
+msgid "Styles"
+msgstr "Styles"
+
+#: id:179
+msgid "Song"
+msgstr "Chanson"
+
+#: id:180
+msgid "Duration"
+msgstr "Durée"
+
+#: id:181
+msgid "Select album"
+msgstr "Sélectionner un album"
+
+#: id:182
+msgid "Tracks"
+msgstr "Pistes"
+
+#: id:183
+msgid "Review"
+msgstr "Revue"
+
+#: id:184
+msgid "Refresh"
+msgstr "Rafraîchir"
+
+#: id:185
+msgid "Searching album"
+msgstr "Recherche d'album"
+
+#: id:186
+msgid "OK"
+msgstr "OK"
+
+#: id:187
+msgid "No albums found!"
+msgstr "Pas d'album trouvé"
+
+#: id:188
+msgid "Select all"
+msgstr "Tout sélectionner"
+
+#: id:189
+msgid "Scanning media info"
+msgstr "Scan des infos du média"
+
+#: id:190
+msgid "Save"
+msgstr "Sauvegarder"
+
+#: id:191
+msgid "Shuffle"
+msgstr "Mélanger"
+
+#: id:192
+msgctxt "Auto context with id 192"
+msgid "Clear"
+msgstr "Effacer"
+
+#: id:193
+msgctxt "Auto context with id 193"
+msgid "Scan"
+msgstr "Scanner"
+
+#: id:194
+msgid "Searching..."
+msgstr "Recherche..."
+
+#: id:195
+msgid "No info found!"
+msgstr "Aucune info trouvée"
+
+#: id:196
+msgid "Select movie:"
+msgstr "Sélection du film :"
+
+#: id:197
+msgid "Querying %s info"
+msgstr "Demande d'info sur %s"
+
+#: id:198
+msgid "Loading movie details"
+msgstr "Chargement des détails du film"
+
+#: id:199
+msgid "Web interface"
+msgstr "Interface Web"
+
+#: id:202
+msgid "Tagline"
+msgstr "Critiques"
+
+#: id:203
+msgid "Plot outline"
+msgstr "Intrigue"
+
+#: id:205
+msgid "Votes"
+msgstr "Votes"
+
+#: id:206
+msgid "Cast"
+msgstr "Casting"
+
+#: id:207
+msgid "Plot"
+msgstr "Résumé"
+
+#: id:208
+msgctxt "Auto context with id 208"
+msgid "Play"
+msgstr "Lire"
+
+#: id:209
+msgid "Next"
+msgstr "Suivant"
+
+#: id:210
+msgid "Previous"
+msgstr "Précédent"
+
+#: id:213
+msgid "Calibrate user interface..."
+msgstr "Calibrer l'interface utilisateur..."
+
+#: id:214
+msgid "Video calibration..."
+msgstr "Étalonnage de l'écran..."
+
+#: id:215
+msgid "Soften"
+msgstr "Adoucir"
+
+#: id:216
+msgid "Zoom amount"
+msgstr "Niveau de Zoom"
+
+#: id:217
+msgid "Pixel ratio"
+msgstr "Rapport largeur/hauteur"
+
+#: id:218
+msgid "DVD drive"
+msgstr "Lecteur DVD"
+
+#: id:219
+msgid "Please insert disc"
+msgstr "Veuillez insérer un disque"
+
+#: id:220
+msgid "Remote share"
+msgstr "Partage distant"
+
+#: id:221
+msgid "Network is not connected"
+msgstr "Le réseau n'est pas connecté"
+
+#: id:222
+msgid "Cancel"
+msgstr "Annuler"
+
+#: id:224
+msgid "Speed"
+msgstr "Vitesse"
+
+#: id:225
+msgid "Vertical Shift"
+msgstr "Hauteur de l'image"
+
+#: id:226
+msgid "Test patterns..."
+msgstr "Afficher la mire..."
+
+#: id:227
+msgid "Lookup audio CD track names from freedb.org"
+msgstr "Rechercher le nom des pistes CD Audio sur freedb.org"
+
+#: id:228
+msgid "Shuffle playlist on load"
+msgstr "Mélanger la playliste lors du chargement"
+
+#: id:229
+msgid "HDD spindown time"
+msgstr "Temps d'arrêt du DD"
+
+#: id:230
+msgid "Video filters"
+msgstr "Filtres Vidéo"
+
+#: id:231
+msgctxt "Auto context with id 231"
+msgid "None"
+msgstr "Aucun"
+
+#: id:232
+msgid "Point"
+msgstr "Point"
+
+#: id:233
+msgid "Linear"
+msgstr "Linéaire"
+
+#: id:234
+msgid "Anisotropic"
+msgstr "Anisotropique"
+
+#: id:235
+msgid "Quincunx"
+msgstr "Quincunx"
+
+#: id:236
+msgid "Gaussian cubic"
+msgstr "Cubique Gaussien"
+
+#: id:237
+msgid "Minification"
+msgstr "Optique (-)"
+
+#: id:238
+msgid "Magnification"
+msgstr "Optique (+)"
+
+#: id:239
+msgid "Clear playlist on finish"
+msgstr "Effacer la playliste à la fin de la lecture"
+
+#: id:240
+msgid "Display Mode"
+msgstr "Mode d'affichage"
+
+#: id:241
+msgid "Full Screen #%d"
+msgstr "Plein écran #%d"
+
+#: id:242
+msgid "Windowed"
+msgstr "Fenêtré"
+
+#: id:243
+msgid "Refresh Rate"
+msgstr "Taux de rafraîchissement"
+
+#: id:244
+msgid "Full screen"
+msgstr "Plein écran"
+
+#: id:245
+msgid "Sizing: (%i,%i)->(%i,%i) (Zoom x%2.2f) AR:%2.2f:1 (Pixels: %2.2f:1) (VShift: %2.2f)"
+msgstr "Sizing : (%i,%i)->(%i,%i) (Zoom x%2.2f) AR :%2.2f :1 (Pixels : %2.2f :1)"
+
+#: id:247
+msgctxt "Auto context with id 247"
+msgid "Scripts"
+msgstr "Scripts"
+
+#: id:248
+msgctxt "Auto context with id 248"
+msgid "Language"
+msgstr "Langue"
+
+#: id:249
+msgctxt "Auto context with id 249"
+msgid "Music"
+msgstr "Musique"
+
+#: id:250
+msgctxt "Auto context with id 250"
+msgid "Visualization"
+msgstr "Visualisation"
+
+#: id:251
+msgid "Select destination directory"
+msgstr "Sélectionnez le répertoire de destination"
+
+#: id:252
+msgid "Output stereo to all speakers"
+msgstr "Utiliser tous les haut-parleurs en stéréo"
+
+#: id:253
+msgid "Number of channels"
+msgstr "Nombre de canaux"
+
+#: id:254
+msgid "- DTS capable receiver"
+msgstr "- Périphérique compatible DTS"
+
+#: id:255
+msgid "CDDB"
+msgstr "CDDB"
+
+#: id:256
+msgid "Fetching CD information"
+msgstr "Récupération des infos CD"
+
+#: id:257
+msgid "Error"
+msgstr "Erreur"
+
+#: id:258
+msgid "Enable tag reading"
+msgstr "Utiliser les étiquettes ID3"
+
+#: id:259
+msgid "Opening"
+msgstr "Ouverture"
+
+#: id:260
+msgid "Shoutcast"
+msgstr "Shoutcast"
+
+#: id:261
+msgid "Waiting for start..."
+msgstr "En attente du démarrage..."
+
+#: id:262
+msgid "Scripts output"
+msgstr "Scripts données de sortie"
+
+#: id:263
+msgid "Allow control of XBMC via HTTP"
+msgstr "Permettre le contrôle de XBMC en HTTP"
+
+#: id:264
+msgid "Record"
+msgstr "Enregistrer"
+
+#: id:265
+msgid "Stop Rec."
+msgstr "Arrêter l'enregistrement"
+
+#: id:266
+msgid "Sort by: Track"
+msgstr "Trier par : Piste"
+
+#: id:267
+msgid "Sort by: Time"
+msgstr "Trier par : Durée"
+
+#: id:268
+msgid "Sort by: Title"
+msgstr "Trier par : Titre"
+
+#: id:269
+msgid "Sort by: Artist"
+msgstr "Trier par : Artiste"
+
+#: id:270
+msgid "Sort by: Album"
+msgstr "Trier par : Album"
+
+#: id:271
+msgid "Top 100"
+msgstr "Top 100"
+
+#: id:272
+msgid "Top-Left overscan compensation"
+msgstr "Compensation taille affichage : Haut gauche"
+
+#: id:273
+msgid "Bottom-Right overscan compensation"
+msgstr "Compensation taille affichage : Bas droite"
+
+#: id:274
+msgid "Subtitle positioning"
+msgstr "Position des sous-titres"
+
+#: id:275
+msgid "Pixel ratio adjustment"
+msgstr "Étalonnage"
+
+#: id:276
+msgid "Adjust the arrow to change the amount of overscan"
+msgstr "Déplacez la flèche pour modifier la taille d'affichage"
+
+#: id:277
+msgid "Adjust the bar to change the subtitles position"
+msgstr "Déplacez la barre pour changer la position des sous-titres"
+
+#: id:278
+msgid "Adjust the rectangle so it is perfectly square"
+msgstr "Ajustez le rectangle pour qu'il devienne un carré"
+
+#: id:279
+msgid "Unable to load settings"
+msgstr "Impossible de charger les préférences"
+
+#: id:280
+msgid "Using default settings"
+msgstr "Utiliser les configurations par défaut"
+
+#: id:281
+msgid "Please check the XML files"
+msgstr "Vérifiez les fichiers XML"
+
+#: id:282
+msgid "Found %i items"
+msgstr "%i objet(s) trouvé(s)"
+
+#: id:283
+msgid "Search results"
+msgstr "Résultats de la recherche"
+
+#: id:284
+msgid "No results found"
+msgstr "Aucun résultat"
+
+#: id:287
+msgctxt "Auto context with id 287"
+msgid "Subtitles"
+msgstr "Sous-titres"
+
+#: id:288
+msgctxt "Auto context with id 288"
+msgid "Font"
+msgstr "Police"
+
+#: id:289
+msgctxt "Auto context with id 289"
+msgid "- Size"
+msgstr "- Taille"
+
+#: id:290
+msgid "Dynamic range compression"
+msgstr "Amplification du volume (dB)"
+
+#: id:291
+msgctxt "Auto context with id 291"
+msgid "Video"
+msgstr "Vidéo"
+
+#: id:292
+msgctxt "Auto context with id 292"
+msgid "Audio"
+msgstr "Audio"
+
+#: id:293
+msgid "Browse for subtitles"
+msgstr "Rechercher des Sous-titres"
+
+#: id:294
+msgid "Create bookmark"
+msgstr "Créer un signet"
+
+#: id:296
+msgid "Clear bookmarks"
+msgstr "Effacer les signets"
+
+#: id:297
+msgid "Audio offset"
+msgstr "Décalage audio"
+
+#: id:298
+msgid "Bookmarks"
+msgstr "Signets"
+
+#: id:299
+msgid "- AAC capable receiver"
+msgstr "- périphérique compatible ACC"
+
+#: id:300
+msgid "- MP1 capable receiver"
+msgstr "- périphérique compatible MP1"
+
+#: id:301
+msgid "- MP2 capable receiver"
+msgstr "- périphérique compatible MP2"
+
+#: id:302
+msgid "- MP3 capable receiver"
+msgstr "- périphérique compatible MP3"
+
+#: id:303
+msgid "Delay"
+msgstr "Délai"
+
+#: id:304
+msgctxt "Auto context with id 304"
+msgid "Language"
+msgstr "Langue"
+
+#: id:305
+msgctxt "Auto context with id 305"
+msgid "Enabled"
+msgstr "Activé"
+
+#: id:306
+msgid "Non-interleaved"
+msgstr "Non entrelacé"
+
+#: id:312
+msgid "(0=auto)"
+msgstr "(0=auto)"
+
+#: id:313
+msgid "Cleaning database"
+msgstr "Nettoyage de la base de données"
+
+#: id:314
+msgid "Preparing..."
+msgstr "Préparation..."
+
+#: id:315
+msgid "Database error"
+msgstr "Erreur sur la base de données"
+
+#: id:316
+msgid "Searching songs..."
+msgstr "Recherche des titres..."
+
+#: id:317
+msgid "Cleaned database successfully"
+msgstr "Base de données nettoyée avec succès"
+
+#: id:318
+msgid "Cleaning songs..."
+msgstr "Nettoyage des titres..."
+
+#: id:319
+msgid "Error cleaning songs"
+msgstr "Erreur pendant le nettoyage des titres"
+
+#: id:320
+msgid "Cleaning artists..."
+msgstr "Nettoyage des artistes"
+
+#: id:321
+msgid "Error cleaning artists"
+msgstr "Erreur durant le nettoyage des artistes"
+
+#: id:322
+msgid "Cleaning genres..."
+msgstr "Nettoyage des genres..."
+
+#: id:323
+msgid "Error cleaning genres"
+msgstr "Erreur durant le nettoyage des genres"
+
+#: id:324
+msgid "Cleaning paths..."
+msgstr "Nettoyage des chemins de fichier..."
+
+#: id:325
+msgid "Error cleaning paths"
+msgstr "Erreur durant le nettoyage des chemins de fichier"
+
+#: id:326
+msgid "Cleaning albums..."
+msgstr "Nettoyage des albums..."
+
+#: id:327
+msgid "Error cleaning albums"
+msgstr "Erreur durant le nettoyage des albums"
+
+#: id:328
+msgid "Writing changes..."
+msgstr "Enregistrement des modifications..."
+
+#: id:329
+msgid "Error writing changes"
+msgstr "Erreur sur l'enregistrement des modifications..."
+
+#: id:330
+msgid "This may take some time..."
+msgstr "Cette option peut durer un moment..."
+
+#: id:331
+msgid "Compressing database..."
+msgstr "Compression de la base de données..."
+
+#: id:332
+msgid "Error compressing database"
+msgstr "Erreur durant la compression de la base de données"
+
+#: id:333
+msgid "Do you want to clean the library?"
+msgstr "Voulez-vous nettoyer la médiathèque ?"
+
+#: id:334
+msgid "Clean library..."
+msgstr "Nettoyage de la médiathèque..."
+
+#: id:335
+msgid "Start"
+msgstr "Lancer"
+
+#: id:336
+msgid "Framerate conversion"
+msgstr "Conversion du taux de rafraîchissement"
+
+#: id:337
+msgctxt "Auto context with id 337"
+msgid "Audio output"
+msgstr "Sortie audio"
+
+#: id:338
+msgid "Analog"
+msgstr "Analogique"
+
+#: id:339
+msgid "Optical/Coax"
+msgstr "Numérique"
+
+#: id:340
+msgid "Various artists"
+msgstr "Artistes divers"
+
+#: id:341
+msgid "Play disc"
+msgstr "Lire le disque"
+
+#: id:342
+msgctxt "Auto context with id 342"
+msgid "Movies"
+msgstr "Films"
+
+#: id:343
+msgid "Adjust framerate"
+msgstr "Ajuster le taux de rafraîchissement"
+
+#: id:344
+msgid "Actors"
+msgstr "Acteurs"
+
+#: id:345
+msgctxt "Auto context with id 345"
+msgid "Year"
+msgstr "Année"
+
+#: id:346
+msgid "Boost volume level on downmix"
+msgstr "Amplifier le volume lors du démultiplexage"
+
+#: id:350
+msgctxt "Auto context with id 350"
+msgid "Programs"
+msgstr "Programmes"
+
+#: id:351
+msgctxt "Auto context with id 351"
+msgid "Off"
+msgstr "Désactiver"
+
+#: id:352
+msgid "Dim"
+msgstr "Atténuer"
+
+#: id:353
+msgid "Black"
+msgstr "Noir"
+
+#: id:354
+msgid "Matrix trails"
+msgstr "Matrix"
+
+#: id:355
+msgid "Screensaver time"
+msgstr "Temps avant la mise en veille"
+
+#: id:356
+msgid "Screensaver mode"
+msgstr "Mode de l'écran de veille"
+
+#: id:357
+msgid "Shutdown function timer"
+msgstr "Fonction minuterie pour la fermeture"
+
+#: id:358
+msgid "All albums"
+msgstr "Tous les albums"
+
+#: id:359
+msgid "Recently added albums"
+msgstr "Albums récemment ajoutés"
+
+#: id:360
+msgctxt "Auto context with id 360"
+msgid "Screensaver"
+msgstr "Écran de veille"
+
+#: id:361
+msgid "R. Slideshow"
+msgstr "Diapos récursives"
+
+#: id:362
+msgid "Screensaver dim level"
+msgstr "Transparence de la mise en veille"
+
+#: id:363
+msgid "Sort by: File"
+msgstr "Trier par : Fichiers"
+
+#: id:364
+msgid "- Dolby Digital (AC3) capable receiver"
+msgstr "- Périphérique compatible Dolby Digital (AC3)"
+
+#: id:365
+msgctxt "Auto context with id 365"
+msgid "Sort by: Name"
+msgstr "Trier par : Nom"
+
+#: id:366
+msgid "Sort by: Year"
+msgstr "Trier par : Année"
+
+#: id:367
+msgid "Sort by: Rating"
+msgstr "Trier par : Note"
+
+#: id:368
+msgid "IMDb"
+msgstr "IMDb"
+
+#: id:369
+msgctxt "Auto context with id 369"
+msgid "Title"
+msgstr "Titre"
+
+#: id:370
+msgid "Thunderstorms"
+msgstr "Orageux"
+
+#: id:371
+msgid "Partly"
+msgstr "Assez"
+
+#: id:372
+msgid "Mostly"
+msgstr "Très"
+
+#: id:373
+msgid "Sunny"
+msgstr "Ensoleillé"
+
+#: id:374
+msgid "Cloudy"
+msgstr "Nuageux"
+
+#: id:375
+msgid "Snow"
+msgstr "Neige"
+
+#: id:376
+msgid "Rain"
+msgstr "Pluie"
+
+#: id:377
+msgid "Light"
+msgstr "Légère"
+
+#: id:378
+msgid "AM"
+msgstr "Matin"
+
+#: id:379
+msgid "PM"
+msgstr "Après-midi"
+
+#: id:380
+msgid "Showers"
+msgstr "Averses"
+
+#: id:381
+msgid "Few"
+msgstr "Quelques"
+
+#: id:382
+msgid "Scattered"
+msgstr "Éparse"
+
+#: id:383
+msgctxt "Auto context with id 383"
+msgid "Wind"
+msgstr "Vent"
+
+#: id:384
+msgid "Strong"
+msgstr "Fort"
+
+#: id:385
+msgid "Fair"
+msgstr "Beau"
+
+#: id:386
+msgctxt "Auto context with id 386"
+msgid "Clear"
+msgstr "Dégagé"
+
+#: id:387
+msgid "Clouds"
+msgstr "Nuages"
+
+#: id:388
+msgid "Early"
+msgstr "Matinal(es)"
+
+#: id:389
+msgid "Shower"
+msgstr "Averses"
+
+#: id:390
+msgid "Flurries"
+msgstr "Rafales"
+
+#: id:391
+msgctxt "Auto context with id 391"
+msgid "Low"
+msgstr "Faible"
+
+#: id:392
+msgctxt "Auto context with id 392"
+msgid "Medium"
+msgstr "Moyen"
+
+#: id:393
+msgctxt "Auto context with id 393"
+msgid "High"
+msgstr "Haut"
+
+#: id:394
+msgid "Fog"
+msgstr "Brouillard"
+
+#: id:395
+msgid "Haze"
+msgstr "Brume"
+
+#: id:396
+msgid "Select location"
+msgstr "Choisir un lieu"
+
+#: id:397
+msgid "Refresh time"
+msgstr "Temps de rafraîchissement"
+
+#: id:398
+msgid "Temperature units"
+msgstr "Unité de température"
+
+#: id:399
+msgid "Speed units"
+msgstr "Unité de vitesse"
+
+#: id:400
+msgctxt "Auto context with id 400"
+msgid "Weather"
+msgstr "Météo"
+
+#: id:401
+msgid "Temp"
+msgstr "Temp."
+
+#: id:402
+msgid "Feels like"
+msgstr "T° Ressentie"
+
+#: id:403
+msgid "UV index"
+msgstr "Indice UV"
+
+#: id:404
+msgctxt "Auto context with id 404"
+msgid "Wind"
+msgstr "Vent"
+
+#: id:405
+msgid "Dew point"
+msgstr "Point de rosée"
+
+#: id:406
+msgid "Humidity"
+msgstr "Humidité"
+
+#: id:409
+msgid "Defaults"
+msgstr "Défauts"
+
+#: id:410
+msgid "Accessing weather service"
+msgstr "Accès aux services météo"
+
+#: id:411
+msgid "Getting weather for:"
+msgstr "Obtenir la météo pour :"
+
+#: id:412
+msgid "Unable to get weather data"
+msgstr "Échec de la récupération météo"
+
+#: id:413
+msgid "Manual"
+msgstr "Manuel"
+
+#: id:414
+msgid "No review for this album"
+msgstr "Pas de critique pour cet album"
+
+#: id:415
+msgid "Downloading thumbnail..."
+msgstr "Télécharge les informations..."
+
+#: id:416
+msgid "Not available"
+msgstr "Non disponible"
+
+#: id:417
+msgid "View: Big icons"
+msgstr "Vue : Affiches"
+
+#: id:418
+msgctxt "Auto context with id 418"
+msgid "Low"
+msgstr "Min."
+
+#: id:419
+msgctxt "Auto context with id 419"
+msgid "High"
+msgstr "Max."
+
+#: id:420
+msgid "HDMI"
+msgstr "HDMI"
+
+#: id:422
+msgid "Delete album info"
+msgstr "Supprimer les infos album"
+
+#: id:423
+msgid "Delete CD information"
+msgstr "Supprimer les infos CD"
+
+#: id:424
+msgid "Select"
+msgstr "Valider"
+
+#: id:425
+msgid "No album information found"
+msgstr "Aucune info album trouvée"
+
+#: id:426
+msgid "No CD information found"
+msgstr "Aucune info CD trouvée"
+
+#: id:427
+msgid "Disc"
+msgstr "Disque"
+
+#: id:428
+msgid "Insert correct CD/DVD"
+msgstr "Insérez le bon CD/DVD"
+
+#: id:429
+msgid "Please insert the following disc:"
+msgstr "Veuillez insérer le CD/DVD"
+
+#: id:430
+msgid "Sort by: DVD#"
+msgstr "Trier par : DVD#"
+
+#: id:431
+msgid "No cache"
+msgstr "Pas de cache"
+
+#: id:432
+msgid "Remove movie from library"
+msgstr "Retirer le film de la médiathèque"
+
+#: id:433
+msgid "Really remove '%s'?"
+msgstr "Êtes-vous sûr(e) de retirer '%s' ?"
+
+#: id:434
+msgid "From %s at %i %s"
+msgstr "%s à %i %s"
+
+#: id:437
+msgid "Removable disk"
+msgstr "Disque amovible"
+
+#: id:438
+msgid "Opening file"
+msgstr "Ouverture du fichier"
+
+#: id:439
+msgid "Cache"
+msgstr "Cache"
+
+#: id:440
+msgid "Harddisk"
+msgstr "Disque dur"
+
+#: id:441
+msgid "UDF"
+msgstr "UDF"
+
+#: id:442
+msgid "Local network"
+msgstr "Réseau Local"
+
+#: id:443
+msgid "Internet"
+msgstr "Internet"
+
+#: id:444
+msgctxt "Auto context with id 444"
+msgid "Video"
+msgstr "Vidéo"
+
+#: id:445
+msgctxt "Auto context with id 445"
+msgid "Audio"
+msgstr "Audio"
+
+#: id:446
+msgctxt "Auto context with id 446"
+msgid "DVD"
+msgstr "DVD"
+
+#: id:447
+msgid "Autorun media"
+msgstr "Lancer automatiquement les médias"
+
+#: id:448
+msgid "LCD"
+msgstr "LCD"
+
+#: id:449
+msgctxt "Auto context with id 449"
+msgid "Enabled"
+msgstr "Activé"
+
+#: id:450
+msgid "Columns"
+msgstr "Colonnes"
+
+#: id:451
+msgid "Row 1 address"
+msgstr "Adresse Ligne 1"
+
+#: id:452
+msgid "Row 2 address"
+msgstr "Adresse Ligne 2"
+
+#: id:453
+msgid "Row 3 address"
+msgstr "Adresse Ligne 3"
+
+#: id:454
+msgid "Row 4 address"
+msgstr "Adresse Ligne 4"
+
+#: id:455
+msgid "Rows"
+msgstr "Lignes"
+
+#: id:456
+msgid "Mode"
+msgstr "Mode"
+
+#: id:457
+msgid "Switch view"
+msgstr "Changer de vue"
+
+#: id:459
+msgid "Subs"
+msgstr "Sous-titres"
+
+#: id:460
+msgid "Audio stream"
+msgstr "Flux audio"
+
+#: id:461
+msgid "[active]"
+msgstr "[actif]"
+
+#: id:462
+msgid "Subtitle"
+msgstr "Sous-titres"
+
+#: id:463
+msgid "Backlight"
+msgstr "Contre-jour"
+
+#: id:464
+msgid "Brightness"
+msgstr "Luminosité"
+
+#: id:465
+msgid "Contrast"
+msgstr "Contraste"
+
+#: id:466
+msgid "Gamma"
+msgstr "Gamma"
+
+#: id:467
+msgctxt "Auto context with id 467"
+msgid "Type"
+msgstr "Type"
+
+#: id:468
+msgid "Move the bar to change the OSD position"
+msgstr "Déplacez la barre pour changer la position de l'OSD"
+
+#: id:469
+msgid "OSD position"
+msgstr "Position OSD"
+
+#: id:470
+msgid "Credits"
+msgstr "Crédits"
+
+#: id:471
+msgid "Modchip"
+msgstr "Modchip"
+
+#: id:474
+msgctxt "Auto context with id 474"
+msgid "Off"
+msgstr "Désactivé"
+
+#: id:475
+msgid "Music only"
+msgstr "Musique seulement"
+
+#: id:476
+msgctxt "Auto context with id 476"
+msgid "Music & video"
+msgstr "Musique & vidéo"
+
+#: id:477
+msgid "Unable to load playlist"
+msgstr "Impossible de charger la playliste"
+
+#: id:478
+msgid "OSD"
+msgstr "Réglages écran"
+
+#: id:479
+msgid "Skin & language"
+msgstr "Thème & langue"
+
+#: id:480
+msgid "Appearance"
+msgstr "Apparence"
+
+#: id:481
+msgid "Audio options"
+msgstr "Options Audio"
+
+#: id:482
+msgid "About XBMC"
+msgstr "À propos de XBMC"
+
+#: id:485
+msgid "Delete album"
+msgstr "Supprimer l'album"
+
+#: id:486
+msgid "Repeat"
+msgstr "Répéter"
+
+#: id:487
+msgid "Repeat one"
+msgstr "Répéter une fois"
+
+#: id:488
+msgid "Repeat folder"
+msgstr "Répéter la liste du dossier"
+
+#: id:489
+msgid "Play the next song automatically"
+msgstr "Enchainer automatiquement la chanson suivante"
+
+#: id:491
+msgid "- Use big icons"
+msgstr "- Utiliser de grandes icônes"
+
+#: id:492
+msgid "Resize VobSubs"
+msgstr "Redimensionner les VobSubs"
+
+#: id:493
+msgid "Advanced options (Experts Only!)"
+msgstr "Options avancées (experts uniquement !)"
+
+#: id:494
+msgid "Overall audio headroom"
+msgstr "Amplitude avant distorsion (dB)"
+
+#: id:495
+msgid "Upsample videos to GUI resolution"
+msgstr "Ajuster les vidéos à la résolution de l'interface"
+
+#: id:496
+msgid "Calibration"
+msgstr "Calibrage"
+
+#: id:497
+msgid "Show file extensions"
+msgstr "Afficher les extensions des fichiers"
+
+#: id:498
+msgid "Sort by: Type"
+msgstr "Trier par : Type"
+
+#: id:499
+msgid "Unable to connect to online lookup service"
+msgstr "Connexion impossible pour recherche en ligne"
+
+#: id:500
+msgid "Downloading album information failed"
+msgstr "Échec du téléchargement des infos de l'album"
+
+#: id:501
+msgid "Looking for album names..."
+msgstr "Recherche des noms d'album..."
+
+#: id:502
+msgctxt "Auto context with id 502"
+msgid "Open"
+msgstr "Ouvert"
+
+#: id:503
+msgid "Busy"
+msgstr "Occupé"
+
+#: id:504
+msgid "Empty"
+msgstr "Vide"
+
+#: id:505
+msgid "Loading media info from files..."
+msgstr "Chargement des infos..."
+
+#: id:507
+msgid "Sort by: Usage"
+msgstr "Trier par : Usage"
+
+#: id:510
+msgid "Enable visualizations"
+msgstr "Activer les visualisations"
+
+#: id:511
+msgid "Enable video mode switching"
+msgstr "Adapter le mode vidéo à la région du jeu"
+
+#: id:512
+msgid "Startup window"
+msgstr "Écran de Démarrage"
+
+#: id:513
+msgid "Home window"
+msgstr "Accueil"
+
+#: id:514
+msgid "Manual settings"
+msgstr "Configuration manuelle"
+
+#: id:515
+msgid "Genre"
+msgstr "Genre"
+
+#: id:517
+msgid "Recently played albums"
+msgstr "Albums récemment joués"
+
+#: id:518
+msgid "Launch"
+msgstr "Lancer"
+
+#: id:519
+msgid "Launch in..."
+msgstr "Lancer en..."
+
+#: id:521
+msgid "Compilations"
+msgstr "Compilations"
+
+#: id:522
+msgid "Remove source"
+msgstr "Supprimer la source"
+
+#: id:523
+msgid "Switch media"
+msgstr "Changer de médias"
+
+#: id:524
+msgid "Select playlist"
+msgstr "Choisir une playliste"
+
+#: id:525
+msgid "New playlist..."
+msgstr "Nouvelle playliste..."
+
+#: id:526
+msgid "Add to playlist"
+msgstr "Ajouter à la playliste"
+
+#: id:527
+msgid "Manually add to library"
+msgstr "Ajout manuel à la médiath..."
+
+#: id:528
+msgid "Enter title"
+msgstr "Entrer le titre"
+
+#: id:529
+msgid "Error: Duplicate title"
+msgstr "Erreur : doublon"
+
+#: id:530
+msgid "Select genre"
+msgstr "Choisir le genre"
+
+#: id:531
+msgid "New genre"
+msgstr "Nouveau genre"
+
+#: id:532
+msgid "Manual addition"
+msgstr "Ajout manuel"
+
+#: id:533
+msgid "Enter genre"
+msgstr "Entrer le genre"
+
+#: id:534
+msgid "View: %s"
+msgstr "Vue : %s"
+
+#: id:535
+msgid "List"
+msgstr "Liste"
+
+#: id:536
+msgid "Icons"
+msgstr "Icônes"
+
+#: id:537
+msgid "Big list"
+msgstr "Grande liste"
+
+#: id:538
+msgid "Big icons"
+msgstr "Grande icônes"
+
+#: id:539
+msgid "Wide"
+msgstr "Large"
+
+#: id:540
+msgid "Big wide"
+msgstr "Panoramique"
+
+#: id:541
+msgid "Album icons"
+msgstr "Icônes album"
+
+#: id:542
+msgid "DVD icons"
+msgstr "Icônes DVD"
+
+#: id:543
+msgctxt "Auto context with id 543"
+msgid "DVD"
+msgstr "DVD"
+
+#: id:544
+msgctxt "Auto context with id 544"
+msgid "Media info"
+msgstr "Infos Média"
+
+#: id:545
+msgid "Audio output device"
+msgstr "Périphérique de sortie audio"
+
+#: id:546
+msgid "Passthrough output device"
+msgstr "Passthrough vers le périphérique de sortie"
+
+#: id:547
+msgid "No biography for this artist"
+msgstr "Pas de biographie pour cet artiste"
+
+#: id:548
+msgid "Downmix multichannel audio to stereo"
+msgstr "Dé-multiplexer l'audio multi-canal en stéréo"
+
+#: id:550
+msgid "Sort by: %s"
+msgstr "Trier par : %s"
+
+#: id:551
+msgctxt "Auto context with id 551"
+msgid "Name"
+msgstr "Nom"
+
+#: id:552
+msgid "Date"
+msgstr "Date"
+
+#: id:553
+msgid "Size"
+msgstr "Taille"
+
+#: id:554
+msgid "Track"
+msgstr "Piste"
+
+#: id:555
+msgid "Time"
+msgstr "Durée"
+
+#: id:556
+msgctxt "Auto context with id 556"
+msgid "Title"
+msgstr "Titre"
+
+#: id:557
+msgid "Artist"
+msgstr "Artiste"
+
+#: id:558
+msgid "Album"
+msgstr "Album"
+
+#: id:559
+msgid "Playlist"
+msgstr "Playliste"
+
+#: id:560
+msgid "ID"
+msgstr "ID"
+
+#: id:561
+msgctxt "Auto context with id 561"
+msgid "File"
+msgstr "Fichier"
+
+#: id:562
+msgctxt "Auto context with id 562"
+msgid "Year"
+msgstr "Année"
+
+#: id:563
+msgid "Rating"
+msgstr "Intérêt"
+
+#: id:564
+msgctxt "Auto context with id 564"
+msgid "Type"
+msgstr "Type"
+
+#: id:565
+msgid "Usage"
+msgstr "Utilisation"
+
+#: id:566
+msgid "Album artist"
+msgstr "Artiste de l'album"
+
+#: id:567
+msgid "Play count"
+msgstr "Décompte lecture"
+
+#: id:568
+msgid "Last played"
+msgstr "Dernière jouée"
+
+#: id:569
+msgctxt "Auto context with id 569"
+msgid "Comment"
+msgstr "Commentaire"
+
+#: id:570
+msgid "Date added"
+msgstr "Ajouté le"
+
+#: id:571
+msgctxt "Auto context with id 571"
+msgid "Default"
+msgstr "Défaut"
+
+#: id:572
+msgid "Studio"
+msgstr "Studio"
+
+#: id:573
+msgid "Path"
+msgstr "Chemin"
+
+#: id:574
+msgctxt "Auto context with id 574"
+msgid "Country"
+msgstr "Pays"
+
+#: id:575
+msgid "In progress"
+msgstr "En cours"
+
+#: id:576
+msgid "Times played"
+msgstr "Nombre de Lectures"
+
+#: id:580
+msgid "Sort direction"
+msgstr "Direction du tri"
+
+#: id:581
+msgid "Sort method"
+msgstr "Méthode du tri"
+
+#: id:582
+msgctxt "Auto context with id 582"
+msgid "View mode"
+msgstr "Mode de vue"
+
+#: id:583
+msgid "Remember views for different folders"
+msgstr "Mémoriser l'affichage des dossiers"
+
+#: id:584
+msgid "Ascending"
+msgstr "Croissant"
+
+#: id:585
+msgid "Descending"
+msgstr "Décroissant"
+
+#: id:586
+msgid "Edit playlist"
+msgstr "Éditer la playliste"
+
+#: id:587
+msgid "Filter"
+msgstr "Filtre"
+
+#: id:588
+msgid "Cancel party mode"
+msgstr "Annuler le Mix de soirée"
+
+#: id:589
+msgid "Party mode"
+msgstr "Mix de soirée"
+
+#: id:590
+msgid "Random"
+msgstr "Aléatoire"
+
+#: id:591
+msgctxt "Auto context with id 591"
+msgid "Off"
+msgstr "Non"
+
+#: id:592
+msgid "One"
+msgstr "Une fois"
+
+#: id:593
+msgid "All"
+msgstr "Toutes"
+
+#: id:594
+msgctxt "Auto context with id 594"
+msgid "Off"
+msgstr "Non"
+
+#: id:595
+msgid "Repeat: Off"
+msgstr "Répéter : Non"
+
+#: id:596
+msgid "Repeat: One"
+msgstr "Répéter : Une fois"
+
+#: id:597
+msgid "Repeat: All"
+msgstr "Répéter : Tous"
+
+#: id:600
+msgid "Rip audio CD"
+msgstr "Importer le CD"
+
+#: id:601
+msgctxt "Auto context with id 601"
+msgid "Medium"
+msgstr "Moyenne"
+
+#: id:602
+msgctxt "Auto context with id 602"
+msgid "Standard"
+msgstr "Standard"
+
+#: id:603
+msgid "Extreme"
+msgstr "Excellente"
+
+#: id:604
+msgid "Constant bitrate"
+msgstr "Débit constant"
+
+#: id:605
+msgid "Ripping..."
+msgstr "Importation en cours..."
+
+#: id:607
+msgid "To:"
+msgstr "Destination :"
+
+#: id:608
+msgid "Could not rip CD or track"
+msgstr "Impossible d'importer le CD ou la piste"
+
+#: id:609
+msgid "CDDARipPath is not set."
+msgstr "Le chemin CDDA d'importation n'est pas défini."
+
+#: id:610
+msgid "Rip audio track"
+msgstr "Importer une piste audio"
+
+#: id:611
+msgid "Enter number"
+msgstr "Entrer le numéro"
+
+#: id:612
+msgid "Bits/Sample"
+msgstr "Bits/Sample"
+
+#: id:613
+msgid "Sample Frequency"
+msgstr "Fréquence d'échantillonage"
+
+#: id:620
+msgid "Audio CDs"
+msgstr "CDs audio"
+
+#: id:621
+msgid "Encoder"
+msgstr "Encodeur"
+
+#: id:622
+msgid "Quality"
+msgstr "Qualité"
+
+#: id:623
+msgid "Bitrate"
+msgstr "Débit"
+
+#: id:624
+msgid "Include track number"
+msgstr "Inclure le numéro de la piste"
+
+#: id:625
+msgid "All songs of"
+msgstr "Toutes les chansons de"
+
+#: id:629
+msgctxt "Auto context with id 629"
+msgid "View mode"
+msgstr "Type de vue"
+
+#: id:630
+msgctxt "Auto context with id 630"
+msgid "Normal"
+msgstr "Normale"
+
+#: id:631
+msgid "Zoom"
+msgstr "Zoom"
+
+#: id:632
+msgid "Stretch 4:3"
+msgstr "Étirée 4:3"
+
+#: id:633
+msgid "Wide Zoom"
+msgstr "Étirée 14:9"
+
+#: id:634
+msgid "Stretch 16:9"
+msgstr "Étirée 16:9"
+
+#: id:635
+msgid "Original Size"
+msgstr "Taille Originale"
+
+#: id:636
+msgctxt "Auto context with id 636"
+msgid "Custom"
+msgstr "Personnalisé"
+
+#: id:637
+msgid "Replay gain"
+msgstr "Replay gain"
+
+#: id:638
+msgid "Replaygain volume adjustments"
+msgstr "Ajustements du volume Replay gain"
+
+#: id:639
+msgid "Use track levels"
+msgstr "Utiliser le volume de la chanson"
+
+#: id:640
+msgid "Use album levels"
+msgstr "Utiliser le volume de l'album"
+
+#: id:641
+msgid "PreAmp Level - Replay gained files"
+msgstr "Amplification des fichiers Replay gain"
+
+#: id:642
+msgid "PreAmp Level - Non replay gained files"
+msgstr "Amplification des fichiers non Replay gain"
+
+#: id:643
+msgid "Avoid clipping on replay gained files"
+msgstr "Éviter les coupures sur les fichiers replay gain"
+
+#: id:644
+msgid "Crop black bars"
+msgstr "Couper les barres noires"
+
+#: id:645
+msgid "Need to unpack a big file. Continue?"
+msgstr "Besoin de décompresser un gros fichier. Continuer ?"
+
+#: id:646
+msgid "Remove from library"
+msgstr "Retirer de la médiathèque"
+
+#: id:647
+msgid "Export video library"
+msgstr "Exporter la médiathèque vidéo"
+
+#: id:648
+msgid "Import video library"
+msgstr "Importer une médiathèque vidéo"
+
+#: id:649
+msgid "Importing"
+msgstr "Importation"
+
+#: id:650
+msgid "Exporting"
+msgstr "Exportation"
+
+#: id:651
+msgid "Browse for library"
+msgstr "Rechercher une médiathèque"
+
+#: id:652
+msgid "Years"
+msgstr "Années"
+
+#: id:653
+msgid "Update library"
+msgstr "Actualiser la médiathèque"
+
+#: id:654
+msgid "Show debug info"
+msgstr "Voir les infos debug"
+
+#: id:655
+msgid "Browse for executable"
+msgstr "Recherche d'exécutable"
+
+#: id:656
+msgid "Browse for playlist"
+msgstr "Recherche d'une playliste"
+
+#: id:657
+msgid "Browse for folder"
+msgstr "Recherche d'un dossier"
+
+#: id:658
+msgid "Song information"
+msgstr "Information de la chanson"
+
+#: id:659
+msgid "Non-linear stretch"
+msgstr "Étirement non-linéaire"
+
+#: id:660
+msgid "Volume amplification"
+msgstr "Volume d'amplification"
+
+#: id:661
+msgid "Choose export folder"
+msgstr "Choisissez le dossier d'exportation"
+
+#: id:662
+msgid "This file is no longer available."
+msgstr "Ce fichier n'est plus disponible."
+
+#: id:663
+msgid "Would you like to remove it from the library?"
+msgstr "Souhaitez-vous le supprimer de la médiathèque ?"
+
+#: id:664
+msgid "Browse for Script"
+msgstr "Rechercher un script"
+
+#: id:665
+msgid "Compression level"
+msgstr "Niveau de compression"
+
+#: id:700
+msgid "Cleaning up library"
+msgstr "Nettoyage de la médiathèque"
+
+#: id:701
+msgid "Removing old songs from the library"
+msgstr "Suppression des anciens morceaux de la médiathèque"
+
+#: id:702
+msgid "This path has been scanned before"
+msgstr "Ce dossier a déjà été scanné"
+
+#: id:705
+msgctxt "Auto context with id 705"
+msgid "Network"
+msgstr "Réseau"
+
+#: id:706
+msgid "- Server"
+msgstr "- Serveur"
+
+#: id:708
+msgid "Use an HTTP proxy server to access the internet"
+msgstr "Utiliser un serveur proxy HTTP pour accéder à internet"
+
+#: id:711
+msgid "Internet Protocol (IP)"
+msgstr "Protocole Internet (IP)"
+
+#: id:712
+msgid "Invalid port specified. Value must be between 1 and 65535."
+msgstr "Port spécifié invalide. Doit être compris entre 1 et 65535."
+
+#: id:713
+msgid "HTTP proxy"
+msgstr "Proxy HTTP"
+
+#: id:715
+msgid "- Assignment"
+msgstr "- Attribution"
+
+#: id:716
+msgid "Automatic (DHCP)"
+msgstr "Automatique (DHCP)"
+
+#: id:717
+msgid "Manual (Static)"
+msgstr "Manuelle (Statique)"
+
+#: id:719
+msgid "- IP address"
+msgstr "- Adresse IP"
+
+#: id:720
+msgid "- Netmask"
+msgstr "- Masque de sous-réseau"
+
+#: id:721
+msgid "- Default gateway"
+msgstr "- Passerelle par défaut"
+
+#: id:722
+msgid "- DNS server"
+msgstr "- Serveur DNS"
+
+#: id:723
+msgid "Save & restart"
+msgstr "Enregistrer & redémarrer"
+
+#: id:724
+msgid "Invalid address specified. Value must be AAA.BBB.CCC.DDD"
+msgstr "Adresse spécifiée invalide. Doit être du type AAA.BBB.CCC.DDD"
+
+#: id:725
+msgid "with numbers between 0 and 255."
+msgstr "avec des nombres de 0 à 255."
+
+#: id:726
+msgid "Changes not saved. Continue without saving?"
+msgstr "Les changements n'ont pas été enregistrés. Continuer sans sauvegarder ?"
+
+#: id:727
+msgid "Web server"
+msgstr "Serveur Web"
+
+#: id:728
+msgctxt "Auto context with id 728"
+msgid "FTP server"
+msgstr "Serveur FTP"
+
+#: id:730
+msgid "- Port"
+msgstr "- Port"
+
+#: id:732
+msgid "Save & apply"
+msgstr "Enregistrer & appliquer"
+
+#: id:733
+msgid "- Password"
+msgstr "- Mot de passe"
+
+#: id:734
+msgid "No pass"
+msgstr "Pas de mot de passe"
+
+#: id:735
+msgid "- Character set"
+msgstr "- Jeu de caractères"
+
+#: id:736
+msgid "- Style"
+msgstr "- Style"
+
+#: id:737
+msgid "- Colour"
+msgstr "- Couleur"
+
+#: id:738
+msgctxt "Auto context with id 738"
+msgid "Normal"
+msgstr "Normal"
+
+#: id:739
+msgid "Bold"
+msgstr "Gras"
+
+#: id:740
+msgid "Italics"
+msgstr "Italique"
+
+#: id:741
+msgid "Bold italics"
+msgstr "Gras italique"
+
+#: id:742
+msgctxt "Auto context with id 742"
+msgid "White"
+msgstr "Blanc"
+
+#: id:743
+msgctxt "Auto context with id 743"
+msgid "Yellow"
+msgstr "Jaune"
+
+#: id:744
+msgctxt "Auto context with id 744"
+msgid "Files"
+msgstr "Fichiers"
+
+#: id:745
+msgid "No scanned information for this view"
+msgstr "Aucune information scannée pour cet affichage"
+
+#: id:746
+msgid "Please turn off library mode"
+msgstr "Merci de désactiver le mode médiathèque"
+
+#: id:747
+msgid "Error loading image"
+msgstr "Erreur lors du chargement de l'image"
+
+#: id:748
+msgid "Edit path"
+msgstr "Éditer le chemin"
+
+#: id:749
+msgid "Mirror image"
+msgstr "Retourner l'image"
+
+#: id:750
+msgid "Are you sure?"
+msgstr "Êtes-vous sûr(e) ?"
+
+#: id:751
+msgid "Removing source"
+msgstr "Supprimer la source"
+
+#: id:754
+msgid "Add program link"
+msgstr "Ajouter un lien programme"
+
+#: id:755
+msgid "Edit program path"
+msgstr "Éditer le chemin du programme"
+
+#: id:756
+msgid "Edit program name"
+msgstr "Éditer le nom du programme"
+
+#: id:757
+msgid "Edit path depth"
+msgstr "Éditer la profondeur du chemin"
+
+#: id:759
+msgid "View: Big list"
+msgstr "Vue : Grande liste"
+
+#: id:760
+msgctxt "Auto context with id 760"
+msgid "Yellow"
+msgstr "Jaune"
+
+#: id:761
+msgctxt "Auto context with id 761"
+msgid "White"
+msgstr "Blanc"
+
+#: id:762
+msgid "Blue"
+msgstr "Bleu"
+
+#: id:763
+msgid "Bright green"
+msgstr "Vert clair"
+
+#: id:764
+msgid "Yellow green"
+msgstr "Jaune Vert"
+
+#: id:765
+msgid "Cyan"
+msgstr "Cyan"
+
+#: id:766
+msgid "Light grey"
+msgstr "Réservé"
+
+#: id:767
+msgid "Grey"
+msgstr "Réservé"
+
+#: id:770
+msgid "Error %i: share not available"
+msgstr "Erreur %i : Partage non disponible"
+
+#: id:772
+msgctxt "Auto context with id 772"
+msgid "Audio output"
+msgstr "Sortie audio"
+
+#: id:773
+msgid "Seeking"
+msgstr "Chercher"
+
+#: id:774
+msgid "Slideshow folder"
+msgstr "Répertoire du diaporama"
+
+#: id:775
+msgid "Network interface"
+msgstr "Interface réseau"
+
+#: id:776
+msgid "- Wireless network name (ESSID)"
+msgstr "- Nom réseau sans fil (ESSID)"
+
+#: id:777
+msgid "- Wireless password"
+msgstr "- Mot de passe sans fil"
+
+#: id:778
+msgid "- Wireless security"
+msgstr "- Sécurité sans fil"
+
+#: id:779
+msgid "Save and apply network interface settings"
+msgstr "Sauvegarder et appliquer les paramètres réseau"
+
+#: id:780
+msgid "No encryption"
+msgstr "Aucun cryptage"
+
+#: id:781
+msgid "WEP"
+msgstr "WEP"
+
+#: id:782
+msgid "WPA"
+msgstr "WPA"
+
+#: id:783
+msgid "WPA2"
+msgstr "WPA2"
+
+#: id:784
+msgid "Applying network interface settings. Please wait."
+msgstr "Modification des paramètres réseaux. Veuillez patienter."
+
+#: id:785
+msgid "Network interface restarted successfully."
+msgstr "L'interface réseau a été réinitialisée avec succès."
+
+#: id:786
+msgid "Network interface did not start successfully."
+msgstr "L'interface réseau n'a pas démarrée correctement."
+
+#: id:787
+msgid "Interface disabled"
+msgstr "Interface désactivée"
+
+#: id:788
+msgid "Network interface disabled successfully."
+msgstr "L'interface réseau a été désactivée avec succès."
+
+#: id:789
+msgid "Wireless network name (ESSID)"
+msgstr "Nom réseau sans fil (ESSID)"
+
+#: id:790
+msgid "Remote control"
+msgstr ""
+
+#: id:791
+msgid "Allow programs on this system to control XBMC"
+msgstr "Autoriser le contrôle de XBMC par des programmes locaux"
+
+#: id:792
+msgctxt "Auto context with id 792"
+msgid "Port"
+msgstr "Port"
+
+#: id:793
+msgid "Port range"
+msgstr "Port série"
+
+#: id:794
+msgid "Allow programs on other systems to control XBMC"
+msgstr "Autoriser le contrôle de XBMC par des programmes distants"
+
+#: id:795
+msgid "Initial repeat delay (ms)"
+msgstr "Délai répétition initial (ms)"
+
+#: id:796
+msgid "Continuous repeat delay (ms)"
+msgstr "Délai répétition continue (ms)"
+
+#: id:797
+msgid "Maximum number of clients"
+msgstr "Nombre maximum de clients"
+
+#: id:798
+msgid "Internet access"
+msgstr "Accès Internet"
+
+#: id:850
+msgid "Invalid port number entered"
+msgstr "Numéro de port invalide"
+
+#: id:851
+msgid "Valid port range is 1-65535"
+msgstr "Port valide compris entre 1-65535"
+
+#: id:852
+msgid "Valid port range is 1024-65535"
+msgstr "Port valide compris entre 1024-65535"
+
+#: id:998
+msgid "Add Music..."
+msgstr "Ajouter une source musicale..."
+
+#: id:999
+msgid "Add Videos..."
+msgstr "Ajouter une source vidéo..."
+
+#: id:1000
+msgid "- Preview"
+msgstr "- Prévisualiser"
+
+#: id:1001
+msgid "Unable to connect"
+msgstr "Impossible de se connecter"
+
+#: id:1002
+msgid "XBMC was unable to connect to the network location."
+msgstr "XBMC ne peut pas se connecter au chemin réseau."
+
+#: id:1003
+msgid "This could be due to the network not being connected."
+msgstr "Vérifiez votre chemin ou votre installation réseau."
+
+#: id:1004
+msgid "Would you like to add it anyway?"
+msgstr "Désirez-vous tout de même l'ajouter ?"
+
+#: id:1006
+msgctxt "Auto context with id 1006"
+msgid "IP address"
+msgstr "Adresse IP"
+
+#: id:1007
+msgid "Add network location"
+msgstr "Ajouter un chemin réseau"
+
+#: id:1008
+msgid "Protocol"
+msgstr "Protocole"
+
+#: id:1009
+msgid "Server address"
+msgstr "Adresse du serveur"
+
+#: id:1010
+msgid "Server name"
+msgstr "Nom du serveur"
+
+#: id:1011
+msgid "Remote path"
+msgstr "Chemin cible"
+
+#: id:1012
+msgid "Shared folder"
+msgstr "Dossier partagé"
+
+#: id:1013
+msgctxt "Auto context with id 1013"
+msgid "Port"
+msgstr "Port"
+
+#: id:1014
+msgctxt "Auto context with id 1014"
+msgid "Username"
+msgstr "Utilisateur"
+
+#: id:1015
+msgid "Browse for network server"
+msgstr "Parcourir pour un serveur réseau"
+
+#: id:1016
+msgid "Enter the network address of the server"
+msgstr "Saisissez l'adresse réseau du serveur"
+
+#: id:1017
+msgid "Enter the path on the server"
+msgstr "Saisissez le chemin du serveur"
+
+#: id:1018
+msgid "Enter the port number"
+msgstr "Saisissez le numéro du port"
+
+#: id:1019
+msgid "Enter the username"
+msgstr "Saisissez le nom de l'utilisateur"
+
+#: id:1020
+msgid "Add %s source"
+msgstr "Ajouter une source %s"
+
+#: id:1021
+msgid "Enter the paths or browse for the media locations."
+msgstr "Saisissez le chemin pour localiser vos médias"
+
+#: id:1022
+msgid "Enter a name for this media Source."
+msgstr "Saisir un nom pour cette source."
+
+#: id:1023
+msgid "Browse for new share"
+msgstr "Sélectionnez le chemin de vos médias"
+
+#: id:1024
+msgid "Browse"
+msgstr "Parcourir"
+
+#: id:1025
+msgid "Could not retrieve directory information."
+msgstr "Impossible de récupérer les informations."
+
+#: id:1026
+msgid "Add source"
+msgstr "Ajouter une source"
+
+#: id:1027
+msgid "Edit source"
+msgstr "Éditer cette source"
+
+#: id:1028
+msgid "Edit %s source"
+msgstr "Éditer la source %s"
+
+#: id:1029
+msgid "Enter the new label"
+msgstr "Saisissez le nouveau label"
+
+#: id:1030
+msgid "Browse for image"
+msgstr "Recherche d'image"
+
+#: id:1031
+msgid "Browse for image folder"
+msgstr "Recherche d'un dossier d'images"
+
+#: id:1032
+msgid "Add network location..."
+msgstr "Ajouter un chemin réseau"
+
+#: id:1033
+msgid "Browse for file"
+msgstr "Recherche d'un fichier"
+
+#: id:1034
+msgid "Submenu"
+msgstr "Sous-menu"
+
+#: id:1035
+msgid "Enable submenu buttons"
+msgstr "Activer les boutons du sous-menu"
+
+#: id:1036
+msgid "Favourites"
+msgstr "Favoris"
+
+#: id:1037
+msgid "Video Add-ons"
+msgstr "Add-ons Vidéo"
+
+#: id:1038
+msgid "Music Add-ons"
+msgstr "Add-ons Musique"
+
+#: id:1039
+msgid "Picture Add-ons"
+msgstr "Add-ons Image"
+
+#: id:1040
+msgid "Loading directory"
+msgstr "Chargement du dossier"
+
+#: id:1041
+msgid "Retrieved %i items"
+msgstr "%i objets chargés"
+
+#: id:1042
+msgid "Retrieved %i of %i items"
+msgstr "%i objets chargés sur %i"
+
+#: id:1043
+msgid "Program Add-ons"
+msgstr "Add-ons programme"
+
+#: id:1044
+msgid "Set plugin thumb"
+msgstr "Choisir une vignette plugin"
+
+#: id:1045
+msgid "Add-on settings"
+msgstr "Paramètres de l'Add-on"
+
+#: id:1046
+msgid "Access points"
+msgstr "Points d'accès"
+
+#: id:1047
+msgid "Other..."
+msgstr "Autre..."
+
+#: id:1048
+msgid "- Username"
+msgstr "- Nom d'utilisateur"
+
+#: id:1049
+msgid "Script settings"
+msgstr "Paramètres du Script"
+
+#: id:1050
+msgid "Singles"
+msgstr "Singles"
+
+#: id:1051
+msgid "Enter web address"
+msgstr "Entrez l'adresse web"
+
+#: id:1200
+msgid "SMB client"
+msgstr "Client SMB"
+
+#: id:1202
+msgid "Workgroup"
+msgstr "Groupe de travail"
+
+#: id:1203
+msgid "Default username"
+msgstr "Utilisateur par défaut"
+
+#: id:1204
+msgid "Default password"
+msgstr "Mot de passe par défaut"
+
+#: id:1207
+msgid "WINS server"
+msgstr "Serveur WINS"
+
+#: id:1208
+msgid "Mount SMB shares"
+msgstr "Monter les partages SMB"
+
+#: id:1210
+msgctxt "Auto context with id 1210"
+msgid "Remove"
+msgstr "Supprimer"
+
+#: id:1211
+msgctxt "Auto context with id 1211"
+msgid "Music"
+msgstr "Musique"
+
+#: id:1212
+msgctxt "Auto context with id 1212"
+msgid "Video"
+msgstr "Vidéo"
+
+#: id:1213
+msgctxt "Auto context with id 1213"
+msgid "Pictures"
+msgstr "Images"
+
+#: id:1214
+msgctxt "Auto context with id 1214"
+msgid "Files"
+msgstr "Fichiers"
+
+#: id:1215
+msgctxt "Auto context with id 1215"
+msgid "Music & video"
+msgstr "Musique & Vidéos"
+
+#: id:1216
+msgid "Music & pictures"
+msgstr "Musique & Images"
+
+#: id:1217
+msgid "Music & files"
+msgstr "Musique & Fichiers"
+
+#: id:1218
+msgid "Video & pictures"
+msgstr "Vidéos & Images"
+
+#: id:1219
+msgid "Video & files"
+msgstr "Vidéos & Fichiers"
+
+#: id:1220
+msgid "Pictures & files"
+msgstr "Images & Fichiers"
+
+#: id:1221
+msgid "Music & video & pictures"
+msgstr "Musique & Vidéos & Images"
+
+#: id:1222
+msgid "Music & video & pictures & files"
+msgstr "Musique & Vidéos & Images & Fichiers"
+
+#: id:1223
+msgctxt "Auto context with id 1223"
+msgid "Disabled"
+msgstr "Désactivé"
+
+#: id:1226
+msgid "Files & music & video"
+msgstr "Fichiers & Musique & Vidéos"
+
+#: id:1227
+msgid "Files & pictures & music"
+msgstr "Fichiers & Images & Musique"
+
+#: id:1228
+msgid "Files & pictures & video"
+msgstr "Fichiers & Images & Vidéos"
+
+#: id:1229
+msgid "Music & programs"
+msgstr "Musique & Programmes"
+
+#: id:1230
+msgid "Video & programs"
+msgstr "Vidéos & Programmes"
+
+#: id:1231
+msgid "Pictures & programs"
+msgstr "Images & Programmes"
+
+#: id:1232
+msgid "Music & video & pictures & programs"
+msgstr "Musique & Vidéos & Images & Programmes"
+
+#: id:1233
+msgid "Programs & video & music"
+msgstr "Programmes & Vidéos & Musique"
+
+#: id:1234
+msgid "Programs & pictures & music"
+msgstr "Programmes & Images & Musique"
+
+#: id:1235
+msgid "Programs & pictures & video"
+msgstr "Programmes & Images & Vidéos"
+
+#: id:1250
+msgid "Auto-detection"
+msgstr "Auto-détection"
+
+#: id:1251
+msgid "Auto-detect system"
+msgstr "Auto-détection du système"
+
+#: id:1252
+msgid "Nickname"
+msgstr "Pseudo"
+
+#: id:1254
+msgid "Ask to connect"
+msgstr "Demander pour se connecter"
+
+#: id:1255
+msgid "Send FTP user and password"
+msgstr "Envoyer les Mot de Passe et Nom d'Utilisateur FTP"
+
+#: id:1256
+msgid "Ping interval"
+msgstr "Temps de réponse (ping)"
+
+#: id:1257
+msgid "Would you like to connect to the auto-detected system?"
+msgstr "Souhaitez-vous vous connecter à l'auto-détection du système ?"
+
+#: id:1259
+msgid "Zeroconf"
+msgstr ""
+
+#: id:1260
+msgid "Announce these services to other systems via Zeroconf"
+msgstr "Annoncer ces services à d'autres systèmes via Zéroconf"
+
+#: id:1270
+msgid "Allow XBMC to receive AirPlay content"
+msgstr "Autoriser XBMC à recevoir du contenu AirPlay"
+
+#: id:1271
+msgid "Device name"
+msgstr "Nom du dispositif"
+
+#: id:1272
+msgid "- Use password protection"
+msgstr "- Protection par mot de passe"
+
+#: id:1273
+msgid "AirPlay"
+msgstr ""
+
+#: id:1300
+msgid "Custom audio device"
+msgstr "Personnaliser le périphérique audio"
+
+#: id:1301
+msgid "Custom passthrough device"
+msgstr "Personnaliser le périphérique passthrough"
+
+#: id:1396
+msgid "Drifting"
+msgstr "Dérivant"
+
+#: id:1397
+msgid "and"
+msgstr "et"
+
+#: id:1398
+msgid "Freezing"
+msgstr "gelant"
+
+#: id:1399
+msgid "Late"
+msgstr "Tard"
+
+#: id:1400
+msgid "Isolated"
+msgstr "Isolé(e)"
+
+#: id:1401
+msgid "Thundershowers"
+msgstr "Orages"
+
+#: id:1402
+msgid "Thunder"
+msgstr "Tonnerre"
+
+#: id:1403
+msgctxt "Auto context with id 1403"
+msgid "Sun"
+msgstr "Soleil"
+
+#: id:1404
+msgid "Heavy"
+msgstr "important(e)(s)"
+
+#: id:1405
+msgid "in"
+msgstr "dans"
+
+#: id:1406
+msgid "the"
+msgstr "la"
+
+#: id:1407
+msgid "Vicinity"
+msgstr "environs"
+
+#: id:1408
+msgid "Ice"
+msgstr "Glace"
+
+#: id:1409
+msgid "Crystals"
+msgstr "Cristaux"
+
+#: id:1410
+msgid "Calm"
+msgstr "Calme"
+
+#: id:1411
+msgid "with"
+msgstr "avec"
+
+#: id:1412
+msgid "windy"
+msgstr "venteux"
+
+#: id:1413
+msgid "drizzle"
+msgstr "bruine"
+
+#: id:1414
+msgid "Thunderstorm"
+msgstr "Orageux"
+
+#: id:1415
+msgid "Drizzle"
+msgstr "Bruine"
+
+#: id:1416
+msgid "Foggy"
+msgstr "Brumeux"
+
+#: id:1417
+msgid "Grains"
+msgstr "Grains"
+
+#: id:1418
+msgid "T-Storms"
+msgstr "Orages électriques"
+
+#: id:1419
+msgid "T-Showers"
+msgstr "Orages"
+
+#: id:1420
+msgid "Moderate"
+msgstr "Modéré"
+
+#: id:1421
+msgid "Very High"
+msgstr "Très Fort"
+
+#: id:1422
+msgid "Windy"
+msgstr "Venteux"
+
+#: id:1423
+msgid "Mist"
+msgstr "Brouillard"
+
+#: id:1450
+msgid "Put display to sleep when idle"
+msgstr "Passer en économie d'énergie en cas d'inactivité"
+
+#: id:2050
+msgid "Runtime"
+msgstr "Durée"
+
+#: id:2100
+msgid "Script failed! : %s"
+msgstr "Échec du script ! : %s"
+
+#: id:2101
+msgid "Newer version needed - See log"
+msgstr "Nouvelle version requise - Voir le log"
+
+#: id:4501
+msgid "Enable LCD/VFD"
+msgstr "Activer LCD/VFD"
+
+#: id:10000
+msgid "Home"
+msgstr "Accueil"
+
+#: id:10001
+msgctxt "Auto context with id 10001"
+msgid "Programs"
+msgstr "Programmes"
+
+#: id:10002
+msgctxt "Auto context with id 10002"
+msgid "Pictures"
+msgstr "Images"
+
+#: id:10003
+msgctxt "Auto context with id 10003"
+msgid "File manager"
+msgstr "Fichiers"
+
+#: id:10004
+msgctxt "Auto context with id 10004"
+msgid "Settings"
+msgstr "Paramètres"
+
+#: id:10005
+msgctxt "Auto context with id 10005"
+msgid "Music"
+msgstr "Musiques"
+
+#: id:10006
+msgctxt "Auto context with id 10006"
+msgid "Videos"
+msgstr "Vidéos"
+
+#: id:10007
+msgid "System information"
+msgstr "Informations Système"
+
+#: id:10008
+msgid "Settings - General"
+msgstr "Paramètres - Général"
+
+#: id:10009
+msgid "Settings - Screen"
+msgstr "Paramètres - Écran"
+
+#: id:10010
+msgid "Settings - Appearance - GUI Calibration"
+msgstr "Paramètres - Apparence - Calibration GUI"
+
+#: id:10011
+msgid "Settings - Videos - Screen Calibration"
+msgstr "Paramètres - Vidéos - Calibration d'écran"
+
+#: id:10012
+msgid "Settings - Pictures"
+msgstr "Paramètres - Images"
+
+#: id:10013
+msgid "Settings - Programs"
+msgstr "Paramètres - Programmes"
+
+#: id:10014
+msgid "Settings - Weather"
+msgstr "Paramètres - Météo"
+
+#: id:10015
+msgid "Settings - Music"
+msgstr "Paramètres - Musique"
+
+#: id:10016
+msgid "Settings - System"
+msgstr "Paramètres - Système"
+
+#: id:10017
+msgid "Settings - Videos"
+msgstr "Paramètres - Vidéos"
+
+#: id:10018
+msgid "Settings - Network"
+msgstr "Paramètres - Réseau"
+
+#: id:10019
+msgid "Settings - Appearance"
+msgstr "Paramètres - Apparence"
+
+#: id:10020
+msgctxt "Auto context with id 10020"
+msgid "Scripts"
+msgstr "Scripts"
+
+#: id:10021
+msgid "Web Browser"
+msgstr "Navigateur"
+
+#: id:10025
+msgctxt "Auto context with id 10025"
+msgid "Videos"
+msgstr "Vidéos"
+
+#: id:10028
+msgid "Videos/Playlist"
+msgstr "Vidéos/Playliste"
+
+#: id:10029
+msgctxt "Auto context with id 10029"
+msgid "Login screen"
+msgstr "Écran de connexion"
+
+#: id:10034
+msgid "Settings - Profiles"
+msgstr "Paramètres - Profils"
+
+#: id:10040
+msgid "Addon browser"
+msgstr "Gestionnaire d'add-ons"
+
+#: id:10100
+msgid "Yes/No dialog"
+msgstr "Dialogues Oui/Non"
+
+#: id:10101
+msgid "Progress dialog"
+msgstr "Dialogues Progression"
+
+#: id:10210
+msgid "Looking for subtitles..."
+msgstr "Recherche de sous-titres..."
+
+#: id:10211
+msgid "Looking for or caching subtitles..."
+msgstr "Recherche de sous-titres mis en cache..."
+
+#: id:10212
+msgid "terminating"
+msgstr "Finalisation"
+
+#: id:10213
+msgid "buffering"
+msgstr "Mise en cache"
+
+#: id:10214
+msgid "Opening stream"
+msgstr "Ouverture du flux"
+
+#: id:10500
+msgid "Music/Playlist"
+msgstr "Musique/Playliste"
+
+#: id:10501
+msgid "Music/Files"
+msgstr "Musique/Fichiers"
+
+#: id:10502
+msgid "Music/Library"
+msgstr "Musique/Médiathèque"
+
+#: id:10503
+msgid "Playlist editor"
+msgstr "Éditeur de playliste"
+
+#: id:10504
+msgid "Top 100 songs"
+msgstr "Top 100 Chansons"
+
+#: id:10505
+msgid "Top 100 albums"
+msgstr "Top 100 Albums"
+
+#: id:10506
+msgctxt "Auto context with id 10506"
+msgid "Programs"
+msgstr "Programmes"
+
+#: id:10507
+msgid "Configuration"
+msgstr "Configuration"
+
+#: id:10508
+msgid "Weather forecast"
+msgstr "Prévisions météo"
+
+#: id:10509
+msgid "Network gaming"
+msgstr "Jeux en réseau"
+
+#: id:10510
+msgid "Extensions"
+msgstr "Extensions"
+
+#: id:10511
+msgctxt "Auto context with id 10511"
+msgid "System info"
+msgstr "Infos Système"
+
+#: id:10516
+msgid "Music - Library"
+msgstr "Musique - Médiath."
+
+#: id:10517
+msgid "Now Playing - Music"
+msgstr "Musique - Lecture en cours"
+
+#: id:10522
+msgid "Now Playing - Videos"
+msgstr "Vidéos - Lecture en cours"
+
+#: id:10523
+msgid "Album info"
+msgstr "Infos Album"
+
+#: id:10524
+msgid "Movie info"
+msgstr "Infos Film"
+
+#: id:12000
+msgid "Select dialog"
+msgstr "Choisir un dialogue"
+
+#: id:12001
+msgid "Music/Info"
+msgstr "Musique/info"
+
+#: id:12002
+msgid "Dialog OK"
+msgstr "Dialogues OK"
+
+#: id:12003
+msgid "Videos/Info"
+msgstr "Vidéos/Info"
+
+#: id:12004
+msgid "Scripts/Info"
+msgstr "Scripts/Info"
+
+#: id:12005
+msgid "Fullscreen video"
+msgstr "Vidéo plein écran"
+
+#: id:12006
+msgid "Audio visualization"
+msgstr "Visualisation audio"
+
+#: id:12008
+msgid "File stacking dialog"
+msgstr "Dialogue empiler fichiers"
+
+#: id:12009
+msgid "Rebuild index..."
+msgstr "Reconstruire l'index..."
+
+#: id:12010
+msgid "Return to music window"
+msgstr "Revenir à l'écran musique"
+
+#: id:12011
+msgid "Return to videos window"
+msgstr "Revenir à l'écran vidéos"
+
+#: id:12021
+msgid "Start from beginning"
+msgstr "Reprendre depuis le début"
+
+#: id:12022
+msgid "Resume from %s"
+msgstr "Reprendre à partir de %s"
+
+#: id:12310
+msgid "0"
+msgstr "0"
+
+#: id:12311
+msgid "1"
+msgstr "1"
+
+#: id:12312
+msgid "2"
+msgstr "2"
+
+#: id:12313
+msgid "3"
+msgstr "3"
+
+#: id:12314
+msgid "4"
+msgstr "4"
+
+#: id:12315
+msgid "5"
+msgstr "5"
+
+#: id:12316
+msgid "6"
+msgstr "6"
+
+#: id:12317
+msgid "7"
+msgstr "7"
+
+#: id:12318
+msgid "8"
+msgstr "8"
+
+#: id:12319
+msgid "9"
+msgstr "9"
+
+#: id:12320
+msgid "c"
+msgstr "c"
+
+#: id:12321
+msgid "Ok"
+msgstr "Ok"
+
+#: id:12322
+msgid "*"
+msgstr "*"
+
+#: id:12325
+msgid "Locked! Enter code..."
+msgstr "Verrouillé ! Entrer le code"
+
+#: id:12326
+msgid "Enter password"
+msgstr "Saisissez le mot de passe"
+
+#: id:12327
+msgid "Enter master code"
+msgstr "Saisissez le code Administrateur"
+
+#: id:12328
+msgid "Enter unlock code"
+msgstr "Saisissez le code de déverrouillage"
+
+#: id:12329
+msgid "or press C to cancel"
+msgstr "ou appuyez sur C pour annuler"
+
+#: id:12330
+msgid "Enter gamepad button combo and"
+msgstr "Saisissez la combinaison de boutons gamepad et"
+
+#: id:12331
+msgid "press OK, or Back to cancel"
+msgstr "pressez OK, ou BACK pour annuler"
+
+#: id:12332
+msgid "Set lock"
+msgstr "Sécuriser"
+
+#: id:12333
+msgid "Unlock"
+msgstr "Déverrouiller"
+
+#: id:12334
+msgid "Reset lock"
+msgstr "Réinitialiser le verrouillage"
+
+#: id:12335
+msgid "Remove lock"
+msgstr "Enlever le verrouillage"
+
+#: id:12337
+msgid "Numeric password"
+msgstr "Mot de passe numérique"
+
+#: id:12338
+msgid "Gamepad button combo"
+msgstr "Combinaison de boutons"
+
+#: id:12339
+msgid "Full-text password"
+msgstr "Mot de passe texte"
+
+#: id:12340
+msgid "Enter new password"
+msgstr "Saisir un nouveau mot de passe"
+
+#: id:12341
+msgid "Re-Enter new password"
+msgstr "Saisir à nouveau le mot de passe"
+
+#: id:12342
+msgid "Incorrect password,"
+msgstr "Mot de passe incorrect,"
+
+#: id:12343
+msgid "retries left"
+msgstr "Nombre d'essais restants"
+
+#: id:12344
+msgid "Passwords entered did not match."
+msgstr "Les mots de passe saisis ne correspondent pas."
+
+#: id:12345
+msgid "Access denied"
+msgstr "Accès refusé"
+
+#: id:12346
+msgid "Password retry limit exceeded."
+msgstr "Vous avez atteint le nombre d'essais autorisés."
+
+#: id:12347
+msgid "The system will now shut off."
+msgstr "Le système va maintenant s'éteindre."
+
+#: id:12348
+msgid "Item locked"
+msgstr "Sécurisé"
+
+#: id:12353
+msgid "Reactivate lock"
+msgstr "Ré-activer le verrou"
+
+#: id:12356
+msgid "Change lock"
+msgstr "Changer le verrou"
+
+#: id:12357
+msgid "Source lock"
+msgstr "Verrou sources"
+
+#: id:12358
+msgid "Password entry was blank. Try again."
+msgstr "Le mot de passe entré est vide. Recommencez."
+
+#: id:12360
+msgid "Master lock"
+msgstr "Verrou admin."
+
+#: id:12362
+msgid "Shutdown system if Master Lock retries exceeded"
+msgstr "Éteindre le système après trop de tentatives"
+
+#: id:12367
+msgid "Master code is not valid"
+msgstr "Le code Admin n'est pas valide"
+
+#: id:12368
+msgid "Please enter a valid master code"
+msgstr "Merci d'entrer un code Admin valide"
+
+#: id:12373
+msgid "Settings & file manager"
+msgstr "Paramètres & Fichiers"
+
+#: id:12376
+msgid "Set as default for all movies"
+msgstr "Définir par défaut pour tous les films"
+
+#: id:12377
+msgid "This will reset any previously saved values"
+msgstr "Toutes les configurations précédentes serons perdues"
+
+#: id:12378
+msgid "Amount of time to display each image"
+msgstr "Temps d'affichage pour chaque image"
+
+#: id:12379
+msgid "Use pan and zoom effects"
+msgstr "Utiliser les effets Pan et Zoom"
+
+#: id:12383
+msgid "12 hour clock"
+msgstr "Horloge 12 Heures"
+
+#: id:12384
+msgid "24 hour clock"
+msgstr "Horloge 24 Heures"
+
+#: id:12385
+msgid "Day/Month"
+msgstr "Jour/Mois"
+
+#: id:12386
+msgid "Month/Day"
+msgstr "Mois/Jour"
+
+#: id:12390
+msgid "System uptime"
+msgstr "Système démarré depuis"
+
+#: id:12391
+msgid "Minutes"
+msgstr "minutes"
+
+#: id:12392
+msgid "Hours"
+msgstr "heures"
+
+#: id:12393
+msgid "Days"
+msgstr "jours"
+
+#: id:12394
+msgid "Total uptime"
+msgstr "Temps de fonctionnement total"
+
+#: id:12395
+msgid "Battery level"
+msgstr "Niveau de batterie"
+
+#: id:12600
+msgctxt "Auto context with id 12600"
+msgid "Weather"
+msgstr "Météo"
+
+#: id:12900
+msgctxt "Auto context with id 12900"
+msgid "Screensaver"
+msgstr "Écran de veille"
+
+#: id:12901
+msgid "Fullscreen OSD"
+msgstr "Réglages plein écran"
+
+#: id:13000
+msgid "System"
+msgstr "Système"
+
+#: id:13001
+msgid "Immediate HD spindown"
+msgstr "Ralentissement immédiat du DD"
+
+#: id:13002
+msgid "Video only"
+msgstr "Vidéo seulement"
+
+#: id:13003
+msgid "- Delay"
+msgstr "- Délai"
+
+#: id:13004
+msgid "- Minimum file duration"
+msgstr "- Durée minimale du fichier"
+
+#: id:13005
+msgid "Shutdown"
+msgstr "Éteindre"
+
+#: id:13008
+msgid "Shutdown function"
+msgstr "Mode d'arrêt par défaut"
+
+#: id:13009
+msgid "Quit"
+msgstr "Quitter"
+
+#: id:13010
+msgid "Hibernate"
+msgstr "Mettre en veille"
+
+#: id:13011
+msgid "Suspend"
+msgstr "Suspendre"
+
+#: id:13012
+msgid "Exit"
+msgstr "Sortir"
+
+#: id:13013
+msgid "Reboot"
+msgstr "Redémarrer"
+
+#: id:13014
+msgid "Minimize"
+msgstr "Minimiser"
+
+#: id:13015
+msgid "Power button action"
+msgstr "Action du bouton Power"
+
+#: id:13016
+msgid "Power off System"
+msgstr "Arrêt du système"
+
+#: id:13020
+msgid "Is another session active, perhaps over ssh?"
+msgstr "Une autre session est en cours, peut être en ssh ?"
+
+#: id:13021
+msgid "Mounted removable harddrive"
+msgstr "Disque dur externe monté"
+
+#: id:13022
+msgid "Unsafe device removal"
+msgstr "Déconnexion non sécurisée du périphérique"
+
+#: id:13023
+msgid "Successfully removed device"
+msgstr "Périphérique déconnecté avec succès"
+
+#: id:13024
+msgid "Joystick plugged"
+msgstr "Manette connectée"
+
+#: id:13025
+msgid "Joystick unplugged"
+msgstr "Manette déconnectée"
+
+#: id:13050
+msgid "Running low on battery"
+msgstr "Batterie faible"
+
+#: id:13100
+msgid "Flicker filter"
+msgstr "Filtre de scintillement"
+
+#: id:13101
+msgid "Let driver choose (requires restart)"
+msgstr "Laisser le pilote choisir (redémarrage nécessaire)"
+
+#: id:13105
+msgid "Vertical blank sync"
+msgstr "Sync. Verticale"
+
+#: id:13106
+msgctxt "Auto context with id 13106"
+msgid "Disabled"
+msgstr "Désactivée"
+
+#: id:13107
+msgid "Enabled during video playback"
+msgstr "Activée pendant la lecture vidéo"
+
+#: id:13108
+msgctxt "Auto context with id 13108"
+msgid "Always enabled"
+msgstr "Toujours activée"
+
+#: id:13109
+msgid "Test & apply resolution"
+msgstr "Tester & appliquer la résolution"
+
+#: id:13110
+msgid "Save resolution?"
+msgstr "Appliquer cette résolution ?"
+
+#: id:13111
+msgid "Would you like to keep this resolution?"
+msgstr "Voulez-vous garder cette résolution ?"
+
+#: id:13112
+msgid "High quality upscaling"
+msgstr "Upscaling Haute Qualité"
+
+#: id:13113
+msgctxt "Auto context with id 13113"
+msgid "Disabled"
+msgstr "Désactivé"
+
+#: id:13114
+msgid "Enabled for SD content"
+msgstr "Activé pour contenu SD"
+
+#: id:13115
+msgctxt "Auto context with id 13115"
+msgid "Always enabled"
+msgstr "Toujours activé"
+
+#: id:13116
+msgid "Upscaling method"
+msgstr "Méthode d'Upscaling"
+
+#: id:13117
+msgctxt "Auto context with id 13117"
+msgid "Bicubic"
+msgstr "Bicubique"
+
+#: id:13118
+msgid "Lanczos"
+msgstr "Lanczos"
+
+#: id:13119
+msgid "Sinc"
+msgstr "Sinc"
+
+#: id:13120
+msgctxt "Auto context with id 13120"
+msgid "VDPAU"
+msgstr "VDPAU"
+
+#: id:13121
+msgid "VDPAU HQ Upscaling level"
+msgstr "VDPAU niveau Upscaling HQ"
+
+#: id:13122
+msgid "VDPAU Studio level color conversion"
+msgstr "VDPAU niveau Studio conversion des couleurs"
+
+#: id:13130
+msgid "Blank other displays"
+msgstr "Vider les autres écrans"
+
+#: id:13131
+msgctxt "Auto context with id 13131"
+msgid "Disabled"
+msgstr "Désactivé"
+
+#: id:13132
+msgid "Blank displays"
+msgstr "Activer Blanking"
+
+#: id:13140
+msgid "Active connections detected!"
+msgstr "Connexions actives détectées !"
+
+#: id:13141
+msgid "If you proceed, you might not be able to control XBMC"
+msgstr "Si vous continuez vous ne serez plus en mesure de"
+
+#: id:13142
+msgid "any longer. Are you sure you want to stop the Event server?"
+msgstr "contrôler XBMC. Êtes-vous sûr d'arrêter le serveur ?"
+
+#: id:13144
+msgid "Change Apple Remote mode?"
+msgstr "Changer le mode Apple Remote ?"
+
+#: id:13145
+msgid "If you are currently using the Apple Remote to control"
+msgstr "Si vous utilisez actuellement la télécommande Apple pour contrôler"
+
+#: id:13146
+msgid "XBMC, changing this setting might affect your ability"
+msgstr "XBMC, le changement de ce paramètre peut affecter la capacité"
+
+#: id:13147
+msgid "to continue controlling it. Do you want to proceed?"
+msgstr "à contrôler celui-ci. Effectuer la modification ?"
+
+#: id:13159
+msgid "Subnet mask"
+msgstr "Masque de sous-réseau"
+
+#: id:13160
+msgid "Gateway"
+msgstr "Passerelle"
+
+#: id:13161
+msgid "Primary DNS"
+msgstr "DNS Primaire"
+
+#: id:13162
+msgid "Initialize failed"
+msgstr "Échec lors de l'initialisation"
+
+#: id:13170
+msgctxt "Auto context with id 13170"
+msgid "Never"
+msgstr "Jamais"
+
+#: id:13171
+msgid "Immediately"
+msgstr "Immédiatement"
+
+#: id:13172
+msgid "After %i secs"
+msgstr "Après %i secs"
+
+#: id:13173
+msgid "HDD install date:"
+msgstr "HDD Installé le :"
+
+#: id:13174
+msgid "HDD power cycle count:"
+msgstr "HDD Nb. de cycles marche/arrêt complets :"
+
+#: id:13200
+msgid "Profiles"
+msgstr "Profils"
+
+#: id:13201
+msgid "Delete profile '%s'?"
+msgstr "Supprimer le profil '%s' ?"
+
+#: id:13204
+msgid "Last loaded profile:"
+msgstr "Dernier profil chargé"
+
+#: id:13205
+msgid "Unknown"
+msgstr "Inconnu"
+
+#: id:13206
+msgid "Overwrite"
+msgstr "Écraser"
+
+#: id:13208
+msgid "Alarm clock"
+msgstr "Alarme"
+
+#: id:13209
+msgid "Alarm clock interval (in minutes)"
+msgstr "Intervalle d'alarme (en minutes)"
+
+#: id:13210
+msgid "Started, alarm in %im"
+msgstr "Démarré, alarme dans %im"
+
+#: id:13211
+msgid "Alarm!"
+msgstr "Alarme !"
+
+#: id:13212
+msgid "Canceled with %im%is left"
+msgstr "Annulé avec %im%is restantes"
+
+#: id:13213
+msgid "%2.0fm"
+msgstr "%2.0fm"
+
+#: id:13214
+msgid "%2.0fs"
+msgstr "%2.0fs"
+
+#: id:13249
+msgid "Search for subtitles in RARs"
+msgstr "Recherche de sous-titres dans les RARs"
+
+#: id:13250
+msgid "Browse for subtitle..."
+msgstr "Recherche d'un sous-titre..."
+
+#: id:13251
+msgid "Move item"
+msgstr "Déplacer"
+
+#: id:13252
+msgid "Move item here"
+msgstr "Déplacer ici"
+
+#: id:13253
+msgid "Cancel move"
+msgstr "Annuler le déplacement"
+
+#: id:13270
+msgid "Hardware:"
+msgstr "Matériel :"
+
+#: id:13271
+msgid "CPU Usage:"
+msgstr "Utilisation CPU :"
+
+#: id:13274
+msgid "Connected, but no DNS is available."
+msgstr "Connecté, mais aucun DNS disponible."
+
+#: id:13275
+msgid "Hard Disk"
+msgstr "Disque Dur"
+
+#: id:13276
+msgid "DVD-ROM"
+msgstr "DVD-ROM"
+
+#: id:13277
+msgctxt "Auto context with id 13277"
+msgid "Storage"
+msgstr "Stockage"
+
+#: id:13278
+msgctxt "Auto context with id 13278"
+msgid "Default"
+msgstr "Défaut"
+
+#: id:13279
+msgctxt "Auto context with id 13279"
+msgid "Network"
+msgstr "Réseau"
+
+#: id:13280
+msgctxt "Auto context with id 13280"
+msgid "Video"
+msgstr "Vidéo"
+
+#: id:13281
+msgid "Hardware"
+msgstr "Matériel"
+
+#: id:13283
+msgid "Operating system:"
+msgstr "Système d'exploitation :"
+
+#: id:13284
+msgid "CPU speed:"
+msgstr "Vitesse du CPU :"
+
+#: id:13286
+msgid "Video encoder:"
+msgstr "Encodeur Vidéo :"
+
+#: id:13287
+msgid "Screen resolution:"
+msgstr "Résolution de l'écran :"
+
+#: id:13292
+msgid "A/V cable:"
+msgstr "Câble A/V :"
+
+#: id:13294
+msgid "DVD region:"
+msgstr "Région DVD :"
+
+#: id:13295
+msgid "Internet:"
+msgstr "Internet :"
+
+#: id:13296
+msgctxt "Auto context with id 13296"
+msgid "Connected"
+msgstr "connecté"
+
+#: id:13297
+msgid "Not connected. Check network settings."
+msgstr "non connecté. Vérifiez vos paramètres réseau."
+
+#: id:13299
+msgid "Target temperature"
+msgstr "Température de consigne"
+
+#: id:13300
+msgid "Fan speed"
+msgstr "Vitesse du ventilateur"
+
+#: id:13301
+msgid "Auto temperature control"
+msgstr "Contrôle automatique de la température"
+
+#: id:13302
+msgid "Fan speed override"
+msgstr "Contrôle de la vitesse du ventilateur"
+
+#: id:13303
+msgid "- Fonts"
+msgstr "- Polices"
+
+#: id:13304
+msgid "Enable flipping bi-directional strings"
+msgstr "Activer le basculement bi-directionnel des strings"
+
+#: id:13305
+msgid "Show RSS news feeds"
+msgstr "Afficher les flux RSS"
+
+#: id:13306
+msgid "Show parent folder items"
+msgstr "Afficher l'accès au répertoire parent"
+
+#: id:13307
+msgid "Track naming template"
+msgstr "Mise en forme des titres"
+
+#: id:13308
+msgid "Do you wish to reboot your system"
+msgstr "Voulez-vous redémarrer le système"
+
+#: id:13309
+msgid "instead of just XBMC?"
+msgstr "au lieu de redémarrer simplement XBMC ?"
+
+#: id:13310
+msgid "Zoom effect"
+msgstr "Effet de zoom"
+
+#: id:13311
+msgid "Float effect"
+msgstr "Effet de flottement"
+
+#: id:13312
+msgid "Black bar reduction"
+msgstr "Réduction de la barre noire"
+
+#: id:13313
+msgid "Restart"
+msgstr "Redémarrer"
+
+#: id:13314
+msgid "Crossfade between songs"
+msgstr "Fondu-enchainé entre les chansons"
+
+#: id:13315
+msgid "Regenerate thumbnails"
+msgstr "Régénérer les vignettes"
+
+#: id:13316
+msgid "Recursive thumbnails"
+msgstr "Vignettes récursives"
+
+#: id:13317
+msgid "View slideshow"
+msgstr "Voir le diaporama"
+
+#: id:13318
+msgid "Recursive slideshow"
+msgstr "Diaporama récursif"
+
+#: id:13319
+msgid "Randomize"
+msgstr "Aléatoire"
+
+#: id:13320
+msgid "Stereo"
+msgstr "Stéréo"
+
+#: id:13321
+msgid "Left only"
+msgstr "Gauche seulement"
+
+#: id:13322
+msgid "Right only"
+msgstr "Droite seulement"
+
+#: id:13323
+msgid "Enable karaoke support"
+msgstr "Activer support karaoké"
+
+#: id:13324
+msgid "Background transparency"
+msgstr "Transparence de l'arrière plan"
+
+#: id:13325
+msgid "Foreground transparency"
+msgstr "Transparence du premier plan"
+
+#: id:13326
+msgid "A/V delay"
+msgstr "Délai A/V"
+
+#: id:13327
+msgid "Karaoke"
+msgstr "Karaoké"
+
+#: id:13328
+msgid "%s not found"
+msgstr "%s non trouvé."
+
+#: id:13329
+msgid "Error opening %s"
+msgstr "Impossible d'ouvrir %s"
+
+#: id:13330
+msgid "Unable to load %s"
+msgstr "Impossible de charger %s"
+
+#: id:13331
+msgid "Error: Out of memory"
+msgstr "Erreur : mémoire insuffisante."
+
+#: id:13332
+msgid "Move up"
+msgstr "Monter"
+
+#: id:13333
+msgid "Move down"
+msgstr "Descendre"
+
+#: id:13334
+msgid "Edit label"
+msgstr "Éditer le nom"
+
+#: id:13335
+msgid "Make default"
+msgstr "Mettre par défaut"
+
+#: id:13336
+msgid "Remove button"
+msgstr "Supprimer"
+
+#: id:13340
+msgid "Leave as is"
+msgstr "Par défaut"
+
+#: id:13341
+msgid "Green"
+msgstr "Verte"
+
+#: id:13342
+msgid "Orange"
+msgstr "Orange"
+
+#: id:13343
+msgid "Red"
+msgstr "Rouge"
+
+#: id:13344
+msgid "Cycle"
+msgstr "Cyclique"
+
+#: id:13345
+msgid "Switch LED off on playback"
+msgstr "Éteindre la LED pendant la lecture"
+
+#: id:13346
+msgctxt "Auto context with id 13346"
+msgid "Movie information"
+msgstr "Informations du film"
+
+#: id:13347
+msgid "Queue item"
+msgstr "Ajouter"
+
+#: id:13348
+msgid "Search IMDb..."
+msgstr "Chercher sur IMDb..."
+
+#: id:13349
+msgid "Scan for new content"
+msgstr "Scanner pour du nouveau contenu"
+
+#: id:13350
+msgid "Now playing..."
+msgstr "Lecture en cours..."
+
+#: id:13351
+msgctxt "Auto context with id 13351"
+msgid "Album information"
+msgstr "Information sur l'album"
+
+#: id:13352
+msgid "Scan item to library"
+msgstr "Scanner vers la Médiathèque"
+
+#: id:13353
+msgid "Stop scanning"
+msgstr "Arrêter le scan"
+
+#: id:13354
+msgctxt "Auto context with id 13354"
+msgid "Render method"
+msgstr "Méthode de rendu :"
+
+#: id:13355
+msgid "Low quality pixel shader"
+msgstr "Pixel shader basse qualité"
+
+#: id:13356
+msgid "Hardware overlays"
+msgstr "Traitement matériel"
+
+#: id:13357
+msgid "High quality pixel shader"
+msgstr "Pixel shader haute qualité"
+
+#: id:13358
+msgid "Play item"
+msgstr "Lire"
+
+#: id:13359
+msgid "Set artist thumb"
+msgstr "Définir image artiste"
+
+#: id:13360
+msgid "Automatically generate thumbnails"
+msgstr "Générer automatiquement les vignettes"
+
+#: id:13361
+msgid "Enable voice"
+msgstr "Activer la voix"
+
+#: id:13375
+msgid "Enable device"
+msgstr "Activer le périphérique"
+
+#: id:13376
+msgid "Volume"
+msgstr "Volume"
+
+#: id:13377
+msgid "Default view mode"
+msgstr "Affichage par défaut"
+
+#: id:13378
+msgid "Default brightness"
+msgstr "Luminosité par défaut"
+
+#: id:13379
+msgid "Default contrast"
+msgstr "Contraste par défaut"
+
+#: id:13380
+msgid "Default gamma"
+msgstr "Gamma par défaut"
+
+#: id:13381
+msgid "Resume video"
+msgstr "Reprendre la vidéo"
+
+#: id:13382
+msgid "Voice mask - Port 1"
+msgstr "Masque voix - Port 1"
+
+#: id:13383
+msgid "Voice mask - Port 2"
+msgstr "Masque voix - Port 2"
+
+#: id:13384
+msgid "Voice mask - Port 3"
+msgstr "Masque voix - Port 3"
+
+#: id:13385
+msgid "Voice mask - Port 4"
+msgstr "Masque voix - Port 4"
+
+#: id:13386
+msgid "Use time based seeking"
+msgstr "Utiliser le déplacement sur la base temps"
+
+#: id:13387
+msgid "Track naming template - right"
+msgstr "Infos des titres à droite"
+
+#: id:13388
+msgid "Preset"
+msgstr "Préréglages"
+
+#: id:13389
+msgid "There are no presets available\nfor this visualization"
+msgstr "Il n'y a pas de préréglages disponibles\npour cette visualisation"
+
+#: id:13390
+msgid "There are no settings available\nfor this visualization"
+msgstr "Il n'y a pas de paramètres disponibles\npour cette visualisation"
+
+#: id:13391
+msgid "Eject/Load"
+msgstr "Éjecter/Fermer"
+
+#: id:13392
+msgid "Use visualization if playing audio"
+msgstr "Utiliser visualisation si lecture audio"
+
+#: id:13393
+msgid "Calculate size"
+msgstr "Calculer la taille"
+
+#: id:13394
+msgid "Calculating folder size"
+msgstr "Calcul de la taille du répertoire"
+
+#: id:13395
+msgid "Video settings"
+msgstr "Configurations vidéo"
+
+#: id:13396
+msgid "Audio and subtitle settings"
+msgstr "Configurations audio et sous-titres"
+
+#: id:13397
+msgid "Enable subtitles"
+msgstr "Activer les sous-titres"
+
+#: id:13398
+msgctxt "Auto context with id 13398"
+msgid "Shortcuts"
+msgstr "Raccourcis"
+
+#: id:13399
+msgid "Ignore articles when sorting (e.g. \"the\")"
+msgstr "Ignorer les articles définis lors du tri (ex : \"Le\")"
+
+#: id:13400
+msgid "Crossfade between songs on the same album"
+msgstr "Fondu-enchainé des morceaux d'un même album"
+
+#: id:13401
+msgid "Browse for %s"
+msgstr "Recherche de %s"
+
+#: id:13402
+msgid "Show track position"
+msgstr "Montrer la position de la piste"
+
+#: id:13403
+msgid "Clear default"
+msgstr "Effacer la source par défaut"
+
+#: id:13404
+msgid "Resume"
+msgstr "Reprendre"
+
+#: id:13405
+msgid "Get thumb"
+msgstr "Vignette"
+
+#: id:13406
+msgid "Picture information"
+msgstr "Informations de l'image"
+
+#: id:13407
+msgid "%s presets"
+msgstr "%s préréglages"
+
+#: id:13408
+msgid "(IMDb user rating)"
+msgstr "(Note Spectateurs IMDb)"
+
+#: id:13409
+msgid "Top 250"
+msgstr "Top 250 :"
+
+#: id:13410
+msgid "Tune in on Last.fm"
+msgstr "Envoyer sur Last.fm"
+
+#: id:13411
+msgid "Minimum fan speed"
+msgstr "Vitesse du ventilateur au minimum"
+
+#: id:13412
+msgid "Play from here"
+msgstr "Lire à partir de cet épisode"
+
+#: id:13413
+msgid "Downloading"
+msgstr "Téléchargement"
+
+#: id:13414
+msgid "Include artists who appear only on compilations"
+msgstr "Afficher les artistes apparaissant uniquement sur les compilations"
+
+#: id:13415
+msgctxt "Auto context with id 13415"
+msgid "Render method"
+msgstr "Méthode de rendu"
+
+#: id:13416
+msgid "Auto detect"
+msgstr "Détection auto"
+
+#: id:13417
+msgid "Basic shaders (ARB)"
+msgstr "Shaders Basiques (ARB)"
+
+#: id:13418
+msgid "Advanced shaders (GLSL)"
+msgstr "Shaders Avancés (GLSL)"
+
+#: id:13419
+msgid "Software"
+msgstr "Logiciel"
+
+#: id:13420
+msgid "Remove safely"
+msgstr "Retirer en toute sécurité"
+
+#: id:13421
+msgctxt "Auto context with id 13421"
+msgid "VDPAU"
+msgstr "VDPAU"
+
+#: id:13422
+msgid "Start slideshow here"
+msgstr "Démarrer le diaporama ici"
+
+#: id:13423
+msgid "Remember for this path"
+msgstr "Retenir pour ce chemin"
+
+#: id:13424
+msgid "Use pixel buffer objects"
+msgstr "Utiliser le pixel buffer"
+
+#: id:13425
+msgid "Allow hardware acceleration (VDPAU)"
+msgstr "Activer l'accélération matérielle (VDPAU)"
+
+#: id:13426
+msgid "Allow hardware acceleration (VAAPI)"
+msgstr "Activer l'accélération matérielle (VAAPI)"
+
+#: id:13427
+msgid "Allow hardware acceleration (DXVA2)"
+msgstr "Activer l'accélération matérielle (DXVA2)"
+
+#: id:13428
+msgid "Allow hardware acceleration (CrystalHD)"
+msgstr "Activer l'accélération matérielle (CrystalHD)"
+
+#: id:13429
+msgid "Allow hardware acceleration (VDADecoder)"
+msgstr "Activer l'accélération matérielle (VDADecoder)"
+
+#: id:13430
+msgid "Allow hardware acceleration (OpenMax)"
+msgstr "Activer l'accélération matérielle (OpenMax)"
+
+#: id:13431
+msgid "Pixel Shaders"
+msgstr "Pixel Shaders"
+
+#: id:13432
+msgid "Allow hardware acceleration (VideoToolbox)"
+msgstr "Autoriser l'accélération matérielle (VideoToolbox)"
+
+#: id:13500
+msgid "A/V sync method"
+msgstr "Méthode de synchro. A/V"
+
+#: id:13501
+msgid "Audio clock"
+msgstr "Horloge audio"
+
+#: id:13502
+msgid "Video clock (Drop/Dupe audio)"
+msgstr "Horloge vidéo (Drop/Dupe audio)"
+
+#: id:13503
+msgid "Video clock (Resample audio)"
+msgstr "Horloge vidéo (Resample audio)"
+
+#: id:13504
+msgid "Maximum resample amount (%)"
+msgstr "Taux de rééchantillonnage maximal (%)"
+
+#: id:13505
+msgid "Resample quality"
+msgstr "Qualité du rééchantillonnage"
+
+#: id:13506
+msgid "Low(fast)"
+msgstr "Faible(rapide)"
+
+#: id:13507
+msgctxt "Auto context with id 13507"
+msgid "Medium"
+msgstr "Moyenne"
+
+#: id:13508
+msgctxt "Auto context with id 13508"
+msgid "High"
+msgstr "Haute"
+
+#: id:13509
+msgid "Really high(slow!)"
+msgstr "Vraiment élevée (lent !)"
+
+#: id:13510
+msgid "Sync playback to display"
+msgstr "Synchro. lecture avec affichage"
+
+#: id:13550
+msgid "Pause during refresh rate change"
+msgstr "Pause pendant le changement de fréquence"
+
+#: id:13551
+msgctxt "Auto context with id 13551"
+msgid "Off"
+msgstr "Off"
+
+#: id:13552
+msgid "%.1f Second"
+msgstr "%.1f Seconde"
+
+#: id:13553
+msgid "%.1f Seconds"
+msgstr "%.1f Secondes"
+
+#: id:13600
+msgid "Apple remote"
+msgstr "Télécommande Apple"
+
+#: id:13602
+msgid "Allow start of XBMC using the remote"
+msgstr "Permettre le démarrage de XBMC par la télécommande"
+
+#: id:13603
+msgid "Sequence delay time"
+msgstr "Temps de délai de séquence"
+
+#: id:13610
+msgctxt "Auto context with id 13610"
+msgid "Disabled"
+msgstr "Désactivé"
+
+#: id:13611
+msgctxt "Auto context with id 13611"
+msgid "Standard"
+msgstr "Standard"
+
+#: id:13612
+msgid "Universal Remote"
+msgstr "Télécommande universelle"
+
+#: id:13613
+msgid "Multi Remote (Harmony)"
+msgstr "Télécommande multiple (Harmony)"
+
+#: id:13620
+msgid "Apple Remote Error"
+msgstr "Erreur Apple Remote."
+
+#: id:13621
+msgid "Apple Remote support could be enabled."
+msgstr "Le support de la télécommande Apple ne peut être activé."
+
+#: id:14000
+msgid "Stack"
+msgstr "Empiler"
+
+#: id:14001
+msgid "Unstack"
+msgstr "Dépiler"
+
+#: id:14003
+msgid "Downloading playlist file..."
+msgstr "Téléchargement de la playliste..."
+
+#: id:14004
+msgid "Downloading streams list..."
+msgstr "Téléchargement de la liste des flux..."
+
+#: id:14005
+msgid "Parsing streams list..."
+msgstr "Scan de la liste des flux..."
+
+#: id:14006
+msgid "Downloading streams list failed"
+msgstr "Échec du téléchargement de la liste des flux"
+
+#: id:14007
+msgid "Downloading playlist file failed"
+msgstr "Échec du téléchargement de la playliste"
+
+#: id:14009
+msgid "Games directory"
+msgstr "Répertoire des jeux"
+
+#: id:14010
+msgid "Auto switch to thumbs based on"
+msgstr "Basculement des vignettes basées sur"
+
+#: id:14011
+msgid "Enable auto switching to thumbs view"
+msgstr "Activer le basculement"
+
+#: id:14012
+msgid "- Use large icons"
+msgstr "- Utiliser les affiches"
+
+#: id:14013
+msgid "- Switch based on"
+msgstr "- Basculement basé sur"
+
+#: id:14014
+msgid "- Percentage"
+msgstr "- Pourcentage"
+
+#: id:14015
+msgid "No files and at least one thumb"
+msgstr "Aucun fichier et au moins 1 vignette"
+
+#: id:14016
+msgid "At least one file and thumb"
+msgstr "Au moins 1 fichier et 1 vignette"
+
+#: id:14017
+msgid "Percentage of thumbs"
+msgstr "Pourcentage des vignettes"
+
+#: id:14018
+msgid "View options"
+msgstr "Options d'affichage"
+
+#: id:14019
+msgid "Change area code 1"
+msgstr "Définir lieu 1"
+
+#: id:14020
+msgid "Change area code 2"
+msgstr "Définir lieu 2"
+
+#: id:14021
+msgid "Change area code 3"
+msgstr "Définir lieu 3"
+
+#: id:14022
+msgctxt "Auto context with id 14022"
+msgid "Library"
+msgstr "Médiathèque"
+
+#: id:14023
+msgid "No TV"
+msgstr "Sans TV"
+
+#: id:14024
+msgid "Enter the nearest large town"
+msgstr "Saisissez la ville la plus proche"
+
+#: id:14025
+msgid "Video/Audio/DVD cache - Harddisk"
+msgstr "Cache vidéo/audio/DVD - Disque dur"
+
+#: id:14026
+msgid "Video cache - DVD-ROM"
+msgstr "Cache vidéo - DVDRom"
+
+#: id:14027
+msgctxt "Auto context with id 14027"
+msgid "- Local Network"
+msgstr "- Réseau local"
+
+#: id:14028
+msgctxt "Auto context with id 14028"
+msgid "- Internet"
+msgstr "- Internet"
+
+#: id:14030
+msgid "Audio cache - DVD-ROM"
+msgstr "Cache audio - DVDRom"
+
+#: id:14031
+msgctxt "Auto context with id 14031"
+msgid "- Local Network"
+msgstr "- Réseau local"
+
+#: id:14032
+msgctxt "Auto context with id 14032"
+msgid "- Internet"
+msgstr "- Internet"
+
+#: id:14034
+msgid "DVD cache - DVD-ROM"
+msgstr "Cache DVD - DVDRom"
+
+#: id:14035
+msgctxt "Auto context with id 14035"
+msgid "- Local Network"
+msgstr "- Réseau Local"
+
+#: id:14036
+msgctxt "Auto context with id 14036"
+msgid "Services"
+msgstr "Services"
+
+#: id:14038
+msgid "Network settings changed"
+msgstr "Les paramètres réseau ont été changés"
+
+#: id:14039
+msgid "XBMC requires to restart to change your"
+msgstr "Vous venez de modifier les paramètres réseau."
+
+#: id:14040
+msgid "network setup. Would you like to restart now?"
+msgstr "Redémarrer XBMC pour appliquer les changements ?"
+
+#: id:14041
+msgid "Internet connection bandwidth limitation"
+msgstr "Limiter la bande passante de la connexion Internet"
+
+#: id:14043
+msgid "- Shutdown while playing"
+msgstr "- Éteindre pendant la lecture"
+
+#: id:14044
+msgid "%i min"
+msgstr "%i min"
+
+#: id:14045
+msgid "%i sec"
+msgstr "%i sec"
+
+#: id:14046
+msgid "%i ms"
+msgstr "%i ms"
+
+#: id:14047
+msgid "%i %%"
+msgstr "%i %%"
+
+#: id:14048
+msgid "%i kbps"
+msgstr "%i kbps"
+
+#: id:14049
+msgid "%i kb"
+msgstr "%i kb"
+
+#: id:14050
+msgid "%i.0 dB"
+msgstr "%i.0 dB"
+
+#: id:14051
+msgid "Time format"
+msgstr "Format de l'heure"
+
+#: id:14052
+msgid "Date format"
+msgstr "Format de la date"
+
+#: id:14053
+msgid "GUI filters"
+msgstr "Filtres Interface"
+
+#: id:14055
+msgid "Use background scanning"
+msgstr "Utiliser le scan en tâche de fond"
+
+#: id:14056
+msgid "Stop scan"
+msgstr "Stopper le scan"
+
+#: id:14057
+msgid "Not possible while scanning for media info"
+msgstr "Impossible d'afficher les infos lors du scan"
+
+#: id:14058
+msgid "Film grain effect"
+msgstr "Effet de grain sur les films"
+
+#: id:14059
+msgid "Search for thumbnails on remote shares"
+msgstr "Rechercher les vignettes sur les partages distants"
+
+#: id:14060
+msgid "Unknown type cache - Internet"
+msgstr "Cache inconnu - Internet"
+
+#: id:14061
+msgctxt "Auto context with id 14061"
+msgid "Auto"
+msgstr "Auto"
+
+#: id:14062
+msgid "Enter username for"
+msgstr "Saisissez le nom d'utilisateur pour"
+
+#: id:14063
+msgid "Date & time"
+msgstr "Date & Heure"
+
+#: id:14064
+msgid "Set date"
+msgstr "Configurer la date"
+
+#: id:14065
+msgid "Set time"
+msgstr "Configurer l'heure"
+
+#: id:14066
+msgid "Enter the time in 24 hour HH:MM format"
+msgstr "Saisissez l'heure dans ce format HH:MM 24 heures"
+
+#: id:14067
+msgid "Enter the date in DD/MM/YYYY format"
+msgstr "Saisissez la date dans ce format JJ/MM/AAAA"
+
+#: id:14068
+msgid "Enter the IP address"
+msgstr "Saisissez l'adresse IP"
+
+#: id:14069
+msgid "Apply these settings now?"
+msgstr "Voulez-vous appliquer cette configuration ?"
+
+#: id:14070
+msgid "Apply changes now"
+msgstr "Appliquer les changements maintenant"
+
+#: id:14071
+msgid "Allow file renaming and deletion"
+msgstr "Permettre de renommer et supprimer"
+
+#: id:14074
+msgid "Set timezone"
+msgstr "Définir le fuseau horaire"
+
+#: id:14075
+msgid "Use daylight saving time"
+msgstr "Ajuster l'horloge pour l'observation auto. de l'heure d'été"
+
+#: id:14076
+msgid "Add to favourites"
+msgstr "Ajouter aux favoris"
+
+#: id:14077
+msgid "Remove from favourites"
+msgstr "Enlever des favoris"
+
+#: id:14078
+msgctxt "Auto context with id 14078"
+msgid "- Colours"
+msgstr "- Couleurs"
+
+#: id:14079
+msgid "Timezone country"
+msgstr "Pays fuseau horaire"
+
+#: id:14080
+msgid "Timezone"
+msgstr "Fuseau horaire"
+
+#: id:14081
+msgid "File lists"
+msgstr "Listes de fichiers"
+
+#: id:14082
+msgid "Show EXIF picture information"
+msgstr "Afficher les informations EXIF des images"
+
+#: id:14083
+msgid "Use a fullscreen window rather than true fullscreen"
+msgstr "Utilisez une fenêtre plein écran à la place du vrai plein écran"
+
+#: id:14084
+msgid "Queue songs on selection"
+msgstr "File d'attente des chansons dans la sélection"
+
+#: id:14086
+msgid "Playback"
+msgstr "Lecture"
+
+#: id:14087
+msgid "DVDs"
+msgstr "DVDs"
+
+#: id:14088
+msgid "Play DVDs automatically"
+msgstr "Lire les DVD automatiquement"
+
+#: id:14089
+msgid "Font to use for text subtitles"
+msgstr "Police à utiliser pour les sous-titres"
+
+#: id:14090
+msgid "International"
+msgstr "Région"
+
+#: id:14091
+msgid "Character set"
+msgstr "Jeu de caractères"
+
+#: id:14092
+msgid "Debugging"
+msgstr "Debogage"
+
+#: id:14093
+msgid "Security"
+msgstr "Sécurité"
+
+#: id:14094
+msgid "Input devices"
+msgstr "Périphériques"
+
+#: id:14095
+msgid "Power saving"
+msgstr "Gestion de l'énergie"
+
+#: id:14096
+msgid "Rip"
+msgstr ""
+
+#: id:14097
+msgid "Audio CD Insert Action"
+msgstr ""
+
+#: id:14098
+msgctxt "Auto context with id 14098"
+msgid "Play"
+msgstr ""
+
+#: id:14099
+msgid "Eject disc when CD ripping is complete"
+msgstr ""
+
+#: id:15015
+msgctxt "Auto context with id 15015"
+msgid "Remove"
+msgstr "Supprimer"
+
+#: id:15016
+msgid "Games"
+msgstr "Jeux"
+
+#: id:15019
+msgid "Add"
+msgstr "Ajouter"
+
+#: id:15052
+msgid "Password"
+msgstr "Mot de passe"
+
+#: id:15100
+msgctxt "Auto context with id 15100"
+msgid "Library"
+msgstr "Médiathèque"
+
+#: id:15101
+msgid "Database"
+msgstr "Base de données"
+
+#: id:15102
+msgid "* All albums"
+msgstr "* Tous les albums"
+
+#: id:15103
+msgid "* All artists"
+msgstr "* Tous les artistes"
+
+#: id:15104
+msgid "* All songs"
+msgstr "* Toutes les chansons"
+
+#: id:15105
+msgid "* All genres"
+msgstr "* Tous les genres"
+
+#: id:15107
+msgid "Buffering..."
+msgstr "Mise en cache..."
+
+#: id:15108
+msgid "Navigation sounds"
+msgstr "Sons de navigation"
+
+#: id:15109
+msgid "Skin default"
+msgstr "Skin par défaut"
+
+#: id:15111
+msgid "- Theme"
+msgstr "- Thème"
+
+#: id:15112
+msgid "Default theme"
+msgstr "Thème par défaut"
+
+#: id:15200
+msgid "Last.fm"
+msgstr "Last.fm"
+
+#: id:15201
+msgid "Submit songs to Last.fm"
+msgstr "Soumettre les chansons à Last.fm"
+
+#: id:15202
+msgid "Last.fm username"
+msgstr "Nom d'utilisateur Last.fm"
+
+#: id:15203
+msgid "Last.fm password"
+msgstr "Mot de passe Last.fm"
+
+#: id:15204
+msgid "Unable to handshake: sleeping..."
+msgstr "Impossible de contacter le serveur : en attente..."
+
+#: id:15205
+msgid "Please update XBMC"
+msgstr "Merci de mettre à jour XBMC"
+
+#: id:15206
+msgid "Bad authorization: Check username and password"
+msgstr "Autorisation refusée : vérifiez vos identifiants"
+
+#: id:15207
+msgctxt "Auto context with id 15207"
+msgid "Connected"
+msgstr "connecté"
+
+#: id:15208
+msgid "Not connected"
+msgstr "non connecté"
+
+#: id:15209
+msgid "Submit interval %i"
+msgstr "Intervalle de transfert %i"
+
+#: id:15210
+msgid "Cached %i songs"
+msgstr "Mise en cache %i chansons"
+
+#: id:15211
+msgid "Submitting..."
+msgstr "Transfert..."
+
+#: id:15212
+msgid "Submitting in %i secs"
+msgstr "Transfert en %i secs"
+
+#: id:15213
+msgid "Play using..."
+msgstr "Lire avec..."
+
+#: id:15214
+msgid "Use smoothed A/V synchronization"
+msgstr "Utiliser une synchronisation A/V lissée"
+
+#: id:15215
+msgid "Hide file names in thumbs view"
+msgstr "Masquer le nom en vue vignettes"
+
+#: id:15216
+msgid "Play in party mode"
+msgstr "Jouer lors du mix de soirée"
+
+#: id:15217
+msgid "Submit songs to Libre.fm"
+msgstr "Soumettre les chansons à Libre.fm"
+
+#: id:15218
+msgid "Libre.fm username"
+msgstr "Nom d'utilisateur Libre.fm"
+
+#: id:15219
+msgid "Libre.fm password"
+msgstr "Mot de passe Libre.fm"
+
+#: id:15220
+msgid "Libre.fm"
+msgstr "Libre.fm"
+
+#: id:15221
+msgid "Song submission"
+msgstr "Soumettre un titre"
+
+#: id:15250
+msgid "Submit Last.fm radio to Last.fm"
+msgstr "Soumettre la radio Last.fm à Last.fm"
+
+#: id:15251
+msgid "Connecting to Last.fm..."
+msgstr "Connexion à Last.fm..."
+
+#: id:15252
+msgid "Selecting station..."
+msgstr "Sélection de la station..."
+
+#: id:15253
+msgid "Search similar artists..."
+msgstr "Chercher des artistes similaires..."
+
+#: id:15254
+msgid "Search similar tags..."
+msgstr "Chercher des tags similaires..."
+
+#: id:15255
+msgid "Your profile (%name%)"
+msgstr "Votre profil (%name%)"
+
+#: id:15256
+msgid "Overall top tags"
+msgstr "Top Tag général"
+
+#: id:15257
+msgid "Top artists for tag %name%"
+msgstr "Le top Artistes pour le tag %name%"
+
+#: id:15258
+msgid "Top albums for tag %name%"
+msgstr "Le top Albums pour le tag %name%"
+
+#: id:15259
+msgid "Top tracks for tag %name%"
+msgstr "Le top Morceaux pour le tag %name%"
+
+#: id:15260
+msgid "Listen to tag %name% Last.fm radio"
+msgstr "Écouter le tag %name% sur Last.fm Radio"
+
+#: id:15261
+msgid "Similar artists as %name%"
+msgstr "Artistes similaires à %name%"
+
+#: id:15262
+msgid "Top %name% albums"
+msgstr "Le top albums pour %name%"
+
+#: id:15263
+msgid "Top %name% tracks"
+msgstr "Le top morceaux pour %name%"
+
+#: id:15264
+msgid "Top %name% tags"
+msgstr "Le top Tags pour %name%"
+
+#: id:15265
+msgid "Biggest fans of %name%"
+msgstr "Les plus grands fans de %name%"
+
+#: id:15266
+msgid "Listen to %name% fans Last.fm radio"
+msgstr "Écouter les radios Last.fm des fans de %name%"
+
+#: id:15267
+msgid "Listen to %name% similar artists Last.fm radio"
+msgstr "Écouter les radios Last.fm similaires à %name%"
+
+#: id:15268
+msgid "Top artists for user %name%"
+msgstr "Le top Artistes de %name%"
+
+#: id:15269
+msgid "Top albums for user %name%"
+msgstr "Le top Albums de %name%"
+
+#: id:15270
+msgid "Top tracks for user %name%"
+msgstr "Le top Morceaux de %name%"
+
+#: id:15271
+msgid "Friends of user %name%"
+msgstr "Amis de %name%"
+
+#: id:15272
+msgid "Neighbours of user %name%"
+msgstr "Profils d'affinité de %name%"
+
+#: id:15273
+msgid "Weekly artist chart for %name%"
+msgstr "Artistes de la semaine pour %name%"
+
+#: id:15274
+msgid "Weekly album chart for %name%"
+msgstr "Albums de la semaine pour %name%"
+
+#: id:15275
+msgid "Weekly track chart for %name%"
+msgstr "Morceaux de la semaine pour %name%"
+
+#: id:15276
+msgid "Listen to %name%'s neighbours Last.fm radio"
+msgstr "Écouter les radios Last.fm affinitées de %name%"
+
+#: id:15277
+msgid "Listen to %name%'s personal Last.fm radio"
+msgstr "Écouter les radios Last.fm personnelles de %name%"
+
+#: id:15278
+msgid "Listen to %name%'s mix Last.fm radio"
+msgstr "Écouter le mix Last.fm radio de %name%"
+
+#: id:15279
+msgid "Retrieving list from Last.fm..."
+msgstr "Récupération des playlistes depuis Last.fm..."
+
+#: id:15280
+msgid "Can't retrieve list from Last.fm..."
+msgstr "Impossible de récupérer la playliste depuis Last.fm..."
+
+#: id:15281
+msgid "Enter an artist name to find related ones"
+msgstr "Saisissez un nom d'artiste pour en trouver des liés"
+
+#: id:15282
+msgid "Enter a tag name to find similar ones"
+msgstr "Saisissez un nom de tag pour en trouver des semblables"
+
+#: id:15283
+msgid "Tracks recently listened by %name%"
+msgstr "Morceaux écoutés récemment par %name%"
+
+#: id:15284
+msgid "Listen to %name%'s recommendations Last.fm radio"
+msgstr "Écouter les recommandations de la radio Last.fm de %name%"
+
+#: id:15285
+msgid "Top tags for user %name%"
+msgstr "Top tags de l'utilisateur %name%"
+
+#: id:15287
+msgid "Do you want to add the current track to your loved tracks?"
+msgstr "Voulez-vous ajouter le morceau actuel dans vos coups de coeur ?"
+
+#: id:15288
+msgid "Do you want to ban the current track?"
+msgstr "Voulez-vous bannir le morceau actuel ?"
+
+#: id:15289
+msgid "Added to your loved tracks: '%s'."
+msgstr "Ajouté dans vos coups de coeur : '%s'."
+
+#: id:15290
+msgid "Could not add '%s' to your loved tracks."
+msgstr "Impossible d'ajouter '%s' dans vos coups de coeur."
+
+#: id:15291
+msgid "Banned: '%s'."
+msgstr "Banni : '%s'."
+
+#: id:15292
+msgid "Could not ban '%s'."
+msgstr "Impossible de bannir '%s'."
+
+#: id:15293
+msgid "Tracks recently loved by %name%"
+msgstr "Coups de coeur récents de %name%"
+
+#: id:15294
+msgid "Tracks recently banned by %name%"
+msgstr "Bannissements récents par %name%"
+
+#: id:15295
+msgid "Remove from loved tracks"
+msgstr "Supprimé des coups de coeur"
+
+#: id:15296
+msgid "Un-ban"
+msgstr "Réhabiliter"
+
+#: id:15297
+msgid "Do you want to remove this track from your loved tracks?"
+msgstr "Voulez-vous supprimer ce morceau de vos coups de coeur ?"
+
+#: id:15298
+msgid "Do you want to un-ban this track?"
+msgstr "Voulez-vous réhabiliter ce morceau ?"
+
+#: id:15300
+msgid "Path not found or invalid"
+msgstr "Chemin non trouvé ou invalide"
+
+#: id:15301
+msgid "Could not connect to network server"
+msgstr "Impossible de se connecter au serveur"
+
+#: id:15302
+msgid "No servers found"
+msgstr "Serveur non trouvé"
+
+#: id:15303
+msgid "Workgroup not found"
+msgstr "Groupe de travail non trouvé"
+
+#: id:15310
+msgid "Opening multi-path source"
+msgstr "Ouverture des sources multi-chemin"
+
+#: id:15311
+msgid "Path:"
+msgstr "Chemin :"
+
+#: id:16000
+msgctxt "Auto context with id 16000"
+msgid "General"
+msgstr "Général"
+
+#: id:16002
+msgid "Internet lookup"
+msgstr "Recherche internet"
+
+#: id:16003
+msgid "Player"
+msgstr "Lecteur"
+
+#: id:16004
+msgid "Play media from disc"
+msgstr "Jouer les médias depuis le disque"
+
+#: id:16008
+msgid "Enter new title"
+msgstr "Saisissez le nouveau titre"
+
+#: id:16009
+msgid "Enter the movie name"
+msgstr "Saisissez le nom du film"
+
+#: id:16010
+msgid "Enter the profile name"
+msgstr "Saisissez le nom du profil"
+
+#: id:16011
+msgid "Enter the album name"
+msgstr "Saisissez le nom de l'album"
+
+#: id:16012
+msgid "Enter the playlist name"
+msgstr "Saisissez un nom pour votre playliste"
+
+#: id:16013
+msgid "Enter new filename"
+msgstr "Saisissez le nouveau nom du fichier"
+
+#: id:16014
+msgid "Enter folder name"
+msgstr "Saisissez le nom du répertoire"
+
+#: id:16015
+msgid "Enter directory"
+msgstr "Saisissez répertoire"
+
+#: id:16016
+msgid "Available options: %A, %T, %N, %B, %D, %G, %Y, %F, %S"
+msgstr "Options disponibles : %A, %T, %N, %B, %D, %G, %Y, %F, %S"
+
+#: id:16017
+msgid "Enter search string"
+msgstr "Saisissez le nom de votre recherche"
+
+#: id:16018
+msgctxt "Auto context with id 16018"
+msgid "None"
+msgstr "Aucun"
+
+#: id:16019
+msgid "Auto select"
+msgstr "Sélection automatique"
+
+#: id:16020
+msgid "De-interlace"
+msgstr "Désentrelacé"
+
+#: id:16021
+msgid "Bob"
+msgstr "Bob"
+
+#: id:16022
+msgid "Bob (inverted)"
+msgstr "Bob (inversé)"
+
+#: id:16024
+msgid "Canceling..."
+msgstr "Annulation..."
+
+#: id:16025
+msgid "Enter the artist name"
+msgstr "Saisissez le nom de l'artiste"
+
+#: id:16026
+msgid "Playback failed"
+msgstr "La lecture a échoué"
+
+#: id:16027
+msgid "One or more items failed to play."
+msgstr "Un ou plusieurs éléments n'ont pu être joués"
+
+#: id:16028
+msgid "Enter value"
+msgstr "Entrer valeur"
+
+#: id:16029
+msgid "Check the log file for details."
+msgstr "Consultez le fichier de log pour plus de détails."
+
+#: id:16030
+msgid "Party mode aborted."
+msgstr "Mix de soirée annulé."
+
+#: id:16031
+msgid "No matching songs in the library."
+msgstr "Aucune correspondance dans l'audiothèque."
+
+#: id:16032
+msgid "Could not initialize database."
+msgstr "Impossible d'initialiser la base de données."
+
+#: id:16033
+msgid "Could not open database."
+msgstr "Impossible d'ouvrir la base de données."
+
+#: id:16034
+msgid "Could not get songs from database."
+msgstr "Impossible de récupérer les chansons depuis la BDD."
+
+#: id:16035
+msgid "Party mode playlist"
+msgstr "Playliste Mix de soirée"
+
+#: id:16036
+msgid "De-interlace (Half)"
+msgstr "Désentrelacer (moitié)"
+
+#: id:16037
+msgid "Deinterlace video"
+msgstr "Désentrelacer la vidéo"
+
+#: id:16038
+msgid "Deinterlace method"
+msgstr "Méthode de désentrelacement"
+
+#: id:16039
+msgctxt "Auto context with id 16039"
+msgid "Off"
+msgstr "Off"
+
+#: id:16040
+msgctxt "Auto context with id 16040"
+msgid "Auto"
+msgstr "Auto"
+
+#: id:16041
+msgid "On"
+msgstr "On"
+
+#: id:16100
+msgid "All Videos"
+msgstr "Toutes les vidéos"
+
+#: id:16101
+msgid "Unwatched"
+msgstr "Non vues"
+
+#: id:16102
+msgid "Watched"
+msgstr "Vues"
+
+#: id:16103
+msgid "Mark as watched"
+msgstr "Marquer comme vue"
+
+#: id:16104
+msgid "Mark as unwatched"
+msgstr "Marquer comme non vue"
+
+#: id:16105
+msgid "Edit title"
+msgstr "Éditer le titre"
+
+#: id:16200
+msgid "Operation was aborted"
+msgstr "Opération annulée"
+
+#: id:16201
+msgid "Copy failed"
+msgstr "La copie a échouée"
+
+#: id:16202
+msgid "Failed to copy at least one file"
+msgstr "Un ou plusieurs fichiers n’ont pas été copiés"
+
+#: id:16203
+msgid "Move failed"
+msgstr "Le déplacement a échoué"
+
+#: id:16204
+msgid "Failed to move at least one file"
+msgstr "Un ou plusieurs fichiers n’ont pas été déplacés"
+
+#: id:16205
+msgid "Delete failed"
+msgstr "La suppression a échoué"
+
+#: id:16206
+msgid "Failed to delete at least one file"
+msgstr "Un ou plusieurs fichiers n’ont pas été supprimés"
+
+#: id:16300
+msgid "Video scaling method"
+msgstr "Méthode de mise à l'échelle"
+
+#: id:16301
+msgid "Nearest neighbour"
+msgstr "La plus proche"
+
+#: id:16302
+msgid "Bilinear"
+msgstr "Bilinéaire"
+
+#: id:16303
+msgctxt "Auto context with id 16303"
+msgid "Bicubic"
+msgstr "Bicubique"
+
+#: id:16304
+msgid "Lanczos2"
+msgstr "Lanczos2"
+
+#: id:16305
+msgid "Lanczos3"
+msgstr "Lanczos3"
+
+#: id:16306
+msgid "Sinc8"
+msgstr "Sinc8"
+
+#: id:16307
+msgid "Bicubic (software)"
+msgstr "Bicubique (logiciel)"
+
+#: id:16308
+msgid "Lanczos (software)"
+msgstr "Lanczos (logiciel)"
+
+#: id:16309
+msgid "Sinc (software)"
+msgstr "Sinc (logiciel)"
+
+#: id:16310
+msgid "Temporal"
+msgstr "Temporel"
+
+#: id:16311
+msgid "Temporal/Spatial"
+msgstr "Temporel/Spatial"
+
+#: id:16312
+msgid "(VDPAU)Noise Reduction"
+msgstr "(VDPAU)Réduction bruit"
+
+#: id:16313
+msgid "(VDPAU)Sharpness"
+msgstr "(VDPAU)Netteté"
+
+#: id:16314
+msgid "Inverse Telecine"
+msgstr "Téléciné inversé"
+
+#: id:16315
+msgid "Lanczos3 optimized"
+msgstr "Lanczos3 optimisé"
+
+#: id:16316
+msgctxt "Auto context with id 16316"
+msgid "Auto"
+msgstr "Auto"
+
+#: id:16317
+msgid "Temporal (Half)"
+msgstr "Temporel (Demi)"
+
+#: id:16318
+msgid "Temporal/Spatial (Half)"
+msgstr "Temporel/Spatial (Demi)"
+
+#: id:16319
+msgid "DXVA"
+msgstr "DXVA"
+
+#: id:16320
+msgid "DXVA Bob"
+msgstr "DXVA Bob"
+
+#: id:16321
+msgid "DXVA Best"
+msgstr "DXVA Best"
+
+#: id:16322
+msgid "Spline36"
+msgstr "Spline36"
+
+#: id:16323
+msgid "Spline36 optimized"
+msgstr "Spline36 optimized"
+
+#: id:16324
+msgid "Software Blend"
+msgstr "Software Blend"
+
+#: id:16400
+msgid "Post-processing"
+msgstr "Post-processing Vidéo"
+
+#: id:17500
+msgid "Display sleep timeout"
+msgstr "Afficher le temps avant la mise en veille"
+
+#: id:19000
+msgid "Switch to channel"
+msgstr "Changer de canal"
+
+#: id:20000
+msgid "Saved music folder"
+msgstr "Dossier des enregistrements musique"
+
+#: id:20001
+msgid "Use external DVD player"
+msgstr "Utiliser un lecteur DVD externe"
+
+#: id:20002
+msgid "External DVD player"
+msgstr "Lecteur DVD externe"
+
+#: id:20003
+msgid "Trainers folder"
+msgstr "Dossier des trainers"
+
+#: id:20004
+msgid "Screenshot folder"
+msgstr "Dossier des captures d'écran"
+
+#: id:20006
+msgid "Playlists folder"
+msgstr "Dossier des playlistes"
+
+#: id:20007
+msgid "Recordings"
+msgstr "Enregistrements"
+
+#: id:20008
+msgid "Screenshots"
+msgstr "Captures d'écran"
+
+#: id:20009
+msgid "Use XBMC"
+msgstr "Utiliser XBMC"
+
+#: id:20011
+msgid "Music playlists"
+msgstr "Playlistes musicales"
+
+#: id:20012
+msgid "Video playlists"
+msgstr "Playlistes vidéo"
+
+#: id:20013
+msgid "Do you wish to launch the game?"
+msgstr "Voulez-vous lancer le jeu ?"
+
+#: id:20014
+msgid "Sort by: Playlist"
+msgstr "Trier par : Playliste"
+
+#: id:20015
+msgid "Remote thumb"
+msgstr "Distante"
+
+#: id:20016
+msgid "Current thumb"
+msgstr "Actuelle"
+
+#: id:20017
+msgid "Local thumb"
+msgstr "Locale"
+
+#: id:20018
+msgid "No thumb"
+msgstr "Aucune"
+
+#: id:20019
+msgid "Choose thumbnail"
+msgstr "Choisir une vignette"
+
+#: id:20023
+msgid "Conflict"
+msgstr "Conflit"
+
+#: id:20024
+msgid "Scan new"
+msgstr "Scanner les nouveaux"
+
+#: id:20025
+msgid "Scan all"
+msgstr "Tout scanner"
+
+#: id:20026
+msgid "Region"
+msgstr "Région"
+
+#: id:20037
+msgid "Summary"
+msgstr "Sommaire"
+
+#: id:20038
+msgid "Lock music window"
+msgstr "Verrouiller la section Musique"
+
+#: id:20039
+msgid "Lock videos window"
+msgstr "Verrouiller la section Vidéo"
+
+#: id:20040
+msgid "Lock pictures window"
+msgstr "Verrouiller la section Images"
+
+#: id:20041
+msgid "Lock programs & scripts windows"
+msgstr "Verrouiller Programmes, Sauvegardes et Scripts"
+
+#: id:20042
+msgid "Lock file manager"
+msgstr "Verrouiller le gestionnaire de fichiers"
+
+#: id:20043
+msgid "Lock settings"
+msgstr "Verrouiller les paramètres"
+
+#: id:20044
+msgid "Start fresh"
+msgstr "Nouvelle configuration"
+
+#: id:20045
+msgid "Enter master mode"
+msgstr "Entrer en mode Admin."
+
+#: id:20046
+msgid "Leave master mode"
+msgstr "Sortir du mode Admin."
+
+#: id:20047
+msgid "Create profile '%s'?"
+msgstr "Créer le profil '%s' ?"
+
+#: id:20048
+msgid "Start with fresh settings"
+msgstr "Démarrer avec une nouvelle configuration"
+
+#: id:20049
+msgid "Best available"
+msgstr "La meilleure disponible"
+
+#: id:20050
+msgid "Auto-switch between 16x9 and 4x3"
+msgstr "Auto-basculement entre 16x9 et 4x3"
+
+#: id:20051
+msgid "Treat stacked files as single file"
+msgstr "Traiter les fichiers empilés comme un seul fichier"
+
+#: id:20052
+msgid "Caution"
+msgstr "Attention"
+
+#: id:20053
+msgid "Left master mode"
+msgstr "Vous quittez le mode Admin."
+
+#: id:20054
+msgid "Entered master mode"
+msgstr "Vous entrez en mode Admin."
+
+#: id:20055
+msgid "Allmusic.com thumb"
+msgstr "Vignette Allmusic.com"
+
+#: id:20057
+msgid "Remove thumbnail"
+msgstr "Supprimer la vignette"
+
+#: id:20058
+msgid "Add profile..."
+msgstr "Ajouter un profil..."
+
+#: id:20059
+msgid "Query info for all albums"
+msgstr "Infos pour tous les albums"
+
+#: id:20060
+msgctxt "Auto context with id 20060"
+msgid "Media info"
+msgstr "Infos sur le Média"
+
+#: id:20061
+msgctxt "Auto context with id 20061"
+msgid "Separate"
+msgstr "Séparer"
+
+#: id:20062
+msgid "Shares with default"
+msgstr "Partages par défaut"
+
+#: id:20063
+msgid "Shares with default (read only)"
+msgstr "Partages par déf. (lect. seule)"
+
+#: id:20064
+msgid "Copy default"
+msgstr "Copier Défaut"
+
+#: id:20065
+msgid "Profile picture"
+msgstr "Image du profil"
+
+#: id:20066
+msgid "Lock preferences"
+msgstr "Préférences verrouillage"
+
+#: id:20067
+msgid "Edit profile"
+msgstr "Éditer le profil"
+
+#: id:20068
+msgid "Profile lock"
+msgstr "Sécuriser le profil"
+
+#: id:20069
+msgid "Could not create folder"
+msgstr "Impossible de créer le dossier"
+
+#: id:20070
+msgid "Profile directory"
+msgstr "Dossier du profil"
+
+#: id:20071
+msgid "Start with fresh media sources"
+msgstr "Démarrer avec de nouvelles sources Média"
+
+#: id:20072
+msgid "Make sure the selected folder is writable"
+msgstr "Vérifier que l'écriture est possible dans le dossier sélectionné"
+
+#: id:20073
+msgid "and that the new folder name is valid"
+msgstr "et que le nom du nouveau dossier est valide"
+
+#: id:20074
+msgid "MPAA rating"
+msgstr "Avis MPAA"
+
+#: id:20075
+msgid "Enter master lock code"
+msgstr "Entrer le code du mode Admin."
+
+#: id:20076
+msgid "Ask for master lock code on startup"
+msgstr "Demander le code du mode Admin. au démarrage"
+
+#: id:20077
+msgid "Skin settings"
+msgstr "Param. Thèmes"
+
+#: id:20078
+msgid "- no link set -"
+msgstr "- pas de lien -"
+
+#: id:20079
+msgid "Enable animations"
+msgstr "Activer les animations"
+
+#: id:20080
+msgid "Disable RSS during music"
+msgstr "Désactiver le flux RSS pendant la musique"
+
+#: id:20081
+msgid "Enable shortcut buttons"
+msgstr "Activer les boutons Signets"
+
+#: id:20082
+msgid "Show programs in main menu"
+msgstr "Afficher Programmes dans le menu principal"
+
+#: id:20083
+msgid "Show music info"
+msgstr "Afficher les infos Musique"
+
+#: id:20084
+msgid "Show weather info"
+msgstr "Afficher les infos Météo"
+
+#: id:20085
+msgid "Show system info"
+msgstr "Afficher les infos Système"
+
+#: id:20086
+msgid "Show available disc space C: E: F:"
+msgstr "Afficher l'espace disponible des partitions C: E: F:"
+
+#: id:20087
+msgid "Show available disc space E: F: G:"
+msgstr "Afficher l'espace disponible des partitions E: F: G:"
+
+#: id:20088
+msgid "Weather info"
+msgstr "Infos Météo"
+
+#: id:20089
+msgid "Drive space free"
+msgstr "Espace disque libre"
+
+#: id:20090
+msgid "Enter the name of an existing share"
+msgstr "Entrer le nom d'un partage existant"
+
+#: id:20091
+msgid "Lock code"
+msgstr "Code de verrouillage"
+
+#: id:20092
+msgid "Load profile"
+msgstr "Charger un profil"
+
+#: id:20093
+msgid "Profile name"
+msgstr "Nom du profil"
+
+#: id:20094
+msgctxt "Auto context with id 20094"
+msgid "Media sources"
+msgstr "Sources des médias"
+
+#: id:20095
+msgid "Enter profile lock code"
+msgstr "Entrer le code du profil"
+
+#: id:20096
+msgctxt "Auto context with id 20096"
+msgid "Login screen"
+msgstr "Écran d'accueil"
+
+#: id:20097
+msgid "Fetching album info"
+msgstr "Récupération des infos sur l'album"
+
+#: id:20098
+msgid "Fetching info for album"
+msgstr "Récupération des infos pour l'album"
+
+#: id:20099
+msgid "Can't rip CD or track while playing from CD"
+msgstr "Impossible d'importer le CD ou le morceau pendant la lecture"
+
+#: id:20100
+msgid "Master lock code and settings"
+msgstr "Codes et paramètres Admin."
+
+#: id:20101
+msgid "Entering master lock code always enables master mode"
+msgstr "Entrer le code Admin. active toujours le mode Admin."
+
+#: id:20102
+msgid "or copy from default?"
+msgstr "ou copier celle(s) définie(s) par défaut ?"
+
+#: id:20103
+msgid "Save changes to profile?"
+msgstr "Enregistrer les changements du profil ?"
+
+#: id:20104
+msgid "Old settings found."
+msgstr "Anciens paramètres trouvés."
+
+#: id:20105
+msgid "Do you want to use them?"
+msgstr "Voulez-vous les utiliser ?"
+
+#: id:20106
+msgid "Old media sources found."
+msgstr "Anciennes sources médias trouvées."
+
+#: id:20107
+msgid "Separate (locked)"
+msgstr "Séparer (sécurisé)"
+
+#: id:20108
+msgid "Root"
+msgstr "Racine"
+
+#: id:20109
+msgid "- Zoom"
+msgstr "- Zoom"
+
+#: id:20110
+msgid "UPnP settings"
+msgstr "Paramètres UPnP"
+
+#: id:20111
+msgid "Autostart UPnP client"
+msgstr "Démarrage auto. du client UPnP"
+
+#: id:20112
+msgid "Last login: %s"
+msgstr "Dernière connexion : %s"
+
+#: id:20113
+msgid "Never logged on"
+msgstr "jamais connecté"
+
+#: id:20114
+msgid "Profile %i / %i"
+msgstr "Profil %i / %i"
+
+#: id:20115
+msgid "User login / Select a profile"
+msgstr "Connexion utilisateur / Choix du profil"
+
+#: id:20116
+msgid "Use lock on login screen"
+msgstr "Utiliser le verrou sur l'écran de connexion"
+
+#: id:20117
+msgid "Invalid lock code."
+msgstr "Code verrou invalide."
+
+#: id:20118
+msgid "This requires the master lock to be set."
+msgstr "Code Admin. nécessaire pour être réglé."
+
+#: id:20119
+msgid "Would you like to set it now?"
+msgstr "Voulez-vous le régler maintenant ?"
+
+#: id:20120
+msgid "Loading program information"
+msgstr "Chargement des informations du programme"
+
+#: id:20121
+msgid "Party on!"
+msgstr "C'est Party !"
+
+#: id:20122
+msgid "True"
+msgstr "Vrai"
+
+#: id:20123
+msgid "Mixing drinks"
+msgstr "Mélange des ingrédients"
+
+#: id:20124
+msgid "Filling glasses"
+msgstr "Remplissage des verres"
+
+#: id:20125
+msgid "Logged on as"
+msgstr "Connecté en tant que"
+
+#: id:20126
+msgid "Log off"
+msgstr "Déconnexion"
+
+#: id:20128
+msgid "Go to root"
+msgstr "Aller à la racine"
+
+#: id:20129
+msgid "Weave"
+msgstr "Tissage"
+
+#: id:20130
+msgid "Weave (inverted)"
+msgstr "Tissage (inversé)"
+
+#: id:20131
+msgid "Blend"
+msgstr "Mélange"
+
+#: id:20132
+msgid "Restart video"
+msgstr "Redémarrer la vidéo"
+
+#: id:20133
+msgid "Edit network location"
+msgstr "Éditer la location réseau"
+
+#: id:20134
+msgid "Remove network location"
+msgstr "Supprimer la location réseau"
+
+#: id:20135
+msgid "Do you want to scan the folder?"
+msgstr "Voulez-vous scanner le dossier ?"
+
+#: id:20136
+msgid "Memory unit"
+msgstr "Unité mémoire"
+
+#: id:20137
+msgid "Memory unit mounted"
+msgstr "Unité mémoire montée"
+
+#: id:20138
+msgid "Unable to mount memory unit"
+msgstr "Impossible de monter l'unité mémoire"
+
+#: id:20139
+msgid "In port %i, slot %i"
+msgstr "Dans le port %i, emplacement %i"
+
+#: id:20140
+msgid "Lock screensaver"
+msgstr "Verrouiller l'écran de veille"
+
+#: id:20141
+msgid "Set"
+msgstr "Choisir"
+
+#: id:20142
+msgctxt "Auto context with id 20142"
+msgid "Username"
+msgstr "Nom d'utilisateur"
+
+#: id:20143
+msgid "Enter password for"
+msgstr "Entrer le mot de passe pour"
+
+#: id:20144
+msgid "Shutdown timer"
+msgstr "Minuteur de fermeture"
+
+#: id:20145
+msgid "Shutdown interval (in minutes)"
+msgstr "Intervalle de fermeture (en minutes)"
+
+#: id:20146
+msgid "Started, shutdown in %im"
+msgstr "Démarré, extinction dans %im"
+
+#: id:20147
+msgid "Shutdown in 30 minutes"
+msgstr "Extinction dans 30 minutes"
+
+#: id:20148
+msgid "Shutdown in 60 minutes"
+msgstr "Extinction dans 60 minutes"
+
+#: id:20149
+msgid "Shutdown in 120 minutes"
+msgstr "Extinction dans 120 minutes"
+
+#: id:20150
+msgid "Custom shutdown timer"
+msgstr "Minuteur d'extinction personnalisé"
+
+#: id:20151
+msgid "Cancel shutdown timer"
+msgstr "Annuler le minuteur d'extinction"
+
+#: id:20152
+msgid "Lock preferences for %s"
+msgstr "Verrouiller les préférences pour %s"
+
+#: id:20153
+msgid "Browse..."
+msgstr "Parcourir..."
+
+#: id:20154
+msgid "Summary information"
+msgstr "Résumé des informations"
+
+#: id:20155
+msgid "Storage information"
+msgstr "Infos de stockage"
+
+#: id:20156
+msgid "Hard disk information"
+msgstr "Infos Disque dur"
+
+#: id:20157
+msgid "DVD-ROM information"
+msgstr "Infos DVD-ROM"
+
+#: id:20158
+msgid "Network information"
+msgstr "Infos Réseau"
+
+#: id:20159
+msgid "Video information"
+msgstr "Infos Vidéo"
+
+#: id:20160
+msgid "Hardware information"
+msgstr "Infos Matériel"
+
+#: id:20161
+msgid "Total"
+msgstr "Total"
+
+#: id:20162
+msgid "Used"
+msgstr "Utilisé"
+
+#: id:20163
+msgid "of"
+msgstr "sur"
+
+#: id:20164
+msgid "Locking not supported"
+msgstr "Verrouillage non soutenu"
+
+#: id:20165
+msgid "Not locked"
+msgstr "Non verrouillé"
+
+#: id:20166
+msgid "Locked"
+msgstr "Verrouillé"
+
+#: id:20167
+msgid "Frozen"
+msgstr "Gelé"
+
+#: id:20168
+msgid "Requires reset"
+msgstr "Nécessite un reset"
+
+#: id:20169
+msgid "Week"
+msgstr "Semaine"
+
+#: id:20170
+msgid "Line"
+msgstr "Ligne"
+
+#: id:20171
+msgid "Windows network (SMB)"
+msgstr "Réseau Windows (SMB)"
+
+#: id:20172
+msgid "XBMSP server"
+msgstr "Serveur XBMSP"
+
+#: id:20173
+msgctxt "Auto context with id 20173"
+msgid "FTP server"
+msgstr "Serveur FTP"
+
+#: id:20174
+msgid "iTunes music share (DAAP)"
+msgstr "Partage musical iTunes (DAAP)"
+
+#: id:20175
+msgid "UPnP server"
+msgstr "Serveur UPnP"
+
+#: id:20176
+msgid "Show video info"
+msgstr "Afficher les infos vidéo"
+
+#: id:20177
+msgid "Done"
+msgstr "Entrée"
+
+#: id:20178
+msgid "Shift"
+msgstr "Maj."
+
+#: id:20179
+msgid "Caps Lock"
+msgstr "Verr. Maj."
+
+#: id:20180
+msgid "Symbols"
+msgstr "Symboles"
+
+#: id:20181
+msgid "Backspace"
+msgstr "Retour"
+
+#: id:20182
+msgid "Space"
+msgstr "Espace"
+
+#: id:20183
+msgid "Reload skin"
+msgstr "Recharger le thème"
+
+#: id:20184
+msgid "Rotate pictures using EXIF information"
+msgstr "Pivoter les images en utilisant les infos EXIF"
+
+#: id:20185
+msgid "Use poster view styles for TV shows"
+msgstr "Utiliser la vue Poster pour les séries TV"
+
+#: id:20186
+msgid "Please wait"
+msgstr "Veuillez patienter"
+
+#: id:20187
+msgid "UPnP"
+msgstr ""
+
+#: id:20189
+msgid "Enable auto scrolling for plot & review"
+msgstr "Activer le défilement auto des résumés & critiques"
+
+#: id:20190
+msgctxt "Auto context with id 20190"
+msgid "Custom"
+msgstr "Personnaliser"
+
+#: id:20191
+msgid "Enable debug logging"
+msgstr "Activer le mode debug"
+
+#: id:20192
+msgid "Download additional information during updates"
+msgstr "Télécharger les infos supplémentaires lors des mises à jour"
+
+#: id:20193
+msgid "Default service for album information"
+msgstr "Service d'informations par défaut - Album"
+
+#: id:20194
+msgid "Default service for artist information"
+msgstr "Service d'informations par défaut - Artiste"
+
+#: id:20195
+msgid "Change scraper"
+msgstr "Changer le scraper"
+
+#: id:20196
+msgid "Export music library"
+msgstr "Exporter la médiathèque musicale"
+
+#: id:20197
+msgid "Import music library"
+msgstr "Importer une médiathèque musicale"
+
+#: id:20198
+msgid "No artist found!"
+msgstr "Aucun artiste trouvé !"
+
+#: id:20199
+msgid "Downloading artist info failed"
+msgstr "Échec du téléchargement des infos Artiste"
+
+#: id:20250
+msgid "Party on! (videos)"
+msgstr "C'est Party ! (vidéos)"
+
+#: id:20251
+msgid "Mixing drinks (videos)"
+msgstr "Barman au shaker (vidéos)"
+
+#: id:20252
+msgid "Filling glasses (videos)"
+msgstr "Remplissage des verres (vidéos)"
+
+#: id:20253
+msgid "WebDAV server (HTTP)"
+msgstr "Serveur WebDAV (HTTP)"
+
+#: id:20254
+msgid "WebDAV server (HTTPS)"
+msgstr "Serveur WebDAV (HTTPS)"
+
+#: id:20255
+msgid "First logon, edit your profile"
+msgstr "Première connexion, modifier votre profil"
+
+#: id:20256
+msgid "HTS Tvheadend client"
+msgstr "Client HTS Tvheadend"
+
+#: id:20257
+msgid "VDR Streamdev client"
+msgstr "Client VDR Streamdev"
+
+#: id:20258
+msgid "MythTV client"
+msgstr "Client MythTV"
+
+#: id:20259
+msgid "Network Filesystem (NFS)"
+msgstr "Network Filesystem (NFS)"
+
+#: id:20260
+msgid "Secure Shell (SSH/SFTP)"
+msgstr "Secure Shell (SSH/SFTP)"
+
+#: id:20261
+msgid "Apple Filing Protocol (AFP)"
+msgstr "Apple File Protocol (AFP)"
+
+#: id:20300
+msgid "Web server directory (HTTP)"
+msgstr "Dossier Server Web (HTTP)"
+
+#: id:20301
+msgid "Web server directory (HTTPS)"
+msgstr "Dossier Server Web (HTTPS)"
+
+#: id:20302
+msgid "Unable to write to folder:"
+msgstr "Impossible d'écrire dans le dossier"
+
+#: id:20303
+msgid "Do you want to skip and proceed?"
+msgstr "Voulez-vous passer et continuer ?"
+
+#: id:20304
+msgid "RSS Feed"
+msgstr "Flux RSS"
+
+#: id:20307
+msgid "Secondary DNS"
+msgstr "DNS secondaire"
+
+#: id:20308
+msgid "DHCP server:"
+msgstr "Serveur DHCP"
+
+#: id:20309
+msgid "Make new folder"
+msgstr "Créer un nouveau dossier"
+
+#: id:20310
+msgid "Dim LCD on playback"
+msgstr "Atténuer LCD en lecture"
+
+#: id:20311
+msgid "Unknown or onboard (protected)"
+msgstr "Inconnu ou embarqué (protégé)"
+
+#: id:20312
+msgid "Dim LCD on paused"
+msgstr "Atténuer LCD en pause"
+
+#: id:20314
+msgid "Videos - Library"
+msgstr "Vidéos - Médiath."
+
+#: id:20316
+msgid "Sort by: ID"
+msgstr "Trier par : ID"
+
+#: id:20324
+msgid "Play part..."
+msgstr "Lecture partie..."
+
+#: id:20325
+msgid "Calibration reset"
+msgstr "Calibrage par défaut"
+
+#: id:20326
+msgid "This will reset the calibration values for %s"
+msgstr "Ceci remettra à zéro les valeurs de calibrage pour %s"
+
+#: id:20327
+msgid "to it's default values."
+msgstr "aux valeurs par défaut."
+
+#: id:20328
+msgid "Browse for destination"
+msgstr "Parcourir pour une destination"
+
+#: id:20329
+msgid "Movies are in separate folders that match the movie title"
+msgstr "Chaque film dans un dossier séparé, libellé avec son titre"
+
+#: id:20330
+msgid "Use folder names for lookups"
+msgstr "Consultation avec les noms des dossiers"
+
+#: id:20331
+msgctxt "Auto context with id 20331"
+msgid "File"
+msgstr "Fichier"
+
+#: id:20332
+msgid "Use file or folder names in lookups?"
+msgstr "Utiliser le nom des dossiers ou fichiers pour la consultation ?"
+
+#: id:20333
+msgid "Set content"
+msgstr "Catégorie"
+
+#: id:20334
+msgid "Folder"
+msgstr "Dossier"
+
+#: id:20335
+msgid "Look for content recursively?"
+msgstr "Rechercher le contenu de façon récursive ?"
+
+#: id:20336
+msgid "Unlock sources"
+msgstr "Déverrouiller les sources"
+
+#: id:20337
+msgid "Actor"
+msgstr "Acteur"
+
+#: id:20338
+msgid "Movie"
+msgstr "Film"
+
+#: id:20339
+msgid "Director"
+msgstr "Réalisateur"
+
+#: id:20340
+msgid "Do you want to remove all items within"
+msgstr "Voulez-vous enlever tous les articles de"
+
+#: id:20341
+msgid "this path from the XBMC library?"
+msgstr "ce chemin de la médiathèque ?"
+
+#: id:20342
+msgctxt "Auto context with id 20342"
+msgid "Movies"
+msgstr "Films"
+
+#: id:20343
+msgid "TV shows"
+msgstr "Séries TV"
+
+#: id:20344
+msgid "This directory contains"
+msgstr "Catégorie du répertoire"
+
+#: id:20345
+msgid "Run automated scan"
+msgstr "Exécuter le scan automatiquement"
+
+#: id:20346
+msgid "Scan recursively"
+msgstr "Scanner les sous-dossiers"
+
+#: id:20347
+msgid "as"
+msgstr "est"
+
+#: id:20348
+msgid "Directors"
+msgstr "Réalisateurs"
+
+#: id:20349
+msgid "No video files found in this path!"
+msgstr "Le fichier vidéo n'a pas été trouvé dans ce chemin !"
+
+#: id:20350
+msgid "votes"
+msgstr "votes"
+
+#: id:20351
+msgid "TV show information"
+msgstr "Infos Série TV"
+
+#: id:20352
+msgid "Episode information"
+msgstr "Information de l'épisode"
+
+#: id:20353
+msgid "Loading TV show details"
+msgstr "Chargement des détails de la série TV"
+
+#: id:20354
+msgid "Fetching episode guide"
+msgstr "Recherche du guide de l'épisode"
+
+#: id:20355
+msgid "Loading info for episodes in directory"
+msgstr "Chargement des infos pour les épisodes dans le répertoire"
+
+#: id:20356
+msgid "Select TV show:"
+msgstr "Choisir la série TV :"
+
+#: id:20357
+msgid "Enter the TV show name"
+msgstr "Entrer le nom de la Série TV"
+
+#: id:20358
+msgid "Season %i"
+msgstr "Saison %i"
+
+#: id:20359
+msgid "Episode"
+msgstr "Épisode"
+
+#: id:20360
+msgid "Episodes"
+msgstr "Épisodes"
+
+#: id:20361
+msgid "Loading episode details"
+msgstr "Chargement des détails des épisodes"
+
+#: id:20362
+msgid "Remove episode from library"
+msgstr "Retirer l'épisode..."
+
+#: id:20363
+msgid "Remove TV show from library"
+msgstr "Retirer la série TV..."
+
+#: id:20364
+msgid "TV show"
+msgstr "Série TV"
+
+#: id:20365
+msgid "Episode plot"
+msgstr "Résumé de l'épisode"
+
+#: id:20366
+msgid "* All seasons"
+msgstr "* Toutes les saisons"
+
+#: id:20367
+msgid "Hide watched"
+msgstr "Masquer vue(s)"
+
+#: id:20368
+msgid "Prod code"
+msgstr "Code Prod."
+
+#: id:20369
+msgid "Show plot for unwatched items"
+msgstr "Afficher le résumé pour les médias non visionnés"
+
+#: id:20370
+msgid "* Hidden to prevent spoilers *"
+msgstr "* Caché pour éviter les spoilers *"
+
+#: id:20371
+msgid "Set season thumb"
+msgstr "Définir l'image de saison"
+
+#: id:20372
+msgid "Season image"
+msgstr "Image de saison"
+
+#: id:20373
+msgid "Season"
+msgstr "Saison"
+
+#: id:20374
+msgid "Downloading movie information"
+msgstr "Téléchargement des infos vidéo"
+
+#: id:20375
+msgid "Unassign content"
+msgstr "Catégorie non assignée"
+
+#: id:20376
+msgid "Original title"
+msgstr "Titre original"
+
+#: id:20377
+msgid "Refresh TV show information"
+msgstr "Rafraîchir les infos séries TV"
+
+#: id:20378
+msgid "Refresh info for all episodes?"
+msgstr "Rafraichir les infos de tous les épisodes ?"
+
+#: id:20379
+msgid "Selected folder contains a single TV show"
+msgstr "Le dossier sélectionné contient une seule Série TV"
+
+#: id:20380
+msgid "Exclude selected folder from scans"
+msgstr "Exclure le dossier sélectionné du scan"
+
+#: id:20381
+msgid "Specials"
+msgstr "Spéciales"
+
+#: id:20382
+msgid "Automatically grab season thumbs"
+msgstr "Récupérer automatiquement les vignettes des saisons"
+
+#: id:20383
+msgid "Selected folder contains a single video"
+msgstr "Le dossier sélectionné contient une seule vidéo"
+
+#: id:20384
+msgid "Link to TV show"
+msgstr "Lien vers une série TV"
+
+#: id:20385
+msgid "Remove link to TV show"
+msgstr "Supprimer le lien vers la série TV"
+
+#: id:20386
+msgid "Recently added movies"
+msgstr "Films récemment ajoutés"
+
+#: id:20387
+msgid "Recently added episodes"
+msgstr "Épisodes TV récemment ajoutés"
+
+#: id:20388
+msgid "Studios"
+msgstr "Studios"
+
+#: id:20389
+msgid "Music videos"
+msgstr "Clips musicaux"
+
+#: id:20390
+msgid "Recently added music videos"
+msgstr "Clips musicaux récemment ajoutés"
+
+#: id:20391
+msgid "Music video"
+msgstr "Clip musical"
+
+#: id:20392
+msgid "Remove music video from library"
+msgstr "Retirer le clip musical de la Médiath."
+
+#: id:20393
+msgctxt "Auto context with id 20393"
+msgid "Music video information"
+msgstr "Informations du clip"
+
+#: id:20394
+msgid "Loading music video information"
+msgstr "Chargement des informations du clip"
+
+#: id:20395
+msgid "Mixed"
+msgstr "Mixé"
+
+#: id:20396
+msgid "Go to albums by artist"
+msgstr "Albums par artiste"
+
+#: id:20397
+msgid "Go to album"
+msgstr "Album"
+
+#: id:20398
+msgid "Play song"
+msgstr "Jouer la chanson"
+
+#: id:20399
+msgid "Go to music videos from album"
+msgstr "Clips musicaux de l'album"
+
+#: id:20400
+msgid "Go to music videos by artist"
+msgstr "Clips musicaux par artiste"
+
+#: id:20401
+msgid "Play music video"
+msgstr "Jouer le clip"
+
+#: id:20402
+msgid "Download actor thumbnails when adding to library"
+msgstr "Télécharger les vignettes d'acteurs lors de l'ajout à la médiathèque"
+
+#: id:20403
+msgid "Set actor thumb"
+msgstr "Définir la vignette Acteur"
+
+#: id:20405
+msgid "Remove episode bookmark"
+msgstr "Supprimer le signet d'épisode"
+
+#: id:20406
+msgid "Set episode bookmark"
+msgstr "Créer un signet d'épisode"
+
+#: id:20407
+msgid "Scraper settings"
+msgstr "Paramètres du scraper"
+
+#: id:20408
+msgid "Downloading music video information"
+msgstr "Téléchargement des infos de Clip Vidéo"
+
+#: id:20409
+msgid "Downloading TV show information"
+msgstr "Téléchargement des infos de Série TV"
+
+#: id:20410
+msgid "Trailer"
+msgstr "Bande-annonce"
+
+#: id:20411
+msgid "Flatten"
+msgstr "Assembler"
+
+#: id:20412
+msgid "Flatten TV shows"
+msgstr "Assembler la série TV"
+
+#: id:20413
+msgid "Get fanart"
+msgstr "Fanart"
+
+#: id:20414
+msgid "Show Fanart in video and music libraries"
+msgstr "Afficher le fanart dans les médiathèques"
+
+#: id:20415
+msgid "Scanning for new content"
+msgstr "Recherche de nouveaux contenus"
+
+#: id:20416
+msgid "First aired"
+msgstr "Diffusion"
+
+#: id:20417
+msgid "Writer"
+msgstr "Scénariste"
+
+#: id:20419
+msgid "Replace file names with library titles"
+msgstr "Montrer les métadonnées en vue fichiers"
+
+#: id:20420
+msgctxt "Auto context with id 20420"
+msgid "Never"
+msgstr "Jamais"
+
+#: id:20421
+msgid "If only one season"
+msgstr "Si 1 saison seulement"
+
+#: id:20422
+msgid "Always"
+msgstr "Toujours"
+
+#: id:20423
+msgid "Has trailer"
+msgstr "A une bande-annonce"
+
+#: id:20424
+msgid "False"
+msgstr "Faux"
+
+#: id:20425
+msgid "Fanart slideshow"
+msgstr "Diaporama Fanart"
+
+#: id:20426
+msgid "Export to a single file or separate"
+msgstr "Exporter vers un seul fichier ou"
+
+#: id:20427
+msgid "files per entry?"
+msgstr "séparer les fichiers par entrée ?"
+
+#: id:20428
+msgid "Single file"
+msgstr "Un fichier"
+
+#: id:20429
+msgctxt "Auto context with id 20429"
+msgid "Separate"
+msgstr "Séparé"
+
+#: id:20430
+msgid "Export thumbnails and fanart?"
+msgstr "Exporter les vignettes et les fanarts ?"
+
+#: id:20431
+msgid "Overwrite old files?"
+msgstr "Écraser les anciens fichiers ?"
+
+#: id:20432
+msgid "Exclude path from library updates"
+msgstr "Exclure le chemin de la MAJ médiathèque"
+
+#: id:20433
+msgid "Extract thumbnails and video information"
+msgstr "Extraire les vignettes et les informations vidéo"
+
+#: id:20434
+msgid "Sets"
+msgstr "Sagas"
+
+#: id:20435
+msgid "Set movieset thumb"
+msgstr "Définir une vignette de saga"
+
+#: id:20436
+msgid "Export actor thumbs?"
+msgstr "Exporter les vignettes acteur"
+
+#: id:20437
+msgid "Choose fanart"
+msgstr "Choisir un fanart"
+
+#: id:20438
+msgid "Local fanart"
+msgstr "En local"
+
+#: id:20439
+msgid "No fanart"
+msgstr "Aucun"
+
+#: id:20440
+msgid "Current fanart"
+msgstr "Actuel"
+
+#: id:20441
+msgid "Remote fanart"
+msgstr "En ligne"
+
+#: id:20442
+msgid "Change content"
+msgstr "Changer de catégorie"
+
+#: id:20443
+msgid "Do you want to refresh info for all"
+msgstr "Voulez-vous rafraîchir les infos pour"
+
+#: id:20444
+msgid "items within this path?"
+msgstr "tous les articles de ce chemin ?"
+
+#: id:20445
+msgid "Fanart"
+msgstr "Fanart"
+
+#: id:20446
+msgid "Locally stored information found."
+msgstr "Informations trouvées en local."
+
+#: id:20447
+msgid "Ignore and refresh from internet?"
+msgstr "Ignorer et rafraîchir en ligne ?"
+
+#: id:20448
+msgid "Could not download information"
+msgstr "Impossible de télécharger les infos"
+
+#: id:20449
+msgid "Unable to connect to remote server"
+msgstr "Impossible de se connecter au serveur"
+
+#: id:20450
+msgid "Would you like to continue scanning?"
+msgstr "Voulez-vous continuer à scanner ?"
+
+#: id:20451
+msgid "Countries"
+msgstr "Pays"
+
+#: id:20452
+msgid "episode"
+msgstr "épisode"
+
+#: id:20453
+msgid "episodes"
+msgstr "épisodes"
+
+#: id:20454
+msgid "Listener"
+msgstr "Auditeur"
+
+#: id:20455
+msgid "Listeners"
+msgstr "Auditeurs"
+
+#: id:20456
+msgid "Set movieset fanart"
+msgstr "Choisir le Fanart de la saga"
+
+#: id:20457
+msgid "Movie set"
+msgstr "Saga"
+
+#: id:20458
+msgid "Group movies in sets"
+msgstr "Grouper les films en saga"
+
+#: id:21330
+msgid "Show hidden files and directories"
+msgstr "Afficher les dossiers et les fichiers cachés"
+
+#: id:21331
+msgid "TuxBox client"
+msgstr "Client TuxBox"
+
+#: id:21332
+msgid "WARNING: Target TuxBox device is in recording-mode!"
+msgstr "AVERTISSEMENT : le dispositif TuxBox est en mode d'enregistrement !"
+
+#: id:21333
+msgid "The stream will be stopped!"
+msgstr "Le flux sera arrêté !"
+
+#: id:21334
+msgid "Zap to channel: %s failed!"
+msgstr "Le zap du canal : %s a échoué !"
+
+#: id:21335
+msgid "Are you sure to start the stream?"
+msgstr "Êtes-vous sûr de débuter le flux ?"
+
+#: id:21336
+msgid "Connecting to: %s"
+msgstr "Connexion à : %s"
+
+#: id:21337
+msgid "TuxBox device"
+msgstr "Dispositif TuxBox"
+
+#: id:21359
+msgid "Add media share..."
+msgstr "Ajouter un partage média..."
+
+#: id:21360
+msgid "Share video and music libraries through UPnP"
+msgstr "Partager les médiathèques vidéos et musique via l'UPnP"
+
+#: id:21364
+msgid "Edit media share"
+msgstr "Éditer le partage média"
+
+#: id:21365
+msgid "Remove media share"
+msgstr "Effacer le partage média"
+
+#: id:21366
+msgid "Subtitle folder"
+msgstr "Dossier de sous-titres"
+
+#: id:21367
+msgid "Movie & alternate subtitle directory"
+msgstr "Film & dossier alternatif de sous-titres"
+
+#: id:21368
+msgid "Override ASS/SSA subtitles fonts"
+msgstr "Outrepasser les polices de sous-titres ASS/SSA"
+
+#: id:21369
+msgid "Enable mouse and Touch Screen support"
+msgstr "Activer la souris et le mode tactile"
+
+#: id:21370
+msgid "Play navigation sounds during media playback"
+msgstr "Sons de la navigation lors de la lecture des médias"
+
+#: id:21371
+msgid "Thumbnail"
+msgstr "Vignette"
+
+#: id:21372
+msgid "Forced DVD player region"
+msgstr "Forcer la région du lecteur DVD"
+
+#: id:21373
+msgid "Video output"
+msgstr "Sortie vidéo"
+
+#: id:21374
+msgid "Video aspect"
+msgstr "Aspect vidéo"
+
+#: id:21375
+msgctxt "Auto context with id 21375"
+msgid "Normal"
+msgstr "Normal"
+
+#: id:21376
+msgid "Letterbox"
+msgstr "Boite aux lettres"
+
+#: id:21377
+msgid "Widescreen"
+msgstr "Panoramique"
+
+#: id:21378
+msgid "Enable 480p"
+msgstr "Activer 480p"
+
+#: id:21379
+msgid "Enable 720p"
+msgstr "Activer 720p"
+
+#: id:21380
+msgid "Enable 1080i"
+msgstr "Activer 1080i"
+
+#: id:21381
+msgid "Enter name of new playlist"
+msgstr "Entrer le nom de la nouvelle playliste"
+
+#: id:21382
+msgid "Show \"Add source\" buttons in file lists"
+msgstr "Afficher le bouton \"Ajouter une source\" dans les listes"
+
+#: id:21383
+msgid "Enable scrollbars"
+msgstr "Activer barres de défilement"
+
+#: id:21384
+msgid "Make watched filtering a toggle in video library"
+msgstr "Activer le filtre Masquer vue(s) en mode médiathèque"
+
+#: id:21385
+msgctxt "Auto context with id 21385"
+msgid "Open"
+msgstr "Ouvrir"
+
+#: id:21386
+msgid "Acoustic management level"
+msgstr "Gestion du niveau acoustique"
+
+#: id:21387
+msgid "Fast"
+msgstr "Rapide"
+
+#: id:21388
+msgid "Quiet"
+msgstr "Silencieux"
+
+#: id:21389
+msgid "Enable custom background"
+msgstr "Activer l'arrière-plan personnel"
+
+#: id:21390
+msgid "Power management level"
+msgstr "Gestion du niveau de la puissance"
+
+#: id:21391
+msgid "High power"
+msgstr "Puissance élevée"
+
+#: id:21392
+msgid "Low power"
+msgstr "Faible puissance"
+
+#: id:21393
+msgid "High standby"
+msgstr "Ressource élevée"
+
+#: id:21394
+msgid "Low standby"
+msgstr "Faible ressource"
+
+#: id:21395
+msgid "Unable to cache files bigger than 4GB"
+msgstr "Impossible de mettre en cache des fichiers supérieurs à 4 GB"
+
+#: id:21396
+msgid "Chapter"
+msgstr "Chapitre"
+
+#: id:21397
+msgid "High quality pixel shader v2"
+msgstr "Pixel shader haute qualité V2"
+
+#: id:21398
+msgid "Enable playlist at startup"
+msgstr "Activer une playliste au démarrage"
+
+#: id:21399
+msgid "Use tween animations"
+msgstr "\"Utiliser le tween pour les animations"
+
+#: id:21400
+msgid "contains"
+msgstr "contient"
+
+#: id:21401
+msgid "does not contain"
+msgstr "ne contient pas"
+
+#: id:21402
+msgid "is"
+msgstr "est"
+
+#: id:21403
+msgid "is not"
+msgstr "n'est pas"
+
+#: id:21404
+msgid "starts with"
+msgstr "commence par"
+
+#: id:21405
+msgid "ends with"
+msgstr "termine par"
+
+#: id:21406
+msgid "greater than"
+msgstr "supérieur à"
+
+#: id:21407
+msgid "less than"
+msgstr "inférieur à"
+
+#: id:21408
+msgid "after"
+msgstr "après"
+
+#: id:21409
+msgid "before"
+msgstr "avant"
+
+#: id:21410
+msgid "in the last"
+msgstr "dans le dernier"
+
+#: id:21411
+msgid "not in the last"
+msgstr "pas dans le dernier"
+
+#: id:21412
+msgid "Scrapers"
+msgstr "Scrapers"
+
+#: id:21413
+msgid "Default movie scraper"
+msgstr "Scraper film par défaut"
+
+#: id:21414
+msgid "Default tvshow scraper"
+msgstr "Scraper série TV par défaut"
+
+#: id:21415
+msgid "Default music video scraper"
+msgstr "Scraper clip musique par défaut"
+
+#: id:21416
+msgid "Enable fallback based on scraper language"
+msgstr "Restreindre le résultat en fonction de la langue"
+
+#: id:21417
+msgid "- Settings"
+msgstr "- Paramètres"
+
+#: id:21418
+msgid "Multilingual"
+msgstr "Multilingue"
+
+#: id:21419
+msgid "No scrapers present"
+msgstr "Aucun scraper présent"
+
+#: id:21420
+msgid "Value to match"
+msgstr "Valeur"
+
+#: id:21421
+msgid "Smart playlist rule"
+msgstr "Règle de smart-playlist"
+
+#: id:21422
+msgid "Match items where"
+msgstr "Assortir les chansons quand"
+
+#: id:21423
+msgid "New rule..."
+msgstr "Nouvelle règle..."
+
+#: id:21424
+msgid "Items must match"
+msgstr "Répondre aux règles suivantes"
+
+#: id:21425
+msgid "all of the rules"
+msgstr "toutes"
+
+#: id:21426
+msgid "one or more of the rules"
+msgstr "n'importe laquelle"
+
+#: id:21427
+msgid "Limit to"
+msgstr "Limité à"
+
+#: id:21428
+msgid "No limit"
+msgstr "Sans Limite"
+
+#: id:21429
+msgid "Order by"
+msgstr "Trier par"
+
+#: id:21430
+msgid "ascending"
+msgstr "croissant"
+
+#: id:21431
+msgid "descending"
+msgstr "décroissant"
+
+#: id:21432
+msgid "Edit smart playlist"
+msgstr "Éditeur de smart-playlist"
+
+#: id:21433
+msgid "Name of the playlist"
+msgstr "Nom de la playliste"
+
+#: id:21434
+msgid "Find items where"
+msgstr "Trouver les chansons assorties"
+
+#: id:21435
+msgid "Edit"
+msgstr "- Éditer"
+
+#: id:21436
+msgid "%i items"
+msgstr "%i objets"
+
+#: id:21437
+msgid "New smart playlist..."
+msgstr "Nouvelle smart-playlist..."
+
+#: id:21438
+msgid "%c Drive"
+msgstr "Disque %c"
+
+#: id:21439
+msgid "Edit party mode rules"
+msgstr "Règles Mix de soirée"
+
+#: id:21440
+msgid "Home folder"
+msgstr "Dossier racine"
+
+#: id:21441
+msgid "Watched count"
+msgstr "Compteur vus"
+
+#: id:21442
+msgid "Episode title"
+msgstr "Titre de l'épisode"
+
+#: id:21443
+msgid "Video resolution"
+msgstr "Résolution de la vidéo"
+
+#: id:21444
+msgid "Audio channels"
+msgstr "Canaux audio"
+
+#: id:21445
+msgid "Video codec"
+msgstr "Codec vidéo"
+
+#: id:21446
+msgid "Audio codec"
+msgstr "Codec audio"
+
+#: id:21447
+msgid "Audio language"
+msgstr "Langue audio"
+
+#: id:21448
+msgid "Subtitle language"
+msgstr "Langue sous-titres"
+
+#: id:21449
+msgid "Remote control sends keyboard presses"
+msgstr "Émulation du clavier par la télécommande"
+
+#: id:21450
+msgid "- Edit"
+msgstr "- Modifier"
+
+#: id:21451
+msgid "Internet connection required."
+msgstr "Connexion Internet requise."
+
+#: id:21452
+msgid "Get More..."
+msgstr "Plus..."
+
+#: id:21453
+msgid "Root filesystem"
+msgstr "Racine"
+
+#: id:21454
+msgid "Cache full"
+msgstr "Cache plein"
+
+#: id:21455
+msgid "Cache filled before reaching required amount for continous playback"
+msgstr "Cache rempli mais insuffisant pour une lecture continue"
+
+#: id:21460
+msgid "Subtitle location"
+msgstr "Emplacement du sous-titre"
+
+#: id:21461
+msgid "Fixed"
+msgstr "Fixe"
+
+#: id:21462
+msgid "Bottom of video"
+msgstr "Au pied de la vidéo"
+
+#: id:21463
+msgid "Below video"
+msgstr "Sous la vidéo"
+
+#: id:21464
+msgid "Top of video"
+msgstr "En haut de la vidéo"
+
+#: id:21465
+msgid "Above video"
+msgstr "Au-dessus de la vidéo"
+
+#: id:21800
+msgid "File name"
+msgstr "Nom du fichier"
+
+#: id:21801
+msgid "File path"
+msgstr "Répertoire du fichier"
+
+#: id:21802
+msgid "File size"
+msgstr "Taille du fichier"
+
+#: id:21803
+msgid "File date/time"
+msgstr "Date/Heure du fichier"
+
+#: id:21804
+msgid "Slide index"
+msgstr "Identification diapositive"
+
+#: id:21805
+msgctxt "Auto context with id 21805"
+msgid "Resolution"
+msgstr "Résolution"
+
+#: id:21806
+msgctxt "Auto context with id 21806"
+msgid "Comment"
+msgstr "Commentaire"
+
+#: id:21807
+msgid "Colour/B&W"
+msgstr "Couleur/N&B"
+
+#: id:21808
+msgid "JPEG process"
+msgstr "Traitement JPEG"
+
+#: id:21820
+msgid "Date/Time"
+msgstr "Date/Heure"
+
+#: id:21821
+msgid "Description"
+msgstr "Description"
+
+#: id:21822
+msgid "Camera make"
+msgstr "Marque de l'appareil"
+
+#: id:21823
+msgid "Camera model"
+msgstr "Modèle de l'appareil"
+
+#: id:21824
+msgid "EXIF comment"
+msgstr "Données EXIF"
+
+#: id:21825
+msgid "Firmware"
+msgstr "Firmware"
+
+#: id:21826
+msgid "Aperture"
+msgstr "Ouverture"
+
+#: id:21827
+msgid "Focal length"
+msgstr "Longueur de focale"
+
+#: id:21828
+msgid "Focus distance"
+msgstr "Distance de la mise au point"
+
+#: id:21829
+msgid "Exposure"
+msgstr "Programme d'exposition"
+
+#: id:21830
+msgid "Exposure time"
+msgstr "Vitesse d'obturation"
+
+#: id:21831
+msgid "Exposure bias"
+msgstr "Compensation de l'exposition"
+
+#: id:21832
+msgid "Exposure mode"
+msgstr "Programme d'exposition"
+
+#: id:21833
+msgid "Flash used"
+msgstr "Flash utilisé"
+
+#: id:21834
+msgid "White-balance"
+msgstr "Balance des blancs"
+
+#: id:21835
+msgid "Light source"
+msgstr "Source lumineuse"
+
+#: id:21836
+msgid "Metering mode"
+msgstr "Mode de mesure"
+
+#: id:21837
+msgid "ISO"
+msgstr "ISO"
+
+#: id:21838
+msgid "Digital zoom"
+msgstr "Zoom numérique"
+
+#: id:21839
+msgid "CCD width"
+msgstr "Largeur CCD"
+
+#: id:21840
+msgid "GPS latitude"
+msgstr "Latitude GPS"
+
+#: id:21841
+msgid "GPS longitude"
+msgstr "Longitude GPS"
+
+#: id:21842
+msgid "GPS altitude"
+msgstr "Altitude GPS"
+
+#: id:21843
+msgid "Orientation"
+msgstr "Orientation"
+
+#: id:21860
+msgid "Supplemental categories"
+msgstr "Catégories supplémentaires"
+
+#: id:21861
+msgid "Keywords"
+msgstr "Mots-clés"
+
+#: id:21862
+msgid "Caption"
+msgstr "Légende"
+
+#: id:21863
+msgid "Author"
+msgstr "Auteur"
+
+#: id:21864
+msgid "Headline"
+msgstr "Titre"
+
+#: id:21865
+msgid "Special instructions"
+msgstr "Instructions spéciales"
+
+#: id:21866
+msgid "Category"
+msgstr "Catégorie"
+
+#: id:21867
+msgid "Byline"
+msgstr "Signature"
+
+#: id:21868
+msgid "Byline title"
+msgstr "Titre de la signature"
+
+#: id:21869
+msgid "Credit"
+msgstr "Crédit"
+
+#: id:21870
+msgid "Source"
+msgstr "Source"
+
+#: id:21871
+msgid "Copyright notice"
+msgstr "Droit d'auteur"
+
+#: id:21872
+msgid "Object name"
+msgstr "Nom de l'objet"
+
+#: id:21873
+msgid "City"
+msgstr "Ville"
+
+#: id:21874
+msgid "State"
+msgstr "Département"
+
+#: id:21875
+msgctxt "Auto context with id 21875"
+msgid "Country"
+msgstr "Pays"
+
+#: id:21876
+msgid "Original Tx Reference"
+msgstr "Référence Tx originale"
+
+#: id:21877
+msgid "Date created"
+msgstr "Date de création"
+
+#: id:21878
+msgid "Copyright flag"
+msgstr "Drapeau du copyright"
+
+#: id:21879
+msgid "Country code"
+msgstr "Code du pays"
+
+#: id:21880
+msgid "Reference service"
+msgstr "Service de référence"
+
+#: id:21881
+msgid "Allow control of XBMC via UPnP"
+msgstr "Permettre le contrôle de XBMC via UPnP"
+
+#: id:21882
+msgid "Attempt to skip introduction before DVD menu"
+msgstr "Tenter de sauter l'intro avant le menu du DVD"
+
+#: id:21883
+msgid "Saved music"
+msgstr "Musique enregistrée"
+
+#: id:21884
+msgid "Query info for all artists"
+msgstr "Infos pour tous les artistes"
+
+#: id:21885
+msgid "Downloading album information"
+msgstr "Téléchargement des informations album"
+
+#: id:21886
+msgid "Downloading artist information"
+msgstr "Téléchargement des informations artiste"
+
+#: id:21887
+msgid "Biography"
+msgstr "Biographie"
+
+#: id:21888
+msgid "Discography"
+msgstr "Discographie"
+
+#: id:21889
+msgid "Searching artist"
+msgstr "Recherche d'artiste"
+
+#: id:21890
+msgid "Select artist"
+msgstr "Sélectionner l'artiste"
+
+#: id:21891
+msgctxt "Auto context with id 21891"
+msgid "Artist information"
+msgstr "Informations sur l'artiste"
+
+#: id:21892
+msgid "Instruments"
+msgstr "Instruments"
+
+#: id:21893
+msgid "Born"
+msgstr "Naissance"
+
+#: id:21894
+msgid "Formed"
+msgstr "Créé"
+
+#: id:21895
+msgid "Themes"
+msgstr "Thèmes"
+
+#: id:21896
+msgid "Disbanded"
+msgstr "Dissous"
+
+#: id:21897
+msgid "Died"
+msgstr "Décédé"
+
+#: id:21898
+msgid "Years active"
+msgstr "Années actives"
+
+#: id:21899
+msgid "Label"
+msgstr "Label(s)"
+
+#: id:21900
+msgid "Born/Formed"
+msgstr "Naissance/Création"
+
+#: id:22000
+msgid "Update library on startup"
+msgstr "Actualiser la médiathèque au démarrage"
+
+#: id:22001
+msgid "Hide progress of library updates"
+msgstr "Masquer l'avancement lors de la màj de la mediathèque"
+
+#: id:22002
+msgid "- DNS suffix"
+msgstr "- Suffixe DNS"
+
+#: id:22003
+msgid "%2.3fs"
+msgstr "%2.3fs"
+
+#: id:22004
+msgid "Delayed by: %2.3fs"
+msgstr "Retarder de : %2.3fs"
+
+#: id:22005
+msgid "Ahead by: %2.3fs"
+msgstr "Avancer de : %2.3fs"
+
+#: id:22006
+msgid "Subtitle offset"
+msgstr "Décalage sous-titres"
+
+#: id:22007
+msgid "OpenGL vendor:"
+msgstr "Vendor OpenGL :"
+
+#: id:22008
+msgid "OpenGL renderer:"
+msgstr "Rendu OpenGL :"
+
+#: id:22009
+msgid "OpenGL version:"
+msgstr "Version OpenGL :"
+
+#: id:22010
+msgid "GPU temperature:"
+msgstr "Température du GPU :"
+
+#: id:22011
+msgid "CPU temperature:"
+msgstr "Température du CPU :"
+
+#: id:22012
+msgid "Total memory"
+msgstr "Mémoire totale"
+
+#: id:22013
+msgid "Profile data"
+msgstr "Données profil"
+
+#: id:22014
+msgid "Use dim if paused during video playback"
+msgstr "Atténuation quand le lecteur vidéo est en pause"
+
+#: id:22015
+msgid "All recordings"
+msgstr "Tous les enregistrements"
+
+#: id:22016
+msgid "By title"
+msgstr "Par titre"
+
+#: id:22017
+msgid "By group"
+msgstr "Par groupe"
+
+#: id:22018
+msgid "Live channels"
+msgstr "Chaînes en direct"
+
+#: id:22019
+msgid "Recordings by title"
+msgstr "Enregistrements par titre"
+
+#: id:22020
+msgid "Guide"
+msgstr "Guide"
+
+#: id:22021
+msgid "Allowed error in aspect ratio to minimize black bars"
+msgstr "Marge d'erreur du ratio pour minimiser les barres noires"
+
+#: id:22022
+msgid "Show video files in listings"
+msgstr "Afficher les fichiers vidéo dans les listes"
+
+#: id:22023
+msgid "DirectX vendor:"
+msgstr "Vendor DirectX :"
+
+#: id:22024
+msgid "Direct3D version:"
+msgstr "Version Direct3D :"
+
+#: id:22030
+msgctxt "Auto context with id 22030"
+msgid "Font"
+msgstr "Police"
+
+#: id:22031
+msgctxt "Auto context with id 22031"
+msgid "- Size"
+msgstr "- Taille"
+
+#: id:22032
+msgctxt "Auto context with id 22032"
+msgid "- Colours"
+msgstr "- Couleurs"
+
+#: id:22033
+msgid "- Charset"
+msgstr "- Jeu de caractères"
+
+#: id:22034
+msgid "Export karaoke titles as HTML"
+msgstr "Exporter titres karaoké vers HTML"
+
+#: id:22035
+msgid "Export karaoke titles as CSV"
+msgstr "Exporter titres karaoké vers CSV"
+
+#: id:22036
+msgid "Import karaoke titles..."
+msgstr "Import titres karaoké..."
+
+#: id:22037
+msgid "Show song selector automatically"
+msgstr "Affichage automatique du sélecteur de chanson"
+
+#: id:22038
+msgid "Export karaoke titles..."
+msgstr "Export titres karaoké..."
+
+#: id:22039
+msgid "Enter song number"
+msgstr "Entrer le numéro de la chanson"
+
+#: id:22040
+msgid "white/green"
+msgstr "blanc/vert"
+
+#: id:22041
+msgid "white/red"
+msgstr "blanc/rouge"
+
+#: id:22042
+msgid "white/blue"
+msgstr "blanc/bleu"
+
+#: id:22043
+msgid "black/white"
+msgstr "noir/blanc"
+
+#: id:22079
+msgid "Default select action"
+msgstr "Action par défaut"
+
+#: id:22080
+msgid "Choose"
+msgstr "Choisir"
+
+#: id:22081
+msgid "Show Information"
+msgstr "Afficher Infos"
+
+#: id:22082
+msgid "More..."
+msgstr "Plus..."
+
+#: id:22083
+msgid "Play all"
+msgstr "Tout jouer"
+
+#: id:23049
+msgid "Teletext not available"
+msgstr "Teletext non disponible"
+
+#: id:23050
+msgid "Activate Teletext"
+msgstr "Activer le télétexte"
+
+#: id:23051
+msgid "Part %i"
+msgstr "Partie %i"
+
+#: id:23052
+msgid "Buffering %i bytes"
+msgstr "%i octets mis en cache"
+
+#: id:23053
+msgid "Stopping"
+msgstr "Arrêt en cours"
+
+#: id:23054
+msgid "Running"
+msgstr "Lecture en cours"
+
+#: id:23100
+msgid "External Player Active"
+msgstr "Lecteur externe actif"
+
+#: id:23101
+msgid "Click OK to terminate the player"
+msgstr "Cliquez sur OK pour arrêter le lecteur"
+
+#: id:23104
+msgid "Click OK when playback has ended"
+msgstr "Cliquez sur OK lorsque la lecture est terminée"
+
+#: id:24000
+msgid "Add-on"
+msgstr "Add-on"
+
+#: id:24001
+msgid "Add-ons"
+msgstr "Add-ons"
+
+#: id:24002
+msgid "Add-on options"
+msgstr "Options Add-on"
+
+#: id:24003
+msgid "Add-on Information"
+msgstr "Infos Add-on"
+
+#: id:24005
+msgctxt "Auto context with id 24005"
+msgid "Media sources"
+msgstr "Sources media"
+
+#: id:24007
+msgctxt "Auto context with id 24007"
+msgid "Movie information"
+msgstr "Infos Film"
+
+#: id:24008
+msgctxt "Auto context with id 24008"
+msgid "Screensaver"
+msgstr "Écran de veille"
+
+#: id:24009
+msgid "Script"
+msgstr "Script"
+
+#: id:24010
+msgctxt "Auto context with id 24010"
+msgid "Visualization"
+msgstr "Visualisation"
+
+#: id:24011
+msgid "Add-on repository"
+msgstr "Dépots d'add-ons"
+
+#: id:24012
+msgctxt "Auto context with id 24012"
+msgid "Subtitles"
+msgstr "Sous-titres"
+
+#: id:24013
+msgid "Lyrics"
+msgstr "Paroles"
+
+#: id:24014
+msgid "TV information"
+msgstr "Infos TV"
+
+#: id:24015
+msgctxt "Auto context with id 24015"
+msgid "Music video information"
+msgstr "Infos clip"
+
+#: id:24016
+msgctxt "Auto context with id 24016"
+msgid "Album information"
+msgstr "Infos album"
+
+#: id:24017
+msgctxt "Auto context with id 24017"
+msgid "Artist information"
+msgstr "Infos artiste"
+
+#: id:24018
+msgctxt "Auto context with id 24018"
+msgid "Services"
+msgstr "Services"
+
+#: id:24020
+msgid "Configure"
+msgstr "Configurer"
+
+#: id:24021
+msgctxt "Auto context with id 24021"
+msgid "Disable"
+msgstr "Désactiver"
+
+#: id:24022
+msgid "Enable"
+msgstr "Activer"
+
+#: id:24023
+msgid "Add-on disabled"
+msgstr "Add-on désactivé"
+
+#: id:24027
+msgctxt "Auto context with id 24027"
+msgid "Weather"
+msgstr "Météo"
+
+#: id:24028
+msgid "Weather.com (standard)"
+msgstr "Weather.com (standard)"
+
+#: id:24030
+msgid "This Add-on can not be configured"
+msgstr "Cet Add-on ne peut pas être configuré"
+
+#: id:24031
+msgid "Error loading settings"
+msgstr "Erreur de chargement des paramètres"
+
+#: id:24032
+msgid "All Add-ons"
+msgstr "Tous les Add-ons"
+
+#: id:24033
+msgid "Get Add-ons"
+msgstr "Télécharger des Add-ons"
+
+#: id:24034
+msgid "Check for updates"
+msgstr "Vérifier les mises à jour"
+
+#: id:24035
+msgid "Force refresh"
+msgstr "Rafraîchir"
+
+#: id:24036
+msgid "Change log"
+msgstr "Changelog"
+
+#: id:24037
+msgid "Uninstall"
+msgstr "Désinstaller"
+
+#: id:24038
+msgid "Install"
+msgstr "Installer"
+
+#: id:24039
+msgid "Disabled Add-ons"
+msgstr "Add-ons désactivés"
+
+#: id:24040
+msgid "(Clear the current setting)"
+msgstr "(Efface le paramètre actuel)"
+
+#: id:24041
+msgid "Install from zip file"
+msgstr "Installer depuis un fichier zip"
+
+#: id:24042
+msgid "Downloading %i%%"
+msgstr "Téléchargement %i%%"
+
+#: id:24043
+msgid "Available Updates"
+msgstr "Mises-à-jour disponibles"
+
+#: id:24044
+msgid "Dependencies not met"
+msgstr "Dépendances non supportées"
+
+#: id:24045
+msgid "Add-on does not have the correct structure"
+msgstr "Structure de l'add-on incorrecte"
+
+#: id:24046
+msgid "%s is used by the following installed add-on(s)"
+msgstr "%s est utilisé par les add-ons suivants"
+
+#: id:24047
+msgid "This add-on cannot be uninstalled"
+msgstr "Cet add-on ne peut être désinstallé"
+
+#: id:24048
+msgid "Rollback"
+msgstr "Rollback"
+
+#: id:24050
+msgid "Available Add-ons"
+msgstr "Add-on disponibles"
+
+#: id:24051
+msgid "Version:"
+msgstr "Version :"
+
+#: id:24052
+msgid "Disclaimer"
+msgstr "Responsabilités"
+
+#: id:24053
+msgid "License:"
+msgstr "Licence :"
+
+#: id:24054
+msgid "Changelog"
+msgstr "Changelog"
+
+#: id:24059
+msgid "Would you like to enable this Add-on?"
+msgstr "Voulez-vous activer cet Add-on ?"
+
+#: id:24060
+msgid "Would you like to disable this Add-on?"
+msgstr "Voulez-vous désactiver cet Add-on ?"
+
+#: id:24061
+msgid "Add-on update available!"
+msgstr "Mise-à-jour d'add-on disponible !"
+
+#: id:24062
+msgid "Enabled Add-ons"
+msgstr "Add-ons activés"
+
+#: id:24063
+msgid "Auto update"
+msgstr "Mise-à-jour auto"
+
+#: id:24064
+msgid "Add-on enabled"
+msgstr "Add-on activé"
+
+#: id:24065
+msgid "Add-on updated"
+msgstr "Add-ons à jour"
+
+#: id:24066
+msgid "Cancel Add-on download?"
+msgstr "Annuler le téléchargement ?"
+
+#: id:24067
+msgid "Currently downloading Add-ons"
+msgstr "Téléchargements en cours"
+
+#: id:24068
+msgid "Update available"
+msgstr "Mise-à-jour disponible"
+
+#: id:24069
+msgid "Update"
+msgstr "Mise-à-jour"
+
+#: id:24070
+msgid "Add-on could not be loaded."
+msgstr "L'Add-on n'a pu être chargé."
+
+#: id:24071
+msgid "An unknown error has occurred."
+msgstr "Une erreur inconnue rencontrée."
+
+#: id:24072
+msgid "Settings required"
+msgstr "Paramètres obligatoires"
+
+#: id:24073
+msgid "Could not connect"
+msgstr "Connexion impossible"
+
+#: id:24074
+msgid "Needs to restart"
+msgstr "Redémarrage requis"
+
+#: id:24075
+msgctxt "Auto context with id 24075"
+msgid "Disable"
+msgstr "Désactiver"
+
+#: id:24076
+msgid "Add-on Required"
+msgstr "Add-on requis"
+
+#: id:24080
+msgid "Try to reconnect?"
+msgstr "Tenter la reconnexion ?"
+
+#: id:24089
+msgid "Add-on restarts"
+msgstr "Redémarrage de l'Add-on"
+
+#: id:24090
+msgid "Lock Add-on manager"
+msgstr "Verrouiller le gestionnaire d'Add-on"
+
+#: id:24094
+msgid "(current)"
+msgstr "(actuel)"
+
+#: id:24095
+msgid "(blacklisted)"
+msgstr "(sur liste noire)"
+
+#: id:24096
+msgid "Add-on has been marked as broken in repository."
+msgstr "Le dépot indique cet add-on comme inutilisable."
+
+#: id:24097
+msgid "Would you like to disable it on your system?"
+msgstr "Voulez-vous le désactiver sur votre système ?"
+
+#: id:24098
+msgid "Broken"
+msgstr "Cassé"
+
+#: id:24099
+msgid "Would you like to switch to this skin?"
+msgstr "Voulez-vous basculer vers ce thème ?"
+
+#: id:24100
+msgid "To use this feature you must download an Add-on:"
+msgstr "Pour utiliser cette fonctionnalité, vous devez télécharger un Add-on :"
+
+#: id:24101
+msgid "Would you like to download this Add-on?"
+msgstr "Voulez-vous télécharger cet Add-on ?"
+
+#: id:25000
+msgid "Notifications"
+msgstr "Notifications"
+
+#: id:29800
+msgid "Library Mode"
+msgstr "Médiathèque"
+
+#: id:29801
+msgid "QWERTY keyboard"
+msgstr "Clavier QWERTY"
+
+#: id:29802
+msgid "Passthrough Audio in use"
+msgstr "Passthrough Audio en cours"
+
+#: id:33001
+msgid "Trailer quality"
+msgstr "Qualité du trailer"
+
+#: id:33002
+msgid "Stream"
+msgstr "Flux"
+
+#: id:33003
+msgid "Download"
+msgstr "Télécharger"
+
+#: id:33004
+msgid "Download & play"
+msgstr "Télécharger & jouer"
+
+#: id:33005
+msgid "Download & save"
+msgstr "Télécharger & enregistrer"
+
+#: id:33006
+msgid "Today"
+msgstr "Aujourd'hui"
+
+#: id:33007
+msgid "Tomorrow"
+msgstr "Demain"
+
+#: id:33008
+msgid "Saving"
+msgstr "Enregistrement en cours"
+
+#: id:33009
+msgid "Copying"
+msgstr "Copie en cours"
+
+#: id:33010
+msgid "Set download directory"
+msgstr "Définir le répertoire de téléchargement"
+
+#: id:33011
+msgid "Search duration"
+msgstr "Durée de la recherche"
+
+#: id:33012
+msgid "Short"
+msgstr "Court"
+
+#: id:33013
+msgid "Long"
+msgstr "Long"
+
+#: id:33014
+msgid "Use DVD player instead of regular player"
+msgstr "Utiliser le lecteur DVD au lieu du lecteur habituel"
+
+#: id:33015
+msgid "Ask for download before playing video"
+msgstr "Confirmer le téléchargement avant de jouer la vidéo"
+
+#: id:33016
+msgid "Clips"
+msgstr "Clips"
+
+#: id:33017
+msgid "Restart plugin to enable"
+msgstr "Relancer le plug-in pour activer"
+
+#: id:33018
+msgid "Tonight"
+msgstr "Ce soir"
+
+#: id:33019
+msgid "Tomorrow Night"
+msgstr "Demain soir"
+
+#: id:33020
+msgid "Condition"
+msgstr "Condition"
+
+#: id:33021
+msgid "Precipitation"
+msgstr "Précipitation"
+
+#: id:33022
+msgid "Precip"
+msgstr "Précip"
+
+#: id:33023
+msgid "Humid"
+msgstr "Humidité"
+
+#: id:33024
+msgid "Feels"
+msgstr "Prévision"
+
+#: id:33025
+msgid "Observed"
+msgstr "Observé"
+
+#: id:33026
+msgid "Departure from normal"
+msgstr "Départ de la normale"
+
+#: id:33027
+msgid "Sunrise"
+msgstr "Aurore"
+
+#: id:33028
+msgid "Sunset"
+msgstr "Crépuscule"
+
+#: id:33029
+msgid "Details"
+msgstr "Détails"
+
+#: id:33030
+msgid "Outlook"
+msgstr "Perspective"
+
+#: id:33031
+msgid "Coverflow"
+msgstr "Coverflow"
+
+#: id:33032
+msgid "Translate text"
+msgstr "Traduire le texte"
+
+#: id:33033
+msgid "Map list %s category"
+msgstr "Liste carte %s catégorie"
+
+#: id:33034
+msgid "36 Hour"
+msgstr "36 Heures"
+
+#: id:33035
+msgid "Maps"
+msgstr "Cartes"
+
+#: id:33036
+msgid "Hourly"
+msgstr "Chaque heure"
+
+#: id:33037
+msgid "Weekend"
+msgstr "Week-end"
+
+#: id:33038
+msgid "%s day"
+msgstr "Jour %s"
+
+#: id:33049
+msgid "Alert"
+msgstr "Alerte"
+
+#: id:33050
+msgid "Alerts"
+msgstr "Alertes"
+
+#: id:33051
+msgid "Choose Your"
+msgstr "Choisissez votre"
+
+#: id:33052
+msgid "Check"
+msgstr "Vérifier"
+
+#: id:33053
+msgctxt "Auto context with id 33053"
+msgid "Configure the"
+msgstr "Configurer le"
+
+#: id:33054
+msgid "Seasons"
+msgstr "Saisons"
+
+#: id:33055
+msgid "Use your"
+msgstr "Utilisez votre"
+
+#: id:33056
+msgid "Watch your"
+msgstr "Surveillez votre"
+
+#: id:33057
+msgid "Listen to"
+msgstr "Ausculter"
+
+#: id:33058
+msgid "View your"
+msgstr "Accédez à votre"
+
+#: id:33059
+msgctxt "Auto context with id 33059"
+msgid "Configure the"
+msgstr "Configurer le"
+
+#: id:33060
+msgid "Power"
+msgstr "Power"
+
+#: id:33061
+msgid "Menu"
+msgstr "Menu"
+
+#: id:33062
+msgid "Play the"
+msgstr "Jouer le"
+
+#: id:33063
+msgid "Options"
+msgstr "Options"
+
+#: id:33065
+msgid "Editor"
+msgstr "Éditeur"
+
+#: id:33066
+msgid "About your"
+msgstr "À propos de votre"
+
+#: id:33067
+msgid "Star rating"
+msgstr "Évaluation"
+
+#: id:33068
+msgid "Background"
+msgstr "Arrière-plan"
+
+#: id:33069
+msgid "Backgrounds"
+msgstr "Arrières-plans"
+
+#: id:33070
+msgid "Custom background"
+msgstr "Arrière-plan personnalisé"
+
+#: id:33071
+msgid "Custom backgrounds"
+msgstr "Arrières-plans personnalisés"
+
+#: id:33072
+msgid "View Readme"
+msgstr "Voir le Readme"
+
+#: id:33073
+msgid "View Changelog"
+msgstr "Voir le Changelog"
+
+#: id:33074
+msgid "This version of %s requires an"
+msgstr "La version de %s nécessite qu'XBMC soit"
+
+#: id:33075
+msgid "XBMC revision of %s or greater to run."
+msgstr "en version %s ou supérieure pour fonctionner."
+
+#: id:33076
+msgid "Please update XBMC."
+msgstr "Veuillez mettre à jour XBMC."
+
+#: id:33077
+msgid "No data found!"
+msgstr "Aucune donnée trouvée !"
+
+#: id:33078
+msgid "Next page"
+msgstr "Page suivante"
+
+#: id:33079
+msgid "Love"
+msgstr "J'aime"
+
+#: id:33080
+msgid "Hate"
+msgstr "Je deteste"
+
+#: id:33081
+msgid "This file is stacked, select the part you want to play from."
+msgstr "Ce fichier est empilé, sélectionnez la partie que vous souhaitez lire."
+
+#: id:33082
+msgid "Path to script"
+msgstr "Chemin du script"
+
+#: id:33083
+msgid "Enable custom script button"
+msgstr "Activer le bouton de script personnalisé"
+
+#: id:33100
+msgid "Failed to start"
+msgstr "Échec du lancement"
+
+#: id:33101
+msgid "Webserver"
+msgstr "Serveur Web"
+
+#: id:33102
+msgid "Event Server"
+msgstr "Serveur d'évènement"
+
+#: id:33103
+msgid "Remote communication server"
+msgstr "Communication à distance avec le serveur"
+
+#: id:33200
+msgid "Detected New Connection"
+msgstr "Nouvelle connexion détectée"
+
+#: id:34000
+msgid "Lame"
+msgstr "Lame"
+
+#: id:34001
+msgid "Vorbis"
+msgstr "Vorbis"
+
+#: id:34002
+msgid "Wav"
+msgstr "Wav"
+
+#: id:34003
+msgid "DXVA2"
+msgstr "DXVA2"
+
+#: id:34004
+msgid "VAAPI"
+msgstr "VAAPI"
+
+#: id:34005
+msgid "Flac"
+msgstr "Flac"
+
+#: id:34100
+msgid "Speaker Configuration"
+msgstr "Configuration des Haut-Parleurs"
+
+#: id:34101
+msgid "2.0"
+msgstr "2.0"
+
+#: id:34102
+msgid "2.1"
+msgstr "2.1"
+
+#: id:34103
+msgid "3.0"
+msgstr "3.0"
+
+#: id:34104
+msgid "3.1"
+msgstr "3.1"
+
+#: id:34105
+msgid "4.0"
+msgstr "4.0"
+
+#: id:34106
+msgid "4.1"
+msgstr "4.1"
+
+#: id:34107
+msgid "5.0"
+msgstr "5.0"
+
+#: id:34108
+msgid "5.1"
+msgstr "5.1"
+
+#: id:34109
+msgid "7.0"
+msgstr "7.0"
+
+#: id:34110
+msgid "7.1"
+msgstr "7.1"
+
+#: id:34201
+msgid "Can't find a next item to play"
+msgstr "Aucun média à suivre"
+
+#: id:34202
+msgid "Can't find a previous item to play"
+msgstr "Aucun média précédent"
+
+#: id:34300
+msgid "Failed to start zeroconf"
+msgstr "Échec du démarrage zeroconf"
+
+#: id:34301
+msgid "Is Apple's Bonjour Service installed? See log for more info."
+msgstr "Est-ce que le service d'Apple Bonjour est installé ? Consultez le log pour plus d'infos."
+
+#: id:34400
+msgid "Video Rendering"
+msgstr "Rendu Vidéo"
+
+#: id:34401
+msgid "Failed to init video filters/scalers, falling back to bilinear scaling"
+msgstr "Échec du filtre/redimensionnement vidéo, utilisation du redimensionnement bilinéaire à la place"
+
+#: id:34402
+msgid "Failed to initialize audio device"
+msgstr "Échec d'initialisation du périphérique audio"
+
+#: id:34403
+msgid "Check your audiosettings"
+msgstr "Vérifiez vos paramètres audio"
+
+#: id:34404
+msgid "Use gestures for navigation:"
+msgstr ""
+
+#: id:34405
+msgid "1 finger swipe left,right,up,down for cursors"
+msgstr ""
+
+#: id:34406
+msgid "2 finger swipe left for backspace"
+msgstr ""
+
+#: id:34407
+msgid "1 finger single tap for enter"
+msgstr ""
+
+#: id:34408
+msgid "2 finger single tap for contextmenu"
+msgstr ""
+
+#: id:35000
+msgid "Peripherals"
+msgstr "Périphériques"
+
+#: id:35001
+msgid "Generic HID device"
+msgstr "Périphérique HID générique"
+
+#: id:35002
+msgid "Generic network adapter"
+msgstr "Adaptateur réseau générique"
+
+#: id:35003
+msgid "Generic disk"
+msgstr "Disque générique"
+
+#: id:35004
+msgid "There are no settings available\nfor this peripheral."
+msgstr "Pas de paramètres possibles\npour ce périphérique."
+
+#: id:35005
+msgid "New device configured"
+msgstr "Nouveau dispositif configuré"
+
+#: id:35006
+msgid "Device removed"
+msgstr "Dispositif retiré"
+
+#: id:35007
+msgid "Keymap to use for this device"
+msgstr "Mappage clavier à utiliser pour ce dispositif"
+
+#: id:35008
+msgid "Keymap enabled"
+msgstr "Mappage clavier activé"
+
+#: id:35009
+msgid "Do not use the custom keymap for this device"
+msgstr ""
+
+#: id:35500
+msgid "Location"
+msgstr "Emplacement"
+
+#: id:35501
+msgid "Class"
+msgstr "Classe"
+
+#: id:35502
+msgctxt "Auto context with id 35502"
+msgid "Name"
+msgstr "Nom"
+
+#: id:35503
+msgid "Vendor"
+msgstr "Vendor"
+
+#: id:35504
+msgid "Product ID"
+msgstr "ID du produit"
+
+#: id:36000
+msgid "Pulse-Eight CEC adapter"
+msgstr "Adaptateur CEC Pulse-Eight"
+
+#: id:36001
+msgid "Pulse-Eight Nyxboard"
+msgstr "Nyxboard Pulse-Eight"
+
+#: id:36002
+msgid "Switch to keyboard side command"
+msgstr "Basculer le contrôle côté clavier"
+
+#: id:36003
+msgid "Switch to remote side command"
+msgstr "Basculer le contrôle côté télécommande"
+
+#: id:36004
+msgid "Press \"user\" button command"
+msgstr "Appuyer sur le bouton de commande \"user\""
+
+#: id:36005
+msgid "Enable switch side commands"
+msgstr "Activer les contrôles de bascule"
+
+#: id:36006
+msgid "Could not open the adapter"
+msgstr "Impossible d'ouvrir l'adaptateur"
+
+#: id:36007
+msgid "Devices to power on when starting XBMC"
+msgstr "Allumer la TV au démarrage de XBMC"
+
+#: id:36008
+msgid "Devices to power off when stopping XBMC"
+msgstr "Éteindre les dispositifs à l'arrêt de XBMC"
+
+#: id:36009
+msgid "Put devices in standby mode when activating screensaver"
+msgstr "Placer les dispositifs en veille si l'écran de veille est activé"
+
+#: id:36011
+msgid "Could not detect the CEC port. Set it up manually."
+msgstr "Impossible de détecter le port CEC. Le paramétrer manuellement."
+
+#: id:36012
+msgid "Could not initialise the CEC adapter. Check your settings."
+msgstr "Impossible de détecter l'adaptateur CEC."
+
+#: id:36013
+msgid "Unsupported libCEC interface version. %d is greater than the version XBMC supports (%d)"
+msgstr "Version de l'interface libcec non-supportée. %d est plus grand que le version supportée par XBMC (%d)"
+
+#: id:36014
+msgid "Put this PC in standby mode when the TV is switched off"
+msgstr "Placer ce PC en veille lorsque la TV est éteinte"
+
+#: id:36015
+msgid "HDMI port number"
+msgstr "Numéro de port HDMI"
+
+#: id:36016
+msgctxt "Auto context with id 36016"
+msgid "Connected"
+msgstr "Connecté"
+
+#: id:36017
+msgid "Adapter found, but libCEC is not available"
+msgstr "Adaptateur trouvé, mais libcec indisponible"
+
+#: id:36018
+msgid "Use the TV's language setting"
+msgstr "Utiliser le paramètre de langage de la TV."
+
+#: id:36019
+msgid "Connected to HDMI device"
+msgstr ""
+
+#: id:36020
+msgid "Make XBMC the active source when starting"
+msgstr ""
+
+#: id:36021
+msgid "Physical address (overrules HDMI port)"
+msgstr ""
+
+#: id:36022
+msgid "COM port (leave empty unless needed)"
+msgstr ""
+
+#: id:36023
+msgid "Configuration updated"
+msgstr ""
+
+#: id:36024
+msgid "Failed to set the new configuration. Please check your settings."
+msgstr ""
+
+#: id:36025
+msgid "Send 'inactive source' command when stopping XBMC"
+msgstr ""
+

--- a/language/German/strings.po
+++ b/language/German/strings.po
@@ -1,0 +1,9093 @@
+# Converted from xbmc strings.xml with xbmc-xml2po (by Team-XBMC)
+msgid ""
+msgstr ""
+"Project-Id-Version: xbmc.core-FRODO_GIT3ed1604ad7\n"
+"Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
+"POT-Creation-Date: 2012-04-09 18:00+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE\n"
+"Language: de\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: id:0
+msgctxt "Auto context with id 0"
+msgid "Programs"
+msgstr "Programme"
+
+#: id:1
+msgctxt "Auto context with id 1"
+msgid "Pictures"
+msgstr "Bilder"
+
+#: id:2
+msgctxt "Auto context with id 2"
+msgid "Music"
+msgstr "Musik"
+
+#: id:3
+msgctxt "Auto context with id 3"
+msgid "Videos"
+msgstr "Videos"
+
+#: id:4
+msgid "TV-Guide"
+msgstr "TV-Programm"
+
+#: id:5
+msgctxt "Auto context with id 5"
+msgid "Settings"
+msgstr "Einstellungen"
+
+#: id:6
+msgid "XBMC SVN"
+msgstr ""
+
+#: id:7
+msgctxt "Auto context with id 7"
+msgid "File manager"
+msgstr "Dateimanager"
+
+#: id:8
+msgctxt "Auto context with id 8"
+msgid "Weather"
+msgstr "Wetter"
+
+#: id:9
+msgid "xbmc media center"
+msgstr "XBMC Media Center"
+
+#: id:11
+msgid "Monday"
+msgstr "Montag"
+
+#: id:12
+msgid "Tuesday"
+msgstr "Dienstag"
+
+#: id:13
+msgid "Wednesday"
+msgstr "Mittwoch"
+
+#: id:14
+msgid "Thursday"
+msgstr "Donnerstag"
+
+#: id:15
+msgid "Friday"
+msgstr "Freitag"
+
+#: id:16
+msgid "Saturday"
+msgstr "Samstag"
+
+#: id:17
+msgid "Sunday"
+msgstr "Sonntag"
+
+#: id:21
+msgid "January"
+msgstr "Januar"
+
+#: id:22
+msgid "February"
+msgstr "Februar"
+
+#: id:23
+msgid "March"
+msgstr "März"
+
+#: id:24
+msgid "April"
+msgstr "April"
+
+#: id:25
+msgctxt "Auto context with id 25"
+msgid "May"
+msgstr "Mai"
+
+#: id:26
+msgid "June"
+msgstr "Juni"
+
+#: id:27
+msgid "July"
+msgstr "Juli"
+
+#: id:28
+msgid "August"
+msgstr "August"
+
+#: id:29
+msgid "September"
+msgstr "September"
+
+#: id:30
+msgid "October"
+msgstr "Oktober"
+
+#: id:31
+msgid "November"
+msgstr "November"
+
+#: id:32
+msgid "December"
+msgstr "Dezember"
+
+#: id:41
+msgid "Mon"
+msgstr "Mo"
+
+#: id:42
+msgid "Tue"
+msgstr "Di"
+
+#: id:43
+msgid "Wed"
+msgstr "Mi"
+
+#: id:44
+msgid "Thu"
+msgstr "Do"
+
+#: id:45
+msgid "Fri"
+msgstr "Fr"
+
+#: id:46
+msgid "Sat"
+msgstr "Sa"
+
+#: id:47
+msgctxt "Auto context with id 47"
+msgid "Sun"
+msgstr "So"
+
+#: id:51
+msgid "Jan"
+msgstr "Jan"
+
+#: id:52
+msgid "Feb"
+msgstr "Feb"
+
+#: id:53
+msgid "Mar"
+msgstr "Mär"
+
+#: id:54
+msgid "Apr"
+msgstr "Apr"
+
+#: id:55
+msgctxt "Auto context with id 55"
+msgid "May"
+msgstr "Mai"
+
+#: id:56
+msgid "Jun"
+msgstr "Jun"
+
+#: id:57
+msgid "Jul"
+msgstr "Jul"
+
+#: id:58
+msgid "Aug"
+msgstr "Aug"
+
+#: id:59
+msgid "Sep"
+msgstr "Sep"
+
+#: id:60
+msgid "Oct"
+msgstr "Okt"
+
+#: id:61
+msgid "Nov"
+msgstr "Nov"
+
+#: id:62
+msgid "Dec"
+msgstr "Dez"
+
+#: id:71
+msgid "N"
+msgstr "N"
+
+#: id:72
+msgid "NNE"
+msgstr "NNO"
+
+#: id:73
+msgid "NE"
+msgstr "NO"
+
+#: id:74
+msgid "ENE"
+msgstr "ONO"
+
+#: id:75
+msgid "E"
+msgstr "O"
+
+#: id:76
+msgid "ESE"
+msgstr "OSO"
+
+#: id:77
+msgid "SE"
+msgstr "SO"
+
+#: id:78
+msgid "SSE"
+msgstr "SSO"
+
+#: id:79
+msgid "S"
+msgstr "S"
+
+#: id:80
+msgid "SSW"
+msgstr "SSW"
+
+#: id:81
+msgid "SW"
+msgstr "SW"
+
+#: id:82
+msgid "WSW"
+msgstr "WSW"
+
+#: id:83
+msgid "W"
+msgstr "W"
+
+#: id:84
+msgid "WNW"
+msgstr "WNW"
+
+#: id:85
+msgid "NW"
+msgstr "NW"
+
+#: id:86
+msgid "NNW"
+msgstr "NNW"
+
+#: id:87
+msgid "VAR"
+msgstr "VAR"
+
+#: id:98
+msgid "View: Auto"
+msgstr "Autoansicht"
+
+#: id:99
+msgid "View: Auto big"
+msgstr "Große Autoansicht"
+
+#: id:100
+msgid "View: Icons"
+msgstr "Symbolansicht"
+
+#: id:101
+msgid "View: List"
+msgstr "Listenansicht"
+
+#: id:102
+msgctxt "Auto context with id 102"
+msgid "Scan"
+msgstr "Durchsuchen"
+
+#: id:103
+msgctxt "Auto context with id 103"
+msgid "Sort by: Name"
+msgstr "Nach Name"
+
+#: id:104
+msgid "Sort by: Date"
+msgstr "Nach Datum"
+
+#: id:105
+msgid "Sort by: Size"
+msgstr "Nach Größe"
+
+#: id:106
+msgid "No"
+msgstr "Nein"
+
+#: id:107
+msgid "Yes"
+msgstr "Ja"
+
+#: id:108
+msgctxt "Auto context with id 108"
+msgid "Slideshow"
+msgstr "Diaschau"
+
+#: id:109
+msgid "Create thumbs"
+msgstr "Thumbnail erstellen"
+
+#: id:110
+msgid "Create thumbnails"
+msgstr "Thumbnail wird erstellt"
+
+#: id:111
+msgctxt "Auto context with id 111"
+msgid "Shortcuts"
+msgstr "Verknüpfungen"
+
+#: id:112
+msgid "Paused"
+msgstr "Pause"
+
+#: id:113
+msgid "Update failed"
+msgstr "Update fehlgeschlagen"
+
+#: id:114
+msgid "Installation failed"
+msgstr "Installation fehlgeschlagen"
+
+#: id:115
+msgid "Copy"
+msgstr "Kopieren"
+
+#: id:116
+msgid "Move"
+msgstr "Verschieben"
+
+#: id:117
+msgid "Delete"
+msgstr "Löschen"
+
+#: id:118
+msgid "Rename"
+msgstr "Umbenennen"
+
+#: id:119
+msgid "New folder"
+msgstr "Neuer Ordner"
+
+#: id:120
+msgid "Confirm file copy"
+msgstr "Kopieren bestätigen"
+
+#: id:121
+msgid "Confirm file move"
+msgstr "Verschieben bestätigen"
+
+#: id:122
+msgid "Confirm file delete?"
+msgstr "Löschen bestätigen"
+
+#: id:123
+msgid "Copy these files?"
+msgstr "Diese Datei(en) kopieren?"
+
+#: id:124
+msgid "Move these files?"
+msgstr "Diese Datei(en) verschieben?"
+
+#: id:125
+msgid "Delete these files? - Deleting files cannot be undone!"
+msgstr "Diese Datei(en) wirklich löschen? - Kann nicht rückgängig gemacht werden!"
+
+#: id:126
+msgid "Status"
+msgstr "Status"
+
+#: id:127
+msgid "Objects"
+msgstr "Objekte"
+
+#: id:128
+msgctxt "Auto context with id 128"
+msgid "General"
+msgstr "Allgemein"
+
+#: id:129
+msgctxt "Auto context with id 129"
+msgid "Slideshow"
+msgstr "Diaschau"
+
+#: id:130
+msgctxt "Auto context with id 130"
+msgid "System info"
+msgstr "Systeminfo"
+
+#: id:131
+msgid "Display"
+msgstr "Anzeige"
+
+#: id:132
+msgid "Albums"
+msgstr "Alben"
+
+#: id:133
+msgid "Artists"
+msgstr "Interpreten"
+
+#: id:134
+msgid "Songs"
+msgstr "Titel"
+
+#: id:135
+msgid "Genres"
+msgstr "Genre"
+
+#: id:136
+msgid "Playlists"
+msgstr "Playlisten"
+
+#: id:137
+msgid "Search"
+msgstr "Suchen"
+
+#: id:138
+msgid "System Information"
+msgstr "System-Informationen"
+
+#: id:139
+msgid "Temperatures:"
+msgstr "Temperatur:"
+
+#: id:140
+msgid "CPU:"
+msgstr "CPU-Temperatur:"
+
+#: id:141
+msgid "GPU:"
+msgstr "GPU-Temperatur:"
+
+#: id:142
+msgid "Time:"
+msgstr "Uhrzeit:"
+
+#: id:143
+msgid "Current:"
+msgstr "Lokal:"
+
+#: id:144
+msgid "Build:"
+msgstr "Version:"
+
+#: id:145
+msgid "Network:"
+msgstr "Netzwerk:"
+
+#: id:146
+msgid "Type:"
+msgstr "Typ:"
+
+#: id:147
+msgid "Static"
+msgstr "Statisch"
+
+#: id:148
+msgid "DHCP"
+msgstr "DHCP"
+
+#: id:149
+msgid "MAC address"
+msgstr "MAC-Adresse"
+
+#: id:150
+msgctxt "Auto context with id 150"
+msgid "IP address"
+msgstr "IP-Adresse"
+
+#: id:151
+msgid "Link:"
+msgstr "Verbindung:"
+
+#: id:152
+msgid "Half duplex"
+msgstr "Halbduplex"
+
+#: id:153
+msgid "Full duplex"
+msgstr "Vollduplex"
+
+#: id:154
+msgctxt "Auto context with id 154"
+msgid "Storage"
+msgstr "Laufwerke"
+
+#: id:155
+msgid "Drive"
+msgstr "Laufwerk"
+
+#: id:156
+msgctxt "Auto context with id 156"
+msgid "Free"
+msgstr "Frei"
+
+#: id:157
+msgctxt "Auto context with id 157"
+msgid "Video"
+msgstr "Video"
+
+#: id:158
+msgid "Free memory"
+msgstr "Freier Hauptspeicher"
+
+#: id:159
+msgid "No link"
+msgstr "Keine Verbindung"
+
+#: id:160
+msgctxt "Auto context with id 160"
+msgid "Free"
+msgstr "Frei"
+
+#: id:161
+msgid "Unavailable"
+msgstr "Nicht verfügbar"
+
+#: id:162
+msgid "Tray open"
+msgstr "Laufwerk offen"
+
+#: id:163
+msgid "Reading"
+msgstr "Einlesen"
+
+#: id:164
+msgid "No disc"
+msgstr "Keine Disc"
+
+#: id:165
+msgid "Disc present"
+msgstr "Disc eingelegt"
+
+#: id:166
+msgid "Skin"
+msgstr "Skin"
+
+#: id:169
+msgctxt "Auto context with id 169"
+msgid "Resolution"
+msgstr "Auflösung"
+
+#: id:170
+msgid "Adjust display refresh rate to match video"
+msgstr "Bildwiederholfrequenz anpassen"
+
+#: id:172
+msgid "Release date"
+msgstr "Veröffentlichung"
+
+#: id:173
+msgid "Display 4:3 videos as"
+msgstr "Darstellung von 4:3 Videos"
+
+#: id:175
+msgid "Moods"
+msgstr "Stimmung"
+
+#: id:176
+msgid "Styles"
+msgstr "Stil"
+
+#: id:179
+msgid "Song"
+msgstr "Titel"
+
+#: id:180
+msgid "Duration"
+msgstr "Dauer"
+
+#: id:181
+msgid "Select album"
+msgstr "Album auswählen"
+
+#: id:182
+msgid "Tracks"
+msgstr "Titel-Liste"
+
+#: id:183
+msgid "Review"
+msgstr "Bewertung"
+
+#: id:184
+msgid "Refresh"
+msgstr "Aktualisieren"
+
+#: id:185
+msgid "Searching album"
+msgstr "Suche nach Album"
+
+#: id:186
+msgid "OK"
+msgstr "OK"
+
+#: id:187
+msgid "No albums found!"
+msgstr "Kein Album gefunden!"
+
+#: id:188
+msgid "Select all"
+msgstr "Alle auswählen"
+
+#: id:189
+msgid "Scanning media info"
+msgstr "Durchsuche Medieninformationen"
+
+#: id:190
+msgid "Save"
+msgstr "Speichern"
+
+#: id:191
+msgid "Shuffle"
+msgstr "Zufall"
+
+#: id:192
+msgctxt "Auto context with id 192"
+msgid "Clear"
+msgstr "Löschen"
+
+#: id:193
+msgctxt "Auto context with id 193"
+msgid "Scan"
+msgstr "Durchsuchen"
+
+#: id:194
+msgid "Searching..."
+msgstr "Durchsuche..."
+
+#: id:195
+msgid "No info found!"
+msgstr "Keine Informationen gefunden!"
+
+#: id:196
+msgid "Select movie:"
+msgstr "Film-Auswahl:"
+
+#: id:197
+msgid "Querying %s info"
+msgstr "Online-Datenbank wird abgefragt..."
+
+#: id:198
+msgid "Loading movie details"
+msgstr "Lade Filminformationen"
+
+#: id:199
+msgid "Web interface"
+msgstr "Webinterface Skin"
+
+#: id:202
+msgid "Tagline"
+msgstr "Kurzinfo"
+
+#: id:203
+msgid "Plot outline"
+msgstr "Handlung"
+
+#: id:205
+msgid "Votes"
+msgstr "Stimmen"
+
+#: id:206
+msgid "Cast"
+msgstr "Besetzung"
+
+#: id:207
+msgid "Plot"
+msgstr "Handlung"
+
+#: id:208
+msgctxt "Auto context with id 208"
+msgid "Play"
+msgstr "Abspielen"
+
+#: id:209
+msgid "Next"
+msgstr "Nächste"
+
+#: id:210
+msgid "Previous"
+msgstr "Vorherige"
+
+#: id:213
+msgid "Calibrate user interface..."
+msgstr "Benutzeroberfläche kalibrieren..."
+
+#: id:214
+msgid "Video calibration..."
+msgstr "Bildschirm kalibrieren..."
+
+#: id:215
+msgid "Soften"
+msgstr "Weichzeichnen"
+
+#: id:216
+msgid "Zoom amount"
+msgstr "Vergrößerung"
+
+#: id:217
+msgid "Pixel ratio"
+msgstr "Bild-Verhältnis"
+
+#: id:218
+msgid "DVD drive"
+msgstr "DVD-Laufwerk"
+
+#: id:219
+msgid "Please insert disc"
+msgstr "Bitte eine Disc einlegen"
+
+#: id:220
+msgid "Remote share"
+msgstr "Netzwerkquelle"
+
+#: id:221
+msgid "Network is not connected"
+msgstr "Netzwerk ist nicht verbunden"
+
+#: id:222
+msgid "Cancel"
+msgstr "Abbrechen"
+
+#: id:224
+msgid "Speed"
+msgstr "Abfolgezeit"
+
+#: id:225
+msgid "Vertical Shift"
+msgstr ""
+
+#: id:226
+msgid "Test patterns..."
+msgstr "Testbilder..."
+
+#: id:227
+msgid "Lookup audio CD track names from freedb.org"
+msgstr "Audio CD Titelnamen mit freedb.org abgleichen"
+
+#: id:228
+msgid "Shuffle playlist on load"
+msgstr "Zufällige Reihenfolge der Playlist nach dem Laden"
+
+#: id:229
+msgid "HDD spindown time"
+msgstr "Festplatten Abschaltzeit"
+
+#: id:230
+msgid "Video filters"
+msgstr "Videofilter"
+
+#: id:231
+msgctxt "Auto context with id 231"
+msgid "None"
+msgstr "Keine"
+
+#: id:232
+msgid "Point"
+msgstr "Punkt"
+
+#: id:233
+msgid "Linear"
+msgstr "Linear"
+
+#: id:234
+msgid "Anisotropic"
+msgstr "Anisotropisch"
+
+#: id:235
+msgid "Quincunx"
+msgstr "Quincunx"
+
+#: id:236
+msgid "Gaussian cubic"
+msgstr "Gaussian Cubic"
+
+#: id:237
+msgid "Minification"
+msgstr "Verkleinerung"
+
+#: id:238
+msgid "Magnification"
+msgstr "Vergrößerung"
+
+#: id:239
+msgid "Clear playlist on finish"
+msgstr "Playlist nach der Wiedergabe löschen"
+
+#: id:240
+msgid "Display Mode"
+msgstr "Anzeige"
+
+#: id:241
+msgid "Full Screen #%d"
+msgstr "Vollbild #%d"
+
+#: id:242
+msgid "Windowed"
+msgstr "Fenster"
+
+#: id:243
+msgid "Refresh Rate"
+msgstr "Bildwiederholrate"
+
+#: id:244
+msgid "Full screen"
+msgstr "Vollbild"
+
+#: id:245
+msgid "Sizing: (%i,%i)->(%i,%i) (Zoom x%2.2f) AR:%2.2f:1 (Pixels: %2.2f:1) (VShift: %2.2f)"
+msgstr "Anpassen: (%i,%i)->(%i,%i) (Zoom x%2.2f) AR:%2.2f:1 (Pixel: %2.2f:1)"
+
+#: id:247
+msgctxt "Auto context with id 247"
+msgid "Scripts"
+msgstr "Skripte"
+
+#: id:248
+msgctxt "Auto context with id 248"
+msgid "Language"
+msgstr "Sprache"
+
+#: id:249
+msgctxt "Auto context with id 249"
+msgid "Music"
+msgstr "Musik"
+
+#: id:250
+msgctxt "Auto context with id 250"
+msgid "Visualization"
+msgstr "Visualisierung"
+
+#: id:251
+msgid "Select destination directory"
+msgstr "Zielordner wählen"
+
+#: id:252
+msgid "Output stereo to all speakers"
+msgstr "Stereo auf allen Lautsprechern ausgeben"
+
+#: id:253
+msgid "Number of channels"
+msgstr "Anzahl der Kanäle"
+
+#: id:254
+msgid "- DTS capable receiver"
+msgstr "- Receiver unterstützt DTS"
+
+#: id:255
+msgid "CDDB"
+msgstr "CDDB"
+
+#: id:256
+msgid "Fetching CD information"
+msgstr "Suche CD-Informationen"
+
+#: id:257
+msgid "Error"
+msgstr "Fehler"
+
+#: id:258
+msgid "Enable tag reading"
+msgstr "Lesen von Tag-Informationen aktivieren"
+
+#: id:259
+msgid "Opening"
+msgstr "Öffne"
+
+#: id:260
+msgid "Shoutcast"
+msgstr "Shoutcast"
+
+#: id:261
+msgid "Waiting for start..."
+msgstr "Warte auf Start..."
+
+#: id:262
+msgid "Scripts output"
+msgstr "Skript-Ausgabe"
+
+#: id:263
+msgid "Allow control of XBMC via HTTP"
+msgstr "Steuerung über Webinterface zulassen"
+
+#: id:264
+msgid "Record"
+msgstr "Aufnehmen"
+
+#: id:265
+msgid "Stop Rec."
+msgstr "Aufnahme beenden"
+
+#: id:266
+msgid "Sort by: Track"
+msgstr "Nach: Titel-Nr."
+
+#: id:267
+msgid "Sort by: Time"
+msgstr "Nach: Zeit"
+
+#: id:268
+msgid "Sort by: Title"
+msgstr "Nach: Titel"
+
+#: id:269
+msgid "Sort by: Artist"
+msgstr "Nach: Interpret"
+
+#: id:270
+msgid "Sort by: Album"
+msgstr "Nach: Album"
+
+#: id:271
+msgid "Top 100"
+msgstr "Top 100"
+
+#: id:272
+msgid "Top-Left overscan compensation"
+msgstr "Bildbereich oben links ausrichten"
+
+#: id:273
+msgid "Bottom-Right overscan compensation"
+msgstr "Bildbereich unten rechts ausrichten"
+
+#: id:274
+msgid "Subtitle positioning"
+msgstr "Position der Untertitel"
+
+#: id:275
+msgid "Pixel ratio adjustment"
+msgstr "Bildverhältnis einstellen"
+
+#: id:276
+msgid "Adjust the arrow to change the amount of overscan"
+msgstr "Bewege den Pfeil um den Bildbereich einzustellen"
+
+#: id:277
+msgid "Adjust the bar to change the subtitles position"
+msgstr "Bewege den Balken um die Position der Untertitel einzustellen"
+
+#: id:278
+msgid "Adjust the rectangle so it is perfectly square"
+msgstr "Ändere das Rechteck so, daß es ein perfektes Quadrat ergibt"
+
+#: id:279
+msgid "Unable to load settings"
+msgstr "Einstellungen können nicht geladen werden"
+
+#: id:280
+msgid "Using default settings"
+msgstr "Standardeinstellungen verwenden"
+
+#: id:281
+msgid "Please check the XML files"
+msgstr "Bitte überprüfe die XML-Dateien"
+
+#: id:282
+msgid "Found %i items"
+msgstr "%i Einträge gefunden"
+
+#: id:283
+msgid "Search results"
+msgstr "Suchergebnisse"
+
+#: id:284
+msgid "No results found"
+msgstr "Keine Ergebnisse gefunden"
+
+#: id:287
+msgctxt "Auto context with id 287"
+msgid "Subtitles"
+msgstr "Untertitel"
+
+#: id:288
+msgctxt "Auto context with id 288"
+msgid "Font"
+msgstr "Schriftart"
+
+#: id:289
+msgctxt "Auto context with id 289"
+msgid "- Size"
+msgstr "- Schriftgröße"
+
+#: id:290
+msgid "Dynamic range compression"
+msgstr "Dynamische Kompression"
+
+#: id:291
+msgctxt "Auto context with id 291"
+msgid "Video"
+msgstr "Video"
+
+#: id:292
+msgctxt "Auto context with id 292"
+msgid "Audio"
+msgstr "Audio"
+
+#: id:293
+msgid "Browse for subtitles"
+msgstr "Nach Untertitel durchsuchen"
+
+#: id:294
+msgid "Create bookmark"
+msgstr "Lesezeichen erstellen"
+
+#: id:296
+msgid "Clear bookmarks"
+msgstr "Lesezeichen löschen"
+
+#: id:297
+msgid "Audio offset"
+msgstr "Audio-Verzögerung"
+
+#: id:298
+msgid "Bookmarks"
+msgstr "Lesezeichen"
+
+#: id:299
+msgid "- AAC capable receiver"
+msgstr "- Receiver unterstützt AAC"
+
+#: id:300
+msgid "- MP1 capable receiver"
+msgstr "- Receiver unterstützt MP1"
+
+#: id:301
+msgid "- MP2 capable receiver"
+msgstr "- Receiver unterstützt MP2"
+
+#: id:302
+msgid "- MP3 capable receiver"
+msgstr "- Receiver unterstützt MP3"
+
+#: id:303
+msgid "Delay"
+msgstr "Verzögerung"
+
+#: id:304
+msgctxt "Auto context with id 304"
+msgid "Language"
+msgstr "Sprache"
+
+#: id:305
+msgctxt "Auto context with id 305"
+msgid "Enabled"
+msgstr "Aktiviert"
+
+#: id:306
+msgid "Non-interleaved"
+msgstr "Nicht-interleaved"
+
+#: id:312
+msgid "(0=auto)"
+msgstr "(0=auto)"
+
+#: id:313
+msgid "Cleaning database"
+msgstr "Datenbank wird bereinigt"
+
+#: id:314
+msgid "Preparing..."
+msgstr "Vorbereitung..."
+
+#: id:315
+msgid "Database error"
+msgstr "Datenbankfehler"
+
+#: id:316
+msgid "Searching songs..."
+msgstr "Durchsuche Titel..."
+
+#: id:317
+msgid "Cleaned database successfully"
+msgstr "Die Datenbank wurde erfolgreich bereinigt"
+
+#: id:318
+msgid "Cleaning songs..."
+msgstr "Titel werden aktualisiert..."
+
+#: id:319
+msgid "Error cleaning songs"
+msgstr "Fehler beim Aktualisieren der Titel"
+
+#: id:320
+msgid "Cleaning artists..."
+msgstr "Interpreten werden aktualisiert..."
+
+#: id:321
+msgid "Error cleaning artists"
+msgstr "Fehler beim Aktualisieren der Interpreten"
+
+#: id:322
+msgid "Cleaning genres..."
+msgstr "Genres werden aktualisiert..."
+
+#: id:323
+msgid "Error cleaning genres"
+msgstr "Fehler beim Aktualisieren der Genres"
+
+#: id:324
+msgid "Cleaning paths..."
+msgstr "Pfade werden aktualisiert..."
+
+#: id:325
+msgid "Error cleaning paths"
+msgstr "Fehler beim Aktualisieren der Pfade"
+
+#: id:326
+msgid "Cleaning albums..."
+msgstr "Alben werden aktualisiert..."
+
+#: id:327
+msgid "Error cleaning albums"
+msgstr "Fehler beim Aktualisieren der Alben"
+
+#: id:328
+msgid "Writing changes..."
+msgstr "Änderungen werden gespeichert..."
+
+#: id:329
+msgid "Error writing changes"
+msgstr "Fehler beim Speichern der Änderungen"
+
+#: id:330
+msgid "This may take some time..."
+msgstr "Einen Moment Geduld bitte..."
+
+#: id:331
+msgid "Compressing database..."
+msgstr "Datenbank wird komprimiert..."
+
+#: id:332
+msgid "Error compressing database"
+msgstr "Fehler beim Komprimieren der Datenbank"
+
+#: id:333
+msgid "Do you want to clean the library?"
+msgstr "Soll die Datenbank bereinigt werden?"
+
+#: id:334
+msgid "Clean library..."
+msgstr "Ungültige Datenbank-Einträge entfernen..."
+
+#: id:335
+msgid "Start"
+msgstr "Start"
+
+#: id:336
+msgid "Framerate conversion"
+msgstr "Bildrate konvertieren"
+
+#: id:337
+msgctxt "Auto context with id 337"
+msgid "Audio output"
+msgstr "Audioausgabe"
+
+#: id:338
+msgid "Analog"
+msgstr "Analog"
+
+#: id:339
+msgid "Optical/Coax"
+msgstr "Optisch/Koaxial"
+
+#: id:340
+msgid "Various artists"
+msgstr "Verschiedene Interpreten"
+
+#: id:341
+msgid "Play disc"
+msgstr "CD/DVD abspielen"
+
+#: id:342
+msgctxt "Auto context with id 342"
+msgid "Movies"
+msgstr "Filme"
+
+#: id:343
+msgid "Adjust framerate"
+msgstr "Framerate anpassen"
+
+#: id:344
+msgid "Actors"
+msgstr "Darsteller"
+
+#: id:345
+msgctxt "Auto context with id 345"
+msgid "Year"
+msgstr "Jahr"
+
+#: id:346
+msgid "Boost volume level on downmix"
+msgstr "Lautstärke bei Downmix erhöhen"
+
+#: id:350
+msgctxt "Auto context with id 350"
+msgid "Programs"
+msgstr "Programme"
+
+#: id:351
+msgctxt "Auto context with id 351"
+msgid "Off"
+msgstr "Aus"
+
+#: id:352
+msgid "Dim"
+msgstr "Dimmen"
+
+#: id:353
+msgid "Black"
+msgstr "Schwarz"
+
+#: id:354
+msgid "Matrix trails"
+msgstr "Matrix Spalten"
+
+#: id:355
+msgid "Screensaver time"
+msgstr "Aktivieren nach"
+
+#: id:356
+msgid "Screensaver mode"
+msgstr "Bildschirmschoner"
+
+#: id:357
+msgid "Shutdown function timer"
+msgstr "System automatisch ausschalten"
+
+#: id:358
+msgid "All albums"
+msgstr "Alle Alben"
+
+#: id:359
+msgid "Recently added albums"
+msgstr "Zuletzt hinzugefügte Alben"
+
+#: id:360
+msgctxt "Auto context with id 360"
+msgid "Screensaver"
+msgstr "Bildschirmschoner"
+
+#: id:361
+msgid "R. Slideshow"
+msgstr "Rekurs. Diaschau"
+
+#: id:362
+msgid "Screensaver dim level"
+msgstr "Bildschirm verdunkeln um"
+
+#: id:363
+msgid "Sort by: File"
+msgstr "Nach Datei"
+
+#: id:364
+msgid "- Dolby Digital (AC3) capable receiver"
+msgstr "- Receiver unterstützt AC3"
+
+#: id:365
+msgctxt "Auto context with id 365"
+msgid "Sort by: Name"
+msgstr "Nach Namen"
+
+#: id:366
+msgid "Sort by: Year"
+msgstr "Nach Jahr"
+
+#: id:367
+msgid "Sort by: Rating"
+msgstr "Nach Bewertung"
+
+#: id:368
+msgid "IMDb"
+msgstr "IMDb"
+
+#: id:369
+msgctxt "Auto context with id 369"
+msgid "Title"
+msgstr "Titel"
+
+#: id:370
+msgid "Thunderstorms"
+msgstr "Gewitter"
+
+#: id:371
+msgid "Partly"
+msgstr "teilweise"
+
+#: id:372
+msgid "Mostly"
+msgstr "weitgehend"
+
+#: id:373
+msgid "Sunny"
+msgstr "sonnig"
+
+#: id:374
+msgid "Cloudy"
+msgstr "wolkig"
+
+#: id:375
+msgid "Snow"
+msgstr "Schnee"
+
+#: id:376
+msgid "Rain"
+msgstr "Regen"
+
+#: id:377
+msgid "Light"
+msgstr "leichter"
+
+#: id:378
+msgid "AM"
+msgstr "vormittags"
+
+#: id:379
+msgid "PM"
+msgstr "nachmittags"
+
+#: id:380
+msgid "Showers"
+msgstr "Schauer"
+
+#: id:381
+msgid "Few"
+msgstr "wenige"
+
+#: id:382
+msgid "Scattered"
+msgstr "vereinzelt"
+
+#: id:383
+msgctxt "Auto context with id 383"
+msgid "Wind"
+msgstr "Wind"
+
+#: id:384
+msgid "Strong"
+msgstr "starker"
+
+#: id:385
+msgid "Fair"
+msgstr "schön"
+
+#: id:386
+msgctxt "Auto context with id 386"
+msgid "Clear"
+msgstr "klar"
+
+#: id:387
+msgid "Clouds"
+msgstr "Wolken"
+
+#: id:388
+msgid "Early"
+msgstr "morgens"
+
+#: id:389
+msgid "Shower"
+msgstr "Regen"
+
+#: id:390
+msgid "Flurries"
+msgstr "Böen"
+
+#: id:391
+msgctxt "Auto context with id 391"
+msgid "Low"
+msgstr "niedrig"
+
+#: id:392
+msgctxt "Auto context with id 392"
+msgid "Medium"
+msgstr "mittel"
+
+#: id:393
+msgctxt "Auto context with id 393"
+msgid "High"
+msgstr "hoch"
+
+#: id:394
+msgid "Fog"
+msgstr "Nebel"
+
+#: id:395
+msgid "Haze"
+msgstr "Dunst"
+
+#: id:396
+msgid "Select location"
+msgstr "Städteauswahl"
+
+#: id:397
+msgid "Refresh time"
+msgstr "Aktualisierungsintervall der Wetterdaten"
+
+#: id:398
+msgid "Temperature units"
+msgstr "Temperatur anzeigen in"
+
+#: id:399
+msgid "Speed units"
+msgstr "Windstärke anzeigen in"
+
+#: id:400
+msgctxt "Auto context with id 400"
+msgid "Weather"
+msgstr "Wetter"
+
+#: id:401
+msgid "Temp"
+msgstr "Temperatur"
+
+#: id:402
+msgid "Feels like"
+msgstr "Gefühlt"
+
+#: id:403
+msgid "UV index"
+msgstr "UV-Wert"
+
+#: id:404
+msgctxt "Auto context with id 404"
+msgid "Wind"
+msgstr "Wind"
+
+#: id:405
+msgid "Dew point"
+msgstr "Taupunkt"
+
+#: id:406
+msgid "Humidity"
+msgstr "Feuchtigkeit"
+
+#: id:409
+msgid "Defaults"
+msgstr "Standards"
+
+#: id:410
+msgid "Accessing weather service"
+msgstr "Verbinde mit Wetterservice"
+
+#: id:411
+msgid "Getting weather for:"
+msgstr "Erhalte Wetter-Informationen für:"
+
+#: id:412
+msgid "Unable to get weather data"
+msgstr "Wetter-Informationen können nicht geladen werden"
+
+#: id:413
+msgid "Manual"
+msgstr "Manuell"
+
+#: id:414
+msgid "No review for this album"
+msgstr "Keine Bewertung für dieses Album"
+
+#: id:415
+msgid "Downloading thumbnail..."
+msgstr "Lade Thumbnail herunter..."
+
+#: id:416
+msgid "Not available"
+msgstr "Nicht verfügbar"
+
+#: id:417
+msgid "View: Big icons"
+msgstr "Große Symbole"
+
+#: id:418
+msgctxt "Auto context with id 418"
+msgid "Low"
+msgstr "Tief"
+
+#: id:419
+msgctxt "Auto context with id 419"
+msgid "High"
+msgstr "Hoch"
+
+#: id:420
+msgid "HDMI"
+msgstr "HDMI"
+
+#: id:422
+msgid "Delete album info"
+msgstr "Albuminformationen löschen"
+
+#: id:423
+msgid "Delete CD information"
+msgstr "CD-Informationen löschen"
+
+#: id:424
+msgid "Select"
+msgstr "Auswählen"
+
+#: id:425
+msgid "No album information found"
+msgstr "Keine Albuminformationen gefunden"
+
+#: id:426
+msgid "No CD information found"
+msgstr "Keine CD-Informationen gefunden"
+
+#: id:427
+msgid "Disc"
+msgstr "Disc"
+
+#: id:428
+msgid "Insert correct CD/DVD"
+msgstr "Bitte korrekte CD/DVD einlegen"
+
+#: id:429
+msgid "Please insert the following disc:"
+msgstr "Bitte folgende CD/DVD einlegen"
+
+#: id:430
+msgid "Sort by: DVD#"
+msgstr "Sortieren nach DVD#"
+
+#: id:431
+msgid "No cache"
+msgstr "Keinen Cache verwenden"
+
+#: id:432
+msgid "Remove movie from library"
+msgstr "Film aus der Datenbank entfernen"
+
+#: id:433
+msgid "Really remove '%s'?"
+msgstr "Soll '%s' wirklich entfernt werden?"
+
+#: id:434
+msgid "From %s at %i %s"
+msgstr "Von %s mit %i %s"
+
+#: id:437
+msgid "Removable disk"
+msgstr "Wechsellaufwerk"
+
+#: id:438
+msgid "Opening file"
+msgstr "Öffne Datei"
+
+#: id:439
+msgid "Cache"
+msgstr "Cache"
+
+#: id:440
+msgid "Harddisk"
+msgstr "Festplatte"
+
+#: id:441
+msgid "UDF"
+msgstr "UDF"
+
+#: id:442
+msgid "Local network"
+msgstr "Lokales Netzwerk"
+
+#: id:443
+msgid "Internet"
+msgstr "Internet"
+
+#: id:444
+msgctxt "Auto context with id 444"
+msgid "Video"
+msgstr "Video"
+
+#: id:445
+msgctxt "Auto context with id 445"
+msgid "Audio"
+msgstr "Audio"
+
+#: id:446
+msgctxt "Auto context with id 446"
+msgid "DVD"
+msgstr "DVD"
+
+#: id:447
+msgid "Autorun media"
+msgstr "Medien automatisch starten"
+
+#: id:448
+msgid "LCD"
+msgstr "LCD"
+
+#: id:449
+msgctxt "Auto context with id 449"
+msgid "Enabled"
+msgstr "Aktivieren"
+
+#: id:450
+msgid "Columns"
+msgstr "Spalten"
+
+#: id:451
+msgid "Row 1 address"
+msgstr "Reihe 1"
+
+#: id:452
+msgid "Row 2 address"
+msgstr "Reihe 2"
+
+#: id:453
+msgid "Row 3 address"
+msgstr "Reihe 3"
+
+#: id:454
+msgid "Row 4 address"
+msgstr "Reihe 4"
+
+#: id:455
+msgid "Rows"
+msgstr "Reihen"
+
+#: id:456
+msgid "Mode"
+msgstr "Modus"
+
+#: id:457
+msgid "Switch view"
+msgstr "Ansicht ändern"
+
+#: id:459
+msgid "Subs"
+msgstr "Untertitel"
+
+#: id:460
+msgid "Audio stream"
+msgstr "Audiospur"
+
+#: id:461
+msgid "[active]"
+msgstr "[aktiv]"
+
+#: id:462
+msgid "Subtitle"
+msgstr "Untertitel"
+
+#: id:463
+msgid "Backlight"
+msgstr "Hintergrundbeleuchtung"
+
+#: id:464
+msgid "Brightness"
+msgstr "Helligkeit"
+
+#: id:465
+msgid "Contrast"
+msgstr "Kontrast"
+
+#: id:466
+msgid "Gamma"
+msgstr "Gamma"
+
+#: id:467
+msgctxt "Auto context with id 467"
+msgid "Type"
+msgstr "Typ"
+
+#: id:468
+msgid "Move the bar to change the OSD position"
+msgstr "Die Leiste bewegen, um die OSD-Position einzustellen"
+
+#: id:469
+msgid "OSD position"
+msgstr "OSD-Position"
+
+#: id:470
+msgid "Credits"
+msgstr "Anerkennung"
+
+#: id:471
+msgid "Modchip"
+msgstr "Modchip"
+
+#: id:474
+msgctxt "Auto context with id 474"
+msgid "Off"
+msgstr "Aus"
+
+#: id:475
+msgid "Music only"
+msgstr "nur Musik"
+
+#: id:476
+msgctxt "Auto context with id 476"
+msgid "Music & video"
+msgstr "Musik & Video"
+
+#: id:477
+msgid "Unable to load playlist"
+msgstr "Playlist konnte nicht geladen werden"
+
+#: id:478
+msgid "OSD"
+msgstr "OSD"
+
+#: id:479
+msgid "Skin & language"
+msgstr "Skin und Sprache"
+
+#: id:480
+msgid "Appearance"
+msgstr "Darstellung"
+
+#: id:481
+msgid "Audio options"
+msgstr "Audioeinstellungen"
+
+#: id:482
+msgid "About XBMC"
+msgstr "Über XBMC"
+
+#: id:485
+msgid "Delete album"
+msgstr "Lösche Album"
+
+#: id:486
+msgid "Repeat"
+msgstr "Wiederholen"
+
+#: id:487
+msgid "Repeat one"
+msgstr "Wiederhole"
+
+#: id:488
+msgid "Repeat folder"
+msgstr "Inhalt eines Ordners wiederholen"
+
+#: id:489
+msgid "Play the next song automatically"
+msgstr "Automatisch nächsten Titel im Ordner abspielen"
+
+#: id:491
+msgid "- Use big icons"
+msgstr "- Große Symbole wechseln"
+
+#: id:492
+msgid "Resize VobSubs"
+msgstr "Vob-Untertitel vergrößern"
+
+#: id:493
+msgid "Advanced options (Experts Only!)"
+msgstr "Erweiterte Optionen (nur für Experten!)"
+
+#: id:494
+msgid "Overall audio headroom"
+msgstr "Übersteuerungsreserve"
+
+#: id:495
+msgid "Upsample videos to GUI resolution"
+msgstr "Videos in GUI-Auflösung abspielen"
+
+#: id:496
+msgid "Calibration"
+msgstr "Kalibrierung"
+
+#: id:497
+msgid "Show file extensions"
+msgstr "Dateityp-Erweiterungen anzeigen"
+
+#: id:498
+msgid "Sort by: Type"
+msgstr "Nach Typ"
+
+#: id:499
+msgid "Unable to connect to online lookup service"
+msgstr "Verbindung mit Online-Service nicht möglich"
+
+#: id:500
+msgid "Downloading album information failed"
+msgstr "Fehler beim Herunterladen der Albuminformationen"
+
+#: id:501
+msgid "Looking for album names..."
+msgstr "Albumnamen werden gesucht..."
+
+#: id:502
+msgctxt "Auto context with id 502"
+msgid "Open"
+msgstr "Offen"
+
+#: id:503
+msgid "Busy"
+msgstr "Beschäftigt"
+
+#: id:504
+msgid "Empty"
+msgstr "Leer"
+
+#: id:505
+msgid "Loading media info from files..."
+msgstr "Metainformationen werden geladen..."
+
+#: id:507
+msgid "Sort by: Usage"
+msgstr "Nach: Gebrauch"
+
+#: id:510
+msgid "Enable visualizations"
+msgstr "Visualisierung verwenden"
+
+#: id:511
+msgid "Enable video mode switching"
+msgstr "Video-Modus auf Basis der Spiele-Region wechseln"
+
+#: id:512
+msgid "Startup window"
+msgstr "Startfenster"
+
+#: id:513
+msgid "Home window"
+msgstr "Hauptfenster"
+
+#: id:514
+msgid "Manual settings"
+msgstr "Manuell einstellen"
+
+#: id:515
+msgid "Genre"
+msgstr "Genre"
+
+#: id:517
+msgid "Recently played albums"
+msgstr "Zuletzt gespielte Alben"
+
+#: id:518
+msgid "Launch"
+msgstr "Starten"
+
+#: id:519
+msgid "Launch in..."
+msgstr "Starten als..."
+
+#: id:521
+msgid "Compilations"
+msgstr "Sampler"
+
+#: id:522
+msgid "Remove source"
+msgstr "Quelle entfernen"
+
+#: id:523
+msgid "Switch media"
+msgstr "Medium wechseln"
+
+#: id:524
+msgid "Select playlist"
+msgstr "Playlist wählen"
+
+#: id:525
+msgid "New playlist..."
+msgstr "Neue Playlist..."
+
+#: id:526
+msgid "Add to playlist"
+msgstr "Zur Playlist hinzufügen"
+
+#: id:527
+msgid "Manually add to library"
+msgstr "Zur Datenbank hinzufügen"
+
+#: id:528
+msgid "Enter title"
+msgstr "Titel eingeben"
+
+#: id:529
+msgid "Error: Duplicate title"
+msgstr "Fehler: Titel doppelt"
+
+#: id:530
+msgid "Select genre"
+msgstr "Genre wählen"
+
+#: id:531
+msgid "New genre"
+msgstr "Neues Genre"
+
+#: id:532
+msgid "Manual addition"
+msgstr "Manuell hinzugefügt"
+
+#: id:533
+msgid "Enter genre"
+msgstr "Genre eingeben"
+
+#: id:534
+msgid "View: %s"
+msgstr "Ansicht: %s"
+
+#: id:535
+msgid "List"
+msgstr "Liste"
+
+#: id:536
+msgid "Icons"
+msgstr "Symbole"
+
+#: id:537
+msgid "Big list"
+msgstr "Liste 2"
+
+#: id:538
+msgid "Big icons"
+msgstr "Symbole 2"
+
+#: id:539
+msgid "Wide"
+msgstr "Wide"
+
+#: id:540
+msgid "Big wide"
+msgstr "Wide 2"
+
+#: id:541
+msgid "Album icons"
+msgstr "Album-Symbole"
+
+#: id:542
+msgid "DVD icons"
+msgstr "DVD-Symbole"
+
+#: id:543
+msgctxt "Auto context with id 543"
+msgid "DVD"
+msgstr "DVD"
+
+#: id:544
+msgctxt "Auto context with id 544"
+msgid "Media info"
+msgstr "Infos"
+
+#: id:545
+msgid "Audio output device"
+msgstr "Audio Ausgabegerät"
+
+#: id:546
+msgid "Passthrough output device"
+msgstr "Digitales Ausgabegerät für Passthrough"
+
+#: id:547
+msgid "No biography for this artist"
+msgstr "Keine Biografie für diesen Interpreten"
+
+#: id:548
+msgid "Downmix multichannel audio to stereo"
+msgstr "Mehrkanal-Audio auf Stereo reduzieren"
+
+#: id:550
+msgid "Sort by: %s"
+msgstr "Nach: %s"
+
+#: id:551
+msgctxt "Auto context with id 551"
+msgid "Name"
+msgstr "Name"
+
+#: id:552
+msgid "Date"
+msgstr "Datum"
+
+#: id:553
+msgid "Size"
+msgstr "Größe"
+
+#: id:554
+msgid "Track"
+msgstr "Nummer"
+
+#: id:555
+msgid "Time"
+msgstr "Zeit"
+
+#: id:556
+msgctxt "Auto context with id 556"
+msgid "Title"
+msgstr "Titel"
+
+#: id:557
+msgid "Artist"
+msgstr "Interpret"
+
+#: id:558
+msgid "Album"
+msgstr "Album"
+
+#: id:559
+msgid "Playlist"
+msgstr "Playlist"
+
+#: id:560
+msgid "ID"
+msgstr "ID"
+
+#: id:561
+msgctxt "Auto context with id 561"
+msgid "File"
+msgstr "Datei"
+
+#: id:562
+msgctxt "Auto context with id 562"
+msgid "Year"
+msgstr "Jahr"
+
+#: id:563
+msgid "Rating"
+msgstr "Bewertung"
+
+#: id:564
+msgctxt "Auto context with id 564"
+msgid "Type"
+msgstr "Typ"
+
+#: id:565
+msgid "Usage"
+msgstr "Gebrauch"
+
+#: id:566
+msgid "Album artist"
+msgstr "Album-Interpret"
+
+#: id:567
+msgid "Play count"
+msgstr "Spielzähler"
+
+#: id:568
+msgid "Last played"
+msgstr "Zuletzt gespielt"
+
+#: id:569
+msgctxt "Auto context with id 569"
+msgid "Comment"
+msgstr "Kommentar"
+
+#: id:570
+msgid "Date added"
+msgstr "Datum (hinzugefügt)"
+
+#: id:571
+msgctxt "Auto context with id 571"
+msgid "Default"
+msgstr "Standard"
+
+#: id:572
+msgid "Studio"
+msgstr "Studio"
+
+#: id:573
+msgid "Path"
+msgstr "Pfad"
+
+#: id:574
+msgctxt "Auto context with id 574"
+msgid "Country"
+msgstr "Land"
+
+#: id:575
+msgid "In progress"
+msgstr "In Gange"
+
+#: id:576
+msgid "Times played"
+msgstr "Abgespielt"
+
+#: id:580
+msgid "Sort direction"
+msgstr "Sortierrichtung"
+
+#: id:581
+msgid "Sort method"
+msgstr "Sortiermethode"
+
+#: id:582
+msgctxt "Auto context with id 582"
+msgid "View mode"
+msgstr "Ansicht"
+
+#: id:583
+msgid "Remember views for different folders"
+msgstr "Ansicht für einzelne Ordner speichern"
+
+#: id:584
+msgid "Ascending"
+msgstr "Aufsteigend"
+
+#: id:585
+msgid "Descending"
+msgstr "Absteigend"
+
+#: id:586
+msgid "Edit playlist"
+msgstr "Playlist editieren"
+
+#: id:587
+msgid "Filter"
+msgstr "Filter"
+
+#: id:588
+msgid "Cancel party mode"
+msgstr "Partymodus abbrechen"
+
+#: id:589
+msgid "Party mode"
+msgstr "Partymodus"
+
+#: id:590
+msgid "Random"
+msgstr "Zufall"
+
+#: id:591
+msgctxt "Auto context with id 591"
+msgid "Off"
+msgstr "Aus"
+
+#: id:592
+msgid "One"
+msgstr "Eins"
+
+#: id:593
+msgid "All"
+msgstr "Alle"
+
+#: id:594
+msgctxt "Auto context with id 594"
+msgid "Off"
+msgstr "Aus"
+
+#: id:595
+msgid "Repeat: Off"
+msgstr "Wiederholen aus"
+
+#: id:596
+msgid "Repeat: One"
+msgstr "Wiederholen eins"
+
+#: id:597
+msgid "Repeat: All"
+msgstr "Wiederholen alle"
+
+#: id:600
+msgid "Rip audio CD"
+msgstr "Audio-CD kopieren"
+
+#: id:601
+msgctxt "Auto context with id 601"
+msgid "Medium"
+msgstr "Mittlere Qualität"
+
+#: id:602
+msgctxt "Auto context with id 602"
+msgid "Standard"
+msgstr "Standard-Qualität"
+
+#: id:603
+msgid "Extreme"
+msgstr "Höchste Qualität"
+
+#: id:604
+msgid "Constant bitrate"
+msgstr "konstante Bitrate"
+
+#: id:605
+msgid "Ripping..."
+msgstr "Kopieren..."
+
+#: id:607
+msgid "To:"
+msgstr "Zielordner:"
+
+#: id:608
+msgid "Could not rip CD or track"
+msgstr "CD oder Titel konnte nicht kopiert werden!"
+
+#: id:609
+msgid "CDDARipPath is not set."
+msgstr "CD Ziel-Pfad ist nicht konfiguriert."
+
+#: id:610
+msgid "Rip audio track"
+msgstr "Titel kopieren"
+
+#: id:611
+msgid "Enter number"
+msgstr "Nummer eingeben"
+
+#: id:612
+msgid "Bits/Sample"
+msgstr "Bits/Sample"
+
+#: id:613
+msgid "Sample Frequency"
+msgstr "Sample Frequenz"
+
+#: id:620
+msgid "Audio CDs"
+msgstr "Musik CDs"
+
+#: id:621
+msgid "Encoder"
+msgstr "Encoder für Umwandlung"
+
+#: id:622
+msgid "Quality"
+msgstr "Qualität"
+
+#: id:623
+msgid "Bitrate"
+msgstr "Bitrate"
+
+#: id:624
+msgid "Include track number"
+msgstr "Titelnummer einbeziehen"
+
+#: id:625
+msgid "All songs of"
+msgstr "Alle Titel von"
+
+#: id:629
+msgctxt "Auto context with id 629"
+msgid "View mode"
+msgstr "Ansicht"
+
+#: id:630
+msgctxt "Auto context with id 630"
+msgid "Normal"
+msgstr "Normal"
+
+#: id:631
+msgid "Zoom"
+msgstr "Zoom"
+
+#: id:632
+msgid "Stretch 4:3"
+msgstr "4:3 Ausgabe"
+
+#: id:633
+msgid "Wide Zoom"
+msgstr "14:9 Ausgabe"
+
+#: id:634
+msgid "Stretch 16:9"
+msgstr "16:9 Ausgabe"
+
+#: id:635
+msgid "Original Size"
+msgstr "Originalgröße"
+
+#: id:636
+msgctxt "Auto context with id 636"
+msgid "Custom"
+msgstr "Benutzerdefiniert"
+
+#: id:637
+msgid "Replay gain"
+msgstr "Wiedergabeverstärkung"
+
+#: id:638
+msgid "Replaygain volume adjustments"
+msgstr "Modus für Wiedergabeverstärkung"
+
+#: id:639
+msgid "Use track levels"
+msgstr "Titel-Niveau"
+
+#: id:640
+msgid "Use album levels"
+msgstr "Album-Niveau"
+
+#: id:641
+msgid "PreAmp Level - Replay gained files"
+msgstr "PreAmp-Level bei Wiedergabeverstärkung"
+
+#: id:642
+msgid "PreAmp Level - Non replay gained files"
+msgstr "PreAmp-Level ohne Wiedergabeverstärkung"
+
+#: id:643
+msgid "Avoid clipping on replay gained files"
+msgstr "Übersteuerung bei Wiedergabeverstärkung vermeiden"
+
+#: id:644
+msgid "Crop black bars"
+msgstr "Schwarze Balken entfernen"
+
+#: id:645
+msgid "Need to unpack a big file. Continue?"
+msgstr "Eine große Datei muss entpackt werden. Fortfahren?"
+
+#: id:646
+msgid "Remove from library"
+msgstr "Aus Datenbank entfernen"
+
+#: id:647
+msgid "Export video library"
+msgstr "Videodatenbank exportieren"
+
+#: id:648
+msgid "Import video library"
+msgstr "Videodatenbank importieren"
+
+#: id:649
+msgid "Importing"
+msgstr "Datenbank wird importiert"
+
+#: id:650
+msgid "Exporting"
+msgstr "Datenbank wird exportiert"
+
+#: id:651
+msgid "Browse for library"
+msgstr "Nach Datenbank durchsuchen"
+
+#: id:652
+msgid "Years"
+msgstr "Jahre"
+
+#: id:653
+msgid "Update library"
+msgstr "Datenbank aktualisieren"
+
+#: id:654
+msgid "Show debug info"
+msgstr "Debug-Info anzeigen"
+
+#: id:655
+msgid "Browse for executable"
+msgstr "Nach einem Programm durchsuchen"
+
+#: id:656
+msgid "Browse for playlist"
+msgstr "Nach einer Playlist durchsuchen"
+
+#: id:657
+msgid "Browse for folder"
+msgstr "Nach einem Ordner durchsuchen"
+
+#: id:658
+msgid "Song information"
+msgstr "Titelinformationen"
+
+#: id:659
+msgid "Non-linear stretch"
+msgstr "Nichtlineare Vergrößerung"
+
+#: id:660
+msgid "Volume amplification"
+msgstr "Lautstärkeanpassung"
+
+#: id:661
+msgid "Choose export folder"
+msgstr "Wähle Export-Ordner"
+
+#: id:662
+msgid "This file is no longer available."
+msgstr "Diese Datei ist nicht mehr verfügbar."
+
+#: id:663
+msgid "Would you like to remove it from the library?"
+msgstr "Soll der Eintrag aus der Datenbank entfernt werden?"
+
+#: id:664
+msgid "Browse for Script"
+msgstr "Nach Skript suchen"
+
+#: id:665
+msgid "Compression level"
+msgstr "Komprimierungsgrad"
+
+#: id:700
+msgid "Cleaning up library"
+msgstr "Datenbank wird bereinigt"
+
+#: id:701
+msgid "Removing old songs from the library"
+msgstr "Alte Musikdaten aus der Datenbank löschen"
+
+#: id:702
+msgid "This path has been scanned before"
+msgstr "Dieser Pfad wurde bereits durchsucht"
+
+#: id:705
+msgctxt "Auto context with id 705"
+msgid "Network"
+msgstr "Netzwerk"
+
+#: id:706
+msgid "- Server"
+msgstr "- Server"
+
+#: id:708
+msgid "Use an HTTP proxy server to access the internet"
+msgstr "HTTP-Proxy für Internetzugriff verwenden"
+
+#: id:711
+msgid "Internet Protocol (IP)"
+msgstr "Internet-Protokoll (IP)"
+
+#: id:712
+msgid "Invalid port specified. Value must be between 1 and 65535."
+msgstr "Es wurde ein ungültiger Port festgelegt. Der Port muß zwischen 1 und 65535 liegen."
+
+#: id:713
+msgid "HTTP proxy"
+msgstr "HTTP-Proxy"
+
+#: id:715
+msgid "- Assignment"
+msgstr "- Zuweisung der IP-Adresse"
+
+#: id:716
+msgid "Automatic (DHCP)"
+msgstr "Automatisch (DHCP)"
+
+#: id:717
+msgid "Manual (Static)"
+msgstr "Manuell (Statisch)"
+
+#: id:719
+msgid "- IP address"
+msgstr "- IP-Adresse"
+
+#: id:720
+msgid "- Netmask"
+msgstr "- Subnetzmaske"
+
+#: id:721
+msgid "- Default gateway"
+msgstr "- Standardgateway"
+
+#: id:722
+msgid "- DNS server"
+msgstr "- DNS-Server"
+
+#: id:723
+msgid "Save & restart"
+msgstr "Speichern & Neustarten"
+
+#: id:724
+msgid "Invalid address specified. Value must be AAA.BBB.CCC.DDD"
+msgstr "Ungültige Adresse. Das Format muss AAA.BBB.CCC.DDD entsprechen"
+
+#: id:725
+msgid "with numbers between 0 and 255."
+msgstr "mit Zahlen zwischen 0 und 255 sein."
+
+#: id:726
+msgid "Changes not saved. Continue without saving?"
+msgstr "Änderungen nicht gespeichert. Weiter ohne Speichern?"
+
+#: id:727
+msgid "Web server"
+msgstr "Webserver"
+
+#: id:728
+msgctxt "Auto context with id 728"
+msgid "FTP server"
+msgstr "FTP-Server"
+
+#: id:730
+msgid "- Port"
+msgstr "- Port"
+
+#: id:732
+msgid "Save & apply"
+msgstr "Speichern & Übernehmen"
+
+#: id:733
+msgid "- Password"
+msgstr "- Passwort"
+
+#: id:734
+msgid "No pass"
+msgstr "Kein Passwort"
+
+#: id:735
+msgid "- Character set"
+msgstr "- Zeichensatz"
+
+#: id:736
+msgid "- Style"
+msgstr "- Stil"
+
+#: id:737
+msgid "- Colour"
+msgstr "- Farbe"
+
+#: id:738
+msgctxt "Auto context with id 738"
+msgid "Normal"
+msgstr "Normal"
+
+#: id:739
+msgid "Bold"
+msgstr "Fett"
+
+#: id:740
+msgid "Italics"
+msgstr "Kursiv"
+
+#: id:741
+msgid "Bold italics"
+msgstr "Fett kursiv"
+
+#: id:742
+msgctxt "Auto context with id 742"
+msgid "White"
+msgstr "Weiß"
+
+#: id:743
+msgctxt "Auto context with id 743"
+msgid "Yellow"
+msgstr "Gelb"
+
+#: id:744
+msgctxt "Auto context with id 744"
+msgid "Files"
+msgstr "Dateien"
+
+#: id:745
+msgid "No scanned information for this view"
+msgstr "Es sind keine Informationen in der Datenbank verfügbar"
+
+#: id:746
+msgid "Please turn off library mode"
+msgstr "Bitte wieder zur Datei-Ansicht wechseln"
+
+#: id:747
+msgid "Error loading image"
+msgstr "Fehler beim Laden des Bildes"
+
+#: id:748
+msgid "Edit path"
+msgstr "Pfad bearbeiten"
+
+#: id:749
+msgid "Mirror image"
+msgstr "Spiegelbild"
+
+#: id:750
+msgid "Are you sure?"
+msgstr "Sind Sie sicher?"
+
+#: id:751
+msgid "Removing source"
+msgstr "Quelle entfernen"
+
+#: id:754
+msgid "Add program link"
+msgstr "Programmlink hinzufügen"
+
+#: id:755
+msgid "Edit program path"
+msgstr "Programmpfad bearbeiten"
+
+#: id:756
+msgid "Edit program name"
+msgstr "Programnamen bearbeiten"
+
+#: id:757
+msgid "Edit path depth"
+msgstr "Pfadtiefe bearbeiten"
+
+#: id:759
+msgid "View: Big list"
+msgstr "Große Liste"
+
+#: id:760
+msgctxt "Auto context with id 760"
+msgid "Yellow"
+msgstr "Gelb"
+
+#: id:761
+msgctxt "Auto context with id 761"
+msgid "White"
+msgstr "Weiß"
+
+#: id:762
+msgid "Blue"
+msgstr "Blau"
+
+#: id:763
+msgid "Bright green"
+msgstr "Hellgrün"
+
+#: id:764
+msgid "Yellow green"
+msgstr "Gelbgrün"
+
+#: id:765
+msgid "Cyan"
+msgstr "Blaugrün"
+
+#: id:766
+msgid "Light grey"
+msgstr "Hellgrau"
+
+#: id:767
+msgid "Grey"
+msgstr "Grau"
+
+#: id:770
+msgid "Error %i: share not available"
+msgstr "Fehler %i: Quelle ist nicht verfügbar!"
+
+#: id:772
+msgctxt "Auto context with id 772"
+msgid "Audio output"
+msgstr "Audio-Hardware"
+
+#: id:773
+msgid "Seeking"
+msgstr "Positionieren"
+
+#: id:774
+msgid "Slideshow folder"
+msgstr "Diaschau-Ordner"
+
+#: id:775
+msgid "Network interface"
+msgstr "Netzwerkkarte"
+
+#: id:776
+msgid "- Wireless network name (ESSID)"
+msgstr "- Wireless Netzwerkname (ESSID)"
+
+#: id:777
+msgid "- Wireless password"
+msgstr "- Wireless Passwort"
+
+#: id:778
+msgid "- Wireless security"
+msgstr "- Wireless Sicherheit"
+
+#: id:779
+msgid "Save and apply network interface settings"
+msgstr "Speichern und Übernehmen der Netzwerkkarteneinstellung"
+
+#: id:780
+msgid "No encryption"
+msgstr "Keine Verschlüsselung"
+
+#: id:781
+msgid "WEP"
+msgstr "WEP"
+
+#: id:782
+msgid "WPA"
+msgstr "WPA"
+
+#: id:783
+msgid "WPA2"
+msgstr "WPA2"
+
+#: id:784
+msgid "Applying network interface settings. Please wait."
+msgstr "Übernehme Netzwerkkarteneinstellung. Bitte warten."
+
+#: id:785
+msgid "Network interface restarted successfully."
+msgstr "Netzwerkkarte erfolgreich neugestartet."
+
+#: id:786
+msgid "Network interface did not start successfully."
+msgstr "Netzwerkkarte konnte nicht erfolgreich gestartet werden."
+
+#: id:787
+msgid "Interface disabled"
+msgstr "Karte deaktiviert"
+
+#: id:788
+msgid "Network interface disabled successfully."
+msgstr "Netzwerkkarte erfolgreich deaktiviert."
+
+#: id:789
+msgid "Wireless network name (ESSID)"
+msgstr "Wireless Netzwerkname (ESSID)"
+
+#: id:790
+msgid "Remote control"
+msgstr "Fernsteuerung"
+
+#: id:791
+msgid "Allow programs on this system to control XBMC"
+msgstr "Steuerung über lokale Programme zulassen"
+
+#: id:792
+msgctxt "Auto context with id 792"
+msgid "Port"
+msgstr "Port"
+
+#: id:793
+msgid "Port range"
+msgstr "Port-Bereich"
+
+#: id:794
+msgid "Allow programs on other systems to control XBMC"
+msgstr "Steuerung über entfernte Programme zulassen"
+
+#: id:795
+msgid "Initial repeat delay (ms)"
+msgstr "Anfängliche Wiederholungsverzögerung (ms)"
+
+#: id:796
+msgid "Continuous repeat delay (ms)"
+msgstr "Kontinuierliche Wiederholungsverzögerung (ms)"
+
+#: id:797
+msgid "Maximum number of clients"
+msgstr "Maximale Anzahl der Clients"
+
+#: id:798
+msgid "Internet access"
+msgstr "Internetzugriff"
+
+#: id:850
+msgid "Invalid port number entered"
+msgstr "Ungültige Portnummer eingegeben"
+
+#: id:851
+msgid "Valid port range is 1-65535"
+msgstr "Gültige Ports: 1-65535"
+
+#: id:852
+msgid "Valid port range is 1024-65535"
+msgstr "Gültige Ports: 1024-65535"
+
+#: id:998
+msgid "Add Music..."
+msgstr "Musik hinzufügen..."
+
+#: id:999
+msgid "Add Videos..."
+msgstr "Videos hinzufügen..."
+
+#: id:1000
+msgid "- Preview"
+msgstr "- Vorschau"
+
+#: id:1001
+msgid "Unable to connect"
+msgstr "Verbindung nicht möglich"
+
+#: id:1002
+msgid "XBMC was unable to connect to the network location."
+msgstr "XBMC konnte sich nicht mit der Netzwerkfreigabe verbinden."
+
+#: id:1003
+msgid "This could be due to the network not being connected."
+msgstr "Es könnte sein, daß das Netzwerk nicht verbunden ist."
+
+#: id:1004
+msgid "Would you like to add it anyway?"
+msgstr "Soll die Freigabe trotzdem hinzugefügt werden?"
+
+#: id:1006
+msgctxt "Auto context with id 1006"
+msgid "IP address"
+msgstr "IP-Adresse"
+
+#: id:1007
+msgid "Add network location"
+msgstr "Netzwerkfreigabe"
+
+#: id:1008
+msgid "Protocol"
+msgstr "Protokoll"
+
+#: id:1009
+msgid "Server address"
+msgstr "Serveradresse"
+
+#: id:1010
+msgid "Server name"
+msgstr "Server"
+
+#: id:1011
+msgid "Remote path"
+msgstr "Remote-Pfad"
+
+#: id:1012
+msgid "Shared folder"
+msgstr "Freigabe"
+
+#: id:1013
+msgctxt "Auto context with id 1013"
+msgid "Port"
+msgstr "Port"
+
+#: id:1014
+msgctxt "Auto context with id 1014"
+msgid "Username"
+msgstr "Benutzername"
+
+#: id:1015
+msgid "Browse for network server"
+msgstr "Nach Netzwerkserver suchen"
+
+#: id:1016
+msgid "Enter the network address of the server"
+msgstr "Bitte die Netzwerkadresse des Servers eingeben"
+
+#: id:1017
+msgid "Enter the path on the server"
+msgstr "Bitte den Namen der Netzwerkfreigabe eingeben"
+
+#: id:1018
+msgid "Enter the port number"
+msgstr "Bitte die Port-Nummer eingeben"
+
+#: id:1019
+msgid "Enter the username"
+msgstr "Bitte den Benutzernamen eingeben"
+
+#: id:1020
+msgid "Add %s source"
+msgstr "Quelle für %s hinzufügen"
+
+#: id:1021
+msgid "Enter the paths or browse for the media locations."
+msgstr "Bitte den Pfad eingeben oder 'Suchen' wählen."
+
+#: id:1022
+msgid "Enter a name for this media Source."
+msgstr "Bitte den Namen der Medienquelle eingeben."
+
+#: id:1023
+msgid "Browse for new share"
+msgstr "Nach einer neuen Quelle suchen"
+
+#: id:1024
+msgid "Browse"
+msgstr "Suchen"
+
+#: id:1025
+msgid "Could not retrieve directory information."
+msgstr "Der Ordner konnte nicht geöffnet werden."
+
+#: id:1026
+msgid "Add source"
+msgstr "Quelle hinzufügen"
+
+#: id:1027
+msgid "Edit source"
+msgstr "Quelle bearbeiten"
+
+#: id:1028
+msgid "Edit %s source"
+msgstr "Quelle für %s bearbeiten"
+
+#: id:1029
+msgid "Enter the new label"
+msgstr "Bitte eine neue Bezeichnung eingeben"
+
+#: id:1030
+msgid "Browse for image"
+msgstr "Nach Bild suchen"
+
+#: id:1031
+msgid "Browse for image folder"
+msgstr "Nach Bilderordner suchen"
+
+#: id:1032
+msgid "Add network location..."
+msgstr "Netzwerkfreigabe hinzufügen..."
+
+#: id:1033
+msgid "Browse for file"
+msgstr "Nach einer Datei suchen"
+
+#: id:1034
+msgid "Submenu"
+msgstr "Untermenü"
+
+#: id:1035
+msgid "Enable submenu buttons"
+msgstr "Untermenü-Einträge aktivieren"
+
+#: id:1036
+msgid "Favourites"
+msgstr "Favoriten"
+
+#: id:1037
+msgid "Video Add-ons"
+msgstr "Video Add-ons"
+
+#: id:1038
+msgid "Music Add-ons"
+msgstr "Musik Add-ons"
+
+#: id:1039
+msgid "Picture Add-ons"
+msgstr "Bilder Add-ons"
+
+#: id:1040
+msgid "Loading directory"
+msgstr "Ordner wird geladen"
+
+#: id:1041
+msgid "Retrieved %i items"
+msgstr "%i Einträge geladen"
+
+#: id:1042
+msgid "Retrieved %i of %i items"
+msgstr "%i von %i Einträgen geladen"
+
+#: id:1043
+msgid "Program Add-ons"
+msgstr "Programm Add-ons"
+
+#: id:1044
+msgid "Set plugin thumb"
+msgstr "Setze Plugin Thumbnail"
+
+#: id:1045
+msgid "Add-on settings"
+msgstr "Plugin-Einstellungen"
+
+#: id:1046
+msgid "Access points"
+msgstr "Zugangspunkte"
+
+#: id:1047
+msgid "Other..."
+msgstr "Andere..."
+
+#: id:1048
+msgid "- Username"
+msgstr "- Benutzername"
+
+#: id:1049
+msgid "Script settings"
+msgstr "Skripteinstellungen"
+
+#: id:1050
+msgid "Singles"
+msgstr "Singles"
+
+#: id:1051
+msgid "Enter web address"
+msgstr "URL eingeben"
+
+#: id:1200
+msgid "SMB client"
+msgstr "SMB-Client"
+
+#: id:1202
+msgid "Workgroup"
+msgstr "Arbeitsgruppe"
+
+#: id:1203
+msgid "Default username"
+msgstr "Standard-Benutzername"
+
+#: id:1204
+msgid "Default password"
+msgstr "Standard-Passwort"
+
+#: id:1207
+msgid "WINS server"
+msgstr "WINS-Server"
+
+#: id:1208
+msgid "Mount SMB shares"
+msgstr "SMB Freigaben einhängen"
+
+#: id:1210
+msgctxt "Auto context with id 1210"
+msgid "Remove"
+msgstr "Entfernen"
+
+#: id:1211
+msgctxt "Auto context with id 1211"
+msgid "Music"
+msgstr "Musik"
+
+#: id:1212
+msgctxt "Auto context with id 1212"
+msgid "Video"
+msgstr "Video"
+
+#: id:1213
+msgctxt "Auto context with id 1213"
+msgid "Pictures"
+msgstr "Bilder"
+
+#: id:1214
+msgctxt "Auto context with id 1214"
+msgid "Files"
+msgstr "Dateien"
+
+#: id:1215
+msgctxt "Auto context with id 1215"
+msgid "Music & video"
+msgstr "Musik & Videos"
+
+#: id:1216
+msgid "Music & pictures"
+msgstr "Musik & Bilder"
+
+#: id:1217
+msgid "Music & files"
+msgstr "Musik & Dateien"
+
+#: id:1218
+msgid "Video & pictures"
+msgstr "Videos & Bilder"
+
+#: id:1219
+msgid "Video & files"
+msgstr "Videos & Dateien"
+
+#: id:1220
+msgid "Pictures & files"
+msgstr "Bilder & Dateien"
+
+#: id:1221
+msgid "Music & video & pictures"
+msgstr "Musik & Videos & Bilder"
+
+#: id:1222
+msgid "Music & video & pictures & files"
+msgstr "Musik & Videos & Bilder & Dateien"
+
+#: id:1223
+msgctxt "Auto context with id 1223"
+msgid "Disabled"
+msgstr "Deaktiviert"
+
+#: id:1226
+msgid "Files & music & video"
+msgstr "Dateien & Musik & Videos"
+
+#: id:1227
+msgid "Files & pictures & music"
+msgstr "Dateien & Bilder & Musik"
+
+#: id:1228
+msgid "Files & pictures & video"
+msgstr "Dateien & Bilder & Videos"
+
+#: id:1229
+msgid "Music & programs"
+msgstr "Musik & Programme"
+
+#: id:1230
+msgid "Video & programs"
+msgstr "Videos & Programme"
+
+#: id:1231
+msgid "Pictures & programs"
+msgstr "Bilder & Programme"
+
+#: id:1232
+msgid "Music & video & pictures & programs"
+msgstr "Musik & Videos & Bilder & Programme"
+
+#: id:1233
+msgid "Programs & video & music"
+msgstr "Programme & Videos & Musik"
+
+#: id:1234
+msgid "Programs & pictures & music"
+msgstr "Programme & Bilder & Musik"
+
+#: id:1235
+msgid "Programs & pictures & video"
+msgstr "Programme & Bilder & Videos"
+
+#: id:1250
+msgid "Auto-detection"
+msgstr "Automatische erkennung"
+
+#: id:1251
+msgid "Auto-detect system"
+msgstr "Andere Systeme erkennen"
+
+#: id:1252
+msgid "Nickname"
+msgstr "Nickname"
+
+#: id:1254
+msgid "Ask to connect"
+msgstr "Nachfragen ob eine Verbindung aufgebaut werden soll"
+
+#: id:1255
+msgid "Send FTP user and password"
+msgstr "FTP-Benutzername und -Passwort senden"
+
+#: id:1256
+msgid "Ping interval"
+msgstr "Ping-Intervall"
+
+#: id:1257
+msgid "Would you like to connect to the auto-detected system?"
+msgstr "Soll eine Verbindung zum automatisch gefundenen System aufgebaut werden?"
+
+#: id:1259
+msgid "Zeroconf"
+msgstr ""
+
+#: id:1260
+msgid "Announce these services to other systems via Zeroconf"
+msgstr "Zeroconf-Veröffentlichung"
+
+#: id:1270
+msgid "Allow XBMC to receive AirPlay content"
+msgstr "AirPlay Inhalte empfangen"
+
+#: id:1271
+msgid "Device name"
+msgstr "Gerätename"
+
+#: id:1272
+msgid "- Use password protection"
+msgstr "- Kennwortschutz verwenden"
+
+#: id:1273
+msgid "AirPlay"
+msgstr ""
+
+#: id:1300
+msgid "Custom audio device"
+msgstr "Benutzerdefiniertes Audiogerät"
+
+#: id:1301
+msgid "Custom passthrough device"
+msgstr "Benutzerdefiniertes Audiogerät für Passthrough"
+
+#: id:1396
+msgid "Drifting"
+msgstr "rutschig"
+
+#: id:1397
+msgid "and"
+msgstr "und"
+
+#: id:1398
+msgid "Freezing"
+msgstr "frierend"
+
+#: id:1399
+msgid "Late"
+msgstr "spät"
+
+#: id:1400
+msgid "Isolated"
+msgstr "vereinzelt"
+
+#: id:1401
+msgid "Thundershowers"
+msgstr "Gewitterschauer"
+
+#: id:1402
+msgid "Thunder"
+msgstr "Donner"
+
+#: id:1403
+msgctxt "Auto context with id 1403"
+msgid "Sun"
+msgstr "Sonne"
+
+#: id:1404
+msgid "Heavy"
+msgstr "heftig"
+
+#: id:1405
+msgid "in"
+msgstr "in"
+
+#: id:1406
+msgid "the"
+msgstr "der"
+
+#: id:1407
+msgid "Vicinity"
+msgstr "Umgebung"
+
+#: id:1408
+msgid "Ice"
+msgstr "Eis"
+
+#: id:1409
+msgid "Crystals"
+msgstr "Kristall"
+
+#: id:1410
+msgid "Calm"
+msgstr "windstill"
+
+#: id:1411
+msgid "with"
+msgstr "mit"
+
+#: id:1412
+msgid "windy"
+msgstr "windig"
+
+#: id:1413
+msgid "drizzle"
+msgstr "Niesel"
+
+#: id:1414
+msgid "Thunderstorm"
+msgstr "Gewitter"
+
+#: id:1415
+msgid "Drizzle"
+msgstr "Niesel"
+
+#: id:1416
+msgid "Foggy"
+msgstr "Neblig"
+
+#: id:1417
+msgid "Grains"
+msgstr "Graupel"
+
+#: id:1418
+msgid "T-Storms"
+msgstr "Gewitter"
+
+#: id:1419
+msgid "T-Showers"
+msgstr "Gewitterregen"
+
+#: id:1420
+msgid "Moderate"
+msgstr "Mäßig"
+
+#: id:1421
+msgid "Very High"
+msgstr "Sehr Hoch"
+
+#: id:1422
+msgid "Windy"
+msgstr "Windig"
+
+#: id:1423
+msgid "Mist"
+msgstr "Dunst"
+
+#: id:1450
+msgid "Put display to sleep when idle"
+msgstr "Energiesparmodus des Bildschirms aktivieren"
+
+#: id:2050
+msgid "Runtime"
+msgstr "Laufzeit"
+
+#: id:2100
+msgid "Script failed! : %s"
+msgstr "Script-Fehler! : %s"
+
+#: id:2101
+msgid "Newer version needed - See log"
+msgstr "Neuere Version benötigt - Siehe Logfile"
+
+#: id:4501
+msgid "Enable LCD/VFD"
+msgstr "LCD/VFD benutzen"
+
+#: id:10000
+msgid "Home"
+msgstr "Hauptmenü"
+
+#: id:10001
+msgctxt "Auto context with id 10001"
+msgid "Programs"
+msgstr "Programme"
+
+#: id:10002
+msgctxt "Auto context with id 10002"
+msgid "Pictures"
+msgstr "Bilder"
+
+#: id:10003
+msgctxt "Auto context with id 10003"
+msgid "File manager"
+msgstr "Dateimanager"
+
+#: id:10004
+msgctxt "Auto context with id 10004"
+msgid "Settings"
+msgstr "Einstellungen"
+
+#: id:10005
+msgctxt "Auto context with id 10005"
+msgid "Music"
+msgstr "Musik"
+
+#: id:10006
+msgctxt "Auto context with id 10006"
+msgid "Videos"
+msgstr "Videos"
+
+#: id:10007
+msgid "System information"
+msgstr "Systeminformationen"
+
+#: id:10008
+msgid "Settings - General"
+msgstr "Einstellungen->Allgemein"
+
+#: id:10009
+msgid "Settings - Screen"
+msgstr "Einstellungen->Bildschirm"
+
+#: id:10010
+msgid "Settings - Appearance - GUI Calibration"
+msgstr "Einstellungen->Darstellung->GUI-Kalibrierung"
+
+#: id:10011
+msgid "Settings - Videos - Screen Calibration"
+msgstr "Einstellungen->Videos->Kalibrierung"
+
+#: id:10012
+msgid "Settings - Pictures"
+msgstr "Einstellungen->Bilder"
+
+#: id:10013
+msgid "Settings - Programs"
+msgstr "Einstellungen->Programme"
+
+#: id:10014
+msgid "Settings - Weather"
+msgstr "Einstellungen->Wetter"
+
+#: id:10015
+msgid "Settings - Music"
+msgstr "Einstellungen->Musik"
+
+#: id:10016
+msgid "Settings - System"
+msgstr "Einstellungen->System"
+
+#: id:10017
+msgid "Settings - Videos"
+msgstr "Einstellungen->Videos"
+
+#: id:10018
+msgid "Settings - Network"
+msgstr "Einstellungen->Netzwerk"
+
+#: id:10019
+msgid "Settings - Appearance"
+msgstr "Einstellungen->Darstellung"
+
+#: id:10020
+msgctxt "Auto context with id 10020"
+msgid "Scripts"
+msgstr "Skripte"
+
+#: id:10021
+msgid "Web Browser"
+msgstr "Webbrowser"
+
+#: id:10025
+msgctxt "Auto context with id 10025"
+msgid "Videos"
+msgstr ""
+
+#: id:10028
+msgid "Videos/Playlist"
+msgstr "Videos/Playlisten"
+
+#: id:10029
+msgctxt "Auto context with id 10029"
+msgid "Login screen"
+msgstr "Anmeldebildschirm"
+
+#: id:10034
+msgid "Settings - Profiles"
+msgstr "Einstellungen->Profile"
+
+#: id:10040
+msgid "Addon browser"
+msgstr "Addon-Browser"
+
+#: id:10100
+msgid "Yes/No dialog"
+msgstr "Ja/Nein Dialog"
+
+#: id:10101
+msgid "Progress dialog"
+msgstr "Fortschrittsanzeige"
+
+#: id:10210
+msgid "Looking for subtitles..."
+msgstr "Suche nach Untertiteln..."
+
+#: id:10211
+msgid "Looking for or caching subtitles..."
+msgstr "Zwischenspeichern der Untertitel..."
+
+#: id:10212
+msgid "terminating"
+msgstr "Abbruch"
+
+#: id:10213
+msgid "buffering"
+msgstr "Zwischenspeichern..."
+
+#: id:10214
+msgid "Opening stream"
+msgstr "Öffne Stream"
+
+#: id:10500
+msgid "Music/Playlist"
+msgstr "Musik/Playlisten"
+
+#: id:10501
+msgid "Music/Files"
+msgstr "Musik/Dateien"
+
+#: id:10502
+msgid "Music/Library"
+msgstr "Musik/Datenbank"
+
+#: id:10503
+msgid "Playlist editor"
+msgstr "Playlist-Editor"
+
+#: id:10504
+msgid "Top 100 songs"
+msgstr "Top 100 Titel"
+
+#: id:10505
+msgid "Top 100 albums"
+msgstr "Top 100 Alben"
+
+#: id:10506
+msgctxt "Auto context with id 10506"
+msgid "Programs"
+msgstr "Programme"
+
+#: id:10507
+msgid "Configuration"
+msgstr "Einstellungen"
+
+#: id:10508
+msgid "Weather forecast"
+msgstr "Wetterbericht"
+
+#: id:10509
+msgid "Network gaming"
+msgstr "Netzwerkspiele"
+
+#: id:10510
+msgid "Extensions"
+msgstr "Erweiterungen"
+
+#: id:10511
+msgctxt "Auto context with id 10511"
+msgid "System info"
+msgstr "Systeminformationen"
+
+#: id:10516
+msgid "Music - Library"
+msgstr "Musik - Datenbank"
+
+#: id:10517
+msgid "Now Playing - Music"
+msgstr "Musik - Playlist"
+
+#: id:10522
+msgid "Now Playing - Videos"
+msgstr "Abspielliste - Videos"
+
+#: id:10523
+msgid "Album info"
+msgstr "Album Info"
+
+#: id:10524
+msgid "Movie info"
+msgstr "Film-Informationen"
+
+#: id:12000
+msgid "Select dialog"
+msgstr "Auswahl-Dialog"
+
+#: id:12001
+msgid "Music/Info"
+msgstr "Musik/Informationen"
+
+#: id:12002
+msgid "Dialog OK"
+msgstr "Dialog OK"
+
+#: id:12003
+msgid "Videos/Info"
+msgstr "Videos/Informationen"
+
+#: id:12004
+msgid "Scripts/Info"
+msgstr "Skripte/Informationen"
+
+#: id:12005
+msgid "Fullscreen video"
+msgstr "Vollbild-Video"
+
+#: id:12006
+msgid "Audio visualization"
+msgstr "Audio-Visualisierung"
+
+#: id:12008
+msgid "File stacking dialog"
+msgstr "Datei-Stapeln-Dialog"
+
+#: id:12009
+msgid "Rebuild index..."
+msgstr "Index neu erstellen..."
+
+#: id:12010
+msgid "Return to music window"
+msgstr "Zurück zu Musik"
+
+#: id:12011
+msgid "Return to videos window"
+msgstr "Zurück zu Videos"
+
+#: id:12021
+msgid "Start from beginning"
+msgstr "Am Anfang starten"
+
+#: id:12022
+msgid "Resume from %s"
+msgstr "Bei %s fortsetzen"
+
+#: id:12310
+msgid "0"
+msgstr "0"
+
+#: id:12311
+msgid "1"
+msgstr "1"
+
+#: id:12312
+msgid "2"
+msgstr "2"
+
+#: id:12313
+msgid "3"
+msgstr "3"
+
+#: id:12314
+msgid "4"
+msgstr "4"
+
+#: id:12315
+msgid "5"
+msgstr "5"
+
+#: id:12316
+msgid "6"
+msgstr "6"
+
+#: id:12317
+msgid "7"
+msgstr "7"
+
+#: id:12318
+msgid "8"
+msgstr "8"
+
+#: id:12319
+msgid "9"
+msgstr "9"
+
+#: id:12320
+msgid "c"
+msgstr "c"
+
+#: id:12321
+msgid "Ok"
+msgstr "Ok"
+
+#: id:12322
+msgid "*"
+msgstr "*"
+
+#: id:12325
+msgid "Locked! Enter code..."
+msgstr "Gesperrt! Bitte Passwort eingeben..."
+
+#: id:12326
+msgid "Enter password"
+msgstr "Bitte Passwort eingeben"
+
+#: id:12327
+msgid "Enter master code"
+msgstr "Bitte Master-Passwort eingeben"
+
+#: id:12328
+msgid "Enter unlock code"
+msgstr "Bitte Passwort zum Entsperren eingeben"
+
+#: id:12329
+msgid "or press C to cancel"
+msgstr "oder mit C abbrechen"
+
+#: id:12330
+msgid "Enter gamepad button combo and"
+msgstr "Bitte die Gamepad-Tastenkombination eingeben"
+
+#: id:12331
+msgid "press OK, or Back to cancel"
+msgstr "und mit der 'Ok'-Taste bestätigen. Um abzubrechen, 'Back'-Taste drücken."
+
+#: id:12332
+msgid "Set lock"
+msgstr "Sperren"
+
+#: id:12333
+msgid "Unlock"
+msgstr "Entsperren"
+
+#: id:12334
+msgid "Reset lock"
+msgstr "Sperre zurücksetzen"
+
+#: id:12335
+msgid "Remove lock"
+msgstr "Sperre entfernen"
+
+#: id:12337
+msgid "Numeric password"
+msgstr "Numerisches Passwort"
+
+#: id:12338
+msgid "Gamepad button combo"
+msgstr "Gamepad-Tastenkombination"
+
+#: id:12339
+msgid "Full-text password"
+msgstr "Volltext-Passwort"
+
+#: id:12340
+msgid "Enter new password"
+msgstr "Bitte neues Passwort eingeben"
+
+#: id:12341
+msgid "Re-Enter new password"
+msgstr "Zur Bestätigung neues Passwort wiederholen"
+
+#: id:12342
+msgid "Incorrect password,"
+msgstr "Falsches Passwort,"
+
+#: id:12343
+msgid "retries left"
+msgstr "Versuch(e) übrig"
+
+#: id:12344
+msgid "Passwords entered did not match."
+msgstr "Die eingegebenen Passwörter stimmen nicht überein!"
+
+#: id:12345
+msgid "Access denied"
+msgstr "Zugriff verweigert"
+
+#: id:12346
+msgid "Password retry limit exceeded."
+msgstr "Anzahl der Fehlversuche erreicht."
+
+#: id:12347
+msgid "The system will now shut off."
+msgstr "Das System wird nun ausgeschaltet."
+
+#: id:12348
+msgid "Item locked"
+msgstr "Freigabe gesperrt"
+
+#: id:12353
+msgid "Reactivate lock"
+msgstr "Sperre reaktivieren"
+
+#: id:12356
+msgid "Change lock"
+msgstr "Sperre ändern"
+
+#: id:12357
+msgid "Source lock"
+msgstr "Sperre"
+
+#: id:12358
+msgid "Password entry was blank. Try again."
+msgstr "Kein Passwort eingegeben. Bitte noch einmal versuchen."
+
+#: id:12360
+msgid "Master lock"
+msgstr "Master-Sperre"
+
+#: id:12362
+msgid "Shutdown system if Master Lock retries exceeded"
+msgstr "System ausschalten, wenn Anzahl Fehlversuche erreicht wird"
+
+#: id:12367
+msgid "Master code is not valid"
+msgstr "Das Master-Passwort ist ungültig"
+
+#: id:12368
+msgid "Please enter a valid master code"
+msgstr "Bitte das gültige Master-Passwort eingeben"
+
+#: id:12373
+msgid "Settings & file manager"
+msgstr "Einstellungen & Dateimanager"
+
+#: id:12376
+msgid "Set as default for all movies"
+msgstr "Einstellungen als Standard für alle Filme setzen"
+
+#: id:12377
+msgid "This will reset any previously saved values"
+msgstr "Alle vorherigen Werte werden damit überschrieben"
+
+#: id:12378
+msgid "Amount of time to display each image"
+msgstr "Anzeigedauer eines Bildes"
+
+#: id:12379
+msgid "Use pan and zoom effects"
+msgstr "Schwenk- und Zoom-Effekte verwenden"
+
+#: id:12383
+msgid "12 hour clock"
+msgstr "12 Stunden Uhr"
+
+#: id:12384
+msgid "24 hour clock"
+msgstr "24 Stunden Uhr"
+
+#: id:12385
+msgid "Day/Month"
+msgstr "Tag/Monat"
+
+#: id:12386
+msgid "Month/Day"
+msgstr "Monat/Tag"
+
+#: id:12390
+msgid "System uptime"
+msgstr "Betriebszeit"
+
+#: id:12391
+msgid "Minutes"
+msgstr "Minuten"
+
+#: id:12392
+msgid "Hours"
+msgstr "Stunden"
+
+#: id:12393
+msgid "Days"
+msgstr "Tage"
+
+#: id:12394
+msgid "Total uptime"
+msgstr "Betriebszeit gesamt"
+
+#: id:12395
+msgid "Battery level"
+msgstr ""
+
+#: id:12600
+msgctxt "Auto context with id 12600"
+msgid "Weather"
+msgstr "Wetter"
+
+#: id:12900
+msgctxt "Auto context with id 12900"
+msgid "Screensaver"
+msgstr "Bildschirmschoner"
+
+#: id:12901
+msgid "Fullscreen OSD"
+msgstr "Vollbild-OSD"
+
+#: id:13000
+msgid "System"
+msgstr "System"
+
+#: id:13001
+msgid "Immediate HD spindown"
+msgstr "Festplatte sofort abschalten"
+
+#: id:13002
+msgid "Video only"
+msgstr "nur Video"
+
+#: id:13003
+msgid "- Delay"
+msgstr "- Verzögerung"
+
+#: id:13004
+msgid "- Minimum file duration"
+msgstr "- minimale Dauer der Datei"
+
+#: id:13005
+msgid "Shutdown"
+msgstr "Ausschalten"
+
+#: id:13008
+msgid "Shutdown function"
+msgstr "Funktion für 'Ausschalten'"
+
+#: id:13009
+msgid "Quit"
+msgstr "Beenden"
+
+#: id:13010
+msgid "Hibernate"
+msgstr "Ruhezustand"
+
+#: id:13011
+msgid "Suspend"
+msgstr "Bereitschaft"
+
+#: id:13012
+msgid "Exit"
+msgstr "Verlassen"
+
+#: id:13013
+msgid "Reboot"
+msgstr "Neustart"
+
+#: id:13014
+msgid "Minimize"
+msgstr "Minimieren"
+
+#: id:13015
+msgid "Power button action"
+msgstr "Power-Button Aktion"
+
+#: id:13016
+msgid "Power off System"
+msgstr "Herunterfahren"
+
+#: id:13020
+msgid "Is another session active, perhaps over ssh?"
+msgstr "Ist noch eine weitere Sitzung aktiv (evtl. SSH)?"
+
+#: id:13021
+msgid "Mounted removable harddrive"
+msgstr "Wechselfestplatte wurde angeschlossen"
+
+#: id:13022
+msgid "Unsafe device removal"
+msgstr "Gerät wurde nicht sicher entfernt"
+
+#: id:13023
+msgid "Successfully removed device"
+msgstr "Gerät wurde erfolgreich entfernt"
+
+#: id:13024
+msgid "Joystick plugged"
+msgstr "Joystick eingesteckt"
+
+#: id:13025
+msgid "Joystick unplugged"
+msgstr "Joystick ausgesteckt"
+
+#: id:13050
+msgid "Running low on battery"
+msgstr "Der Akku ist fast leer"
+
+#: id:13100
+msgid "Flicker filter"
+msgstr "Flicker-Filter"
+
+#: id:13101
+msgid "Let driver choose (requires restart)"
+msgstr "Wie Treiber (benötigt Neustart)"
+
+#: id:13105
+msgid "Vertical blank sync"
+msgstr "Vertical Blank Synchronisation"
+
+#: id:13106
+msgctxt "Auto context with id 13106"
+msgid "Disabled"
+msgstr "Deaktiviert"
+
+#: id:13107
+msgid "Enabled during video playback"
+msgstr "Aktiviert während der Videowiedergabe"
+
+#: id:13108
+msgctxt "Auto context with id 13108"
+msgid "Always enabled"
+msgstr "Immer aktiviert"
+
+#: id:13109
+msgid "Test & apply resolution"
+msgstr "Teste Auflösung"
+
+#: id:13110
+msgid "Save resolution?"
+msgstr "Auflösung speichern?"
+
+#: id:13111
+msgid "Would you like to keep this resolution?"
+msgstr "Soll diese Auflösung beibehalten werden?"
+
+#: id:13112
+msgid "High quality upscaling"
+msgstr "Hochauflösende Software-Hochskalierung"
+
+#: id:13113
+msgctxt "Auto context with id 13113"
+msgid "Disabled"
+msgstr "Deaktiviert"
+
+#: id:13114
+msgid "Enabled for SD content"
+msgstr "Nur für SD-Inhalte aktivieren"
+
+#: id:13115
+msgctxt "Auto context with id 13115"
+msgid "Always enabled"
+msgstr "Immer aktiviert"
+
+#: id:13116
+msgid "Upscaling method"
+msgstr "Hochskalierungs-Methode"
+
+#: id:13117
+msgctxt "Auto context with id 13117"
+msgid "Bicubic"
+msgstr "Bikubisch"
+
+#: id:13118
+msgid "Lanczos"
+msgstr "Lanczos"
+
+#: id:13119
+msgid "Sinc"
+msgstr "Sinc"
+
+#: id:13120
+msgctxt "Auto context with id 13120"
+msgid "VDPAU"
+msgstr "VDPAU"
+
+#: id:13121
+msgid "VDPAU HQ Upscaling level"
+msgstr "VDPAU HQ Hochskalierungs-Niveau"
+
+#: id:13122
+msgid "VDPAU Studio level color conversion"
+msgstr "VDPAU Studio-Niveau Farbkonvertierung"
+
+#: id:13130
+msgid "Blank other displays"
+msgstr "Bildschirm abschalten"
+
+#: id:13131
+msgctxt "Auto context with id 13131"
+msgid "Disabled"
+msgstr "Deaktiviert"
+
+#: id:13132
+msgid "Blank displays"
+msgstr "leerer Bildschirm"
+
+#: id:13140
+msgid "Active connections detected!"
+msgstr "Aktive Verbindungen festgestellt!"
+
+#: id:13141
+msgid "If you proceed, you might not be able to control XBMC"
+msgstr "Wird fortgefahren, kann XBMC möglicherweise nicht mehr"
+
+#: id:13142
+msgid "any longer. Are you sure you want to stop the Event server?"
+msgstr "gesteuert werden. Fernsteuerung wirklich beenden?"
+
+#: id:13144
+msgid "Change Apple Remote mode?"
+msgstr "Wechsle Apple-Remote-Modus?"
+
+#: id:13145
+msgid "If you are currently using the Apple Remote to control"
+msgstr "Wird aktuell Apple Remote zur Steuerung von XBMC"
+
+#: id:13146
+msgid "XBMC, changing this setting might affect your ability"
+msgstr "verwendet, zieht ein Wechseln dieser Einstellung den"
+
+#: id:13147
+msgid "to continue controlling it. Do you want to proceed?"
+msgstr "Verlust der Steuerung nach sich. Soll fortgefahren werden?"
+
+#: id:13159
+msgid "Subnet mask"
+msgstr "Subnetzmaske"
+
+#: id:13160
+msgid "Gateway"
+msgstr "Gateway"
+
+#: id:13161
+msgid "Primary DNS"
+msgstr "Primärer DNS-Server"
+
+#: id:13162
+msgid "Initialize failed"
+msgstr "Initialisierung fehlgeschlagen"
+
+#: id:13170
+msgctxt "Auto context with id 13170"
+msgid "Never"
+msgstr "Nie"
+
+#: id:13171
+msgid "Immediately"
+msgstr "Sofort"
+
+#: id:13172
+msgid "After %i secs"
+msgstr "Nach %i Sek"
+
+#: id:13173
+msgid "HDD install date:"
+msgstr "HD Installations-Datum:"
+
+#: id:13174
+msgid "HDD power cycle count:"
+msgstr "HD Anzahl Einschaltungen:"
+
+#: id:13200
+msgid "Profiles"
+msgstr "Profile"
+
+#: id:13201
+msgid "Delete profile '%s'?"
+msgstr "Soll das Profil '%s' wirklich gelöscht werden?"
+
+#: id:13204
+msgid "Last loaded profile:"
+msgstr "Zuletzt geladenes Profil:"
+
+#: id:13205
+msgid "Unknown"
+msgstr "Unbekannt"
+
+#: id:13206
+msgid "Overwrite"
+msgstr "Überschreiben"
+
+#: id:13208
+msgid "Alarm clock"
+msgstr "Wecker"
+
+#: id:13209
+msgid "Alarm clock interval (in minutes)"
+msgstr "Intervall (in Minuten)"
+
+#: id:13210
+msgid "Started, alarm in %im"
+msgstr "Gestartet, Alarm in %im"
+
+#: id:13211
+msgid "Alarm!"
+msgstr "Alarm!"
+
+#: id:13212
+msgid "Canceled with %im%is left"
+msgstr "Deaktiviert. Restzeit war %im%is."
+
+#: id:13213
+msgid "%2.0fm"
+msgstr "%2.0fm"
+
+#: id:13214
+msgid "%2.0fs"
+msgstr "%2.0fs"
+
+#: id:13249
+msgid "Search for subtitles in RARs"
+msgstr "Untertitel in RAR-Dateien suchen"
+
+#: id:13250
+msgid "Browse for subtitle..."
+msgstr "Untertitel suchen..."
+
+#: id:13251
+msgid "Move item"
+msgstr "Verschieben"
+
+#: id:13252
+msgid "Move item here"
+msgstr "Hierhin verschieben"
+
+#: id:13253
+msgid "Cancel move"
+msgstr "Verschieben abbrechen"
+
+#: id:13270
+msgid "Hardware:"
+msgstr "Hardware:"
+
+#: id:13271
+msgid "CPU Usage:"
+msgstr "CPU-Auslastung:"
+
+#: id:13274
+msgid "Connected, but no DNS is available."
+msgstr "System ist verbunden, aber es ist kein DNS verfügbar."
+
+#: id:13275
+msgid "Hard Disk"
+msgstr "Festplatte"
+
+#: id:13276
+msgid "DVD-ROM"
+msgstr "DVD-Laufwerk"
+
+#: id:13277
+msgctxt "Auto context with id 13277"
+msgid "Storage"
+msgstr "Speicherplatz"
+
+#: id:13278
+msgctxt "Auto context with id 13278"
+msgid "Default"
+msgstr "Standard"
+
+#: id:13279
+msgctxt "Auto context with id 13279"
+msgid "Network"
+msgstr "Netzwerk"
+
+#: id:13280
+msgctxt "Auto context with id 13280"
+msgid "Video"
+msgstr "Grafik"
+
+#: id:13281
+msgid "Hardware"
+msgstr "Hardware"
+
+#: id:13283
+msgid "Operating system:"
+msgstr "Betriebssystem:"
+
+#: id:13284
+msgid "CPU speed:"
+msgstr "CPU-Geschwindigkeit:"
+
+#: id:13286
+msgid "Video encoder:"
+msgstr "Grafik-Chip:"
+
+#: id:13287
+msgid "Screen resolution:"
+msgstr "Bildschirm-Auflösung:"
+
+#: id:13292
+msgid "A/V cable:"
+msgstr "A/V-Kabel:"
+
+#: id:13294
+msgid "DVD region:"
+msgstr "DVD-Region:"
+
+#: id:13295
+msgid "Internet:"
+msgstr "Internet:"
+
+#: id:13296
+msgctxt "Auto context with id 13296"
+msgid "Connected"
+msgstr "System ist mit dem Internet verbunden."
+
+#: id:13297
+msgid "Not connected. Check network settings."
+msgstr "Keine Verbindung. Bitte Netzwerkeinstellungen überprüfen."
+
+#: id:13299
+msgid "Target temperature"
+msgstr "Angestrebte CPU-Temperatur"
+
+#: id:13300
+msgid "Fan speed"
+msgstr "Lüftergeschwindigkeit"
+
+#: id:13301
+msgid "Auto temperature control"
+msgstr "Lüftergeschwindigkeit über CPU-Temperatur regeln"
+
+#: id:13302
+msgid "Fan speed override"
+msgstr "Lüftergeschwindigkeit manuell einstellen"
+
+#: id:13303
+msgid "- Fonts"
+msgstr "- Schriftart"
+
+#: id:13304
+msgid "Enable flipping bi-directional strings"
+msgstr "Links-/Rechtsläufige Zeichenfolgen ermöglichen"
+
+#: id:13305
+msgid "Show RSS news feeds"
+msgstr "RSS-Newsfeeds aktivieren"
+
+#: id:13306
+msgid "Show parent folder items"
+msgstr "Symbol zum übergeordneten Ordner anzeigen"
+
+#: id:13307
+msgid "Track naming template"
+msgstr "Formatvorlage für Musiktitel-Dateinamen"
+
+#: id:13308
+msgid "Do you wish to reboot your system"
+msgstr "Soll das System neu gestartet werden?"
+
+#: id:13309
+msgid "instead of just XBMC?"
+msgstr "'Nein' wählen, um nur XBMC neu zu starten."
+
+#: id:13310
+msgid "Zoom effect"
+msgstr "Übergang streckend"
+
+#: id:13311
+msgid "Float effect"
+msgstr "Übergang gleitend"
+
+#: id:13312
+msgid "Black bar reduction"
+msgstr "Schwarzen Rand reduzieren"
+
+#: id:13313
+msgid "Restart"
+msgstr "Neustart"
+
+#: id:13314
+msgid "Crossfade between songs"
+msgstr "Überblendung"
+
+#: id:13315
+msgid "Regenerate thumbnails"
+msgstr "Thumbnails neu erstellen"
+
+#: id:13316
+msgid "Recursive thumbnails"
+msgstr "Rekursive Thumbnails"
+
+#: id:13317
+msgid "View slideshow"
+msgstr "Diaschau starten"
+
+#: id:13318
+msgid "Recursive slideshow"
+msgstr "Rekursive Diaschau"
+
+#: id:13319
+msgid "Randomize"
+msgstr "Zufallsauswahl"
+
+#: id:13320
+msgid "Stereo"
+msgstr "Stereo"
+
+#: id:13321
+msgid "Left only"
+msgstr "Nur links"
+
+#: id:13322
+msgid "Right only"
+msgstr "Nur rechts"
+
+#: id:13323
+msgid "Enable karaoke support"
+msgstr "Karaoke CD+G aktivieren"
+
+#: id:13324
+msgid "Background transparency"
+msgstr "Hintergrundtransparenz"
+
+#: id:13325
+msgid "Foreground transparency"
+msgstr "Vordergrundtransparenz"
+
+#: id:13326
+msgid "A/V delay"
+msgstr "A/V-Verzögerung"
+
+#: id:13327
+msgid "Karaoke"
+msgstr "Karaoke"
+
+#: id:13328
+msgid "%s not found"
+msgstr "%s wurde nicht gefunden."
+
+#: id:13329
+msgid "Error opening %s"
+msgstr "Fehler beim Öffnen von %s"
+
+#: id:13330
+msgid "Unable to load %s"
+msgstr "Das Laden von %s ist fehlgeschlagen"
+
+#: id:13331
+msgid "Error: Out of memory"
+msgstr "Fehler: Nicht genügend Speicher"
+
+#: id:13332
+msgid "Move up"
+msgstr "Nach oben"
+
+#: id:13333
+msgid "Move down"
+msgstr "Nach unten"
+
+#: id:13334
+msgid "Edit label"
+msgstr "Beschriftung ändern"
+
+#: id:13335
+msgid "Make default"
+msgstr "Als Standard setzen"
+
+#: id:13336
+msgid "Remove button"
+msgstr "Schaltfläche entfernen"
+
+#: id:13340
+msgid "Leave as is"
+msgstr "Nicht ändern"
+
+#: id:13341
+msgid "Green"
+msgstr "Grün"
+
+#: id:13342
+msgid "Orange"
+msgstr "Orange"
+
+#: id:13343
+msgid "Red"
+msgstr "Rot"
+
+#: id:13344
+msgid "Cycle"
+msgstr "Zyklisch"
+
+#: id:13345
+msgid "Switch LED off on playback"
+msgstr "LED während der Wiedergabe ausschalten"
+
+#: id:13346
+msgctxt "Auto context with id 13346"
+msgid "Movie information"
+msgstr "Filminformationen"
+
+#: id:13347
+msgid "Queue item"
+msgstr "In Abspielliste einreihen"
+
+#: id:13348
+msgid "Search IMDb..."
+msgstr "Film in IMDb suchen..."
+
+#: id:13349
+msgid "Scan for new content"
+msgstr "Neue Inhalte suchen"
+
+#: id:13350
+msgid "Now playing..."
+msgstr "wird abgespielt..."
+
+#: id:13351
+msgctxt "Auto context with id 13351"
+msgid "Album information"
+msgstr "Albuminformationen"
+
+#: id:13352
+msgid "Scan item to library"
+msgstr "In Datenbank aufnehmen"
+
+#: id:13353
+msgid "Stop scanning"
+msgstr "Aktualisieren abbrechen"
+
+#: id:13354
+msgctxt "Auto context with id 13354"
+msgid "Render method"
+msgstr "Render-Methode"
+
+#: id:13355
+msgid "Low quality pixel shader"
+msgstr "Shader (niedrige Qualität)"
+
+#: id:13356
+msgid "Hardware overlays"
+msgstr "Hardware-Overlays"
+
+#: id:13357
+msgid "High quality pixel shader"
+msgstr "Shader (hohe Qualität)"
+
+#: id:13358
+msgid "Play item"
+msgstr "Abspielen"
+
+#: id:13359
+msgid "Set artist thumb"
+msgstr "Interpreten Bild setzen"
+
+#: id:13360
+msgid "Automatically generate thumbnails"
+msgstr "Thumbnails automatisch erstellen"
+
+#: id:13361
+msgid "Enable voice"
+msgstr "Spracheingabe aktivieren"
+
+#: id:13375
+msgid "Enable device"
+msgstr "Gerät verwenden"
+
+#: id:13376
+msgid "Volume"
+msgstr "Lautstärke"
+
+#: id:13377
+msgid "Default view mode"
+msgstr "Standard-Bildmodus"
+
+#: id:13378
+msgid "Default brightness"
+msgstr "Standard-Helligkeit"
+
+#: id:13379
+msgid "Default contrast"
+msgstr "Standard-Kontrast"
+
+#: id:13380
+msgid "Default gamma"
+msgstr "Standard-Gamma"
+
+#: id:13381
+msgid "Resume video"
+msgstr "Video fortsetzen"
+
+#: id:13382
+msgid "Voice mask - Port 1"
+msgstr "Stimmen-Maske - Port 1"
+
+#: id:13383
+msgid "Voice mask - Port 2"
+msgstr "Stimmen-Maske - Port 2"
+
+#: id:13384
+msgid "Voice mask - Port 3"
+msgstr "Stimmen-Maske - Port 3"
+
+#: id:13385
+msgid "Voice mask - Port 4"
+msgstr "Stimmen-Maske - Port 4"
+
+#: id:13386
+msgid "Use time based seeking"
+msgstr "Zeitbasiertes Vor-/Zurückspulen"
+
+#: id:13387
+msgid "Track naming template - right"
+msgstr "Formatvorlage für Musiktitel-Dateinamen rechts"
+
+#: id:13388
+msgid "Preset"
+msgstr "Voreinstellung"
+
+#: id:13389
+msgid "There are no presets available\nfor this visualization"
+msgstr "Es sind keine Voreinstellungen für diese Visualisierung verfügbar"
+
+#: id:13390
+msgid "There are no settings available\nfor this visualization"
+msgstr "Es sind keine Einstellungen für diese Visualisierung verfügbar"
+
+#: id:13391
+msgid "Eject/Load"
+msgstr "Öffnen/Schließen"
+
+#: id:13392
+msgid "Use visualization if playing audio"
+msgstr "Bei Musikwiedergabe die Visualisierung verwenden"
+
+#: id:13393
+msgid "Calculate size"
+msgstr "Größe berechnen"
+
+#: id:13394
+msgid "Calculating folder size"
+msgstr "Größe des Ordners wird berechnet"
+
+#: id:13395
+msgid "Video settings"
+msgstr "Video-Einstellungen"
+
+#: id:13396
+msgid "Audio and subtitle settings"
+msgstr "Audio- und Untertitel-Einstellungen"
+
+#: id:13397
+msgid "Enable subtitles"
+msgstr "Untertitel aktivieren"
+
+#: id:13398
+msgctxt "Auto context with id 13398"
+msgid "Shortcuts"
+msgstr "Lesezeichen"
+
+#: id:13399
+msgid "Ignore articles when sorting (e.g. \"the\")"
+msgstr "Grammatische Artikel bei der Sortierung ignorieren"
+
+#: id:13400
+msgid "Crossfade between songs on the same album"
+msgstr "Überblenden bei Titeln des gleichen Albums"
+
+#: id:13401
+msgid "Browse for %s"
+msgstr "%s wählen"
+
+#: id:13402
+msgid "Show track position"
+msgstr "Titelposition anzeigen"
+
+#: id:13403
+msgid "Clear default"
+msgstr "Standard entfernen"
+
+#: id:13404
+msgid "Resume"
+msgstr "Fortsetzen"
+
+#: id:13405
+msgid "Get thumb"
+msgstr "Lade Poster"
+
+#: id:13406
+msgid "Picture information"
+msgstr "Bildinformation"
+
+#: id:13407
+msgid "%s presets"
+msgstr "%s Voreinstellungen"
+
+#: id:13408
+msgid "(IMDb user rating)"
+msgstr "(IMDb Benutzer-Bewertung)"
+
+#: id:13409
+msgid "Top 250"
+msgstr "Top 250"
+
+#: id:13410
+msgid "Tune in on Last.fm"
+msgstr "Last.fm einschalten"
+
+#: id:13411
+msgid "Minimum fan speed"
+msgstr "Minimale Lüftergeschwindigkeit"
+
+#: id:13412
+msgid "Play from here"
+msgstr "Ab hier abspielen"
+
+#: id:13413
+msgid "Downloading"
+msgstr "Herunterladen"
+
+#: id:13414
+msgid "Include artists who appear only on compilations"
+msgstr "Interpreten anzeigen die nur in Zusammenstellungen vorkommen"
+
+#: id:13415
+msgctxt "Auto context with id 13415"
+msgid "Render method"
+msgstr "Render-Methode"
+
+#: id:13416
+msgid "Auto detect"
+msgstr "Auto-Erkennung"
+
+#: id:13417
+msgid "Basic shaders (ARB)"
+msgstr "Basis Shader (ARB)"
+
+#: id:13418
+msgid "Advanced shaders (GLSL)"
+msgstr "Erweiterte Shader (GLSL)"
+
+#: id:13419
+msgid "Software"
+msgstr "Software"
+
+#: id:13420
+msgid "Remove safely"
+msgstr "Sicher entfernen"
+
+#: id:13421
+msgctxt "Auto context with id 13421"
+msgid "VDPAU"
+msgstr "VDPAU"
+
+#: id:13422
+msgid "Start slideshow here"
+msgstr "Diaschau hier starten"
+
+#: id:13423
+msgid "Remember for this path"
+msgstr "Für diesen Pfad merken"
+
+#: id:13424
+msgid "Use pixel buffer objects"
+msgstr "Verwende 'pixel buffer objects'"
+
+#: id:13425
+msgid "Allow hardware acceleration (VDPAU)"
+msgstr "Hardwarebeschleunigung erlauben (VDPAU)"
+
+#: id:13426
+msgid "Allow hardware acceleration (VAAPI)"
+msgstr "Hardwarebeschleunigung erlauben (VAAPI)"
+
+#: id:13427
+msgid "Allow hardware acceleration (DXVA2)"
+msgstr "Hardwarebeschleunigung erlauben (DXVA2)"
+
+#: id:13428
+msgid "Allow hardware acceleration (CrystalHD)"
+msgstr "Hardwarebeschleunigung erlauben (CrystalHD)"
+
+#: id:13429
+msgid "Allow hardware acceleration (VDADecoder)"
+msgstr "Hardwarebeschleunigung erlauben (VDADecoder)"
+
+#: id:13430
+msgid "Allow hardware acceleration (OpenMax)"
+msgstr "Hardwarebeschleunigung erlauben (OpenMax)"
+
+#: id:13431
+msgid "Pixel Shaders"
+msgstr "Pixel Shaders"
+
+#: id:13432
+msgid "Allow hardware acceleration (VideoToolbox)"
+msgstr "Hardwarebeschleunigung erlauben (VideoToolbox)"
+
+#: id:13500
+msgid "A/V sync method"
+msgstr "A/V Sync Methode"
+
+#: id:13501
+msgid "Audio clock"
+msgstr "Audio Takt"
+
+#: id:13502
+msgid "Video clock (Drop/Dupe audio)"
+msgstr "Video Takt (Verwerfe/Dupliziere Audio)"
+
+#: id:13503
+msgid "Video clock (Resample audio)"
+msgstr "Video Takt (Audio Anpassen)"
+
+#: id:13504
+msgid "Maximum resample amount (%)"
+msgstr "Maximale Anpassung (%)"
+
+#: id:13505
+msgid "Resample quality"
+msgstr "Qualität der Anpassung"
+
+#: id:13506
+msgid "Low(fast)"
+msgstr "Gering(schnell)"
+
+#: id:13507
+msgctxt "Auto context with id 13507"
+msgid "Medium"
+msgstr "Medium"
+
+#: id:13508
+msgctxt "Auto context with id 13508"
+msgid "High"
+msgstr "Hoch"
+
+#: id:13509
+msgid "Really high(slow!)"
+msgstr "Sehr Hoch(langsam!)"
+
+#: id:13510
+msgid "Sync playback to display"
+msgstr "Synchronisiere Wiedergabe zur Anzeige"
+
+#: id:13550
+msgid "Pause during refresh rate change"
+msgstr "Pause während der Wiederholfrequenz Änderung"
+
+#: id:13551
+msgctxt "Auto context with id 13551"
+msgid "Off"
+msgstr "Aus"
+
+#: id:13552
+msgid "%.1f Second"
+msgstr "%.1f Sekunden"
+
+#: id:13553
+msgid "%.1f Seconds"
+msgstr "%.1f Sekunden"
+
+#: id:13600
+msgid "Apple remote"
+msgstr "Apple-Remote"
+
+#: id:13602
+msgid "Allow start of XBMC using the remote"
+msgstr "XBMC Start mit Fernbedienung erlauben"
+
+#: id:13603
+msgid "Sequence delay time"
+msgstr "Ablauf-Verzögerung"
+
+#: id:13610
+msgctxt "Auto context with id 13610"
+msgid "Disabled"
+msgstr "Deaktiviert"
+
+#: id:13611
+msgctxt "Auto context with id 13611"
+msgid "Standard"
+msgstr "Standard"
+
+#: id:13612
+msgid "Universal Remote"
+msgstr "Universal-Fernbedieung"
+
+#: id:13613
+msgid "Multi Remote (Harmony)"
+msgstr "Multi-Fernbedienung (Harmony)"
+
+#: id:13620
+msgid "Apple Remote Error"
+msgstr "Apple-Remote Fehler"
+
+#: id:13621
+msgid "Apple Remote support could be enabled."
+msgstr "Apple-Remote-Unterstützung könnte eingeschaltet sein."
+
+#: id:14000
+msgid "Stack"
+msgstr "Videos stapeln"
+
+#: id:14001
+msgid "Unstack"
+msgstr "Stapeln deaktivieren"
+
+#: id:14003
+msgid "Downloading playlist file..."
+msgstr "Playlist wird heruntergeladen..."
+
+#: id:14004
+msgid "Downloading streams list..."
+msgstr "Streamliste wird heruntergeladen..."
+
+#: id:14005
+msgid "Parsing streams list..."
+msgstr "Streamliste wird verarbeitet..."
+
+#: id:14006
+msgid "Downloading streams list failed"
+msgstr "Herunterladen der Streamliste ist fehlgeschlagen"
+
+#: id:14007
+msgid "Downloading playlist file failed"
+msgstr "Herunterladen der Playlist ist fehlgeschlagen"
+
+#: id:14009
+msgid "Games directory"
+msgstr "Spiele-Ordner"
+
+#: id:14010
+msgid "Auto switch to thumbs based on"
+msgstr "Zu Thumbnails wechseln basierend auf"
+
+#: id:14011
+msgid "Enable auto switching to thumbs view"
+msgstr "Auto-Wechsel zur Thumbnail-Ansicht aktivieren"
+
+#: id:14012
+msgid "- Use large icons"
+msgstr "- Große Symbole verwenden"
+
+#: id:14013
+msgid "- Switch based on"
+msgstr "- Wechsel basierend auf"
+
+#: id:14014
+msgid "- Percentage"
+msgstr "- Prozent"
+
+#: id:14015
+msgid "No files and at least one thumb"
+msgstr "keine Dateien & mindestens ein Thumbnail"
+
+#: id:14016
+msgid "At least one file and thumb"
+msgstr "mindestens eine Datei und ein Thumbnail"
+
+#: id:14017
+msgid "Percentage of thumbs"
+msgstr "Thumbnails in Prozent"
+
+#: id:14018
+msgid "View options"
+msgstr "Ansichts-Optionen"
+
+#: id:14019
+msgid "Change area code 1"
+msgstr "Stadt 1"
+
+#: id:14020
+msgid "Change area code 2"
+msgstr "Stadt 2"
+
+#: id:14021
+msgid "Change area code 3"
+msgstr "Stadt 3"
+
+#: id:14022
+msgctxt "Auto context with id 14022"
+msgid "Library"
+msgstr "Datenbank"
+
+#: id:14023
+msgid "No TV"
+msgstr "Kein TV"
+
+#: id:14024
+msgid "Enter the nearest large town"
+msgstr "Bitte die nächste große Stadt eingeben"
+
+#: id:14025
+msgid "Video/Audio/DVD cache - Harddisk"
+msgstr "Video/Audio/DVD-Cache - Festplatte"
+
+#: id:14026
+msgid "Video cache - DVD-ROM"
+msgstr "Video-Cache - DVD-Rom"
+
+#: id:14027
+msgctxt "Auto context with id 14027"
+msgid "- Local Network"
+msgstr "- Lokales Netzwerk"
+
+#: id:14028
+msgctxt "Auto context with id 14028"
+msgid "- Internet"
+msgstr "- Internet"
+
+#: id:14030
+msgid "Audio cache - DVD-ROM"
+msgstr "Audio-Cache - DVD-Rom"
+
+#: id:14031
+msgctxt "Auto context with id 14031"
+msgid "- Local Network"
+msgstr "- Lokales Netzwerk"
+
+#: id:14032
+msgctxt "Auto context with id 14032"
+msgid "- Internet"
+msgstr "- Internet"
+
+#: id:14034
+msgid "DVD cache - DVD-ROM"
+msgstr "DVD-Cache - DVD-Rom"
+
+#: id:14035
+msgctxt "Auto context with id 14035"
+msgid "- Local Network"
+msgstr "- Lokales Netzwerk"
+
+#: id:14036
+msgctxt "Auto context with id 14036"
+msgid "Services"
+msgstr "Server"
+
+#: id:14038
+msgid "Network settings changed"
+msgstr "Netzwerkeinstellungen wurden geändert"
+
+#: id:14039
+msgid "XBMC requires to restart to change your"
+msgstr "XBMC muss neu gestartet werden, damit die Änderung"
+
+#: id:14040
+msgid "network setup. Would you like to restart now?"
+msgstr "wirksam wird. Soll jetzt neu gestartet werden?"
+
+#: id:14041
+msgid "Internet connection bandwidth limitation"
+msgstr "Internetverbindung Bandbreitenbegrenzung"
+
+#: id:14043
+msgid "- Shutdown while playing"
+msgstr "- Auch während der Wiedergabe ausschalten"
+
+#: id:14044
+msgid "%i min"
+msgstr "%i Min"
+
+#: id:14045
+msgid "%i sec"
+msgstr "%i Sek"
+
+#: id:14046
+msgid "%i ms"
+msgstr "%i ms"
+
+#: id:14047
+msgid "%i %%"
+msgstr "%i %%"
+
+#: id:14048
+msgid "%i kbps"
+msgstr "%i kbps"
+
+#: id:14049
+msgid "%i kb"
+msgstr "%i kb"
+
+#: id:14050
+msgid "%i.0 dB"
+msgstr "%i.0 dB"
+
+#: id:14051
+msgid "Time format"
+msgstr "Zeitformat"
+
+#: id:14052
+msgid "Date format"
+msgstr "Datumsformat"
+
+#: id:14053
+msgid "GUI filters"
+msgstr "GUI-Filter"
+
+#: id:14055
+msgid "Use background scanning"
+msgstr "Durchsuchen im Hintergrund"
+
+#: id:14056
+msgid "Stop scan"
+msgstr "Scan beenden"
+
+#: id:14057
+msgid "Not possible while scanning for media info"
+msgstr "Nicht möglich während des Durchsuchens"
+
+#: id:14058
+msgid "Film grain effect"
+msgstr "Filmkörnungseffekt"
+
+#: id:14059
+msgid "Search for thumbnails on remote shares"
+msgstr "Netzwerkquellen nach Thumbnails durchsuchen"
+
+#: id:14060
+msgid "Unknown type cache - Internet"
+msgstr "Unbekannter Typ - Internet"
+
+#: id:14061
+msgctxt "Auto context with id 14061"
+msgid "Auto"
+msgstr "Automatisch"
+
+#: id:14062
+msgid "Enter username for"
+msgstr "Bitte Benutzernamen eingeben für"
+
+#: id:14063
+msgid "Date & time"
+msgstr "Datum & Uhrzeit"
+
+#: id:14064
+msgid "Set date"
+msgstr "Datum ändern"
+
+#: id:14065
+msgid "Set time"
+msgstr "Uhrzeit ändern"
+
+#: id:14066
+msgid "Enter the time in 24 hour HH:MM format"
+msgstr "Bitte die Uhrzeit im 24-Std Format (HH:MM) eingeben"
+
+#: id:14067
+msgid "Enter the date in DD/MM/YYYY format"
+msgstr "Bitte das Datum im Format TT/MM/JJJJ eingeben"
+
+#: id:14068
+msgid "Enter the IP address"
+msgstr "Bitte IP-Adresse eingeben"
+
+#: id:14069
+msgid "Apply these settings now?"
+msgstr "Einstellungen jetzt übernehmen?"
+
+#: id:14070
+msgid "Apply changes now"
+msgstr "Übernehmen"
+
+#: id:14071
+msgid "Allow file renaming and deletion"
+msgstr "Löschen und Umbenennen von Dateien erlauben"
+
+#: id:14074
+msgid "Set timezone"
+msgstr "Zeitzone"
+
+#: id:14075
+msgid "Use daylight saving time"
+msgstr "Sommerzeit verwenden"
+
+#: id:14076
+msgid "Add to favourites"
+msgstr "Zu Favoriten hinzufügen"
+
+#: id:14077
+msgid "Remove from favourites"
+msgstr "Von Favoriten entfernen"
+
+#: id:14078
+msgctxt "Auto context with id 14078"
+msgid "- Colours"
+msgstr "- Farben"
+
+#: id:14079
+msgid "Timezone country"
+msgstr "Zeitzonen-Region"
+
+#: id:14080
+msgid "Timezone"
+msgstr "Zeitzone"
+
+#: id:14081
+msgid "File lists"
+msgstr "Dateilisten"
+
+#: id:14082
+msgid "Show EXIF picture information"
+msgstr "EXIF Bildinformationen zeigen"
+
+#: id:14083
+msgid "Use a fullscreen window rather than true fullscreen"
+msgstr "Benutze Vollbild Fenster anstatt echtes Vollbild"
+
+#: id:14084
+msgid "Queue songs on selection"
+msgstr "Reihenfolge der Lieder nach Auswahl"
+
+#: id:14086
+msgid "Playback"
+msgstr "Wiedergabe"
+
+#: id:14087
+msgid "DVDs"
+msgstr "DVDs"
+
+#: id:14088
+msgid "Play DVDs automatically"
+msgstr "DVDs automatisch wiedergeben"
+
+#: id:14089
+msgid "Font to use for text subtitles"
+msgstr "Schriftart"
+
+#: id:14090
+msgid "International"
+msgstr "Sprache & Region"
+
+#: id:14091
+msgid "Character set"
+msgstr "Zeichensatz"
+
+#: id:14092
+msgid "Debugging"
+msgstr "Debugging"
+
+#: id:14093
+msgid "Security"
+msgstr "Sicherheit"
+
+#: id:14094
+msgid "Input devices"
+msgstr "Eingabegeräte"
+
+#: id:14095
+msgid "Power saving"
+msgstr "Energiesparen"
+
+#: id:14096
+msgid "Rip"
+msgstr "Rippen"
+
+#: id:14097
+msgid "Audio CD Insert Action"
+msgstr "Aktion beim Einlegen einer Audio CD"
+
+#: id:14098
+msgctxt "Auto context with id 14098"
+msgid "Play"
+msgstr "Wiedergeben"
+
+#: id:14099
+msgid "Eject disc when CD ripping is complete"
+msgstr "Disk auswerfen wenn Rippen fertig gestellt wurde"
+
+#: id:15015
+msgctxt "Auto context with id 15015"
+msgid "Remove"
+msgstr "Entfernen"
+
+#: id:15016
+msgid "Games"
+msgstr "Spiele"
+
+#: id:15019
+msgid "Add"
+msgstr "Hinzufügen"
+
+#: id:15052
+msgid "Password"
+msgstr "Passwort"
+
+#: id:15100
+msgctxt "Auto context with id 15100"
+msgid "Library"
+msgstr "Datenbank"
+
+#: id:15101
+msgid "Database"
+msgstr "Datenbank"
+
+#: id:15102
+msgid "* All albums"
+msgstr "* Alle Alben"
+
+#: id:15103
+msgid "* All artists"
+msgstr "* Alle Interpreten"
+
+#: id:15104
+msgid "* All songs"
+msgstr "* Alle Titel"
+
+#: id:15105
+msgid "* All genres"
+msgstr "* Alle Genre"
+
+#: id:15107
+msgid "Buffering..."
+msgstr "Zwischenspeichern..."
+
+#: id:15108
+msgid "Navigation sounds"
+msgstr "Navigationssounds"
+
+#: id:15109
+msgid "Skin default"
+msgstr "Vorgabe des Skins"
+
+#: id:15111
+msgid "- Theme"
+msgstr "Theme"
+
+#: id:15112
+msgid "Default theme"
+msgstr "Standardschema"
+
+#: id:15200
+msgid "Last.fm"
+msgstr "Last.fm"
+
+#: id:15201
+msgid "Submit songs to Last.fm"
+msgstr "Abgespielte Musiktitel an Last.fm übermitteln"
+
+#: id:15202
+msgid "Last.fm username"
+msgstr "Last.fm Benutzername"
+
+#: id:15203
+msgid "Last.fm password"
+msgstr "Last.fm Passwort"
+
+#: id:15204
+msgid "Unable to handshake: sleeping..."
+msgstr "Verbindung fehlgeschlagen."
+
+#: id:15205
+msgid "Please update XBMC"
+msgstr "Bitte XBMC aktualisieren"
+
+#: id:15206
+msgid "Bad authorization: Check username and password"
+msgstr "Authorisierung fehlgeschlagen: Bitte Benutzerdaten prüfen!"
+
+#: id:15207
+msgctxt "Auto context with id 15207"
+msgid "Connected"
+msgstr "Verbunden"
+
+#: id:15208
+msgid "Not connected"
+msgstr "Nicht verbunden"
+
+#: id:15209
+msgid "Submit interval %i"
+msgstr "Übertragungsintervall %i"
+
+#: id:15210
+msgid "Cached %i songs"
+msgstr "%i Titel im Cache"
+
+#: id:15211
+msgid "Submitting..."
+msgstr "Übermittlung..."
+
+#: id:15212
+msgid "Submitting in %i secs"
+msgstr "Übermittlung in %i sek"
+
+#: id:15213
+msgid "Play using..."
+msgstr "Abspielen mit..."
+
+#: id:15214
+msgid "Use smoothed A/V synchronization"
+msgstr "Weiche Audio/Video-Synchronisation verwenden"
+
+#: id:15215
+msgid "Hide file names in thumbs view"
+msgstr "Keine Dateinamen in der Symbolansicht anzeigen"
+
+#: id:15216
+msgid "Play in party mode"
+msgstr "Im Party-Modus abspielen"
+
+#: id:15217
+msgid "Submit songs to Libre.fm"
+msgstr "Abgespielte Musiktitel an Libre.fm übermitteln"
+
+#: id:15218
+msgid "Libre.fm username"
+msgstr "Libre.fm Benutzername"
+
+#: id:15219
+msgid "Libre.fm password"
+msgstr "Libre.fm Passwort"
+
+#: id:15220
+msgid "Libre.fm"
+msgstr "Libre.fm"
+
+#: id:15221
+msgid "Song submission"
+msgstr "Musikübertragung"
+
+#: id:15250
+msgid "Submit Last.fm radio to Last.fm"
+msgstr "Last.fm Radio an Last.fm übermitteln"
+
+#: id:15251
+msgid "Connecting to Last.fm..."
+msgstr "Verbindung mit Last.fm herstellen..."
+
+#: id:15252
+msgid "Selecting station..."
+msgstr "Station wird ausgewählt..."
+
+#: id:15253
+msgid "Search similar artists..."
+msgstr "Ähnliche Interpreten suchen..."
+
+#: id:15254
+msgid "Search similar tags..."
+msgstr "Ähnliche Tags suchen..."
+
+#: id:15255
+msgid "Your profile (%name%)"
+msgstr "Eigenes Profil (%name%)"
+
+#: id:15256
+msgid "Overall top tags"
+msgstr "Die besten Tags"
+
+#: id:15257
+msgid "Top artists for tag %name%"
+msgstr "Die besten Interpreten des Tags %name%"
+
+#: id:15258
+msgid "Top albums for tag %name%"
+msgstr "Die besten Alben des Tags %name%"
+
+#: id:15259
+msgid "Top tracks for tag %name%"
+msgstr "Die besten Titel des Tags %name%"
+
+#: id:15260
+msgid "Listen to tag %name% Last.fm radio"
+msgstr "%name% Last.fm Radio Tag anhören"
+
+#: id:15261
+msgid "Similar artists as %name%"
+msgstr "Ähnliche Interpreten wie %name%"
+
+#: id:15262
+msgid "Top %name% albums"
+msgstr "Die besten %name% Alben"
+
+#: id:15263
+msgid "Top %name% tracks"
+msgstr "Die besten %name% Titel"
+
+#: id:15264
+msgid "Top %name% tags"
+msgstr "Die besten %name% Tags"
+
+#: id:15265
+msgid "Biggest fans of %name%"
+msgstr "Größte Fans von %name%"
+
+#: id:15266
+msgid "Listen to %name% fans Last.fm radio"
+msgstr "%name% Fan Last.fm Radio anhören"
+
+#: id:15267
+msgid "Listen to %name% similar artists Last.fm radio"
+msgstr "Ähnliche Interpreten wie %name% im Last.fm Radio anhören"
+
+#: id:15268
+msgid "Top artists for user %name%"
+msgstr "Lieblingsinterpreten von %name%"
+
+#: id:15269
+msgid "Top albums for user %name%"
+msgstr "Lieblingsalben von %name%"
+
+#: id:15270
+msgid "Top tracks for user %name%"
+msgstr "Lieblingstitel von %name%"
+
+#: id:15271
+msgid "Friends of user %name%"
+msgstr "Freunde von %name%"
+
+#: id:15272
+msgid "Neighbours of user %name%"
+msgstr "Nachbarn von %name%"
+
+#: id:15273
+msgid "Weekly artist chart for %name%"
+msgstr "Wöchentliche Interpretencharts von %name%"
+
+#: id:15274
+msgid "Weekly album chart for %name%"
+msgstr "Wöchentliche Albumcharts von %name%"
+
+#: id:15275
+msgid "Weekly track chart for %name%"
+msgstr "Wöchentliche Titelcharts von %name%"
+
+#: id:15276
+msgid "Listen to %name%'s neighbours Last.fm radio"
+msgstr "Last.fm Radio der Nachbarn von %name% anhören"
+
+#: id:15277
+msgid "Listen to %name%'s personal Last.fm radio"
+msgstr "Privates Last.fm Radio von %name% anhören"
+
+#: id:15278
+msgid "Listen to %name%'s mix Last.fm radio"
+msgstr "Die Lieblingstitel von %name% im Last.fm Radio anhören"
+
+#: id:15279
+msgid "Retrieving list from Last.fm..."
+msgstr "Daten werden von Last.fm übertragen..."
+
+#: id:15280
+msgid "Can't retrieve list from Last.fm..."
+msgstr "Daten konnten nicht von Last.fm übertragen werden."
+
+#: id:15281
+msgid "Enter an artist name to find related ones"
+msgstr "Bitte Interpreten eingeben, um gleichartige zu finden"
+
+#: id:15282
+msgid "Enter a tag name to find similar ones"
+msgstr "Bitte Tagnamen eingeben, um dazu passende Einträge zu finden"
+
+#: id:15283
+msgid "Tracks recently listened by %name%"
+msgstr "Kürzlich gehörte Titel von %name%"
+
+#: id:15284
+msgid "Listen to %name%'s recommendations Last.fm radio"
+msgstr "Last.fm Radio Empfehlungen für %name% anhören"
+
+#: id:15285
+msgid "Top tags for user %name%"
+msgstr "Die besten Tags von %name%"
+
+#: id:15287
+msgid "Do you want to add the current track to your loved tracks?"
+msgstr "Den aktuellen Titel zur Lieblingsliste hinzufügen?"
+
+#: id:15288
+msgid "Do you want to ban the current track?"
+msgstr "Den aktuellen Titel sperren?"
+
+#: id:15289
+msgid "Added to your loved tracks: '%s'."
+msgstr "Zur Lieblingsliste hinzugefügt: '%s'"
+
+#: id:15290
+msgid "Could not add '%s' to your loved tracks."
+msgstr "'%s' konnte nicht zur Lieblingsliste hinzugefügt werden."
+
+#: id:15291
+msgid "Banned: '%s'."
+msgstr "gesperrt: '%s'"
+
+#: id:15292
+msgid "Could not ban '%s'."
+msgstr "'%s' konnte nicht gesperrt werden."
+
+#: id:15293
+msgid "Tracks recently loved by %name%"
+msgstr "Kürzlich zur Lieblingsliste hinzugefügte Titel von %name%"
+
+#: id:15294
+msgid "Tracks recently banned by %name%"
+msgstr "Kürzlich gesperrte Titel von %name%"
+
+#: id:15295
+msgid "Remove from loved tracks"
+msgstr "Aus Lieblingsliste entfernen"
+
+#: id:15296
+msgid "Un-ban"
+msgstr "Sperre aufheben"
+
+#: id:15297
+msgid "Do you want to remove this track from your loved tracks?"
+msgstr "Diesen Titel aus der Lieblingsliste entfernen?"
+
+#: id:15298
+msgid "Do you want to un-ban this track?"
+msgstr "Sperre für diesen Titel aufheben?"
+
+#: id:15300
+msgid "Path not found or invalid"
+msgstr "Pfad wurde nicht gefunden oder ist ungültig."
+
+#: id:15301
+msgid "Could not connect to network server"
+msgstr "Keine Verbindung zum Netzwerkserver."
+
+#: id:15302
+msgid "No servers found"
+msgstr "Es wurden keine Server gefunden."
+
+#: id:15303
+msgid "Workgroup not found"
+msgstr "Es konnte keine Arbeitsgruppe gefunden werden."
+
+#: id:15310
+msgid "Opening multi-path source"
+msgstr "Multi-Pfad-Freigabe wird geöffnet..."
+
+#: id:15311
+msgid "Path:"
+msgstr "Pfad:"
+
+#: id:16000
+msgctxt "Auto context with id 16000"
+msgid "General"
+msgstr "Allgemein"
+
+#: id:16002
+msgid "Internet lookup"
+msgstr "Internet-Anfrage"
+
+#: id:16003
+msgid "Player"
+msgstr "Wiedergabe"
+
+#: id:16004
+msgid "Play media from disc"
+msgstr "Inhalt der CD/DVD abspielen"
+
+#: id:16008
+msgid "Enter new title"
+msgstr "Bitte einen neuen Titel eingeben"
+
+#: id:16009
+msgid "Enter the movie name"
+msgstr "Bitte den Namen des Films eingeben"
+
+#: id:16010
+msgid "Enter the profile name"
+msgstr "Bitte einen Namen für dieses Profil eingeben"
+
+#: id:16011
+msgid "Enter the album name"
+msgstr "Bitte den Namen des Albums eingeben"
+
+#: id:16012
+msgid "Enter the playlist name"
+msgstr "Bitte einen Namen für die Playlist eingeben"
+
+#: id:16013
+msgid "Enter new filename"
+msgstr "Bitte einen neuen Dateinamen eingeben"
+
+#: id:16014
+msgid "Enter folder name"
+msgstr "Bitte einen Namen für diesen Ordner eingeben"
+
+#: id:16015
+msgid "Enter directory"
+msgstr "In den Ordner wechseln"
+
+#: id:16016
+msgid "Available options: %A, %T, %N, %B, %D, %G, %Y, %F, %S"
+msgstr "Verfügbare Optionen: %A, %T, %N, %B, %D, %G, %Y, %F, %S"
+
+#: id:16017
+msgid "Enter search string"
+msgstr "Bitte einen Suchbegriff eingeben"
+
+#: id:16018
+msgctxt "Auto context with id 16018"
+msgid "None"
+msgstr "Aus"
+
+#: id:16019
+msgid "Auto select"
+msgstr "Auto"
+
+#: id:16020
+msgid "De-interlace"
+msgstr "Deinterlace"
+
+#: id:16021
+msgid "Bob"
+msgstr "Bob"
+
+#: id:16022
+msgid "Bob (inverted)"
+msgstr "Bob (Invertiert)"
+
+#: id:16024
+msgid "Canceling..."
+msgstr "Abbrechen..."
+
+#: id:16025
+msgid "Enter the artist name"
+msgstr "Bitte den Namen des Interpreten eingeben"
+
+#: id:16026
+msgid "Playback failed"
+msgstr "Wiedergabe nicht möglich"
+
+#: id:16027
+msgid "One or more items failed to play."
+msgstr "Ein/mehrere Inhalt(e) konnte(n) nicht wiedergegeben werden"
+
+#: id:16028
+msgid "Enter value"
+msgstr "Wert eingeben"
+
+#: id:16029
+msgid "Check the log file for details."
+msgstr "Für Details bitte Logdatei einsehen."
+
+#: id:16030
+msgid "Party mode aborted."
+msgstr "Party-Modus abgebrochen"
+
+#: id:16031
+msgid "No matching songs in the library."
+msgstr "Es sind keine passenden Titel in der Datenbank."
+
+#: id:16032
+msgid "Could not initialize database."
+msgstr "Die Datenbank konnte nicht gestartet werden."
+
+#: id:16033
+msgid "Could not open database."
+msgstr "Die Datenbank konnte nicht geöffnet werden."
+
+#: id:16034
+msgid "Could not get songs from database."
+msgstr "Es konnten keine Titel aus der Datenbank geladen werden."
+
+#: id:16035
+msgid "Party mode playlist"
+msgstr "Party-Modus Playlist"
+
+#: id:16036
+msgid "De-interlace (Half)"
+msgstr ""
+
+#: id:16037
+msgid "Deinterlace video"
+msgstr ""
+
+#: id:16038
+msgid "Deinterlace method"
+msgstr ""
+
+#: id:16039
+msgctxt "Auto context with id 16039"
+msgid "Off"
+msgstr ""
+
+#: id:16040
+msgctxt "Auto context with id 16040"
+msgid "Auto"
+msgstr ""
+
+#: id:16041
+msgid "On"
+msgstr ""
+
+#: id:16100
+msgid "All Videos"
+msgstr "Alle Videos"
+
+#: id:16101
+msgid "Unwatched"
+msgstr "Nicht gesehen"
+
+#: id:16102
+msgid "Watched"
+msgstr "Gesehen"
+
+#: id:16103
+msgid "Mark as watched"
+msgstr "Als 'gesehen' markieren"
+
+#: id:16104
+msgid "Mark as unwatched"
+msgstr "Als 'ungesehen' markieren"
+
+#: id:16105
+msgid "Edit title"
+msgstr "Titel umbenennen"
+
+#: id:16200
+msgid "Operation was aborted"
+msgstr "Der Vorgang wurde abgebrochen."
+
+#: id:16201
+msgid "Copy failed"
+msgstr "Fehler beim Kopieren"
+
+#: id:16202
+msgid "Failed to copy at least one file"
+msgstr "Fehler beim Kopieren von mindestens einer Datei."
+
+#: id:16203
+msgid "Move failed"
+msgstr "Fehler beim Verschieben."
+
+#: id:16204
+msgid "Failed to move at least one file"
+msgstr "Fehler beim Verschieben von mindestens einer Datei."
+
+#: id:16205
+msgid "Delete failed"
+msgstr "Fehler beim Löschen."
+
+#: id:16206
+msgid "Failed to delete at least one file"
+msgstr "Fehler beim Löschen von mindestens einer Datei."
+
+#: id:16300
+msgid "Video scaling method"
+msgstr "Videoskalierungsmethode"
+
+#: id:16301
+msgid "Nearest neighbour"
+msgstr "Nächster Nachbar"
+
+#: id:16302
+msgid "Bilinear"
+msgstr "Bilinear"
+
+#: id:16303
+msgctxt "Auto context with id 16303"
+msgid "Bicubic"
+msgstr "Bicubic"
+
+#: id:16304
+msgid "Lanczos2"
+msgstr "Lanczos2"
+
+#: id:16305
+msgid "Lanczos3"
+msgstr "Lanczos3"
+
+#: id:16306
+msgid "Sinc8"
+msgstr "Sinc8"
+
+#: id:16307
+msgid "Bicubic (software)"
+msgstr "Bicubic (Software)"
+
+#: id:16308
+msgid "Lanczos (software)"
+msgstr "Lanczos (Software)"
+
+#: id:16309
+msgid "Sinc (software)"
+msgstr "Sinc (Software)"
+
+#: id:16310
+msgid "Temporal"
+msgstr "Zeitlich"
+
+#: id:16311
+msgid "Temporal/Spatial"
+msgstr "Zeitlich/Räumlich"
+
+#: id:16312
+msgid "(VDPAU)Noise Reduction"
+msgstr "(VDPAU)Rauschunterdrückung"
+
+#: id:16313
+msgid "(VDPAU)Sharpness"
+msgstr "(VDPAU)Schärfe"
+
+#: id:16314
+msgid "Inverse Telecine"
+msgstr "Inverse Telecine"
+
+#: id:16315
+msgid "Lanczos3 optimized"
+msgstr "Lanczos3 optimiert"
+
+#: id:16316
+msgctxt "Auto context with id 16316"
+msgid "Auto"
+msgstr "Automatisch"
+
+#: id:16317
+msgid "Temporal (Half)"
+msgstr "Zeitlich (Hälfte)"
+
+#: id:16318
+msgid "Temporal/Spatial (Half)"
+msgstr "Zeitlich/Räumlich (Hälfte)"
+
+#: id:16319
+msgid "DXVA"
+msgstr "DXVA"
+
+#: id:16320
+msgid "DXVA Bob"
+msgstr ""
+
+#: id:16321
+msgid "DXVA Best"
+msgstr ""
+
+#: id:16322
+msgid "Spline36"
+msgstr ""
+
+#: id:16323
+msgid "Spline36 optimized"
+msgstr ""
+
+#: id:16324
+msgid "Software Blend"
+msgstr ""
+
+#: id:16400
+msgid "Post-processing"
+msgstr "Video Nachbearbeitung"
+
+#: id:17500
+msgid "Display sleep timeout"
+msgstr "Bildschirm Sleep Timeout"
+
+#: id:19000
+msgid "Switch to channel"
+msgstr "Zum Kanal wechseln"
+
+#: id:20000
+msgid "Saved music folder"
+msgstr "Ordner für CD-Kopien"
+
+#: id:20001
+msgid "Use external DVD player"
+msgstr "Externen DVD-Player verwenden"
+
+#: id:20002
+msgid "External DVD player"
+msgstr "Externer DVD-Player"
+
+#: id:20003
+msgid "Trainers folder"
+msgstr "Ordner für Trainer"
+
+#: id:20004
+msgid "Screenshot folder"
+msgstr "Ordner für Screenshots"
+
+#: id:20006
+msgid "Playlists folder"
+msgstr "Ordner für Playlisten"
+
+#: id:20007
+msgid "Recordings"
+msgstr "Aufnahmen"
+
+#: id:20008
+msgid "Screenshots"
+msgstr "Screenshots"
+
+#: id:20009
+msgid "Use XBMC"
+msgstr "XBMC verwenden"
+
+#: id:20011
+msgid "Music playlists"
+msgstr "Musik-Playlisten"
+
+#: id:20012
+msgid "Video playlists"
+msgstr "Video-Playlisten"
+
+#: id:20013
+msgid "Do you wish to launch the game?"
+msgstr "Das Spiel jetzt starten?"
+
+#: id:20014
+msgid "Sort by: Playlist"
+msgstr "Nach Playlisten"
+
+#: id:20015
+msgid "Remote thumb"
+msgstr "Online-Cover"
+
+#: id:20016
+msgid "Current thumb"
+msgstr "Aktuelles Cover"
+
+#: id:20017
+msgid "Local thumb"
+msgstr "Lokales Cover"
+
+#: id:20018
+msgid "No thumb"
+msgstr "Kein Cover"
+
+#: id:20019
+msgid "Choose thumbnail"
+msgstr "Thumbnail wählen"
+
+#: id:20023
+msgid "Conflict"
+msgstr "Konflikt"
+
+#: id:20024
+msgid "Scan new"
+msgstr "Nur neue"
+
+#: id:20025
+msgid "Scan all"
+msgstr "Komplett"
+
+#: id:20026
+msgid "Region"
+msgstr "Region"
+
+#: id:20037
+msgid "Summary"
+msgstr "Info"
+
+#: id:20038
+msgid "Lock music window"
+msgstr "Musik-Bereich sperren"
+
+#: id:20039
+msgid "Lock videos window"
+msgstr "Videos-Bereich sperren"
+
+#: id:20040
+msgid "Lock pictures window"
+msgstr "Bilder-Bereich sperren"
+
+#: id:20041
+msgid "Lock programs & scripts windows"
+msgstr "Programme- und Skript-Bereich sperren"
+
+#: id:20042
+msgid "Lock file manager"
+msgstr "Dateimanager sperren"
+
+#: id:20043
+msgid "Lock settings"
+msgstr "Einstellungen sperren"
+
+#: id:20044
+msgid "Start fresh"
+msgstr "Neu beginnen"
+
+#: id:20045
+msgid "Enter master mode"
+msgstr "Master-Modus aktivieren"
+
+#: id:20046
+msgid "Leave master mode"
+msgstr "Master-Modus deaktivieren"
+
+#: id:20047
+msgid "Create profile '%s'?"
+msgstr "Profil '%s' erstellen?"
+
+#: id:20048
+msgid "Start with fresh settings"
+msgstr "Mit neuen Einstellungen beginnen"
+
+#: id:20049
+msgid "Best available"
+msgstr "Bestmögliche"
+
+#: id:20050
+msgid "Auto-switch between 16x9 and 4x3"
+msgstr "Zwischen 16x9 und 4x3 automatisch umschalten"
+
+#: id:20051
+msgid "Treat stacked files as single file"
+msgstr "Gestapelte Dateien als eine Datei behandeln"
+
+#: id:20052
+msgid "Caution"
+msgstr "Achtung!"
+
+#: id:20053
+msgid "Left master mode"
+msgstr "Master-Modus ist deaktiviert."
+
+#: id:20054
+msgid "Entered master mode"
+msgstr "Master-Modus ist aktiviert."
+
+#: id:20055
+msgid "Allmusic.com thumb"
+msgstr "Allmusic.com Thumbnail"
+
+#: id:20057
+msgid "Remove thumbnail"
+msgstr "Thumbnail entfernen"
+
+#: id:20058
+msgid "Add profile..."
+msgstr "Profil hinzufügen..."
+
+#: id:20059
+msgid "Query info for all albums"
+msgstr "Alle Alben-Infos laden"
+
+#: id:20060
+msgctxt "Auto context with id 20060"
+msgid "Media info"
+msgstr "Medien-Informationen"
+
+#: id:20061
+msgctxt "Auto context with id 20061"
+msgid "Separate"
+msgstr "Eigenständig"
+
+#: id:20062
+msgid "Shares with default"
+msgstr "Wie Hauptbenutzer"
+
+#: id:20063
+msgid "Shares with default (read only)"
+msgstr "Wie Hauptbenutzer (Nur lesen)"
+
+#: id:20064
+msgid "Copy default"
+msgstr "Standard übernehmen"
+
+#: id:20065
+msgid "Profile picture"
+msgstr "Profil-Bild"
+
+#: id:20066
+msgid "Lock preferences"
+msgstr "Sperren konfigurieren"
+
+#: id:20067
+msgid "Edit profile"
+msgstr "Profil bearbeiten"
+
+#: id:20068
+msgid "Profile lock"
+msgstr "Profil-Passwort"
+
+#: id:20069
+msgid "Could not create folder"
+msgstr "Der Ordner konnte nicht erstellt werden!"
+
+#: id:20070
+msgid "Profile directory"
+msgstr "Profil-Ordner"
+
+#: id:20071
+msgid "Start with fresh media sources"
+msgstr "Mit neuen Medien-Quellen beginnen"
+
+#: id:20072
+msgid "Make sure the selected folder is writable"
+msgstr "Bitte sicherstellen, dass der gewählte Ordner beschreibbar ist"
+
+#: id:20073
+msgid "and that the new folder name is valid"
+msgstr "und dass der neue Ordnername gültig ist."
+
+#: id:20074
+msgid "MPAA rating"
+msgstr "FSK"
+
+#: id:20075
+msgid "Enter master lock code"
+msgstr "Bitte das Master-Passwort eingeben"
+
+#: id:20076
+msgid "Ask for master lock code on startup"
+msgstr "Master-Passwort beim Start abfragen"
+
+#: id:20077
+msgid "Skin settings"
+msgstr "Skin-Optionen"
+
+#: id:20078
+msgid "- no link set -"
+msgstr "- nicht gesetzt -"
+
+#: id:20079
+msgid "Enable animations"
+msgstr "Animationen aktivieren"
+
+#: id:20080
+msgid "Disable RSS during music"
+msgstr "RSS während der Musikwiedergabe deaktivieren"
+
+#: id:20081
+msgid "Enable shortcut buttons"
+msgstr "Eigene Lesezeichen aktivieren"
+
+#: id:20082
+msgid "Show programs in main menu"
+msgstr "Programme im Hauptmenü anzeigen"
+
+#: id:20083
+msgid "Show music info"
+msgstr "Musik-Informationen anzeigen"
+
+#: id:20084
+msgid "Show weather info"
+msgstr "Wetter-Informationen anzeigen"
+
+#: id:20085
+msgid "Show system info"
+msgstr "System-Informationen anzeigen"
+
+#: id:20086
+msgid "Show available disc space C: E: F:"
+msgstr "Verfügbaren Speicherplatz für C: E: F: anzeigen"
+
+#: id:20087
+msgid "Show available disc space E: F: G:"
+msgstr "Verfügbaren Speicherplatz für E: F: G: anzeigen"
+
+#: id:20088
+msgid "Weather info"
+msgstr "Wetter-Informationen"
+
+#: id:20089
+msgid "Drive space free"
+msgstr "Verfügbarer Speicherplatz"
+
+#: id:20090
+msgid "Enter the name of an existing share"
+msgstr "Bitte den Namen einer verfügbaren Quelle eingeben"
+
+#: id:20091
+msgid "Lock code"
+msgstr "Passwort"
+
+#: id:20092
+msgid "Load profile"
+msgstr "Profil laden"
+
+#: id:20093
+msgid "Profile name"
+msgstr "Profil-Name"
+
+#: id:20094
+msgctxt "Auto context with id 20094"
+msgid "Media sources"
+msgstr "Medien-Quellen"
+
+#: id:20095
+msgid "Enter profile lock code"
+msgstr "Bitte Profil-Passwort eingeben"
+
+#: id:20096
+msgctxt "Auto context with id 20096"
+msgid "Login screen"
+msgstr "Anmeldung"
+
+#: id:20097
+msgid "Fetching album info"
+msgstr "Album-Informationen werden gesucht"
+
+#: id:20098
+msgid "Fetching info for album"
+msgstr "Informationen werden gesucht für das Album"
+
+#: id:20099
+msgid "Can't rip CD or track while playing from CD"
+msgstr "Während der CD-Wiedergabe kann nicht kopiert werden!"
+
+#: id:20100
+msgid "Master lock code and settings"
+msgstr "Master-Passwort und Sperren"
+
+#: id:20101
+msgid "Entering master lock code always enables master mode"
+msgstr "Master-Passwort aktiviert immer den Master-Modus"
+
+#: id:20102
+msgid "or copy from default?"
+msgstr "oder diese vom Hauptbenutzer übernehmen?"
+
+#: id:20103
+msgid "Save changes to profile?"
+msgstr "Sollen die Änderungen gespeichert werden?"
+
+#: id:20104
+msgid "Old settings found."
+msgstr "Bestehende Einstellungen wurden gefunden."
+
+#: id:20105
+msgid "Do you want to use them?"
+msgstr "Sollen diese verwendet werden?"
+
+#: id:20106
+msgid "Old media sources found."
+msgstr "Bestehende Medienquellen wurden gefunden."
+
+#: id:20107
+msgid "Separate (locked)"
+msgstr "Eigenständig (nur lesen)"
+
+#: id:20108
+msgid "Root"
+msgstr "Hauptordner"
+
+#: id:20109
+msgid "- Zoom"
+msgstr "Skin-Zoom"
+
+#: id:20110
+msgid "UPnP settings"
+msgstr "UPnP-Einstellungen"
+
+#: id:20111
+msgid "Autostart UPnP client"
+msgstr "UPnP-Client automatisch starten"
+
+#: id:20112
+msgid "Last login: %s"
+msgstr "Letzte Anmeldung: %s"
+
+#: id:20113
+msgid "Never logged on"
+msgstr "Bisher noch nicht angemeldet"
+
+#: id:20114
+msgid "Profile %i / %i"
+msgstr "Profil %i / %i"
+
+#: id:20115
+msgid "User login / Select a profile"
+msgstr "Bitte ein Profil wählen"
+
+#: id:20116
+msgid "Use lock on login screen"
+msgstr "Anmeldung sperren"
+
+#: id:20117
+msgid "Invalid lock code."
+msgstr "Das eingegebene Passwort ist ungültig!"
+
+#: id:20118
+msgid "This requires the master lock to be set."
+msgstr "Hierfür muss die Master-Sperre gesetzt werden."
+
+#: id:20119
+msgid "Would you like to set it now?"
+msgstr "Diese nun aktivieren?"
+
+#: id:20120
+msgid "Loading program information"
+msgstr "Programm-Informationen werden geladen..."
+
+#: id:20121
+msgid "Party on!"
+msgstr "Party-Modus ist aktiviert!"
+
+#: id:20122
+msgid "True"
+msgstr "Richtig"
+
+#: id:20123
+msgid "Mixing drinks"
+msgstr "Titel werden gefiltert..."
+
+#: id:20124
+msgid "Filling glasses"
+msgstr "Titel werden hinzugefügt"
+
+#: id:20125
+msgid "Logged on as"
+msgstr "Angemeldet als"
+
+#: id:20126
+msgid "Log off"
+msgstr "Abmelden"
+
+#: id:20128
+msgid "Go to root"
+msgstr "Zum Hauptordner"
+
+#: id:20129
+msgid "Weave"
+msgstr "Weave"
+
+#: id:20130
+msgid "Weave (inverted)"
+msgstr "Weave (Invertiert)"
+
+#: id:20131
+msgid "Blend"
+msgstr "Blend"
+
+#: id:20132
+msgid "Restart video"
+msgstr "Video neustarten"
+
+#: id:20133
+msgid "Edit network location"
+msgstr "Netzwerkquelle bearbeiten"
+
+#: id:20134
+msgid "Remove network location"
+msgstr "Netzwerkquelle entfernen"
+
+#: id:20135
+msgid "Do you want to scan the folder?"
+msgstr "Diesen Ordner jetzt durchsuchen?"
+
+#: id:20136
+msgid "Memory unit"
+msgstr "Speicherkarte"
+
+#: id:20137
+msgid "Memory unit mounted"
+msgstr "Speicherkarte eingesteckt"
+
+#: id:20138
+msgid "Unable to mount memory unit"
+msgstr "Die Speicherkarte konnte nicht erkannt werden!"
+
+#: id:20139
+msgid "In port %i, slot %i"
+msgstr "In Port %i, Slot %i"
+
+#: id:20140
+msgid "Lock screensaver"
+msgstr "Bildschirmschoner sperren"
+
+#: id:20141
+msgid "Set"
+msgstr "Einstellen"
+
+#: id:20142
+msgctxt "Auto context with id 20142"
+msgid "Username"
+msgstr "Benutzername"
+
+#: id:20143
+msgid "Enter password for"
+msgstr "Bitte Passwort eingeben für"
+
+#: id:20144
+msgid "Shutdown timer"
+msgstr "Ausschalt-Timer"
+
+#: id:20145
+msgid "Shutdown interval (in minutes)"
+msgstr "Ausschalt-Intervall (in Minuten)"
+
+#: id:20146
+msgid "Started, shutdown in %im"
+msgstr "Ausschalten in %imin aktiviert."
+
+#: id:20147
+msgid "Shutdown in 30 minutes"
+msgstr "Ausschalten in 30 Minuten"
+
+#: id:20148
+msgid "Shutdown in 60 minutes"
+msgstr "Ausschalten in 60 Minuten"
+
+#: id:20149
+msgid "Shutdown in 120 minutes"
+msgstr "Ausschalten in 120 Minuten"
+
+#: id:20150
+msgid "Custom shutdown timer"
+msgstr "Eigener Ausschalt-Timer"
+
+#: id:20151
+msgid "Cancel shutdown timer"
+msgstr "Ausschalt-Timer deaktiveren"
+
+#: id:20152
+msgid "Lock preferences for %s"
+msgstr "Einstellungen für %s sperren"
+
+#: id:20153
+msgid "Browse..."
+msgstr "Durchsuchen..."
+
+#: id:20154
+msgid "Summary information"
+msgstr "Allgemeine Informationen"
+
+#: id:20155
+msgid "Storage information"
+msgstr "Speicherplatz-Informationen"
+
+#: id:20156
+msgid "Hard disk information"
+msgstr "Festplatten-Informationen"
+
+#: id:20157
+msgid "DVD-ROM information"
+msgstr "DVD-Laufwerks-Informationen"
+
+#: id:20158
+msgid "Network information"
+msgstr "Netzwerk-Informationen"
+
+#: id:20159
+msgid "Video information"
+msgstr "Grafik-Informationen"
+
+#: id:20160
+msgid "Hardware information"
+msgstr "Hardware-Informationen"
+
+#: id:20161
+msgid "Total"
+msgstr "Gesamt"
+
+#: id:20162
+msgid "Used"
+msgstr "Belegt"
+
+#: id:20163
+msgid "of"
+msgstr "von"
+
+#: id:20164
+msgid "Locking not supported"
+msgstr "Sperren nicht unterstützt"
+
+#: id:20165
+msgid "Not locked"
+msgstr "Nicht gesperrt"
+
+#: id:20166
+msgid "Locked"
+msgstr "Gesperrt"
+
+#: id:20167
+msgid "Frozen"
+msgstr "Angehalten"
+
+#: id:20168
+msgid "Requires reset"
+msgstr "Reset erforderlich"
+
+#: id:20169
+msgid "Week"
+msgstr "Woche"
+
+#: id:20170
+msgid "Line"
+msgstr "Linie"
+
+#: id:20171
+msgid "Windows network (SMB)"
+msgstr "Windows-Netzwerk (SMB)"
+
+#: id:20172
+msgid "XBMSP server"
+msgstr "XBMSP-Server"
+
+#: id:20173
+msgctxt "Auto context with id 20173"
+msgid "FTP server"
+msgstr "FTP-Server"
+
+#: id:20174
+msgid "iTunes music share (DAAP)"
+msgstr "iTunes Musik-Freigabe (DAAP)"
+
+#: id:20175
+msgid "UPnP server"
+msgstr "UPnP-Server"
+
+#: id:20176
+msgid "Show video info"
+msgstr "Video-Informationen anzeigen"
+
+#: id:20177
+msgid "Done"
+msgstr "Fertig"
+
+#: id:20178
+msgid "Shift"
+msgstr "Umschalttaste"
+
+#: id:20179
+msgid "Caps Lock"
+msgstr "Feststelltaste"
+
+#: id:20180
+msgid "Symbols"
+msgstr "Symbole"
+
+#: id:20181
+msgid "Backspace"
+msgstr "Löschen"
+
+#: id:20182
+msgid "Space"
+msgstr "Leertaste"
+
+#: id:20183
+msgid "Reload skin"
+msgstr "Skin aktualisieren"
+
+#: id:20184
+msgid "Rotate pictures using EXIF information"
+msgstr "Bilder anhand der EXIF-Informationen drehen"
+
+#: id:20185
+msgid "Use poster view styles for TV shows"
+msgstr "Benutze Poster-Ansicht für TV-Serien"
+
+#: id:20186
+msgid "Please wait"
+msgstr "Bitte warten"
+
+#: id:20187
+msgid "UPnP"
+msgstr ""
+
+#: id:20189
+msgid "Enable auto scrolling for plot & review"
+msgstr "Aktiviere Auto Scrolling für Handlung & Kritiken"
+
+#: id:20190
+msgctxt "Auto context with id 20190"
+msgid "Custom"
+msgstr "Benutzerdefiniert"
+
+#: id:20191
+msgid "Enable debug logging"
+msgstr "Debug-Logging aktivieren"
+
+#: id:20192
+msgid "Download additional information during updates"
+msgstr "Zusätzliche Informationen wärend des Updates herunterladen"
+
+#: id:20193
+msgid "Default service for album information"
+msgstr "Standard-Service für Albuminformationen"
+
+#: id:20194
+msgid "Default service for artist information"
+msgstr "Standard-Service für Interpretinformationen"
+
+#: id:20195
+msgid "Change scraper"
+msgstr "Wechsel-Scraper"
+
+#: id:20196
+msgid "Export music library"
+msgstr "Musikdatenbank exportieren"
+
+#: id:20197
+msgid "Import music library"
+msgstr "Musikdatenbank importieren"
+
+#: id:20198
+msgid "No artist found!"
+msgstr "Kein Künstler gefunden!"
+
+#: id:20199
+msgid "Downloading artist info failed"
+msgstr "Herunterladen der Interpreten Info fehlgeschlagen"
+
+#: id:20250
+msgid "Party on! (videos)"
+msgstr "Party-Modus ist aktiviert!"
+
+#: id:20251
+msgid "Mixing drinks (videos)"
+msgstr "Titel werden gefiltert..."
+
+#: id:20252
+msgid "Filling glasses (videos)"
+msgstr "Titel werden hinzugefügt..."
+
+#: id:20253
+msgid "WebDAV server (HTTP)"
+msgstr "WebDAV server (HTTP)"
+
+#: id:20254
+msgid "WebDAV server (HTTPS)"
+msgstr "WebDAV server (HTTPS)"
+
+#: id:20255
+msgid "First logon, edit your profile"
+msgstr "Erster Login: Bearbeite dein Profil."
+
+#: id:20256
+msgid "HTS Tvheadend client"
+msgstr "HTS Tvheadend Client"
+
+#: id:20257
+msgid "VDR Streamdev client"
+msgstr "VDR Streamdev Client"
+
+#: id:20258
+msgid "MythTV client"
+msgstr ""
+
+#: id:20259
+msgid "Network Filesystem (NFS)"
+msgstr "Netzwerk Dateisystem (NFS)"
+
+#: id:20260
+msgid "Secure Shell (SSH/SFTP)"
+msgstr ""
+
+#: id:20261
+msgid "Apple Filing Protocol (AFP)"
+msgstr ""
+
+#: id:20300
+msgid "Web server directory (HTTP)"
+msgstr "Webserver-Verzeichnis (HTTP)"
+
+#: id:20301
+msgid "Web server directory (HTTPS)"
+msgstr "Webserver-Verzeichnis (HTTPS)"
+
+#: id:20302
+msgid "Unable to write to folder:"
+msgstr "Ordner ist nicht beschreibbar:"
+
+#: id:20303
+msgid "Do you want to skip and proceed?"
+msgstr "Export Überspringen und fortsetzen?"
+
+#: id:20304
+msgid "RSS Feed"
+msgstr "RSS Feed"
+
+#: id:20307
+msgid "Secondary DNS"
+msgstr "Sekundärer DNS-Server"
+
+#: id:20308
+msgid "DHCP server:"
+msgstr "DHCP-Server"
+
+#: id:20309
+msgid "Make new folder"
+msgstr "Neuer Ordner"
+
+#: id:20310
+msgid "Dim LCD on playback"
+msgstr "LCD während der Wiedergabe ausschalten"
+
+#: id:20311
+msgid "Unknown or onboard (protected)"
+msgstr "Unbekannt oder OnBoard (geschützt)"
+
+#: id:20312
+msgid "Dim LCD on paused"
+msgstr "Während 'Pause' das LCD dimmen"
+
+#: id:20314
+msgid "Videos - Library"
+msgstr "Videodatenbank"
+
+#: id:20316
+msgid "Sort by: ID"
+msgstr "Sortiert nach ID"
+
+#: id:20324
+msgid "Play part..."
+msgstr "Einzelteil spielen..."
+
+#: id:20325
+msgid "Calibration reset"
+msgstr "Kalibrierung zurücksetzen"
+
+#: id:20326
+msgid "This will reset the calibration values for %s"
+msgstr "Dies setzt den Kalibrierwert für %s"
+
+#: id:20327
+msgid "to it's default values."
+msgstr "auf den Standardwert zurück"
+
+#: id:20328
+msgid "Browse for destination"
+msgstr "Nach einem Speicherort durchsuchen..."
+
+#: id:20329
+msgid "Movies are in separate folders that match the movie title"
+msgstr "Filme sind in seperaten Ordnern, welche Filmtitel entsprechen"
+
+#: id:20330
+msgid "Use folder names for lookups"
+msgstr "Ordnernamen für Anfragen verwenden"
+
+#: id:20331
+msgctxt "Auto context with id 20331"
+msgid "File"
+msgstr "Dateinamen"
+
+#: id:20332
+msgid "Use file or folder names in lookups?"
+msgstr "Datei- oder Ordnernamen für Anfragen verwenden?"
+
+#: id:20333
+msgid "Set content"
+msgstr "Inhalt festlegen"
+
+#: id:20334
+msgid "Folder"
+msgstr "Ordnernamen"
+
+#: id:20335
+msgid "Look for content recursively?"
+msgstr "Im Ordner rekursiv nach Inhalten suchen?"
+
+#: id:20336
+msgid "Unlock sources"
+msgstr "Quellen freigeben"
+
+#: id:20337
+msgid "Actor"
+msgstr "Darsteller"
+
+#: id:20338
+msgid "Movie"
+msgstr "Film"
+
+#: id:20339
+msgid "Director"
+msgstr "Regisseur"
+
+#: id:20340
+msgid "Do you want to remove all items within"
+msgstr "Alle Elemente innerhalb dieses Pfades"
+
+#: id:20341
+msgid "this path from the XBMC library?"
+msgstr "aus der Datenbank entfernen?"
+
+#: id:20342
+msgctxt "Auto context with id 20342"
+msgid "Movies"
+msgstr "Filme"
+
+#: id:20343
+msgid "TV shows"
+msgstr "TV-Serien"
+
+#: id:20344
+msgid "This directory contains"
+msgstr "Dieser Ordner beinhaltet"
+
+#: id:20345
+msgid "Run automated scan"
+msgstr "Automatisierten Scan verwenden"
+
+#: id:20346
+msgid "Scan recursively"
+msgstr "Rekursives Scannen"
+
+#: id:20347
+msgid "as"
+msgstr "als"
+
+#: id:20348
+msgid "Directors"
+msgstr "Regisseure"
+
+#: id:20349
+msgid "No video files found in this path!"
+msgstr "Es wurden keine Videos in diesem Pfad gefunden!"
+
+#: id:20350
+msgid "votes"
+msgstr "Stimmen"
+
+#: id:20351
+msgid "TV show information"
+msgstr "TV-Serien Information"
+
+#: id:20352
+msgid "Episode information"
+msgstr "Episoden-Information"
+
+#: id:20353
+msgid "Loading TV show details"
+msgstr "TV-Serien Details werden geladen"
+
+#: id:20354
+msgid "Fetching episode guide"
+msgstr "Episoden-Guide wird geladen"
+
+#: id:20355
+msgid "Loading info for episodes in directory"
+msgstr "Episoden-Informationen werden geladen"
+
+#: id:20356
+msgid "Select TV show:"
+msgstr "TV-Serien-Auswahl:"
+
+#: id:20357
+msgid "Enter the TV show name"
+msgstr "Bitte den Namen der TV-Serie eingeben"
+
+#: id:20358
+msgid "Season %i"
+msgstr "Staffel %i"
+
+#: id:20359
+msgid "Episode"
+msgstr "Episode"
+
+#: id:20360
+msgid "Episodes"
+msgstr "Episoden"
+
+#: id:20361
+msgid "Loading episode details"
+msgstr "Episoden-Details werden geladen"
+
+#: id:20362
+msgid "Remove episode from library"
+msgstr "Episode aus der Datenbank entfernen"
+
+#: id:20363
+msgid "Remove TV show from library"
+msgstr "TV-Serie aus der Datenbank entfernen"
+
+#: id:20364
+msgid "TV show"
+msgstr "TV-Serie"
+
+#: id:20365
+msgid "Episode plot"
+msgstr "Handlung (Episode)"
+
+#: id:20366
+msgid "* All seasons"
+msgstr "* Alle Staffeln"
+
+#: id:20367
+msgid "Hide watched"
+msgstr "Gesehene ausblenden"
+
+#: id:20368
+msgid "Prod code"
+msgstr "Produktions-Code"
+
+#: id:20369
+msgid "Show plot for unwatched items"
+msgstr "Handlung bei ungesehenen Filmen anzeigen"
+
+#: id:20370
+msgid "* Hidden to prevent spoilers *"
+msgstr "* Die Handlung wird nicht angezeigt. *"
+
+#: id:20371
+msgid "Set season thumb"
+msgstr "Staffel-Cover setzen"
+
+#: id:20372
+msgid "Season image"
+msgstr "Staffel-Cover"
+
+#: id:20373
+msgid "Season"
+msgstr "Staffel"
+
+#: id:20374
+msgid "Downloading movie information"
+msgstr "Film-Informationen werden geladen..."
+
+#: id:20375
+msgid "Unassign content"
+msgstr "Inhalt zurücksetzen"
+
+#: id:20376
+msgid "Original title"
+msgstr "Originaltitel"
+
+#: id:20377
+msgid "Refresh TV show information"
+msgstr "TV-Serien-Informationen aktualisieren"
+
+#: id:20378
+msgid "Refresh info for all episodes?"
+msgstr "Die Informationen für alle Episoden aktualisieren?"
+
+#: id:20379
+msgid "Selected folder contains a single TV show"
+msgstr "Ordner beinhaltet eine einzige TV-Serie"
+
+#: id:20380
+msgid "Exclude selected folder from scans"
+msgstr "Ordner vom Scan ausschließen"
+
+#: id:20381
+msgid "Specials"
+msgstr "Specials"
+
+#: id:20382
+msgid "Automatically grab season thumbs"
+msgstr "Staffel-Cover von TV-Serien automatisch herunterladen"
+
+#: id:20383
+msgid "Selected folder contains a single video"
+msgstr "Ordner enthält ein einziges Video"
+
+#: id:20384
+msgid "Link to TV show"
+msgstr "Link zur TV-Serie"
+
+#: id:20385
+msgid "Remove link to TV show"
+msgstr "Link zur TV-Serie entfernen"
+
+#: id:20386
+msgid "Recently added movies"
+msgstr "Neu hinzugefügte Filme"
+
+#: id:20387
+msgid "Recently added episodes"
+msgstr "Neu hinzugefügte Episoden"
+
+#: id:20388
+msgid "Studios"
+msgstr "Studios"
+
+#: id:20389
+msgid "Music videos"
+msgstr "Musikvideos"
+
+#: id:20390
+msgid "Recently added music videos"
+msgstr "Neu hinzugefügte Musikvideos"
+
+#: id:20391
+msgid "Music video"
+msgstr "Musikvideo"
+
+#: id:20392
+msgid "Remove music video from library"
+msgstr "Musikvideos aus Datenbank entfernen"
+
+#: id:20393
+msgctxt "Auto context with id 20393"
+msgid "Music video information"
+msgstr "Musikvideo-Informationen"
+
+#: id:20394
+msgid "Loading music video information"
+msgstr "Musikvideo-Informationen werden geladen..."
+
+#: id:20395
+msgid "Mixed"
+msgstr "Gemischt"
+
+#: id:20396
+msgid "Go to albums by artist"
+msgstr "Zu Alben dieses Interpreten wechseln"
+
+#: id:20397
+msgid "Go to album"
+msgstr "Zum Album wechseln"
+
+#: id:20398
+msgid "Play song"
+msgstr "Titel abspielen"
+
+#: id:20399
+msgid "Go to music videos from album"
+msgstr "Zu den Musikvideos dieses Albums wechseln"
+
+#: id:20400
+msgid "Go to music videos by artist"
+msgstr "Zu den Musikvideos dieses Interpreten wechseln"
+
+#: id:20401
+msgid "Play music video"
+msgstr "Musikvideo abspielen"
+
+#: id:20402
+msgid "Download actor thumbnails when adding to library"
+msgstr "Bilder der Schauspieler automatisch herunterladen"
+
+#: id:20403
+msgid "Set actor thumb"
+msgstr "Schauspieler Bild setzen"
+
+#: id:20405
+msgid "Remove episode bookmark"
+msgstr "Episoden-Lesez. entfernen"
+
+#: id:20406
+msgid "Set episode bookmark"
+msgstr "Episoden-Lesez. setzen"
+
+#: id:20407
+msgid "Scraper settings"
+msgstr "Scraper-Einstellungen"
+
+#: id:20408
+msgid "Downloading music video information"
+msgstr "Musikvideo-Informationen werden heruntergeladen..."
+
+#: id:20409
+msgid "Downloading TV show information"
+msgstr "TV-Serien-Informationen werden heruntergeladen..."
+
+#: id:20410
+msgid "Trailer"
+msgstr "Trailer"
+
+#: id:20411
+msgid "Flatten"
+msgstr "Reduzieren"
+
+#: id:20412
+msgid "Flatten TV shows"
+msgstr "TV-Serien reduzieren"
+
+#: id:20413
+msgid "Get fanart"
+msgstr "Lade Fanart"
+
+#: id:20414
+msgid "Show Fanart in video and music libraries"
+msgstr "Zeige Fanart in Video & Musik-Datenbanken"
+
+#: id:20415
+msgid "Scanning for new content"
+msgstr "Neue Inhalte suchen"
+
+#: id:20416
+msgid "First aired"
+msgstr "Erstausstrahlung"
+
+#: id:20417
+msgid "Writer"
+msgstr "Autor"
+
+#: id:20419
+msgid "Replace file names with library titles"
+msgstr "Ersetze Dateinamen durch Datenbankeinträge"
+
+#: id:20420
+msgctxt "Auto context with id 20420"
+msgid "Never"
+msgstr "Nie"
+
+#: id:20421
+msgid "If only one season"
+msgstr "Nur bei einer Staffel"
+
+#: id:20422
+msgid "Always"
+msgstr "Immer"
+
+#: id:20423
+msgid "Has trailer"
+msgstr "Trailer vorhanden"
+
+#: id:20424
+msgid "False"
+msgstr "Falsch"
+
+#: id:20425
+msgid "Fanart slideshow"
+msgstr "Fanart Slideshow"
+
+#: id:20426
+msgid "Export to a single file or separate"
+msgstr "In eine einzelne Datei oder in separate Dateien"
+
+#: id:20427
+msgid "files per entry?"
+msgstr "pro Eintrag exportieren?"
+
+#: id:20428
+msgid "Single file"
+msgstr "Einzeln"
+
+#: id:20429
+msgctxt "Auto context with id 20429"
+msgid "Separate"
+msgstr "Separat"
+
+#: id:20430
+msgid "Export thumbnails and fanart?"
+msgstr "Sollen Bilder und Fanart exportiert werden?"
+
+#: id:20431
+msgid "Overwrite old files?"
+msgstr "Alte Dateien überschreiben?"
+
+#: id:20432
+msgid "Exclude path from library updates"
+msgstr "Pfad von Aktualisierungen der Bibliothek ausschließen"
+
+#: id:20433
+msgid "Extract thumbnails and video information"
+msgstr "Metainformationen aus Mediendateien extrahieren"
+
+#: id:20434
+msgid "Sets"
+msgstr "Zusammenstellungen"
+
+#: id:20435
+msgid "Set movieset thumb"
+msgstr "Filmset Bild setzen"
+
+#: id:20436
+msgid "Export actor thumbs?"
+msgstr "Schauspieler Bilder exportieren?"
+
+#: id:20437
+msgid "Choose fanart"
+msgstr "Fanart wählen"
+
+#: id:20438
+msgid "Local fanart"
+msgstr "Lokale Fanart"
+
+#: id:20439
+msgid "No fanart"
+msgstr "Keine Fanart"
+
+#: id:20440
+msgid "Current fanart"
+msgstr "Aktuelle Fanart"
+
+#: id:20441
+msgid "Remote fanart"
+msgstr "Online-Fanart"
+
+#: id:20442
+msgid "Change content"
+msgstr "Inhalt wechseln"
+
+#: id:20443
+msgid "Do you want to refresh info for all"
+msgstr "Wollen Sie die Informationen für alle Einträge"
+
+#: id:20444
+msgid "items within this path?"
+msgstr "in diesem Pfad aktualisieren?"
+
+#: id:20445
+msgid "Fanart"
+msgstr "Fanart"
+
+#: id:20446
+msgid "Locally stored information found."
+msgstr "Lokal gespeicherte Informationen gefunden."
+
+#: id:20447
+msgid "Ignore and refresh from internet?"
+msgstr "Ignorieren und neu aus dem Internet laden?"
+
+#: id:20448
+msgid "Could not download information"
+msgstr "Informationen können nicht herunter geladen werden"
+
+#: id:20449
+msgid "Unable to connect to remote server"
+msgstr "Es kann keine Verbindung zum Server hergestellt werden"
+
+#: id:20450
+msgid "Would you like to continue scanning?"
+msgstr "Wollen Sie mit der Aktualisierung fortfahren?"
+
+#: id:20451
+msgid "Countries"
+msgstr "Länder"
+
+#: id:20452
+msgid "episode"
+msgstr "Episode"
+
+#: id:20453
+msgid "episodes"
+msgstr "Episoden"
+
+#: id:20454
+msgid "Listener"
+msgstr ""
+
+#: id:20455
+msgid "Listeners"
+msgstr ""
+
+#: id:20456
+msgid "Set movieset fanart"
+msgstr "Filmset Fanart setzen"
+
+#: id:20457
+msgid "Movie set"
+msgstr "Zusammenstellung"
+
+#: id:20458
+msgid "Group movies in sets"
+msgstr "Gruppiere Filme nach Zusammenstellungen"
+
+#: id:21330
+msgid "Show hidden files and directories"
+msgstr "Versteckte Ordner und Dateien anzeigen"
+
+#: id:21331
+msgid "TuxBox client"
+msgstr "TuxBox Client"
+
+#: id:21332
+msgid "WARNING: Target TuxBox device is in recording-mode!"
+msgstr "WARNUNG: Ziel-TuxBox-Laufwerk ist im Aufnahme-Modus!"
+
+#: id:21333
+msgid "The stream will be stopped!"
+msgstr "Der Stream wird beendet!"
+
+#: id:21334
+msgid "Zap to channel: %s failed!"
+msgstr "Umschalten auf Kanal: %s fehlgeschlagen!"
+
+#: id:21335
+msgid "Are you sure to start the stream?"
+msgstr "Den Stream jetzt starten?"
+
+#: id:21336
+msgid "Connecting to: %s"
+msgstr "Verbinden zu: %s"
+
+#: id:21337
+msgid "TuxBox device"
+msgstr "TuxBox-Laufwerk"
+
+#: id:21359
+msgid "Add media share..."
+msgstr "Quelle hinzufügen"
+
+#: id:21360
+msgid "Share video and music libraries through UPnP"
+msgstr "UPnP-Server aktivieren"
+
+#: id:21364
+msgid "Edit media share"
+msgstr "Quelle bearbeiten"
+
+#: id:21365
+msgid "Remove media share"
+msgstr "Quelle entfernen"
+
+#: id:21366
+msgid "Subtitle folder"
+msgstr "Alternatives Untertitel-Verzeichnis"
+
+#: id:21367
+msgid "Movie & alternate subtitle directory"
+msgstr "Video- & alternatives Untertitel-Verzeichnis"
+
+#: id:21368
+msgid "Override ASS/SSA subtitles fonts"
+msgstr "ASS/SSA Untertitel Schriftarten ignorieren"
+
+#: id:21369
+msgid "Enable mouse and Touch Screen support"
+msgstr "Maus und Touchscreen Unterstützung aktivieren"
+
+#: id:21370
+msgid "Play navigation sounds during media playback"
+msgstr "Navigations-Sounds während Medienwiedergabe aktivieren"
+
+#: id:21371
+msgid "Thumbnail"
+msgstr "Thumbnail"
+
+#: id:21372
+msgid "Forced DVD player region"
+msgstr "Erzwungene DVD-Player Region"
+
+#: id:21373
+msgid "Video output"
+msgstr "Video-Hardware"
+
+#: id:21374
+msgid "Video aspect"
+msgstr "Bildseitenverhältnis"
+
+#: id:21375
+msgctxt "Auto context with id 21375"
+msgid "Normal"
+msgstr "Normal"
+
+#: id:21376
+msgid "Letterbox"
+msgstr "4:3 Letterbox"
+
+#: id:21377
+msgid "Widescreen"
+msgstr "16:9 Widescreen"
+
+#: id:21378
+msgid "Enable 480p"
+msgstr "480p-Auflösung aktivieren"
+
+#: id:21379
+msgid "Enable 720p"
+msgstr "720p-Auflösung aktivieren"
+
+#: id:21380
+msgid "Enable 1080i"
+msgstr "1080i-Auflösung aktivieren"
+
+#: id:21381
+msgid "Enter name of new playlist"
+msgstr "Bitte einen Namen für die Playlist eingeben"
+
+#: id:21382
+msgid "Show \"Add source\" buttons in file lists"
+msgstr "'Quelle hinzufügen'-Symbol im Haupt-Ordner anzeigen"
+
+#: id:21383
+msgid "Enable scrollbars"
+msgstr "Scrollbalken aktivieren"
+
+#: id:21384
+msgid "Make watched filtering a toggle in video library"
+msgstr "Filter für 'Gesehen' als Einstellung in Datenbank aktivieren"
+
+#: id:21385
+msgctxt "Auto context with id 21385"
+msgid "Open"
+msgstr "Öffnen"
+
+#: id:21386
+msgid "Acoustic management level"
+msgstr "Acoustic-Management-Stufe"
+
+#: id:21387
+msgid "Fast"
+msgstr "Schnell"
+
+#: id:21388
+msgid "Quiet"
+msgstr "Leise"
+
+#: id:21389
+msgid "Enable custom background"
+msgstr "Eigenen Hintergrund aktivieren"
+
+#: id:21390
+msgid "Power management level"
+msgstr "Energiemanagement-Stufe"
+
+#: id:21391
+msgid "High power"
+msgstr "Hoher Stromverbrauch"
+
+#: id:21392
+msgid "Low power"
+msgstr "Niedriger Stromverbrauch"
+
+#: id:21393
+msgid "High standby"
+msgstr "Hohes Standby"
+
+#: id:21394
+msgid "Low standby"
+msgstr "Niedriges Standby"
+
+#: id:21395
+msgid "Unable to cache files bigger than 4GB"
+msgstr "Es ist nicht möglich, Dateien größer als 4GB zwischenzuspeichern!"
+
+#: id:21396
+msgid "Chapter"
+msgstr "Kapitel"
+
+#: id:21397
+msgid "High quality pixel shader v2"
+msgstr "Pixelshader V2 (Hohe Qualität)"
+
+#: id:21398
+msgid "Enable playlist at startup"
+msgstr "Playlist beim Einschalten abspielen"
+
+#: id:21399
+msgid "Use tween animations"
+msgstr "Zwischenanimationen aktivieren"
+
+#: id:21400
+msgid "contains"
+msgstr "beinhaltet"
+
+#: id:21401
+msgid "does not contain"
+msgstr "beinhaltet nicht"
+
+#: id:21402
+msgid "is"
+msgstr "ist"
+
+#: id:21403
+msgid "is not"
+msgstr "ist nicht"
+
+#: id:21404
+msgid "starts with"
+msgstr "startet mit"
+
+#: id:21405
+msgid "ends with"
+msgstr "endet mit"
+
+#: id:21406
+msgid "greater than"
+msgstr "größer als"
+
+#: id:21407
+msgid "less than"
+msgstr "kleiner als"
+
+#: id:21408
+msgid "after"
+msgstr "nach"
+
+#: id:21409
+msgid "before"
+msgstr "bevor"
+
+#: id:21410
+msgid "in the last"
+msgstr "im letzten"
+
+#: id:21411
+msgid "not in the last"
+msgstr "nicht im letzten"
+
+#: id:21412
+msgid "Scrapers"
+msgstr "Scraper"
+
+#: id:21413
+msgid "Default movie scraper"
+msgstr "Standard Film-Scraper"
+
+#: id:21414
+msgid "Default tvshow scraper"
+msgstr "Standard Serien-Scraper"
+
+#: id:21415
+msgid "Default music video scraper"
+msgstr "Standard Musikvideo-Scraper"
+
+#: id:21416
+msgid "Enable fallback based on scraper language"
+msgstr "Aktiviere Alternativsuche für gleichsprachige Scraper"
+
+#: id:21417
+msgid "- Settings"
+msgstr "- Einstellungen"
+
+#: id:21418
+msgid "Multilingual"
+msgstr "Mehrsprachig"
+
+#: id:21419
+msgid "No scrapers present"
+msgstr "Keine Scraper verfügbar"
+
+#: id:21420
+msgid "Value to match"
+msgstr "Wert zum angleichen"
+
+#: id:21421
+msgid "Smart playlist rule"
+msgstr "Smart-Playlist-Regel"
+
+#: id:21422
+msgid "Match items where"
+msgstr "Titel angleichen mit"
+
+#: id:21423
+msgid "New rule..."
+msgstr "Neue Regel..."
+
+#: id:21424
+msgid "Items must match"
+msgstr "Einträge müssen übereinstimmen mit"
+
+#: id:21425
+msgid "all of the rules"
+msgstr "allen Regeln"
+
+#: id:21426
+msgid "one or more of the rules"
+msgstr "eine oder mehreren Regeln"
+
+#: id:21427
+msgid "Limit to"
+msgstr "Beschränken auf"
+
+#: id:21428
+msgid "No limit"
+msgstr "Keine Beschränkung"
+
+#: id:21429
+msgid "Order by"
+msgstr "Sortieren nach"
+
+#: id:21430
+msgid "ascending"
+msgstr "Aufsteigend"
+
+#: id:21431
+msgid "descending"
+msgstr "Absteigend"
+
+#: id:21432
+msgid "Edit smart playlist"
+msgstr "Smart-Playlist-Editor"
+
+#: id:21433
+msgid "Name of the playlist"
+msgstr "Name der Playlist"
+
+#: id:21434
+msgid "Find items where"
+msgstr "Suche passende Titel anhand"
+
+#: id:21435
+msgid "Edit"
+msgstr "Bearbeiten"
+
+#: id:21436
+msgid "%i items"
+msgstr "%i Titel"
+
+#: id:21437
+msgid "New smart playlist..."
+msgstr "Neue Smart Playlist..."
+
+#: id:21438
+msgid "%c Drive"
+msgstr "%c Laufwerk"
+
+#: id:21439
+msgid "Edit party mode rules"
+msgstr "Party-Modus-Regeln editieren"
+
+#: id:21440
+msgid "Home folder"
+msgstr "Home-Ordner"
+
+#: id:21441
+msgid "Watched count"
+msgstr "Gesehen-Zähler"
+
+#: id:21442
+msgid "Episode title"
+msgstr "Episodentitel"
+
+#: id:21443
+msgid "Video resolution"
+msgstr "Video Auflösung"
+
+#: id:21444
+msgid "Audio channels"
+msgstr "Audio Kanäle"
+
+#: id:21445
+msgid "Video codec"
+msgstr "Video Codec"
+
+#: id:21446
+msgid "Audio codec"
+msgstr "Audio Codec"
+
+#: id:21447
+msgid "Audio language"
+msgstr "Audio Sprache"
+
+#: id:21448
+msgid "Subtitle language"
+msgstr "Untertitlesprache"
+
+#: id:21449
+msgid "Remote control sends keyboard presses"
+msgstr "Fernbedienung sendet Tastatureingaben"
+
+#: id:21450
+msgid "- Edit"
+msgstr "- Bearbeiten"
+
+#: id:21451
+msgid "Internet connection required."
+msgstr "Internetverbindung benötigt."
+
+#: id:21452
+msgid "Get More..."
+msgstr "Mehr..."
+
+#: id:21453
+msgid "Root filesystem"
+msgstr "Root Dateisystem"
+
+#: id:21454
+msgid "Cache full"
+msgstr "Cache voll"
+
+#: id:21455
+msgid "Cache filled before reaching required amount for continous playback"
+msgstr "Cache gefüllt bevor ausreichende Datenmenge für ruckelfreie Wiedergabe erreicht wurde"
+
+#: id:21460
+msgid "Subtitle location"
+msgstr "Position der Untertitel"
+
+#: id:21461
+msgid "Fixed"
+msgstr "Fixiert"
+
+#: id:21462
+msgid "Bottom of video"
+msgstr "Unterhalb des Bildes"
+
+#: id:21463
+msgid "Below video"
+msgstr "Unten"
+
+#: id:21464
+msgid "Top of video"
+msgstr "Oberhalb des Bildes"
+
+#: id:21465
+msgid "Above video"
+msgstr "Oben"
+
+#: id:21800
+msgid "File name"
+msgstr "Dateiname"
+
+#: id:21801
+msgid "File path"
+msgstr "Dateipfad"
+
+#: id:21802
+msgid "File size"
+msgstr "Dateigröße"
+
+#: id:21803
+msgid "File date/time"
+msgstr "Datei Datum/Uhrzeit"
+
+#: id:21804
+msgid "Slide index"
+msgstr "Dia-Index"
+
+#: id:21805
+msgctxt "Auto context with id 21805"
+msgid "Resolution"
+msgstr "Auflösung"
+
+#: id:21806
+msgctxt "Auto context with id 21806"
+msgid "Comment"
+msgstr "Kommentar"
+
+#: id:21807
+msgid "Colour/B&W"
+msgstr "Farbe/BW"
+
+#: id:21808
+msgid "JPEG process"
+msgstr "JPEG Prozess"
+
+#: id:21820
+msgid "Date/Time"
+msgstr "Datum/Uhrzeit"
+
+#: id:21821
+msgid "Description"
+msgstr "Beschreibung"
+
+#: id:21822
+msgid "Camera make"
+msgstr "Kamerahersteller"
+
+#: id:21823
+msgid "Camera model"
+msgstr "Kameramodell"
+
+#: id:21824
+msgid "EXIF comment"
+msgstr "Exif-Kommentar"
+
+#: id:21825
+msgid "Firmware"
+msgstr "Firmware"
+
+#: id:21826
+msgid "Aperture"
+msgstr "Blendeneinstellung"
+
+#: id:21827
+msgid "Focal length"
+msgstr "Brennweite"
+
+#: id:21828
+msgid "Focus distance"
+msgstr "Fokus-Distanz"
+
+#: id:21829
+msgid "Exposure"
+msgstr "Belichtung"
+
+#: id:21830
+msgid "Exposure time"
+msgstr "Belichtungszeit"
+
+#: id:21831
+msgid "Exposure bias"
+msgstr "Belichtungsausrichtung"
+
+#: id:21832
+msgid "Exposure mode"
+msgstr "Belichtungsmodus"
+
+#: id:21833
+msgid "Flash used"
+msgstr "Blitz"
+
+#: id:21834
+msgid "White-balance"
+msgstr "Weißabgleich"
+
+#: id:21835
+msgid "Light source"
+msgstr "Lichtquelle"
+
+#: id:21836
+msgid "Metering mode"
+msgstr "Messmodus"
+
+#: id:21837
+msgid "ISO"
+msgstr "ISO"
+
+#: id:21838
+msgid "Digital zoom"
+msgstr "Digitalzoom"
+
+#: id:21839
+msgid "CCD width"
+msgstr "CCD-Weite"
+
+#: id:21840
+msgid "GPS latitude"
+msgstr "GPS-Breitengrad"
+
+#: id:21841
+msgid "GPS longitude"
+msgstr "GPS-Längengrad"
+
+#: id:21842
+msgid "GPS altitude"
+msgstr "GPS-Höhe"
+
+#: id:21843
+msgid "Orientation"
+msgstr "Ausrichtung"
+
+#: id:21860
+msgid "Supplemental categories"
+msgstr "Zusätzliche Kategorien"
+
+#: id:21861
+msgid "Keywords"
+msgstr "Stichwörter"
+
+#: id:21862
+msgid "Caption"
+msgstr "Bildtext"
+
+#: id:21863
+msgid "Author"
+msgstr "Autor"
+
+#: id:21864
+msgid "Headline"
+msgstr "Kopfzeile"
+
+#: id:21865
+msgid "Special instructions"
+msgstr "Besondere Anweisungen"
+
+#: id:21866
+msgid "Category"
+msgstr "Kategorie"
+
+#: id:21867
+msgid "Byline"
+msgstr "Verfasserzeile"
+
+#: id:21868
+msgid "Byline title"
+msgstr "Titel der Verfasserzeile"
+
+#: id:21869
+msgid "Credit"
+msgstr "Credit"
+
+#: id:21870
+msgid "Source"
+msgstr "Quelle"
+
+#: id:21871
+msgid "Copyright notice"
+msgstr "Urheberrechtshinweis"
+
+#: id:21872
+msgid "Object name"
+msgstr "Objekt Name"
+
+#: id:21873
+msgid "City"
+msgstr "Stadt"
+
+#: id:21874
+msgid "State"
+msgstr "Staat"
+
+#: id:21875
+msgctxt "Auto context with id 21875"
+msgid "Country"
+msgstr "Land"
+
+#: id:21876
+msgid "Original Tx Reference"
+msgstr "Originale Tx-Abhängigkeit"
+
+#: id:21877
+msgid "Date created"
+msgstr "Erstellungsdatum"
+
+#: id:21878
+msgid "Copyright flag"
+msgstr "Urheberrechtskennzeichnung"
+
+#: id:21879
+msgid "Country code"
+msgstr "Länderkennzahl"
+
+#: id:21880
+msgid "Reference service"
+msgstr "Auskunftsdienst"
+
+#: id:21881
+msgid "Allow control of XBMC via UPnP"
+msgstr "UPnP Renderer aktivieren"
+
+#: id:21882
+msgid "Attempt to skip introduction before DVD menu"
+msgstr "Filmeinleitung vor dem DVD-Menü überspringen"
+
+#: id:21883
+msgid "Saved music"
+msgstr "Kopierte Audio CDs"
+
+#: id:21884
+msgid "Query info for all artists"
+msgstr "Lade alle Interpreten-Infos"
+
+#: id:21885
+msgid "Downloading album information"
+msgstr "Lade Album Informationen herunter"
+
+#: id:21886
+msgid "Downloading artist information"
+msgstr "Lade Interpreten Informationen herunter"
+
+#: id:21887
+msgid "Biography"
+msgstr "Biografie"
+
+#: id:21888
+msgid "Discography"
+msgstr "Diskografie"
+
+#: id:21889
+msgid "Searching artist"
+msgstr "Suche Interpret"
+
+#: id:21890
+msgid "Select artist"
+msgstr "Wähle Interpret"
+
+#: id:21891
+msgctxt "Auto context with id 21891"
+msgid "Artist information"
+msgstr "Interpreten-Information"
+
+#: id:21892
+msgid "Instruments"
+msgstr "Instrumente"
+
+#: id:21893
+msgid "Born"
+msgstr "Geboren"
+
+#: id:21894
+msgid "Formed"
+msgstr "Gegründet"
+
+#: id:21895
+msgid "Themes"
+msgstr "Themen"
+
+#: id:21896
+msgid "Disbanded"
+msgstr "Aufgelöst"
+
+#: id:21897
+msgid "Died"
+msgstr "Gestorben"
+
+#: id:21898
+msgid "Years active"
+msgstr "Jahre aktiv"
+
+#: id:21899
+msgid "Label"
+msgstr "Label"
+
+#: id:21900
+msgid "Born/Formed"
+msgstr "Geboren/Gegründet"
+
+#: id:22000
+msgid "Update library on startup"
+msgstr "Aktualisiere Datenbank beim Start"
+
+#: id:22001
+msgid "Hide progress of library updates"
+msgstr "Fortschritt von Datenbank-Aktualisierungen verbergen"
+
+#: id:22002
+msgid "- DNS suffix"
+msgstr "DNS Suffix"
+
+#: id:22003
+msgid "%2.3fs"
+msgstr "%2.3fs"
+
+#: id:22004
+msgid "Delayed by: %2.3fs"
+msgstr "Verzögert um: %2.3fs"
+
+#: id:22005
+msgid "Ahead by: %2.3fs"
+msgstr "Beschleunigt um: %2.3fs"
+
+#: id:22006
+msgid "Subtitle offset"
+msgstr "Untertitelabstand"
+
+#: id:22007
+msgid "OpenGL vendor:"
+msgstr "OpenGL-Anbieter:"
+
+#: id:22008
+msgid "OpenGL renderer:"
+msgstr "OpenGL-Renderer:"
+
+#: id:22009
+msgid "OpenGL version:"
+msgstr "OpenGL-Version:"
+
+#: id:22010
+msgid "GPU temperature:"
+msgstr "GPU-Temperatur:"
+
+#: id:22011
+msgid "CPU temperature:"
+msgstr "CPU-Temperatur:"
+
+#: id:22012
+msgid "Total memory"
+msgstr "Gesamter Speicher"
+
+#: id:22013
+msgid "Profile data"
+msgstr "Profildaten"
+
+#: id:22014
+msgid "Use dim if paused during video playback"
+msgstr "Dimmen, wenn die Videowiedergabe pausiert wird"
+
+#: id:22015
+msgid "All recordings"
+msgstr "Alle Aufnahmen"
+
+#: id:22016
+msgid "By title"
+msgstr "Nach Titel"
+
+#: id:22017
+msgid "By group"
+msgstr "Nach Interpret"
+
+#: id:22018
+msgid "Live channels"
+msgstr "Live Kanäle"
+
+#: id:22019
+msgid "Recordings by title"
+msgstr "Aufnahmen nach Titel"
+
+#: id:22020
+msgid "Guide"
+msgstr "Handbuch"
+
+#: id:22021
+msgid "Allowed error in aspect ratio to minimize black bars"
+msgstr "Erlaube Fehler im Seitenverhältnis (%)"
+
+#: id:22022
+msgid "Show video files in listings"
+msgstr "Video Dateien in Listen aufnehmen"
+
+#: id:22023
+msgid "DirectX vendor:"
+msgstr "DirectX Anbieter"
+
+#: id:22024
+msgid "Direct3D version:"
+msgstr "Direct3D Version"
+
+#: id:22030
+msgctxt "Auto context with id 22030"
+msgid "Font"
+msgstr "Schriftart"
+
+#: id:22031
+msgctxt "Auto context with id 22031"
+msgid "- Size"
+msgstr "Größe"
+
+#: id:22032
+msgctxt "Auto context with id 22032"
+msgid "- Colours"
+msgstr "Farben"
+
+#: id:22033
+msgid "- Charset"
+msgstr "Schriftsatz"
+
+#: id:22034
+msgid "Export karaoke titles as HTML"
+msgstr "Karaoke-Titel als HTML exportieren"
+
+#: id:22035
+msgid "Export karaoke titles as CSV"
+msgstr "Karaoke-Titel als CSV exportieren"
+
+#: id:22036
+msgid "Import karaoke titles..."
+msgstr "Karaoke-Titel importieren..."
+
+#: id:22037
+msgid "Show song selector automatically"
+msgstr "Titel-Auswahl automatisch öffnen"
+
+#: id:22038
+msgid "Export karaoke titles..."
+msgstr "Karaoke-Titel exportieren..."
+
+#: id:22039
+msgid "Enter song number"
+msgstr "Titelnummer eingeben"
+
+#: id:22040
+msgid "white/green"
+msgstr "weiß/grün"
+
+#: id:22041
+msgid "white/red"
+msgstr "weiß/rot"
+
+#: id:22042
+msgid "white/blue"
+msgstr "weiß/blau"
+
+#: id:22043
+msgid "black/white"
+msgstr "schwarz/weiß"
+
+#: id:22079
+msgid "Default select action"
+msgstr "Standard Auswahl Aktion"
+
+#: id:22080
+msgid "Choose"
+msgstr "Wähle"
+
+#: id:22081
+msgid "Show Information"
+msgstr "Informationen anzeigen"
+
+#: id:22082
+msgid "More..."
+msgstr "Mehr..."
+
+#: id:22083
+msgid "Play all"
+msgstr "Alles abspielen"
+
+#: id:23049
+msgid "Teletext not available"
+msgstr "Videotext nicht verfügbar"
+
+#: id:23050
+msgid "Activate Teletext"
+msgstr "Videotext aktivieren"
+
+#: id:23051
+msgid "Part %i"
+msgstr "Teil %i"
+
+#: id:23052
+msgid "Buffering %i bytes"
+msgstr "Zwischenspeichern - %i Bytes"
+
+#: id:23053
+msgid "Stopping"
+msgstr "Wird beendet"
+
+#: id:23054
+msgid "Running"
+msgstr "Läuft"
+
+#: id:23100
+msgid "External Player Active"
+msgstr "Externer Player ist aktiv"
+
+#: id:23101
+msgid "Click OK to terminate the player"
+msgstr "Drücke OK um den Player zu beenden"
+
+#: id:23104
+msgid "Click OK when playback has ended"
+msgstr "Drücke OK wenn die Wiedergabe beendet ist"
+
+#: id:24000
+msgid "Add-on"
+msgstr "Add-on"
+
+#: id:24001
+msgid "Add-ons"
+msgstr "Add-ons"
+
+#: id:24002
+msgid "Add-on options"
+msgstr "Add-on Optionen"
+
+#: id:24003
+msgid "Add-on Information"
+msgstr "Add-on Informationen"
+
+#: id:24005
+msgctxt "Auto context with id 24005"
+msgid "Media sources"
+msgstr "Medienquellen"
+
+#: id:24007
+msgctxt "Auto context with id 24007"
+msgid "Movie information"
+msgstr "Film-Informationen"
+
+#: id:24008
+msgctxt "Auto context with id 24008"
+msgid "Screensaver"
+msgstr "Bildschirmschoner"
+
+#: id:24009
+msgid "Script"
+msgstr "Skript"
+
+#: id:24010
+msgctxt "Auto context with id 24010"
+msgid "Visualization"
+msgstr "Visualisierung"
+
+#: id:24011
+msgid "Add-on repository"
+msgstr "Add-on Depot"
+
+#: id:24012
+msgctxt "Auto context with id 24012"
+msgid "Subtitles"
+msgstr "Untertitel"
+
+#: id:24013
+msgid "Lyrics"
+msgstr "Songtext"
+
+#: id:24014
+msgid "TV information"
+msgstr "TV-Informationen"
+
+#: id:24015
+msgctxt "Auto context with id 24015"
+msgid "Music video information"
+msgstr "Musikvideo-Informationen"
+
+#: id:24016
+msgctxt "Auto context with id 24016"
+msgid "Album information"
+msgstr "Album-Informationen"
+
+#: id:24017
+msgctxt "Auto context with id 24017"
+msgid "Artist information"
+msgstr "Interpret-Informationen"
+
+#: id:24018
+msgctxt "Auto context with id 24018"
+msgid "Services"
+msgstr "Dienste"
+
+#: id:24020
+msgid "Configure"
+msgstr "Konfigurieren"
+
+#: id:24021
+msgctxt "Auto context with id 24021"
+msgid "Disable"
+msgstr "Deaktivieren"
+
+#: id:24022
+msgid "Enable"
+msgstr "Aktivieren"
+
+#: id:24023
+msgid "Add-on disabled"
+msgstr "Add-on deaktiviert"
+
+#: id:24027
+msgctxt "Auto context with id 24027"
+msgid "Weather"
+msgstr "Wetter"
+
+#: id:24028
+msgid "Weather.com (standard)"
+msgstr "Weather.com (Standard)"
+
+#: id:24030
+msgid "This Add-on can not be configured"
+msgstr "Dieses Add-on kann nicht konfiguriert werden"
+
+#: id:24031
+msgid "Error loading settings"
+msgstr "Fehler beim Laden der Einstellungen"
+
+#: id:24032
+msgid "All Add-ons"
+msgstr "Alle Add-ons"
+
+#: id:24033
+msgid "Get Add-ons"
+msgstr "Weitere Add-ons"
+
+#: id:24034
+msgid "Check for updates"
+msgstr "Updates suchen"
+
+#: id:24035
+msgid "Force refresh"
+msgstr "Aktualisierung erzwingen"
+
+#: id:24036
+msgid "Change log"
+msgstr "Änderungen"
+
+#: id:24037
+msgid "Uninstall"
+msgstr "Deinstallieren"
+
+#: id:24038
+msgid "Install"
+msgstr "Installieren"
+
+#: id:24039
+msgid "Disabled Add-ons"
+msgstr "Deaktivierte Add-ons"
+
+#: id:24040
+msgid "(Clear the current setting)"
+msgstr "(Die aktuelle Einstellung löschen)"
+
+#: id:24041
+msgid "Install from zip file"
+msgstr "Aus ZIP Datei installieren"
+
+#: id:24042
+msgid "Downloading %i%%"
+msgstr "Herunterladen %i%%"
+
+#: id:24043
+msgid "Available Updates"
+msgstr "Verfügbare Updates"
+
+#: id:24044
+msgid "Dependencies not met"
+msgstr "Abhängigkeiten nicht erfüllt"
+
+#: id:24045
+msgid "Add-on does not have the correct structure"
+msgstr "Add-on verfügt nicht über die richtige Struktur"
+
+#: id:24046
+msgid "%s is used by the following installed add-on(s)"
+msgstr "%s wird von den folgenden Add-ons verwendet"
+
+#: id:24047
+msgid "This add-on cannot be uninstalled"
+msgstr "Das Add-on kann nicht deinstalliert werden"
+
+#: id:24048
+msgid "Rollback"
+msgstr "Vorherige Version"
+
+#: id:24050
+msgid "Available Add-ons"
+msgstr "Verfügbare Add-ons"
+
+#: id:24051
+msgid "Version:"
+msgstr "Version:"
+
+#: id:24052
+msgid "Disclaimer"
+msgstr "Haftungsausschluss"
+
+#: id:24053
+msgid "License:"
+msgstr "Lizenz:"
+
+#: id:24054
+msgid "Changelog"
+msgstr "Änderungen"
+
+#: id:24059
+msgid "Would you like to enable this Add-on?"
+msgstr "Wollen Sie dieses Add-on aktivieren?"
+
+#: id:24060
+msgid "Would you like to disable this Add-on?"
+msgstr "Wollen Sie dieses Add-on deaktivieren?"
+
+#: id:24061
+msgid "Add-on update available!"
+msgstr "Neue Version des Add-on verfügbar!"
+
+#: id:24062
+msgid "Enabled Add-ons"
+msgstr "Aktivierte Add-ons"
+
+#: id:24063
+msgid "Auto update"
+msgstr "Auto Update"
+
+#: id:24064
+msgid "Add-on enabled"
+msgstr "Add-on aktiviert"
+
+#: id:24065
+msgid "Add-on updated"
+msgstr "Add-on aktualisiert"
+
+#: id:24066
+msgid "Cancel Add-on download?"
+msgstr "Herunterladen des Add-on abbrechen?"
+
+#: id:24067
+msgid "Currently downloading Add-ons"
+msgstr "Add-ons die gerade heruntergeladen werden"
+
+#: id:24068
+msgid "Update available"
+msgstr "Aktualisierung verfügbar"
+
+#: id:24069
+msgid "Update"
+msgstr "Aktualisierung"
+
+#: id:24070
+msgid "Add-on could not be loaded."
+msgstr "Das Add-on kann nicht geladen werden."
+
+#: id:24071
+msgid "An unknown error has occurred."
+msgstr "Ein unbekannter Fehler ist aufgetreten."
+
+#: id:24072
+msgid "Settings required"
+msgstr "Einstellungen fehlen oder sind ungültig"
+
+#: id:24073
+msgid "Could not connect"
+msgstr "Die Verbindung kann nicht hergestellt werden"
+
+#: id:24074
+msgid "Needs to restart"
+msgstr "Neustart erforderlich"
+
+#: id:24075
+msgctxt "Auto context with id 24075"
+msgid "Disable"
+msgstr "Deaktivieren"
+
+#: id:24076
+msgid "Add-on Required"
+msgstr "Add-on benötigt"
+
+#: id:24080
+msgid "Try to reconnect?"
+msgstr "Nochmals Verbindungsherstellung versuchen?"
+
+#: id:24089
+msgid "Add-on restarts"
+msgstr "Add-on startet neu"
+
+#: id:24090
+msgid "Lock Add-on manager"
+msgstr "Add-on Verwaltung sperren"
+
+#: id:24094
+msgid "(current)"
+msgstr ""
+
+#: id:24095
+msgid "(blacklisted)"
+msgstr ""
+
+#: id:24096
+msgid "Add-on has been marked as broken in repository."
+msgstr "Das Add-on wurde im Depot als defekt markiert."
+
+#: id:24097
+msgid "Would you like to disable it on your system?"
+msgstr "Wollen Sie es in Ihrem System deaktivieren?"
+
+#: id:24098
+msgid "Broken"
+msgstr "Defekt"
+
+#: id:24099
+msgid "Would you like to switch to this skin?"
+msgstr "Möchten Sie zu diesem Skin wechseln?"
+
+#: id:24100
+msgid "To use this feature you must download an Add-on:"
+msgstr "Für diese Funktion wird ein Add-on benötigt:"
+
+#: id:24101
+msgid "Would you like to download this Add-on?"
+msgstr "Soll das Add-on heruntergeladen werden?"
+
+#: id:25000
+msgid "Notifications"
+msgstr "Benachrichtigungen"
+
+#: id:29800
+msgid "Library Mode"
+msgstr "Datenbankmodus"
+
+#: id:29801
+msgid "QWERTY keyboard"
+msgstr "QWERTY Tastatur"
+
+#: id:29802
+msgid "Passthrough Audio in use"
+msgstr "Passthrough-Modus aktiv"
+
+#: id:33001
+msgid "Trailer quality"
+msgstr "Trailer Qualität"
+
+#: id:33002
+msgid "Stream"
+msgstr "Streamen"
+
+#: id:33003
+msgid "Download"
+msgstr "Herunterladen"
+
+#: id:33004
+msgid "Download & play"
+msgstr "Herunterladen & abspielen"
+
+#: id:33005
+msgid "Download & save"
+msgstr "Herunterladen & speichern"
+
+#: id:33006
+msgid "Today"
+msgstr "Heute"
+
+#: id:33007
+msgid "Tomorrow"
+msgstr "Morgen"
+
+#: id:33008
+msgid "Saving"
+msgstr "Speichern"
+
+#: id:33009
+msgid "Copying"
+msgstr "Kopieren"
+
+#: id:33010
+msgid "Set download directory"
+msgstr "Download-Ordner wählen"
+
+#: id:33011
+msgid "Search duration"
+msgstr "Suchdauer"
+
+#: id:33012
+msgid "Short"
+msgstr "Kurz"
+
+#: id:33013
+msgid "Long"
+msgstr "Lang"
+
+#: id:33014
+msgid "Use DVD player instead of regular player"
+msgstr "Benutze DVDplayer statt dem regulären"
+
+#: id:33015
+msgid "Ask for download before playing video"
+msgstr "Vor dem Abspielen von Video nach Herunterladen fragen"
+
+#: id:33016
+msgid "Clips"
+msgstr "Clips"
+
+#: id:33017
+msgid "Restart plugin to enable"
+msgstr "Plugin zur Aktivierung neustarten"
+
+#: id:33018
+msgid "Tonight"
+msgstr "Heute Abend"
+
+#: id:33019
+msgid "Tomorrow Night"
+msgstr "Morgen Abend"
+
+#: id:33020
+msgid "Condition"
+msgstr "Bedingung"
+
+#: id:33021
+msgid "Precipitation"
+msgstr "Niederschlag"
+
+#: id:33022
+msgid "Precip"
+msgstr "regnen"
+
+#: id:33023
+msgid "Humid"
+msgstr "feucht"
+
+#: id:33024
+msgid "Feels"
+msgstr "gefühlt"
+
+#: id:33025
+msgid "Observed"
+msgstr "beobachtet"
+
+#: id:33026
+msgid "Departure from normal"
+msgstr "Abweichung vom Normalwert"
+
+#: id:33027
+msgid "Sunrise"
+msgstr "Sonnenaufgang"
+
+#: id:33028
+msgid "Sunset"
+msgstr "Sonnenuntergang"
+
+#: id:33029
+msgid "Details"
+msgstr "Details"
+
+#: id:33030
+msgid "Outlook"
+msgstr "Outlook"
+
+#: id:33031
+msgid "Coverflow"
+msgstr "Coverflow"
+
+#: id:33032
+msgid "Translate text"
+msgstr "Übersetze Text"
+
+#: id:33033
+msgid "Map list %s category"
+msgstr "Kartenliste %s Kategorie"
+
+#: id:33034
+msgid "36 Hour"
+msgstr "36 Stunden"
+
+#: id:33035
+msgid "Maps"
+msgstr "Karten"
+
+#: id:33036
+msgid "Hourly"
+msgstr "Stündlich"
+
+#: id:33037
+msgid "Weekend"
+msgstr "Wochenende"
+
+#: id:33038
+msgid "%s day"
+msgstr "%s Tag"
+
+#: id:33049
+msgid "Alert"
+msgstr "Alarm"
+
+#: id:33050
+msgid "Alerts"
+msgstr "Alarme"
+
+#: id:33051
+msgid "Choose Your"
+msgstr "Wähle Dein"
+
+#: id:33052
+msgid "Check"
+msgstr "Prüfe"
+
+#: id:33053
+msgctxt "Auto context with id 33053"
+msgid "Configure the"
+msgstr "Konfiguriere die"
+
+#: id:33054
+msgid "Seasons"
+msgstr "Staffeln"
+
+#: id:33055
+msgid "Use your"
+msgstr "Benutze Dein"
+
+#: id:33056
+msgid "Watch your"
+msgstr "Schaue Deine"
+
+#: id:33057
+msgid "Listen to"
+msgstr "Höre Deine"
+
+#: id:33058
+msgid "View your"
+msgstr "Schaue Deine"
+
+#: id:33059
+msgctxt "Auto context with id 33059"
+msgid "Configure the"
+msgstr "Konfiguriere die"
+
+#: id:33060
+msgid "Power"
+msgstr "Power"
+
+#: id:33061
+msgid "Menu"
+msgstr "Menü"
+
+#: id:33062
+msgid "Play the"
+msgstr "Spiele die"
+
+#: id:33063
+msgid "Options"
+msgstr "Optionen"
+
+#: id:33065
+msgid "Editor"
+msgstr "Editor"
+
+#: id:33066
+msgid "About your"
+msgstr "Über Dein"
+
+#: id:33067
+msgid "Star rating"
+msgstr "Sterne-Bewertung"
+
+#: id:33068
+msgid "Background"
+msgstr "Hintergrund"
+
+#: id:33069
+msgid "Backgrounds"
+msgstr "Hintergründe"
+
+#: id:33070
+msgid "Custom background"
+msgstr "Benutzerdefinierter Hintergrund"
+
+#: id:33071
+msgid "Custom backgrounds"
+msgstr "Benutzerdefinierte Hintergründe"
+
+#: id:33072
+msgid "View Readme"
+msgstr "Readme lesen"
+
+#: id:33073
+msgid "View Changelog"
+msgstr "Änderungen anzeigen"
+
+#: id:33074
+msgid "This version of %s requires an"
+msgstr "Diese Version von %s benötigt eine"
+
+#: id:33075
+msgid "XBMC revision of %s or greater to run."
+msgstr "XBMC Revision %s oder höher um ausgeführt zu werden."
+
+#: id:33076
+msgid "Please update XBMC."
+msgstr "Bitte XBMC aktualisieren."
+
+#: id:33077
+msgid "No data found!"
+msgstr "Keine Daten gefunden!"
+
+#: id:33078
+msgid "Next page"
+msgstr "Nächste Seite"
+
+#: id:33079
+msgid "Love"
+msgstr "Liebe"
+
+#: id:33080
+msgid "Hate"
+msgstr "Hass"
+
+#: id:33081
+msgid "This file is stacked, select the part you want to play from."
+msgstr "Diese Datei ist gestapelt, wähle den Teil der abgespielt werden soll."
+
+#: id:33082
+msgid "Path to script"
+msgstr "Skriptpfad"
+
+#: id:33083
+msgid "Enable custom script button"
+msgstr "Benutzerdefinierten Skript Button aktivieren"
+
+#: id:33100
+msgid "Failed to start"
+msgstr ""
+
+#: id:33101
+msgid "Webserver"
+msgstr ""
+
+#: id:33102
+msgid "Event Server"
+msgstr ""
+
+#: id:33103
+msgid "Remote communication server"
+msgstr ""
+
+#: id:33200
+msgid "Detected New Connection"
+msgstr "Neue Verbindung erkannt"
+
+#: id:34000
+msgid "Lame"
+msgstr ""
+
+#: id:34001
+msgid "Vorbis"
+msgstr ""
+
+#: id:34002
+msgid "Wav"
+msgstr ""
+
+#: id:34003
+msgid "DXVA2"
+msgstr ""
+
+#: id:34004
+msgid "VAAPI"
+msgstr ""
+
+#: id:34005
+msgid "Flac"
+msgstr ""
+
+#: id:34100
+msgid "Speaker Configuration"
+msgstr "Lautsprecherkonfiguration"
+
+#: id:34101
+msgid "2.0"
+msgstr ""
+
+#: id:34102
+msgid "2.1"
+msgstr ""
+
+#: id:34103
+msgid "3.0"
+msgstr ""
+
+#: id:34104
+msgid "3.1"
+msgstr ""
+
+#: id:34105
+msgid "4.0"
+msgstr ""
+
+#: id:34106
+msgid "4.1"
+msgstr ""
+
+#: id:34107
+msgid "5.0"
+msgstr ""
+
+#: id:34108
+msgid "5.1"
+msgstr ""
+
+#: id:34109
+msgid "7.0"
+msgstr ""
+
+#: id:34110
+msgid "7.1"
+msgstr ""
+
+#: id:34201
+msgid "Can't find a next item to play"
+msgstr "Nächstes Element konnte nicht gefunden werden"
+
+#: id:34202
+msgid "Can't find a previous item to play"
+msgstr "Vorheriges Element konnte nich gefunden werden"
+
+#: id:34300
+msgid "Failed to start zeroconf"
+msgstr "zeroconf konnte nicht gestartet werden"
+
+#: id:34301
+msgid "Is Apple's Bonjour Service installed? See log for more info."
+msgstr "Ist der Bonjour Service von Apple installiert? Log-File einsehen für mehr Info"
+
+#: id:34400
+msgid "Video Rendering"
+msgstr "Video Rendering"
+
+#: id:34401
+msgid "Failed to init video filters/scalers, falling back to bilinear scaling"
+msgstr "Videofilter/-scaler konnte nicht initialisiert werden! Verwende Bilineares Scaling"
+
+#: id:34402
+msgid "Failed to initialize audio device"
+msgstr "Audiogerät konnte nicht initialisiert werden"
+
+#: id:34403
+msgid "Check your audiosettings"
+msgstr "Audio-Einstellungen überprüfen"
+
+#: id:34404
+msgid "Use gestures for navigation:"
+msgstr "Benutze folgende Gesten zur Navigation:"
+
+#: id:34405
+msgid "1 finger swipe left,right,up,down for cursors"
+msgstr "1 Finger: links,rechts,hoch,runter wischen (cursor Tasten)"
+
+#: id:34406
+msgid "2 finger swipe left for backspace"
+msgstr "2 Finger: links wischen für Backspace"
+
+#: id:34407
+msgid "1 finger single tap for enter"
+msgstr "1 Finger: tippen für Enter"
+
+#: id:34408
+msgid "2 finger single tap for contextmenu"
+msgstr "2 Finger: tippen für Context Menü"
+
+#: id:35000
+msgid "Peripherals"
+msgstr "Geräte"
+
+#: id:35001
+msgid "Generic HID device"
+msgstr "HID-Gerät"
+
+#: id:35002
+msgid "Generic network adapter"
+msgstr "Netzwerkadapter"
+
+#: id:35003
+msgid "Generic disk"
+msgstr "Festplatte"
+
+#: id:35004
+msgid "There are no settings available\nfor this peripheral."
+msgstr "Für dieses Gerät sind keine Einstellungen verfügbar"
+
+#: id:35005
+msgid "New device configured"
+msgstr "Neues Gerät konfiguriert"
+
+#: id:35006
+msgid "Device removed"
+msgstr "Gerät entfernt"
+
+#: id:35007
+msgid "Keymap to use for this device"
+msgstr "Tastenbelegung für dieses Gerät"
+
+#: id:35008
+msgid "Keymap enabled"
+msgstr "Tastenbelegung aktiviert"
+
+#: id:35009
+msgid "Do not use the custom keymap for this device"
+msgstr "Keine benutzerdefinierte Keymap für dieses Gerät verwenden"
+
+#: id:35500
+msgid "Location"
+msgstr "Ort"
+
+#: id:35501
+msgid "Class"
+msgstr "Klasse"
+
+#: id:35502
+msgctxt "Auto context with id 35502"
+msgid "Name"
+msgstr "Name"
+
+#: id:35503
+msgid "Vendor"
+msgstr "Hersteller"
+
+#: id:35504
+msgid "Product ID"
+msgstr "Produkt ID"
+
+#: id:36000
+msgid "Pulse-Eight CEC adapter"
+msgstr "Pulse-Eight CEC Adapter"
+
+#: id:36001
+msgid "Pulse-Eight Nyxboard"
+msgstr "Pulse-Eight Nyxboard"
+
+#: id:36002
+msgid "Switch to keyboard side command"
+msgstr "Befehl beim Wechsel zur Tastatur-Seite"
+
+#: id:36003
+msgid "Switch to remote side command"
+msgstr "Befehl beim Wechsel zur Fernbedienungs-Seite"
+
+#: id:36004
+msgid "Press \"user\" button command"
+msgstr "Befehl der benutzerdefinierten Taste (USER)"
+
+#: id:36005
+msgid "Enable switch side commands"
+msgstr "Seitenwechsel Befehle aktivieren"
+
+#: id:36006
+msgid "Could not open the adapter"
+msgstr "Der Adapter konnte nicht geöffnet werden"
+
+#: id:36007
+msgid "Devices to power on when starting XBMC"
+msgstr "Geräte, welche den TV anschalten, wenn XBMC startet"
+
+#: id:36008
+msgid "Devices to power off when stopping XBMC"
+msgstr "Geräte, welche den TV ausschalten, wenn XBMC beendet wird"
+
+#: id:36009
+msgid "Put devices in standby mode when activating screensaver"
+msgstr "Geräte in den Standby versetzen wenn der Bilschirmschoner aktiviert wird"
+
+#: id:36011
+msgid "Could not detect the CEC port. Set it up manually."
+msgstr "Der CEC Port konnte nicht gefunden werden. Manuell einstellen."
+
+#: id:36012
+msgid "Could not initialise the CEC adapter. Check your settings."
+msgstr "Der CEC Adapter konnte nicht initialisiert werden. Bitte Einstellungen prüfen!"
+
+#: id:36013
+msgid "Unsupported libCEC interface version. %d is greater than the version XBMC supports (%d)"
+msgstr "Nicht unterstützte libCEC Version. %d ist größer als die von XBMC unterstützte Version (%d)"
+
+#: id:36014
+msgid "Put this PC in standby mode when the TV is switched off"
+msgstr "PC in den Standby versetzen wenn der Fernseher ausgeschaltet wird"
+
+#: id:36015
+msgid "HDMI port number"
+msgstr "HDMI Port Nummer"
+
+#: id:36016
+msgctxt "Auto context with id 36016"
+msgid "Connected"
+msgstr "Verbunden"
+
+#: id:36017
+msgid "Adapter found, but libCEC is not available"
+msgstr "CEC Adapter gefunden, aber libCEC ist nicht verfügbar"
+
+#: id:36018
+msgid "Use the TV's language setting"
+msgstr "Spracheinstellung des Fernsehers in XBMC nutzen"
+
+#: id:36019
+msgid "Connected to HDMI device"
+msgstr "Verbunden mit HDMI-Gerät"
+
+#: id:36020
+msgid "Make XBMC the active source when starting"
+msgstr "Setze beim Starten XBMC als aktive Quelle"
+
+#: id:36021
+msgid "Physical address (overrules HDMI port)"
+msgstr "Physikalische Adresse (verwirft HDMI-Port)"
+
+#: id:36022
+msgid "COM port (leave empty unless needed)"
+msgstr "COM-Port (frei lassen, falls nicht benötigt)"
+
+#: id:36023
+msgid "Configuration updated"
+msgstr "Konfiguration aktualisiert"
+
+#: id:36024
+msgid "Failed to set the new configuration. Please check your settings."
+msgstr "Konfiguration konnte nicht aktualisiert werden. Bitte Einstellungen prüfen!"
+
+#: id:36025
+msgid "Send 'inactive source' command when stopping XBMC"
+msgstr "Sende 'inaktive Quelle' wenn XBMC beendet wird"
+

--- a/language/Greek/strings.po
+++ b/language/Greek/strings.po
@@ -1,0 +1,9093 @@
+# Converted from xbmc strings.xml with xbmc-xml2po (by Team-XBMC)
+msgid ""
+msgstr ""
+"Project-Id-Version: xbmc.core-FRODO_GIT3ed1604ad7\n"
+"Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
+"POT-Creation-Date: 2012-04-09 18:00+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE\n"
+"Language: el\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: id:0
+msgctxt "Auto context with id 0"
+msgid "Programs"
+msgstr "Εφαρμογές"
+
+#: id:1
+msgctxt "Auto context with id 1"
+msgid "Pictures"
+msgstr "Εικόνες"
+
+#: id:2
+msgctxt "Auto context with id 2"
+msgid "Music"
+msgstr "Μουσική"
+
+#: id:3
+msgctxt "Auto context with id 3"
+msgid "Videos"
+msgstr "Βίντεο"
+
+#: id:4
+msgid "TV-Guide"
+msgstr "Οδηγός τηλεόρασης"
+
+#: id:5
+msgctxt "Auto context with id 5"
+msgid "Settings"
+msgstr "Ρυθμίσεις"
+
+#: id:6
+msgid "XBMC SVN"
+msgstr "XBMC SVN"
+
+#: id:7
+msgctxt "Auto context with id 7"
+msgid "File manager"
+msgstr "Διαχείριση αρχείων"
+
+#: id:8
+msgctxt "Auto context with id 8"
+msgid "Weather"
+msgstr "Καιρός"
+
+#: id:9
+msgid "xbmc media center"
+msgstr "xbmc media center"
+
+#: id:11
+msgid "Monday"
+msgstr "Δευτέρα"
+
+#: id:12
+msgid "Tuesday"
+msgstr "Τρίτη"
+
+#: id:13
+msgid "Wednesday"
+msgstr "Τετάρτη"
+
+#: id:14
+msgid "Thursday"
+msgstr "Πέμπτη"
+
+#: id:15
+msgid "Friday"
+msgstr "Παρασκευή"
+
+#: id:16
+msgid "Saturday"
+msgstr "Σάββατο"
+
+#: id:17
+msgid "Sunday"
+msgstr "Κυριακή"
+
+#: id:21
+msgid "January"
+msgstr "Ιανουαρίου"
+
+#: id:22
+msgid "February"
+msgstr "Φεβρουαρίου"
+
+#: id:23
+msgid "March"
+msgstr "Μαρτίου"
+
+#: id:24
+msgid "April"
+msgstr "Απριλίου"
+
+#: id:25
+msgctxt "Auto context with id 25"
+msgid "May"
+msgstr "Μαΐου"
+
+#: id:26
+msgid "June"
+msgstr "Ιουνίου"
+
+#: id:27
+msgid "July"
+msgstr "Ιουλίου"
+
+#: id:28
+msgid "August"
+msgstr "Αυγούστου"
+
+#: id:29
+msgid "September"
+msgstr "Σεπτεμβρίου"
+
+#: id:30
+msgid "October"
+msgstr "Οκτωβρίου"
+
+#: id:31
+msgid "November"
+msgstr "Νοεμβρίου"
+
+#: id:32
+msgid "December"
+msgstr "Δεκεμβρίου"
+
+#: id:41
+msgid "Mon"
+msgstr "Δευ"
+
+#: id:42
+msgid "Tue"
+msgstr "Τρι"
+
+#: id:43
+msgid "Wed"
+msgstr "Τετ"
+
+#: id:44
+msgid "Thu"
+msgstr "Πεμ"
+
+#: id:45
+msgid "Fri"
+msgstr "Παρ"
+
+#: id:46
+msgid "Sat"
+msgstr "Σαβ"
+
+#: id:47
+msgctxt "Auto context with id 47"
+msgid "Sun"
+msgstr "Κυρ"
+
+#: id:51
+msgid "Jan"
+msgstr "Ιαν"
+
+#: id:52
+msgid "Feb"
+msgstr "Φεβ"
+
+#: id:53
+msgid "Mar"
+msgstr "Μαρ"
+
+#: id:54
+msgid "Apr"
+msgstr "Απρ"
+
+#: id:55
+msgctxt "Auto context with id 55"
+msgid "May"
+msgstr "Μάι"
+
+#: id:56
+msgid "Jun"
+msgstr "Ιουν"
+
+#: id:57
+msgid "Jul"
+msgstr "Ιουλ"
+
+#: id:58
+msgid "Aug"
+msgstr "Αυγ"
+
+#: id:59
+msgid "Sep"
+msgstr "Σεπ"
+
+#: id:60
+msgid "Oct"
+msgstr "Οκτ"
+
+#: id:61
+msgid "Nov"
+msgstr "Νοε"
+
+#: id:62
+msgid "Dec"
+msgstr "Δεκ"
+
+#: id:71
+msgid "N"
+msgstr "Β"
+
+#: id:72
+msgid "NNE"
+msgstr "ΒΒΑ"
+
+#: id:73
+msgid "NE"
+msgstr "ΒΑ"
+
+#: id:74
+msgid "ENE"
+msgstr "ΑΒΑ"
+
+#: id:75
+msgid "E"
+msgstr "Α"
+
+#: id:76
+msgid "ESE"
+msgstr "ΑΝΑ"
+
+#: id:77
+msgid "SE"
+msgstr "ΝΑ"
+
+#: id:78
+msgid "SSE"
+msgstr "ΝΝΑ"
+
+#: id:79
+msgid "S"
+msgstr "Ν"
+
+#: id:80
+msgid "SSW"
+msgstr "ΝΝΔ"
+
+#: id:81
+msgid "SW"
+msgstr "ΝΔ"
+
+#: id:82
+msgid "WSW"
+msgstr "ΔΝΔ"
+
+#: id:83
+msgid "W"
+msgstr "Δ"
+
+#: id:84
+msgid "WNW"
+msgstr "ΔΒΔ"
+
+#: id:85
+msgid "NW"
+msgstr "ΒΔ"
+
+#: id:86
+msgid "NNW"
+msgstr "ΒΒΔ"
+
+#: id:87
+msgid "VAR"
+msgstr "ΔΙΑΦ"
+
+#: id:98
+msgid "View: Auto"
+msgstr "Προβολή: Αυτόματη"
+
+#: id:99
+msgid "View: Auto big"
+msgstr "Προβολή: Εικόνες"
+
+#: id:100
+msgid "View: Icons"
+msgstr "Προβολή: Εικονίδια"
+
+#: id:101
+msgid "View: List"
+msgstr "Προβολή: Λίστα"
+
+#: id:102
+msgctxt "Auto context with id 102"
+msgid "Scan"
+msgstr "Σάρωση"
+
+#: id:103
+msgctxt "Auto context with id 103"
+msgid "Sort by: Name"
+msgstr "Ταξ.: Όνομα"
+
+#: id:104
+msgid "Sort by: Date"
+msgstr "Ταξ.: Ημ/νία"
+
+#: id:105
+msgid "Sort by: Size"
+msgstr "Ταξ.: Μέγεθος"
+
+#: id:106
+msgid "No"
+msgstr "Όχι"
+
+#: id:107
+msgid "Yes"
+msgstr "Ναι"
+
+#: id:108
+msgctxt "Auto context with id 108"
+msgid "Slideshow"
+msgstr "Παρουσίαση διαφανειών"
+
+#: id:109
+msgid "Create thumbs"
+msgstr "Δημιουργία εικονιδίων"
+
+#: id:110
+msgid "Create thumbnails"
+msgstr "Δημιουργία μικρογραφιών"
+
+#: id:111
+msgctxt "Auto context with id 111"
+msgid "Shortcuts"
+msgstr "Συντομεύσεις"
+
+#: id:112
+msgid "Paused"
+msgstr "Παύση"
+
+#: id:113
+msgid "Update failed"
+msgstr "Η ενημέρωση απέτυχε"
+
+#: id:114
+msgid "Installation failed"
+msgstr "Η εγκατάσταση απέτυχε"
+
+#: id:115
+msgid "Copy"
+msgstr "Αντιγραφή"
+
+#: id:116
+msgid "Move"
+msgstr "Μετακίνηση"
+
+#: id:117
+msgid "Delete"
+msgstr "Διαγραφή"
+
+#: id:118
+msgid "Rename"
+msgstr "Μετονομασία"
+
+#: id:119
+msgid "New folder"
+msgstr "Νέος φάκελος"
+
+#: id:120
+msgid "Confirm file copy"
+msgstr "Επιβεβαίωση αντιγραφής"
+
+#: id:121
+msgid "Confirm file move"
+msgstr "Επιβεβαίωση μετακίνησης"
+
+#: id:122
+msgid "Confirm file delete?"
+msgstr "Επιβεβαίωση διαγραφής"
+
+#: id:123
+msgid "Copy these files?"
+msgstr "Αντιγραφή αυτών των αρχείων;"
+
+#: id:124
+msgid "Move these files?"
+msgstr "Μετακίνηση αυτών των αρχείων;"
+
+#: id:125
+msgid "Delete these files? - Deleting files cannot be undone!"
+msgstr "Διαγραφή αυτών των αρχείων; - Τα αρχεία σας θα διαγραφούν οριστικά!"
+
+#: id:126
+msgid "Status"
+msgstr "Λειτουργία"
+
+#: id:127
+msgid "Objects"
+msgstr "Αντικείμενα"
+
+#: id:128
+msgctxt "Auto context with id 128"
+msgid "General"
+msgstr "Γενικά"
+
+#: id:129
+msgctxt "Auto context with id 129"
+msgid "Slideshow"
+msgstr "Παρουσίαση διαφανειών"
+
+#: id:130
+msgctxt "Auto context with id 130"
+msgid "System info"
+msgstr "Πληροφορίες συστήματος"
+
+#: id:131
+msgid "Display"
+msgstr "Απεικόνιση"
+
+#: id:132
+msgid "Albums"
+msgstr "Άλμπουμ"
+
+#: id:133
+msgid "Artists"
+msgstr "Καλλιτέχνης"
+
+#: id:134
+msgid "Songs"
+msgstr "Τραγούδια"
+
+#: id:135
+msgid "Genres"
+msgstr "Είδος"
+
+#: id:136
+msgid "Playlists"
+msgstr "Λίστες αναπαραγωγής"
+
+#: id:137
+msgid "Search"
+msgstr "Αναζήτηση"
+
+#: id:138
+msgid "System Information"
+msgstr "Πληροφορίες Συστήματος"
+
+#: id:139
+msgid "Temperatures:"
+msgstr "Θερμοκρασίες:"
+
+#: id:140
+msgid "CPU:"
+msgstr "CPU:"
+
+#: id:141
+msgid "GPU:"
+msgstr "GPU:"
+
+#: id:142
+msgid "Time:"
+msgstr "Ώρα:"
+
+#: id:143
+msgid "Current:"
+msgstr "Τρέχουσα:"
+
+#: id:144
+msgid "Build:"
+msgstr "Έκδοση:"
+
+#: id:145
+msgid "Network:"
+msgstr "Δίκτυο:"
+
+#: id:146
+msgid "Type:"
+msgstr "Τύπος:"
+
+#: id:147
+msgid "Static"
+msgstr "Στατική"
+
+#: id:148
+msgid "DHCP"
+msgstr "DHCP"
+
+#: id:149
+msgid "MAC address"
+msgstr "Διεύθυνση MAC"
+
+#: id:150
+msgctxt "Auto context with id 150"
+msgid "IP address"
+msgstr "Διεύθυνση IP"
+
+#: id:151
+msgid "Link:"
+msgstr "Σύνδεση:"
+
+#: id:152
+msgid "Half duplex"
+msgstr "Μονόδρομη"
+
+#: id:153
+msgid "Full duplex"
+msgstr "Αμφίδρομη"
+
+#: id:154
+msgctxt "Auto context with id 154"
+msgid "Storage"
+msgstr "Αποθήκευση"
+
+#: id:155
+msgid "Drive"
+msgstr "Δίσκος"
+
+#: id:156
+msgctxt "Auto context with id 156"
+msgid "Free"
+msgstr "Ελεύθερος"
+
+#: id:157
+msgctxt "Auto context with id 157"
+msgid "Video"
+msgstr "Βίντεο"
+
+#: id:158
+msgid "Free memory"
+msgstr "Ελεύθερη μνήμη"
+
+#: id:159
+msgid "No link"
+msgstr "Καμία σύνδεση"
+
+#: id:160
+msgctxt "Auto context with id 160"
+msgid "Free"
+msgstr "Ελεύθερα"
+
+#: id:161
+msgid "Unavailable"
+msgstr "Μη διαθέσιμο"
+
+#: id:162
+msgid "Tray open"
+msgstr "Θύρα δίσκου ανοικτή"
+
+#: id:163
+msgid "Reading"
+msgstr "Ανάγνωση"
+
+#: id:164
+msgid "No disc"
+msgstr "Δεν υπάρχει δίσκος"
+
+#: id:165
+msgid "Disc present"
+msgstr "Υπάρχει δίσκος"
+
+#: id:166
+msgid "Skin"
+msgstr "Κέλυφος"
+
+#: id:169
+msgctxt "Auto context with id 169"
+msgid "Resolution"
+msgstr "Ανάλυση"
+
+#: id:170
+msgid "Adjust display refresh rate to match video"
+msgstr "Προσαρμογή του ρυθμού ανανέωσης για να ταιριάζει με το βίντεο"
+
+#: id:172
+msgid "Release date"
+msgstr "Ημερομηνία κυκλοφορίας"
+
+#: id:173
+msgid "Display 4:3 videos as"
+msgstr "Προβολή των βίντεο με αναλογία 4:3 ως"
+
+#: id:175
+msgid "Moods"
+msgstr "Τάσεις"
+
+#: id:176
+msgid "Styles"
+msgstr "Στυλ"
+
+#: id:179
+msgid "Song"
+msgstr "Τραγούδι"
+
+#: id:180
+msgid "Duration"
+msgstr "Διάρκεια"
+
+#: id:181
+msgid "Select album"
+msgstr "Επιλογή άλμπουμ"
+
+#: id:182
+msgid "Tracks"
+msgstr "Κομμάτια"
+
+#: id:183
+msgid "Review"
+msgstr "Κριτική"
+
+#: id:184
+msgid "Refresh"
+msgstr "Ανανέωση"
+
+#: id:185
+msgid "Searching album"
+msgstr "Αναζήτηση άλμπουμ"
+
+#: id:186
+msgid "OK"
+msgstr "Εντάξει"
+
+#: id:187
+msgid "No albums found!"
+msgstr "Δεν βρέθηκαν άλμπουμ!"
+
+#: id:188
+msgid "Select all"
+msgstr "Επιλογή όλων"
+
+#: id:189
+msgid "Scanning media info"
+msgstr "Σάρωση πληροφοριών"
+
+#: id:190
+msgid "Save"
+msgstr "Αποθήκευση"
+
+#: id:191
+msgid "Shuffle"
+msgstr "Τυχαία"
+
+#: id:192
+msgctxt "Auto context with id 192"
+msgid "Clear"
+msgstr "Απαλοιφή"
+
+#: id:193
+msgctxt "Auto context with id 193"
+msgid "Scan"
+msgstr "Σάρωση"
+
+#: id:194
+msgid "Searching..."
+msgstr "Αναζήτηση..."
+
+#: id:195
+msgid "No info found!"
+msgstr "Δεν βρέθηκαν πληροφορίες!"
+
+#: id:196
+msgid "Select movie:"
+msgstr "Επιλογή ταινίας:"
+
+#: id:197
+msgid "Querying %s info"
+msgstr "Εύρεση πληροφοριών %s"
+
+#: id:198
+msgid "Loading movie details"
+msgstr "Φόρτωση πληροφοριών ταινίας"
+
+#: id:199
+msgid "Web interface"
+msgstr "Διεπαφή ιστού"
+
+#: id:202
+msgid "Tagline"
+msgstr "Σλόγκαν"
+
+#: id:203
+msgid "Plot outline"
+msgstr "Περίληψη πλοκής"
+
+#: id:205
+msgid "Votes"
+msgstr "Ψήφοι"
+
+#: id:206
+msgid "Cast"
+msgstr "Διανομή ρόλων"
+
+#: id:207
+msgid "Plot"
+msgstr "Πλοκή"
+
+#: id:208
+msgctxt "Auto context with id 208"
+msgid "Play"
+msgstr "Εκκίνηση"
+
+#: id:209
+msgid "Next"
+msgstr "Επόμενο"
+
+#: id:210
+msgid "Previous"
+msgstr "Προηγούμενο"
+
+#: id:213
+msgid "Calibrate user interface..."
+msgstr "Βαθμονόμηση οθόνης..."
+
+#: id:214
+msgid "Video calibration..."
+msgstr "Βαθμονόμηση βίντεο..."
+
+#: id:215
+msgid "Soften"
+msgstr "Απάλυνση εικόνας"
+
+#: id:216
+msgid "Zoom amount"
+msgstr "Ποσοστό μεγέθυνσης"
+
+#: id:217
+msgid "Pixel ratio"
+msgstr "Λόγος εικονοστοιχείων"
+
+#: id:218
+msgid "DVD drive"
+msgstr "Μονάδα DVD"
+
+#: id:219
+msgid "Please insert disc"
+msgstr "Παρακαλώ εισάγετε δίσκο"
+
+#: id:220
+msgid "Remote share"
+msgstr "Απομακρυσμένος κοινόχρηστος πόρος"
+
+#: id:221
+msgid "Network is not connected"
+msgstr "Το δίκτυο είναι αποσυνδεμένο"
+
+#: id:222
+msgid "Cancel"
+msgstr "Άκυρο"
+
+#: id:224
+msgid "Speed"
+msgstr "Ταχύτητα"
+
+#: id:225
+msgid "Vertical Shift"
+msgstr "Κατακόρυφη μετατόπιση"
+
+#: id:226
+msgid "Test patterns..."
+msgstr "Δοκιμή μοτίβων..."
+
+#: id:227
+msgid "Lookup audio CD track names from freedb.org"
+msgstr "Αναζήτηση ονομάτων μουσικών κομματιών από το freedb.org"
+
+#: id:228
+msgid "Shuffle playlist on load"
+msgstr "Ανακάτεμα λίστας αναπαραγωγής κατά τη φόρτωση"
+
+#: id:229
+msgid "HDD spindown time"
+msgstr "Χρόνος ελάττωσης περιστροφής (Spindown)"
+
+#: id:230
+msgid "Video filters"
+msgstr "Φίλτρα βίντεο"
+
+#: id:231
+msgctxt "Auto context with id 231"
+msgid "None"
+msgstr "Κανένα"
+
+#: id:232
+msgid "Point"
+msgstr "Σημειακό"
+
+#: id:233
+msgid "Linear"
+msgstr "Γραμμικό"
+
+#: id:234
+msgid "Anisotropic"
+msgstr "Ανισοτροπικό"
+
+#: id:235
+msgid "Quincunx"
+msgstr "Quincunx"
+
+#: id:236
+msgid "Gaussian cubic"
+msgstr "Gaussian cubic"
+
+#: id:237
+msgid "Minification"
+msgstr "Σμίκρυνση"
+
+#: id:238
+msgid "Magnification"
+msgstr "Μεγέθυνση"
+
+#: id:239
+msgid "Clear playlist on finish"
+msgstr "Εκκαθάριση λίστας αναπαραγωγής στη λήξη"
+
+#: id:240
+msgid "Display Mode"
+msgstr "Λειτουργία Προβολής"
+
+#: id:241
+msgid "Full Screen #%d"
+msgstr "Πλήρης οθόνη #%d"
+
+#: id:242
+msgid "Windowed"
+msgstr "Σε παράθυρο"
+
+#: id:243
+msgid "Refresh Rate"
+msgstr "Ανανέωση βαθμολογίας"
+
+#: id:244
+msgid "Full screen"
+msgstr "Πλήρης οθόνη"
+
+#: id:245
+msgid "Sizing: (%i,%i)->(%i,%i) (Zoom x%2.2f) AR:%2.2f:1 (Pixels: %2.2f:1) (VShift: %2.2f)"
+msgstr "Μέγεθος: (%i,%i)->(%i,%i) (Εστίαση x%2.2f) AR:%2.2f:1 (Εικονοστοιχεία: %2.2f:1) (ΚΜετατόπιση: %2.2f)"
+
+#: id:247
+msgctxt "Auto context with id 247"
+msgid "Scripts"
+msgstr "Scripts"
+
+#: id:248
+msgctxt "Auto context with id 248"
+msgid "Language"
+msgstr "Γλώσσα"
+
+#: id:249
+msgctxt "Auto context with id 249"
+msgid "Music"
+msgstr "Μουσική"
+
+#: id:250
+msgctxt "Auto context with id 250"
+msgid "Visualization"
+msgstr "Οπτικοποίηση"
+
+#: id:251
+msgid "Select destination directory"
+msgstr "Επιλογή καταλόγου προορισμού"
+
+#: id:252
+msgid "Output stereo to all speakers"
+msgstr "Στέρεο έξοδος σε όλα τα ηχεία"
+
+#: id:253
+msgid "Number of channels"
+msgstr "Αριθμός καναλιών"
+
+#: id:254
+msgid "- DTS capable receiver"
+msgstr "- Δέκτης ικανός για αναπαραγωγή DTS"
+
+#: id:255
+msgid "CDDB"
+msgstr "CDDB"
+
+#: id:256
+msgid "Fetching CD information"
+msgstr "Ανάκτηση πληροφοριών CD"
+
+#: id:257
+msgid "Error"
+msgstr "Σφάλμα"
+
+#: id:258
+msgid "Enable tag reading"
+msgstr "Ενεργοποίηση ID3 ετικετών"
+
+#: id:259
+msgid "Opening"
+msgstr "Άνοιγμα"
+
+#: id:260
+msgid "Shoutcast"
+msgstr "Shoutcast"
+
+#: id:261
+msgid "Waiting for start..."
+msgstr "Αναμονή για την έναρξη..."
+
+#: id:262
+msgid "Scripts output"
+msgstr "Εξαγωγές Scripts"
+
+#: id:263
+msgid "Allow control of XBMC via HTTP"
+msgstr "Έγκριση ελέγχου του XBMC μέσω HTTP"
+
+#: id:264
+msgid "Record"
+msgstr "Εγγραφή"
+
+#: id:265
+msgid "Stop Rec."
+msgstr "Διακοπή εγγραφής"
+
+#: id:266
+msgid "Sort by: Track"
+msgstr "Ταξ.: Κομμάτι"
+
+#: id:267
+msgid "Sort by: Time"
+msgstr "Ταξ.: Χρόνος"
+
+#: id:268
+msgid "Sort by: Title"
+msgstr "Ταξ.: Τίτλος"
+
+#: id:269
+msgid "Sort by: Artist"
+msgstr "Ταξ.: Καλλιτέχνης"
+
+#: id:270
+msgid "Sort by: Album"
+msgstr "Ταξ.: Άλμπουμ"
+
+#: id:271
+msgid "Top 100"
+msgstr "100 κορυφαία"
+
+#: id:272
+msgid "Top-Left overscan compensation"
+msgstr "Επάνω αριστερή προσαρμογή του ορατού πλαισίου"
+
+#: id:273
+msgid "Bottom-Right overscan compensation"
+msgstr "Κάτω δεξιά προσαρμογή του ορατού πλαισίου"
+
+#: id:274
+msgid "Subtitle positioning"
+msgstr "Θέση υποτίτλων"
+
+#: id:275
+msgid "Pixel ratio adjustment"
+msgstr "Ρύθμιση λόγου εικονοστοιχείων"
+
+#: id:276
+msgid "Adjust the arrow to change the amount of overscan"
+msgstr "Μετακινήστε το βέλος για να αλλάξετε το μέγεθος του ορατού πλαισίου"
+
+#: id:277
+msgid "Adjust the bar to change the subtitles position"
+msgstr "Μετακινήστε τη μπάρα για να αλλάξει η θέση των υποτίτλων"
+
+#: id:278
+msgid "Adjust the rectangle so it is perfectly square"
+msgstr "Αλλάξτε το σχήμα ώστε να είναι τέλειο τετράγωνο"
+
+#: id:279
+msgid "Unable to load settings"
+msgstr "Αδυναμία φόρτωσης των ρυθμίσεων"
+
+#: id:280
+msgid "Using default settings"
+msgstr "Χρήση προεπιλεγμένων ρυθμίσεων"
+
+#: id:281
+msgid "Please check the XML files"
+msgstr "Παρακαλώ ελέγξτε τα αρχεία .XML"
+
+#: id:282
+msgid "Found %i items"
+msgstr "Βρέθηκαν %i αντικείμενα"
+
+#: id:283
+msgid "Search results"
+msgstr "Αποτελέσματα αναζήτησης"
+
+#: id:284
+msgid "No results found"
+msgstr "Δεν βρέθηκαν αποτελέσματα"
+
+#: id:287
+msgctxt "Auto context with id 287"
+msgid "Subtitles"
+msgstr "Υπότιτλοι"
+
+#: id:288
+msgctxt "Auto context with id 288"
+msgid "Font"
+msgstr "Γραμματοσειρά"
+
+#: id:289
+msgctxt "Auto context with id 289"
+msgid "- Size"
+msgstr "- Μέγεθος"
+
+#: id:290
+msgid "Dynamic range compression"
+msgstr "Δυναμικό εύρος συμπίεσης"
+
+#: id:291
+msgctxt "Auto context with id 291"
+msgid "Video"
+msgstr "Βίντεο"
+
+#: id:292
+msgctxt "Auto context with id 292"
+msgid "Audio"
+msgstr "Ήχος"
+
+#: id:293
+msgid "Browse for subtitles"
+msgstr "Αναζήτηση για υπότιτλους"
+
+#: id:294
+msgid "Create bookmark"
+msgstr "Δημιουργία"
+
+#: id:296
+msgid "Clear bookmarks"
+msgstr "Εκκαθάριση"
+
+#: id:297
+msgid "Audio offset"
+msgstr "Καθυστέρηση ήχου"
+
+#: id:298
+msgid "Bookmarks"
+msgstr "Σελιδοδείκτες"
+
+#: id:299
+msgid "- AAC capable receiver"
+msgstr "- Δέκτης ικανός για αναπαραγωγή AAC"
+
+#: id:300
+msgid "- MP1 capable receiver"
+msgstr "- Δέκτης ικανός για αναπαραγωγή MP1"
+
+#: id:301
+msgid "- MP2 capable receiver"
+msgstr "- Δέκτης ικανός για αναπαραγωγή MP2"
+
+#: id:302
+msgid "- MP3 capable receiver"
+msgstr "- Δέκτης ικανός για αναπαραγωγή MP3"
+
+#: id:303
+msgid "Delay"
+msgstr "Καθυστέρηση"
+
+#: id:304
+msgctxt "Auto context with id 304"
+msgid "Language"
+msgstr "Γλώσσα"
+
+#: id:305
+msgctxt "Auto context with id 305"
+msgid "Enabled"
+msgstr "Ενεργό/ή"
+
+#: id:306
+msgid "Non-interleaved"
+msgstr "Non-interleaved"
+
+#: id:312
+msgid "(0=auto)"
+msgstr "(0=αυτόματα)"
+
+#: id:313
+msgid "Cleaning database"
+msgstr "Εκκαθάριση βάσης δεδομένων"
+
+#: id:314
+msgid "Preparing..."
+msgstr "Προετοιμασία..."
+
+#: id:315
+msgid "Database error"
+msgstr "Σφάλμα στη βάση δεδομένων"
+
+#: id:316
+msgid "Searching songs..."
+msgstr "Αναζήτηση τραγουδιών..."
+
+#: id:317
+msgid "Cleaned database successfully"
+msgstr "Επιτυχής εκκαθάριση της βάσης δεδομένων"
+
+#: id:318
+msgid "Cleaning songs..."
+msgstr "Εκκαθάριση τραγουδιών..."
+
+#: id:319
+msgid "Error cleaning songs"
+msgstr "Σφάλμα κατά την εκκαθάριση τραγουδιών"
+
+#: id:320
+msgid "Cleaning artists..."
+msgstr "Εκκαθάριση καλλιτεχνών..."
+
+#: id:321
+msgid "Error cleaning artists"
+msgstr "Σφάλμα κατά την εκκαθάριση καλλιτεχνών"
+
+#: id:322
+msgid "Cleaning genres..."
+msgstr "Εκκαθάριση ειδών..."
+
+#: id:323
+msgid "Error cleaning genres"
+msgstr "Σφάλμα κατά την εκκαθάριση ειδών"
+
+#: id:324
+msgid "Cleaning paths..."
+msgstr "Εκκαθάριση διαδρομών..."
+
+#: id:325
+msgid "Error cleaning paths"
+msgstr "Σφάλμα κατά την εκκαθάριση διαδρομών"
+
+#: id:326
+msgid "Cleaning albums..."
+msgstr "Εκκαθάριση άλμπουμ..."
+
+#: id:327
+msgid "Error cleaning albums"
+msgstr "Σφάλμα κατά την εκκαθάριση άλμπουμ"
+
+#: id:328
+msgid "Writing changes..."
+msgstr "Εγγραφή αλλαγών..."
+
+#: id:329
+msgid "Error writing changes"
+msgstr "Σφάλμα κατά την εγγραφή αλλαγών"
+
+#: id:330
+msgid "This may take some time..."
+msgstr "Αυτό ίσως πάρει λίγο χρόνο..."
+
+#: id:331
+msgid "Compressing database..."
+msgstr "Συμπίεση βάσης δεδομένων..."
+
+#: id:332
+msgid "Error compressing database"
+msgstr "Σφάλμα κατά την συμπίεση της βάσης δεδομένων"
+
+#: id:333
+msgid "Do you want to clean the library?"
+msgstr "Εκκαθάριση της συλλογής από τα περιεχόμενα;"
+
+#: id:334
+msgid "Clean library..."
+msgstr "Εκκαθάριση συλλογής..."
+
+#: id:335
+msgid "Start"
+msgstr "Έναρξη"
+
+#: id:336
+msgid "Framerate conversion"
+msgstr "Μετατροπή δειγματοληψίας"
+
+#: id:337
+msgctxt "Auto context with id 337"
+msgid "Audio output"
+msgstr "Έξοδος ήχου"
+
+#: id:338
+msgid "Analog"
+msgstr "Αναλογική"
+
+#: id:339
+msgid "Optical/Coax"
+msgstr "Οπτική/Coax"
+
+#: id:340
+msgid "Various artists"
+msgstr "Διάφοροι καλλιτέχνες"
+
+#: id:341
+msgid "Play disc"
+msgstr "Έναρξη δίσκου"
+
+#: id:342
+msgctxt "Auto context with id 342"
+msgid "Movies"
+msgstr "Ταινίες"
+
+#: id:343
+msgid "Adjust framerate"
+msgstr "Προσαρμογή δειγματοληψίας"
+
+#: id:344
+msgid "Actors"
+msgstr "Ηθοποιοί"
+
+#: id:345
+msgctxt "Auto context with id 345"
+msgid "Year"
+msgstr "Έτος"
+
+#: id:346
+msgid "Boost volume level on downmix"
+msgstr "Ενίσχυση έντασης ήχου κατά το χειρισμό downmix"
+
+#: id:350
+msgctxt "Auto context with id 350"
+msgid "Programs"
+msgstr "Εφαρμογές"
+
+#: id:351
+msgctxt "Auto context with id 351"
+msgid "Off"
+msgstr "Ανενεργό/ή"
+
+#: id:352
+msgid "Dim"
+msgstr "Αμυδρό φως"
+
+#: id:353
+msgid "Black"
+msgstr "Μαύρη οθόνη"
+
+#: id:354
+msgid "Matrix trails"
+msgstr "Ίχνη πλέγματος"
+
+#: id:355
+msgid "Screensaver time"
+msgstr "Αναμονή για προφύλαξη οθόνης"
+
+#: id:356
+msgid "Screensaver mode"
+msgstr "Λειτουργία προφύλαξης οθόνης"
+
+#: id:357
+msgid "Shutdown function timer"
+msgstr "Λειτουργία χρονοδιακόπτη τερματισμού"
+
+#: id:358
+msgid "All albums"
+msgstr "Όλα τα άλμπουμ"
+
+#: id:359
+msgid "Recently added albums"
+msgstr "Πρόσφατα άλμπουμ"
+
+#: id:360
+msgctxt "Auto context with id 360"
+msgid "Screensaver"
+msgstr "Προφύλαξη οθόνης"
+
+#: id:361
+msgid "R. Slideshow"
+msgstr "Παρουσίαση διαφανειών και των υποφακέλων"
+
+#: id:362
+msgid "Screensaver dim level"
+msgstr "Ποσοστό εξασθένισης της προφύλαξης οθόνης"
+
+#: id:363
+msgid "Sort by: File"
+msgstr "Ταξ.: Αρχείο"
+
+#: id:364
+msgid "- Dolby Digital (AC3) capable receiver"
+msgstr "- Δέκτης με ικανότητα αναπαραγωγής Dolby Digital (AC3)"
+
+#: id:365
+msgctxt "Auto context with id 365"
+msgid "Sort by: Name"
+msgstr "Ταξ.: Όνομα"
+
+#: id:366
+msgid "Sort by: Year"
+msgstr "Ταξ.: Έτος"
+
+#: id:367
+msgid "Sort by: Rating"
+msgstr "Ταξ.: Βαθμολογία"
+
+#: id:368
+msgid "IMDb"
+msgstr "IMDb"
+
+#: id:369
+msgctxt "Auto context with id 369"
+msgid "Title"
+msgstr "Τίτλος"
+
+#: id:370
+msgid "Thunderstorms"
+msgstr "Καταιγίδες"
+
+#: id:371
+msgid "Partly"
+msgstr "Διάσπαρτα"
+
+#: id:372
+msgid "Mostly"
+msgstr "Κυρίως"
+
+#: id:373
+msgid "Sunny"
+msgstr "Ηλιοφάνεια"
+
+#: id:374
+msgid "Cloudy"
+msgstr "Νέφη"
+
+#: id:375
+msgid "Snow"
+msgstr "Χιόνι"
+
+#: id:376
+msgid "Rain"
+msgstr "Βροχή"
+
+#: id:377
+msgid "Light"
+msgstr "Ασθενής"
+
+#: id:378
+msgid "AM"
+msgstr "Προ μεσημβρίας"
+
+#: id:379
+msgid "PM"
+msgstr "Μετά μεσημβρίας"
+
+#: id:380
+msgid "Showers"
+msgstr "Μπόρες"
+
+#: id:381
+msgid "Few"
+msgstr "Λίγες"
+
+#: id:382
+msgid "Scattered"
+msgstr "Σποραδικά"
+
+#: id:383
+msgctxt "Auto context with id 383"
+msgid "Wind"
+msgstr "Άνεμος"
+
+#: id:384
+msgid "Strong"
+msgstr "Δυνατός"
+
+#: id:385
+msgid "Fair"
+msgstr "Ήπιος"
+
+#: id:386
+msgctxt "Auto context with id 386"
+msgid "Clear"
+msgstr "Αίθριος"
+
+#: id:387
+msgid "Clouds"
+msgstr "Νεφοσκεπής"
+
+#: id:388
+msgid "Early"
+msgstr "τις πρώτες πρωινές ώρες"
+
+#: id:389
+msgid "Shower"
+msgstr "Μπόρα"
+
+#: id:390
+msgid "Flurries"
+msgstr "Ελαφρές χιονοπτώσεις"
+
+#: id:391
+msgctxt "Auto context with id 391"
+msgid "Low"
+msgstr "Ελαχ."
+
+#: id:392
+msgctxt "Auto context with id 392"
+msgid "Medium"
+msgstr "Μεσ."
+
+#: id:393
+msgctxt "Auto context with id 393"
+msgid "High"
+msgstr "Μεγ."
+
+#: id:394
+msgid "Fog"
+msgstr "Ομίχλη"
+
+#: id:395
+msgid "Haze"
+msgstr "Ξηρά αχλή"
+
+#: id:396
+msgid "Select location"
+msgstr "Επιλογή τοποθεσίας"
+
+#: id:397
+msgid "Refresh time"
+msgstr "Ανανέωση χρόνου"
+
+#: id:398
+msgid "Temperature units"
+msgstr "Μονάδα θερμοκρασίας"
+
+#: id:399
+msgid "Speed units"
+msgstr "Μονάδα ταχύτητας"
+
+#: id:400
+msgctxt "Auto context with id 400"
+msgid "Weather"
+msgstr "Ο Καιρός"
+
+#: id:401
+msgid "Temp"
+msgstr "Θερμοκρασία"
+
+#: id:402
+msgid "Feels like"
+msgstr "Αίσθηση ως"
+
+#: id:403
+msgid "UV index"
+msgstr "Δείκτης UV"
+
+#: id:404
+msgctxt "Auto context with id 404"
+msgid "Wind"
+msgstr "Άνεμος"
+
+#: id:405
+msgid "Dew point"
+msgstr "Σημείο δρόσου"
+
+#: id:406
+msgid "Humidity"
+msgstr "Υγρασία"
+
+#: id:409
+msgid "Defaults"
+msgstr "Προεπιλεγμένα"
+
+#: id:410
+msgid "Accessing weather service"
+msgstr "Πρόσβαση στην υπηρεσία καιρού"
+
+#: id:411
+msgid "Getting weather for:"
+msgstr "Ανάκτηση καιρού για:"
+
+#: id:412
+msgid "Unable to get weather data"
+msgstr "Αδυναμία λήψης δεδομένων καιρού"
+
+#: id:413
+msgid "Manual"
+msgstr "Χειροκίνητα"
+
+#: id:414
+msgid "No review for this album"
+msgstr "Καμιά κριτική για το άλμπουμ"
+
+#: id:415
+msgid "Downloading thumbnail..."
+msgstr "Λήψη μικρογραφίας..."
+
+#: id:416
+msgid "Not available"
+msgstr "Μη διαθέσιμος πόρος"
+
+#: id:417
+msgid "View: Big icons"
+msgstr "Προβολή: Μεγ. Εικονίδια"
+
+#: id:418
+msgctxt "Auto context with id 418"
+msgid "Low"
+msgstr "Ελαχ."
+
+#: id:419
+msgctxt "Auto context with id 419"
+msgid "High"
+msgstr "Μεγ."
+
+#: id:420
+msgid "HDMI"
+msgstr "HDMI"
+
+#: id:422
+msgid "Delete album info"
+msgstr "Διαγραφή πληροφοριών άλμπουμ"
+
+#: id:423
+msgid "Delete CD information"
+msgstr "Διαγραφή πληροφοριών CD"
+
+#: id:424
+msgid "Select"
+msgstr "Επιλογή"
+
+#: id:425
+msgid "No album information found"
+msgstr "Δεν βρέθηκαν πληροφορίες για το άλμπουμ"
+
+#: id:426
+msgid "No CD information found"
+msgstr "Δεν βρέθηκαν πληροφορίες για το CD"
+
+#: id:427
+msgid "Disc"
+msgstr "Δίσκος"
+
+#: id:428
+msgid "Insert correct CD/DVD"
+msgstr "Εισάγετε το σωστό CD/DVD"
+
+#: id:429
+msgid "Please insert the following disc:"
+msgstr "Παρακαλώ, εισάγετε τον ακόλουθο δίσκο:"
+
+#: id:430
+msgid "Sort by: DVD#"
+msgstr "Ταξ.: DVD#"
+
+#: id:431
+msgid "No cache"
+msgstr "Δεν υπάρχει ελεύθερη λανθάνουσα μνήμη"
+
+#: id:432
+msgid "Remove movie from library"
+msgstr "Διαγραφή ταινίας από τη συλλογή"
+
+#: id:433
+msgid "Really remove '%s'?"
+msgstr "Να διαγραφεί '%s';"
+
+#: id:434
+msgid "From %s at %i %s"
+msgstr "Από %s με ένταση %i %s"
+
+#: id:437
+msgid "Removable disk"
+msgstr "Αφαιρούμενος δίσκος"
+
+#: id:438
+msgid "Opening file"
+msgstr "Άνοιγμα αρχείου"
+
+#: id:439
+msgid "Cache"
+msgstr "Λανθάνουσα μνήμη"
+
+#: id:440
+msgid "Harddisk"
+msgstr "Σκληρός δίσκος"
+
+#: id:441
+msgid "UDF"
+msgstr "UDF"
+
+#: id:442
+msgid "Local network"
+msgstr "Τοπικό δίκτυο"
+
+#: id:443
+msgid "Internet"
+msgstr "Διαδίκτυο"
+
+#: id:444
+msgctxt "Auto context with id 444"
+msgid "Video"
+msgstr "Βίντεο"
+
+#: id:445
+msgctxt "Auto context with id 445"
+msgid "Audio"
+msgstr "Ήχος"
+
+#: id:446
+msgctxt "Auto context with id 446"
+msgid "DVD"
+msgstr "DVD"
+
+#: id:447
+msgid "Autorun media"
+msgstr "Αυτόματη εκκίνηση πολυμέσων"
+
+#: id:448
+msgid "LCD"
+msgstr "LCD"
+
+#: id:449
+msgctxt "Auto context with id 449"
+msgid "Enabled"
+msgstr "Ενεργό/ή"
+
+#: id:450
+msgid "Columns"
+msgstr "Στήλες"
+
+#: id:451
+msgid "Row 1 address"
+msgstr "Διεύθυνση 1ης γραμμής"
+
+#: id:452
+msgid "Row 2 address"
+msgstr "Διεύθυνση 2ης γραμμής"
+
+#: id:453
+msgid "Row 3 address"
+msgstr "Διεύθυνση 3ης γραμμής"
+
+#: id:454
+msgid "Row 4 address"
+msgstr "Διεύθυνση 4ης γραμμής"
+
+#: id:455
+msgid "Rows"
+msgstr "Γραμμές"
+
+#: id:456
+msgid "Mode"
+msgstr "Μέθοδος"
+
+#: id:457
+msgid "Switch view"
+msgstr "Εναλλαγή προβολής"
+
+#: id:459
+msgid "Subs"
+msgstr "Υπότιτλοι"
+
+#: id:460
+msgid "Audio stream"
+msgstr "Ηχητική ροή"
+
+#: id:461
+msgid "[active]"
+msgstr "[ενεργό]"
+
+#: id:462
+msgid "Subtitle"
+msgstr "Υπότιτλος"
+
+#: id:463
+msgid "Backlight"
+msgstr "Οπίσθιος φωτισμός"
+
+#: id:464
+msgid "Brightness"
+msgstr "Φωτεινότητα"
+
+#: id:465
+msgid "Contrast"
+msgstr "Αντίθεση"
+
+#: id:466
+msgid "Gamma"
+msgstr "Συντελεστής γάμμα"
+
+#: id:467
+msgctxt "Auto context with id 467"
+msgid "Type"
+msgstr "Τύπος"
+
+#: id:468
+msgid "Move the bar to change the OSD position"
+msgstr "Μετακινήστε τη μπάρα για αλλαγή της θέσης των απεικονίσεων οθόνης (OSD)"
+
+#: id:469
+msgid "OSD position"
+msgstr "Θέση απεικονίσεων οθόνης (OSD)"
+
+#: id:470
+msgid "Credits"
+msgstr "Συντελεστές"
+
+#: id:471
+msgid "Modchip"
+msgstr "Τσιπάκι"
+
+#: id:474
+msgctxt "Auto context with id 474"
+msgid "Off"
+msgstr "Ανενεργό/ή"
+
+#: id:475
+msgid "Music only"
+msgstr "Μουσική μόνο"
+
+#: id:476
+msgctxt "Auto context with id 476"
+msgid "Music & video"
+msgstr "Μουσική & βίντεο"
+
+#: id:477
+msgid "Unable to load playlist"
+msgstr "Αδυναμία φόρτωσης της λίστας αναπαραγωγής"
+
+#: id:478
+msgid "OSD"
+msgstr "Aπεικονίσεις οθόνης (OSD)"
+
+#: id:479
+msgid "Skin & language"
+msgstr "Κέλυφος & γλώσσα"
+
+#: id:480
+msgid "Appearance"
+msgstr "Εξατομίκευση"
+
+#: id:481
+msgid "Audio options"
+msgstr "Ιδιότητες ήχου"
+
+#: id:482
+msgid "About XBMC"
+msgstr "Περί XBMC"
+
+#: id:485
+msgid "Delete album"
+msgstr "Διαγραφή άλμπουμ"
+
+#: id:486
+msgid "Repeat"
+msgstr "Επανάληψη"
+
+#: id:487
+msgid "Repeat one"
+msgstr "Επανάληψη του ίδιου"
+
+#: id:488
+msgid "Repeat folder"
+msgstr "Επανάληψη φακέλου"
+
+#: id:489
+msgid "Play the next song automatically"
+msgstr "Αυτόματη αναπαραγωγή επόμενου κομματιού"
+
+#: id:491
+msgid "- Use big icons"
+msgstr "- Χρήση Μεγ. εικονιδίων"
+
+#: id:492
+msgid "Resize VobSubs"
+msgstr "Μεγέθυνση υποτίτλων"
+
+#: id:493
+msgid "Advanced options (Experts Only!)"
+msgstr "Ρυθμίσεις για προχωρημένους!"
+
+#: id:494
+msgid "Overall audio headroom"
+msgstr "Εύρος στάθμης γενικού ήχου"
+
+#: id:495
+msgid "Upsample videos to GUI resolution"
+msgstr "Αύξηση δειγματοληψίας ανάλυσης σε γραφικό περιβάλλον (GUI)"
+
+#: id:496
+msgid "Calibration"
+msgstr "Βαθμονόμηση"
+
+#: id:497
+msgid "Show file extensions"
+msgstr "Εμφάνιση επεκτάσεων αρχείων"
+
+#: id:498
+msgid "Sort by: Type"
+msgstr "Ταξ.: Τύπος"
+
+#: id:499
+msgid "Unable to connect to online lookup service"
+msgstr "Αδυναμία σύνδεσης στην υπηρεσία έρευνας"
+
+#: id:500
+msgid "Downloading album information failed"
+msgstr "Απέτυχε η λήψη των πληροφοριών άλμπουμ"
+
+#: id:501
+msgid "Looking for album names..."
+msgstr "Αναζήτηση για ονόματα άλμπουμ..."
+
+#: id:502
+msgctxt "Auto context with id 502"
+msgid "Open"
+msgstr "Άνοιγμα"
+
+#: id:503
+msgid "Busy"
+msgstr "Απασχολημένο"
+
+#: id:504
+msgid "Empty"
+msgstr "Κενός"
+
+#: id:505
+msgid "Loading media info from files..."
+msgstr "Φόρτωση πληροφοριών πολυμέσων..."
+
+#: id:507
+msgid "Sort by: Usage"
+msgstr "Ταξ.: Χρήση"
+
+#: id:510
+msgid "Enable visualizations"
+msgstr "Ενεργοποίηση οπτικοποιήσεων"
+
+#: id:511
+msgid "Enable video mode switching"
+msgstr "Ενεργοποίηση εναλλαγής λειτουργίας βίντεο"
+
+#: id:512
+msgid "Startup window"
+msgstr "Παράθυρο εκκίνησης"
+
+#: id:513
+msgid "Home window"
+msgstr "Αρχική οθόνη"
+
+#: id:514
+msgid "Manual settings"
+msgstr "Χειροκίνητες ρυθμίσεις"
+
+#: id:515
+msgid "Genre"
+msgstr "Είδος"
+
+#: id:517
+msgid "Recently played albums"
+msgstr "Πρόσφατα εκτελεσθέντα άλμπουμ"
+
+#: id:518
+msgid "Launch"
+msgstr "Εκκίνηση"
+
+#: id:519
+msgid "Launch in..."
+msgstr "Εκκίνηση σε..."
+
+#: id:521
+msgid "Compilations"
+msgstr "Συνθέσεις"
+
+#: id:522
+msgid "Remove source"
+msgstr "Απομάκρυνση πηγής"
+
+#: id:523
+msgid "Switch media"
+msgstr "Εναλλαγή πολυμέσων"
+
+#: id:524
+msgid "Select playlist"
+msgstr "Επιλογή λίστας αναπαραγωγής"
+
+#: id:525
+msgid "New playlist..."
+msgstr "Νέα λίστα αναπαραγωγής..."
+
+#: id:526
+msgid "Add to playlist"
+msgstr "Προσθήκη στη λίστα αναπαραγωγής"
+
+#: id:527
+msgid "Manually add to library"
+msgstr "Χειροκίνητη προσθήκη στη συλλογή"
+
+#: id:528
+msgid "Enter title"
+msgstr "Εισάγετε τίτλο"
+
+#: id:529
+msgid "Error: Duplicate title"
+msgstr "Σφάλμα: Διπλότυπος τίτλος"
+
+#: id:530
+msgid "Select genre"
+msgstr "Επιλέξτε είδος"
+
+#: id:531
+msgid "New genre"
+msgstr "Νέο είδος"
+
+#: id:532
+msgid "Manual addition"
+msgstr "Χειροκίνητη προσθήκη"
+
+#: id:533
+msgid "Enter genre"
+msgstr "Εισαγωγή είδους"
+
+#: id:534
+msgid "View: %s"
+msgstr "Προβολή: %s"
+
+#: id:535
+msgid "List"
+msgstr "Λίστα"
+
+#: id:536
+msgid "Icons"
+msgstr "Εικονίδια"
+
+#: id:537
+msgid "Big list"
+msgstr "Μεγάλη λίστα"
+
+#: id:538
+msgid "Big icons"
+msgstr "Μεγ. Εικονίδια"
+
+#: id:539
+msgid "Wide"
+msgstr "Ευρεία"
+
+#: id:540
+msgid "Big wide"
+msgstr "Πολύ ευρεία"
+
+#: id:541
+msgid "Album icons"
+msgstr "Εικον. άλμπουμ"
+
+#: id:542
+msgid "DVD icons"
+msgstr "Εικον. DVD"
+
+#: id:543
+msgctxt "Auto context with id 543"
+msgid "DVD"
+msgstr "DVD"
+
+#: id:544
+msgctxt "Auto context with id 544"
+msgid "Media info"
+msgstr "Πληροφορίες"
+
+#: id:545
+msgid "Audio output device"
+msgstr "Συσκευή εξόδου ήχου"
+
+#: id:546
+msgid "Passthrough output device"
+msgstr "Συσκευή εξόδου διέλευσης"
+
+#: id:547
+msgid "No biography for this artist"
+msgstr "Δεν υπάρχει βιογραφία γι' αυτόν τον καλλιτέχνη"
+
+#: id:548
+msgid "Downmix multichannel audio to stereo"
+msgstr "Υποβιβασμός πολυκάναλου ήχου σε στερεοφωνικό"
+
+#: id:550
+msgid "Sort by: %s"
+msgstr "Ταξ.: %s"
+
+#: id:551
+msgctxt "Auto context with id 551"
+msgid "Name"
+msgstr "Όνομα"
+
+#: id:552
+msgid "Date"
+msgstr "Ημερομηνία"
+
+#: id:553
+msgid "Size"
+msgstr "Μέγεθος"
+
+#: id:554
+msgid "Track"
+msgstr "Κομμάτι"
+
+#: id:555
+msgid "Time"
+msgstr "Χρόνος"
+
+#: id:556
+msgctxt "Auto context with id 556"
+msgid "Title"
+msgstr "Τίτλος"
+
+#: id:557
+msgid "Artist"
+msgstr "Καλλιτέχνης"
+
+#: id:558
+msgid "Album"
+msgstr "Άλμπουμ"
+
+#: id:559
+msgid "Playlist"
+msgstr "Λίστα αναπαραγωγής"
+
+#: id:560
+msgid "ID"
+msgstr "ID"
+
+#: id:561
+msgctxt "Auto context with id 561"
+msgid "File"
+msgstr "Αρχείο"
+
+#: id:562
+msgctxt "Auto context with id 562"
+msgid "Year"
+msgstr "Έτος"
+
+#: id:563
+msgid "Rating"
+msgstr "Αξιολόγηση"
+
+#: id:564
+msgctxt "Auto context with id 564"
+msgid "Type"
+msgstr "Τύπος"
+
+#: id:565
+msgid "Usage"
+msgstr "Χρήση"
+
+#: id:566
+msgid "Album artist"
+msgstr "Καλλιτέχνης Άλμπουμ"
+
+#: id:567
+msgid "Play count"
+msgstr "Αναπαράχθηκε"
+
+#: id:568
+msgid "Last played"
+msgstr "Τελευταία αναπαραγωγή"
+
+#: id:569
+msgctxt "Auto context with id 569"
+msgid "Comment"
+msgstr "Σχόλια"
+
+#: id:570
+msgid "Date added"
+msgstr "Ημ/νία προσθήκης"
+
+#: id:571
+msgctxt "Auto context with id 571"
+msgid "Default"
+msgstr "Προεπιλεγμένη"
+
+#: id:572
+msgid "Studio"
+msgstr "Στούντιο"
+
+#: id:573
+msgid "Path"
+msgstr "Διαδρομή"
+
+#: id:574
+msgctxt "Auto context with id 574"
+msgid "Country"
+msgstr "Χώρα"
+
+#: id:575
+msgid "In progress"
+msgstr "Σε εξέλιξη"
+
+#: id:576
+msgid "Times played"
+msgstr "Αριθμός αναπαραγωγών"
+
+#: id:580
+msgid "Sort direction"
+msgstr "Σειρά ταξινόμησης"
+
+#: id:581
+msgid "Sort method"
+msgstr "Μέθοδος ταξινόμησης"
+
+#: id:582
+msgctxt "Auto context with id 582"
+msgid "View mode"
+msgstr "Λειτουργία Προβολής"
+
+#: id:583
+msgid "Remember views for different folders"
+msgstr "Απομνημόνευση προβολών διαφορετικών φακέλων"
+
+#: id:584
+msgid "Ascending"
+msgstr "Αύξουσα"
+
+#: id:585
+msgid "Descending"
+msgstr "Φθίνουσα"
+
+#: id:586
+msgid "Edit playlist"
+msgstr "Επεξεργασία λίστας αναπαραγωγής"
+
+#: id:587
+msgid "Filter"
+msgstr "Φίλτρο"
+
+#: id:588
+msgid "Cancel party mode"
+msgstr "Ακύρωση Party Mode"
+
+#: id:589
+msgid "Party mode"
+msgstr "Party Mode"
+
+#: id:590
+msgid "Random"
+msgstr "Τυχαίο"
+
+#: id:591
+msgctxt "Auto context with id 591"
+msgid "Off"
+msgstr "Όχι"
+
+#: id:592
+msgid "One"
+msgstr "Ένα"
+
+#: id:593
+msgid "All"
+msgstr "Όλα"
+
+#: id:594
+msgctxt "Auto context with id 594"
+msgid "Off"
+msgstr "Όχι"
+
+#: id:595
+msgid "Repeat: Off"
+msgstr "Επανάληψη: Όχι"
+
+#: id:596
+msgid "Repeat: One"
+msgstr "Επανάληψη: Μία φορά"
+
+#: id:597
+msgid "Repeat: All"
+msgstr "Επανάληψη: Όλων"
+
+#: id:600
+msgid "Rip audio CD"
+msgstr "Αντιγραφή CD ήχου"
+
+#: id:601
+msgctxt "Auto context with id 601"
+msgid "Medium"
+msgstr "Μεσαία"
+
+#: id:602
+msgctxt "Auto context with id 602"
+msgid "Standard"
+msgstr "Κανονική"
+
+#: id:603
+msgid "Extreme"
+msgstr "Ακραία"
+
+#: id:604
+msgid "Constant bitrate"
+msgstr "Σταθερό bitrate"
+
+#: id:605
+msgid "Ripping..."
+msgstr "Αντιγραφή..."
+
+#: id:607
+msgid "To:"
+msgstr "Προς:"
+
+#: id:608
+msgid "Could not rip CD or track"
+msgstr "Αδυναμία αντιγραφής CD ή κομματιού"
+
+#: id:609
+msgid "CDDARipPath is not set."
+msgstr "Δεν ορίσθηκε διαδρομή αντιγραφής CDDA."
+
+#: id:610
+msgid "Rip audio track"
+msgstr "Αντιγραφή κομματιού"
+
+#: id:611
+msgid "Enter number"
+msgstr "Εισαγωγή αριθμού"
+
+#: id:612
+msgid "Bits/Sample"
+msgstr "Bits/Sample"
+
+#: id:613
+msgid "Sample Frequency"
+msgstr "Συχνότητα δειγματοληψίας"
+
+#: id:620
+msgid "Audio CDs"
+msgstr "CD ήχου"
+
+#: id:621
+msgid "Encoder"
+msgstr "Κωδικοποιητής"
+
+#: id:622
+msgid "Quality"
+msgstr "Ποιότητα"
+
+#: id:623
+msgid "Bitrate"
+msgstr "Bitrate"
+
+#: id:624
+msgid "Include track number"
+msgstr "Συμπερίληψη αριθμού κομματιού"
+
+#: id:625
+msgid "All songs of"
+msgstr "Όλα τα τραγούδια"
+
+#: id:629
+msgctxt "Auto context with id 629"
+msgid "View mode"
+msgstr "Λειτουργία προβολής"
+
+#: id:630
+msgctxt "Auto context with id 630"
+msgid "Normal"
+msgstr "Φυσιολογικό"
+
+#: id:631
+msgid "Zoom"
+msgstr "Μεγέθυνση"
+
+#: id:632
+msgid "Stretch 4:3"
+msgstr "Επέκταση 4:3"
+
+#: id:633
+msgid "Wide Zoom"
+msgstr "Ευρεία μεγέθυνση"
+
+#: id:634
+msgid "Stretch 16:9"
+msgstr "Επέκταση 16:9"
+
+#: id:635
+msgid "Original Size"
+msgstr "Κανονικό μέγεθος"
+
+#: id:636
+msgctxt "Auto context with id 636"
+msgid "Custom"
+msgstr "Προσαρμογή"
+
+#: id:637
+msgid "Replay gain"
+msgstr "Ενίσχυση ήχου"
+
+#: id:638
+msgid "Replaygain volume adjustments"
+msgstr "Προσαρμογή έντασης ενίσχυσης ήχου"
+
+#: id:639
+msgid "Use track levels"
+msgstr "Σε επίπεδο κομματιού"
+
+#: id:640
+msgid "Use album levels"
+msgstr "Σε επίπεδο άλμπουμ"
+
+#: id:641
+msgid "PreAmp Level - Replay gained files"
+msgstr "Ένταση Προενισχυτή - Στα ήδη ενισχυμένα αρχεία"
+
+#: id:642
+msgid "PreAmp Level - Non replay gained files"
+msgstr "Ένταση Προενισχυτή - Στα μη ενισχυμένα αρχεία"
+
+#: id:643
+msgid "Avoid clipping on replay gained files"
+msgstr "Αποφυγή μείωσης της έντασης ενίσχυσης"
+
+#: id:644
+msgid "Crop black bars"
+msgstr "Αποκοπή μαύρων μπαρών"
+
+#: id:645
+msgid "Need to unpack a big file. Continue?"
+msgstr "Μεγάλο αρχείο προς αποσυμπίεση. Να συνεχίσει;"
+
+#: id:646
+msgid "Remove from library"
+msgstr "Αφαίρεση από τη συλλογή"
+
+#: id:647
+msgid "Export video library"
+msgstr "Εξαγωγή συλλογής βίντεο"
+
+#: id:648
+msgid "Import video library"
+msgstr "Εισαγωγή συλλογής βίντεο"
+
+#: id:649
+msgid "Importing"
+msgstr "Εισαγωγή"
+
+#: id:650
+msgid "Exporting"
+msgstr "Εξαγωγή"
+
+#: id:651
+msgid "Browse for library"
+msgstr "Αναζήτηση συλλογής"
+
+#: id:652
+msgid "Years"
+msgstr "Έτη"
+
+#: id:653
+msgid "Update library"
+msgstr "Ενημέρωση συλλογής"
+
+#: id:654
+msgid "Show debug info"
+msgstr "Επίδειξη σφαλμάτων"
+
+#: id:655
+msgid "Browse for executable"
+msgstr "Αναζήτηση εκτελέσιμου"
+
+#: id:656
+msgid "Browse for playlist"
+msgstr "Αναζήτηση λίστας αναπαραγωγής"
+
+#: id:657
+msgid "Browse for folder"
+msgstr "Αναζήτηση φακέλου"
+
+#: id:658
+msgid "Song information"
+msgstr "Πληροφορίες τραγουδιού"
+
+#: id:659
+msgid "Non-linear stretch"
+msgstr "Μη γραμμική παραμόρφωση"
+
+#: id:660
+msgid "Volume amplification"
+msgstr "Ενίσχυση έντασης"
+
+#: id:661
+msgid "Choose export folder"
+msgstr "Επιλογή φακέλου εξαγωγής"
+
+#: id:662
+msgid "This file is no longer available."
+msgstr "Αυτό το αρχείο δεν είναι πλέον διαθέσιμο."
+
+#: id:663
+msgid "Would you like to remove it from the library?"
+msgstr "Να αφαιρεθεί από τη συλλογή;"
+
+#: id:664
+msgid "Browse for Script"
+msgstr "Αναζήτηση Script"
+
+#: id:665
+msgid "Compression level"
+msgstr "Επίπεδο συμπίεσης"
+
+#: id:700
+msgid "Cleaning up library"
+msgstr "Εκκαθάριση συλλογής"
+
+#: id:701
+msgid "Removing old songs from the library"
+msgstr "Απομάκρυνση παλαιών τραγουδιών από τη συλλογή"
+
+#: id:702
+msgid "This path has been scanned before"
+msgstr "Η διαδρομή έχει σαρωθεί παλαιότερα"
+
+#: id:705
+msgctxt "Auto context with id 705"
+msgid "Network"
+msgstr "Δίκτυο"
+
+#: id:706
+msgid "- Server"
+msgstr "- Διακομιστής"
+
+#: id:708
+msgid "Use an HTTP proxy server to access the internet"
+msgstr "Χρήση διαμεσολαβητή HTTP για πρόσβαση στο Διαδίκτυο"
+
+#: id:711
+msgid "Internet Protocol (IP)"
+msgstr "Πρωτόκολλο Internet (IP)"
+
+#: id:712
+msgid "Invalid port specified. Value must be between 1 and 65535."
+msgstr "Ορίστηκε λάθος θύρα. Η τιμή πρέπει να είναι μεταξύ 1 και 65535."
+
+#: id:713
+msgid "HTTP proxy"
+msgstr "Διαμεσολαβητής HTTP"
+
+#: id:715
+msgid "- Assignment"
+msgstr "- Ανάθεση"
+
+#: id:716
+msgid "Automatic (DHCP)"
+msgstr "Αυτόματη (DHCP)"
+
+#: id:717
+msgid "Manual (Static)"
+msgstr "Χειροκίνητη (Στατική)"
+
+#: id:719
+msgid "- IP address"
+msgstr "- Διεύθυνση IP"
+
+#: id:720
+msgid "- Netmask"
+msgstr "- Μάσκα δικτύου"
+
+#: id:721
+msgid "- Default gateway"
+msgstr "- Προεπιλεγμένη πύλη"
+
+#: id:722
+msgid "- DNS server"
+msgstr "- Διακομιστής DNS"
+
+#: id:723
+msgid "Save & restart"
+msgstr "Αποθήκευση & επανεκκίνηση"
+
+#: id:724
+msgid "Invalid address specified. Value must be AAA.BBB.CCC.DDD"
+msgstr "Ορίστηκε λάθος διεύθυνση. Πρέπει να έχει τη μορφή AAA.BBB.CCC.DDD"
+
+#: id:725
+msgid "with numbers between 0 and 255."
+msgstr "με τιμές μεταξύ 0 και 255."
+
+#: id:726
+msgid "Changes not saved. Continue without saving?"
+msgstr "Οι αλλαγές δεν αποθηκεύτηκαν. Συνέχεια χωρίς αποθήκευση;"
+
+#: id:727
+msgid "Web server"
+msgstr "Διακομιστής Ιστού"
+
+#: id:728
+msgctxt "Auto context with id 728"
+msgid "FTP server"
+msgstr "Διακομιστής FTP"
+
+#: id:730
+msgid "- Port"
+msgstr "- Θύρα"
+
+#: id:732
+msgid "Save & apply"
+msgstr "Αποθήκευση & εφαρμογή"
+
+#: id:733
+msgid "- Password"
+msgstr "- Κωδικός πρόσβασης"
+
+#: id:734
+msgid "No pass"
+msgstr "Χωρίς κωδικό"
+
+#: id:735
+msgid "- Character set"
+msgstr "- Κωδικοποίηση χαρακτήρων"
+
+#: id:736
+msgid "- Style"
+msgstr "- Στυλ"
+
+#: id:737
+msgid "- Colour"
+msgstr "- Χρώμα"
+
+#: id:738
+msgctxt "Auto context with id 738"
+msgid "Normal"
+msgstr "Κανονικά"
+
+#: id:739
+msgid "Bold"
+msgstr "Έντονα"
+
+#: id:740
+msgid "Italics"
+msgstr "Πλάγια"
+
+#: id:741
+msgid "Bold italics"
+msgstr "Πλάγια έντονα"
+
+#: id:742
+msgctxt "Auto context with id 742"
+msgid "White"
+msgstr "Λευκό"
+
+#: id:743
+msgctxt "Auto context with id 743"
+msgid "Yellow"
+msgstr "Κίτρινο"
+
+#: id:744
+msgctxt "Auto context with id 744"
+msgid "Files"
+msgstr "Αρχεία"
+
+#: id:745
+msgid "No scanned information for this view"
+msgstr "Καμία πληροφορία για αυτήν την προβολή"
+
+#: id:746
+msgid "Please turn off library mode"
+msgstr "Απενεργοποιήστε τη λειτουργία συλλογής"
+
+#: id:747
+msgid "Error loading image"
+msgstr "Σφάλμα κατά τη φόρτωση της εικόνας"
+
+#: id:748
+msgid "Edit path"
+msgstr "Επεξεργασία διαδρομής"
+
+#: id:749
+msgid "Mirror image"
+msgstr "Kατοπτρική εικόνα"
+
+#: id:750
+msgid "Are you sure?"
+msgstr "Είστε σίγουρος;"
+
+#: id:751
+msgid "Removing source"
+msgstr "Απομάκρυνση πηγής"
+
+#: id:754
+msgid "Add program link"
+msgstr "Προσθήκη συνδέσμου εφαρμογής"
+
+#: id:755
+msgid "Edit program path"
+msgstr "Επεξεργασία διαδρομής εφαρμογής"
+
+#: id:756
+msgid "Edit program name"
+msgstr "Επεξεργασία ονόματος εφαρμογής"
+
+#: id:757
+msgid "Edit path depth"
+msgstr "Επεξεργασία βάθους διαδρομής"
+
+#: id:759
+msgid "View: Big list"
+msgstr "Προβολή: Μεγάλη λίστα"
+
+#: id:760
+msgctxt "Auto context with id 760"
+msgid "Yellow"
+msgstr "Κίτρινο"
+
+#: id:761
+msgctxt "Auto context with id 761"
+msgid "White"
+msgstr "Λευκό"
+
+#: id:762
+msgid "Blue"
+msgstr "Μπλε"
+
+#: id:763
+msgid "Bright green"
+msgstr "Έντονο πράσινο"
+
+#: id:764
+msgid "Yellow green"
+msgstr "Κιτρινοπράσινο"
+
+#: id:765
+msgid "Cyan"
+msgstr "Κυανό"
+
+#: id:766
+msgid "Light grey"
+msgstr "Ανοικτό γκρι"
+
+#: id:767
+msgid "Grey"
+msgstr "Γκρι"
+
+#: id:770
+msgid "Error %i: share not available"
+msgstr "Σφάλμα %i: ο κοινόχρηστος πόρος δεν είναι διαθέσιμος"
+
+#: id:772
+msgctxt "Auto context with id 772"
+msgid "Audio output"
+msgstr "Έξοδος ήχου"
+
+#: id:773
+msgid "Seeking"
+msgstr "Αναζήτηση"
+
+#: id:774
+msgid "Slideshow folder"
+msgstr "Φάκελος παρουσίασης διαφανειών"
+
+#: id:775
+msgid "Network interface"
+msgstr "Διασύνδεση δικτύου"
+
+#: id:776
+msgid "- Wireless network name (ESSID)"
+msgstr "- Όνομα ασύρματου δικτύου (ESSID)"
+
+#: id:777
+msgid "- Wireless password"
+msgstr "- Κωδικός πρόσβασης ασύρματου δικτύου"
+
+#: id:778
+msgid "- Wireless security"
+msgstr "- Ασφάλεια ασύρματου δικτύου"
+
+#: id:779
+msgid "Save and apply network interface settings"
+msgstr "Αποθήκευση και εφαρμογή των ρυθμίσεων διασύνδεσης"
+
+#: id:780
+msgid "No encryption"
+msgstr "Χωρίς κρυπτογράφηση"
+
+#: id:781
+msgid "WEP"
+msgstr "WEP"
+
+#: id:782
+msgid "WPA"
+msgstr "WPA"
+
+#: id:783
+msgid "WPA2"
+msgstr "WPA2"
+
+#: id:784
+msgid "Applying network interface settings. Please wait."
+msgstr "Εφαρμογή των ρυθμίσεων διασύνδεσης δικτύου. Παρακαλώ περιμένετε."
+
+#: id:785
+msgid "Network interface restarted successfully."
+msgstr "Επιτυχής επανεκκίνηση της διασύνδεσης δικτύου."
+
+#: id:786
+msgid "Network interface did not start successfully."
+msgstr "Δεν ήταν επιτυχής η εκκίνηση της διασύνδεσης δικτύου."
+
+#: id:787
+msgid "Interface disabled"
+msgstr "Απενεργοποίηση Διασύνδεσης"
+
+#: id:788
+msgid "Network interface disabled successfully."
+msgstr "Η Διασύνδεση δικτύου απενεργοποιήθηκε επιτυχώς."
+
+#: id:789
+msgid "Wireless network name (ESSID)"
+msgstr "Όνομα ασύρματου δικτύου (ESSID)"
+
+#: id:790
+msgid "Remote control"
+msgstr ""
+
+#: id:791
+msgid "Allow programs on this system to control XBMC"
+msgstr "Έγκριση σε προγράμματα του συστήματος να ελέγχουν το XBMC"
+
+#: id:792
+msgctxt "Auto context with id 792"
+msgid "Port"
+msgstr "Θύρα"
+
+#: id:793
+msgid "Port range"
+msgstr "Εύρος θυρών"
+
+#: id:794
+msgid "Allow programs on other systems to control XBMC"
+msgstr "Έγκριση σε προγράμματα άλλων συστημάτων να ελέγχουν το XBMC"
+
+#: id:795
+msgid "Initial repeat delay (ms)"
+msgstr "Αρχική καθυστέρηση (ms)"
+
+#: id:796
+msgid "Continuous repeat delay (ms)"
+msgstr "Συνεχής καθυστέρηση (ms)"
+
+#: id:797
+msgid "Maximum number of clients"
+msgstr "Μέγιστος αριθμός πελατών"
+
+#: id:798
+msgid "Internet access"
+msgstr "Πρόσβαση στο Διαδίκτυο"
+
+#: id:850
+msgid "Invalid port number entered"
+msgstr "Εισαγωγή μη έγκυρης τιμής θύρας"
+
+#: id:851
+msgid "Valid port range is 1-65535"
+msgstr "Το έγκυρο εύρος θυρών είναι 1-65535"
+
+#: id:852
+msgid "Valid port range is 1024-65535"
+msgstr "Το έγκυρο εύρος θυρών είναι 1024-65535"
+
+#: id:998
+msgid "Add Music..."
+msgstr "Προσθήκη Μουσικής..."
+
+#: id:999
+msgid "Add Videos..."
+msgstr "Προσθήκη Βίντεο..."
+
+#: id:1000
+msgid "- Preview"
+msgstr "- Προεπισκόπηση"
+
+#: id:1001
+msgid "Unable to connect"
+msgstr "Αδυναμία σύνδεσης"
+
+#: id:1002
+msgid "XBMC was unable to connect to the network location."
+msgstr "Το XBMC δεν μπόρεσε να συνδεθεί στο δίκτυο."
+
+#: id:1003
+msgid "This could be due to the network not being connected."
+msgstr "Αυτό μπορεί να συνέβη διότι το δίκτυο δεν είναι συνδεδεμένο."
+
+#: id:1004
+msgid "Would you like to add it anyway?"
+msgstr "Θέλετε παρ' όλα αυτά να το προσθέσετε;"
+
+#: id:1006
+msgctxt "Auto context with id 1006"
+msgid "IP address"
+msgstr "Διεύθυνση IP"
+
+#: id:1007
+msgid "Add network location"
+msgstr "Προσθήκη τοποθεσίας δικτύου"
+
+#: id:1008
+msgid "Protocol"
+msgstr "Πρωτόκολλο"
+
+#: id:1009
+msgid "Server address"
+msgstr "Διεύθυνση διακομιστή"
+
+#: id:1010
+msgid "Server name"
+msgstr "Όνομα διακομιστή"
+
+#: id:1011
+msgid "Remote path"
+msgstr "Απομακρυσμένη διαδρομή"
+
+#: id:1012
+msgid "Shared folder"
+msgstr "Κοινόχρηστος φάκελος"
+
+#: id:1013
+msgctxt "Auto context with id 1013"
+msgid "Port"
+msgstr "Θύρα"
+
+#: id:1014
+msgctxt "Auto context with id 1014"
+msgid "Username"
+msgstr "Όνομα χρήστη"
+
+#: id:1015
+msgid "Browse for network server"
+msgstr "Αναζήτηση δικτυακού διακομιστή"
+
+#: id:1016
+msgid "Enter the network address of the server"
+msgstr "Εισαγωγή της δικτυακής διεύθυνσης για το διακομιστή"
+
+#: id:1017
+msgid "Enter the path on the server"
+msgstr "Εισαγωγή της διαδρομής στο διακομιστή"
+
+#: id:1018
+msgid "Enter the port number"
+msgstr "Εισαγωγή του αριθμού θύρας"
+
+#: id:1019
+msgid "Enter the username"
+msgstr "Εισαγωγή του ονόματος χρήστη"
+
+#: id:1020
+msgid "Add %s source"
+msgstr "Προσθήκη πηγής %s"
+
+#: id:1021
+msgid "Enter the paths or browse for the media locations."
+msgstr "Εισαγωγή διαδρομών ή αναζήτηση τοποθεσιών πολυμέσων."
+
+#: id:1022
+msgid "Enter a name for this media Source."
+msgstr "Εισαγωγή ονόματος για την πηγή πολυμέσων."
+
+#: id:1023
+msgid "Browse for new share"
+msgstr "Αναζήτηση νέου κοινόχρηστου πόρου"
+
+#: id:1024
+msgid "Browse"
+msgstr "Αναζήτηση"
+
+#: id:1025
+msgid "Could not retrieve directory information."
+msgstr "Δεν ήταν δυνατόν να ανακτηθούν οι πληροφορίες καταλόγου."
+
+#: id:1026
+msgid "Add source"
+msgstr "Προσθήκη πηγής"
+
+#: id:1027
+msgid "Edit source"
+msgstr "Επεξεργασία πηγής"
+
+#: id:1028
+msgid "Edit %s source"
+msgstr "Επεξεργασία πηγής %s"
+
+#: id:1029
+msgid "Enter the new label"
+msgstr "Εισαγωγή νέας ετικέτας"
+
+#: id:1030
+msgid "Browse for image"
+msgstr "Αναζήτηση εικόνας"
+
+#: id:1031
+msgid "Browse for image folder"
+msgstr "Αναζήτηση φακέλου εικόνων"
+
+#: id:1032
+msgid "Add network location..."
+msgstr "Προσθήκη τοποθεσίας δικτύου..."
+
+#: id:1033
+msgid "Browse for file"
+msgstr "Αναζήτηση αρχείου"
+
+#: id:1034
+msgid "Submenu"
+msgstr "Υπομενού"
+
+#: id:1035
+msgid "Enable submenu buttons"
+msgstr "Ενεργοποίηση πλήκτρων υπομενού"
+
+#: id:1036
+msgid "Favourites"
+msgstr "Αγαπημένα"
+
+#: id:1037
+msgid "Video Add-ons"
+msgstr "Πρόσθετα Βίντεο"
+
+#: id:1038
+msgid "Music Add-ons"
+msgstr "Πρόσθετα Μουσικής"
+
+#: id:1039
+msgid "Picture Add-ons"
+msgstr "Πρόσθετα Εικόνας"
+
+#: id:1040
+msgid "Loading directory"
+msgstr "Φόρτωση φακέλου"
+
+#: id:1041
+msgid "Retrieved %i items"
+msgstr "Ανακτήθηκαν %i αντικείμενα"
+
+#: id:1042
+msgid "Retrieved %i of %i items"
+msgstr "Ανακτήθηκαν %i από τα %i αντικείμενα"
+
+#: id:1043
+msgid "Program Add-ons"
+msgstr "Πρόσθετες Εφαρμογές"
+
+#: id:1044
+msgid "Set plugin thumb"
+msgstr "Ορισμός μικρογραφίας plugin"
+
+#: id:1045
+msgid "Add-on settings"
+msgstr "Ρυθμίσεις πρόσθετου"
+
+#: id:1046
+msgid "Access points"
+msgstr "Σημεία πρόσβασης"
+
+#: id:1047
+msgid "Other..."
+msgstr "Άλλα..."
+
+#: id:1048
+msgid "- Username"
+msgstr "- Όνομα χρήστη"
+
+#: id:1049
+msgid "Script settings"
+msgstr "Ρυθμίσεις script"
+
+#: id:1050
+msgid "Singles"
+msgstr "Μεμονωμένα"
+
+#: id:1051
+msgid "Enter web address"
+msgstr "Εισαγωγή διεύθυνσης"
+
+#: id:1200
+msgid "SMB client"
+msgstr "Πελάτης SMB"
+
+#: id:1202
+msgid "Workgroup"
+msgstr "Ομάδα Εργασίας"
+
+#: id:1203
+msgid "Default username"
+msgstr "Προεπιλεγμένο όνομα χρήστη"
+
+#: id:1204
+msgid "Default password"
+msgstr "Προεπιλεγμένος κωδικός πρόσβασης"
+
+#: id:1207
+msgid "WINS server"
+msgstr "Διακομιστής WINS"
+
+#: id:1208
+msgid "Mount SMB shares"
+msgstr "Προσάρτηση κοινόχρηστων SMB"
+
+#: id:1210
+msgctxt "Auto context with id 1210"
+msgid "Remove"
+msgstr "Απομάκρυνση"
+
+#: id:1211
+msgctxt "Auto context with id 1211"
+msgid "Music"
+msgstr "Μουσική"
+
+#: id:1212
+msgctxt "Auto context with id 1212"
+msgid "Video"
+msgstr "Βίντεο"
+
+#: id:1213
+msgctxt "Auto context with id 1213"
+msgid "Pictures"
+msgstr "Εικόνες"
+
+#: id:1214
+msgctxt "Auto context with id 1214"
+msgid "Files"
+msgstr "Αρχεία"
+
+#: id:1215
+msgctxt "Auto context with id 1215"
+msgid "Music & video"
+msgstr "Μουσική & βίντεο"
+
+#: id:1216
+msgid "Music & pictures"
+msgstr "Μουσική & εικόνες"
+
+#: id:1217
+msgid "Music & files"
+msgstr "Μουσική & αρχεία"
+
+#: id:1218
+msgid "Video & pictures"
+msgstr "Βίντεο & εικόνες"
+
+#: id:1219
+msgid "Video & files"
+msgstr "Βίντεο & αρχεία"
+
+#: id:1220
+msgid "Pictures & files"
+msgstr "Εικόνες & αρχεία"
+
+#: id:1221
+msgid "Music & video & pictures"
+msgstr "Μουσική & βίντεο & εικόνες"
+
+#: id:1222
+msgid "Music & video & pictures & files"
+msgstr "Μουσική & βίντεο & εικόνες & αρχεία"
+
+#: id:1223
+msgctxt "Auto context with id 1223"
+msgid "Disabled"
+msgstr "Ανενεργό/ή"
+
+#: id:1226
+msgid "Files & music & video"
+msgstr "Αρχεία & μουσική & βίντεο"
+
+#: id:1227
+msgid "Files & pictures & music"
+msgstr "Αρχεία & εικόνες & μουσική"
+
+#: id:1228
+msgid "Files & pictures & video"
+msgstr "Αρχεία & εικόνες & βίντεο"
+
+#: id:1229
+msgid "Music & programs"
+msgstr "Μουσική & εφαρμογές"
+
+#: id:1230
+msgid "Video & programs"
+msgstr "Βίντεο & εφαρμογές"
+
+#: id:1231
+msgid "Pictures & programs"
+msgstr "Εικόνες & εφαρμογές"
+
+#: id:1232
+msgid "Music & video & pictures & programs"
+msgstr "Μουσική & βίντεο & εικόνες & εφαρμογές"
+
+#: id:1233
+msgid "Programs & video & music"
+msgstr "Εφαρμογές & βίντεο & μουσική"
+
+#: id:1234
+msgid "Programs & pictures & music"
+msgstr "Εφαρμογές & εικόνες & μουσική"
+
+#: id:1235
+msgid "Programs & pictures & video"
+msgstr "Εφαρμογές & εικόνες & βίντεο"
+
+#: id:1250
+msgid "Auto-detection"
+msgstr "Αυτόματος εντοπισμός"
+
+#: id:1251
+msgid "Auto-detect system"
+msgstr "Αυτόματος εντοπισμός συστήματος"
+
+#: id:1252
+msgid "Nickname"
+msgstr "Ψευδώνυμο"
+
+#: id:1254
+msgid "Ask to connect"
+msgstr "Επιβεβαίωση σύνδεσης"
+
+#: id:1255
+msgid "Send FTP user and password"
+msgstr "Αποστολή ονόματος και κωδικού πρόσβασης χρήστη (FTP)"
+
+#: id:1256
+msgid "Ping interval"
+msgstr "Χρονικό διάστημα ping"
+
+#: id:1257
+msgid "Would you like to connect to the auto-detected system?"
+msgstr "Επιθυμείτε να συνδεθείτε στο σύστημα που εντοπίστηκε;"
+
+#: id:1259
+msgid "Zeroconf"
+msgstr ""
+
+#: id:1260
+msgid "Announce these services to other systems via Zeroconf"
+msgstr "Αναγγελία αυτών των υπηρεσιών σε άλλα συστήματα μέσω του Zeroconf"
+
+#: id:1270
+msgid "Allow XBMC to receive AirPlay content"
+msgstr "Έγκριση στο XBMC να λαμβάνει περιεχόμενο AirPlay"
+
+#: id:1271
+msgid "Device name"
+msgstr "Όνομα συσκευής"
+
+#: id:1272
+msgid "- Use password protection"
+msgstr "- Χρήση προστασίας με κωδικό"
+
+#: id:1273
+msgid "AirPlay"
+msgstr ""
+
+#: id:1300
+msgid "Custom audio device"
+msgstr "Ειδική συσκευή ήχου"
+
+#: id:1301
+msgid "Custom passthrough device"
+msgstr "Ειδική συσκευή διέλευσης"
+
+#: id:1396
+msgid "Drifting"
+msgstr "Μετακινούμενο"
+
+#: id:1397
+msgid "and"
+msgstr "και"
+
+#: id:1398
+msgid "Freezing"
+msgstr "Παγωνιά"
+
+#: id:1399
+msgid "Late"
+msgstr "Το βράδυ"
+
+#: id:1400
+msgid "Isolated"
+msgstr "Τοπικά"
+
+#: id:1401
+msgid "Thundershowers"
+msgstr "Μπόρες (με κεραυνούς)"
+
+#: id:1402
+msgid "Thunder"
+msgstr "Κεραυνοί"
+
+#: id:1403
+msgctxt "Auto context with id 1403"
+msgid "Sun"
+msgstr "Ήλιος"
+
+#: id:1404
+msgid "Heavy"
+msgstr "Έντονη"
+
+#: id:1405
+msgid "in"
+msgstr "μέσα"
+
+#: id:1406
+msgid "the"
+msgstr "στο"
+
+#: id:1407
+msgid "Vicinity"
+msgstr "Εγγύτητα"
+
+#: id:1408
+msgid "Ice"
+msgstr "Πάγος"
+
+#: id:1409
+msgid "Crystals"
+msgstr "Κρύσταλλοι"
+
+#: id:1410
+msgid "Calm"
+msgstr "Άπνοια"
+
+#: id:1411
+msgid "with"
+msgstr "με"
+
+#: id:1412
+msgid "windy"
+msgstr "θυελλώδης"
+
+#: id:1413
+msgid "drizzle"
+msgstr "ασθενής βροχή"
+
+#: id:1414
+msgid "Thunderstorm"
+msgstr "Καταιγίδα"
+
+#: id:1415
+msgid "Drizzle"
+msgstr "Ασθενής βροχή"
+
+#: id:1416
+msgid "Foggy"
+msgstr "Ομιχλώδης"
+
+#: id:1417
+msgid "Grains"
+msgstr "Κόκκοι"
+
+#: id:1418
+msgid "T-Storms"
+msgstr "Καταιγίδες (με κεραυνούς)"
+
+#: id:1419
+msgid "T-Showers"
+msgstr "Μπόρες (με κεραυνούς)"
+
+#: id:1420
+msgid "Moderate"
+msgstr "Ήπια"
+
+#: id:1421
+msgid "Very High"
+msgstr "Πολύ υψηλή"
+
+#: id:1422
+msgid "Windy"
+msgstr "Θυελλώδης"
+
+#: id:1423
+msgid "Mist"
+msgstr "Υγρά αχλή"
+
+#: id:1450
+msgid "Put display to sleep when idle"
+msgstr "Απενεργοποίηση οθόνης κατά την αναμονή"
+
+#: id:2050
+msgid "Runtime"
+msgstr "Διάρκεια"
+
+#: id:2100
+msgid "Script failed! : %s"
+msgstr "Αποτυχία script! : %s"
+
+#: id:2101
+msgid "Newer version needed - See log"
+msgstr "Απαιτείται νεώτερη έκδοση - Δείτε το αρχείο καταγραφής"
+
+#: id:4501
+msgid "Enable LCD/VFD"
+msgstr "Ενεργοποίηση LCD/VFD"
+
+#: id:10000
+msgid "Home"
+msgstr "Αρχική τοποθεσία"
+
+#: id:10001
+msgctxt "Auto context with id 10001"
+msgid "Programs"
+msgstr "Εφαρμογές"
+
+#: id:10002
+msgctxt "Auto context with id 10002"
+msgid "Pictures"
+msgstr "Εικόνες"
+
+#: id:10003
+msgctxt "Auto context with id 10003"
+msgid "File manager"
+msgstr "Διαχείριση αρχείων"
+
+#: id:10004
+msgctxt "Auto context with id 10004"
+msgid "Settings"
+msgstr "Ρυθμίσεις"
+
+#: id:10005
+msgctxt "Auto context with id 10005"
+msgid "Music"
+msgstr "Μουσική"
+
+#: id:10006
+msgctxt "Auto context with id 10006"
+msgid "Videos"
+msgstr "Βίντεο"
+
+#: id:10007
+msgid "System information"
+msgstr "Πληροφορίες συστήματος"
+
+#: id:10008
+msgid "Settings - General"
+msgstr "Ρυθμίσεις - Γενικά"
+
+#: id:10009
+msgid "Settings - Screen"
+msgstr "Ρυθμίσεις - Οθόνη"
+
+#: id:10010
+msgid "Settings - Appearance - GUI Calibration"
+msgstr "Ρυθμίσεις - Εμφάνιση - Βαθμονόμηση γραφικού περιβάλλοντος (GUI)"
+
+#: id:10011
+msgid "Settings - Videos - Screen Calibration"
+msgstr "Ρυθμίσεις - Βίντεο - Βαθμονόμηση Οθόνης"
+
+#: id:10012
+msgid "Settings - Pictures"
+msgstr "Ρυθμίσεις - Εικόνες"
+
+#: id:10013
+msgid "Settings - Programs"
+msgstr "Ρυθμίσεις - Εφαρμογές"
+
+#: id:10014
+msgid "Settings - Weather"
+msgstr "Ρυθμίσεις - Καιρός"
+
+#: id:10015
+msgid "Settings - Music"
+msgstr "Ρυθμίσεις - Μουσική"
+
+#: id:10016
+msgid "Settings - System"
+msgstr "Ρυθμίσεις - Σύστημα"
+
+#: id:10017
+msgid "Settings - Videos"
+msgstr "Ρυθμίσεις - Βίντεο"
+
+#: id:10018
+msgid "Settings - Network"
+msgstr "Ρυθμίσεις - Δίκτυο"
+
+#: id:10019
+msgid "Settings - Appearance"
+msgstr "Ρυθμίσεις - Εξατομίκευση"
+
+#: id:10020
+msgctxt "Auto context with id 10020"
+msgid "Scripts"
+msgstr "Scripts"
+
+#: id:10021
+msgid "Web Browser"
+msgstr "Περιηγητής ιστού"
+
+#: id:10025
+msgctxt "Auto context with id 10025"
+msgid "Videos"
+msgstr "Βίντεο"
+
+#: id:10028
+msgid "Videos/Playlist"
+msgstr "Βίντεο/Λίστα Αναπαραγωγής"
+
+#: id:10029
+msgctxt "Auto context with id 10029"
+msgid "Login screen"
+msgstr "Οθόνη σύνδεσης"
+
+#: id:10034
+msgid "Settings - Profiles"
+msgstr "Ρυθμίσεις - Προφίλ"
+
+#: id:10040
+msgid "Addon browser"
+msgstr "Περιηγητής Πρόσθετων"
+
+#: id:10100
+msgid "Yes/No dialog"
+msgstr "Παράθυρο Ναι/Όχι"
+
+#: id:10101
+msgid "Progress dialog"
+msgstr "Παράθυρο διαδικασίας"
+
+#: id:10210
+msgid "Looking for subtitles..."
+msgstr "Αναζήτηση για υπότιτλους..."
+
+#: id:10211
+msgid "Looking for or caching subtitles..."
+msgstr "Προσωρινή αποθήκευση υποτίτλων..."
+
+#: id:10212
+msgid "terminating"
+msgstr "τερματισμός"
+
+#: id:10213
+msgid "buffering"
+msgstr "αποθήκευση"
+
+#: id:10214
+msgid "Opening stream"
+msgstr "Άνοιγμα ροής"
+
+#: id:10500
+msgid "Music/Playlist"
+msgstr "Μουσική/Λίστα αναπαραγωγής"
+
+#: id:10501
+msgid "Music/Files"
+msgstr "Μουσική/Αρχεία"
+
+#: id:10502
+msgid "Music/Library"
+msgstr "Μουσική/Συλλογή"
+
+#: id:10503
+msgid "Playlist editor"
+msgstr "Επεξεργασία λίστας αναπαραγωγής"
+
+#: id:10504
+msgid "Top 100 songs"
+msgstr "100 κορυφαία τραγούδια"
+
+#: id:10505
+msgid "Top 100 albums"
+msgstr "100 κορυφαία άλμπουμ"
+
+#: id:10506
+msgctxt "Auto context with id 10506"
+msgid "Programs"
+msgstr "Εφαρμογές"
+
+#: id:10507
+msgid "Configuration"
+msgstr "Ρυθμίσεις"
+
+#: id:10508
+msgid "Weather forecast"
+msgstr "Πρόγνωση καιρού"
+
+#: id:10509
+msgid "Network gaming"
+msgstr "Δικτυακό παιχνίδι"
+
+#: id:10510
+msgid "Extensions"
+msgstr "Επεκτάσεις"
+
+#: id:10511
+msgctxt "Auto context with id 10511"
+msgid "System info"
+msgstr "Πληροφορίες συστήματος"
+
+#: id:10516
+msgid "Music - Library"
+msgstr "Μουσική - Συλλογή"
+
+#: id:10517
+msgid "Now Playing - Music"
+msgstr "Τώρα Εκτελείται - Μουσική"
+
+#: id:10522
+msgid "Now Playing - Videos"
+msgstr "Τώρα Εκτελείται - Βίντεο"
+
+#: id:10523
+msgid "Album info"
+msgstr "Πληροφορίες άλμπουμ"
+
+#: id:10524
+msgid "Movie info"
+msgstr "Πληροφορίες ταινίας"
+
+#: id:12000
+msgid "Select dialog"
+msgstr "Παράθυρο επιλογής"
+
+#: id:12001
+msgid "Music/Info"
+msgstr "Μουσική/Πληροφορίες"
+
+#: id:12002
+msgid "Dialog OK"
+msgstr "Παράθυρο 'Επιλογή'"
+
+#: id:12003
+msgid "Videos/Info"
+msgstr "Βίντεο/Πληροφορίες"
+
+#: id:12004
+msgid "Scripts/Info"
+msgstr "Scripts/Πληροφορίες"
+
+#: id:12005
+msgid "Fullscreen video"
+msgstr "Βίντεο πλήρους οθόνης"
+
+#: id:12006
+msgid "Audio visualization"
+msgstr "Μουσική οπτικοποίηση"
+
+#: id:12008
+msgid "File stacking dialog"
+msgstr "Παράθυρο στοιβαγμένου αρχείου"
+
+#: id:12009
+msgid "Rebuild index..."
+msgstr "Ανακατασκευή περιεχομένων..."
+
+#: id:12010
+msgid "Return to music window"
+msgstr "Επιστροφή στη μουσική"
+
+#: id:12011
+msgid "Return to videos window"
+msgstr "Επιστροφή στα βίντεο"
+
+#: id:12021
+msgid "Start from beginning"
+msgstr "Εκκίνηση από την αρχή"
+
+#: id:12022
+msgid "Resume from %s"
+msgstr "Συνέχεια από %s"
+
+#: id:12310
+msgid "0"
+msgstr "0"
+
+#: id:12311
+msgid "1"
+msgstr "1"
+
+#: id:12312
+msgid "2"
+msgstr "2"
+
+#: id:12313
+msgid "3"
+msgstr "3"
+
+#: id:12314
+msgid "4"
+msgstr "4"
+
+#: id:12315
+msgid "5"
+msgstr "5"
+
+#: id:12316
+msgid "6"
+msgstr "6"
+
+#: id:12317
+msgid "7"
+msgstr "7"
+
+#: id:12318
+msgid "8"
+msgstr "8"
+
+#: id:12319
+msgid "9"
+msgstr "9"
+
+#: id:12320
+msgid "c"
+msgstr "c"
+
+#: id:12321
+msgid "Ok"
+msgstr "Επιλογή"
+
+#: id:12322
+msgid "*"
+msgstr "*"
+
+#: id:12325
+msgid "Locked! Enter code..."
+msgstr "Κλειδώθηκε! Εισαγωγή κωδικού..."
+
+#: id:12326
+msgid "Enter password"
+msgstr "Εισαγωγή κωδικού πρόσβασης"
+
+#: id:12327
+msgid "Enter master code"
+msgstr "Εισαγωγή κεντρικού κωδικού"
+
+#: id:12328
+msgid "Enter unlock code"
+msgstr "Εισάγετε κωδικό ξεκλειδώματος"
+
+#: id:12329
+msgid "or press C to cancel"
+msgstr "ή πιέστε C για ακύρωση"
+
+#: id:12330
+msgid "Enter gamepad button combo and"
+msgstr "Εισάγετε συνδυασμό πλήκτρων (combo) και"
+
+#: id:12331
+msgid "press OK, or Back to cancel"
+msgstr "πιέστε 'Επιλογή', ή 'Επιστροφή' για ακύρωση"
+
+#: id:12332
+msgid "Set lock"
+msgstr "Ορισμός κλειδώματος"
+
+#: id:12333
+msgid "Unlock"
+msgstr "Ξεκλείδωμα"
+
+#: id:12334
+msgid "Reset lock"
+msgstr "Επανατοποθέτηση κλειδώματος"
+
+#: id:12335
+msgid "Remove lock"
+msgstr "Απομάκρυνση κλειδώματος"
+
+#: id:12337
+msgid "Numeric password"
+msgstr "Αριθμητικός κωδικός πρόσβασης"
+
+#: id:12338
+msgid "Gamepad button combo"
+msgstr "Συνδυασμός πλήκτρων (combo) του μοχλού"
+
+#: id:12339
+msgid "Full-text password"
+msgstr "Κωδικός πρόσβασης πλήρους κειμένου"
+
+#: id:12340
+msgid "Enter new password"
+msgstr "Εισαγωγή νέου κωδικού πρόσβασης"
+
+#: id:12341
+msgid "Re-Enter new password"
+msgstr "Επανεισαγωγή νέου κωδικού πρόσβασης"
+
+#: id:12342
+msgid "Incorrect password,"
+msgstr "Λάθος κωδικός πρόσβασης,"
+
+#: id:12343
+msgid "retries left"
+msgstr "δοκιμές έμειναν"
+
+#: id:12344
+msgid "Passwords entered did not match."
+msgstr "Ο κωδικός πρόσβασης δεν ταιριάζει."
+
+#: id:12345
+msgid "Access denied"
+msgstr "Δεν επιτρέπεται η πρόσβαση"
+
+#: id:12346
+msgid "Password retry limit exceeded."
+msgstr "Οι δοκιμές εισαγωγής κωδικού πρόσβασης εξαντλήθηκαν."
+
+#: id:12347
+msgid "The system will now shut off."
+msgstr "Το σύστημα τώρα θα απενεργοποιηθεί."
+
+#: id:12348
+msgid "Item locked"
+msgstr "Το αντικείμενο κλειδώθηκε"
+
+#: id:12353
+msgid "Reactivate lock"
+msgstr "Επανενεργοποίηση κλειδώματος"
+
+#: id:12356
+msgid "Change lock"
+msgstr "Αλλαγή κλειδώματος"
+
+#: id:12357
+msgid "Source lock"
+msgstr "Πηγαίο κλείδωμα"
+
+#: id:12358
+msgid "Password entry was blank. Try again."
+msgstr "Το πεδίο του κωδικού πρόσβασης ήταν κενό. Ξαναπροσπαθήστε."
+
+#: id:12360
+msgid "Master lock"
+msgstr "Κεντρικό κλείδωμα"
+
+#: id:12362
+msgid "Shutdown system if Master Lock retries exceeded"
+msgstr "Απενεργοποίηση συστήματος όταν εξαντληθούν οι προσπάθειες εισαγωγής"
+
+#: id:12367
+msgid "Master code is not valid"
+msgstr "Ο κεντρικός κωδικός δεν είναι έγκυρος"
+
+#: id:12368
+msgid "Please enter a valid master code"
+msgstr "Παρακαλώ εισάγετε έναν έγκυρο κεντρικό κωδικό"
+
+#: id:12373
+msgid "Settings & file manager"
+msgstr "Ρυθμίσεις & διαχείριση αρχείων"
+
+#: id:12376
+msgid "Set as default for all movies"
+msgstr "Ορισμός ως προεπιλογή για όλες τις ταινίες"
+
+#: id:12377
+msgid "This will reset any previously saved values"
+msgstr "Διαγράφει όλες τις προηγούμενες αποθηκευμένες τιμές"
+
+#: id:12378
+msgid "Amount of time to display each image"
+msgstr "Χρονικό διάστημα προβολής κάθε εικόνας"
+
+#: id:12379
+msgid "Use pan and zoom effects"
+msgstr "Εφέ προσαρμογής αναλογιών σήματος (pan & zoom)"
+
+#: id:12383
+msgid "12 hour clock"
+msgstr "Ρολόι 12 ωρών"
+
+#: id:12384
+msgid "24 hour clock"
+msgstr "Ρολόι 24 ωρών"
+
+#: id:12385
+msgid "Day/Month"
+msgstr "Μέρα/Μήνας"
+
+#: id:12386
+msgid "Month/Day"
+msgstr "Μήνας/Μέρα"
+
+#: id:12390
+msgid "System uptime"
+msgstr "Χρόνος λειτουργίας συστήματος"
+
+#: id:12391
+msgid "Minutes"
+msgstr "Λεπτά"
+
+#: id:12392
+msgid "Hours"
+msgstr "Ώρες"
+
+#: id:12393
+msgid "Days"
+msgstr "Μέρες"
+
+#: id:12394
+msgid "Total uptime"
+msgstr "Συνολικός χρόνος λειτουργίας"
+
+#: id:12395
+msgid "Battery level"
+msgstr "Επίπεδο φόρτισης"
+
+#: id:12600
+msgctxt "Auto context with id 12600"
+msgid "Weather"
+msgstr "Ο καιρός"
+
+#: id:12900
+msgctxt "Auto context with id 12900"
+msgid "Screensaver"
+msgstr "Προφύλαξη οθόνης"
+
+#: id:12901
+msgid "Fullscreen OSD"
+msgstr "Απεικονίσεις πλήρους οθόνης (OSD)"
+
+#: id:13000
+msgid "System"
+msgstr "Σύστημα"
+
+#: id:13001
+msgid "Immediate HD spindown"
+msgstr "Άμεση ελάττωση περιστροφής (Spindown)"
+
+#: id:13002
+msgid "Video only"
+msgstr "Βίντεο μόνο"
+
+#: id:13003
+msgid "- Delay"
+msgstr "- Καθυστέρηση"
+
+#: id:13004
+msgid "- Minimum file duration"
+msgstr "- Ελάχιστη διάρκεια αρχείου"
+
+#: id:13005
+msgid "Shutdown"
+msgstr "Παύση λειτουργίας"
+
+#: id:13008
+msgid "Shutdown function"
+msgstr "Λειτουργία τερματισμού"
+
+#: id:13009
+msgid "Quit"
+msgstr "Έξοδος"
+
+#: id:13010
+msgid "Hibernate"
+msgstr "Αδρανοποίηση"
+
+#: id:13011
+msgid "Suspend"
+msgstr "Αναστολή"
+
+#: id:13012
+msgid "Exit"
+msgstr "Έξοδος"
+
+#: id:13013
+msgid "Reboot"
+msgstr "Επανεκκίνηση Συστήματος"
+
+#: id:13014
+msgid "Minimize"
+msgstr "Ελαχιστοποίηση"
+
+#: id:13015
+msgid "Power button action"
+msgstr "Ενέργεια πλήκτρου λειτουργίας"
+
+#: id:13016
+msgid "Power off System"
+msgstr "Απενεργοποίηση συστήματος"
+
+#: id:13020
+msgid "Is another session active, perhaps over ssh?"
+msgstr "Είναι ενεργή άλλη συνεδρία, ίσως μέσω ssh;"
+
+#: id:13021
+msgid "Mounted removable harddrive"
+msgstr "Προσαρτήθηκε αφαιρούμενος δίσκος"
+
+#: id:13022
+msgid "Unsafe device removal"
+msgstr "Μη ασφαλής αφαίρεση συσκευής"
+
+#: id:13023
+msgid "Successfully removed device"
+msgstr "Η συσκευή αφαιρέθηκε επιτυχώς"
+
+#: id:13024
+msgid "Joystick plugged"
+msgstr "Συνδέθηκε χειριστήριο"
+
+#: id:13025
+msgid "Joystick unplugged"
+msgstr "Αποσυνδέθηκε χειριστήριο"
+
+#: id:13050
+msgid "Running low on battery"
+msgstr "Έχει αποφορτιστεί η μπαταρία"
+
+#: id:13100
+msgid "Flicker filter"
+msgstr "Φίλτρο Flicker (τρεμόπαιγμα οθόνης)"
+
+#: id:13101
+msgid "Let driver choose (requires restart)"
+msgstr "Αφήστε τον οδηγό να επιλέξει (απαιτεί επανεκκίνηση)"
+
+#: id:13105
+msgid "Vertical blank sync"
+msgstr "Κατακόρυφος χρονισμός"
+
+#: id:13106
+msgctxt "Auto context with id 13106"
+msgid "Disabled"
+msgstr "Ανενεργός"
+
+#: id:13107
+msgid "Enabled during video playback"
+msgstr "Ενεργός κατά την αναπαραγωγή βίντεο"
+
+#: id:13108
+msgctxt "Auto context with id 13108"
+msgid "Always enabled"
+msgstr "Πάντα ενεργός"
+
+#: id:13109
+msgid "Test & apply resolution"
+msgstr "Δοκιμή & εφαρμογή ανάλυσης"
+
+#: id:13110
+msgid "Save resolution?"
+msgstr "Αποθήκευση ανάλυσης;"
+
+#: id:13111
+msgid "Would you like to keep this resolution?"
+msgstr "Θέλετε να διατηρήσετε αυτή την ανάλυση;"
+
+#: id:13112
+msgid "High quality upscaling"
+msgstr "Υψηλή ποιότητα ανακλιμακοθέτησης"
+
+#: id:13113
+msgctxt "Auto context with id 13113"
+msgid "Disabled"
+msgstr "Ανενεργό"
+
+#: id:13114
+msgid "Enabled for SD content"
+msgstr "Ενεργό για περιεχόμενο SD"
+
+#: id:13115
+msgctxt "Auto context with id 13115"
+msgid "Always enabled"
+msgstr "Πάντα ενεργό"
+
+#: id:13116
+msgid "Upscaling method"
+msgstr "Μέθοδος Upscaling"
+
+#: id:13117
+msgctxt "Auto context with id 13117"
+msgid "Bicubic"
+msgstr "Bicubic"
+
+#: id:13118
+msgid "Lanczos"
+msgstr "Lanczos"
+
+#: id:13119
+msgid "Sinc"
+msgstr "Sinc"
+
+#: id:13120
+msgctxt "Auto context with id 13120"
+msgid "VDPAU"
+msgstr "VDPAU"
+
+#: id:13121
+msgid "VDPAU HQ Upscaling level"
+msgstr "VDPAU HQ Upscaling επίπεδο"
+
+#: id:13122
+msgid "VDPAU Studio level color conversion"
+msgstr "VDPAU Μετατροπή χρώματος επιπέδου στούντιο"
+
+#: id:13130
+msgid "Blank other displays"
+msgstr "Κενό σε άλλες οθόνες"
+
+#: id:13131
+msgctxt "Auto context with id 13131"
+msgid "Disabled"
+msgstr "Ανενεργή"
+
+#: id:13132
+msgid "Blank displays"
+msgstr "Κενές οθόνες"
+
+#: id:13140
+msgid "Active connections detected!"
+msgstr "Έχουν ανιχνευτεί ενεργές συνδέσεις!"
+
+#: id:13141
+msgid "If you proceed, you might not be able to control XBMC"
+msgstr "Αν συνεχίσετε, μπορεί να χάσετε τον έλεγχο του XBMC."
+
+#: id:13142
+msgid "any longer. Are you sure you want to stop the Event server?"
+msgstr "Να διακοπεί η λειτουργία του απομακρυσμένου διακομιστή;"
+
+#: id:13144
+msgid "Change Apple Remote mode?"
+msgstr "Αλλαγή λειτουργίας συσκευής Apple Remote;"
+
+#: id:13145
+msgid "If you are currently using the Apple Remote to control"
+msgstr "Εάν χρησιμοποιείτε τώρα τη συσκευή Apple Remote για να"
+
+#: id:13146
+msgid "XBMC, changing this setting might affect your ability"
+msgstr "ελέγχετε το XBMC, η αλλαγή αυτής της ρύθμισης θα επηρεάσει"
+
+#: id:13147
+msgid "to continue controlling it. Do you want to proceed?"
+msgstr "την ικανότητα ελέγχου του. Θέλετε να συνεχίσετε;"
+
+#: id:13159
+msgid "Subnet mask"
+msgstr "Μάσκα Υποδικτύου"
+
+#: id:13160
+msgid "Gateway"
+msgstr "Πύλη"
+
+#: id:13161
+msgid "Primary DNS"
+msgstr "Πρωτεύον DNS"
+
+#: id:13162
+msgid "Initialize failed"
+msgstr "Η αναγνώριση απέτυχε"
+
+#: id:13170
+msgctxt "Auto context with id 13170"
+msgid "Never"
+msgstr "Ποτέ"
+
+#: id:13171
+msgid "Immediately"
+msgstr "Αμέσως"
+
+#: id:13172
+msgid "After %i secs"
+msgstr "Μετά από %i δευτ."
+
+#: id:13173
+msgid "HDD install date:"
+msgstr "Ημερομηνία εγκατάστασης:"
+
+#: id:13174
+msgid "HDD power cycle count:"
+msgstr "Πλήθος περιστροφών σε ισχύ:"
+
+#: id:13200
+msgid "Profiles"
+msgstr "Προφίλ"
+
+#: id:13201
+msgid "Delete profile '%s'?"
+msgstr "Διαγραφή προφίλ '%s';"
+
+#: id:13204
+msgid "Last loaded profile:"
+msgstr "Προηγούμενο προφίλ:"
+
+#: id:13205
+msgid "Unknown"
+msgstr "Άγνωστο"
+
+#: id:13206
+msgid "Overwrite"
+msgstr "Αντικατάσταση"
+
+#: id:13208
+msgid "Alarm clock"
+msgstr "Ξυπνητήρι"
+
+#: id:13209
+msgid "Alarm clock interval (in minutes)"
+msgstr "Διάρκεια κουδουνισμού (σε λεπτά)"
+
+#: id:13210
+msgid "Started, alarm in %im"
+msgstr "Εκκίνηση ξυπνητηριού σε %im"
+
+#: id:13211
+msgid "Alarm!"
+msgstr "Συναγερμός!"
+
+#: id:13212
+msgid "Canceled with %im%is left"
+msgstr "Ακυρώθηκε με %im%is να απομένουν"
+
+#: id:13213
+msgid "%2.0fm"
+msgstr "%2.0fm"
+
+#: id:13214
+msgid "%2.0fs"
+msgstr "%2.0fs"
+
+#: id:13249
+msgid "Search for subtitles in RARs"
+msgstr "Αναζήτηση υποτίτλων σε RAR"
+
+#: id:13250
+msgid "Browse for subtitle..."
+msgstr "Αναζήτηση για υπότιτλο..."
+
+#: id:13251
+msgid "Move item"
+msgstr "Μετακίνηση αντικειμένου"
+
+#: id:13252
+msgid "Move item here"
+msgstr "Μετακίνηση αντικειμένου εδώ"
+
+#: id:13253
+msgid "Cancel move"
+msgstr "Ακύρωση μετακίνησης"
+
+#: id:13270
+msgid "Hardware:"
+msgstr "Υλικό:"
+
+#: id:13271
+msgid "CPU Usage:"
+msgstr "Χρήση CPU:"
+
+#: id:13274
+msgid "Connected, but no DNS is available."
+msgstr "Συνδέθηκε, αλλά δεν υπάρχει διαθέσιμη DNS."
+
+#: id:13275
+msgid "Hard Disk"
+msgstr "Σκληρός δίσκος"
+
+#: id:13276
+msgid "DVD-ROM"
+msgstr "DVD-ROM"
+
+#: id:13277
+msgctxt "Auto context with id 13277"
+msgid "Storage"
+msgstr "Μέσα αποθήκευσης"
+
+#: id:13278
+msgctxt "Auto context with id 13278"
+msgid "Default"
+msgstr "Προεπιλογή"
+
+#: id:13279
+msgctxt "Auto context with id 13279"
+msgid "Network"
+msgstr "Δίκτυο"
+
+#: id:13280
+msgctxt "Auto context with id 13280"
+msgid "Video"
+msgstr "Βίντεο"
+
+#: id:13281
+msgid "Hardware"
+msgstr "Υλικό"
+
+#: id:13283
+msgid "Operating system:"
+msgstr "Λειτουργικό σύστημα:"
+
+#: id:13284
+msgid "CPU speed:"
+msgstr "Ταχύτητα CPU:"
+
+#: id:13286
+msgid "Video encoder:"
+msgstr "Κωδικοποιητής βίντεο:"
+
+#: id:13287
+msgid "Screen resolution:"
+msgstr "Ανάλυση οθόνης:"
+
+#: id:13292
+msgid "A/V cable:"
+msgstr "Καλώδιο A/V:"
+
+#: id:13294
+msgid "DVD region:"
+msgstr "Περιοχή DVD:"
+
+#: id:13295
+msgid "Internet:"
+msgstr "Διαδίκτυο:"
+
+#: id:13296
+msgctxt "Auto context with id 13296"
+msgid "Connected"
+msgstr "Συνδέθηκε"
+
+#: id:13297
+msgid "Not connected. Check network settings."
+msgstr "Δε συνδέθηκε. Ελέγξτε τις ρυθμίσεις δικτύου."
+
+#: id:13299
+msgid "Target temperature"
+msgstr "Επιθυμητή θερμοκρασία"
+
+#: id:13300
+msgid "Fan speed"
+msgstr "Ταχύτητα ανεμιστήρα"
+
+#: id:13301
+msgid "Auto temperature control"
+msgstr "Αυτόματος έλεγχος θερμοκρασίας"
+
+#: id:13302
+msgid "Fan speed override"
+msgstr "Παράκαμψη ταχύτητας ανεμιστήρα"
+
+#: id:13303
+msgid "- Fonts"
+msgstr "- Γραμματοσειρές"
+
+#: id:13304
+msgid "Enable flipping bi-directional strings"
+msgstr "Ενεργοποίηση αμφίδρομης κατεύθυνσης"
+
+#: id:13305
+msgid "Show RSS news feeds"
+msgstr "Εμφάνιση ροής τίτλων ειδήσεων (RSS)"
+
+#: id:13306
+msgid "Show parent folder items"
+msgstr "Εμφάνιση περιεχομένων αρχικού φακέλου"
+
+#: id:13307
+msgid "Track naming template"
+msgstr "Πρότυπο ονομασίας κομματιών"
+
+#: id:13308
+msgid "Do you wish to reboot your system"
+msgstr "Επιθυμείτε επανεκκίνηση του συστήματος"
+
+#: id:13309
+msgid "instead of just XBMC?"
+msgstr "και όχι μόνο του XBMC;"
+
+#: id:13310
+msgid "Zoom effect"
+msgstr "Εφέ μεγέθυνσης"
+
+#: id:13311
+msgid "Float effect"
+msgstr "Εφέ κίνησης"
+
+#: id:13312
+msgid "Black bar reduction"
+msgstr "Ελαχιστοποίηση μαύρης μπάρας"
+
+#: id:13313
+msgid "Restart"
+msgstr "Επανεκκίνηση"
+
+#: id:13314
+msgid "Crossfade between songs"
+msgstr "Βαθμιαία εξασθένιση μεταξύ των τραγουδιών"
+
+#: id:13315
+msgid "Regenerate thumbnails"
+msgstr "Επαναδημιουργία μικρογραφιών"
+
+#: id:13316
+msgid "Recursive thumbnails"
+msgstr "Μικρογραφίες και σε υποφακέλους"
+
+#: id:13317
+msgid "View slideshow"
+msgstr "Παρουσίαση διαφανειών"
+
+#: id:13318
+msgid "Recursive slideshow"
+msgstr "Παρουσίαση διαφανειών και των υποφακέλων"
+
+#: id:13319
+msgid "Randomize"
+msgstr "Τυχαία διάταξη"
+
+#: id:13320
+msgid "Stereo"
+msgstr "Στερεοφωνικά"
+
+#: id:13321
+msgid "Left only"
+msgstr "Αριστερό μόνο"
+
+#: id:13322
+msgid "Right only"
+msgstr "Δεξί μόνο"
+
+#: id:13323
+msgid "Enable karaoke support"
+msgstr "Ενεργοποίηση υποστήριξης karaoke"
+
+#: id:13324
+msgid "Background transparency"
+msgstr "Διαφάνεια υποβάθρου"
+
+#: id:13325
+msgid "Foreground transparency"
+msgstr "Διαφάνεια προσκήνιου"
+
+#: id:13326
+msgid "A/V delay"
+msgstr "A/V καθυστέρηση"
+
+#: id:13327
+msgid "Karaoke"
+msgstr "Karaoke"
+
+#: id:13328
+msgid "%s not found"
+msgstr "%s δεν βρέθηκε"
+
+#: id:13329
+msgid "Error opening %s"
+msgstr "Σφάλμα κατά το άνοιγμα %s"
+
+#: id:13330
+msgid "Unable to load %s"
+msgstr "Αδυναμία φόρτωσης %s"
+
+#: id:13331
+msgid "Error: Out of memory"
+msgstr "Σφάλμα: Έλλειψη μνήμης"
+
+#: id:13332
+msgid "Move up"
+msgstr "Μετακίνηση πάνω"
+
+#: id:13333
+msgid "Move down"
+msgstr "Μετακίνηση κάτω"
+
+#: id:13334
+msgid "Edit label"
+msgstr "Επεξεργασία ετικέτας"
+
+#: id:13335
+msgid "Make default"
+msgstr "Εξ' ορισμού επιλογή"
+
+#: id:13336
+msgid "Remove button"
+msgstr "Απαλοιφή πλήκτρου"
+
+#: id:13340
+msgid "Leave as is"
+msgstr "Παραμένει ως έχει"
+
+#: id:13341
+msgid "Green"
+msgstr "Πράσινο"
+
+#: id:13342
+msgid "Orange"
+msgstr "Πορτοκαλί"
+
+#: id:13343
+msgid "Red"
+msgstr "Κόκκινο"
+
+#: id:13344
+msgid "Cycle"
+msgstr "Κύκλος"
+
+#: id:13345
+msgid "Switch LED off on playback"
+msgstr "Απενεργοποίηση λυχνίας (LED) κατά την αναπαραγωγή"
+
+#: id:13346
+msgctxt "Auto context with id 13346"
+msgid "Movie information"
+msgstr "Πληροφορίες ταινίας"
+
+#: id:13347
+msgid "Queue item"
+msgstr "Κομμάτι σε αναμονή"
+
+#: id:13348
+msgid "Search IMDb..."
+msgstr "Αναζήτηση στο IMDb..."
+
+#: id:13349
+msgid "Scan for new content"
+msgstr "Έρευνα για νέο περιεχόμενο"
+
+#: id:13350
+msgid "Now playing..."
+msgstr "Τώρα εκτελείται..."
+
+#: id:13351
+msgctxt "Auto context with id 13351"
+msgid "Album information"
+msgstr "Πληροφορίες άλμπουμ"
+
+#: id:13352
+msgid "Scan item to library"
+msgstr "Ανίχνευση αντικειμένου στη συλλογή"
+
+#: id:13353
+msgid "Stop scanning"
+msgstr "Διακοπή αναζήτησης"
+
+#: id:13354
+msgctxt "Auto context with id 13354"
+msgid "Render method"
+msgstr "Μέθοδος απόδοσης"
+
+#: id:13355
+msgid "Low quality pixel shader"
+msgstr "Χαμηλής ποιότητας σκίαση pixel"
+
+#: id:13356
+msgid "Hardware overlays"
+msgstr "Επικαλύψεις υλικού"
+
+#: id:13357
+msgid "High quality pixel shader"
+msgstr "Υψηλής ποιότητας σκίαση pixel"
+
+#: id:13358
+msgid "Play item"
+msgstr "Αναπαραγωγή αντικειμένου"
+
+#: id:13359
+msgid "Set artist thumb"
+msgstr "Ορισμός μικρογραφίας καλλιτέχνη"
+
+#: id:13360
+msgid "Automatically generate thumbnails"
+msgstr "Αυτόματη δημιουργία μικρογραφιών"
+
+#: id:13361
+msgid "Enable voice"
+msgstr "Ενεργοποίηση φωνής"
+
+#: id:13375
+msgid "Enable device"
+msgstr "Ενεργοποίηση συσκευής"
+
+#: id:13376
+msgid "Volume"
+msgstr "Ένταση"
+
+#: id:13377
+msgid "Default view mode"
+msgstr "Προεπιλεγμένη κατάσταση προβολής"
+
+#: id:13378
+msgid "Default brightness"
+msgstr "Προεπιλεγμένη φωτεινότητα"
+
+#: id:13379
+msgid "Default contrast"
+msgstr "Προεπιλεγμένη αντίθεση"
+
+#: id:13380
+msgid "Default gamma"
+msgstr "Προεπιλεγμένος συντελεστής γάμμα"
+
+#: id:13381
+msgid "Resume video"
+msgstr "Συνέχιση βίντεο"
+
+#: id:13382
+msgid "Voice mask - Port 1"
+msgstr "Μάσκα φωνής - Θύρα 1"
+
+#: id:13383
+msgid "Voice mask - Port 2"
+msgstr "Μάσκα φωνής - Θύρα 2"
+
+#: id:13384
+msgid "Voice mask - Port 3"
+msgstr "Μάσκα φωνής - Θύρα 3"
+
+#: id:13385
+msgid "Voice mask - Port 4"
+msgstr "Μάσκα φωνής - Θύρα 4"
+
+#: id:13386
+msgid "Use time based seeking"
+msgstr "Αναζήτηση βάσει χρόνου"
+
+#: id:13387
+msgid "Track naming template - right"
+msgstr "Πρότυπο ονομασίας κομματιού (δεξιά πλευρά)"
+
+#: id:13388
+msgid "Preset"
+msgstr "Προκαθορισμένο"
+
+#: id:13389
+msgid "There are no presets available\nfor this visualization"
+msgstr "Δεν υπάρχουν διαθέσιμα προκαθορισμένα\nγι' αυτή την οπτικοποίηση"
+
+#: id:13390
+msgid "There are no settings available\nfor this visualization"
+msgstr "Δεν υπάρχουν διαθέσιμες ρυθμίσεις\nγι' αυτή την οπτικοποίηση"
+
+#: id:13391
+msgid "Eject/Load"
+msgstr "Εξαγωγή/Εισαγωγή"
+
+#: id:13392
+msgid "Use visualization if playing audio"
+msgstr "Χρήση οπτικοποιήσεων κατά την αναπαραγωγή μουσικής"
+
+#: id:13393
+msgid "Calculate size"
+msgstr "Υπολόγισε το μέγεθος"
+
+#: id:13394
+msgid "Calculating folder size"
+msgstr "Υπολογισμός μεγέθους φακέλου"
+
+#: id:13395
+msgid "Video settings"
+msgstr "Ρυθμίσεις βίντεο"
+
+#: id:13396
+msgid "Audio and subtitle settings"
+msgstr "Ρυθμίσεις ήχου και υποτίτλων"
+
+#: id:13397
+msgid "Enable subtitles"
+msgstr "Ενεργοποίηση υποτίτλων"
+
+#: id:13398
+msgctxt "Auto context with id 13398"
+msgid "Shortcuts"
+msgstr "Συντομεύσεις"
+
+#: id:13399
+msgid "Ignore articles when sorting (e.g. \"the\")"
+msgstr "Αγνόησε τα άρθρα κατά την ταξινόμηση (π.χ. το \"The\")"
+
+#: id:13400
+msgid "Crossfade between songs on the same album"
+msgstr "Βαθμιαία εξασθένιση μεταξύ τραγουδιών του ίδιου άλμπουμ"
+
+#: id:13401
+msgid "Browse for %s"
+msgstr "Αναζήτηση για %s"
+
+#: id:13402
+msgid "Show track position"
+msgstr "Εμφάνιση της θέσης του κομματιού"
+
+#: id:13403
+msgid "Clear default"
+msgstr "Απαλοιφή προεπιλογών"
+
+#: id:13404
+msgid "Resume"
+msgstr "Συνέχεια"
+
+#: id:13405
+msgid "Get thumb"
+msgstr "Λήψη μικρογραφίας"
+
+#: id:13406
+msgid "Picture information"
+msgstr "Πληροφορίες εικόνας"
+
+#: id:13407
+msgid "%s presets"
+msgstr "%s προκαθορισμένα"
+
+#: id:13408
+msgid "(IMDb user rating)"
+msgstr "(Αξιολόγηση IMDb)"
+
+#: id:13409
+msgid "Top 250"
+msgstr "250 κορυφαία"
+
+#: id:13410
+msgid "Tune in on Last.fm"
+msgstr "Συντονισμός στο Last.fm"
+
+#: id:13411
+msgid "Minimum fan speed"
+msgstr "Ελάχιστη ταχύτητα ανεμιστήρα"
+
+#: id:13412
+msgid "Play from here"
+msgstr "Αναπαραγωγή από εδώ"
+
+#: id:13413
+msgid "Downloading"
+msgstr "Λήψη"
+
+#: id:13414
+msgid "Include artists who appear only on compilations"
+msgstr "Συμπερίληψη καλλιτεχνών που εμφανίζονται μόνο σε συνθέσεις"
+
+#: id:13415
+msgctxt "Auto context with id 13415"
+msgid "Render method"
+msgstr "Μέθοδος απόδοσης"
+
+#: id:13416
+msgid "Auto detect"
+msgstr "Αυτόματη ανίχνευση"
+
+#: id:13417
+msgid "Basic shaders (ARB)"
+msgstr "Στοιχειώδεις σκιαστές (ARB)"
+
+#: id:13418
+msgid "Advanced shaders (GLSL)"
+msgstr "Προηγμένοι σκιαστές (GLSL)"
+
+#: id:13419
+msgid "Software"
+msgstr "Λογισμικό"
+
+#: id:13420
+msgid "Remove safely"
+msgstr "Ασφαλής κατάργηση"
+
+#: id:13421
+msgctxt "Auto context with id 13421"
+msgid "VDPAU"
+msgstr "VDPAU"
+
+#: id:13422
+msgid "Start slideshow here"
+msgstr "Παρουσίαση διαφανειών από εδώ"
+
+#: id:13423
+msgid "Remember for this path"
+msgstr "Απομνημόνευση για αυτή τη διαδρομή"
+
+#: id:13424
+msgid "Use pixel buffer objects"
+msgstr "Χρήση αντικειμένων προσωρινής μνήμης pixel"
+
+#: id:13425
+msgid "Allow hardware acceleration (VDPAU)"
+msgstr "Έγκριση επιτάχυνσης υλικού (VDPAU)"
+
+#: id:13426
+msgid "Allow hardware acceleration (VAAPI)"
+msgstr "Έγκριση επιτάχυνσης υλικού (VAAPI)"
+
+#: id:13427
+msgid "Allow hardware acceleration (DXVA2)"
+msgstr "Έγκριση επιτάχυνσης υλικού (DXVA2)"
+
+#: id:13428
+msgid "Allow hardware acceleration (CrystalHD)"
+msgstr "Έγκριση επιτάχυνσης υλικού (CrystalHD)"
+
+#: id:13429
+msgid "Allow hardware acceleration (VDADecoder)"
+msgstr "Έγκριση επιτάχυνσης υλικού (VDADecoder)"
+
+#: id:13430
+msgid "Allow hardware acceleration (OpenMax)"
+msgstr "Έγκριση επιτάχυνσης υλικού (OpenMax)"
+
+#: id:13431
+msgid "Pixel Shaders"
+msgstr "Σκιάσεις Pixel"
+
+#: id:13432
+msgid "Allow hardware acceleration (VideoToolbox)"
+msgstr "Έγκριση επιτάχυνσης υλικού (VideoToolbox)"
+
+#: id:13500
+msgid "A/V sync method"
+msgstr "Μέθοδος συγχρονισμού A/V"
+
+#: id:13501
+msgid "Audio clock"
+msgstr "Χρονισμός ήχου"
+
+#: id:13502
+msgid "Video clock (Drop/Dupe audio)"
+msgstr "Χρονισµός βίντεο (εις βάρος του ήχου)"
+
+#: id:13503
+msgid "Video clock (Resample audio)"
+msgstr "Χρονισμός βίντεο (εκ νέου δειγματοληψία ήχου)"
+
+#: id:13504
+msgid "Maximum resample amount (%)"
+msgstr "Μέγιστο ποσοστό επανάληψης δειγματοληψίας (%)"
+
+#: id:13505
+msgid "Resample quality"
+msgstr "Ποιότητα επανάληψης δειγματοληψίας"
+
+#: id:13506
+msgid "Low(fast)"
+msgstr "Χαμηλή (γρήγορη)"
+
+#: id:13507
+msgctxt "Auto context with id 13507"
+msgid "Medium"
+msgstr "Μεσαία"
+
+#: id:13508
+msgctxt "Auto context with id 13508"
+msgid "High"
+msgstr "Υψηλή"
+
+#: id:13509
+msgid "Really high(slow!)"
+msgstr "Πραγματικά υψηλή (αργή!)"
+
+#: id:13510
+msgid "Sync playback to display"
+msgstr "Συγχρονισμός αναπαραγωγής ήχου με οθόνη"
+
+#: id:13550
+msgid "Pause during refresh rate change"
+msgstr "Παύση κατά την αλλαγή του ρυθμού ανανέωσης"
+
+#: id:13551
+msgctxt "Auto context with id 13551"
+msgid "Off"
+msgstr "Ανενεργό"
+
+#: id:13552
+msgid "%.1f Second"
+msgstr "%.1f Δευτερόλεπτο"
+
+#: id:13553
+msgid "%.1f Seconds"
+msgstr "%.1f Δευτερόλεπτα"
+
+#: id:13600
+msgid "Apple remote"
+msgstr "Apple Remote"
+
+#: id:13602
+msgid "Allow start of XBMC using the remote"
+msgstr "Έγκριση έναρξης του XBMC μέσω του χειριστηρίου"
+
+#: id:13603
+msgid "Sequence delay time"
+msgstr "Χρόνος καθυστέρησης ακολουθίας"
+
+#: id:13610
+msgctxt "Auto context with id 13610"
+msgid "Disabled"
+msgstr "Ανενεργή"
+
+#: id:13611
+msgctxt "Auto context with id 13611"
+msgid "Standard"
+msgstr "Τυπική"
+
+#: id:13612
+msgid "Universal Remote"
+msgstr "Τηλεχειριστήριο γενικής χρήσης"
+
+#: id:13613
+msgid "Multi Remote (Harmony)"
+msgstr "Τηλεχειριστήριο Multi (Harmony)"
+
+#: id:13620
+msgid "Apple Remote Error"
+msgstr "Σφάλμα συσκευής Apple Remote"
+
+#: id:13621
+msgid "Apple Remote support could be enabled."
+msgstr "Αδυναμία υποστήριξης συσκευής Apple Remote."
+
+#: id:14000
+msgid "Stack"
+msgstr "Στοίβαγμα"
+
+#: id:14001
+msgid "Unstack"
+msgstr "Σκόρπισμα"
+
+#: id:14003
+msgid "Downloading playlist file..."
+msgstr "Λήψη αρχείου λίστας αναπαραγωγής..."
+
+#: id:14004
+msgid "Downloading streams list..."
+msgstr "Λήψη λίστας ροής πολυμέσων..."
+
+#: id:14005
+msgid "Parsing streams list..."
+msgstr "Ανάλυση λίστας ροής πολυμέσων..."
+
+#: id:14006
+msgid "Downloading streams list failed"
+msgstr "Αποτυχία λήψης λίστας ροής πολυμέσων"
+
+#: id:14007
+msgid "Downloading playlist file failed"
+msgstr "Αποτυχία λήψης αρχείου λίστας αναπαραγωγής"
+
+#: id:14009
+msgid "Games directory"
+msgstr "Κατάλογος παιχνιδιών"
+
+#: id:14010
+msgid "Auto switch to thumbs based on"
+msgstr "Αυτόματη εναλλαγή σε μικρογραφίες βάσει"
+
+#: id:14011
+msgid "Enable auto switching to thumbs view"
+msgstr "Ενεργοποίηση αυτόματης εναλλαγής στην προβολή μικρογραφιών"
+
+#: id:14012
+msgid "- Use large icons"
+msgstr "- Χρήση μεγάλων εικονιδίων"
+
+#: id:14013
+msgid "- Switch based on"
+msgstr "- Εναλλαγή βάσει"
+
+#: id:14014
+msgid "- Percentage"
+msgstr "- Ποσοστό"
+
+#: id:14015
+msgid "No files and at least one thumb"
+msgstr "Καθόλου αρχεία και τουλάχιστον μία μικρογραφία"
+
+#: id:14016
+msgid "At least one file and thumb"
+msgstr "Τουλάχιστον ένα αρχείο και μία μικρογραφία"
+
+#: id:14017
+msgid "Percentage of thumbs"
+msgstr "Ποσοστό μικρογραφιών"
+
+#: id:14018
+msgid "View options"
+msgstr "Επιλογές προβολής"
+
+#: id:14019
+msgid "Change area code 1"
+msgstr "Αλλαγή κωδικού 1ης περιοχής"
+
+#: id:14020
+msgid "Change area code 2"
+msgstr "Αλλαγή κωδικού 2ης περιοχής"
+
+#: id:14021
+msgid "Change area code 3"
+msgstr "Αλλαγή κωδικού 3ης περιοχής"
+
+#: id:14022
+msgctxt "Auto context with id 14022"
+msgid "Library"
+msgstr "Συλλογή"
+
+#: id:14023
+msgid "No TV"
+msgstr "Χωρίς τηλεόραση"
+
+#: id:14024
+msgid "Enter the nearest large town"
+msgstr "Εισαγωγή της κοντινότερης μεγάλης πόλης"
+
+#: id:14025
+msgid "Video/Audio/DVD cache - Harddisk"
+msgstr "Συνολική λανθάνουσα μνήμη - Σκληρός δίσκος"
+
+#: id:14026
+msgid "Video cache - DVD-ROM"
+msgstr "Λανθάνουσα μνήμη βίντεο - DVD-ROM"
+
+#: id:14027
+msgctxt "Auto context with id 14027"
+msgid "- Local Network"
+msgstr "- Τοπικό δίκτυο"
+
+#: id:14028
+msgctxt "Auto context with id 14028"
+msgid "- Internet"
+msgstr "- Διαδίκτυο"
+
+#: id:14030
+msgid "Audio cache - DVD-ROM"
+msgstr "Λανθάνουσα μνήμη ήχου - DVD-ROM"
+
+#: id:14031
+msgctxt "Auto context with id 14031"
+msgid "- Local Network"
+msgstr "- Τοπικό δίκτυο"
+
+#: id:14032
+msgctxt "Auto context with id 14032"
+msgid "- Internet"
+msgstr "- Διαδίκτυο"
+
+#: id:14034
+msgid "DVD cache - DVD-ROM"
+msgstr "Λανθάνουσα μνήμη DVD - DVD-ROM"
+
+#: id:14035
+msgctxt "Auto context with id 14035"
+msgid "- Local Network"
+msgstr "- Τοπικό δίκτυο"
+
+#: id:14036
+msgctxt "Auto context with id 14036"
+msgid "Services"
+msgstr "Υπηρεσίες"
+
+#: id:14038
+msgid "Network settings changed"
+msgstr "Οι ρυθμίσεις του δικτύου άλλαξαν"
+
+#: id:14039
+msgid "XBMC requires to restart to change your"
+msgstr "Το XBMC πρέπει να επανεκκινηθεί για να αλλάξουν"
+
+#: id:14040
+msgid "network setup. Would you like to restart now?"
+msgstr "οι ρυθμίσεις δικτύου. Να γίνει επανεκκίνηση;"
+
+#: id:14041
+msgid "Internet connection bandwidth limitation"
+msgstr "Σύνδεση Διαδικτύου με περιορισμένη ταχύτητα"
+
+#: id:14043
+msgid "- Shutdown while playing"
+msgstr "- Τερματισμός κατά την αναπαραγωγή"
+
+#: id:14044
+msgid "%i min"
+msgstr "%i λεπτ."
+
+#: id:14045
+msgid "%i sec"
+msgstr "%i δευτ."
+
+#: id:14046
+msgid "%i ms"
+msgstr "%i ms"
+
+#: id:14047
+msgid "%i %%"
+msgstr "%i %%"
+
+#: id:14048
+msgid "%i kbps"
+msgstr "%i kbps"
+
+#: id:14049
+msgid "%i kb"
+msgstr "%i kb"
+
+#: id:14050
+msgid "%i.0 dB"
+msgstr "%i.0 dB"
+
+#: id:14051
+msgid "Time format"
+msgstr "Μορφή Ώρας"
+
+#: id:14052
+msgid "Date format"
+msgstr "Μορφή Ημ/νίας"
+
+#: id:14053
+msgid "GUI filters"
+msgstr "Φίλτρα γραφικού περιβάλλοντος (GUI)"
+
+#: id:14055
+msgid "Use background scanning"
+msgstr "Σάρωση στο παρασκήνιο"
+
+#: id:14056
+msgid "Stop scan"
+msgstr "Διακοπή σάρωσης"
+
+#: id:14057
+msgid "Not possible while scanning for media info"
+msgstr "Δεν είναι εφικτό κατά τη σάρωση πληροφοριών πολυμέσων"
+
+#: id:14058
+msgid "Film grain effect"
+msgstr "Εφέ Film Grain"
+
+#: id:14059
+msgid "Search for thumbnails on remote shares"
+msgstr "Έρευνα στους κοινόχρηστους πόρους για μικρογραφίες"
+
+#: id:14060
+msgid "Unknown type cache - Internet"
+msgstr "Άγνωστος τύπος λανθάνουσας μνήμης - Διαδίκτυο"
+
+#: id:14061
+msgctxt "Auto context with id 14061"
+msgid "Auto"
+msgstr "Αυτόματο/η"
+
+#: id:14062
+msgid "Enter username for"
+msgstr "Εισάγετε όνομα χρήστη για"
+
+#: id:14063
+msgid "Date & time"
+msgstr "Ημερομηνία & ώρα"
+
+#: id:14064
+msgid "Set date"
+msgstr "Ορισμός ημ/νίας"
+
+#: id:14065
+msgid "Set time"
+msgstr "Ορισμός ώρας"
+
+#: id:14066
+msgid "Enter the time in 24 hour HH:MM format"
+msgstr "Εισάγετε την ώρα σε 24ωρη μορφή (ΩΩ:ΛΛ)"
+
+#: id:14067
+msgid "Enter the date in DD/MM/YYYY format"
+msgstr "Εισάγετε την ημ/νία σε μορφή ΗΗ/MM/ΕΤΟΣ"
+
+#: id:14068
+msgid "Enter the IP address"
+msgstr "Εισάγετε την διεύθυνση ΙP"
+
+#: id:14069
+msgid "Apply these settings now?"
+msgstr "Εφαρμογή αυτών των ρυθμίσεων τώρα;"
+
+#: id:14070
+msgid "Apply changes now"
+msgstr "Εφαρμογή ρυθμίσεων τώρα"
+
+#: id:14071
+msgid "Allow file renaming and deletion"
+msgstr "Επιτρεπτή η μετονομασία και η διαγραφή αρχείων"
+
+#: id:14074
+msgid "Set timezone"
+msgstr "Ορισμός ζώνης ώρας"
+
+#: id:14075
+msgid "Use daylight saving time"
+msgstr "Ενεργοποίηση θερινής ώρας"
+
+#: id:14076
+msgid "Add to favourites"
+msgstr "Προσθήκη στα αγαπημένα"
+
+#: id:14077
+msgid "Remove from favourites"
+msgstr "Απομάκρυνση από τα αγαπημένα"
+
+#: id:14078
+msgctxt "Auto context with id 14078"
+msgid "- Colours"
+msgstr "- Χρώματα"
+
+#: id:14079
+msgid "Timezone country"
+msgstr "Ζώνη ώρας χώρας"
+
+#: id:14080
+msgid "Timezone"
+msgstr "Ζώνη ώρας"
+
+#: id:14081
+msgid "File lists"
+msgstr "Λίστες αρχείων"
+
+#: id:14082
+msgid "Show EXIF picture information"
+msgstr "Εμφάνιση πληροφοριών εικόνας (EXIF)"
+
+#: id:14083
+msgid "Use a fullscreen window rather than true fullscreen"
+msgstr "Χρήση του μεγιστοποιημένου παραθύρου αντί της πλήρους οθόνης"
+
+#: id:14084
+msgid "Queue songs on selection"
+msgstr "Επιλεγμένα τραγούδια στη λίστα αναμονής"
+
+#: id:14086
+msgid "Playback"
+msgstr "Αναπαραγωγή"
+
+#: id:14087
+msgid "DVDs"
+msgstr "DVD"
+
+#: id:14088
+msgid "Play DVDs automatically"
+msgstr "Αυτόματη αναπαραγωγή DVD"
+
+#: id:14089
+msgid "Font to use for text subtitles"
+msgstr "Χρήση γραμματοσειράς στους υπότιτλους"
+
+#: id:14090
+msgid "International"
+msgstr "Διεθνοποίηση"
+
+#: id:14091
+msgid "Character set"
+msgstr "Κωδικοποίηση χαρακτήρων"
+
+#: id:14092
+msgid "Debugging"
+msgstr "Εντοπισμός σφαλμάτων"
+
+#: id:14093
+msgid "Security"
+msgstr "Ασφάλεια"
+
+#: id:14094
+msgid "Input devices"
+msgstr "Συσκευές εισόδου"
+
+#: id:14095
+msgid "Power saving"
+msgstr "Εξοικονόμηση ενέργειας"
+
+#: id:14096
+msgid "Rip"
+msgstr ""
+
+#: id:14097
+msgid "Audio CD Insert Action"
+msgstr ""
+
+#: id:14098
+msgctxt "Auto context with id 14098"
+msgid "Play"
+msgstr ""
+
+#: id:14099
+msgid "Eject disc when CD ripping is complete"
+msgstr ""
+
+#: id:15015
+msgctxt "Auto context with id 15015"
+msgid "Remove"
+msgstr "Απομάκρυνση"
+
+#: id:15016
+msgid "Games"
+msgstr "Παιχνίδια"
+
+#: id:15019
+msgid "Add"
+msgstr "Προσθήκη"
+
+#: id:15052
+msgid "Password"
+msgstr "Κωδικός πρόσβασης"
+
+#: id:15100
+msgctxt "Auto context with id 15100"
+msgid "Library"
+msgstr "Συλλογή"
+
+#: id:15101
+msgid "Database"
+msgstr "Βάση δεδομένων"
+
+#: id:15102
+msgid "* All albums"
+msgstr "* Όλα τα άλμπουμ"
+
+#: id:15103
+msgid "* All artists"
+msgstr "* Όλοι οι καλλιτέχνες"
+
+#: id:15104
+msgid "* All songs"
+msgstr "* Όλα τα τραγούδια"
+
+#: id:15105
+msgid "* All genres"
+msgstr "* Όλα τα είδη"
+
+#: id:15107
+msgid "Buffering..."
+msgstr "Aποθήκευση..."
+
+#: id:15108
+msgid "Navigation sounds"
+msgstr "Ήχοι πλοήγησης"
+
+#: id:15109
+msgid "Skin default"
+msgstr "Προεπιλογή κελύφους"
+
+#: id:15111
+msgid "- Theme"
+msgstr "- Θέμα"
+
+#: id:15112
+msgid "Default theme"
+msgstr "Προεπιλεγμένο Θέμα"
+
+#: id:15200
+msgid "Last.fm"
+msgstr "Last.fm"
+
+#: id:15201
+msgid "Submit songs to Last.fm"
+msgstr "Αποστολή τραγουδιών στο Last.fm"
+
+#: id:15202
+msgid "Last.fm username"
+msgstr "Όνομα χρήστη Last.fm"
+
+#: id:15203
+msgid "Last.fm password"
+msgstr "Κωδικός πρόσβασης Last.fm"
+
+#: id:15204
+msgid "Unable to handshake: sleeping..."
+msgstr "Αδύνατη η χειραψία: σε αδράνεια..."
+
+#: id:15205
+msgid "Please update XBMC"
+msgstr "Παρακαλώ αναβαθμίστε το XBMC"
+
+#: id:15206
+msgid "Bad authorization: Check username and password"
+msgstr "Απέτυχε η εξακρίβωση: Ελέγξτε το όνομα χρήστη και τον κωδικό πρόσβασης"
+
+#: id:15207
+msgctxt "Auto context with id 15207"
+msgid "Connected"
+msgstr "Συνδεμένο"
+
+#: id:15208
+msgid "Not connected"
+msgstr "Αποσυνδεμένο"
+
+#: id:15209
+msgid "Submit interval %i"
+msgstr "Διάστημα αποστολής %i"
+
+#: id:15210
+msgid "Cached %i songs"
+msgstr "%i τραγούδια στη λανθάνουσα μνήμη"
+
+#: id:15211
+msgid "Submitting..."
+msgstr "Αποστολή..."
+
+#: id:15212
+msgid "Submitting in %i secs"
+msgstr "Αποστολή σε %i δευτ."
+
+#: id:15213
+msgid "Play using..."
+msgstr "Άνοιγμα με..."
+
+#: id:15214
+msgid "Use smoothed A/V synchronization"
+msgstr "Χρήση συγχρονισμού Smoothed A/V"
+
+#: id:15215
+msgid "Hide file names in thumbs view"
+msgstr "Απόκρυψη ονομάτων αρχείων στην προβολή μικρογραφιών"
+
+#: id:15216
+msgid "Play in party mode"
+msgstr "Εκτέλεση σε Party Mode"
+
+#: id:15217
+msgid "Submit songs to Libre.fm"
+msgstr "Αποστολή τραγουδιών στο Libre.fm"
+
+#: id:15218
+msgid "Libre.fm username"
+msgstr "Όνομα χρήστη Libre.fm"
+
+#: id:15219
+msgid "Libre.fm password"
+msgstr "Κωδικός πρόσβασης Libre.fm"
+
+#: id:15220
+msgid "Libre.fm"
+msgstr "Libre.fm"
+
+#: id:15221
+msgid "Song submission"
+msgstr "Υποβολή τραγουδιού"
+
+#: id:15250
+msgid "Submit Last.fm radio to Last.fm"
+msgstr "Αποστολή Last.fm radio στο Last.fm"
+
+#: id:15251
+msgid "Connecting to Last.fm..."
+msgstr "Σύνδεση με Last.fm..."
+
+#: id:15252
+msgid "Selecting station..."
+msgstr "Επιλογή σταθμού..."
+
+#: id:15253
+msgid "Search similar artists..."
+msgstr "Αναζήτηση παρόμοιων καλλιτεχνών..."
+
+#: id:15254
+msgid "Search similar tags..."
+msgstr "Αναζήτηση παρόμοιων ετικετών..."
+
+#: id:15255
+msgid "Your profile (%name%)"
+msgstr "Το προφίλ σας (%name%)"
+
+#: id:15256
+msgid "Overall top tags"
+msgstr "Γενικά κορυφαίες ετικέτες"
+
+#: id:15257
+msgid "Top artists for tag %name%"
+msgstr "Κορυφαίοι καλλιτέχνες για την ετικέτα %name%"
+
+#: id:15258
+msgid "Top albums for tag %name%"
+msgstr "Κορυφαία άλμπουμ για την ετικέτα %name%"
+
+#: id:15259
+msgid "Top tracks for tag %name%"
+msgstr "Κορυφαία κομμάτια για την ετικέτα %name%"
+
+#: id:15260
+msgid "Listen to tag %name% Last.fm radio"
+msgstr "Ακρόαση της ετικέτας %name% στο Last.fm radio"
+
+#: id:15261
+msgid "Similar artists as %name%"
+msgstr "Παρόμοιοι καλλιτέχνες όπως ο %name%"
+
+#: id:15262
+msgid "Top %name% albums"
+msgstr "Κορυφαία άλμπουμ %name%"
+
+#: id:15263
+msgid "Top %name% tracks"
+msgstr "Κορυφαία κομμάτια %name%"
+
+#: id:15264
+msgid "Top %name% tags"
+msgstr "Κορυφαίες ετικέτες %name%"
+
+#: id:15265
+msgid "Biggest fans of %name%"
+msgstr "Οι μεγαλύτεροι θαυμαστές του %name%"
+
+#: id:15266
+msgid "Listen to %name% fans Last.fm radio"
+msgstr "Ακρόαση θαυμαστών του %name% στο Last.fm radio"
+
+#: id:15267
+msgid "Listen to %name% similar artists Last.fm radio"
+msgstr "Ακρόαση καλλιτεχνών παρόμοιων με τον %name% στο Last.fm radio"
+
+#: id:15268
+msgid "Top artists for user %name%"
+msgstr "Οι καλύτεροι καλλιτέχνες του χρήστη %name%"
+
+#: id:15269
+msgid "Top albums for user %name%"
+msgstr "Τα καλύτερα άλμπουμ του χρήστη %name%"
+
+#: id:15270
+msgid "Top tracks for user %name%"
+msgstr "Τα καλύτερα κομμάτια του χρήστη %name%"
+
+#: id:15271
+msgid "Friends of user %name%"
+msgstr "Φίλοι του χρήστη %name%"
+
+#: id:15272
+msgid "Neighbours of user %name%"
+msgstr "Γείτονες του χρήστη %name%"
+
+#: id:15273
+msgid "Weekly artist chart for %name%"
+msgstr "Εβδομαδιαίο chart του καλλιτέχνη %name%"
+
+#: id:15274
+msgid "Weekly album chart for %name%"
+msgstr "Εβδομαδιαίο chart του άλμπουμ %name%"
+
+#: id:15275
+msgid "Weekly track chart for %name%"
+msgstr "Εβδομαδιαίο chart του κομματιού %name%"
+
+#: id:15276
+msgid "Listen to %name%'s neighbours Last.fm radio"
+msgstr "Ακρόαση του Last.fm radio των γειτόνων του %name%"
+
+#: id:15277
+msgid "Listen to %name%'s personal Last.fm radio"
+msgstr "Ακρόαση του προσωπικού Last.fm radio του %name%"
+
+#: id:15278
+msgid "Listen to %name%'s mix Last.fm radio"
+msgstr "Ακρόαση της μίξης Last.fm radio του %name%"
+
+#: id:15279
+msgid "Retrieving list from Last.fm..."
+msgstr "Ανάκτηση λίστας από Last.fm..."
+
+#: id:15280
+msgid "Can't retrieve list from Last.fm..."
+msgstr "Αδύνατη η ανάκτηση λίστας από Last.fm..."
+
+#: id:15281
+msgid "Enter an artist name to find related ones"
+msgstr "Εισάγετε ένα όνομα καλλιτέχνη για να βρείτε παρόμοια"
+
+#: id:15282
+msgid "Enter a tag name to find similar ones"
+msgstr "Εισάγετε μία ετικέτα για να βρείτε παρόμοιες"
+
+#: id:15283
+msgid "Tracks recently listened by %name%"
+msgstr "Κομμάτια που ακούστηκαν πρόσφατα από τον %name%"
+
+#: id:15284
+msgid "Listen to %name%'s recommendations Last.fm radio"
+msgstr "Ακρόαση των προτιμήσεων του %name% στο Last.fm radio"
+
+#: id:15285
+msgid "Top tags for user %name%"
+msgstr "Κορυφαίες ετικέτες για τον χρήστη %name%"
+
+#: id:15287
+msgid "Do you want to add the current track to your loved tracks?"
+msgstr "Να προστεθεί το παρόν κομμάτι στα αγαπημένα σας;"
+
+#: id:15288
+msgid "Do you want to ban the current track?"
+msgstr "Να αποκλειστεί το παρόν κομμάτι;"
+
+#: id:15289
+msgid "Added to your loved tracks: '%s'."
+msgstr "Προσθήκη στα αγαπημένα σας κομμάτια: '%s'."
+
+#: id:15290
+msgid "Could not add '%s' to your loved tracks."
+msgstr "Δεν μπορεί να προστεθεί το '%s' στα αγαπημένα σας."
+
+#: id:15291
+msgid "Banned: '%s'."
+msgstr "Αποκλεισμένα: '%s'."
+
+#: id:15292
+msgid "Could not ban '%s'."
+msgstr "Δεν μπορεί να αποκλειστεί το '%s'."
+
+#: id:15293
+msgid "Tracks recently loved by %name%"
+msgstr "Πρόσφατα αγαπημένα κομμάτια από %name%"
+
+#: id:15294
+msgid "Tracks recently banned by %name%"
+msgstr "Πρόσφατα αποκλεισμένα κομμάτια από %name%"
+
+#: id:15295
+msgid "Remove from loved tracks"
+msgstr "Αφαίρεση από τα αγαπημένα σας"
+
+#: id:15296
+msgid "Un-ban"
+msgstr "Άρση αποκλεισμού"
+
+#: id:15297
+msgid "Do you want to remove this track from your loved tracks?"
+msgstr "Να αφαιρεθεί το παρόν κομμάτι από τα αγαπημένα σας;"
+
+#: id:15298
+msgid "Do you want to un-ban this track?"
+msgstr "Να αρθεί ο αποκλεισμός για αυτό το κομμάτι;"
+
+#: id:15300
+msgid "Path not found or invalid"
+msgstr "Η διαδρομή δε βρέθηκε"
+
+#: id:15301
+msgid "Could not connect to network server"
+msgstr "Απέτυχε η σύνδεση με το διακομιστή δικτύου"
+
+#: id:15302
+msgid "No servers found"
+msgstr "Δεν βρέθηκαν διακομιστές"
+
+#: id:15303
+msgid "Workgroup not found"
+msgstr "Δεν βρέθηκε η ομάδα εργασίας"
+
+#: id:15310
+msgid "Opening multi-path source"
+msgstr "Άνοιγμα πηγής multi-path"
+
+#: id:15311
+msgid "Path:"
+msgstr "Διαδρομή:"
+
+#: id:16000
+msgctxt "Auto context with id 16000"
+msgid "General"
+msgstr "Γενικά"
+
+#: id:16002
+msgid "Internet lookup"
+msgstr "Έρευνα στο Διαδίκτυο"
+
+#: id:16003
+msgid "Player"
+msgstr "Αναπαραγωγή"
+
+#: id:16004
+msgid "Play media from disc"
+msgstr "Αναπαραγωγή πολυμέσων από το δίσκο"
+
+#: id:16008
+msgid "Enter new title"
+msgstr "Εισάγετε νέο τίτλο"
+
+#: id:16009
+msgid "Enter the movie name"
+msgstr "Εισάγετε το όνομα της ταινίας"
+
+#: id:16010
+msgid "Enter the profile name"
+msgstr "Εισάγετε το όνομα του προφίλ"
+
+#: id:16011
+msgid "Enter the album name"
+msgstr "Εισάγετε το όνομα του άλμπουμ"
+
+#: id:16012
+msgid "Enter the playlist name"
+msgstr "Εισάγετε το όνομα της λίστας αναπαραγωγής"
+
+#: id:16013
+msgid "Enter new filename"
+msgstr "Εισάγετε νέο όνομα αρχείου"
+
+#: id:16014
+msgid "Enter folder name"
+msgstr "Εισάγετε όνομα φακέλου"
+
+#: id:16015
+msgid "Enter directory"
+msgstr "Εισάγετε κατάλογο"
+
+#: id:16016
+msgid "Available options: %A, %T, %N, %B, %D, %G, %Y, %F, %S"
+msgstr "Διαθέσιμες επιλογές: %A, %T, %N, %B, %D, %G, %Y, %F, %S"
+
+#: id:16017
+msgid "Enter search string"
+msgstr "Εισαγωγή κειμένου αναζήτησης"
+
+#: id:16018
+msgctxt "Auto context with id 16018"
+msgid "None"
+msgstr "Καμία"
+
+#: id:16019
+msgid "Auto select"
+msgstr "Αυτόματη επιλογή"
+
+#: id:16020
+msgid "De-interlace"
+msgstr "Απόπλεξη"
+
+#: id:16021
+msgid "Bob"
+msgstr "Bob"
+
+#: id:16022
+msgid "Bob (inverted)"
+msgstr "Bob (αντιστροφή)"
+
+#: id:16024
+msgid "Canceling..."
+msgstr "Ακύρωση..."
+
+#: id:16025
+msgid "Enter the artist name"
+msgstr "Εισάγετε το όνομα του καλλιτέχνη"
+
+#: id:16026
+msgid "Playback failed"
+msgstr "Η αναπαραγωγή απέτυχε"
+
+#: id:16027
+msgid "One or more items failed to play."
+msgstr "Αποτυχία αναπαραγωγής ενός ή περισσότερων αντικειμένων."
+
+#: id:16028
+msgid "Enter value"
+msgstr "Εισαγωγή τιμής"
+
+#: id:16029
+msgid "Check the log file for details."
+msgstr "Για λεπτομέρειες ελέγξτε το αρχείο καταγραφής."
+
+#: id:16030
+msgid "Party mode aborted."
+msgstr "Το Party Mode απορρίφθηκε."
+
+#: id:16031
+msgid "No matching songs in the library."
+msgstr "Δεν υπάρχουν παρόμοια τραγούδια στη συλλογή."
+
+#: id:16032
+msgid "Could not initialize database."
+msgstr "Δεν είναι δυνατός ο συγχρονισμός με τη βάση δεδομένων."
+
+#: id:16033
+msgid "Could not open database."
+msgstr "Απέτυχε το άνοιγμα της βάσης δεδομένων."
+
+#: id:16034
+msgid "Could not get songs from database."
+msgstr "Απέτυχε η λήψη τραγουδιών από τη βάση δεδομένων."
+
+#: id:16035
+msgid "Party mode playlist"
+msgstr "Λίστα αναπαραγωγής σε Party Mode"
+
+#: id:16036
+msgid "De-interlace (Half)"
+msgstr "Απόπλεξη (κατά το ήμισυ)"
+
+#: id:16037
+msgid "Deinterlace video"
+msgstr "Απόπλεξη βίντεο (Deinterlace)"
+
+#: id:16038
+msgid "Deinterlace method"
+msgstr "Μέθοδος απόπλεξης"
+
+#: id:16039
+msgctxt "Auto context with id 16039"
+msgid "Off"
+msgstr "Ανενεργή"
+
+#: id:16040
+msgctxt "Auto context with id 16040"
+msgid "Auto"
+msgstr "Αυτόματη"
+
+#: id:16041
+msgid "On"
+msgstr "Ενεργή"
+
+#: id:16100
+msgid "All Videos"
+msgstr "Όλα τα βίντεο"
+
+#: id:16101
+msgid "Unwatched"
+msgstr "Μη προβληθέντα"
+
+#: id:16102
+msgid "Watched"
+msgstr "Προβληθέντα"
+
+#: id:16103
+msgid "Mark as watched"
+msgstr "Επισήμανση ως προβληθέντα"
+
+#: id:16104
+msgid "Mark as unwatched"
+msgstr "Επισήμανση ως μη προβληθέντα"
+
+#: id:16105
+msgid "Edit title"
+msgstr "Επεξεργασία τίτλου"
+
+#: id:16200
+msgid "Operation was aborted"
+msgstr "Η διαδικασία ακυρώθηκε"
+
+#: id:16201
+msgid "Copy failed"
+msgstr "Η αντιγραφή απέτυχε"
+
+#: id:16202
+msgid "Failed to copy at least one file"
+msgstr "Απέτυχε η αντιγραφή τουλάχιστον ενός αρχείου"
+
+#: id:16203
+msgid "Move failed"
+msgstr "Η μετακίνηση απέτυχε"
+
+#: id:16204
+msgid "Failed to move at least one file"
+msgstr "Απέτυχε η μετακίνηση τουλάχιστον ενός αρχείου"
+
+#: id:16205
+msgid "Delete failed"
+msgstr "Η διαγραφή απέτυχε"
+
+#: id:16206
+msgid "Failed to delete at least one file"
+msgstr "Απέτυχε η διαγραφή τουλάχιστον ενός αρχείου"
+
+#: id:16300
+msgid "Video scaling method"
+msgstr "Μέθοδος προσαρμογής ανάλυσης βίντεο"
+
+#: id:16301
+msgid "Nearest neighbour"
+msgstr "Εγγύτερη προσέγγιση"
+
+#: id:16302
+msgid "Bilinear"
+msgstr "Bilinear"
+
+#: id:16303
+msgctxt "Auto context with id 16303"
+msgid "Bicubic"
+msgstr "Bicubic"
+
+#: id:16304
+msgid "Lanczos2"
+msgstr "Lanczos2"
+
+#: id:16305
+msgid "Lanczos3"
+msgstr "Lanczos3"
+
+#: id:16306
+msgid "Sinc8"
+msgstr "Sinc8"
+
+#: id:16307
+msgid "Bicubic (software)"
+msgstr "Bicubic (λογισμικό)"
+
+#: id:16308
+msgid "Lanczos (software)"
+msgstr "Lanczos (λογισμικό)"
+
+#: id:16309
+msgid "Sinc (software)"
+msgstr "Sinc (λογισμικό)"
+
+#: id:16310
+msgid "Temporal"
+msgstr "Χρονική"
+
+#: id:16311
+msgid "Temporal/Spatial"
+msgstr "Χρονική/Χωρική"
+
+#: id:16312
+msgid "(VDPAU)Noise Reduction"
+msgstr "(VDPAU) Μείωση θορύβου"
+
+#: id:16313
+msgid "(VDPAU)Sharpness"
+msgstr "(VDPAU) Οξύτητα"
+
+#: id:16314
+msgid "Inverse Telecine"
+msgstr "Αντίστροφη Telecine"
+
+#: id:16315
+msgid "Lanczos3 optimized"
+msgstr "Lanczos3 βελτιστοποιημένη"
+
+#: id:16316
+msgctxt "Auto context with id 16316"
+msgid "Auto"
+msgstr "Αυτόματη"
+
+#: id:16317
+msgid "Temporal (Half)"
+msgstr "Χρονική (κατά το ήμισυ)"
+
+#: id:16318
+msgid "Temporal/Spatial (Half)"
+msgstr "Χρονική/Χωρική (κατά το ήμισυ)"
+
+#: id:16319
+msgid "DXVA"
+msgstr "DXVA"
+
+#: id:16320
+msgid "DXVA Bob"
+msgstr "DXVA Bob"
+
+#: id:16321
+msgid "DXVA Best"
+msgstr "DXVA Best"
+
+#: id:16322
+msgid "Spline36"
+msgstr "Spline36"
+
+#: id:16323
+msgid "Spline36 optimized"
+msgstr "Spline36 βελτιστοποιημένο"
+
+#: id:16324
+msgid "Software Blend"
+msgstr "Blend λογισμικού"
+
+#: id:16400
+msgid "Post-processing"
+msgstr "Μετα-επεξεργασία"
+
+#: id:17500
+msgid "Display sleep timeout"
+msgstr "Προβολή λήξης χρόνου αναστολής"
+
+#: id:19000
+msgid "Switch to channel"
+msgstr "Αλλαγή καναλιού"
+
+#: id:20000
+msgid "Saved music folder"
+msgstr "Φάκελος αποθήκευσης μουσικής"
+
+#: id:20001
+msgid "Use external DVD player"
+msgstr "Χρήση εξωτερικού αναπαραγωγέα DVD"
+
+#: id:20002
+msgid "External DVD player"
+msgstr "Εξωτερικός αναπαραγωγέας DVD"
+
+#: id:20003
+msgid "Trainers folder"
+msgstr "Φάκελος trainers"
+
+#: id:20004
+msgid "Screenshot folder"
+msgstr "Φάκελος στιγμιότυπων"
+
+#: id:20006
+msgid "Playlists folder"
+msgstr "Φάκελος λίστας αναπαραγωγής"
+
+#: id:20007
+msgid "Recordings"
+msgstr "Εγγραφές"
+
+#: id:20008
+msgid "Screenshots"
+msgstr "Στιγμιότυπα"
+
+#: id:20009
+msgid "Use XBMC"
+msgstr "Χρήση XBMC"
+
+#: id:20011
+msgid "Music playlists"
+msgstr "Λίστες αναπαραγωγής μουσικής"
+
+#: id:20012
+msgid "Video playlists"
+msgstr "Λίστες αναπαραγωγής βίντεο"
+
+#: id:20013
+msgid "Do you wish to launch the game?"
+msgstr "Να εκτελεστεί το παιχνίδι;"
+
+#: id:20014
+msgid "Sort by: Playlist"
+msgstr "Ταξ.: Λίστα αναπαραγωγής"
+
+#: id:20015
+msgid "Remote thumb"
+msgstr "Απομακρυσμένη μικρογραφία"
+
+#: id:20016
+msgid "Current thumb"
+msgstr "Τρέχουσα μικρογραφία"
+
+#: id:20017
+msgid "Local thumb"
+msgstr "Τοπική μικρογραφία"
+
+#: id:20018
+msgid "No thumb"
+msgstr "Χωρίς μικρογραφία"
+
+#: id:20019
+msgid "Choose thumbnail"
+msgstr "Επιλογή μικρογραφίας"
+
+#: id:20023
+msgid "Conflict"
+msgstr "Διένεξη"
+
+#: id:20024
+msgid "Scan new"
+msgstr "Σάρωση νέων"
+
+#: id:20025
+msgid "Scan all"
+msgstr "Σάρωση όλων"
+
+#: id:20026
+msgid "Region"
+msgstr "Περιοχή"
+
+#: id:20037
+msgid "Summary"
+msgstr "Συνοπτικά"
+
+#: id:20038
+msgid "Lock music window"
+msgstr "Κλείδωμα παραθύρου μουσικής"
+
+#: id:20039
+msgid "Lock videos window"
+msgstr "Κλείδωμα παραθύρου βίντεο"
+
+#: id:20040
+msgid "Lock pictures window"
+msgstr "Κλείδωμα παραθύρου εικόνων"
+
+#: id:20041
+msgid "Lock programs & scripts windows"
+msgstr "Κλείδωμα παραθύρου εφαρμογών & script"
+
+#: id:20042
+msgid "Lock file manager"
+msgstr "Κλείδωμα της διαχείρισης αρχείων"
+
+#: id:20043
+msgid "Lock settings"
+msgstr "Κλείδωμα των ρυθμίσεων"
+
+#: id:20044
+msgid "Start fresh"
+msgstr "Νέα έναρξη"
+
+#: id:20045
+msgid "Enter master mode"
+msgstr "Είσοδος στη γενική διαχείριση"
+
+#: id:20046
+msgid "Leave master mode"
+msgstr "Έξοδος από τη γενική διαχείριση"
+
+#: id:20047
+msgid "Create profile '%s'?"
+msgstr "Δημιουργία προφίλ '%s';"
+
+#: id:20048
+msgid "Start with fresh settings"
+msgstr "Έναρξη με νέες ρυθμίσεις"
+
+#: id:20049
+msgid "Best available"
+msgstr "Η καλύτερη δυνατή"
+
+#: id:20050
+msgid "Auto-switch between 16x9 and 4x3"
+msgstr "Αυτόματη εναλλαγή μεταξύ 16:9 και 4:3"
+
+#: id:20051
+msgid "Treat stacked files as single file"
+msgstr "Μεταχείριση στοιβαγμένων αρχείων σαν ένα"
+
+#: id:20052
+msgid "Caution"
+msgstr "Προσοχή"
+
+#: id:20053
+msgid "Left master mode"
+msgstr "Αποχώρηση από τη γεν. διαχείριση"
+
+#: id:20054
+msgid "Entered master mode"
+msgstr "Εισαγωγή στη γεν. διαχείριση"
+
+#: id:20055
+msgid "Allmusic.com thumb"
+msgstr "Μικρογραφία Allmusic.com"
+
+#: id:20057
+msgid "Remove thumbnail"
+msgstr "Απομάκρυνση μικρογραφίας"
+
+#: id:20058
+msgid "Add profile..."
+msgstr "Προσθήκη προφίλ..."
+
+#: id:20059
+msgid "Query info for all albums"
+msgstr "Εύρεση πληροφοριών για όλα τα άλμπουμ"
+
+#: id:20060
+msgctxt "Auto context with id 20060"
+msgid "Media info"
+msgstr "Πληροφορίες πολυμέσων"
+
+#: id:20061
+msgctxt "Auto context with id 20061"
+msgid "Separate"
+msgstr "Ξεχωριστές"
+
+#: id:20062
+msgid "Shares with default"
+msgstr "Κοινόχρηστα με προεπιλογές"
+
+#: id:20063
+msgid "Shares with default (read only)"
+msgstr "Κοινόχρηστα με προεπιλογές (ανάγνωση μόνο)"
+
+#: id:20064
+msgid "Copy default"
+msgstr "Αντιγραφή προεπιλογών"
+
+#: id:20065
+msgid "Profile picture"
+msgstr "Εικόνα προφίλ"
+
+#: id:20066
+msgid "Lock preferences"
+msgstr "Προτιμήσεις κλειδώματος"
+
+#: id:20067
+msgid "Edit profile"
+msgstr "Επεξεργασία προφίλ"
+
+#: id:20068
+msgid "Profile lock"
+msgstr "Κλείδωμα προφίλ"
+
+#: id:20069
+msgid "Could not create folder"
+msgstr "Αδύνατη η δημιουργία φακέλου"
+
+#: id:20070
+msgid "Profile directory"
+msgstr "Κατάλογος προφίλ"
+
+#: id:20071
+msgid "Start with fresh media sources"
+msgstr "Έναρξη με νέες πηγές πολυμέσων"
+
+#: id:20072
+msgid "Make sure the selected folder is writable"
+msgstr "Σιγουρευτείτε ότι ο επιλεγμένος φάκελος μπορεί να εγγραφεί"
+
+#: id:20073
+msgid "and that the new folder name is valid"
+msgstr "και ότι το νέο όνομα είναι έγκυρο"
+
+#: id:20074
+msgid "MPAA rating"
+msgstr "Αξιολόγ. MPAA"
+
+#: id:20075
+msgid "Enter master lock code"
+msgstr "Εισαγωγή κωδικού κεντρικού κλειδώματος"
+
+#: id:20076
+msgid "Ask for master lock code on startup"
+msgstr "Αίτημα για κωδικό κεντρικού κλειδώματος στην εκκίνηση"
+
+#: id:20077
+msgid "Skin settings"
+msgstr "Ρυθμίσεις κελύφους"
+
+#: id:20078
+msgid "- no link set -"
+msgstr "- δεν έχει οριστεί σύνδεση -"
+
+#: id:20079
+msgid "Enable animations"
+msgstr "Ενεργοποίηση εφέ κίνησης"
+
+#: id:20080
+msgid "Disable RSS during music"
+msgstr "Απενεργοποίηση της Ροής Τίτλων Ειδήσεων (RSS) κατά την ακρόαση μουσικής"
+
+#: id:20081
+msgid "Enable shortcut buttons"
+msgstr "Ενεργοποίηση πλήκτρων συντόμευσης"
+
+#: id:20082
+msgid "Show programs in main menu"
+msgstr "Εμφάνιση των εφαρμογών στο κεντρικό μενού"
+
+#: id:20083
+msgid "Show music info"
+msgstr "Εμφάνιση πληροφοριών για τη μουσική"
+
+#: id:20084
+msgid "Show weather info"
+msgstr "Εμφάνιση πληροφοριών για τον καιρό"
+
+#: id:20085
+msgid "Show system info"
+msgstr "Εμφάνιση πληροφοριών για το σύστημα"
+
+#: id:20086
+msgid "Show available disc space C: E: F:"
+msgstr "Εμφάνιση διαθέσιμου χώρου στα C: E: F:"
+
+#: id:20087
+msgid "Show available disc space E: F: G:"
+msgstr "Εμφάνιση διαθέσιμου χώρου στα E: F: G:"
+
+#: id:20088
+msgid "Weather info"
+msgstr "Πληροφορίες καιρού"
+
+#: id:20089
+msgid "Drive space free"
+msgstr "Ελεύθερος χώρος"
+
+#: id:20090
+msgid "Enter the name of an existing share"
+msgstr "Εισάγετε όνομα κοινόχρηστου πόρου"
+
+#: id:20091
+msgid "Lock code"
+msgstr "Κωδικός κλειδώματος"
+
+#: id:20092
+msgid "Load profile"
+msgstr "Φόρτωση προφίλ"
+
+#: id:20093
+msgid "Profile name"
+msgstr "Όνομα προφίλ"
+
+#: id:20094
+msgctxt "Auto context with id 20094"
+msgid "Media sources"
+msgstr "Πηγές πολυμέσων"
+
+#: id:20095
+msgid "Enter profile lock code"
+msgstr "Εισάγετε κωδικό κλειδώματος προφίλ"
+
+#: id:20096
+msgctxt "Auto context with id 20096"
+msgid "Login screen"
+msgstr "Οθόνη σύνδεσης"
+
+#: id:20097
+msgid "Fetching album info"
+msgstr "Λήψη πληροφοριών άλμπουμ"
+
+#: id:20098
+msgid "Fetching info for album"
+msgstr "Λαμβάνονται πληροφορίες για το άλμπουμ"
+
+#: id:20099
+msgid "Can't rip CD or track while playing from CD"
+msgstr "Αδυναμία αντιγραφής του CD ή του κομματιού κατά την αναπαραγωγή του CD"
+
+#: id:20100
+msgid "Master lock code and settings"
+msgstr "Κωδικός κεντρικού κλειδώματος και επιλογές"
+
+#: id:20101
+msgid "Entering master lock code always enables master mode"
+msgstr "Ο κωδικός κεντρικού κλειδώματος να ενεργοποιεί πάντα τη γεν. διαχείριση"
+
+#: id:20102
+msgid "or copy from default?"
+msgstr "ή να αντιγράφεται ο προκαθορισμένος κωδικός;"
+
+#: id:20103
+msgid "Save changes to profile?"
+msgstr "Αποθήκευση αλλαγών στο προφίλ;"
+
+#: id:20104
+msgid "Old settings found."
+msgstr "Βρέθηκαν παλιές ρυθμίσεις."
+
+#: id:20105
+msgid "Do you want to use them?"
+msgstr "Θέλετε να τις χρησιμοποιήσετε;"
+
+#: id:20106
+msgid "Old media sources found."
+msgstr "Βρέθηκαν παλιές πηγές πολυμέσων."
+
+#: id:20107
+msgid "Separate (locked)"
+msgstr "Ξεχωριστές (κλειδωμένο)"
+
+#: id:20108
+msgid "Root"
+msgstr "Root"
+
+#: id:20109
+msgid "- Zoom"
+msgstr "- Μεγέθυνση"
+
+#: id:20110
+msgid "UPnP settings"
+msgstr "Ρυθμίσεις UPnP"
+
+#: id:20111
+msgid "Autostart UPnP client"
+msgstr "Αυτόματη έναρξη πελάτη UPnP"
+
+#: id:20112
+msgid "Last login: %s"
+msgstr "Τελευταία σύνδεση: %s"
+
+#: id:20113
+msgid "Never logged on"
+msgstr "Ποτέ δε συνδέθηκε"
+
+#: id:20114
+msgid "Profile %i / %i"
+msgstr "Προφίλ %i / %i"
+
+#: id:20115
+msgid "User login / Select a profile"
+msgstr "Σύνδεση χρήστη / Επιλέξτε ένα προφίλ"
+
+#: id:20116
+msgid "Use lock on login screen"
+msgstr "Χρήση κλειδώματος στην οθόνη σύνδεσης"
+
+#: id:20117
+msgid "Invalid lock code."
+msgstr "Λάθος κωδικός κλειδώματος."
+
+#: id:20118
+msgid "This requires the master lock to be set."
+msgstr "Απαιτείται ορισμός του κεντρικού κλειδώματος."
+
+#: id:20119
+msgid "Would you like to set it now?"
+msgstr "Θέλετε να το ορίσετε τώρα;"
+
+#: id:20120
+msgid "Loading program information"
+msgstr "Φόρτωση πληροφοριών εφαρμογής"
+
+#: id:20121
+msgid "Party on!"
+msgstr "Party on!"
+
+#: id:20122
+msgid "True"
+msgstr "Αληθές"
+
+#: id:20123
+msgid "Mixing drinks"
+msgstr "Αναμιγνύονται τα ποτά"
+
+#: id:20124
+msgid "Filling glasses"
+msgstr "Γεμίζουν τα ποτήρια"
+
+#: id:20125
+msgid "Logged on as"
+msgstr "Συνδεμένος σαν"
+
+#: id:20126
+msgid "Log off"
+msgstr "Αποσύνδεση"
+
+#: id:20128
+msgid "Go to root"
+msgstr "Μετάβαση σε root"
+
+#: id:20129
+msgid "Weave"
+msgstr "Weave"
+
+#: id:20130
+msgid "Weave (inverted)"
+msgstr "Weave (αντιστροφή)"
+
+#: id:20131
+msgid "Blend"
+msgstr "Blend"
+
+#: id:20132
+msgid "Restart video"
+msgstr "Επανεκκίνηση βίντεο"
+
+#: id:20133
+msgid "Edit network location"
+msgstr "Επεξεργασία τοποθεσίας δικτύου"
+
+#: id:20134
+msgid "Remove network location"
+msgstr "Απομάκρυνση τοποθεσίας δικτύου"
+
+#: id:20135
+msgid "Do you want to scan the folder?"
+msgstr "Θέλετε να σαρώσετε το φάκελο;"
+
+#: id:20136
+msgid "Memory unit"
+msgstr "Μονάδα μνήμης"
+
+#: id:20137
+msgid "Memory unit mounted"
+msgstr "Προσάρτηση μονάδας μνήμης"
+
+#: id:20138
+msgid "Unable to mount memory unit"
+msgstr "Αδύνατη η προσάρτηση μονάδας μνήμης"
+
+#: id:20139
+msgid "In port %i, slot %i"
+msgstr "Στη θύρα %i, υποδοχή %i"
+
+#: id:20140
+msgid "Lock screensaver"
+msgstr "Κλείδωμα προφύλαξης οθόνης"
+
+#: id:20141
+msgid "Set"
+msgstr "Ορισμός σε"
+
+#: id:20142
+msgctxt "Auto context with id 20142"
+msgid "Username"
+msgstr "Όνομα χρήστη"
+
+#: id:20143
+msgid "Enter password for"
+msgstr "Εισαγωγή κωδικού πρόσβασης για"
+
+#: id:20144
+msgid "Shutdown timer"
+msgstr "Χρονοδιακόπτης τερματισμού"
+
+#: id:20145
+msgid "Shutdown interval (in minutes)"
+msgstr "Χρόνος τερματισμού (σε λεπτά)"
+
+#: id:20146
+msgid "Started, shutdown in %im"
+msgstr "Ξεκίνησε, τερματισμός σε %im"
+
+#: id:20147
+msgid "Shutdown in 30 minutes"
+msgstr "Τερματισμός σε 30 λεπτά"
+
+#: id:20148
+msgid "Shutdown in 60 minutes"
+msgstr "Τερματισμός σε 60 λεπτά"
+
+#: id:20149
+msgid "Shutdown in 120 minutes"
+msgstr "Τερματισμός σε 120 λεπτά"
+
+#: id:20150
+msgid "Custom shutdown timer"
+msgstr "Προσαρμογή χρονοδιακόπτη τερματισμού"
+
+#: id:20151
+msgid "Cancel shutdown timer"
+msgstr "Ακύρωση χρονοδιακόπτη τερματισμού"
+
+#: id:20152
+msgid "Lock preferences for %s"
+msgstr "Κλείδωμα ρυθμίσεων για %s"
+
+#: id:20153
+msgid "Browse..."
+msgstr "Αναζήτηση..."
+
+#: id:20154
+msgid "Summary information"
+msgstr "Συνοπτικές πληροφορίες"
+
+#: id:20155
+msgid "Storage information"
+msgstr "Πληροφορίες αποθηκευτικού χώρου"
+
+#: id:20156
+msgid "Hard disk information"
+msgstr "Πληροφορίες σκληρού δίσκου"
+
+#: id:20157
+msgid "DVD-ROM information"
+msgstr "Πληροφορίες DVD-ROM"
+
+#: id:20158
+msgid "Network information"
+msgstr "Πληροφορίες δικτύου"
+
+#: id:20159
+msgid "Video information"
+msgstr "Πληροφορίες βίντεο"
+
+#: id:20160
+msgid "Hardware information"
+msgstr "Πληροφορίες υλικού"
+
+#: id:20161
+msgid "Total"
+msgstr "Συνολικά"
+
+#: id:20162
+msgid "Used"
+msgstr "Χρησιμοποιημένα"
+
+#: id:20163
+msgid "of"
+msgstr "από τα"
+
+#: id:20164
+msgid "Locking not supported"
+msgstr "Δεν υποστηρίζεται κλείδωμα"
+
+#: id:20165
+msgid "Not locked"
+msgstr "Ξεκλείδωτος"
+
+#: id:20166
+msgid "Locked"
+msgstr "Κλειδωμένος"
+
+#: id:20167
+msgid "Frozen"
+msgstr "Παγωμένος"
+
+#: id:20168
+msgid "Requires reset"
+msgstr "Απαιτεί επανεκκίνηση"
+
+#: id:20169
+msgid "Week"
+msgstr "Εβδομάδα"
+
+#: id:20170
+msgid "Line"
+msgstr "Γραμμή"
+
+#: id:20171
+msgid "Windows network (SMB)"
+msgstr "Δίκτυο Windows (SMB)"
+
+#: id:20172
+msgid "XBMSP server"
+msgstr "Διακομιστής XBMSP"
+
+#: id:20173
+msgctxt "Auto context with id 20173"
+msgid "FTP server"
+msgstr "Διακομιστής FTP"
+
+#: id:20174
+msgid "iTunes music share (DAAP)"
+msgstr "Διαμοίραση μουσικής iTunes (DAAP)"
+
+#: id:20175
+msgid "UPnP server"
+msgstr "Διακομιστής UPnP"
+
+#: id:20176
+msgid "Show video info"
+msgstr "Εμφάνιση πληροφοριών για το βίντεο"
+
+#: id:20177
+msgid "Done"
+msgstr "Τέλος"
+
+#: id:20178
+msgid "Shift"
+msgstr "Shift"
+
+#: id:20179
+msgid "Caps Lock"
+msgstr "Caps Lock"
+
+#: id:20180
+msgid "Symbols"
+msgstr "Σύμβολα"
+
+#: id:20181
+msgid "Backspace"
+msgstr "Διαγραφή"
+
+#: id:20182
+msgid "Space"
+msgstr "Κενό"
+
+#: id:20183
+msgid "Reload skin"
+msgstr "Επαναφόρτωση κελύφους"
+
+#: id:20184
+msgid "Rotate pictures using EXIF information"
+msgstr "Περιστροφή εικόνων που χρησιμοποιούν πληροφορίες EXIF"
+
+#: id:20185
+msgid "Use poster view styles for TV shows"
+msgstr "Χρήση στυλ αφισών για τις τηλεοπτικές σειρές"
+
+#: id:20186
+msgid "Please wait"
+msgstr "Απασχολημένο"
+
+#: id:20187
+msgid "UPnP"
+msgstr ""
+
+#: id:20189
+msgid "Enable auto scrolling for plot & review"
+msgstr "Ενεργοποίηση αυτόματης κύλισης για πλοκή & κριτική"
+
+#: id:20190
+msgctxt "Auto context with id 20190"
+msgid "Custom"
+msgstr "Προσαρμογή"
+
+#: id:20191
+msgid "Enable debug logging"
+msgstr "Ενεργοποίηση καταγραφής σφαλμάτων (debug log)"
+
+#: id:20192
+msgid "Download additional information during updates"
+msgstr "Λήψη πρόσθετων πληροφοριών κατά τις ενημερώσεις συλλογής"
+
+#: id:20193
+msgid "Default service for album information"
+msgstr "Προκαθορισμένη υπηρεσία πληροφοριών άλμπουμ"
+
+#: id:20194
+msgid "Default service for artist information"
+msgstr "Προκαθορισμένη υπηρεσία πληροφοριών καλλιτέχνη"
+
+#: id:20195
+msgid "Change scraper"
+msgstr "Αλλαγή scraper"
+
+#: id:20196
+msgid "Export music library"
+msgstr "Εξαγωγή μουσικής συλλογής"
+
+#: id:20197
+msgid "Import music library"
+msgstr "Εισαγωγή μουσικής συλλογής"
+
+#: id:20198
+msgid "No artist found!"
+msgstr "Δεν βρέθηκε ο καλλιτέχνης!"
+
+#: id:20199
+msgid "Downloading artist info failed"
+msgstr "Αποτυχία λήψης πληροφοριών καλλιτέχνη"
+
+#: id:20250
+msgid "Party on! (videos)"
+msgstr "Party on! (βίντεο)"
+
+#: id:20251
+msgid "Mixing drinks (videos)"
+msgstr "Αναμιγνύονται τα ποτά (βίντεο)"
+
+#: id:20252
+msgid "Filling glasses (videos)"
+msgstr "Γεμίζουν τα ποτήρια (βίντεο)"
+
+#: id:20253
+msgid "WebDAV server (HTTP)"
+msgstr "Διακομιστής WebDAV (HTTP)"
+
+#: id:20254
+msgid "WebDAV server (HTTPS)"
+msgstr "Διακομιστής WebDAV (HTTPS)"
+
+#: id:20255
+msgid "First logon, edit your profile"
+msgstr "Πρώτη σύνδεση, επεξεργαστείτε το προφίλ σας"
+
+#: id:20256
+msgid "HTS Tvheadend client"
+msgstr "Πελάτης HTS Tvheadend"
+
+#: id:20257
+msgid "VDR Streamdev client"
+msgstr "Πελάτης VDR Streamdev"
+
+#: id:20258
+msgid "MythTV client"
+msgstr "Πελάτης MythTV"
+
+#: id:20259
+msgid "Network Filesystem (NFS)"
+msgstr "Σύστημα Αρχείων Δικτύου (NFS)"
+
+#: id:20260
+msgid "Secure Shell (SSH/SFTP)"
+msgstr "Κέλυφος Ασφαλείας (SSH/SFTP)"
+
+#: id:20261
+msgid "Apple Filing Protocol (AFP)"
+msgstr "Πρωτόκολλο Αρχειοθέτησης Apple (AFP)"
+
+#: id:20300
+msgid "Web server directory (HTTP)"
+msgstr "Κατάλογος διακομιστή ιστού (HTTP)"
+
+#: id:20301
+msgid "Web server directory (HTTPS)"
+msgstr "Κατάλογος διακομιστή ιστού (HTTPS)"
+
+#: id:20302
+msgid "Unable to write to folder:"
+msgstr "Αδυναμία εγγραφής στο φάκελο:"
+
+#: id:20303
+msgid "Do you want to skip and proceed?"
+msgstr "Θέλετε να παραβλεφθεί και να συνεχίσετε;"
+
+#: id:20304
+msgid "RSS Feed"
+msgstr "Ροή τίτλων ειδήσεων (RSS)"
+
+#: id:20307
+msgid "Secondary DNS"
+msgstr "Δευτερεύον DNS"
+
+#: id:20308
+msgid "DHCP server:"
+msgstr "Διακομιστής DHCP:"
+
+#: id:20309
+msgid "Make new folder"
+msgstr "Δημιουργία νέου φακέλου"
+
+#: id:20310
+msgid "Dim LCD on playback"
+msgstr "Αμαύρωση LCD κατά την αναπαραγωγή"
+
+#: id:20311
+msgid "Unknown or onboard (protected)"
+msgstr "Άγνωστο ή πάνω στην μητρική (προστατεύεται)"
+
+#: id:20312
+msgid "Dim LCD on paused"
+msgstr "Αμαύρωση LCD στην παύση"
+
+#: id:20314
+msgid "Videos - Library"
+msgstr "Βίντεο - Συλλογή"
+
+#: id:20316
+msgid "Sort by: ID"
+msgstr "Ταξ.: ID"
+
+#: id:20324
+msgid "Play part..."
+msgstr "Αναπαραγωγή κομματιού..."
+
+#: id:20325
+msgid "Calibration reset"
+msgstr "Επαναφορά βαθμονόμησης"
+
+#: id:20326
+msgid "This will reset the calibration values for %s"
+msgstr "Επαναφορά των τιμών βαθμονόμησης για %s"
+
+#: id:20327
+msgid "to it's default values."
+msgstr "στις προκαθορισμένες τιμές."
+
+#: id:20328
+msgid "Browse for destination"
+msgstr "Αναζήτηση προορισμού"
+
+#: id:20329
+msgid "Movies are in separate folders that match the movie title"
+msgstr "Οι ταινίες είναι σε διαφορετικούς φακέλους που ταιριάζουν με τον τίτλο της ταινίας"
+
+#: id:20330
+msgid "Use folder names for lookups"
+msgstr "Χρήση ονόματος φακέλου για αναζητήσεις"
+
+#: id:20331
+msgctxt "Auto context with id 20331"
+msgid "File"
+msgstr "Αρχείο"
+
+#: id:20332
+msgid "Use file or folder names in lookups?"
+msgstr "Χρήση φακέλων ή ονομάτων αρχείων στις αναζητήσεις;"
+
+#: id:20333
+msgid "Set content"
+msgstr "Ορισμός περιεχομένου"
+
+#: id:20334
+msgid "Folder"
+msgstr "Φάκελος"
+
+#: id:20335
+msgid "Look for content recursively?"
+msgstr "Έλεγχος περιεχομένου και των υποφακέλων;"
+
+#: id:20336
+msgid "Unlock sources"
+msgstr "Ξεκλείδωμα πηγών"
+
+#: id:20337
+msgid "Actor"
+msgstr "Ηθοποιός"
+
+#: id:20338
+msgid "Movie"
+msgstr "Ταινία"
+
+#: id:20339
+msgid "Director"
+msgstr "Σκηνοθεσία"
+
+#: id:20340
+msgid "Do you want to remove all items within"
+msgstr "Θέλετε να απομακρύνετε όλα τα αντικείμενα"
+
+#: id:20341
+msgid "this path from the XBMC library?"
+msgstr "αυτής της διαδρομής από τη συλλογή του XBMC;"
+
+#: id:20342
+msgctxt "Auto context with id 20342"
+msgid "Movies"
+msgstr "Ταινίες"
+
+#: id:20343
+msgid "TV shows"
+msgstr "Τηλεοπτικές σειρές"
+
+#: id:20344
+msgid "This directory contains"
+msgstr "Αυτός ο φάκελος περιέχει"
+
+#: id:20345
+msgid "Run automated scan"
+msgstr "Εκτέλεση αυτόματης σάρωσης"
+
+#: id:20346
+msgid "Scan recursively"
+msgstr "Σάρωση και των υποφακέλων"
+
+#: id:20347
+msgid "as"
+msgstr "ως"
+
+#: id:20348
+msgid "Directors"
+msgstr "Σκηνοθέτες"
+
+#: id:20349
+msgid "No video files found in this path!"
+msgstr "Δεν βρέθηκαν αρχεία βίντεο σε αυτή τη διαδρομή!"
+
+#: id:20350
+msgid "votes"
+msgstr "ψήφοι"
+
+#: id:20351
+msgid "TV show information"
+msgstr "Πληροφορίες τηλεοπτικής σειράς"
+
+#: id:20352
+msgid "Episode information"
+msgstr "Πληροφορίες επεισοδίου"
+
+#: id:20353
+msgid "Loading TV show details"
+msgstr "Φόρτωση λεπτομερειών τηλεοπτικής σειράς"
+
+#: id:20354
+msgid "Fetching episode guide"
+msgstr "Ανάκτηση οδηγού επεισοδίου"
+
+#: id:20355
+msgid "Loading info for episodes in directory"
+msgstr "Φόρτωση πληροφοριών για τα επεισόδια στο φάκελο"
+
+#: id:20356
+msgid "Select TV show:"
+msgstr "Επιλεγμένη τηλεοπτική σειρά:"
+
+#: id:20357
+msgid "Enter the TV show name"
+msgstr "Εισαγωγή ονόματος τηλεοπτικής σειράς"
+
+#: id:20358
+msgid "Season %i"
+msgstr "Κύκλος %i"
+
+#: id:20359
+msgid "Episode"
+msgstr "Επεισόδιο"
+
+#: id:20360
+msgid "Episodes"
+msgstr "Επεισόδια"
+
+#: id:20361
+msgid "Loading episode details"
+msgstr "Λαμβάνονται λεπτομέρειες για το επεισόδιο"
+
+#: id:20362
+msgid "Remove episode from library"
+msgstr "Αφαίρεση επεισοδίου από τη συλλογή"
+
+#: id:20363
+msgid "Remove TV show from library"
+msgstr "Αφαίρεση τηλεοπτικής σειράς από τη συλλογή"
+
+#: id:20364
+msgid "TV show"
+msgstr "Τηλεοπτική σειρά"
+
+#: id:20365
+msgid "Episode plot"
+msgstr "Πλοκή επεισοδίου"
+
+#: id:20366
+msgid "* All seasons"
+msgstr "* Όλοι οι κύκλοι"
+
+#: id:20367
+msgid "Hide watched"
+msgstr "Απόκρυψη προβληθέντων"
+
+#: id:20368
+msgid "Prod code"
+msgstr "Κωδικός παραγωγής"
+
+#: id:20369
+msgid "Show plot for unwatched items"
+msgstr "Εμφάνιση πλοκής στα μη προβληθέντα"
+
+#: id:20370
+msgid "* Hidden to prevent spoilers *"
+msgstr "* Απόκρυψη για αποφυγή spoiler *"
+
+#: id:20371
+msgid "Set season thumb"
+msgstr "Ορισμός μικρογραφίας κύκλου"
+
+#: id:20372
+msgid "Season image"
+msgstr "Εικόνα κύκλου"
+
+#: id:20373
+msgid "Season"
+msgstr "Κύκλος"
+
+#: id:20374
+msgid "Downloading movie information"
+msgstr "Λήψη πληροφοριών για την ταινία"
+
+#: id:20375
+msgid "Unassign content"
+msgstr "Εκχώρηση περιεχόμενου"
+
+#: id:20376
+msgid "Original title"
+msgstr "Πρωτότυπος τίτλος"
+
+#: id:20377
+msgid "Refresh TV show information"
+msgstr "Ανανέωση πληροφοριών τηλεοπτικής σειράς"
+
+#: id:20378
+msgid "Refresh info for all episodes?"
+msgstr "Ανανέωση πληροφοριών για όλα τα επεισόδια;"
+
+#: id:20379
+msgid "Selected folder contains a single TV show"
+msgstr "Ο επιλεγμένος φάκελος περιέχει μόνο μία τηλεοπτική σειρά"
+
+#: id:20380
+msgid "Exclude selected folder from scans"
+msgstr "Εξαίρεση του επιλεγμένου φακέλου από τυχόν ελέγχους"
+
+#: id:20381
+msgid "Specials"
+msgstr "Ιδιαίτερα στοιχεία"
+
+#: id:20382
+msgid "Automatically grab season thumbs"
+msgstr "Αυτόματη λήψη μικρογραφιών κύκλων"
+
+#: id:20383
+msgid "Selected folder contains a single video"
+msgstr "Ο επιλεγμένος φάκελος περιέχει μόνο ένα βίντεο"
+
+#: id:20384
+msgid "Link to TV show"
+msgstr "Σύνδεσμος σε τηλεοπτική σειρά"
+
+#: id:20385
+msgid "Remove link to TV show"
+msgstr "Αφαίρεση συνδέσμου από τηλεοπτική σειρά"
+
+#: id:20386
+msgid "Recently added movies"
+msgstr "Πρόσφατα εισαχθείσες ταινίες"
+
+#: id:20387
+msgid "Recently added episodes"
+msgstr "Πρόσφατα εισαχθέντα επεισόδια"
+
+#: id:20388
+msgid "Studios"
+msgstr "Στούντιο"
+
+#: id:20389
+msgid "Music videos"
+msgstr "Μουσικά βίντεο"
+
+#: id:20390
+msgid "Recently added music videos"
+msgstr "Πρόσφατα εισαχθέντα μουσικά βίντεο"
+
+#: id:20391
+msgid "Music video"
+msgstr "Μουσικό βίντεο"
+
+#: id:20392
+msgid "Remove music video from library"
+msgstr "Αφαίρεση μουσικού βίντεο από τη συλλογή"
+
+#: id:20393
+msgctxt "Auto context with id 20393"
+msgid "Music video information"
+msgstr "Πληροφορίες μουσικού βίντεο"
+
+#: id:20394
+msgid "Loading music video information"
+msgstr "Φόρτωση πληροφοριών για το μουσικό βίντεο"
+
+#: id:20395
+msgid "Mixed"
+msgstr "Ανάμικτα"
+
+#: id:20396
+msgid "Go to albums by artist"
+msgstr "Άλμπουμ καλλιτέχνη"
+
+#: id:20397
+msgid "Go to album"
+msgstr "Άλμπουμ"
+
+#: id:20398
+msgid "Play song"
+msgstr "Αναπαραγωγή τραγουδιού"
+
+#: id:20399
+msgid "Go to music videos from album"
+msgstr "Μουσικά βίντεο από άλμπουμ"
+
+#: id:20400
+msgid "Go to music videos by artist"
+msgstr "Μουσικά βίντεο ανά καλλιτέχνη"
+
+#: id:20401
+msgid "Play music video"
+msgstr "Αναπαραγωγή μουσικού βίντεο"
+
+#: id:20402
+msgid "Download actor thumbnails when adding to library"
+msgstr "Λήψη μικρογραφιών ηθοποιού κατά την προσθήκη στη συλλογή"
+
+#: id:20403
+msgid "Set actor thumb"
+msgstr "Ορισμός μικρογραφίας ηθοποιού"
+
+#: id:20405
+msgid "Remove episode bookmark"
+msgstr "Αφαίρεση σελιδοδείκτη επεισοδίου"
+
+#: id:20406
+msgid "Set episode bookmark"
+msgstr "Ορισμός σελιδοδείκτη επεισοδίου"
+
+#: id:20407
+msgid "Scraper settings"
+msgstr "Ρυθμίσεις scraper"
+
+#: id:20408
+msgid "Downloading music video information"
+msgstr "Λήψη πληροφοριών για το μουσικό βίντεο"
+
+#: id:20409
+msgid "Downloading TV show information"
+msgstr "Λήψη πληροφοριών για την τηλεοπτική σειρά"
+
+#: id:20410
+msgid "Trailer"
+msgstr "Διαφημιστικό"
+
+#: id:20411
+msgid "Flatten"
+msgstr "Ενιαία λίστα (Flatten)"
+
+#: id:20412
+msgid "Flatten TV shows"
+msgstr "Ενιαία λίστα επεισοδίων σειράς (Flatten)"
+
+#: id:20413
+msgid "Get fanart"
+msgstr "Λήψη Fanart"
+
+#: id:20414
+msgid "Show Fanart in video and music libraries"
+msgstr "Προβολή Fanart στις συλλογές βίντεο και μουσικής"
+
+#: id:20415
+msgid "Scanning for new content"
+msgstr "Έλεγχος για νέα περιεχόμενα"
+
+#: id:20416
+msgid "First aired"
+msgstr "Πρεμιέρα"
+
+#: id:20417
+msgid "Writer"
+msgstr "Σενάριο"
+
+#: id:20419
+msgid "Replace file names with library titles"
+msgstr "Αντικατάσταση ονομάτων αρχείων με τίτλους συλλογών"
+
+#: id:20420
+msgctxt "Auto context with id 20420"
+msgid "Never"
+msgstr "Ποτέ"
+
+#: id:20421
+msgid "If only one season"
+msgstr "Eάν είναι ενός κύκλου"
+
+#: id:20422
+msgid "Always"
+msgstr "Πάντα"
+
+#: id:20423
+msgid "Has trailer"
+msgstr "Έχει διαφημιστικό"
+
+#: id:20424
+msgid "False"
+msgstr "Ψευδές"
+
+#: id:20425
+msgid "Fanart slideshow"
+msgstr "Παρουσίαση διαφανειών Fanart"
+
+#: id:20426
+msgid "Export to a single file or separate"
+msgstr "Εξαγωγή σε ένα αρχείο ή σε πολλαπλά"
+
+#: id:20427
+msgid "files per entry?"
+msgstr "αρχεία ανά εγγραφή;"
+
+#: id:20428
+msgid "Single file"
+msgstr "Ένα αρχείο"
+
+#: id:20429
+msgctxt "Auto context with id 20429"
+msgid "Separate"
+msgstr "Πολλαπλά"
+
+#: id:20430
+msgid "Export thumbnails and fanart?"
+msgstr "Εξαγωγή μικρογραφιών και fanart;"
+
+#: id:20431
+msgid "Overwrite old files?"
+msgstr "Αντικατάσταση παλιών αρχείων;"
+
+#: id:20432
+msgid "Exclude path from library updates"
+msgstr "Εξαίρεση διαδρομής από τις ενημερώσεις συλλογής"
+
+#: id:20433
+msgid "Extract thumbnails and video information"
+msgstr "Εξαγωγή μικρογραφιών και πληροφοριών"
+
+#: id:20434
+msgid "Sets"
+msgstr "Ομάδες Ταινιών"
+
+#: id:20435
+msgid "Set movieset thumb"
+msgstr "Ορισμός μικρογραφίας ομάδας"
+
+#: id:20436
+msgid "Export actor thumbs?"
+msgstr "Εξαγωγή μικρογραφιών ηθοποιού;"
+
+#: id:20437
+msgid "Choose fanart"
+msgstr "Επιλογή fanart"
+
+#: id:20438
+msgid "Local fanart"
+msgstr "Τοπικό fanart"
+
+#: id:20439
+msgid "No fanart"
+msgstr "Χωρίς fanart"
+
+#: id:20440
+msgid "Current fanart"
+msgstr "Τρέχον fanart"
+
+#: id:20441
+msgid "Remote fanart"
+msgstr "Απομακρυσμένο fanart"
+
+#: id:20442
+msgid "Change content"
+msgstr "Αλλαγή περιεχομένου"
+
+#: id:20443
+msgid "Do you want to refresh info for all"
+msgstr "Επιθυμείτε να ανανεώσετε τις πληροφορίες"
+
+#: id:20444
+msgid "items within this path?"
+msgstr "για όλα τα στοιχεία αυτής της διαδρομής;"
+
+#: id:20445
+msgid "Fanart"
+msgstr "Fanart"
+
+#: id:20446
+msgid "Locally stored information found."
+msgstr "Βρέθηκαν τοπικά αποθηκευμένες πληροφορίες."
+
+#: id:20447
+msgid "Ignore and refresh from internet?"
+msgstr "Να αγνοηθούν και να ανανεωθούν από το διαδίκτυο;"
+
+#: id:20448
+msgid "Could not download information"
+msgstr "Αδυναμία λήψης πληροφοριών"
+
+#: id:20449
+msgid "Unable to connect to remote server"
+msgstr "Αδυναμία σύνδεσης με τον απομακρυσμένο διακομιστή"
+
+#: id:20450
+msgid "Would you like to continue scanning?"
+msgstr "Επιθυμείτε να συνεχίσετε την αναζήτηση;"
+
+#: id:20451
+msgid "Countries"
+msgstr "Χώρες"
+
+#: id:20452
+msgid "episode"
+msgstr "επεισόδιο"
+
+#: id:20453
+msgid "episodes"
+msgstr "επεισόδια"
+
+#: id:20454
+msgid "Listener"
+msgstr "Ακροατής"
+
+#: id:20455
+msgid "Listeners"
+msgstr "Ακροατές"
+
+#: id:20456
+msgid "Set movieset fanart"
+msgstr "Ορισμός fanart ομάδας ταινιών"
+
+#: id:20457
+msgid "Movie set"
+msgstr "Ομάδα Ταινιών"
+
+#: id:20458
+msgid "Group movies in sets"
+msgstr "Ομαδοποίηση ταινιών"
+
+#: id:21330
+msgid "Show hidden files and directories"
+msgstr "Προβολή κρυφών αρχείων και φακέλων"
+
+#: id:21331
+msgid "TuxBox client"
+msgstr "Πελάτης TuxBox"
+
+#: id:21332
+msgid "WARNING: Target TuxBox device is in recording-mode!"
+msgstr "ΠΡΟΣΟΧΗ: Η συσκευή TuxBox βρίσκεται σε κατάσταση εγγραφής!"
+
+#: id:21333
+msgid "The stream will be stopped!"
+msgstr "Η ροή πολυμέσων θα σταματήσει!"
+
+#: id:21334
+msgid "Zap to channel: %s failed!"
+msgstr "Η αλλαγή καναλιού: %s απέτυχε!"
+
+#: id:21335
+msgid "Are you sure to start the stream?"
+msgstr "Θέλετε να ξεκινήσει η ροή πολυμέσων;"
+
+#: id:21336
+msgid "Connecting to: %s"
+msgstr "Σύνδεση στο: %s"
+
+#: id:21337
+msgid "TuxBox device"
+msgstr "Συσκευή TuxBox"
+
+#: id:21359
+msgid "Add media share..."
+msgstr "Προσθήκη κοινόχρηστου πολυμέσου..."
+
+#: id:21360
+msgid "Share video and music libraries through UPnP"
+msgstr "Διαμοιρασμός συλλογών μουσικής και βίντεο μέσω UPnP"
+
+#: id:21364
+msgid "Edit media share"
+msgstr "Επεξεργασία κοινόχρηστων πολυμέσων"
+
+#: id:21365
+msgid "Remove media share"
+msgstr "Απομάκρυνση κοινόχρηστων πολυμέσων"
+
+#: id:21366
+msgid "Subtitle folder"
+msgstr "Φάκελος υποτίτλων"
+
+#: id:21367
+msgid "Movie & alternate subtitle directory"
+msgstr "Ταινία & εναλλακτικός φάκελος υποτίτλων"
+
+#: id:21368
+msgid "Override ASS/SSA subtitles fonts"
+msgstr "Παράκαμψη γραμματοσειρών υποτίτλων ASS/SSA"
+
+#: id:21369
+msgid "Enable mouse and Touch Screen support"
+msgstr "Ενεργοποίηση ποντικιού και υποστήριξης οθόνης αφής"
+
+#: id:21370
+msgid "Play navigation sounds during media playback"
+msgstr "Ενεργοποίηση ήχων πλοήγησης κατά την αναπαραγωγή"
+
+#: id:21371
+msgid "Thumbnail"
+msgstr "Μικρογραφία"
+
+#: id:21372
+msgid "Forced DVD player region"
+msgstr "Περιοχή αναπαραγωγέα DVD"
+
+#: id:21373
+msgid "Video output"
+msgstr "Έξοδος βίντεο"
+
+#: id:21374
+msgid "Video aspect"
+msgstr "Αναλογία οθόνης"
+
+#: id:21375
+msgctxt "Auto context with id 21375"
+msgid "Normal"
+msgstr "Κανονική"
+
+#: id:21376
+msgid "Letterbox"
+msgstr "Letterbox"
+
+#: id:21377
+msgid "Widescreen"
+msgstr "Ευρεία οθόνη"
+
+#: id:21378
+msgid "Enable 480p"
+msgstr "Ενεργοποίηση 480p"
+
+#: id:21379
+msgid "Enable 720p"
+msgstr "Ενεργοποίηση 720p"
+
+#: id:21380
+msgid "Enable 1080i"
+msgstr "Ενεργοποίηση 1080i"
+
+#: id:21381
+msgid "Enter name of new playlist"
+msgstr "Εισαγωγή ονόματος για τη νέα λίστα αναπαραγωγής"
+
+#: id:21382
+msgid "Show \"Add source\" buttons in file lists"
+msgstr "Εμφάνιση πλήκτρου \"Προσθήκη πηγής\" στις λίστες αρχείων"
+
+#: id:21383
+msgid "Enable scrollbars"
+msgstr "Ενεργοποίηση μπαρών κύλισης"
+
+#: id:21384
+msgid "Make watched filtering a toggle in video library"
+msgstr "Δημιουργία μεταβλητών για φιλτράρισμα στη συλλογή των βίντεο"
+
+#: id:21385
+msgctxt "Auto context with id 21385"
+msgid "Open"
+msgstr "Άνοιγμα"
+
+#: id:21386
+msgid "Acoustic management level"
+msgstr "Διαχείριση στάθμης θορύβου"
+
+#: id:21387
+msgid "Fast"
+msgstr "Θορυβώδες"
+
+#: id:21388
+msgid "Quiet"
+msgstr "Αθόρυβο"
+
+#: id:21389
+msgid "Enable custom background"
+msgstr "Ενεργοποίηση προσαρμοσμένου υποβάθρου"
+
+#: id:21390
+msgid "Power management level"
+msgstr "Διαχείριση παροχής ενέργειας"
+
+#: id:21391
+msgid "High power"
+msgstr "Υψηλή τροφοδοσία"
+
+#: id:21392
+msgid "Low power"
+msgstr "Χαμηλή τροφοδοσία"
+
+#: id:21393
+msgid "High standby"
+msgstr "Υψηλή αναμονή"
+
+#: id:21394
+msgid "Low standby"
+msgstr "Χαμηλή αναμονή"
+
+#: id:21395
+msgid "Unable to cache files bigger than 4GB"
+msgstr "Αδυναμία δημιουργίας προσωρινών αρχείων μεγαλύτερων από 4GB"
+
+#: id:21396
+msgid "Chapter"
+msgstr "Κεφάλαιο"
+
+#: id:21397
+msgid "High quality pixel shader v2"
+msgstr "Υψηλή ποιότητα (Σκίαση pixel v2)"
+
+#: id:21398
+msgid "Enable playlist at startup"
+msgstr "Ενεργοποίηση λίστας αναπαραγωγής κατά την εκκίνηση"
+
+#: id:21399
+msgid "Use tween animations"
+msgstr "Ενεργοποίηση εφέ παλινδρομικής κίνησης"
+
+#: id:21400
+msgid "contains"
+msgstr "περιέχει"
+
+#: id:21401
+msgid "does not contain"
+msgstr "δεν περιέχει"
+
+#: id:21402
+msgid "is"
+msgstr "είναι"
+
+#: id:21403
+msgid "is not"
+msgstr "δεν είναι"
+
+#: id:21404
+msgid "starts with"
+msgstr "αρχίζει με"
+
+#: id:21405
+msgid "ends with"
+msgstr "τελειώνει σε"
+
+#: id:21406
+msgid "greater than"
+msgstr "μεγαλύτερο από"
+
+#: id:21407
+msgid "less than"
+msgstr "μικρότερο από"
+
+#: id:21408
+msgid "after"
+msgstr "μετά"
+
+#: id:21409
+msgid "before"
+msgstr "πριν"
+
+#: id:21410
+msgid "in the last"
+msgstr "στο τελευταίο"
+
+#: id:21411
+msgid "not in the last"
+msgstr "όχι στο τελευταίο"
+
+#: id:21412
+msgid "Scrapers"
+msgstr "Scraper"
+
+#: id:21413
+msgid "Default movie scraper"
+msgstr "Προεπιλεγμένο scraper ταινιών"
+
+#: id:21414
+msgid "Default tvshow scraper"
+msgstr "Προεπιλεγμένο scraper τηλεοπτικών σειρών"
+
+#: id:21415
+msgid "Default music video scraper"
+msgstr "Προεπιλεγμένο scraper μουσικών βίντεο"
+
+#: id:21416
+msgid "Enable fallback based on scraper language"
+msgstr "Ενεργοποίηση εναλλακτικής βάσει της γλώσσας του scraper"
+
+#: id:21417
+msgid "- Settings"
+msgstr "- Ρυθμίσεις"
+
+#: id:21418
+msgid "Multilingual"
+msgstr "Πολύγλωσσο"
+
+#: id:21419
+msgid "No scrapers present"
+msgstr "Δεν υπάρχει διαθέσιμο scraper"
+
+#: id:21420
+msgid "Value to match"
+msgstr "Τιμή για αντιστοίχιση"
+
+#: id:21421
+msgid "Smart playlist rule"
+msgstr "Κανόνας έξυπνης λίστας αναπαραγωγής"
+
+#: id:21422
+msgid "Match items where"
+msgstr "Αντιστοίχιση αντικειμένων όταν"
+
+#: id:21423
+msgid "New rule..."
+msgstr "Νέος κανόνας..."
+
+#: id:21424
+msgid "Items must match"
+msgstr "Τα αντικείμενα πρέπει να πληρούν"
+
+#: id:21425
+msgid "all of the rules"
+msgstr "όλους τους κανόνες"
+
+#: id:21426
+msgid "one or more of the rules"
+msgstr "έναν ή περισσότερους κανόνες"
+
+#: id:21427
+msgid "Limit to"
+msgstr "Αριθμητικό όριο"
+
+#: id:21428
+msgid "No limit"
+msgstr "Χωρίς περιορισμό"
+
+#: id:21429
+msgid "Order by"
+msgstr "Σειρά κατά"
+
+#: id:21430
+msgid "ascending"
+msgstr "αύξουσα"
+
+#: id:21431
+msgid "descending"
+msgstr "φθίνουσα"
+
+#: id:21432
+msgid "Edit smart playlist"
+msgstr "Επεξεργασία έξυπνης λίστας αναπαραγωγής"
+
+#: id:21433
+msgid "Name of the playlist"
+msgstr "Όνομα λίστας αναπαραγωγής"
+
+#: id:21434
+msgid "Find items where"
+msgstr "Εύρεση αντικειμένων για τα οποία"
+
+#: id:21435
+msgid "Edit"
+msgstr "Επεξεργασία"
+
+#: id:21436
+msgid "%i items"
+msgstr "%i αντικείμενα"
+
+#: id:21437
+msgid "New smart playlist..."
+msgstr "Νέα έξυπνη λίστα αναπαραγωγής..."
+
+#: id:21438
+msgid "%c Drive"
+msgstr "%c Δίσκος"
+
+#: id:21439
+msgid "Edit party mode rules"
+msgstr "Επεξεργασία κανόνων Party Mode"
+
+#: id:21440
+msgid "Home folder"
+msgstr "Αρχικός φάκελος"
+
+#: id:21441
+msgid "Watched count"
+msgstr "Πλήθος προβληθέντων"
+
+#: id:21442
+msgid "Episode title"
+msgstr "Τίτλος επεισοδίου"
+
+#: id:21443
+msgid "Video resolution"
+msgstr "Ανάλυση βίντεο"
+
+#: id:21444
+msgid "Audio channels"
+msgstr "Κανάλια ήχου"
+
+#: id:21445
+msgid "Video codec"
+msgstr "Κωδικοποίηση βίντεο"
+
+#: id:21446
+msgid "Audio codec"
+msgstr "Κωδικοποίηση ήχου"
+
+#: id:21447
+msgid "Audio language"
+msgstr "Γλώσσα ήχου"
+
+#: id:21448
+msgid "Subtitle language"
+msgstr "Γλώσσα υποτίτλων"
+
+#: id:21449
+msgid "Remote control sends keyboard presses"
+msgstr "Το τηλεχειριστήριο στέλνει εντολές πληκτρολογίου"
+
+#: id:21450
+msgid "- Edit"
+msgstr "- Επεξεργασία"
+
+#: id:21451
+msgid "Internet connection required."
+msgstr "Απαιτείται σύνδεση στο Διαδίκτυο."
+
+#: id:21452
+msgid "Get More..."
+msgstr "Λήψη Περισσότερων..."
+
+#: id:21453
+msgid "Root filesystem"
+msgstr "Σύστημα αρχείων root"
+
+#: id:21454
+msgid "Cache full"
+msgstr "Λανθάνουσα μνήμη πλήρης"
+
+#: id:21455
+msgid "Cache filled before reaching required amount for continous playback"
+msgstr "Η λανθάνουσα μνήμη γέμισε πριν φθάσει το απαιτούμενο μέγεθος για συνεχόμενη αναπαραγωγή"
+
+#: id:21460
+msgid "Subtitle location"
+msgstr "Θέση υποτίτλου"
+
+#: id:21461
+msgid "Fixed"
+msgstr "Σταθερή"
+
+#: id:21462
+msgid "Bottom of video"
+msgstr "Κάτω πλευρά του βίντεο"
+
+#: id:21463
+msgid "Below video"
+msgstr "Κάτω από το βίντεο"
+
+#: id:21464
+msgid "Top of video"
+msgstr "Πάνω πλευρά του βίντεο"
+
+#: id:21465
+msgid "Above video"
+msgstr "Πάνω από το βίντεο"
+
+#: id:21800
+msgid "File name"
+msgstr "Όνομα αρχείου"
+
+#: id:21801
+msgid "File path"
+msgstr "Διαδρομή αρχείου"
+
+#: id:21802
+msgid "File size"
+msgstr "Μέγεθος αρχείου"
+
+#: id:21803
+msgid "File date/time"
+msgstr "Ημερομηνία αρχείου"
+
+#: id:21804
+msgid "Slide index"
+msgstr "Θέση διαφάνειας"
+
+#: id:21805
+msgctxt "Auto context with id 21805"
+msgid "Resolution"
+msgstr "Ανάλυση"
+
+#: id:21806
+msgctxt "Auto context with id 21806"
+msgid "Comment"
+msgstr "Σχόλιο"
+
+#: id:21807
+msgid "Colour/B&W"
+msgstr "Έγχρωμη/Ασπρόμαυρη"
+
+#: id:21808
+msgid "JPEG process"
+msgstr "Επεξεργασία JPEG"
+
+#: id:21820
+msgid "Date/Time"
+msgstr "Ημερομηνία/Ώρα"
+
+#: id:21821
+msgid "Description"
+msgstr "Περιγραφή"
+
+#: id:21822
+msgid "Camera make"
+msgstr "Κατασκευαστής κάμερας"
+
+#: id:21823
+msgid "Camera model"
+msgstr "Μοντέλο κάμερας"
+
+#: id:21824
+msgid "EXIF comment"
+msgstr "Σχόλια EXIF"
+
+#: id:21825
+msgid "Firmware"
+msgstr "Έκδοση υλικού"
+
+#: id:21826
+msgid "Aperture"
+msgstr "Διάφραγμα"
+
+#: id:21827
+msgid "Focal length"
+msgstr "Εστιακή απόσταση"
+
+#: id:21828
+msgid "Focus distance"
+msgstr "Απόσταση αντικειμένου"
+
+#: id:21829
+msgid "Exposure"
+msgstr "Έκθεση"
+
+#: id:21830
+msgid "Exposure time"
+msgstr "Χρόνος έκθεσης"
+
+#: id:21831
+msgid "Exposure bias"
+msgstr "Πόλωση έκθεσης"
+
+#: id:21832
+msgid "Exposure mode"
+msgstr "Μέθοδος έκθεσης"
+
+#: id:21833
+msgid "Flash used"
+msgstr "Χρήση φλας"
+
+#: id:21834
+msgid "White-balance"
+msgstr "Ισορροπία λευκού"
+
+#: id:21835
+msgid "Light source"
+msgstr "Φωτεινή πηγή"
+
+#: id:21836
+msgid "Metering mode"
+msgstr "Λειτουργία μέτρησης"
+
+#: id:21837
+msgid "ISO"
+msgstr "Ευαισθησία ISO"
+
+#: id:21838
+msgid "Digital zoom"
+msgstr "Ψηφιακή μεγέθυνση"
+
+#: id:21839
+msgid "CCD width"
+msgstr "Πλάτος CCD"
+
+#: id:21840
+msgid "GPS latitude"
+msgstr "GPS γεωγρ. πλάτος"
+
+#: id:21841
+msgid "GPS longitude"
+msgstr "GPS γεωγρ. μήκος"
+
+#: id:21842
+msgid "GPS altitude"
+msgstr "GPS υψόμετρο"
+
+#: id:21843
+msgid "Orientation"
+msgstr "Προσανατολισμός"
+
+#: id:21860
+msgid "Supplemental categories"
+msgstr "Συμπληρωματικές πληροφορίες"
+
+#: id:21861
+msgid "Keywords"
+msgstr "Λέξεις κλειδιά"
+
+#: id:21862
+msgid "Caption"
+msgstr "Λεζάντα"
+
+#: id:21863
+msgid "Author"
+msgstr "Δημιουργός"
+
+#: id:21864
+msgid "Headline"
+msgstr "Επικεφαλίδα"
+
+#: id:21865
+msgid "Special instructions"
+msgstr "Ειδικές πληροφορίες"
+
+#: id:21866
+msgid "Category"
+msgstr "Κατηγορία"
+
+#: id:21867
+msgid "Byline"
+msgstr "Προέλευση"
+
+#: id:21868
+msgid "Byline title"
+msgstr "Τίτλος"
+
+#: id:21869
+msgid "Credit"
+msgstr "Ειδική μνεία"
+
+#: id:21870
+msgid "Source"
+msgstr "Πηγή"
+
+#: id:21871
+msgid "Copyright notice"
+msgstr "Σημειώσεις πνευματικής ιδιοκτησίας"
+
+#: id:21872
+msgid "Object name"
+msgstr "Όνομα αντικειμένου"
+
+#: id:21873
+msgid "City"
+msgstr "Πόλη"
+
+#: id:21874
+msgid "State"
+msgstr "Πολιτεία"
+
+#: id:21875
+msgctxt "Auto context with id 21875"
+msgid "Country"
+msgstr "Χώρα"
+
+#: id:21876
+msgid "Original Tx Reference"
+msgstr "Νομοθετικές πληροφορίες"
+
+#: id:21877
+msgid "Date created"
+msgstr "Ημερομηνία δημιουργίας"
+
+#: id:21878
+msgid "Copyright flag"
+msgstr "Πνευματικά δικαιώματα"
+
+#: id:21879
+msgid "Country code"
+msgstr "Κωδικός χώρας"
+
+#: id:21880
+msgid "Reference service"
+msgstr "Υπηρεσία πληροφόρησης"
+
+#: id:21881
+msgid "Allow control of XBMC via UPnP"
+msgstr "Έγκριση ελέγχου του XBMC μέσω UPnP"
+
+#: id:21882
+msgid "Attempt to skip introduction before DVD menu"
+msgstr "Απόπειρα αποφυγής οδηγιών πριν το μενού DVD"
+
+#: id:21883
+msgid "Saved music"
+msgstr "Αποθηκευμένη μουσική"
+
+#: id:21884
+msgid "Query info for all artists"
+msgstr "Εύρεση πληροφοριών για όλους τους καλλιτέχνες"
+
+#: id:21885
+msgid "Downloading album information"
+msgstr "Λήψη πληροφοριών για το άλμπουμ"
+
+#: id:21886
+msgid "Downloading artist information"
+msgstr "Λήψη πληροφοριών για τον καλλιτέχνη"
+
+#: id:21887
+msgid "Biography"
+msgstr "Βιογραφικό"
+
+#: id:21888
+msgid "Discography"
+msgstr "Δισκογραφία"
+
+#: id:21889
+msgid "Searching artist"
+msgstr "Αναζήτηση καλλιτέχνη"
+
+#: id:21890
+msgid "Select artist"
+msgstr "Επιλογή καλλιτέxνη"
+
+#: id:21891
+msgctxt "Auto context with id 21891"
+msgid "Artist information"
+msgstr "Πληροφορίες καλλιτέχνη"
+
+#: id:21892
+msgid "Instruments"
+msgstr "Όργανα"
+
+#: id:21893
+msgid "Born"
+msgstr "Γεννήθηκε"
+
+#: id:21894
+msgid "Formed"
+msgstr "Δημιουργία"
+
+#: id:21895
+msgid "Themes"
+msgstr "Θεματολόγιο"
+
+#: id:21896
+msgid "Disbanded"
+msgstr "Διαλύθηκε"
+
+#: id:21897
+msgid "Died"
+msgstr "Πέθανε"
+
+#: id:21898
+msgid "Years active"
+msgstr "Έτη ενεργής σταδιοδρομίας"
+
+#: id:21899
+msgid "Label"
+msgstr "Ετικέτα"
+
+#: id:21900
+msgid "Born/Formed"
+msgstr "Γέννηση/Δημιουργία"
+
+#: id:22000
+msgid "Update library on startup"
+msgstr "Ενημέρωση της συλλογής κατά την εκκίνηση"
+
+#: id:22001
+msgid "Hide progress of library updates"
+msgstr "Απόκρυψη εξέλιξης ενημερώσεων συλλογής"
+
+#: id:22002
+msgid "- DNS suffix"
+msgstr "- Κατάληξη DNS"
+
+#: id:22003
+msgid "%2.3fs"
+msgstr "%2.3fs"
+
+#: id:22004
+msgid "Delayed by: %2.3fs"
+msgstr "Καθυστέρηση κατά: %2.3fs"
+
+#: id:22005
+msgid "Ahead by: %2.3fs"
+msgstr "Προβάδισμα κατά: %2.3fs"
+
+#: id:22006
+msgid "Subtitle offset"
+msgstr "Μετατόπιση υποτίτλων"
+
+#: id:22007
+msgid "OpenGL vendor:"
+msgstr "Κατασκευαστής OpenGL:"
+
+#: id:22008
+msgid "OpenGL renderer:"
+msgstr "Αποτυπωτής OpenGL:"
+
+#: id:22009
+msgid "OpenGL version:"
+msgstr "Έκδοση OpenGL:"
+
+#: id:22010
+msgid "GPU temperature:"
+msgstr "Θερμοκρασία GPU:"
+
+#: id:22011
+msgid "CPU temperature:"
+msgstr "Θερμοκρασία CPU:"
+
+#: id:22012
+msgid "Total memory"
+msgstr "Συνολική μνήμη"
+
+#: id:22013
+msgid "Profile data"
+msgstr "Δεδομένα προφίλ"
+
+#: id:22014
+msgid "Use dim if paused during video playback"
+msgstr "Χρήση 'Αμυδρού φωτός' κατά την παύση αναπαραγωγής βίντεο"
+
+#: id:22015
+msgid "All recordings"
+msgstr "Όλες οι εγγραφές"
+
+#: id:22016
+msgid "By title"
+msgstr "Aνά τίτλο"
+
+#: id:22017
+msgid "By group"
+msgstr "Ανά ομάδα"
+
+#: id:22018
+msgid "Live channels"
+msgstr "Δικτυακά κανάλια"
+
+#: id:22019
+msgid "Recordings by title"
+msgstr "Εγγραφές ανά τίτλο"
+
+#: id:22020
+msgid "Guide"
+msgstr "Οδηγός"
+
+#: id:22021
+msgid "Allowed error in aspect ratio to minimize black bars"
+msgstr "Σφάλμα αναλογίας οθόνης για μείωση μαύρων μπαρών"
+
+#: id:22022
+msgid "Show video files in listings"
+msgstr "Εμφάνιση αρχείων βίντεο στις λίστες"
+
+#: id:22023
+msgid "DirectX vendor:"
+msgstr "Κατασκευαστής DirectX:"
+
+#: id:22024
+msgid "Direct3D version:"
+msgstr "Έκδοση Direct3D:"
+
+#: id:22030
+msgctxt "Auto context with id 22030"
+msgid "Font"
+msgstr "Γραμματοσειρά"
+
+#: id:22031
+msgctxt "Auto context with id 22031"
+msgid "- Size"
+msgstr "- Μέγεθος"
+
+#: id:22032
+msgctxt "Auto context with id 22032"
+msgid "- Colours"
+msgstr "- Χρώματα"
+
+#: id:22033
+msgid "- Charset"
+msgstr "- Κωδικοποίηση χαρακτήρων"
+
+#: id:22034
+msgid "Export karaoke titles as HTML"
+msgstr "Εξαγωγή τίτλων karaoke ως HTML"
+
+#: id:22035
+msgid "Export karaoke titles as CSV"
+msgstr "Εξαγωγή τίτλων karaoke ως CSV"
+
+#: id:22036
+msgid "Import karaoke titles..."
+msgstr "Εισαγωγή τίτλων karaoke..."
+
+#: id:22037
+msgid "Show song selector automatically"
+msgstr "Αυτόματη εμφάνιση επιλογέα τραγουδιών"
+
+#: id:22038
+msgid "Export karaoke titles..."
+msgstr "Εξαγωγή τίτλων karaoke..."
+
+#: id:22039
+msgid "Enter song number"
+msgstr "Εισαγωγή αριθμού τραγουδιού"
+
+#: id:22040
+msgid "white/green"
+msgstr "άσπρο/πράσινο"
+
+#: id:22041
+msgid "white/red"
+msgstr "άσπρο/κόκκινο"
+
+#: id:22042
+msgid "white/blue"
+msgstr "άσπρο/μπλε"
+
+#: id:22043
+msgid "black/white"
+msgstr "μαύρο/άσπρο"
+
+#: id:22079
+msgid "Default select action"
+msgstr "Προεπιλεγμένη ενέργεια"
+
+#: id:22080
+msgid "Choose"
+msgstr "Επιλογή"
+
+#: id:22081
+msgid "Show Information"
+msgstr "Προβολή πληροφοριών"
+
+#: id:22082
+msgid "More..."
+msgstr "Περισσότερα..."
+
+#: id:22083
+msgid "Play all"
+msgstr "Αναπαραγωγή όλων"
+
+#: id:23049
+msgid "Teletext not available"
+msgstr "Μη διαθέσιμο Teletext"
+
+#: id:23050
+msgid "Activate Teletext"
+msgstr "Ενεργοποίηση Teletext"
+
+#: id:23051
+msgid "Part %i"
+msgstr "Μέρος %i"
+
+#: id:23052
+msgid "Buffering %i bytes"
+msgstr "Aποθήκευση %i bytes"
+
+#: id:23053
+msgid "Stopping"
+msgstr "Διακόπτεται"
+
+#: id:23054
+msgid "Running"
+msgstr "Εκτελείται"
+
+#: id:23100
+msgid "External Player Active"
+msgstr "Ενεργός εξωτερικός αναπαραγωγέας"
+
+#: id:23101
+msgid "Click OK to terminate the player"
+msgstr "Πιέστε 'Επιλογή' για να τερματίσετε την αναπαραγωγή"
+
+#: id:23104
+msgid "Click OK when playback has ended"
+msgstr "Πιέστε 'Επιλογή' όταν η αναπαραγωγή ολοκληρωθεί"
+
+#: id:24000
+msgid "Add-on"
+msgstr "Πρόσθετο"
+
+#: id:24001
+msgid "Add-ons"
+msgstr "Πρόσθετα"
+
+#: id:24002
+msgid "Add-on options"
+msgstr "Ρυθμίσεις πρόσθετου"
+
+#: id:24003
+msgid "Add-on Information"
+msgstr "Πληροφορίες πρόσθετου"
+
+#: id:24005
+msgctxt "Auto context with id 24005"
+msgid "Media sources"
+msgstr "Πηγές πολυμέσων"
+
+#: id:24007
+msgctxt "Auto context with id 24007"
+msgid "Movie information"
+msgstr "Πληροφορίες ταινίας"
+
+#: id:24008
+msgctxt "Auto context with id 24008"
+msgid "Screensaver"
+msgstr "Προφύλαξη οθόνης"
+
+#: id:24009
+msgid "Script"
+msgstr "Script"
+
+#: id:24010
+msgctxt "Auto context with id 24010"
+msgid "Visualization"
+msgstr "Οπτικοποίηση"
+
+#: id:24011
+msgid "Add-on repository"
+msgstr "Αποθετήριο πρόσθετων"
+
+#: id:24012
+msgctxt "Auto context with id 24012"
+msgid "Subtitles"
+msgstr "Υπότιτλοι"
+
+#: id:24013
+msgid "Lyrics"
+msgstr "Στίχοι"
+
+#: id:24014
+msgid "TV information"
+msgstr "Πληροφορίες τηλεόρασης"
+
+#: id:24015
+msgctxt "Auto context with id 24015"
+msgid "Music video information"
+msgstr "Πληροφορίες μουσικού βίντεο"
+
+#: id:24016
+msgctxt "Auto context with id 24016"
+msgid "Album information"
+msgstr "Πληροφορίες άλμπουμ"
+
+#: id:24017
+msgctxt "Auto context with id 24017"
+msgid "Artist information"
+msgstr "Πληροφορίες καλλιτέχνη"
+
+#: id:24018
+msgctxt "Auto context with id 24018"
+msgid "Services"
+msgstr "Υπηρεσίες"
+
+#: id:24020
+msgid "Configure"
+msgstr "Ρύθμιση"
+
+#: id:24021
+msgctxt "Auto context with id 24021"
+msgid "Disable"
+msgstr "Απενεργοποίηση"
+
+#: id:24022
+msgid "Enable"
+msgstr "Ενεργοποίηση"
+
+#: id:24023
+msgid "Add-on disabled"
+msgstr "Απενεργοποιημένο πρόσθετο"
+
+#: id:24027
+msgctxt "Auto context with id 24027"
+msgid "Weather"
+msgstr "Καιρός"
+
+#: id:24028
+msgid "Weather.com (standard)"
+msgstr "Weather.com (βασική)"
+
+#: id:24030
+msgid "This Add-on can not be configured"
+msgstr "Δεν είναι δυνατή η ρύθμιση αυτού του πρόσθετου"
+
+#: id:24031
+msgid "Error loading settings"
+msgstr "Σφάλμα στη λήψη ρυθμίσεων"
+
+#: id:24032
+msgid "All Add-ons"
+msgstr "Όλα τα πρόσθετα"
+
+#: id:24033
+msgid "Get Add-ons"
+msgstr "Λήψη πρόσθετων"
+
+#: id:24034
+msgid "Check for updates"
+msgstr "Έλεγχος για ενημερώσεις"
+
+#: id:24035
+msgid "Force refresh"
+msgstr "Εξαναγκασμένη ανανέωση"
+
+#: id:24036
+msgid "Change log"
+msgstr "Καταγραφή αλλαγών"
+
+#: id:24037
+msgid "Uninstall"
+msgstr "Κατάργηση εγκατάστασης"
+
+#: id:24038
+msgid "Install"
+msgstr "Εγκατάσταση"
+
+#: id:24039
+msgid "Disabled Add-ons"
+msgstr "Απενεργοποιημένα πρόσθετα"
+
+#: id:24040
+msgid "(Clear the current setting)"
+msgstr "(Απαλοιφή της τρέχουσας ρύθμισης)"
+
+#: id:24041
+msgid "Install from zip file"
+msgstr "Εγκατάσταση από αρχείο zip"
+
+#: id:24042
+msgid "Downloading %i%%"
+msgstr "Λήψη %i%%"
+
+#: id:24043
+msgid "Available Updates"
+msgstr "Διαθέσιμες ενημερώσεις"
+
+#: id:24044
+msgid "Dependencies not met"
+msgstr "Δεν πληρούνται οι εξαρτήσεις"
+
+#: id:24045
+msgid "Add-on does not have the correct structure"
+msgstr "Το πρόσθετο δεν έχει τη σωστή δομή"
+
+#: id:24046
+msgid "%s is used by the following installed add-on(s)"
+msgstr "Το %s χρησιμοποιείται από τα εγκατεστημένα πρόσθετα"
+
+#: id:24047
+msgid "This add-on cannot be uninstalled"
+msgstr "Αδυναμία απεγκατάστασης αυτού του πρόσθετου"
+
+#: id:24048
+msgid "Rollback"
+msgstr "Επαναφορά"
+
+#: id:24050
+msgid "Available Add-ons"
+msgstr "Διαθέσιμα πρόσθετα"
+
+#: id:24051
+msgid "Version:"
+msgstr "Έκδοση:"
+
+#: id:24052
+msgid "Disclaimer"
+msgstr "Αποποίηση ευθυνών"
+
+#: id:24053
+msgid "License:"
+msgstr "Άδεια χρήσης:"
+
+#: id:24054
+msgid "Changelog"
+msgstr "Αρχείο καταγραφής αλλαγών"
+
+#: id:24059
+msgid "Would you like to enable this Add-on?"
+msgstr "Επιθυμείτε να ενεργοποιηθεί αυτό το πρόσθετο;"
+
+#: id:24060
+msgid "Would you like to disable this Add-on?"
+msgstr "Επιθυμείτε να απενεργοποιηθεί αυτό το πρόσθετο;"
+
+#: id:24061
+msgid "Add-on update available!"
+msgstr "Διαθέσιμη ενημέρωση πρόσθετου!"
+
+#: id:24062
+msgid "Enabled Add-ons"
+msgstr "Ενεργοποιημένα πρόσθετα"
+
+#: id:24063
+msgid "Auto update"
+msgstr "Αυτόματη ενημέρωση"
+
+#: id:24064
+msgid "Add-on enabled"
+msgstr "Το πρόσθετο ενεργοποιήθηκε"
+
+#: id:24065
+msgid "Add-on updated"
+msgstr "Το πρόσθετο ενημερώθηκε"
+
+#: id:24066
+msgid "Cancel Add-on download?"
+msgstr "Ακύρωση λήψης πρόσθετου;"
+
+#: id:24067
+msgid "Currently downloading Add-ons"
+msgstr "Γίνεται λήψη πρόσθετων"
+
+#: id:24068
+msgid "Update available"
+msgstr "Διαθέσιμη ενημέρωση"
+
+#: id:24069
+msgid "Update"
+msgstr "Ενημέρωση"
+
+#: id:24070
+msgid "Add-on could not be loaded."
+msgstr "Αδυναμία χρήσης πρόσθετου."
+
+#: id:24071
+msgid "An unknown error has occurred."
+msgstr "Παρουσιάστηκε άγνωστο σφάλμα."
+
+#: id:24072
+msgid "Settings required"
+msgstr "Απαιτούνται ρυθμίσεις"
+
+#: id:24073
+msgid "Could not connect"
+msgstr "Δεν ήταν δυνατή η σύνδεση"
+
+#: id:24074
+msgid "Needs to restart"
+msgstr "Απαιτείται επανεκκίνηση"
+
+#: id:24075
+msgctxt "Auto context with id 24075"
+msgid "Disable"
+msgstr "Απενεργοποίηση"
+
+#: id:24076
+msgid "Add-on Required"
+msgstr "Απαιτείται πρόσθετο"
+
+#: id:24080
+msgid "Try to reconnect?"
+msgstr "Νέα προσπάθεια επανασύνδεσης;"
+
+#: id:24089
+msgid "Add-on restarts"
+msgstr "Επανεκκινήσεις πρόσθετου"
+
+#: id:24090
+msgid "Lock Add-on manager"
+msgstr "Κλείδωμα διαχειριστή πρόσθετων"
+
+#: id:24094
+msgid "(current)"
+msgstr "(τρέχων)"
+
+#: id:24095
+msgid "(blacklisted)"
+msgstr "(ανεπιθύμητο)"
+
+#: id:24096
+msgid "Add-on has been marked as broken in repository."
+msgstr "Το πρόσθετο έχει επισημανθεί ως κατεστραμμένο στο αποθετήριο."
+
+#: id:24097
+msgid "Would you like to disable it on your system?"
+msgstr "Επιθυμείτε να απενεργοποιηθεί από το σύστημά σας;"
+
+#: id:24098
+msgid "Broken"
+msgstr "Κατεστραμμένο"
+
+#: id:24099
+msgid "Would you like to switch to this skin?"
+msgstr "Επιθυμείτε να εφαρμοστεί αυτό το κέλυφος;"
+
+#: id:24100
+msgid "To use this feature you must download an Add-on:"
+msgstr "Για να χρησιμοποιήσετε αυτή τη λειτουργία πρέπει να κατεβάσετε ένα πρόσθετο:"
+
+#: id:24101
+msgid "Would you like to download this Add-on?"
+msgstr "Επιθυμείτε να κατεβάσετε αυτό το πρόσθετο;"
+
+#: id:25000
+msgid "Notifications"
+msgstr "Ειδοποιήσεις"
+
+#: id:29800
+msgid "Library Mode"
+msgstr "Λειτουργία Συλλογής"
+
+#: id:29801
+msgid "QWERTY keyboard"
+msgstr "Διάταξη πληκτρολογίου QWERTY"
+
+#: id:29802
+msgid "Passthrough Audio in use"
+msgstr "Σε λειτουργία η διέλευση ήχου"
+
+#: id:33001
+msgid "Trailer quality"
+msgstr "Ποιότητα διαφημιστικού"
+
+#: id:33002
+msgid "Stream"
+msgstr "Ροή πολυμέσων"
+
+#: id:33003
+msgid "Download"
+msgstr "Λήψη"
+
+#: id:33004
+msgid "Download & play"
+msgstr "Λήψη & εκτέλεση"
+
+#: id:33005
+msgid "Download & save"
+msgstr "Λήψη & αποθήκευση"
+
+#: id:33006
+msgid "Today"
+msgstr "Σήμερα"
+
+#: id:33007
+msgid "Tomorrow"
+msgstr "Αύριο"
+
+#: id:33008
+msgid "Saving"
+msgstr "Αποθήκευση"
+
+#: id:33009
+msgid "Copying"
+msgstr "Αντιγραφή"
+
+#: id:33010
+msgid "Set download directory"
+msgstr "Ορισμός φακέλου λήψης"
+
+#: id:33011
+msgid "Search duration"
+msgstr "Αναζήτηση διάρκειας"
+
+#: id:33012
+msgid "Short"
+msgstr "Σύντομος"
+
+#: id:33013
+msgid "Long"
+msgstr "Εκτεταμένος"
+
+#: id:33014
+msgid "Use DVD player instead of regular player"
+msgstr "Ορισμός αναπαραγωγέα DVD αντί του κανονικού"
+
+#: id:33015
+msgid "Ask for download before playing video"
+msgstr "Επιβεβαίωση λήψης πριν την αναπαραγωγή του βίντεο"
+
+#: id:33016
+msgid "Clips"
+msgstr "Clip"
+
+#: id:33017
+msgid "Restart plugin to enable"
+msgstr "Επανεκκίνηση plugin για την ενεργοποίησή του"
+
+#: id:33018
+msgid "Tonight"
+msgstr "Απόψε"
+
+#: id:33019
+msgid "Tomorrow Night"
+msgstr "Αύριο βράδυ"
+
+#: id:33020
+msgid "Condition"
+msgstr "Kατάσταση καιρού"
+
+#: id:33021
+msgid "Precipitation"
+msgstr "Υετός"
+
+#: id:33022
+msgid "Precip"
+msgstr "Βροχή"
+
+#: id:33023
+msgid "Humid"
+msgstr "Υγρασία"
+
+#: id:33024
+msgid "Feels"
+msgstr "Αίσθηση"
+
+#: id:33025
+msgid "Observed"
+msgstr "Παρατηρούμενη"
+
+#: id:33026
+msgid "Departure from normal"
+msgstr "Παρέκκλιση από το κανονικό"
+
+#: id:33027
+msgid "Sunrise"
+msgstr "Ανατολή ηλίου"
+
+#: id:33028
+msgid "Sunset"
+msgstr "Δύση ηλίου"
+
+#: id:33029
+msgid "Details"
+msgstr "Λεπτομέρειες"
+
+#: id:33030
+msgid "Outlook"
+msgstr "Πρόγνωση"
+
+#: id:33031
+msgid "Coverflow"
+msgstr "Ροή εξωφύλλων"
+
+#: id:33032
+msgid "Translate text"
+msgstr "Μετάφραση κειμένου"
+
+#: id:33033
+msgid "Map list %s category"
+msgstr "Κατηγορία λίστας χαρτών %s"
+
+#: id:33034
+msgid "36 Hour"
+msgstr "36ωρο"
+
+#: id:33035
+msgid "Maps"
+msgstr "Χάρτες"
+
+#: id:33036
+msgid "Hourly"
+msgstr "Ωριαία"
+
+#: id:33037
+msgid "Weekend"
+msgstr "Σαββατοκύριακο"
+
+#: id:33038
+msgid "%s day"
+msgstr "%sη ημέρα"
+
+#: id:33049
+msgid "Alert"
+msgstr "Προειδοποίηση"
+
+#: id:33050
+msgid "Alerts"
+msgstr "Προειδοποιήσεις"
+
+#: id:33051
+msgid "Choose Your"
+msgstr "Επιλογή"
+
+#: id:33052
+msgid "Check"
+msgstr "Έλεγχος"
+
+#: id:33053
+msgctxt "Auto context with id 33053"
+msgid "Configure the"
+msgstr "Ρύθμιση"
+
+#: id:33054
+msgid "Seasons"
+msgstr "Κύκλοι"
+
+#: id:33055
+msgid "Use your"
+msgstr "Εκτέλεση"
+
+#: id:33056
+msgid "Watch your"
+msgstr "Παρακολούθηση"
+
+#: id:33057
+msgid "Listen to"
+msgstr "Ακρόαση"
+
+#: id:33058
+msgid "View your"
+msgstr "Προβολή"
+
+#: id:33059
+msgctxt "Auto context with id 33059"
+msgid "Configure the"
+msgstr "Ρύθμιση"
+
+#: id:33060
+msgid "Power"
+msgstr "Λειτουργία"
+
+#: id:33061
+msgid "Menu"
+msgstr "Μενού"
+
+#: id:33062
+msgid "Play the"
+msgstr "Αναπαραγωγή"
+
+#: id:33063
+msgid "Options"
+msgstr "Επιλογές"
+
+#: id:33065
+msgid "Editor"
+msgstr "Επεξεργαστής"
+
+#: id:33066
+msgid "About your"
+msgstr "Περιήγηση"
+
+#: id:33067
+msgid "Star rating"
+msgstr "Αξιολόγηση"
+
+#: id:33068
+msgid "Background"
+msgstr "Υπόβαθρο"
+
+#: id:33069
+msgid "Backgrounds"
+msgstr "Υπόβαθρα"
+
+#: id:33070
+msgid "Custom background"
+msgstr "Προσαρμοσμένο υπόβαθρο"
+
+#: id:33071
+msgid "Custom backgrounds"
+msgstr "Προσαρμοσμένα υπόβαθρα"
+
+#: id:33072
+msgid "View Readme"
+msgstr "Σημειώσεις έκδοσης"
+
+#: id:33073
+msgid "View Changelog"
+msgstr "Αλλαγές έκδοσης"
+
+#: id:33074
+msgid "This version of %s requires an"
+msgstr "Για να εκτελεστεί η έκδοση %s απαιτείται"
+
+#: id:33075
+msgid "XBMC revision of %s or greater to run."
+msgstr "η %s αναθεωρημένη έκδοση του XBMC ή νεώτερη."
+
+#: id:33076
+msgid "Please update XBMC."
+msgstr "Παρακαλώ αναβαθμίστε το XBMC."
+
+#: id:33077
+msgid "No data found!"
+msgstr "Δε βρέθηκαν δεδομένα!"
+
+#: id:33078
+msgid "Next page"
+msgstr "Επόμενη σελίδα"
+
+#: id:33079
+msgid "Love"
+msgstr "Αγαπητό"
+
+#: id:33080
+msgid "Hate"
+msgstr "Απεχθές"
+
+#: id:33081
+msgid "This file is stacked, select the part you want to play from."
+msgstr "Αυτό το αρχείο είναι στοιβαγμένο, επιλέξτε από που να γίνει αναπαραγωγή."
+
+#: id:33082
+msgid "Path to script"
+msgstr "Διαδρομή για το script"
+
+#: id:33083
+msgid "Enable custom script button"
+msgstr "Ενεργοποίηση προσαρμοσμένου πλήκτρου script"
+
+#: id:33100
+msgid "Failed to start"
+msgstr "Αποτυχία εκκίνησης"
+
+#: id:33101
+msgid "Webserver"
+msgstr "Διακομιστής ιστού"
+
+#: id:33102
+msgid "Event Server"
+msgstr "Διακομιστής Συμβάντων"
+
+#: id:33103
+msgid "Remote communication server"
+msgstr "Απομακρυσμένος Διακομιστής Επικοινωνίας"
+
+#: id:33200
+msgid "Detected New Connection"
+msgstr "Εντοπίστηκε Νέα Σύνδεση"
+
+#: id:34000
+msgid "Lame"
+msgstr "Lame"
+
+#: id:34001
+msgid "Vorbis"
+msgstr "Vorbis"
+
+#: id:34002
+msgid "Wav"
+msgstr "Wav"
+
+#: id:34003
+msgid "DXVA2"
+msgstr "DXVA2"
+
+#: id:34004
+msgid "VAAPI"
+msgstr "VAAPI"
+
+#: id:34005
+msgid "Flac"
+msgstr "Flac"
+
+#: id:34100
+msgid "Speaker Configuration"
+msgstr "Διάταξη ηχείων"
+
+#: id:34101
+msgid "2.0"
+msgstr "2.0"
+
+#: id:34102
+msgid "2.1"
+msgstr "2.1"
+
+#: id:34103
+msgid "3.0"
+msgstr "3.0"
+
+#: id:34104
+msgid "3.1"
+msgstr "3.1"
+
+#: id:34105
+msgid "4.0"
+msgstr "4.0"
+
+#: id:34106
+msgid "4.1"
+msgstr "4.1"
+
+#: id:34107
+msgid "5.0"
+msgstr "5.0"
+
+#: id:34108
+msgid "5.1"
+msgstr "5.1"
+
+#: id:34109
+msgid "7.0"
+msgstr "7.0"
+
+#: id:34110
+msgid "7.1"
+msgstr "7.1"
+
+#: id:34201
+msgid "Can't find a next item to play"
+msgstr "Αδυναμία εύρεσης επόμενου αντικειμένου για αναπαραγωγή"
+
+#: id:34202
+msgid "Can't find a previous item to play"
+msgstr "Αδυναμία εύρεσης προηγούμενου αντικειμένου για αναπαραγωγή"
+
+#: id:34300
+msgid "Failed to start zeroconf"
+msgstr "Αποτυχία εκκίνησης του zeroconf"
+
+#: id:34301
+msgid "Is Apple's Bonjour Service installed? See log for more info."
+msgstr "Είναι εγκατεστημένη η υπηρεσία Bonjour της Apple; Δείτε το αρχείο καταγραφής για περισσότερες πληροφορίες."
+
+#: id:34400
+msgid "Video Rendering"
+msgstr "Απόδοση Βίντεο"
+
+#: id:34401
+msgid "Failed to init video filters/scalers, falling back to bilinear scaling"
+msgstr "Αποτυχία χρήσης φίλτρων/scalers βίντεο, επαναφορά σε bilinear προσαρμογή ανάλυσης"
+
+#: id:34402
+msgid "Failed to initialize audio device"
+msgstr "Αποτυχία έναρξης της συσκευής ήχου"
+
+#: id:34403
+msgid "Check your audiosettings"
+msgstr "Ελέγξτε τις ρυθμίσεις ήχου"
+
+#: id:34404
+msgid "Use gestures for navigation:"
+msgstr ""
+
+#: id:34405
+msgid "1 finger swipe left,right,up,down for cursors"
+msgstr ""
+
+#: id:34406
+msgid "2 finger swipe left for backspace"
+msgstr ""
+
+#: id:34407
+msgid "1 finger single tap for enter"
+msgstr ""
+
+#: id:34408
+msgid "2 finger single tap for contextmenu"
+msgstr ""
+
+#: id:35000
+msgid "Peripherals"
+msgstr "Περιφερειακά"
+
+#: id:35001
+msgid "Generic HID device"
+msgstr "Γενική συσκευή HID"
+
+#: id:35002
+msgid "Generic network adapter"
+msgstr "Γενικός προσαρμογέας δικτύου"
+
+#: id:35003
+msgid "Generic disk"
+msgstr "Γενικός δίσκος"
+
+#: id:35004
+msgid "There are no settings available\nfor this peripheral."
+msgstr "Δεν υπάρχουν διαθέσιμες ρυθμίσεις\nγια αυτό το περιφερειακό."
+
+#: id:35005
+msgid "New device configured"
+msgstr "Η νέα συσκευή ρυθμίστηκε"
+
+#: id:35006
+msgid "Device removed"
+msgstr "Η συσκευή αφαιρέθηκε"
+
+#: id:35007
+msgid "Keymap to use for this device"
+msgstr "Keymap για χρήση με αυτή τη συσκευή"
+
+#: id:35008
+msgid "Keymap enabled"
+msgstr "Ενεργοποιημένο Keymap"
+
+#: id:35009
+msgid "Do not use the custom keymap for this device"
+msgstr ""
+
+#: id:35500
+msgid "Location"
+msgstr "Τοποθεσία"
+
+#: id:35501
+msgid "Class"
+msgstr "Κλάση"
+
+#: id:35502
+msgctxt "Auto context with id 35502"
+msgid "Name"
+msgstr "Όνομα"
+
+#: id:35503
+msgid "Vendor"
+msgstr "Προμηθευτής"
+
+#: id:35504
+msgid "Product ID"
+msgstr "Αναγνωριστικό προϊόντος"
+
+#: id:36000
+msgid "Pulse-Eight CEC adapter"
+msgstr "Προσαρμογέας Pulse-Eight CEC"
+
+#: id:36001
+msgid "Pulse-Eight Nyxboard"
+msgstr "Pulse-Eight Nyxboard"
+
+#: id:36002
+msgid "Switch to keyboard side command"
+msgstr "Μετάβαση στο πληκτρολόγιο εντολών"
+
+#: id:36003
+msgid "Switch to remote side command"
+msgstr "Ενεργοποίηση διακόπτη εντολών"
+
+#: id:36004
+msgid "Press \"user\" button command"
+msgstr "Πιέστε το \"user\" πλήκτρο εντολών"
+
+#: id:36005
+msgid "Enable switch side commands"
+msgstr "Ενεργοποίηση διακόπτη εντολών"
+
+#: id:36006
+msgid "Could not open the adapter"
+msgstr "Αδυναμία εκκίνησης του προσαρμογέα"
+
+#: id:36007
+msgid "Devices to power on when starting XBMC"
+msgstr "Ενεργοποίηση της τηλεόρασης κατά την εκκίνηση του XBMC"
+
+#: id:36008
+msgid "Devices to power off when stopping XBMC"
+msgstr "Απενεργοποίηση συσκευών κατά τον τερματισμό του XBMC"
+
+#: id:36009
+msgid "Put devices in standby mode when activating screensaver"
+msgstr "Συσκευές σε κατάσταση αναμονής κατά την προφύλαξη οθόνης"
+
+#: id:36011
+msgid "Could not detect the CEC port. Set it up manually."
+msgstr "Δεν εντοπίστηκε η θύρα CEC. Ρυθμίστε την χειροκίνητα."
+
+#: id:36012
+msgid "Could not initialise the CEC adapter. Check your settings."
+msgstr "Δεν εντοπίστηκε ο προσαρμογέας CEC."
+
+#: id:36013
+msgid "Unsupported libCEC interface version. %d is greater than the version XBMC supports (%d)"
+msgstr "Μη υποστηριζόμενη έκδοση libCEC. Η %d είναι μεγαλύτερη από την έκδοση που το XBMC υποστηρίζει (%d)"
+
+#: id:36014
+msgid "Put this PC in standby mode when the TV is switched off"
+msgstr "Ο υπολογιστής σε κατάσταση αναμονής όταν κλείσει η τηλεόραση"
+
+#: id:36015
+msgid "HDMI port number"
+msgstr "Αριθμός θύρας HDMI"
+
+#: id:36016
+msgctxt "Auto context with id 36016"
+msgid "Connected"
+msgstr "Συνδεδεμένη"
+
+#: id:36017
+msgid "Adapter found, but libCEC is not available"
+msgstr "O προσαρμογέας εντοπίσθηκε, αλλά η libCEC δεν είναι διαθέσιμη"
+
+#: id:36018
+msgid "Use the TV's language setting"
+msgstr "Χρήση των ρυθμίσεων γλώσσας της τηλεόρασης"
+
+#: id:36019
+msgid "Connected to HDMI device"
+msgstr ""
+
+#: id:36020
+msgid "Make XBMC the active source when starting"
+msgstr ""
+
+#: id:36021
+msgid "Physical address (overrules HDMI port)"
+msgstr ""
+
+#: id:36022
+msgid "COM port (leave empty unless needed)"
+msgstr ""
+
+#: id:36023
+msgid "Configuration updated"
+msgstr ""
+
+#: id:36024
+msgid "Failed to set the new configuration. Please check your settings."
+msgstr ""
+
+#: id:36025
+msgid "Send 'inactive source' command when stopping XBMC"
+msgstr ""
+

--- a/language/Hebrew/strings.po
+++ b/language/Hebrew/strings.po
@@ -1,0 +1,9093 @@
+# Converted from xbmc strings.xml with xbmc-xml2po (by Team-XBMC)
+msgid ""
+msgstr ""
+"Project-Id-Version: xbmc.core-FRODO_GIT3ed1604ad7\n"
+"Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
+"POT-Creation-Date: 2012-04-09 18:00+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE\n"
+"Language: he\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: id:0
+msgctxt "Auto context with id 0"
+msgid "Programs"
+msgstr "תוכנות"
+
+#: id:1
+msgctxt "Auto context with id 1"
+msgid "Pictures"
+msgstr "תמונות"
+
+#: id:2
+msgctxt "Auto context with id 2"
+msgid "Music"
+msgstr "מוסיקה"
+
+#: id:3
+msgctxt "Auto context with id 3"
+msgid "Videos"
+msgstr "וידאו"
+
+#: id:4
+msgid "TV-Guide"
+msgstr "מדריך תוכניות"
+
+#: id:5
+msgctxt "Auto context with id 5"
+msgid "Settings"
+msgstr "הגדרות"
+
+#: id:6
+msgid "XBMC SVN"
+msgstr ""
+
+#: id:7
+msgctxt "Auto context with id 7"
+msgid "File manager"
+msgstr "מנהל קבצים"
+
+#: id:8
+msgctxt "Auto context with id 8"
+msgid "Weather"
+msgstr "מזג האויר"
+
+#: id:9
+msgid "xbmc media center"
+msgstr "XBMC מדיה סנטר"
+
+#: id:11
+msgid "Monday"
+msgstr "יום שני"
+
+#: id:12
+msgid "Tuesday"
+msgstr "יום שלישי"
+
+#: id:13
+msgid "Wednesday"
+msgstr "יום רביעי"
+
+#: id:14
+msgid "Thursday"
+msgstr "יום חמישי"
+
+#: id:15
+msgid "Friday"
+msgstr "יום שישי"
+
+#: id:16
+msgid "Saturday"
+msgstr "יום שבת"
+
+#: id:17
+msgid "Sunday"
+msgstr "יום ראשון"
+
+#: id:21
+msgid "January"
+msgstr "ינואר"
+
+#: id:22
+msgid "February"
+msgstr "פברואר"
+
+#: id:23
+msgid "March"
+msgstr "מרץ"
+
+#: id:24
+msgid "April"
+msgstr "אפריל"
+
+#: id:25
+msgctxt "Auto context with id 25"
+msgid "May"
+msgstr "מאי"
+
+#: id:26
+msgid "June"
+msgstr "יוני"
+
+#: id:27
+msgid "July"
+msgstr "יולי"
+
+#: id:28
+msgid "August"
+msgstr "אוגוסט"
+
+#: id:29
+msgid "September"
+msgstr "ספטמבר"
+
+#: id:30
+msgid "October"
+msgstr "אוקטובר"
+
+#: id:31
+msgid "November"
+msgstr "נובמבר"
+
+#: id:32
+msgid "December"
+msgstr "דצמבר"
+
+#: id:41
+msgid "Mon"
+msgstr "שני"
+
+#: id:42
+msgid "Tue"
+msgstr "שלישי"
+
+#: id:43
+msgid "Wed"
+msgstr "רביעי"
+
+#: id:44
+msgid "Thu"
+msgstr "חמישי"
+
+#: id:45
+msgid "Fri"
+msgstr "שישי"
+
+#: id:46
+msgid "Sat"
+msgstr "שבת"
+
+#: id:47
+msgctxt "Auto context with id 47"
+msgid "Sun"
+msgstr "ראשון"
+
+#: id:51
+msgid "Jan"
+msgstr "ינו"
+
+#: id:52
+msgid "Feb"
+msgstr "פבר"
+
+#: id:53
+msgid "Mar"
+msgstr "מרץ"
+
+#: id:54
+msgid "Apr"
+msgstr "אפר"
+
+#: id:55
+msgctxt "Auto context with id 55"
+msgid "May"
+msgstr "מאי"
+
+#: id:56
+msgid "Jun"
+msgstr "יונ"
+
+#: id:57
+msgid "Jul"
+msgstr "יול"
+
+#: id:58
+msgid "Aug"
+msgstr "אוג"
+
+#: id:59
+msgid "Sep"
+msgstr "ספט"
+
+#: id:60
+msgid "Oct"
+msgstr "אוק"
+
+#: id:61
+msgid "Nov"
+msgstr "נוב"
+
+#: id:62
+msgid "Dec"
+msgstr "דצמ"
+
+#: id:71
+msgid "N"
+msgstr "צ"
+
+#: id:72
+msgid "NNE"
+msgstr "צ-צ-מז"
+
+#: id:73
+msgid "NE"
+msgstr "צ-מז"
+
+#: id:74
+msgid "ENE"
+msgstr "מז-צ-מז"
+
+#: id:75
+msgid "E"
+msgstr "מז"
+
+#: id:76
+msgid "ESE"
+msgstr "מז-ד-מז"
+
+#: id:77
+msgid "SE"
+msgstr "ד-מז"
+
+#: id:78
+msgid "SSE"
+msgstr "ד-ד-מז"
+
+#: id:79
+msgid "S"
+msgstr "ד"
+
+#: id:80
+msgid "SSW"
+msgstr "ד-ד-מע"
+
+#: id:81
+msgid "SW"
+msgstr "ד-מע"
+
+#: id:82
+msgid "WSW"
+msgstr "מע-ד-מע"
+
+#: id:83
+msgid "W"
+msgstr "מע"
+
+#: id:84
+msgid "WNW"
+msgstr "מע-צ-מע"
+
+#: id:85
+msgid "NW"
+msgstr "צ-מע"
+
+#: id:86
+msgid "NNW"
+msgstr "צ-צ-מע"
+
+#: id:87
+msgid "VAR"
+msgstr "VAR"
+
+#: id:98
+msgid "View: Auto"
+msgstr "תצוגה: אוטומטי"
+
+#: id:99
+msgid "View: Auto big"
+msgstr "תצוגה: אוטומטי גדול"
+
+#: id:100
+msgid "View: Icons"
+msgstr "תצוגה: צלמיות"
+
+#: id:101
+msgid "View: List"
+msgstr "תצוגה: רשימה"
+
+#: id:102
+msgctxt "Auto context with id 102"
+msgid "Scan"
+msgstr "סרוק"
+
+#: id:103
+msgctxt "Auto context with id 103"
+msgid "Sort by: Name"
+msgstr "מיין לפי : שם"
+
+#: id:104
+msgid "Sort by: Date"
+msgstr "מיין לפי : תאריך"
+
+#: id:105
+msgid "Sort by: Size"
+msgstr "מיין לפי : גודל"
+
+#: id:106
+msgid "No"
+msgstr "לא"
+
+#: id:107
+msgid "Yes"
+msgstr "כן"
+
+#: id:108
+msgctxt "Auto context with id 108"
+msgid "Slideshow"
+msgstr "מצגת"
+
+#: id:109
+msgid "Create thumbs"
+msgstr "צור תמונות ממוזערות"
+
+#: id:110
+msgid "Create thumbnails"
+msgstr "צור תמונות ממוזערות"
+
+#: id:111
+msgctxt "Auto context with id 111"
+msgid "Shortcuts"
+msgstr "קיצורי דרך"
+
+#: id:112
+msgid "Paused"
+msgstr "מושהה"
+
+#: id:113
+msgid "Update failed"
+msgstr "עדכון נכשל"
+
+#: id:114
+msgid "Installation failed"
+msgstr "ההתקנה נכשלה"
+
+#: id:115
+msgid "Copy"
+msgstr "העתק"
+
+#: id:116
+msgid "Move"
+msgstr "העבר"
+
+#: id:117
+msgid "Delete"
+msgstr "מחק"
+
+#: id:118
+msgid "Rename"
+msgstr "שנה שם"
+
+#: id:119
+msgid "New folder"
+msgstr "תיקיה חדשה"
+
+#: id:120
+msgid "Confirm file copy"
+msgstr "אשר העתקת קובץ"
+
+#: id:121
+msgid "Confirm file move"
+msgstr "אשר העברת קובץ"
+
+#: id:122
+msgid "Confirm file delete?"
+msgstr "אשר מחיקת קובץ"
+
+#: id:123
+msgid "Copy these files?"
+msgstr "?להעתיק קבצים אלו"
+
+#: id:124
+msgid "Move these files?"
+msgstr "?להעביר קבצים אלו"
+
+#: id:125
+msgid "Delete these files? - Deleting files cannot be undone!"
+msgstr "למחוק קבצים אלה? - !קבצים לאחר מחיקה אינם ניתנים לשיחזור"
+
+#: id:126
+msgid "Status"
+msgstr "מצב"
+
+#: id:127
+msgid "Objects"
+msgstr "אובייקטים"
+
+#: id:128
+msgctxt "Auto context with id 128"
+msgid "General"
+msgstr "כללי"
+
+#: id:129
+msgctxt "Auto context with id 129"
+msgid "Slideshow"
+msgstr "מצגת"
+
+#: id:130
+msgctxt "Auto context with id 130"
+msgid "System info"
+msgstr "פרטי מערכת"
+
+#: id:131
+msgid "Display"
+msgstr "מסך"
+
+#: id:132
+msgid "Albums"
+msgstr "אלבומים"
+
+#: id:133
+msgid "Artists"
+msgstr "אמנים"
+
+#: id:134
+msgid "Songs"
+msgstr "שירים"
+
+#: id:135
+msgid "Genres"
+msgstr "סגנונות"
+
+#: id:136
+msgid "Playlists"
+msgstr "רשימות ניגון"
+
+#: id:137
+msgid "Search"
+msgstr "חפש"
+
+#: id:138
+msgid "System Information"
+msgstr "פרטי מערכת"
+
+#: id:139
+msgid "Temperatures:"
+msgstr "טמפרטורות:"
+
+#: id:140
+msgid "CPU:"
+msgstr "מעבד:"
+
+#: id:141
+msgid "GPU:"
+msgstr "מעבד גרפי:"
+
+#: id:142
+msgid "Time:"
+msgstr "זמן:"
+
+#: id:143
+msgid "Current:"
+msgstr "נוכחי:"
+
+#: id:144
+msgid "Build:"
+msgstr "גירסה:"
+
+#: id:145
+msgid "Network:"
+msgstr "רשת:"
+
+#: id:146
+msgid "Type:"
+msgstr "סוג:"
+
+#: id:147
+msgid "Static"
+msgstr "סטאטי"
+
+#: id:148
+msgid "DHCP"
+msgstr "DHCP"
+
+#: id:149
+msgid "MAC address"
+msgstr "MAC"
+
+#: id:150
+msgctxt "Auto context with id 150"
+msgid "IP address"
+msgstr "IP"
+
+#: id:151
+msgid "Link:"
+msgstr "Link:"
+
+#: id:152
+msgid "Half duplex"
+msgstr "Half duplex"
+
+#: id:153
+msgid "Full duplex"
+msgstr "Full duplex"
+
+#: id:154
+msgctxt "Auto context with id 154"
+msgid "Storage"
+msgstr "אחסון"
+
+#: id:155
+msgid "Drive"
+msgstr "כונן"
+
+#: id:156
+msgctxt "Auto context with id 156"
+msgid "Free"
+msgstr "פנוי"
+
+#: id:157
+msgctxt "Auto context with id 157"
+msgid "Video"
+msgstr "וידאו"
+
+#: id:158
+msgid "Free memory"
+msgstr "זיכרון פנוי"
+
+#: id:159
+msgid "No link"
+msgstr "אין חיבור"
+
+#: id:160
+msgctxt "Auto context with id 160"
+msgid "Free"
+msgstr "פנוי"
+
+#: id:161
+msgid "Unavailable"
+msgstr "לא זמין"
+
+#: id:162
+msgid "Tray open"
+msgstr "מגש פתוח"
+
+#: id:163
+msgid "Reading"
+msgstr "קורא"
+
+#: id:164
+msgid "No disc"
+msgstr "אין דיסק"
+
+#: id:165
+msgid "Disc present"
+msgstr "דיסק נמצא"
+
+#: id:166
+msgid "Skin"
+msgstr "סקין"
+
+#: id:169
+msgctxt "Auto context with id 169"
+msgid "Resolution"
+msgstr "רזולוציה"
+
+#: id:170
+msgid "Adjust display refresh rate to match video"
+msgstr "התאם את קצב רענון המסך לוידאו"
+
+#: id:172
+msgid "Release date"
+msgstr "תאריך הפצה"
+
+#: id:173
+msgid "Display 4:3 videos as"
+msgstr "הצג וידאו 4:3 כמו"
+
+#: id:175
+msgid "Moods"
+msgstr "מצבים"
+
+#: id:176
+msgid "Styles"
+msgstr "סגנונות"
+
+#: id:179
+msgid "Song"
+msgstr "שיר"
+
+#: id:180
+msgid "Duration"
+msgstr "אורך"
+
+#: id:181
+msgid "Select album"
+msgstr "בחר אלבום"
+
+#: id:182
+msgid "Tracks"
+msgstr "רצועות"
+
+#: id:183
+msgid "Review"
+msgstr "ביקורת"
+
+#: id:184
+msgid "Refresh"
+msgstr "רענן"
+
+#: id:185
+msgid "Searching album"
+msgstr "מחפש אלבום"
+
+#: id:186
+msgid "OK"
+msgstr "אישור"
+
+#: id:187
+msgid "No albums found!"
+msgstr "!לא נמצאו אלבומים"
+
+#: id:188
+msgid "Select all"
+msgstr "בחר הכל"
+
+#: id:189
+msgid "Scanning media info"
+msgstr "סורק פרטי מערכת"
+
+#: id:190
+msgid "Save"
+msgstr "שמור"
+
+#: id:191
+msgid "Shuffle"
+msgstr "ערבב"
+
+#: id:192
+msgctxt "Auto context with id 192"
+msgid "Clear"
+msgstr "נקה"
+
+#: id:193
+msgctxt "Auto context with id 193"
+msgid "Scan"
+msgstr "סרוק"
+
+#: id:194
+msgid "Searching..."
+msgstr "...מחפש"
+
+#: id:195
+msgid "No info found!"
+msgstr "!לא נמצאו פרטים"
+
+#: id:196
+msgid "Select movie:"
+msgstr ":בחר סרט"
+
+#: id:197
+msgid "Querying %s info"
+msgstr "%s מחפש פרטים"
+
+#: id:198
+msgid "Loading movie details"
+msgstr "טוען פרטים אודות הסרט"
+
+#: id:199
+msgid "Web interface"
+msgstr "ממשק אינטרנט"
+
+#: id:202
+msgid "Tagline"
+msgstr "מילות מפתח"
+
+#: id:203
+msgid "Plot outline"
+msgstr "תקציר עלילה"
+
+#: id:205
+msgid "Votes"
+msgstr ":הצבעות"
+
+#: id:206
+msgid "Cast"
+msgstr "צוות"
+
+#: id:207
+msgid "Plot"
+msgstr "עלילה"
+
+#: id:208
+msgctxt "Auto context with id 208"
+msgid "Play"
+msgstr "נגן"
+
+#: id:209
+msgid "Next"
+msgstr "הבא"
+
+#: id:210
+msgid "Previous"
+msgstr "הקודם"
+
+#: id:213
+msgid "Calibrate user interface..."
+msgstr "כיול ממשק משתמש"
+
+#: id:214
+msgid "Video calibration..."
+msgstr "כיול וידאו..."
+
+#: id:215
+msgid "Soften"
+msgstr "רכך"
+
+#: id:216
+msgid "Zoom amount"
+msgstr "כמות זום"
+
+#: id:217
+msgid "Pixel ratio"
+msgstr "יחס פיקסלים"
+
+#: id:218
+msgid "DVD drive"
+msgstr "DVD כונן"
+
+#: id:219
+msgid "Please insert disc"
+msgstr "הכנס דיסק בבקשה"
+
+#: id:220
+msgid "Remote share"
+msgstr "תקיית רשת"
+
+#: id:221
+msgid "Network is not connected"
+msgstr "הרשת אינה מחוברת"
+
+#: id:222
+msgid "Cancel"
+msgstr "בטל"
+
+#: id:224
+msgid "Speed"
+msgstr "מהירות"
+
+#: id:225
+msgid "Vertical Shift"
+msgstr "תזוזה אנכי"
+
+#: id:226
+msgid "Test patterns..."
+msgstr "בדוק תבניות..."
+
+#: id:227
+msgid "Lookup audio CD track names from freedb.org"
+msgstr "חפש את שמות רצועות הדיסק ב freedb.org"
+
+#: id:228
+msgid "Shuffle playlist on load"
+msgstr "רשימת השמעה אקראית בעת הטעינה"
+
+#: id:229
+msgid "HDD spindown time"
+msgstr "זמן סיבוב כונן קשיח (בדקות)"
+
+#: id:230
+msgid "Video filters"
+msgstr "פילטרים"
+
+#: id:231
+msgctxt "Auto context with id 231"
+msgid "None"
+msgstr "ללא"
+
+#: id:232
+msgid "Point"
+msgstr "נקודה"
+
+#: id:233
+msgid "Linear"
+msgstr "קווי"
+
+#: id:234
+msgid "Anisotropic"
+msgstr "אנזיאוטרופי"
+
+#: id:235
+msgid "Quincunx"
+msgstr "מחומש"
+
+#: id:236
+msgid "Gaussian cubic"
+msgstr "קוביה גאוסנית"
+
+#: id:237
+msgid "Minification"
+msgstr "הקטנה"
+
+#: id:238
+msgid "Magnification"
+msgstr "הגדלה"
+
+#: id:239
+msgid "Clear playlist on finish"
+msgstr "נקה רשימת השמעה בסיום"
+
+#: id:240
+msgid "Display Mode"
+msgstr "סגנון תצוגה"
+
+#: id:241
+msgid "Full Screen #%d"
+msgstr "מסך מלא #%d"
+
+#: id:242
+msgid "Windowed"
+msgstr "חלון"
+
+#: id:243
+msgid "Refresh Rate"
+msgstr "קצב רענון"
+
+#: id:244
+msgid "Full screen"
+msgstr "מסך מלא"
+
+#: id:245
+msgid "Sizing: (%i,%i)->(%i,%i) (Zoom x%2.2f) AR:%2.2f:1 (Pixels: %2.2f:1) (VShift: %2.2f)"
+msgstr "גודל: (%i,%i)->(%i,%i) (זום x%2.2f) AR:%2.2f:1 (פיקסלים: %2.2f:1) (VShift: %2.2f)"
+
+#: id:247
+msgctxt "Auto context with id 247"
+msgid "Scripts"
+msgstr "סקריפטים"
+
+#: id:248
+msgctxt "Auto context with id 248"
+msgid "Language"
+msgstr "שפה"
+
+#: id:249
+msgctxt "Auto context with id 249"
+msgid "Music"
+msgstr "מוסיקה"
+
+#: id:250
+msgctxt "Auto context with id 250"
+msgid "Visualization"
+msgstr "חיזוי"
+
+#: id:251
+msgid "Select destination directory"
+msgstr "בחר ספרית יעד"
+
+#: id:252
+msgid "Output stereo to all speakers"
+msgstr "- פלט סטריאו לכל הרמקולים"
+
+#: id:253
+msgid "Number of channels"
+msgstr "מספר ערוצים"
+
+#: id:254
+msgid "- DTS capable receiver"
+msgstr "DTS רסיבר תומך"
+
+#: id:255
+msgid "CDDB"
+msgstr "CDDB"
+
+#: id:256
+msgid "Fetching CD information"
+msgstr "CDDB מחפש ברשת פרטי"
+
+#: id:257
+msgid "Error"
+msgstr "שגיאה"
+
+#: id:258
+msgid "Enable tag reading"
+msgstr "ID3 אפשר תגיות"
+
+#: id:259
+msgid "Opening"
+msgstr "פותח"
+
+#: id:260
+msgid "Shoutcast"
+msgstr "Shoutcast"
+
+#: id:261
+msgid "Waiting for start..."
+msgstr "....ממתין להתחלה"
+
+#: id:262
+msgid "Scripts output"
+msgstr "פלט סקריפטים"
+
+#: id:263
+msgid "Allow control of XBMC via HTTP"
+msgstr "אפשר שליטה על XBMC דרך HTTP"
+
+#: id:264
+msgid "Record"
+msgstr "הקלט"
+
+#: id:265
+msgid "Stop Rec."
+msgstr "עצור הקלטה"
+
+#: id:266
+msgid "Sort by: Track"
+msgstr "מיין לפי : רצועה"
+
+#: id:267
+msgid "Sort by: Time"
+msgstr "מיין לפי : זמן"
+
+#: id:268
+msgid "Sort by: Title"
+msgstr "מיין לפי : כותרת"
+
+#: id:269
+msgid "Sort by: Artist"
+msgstr "מיין לפי : אמן"
+
+#: id:270
+msgid "Sort by: Album"
+msgstr "מיין לפי : אלבום"
+
+#: id:271
+msgid "Top 100"
+msgstr "מאה הגדולים"
+
+#: id:272
+msgid "Top-Left overscan compensation"
+msgstr "פיצוי סריקת יתר משמאל למעלה"
+
+#: id:273
+msgid "Bottom-Right overscan compensation"
+msgstr "פיצוי סריקת יתר מימין למטה"
+
+#: id:274
+msgid "Subtitle positioning"
+msgstr "מיקום הכתוביות"
+
+#: id:275
+msgid "Pixel ratio adjustment"
+msgstr "כיוון יחס הפיקסלים"
+
+#: id:276
+msgid "Adjust the arrow to change the amount of overscan"
+msgstr "הזז את הסמן לשינוי רמת סריקת היתר"
+
+#: id:277
+msgid "Adjust the bar to change the subtitles position"
+msgstr "הזז את המצביע לשינוי מקום הכתוביות"
+
+#: id:278
+msgid "Adjust the rectangle so it is perfectly square"
+msgstr "כוון את המלבן כך שיהפוך לריבוע מושלם"
+
+#: id:279
+msgid "Unable to load settings"
+msgstr "אין אפשרות לטעון הגדרות"
+
+#: id:280
+msgid "Using default settings"
+msgstr "משתמש בהגדרות ברירת מחדל"
+
+#: id:281
+msgid "Please check the XML files"
+msgstr "XML אנא בדוק קבצי"
+
+#: id:282
+msgid "Found %i items"
+msgstr "התאמות %i נמצאו"
+
+#: id:283
+msgid "Search results"
+msgstr "תוצאות חיפוש"
+
+#: id:284
+msgid "No results found"
+msgstr "לא נמצאו התאמות לחיפוש"
+
+#: id:287
+msgctxt "Auto context with id 287"
+msgid "Subtitles"
+msgstr "כתוביות"
+
+#: id:288
+msgctxt "Auto context with id 288"
+msgid "Font"
+msgstr "פונט"
+
+#: id:289
+msgctxt "Auto context with id 289"
+msgid "- Size"
+msgstr "גודל"
+
+#: id:290
+msgid "Dynamic range compression"
+msgstr "(db) הגברת ווליום"
+
+#: id:291
+msgctxt "Auto context with id 291"
+msgid "Video"
+msgstr "וידאו"
+
+#: id:292
+msgctxt "Auto context with id 292"
+msgid "Audio"
+msgstr "אודיו"
+
+#: id:293
+msgid "Browse for subtitles"
+msgstr "עיין לכתוביות"
+
+#: id:294
+msgid "Create bookmark"
+msgstr "צור סימניה"
+
+#: id:296
+msgid "Clear bookmarks"
+msgstr "נקה סימניות"
+
+#: id:297
+msgid "Audio offset"
+msgstr "השהיית קול הנומתו"
+
+#: id:298
+msgid "Bookmarks"
+msgstr "סימניות"
+
+#: id:299
+msgid "- AAC capable receiver"
+msgstr "- AAC רסיבר נתמך"
+
+#: id:300
+msgid "- MP1 capable receiver"
+msgstr "- MP1 רסיבר נתמך"
+
+#: id:301
+msgid "- MP2 capable receiver"
+msgstr "- MP2 רסיבר נתמך"
+
+#: id:302
+msgid "- MP3 capable receiver"
+msgstr "- MP3 רסיבר נתמך"
+
+#: id:303
+msgid "Delay"
+msgstr "השהייה"
+
+#: id:304
+msgctxt "Auto context with id 304"
+msgid "Language"
+msgstr "שפה"
+
+#: id:305
+msgctxt "Auto context with id 305"
+msgid "Enabled"
+msgstr "זמין"
+
+#: id:306
+msgid "Non-interleaved"
+msgstr "ללא-הפרדה"
+
+#: id:312
+msgid "(0=auto)"
+msgstr "(0=אוטומטי)"
+
+#: id:313
+msgid "Cleaning database"
+msgstr "מנקה מסד נתונים"
+
+#: id:314
+msgid "Preparing..."
+msgstr "...מתכונן"
+
+#: id:315
+msgid "Database error"
+msgstr "שגיאת מסד נתונים"
+
+#: id:316
+msgid "Searching songs..."
+msgstr "...מחפש שירים"
+
+#: id:317
+msgid "Cleaned database successfully"
+msgstr "ניקוי הושלם בהצלחה"
+
+#: id:318
+msgid "Cleaning songs..."
+msgstr "...מנקה שירים"
+
+#: id:319
+msgid "Error cleaning songs"
+msgstr "שגיאה בניקוי שירים"
+
+#: id:320
+msgid "Cleaning artists..."
+msgstr "...ניקוי אמנים"
+
+#: id:321
+msgid "Error cleaning artists"
+msgstr "שגיאה בניקוי אמנים"
+
+#: id:322
+msgid "Cleaning genres..."
+msgstr "...ניקוי סגנונות"
+
+#: id:323
+msgid "Error cleaning genres"
+msgstr "שגיאה בניקוי סגנונות"
+
+#: id:324
+msgid "Cleaning paths..."
+msgstr "...ניקוי נתיבים"
+
+#: id:325
+msgid "Error cleaning paths"
+msgstr "שגיאה בניקוי נתיבים"
+
+#: id:326
+msgid "Cleaning albums..."
+msgstr "...ניקוי אלבומים"
+
+#: id:327
+msgid "Error cleaning albums"
+msgstr "שגיאה בניקוי אלבומים"
+
+#: id:328
+msgid "Writing changes..."
+msgstr "...כותב שינויים"
+
+#: id:329
+msgid "Error writing changes"
+msgstr "שגיאה בכתיבת שינויים"
+
+#: id:330
+msgid "This may take some time..."
+msgstr "...פעולה זו עשויה לקחת זמן"
+
+#: id:331
+msgid "Compressing database..."
+msgstr "...דוחס נתונים"
+
+#: id:332
+msgid "Error compressing database"
+msgstr "שגיאה בדחיסת נתונים"
+
+#: id:333
+msgid "Do you want to clean the library?"
+msgstr "?האם ברצונך לנקות את הספריה"
+
+#: id:334
+msgid "Clean library..."
+msgstr "נקה ספריה..."
+
+#: id:335
+msgid "Start"
+msgstr "התחל"
+
+#: id:336
+msgid "Framerate conversion"
+msgstr "המרת קצב פריימים"
+
+#: id:337
+msgctxt "Auto context with id 337"
+msgid "Audio output"
+msgstr "פלט אודיו"
+
+#: id:338
+msgid "Analog"
+msgstr "אנלוגי"
+
+#: id:339
+msgid "Optical/Coax"
+msgstr "דיגיטאלי"
+
+#: id:340
+msgid "Various artists"
+msgstr "אמנים שונים"
+
+#: id:341
+msgid "Play disc"
+msgstr "נגן דיסק"
+
+#: id:342
+msgctxt "Auto context with id 342"
+msgid "Movies"
+msgstr "סרטים"
+
+#: id:343
+msgid "Adjust framerate"
+msgstr "התאם קצב פריימים"
+
+#: id:344
+msgid "Actors"
+msgstr "שחקנים"
+
+#: id:345
+msgctxt "Auto context with id 345"
+msgid "Year"
+msgstr "שנה"
+
+#: id:346
+msgid "Boost volume level on downmix"
+msgstr "הגבר קול ב downmix"
+
+#: id:350
+msgctxt "Auto context with id 350"
+msgid "Programs"
+msgstr "תוכנות"
+
+#: id:351
+msgctxt "Auto context with id 351"
+msgid "Off"
+msgstr "כבה"
+
+#: id:352
+msgid "Dim"
+msgstr "עמעם"
+
+#: id:353
+msgid "Black"
+msgstr "מסך שחור"
+
+#: id:354
+msgid "Matrix trails"
+msgstr "Matrix trails"
+
+#: id:355
+msgid "Screensaver time"
+msgstr "זמן לשומר מסך"
+
+#: id:356
+msgid "Screensaver mode"
+msgstr "מצב שומר מסך"
+
+#: id:357
+msgid "Shutdown function timer"
+msgstr "זמן המתנה לפני כיבוי"
+
+#: id:358
+msgid "All albums"
+msgstr "כל האלבומים"
+
+#: id:359
+msgid "Recently added albums"
+msgstr "אלבומים אחרונים"
+
+#: id:360
+msgctxt "Auto context with id 360"
+msgid "Screensaver"
+msgstr "שומר מסך"
+
+#: id:361
+msgid "R. Slideshow"
+msgstr "מצגת רקורס."
+
+#: id:362
+msgid "Screensaver dim level"
+msgstr "רמת עמעום המסך"
+
+#: id:363
+msgid "Sort by: File"
+msgstr "סדר לפי : קובץ"
+
+#: id:364
+msgid "- Dolby Digital (AC3) capable receiver"
+msgstr "AC3 רסיבר תומך"
+
+#: id:365
+msgctxt "Auto context with id 365"
+msgid "Sort by: Name"
+msgstr "סדר לפי : שם"
+
+#: id:366
+msgid "Sort by: Year"
+msgstr "סדר לפי : שנה"
+
+#: id:367
+msgid "Sort by: Rating"
+msgstr "סדר לפי : רייטינג"
+
+#: id:368
+msgid "IMDb"
+msgstr "IMDb"
+
+#: id:369
+msgctxt "Auto context with id 369"
+msgid "Title"
+msgstr "כותרת"
+
+#: id:370
+msgid "Thunderstorms"
+msgstr "רעמים"
+
+#: id:371
+msgid "Partly"
+msgstr "חלקית"
+
+#: id:372
+msgid "Mostly"
+msgstr "בעיקר"
+
+#: id:373
+msgid "Sunny"
+msgstr "שמשי"
+
+#: id:374
+msgid "Cloudy"
+msgstr "מעונן"
+
+#: id:375
+msgid "Snow"
+msgstr "שלג"
+
+#: id:376
+msgid "Rain"
+msgstr "גשם"
+
+#: id:377
+msgid "Light"
+msgstr "קל"
+
+#: id:378
+msgid "AM"
+msgstr "בוקר"
+
+#: id:379
+msgid "PM"
+msgstr "ערב"
+
+#: id:380
+msgid "Showers"
+msgstr "ממטרים"
+
+#: id:381
+msgid "Few"
+msgstr "מעטים"
+
+#: id:382
+msgid "Scattered"
+msgstr "לסירוגין"
+
+#: id:383
+msgctxt "Auto context with id 383"
+msgid "Wind"
+msgstr "רוח"
+
+#: id:384
+msgid "Strong"
+msgstr "חזקה"
+
+#: id:385
+msgid "Fair"
+msgstr "קלילה"
+
+#: id:386
+msgctxt "Auto context with id 386"
+msgid "Clear"
+msgstr "בהיר"
+
+#: id:387
+msgid "Clouds"
+msgstr "עננים"
+
+#: id:388
+msgid "Early"
+msgstr "מוקדם"
+
+#: id:389
+msgid "Shower"
+msgstr "ממטרים"
+
+#: id:390
+msgid "Flurries"
+msgstr "סוער"
+
+#: id:391
+msgctxt "Auto context with id 391"
+msgid "Low"
+msgstr "נמוך"
+
+#: id:392
+msgctxt "Auto context with id 392"
+msgid "Medium"
+msgstr "בינוני"
+
+#: id:393
+msgctxt "Auto context with id 393"
+msgid "High"
+msgstr "גבוה"
+
+#: id:394
+msgid "Fog"
+msgstr "ערפילי"
+
+#: id:395
+msgid "Haze"
+msgstr "אביך"
+
+#: id:396
+msgid "Select location"
+msgstr "בחר מיקום"
+
+#: id:397
+msgid "Refresh time"
+msgstr "זמני רענון"
+
+#: id:398
+msgid "Temperature units"
+msgstr "יחידות טמפרטורה"
+
+#: id:399
+msgid "Speed units"
+msgstr "יחידות מהירות"
+
+#: id:400
+msgctxt "Auto context with id 400"
+msgid "Weather"
+msgstr "מזג אוויר"
+
+#: id:401
+msgid "Temp"
+msgstr "טמפרטורה"
+
+#: id:402
+msgid "Feels like"
+msgstr "מרגיש כאילו"
+
+#: id:403
+msgid "UV index"
+msgstr "UV רמת"
+
+#: id:404
+msgctxt "Auto context with id 404"
+msgid "Wind"
+msgstr "רוח"
+
+#: id:405
+msgid "Dew point"
+msgstr "נקודת אידוי"
+
+#: id:406
+msgid "Humidity"
+msgstr "לחות"
+
+#: id:409
+msgid "Defaults"
+msgstr "ברירת מחדל"
+
+#: id:410
+msgid "Accessing weather service"
+msgstr "ניגש לשירות מזג אויר"
+
+#: id:411
+msgid "Getting weather for:"
+msgstr ":טוען מזג אויר עבור"
+
+#: id:412
+msgid "Unable to get weather data"
+msgstr "אין אפשרות לקבל פרטי מזג אויר"
+
+#: id:413
+msgid "Manual"
+msgstr "ידני"
+
+#: id:414
+msgid "No review for this album"
+msgstr "אין סקירות עבור אלבום זה"
+
+#: id:415
+msgid "Downloading thumbnail..."
+msgstr "...מוריד תמונות ממוזערות"
+
+#: id:416
+msgid "Not available"
+msgstr "לא זמין"
+
+#: id:417
+msgid "View: Big icons"
+msgstr "תצוגה : צלמיות גדולות"
+
+#: id:418
+msgctxt "Auto context with id 418"
+msgid "Low"
+msgstr "נמוך"
+
+#: id:419
+msgctxt "Auto context with id 419"
+msgid "High"
+msgstr "גבוה"
+
+#: id:420
+msgid "HDMI"
+msgstr "HDMI"
+
+#: id:422
+msgid "Delete album info"
+msgstr "מחק פרטי אלבום"
+
+#: id:423
+msgid "Delete CD information"
+msgstr "מחק פרטי CDDB"
+
+#: id:424
+msgid "Select"
+msgstr "בחר"
+
+#: id:425
+msgid "No album information found"
+msgstr "לא נמצא פרטי אלבום"
+
+#: id:426
+msgid "No CD information found"
+msgstr "לא נמצא פרטי דיסק"
+
+#: id:427
+msgid "Disc"
+msgstr "דיסק"
+
+#: id:428
+msgid "Insert correct CD/DVD"
+msgstr "הכנס דיסק נכון"
+
+#: id:429
+msgid "Please insert the following disc:"
+msgstr "אנא הכנס את הדיסק הבא:"
+
+#: id:430
+msgid "Sort by: DVD#"
+msgstr "DVD# : מיין לפי"
+
+#: id:431
+msgid "No cache"
+msgstr "אין זכרון מטמון"
+
+#: id:432
+msgid "Remove movie from library"
+msgstr "מחק סרט מהספריה"
+
+#: id:433
+msgid "Really remove '%s'?"
+msgstr "?'%s' האם אתה בטוח שברצונך למחוק את"
+
+#: id:434
+msgid "From %s at %i %s"
+msgstr "מ%s ב%i %s"
+
+#: id:437
+msgid "Removable disk"
+msgstr "כונן נייד"
+
+#: id:438
+msgid "Opening file"
+msgstr "פותח קובץ"
+
+#: id:439
+msgid "Cache"
+msgstr "זכרון מטמון"
+
+#: id:440
+msgid "Harddisk"
+msgstr "כונן קשיח"
+
+#: id:441
+msgid "UDF"
+msgstr "UDF"
+
+#: id:442
+msgid "Local network"
+msgstr "רשת מקומית"
+
+#: id:443
+msgid "Internet"
+msgstr "אינטרנט"
+
+#: id:444
+msgctxt "Auto context with id 444"
+msgid "Video"
+msgstr "וידאו"
+
+#: id:445
+msgctxt "Auto context with id 445"
+msgid "Audio"
+msgstr "אודיו"
+
+#: id:446
+msgctxt "Auto context with id 446"
+msgid "DVD"
+msgstr "DVD"
+
+#: id:447
+msgid "Autorun media"
+msgstr "נגן אוטומטית"
+
+#: id:448
+msgid "LCD"
+msgstr "LCD"
+
+#: id:449
+msgctxt "Auto context with id 449"
+msgid "Enabled"
+msgstr "פעיל"
+
+#: id:450
+msgid "Columns"
+msgstr "עמודות"
+
+#: id:451
+msgid "Row 1 address"
+msgstr "1: שורת כתובת"
+
+#: id:452
+msgid "Row 2 address"
+msgstr "2: שורת כתובת"
+
+#: id:453
+msgid "Row 3 address"
+msgstr "3: שורת כתובת"
+
+#: id:454
+msgid "Row 4 address"
+msgstr "4: שורת כתובת"
+
+#: id:455
+msgid "Rows"
+msgstr "שורות"
+
+#: id:456
+msgid "Mode"
+msgstr "מצב"
+
+#: id:457
+msgid "Switch view"
+msgstr "החלף תצוגה"
+
+#: id:459
+msgid "Subs"
+msgstr "כתוביות"
+
+#: id:460
+msgid "Audio stream"
+msgstr "זרימת אודיו"
+
+#: id:461
+msgid "[active]"
+msgstr "[פעיל]"
+
+#: id:462
+msgid "Subtitle"
+msgstr "כתובית"
+
+#: id:463
+msgid "Backlight"
+msgstr "תאורה אחורית"
+
+#: id:464
+msgid "Brightness"
+msgstr "בהירות"
+
+#: id:465
+msgid "Contrast"
+msgstr "ניגודיות"
+
+#: id:466
+msgid "Gamma"
+msgstr "גאמה"
+
+#: id:467
+msgctxt "Auto context with id 467"
+msgid "Type"
+msgstr "סוג"
+
+#: id:468
+msgid "Move the bar to change the OSD position"
+msgstr "הזז את הסמן כדי לשנות את מיקום התפריט"
+
+#: id:469
+msgid "OSD position"
+msgstr "מיקום תפריט"
+
+#: id:470
+msgid "Credits"
+msgstr "תודות"
+
+#: id:471
+msgid "Modchip"
+msgstr "Modchip"
+
+#: id:474
+msgctxt "Auto context with id 474"
+msgid "Off"
+msgstr "כבוי"
+
+#: id:475
+msgid "Music only"
+msgstr "מוזיקה בלבד"
+
+#: id:476
+msgctxt "Auto context with id 476"
+msgid "Music & video"
+msgstr "מוזיקה ווידאו"
+
+#: id:477
+msgid "Unable to load playlist"
+msgstr "לא יכול לטעון רשימת השמעה"
+
+#: id:478
+msgid "OSD"
+msgstr "תפריט"
+
+#: id:479
+msgid "Skin & language"
+msgstr "סקין ושפה"
+
+#: id:480
+msgid "Appearance"
+msgstr "מראה"
+
+#: id:481
+msgid "Audio options"
+msgstr "אפשרויות אודיו"
+
+#: id:482
+msgid "About XBMC"
+msgstr "XBMC אודות"
+
+#: id:485
+msgid "Delete album"
+msgstr "מחק אלבום"
+
+#: id:486
+msgid "Repeat"
+msgstr "חזרה"
+
+#: id:487
+msgid "Repeat one"
+msgstr "חזור פעם אחת"
+
+#: id:488
+msgid "Repeat folder"
+msgstr "חזור רשימת השמעה לתיקיה"
+
+#: id:489
+msgid "Play the next song automatically"
+msgstr "נגן את השיר הבא אוטומטית"
+
+#: id:491
+msgid "- Use big icons"
+msgstr "- השתמש בצלמיות גדולות"
+
+#: id:492
+msgid "Resize VobSubs"
+msgstr "הגדל כתוביות"
+
+#: id:493
+msgid "Advanced options (Experts Only!)"
+msgstr "אפשרויות מתקדמות"
+
+#: id:494
+msgid "Overall audio headroom"
+msgstr "Overall Audio Headroom (dB)"
+
+#: id:495
+msgid "Upsample videos to GUI resolution"
+msgstr "דגום מחדש וידאו לרזולוצית תצוגה"
+
+#: id:496
+msgid "Calibration"
+msgstr "כיוונון"
+
+#: id:497
+msgid "Show file extensions"
+msgstr "הראה סיומות קבצים"
+
+#: id:498
+msgid "Sort by: Type"
+msgstr "מיין לפי : סוג"
+
+#: id:499
+msgid "Unable to connect to online lookup service"
+msgstr "אין אפשרות להתחבר לשירות החיפוש"
+
+#: id:500
+msgid "Downloading album information failed"
+msgstr "הורדת פרטי אלבום נכשלה"
+
+#: id:501
+msgid "Looking for album names..."
+msgstr "מחפש שמות אלבום..."
+
+#: id:502
+msgctxt "Auto context with id 502"
+msgid "Open"
+msgstr "פתח"
+
+#: id:503
+msgid "Busy"
+msgstr "עסוק"
+
+#: id:504
+msgid "Empty"
+msgstr "ריק"
+
+#: id:505
+msgid "Loading media info from files..."
+msgstr "טוען פרטי מדיה מהקבצים"
+
+#: id:507
+msgid "Sort by: Usage"
+msgstr "מיין לפי : שימוש"
+
+#: id:510
+msgid "Enable visualizations"
+msgstr "אפשר חיזוי"
+
+#: id:511
+msgid "Enable video mode switching"
+msgstr "אפשר החלפת מצב וידאו"
+
+#: id:512
+msgid "Startup window"
+msgstr "חלון ראשוני"
+
+#: id:513
+msgid "Home window"
+msgstr "חלון הבית"
+
+#: id:514
+msgid "Manual settings"
+msgstr "הגדרות ידניות"
+
+#: id:515
+msgid "Genre"
+msgstr "סגנון"
+
+#: id:517
+msgid "Recently played albums"
+msgstr "אלבומים שנוגנו לאחרונה"
+
+#: id:518
+msgid "Launch"
+msgstr "הפעל"
+
+#: id:519
+msgid "Launch in..."
+msgstr "...הפעל ב"
+
+#: id:521
+msgid "Compilations"
+msgstr "אוספים"
+
+#: id:522
+msgid "Remove source"
+msgstr "הסר מקור"
+
+#: id:523
+msgid "Switch media"
+msgstr "החלף מדיה"
+
+#: id:524
+msgid "Select playlist"
+msgstr "בחר רשימת ניגון"
+
+#: id:525
+msgid "New playlist..."
+msgstr "רשימת ניגון חדשה"
+
+#: id:526
+msgid "Add to playlist"
+msgstr "הוסף לרשימת ניגון"
+
+#: id:527
+msgid "Manually add to library"
+msgstr "הוסף ידנית למסד הנתונים"
+
+#: id:528
+msgid "Enter title"
+msgstr "הזן כותרת"
+
+#: id:529
+msgid "Error: Duplicate title"
+msgstr "שגיאה: כותרת כפולה"
+
+#: id:530
+msgid "Select genre"
+msgstr "בחר סגנון"
+
+#: id:531
+msgid "New genre"
+msgstr "סגנון חדש"
+
+#: id:532
+msgid "Manual addition"
+msgstr "הוספה ידנית"
+
+#: id:533
+msgid "Enter genre"
+msgstr "הזן סגנון"
+
+#: id:534
+msgid "View: %s"
+msgstr "תצוגה: %s"
+
+#: id:535
+msgid "List"
+msgstr "רשימה"
+
+#: id:536
+msgid "Icons"
+msgstr "צלמיות"
+
+#: id:537
+msgid "Big list"
+msgstr "רשימה גדולה"
+
+#: id:538
+msgid "Big icons"
+msgstr "צלמיות גדולות"
+
+#: id:539
+msgid "Wide"
+msgstr "רחב"
+
+#: id:540
+msgid "Big wide"
+msgstr "רחב גדול"
+
+#: id:541
+msgid "Album icons"
+msgstr "צלמיות אלבומים"
+
+#: id:542
+msgid "DVD icons"
+msgstr "צלמיות DVD"
+
+#: id:543
+msgctxt "Auto context with id 543"
+msgid "DVD"
+msgstr "DVD"
+
+#: id:544
+msgctxt "Auto context with id 544"
+msgid "Media info"
+msgstr "פרטי מדיה"
+
+#: id:545
+msgid "Audio output device"
+msgstr "התקן פלט אודיו"
+
+#: id:546
+msgid "Passthrough output device"
+msgstr "עובר דרך התקן חיצוני"
+
+#: id:547
+msgid "No biography for this artist"
+msgstr "אין ביוגרפיה לאמן זה"
+
+#: id:548
+msgid "Downmix multichannel audio to stereo"
+msgstr "התאם אודיו רב-ערוצי לסטריאו"
+
+#: id:550
+msgid "Sort by: %s"
+msgstr "מיין לפי: %s"
+
+#: id:551
+msgctxt "Auto context with id 551"
+msgid "Name"
+msgstr "שם"
+
+#: id:552
+msgid "Date"
+msgstr "תאריך"
+
+#: id:553
+msgid "Size"
+msgstr "גודל"
+
+#: id:554
+msgid "Track"
+msgstr "רצועה"
+
+#: id:555
+msgid "Time"
+msgstr "זמן"
+
+#: id:556
+msgctxt "Auto context with id 556"
+msgid "Title"
+msgstr "כותרת"
+
+#: id:557
+msgid "Artist"
+msgstr "אמן"
+
+#: id:558
+msgid "Album"
+msgstr "אלבום"
+
+#: id:559
+msgid "Playlist"
+msgstr "רשימת השמעה"
+
+#: id:560
+msgid "ID"
+msgstr "ID"
+
+#: id:561
+msgctxt "Auto context with id 561"
+msgid "File"
+msgstr "קובץ"
+
+#: id:562
+msgctxt "Auto context with id 562"
+msgid "Year"
+msgstr "שנה"
+
+#: id:563
+msgid "Rating"
+msgstr "דירוג"
+
+#: id:564
+msgctxt "Auto context with id 564"
+msgid "Type"
+msgstr "סוג"
+
+#: id:565
+msgid "Usage"
+msgstr "שימוש"
+
+#: id:566
+msgid "Album artist"
+msgstr "אלבום אמן"
+
+#: id:567
+msgid "Play count"
+msgstr "מספר פעמים שנוגן"
+
+#: id:568
+msgid "Last played"
+msgstr "נוגן לאחרונה"
+
+#: id:569
+msgctxt "Auto context with id 569"
+msgid "Comment"
+msgstr "הערות"
+
+#: id:570
+msgid "Date added"
+msgstr "תאריך הוספה"
+
+#: id:571
+msgctxt "Auto context with id 571"
+msgid "Default"
+msgstr "ברירת מחדל"
+
+#: id:572
+msgid "Studio"
+msgstr "אולפן"
+
+#: id:573
+msgid "Path"
+msgstr "נתיב"
+
+#: id:574
+msgctxt "Auto context with id 574"
+msgid "Country"
+msgstr "ארץ"
+
+#: id:575
+msgid "In progress"
+msgstr "בתהליך"
+
+#: id:576
+msgid "Times played"
+msgstr "פעמים שנוגן"
+
+#: id:580
+msgid "Sort direction"
+msgstr "כיוון מיון"
+
+#: id:581
+msgid "Sort method"
+msgstr "שיטת מיון"
+
+#: id:582
+msgctxt "Auto context with id 582"
+msgid "View mode"
+msgstr "מצב תצוגה"
+
+#: id:583
+msgid "Remember views for different folders"
+msgstr "זכור תצוגות לתיקיות שונות"
+
+#: id:584
+msgid "Ascending"
+msgstr "עולה"
+
+#: id:585
+msgid "Descending"
+msgstr "יורד"
+
+#: id:586
+msgid "Edit playlist"
+msgstr "ערוך רשימת השמעה"
+
+#: id:587
+msgid "Filter"
+msgstr "פילטר"
+
+#: id:588
+msgid "Cancel party mode"
+msgstr "בטל מצב מסיבה"
+
+#: id:589
+msgid "Party mode"
+msgstr "מצב מסיבה"
+
+#: id:590
+msgid "Random"
+msgstr "אקראי"
+
+#: id:591
+msgctxt "Auto context with id 591"
+msgid "Off"
+msgstr "כבוי"
+
+#: id:592
+msgid "One"
+msgstr "אחד"
+
+#: id:593
+msgid "All"
+msgstr "הכל"
+
+#: id:594
+msgctxt "Auto context with id 594"
+msgid "Off"
+msgstr "כבוי"
+
+#: id:595
+msgid "Repeat: Off"
+msgstr "חזרה: כבוי"
+
+#: id:596
+msgid "Repeat: One"
+msgstr "חזרה: אחד"
+
+#: id:597
+msgid "Repeat: All"
+msgstr "חזרה: הכל"
+
+#: id:600
+msgid "Rip audio CD"
+msgstr "העתק דיסק"
+
+#: id:601
+msgctxt "Auto context with id 601"
+msgid "Medium"
+msgstr "בינוני"
+
+#: id:602
+msgctxt "Auto context with id 602"
+msgid "Standard"
+msgstr "רגיל"
+
+#: id:603
+msgid "Extreme"
+msgstr "קיצוני"
+
+#: id:604
+msgid "Constant bitrate"
+msgstr "קצב ביטים קבוע"
+
+#: id:605
+msgid "Ripping..."
+msgstr "...מעתיק"
+
+#: id:607
+msgid "To:"
+msgstr "אל:"
+
+#: id:608
+msgid "Could not rip CD or track"
+msgstr "לא יכול להעתיק דיסק או רצועה"
+
+#: id:609
+msgid "CDDARipPath is not set."
+msgstr "נתיב CDDARipPath אינו מוגדר"
+
+#: id:610
+msgid "Rip audio track"
+msgstr "העתק רצועת דיסק"
+
+#: id:611
+msgid "Enter number"
+msgstr "הזן מספר"
+
+#: id:612
+msgid "Bits/Sample"
+msgstr ""
+
+#: id:613
+msgid "Sample Frequency"
+msgstr ""
+
+#: id:620
+msgid "Audio CDs"
+msgstr "דיסק אודיו"
+
+#: id:621
+msgid "Encoder"
+msgstr "מקודד"
+
+#: id:622
+msgid "Quality"
+msgstr "איכות"
+
+#: id:623
+msgid "Bitrate"
+msgstr "קצב ביטים"
+
+#: id:624
+msgid "Include track number"
+msgstr "כלול מספר רצועה"
+
+#: id:625
+msgid "All songs of"
+msgstr "כל השירים של"
+
+#: id:629
+msgctxt "Auto context with id 629"
+msgid "View mode"
+msgstr "מצב תצוגה"
+
+#: id:630
+msgctxt "Auto context with id 630"
+msgid "Normal"
+msgstr "רגיל"
+
+#: id:631
+msgid "Zoom"
+msgstr "זום"
+
+#: id:632
+msgid "Stretch 4:3"
+msgstr "4:3 מתח"
+
+#: id:633
+msgid "Wide Zoom"
+msgstr "זום רחב"
+
+#: id:634
+msgid "Stretch 16:9"
+msgstr "16:9 מתח"
+
+#: id:635
+msgid "Original Size"
+msgstr "גודל מקורי"
+
+#: id:636
+msgctxt "Auto context with id 636"
+msgid "Custom"
+msgstr "מותאם אישי"
+
+#: id:637
+msgid "Replay gain"
+msgstr "תיקון עוצמת הקול"
+
+#: id:638
+msgid "Replaygain volume adjustments"
+msgstr "כיוונון תיקון עוצמת הקול"
+
+#: id:639
+msgid "Use track levels"
+msgstr "השתמש בעוצמת הרצועה"
+
+#: id:640
+msgid "Use album levels"
+msgstr "השתמש בעוצמת האלבום"
+
+#: id:641
+msgid "PreAmp Level - Replay gained files"
+msgstr "עוצמת PreAmp - תיקון עוצמת קבצים"
+
+#: id:642
+msgid "PreAmp Level - Non replay gained files"
+msgstr "עוצמת PreAmp - ללא תיקון עוצמת קבצים"
+
+#: id:643
+msgid "Avoid clipping on replay gained files"
+msgstr "המנע מחיתוך קבצים מתוקני עוצמה"
+
+#: id:644
+msgid "Crop black bars"
+msgstr "חתוך פסים שחורים"
+
+#: id:645
+msgid "Need to unpack a big file. Continue?"
+msgstr "?צריך לחלץ קובץ גדול. להמשיך"
+
+#: id:646
+msgid "Remove from library"
+msgstr "הסר כותרת"
+
+#: id:647
+msgid "Export video library"
+msgstr "ייצא ספרית וידאו"
+
+#: id:648
+msgid "Import video library"
+msgstr "ייבא ספרית וידאו"
+
+#: id:649
+msgid "Importing"
+msgstr "מייבא"
+
+#: id:650
+msgid "Exporting"
+msgstr "מייצא"
+
+#: id:651
+msgid "Browse for library"
+msgstr "עיין לספריה"
+
+#: id:652
+msgid "Years"
+msgstr "שנים"
+
+#: id:653
+msgid "Update library"
+msgstr "עדכן ספריה"
+
+#: id:654
+msgid "Show debug info"
+msgstr "הצג פרטי ניפוי שגיאות"
+
+#: id:655
+msgid "Browse for executable"
+msgstr "עיין לקובץ הפעלה"
+
+#: id:656
+msgid "Browse for playlist"
+msgstr "עיין לרשימת ניגון"
+
+#: id:657
+msgid "Browse for folder"
+msgstr "עיין לתיקייה"
+
+#: id:658
+msgid "Song information"
+msgstr "פרטי שיר"
+
+#: id:659
+msgid "Non-linear stretch"
+msgstr ""
+
+#: id:660
+msgid "Volume amplification"
+msgstr "הגברת ווליום"
+
+#: id:661
+msgid "Choose export folder"
+msgstr "בחר תיקיית ייצוא"
+
+#: id:662
+msgid "This file is no longer available."
+msgstr "קובץ זה לא זמין יותר"
+
+#: id:663
+msgid "Would you like to remove it from the library?"
+msgstr "?האם תרצה להסיר אותו מהספריה"
+
+#: id:664
+msgid "Browse for Script"
+msgstr "עיין לסקריפט"
+
+#: id:665
+msgid "Compression level"
+msgstr "רמת דחיסה"
+
+#: id:700
+msgid "Cleaning up library"
+msgstr "מנקה מסד נתונים"
+
+#: id:701
+msgid "Removing old songs from the library"
+msgstr "מוחק שירים ישנים ממסד הנתונים"
+
+#: id:702
+msgid "This path has been scanned before"
+msgstr "נתיב זה נסרק בעבר"
+
+#: id:705
+msgctxt "Auto context with id 705"
+msgid "Network"
+msgstr "רשת"
+
+#: id:706
+msgid "- Server"
+msgstr "- שרת"
+
+#: id:708
+msgid "Use an HTTP proxy server to access the internet"
+msgstr "השתמש ב HTTP Proxy על מנת להיכנס לאינטרנט"
+
+#: id:711
+msgid "Internet Protocol (IP)"
+msgstr "פרוטוקול תקשורת (IP)"
+
+#: id:712
+msgid "Invalid port specified. Value must be between 1 and 65535."
+msgstr "מספר פורט שגוי. ערך חייב להיות בין 1 ל 65535."
+
+#: id:713
+msgid "HTTP proxy"
+msgstr "HTTP פרוקסי"
+
+#: id:715
+msgid "- Assignment"
+msgstr "השמת כתובת"
+
+#: id:716
+msgid "Automatic (DHCP)"
+msgstr "אוטומטית (DHCP)"
+
+#: id:717
+msgid "Manual (Static)"
+msgstr "ידנית (סטטית)"
+
+#: id:719
+msgid "- IP address"
+msgstr "- IP address"
+
+#: id:720
+msgid "- Netmask"
+msgstr "- Netmask"
+
+#: id:721
+msgid "- Default gateway"
+msgstr "- Default gateway"
+
+#: id:722
+msgid "- DNS server"
+msgstr "- DNS server"
+
+#: id:723
+msgid "Save & restart"
+msgstr "שמור והפעל מחדש"
+
+#: id:724
+msgid "Invalid address specified. Value must be AAA.BBB.CCC.DDD"
+msgstr "כתובת שגויה. הכתובת חייבת להיות במבנה AAA.BBB.CCC.DDD"
+
+#: id:725
+msgid "with numbers between 0 and 255."
+msgstr "עם מספרים בין 0 ל- 255."
+
+#: id:726
+msgid "Changes not saved. Continue without saving?"
+msgstr "שינויים לא נשמרו. להמשיך בלי לשמור?"
+
+#: id:727
+msgid "Web server"
+msgstr "שרת Web"
+
+#: id:728
+msgctxt "Auto context with id 728"
+msgid "FTP server"
+msgstr "שרת FTP"
+
+#: id:730
+msgid "- Port"
+msgstr "- פורט"
+
+#: id:732
+msgid "Save & apply"
+msgstr "שמור והפעל"
+
+#: id:733
+msgid "- Password"
+msgstr "- סיסמא"
+
+#: id:734
+msgid "No pass"
+msgstr "ללא סיסמא"
+
+#: id:735
+msgid "- Character set"
+msgstr "ערכת התווים -"
+
+#: id:736
+msgid "- Style"
+msgstr "סגנון -"
+
+#: id:737
+msgid "- Colour"
+msgstr "צבע -"
+
+#: id:738
+msgctxt "Auto context with id 738"
+msgid "Normal"
+msgstr "רגיל"
+
+#: id:739
+msgid "Bold"
+msgstr "מודגש"
+
+#: id:740
+msgid "Italics"
+msgstr "נטוי"
+
+#: id:741
+msgid "Bold italics"
+msgstr "מודגש ונטוי"
+
+#: id:742
+msgctxt "Auto context with id 742"
+msgid "White"
+msgstr "לבן"
+
+#: id:743
+msgctxt "Auto context with id 743"
+msgid "Yellow"
+msgstr "צהוב"
+
+#: id:744
+msgctxt "Auto context with id 744"
+msgid "Files"
+msgstr "קבצים"
+
+#: id:745
+msgid "No scanned information for this view"
+msgstr "לא נסרקו פרטים עבור תצוגה זו"
+
+#: id:746
+msgid "Please turn off library mode"
+msgstr "שנה לתצוגת קבצים"
+
+#: id:747
+msgid "Error loading image"
+msgstr "שגיאה בטעינת התמונה"
+
+#: id:748
+msgid "Edit path"
+msgstr "ערוך נתיב"
+
+#: id:749
+msgid "Mirror image"
+msgstr "הפוך תמונה"
+
+#: id:750
+msgid "Are you sure?"
+msgstr "האם אתה בטוח?"
+
+#: id:751
+msgid "Removing source"
+msgstr "מסיר מקור"
+
+#: id:754
+msgid "Add program link"
+msgstr "הוסף קישור לתוכנה"
+
+#: id:755
+msgid "Edit program path"
+msgstr "ערוך נתיב תוכנה"
+
+#: id:756
+msgid "Edit program name"
+msgstr "ערוך שם תוכנה"
+
+#: id:757
+msgid "Edit path depth"
+msgstr "ערוך עומק נתיב"
+
+#: id:759
+msgid "View: Big list"
+msgstr "תצוגה: רשימה גדולה"
+
+#: id:760
+msgctxt "Auto context with id 760"
+msgid "Yellow"
+msgstr "צהוב"
+
+#: id:761
+msgctxt "Auto context with id 761"
+msgid "White"
+msgstr "לבן"
+
+#: id:762
+msgid "Blue"
+msgstr "כחול"
+
+#: id:763
+msgid "Bright green"
+msgstr "ירוק בוהק"
+
+#: id:764
+msgid "Yellow green"
+msgstr "צהוב ירוק"
+
+#: id:765
+msgid "Cyan"
+msgstr "תכלת"
+
+#: id:766
+msgid "Light grey"
+msgstr "שמור"
+
+#: id:767
+msgid "Grey"
+msgstr "שמור"
+
+#: id:770
+msgid "Error %i: share not available"
+msgstr "שיתוף לא קיים :%i שגיאה"
+
+#: id:772
+msgctxt "Auto context with id 772"
+msgid "Audio output"
+msgstr "פלט אודיו"
+
+#: id:773
+msgid "Seeking"
+msgstr "מחפש"
+
+#: id:774
+msgid "Slideshow folder"
+msgstr "ספריית מצגת"
+
+#: id:775
+msgid "Network interface"
+msgstr "ממשק רשת"
+
+#: id:776
+msgid "- Wireless network name (ESSID)"
+msgstr "- שם רשת אלחוטית (ESSID)"
+
+#: id:777
+msgid "- Wireless password"
+msgstr "- סיסמאת רשת אלחוטית"
+
+#: id:778
+msgid "- Wireless security"
+msgstr "- אבטחת רשת אלחוטית"
+
+#: id:779
+msgid "Save and apply network interface settings"
+msgstr "שמור הגדרות ממשק רשת"
+
+#: id:780
+msgid "No encryption"
+msgstr "ללא הצפנה"
+
+#: id:781
+msgid "WEP"
+msgstr "WEP"
+
+#: id:782
+msgid "WPA"
+msgstr "WPA"
+
+#: id:783
+msgid "WPA2"
+msgstr "WPA2"
+
+#: id:784
+msgid "Applying network interface settings. Please wait."
+msgstr "מגדיר הגדרות ממשק רשת. אנא המתן."
+
+#: id:785
+msgid "Network interface restarted successfully."
+msgstr "ממשק רשת הופעל מחדש בהצלחה"
+
+#: id:786
+msgid "Network interface did not start successfully."
+msgstr "ממשק רשת לא הופעל בהצלחה."
+
+#: id:787
+msgid "Interface disabled"
+msgstr "ממשק מנוטרל"
+
+#: id:788
+msgid "Network interface disabled successfully."
+msgstr "ממשק רשת נוטרל בהצלחה."
+
+#: id:789
+msgid "Wireless network name (ESSID)"
+msgstr "שם רשת אלחוטית (ESSID)"
+
+#: id:790
+msgid "Remote control"
+msgstr "שליטה מרחוק"
+
+#: id:791
+msgid "Allow programs on this system to control XBMC"
+msgstr "אפשר לתוכנות במערכת זו לשלוט על XBMC"
+
+#: id:792
+msgctxt "Auto context with id 792"
+msgid "Port"
+msgstr "פורט"
+
+#: id:793
+msgid "Port range"
+msgstr "תווך פורטים"
+
+#: id:794
+msgid "Allow programs on other systems to control XBMC"
+msgstr "אפשר לתוכנות במערכות אחרות לשלוט על XBMC"
+
+#: id:795
+msgid "Initial repeat delay (ms)"
+msgstr "חוזר על עיכוב ראשוני (ms)"
+
+#: id:796
+msgid "Continuous repeat delay (ms)"
+msgstr "חזור על עיקוב מתמשך (ms)"
+
+#: id:797
+msgid "Maximum number of clients"
+msgstr "מספר קליינטים מירבי"
+
+#: id:798
+msgid "Internet access"
+msgstr "גישת אינטרנט"
+
+#: id:850
+msgid "Invalid port number entered"
+msgstr "מספר פורט שגוי"
+
+#: id:851
+msgid "Valid port range is 1-65535"
+msgstr "טווח פורט תקין הוא 1-65535"
+
+#: id:852
+msgid "Valid port range is 1024-65535"
+msgstr "טווח פורט תקין הוא 1024-65535"
+
+#: id:998
+msgid "Add Music..."
+msgstr "הוסף מוזיקה..."
+
+#: id:999
+msgid "Add Videos..."
+msgstr "הוסף וידאו..."
+
+#: id:1000
+msgid "- Preview"
+msgstr "- תצוגה מקדימה"
+
+#: id:1001
+msgid "Unable to connect"
+msgstr "חיבור נכשל"
+
+#: id:1002
+msgid "XBMC was unable to connect to the network location."
+msgstr "XBMC נכשל בחיבור לרשת המיקום."
+
+#: id:1003
+msgid "This could be due to the network not being connected."
+msgstr "זהו כנראה עקב הרשת שאיננה מחוברת."
+
+#: id:1004
+msgid "Would you like to add it anyway?"
+msgstr "האם ברצונך להוסיף בכל זאת?"
+
+#: id:1006
+msgctxt "Auto context with id 1006"
+msgid "IP address"
+msgstr "IP כתובת"
+
+#: id:1007
+msgid "Add network location"
+msgstr "הוסף מיקום ברשת"
+
+#: id:1008
+msgid "Protocol"
+msgstr "פרוטוקול"
+
+#: id:1009
+msgid "Server address"
+msgstr "כתובת שרת"
+
+#: id:1010
+msgid "Server name"
+msgstr "שם שרת"
+
+#: id:1011
+msgid "Remote path"
+msgstr "נתיב מרוחק"
+
+#: id:1012
+msgid "Shared folder"
+msgstr "ספריה משותפת"
+
+#: id:1013
+msgctxt "Auto context with id 1013"
+msgid "Port"
+msgstr "פורט"
+
+#: id:1014
+msgctxt "Auto context with id 1014"
+msgid "Username"
+msgstr "שם משתמש"
+
+#: id:1015
+msgid "Browse for network server"
+msgstr "עיין לחיפוש שרת רשת"
+
+#: id:1016
+msgid "Enter the network address of the server"
+msgstr "הזן כתובת רשת של השרת"
+
+#: id:1017
+msgid "Enter the path on the server"
+msgstr "הזן נתיב של השרת"
+
+#: id:1018
+msgid "Enter the port number"
+msgstr "הזן מספר פורט"
+
+#: id:1019
+msgid "Enter the username"
+msgstr "הזן שם משתמש"
+
+#: id:1020
+msgid "Add %s source"
+msgstr "%s הוסף מקור"
+
+#: id:1021
+msgid "Enter the paths or browse for the media locations."
+msgstr "הזן נתיב או עיין למיקום המדיה."
+
+#: id:1022
+msgid "Enter a name for this media Source."
+msgstr "הזן שם למקור מדיה זה."
+
+#: id:1023
+msgid "Browse for new share"
+msgstr "עיין לשיתוף חדש"
+
+#: id:1024
+msgid "Browse"
+msgstr "עיון"
+
+#: id:1025
+msgid "Could not retrieve directory information."
+msgstr "בעיה בקבלת פרטי הספריה."
+
+#: id:1026
+msgid "Add source"
+msgstr "הוסף מקור"
+
+#: id:1027
+msgid "Edit source"
+msgstr "ערוך מקור"
+
+#: id:1028
+msgid "Edit %s source"
+msgstr "%s ערוך מקור"
+
+#: id:1029
+msgid "Enter the new label"
+msgstr "הזן תווית"
+
+#: id:1030
+msgid "Browse for image"
+msgstr "עיין לתמונה"
+
+#: id:1031
+msgid "Browse for image folder"
+msgstr "עיין לתמונת תיקיה"
+
+#: id:1032
+msgid "Add network location..."
+msgstr "הוסף מיקום רשת..."
+
+#: id:1033
+msgid "Browse for file"
+msgstr "עיין לקובץ"
+
+#: id:1034
+msgid "Submenu"
+msgstr "תת-תפריט"
+
+#: id:1035
+msgid "Enable submenu buttons"
+msgstr "אפשר כפתורי תת-תפריט"
+
+#: id:1036
+msgid "Favourites"
+msgstr "מועדפים"
+
+#: id:1037
+msgid "Video Add-ons"
+msgstr "הרחבות וידאו"
+
+#: id:1038
+msgid "Music Add-ons"
+msgstr "הרחבות מוזיקה"
+
+#: id:1039
+msgid "Picture Add-ons"
+msgstr "הרחבות תמונות"
+
+#: id:1040
+msgid "Loading directory"
+msgstr "טוען ספריה"
+
+#: id:1041
+msgid "Retrieved %i items"
+msgstr "קיבל %i פריטים"
+
+#: id:1042
+msgid "Retrieved %i of %i items"
+msgstr "קיבל %i מתוך %i פריטים"
+
+#: id:1043
+msgid "Program Add-ons"
+msgstr "הרחבות תוכנות"
+
+#: id:1044
+msgid "Set plugin thumb"
+msgstr "הגדר תמונה ממוזערת להרחבה"
+
+#: id:1045
+msgid "Add-on settings"
+msgstr "הגדרות הרחבה"
+
+#: id:1046
+msgid "Access points"
+msgstr "נקודת גישה"
+
+#: id:1047
+msgid "Other..."
+msgstr "אחר..."
+
+#: id:1048
+msgid "- Username"
+msgstr "- שם משתמש"
+
+#: id:1049
+msgid "Script settings"
+msgstr "הגדרות סקריפט"
+
+#: id:1050
+msgid "Singles"
+msgstr "סינגלים"
+
+#: id:1051
+msgid "Enter web address"
+msgstr "הזן כתובת אינטרנט"
+
+#: id:1200
+msgid "SMB client"
+msgstr "SMB חלוקה"
+
+#: id:1202
+msgid "Workgroup"
+msgstr "SMB קבוצת עבודה"
+
+#: id:1203
+msgid "Default username"
+msgstr "SMB שם משתמש"
+
+#: id:1204
+msgid "Default password"
+msgstr "SMB סיסמא"
+
+#: id:1207
+msgid "WINS server"
+msgstr "SMB WINS שרת"
+
+#: id:1208
+msgid "Mount SMB shares"
+msgstr "מאונט שיתופי SMB"
+
+#: id:1210
+msgctxt "Auto context with id 1210"
+msgid "Remove"
+msgstr "הסר"
+
+#: id:1211
+msgctxt "Auto context with id 1211"
+msgid "Music"
+msgstr "מוסיקה"
+
+#: id:1212
+msgctxt "Auto context with id 1212"
+msgid "Video"
+msgstr "וידאו"
+
+#: id:1213
+msgctxt "Auto context with id 1213"
+msgid "Pictures"
+msgstr "תמונות"
+
+#: id:1214
+msgctxt "Auto context with id 1214"
+msgid "Files"
+msgstr "קבצים"
+
+#: id:1215
+msgctxt "Auto context with id 1215"
+msgid "Music & video"
+msgstr "מוסיקה ווידאו"
+
+#: id:1216
+msgid "Music & pictures"
+msgstr "מוסיקה ותמונות"
+
+#: id:1217
+msgid "Music & files"
+msgstr "מוסיקה וקבצים"
+
+#: id:1218
+msgid "Video & pictures"
+msgstr "וידאו ותמונות"
+
+#: id:1219
+msgid "Video & files"
+msgstr "וידאו וקבצים"
+
+#: id:1220
+msgid "Pictures & files"
+msgstr "תמונות וקבצים"
+
+#: id:1221
+msgid "Music & video & pictures"
+msgstr "מוזיקה, וידאו ותמונות"
+
+#: id:1222
+msgid "Music & video & pictures & files"
+msgstr "מוסיקה, וידאו, תמונות וקבצים"
+
+#: id:1223
+msgctxt "Auto context with id 1223"
+msgid "Disabled"
+msgstr "מנוטרל"
+
+#: id:1226
+msgid "Files & music & video"
+msgstr "קבצים, מוסיקה ווידאו"
+
+#: id:1227
+msgid "Files & pictures & music"
+msgstr "קבצים, תמונות ומוסיקה"
+
+#: id:1228
+msgid "Files & pictures & video"
+msgstr "קבצים, תמונות ווידאו"
+
+#: id:1229
+msgid "Music & programs"
+msgstr "מוסיקה ותוכנות"
+
+#: id:1230
+msgid "Video & programs"
+msgstr "וידאו ותוכנות"
+
+#: id:1231
+msgid "Pictures & programs"
+msgstr "תמונות ותוכנות"
+
+#: id:1232
+msgid "Music & video & pictures & programs"
+msgstr "מוסיקה, וידאו, תמונות ותוכנות"
+
+#: id:1233
+msgid "Programs & video & music"
+msgstr "תוכנות, וידאו ומוסיקה"
+
+#: id:1234
+msgid "Programs & pictures & music"
+msgstr "תוכנות, תמונות ומוסיקה"
+
+#: id:1235
+msgid "Programs & pictures & video"
+msgstr "תוכנות, תמונות ווידאו"
+
+#: id:1250
+msgid "Auto-detection"
+msgstr "זיהוי אוטומטי"
+
+#: id:1251
+msgid "Auto-detect system"
+msgstr "זיהוי מערכת אוטומטי"
+
+#: id:1252
+msgid "Nickname"
+msgstr "כינוי"
+
+#: id:1254
+msgid "Ask to connect"
+msgstr "שאל על מנת להתחבר"
+
+#: id:1255
+msgid "Send FTP user and password"
+msgstr "שלח פרטי FTP משתמש וסיסמא"
+
+#: id:1256
+msgid "Ping interval"
+msgstr "השהיית פינג"
+
+#: id:1257
+msgid "Would you like to connect to the auto-detected system?"
+msgstr "האם ברצונך להתחבר למערכת שזוהתה אוטומטית?"
+
+#: id:1259
+msgid "Zeroconf"
+msgstr "Zeroconf"
+
+#: id:1260
+msgid "Announce these services to other systems via Zeroconf"
+msgstr "הכרז על שירותים אלו למערכות אחרות דרך Zeroconf"
+
+#: id:1270
+msgid "Allow XBMC to receive AirPlay content"
+msgstr "אפשר ל-XBMC לקבל תכני AirPlay"
+
+#: id:1271
+msgid "Device name"
+msgstr "שם התקן"
+
+#: id:1272
+msgid "- Use password protection"
+msgstr "- השתמש בהגנת סיסמא"
+
+#: id:1273
+msgid "AirPlay"
+msgstr "AirPlay"
+
+#: id:1300
+msgid "Custom audio device"
+msgstr "התקן אודיו מותאם אישית"
+
+#: id:1301
+msgid "Custom passthrough device"
+msgstr "התקן פלט מותאם אישית"
+
+#: id:1396
+msgid "Drifting"
+msgstr "זולג"
+
+#: id:1397
+msgid "and"
+msgstr "ו"
+
+#: id:1398
+msgid "Freezing"
+msgstr "קופא"
+
+#: id:1399
+msgid "Late"
+msgstr "מאוחר"
+
+#: id:1400
+msgid "Isolated"
+msgstr "מבודד"
+
+#: id:1401
+msgid "Thundershowers"
+msgstr "רעמים וגשם"
+
+#: id:1402
+msgid "Thunder"
+msgstr "רעמים"
+
+#: id:1403
+msgctxt "Auto context with id 1403"
+msgid "Sun"
+msgstr "שמש"
+
+#: id:1404
+msgid "Heavy"
+msgstr "כבד"
+
+#: id:1405
+msgid "in"
+msgstr "ב"
+
+#: id:1406
+msgid "the"
+msgstr "ה"
+
+#: id:1407
+msgid "Vicinity"
+msgstr "אזור"
+
+#: id:1408
+msgid "Ice"
+msgstr "קרח"
+
+#: id:1409
+msgid "Crystals"
+msgstr "גבישי"
+
+#: id:1410
+msgid "Calm"
+msgstr "רגוע"
+
+#: id:1411
+msgid "with"
+msgstr "עם"
+
+#: id:1412
+msgid "windy"
+msgstr "סוער"
+
+#: id:1413
+msgid "drizzle"
+msgstr "טפטוף"
+
+#: id:1414
+msgid "Thunderstorm"
+msgstr "סערת רעמים"
+
+#: id:1415
+msgid "Drizzle"
+msgstr "טפטוף"
+
+#: id:1416
+msgid "Foggy"
+msgstr "ערפלי"
+
+#: id:1417
+msgid "Grains"
+msgstr "גרגירים"
+
+#: id:1418
+msgid "T-Storms"
+msgstr ""
+
+#: id:1419
+msgid "T-Showers"
+msgstr ""
+
+#: id:1420
+msgid "Moderate"
+msgstr "מתון"
+
+#: id:1421
+msgid "Very High"
+msgstr "גבוה מאוד"
+
+#: id:1422
+msgid "Windy"
+msgstr "סוער"
+
+#: id:1423
+msgid "Mist"
+msgstr "ערפל"
+
+#: id:1450
+msgid "Put display to sleep when idle"
+msgstr "הכנס צג למצב שינה כשאין פעילות"
+
+#: id:2050
+msgid "Runtime"
+msgstr "זמן ריצה"
+
+#: id:2100
+msgid "Script failed! : %s"
+msgstr "הסקריפט ניכשל!: %s"
+
+#: id:2101
+msgid "Newer version needed - See log"
+msgstr "יש צורך בגרסא חדשה - עיין בלוג"
+
+#: id:4501
+msgid "Enable LCD/VFD"
+msgstr "הפעל LCD/VFD"
+
+#: id:10000
+msgid "Home"
+msgstr "בית"
+
+#: id:10001
+msgctxt "Auto context with id 10001"
+msgid "Programs"
+msgstr "תוכנות"
+
+#: id:10002
+msgctxt "Auto context with id 10002"
+msgid "Pictures"
+msgstr "תמונות"
+
+#: id:10003
+msgctxt "Auto context with id 10003"
+msgid "File manager"
+msgstr "מנהל קבצים"
+
+#: id:10004
+msgctxt "Auto context with id 10004"
+msgid "Settings"
+msgstr "הגדרות"
+
+#: id:10005
+msgctxt "Auto context with id 10005"
+msgid "Music"
+msgstr "מוסיקה"
+
+#: id:10006
+msgctxt "Auto context with id 10006"
+msgid "Videos"
+msgstr "וידאו"
+
+#: id:10007
+msgid "System information"
+msgstr "פרטי מערכת"
+
+#: id:10008
+msgid "Settings - General"
+msgstr "הגדרות - כללי"
+
+#: id:10009
+msgid "Settings - Screen"
+msgstr "הגדרות - מסך"
+
+#: id:10010
+msgid "Settings - Appearance - GUI Calibration"
+msgstr "הגדרות - מראה - כיוונון GUI"
+
+#: id:10011
+msgid "Settings - Videos - Screen Calibration"
+msgstr "הגדרות - וידאו - כיוונון מסך"
+
+#: id:10012
+msgid "Settings - Pictures"
+msgstr "הגדרות - תמונות"
+
+#: id:10013
+msgid "Settings - Programs"
+msgstr "הגדרות - תוכניות"
+
+#: id:10014
+msgid "Settings - Weather"
+msgstr "הגדרות - מזג האויר"
+
+#: id:10015
+msgid "Settings - Music"
+msgstr "הגדרות - מוסיקה"
+
+#: id:10016
+msgid "Settings - System"
+msgstr "הגדרות - מערכת"
+
+#: id:10017
+msgid "Settings - Videos"
+msgstr "הגדרות - וידאו"
+
+#: id:10018
+msgid "Settings - Network"
+msgstr "הגדרות - רשת"
+
+#: id:10019
+msgid "Settings - Appearance"
+msgstr "הגדרות - מראה"
+
+#: id:10020
+msgctxt "Auto context with id 10020"
+msgid "Scripts"
+msgstr "סקריפטים"
+
+#: id:10021
+msgid "Web Browser"
+msgstr "דפדפן אינטרנט"
+
+#: id:10025
+msgctxt "Auto context with id 10025"
+msgid "Videos"
+msgstr "וידאו"
+
+#: id:10028
+msgid "Videos/Playlist"
+msgstr "וידאו/רשימת ניגון"
+
+#: id:10029
+msgctxt "Auto context with id 10029"
+msgid "Login screen"
+msgstr "מסך כניסה"
+
+#: id:10034
+msgid "Settings - Profiles"
+msgstr "הגדרות - פרופילים"
+
+#: id:10040
+msgid "Addon browser"
+msgstr "דפדפן הרחבות"
+
+#: id:10100
+msgid "Yes/No dialog"
+msgstr "דיאלוג לא/כן"
+
+#: id:10101
+msgid "Progress dialog"
+msgstr "דיאלוג התקדמות"
+
+#: id:10210
+msgid "Looking for subtitles..."
+msgstr "מחפש כתוביות..."
+
+#: id:10211
+msgid "Looking for or caching subtitles..."
+msgstr "מחפש או אוגר כתוביות..."
+
+#: id:10212
+msgid "terminating"
+msgstr "מבטל"
+
+#: id:10213
+msgid "buffering"
+msgstr "אוגר מידע"
+
+#: id:10214
+msgid "Opening stream"
+msgstr "פותח זרימה"
+
+#: id:10500
+msgid "Music/Playlist"
+msgstr "מוסיקה/רשימת ניגון"
+
+#: id:10501
+msgid "Music/Files"
+msgstr "מוסיקה/קבצים"
+
+#: id:10502
+msgid "Music/Library"
+msgstr "מוסיקה/ספרייה"
+
+#: id:10503
+msgid "Playlist editor"
+msgstr "עורך רשימת ניגון"
+
+#: id:10504
+msgid "Top 100 songs"
+msgstr "מאה השירים הגדולים"
+
+#: id:10505
+msgid "Top 100 albums"
+msgstr "מאה האלבומים הגדולים"
+
+#: id:10506
+msgctxt "Auto context with id 10506"
+msgid "Programs"
+msgstr "תוכנות"
+
+#: id:10507
+msgid "Configuration"
+msgstr "הגדרות"
+
+#: id:10508
+msgid "Weather forecast"
+msgstr "תחזית מזג אויר"
+
+#: id:10509
+msgid "Network gaming"
+msgstr "משחקי רשת"
+
+#: id:10510
+msgid "Extensions"
+msgstr "סיומות"
+
+#: id:10511
+msgctxt "Auto context with id 10511"
+msgid "System info"
+msgstr "פרטי מערכת"
+
+#: id:10516
+msgid "Music - Library"
+msgstr "מוסיקה - ספריה"
+
+#: id:10517
+msgid "Now Playing - Music"
+msgstr "מנגן כעת - מוסיקה"
+
+#: id:10522
+msgid "Now Playing - Videos"
+msgstr "מנגן כעת - וידאו"
+
+#: id:10523
+msgid "Album info"
+msgstr "פרטי אלבום"
+
+#: id:10524
+msgid "Movie info"
+msgstr "פרטי סרט"
+
+#: id:12000
+msgid "Select dialog"
+msgstr "בחר דיאלוג"
+
+#: id:12001
+msgid "Music/Info"
+msgstr "מוסיקה/פרטים"
+
+#: id:12002
+msgid "Dialog OK"
+msgstr "דיאלוג אישור"
+
+#: id:12003
+msgid "Videos/Info"
+msgstr "וידאו/פרטים"
+
+#: id:12004
+msgid "Scripts/Info"
+msgstr "סקרפטים/פרטים"
+
+#: id:12005
+msgid "Fullscreen video"
+msgstr "וידאו במסך מלא"
+
+#: id:12006
+msgid "Audio visualization"
+msgstr "חיזוי אודיו"
+
+#: id:12008
+msgid "File stacking dialog"
+msgstr "דיאלוג ערימת קבצים"
+
+#: id:12009
+msgid "Rebuild index..."
+msgstr "בונה אינדקס..."
+
+#: id:12010
+msgid "Return to music window"
+msgstr "חזור לחלון המוזיקה"
+
+#: id:12011
+msgid "Return to videos window"
+msgstr "חזור לחלון הוידאו"
+
+#: id:12021
+msgid "Start from beginning"
+msgstr "התחל מהתחלה"
+
+#: id:12022
+msgid "Resume from %s"
+msgstr "המשך מנקודה %s"
+
+#: id:12310
+msgid "0"
+msgstr "0"
+
+#: id:12311
+msgid "1"
+msgstr "1"
+
+#: id:12312
+msgid "2"
+msgstr "2"
+
+#: id:12313
+msgid "3"
+msgstr "3"
+
+#: id:12314
+msgid "4"
+msgstr "4"
+
+#: id:12315
+msgid "5"
+msgstr "5"
+
+#: id:12316
+msgid "6"
+msgstr "6"
+
+#: id:12317
+msgid "7"
+msgstr "7"
+
+#: id:12318
+msgid "8"
+msgstr "8"
+
+#: id:12319
+msgid "9"
+msgstr "9"
+
+#: id:12320
+msgid "c"
+msgstr "c"
+
+#: id:12321
+msgid "Ok"
+msgstr "ok"
+
+#: id:12322
+msgid "*"
+msgstr "*"
+
+#: id:12325
+msgid "Locked! Enter code..."
+msgstr "נעול! הקש קוד..."
+
+#: id:12326
+msgid "Enter password"
+msgstr "הזן סיסמא"
+
+#: id:12327
+msgid "Enter master code"
+msgstr "הזן קוד נעילה ראשי"
+
+#: id:12328
+msgid "Enter unlock code"
+msgstr "הזן קוד שחרור"
+
+#: id:12329
+msgid "or press C to cancel"
+msgstr "או הקש C לביטול"
+
+#: id:12330
+msgid "Enter gamepad button combo and"
+msgstr "לחץ על כפתורי קומבו בגיימפד"
+
+#: id:12331
+msgid "press OK, or Back to cancel"
+msgstr "ולחץ אישור או אחורה לביטול"
+
+#: id:12332
+msgid "Set lock"
+msgstr "נעל"
+
+#: id:12333
+msgid "Unlock"
+msgstr "שחרר"
+
+#: id:12334
+msgid "Reset lock"
+msgstr "אפס נעילה"
+
+#: id:12335
+msgid "Remove lock"
+msgstr "הסר נעילה"
+
+#: id:12337
+msgid "Numeric password"
+msgstr "סיסמת מספר"
+
+#: id:12338
+msgid "Gamepad button combo"
+msgstr "כפתור קומבו בגיימפד"
+
+#: id:12339
+msgid "Full-text password"
+msgstr "סיסמת טקסט מלא"
+
+#: id:12340
+msgid "Enter new password"
+msgstr "הזן סיסמא חדשה"
+
+#: id:12341
+msgid "Re-Enter new password"
+msgstr "הזן סיסמא פעם נוספת"
+
+#: id:12342
+msgid "Incorrect password,"
+msgstr "סיסמא שגויה,"
+
+#: id:12343
+msgid "retries left"
+msgstr "נסיונות נותרו"
+
+#: id:12344
+msgid "Passwords entered did not match."
+msgstr "סיסמאות לא תואמות."
+
+#: id:12345
+msgid "Access denied"
+msgstr "הגישה נדחתה"
+
+#: id:12346
+msgid "Password retry limit exceeded."
+msgstr "נסיונות כניסה כושלים רבים מדי."
+
+#: id:12347
+msgid "The system will now shut off."
+msgstr "המערכת כעת תכבה."
+
+#: id:12348
+msgid "Item locked"
+msgstr "פריט נעול"
+
+#: id:12353
+msgid "Reactivate lock"
+msgstr "הפעל נעילה מחדש"
+
+#: id:12356
+msgid "Change lock"
+msgstr "שנה נעילה"
+
+#: id:12357
+msgid "Source lock"
+msgstr "נעילת מקור"
+
+#: id:12358
+msgid "Password entry was blank. Try again."
+msgstr "שדה הסיסמא ריק. נסה שנית."
+
+#: id:12360
+msgid "Master lock"
+msgstr "נעילה ראשית"
+
+#: id:12362
+msgid "Shutdown system if Master Lock retries exceeded"
+msgstr "כבה מערכת כאשר ניסיונות הקוד הראשי רבים מדי"
+
+#: id:12367
+msgid "Master code is not valid"
+msgstr "קוד ראשי אינו תקין"
+
+#: id:12368
+msgid "Please enter a valid master code"
+msgstr "אנא הזן קוד ראשי תקין"
+
+#: id:12373
+msgid "Settings & file manager"
+msgstr "הגדרות & הקבצים שלי"
+
+#: id:12376
+msgid "Set as default for all movies"
+msgstr "הגדר כברירת מחדל לכל הסרטים"
+
+#: id:12377
+msgid "This will reset any previously saved values"
+msgstr "פעולה זו תאתחל כל ערכים קודמים שנשמרו"
+
+#: id:12378
+msgid "Amount of time to display each image"
+msgstr "זמן הצגת כל תמונה"
+
+#: id:12379
+msgid "Use pan and zoom effects"
+msgstr "Pan and Zoom השתמש באפקט"
+
+#: id:12383
+msgid "12 hour clock"
+msgstr "שעון 12 שעות"
+
+#: id:12384
+msgid "24 hour clock"
+msgstr "שעון 24 שעות"
+
+#: id:12385
+msgid "Day/Month"
+msgstr "יום/חודש"
+
+#: id:12386
+msgid "Month/Day"
+msgstr "חודש/יום"
+
+#: id:12390
+msgid "System uptime"
+msgstr "זמן מערכת פעילה"
+
+#: id:12391
+msgid "Minutes"
+msgstr "דקות"
+
+#: id:12392
+msgid "Hours"
+msgstr "שעות"
+
+#: id:12393
+msgid "Days"
+msgstr "ימים"
+
+#: id:12394
+msgid "Total uptime"
+msgstr "סה\"כ פעילות"
+
+#: id:12395
+msgid "Battery level"
+msgstr "רמת סוללה"
+
+#: id:12600
+msgctxt "Auto context with id 12600"
+msgid "Weather"
+msgstr "מזג אויר"
+
+#: id:12900
+msgctxt "Auto context with id 12900"
+msgid "Screensaver"
+msgstr "שומר מסך"
+
+#: id:12901
+msgid "Fullscreen OSD"
+msgstr "תפריט במסך מלא"
+
+#: id:13000
+msgid "System"
+msgstr "מערכת"
+
+#: id:13001
+msgid "Immediate HD spindown"
+msgstr "הורד כמות סיבובים בדיסק הקשיח מיידית"
+
+#: id:13002
+msgid "Video only"
+msgstr "וידאו בלבד"
+
+#: id:13003
+msgid "- Delay"
+msgstr "- השהייה"
+
+#: id:13004
+msgid "- Minimum file duration"
+msgstr "- אורך קובץ מינימאלי"
+
+#: id:13005
+msgid "Shutdown"
+msgstr "כיבוי"
+
+#: id:13008
+msgid "Shutdown function"
+msgstr "פעולת כיבוי"
+
+#: id:13009
+msgid "Quit"
+msgstr "צא"
+
+#: id:13010
+msgid "Hibernate"
+msgstr "מצב שינה"
+
+#: id:13011
+msgid "Suspend"
+msgstr "השהייה"
+
+#: id:13012
+msgid "Exit"
+msgstr "יציאה"
+
+#: id:13013
+msgid "Reboot"
+msgstr "הפעלה מחדש"
+
+#: id:13014
+msgid "Minimize"
+msgstr "מזער"
+
+#: id:13015
+msgid "Power button action"
+msgstr "פעולת כפתור הכיבוי"
+
+#: id:13016
+msgid "Power off System"
+msgstr "כיבוי מערכת"
+
+#: id:13020
+msgid "Is another session active, perhaps over ssh?"
+msgstr "יש תוכנית אחרת פעילה, יכול להיות SSH?"
+
+#: id:13021
+msgid "Mounted removable harddrive"
+msgstr "כונן נייד מחובר"
+
+#: id:13022
+msgid "Unsafe device removal"
+msgstr "לא בטוח להסיר התקן נייד"
+
+#: id:13023
+msgid "Successfully removed device"
+msgstr "התקן הוסר בהצלחה"
+
+#: id:13024
+msgid "Joystick plugged"
+msgstr "ג'ויסטיק חובר"
+
+#: id:13025
+msgid "Joystick unplugged"
+msgstr "ג'ויסטיק נותק"
+
+#: id:13050
+msgid "Running low on battery"
+msgstr "רץ על סוללה חלשה"
+
+#: id:13100
+msgid "Flicker filter"
+msgstr "פילטר הבהובים"
+
+#: id:13101
+msgid "Let driver choose (requires restart)"
+msgstr "תן למנהל ההתקן להחליט (הפעלה מחדש)"
+
+#: id:13105
+msgid "Vertical blank sync"
+msgstr ""
+
+#: id:13106
+msgctxt "Auto context with id 13106"
+msgid "Disabled"
+msgstr "מנוטרל"
+
+#: id:13107
+msgid "Enabled during video playback"
+msgstr "הפעל בזמן ניגון וידאו"
+
+#: id:13108
+msgctxt "Auto context with id 13108"
+msgid "Always enabled"
+msgstr "מופעל תמיד"
+
+#: id:13109
+msgid "Test & apply resolution"
+msgstr "בדוק והחל רזולוציה"
+
+#: id:13110
+msgid "Save resolution?"
+msgstr "לשמור רזולוציה?"
+
+#: id:13111
+msgid "Would you like to keep this resolution?"
+msgstr "האם תרצה לשמור את הרזולוציה הזו?"
+
+#: id:13112
+msgid "High quality upscaling"
+msgstr ""
+
+#: id:13113
+msgctxt "Auto context with id 13113"
+msgid "Disabled"
+msgstr "מנוטרל"
+
+#: id:13114
+msgid "Enabled for SD content"
+msgstr "מופעל רק לתכני SD"
+
+#: id:13115
+msgctxt "Auto context with id 13115"
+msgid "Always enabled"
+msgstr "אפשר תמיד"
+
+#: id:13116
+msgid "Upscaling method"
+msgstr ""
+
+#: id:13117
+msgctxt "Auto context with id 13117"
+msgid "Bicubic"
+msgstr ""
+
+#: id:13118
+msgid "Lanczos"
+msgstr ""
+
+#: id:13119
+msgid "Sinc"
+msgstr ""
+
+#: id:13120
+msgctxt "Auto context with id 13120"
+msgid "VDPAU"
+msgstr "VDPAU"
+
+#: id:13121
+msgid "VDPAU HQ Upscaling level"
+msgstr ""
+
+#: id:13122
+msgid "VDPAU Studio level color conversion"
+msgstr ""
+
+#: id:13130
+msgid "Blank other displays"
+msgstr "החשך צגים אחרים"
+
+#: id:13131
+msgctxt "Auto context with id 13131"
+msgid "Disabled"
+msgstr "מנוטרל"
+
+#: id:13132
+msgid "Blank displays"
+msgstr "צגים ריקים"
+
+#: id:13140
+msgid "Active connections detected!"
+msgstr "חיבורים פעילים זוהו!"
+
+#: id:13141
+msgid "If you proceed, you might not be able to control XBMC"
+msgstr "אם תמשיך, ייתכן שלא תוכל לשלוט ב-XBMC יותר"
+
+#: id:13142
+msgid "any longer. Are you sure you want to stop the Event server?"
+msgstr "אתה בטוח שברצונך להפסיק את EventServer?"
+
+#: id:13144
+msgid "Change Apple Remote mode?"
+msgstr "שנה מצב שלט Apple?"
+
+#: id:13145
+msgid "If you are currently using the Apple Remote to control"
+msgstr "אם אתה משתמש כרגע בשלט Apple כדי לשלוט"
+
+#: id:13146
+msgid "XBMC, changing this setting might affect your ability"
+msgstr "ב- XBMC. שינוי הגדרות אלה כנראה ישפיעו על היכולות שלך"
+
+#: id:13147
+msgid "to continue controlling it. Do you want to proceed?"
+msgstr "כדי להמשיך לשלוט בזה. האם ברצונך להמשיך?"
+
+#: id:13159
+msgid "Subnet mask"
+msgstr ""
+
+#: id:13160
+msgid "Gateway"
+msgstr "שער"
+
+#: id:13161
+msgid "Primary DNS"
+msgstr "DNS ראשי"
+
+#: id:13162
+msgid "Initialize failed"
+msgstr "אתחול נכשל"
+
+#: id:13170
+msgctxt "Auto context with id 13170"
+msgid "Never"
+msgstr "אף פעם"
+
+#: id:13171
+msgid "Immediately"
+msgstr "מיידי"
+
+#: id:13172
+msgid "After %i secs"
+msgstr "לאחר %i שניות"
+
+#: id:13173
+msgid "HDD install date:"
+msgstr "תאריך התקנת כונן קשיח:"
+
+#: id:13174
+msgid "HDD power cycle count:"
+msgstr "HDD ספירת מחזור האנרגיה:"
+
+#: id:13200
+msgid "Profiles"
+msgstr "פרופילים"
+
+#: id:13201
+msgid "Delete profile '%s'?"
+msgstr "למחוק פרופיל '%s'?"
+
+#: id:13204
+msgid "Last loaded profile:"
+msgstr "פרופיל אחרון בשימוש:"
+
+#: id:13205
+msgid "Unknown"
+msgstr "לא ידוע"
+
+#: id:13206
+msgid "Overwrite"
+msgstr "לדרוס"
+
+#: id:13208
+msgid "Alarm clock"
+msgstr "שעון מעורר"
+
+#: id:13209
+msgid "Alarm clock interval (in minutes)"
+msgstr "השהיית שעון מעורר (בדקות)"
+
+#: id:13210
+msgid "Started, alarm in %im"
+msgstr "התחיל. צלצול בעוד %i דקות"
+
+#: id:13211
+msgid "Alarm!"
+msgstr "צלצול!"
+
+#: id:13212
+msgid "Canceled with %im%is left"
+msgstr "בוטל עם %i דק' %i שנ' שנשארו"
+
+#: id:13213
+msgid "%2.0fm"
+msgstr "%2.0f דק'"
+
+#: id:13214
+msgid "%2.0fs"
+msgstr "%2.0f שנ'"
+
+#: id:13249
+msgid "Search for subtitles in RARs"
+msgstr "חפש כתוביות בקבצי RAR"
+
+#: id:13250
+msgid "Browse for subtitle..."
+msgstr "עיין לכתובית..."
+
+#: id:13251
+msgid "Move item"
+msgstr "הזז פריט"
+
+#: id:13252
+msgid "Move item here"
+msgstr "הזז פריט לכאן"
+
+#: id:13253
+msgid "Cancel move"
+msgstr "בטל העברה"
+
+#: id:13270
+msgid "Hardware:"
+msgstr "חומרה:"
+
+#: id:13271
+msgid "CPU Usage:"
+msgstr "CPU מהירות:"
+
+#: id:13274
+msgid "Connected, but no DNS is available."
+msgstr "מחובר. אבל DNS לא זמין"
+
+#: id:13275
+msgid "Hard Disk"
+msgstr "דיסק קשיח"
+
+#: id:13276
+msgid "DVD-ROM"
+msgstr "DVD-ROM"
+
+#: id:13277
+msgctxt "Auto context with id 13277"
+msgid "Storage"
+msgstr "אחסון"
+
+#: id:13278
+msgctxt "Auto context with id 13278"
+msgid "Default"
+msgstr "ברירת מחדל"
+
+#: id:13279
+msgctxt "Auto context with id 13279"
+msgid "Network"
+msgstr "רשת"
+
+#: id:13280
+msgctxt "Auto context with id 13280"
+msgid "Video"
+msgstr "וידאו"
+
+#: id:13281
+msgid "Hardware"
+msgstr "חומרה"
+
+#: id:13283
+msgid "Operating system:"
+msgstr "מערכת הפעלה:"
+
+#: id:13284
+msgid "CPU speed:"
+msgstr "CPU מהירות:"
+
+#: id:13286
+msgid "Video encoder:"
+msgstr "מקודד וידאו:"
+
+#: id:13287
+msgid "Screen resolution:"
+msgstr "רזולוצית מסך:"
+
+#: id:13292
+msgid "A/V cable:"
+msgstr "A/V כבל:"
+
+#: id:13294
+msgid "DVD region:"
+msgstr "DVD איזור:"
+
+#: id:13295
+msgid "Internet:"
+msgstr "אינטרנט:"
+
+#: id:13296
+msgctxt "Auto context with id 13296"
+msgid "Connected"
+msgstr "מחובר"
+
+#: id:13297
+msgid "Not connected. Check network settings."
+msgstr "לא מחובר. בדוק הגדרות רשת"
+
+#: id:13299
+msgid "Target temperature"
+msgstr "טמפרטורת יעד"
+
+#: id:13300
+msgid "Fan speed"
+msgstr "מהירות מאורר:"
+
+#: id:13301
+msgid "Auto temperature control"
+msgstr "בקרת טמפרטורה אוטומטית"
+
+#: id:13302
+msgid "Fan speed override"
+msgstr "בקרת מהירות מאורר"
+
+#: id:13303
+msgid "- Fonts"
+msgstr "- פונטים"
+
+#: id:13304
+msgid "Enable flipping bi-directional strings"
+msgstr "אפשר הפיכת תווים דו-כיווניים"
+
+#: id:13305
+msgid "Show RSS news feeds"
+msgstr "הראה RSS לעידכוני חדשות"
+
+#: id:13306
+msgid "Show parent folder items"
+msgstr "הראה פריטי ספריית אב"
+
+#: id:13307
+msgid "Track naming template"
+msgstr "תבנית שם רצועה"
+
+#: id:13308
+msgid "Do you wish to reboot your system"
+msgstr "האם ברצונך לאתחל את המערכת"
+
+#: id:13309
+msgid "instead of just XBMC?"
+msgstr "במקום רק את XBMC?"
+
+#: id:13310
+msgid "Zoom effect"
+msgstr "אפקט זום"
+
+#: id:13311
+msgid "Float effect"
+msgstr "אפקט ציפה"
+
+#: id:13312
+msgid "Black bar reduction"
+msgstr "הפחת פסים שחורים"
+
+#: id:13313
+msgid "Restart"
+msgstr "הפעלה מחדש"
+
+#: id:13314
+msgid "Crossfade between songs"
+msgstr "זמן חפיפה במעבר בין שירים"
+
+#: id:13315
+msgid "Regenerate thumbnails"
+msgstr "חדש תמונות ממוזערות"
+
+#: id:13316
+msgid "Recursive thumbnails"
+msgstr "תמונות ממוזערות רקורסיביות"
+
+#: id:13317
+msgid "View slideshow"
+msgstr "צפה במצגת תמונות"
+
+#: id:13318
+msgid "Recursive slideshow"
+msgstr "מצגת תמונות רקורסיבית"
+
+#: id:13319
+msgid "Randomize"
+msgstr "אקראי"
+
+#: id:13320
+msgid "Stereo"
+msgstr "סטריאו"
+
+#: id:13321
+msgid "Left only"
+msgstr "שמאל בלבד"
+
+#: id:13322
+msgid "Right only"
+msgstr "ימין בלבד"
+
+#: id:13323
+msgid "Enable karaoke support"
+msgstr "הפעל תמיכת קריוקי"
+
+#: id:13324
+msgid "Background transparency"
+msgstr "שקיפות רקע"
+
+#: id:13325
+msgid "Foreground transparency"
+msgstr "שקיפות רקע קדמי"
+
+#: id:13326
+msgid "A/V delay"
+msgstr "השהיית A/V"
+
+#: id:13327
+msgid "Karaoke"
+msgstr "קריוקי"
+
+#: id:13328
+msgid "%s not found"
+msgstr "%s לא נמצא"
+
+#: id:13329
+msgid "Error opening %s"
+msgstr "שגיאה בפתיחת %s"
+
+#: id:13330
+msgid "Unable to load %s"
+msgstr "כשלון בטעינת %s"
+
+#: id:13331
+msgid "Error: Out of memory"
+msgstr "שגיאה: הזכרון מלא."
+
+#: id:13332
+msgid "Move up"
+msgstr "הזז למעלה"
+
+#: id:13333
+msgid "Move down"
+msgstr "הזז למטה"
+
+#: id:13334
+msgid "Edit label"
+msgstr "ערוך תווית"
+
+#: id:13335
+msgid "Make default"
+msgstr "קבע כברירת מחדל"
+
+#: id:13336
+msgid "Remove button"
+msgstr "הסר כפתור"
+
+#: id:13340
+msgid "Leave as is"
+msgstr "השאר ללא שינוי"
+
+#: id:13341
+msgid "Green"
+msgstr "ירוק"
+
+#: id:13342
+msgid "Orange"
+msgstr "כתום"
+
+#: id:13343
+msgid "Red"
+msgstr "אדום"
+
+#: id:13344
+msgid "Cycle"
+msgstr "משתנה"
+
+#: id:13345
+msgid "Switch LED off on playback"
+msgstr "כבה נורית בזמן ניגון"
+
+#: id:13346
+msgctxt "Auto context with id 13346"
+msgid "Movie information"
+msgstr "פרטי סרט"
+
+#: id:13347
+msgid "Queue item"
+msgstr "הכנס פריט לתור"
+
+#: id:13348
+msgid "Search IMDb..."
+msgstr "חפש ב- IMDb..."
+
+#: id:13349
+msgid "Scan for new content"
+msgstr "סרוק לתוכן חדש"
+
+#: id:13350
+msgid "Now playing..."
+msgstr "מנגן כעת..."
+
+#: id:13351
+msgctxt "Auto context with id 13351"
+msgid "Album information"
+msgstr "פרטי אלבום"
+
+#: id:13352
+msgid "Scan item to library"
+msgstr "סרוק פריט לספריה"
+
+#: id:13353
+msgid "Stop scanning"
+msgstr "עצור סריקה"
+
+#: id:13354
+msgctxt "Auto context with id 13354"
+msgid "Render method"
+msgstr "שיטת Render"
+
+#: id:13355
+msgid "Low quality pixel shader"
+msgstr "באיכות נמוכה Pixel Shader"
+
+#: id:13356
+msgid "Hardware overlays"
+msgstr "Hardware Overlays"
+
+#: id:13357
+msgid "High quality pixel shader"
+msgstr "באיכות גבוהה Pixel Shader"
+
+#: id:13358
+msgid "Play item"
+msgstr "נגן פריט"
+
+#: id:13359
+msgid "Set artist thumb"
+msgstr "הגדר תמונה ממוזערת לאמן"
+
+#: id:13360
+msgid "Automatically generate thumbnails"
+msgstr "צור תמונות ממוזערות אוטומטית"
+
+#: id:13361
+msgid "Enable voice"
+msgstr "הפעל קול"
+
+#: id:13375
+msgid "Enable device"
+msgstr "הפעל מתקן"
+
+#: id:13376
+msgid "Volume"
+msgstr "עוצמה"
+
+#: id:13377
+msgid "Default view mode"
+msgstr "מצב תצוגה ברירת מחדל"
+
+#: id:13378
+msgid "Default brightness"
+msgstr "בהירות ברירת מחדל"
+
+#: id:13379
+msgid "Default contrast"
+msgstr "ניגודיות ברירת מחדל"
+
+#: id:13380
+msgid "Default gamma"
+msgstr "גאמה ברירת מחדל"
+
+#: id:13381
+msgid "Resume video"
+msgstr "המשך וידאו"
+
+#: id:13382
+msgid "Voice mask - Port 1"
+msgstr "Voice mask - Port 3"
+
+#: id:13383
+msgid "Voice mask - Port 2"
+msgstr "Voice mask - Port 3"
+
+#: id:13384
+msgid "Voice mask - Port 3"
+msgstr "Voice Mask - Port 3"
+
+#: id:13385
+msgid "Voice mask - Port 4"
+msgstr "Voice Mask - Port 4"
+
+#: id:13386
+msgid "Use time based seeking"
+msgstr "השתמש בחיפוש מבוסס זמן"
+
+#: id:13387
+msgid "Track naming template - right"
+msgstr "תבנית שם רצועה - ימין"
+
+#: id:13388
+msgid "Preset"
+msgstr "ערכים קבועים מראש"
+
+#: id:13389
+msgid "There are no presets available\nfor this visualization"
+msgstr "אין ערכים קבועים מראש לחיזוי זה"
+
+#: id:13390
+msgid "There are no settings available\nfor this visualization"
+msgstr "אין הגדרות לחיזוי זה"
+
+#: id:13391
+msgid "Eject/Load"
+msgstr "הוצאה/טעינה"
+
+#: id:13392
+msgid "Use visualization if playing audio"
+msgstr "השתמש בחיזוי בזמן נגינת אודיו"
+
+#: id:13393
+msgid "Calculate size"
+msgstr "חשב גודל"
+
+#: id:13394
+msgid "Calculating folder size"
+msgstr "מחשב גודל תקייה"
+
+#: id:13395
+msgid "Video settings"
+msgstr "הגדרות וידאו"
+
+#: id:13396
+msgid "Audio and subtitle settings"
+msgstr "הגדרות אודיו וכתוביות"
+
+#: id:13397
+msgid "Enable subtitles"
+msgstr "הפעל כתוביות"
+
+#: id:13398
+msgctxt "Auto context with id 13398"
+msgid "Shortcuts"
+msgstr "קיצורים"
+
+#: id:13399
+msgid "Ignore articles when sorting (e.g. \"the\")"
+msgstr "התעלם מתוויות בזמן מיון (למשל: \"The\")"
+
+#: id:13400
+msgid "Crossfade between songs on the same album"
+msgstr "נגן בחפיפה במעבר שירים באותו אלבום"
+
+#: id:13401
+msgid "Browse for %s"
+msgstr "עיין ל%s"
+
+#: id:13402
+msgid "Show track position"
+msgstr "הצג מיקום ברצועה"
+
+#: id:13403
+msgid "Clear default"
+msgstr "נקה ברירות מחדל"
+
+#: id:13404
+msgid "Resume"
+msgstr "המשך"
+
+#: id:13405
+msgid "Get thumb"
+msgstr "קבל תמונה ממוזערת"
+
+#: id:13406
+msgid "Picture information"
+msgstr "פרטי תמונה"
+
+#: id:13407
+msgid "%s presets"
+msgstr "%s ערכים מוגדרים מראש"
+
+#: id:13408
+msgid "(IMDb user rating)"
+msgstr "(דירוג משתמשים IMDB)"
+
+#: id:13409
+msgid "Top 250"
+msgstr "250 המובילים"
+
+#: id:13410
+msgid "Tune in on Last.fm"
+msgstr "התחבר ל LAST.FM"
+
+#: id:13411
+msgid "Minimum fan speed"
+msgstr "מהירות מאוורר מינימאלית"
+
+#: id:13412
+msgid "Play from here"
+msgstr "נגן מכאן"
+
+#: id:13413
+msgid "Downloading"
+msgstr "מוריד"
+
+#: id:13414
+msgid "Include artists who appear only on compilations"
+msgstr "הוסף אמנים שמופיעים רק באוספים"
+
+#: id:13415
+msgctxt "Auto context with id 13415"
+msgid "Render method"
+msgstr "שיטת Render"
+
+#: id:13416
+msgid "Auto detect"
+msgstr "זהה אוטומטית"
+
+#: id:13417
+msgid "Basic shaders (ARB)"
+msgstr ""
+
+#: id:13418
+msgid "Advanced shaders (GLSL)"
+msgstr ""
+
+#: id:13419
+msgid "Software"
+msgstr "תוכנתי"
+
+#: id:13420
+msgid "Remove safely"
+msgstr "הסר בבטחה"
+
+#: id:13421
+msgctxt "Auto context with id 13421"
+msgid "VDPAU"
+msgstr "VDPAU"
+
+#: id:13422
+msgid "Start slideshow here"
+msgstr "התחל מצגת תמונות כאן"
+
+#: id:13423
+msgid "Remember for this path"
+msgstr "זכור לנתיב זה"
+
+#: id:13424
+msgid "Use pixel buffer objects"
+msgstr ""
+
+#: id:13425
+msgid "Allow hardware acceleration (VDPAU)"
+msgstr "אפשר תאוצת חומרה (VDPAU)"
+
+#: id:13426
+msgid "Allow hardware acceleration (VAAPI)"
+msgstr "אפשר תאוצת חומרה (VAAPI)"
+
+#: id:13427
+msgid "Allow hardware acceleration (DXVA2)"
+msgstr "אפשר תאוצת חומרה (DXVA2)"
+
+#: id:13428
+msgid "Allow hardware acceleration (CrystalHD)"
+msgstr "אפשר תאוצת חומרה (CrystalHD)"
+
+#: id:13429
+msgid "Allow hardware acceleration (VDADecoder)"
+msgstr "אפשר תאוצת חומרה (VDADecoder)"
+
+#: id:13430
+msgid "Allow hardware acceleration (OpenMax)"
+msgstr "אפשרת תאוצת חומרה (OpenMax)"
+
+#: id:13431
+msgid "Pixel Shaders"
+msgstr ""
+
+#: id:13432
+msgid "Allow hardware acceleration (VideoToolbox)"
+msgstr "אפשר תאוצת חומרה (VideoToolbox)"
+
+#: id:13500
+msgid "A/V sync method"
+msgstr "שיטת סינכרון ניגון למסך"
+
+#: id:13501
+msgid "Audio clock"
+msgstr "שעון שמע"
+
+#: id:13502
+msgid "Video clock (Drop/Dupe audio)"
+msgstr "שעון וידאו (Drop/Dupe audio)"
+
+#: id:13503
+msgid "Video clock (Resample audio)"
+msgstr "שעון וידאו"
+
+#: id:13504
+msgid "Maximum resample amount (%)"
+msgstr "כמות דגימה מקסימלית (%)"
+
+#: id:13505
+msgid "Resample quality"
+msgstr "דגום איכות שוב"
+
+#: id:13506
+msgid "Low(fast)"
+msgstr "נמוך (מהיר)"
+
+#: id:13507
+msgctxt "Auto context with id 13507"
+msgid "Medium"
+msgstr "בינוני"
+
+#: id:13508
+msgctxt "Auto context with id 13508"
+msgid "High"
+msgstr "גבוה"
+
+#: id:13509
+msgid "Really high(slow!)"
+msgstr "ממש גבוה (איטי!)"
+
+#: id:13510
+msgid "Sync playback to display"
+msgstr "סנכרן ניגון למסך"
+
+#: id:13550
+msgid "Pause during refresh rate change"
+msgstr "עצור בזמן שינוי קצב רענון"
+
+#: id:13551
+msgctxt "Auto context with id 13551"
+msgid "Off"
+msgstr "כבוי"
+
+#: id:13552
+msgid "%.1f Second"
+msgstr "%.1f שניה"
+
+#: id:13553
+msgid "%.1f Seconds"
+msgstr "%.1f שניות"
+
+#: id:13600
+msgid "Apple remote"
+msgstr "APPLE שלט"
+
+#: id:13602
+msgid "Allow start of XBMC using the remote"
+msgstr "אפשר הפעלת XBMC בעזרת השלט"
+
+#: id:13603
+msgid "Sequence delay time"
+msgstr "זמן השהייה ברצף"
+
+#: id:13610
+msgctxt "Auto context with id 13610"
+msgid "Disabled"
+msgstr "מנוטרל"
+
+#: id:13611
+msgctxt "Auto context with id 13611"
+msgid "Standard"
+msgstr "סטנדרטי"
+
+#: id:13612
+msgid "Universal Remote"
+msgstr "שלט אוניברסלי"
+
+#: id:13613
+msgid "Multi Remote (Harmony)"
+msgstr "רב שלט (הרמוני)"
+
+#: id:13620
+msgid "Apple Remote Error"
+msgstr "שגיאת שלט Apple"
+
+#: id:13621
+msgid "Apple Remote support could be enabled."
+msgstr "יש אפשרות להפעיל תמיכה בשלט Apple"
+
+#: id:14000
+msgid "Stack"
+msgstr "לערום"
+
+#: id:14001
+msgid "Unstack"
+msgstr "לפזר"
+
+#: id:14003
+msgid "Downloading playlist file..."
+msgstr "מוריד קובץ רשימת השמעה..."
+
+#: id:14004
+msgid "Downloading streams list..."
+msgstr "מוריד רשימת זרימה..."
+
+#: id:14005
+msgid "Parsing streams list..."
+msgstr "מפענח רשימת זרימה..."
+
+#: id:14006
+msgid "Downloading streams list failed"
+msgstr "הורדת רשימת זרימה נכשלה"
+
+#: id:14007
+msgid "Downloading playlist file failed"
+msgstr "הורדת קובץ רשימת שמע נכשלה"
+
+#: id:14009
+msgid "Games directory"
+msgstr "ספריית משחקים"
+
+#: id:14010
+msgid "Auto switch to thumbs based on"
+msgstr "העבר אוטומטי לתמונות ממוזערות שמבוססות על"
+
+#: id:14011
+msgid "Enable auto switching to thumbs view"
+msgstr "הפעל העברה אוטומטית לתצוגת תמונות ממוזערות"
+
+#: id:14012
+msgid "- Use large icons"
+msgstr "- השתמש בצלמיות גדולות"
+
+#: id:14013
+msgid "- Switch based on"
+msgstr "- החלפה מבוססת על"
+
+#: id:14014
+msgid "- Percentage"
+msgstr "- אחוזים"
+
+#: id:14015
+msgid "No files and at least one thumb"
+msgstr "אין קבצים ולפחות תמונה ממוזערת אחת"
+
+#: id:14016
+msgid "At least one file and thumb"
+msgstr "לפחות קובץ אחד ותמונה ממוזערת"
+
+#: id:14017
+msgid "Percentage of thumbs"
+msgstr "אחוזי התמונות הממוזערות"
+
+#: id:14018
+msgid "View options"
+msgstr "צפה באפשריות"
+
+#: id:14019
+msgid "Change area code 1"
+msgstr "שנה קוד אזור 1"
+
+#: id:14020
+msgid "Change area code 2"
+msgstr "שנה קוד אזור 2"
+
+#: id:14021
+msgid "Change area code 3"
+msgstr "שנה קוד אזור 3"
+
+#: id:14022
+msgctxt "Auto context with id 14022"
+msgid "Library"
+msgstr "ספריה"
+
+#: id:14023
+msgid "No TV"
+msgstr "אין טלויזיה"
+
+#: id:14024
+msgid "Enter the nearest large town"
+msgstr "הזן את העיר הגדולה הקרובה"
+
+#: id:14025
+msgid "Video/Audio/DVD cache - Harddisk"
+msgstr "מטמון וידאו/אודיו/DVD - דיסק קשיח"
+
+#: id:14026
+msgid "Video cache - DVD-ROM"
+msgstr "מטמון וידאו - DVD-ROM"
+
+#: id:14027
+msgctxt "Auto context with id 14027"
+msgid "- Local Network"
+msgstr "- רשת מקומית"
+
+#: id:14028
+msgctxt "Auto context with id 14028"
+msgid "- Internet"
+msgstr "- אינטרנט"
+
+#: id:14030
+msgid "Audio cache - DVD-ROM"
+msgstr "מטמון אודיו - DVD-ROM"
+
+#: id:14031
+msgctxt "Auto context with id 14031"
+msgid "- Local Network"
+msgstr "- רשמת מקומית"
+
+#: id:14032
+msgctxt "Auto context with id 14032"
+msgid "- Internet"
+msgstr "- אינטרנט"
+
+#: id:14034
+msgid "DVD cache - DVD-ROM"
+msgstr "מטמון DVD - DVD-ROM"
+
+#: id:14035
+msgctxt "Auto context with id 14035"
+msgid "- Local Network"
+msgstr "- רשת מקומית"
+
+#: id:14036
+msgctxt "Auto context with id 14036"
+msgid "Services"
+msgstr "שרותים"
+
+#: id:14038
+msgid "Network settings changed"
+msgstr "הגדרות רשת שונו"
+
+#: id:14039
+msgid "XBMC requires to restart to change your"
+msgstr "XBMC דורש הפעלה מחדש כדי לשנות את"
+
+#: id:14040
+msgid "network setup. Would you like to restart now?"
+msgstr "הגדרות הרשת. האם ברצונך להפעיל מחדש כעת?"
+
+#: id:14041
+msgid "Internet connection bandwidth limitation"
+msgstr "הגבלת חיבור אינטרנט"
+
+#: id:14043
+msgid "- Shutdown while playing"
+msgstr "- כבה תוך כדי ניגון"
+
+#: id:14044
+msgid "%i min"
+msgstr "%i דקות"
+
+#: id:14045
+msgid "%i sec"
+msgstr "%i שניות"
+
+#: id:14046
+msgid "%i ms"
+msgstr "%i מ.ש"
+
+#: id:14047
+msgid "%i %%"
+msgstr "%i %%"
+
+#: id:14048
+msgid "%i kbps"
+msgstr "%i kbps"
+
+#: id:14049
+msgid "%i kb"
+msgstr "%i kb"
+
+#: id:14050
+msgid "%i.0 dB"
+msgstr "%i.0 dB"
+
+#: id:14051
+msgid "Time format"
+msgstr "מבנה שעה"
+
+#: id:14052
+msgid "Date format"
+msgstr "מבנה תאריך"
+
+#: id:14053
+msgid "GUI filters"
+msgstr "GUI פילטרים ב"
+
+#: id:14055
+msgid "Use background scanning"
+msgstr "השתמש בסריקה ברקע"
+
+#: id:14056
+msgid "Stop scan"
+msgstr "הפסק סריקה"
+
+#: id:14057
+msgid "Not possible while scanning for media info"
+msgstr "לא אפשרי בזמן סריקת פרטי מדיה"
+
+#: id:14058
+msgid "Film grain effect"
+msgstr "אפקט גרעיניות סרטים"
+
+#: id:14059
+msgid "Search for thumbnails on remote shares"
+msgstr "חפש תמונות ממוזערות בשיתוף מרוחק"
+
+#: id:14060
+msgid "Unknown type cache - Internet"
+msgstr "סוג מטמון לא מוכר - אינטרנט"
+
+#: id:14061
+msgctxt "Auto context with id 14061"
+msgid "Auto"
+msgstr "אוטומטי"
+
+#: id:14062
+msgid "Enter username for"
+msgstr "הזן שם משתמש עבור"
+
+#: id:14063
+msgid "Date & time"
+msgstr "תאריך & שעה"
+
+#: id:14064
+msgid "Set date"
+msgstr "קבע תאריך"
+
+#: id:14065
+msgid "Set time"
+msgstr "קבע שעה"
+
+#: id:14066
+msgid "Enter the time in 24 hour HH:MM format"
+msgstr "הזן זמן 24 שעות במבנה HH:MM"
+
+#: id:14067
+msgid "Enter the date in DD/MM/YYYY format"
+msgstr "הזן תאריך במבנה DD/MM/YYYY"
+
+#: id:14068
+msgid "Enter the IP address"
+msgstr "IP הזן כתובת"
+
+#: id:14069
+msgid "Apply these settings now?"
+msgstr "החל הגדרות אלה כעת?"
+
+#: id:14070
+msgid "Apply changes now"
+msgstr "החל שינויים כעת"
+
+#: id:14071
+msgid "Allow file renaming and deletion"
+msgstr "אפשר שינויי שמות ומחיקת קבצים"
+
+#: id:14074
+msgid "Set timezone"
+msgstr "הגדר איזור זמן"
+
+#: id:14075
+msgid "Use daylight saving time"
+msgstr "השתמש בשעון קיץ"
+
+#: id:14076
+msgid "Add to favourites"
+msgstr "הוסף למועדפים"
+
+#: id:14077
+msgid "Remove from favourites"
+msgstr "הסר ממועדפים"
+
+#: id:14078
+msgctxt "Auto context with id 14078"
+msgid "- Colours"
+msgstr "- צבעים"
+
+#: id:14079
+msgid "Timezone country"
+msgstr "מדינת איזור זמן"
+
+#: id:14080
+msgid "Timezone"
+msgstr "איזור זמן"
+
+#: id:14081
+msgid "File lists"
+msgstr "רשימות קבצים"
+
+#: id:14082
+msgid "Show EXIF picture information"
+msgstr "הצג פרטי EXIF מתמונה"
+
+#: id:14083
+msgid "Use a fullscreen window rather than true fullscreen"
+msgstr "השתמש בחלון מסך מלא במקום מסך מלא אמיתי"
+
+#: id:14084
+msgid "Queue songs on selection"
+msgstr "הכנס שירים לתור בבחירה"
+
+#: id:14086
+msgid "Playback"
+msgstr "ניגון"
+
+#: id:14087
+msgid "DVDs"
+msgstr ""
+
+#: id:14088
+msgid "Play DVDs automatically"
+msgstr "נגן DVD אוטומטית"
+
+#: id:14089
+msgid "Font to use for text subtitles"
+msgstr "פונט לשימוש עבור כתוביות טקסט"
+
+#: id:14090
+msgid "International"
+msgstr "בינלאומי"
+
+#: id:14091
+msgid "Character set"
+msgstr "ערכת תווים"
+
+#: id:14092
+msgid "Debugging"
+msgstr "ניפוי שגיאות"
+
+#: id:14093
+msgid "Security"
+msgstr "אבטחה"
+
+#: id:14094
+msgid "Input devices"
+msgstr "התקני קלט"
+
+#: id:14095
+msgid "Power saving"
+msgstr "חסכון באנרגיה"
+
+#: id:14096
+msgid "Rip"
+msgstr ""
+
+#: id:14097
+msgid "Audio CD Insert Action"
+msgstr ""
+
+#: id:14098
+msgctxt "Auto context with id 14098"
+msgid "Play"
+msgstr ""
+
+#: id:14099
+msgid "Eject disc when CD ripping is complete"
+msgstr "הוצא דיסק כאשר ההעתקה הושלמה"
+
+#: id:15015
+msgctxt "Auto context with id 15015"
+msgid "Remove"
+msgstr "הסר"
+
+#: id:15016
+msgid "Games"
+msgstr "משחקים"
+
+#: id:15019
+msgid "Add"
+msgstr "הוסף"
+
+#: id:15052
+msgid "Password"
+msgstr "סיסמא"
+
+#: id:15100
+msgctxt "Auto context with id 15100"
+msgid "Library"
+msgstr "ספריה"
+
+#: id:15101
+msgid "Database"
+msgstr "מסד נתונים"
+
+#: id:15102
+msgid "* All albums"
+msgstr "* כל האלבומים"
+
+#: id:15103
+msgid "* All artists"
+msgstr "* כל האמנים"
+
+#: id:15104
+msgid "* All songs"
+msgstr "* כל השירים"
+
+#: id:15105
+msgid "* All genres"
+msgstr "* כל הסגנונות"
+
+#: id:15107
+msgid "Buffering..."
+msgstr "אוגר..."
+
+#: id:15108
+msgid "Navigation sounds"
+msgstr "צלילי ניווט"
+
+#: id:15109
+msgid "Skin default"
+msgstr "ברירת מחדל של הסקין"
+
+#: id:15111
+msgid "- Theme"
+msgstr "- ערכת נושא"
+
+#: id:15112
+msgid "Default theme"
+msgstr "ערכת נושא ברירת מחדל"
+
+#: id:15200
+msgid "Last.fm"
+msgstr "LastFM"
+
+#: id:15201
+msgid "Submit songs to Last.fm"
+msgstr "שלח שירים לשירות LastFM"
+
+#: id:15202
+msgid "Last.fm username"
+msgstr "LastFM משתמש"
+
+#: id:15203
+msgid "Last.fm password"
+msgstr "LastFM סיסמא"
+
+#: id:15204
+msgid "Unable to handshake: sleeping..."
+msgstr "לחיצת ידיים נכשלה: שינה..."
+
+#: id:15205
+msgid "Please update XBMC"
+msgstr "XBMC אנא עדכן"
+
+#: id:15206
+msgid "Bad authorization: Check username and password"
+msgstr "הרשאה שגויה: בדוק שם ומשתמש וסיסמא"
+
+#: id:15207
+msgctxt "Auto context with id 15207"
+msgid "Connected"
+msgstr "מחובר"
+
+#: id:15208
+msgid "Not connected"
+msgstr "לא מחובר"
+
+#: id:15209
+msgid "Submit interval %i"
+msgstr "השהיית שליחה %i"
+
+#: id:15210
+msgid "Cached %i songs"
+msgstr "אגר %i שירים"
+
+#: id:15211
+msgid "Submitting..."
+msgstr "שולח..."
+
+#: id:15212
+msgid "Submitting in %i secs"
+msgstr "שולח בעוד %i שניות"
+
+#: id:15213
+msgid "Play using..."
+msgstr "נגן באמצעות..."
+
+#: id:15214
+msgid "Use smoothed A/V synchronization"
+msgstr "השתמש בסנכרון A/V חלק"
+
+#: id:15215
+msgid "Hide file names in thumbs view"
+msgstr "הסתר שמות קבצים בתצוגת תמונות ממוזערות"
+
+#: id:15216
+msgid "Play in party mode"
+msgstr "נגן במצב מסיבה"
+
+#: id:15217
+msgid "Submit songs to Libre.fm"
+msgstr "שלח שירים לשירות Libre.fm"
+
+#: id:15218
+msgid "Libre.fm username"
+msgstr "Libre.fm משתמש"
+
+#: id:15219
+msgid "Libre.fm password"
+msgstr "Libre.fm סיסמא"
+
+#: id:15220
+msgid "Libre.fm"
+msgstr "Libre.fm"
+
+#: id:15221
+msgid "Song submission"
+msgstr "הגשת שיר"
+
+#: id:15250
+msgid "Submit Last.fm radio to Last.fm"
+msgstr "שלח Last.fm אל Last.fm"
+
+#: id:15251
+msgid "Connecting to Last.fm..."
+msgstr "מתחבר אל Last.fm..."
+
+#: id:15252
+msgid "Selecting station..."
+msgstr "בחירת תחנה..."
+
+#: id:15253
+msgid "Search similar artists..."
+msgstr "חפש אמנים דומים..."
+
+#: id:15254
+msgid "Search similar tags..."
+msgstr "חפש תגיות דומות..."
+
+#: id:15255
+msgid "Your profile (%name%)"
+msgstr "הפרופיל שלך (%name%)"
+
+#: id:15256
+msgid "Overall top tags"
+msgstr "תגיות במקומות הראשונים"
+
+#: id:15257
+msgid "Top artists for tag %name%"
+msgstr "%name% אמנים מובילים עבור תגית %name%"
+
+#: id:15258
+msgid "Top albums for tag %name%"
+msgstr "אלבומים מובילים עבור תגית %name%"
+
+#: id:15259
+msgid "Top tracks for tag %name%"
+msgstr "רצועות מובילות עבור תגית %name%"
+
+#: id:15260
+msgid "Listen to tag %name% Last.fm radio"
+msgstr "האזן לתגית %name% Last.fm"
+
+#: id:15261
+msgid "Similar artists as %name%"
+msgstr "אמנים דומים ל%name%"
+
+#: id:15262
+msgid "Top %name% albums"
+msgstr "%name% האלבומים המובילים"
+
+#: id:15263
+msgid "Top %name% tracks"
+msgstr "%name% הרצועות המובילות"
+
+#: id:15264
+msgid "Top %name% tags"
+msgstr "%name% התגיות המובילות"
+
+#: id:15265
+msgid "Biggest fans of %name%"
+msgstr "המעריצים הגדולים של %name%"
+
+#: id:15266
+msgid "Listen to %name% fans Last.fm radio"
+msgstr "האזן למעריצי %name% רדיו Last.fm"
+
+#: id:15267
+msgid "Listen to %name% similar artists Last.fm radio"
+msgstr "האזן לאמנים דומים last.fm %name%"
+
+#: id:15268
+msgid "Top artists for user %name%"
+msgstr "האמנים הנבחרים של משתמש %name%"
+
+#: id:15269
+msgid "Top albums for user %name%"
+msgstr "האלבומים הנבחרים של משתמש %name%"
+
+#: id:15270
+msgid "Top tracks for user %name%"
+msgstr "הרצועות הנבחרות של משתמש %name%"
+
+#: id:15271
+msgid "Friends of user %name%"
+msgstr "חברים של משתמש %name%"
+
+#: id:15272
+msgid "Neighbours of user %name%"
+msgstr "שכנים של משתמש %name%"
+
+#: id:15273
+msgid "Weekly artist chart for %name%"
+msgstr "המצעד השבועי של אמן %name%"
+
+#: id:15274
+msgid "Weekly album chart for %name%"
+msgstr "המצעד השבועי של אלבום %name%"
+
+#: id:15275
+msgid "Weekly track chart for %name%"
+msgstr "המצעד השבועי של רצועת %name%"
+
+#: id:15276
+msgid "Listen to %name%'s neighbours Last.fm radio"
+msgstr "האזן לשכנים של %name% רדיו Last.fm"
+
+#: id:15277
+msgid "Listen to %name%'s personal Last.fm radio"
+msgstr "האזן להעדפות האישיות של %name% רדיו Last.fm"
+
+#: id:15278
+msgid "Listen to %name%'s mix Last.fm radio"
+msgstr "האזן לרצועות האהובות של %name% רדיו Last.fm"
+
+#: id:15279
+msgid "Retrieving list from Last.fm..."
+msgstr "שולף רשימה מ last.fm..."
+
+#: id:15280
+msgid "Can't retrieve list from Last.fm..."
+msgstr "בעיה בקבלת רשימה מ last.fm..."
+
+#: id:15281
+msgid "Enter an artist name to find related ones"
+msgstr "הזן שם אמן למציאת אמנים דומים"
+
+#: id:15282
+msgid "Enter a tag name to find similar ones"
+msgstr "הזן תגית למציאת שירים דומים"
+
+#: id:15283
+msgid "Tracks recently listened by %name%"
+msgstr "רצועות שנשמעו לאחרונה ע\"י %name%"
+
+#: id:15284
+msgid "Listen to %name%'s recommendations Last.fm radio"
+msgstr "האזן להמלצות %name%'s רדיו Last.FM"
+
+#: id:15285
+msgid "Top tags for user %name%"
+msgstr "התגיות המובילות למשתמש %name%"
+
+#: id:15287
+msgid "Do you want to add the current track to your loved tracks?"
+msgstr "האם ברצונך להוסיף את השיר הנוכחי לרשימת האהובים?"
+
+#: id:15288
+msgid "Do you want to ban the current track?"
+msgstr "האם אתה רוצה להחרים את השיר הנוכחי?"
+
+#: id:15289
+msgid "Added to your loved tracks: '%s'."
+msgstr "הוסף לרשימת השירים האהובים: '%s'."
+
+#: id:15290
+msgid "Could not add '%s' to your loved tracks."
+msgstr "לא יכול להוסיף את '%s' לרשימת שירים אהובים"
+
+#: id:15291
+msgid "Banned: '%s'."
+msgstr "החרם '%s'."
+
+#: id:15292
+msgid "Could not ban '%s'."
+msgstr "לא יכול להחרים '%s'."
+
+#: id:15293
+msgid "Tracks recently loved by %name%"
+msgstr "שירים אהובים שנוספו לאחרונה לפי %name%"
+
+#: id:15294
+msgid "Tracks recently banned by %name%"
+msgstr "שירים שהוחרמו לאחרונה לפי %name%"
+
+#: id:15295
+msgid "Remove from loved tracks"
+msgstr "הסר מרשימת שירים אהובים"
+
+#: id:15296
+msgid "Un-ban"
+msgstr "בטל החרמה"
+
+#: id:15297
+msgid "Do you want to remove this track from your loved tracks?"
+msgstr "האם אתה רוצה להסיר את השיר מרשימת שירים אהובים?"
+
+#: id:15298
+msgid "Do you want to un-ban this track?"
+msgstr "האם אתה רוצה לבטל החרמת שיר?"
+
+#: id:15300
+msgid "Path not found or invalid"
+msgstr "נתיב לא נמצא או לא חוקי"
+
+#: id:15301
+msgid "Could not connect to network server"
+msgstr "חיבור לשרת נכשל"
+
+#: id:15302
+msgid "No servers found"
+msgstr "שרתים לא נמצאו"
+
+#: id:15303
+msgid "Workgroup not found"
+msgstr "קבוצת עבודה לא נמצאה"
+
+#: id:15310
+msgid "Opening multi-path source"
+msgstr "פותח מקור עם מספר נתיבים"
+
+#: id:15311
+msgid "Path:"
+msgstr "נתיב:"
+
+#: id:16000
+msgctxt "Auto context with id 16000"
+msgid "General"
+msgstr "כללי"
+
+#: id:16002
+msgid "Internet lookup"
+msgstr "חיפוש באינטרנט"
+
+#: id:16003
+msgid "Player"
+msgstr "נגן"
+
+#: id:16004
+msgid "Play media from disc"
+msgstr "נגן מדיה מדיסק"
+
+#: id:16008
+msgid "Enter new title"
+msgstr "הזן כותרת חדשה"
+
+#: id:16009
+msgid "Enter the movie name"
+msgstr "הזן שם סרט"
+
+#: id:16010
+msgid "Enter the profile name"
+msgstr "הזן שם פרופיל"
+
+#: id:16011
+msgid "Enter the album name"
+msgstr "הזן שם אלבום"
+
+#: id:16012
+msgid "Enter the playlist name"
+msgstr "הזן שם רשימת ניגון"
+
+#: id:16013
+msgid "Enter new filename"
+msgstr "הזן שם קובץ חדש"
+
+#: id:16014
+msgid "Enter folder name"
+msgstr "הזן שם ספריה חדשה"
+
+#: id:16015
+msgid "Enter directory"
+msgstr "הזן ספריה"
+
+#: id:16016
+msgid "Available options: %A, %T, %N, %B, %D, %G, %Y, %F, %S"
+msgstr "אפשרויות זמינות: %A, %T, %N, %B, %D, %G, %Y, %F, %S"
+
+#: id:16017
+msgid "Enter search string"
+msgstr "הזן מחרוזת חיפוש"
+
+#: id:16018
+msgctxt "Auto context with id 16018"
+msgid "None"
+msgstr "ללא"
+
+#: id:16019
+msgid "Auto select"
+msgstr "חיפוש אוטומטי"
+
+#: id:16020
+msgid "De-interlace"
+msgstr ""
+
+#: id:16021
+msgid "Bob"
+msgstr ""
+
+#: id:16022
+msgid "Bob (inverted)"
+msgstr ""
+
+#: id:16024
+msgid "Canceling..."
+msgstr "מבטל..."
+
+#: id:16025
+msgid "Enter the artist name"
+msgstr "הזן שם האמן"
+
+#: id:16026
+msgid "Playback failed"
+msgstr "ניגון רשימת השמעה בוטל"
+
+#: id:16027
+msgid "One or more items failed to play."
+msgstr "יותר מידי פריטים שנכשלו"
+
+#: id:16028
+msgid "Enter value"
+msgstr "הזן ערך"
+
+#: id:16029
+msgid "Check the log file for details."
+msgstr "בדוק לוג לפרטים"
+
+#: id:16030
+msgid "Party mode aborted."
+msgstr "מצב מסיבה בוטל."
+
+#: id:16031
+msgid "No matching songs in the library."
+msgstr "לא נמצאו שירים מתאימים במסד הנתונים."
+
+#: id:16032
+msgid "Could not initialize database."
+msgstr "אתחול מסד הנתונים נכשל."
+
+#: id:16033
+msgid "Could not open database."
+msgstr "פתיחת מסד נתונים נכשלה."
+
+#: id:16034
+msgid "Could not get songs from database."
+msgstr "בעיה בשליפת השירים ממסד הנתונים."
+
+#: id:16035
+msgid "Party mode playlist"
+msgstr "רשימת השמעה מצב מסיבה"
+
+#: id:16036
+msgid "De-interlace (Half)"
+msgstr ""
+
+#: id:16037
+msgid "Deinterlace video"
+msgstr ""
+
+#: id:16038
+msgid "Deinterlace method"
+msgstr ""
+
+#: id:16039
+msgctxt "Auto context with id 16039"
+msgid "Off"
+msgstr "כבוי"
+
+#: id:16040
+msgctxt "Auto context with id 16040"
+msgid "Auto"
+msgstr "אוטומטי"
+
+#: id:16041
+msgid "On"
+msgstr "פעיל"
+
+#: id:16100
+msgid "All Videos"
+msgstr "כל הוידאו"
+
+#: id:16101
+msgid "Unwatched"
+msgstr "לא נצפו"
+
+#: id:16102
+msgid "Watched"
+msgstr "נצפו"
+
+#: id:16103
+msgid "Mark as watched"
+msgstr "סמן כנצפה"
+
+#: id:16104
+msgid "Mark as unwatched"
+msgstr "סמן כלא כנצפה"
+
+#: id:16105
+msgid "Edit title"
+msgstr "ערוך כותרת"
+
+#: id:16200
+msgid "Operation was aborted"
+msgstr "פעולה בוטלה"
+
+#: id:16201
+msgid "Copy failed"
+msgstr "העתקה נכשלה"
+
+#: id:16202
+msgid "Failed to copy at least one file"
+msgstr "נכשל בהעתקת קובץ אחד לפחות"
+
+#: id:16203
+msgid "Move failed"
+msgstr "העברה נכשלה"
+
+#: id:16204
+msgid "Failed to move at least one file"
+msgstr "נכשל בהעברת קובץ אחד לפחות"
+
+#: id:16205
+msgid "Delete failed"
+msgstr "מחיקה נכשלה"
+
+#: id:16206
+msgid "Failed to delete at least one file"
+msgstr "נכשל במחיקת קובץ אחד לפחות"
+
+#: id:16300
+msgid "Video scaling method"
+msgstr ""
+
+#: id:16301
+msgid "Nearest neighbour"
+msgstr "השכן הקרוב"
+
+#: id:16302
+msgid "Bilinear"
+msgstr ""
+
+#: id:16303
+msgctxt "Auto context with id 16303"
+msgid "Bicubic"
+msgstr ""
+
+#: id:16304
+msgid "Lanczos2"
+msgstr ""
+
+#: id:16305
+msgid "Lanczos3"
+msgstr ""
+
+#: id:16306
+msgid "Sinc8"
+msgstr ""
+
+#: id:16307
+msgid "Bicubic (software)"
+msgstr ""
+
+#: id:16308
+msgid "Lanczos (software)"
+msgstr ""
+
+#: id:16309
+msgid "Sinc (software)"
+msgstr ""
+
+#: id:16310
+msgid "Temporal"
+msgstr ""
+
+#: id:16311
+msgid "Temporal/Spatial"
+msgstr ""
+
+#: id:16312
+msgid "(VDPAU)Noise Reduction"
+msgstr ""
+
+#: id:16313
+msgid "(VDPAU)Sharpness"
+msgstr ""
+
+#: id:16314
+msgid "Inverse Telecine"
+msgstr ""
+
+#: id:16315
+msgid "Lanczos3 optimized"
+msgstr ""
+
+#: id:16316
+msgctxt "Auto context with id 16316"
+msgid "Auto"
+msgstr "אוטומטי"
+
+#: id:16317
+msgid "Temporal (Half)"
+msgstr ""
+
+#: id:16318
+msgid "Temporal/Spatial (Half)"
+msgstr ""
+
+#: id:16319
+msgid "DXVA"
+msgstr "DXVA"
+
+#: id:16320
+msgid "DXVA Bob"
+msgstr ""
+
+#: id:16321
+msgid "DXVA Best"
+msgstr ""
+
+#: id:16322
+msgid "Spline36"
+msgstr ""
+
+#: id:16323
+msgid "Spline36 optimized"
+msgstr ""
+
+#: id:16324
+msgid "Software Blend"
+msgstr ""
+
+#: id:16400
+msgid "Post-processing"
+msgstr ""
+
+#: id:17500
+msgid "Display sleep timeout"
+msgstr "מסך פרק זמן שינה"
+
+#: id:19000
+msgid "Switch to channel"
+msgstr "החלף לערוץ"
+
+#: id:20000
+msgid "Saved music folder"
+msgstr "תיקיית שמירת מוזיקה"
+
+#: id:20001
+msgid "Use external DVD player"
+msgstr "השתמש בנגן DVD חיצוני"
+
+#: id:20002
+msgid "External DVD player"
+msgstr "נגן DVD חיצוני"
+
+#: id:20003
+msgid "Trainers folder"
+msgstr "תיקיית מאמנים"
+
+#: id:20004
+msgid "Screenshot folder"
+msgstr "תיקיית תמונות מסך"
+
+#: id:20006
+msgid "Playlists folder"
+msgstr "תיקיית רשימות ניגון"
+
+#: id:20007
+msgid "Recordings"
+msgstr "הקלטות"
+
+#: id:20008
+msgid "Screenshots"
+msgstr "תמונות מסך"
+
+#: id:20009
+msgid "Use XBMC"
+msgstr "השתמש ב XBMC"
+
+#: id:20011
+msgid "Music playlists"
+msgstr "רשימות השמעה למוזיקה"
+
+#: id:20012
+msgid "Video playlists"
+msgstr "רשימות השמעה לוידאו"
+
+#: id:20013
+msgid "Do you wish to launch the game?"
+msgstr "האם ברצונך להריץ את המשחק?"
+
+#: id:20014
+msgid "Sort by: Playlist"
+msgstr "מיין לפי: רשימת השמעה"
+
+#: id:20015
+msgid "Remote thumb"
+msgstr "תמונה ממוזערת בשרת מרוחק"
+
+#: id:20016
+msgid "Current thumb"
+msgstr "תמונה ממוזערת נוכחית"
+
+#: id:20017
+msgid "Local thumb"
+msgstr "תמונה ממוזערת מקומית"
+
+#: id:20018
+msgid "No thumb"
+msgstr "ללא תמונה ממוזערת"
+
+#: id:20019
+msgid "Choose thumbnail"
+msgstr "בחר תמונה ממוזערת"
+
+#: id:20023
+msgid "Conflict"
+msgstr "קונפליקט"
+
+#: id:20024
+msgid "Scan new"
+msgstr "סרוק חדש"
+
+#: id:20025
+msgid "Scan all"
+msgstr "סרוק הכול"
+
+#: id:20026
+msgid "Region"
+msgstr "אזור"
+
+#: id:20037
+msgid "Summary"
+msgstr "סיכום"
+
+#: id:20038
+msgid "Lock music window"
+msgstr "נעל חלון מוסיקה"
+
+#: id:20039
+msgid "Lock videos window"
+msgstr "נעל חלון וידאו"
+
+#: id:20040
+msgid "Lock pictures window"
+msgstr "נעל חלון תמונות"
+
+#: id:20041
+msgid "Lock programs & scripts windows"
+msgstr "נעל חלונות תוכנות וסקריפטים"
+
+#: id:20042
+msgid "Lock file manager"
+msgstr "נעל מנהל קבצים"
+
+#: id:20043
+msgid "Lock settings"
+msgstr "נעל הגדרות"
+
+#: id:20044
+msgid "Start fresh"
+msgstr "התחל מחדש"
+
+#: id:20045
+msgid "Enter master mode"
+msgstr "היכנס למצב ראשי"
+
+#: id:20046
+msgid "Leave master mode"
+msgstr "צא ממצב ראשי"
+
+#: id:20047
+msgid "Create profile '%s'?"
+msgstr "צור פרופיל '%s' ?"
+
+#: id:20048
+msgid "Start with fresh settings"
+msgstr "התחל עם הגדרות חדשות"
+
+#: id:20049
+msgid "Best available"
+msgstr "הזמין הטוב ביותר"
+
+#: id:20050
+msgid "Auto-switch between 16x9 and 4x3"
+msgstr "החלף אוטומטית בין 16x9 ו 4x3"
+
+#: id:20051
+msgid "Treat stacked files as single file"
+msgstr "התייחס לערימת קבצים כקובץ אחד"
+
+#: id:20052
+msgid "Caution"
+msgstr "זהירות"
+
+#: id:20053
+msgid "Left master mode"
+msgstr "עזב מצב ראשי"
+
+#: id:20054
+msgid "Entered master mode"
+msgstr "נכנס למצב ראשי"
+
+#: id:20055
+msgid "Allmusic.com thumb"
+msgstr "תמונה ממוזערת Allmusic.com"
+
+#: id:20057
+msgid "Remove thumbnail"
+msgstr "הסר תמונה ממוזערת"
+
+#: id:20058
+msgid "Add profile..."
+msgstr "הוסף פרופיל..."
+
+#: id:20059
+msgid "Query info for all albums"
+msgstr "בקש אחזור פרטים עבור כל האלבומים"
+
+#: id:20060
+msgctxt "Auto context with id 20060"
+msgid "Media info"
+msgstr "פרטי מדיה"
+
+#: id:20061
+msgctxt "Auto context with id 20061"
+msgid "Separate"
+msgstr "הפרד"
+
+#: id:20062
+msgid "Shares with default"
+msgstr "משתף עם ברירת מחדל"
+
+#: id:20063
+msgid "Shares with default (read only)"
+msgstr "משתף עם ברירת מחדל (קריאה בלבד)"
+
+#: id:20064
+msgid "Copy default"
+msgstr "העתק ברירת מחדל"
+
+#: id:20065
+msgid "Profile picture"
+msgstr "תמונת פרופיל"
+
+#: id:20066
+msgid "Lock preferences"
+msgstr "נעל העדפות"
+
+#: id:20067
+msgid "Edit profile"
+msgstr "ערוך פרופיל"
+
+#: id:20068
+msgid "Profile lock"
+msgstr "נעילת פרופיל"
+
+#: id:20069
+msgid "Could not create folder"
+msgstr "לא ניתן ליצור תיקיה"
+
+#: id:20070
+msgid "Profile directory"
+msgstr "ספריית פרופיל"
+
+#: id:20071
+msgid "Start with fresh media sources"
+msgstr "התחל עם מקורות מדיה חדשים"
+
+#: id:20072
+msgid "Make sure the selected folder is writable"
+msgstr "ודא כי התיקיה הנבחרת ניתנת לכתיבה"
+
+#: id:20073
+msgid "and that the new folder name is valid"
+msgstr "וכי שם התיקיה החדשה תקף"
+
+#: id:20074
+msgid "MPAA rating"
+msgstr "דירוג MPAA:"
+
+#: id:20075
+msgid "Enter master lock code"
+msgstr "הזן קוד נעיל ראשי"
+
+#: id:20076
+msgid "Ask for master lock code on startup"
+msgstr "בקש קוד נעילה ראשי בזמן אתחול"
+
+#: id:20077
+msgid "Skin settings"
+msgstr "הגדרות סקין"
+
+#: id:20078
+msgid "- no link set -"
+msgstr "- קישור לא נקבע -"
+
+#: id:20079
+msgid "Enable animations"
+msgstr "אפשר הנפשה"
+
+#: id:20080
+msgid "Disable RSS during music"
+msgstr "נטרל RSS בעת מוזיקה"
+
+#: id:20081
+msgid "Enable shortcut buttons"
+msgstr "אפשר כפתורי קיצורים"
+
+#: id:20082
+msgid "Show programs in main menu"
+msgstr "הצג תוכנות בתפריט ראשי"
+
+#: id:20083
+msgid "Show music info"
+msgstr "הצג פרטים אודות המוסיקה"
+
+#: id:20084
+msgid "Show weather info"
+msgstr "הצג פרטים אודות מזג האויר"
+
+#: id:20085
+msgid "Show system info"
+msgstr "הצג פרטים אודות המערכת"
+
+#: id:20086
+msgid "Show available disc space C: E: F:"
+msgstr "הצג מקום פנוי בכונן C: E: F:"
+
+#: id:20087
+msgid "Show available disc space E: F: G:"
+msgstr "הצג מקום פנוי בכונן E: F: G:"
+
+#: id:20088
+msgid "Weather info"
+msgstr "פרטי מזג האויר"
+
+#: id:20089
+msgid "Drive space free"
+msgstr "מקום פנוי בכונן"
+
+#: id:20090
+msgid "Enter the name of an existing share"
+msgstr "הזן את השם של שיתוף קיים"
+
+#: id:20091
+msgid "Lock code"
+msgstr "קוד נעילה"
+
+#: id:20092
+msgid "Load profile"
+msgstr "טען פרופיל"
+
+#: id:20093
+msgid "Profile name"
+msgstr "שם הפרופיל"
+
+#: id:20094
+msgctxt "Auto context with id 20094"
+msgid "Media sources"
+msgstr "מקורות מדיה"
+
+#: id:20095
+msgid "Enter profile lock code"
+msgstr "הזן קוד נעילת פרופיל"
+
+#: id:20096
+msgctxt "Auto context with id 20096"
+msgid "Login screen"
+msgstr "מסך התחברות"
+
+#: id:20097
+msgid "Fetching album info"
+msgstr "משיג פרטי אלבום"
+
+#: id:20098
+msgid "Fetching info for album"
+msgstr "משיג פרטים עבור האלבום"
+
+#: id:20099
+msgid "Can't rip CD or track while playing from CD"
+msgstr "לא יכול להעתיק דיסק או רצועה בזמן ניגון מהדיסק"
+
+#: id:20100
+msgid "Master lock code and settings"
+msgstr "קוד נעילה ראשי והגדרות"
+
+#: id:20101
+msgid "Entering master lock code always enables master mode"
+msgstr "הזנת קוד נעילה ראשי תמיד מאפשרת מצב ראשי"
+
+#: id:20102
+msgid "or copy from default?"
+msgstr "או העתק מברירת מחדל?"
+
+#: id:20103
+msgid "Save changes to profile?"
+msgstr "שמור שינויים לפרופיל?"
+
+#: id:20104
+msgid "Old settings found."
+msgstr "הגדרות ישנות נמצאו"
+
+#: id:20105
+msgid "Do you want to use them?"
+msgstr "האם ברצונך להשתמש בהן?"
+
+#: id:20106
+msgid "Old media sources found."
+msgstr "מקורות מדיה ישנות נמצאו."
+
+#: id:20107
+msgid "Separate (locked)"
+msgstr "הפרד (נעול)"
+
+#: id:20108
+msgid "Root"
+msgstr "ראשי"
+
+#: id:20109
+msgid "- Zoom"
+msgstr "- הגדלה"
+
+#: id:20110
+msgid "UPnP settings"
+msgstr "הגדרות UPnP"
+
+#: id:20111
+msgid "Autostart UPnP client"
+msgstr "הפעלה אוטומטית"
+
+#: id:20112
+msgid "Last login: %s"
+msgstr "התחברות אחרונה: %s"
+
+#: id:20113
+msgid "Never logged on"
+msgstr "אף פעם לא התחבר"
+
+#: id:20114
+msgid "Profile %i / %i"
+msgstr "פרופיל %i / %i"
+
+#: id:20115
+msgid "User login / Select a profile"
+msgstr "חיבור משתמש / בחר פרופיל"
+
+#: id:20116
+msgid "Use lock on login screen"
+msgstr "במסך ההתחברות השתמש בנעילה"
+
+#: id:20117
+msgid "Invalid lock code."
+msgstr "קוד נעילה שגוי"
+
+#: id:20118
+msgid "This requires the master lock to be set."
+msgstr "זה מצריך קביעה של קוד נעילה ראשי"
+
+#: id:20119
+msgid "Would you like to set it now?"
+msgstr "האם ברצונך לקבוע זאת כעת?"
+
+#: id:20120
+msgid "Loading program information"
+msgstr "טוען פרטי התוכנה"
+
+#: id:20121
+msgid "Party on!"
+msgstr "מסיבה!"
+
+#: id:20122
+msgid "True"
+msgstr "אמת"
+
+#: id:20123
+msgid "Mixing drinks"
+msgstr "מערבב משקאות"
+
+#: id:20124
+msgid "Filling glasses"
+msgstr "ממלא כוסות"
+
+#: id:20125
+msgid "Logged on as"
+msgstr "מחובר בתור"
+
+#: id:20126
+msgid "Log off"
+msgstr "ניתוק"
+
+#: id:20128
+msgid "Go to root"
+msgstr "לך לראשי"
+
+#: id:20129
+msgid "Weave"
+msgstr "ארוג"
+
+#: id:20130
+msgid "Weave (inverted)"
+msgstr "ארוג (הפוך)"
+
+#: id:20131
+msgid "Blend"
+msgstr "מזג"
+
+#: id:20132
+msgid "Restart video"
+msgstr "התחל וידאו מחדש"
+
+#: id:20133
+msgid "Edit network location"
+msgstr "ערוך מיקום רשת"
+
+#: id:20134
+msgid "Remove network location"
+msgstr "הסר מיקום רשת"
+
+#: id:20135
+msgid "Do you want to scan the folder?"
+msgstr "האם ברצונך לסרוק את התיקייה?"
+
+#: id:20136
+msgid "Memory unit"
+msgstr "יחידת זיכרון"
+
+#: id:20137
+msgid "Memory unit mounted"
+msgstr "יחידת זיכרון מחוברת"
+
+#: id:20138
+msgid "Unable to mount memory unit"
+msgstr "לא מסוגל לחבר יחידת זיכרון"
+
+#: id:20139
+msgid "In port %i, slot %i"
+msgstr "ביציאה %i, חריץ %i"
+
+#: id:20140
+msgid "Lock screensaver"
+msgstr "נעל שומר מסך"
+
+#: id:20141
+msgid "Set"
+msgstr "קבע"
+
+#: id:20142
+msgctxt "Auto context with id 20142"
+msgid "Username"
+msgstr "שם משתמש"
+
+#: id:20143
+msgid "Enter password for"
+msgstr "הזן סיסמא עבור"
+
+#: id:20144
+msgid "Shutdown timer"
+msgstr "תזמון כיבוי"
+
+#: id:20145
+msgid "Shutdown interval (in minutes)"
+msgstr "השהיית זמן כיבוי (בדקות)"
+
+#: id:20146
+msgid "Started, shutdown in %im"
+msgstr "הוחל, כיבוי ב %im"
+
+#: id:20147
+msgid "Shutdown in 30 minutes"
+msgstr "כיבוי תוך 30 דקות"
+
+#: id:20148
+msgid "Shutdown in 60 minutes"
+msgstr "כיבוי תוך 60 דקות"
+
+#: id:20149
+msgid "Shutdown in 120 minutes"
+msgstr "כיבוי תוך 120 דקות"
+
+#: id:20150
+msgid "Custom shutdown timer"
+msgstr "תזמן כיבוי מותאם אישית"
+
+#: id:20151
+msgid "Cancel shutdown timer"
+msgstr "בטל תזמון כיבוי"
+
+#: id:20152
+msgid "Lock preferences for %s"
+msgstr "נעל העדפות עבור %s"
+
+#: id:20153
+msgid "Browse..."
+msgstr "עיון..."
+
+#: id:20154
+msgid "Summary information"
+msgstr "פרטים בסיסיים"
+
+#: id:20155
+msgid "Storage information"
+msgstr "פרטים אודות מקום האיכסון"
+
+#: id:20156
+msgid "Hard disk information"
+msgstr "פרטי הכונן הקשיח"
+
+#: id:20157
+msgid "DVD-ROM information"
+msgstr "פרטי כונן ה DVD"
+
+#: id:20158
+msgid "Network information"
+msgstr "פרטי הרשת"
+
+#: id:20159
+msgid "Video information"
+msgstr "פרטי הוידאו"
+
+#: id:20160
+msgid "Hardware information"
+msgstr "פרטי החומרה"
+
+#: id:20161
+msgid "Total"
+msgstr "סך הכל"
+
+#: id:20162
+msgid "Used"
+msgstr "בשימוש"
+
+#: id:20163
+msgid "of"
+msgstr "מתוך"
+
+#: id:20164
+msgid "Locking not supported"
+msgstr "נעילה לא נתמכת"
+
+#: id:20165
+msgid "Not locked"
+msgstr "לא נעול"
+
+#: id:20166
+msgid "Locked"
+msgstr "נעול"
+
+#: id:20167
+msgid "Frozen"
+msgstr "קפוא"
+
+#: id:20168
+msgid "Requires reset"
+msgstr "מצריך אתחול"
+
+#: id:20169
+msgid "Week"
+msgstr "שבוע"
+
+#: id:20170
+msgid "Line"
+msgstr "שורה"
+
+#: id:20171
+msgid "Windows network (SMB)"
+msgstr "רשת חלונות (SMB)"
+
+#: id:20172
+msgid "XBMSP server"
+msgstr "שרת XBMSP"
+
+#: id:20173
+msgctxt "Auto context with id 20173"
+msgid "FTP server"
+msgstr "שרת FTP"
+
+#: id:20174
+msgid "iTunes music share (DAAP)"
+msgstr "מוזיקה משותפת של iTunes (DAAP)"
+
+#: id:20175
+msgid "UPnP server"
+msgstr "שרת UPnP"
+
+#: id:20176
+msgid "Show video info"
+msgstr "הצג פרטי וידאו"
+
+#: id:20177
+msgid "Done"
+msgstr "סיים"
+
+#: id:20178
+msgid "Shift"
+msgstr "Shift"
+
+#: id:20179
+msgid "Caps Lock"
+msgstr "Caps Lock"
+
+#: id:20180
+msgid "Symbols"
+msgstr "סמלים"
+
+#: id:20181
+msgid "Backspace"
+msgstr "Backspace"
+
+#: id:20182
+msgid "Space"
+msgstr "רווח"
+
+#: id:20183
+msgid "Reload skin"
+msgstr "טען סקין מחדש"
+
+#: id:20184
+msgid "Rotate pictures using EXIF information"
+msgstr "סובב תמונות בעזרת פרטי EXIF"
+
+#: id:20185
+msgid "Use poster view styles for TV shows"
+msgstr "השתמש בפוסטרים לתוכניות טלויזיה"
+
+#: id:20186
+msgid "Please wait"
+msgstr "אנא המתן"
+
+#: id:20187
+msgid "UPnP"
+msgstr "UPnP"
+
+#: id:20189
+msgid "Enable auto scrolling for plot & review"
+msgstr "אפשר גלילה אוטומטית לעלילות וסקירות"
+
+#: id:20190
+msgctxt "Auto context with id 20190"
+msgid "Custom"
+msgstr "מותאם אישית"
+
+#: id:20191
+msgid "Enable debug logging"
+msgstr "הפעל לוג מורחב"
+
+#: id:20192
+msgid "Download additional information during updates"
+msgstr "הורד פרטים נוספים בזמן עדכון"
+
+#: id:20193
+msgid "Default service for album information"
+msgstr "שירות ברירת מחדל לפרטי אלבום"
+
+#: id:20194
+msgid "Default service for artist information"
+msgstr "שירות ברירת מחדל לפרטי אמן"
+
+#: id:20195
+msgid "Change scraper"
+msgstr "החלף סקרייפר"
+
+#: id:20196
+msgid "Export music library"
+msgstr "ייצא ספרית המוסיקה"
+
+#: id:20197
+msgid "Import music library"
+msgstr "ייבא ספרית המוסיקה"
+
+#: id:20198
+msgid "No artist found!"
+msgstr "לא נימצא אמן!"
+
+#: id:20199
+msgid "Downloading artist info failed"
+msgstr "הורדת פרטי אמן נכשלה"
+
+#: id:20250
+msgid "Party on! (videos)"
+msgstr "יש מסיבה! (וידאו)"
+
+#: id:20251
+msgid "Mixing drinks (videos)"
+msgstr "מערבב משקאות (וידאו)"
+
+#: id:20252
+msgid "Filling glasses (videos)"
+msgstr "ממלא כוסות (וידאו)"
+
+#: id:20253
+msgid "WebDAV server (HTTP)"
+msgstr ""
+
+#: id:20254
+msgid "WebDAV server (HTTPS)"
+msgstr ""
+
+#: id:20255
+msgid "First logon, edit your profile"
+msgstr "ראשית התחבר, ערוך את הפרופיל שלך"
+
+#: id:20256
+msgid "HTS Tvheadend client"
+msgstr ""
+
+#: id:20257
+msgid "VDR Streamdev client"
+msgstr ""
+
+#: id:20258
+msgid "MythTV client"
+msgstr "קליינט MythTV"
+
+#: id:20259
+msgid "Network Filesystem (NFS)"
+msgstr ""
+
+#: id:20260
+msgid "Secure Shell (SSH/SFTP)"
+msgstr ""
+
+#: id:20261
+msgid "Apple Filing Protocol (AFP)"
+msgstr ""
+
+#: id:20300
+msgid "Web server directory (HTTP)"
+msgstr "נתיב שרת האינטרנט (HTTP)"
+
+#: id:20301
+msgid "Web server directory (HTTPS)"
+msgstr "נתיב שרת האינטרנט (HTTPS)"
+
+#: id:20302
+msgid "Unable to write to folder:"
+msgstr "לא יכול לרשום לתיקייה:"
+
+#: id:20303
+msgid "Do you want to skip and proceed?"
+msgstr "האם תרצה לדלג ולהמשיך?"
+
+#: id:20304
+msgid "RSS Feed"
+msgstr "הזנת RSS"
+
+#: id:20307
+msgid "Secondary DNS"
+msgstr "DNS משני"
+
+#: id:20308
+msgid "DHCP server:"
+msgstr "DHCP שרת:"
+
+#: id:20309
+msgid "Make new folder"
+msgstr "צור תיקיה חדשה"
+
+#: id:20310
+msgid "Dim LCD on playback"
+msgstr "עמעם LCD בזמן ניגון"
+
+#: id:20311
+msgid "Unknown or onboard (protected)"
+msgstr "לא ידוע או על הלוח (מוגן)"
+
+#: id:20312
+msgid "Dim LCD on paused"
+msgstr "עמעם LCD בזמן הפסקה"
+
+#: id:20314
+msgid "Videos - Library"
+msgstr "וידאו - ספריה"
+
+#: id:20316
+msgid "Sort by: ID"
+msgstr "מיין לפי: ID"
+
+#: id:20324
+msgid "Play part..."
+msgstr "נגן חלק..."
+
+#: id:20325
+msgid "Calibration reset"
+msgstr "אפס כיול"
+
+#: id:20326
+msgid "This will reset the calibration values for %s"
+msgstr "זה יאפס את ערכי הכיול ל %s"
+
+#: id:20327
+msgid "to it's default values."
+msgstr "לערכי ברירת המחדל שלו"
+
+#: id:20328
+msgid "Browse for destination"
+msgstr "עיין לנתיב יעד"
+
+#: id:20329
+msgid "Movies are in separate folders that match the movie title"
+msgstr "סרטים נמצאים בתיקיות נפרדות עם כותרת הסרט"
+
+#: id:20330
+msgid "Use folder names for lookups"
+msgstr "השתמש בשמות תיקיות לחיפוש"
+
+#: id:20331
+msgctxt "Auto context with id 20331"
+msgid "File"
+msgstr "קובץ"
+
+#: id:20332
+msgid "Use file or folder names in lookups?"
+msgstr "השתמש בשמות תיקיה או קובץ בחיפוש?"
+
+#: id:20333
+msgid "Set content"
+msgstr "קבע תוכן"
+
+#: id:20334
+msgid "Folder"
+msgstr "תיקיה"
+
+#: id:20335
+msgid "Look for content recursively?"
+msgstr "לחפש תוכן בצורה רקורסיבית?"
+
+#: id:20336
+msgid "Unlock sources"
+msgstr "שחרר מקורות"
+
+#: id:20337
+msgid "Actor"
+msgstr "שחקן"
+
+#: id:20338
+msgid "Movie"
+msgstr "סרט"
+
+#: id:20339
+msgid "Director"
+msgstr "במאי"
+
+#: id:20340
+msgid "Do you want to remove all items within"
+msgstr "האם ברצונך להסיר את כל הפרטים מתוך"
+
+#: id:20341
+msgid "this path from the XBMC library?"
+msgstr "נתיב זה ממסד הנתונים?"
+
+#: id:20342
+msgctxt "Auto context with id 20342"
+msgid "Movies"
+msgstr "סרטים"
+
+#: id:20343
+msgid "TV shows"
+msgstr "תוכניות טלוויזיה"
+
+#: id:20344
+msgid "This directory contains"
+msgstr "ספריה זו מכילה"
+
+#: id:20345
+msgid "Run automated scan"
+msgstr "הרץ סריקה אוטומטית"
+
+#: id:20346
+msgid "Scan recursively"
+msgstr "סרוק בצורה רקורסיבית"
+
+#: id:20347
+msgid "as"
+msgstr "בתור"
+
+#: id:20348
+msgid "Directors"
+msgstr "במאים"
+
+#: id:20349
+msgid "No video files found in this path!"
+msgstr "לא נמצאו קבצי וידאו בנתיב זה!"
+
+#: id:20350
+msgid "votes"
+msgstr "הצבעות"
+
+#: id:20351
+msgid "TV show information"
+msgstr "פרטי תוכנית טלוויזיה"
+
+#: id:20352
+msgid "Episode information"
+msgstr "פרטי פרק"
+
+#: id:20353
+msgid "Loading TV show details"
+msgstr "טוען פרטי תוכנית טלוויזיה"
+
+#: id:20354
+msgid "Fetching episode guide"
+msgstr "מייבא מדריך פרקים"
+
+#: id:20355
+msgid "Loading info for episodes in directory"
+msgstr "טוען פרטים עבור פרקים בתיקייה"
+
+#: id:20356
+msgid "Select TV show:"
+msgstr "בחר תוכנית טלוויזיה:"
+
+#: id:20357
+msgid "Enter the TV show name"
+msgstr "הזן שם תוכנית טלויזיה"
+
+#: id:20358
+msgid "Season %i"
+msgstr "עונה %i"
+
+#: id:20359
+msgid "Episode"
+msgstr "פרק"
+
+#: id:20360
+msgid "Episodes"
+msgstr "פרקים"
+
+#: id:20361
+msgid "Loading episode details"
+msgstr "טוען פרטי פרק"
+
+#: id:20362
+msgid "Remove episode from library"
+msgstr "הסר פרק מספריה"
+
+#: id:20363
+msgid "Remove TV show from library"
+msgstr "הסר תוכנית טלויזיה מספריה"
+
+#: id:20364
+msgid "TV show"
+msgstr "תוכנית טלויזיה"
+
+#: id:20365
+msgid "Episode plot"
+msgstr "עלילת פרק"
+
+#: id:20366
+msgid "* All seasons"
+msgstr "* כל העונות"
+
+#: id:20367
+msgid "Hide watched"
+msgstr "הסתר שנצפו"
+
+#: id:20368
+msgid "Prod code"
+msgstr "קוד הפקה"
+
+#: id:20369
+msgid "Show plot for unwatched items"
+msgstr "הראה עלילה לפריטים שעוד לא נצפו"
+
+#: id:20370
+msgid "* Hidden to prevent spoilers *"
+msgstr "* הסתר למניעת ספוילרים *"
+
+#: id:20371
+msgid "Set season thumb"
+msgstr "בחר תמונה ממוזערת לעונה"
+
+#: id:20372
+msgid "Season image"
+msgstr "תמונת עונה"
+
+#: id:20373
+msgid "Season"
+msgstr "עונה"
+
+#: id:20374
+msgid "Downloading movie information"
+msgstr "מוריד פרטי סרט"
+
+#: id:20375
+msgid "Unassign content"
+msgstr "תוכן לא מוקצה"
+
+#: id:20376
+msgid "Original title"
+msgstr "כותרת מקורית"
+
+#: id:20377
+msgid "Refresh TV show information"
+msgstr "רענן פרטי תוכנית טלויזיה"
+
+#: id:20378
+msgid "Refresh info for all episodes?"
+msgstr "רענן פרטים לכל הפרקים?"
+
+#: id:20379
+msgid "Selected folder contains a single TV show"
+msgstr "תיקיה מכילה תוכנית טלויזיה בודדת"
+
+#: id:20380
+msgid "Exclude selected folder from scans"
+msgstr "מנע תיקייה מסריקות"
+
+#: id:20381
+msgid "Specials"
+msgstr "ספיישלים"
+
+#: id:20382
+msgid "Automatically grab season thumbs"
+msgstr "הורד אוטומטי תמונה ממוזערת לעונה"
+
+#: id:20383
+msgid "Selected folder contains a single video"
+msgstr "תיקייה מכילה וידאו בודד"
+
+#: id:20384
+msgid "Link to TV show"
+msgstr "קשר לתוכנית טלויזיה"
+
+#: id:20385
+msgid "Remove link to TV show"
+msgstr "הסר קישור לתוכנית טלויזיה"
+
+#: id:20386
+msgid "Recently added movies"
+msgstr "סרטים שנוספו לאחרונה"
+
+#: id:20387
+msgid "Recently added episodes"
+msgstr "פרקים שנוספו לאחרונה"
+
+#: id:20388
+msgid "Studios"
+msgstr "אולפנים"
+
+#: id:20389
+msgid "Music videos"
+msgstr "קליפים"
+
+#: id:20390
+msgid "Recently added music videos"
+msgstr "קליפים שנוספו לאחרונה"
+
+#: id:20391
+msgid "Music video"
+msgstr "קליפ"
+
+#: id:20392
+msgid "Remove music video from library"
+msgstr "הסר קליפ מספרית הוידאו"
+
+#: id:20393
+msgctxt "Auto context with id 20393"
+msgid "Music video information"
+msgstr "פרטי קליפ"
+
+#: id:20394
+msgid "Loading music video information"
+msgstr "טוען פרטי קליפ"
+
+#: id:20395
+msgid "Mixed"
+msgstr "מעורבב"
+
+#: id:20396
+msgid "Go to albums by artist"
+msgstr "עבור לאלבומים לפי אמנים"
+
+#: id:20397
+msgid "Go to album"
+msgstr "עבור לאלבומים"
+
+#: id:20398
+msgid "Play song"
+msgstr "נגן שיר"
+
+#: id:20399
+msgid "Go to music videos from album"
+msgstr "לך לקליפים מהאלבום"
+
+#: id:20400
+msgid "Go to music videos by artist"
+msgstr "לך לקליפים לפי אמן"
+
+#: id:20401
+msgid "Play music video"
+msgstr "נגן קליפ"
+
+#: id:20402
+msgid "Download actor thumbnails when adding to library"
+msgstr "הורד תמונות ממוזערות לשחקנים בהוספה לספריה"
+
+#: id:20403
+msgid "Set actor thumb"
+msgstr "בחר תמונה ממוזערת לשחקן"
+
+#: id:20405
+msgid "Remove episode bookmark"
+msgstr "הסר סימניית פרק"
+
+#: id:20406
+msgid "Set episode bookmark"
+msgstr "הוסף סימניית פרק"
+
+#: id:20407
+msgid "Scraper settings"
+msgstr "הגדרות סקרייפר"
+
+#: id:20408
+msgid "Downloading music video information"
+msgstr "מוריד פרטי קליפ"
+
+#: id:20409
+msgid "Downloading TV show information"
+msgstr "מוריד פרטי תוכנית טלויזיה"
+
+#: id:20410
+msgid "Trailer"
+msgstr "קדימון"
+
+#: id:20411
+msgid "Flatten"
+msgstr "שטח"
+
+#: id:20412
+msgid "Flatten TV shows"
+msgstr "שטח תוכניות טלויזיה"
+
+#: id:20413
+msgid "Get fanart"
+msgstr "קבל פאנארט"
+
+#: id:20414
+msgid "Show Fanart in video and music libraries"
+msgstr "הצג פאנארט בספריות וידאו ומוזיקה"
+
+#: id:20415
+msgid "Scanning for new content"
+msgstr "סורק עבור תוכן חדש"
+
+#: id:20416
+msgid "First aired"
+msgstr "שודר לראשונה"
+
+#: id:20417
+msgid "Writer"
+msgstr "כותב"
+
+#: id:20419
+msgid "Replace file names with library titles"
+msgstr "החלף שמות קבצים עם כותרות ספריה"
+
+#: id:20420
+msgctxt "Auto context with id 20420"
+msgid "Never"
+msgstr "אף פעם"
+
+#: id:20421
+msgid "If only one season"
+msgstr "אם רק עונה אחת"
+
+#: id:20422
+msgid "Always"
+msgstr "תמיד"
+
+#: id:20423
+msgid "Has trailer"
+msgstr "יש קדימון"
+
+#: id:20424
+msgid "False"
+msgstr "שקר"
+
+#: id:20425
+msgid "Fanart slideshow"
+msgstr "מצגת פאנארט"
+
+#: id:20426
+msgid "Export to a single file or separate"
+msgstr "?לייצא לקובץ בודד או קבצים ניפרדים"
+
+#: id:20427
+msgid "files per entry?"
+msgstr "קבצים לכל ערך?"
+
+#: id:20428
+msgid "Single file"
+msgstr "קובץ בודד"
+
+#: id:20429
+msgctxt "Auto context with id 20429"
+msgid "Separate"
+msgstr "ניפרדים"
+
+#: id:20430
+msgid "Export thumbnails and fanart?"
+msgstr "?לייצא תמונות ממוזערות ופאנארט"
+
+#: id:20431
+msgid "Overwrite old files?"
+msgstr "?לדרוס קבצים קיימים"
+
+#: id:20432
+msgid "Exclude path from library updates"
+msgstr "אל תכלול נתיב זה בעידכוני ספריה"
+
+#: id:20433
+msgid "Extract thumbnails and video information"
+msgstr "חלץ תמונות ממוזערות ופרטי וידאו"
+
+#: id:20434
+msgid "Sets"
+msgstr "מארזים"
+
+#: id:20435
+msgid "Set movieset thumb"
+msgstr "קבע תמונה ממוזערת למארז סרטים"
+
+#: id:20436
+msgid "Export actor thumbs?"
+msgstr "לייצא תמונות ממוזערות לשחקנים"
+
+#: id:20437
+msgid "Choose fanart"
+msgstr "בחר פאנארט"
+
+#: id:20438
+msgid "Local fanart"
+msgstr "פאנארט מקומי"
+
+#: id:20439
+msgid "No fanart"
+msgstr "ללא פאנארט"
+
+#: id:20440
+msgid "Current fanart"
+msgstr "פאנארט נוכחי"
+
+#: id:20441
+msgid "Remote fanart"
+msgstr "פאנארט מרוחק"
+
+#: id:20442
+msgid "Change content"
+msgstr "שנה תוכן"
+
+#: id:20443
+msgid "Do you want to refresh info for all"
+msgstr "האם ברצונך לרענן את כל הפרטים"
+
+#: id:20444
+msgid "items within this path?"
+msgstr "פריטים בתוך נתיב זה?"
+
+#: id:20445
+msgid "Fanart"
+msgstr "פאנארט"
+
+#: id:20446
+msgid "Locally stored information found."
+msgstr "מידע מקומי נמצא."
+
+#: id:20447
+msgid "Ignore and refresh from internet?"
+msgstr "התעלם ולעדכן מהאינטרנט?"
+
+#: id:20448
+msgid "Could not download information"
+msgstr "אין אפשרות להוריד פרטים"
+
+#: id:20449
+msgid "Unable to connect to remote server"
+msgstr "אין אפשרות להתחבר לשרת מרוחק"
+
+#: id:20450
+msgid "Would you like to continue scanning?"
+msgstr "האם ברצונך להמשיך בסריקה?"
+
+#: id:20451
+msgid "Countries"
+msgstr "ארצות"
+
+#: id:20452
+msgid "episode"
+msgstr "פרק"
+
+#: id:20453
+msgid "episodes"
+msgstr "פרקים"
+
+#: id:20454
+msgid "Listener"
+msgstr "מאזין"
+
+#: id:20455
+msgid "Listeners"
+msgstr "מאזינים"
+
+#: id:20456
+msgid "Set movieset fanart"
+msgstr "הגדר פאנארט למארז סרטים"
+
+#: id:20457
+msgid "Movie set"
+msgstr "מארז סרטים"
+
+#: id:20458
+msgid "Group movies in sets"
+msgstr "קבוצות סרטים במארזים"
+
+#: id:21330
+msgid "Show hidden files and directories"
+msgstr "הצג קבצים וספריות מוחבאים"
+
+#: id:21331
+msgid "TuxBox client"
+msgstr "קליינט TuxBox"
+
+#: id:21332
+msgid "WARNING: Target TuxBox device is in recording-mode!"
+msgstr "אזהרה: הצב את מכשיר ה TuxBox במצב הקלטה"
+
+#: id:21333
+msgid "The stream will be stopped!"
+msgstr "הזרימה תופסק!"
+
+#: id:21334
+msgid "Zap to channel: %s failed!"
+msgstr "זפזופ לערוץ: %s נכשל"
+
+#: id:21335
+msgid "Are you sure to start the stream?"
+msgstr "האם אתה בטוח להתחיל את הזרימה?"
+
+#: id:21336
+msgid "Connecting to: %s"
+msgstr "מתחבר אל: %s"
+
+#: id:21337
+msgid "TuxBox device"
+msgstr "מכשיר TuxBox"
+
+#: id:21359
+msgid "Add media share..."
+msgstr "הוסף שיתוף מדיה..."
+
+#: id:21360
+msgid "Share video and music libraries through UPnP"
+msgstr "שתף את ספריות הוידאו והמוסיקה דרך UPnP"
+
+#: id:21364
+msgid "Edit media share"
+msgstr "ערוך שיתוף מדיה"
+
+#: id:21365
+msgid "Remove media share"
+msgstr "הסר סיתוף מדיה"
+
+#: id:21366
+msgid "Subtitle folder"
+msgstr "תיקיית כתוביות"
+
+#: id:21367
+msgid "Movie & alternate subtitle directory"
+msgstr "ספריית סרט ותרגום חלופי"
+
+#: id:21368
+msgid "Override ASS/SSA subtitles fonts"
+msgstr "דלג על גופני כתוביות ASS/SSA"
+
+#: id:21369
+msgid "Enable mouse and Touch Screen support"
+msgstr "אפשר תמיכה בעכבר ומסך מגע"
+
+#: id:21370
+msgid "Play navigation sounds during media playback"
+msgstr "בזמן ניגון המדיה נגן צלילי ניווט"
+
+#: id:21371
+msgid "Thumbnail"
+msgstr "תמונה ממוזערת"
+
+#: id:21372
+msgid "Forced DVD player region"
+msgstr "קביעת איזור נגן דיוידי"
+
+#: id:21373
+msgid "Video output"
+msgstr "פלט וידאו"
+
+#: id:21374
+msgid "Video aspect"
+msgstr "גודל וידאו"
+
+#: id:21375
+msgctxt "Auto context with id 21375"
+msgid "Normal"
+msgstr "רגיל"
+
+#: id:21376
+msgid "Letterbox"
+msgstr "תיבת מכתבים"
+
+#: id:21377
+msgid "Widescreen"
+msgstr "מסך רחב"
+
+#: id:21378
+msgid "Enable 480p"
+msgstr "הפעל 480p"
+
+#: id:21379
+msgid "Enable 720p"
+msgstr "הפעל 720p"
+
+#: id:21380
+msgid "Enable 1080i"
+msgstr "הפעל 1080i"
+
+#: id:21381
+msgid "Enter name of new playlist"
+msgstr "הזן שם רשימת השמעה חדשה"
+
+#: id:21382
+msgid "Show \"Add source\" buttons in file lists"
+msgstr "הראה כפתור \"הוסף מקור\" ברשימות קבצים"
+
+#: id:21383
+msgid "Enable scrollbars"
+msgstr "אפשר פסי גלילה"
+
+#: id:21384
+msgid "Make watched filtering a toggle in video library"
+msgstr "אפשר פילטר נצפו בספריית וידאו"
+
+#: id:21385
+msgctxt "Auto context with id 21385"
+msgid "Open"
+msgstr "פתח"
+
+#: id:21386
+msgid "Acoustic management level"
+msgstr "רמת ניהול אקוסטי"
+
+#: id:21387
+msgid "Fast"
+msgstr "מהר"
+
+#: id:21388
+msgid "Quiet"
+msgstr "שקט"
+
+#: id:21389
+msgid "Enable custom background"
+msgstr "אפשר רקע מותאם אישית"
+
+#: id:21390
+msgid "Power management level"
+msgstr "רמת ניהול כוח"
+
+#: id:21391
+msgid "High power"
+msgstr "כוח גבוה"
+
+#: id:21392
+msgid "Low power"
+msgstr "כוח נמוך"
+
+#: id:21393
+msgid "High standby"
+msgstr "המתנה גבוהה"
+
+#: id:21394
+msgid "Low standby"
+msgstr "המתנה נמוכה"
+
+#: id:21395
+msgid "Unable to cache files bigger than 4GB"
+msgstr "לא יכול להכניס למטמון קבצים גדולים מ 4 גיגה"
+
+#: id:21396
+msgid "Chapter"
+msgstr "פרק"
+
+#: id:21397
+msgid "High quality pixel shader v2"
+msgstr ""
+
+#: id:21398
+msgid "Enable playlist at startup"
+msgstr "אפר רשימת ניגון בהפעלה"
+
+#: id:21399
+msgid "Use tween animations"
+msgstr "השתמש בתאוצת (tween) אנימציות"
+
+#: id:21400
+msgid "contains"
+msgstr "מכיל"
+
+#: id:21401
+msgid "does not contain"
+msgstr "לא מכיל"
+
+#: id:21402
+msgid "is"
+msgstr "הוא"
+
+#: id:21403
+msgid "is not"
+msgstr "הוא לא"
+
+#: id:21404
+msgid "starts with"
+msgstr "מתחיל עם"
+
+#: id:21405
+msgid "ends with"
+msgstr "נגמר עם"
+
+#: id:21406
+msgid "greater than"
+msgstr "גדול יותר מ"
+
+#: id:21407
+msgid "less than"
+msgstr "פחות מ"
+
+#: id:21408
+msgid "after"
+msgstr "אחרי"
+
+#: id:21409
+msgid "before"
+msgstr "לפני"
+
+#: id:21410
+msgid "in the last"
+msgstr "באחרון"
+
+#: id:21411
+msgid "not in the last"
+msgstr "לא באחרון"
+
+#: id:21412
+msgid "Scrapers"
+msgstr "סקרייפרים"
+
+#: id:21413
+msgid "Default movie scraper"
+msgstr "סקרייפר ברירת מחדל לסרטים"
+
+#: id:21414
+msgid "Default tvshow scraper"
+msgstr "סקרייפר ברירת מחדל לתוכניות"
+
+#: id:21415
+msgid "Default music video scraper"
+msgstr "סקרייפר ברירת מחדל למוסיקה"
+
+#: id:21416
+msgid "Enable fallback based on scraper language"
+msgstr "אפשר גיבוי על פי שפת הסקרייפר"
+
+#: id:21417
+msgid "- Settings"
+msgstr "- הגדרות"
+
+#: id:21418
+msgid "Multilingual"
+msgstr "רב-לשוני"
+
+#: id:21419
+msgid "No scrapers present"
+msgstr "אין סקרייפרים"
+
+#: id:21420
+msgid "Value to match"
+msgstr "ערך להתאמה"
+
+#: id:21421
+msgid "Smart playlist rule"
+msgstr "חוקי רשימת השמעה חכמה"
+
+#: id:21422
+msgid "Match items where"
+msgstr "התאם פריטים בהם"
+
+#: id:21423
+msgid "New rule..."
+msgstr "חוק חדש..."
+
+#: id:21424
+msgid "Items must match"
+msgstr "הפריטים חייבים להתאים"
+
+#: id:21425
+msgid "all of the rules"
+msgstr "כל החוקים"
+
+#: id:21426
+msgid "one or more of the rules"
+msgstr "חוק אחד או יותר"
+
+#: id:21427
+msgid "Limit to"
+msgstr "הגבלה"
+
+#: id:21428
+msgid "No limit"
+msgstr "אין הגבלה"
+
+#: id:21429
+msgid "Order by"
+msgstr "סדר לפי"
+
+#: id:21430
+msgid "ascending"
+msgstr "עולה"
+
+#: id:21431
+msgid "descending"
+msgstr "יורד"
+
+#: id:21432
+msgid "Edit smart playlist"
+msgstr "ערוך רשימת השמעה חכמה"
+
+#: id:21433
+msgid "Name of the playlist"
+msgstr "שם רשימת השמעה"
+
+#: id:21434
+msgid "Find items where"
+msgstr "מצא פריטים בהם"
+
+#: id:21435
+msgid "Edit"
+msgstr "- ערוך"
+
+#: id:21436
+msgid "%i items"
+msgstr "פריטים %i"
+
+#: id:21437
+msgid "New smart playlist..."
+msgstr "רשימת השמעה חכמה חדשה"
+
+#: id:21438
+msgid "%c Drive"
+msgstr "כונן %c"
+
+#: id:21439
+msgid "Edit party mode rules"
+msgstr "ערוך חוקי מצב מסיבה"
+
+#: id:21440
+msgid "Home folder"
+msgstr "תיקיית בית"
+
+#: id:21441
+msgid "Watched count"
+msgstr "ספירת שנצפו"
+
+#: id:21442
+msgid "Episode title"
+msgstr "שם פרק"
+
+#: id:21443
+msgid "Video resolution"
+msgstr "רזולוצית וידאו"
+
+#: id:21444
+msgid "Audio channels"
+msgstr "ערוצי שמע"
+
+#: id:21445
+msgid "Video codec"
+msgstr "מקודד וידאו"
+
+#: id:21446
+msgid "Audio codec"
+msgstr "מקודד שמע"
+
+#: id:21447
+msgid "Audio language"
+msgstr "שפת שמע"
+
+#: id:21448
+msgid "Subtitle language"
+msgstr "שפת כתובית"
+
+#: id:21449
+msgid "Remote control sends keyboard presses"
+msgstr "שלט רחוק שולח לחיצות מקלדת"
+
+#: id:21450
+msgid "- Edit"
+msgstr "- עריכה"
+
+#: id:21451
+msgid "Internet connection required."
+msgstr "נחוץ חיבור לאינטרנט."
+
+#: id:21452
+msgid "Get More..."
+msgstr "קבל עוד..."
+
+#: id:21453
+msgid "Root filesystem"
+msgstr "שורש מערכת הקבצים"
+
+#: id:21454
+msgid "Cache full"
+msgstr "מטמון מלא"
+
+#: id:21455
+msgid "Cache filled before reaching required amount for continous playback"
+msgstr "המטמון התמלא לפני שהגיע לכמות הנחוצה לניגון רציף"
+
+#: id:21460
+msgid "Subtitle location"
+msgstr "מיקום הכתובית"
+
+#: id:21461
+msgid "Fixed"
+msgstr "מקובע"
+
+#: id:21462
+msgid "Bottom of video"
+msgstr "תחתית הוידאו"
+
+#: id:21463
+msgid "Below video"
+msgstr "מתחת לוידאו"
+
+#: id:21464
+msgid "Top of video"
+msgstr "בראש הוידאו"
+
+#: id:21465
+msgid "Above video"
+msgstr "מעל הוידאו"
+
+#: id:21800
+msgid "File name"
+msgstr "שם קובץ"
+
+#: id:21801
+msgid "File path"
+msgstr "נתיב קובץ"
+
+#: id:21802
+msgid "File size"
+msgstr "גודל קובץ"
+
+#: id:21803
+msgid "File date/time"
+msgstr "תאריך/שעה קובץ"
+
+#: id:21804
+msgid "Slide index"
+msgstr "שקופית אינדקס"
+
+#: id:21805
+msgctxt "Auto context with id 21805"
+msgid "Resolution"
+msgstr "רזולוציה"
+
+#: id:21806
+msgctxt "Auto context with id 21806"
+msgid "Comment"
+msgstr "הערות"
+
+#: id:21807
+msgid "Colour/B&W"
+msgstr "צבעוני/שחור-לבן"
+
+#: id:21808
+msgid "JPEG process"
+msgstr "תהליך JPEG"
+
+#: id:21820
+msgid "Date/Time"
+msgstr "תאריך/שעה"
+
+#: id:21821
+msgid "Description"
+msgstr "תיאור"
+
+#: id:21822
+msgid "Camera make"
+msgstr "יצרן המצלמה"
+
+#: id:21823
+msgid "Camera model"
+msgstr "דגם המצלמה"
+
+#: id:21824
+msgid "EXIF comment"
+msgstr "EXIF תגובה"
+
+#: id:21825
+msgid "Firmware"
+msgstr "קושחה"
+
+#: id:21826
+msgid "Aperture"
+msgstr "צמצם"
+
+#: id:21827
+msgid "Focal length"
+msgstr "מוקד אורך"
+
+#: id:21828
+msgid "Focus distance"
+msgstr "מרחק הפוקוס"
+
+#: id:21829
+msgid "Exposure"
+msgstr "חשיפה"
+
+#: id:21830
+msgid "Exposure time"
+msgstr "זמן חשיפה"
+
+#: id:21831
+msgid "Exposure bias"
+msgstr "הטיית חשיפה"
+
+#: id:21832
+msgid "Exposure mode"
+msgstr "מצב חשיפה"
+
+#: id:21833
+msgid "Flash used"
+msgstr "פלאש בשימוש"
+
+#: id:21834
+msgid "White-balance"
+msgstr "איזון לבן"
+
+#: id:21835
+msgid "Light source"
+msgstr "מקור האור"
+
+#: id:21836
+msgid "Metering mode"
+msgstr "מצב מדידה"
+
+#: id:21837
+msgid "ISO"
+msgstr "ISO"
+
+#: id:21838
+msgid "Digital zoom"
+msgstr "זום דיגיטלי"
+
+#: id:21839
+msgid "CCD width"
+msgstr "CCD רוחב"
+
+#: id:21840
+msgid "GPS latitude"
+msgstr "GPS קו-רוחב"
+
+#: id:21841
+msgid "GPS longitude"
+msgstr "GPS קו-אורך"
+
+#: id:21842
+msgid "GPS altitude"
+msgstr "GPS גובה"
+
+#: id:21843
+msgid "Orientation"
+msgstr "התמצאות"
+
+#: id:21860
+msgid "Supplemental categories"
+msgstr "קטגוריות נוספות"
+
+#: id:21861
+msgid "Keywords"
+msgstr "מילות מפתח"
+
+#: id:21862
+msgid "Caption"
+msgstr "מלות הסבר"
+
+#: id:21863
+msgid "Author"
+msgstr "מחבר"
+
+#: id:21864
+msgid "Headline"
+msgstr "כותרת"
+
+#: id:21865
+msgid "Special instructions"
+msgstr "הוראות מיוחדות"
+
+#: id:21866
+msgid "Category"
+msgstr "קטגוריה"
+
+#: id:21867
+msgid "Byline"
+msgstr "כותרת-משנה"
+
+#: id:21868
+msgid "Byline title"
+msgstr "כותרת-משנה"
+
+#: id:21869
+msgid "Credit"
+msgstr "קרדיט"
+
+#: id:21870
+msgid "Source"
+msgstr "מקור"
+
+#: id:21871
+msgid "Copyright notice"
+msgstr "הערת זכויות יוצרים"
+
+#: id:21872
+msgid "Object name"
+msgstr "שם אובייקט"
+
+#: id:21873
+msgid "City"
+msgstr "עיר"
+
+#: id:21874
+msgid "State"
+msgstr "מדינה"
+
+#: id:21875
+msgctxt "Auto context with id 21875"
+msgid "Country"
+msgstr "ארץ"
+
+#: id:21876
+msgid "Original Tx Reference"
+msgstr ""
+
+#: id:21877
+msgid "Date created"
+msgstr "תאריך יצירה"
+
+#: id:21878
+msgid "Copyright flag"
+msgstr "דגל זכויות יוצרים"
+
+#: id:21879
+msgid "Country code"
+msgstr "קוד מדינה"
+
+#: id:21880
+msgid "Reference service"
+msgstr ""
+
+#: id:21881
+msgid "Allow control of XBMC via UPnP"
+msgstr "אפשר שליטה על XBMC דרך UPnP"
+
+#: id:21882
+msgid "Attempt to skip introduction before DVD menu"
+msgstr "נסה לדלג על הקדמות לפני תפריט DVD"
+
+#: id:21883
+msgid "Saved music"
+msgstr "מוסיקה שמורה"
+
+#: id:21884
+msgid "Query info for all artists"
+msgstr "בדוק פרטים של כל האמנים"
+
+#: id:21885
+msgid "Downloading album information"
+msgstr "מוריד פרטי אלבום"
+
+#: id:21886
+msgid "Downloading artist information"
+msgstr "מוריד פרטי אמן"
+
+#: id:21887
+msgid "Biography"
+msgstr "ביוגרפיה"
+
+#: id:21888
+msgid "Discography"
+msgstr "דיסקוגרפיה"
+
+#: id:21889
+msgid "Searching artist"
+msgstr "מחפש אמן"
+
+#: id:21890
+msgid "Select artist"
+msgstr "בחר אמן"
+
+#: id:21891
+msgctxt "Auto context with id 21891"
+msgid "Artist information"
+msgstr "פרטי אמן"
+
+#: id:21892
+msgid "Instruments"
+msgstr "כלי נגינה"
+
+#: id:21893
+msgid "Born"
+msgstr "נולד"
+
+#: id:21894
+msgid "Formed"
+msgstr "הוקמו"
+
+#: id:21895
+msgid "Themes"
+msgstr "נושאים"
+
+#: id:21896
+msgid "Disbanded"
+msgstr "התפרקו"
+
+#: id:21897
+msgid "Died"
+msgstr "נפטר"
+
+#: id:21898
+msgid "Years active"
+msgstr "שנות פעילות"
+
+#: id:21899
+msgid "Label"
+msgstr "חברת הפקה"
+
+#: id:21900
+msgid "Born/Formed"
+msgstr "נולד / הוקם"
+
+#: id:22000
+msgid "Update library on startup"
+msgstr "עדכן את הספריה בהפעלה"
+
+#: id:22001
+msgid "Hide progress of library updates"
+msgstr "תמיד עדכן ספרייה ברקע"
+
+#: id:22002
+msgid "- DNS suffix"
+msgstr "- DNS סיומת"
+
+#: id:22003
+msgid "%2.3fs"
+msgstr "%2.3fs"
+
+#: id:22004
+msgid "Delayed by: %2.3fs"
+msgstr "%2.3f שניות עוכבו"
+
+#: id:22005
+msgid "Ahead by: %2.3fs"
+msgstr "%2.3f שניות הוקדמו"
+
+#: id:22006
+msgid "Subtitle offset"
+msgstr "השהיית כתוביות"
+
+#: id:22007
+msgid "OpenGL vendor:"
+msgstr "OpenGL ספק:"
+
+#: id:22008
+msgid "OpenGL renderer:"
+msgstr ""
+
+#: id:22009
+msgid "OpenGL version:"
+msgstr "OpenGL גרסה:"
+
+#: id:22010
+msgid "GPU temperature:"
+msgstr "GPU טמפרטורה:"
+
+#: id:22011
+msgid "CPU temperature:"
+msgstr "CPU טמפרטורה:"
+
+#: id:22012
+msgid "Total memory"
+msgstr "סה\"כ זיכרון"
+
+#: id:22013
+msgid "Profile data"
+msgstr "נתוני פרופיל"
+
+#: id:22014
+msgid "Use dim if paused during video playback"
+msgstr "השתמש בעמעום כשמושהה בזמן ניגון וידאו"
+
+#: id:22015
+msgid "All recordings"
+msgstr "כל ההקלטות"
+
+#: id:22016
+msgid "By title"
+msgstr "לפי כותרת"
+
+#: id:22017
+msgid "By group"
+msgstr "לפי קבוצה"
+
+#: id:22018
+msgid "Live channels"
+msgstr "ערוצים חיים"
+
+#: id:22019
+msgid "Recordings by title"
+msgstr "הקלטות לפי כותרת"
+
+#: id:22020
+msgid "Guide"
+msgstr "מדריך"
+
+#: id:22021
+msgid "Allowed error in aspect ratio to minimize black bars"
+msgstr "אפשר שגיאות ביחס גודל כדי להקטין פסים שחורים"
+
+#: id:22022
+msgid "Show video files in listings"
+msgstr "הצג קיבצי וידאו ברשימה"
+
+#: id:22023
+msgid "DirectX vendor:"
+msgstr "DirectX ספק:"
+
+#: id:22024
+msgid "Direct3D version:"
+msgstr "Direct3D גרסה:"
+
+#: id:22030
+msgctxt "Auto context with id 22030"
+msgid "Font"
+msgstr "פונט"
+
+#: id:22031
+msgctxt "Auto context with id 22031"
+msgid "- Size"
+msgstr "- גודל"
+
+#: id:22032
+msgctxt "Auto context with id 22032"
+msgid "- Colours"
+msgstr "- צבעים"
+
+#: id:22033
+msgid "- Charset"
+msgstr "- מערך תוים"
+
+#: id:22034
+msgid "Export karaoke titles as HTML"
+msgstr "ייצא כותרות קריוקי כקובץ HTML"
+
+#: id:22035
+msgid "Export karaoke titles as CSV"
+msgstr "ייצא כותרות קריוקי כקובץ CSV"
+
+#: id:22036
+msgid "Import karaoke titles..."
+msgstr "ייבא כותרות קריוקי..."
+
+#: id:22037
+msgid "Show song selector automatically"
+msgstr "הראה אוטומטית את בורר השירים"
+
+#: id:22038
+msgid "Export karaoke titles..."
+msgstr "ייצא כותרות קריוקי..."
+
+#: id:22039
+msgid "Enter song number"
+msgstr "הזן מספר שיר"
+
+#: id:22040
+msgid "white/green"
+msgstr "לבן/ירוק"
+
+#: id:22041
+msgid "white/red"
+msgstr "לבן/אדום"
+
+#: id:22042
+msgid "white/blue"
+msgstr "לבן/כחול"
+
+#: id:22043
+msgid "black/white"
+msgstr "שחור/לבן"
+
+#: id:22079
+msgid "Default select action"
+msgstr "פעולת בחירה ברירת מחדל"
+
+#: id:22080
+msgid "Choose"
+msgstr "בחר"
+
+#: id:22081
+msgid "Show Information"
+msgstr "הצג פרטים"
+
+#: id:22082
+msgid "More..."
+msgstr "עוד..."
+
+#: id:22083
+msgid "Play all"
+msgstr "נגן הכל"
+
+#: id:23049
+msgid "Teletext not available"
+msgstr "טלטקסט לא זמין"
+
+#: id:23050
+msgid "Activate Teletext"
+msgstr "הפעל טלטקסט"
+
+#: id:23051
+msgid "Part %i"
+msgstr "חלק %i"
+
+#: id:23052
+msgid "Buffering %i bytes"
+msgstr "אוגר %i בייטים"
+
+#: id:23053
+msgid "Stopping"
+msgstr "עוצר"
+
+#: id:23054
+msgid "Running"
+msgstr "רץ"
+
+#: id:23100
+msgid "External Player Active"
+msgstr "נגן חיצוני פעיל"
+
+#: id:23101
+msgid "Click OK to terminate the player"
+msgstr "לחץ על אישור כדי לנטרל את הנגן"
+
+#: id:23104
+msgid "Click OK when playback has ended"
+msgstr "לחץ אישור כאשר ההשמעה הסתיימה"
+
+#: id:24000
+msgid "Add-on"
+msgstr "תוסף"
+
+#: id:24001
+msgid "Add-ons"
+msgstr "הרחבות"
+
+#: id:24002
+msgid "Add-on options"
+msgstr "אפשרויות הרחבות"
+
+#: id:24003
+msgid "Add-on Information"
+msgstr "פרטי תוסף"
+
+#: id:24005
+msgctxt "Auto context with id 24005"
+msgid "Media sources"
+msgstr "מקורות מדיה"
+
+#: id:24007
+msgctxt "Auto context with id 24007"
+msgid "Movie information"
+msgstr "פרטי סרט"
+
+#: id:24008
+msgctxt "Auto context with id 24008"
+msgid "Screensaver"
+msgstr "שומר מסך"
+
+#: id:24009
+msgid "Script"
+msgstr "סקריפט"
+
+#: id:24010
+msgctxt "Auto context with id 24010"
+msgid "Visualization"
+msgstr "חיזוי"
+
+#: id:24011
+msgid "Add-on repository"
+msgstr "מאגר הרחבות"
+
+#: id:24012
+msgctxt "Auto context with id 24012"
+msgid "Subtitles"
+msgstr "כתוביות"
+
+#: id:24013
+msgid "Lyrics"
+msgstr "מילות שירים"
+
+#: id:24014
+msgid "TV information"
+msgstr "פרטי טלויזיה"
+
+#: id:24015
+msgctxt "Auto context with id 24015"
+msgid "Music video information"
+msgstr "פרטי קליפים"
+
+#: id:24016
+msgctxt "Auto context with id 24016"
+msgid "Album information"
+msgstr "פרטי אלבומים"
+
+#: id:24017
+msgctxt "Auto context with id 24017"
+msgid "Artist information"
+msgstr "פרטי אמנים"
+
+#: id:24018
+msgctxt "Auto context with id 24018"
+msgid "Services"
+msgstr "שירותים"
+
+#: id:24020
+msgid "Configure"
+msgstr "הגדר"
+
+#: id:24021
+msgctxt "Auto context with id 24021"
+msgid "Disable"
+msgstr "נטרל"
+
+#: id:24022
+msgid "Enable"
+msgstr "הפעל"
+
+#: id:24023
+msgid "Add-on disabled"
+msgstr "תוסף מנוטרל"
+
+#: id:24027
+msgctxt "Auto context with id 24027"
+msgid "Weather"
+msgstr "מזג אויר"
+
+#: id:24028
+msgid "Weather.com (standard)"
+msgstr "Weather.com (רגיל)"
+
+#: id:24030
+msgid "This Add-on can not be configured"
+msgstr "הרחבה זו אינה ניתנת להגדרה"
+
+#: id:24031
+msgid "Error loading settings"
+msgstr "תקלה בעת טעינת הגדרות"
+
+#: id:24032
+msgid "All Add-ons"
+msgstr "כל ההרחבות"
+
+#: id:24033
+msgid "Get Add-ons"
+msgstr "קבל הרחבות"
+
+#: id:24034
+msgid "Check for updates"
+msgstr "חפש עדכונים"
+
+#: id:24035
+msgid "Force refresh"
+msgstr "רענן בכוח"
+
+#: id:24036
+msgid "Change log"
+msgstr "שינויים"
+
+#: id:24037
+msgid "Uninstall"
+msgstr "הסר הרחבה"
+
+#: id:24038
+msgid "Install"
+msgstr "התקן הרחבה"
+
+#: id:24039
+msgid "Disabled Add-ons"
+msgstr "הרחבות מנוטרלות"
+
+#: id:24040
+msgid "(Clear the current setting)"
+msgstr "(נקה הגדרות קיימות)"
+
+#: id:24041
+msgid "Install from zip file"
+msgstr "התקן מקובץ zip"
+
+#: id:24042
+msgid "Downloading %i%%"
+msgstr "מוריד %i%%"
+
+#: id:24043
+msgid "Available Updates"
+msgstr "עדכונים קיימים"
+
+#: id:24044
+msgid "Dependencies not met"
+msgstr "אין התאמה בתלויות"
+
+#: id:24045
+msgid "Add-on does not have the correct structure"
+msgstr "להרחבה אין את המבנה הנכון"
+
+#: id:24046
+msgid "%s is used by the following installed add-on(s)"
+msgstr "%s בשימוש ע\"י ההרחבה/ות המותקנות הבאות"
+
+#: id:24047
+msgid "This add-on cannot be uninstalled"
+msgstr "התקן זה אינו ניתן להסרה"
+
+#: id:24048
+msgid "Rollback"
+msgstr "חזור לאחור"
+
+#: id:24050
+msgid "Available Add-ons"
+msgstr "הרחבות קיימות"
+
+#: id:24051
+msgid "Version:"
+msgstr "גרסה:"
+
+#: id:24052
+msgid "Disclaimer"
+msgstr "הצהרת אחריות"
+
+#: id:24053
+msgid "License:"
+msgstr "רישיון:"
+
+#: id:24054
+msgid "Changelog"
+msgstr "רשימת שינויים"
+
+#: id:24059
+msgid "Would you like to enable this Add-on?"
+msgstr "האם תרצה/י להפעיל הרחבה זו?"
+
+#: id:24060
+msgid "Would you like to disable this Add-on?"
+msgstr "האם תרצה/י לנטרל הרחבה זו?"
+
+#: id:24061
+msgid "Add-on update available!"
+msgstr "יש עדכון להרחבה זו!"
+
+#: id:24062
+msgid "Enabled Add-ons"
+msgstr "הרחבות מופעלות"
+
+#: id:24063
+msgid "Auto update"
+msgstr "עדכון אוטומטי"
+
+#: id:24064
+msgid "Add-on enabled"
+msgstr "הרחבה מופעלת"
+
+#: id:24065
+msgid "Add-on updated"
+msgstr "הרחבה עודכנה"
+
+#: id:24066
+msgid "Cancel Add-on download?"
+msgstr "בטל הורדת הרחבה?"
+
+#: id:24067
+msgid "Currently downloading Add-ons"
+msgstr "בתהליך הורדת הרחבות"
+
+#: id:24068
+msgid "Update available"
+msgstr "קיים עדכון"
+
+#: id:24069
+msgid "Update"
+msgstr "עדכן"
+
+#: id:24070
+msgid "Add-on could not be loaded."
+msgstr "לא ניתן לטעון את ההרחבה"
+
+#: id:24071
+msgid "An unknown error has occurred."
+msgstr "ארעה תקלה בלתי ידועה"
+
+#: id:24072
+msgid "Settings required"
+msgstr "דרושות הגדרות"
+
+#: id:24073
+msgid "Could not connect"
+msgstr "לא מצליח להתחבר"
+
+#: id:24074
+msgid "Needs to restart"
+msgstr "צריך לבצע הפעלה מחדש"
+
+#: id:24075
+msgctxt "Auto context with id 24075"
+msgid "Disable"
+msgstr "נטרל"
+
+#: id:24076
+msgid "Add-on Required"
+msgstr "דרושה הרחבה"
+
+#: id:24080
+msgid "Try to reconnect?"
+msgstr "לנסות להתחבר מחדש?"
+
+#: id:24089
+msgid "Add-on restarts"
+msgstr "ההרחבה מופעלת מחדש"
+
+#: id:24090
+msgid "Lock Add-on manager"
+msgstr "נעל מנהל הרחבות"
+
+#: id:24094
+msgid "(current)"
+msgstr "(נוכחי)"
+
+#: id:24095
+msgid "(blacklisted)"
+msgstr "(רשימה שחורה)"
+
+#: id:24096
+msgid "Add-on has been marked as broken in repository."
+msgstr "ההרחבה מסומנת כלא תקינה במאגר"
+
+#: id:24097
+msgid "Would you like to disable it on your system?"
+msgstr "תרצה לנטרל אותה אצלך במערכת?"
+
+#: id:24098
+msgid "Broken"
+msgstr "לא תקין"
+
+#: id:24099
+msgid "Would you like to switch to this skin?"
+msgstr "תרצה להחליף לסקין זה?"
+
+#: id:24100
+msgid "To use this feature you must download an Add-on:"
+msgstr "לשימוש ביכולת זו עליך להוריד הרחבה:"
+
+#: id:24101
+msgid "Would you like to download this Add-on?"
+msgstr "ברצונך להוריד הרחבה זו?"
+
+#: id:25000
+msgid "Notifications"
+msgstr "הודעות"
+
+#: id:29800
+msgid "Library Mode"
+msgstr "מצב ספריה"
+
+#: id:29801
+msgid "QWERTY keyboard"
+msgstr "מקלדת QWERTY"
+
+#: id:29802
+msgid "Passthrough Audio in use"
+msgstr "שימוש בהעברת קול ישירה (passthrough)"
+
+#: id:33001
+msgid "Trailer quality"
+msgstr "איכות הקדימון"
+
+#: id:33002
+msgid "Stream"
+msgstr "זרימה"
+
+#: id:33003
+msgid "Download"
+msgstr "הורד"
+
+#: id:33004
+msgid "Download & play"
+msgstr "הורד ונגן"
+
+#: id:33005
+msgid "Download & save"
+msgstr "הורד ושמור"
+
+#: id:33006
+msgid "Today"
+msgstr "היום"
+
+#: id:33007
+msgid "Tomorrow"
+msgstr "מחר"
+
+#: id:33008
+msgid "Saving"
+msgstr "שומר"
+
+#: id:33009
+msgid "Copying"
+msgstr "מעתיק"
+
+#: id:33010
+msgid "Set download directory"
+msgstr "הגדר תיקיית הורדות"
+
+#: id:33011
+msgid "Search duration"
+msgstr "חפש אורך"
+
+#: id:33012
+msgid "Short"
+msgstr "קצר"
+
+#: id:33013
+msgid "Long"
+msgstr "ארוך"
+
+#: id:33014
+msgid "Use DVD player instead of regular player"
+msgstr "השתמש בנגן DVD במקום הנגן הרגיל"
+
+#: id:33015
+msgid "Ask for download before playing video"
+msgstr "בקש לשמור לפני נגינת הוידאו"
+
+#: id:33016
+msgid "Clips"
+msgstr "קליפים"
+
+#: id:33017
+msgid "Restart plugin to enable"
+msgstr "הפעל תוסף מחדש כדי להפעיל"
+
+#: id:33018
+msgid "Tonight"
+msgstr "הלילה"
+
+#: id:33019
+msgid "Tomorrow Night"
+msgstr "מחר בלילה"
+
+#: id:33020
+msgid "Condition"
+msgstr "תנאי"
+
+#: id:33021
+msgid "Precipitation"
+msgstr "משקעים"
+
+#: id:33022
+msgid "Precip"
+msgstr "משקעים"
+
+#: id:33023
+msgid "Humid"
+msgstr "לח"
+
+#: id:33024
+msgid "Feels"
+msgstr "מרגיש כמו"
+
+#: id:33025
+msgid "Observed"
+msgstr "ניצפה"
+
+#: id:33026
+msgid "Departure from normal"
+msgstr "פרידה מהרגיל"
+
+#: id:33027
+msgid "Sunrise"
+msgstr "זריחה"
+
+#: id:33028
+msgid "Sunset"
+msgstr "שקיעה"
+
+#: id:33029
+msgid "Details"
+msgstr "פרטים"
+
+#: id:33030
+msgid "Outlook"
+msgstr "השקפה"
+
+#: id:33031
+msgid "Coverflow"
+msgstr "Coverflow"
+
+#: id:33032
+msgid "Translate text"
+msgstr "תרגם טקסט"
+
+#: id:33033
+msgid "Map list %s category"
+msgstr "קטגוריה %s מרשימת המפות"
+
+#: id:33034
+msgid "36 Hour"
+msgstr "36 שעות"
+
+#: id:33035
+msgid "Maps"
+msgstr "מפות"
+
+#: id:33036
+msgid "Hourly"
+msgstr "לפי שעה"
+
+#: id:33037
+msgid "Weekend"
+msgstr "סוף שבוע"
+
+#: id:33038
+msgid "%s day"
+msgstr "יום %s"
+
+#: id:33049
+msgid "Alert"
+msgstr "התראה"
+
+#: id:33050
+msgid "Alerts"
+msgstr "התראות"
+
+#: id:33051
+msgid "Choose Your"
+msgstr "בחר את"
+
+#: id:33052
+msgid "Check"
+msgstr "בדוק"
+
+#: id:33053
+msgctxt "Auto context with id 33053"
+msgid "Configure the"
+msgstr "הגדר את"
+
+#: id:33054
+msgid "Seasons"
+msgstr "עונות"
+
+#: id:33055
+msgid "Use your"
+msgstr "השתמש ב"
+
+#: id:33056
+msgid "Watch your"
+msgstr "תיראה את"
+
+#: id:33057
+msgid "Listen to"
+msgstr "הקשב ל"
+
+#: id:33058
+msgid "View your"
+msgstr "צפה ב"
+
+#: id:33059
+msgctxt "Auto context with id 33059"
+msgid "Configure the"
+msgstr "הגדר את ה"
+
+#: id:33060
+msgid "Power"
+msgstr "הפעלה"
+
+#: id:33061
+msgid "Menu"
+msgstr "תפריט"
+
+#: id:33062
+msgid "Play the"
+msgstr "נגן את ה"
+
+#: id:33063
+msgid "Options"
+msgstr "אפשרויות"
+
+#: id:33065
+msgid "Editor"
+msgstr "עורך"
+
+#: id:33066
+msgid "About your"
+msgstr "אודות ה"
+
+#: id:33067
+msgid "Star rating"
+msgstr "כוכבי דירוג"
+
+#: id:33068
+msgid "Background"
+msgstr "רקע"
+
+#: id:33069
+msgid "Backgrounds"
+msgstr "רקעים"
+
+#: id:33070
+msgid "Custom background"
+msgstr "רקע מותאם אישית"
+
+#: id:33071
+msgid "Custom backgrounds"
+msgstr "רקעים מותאמים אישית"
+
+#: id:33072
+msgid "View Readme"
+msgstr "צפה בקובץ README"
+
+#: id:33073
+msgid "View Changelog"
+msgstr "צפה בקובץ שינויים"
+
+#: id:33074
+msgid "This version of %s requires an"
+msgstr "גרסה זו של %s דורשת"
+
+#: id:33075
+msgid "XBMC revision of %s or greater to run."
+msgstr "דרושה גרסה %s של XBMC או יותר כדי לרוץ"
+
+#: id:33076
+msgid "Please update XBMC."
+msgstr "אנא עדכן את XBMC."
+
+#: id:33077
+msgid "No data found!"
+msgstr "לא נמצאו פרטים!"
+
+#: id:33078
+msgid "Next page"
+msgstr "עמוד הבא"
+
+#: id:33079
+msgid "Love"
+msgstr "אוהב"
+
+#: id:33080
+msgid "Hate"
+msgstr "שונא"
+
+#: id:33081
+msgid "This file is stacked, select the part you want to play from."
+msgstr "קובץ זה שייך לערמה. בחר נקודת התחלה"
+
+#: id:33082
+msgid "Path to script"
+msgstr "נתיב לסקריפט"
+
+#: id:33083
+msgid "Enable custom script button"
+msgstr "הפעל כפתור סקריפט מותאם אישית"
+
+#: id:33100
+msgid "Failed to start"
+msgstr "אתחול נכשל"
+
+#: id:33101
+msgid "Webserver"
+msgstr "שרת"
+
+#: id:33102
+msgid "Event Server"
+msgstr "Event Server"
+
+#: id:33103
+msgid "Remote communication server"
+msgstr "שרת התחברות מרחוק"
+
+#: id:33200
+msgid "Detected New Connection"
+msgstr "זוהה חיבור חדש"
+
+#: id:34000
+msgid "Lame"
+msgstr "Lame"
+
+#: id:34001
+msgid "Vorbis"
+msgstr "Vorbis"
+
+#: id:34002
+msgid "Wav"
+msgstr "Wav"
+
+#: id:34003
+msgid "DXVA2"
+msgstr "DXVA2"
+
+#: id:34004
+msgid "VAAPI"
+msgstr "VAAPI"
+
+#: id:34005
+msgid "Flac"
+msgstr "Flac"
+
+#: id:34100
+msgid "Speaker Configuration"
+msgstr "תצורת רמקול"
+
+#: id:34101
+msgid "2.0"
+msgstr "2.0"
+
+#: id:34102
+msgid "2.1"
+msgstr "2.1"
+
+#: id:34103
+msgid "3.0"
+msgstr "3.0"
+
+#: id:34104
+msgid "3.1"
+msgstr "3.1"
+
+#: id:34105
+msgid "4.0"
+msgstr "4.0"
+
+#: id:34106
+msgid "4.1"
+msgstr "4.1"
+
+#: id:34107
+msgid "5.0"
+msgstr "5.0"
+
+#: id:34108
+msgid "5.1"
+msgstr "5.1"
+
+#: id:34109
+msgid "7.0"
+msgstr "7.0"
+
+#: id:34110
+msgid "7.1"
+msgstr "7.1"
+
+#: id:34201
+msgid "Can't find a next item to play"
+msgstr "לא נמצא פריט הבא לניגון"
+
+#: id:34202
+msgid "Can't find a previous item to play"
+msgstr "לא נמצא הפריט הקודם לניגון"
+
+#: id:34300
+msgid "Failed to start zeroconf"
+msgstr "נכשל בהפעלת zeroconf"
+
+#: id:34301
+msgid "Is Apple's Bonjour Service installed? See log for more info."
+msgstr "האם שירות Apple's Bonjour מותקן? ראה לוג למידע נוסף"
+
+#: id:34400
+msgid "Video Rendering"
+msgstr "עיבוד וידאו"
+
+#: id:34401
+msgid "Failed to init video filters/scalers, falling back to bilinear scaling"
+msgstr ""
+
+#: id:34402
+msgid "Failed to initialize audio device"
+msgstr "נכשל בהפעלת התקן האודיו"
+
+#: id:34403
+msgid "Check your audiosettings"
+msgstr "בדוק הגדרות אודיו"
+
+#: id:34404
+msgid "Use gestures for navigation:"
+msgstr ""
+
+#: id:34405
+msgid "1 finger swipe left,right,up,down for cursors"
+msgstr ""
+
+#: id:34406
+msgid "2 finger swipe left for backspace"
+msgstr ""
+
+#: id:34407
+msgid "1 finger single tap for enter"
+msgstr ""
+
+#: id:34408
+msgid "2 finger single tap for contextmenu"
+msgstr ""
+
+#: id:35000
+msgid "Peripherals"
+msgstr "ציוד היקפי"
+
+#: id:35001
+msgid "Generic HID device"
+msgstr "התקן HID כללי"
+
+#: id:35002
+msgid "Generic network adapter"
+msgstr "מתאם רשת כללי"
+
+#: id:35003
+msgid "Generic disk"
+msgstr "דיסק כללי"
+
+#: id:35004
+msgid "There are no settings available\nfor this peripheral."
+msgstr "אין הגדרות להתקן זה"
+
+#: id:35005
+msgid "New device configured"
+msgstr "התקן חדש הוגדר"
+
+#: id:35006
+msgid "Device removed"
+msgstr "התקן הוסר"
+
+#: id:35007
+msgid "Keymap to use for this device"
+msgstr ""
+
+#: id:35008
+msgid "Keymap enabled"
+msgstr "Keymap פעיל"
+
+#: id:35009
+msgid "Do not use the custom keymap for this device"
+msgstr "אל תשתמש ב 'keymap' מותאם אישית להתקן זה"
+
+#: id:35500
+msgid "Location"
+msgstr "מיקום"
+
+#: id:35501
+msgid "Class"
+msgstr "מחלקה"
+
+#: id:35502
+msgctxt "Auto context with id 35502"
+msgid "Name"
+msgstr "שם"
+
+#: id:35503
+msgid "Vendor"
+msgstr "ספק"
+
+#: id:35504
+msgid "Product ID"
+msgstr "מוצר ID"
+
+#: id:36000
+msgid "Pulse-Eight CEC adapter"
+msgstr ""
+
+#: id:36001
+msgid "Pulse-Eight Nyxboard"
+msgstr ""
+
+#: id:36002
+msgid "Switch to keyboard side command"
+msgstr ""
+
+#: id:36003
+msgid "Switch to remote side command"
+msgstr ""
+
+#: id:36004
+msgid "Press \"user\" button command"
+msgstr ""
+
+#: id:36005
+msgid "Enable switch side commands"
+msgstr ""
+
+#: id:36006
+msgid "Could not open the adapter"
+msgstr "אין אפשרות לפתוח מתאם"
+
+#: id:36007
+msgid "Devices to power on when starting XBMC"
+msgstr "התקנים אשר יפעלו כאשר מפעילים את XBMC"
+
+#: id:36008
+msgid "Devices to power off when stopping XBMC"
+msgstr "התקנים אשר יכבו כאשר מפסיקים את XBMC"
+
+#: id:36009
+msgid "Put devices in standby mode when activating screensaver"
+msgstr "הכנס את ההתקנים למצב שינה כאשר מפעילים שומר מסך"
+
+#: id:36011
+msgid "Could not detect the CEC port. Set it up manually."
+msgstr "אין אפשרות לזהות פורט CEC. הגדר זאת ידנית."
+
+#: id:36012
+msgid "Could not initialise the CEC adapter. Check your settings."
+msgstr "אין אפשרות לאתחל מתאם CEC. בדוק את ההגדרות שלך"
+
+#: id:36013
+msgid "Unsupported libCEC interface version. %d is greater than the version XBMC supports (%d)"
+msgstr "ממשק libCEC לא נתמך. %d גדול יותר מאשר הגרסא ש- XBMC תומך (%d)"
+
+#: id:36014
+msgid "Put this PC in standby mode when the TV is switched off"
+msgstr "הכנס את המחשב למצב המתנה כאשר הטלוויזיה נכבית"
+
+#: id:36015
+msgid "HDMI port number"
+msgstr "מספר פורט HDMI"
+
+#: id:36016
+msgctxt "Auto context with id 36016"
+msgid "Connected"
+msgstr "מחובר"
+
+#: id:36017
+msgid "Adapter found, but libCEC is not available"
+msgstr "מתאם נמצא. אבל libCEC לא זמין"
+
+#: id:36018
+msgid "Use the TV's language setting"
+msgstr "השתמש בהגדרות שפה של הטלוויזיה"
+
+#: id:36019
+msgid "Connected to HDMI device"
+msgstr "מחובר להתקן HDMI"
+
+#: id:36020
+msgid "Make XBMC the active source when starting"
+msgstr "הפוך את XBMC למקור הפעיל כאשר מפעילים"
+
+#: id:36021
+msgid "Physical address (overrules HDMI port)"
+msgstr "כתובת פיזית (מבטל יציאת HDMI)"
+
+#: id:36022
+msgid "COM port (leave empty unless needed)"
+msgstr "יציאת COM (השאר ריק אלא אם יש צורך)"
+
+#: id:36023
+msgid "Configuration updated"
+msgstr "תצורה עודכנה"
+
+#: id:36024
+msgid "Failed to set the new configuration. Please check your settings."
+msgstr "נכשל בהגדרת תצורה חדשה. אנא בדוק את ההגדרות שלך."
+
+#: id:36025
+msgid "Send 'inactive source' command when stopping XBMC"
+msgstr "שלח פקודת 'מקור לא פעיל' כאשר עוצרים את XBMC"
+

--- a/language/Hindi (Devanagiri)/strings.po
+++ b/language/Hindi (Devanagiri)/strings.po
@@ -1,0 +1,9093 @@
+# Converted from xbmc strings.xml with xbmc-xml2po (by Team-XBMC)
+msgid ""
+msgstr ""
+"Project-Id-Version: xbmc.core-FRODO_GIT3ed1604ad7\n"
+"Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
+"POT-Creation-Date: 2012-04-09 18:00+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE\n"
+"Language: hi\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: id:0
+msgctxt "Auto context with id 0"
+msgid "Programs"
+msgstr "करिअक्रम"
+
+#: id:1
+msgctxt "Auto context with id 1"
+msgid "Pictures"
+msgstr "तसवीरें"
+
+#: id:2
+msgctxt "Auto context with id 2"
+msgid "Music"
+msgstr "संगीत"
+
+#: id:3
+msgctxt "Auto context with id 3"
+msgid "Videos"
+msgstr "विडियो"
+
+#: id:4
+msgid "TV-Guide"
+msgstr "टीवी-गइड"
+
+#: id:5
+msgctxt "Auto context with id 5"
+msgid "Settings"
+msgstr "सेट्टिंग"
+
+#: id:6
+msgid "XBMC SVN"
+msgstr "XBMC स्वं"
+
+#: id:7
+msgctxt "Auto context with id 7"
+msgid "File manager"
+msgstr "File मेनेजर"
+
+#: id:8
+msgctxt "Auto context with id 8"
+msgid "Weather"
+msgstr "मौसम"
+
+#: id:9
+msgid "xbmc media center"
+msgstr "क्स्बम्क मीडिया प्लयेर"
+
+#: id:11
+msgid "Monday"
+msgstr "सोमवार"
+
+#: id:12
+msgid "Tuesday"
+msgstr "मंगलवार"
+
+#: id:13
+msgid "Wednesday"
+msgstr "बुधवार"
+
+#: id:14
+msgid "Thursday"
+msgstr "गुरूवार"
+
+#: id:15
+msgid "Friday"
+msgstr "शुक्रवार"
+
+#: id:16
+msgid "Saturday"
+msgstr "शनिवार"
+
+#: id:17
+msgid "Sunday"
+msgstr "रविवार"
+
+#: id:21
+msgid "January"
+msgstr "जनुअरी"
+
+#: id:22
+msgid "February"
+msgstr "फेब्रुअरी"
+
+#: id:23
+msgid "March"
+msgstr "मार्च"
+
+#: id:24
+msgid "April"
+msgstr "अप्रैल"
+
+#: id:25
+msgctxt "Auto context with id 25"
+msgid "May"
+msgstr "माय"
+
+#: id:26
+msgid "June"
+msgstr "जून"
+
+#: id:27
+msgid "July"
+msgstr "जुलाई"
+
+#: id:28
+msgid "August"
+msgstr "अगस्त"
+
+#: id:29
+msgid "September"
+msgstr "सितम्बर"
+
+#: id:30
+msgid "October"
+msgstr "अक्टूबर"
+
+#: id:31
+msgid "November"
+msgstr "नवम्बर"
+
+#: id:32
+msgid "December"
+msgstr "दिसम्बर"
+
+#: id:41
+msgid "Mon"
+msgstr "मों."
+
+#: id:42
+msgid "Tue"
+msgstr "तुए."
+
+#: id:43
+msgid "Wed"
+msgstr "वेद"
+
+#: id:44
+msgid "Thu"
+msgstr "ठुर्स"
+
+#: id:45
+msgid "Fri"
+msgstr "फ्री"
+
+#: id:46
+msgid "Sat"
+msgstr "सैट"
+
+#: id:47
+msgctxt "Auto context with id 47"
+msgid "Sun"
+msgstr "सुन"
+
+#: id:51
+msgid "Jan"
+msgstr "जन"
+
+#: id:52
+msgid "Feb"
+msgstr "फेब"
+
+#: id:53
+msgid "Mar"
+msgstr "मार्च"
+
+#: id:54
+msgid "Apr"
+msgstr "अपर"
+
+#: id:55
+msgctxt "Auto context with id 55"
+msgid "May"
+msgstr "माय"
+
+#: id:56
+msgid "Jun"
+msgstr "जून"
+
+#: id:57
+msgid "Jul"
+msgstr "जुलाई"
+
+#: id:58
+msgid "Aug"
+msgstr "औग"
+
+#: id:59
+msgid "Sep"
+msgstr "सप्त"
+
+#: id:60
+msgid "Oct"
+msgstr "ओक्ट"
+
+#: id:61
+msgid "Nov"
+msgstr "नोव"
+
+#: id:62
+msgid "Dec"
+msgstr "देक"
+
+#: id:71
+msgid "N"
+msgstr ""
+
+#: id:72
+msgid "NNE"
+msgstr ""
+
+#: id:73
+msgid "NE"
+msgstr ""
+
+#: id:74
+msgid "ENE"
+msgstr ""
+
+#: id:75
+msgid "E"
+msgstr ""
+
+#: id:76
+msgid "ESE"
+msgstr ""
+
+#: id:77
+msgid "SE"
+msgstr ""
+
+#: id:78
+msgid "SSE"
+msgstr ""
+
+#: id:79
+msgid "S"
+msgstr ""
+
+#: id:80
+msgid "SSW"
+msgstr ""
+
+#: id:81
+msgid "SW"
+msgstr ""
+
+#: id:82
+msgid "WSW"
+msgstr ""
+
+#: id:83
+msgid "W"
+msgstr ""
+
+#: id:84
+msgid "WNW"
+msgstr ""
+
+#: id:85
+msgid "NW"
+msgstr ""
+
+#: id:86
+msgid "NNW"
+msgstr ""
+
+#: id:87
+msgid "VAR"
+msgstr ""
+
+#: id:98
+msgid "View: Auto"
+msgstr "द्रिस्तिकों: ऑटो"
+
+#: id:99
+msgid "View: Auto big"
+msgstr "द्रिस्तिकों: स्वचालित बड़ा"
+
+#: id:100
+msgid "View: Icons"
+msgstr "द्रिस्तिकों: चित्रें"
+
+#: id:101
+msgid "View: List"
+msgstr "द्रिस्तिकों: लिस्ट"
+
+#: id:102
+msgctxt "Auto context with id 102"
+msgid "Scan"
+msgstr "सकें"
+
+#: id:103
+msgctxt "Auto context with id 103"
+msgid "Sort by: Name"
+msgstr "रकाना: नाम"
+
+#: id:104
+msgid "Sort by: Date"
+msgstr "रकाना: तारीख"
+
+#: id:105
+msgid "Sort by: Size"
+msgstr "रकाना: लम्बाई"
+
+#: id:106
+msgid "No"
+msgstr "नहीं"
+
+#: id:107
+msgid "Yes"
+msgstr "टेके"
+
+#: id:108
+msgctxt "Auto context with id 108"
+msgid "Slideshow"
+msgstr "फोटो जो फिल्म पर हो"
+
+#: id:109
+msgid "Create thumbs"
+msgstr "निर्माण करना अन्गुतियाँ"
+
+#: id:110
+msgid "Create thumbnails"
+msgstr "निर्माण करना अंगूठे का नाखुन"
+
+#: id:111
+msgctxt "Auto context with id 111"
+msgid "Shortcuts"
+msgstr "लघु पाथें"
+
+#: id:112
+msgid "Paused"
+msgstr "अवकासा"
+
+#: id:113
+msgid "Update failed"
+msgstr "अद्यातानिकराना हर गया"
+
+#: id:114
+msgid "Installation failed"
+msgstr "अधिस्थापना हर गया"
+
+#: id:115
+msgid "Copy"
+msgstr "निकल करना"
+
+#: id:116
+msgid "Move"
+msgstr "हटाना"
+
+#: id:117
+msgid "Delete"
+msgstr "मिटाना"
+
+#: id:118
+msgid "Rename"
+msgstr "नया नामा रखना"
+
+#: id:119
+msgid "New folder"
+msgstr "नया फोल्डर"
+
+#: id:120
+msgid "Confirm file copy"
+msgstr "पक्का करना फाइल नक़ल करना"
+
+#: id:121
+msgid "Confirm file move"
+msgstr "पक्का करना फाइल हटाना"
+
+#: id:122
+msgid "Confirm file delete?"
+msgstr "पक्का करना फाइल मिटाना?"
+
+#: id:123
+msgid "Copy these files?"
+msgstr "निकल करना ये फिल्स"
+
+#: id:124
+msgid "Move these files?"
+msgstr "ये निकल करना है?"
+
+#: id:125
+msgid "Delete these files? - Deleting files cannot be undone!"
+msgstr "Yये फिल्स मिटाना है? - ये फिल्स पीर मिटाना"
+
+#: id:126
+msgid "Status"
+msgstr "हालात"
+
+#: id:127
+msgid "Objects"
+msgstr "वस्तुएं"
+
+#: id:128
+msgctxt "Auto context with id 128"
+msgid "General"
+msgstr "साधारनन"
+
+#: id:129
+msgctxt "Auto context with id 129"
+msgid "Slideshow"
+msgstr "फोटो जो फिल्म पर हो"
+
+#: id:130
+msgctxt "Auto context with id 130"
+msgid "System info"
+msgstr "सिस्टम की सुकाना"
+
+#: id:131
+msgid "Display"
+msgstr "दिखावा"
+
+#: id:132
+msgid "Albums"
+msgstr "अल्बुम्स"
+
+#: id:133
+msgid "Artists"
+msgstr "कलाकार"
+
+#: id:134
+msgid "Songs"
+msgstr "गीतें"
+
+#: id:135
+msgid "Genres"
+msgstr "तरीका"
+
+#: id:136
+msgid "Playlists"
+msgstr "संगीता के किनारा"
+
+#: id:137
+msgid "Search"
+msgstr "धुन्धना"
+
+#: id:138
+msgid "System Information"
+msgstr "सिस्टम की सुकाना"
+
+#: id:139
+msgid "Temperatures:"
+msgstr "तापमान:"
+
+#: id:140
+msgid "CPU:"
+msgstr ""
+
+#: id:141
+msgid "GPU:"
+msgstr ""
+
+#: id:142
+msgid "Time:"
+msgstr "वक्त:"
+
+#: id:143
+msgid "Current:"
+msgstr "वर्तमाना:"
+
+#: id:144
+msgid "Build:"
+msgstr ""
+
+#: id:145
+msgid "Network:"
+msgstr ""
+
+#: id:146
+msgid "Type:"
+msgstr ""
+
+#: id:147
+msgid "Static"
+msgstr ""
+
+#: id:148
+msgid "DHCP"
+msgstr ""
+
+#: id:149
+msgid "MAC address"
+msgstr ""
+
+#: id:150
+msgctxt "Auto context with id 150"
+msgid "IP address"
+msgstr ""
+
+#: id:151
+msgid "Link:"
+msgstr ""
+
+#: id:152
+msgid "Half duplex"
+msgstr ""
+
+#: id:153
+msgid "Full duplex"
+msgstr ""
+
+#: id:154
+msgctxt "Auto context with id 154"
+msgid "Storage"
+msgstr "संन्कायाना"
+
+#: id:155
+msgid "Drive"
+msgstr "ड्रिवे"
+
+#: id:156
+msgctxt "Auto context with id 156"
+msgid "Free"
+msgstr "कलि जग्गा"
+
+#: id:157
+msgctxt "Auto context with id 157"
+msgid "Video"
+msgstr "विडियो"
+
+#: id:158
+msgid "Free memory"
+msgstr "पूरा मेमोरी"
+
+#: id:159
+msgid "No link"
+msgstr "कोई लिंक नहीं"
+
+#: id:160
+msgctxt "Auto context with id 160"
+msgid "Free"
+msgstr "कलि जग्गा"
+
+#: id:161
+msgid "Unavailable"
+msgstr "उनवैलाब्ले"
+
+#: id:162
+msgid "Tray open"
+msgstr "कद त्रय कुला है"
+
+#: id:163
+msgid "Reading"
+msgstr "पर रहा है"
+
+#: id:164
+msgid "No disc"
+msgstr "कद अंधार नहीं"
+
+#: id:165
+msgid "Disc present"
+msgstr "कद अंधार है"
+
+#: id:166
+msgid "Skin"
+msgstr "विषय"
+
+#: id:169
+msgctxt "Auto context with id 169"
+msgid "Resolution"
+msgstr "संकल्प"
+
+#: id:170
+msgid "Adjust display refresh rate to match video"
+msgstr "ताज़ा करने के लिए वीडियो मैच दर प्रदर्शित करने के लिए समायोजित करें"
+
+#: id:172
+msgid "Release date"
+msgstr "पहला प्रदर्सन"
+
+#: id:173
+msgid "Display 4:3 videos as"
+msgstr "4:3 विडोस दिखने केलिए"
+
+#: id:175
+msgid "Moods"
+msgstr "स्वभावें"
+
+#: id:176
+msgid "Styles"
+msgstr "प्रकारें"
+
+#: id:179
+msgid "Song"
+msgstr "संगीता"
+
+#: id:180
+msgid "Duration"
+msgstr "अवधि"
+
+#: id:181
+msgid "Select album"
+msgstr "एल्बम चुन्लेना"
+
+#: id:182
+msgid "Tracks"
+msgstr "रास्तें"
+
+#: id:183
+msgid "Review"
+msgstr "सर्वेक्सना"
+
+#: id:184
+msgid "Refresh"
+msgstr "फिरा से भरना"
+
+#: id:185
+msgid "Searching album"
+msgstr "एल्बम धुंद रहा है"
+
+#: id:186
+msgid "OK"
+msgstr "टेके"
+
+#: id:187
+msgid "No albums found!"
+msgstr "कोई एल्बम मिला नहीं"
+
+#: id:188
+msgid "Select all"
+msgstr "पूरा चुन्लेना"
+
+#: id:189
+msgid "Scanning media info"
+msgstr "परिक्सन करना मीडिया की सुकाना"
+
+#: id:190
+msgid "Save"
+msgstr "बचाना"
+
+#: id:191
+msgid "Shuffle"
+msgstr "शुफ्फ्ले"
+
+#: id:192
+msgctxt "Auto context with id 192"
+msgid "Clear"
+msgstr "निपटाना"
+
+#: id:193
+msgctxt "Auto context with id 193"
+msgid "Scan"
+msgstr "बारीकी से देखना"
+
+#: id:194
+msgid "Searching..."
+msgstr "धुंद रहा है..."
+
+#: id:195
+msgid "No info found!"
+msgstr "कोई सुकाना मिला नहीं!"
+
+#: id:196
+msgid "Select movie:"
+msgstr "फिल्म चुन्लेना:"
+
+#: id:197
+msgid "Querying %s info"
+msgstr "लोकेटिंग % सुकाना"
+
+#: id:198
+msgid "Loading movie details"
+msgstr "भरना फिल्म की सुकाना"
+
+#: id:199
+msgid "Web interface"
+msgstr "इन्टरनेट की अंतराप्र्स्था"
+
+#: id:202
+msgid "Tagline"
+msgstr "ताग्लिने"
+
+#: id:203
+msgid "Plot outline"
+msgstr "कथावस्तु की सीमा"
+
+#: id:205
+msgid "Votes"
+msgstr "मतदानें"
+
+#: id:206
+msgid "Cast"
+msgstr "फिल्म की नादानोंं"
+
+#: id:207
+msgid "Plot"
+msgstr "कथावस्तु"
+
+#: id:208
+msgctxt "Auto context with id 208"
+msgid "Play"
+msgstr "खेलना"
+
+#: id:209
+msgid "Next"
+msgstr "अगला"
+
+#: id:210
+msgid "Previous"
+msgstr "पूर्ववर्ती"
+
+#: id:213
+msgid "Calibrate user interface..."
+msgstr "उपयोगकर्ता इन्तेर्फास जन्न्काना..."
+
+#: id:214
+msgid "Video calibration..."
+msgstr "फिल्म की अन्सोधना..."
+
+#: id:215
+msgid "Soften"
+msgstr "कोमला करना या होना"
+
+#: id:216
+msgid "Zoom amount"
+msgstr "जूम की मात्र"
+
+#: id:217
+msgid "Pixel ratio"
+msgstr "पिक्सेल अनुपात"
+
+#: id:218
+msgid "DVD drive"
+msgstr "DVD की ड्रिवे"
+
+#: id:219
+msgid "Please insert disc"
+msgstr "डिस्क समिलिता करने के लिए क्रपया"
+
+#: id:220
+msgid "Remote share"
+msgstr "रेमोते शेयर"
+
+#: id:221
+msgid "Network is not connected"
+msgstr "नेटवर्क से जुरा नहीं है"
+
+#: id:222
+msgid "Cancel"
+msgstr "कटना"
+
+#: id:224
+msgid "Speed"
+msgstr "गति"
+
+#: id:225
+msgid "Vertical Shift"
+msgstr ""
+
+#: id:226
+msgid "Test patterns..."
+msgstr "अभ्यासें टेस्ट पत्तेर्न्स..."
+
+#: id:227
+msgid "Lookup audio CD track names from freedb.org"
+msgstr "Freedb.Org से ऑडियो CD ट्रैक नाम लुकापा"
+
+#: id:228
+msgid "Shuffle playlist on load"
+msgstr "शुफ्फ्ले प्लेलिस्ट परा निवेसा"
+
+#: id:229
+msgid "HDD spindown time"
+msgstr "HDD स्पिन्दोवं वक्त"
+
+#: id:230
+msgid "Video filters"
+msgstr "विडियो की सफें"
+
+#: id:231
+msgctxt "Auto context with id 231"
+msgid "None"
+msgstr "कोई नहीं"
+
+#: id:232
+msgid "Point"
+msgstr "पॉइंट"
+
+#: id:233
+msgid "Linear"
+msgstr ""
+
+#: id:234
+msgid "Anisotropic"
+msgstr ""
+
+#: id:235
+msgid "Quincunx"
+msgstr ""
+
+#: id:236
+msgid "Gaussian cubic"
+msgstr ""
+
+#: id:237
+msgid "Minification"
+msgstr ""
+
+#: id:238
+msgid "Magnification"
+msgstr ""
+
+#: id:239
+msgid "Clear playlist on finish"
+msgstr "खत्म परा सफा प्लेलिस्ट"
+
+#: id:240
+msgid "Display Mode"
+msgstr "डिस्प्ले अंदाजा"
+
+#: id:241
+msgid "Full Screen #%d"
+msgstr "पूर्ण स्क्रीन #%d"
+
+#: id:242
+msgid "Windowed"
+msgstr "विन्दोवेद"
+
+#: id:243
+msgid "Refresh Rate"
+msgstr "तरोताजा करना की डरा"
+
+#: id:244
+msgid "Full screen"
+msgstr "पूर्ण स्क्रीन"
+
+#: id:245
+msgid "Sizing: (%i,%i)->(%i,%i) (Zoom x%2.2f) AR:%2.2f:1 (Pixels: %2.2f:1) (VShift: %2.2f)"
+msgstr ""
+
+#: id:247
+msgctxt "Auto context with id 247"
+msgid "Scripts"
+msgstr "अलेक्हें"
+
+#: id:248
+msgctxt "Auto context with id 248"
+msgid "Language"
+msgstr "बाशा"
+
+#: id:249
+msgctxt "Auto context with id 249"
+msgid "Music"
+msgstr "संगीतें"
+
+#: id:250
+msgctxt "Auto context with id 250"
+msgid "Visualization"
+msgstr "कल्पना"
+
+#: id:251
+msgid "Select destination directory"
+msgstr "चुन्लेना अभिप्राय की निदेशिका"
+
+#: id:252
+msgid "Output stereo to all speakers"
+msgstr "ओउत्पुत सभी वक्तों करने के लिए स्तेरेओ"
+
+#: id:253
+msgid "Number of channels"
+msgstr "मर्गें की संख्या"
+
+#: id:254
+msgid "- DTS capable receiver"
+msgstr ""
+
+#: id:255
+msgid "CDDB"
+msgstr ""
+
+#: id:256
+msgid "Fetching CD information"
+msgstr "CD की सुकाना धुंद रहा है"
+
+#: id:257
+msgid "Error"
+msgstr "एर्रोर"
+
+#: id:258
+msgid "Enable tag reading"
+msgstr "एनाबले ताग रेअडिंग"
+
+#: id:259
+msgid "Opening"
+msgstr "डिस्क उद्घताना"
+
+#: id:260
+msgid "Shoutcast"
+msgstr "शौत्कास्त"
+
+#: id:261
+msgid "Waiting for start..."
+msgstr "प्रस्थान रोका देना रहा है..."
+
+#: id:262
+msgid "Scripts output"
+msgstr ""
+
+#: id:263
+msgid "Allow control of XBMC via HTTP"
+msgstr "XBMC की नियंत्रण घराना विया HTTP"
+
+#: id:264
+msgid "Record"
+msgstr "लिखना"
+
+#: id:265
+msgid "Stop Rec."
+msgstr "अभिलेखिना रोकना"
+
+#: id:266
+msgid "Sort by: Track"
+msgstr "रकाना: तरीका"
+
+#: id:267
+msgid "Sort by: Time"
+msgstr "रकाना: वक्त"
+
+#: id:268
+msgid "Sort by: Title"
+msgstr "रकाना: नाम"
+
+#: id:269
+msgid "Sort by: Artist"
+msgstr "रकाना: कलाकार"
+
+#: id:270
+msgid "Sort by: Album"
+msgstr "रकाना: एल्बम"
+
+#: id:271
+msgid "Top 100"
+msgstr "मुख्य 100"
+
+#: id:272
+msgid "Top-Left overscan compensation"
+msgstr "टॉप-लेफ्ट ओवेर्स्कां कोम्पेन्सतिओन"
+
+#: id:273
+msgid "Bottom-Right overscan compensation"
+msgstr "बोत्तोम-राईट ओवेर्स्कां कोम्पेन्सतिओन"
+
+#: id:274
+msgid "Subtitle positioning"
+msgstr "उपसिर्सका स्थापना"
+
+#: id:275
+msgid "Pixel ratio adjustment"
+msgstr "पिक्सेल रतियो समाधान"
+
+#: id:276
+msgid "Adjust the arrow to change the amount of overscan"
+msgstr "तीर समायोजित करने के लिए ओवेर्स्कां की रासी परिवर्तन"
+
+#: id:277
+msgid "Adjust the bar to change the subtitles position"
+msgstr "बार समायोजित करने के लिए उपसिर्सका स्थिति को बदलने"
+
+#: id:278
+msgid "Adjust the rectangle so it is perfectly square"
+msgstr "यता समायोजित करने तो यहाँ पूरी तरह से वर्ग है"
+
+#: id:279
+msgid "Unable to load settings"
+msgstr "उनबले तो लोड सेत्तिंग्स"
+
+#: id:280
+msgid "Using default settings"
+msgstr "डिफ़ॉल्ट सेटिंग्स का उपयोग करना"
+
+#: id:281
+msgid "Please check the XML files"
+msgstr "XML फ़ाइलों की जाँच करें"
+
+#: id:282
+msgid "Found %i items"
+msgstr "मिला %मैं आइटम"
+
+#: id:283
+msgid "Search results"
+msgstr "परिणाम की असरें"
+
+#: id:284
+msgid "No results found"
+msgstr "कोई परिणाम नहीं मिले"
+
+#: id:287
+msgctxt "Auto context with id 287"
+msgid "Subtitles"
+msgstr "उपसिर्सकें"
+
+#: id:288
+msgctxt "Auto context with id 288"
+msgid "Font"
+msgstr "अक्सर"
+
+#: id:289
+msgctxt "Auto context with id 289"
+msgid "- Size"
+msgstr "- अकारण"
+
+#: id:290
+msgid "Dynamic range compression"
+msgstr ""
+
+#: id:291
+msgctxt "Auto context with id 291"
+msgid "Video"
+msgstr "विडियो"
+
+#: id:292
+msgctxt "Auto context with id 292"
+msgid "Audio"
+msgstr "श्रव्य"
+
+#: id:293
+msgid "Browse for subtitles"
+msgstr "उपसिर्सका की चुगना"
+
+#: id:294
+msgid "Create bookmark"
+msgstr "प्रस्थ स्मरति तैयार करना"
+
+#: id:296
+msgid "Clear bookmarks"
+msgstr "प्रस्थ स्मरति स्वीकरता करना"
+
+#: id:297
+msgid "Audio offset"
+msgstr "श्रव्य ओफ्फ्सेट"
+
+#: id:298
+msgid "Bookmarks"
+msgstr "प्रस्थ स्मरति"
+
+#: id:299
+msgid "- AAC capable receiver"
+msgstr ""
+
+#: id:300
+msgid "- MP1 capable receiver"
+msgstr ""
+
+#: id:301
+msgid "- MP2 capable receiver"
+msgstr ""
+
+#: id:302
+msgid "- MP3 capable receiver"
+msgstr "- MP3 कापबले रिसीवर"
+
+#: id:303
+msgid "Delay"
+msgstr "टालना"
+
+#: id:304
+msgctxt "Auto context with id 304"
+msgid "Language"
+msgstr "भाषा"
+
+#: id:305
+msgctxt "Auto context with id 305"
+msgid "Enabled"
+msgstr "एनाब्लेद"
+
+#: id:306
+msgid "Non-interleaved"
+msgstr "नॉन-इन्तेर्लेअवेद"
+
+#: id:312
+msgid "(0=auto)"
+msgstr ""
+
+#: id:313
+msgid "Cleaning database"
+msgstr "अंकारा अधर धोना रहा है"
+
+#: id:314
+msgid "Preparing..."
+msgstr "पकाना रहा है..."
+
+#: id:315
+msgid "Database error"
+msgstr "अंकारा अधर की एर्रोर"
+
+#: id:316
+msgid "Searching songs..."
+msgstr "संगीतें धोना रहा है"
+
+#: id:317
+msgid "Cleaned database successfully"
+msgstr "साफ सफलतापूर्वक डेटाबेस"
+
+#: id:318
+msgid "Cleaning songs..."
+msgstr "संगीतें धोना रहा है..."
+
+#: id:319
+msgid "Error cleaning songs"
+msgstr "संगीतें की धोना एर्रोर"
+
+#: id:320
+msgid "Cleaning artists..."
+msgstr "कलाकार धोना रहा है..."
+
+#: id:321
+msgid "Error cleaning artists"
+msgstr "कलाकार की धोना एर्रोर"
+
+#: id:322
+msgid "Cleaning genres..."
+msgstr "प्रकारें धोना रहा है"
+
+#: id:323
+msgid "Error cleaning genres"
+msgstr "प्रकारें की धोना एर्रोर"
+
+#: id:324
+msgid "Cleaning paths..."
+msgstr "क्लेअनिंग पठस..."
+
+#: id:325
+msgid "Error cleaning paths"
+msgstr "एर्रोर क्लेअनिंग पठस"
+
+#: id:326
+msgid "Cleaning albums..."
+msgstr "क्लेअनिंग अल्बुम्स..."
+
+#: id:327
+msgid "Error cleaning albums"
+msgstr "एर्रोर क्लेअनिंग अल्बुम्स"
+
+#: id:328
+msgid "Writing changes..."
+msgstr "व्रितिंग चंगेस..."
+
+#: id:329
+msgid "Error writing changes"
+msgstr "लिखने में त्रुटि परिवर्तन"
+
+#: id:330
+msgid "This may take some time..."
+msgstr "यह कुछ समय लग सकता है ..."
+
+#: id:331
+msgid "Compressing database..."
+msgstr "डेटाबेस संपीड़ित ..."
+
+#: id:332
+msgid "Error compressing database"
+msgstr "त्रुटि कोम्प्रेस्सिंग डेटाबेस"
+
+#: id:333
+msgid "Do you want to clean the library?"
+msgstr "क्या आप पुस्तकालय साफ़ करना चाहेंगे?"
+
+#: id:334
+msgid "Clean library..."
+msgstr "साफ़ पुस्तकालय ..."
+
+#: id:335
+msgid "Start"
+msgstr "प्रारंभ"
+
+#: id:336
+msgid "Framerate conversion"
+msgstr "फ्रेमरेट रूपांतरण"
+
+#: id:337
+msgctxt "Auto context with id 337"
+msgid "Audio output"
+msgstr "ऑडियो आउटपुट"
+
+#: id:338
+msgid "Analog"
+msgstr "अनुरूप"
+
+#: id:339
+msgid "Optical/Coax"
+msgstr "ऑप्टिकल / मनाना"
+
+#: id:340
+msgid "Various artists"
+msgstr "विभिन्न कलाकारों"
+
+#: id:341
+msgid "Play disc"
+msgstr "डिस्क प्ले"
+
+#: id:342
+msgctxt "Auto context with id 342"
+msgid "Movies"
+msgstr "सिनेमा"
+
+#: id:343
+msgid "Adjust framerate"
+msgstr "फ्रेम दर को समायोजित करें"
+
+#: id:344
+msgid "Actors"
+msgstr "एक्टर्स"
+
+#: id:345
+msgctxt "Auto context with id 345"
+msgid "Year"
+msgstr "वर्ष"
+
+#: id:346
+msgid "Boost volume level on downmix"
+msgstr "दोव्न्मिक्स पर वॉल्यूम स्तर बूस्ट"
+
+#: id:350
+msgctxt "Auto context with id 350"
+msgid "Programs"
+msgstr "प्रोग्राम्स"
+
+#: id:351
+msgctxt "Auto context with id 351"
+msgid "Off"
+msgstr "से"
+
+#: id:352
+msgid "Dim"
+msgstr "धुंधला"
+
+#: id:353
+msgid "Black"
+msgstr "धुंधला"
+
+#: id:354
+msgid "Matrix trails"
+msgstr "मैट्रिक्स ट्रेल्स"
+
+#: id:355
+msgid "Screensaver time"
+msgstr "स्क्रीनसेवर समय"
+
+#: id:356
+msgid "Screensaver mode"
+msgstr "स्क्रीनसेवर मोड"
+
+#: id:357
+msgid "Shutdown function timer"
+msgstr "शट डाउन समारोह टाइमर"
+
+#: id:358
+msgid "All albums"
+msgstr "सभी एल्बमें"
+
+#: id:359
+msgid "Recently added albums"
+msgstr "हाल में जोड़ी एल्बमों"
+
+#: id:360
+msgctxt "Auto context with id 360"
+msgid "Screensaver"
+msgstr "स्क्रीनसेवर"
+
+#: id:361
+msgid "R. Slideshow"
+msgstr "आर स्लाइड शो"
+
+#: id:362
+msgid "Screensaver dim level"
+msgstr "स्क्रीनसेवर मंद स्तर"
+
+#: id:363
+msgid "Sort by: File"
+msgstr "द्वारा क्रमबद्ध करें: फ़ाइल"
+
+#: id:364
+msgid "- Dolby Digital (AC3) capable receiver"
+msgstr ""
+
+#: id:365
+msgctxt "Auto context with id 365"
+msgid "Sort by: Name"
+msgstr "द्वारा क्रमबद्ध करें: नाम"
+
+#: id:366
+msgid "Sort by: Year"
+msgstr "द्वारा क्रमबद्ध करें: वर्ष"
+
+#: id:367
+msgid "Sort by: Rating"
+msgstr "इसके द्वारा सॉर्ट करें: रेटिंग"
+
+#: id:368
+msgid "IMDb"
+msgstr ""
+
+#: id:369
+msgctxt "Auto context with id 369"
+msgid "Title"
+msgstr "शीर्षक"
+
+#: id:370
+msgid "Thunderstorms"
+msgstr "गरज"
+
+#: id:371
+msgid "Partly"
+msgstr "आंशिक रूप से"
+
+#: id:372
+msgid "Mostly"
+msgstr "अधिकतर"
+
+#: id:373
+msgid "Sunny"
+msgstr "धूप"
+
+#: id:374
+msgid "Cloudy"
+msgstr "मेघच्चान्ना"
+
+#: id:375
+msgid "Snow"
+msgstr "बरफ"
+
+#: id:376
+msgid "Rain"
+msgstr "बरसात"
+
+#: id:377
+msgid "Light"
+msgstr "प्रकासा"
+
+#: id:378
+msgid "AM"
+msgstr "AM"
+
+#: id:379
+msgid "PM"
+msgstr "PM"
+
+#: id:380
+msgid "Showers"
+msgstr "झड़ी"
+
+#: id:381
+msgid "Few"
+msgstr "कुछ"
+
+#: id:382
+msgid "Scattered"
+msgstr "छितरे"
+
+#: id:383
+msgctxt "Auto context with id 383"
+msgid "Wind"
+msgstr "हवा"
+
+#: id:384
+msgid "Strong"
+msgstr "मज़बूत"
+
+#: id:385
+msgid "Fair"
+msgstr "निष्पक्ष"
+
+#: id:386
+msgctxt "Auto context with id 386"
+msgid "Clear"
+msgstr "साफ़"
+
+#: id:387
+msgid "Clouds"
+msgstr "बादल"
+
+#: id:388
+msgid "Early"
+msgstr "शीघ्र"
+
+#: id:389
+msgid "Shower"
+msgstr "शावर"
+
+#: id:390
+msgid "Flurries"
+msgstr "आंधी"
+
+#: id:391
+msgctxt "Auto context with id 391"
+msgid "Low"
+msgstr "लो"
+
+#: id:392
+msgctxt "Auto context with id 392"
+msgid "Medium"
+msgstr "मध्यम"
+
+#: id:393
+msgctxt "Auto context with id 393"
+msgid "High"
+msgstr "उच्च"
+
+#: id:394
+msgid "Fog"
+msgstr "कोहरा"
+
+#: id:395
+msgid "Haze"
+msgstr "धुन्ध"
+
+#: id:396
+msgid "Select location"
+msgstr "स्थान का चयन करें"
+
+#: id:397
+msgid "Refresh time"
+msgstr "ताज़ा करें समय"
+
+#: id:398
+msgid "Temperature units"
+msgstr "तापमान इकाइयों"
+
+#: id:399
+msgid "Speed units"
+msgstr "स्पीड इकाइयों"
+
+#: id:400
+msgctxt "Auto context with id 400"
+msgid "Weather"
+msgstr "मौसम"
+
+#: id:401
+msgid "Temp"
+msgstr "अस्थायी"
+
+#: id:402
+msgid "Feels like"
+msgstr "ऐसा लगता है"
+
+#: id:403
+msgid "UV index"
+msgstr "यूवी सूचकांक"
+
+#: id:404
+msgctxt "Auto context with id 404"
+msgid "Wind"
+msgstr "हवा"
+
+#: id:405
+msgid "Dew point"
+msgstr "पिघलाव का तापक्रम"
+
+#: id:406
+msgid "Humidity"
+msgstr "नमी"
+
+#: id:409
+msgid "Defaults"
+msgstr "डिफ़ॉल्ट्स"
+
+#: id:410
+msgid "Accessing weather service"
+msgstr "मौसम सेवा तक पहुँचने"
+
+#: id:411
+msgid "Getting weather for:"
+msgstr "मौसम प्राप्त करने के लिए:"
+
+#: id:412
+msgid "Unable to get weather data"
+msgstr "मौसम के डेटा प्राप्त करने में असमर्थ"
+
+#: id:413
+msgid "Manual"
+msgstr "मैनुअल"
+
+#: id:414
+msgid "No review for this album"
+msgstr "इस एल्बम के लिए कोई समीक्षा"
+
+#: id:415
+msgid "Downloading thumbnail..."
+msgstr "थंबनेल डाउनलोड करना ..."
+
+#: id:416
+msgid "Not available"
+msgstr "उपलब्ध नहीं"
+
+#: id:417
+msgid "View: Big icons"
+msgstr "देखें: बिग आइकनों"
+
+#: id:418
+msgctxt "Auto context with id 418"
+msgid "Low"
+msgstr "लो"
+
+#: id:419
+msgctxt "Auto context with id 419"
+msgid "High"
+msgstr "हाई"
+
+#: id:420
+msgid "HDMI"
+msgstr ""
+
+#: id:422
+msgid "Delete album info"
+msgstr "एलबम जानकारी मिटाएँ"
+
+#: id:423
+msgid "Delete CD information"
+msgstr "हटाएँ सीडी जानकारी"
+
+#: id:424
+msgid "Select"
+msgstr "चुनें"
+
+#: id:425
+msgid "No album information found"
+msgstr "कोई एल्बम नहीं मिली जानकारी"
+
+#: id:426
+msgid "No CD information found"
+msgstr "कोई सीडी पाया जानकारी"
+
+#: id:427
+msgid "Disc"
+msgstr "डिस्क"
+
+#: id:428
+msgid "Insert correct CD/DVD"
+msgstr "सही सीडी / डीवीडी डालें"
+
+#: id:429
+msgid "Please insert the following disc:"
+msgstr "निम्नलिखित सीडी / डीवीडी दर्ज करें"
+
+#: id:430
+msgid "Sort by: DVD#"
+msgstr "इसके द्वारा सॉर्ट करें: डीवीडी #"
+
+#: id:431
+msgid "No cache"
+msgstr ""
+
+#: id:432
+msgid "Remove movie from library"
+msgstr "लाइब्रेरी से फिल्म निकालें"
+
+#: id:433
+msgid "Really remove '%s'?"
+msgstr "वास्तव में '% s' को दूर?"
+
+#: id:434
+msgid "From %s at %i %s"
+msgstr ""
+
+#: id:437
+msgid "Removable disk"
+msgstr "निकाले जाने योग्य डिस्क"
+
+#: id:438
+msgid "Opening file"
+msgstr "फ़ाइल खोलना"
+
+#: id:439
+msgid "Cache"
+msgstr "कैश"
+
+#: id:440
+msgid "Harddisk"
+msgstr "हार्ड डिस्क"
+
+#: id:441
+msgid "UDF"
+msgstr ""
+
+#: id:442
+msgid "Local network"
+msgstr "स्थानीय नेटवर्क"
+
+#: id:443
+msgid "Internet"
+msgstr "इंटरनेट"
+
+#: id:444
+msgctxt "Auto context with id 444"
+msgid "Video"
+msgstr "वीडियो"
+
+#: id:445
+msgctxt "Auto context with id 445"
+msgid "Audio"
+msgstr "ऑडियो"
+
+#: id:446
+msgctxt "Auto context with id 446"
+msgid "DVD"
+msgstr ""
+
+#: id:447
+msgid "Autorun media"
+msgstr "ऑटो चलाने मीडिया"
+
+#: id:448
+msgid "LCD"
+msgstr ""
+
+#: id:449
+msgctxt "Auto context with id 449"
+msgid "Enabled"
+msgstr "सक्रिय"
+
+#: id:450
+msgid "Columns"
+msgstr "स्तंभ"
+
+#: id:451
+msgid "Row 1 address"
+msgstr "1 पता पंक्ति"
+
+#: id:452
+msgid "Row 2 address"
+msgstr "2 पता पंक्ति"
+
+#: id:453
+msgid "Row 3 address"
+msgstr "3 पता पंक्ति"
+
+#: id:454
+msgid "Row 4 address"
+msgstr "4 पता पंक्ति"
+
+#: id:455
+msgid "Rows"
+msgstr "पंक्तियाँ"
+
+#: id:456
+msgid "Mode"
+msgstr "विधि"
+
+#: id:457
+msgid "Switch view"
+msgstr "दृश्य स्विच करें"
+
+#: id:459
+msgid "Subs"
+msgstr ""
+
+#: id:460
+msgid "Audio stream"
+msgstr "ऑडियो स्ट्रीम"
+
+#: id:461
+msgid "[active]"
+msgstr ""
+
+#: id:462
+msgid "Subtitle"
+msgstr "उपशीर्षक"
+
+#: id:463
+msgid "Backlight"
+msgstr "वापस प्रकाश"
+
+#: id:464
+msgid "Brightness"
+msgstr "चमक"
+
+#: id:465
+msgid "Contrast"
+msgstr "कंट्रास्ट"
+
+#: id:466
+msgid "Gamma"
+msgstr ""
+
+#: id:467
+msgctxt "Auto context with id 467"
+msgid "Type"
+msgstr "टाइप"
+
+#: id:468
+msgid "Move the bar to change the OSD position"
+msgstr "बार स्थानांतरित करने के ओएसडी स्थिति को बदलने"
+
+#: id:469
+msgid "OSD position"
+msgstr ""
+
+#: id:470
+msgid "Credits"
+msgstr "क्रेडिट्स"
+
+#: id:471
+msgid "Modchip"
+msgstr ""
+
+#: id:474
+msgctxt "Auto context with id 474"
+msgid "Off"
+msgstr "से"
+
+#: id:475
+msgid "Music only"
+msgstr "संगीत ही"
+
+#: id:476
+msgctxt "Auto context with id 476"
+msgid "Music & video"
+msgstr "संगीत और वीडियो"
+
+#: id:477
+msgid "Unable to load playlist"
+msgstr "प्लेलिस्ट में लोड करने में असमर्थ"
+
+#: id:478
+msgid "OSD"
+msgstr ""
+
+#: id:479
+msgid "Skin & language"
+msgstr "त्वचा और भाषा"
+
+#: id:480
+msgid "Appearance"
+msgstr "दिखावट"
+
+#: id:481
+msgid "Audio options"
+msgstr "ऑडियो विकल्प"
+
+#: id:482
+msgid "About XBMC"
+msgstr "XBMC के बारे में"
+
+#: id:485
+msgid "Delete album"
+msgstr "एल्बम हटाएं"
+
+#: id:486
+msgid "Repeat"
+msgstr "दोहराना"
+
+#: id:487
+msgid "Repeat one"
+msgstr "एक दोहराएँ"
+
+#: id:488
+msgid "Repeat folder"
+msgstr "दोहराएँ फ़ोल्डर"
+
+#: id:489
+msgid "Play the next song automatically"
+msgstr "अगले गीत स्वतः प्ले"
+
+#: id:491
+msgid "- Use big icons"
+msgstr "- बड़े चिह्नों का प्रयोग करें"
+
+#: id:492
+msgid "Resize VobSubs"
+msgstr ""
+
+#: id:493
+msgid "Advanced options (Experts Only!)"
+msgstr "उन्नत विकल्प (विशेषज्ञों केवल!)"
+
+#: id:494
+msgid "Overall audio headroom"
+msgstr "कुल मिलाकर ऑडियो सिर कमरा"
+
+#: id:495
+msgid "Upsample videos to GUI resolution"
+msgstr "जीयूआई संकल्प उपसकाले वीडियो"
+
+#: id:496
+msgid "Calibration"
+msgstr "अंशांकन"
+
+#: id:497
+msgid "Show file extensions"
+msgstr "फ़ाइल एक्सटेंशन दिखाएँ"
+
+#: id:498
+msgid "Sort by: Type"
+msgstr "द्वारा क्रमबद्ध करें: प्रकार"
+
+#: id:499
+msgid "Unable to connect to online lookup service"
+msgstr "करने के लिए ऑनलाइन खोज सेवा से कनेक्ट करने में असमर्थ"
+
+#: id:500
+msgid "Downloading album information failed"
+msgstr "डाउनलोडिंग एलबम जानकारी में विफल रहा है"
+
+#: id:501
+msgid "Looking for album names..."
+msgstr "एल्बम नाम के लिए खोज ..."
+
+#: id:502
+msgctxt "Auto context with id 502"
+msgid "Open"
+msgstr "खुला है"
+
+#: id:503
+msgid "Busy"
+msgstr "व्यस्त"
+
+#: id:504
+msgid "Empty"
+msgstr "रिक्त"
+
+#: id:505
+msgid "Loading media info from files..."
+msgstr "लोड हो रहा है फाइलों से जानकारी मीडिया ..."
+
+#: id:507
+msgid "Sort by: Usage"
+msgstr "इसके द्वारा सॉर्ट करें: यूसेज"
+
+#: id:510
+msgid "Enable visualizations"
+msgstr "विसुअलिज़तिओन्स सक्षम करें"
+
+#: id:511
+msgid "Enable video mode switching"
+msgstr "वीडियो मोड स्विचन सक्षम करें"
+
+#: id:512
+msgid "Startup window"
+msgstr "स्टार्टअप खिड़की"
+
+#: id:513
+msgid "Home window"
+msgstr "होम खिड़की"
+
+#: id:514
+msgid "Manual settings"
+msgstr "मैनुअल सेटिंग्स"
+
+#: id:515
+msgid "Genre"
+msgstr "शैली"
+
+#: id:517
+msgid "Recently played albums"
+msgstr "हाल ही में खेला एल्बमों"
+
+#: id:518
+msgid "Launch"
+msgstr "लॉन्च"
+
+#: id:519
+msgid "Launch in..."
+msgstr "अंदर लॉन्च .."
+
+#: id:521
+msgid "Compilations"
+msgstr "संकलन"
+
+#: id:522
+msgid "Remove source"
+msgstr "स्रोत निकालें"
+
+#: id:523
+msgid "Switch media"
+msgstr "स्विच मीडिया"
+
+#: id:524
+msgid "Select playlist"
+msgstr "चुनें प्लेलिस्ट"
+
+#: id:525
+msgid "New playlist..."
+msgstr "नई प्लेलिस्ट ..."
+
+#: id:526
+msgid "Add to playlist"
+msgstr "प्लेलिस्ट में जोड़ें"
+
+#: id:527
+msgid "Manually add to library"
+msgstr "मैन्युअल रूप से लायब्रेरी में जोड़ना"
+
+#: id:528
+msgid "Enter title"
+msgstr "शीर्षक दर्ज करें"
+
+#: id:529
+msgid "Error: Duplicate title"
+msgstr "त्रुटि: डुप्लिकेट शीर्षक"
+
+#: id:530
+msgid "Select genre"
+msgstr "शैली का चयन करें"
+
+#: id:531
+msgid "New genre"
+msgstr "नई शैली"
+
+#: id:532
+msgid "Manual addition"
+msgstr "मैनुअल इसके अलावा"
+
+#: id:533
+msgid "Enter genre"
+msgstr "शैली का नाम लिखें"
+
+#: id:534
+msgid "View: %s"
+msgstr "देखें:% s"
+
+#: id:535
+msgid "List"
+msgstr "सूची"
+
+#: id:536
+msgid "Icons"
+msgstr "प्रतीक"
+
+#: id:537
+msgid "Big list"
+msgstr "बिग सूची"
+
+#: id:538
+msgid "Big icons"
+msgstr "बिग आइकनों"
+
+#: id:539
+msgid "Wide"
+msgstr "चौड़ा"
+
+#: id:540
+msgid "Big wide"
+msgstr "बिग विस्तृत"
+
+#: id:541
+msgid "Album icons"
+msgstr "एल्बम आइकनों"
+
+#: id:542
+msgid "DVD icons"
+msgstr "DVD आइकनों"
+
+#: id:543
+msgctxt "Auto context with id 543"
+msgid "DVD"
+msgstr "DVD"
+
+#: id:544
+msgctxt "Auto context with id 544"
+msgid "Media info"
+msgstr "मीडिया की जानकारी"
+
+#: id:545
+msgid "Audio output device"
+msgstr "ऑडियो आउटपुट डिवाइस"
+
+#: id:546
+msgid "Passthrough output device"
+msgstr "पासथ्रू आउटपुट डिवाइस"
+
+#: id:547
+msgid "No biography for this artist"
+msgstr "इस कलाकार के लिए कोई जीवनी"
+
+#: id:548
+msgid "Downmix multichannel audio to stereo"
+msgstr ""
+
+#: id:550
+msgid "Sort by: %s"
+msgstr "द्वारा क्रमबद्ध करें:% s"
+
+#: id:551
+msgctxt "Auto context with id 551"
+msgid "Name"
+msgstr "नाम"
+
+#: id:552
+msgid "Date"
+msgstr "तिथि"
+
+#: id:553
+msgid "Size"
+msgstr "आकार"
+
+#: id:554
+msgid "Track"
+msgstr "ट्रैक"
+
+#: id:555
+msgid "Time"
+msgstr "समय"
+
+#: id:556
+msgctxt "Auto context with id 556"
+msgid "Title"
+msgstr "शीर्षक"
+
+#: id:557
+msgid "Artist"
+msgstr "कलाकार"
+
+#: id:558
+msgid "Album"
+msgstr "एल्बम"
+
+#: id:559
+msgid "Playlist"
+msgstr "प्लेलिस्ट"
+
+#: id:560
+msgid "ID"
+msgstr ""
+
+#: id:561
+msgctxt "Auto context with id 561"
+msgid "File"
+msgstr "फ़ाइल"
+
+#: id:562
+msgctxt "Auto context with id 562"
+msgid "Year"
+msgstr "वर्ष"
+
+#: id:563
+msgid "Rating"
+msgstr "रेटिंग"
+
+#: id:564
+msgctxt "Auto context with id 564"
+msgid "Type"
+msgstr "टाइप"
+
+#: id:565
+msgid "Usage"
+msgstr "प्रयोग"
+
+#: id:566
+msgid "Album artist"
+msgstr "एल्बम कलाकार"
+
+#: id:567
+msgid "Play count"
+msgstr "गिनती प्ले"
+
+#: id:568
+msgid "Last played"
+msgstr "अंतिम बार खेला गया"
+
+#: id:569
+msgctxt "Auto context with id 569"
+msgid "Comment"
+msgstr "टिप्पणी"
+
+#: id:570
+msgid "Date added"
+msgstr "तिथि जोड़ी"
+
+#: id:571
+msgctxt "Auto context with id 571"
+msgid "Default"
+msgstr "डिफ़ॉल्ट"
+
+#: id:572
+msgid "Studio"
+msgstr "स्टूडियो"
+
+#: id:573
+msgid "Path"
+msgstr "पथ"
+
+#: id:574
+msgctxt "Auto context with id 574"
+msgid "Country"
+msgstr "देश"
+
+#: id:575
+msgid "In progress"
+msgstr "प्रगति में"
+
+#: id:576
+msgid "Times played"
+msgstr ""
+
+#: id:580
+msgid "Sort direction"
+msgstr "सॉर्ट दिशा"
+
+#: id:581
+msgid "Sort method"
+msgstr "क्रमबद्ध विधि"
+
+#: id:582
+msgctxt "Auto context with id 582"
+msgid "View mode"
+msgstr "देखें मोड"
+
+#: id:583
+msgid "Remember views for different folders"
+msgstr "अलग फ़ोल्डर्स के लिए दृश्य याद रखें"
+
+#: id:584
+msgid "Ascending"
+msgstr "आरोही"
+
+#: id:585
+msgid "Descending"
+msgstr "अवरोही"
+
+#: id:586
+msgid "Edit playlist"
+msgstr "संपादित करें प्लेलिस्ट"
+
+#: id:587
+msgid "Filter"
+msgstr "फ़िल्टर"
+
+#: id:588
+msgid "Cancel party mode"
+msgstr "रद्द पार्टी मोड"
+
+#: id:589
+msgid "Party mode"
+msgstr "पार्टी के विधि"
+
+#: id:590
+msgid "Random"
+msgstr "रैंडम"
+
+#: id:591
+msgctxt "Auto context with id 591"
+msgid "Off"
+msgstr "से"
+
+#: id:592
+msgid "One"
+msgstr "एक"
+
+#: id:593
+msgid "All"
+msgstr "सब"
+
+#: id:594
+msgctxt "Auto context with id 594"
+msgid "Off"
+msgstr "से"
+
+#: id:595
+msgid "Repeat: Off"
+msgstr "दोहराएँ: बंद"
+
+#: id:596
+msgid "Repeat: One"
+msgstr "दोहराएँ: एक"
+
+#: id:597
+msgid "Repeat: All"
+msgstr "दोहराएँ: सभी"
+
+#: id:600
+msgid "Rip audio CD"
+msgstr "ऑडियो सीडी चीर"
+
+#: id:601
+msgctxt "Auto context with id 601"
+msgid "Medium"
+msgstr "मध्यम"
+
+#: id:602
+msgctxt "Auto context with id 602"
+msgid "Standard"
+msgstr "मानक"
+
+#: id:603
+msgid "Extreme"
+msgstr "चरम"
+
+#: id:604
+msgid "Constant bitrate"
+msgstr ""
+
+#: id:605
+msgid "Ripping..."
+msgstr "तेजस्वी ..."
+
+#: id:607
+msgid "To:"
+msgstr "करने के लिए:"
+
+#: id:608
+msgid "Could not rip CD or track"
+msgstr "सीडी या ट्रैक चीर नहीं कर सका"
+
+#: id:609
+msgid "CDDARipPath is not set."
+msgstr "CDDARipPath सेट नहीं है."
+
+#: id:610
+msgid "Rip audio track"
+msgstr "ऑडियो ट्रैक रिप"
+
+#: id:611
+msgid "Enter number"
+msgstr "संख्या दर्ज"
+
+#: id:612
+msgid "Bits/Sample"
+msgstr "बिट्स / नमूना"
+
+#: id:613
+msgid "Sample Frequency"
+msgstr "नमूना आवृत्ति"
+
+#: id:620
+msgid "Audio CDs"
+msgstr "ऑडियो सीडी"
+
+#: id:621
+msgid "Encoder"
+msgstr "एनकोडर"
+
+#: id:622
+msgid "Quality"
+msgstr "गुणवत्ता"
+
+#: id:623
+msgid "Bitrate"
+msgstr "बिट दर"
+
+#: id:624
+msgid "Include track number"
+msgstr "ट्रैक संख्या में शामिल"
+
+#: id:625
+msgid "All songs of"
+msgstr "सब के सब गाने"
+
+#: id:629
+msgctxt "Auto context with id 629"
+msgid "View mode"
+msgstr "देखें मोड"
+
+#: id:630
+msgctxt "Auto context with id 630"
+msgid "Normal"
+msgstr "साधारण"
+
+#: id:631
+msgid "Zoom"
+msgstr "ज़ूम"
+
+#: id:632
+msgid "Stretch 4:3"
+msgstr "खिंचाव 4:3"
+
+#: id:633
+msgid "Wide Zoom"
+msgstr "वाइड ज़ूम"
+
+#: id:634
+msgid "Stretch 16:9"
+msgstr "खिंचाव 16:9"
+
+#: id:635
+msgid "Original Size"
+msgstr "मूल आकार"
+
+#: id:636
+msgctxt "Auto context with id 636"
+msgid "Custom"
+msgstr "रिवाज"
+
+#: id:637
+msgid "Replay gain"
+msgstr "रिप्ले लाभ"
+
+#: id:638
+msgid "Replaygain volume adjustments"
+msgstr "रिप्ले लाभ की मात्रा का समायोजन"
+
+#: id:639
+msgid "Use track levels"
+msgstr "ट्रैक स्तर का उपयोग करें"
+
+#: id:640
+msgid "Use album levels"
+msgstr "एलबम के स्तर का प्रयोग करें"
+
+#: id:641
+msgid "PreAmp Level - Replay gained files"
+msgstr ""
+
+#: id:642
+msgid "PreAmp Level - Non replay gained files"
+msgstr ""
+
+#: id:643
+msgid "Avoid clipping on replay gained files"
+msgstr "पुनरावृत्ति पर क्लिपिंग बचें फ़ाइलें प्राप्त"
+
+#: id:644
+msgid "Crop black bars"
+msgstr "फसल काली सलाखों"
+
+#: id:645
+msgid "Need to unpack a big file. Continue?"
+msgstr "के लिए एक बड़ी फ़ाइल खोल देना चाहिए. जारी रखें?"
+
+#: id:646
+msgid "Remove from library"
+msgstr "पुस्तकालय से निकालें"
+
+#: id:647
+msgid "Export video library"
+msgstr "निर्यात वीडियो लाइब्रेरी"
+
+#: id:648
+msgid "Import video library"
+msgstr "आयात वीडियो लाइब्रेरी"
+
+#: id:649
+msgid "Importing"
+msgstr "आयात करना"
+
+#: id:650
+msgid "Exporting"
+msgstr "निर्यात"
+
+#: id:651
+msgid "Browse for library"
+msgstr "लाइब्रेरी के लिए ब्राउज़ करें"
+
+#: id:652
+msgid "Years"
+msgstr "वर्षों"
+
+#: id:653
+msgid "Update library"
+msgstr "अद्यतन पुस्तकालय"
+
+#: id:654
+msgid "Show debug info"
+msgstr "अद्यतन पुस्तकालय"
+
+#: id:655
+msgid "Browse for executable"
+msgstr "निष्पादन के लिए ब्राउज़ करें"
+
+#: id:656
+msgid "Browse for playlist"
+msgstr "प्लेलिस्ट के लिए ब्राउज़ करें"
+
+#: id:657
+msgid "Browse for folder"
+msgstr "फ़ोल्डर के लिए ब्राउज़ करें"
+
+#: id:658
+msgid "Song information"
+msgstr "सांग जानकारी"
+
+#: id:659
+msgid "Non-linear stretch"
+msgstr ""
+
+#: id:660
+msgid "Volume amplification"
+msgstr "वॉल्यूम प्रवर्धन"
+
+#: id:661
+msgid "Choose export folder"
+msgstr "निर्यात फ़ोल्डर"
+
+#: id:662
+msgid "This file is no longer available."
+msgstr "यह फाइल अब उपलब्ध नहीं है"
+
+#: id:663
+msgid "Would you like to remove it from the library?"
+msgstr "आप इसे लाइब्रेरी से निकालना चाहेंगे?"
+
+#: id:664
+msgid "Browse for Script"
+msgstr "स्क्रिप्ट के लिए स्ट्रिंग"
+
+#: id:665
+msgid "Compression level"
+msgstr "संपीड़न स्तर"
+
+#: id:700
+msgid "Cleaning up library"
+msgstr "ऊपर क्लीनिंग पुस्तकालय"
+
+#: id:701
+msgid "Removing old songs from the library"
+msgstr "पुस्तकालय से पुराने गाने को निकालना"
+
+#: id:702
+msgid "This path has been scanned before"
+msgstr "यह पथ पहले स्कैन किया गया है"
+
+#: id:705
+msgctxt "Auto context with id 705"
+msgid "Network"
+msgstr "नेटवर्क"
+
+#: id:706
+msgid "- Server"
+msgstr "- सर्वर"
+
+#: id:708
+msgid "Use an HTTP proxy server to access the internet"
+msgstr "एक HTTP प्रॉक्सी सर्वर का प्रयोग करें इंटरनेट एक्सेस"
+
+#: id:711
+msgid "Internet Protocol (IP)"
+msgstr ""
+
+#: id:712
+msgid "Invalid port specified. Value must be between 1 and 65535."
+msgstr ""
+
+#: id:713
+msgid "HTTP proxy"
+msgstr "HTTP प्रॉक्सी."
+
+#: id:715
+msgid "- Assignment"
+msgstr "- असाइनमेंट"
+
+#: id:716
+msgid "Automatic (DHCP)"
+msgstr ""
+
+#: id:717
+msgid "Manual (Static)"
+msgstr ""
+
+#: id:719
+msgid "- IP address"
+msgstr ""
+
+#: id:720
+msgid "- Netmask"
+msgstr ""
+
+#: id:721
+msgid "- Default gateway"
+msgstr ""
+
+#: id:722
+msgid "- DNS server"
+msgstr ""
+
+#: id:723
+msgid "Save & restart"
+msgstr "सहेजें और पुनर्प्रारंभ करें"
+
+#: id:724
+msgid "Invalid address specified. Value must be AAA.BBB.CCC.DDD"
+msgstr ""
+
+#: id:725
+msgid "with numbers between 0 and 255."
+msgstr ""
+
+#: id:726
+msgid "Changes not saved. Continue without saving?"
+msgstr "सहेजे नहीं गए परिवर्तन. बचत के बिना जारी रखें?"
+
+#: id:727
+msgid "Web server"
+msgstr ""
+
+#: id:728
+msgctxt "Auto context with id 728"
+msgid "FTP server"
+msgstr ""
+
+#: id:730
+msgid "- Port"
+msgstr "-बंदरगाह"
+
+#: id:732
+msgid "Save & apply"
+msgstr "सहेजें और लागू"
+
+#: id:733
+msgid "- Password"
+msgstr "- पासवर्ड"
+
+#: id:734
+msgid "No pass"
+msgstr "कोई उत्तीर्ण"
+
+#: id:735
+msgid "- Character set"
+msgstr "- कैरेक्टर सेट"
+
+#: id:736
+msgid "- Style"
+msgstr "- शैली"
+
+#: id:737
+msgid "- Colour"
+msgstr "- रंगीन"
+
+#: id:738
+msgctxt "Auto context with id 738"
+msgid "Normal"
+msgstr "सामान्य"
+
+#: id:739
+msgid "Bold"
+msgstr "साहसिक"
+
+#: id:740
+msgid "Italics"
+msgstr "इटैलिक्स"
+
+#: id:741
+msgid "Bold italics"
+msgstr "बोल्ड इटैलिक"
+
+#: id:742
+msgctxt "Auto context with id 742"
+msgid "White"
+msgstr "सफ़ेद"
+
+#: id:743
+msgctxt "Auto context with id 743"
+msgid "Yellow"
+msgstr "पीला"
+
+#: id:744
+msgctxt "Auto context with id 744"
+msgid "Files"
+msgstr "फ़ाइलें"
+
+#: id:745
+msgid "No scanned information for this view"
+msgstr "इस दृश्य के लिए कोई स्कैन की जानकारी"
+
+#: id:746
+msgid "Please turn off library mode"
+msgstr "बंद पुस्तकालय मोड बारी कृपया"
+
+#: id:747
+msgid "Error loading image"
+msgstr "लोड करने में त्रुटि छवि"
+
+#: id:748
+msgid "Edit path"
+msgstr "पथ संपादित करें"
+
+#: id:749
+msgid "Mirror image"
+msgstr "आईना छवि"
+
+#: id:750
+msgid "Are you sure?"
+msgstr "तुम्हें यकीन है?"
+
+#: id:751
+msgid "Removing source"
+msgstr "स्रोत को निकालना"
+
+#: id:754
+msgid "Add program link"
+msgstr "कार्यक्रम लिंक जोड़ें"
+
+#: id:755
+msgid "Edit program path"
+msgstr "कार्यक्रम पथ संपादित करें"
+
+#: id:756
+msgid "Edit program name"
+msgstr "प्रोग्राम का नाम संपादित करें"
+
+#: id:757
+msgid "Edit path depth"
+msgstr "पथ गहराई संपादित करें"
+
+#: id:759
+msgid "View: Big list"
+msgstr "देखें: बिग सूची"
+
+#: id:760
+msgctxt "Auto context with id 760"
+msgid "Yellow"
+msgstr "पीला"
+
+#: id:761
+msgctxt "Auto context with id 761"
+msgid "White"
+msgstr "सफ़ेद"
+
+#: id:762
+msgid "Blue"
+msgstr "नीला"
+
+#: id:763
+msgid "Bright green"
+msgstr "ब्राइट हरा"
+
+#: id:764
+msgid "Yellow green"
+msgstr "पीला हरा"
+
+#: id:765
+msgid "Cyan"
+msgstr "सियान"
+
+#: id:766
+msgid "Light grey"
+msgstr "हल्की धूसर"
+
+#: id:767
+msgid "Grey"
+msgstr "धूसर"
+
+#: id:770
+msgid "Error %i: share not available"
+msgstr "त्रुटि% मैं: उपलब्ध नहीं शेयर"
+
+#: id:772
+msgctxt "Auto context with id 772"
+msgid "Audio output"
+msgstr "ऑडियो आउटपुट"
+
+#: id:773
+msgid "Seeking"
+msgstr "मांग"
+
+#: id:774
+msgid "Slideshow folder"
+msgstr "स्लाइड शो फ़ोल्डर"
+
+#: id:775
+msgid "Network interface"
+msgstr "नेटवर्क इंटरफेस"
+
+#: id:776
+msgid "- Wireless network name (ESSID)"
+msgstr "- वायरलेस नेटवर्क नाम (ESSID)"
+
+#: id:777
+msgid "- Wireless password"
+msgstr "- वायरलेस पासवर्ड"
+
+#: id:778
+msgid "- Wireless security"
+msgstr "- वायरलेस सुरक्षा"
+
+#: id:779
+msgid "Save and apply network interface settings"
+msgstr "सहेजें और नेटवर्क इंटरफेस सेटिंग्स लागू"
+
+#: id:780
+msgid "No encryption"
+msgstr "कोई एन्क्रिप्शन"
+
+#: id:781
+msgid "WEP"
+msgstr ""
+
+#: id:782
+msgid "WPA"
+msgstr ""
+
+#: id:783
+msgid "WPA2"
+msgstr ""
+
+#: id:784
+msgid "Applying network interface settings. Please wait."
+msgstr "नेटवर्क इंटरफेस सेटिंग्स लागू. कृपया प्रतीक्षा करें."
+
+#: id:785
+msgid "Network interface restarted successfully."
+msgstr "नेटवर्क इंटरफेस को सफलतापूर्वक पुनरारंभ."
+
+#: id:786
+msgid "Network interface did not start successfully."
+msgstr "नेटवर्क इंटरफेस सफलतापूर्वक शुरू नहीं किया."
+
+#: id:787
+msgid "Interface disabled"
+msgstr "विकलांग इंटरफ़ेस"
+
+#: id:788
+msgid "Network interface disabled successfully."
+msgstr "नेटवर्क इंटरफेस सफलतापूर्वक अक्षम."
+
+#: id:789
+msgid "Wireless network name (ESSID)"
+msgstr "वायरलेस नेटवर्क नाम (ESSID)"
+
+#: id:790
+msgid "Remote control"
+msgstr ""
+
+#: id:791
+msgid "Allow programs on this system to control XBMC"
+msgstr "इस सिस्टम पर प्रोग्रामों XBMC नियंत्रण करने दें"
+
+#: id:792
+msgctxt "Auto context with id 792"
+msgid "Port"
+msgstr "बंदरगाह"
+
+#: id:793
+msgid "Port range"
+msgstr "पोर्ट रेंज"
+
+#: id:794
+msgid "Allow programs on other systems to control XBMC"
+msgstr "अन्य प्रणालियों पर कार्यक्रमों XBMC नियंत्रण करने दें"
+
+#: id:795
+msgid "Initial repeat delay (ms)"
+msgstr "प्रारंभिक दोहराना विलंब (ms)"
+
+#: id:796
+msgid "Continuous repeat delay (ms)"
+msgstr "सतत दोहराने देरी (ms)"
+
+#: id:797
+msgid "Maximum number of clients"
+msgstr "ग्राहकों की अधिकतम संख्या"
+
+#: id:798
+msgid "Internet access"
+msgstr "इंटरनेट का उपयोग"
+
+#: id:850
+msgid "Invalid port number entered"
+msgstr "अवैध पोर्ट संख्या दर्ज"
+
+#: id:851
+msgid "Valid port range is 1-65535"
+msgstr ""
+
+#: id:852
+msgid "Valid port range is 1024-65535"
+msgstr ""
+
+#: id:998
+msgid "Add Music..."
+msgstr ""
+
+#: id:999
+msgid "Add Videos..."
+msgstr ""
+
+#: id:1000
+msgid "- Preview"
+msgstr "- पूर्वावलोकन"
+
+#: id:1001
+msgid "Unable to connect"
+msgstr "कनेक्ट करने में असमर्थ"
+
+#: id:1002
+msgid "XBMC was unable to connect to the network location."
+msgstr "XBMC के लिए नेटवर्क स्थान से कनेक्ट करने में असमर्थ था."
+
+#: id:1003
+msgid "This could be due to the network not being connected."
+msgstr "इस नेटवर्क नहीं किया जा रहा जुड़ा के कारण हो सकता है."
+
+#: id:1004
+msgid "Would you like to add it anyway?"
+msgstr "क्या आप इसे वैसे भी जोड़ना चाहेंगे?"
+
+#: id:1006
+msgctxt "Auto context with id 1006"
+msgid "IP address"
+msgstr "IP पता"
+
+#: id:1007
+msgid "Add network location"
+msgstr "नेटवर्क स्थान जोड़ें"
+
+#: id:1008
+msgid "Protocol"
+msgstr "प्रोटोकॉल"
+
+#: id:1009
+msgid "Server address"
+msgstr "सर्वर पता"
+
+#: id:1010
+msgid "Server name"
+msgstr "सर्वर का नाम"
+
+#: id:1011
+msgid "Remote path"
+msgstr "रिमोट पथ"
+
+#: id:1012
+msgid "Shared folder"
+msgstr "साझा फ़ोल्डर"
+
+#: id:1013
+msgctxt "Auto context with id 1013"
+msgid "Port"
+msgstr "बंदरगाह"
+
+#: id:1014
+msgctxt "Auto context with id 1014"
+msgid "Username"
+msgstr "उपयोगकर्ता नाम"
+
+#: id:1015
+msgid "Browse for network server"
+msgstr "नेटवर्क सर्वर के लिए ब्राउज़ करें"
+
+#: id:1016
+msgid "Enter the network address of the server"
+msgstr "सर्वर के नेटवर्क पता दर्ज करें"
+
+#: id:1017
+msgid "Enter the path on the server"
+msgstr "सर्वर पर पथ दर्ज करें"
+
+#: id:1018
+msgid "Enter the port number"
+msgstr "पोर्ट संख्या दर्ज करें"
+
+#: id:1019
+msgid "Enter the username"
+msgstr "उपयोगकर्ता नाम दर्ज करें"
+
+#: id:1020
+msgid "Add %s source"
+msgstr "% S स्रोत जोड़ें"
+
+#: id:1021
+msgid "Enter the paths or browse for the media locations."
+msgstr "पथ दर्ज करें या मीडिया स्थानों के लिए ब्राउज़ करें."
+
+#: id:1022
+msgid "Enter a name for this media Source."
+msgstr "यह मीडिया के स्रोत के लिए कोई नाम दर्ज करें."
+
+#: id:1023
+msgid "Browse for new share"
+msgstr "नए शेयर के लिए ब्राउज़ करें"
+
+#: id:1024
+msgid "Browse"
+msgstr "ब्राउज़ करें"
+
+#: id:1025
+msgid "Could not retrieve directory information."
+msgstr "निर्देशिका जानकारी पुनर्प्राप्त नहीं कर सका."
+
+#: id:1026
+msgid "Add source"
+msgstr "स्रोत जोड़ें"
+
+#: id:1027
+msgid "Edit source"
+msgstr "स्रोत संपादित करें"
+
+#: id:1028
+msgid "Edit %s source"
+msgstr "% S स्रोत संपादित करें"
+
+#: id:1029
+msgid "Enter the new label"
+msgstr "नया लेबल दर्ज करें"
+
+#: id:1030
+msgid "Browse for image"
+msgstr "छवि के लिए ब्राउज़ करें"
+
+#: id:1031
+msgid "Browse for image folder"
+msgstr "छवि फ़ोल्डर के लिए ब्राउज़ करें"
+
+#: id:1032
+msgid "Add network location..."
+msgstr "नेटवर्क स्थान जोड़ें..."
+
+#: id:1033
+msgid "Browse for file"
+msgstr "फ़ाइल के लिए ब्राउज़ करें"
+
+#: id:1034
+msgid "Submenu"
+msgstr "सबमेनू"
+
+#: id:1035
+msgid "Enable submenu buttons"
+msgstr "सबमेनू बटनों को सक्षम करें"
+
+#: id:1036
+msgid "Favourites"
+msgstr "प्रिय"
+
+#: id:1037
+msgid "Video Add-ons"
+msgstr "जोड़ें-ons के वीडियो"
+
+#: id:1038
+msgid "Music Add-ons"
+msgstr "संगीत परिवर्धन"
+
+#: id:1039
+msgid "Picture Add-ons"
+msgstr "चित्र परिवर्धन"
+
+#: id:1040
+msgid "Loading directory"
+msgstr "निर्देशिका लोड हो रहा है"
+
+#: id:1041
+msgid "Retrieved %i items"
+msgstr "पुनःप्राप्त% मैं आइटम"
+
+#: id:1042
+msgid "Retrieved %i of %i items"
+msgstr "पुनःप्राप्त% का% मैं आइटम मैं"
+
+#: id:1043
+msgid "Program Add-ons"
+msgstr "कार्यक्रम परिवर्धन"
+
+#: id:1044
+msgid "Set plugin thumb"
+msgstr "पप्लगइन अंगूठा सेट करें"
+
+#: id:1045
+msgid "Add-on settings"
+msgstr "इसके अतिरिक्त सेटिंग्स"
+
+#: id:1046
+msgid "Access points"
+msgstr "प्रवेश अंक"
+
+#: id:1047
+msgid "Other..."
+msgstr "अन्य ..."
+
+#: id:1048
+msgid "- Username"
+msgstr "- उपयोगकर्ता नाम"
+
+#: id:1049
+msgid "Script settings"
+msgstr "स्क्रिप्ट सेटिंग्स"
+
+#: id:1050
+msgid "Singles"
+msgstr "एकल"
+
+#: id:1051
+msgid "Enter web address"
+msgstr "वेब पता दर्ज करें"
+
+#: id:1200
+msgid "SMB client"
+msgstr ""
+
+#: id:1202
+msgid "Workgroup"
+msgstr "कार्यसमूह"
+
+#: id:1203
+msgid "Default username"
+msgstr "डिफ़ॉल्ट उपयोगकर्ता नाम"
+
+#: id:1204
+msgid "Default password"
+msgstr "डिफ़ॉल्ट पासवर्ड"
+
+#: id:1207
+msgid "WINS server"
+msgstr ""
+
+#: id:1208
+msgid "Mount SMB shares"
+msgstr "माउंट SMB शेयर"
+
+#: id:1210
+msgctxt "Auto context with id 1210"
+msgid "Remove"
+msgstr "हटाना"
+
+#: id:1211
+msgctxt "Auto context with id 1211"
+msgid "Music"
+msgstr "संगीत"
+
+#: id:1212
+msgctxt "Auto context with id 1212"
+msgid "Video"
+msgstr "वीडियो"
+
+#: id:1213
+msgctxt "Auto context with id 1213"
+msgid "Pictures"
+msgstr "चित्र"
+
+#: id:1214
+msgctxt "Auto context with id 1214"
+msgid "Files"
+msgstr "फ़ाइलें"
+
+#: id:1215
+msgctxt "Auto context with id 1215"
+msgid "Music & video"
+msgstr "संगीत और वीडियो"
+
+#: id:1216
+msgid "Music & pictures"
+msgstr "संगीत और चित्रों"
+
+#: id:1217
+msgid "Music & files"
+msgstr "संगीत और फ़ाइलें"
+
+#: id:1218
+msgid "Video & pictures"
+msgstr "वीडियो और तस्वीरें"
+
+#: id:1219
+msgid "Video & files"
+msgstr "वीडियो और फ़ाइलें"
+
+#: id:1220
+msgid "Pictures & files"
+msgstr "चित्र और फ़ाइलों"
+
+#: id:1221
+msgid "Music & video & pictures"
+msgstr "संगीत और वीडियो और तस्वीरें"
+
+#: id:1222
+msgid "Music & video & pictures & files"
+msgstr "संगीत और वीडियो और तस्वीरों और फ़ाइलें"
+
+#: id:1223
+msgctxt "Auto context with id 1223"
+msgid "Disabled"
+msgstr "विकलांग"
+
+#: id:1226
+msgid "Files & music & video"
+msgstr "फ़ाइलें और संगीत वीडियो"
+
+#: id:1227
+msgid "Files & pictures & music"
+msgstr "और फ़ाइलें चित्रों और संगीत"
+
+#: id:1228
+msgid "Files & pictures & video"
+msgstr "और फ़ाइलें तस्वीरें और वीडियो"
+
+#: id:1229
+msgid "Music & programs"
+msgstr "संगीत और कार्यक्रमों"
+
+#: id:1230
+msgid "Video & programs"
+msgstr "वीडियो और कार्यक्रमों"
+
+#: id:1231
+msgid "Pictures & programs"
+msgstr "चित्र और कार्यक्रमों"
+
+#: id:1232
+msgid "Music & video & pictures & programs"
+msgstr "संगीत और वीडियो और तस्वीरों और कार्यक्रमों"
+
+#: id:1233
+msgid "Programs & video & music"
+msgstr "प्रोग्राम्स एवं वीडियो और संगीत"
+
+#: id:1234
+msgid "Programs & pictures & music"
+msgstr "प्रोग्राम्स और तस्वीरें और संगीत"
+
+#: id:1235
+msgid "Programs & pictures & video"
+msgstr "प्रोग्राम्स और तस्वीरें और वीडियो"
+
+#: id:1250
+msgid "Auto-detection"
+msgstr "ऑटो का पता लगाने"
+
+#: id:1251
+msgid "Auto-detect system"
+msgstr "स्वत: पता लगाने के लिए प्रणाली"
+
+#: id:1252
+msgid "Nickname"
+msgstr "उपनाम"
+
+#: id:1254
+msgid "Ask to connect"
+msgstr "से कनेक्ट पूछें"
+
+#: id:1255
+msgid "Send FTP user and password"
+msgstr "एफ़टीपी उपयोगकर्ता और पासवर्ड भेजें"
+
+#: id:1256
+msgid "Ping interval"
+msgstr "पिंग अंतराल"
+
+#: id:1257
+msgid "Would you like to connect to the auto-detected system?"
+msgstr "क्या आप प्रणाली ऑटो का पता लगाया करने के लिए कनेक्ट करना चाहेंगे?"
+
+#: id:1259
+msgid "Zeroconf"
+msgstr ""
+
+#: id:1260
+msgid "Announce these services to other systems via Zeroconf"
+msgstr ""
+
+#: id:1270
+msgid "Allow XBMC to receive AirPlay content"
+msgstr ""
+
+#: id:1271
+msgid "Device name"
+msgstr ""
+
+#: id:1272
+msgid "- Use password protection"
+msgstr ""
+
+#: id:1273
+msgid "AirPlay"
+msgstr ""
+
+#: id:1300
+msgid "Custom audio device"
+msgstr ""
+
+#: id:1301
+msgid "Custom passthrough device"
+msgstr ""
+
+#: id:1396
+msgid "Drifting"
+msgstr ""
+
+#: id:1397
+msgid "and"
+msgstr ""
+
+#: id:1398
+msgid "Freezing"
+msgstr ""
+
+#: id:1399
+msgid "Late"
+msgstr ""
+
+#: id:1400
+msgid "Isolated"
+msgstr ""
+
+#: id:1401
+msgid "Thundershowers"
+msgstr ""
+
+#: id:1402
+msgid "Thunder"
+msgstr ""
+
+#: id:1403
+msgctxt "Auto context with id 1403"
+msgid "Sun"
+msgstr ""
+
+#: id:1404
+msgid "Heavy"
+msgstr ""
+
+#: id:1405
+msgid "in"
+msgstr ""
+
+#: id:1406
+msgid "the"
+msgstr ""
+
+#: id:1407
+msgid "Vicinity"
+msgstr ""
+
+#: id:1408
+msgid "Ice"
+msgstr ""
+
+#: id:1409
+msgid "Crystals"
+msgstr ""
+
+#: id:1410
+msgid "Calm"
+msgstr ""
+
+#: id:1411
+msgid "with"
+msgstr ""
+
+#: id:1412
+msgid "windy"
+msgstr ""
+
+#: id:1413
+msgid "drizzle"
+msgstr ""
+
+#: id:1414
+msgid "Thunderstorm"
+msgstr ""
+
+#: id:1415
+msgid "Drizzle"
+msgstr ""
+
+#: id:1416
+msgid "Foggy"
+msgstr ""
+
+#: id:1417
+msgid "Grains"
+msgstr ""
+
+#: id:1418
+msgid "T-Storms"
+msgstr ""
+
+#: id:1419
+msgid "T-Showers"
+msgstr ""
+
+#: id:1420
+msgid "Moderate"
+msgstr ""
+
+#: id:1421
+msgid "Very High"
+msgstr ""
+
+#: id:1422
+msgid "Windy"
+msgstr ""
+
+#: id:1423
+msgid "Mist"
+msgstr ""
+
+#: id:1450
+msgid "Put display to sleep when idle"
+msgstr "जब नींद निष्क्रिय प्रदर्शित रखो"
+
+#: id:2050
+msgid "Runtime"
+msgstr ""
+
+#: id:2100
+msgid "Script failed! : %s"
+msgstr ""
+
+#: id:2101
+msgid "Newer version needed - See log"
+msgstr ""
+
+#: id:4501
+msgid "Enable LCD/VFD"
+msgstr ""
+
+#: id:10000
+msgid "Home"
+msgstr ""
+
+#: id:10001
+msgctxt "Auto context with id 10001"
+msgid "Programs"
+msgstr ""
+
+#: id:10002
+msgctxt "Auto context with id 10002"
+msgid "Pictures"
+msgstr ""
+
+#: id:10003
+msgctxt "Auto context with id 10003"
+msgid "File manager"
+msgstr ""
+
+#: id:10004
+msgctxt "Auto context with id 10004"
+msgid "Settings"
+msgstr ""
+
+#: id:10005
+msgctxt "Auto context with id 10005"
+msgid "Music"
+msgstr ""
+
+#: id:10006
+msgctxt "Auto context with id 10006"
+msgid "Videos"
+msgstr ""
+
+#: id:10007
+msgid "System information"
+msgstr ""
+
+#: id:10008
+msgid "Settings - General"
+msgstr ""
+
+#: id:10009
+msgid "Settings - Screen"
+msgstr ""
+
+#: id:10010
+msgid "Settings - Appearance - GUI Calibration"
+msgstr ""
+
+#: id:10011
+msgid "Settings - Videos - Screen Calibration"
+msgstr ""
+
+#: id:10012
+msgid "Settings - Pictures"
+msgstr ""
+
+#: id:10013
+msgid "Settings - Programs"
+msgstr ""
+
+#: id:10014
+msgid "Settings - Weather"
+msgstr ""
+
+#: id:10015
+msgid "Settings - Music"
+msgstr ""
+
+#: id:10016
+msgid "Settings - System"
+msgstr ""
+
+#: id:10017
+msgid "Settings - Videos"
+msgstr ""
+
+#: id:10018
+msgid "Settings - Network"
+msgstr ""
+
+#: id:10019
+msgid "Settings - Appearance"
+msgstr ""
+
+#: id:10020
+msgctxt "Auto context with id 10020"
+msgid "Scripts"
+msgstr ""
+
+#: id:10021
+msgid "Web Browser"
+msgstr ""
+
+#: id:10025
+msgctxt "Auto context with id 10025"
+msgid "Videos"
+msgstr ""
+
+#: id:10028
+msgid "Videos/Playlist"
+msgstr ""
+
+#: id:10029
+msgctxt "Auto context with id 10029"
+msgid "Login screen"
+msgstr ""
+
+#: id:10034
+msgid "Settings - Profiles"
+msgstr ""
+
+#: id:10040
+msgid "Addon browser"
+msgstr ""
+
+#: id:10100
+msgid "Yes/No dialog"
+msgstr ""
+
+#: id:10101
+msgid "Progress dialog"
+msgstr ""
+
+#: id:10210
+msgid "Looking for subtitles..."
+msgstr ""
+
+#: id:10211
+msgid "Looking for or caching subtitles..."
+msgstr ""
+
+#: id:10212
+msgid "terminating"
+msgstr ""
+
+#: id:10213
+msgid "buffering"
+msgstr ""
+
+#: id:10214
+msgid "Opening stream"
+msgstr ""
+
+#: id:10500
+msgid "Music/Playlist"
+msgstr ""
+
+#: id:10501
+msgid "Music/Files"
+msgstr ""
+
+#: id:10502
+msgid "Music/Library"
+msgstr ""
+
+#: id:10503
+msgid "Playlist editor"
+msgstr ""
+
+#: id:10504
+msgid "Top 100 songs"
+msgstr ""
+
+#: id:10505
+msgid "Top 100 albums"
+msgstr ""
+
+#: id:10506
+msgctxt "Auto context with id 10506"
+msgid "Programs"
+msgstr ""
+
+#: id:10507
+msgid "Configuration"
+msgstr ""
+
+#: id:10508
+msgid "Weather forecast"
+msgstr ""
+
+#: id:10509
+msgid "Network gaming"
+msgstr ""
+
+#: id:10510
+msgid "Extensions"
+msgstr ""
+
+#: id:10511
+msgctxt "Auto context with id 10511"
+msgid "System info"
+msgstr ""
+
+#: id:10516
+msgid "Music - Library"
+msgstr ""
+
+#: id:10517
+msgid "Now Playing - Music"
+msgstr ""
+
+#: id:10522
+msgid "Now Playing - Videos"
+msgstr ""
+
+#: id:10523
+msgid "Album info"
+msgstr ""
+
+#: id:10524
+msgid "Movie info"
+msgstr ""
+
+#: id:12000
+msgid "Select dialog"
+msgstr ""
+
+#: id:12001
+msgid "Music/Info"
+msgstr ""
+
+#: id:12002
+msgid "Dialog OK"
+msgstr ""
+
+#: id:12003
+msgid "Videos/Info"
+msgstr ""
+
+#: id:12004
+msgid "Scripts/Info"
+msgstr ""
+
+#: id:12005
+msgid "Fullscreen video"
+msgstr ""
+
+#: id:12006
+msgid "Audio visualization"
+msgstr ""
+
+#: id:12008
+msgid "File stacking dialog"
+msgstr ""
+
+#: id:12009
+msgid "Rebuild index..."
+msgstr ""
+
+#: id:12010
+msgid "Return to music window"
+msgstr ""
+
+#: id:12011
+msgid "Return to videos window"
+msgstr ""
+
+#: id:12021
+msgid "Start from beginning"
+msgstr ""
+
+#: id:12022
+msgid "Resume from %s"
+msgstr ""
+
+#: id:12310
+msgid "0"
+msgstr ""
+
+#: id:12311
+msgid "1"
+msgstr ""
+
+#: id:12312
+msgid "2"
+msgstr ""
+
+#: id:12313
+msgid "3"
+msgstr ""
+
+#: id:12314
+msgid "4"
+msgstr ""
+
+#: id:12315
+msgid "5"
+msgstr ""
+
+#: id:12316
+msgid "6"
+msgstr ""
+
+#: id:12317
+msgid "7"
+msgstr ""
+
+#: id:12318
+msgid "8"
+msgstr ""
+
+#: id:12319
+msgid "9"
+msgstr ""
+
+#: id:12320
+msgid "c"
+msgstr ""
+
+#: id:12321
+msgid "Ok"
+msgstr ""
+
+#: id:12322
+msgid "*"
+msgstr ""
+
+#: id:12325
+msgid "Locked! Enter code..."
+msgstr ""
+
+#: id:12326
+msgid "Enter password"
+msgstr ""
+
+#: id:12327
+msgid "Enter master code"
+msgstr ""
+
+#: id:12328
+msgid "Enter unlock code"
+msgstr ""
+
+#: id:12329
+msgid "or press C to cancel"
+msgstr ""
+
+#: id:12330
+msgid "Enter gamepad button combo and"
+msgstr ""
+
+#: id:12331
+msgid "press OK, or Back to cancel"
+msgstr ""
+
+#: id:12332
+msgid "Set lock"
+msgstr ""
+
+#: id:12333
+msgid "Unlock"
+msgstr ""
+
+#: id:12334
+msgid "Reset lock"
+msgstr ""
+
+#: id:12335
+msgid "Remove lock"
+msgstr ""
+
+#: id:12337
+msgid "Numeric password"
+msgstr ""
+
+#: id:12338
+msgid "Gamepad button combo"
+msgstr ""
+
+#: id:12339
+msgid "Full-text password"
+msgstr ""
+
+#: id:12340
+msgid "Enter new password"
+msgstr ""
+
+#: id:12341
+msgid "Re-Enter new password"
+msgstr ""
+
+#: id:12342
+msgid "Incorrect password,"
+msgstr ""
+
+#: id:12343
+msgid "retries left"
+msgstr ""
+
+#: id:12344
+msgid "Passwords entered did not match."
+msgstr ""
+
+#: id:12345
+msgid "Access denied"
+msgstr ""
+
+#: id:12346
+msgid "Password retry limit exceeded."
+msgstr ""
+
+#: id:12347
+msgid "The system will now shut off."
+msgstr ""
+
+#: id:12348
+msgid "Item locked"
+msgstr ""
+
+#: id:12353
+msgid "Reactivate lock"
+msgstr ""
+
+#: id:12356
+msgid "Change lock"
+msgstr ""
+
+#: id:12357
+msgid "Source lock"
+msgstr ""
+
+#: id:12358
+msgid "Password entry was blank. Try again."
+msgstr ""
+
+#: id:12360
+msgid "Master lock"
+msgstr "मास्टर ताला"
+
+#: id:12362
+msgid "Shutdown system if Master Lock retries exceeded"
+msgstr ""
+
+#: id:12367
+msgid "Master code is not valid"
+msgstr ""
+
+#: id:12368
+msgid "Please enter a valid master code"
+msgstr ""
+
+#: id:12373
+msgid "Settings & file manager"
+msgstr ""
+
+#: id:12376
+msgid "Set as default for all movies"
+msgstr ""
+
+#: id:12377
+msgid "This will reset any previously saved values"
+msgstr ""
+
+#: id:12378
+msgid "Amount of time to display each image"
+msgstr "समय की राशि प्रत्येक छवि प्रदर्शित करने के लिए"
+
+#: id:12379
+msgid "Use pan and zoom effects"
+msgstr "पैन और ज़ूम प्रभाव का उपयोग करें"
+
+#: id:12383
+msgid "12 hour clock"
+msgstr ""
+
+#: id:12384
+msgid "24 hour clock"
+msgstr ""
+
+#: id:12385
+msgid "Day/Month"
+msgstr ""
+
+#: id:12386
+msgid "Month/Day"
+msgstr ""
+
+#: id:12390
+msgid "System uptime"
+msgstr ""
+
+#: id:12391
+msgid "Minutes"
+msgstr ""
+
+#: id:12392
+msgid "Hours"
+msgstr ""
+
+#: id:12393
+msgid "Days"
+msgstr ""
+
+#: id:12394
+msgid "Total uptime"
+msgstr ""
+
+#: id:12395
+msgid "Battery level"
+msgstr ""
+
+#: id:12600
+msgctxt "Auto context with id 12600"
+msgid "Weather"
+msgstr "मौसम"
+
+#: id:12900
+msgctxt "Auto context with id 12900"
+msgid "Screensaver"
+msgstr ""
+
+#: id:12901
+msgid "Fullscreen OSD"
+msgstr ""
+
+#: id:13000
+msgid "System"
+msgstr "प्रणाली"
+
+#: id:13001
+msgid "Immediate HD spindown"
+msgstr ""
+
+#: id:13002
+msgid "Video only"
+msgstr ""
+
+#: id:13003
+msgid "- Delay"
+msgstr ""
+
+#: id:13004
+msgid "- Minimum file duration"
+msgstr ""
+
+#: id:13005
+msgid "Shutdown"
+msgstr ""
+
+#: id:13008
+msgid "Shutdown function"
+msgstr "शट डाउन समारोह"
+
+#: id:13009
+msgid "Quit"
+msgstr "छोड़ो"
+
+#: id:13010
+msgid "Hibernate"
+msgstr ""
+
+#: id:13011
+msgid "Suspend"
+msgstr ""
+
+#: id:13012
+msgid "Exit"
+msgstr ""
+
+#: id:13013
+msgid "Reboot"
+msgstr ""
+
+#: id:13014
+msgid "Minimize"
+msgstr ""
+
+#: id:13015
+msgid "Power button action"
+msgstr ""
+
+#: id:13016
+msgid "Power off System"
+msgstr ""
+
+#: id:13020
+msgid "Is another session active, perhaps over ssh?"
+msgstr ""
+
+#: id:13021
+msgid "Mounted removable harddrive"
+msgstr ""
+
+#: id:13022
+msgid "Unsafe device removal"
+msgstr ""
+
+#: id:13023
+msgid "Successfully removed device"
+msgstr ""
+
+#: id:13024
+msgid "Joystick plugged"
+msgstr ""
+
+#: id:13025
+msgid "Joystick unplugged"
+msgstr ""
+
+#: id:13050
+msgid "Running low on battery"
+msgstr ""
+
+#: id:13100
+msgid "Flicker filter"
+msgstr ""
+
+#: id:13101
+msgid "Let driver choose (requires restart)"
+msgstr ""
+
+#: id:13105
+msgid "Vertical blank sync"
+msgstr "अनुलंब रिक्त सिंक"
+
+#: id:13106
+msgctxt "Auto context with id 13106"
+msgid "Disabled"
+msgstr ""
+
+#: id:13107
+msgid "Enabled during video playback"
+msgstr ""
+
+#: id:13108
+msgctxt "Auto context with id 13108"
+msgid "Always enabled"
+msgstr ""
+
+#: id:13109
+msgid "Test & apply resolution"
+msgstr ""
+
+#: id:13110
+msgid "Save resolution?"
+msgstr ""
+
+#: id:13111
+msgid "Would you like to keep this resolution?"
+msgstr ""
+
+#: id:13112
+msgid "High quality upscaling"
+msgstr ""
+
+#: id:13113
+msgctxt "Auto context with id 13113"
+msgid "Disabled"
+msgstr ""
+
+#: id:13114
+msgid "Enabled for SD content"
+msgstr ""
+
+#: id:13115
+msgctxt "Auto context with id 13115"
+msgid "Always enabled"
+msgstr ""
+
+#: id:13116
+msgid "Upscaling method"
+msgstr ""
+
+#: id:13117
+msgctxt "Auto context with id 13117"
+msgid "Bicubic"
+msgstr ""
+
+#: id:13118
+msgid "Lanczos"
+msgstr ""
+
+#: id:13119
+msgid "Sinc"
+msgstr ""
+
+#: id:13120
+msgctxt "Auto context with id 13120"
+msgid "VDPAU"
+msgstr ""
+
+#: id:13121
+msgid "VDPAU HQ Upscaling level"
+msgstr ""
+
+#: id:13122
+msgid "VDPAU Studio level color conversion"
+msgstr ""
+
+#: id:13130
+msgid "Blank other displays"
+msgstr "खाली अन्य प्रदर्शित करता है"
+
+#: id:13131
+msgctxt "Auto context with id 13131"
+msgid "Disabled"
+msgstr ""
+
+#: id:13132
+msgid "Blank displays"
+msgstr ""
+
+#: id:13140
+msgid "Active connections detected!"
+msgstr ""
+
+#: id:13141
+msgid "If you proceed, you might not be able to control XBMC"
+msgstr ""
+
+#: id:13142
+msgid "any longer. Are you sure you want to stop the Event server?"
+msgstr ""
+
+#: id:13144
+msgid "Change Apple Remote mode?"
+msgstr ""
+
+#: id:13145
+msgid "If you are currently using the Apple Remote to control"
+msgstr ""
+
+#: id:13146
+msgid "XBMC, changing this setting might affect your ability"
+msgstr ""
+
+#: id:13147
+msgid "to continue controlling it. Do you want to proceed?"
+msgstr ""
+
+#: id:13159
+msgid "Subnet mask"
+msgstr ""
+
+#: id:13160
+msgid "Gateway"
+msgstr ""
+
+#: id:13161
+msgid "Primary DNS"
+msgstr ""
+
+#: id:13162
+msgid "Initialize failed"
+msgstr ""
+
+#: id:13170
+msgctxt "Auto context with id 13170"
+msgid "Never"
+msgstr ""
+
+#: id:13171
+msgid "Immediately"
+msgstr ""
+
+#: id:13172
+msgid "After %i secs"
+msgstr ""
+
+#: id:13173
+msgid "HDD install date:"
+msgstr ""
+
+#: id:13174
+msgid "HDD power cycle count:"
+msgstr ""
+
+#: id:13200
+msgid "Profiles"
+msgstr ""
+
+#: id:13201
+msgid "Delete profile '%s'?"
+msgstr ""
+
+#: id:13204
+msgid "Last loaded profile:"
+msgstr ""
+
+#: id:13205
+msgid "Unknown"
+msgstr ""
+
+#: id:13206
+msgid "Overwrite"
+msgstr ""
+
+#: id:13208
+msgid "Alarm clock"
+msgstr ""
+
+#: id:13209
+msgid "Alarm clock interval (in minutes)"
+msgstr ""
+
+#: id:13210
+msgid "Started, alarm in %im"
+msgstr ""
+
+#: id:13211
+msgid "Alarm!"
+msgstr ""
+
+#: id:13212
+msgid "Canceled with %im%is left"
+msgstr ""
+
+#: id:13213
+msgid "%2.0fm"
+msgstr ""
+
+#: id:13214
+msgid "%2.0fs"
+msgstr ""
+
+#: id:13249
+msgid "Search for subtitles in RARs"
+msgstr ""
+
+#: id:13250
+msgid "Browse for subtitle..."
+msgstr ""
+
+#: id:13251
+msgid "Move item"
+msgstr ""
+
+#: id:13252
+msgid "Move item here"
+msgstr ""
+
+#: id:13253
+msgid "Cancel move"
+msgstr ""
+
+#: id:13270
+msgid "Hardware:"
+msgstr ""
+
+#: id:13271
+msgid "CPU Usage:"
+msgstr ""
+
+#: id:13274
+msgid "Connected, but no DNS is available."
+msgstr ""
+
+#: id:13275
+msgid "Hard Disk"
+msgstr ""
+
+#: id:13276
+msgid "DVD-ROM"
+msgstr ""
+
+#: id:13277
+msgctxt "Auto context with id 13277"
+msgid "Storage"
+msgstr ""
+
+#: id:13278
+msgctxt "Auto context with id 13278"
+msgid "Default"
+msgstr ""
+
+#: id:13279
+msgctxt "Auto context with id 13279"
+msgid "Network"
+msgstr ""
+
+#: id:13280
+msgctxt "Auto context with id 13280"
+msgid "Video"
+msgstr ""
+
+#: id:13281
+msgid "Hardware"
+msgstr ""
+
+#: id:13283
+msgid "Operating system:"
+msgstr ""
+
+#: id:13284
+msgid "CPU speed:"
+msgstr ""
+
+#: id:13286
+msgid "Video encoder:"
+msgstr ""
+
+#: id:13287
+msgid "Screen resolution:"
+msgstr ""
+
+#: id:13292
+msgid "A/V cable:"
+msgstr ""
+
+#: id:13294
+msgid "DVD region:"
+msgstr ""
+
+#: id:13295
+msgid "Internet:"
+msgstr ""
+
+#: id:13296
+msgctxt "Auto context with id 13296"
+msgid "Connected"
+msgstr ""
+
+#: id:13297
+msgid "Not connected. Check network settings."
+msgstr ""
+
+#: id:13299
+msgid "Target temperature"
+msgstr ""
+
+#: id:13300
+msgid "Fan speed"
+msgstr ""
+
+#: id:13301
+msgid "Auto temperature control"
+msgstr ""
+
+#: id:13302
+msgid "Fan speed override"
+msgstr ""
+
+#: id:13303
+msgid "- Fonts"
+msgstr "- फ़ॉन्ट्स"
+
+#: id:13304
+msgid "Enable flipping bi-directional strings"
+msgstr ""
+
+#: id:13305
+msgid "Show RSS news feeds"
+msgstr "दिखाएँ आरएसएस समाचार फ़ीड"
+
+#: id:13306
+msgid "Show parent folder items"
+msgstr "दिखाएँ पैरेंट फ़ोल्डर आइटम"
+
+#: id:13307
+msgid "Track naming template"
+msgstr "टेम्पलेट नामकरण ट्रैक"
+
+#: id:13308
+msgid "Do you wish to reboot your system"
+msgstr ""
+
+#: id:13309
+msgid "instead of just XBMC?"
+msgstr ""
+
+#: id:13310
+msgid "Zoom effect"
+msgstr ""
+
+#: id:13311
+msgid "Float effect"
+msgstr ""
+
+#: id:13312
+msgid "Black bar reduction"
+msgstr ""
+
+#: id:13313
+msgid "Restart"
+msgstr ""
+
+#: id:13314
+msgid "Crossfade between songs"
+msgstr "गीतों के बीच क्रॉस - फीका"
+
+#: id:13315
+msgid "Regenerate thumbnails"
+msgstr ""
+
+#: id:13316
+msgid "Recursive thumbnails"
+msgstr ""
+
+#: id:13317
+msgid "View slideshow"
+msgstr ""
+
+#: id:13318
+msgid "Recursive slideshow"
+msgstr ""
+
+#: id:13319
+msgid "Randomize"
+msgstr ""
+
+#: id:13320
+msgid "Stereo"
+msgstr ""
+
+#: id:13321
+msgid "Left only"
+msgstr ""
+
+#: id:13322
+msgid "Right only"
+msgstr ""
+
+#: id:13323
+msgid "Enable karaoke support"
+msgstr "कराओके समर्थन सक्षम करें"
+
+#: id:13324
+msgid "Background transparency"
+msgstr ""
+
+#: id:13325
+msgid "Foreground transparency"
+msgstr ""
+
+#: id:13326
+msgid "A/V delay"
+msgstr ""
+
+#: id:13327
+msgid "Karaoke"
+msgstr "कराओके"
+
+#: id:13328
+msgid "%s not found"
+msgstr ""
+
+#: id:13329
+msgid "Error opening %s"
+msgstr ""
+
+#: id:13330
+msgid "Unable to load %s"
+msgstr ""
+
+#: id:13331
+msgid "Error: Out of memory"
+msgstr ""
+
+#: id:13332
+msgid "Move up"
+msgstr ""
+
+#: id:13333
+msgid "Move down"
+msgstr ""
+
+#: id:13334
+msgid "Edit label"
+msgstr ""
+
+#: id:13335
+msgid "Make default"
+msgstr ""
+
+#: id:13336
+msgid "Remove button"
+msgstr ""
+
+#: id:13340
+msgid "Leave as is"
+msgstr ""
+
+#: id:13341
+msgid "Green"
+msgstr ""
+
+#: id:13342
+msgid "Orange"
+msgstr ""
+
+#: id:13343
+msgid "Red"
+msgstr ""
+
+#: id:13344
+msgid "Cycle"
+msgstr ""
+
+#: id:13345
+msgid "Switch LED off on playback"
+msgstr ""
+
+#: id:13346
+msgctxt "Auto context with id 13346"
+msgid "Movie information"
+msgstr ""
+
+#: id:13347
+msgid "Queue item"
+msgstr ""
+
+#: id:13348
+msgid "Search IMDb..."
+msgstr ""
+
+#: id:13349
+msgid "Scan for new content"
+msgstr ""
+
+#: id:13350
+msgid "Now playing..."
+msgstr ""
+
+#: id:13351
+msgctxt "Auto context with id 13351"
+msgid "Album information"
+msgstr ""
+
+#: id:13352
+msgid "Scan item to library"
+msgstr ""
+
+#: id:13353
+msgid "Stop scanning"
+msgstr ""
+
+#: id:13354
+msgctxt "Auto context with id 13354"
+msgid "Render method"
+msgstr ""
+
+#: id:13355
+msgid "Low quality pixel shader"
+msgstr ""
+
+#: id:13356
+msgid "Hardware overlays"
+msgstr ""
+
+#: id:13357
+msgid "High quality pixel shader"
+msgstr ""
+
+#: id:13358
+msgid "Play item"
+msgstr ""
+
+#: id:13359
+msgid "Set artist thumb"
+msgstr ""
+
+#: id:13360
+msgid "Automatically generate thumbnails"
+msgstr "स्वचालित रूप से थंबनेल उत्पन्न"
+
+#: id:13361
+msgid "Enable voice"
+msgstr ""
+
+#: id:13375
+msgid "Enable device"
+msgstr ""
+
+#: id:13376
+msgid "Volume"
+msgstr ""
+
+#: id:13377
+msgid "Default view mode"
+msgstr ""
+
+#: id:13378
+msgid "Default brightness"
+msgstr ""
+
+#: id:13379
+msgid "Default contrast"
+msgstr ""
+
+#: id:13380
+msgid "Default gamma"
+msgstr ""
+
+#: id:13381
+msgid "Resume video"
+msgstr ""
+
+#: id:13382
+msgid "Voice mask - Port 1"
+msgstr ""
+
+#: id:13383
+msgid "Voice mask - Port 2"
+msgstr ""
+
+#: id:13384
+msgid "Voice mask - Port 3"
+msgstr ""
+
+#: id:13385
+msgid "Voice mask - Port 4"
+msgstr ""
+
+#: id:13386
+msgid "Use time based seeking"
+msgstr ""
+
+#: id:13387
+msgid "Track naming template - right"
+msgstr "ट्रैक नामकरण टेम्पलेट - ठीक है"
+
+#: id:13388
+msgid "Preset"
+msgstr ""
+
+#: id:13389
+msgid "There are no presets available\nfor this visualization"
+msgstr ""
+
+#: id:13390
+msgid "There are no settings available\nfor this visualization"
+msgstr ""
+
+#: id:13391
+msgid "Eject/Load"
+msgstr ""
+
+#: id:13392
+msgid "Use visualization if playing audio"
+msgstr "दृश्य का प्रयोग करें अगर ऑडियो खेल"
+
+#: id:13393
+msgid "Calculate size"
+msgstr ""
+
+#: id:13394
+msgid "Calculating folder size"
+msgstr ""
+
+#: id:13395
+msgid "Video settings"
+msgstr ""
+
+#: id:13396
+msgid "Audio and subtitle settings"
+msgstr ""
+
+#: id:13397
+msgid "Enable subtitles"
+msgstr ""
+
+#: id:13398
+msgctxt "Auto context with id 13398"
+msgid "Shortcuts"
+msgstr ""
+
+#: id:13399
+msgid "Ignore articles when sorting (e.g. \"the\")"
+msgstr "लेख पर ध्यान न दें जब छँटाई (उदाहरण के लिए \"\")"
+
+#: id:13400
+msgid "Crossfade between songs on the same album"
+msgstr "गीतों के बीच एक ही एलबम पर पार - फीका"
+
+#: id:13401
+msgid "Browse for %s"
+msgstr ""
+
+#: id:13402
+msgid "Show track position"
+msgstr ""
+
+#: id:13403
+msgid "Clear default"
+msgstr ""
+
+#: id:13404
+msgid "Resume"
+msgstr ""
+
+#: id:13405
+msgid "Get thumb"
+msgstr ""
+
+#: id:13406
+msgid "Picture information"
+msgstr ""
+
+#: id:13407
+msgid "%s presets"
+msgstr ""
+
+#: id:13408
+msgid "(IMDb user rating)"
+msgstr ""
+
+#: id:13409
+msgid "Top 250"
+msgstr ""
+
+#: id:13410
+msgid "Tune in on Last.fm"
+msgstr ""
+
+#: id:13411
+msgid "Minimum fan speed"
+msgstr ""
+
+#: id:13412
+msgid "Play from here"
+msgstr ""
+
+#: id:13413
+msgid "Downloading"
+msgstr ""
+
+#: id:13414
+msgid "Include artists who appear only on compilations"
+msgstr "कलाकारों को जो केवल संकलन पर दिखाई देते हैं शामिल"
+
+#: id:13415
+msgctxt "Auto context with id 13415"
+msgid "Render method"
+msgstr "विधि सौंपनेवाला"
+
+#: id:13416
+msgid "Auto detect"
+msgstr ""
+
+#: id:13417
+msgid "Basic shaders (ARB)"
+msgstr ""
+
+#: id:13418
+msgid "Advanced shaders (GLSL)"
+msgstr ""
+
+#: id:13419
+msgid "Software"
+msgstr ""
+
+#: id:13420
+msgid "Remove safely"
+msgstr ""
+
+#: id:13421
+msgctxt "Auto context with id 13421"
+msgid "VDPAU"
+msgstr ""
+
+#: id:13422
+msgid "Start slideshow here"
+msgstr ""
+
+#: id:13423
+msgid "Remember for this path"
+msgstr ""
+
+#: id:13424
+msgid "Use pixel buffer objects"
+msgstr ""
+
+#: id:13425
+msgid "Allow hardware acceleration (VDPAU)"
+msgstr ""
+
+#: id:13426
+msgid "Allow hardware acceleration (VAAPI)"
+msgstr ""
+
+#: id:13427
+msgid "Allow hardware acceleration (DXVA2)"
+msgstr ""
+
+#: id:13428
+msgid "Allow hardware acceleration (CrystalHD)"
+msgstr ""
+
+#: id:13429
+msgid "Allow hardware acceleration (VDADecoder)"
+msgstr ""
+
+#: id:13430
+msgid "Allow hardware acceleration (OpenMax)"
+msgstr ""
+
+#: id:13431
+msgid "Pixel Shaders"
+msgstr ""
+
+#: id:13432
+msgid "Allow hardware acceleration (VideoToolbox)"
+msgstr ""
+
+#: id:13500
+msgid "A/V sync method"
+msgstr "A/V सिंक विधि"
+
+#: id:13501
+msgid "Audio clock"
+msgstr ""
+
+#: id:13502
+msgid "Video clock (Drop/Dupe audio)"
+msgstr ""
+
+#: id:13503
+msgid "Video clock (Resample audio)"
+msgstr ""
+
+#: id:13504
+msgid "Maximum resample amount (%)"
+msgstr ""
+
+#: id:13505
+msgid "Resample quality"
+msgstr ""
+
+#: id:13506
+msgid "Low(fast)"
+msgstr ""
+
+#: id:13507
+msgctxt "Auto context with id 13507"
+msgid "Medium"
+msgstr ""
+
+#: id:13508
+msgctxt "Auto context with id 13508"
+msgid "High"
+msgstr ""
+
+#: id:13509
+msgid "Really high(slow!)"
+msgstr ""
+
+#: id:13510
+msgid "Sync playback to display"
+msgstr "सिंक प्लेबैक करने के लिए प्रदर्शन"
+
+#: id:13550
+msgid "Pause during refresh rate change"
+msgstr ""
+
+#: id:13551
+msgctxt "Auto context with id 13551"
+msgid "Off"
+msgstr ""
+
+#: id:13552
+msgid "%.1f Second"
+msgstr ""
+
+#: id:13553
+msgid "%.1f Seconds"
+msgstr ""
+
+#: id:13600
+msgid "Apple remote"
+msgstr ""
+
+#: id:13602
+msgid "Allow start of XBMC using the remote"
+msgstr ""
+
+#: id:13603
+msgid "Sequence delay time"
+msgstr ""
+
+#: id:13610
+msgctxt "Auto context with id 13610"
+msgid "Disabled"
+msgstr ""
+
+#: id:13611
+msgctxt "Auto context with id 13611"
+msgid "Standard"
+msgstr ""
+
+#: id:13612
+msgid "Universal Remote"
+msgstr ""
+
+#: id:13613
+msgid "Multi Remote (Harmony)"
+msgstr ""
+
+#: id:13620
+msgid "Apple Remote Error"
+msgstr ""
+
+#: id:13621
+msgid "Apple Remote support could be enabled."
+msgstr ""
+
+#: id:14000
+msgid "Stack"
+msgstr ""
+
+#: id:14001
+msgid "Unstack"
+msgstr ""
+
+#: id:14003
+msgid "Downloading playlist file..."
+msgstr ""
+
+#: id:14004
+msgid "Downloading streams list..."
+msgstr ""
+
+#: id:14005
+msgid "Parsing streams list..."
+msgstr ""
+
+#: id:14006
+msgid "Downloading streams list failed"
+msgstr ""
+
+#: id:14007
+msgid "Downloading playlist file failed"
+msgstr ""
+
+#: id:14009
+msgid "Games directory"
+msgstr ""
+
+#: id:14010
+msgid "Auto switch to thumbs based on"
+msgstr ""
+
+#: id:14011
+msgid "Enable auto switching to thumbs view"
+msgstr ""
+
+#: id:14012
+msgid "- Use large icons"
+msgstr ""
+
+#: id:14013
+msgid "- Switch based on"
+msgstr ""
+
+#: id:14014
+msgid "- Percentage"
+msgstr ""
+
+#: id:14015
+msgid "No files and at least one thumb"
+msgstr ""
+
+#: id:14016
+msgid "At least one file and thumb"
+msgstr ""
+
+#: id:14017
+msgid "Percentage of thumbs"
+msgstr ""
+
+#: id:14018
+msgid "View options"
+msgstr ""
+
+#: id:14019
+msgid "Change area code 1"
+msgstr "क्षेत्र कोड बदलें 1"
+
+#: id:14020
+msgid "Change area code 2"
+msgstr "क्षेत्र कोड बदलें 2"
+
+#: id:14021
+msgid "Change area code 3"
+msgstr "क्षेत्र कोड बदले 3"
+
+#: id:14022
+msgctxt "Auto context with id 14022"
+msgid "Library"
+msgstr "पुस्तकालय"
+
+#: id:14023
+msgid "No TV"
+msgstr ""
+
+#: id:14024
+msgid "Enter the nearest large town"
+msgstr ""
+
+#: id:14025
+msgid "Video/Audio/DVD cache - Harddisk"
+msgstr ""
+
+#: id:14026
+msgid "Video cache - DVD-ROM"
+msgstr ""
+
+#: id:14027
+msgctxt "Auto context with id 14027"
+msgid "- Local Network"
+msgstr ""
+
+#: id:14028
+msgctxt "Auto context with id 14028"
+msgid "- Internet"
+msgstr ""
+
+#: id:14030
+msgid "Audio cache - DVD-ROM"
+msgstr ""
+
+#: id:14031
+msgctxt "Auto context with id 14031"
+msgid "- Local Network"
+msgstr ""
+
+#: id:14032
+msgctxt "Auto context with id 14032"
+msgid "- Internet"
+msgstr ""
+
+#: id:14034
+msgid "DVD cache - DVD-ROM"
+msgstr ""
+
+#: id:14035
+msgctxt "Auto context with id 14035"
+msgid "- Local Network"
+msgstr ""
+
+#: id:14036
+msgctxt "Auto context with id 14036"
+msgid "Services"
+msgstr "सेवाएँ"
+
+#: id:14038
+msgid "Network settings changed"
+msgstr ""
+
+#: id:14039
+msgid "XBMC requires to restart to change your"
+msgstr ""
+
+#: id:14040
+msgid "network setup. Would you like to restart now?"
+msgstr ""
+
+#: id:14041
+msgid "Internet connection bandwidth limitation"
+msgstr ""
+
+#: id:14043
+msgid "- Shutdown while playing"
+msgstr ""
+
+#: id:14044
+msgid "%i min"
+msgstr ""
+
+#: id:14045
+msgid "%i sec"
+msgstr ""
+
+#: id:14046
+msgid "%i ms"
+msgstr ""
+
+#: id:14047
+msgid "%i %%"
+msgstr ""
+
+#: id:14048
+msgid "%i kbps"
+msgstr ""
+
+#: id:14049
+msgid "%i kb"
+msgstr ""
+
+#: id:14050
+msgid "%i.0 dB"
+msgstr ""
+
+#: id:14051
+msgid "Time format"
+msgstr ""
+
+#: id:14052
+msgid "Date format"
+msgstr ""
+
+#: id:14053
+msgid "GUI filters"
+msgstr ""
+
+#: id:14055
+msgid "Use background scanning"
+msgstr ""
+
+#: id:14056
+msgid "Stop scan"
+msgstr ""
+
+#: id:14057
+msgid "Not possible while scanning for media info"
+msgstr ""
+
+#: id:14058
+msgid "Film grain effect"
+msgstr ""
+
+#: id:14059
+msgid "Search for thumbnails on remote shares"
+msgstr ""
+
+#: id:14060
+msgid "Unknown type cache - Internet"
+msgstr "अज्ञात प्रकार कैश - इंटरनेट"
+
+#: id:14061
+msgctxt "Auto context with id 14061"
+msgid "Auto"
+msgstr ""
+
+#: id:14062
+msgid "Enter username for"
+msgstr ""
+
+#: id:14063
+msgid "Date & time"
+msgstr ""
+
+#: id:14064
+msgid "Set date"
+msgstr ""
+
+#: id:14065
+msgid "Set time"
+msgstr ""
+
+#: id:14066
+msgid "Enter the time in 24 hour HH:MM format"
+msgstr ""
+
+#: id:14067
+msgid "Enter the date in DD/MM/YYYY format"
+msgstr ""
+
+#: id:14068
+msgid "Enter the IP address"
+msgstr ""
+
+#: id:14069
+msgid "Apply these settings now?"
+msgstr ""
+
+#: id:14070
+msgid "Apply changes now"
+msgstr ""
+
+#: id:14071
+msgid "Allow file renaming and deletion"
+msgstr "फ़ाइल का नाम बदलने और विलोपन की अनुमति दें"
+
+#: id:14074
+msgid "Set timezone"
+msgstr ""
+
+#: id:14075
+msgid "Use daylight saving time"
+msgstr ""
+
+#: id:14076
+msgid "Add to favourites"
+msgstr ""
+
+#: id:14077
+msgid "Remove from favourites"
+msgstr ""
+
+#: id:14078
+msgctxt "Auto context with id 14078"
+msgid "- Colours"
+msgstr ""
+
+#: id:14079
+msgid "Timezone country"
+msgstr ""
+
+#: id:14080
+msgid "Timezone"
+msgstr ""
+
+#: id:14081
+msgid "File lists"
+msgstr "फ़ाइल सूचियाँ"
+
+#: id:14082
+msgid "Show EXIF picture information"
+msgstr "Show EXIF picture information"
+
+#: id:14083
+msgid "Use a fullscreen window rather than true fullscreen"
+msgstr "सच पूर्ण स्क्रीन के बजाय एक पूर्ण स्क्रीन विंडो का उपयोग करें"
+
+#: id:14084
+msgid "Queue songs on selection"
+msgstr "चयन पर कतार गाने"
+
+#: id:14086
+msgid "Playback"
+msgstr "प्लेबैक"
+
+#: id:14087
+msgid "DVDs"
+msgstr ""
+
+#: id:14088
+msgid "Play DVDs automatically"
+msgstr "डीवीडी स्वचालित रूप से चलायें"
+
+#: id:14089
+msgid "Font to use for text subtitles"
+msgstr "पाठ उपशीर्षक के लिए उपयोग करने के लिए फ़ॉन्ट"
+
+#: id:14090
+msgid "International"
+msgstr "तरराष्ट्रीय"
+
+#: id:14091
+msgid "Character set"
+msgstr "वर्ण सेट"
+
+#: id:14092
+msgid "Debugging"
+msgstr "डिबगिंग"
+
+#: id:14093
+msgid "Security"
+msgstr ""
+
+#: id:14094
+msgid "Input devices"
+msgstr "इनपुट डिवाइस"
+
+#: id:14095
+msgid "Power saving"
+msgstr "बिजली बचाने के"
+
+#: id:14096
+msgid "Rip"
+msgstr ""
+
+#: id:14097
+msgid "Audio CD Insert Action"
+msgstr ""
+
+#: id:14098
+msgctxt "Auto context with id 14098"
+msgid "Play"
+msgstr ""
+
+#: id:14099
+msgid "Eject disc when CD ripping is complete"
+msgstr ""
+
+#: id:15015
+msgctxt "Auto context with id 15015"
+msgid "Remove"
+msgstr ""
+
+#: id:15016
+msgid "Games"
+msgstr ""
+
+#: id:15019
+msgid "Add"
+msgstr ""
+
+#: id:15052
+msgid "Password"
+msgstr ""
+
+#: id:15100
+msgctxt "Auto context with id 15100"
+msgid "Library"
+msgstr ""
+
+#: id:15101
+msgid "Database"
+msgstr ""
+
+#: id:15102
+msgid "* All albums"
+msgstr ""
+
+#: id:15103
+msgid "* All artists"
+msgstr ""
+
+#: id:15104
+msgid "* All songs"
+msgstr ""
+
+#: id:15105
+msgid "* All genres"
+msgstr ""
+
+#: id:15107
+msgid "Buffering..."
+msgstr ""
+
+#: id:15108
+msgid "Navigation sounds"
+msgstr "नेविगेशन लगता है"
+
+#: id:15109
+msgid "Skin default"
+msgstr ""
+
+#: id:15111
+msgid "- Theme"
+msgstr "- विषय"
+
+#: id:15112
+msgid "Default theme"
+msgstr ""
+
+#: id:15200
+msgid "Last.fm"
+msgstr ""
+
+#: id:15201
+msgid "Submit songs to Last.fm"
+msgstr "Last.fm के लिए गाने सबमिट"
+
+#: id:15202
+msgid "Last.fm username"
+msgstr "Last.fm उपयोगकर्ता नाम"
+
+#: id:15203
+msgid "Last.fm password"
+msgstr "Last.fm पासवर्ड"
+
+#: id:15204
+msgid "Unable to handshake: sleeping..."
+msgstr ""
+
+#: id:15205
+msgid "Please update XBMC"
+msgstr ""
+
+#: id:15206
+msgid "Bad authorization: Check username and password"
+msgstr ""
+
+#: id:15207
+msgctxt "Auto context with id 15207"
+msgid "Connected"
+msgstr ""
+
+#: id:15208
+msgid "Not connected"
+msgstr ""
+
+#: id:15209
+msgid "Submit interval %i"
+msgstr ""
+
+#: id:15210
+msgid "Cached %i songs"
+msgstr ""
+
+#: id:15211
+msgid "Submitting..."
+msgstr ""
+
+#: id:15212
+msgid "Submitting in %i secs"
+msgstr ""
+
+#: id:15213
+msgid "Play using..."
+msgstr ""
+
+#: id:15214
+msgid "Use smoothed A/V synchronization"
+msgstr ""
+
+#: id:15215
+msgid "Hide file names in thumbs view"
+msgstr ""
+
+#: id:15216
+msgid "Play in party mode"
+msgstr ""
+
+#: id:15217
+msgid "Submit songs to Libre.fm"
+msgstr "Libre.fm के लिए गाने सबमिट"
+
+#: id:15218
+msgid "Libre.fm username"
+msgstr "Libre.fm उपयोगकर्ता नाम"
+
+#: id:15219
+msgid "Libre.fm password"
+msgstr "Libre.fm पासवर्ड"
+
+#: id:15220
+msgid "Libre.fm"
+msgstr ""
+
+#: id:15221
+msgid "Song submission"
+msgstr "सांग प्रस्तुत"
+
+#: id:15250
+msgid "Submit Last.fm radio to Last.fm"
+msgstr "Last.fm के लिए Last.fm रेडियो सबमिट"
+
+#: id:15251
+msgid "Connecting to Last.fm..."
+msgstr ""
+
+#: id:15252
+msgid "Selecting station..."
+msgstr ""
+
+#: id:15253
+msgid "Search similar artists..."
+msgstr ""
+
+#: id:15254
+msgid "Search similar tags..."
+msgstr ""
+
+#: id:15255
+msgid "Your profile (%name%)"
+msgstr ""
+
+#: id:15256
+msgid "Overall top tags"
+msgstr ""
+
+#: id:15257
+msgid "Top artists for tag %name%"
+msgstr ""
+
+#: id:15258
+msgid "Top albums for tag %name%"
+msgstr ""
+
+#: id:15259
+msgid "Top tracks for tag %name%"
+msgstr ""
+
+#: id:15260
+msgid "Listen to tag %name% Last.fm radio"
+msgstr ""
+
+#: id:15261
+msgid "Similar artists as %name%"
+msgstr ""
+
+#: id:15262
+msgid "Top %name% albums"
+msgstr ""
+
+#: id:15263
+msgid "Top %name% tracks"
+msgstr ""
+
+#: id:15264
+msgid "Top %name% tags"
+msgstr ""
+
+#: id:15265
+msgid "Biggest fans of %name%"
+msgstr ""
+
+#: id:15266
+msgid "Listen to %name% fans Last.fm radio"
+msgstr ""
+
+#: id:15267
+msgid "Listen to %name% similar artists Last.fm radio"
+msgstr ""
+
+#: id:15268
+msgid "Top artists for user %name%"
+msgstr ""
+
+#: id:15269
+msgid "Top albums for user %name%"
+msgstr ""
+
+#: id:15270
+msgid "Top tracks for user %name%"
+msgstr ""
+
+#: id:15271
+msgid "Friends of user %name%"
+msgstr ""
+
+#: id:15272
+msgid "Neighbours of user %name%"
+msgstr ""
+
+#: id:15273
+msgid "Weekly artist chart for %name%"
+msgstr ""
+
+#: id:15274
+msgid "Weekly album chart for %name%"
+msgstr ""
+
+#: id:15275
+msgid "Weekly track chart for %name%"
+msgstr ""
+
+#: id:15276
+msgid "Listen to %name%'s neighbours Last.fm radio"
+msgstr ""
+
+#: id:15277
+msgid "Listen to %name%'s personal Last.fm radio"
+msgstr ""
+
+#: id:15278
+msgid "Listen to %name%'s mix Last.fm radio"
+msgstr ""
+
+#: id:15279
+msgid "Retrieving list from Last.fm..."
+msgstr ""
+
+#: id:15280
+msgid "Can't retrieve list from Last.fm..."
+msgstr ""
+
+#: id:15281
+msgid "Enter an artist name to find related ones"
+msgstr ""
+
+#: id:15282
+msgid "Enter a tag name to find similar ones"
+msgstr ""
+
+#: id:15283
+msgid "Tracks recently listened by %name%"
+msgstr ""
+
+#: id:15284
+msgid "Listen to %name%'s recommendations Last.fm radio"
+msgstr ""
+
+#: id:15285
+msgid "Top tags for user %name%"
+msgstr ""
+
+#: id:15287
+msgid "Do you want to add the current track to your loved tracks?"
+msgstr ""
+
+#: id:15288
+msgid "Do you want to ban the current track?"
+msgstr ""
+
+#: id:15289
+msgid "Added to your loved tracks: '%s'."
+msgstr ""
+
+#: id:15290
+msgid "Could not add '%s' to your loved tracks."
+msgstr ""
+
+#: id:15291
+msgid "Banned: '%s'."
+msgstr ""
+
+#: id:15292
+msgid "Could not ban '%s'."
+msgstr ""
+
+#: id:15293
+msgid "Tracks recently loved by %name%"
+msgstr ""
+
+#: id:15294
+msgid "Tracks recently banned by %name%"
+msgstr ""
+
+#: id:15295
+msgid "Remove from loved tracks"
+msgstr ""
+
+#: id:15296
+msgid "Un-ban"
+msgstr ""
+
+#: id:15297
+msgid "Do you want to remove this track from your loved tracks?"
+msgstr ""
+
+#: id:15298
+msgid "Do you want to un-ban this track?"
+msgstr ""
+
+#: id:15300
+msgid "Path not found or invalid"
+msgstr ""
+
+#: id:15301
+msgid "Could not connect to network server"
+msgstr ""
+
+#: id:15302
+msgid "No servers found"
+msgstr ""
+
+#: id:15303
+msgid "Workgroup not found"
+msgstr ""
+
+#: id:15310
+msgid "Opening multi-path source"
+msgstr ""
+
+#: id:15311
+msgid "Path:"
+msgstr ""
+
+#: id:16000
+msgctxt "Auto context with id 16000"
+msgid "General"
+msgstr "सामान्य"
+
+#: id:16002
+msgid "Internet lookup"
+msgstr ""
+
+#: id:16003
+msgid "Player"
+msgstr ""
+
+#: id:16004
+msgid "Play media from disc"
+msgstr ""
+
+#: id:16008
+msgid "Enter new title"
+msgstr ""
+
+#: id:16009
+msgid "Enter the movie name"
+msgstr ""
+
+#: id:16010
+msgid "Enter the profile name"
+msgstr ""
+
+#: id:16011
+msgid "Enter the album name"
+msgstr ""
+
+#: id:16012
+msgid "Enter the playlist name"
+msgstr ""
+
+#: id:16013
+msgid "Enter new filename"
+msgstr ""
+
+#: id:16014
+msgid "Enter folder name"
+msgstr ""
+
+#: id:16015
+msgid "Enter directory"
+msgstr ""
+
+#: id:16016
+msgid "Available options: %A, %T, %N, %B, %D, %G, %Y, %F, %S"
+msgstr ""
+
+#: id:16017
+msgid "Enter search string"
+msgstr ""
+
+#: id:16018
+msgctxt "Auto context with id 16018"
+msgid "None"
+msgstr ""
+
+#: id:16019
+msgid "Auto select"
+msgstr ""
+
+#: id:16020
+msgid "De-interlace"
+msgstr ""
+
+#: id:16021
+msgid "Bob"
+msgstr ""
+
+#: id:16022
+msgid "Bob (inverted)"
+msgstr ""
+
+#: id:16024
+msgid "Canceling..."
+msgstr ""
+
+#: id:16025
+msgid "Enter the artist name"
+msgstr ""
+
+#: id:16026
+msgid "Playback failed"
+msgstr ""
+
+#: id:16027
+msgid "One or more items failed to play."
+msgstr ""
+
+#: id:16028
+msgid "Enter value"
+msgstr ""
+
+#: id:16029
+msgid "Check the log file for details."
+msgstr ""
+
+#: id:16030
+msgid "Party mode aborted."
+msgstr ""
+
+#: id:16031
+msgid "No matching songs in the library."
+msgstr ""
+
+#: id:16032
+msgid "Could not initialize database."
+msgstr ""
+
+#: id:16033
+msgid "Could not open database."
+msgstr ""
+
+#: id:16034
+msgid "Could not get songs from database."
+msgstr ""
+
+#: id:16035
+msgid "Party mode playlist"
+msgstr ""
+
+#: id:16036
+msgid "De-interlace (Half)"
+msgstr ""
+
+#: id:16037
+msgid "Deinterlace video"
+msgstr ""
+
+#: id:16038
+msgid "Deinterlace method"
+msgstr ""
+
+#: id:16039
+msgctxt "Auto context with id 16039"
+msgid "Off"
+msgstr ""
+
+#: id:16040
+msgctxt "Auto context with id 16040"
+msgid "Auto"
+msgstr ""
+
+#: id:16041
+msgid "On"
+msgstr ""
+
+#: id:16100
+msgid "All Videos"
+msgstr ""
+
+#: id:16101
+msgid "Unwatched"
+msgstr ""
+
+#: id:16102
+msgid "Watched"
+msgstr ""
+
+#: id:16103
+msgid "Mark as watched"
+msgstr ""
+
+#: id:16104
+msgid "Mark as unwatched"
+msgstr ""
+
+#: id:16105
+msgid "Edit title"
+msgstr ""
+
+#: id:16200
+msgid "Operation was aborted"
+msgstr ""
+
+#: id:16201
+msgid "Copy failed"
+msgstr ""
+
+#: id:16202
+msgid "Failed to copy at least one file"
+msgstr ""
+
+#: id:16203
+msgid "Move failed"
+msgstr ""
+
+#: id:16204
+msgid "Failed to move at least one file"
+msgstr ""
+
+#: id:16205
+msgid "Delete failed"
+msgstr ""
+
+#: id:16206
+msgid "Failed to delete at least one file"
+msgstr ""
+
+#: id:16300
+msgid "Video scaling method"
+msgstr ""
+
+#: id:16301
+msgid "Nearest neighbour"
+msgstr ""
+
+#: id:16302
+msgid "Bilinear"
+msgstr ""
+
+#: id:16303
+msgctxt "Auto context with id 16303"
+msgid "Bicubic"
+msgstr ""
+
+#: id:16304
+msgid "Lanczos2"
+msgstr ""
+
+#: id:16305
+msgid "Lanczos3"
+msgstr ""
+
+#: id:16306
+msgid "Sinc8"
+msgstr ""
+
+#: id:16307
+msgid "Bicubic (software)"
+msgstr ""
+
+#: id:16308
+msgid "Lanczos (software)"
+msgstr ""
+
+#: id:16309
+msgid "Sinc (software)"
+msgstr ""
+
+#: id:16310
+msgid "Temporal"
+msgstr ""
+
+#: id:16311
+msgid "Temporal/Spatial"
+msgstr ""
+
+#: id:16312
+msgid "(VDPAU)Noise Reduction"
+msgstr ""
+
+#: id:16313
+msgid "(VDPAU)Sharpness"
+msgstr ""
+
+#: id:16314
+msgid "Inverse Telecine"
+msgstr ""
+
+#: id:16315
+msgid "Lanczos3 optimized"
+msgstr ""
+
+#: id:16316
+msgctxt "Auto context with id 16316"
+msgid "Auto"
+msgstr ""
+
+#: id:16317
+msgid "Temporal (Half)"
+msgstr ""
+
+#: id:16318
+msgid "Temporal/Spatial (Half)"
+msgstr ""
+
+#: id:16319
+msgid "DXVA"
+msgstr ""
+
+#: id:16320
+msgid "DXVA Bob"
+msgstr ""
+
+#: id:16321
+msgid "DXVA Best"
+msgstr ""
+
+#: id:16322
+msgid "Spline36"
+msgstr ""
+
+#: id:16323
+msgid "Spline36 optimized"
+msgstr ""
+
+#: id:16324
+msgid "Software Blend"
+msgstr ""
+
+#: id:16400
+msgid "Post-processing"
+msgstr "वीडियो पोस्ट - प्रसंस्करण"
+
+#: id:17500
+msgid "Display sleep timeout"
+msgstr ""
+
+#: id:19000
+msgid "Switch to channel"
+msgstr ""
+
+#: id:20000
+msgid "Saved music folder"
+msgstr "सहेजे गए संगीत फ़ोल्डर"
+
+#: id:20001
+msgid "Use external DVD player"
+msgstr ""
+
+#: id:20002
+msgid "External DVD player"
+msgstr ""
+
+#: id:20003
+msgid "Trainers folder"
+msgstr ""
+
+#: id:20004
+msgid "Screenshot folder"
+msgstr "स्क्रीनशॉट फ़ोल्डर"
+
+#: id:20006
+msgid "Playlists folder"
+msgstr ""
+
+#: id:20007
+msgid "Recordings"
+msgstr ""
+
+#: id:20008
+msgid "Screenshots"
+msgstr ""
+
+#: id:20009
+msgid "Use XBMC"
+msgstr ""
+
+#: id:20011
+msgid "Music playlists"
+msgstr ""
+
+#: id:20012
+msgid "Video playlists"
+msgstr ""
+
+#: id:20013
+msgid "Do you wish to launch the game?"
+msgstr ""
+
+#: id:20014
+msgid "Sort by: Playlist"
+msgstr ""
+
+#: id:20015
+msgid "Remote thumb"
+msgstr ""
+
+#: id:20016
+msgid "Current thumb"
+msgstr ""
+
+#: id:20017
+msgid "Local thumb"
+msgstr ""
+
+#: id:20018
+msgid "No thumb"
+msgstr ""
+
+#: id:20019
+msgid "Choose thumbnail"
+msgstr ""
+
+#: id:20023
+msgid "Conflict"
+msgstr ""
+
+#: id:20024
+msgid "Scan new"
+msgstr ""
+
+#: id:20025
+msgid "Scan all"
+msgstr ""
+
+#: id:20026
+msgid "Region"
+msgstr "क्षेत्र"
+
+#: id:20037
+msgid "Summary"
+msgstr ""
+
+#: id:20038
+msgid "Lock music window"
+msgstr ""
+
+#: id:20039
+msgid "Lock videos window"
+msgstr ""
+
+#: id:20040
+msgid "Lock pictures window"
+msgstr ""
+
+#: id:20041
+msgid "Lock programs & scripts windows"
+msgstr ""
+
+#: id:20042
+msgid "Lock file manager"
+msgstr ""
+
+#: id:20043
+msgid "Lock settings"
+msgstr ""
+
+#: id:20044
+msgid "Start fresh"
+msgstr ""
+
+#: id:20045
+msgid "Enter master mode"
+msgstr ""
+
+#: id:20046
+msgid "Leave master mode"
+msgstr ""
+
+#: id:20047
+msgid "Create profile '%s'?"
+msgstr ""
+
+#: id:20048
+msgid "Start with fresh settings"
+msgstr ""
+
+#: id:20049
+msgid "Best available"
+msgstr ""
+
+#: id:20050
+msgid "Auto-switch between 16x9 and 4x3"
+msgstr ""
+
+#: id:20051
+msgid "Treat stacked files as single file"
+msgstr ""
+
+#: id:20052
+msgid "Caution"
+msgstr ""
+
+#: id:20053
+msgid "Left master mode"
+msgstr ""
+
+#: id:20054
+msgid "Entered master mode"
+msgstr ""
+
+#: id:20055
+msgid "Allmusic.com thumb"
+msgstr ""
+
+#: id:20057
+msgid "Remove thumbnail"
+msgstr ""
+
+#: id:20058
+msgid "Add profile..."
+msgstr ""
+
+#: id:20059
+msgid "Query info for all albums"
+msgstr ""
+
+#: id:20060
+msgctxt "Auto context with id 20060"
+msgid "Media info"
+msgstr ""
+
+#: id:20061
+msgctxt "Auto context with id 20061"
+msgid "Separate"
+msgstr ""
+
+#: id:20062
+msgid "Shares with default"
+msgstr ""
+
+#: id:20063
+msgid "Shares with default (read only)"
+msgstr ""
+
+#: id:20064
+msgid "Copy default"
+msgstr ""
+
+#: id:20065
+msgid "Profile picture"
+msgstr ""
+
+#: id:20066
+msgid "Lock preferences"
+msgstr ""
+
+#: id:20067
+msgid "Edit profile"
+msgstr ""
+
+#: id:20068
+msgid "Profile lock"
+msgstr ""
+
+#: id:20069
+msgid "Could not create folder"
+msgstr ""
+
+#: id:20070
+msgid "Profile directory"
+msgstr ""
+
+#: id:20071
+msgid "Start with fresh media sources"
+msgstr ""
+
+#: id:20072
+msgid "Make sure the selected folder is writable"
+msgstr ""
+
+#: id:20073
+msgid "and that the new folder name is valid"
+msgstr ""
+
+#: id:20074
+msgid "MPAA rating"
+msgstr ""
+
+#: id:20075
+msgid "Enter master lock code"
+msgstr ""
+
+#: id:20076
+msgid "Ask for master lock code on startup"
+msgstr "स्टार्टअप पर मास्टर लॉक कोड के लिए पूछें"
+
+#: id:20077
+msgid "Skin settings"
+msgstr ""
+
+#: id:20078
+msgid "- no link set -"
+msgstr ""
+
+#: id:20079
+msgid "Enable animations"
+msgstr ""
+
+#: id:20080
+msgid "Disable RSS during music"
+msgstr ""
+
+#: id:20081
+msgid "Enable shortcut buttons"
+msgstr ""
+
+#: id:20082
+msgid "Show programs in main menu"
+msgstr ""
+
+#: id:20083
+msgid "Show music info"
+msgstr "संगीत जानकारी दिखाएँ"
+
+#: id:20084
+msgid "Show weather info"
+msgstr "मौसम की जानकारी दिखाएँ"
+
+#: id:20085
+msgid "Show system info"
+msgstr ""
+
+#: id:20086
+msgid "Show available disc space C: E: F:"
+msgstr ""
+
+#: id:20087
+msgid "Show available disc space E: F: G:"
+msgstr ""
+
+#: id:20088
+msgid "Weather info"
+msgstr ""
+
+#: id:20089
+msgid "Drive space free"
+msgstr ""
+
+#: id:20090
+msgid "Enter the name of an existing share"
+msgstr ""
+
+#: id:20091
+msgid "Lock code"
+msgstr ""
+
+#: id:20092
+msgid "Load profile"
+msgstr ""
+
+#: id:20093
+msgid "Profile name"
+msgstr ""
+
+#: id:20094
+msgctxt "Auto context with id 20094"
+msgid "Media sources"
+msgstr ""
+
+#: id:20095
+msgid "Enter profile lock code"
+msgstr ""
+
+#: id:20096
+msgctxt "Auto context with id 20096"
+msgid "Login screen"
+msgstr ""
+
+#: id:20097
+msgid "Fetching album info"
+msgstr ""
+
+#: id:20098
+msgid "Fetching info for album"
+msgstr ""
+
+#: id:20099
+msgid "Can't rip CD or track while playing from CD"
+msgstr ""
+
+#: id:20100
+msgid "Master lock code and settings"
+msgstr "मास्टर ताला कोड और सेटिंग्स"
+
+#: id:20101
+msgid "Entering master lock code always enables master mode"
+msgstr ""
+
+#: id:20102
+msgid "or copy from default?"
+msgstr ""
+
+#: id:20103
+msgid "Save changes to profile?"
+msgstr ""
+
+#: id:20104
+msgid "Old settings found."
+msgstr ""
+
+#: id:20105
+msgid "Do you want to use them?"
+msgstr ""
+
+#: id:20106
+msgid "Old media sources found."
+msgstr ""
+
+#: id:20107
+msgid "Separate (locked)"
+msgstr ""
+
+#: id:20108
+msgid "Root"
+msgstr ""
+
+#: id:20109
+msgid "- Zoom"
+msgstr "- ज़ूम"
+
+#: id:20110
+msgid "UPnP settings"
+msgstr ""
+
+#: id:20111
+msgid "Autostart UPnP client"
+msgstr ""
+
+#: id:20112
+msgid "Last login: %s"
+msgstr ""
+
+#: id:20113
+msgid "Never logged on"
+msgstr ""
+
+#: id:20114
+msgid "Profile %i / %i"
+msgstr ""
+
+#: id:20115
+msgid "User login / Select a profile"
+msgstr ""
+
+#: id:20116
+msgid "Use lock on login screen"
+msgstr ""
+
+#: id:20117
+msgid "Invalid lock code."
+msgstr ""
+
+#: id:20118
+msgid "This requires the master lock to be set."
+msgstr ""
+
+#: id:20119
+msgid "Would you like to set it now?"
+msgstr ""
+
+#: id:20120
+msgid "Loading program information"
+msgstr ""
+
+#: id:20121
+msgid "Party on!"
+msgstr ""
+
+#: id:20122
+msgid "True"
+msgstr ""
+
+#: id:20123
+msgid "Mixing drinks"
+msgstr ""
+
+#: id:20124
+msgid "Filling glasses"
+msgstr ""
+
+#: id:20125
+msgid "Logged on as"
+msgstr ""
+
+#: id:20126
+msgid "Log off"
+msgstr ""
+
+#: id:20128
+msgid "Go to root"
+msgstr ""
+
+#: id:20129
+msgid "Weave"
+msgstr ""
+
+#: id:20130
+msgid "Weave (inverted)"
+msgstr ""
+
+#: id:20131
+msgid "Blend"
+msgstr ""
+
+#: id:20132
+msgid "Restart video"
+msgstr ""
+
+#: id:20133
+msgid "Edit network location"
+msgstr ""
+
+#: id:20134
+msgid "Remove network location"
+msgstr ""
+
+#: id:20135
+msgid "Do you want to scan the folder?"
+msgstr ""
+
+#: id:20136
+msgid "Memory unit"
+msgstr ""
+
+#: id:20137
+msgid "Memory unit mounted"
+msgstr ""
+
+#: id:20138
+msgid "Unable to mount memory unit"
+msgstr ""
+
+#: id:20139
+msgid "In port %i, slot %i"
+msgstr ""
+
+#: id:20140
+msgid "Lock screensaver"
+msgstr ""
+
+#: id:20141
+msgid "Set"
+msgstr ""
+
+#: id:20142
+msgctxt "Auto context with id 20142"
+msgid "Username"
+msgstr ""
+
+#: id:20143
+msgid "Enter password for"
+msgstr ""
+
+#: id:20144
+msgid "Shutdown timer"
+msgstr ""
+
+#: id:20145
+msgid "Shutdown interval (in minutes)"
+msgstr ""
+
+#: id:20146
+msgid "Started, shutdown in %im"
+msgstr ""
+
+#: id:20147
+msgid "Shutdown in 30 minutes"
+msgstr ""
+
+#: id:20148
+msgid "Shutdown in 60 minutes"
+msgstr ""
+
+#: id:20149
+msgid "Shutdown in 120 minutes"
+msgstr ""
+
+#: id:20150
+msgid "Custom shutdown timer"
+msgstr ""
+
+#: id:20151
+msgid "Cancel shutdown timer"
+msgstr ""
+
+#: id:20152
+msgid "Lock preferences for %s"
+msgstr ""
+
+#: id:20153
+msgid "Browse..."
+msgstr ""
+
+#: id:20154
+msgid "Summary information"
+msgstr ""
+
+#: id:20155
+msgid "Storage information"
+msgstr ""
+
+#: id:20156
+msgid "Hard disk information"
+msgstr ""
+
+#: id:20157
+msgid "DVD-ROM information"
+msgstr ""
+
+#: id:20158
+msgid "Network information"
+msgstr ""
+
+#: id:20159
+msgid "Video information"
+msgstr ""
+
+#: id:20160
+msgid "Hardware information"
+msgstr ""
+
+#: id:20161
+msgid "Total"
+msgstr ""
+
+#: id:20162
+msgid "Used"
+msgstr ""
+
+#: id:20163
+msgid "of"
+msgstr ""
+
+#: id:20164
+msgid "Locking not supported"
+msgstr ""
+
+#: id:20165
+msgid "Not locked"
+msgstr ""
+
+#: id:20166
+msgid "Locked"
+msgstr ""
+
+#: id:20167
+msgid "Frozen"
+msgstr ""
+
+#: id:20168
+msgid "Requires reset"
+msgstr ""
+
+#: id:20169
+msgid "Week"
+msgstr ""
+
+#: id:20170
+msgid "Line"
+msgstr ""
+
+#: id:20171
+msgid "Windows network (SMB)"
+msgstr ""
+
+#: id:20172
+msgid "XBMSP server"
+msgstr ""
+
+#: id:20173
+msgctxt "Auto context with id 20173"
+msgid "FTP server"
+msgstr ""
+
+#: id:20174
+msgid "iTunes music share (DAAP)"
+msgstr ""
+
+#: id:20175
+msgid "UPnP server"
+msgstr ""
+
+#: id:20176
+msgid "Show video info"
+msgstr "वीडियो जानकारी दिखाएँ"
+
+#: id:20177
+msgid "Done"
+msgstr ""
+
+#: id:20178
+msgid "Shift"
+msgstr ""
+
+#: id:20179
+msgid "Caps Lock"
+msgstr ""
+
+#: id:20180
+msgid "Symbols"
+msgstr ""
+
+#: id:20181
+msgid "Backspace"
+msgstr ""
+
+#: id:20182
+msgid "Space"
+msgstr ""
+
+#: id:20183
+msgid "Reload skin"
+msgstr ""
+
+#: id:20184
+msgid "Rotate pictures using EXIF information"
+msgstr "EXIF जानकारी का उपयोग कर चित्रों घुमाएँ"
+
+#: id:20185
+msgid "Use poster view styles for TV shows"
+msgstr ""
+
+#: id:20186
+msgid "Please wait"
+msgstr ""
+
+#: id:20187
+msgid "UPnP"
+msgstr ""
+
+#: id:20189
+msgid "Enable auto scrolling for plot & review"
+msgstr "साजिश और समीक्षा के लिए ऑटो स्क्रॉल सक्षम"
+
+#: id:20190
+msgctxt "Auto context with id 20190"
+msgid "Custom"
+msgstr ""
+
+#: id:20191
+msgid "Enable debug logging"
+msgstr "लॉगिंग डिबग सक्षम"
+
+#: id:20192
+msgid "Download additional information during updates"
+msgstr "डाउनलोड अद्यतन के दौरान अतिरिक्त जानकारी"
+
+#: id:20193
+msgid "Default service for album information"
+msgstr "एल्बम जानकारी के लिए डिफ़ॉल्ट सेवा"
+
+#: id:20194
+msgid "Default service for artist information"
+msgstr "कलाकार जानकारी के लिए डिफ़ॉल्ट सेवा"
+
+#: id:20195
+msgid "Change scraper"
+msgstr ""
+
+#: id:20196
+msgid "Export music library"
+msgstr "निर्यात संगीत पुस्तकालय"
+
+#: id:20197
+msgid "Import music library"
+msgstr "संगीत पुस्तकालय आयात"
+
+#: id:20198
+msgid "No artist found!"
+msgstr ""
+
+#: id:20199
+msgid "Downloading artist info failed"
+msgstr ""
+
+#: id:20250
+msgid "Party on! (videos)"
+msgstr ""
+
+#: id:20251
+msgid "Mixing drinks (videos)"
+msgstr ""
+
+#: id:20252
+msgid "Filling glasses (videos)"
+msgstr ""
+
+#: id:20253
+msgid "WebDAV server (HTTP)"
+msgstr ""
+
+#: id:20254
+msgid "WebDAV server (HTTPS)"
+msgstr ""
+
+#: id:20255
+msgid "First logon, edit your profile"
+msgstr ""
+
+#: id:20256
+msgid "HTS Tvheadend client"
+msgstr ""
+
+#: id:20257
+msgid "VDR Streamdev client"
+msgstr ""
+
+#: id:20258
+msgid "MythTV client"
+msgstr ""
+
+#: id:20259
+msgid "Network Filesystem (NFS)"
+msgstr ""
+
+#: id:20260
+msgid "Secure Shell (SSH/SFTP)"
+msgstr ""
+
+#: id:20261
+msgid "Apple Filing Protocol (AFP)"
+msgstr ""
+
+#: id:20300
+msgid "Web server directory (HTTP)"
+msgstr ""
+
+#: id:20301
+msgid "Web server directory (HTTPS)"
+msgstr ""
+
+#: id:20302
+msgid "Unable to write to folder:"
+msgstr ""
+
+#: id:20303
+msgid "Do you want to skip and proceed?"
+msgstr ""
+
+#: id:20304
+msgid "RSS Feed"
+msgstr ""
+
+#: id:20307
+msgid "Secondary DNS"
+msgstr ""
+
+#: id:20308
+msgid "DHCP server:"
+msgstr ""
+
+#: id:20309
+msgid "Make new folder"
+msgstr ""
+
+#: id:20310
+msgid "Dim LCD on playback"
+msgstr ""
+
+#: id:20311
+msgid "Unknown or onboard (protected)"
+msgstr ""
+
+#: id:20312
+msgid "Dim LCD on paused"
+msgstr ""
+
+#: id:20314
+msgid "Videos - Library"
+msgstr ""
+
+#: id:20316
+msgid "Sort by: ID"
+msgstr ""
+
+#: id:20324
+msgid "Play part..."
+msgstr ""
+
+#: id:20325
+msgid "Calibration reset"
+msgstr ""
+
+#: id:20326
+msgid "This will reset the calibration values for %s"
+msgstr ""
+
+#: id:20327
+msgid "to it's default values."
+msgstr ""
+
+#: id:20328
+msgid "Browse for destination"
+msgstr ""
+
+#: id:20329
+msgid "Movies are in separate folders that match the movie title"
+msgstr ""
+
+#: id:20330
+msgid "Use folder names for lookups"
+msgstr ""
+
+#: id:20331
+msgctxt "Auto context with id 20331"
+msgid "File"
+msgstr ""
+
+#: id:20332
+msgid "Use file or folder names in lookups?"
+msgstr ""
+
+#: id:20333
+msgid "Set content"
+msgstr ""
+
+#: id:20334
+msgid "Folder"
+msgstr ""
+
+#: id:20335
+msgid "Look for content recursively?"
+msgstr ""
+
+#: id:20336
+msgid "Unlock sources"
+msgstr ""
+
+#: id:20337
+msgid "Actor"
+msgstr ""
+
+#: id:20338
+msgid "Movie"
+msgstr ""
+
+#: id:20339
+msgid "Director"
+msgstr ""
+
+#: id:20340
+msgid "Do you want to remove all items within"
+msgstr ""
+
+#: id:20341
+msgid "this path from the XBMC library?"
+msgstr ""
+
+#: id:20342
+msgctxt "Auto context with id 20342"
+msgid "Movies"
+msgstr ""
+
+#: id:20343
+msgid "TV shows"
+msgstr ""
+
+#: id:20344
+msgid "This directory contains"
+msgstr ""
+
+#: id:20345
+msgid "Run automated scan"
+msgstr ""
+
+#: id:20346
+msgid "Scan recursively"
+msgstr ""
+
+#: id:20347
+msgid "as"
+msgstr ""
+
+#: id:20348
+msgid "Directors"
+msgstr ""
+
+#: id:20349
+msgid "No video files found in this path!"
+msgstr ""
+
+#: id:20350
+msgid "votes"
+msgstr ""
+
+#: id:20351
+msgid "TV show information"
+msgstr ""
+
+#: id:20352
+msgid "Episode information"
+msgstr ""
+
+#: id:20353
+msgid "Loading TV show details"
+msgstr ""
+
+#: id:20354
+msgid "Fetching episode guide"
+msgstr ""
+
+#: id:20355
+msgid "Loading info for episodes in directory"
+msgstr ""
+
+#: id:20356
+msgid "Select TV show:"
+msgstr ""
+
+#: id:20357
+msgid "Enter the TV show name"
+msgstr ""
+
+#: id:20358
+msgid "Season %i"
+msgstr ""
+
+#: id:20359
+msgid "Episode"
+msgstr ""
+
+#: id:20360
+msgid "Episodes"
+msgstr ""
+
+#: id:20361
+msgid "Loading episode details"
+msgstr ""
+
+#: id:20362
+msgid "Remove episode from library"
+msgstr ""
+
+#: id:20363
+msgid "Remove TV show from library"
+msgstr ""
+
+#: id:20364
+msgid "TV show"
+msgstr ""
+
+#: id:20365
+msgid "Episode plot"
+msgstr ""
+
+#: id:20366
+msgid "* All seasons"
+msgstr ""
+
+#: id:20367
+msgid "Hide watched"
+msgstr ""
+
+#: id:20368
+msgid "Prod code"
+msgstr ""
+
+#: id:20369
+msgid "Show plot for unwatched items"
+msgstr "उन्वात्चेद मदों के लिए साजिश दिखाएँ"
+
+#: id:20370
+msgid "* Hidden to prevent spoilers *"
+msgstr ""
+
+#: id:20371
+msgid "Set season thumb"
+msgstr ""
+
+#: id:20372
+msgid "Season image"
+msgstr ""
+
+#: id:20373
+msgid "Season"
+msgstr ""
+
+#: id:20374
+msgid "Downloading movie information"
+msgstr ""
+
+#: id:20375
+msgid "Unassign content"
+msgstr ""
+
+#: id:20376
+msgid "Original title"
+msgstr ""
+
+#: id:20377
+msgid "Refresh TV show information"
+msgstr ""
+
+#: id:20378
+msgid "Refresh info for all episodes?"
+msgstr ""
+
+#: id:20379
+msgid "Selected folder contains a single TV show"
+msgstr ""
+
+#: id:20380
+msgid "Exclude selected folder from scans"
+msgstr ""
+
+#: id:20381
+msgid "Specials"
+msgstr ""
+
+#: id:20382
+msgid "Automatically grab season thumbs"
+msgstr ""
+
+#: id:20383
+msgid "Selected folder contains a single video"
+msgstr ""
+
+#: id:20384
+msgid "Link to TV show"
+msgstr ""
+
+#: id:20385
+msgid "Remove link to TV show"
+msgstr ""
+
+#: id:20386
+msgid "Recently added movies"
+msgstr ""
+
+#: id:20387
+msgid "Recently added episodes"
+msgstr ""
+
+#: id:20388
+msgid "Studios"
+msgstr ""
+
+#: id:20389
+msgid "Music videos"
+msgstr ""
+
+#: id:20390
+msgid "Recently added music videos"
+msgstr ""
+
+#: id:20391
+msgid "Music video"
+msgstr ""
+
+#: id:20392
+msgid "Remove music video from library"
+msgstr ""
+
+#: id:20393
+msgctxt "Auto context with id 20393"
+msgid "Music video information"
+msgstr "संगीत वीडियो की जानकारी"
+
+#: id:20394
+msgid "Loading music video information"
+msgstr ""
+
+#: id:20395
+msgid "Mixed"
+msgstr ""
+
+#: id:20396
+msgid "Go to albums by artist"
+msgstr ""
+
+#: id:20397
+msgid "Go to album"
+msgstr ""
+
+#: id:20398
+msgid "Play song"
+msgstr ""
+
+#: id:20399
+msgid "Go to music videos from album"
+msgstr ""
+
+#: id:20400
+msgid "Go to music videos by artist"
+msgstr ""
+
+#: id:20401
+msgid "Play music video"
+msgstr ""
+
+#: id:20402
+msgid "Download actor thumbnails when adding to library"
+msgstr "अभिनेता थंबनेल डाउनलोड जब पुस्तकालय को जोड़ने"
+
+#: id:20403
+msgid "Set actor thumb"
+msgstr ""
+
+#: id:20405
+msgid "Remove episode bookmark"
+msgstr ""
+
+#: id:20406
+msgid "Set episode bookmark"
+msgstr ""
+
+#: id:20407
+msgid "Scraper settings"
+msgstr ""
+
+#: id:20408
+msgid "Downloading music video information"
+msgstr ""
+
+#: id:20409
+msgid "Downloading TV show information"
+msgstr ""
+
+#: id:20410
+msgid "Trailer"
+msgstr ""
+
+#: id:20411
+msgid "Flatten"
+msgstr ""
+
+#: id:20412
+msgid "Flatten TV shows"
+msgstr "टीवी शो समतल"
+
+#: id:20413
+msgid "Get fanart"
+msgstr ""
+
+#: id:20414
+msgid "Show Fanart in video and music libraries"
+msgstr ""
+
+#: id:20415
+msgid "Scanning for new content"
+msgstr ""
+
+#: id:20416
+msgid "First aired"
+msgstr ""
+
+#: id:20417
+msgid "Writer"
+msgstr ""
+
+#: id:20419
+msgid "Replace file names with library titles"
+msgstr ""
+
+#: id:20420
+msgctxt "Auto context with id 20420"
+msgid "Never"
+msgstr ""
+
+#: id:20421
+msgid "If only one season"
+msgstr ""
+
+#: id:20422
+msgid "Always"
+msgstr ""
+
+#: id:20423
+msgid "Has trailer"
+msgstr ""
+
+#: id:20424
+msgid "False"
+msgstr ""
+
+#: id:20425
+msgid "Fanart slideshow"
+msgstr ""
+
+#: id:20426
+msgid "Export to a single file or separate"
+msgstr ""
+
+#: id:20427
+msgid "files per entry?"
+msgstr ""
+
+#: id:20428
+msgid "Single file"
+msgstr ""
+
+#: id:20429
+msgctxt "Auto context with id 20429"
+msgid "Separate"
+msgstr ""
+
+#: id:20430
+msgid "Export thumbnails and fanart?"
+msgstr ""
+
+#: id:20431
+msgid "Overwrite old files?"
+msgstr ""
+
+#: id:20432
+msgid "Exclude path from library updates"
+msgstr ""
+
+#: id:20433
+msgid "Extract thumbnails and video information"
+msgstr "निकालें थंबनेल और वीडियो जानकारी"
+
+#: id:20434
+msgid "Sets"
+msgstr ""
+
+#: id:20435
+msgid "Set movieset thumb"
+msgstr ""
+
+#: id:20436
+msgid "Export actor thumbs?"
+msgstr ""
+
+#: id:20437
+msgid "Choose fanart"
+msgstr ""
+
+#: id:20438
+msgid "Local fanart"
+msgstr ""
+
+#: id:20439
+msgid "No fanart"
+msgstr ""
+
+#: id:20440
+msgid "Current fanart"
+msgstr ""
+
+#: id:20441
+msgid "Remote fanart"
+msgstr ""
+
+#: id:20442
+msgid "Change content"
+msgstr ""
+
+#: id:20443
+msgid "Do you want to refresh info for all"
+msgstr ""
+
+#: id:20444
+msgid "items within this path?"
+msgstr ""
+
+#: id:20445
+msgid "Fanart"
+msgstr ""
+
+#: id:20446
+msgid "Locally stored information found."
+msgstr ""
+
+#: id:20447
+msgid "Ignore and refresh from internet?"
+msgstr ""
+
+#: id:20448
+msgid "Could not download information"
+msgstr ""
+
+#: id:20449
+msgid "Unable to connect to remote server"
+msgstr ""
+
+#: id:20450
+msgid "Would you like to continue scanning?"
+msgstr ""
+
+#: id:20451
+msgid "Countries"
+msgstr ""
+
+#: id:20452
+msgid "episode"
+msgstr ""
+
+#: id:20453
+msgid "episodes"
+msgstr ""
+
+#: id:20454
+msgid "Listener"
+msgstr ""
+
+#: id:20455
+msgid "Listeners"
+msgstr ""
+
+#: id:20456
+msgid "Set movieset fanart"
+msgstr ""
+
+#: id:20457
+msgid "Movie set"
+msgstr ""
+
+#: id:20458
+msgid "Group movies in sets"
+msgstr ""
+
+#: id:21330
+msgid "Show hidden files and directories"
+msgstr "दिखाएँ छुपी फ़ाइलें और निर्देशिका"
+
+#: id:21331
+msgid "TuxBox client"
+msgstr ""
+
+#: id:21332
+msgid "WARNING: Target TuxBox device is in recording-mode!"
+msgstr ""
+
+#: id:21333
+msgid "The stream will be stopped!"
+msgstr ""
+
+#: id:21334
+msgid "Zap to channel: %s failed!"
+msgstr ""
+
+#: id:21335
+msgid "Are you sure to start the stream?"
+msgstr ""
+
+#: id:21336
+msgid "Connecting to: %s"
+msgstr ""
+
+#: id:21337
+msgid "TuxBox device"
+msgstr ""
+
+#: id:21359
+msgid "Add media share..."
+msgstr ""
+
+#: id:21360
+msgid "Share video and music libraries through UPnP"
+msgstr "शेयर और UPnP के माध्यम से वीडियो संगीत पुस्तकालयों"
+
+#: id:21364
+msgid "Edit media share"
+msgstr ""
+
+#: id:21365
+msgid "Remove media share"
+msgstr ""
+
+#: id:21366
+msgid "Subtitle folder"
+msgstr "उपशीर्षक फ़ोल्डर"
+
+#: id:21367
+msgid "Movie & alternate subtitle directory"
+msgstr ""
+
+#: id:21368
+msgid "Override ASS/SSA subtitles fonts"
+msgstr ""
+
+#: id:21369
+msgid "Enable mouse and Touch Screen support"
+msgstr "माउस सक्षम"
+
+#: id:21370
+msgid "Play navigation sounds during media playback"
+msgstr ""
+
+#: id:21371
+msgid "Thumbnail"
+msgstr ""
+
+#: id:21372
+msgid "Forced DVD player region"
+msgstr "जबरिया डीवीडी प्लेयर क्षेत्र"
+
+#: id:21373
+msgid "Video output"
+msgstr "वीडियो आउटपुट"
+
+#: id:21374
+msgid "Video aspect"
+msgstr ""
+
+#: id:21375
+msgctxt "Auto context with id 21375"
+msgid "Normal"
+msgstr ""
+
+#: id:21376
+msgid "Letterbox"
+msgstr ""
+
+#: id:21377
+msgid "Widescreen"
+msgstr ""
+
+#: id:21378
+msgid "Enable 480p"
+msgstr ""
+
+#: id:21379
+msgid "Enable 720p"
+msgstr ""
+
+#: id:21380
+msgid "Enable 1080i"
+msgstr ""
+
+#: id:21381
+msgid "Enter name of new playlist"
+msgstr ""
+
+#: id:21382
+msgid "Show \"Add source\" buttons in file lists"
+msgstr "दिखाएँ फ़ाइल सूची में बटन \"स्रोत\" जोड़ें"
+
+#: id:21383
+msgid "Enable scrollbars"
+msgstr ""
+
+#: id:21384
+msgid "Make watched filtering a toggle in video library"
+msgstr ""
+
+#: id:21385
+msgctxt "Auto context with id 21385"
+msgid "Open"
+msgstr ""
+
+#: id:21386
+msgid "Acoustic management level"
+msgstr ""
+
+#: id:21387
+msgid "Fast"
+msgstr ""
+
+#: id:21388
+msgid "Quiet"
+msgstr ""
+
+#: id:21389
+msgid "Enable custom background"
+msgstr "कस्टम पृष्ठभूमि सक्षम"
+
+#: id:21390
+msgid "Power management level"
+msgstr ""
+
+#: id:21391
+msgid "High power"
+msgstr ""
+
+#: id:21392
+msgid "Low power"
+msgstr ""
+
+#: id:21393
+msgid "High standby"
+msgstr ""
+
+#: id:21394
+msgid "Low standby"
+msgstr ""
+
+#: id:21395
+msgid "Unable to cache files bigger than 4GB"
+msgstr ""
+
+#: id:21396
+msgid "Chapter"
+msgstr ""
+
+#: id:21397
+msgid "High quality pixel shader v2"
+msgstr ""
+
+#: id:21398
+msgid "Enable playlist at startup"
+msgstr ""
+
+#: id:21399
+msgid "Use tween animations"
+msgstr ""
+
+#: id:21400
+msgid "contains"
+msgstr ""
+
+#: id:21401
+msgid "does not contain"
+msgstr ""
+
+#: id:21402
+msgid "is"
+msgstr ""
+
+#: id:21403
+msgid "is not"
+msgstr ""
+
+#: id:21404
+msgid "starts with"
+msgstr ""
+
+#: id:21405
+msgid "ends with"
+msgstr ""
+
+#: id:21406
+msgid "greater than"
+msgstr ""
+
+#: id:21407
+msgid "less than"
+msgstr ""
+
+#: id:21408
+msgid "after"
+msgstr ""
+
+#: id:21409
+msgid "before"
+msgstr ""
+
+#: id:21410
+msgid "in the last"
+msgstr ""
+
+#: id:21411
+msgid "not in the last"
+msgstr ""
+
+#: id:21412
+msgid "Scrapers"
+msgstr ""
+
+#: id:21413
+msgid "Default movie scraper"
+msgstr ""
+
+#: id:21414
+msgid "Default tvshow scraper"
+msgstr ""
+
+#: id:21415
+msgid "Default music video scraper"
+msgstr ""
+
+#: id:21416
+msgid "Enable fallback based on scraper language"
+msgstr ""
+
+#: id:21417
+msgid "- Settings"
+msgstr "- सेटिंग्स"
+
+#: id:21418
+msgid "Multilingual"
+msgstr ""
+
+#: id:21419
+msgid "No scrapers present"
+msgstr ""
+
+#: id:21420
+msgid "Value to match"
+msgstr ""
+
+#: id:21421
+msgid "Smart playlist rule"
+msgstr ""
+
+#: id:21422
+msgid "Match items where"
+msgstr ""
+
+#: id:21423
+msgid "New rule..."
+msgstr ""
+
+#: id:21424
+msgid "Items must match"
+msgstr ""
+
+#: id:21425
+msgid "all of the rules"
+msgstr ""
+
+#: id:21426
+msgid "one or more of the rules"
+msgstr ""
+
+#: id:21427
+msgid "Limit to"
+msgstr ""
+
+#: id:21428
+msgid "No limit"
+msgstr ""
+
+#: id:21429
+msgid "Order by"
+msgstr ""
+
+#: id:21430
+msgid "ascending"
+msgstr ""
+
+#: id:21431
+msgid "descending"
+msgstr ""
+
+#: id:21432
+msgid "Edit smart playlist"
+msgstr ""
+
+#: id:21433
+msgid "Name of the playlist"
+msgstr ""
+
+#: id:21434
+msgid "Find items where"
+msgstr ""
+
+#: id:21435
+msgid "Edit"
+msgstr ""
+
+#: id:21436
+msgid "%i items"
+msgstr ""
+
+#: id:21437
+msgid "New smart playlist..."
+msgstr ""
+
+#: id:21438
+msgid "%c Drive"
+msgstr ""
+
+#: id:21439
+msgid "Edit party mode rules"
+msgstr ""
+
+#: id:21440
+msgid "Home folder"
+msgstr ""
+
+#: id:21441
+msgid "Watched count"
+msgstr ""
+
+#: id:21442
+msgid "Episode title"
+msgstr ""
+
+#: id:21443
+msgid "Video resolution"
+msgstr ""
+
+#: id:21444
+msgid "Audio channels"
+msgstr ""
+
+#: id:21445
+msgid "Video codec"
+msgstr ""
+
+#: id:21446
+msgid "Audio codec"
+msgstr ""
+
+#: id:21447
+msgid "Audio language"
+msgstr ""
+
+#: id:21448
+msgid "Subtitle language"
+msgstr ""
+
+#: id:21449
+msgid "Remote control sends keyboard presses"
+msgstr "रिमोट कंट्रोल कुंजीपटल प्रेस भेजता"
+
+#: id:21450
+msgid "- Edit"
+msgstr "- संपादित करें"
+
+#: id:21451
+msgid "Internet connection required."
+msgstr ""
+
+#: id:21452
+msgid "Get More..."
+msgstr "और जाओ ..."
+
+#: id:21453
+msgid "Root filesystem"
+msgstr ""
+
+#: id:21454
+msgid "Cache full"
+msgstr ""
+
+#: id:21455
+msgid "Cache filled before reaching required amount for continous playback"
+msgstr ""
+
+#: id:21460
+msgid "Subtitle location"
+msgstr ""
+
+#: id:21461
+msgid "Fixed"
+msgstr ""
+
+#: id:21462
+msgid "Bottom of video"
+msgstr ""
+
+#: id:21463
+msgid "Below video"
+msgstr ""
+
+#: id:21464
+msgid "Top of video"
+msgstr ""
+
+#: id:21465
+msgid "Above video"
+msgstr ""
+
+#: id:21800
+msgid "File name"
+msgstr ""
+
+#: id:21801
+msgid "File path"
+msgstr ""
+
+#: id:21802
+msgid "File size"
+msgstr ""
+
+#: id:21803
+msgid "File date/time"
+msgstr ""
+
+#: id:21804
+msgid "Slide index"
+msgstr ""
+
+#: id:21805
+msgctxt "Auto context with id 21805"
+msgid "Resolution"
+msgstr ""
+
+#: id:21806
+msgctxt "Auto context with id 21806"
+msgid "Comment"
+msgstr ""
+
+#: id:21807
+msgid "Colour/B&W"
+msgstr ""
+
+#: id:21808
+msgid "JPEG process"
+msgstr ""
+
+#: id:21820
+msgid "Date/Time"
+msgstr ""
+
+#: id:21821
+msgid "Description"
+msgstr ""
+
+#: id:21822
+msgid "Camera make"
+msgstr ""
+
+#: id:21823
+msgid "Camera model"
+msgstr ""
+
+#: id:21824
+msgid "EXIF comment"
+msgstr ""
+
+#: id:21825
+msgid "Firmware"
+msgstr ""
+
+#: id:21826
+msgid "Aperture"
+msgstr ""
+
+#: id:21827
+msgid "Focal length"
+msgstr ""
+
+#: id:21828
+msgid "Focus distance"
+msgstr ""
+
+#: id:21829
+msgid "Exposure"
+msgstr ""
+
+#: id:21830
+msgid "Exposure time"
+msgstr ""
+
+#: id:21831
+msgid "Exposure bias"
+msgstr ""
+
+#: id:21832
+msgid "Exposure mode"
+msgstr ""
+
+#: id:21833
+msgid "Flash used"
+msgstr ""
+
+#: id:21834
+msgid "White-balance"
+msgstr ""
+
+#: id:21835
+msgid "Light source"
+msgstr ""
+
+#: id:21836
+msgid "Metering mode"
+msgstr ""
+
+#: id:21837
+msgid "ISO"
+msgstr ""
+
+#: id:21838
+msgid "Digital zoom"
+msgstr ""
+
+#: id:21839
+msgid "CCD width"
+msgstr ""
+
+#: id:21840
+msgid "GPS latitude"
+msgstr ""
+
+#: id:21841
+msgid "GPS longitude"
+msgstr ""
+
+#: id:21842
+msgid "GPS altitude"
+msgstr ""
+
+#: id:21843
+msgid "Orientation"
+msgstr ""
+
+#: id:21860
+msgid "Supplemental categories"
+msgstr ""
+
+#: id:21861
+msgid "Keywords"
+msgstr ""
+
+#: id:21862
+msgid "Caption"
+msgstr ""
+
+#: id:21863
+msgid "Author"
+msgstr ""
+
+#: id:21864
+msgid "Headline"
+msgstr ""
+
+#: id:21865
+msgid "Special instructions"
+msgstr ""
+
+#: id:21866
+msgid "Category"
+msgstr ""
+
+#: id:21867
+msgid "Byline"
+msgstr ""
+
+#: id:21868
+msgid "Byline title"
+msgstr ""
+
+#: id:21869
+msgid "Credit"
+msgstr ""
+
+#: id:21870
+msgid "Source"
+msgstr ""
+
+#: id:21871
+msgid "Copyright notice"
+msgstr ""
+
+#: id:21872
+msgid "Object name"
+msgstr ""
+
+#: id:21873
+msgid "City"
+msgstr ""
+
+#: id:21874
+msgid "State"
+msgstr ""
+
+#: id:21875
+msgctxt "Auto context with id 21875"
+msgid "Country"
+msgstr ""
+
+#: id:21876
+msgid "Original Tx Reference"
+msgstr ""
+
+#: id:21877
+msgid "Date created"
+msgstr ""
+
+#: id:21878
+msgid "Copyright flag"
+msgstr ""
+
+#: id:21879
+msgid "Country code"
+msgstr ""
+
+#: id:21880
+msgid "Reference service"
+msgstr ""
+
+#: id:21881
+msgid "Allow control of XBMC via UPnP"
+msgstr "XBMC के UPnP के माध्यम से नियंत्रण की अनुमति दें"
+
+#: id:21882
+msgid "Attempt to skip introduction before DVD menu"
+msgstr ""
+
+#: id:21883
+msgid "Saved music"
+msgstr "सहेजे गए संगीत"
+
+#: id:21884
+msgid "Query info for all artists"
+msgstr ""
+
+#: id:21885
+msgid "Downloading album information"
+msgstr ""
+
+#: id:21886
+msgid "Downloading artist information"
+msgstr ""
+
+#: id:21887
+msgid "Biography"
+msgstr ""
+
+#: id:21888
+msgid "Discography"
+msgstr ""
+
+#: id:21889
+msgid "Searching artist"
+msgstr ""
+
+#: id:21890
+msgid "Select artist"
+msgstr ""
+
+#: id:21891
+msgctxt "Auto context with id 21891"
+msgid "Artist information"
+msgstr ""
+
+#: id:21892
+msgid "Instruments"
+msgstr ""
+
+#: id:21893
+msgid "Born"
+msgstr ""
+
+#: id:21894
+msgid "Formed"
+msgstr ""
+
+#: id:21895
+msgid "Themes"
+msgstr ""
+
+#: id:21896
+msgid "Disbanded"
+msgstr ""
+
+#: id:21897
+msgid "Died"
+msgstr ""
+
+#: id:21898
+msgid "Years active"
+msgstr ""
+
+#: id:21899
+msgid "Label"
+msgstr ""
+
+#: id:21900
+msgid "Born/Formed"
+msgstr ""
+
+#: id:22000
+msgid "Update library on startup"
+msgstr "स्टार्टअप पर अद्यतन लायब्रेरी"
+
+#: id:22001
+msgid "Hide progress of library updates"
+msgstr "पुस्तकालय अद्यतन की प्रगति छुपाएँ"
+
+#: id:22002
+msgid "- DNS suffix"
+msgstr ""
+
+#: id:22003
+msgid "%2.3fs"
+msgstr ""
+
+#: id:22004
+msgid "Delayed by: %2.3fs"
+msgstr ""
+
+#: id:22005
+msgid "Ahead by: %2.3fs"
+msgstr ""
+
+#: id:22006
+msgid "Subtitle offset"
+msgstr ""
+
+#: id:22007
+msgid "OpenGL vendor:"
+msgstr ""
+
+#: id:22008
+msgid "OpenGL renderer:"
+msgstr ""
+
+#: id:22009
+msgid "OpenGL version:"
+msgstr ""
+
+#: id:22010
+msgid "GPU temperature:"
+msgstr ""
+
+#: id:22011
+msgid "CPU temperature:"
+msgstr ""
+
+#: id:22012
+msgid "Total memory"
+msgstr ""
+
+#: id:22013
+msgid "Profile data"
+msgstr ""
+
+#: id:22014
+msgid "Use dim if paused during video playback"
+msgstr "मंद का प्रयोग करें अगर वीडियो प्लेबैक के दौरान रोके गए"
+
+#: id:22015
+msgid "All recordings"
+msgstr ""
+
+#: id:22016
+msgid "By title"
+msgstr ""
+
+#: id:22017
+msgid "By group"
+msgstr ""
+
+#: id:22018
+msgid "Live channels"
+msgstr ""
+
+#: id:22019
+msgid "Recordings by title"
+msgstr ""
+
+#: id:22020
+msgid "Guide"
+msgstr ""
+
+#: id:22021
+msgid "Allowed error in aspect ratio to minimize black bars"
+msgstr "पहलू अनुपात में रख सकते त्रुटि काली सलाखों के कम से कम"
+
+#: id:22022
+msgid "Show video files in listings"
+msgstr "लिस्टिंग में वीडियो फ़ाइलों को दिखाएँ"
+
+#: id:22023
+msgid "DirectX vendor:"
+msgstr ""
+
+#: id:22024
+msgid "Direct3D version:"
+msgstr ""
+
+#: id:22030
+msgctxt "Auto context with id 22030"
+msgid "Font"
+msgstr "फ़ॉन्ट"
+
+#: id:22031
+msgctxt "Auto context with id 22031"
+msgid "- Size"
+msgstr "- आकार"
+
+#: id:22032
+msgctxt "Auto context with id 22032"
+msgid "- Colours"
+msgstr "- रंगीन"
+
+#: id:22033
+msgid "- Charset"
+msgstr "- वर्ण सेट"
+
+#: id:22034
+msgid "Export karaoke titles as HTML"
+msgstr ""
+
+#: id:22035
+msgid "Export karaoke titles as CSV"
+msgstr ""
+
+#: id:22036
+msgid "Import karaoke titles..."
+msgstr "आयात कराओके खिताब ..."
+
+#: id:22037
+msgid "Show song selector automatically"
+msgstr "गीत चयनकर्ता स्वतः दिखाएँ"
+
+#: id:22038
+msgid "Export karaoke titles..."
+msgstr "कराओके खिताब निर्यात ..."
+
+#: id:22039
+msgid "Enter song number"
+msgstr ""
+
+#: id:22040
+msgid "white/green"
+msgstr ""
+
+#: id:22041
+msgid "white/red"
+msgstr ""
+
+#: id:22042
+msgid "white/blue"
+msgstr ""
+
+#: id:22043
+msgid "black/white"
+msgstr ""
+
+#: id:22079
+msgid "Default select action"
+msgstr "डिफ़ॉल्ट का चयन करें कार्रवाई"
+
+#: id:22080
+msgid "Choose"
+msgstr ""
+
+#: id:22081
+msgid "Show Information"
+msgstr ""
+
+#: id:22082
+msgid "More..."
+msgstr ""
+
+#: id:22083
+msgid "Play all"
+msgstr ""
+
+#: id:23049
+msgid "Teletext not available"
+msgstr ""
+
+#: id:23050
+msgid "Activate Teletext"
+msgstr "टेली - पाठ सक्रिय करें"
+
+#: id:23051
+msgid "Part %i"
+msgstr ""
+
+#: id:23052
+msgid "Buffering %i bytes"
+msgstr ""
+
+#: id:23053
+msgid "Stopping"
+msgstr ""
+
+#: id:23054
+msgid "Running"
+msgstr ""
+
+#: id:23100
+msgid "External Player Active"
+msgstr ""
+
+#: id:23101
+msgid "Click OK to terminate the player"
+msgstr ""
+
+#: id:23104
+msgid "Click OK when playback has ended"
+msgstr ""
+
+#: id:24000
+msgid "Add-on"
+msgstr "जोड़ें पर"
+
+#: id:24001
+msgid "Add-ons"
+msgstr "ऐड - ऑन"
+
+#: id:24002
+msgid "Add-on options"
+msgstr ""
+
+#: id:24003
+msgid "Add-on Information"
+msgstr ""
+
+#: id:24005
+msgctxt "Auto context with id 24005"
+msgid "Media sources"
+msgstr ""
+
+#: id:24007
+msgctxt "Auto context with id 24007"
+msgid "Movie information"
+msgstr "मूवी जानकारी"
+
+#: id:24008
+msgctxt "Auto context with id 24008"
+msgid "Screensaver"
+msgstr ""
+
+#: id:24009
+msgid "Script"
+msgstr ""
+
+#: id:24010
+msgctxt "Auto context with id 24010"
+msgid "Visualization"
+msgstr ""
+
+#: id:24011
+msgid "Add-on repository"
+msgstr ""
+
+#: id:24012
+msgctxt "Auto context with id 24012"
+msgid "Subtitles"
+msgstr "उपशीर्षक"
+
+#: id:24013
+msgid "Lyrics"
+msgstr "गीत"
+
+#: id:24014
+msgid "TV information"
+msgstr "टीवी जानकारी"
+
+#: id:24015
+msgctxt "Auto context with id 24015"
+msgid "Music video information"
+msgstr "मूवी जानकारी"
+
+#: id:24016
+msgctxt "Auto context with id 24016"
+msgid "Album information"
+msgstr "एल्बम जानकारी"
+
+#: id:24017
+msgctxt "Auto context with id 24017"
+msgid "Artist information"
+msgstr "कलाकार जानकारी"
+
+#: id:24018
+msgctxt "Auto context with id 24018"
+msgid "Services"
+msgstr ""
+
+#: id:24020
+msgid "Configure"
+msgstr ""
+
+#: id:24021
+msgctxt "Auto context with id 24021"
+msgid "Disable"
+msgstr ""
+
+#: id:24022
+msgid "Enable"
+msgstr ""
+
+#: id:24023
+msgid "Add-on disabled"
+msgstr ""
+
+#: id:24027
+msgctxt "Auto context with id 24027"
+msgid "Weather"
+msgstr "मौसम"
+
+#: id:24028
+msgid "Weather.com (standard)"
+msgstr ""
+
+#: id:24030
+msgid "This Add-on can not be configured"
+msgstr ""
+
+#: id:24031
+msgid "Error loading settings"
+msgstr ""
+
+#: id:24032
+msgid "All Add-ons"
+msgstr ""
+
+#: id:24033
+msgid "Get Add-ons"
+msgstr "ऐड - ऑन"
+
+#: id:24034
+msgid "Check for updates"
+msgstr ""
+
+#: id:24035
+msgid "Force refresh"
+msgstr ""
+
+#: id:24036
+msgid "Change log"
+msgstr ""
+
+#: id:24037
+msgid "Uninstall"
+msgstr ""
+
+#: id:24038
+msgid "Install"
+msgstr ""
+
+#: id:24039
+msgid "Disabled Add-ons"
+msgstr ""
+
+#: id:24040
+msgid "(Clear the current setting)"
+msgstr ""
+
+#: id:24041
+msgid "Install from zip file"
+msgstr "ज़िप फ़ाइल से स्थापित"
+
+#: id:24042
+msgid "Downloading %i%%"
+msgstr ""
+
+#: id:24043
+msgid "Available Updates"
+msgstr ""
+
+#: id:24044
+msgid "Dependencies not met"
+msgstr ""
+
+#: id:24045
+msgid "Add-on does not have the correct structure"
+msgstr ""
+
+#: id:24046
+msgid "%s is used by the following installed add-on(s)"
+msgstr ""
+
+#: id:24047
+msgid "This add-on cannot be uninstalled"
+msgstr ""
+
+#: id:24048
+msgid "Rollback"
+msgstr ""
+
+#: id:24050
+msgid "Available Add-ons"
+msgstr ""
+
+#: id:24051
+msgid "Version:"
+msgstr ""
+
+#: id:24052
+msgid "Disclaimer"
+msgstr ""
+
+#: id:24053
+msgid "License:"
+msgstr ""
+
+#: id:24054
+msgid "Changelog"
+msgstr ""
+
+#: id:24059
+msgid "Would you like to enable this Add-on?"
+msgstr ""
+
+#: id:24060
+msgid "Would you like to disable this Add-on?"
+msgstr ""
+
+#: id:24061
+msgid "Add-on update available!"
+msgstr ""
+
+#: id:24062
+msgid "Enabled Add-ons"
+msgstr "ऐड - ऑन सक्षम"
+
+#: id:24063
+msgid "Auto update"
+msgstr "ऑटो अद्यतन"
+
+#: id:24064
+msgid "Add-on enabled"
+msgstr ""
+
+#: id:24065
+msgid "Add-on updated"
+msgstr ""
+
+#: id:24066
+msgid "Cancel Add-on download?"
+msgstr ""
+
+#: id:24067
+msgid "Currently downloading Add-ons"
+msgstr ""
+
+#: id:24068
+msgid "Update available"
+msgstr ""
+
+#: id:24069
+msgid "Update"
+msgstr ""
+
+#: id:24070
+msgid "Add-on could not be loaded."
+msgstr ""
+
+#: id:24071
+msgid "An unknown error has occurred."
+msgstr ""
+
+#: id:24072
+msgid "Settings required"
+msgstr ""
+
+#: id:24073
+msgid "Could not connect"
+msgstr ""
+
+#: id:24074
+msgid "Needs to restart"
+msgstr ""
+
+#: id:24075
+msgctxt "Auto context with id 24075"
+msgid "Disable"
+msgstr ""
+
+#: id:24076
+msgid "Add-on Required"
+msgstr ""
+
+#: id:24080
+msgid "Try to reconnect?"
+msgstr ""
+
+#: id:24089
+msgid "Add-on restarts"
+msgstr ""
+
+#: id:24090
+msgid "Lock Add-on manager"
+msgstr ""
+
+#: id:24094
+msgid "(current)"
+msgstr ""
+
+#: id:24095
+msgid "(blacklisted)"
+msgstr ""
+
+#: id:24096
+msgid "Add-on has been marked as broken in repository."
+msgstr ""
+
+#: id:24097
+msgid "Would you like to disable it on your system?"
+msgstr ""
+
+#: id:24098
+msgid "Broken"
+msgstr ""
+
+#: id:24099
+msgid "Would you like to switch to this skin?"
+msgstr ""
+
+#: id:24100
+msgid "To use this feature you must download an Add-on:"
+msgstr ""
+
+#: id:24101
+msgid "Would you like to download this Add-on?"
+msgstr ""
+
+#: id:25000
+msgid "Notifications"
+msgstr "अधिसूचनाएं"
+
+#: id:29800
+msgid "Library Mode"
+msgstr ""
+
+#: id:29801
+msgid "QWERTY keyboard"
+msgstr ""
+
+#: id:29802
+msgid "Passthrough Audio in use"
+msgstr ""
+
+#: id:33001
+msgid "Trailer quality"
+msgstr ""
+
+#: id:33002
+msgid "Stream"
+msgstr ""
+
+#: id:33003
+msgid "Download"
+msgstr ""
+
+#: id:33004
+msgid "Download & play"
+msgstr ""
+
+#: id:33005
+msgid "Download & save"
+msgstr ""
+
+#: id:33006
+msgid "Today"
+msgstr ""
+
+#: id:33007
+msgid "Tomorrow"
+msgstr ""
+
+#: id:33008
+msgid "Saving"
+msgstr ""
+
+#: id:33009
+msgid "Copying"
+msgstr ""
+
+#: id:33010
+msgid "Set download directory"
+msgstr ""
+
+#: id:33011
+msgid "Search duration"
+msgstr ""
+
+#: id:33012
+msgid "Short"
+msgstr ""
+
+#: id:33013
+msgid "Long"
+msgstr ""
+
+#: id:33014
+msgid "Use DVD player instead of regular player"
+msgstr ""
+
+#: id:33015
+msgid "Ask for download before playing video"
+msgstr ""
+
+#: id:33016
+msgid "Clips"
+msgstr ""
+
+#: id:33017
+msgid "Restart plugin to enable"
+msgstr ""
+
+#: id:33018
+msgid "Tonight"
+msgstr ""
+
+#: id:33019
+msgid "Tomorrow Night"
+msgstr ""
+
+#: id:33020
+msgid "Condition"
+msgstr ""
+
+#: id:33021
+msgid "Precipitation"
+msgstr ""
+
+#: id:33022
+msgid "Precip"
+msgstr ""
+
+#: id:33023
+msgid "Humid"
+msgstr ""
+
+#: id:33024
+msgid "Feels"
+msgstr ""
+
+#: id:33025
+msgid "Observed"
+msgstr ""
+
+#: id:33026
+msgid "Departure from normal"
+msgstr ""
+
+#: id:33027
+msgid "Sunrise"
+msgstr ""
+
+#: id:33028
+msgid "Sunset"
+msgstr ""
+
+#: id:33029
+msgid "Details"
+msgstr ""
+
+#: id:33030
+msgid "Outlook"
+msgstr ""
+
+#: id:33031
+msgid "Coverflow"
+msgstr ""
+
+#: id:33032
+msgid "Translate text"
+msgstr ""
+
+#: id:33033
+msgid "Map list %s category"
+msgstr ""
+
+#: id:33034
+msgid "36 Hour"
+msgstr ""
+
+#: id:33035
+msgid "Maps"
+msgstr ""
+
+#: id:33036
+msgid "Hourly"
+msgstr ""
+
+#: id:33037
+msgid "Weekend"
+msgstr ""
+
+#: id:33038
+msgid "%s day"
+msgstr ""
+
+#: id:33049
+msgid "Alert"
+msgstr ""
+
+#: id:33050
+msgid "Alerts"
+msgstr ""
+
+#: id:33051
+msgid "Choose Your"
+msgstr ""
+
+#: id:33052
+msgid "Check"
+msgstr ""
+
+#: id:33053
+msgctxt "Auto context with id 33053"
+msgid "Configure the"
+msgstr ""
+
+#: id:33054
+msgid "Seasons"
+msgstr ""
+
+#: id:33055
+msgid "Use your"
+msgstr ""
+
+#: id:33056
+msgid "Watch your"
+msgstr ""
+
+#: id:33057
+msgid "Listen to"
+msgstr ""
+
+#: id:33058
+msgid "View your"
+msgstr ""
+
+#: id:33059
+msgctxt "Auto context with id 33059"
+msgid "Configure the"
+msgstr ""
+
+#: id:33060
+msgid "Power"
+msgstr ""
+
+#: id:33061
+msgid "Menu"
+msgstr ""
+
+#: id:33062
+msgid "Play the"
+msgstr ""
+
+#: id:33063
+msgid "Options"
+msgstr ""
+
+#: id:33065
+msgid "Editor"
+msgstr ""
+
+#: id:33066
+msgid "About your"
+msgstr ""
+
+#: id:33067
+msgid "Star rating"
+msgstr ""
+
+#: id:33068
+msgid "Background"
+msgstr "पृष्ठभूमि"
+
+#: id:33069
+msgid "Backgrounds"
+msgstr ""
+
+#: id:33070
+msgid "Custom background"
+msgstr ""
+
+#: id:33071
+msgid "Custom backgrounds"
+msgstr ""
+
+#: id:33072
+msgid "View Readme"
+msgstr ""
+
+#: id:33073
+msgid "View Changelog"
+msgstr ""
+
+#: id:33074
+msgid "This version of %s requires an"
+msgstr ""
+
+#: id:33075
+msgid "XBMC revision of %s or greater to run."
+msgstr ""
+
+#: id:33076
+msgid "Please update XBMC."
+msgstr ""
+
+#: id:33077
+msgid "No data found!"
+msgstr ""
+
+#: id:33078
+msgid "Next page"
+msgstr ""
+
+#: id:33079
+msgid "Love"
+msgstr ""
+
+#: id:33080
+msgid "Hate"
+msgstr ""
+
+#: id:33081
+msgid "This file is stacked, select the part you want to play from."
+msgstr ""
+
+#: id:33082
+msgid "Path to script"
+msgstr ""
+
+#: id:33083
+msgid "Enable custom script button"
+msgstr ""
+
+#: id:33100
+msgid "Failed to start"
+msgstr ""
+
+#: id:33101
+msgid "Webserver"
+msgstr ""
+
+#: id:33102
+msgid "Event Server"
+msgstr ""
+
+#: id:33103
+msgid "Remote communication server"
+msgstr ""
+
+#: id:33200
+msgid "Detected New Connection"
+msgstr ""
+
+#: id:34000
+msgid "Lame"
+msgstr ""
+
+#: id:34001
+msgid "Vorbis"
+msgstr ""
+
+#: id:34002
+msgid "Wav"
+msgstr ""
+
+#: id:34003
+msgid "DXVA2"
+msgstr ""
+
+#: id:34004
+msgid "VAAPI"
+msgstr ""
+
+#: id:34005
+msgid "Flac"
+msgstr ""
+
+#: id:34100
+msgid "Speaker Configuration"
+msgstr "वक्ता विन्यास"
+
+#: id:34101
+msgid "2.0"
+msgstr ""
+
+#: id:34102
+msgid "2.1"
+msgstr ""
+
+#: id:34103
+msgid "3.0"
+msgstr ""
+
+#: id:34104
+msgid "3.1"
+msgstr ""
+
+#: id:34105
+msgid "4.0"
+msgstr ""
+
+#: id:34106
+msgid "4.1"
+msgstr ""
+
+#: id:34107
+msgid "5.0"
+msgstr ""
+
+#: id:34108
+msgid "5.1"
+msgstr ""
+
+#: id:34109
+msgid "7.0"
+msgstr ""
+
+#: id:34110
+msgid "7.1"
+msgstr ""
+
+#: id:34201
+msgid "Can't find a next item to play"
+msgstr ""
+
+#: id:34202
+msgid "Can't find a previous item to play"
+msgstr ""
+
+#: id:34300
+msgid "Failed to start zeroconf"
+msgstr ""
+
+#: id:34301
+msgid "Is Apple's Bonjour Service installed? See log for more info."
+msgstr ""
+
+#: id:34400
+msgid "Video Rendering"
+msgstr ""
+
+#: id:34401
+msgid "Failed to init video filters/scalers, falling back to bilinear scaling"
+msgstr ""
+
+#: id:34402
+msgid "Failed to initialize audio device"
+msgstr ""
+
+#: id:34403
+msgid "Check your audiosettings"
+msgstr ""
+
+#: id:34404
+msgid "Use gestures for navigation:"
+msgstr ""
+
+#: id:34405
+msgid "1 finger swipe left,right,up,down for cursors"
+msgstr ""
+
+#: id:34406
+msgid "2 finger swipe left for backspace"
+msgstr ""
+
+#: id:34407
+msgid "1 finger single tap for enter"
+msgstr ""
+
+#: id:34408
+msgid "2 finger single tap for contextmenu"
+msgstr ""
+
+#: id:35000
+msgid "Peripherals"
+msgstr ""
+
+#: id:35001
+msgid "Generic HID device"
+msgstr ""
+
+#: id:35002
+msgid "Generic network adapter"
+msgstr ""
+
+#: id:35003
+msgid "Generic disk"
+msgstr ""
+
+#: id:35004
+msgid "There are no settings available\nfor this peripheral."
+msgstr ""
+
+#: id:35005
+msgid "New device configured"
+msgstr ""
+
+#: id:35006
+msgid "Device removed"
+msgstr ""
+
+#: id:35007
+msgid "Keymap to use for this device"
+msgstr ""
+
+#: id:35008
+msgid "Keymap enabled"
+msgstr ""
+
+#: id:35009
+msgid "Do not use the custom keymap for this device"
+msgstr ""
+
+#: id:35500
+msgid "Location"
+msgstr ""
+
+#: id:35501
+msgid "Class"
+msgstr ""
+
+#: id:35502
+msgctxt "Auto context with id 35502"
+msgid "Name"
+msgstr ""
+
+#: id:35503
+msgid "Vendor"
+msgstr ""
+
+#: id:35504
+msgid "Product ID"
+msgstr ""
+
+#: id:36000
+msgid "Pulse-Eight CEC adapter"
+msgstr ""
+
+#: id:36001
+msgid "Pulse-Eight Nyxboard"
+msgstr ""
+
+#: id:36002
+msgid "Switch to keyboard side command"
+msgstr ""
+
+#: id:36003
+msgid "Switch to remote side command"
+msgstr ""
+
+#: id:36004
+msgid "Press \"user\" button command"
+msgstr ""
+
+#: id:36005
+msgid "Enable switch side commands"
+msgstr ""
+
+#: id:36006
+msgid "Could not open the adapter"
+msgstr ""
+
+#: id:36007
+msgid "Devices to power on when starting XBMC"
+msgstr ""
+
+#: id:36008
+msgid "Devices to power off when stopping XBMC"
+msgstr ""
+
+#: id:36009
+msgid "Put devices in standby mode when activating screensaver"
+msgstr ""
+
+#: id:36011
+msgid "Could not detect the CEC port. Set it up manually."
+msgstr ""
+
+#: id:36012
+msgid "Could not initialise the CEC adapter. Check your settings."
+msgstr ""
+
+#: id:36013
+msgid "Unsupported libCEC interface version. %d is greater than the version XBMC supports (%d)"
+msgstr ""
+
+#: id:36014
+msgid "Put this PC in standby mode when the TV is switched off"
+msgstr ""
+
+#: id:36015
+msgid "HDMI port number"
+msgstr ""
+
+#: id:36016
+msgctxt "Auto context with id 36016"
+msgid "Connected"
+msgstr ""
+
+#: id:36017
+msgid "Adapter found, but libCEC is not available"
+msgstr ""
+
+#: id:36018
+msgid "Use the TV's language setting"
+msgstr ""
+
+#: id:36019
+msgid "Connected to HDMI device"
+msgstr ""
+
+#: id:36020
+msgid "Make XBMC the active source when starting"
+msgstr ""
+
+#: id:36021
+msgid "Physical address (overrules HDMI port)"
+msgstr ""
+
+#: id:36022
+msgid "COM port (leave empty unless needed)"
+msgstr ""
+
+#: id:36023
+msgid "Configuration updated"
+msgstr ""
+
+#: id:36024
+msgid "Failed to set the new configuration. Please check your settings."
+msgstr ""
+
+#: id:36025
+msgid "Send 'inactive source' command when stopping XBMC"
+msgstr ""
+

--- a/language/Hungarian/strings.po
+++ b/language/Hungarian/strings.po
@@ -1,0 +1,9093 @@
+# Converted from xbmc strings.xml with xbmc-xml2po (by Team-XBMC)
+msgid ""
+msgstr ""
+"Project-Id-Version: xbmc.core-FRODO_GIT3ed1604ad7\n"
+"Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
+"POT-Creation-Date: 2012-04-09 18:00+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE\n"
+"Language: hu\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: id:0
+msgctxt "Auto context with id 0"
+msgid "Programs"
+msgstr "Programok"
+
+#: id:1
+msgctxt "Auto context with id 1"
+msgid "Pictures"
+msgstr "Képek"
+
+#: id:2
+msgctxt "Auto context with id 2"
+msgid "Music"
+msgstr "Zene"
+
+#: id:3
+msgctxt "Auto context with id 3"
+msgid "Videos"
+msgstr "Videók"
+
+#: id:4
+msgid "TV-Guide"
+msgstr "TV Műsor kalauz"
+
+#: id:5
+msgctxt "Auto context with id 5"
+msgid "Settings"
+msgstr "Beállítások"
+
+#: id:6
+msgid "XBMC SVN"
+msgstr "XBMC SVN"
+
+#: id:7
+msgctxt "Auto context with id 7"
+msgid "File manager"
+msgstr "Fájlkezelő"
+
+#: id:8
+msgctxt "Auto context with id 8"
+msgid "Weather"
+msgstr "Időjárás"
+
+#: id:9
+msgid "xbmc media center"
+msgstr "xbmc media center"
+
+#: id:11
+msgid "Monday"
+msgstr "Hétfő"
+
+#: id:12
+msgid "Tuesday"
+msgstr "Kedd"
+
+#: id:13
+msgid "Wednesday"
+msgstr "Szerda"
+
+#: id:14
+msgid "Thursday"
+msgstr "Csütörtök"
+
+#: id:15
+msgid "Friday"
+msgstr "Péntek"
+
+#: id:16
+msgid "Saturday"
+msgstr "Szombat"
+
+#: id:17
+msgid "Sunday"
+msgstr "Vasárnap"
+
+#: id:21
+msgid "January"
+msgstr "Január"
+
+#: id:22
+msgid "February"
+msgstr "Február"
+
+#: id:23
+msgid "March"
+msgstr "Március"
+
+#: id:24
+msgid "April"
+msgstr "Április"
+
+#: id:25
+msgctxt "Auto context with id 25"
+msgid "May"
+msgstr "Május"
+
+#: id:26
+msgid "June"
+msgstr "Június"
+
+#: id:27
+msgid "July"
+msgstr "Július"
+
+#: id:28
+msgid "August"
+msgstr "Augusztus"
+
+#: id:29
+msgid "September"
+msgstr "Szeptember"
+
+#: id:30
+msgid "October"
+msgstr "Október"
+
+#: id:31
+msgid "November"
+msgstr "November"
+
+#: id:32
+msgid "December"
+msgstr "December"
+
+#: id:41
+msgid "Mon"
+msgstr "Hétf"
+
+#: id:42
+msgid "Tue"
+msgstr "Kedd"
+
+#: id:43
+msgid "Wed"
+msgstr "Szer"
+
+#: id:44
+msgid "Thu"
+msgstr "Csüt"
+
+#: id:45
+msgid "Fri"
+msgstr "Pén"
+
+#: id:46
+msgid "Sat"
+msgstr "Szom"
+
+#: id:47
+msgctxt "Auto context with id 47"
+msgid "Sun"
+msgstr "Vas"
+
+#: id:51
+msgid "Jan"
+msgstr "Jan"
+
+#: id:52
+msgid "Feb"
+msgstr "Feb"
+
+#: id:53
+msgid "Mar"
+msgstr "Már"
+
+#: id:54
+msgid "Apr"
+msgstr "Ápr"
+
+#: id:55
+msgctxt "Auto context with id 55"
+msgid "May"
+msgstr "Máj"
+
+#: id:56
+msgid "Jun"
+msgstr "Jún"
+
+#: id:57
+msgid "Jul"
+msgstr "Júl"
+
+#: id:58
+msgid "Aug"
+msgstr "Aug"
+
+#: id:59
+msgid "Sep"
+msgstr "Szep"
+
+#: id:60
+msgid "Oct"
+msgstr "Okt"
+
+#: id:61
+msgid "Nov"
+msgstr "Nov"
+
+#: id:62
+msgid "Dec"
+msgstr "Dec"
+
+#: id:71
+msgid "N"
+msgstr "É"
+
+#: id:72
+msgid "NNE"
+msgstr "ÉÉK"
+
+#: id:73
+msgid "NE"
+msgstr "ÉK"
+
+#: id:74
+msgid "ENE"
+msgstr "KÉK"
+
+#: id:75
+msgid "E"
+msgstr "K"
+
+#: id:76
+msgid "ESE"
+msgstr "KDK"
+
+#: id:77
+msgid "SE"
+msgstr "DK"
+
+#: id:78
+msgid "SSE"
+msgstr "DDK"
+
+#: id:79
+msgid "S"
+msgstr "D"
+
+#: id:80
+msgid "SSW"
+msgstr "DDNY"
+
+#: id:81
+msgid "SW"
+msgstr "DNY"
+
+#: id:82
+msgid "WSW"
+msgstr "NYDNY"
+
+#: id:83
+msgid "W"
+msgstr "NY"
+
+#: id:84
+msgid "WNW"
+msgstr "NYÉNY"
+
+#: id:85
+msgid "NW"
+msgstr "ÉNY"
+
+#: id:86
+msgid "NNW"
+msgstr "ÉÉNY"
+
+#: id:87
+msgid "VAR"
+msgstr "VÁLT"
+
+#: id:98
+msgid "View: Auto"
+msgstr "Nézet: Auto"
+
+#: id:99
+msgid "View: Auto big"
+msgstr "Nézet: Auto nagy"
+
+#: id:100
+msgid "View: Icons"
+msgstr "Nézet: Ikon"
+
+#: id:101
+msgid "View: List"
+msgstr "Nézet: Lista"
+
+#: id:102
+msgctxt "Auto context with id 102"
+msgid "Scan"
+msgstr "Vizsgálat"
+
+#: id:103
+msgctxt "Auto context with id 103"
+msgid "Sort by: Name"
+msgstr "Név szerint"
+
+#: id:104
+msgid "Sort by: Date"
+msgstr "Dátum szerint"
+
+#: id:105
+msgid "Sort by: Size"
+msgstr "Méret szerint"
+
+#: id:106
+msgid "No"
+msgstr "Nem"
+
+#: id:107
+msgid "Yes"
+msgstr "Igen"
+
+#: id:108
+msgctxt "Auto context with id 108"
+msgid "Slideshow"
+msgstr "Diavetítés"
+
+#: id:109
+msgid "Create thumbs"
+msgstr "Bélyegképek létrehozása"
+
+#: id:110
+msgid "Create thumbnails"
+msgstr "Bélyegképek létrehozása"
+
+#: id:111
+msgctxt "Auto context with id 111"
+msgid "Shortcuts"
+msgstr "Parancsikonok"
+
+#: id:112
+msgid "Paused"
+msgstr "Szünet"
+
+#: id:113
+msgid "Update failed"
+msgstr "A frissítés nem sikerült"
+
+#: id:114
+msgid "Installation failed"
+msgstr "A telepítés nem sikerült"
+
+#: id:115
+msgid "Copy"
+msgstr "Másolás"
+
+#: id:116
+msgid "Move"
+msgstr "Áthelyezés"
+
+#: id:117
+msgid "Delete"
+msgstr "Törlés"
+
+#: id:118
+msgid "Rename"
+msgstr "Átnevezés"
+
+#: id:119
+msgid "New folder"
+msgstr "Új mappa"
+
+#: id:120
+msgid "Confirm file copy"
+msgstr "Másolás megerősítése"
+
+#: id:121
+msgid "Confirm file move"
+msgstr "Áthelyezés megerősítése"
+
+#: id:122
+msgid "Confirm file delete?"
+msgstr "Fájltörlés megerősítése?"
+
+#: id:123
+msgid "Copy these files?"
+msgstr "Kijelölt mappák és fájlok átmásolása?"
+
+#: id:124
+msgid "Move these files?"
+msgstr "Kijelölt mappák és fájlok áthelyezése?"
+
+#: id:125
+msgid "Delete these files? - Deleting files cannot be undone!"
+msgstr "Kijelölt mappák és fájlok törlése? Nem visszaállítható!"
+
+#: id:126
+msgid "Status"
+msgstr "Állapot"
+
+#: id:127
+msgid "Objects"
+msgstr "Elem"
+
+#: id:128
+msgctxt "Auto context with id 128"
+msgid "General"
+msgstr "Általános"
+
+#: id:129
+msgctxt "Auto context with id 129"
+msgid "Slideshow"
+msgstr "Diavetítés"
+
+#: id:130
+msgctxt "Auto context with id 130"
+msgid "System info"
+msgstr "Rendszerinfó"
+
+#: id:131
+msgid "Display"
+msgstr "Képernyő"
+
+#: id:132
+msgid "Albums"
+msgstr "Albumok"
+
+#: id:133
+msgid "Artists"
+msgstr "Előadók"
+
+#: id:134
+msgid "Songs"
+msgstr "Zeneszámok"
+
+#: id:135
+msgid "Genres"
+msgstr "Műfajok"
+
+#: id:136
+msgid "Playlists"
+msgstr "Lejátszáslisták"
+
+#: id:137
+msgid "Search"
+msgstr "Keresés"
+
+#: id:138
+msgid "System Information"
+msgstr "Rendszerinformáció"
+
+#: id:139
+msgid "Temperatures:"
+msgstr "Hőmérsékletek:"
+
+#: id:140
+msgid "CPU:"
+msgstr "CPU:"
+
+#: id:141
+msgid "GPU:"
+msgstr "GPU:"
+
+#: id:142
+msgid "Time:"
+msgstr "Idő:"
+
+#: id:143
+msgid "Current:"
+msgstr "Aktuális:"
+
+#: id:144
+msgid "Build:"
+msgstr "Verzió:"
+
+#: id:145
+msgid "Network:"
+msgstr "Hálózat:"
+
+#: id:146
+msgid "Type:"
+msgstr "Típus:"
+
+#: id:147
+msgid "Static"
+msgstr "Statikus"
+
+#: id:148
+msgid "DHCP"
+msgstr "DHCP"
+
+#: id:149
+msgid "MAC address"
+msgstr "MAC cím"
+
+#: id:150
+msgctxt "Auto context with id 150"
+msgid "IP address"
+msgstr "IP cím"
+
+#: id:151
+msgid "Link:"
+msgstr "Kapcsolat:"
+
+#: id:152
+msgid "Half duplex"
+msgstr "Fél-duplex"
+
+#: id:153
+msgid "Full duplex"
+msgstr "Teljes-duplex"
+
+#: id:154
+msgctxt "Auto context with id 154"
+msgid "Storage"
+msgstr "Háttértár"
+
+#: id:155
+msgid "Drive"
+msgstr "Meghajtó"
+
+#: id:156
+msgctxt "Auto context with id 156"
+msgid "Free"
+msgstr "Szabad"
+
+#: id:157
+msgctxt "Auto context with id 157"
+msgid "Video"
+msgstr "Videó"
+
+#: id:158
+msgid "Free memory"
+msgstr "Szabad memória"
+
+#: id:159
+msgid "No link"
+msgstr "Nincs kapcsolat"
+
+#: id:160
+msgctxt "Auto context with id 160"
+msgid "Free"
+msgstr "Szabad"
+
+#: id:161
+msgid "Unavailable"
+msgstr "Nem elérhető"
+
+#: id:162
+msgid "Tray open"
+msgstr "Tálca nyitva"
+
+#: id:163
+msgid "Reading"
+msgstr "Beolvasás"
+
+#: id:164
+msgid "No disc"
+msgstr "Nincs lemez"
+
+#: id:165
+msgid "Disc present"
+msgstr "Lemezt találtam"
+
+#: id:166
+msgid "Skin"
+msgstr "Felszín"
+
+#: id:169
+msgctxt "Auto context with id 169"
+msgid "Resolution"
+msgstr "Felbontás"
+
+#: id:170
+msgid "Adjust display refresh rate to match video"
+msgstr "Képfrissítésfrekvencia igazítása a film-képkockasebességhez"
+
+#: id:172
+msgid "Release date"
+msgstr "Megjelenés dátuma"
+
+#: id:173
+msgid "Display 4:3 videos as"
+msgstr "4:3 képarányú videók megjelenítési módja"
+
+#: id:175
+msgid "Moods"
+msgstr "Hangulatok"
+
+#: id:176
+msgid "Styles"
+msgstr "Stílusok"
+
+#: id:179
+msgid "Song"
+msgstr "Zeneszám"
+
+#: id:180
+msgid "Duration"
+msgstr "Hossz"
+
+#: id:181
+msgid "Select album"
+msgstr "Albumválasztás"
+
+#: id:182
+msgid "Tracks"
+msgstr "Zeneszámok"
+
+#: id:183
+msgid "Review"
+msgstr "Ismertető"
+
+#: id:184
+msgid "Refresh"
+msgstr "Frissítés"
+
+#: id:185
+msgid "Searching album"
+msgstr "Album keresése"
+
+#: id:186
+msgid "OK"
+msgstr "OK"
+
+#: id:187
+msgid "No albums found!"
+msgstr "Nincs találat!"
+
+#: id:188
+msgid "Select all"
+msgstr "Összes kijelölése"
+
+#: id:189
+msgid "Scanning media info"
+msgstr "Média információ keresése"
+
+#: id:190
+msgid "Save"
+msgstr "Mentés"
+
+#: id:191
+msgid "Shuffle"
+msgstr "Keverés"
+
+#: id:192
+msgctxt "Auto context with id 192"
+msgid "Clear"
+msgstr "Törlés"
+
+#: id:193
+msgctxt "Auto context with id 193"
+msgid "Scan"
+msgstr "Keresés"
+
+#: id:194
+msgid "Searching..."
+msgstr "Keresés..."
+
+#: id:195
+msgid "No info found!"
+msgstr "Információ nem található!"
+
+#: id:196
+msgid "Select movie:"
+msgstr "Film választás:"
+
+#: id:197
+msgid "Querying %s info"
+msgstr "%s lekérdezése"
+
+#: id:198
+msgid "Loading movie details"
+msgstr "Filminformációk betöltése"
+
+#: id:199
+msgid "Web interface"
+msgstr "Webes kezelőfelület"
+
+#: id:202
+msgid "Tagline"
+msgstr "Röviden"
+
+#: id:203
+msgid "Plot outline"
+msgstr "Tartalom"
+
+#: id:205
+msgid "Votes"
+msgstr "Szavazatok"
+
+#: id:206
+msgid "Cast"
+msgstr "Szereplők"
+
+#: id:207
+msgid "Plot"
+msgstr "Tartalom"
+
+#: id:208
+msgctxt "Auto context with id 208"
+msgid "Play"
+msgstr "Lejátszás"
+
+#: id:209
+msgid "Next"
+msgstr "Következő"
+
+#: id:210
+msgid "Previous"
+msgstr "Előző"
+
+#: id:213
+msgid "Calibrate user interface..."
+msgstr "Felhasználói felület kalibrálása..."
+
+#: id:214
+msgid "Video calibration..."
+msgstr "Képernyő kalibrálása"
+
+#: id:215
+msgid "Soften"
+msgstr "Lágyítás"
+
+#: id:216
+msgid "Zoom amount"
+msgstr "Nagyítási arány"
+
+#: id:217
+msgid "Pixel ratio"
+msgstr "Képpontarány"
+
+#: id:218
+msgid "DVD drive"
+msgstr "DVD meghajtó"
+
+#: id:219
+msgid "Please insert disc"
+msgstr "Helyezz be egy lemezt"
+
+#: id:220
+msgid "Remote share"
+msgstr "Távoli megosztás"
+
+#: id:221
+msgid "Network is not connected"
+msgstr "Hálózat nem elérhető"
+
+#: id:222
+msgid "Cancel"
+msgstr "Mégsem"
+
+#: id:224
+msgid "Speed"
+msgstr "Sebesség"
+
+#: id:225
+msgid "Vertical Shift"
+msgstr "Függőleges eltolás"
+
+#: id:226
+msgid "Test patterns..."
+msgstr "Teszt minták..."
+
+#: id:227
+msgid "Lookup audio CD track names from freedb.org"
+msgstr "Zenei CD-k keresése a freedb.org-on"
+
+#: id:228
+msgid "Shuffle playlist on load"
+msgstr "Véletlenszerû lejátszáslista betöltéskor"
+
+#: id:229
+msgid "HDD spindown time"
+msgstr "Merevlemez kikapcsolási ideje"
+
+#: id:230
+msgid "Video filters"
+msgstr "Képszűrők"
+
+#: id:231
+msgctxt "Auto context with id 231"
+msgid "None"
+msgstr "Nincs"
+
+#: id:232
+msgid "Point"
+msgstr "Point"
+
+#: id:233
+msgid "Linear"
+msgstr "Linear"
+
+#: id:234
+msgid "Anisotropic"
+msgstr "Anisotropic"
+
+#: id:235
+msgid "Quincunx"
+msgstr "Quincunx"
+
+#: id:236
+msgid "Gaussian cubic"
+msgstr "Gaussian Cubic"
+
+#: id:237
+msgid "Minification"
+msgstr "Kicsinyítés"
+
+#: id:238
+msgid "Magnification"
+msgstr "Nagyítás"
+
+#: id:239
+msgid "Clear playlist on finish"
+msgstr "Lejátszáslista törlése kilépéskor"
+
+#: id:240
+msgid "Display Mode"
+msgstr "Megjelenítés típusa"
+
+#: id:241
+msgid "Full Screen #%d"
+msgstr "Teljes képernyő #%d"
+
+#: id:242
+msgid "Windowed"
+msgstr "Ablak mód"
+
+#: id:243
+msgid "Refresh Rate"
+msgstr "Képfrissítési frekvencia"
+
+#: id:244
+msgid "Full screen"
+msgstr "Teljes képernyő"
+
+#: id:245
+msgid "Sizing: (%i,%i)->(%i,%i) (Zoom x%2.2f) AR:%2.2f:1 (Pixels: %2.2f:1) (VShift: %2.2f)"
+msgstr "Méretezés: (%i,%i)->(%i,%i) (Nagyítás: x%2.2f) Arány:%2.2f:1 (Képpontarány: %2.2f:1) (Függőleges Eltolás: %2.2f)"
+
+#: id:247
+msgctxt "Auto context with id 247"
+msgid "Scripts"
+msgstr "Programok"
+
+#: id:248
+msgctxt "Auto context with id 248"
+msgid "Language"
+msgstr "Nyelv"
+
+#: id:249
+msgctxt "Auto context with id 249"
+msgid "Music"
+msgstr "Zene"
+
+#: id:250
+msgctxt "Auto context with id 250"
+msgid "Visualization"
+msgstr "Vizualizáció"
+
+#: id:251
+msgid "Select destination directory"
+msgstr "Célkönyvtár választása"
+
+#: id:252
+msgid "Output stereo to all speakers"
+msgstr "A sztereó hangforrás szóljon mindegyik hangszórón"
+
+#: id:253
+msgid "Number of channels"
+msgstr "Csatornák száma"
+
+#: id:254
+msgid "- DTS capable receiver"
+msgstr "- DTS képes erősítő"
+
+#: id:255
+msgid "CDDB"
+msgstr "CDDB"
+
+#: id:256
+msgid "Fetching CD information"
+msgstr "CD információ letöltése"
+
+#: id:257
+msgid "Error"
+msgstr "Hiba"
+
+#: id:258
+msgid "Enable tag reading"
+msgstr "Címkeolvasás engedélyezése"
+
+#: id:259
+msgid "Opening"
+msgstr "Adatfolyam megnyitása"
+
+#: id:260
+msgid "Shoutcast"
+msgstr "Shoutcast rádiók"
+
+#: id:261
+msgid "Waiting for start..."
+msgstr "Indulásra vár..."
+
+#: id:262
+msgid "Scripts output"
+msgstr "Programok kimenete"
+
+#: id:263
+msgid "Allow control of XBMC via HTTP"
+msgstr "XBMC távoli vezérelhetősége HTTP-n"
+
+#: id:264
+msgid "Record"
+msgstr "Felvétel"
+
+#: id:265
+msgid "Stop Rec."
+msgstr "Felvétel leállítása"
+
+#: id:266
+msgid "Sort by: Track"
+msgstr "Számok szerint"
+
+#: id:267
+msgid "Sort by: Time"
+msgstr "Idő szerint"
+
+#: id:268
+msgid "Sort by: Title"
+msgstr "Cím szerint"
+
+#: id:269
+msgid "Sort by: Artist"
+msgstr "Előadó szerint"
+
+#: id:270
+msgid "Sort by: Album"
+msgstr "Album szerint"
+
+#: id:271
+msgid "Top 100"
+msgstr "Top 100"
+
+#: id:272
+msgid "Top-Left overscan compensation"
+msgstr "Bal-felső túllógás javítása"
+
+#: id:273
+msgid "Bottom-Right overscan compensation"
+msgstr "Jobb-alsó túllógás javítása"
+
+#: id:274
+msgid "Subtitle positioning"
+msgstr "Felirat pozicionálása"
+
+#: id:275
+msgid "Pixel ratio adjustment"
+msgstr "Képpontarány igazítása"
+
+#: id:276
+msgid "Adjust the arrow to change the amount of overscan"
+msgstr "Használd a nyilakat a túllógás beállításához"
+
+#: id:277
+msgid "Adjust the bar to change the subtitles position"
+msgstr "Használd a sávot a felirat pozicionálásához"
+
+#: id:278
+msgid "Adjust the rectangle so it is perfectly square"
+msgstr "Változtasd a négyszöget, míg tökéletes négyzet nem lesz"
+
+#: id:279
+msgid "Unable to load settings"
+msgstr "Beállítások betöltése sikertelen"
+
+#: id:280
+msgid "Using default settings"
+msgstr "Alapértelmezett beállítások visszaállítása"
+
+#: id:281
+msgid "Please check the XML files"
+msgstr "Ellenőrizd az XML fájlokat"
+
+#: id:282
+msgid "Found %i items"
+msgstr "%i találat"
+
+#: id:283
+msgid "Search results"
+msgstr "Keresési eredmények"
+
+#: id:284
+msgid "No results found"
+msgstr "Nincs találat"
+
+#: id:287
+msgctxt "Auto context with id 287"
+msgid "Subtitles"
+msgstr "Feliratok"
+
+#: id:288
+msgctxt "Auto context with id 288"
+msgid "Font"
+msgstr "Betűtípus"
+
+#: id:289
+msgctxt "Auto context with id 289"
+msgid "- Size"
+msgstr "- Méret"
+
+#: id:290
+msgid "Dynamic range compression"
+msgstr "Normalizálás (DRC)"
+
+#: id:291
+msgctxt "Auto context with id 291"
+msgid "Video"
+msgstr "Videó"
+
+#: id:292
+msgctxt "Auto context with id 292"
+msgid "Audio"
+msgstr "Hang"
+
+#: id:293
+msgid "Browse for subtitles"
+msgstr "Feliratok keresése"
+
+#: id:294
+msgid "Create bookmark"
+msgstr "Új könyvjelző"
+
+#: id:296
+msgid "Clear bookmarks"
+msgstr "Könyvjelzők törlése"
+
+#: id:297
+msgid "Audio offset"
+msgstr "Hang csúsztatás"
+
+#: id:298
+msgid "Bookmarks"
+msgstr "Könyvjelzők"
+
+#: id:299
+msgid "- AAC capable receiver"
+msgstr "- AAC képes erősítő"
+
+#: id:300
+msgid "- MP1 capable receiver"
+msgstr "- MP1 képes erősítő"
+
+#: id:301
+msgid "- MP2 capable receiver"
+msgstr "- MP2 képes erősítő"
+
+#: id:302
+msgid "- MP3 capable receiver"
+msgstr "- MP3 képes erősítő"
+
+#: id:303
+msgid "Delay"
+msgstr "Késleltetés"
+
+#: id:304
+msgctxt "Auto context with id 304"
+msgid "Language"
+msgstr "Nyelv"
+
+#: id:305
+msgctxt "Auto context with id 305"
+msgid "Enabled"
+msgstr "Engedélyezve"
+
+#: id:306
+msgid "Non-interleaved"
+msgstr "Nem interleave típusú"
+
+#: id:312
+msgid "(0=auto)"
+msgstr "(0=auto)"
+
+#: id:313
+msgid "Cleaning database"
+msgstr "Adatbázis tisztítása"
+
+#: id:314
+msgid "Preparing..."
+msgstr "Előkészítés..."
+
+#: id:315
+msgid "Database error"
+msgstr "Adatbázis hiba"
+
+#: id:316
+msgid "Searching songs..."
+msgstr "Zeneszámok keresése..."
+
+#: id:317
+msgid "Cleaned database successfully"
+msgstr "Adatbázis tisztítása sikeres"
+
+#: id:318
+msgid "Cleaning songs..."
+msgstr "Zeneszámok tisztítása..."
+
+#: id:319
+msgid "Error cleaning songs"
+msgstr "Hiba a zeneszámok tisztítása közben"
+
+#: id:320
+msgid "Cleaning artists..."
+msgstr "Előadók tisztítása..."
+
+#: id:321
+msgid "Error cleaning artists"
+msgstr "Hiba az előadók tisztítása közben"
+
+#: id:322
+msgid "Cleaning genres..."
+msgstr "Műfajok tisztítása..."
+
+#: id:323
+msgid "Error cleaning genres"
+msgstr "Hiba a műfajok tisztítása közben"
+
+#: id:324
+msgid "Cleaning paths..."
+msgstr "Elérési utak tisztítása..."
+
+#: id:325
+msgid "Error cleaning paths"
+msgstr "Hiba az elérési utak tisztítása közben"
+
+#: id:326
+msgid "Cleaning albums..."
+msgstr "Albumok tisztítása..."
+
+#: id:327
+msgid "Error cleaning albums"
+msgstr "Hiba az albumok tisztítása közben"
+
+#: id:328
+msgid "Writing changes..."
+msgstr "Változások mentése..."
+
+#: id:329
+msgid "Error writing changes"
+msgstr "Hiba a változások mentése közben"
+
+#: id:330
+msgid "This may take some time..."
+msgstr "Ez a művelet akár sok időt is igénybe vehet..."
+
+#: id:331
+msgid "Compressing database..."
+msgstr "Adatbázis tömörítése..."
+
+#: id:332
+msgid "Error compressing database"
+msgstr "Hiba az adatbázis tömörítése közben"
+
+#: id:333
+msgid "Do you want to clean the library?"
+msgstr "Médiatár tisztítása?"
+
+#: id:334
+msgid "Clean library..."
+msgstr "Médiatár tisztítása..."
+
+#: id:335
+msgid "Start"
+msgstr "Indítás"
+
+#: id:336
+msgid "Framerate conversion"
+msgstr "Képkockasebesség konvertálás"
+
+#: id:337
+msgctxt "Auto context with id 337"
+msgid "Audio output"
+msgstr "Hangkimenet"
+
+#: id:338
+msgid "Analog"
+msgstr "Analóg"
+
+#: id:339
+msgid "Optical/Coax"
+msgstr "Optikai/Coax"
+
+#: id:340
+msgid "Various artists"
+msgstr "Különböző előadók"
+
+#: id:341
+msgid "Play disc"
+msgstr "Lemezek"
+
+#: id:342
+msgctxt "Auto context with id 342"
+msgid "Movies"
+msgstr "Filmek"
+
+#: id:343
+msgid "Adjust framerate"
+msgstr "Képkockasebesség igazítás"
+
+#: id:344
+msgid "Actors"
+msgstr "Színészek"
+
+#: id:345
+msgctxt "Auto context with id 345"
+msgid "Year"
+msgstr "Év"
+
+#: id:346
+msgid "Boost volume level on downmix"
+msgstr "Csatornalekeverésnél hangerő emelése"
+
+#: id:350
+msgctxt "Auto context with id 350"
+msgid "Programs"
+msgstr "Programok"
+
+#: id:351
+msgctxt "Auto context with id 351"
+msgid "Off"
+msgstr "Ki"
+
+#: id:352
+msgid "Dim"
+msgstr "Elhalványít"
+
+#: id:353
+msgid "Black"
+msgstr "Fekete"
+
+#: id:354
+msgid "Matrix trails"
+msgstr "Mátrix animáció"
+
+#: id:355
+msgid "Screensaver time"
+msgstr "Képernyőkímélő késleltetés beállítás"
+
+#: id:356
+msgid "Screensaver mode"
+msgstr "Képernyőkímélő típusa"
+
+#: id:357
+msgid "Shutdown function timer"
+msgstr "Alvó üzemmód, ha inaktív a következő ideig"
+
+#: id:358
+msgid "All albums"
+msgstr "Minden album"
+
+#: id:359
+msgid "Recently added albums"
+msgstr "Új albumok"
+
+#: id:360
+msgctxt "Auto context with id 360"
+msgid "Screensaver"
+msgstr "Képernyőkímélő"
+
+#: id:361
+msgid "R. Slideshow"
+msgstr "Rekurzív diavetítés"
+
+#: id:362
+msgid "Screensaver dim level"
+msgstr "Képernyőkímélő elhalványodási szintje"
+
+#: id:363
+msgid "Sort by: File"
+msgstr "Fájlnév szerint"
+
+#: id:364
+msgid "- Dolby Digital (AC3) capable receiver"
+msgstr "- Dolby Digital (AC3) képes erősítő"
+
+#: id:365
+msgctxt "Auto context with id 365"
+msgid "Sort by: Name"
+msgstr "Név szerint"
+
+#: id:366
+msgid "Sort by: Year"
+msgstr "Év szerint"
+
+#: id:367
+msgid "Sort by: Rating"
+msgstr "Érték szerint"
+
+#: id:368
+msgid "IMDb"
+msgstr "IMDb"
+
+#: id:369
+msgctxt "Auto context with id 369"
+msgid "Title"
+msgstr "Cím"
+
+#: id:370
+msgid "Thunderstorms"
+msgstr "viharok, villámok"
+
+#: id:371
+msgid "Partly"
+msgstr "részben"
+
+#: id:372
+msgid "Mostly"
+msgstr "többnyire"
+
+#: id:373
+msgid "Sunny"
+msgstr "napos"
+
+#: id:374
+msgid "Cloudy"
+msgstr "felhős"
+
+#: id:375
+msgid "Snow"
+msgstr "havazás"
+
+#: id:376
+msgid "Rain"
+msgstr "eső"
+
+#: id:377
+msgid "Light"
+msgstr "enyhe"
+
+#: id:378
+msgid "AM"
+msgstr "délelőtt"
+
+#: id:379
+msgid "PM"
+msgstr "délután"
+
+#: id:380
+msgid "Showers"
+msgstr "zivatar"
+
+#: id:381
+msgid "Few"
+msgstr "helyenként"
+
+#: id:382
+msgid "Scattered"
+msgstr "elszórtan"
+
+#: id:383
+msgctxt "Auto context with id 383"
+msgid "Wind"
+msgstr "szél"
+
+#: id:384
+msgid "Strong"
+msgstr "erős"
+
+#: id:385
+msgid "Fair"
+msgstr "szép idő"
+
+#: id:386
+msgctxt "Auto context with id 386"
+msgid "Clear"
+msgstr "tiszta"
+
+#: id:387
+msgid "Clouds"
+msgstr "felhők"
+
+#: id:388
+msgid "Early"
+msgstr "hajnalban"
+
+#: id:389
+msgid "Shower"
+msgstr "zápor"
+
+#: id:390
+msgid "Flurries"
+msgstr "szélroham"
+
+#: id:391
+msgctxt "Auto context with id 391"
+msgid "Low"
+msgstr "alacsony"
+
+#: id:392
+msgctxt "Auto context with id 392"
+msgid "Medium"
+msgstr "közepes"
+
+#: id:393
+msgctxt "Auto context with id 393"
+msgid "High"
+msgstr "magas"
+
+#: id:394
+msgid "Fog"
+msgstr "ködös"
+
+#: id:395
+msgid "Haze"
+msgstr "párás"
+
+#: id:396
+msgid "Select location"
+msgstr "Területválasztás"
+
+#: id:397
+msgid "Refresh time"
+msgstr "Frissítés gyakorisága"
+
+#: id:398
+msgid "Temperature units"
+msgstr "Hőmérséklet mértékegysége"
+
+#: id:399
+msgid "Speed units"
+msgstr "Sebesség mértékegysége"
+
+#: id:400
+msgctxt "Auto context with id 400"
+msgid "Weather"
+msgstr "Időjárás"
+
+#: id:401
+msgid "Temp"
+msgstr "Hőmérséklet"
+
+#: id:402
+msgid "Feels like"
+msgstr "Hőérzet"
+
+#: id:403
+msgid "UV index"
+msgstr "UV index"
+
+#: id:404
+msgctxt "Auto context with id 404"
+msgid "Wind"
+msgstr "Szél"
+
+#: id:405
+msgid "Dew point"
+msgstr "Harmatpont"
+
+#: id:406
+msgid "Humidity"
+msgstr "Páratartalom"
+
+#: id:409
+msgid "Defaults"
+msgstr "Alapértelmezett"
+
+#: id:410
+msgid "Accessing weather service"
+msgstr "Időjárás-szolgáltató keresése"
+
+#: id:411
+msgid "Getting weather for:"
+msgstr "Időjárás lekérdezése:"
+
+#: id:412
+msgid "Unable to get weather data"
+msgstr "Hiba az időjárás lekérdezése közben"
+
+#: id:413
+msgid "Manual"
+msgstr "Kézi"
+
+#: id:414
+msgid "No review for this album"
+msgstr "Nincs ismertető ehhez az albumhoz"
+
+#: id:415
+msgid "Downloading thumbnail..."
+msgstr "Bélyegkép letöltése..."
+
+#: id:416
+msgid "Not available"
+msgstr "Nem elérhető"
+
+#: id:417
+msgid "View: Big icons"
+msgstr "Nézet: Nagy ikon"
+
+#: id:418
+msgctxt "Auto context with id 418"
+msgid "Low"
+msgstr "Min"
+
+#: id:419
+msgctxt "Auto context with id 419"
+msgid "High"
+msgstr "Max"
+
+#: id:420
+msgid "HDMI"
+msgstr "HDMI"
+
+#: id:422
+msgid "Delete album info"
+msgstr "Album információ törlése"
+
+#: id:423
+msgid "Delete CD information"
+msgstr "CD információ törlése"
+
+#: id:424
+msgid "Select"
+msgstr "Kiválaszt"
+
+#: id:425
+msgid "No album information found"
+msgstr "Album információ nem található"
+
+#: id:426
+msgid "No CD information found"
+msgstr "CD információ nem található"
+
+#: id:427
+msgid "Disc"
+msgstr "Lemez"
+
+#: id:428
+msgid "Insert correct CD/DVD"
+msgstr "Hibás CD/DVD"
+
+#: id:429
+msgid "Please insert the following disc:"
+msgstr "Helyezze be a következő lemezt:"
+
+#: id:430
+msgid "Sort by: DVD#"
+msgstr "Rendezés: DVD alapján"
+
+#: id:431
+msgid "No cache"
+msgstr "Nincs gyorsítótár"
+
+#: id:432
+msgid "Remove movie from library"
+msgstr "Film eltávolítása a médiatárból"
+
+#: id:433
+msgid "Really remove '%s'?"
+msgstr "Biztos el akarod távolítani a '%s'-t?"
+
+#: id:434
+msgid "From %s at %i %s"
+msgstr "irány: %s, seb.: %i %s"
+
+#: id:437
+msgid "Removable disk"
+msgstr "Cserélhető lemez"
+
+#: id:438
+msgid "Opening file"
+msgstr "Fájl megnyitása"
+
+#: id:439
+msgid "Cache"
+msgstr "Gyorsítótár"
+
+#: id:440
+msgid "Harddisk"
+msgstr "Merevlemez"
+
+#: id:441
+msgid "UDF"
+msgstr "UDF"
+
+#: id:442
+msgid "Local network"
+msgstr "Helyi hálózat"
+
+#: id:443
+msgid "Internet"
+msgstr "Internet"
+
+#: id:444
+msgctxt "Auto context with id 444"
+msgid "Video"
+msgstr "Videó"
+
+#: id:445
+msgctxt "Auto context with id 445"
+msgid "Audio"
+msgstr "Hang"
+
+#: id:446
+msgctxt "Auto context with id 446"
+msgid "DVD"
+msgstr "DVD"
+
+#: id:447
+msgid "Autorun media"
+msgstr "Média autoindítás"
+
+#: id:448
+msgid "LCD"
+msgstr "LCD"
+
+#: id:449
+msgctxt "Auto context with id 449"
+msgid "Enabled"
+msgstr "Engedélyezve"
+
+#: id:450
+msgid "Columns"
+msgstr "Oszlopok"
+
+#: id:451
+msgid "Row 1 address"
+msgstr "Sor 1 cím"
+
+#: id:452
+msgid "Row 2 address"
+msgstr "Sor 2 cím"
+
+#: id:453
+msgid "Row 3 address"
+msgstr "Sor 3 cím"
+
+#: id:454
+msgid "Row 4 address"
+msgstr "Sor 4 cím"
+
+#: id:455
+msgid "Rows"
+msgstr "Sorok"
+
+#: id:456
+msgid "Mode"
+msgstr "Mód"
+
+#: id:457
+msgid "Switch view"
+msgstr "Nézet váltása"
+
+#: id:459
+msgid "Subs"
+msgstr "Feliratok"
+
+#: id:460
+msgid "Audio stream"
+msgstr "Hangfolyam"
+
+#: id:461
+msgid "[active]"
+msgstr "[aktív]"
+
+#: id:462
+msgid "Subtitle"
+msgstr "Felirat"
+
+#: id:463
+msgid "Backlight"
+msgstr "Háttérvilágítás"
+
+#: id:464
+msgid "Brightness"
+msgstr "Fényerő"
+
+#: id:465
+msgid "Contrast"
+msgstr "Kontraszt"
+
+#: id:466
+msgid "Gamma"
+msgstr "Gamma"
+
+#: id:467
+msgctxt "Auto context with id 467"
+msgid "Type"
+msgstr "Típus"
+
+#: id:468
+msgid "Move the bar to change the OSD position"
+msgstr "Navigációs-tálca (OSD) pozíció beállítása a sáv mozgatásával"
+
+#: id:469
+msgid "OSD position"
+msgstr "Navigációs-tálca (OSD) pozíció"
+
+#: id:470
+msgid "Credits"
+msgstr "Készítők"
+
+#: id:471
+msgid "Modchip"
+msgstr "Modchip"
+
+#: id:474
+msgctxt "Auto context with id 474"
+msgid "Off"
+msgstr "Ki"
+
+#: id:475
+msgid "Music only"
+msgstr "Csak zene"
+
+#: id:476
+msgctxt "Auto context with id 476"
+msgid "Music & video"
+msgstr "Zene és Videó"
+
+#: id:477
+msgid "Unable to load playlist"
+msgstr "Lejátszáslista nem tölthető be"
+
+#: id:478
+msgid "OSD"
+msgstr "Navigációs tálca"
+
+#: id:479
+msgid "Skin & language"
+msgstr "Felszín és Nyelv"
+
+#: id:480
+msgid "Appearance"
+msgstr "Megjelenés"
+
+#: id:481
+msgid "Audio options"
+msgstr "Hangbeállítások"
+
+#: id:482
+msgid "About XBMC"
+msgstr "Az XBMC-ről"
+
+#: id:485
+msgid "Delete album"
+msgstr "Album törlése"
+
+#: id:486
+msgid "Repeat"
+msgstr "Ismétlés"
+
+#: id:487
+msgid "Repeat one"
+msgstr "Egy ismétlése"
+
+#: id:488
+msgid "Repeat folder"
+msgstr "Mappa ismétlése"
+
+#: id:489
+msgid "Play the next song automatically"
+msgstr "Lejátszás automatikus folytatása"
+
+#: id:491
+msgid "- Use big icons"
+msgstr "- Nagy ikonok használata"
+
+#: id:492
+msgid "Resize VobSubs"
+msgstr "Feliratok méretezése"
+
+#: id:493
+msgid "Advanced options (Experts Only!)"
+msgstr "Haladó beállítások (csak szakértőknek!)"
+
+#: id:494
+msgid "Overall audio headroom"
+msgstr "Hangerőkilengések megengedett tartománya"
+
+#: id:495
+msgid "Upsample videos to GUI resolution"
+msgstr "Videók felskálázása a GUI felbontásához"
+
+#: id:496
+msgid "Calibration"
+msgstr "Kalibrálás"
+
+#: id:497
+msgid "Show file extensions"
+msgstr "Fájlkiterjesztések megjelenítése"
+
+#: id:498
+msgid "Sort by: Type"
+msgstr "Típus szerint"
+
+#: id:499
+msgid "Unable to connect to online lookup service"
+msgstr "Sikertelen csatlakozás az online szolgáltatóhoz"
+
+#: id:500
+msgid "Downloading album information failed"
+msgstr "Hiba az albuminformáció letöltése közben"
+
+#: id:501
+msgid "Looking for album names..."
+msgstr "Album nevek keresése..."
+
+#: id:502
+msgctxt "Auto context with id 502"
+msgid "Open"
+msgstr "Nyitva"
+
+#: id:503
+msgid "Busy"
+msgstr "Foglalt"
+
+#: id:504
+msgid "Empty"
+msgstr "Üres"
+
+#: id:505
+msgid "Loading media info from files..."
+msgstr "Médiainformáció betöltése fájlokból..."
+
+#: id:507
+msgid "Sort by: Usage"
+msgstr "Rendezés: Használat alapján"
+
+#: id:510
+msgid "Enable visualizations"
+msgstr "Vizualizációk engedélyezése"
+
+#: id:511
+msgid "Enable video mode switching"
+msgstr "Automatikus képmód váltás"
+
+#: id:512
+msgid "Startup window"
+msgstr "Kezdőablak"
+
+#: id:513
+msgid "Home window"
+msgstr "Főképernyő"
+
+#: id:514
+msgid "Manual settings"
+msgstr "Kézi beállítások"
+
+#: id:515
+msgid "Genre"
+msgstr "Műfaj"
+
+#: id:517
+msgid "Recently played albums"
+msgstr "Mostanában játszott albumok"
+
+#: id:518
+msgid "Launch"
+msgstr "Indítás"
+
+#: id:519
+msgid "Launch in..."
+msgstr "Indítás a..."
+
+#: id:521
+msgid "Compilations"
+msgstr "Összeállítások"
+
+#: id:522
+msgid "Remove source"
+msgstr "Forrás eltávolítása"
+
+#: id:523
+msgid "Switch media"
+msgstr "Médiaváltás"
+
+#: id:524
+msgid "Select playlist"
+msgstr "Lejátszáslista választása"
+
+#: id:525
+msgid "New playlist..."
+msgstr "Új lejátszáslista"
+
+#: id:526
+msgid "Add to playlist"
+msgstr "Hozzáadás a lejátszáslistához"
+
+#: id:527
+msgid "Manually add to library"
+msgstr "Kézi hozzáadás a Médiatárhoz"
+
+#: id:528
+msgid "Enter title"
+msgstr "Cím"
+
+#: id:529
+msgid "Error: Duplicate title"
+msgstr "Hiba: már létező cím"
+
+#: id:530
+msgid "Select genre"
+msgstr "Műfaj választása"
+
+#: id:531
+msgid "New genre"
+msgstr "Új műfaj"
+
+#: id:532
+msgid "Manual addition"
+msgstr "Kézi hozzáadás"
+
+#: id:533
+msgid "Enter genre"
+msgstr "Műfaj"
+
+#: id:534
+msgid "View: %s"
+msgstr "Nézet: %s"
+
+#: id:535
+msgid "List"
+msgstr "Lista"
+
+#: id:536
+msgid "Icons"
+msgstr "Ikon"
+
+#: id:537
+msgid "Big list"
+msgstr "Nagy lista"
+
+#: id:538
+msgid "Big icons"
+msgstr "Nagy ikonok"
+
+#: id:539
+msgid "Wide"
+msgstr "Széles"
+
+#: id:540
+msgid "Big wide"
+msgstr "Széles (nagy)"
+
+#: id:541
+msgid "Album icons"
+msgstr "Album ikonok"
+
+#: id:542
+msgid "DVD icons"
+msgstr "DVD ikonok"
+
+#: id:543
+msgctxt "Auto context with id 543"
+msgid "DVD"
+msgstr "DVD"
+
+#: id:544
+msgctxt "Auto context with id 544"
+msgid "Media info"
+msgstr "Médiainfó"
+
+#: id:545
+msgid "Audio output device"
+msgstr "Hanglejátszás eszköze"
+
+#: id:546
+msgid "Passthrough output device"
+msgstr "Közvetlen-hangtovábbítás (passthrough) eszköze"
+
+#: id:547
+msgid "No biography for this artist"
+msgstr "Nincs életrajz ehhez az előadóhoz"
+
+#: id:548
+msgid "Downmix multichannel audio to stereo"
+msgstr "A dekódolt többcsatornás hangok lekeverése sztereóra"
+
+#: id:550
+msgid "Sort by: %s"
+msgstr "%s szerint"
+
+#: id:551
+msgctxt "Auto context with id 551"
+msgid "Name"
+msgstr "Név"
+
+#: id:552
+msgid "Date"
+msgstr "Dátum"
+
+#: id:553
+msgid "Size"
+msgstr "Méret"
+
+#: id:554
+msgid "Track"
+msgstr "Szám"
+
+#: id:555
+msgid "Time"
+msgstr "Idő"
+
+#: id:556
+msgctxt "Auto context with id 556"
+msgid "Title"
+msgstr "Cím"
+
+#: id:557
+msgid "Artist"
+msgstr "Előadó"
+
+#: id:558
+msgid "Album"
+msgstr "Album"
+
+#: id:559
+msgid "Playlist"
+msgstr "Lejátszási lista"
+
+#: id:560
+msgid "ID"
+msgstr "Azonosító"
+
+#: id:561
+msgctxt "Auto context with id 561"
+msgid "File"
+msgstr "Fájl"
+
+#: id:562
+msgctxt "Auto context with id 562"
+msgid "Year"
+msgstr "Év"
+
+#: id:563
+msgid "Rating"
+msgstr "Pontszám"
+
+#: id:564
+msgctxt "Auto context with id 564"
+msgid "Type"
+msgstr "Típus"
+
+#: id:565
+msgid "Usage"
+msgstr "Használat"
+
+#: id:566
+msgid "Album artist"
+msgstr "Album előadó"
+
+#: id:567
+msgid "Play count"
+msgstr "Lejátszás-számláló"
+
+#: id:568
+msgid "Last played"
+msgstr "Utoljára játszott"
+
+#: id:569
+msgctxt "Auto context with id 569"
+msgid "Comment"
+msgstr "Leírás"
+
+#: id:570
+msgid "Date added"
+msgstr "Hozzáadás"
+
+#: id:571
+msgctxt "Auto context with id 571"
+msgid "Default"
+msgstr "Eredeti"
+
+#: id:572
+msgid "Studio"
+msgstr "Stúdió"
+
+#: id:573
+msgid "Path"
+msgstr "Elérési út"
+
+#: id:574
+msgctxt "Auto context with id 574"
+msgid "Country"
+msgstr "Ország"
+
+#: id:575
+msgid "In progress"
+msgstr "Folyamatban"
+
+#: id:576
+msgid "Times played"
+msgstr "Lejátszás"
+
+#: id:580
+msgid "Sort direction"
+msgstr "Rendezés iránya"
+
+#: id:581
+msgid "Sort method"
+msgstr "Rendezés módja"
+
+#: id:582
+msgctxt "Auto context with id 582"
+msgid "View mode"
+msgstr "Nézetmód"
+
+#: id:583
+msgid "Remember views for different folders"
+msgstr "Mappanézet megjegyzése"
+
+#: id:584
+msgid "Ascending"
+msgstr "Növekvő"
+
+#: id:585
+msgid "Descending"
+msgstr "Csökkenő"
+
+#: id:586
+msgid "Edit playlist"
+msgstr "Lejátszáslista szerkesztése"
+
+#: id:587
+msgid "Filter"
+msgstr "Szűrő"
+
+#: id:588
+msgid "Cancel party mode"
+msgstr "Kilépés partymódból"
+
+#: id:589
+msgid "Party mode"
+msgstr "Partymód"
+
+#: id:590
+msgid "Random"
+msgstr "Véletlenszerű"
+
+#: id:591
+msgctxt "Auto context with id 591"
+msgid "Off"
+msgstr "Ki"
+
+#: id:592
+msgid "One"
+msgstr "Egyszer"
+
+#: id:593
+msgid "All"
+msgstr "Mind"
+
+#: id:594
+msgctxt "Auto context with id 594"
+msgid "Off"
+msgstr "Ki"
+
+#: id:595
+msgid "Repeat: Off"
+msgstr "Ismétlés: Ki"
+
+#: id:596
+msgid "Repeat: One"
+msgstr "Ismétlés: Egyszer"
+
+#: id:597
+msgid "Repeat: All"
+msgstr "Ismétlés: Mind"
+
+#: id:600
+msgid "Rip audio CD"
+msgstr "Zenei CD bemásolása (rip)"
+
+#: id:601
+msgctxt "Auto context with id 601"
+msgid "Medium"
+msgstr "Közepes"
+
+#: id:602
+msgctxt "Auto context with id 602"
+msgid "Standard"
+msgstr "Normál"
+
+#: id:603
+msgid "Extreme"
+msgstr "Extrém"
+
+#: id:604
+msgid "Constant bitrate"
+msgstr "Állandó bitarány"
+
+#: id:605
+msgid "Ripping..."
+msgstr "Bemásolás..."
+
+#: id:607
+msgid "To:"
+msgstr "Ide:"
+
+#: id:608
+msgid "Could not rip CD or track"
+msgstr "CD vagy zeneszám nem bemásolható"
+
+#: id:609
+msgid "CDDARipPath is not set."
+msgstr "CDDA bemásolási mappa nincs beállítva."
+
+#: id:610
+msgid "Rip audio track"
+msgstr "Zeneszám bemásolása"
+
+#: id:611
+msgid "Enter number"
+msgstr "Szám megadása"
+
+#: id:612
+msgid "Bits/Sample"
+msgstr "Bitszám/minta"
+
+#: id:613
+msgid "Sample Frequency"
+msgstr "Mintavételi frekvencia"
+
+#: id:620
+msgid "Audio CDs"
+msgstr "Zenei CD"
+
+#: id:621
+msgid "Encoder"
+msgstr "Kódoló"
+
+#: id:622
+msgid "Quality"
+msgstr "Minőség"
+
+#: id:623
+msgid "Bitrate"
+msgstr "Bitarány"
+
+#: id:624
+msgid "Include track number"
+msgstr "Zene számának bevonása"
+
+#: id:625
+msgid "All songs of"
+msgstr "Minden zeneszám a(z)"
+
+#: id:629
+msgctxt "Auto context with id 629"
+msgid "View mode"
+msgstr "Nézet mód"
+
+#: id:630
+msgctxt "Auto context with id 630"
+msgid "Normal"
+msgstr "Normál"
+
+#: id:631
+msgid "Zoom"
+msgstr "Nagyítás"
+
+#: id:632
+msgid "Stretch 4:3"
+msgstr "Széthúzás 4:3-ra"
+
+#: id:633
+msgid "Wide Zoom"
+msgstr "Széles nagyítás"
+
+#: id:634
+msgid "Stretch 16:9"
+msgstr "Széthúzás 16:9-re"
+
+#: id:635
+msgid "Original Size"
+msgstr "Eredeti méret"
+
+#: id:636
+msgctxt "Auto context with id 636"
+msgid "Custom"
+msgstr "Egyéni"
+
+#: id:637
+msgid "Replay gain"
+msgstr "Hangerőingadozások kiegyenlítése"
+
+#: id:638
+msgid "Replaygain volume adjustments"
+msgstr "Hangerőingadozások kiegyenlítése"
+
+#: id:639
+msgid "Use track levels"
+msgstr "Zeneszám szintekhez"
+
+#: id:640
+msgid "Use album levels"
+msgstr "Album szintekhez"
+
+#: id:641
+msgid "PreAmp Level - Replay gained files"
+msgstr "Előerősítés - Hangerőkiegyenlített fájlok"
+
+#: id:642
+msgid "PreAmp Level - Non replay gained files"
+msgstr "Előerősítés - Nem hangerőkiegyenlített fájlok"
+
+#: id:643
+msgid "Avoid clipping on replay gained files"
+msgstr "Túlvezérelt torzítás elkerülése hangerőkiegyenlítésnél"
+
+#: id:644
+msgid "Crop black bars"
+msgstr "Feketesávok levágása"
+
+#: id:645
+msgid "Need to unpack a big file. Continue?"
+msgstr "Egy nagy fájl kitömörítése szükséges. Folytatod?"
+
+#: id:646
+msgid "Remove from library"
+msgstr "Eltávolítás a médiatárból"
+
+#: id:647
+msgid "Export video library"
+msgstr "Médiatár (videó) exportálása"
+
+#: id:648
+msgid "Import video library"
+msgstr "Médiatár (videó) importálása"
+
+#: id:649
+msgid "Importing"
+msgstr "Importálás"
+
+#: id:650
+msgid "Exporting"
+msgstr "Exportálás"
+
+#: id:651
+msgid "Browse for library"
+msgstr "Médiatár keresése"
+
+#: id:652
+msgid "Years"
+msgstr "Év"
+
+#: id:653
+msgid "Update library"
+msgstr "Médiatár frissítése"
+
+#: id:654
+msgid "Show debug info"
+msgstr "Hibakeresési-infó megjelenítése"
+
+#: id:655
+msgid "Browse for executable"
+msgstr "Futtatható fájl keresése"
+
+#: id:656
+msgid "Browse for playlist"
+msgstr "Lejátszáslista keresése"
+
+#: id:657
+msgid "Browse for folder"
+msgstr "Mappa keresése"
+
+#: id:658
+msgid "Song information"
+msgstr "Dal információ"
+
+#: id:659
+msgid "Non-linear stretch"
+msgstr "Nemlineáris széthúzás"
+
+#: id:660
+msgid "Volume amplification"
+msgstr "Hang előerősítés"
+
+#: id:661
+msgid "Choose export folder"
+msgstr "Export mappa választása"
+
+#: id:662
+msgid "This file is no longer available."
+msgstr "A fájl már nem elérhető."
+
+#: id:663
+msgid "Would you like to remove it from the library?"
+msgstr "Eltávolítás a médiatárból?"
+
+#: id:664
+msgid "Browse for Script"
+msgstr "Program keresése"
+
+#: id:665
+msgid "Compression level"
+msgstr "Tömörítés erőssége"
+
+#: id:700
+msgid "Cleaning up library"
+msgstr "Médiatár tisztítása"
+
+#: id:701
+msgid "Removing old songs from the library"
+msgstr "Régi dalok eltávolítása a médiatárból"
+
+#: id:702
+msgid "This path has been scanned before"
+msgstr "Ez az elérési út már át lett vizsgálva korábban"
+
+#: id:705
+msgctxt "Auto context with id 705"
+msgid "Network"
+msgstr "Hálózat"
+
+#: id:706
+msgid "- Server"
+msgstr "- Kiszolgáló"
+
+#: id:708
+msgid "Use an HTTP proxy server to access the internet"
+msgstr "HTTP proxykiszolgáló használata az internet eléréséhez"
+
+#: id:711
+msgid "Internet Protocol (IP)"
+msgstr "Internetprotokoll (IP)"
+
+#: id:712
+msgid "Invalid port specified. Value must be between 1 and 65535."
+msgstr "Érvénytelen port. Az értéknek 1 és 65535 között kell lennie."
+
+#: id:713
+msgid "HTTP proxy"
+msgstr "HTTP proxy"
+
+#: id:715
+msgid "- Assignment"
+msgstr "- Hozzárendelés"
+
+#: id:716
+msgid "Automatic (DHCP)"
+msgstr "Automatikus (DHCP)"
+
+#: id:717
+msgid "Manual (Static)"
+msgstr "Kézi (Állandó)"
+
+#: id:719
+msgid "- IP address"
+msgstr "- IP cím"
+
+#: id:720
+msgid "- Netmask"
+msgstr "- Hálózati maszk"
+
+#: id:721
+msgid "- Default gateway"
+msgstr "- Alapértelmezett átjáró"
+
+#: id:722
+msgid "- DNS server"
+msgstr "- DNS kiszolgáló"
+
+#: id:723
+msgid "Save & restart"
+msgstr "Mentés & újraindítás"
+
+#: id:724
+msgid "Invalid address specified. Value must be AAA.BBB.CCC.DDD"
+msgstr "Érvénytelen cím. Az értéknek AAA.BBB.CCC.DDD-nek kell lennie."
+
+#: id:725
+msgid "with numbers between 0 and 255."
+msgstr "0 és 255 közötti számokkal."
+
+#: id:726
+msgid "Changes not saved. Continue without saving?"
+msgstr "A változtatások nincsenek elmentve. Folytatás?"
+
+#: id:727
+msgid "Web server"
+msgstr "Webkiszolgáló"
+
+#: id:728
+msgctxt "Auto context with id 728"
+msgid "FTP server"
+msgstr "FTP kiszolgáló"
+
+#: id:730
+msgid "- Port"
+msgstr "- Port"
+
+#: id:732
+msgid "Save & apply"
+msgstr "Mentés és érvényesítés"
+
+#: id:733
+msgid "- Password"
+msgstr "- Jelszó"
+
+#: id:734
+msgid "No pass"
+msgstr "Nincs jelszó"
+
+#: id:735
+msgid "- Character set"
+msgstr "- Karakterkészlet"
+
+#: id:736
+msgid "- Style"
+msgstr "- Stílus"
+
+#: id:737
+msgid "- Colour"
+msgstr "- Szín"
+
+#: id:738
+msgctxt "Auto context with id 738"
+msgid "Normal"
+msgstr "Normál"
+
+#: id:739
+msgid "Bold"
+msgstr "Félkövér"
+
+#: id:740
+msgid "Italics"
+msgstr "Dőlt"
+
+#: id:741
+msgid "Bold italics"
+msgstr "Félkövér és Dőlt"
+
+#: id:742
+msgctxt "Auto context with id 742"
+msgid "White"
+msgstr "Fehér"
+
+#: id:743
+msgctxt "Auto context with id 743"
+msgid "Yellow"
+msgstr "Sárga"
+
+#: id:744
+msgctxt "Auto context with id 744"
+msgid "Files"
+msgstr "Fájlok"
+
+#: id:745
+msgid "No scanned information for this view"
+msgstr "Nincs információ ehhez a nézethez"
+
+#: id:746
+msgid "Please turn off library mode"
+msgstr "Médiatár kikapcsolása szükséges"
+
+#: id:747
+msgid "Error loading image"
+msgstr "Hiba a kép beolvasása közben"
+
+#: id:748
+msgid "Edit path"
+msgstr "Elérési út szerkesztése"
+
+#: id:749
+msgid "Mirror image"
+msgstr "Kép tükrözése"
+
+#: id:750
+msgid "Are you sure?"
+msgstr "Megerősítés?"
+
+#: id:751
+msgid "Removing source"
+msgstr "Forrás eltávolítása"
+
+#: id:754
+msgid "Add program link"
+msgstr "Programhivatkozás hozzáadása"
+
+#: id:755
+msgid "Edit program path"
+msgstr "Program elérési út szerkesztése"
+
+#: id:756
+msgid "Edit program name"
+msgstr "Program nevének szerkesztése"
+
+#: id:757
+msgid "Edit path depth"
+msgstr "Elérési út mélységének szerkesztése"
+
+#: id:759
+msgid "View: Big list"
+msgstr "Nézet: Nagy lista"
+
+#: id:760
+msgctxt "Auto context with id 760"
+msgid "Yellow"
+msgstr "Sárga"
+
+#: id:761
+msgctxt "Auto context with id 761"
+msgid "White"
+msgstr "Fehér"
+
+#: id:762
+msgid "Blue"
+msgstr "Kék"
+
+#: id:763
+msgid "Bright green"
+msgstr "Világoszöld"
+
+#: id:764
+msgid "Yellow green"
+msgstr "Sárgászöld"
+
+#: id:765
+msgid "Cyan"
+msgstr "Cián"
+
+#: id:766
+msgid "Light grey"
+msgstr "Világosszürke"
+
+#: id:767
+msgid "Grey"
+msgstr "Szürke"
+
+#: id:770
+msgid "Error %i: share not available"
+msgstr "Hiba %i: megosztás nem elérhető"
+
+#: id:772
+msgctxt "Auto context with id 772"
+msgid "Audio output"
+msgstr "Hangkimenet"
+
+#: id:773
+msgid "Seeking"
+msgstr "POZÍCIÓKERESÉS"
+
+#: id:774
+msgid "Slideshow folder"
+msgstr "Diavetítés mappa"
+
+#: id:775
+msgid "Network interface"
+msgstr "Hálózati eszköz"
+
+#: id:776
+msgid "- Wireless network name (ESSID)"
+msgstr "- Vezetéknélküli hálózat neve (ESSID)"
+
+#: id:777
+msgid "- Wireless password"
+msgstr "- Vezetéknélküli hálózat jelszava"
+
+#: id:778
+msgid "- Wireless security"
+msgstr "- Vezetéknélküli biztonság"
+
+#: id:779
+msgid "Save and apply network interface settings"
+msgstr "Hálózati eszköz beállításainak mentése"
+
+#: id:780
+msgid "No encryption"
+msgstr "Nincs titkosítás"
+
+#: id:781
+msgid "WEP"
+msgstr "WEP"
+
+#: id:782
+msgid "WPA"
+msgstr "WPA"
+
+#: id:783
+msgid "WPA2"
+msgstr "WPA2"
+
+#: id:784
+msgid "Applying network interface settings. Please wait."
+msgstr "Hálózati eszköz beállításainak mentése. Kérlek várj."
+
+#: id:785
+msgid "Network interface restarted successfully."
+msgstr "Hálózati eszköz sikeresen újraindult."
+
+#: id:786
+msgid "Network interface did not start successfully."
+msgstr "Hálózati eszköz nem indult el."
+
+#: id:787
+msgid "Interface disabled"
+msgstr "Eszköz letiltva"
+
+#: id:788
+msgid "Network interface disabled successfully."
+msgstr "Hálózati eszköz letiltva."
+
+#: id:789
+msgid "Wireless network name (ESSID)"
+msgstr "Vezetéknélküli hálózat neve (ESSID)"
+
+#: id:790
+msgid "Remote control"
+msgstr ""
+
+#: id:791
+msgid "Allow programs on this system to control XBMC"
+msgstr "XBMC irányítható az ezen a rendszeren futó programokkal"
+
+#: id:792
+msgctxt "Auto context with id 792"
+msgid "Port"
+msgstr "Port"
+
+#: id:793
+msgid "Port range"
+msgstr "Port tartomány"
+
+#: id:794
+msgid "Allow programs on other systems to control XBMC"
+msgstr "XBMC irányítható a más rendszereken futó programokkal is"
+
+#: id:795
+msgid "Initial repeat delay (ms)"
+msgstr "Kezdeti ismétlés késleltetés (ms)"
+
+#: id:796
+msgid "Continuous repeat delay (ms)"
+msgstr "Folyamatos ismétlés késleltetése (ms)"
+
+#: id:797
+msgid "Maximum number of clients"
+msgstr "Kliensek maximális száma"
+
+#: id:798
+msgid "Internet access"
+msgstr "Internet elérés"
+
+#: id:850
+msgid "Invalid port number entered"
+msgstr "Hibás portszám lett megadva"
+
+#: id:851
+msgid "Valid port range is 1-65535"
+msgstr "Érvényes porttartomány: 1-65535"
+
+#: id:852
+msgid "Valid port range is 1024-65535"
+msgstr "Érvényes porttartomány: 1024-65535"
+
+#: id:998
+msgid "Add Music..."
+msgstr "Zene hozzáadása..."
+
+#: id:999
+msgid "Add Videos..."
+msgstr "Videó hozzáadása..."
+
+#: id:1000
+msgid "- Preview"
+msgstr "- Előnézet"
+
+#: id:1001
+msgid "Unable to connect"
+msgstr "Kapcsolódás sikertelen"
+
+#: id:1002
+msgid "XBMC was unable to connect to the network location."
+msgstr "Sikertelen csatlakozás a hálózati helyhez."
+
+#: id:1003
+msgid "This could be due to the network not being connected."
+msgstr "Ez a hálózati kapcsolat hiánya miatt lehet."
+
+#: id:1004
+msgid "Would you like to add it anyway?"
+msgstr "Hozzáadás ettől függetlenül?"
+
+#: id:1006
+msgctxt "Auto context with id 1006"
+msgid "IP address"
+msgstr "IP cím"
+
+#: id:1007
+msgid "Add network location"
+msgstr "Hálózati hely hozzáadása"
+
+#: id:1008
+msgid "Protocol"
+msgstr "Protokoll"
+
+#: id:1009
+msgid "Server address"
+msgstr "Kiszolgáló címe"
+
+#: id:1010
+msgid "Server name"
+msgstr "Kiszolgáló neve"
+
+#: id:1011
+msgid "Remote path"
+msgstr "Távoli elérési út"
+
+#: id:1012
+msgid "Shared folder"
+msgstr "Megosztott mappa"
+
+#: id:1013
+msgctxt "Auto context with id 1013"
+msgid "Port"
+msgstr "Port"
+
+#: id:1014
+msgctxt "Auto context with id 1014"
+msgid "Username"
+msgstr "Felhasználónév"
+
+#: id:1015
+msgid "Browse for network server"
+msgstr "Hálózati megosztások tallózása"
+
+#: id:1016
+msgid "Enter the network address of the server"
+msgstr "Kiszolgáló IP címe"
+
+#: id:1017
+msgid "Enter the path on the server"
+msgstr "Kiszolgáló elérési útja"
+
+#: id:1018
+msgid "Enter the port number"
+msgstr "Port"
+
+#: id:1019
+msgid "Enter the username"
+msgstr "Felhasználónév"
+
+#: id:1020
+msgid "Add %s source"
+msgstr "%s forrás hozzáadása"
+
+#: id:1021
+msgid "Enter the paths or browse for the media locations."
+msgstr "Elérési-út megadása, vagy médiamappák tallózása"
+
+#: id:1022
+msgid "Enter a name for this media Source."
+msgstr "Médiaforrás nevének megadása"
+
+#: id:1023
+msgid "Browse for new share"
+msgstr "Új megosztás keresése"
+
+#: id:1024
+msgid "Browse"
+msgstr "Tallózás"
+
+#: id:1025
+msgid "Could not retrieve directory information."
+msgstr "Mappainformáció nem elérhető"
+
+#: id:1026
+msgid "Add source"
+msgstr "Forrás hozzáadása"
+
+#: id:1027
+msgid "Edit source"
+msgstr "Forrás szerkesztése"
+
+#: id:1028
+msgid "Edit %s source"
+msgstr "%s forrás szerkesztése"
+
+#: id:1029
+msgid "Enter the new label"
+msgstr "Új név megadása"
+
+#: id:1030
+msgid "Browse for image"
+msgstr "Kép keresése"
+
+#: id:1031
+msgid "Browse for image folder"
+msgstr "Képmappa keresése"
+
+#: id:1032
+msgid "Add network location..."
+msgstr "Hálózati hely hozzáadása..."
+
+#: id:1033
+msgid "Browse for file"
+msgstr "Fájl keresése"
+
+#: id:1034
+msgid "Submenu"
+msgstr "Almenü"
+
+#: id:1035
+msgid "Enable submenu buttons"
+msgstr "Almenügombok engedélyezése"
+
+#: id:1036
+msgid "Favourites"
+msgstr "Kedvencek"
+
+#: id:1037
+msgid "Video Add-ons"
+msgstr "Videó kiegészítők"
+
+#: id:1038
+msgid "Music Add-ons"
+msgstr "Zenei kiegészítők"
+
+#: id:1039
+msgid "Picture Add-ons"
+msgstr "Kép kiegészítők"
+
+#: id:1040
+msgid "Loading directory"
+msgstr "Könyvtár betöltése"
+
+#: id:1041
+msgid "Retrieved %i items"
+msgstr "%i elem letöltve"
+
+#: id:1042
+msgid "Retrieved %i of %i items"
+msgstr "%i elemből %i letöltve"
+
+#: id:1043
+msgid "Program Add-ons"
+msgstr "Program kiegészítők"
+
+#: id:1044
+msgid "Set plugin thumb"
+msgstr "Kiegészítő bélyegkép beállítás"
+
+#: id:1045
+msgid "Add-on settings"
+msgstr "Kiegészítő beállítások"
+
+#: id:1046
+msgid "Access points"
+msgstr "Hozzáférési pontok"
+
+#: id:1047
+msgid "Other..."
+msgstr "Más..."
+
+#: id:1048
+msgid "- Username"
+msgstr "- Felhasználónév"
+
+#: id:1049
+msgid "Script settings"
+msgstr "Program beállítások"
+
+#: id:1050
+msgid "Singles"
+msgstr "Kislemezek"
+
+#: id:1051
+msgid "Enter web address"
+msgstr "Webcím megadása"
+
+#: id:1200
+msgid "SMB client"
+msgstr "SMB kliens"
+
+#: id:1202
+msgid "Workgroup"
+msgstr "Munkacsoport"
+
+#: id:1203
+msgid "Default username"
+msgstr "Alapértelmezett felhasználónév"
+
+#: id:1204
+msgid "Default password"
+msgstr "Alapértelmezett jelszó"
+
+#: id:1207
+msgid "WINS server"
+msgstr "WINS kiszolgáló"
+
+#: id:1208
+msgid "Mount SMB shares"
+msgstr "SMB megosztás felcsatolása"
+
+#: id:1210
+msgctxt "Auto context with id 1210"
+msgid "Remove"
+msgstr "Eltávolítás"
+
+#: id:1211
+msgctxt "Auto context with id 1211"
+msgid "Music"
+msgstr "Zene"
+
+#: id:1212
+msgctxt "Auto context with id 1212"
+msgid "Video"
+msgstr "Videó"
+
+#: id:1213
+msgctxt "Auto context with id 1213"
+msgid "Pictures"
+msgstr "Képek"
+
+#: id:1214
+msgctxt "Auto context with id 1214"
+msgid "Files"
+msgstr "Fájlok"
+
+#: id:1215
+msgctxt "Auto context with id 1215"
+msgid "Music & video"
+msgstr "Zene & videó"
+
+#: id:1216
+msgid "Music & pictures"
+msgstr "Zene & képek"
+
+#: id:1217
+msgid "Music & files"
+msgstr "Zene & fájlok"
+
+#: id:1218
+msgid "Video & pictures"
+msgstr "Videó & képek"
+
+#: id:1219
+msgid "Video & files"
+msgstr "Videó & fájlok"
+
+#: id:1220
+msgid "Pictures & files"
+msgstr "Képek & fájlok"
+
+#: id:1221
+msgid "Music & video & pictures"
+msgstr "Zene & videó & képek"
+
+#: id:1222
+msgid "Music & video & pictures & files"
+msgstr "Zene & videó & képek & fájlok"
+
+#: id:1223
+msgctxt "Auto context with id 1223"
+msgid "Disabled"
+msgstr "Letiltva"
+
+#: id:1226
+msgid "Files & music & video"
+msgstr "Fájlok & zene & videó"
+
+#: id:1227
+msgid "Files & pictures & music"
+msgstr "Fájlok & képek & zene"
+
+#: id:1228
+msgid "Files & pictures & video"
+msgstr "Fájlok & képek & videó"
+
+#: id:1229
+msgid "Music & programs"
+msgstr "Zene & programok"
+
+#: id:1230
+msgid "Video & programs"
+msgstr "Videó & programok"
+
+#: id:1231
+msgid "Pictures & programs"
+msgstr "Képek & programok"
+
+#: id:1232
+msgid "Music & video & pictures & programs"
+msgstr "Zene & videó & képek & programok"
+
+#: id:1233
+msgid "Programs & video & music"
+msgstr "Programok & videó & zene"
+
+#: id:1234
+msgid "Programs & pictures & music"
+msgstr "Programok & képek & zene"
+
+#: id:1235
+msgid "Programs & pictures & video"
+msgstr "Programok & képek & videó"
+
+#: id:1250
+msgid "Auto-detection"
+msgstr "Automatikus felismerés"
+
+#: id:1251
+msgid "Auto-detect system"
+msgstr "Automatikus rendszerfelismerés"
+
+#: id:1252
+msgid "Nickname"
+msgstr "Becenév"
+
+#: id:1254
+msgid "Ask to connect"
+msgstr "Kérdés csatlakozás előtt"
+
+#: id:1255
+msgid "Send FTP user and password"
+msgstr "FTP felhasználónév és jelszó elküldése"
+
+#: id:1256
+msgid "Ping interval"
+msgstr "Ping gyakoriság"
+
+#: id:1257
+msgid "Would you like to connect to the auto-detected system?"
+msgstr "Kapcsolódás az automatikusan felismert rendszerhez?"
+
+#: id:1259
+msgid "Zeroconf"
+msgstr ""
+
+#: id:1260
+msgid "Announce these services to other systems via Zeroconf"
+msgstr "Szolgáltatások hirdetése más rendszerek felé a Zeroconf segítségével"
+
+#: id:1270
+msgid "Allow XBMC to receive AirPlay content"
+msgstr "AirPlay tartalom vételének engedélyezése az XBMC számára"
+
+#: id:1271
+msgid "Device name"
+msgstr "Eszköz neve"
+
+#: id:1272
+msgid "- Use password protection"
+msgstr "- Jelszavas védelem használata"
+
+#: id:1273
+msgid "AirPlay"
+msgstr ""
+
+#: id:1300
+msgid "Custom audio device"
+msgstr "Egyedi hanglejátszó eszköz megadása"
+
+#: id:1301
+msgid "Custom passthrough device"
+msgstr "Egyedi hangtovábbító eszköz megadása"
+
+#: id:1396
+msgid "Drifting"
+msgstr "viharos"
+
+#: id:1397
+msgid "and"
+msgstr "és"
+
+#: id:1398
+msgid "Freezing"
+msgstr "fagyos"
+
+#: id:1399
+msgid "Late"
+msgstr "éjjel"
+
+#: id:1400
+msgid "Isolated"
+msgstr "helyi"
+
+#: id:1401
+msgid "Thundershowers"
+msgstr "záporok"
+
+#: id:1402
+msgid "Thunder"
+msgstr "villámok"
+
+#: id:1403
+msgctxt "Auto context with id 1403"
+msgid "Sun"
+msgstr "napos"
+
+#: id:1404
+msgid "Heavy"
+msgstr "erős"
+
+#: id:1405
+msgid "in"
+msgstr "-"
+
+#: id:1406
+msgid "the"
+msgstr "-"
+
+#: id:1407
+msgid "Vicinity"
+msgstr "környéken"
+
+#: id:1408
+msgid "Ice"
+msgstr "jég"
+
+#: id:1409
+msgid "Crystals"
+msgstr "kristályok"
+
+#: id:1410
+msgid "Calm"
+msgstr "nyugodt"
+
+#: id:1411
+msgid "with"
+msgstr "-val/-vel"
+
+#: id:1412
+msgid "windy"
+msgstr "szeles"
+
+#: id:1413
+msgid "drizzle"
+msgstr "szitáló"
+
+#: id:1414
+msgid "Thunderstorm"
+msgstr "vihar"
+
+#: id:1415
+msgid "Drizzle"
+msgstr "szemerkél"
+
+#: id:1416
+msgid "Foggy"
+msgstr "ködös"
+
+#: id:1417
+msgid "Grains"
+msgstr "szitálás"
+
+#: id:1418
+msgid "T-Storms"
+msgstr "viharok"
+
+#: id:1419
+msgid "T-Showers"
+msgstr "viharos esőzések"
+
+#: id:1420
+msgid "Moderate"
+msgstr "enyhe"
+
+#: id:1421
+msgid "Very High"
+msgstr "nagyon magas"
+
+#: id:1422
+msgid "Windy"
+msgstr "szeles"
+
+#: id:1423
+msgid "Mist"
+msgstr "köd"
+
+#: id:1450
+msgid "Put display to sleep when idle"
+msgstr "Kijelző altatása üresjárat esetén"
+
+#: id:2050
+msgid "Runtime"
+msgstr "Hossz"
+
+#: id:2100
+msgid "Script failed! : %s"
+msgstr "Program hiba: %s"
+
+#: id:2101
+msgid "Newer version needed - See log"
+msgstr "Újabb verzió szükséges - Lásd: napló"
+
+#: id:4501
+msgid "Enable LCD/VFD"
+msgstr "LCD/VFD kijelző engedélyezése"
+
+#: id:10000
+msgid "Home"
+msgstr "Főképernyő"
+
+#: id:10001
+msgctxt "Auto context with id 10001"
+msgid "Programs"
+msgstr "Programok"
+
+#: id:10002
+msgctxt "Auto context with id 10002"
+msgid "Pictures"
+msgstr "Képek"
+
+#: id:10003
+msgctxt "Auto context with id 10003"
+msgid "File manager"
+msgstr "Fájlkezelő"
+
+#: id:10004
+msgctxt "Auto context with id 10004"
+msgid "Settings"
+msgstr "Beállítások"
+
+#: id:10005
+msgctxt "Auto context with id 10005"
+msgid "Music"
+msgstr "Zene"
+
+#: id:10006
+msgctxt "Auto context with id 10006"
+msgid "Videos"
+msgstr "Videók"
+
+#: id:10007
+msgid "System information"
+msgstr "Rendszerinfó"
+
+#: id:10008
+msgid "Settings - General"
+msgstr "Beállítások - Általános"
+
+#: id:10009
+msgid "Settings - Screen"
+msgstr "Beállítások - Képernyő"
+
+#: id:10010
+msgid "Settings - Appearance - GUI Calibration"
+msgstr "Beállítások - Megjelenítés - UI Kalibrálás"
+
+#: id:10011
+msgid "Settings - Videos - Screen Calibration"
+msgstr "Beállítások - Videók - Képernyő Kalibrálás"
+
+#: id:10012
+msgid "Settings - Pictures"
+msgstr "Beállítások - Képek"
+
+#: id:10013
+msgid "Settings - Programs"
+msgstr "Beállítások - Programok"
+
+#: id:10014
+msgid "Settings - Weather"
+msgstr "Beállítások - Időjárás"
+
+#: id:10015
+msgid "Settings - Music"
+msgstr "Beállítások - Zene"
+
+#: id:10016
+msgid "Settings - System"
+msgstr "Beállítások - Rendszer"
+
+#: id:10017
+msgid "Settings - Videos"
+msgstr "Beállítások - Videók"
+
+#: id:10018
+msgid "Settings - Network"
+msgstr "Beállítások - Hálózat"
+
+#: id:10019
+msgid "Settings - Appearance"
+msgstr "Beállítások - Megjelenítés"
+
+#: id:10020
+msgctxt "Auto context with id 10020"
+msgid "Scripts"
+msgstr "Programok"
+
+#: id:10021
+msgid "Web Browser"
+msgstr "Internet böngésző"
+
+#: id:10025
+msgctxt "Auto context with id 10025"
+msgid "Videos"
+msgstr "Videók"
+
+#: id:10028
+msgid "Videos/Playlist"
+msgstr "Videók/lejátszáslista"
+
+#: id:10029
+msgctxt "Auto context with id 10029"
+msgid "Login screen"
+msgstr "Bejelentkezési képernyő"
+
+#: id:10034
+msgid "Settings - Profiles"
+msgstr "Beállítások - Profilok"
+
+#: id:10040
+msgid "Addon browser"
+msgstr "Kiegészítő böngésző"
+
+#: id:10100
+msgid "Yes/No dialog"
+msgstr "Igen/nem párbeszédpanel"
+
+#: id:10101
+msgid "Progress dialog"
+msgstr "Folyamatjelző párbeszédpanel"
+
+#: id:10210
+msgid "Looking for subtitles..."
+msgstr "Feliratok keresése..."
+
+#: id:10211
+msgid "Looking for or caching subtitles..."
+msgstr "Feliratok keresése vagy gyorsítótárazása..."
+
+#: id:10212
+msgid "terminating"
+msgstr "megszakítás"
+
+#: id:10213
+msgid "buffering"
+msgstr "előtöltés"
+
+#: id:10214
+msgid "Opening stream"
+msgstr "Adatfolyam megnyitása"
+
+#: id:10500
+msgid "Music/Playlist"
+msgstr "Zene/Lejátszáslista"
+
+#: id:10501
+msgid "Music/Files"
+msgstr "Zene/Fájlok"
+
+#: id:10502
+msgid "Music/Library"
+msgstr "Zene/Médiatár"
+
+#: id:10503
+msgid "Playlist editor"
+msgstr "Lejátszáslista szerkesztő"
+
+#: id:10504
+msgid "Top 100 songs"
+msgstr "Top 100 dal"
+
+#: id:10505
+msgid "Top 100 albums"
+msgstr "Top 100 album"
+
+#: id:10506
+msgctxt "Auto context with id 10506"
+msgid "Programs"
+msgstr "Programok"
+
+#: id:10507
+msgid "Configuration"
+msgstr "Konfiguráció"
+
+#: id:10508
+msgid "Weather forecast"
+msgstr "Időjárás-előrejelzés"
+
+#: id:10509
+msgid "Network gaming"
+msgstr "Hálózati játék"
+
+#: id:10510
+msgid "Extensions"
+msgstr "Kiterjesztések"
+
+#: id:10511
+msgctxt "Auto context with id 10511"
+msgid "System info"
+msgstr "Rendszerinfó"
+
+#: id:10516
+msgid "Music - Library"
+msgstr "Zene - Médiatár"
+
+#: id:10517
+msgid "Now Playing - Music"
+msgstr "Játszásra jelölt zenék"
+
+#: id:10522
+msgid "Now Playing - Videos"
+msgstr "Játszásra jelölt videók"
+
+#: id:10523
+msgid "Album info"
+msgstr "Albuminfó"
+
+#: id:10524
+msgid "Movie info"
+msgstr "Filminfó"
+
+#: id:12000
+msgid "Select dialog"
+msgstr "Párbeszédpanel választása"
+
+#: id:12001
+msgid "Music/Info"
+msgstr "Zene/Infó"
+
+#: id:12002
+msgid "Dialog OK"
+msgstr "Párbeszédpanel OK"
+
+#: id:12003
+msgid "Videos/Info"
+msgstr "Videók/Infó"
+
+#: id:12004
+msgid "Scripts/Info"
+msgstr "Programok/Infó"
+
+#: id:12005
+msgid "Fullscreen video"
+msgstr "Teljesképernyős videó"
+
+#: id:12006
+msgid "Audio visualization"
+msgstr "Vizualizáció kiválasztása"
+
+#: id:12008
+msgid "File stacking dialog"
+msgstr "Fájl egyesítés"
+
+#: id:12009
+msgid "Rebuild index..."
+msgstr "Index újraépítése..."
+
+#: id:12010
+msgid "Return to music window"
+msgstr "Vissza a Zenékhez"
+
+#: id:12011
+msgid "Return to videos window"
+msgstr "Vissza a Videókhoz"
+
+#: id:12021
+msgid "Start from beginning"
+msgstr "Lejátszás az elejéről"
+
+#: id:12022
+msgid "Resume from %s"
+msgstr "Folytatás innen: %s"
+
+#: id:12310
+msgid "0"
+msgstr "0"
+
+#: id:12311
+msgid "1"
+msgstr "1"
+
+#: id:12312
+msgid "2"
+msgstr "2"
+
+#: id:12313
+msgid "3"
+msgstr "3"
+
+#: id:12314
+msgid "4"
+msgstr "4"
+
+#: id:12315
+msgid "5"
+msgstr "5"
+
+#: id:12316
+msgid "6"
+msgstr "6"
+
+#: id:12317
+msgid "7"
+msgstr "7"
+
+#: id:12318
+msgid "8"
+msgstr "8"
+
+#: id:12319
+msgid "9"
+msgstr "9"
+
+#: id:12320
+msgid "c"
+msgstr "c"
+
+#: id:12321
+msgid "Ok"
+msgstr "Ok"
+
+#: id:12322
+msgid "*"
+msgstr "*"
+
+#: id:12325
+msgid "Locked! Enter code..."
+msgstr "Zárolva! Kód szükséges..."
+
+#: id:12326
+msgid "Enter password"
+msgstr "Jelszó"
+
+#: id:12327
+msgid "Enter master code"
+msgstr "Mesterkód"
+
+#: id:12328
+msgid "Enter unlock code"
+msgstr "Feloldási kód megadása"
+
+#: id:12329
+msgid "or press C to cancel"
+msgstr "ill. nyomj C-t a visszalépéshez"
+
+#: id:12330
+msgid "Enter gamepad button combo and"
+msgstr "Nyomd a gamepad gomb kombinációt és"
+
+#: id:12331
+msgid "press OK, or Back to cancel"
+msgstr "nyomj \"start\"-ot vagy \"vissza\"-t a kilépéshez"
+
+#: id:12332
+msgid "Set lock"
+msgstr "Zárolás"
+
+#: id:12333
+msgid "Unlock"
+msgstr "Feloldás"
+
+#: id:12334
+msgid "Reset lock"
+msgstr "Zárolás újrabeállítása"
+
+#: id:12335
+msgid "Remove lock"
+msgstr "Zárolás törlése"
+
+#: id:12337
+msgid "Numeric password"
+msgstr "Numerikus jelszó"
+
+#: id:12338
+msgid "Gamepad button combo"
+msgstr "Gamepad gombkombináció"
+
+#: id:12339
+msgid "Full-text password"
+msgstr "Szöveges jelszó"
+
+#: id:12340
+msgid "Enter new password"
+msgstr "Új jelszó"
+
+#: id:12341
+msgid "Re-Enter new password"
+msgstr "Jelszó megerősítése"
+
+#: id:12342
+msgid "Incorrect password,"
+msgstr "Érvénytelen jelszó,"
+
+#: id:12343
+msgid "retries left"
+msgstr "lehetőséged maradt"
+
+#: id:12344
+msgid "Passwords entered did not match."
+msgstr "A két jelszó nem egyezik."
+
+#: id:12345
+msgid "Access denied"
+msgstr "Hozzáférés megtagadva"
+
+#: id:12346
+msgid "Password retry limit exceeded."
+msgstr "Túl sok sikertelen próbálkozás."
+
+#: id:12347
+msgid "The system will now shut off."
+msgstr "A rendszer leáll."
+
+#: id:12348
+msgid "Item locked"
+msgstr "Az elem zárolva"
+
+#: id:12353
+msgid "Reactivate lock"
+msgstr "Zárolás újraaktiválása"
+
+#: id:12356
+msgid "Change lock"
+msgstr "Változtatás zárolása"
+
+#: id:12357
+msgid "Source lock"
+msgstr "Források zárolása"
+
+#: id:12358
+msgid "Password entry was blank. Try again."
+msgstr "Érvénytelen jelszó. Próbáld újra."
+
+#: id:12360
+msgid "Master lock"
+msgstr "Mester zárolás"
+
+#: id:12362
+msgid "Shutdown system if Master Lock retries exceeded"
+msgstr "Leállítás, ha a mesterkód próbálkozások száma eléri a"
+
+#: id:12367
+msgid "Master code is not valid"
+msgstr "Érvénytelen mesterkód"
+
+#: id:12368
+msgid "Please enter a valid master code"
+msgstr "Adj meg érvényes mesterkódot"
+
+#: id:12373
+msgid "Settings & file manager"
+msgstr "Beállítások & Fájlkezelő"
+
+#: id:12376
+msgid "Set as default for all movies"
+msgstr "Alapértelmezettként minden filmre"
+
+#: id:12377
+msgid "This will reset any previously saved values"
+msgstr "Minden eddigi beállítás törlése?"
+
+#: id:12378
+msgid "Amount of time to display each image"
+msgstr "Képek megjelenítése:"
+
+#: id:12379
+msgid "Use pan and zoom effects"
+msgstr "Pásztázás és nagyítás (pan&zoom) effektek használata"
+
+#: id:12383
+msgid "12 hour clock"
+msgstr "12 órás számozás"
+
+#: id:12384
+msgid "24 hour clock"
+msgstr "24 órás számozás"
+
+#: id:12385
+msgid "Day/Month"
+msgstr "Nap/Hónap"
+
+#: id:12386
+msgid "Month/Day"
+msgstr "Hónap/Nap"
+
+#: id:12390
+msgid "System uptime"
+msgstr "Rendszer üzemidő"
+
+#: id:12391
+msgid "Minutes"
+msgstr "perc"
+
+#: id:12392
+msgid "Hours"
+msgstr "óra"
+
+#: id:12393
+msgid "Days"
+msgstr "nap"
+
+#: id:12394
+msgid "Total uptime"
+msgstr "Folyamatos üzemidő"
+
+#: id:12395
+msgid "Battery level"
+msgstr "Akkumlátor töltöttsége"
+
+#: id:12600
+msgctxt "Auto context with id 12600"
+msgid "Weather"
+msgstr "Időjárás"
+
+#: id:12900
+msgctxt "Auto context with id 12900"
+msgid "Screensaver"
+msgstr "Képernyőkímélő"
+
+#: id:12901
+msgid "Fullscreen OSD"
+msgstr "Teljes képernyős OSD"
+
+#: id:13000
+msgid "System"
+msgstr "Rendszer"
+
+#: id:13001
+msgid "Immediate HD spindown"
+msgstr "Azonnali merevlemez kikapcsolás"
+
+#: id:13002
+msgid "Video only"
+msgstr "Csak videó"
+
+#: id:13003
+msgid "- Delay"
+msgstr "- Késleltetés"
+
+#: id:13004
+msgid "- Minimum file duration"
+msgstr "- Minimum fájl hossz"
+
+#: id:13005
+msgid "Shutdown"
+msgstr "Leállítás"
+
+#: id:13008
+msgid "Shutdown function"
+msgstr "Alapértelmezett leállítási mód"
+
+#: id:13009
+msgid "Quit"
+msgstr "Kilépés"
+
+#: id:13010
+msgid "Hibernate"
+msgstr "Hibernálás"
+
+#: id:13011
+msgid "Suspend"
+msgstr "Alvó üzemmód"
+
+#: id:13012
+msgid "Exit"
+msgstr "Kilépés"
+
+#: id:13013
+msgid "Reboot"
+msgstr "Újraindítás"
+
+#: id:13014
+msgid "Minimize"
+msgstr "Kicsinyítés"
+
+#: id:13015
+msgid "Power button action"
+msgstr "Be(ki)kapcsoló gomb művelet"
+
+#: id:13016
+msgid "Power off System"
+msgstr "Gép kikapcsolása"
+
+#: id:13020
+msgid "Is another session active, perhaps over ssh?"
+msgstr "Lehet hogy egy másik bejelentkezés aktív (ssh)?"
+
+#: id:13021
+msgid "Mounted removable harddrive"
+msgstr "Külső meghajtó csatlakoztatva"
+
+#: id:13022
+msgid "Unsafe device removal"
+msgstr "Nem biztonságos eltávolítás"
+
+#: id:13023
+msgid "Successfully removed device"
+msgstr "Eszköz sikeresen eltávolítva"
+
+#: id:13024
+msgid "Joystick plugged"
+msgstr "Joystick csatlakoztatva"
+
+#: id:13025
+msgid "Joystick unplugged"
+msgstr "Joystick eltávolítva"
+
+#: id:13050
+msgid "Running low on battery"
+msgstr "Az akkumlátor kezd lemerülni"
+
+#: id:13100
+msgid "Flicker filter"
+msgstr "Villogásszűrő"
+
+#: id:13101
+msgid "Let driver choose (requires restart)"
+msgstr "Automatikus (újraindítás szükséges)"
+
+#: id:13105
+msgid "Vertical blank sync"
+msgstr "Függőleges szinkronizálás"
+
+#: id:13106
+msgctxt "Auto context with id 13106"
+msgid "Disabled"
+msgstr "Letiltva"
+
+#: id:13107
+msgid "Enabled during video playback"
+msgstr "Lejátszáskor"
+
+#: id:13108
+msgctxt "Auto context with id 13108"
+msgid "Always enabled"
+msgstr "Mindig"
+
+#: id:13109
+msgid "Test & apply resolution"
+msgstr "Felbontás tesztelése"
+
+#: id:13110
+msgid "Save resolution?"
+msgstr "Felbontás mentése?"
+
+#: id:13111
+msgid "Would you like to keep this resolution?"
+msgstr "Jelenlegi felbontás megtartása?"
+
+#: id:13112
+msgid "High quality upscaling"
+msgstr "Magas minőségű szoftveres felskálázás"
+
+#: id:13113
+msgctxt "Auto context with id 13113"
+msgid "Disabled"
+msgstr "Letiltva"
+
+#: id:13114
+msgid "Enabled for SD content"
+msgstr "SD tartalom esetén bekapcsolva"
+
+#: id:13115
+msgctxt "Auto context with id 13115"
+msgid "Always enabled"
+msgstr "Mindig bekapcsolva"
+
+#: id:13116
+msgid "Upscaling method"
+msgstr "Felskálázás módja"
+
+#: id:13117
+msgctxt "Auto context with id 13117"
+msgid "Bicubic"
+msgstr "Bicubic"
+
+#: id:13118
+msgid "Lanczos"
+msgstr "Lanczos"
+
+#: id:13119
+msgid "Sinc"
+msgstr "Sinc"
+
+#: id:13120
+msgctxt "Auto context with id 13120"
+msgid "VDPAU"
+msgstr "VDPAU"
+
+#: id:13121
+msgid "VDPAU HQ Upscaling level"
+msgstr "VDPAU HQ felskálázás (csak megfelelő HW esetén)"
+
+#: id:13122
+msgid "VDPAU Studio level color conversion"
+msgstr "VDPAU stúdiószint színkonverzió"
+
+#: id:13130
+msgid "Blank other displays"
+msgstr "A többi megjelenítő sötétítése"
+
+#: id:13131
+msgctxt "Auto context with id 13131"
+msgid "Disabled"
+msgstr "Letiltva"
+
+#: id:13132
+msgid "Blank displays"
+msgstr "Megjelenítők sötétítése"
+
+#: id:13140
+msgid "Active connections detected!"
+msgstr "Aktív kapcsolatok észlelhetők!"
+
+#: id:13141
+msgid "If you proceed, you might not be able to control XBMC"
+msgstr "Továbblépés esetén az XBMC esetleg nem lesz irányítható."
+
+#: id:13142
+msgid "any longer. Are you sure you want to stop the Event server?"
+msgstr "Eseménykiszolgáló leállítása?"
+
+#: id:13144
+msgid "Change Apple Remote mode?"
+msgstr "Apple távirányítómód váltása?"
+
+#: id:13145
+msgid "If you are currently using the Apple Remote to control"
+msgstr "Ha jelenleg az Apple távirányító van használatban,"
+
+#: id:13146
+msgid "XBMC, changing this setting might affect your ability"
+msgstr "ennek a beállításnak a használata a távirányítás"
+
+#: id:13147
+msgid "to continue controlling it. Do you want to proceed?"
+msgstr "lehetőségének elvesztését jelentheti. Folytatod?"
+
+#: id:13159
+msgid "Subnet mask"
+msgstr "Alhálózati maszk"
+
+#: id:13160
+msgid "Gateway"
+msgstr "Átjáró"
+
+#: id:13161
+msgid "Primary DNS"
+msgstr "Elsődleges DNS"
+
+#: id:13162
+msgid "Initialize failed"
+msgstr "A beállítás meghiúsult"
+
+#: id:13170
+msgctxt "Auto context with id 13170"
+msgid "Never"
+msgstr "Soha"
+
+#: id:13171
+msgid "Immediately"
+msgstr "Azonnal"
+
+#: id:13172
+msgid "After %i secs"
+msgstr "%i másodperc után"
+
+#: id:13173
+msgid "HDD install date:"
+msgstr "HDD telepítés dátuma:"
+
+#: id:13174
+msgid "HDD power cycle count:"
+msgstr "HDD indítások száma:"
+
+#: id:13200
+msgid "Profiles"
+msgstr "Profilok"
+
+#: id:13201
+msgid "Delete profile '%s'?"
+msgstr "Törlöd ezt a profilt: '%s'?"
+
+#: id:13204
+msgid "Last loaded profile:"
+msgstr "Utoljára betöltött profil:"
+
+#: id:13205
+msgid "Unknown"
+msgstr "Ismeretlen"
+
+#: id:13206
+msgid "Overwrite"
+msgstr "Felülírás"
+
+#: id:13208
+msgid "Alarm clock"
+msgstr "Ébresztőóra"
+
+#: id:13209
+msgid "Alarm clock interval (in minutes)"
+msgstr "Jelzés intervalluma (hány perc múlva)"
+
+#: id:13210
+msgid "Started, alarm in %im"
+msgstr "Elindítva, ébresztés %i perc múlva"
+
+#: id:13211
+msgid "Alarm!"
+msgstr "Ébresztés!"
+
+#: id:13212
+msgid "Canceled with %im%is left"
+msgstr "Megszakítva, %i perc %i mp volt még hátra"
+
+#: id:13213
+msgid "%2.0fm"
+msgstr "%2.0fperc"
+
+#: id:13214
+msgid "%2.0fs"
+msgstr "%2.0fmp"
+
+#: id:13249
+msgid "Search for subtitles in RARs"
+msgstr "Feliratok keresése RAR fájlokban"
+
+#: id:13250
+msgid "Browse for subtitle..."
+msgstr "Felirat keresése..."
+
+#: id:13251
+msgid "Move item"
+msgstr "Elem átmozgatása"
+
+#: id:13252
+msgid "Move item here"
+msgstr "Elem átmozgatása ide"
+
+#: id:13253
+msgid "Cancel move"
+msgstr "Átmozgatás megszakítása"
+
+#: id:13270
+msgid "Hardware:"
+msgstr "Hardver:"
+
+#: id:13271
+msgid "CPU Usage:"
+msgstr "Terhelés:"
+
+#: id:13274
+msgid "Connected, but no DNS is available."
+msgstr "Csatlakoztatva, de nincs elérhető DNS"
+
+#: id:13275
+msgid "Hard Disk"
+msgstr "Merevlemez"
+
+#: id:13276
+msgid "DVD-ROM"
+msgstr "DVD-ROM"
+
+#: id:13277
+msgctxt "Auto context with id 13277"
+msgid "Storage"
+msgstr "Háttértárak"
+
+#: id:13278
+msgctxt "Auto context with id 13278"
+msgid "Default"
+msgstr "Alapértelmezett"
+
+#: id:13279
+msgctxt "Auto context with id 13279"
+msgid "Network"
+msgstr "Hálózat"
+
+#: id:13280
+msgctxt "Auto context with id 13280"
+msgid "Video"
+msgstr "Videó"
+
+#: id:13281
+msgid "Hardware"
+msgstr "Hardver"
+
+#: id:13283
+msgid "Operating system:"
+msgstr "Operációs rendszer:"
+
+#: id:13284
+msgid "CPU speed:"
+msgstr "CPU sebesség:"
+
+#: id:13286
+msgid "Video encoder:"
+msgstr "Videó kódoló:"
+
+#: id:13287
+msgid "Screen resolution:"
+msgstr "Képernyő felbontása:"
+
+#: id:13292
+msgid "A/V cable:"
+msgstr "Hang/Kép kábel:"
+
+#: id:13294
+msgid "DVD region:"
+msgstr "DVD régió:"
+
+#: id:13295
+msgid "Internet:"
+msgstr "Internet:"
+
+#: id:13296
+msgctxt "Auto context with id 13296"
+msgid "Connected"
+msgstr "Csatlakoztatva"
+
+#: id:13297
+msgid "Not connected. Check network settings."
+msgstr "Nincs csatlakozás. Hálózati beállítások ellenőrzése szükséges."
+
+#: id:13299
+msgid "Target temperature"
+msgstr "Célhőmérséklet"
+
+#: id:13300
+msgid "Fan speed"
+msgstr "Ventilátorsebesség"
+
+#: id:13301
+msgid "Auto temperature control"
+msgstr "Automata hőmérséklet-vezérlés"
+
+#: id:13302
+msgid "Fan speed override"
+msgstr "Ventilátorsebesség felülbírálása"
+
+#: id:13303
+msgid "- Fonts"
+msgstr "- Betűtípus"
+
+#: id:13304
+msgid "Enable flipping bi-directional strings"
+msgstr "Kétirányú szövegek megfordítása"
+
+#: id:13305
+msgid "Show RSS news feeds"
+msgstr "RSS hírek bekapcsolása"
+
+#: id:13306
+msgid "Show parent folder items"
+msgstr "Szülőmappaelemek megjelenítése"
+
+#: id:13307
+msgid "Track naming template"
+msgstr "Zeneszám elnevezés-sablon"
+
+#: id:13308
+msgid "Do you wish to reboot your system"
+msgstr "Teljes rendszer újraindítása"
+
+#: id:13309
+msgid "instead of just XBMC?"
+msgstr "csak az XBMC helyett?"
+
+#: id:13310
+msgid "Zoom effect"
+msgstr "Nagyítás hatás"
+
+#: id:13311
+msgid "Float effect"
+msgstr "Úszó hatás"
+
+#: id:13312
+msgid "Black bar reduction"
+msgstr "Fekete sáv csökkentés"
+
+#: id:13313
+msgid "Restart"
+msgstr "Újraindítás"
+
+#: id:13314
+msgid "Crossfade between songs"
+msgstr "Zeneszámok egymásbakeverése"
+
+#: id:13315
+msgid "Regenerate thumbnails"
+msgstr "Bélyegképek újragenerálása"
+
+#: id:13316
+msgid "Recursive thumbnails"
+msgstr "Rekurzív bélyegképek"
+
+#: id:13317
+msgid "View slideshow"
+msgstr "Diavetítés"
+
+#: id:13318
+msgid "Recursive slideshow"
+msgstr "Rekurzív diavetítés"
+
+#: id:13319
+msgid "Randomize"
+msgstr "Véletlenszerű"
+
+#: id:13320
+msgid "Stereo"
+msgstr "Sztereó"
+
+#: id:13321
+msgid "Left only"
+msgstr "Csak a bal"
+
+#: id:13322
+msgid "Right only"
+msgstr "Csak a jobb"
+
+#: id:13323
+msgid "Enable karaoke support"
+msgstr "Karaoke-támogatás engedélyezése"
+
+#: id:13324
+msgid "Background transparency"
+msgstr "Háttér átlátszósága"
+
+#: id:13325
+msgid "Foreground transparency"
+msgstr "Előtér átlátszósága"
+
+#: id:13326
+msgid "A/V delay"
+msgstr "Hang/Kép késleltetés"
+
+#: id:13327
+msgid "Karaoke"
+msgstr "Karaoke"
+
+#: id:13328
+msgid "%s not found"
+msgstr "%s nem található"
+
+#: id:13329
+msgid "Error opening %s"
+msgstr "Hiba a(z) %s megnyitása közben"
+
+#: id:13330
+msgid "Unable to load %s"
+msgstr "Hiba a(z) %s betöltése közben"
+
+#: id:13331
+msgid "Error: Out of memory"
+msgstr "Hiba: Kevés a memória."
+
+#: id:13332
+msgid "Move up"
+msgstr "Mozgatás fel"
+
+#: id:13333
+msgid "Move down"
+msgstr "Mozgatás le"
+
+#: id:13334
+msgid "Edit label"
+msgstr "Cím szerkesztése"
+
+#: id:13335
+msgid "Make default"
+msgstr "Alapértelmezetté tesz"
+
+#: id:13336
+msgid "Remove button"
+msgstr "Gomb eltávolítása"
+
+#: id:13340
+msgid "Leave as is"
+msgstr "Maradjon az eredeti"
+
+#: id:13341
+msgid "Green"
+msgstr "Zöld"
+
+#: id:13342
+msgid "Orange"
+msgstr "Narancs"
+
+#: id:13343
+msgid "Red"
+msgstr "Vörös"
+
+#: id:13344
+msgid "Cycle"
+msgstr "Váltakozó"
+
+#: id:13345
+msgid "Switch LED off on playback"
+msgstr "LED kikapcsolása lejátszás alatt"
+
+#: id:13346
+msgctxt "Auto context with id 13346"
+msgid "Movie information"
+msgstr "Film információ"
+
+#: id:13347
+msgid "Queue item"
+msgstr "Lejátszási sorba tesz"
+
+#: id:13348
+msgid "Search IMDb..."
+msgstr "Keresés az IMDB-n..."
+
+#: id:13349
+msgid "Scan for new content"
+msgstr "Új tartalom keresése"
+
+#: id:13350
+msgid "Now playing..."
+msgstr "Lejátszási sor..."
+
+#: id:13351
+msgctxt "Auto context with id 13351"
+msgid "Album information"
+msgstr "Album információ"
+
+#: id:13352
+msgid "Scan item to library"
+msgstr "Hozzáadás médiatárhoz"
+
+#: id:13353
+msgid "Stop scanning"
+msgstr "Átvizsgálás leállítása"
+
+#: id:13354
+msgctxt "Auto context with id 13354"
+msgid "Render method"
+msgstr "Renderelés módja"
+
+#: id:13355
+msgid "Low quality pixel shader"
+msgstr "Alacsony minőségű pixel-árnyékoló"
+
+#: id:13356
+msgid "Hardware overlays"
+msgstr "Hardveres képréteg átfedések"
+
+#: id:13357
+msgid "High quality pixel shader"
+msgstr "Magas minőségű pixel-árnyékoló"
+
+#: id:13358
+msgid "Play item"
+msgstr "Elem lejátszása"
+
+#: id:13359
+msgid "Set artist thumb"
+msgstr "Előadó bélyegkép"
+
+#: id:13360
+msgid "Automatically generate thumbnails"
+msgstr "Automatikus bélyegkép generálás"
+
+#: id:13361
+msgid "Enable voice"
+msgstr "Hang engedélyezése"
+
+#: id:13375
+msgid "Enable device"
+msgstr "Eszköz engedélyezése"
+
+#: id:13376
+msgid "Volume"
+msgstr "Hangerő"
+
+#: id:13377
+msgid "Default view mode"
+msgstr "Alapértelmezett nézet"
+
+#: id:13378
+msgid "Default brightness"
+msgstr "Alapértelmezett fényerő"
+
+#: id:13379
+msgid "Default contrast"
+msgstr "Alapértelmezett kontraszt"
+
+#: id:13380
+msgid "Default gamma"
+msgstr "Alapértelmezett gamma"
+
+#: id:13381
+msgid "Resume video"
+msgstr "Videó folytatása"
+
+#: id:13382
+msgid "Voice mask - Port 1"
+msgstr "Hangmaszk - 1. port"
+
+#: id:13383
+msgid "Voice mask - Port 2"
+msgstr "Hangmaszk - 2. port"
+
+#: id:13384
+msgid "Voice mask - Port 3"
+msgstr "Hangmaszk - 3. port"
+
+#: id:13385
+msgid "Voice mask - Port 4"
+msgstr "Hangmaszk - 4. port"
+
+#: id:13386
+msgid "Use time based seeking"
+msgstr "Idő-alapú pörgetés"
+
+#: id:13387
+msgid "Track naming template - right"
+msgstr "Zeneszám formátum-sablon (jobb oldalt megjelenő oszlopra)"
+
+#: id:13388
+msgid "Preset"
+msgstr "Előbeállítások"
+
+#: id:13389
+msgid "There are no presets available\nfor this visualization"
+msgstr "Nincs előbeállítás\nehhez a vizualizációhoz"
+
+#: id:13390
+msgid "There are no settings available\nfor this visualization"
+msgstr "Nincs altípusa\nennek a vizualizációnak"
+
+#: id:13391
+msgid "Eject/Load"
+msgstr "Tálcát nyit/zár"
+
+#: id:13392
+msgid "Use visualization if playing audio"
+msgstr "Vizualizáció használata zenelejátszás esetén"
+
+#: id:13393
+msgid "Calculate size"
+msgstr "Méret kiszámolása"
+
+#: id:13394
+msgid "Calculating folder size"
+msgstr "Mappa méretének kiszámolása"
+
+#: id:13395
+msgid "Video settings"
+msgstr "Kép beállítások"
+
+#: id:13396
+msgid "Audio and subtitle settings"
+msgstr "Hang és felirat beállítások"
+
+#: id:13397
+msgid "Enable subtitles"
+msgstr "Feliratok bekapcsolása"
+
+#: id:13398
+msgctxt "Auto context with id 13398"
+msgid "Shortcuts"
+msgstr "Parancsikonok"
+
+#: id:13399
+msgid "Ignore articles when sorting (e.g. \"the\")"
+msgstr "Névelő figyelmen kívül hagyása névsorba rendezésnél"
+
+#: id:13400
+msgid "Crossfade between songs on the same album"
+msgstr "Egymásbakeverés ugyanazon albumon belüli számoknál"
+
+#: id:13401
+msgid "Browse for %s"
+msgstr "%s keresése"
+
+#: id:13402
+msgid "Show track position"
+msgstr "Szám pozíció kijelzése"
+
+#: id:13403
+msgid "Clear default"
+msgstr "Alapértelmezés törlése"
+
+#: id:13404
+msgid "Resume"
+msgstr "Folytatás"
+
+#: id:13405
+msgid "Get thumb"
+msgstr "Bélyegkép"
+
+#: id:13406
+msgid "Picture information"
+msgstr "Képinformáció"
+
+#: id:13407
+msgid "%s presets"
+msgstr "%s előbeállítás"
+
+#: id:13408
+msgid "(IMDb user rating)"
+msgstr "(IMDb nézői értékelés)"
+
+#: id:13409
+msgid "Top 250"
+msgstr "Top 250"
+
+#: id:13410
+msgid "Tune in on Last.fm"
+msgstr "Keresés a Last.fm-en"
+
+#: id:13411
+msgid "Minimum fan speed"
+msgstr "Minimum ventilátor-sebesség"
+
+#: id:13412
+msgid "Play from here"
+msgstr "Lejátszás innen"
+
+#: id:13413
+msgid "Downloading"
+msgstr "Letöltés folyamatban"
+
+#: id:13414
+msgid "Include artists who appear only on compilations"
+msgstr "Válogatáslemezen lévők szerepeltetése az előadólistán"
+
+#: id:13415
+msgctxt "Auto context with id 13415"
+msgid "Render method"
+msgstr "Renderelés módja"
+
+#: id:13416
+msgid "Auto detect"
+msgstr "Automatikus"
+
+#: id:13417
+msgid "Basic shaders (ARB)"
+msgstr "Alap árnyékolók (ARB)"
+
+#: id:13418
+msgid "Advanced shaders (GLSL)"
+msgstr "Fejlett árnyékolók (GLSL)"
+
+#: id:13419
+msgid "Software"
+msgstr "Szoftveres"
+
+#: id:13420
+msgid "Remove safely"
+msgstr "Biztonságos eltávolítás"
+
+#: id:13421
+msgctxt "Auto context with id 13421"
+msgid "VDPAU"
+msgstr "VDPAU"
+
+#: id:13422
+msgid "Start slideshow here"
+msgstr "Diavetítés indítása innen"
+
+#: id:13423
+msgid "Remember for this path"
+msgstr "Megjegyzés ennél a helynél"
+
+#: id:13424
+msgid "Use pixel buffer objects"
+msgstr "Pixel buffer objektumok használata"
+
+#: id:13425
+msgid "Allow hardware acceleration (VDPAU)"
+msgstr "Hardveres gyorsítás engedélyezése (VDPAU)"
+
+#: id:13426
+msgid "Allow hardware acceleration (VAAPI)"
+msgstr "Hardveres gyorsítás engedélyezése (VAAPI)"
+
+#: id:13427
+msgid "Allow hardware acceleration (DXVA2)"
+msgstr "Hardveres gyorsítás engedélyezése (DXVA2)"
+
+#: id:13428
+msgid "Allow hardware acceleration (CrystalHD)"
+msgstr "Hardveres gyorsítás engedélyezése (CrystalHD)"
+
+#: id:13429
+msgid "Allow hardware acceleration (VDADecoder)"
+msgstr "Hardveres gyorsítás engedélyezése (VDADecoder)"
+
+#: id:13430
+msgid "Allow hardware acceleration (OpenMax)"
+msgstr "Hardveres gyorsítás engedélyezése (OpenMax)"
+
+#: id:13431
+msgid "Pixel Shaders"
+msgstr "Pixel árnyékolók (PS)"
+
+#: id:13432
+msgid "Allow hardware acceleration (VideoToolbox)"
+msgstr "Hardveres gyorsítás engedélyezése (VideoToolbox)"
+
+#: id:13500
+msgid "A/V sync method"
+msgstr "Hang/Kép szinkron ehhez"
+
+#: id:13501
+msgid "Audio clock"
+msgstr "Hang-órajel (hang érintetlen)"
+
+#: id:13502
+msgid "Video clock (Drop/Dupe audio)"
+msgstr "Kép-órajel (hang duplázás/kiejtés)"
+
+#: id:13503
+msgid "Video clock (Resample audio)"
+msgstr "Kép-órajel (hang sebesség váltás)"
+
+#: id:13504
+msgid "Maximum resample amount (%)"
+msgstr "Maximális sebességváltási mérték (%)"
+
+#: id:13505
+msgid "Resample quality"
+msgstr "Újramintavételezés minősége"
+
+#: id:13506
+msgid "Low(fast)"
+msgstr "Alacsony(gyors)"
+
+#: id:13507
+msgctxt "Auto context with id 13507"
+msgid "Medium"
+msgstr "Közepes"
+
+#: id:13508
+msgctxt "Auto context with id 13508"
+msgid "High"
+msgstr "Magas"
+
+#: id:13509
+msgid "Really high(slow!)"
+msgstr "Nagyon magas(lassú!)"
+
+#: id:13510
+msgid "Sync playback to display"
+msgstr "Lejátszás szinkronizálása a megjelenítőhöz"
+
+#: id:13550
+msgid "Pause during refresh rate change"
+msgstr "Videó megállítása a frekvenciaváltás alatt"
+
+#: id:13551
+msgctxt "Auto context with id 13551"
+msgid "Off"
+msgstr "Kikapcsolva"
+
+#: id:13552
+msgid "%.1f Second"
+msgstr "%.1f másodperc"
+
+#: id:13553
+msgid "%.1f Seconds"
+msgstr "%.1f másodperc"
+
+#: id:13600
+msgid "Apple remote"
+msgstr "Apple távirányító"
+
+#: id:13602
+msgid "Allow start of XBMC using the remote"
+msgstr "XBMC indítható legyen távirányítóval"
+
+#: id:13603
+msgid "Sequence delay time"
+msgstr "Szekvencia késleltetési idő"
+
+#: id:13610
+msgctxt "Auto context with id 13610"
+msgid "Disabled"
+msgstr "Letiltva"
+
+#: id:13611
+msgctxt "Auto context with id 13611"
+msgid "Standard"
+msgstr "Standard"
+
+#: id:13612
+msgid "Universal Remote"
+msgstr "Univerzális távirányító"
+
+#: id:13613
+msgid "Multi Remote (Harmony)"
+msgstr "Multi távirányító (Harmony)"
+
+#: id:13620
+msgid "Apple Remote Error"
+msgstr "Apple távirányító hiba"
+
+#: id:13621
+msgid "Apple Remote support could be enabled."
+msgstr "Apple távirányító támogatás engedélyezhető."
+
+#: id:14000
+msgid "Stack"
+msgstr "Egyesítés: be"
+
+#: id:14001
+msgid "Unstack"
+msgstr "Egyesítés: ki"
+
+#: id:14003
+msgid "Downloading playlist file..."
+msgstr "Lejátszáslista letöltése..."
+
+#: id:14004
+msgid "Downloading streams list..."
+msgstr "Adatfolyamlista letöltése..."
+
+#: id:14005
+msgid "Parsing streams list..."
+msgstr "Adatfolyamlista előkészítése..."
+
+#: id:14006
+msgid "Downloading streams list failed"
+msgstr "Adatfolyamlista letöltése sikertelen"
+
+#: id:14007
+msgid "Downloading playlist file failed"
+msgstr "Hiba a lejátszáslista letöltése közben"
+
+#: id:14009
+msgid "Games directory"
+msgstr "Játék könyvtár"
+
+#: id:14010
+msgid "Auto switch to thumbs based on"
+msgstr "Automatikus váltás bélyegképekre a következő alapján"
+
+#: id:14011
+msgid "Enable auto switching to thumbs view"
+msgstr "Automatikus váltás bélyegképek nézetre"
+
+#: id:14012
+msgid "- Use large icons"
+msgstr "- Nagy ikonok használata"
+
+#: id:14013
+msgid "- Switch based on"
+msgstr "- Váltás a következő alapján"
+
+#: id:14014
+msgid "- Percentage"
+msgstr "- Százalék"
+
+#: id:14015
+msgid "No files and at least one thumb"
+msgstr "Nincs fájl, de minimum egy bélyegkép"
+
+#: id:14016
+msgid "At least one file and thumb"
+msgstr "Minimum egy fájl és bélyegkép"
+
+#: id:14017
+msgid "Percentage of thumbs"
+msgstr "Bélyegképek mérete"
+
+#: id:14018
+msgid "View options"
+msgstr "Nézet beállítások"
+
+#: id:14019
+msgid "Change area code 1"
+msgstr "1. Régió beállítása"
+
+#: id:14020
+msgid "Change area code 2"
+msgstr "2. Régió beállítása"
+
+#: id:14021
+msgid "Change area code 3"
+msgstr "3. Régió beállítása"
+
+#: id:14022
+msgctxt "Auto context with id 14022"
+msgid "Library"
+msgstr "Médiatár"
+
+#: id:14023
+msgid "No TV"
+msgstr "Nincs TV"
+
+#: id:14024
+msgid "Enter the nearest large town"
+msgstr "Legközelebbi nagyváros"
+
+#: id:14025
+msgid "Video/Audio/DVD cache - Harddisk"
+msgstr "Videó/Hang/DVD gyorsítótár - Merevlemez"
+
+#: id:14026
+msgid "Video cache - DVD-ROM"
+msgstr "Videó gyorsítótár - DVD-ROM"
+
+#: id:14027
+msgctxt "Auto context with id 14027"
+msgid "- Local Network"
+msgstr "- Helyi Hálózat"
+
+#: id:14028
+msgctxt "Auto context with id 14028"
+msgid "- Internet"
+msgstr "- Internet"
+
+#: id:14030
+msgid "Audio cache - DVD-ROM"
+msgstr "Hang gyorsítótár - DVD-ROM"
+
+#: id:14031
+msgctxt "Auto context with id 14031"
+msgid "- Local Network"
+msgstr "- Helyi Hálózat"
+
+#: id:14032
+msgctxt "Auto context with id 14032"
+msgid "- Internet"
+msgstr "- Internet"
+
+#: id:14034
+msgid "DVD cache - DVD-ROM"
+msgstr "DVD gyorsítótár - DVD-ROM"
+
+#: id:14035
+msgctxt "Auto context with id 14035"
+msgid "- Local Network"
+msgstr "- Helyi Hálózat"
+
+#: id:14036
+msgctxt "Auto context with id 14036"
+msgid "Services"
+msgstr "Szolgáltatások"
+
+#: id:14038
+msgid "Network settings changed"
+msgstr "A hálózati beállítások megváltoztatva"
+
+#: id:14039
+msgid "XBMC requires to restart to change your"
+msgstr "Az XBMC-t újra kell indítani, a hálózati beállítások"
+
+#: id:14040
+msgid "network setup. Would you like to restart now?"
+msgstr "megváltoztatásához. Újraindítás most?"
+
+#: id:14041
+msgid "Internet connection bandwidth limitation"
+msgstr "Internetkapcsolat sávszélesség-korlátozás"
+
+#: id:14043
+msgid "- Shutdown while playing"
+msgstr "- Leállítás lejátszás közben"
+
+#: id:14044
+msgid "%i min"
+msgstr "%i perc"
+
+#: id:14045
+msgid "%i sec"
+msgstr "%i mp."
+
+#: id:14046
+msgid "%i ms"
+msgstr "%i ms."
+
+#: id:14047
+msgid "%i %%"
+msgstr "%i %%"
+
+#: id:14048
+msgid "%i kbps"
+msgstr "%i kb/s"
+
+#: id:14049
+msgid "%i kb"
+msgstr "%i kb"
+
+#: id:14050
+msgid "%i.0 dB"
+msgstr "%i.0 dB"
+
+#: id:14051
+msgid "Time format"
+msgstr "Időformátum(12/24)"
+
+#: id:14052
+msgid "Date format"
+msgstr "Dátumformátum(N-H/H-N)"
+
+#: id:14053
+msgid "GUI filters"
+msgstr "GUI szűrők"
+
+#: id:14055
+msgid "Use background scanning"
+msgstr "Átvizsgálás a háttérben"
+
+#: id:14056
+msgid "Stop scan"
+msgstr "Átvizsgálás leállítása"
+
+#: id:14057
+msgid "Not possible while scanning for media info"
+msgstr "Médiainfó átvizsgálása közben nem lehetséges"
+
+#: id:14058
+msgid "Film grain effect"
+msgstr "Filmszemcsézet (grain) hatás"
+
+#: id:14059
+msgid "Search for thumbnails on remote shares"
+msgstr "Bélyegképek keresése távoli megosztásokon"
+
+#: id:14060
+msgid "Unknown type cache - Internet"
+msgstr "Ismeretlen típusú gyorsítótár - Internet"
+
+#: id:14061
+msgctxt "Auto context with id 14061"
+msgid "Auto"
+msgstr "Auto"
+
+#: id:14062
+msgid "Enter username for"
+msgstr "Felhasználónév a következőhöz:"
+
+#: id:14063
+msgid "Date & time"
+msgstr "Dátum és Idő"
+
+#: id:14064
+msgid "Set date"
+msgstr "Dátum beállítása"
+
+#: id:14065
+msgid "Set time"
+msgstr "Idő beállítása"
+
+#: id:14066
+msgid "Enter the time in 24 hour HH:MM format"
+msgstr "Idő beállítása (ÓÓ:PP formátumban)"
+
+#: id:14067
+msgid "Enter the date in DD/MM/YYYY format"
+msgstr "Dátum beállítása (NN/HH/ÉÉÉÉ formátumban)"
+
+#: id:14068
+msgid "Enter the IP address"
+msgstr "IP cím beállítása"
+
+#: id:14069
+msgid "Apply these settings now?"
+msgstr "Változások érvényesítése?"
+
+#: id:14070
+msgid "Apply changes now"
+msgstr "Változások azonnali érvényesítése"
+
+#: id:14071
+msgid "Allow file renaming and deletion"
+msgstr "Fájltörlés és átnevezés engedélyezése"
+
+#: id:14074
+msgid "Set timezone"
+msgstr "Időzóna beállítása"
+
+#: id:14075
+msgid "Use daylight saving time"
+msgstr "Automatikus téli/nyári időszámítás"
+
+#: id:14076
+msgid "Add to favourites"
+msgstr "Hozzáadás kedvencekhez"
+
+#: id:14077
+msgid "Remove from favourites"
+msgstr "Eltávolítás kedvencekből"
+
+#: id:14078
+msgctxt "Auto context with id 14078"
+msgid "- Colours"
+msgstr "- Színek"
+
+#: id:14079
+msgid "Timezone country"
+msgstr "Időzóna (ország)"
+
+#: id:14080
+msgid "Timezone"
+msgstr "Időzóna"
+
+#: id:14081
+msgid "File lists"
+msgstr "Fájllisták"
+
+#: id:14082
+msgid "Show EXIF picture information"
+msgstr "EXIF képinformációk megjelenítése"
+
+#: id:14083
+msgid "Use a fullscreen window rather than true fullscreen"
+msgstr "Maximált ablak használata, igazi teljesképernyős-mód helyett"
+
+#: id:14084
+msgid "Queue songs on selection"
+msgstr "Zeneszám kiválasztására hozzáadás a játszáslistához"
+
+#: id:14086
+msgid "Playback"
+msgstr "Lejátszás"
+
+#: id:14087
+msgid "DVDs"
+msgstr "DVD lemezek"
+
+#: id:14088
+msgid "Play DVDs automatically"
+msgstr "DVD lemezek automatikus lejátszása"
+
+#: id:14089
+msgid "Font to use for text subtitles"
+msgstr "Feliratok betűtípusa"
+
+#: id:14090
+msgid "International"
+msgstr "Nyelv"
+
+#: id:14091
+msgid "Character set"
+msgstr "Karakterkészlet"
+
+#: id:14092
+msgid "Debugging"
+msgstr "Hibakeresés"
+
+#: id:14093
+msgid "Security"
+msgstr "Biztonság"
+
+#: id:14094
+msgid "Input devices"
+msgstr "Beviteli-eszközök"
+
+#: id:14095
+msgid "Power saving"
+msgstr "Energiakezelés"
+
+#: id:14096
+msgid "Rip"
+msgstr ""
+
+#: id:14097
+msgid "Audio CD Insert Action"
+msgstr ""
+
+#: id:14098
+msgctxt "Auto context with id 14098"
+msgid "Play"
+msgstr ""
+
+#: id:14099
+msgid "Eject disc when CD ripping is complete"
+msgstr ""
+
+#: id:15015
+msgctxt "Auto context with id 15015"
+msgid "Remove"
+msgstr "Törlés"
+
+#: id:15016
+msgid "Games"
+msgstr "Játékok"
+
+#: id:15019
+msgid "Add"
+msgstr "Hozzáadás"
+
+#: id:15052
+msgid "Password"
+msgstr "Jelszó"
+
+#: id:15100
+msgctxt "Auto context with id 15100"
+msgid "Library"
+msgstr "Médiatár"
+
+#: id:15101
+msgid "Database"
+msgstr "Adatbázis"
+
+#: id:15102
+msgid "* All albums"
+msgstr "* Minden album"
+
+#: id:15103
+msgid "* All artists"
+msgstr "* Minden előadó"
+
+#: id:15104
+msgid "* All songs"
+msgstr "* Minden zeneszám"
+
+#: id:15105
+msgid "* All genres"
+msgstr "* Minden műfaj"
+
+#: id:15107
+msgid "Buffering..."
+msgstr "Előtöltés..."
+
+#: id:15108
+msgid "Navigation sounds"
+msgstr "Navigációs hangok"
+
+#: id:15109
+msgid "Skin default"
+msgstr "Felszín alapértelmezése"
+
+#: id:15111
+msgid "- Theme"
+msgstr "- Téma"
+
+#: id:15112
+msgid "Default theme"
+msgstr "Alapértelmezett téma"
+
+#: id:15200
+msgid "Last.fm"
+msgstr "Last.fm"
+
+#: id:15201
+msgid "Submit songs to Last.fm"
+msgstr "Zenehallgatási információk elküldése az Last.fm-nek"
+
+#: id:15202
+msgid "Last.fm username"
+msgstr "Last.fm felhasználónév"
+
+#: id:15203
+msgid "Last.fm password"
+msgstr "Last.fm Jelszó"
+
+#: id:15204
+msgid "Unable to handshake: sleeping..."
+msgstr "Kapcsolódás sikertelen..."
+
+#: id:15205
+msgid "Please update XBMC"
+msgstr "XBMC frissítése szükséges"
+
+#: id:15206
+msgid "Bad authorization: Check username and password"
+msgstr "Sikertelen azonosítás: Ellenőrizd a belépőnevet és a jelszót"
+
+#: id:15207
+msgctxt "Auto context with id 15207"
+msgid "Connected"
+msgstr "Csatlakoztatva"
+
+#: id:15208
+msgid "Not connected"
+msgstr "Nincs csatlakozás"
+
+#: id:15209
+msgid "Submit interval %i"
+msgstr "Küldési gyakoriság %i"
+
+#: id:15210
+msgid "Cached %i songs"
+msgstr "%i dal gyorsítótárazva"
+
+#: id:15211
+msgid "Submitting..."
+msgstr "Küldés..."
+
+#: id:15212
+msgid "Submitting in %i secs"
+msgstr "Küldés %i mp. múlva"
+
+#: id:15213
+msgid "Play using..."
+msgstr "Egyéb lejátszóval..."
+
+#: id:15214
+msgid "Use smoothed A/V synchronization"
+msgstr "Finomított Hang/Kép szinkronizáció"
+
+#: id:15215
+msgid "Hide file names in thumbs view"
+msgstr "Fájlnevek elrejtése bélyegkép nézetben"
+
+#: id:15216
+msgid "Play in party mode"
+msgstr "Lejátszás partymódban"
+
+#: id:15217
+msgid "Submit songs to Libre.fm"
+msgstr "Zenehallgatási információk elküldése a Libre.fm-nek"
+
+#: id:15218
+msgid "Libre.fm username"
+msgstr "Libre.fm felhasználónév"
+
+#: id:15219
+msgid "Libre.fm password"
+msgstr "Libre.fm jelszó"
+
+#: id:15220
+msgid "Libre.fm"
+msgstr "Libre.fm"
+
+#: id:15221
+msgid "Song submission"
+msgstr "Zeneajánló"
+
+#: id:15250
+msgid "Submit Last.fm radio to Last.fm"
+msgstr "Last.fm rádió küldése a Last.fm-nek"
+
+#: id:15251
+msgid "Connecting to Last.fm..."
+msgstr "Csatlakozás a Last.fm-hez..."
+
+#: id:15252
+msgid "Selecting station..."
+msgstr "Állomás kiválasztása..."
+
+#: id:15253
+msgid "Search similar artists..."
+msgstr "Előadók keresése..."
+
+#: id:15254
+msgid "Search similar tags..."
+msgstr "Címkék keresése..."
+
+#: id:15255
+msgid "Your profile (%name%)"
+msgstr "Profilod (%name%)"
+
+#: id:15256
+msgid "Overall top tags"
+msgstr "Legnépszerűbb címkék"
+
+#: id:15257
+msgid "Top artists for tag %name%"
+msgstr "Legjobb előadók a %name% címkével"
+
+#: id:15258
+msgid "Top albums for tag %name%"
+msgstr "Legjobb albumok a %name% címkével"
+
+#: id:15259
+msgid "Top tracks for tag %name%"
+msgstr "Legjobb számok a %name% címkével"
+
+#: id:15260
+msgid "Listen to tag %name% Last.fm radio"
+msgstr "%name% címkéjű Last.fm rádió hallgatása"
+
+#: id:15261
+msgid "Similar artists as %name%"
+msgstr "Hasonló előadók ehhez: %name%"
+
+#: id:15262
+msgid "Top %name% albums"
+msgstr "A legnépszerűbb %name% albumok"
+
+#: id:15263
+msgid "Top %name% tracks"
+msgstr "A legnépszerűbb %name% számok"
+
+#: id:15264
+msgid "Top %name% tags"
+msgstr "A legnépszerűbb %name% címkék"
+
+#: id:15265
+msgid "Biggest fans of %name%"
+msgstr "A legnagyobb %name% rajongók"
+
+#: id:15266
+msgid "Listen to %name% fans Last.fm radio"
+msgstr "%name% rajongók Last.fm rádió hallgatása"
+
+#: id:15267
+msgid "Listen to %name% similar artists Last.fm radio"
+msgstr "%name% hasonló előadók Last.fm rádió hallgatása"
+
+#: id:15268
+msgid "Top artists for user %name%"
+msgstr "%name% kedvenc előadói"
+
+#: id:15269
+msgid "Top albums for user %name%"
+msgstr "%name% kedvenc albumai"
+
+#: id:15270
+msgid "Top tracks for user %name%"
+msgstr "%name% kedvenc számai"
+
+#: id:15271
+msgid "Friends of user %name%"
+msgstr "%name% barátai"
+
+#: id:15272
+msgid "Neighbours of user %name%"
+msgstr "%name% zenei \"szomszédai\""
+
+#: id:15273
+msgid "Weekly artist chart for %name%"
+msgstr "%name% heti előadó toplistája"
+
+#: id:15274
+msgid "Weekly album chart for %name%"
+msgstr "%name% heti album toplistája"
+
+#: id:15275
+msgid "Weekly track chart for %name%"
+msgstr "%name% heti zeneszám toplistája"
+
+#: id:15276
+msgid "Listen to %name%'s neighbours Last.fm radio"
+msgstr "%name% zenei \"szomszédai\" Last.fm rádió hallgatása"
+
+#: id:15277
+msgid "Listen to %name%'s personal Last.fm radio"
+msgstr "%name% saját Last.fm rádiójának hallgatása"
+
+#: id:15278
+msgid "Listen to %name%'s mix Last.fm radio"
+msgstr "%name% saját Last.fm mix radiójának hallgatása"
+
+#: id:15279
+msgid "Retrieving list from Last.fm..."
+msgstr "Lista lekérése a last.fm-ről..."
+
+#: id:15280
+msgid "Can't retrieve list from Last.fm..."
+msgstr "Lista nem lekérhető a last.fm-ről..."
+
+#: id:15281
+msgid "Enter an artist name to find related ones"
+msgstr "Előadó magdása hasonlók kereséséhez"
+
+#: id:15282
+msgid "Enter a tag name to find similar ones"
+msgstr "Címke megadása a hasonlók kereséséhez"
+
+#: id:15283
+msgid "Tracks recently listened by %name%"
+msgstr "%name% mostanában hallgatott zenéi"
+
+#: id:15284
+msgid "Listen to %name%'s recommendations Last.fm radio"
+msgstr "%name% ajánlásai Last.fm rádió hallgatása"
+
+#: id:15285
+msgid "Top tags for user %name%"
+msgstr "%name% top címkéi"
+
+#: id:15287
+msgid "Do you want to add the current track to your loved tracks?"
+msgstr "Jelenlegi szám hozzáadása a kedvencekhez?"
+
+#: id:15288
+msgid "Do you want to ban the current track?"
+msgstr "Jelenlegi szám letiltása?"
+
+#: id:15289
+msgid "Added to your loved tracks: '%s'."
+msgstr "'%s' hozzáadva a kedvenc számokhoz."
+
+#: id:15290
+msgid "Could not add '%s' to your loved tracks."
+msgstr "'%s' nem adható hozzá a kedvenc számokhoz."
+
+#: id:15291
+msgid "Banned: '%s'."
+msgstr "Letiltva: '%s'."
+
+#: id:15292
+msgid "Could not ban '%s'."
+msgstr "'%s' letiltása sikertelen."
+
+#: id:15293
+msgid "Tracks recently loved by %name%"
+msgstr "%name% jelenlegi kedvenc számai"
+
+#: id:15294
+msgid "Tracks recently banned by %name%"
+msgstr "%name% által mostanában letiltott számok"
+
+#: id:15295
+msgid "Remove from loved tracks"
+msgstr "Ki a kedvencekből"
+
+#: id:15296
+msgid "Un-ban"
+msgstr "Újraengedélyezés"
+
+#: id:15297
+msgid "Do you want to remove this track from your loved tracks?"
+msgstr "Eltávolítás a kedvenc számok közül?"
+
+#: id:15298
+msgid "Do you want to un-ban this track?"
+msgstr "Zeneszám újraengedélyezése?"
+
+#: id:15300
+msgid "Path not found or invalid"
+msgstr "Az elérési út érvénytelen, vagy nem található"
+
+#: id:15301
+msgid "Could not connect to network server"
+msgstr "Sikertelen csatlakozás a kiszolgálóhoz"
+
+#: id:15302
+msgid "No servers found"
+msgstr "Nincs elérhető kiszolgáló"
+
+#: id:15303
+msgid "Workgroup not found"
+msgstr "A munkacsoport nem elérhető"
+
+#: id:15310
+msgid "Opening multi-path source"
+msgstr "Több elérésiúttal rendelkező forrás megnyitása"
+
+#: id:15311
+msgid "Path:"
+msgstr "Elérési út:"
+
+#: id:16000
+msgctxt "Auto context with id 16000"
+msgid "General"
+msgstr "Általános"
+
+#: id:16002
+msgid "Internet lookup"
+msgstr "Keresés Interneten"
+
+#: id:16003
+msgid "Player"
+msgstr "Lejátszó"
+
+#: id:16004
+msgid "Play media from disc"
+msgstr "Média lejátszása lemezről"
+
+#: id:16008
+msgid "Enter new title"
+msgstr "Új cím"
+
+#: id:16009
+msgid "Enter the movie name"
+msgstr "Film címe"
+
+#: id:16010
+msgid "Enter the profile name"
+msgstr "Profil neve"
+
+#: id:16011
+msgid "Enter the album name"
+msgstr "Album neve"
+
+#: id:16012
+msgid "Enter the playlist name"
+msgstr "Lejátszáslista neve"
+
+#: id:16013
+msgid "Enter new filename"
+msgstr "Új fájl neve"
+
+#: id:16014
+msgid "Enter folder name"
+msgstr "Mappa neve"
+
+#: id:16015
+msgid "Enter directory"
+msgstr "Könyvtár"
+
+#: id:16016
+msgid "Available options: %A, %T, %N, %B, %D, %G, %Y, %F, %S"
+msgstr "Elérhető beállítások: %A, %T, %N, %B, %D, %G, %Y, %F, %S"
+
+#: id:16017
+msgid "Enter search string"
+msgstr "Keresőszó"
+
+#: id:16018
+msgctxt "Auto context with id 16018"
+msgid "None"
+msgstr "Nincs"
+
+#: id:16019
+msgid "Auto select"
+msgstr "Automatikus kiválasztás"
+
+#: id:16020
+msgid "De-interlace"
+msgstr "Teljes képkockasebességgel"
+
+#: id:16021
+msgid "Bob"
+msgstr "Bob"
+
+#: id:16022
+msgid "Bob (inverted)"
+msgstr "Bob (fordított)"
+
+#: id:16024
+msgid "Canceling..."
+msgstr "Megszakítás..."
+
+#: id:16025
+msgid "Enter the artist name"
+msgstr "Előadó neve"
+
+#: id:16026
+msgid "Playback failed"
+msgstr "Lejátszás sikertelen"
+
+#: id:16027
+msgid "One or more items failed to play."
+msgstr "Egy vagy több elem lejátszása sikertelen."
+
+#: id:16028
+msgid "Enter value"
+msgstr "Érték"
+
+#: id:16029
+msgid "Check the log file for details."
+msgstr "Részletek a napló fájlban."
+
+#: id:16030
+msgid "Party mode aborted."
+msgstr "Partymód megszakítva."
+
+#: id:16031
+msgid "No matching songs in the library."
+msgstr "Zeneszám nem található a médiatárban."
+
+#: id:16032
+msgid "Could not initialize database."
+msgstr "Sikertelen adatbázis előkészítés."
+
+#: id:16033
+msgid "Could not open database."
+msgstr "Adatbázis nem nyitható meg."
+
+#: id:16034
+msgid "Could not get songs from database."
+msgstr "Nincs elérhető zeneszám az adatbázisban."
+
+#: id:16035
+msgid "Party mode playlist"
+msgstr "Partymód lejátszáslista"
+
+#: id:16036
+msgid "De-interlace (Half)"
+msgstr "Fél képkockasebességgel (Half)"
+
+#: id:16037
+msgid "Deinterlace video"
+msgstr "Videó váltottsorosság mentesítése (Deinterlace)"
+
+#: id:16038
+msgid "Deinterlace method"
+msgstr "A mentesítés módja"
+
+#: id:16039
+msgctxt "Auto context with id 16039"
+msgid "Off"
+msgstr "Ki"
+
+#: id:16040
+msgctxt "Auto context with id 16040"
+msgid "Auto"
+msgstr "Auto"
+
+#: id:16041
+msgid "On"
+msgstr "Be"
+
+#: id:16100
+msgid "All Videos"
+msgstr "Minden videó"
+
+#: id:16101
+msgid "Unwatched"
+msgstr "Nem látott"
+
+#: id:16102
+msgid "Watched"
+msgstr "Megnézett"
+
+#: id:16103
+msgid "Mark as watched"
+msgstr "Megnézettként megjelöl"
+
+#: id:16104
+msgid "Mark as unwatched"
+msgstr "Nem látottként megjelöl"
+
+#: id:16105
+msgid "Edit title"
+msgstr "Cím szerkesztése"
+
+#: id:16200
+msgid "Operation was aborted"
+msgstr "Művelet megszakadt"
+
+#: id:16201
+msgid "Copy failed"
+msgstr "Másolási hiba"
+
+#: id:16202
+msgid "Failed to copy at least one file"
+msgstr "Nem minden fájlt sikerült átmásolni"
+
+#: id:16203
+msgid "Move failed"
+msgstr "Átmozgatás nem sikerült"
+
+#: id:16204
+msgid "Failed to move at least one file"
+msgstr "Nem minden fájlt sikerült átmozgatni"
+
+#: id:16205
+msgid "Delete failed"
+msgstr "Törlés nem sikerült"
+
+#: id:16206
+msgid "Failed to delete at least one file"
+msgstr "Nem minden fájlt sikerült törölni"
+
+#: id:16300
+msgid "Video scaling method"
+msgstr "Képskálázás módja"
+
+#: id:16301
+msgid "Nearest neighbour"
+msgstr "Legközelebbi szomszéd"
+
+#: id:16302
+msgid "Bilinear"
+msgstr "Bilinear"
+
+#: id:16303
+msgctxt "Auto context with id 16303"
+msgid "Bicubic"
+msgstr "Bicubic"
+
+#: id:16304
+msgid "Lanczos2"
+msgstr "Lanczos2"
+
+#: id:16305
+msgid "Lanczos3"
+msgstr "Lanczos3 komplex"
+
+#: id:16306
+msgid "Sinc8"
+msgstr "Sinc8"
+
+#: id:16307
+msgid "Bicubic (software)"
+msgstr "Bicubic (software)"
+
+#: id:16308
+msgid "Lanczos (software)"
+msgstr "Lanczos (software)"
+
+#: id:16309
+msgid "Sinc (software)"
+msgstr "Sinc (software)"
+
+#: id:16310
+msgid "Temporal"
+msgstr "Temporal"
+
+#: id:16311
+msgid "Temporal/Spatial"
+msgstr "Temporal/Spatial"
+
+#: id:16312
+msgid "(VDPAU)Noise Reduction"
+msgstr "(VDPAU)Zajszűrés"
+
+#: id:16313
+msgid "(VDPAU)Sharpness"
+msgstr "(VDPAU)Képélesség"
+
+#: id:16314
+msgid "Inverse Telecine"
+msgstr "Inverse Telecine"
+
+#: id:16315
+msgid "Lanczos3 optimized"
+msgstr "Lanczos3 gyors"
+
+#: id:16316
+msgctxt "Auto context with id 16316"
+msgid "Auto"
+msgstr "Auto"
+
+#: id:16317
+msgid "Temporal (Half)"
+msgstr "Temporal (fél)"
+
+#: id:16318
+msgid "Temporal/Spatial (Half)"
+msgstr "Temporal/Spatial (fél)"
+
+#: id:16319
+msgid "DXVA"
+msgstr "DXVA"
+
+#: id:16320
+msgid "DXVA Bob"
+msgstr "DXVA Bob"
+
+#: id:16321
+msgid "DXVA Best"
+msgstr "DXVA Legjobb"
+
+#: id:16322
+msgid "Spline36"
+msgstr "Spline36"
+
+#: id:16323
+msgid "Spline36 optimized"
+msgstr "Spline36 optimalizált"
+
+#: id:16324
+msgid "Software Blend"
+msgstr "Software Blend"
+
+#: id:16400
+msgid "Post-processing"
+msgstr "Videó minőségjavítás (post processing)"
+
+#: id:17500
+msgid "Display sleep timeout"
+msgstr "Alvó üzemmódig hátralévő idő kijelzése"
+
+#: id:19000
+msgid "Switch to channel"
+msgstr "Csatornára váltás"
+
+#: id:20000
+msgid "Saved music folder"
+msgstr "Bemásolt (rip-elt) zene mappája"
+
+#: id:20001
+msgid "Use external DVD player"
+msgstr "Külső DVD-lejátszó használata"
+
+#: id:20002
+msgid "External DVD player"
+msgstr "Külső DVD-lejátszó"
+
+#: id:20003
+msgid "Trainers folder"
+msgstr "Bemutatók (Trailerek) mappája"
+
+#: id:20004
+msgid "Screenshot folder"
+msgstr "Képernyőmentések mappája"
+
+#: id:20006
+msgid "Playlists folder"
+msgstr "Lejátszáslisták mappája"
+
+#: id:20007
+msgid "Recordings"
+msgstr "Felvételek"
+
+#: id:20008
+msgid "Screenshots"
+msgstr "Képernyőmentések"
+
+#: id:20009
+msgid "Use XBMC"
+msgstr "XBMC használata"
+
+#: id:20011
+msgid "Music playlists"
+msgstr "Zenei lejátszáslista"
+
+#: id:20012
+msgid "Video playlists"
+msgstr "Videó lejátszáslista"
+
+#: id:20013
+msgid "Do you wish to launch the game?"
+msgstr "Játék futtatása?"
+
+#: id:20014
+msgid "Sort by: Playlist"
+msgstr "Rendezés: Lista"
+
+#: id:20015
+msgid "Remote thumb"
+msgstr "Letölthető bélyegkép"
+
+#: id:20016
+msgid "Current thumb"
+msgstr "Jelenlegi bélyegkép"
+
+#: id:20017
+msgid "Local thumb"
+msgstr "Helyi bélyegkép"
+
+#: id:20018
+msgid "No thumb"
+msgstr "Nincs bélyegkép"
+
+#: id:20019
+msgid "Choose thumbnail"
+msgstr "Bélyegkép választása"
+
+#: id:20023
+msgid "Conflict"
+msgstr "Ütközés"
+
+#: id:20024
+msgid "Scan new"
+msgstr "Új keresése"
+
+#: id:20025
+msgid "Scan all"
+msgstr "Mindent átvizsgál"
+
+#: id:20026
+msgid "Region"
+msgstr "Régió"
+
+#: id:20037
+msgid "Summary"
+msgstr "Rövid infó"
+
+#: id:20038
+msgid "Lock music window"
+msgstr "Zene menü zárolása"
+
+#: id:20039
+msgid "Lock videos window"
+msgstr "Videó menü zárolása"
+
+#: id:20040
+msgid "Lock pictures window"
+msgstr "Képek menü zárolása"
+
+#: id:20041
+msgid "Lock programs & scripts windows"
+msgstr "Programok menü zárolása"
+
+#: id:20042
+msgid "Lock file manager"
+msgstr "Fájlkezelő zárolása"
+
+#: id:20043
+msgid "Lock settings"
+msgstr "Beállítások zárolása"
+
+#: id:20044
+msgid "Start fresh"
+msgstr "Friss adatokkal"
+
+#: id:20045
+msgid "Enter master mode"
+msgstr "Belépés mester-módba"
+
+#: id:20046
+msgid "Leave master mode"
+msgstr "Kilépés mester-módból"
+
+#: id:20047
+msgid "Create profile '%s'?"
+msgstr "A(z) '%s' profil létrehozása?"
+
+#: id:20048
+msgid "Start with fresh settings"
+msgstr "Létrehozás friss beállításokkal"
+
+#: id:20049
+msgid "Best available"
+msgstr "Az elérhető legjobb"
+
+#: id:20050
+msgid "Auto-switch between 16x9 and 4x3"
+msgstr "Automatikus váltás 16:9 és 4:3 között"
+
+#: id:20051
+msgid "Treat stacked files as single file"
+msgstr "Többrészes fájlok egy fájlként kezelése"
+
+#: id:20052
+msgid "Caution"
+msgstr "Figyelmeztetés"
+
+#: id:20053
+msgid "Left master mode"
+msgstr "Kilépés mester-módból"
+
+#: id:20054
+msgid "Entered master mode"
+msgstr "Belépés mester-módba"
+
+#: id:20055
+msgid "Allmusic.com thumb"
+msgstr "Allmusic.com bélyegkép"
+
+#: id:20057
+msgid "Remove thumbnail"
+msgstr "Bélyegkép eltávolítása"
+
+#: id:20058
+msgid "Add profile..."
+msgstr "Új profil..."
+
+#: id:20059
+msgid "Query info for all albums"
+msgstr "Minden album lekérdezése"
+
+#: id:20060
+msgctxt "Auto context with id 20060"
+msgid "Media info"
+msgstr "Médiainformáció"
+
+#: id:20061
+msgctxt "Auto context with id 20061"
+msgid "Separate"
+msgstr "Saját"
+
+#: id:20062
+msgid "Shares with default"
+msgstr "Megosztott"
+
+#: id:20063
+msgid "Shares with default (read only)"
+msgstr "Megosztott (csak olvasva)"
+
+#: id:20064
+msgid "Copy default"
+msgstr "Másolás"
+
+#: id:20065
+msgid "Profile picture"
+msgstr "Profilkép"
+
+#: id:20066
+msgid "Lock preferences"
+msgstr "Tulajdonságok zárolása"
+
+#: id:20067
+msgid "Edit profile"
+msgstr "Profil módosítás"
+
+#: id:20068
+msgid "Profile lock"
+msgstr "Profil zárolás"
+
+#: id:20069
+msgid "Could not create folder"
+msgstr "Mappa nem hozható létre"
+
+#: id:20070
+msgid "Profile directory"
+msgstr "Profilmappa"
+
+#: id:20071
+msgid "Start with fresh media sources"
+msgstr "Létrehozás új médiaforrásokkal"
+
+#: id:20072
+msgid "Make sure the selected folder is writable"
+msgstr "Győződjön meg, hogy a kiválasztott mappa írható"
+
+#: id:20073
+msgid "and that the new folder name is valid"
+msgstr "és az új mappa neve megfelelő"
+
+#: id:20074
+msgid "MPAA rating"
+msgstr "MPAA"
+
+#: id:20075
+msgid "Enter master lock code"
+msgstr "Mesterkód"
+
+#: id:20076
+msgid "Ask for master lock code on startup"
+msgstr "Mesterkód bekérése induláskor"
+
+#: id:20077
+msgid "Skin settings"
+msgstr "Felszín beállítások"
+
+#: id:20078
+msgid "- no link set -"
+msgstr "- nincs beállított hivatkozás -"
+
+#: id:20079
+msgid "Enable animations"
+msgstr "Animációk engedélyezése"
+
+#: id:20080
+msgid "Disable RSS during music"
+msgstr "RSS tiltása zene közben"
+
+#: id:20081
+msgid "Enable shortcut buttons"
+msgstr "Parancsikon gombok engedélyezése"
+
+#: id:20082
+msgid "Show programs in main menu"
+msgstr "\"Programok\" megjelenítése a főmenüben"
+
+#: id:20083
+msgid "Show music info"
+msgstr "Zeneinformáció megjelenítése"
+
+#: id:20084
+msgid "Show weather info"
+msgstr "Időjárás információ megjelenítése"
+
+#: id:20085
+msgid "Show system info"
+msgstr "Rendszerinformáció megjelenítése"
+
+#: id:20086
+msgid "Show available disc space C: E: F:"
+msgstr "C, E, F lemezek szabad területének megjelenítése"
+
+#: id:20087
+msgid "Show available disc space E: F: G:"
+msgstr "E, F, G lemezek szabad területének megjelenítése"
+
+#: id:20088
+msgid "Weather info"
+msgstr "Időjárás"
+
+#: id:20089
+msgid "Drive space free"
+msgstr "Szabad lemezterület"
+
+#: id:20090
+msgid "Enter the name of an existing share"
+msgstr "Egy létező megosztás nevének megadása"
+
+#: id:20091
+msgid "Lock code"
+msgstr "Zárolási kód"
+
+#: id:20092
+msgid "Load profile"
+msgstr "Profil betöltése"
+
+#: id:20093
+msgid "Profile name"
+msgstr "Profil neve"
+
+#: id:20094
+msgctxt "Auto context with id 20094"
+msgid "Media sources"
+msgstr "Médiaforrások"
+
+#: id:20095
+msgid "Enter profile lock code"
+msgstr "Adja meg a profil zárolási kódját"
+
+#: id:20096
+msgctxt "Auto context with id 20096"
+msgid "Login screen"
+msgstr "Belépőablak"
+
+#: id:20097
+msgid "Fetching album info"
+msgstr "Albuminformáció lekérése"
+
+#: id:20098
+msgid "Fetching info for album"
+msgstr "Információlekérés az albumról"
+
+#: id:20099
+msgid "Can't rip CD or track while playing from CD"
+msgstr "Lejátszás közben nem lehet bemásolni a lemezt"
+
+#: id:20100
+msgid "Master lock code and settings"
+msgstr "Mesterkód és beállításai"
+
+#: id:20101
+msgid "Entering master lock code always enables master mode"
+msgstr "A Mesterkód megadása után Mester-módban marad"
+
+#: id:20102
+msgid "or copy from default?"
+msgstr "vagy a megosztottak másolása?"
+
+#: id:20103
+msgid "Save changes to profile?"
+msgstr "Profil változások mentése?"
+
+#: id:20104
+msgid "Old settings found."
+msgstr "Korábbi beállítások találhatók."
+
+#: id:20105
+msgid "Do you want to use them?"
+msgstr "Használni kívánja ezeket?"
+
+#: id:20106
+msgid "Old media sources found."
+msgstr "Korábbi médiaforrások találhatók."
+
+#: id:20107
+msgid "Separate (locked)"
+msgstr "Saját (zárolt)"
+
+#: id:20108
+msgid "Root"
+msgstr "Gyökér"
+
+#: id:20109
+msgid "- Zoom"
+msgstr "- Nagyítás"
+
+#: id:20110
+msgid "UPnP settings"
+msgstr "UPnP beállítások"
+
+#: id:20111
+msgid "Autostart UPnP client"
+msgstr "UPnP kliens automatikus indítása"
+
+#: id:20112
+msgid "Last login: %s"
+msgstr "Utoljára belépett: %s"
+
+#: id:20113
+msgid "Never logged on"
+msgstr "Sosem lépett be"
+
+#: id:20114
+msgid "Profile %i / %i"
+msgstr "Profil i% / i%"
+
+#: id:20115
+msgid "User login / Select a profile"
+msgstr "Belépés / Válasszon profilt"
+
+#: id:20116
+msgid "Use lock on login screen"
+msgstr "Zárolás a bejelentkező képernyőn"
+
+#: id:20117
+msgid "Invalid lock code."
+msgstr "Érvénytelen zárolási kód."
+
+#: id:20118
+msgid "This requires the master lock to be set."
+msgstr "Ehhez a mesterkód beállítása szükséges."
+
+#: id:20119
+msgid "Would you like to set it now?"
+msgstr "Kívánja most beállítani?"
+
+#: id:20120
+msgid "Loading program information"
+msgstr "Program-infó betöltése"
+
+#: id:20121
+msgid "Party on!"
+msgstr "Party indul!"
+
+#: id:20122
+msgid "True"
+msgstr "Igaz"
+
+#: id:20123
+msgid "Mixing drinks"
+msgstr "Italok mixelése"
+
+#: id:20124
+msgid "Filling glasses"
+msgstr "Poharak megtöltése"
+
+#: id:20125
+msgid "Logged on as"
+msgstr "Belépve mint"
+
+#: id:20126
+msgid "Log off"
+msgstr "Kilépés"
+
+#: id:20128
+msgid "Go to root"
+msgstr "Gyökérbe"
+
+#: id:20129
+msgid "Weave"
+msgstr "Összefonás"
+
+#: id:20130
+msgid "Weave (inverted)"
+msgstr "Összefonás (Inverz)"
+
+#: id:20131
+msgid "Blend"
+msgstr "Kever"
+
+#: id:20132
+msgid "Restart video"
+msgstr "Videó újraindítása"
+
+#: id:20133
+msgid "Edit network location"
+msgstr "Hálózati hely módosítása"
+
+#: id:20134
+msgid "Remove network location"
+msgstr "Hálózati hely törlése"
+
+#: id:20135
+msgid "Do you want to scan the folder?"
+msgstr "Mappa átvizsgálása?"
+
+#: id:20136
+msgid "Memory unit"
+msgstr "Memóriakártya"
+
+#: id:20137
+msgid "Memory unit mounted"
+msgstr "Memóriakártya felcsatolva"
+
+#: id:20138
+msgid "Unable to mount memory unit"
+msgstr "Memóriakártya felcsatolása sikertelen"
+
+#: id:20139
+msgid "In port %i, slot %i"
+msgstr "Port %i, csatlakozó %i"
+
+#: id:20140
+msgid "Lock screensaver"
+msgstr "Képernyőkímélő zárolása"
+
+#: id:20141
+msgid "Set"
+msgstr "Beállítva"
+
+#: id:20142
+msgctxt "Auto context with id 20142"
+msgid "Username"
+msgstr "Felhasználónév"
+
+#: id:20143
+msgid "Enter password for"
+msgstr "Jelszó megadása"
+
+#: id:20144
+msgid "Shutdown timer"
+msgstr "Időzített leállítás"
+
+#: id:20145
+msgid "Shutdown interval (in minutes)"
+msgstr "Leállítás ideje (percben)"
+
+#: id:20146
+msgid "Started, shutdown in %im"
+msgstr "Leállítás %i perc után"
+
+#: id:20147
+msgid "Shutdown in 30 minutes"
+msgstr "Leállítás 30 perc után"
+
+#: id:20148
+msgid "Shutdown in 60 minutes"
+msgstr "Leállítás 60 perc után"
+
+#: id:20149
+msgid "Shutdown in 120 minutes"
+msgstr "Leállítás 120 perc után"
+
+#: id:20150
+msgid "Custom shutdown timer"
+msgstr "Egyedi időzítés"
+
+#: id:20151
+msgid "Cancel shutdown timer"
+msgstr "Időzített leállítás megszakítása"
+
+#: id:20152
+msgid "Lock preferences for %s"
+msgstr "Tulajdonságok zárolása %s számára"
+
+#: id:20153
+msgid "Browse..."
+msgstr "Tallózás..."
+
+#: id:20154
+msgid "Summary information"
+msgstr "Alapinformációk"
+
+#: id:20155
+msgid "Storage information"
+msgstr "Tároló információk"
+
+#: id:20156
+msgid "Hard disk information"
+msgstr "HDD információk"
+
+#: id:20157
+msgid "DVD-ROM information"
+msgstr "DVD-ROM információk"
+
+#: id:20158
+msgid "Network information"
+msgstr "Hálózat információk"
+
+#: id:20159
+msgid "Video information"
+msgstr "Videó információk"
+
+#: id:20160
+msgid "Hardware information"
+msgstr "Hardver információk"
+
+#: id:20161
+msgid "Total"
+msgstr "Teljes"
+
+#: id:20162
+msgid "Used"
+msgstr "Használatban"
+
+#: id:20163
+msgid "of"
+msgstr "per"
+
+#: id:20164
+msgid "Locking not supported"
+msgstr "Zárolás nem támogatott"
+
+#: id:20165
+msgid "Not locked"
+msgstr "Nincs zárolva"
+
+#: id:20166
+msgid "Locked"
+msgstr "Zárolva"
+
+#: id:20167
+msgid "Frozen"
+msgstr "Fagyasztva"
+
+#: id:20168
+msgid "Requires reset"
+msgstr "Újraindítás szükséges"
+
+#: id:20169
+msgid "Week"
+msgstr "Hét"
+
+#: id:20170
+msgid "Line"
+msgstr "Sor"
+
+#: id:20171
+msgid "Windows network (SMB)"
+msgstr "Windows hálózat (SMB)"
+
+#: id:20172
+msgid "XBMSP server"
+msgstr "XBSMP kiszolgáló"
+
+#: id:20173
+msgctxt "Auto context with id 20173"
+msgid "FTP server"
+msgstr "FTP kiszolgáló"
+
+#: id:20174
+msgid "iTunes music share (DAAP)"
+msgstr "iTunes zenei megosztás (DAAP)"
+
+#: id:20175
+msgid "UPnP server"
+msgstr "UPnP kiszolgáló"
+
+#: id:20176
+msgid "Show video info"
+msgstr "Videóinformáció megjelenítése"
+
+#: id:20177
+msgid "Done"
+msgstr "Rendben"
+
+#: id:20178
+msgid "Shift"
+msgstr "Shift"
+
+#: id:20179
+msgid "Caps Lock"
+msgstr "Caps Lock"
+
+#: id:20180
+msgid "Symbols"
+msgstr "Szimbólum"
+
+#: id:20181
+msgid "Backspace"
+msgstr "Törlés"
+
+#: id:20182
+msgid "Space"
+msgstr "Szóköz"
+
+#: id:20183
+msgid "Reload skin"
+msgstr "Felhasználói felület újraindítása"
+
+#: id:20184
+msgid "Rotate pictures using EXIF information"
+msgstr "Forgatás EXIF információ alapján"
+
+#: id:20185
+msgid "Use poster view styles for TV shows"
+msgstr "Poszter nézet használata sorozatoknál"
+
+#: id:20186
+msgid "Please wait"
+msgstr "Kérem várjon"
+
+#: id:20187
+msgid "UPnP"
+msgstr ""
+
+#: id:20189
+msgid "Enable auto scrolling for plot & review"
+msgstr "Automatikus sorgörgetés a filmtartalom megjelenítésekor"
+
+#: id:20190
+msgctxt "Auto context with id 20190"
+msgid "Custom"
+msgstr "Saját"
+
+#: id:20191
+msgid "Enable debug logging"
+msgstr "Naplózás engedélyezése"
+
+#: id:20192
+msgid "Download additional information during updates"
+msgstr "Médiaadatok frissítésekor kiegészítő információk letöltése"
+
+#: id:20193
+msgid "Default service for album information"
+msgstr "Alapértelmezett leolvasó az album információkhoz"
+
+#: id:20194
+msgid "Default service for artist information"
+msgstr "Alapértelmezett leolvasó az előadó információkhoz"
+
+#: id:20195
+msgid "Change scraper"
+msgstr "Leolvasó váltása"
+
+#: id:20196
+msgid "Export music library"
+msgstr "Zenetár exportálása"
+
+#: id:20197
+msgid "Import music library"
+msgstr "Zenetár importálása"
+
+#: id:20198
+msgid "No artist found!"
+msgstr "Előadó nem található!"
+
+#: id:20199
+msgid "Downloading artist info failed"
+msgstr "Előadóinformáció letöltése sikertelen"
+
+#: id:20250
+msgid "Party on! (videos)"
+msgstr "Party indul! (videók)"
+
+#: id:20251
+msgid "Mixing drinks (videos)"
+msgstr "Italok mixelése (videók)"
+
+#: id:20252
+msgid "Filling glasses (videos)"
+msgstr "poharak megtöltése (videók)"
+
+#: id:20253
+msgid "WebDAV server (HTTP)"
+msgstr "WebDAV kiszolgáló (HTTP)"
+
+#: id:20254
+msgid "WebDAV server (HTTPS)"
+msgstr "WebDAV kiszolgáló (HTTPS)"
+
+#: id:20255
+msgid "First logon, edit your profile"
+msgstr "Első bejelentkezés, profilod szerkesztése"
+
+#: id:20256
+msgid "HTS Tvheadend client"
+msgstr "HTS Tvheadend TV kliens"
+
+#: id:20257
+msgid "VDR Streamdev client"
+msgstr "VDR Streamdev TV kliens"
+
+#: id:20258
+msgid "MythTV client"
+msgstr "MythTV kliens"
+
+#: id:20259
+msgid "Network Filesystem (NFS)"
+msgstr "Hálózati fájlrendszer (NFS)"
+
+#: id:20260
+msgid "Secure Shell (SSH/SFTP)"
+msgstr "Biztonsági héj (SSH/SFTP)"
+
+#: id:20261
+msgid "Apple Filing Protocol (AFP)"
+msgstr "Apple fájlrendszer (AFP)"
+
+#: id:20300
+msgid "Web server directory (HTTP)"
+msgstr "Webkiszolgáló könyvtár (HTTP)"
+
+#: id:20301
+msgid "Web server directory (HTTPS)"
+msgstr "Webkiszolgáló könyvtár (HTTPS)"
+
+#: id:20302
+msgid "Unable to write to folder:"
+msgstr "Mentés a következő mappába sikertelen:"
+
+#: id:20303
+msgid "Do you want to skip and proceed?"
+msgstr "Kihagyod és továbblépsz?"
+
+#: id:20304
+msgid "RSS Feed"
+msgstr "RSS forrás"
+
+#: id:20307
+msgid "Secondary DNS"
+msgstr "Másodlagos DNS"
+
+#: id:20308
+msgid "DHCP server:"
+msgstr "DHCP kiszolgáló:"
+
+#: id:20309
+msgid "Make new folder"
+msgstr "Új mappa létrehozása"
+
+#: id:20310
+msgid "Dim LCD on playback"
+msgstr "LCD halványítás lejátszás közben"
+
+#: id:20311
+msgid "Unknown or onboard (protected)"
+msgstr "Ismeretlen vagy alaplapi (védett)"
+
+#: id:20312
+msgid "Dim LCD on paused"
+msgstr "LCD halványítás szünet közben"
+
+#: id:20314
+msgid "Videos - Library"
+msgstr "Videók - Médiatár"
+
+#: id:20316
+msgid "Sort by: ID"
+msgstr "ID szerint"
+
+#: id:20324
+msgid "Play part..."
+msgstr "Rész lejátszása..."
+
+#: id:20325
+msgid "Calibration reset"
+msgstr "Kalibráció visszaállítása"
+
+#: id:20326
+msgid "This will reset the calibration values for %s"
+msgstr "Kalibrációs értékek törlése %s számára"
+
+#: id:20327
+msgid "to it's default values."
+msgstr "az alapértelmezett értékekere."
+
+#: id:20328
+msgid "Browse for destination"
+msgstr "Tallózás"
+
+#: id:20329
+msgid "Movies are in separate folders that match the movie title"
+msgstr "A filmcímnek megfelelő találatok külön mappákban találhatók"
+
+#: id:20330
+msgid "Use folder names for lookups"
+msgstr "Használja a mappanevet a keresésekhez"
+
+#: id:20331
+msgctxt "Auto context with id 20331"
+msgid "File"
+msgstr "Fájl"
+
+#: id:20332
+msgid "Use file or folder names in lookups?"
+msgstr "Mappa- vagy fájlnevek használata kereséskor?"
+
+#: id:20333
+msgid "Set content"
+msgstr "Tartalommegadás"
+
+#: id:20334
+msgid "Folder"
+msgstr "Mappa"
+
+#: id:20335
+msgid "Look for content recursively?"
+msgstr "Tartalom rekurzív keresése?"
+
+#: id:20336
+msgid "Unlock sources"
+msgstr "Forrászárolás feloldása"
+
+#: id:20337
+msgid "Actor"
+msgstr "Színész"
+
+#: id:20338
+msgid "Movie"
+msgstr "Film"
+
+#: id:20339
+msgid "Director"
+msgstr "Rendező"
+
+#: id:20340
+msgid "Do you want to remove all items within"
+msgstr "A megadott elérési út minden elemének"
+
+#: id:20341
+msgid "this path from the XBMC library?"
+msgstr "eltávolítása az XBMC médiatárból?"
+
+#: id:20342
+msgctxt "Auto context with id 20342"
+msgid "Movies"
+msgstr "Filmek"
+
+#: id:20343
+msgid "TV shows"
+msgstr "Sorozatok"
+
+#: id:20344
+msgid "This directory contains"
+msgstr "A könyvtár tartalma"
+
+#: id:20345
+msgid "Run automated scan"
+msgstr "Automatikus átvizsgálás"
+
+#: id:20346
+msgid "Scan recursively"
+msgstr "Rekurzív átvizsgálás"
+
+#: id:20347
+msgid "as"
+msgstr "mint"
+
+#: id:20348
+msgid "Directors"
+msgstr "Rendezők"
+
+#: id:20349
+msgid "No video files found in this path!"
+msgstr "Nem található videófájl a megadott elérésiúton!"
+
+#: id:20350
+msgid "votes"
+msgstr "szavazat"
+
+#: id:20351
+msgid "TV show information"
+msgstr "Sorozat információ"
+
+#: id:20352
+msgid "Episode information"
+msgstr "Epizód információ"
+
+#: id:20353
+msgid "Loading TV show details"
+msgstr "Sorozat információ betöltése"
+
+#: id:20354
+msgid "Fetching episode guide"
+msgstr "Epizódkalauz letöltése"
+
+#: id:20355
+msgid "Loading info for episodes in directory"
+msgstr "Információ betöltése a könyvtárban található epizódokhoz"
+
+#: id:20356
+msgid "Select TV show:"
+msgstr "Sorozat választása:"
+
+#: id:20357
+msgid "Enter the TV show name"
+msgstr "Sorozat neve"
+
+#: id:20358
+msgid "Season %i"
+msgstr "Évad %i"
+
+#: id:20359
+msgid "Episode"
+msgstr "Epizód"
+
+#: id:20360
+msgid "Episodes"
+msgstr "Epizód"
+
+#: id:20361
+msgid "Loading episode details"
+msgstr "Epizódrészletek betöltése"
+
+#: id:20362
+msgid "Remove episode from library"
+msgstr "Epizód eltávolítása a médiatárból"
+
+#: id:20363
+msgid "Remove TV show from library"
+msgstr "Sorozat eltávolítása a médiatárból"
+
+#: id:20364
+msgid "TV show"
+msgstr "Sorozat"
+
+#: id:20365
+msgid "Episode plot"
+msgstr "Epizód tartalma"
+
+#: id:20366
+msgid "* All seasons"
+msgstr "* Összes évad"
+
+#: id:20367
+msgid "Hide watched"
+msgstr "Látottak rejtve"
+
+#: id:20368
+msgid "Prod code"
+msgstr "Prod kód"
+
+#: id:20369
+msgid "Show plot for unwatched items"
+msgstr "Tartalom megjelenítése nem látott filmek esetén"
+
+#: id:20370
+msgid "* Hidden to prevent spoilers *"
+msgstr "* Elrejtve, spoiler-védelem miatt *"
+
+#: id:20371
+msgid "Set season thumb"
+msgstr "Évad bélyegkép beállítása"
+
+#: id:20372
+msgid "Season image"
+msgstr "Évad kép"
+
+#: id:20373
+msgid "Season"
+msgstr "Évad"
+
+#: id:20374
+msgid "Downloading movie information"
+msgstr "Film információ letöltése"
+
+#: id:20375
+msgid "Unassign content"
+msgstr "Tartalom hozzárendelés megszüntetése"
+
+#: id:20376
+msgid "Original title"
+msgstr "Eredeti cím"
+
+#: id:20377
+msgid "Refresh TV show information"
+msgstr "Sorozat információ frissítése"
+
+#: id:20378
+msgid "Refresh info for all episodes?"
+msgstr "Minden epizód frissítése?"
+
+#: id:20379
+msgid "Selected folder contains a single TV show"
+msgstr "A kiválasztott mappa egyetlen sorozatot tartalmaz"
+
+#: id:20380
+msgid "Exclude selected folder from scans"
+msgstr "A kiválasztott mappa kihagyása az átvizsgálásokból"
+
+#: id:20381
+msgid "Specials"
+msgstr "Egyediek"
+
+#: id:20382
+msgid "Automatically grab season thumbs"
+msgstr "Évad bélyegképek automatikus letöltése"
+
+#: id:20383
+msgid "Selected folder contains a single video"
+msgstr "A kiválasztott mappa egyetlen videót tartalmaz"
+
+#: id:20384
+msgid "Link to TV show"
+msgstr "Hivatkozás a sorozathoz"
+
+#: id:20385
+msgid "Remove link to TV show"
+msgstr "Sorozat hivatkozás törlése"
+
+#: id:20386
+msgid "Recently added movies"
+msgstr "Nemrég bekerült filmek"
+
+#: id:20387
+msgid "Recently added episodes"
+msgstr "Nemrég bekerült epizódok"
+
+#: id:20388
+msgid "Studios"
+msgstr "Stúdiók"
+
+#: id:20389
+msgid "Music videos"
+msgstr "Videóklipek"
+
+#: id:20390
+msgid "Recently added music videos"
+msgstr "Nemrég bekerült videóklipek"
+
+#: id:20391
+msgid "Music video"
+msgstr "Videóklip"
+
+#: id:20392
+msgid "Remove music video from library"
+msgstr "Videóklip eltávolítása a médiatárból"
+
+#: id:20393
+msgctxt "Auto context with id 20393"
+msgid "Music video information"
+msgstr "Videóklip információ"
+
+#: id:20394
+msgid "Loading music video information"
+msgstr "Videóklip információ betöltése"
+
+#: id:20395
+msgid "Mixed"
+msgstr "Kevert"
+
+#: id:20396
+msgid "Go to albums by artist"
+msgstr "Albumhoz, előadó szerint"
+
+#: id:20397
+msgid "Go to album"
+msgstr "Albumhoz"
+
+#: id:20398
+msgid "Play song"
+msgstr "Zeneszám lejátszása"
+
+#: id:20399
+msgid "Go to music videos from album"
+msgstr "Videóklipekhez, az albumról"
+
+#: id:20400
+msgid "Go to music videos by artist"
+msgstr "Videóklipekhez, előadótól"
+
+#: id:20401
+msgid "Play music video"
+msgstr "Videóklip lejátszása"
+
+#: id:20402
+msgid "Download actor thumbnails when adding to library"
+msgstr "Színész bélyegképek letöltése médiatárhoz való hozzáadáskor"
+
+#: id:20403
+msgid "Set actor thumb"
+msgstr "Színész bélyegkép beállítás"
+
+#: id:20405
+msgid "Remove episode bookmark"
+msgstr "Epizód-könyvj. törlése"
+
+#: id:20406
+msgid "Set episode bookmark"
+msgstr "Epizód-könyvjelző"
+
+#: id:20407
+msgid "Scraper settings"
+msgstr "Leolvasó beállításai"
+
+#: id:20408
+msgid "Downloading music video information"
+msgstr "Videóklip információ letöltése"
+
+#: id:20409
+msgid "Downloading TV show information"
+msgstr "Sorozat információ letöltése"
+
+#: id:20410
+msgid "Trailer"
+msgstr "Filmajánló"
+
+#: id:20411
+msgid "Flatten"
+msgstr "Listák szűkítése"
+
+#: id:20412
+msgid "Flatten TV shows"
+msgstr "Sorozat listaszűkítés"
+
+#: id:20413
+msgid "Get fanart"
+msgstr "Fanartkép"
+
+#: id:20414
+msgid "Show Fanart in video and music libraries"
+msgstr "Fanartkép megjelenítése a médiatárban"
+
+#: id:20415
+msgid "Scanning for new content"
+msgstr "Új tartalom keresése"
+
+#: id:20416
+msgid "First aired"
+msgstr "Első adás"
+
+#: id:20417
+msgid "Writer"
+msgstr "Írta"
+
+#: id:20419
+msgid "Replace file names with library titles"
+msgstr "Fájlnevek helyett a médiatár címek mutatása"
+
+#: id:20420
+msgctxt "Auto context with id 20420"
+msgid "Never"
+msgstr "Soha"
+
+#: id:20421
+msgid "If only one season"
+msgstr "Csak, ha egy évad van"
+
+#: id:20422
+msgid "Always"
+msgstr "Mindig"
+
+#: id:20423
+msgid "Has trailer"
+msgstr "Van filmajánló"
+
+#: id:20424
+msgid "False"
+msgstr "Hamis"
+
+#: id:20425
+msgid "Fanart slideshow"
+msgstr "Fanartkép vetítés"
+
+#: id:20426
+msgid "Export to a single file or separate"
+msgstr "Exportálás egyetlen fájlba, vagy"
+
+#: id:20427
+msgid "files per entry?"
+msgstr "külön-külön adatbázis bejegyzésenként?"
+
+#: id:20428
+msgid "Single file"
+msgstr "Egyetlen fájl"
+
+#: id:20429
+msgctxt "Auto context with id 20429"
+msgid "Separate"
+msgstr "Külön-külön"
+
+#: id:20430
+msgid "Export thumbnails and fanart?"
+msgstr "Bélyegképek és fanartképek exportálása?"
+
+#: id:20431
+msgid "Overwrite old files?"
+msgstr "Korábbi fájlok felülírása?"
+
+#: id:20432
+msgid "Exclude path from library updates"
+msgstr "Elérési út kihagyása a médiatár-frissítésekor"
+
+#: id:20433
+msgid "Extract thumbnails and video information"
+msgstr "Média információk és bélyegképek kinyerése"
+
+#: id:20434
+msgid "Sets"
+msgstr "Lemezgyűjtemény"
+
+#: id:20435
+msgid "Set movieset thumb"
+msgstr "Lemezgyűjtemény bélyegkép"
+
+#: id:20436
+msgid "Export actor thumbs?"
+msgstr "Színész-bélyegképek exportálása?"
+
+#: id:20437
+msgid "Choose fanart"
+msgstr "Fanartkép választás"
+
+#: id:20438
+msgid "Local fanart"
+msgstr "Helyi fanartkép"
+
+#: id:20439
+msgid "No fanart"
+msgstr "Nincs fanartkép"
+
+#: id:20440
+msgid "Current fanart"
+msgstr "Jelenlegi fanartkép"
+
+#: id:20441
+msgid "Remote fanart"
+msgstr "Távoli fanartkép"
+
+#: id:20442
+msgid "Change content"
+msgstr "Tartalom változtatása"
+
+#: id:20443
+msgid "Do you want to refresh info for all"
+msgstr "Akarod frissíteni az infó-t minden"
+
+#: id:20444
+msgid "items within this path?"
+msgstr "elemhez ezen az útvonalon?"
+
+#: id:20445
+msgid "Fanart"
+msgstr "Fanartkép"
+
+#: id:20446
+msgid "Locally stored information found."
+msgstr "Helyben tárolt információt találtam."
+
+#: id:20447
+msgid "Ignore and refresh from internet?"
+msgstr "Elvetés és frissítés az internetről?"
+
+#: id:20448
+msgid "Could not download information"
+msgstr "Nem tudtam letölteni az információt"
+
+#: id:20449
+msgid "Unable to connect to remote server"
+msgstr "Nem lehet kapcsolódni a távoli kiszolgálóhoz"
+
+#: id:20450
+msgid "Would you like to continue scanning?"
+msgstr "Szeretnéd a keresést folytatni?"
+
+#: id:20451
+msgid "Countries"
+msgstr "Országok"
+
+#: id:20452
+msgid "episode"
+msgstr "epizód"
+
+#: id:20453
+msgid "episodes"
+msgstr "epizód"
+
+#: id:20454
+msgid "Listener"
+msgstr "Hallgató"
+
+#: id:20455
+msgid "Listeners"
+msgstr "Hallgató"
+
+#: id:20456
+msgid "Set movieset fanart"
+msgstr "Filmgyűjtemény fanart beállítása"
+
+#: id:20457
+msgid "Movie set"
+msgstr "Filmgyűjtemény"
+
+#: id:20458
+msgid "Group movies in sets"
+msgstr "Filmek csoportosítása készletekbe"
+
+#: id:21330
+msgid "Show hidden files and directories"
+msgstr "Rejtett fájlok és mappák megjelenítése"
+
+#: id:21331
+msgid "TuxBox client"
+msgstr "TuxBox kliens"
+
+#: id:21332
+msgid "WARNING: Target TuxBox device is in recording-mode!"
+msgstr "FIGYELEM:TuxBox céleszköz felvétel módban lesz!"
+
+#: id:21333
+msgid "The stream will be stopped!"
+msgstr "Az adatfolyam megáll!"
+
+#: id:21334
+msgid "Zap to channel: %s failed!"
+msgstr "Erre a csatornára váltás nem sikerült: %s"
+
+#: id:21335
+msgid "Are you sure to start the stream?"
+msgstr "Adatfolyam indítása?"
+
+#: id:21336
+msgid "Connecting to: %s"
+msgstr "Csatlakozás: %s"
+
+#: id:21337
+msgid "TuxBox device"
+msgstr "TuxBox eszköz"
+
+#: id:21359
+msgid "Add media share..."
+msgstr "Médiamegosztás hozzáadása..."
+
+#: id:21360
+msgid "Share video and music libraries through UPnP"
+msgstr "Videó és zene megosztás UPnP-n keresztül"
+
+#: id:21364
+msgid "Edit media share"
+msgstr "Médiamegosztás szerkesztése"
+
+#: id:21365
+msgid "Remove media share"
+msgstr "Médiamegosztás eltávolítása"
+
+#: id:21366
+msgid "Subtitle folder"
+msgstr "Felirat mappa"
+
+#: id:21367
+msgid "Movie & alternate subtitle directory"
+msgstr "Film és alternatív felirat mappa"
+
+#: id:21368
+msgid "Override ASS/SSA subtitles fonts"
+msgstr "Az ASS/SSA betűtípusok figyelmen kívül hagyása"
+
+#: id:21369
+msgid "Enable mouse and Touch Screen support"
+msgstr "Egér- és érintőképernyő támogatás engedélyezése"
+
+#: id:21370
+msgid "Play navigation sounds during media playback"
+msgstr "Navigációs hangok lejátszás közben"
+
+#: id:21371
+msgid "Thumbnail"
+msgstr "Bélyegkép"
+
+#: id:21372
+msgid "Forced DVD player region"
+msgstr "Kényszerített DVD régiókód használata"
+
+#: id:21373
+msgid "Video output"
+msgstr "Képkimenet"
+
+#: id:21374
+msgid "Video aspect"
+msgstr "Videó képarány"
+
+#: id:21375
+msgctxt "Auto context with id 21375"
+msgid "Normal"
+msgstr "Normál"
+
+#: id:21376
+msgid "Letterbox"
+msgstr "Hagyományos megjelenítő"
+
+#: id:21377
+msgid "Widescreen"
+msgstr "Szélesvászon"
+
+#: id:21378
+msgid "Enable 480p"
+msgstr "480p engedélyezése"
+
+#: id:21379
+msgid "Enable 720p"
+msgstr "720p engedélyezése"
+
+#: id:21380
+msgid "Enable 1080i"
+msgstr "1080i engedélyezése"
+
+#: id:21381
+msgid "Enter name of new playlist"
+msgstr "Lejátszáslista nevének megadása"
+
+#: id:21382
+msgid "Show \"Add source\" buttons in file lists"
+msgstr "A \"Forrás hozzáadása\" gomb megjelenítése a fájllistában"
+
+#: id:21383
+msgid "Enable scrollbars"
+msgstr "Görgetősávok engedélyezése"
+
+#: id:21384
+msgid "Make watched filtering a toggle in video library"
+msgstr "A látott-státusz kapcsolóként értelmezése a médiatárban"
+
+#: id:21385
+msgctxt "Auto context with id 21385"
+msgid "Open"
+msgstr "Megnyitás"
+
+#: id:21386
+msgid "Acoustic management level"
+msgstr "Zajszint menedzsment"
+
+#: id:21387
+msgid "Fast"
+msgstr "Gyors (hangos)"
+
+#: id:21388
+msgid "Quiet"
+msgstr "Lassú (csendes)"
+
+#: id:21389
+msgid "Enable custom background"
+msgstr "Saját háttér"
+
+#: id:21390
+msgid "Power management level"
+msgstr "Energiagazdálkodási szint"
+
+#: id:21391
+msgid "High power"
+msgstr "Magas teljesítmény"
+
+#: id:21392
+msgid "Low power"
+msgstr "Energiatakarékos"
+
+#: id:21393
+msgid "High standby"
+msgstr "Magas készenlét"
+
+#: id:21394
+msgid "Low standby"
+msgstr "Alacsony készenlét"
+
+#: id:21395
+msgid "Unable to cache files bigger than 4GB"
+msgstr "4GB-nál nagyobb fájlok nem gyorsítótárazhatók"
+
+#: id:21396
+msgid "Chapter"
+msgstr "Fejezet"
+
+#: id:21397
+msgid "High quality pixel shader v2"
+msgstr "Magas minőségű pixel árnyékoló v2"
+
+#: id:21398
+msgid "Enable playlist at startup"
+msgstr "Lejátszáslista engedélyezése induláskor"
+
+#: id:21399
+msgid "Use tween animations"
+msgstr "Pattogó animációk használata"
+
+#: id:21400
+msgid "contains"
+msgstr "tartalmazza"
+
+#: id:21401
+msgid "does not contain"
+msgstr "nem tartalmazza"
+
+#: id:21402
+msgid "is"
+msgstr "egyenlő"
+
+#: id:21403
+msgid "is not"
+msgstr "nem egyenlő"
+
+#: id:21404
+msgid "starts with"
+msgstr "kezdődik"
+
+#: id:21405
+msgid "ends with"
+msgstr "végződik"
+
+#: id:21406
+msgid "greater than"
+msgstr "nagyobb, mint"
+
+#: id:21407
+msgid "less than"
+msgstr "kevesebb, mint"
+
+#: id:21408
+msgid "after"
+msgstr "után"
+
+#: id:21409
+msgid "before"
+msgstr "előtt"
+
+#: id:21410
+msgid "in the last"
+msgstr "az utolsó X-ben van"
+
+#: id:21411
+msgid "not in the last"
+msgstr "nincs az utolsó X-ben"
+
+#: id:21412
+msgid "Scrapers"
+msgstr "Leolvasók"
+
+#: id:21413
+msgid "Default movie scraper"
+msgstr "Alapértelmezett film leolvasó"
+
+#: id:21414
+msgid "Default tvshow scraper"
+msgstr "Alapértelmezett sorozat leolvasó"
+
+#: id:21415
+msgid "Default music video scraper"
+msgstr "Alapértelmezett videóklip leolvasó"
+
+#: id:21416
+msgid "Enable fallback based on scraper language"
+msgstr "Helyettesítés engedélyezése a leolvasó nyelve alapján"
+
+#: id:21417
+msgid "- Settings"
+msgstr "- Beállítások"
+
+#: id:21418
+msgid "Multilingual"
+msgstr "Többnyelvű"
+
+#: id:21419
+msgid "No scrapers present"
+msgstr "Nincs leolvasó"
+
+#: id:21420
+msgid "Value to match"
+msgstr "Kívánt érték"
+
+#: id:21421
+msgid "Smart playlist rule"
+msgstr "Intelligens lejátszáslista szabály"
+
+#: id:21422
+msgid "Match items where"
+msgstr "Elemek összehasonlítása, ahol"
+
+#: id:21423
+msgid "New rule..."
+msgstr "Új szabály..."
+
+#: id:21424
+msgid "Items must match"
+msgstr "Az elemeknek összhangban kell lenniük"
+
+#: id:21425
+msgid "all of the rules"
+msgstr "minden szabállyal"
+
+#: id:21426
+msgid "one or more of the rules"
+msgstr "egy vagy több szabállyal"
+
+#: id:21427
+msgid "Limit to"
+msgstr "Korlátozás"
+
+#: id:21428
+msgid "No limit"
+msgstr "Nincs korlátozás"
+
+#: id:21429
+msgid "Order by"
+msgstr "Rendezés"
+
+#: id:21430
+msgid "ascending"
+msgstr "növekvő"
+
+#: id:21431
+msgid "descending"
+msgstr "csökkenő"
+
+#: id:21432
+msgid "Edit smart playlist"
+msgstr "Intelligens lejátszáslista szerkesztése"
+
+#: id:21433
+msgid "Name of the playlist"
+msgstr "Lejátszáslista neve"
+
+#: id:21434
+msgid "Find items where"
+msgstr "Elemek keresése, ahol"
+
+#: id:21435
+msgid "Edit"
+msgstr "Szerkeszt"
+
+#: id:21436
+msgid "%i items"
+msgstr "%i elemre"
+
+#: id:21437
+msgid "New smart playlist..."
+msgstr "Új intelligens lejátszáslista..."
+
+#: id:21438
+msgid "%c Drive"
+msgstr "%c Meghajtó"
+
+#: id:21439
+msgid "Edit party mode rules"
+msgstr "Partymód-szabályok szerk."
+
+#: id:21440
+msgid "Home folder"
+msgstr "Saját mappa"
+
+#: id:21441
+msgid "Watched count"
+msgstr "Lejátszás számláló"
+
+#: id:21442
+msgid "Episode title"
+msgstr "Epizódcím"
+
+#: id:21443
+msgid "Video resolution"
+msgstr "Felbontás"
+
+#: id:21444
+msgid "Audio channels"
+msgstr "Hangcsatornák"
+
+#: id:21445
+msgid "Video codec"
+msgstr "Videó codec"
+
+#: id:21446
+msgid "Audio codec"
+msgstr "Hang codec"
+
+#: id:21447
+msgid "Audio language"
+msgstr "Hang nyelve"
+
+#: id:21448
+msgid "Subtitle language"
+msgstr "Felirat nyelve"
+
+#: id:21449
+msgid "Remote control sends keyboard presses"
+msgstr "Távirányító billentyűleütéseket küld"
+
+#: id:21450
+msgid "- Edit"
+msgstr "- Szerkeszt"
+
+#: id:21451
+msgid "Internet connection required."
+msgstr "Internet kapcsolat szükséges."
+
+#: id:21452
+msgid "Get More..."
+msgstr "Több beszerzése..."
+
+#: id:21453
+msgid "Root filesystem"
+msgstr "Fájlrendszer"
+
+#: id:21454
+msgid "Cache full"
+msgstr "Gyorsítótár megtelt"
+
+#: id:21455
+msgid "Cache filled before reaching required amount for continous playback"
+msgstr "A gyorsítótár még azelőtt megtelt, hogy elegendő lett volna a folyamatos lejátszáshoz"
+
+#: id:21460
+msgid "Subtitle location"
+msgstr "Felirat helye"
+
+#: id:21461
+msgid "Fixed"
+msgstr "Rögzített"
+
+#: id:21462
+msgid "Bottom of video"
+msgstr "Videó alján"
+
+#: id:21463
+msgid "Below video"
+msgstr "Videó alatt"
+
+#: id:21464
+msgid "Top of video"
+msgstr "Videó tetején"
+
+#: id:21465
+msgid "Above video"
+msgstr "Videó felett"
+
+#: id:21800
+msgid "File name"
+msgstr "Fájlnév"
+
+#: id:21801
+msgid "File path"
+msgstr "Fájl helye"
+
+#: id:21802
+msgid "File size"
+msgstr "Fájlméret"
+
+#: id:21803
+msgid "File date/time"
+msgstr "Fájl dátum"
+
+#: id:21804
+msgid "Slide index"
+msgstr "Dia index"
+
+#: id:21805
+msgctxt "Auto context with id 21805"
+msgid "Resolution"
+msgstr "Felbontás"
+
+#: id:21806
+msgctxt "Auto context with id 21806"
+msgid "Comment"
+msgstr "Megjegyzés"
+
+#: id:21807
+msgid "Colour/B&W"
+msgstr "Színes/FF"
+
+#: id:21808
+msgid "JPEG process"
+msgstr "JPEG típus"
+
+#: id:21820
+msgid "Date/Time"
+msgstr "Dátum/idő"
+
+#: id:21821
+msgid "Description"
+msgstr "Leírás"
+
+#: id:21822
+msgid "Camera make"
+msgstr "Fényk.gyártó"
+
+#: id:21823
+msgid "Camera model"
+msgstr "Fényk.típus"
+
+#: id:21824
+msgid "EXIF comment"
+msgstr "EXIF adat"
+
+#: id:21825
+msgid "Firmware"
+msgstr "Firmware"
+
+#: id:21826
+msgid "Aperture"
+msgstr "Rekesz"
+
+#: id:21827
+msgid "Focal length"
+msgstr "Gyújtótáv"
+
+#: id:21828
+msgid "Focus distance"
+msgstr "Fókusztáv"
+
+#: id:21829
+msgid "Exposure"
+msgstr "Exponálás"
+
+#: id:21830
+msgid "Exposure time"
+msgstr "Expon.idő"
+
+#: id:21831
+msgid "Exposure bias"
+msgstr "Expon.eltérés"
+
+#: id:21832
+msgid "Exposure mode"
+msgstr "Expon.mód"
+
+#: id:21833
+msgid "Flash used"
+msgstr "Vaku"
+
+#: id:21834
+msgid "White-balance"
+msgstr "F.egyensúly"
+
+#: id:21835
+msgid "Light source"
+msgstr "Fényforrás"
+
+#: id:21836
+msgid "Metering mode"
+msgstr "Fénymérés"
+
+#: id:21837
+msgid "ISO"
+msgstr "ISO"
+
+#: id:21838
+msgid "Digital zoom"
+msgstr "Digitális nagyítás"
+
+#: id:21839
+msgid "CCD width"
+msgstr "CCD szélesség"
+
+#: id:21840
+msgid "GPS latitude"
+msgstr "GPS szélesség"
+
+#: id:21841
+msgid "GPS longitude"
+msgstr "GPS hosszúság"
+
+#: id:21842
+msgid "GPS altitude"
+msgstr "GPS magasság"
+
+#: id:21843
+msgid "Orientation"
+msgstr "Tájolás"
+
+#: id:21860
+msgid "Supplemental categories"
+msgstr "Kiegészítő kategóriák"
+
+#: id:21861
+msgid "Keywords"
+msgstr "Kulcsszavak"
+
+#: id:21862
+msgid "Caption"
+msgstr "Képaláírás"
+
+#: id:21863
+msgid "Author"
+msgstr "Szerző"
+
+#: id:21864
+msgid "Headline"
+msgstr "Főcím"
+
+#: id:21865
+msgid "Special instructions"
+msgstr "Különleges útmutatás"
+
+#: id:21866
+msgid "Category"
+msgstr "Kategória"
+
+#: id:21867
+msgid "Byline"
+msgstr "Cikkszerző"
+
+#: id:21868
+msgid "Byline title"
+msgstr "Cikkszerző beosztás"
+
+#: id:21869
+msgid "Credit"
+msgstr "Készítő"
+
+#: id:21870
+msgid "Source"
+msgstr "Forrás"
+
+#: id:21871
+msgid "Copyright notice"
+msgstr "Szerzői jogi megjegyzés"
+
+#: id:21872
+msgid "Object name"
+msgstr "Elem neve"
+
+#: id:21873
+msgid "City"
+msgstr "Város"
+
+#: id:21874
+msgid "State"
+msgstr "Állam"
+
+#: id:21875
+msgctxt "Auto context with id 21875"
+msgid "Country"
+msgstr "Ország"
+
+#: id:21876
+msgid "Original Tx Reference"
+msgstr "Eredeti Tx referencia"
+
+#: id:21877
+msgid "Date created"
+msgstr "Létrehozás dátuma"
+
+#: id:21878
+msgid "Copyright flag"
+msgstr "Szerzői jogi állapot"
+
+#: id:21879
+msgid "Country code"
+msgstr "Országkód"
+
+#: id:21880
+msgid "Reference service"
+msgstr "Referencia szolgáltatás"
+
+#: id:21881
+msgid "Allow control of XBMC via UPnP"
+msgstr "XBMC távoli vezérelhetősége UPnP-n keresztül"
+
+#: id:21882
+msgid "Attempt to skip introduction before DVD menu"
+msgstr "Kísérlet a DVD főmenü előtti előzetes átugrására"
+
+#: id:21883
+msgid "Saved music"
+msgstr "Bemásolt (rip-elt), vagy felvett zene"
+
+#: id:21884
+msgid "Query info for all artists"
+msgstr "Információ minden előadóról"
+
+#: id:21885
+msgid "Downloading album information"
+msgstr "Albuminformáció letöltése"
+
+#: id:21886
+msgid "Downloading artist information"
+msgstr "Előadóinformáció letöltése"
+
+#: id:21887
+msgid "Biography"
+msgstr "Életrajz"
+
+#: id:21888
+msgid "Discography"
+msgstr "Diszkográfia"
+
+#: id:21889
+msgid "Searching artist"
+msgstr "Előadó keresése"
+
+#: id:21890
+msgid "Select artist"
+msgstr "Előadó kiválasztása"
+
+#: id:21891
+msgctxt "Auto context with id 21891"
+msgid "Artist information"
+msgstr "Információ az előadóról"
+
+#: id:21892
+msgid "Instruments"
+msgstr "Hangszerek"
+
+#: id:21893
+msgid "Born"
+msgstr "Született"
+
+#: id:21894
+msgid "Formed"
+msgstr "Alakult"
+
+#: id:21895
+msgid "Themes"
+msgstr "Témák"
+
+#: id:21896
+msgid "Disbanded"
+msgstr "Feloszlott"
+
+#: id:21897
+msgid "Died"
+msgstr "Meghalt"
+
+#: id:21898
+msgid "Years active"
+msgstr "Aktív évek"
+
+#: id:21899
+msgid "Label"
+msgstr "Kiadó"
+
+#: id:21900
+msgid "Born/Formed"
+msgstr "Született/Alakult"
+
+#: id:22000
+msgid "Update library on startup"
+msgstr "Médiatár frissítése induláskor"
+
+#: id:22001
+msgid "Hide progress of library updates"
+msgstr "Médiatár frissítési állapotának elrejtése"
+
+#: id:22002
+msgid "- DNS suffix"
+msgstr "- DNS utótag"
+
+#: id:22003
+msgid "%2.3fs"
+msgstr "%2.3fmp"
+
+#: id:22004
+msgid "Delayed by: %2.3fs"
+msgstr "Késleltet: %2.3fmp"
+
+#: id:22005
+msgid "Ahead by: %2.3fs"
+msgstr "Előrehoz: %2.3fmp"
+
+#: id:22006
+msgid "Subtitle offset"
+msgstr "Felirat csúsztatás"
+
+#: id:22007
+msgid "OpenGL vendor:"
+msgstr "OpenGL gyártója:"
+
+#: id:22008
+msgid "OpenGL renderer:"
+msgstr "OpenGL renderelő:"
+
+#: id:22009
+msgid "OpenGL version:"
+msgstr "OpenGL verzió:"
+
+#: id:22010
+msgid "GPU temperature:"
+msgstr "GPU hőmérséklete:"
+
+#: id:22011
+msgid "CPU temperature:"
+msgstr "CPU hőmérséklete:"
+
+#: id:22012
+msgid "Total memory"
+msgstr "Teljes memória"
+
+#: id:22013
+msgid "Profile data"
+msgstr "Profil adatok"
+
+#: id:22014
+msgid "Use dim if paused during video playback"
+msgstr "Elhalványítás videólejátszás pillanatmegállítása közben"
+
+#: id:22015
+msgid "All recordings"
+msgstr "Összes felvétel"
+
+#: id:22016
+msgid "By title"
+msgstr "Cím szerint"
+
+#: id:22017
+msgid "By group"
+msgstr "Csoport szerint"
+
+#: id:22018
+msgid "Live channels"
+msgstr "TV csatornák"
+
+#: id:22019
+msgid "Recordings by title"
+msgstr "Felvételek cím szerint"
+
+#: id:22020
+msgid "Guide"
+msgstr "Műsorkalauz"
+
+#: id:22021
+msgid "Allowed error in aspect ratio to minimize black bars"
+msgstr "Max. képarányhiba, feketesávok minimalizálásakor (%)"
+
+#: id:22022
+msgid "Show video files in listings"
+msgstr "Videófájlokat is megjelenít a listázáskor"
+
+#: id:22023
+msgid "DirectX vendor:"
+msgstr "DirectX gyártó:"
+
+#: id:22024
+msgid "Direct3D version:"
+msgstr "Direct3D verzió:"
+
+#: id:22030
+msgctxt "Auto context with id 22030"
+msgid "Font"
+msgstr "Betűtípus"
+
+#: id:22031
+msgctxt "Auto context with id 22031"
+msgid "- Size"
+msgstr "- Méret"
+
+#: id:22032
+msgctxt "Auto context with id 22032"
+msgid "- Colours"
+msgstr "- Szín"
+
+#: id:22033
+msgid "- Charset"
+msgstr "- Karakterkészlet"
+
+#: id:22034
+msgid "Export karaoke titles as HTML"
+msgstr "Exportálás HTML-be."
+
+#: id:22035
+msgid "Export karaoke titles as CSV"
+msgstr "Exportálás CSV fájlba."
+
+#: id:22036
+msgid "Import karaoke titles..."
+msgstr "Karaoke címek importálása..."
+
+#: id:22037
+msgid "Show song selector automatically"
+msgstr "Dalválasztó automatikus megnyitása"
+
+#: id:22038
+msgid "Export karaoke titles..."
+msgstr "Karaoke címek exportálása..."
+
+#: id:22039
+msgid "Enter song number"
+msgstr "Dal számának megadása"
+
+#: id:22040
+msgid "white/green"
+msgstr "fehér/zöld"
+
+#: id:22041
+msgid "white/red"
+msgstr "fehér/vörös"
+
+#: id:22042
+msgid "white/blue"
+msgstr "fehér/kék"
+
+#: id:22043
+msgid "black/white"
+msgstr "fekete/fehér"
+
+#: id:22079
+msgid "Default select action"
+msgstr "Alapértelmezett kiválasztási művelet"
+
+#: id:22080
+msgid "Choose"
+msgstr "Választás"
+
+#: id:22081
+msgid "Show Information"
+msgstr "Információ mutatása"
+
+#: id:22082
+msgid "More..."
+msgstr "Több..."
+
+#: id:22083
+msgid "Play all"
+msgstr "Összes játszása"
+
+#: id:23049
+msgid "Teletext not available"
+msgstr "Teletext nem elérhető"
+
+#: id:23050
+msgid "Activate Teletext"
+msgstr "Teletext aktiválása"
+
+#: id:23051
+msgid "Part %i"
+msgstr "Rész %i"
+
+#: id:23052
+msgid "Buffering %i bytes"
+msgstr "Előtöltve %i byte"
+
+#: id:23053
+msgid "Stopping"
+msgstr "Leáll"
+
+#: id:23054
+msgid "Running"
+msgstr "Fut"
+
+#: id:23100
+msgid "External Player Active"
+msgstr "Külső lejátszó aktív"
+
+#: id:23101
+msgid "Click OK to terminate the player"
+msgstr "A lejátszó megszakításához nyomj az OK-ra"
+
+#: id:23104
+msgid "Click OK when playback has ended"
+msgstr "Lejátszás végén nyomj az OK-ra"
+
+#: id:24000
+msgid "Add-on"
+msgstr "Kiegészítő"
+
+#: id:24001
+msgid "Add-ons"
+msgstr "Kiegészítők"
+
+#: id:24002
+msgid "Add-on options"
+msgstr "Kiegészítő lehetőségei"
+
+#: id:24003
+msgid "Add-on Information"
+msgstr "Kiegészítő információ"
+
+#: id:24005
+msgctxt "Auto context with id 24005"
+msgid "Media sources"
+msgstr "Médiaforrások"
+
+#: id:24007
+msgctxt "Auto context with id 24007"
+msgid "Movie information"
+msgstr "Film információ"
+
+#: id:24008
+msgctxt "Auto context with id 24008"
+msgid "Screensaver"
+msgstr "Képernyővédő"
+
+#: id:24009
+msgid "Script"
+msgstr "Program"
+
+#: id:24010
+msgctxt "Auto context with id 24010"
+msgid "Visualization"
+msgstr "Vizualizáció"
+
+#: id:24011
+msgid "Add-on repository"
+msgstr "Kiegészítő tárolóhely"
+
+#: id:24012
+msgctxt "Auto context with id 24012"
+msgid "Subtitles"
+msgstr "Feliratok"
+
+#: id:24013
+msgid "Lyrics"
+msgstr "Dalszöveg"
+
+#: id:24014
+msgid "TV information"
+msgstr "Sorozat információ"
+
+#: id:24015
+msgctxt "Auto context with id 24015"
+msgid "Music video information"
+msgstr "Zenei videóklip információ"
+
+#: id:24016
+msgctxt "Auto context with id 24016"
+msgid "Album information"
+msgstr "Album információ"
+
+#: id:24017
+msgctxt "Auto context with id 24017"
+msgid "Artist information"
+msgstr "Előadó információ"
+
+#: id:24018
+msgctxt "Auto context with id 24018"
+msgid "Services"
+msgstr "Szolgáltatások"
+
+#: id:24020
+msgid "Configure"
+msgstr "Beállítás"
+
+#: id:24021
+msgctxt "Auto context with id 24021"
+msgid "Disable"
+msgstr "Kikapcsolás"
+
+#: id:24022
+msgid "Enable"
+msgstr "Engedélyezés"
+
+#: id:24023
+msgid "Add-on disabled"
+msgstr "Kiegészítő tiltva"
+
+#: id:24027
+msgctxt "Auto context with id 24027"
+msgid "Weather"
+msgstr "Időjárás"
+
+#: id:24028
+msgid "Weather.com (standard)"
+msgstr "Weather.com (alap)"
+
+#: id:24030
+msgid "This Add-on can not be configured"
+msgstr "Ez a kiegészítő nem konfigurálható"
+
+#: id:24031
+msgid "Error loading settings"
+msgstr "Hiba a beállítások betöltésekor"
+
+#: id:24032
+msgid "All Add-ons"
+msgstr "Minden kiegészítő"
+
+#: id:24033
+msgid "Get Add-ons"
+msgstr "Kiegészítő beszerzése"
+
+#: id:24034
+msgid "Check for updates"
+msgstr "Frissítések keresése"
+
+#: id:24035
+msgid "Force refresh"
+msgstr "Frissítés kényszerítése"
+
+#: id:24036
+msgid "Change log"
+msgstr "Változáslista"
+
+#: id:24037
+msgid "Uninstall"
+msgstr "Törlés"
+
+#: id:24038
+msgid "Install"
+msgstr "Telepítés"
+
+#: id:24039
+msgid "Disabled Add-ons"
+msgstr "Kikapcsolt kiegészítők"
+
+#: id:24040
+msgid "(Clear the current setting)"
+msgstr "(A jelenlegi beállítás törlése)"
+
+#: id:24041
+msgid "Install from zip file"
+msgstr "Telepítés zip fájlból"
+
+#: id:24042
+msgid "Downloading %i%%"
+msgstr "Letöltve %i%%"
+
+#: id:24043
+msgid "Available Updates"
+msgstr "Elérhető frissítések"
+
+#: id:24044
+msgid "Dependencies not met"
+msgstr "Előfeltételek nem teljesülnek"
+
+#: id:24045
+msgid "Add-on does not have the correct structure"
+msgstr "A kiegészítőnek nem megfelelő a felépítése"
+
+#: id:24046
+msgid "%s is used by the following installed add-on(s)"
+msgstr "%s haszálatban van az alábbi kiegészítő(k) által"
+
+#: id:24047
+msgid "This add-on cannot be uninstalled"
+msgstr "Ez a kiegészítő nem törölhető"
+
+#: id:24048
+msgid "Rollback"
+msgstr "Előző verzió"
+
+#: id:24050
+msgid "Available Add-ons"
+msgstr "Elérhető kiegészítők"
+
+#: id:24051
+msgid "Version:"
+msgstr "Verzió:"
+
+#: id:24052
+msgid "Disclaimer"
+msgstr "Figyelmeztetés"
+
+#: id:24053
+msgid "License:"
+msgstr "Licenc:"
+
+#: id:24054
+msgid "Changelog"
+msgstr "Változáslista"
+
+#: id:24059
+msgid "Would you like to enable this Add-on?"
+msgstr "Akarod engedélyezni ezt a kiegészítőt?"
+
+#: id:24060
+msgid "Would you like to disable this Add-on?"
+msgstr "Akarod kikapcsolni ezt a kiegészítőt?"
+
+#: id:24061
+msgid "Add-on update available!"
+msgstr "Kiegészítő frissítése elérhető!"
+
+#: id:24062
+msgid "Enabled Add-ons"
+msgstr "Engedélyezett kiegészítők"
+
+#: id:24063
+msgid "Auto update"
+msgstr "Auto-frissítés"
+
+#: id:24064
+msgid "Add-on enabled"
+msgstr "Kiegészítő engedélyezve"
+
+#: id:24065
+msgid "Add-on updated"
+msgstr "Kiegészítő frissítve"
+
+#: id:24066
+msgid "Cancel Add-on download?"
+msgstr "Kiegészítő letöltés megszakítása?"
+
+#: id:24067
+msgid "Currently downloading Add-ons"
+msgstr "Kiegészítők letöltése"
+
+#: id:24068
+msgid "Update available"
+msgstr "Frissítés elérhető"
+
+#: id:24069
+msgid "Update"
+msgstr "Frissítés"
+
+#: id:24070
+msgid "Add-on could not be loaded."
+msgstr "A kiegészítő nem tölthető be."
+
+#: id:24071
+msgid "An unknown error has occurred."
+msgstr "Ismeretlen hiba lépett fel."
+
+#: id:24072
+msgid "Settings required"
+msgstr "Beállítás szükséges"
+
+#: id:24073
+msgid "Could not connect"
+msgstr "Nem tudott csatlakozni"
+
+#: id:24074
+msgid "Needs to restart"
+msgstr "Újraindítás szükséges"
+
+#: id:24075
+msgctxt "Auto context with id 24075"
+msgid "Disable"
+msgstr "Kikapcsolás"
+
+#: id:24076
+msgid "Add-on Required"
+msgstr "Kiegészítő szükséges"
+
+#: id:24080
+msgid "Try to reconnect?"
+msgstr "Próbáljon újra csatlakozni?"
+
+#: id:24089
+msgid "Add-on restarts"
+msgstr "Kiegészítő újraindul"
+
+#: id:24090
+msgid "Lock Add-on manager"
+msgstr "Kiegészítő-kezelő zárolása"
+
+#: id:24094
+msgid "(current)"
+msgstr "(jelenlegi)"
+
+#: id:24095
+msgid "(blacklisted)"
+msgstr "(letiltott)"
+
+#: id:24096
+msgid "Add-on has been marked as broken in repository."
+msgstr "A kiegészítőt működésképtelennek jelölték a tárhelyen."
+
+#: id:24097
+msgid "Would you like to disable it on your system?"
+msgstr "Akarod letiltani a számítógépeden?"
+
+#: id:24098
+msgid "Broken"
+msgstr "Működésképtelen"
+
+#: id:24099
+msgid "Would you like to switch to this skin?"
+msgstr "Átváltasz erre a felszínre ?"
+
+#: id:24100
+msgid "To use this feature you must download an Add-on:"
+msgstr "A funkció használatához le kell töltened egy kiegészítőt:"
+
+#: id:24101
+msgid "Would you like to download this Add-on?"
+msgstr "Szeretnéd letölteni ezt a kiegészítőt?"
+
+#: id:25000
+msgid "Notifications"
+msgstr "Értesítések"
+
+#: id:29800
+msgid "Library Mode"
+msgstr "Médiatár mód"
+
+#: id:29801
+msgid "QWERTY keyboard"
+msgstr "QWERTY billentyűzet"
+
+#: id:29802
+msgid "Passthrough Audio in use"
+msgstr "Hangtovábbítás-módban tiltva"
+
+#: id:33001
+msgid "Trailer quality"
+msgstr "Filmelőzetes minőség"
+
+#: id:33002
+msgid "Stream"
+msgstr "Adatfolyam"
+
+#: id:33003
+msgid "Download"
+msgstr "Letöltés"
+
+#: id:33004
+msgid "Download & play"
+msgstr "Letöltés & lejátszás"
+
+#: id:33005
+msgid "Download & save"
+msgstr "Letöltés & mentés"
+
+#: id:33006
+msgid "Today"
+msgstr "Ma"
+
+#: id:33007
+msgid "Tomorrow"
+msgstr "Holnap"
+
+#: id:33008
+msgid "Saving"
+msgstr "Mentés"
+
+#: id:33009
+msgid "Copying"
+msgstr "Másolás"
+
+#: id:33010
+msgid "Set download directory"
+msgstr "Letöltési mappa megadása"
+
+#: id:33011
+msgid "Search duration"
+msgstr "Keresési idő"
+
+#: id:33012
+msgid "Short"
+msgstr "Rövid"
+
+#: id:33013
+msgid "Long"
+msgstr "Hosszú"
+
+#: id:33014
+msgid "Use DVD player instead of regular player"
+msgstr "DVD lejátszó használata az általános lejátszó helyett"
+
+#: id:33015
+msgid "Ask for download before playing video"
+msgstr "Kérdezzen rá a letöltésre a videó lejátszása előtt"
+
+#: id:33016
+msgid "Clips"
+msgstr "Klipek"
+
+#: id:33017
+msgid "Restart plugin to enable"
+msgstr "Az érvényesítéshez a kiegészítő újraindítása szükséges"
+
+#: id:33018
+msgid "Tonight"
+msgstr "Ma este"
+
+#: id:33019
+msgid "Tomorrow Night"
+msgstr "Holnap este"
+
+#: id:33020
+msgid "Condition"
+msgstr "Körülmény"
+
+#: id:33021
+msgid "Precipitation"
+msgstr "Csapadék"
+
+#: id:33022
+msgid "Precip"
+msgstr "Csapadékos"
+
+#: id:33023
+msgid "Humid"
+msgstr "Párás"
+
+#: id:33024
+msgid "Feels"
+msgstr "Érzet"
+
+#: id:33025
+msgid "Observed"
+msgstr "Megtekintett"
+
+#: id:33026
+msgid "Departure from normal"
+msgstr "Eltérés a megszokottól"
+
+#: id:33027
+msgid "Sunrise"
+msgstr "Napfelkelte"
+
+#: id:33028
+msgid "Sunset"
+msgstr "Naplemente"
+
+#: id:33029
+msgid "Details"
+msgstr "Részletek"
+
+#: id:33030
+msgid "Outlook"
+msgstr "Összefoglaló"
+
+#: id:33031
+msgid "Coverflow"
+msgstr "Borítófolyam"
+
+#: id:33032
+msgid "Translate text"
+msgstr "Szöveg lefordítása"
+
+#: id:33033
+msgid "Map list %s category"
+msgstr "Listázás %s kategória"
+
+#: id:33034
+msgid "36 Hour"
+msgstr "36 órás"
+
+#: id:33035
+msgid "Maps"
+msgstr "Térképek"
+
+#: id:33036
+msgid "Hourly"
+msgstr "Óránként"
+
+#: id:33037
+msgid "Weekend"
+msgstr "Hétvége"
+
+#: id:33038
+msgid "%s day"
+msgstr "%s nap"
+
+#: id:33049
+msgid "Alert"
+msgstr "Riasztás"
+
+#: id:33050
+msgid "Alerts"
+msgstr "Riasztások"
+
+#: id:33051
+msgid "Choose Your"
+msgstr "Válaszd ki a saját"
+
+#: id:33052
+msgid "Check"
+msgstr "Ellenőrzés"
+
+#: id:33053
+msgctxt "Auto context with id 33053"
+msgid "Configure the"
+msgstr "Állítsd be a(z)"
+
+#: id:33054
+msgid "Seasons"
+msgstr "Évad"
+
+#: id:33055
+msgid "Use your"
+msgstr "Használd"
+
+#: id:33056
+msgid "Watch your"
+msgstr "Nézd"
+
+#: id:33057
+msgid "Listen to"
+msgstr "Hallgasd"
+
+#: id:33058
+msgid "View your"
+msgstr "Megnézd"
+
+#: id:33059
+msgctxt "Auto context with id 33059"
+msgid "Configure the"
+msgstr "Konfiguráld"
+
+#: id:33060
+msgid "Power"
+msgstr "Betáplálás"
+
+#: id:33061
+msgid "Menu"
+msgstr "Menü"
+
+#: id:33062
+msgid "Play the"
+msgstr "Játszd"
+
+#: id:33063
+msgid "Options"
+msgstr "Beállítások"
+
+#: id:33065
+msgid "Editor"
+msgstr "Szerkesztő"
+
+#: id:33066
+msgid "About your"
+msgstr "Erről"
+
+#: id:33067
+msgid "Star rating"
+msgstr "Csillag minősítés"
+
+#: id:33068
+msgid "Background"
+msgstr "Háttér"
+
+#: id:33069
+msgid "Backgrounds"
+msgstr "Hátterek"
+
+#: id:33070
+msgid "Custom background"
+msgstr "Testreszabott háttér"
+
+#: id:33071
+msgid "Custom backgrounds"
+msgstr "Testreszabott hátterek"
+
+#: id:33072
+msgid "View Readme"
+msgstr "Az 'Olvass el' megtekintése"
+
+#: id:33073
+msgid "View Changelog"
+msgstr "Változási napló megtekintése"
+
+#: id:33074
+msgid "This version of %s requires an"
+msgstr "A(z) %s ezen verziójához"
+
+#: id:33075
+msgid "XBMC revision of %s or greater to run."
+msgstr "%s vagy magasabb XBMC verzió szükséges."
+
+#: id:33076
+msgid "Please update XBMC."
+msgstr "Frissítsd az XBMC-t."
+
+#: id:33077
+msgid "No data found!"
+msgstr "Nincs adat!"
+
+#: id:33078
+msgid "Next page"
+msgstr "Következő oldal"
+
+#: id:33079
+msgid "Love"
+msgstr "Szeretem"
+
+#: id:33080
+msgid "Hate"
+msgstr "Utálom"
+
+#: id:33081
+msgid "This file is stacked, select the part you want to play from."
+msgstr "Ez egy egyesített fájl, melyik részt akarod játszani?"
+
+#: id:33082
+msgid "Path to script"
+msgstr "Program útvonal"
+
+#: id:33083
+msgid "Enable custom script button"
+msgstr "Egyedi program gomb engedélyezése"
+
+#: id:33100
+msgid "Failed to start"
+msgstr "Elindítás meghiúsult"
+
+#: id:33101
+msgid "Webserver"
+msgstr "Webkiszolgáló"
+
+#: id:33102
+msgid "Event Server"
+msgstr "Eseménykiszolgáló"
+
+#: id:33103
+msgid "Remote communication server"
+msgstr "Távoli kommunikációs kiszolgáló"
+
+#: id:33200
+msgid "Detected New Connection"
+msgstr "Új kapcsolatot észleltem"
+
+#: id:34000
+msgid "Lame"
+msgstr ""
+
+#: id:34001
+msgid "Vorbis"
+msgstr ""
+
+#: id:34002
+msgid "Wav"
+msgstr ""
+
+#: id:34003
+msgid "DXVA2"
+msgstr ""
+
+#: id:34004
+msgid "VAAPI"
+msgstr ""
+
+#: id:34005
+msgid "Flac"
+msgstr ""
+
+#: id:34100
+msgid "Speaker Configuration"
+msgstr "Hangfalkiépítés"
+
+#: id:34101
+msgid "2.0"
+msgstr ""
+
+#: id:34102
+msgid "2.1"
+msgstr ""
+
+#: id:34103
+msgid "3.0"
+msgstr ""
+
+#: id:34104
+msgid "3.1"
+msgstr ""
+
+#: id:34105
+msgid "4.0"
+msgstr ""
+
+#: id:34106
+msgid "4.1"
+msgstr ""
+
+#: id:34107
+msgid "5.0"
+msgstr ""
+
+#: id:34108
+msgid "5.1"
+msgstr ""
+
+#: id:34109
+msgid "7.0"
+msgstr ""
+
+#: id:34110
+msgid "7.1"
+msgstr ""
+
+#: id:34201
+msgid "Can't find a next item to play"
+msgstr "Nincs következő lejátszandó elem"
+
+#: id:34202
+msgid "Can't find a previous item to play"
+msgstr "Nincs előző lejátszandó elem"
+
+#: id:34300
+msgid "Failed to start zeroconf"
+msgstr "A zeroconf elindítása nem sikerült"
+
+#: id:34301
+msgid "Is Apple's Bonjour Service installed? See log for more info."
+msgstr "Biztos, hogy az Apple Bonjour Service telepítve van? (Részletes információ a naplóban)"
+
+#: id:34400
+msgid "Video Rendering"
+msgstr "Video leképező rendszer hiba"
+
+#: id:34401
+msgid "Failed to init video filters/scalers, falling back to bilinear scaling"
+msgstr "Az átméretező (scaler) nem használható, visszaállva a bilinear eljárásra"
+
+#: id:34402
+msgid "Failed to initialize audio device"
+msgstr "A beállított hangeszköz nem használható"
+
+#: id:34403
+msgid "Check your audiosettings"
+msgstr "Ellenőrizd a hangbeállításokat"
+
+#: id:34404
+msgid "Use gestures for navigation:"
+msgstr ""
+
+#: id:34405
+msgid "1 finger swipe left,right,up,down for cursors"
+msgstr ""
+
+#: id:34406
+msgid "2 finger swipe left for backspace"
+msgstr ""
+
+#: id:34407
+msgid "1 finger single tap for enter"
+msgstr ""
+
+#: id:34408
+msgid "2 finger single tap for contextmenu"
+msgstr ""
+
+#: id:35000
+msgid "Peripherals"
+msgstr "Perifériák"
+
+#: id:35001
+msgid "Generic HID device"
+msgstr "Szabványos HID eszköz"
+
+#: id:35002
+msgid "Generic network adapter"
+msgstr "Szabványos hálózati adapter"
+
+#: id:35003
+msgid "Generic disk"
+msgstr "Szabványos lemez"
+
+#: id:35004
+msgid "There are no settings available\nfor this peripheral."
+msgstr "Ehez a perifériához\nnem tartozik beállítás."
+
+#: id:35005
+msgid "New device configured"
+msgstr "Új eszköz lett beállítva"
+
+#: id:35006
+msgid "Device removed"
+msgstr "Az eszközt eltávolították"
+
+#: id:35007
+msgid "Keymap to use for this device"
+msgstr "Használt billentyűzetkiosztás ehhez az eszközhöz"
+
+#: id:35008
+msgid "Keymap enabled"
+msgstr "Billentyűzetkiosztás engedélyezve"
+
+#: id:35009
+msgid "Do not use the custom keymap for this device"
+msgstr ""
+
+#: id:35500
+msgid "Location"
+msgstr "Hely"
+
+#: id:35501
+msgid "Class"
+msgstr "Osztály"
+
+#: id:35502
+msgctxt "Auto context with id 35502"
+msgid "Name"
+msgstr "Név"
+
+#: id:35503
+msgid "Vendor"
+msgstr "Gyártó"
+
+#: id:35504
+msgid "Product ID"
+msgstr "Gyári szám"
+
+#: id:36000
+msgid "Pulse-Eight CEC adapter"
+msgstr "Pulse-Eight CEC adapter"
+
+#: id:36001
+msgid "Pulse-Eight Nyxboard"
+msgstr "Pulse-Eight Nyxboard"
+
+#: id:36002
+msgid "Switch to keyboard side command"
+msgstr "Váltás billentyû parancsra"
+
+#: id:36003
+msgid "Switch to remote side command"
+msgstr "Váltás távirányító parancsra"
+
+#: id:36004
+msgid "Press \"user\" button command"
+msgstr "Nyomd meg a \"felhasználó\" gomb parancsot"
+
+#: id:36005
+msgid "Enable switch side commands"
+msgstr "Kapcsoló parancsok engedélyezése"
+
+#: id:36006
+msgid "Could not open the adapter"
+msgstr "Adapter megnyitása sikertelen"
+
+#: id:36007
+msgid "Devices to power on when starting XBMC"
+msgstr "TV bekapcsolása XBMC elindításával"
+
+#: id:36008
+msgid "Devices to power off when stopping XBMC"
+msgstr "TV kikapcsolása XBMC leállításával"
+
+#: id:36009
+msgid "Put devices in standby mode when activating screensaver"
+msgstr "Képernyővédő bekapcsolásával az eszközöket készenléti módba helyezni"
+
+#: id:36011
+msgid "Could not detect the CEC port. Set it up manually."
+msgstr "A CEC csatlakozó nem található. Állítsd be manuálisan."
+
+#: id:36012
+msgid "Could not initialise the CEC adapter. Check your settings."
+msgstr "A CEC adapter nem található."
+
+#: id:36013
+msgid "Unsupported libCEC interface version. %d is greater than the version XBMC supports (%d)"
+msgstr "Nem támogatott libcec csatoló verzió. %d nagyobb mint amit az XBMC támogat (%d)"
+
+#: id:36014
+msgid "Put this PC in standby mode when the TV is switched off"
+msgstr "A Média Center készenléti módba helyezése, a TV kikapcsolásával"
+
+#: id:36015
+msgid "HDMI port number"
+msgstr "HDMI csatlakozó száma"
+
+#: id:36016
+msgctxt "Auto context with id 36016"
+msgid "Connected"
+msgstr "Csatlakozva"
+
+#: id:36017
+msgid "Adapter found, but libCEC is not available"
+msgstr "Az adaptert megtaláltam, de a libcec nem elérhető"
+
+#: id:36018
+msgid "Use the TV's language setting"
+msgstr "A TV nyelvi beállításainak használata"
+
+#: id:36019
+msgid "Connected to HDMI device"
+msgstr ""
+
+#: id:36020
+msgid "Make XBMC the active source when starting"
+msgstr ""
+
+#: id:36021
+msgid "Physical address (overrules HDMI port)"
+msgstr ""
+
+#: id:36022
+msgid "COM port (leave empty unless needed)"
+msgstr ""
+
+#: id:36023
+msgid "Configuration updated"
+msgstr ""
+
+#: id:36024
+msgid "Failed to set the new configuration. Please check your settings."
+msgstr ""
+
+#: id:36025
+msgid "Send 'inactive source' command when stopping XBMC"
+msgstr ""
+

--- a/language/Icelandic/strings.po
+++ b/language/Icelandic/strings.po
@@ -1,0 +1,9093 @@
+# Converted from xbmc strings.xml with xbmc-xml2po (by Team-XBMC)
+msgid ""
+msgstr ""
+"Project-Id-Version: xbmc.core-FRODO_GIT3ed1604ad7\n"
+"Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
+"POT-Creation-Date: 2012-04-09 18:00+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE\n"
+"Language: is\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: id:0
+msgctxt "Auto context with id 0"
+msgid "Programs"
+msgstr "Forrit"
+
+#: id:1
+msgctxt "Auto context with id 1"
+msgid "Pictures"
+msgstr "Ljósmyndir"
+
+#: id:2
+msgctxt "Auto context with id 2"
+msgid "Music"
+msgstr "Tónlist"
+
+#: id:3
+msgctxt "Auto context with id 3"
+msgid "Videos"
+msgstr "Myndefni"
+
+#: id:4
+msgid "TV-Guide"
+msgstr "Sjónvarpsvísir"
+
+#: id:5
+msgctxt "Auto context with id 5"
+msgid "Settings"
+msgstr "Stillingar"
+
+#: id:6
+msgid "XBMC SVN"
+msgstr "XBMC SVN"
+
+#: id:7
+msgctxt "Auto context with id 7"
+msgid "File manager"
+msgstr "Skráarsýsl"
+
+#: id:8
+msgctxt "Auto context with id 8"
+msgid "Weather"
+msgstr "Veður"
+
+#: id:9
+msgid "xbmc media center"
+msgstr "xbmc media center"
+
+#: id:11
+msgid "Monday"
+msgstr "Mánudagur"
+
+#: id:12
+msgid "Tuesday"
+msgstr "Þriðjudagur"
+
+#: id:13
+msgid "Wednesday"
+msgstr "Miðvikudagur"
+
+#: id:14
+msgid "Thursday"
+msgstr "Fimmtudagur"
+
+#: id:15
+msgid "Friday"
+msgstr "Föstudagur"
+
+#: id:16
+msgid "Saturday"
+msgstr "Laugardagur"
+
+#: id:17
+msgid "Sunday"
+msgstr "Sunnudagur"
+
+#: id:21
+msgid "January"
+msgstr "janúar"
+
+#: id:22
+msgid "February"
+msgstr "febrúar"
+
+#: id:23
+msgid "March"
+msgstr "mars"
+
+#: id:24
+msgid "April"
+msgstr "apríl"
+
+#: id:25
+msgctxt "Auto context with id 25"
+msgid "May"
+msgstr "maí"
+
+#: id:26
+msgid "June"
+msgstr "júní"
+
+#: id:27
+msgid "July"
+msgstr "júlí"
+
+#: id:28
+msgid "August"
+msgstr "ágúst"
+
+#: id:29
+msgid "September"
+msgstr "september"
+
+#: id:30
+msgid "October"
+msgstr "október"
+
+#: id:31
+msgid "November"
+msgstr "nóvember"
+
+#: id:32
+msgid "December"
+msgstr "desember"
+
+#: id:41
+msgid "Mon"
+msgstr "Mán"
+
+#: id:42
+msgid "Tue"
+msgstr "Þri"
+
+#: id:43
+msgid "Wed"
+msgstr "Mið"
+
+#: id:44
+msgid "Thu"
+msgstr "Fim"
+
+#: id:45
+msgid "Fri"
+msgstr "Fös"
+
+#: id:46
+msgid "Sat"
+msgstr "Lau"
+
+#: id:47
+msgctxt "Auto context with id 47"
+msgid "Sun"
+msgstr "Sun"
+
+#: id:51
+msgid "Jan"
+msgstr "jan"
+
+#: id:52
+msgid "Feb"
+msgstr "feb"
+
+#: id:53
+msgid "Mar"
+msgstr "mar"
+
+#: id:54
+msgid "Apr"
+msgstr "apr"
+
+#: id:55
+msgctxt "Auto context with id 55"
+msgid "May"
+msgstr "maí"
+
+#: id:56
+msgid "Jun"
+msgstr "jún"
+
+#: id:57
+msgid "Jul"
+msgstr "júl"
+
+#: id:58
+msgid "Aug"
+msgstr "ágú"
+
+#: id:59
+msgid "Sep"
+msgstr "sep"
+
+#: id:60
+msgid "Oct"
+msgstr "okt"
+
+#: id:61
+msgid "Nov"
+msgstr "nóv"
+
+#: id:62
+msgid "Dec"
+msgstr "des"
+
+#: id:71
+msgid "N"
+msgstr "N"
+
+#: id:72
+msgid "NNE"
+msgstr "NNA"
+
+#: id:73
+msgid "NE"
+msgstr "NA"
+
+#: id:74
+msgid "ENE"
+msgstr "ANA"
+
+#: id:75
+msgid "E"
+msgstr "A"
+
+#: id:76
+msgid "ESE"
+msgstr "ASA"
+
+#: id:77
+msgid "SE"
+msgstr "SA"
+
+#: id:78
+msgid "SSE"
+msgstr "SSA"
+
+#: id:79
+msgid "S"
+msgstr "S"
+
+#: id:80
+msgid "SSW"
+msgstr "SSV"
+
+#: id:81
+msgid "SW"
+msgstr "SV"
+
+#: id:82
+msgid "WSW"
+msgstr "VSV"
+
+#: id:83
+msgid "W"
+msgstr "V"
+
+#: id:84
+msgid "WNW"
+msgstr "VNV"
+
+#: id:85
+msgid "NW"
+msgstr "NV"
+
+#: id:86
+msgid "NNW"
+msgstr "NNV"
+
+#: id:87
+msgid "VAR"
+msgstr "VAR"
+
+#: id:98
+msgid "View: Auto"
+msgstr "Útlit: Sjálfvirkt"
+
+#: id:99
+msgid "View: Auto big"
+msgstr "Útlit: Sjálfvirkt stórt"
+
+#: id:100
+msgid "View: Icons"
+msgstr "Sjá sem: Tákn"
+
+#: id:101
+msgid "View: List"
+msgstr "Sjá sem: Lista"
+
+#: id:102
+msgctxt "Auto context with id 102"
+msgid "Scan"
+msgstr "Skanna"
+
+#: id:103
+msgctxt "Auto context with id 103"
+msgid "Sort by: Name"
+msgstr "Raða eftir: Nafni"
+
+#: id:104
+msgid "Sort by: Date"
+msgstr "Raða eftir: Dags."
+
+#: id:105
+msgid "Sort by: Size"
+msgstr "Raða eftir: Stærð"
+
+#: id:106
+msgid "No"
+msgstr "Nei"
+
+#: id:107
+msgid "Yes"
+msgstr "Já"
+
+#: id:108
+msgctxt "Auto context with id 108"
+msgid "Slideshow"
+msgstr "Myndasýning"
+
+#: id:109
+msgid "Create thumbs"
+msgstr "Gera smámyndir"
+
+#: id:110
+msgid "Create thumbnails"
+msgstr "Gera smámyndir"
+
+#: id:111
+msgctxt "Auto context with id 111"
+msgid "Shortcuts"
+msgstr "Flýtival"
+
+#: id:112
+msgid "Paused"
+msgstr "Í bið"
+
+#: id:113
+msgid "Update failed"
+msgstr "Uppfærsla mistókst"
+
+#: id:114
+msgid "Installation failed"
+msgstr "Uppsetning mistókst"
+
+#: id:115
+msgid "Copy"
+msgstr "Afrita"
+
+#: id:116
+msgid "Move"
+msgstr "Færa"
+
+#: id:117
+msgid "Delete"
+msgstr "Eyða"
+
+#: id:118
+msgid "Rename"
+msgstr "Endurnefna"
+
+#: id:119
+msgid "New folder"
+msgstr "Ný mappa"
+
+#: id:120
+msgid "Confirm file copy"
+msgstr "Staðfesta afritun"
+
+#: id:121
+msgid "Confirm file move"
+msgstr "Staðfesta færslu"
+
+#: id:122
+msgid "Confirm file delete?"
+msgstr "Staðfesta eyðingu á skrá?"
+
+#: id:123
+msgid "Copy these files?"
+msgstr "Afrita þessar skrár?"
+
+#: id:124
+msgid "Move these files?"
+msgstr "Færa þessar skrár?"
+
+#: id:125
+msgid "Delete these files? - Deleting files cannot be undone!"
+msgstr "Eyða þessum skrám? - Ekki er hægt að afturkalla þessa aðgerð!"
+
+#: id:126
+msgid "Status"
+msgstr "Staða"
+
+#: id:127
+msgid "Objects"
+msgstr "Hlutir"
+
+#: id:128
+msgctxt "Auto context with id 128"
+msgid "General"
+msgstr "Almennt"
+
+#: id:129
+msgctxt "Auto context with id 129"
+msgid "Slideshow"
+msgstr "Myndasýning"
+
+#: id:130
+msgctxt "Auto context with id 130"
+msgid "System info"
+msgstr "Kerfisupplýsingar"
+
+#: id:131
+msgid "Display"
+msgstr "Skjár"
+
+#: id:132
+msgid "Albums"
+msgstr "Hljómplötur"
+
+#: id:133
+msgid "Artists"
+msgstr "Tónlistarmenn"
+
+#: id:134
+msgid "Songs"
+msgstr "Lög"
+
+#: id:135
+msgid "Genres"
+msgstr "Flokkar"
+
+#: id:136
+msgid "Playlists"
+msgstr "Spilunarlistar"
+
+#: id:137
+msgid "Search"
+msgstr "Leita"
+
+#: id:138
+msgid "System Information"
+msgstr "Kerfisupplýsingar"
+
+#: id:139
+msgid "Temperatures:"
+msgstr "Hitastig:"
+
+#: id:140
+msgid "CPU:"
+msgstr "CPU:"
+
+#: id:141
+msgid "GPU:"
+msgstr "GPU:"
+
+#: id:142
+msgid "Time:"
+msgstr "Klukka:"
+
+#: id:143
+msgid "Current:"
+msgstr "Núna:"
+
+#: id:144
+msgid "Build:"
+msgstr "Útgáfa:"
+
+#: id:145
+msgid "Network:"
+msgstr "Netumhverfi:"
+
+#: id:146
+msgid "Type:"
+msgstr "Tegund:"
+
+#: id:147
+msgid "Static"
+msgstr "Föst"
+
+#: id:148
+msgid "DHCP"
+msgstr "DHCP"
+
+#: id:149
+msgid "MAC address"
+msgstr "MAC vistfang"
+
+#: id:150
+msgctxt "Auto context with id 150"
+msgid "IP address"
+msgstr "IP tala"
+
+#: id:151
+msgid "Link:"
+msgstr "Tenging:"
+
+#: id:152
+msgid "Half duplex"
+msgstr "Einstefna"
+
+#: id:153
+msgid "Full duplex"
+msgstr "Tvístefna"
+
+#: id:154
+msgctxt "Auto context with id 154"
+msgid "Storage"
+msgstr "Geymslurými"
+
+#: id:155
+msgid "Drive"
+msgstr "Drif"
+
+#: id:156
+msgctxt "Auto context with id 156"
+msgid "Free"
+msgstr "Laust"
+
+#: id:157
+msgctxt "Auto context with id 157"
+msgid "Video"
+msgstr "Mynd"
+
+#: id:158
+msgid "Free memory"
+msgstr "Laust minni"
+
+#: id:159
+msgid "No link"
+msgstr "Engin tenging"
+
+#: id:160
+msgctxt "Auto context with id 160"
+msgid "Free"
+msgstr "Laust"
+
+#: id:161
+msgid "Unavailable"
+msgstr "Ófáanlegt"
+
+#: id:162
+msgid "Tray open"
+msgstr "Bakki opinn"
+
+#: id:163
+msgid "Reading"
+msgstr "Les"
+
+#: id:164
+msgid "No disc"
+msgstr "Enginn diskur"
+
+#: id:165
+msgid "Disc present"
+msgstr "Diskur í bakka"
+
+#: id:166
+msgid "Skin"
+msgstr "Útlit"
+
+#: id:169
+msgctxt "Auto context with id 169"
+msgid "Resolution"
+msgstr "Upplausn"
+
+#: id:170
+msgid "Adjust display refresh rate to match video"
+msgstr "Stilla glæðningartíðni til að passa við myndefni"
+
+#: id:172
+msgid "Release date"
+msgstr "Útgáfudagur"
+
+#: id:173
+msgid "Display 4:3 videos as"
+msgstr "Sýna 4:3 myndefni sem"
+
+#: id:175
+msgid "Moods"
+msgstr "Tónar"
+
+#: id:176
+msgid "Styles"
+msgstr "Stílar"
+
+#: id:179
+msgid "Song"
+msgstr "Lag"
+
+#: id:180
+msgid "Duration"
+msgstr "Lengd"
+
+#: id:181
+msgid "Select album"
+msgstr "Veldu hljómplötu"
+
+#: id:182
+msgid "Tracks"
+msgstr "Lög"
+
+#: id:183
+msgid "Review"
+msgstr "Umsögn"
+
+#: id:184
+msgid "Refresh"
+msgstr "Endurlesa"
+
+#: id:185
+msgid "Searching album"
+msgstr "Leita að hljómplötu"
+
+#: id:186
+msgid "OK"
+msgstr "Í lagi"
+
+#: id:187
+msgid "No albums found!"
+msgstr "Engar hljómplötur fundust!"
+
+#: id:188
+msgid "Select all"
+msgstr "Velja allt"
+
+#: id:189
+msgid "Scanning media info"
+msgstr "Skoða upplýsingar"
+
+#: id:190
+msgid "Save"
+msgstr "Vista"
+
+#: id:191
+msgid "Shuffle"
+msgstr "Endurraða"
+
+#: id:192
+msgctxt "Auto context with id 192"
+msgid "Clear"
+msgstr "Hreinsa"
+
+#: id:193
+msgctxt "Auto context with id 193"
+msgid "Scan"
+msgstr "Leita"
+
+#: id:194
+msgid "Searching..."
+msgstr "Leitar..."
+
+#: id:195
+msgid "No info found!"
+msgstr "Engar upplýsingar fundust!"
+
+#: id:196
+msgid "Select movie:"
+msgstr "Veldu kvikmynd:"
+
+#: id:197
+msgid "Querying %s info"
+msgstr "Sæki %s upplýsingar"
+
+#: id:198
+msgid "Loading movie details"
+msgstr "Sæki upplýsingar um mynd"
+
+#: id:199
+msgid "Web interface"
+msgstr "Vefviðmót"
+
+#: id:202
+msgid "Tagline"
+msgstr "Undirtitill"
+
+#: id:203
+msgid "Plot outline"
+msgstr "Söguþráður"
+
+#: id:205
+msgid "Votes"
+msgstr "Atkvæði"
+
+#: id:206
+msgid "Cast"
+msgstr "Leikarar"
+
+#: id:207
+msgid "Plot"
+msgstr "Söguþráður"
+
+#: id:208
+msgctxt "Auto context with id 208"
+msgid "Play"
+msgstr "Spila"
+
+#: id:209
+msgid "Next"
+msgstr "Næst"
+
+#: id:210
+msgid "Previous"
+msgstr "Fyrra"
+
+#: id:213
+msgid "Calibrate user interface..."
+msgstr "Stilla viðmót..."
+
+#: id:214
+msgid "Video calibration..."
+msgstr "Skjástilling..."
+
+#: id:215
+msgid "Soften"
+msgstr "Mýkja"
+
+#: id:216
+msgid "Zoom amount"
+msgstr "Stækka"
+
+#: id:217
+msgid "Pixel ratio"
+msgstr "Teygja"
+
+#: id:218
+msgid "DVD drive"
+msgstr "DVD drif"
+
+#: id:219
+msgid "Please insert disc"
+msgstr "Setjið disk inn"
+
+#: id:220
+msgid "Remote share"
+msgstr "Fjarlæg geymsla"
+
+#: id:221
+msgid "Network is not connected"
+msgstr "Netkerfi ótengt"
+
+#: id:222
+msgid "Cancel"
+msgstr "Hætta við"
+
+#: id:224
+msgid "Speed"
+msgstr "Hraði"
+
+#: id:225
+msgid "Vertical Shift"
+msgstr "Lóðrétt hliðrun"
+
+#: id:226
+msgid "Test patterns..."
+msgstr "Prufumynstur..."
+
+#: id:227
+msgid "Lookup audio CD track names from freedb.org"
+msgstr "Sækja upplýsingar um tónlistardiska frá freedb.org"
+
+#: id:228
+msgid "Shuffle playlist on load"
+msgstr "Endurraða spilunarlista í byrjun"
+
+#: id:229
+msgid "HDD spindown time"
+msgstr "Hvíldartími harðdisks"
+
+#: id:230
+msgid "Video filters"
+msgstr "Myndasíur"
+
+#: id:231
+msgctxt "Auto context with id 231"
+msgid "None"
+msgstr "Ekkert"
+
+#: id:232
+msgid "Point"
+msgstr "Punkta"
+
+#: id:233
+msgid "Linear"
+msgstr "Línulegur"
+
+#: id:234
+msgid "Anisotropic"
+msgstr "Anisotropic"
+
+#: id:235
+msgid "Quincunx"
+msgstr "Quincunx"
+
+#: id:236
+msgid "Gaussian cubic"
+msgstr "Gaussian Cubic"
+
+#: id:237
+msgid "Minification"
+msgstr "Minnkun"
+
+#: id:238
+msgid "Magnification"
+msgstr "Stækkun"
+
+#: id:239
+msgid "Clear playlist on finish"
+msgstr "Hreinsa spilunarlista við enda"
+
+#: id:240
+msgid "Display Mode"
+msgstr "Skjáhamur"
+
+#: id:241
+msgid "Full Screen #%d"
+msgstr "Fylla skjá #%d"
+
+#: id:242
+msgid "Windowed"
+msgstr "Glugga"
+
+#: id:243
+msgid "Refresh Rate"
+msgstr "Glæðingartíðni"
+
+#: id:244
+msgid "Full screen"
+msgstr "Fylla skjá"
+
+#: id:245
+msgid "Sizing: (%i,%i)->(%i,%i) (Zoom x%2.2f) AR:%2.2f:1 (Pixels: %2.2f:1) (VShift: %2.2f)"
+msgstr "Stærðir: (%i,%i)->(%i,%i) (Aðdráttur x%2.2f) AR:%2.2f:1 (Punktar: %2.2f:1) (Lóð.hliðrun: %2.2f)"
+
+#: id:247
+msgctxt "Auto context with id 247"
+msgid "Scripts"
+msgstr "Skriftur"
+
+#: id:248
+msgctxt "Auto context with id 248"
+msgid "Language"
+msgstr "Tungumál"
+
+#: id:249
+msgctxt "Auto context with id 249"
+msgid "Music"
+msgstr "Tónlist"
+
+#: id:250
+msgctxt "Auto context with id 250"
+msgid "Visualization"
+msgstr "Myndskreyting"
+
+#: id:251
+msgid "Select destination directory"
+msgstr "Veldu ákvörðunarstað"
+
+#: id:252
+msgid "Output stereo to all speakers"
+msgstr "Senda í alla hátalara"
+
+#: id:253
+msgid "Number of channels"
+msgstr "Fjöldi rása"
+
+#: id:254
+msgid "- DTS capable receiver"
+msgstr "- DTS móttakari"
+
+#: id:255
+msgid "CDDB"
+msgstr "CDDB"
+
+#: id:256
+msgid "Fetching CD information"
+msgstr "Sæki upplýsingar um geisladisk"
+
+#: id:257
+msgid "Error"
+msgstr "Villa"
+
+#: id:258
+msgid "Enable tag reading"
+msgstr "Virkja að lesa merkingar"
+
+#: id:259
+msgid "Opening"
+msgstr "Opna"
+
+#: id:260
+msgid "Shoutcast"
+msgstr "Shoutcast"
+
+#: id:261
+msgid "Waiting for start..."
+msgstr "Bíð eftir upphafi..."
+
+#: id:262
+msgid "Scripts output"
+msgstr "Skriftuúttak"
+
+#: id:263
+msgid "Allow control of XBMC via HTTP"
+msgstr "Leyfa stjórnun á XBMC með HTTP"
+
+#: id:264
+msgid "Record"
+msgstr "Taka upp"
+
+#: id:265
+msgid "Stop Rec."
+msgstr "Stöðva upptöku"
+
+#: id:266
+msgid "Sort by: Track"
+msgstr "Flokka eftir: Lagi"
+
+#: id:267
+msgid "Sort by: Time"
+msgstr "Flokka eftir: Tíma"
+
+#: id:268
+msgid "Sort by: Title"
+msgstr "Flokka eftir: Titli"
+
+#: id:269
+msgid "Sort by: Artist"
+msgstr "Flokka eftir: Listamanni"
+
+#: id:270
+msgid "Sort by: Album"
+msgstr "Flokka eftir: Hljómplötu"
+
+#: id:271
+msgid "Top 100"
+msgstr "Topp 100"
+
+#: id:272
+msgid "Top-Left overscan compensation"
+msgstr "Efri-vinstri yfirflóðsjöfnun"
+
+#: id:273
+msgid "Bottom-Right overscan compensation"
+msgstr "Neðri-hægri yfirflóðsjöfnun"
+
+#: id:274
+msgid "Subtitle positioning"
+msgstr "Staðsetning þýðingartexta"
+
+#: id:275
+msgid "Pixel ratio adjustment"
+msgstr "Stillingar skjápunktahlutfalla"
+
+#: id:276
+msgid "Adjust the arrow to change the amount of overscan"
+msgstr "Færðu örina til að breyta yfirflóði myndar"
+
+#: id:277
+msgid "Adjust the bar to change the subtitles position"
+msgstr "Færðu strikið til að breyta staðsetningu þýðingartexta"
+
+#: id:278
+msgid "Adjust the rectangle so it is perfectly square"
+msgstr "Breyttu ferhyrningnum þar til hliðarnar eru jafnar"
+
+#: id:279
+msgid "Unable to load settings"
+msgstr "Gat ekki hlaðið inn stillingum"
+
+#: id:280
+msgid "Using default settings"
+msgstr "Nota sjálfgefin gildi"
+
+#: id:281
+msgid "Please check the XML files"
+msgstr "Vinsamlegast athugið XML skrár"
+
+#: id:282
+msgid "Found %i items"
+msgstr "Fann %i atriði"
+
+#: id:283
+msgid "Search results"
+msgstr "Leitarniðurstöður"
+
+#: id:284
+msgid "No results found"
+msgstr "Ekkert fannst"
+
+#: id:287
+msgctxt "Auto context with id 287"
+msgid "Subtitles"
+msgstr "Þýðingartextar"
+
+#: id:288
+msgctxt "Auto context with id 288"
+msgid "Font"
+msgstr "Leturgerð"
+
+#: id:289
+msgctxt "Auto context with id 289"
+msgid "- Size"
+msgstr "- Stærð"
+
+#: id:290
+msgid "Dynamic range compression"
+msgstr "Samþjappa tónsviði"
+
+#: id:291
+msgctxt "Auto context with id 291"
+msgid "Video"
+msgstr "Mynd"
+
+#: id:292
+msgctxt "Auto context with id 292"
+msgid "Audio"
+msgstr "Hljóð"
+
+#: id:293
+msgid "Browse for subtitles"
+msgstr "Þýðingartextar"
+
+#: id:294
+msgid "Create bookmark"
+msgstr "Búa til bókamerki"
+
+#: id:296
+msgid "Clear bookmarks"
+msgstr "Hreinsa bókamerki"
+
+#: id:297
+msgid "Audio offset"
+msgstr "Hliðra hljóði"
+
+#: id:298
+msgid "Bookmarks"
+msgstr "Bókamerki"
+
+#: id:299
+msgid "- AAC capable receiver"
+msgstr "- AAC móttakari"
+
+#: id:300
+msgid "- MP1 capable receiver"
+msgstr "- MP1 móttakari"
+
+#: id:301
+msgid "- MP2 capable receiver"
+msgstr "- MP2 móttakari"
+
+#: id:302
+msgid "- MP3 capable receiver"
+msgstr "- MP3 móttakari"
+
+#: id:303
+msgid "Delay"
+msgstr "Bið"
+
+#: id:304
+msgctxt "Auto context with id 304"
+msgid "Language"
+msgstr "Tungumál"
+
+#: id:305
+msgctxt "Auto context with id 305"
+msgid "Enabled"
+msgstr "Virkt"
+
+#: id:306
+msgid "Non-interleaved"
+msgstr "Ekki önnur hver lína"
+
+#: id:312
+msgid "(0=auto)"
+msgstr "(0=sjálfv.)"
+
+#: id:313
+msgid "Cleaning database"
+msgstr "Hreinsa gagnagrunn"
+
+#: id:314
+msgid "Preparing..."
+msgstr "Undirbý..."
+
+#: id:315
+msgid "Database error"
+msgstr "Gagnagrunnsvilla"
+
+#: id:316
+msgid "Searching songs..."
+msgstr "Leita í lögum..."
+
+#: id:317
+msgid "Cleaned database successfully"
+msgstr "Hreinsun tókst"
+
+#: id:318
+msgid "Cleaning songs..."
+msgstr "Hreinsa lög..."
+
+#: id:319
+msgid "Error cleaning songs"
+msgstr "Villa við hreinsun laga"
+
+#: id:320
+msgid "Cleaning artists..."
+msgstr "Hreinsa í listamönnum..."
+
+#: id:321
+msgid "Error cleaning artists"
+msgstr "Villa við endurröðun listamanna"
+
+#: id:322
+msgid "Cleaning genres..."
+msgstr "Hreinsa tegundir..."
+
+#: id:323
+msgid "Error cleaning genres"
+msgstr "Villa við hreinsun tegunda"
+
+#: id:324
+msgid "Cleaning paths..."
+msgstr "Hreinsa slóðir..."
+
+#: id:325
+msgid "Error cleaning paths"
+msgstr "Villa við hreinsun slóða"
+
+#: id:326
+msgid "Cleaning albums..."
+msgstr "Hreinsa hljómplötur..."
+
+#: id:327
+msgid "Error cleaning albums"
+msgstr "Villa við hreinsun platna"
+
+#: id:328
+msgid "Writing changes..."
+msgstr "Vista breytingar..."
+
+#: id:329
+msgid "Error writing changes"
+msgstr "Villa við vistun breytinga"
+
+#: id:330
+msgid "This may take some time..."
+msgstr "Gæti tekið sinn tíma..."
+
+#: id:331
+msgid "Compressing database..."
+msgstr "Þjappa gagnagrunni..."
+
+#: id:332
+msgid "Error compressing database"
+msgstr "Villa við þjöppun gagnagrunns"
+
+#: id:333
+msgid "Do you want to clean the library?"
+msgstr "Viltu hreinsa til í safninu?"
+
+#: id:334
+msgid "Clean library..."
+msgstr "Hreinsa til í safni..."
+
+#: id:335
+msgid "Start"
+msgstr "Byrja"
+
+#: id:336
+msgid "Framerate conversion"
+msgstr "Stilla rammafjölda"
+
+#: id:337
+msgctxt "Auto context with id 337"
+msgid "Audio output"
+msgstr "Hljóðútgangur"
+
+#: id:338
+msgid "Analog"
+msgstr "Hliðrænt"
+
+#: id:339
+msgid "Optical/Coax"
+msgstr "Stafrænt"
+
+#: id:340
+msgid "Various artists"
+msgstr "Ýmsir flytjendur"
+
+#: id:341
+msgid "Play disc"
+msgstr "Spila disk"
+
+#: id:342
+msgctxt "Auto context with id 342"
+msgid "Movies"
+msgstr "Kvikmyndir"
+
+#: id:343
+msgid "Adjust framerate"
+msgstr "Stilla rammafjölda"
+
+#: id:344
+msgid "Actors"
+msgstr "Leikarar"
+
+#: id:345
+msgctxt "Auto context with id 345"
+msgid "Year"
+msgstr "Ár"
+
+#: id:346
+msgid "Boost volume level on downmix"
+msgstr "Magna hljóðstyrk við endurblöndun"
+
+#: id:350
+msgctxt "Auto context with id 350"
+msgid "Programs"
+msgstr "Forrit"
+
+#: id:351
+msgctxt "Auto context with id 351"
+msgid "Off"
+msgstr "Slökkt"
+
+#: id:352
+msgid "Dim"
+msgstr "Dekkja"
+
+#: id:353
+msgid "Black"
+msgstr "Svart"
+
+#: id:354
+msgid "Matrix trails"
+msgstr "Matrix línur"
+
+#: id:355
+msgid "Screensaver time"
+msgstr "Biðtími skjávara"
+
+#: id:356
+msgid "Screensaver mode"
+msgstr "Skjávari"
+
+#: id:357
+msgid "Shutdown function timer"
+msgstr "Slökkt eftir"
+
+#: id:358
+msgid "All albums"
+msgstr "Allar hljómplötur"
+
+#: id:359
+msgid "Recently added albums"
+msgstr "Nýlegar hljómplötur"
+
+#: id:360
+msgctxt "Auto context with id 360"
+msgid "Screensaver"
+msgstr "Skjávari"
+
+#: id:361
+msgid "R. Slideshow"
+msgstr "End. myndasýningu"
+
+#: id:362
+msgid "Screensaver dim level"
+msgstr "Myrkvun skjávara"
+
+#: id:363
+msgid "Sort by: File"
+msgstr "Raða eftir: Skrá"
+
+#: id:364
+msgid "- Dolby Digital (AC3) capable receiver"
+msgstr "- Dolby Digital (AC3) móttakari"
+
+#: id:365
+msgctxt "Auto context with id 365"
+msgid "Sort by: Name"
+msgstr "Raða eftir: Nafni"
+
+#: id:366
+msgid "Sort by: Year"
+msgstr "Raða eftir: Ártali"
+
+#: id:367
+msgid "Sort by: Rating"
+msgstr "Raða eftir: Einkunn"
+
+#: id:368
+msgid "IMDb"
+msgstr "IMDb"
+
+#: id:369
+msgctxt "Auto context with id 369"
+msgid "Title"
+msgstr "Titill"
+
+#: id:370
+msgid "Thunderstorms"
+msgstr "Þrumuveður"
+
+#: id:371
+msgid "Partly"
+msgstr "Hálf"
+
+#: id:372
+msgid "Mostly"
+msgstr "Að mestu"
+
+#: id:373
+msgid "Sunny"
+msgstr "Sólskin"
+
+#: id:374
+msgid "Cloudy"
+msgstr "Skýjað"
+
+#: id:375
+msgid "Snow"
+msgstr "Snjór"
+
+#: id:376
+msgid "Rain"
+msgstr "Rigning"
+
+#: id:377
+msgid "Light"
+msgstr "Létt"
+
+#: id:378
+msgid "AM"
+msgstr "FH"
+
+#: id:379
+msgid "PM"
+msgstr "EH"
+
+#: id:380
+msgid "Showers"
+msgstr "Skúrir"
+
+#: id:381
+msgid "Few"
+msgstr "Fá"
+
+#: id:382
+msgid "Scattered"
+msgstr "Dreifð"
+
+#: id:383
+msgctxt "Auto context with id 383"
+msgid "Wind"
+msgstr "Vindur"
+
+#: id:384
+msgid "Strong"
+msgstr "Sterkt"
+
+#: id:385
+msgid "Fair"
+msgstr "Létt"
+
+#: id:386
+msgctxt "Auto context with id 386"
+msgid "Clear"
+msgstr "Bjart"
+
+#: id:387
+msgid "Clouds"
+msgstr "Ský"
+
+#: id:388
+msgid "Early"
+msgstr "Snemma"
+
+#: id:389
+msgid "Shower"
+msgstr "Skúrir"
+
+#: id:390
+msgid "Flurries"
+msgstr "Gustur"
+
+#: id:391
+msgctxt "Auto context with id 391"
+msgid "Low"
+msgstr "Lægst"
+
+#: id:392
+msgctxt "Auto context with id 392"
+msgid "Medium"
+msgstr "Meðal"
+
+#: id:393
+msgctxt "Auto context with id 393"
+msgid "High"
+msgstr "Hæst"
+
+#: id:394
+msgid "Fog"
+msgstr "Þoka"
+
+#: id:395
+msgid "Haze"
+msgstr "Mistur"
+
+#: id:396
+msgid "Select location"
+msgstr "Veldu staðsetningu"
+
+#: id:397
+msgid "Refresh time"
+msgstr "Glæðingartími"
+
+#: id:398
+msgid "Temperature units"
+msgstr "Hitamælieiningar"
+
+#: id:399
+msgid "Speed units"
+msgstr "Hraðamælieiningar"
+
+#: id:400
+msgctxt "Auto context with id 400"
+msgid "Weather"
+msgstr "Veður"
+
+#: id:401
+msgid "Temp"
+msgstr "Hiti"
+
+#: id:402
+msgid "Feels like"
+msgstr "Skynjast sem"
+
+#: id:403
+msgid "UV index"
+msgstr "UV einingar"
+
+#: id:404
+msgctxt "Auto context with id 404"
+msgid "Wind"
+msgstr "Vindur"
+
+#: id:405
+msgid "Dew point"
+msgstr "Daggarmark"
+
+#: id:406
+msgid "Humidity"
+msgstr "Raki"
+
+#: id:409
+msgid "Defaults"
+msgstr "Sjálfgildi"
+
+#: id:410
+msgid "Accessing weather service"
+msgstr "Tengist veðurþjónustu"
+
+#: id:411
+msgid "Getting weather for:"
+msgstr "Sæki veðurgögn fyrir:"
+
+#: id:412
+msgid "Unable to get weather data"
+msgstr "Finn ekki veðurgögn"
+
+#: id:413
+msgid "Manual"
+msgstr "Handvirkt"
+
+#: id:414
+msgid "No review for this album"
+msgstr "Engin umsögn um þessa hljómplötu"
+
+#: id:415
+msgid "Downloading thumbnail..."
+msgstr "Sæki smámynd..."
+
+#: id:416
+msgid "Not available"
+msgstr "Ekki til"
+
+#: id:417
+msgid "View: Big icons"
+msgstr "Sjá sem: Stór tákn"
+
+#: id:418
+msgctxt "Auto context with id 418"
+msgid "Low"
+msgstr "Lágt"
+
+#: id:419
+msgctxt "Auto context with id 419"
+msgid "High"
+msgstr "Hátt"
+
+#: id:420
+msgid "HDMI"
+msgstr "HDMI"
+
+#: id:422
+msgid "Delete album info"
+msgstr "Eyða hljómplötuupplýsingum"
+
+#: id:423
+msgid "Delete CD information"
+msgstr "Eyða upplýsingum um geisladisk"
+
+#: id:424
+msgid "Select"
+msgstr "Velja"
+
+#: id:425
+msgid "No album information found"
+msgstr "Engar hljómplötuupplýsingar fundust"
+
+#: id:426
+msgid "No CD information found"
+msgstr "Engar upplýsingar fundust um geisladisk"
+
+#: id:427
+msgid "Disc"
+msgstr "Diskur"
+
+#: id:428
+msgid "Insert correct CD/DVD"
+msgstr "Settu inn réttan CD/DVD"
+
+#: id:429
+msgid "Please insert the following disc:"
+msgstr "Settu inn eftirfarandi disk:"
+
+#: id:430
+msgid "Sort by: DVD#"
+msgstr "Raða eftir: DVD#"
+
+#: id:431
+msgid "No cache"
+msgstr "Ekkert biðminni"
+
+#: id:432
+msgid "Remove movie from library"
+msgstr "Eyða kvikmynd úr safni"
+
+#: id:433
+msgid "Really remove '%s'?"
+msgstr "Viltu fjarlægja '%s'?"
+
+#: id:434
+msgid "From %s at %i %s"
+msgstr "Frá %s á %i %s"
+
+#: id:437
+msgid "Removable disk"
+msgstr "Færanlegur diskur"
+
+#: id:438
+msgid "Opening file"
+msgstr "Opna skrá"
+
+#: id:439
+msgid "Cache"
+msgstr "Biðminni"
+
+#: id:440
+msgid "Harddisk"
+msgstr "Harður diskur"
+
+#: id:441
+msgid "UDF"
+msgstr "UDF"
+
+#: id:442
+msgid "Local network"
+msgstr "Staðbundið netkerfi"
+
+#: id:443
+msgid "Internet"
+msgstr "Internet"
+
+#: id:444
+msgctxt "Auto context with id 444"
+msgid "Video"
+msgstr "Myndband"
+
+#: id:445
+msgctxt "Auto context with id 445"
+msgid "Audio"
+msgstr "Hljóð"
+
+#: id:446
+msgctxt "Auto context with id 446"
+msgid "DVD"
+msgstr "DVD"
+
+#: id:447
+msgid "Autorun media"
+msgstr "Sjálfkeyra"
+
+#: id:448
+msgid "LCD"
+msgstr "LCD"
+
+#: id:449
+msgctxt "Auto context with id 449"
+msgid "Enabled"
+msgstr "Virkt"
+
+#: id:450
+msgid "Columns"
+msgstr "Dálkar"
+
+#: id:451
+msgid "Row 1 address"
+msgstr "Röð 1 númer"
+
+#: id:452
+msgid "Row 2 address"
+msgstr "Röð 2 númer"
+
+#: id:453
+msgid "Row 3 address"
+msgstr "Röð 3 númer"
+
+#: id:454
+msgid "Row 4 address"
+msgstr "Röð 4 númer"
+
+#: id:455
+msgid "Rows"
+msgstr "Raðir"
+
+#: id:456
+msgid "Mode"
+msgstr "Hamur"
+
+#: id:457
+msgid "Switch view"
+msgstr "Breyta sýn"
+
+#: id:459
+msgid "Subs"
+msgstr "Textar"
+
+#: id:460
+msgid "Audio stream"
+msgstr "Hljóðstraumur"
+
+#: id:461
+msgid "[active]"
+msgstr "[virkt]"
+
+#: id:462
+msgid "Subtitle"
+msgstr "Þýðingartexti"
+
+#: id:463
+msgid "Backlight"
+msgstr "Baklýsing"
+
+#: id:464
+msgid "Brightness"
+msgstr "Birta"
+
+#: id:465
+msgid "Contrast"
+msgstr "Skerpa"
+
+#: id:466
+msgid "Gamma"
+msgstr "Gamma"
+
+#: id:467
+msgctxt "Auto context with id 467"
+msgid "Type"
+msgstr "Gerð"
+
+#: id:468
+msgid "Move the bar to change the OSD position"
+msgstr "Hreyfðu línuna til að breyta staðsetningu OSD"
+
+#: id:469
+msgid "OSD position"
+msgstr "OSD staðsetning"
+
+#: id:470
+msgid "Credits"
+msgstr "Þakkir"
+
+#: id:471
+msgid "Modchip"
+msgstr "Mod kubbur"
+
+#: id:474
+msgctxt "Auto context with id 474"
+msgid "Off"
+msgstr "Af"
+
+#: id:475
+msgid "Music only"
+msgstr "Bara tónlist"
+
+#: id:476
+msgctxt "Auto context with id 476"
+msgid "Music & video"
+msgstr "Tónlist og myndefni"
+
+#: id:477
+msgid "Unable to load playlist"
+msgstr "Gat ekki hlaðið spilunarlista"
+
+#: id:478
+msgid "OSD"
+msgstr "OSD"
+
+#: id:479
+msgid "Skin & language"
+msgstr "Útlit og tungumál"
+
+#: id:480
+msgid "Appearance"
+msgstr "Viðmót"
+
+#: id:481
+msgid "Audio options"
+msgstr "Hljóðvalmöguleikar"
+
+#: id:482
+msgid "About XBMC"
+msgstr "Um XBMC"
+
+#: id:485
+msgid "Delete album"
+msgstr "Eyða hljómplötu"
+
+#: id:486
+msgid "Repeat"
+msgstr "Endurtaka"
+
+#: id:487
+msgid "Repeat one"
+msgstr "Endurtaka eitt"
+
+#: id:488
+msgid "Repeat folder"
+msgstr "Endurtaka spilunarlista í möppu"
+
+#: id:489
+msgid "Play the next song automatically"
+msgstr "Nota spilunarlista fyrir lög"
+
+#: id:491
+msgid "- Use big icons"
+msgstr "- Nota stór tákn"
+
+#: id:492
+msgid "Resize VobSubs"
+msgstr "Breyta stærð skjátexta"
+
+#: id:493
+msgid "Advanced options (Experts Only!)"
+msgstr "Frekari valmöguleikar (fyrir sérfræðinga!)"
+
+#: id:494
+msgid "Overall audio headroom"
+msgstr "Heildarhljóðsvið"
+
+#: id:495
+msgid "Upsample videos to GUI resolution"
+msgstr "Stækka kvikmyndir í viðmótsupplausn"
+
+#: id:496
+msgid "Calibration"
+msgstr "Stilla"
+
+#: id:497
+msgid "Show file extensions"
+msgstr "Sýna skráarendingar"
+
+#: id:498
+msgid "Sort by: Type"
+msgstr "Raða eftir: Tegund"
+
+#: id:499
+msgid "Unable to connect to online lookup service"
+msgstr "Get ekki tengst upplýsingaþjónustu"
+
+#: id:500
+msgid "Downloading album information failed"
+msgstr "Niðurhal hljómplötuupplýsinga brást"
+
+#: id:501
+msgid "Looking for album names..."
+msgstr "Leita eftir hljómplötunafni..."
+
+#: id:502
+msgctxt "Auto context with id 502"
+msgid "Open"
+msgstr "Opinn"
+
+#: id:503
+msgid "Busy"
+msgstr "Í vinnslu"
+
+#: id:504
+msgid "Empty"
+msgstr "Tómur"
+
+#: id:505
+msgid "Loading media info from files..."
+msgstr "Sæki upplýsingar frá skrám..."
+
+#: id:507
+msgid "Sort by: Usage"
+msgstr "Raða eftir: Notkun"
+
+#: id:510
+msgid "Enable visualizations"
+msgstr "Virkja myndskreytingu"
+
+#: id:511
+msgid "Enable video mode switching"
+msgstr "Skipta sjálfvirkt um skjáham eftir svæði leiks"
+
+#: id:512
+msgid "Startup window"
+msgstr "Ræsi gluggi"
+
+#: id:513
+msgid "Home window"
+msgstr "Forsíða"
+
+#: id:514
+msgid "Manual settings"
+msgstr "Handvirkar stillingar"
+
+#: id:515
+msgid "Genre"
+msgstr "Flokkur"
+
+#: id:517
+msgid "Recently played albums"
+msgstr "Nýlega spilaðar hljómplötur"
+
+#: id:518
+msgid "Launch"
+msgstr "Keyra"
+
+#: id:519
+msgid "Launch in..."
+msgstr "Keyra í..."
+
+#: id:521
+msgid "Compilations"
+msgstr "Safnplötur"
+
+#: id:522
+msgid "Remove source"
+msgstr "Eyða uppsprettu"
+
+#: id:523
+msgid "Switch media"
+msgstr "Skipta um miðil"
+
+#: id:524
+msgid "Select playlist"
+msgstr "Velja spilunarlista"
+
+#: id:525
+msgid "New playlist..."
+msgstr "Nýr spilunarlisti..."
+
+#: id:526
+msgid "Add to playlist"
+msgstr "Bæta á spilunarlista"
+
+#: id:527
+msgid "Manually add to library"
+msgstr "Bæta handvirkt við safn"
+
+#: id:528
+msgid "Enter title"
+msgstr "Sláðu inn titil"
+
+#: id:529
+msgid "Error: Duplicate title"
+msgstr "Villa: Titill þegar til"
+
+#: id:530
+msgid "Select genre"
+msgstr "Veldu flokk"
+
+#: id:531
+msgid "New genre"
+msgstr "Nýr flokkur"
+
+#: id:532
+msgid "Manual addition"
+msgstr "Handvirk viðbót"
+
+#: id:533
+msgid "Enter genre"
+msgstr "Sláðu inn flokk"
+
+#: id:534
+msgid "View: %s"
+msgstr "Sýn: %s"
+
+#: id:535
+msgid "List"
+msgstr "Listi"
+
+#: id:536
+msgid "Icons"
+msgstr "Tákn"
+
+#: id:537
+msgid "Big list"
+msgstr "Stór listi"
+
+#: id:538
+msgid "Big icons"
+msgstr "Stór tákn"
+
+#: id:539
+msgid "Wide"
+msgstr "Breiðir"
+
+#: id:540
+msgid "Big wide"
+msgstr "Stórir breiðir"
+
+#: id:541
+msgid "Album icons"
+msgstr "Hjómplötu tákn"
+
+#: id:542
+msgid "DVD icons"
+msgstr "DVD tákn"
+
+#: id:543
+msgctxt "Auto context with id 543"
+msgid "DVD"
+msgstr "DVD"
+
+#: id:544
+msgctxt "Auto context with id 544"
+msgid "Media info"
+msgstr "Upplýsingar"
+
+#: id:545
+msgid "Audio output device"
+msgstr "Hljóðúttakstæki"
+
+#: id:546
+msgid "Passthrough output device"
+msgstr "Gegnumúttakstæki"
+
+#: id:547
+msgid "No biography for this artist"
+msgstr "Ekkert æviágrip fyrir þennan listamann"
+
+#: id:548
+msgid "Downmix multichannel audio to stereo"
+msgstr "Endurblanda fjölrása hljóð yfir í víðóma"
+
+#: id:550
+msgid "Sort by: %s"
+msgstr "Raða eftir: %s"
+
+#: id:551
+msgctxt "Auto context with id 551"
+msgid "Name"
+msgstr "Nafni"
+
+#: id:552
+msgid "Date"
+msgstr "Dags"
+
+#: id:553
+msgid "Size"
+msgstr "Stærð"
+
+#: id:554
+msgid "Track"
+msgstr "Lag"
+
+#: id:555
+msgid "Time"
+msgstr "Tíma"
+
+#: id:556
+msgctxt "Auto context with id 556"
+msgid "Title"
+msgstr "Titli"
+
+#: id:557
+msgid "Artist"
+msgstr "Tónlistarmanni"
+
+#: id:558
+msgid "Album"
+msgstr "Hljómplata"
+
+#: id:559
+msgid "Playlist"
+msgstr "Lagalista"
+
+#: id:560
+msgid "ID"
+msgstr "Auðkenni"
+
+#: id:561
+msgctxt "Auto context with id 561"
+msgid "File"
+msgstr "Skrá"
+
+#: id:562
+msgctxt "Auto context with id 562"
+msgid "Year"
+msgstr "Ár"
+
+#: id:563
+msgid "Rating"
+msgstr "Einkunn"
+
+#: id:564
+msgctxt "Auto context with id 564"
+msgid "Type"
+msgstr "Tegund"
+
+#: id:565
+msgid "Usage"
+msgstr "Notkun"
+
+#: id:566
+msgid "Album artist"
+msgstr "Tónlistarmaður"
+
+#: id:567
+msgid "Play count"
+msgstr "Fjöldi spilana"
+
+#: id:568
+msgid "Last played"
+msgstr "Síðast spilað"
+
+#: id:569
+msgctxt "Auto context with id 569"
+msgid "Comment"
+msgstr "Athugasemd"
+
+#: id:570
+msgid "Date added"
+msgstr "Bætt við dags"
+
+#: id:571
+msgctxt "Auto context with id 571"
+msgid "Default"
+msgstr "Sjálfgefið"
+
+#: id:572
+msgid "Studio"
+msgstr "Stúdíó"
+
+#: id:573
+msgid "Path"
+msgstr "Slóð"
+
+#: id:574
+msgctxt "Auto context with id 574"
+msgid "Country"
+msgstr "Land"
+
+#: id:575
+msgid "In progress"
+msgstr "Í vinnslu"
+
+#: id:576
+msgid "Times played"
+msgstr "Sinnum spilað"
+
+#: id:580
+msgid "Sort direction"
+msgstr "Raða í átt"
+
+#: id:581
+msgid "Sort method"
+msgstr "Röðunaraðferð"
+
+#: id:582
+msgctxt "Auto context with id 582"
+msgid "View mode"
+msgstr "Tegund Sýnar"
+
+#: id:583
+msgid "Remember views for different folders"
+msgstr "Muna sýn á mismunandi möppur"
+
+#: id:584
+msgid "Ascending"
+msgstr "Hækkandi"
+
+#: id:585
+msgid "Descending"
+msgstr "Lækkandi"
+
+#: id:586
+msgid "Edit playlist"
+msgstr "Breyta spilunarlista"
+
+#: id:587
+msgid "Filter"
+msgstr "Sía"
+
+#: id:588
+msgid "Cancel party mode"
+msgstr "Hætta við partí ham"
+
+#: id:589
+msgid "Party mode"
+msgstr "Partí hamur"
+
+#: id:590
+msgid "Random"
+msgstr "Handahófskenndur"
+
+#: id:591
+msgctxt "Auto context with id 591"
+msgid "Off"
+msgstr "Af"
+
+#: id:592
+msgid "One"
+msgstr "Einn"
+
+#: id:593
+msgid "All"
+msgstr "Allir"
+
+#: id:594
+msgctxt "Auto context with id 594"
+msgid "Off"
+msgstr "Af"
+
+#: id:595
+msgid "Repeat: Off"
+msgstr "Endurtaka: Af"
+
+#: id:596
+msgid "Repeat: One"
+msgstr "Endurtaka: Einn"
+
+#: id:597
+msgid "Repeat: All"
+msgstr "Endurtaka: Allir"
+
+#: id:600
+msgid "Rip audio CD"
+msgstr "Afrita CD tónlist"
+
+#: id:601
+msgctxt "Auto context with id 601"
+msgid "Medium"
+msgstr "Meðal"
+
+#: id:602
+msgctxt "Auto context with id 602"
+msgid "Standard"
+msgstr "Venjulegt"
+
+#: id:603
+msgid "Extreme"
+msgstr "Öfgakenndur"
+
+#: id:604
+msgid "Constant bitrate"
+msgstr "Fastur bita hraði"
+
+#: id:605
+msgid "Ripping..."
+msgstr "Afrita..."
+
+#: id:607
+msgid "To:"
+msgstr "Til:"
+
+#: id:608
+msgid "Could not rip CD or track"
+msgstr "Get ekki lesið disk eða rás"
+
+#: id:609
+msgid "CDDARipPath is not set."
+msgstr "CDDARipPath er ekki skilgreint."
+
+#: id:610
+msgid "Rip audio track"
+msgstr "Afrita lag"
+
+#: id:611
+msgid "Enter number"
+msgstr "Sláðu inn númer"
+
+#: id:612
+msgid "Bits/Sample"
+msgstr "Bitar/úrtak"
+
+#: id:613
+msgid "Sample Frequency"
+msgstr "Tíðni"
+
+#: id:620
+msgid "Audio CDs"
+msgstr "Tónlistardiskar"
+
+#: id:621
+msgid "Encoder"
+msgstr "Kótari"
+
+#: id:622
+msgid "Quality"
+msgstr "Gæði"
+
+#: id:623
+msgid "Bitrate"
+msgstr "Bita hraði"
+
+#: id:624
+msgid "Include track number"
+msgstr "Bæta við laga númeri"
+
+#: id:625
+msgid "All songs of"
+msgstr "Öll lög með"
+
+#: id:629
+msgctxt "Auto context with id 629"
+msgid "View mode"
+msgstr "Tegund sjónarhorns"
+
+#: id:630
+msgctxt "Auto context with id 630"
+msgid "Normal"
+msgstr "Venjulegt"
+
+#: id:631
+msgid "Zoom"
+msgstr "Þysja"
+
+#: id:632
+msgid "Stretch 4:3"
+msgstr "Teygja 4:3"
+
+#: id:633
+msgid "Wide Zoom"
+msgstr "Þysja breiðmynd"
+
+#: id:634
+msgid "Stretch 16:9"
+msgstr "Teygja 16:9"
+
+#: id:635
+msgid "Original Size"
+msgstr "Upprunaleg stærð"
+
+#: id:636
+msgctxt "Auto context with id 636"
+msgid "Custom"
+msgstr "Sérsnið"
+
+#: id:637
+msgid "Replay gain"
+msgstr "Jöfnun tónstyrks"
+
+#: id:638
+msgid "Replaygain volume adjustments"
+msgstr "Jöfnunarhamur tónstyrks"
+
+#: id:639
+msgid "Use track levels"
+msgstr "Nota laga stig"
+
+#: id:640
+msgid "Use album levels"
+msgstr "Nota hljómplötu stig"
+
+#: id:641
+msgid "PreAmp Level - Replay gained files"
+msgstr "Stig formagnara - Skrár með jöfnun tónstyrks"
+
+#: id:642
+msgid "PreAmp Level - Non replay gained files"
+msgstr "Stig formagnara - Skrár ekki með jöfnun tónstyrks"
+
+#: id:643
+msgid "Avoid clipping on replay gained files"
+msgstr "Ekki klippa á skrár með jöfnun tónstyrks"
+
+#: id:644
+msgid "Crop black bars"
+msgstr "Skera af svartar rendur"
+
+#: id:645
+msgid "Need to unpack a big file. Continue?"
+msgstr "Nauðsynlegt er að vista tímabundið stóra skrá. Halda áfram?"
+
+#: id:646
+msgid "Remove from library"
+msgstr "Fjarlægja úr safni"
+
+#: id:647
+msgid "Export video library"
+msgstr "Flytja út bíómyndasafn"
+
+#: id:648
+msgid "Import video library"
+msgstr "Flytja inn bíómyndasafn"
+
+#: id:649
+msgid "Importing"
+msgstr "Flytja inn"
+
+#: id:650
+msgid "Exporting"
+msgstr "Flytja út"
+
+#: id:651
+msgid "Browse for library"
+msgstr "Leita að safni"
+
+#: id:652
+msgid "Years"
+msgstr "Ár"
+
+#: id:653
+msgid "Update library"
+msgstr "Uppfæra safn"
+
+#: id:654
+msgid "Show debug info"
+msgstr "Sýna kembi upplýsingar"
+
+#: id:655
+msgid "Browse for executable"
+msgstr "Finna forrit"
+
+#: id:656
+msgid "Browse for playlist"
+msgstr "Finna lagalista"
+
+#: id:657
+msgid "Browse for folder"
+msgstr "Finna möppu"
+
+#: id:658
+msgid "Song information"
+msgstr "Lagaupplýsingar"
+
+#: id:659
+msgid "Non-linear stretch"
+msgstr "Ólínuleg teygja"
+
+#: id:660
+msgid "Volume amplification"
+msgstr "Mögnun Hljóðstyrks"
+
+#: id:661
+msgid "Choose export folder"
+msgstr "Veldu möppu til að vista í"
+
+#: id:662
+msgid "This file is no longer available."
+msgstr "Þessi skrá er ekki lengur tiltæk."
+
+#: id:663
+msgid "Would you like to remove it from the library?"
+msgstr "Viltu fjarlægja hana úr safninu?"
+
+#: id:664
+msgid "Browse for Script"
+msgstr "Leita eftir skriftu"
+
+#: id:665
+msgid "Compression level"
+msgstr "Þjöppun"
+
+#: id:700
+msgid "Cleaning up library"
+msgstr "Hreinsa upp safn"
+
+#: id:701
+msgid "Removing old songs from the library"
+msgstr "Fjarlægi gömul lög úr tónlistarsafninu"
+
+#: id:702
+msgid "This path has been scanned before"
+msgstr "Þessi slóð hefur verið skönnuð áður"
+
+#: id:705
+msgctxt "Auto context with id 705"
+msgid "Network"
+msgstr "Netkerfi"
+
+#: id:706
+msgid "- Server"
+msgstr "- Netþjónn"
+
+#: id:708
+msgid "Use an HTTP proxy server to access the internet"
+msgstr "Nota HTTP milliþjón til að tengjast netinu"
+
+#: id:711
+msgid "Internet Protocol (IP)"
+msgstr "Internet samskiptareglur (IP)"
+
+#: id:712
+msgid "Invalid port specified. Value must be between 1 and 65535."
+msgstr "Röng gátt valinn. Gildi þarf að vera á milli 1 og 65535."
+
+#: id:713
+msgid "HTTP proxy"
+msgstr "HTTP milliþjónn (Proxy)"
+
+#: id:715
+msgid "- Assignment"
+msgstr "- Úthlutað"
+
+#: id:716
+msgid "Automatic (DHCP)"
+msgstr "Sjálfvirkt (DHCP)"
+
+#: id:717
+msgid "Manual (Static)"
+msgstr "Handvirkt (Föst)"
+
+#: id:719
+msgid "- IP address"
+msgstr "- IP tala"
+
+#: id:720
+msgid "- Netmask"
+msgstr "- Undirnetssía"
+
+#: id:721
+msgid "- Default gateway"
+msgstr "- Sjálfgefinn gátt"
+
+#: id:722
+msgid "- DNS server"
+msgstr "- DNS þjónn"
+
+#: id:723
+msgid "Save & restart"
+msgstr "Vista og endurræsa"
+
+#: id:724
+msgid "Invalid address specified. Value must be AAA.BBB.CCC.DDD"
+msgstr "Rangt vistfang tilgreint. Gildi verður að vera AAA.BBB.CCC.DDD"
+
+#: id:725
+msgid "with numbers between 0 and 255."
+msgstr "með númerum á milli 0 og 255."
+
+#: id:726
+msgid "Changes not saved. Continue without saving?"
+msgstr "Breytingar ekki vistaðar. Halda áfram án þess að vista?"
+
+#: id:727
+msgid "Web server"
+msgstr "Vefþjónn"
+
+#: id:728
+msgctxt "Auto context with id 728"
+msgid "FTP server"
+msgstr "FTP þjónn"
+
+#: id:730
+msgid "- Port"
+msgstr "- Gátt"
+
+#: id:732
+msgid "Save & apply"
+msgstr "Vista og virkja"
+
+#: id:733
+msgid "- Password"
+msgstr "- Lykilorð"
+
+#: id:734
+msgid "No pass"
+msgstr "Ekkert lykilorð"
+
+#: id:735
+msgid "- Character set"
+msgstr "- Stafasett"
+
+#: id:736
+msgid "- Style"
+msgstr "- Stíll"
+
+#: id:737
+msgid "- Colour"
+msgstr "- Litur"
+
+#: id:738
+msgctxt "Auto context with id 738"
+msgid "Normal"
+msgstr "Venjulegt"
+
+#: id:739
+msgid "Bold"
+msgstr "Feitletrað"
+
+#: id:740
+msgid "Italics"
+msgstr "Skáletrað"
+
+#: id:741
+msgid "Bold italics"
+msgstr "Feitletrað skáletrað"
+
+#: id:742
+msgctxt "Auto context with id 742"
+msgid "White"
+msgstr "Hvítur"
+
+#: id:743
+msgctxt "Auto context with id 743"
+msgid "Yellow"
+msgstr "Gulur"
+
+#: id:744
+msgctxt "Auto context with id 744"
+msgid "Files"
+msgstr "Skrár"
+
+#: id:745
+msgid "No scanned information for this view"
+msgstr "Engar skannaðar upplýsingar eru til fyrir þessa sýn"
+
+#: id:746
+msgid "Please turn off library mode"
+msgstr "Vinsamlegast slökktu á safnham"
+
+#: id:747
+msgid "Error loading image"
+msgstr "Villa við niðurhal myndar"
+
+#: id:748
+msgid "Edit path"
+msgstr "Breyta slóð"
+
+#: id:749
+msgid "Mirror image"
+msgstr "Spegla mynd"
+
+#: id:750
+msgid "Are you sure?"
+msgstr "Ertu viss?"
+
+#: id:751
+msgid "Removing source"
+msgstr "Fjarlægi uppsprettu"
+
+#: id:754
+msgid "Add program link"
+msgstr "Bæta við forrita tengli"
+
+#: id:755
+msgid "Edit program path"
+msgstr "Breyta forrita slóð"
+
+#: id:756
+msgid "Edit program name"
+msgstr "Breyta nafni forrits"
+
+#: id:757
+msgid "Edit path depth"
+msgstr "Breyta dýpt slóða"
+
+#: id:759
+msgid "View: Big list"
+msgstr "Sýn: Stór listi"
+
+#: id:760
+msgctxt "Auto context with id 760"
+msgid "Yellow"
+msgstr "Gulur"
+
+#: id:761
+msgctxt "Auto context with id 761"
+msgid "White"
+msgstr "Hvítur"
+
+#: id:762
+msgid "Blue"
+msgstr "Blár"
+
+#: id:763
+msgid "Bright green"
+msgstr "Skærgrænn"
+
+#: id:764
+msgid "Yellow green"
+msgstr "Gulgrænn"
+
+#: id:765
+msgid "Cyan"
+msgstr "Blágrænn"
+
+#: id:766
+msgid "Light grey"
+msgstr "Frátekið"
+
+#: id:767
+msgid "Grey"
+msgstr "Frátekið"
+
+#: id:770
+msgid "Error %i: share not available"
+msgstr "Villa %i: samnýting ekki aðgengileg"
+
+#: id:772
+msgctxt "Auto context with id 772"
+msgid "Audio output"
+msgstr "Hljóðbúnaður"
+
+#: id:773
+msgid "Seeking"
+msgstr "Leita"
+
+#: id:774
+msgid "Slideshow folder"
+msgstr "Mappa fyrir myndasýningar skjávara"
+
+#: id:775
+msgid "Network interface"
+msgstr "Nettenging"
+
+#: id:776
+msgid "- Wireless network name (ESSID)"
+msgstr "- Þráðlaust net nafn (ESSID)"
+
+#: id:777
+msgid "- Wireless password"
+msgstr "- Þráðlaust lykilorð"
+
+#: id:778
+msgid "- Wireless security"
+msgstr "- Þráðlaust öryggi"
+
+#: id:779
+msgid "Save and apply network interface settings"
+msgstr "Vista og virkja nettenginga stillingar"
+
+#: id:780
+msgid "No encryption"
+msgstr "Engin dulkóðun"
+
+#: id:781
+msgid "WEP"
+msgstr "WEP"
+
+#: id:782
+msgid "WPA"
+msgstr "WPA"
+
+#: id:783
+msgid "WPA2"
+msgstr "WPA2"
+
+#: id:784
+msgid "Applying network interface settings. Please wait."
+msgstr "Virkja stillingar nettengingar. Augnablik."
+
+#: id:785
+msgid "Network interface restarted successfully."
+msgstr "Tókst að endurræsa nettengingu."
+
+#: id:786
+msgid "Network interface did not start successfully."
+msgstr "Ekki tókst að endurræsa nettengingu."
+
+#: id:787
+msgid "Interface disabled"
+msgstr "Tenging gerð óvirk"
+
+#: id:788
+msgid "Network interface disabled successfully."
+msgstr "Tókst að gera nettengingu óvirka."
+
+#: id:789
+msgid "Wireless network name (ESSID)"
+msgstr "Þráðlaust net nafn (ESSID)"
+
+#: id:790
+msgid "Remote control"
+msgstr ""
+
+#: id:791
+msgid "Allow programs on this system to control XBMC"
+msgstr "Leyfa forritum að stjórna XBMC"
+
+#: id:792
+msgctxt "Auto context with id 792"
+msgid "Port"
+msgstr "Gátt"
+
+#: id:793
+msgid "Port range"
+msgstr "Gáttabil"
+
+#: id:794
+msgid "Allow programs on other systems to control XBMC"
+msgstr "Leyfa forritum á öðrum tölvum að stjórna XBMC"
+
+#: id:795
+msgid "Initial repeat delay (ms)"
+msgstr "Upphafleg endurtekningarbið (ms)"
+
+#: id:796
+msgid "Continuous repeat delay (ms)"
+msgstr "Samfelld endurtekningarbið (ms)"
+
+#: id:797
+msgid "Maximum number of clients"
+msgstr "Hámarksfjöldi biðlara"
+
+#: id:798
+msgid "Internet access"
+msgstr "Internet aðgangur"
+
+#: id:850
+msgid "Invalid port number entered"
+msgstr "Ógilt númer á gátt slegið inn"
+
+#: id:851
+msgid "Valid port range is 1-65535"
+msgstr "Gild gátt er á bilinu 1-65535"
+
+#: id:852
+msgid "Valid port range is 1024-65535"
+msgstr "Gild gátt er á bilinu 1024-65535"
+
+#: id:998
+msgid "Add Music..."
+msgstr "Bæta við tónlist..."
+
+#: id:999
+msgid "Add Videos..."
+msgstr "Bæta við myndefni..."
+
+#: id:1000
+msgid "- Preview"
+msgstr "- Forsýna"
+
+#: id:1001
+msgid "Unable to connect"
+msgstr "Get ekki tengst"
+
+#: id:1002
+msgid "XBMC was unable to connect to the network location."
+msgstr "XBMC getur ekki tengst við netslóð."
+
+#: id:1003
+msgid "This could be due to the network not being connected."
+msgstr "Þetta gæti verið vegna þess að netið er ekki tengt."
+
+#: id:1004
+msgid "Would you like to add it anyway?"
+msgstr "Viltu samt bæta því við?"
+
+#: id:1006
+msgctxt "Auto context with id 1006"
+msgid "IP address"
+msgstr "IP tala"
+
+#: id:1007
+msgid "Add network location"
+msgstr "Bæta við net slóð"
+
+#: id:1008
+msgid "Protocol"
+msgstr "Samskiptareglur"
+
+#: id:1009
+msgid "Server address"
+msgstr "Vistfang miðlara"
+
+#: id:1010
+msgid "Server name"
+msgstr "Nafn miðlara"
+
+#: id:1011
+msgid "Remote path"
+msgstr "Slóð fjartengingar"
+
+#: id:1012
+msgid "Shared folder"
+msgstr "Samnýtt mappa"
+
+#: id:1013
+msgctxt "Auto context with id 1013"
+msgid "Port"
+msgstr "Gátt"
+
+#: id:1014
+msgctxt "Auto context with id 1014"
+msgid "Username"
+msgstr "Notandanafn"
+
+#: id:1015
+msgid "Browse for network server"
+msgstr "Leita að netþjóni"
+
+#: id:1016
+msgid "Enter the network address of the server"
+msgstr "Sláði inn vistfang miðlarans"
+
+#: id:1017
+msgid "Enter the path on the server"
+msgstr "Sláðu inn slóð á miðlara"
+
+#: id:1018
+msgid "Enter the port number"
+msgstr "Sláðu inn númer gáttar"
+
+#: id:1019
+msgid "Enter the username"
+msgstr "Sláðu inn notandanafn"
+
+#: id:1020
+msgid "Add %s source"
+msgstr "Bæta við %s uppsprettu"
+
+#: id:1021
+msgid "Enter the paths or browse for the media locations."
+msgstr "Sláðu inn slóð eða leitaðu að slóð fyrir miðlara."
+
+#: id:1022
+msgid "Enter a name for this media Source."
+msgstr "Sláðu inn nafn fyrir þessa uppsprettu."
+
+#: id:1023
+msgid "Browse for new share"
+msgstr "Leita að nýrri samnýtingu"
+
+#: id:1024
+msgid "Browse"
+msgstr "Leita"
+
+#: id:1025
+msgid "Could not retrieve directory information."
+msgstr "Gat ekki náð í upplýsingar um möppu."
+
+#: id:1026
+msgid "Add source"
+msgstr "Bæta við uppsprettu"
+
+#: id:1027
+msgid "Edit source"
+msgstr "Breyta uppsprettu"
+
+#: id:1028
+msgid "Edit %s source"
+msgstr "Breyta %s uppsprettu"
+
+#: id:1029
+msgid "Enter the new label"
+msgstr "Sláðu inn nýjan titil"
+
+#: id:1030
+msgid "Browse for image"
+msgstr "Leita að mynd"
+
+#: id:1031
+msgid "Browse for image folder"
+msgstr "Leita að mynda möppu"
+
+#: id:1032
+msgid "Add network location..."
+msgstr "Bæta við net slóð..."
+
+#: id:1033
+msgid "Browse for file"
+msgstr "Leita að skrá"
+
+#: id:1034
+msgid "Submenu"
+msgstr "Undirvalmynd"
+
+#: id:1035
+msgid "Enable submenu buttons"
+msgstr "Virkja undirvalmyndar takka"
+
+#: id:1036
+msgid "Favourites"
+msgstr "Uppáhalds"
+
+#: id:1037
+msgid "Video Add-ons"
+msgstr "Myndefnisviðbætur"
+
+#: id:1038
+msgid "Music Add-ons"
+msgstr "Tónlistaviðbætur"
+
+#: id:1039
+msgid "Picture Add-ons"
+msgstr "Ljósmyndaviðbætur"
+
+#: id:1040
+msgid "Loading directory"
+msgstr "Hleð inn möppu"
+
+#: id:1041
+msgid "Retrieved %i items"
+msgstr "Náði í %i hluti"
+
+#: id:1042
+msgid "Retrieved %i of %i items"
+msgstr "Náði í %i af %i hlutum"
+
+#: id:1043
+msgid "Program Add-ons"
+msgstr "Forritsviðbætur"
+
+#: id:1044
+msgid "Set plugin thumb"
+msgstr "Setja viðbótar smámynd"
+
+#: id:1045
+msgid "Add-on settings"
+msgstr "Stilling viðbóta"
+
+#: id:1046
+msgid "Access points"
+msgstr "Aðgangsstaðir"
+
+#: id:1047
+msgid "Other..."
+msgstr "Annað..."
+
+#: id:1048
+msgid "- Username"
+msgstr "- Notandanafn"
+
+#: id:1049
+msgid "Script settings"
+msgstr "Skriftu stillingar"
+
+#: id:1050
+msgid "Singles"
+msgstr "Smáskífur"
+
+#: id:1051
+msgid "Enter web address"
+msgstr "Sláðu inn veffang"
+
+#: id:1200
+msgid "SMB client"
+msgstr "SMB biðlari"
+
+#: id:1202
+msgid "Workgroup"
+msgstr "Vinnuhópur"
+
+#: id:1203
+msgid "Default username"
+msgstr "Sjálfgefið notandanafn"
+
+#: id:1204
+msgid "Default password"
+msgstr "Sjálfgefið lykilorð"
+
+#: id:1207
+msgid "WINS server"
+msgstr "WINS þjónn"
+
+#: id:1208
+msgid "Mount SMB shares"
+msgstr "Tengjast við SMB samnýtingar"
+
+#: id:1210
+msgctxt "Auto context with id 1210"
+msgid "Remove"
+msgstr "Fjarlægja"
+
+#: id:1211
+msgctxt "Auto context with id 1211"
+msgid "Music"
+msgstr "Tónlist"
+
+#: id:1212
+msgctxt "Auto context with id 1212"
+msgid "Video"
+msgstr "Myndefni"
+
+#: id:1213
+msgctxt "Auto context with id 1213"
+msgid "Pictures"
+msgstr "Myndir"
+
+#: id:1214
+msgctxt "Auto context with id 1214"
+msgid "Files"
+msgstr "Skrár"
+
+#: id:1215
+msgctxt "Auto context with id 1215"
+msgid "Music & video"
+msgstr "Tónlist & myndefni"
+
+#: id:1216
+msgid "Music & pictures"
+msgstr "Tónlist & myndir"
+
+#: id:1217
+msgid "Music & files"
+msgstr "Tónlist & skrár"
+
+#: id:1218
+msgid "Video & pictures"
+msgstr "Myndefni & myndir"
+
+#: id:1219
+msgid "Video & files"
+msgstr "Myndefni & skrár"
+
+#: id:1220
+msgid "Pictures & files"
+msgstr "Myndir & skrár"
+
+#: id:1221
+msgid "Music & video & pictures"
+msgstr "Tónlist & myndefni & myndir"
+
+#: id:1222
+msgid "Music & video & pictures & files"
+msgstr "Tónlist & myndefni & myndir & skrár"
+
+#: id:1223
+msgctxt "Auto context with id 1223"
+msgid "Disabled"
+msgstr "Óvirkt"
+
+#: id:1226
+msgid "Files & music & video"
+msgstr "Skrár & tónlist & myndefni"
+
+#: id:1227
+msgid "Files & pictures & music"
+msgstr "Skrár & myndir& tónlist"
+
+#: id:1228
+msgid "Files & pictures & video"
+msgstr "Skrár & myndir & myndefni"
+
+#: id:1229
+msgid "Music & programs"
+msgstr "Tónlist & forrit"
+
+#: id:1230
+msgid "Video & programs"
+msgstr "Myndefni & forrit"
+
+#: id:1231
+msgid "Pictures & programs"
+msgstr "Myndir & forrit"
+
+#: id:1232
+msgid "Music & video & pictures & programs"
+msgstr "Tónlist & myndefni & myndir & forrit"
+
+#: id:1233
+msgid "Programs & video & music"
+msgstr "Forrit & myndefni & tónlist"
+
+#: id:1234
+msgid "Programs & pictures & music"
+msgstr "Forrit & myndir & tónlist"
+
+#: id:1235
+msgid "Programs & pictures & video"
+msgstr "Forrit & myndir & myndefni"
+
+#: id:1250
+msgid "Auto-detection"
+msgstr "Sjálfvirk uppgötvun"
+
+#: id:1251
+msgid "Auto-detect system"
+msgstr "Sjálfvirk uppgötvun kerfa"
+
+#: id:1252
+msgid "Nickname"
+msgstr "Gælunafn"
+
+#: id:1254
+msgid "Ask to connect"
+msgstr "Biðja um tengingu"
+
+#: id:1255
+msgid "Send FTP user and password"
+msgstr "Senda FTP notandanafn og lykilorð"
+
+#: id:1256
+msgid "Ping interval"
+msgstr "Ping millibil"
+
+#: id:1257
+msgid "Would you like to connect to the auto-detected system?"
+msgstr "Viltu tengjast uppgötvuðu kerfi?"
+
+#: id:1259
+msgid "Zeroconf"
+msgstr ""
+
+#: id:1260
+msgid "Announce these services to other systems via Zeroconf"
+msgstr "Tilkynna þjónustur til annarra kerfa með Zeroconf"
+
+#: id:1270
+msgid "Allow XBMC to receive AirPlay content"
+msgstr "Leyfa XBMC að taka á móti AirPlay efni"
+
+#: id:1271
+msgid "Device name"
+msgstr "Nafn tækis"
+
+#: id:1272
+msgid "- Use password protection"
+msgstr "- Nota lykilorð"
+
+#: id:1273
+msgid "AirPlay"
+msgstr ""
+
+#: id:1300
+msgid "Custom audio device"
+msgstr "Sérsniðið hljóðtæki"
+
+#: id:1301
+msgid "Custom passthrough device"
+msgstr "Sérsniðið gegnumstreymitæki"
+
+#: id:1396
+msgid "Drifting"
+msgstr "Fjúka"
+
+#: id:1397
+msgid "and"
+msgstr "og"
+
+#: id:1398
+msgid "Freezing"
+msgstr "Frost"
+
+#: id:1399
+msgid "Late"
+msgstr "Seint"
+
+#: id:1400
+msgid "Isolated"
+msgstr "Einangrað"
+
+#: id:1401
+msgid "Thundershowers"
+msgstr "Þrumuskúrir"
+
+#: id:1402
+msgid "Thunder"
+msgstr "Þrumur"
+
+#: id:1403
+msgctxt "Auto context with id 1403"
+msgid "Sun"
+msgstr "Sól"
+
+#: id:1404
+msgid "Heavy"
+msgstr "Þungbúinn"
+
+#: id:1405
+msgid "in"
+msgstr "í"
+
+#: id:1406
+msgid "the"
+msgstr ""
+
+#: id:1407
+msgid "Vicinity"
+msgstr "Nágrenni"
+
+#: id:1408
+msgid "Ice"
+msgstr "Ís"
+
+#: id:1409
+msgid "Crystals"
+msgstr "Kristallar"
+
+#: id:1410
+msgid "Calm"
+msgstr "Logn"
+
+#: id:1411
+msgid "with"
+msgstr "með"
+
+#: id:1412
+msgid "windy"
+msgstr "vindasamt"
+
+#: id:1413
+msgid "drizzle"
+msgstr "úði"
+
+#: id:1414
+msgid "Thunderstorm"
+msgstr "Þrumuveður"
+
+#: id:1415
+msgid "Drizzle"
+msgstr "Úði"
+
+#: id:1416
+msgid "Foggy"
+msgstr "Þoka"
+
+#: id:1417
+msgid "Grains"
+msgstr "Haglél"
+
+#: id:1418
+msgid "T-Storms"
+msgstr "Þrumuveður"
+
+#: id:1419
+msgid "T-Showers"
+msgstr "Þrumuskúrir"
+
+#: id:1420
+msgid "Moderate"
+msgstr "Hóflegt"
+
+#: id:1421
+msgid "Very High"
+msgstr "Mjög hátt"
+
+#: id:1422
+msgid "Windy"
+msgstr "Vindasamt"
+
+#: id:1423
+msgid "Mist"
+msgstr "Mistur"
+
+#: id:1450
+msgid "Put display to sleep when idle"
+msgstr "Virkja lágt orkustig ef aðgerðalaus"
+
+#: id:2050
+msgid "Runtime"
+msgstr "Lengd"
+
+#: id:2100
+msgid "Script failed! : %s"
+msgstr "Skrifta mistókst! : %s"
+
+#: id:2101
+msgid "Newer version needed - See log"
+msgstr "Þarfnast nýrrar útgáfu - Skoðaðu atburðaskrá"
+
+#: id:4501
+msgid "Enable LCD/VFD"
+msgstr "Virkja LCD/VFD"
+
+#: id:10000
+msgid "Home"
+msgstr "Heim"
+
+#: id:10001
+msgctxt "Auto context with id 10001"
+msgid "Programs"
+msgstr "Forrit"
+
+#: id:10002
+msgctxt "Auto context with id 10002"
+msgid "Pictures"
+msgstr "Ljósmyndir"
+
+#: id:10003
+msgctxt "Auto context with id 10003"
+msgid "File manager"
+msgstr "Skráarsýsl"
+
+#: id:10004
+msgctxt "Auto context with id 10004"
+msgid "Settings"
+msgstr "Stillingar"
+
+#: id:10005
+msgctxt "Auto context with id 10005"
+msgid "Music"
+msgstr "Tónlist"
+
+#: id:10006
+msgctxt "Auto context with id 10006"
+msgid "Videos"
+msgstr "Myndefni"
+
+#: id:10007
+msgid "System information"
+msgstr "Kerfisupplýsingar"
+
+#: id:10008
+msgid "Settings - General"
+msgstr "Stillingar - Almennar"
+
+#: id:10009
+msgid "Settings - Screen"
+msgstr "Stillingar - Skjár"
+
+#: id:10010
+msgid "Settings - Appearance - GUI Calibration"
+msgstr "Stillingar - Viðmót - Viðmótsstilling"
+
+#: id:10011
+msgid "Settings - Videos - Screen Calibration"
+msgstr "Stillingar - Myndefni - Skjástilling"
+
+#: id:10012
+msgid "Settings - Pictures"
+msgstr "Stillingar - Ljósmyndir"
+
+#: id:10013
+msgid "Settings - Programs"
+msgstr "Stillingar - Forrit"
+
+#: id:10014
+msgid "Settings - Weather"
+msgstr "Stillingar - Veður"
+
+#: id:10015
+msgid "Settings - Music"
+msgstr "Stillingar - Tónlist"
+
+#: id:10016
+msgid "Settings - System"
+msgstr "Stillingar - Kerfi"
+
+#: id:10017
+msgid "Settings - Videos"
+msgstr "Stillingar - Myndefni"
+
+#: id:10018
+msgid "Settings - Network"
+msgstr "Stillingar - Netkerfi"
+
+#: id:10019
+msgid "Settings - Appearance"
+msgstr "Stillingar - Viðmót"
+
+#: id:10020
+msgctxt "Auto context with id 10020"
+msgid "Scripts"
+msgstr "Skriftur"
+
+#: id:10021
+msgid "Web Browser"
+msgstr "Vafri"
+
+#: id:10025
+msgctxt "Auto context with id 10025"
+msgid "Videos"
+msgstr ""
+
+#: id:10028
+msgid "Videos/Playlist"
+msgstr "Myndefni/Spilunarlisti"
+
+#: id:10029
+msgctxt "Auto context with id 10029"
+msgid "Login screen"
+msgstr ""
+
+#: id:10034
+msgid "Settings - Profiles"
+msgstr "Stillingar - Notendur"
+
+#: id:10040
+msgid "Addon browser"
+msgstr ""
+
+#: id:10100
+msgid "Yes/No dialog"
+msgstr "Já/Nei melding"
+
+#: id:10101
+msgid "Progress dialog"
+msgstr "Vinnslumelding"
+
+#: id:10210
+msgid "Looking for subtitles..."
+msgstr "Leita að þýðingartexta..."
+
+#: id:10211
+msgid "Looking for or caching subtitles..."
+msgstr "Leita að þýðingartexta eða set í biðminni..."
+
+#: id:10212
+msgid "terminating"
+msgstr "loka"
+
+#: id:10213
+msgid "buffering"
+msgstr "biðminni"
+
+#: id:10214
+msgid "Opening stream"
+msgstr "Opna straum"
+
+#: id:10500
+msgid "Music/Playlist"
+msgstr "Tónlist/Lagalisti"
+
+#: id:10501
+msgid "Music/Files"
+msgstr "Tónlist/Skrár"
+
+#: id:10502
+msgid "Music/Library"
+msgstr "Tónlist/Safn"
+
+#: id:10503
+msgid "Playlist editor"
+msgstr "Spilunarlistaritill"
+
+#: id:10504
+msgid "Top 100 songs"
+msgstr "Topp 100 lög"
+
+#: id:10505
+msgid "Top 100 albums"
+msgstr "Topp 100 plötur"
+
+#: id:10506
+msgctxt "Auto context with id 10506"
+msgid "Programs"
+msgstr "Forrit"
+
+#: id:10507
+msgid "Configuration"
+msgstr "Uppsetning"
+
+#: id:10508
+msgid "Weather forecast"
+msgstr "Veðurspá"
+
+#: id:10509
+msgid "Network gaming"
+msgstr "Netspilun"
+
+#: id:10510
+msgid "Extensions"
+msgstr "Framlengingar"
+
+#: id:10511
+msgctxt "Auto context with id 10511"
+msgid "System info"
+msgstr "Kerfisupplýsingar"
+
+#: id:10516
+msgid "Music - Library"
+msgstr "Tónlist - Tónlistarsafn"
+
+#: id:10517
+msgid "Now Playing - Music"
+msgstr "Í spilun - Tónlist"
+
+#: id:10522
+msgid "Now Playing - Videos"
+msgstr "Í spilun - Myndefni"
+
+#: id:10523
+msgid "Album info"
+msgstr "Hljómplötuupplýsingar"
+
+#: id:10524
+msgid "Movie info"
+msgstr "Kvikmyndaupplýsingar"
+
+#: id:12000
+msgid "Select dialog"
+msgstr "Valskilti"
+
+#: id:12001
+msgid "Music/Info"
+msgstr "Tónlist/upplýsingar"
+
+#: id:12002
+msgid "Dialog OK"
+msgstr "Gluggi í lagi"
+
+#: id:12003
+msgid "Videos/Info"
+msgstr "Kvikmyndir/Uppl."
+
+#: id:12004
+msgid "Scripts/Info"
+msgstr "Skriftur/Uppl."
+
+#: id:12005
+msgid "Fullscreen video"
+msgstr "Heilskjásmynd"
+
+#: id:12006
+msgid "Audio visualization"
+msgstr "Myndskreyting"
+
+#: id:12008
+msgid "File stacking dialog"
+msgstr "Skjalaröðunarskilti"
+
+#: id:12009
+msgid "Rebuild index..."
+msgstr "Endurbygging á atriðaskrá..."
+
+#: id:12010
+msgid "Return to music window"
+msgstr "Til baka í tónlist"
+
+#: id:12011
+msgid "Return to videos window"
+msgstr "Til baka í myndefni"
+
+#: id:12021
+msgid "Start from beginning"
+msgstr "Byrja frá byrjun"
+
+#: id:12022
+msgid "Resume from %s"
+msgstr "Áfram frá %s"
+
+#: id:12310
+msgid "0"
+msgstr "0"
+
+#: id:12311
+msgid "1"
+msgstr "1"
+
+#: id:12312
+msgid "2"
+msgstr "2"
+
+#: id:12313
+msgid "3"
+msgstr "3"
+
+#: id:12314
+msgid "4"
+msgstr "4"
+
+#: id:12315
+msgid "5"
+msgstr "5"
+
+#: id:12316
+msgid "6"
+msgstr "6"
+
+#: id:12317
+msgid "7"
+msgstr "7"
+
+#: id:12318
+msgid "8"
+msgstr "8"
+
+#: id:12319
+msgid "9"
+msgstr "9"
+
+#: id:12320
+msgid "c"
+msgstr "c"
+
+#: id:12321
+msgid "Ok"
+msgstr "Í lagi"
+
+#: id:12322
+msgid "*"
+msgstr "*"
+
+#: id:12325
+msgid "Locked! Enter code..."
+msgstr "Læst! Sláðu inn kóða..."
+
+#: id:12326
+msgid "Enter password"
+msgstr "Sláðu inn lykilorð"
+
+#: id:12327
+msgid "Enter master code"
+msgstr "Sláðu inn aðal kóða"
+
+#: id:12328
+msgid "Enter unlock code"
+msgstr "Sláðu inn opnunar kóða"
+
+#: id:12329
+msgid "or press C to cancel"
+msgstr "eða ýttu á C til að hætta við"
+
+#: id:12330
+msgid "Enter gamepad button combo and"
+msgstr "Ýttu á hnappa samsetningu og"
+
+#: id:12331
+msgid "press OK, or Back to cancel"
+msgstr "ýttu á Start, eða Back til að hætta við"
+
+#: id:12332
+msgid "Set lock"
+msgstr "Setja lás"
+
+#: id:12333
+msgid "Unlock"
+msgstr "Taka úr lás"
+
+#: id:12334
+msgid "Reset lock"
+msgstr "Endurstilla læsingu"
+
+#: id:12335
+msgid "Remove lock"
+msgstr "Fjarlægja læsingu"
+
+#: id:12337
+msgid "Numeric password"
+msgstr "Tölulegt lykilorð"
+
+#: id:12338
+msgid "Gamepad button combo"
+msgstr "Hnappa lykilorð"
+
+#: id:12339
+msgid "Full-text password"
+msgstr "Texta lykilorð"
+
+#: id:12340
+msgid "Enter new password"
+msgstr "Sláðu inn nýtt lykilorð"
+
+#: id:12341
+msgid "Re-Enter new password"
+msgstr "Sláðu aftur inn nýtt lykilorð"
+
+#: id:12342
+msgid "Incorrect password,"
+msgstr "Vitlaust Lykilorð,"
+
+#: id:12343
+msgid "retries left"
+msgstr "endurtekningar eftir"
+
+#: id:12344
+msgid "Passwords entered did not match."
+msgstr "Lykilorð passa ekki."
+
+#: id:12345
+msgid "Access denied"
+msgstr "Aðgangur ekki leyfður"
+
+#: id:12346
+msgid "Password retry limit exceeded."
+msgstr "Fjöldi ágiskana á lykilorð er uppurinn."
+
+#: id:12347
+msgid "The system will now shut off."
+msgstr "Kerfið mun núna slökkva á sér."
+
+#: id:12348
+msgid "Item locked"
+msgstr "Atriði læst"
+
+#: id:12353
+msgid "Reactivate lock"
+msgstr "Setja læsingu á"
+
+#: id:12356
+msgid "Change lock"
+msgstr "Breyta læsingu"
+
+#: id:12357
+msgid "Source lock"
+msgstr "Læsa Samnýtingu"
+
+#: id:12358
+msgid "Password entry was blank. Try again."
+msgstr "Lyklorð var tómt. Reyndu aftur."
+
+#: id:12360
+msgid "Master lock"
+msgstr "Aðal læsing"
+
+#: id:12362
+msgid "Shutdown system if Master Lock retries exceeded"
+msgstr "Slökkva á kerfi ef fjöldi lykilorðságiskana á lás fer yfir hámark"
+
+#: id:12367
+msgid "Master code is not valid"
+msgstr "Aðal kóði er ekki gildur"
+
+#: id:12368
+msgid "Please enter a valid master code"
+msgstr "Vinsamlega sláðu inn aðal kóða"
+
+#: id:12373
+msgid "Settings & file manager"
+msgstr "Stillingar og skráarsýsl"
+
+#: id:12376
+msgid "Set as default for all movies"
+msgstr "Setja sem sjálfgefið fyrir allar myndir"
+
+#: id:12377
+msgid "This will reset any previously saved values"
+msgstr "Þetta mun endurstilla allar fyrri vistaðar stillingar"
+
+#: id:12378
+msgid "Amount of time to display each image"
+msgstr "Sýna hverja mynd í"
+
+#: id:12379
+msgid "Use pan and zoom effects"
+msgstr "Nota skotrun og þysjun"
+
+#: id:12383
+msgid "12 hour clock"
+msgstr "12 klst klukka"
+
+#: id:12384
+msgid "24 hour clock"
+msgstr "24 klst klukka"
+
+#: id:12385
+msgid "Day/Month"
+msgstr "Dagur/Mánuður"
+
+#: id:12386
+msgid "Month/Day"
+msgstr "Mánuður/Dagur"
+
+#: id:12390
+msgid "System uptime"
+msgstr "Uppitími Kerfis"
+
+#: id:12391
+msgid "Minutes"
+msgstr "Mínútur"
+
+#: id:12392
+msgid "Hours"
+msgstr "Klukkustundir"
+
+#: id:12393
+msgid "Days"
+msgstr "Dagar"
+
+#: id:12394
+msgid "Total uptime"
+msgstr "Heildar uppitími"
+
+#: id:12395
+msgid "Battery level"
+msgstr "Rafhlaða"
+
+#: id:12600
+msgctxt "Auto context with id 12600"
+msgid "Weather"
+msgstr "Veður"
+
+#: id:12900
+msgctxt "Auto context with id 12900"
+msgid "Screensaver"
+msgstr "Skjávari"
+
+#: id:12901
+msgid "Fullscreen OSD"
+msgstr "Heilskjár OSD"
+
+#: id:13000
+msgid "System"
+msgstr "Kerfi"
+
+#: id:13001
+msgid "Immediate HD spindown"
+msgstr "Slökkva strax á disk"
+
+#: id:13002
+msgid "Video only"
+msgstr "Bara myndefni"
+
+#: id:13003
+msgid "- Delay"
+msgstr "- Bið"
+
+#: id:13004
+msgid "- Minimum file duration"
+msgstr "- Lágmarks tímalengd"
+
+#: id:13005
+msgid "Shutdown"
+msgstr "Slökkva"
+
+#: id:13008
+msgid "Shutdown function"
+msgstr "Hætta aðgerð"
+
+#: id:13009
+msgid "Quit"
+msgstr "Hætta"
+
+#: id:13010
+msgid "Hibernate"
+msgstr "Dvali"
+
+#: id:13011
+msgid "Suspend"
+msgstr "Svæfa"
+
+#: id:13012
+msgid "Exit"
+msgstr "Hætta"
+
+#: id:13013
+msgid "Reboot"
+msgstr "Endurræsa"
+
+#: id:13014
+msgid "Minimize"
+msgstr "Minnka"
+
+#: id:13015
+msgid "Power button action"
+msgstr "Aðgerð straumrofa"
+
+#: id:13016
+msgid "Power off System"
+msgstr "Slökkva á kerfi"
+
+#: id:13020
+msgid "Is another session active, perhaps over ssh?"
+msgstr "Er önnur lota virk, kannski yfir ssh?"
+
+#: id:13021
+msgid "Mounted removable harddrive"
+msgstr "Tengdur utanáliggjandi harður diskur"
+
+#: id:13022
+msgid "Unsafe device removal"
+msgstr "Ótraust fjarlæging á tæki"
+
+#: id:13023
+msgid "Successfully removed device"
+msgstr "Tókst að fjarlægja tæki"
+
+#: id:13024
+msgid "Joystick plugged"
+msgstr "Stýripinni tengdur"
+
+#: id:13025
+msgid "Joystick unplugged"
+msgstr "Stýripinni ótengdur"
+
+#: id:13050
+msgid "Running low on battery"
+msgstr "Rafhlaða er alveg að tæmast"
+
+#: id:13100
+msgid "Flicker filter"
+msgstr "Flökt sía"
+
+#: id:13101
+msgid "Let driver choose (requires restart)"
+msgstr "Láta rekil ráða (þarfnast endurræsingar)"
+
+#: id:13105
+msgid "Vertical blank sync"
+msgstr "Lóðrétt auð samstilling"
+
+#: id:13106
+msgctxt "Auto context with id 13106"
+msgid "Disabled"
+msgstr "Óvirkt"
+
+#: id:13107
+msgid "Enabled during video playback"
+msgstr "Virkt við afspilun"
+
+#: id:13108
+msgctxt "Auto context with id 13108"
+msgid "Always enabled"
+msgstr "Alltaf virkt"
+
+#: id:13109
+msgid "Test & apply resolution"
+msgstr "Prufa og virkja upplausn"
+
+#: id:13110
+msgid "Save resolution?"
+msgstr "Vista upplausn?"
+
+#: id:13111
+msgid "Would you like to keep this resolution?"
+msgstr "Viltu nota þessa upplausn?"
+
+#: id:13112
+msgid "High quality upscaling"
+msgstr "Hágæða stækkun í hugbúnaði"
+
+#: id:13113
+msgctxt "Auto context with id 13113"
+msgid "Disabled"
+msgstr "Óvirkt"
+
+#: id:13114
+msgid "Enabled for SD content"
+msgstr "Virkjað fyrir SD efni"
+
+#: id:13115
+msgctxt "Auto context with id 13115"
+msgid "Always enabled"
+msgstr "Alltaf virkt"
+
+#: id:13116
+msgid "Upscaling method"
+msgstr "Stækkunaraðferð"
+
+#: id:13117
+msgctxt "Auto context with id 13117"
+msgid "Bicubic"
+msgstr "Bicubic"
+
+#: id:13118
+msgid "Lanczos"
+msgstr "Lanczos"
+
+#: id:13119
+msgid "Sinc"
+msgstr "Sinc"
+
+#: id:13120
+msgctxt "Auto context with id 13120"
+msgid "VDPAU"
+msgstr "VDPAU"
+
+#: id:13121
+msgid "VDPAU HQ Upscaling level"
+msgstr "VDPAU HQ stækkunargildi"
+
+#: id:13122
+msgid "VDPAU Studio level color conversion"
+msgstr "VDPAU Studio litabreytingargildi"
+
+#: id:13130
+msgid "Blank other displays"
+msgstr "Tæma aðra skjái"
+
+#: id:13131
+msgctxt "Auto context with id 13131"
+msgid "Disabled"
+msgstr "Óvirkt"
+
+#: id:13132
+msgid "Blank displays"
+msgstr "Tómur skjár"
+
+#: id:13140
+msgid "Active connections detected!"
+msgstr "Uppgötvaði virkar tengingar!"
+
+#: id:13141
+msgid "If you proceed, you might not be able to control XBMC"
+msgstr "Ef þú heldur áfram, er hætta á því að þú munir ekki getað"
+
+#: id:13142
+msgid "any longer. Are you sure you want to stop the Event server?"
+msgstr "stjórnað XBMC áfram. Ertu viss um að þú viljir stöðva atriðaþjón?"
+
+#: id:13144
+msgid "Change Apple Remote mode?"
+msgstr "Breyta ham Apple fjarstýringar?"
+
+#: id:13145
+msgid "If you are currently using the Apple Remote to control"
+msgstr "Ef þú ert núna þegar að nota Apple fjarstýringu til að stjórna"
+
+#: id:13146
+msgid "XBMC, changing this setting might affect your ability"
+msgstr "XBMC, gæti breyting á þessu haft áhrif á getu þína"
+
+#: id:13147
+msgid "to continue controlling it. Do you want to proceed?"
+msgstr "til að halda áfram að stjórna því. Viltu halda áfram?"
+
+#: id:13159
+msgid "Subnet mask"
+msgstr "Undirnetssía"
+
+#: id:13160
+msgid "Gateway"
+msgstr "Gátt"
+
+#: id:13161
+msgid "Primary DNS"
+msgstr "Aðal DNS"
+
+#: id:13162
+msgid "Initialize failed"
+msgstr "Frumstilling mistókst"
+
+#: id:13170
+msgctxt "Auto context with id 13170"
+msgid "Never"
+msgstr "Aldrei"
+
+#: id:13171
+msgid "Immediately"
+msgstr "Strax"
+
+#: id:13172
+msgid "After %i secs"
+msgstr "Eftir %i sek"
+
+#: id:13173
+msgid "HDD install date:"
+msgstr "Uppsetningardagur Harðdisks:"
+
+#: id:13174
+msgid "HDD power cycle count:"
+msgstr "Fjöldi skipta sem slökkt hefur verið á HDD:"
+
+#: id:13200
+msgid "Profiles"
+msgstr "Notendur"
+
+#: id:13201
+msgid "Delete profile '%s'?"
+msgstr "Eyða notanda '%s'?"
+
+#: id:13204
+msgid "Last loaded profile:"
+msgstr "Seinasti notandi:"
+
+#: id:13205
+msgid "Unknown"
+msgstr "Óþekkt"
+
+#: id:13206
+msgid "Overwrite"
+msgstr "Yfirskrifa"
+
+#: id:13208
+msgid "Alarm clock"
+msgstr "Vekjaraklukka"
+
+#: id:13209
+msgid "Alarm clock interval (in minutes)"
+msgstr "Vekjaraklukku tími (í mínútum)"
+
+#: id:13210
+msgid "Started, alarm in %im"
+msgstr "Í gangi, vakning eftir %im"
+
+#: id:13211
+msgid "Alarm!"
+msgstr "Vakna!"
+
+#: id:13212
+msgid "Canceled with %im%is left"
+msgstr "Slökkt með %im%is eftir"
+
+#: id:13213
+msgid "%2.0fm"
+msgstr "%2.0fm"
+
+#: id:13214
+msgid "%2.0fs"
+msgstr "%2.0fs"
+
+#: id:13249
+msgid "Search for subtitles in RARs"
+msgstr "Leita að þýðingartextum í RAR skrám"
+
+#: id:13250
+msgid "Browse for subtitle..."
+msgstr "Leita eftir þýðingartexta..."
+
+#: id:13251
+msgid "Move item"
+msgstr "Færa hlut"
+
+#: id:13252
+msgid "Move item here"
+msgstr "Færa hlut hingað"
+
+#: id:13253
+msgid "Cancel move"
+msgstr "Hætta við að færa"
+
+#: id:13270
+msgid "Hardware:"
+msgstr "Vélbúnaður:"
+
+#: id:13271
+msgid "CPU Usage:"
+msgstr "CPU notkun:"
+
+#: id:13274
+msgid "Connected, but no DNS is available."
+msgstr "Tengdur, en enginn DNS er til staðar."
+
+#: id:13275
+msgid "Hard Disk"
+msgstr "Harður diskur"
+
+#: id:13276
+msgid "DVD-ROM"
+msgstr "DVD-ROM"
+
+#: id:13277
+msgctxt "Auto context with id 13277"
+msgid "Storage"
+msgstr "Geymsla"
+
+#: id:13278
+msgctxt "Auto context with id 13278"
+msgid "Default"
+msgstr "Sjálfgefið"
+
+#: id:13279
+msgctxt "Auto context with id 13279"
+msgid "Network"
+msgstr "Netið"
+
+#: id:13280
+msgctxt "Auto context with id 13280"
+msgid "Video"
+msgstr "Skjár"
+
+#: id:13281
+msgid "Hardware"
+msgstr "Vélbúnaður"
+
+#: id:13283
+msgid "Operating system:"
+msgstr "Stýrikerfi:"
+
+#: id:13284
+msgid "CPU speed:"
+msgstr "CPU hraði:"
+
+#: id:13286
+msgid "Video encoder:"
+msgstr "Skjáhraðall:"
+
+#: id:13287
+msgid "Screen resolution:"
+msgstr "Skjáupplausn:"
+
+#: id:13292
+msgid "A/V cable:"
+msgstr "Hljóð/Mynd tengi:"
+
+#: id:13294
+msgid "DVD region:"
+msgstr "DVD svæði:"
+
+#: id:13295
+msgid "Internet:"
+msgstr "Internet:"
+
+#: id:13296
+msgctxt "Auto context with id 13296"
+msgid "Connected"
+msgstr "Tengdur"
+
+#: id:13297
+msgid "Not connected. Check network settings."
+msgstr "Ekki tengdur. Athugaðu netstillingar."
+
+#: id:13299
+msgid "Target temperature"
+msgstr "Fastur hiti"
+
+#: id:13300
+msgid "Fan speed"
+msgstr "Viftuhraði"
+
+#: id:13301
+msgid "Auto temperature control"
+msgstr "Sjálfvikur hitastillir"
+
+#: id:13302
+msgid "Fan speed override"
+msgstr "Fastur viftuhraði"
+
+#: id:13303
+msgid "- Fonts"
+msgstr "- Leturgerðir"
+
+#: id:13304
+msgid "Enable flipping bi-directional strings"
+msgstr "Snúa margstefnu texta"
+
+#: id:13305
+msgid "Show RSS news feeds"
+msgstr "Sýna RSS fréttastrauma"
+
+#: id:13306
+msgid "Show parent folder items"
+msgstr "Sýna yfirmöpputákn"
+
+#: id:13307
+msgid "Track naming template"
+msgstr "Sniðmát lagaheita"
+
+#: id:13308
+msgid "Do you wish to reboot your system"
+msgstr "Viltu endurræsa vélina"
+
+#: id:13309
+msgid "instead of just XBMC?"
+msgstr "í staðinn fyrir bara XBMC?"
+
+#: id:13310
+msgid "Zoom effect"
+msgstr "Aðdráttar áhrif"
+
+#: id:13311
+msgid "Float effect"
+msgstr "Fljóta áhrif"
+
+#: id:13312
+msgid "Black bar reduction"
+msgstr "Minnka svartar rendur"
+
+#: id:13313
+msgid "Restart"
+msgstr "Endurræsa"
+
+#: id:13314
+msgid "Crossfade between songs"
+msgstr "Renna saman lögum"
+
+#: id:13315
+msgid "Regenerate thumbnails"
+msgstr "Endurgera smámyndir"
+
+#: id:13316
+msgid "Recursive thumbnails"
+msgstr "Endurkvæmar smámyndir"
+
+#: id:13317
+msgid "View slideshow"
+msgstr "Horfa á myndasýningu"
+
+#: id:13318
+msgid "Recursive slideshow"
+msgstr "Endurkvæm myndasýning"
+
+#: id:13319
+msgid "Randomize"
+msgstr "Handahófskennt"
+
+#: id:13320
+msgid "Stereo"
+msgstr "Víðómur"
+
+#: id:13321
+msgid "Left only"
+msgstr "Bara vinstri"
+
+#: id:13322
+msgid "Right only"
+msgstr "Bara hægri"
+
+#: id:13323
+msgid "Enable karaoke support"
+msgstr "Virkja karaoke stuðning"
+
+#: id:13324
+msgid "Background transparency"
+msgstr "Gegnsæi bakgrunns"
+
+#: id:13325
+msgid "Foreground transparency"
+msgstr "Gegnsæi forgrunns"
+
+#: id:13326
+msgid "A/V delay"
+msgstr "Hljóð/Mynd seinkun"
+
+#: id:13327
+msgid "Karaoke"
+msgstr "Karaoke"
+
+#: id:13328
+msgid "%s not found"
+msgstr "%s fannst ekki"
+
+#: id:13329
+msgid "Error opening %s"
+msgstr "Get ekki opnað %s"
+
+#: id:13330
+msgid "Unable to load %s"
+msgstr "Get ekki hlaðið inn %s"
+
+#: id:13331
+msgid "Error: Out of memory"
+msgstr "Villa: Ekki nóg minni"
+
+#: id:13332
+msgid "Move up"
+msgstr "Færa upp"
+
+#: id:13333
+msgid "Move down"
+msgstr "Færa niður"
+
+#: id:13334
+msgid "Edit label"
+msgstr "Breyta nafni"
+
+#: id:13335
+msgid "Make default"
+msgstr "Gera sjálfgefið"
+
+#: id:13336
+msgid "Remove button"
+msgstr "Eyða takka"
+
+#: id:13340
+msgid "Leave as is"
+msgstr "Láta eiga sig"
+
+#: id:13341
+msgid "Green"
+msgstr "Grænn"
+
+#: id:13342
+msgid "Orange"
+msgstr "Appelsínugulur"
+
+#: id:13343
+msgid "Red"
+msgstr "Rauður"
+
+#: id:13344
+msgid "Cycle"
+msgstr "Hringrás"
+
+#: id:13345
+msgid "Switch LED off on playback"
+msgstr "Slökkva á LED við spilun"
+
+#: id:13346
+msgctxt "Auto context with id 13346"
+msgid "Movie information"
+msgstr "Kvikmyndaupplýsingar"
+
+#: id:13347
+msgid "Queue item"
+msgstr "Setja í biðröð"
+
+#: id:13348
+msgid "Search IMDb..."
+msgstr "Leita í IMDb..."
+
+#: id:13349
+msgid "Scan for new content"
+msgstr "Leita að nýju innihaldi"
+
+#: id:13350
+msgid "Now playing..."
+msgstr "Í spilun..."
+
+#: id:13351
+msgctxt "Auto context with id 13351"
+msgid "Album information"
+msgstr "Hljómplötuupplýsingar"
+
+#: id:13352
+msgid "Scan item to library"
+msgstr "Skanna hlut í safn"
+
+#: id:13353
+msgid "Stop scanning"
+msgstr "Hætta skönnun"
+
+#: id:13354
+msgctxt "Auto context with id 13354"
+msgid "Render method"
+msgstr "Teikni hamur"
+
+#: id:13355
+msgid "Low quality pixel shader"
+msgstr "Lágæða punkta skygging"
+
+#: id:13356
+msgid "Hardware overlays"
+msgstr "Vélbúnaðar yfirlag"
+
+#: id:13357
+msgid "High quality pixel shader"
+msgstr "Hágæða punkta skyggir"
+
+#: id:13358
+msgid "Play item"
+msgstr "Spila hlut"
+
+#: id:13359
+msgid "Set artist thumb"
+msgstr "Setja smámynd á listamann"
+
+#: id:13360
+msgid "Automatically generate thumbnails"
+msgstr "Búa til smámyndir"
+
+#: id:13361
+msgid "Enable voice"
+msgstr "Virkja rödd"
+
+#: id:13375
+msgid "Enable device"
+msgstr "Virkja Tæki"
+
+#: id:13376
+msgid "Volume"
+msgstr "Hljóðstyrkur"
+
+#: id:13377
+msgid "Default view mode"
+msgstr "Sjálfgefinn sjónarhornsháttur"
+
+#: id:13378
+msgid "Default brightness"
+msgstr "Sjálfgefin birtuskil"
+
+#: id:13379
+msgid "Default contrast"
+msgstr "Sjálfgefin skerpuskil"
+
+#: id:13380
+msgid "Default gamma"
+msgstr "Sjálfgefið gamma"
+
+#: id:13381
+msgid "Resume video"
+msgstr "Áfram með mynd"
+
+#: id:13382
+msgid "Voice mask - Port 1"
+msgstr "Fela rödd - Tengi 1"
+
+#: id:13383
+msgid "Voice mask - Port 2"
+msgstr "Fela rödd - Tengi 2"
+
+#: id:13384
+msgid "Voice mask - Port 3"
+msgstr "Fela rödd - Tengi 3"
+
+#: id:13385
+msgid "Voice mask - Port 4"
+msgstr "Fela rödd - Tengi 4"
+
+#: id:13386
+msgid "Use time based seeking"
+msgstr "Nota tíma leit"
+
+#: id:13387
+msgid "Track naming template - right"
+msgstr "Sniðmát lagaheita - hægri"
+
+#: id:13388
+msgid "Preset"
+msgstr "Forstilling"
+
+#: id:13389
+msgid "There are no presets available\nfor this visualization"
+msgstr "Það eru ekki til neinar forstillingar fyrir þessa myndskreytingu"
+
+#: id:13390
+msgid "There are no settings available\nfor this visualization"
+msgstr "Það eru ekki til neinar stillingar fyrir þessa myndskreytingu"
+
+#: id:13391
+msgid "Eject/Load"
+msgstr "Disk út/inn"
+
+#: id:13392
+msgid "Use visualization if playing audio"
+msgstr "Nota myndskreytingu við tónlist"
+
+#: id:13393
+msgid "Calculate size"
+msgstr "Reikna stærð"
+
+#: id:13394
+msgid "Calculating folder size"
+msgstr "Reikna möppu stærð"
+
+#: id:13395
+msgid "Video settings"
+msgstr "Myndstillingar"
+
+#: id:13396
+msgid "Audio and subtitle settings"
+msgstr "Hljóð og texta stillingar"
+
+#: id:13397
+msgid "Enable subtitles"
+msgstr "Virkja þýðingartexta"
+
+#: id:13398
+msgctxt "Auto context with id 13398"
+msgid "Shortcuts"
+msgstr "Flýtileiðir"
+
+#: id:13399
+msgid "Ignore articles when sorting (e.g. \"the\")"
+msgstr "Hunsa greinir þegar raðað er (t.d. \"the\")"
+
+#: id:13400
+msgid "Crossfade between songs on the same album"
+msgstr "Renna saman lögum á sömu hljómplötu"
+
+#: id:13401
+msgid "Browse for %s"
+msgstr "Leita að %s"
+
+#: id:13402
+msgid "Show track position"
+msgstr "Sýna staðsetningu í lögum"
+
+#: id:13403
+msgid "Clear default"
+msgstr "Hreinsa sjálfgildi"
+
+#: id:13404
+msgid "Resume"
+msgstr "Halda áfram"
+
+#: id:13405
+msgid "Get thumb"
+msgstr "Ná í smámynd"
+
+#: id:13406
+msgid "Picture information"
+msgstr "Myndupplýsingar"
+
+#: id:13407
+msgid "%s presets"
+msgstr "%s forstillingar"
+
+#: id:13408
+msgid "(IMDb user rating)"
+msgstr "(IMDb Stjörnugjöf notanda)"
+
+#: id:13409
+msgid "Top 250"
+msgstr "Topp 250"
+
+#: id:13410
+msgid "Tune in on Last.fm"
+msgstr "Stilla inn á Last.fm"
+
+#: id:13411
+msgid "Minimum fan speed"
+msgstr "Lágmarks viftuhraði"
+
+#: id:13412
+msgid "Play from here"
+msgstr "Spila hér"
+
+#: id:13413
+msgid "Downloading"
+msgstr "Niðurhala"
+
+#: id:13414
+msgid "Include artists who appear only on compilations"
+msgstr "Fela tónlistarmenn sem birtast aðeins á safndiskum"
+
+#: id:13415
+msgctxt "Auto context with id 13415"
+msgid "Render method"
+msgstr "Teikni hamur"
+
+#: id:13416
+msgid "Auto detect"
+msgstr "Sjálfvirkt"
+
+#: id:13417
+msgid "Basic shaders (ARB)"
+msgstr "Grunn skygging (ARB)"
+
+#: id:13418
+msgid "Advanced shaders (GLSL)"
+msgstr "Ítarleg skygging (GLSL)"
+
+#: id:13419
+msgid "Software"
+msgstr "Hugbúnaður"
+
+#: id:13420
+msgid "Remove safely"
+msgstr "Fjarlægja á öruggan hátt"
+
+#: id:13421
+msgctxt "Auto context with id 13421"
+msgid "VDPAU"
+msgstr "VDPAU"
+
+#: id:13422
+msgid "Start slideshow here"
+msgstr "Byrja myndasýningu hér"
+
+#: id:13423
+msgid "Remember for this path"
+msgstr "Muna fyrir þessa slóð"
+
+#: id:13424
+msgid "Use pixel buffer objects"
+msgstr "Nota punkta biðminni hluti"
+
+#: id:13425
+msgid "Allow hardware acceleration (VDPAU)"
+msgstr "Leyfa vélbúnaðarhröðun (VDPAU)"
+
+#: id:13426
+msgid "Allow hardware acceleration (VAAPI)"
+msgstr "Leyfa vélbúnaðarhröðun (VAAPI)"
+
+#: id:13427
+msgid "Allow hardware acceleration (DXVA2)"
+msgstr "Leyfa vélbúnaðarhröðun (DXVA2)"
+
+#: id:13428
+msgid "Allow hardware acceleration (CrystalHD)"
+msgstr "Leyfa vélbúnaðarhröðun (CrystalHD)"
+
+#: id:13429
+msgid "Allow hardware acceleration (VDADecoder)"
+msgstr "Leyfa vélbúnaðarhröðun (VDADecoder)"
+
+#: id:13430
+msgid "Allow hardware acceleration (OpenMax)"
+msgstr "Leyfa vélbúnaðarhröðun (OpenMax)"
+
+#: id:13431
+msgid "Pixel Shaders"
+msgstr "Punktaskyggir"
+
+#: id:13432
+msgid "Allow hardware acceleration (VideoToolbox)"
+msgstr "Leyfa vélbúnaðarhröðun (VideoToolbox)"
+
+#: id:13500
+msgid "A/V sync method"
+msgstr "A/V samstillingaraðferð"
+
+#: id:13501
+msgid "Audio clock"
+msgstr "Hljóðklukka"
+
+#: id:13502
+msgid "Video clock (Drop/Dupe audio)"
+msgstr "Myndklukka (Sleppa/Afrita hljóð)"
+
+#: id:13503
+msgid "Video clock (Resample audio)"
+msgstr "Myndklukka (Endurblanda hljóð)"
+
+#: id:13504
+msgid "Maximum resample amount (%)"
+msgstr "Hámark endurblöndunar (%)"
+
+#: id:13505
+msgid "Resample quality"
+msgstr "Endurblöndunargæði"
+
+#: id:13506
+msgid "Low(fast)"
+msgstr "Lágt(hratt)"
+
+#: id:13507
+msgctxt "Auto context with id 13507"
+msgid "Medium"
+msgstr "Meðal"
+
+#: id:13508
+msgctxt "Auto context with id 13508"
+msgid "High"
+msgstr "Hátt"
+
+#: id:13509
+msgid "Really high(slow!)"
+msgstr "Mjög hátt(hægvirkt!)"
+
+#: id:13510
+msgid "Sync playback to display"
+msgstr "Samstilla spilun við skjá"
+
+#: id:13550
+msgid "Pause during refresh rate change"
+msgstr "Setja í bið þegar glæðningartíðni er breytt"
+
+#: id:13551
+msgctxt "Auto context with id 13551"
+msgid "Off"
+msgstr "Af"
+
+#: id:13552
+msgid "%.1f Second"
+msgstr "%.1f Sekúnda"
+
+#: id:13553
+msgid "%.1f Seconds"
+msgstr "%.1f Sekúndur"
+
+#: id:13600
+msgid "Apple remote"
+msgstr "Apple fjarstýring"
+
+#: id:13602
+msgid "Allow start of XBMC using the remote"
+msgstr "Leyfa að ræsa XBMC með fjarstýringunni"
+
+#: id:13603
+msgid "Sequence delay time"
+msgstr "Runu biðtími"
+
+#: id:13610
+msgctxt "Auto context with id 13610"
+msgid "Disabled"
+msgstr "Óvirkt"
+
+#: id:13611
+msgctxt "Auto context with id 13611"
+msgid "Standard"
+msgstr "Venjulegt"
+
+#: id:13612
+msgid "Universal Remote"
+msgstr "Altæk fjarstýring"
+
+#: id:13613
+msgid "Multi Remote (Harmony)"
+msgstr "Fjölfjarstýring (Harmony)"
+
+#: id:13620
+msgid "Apple Remote Error"
+msgstr "Villa í Apple fjarstýringu"
+
+#: id:13621
+msgid "Apple Remote support could be enabled."
+msgstr "Ekki er hægt að virkja stuðning við Apple fjarstýringu."
+
+#: id:14000
+msgid "Stack"
+msgstr "Stafla"
+
+#: id:14001
+msgid "Unstack"
+msgstr "Ekki stafla"
+
+#: id:14003
+msgid "Downloading playlist file..."
+msgstr "Hala niður spilunarlista..."
+
+#: id:14004
+msgid "Downloading streams list..."
+msgstr "Hala niður streymi lista..."
+
+#: id:14005
+msgid "Parsing streams list..."
+msgstr "Þátta streymi lista..."
+
+#: id:14006
+msgid "Downloading streams list failed"
+msgstr "Niðurhölun streymilista mistókst"
+
+#: id:14007
+msgid "Downloading playlist file failed"
+msgstr "Niðurhölun spilunarlista mistókst"
+
+#: id:14009
+msgid "Games directory"
+msgstr "Leikja mappa"
+
+#: id:14010
+msgid "Auto switch to thumbs based on"
+msgstr "Skipta sjálfvirkt á smámyndir ef"
+
+#: id:14011
+msgid "Enable auto switching to thumbs view"
+msgstr "Virkja sjálfvirka skiptingu á smámyndasýn"
+
+#: id:14012
+msgid "- Use large icons"
+msgstr "- Nota stór tákn"
+
+#: id:14013
+msgid "- Switch based on"
+msgstr "- Skipting notar"
+
+#: id:14014
+msgid "- Percentage"
+msgstr "- Prósentu"
+
+#: id:14015
+msgid "No files and at least one thumb"
+msgstr "Engar skrár og minnst ein smámynd"
+
+#: id:14016
+msgid "At least one file and thumb"
+msgstr "Minnst ein skrá og smámynd"
+
+#: id:14017
+msgid "Percentage of thumbs"
+msgstr "Prósent smámynda"
+
+#: id:14018
+msgid "View options"
+msgstr "Stillingar sjónarhorns"
+
+#: id:14019
+msgid "Change area code 1"
+msgstr "Breyta svæði 1"
+
+#: id:14020
+msgid "Change area code 2"
+msgstr "Breyta svæði 2"
+
+#: id:14021
+msgid "Change area code 3"
+msgstr "Breyta Svæði 3"
+
+#: id:14022
+msgctxt "Auto context with id 14022"
+msgid "Library"
+msgstr "Safn"
+
+#: id:14023
+msgid "No TV"
+msgstr "Ekkert sjónvarp"
+
+#: id:14024
+msgid "Enter the nearest large town"
+msgstr "Sláðu inn nálæga stóra borg"
+
+#: id:14025
+msgid "Video/Audio/DVD cache - Harddisk"
+msgstr "Myndefni/Hljóð/DVD flýtiminni - Harður diskur"
+
+#: id:14026
+msgid "Video cache - DVD-ROM"
+msgstr "Myndefni flýtiminni - DVD-ROM"
+
+#: id:14027
+msgctxt "Auto context with id 14027"
+msgid "- Local Network"
+msgstr "- Staðarnet"
+
+#: id:14028
+msgctxt "Auto context with id 14028"
+msgid "- Internet"
+msgstr "- Internet"
+
+#: id:14030
+msgid "Audio cache - DVD-ROM"
+msgstr "Hljóð flýtiminni - DVD-ROM"
+
+#: id:14031
+msgctxt "Auto context with id 14031"
+msgid "- Local Network"
+msgstr "- Staðarnet"
+
+#: id:14032
+msgctxt "Auto context with id 14032"
+msgid "- Internet"
+msgstr "- Internet"
+
+#: id:14034
+msgid "DVD cache - DVD-ROM"
+msgstr "DVD flýtiminni - DVD-ROM"
+
+#: id:14035
+msgctxt "Auto context with id 14035"
+msgid "- Local Network"
+msgstr "- Staðarnet"
+
+#: id:14036
+msgctxt "Auto context with id 14036"
+msgid "Services"
+msgstr "Miðlarar"
+
+#: id:14038
+msgid "Network settings changed"
+msgstr "Netstillingum breytt"
+
+#: id:14039
+msgid "XBMC requires to restart to change your"
+msgstr "XBMC þarf að endurræsa til að virkja"
+
+#: id:14040
+msgid "network setup. Would you like to restart now?"
+msgstr "netstillingar. Viltu endurræsa núna?"
+
+#: id:14041
+msgid "Internet connection bandwidth limitation"
+msgstr "Bandvíddstakmarkanir á Internettengingu"
+
+#: id:14043
+msgid "- Shutdown while playing"
+msgstr "- Slökkva í miðri spilun"
+
+#: id:14044
+msgid "%i min"
+msgstr "%i mín"
+
+#: id:14045
+msgid "%i sec"
+msgstr "%i sek"
+
+#: id:14046
+msgid "%i ms"
+msgstr "%i ms"
+
+#: id:14047
+msgid "%i %%"
+msgstr "%i %%"
+
+#: id:14048
+msgid "%i kbps"
+msgstr "%i kbps"
+
+#: id:14049
+msgid "%i kb"
+msgstr "%i kb"
+
+#: id:14050
+msgid "%i.0 dB"
+msgstr "%i.0 dB"
+
+#: id:14051
+msgid "Time format"
+msgstr "Tímasnið"
+
+#: id:14052
+msgid "Date format"
+msgstr "Dagsetningarsnið"
+
+#: id:14053
+msgid "GUI filters"
+msgstr "Viðmóts síur"
+
+#: id:14055
+msgid "Use background scanning"
+msgstr "Nota bakgrunns skönnun"
+
+#: id:14056
+msgid "Stop scan"
+msgstr "Hætta skönnun"
+
+#: id:14057
+msgid "Not possible while scanning for media info"
+msgstr "Ekki hægt á meðan verið er að skanna"
+
+#: id:14058
+msgid "Film grain effect"
+msgstr "Filmukorna áhrif"
+
+#: id:14059
+msgid "Search for thumbnails on remote shares"
+msgstr "Leita að smámyndum á fjartengdum geymslum"
+
+#: id:14060
+msgid "Unknown type cache - Internet"
+msgstr "Flýtiminni fyrir óþekkt efni - Internet"
+
+#: id:14061
+msgctxt "Auto context with id 14061"
+msgid "Auto"
+msgstr "Sjálfvirkt"
+
+#: id:14062
+msgid "Enter username for"
+msgstr "Sláðu inn notandanafn fyrir"
+
+#: id:14063
+msgid "Date & time"
+msgstr "Dagsetning og tími"
+
+#: id:14064
+msgid "Set date"
+msgstr "Stilla dagsetningu"
+
+#: id:14065
+msgid "Set time"
+msgstr "Stilla tíma"
+
+#: id:14066
+msgid "Enter the time in 24 hour HH:MM format"
+msgstr "Sláðu inn dagsetningu á 24 tíma HH:MM sniði"
+
+#: id:14067
+msgid "Enter the date in DD/MM/YYYY format"
+msgstr "Sláðu inn dagsetningu á DD/MM/YYYY sniði"
+
+#: id:14068
+msgid "Enter the IP address"
+msgstr "Sláðu inn IP vistfang"
+
+#: id:14069
+msgid "Apply these settings now?"
+msgstr "Viltu virkja þessar stillingar núna?"
+
+#: id:14070
+msgid "Apply changes now"
+msgstr "Virkja stillingar núna"
+
+#: id:14071
+msgid "Allow file renaming and deletion"
+msgstr "Leyfa að eyða skrám"
+
+#: id:14074
+msgid "Set timezone"
+msgstr "Velja tímabelti"
+
+#: id:14075
+msgid "Use daylight saving time"
+msgstr "Nota sumartíma"
+
+#: id:14076
+msgid "Add to favourites"
+msgstr "Bæta við í uppáhalds"
+
+#: id:14077
+msgid "Remove from favourites"
+msgstr "Fjarlægja úr uppáhalds"
+
+#: id:14078
+msgctxt "Auto context with id 14078"
+msgid "- Colours"
+msgstr "- Litir"
+
+#: id:14079
+msgid "Timezone country"
+msgstr "Tímabelti lands"
+
+#: id:14080
+msgid "Timezone"
+msgstr "Tímabelti"
+
+#: id:14081
+msgid "File lists"
+msgstr "Skráarlistar"
+
+#: id:14082
+msgid "Show EXIF picture information"
+msgstr "Sýna EXIF myndaupplýsingar"
+
+#: id:14083
+msgid "Use a fullscreen window rather than true fullscreen"
+msgstr "Fylla skjáglugga frekar en að fylla skjá"
+
+#: id:14084
+msgid "Queue songs on selection"
+msgstr "Setja lög á biðröð þegar valið er"
+
+#: id:14086
+msgid "Playback"
+msgstr "Spila"
+
+#: id:14087
+msgid "DVDs"
+msgstr "DVD"
+
+#: id:14088
+msgid "Play DVDs automatically"
+msgstr "Spila DVD sjálfvirkt"
+
+#: id:14089
+msgid "Font to use for text subtitles"
+msgstr "Leturgerð til að nota fyrir þýðingartexta"
+
+#: id:14090
+msgid "International"
+msgstr "Alþjóðlegt"
+
+#: id:14091
+msgid "Character set"
+msgstr "Stafasett"
+
+#: id:14092
+msgid "Debugging"
+msgstr "Aflúsa"
+
+#: id:14093
+msgid "Security"
+msgstr "Öryggi"
+
+#: id:14094
+msgid "Input devices"
+msgstr "Inntakstæki"
+
+#: id:14095
+msgid "Power saving"
+msgstr "Orkusparnaður"
+
+#: id:14096
+msgid "Rip"
+msgstr ""
+
+#: id:14097
+msgid "Audio CD Insert Action"
+msgstr ""
+
+#: id:14098
+msgctxt "Auto context with id 14098"
+msgid "Play"
+msgstr ""
+
+#: id:14099
+msgid "Eject disc when CD ripping is complete"
+msgstr ""
+
+#: id:15015
+msgctxt "Auto context with id 15015"
+msgid "Remove"
+msgstr "Fjarlægja"
+
+#: id:15016
+msgid "Games"
+msgstr "Leikir"
+
+#: id:15019
+msgid "Add"
+msgstr "Bæta við"
+
+#: id:15052
+msgid "Password"
+msgstr "Lykilorð"
+
+#: id:15100
+msgctxt "Auto context with id 15100"
+msgid "Library"
+msgstr "Tónlistarsafn"
+
+#: id:15101
+msgid "Database"
+msgstr "Gagnagrunnur"
+
+#: id:15102
+msgid "* All albums"
+msgstr "* Allar hljómplötur"
+
+#: id:15103
+msgid "* All artists"
+msgstr "* Allir flytjendur"
+
+#: id:15104
+msgid "* All songs"
+msgstr "* Öll lög"
+
+#: id:15105
+msgid "* All genres"
+msgstr "* Allir flokkar"
+
+#: id:15107
+msgid "Buffering..."
+msgstr "Biðminni..."
+
+#: id:15108
+msgid "Navigation sounds"
+msgstr "Leiðsagnarhljóð"
+
+#: id:15109
+msgid "Skin default"
+msgstr "Sjálfgildi útlits"
+
+#: id:15111
+msgid "- Theme"
+msgstr "- Þema"
+
+#: id:15112
+msgid "Default theme"
+msgstr "Sjálfgilt Þema"
+
+#: id:15200
+msgid "Last.fm"
+msgstr "Last.fm"
+
+#: id:15201
+msgid "Submit songs to Last.fm"
+msgstr "Senda lög á Last.fm"
+
+#: id:15202
+msgid "Last.fm username"
+msgstr "Last.fm notandanafn"
+
+#: id:15203
+msgid "Last.fm password"
+msgstr "Last.fm lykilorð"
+
+#: id:15204
+msgid "Unable to handshake: sleeping..."
+msgstr "Get ekki tengst með handabandi: bíða..."
+
+#: id:15205
+msgid "Please update XBMC"
+msgstr "Vinsamlegast uppfærðu XBMC"
+
+#: id:15206
+msgid "Bad authorization: Check username and password"
+msgstr "Rangt auðkenni: Athugaðu notandanafn og lykilorð"
+
+#: id:15207
+msgctxt "Auto context with id 15207"
+msgid "Connected"
+msgstr "Tengdur"
+
+#: id:15208
+msgid "Not connected"
+msgstr "Ekki tengdur"
+
+#: id:15209
+msgid "Submit interval %i"
+msgstr "Sendi Millibil %i"
+
+#: id:15210
+msgid "Cached %i songs"
+msgstr "Skyndivistaði %i Lög"
+
+#: id:15211
+msgid "Submitting..."
+msgstr "Sendi..."
+
+#: id:15212
+msgid "Submitting in %i secs"
+msgstr "Sendi eftir %i sek"
+
+#: id:15213
+msgid "Play using..."
+msgstr "Spila Með..."
+
+#: id:15214
+msgid "Use smoothed A/V synchronization"
+msgstr "Nota fína Hljóð/Mynd samstillingu"
+
+#: id:15215
+msgid "Hide file names in thumbs view"
+msgstr "Fela skráarnöfn í smámynda sjónarhorni"
+
+#: id:15216
+msgid "Play in party mode"
+msgstr "Spila í partýham"
+
+#: id:15217
+msgid "Submit songs to Libre.fm"
+msgstr "Senda lög á Libre.fm"
+
+#: id:15218
+msgid "Libre.fm username"
+msgstr "Libre.fm notandanafn"
+
+#: id:15219
+msgid "Libre.fm password"
+msgstr "Libre.fm lykilorð"
+
+#: id:15220
+msgid "Libre.fm"
+msgstr "Libre.fm"
+
+#: id:15221
+msgid "Song submission"
+msgstr "Senda lög"
+
+#: id:15250
+msgid "Submit Last.fm radio to Last.fm"
+msgstr "Senda Last.fm útvarp til Last.fm"
+
+#: id:15251
+msgid "Connecting to Last.fm..."
+msgstr "Tengist við Last.fm..."
+
+#: id:15252
+msgid "Selecting station..."
+msgstr "Vel stöð..."
+
+#: id:15253
+msgid "Search similar artists..."
+msgstr "Leita að svipuðum listamönnum..."
+
+#: id:15254
+msgid "Search similar tags..."
+msgstr "Leita að svipuðum tögum..."
+
+#: id:15255
+msgid "Your profile (%name%)"
+msgstr "Þinn notandi (%name%)"
+
+#: id:15256
+msgid "Overall top tags"
+msgstr "Hæstu tegundir"
+
+#: id:15257
+msgid "Top artists for tag %name%"
+msgstr "Hæstu tónlistarmenn fyrir tegundir %name%"
+
+#: id:15258
+msgid "Top albums for tag %name%"
+msgstr "Hæstu hljómplötur fyrir tegundir %name%"
+
+#: id:15259
+msgid "Top tracks for tag %name%"
+msgstr "Hæstu lög fyrir tegundir %name%"
+
+#: id:15260
+msgid "Listen to tag %name% Last.fm radio"
+msgstr "Hlusta á merki %name% last.fm útvarp"
+
+#: id:15261
+msgid "Similar artists as %name%"
+msgstr "Áþekkir tónlistarmenn og %name%"
+
+#: id:15262
+msgid "Top %name% albums"
+msgstr "Bestu %name% hljómlötur"
+
+#: id:15263
+msgid "Top %name% tracks"
+msgstr "Bestu %name% lög"
+
+#: id:15264
+msgid "Top %name% tags"
+msgstr "Bestu %name% tegundir"
+
+#: id:15265
+msgid "Biggest fans of %name%"
+msgstr "Mestu aðdáendur %name%"
+
+#: id:15266
+msgid "Listen to %name% fans Last.fm radio"
+msgstr "Hlusta á %name% aðdáendur Last.fm útvarp"
+
+#: id:15267
+msgid "Listen to %name% similar artists Last.fm radio"
+msgstr "Hlusta á %name% samskonar tónlistarmenn Last.fm útvarp"
+
+#: id:15268
+msgid "Top artists for user %name%"
+msgstr "Bestu tónlistarmenn fyrir notanda %name%"
+
+#: id:15269
+msgid "Top albums for user %name%"
+msgstr "Bestu hljómlpötur fyrir notanda %name%"
+
+#: id:15270
+msgid "Top tracks for user %name%"
+msgstr "Bestu lög fyrir notanda %name%"
+
+#: id:15271
+msgid "Friends of user %name%"
+msgstr "Vinir notanda %name%"
+
+#: id:15272
+msgid "Neighbours of user %name%"
+msgstr "Nágrannar notanda %name%"
+
+#: id:15273
+msgid "Weekly artist chart for %name%"
+msgstr "Vikulegur listamanna listi fyrir %name%"
+
+#: id:15274
+msgid "Weekly album chart for %name%"
+msgstr "Vikulegur hljómplötu listi fyrir %name%"
+
+#: id:15275
+msgid "Weekly track chart for %name%"
+msgstr "Vikulegur laga listi fyrir %name%"
+
+#: id:15276
+msgid "Listen to %name%'s neighbours Last.fm radio"
+msgstr "Hlusta á nágranna %name%' Last.fm útvarp"
+
+#: id:15277
+msgid "Listen to %name%'s personal Last.fm radio"
+msgstr "Hlusta á einkalista %name%' Last.fm útvarp"
+
+#: id:15278
+msgid "Listen to %name%'s mix Last.fm radio"
+msgstr "Hlusta á uppháhalds lög %name%'s Last.fm útvarp"
+
+#: id:15279
+msgid "Retrieving list from Last.fm..."
+msgstr "Næ í lista frá Last.fm..."
+
+#: id:15280
+msgid "Can't retrieve list from Last.fm..."
+msgstr "Get ekki náð í lista frá Last.fm..."
+
+#: id:15281
+msgid "Enter an artist name to find related ones"
+msgstr "Sláðu inn nafn listamanns til að finna tengda aðila"
+
+#: id:15282
+msgid "Enter a tag name to find similar ones"
+msgstr "Sláðu inn tegund til að finna tengdar tegundir"
+
+#: id:15283
+msgid "Tracks recently listened by %name%"
+msgstr "Lög sem %name% hefur nýlega hlustað á"
+
+#: id:15284
+msgid "Listen to %name%'s recommendations Last.fm radio"
+msgstr "Hlusta á það sem %name%'s mælir með á Last.fm"
+
+#: id:15285
+msgid "Top tags for user %name%"
+msgstr "Topp merki fyrir notanda %name%"
+
+#: id:15287
+msgid "Do you want to add the current track to your loved tracks?"
+msgstr "Viltju setja núverandi lag í uppáhalds lögin?"
+
+#: id:15288
+msgid "Do you want to ban the current track?"
+msgstr "Viltu banna núverandi lag?"
+
+#: id:15289
+msgid "Added to your loved tracks: '%s'."
+msgstr "Bætt við í uppáhaldslög: '%s'."
+
+#: id:15290
+msgid "Could not add '%s' to your loved tracks."
+msgstr "Gat ekki bætt '%s' í uppáhaldslög."
+
+#: id:15291
+msgid "Banned: '%s'."
+msgstr "Bannað: '%s'."
+
+#: id:15292
+msgid "Could not ban '%s'."
+msgstr "Gat ekki bannað '%s'."
+
+#: id:15293
+msgid "Tracks recently loved by %name%"
+msgstr "Nýleg uppáhaldslög %name%"
+
+#: id:15294
+msgid "Tracks recently banned by %name%"
+msgstr "Nýlega bönnuð af %name%"
+
+#: id:15295
+msgid "Remove from loved tracks"
+msgstr "Fjarlægja úr uppáhaldslögum"
+
+#: id:15296
+msgid "Un-ban"
+msgstr "Leyfa"
+
+#: id:15297
+msgid "Do you want to remove this track from your loved tracks?"
+msgstr "Viltu fjarlægja þetta lag úr uppáhaldslista?"
+
+#: id:15298
+msgid "Do you want to un-ban this track?"
+msgstr "Viltu hætta við að banna þetta lag?"
+
+#: id:15300
+msgid "Path not found or invalid"
+msgstr "Slóð fannst ekki eða var röng"
+
+#: id:15301
+msgid "Could not connect to network server"
+msgstr "Gat ekki tengst við miðil"
+
+#: id:15302
+msgid "No servers found"
+msgstr "Engir miðlar fundust"
+
+#: id:15303
+msgid "Workgroup not found"
+msgstr "Vinnuhópur fannst ekki"
+
+#: id:15310
+msgid "Opening multi-path source"
+msgstr "Opna fjölslóða bókamerki"
+
+#: id:15311
+msgid "Path:"
+msgstr "Slóð:"
+
+#: id:16000
+msgctxt "Auto context with id 16000"
+msgid "General"
+msgstr "Almennt"
+
+#: id:16002
+msgid "Internet lookup"
+msgstr "Internet uppfletting"
+
+#: id:16003
+msgid "Player"
+msgstr "Spilari"
+
+#: id:16004
+msgid "Play media from disc"
+msgstr "Spila efni af disk"
+
+#: id:16008
+msgid "Enter new title"
+msgstr "Sláðu inn nýtt nafn"
+
+#: id:16009
+msgid "Enter the movie name"
+msgstr "Sláðu inn nafn kvikmyndar"
+
+#: id:16010
+msgid "Enter the profile name"
+msgstr "Sláðu inn nafn notanda"
+
+#: id:16011
+msgid "Enter the album name"
+msgstr "Sláðu inn nafn hljómplötu"
+
+#: id:16012
+msgid "Enter the playlist name"
+msgstr "Sláðu inn nafn spilunarlista"
+
+#: id:16013
+msgid "Enter new filename"
+msgstr "Sláðu inn nýtt skráarnafn"
+
+#: id:16014
+msgid "Enter folder name"
+msgstr "Sláðu inn nafn möppu"
+
+#: id:16015
+msgid "Enter directory"
+msgstr "Sláðu inn möppu"
+
+#: id:16016
+msgid "Available options: %A, %T, %N, %B, %D, %G, %Y, %F, %S"
+msgstr "Möguleikar: %A, %T, %N, %B, %D, %G, %Y, %F, %S"
+
+#: id:16017
+msgid "Enter search string"
+msgstr "Sláðu inn leitarstreng"
+
+#: id:16018
+msgctxt "Auto context with id 16018"
+msgid "None"
+msgstr "Ekkert"
+
+#: id:16019
+msgid "Auto select"
+msgstr "Sjálfvirkt"
+
+#: id:16020
+msgid "De-interlace"
+msgstr "De-interlace"
+
+#: id:16021
+msgid "Bob"
+msgstr "Bob"
+
+#: id:16022
+msgid "Bob (inverted)"
+msgstr "Bob (Umsnúinn)"
+
+#: id:16024
+msgid "Canceling..."
+msgstr "Hætti við..."
+
+#: id:16025
+msgid "Enter the artist name"
+msgstr "Sláðu inn nafn listamanns"
+
+#: id:16026
+msgid "Playback failed"
+msgstr "Hætt við spilun spilunarlista"
+
+#: id:16027
+msgid "One or more items failed to play."
+msgstr "Mistókst að spila einn eða fleiri hluti."
+
+#: id:16028
+msgid "Enter value"
+msgstr "Sláðu inn gildi"
+
+#: id:16029
+msgid "Check the log file for details."
+msgstr "Athugaðu kladdaskrá fyrir meiri upplýsingar."
+
+#: id:16030
+msgid "Party mode aborted."
+msgstr "Hætt við partí ham."
+
+#: id:16031
+msgid "No matching songs in the library."
+msgstr "Engin samsvarandi lög í lagasafni."
+
+#: id:16032
+msgid "Could not initialize database."
+msgstr "Gat ekki frumstillt gagnagrunn."
+
+#: id:16033
+msgid "Could not open database."
+msgstr "Gat ekki opnað gagnagrunn."
+
+#: id:16034
+msgid "Could not get songs from database."
+msgstr "Gat ekki náð í lög frá gagnagrunni."
+
+#: id:16035
+msgid "Party mode playlist"
+msgstr "Partí spilunarlisti"
+
+#: id:16036
+msgid "De-interlace (Half)"
+msgstr "De-interlace (Hálft)"
+
+#: id:16037
+msgid "Deinterlace video"
+msgstr "Deinterlace mynd"
+
+#: id:16038
+msgid "Deinterlace method"
+msgstr "Deinterlace aðferð"
+
+#: id:16039
+msgctxt "Auto context with id 16039"
+msgid "Off"
+msgstr "Af"
+
+#: id:16040
+msgctxt "Auto context with id 16040"
+msgid "Auto"
+msgstr "Sjálfvirkt"
+
+#: id:16041
+msgid "On"
+msgstr "Á"
+
+#: id:16100
+msgid "All Videos"
+msgstr "Allar Myndir"
+
+#: id:16101
+msgid "Unwatched"
+msgstr "Ekki búið að horfa á"
+
+#: id:16102
+msgid "Watched"
+msgstr "Búið að horfa"
+
+#: id:16103
+msgid "Mark as watched"
+msgstr "Merkja sem búið að horfa á"
+
+#: id:16104
+msgid "Mark as unwatched"
+msgstr "Merkja sem ekki búið að horfa á"
+
+#: id:16105
+msgid "Edit title"
+msgstr "Breyta titli"
+
+#: id:16200
+msgid "Operation was aborted"
+msgstr "Hætt var við aðgerð"
+
+#: id:16201
+msgid "Copy failed"
+msgstr "Afritun mistókst"
+
+#: id:16202
+msgid "Failed to copy at least one file"
+msgstr "Mistókst að afrita amk eina skrá"
+
+#: id:16203
+msgid "Move failed"
+msgstr "Færsla mistókst"
+
+#: id:16204
+msgid "Failed to move at least one file"
+msgstr "Mistókst að færa amk eina skrá"
+
+#: id:16205
+msgid "Delete failed"
+msgstr "Eyðing mistókst"
+
+#: id:16206
+msgid "Failed to delete at least one file"
+msgstr "Mistókst að eyða amk einni skrá"
+
+#: id:16300
+msgid "Video scaling method"
+msgstr "Skjástækkunaraðferð"
+
+#: id:16301
+msgid "Nearest neighbour"
+msgstr "Nearest neighbour"
+
+#: id:16302
+msgid "Bilinear"
+msgstr "Bilinear"
+
+#: id:16303
+msgctxt "Auto context with id 16303"
+msgid "Bicubic"
+msgstr "Bicubic"
+
+#: id:16304
+msgid "Lanczos2"
+msgstr "Lanczos2"
+
+#: id:16305
+msgid "Lanczos3"
+msgstr "Lanczos3"
+
+#: id:16306
+msgid "Sinc8"
+msgstr "Sinc8"
+
+#: id:16307
+msgid "Bicubic (software)"
+msgstr "Bicubic (hugbúnaður)"
+
+#: id:16308
+msgid "Lanczos (software)"
+msgstr "Lanczos (hugbúnaður)"
+
+#: id:16309
+msgid "Sinc (software)"
+msgstr "Sinc (hugbúnaður)"
+
+#: id:16310
+msgid "Temporal"
+msgstr "Temporal"
+
+#: id:16311
+msgid "Temporal/Spatial"
+msgstr "Temporal/Spatial"
+
+#: id:16312
+msgid "(VDPAU)Noise Reduction"
+msgstr "(VDPAU)Suðhreinsun"
+
+#: id:16313
+msgid "(VDPAU)Sharpness"
+msgstr "(VDPAU)Skerpa"
+
+#: id:16314
+msgid "Inverse Telecine"
+msgstr "Inverse Telecine"
+
+#: id:16315
+msgid "Lanczos3 optimized"
+msgstr "Lanczos3 optimized"
+
+#: id:16316
+msgctxt "Auto context with id 16316"
+msgid "Auto"
+msgstr "Sjálfvirkt"
+
+#: id:16317
+msgid "Temporal (Half)"
+msgstr "Temporal (Half)"
+
+#: id:16318
+msgid "Temporal/Spatial (Half)"
+msgstr "Temporal/Spatial (Half)"
+
+#: id:16319
+msgid "DXVA"
+msgstr "DXVA"
+
+#: id:16320
+msgid "DXVA Bob"
+msgstr "DXVA Bob"
+
+#: id:16321
+msgid "DXVA Best"
+msgstr "DXVA Best"
+
+#: id:16322
+msgid "Spline36"
+msgstr "Spline36"
+
+#: id:16323
+msgid "Spline36 optimized"
+msgstr "Spline36 optimized"
+
+#: id:16324
+msgid "Software Blend"
+msgstr "Software Blend"
+
+#: id:16400
+msgid "Post-processing"
+msgstr "Eftirvinnsla"
+
+#: id:17500
+msgid "Display sleep timeout"
+msgstr "Sýna biðtíma"
+
+#: id:19000
+msgid "Switch to channel"
+msgstr "Skipta yfir á rás"
+
+#: id:20000
+msgid "Saved music folder"
+msgstr "Tónlistarmappa fyrir vistun"
+
+#: id:20001
+msgid "Use external DVD player"
+msgstr "Nota ytri DVD spilara"
+
+#: id:20002
+msgid "External DVD player"
+msgstr "Ytri DVD spilari"
+
+#: id:20003
+msgid "Trainers folder"
+msgstr "Svindl mappa"
+
+#: id:20004
+msgid "Screenshot folder"
+msgstr "Skjámynda mappa"
+
+#: id:20006
+msgid "Playlists folder"
+msgstr "Spilunarlista mappa"
+
+#: id:20007
+msgid "Recordings"
+msgstr "Upptökur"
+
+#: id:20008
+msgid "Screenshots"
+msgstr "Skjámyndir"
+
+#: id:20009
+msgid "Use XBMC"
+msgstr "Nota XBMC"
+
+#: id:20011
+msgid "Music playlists"
+msgstr "Lagalistar"
+
+#: id:20012
+msgid "Video playlists"
+msgstr "Myndbandalistar"
+
+#: id:20013
+msgid "Do you wish to launch the game?"
+msgstr "Viltu ræsa leikinn?"
+
+#: id:20014
+msgid "Sort by: Playlist"
+msgstr "Raða eftir: Spilunarlista"
+
+#: id:20015
+msgid "Remote thumb"
+msgstr "Fjarlæg smámynd"
+
+#: id:20016
+msgid "Current thumb"
+msgstr "Núverandi smámynd"
+
+#: id:20017
+msgid "Local thumb"
+msgstr "Nærliggjandi smámynd"
+
+#: id:20018
+msgid "No thumb"
+msgstr "Engin smámynd"
+
+#: id:20019
+msgid "Choose thumbnail"
+msgstr "Velja smámynd"
+
+#: id:20023
+msgid "Conflict"
+msgstr "Stangast á"
+
+#: id:20024
+msgid "Scan new"
+msgstr "Skanna nýtt"
+
+#: id:20025
+msgid "Scan all"
+msgstr "Skanna allt"
+
+#: id:20026
+msgid "Region"
+msgstr "Svæði"
+
+#: id:20037
+msgid "Summary"
+msgstr "Samantekt"
+
+#: id:20038
+msgid "Lock music window"
+msgstr "Læsa tónlistar glugga"
+
+#: id:20039
+msgid "Lock videos window"
+msgstr "Læsa myndbanda glugga"
+
+#: id:20040
+msgid "Lock pictures window"
+msgstr "Læsa ljósmynda glugga"
+
+#: id:20041
+msgid "Lock programs & scripts windows"
+msgstr "Læsa forrita, leikjavistunar og skriftu gluggum"
+
+#: id:20042
+msgid "Lock file manager"
+msgstr "Læsa skráarsýsli"
+
+#: id:20043
+msgid "Lock settings"
+msgstr "Læsa stillingum"
+
+#: id:20044
+msgid "Start fresh"
+msgstr "Byrja upp á nýtt"
+
+#: id:20045
+msgid "Enter master mode"
+msgstr "Fara í aðal ham"
+
+#: id:20046
+msgid "Leave master mode"
+msgstr "Fara úr aðal ham"
+
+#: id:20047
+msgid "Create profile '%s'?"
+msgstr "Búa til notanda '%s' ?"
+
+#: id:20048
+msgid "Start with fresh settings"
+msgstr "Byrja með ferskar stillingar"
+
+#: id:20049
+msgid "Best available"
+msgstr "Besta fáanlega"
+
+#: id:20050
+msgid "Auto-switch between 16x9 and 4x3"
+msgstr "Skipta sjálfvirkt á milli 16x9 og 4x3"
+
+#: id:20051
+msgid "Treat stacked files as single file"
+msgstr "Meðhöndla staflaðar skrár sem eina skrá"
+
+#: id:20052
+msgid "Caution"
+msgstr "Varúð"
+
+#: id:20053
+msgid "Left master mode"
+msgstr "Fer úr aðal ham"
+
+#: id:20054
+msgid "Entered master mode"
+msgstr "Fer í aðal ham"
+
+#: id:20055
+msgid "Allmusic.com thumb"
+msgstr "Allmusic.com smámynd"
+
+#: id:20057
+msgid "Remove thumbnail"
+msgstr "Fjarlægja smámynd"
+
+#: id:20058
+msgid "Add profile..."
+msgstr "Bæta við notanda..."
+
+#: id:20059
+msgid "Query info for all albums"
+msgstr "Senda fyrirspurn fyrir allar hljómplötur"
+
+#: id:20060
+msgctxt "Auto context with id 20060"
+msgid "Media info"
+msgstr "Upplýsingar"
+
+#: id:20061
+msgctxt "Auto context with id 20061"
+msgid "Separate"
+msgstr "Aðskilja"
+
+#: id:20062
+msgid "Shares with default"
+msgstr "Geymslur með sjálfval"
+
+#: id:20063
+msgid "Shares with default (read only)"
+msgstr "Geymslur með sjálfval (aðeins lesa)"
+
+#: id:20064
+msgid "Copy default"
+msgstr "Afrita sjálfval"
+
+#: id:20065
+msgid "Profile picture"
+msgstr "Notandamynd"
+
+#: id:20066
+msgid "Lock preferences"
+msgstr "Læsa kjörstillingum"
+
+#: id:20067
+msgid "Edit profile"
+msgstr "Breyta notanda"
+
+#: id:20068
+msgid "Profile lock"
+msgstr "Læsa notanda"
+
+#: id:20069
+msgid "Could not create folder"
+msgstr "Gat ekki búið til möppu"
+
+#: id:20070
+msgid "Profile directory"
+msgstr "Notandamappa"
+
+#: id:20071
+msgid "Start with fresh media sources"
+msgstr "Byrja með hreinar uppsprettur"
+
+#: id:20072
+msgid "Make sure the selected folder is writable"
+msgstr "Athugaðu að valinn mappa sé með skrifheimilidir"
+
+#: id:20073
+msgid "and that the new folder name is valid"
+msgstr "og nafn möppu sé löglegt"
+
+#: id:20074
+msgid "MPAA rating"
+msgstr "MPAA einkunnagjöf"
+
+#: id:20075
+msgid "Enter master lock code"
+msgstr "Sláðu inn lykilorð fyrir aðal ham"
+
+#: id:20076
+msgid "Ask for master lock code on startup"
+msgstr "Spyrja um aðal lykilorð við ræsingu"
+
+#: id:20077
+msgid "Skin settings"
+msgstr "Útlitsstillingar"
+
+#: id:20078
+msgid "- no link set -"
+msgstr "- enginn hlekkur stilltur -"
+
+#: id:20079
+msgid "Enable animations"
+msgstr "Virkja hreyfimyndir"
+
+#: id:20080
+msgid "Disable RSS during music"
+msgstr "Slökkva á RSS þegar spiluð er tónlist"
+
+#: id:20081
+msgid "Enable shortcut buttons"
+msgstr "Virkja takka fyrir flýtileiðir"
+
+#: id:20082
+msgid "Show programs in main menu"
+msgstr "Sýna forrit í aðalvalmynd"
+
+#: id:20083
+msgid "Show music info"
+msgstr "Sýna tónlistarupplýsingar"
+
+#: id:20084
+msgid "Show weather info"
+msgstr "Sýna veðurupplýsingar"
+
+#: id:20085
+msgid "Show system info"
+msgstr "Sýna kerfisupplýsingar"
+
+#: id:20086
+msgid "Show available disc space C: E: F:"
+msgstr "Sýna laust diskpláss C: E: F:"
+
+#: id:20087
+msgid "Show available disc space E: F: G:"
+msgstr "Sýna laust diskpláss E: F: G:"
+
+#: id:20088
+msgid "Weather info"
+msgstr "Veður"
+
+#: id:20089
+msgid "Drive space free"
+msgstr "Laust diskpláss"
+
+#: id:20090
+msgid "Enter the name of an existing share"
+msgstr "Sláðu inn nafn á samnýtingu"
+
+#: id:20091
+msgid "Lock code"
+msgstr "Læsingar kóði"
+
+#: id:20092
+msgid "Load profile"
+msgstr "Hlaða inn notanda"
+
+#: id:20093
+msgid "Profile name"
+msgstr "Nafn notanda"
+
+#: id:20094
+msgctxt "Auto context with id 20094"
+msgid "Media sources"
+msgstr "Uppsprettur"
+
+#: id:20095
+msgid "Enter profile lock code"
+msgstr "Sláðu inn læsingarkóða fyrir notanda"
+
+#: id:20096
+msgctxt "Auto context with id 20096"
+msgid "Login screen"
+msgstr "Innskráning"
+
+#: id:20097
+msgid "Fetching album info"
+msgstr "Næ í plötuupplýsingar"
+
+#: id:20098
+msgid "Fetching info for album"
+msgstr "Næ í plötuupplýsingar"
+
+#: id:20099
+msgid "Can't rip CD or track while playing from CD"
+msgstr "Get ekki afritað geisladisk á meðan verið er að spila"
+
+#: id:20100
+msgid "Master lock code and settings"
+msgstr "Aðal læsing og stillingar"
+
+#: id:20101
+msgid "Entering master lock code always enables master mode"
+msgstr "Að slá inn aðal lykilorð virkjar alltaf aðal ham"
+
+#: id:20102
+msgid "or copy from default?"
+msgstr "eða afrita frá sjálfvali?"
+
+#: id:20103
+msgid "Save changes to profile?"
+msgstr "Vista breytingar á notanda?"
+
+#: id:20104
+msgid "Old settings found."
+msgstr "Fann gamlar stillingar."
+
+#: id:20105
+msgid "Do you want to use them?"
+msgstr "Viltu nota þær?"
+
+#: id:20106
+msgid "Old media sources found."
+msgstr "Fann gamlar uppsprettur."
+
+#: id:20107
+msgid "Separate (locked)"
+msgstr "Aðskilja (læst)"
+
+#: id:20108
+msgid "Root"
+msgstr "Rót"
+
+#: id:20109
+msgid "- Zoom"
+msgstr "- Stækkun"
+
+#: id:20110
+msgid "UPnP settings"
+msgstr "UPnP stillingar"
+
+#: id:20111
+msgid "Autostart UPnP client"
+msgstr "Sjálfvirk ræsing UPnP biðlara"
+
+#: id:20112
+msgid "Last login: %s"
+msgstr "Seinasta innskráning: %s"
+
+#: id:20113
+msgid "Never logged on"
+msgstr "Aldrei skráð sig inn"
+
+#: id:20114
+msgid "Profile %i / %i"
+msgstr "Notandi %i / %i"
+
+#: id:20115
+msgid "User login / Select a profile"
+msgstr "Skráning notanda / Veldu notanda"
+
+#: id:20116
+msgid "Use lock on login screen"
+msgstr "Nota læsingu á skráningarskjá"
+
+#: id:20117
+msgid "Invalid lock code."
+msgstr "Rangur læsingarkóði."
+
+#: id:20118
+msgid "This requires the master lock to be set."
+msgstr "Þetta þarfnast þess að aðal læsing sé virk."
+
+#: id:20119
+msgid "Would you like to set it now?"
+msgstr "Viltu setja hana núna?"
+
+#: id:20120
+msgid "Loading program information"
+msgstr "Hleð inn upplýsingum um forrit"
+
+#: id:20121
+msgid "Party on!"
+msgstr "Gleðskapur í gang!"
+
+#: id:20122
+msgid "True"
+msgstr "Satt"
+
+#: id:20123
+msgid "Mixing drinks"
+msgstr "Blanda drykki"
+
+#: id:20124
+msgid "Filling glasses"
+msgstr "Fylli glös"
+
+#: id:20125
+msgid "Logged on as"
+msgstr "Innskráður sem"
+
+#: id:20126
+msgid "Log off"
+msgstr "Útskrá"
+
+#: id:20128
+msgid "Go to root"
+msgstr "Fara á rót"
+
+#: id:20129
+msgid "Weave"
+msgstr "Þræða"
+
+#: id:20130
+msgid "Weave (inverted)"
+msgstr "Þræða (öfugt)"
+
+#: id:20131
+msgid "Blend"
+msgstr "Blanda"
+
+#: id:20132
+msgid "Restart video"
+msgstr "Endurræsa myndband"
+
+#: id:20133
+msgid "Edit network location"
+msgstr "Breyta net staðsetningu"
+
+#: id:20134
+msgid "Remove network location"
+msgstr "Fjarlægja net staðsetningu"
+
+#: id:20135
+msgid "Do you want to scan the folder?"
+msgstr "Viltu skanna möppuna?"
+
+#: id:20136
+msgid "Memory unit"
+msgstr "Minniseining"
+
+#: id:20137
+msgid "Memory unit mounted"
+msgstr "Minniseining sett upp"
+
+#: id:20138
+msgid "Unable to mount memory unit"
+msgstr "Get ekki sett upp minniseiningu"
+
+#: id:20139
+msgid "In port %i, slot %i"
+msgstr "Í gátt %i, rauf %i"
+
+#: id:20140
+msgid "Lock screensaver"
+msgstr "Læsa skjávara"
+
+#: id:20141
+msgid "Set"
+msgstr "Setja"
+
+#: id:20142
+msgctxt "Auto context with id 20142"
+msgid "Username"
+msgstr "Notandanafn"
+
+#: id:20143
+msgid "Enter password for"
+msgstr "Sláðu inn lykilorð fyrir"
+
+#: id:20144
+msgid "Shutdown timer"
+msgstr "Tímastýring fyrir slökkvun"
+
+#: id:20145
+msgid "Shutdown interval (in minutes)"
+msgstr "Tímaslökkvari (í mínútum)"
+
+#: id:20146
+msgid "Started, shutdown in %im"
+msgstr "Ræsing, slökkt eftir %im"
+
+#: id:20147
+msgid "Shutdown in 30 minutes"
+msgstr "Slekk eftir 30 mínútur"
+
+#: id:20148
+msgid "Shutdown in 60 minutes"
+msgstr "Slekk eftir 60 mínútur"
+
+#: id:20149
+msgid "Shutdown in 120 minutes"
+msgstr "Slekk eftir 120 mínútur"
+
+#: id:20150
+msgid "Custom shutdown timer"
+msgstr "Sérsniðinn tímaslökkvari"
+
+#: id:20151
+msgid "Cancel shutdown timer"
+msgstr "Hætta við slökkvun"
+
+#: id:20152
+msgid "Lock preferences for %s"
+msgstr "Læsa stillingum fyrir %s"
+
+#: id:20153
+msgid "Browse..."
+msgstr "Fletta..."
+
+#: id:20154
+msgid "Summary information"
+msgstr "Grunnupplýsingar"
+
+#: id:20155
+msgid "Storage information"
+msgstr "Geymsluupplýsingar"
+
+#: id:20156
+msgid "Hard disk information"
+msgstr "Upplýsingar um harðan disk"
+
+#: id:20157
+msgid "DVD-ROM information"
+msgstr "DVD-ROM upplýsingar"
+
+#: id:20158
+msgid "Network information"
+msgstr "Netupplýsingar"
+
+#: id:20159
+msgid "Video information"
+msgstr "Skjáupplýsingar"
+
+#: id:20160
+msgid "Hardware information"
+msgstr "Vélbúnaðarupplýsingar"
+
+#: id:20161
+msgid "Total"
+msgstr "Samtals"
+
+#: id:20162
+msgid "Used"
+msgstr "Notað"
+
+#: id:20163
+msgid "of"
+msgstr "af"
+
+#: id:20164
+msgid "Locking not supported"
+msgstr "Læsing ekki nothæf"
+
+#: id:20165
+msgid "Not locked"
+msgstr "Ekki læst"
+
+#: id:20166
+msgid "Locked"
+msgstr "Læst"
+
+#: id:20167
+msgid "Frozen"
+msgstr "Frosið"
+
+#: id:20168
+msgid "Requires reset"
+msgstr "Þarfnast endurstillingar"
+
+#: id:20169
+msgid "Week"
+msgstr "Vika"
+
+#: id:20170
+msgid "Line"
+msgstr "Lína"
+
+#: id:20171
+msgid "Windows network (SMB)"
+msgstr "Windows net (SMB)"
+
+#: id:20172
+msgid "XBMSP server"
+msgstr "XBMSP miðlari"
+
+#: id:20173
+msgctxt "Auto context with id 20173"
+msgid "FTP server"
+msgstr "FTP miðlari"
+
+#: id:20174
+msgid "iTunes music share (DAAP)"
+msgstr "iTunes tónlistarmiðlari (DAAP)"
+
+#: id:20175
+msgid "UPnP server"
+msgstr "UPnP miðlari"
+
+#: id:20176
+msgid "Show video info"
+msgstr "Sýna skjáupplýsingar"
+
+#: id:20177
+msgid "Done"
+msgstr "Búið"
+
+#: id:20178
+msgid "Shift"
+msgstr "Shift"
+
+#: id:20179
+msgid "Caps Lock"
+msgstr "Hástafalás"
+
+#: id:20180
+msgid "Symbols"
+msgstr "Tákn"
+
+#: id:20181
+msgid "Backspace"
+msgstr "Hopa"
+
+#: id:20182
+msgid "Space"
+msgstr "Bil"
+
+#: id:20183
+msgid "Reload skin"
+msgstr "Endurhlaða útlit"
+
+#: id:20184
+msgid "Rotate pictures using EXIF information"
+msgstr "Snúa mynd með upplýsingum frá EXIF"
+
+#: id:20185
+msgid "Use poster view styles for TV shows"
+msgstr "Nota veggspjaldasnið fyrir sjónvarpsþætti"
+
+#: id:20186
+msgid "Please wait"
+msgstr "Bíddu Aðeins"
+
+#: id:20187
+msgid "UPnP"
+msgstr ""
+
+#: id:20189
+msgid "Enable auto scrolling for plot & review"
+msgstr "Virkja sjálfvirkt skrun fyrir söguþráð og gagnrýni"
+
+#: id:20190
+msgctxt "Auto context with id 20190"
+msgid "Custom"
+msgstr "Sérsniðið"
+
+#: id:20191
+msgid "Enable debug logging"
+msgstr "Virkja kembi úttak"
+
+#: id:20192
+msgid "Download additional information during updates"
+msgstr "Ná í viðbótar upplýsingar við uppfærslu"
+
+#: id:20193
+msgid "Default service for album information"
+msgstr "Sjálfgefin þjónusta fyrir hljómplötuupplýsingar"
+
+#: id:20194
+msgid "Default service for artist information"
+msgstr "Sjálfgefin þjónusta fyrir tónlistarupplýsingar"
+
+#: id:20195
+msgid "Change scraper"
+msgstr "Breyta skrapara"
+
+#: id:20196
+msgid "Export music library"
+msgstr "Flytja út tónlistarsafn"
+
+#: id:20197
+msgid "Import music library"
+msgstr "Flytja inn tónlistarsafn"
+
+#: id:20198
+msgid "No artist found!"
+msgstr "Fann engan listamann!"
+
+#: id:20199
+msgid "Downloading artist info failed"
+msgstr "Niðurhal á upplýsingum um listamann mistókst"
+
+#: id:20250
+msgid "Party on! (videos)"
+msgstr "Partí! (tónlistarmyndbönd)"
+
+#: id:20251
+msgid "Mixing drinks (videos)"
+msgstr "Blanda drykki (tónlistarmyndbönd)"
+
+#: id:20252
+msgid "Filling glasses (videos)"
+msgstr "Fylli glös (tónlistarmyndbönd)"
+
+#: id:20253
+msgid "WebDAV server (HTTP)"
+msgstr "WebDAV þjónn (HTTP)"
+
+#: id:20254
+msgid "WebDAV server (HTTPS)"
+msgstr "WebDAV þjónn (HTTPS)"
+
+#: id:20255
+msgid "First logon, edit your profile"
+msgstr "Fyrsta innskráning, breyttu notandastillingum"
+
+#: id:20256
+msgid "HTS Tvheadend client"
+msgstr "HTS Tvheadend biðlari"
+
+#: id:20257
+msgid "VDR Streamdev client"
+msgstr "VDR Streamdev biðlari"
+
+#: id:20258
+msgid "MythTV client"
+msgstr "MythTV biðlari"
+
+#: id:20259
+msgid "Network Filesystem (NFS)"
+msgstr "Network Filesystem (NFS)"
+
+#: id:20260
+msgid "Secure Shell (SSH/SFTP)"
+msgstr "Secure Shell (SSH/SFTP)"
+
+#: id:20261
+msgid "Apple Filing Protocol (AFP)"
+msgstr "Apple Filing Protocol (AFP)"
+
+#: id:20300
+msgid "Web server directory (HTTP)"
+msgstr "Mappa vefþjóns (HTTP)"
+
+#: id:20301
+msgid "Web server directory (HTTPS)"
+msgstr "Mappa vefþjóns (HTTPS)"
+
+#: id:20302
+msgid "Unable to write to folder:"
+msgstr "Get ekki skrifað í möppu:"
+
+#: id:20303
+msgid "Do you want to skip and proceed?"
+msgstr "Viltu sleppa og halda áfram?"
+
+#: id:20304
+msgid "RSS Feed"
+msgstr "RSS straumur"
+
+#: id:20307
+msgid "Secondary DNS"
+msgstr "Auka DNS"
+
+#: id:20308
+msgid "DHCP server:"
+msgstr "DHCP miðlari:"
+
+#: id:20309
+msgid "Make new folder"
+msgstr "Búa til nýja möppu"
+
+#: id:20310
+msgid "Dim LCD on playback"
+msgstr "Deyfa LCD við spilun"
+
+#: id:20311
+msgid "Unknown or onboard (protected)"
+msgstr "Óþekktur eða á borði (varinn)"
+
+#: id:20312
+msgid "Dim LCD on paused"
+msgstr "Deyfa LCD við hlé"
+
+#: id:20314
+msgid "Videos - Library"
+msgstr "Myndefni - Safn"
+
+#: id:20316
+msgid "Sort by: ID"
+msgstr "Raða eftir: Auðkenni"
+
+#: id:20324
+msgid "Play part..."
+msgstr "Spila hlut..."
+
+#: id:20325
+msgid "Calibration reset"
+msgstr "Endurstilla tækjastillingu"
+
+#: id:20326
+msgid "This will reset the calibration values for %s"
+msgstr "Þetta endurstillir tækjastillingu fyrir %s"
+
+#: id:20327
+msgid "to it's default values."
+msgstr "á sín upprunalegu gildi."
+
+#: id:20328
+msgid "Browse for destination"
+msgstr "Veldu staðsetningu"
+
+#: id:20329
+msgid "Movies are in separate folders that match the movie title"
+msgstr ""
+
+#: id:20330
+msgid "Use folder names for lookups"
+msgstr "Nota möppunafn til að leita eftir"
+
+#: id:20331
+msgctxt "Auto context with id 20331"
+msgid "File"
+msgstr "Skrá"
+
+#: id:20332
+msgid "Use file or folder names in lookups?"
+msgstr "Nota möppu eða skráarnafn til að leita?"
+
+#: id:20333
+msgid "Set content"
+msgstr "Velja innihald"
+
+#: id:20334
+msgid "Folder"
+msgstr "Mappa"
+
+#: id:20335
+msgid "Look for content recursively?"
+msgstr "Leita að innihaldi í undirmöppum?"
+
+#: id:20336
+msgid "Unlock sources"
+msgstr "Aflæsa uppsprettum"
+
+#: id:20337
+msgid "Actor"
+msgstr "Leikari"
+
+#: id:20338
+msgid "Movie"
+msgstr "Kvikmynd"
+
+#: id:20339
+msgid "Director"
+msgstr "Leikstjóri"
+
+#: id:20340
+msgid "Do you want to remove all items within"
+msgstr "Viltu fjarlægja öll atriði frá"
+
+#: id:20341
+msgid "this path from the XBMC library?"
+msgstr "þessari slóð úr gagnasafninu?"
+
+#: id:20342
+msgctxt "Auto context with id 20342"
+msgid "Movies"
+msgstr "Kvikmyndir"
+
+#: id:20343
+msgid "TV shows"
+msgstr "Sjónvarpsþættir"
+
+#: id:20344
+msgid "This directory contains"
+msgstr "Þessi mappa inniheldur"
+
+#: id:20345
+msgid "Run automated scan"
+msgstr "Leita sjálfvirkt"
+
+#: id:20346
+msgid "Scan recursively"
+msgstr "Leita í undirmöppum"
+
+#: id:20347
+msgid "as"
+msgstr "sem"
+
+#: id:20348
+msgid "Directors"
+msgstr "Leikstjórar"
+
+#: id:20349
+msgid "No video files found in this path!"
+msgstr "Ekkert myndefni fannst á þessari slóð!"
+
+#: id:20350
+msgid "votes"
+msgstr "atkvæði"
+
+#: id:20351
+msgid "TV show information"
+msgstr "Upplýsingar um sjónvarpsþáttaröð"
+
+#: id:20352
+msgid "Episode information"
+msgstr "Upplýsingar um þátt"
+
+#: id:20353
+msgid "Loading TV show details"
+msgstr "Sæki upplýsingar um sjónvarpsþáttaröð"
+
+#: id:20354
+msgid "Fetching episode guide"
+msgstr "Sæki upplýsingar um þátt"
+
+#: id:20355
+msgid "Loading info for episodes in directory"
+msgstr "Sæki upplýsingar um þætti í möppu"
+
+#: id:20356
+msgid "Select TV show:"
+msgstr "Veldu sjónvarpsþáttaröð:"
+
+#: id:20357
+msgid "Enter the TV show name"
+msgstr "Sláðu inn nafn á sjónvarpsþáttaröðinni"
+
+#: id:20358
+msgid "Season %i"
+msgstr "Þáttaröð %i"
+
+#: id:20359
+msgid "Episode"
+msgstr "Þáttur"
+
+#: id:20360
+msgid "Episodes"
+msgstr "Þættir"
+
+#: id:20361
+msgid "Loading episode details"
+msgstr "Sæki upplýsingar um þátt"
+
+#: id:20362
+msgid "Remove episode from library"
+msgstr "Fjarlægja þátt úr safni"
+
+#: id:20363
+msgid "Remove TV show from library"
+msgstr "Fjarlægja sjónvarpsþátt úr safni"
+
+#: id:20364
+msgid "TV show"
+msgstr "Sjónvarpsþáttur"
+
+#: id:20365
+msgid "Episode plot"
+msgstr "Söguþráður þáttar"
+
+#: id:20366
+msgid "* All seasons"
+msgstr "* Allar þáttaraðir"
+
+#: id:20367
+msgid "Hide watched"
+msgstr "Fela búið"
+
+#: id:20368
+msgid "Prod code"
+msgstr "Framleiðslu kóði"
+
+#: id:20369
+msgid "Show plot for unwatched items"
+msgstr "Fela söguþráð á því sem ekki er búið að horfa á"
+
+#: id:20370
+msgid "* Hidden to prevent spoilers *"
+msgstr "* Falið til að spilla ekki söguþræði *"
+
+#: id:20371
+msgid "Set season thumb"
+msgstr "Velja smámynd fyrir þáttaröð"
+
+#: id:20372
+msgid "Season image"
+msgstr "Mynd þáttaraðar"
+
+#: id:20373
+msgid "Season"
+msgstr "Þáttaröð"
+
+#: id:20374
+msgid "Downloading movie information"
+msgstr "Sæki upplýsingar um myndefni"
+
+#: id:20375
+msgid "Unassign content"
+msgstr "Taka af innihald"
+
+#: id:20376
+msgid "Original title"
+msgstr "Upprunalegur titill"
+
+#: id:20377
+msgid "Refresh TV show information"
+msgstr "Uppfæra upplýsingar um sjónvarpsþátt"
+
+#: id:20378
+msgid "Refresh info for all episodes?"
+msgstr "Uppfæra upplýsingar um alla þætti?"
+
+#: id:20379
+msgid "Selected folder contains a single TV show"
+msgstr "Mappa inniheldur einn sjónvarpsþátt"
+
+#: id:20380
+msgid "Exclude selected folder from scans"
+msgstr "Undanskilja möppu frá leit"
+
+#: id:20381
+msgid "Specials"
+msgstr "Sérþættir"
+
+#: id:20382
+msgid "Automatically grab season thumbs"
+msgstr "Ná sjálfkrafa í þáttaraðarsmámynd"
+
+#: id:20383
+msgid "Selected folder contains a single video"
+msgstr "Mappa inniheldur eina myndskrá"
+
+#: id:20384
+msgid "Link to TV show"
+msgstr "Tengja við sjónvarpsþáttaröð"
+
+#: id:20385
+msgid "Remove link to TV show"
+msgstr "Fjarlægja tengingu við sjónvarpsþáttaröð"
+
+#: id:20386
+msgid "Recently added movies"
+msgstr "Kvikmyndir, nýlega bætt við"
+
+#: id:20387
+msgid "Recently added episodes"
+msgstr "Þættir, nýlega bætt við"
+
+#: id:20388
+msgid "Studios"
+msgstr "Kvikmyndaver"
+
+#: id:20389
+msgid "Music videos"
+msgstr "Tónlistarmyndbönd"
+
+#: id:20390
+msgid "Recently added music videos"
+msgstr "Tónlistarmyndbönd, nýlega bætt við"
+
+#: id:20391
+msgid "Music video"
+msgstr "Tónlistarmyndband"
+
+#: id:20392
+msgid "Remove music video from library"
+msgstr "Fjarlægja tónlistarmyndband úr safni"
+
+#: id:20393
+msgctxt "Auto context with id 20393"
+msgid "Music video information"
+msgstr "Upplýsingar um tónlistarmyndband"
+
+#: id:20394
+msgid "Loading music video information"
+msgstr "Hleð inn upplýsingum um tónlistarmyndband"
+
+#: id:20395
+msgid "Mixed"
+msgstr "Blandaður"
+
+#: id:20396
+msgid "Go to albums by artist"
+msgstr "Hoppa á hljómplötu eftir tónlistarmanni"
+
+#: id:20397
+msgid "Go to album"
+msgstr "Hoppa til hljómplötu"
+
+#: id:20398
+msgid "Play song"
+msgstr "Spila lag"
+
+#: id:20399
+msgid "Go to music videos from album"
+msgstr "Hoppa á tónlistarmyndbönd af hljómplötu"
+
+#: id:20400
+msgid "Go to music videos by artist"
+msgstr "Hoppa á tónlistarmyndbönd eftir tónlistarlistamanni"
+
+#: id:20401
+msgid "Play music video"
+msgstr "Spila tónlistarmyndband"
+
+#: id:20402
+msgid "Download actor thumbnails when adding to library"
+msgstr "Hlaða niður smámyndum fyrir leikara þegar bætt er við í safn"
+
+#: id:20403
+msgid "Set actor thumb"
+msgstr "Velja smámynd leikara"
+
+#: id:20405
+msgid "Remove episode bookmark"
+msgstr "Fjarlægja bókamerki þáttar"
+
+#: id:20406
+msgid "Set episode bookmark"
+msgstr "Setja bókamerki þáttar"
+
+#: id:20407
+msgid "Scraper settings"
+msgstr "Stillingar skrapara"
+
+#: id:20408
+msgid "Downloading music video information"
+msgstr "Sæki upplýsingar fyrir tónlistarmyndband"
+
+#: id:20409
+msgid "Downloading TV show information"
+msgstr "Sæki upplýsingar fyrir sjónvarpsþáttaröð"
+
+#: id:20410
+msgid "Trailer"
+msgstr "Sýnishorn"
+
+#: id:20411
+msgid "Flatten"
+msgstr "Fletja"
+
+#: id:20412
+msgid "Flatten TV shows"
+msgstr "Fletja út sjónvarpsþætti"
+
+#: id:20413
+msgid "Get fanart"
+msgstr "Ná í aðdáendamyndir"
+
+#: id:20414
+msgid "Show Fanart in video and music libraries"
+msgstr "Sýna aðdáendamyndir í tónlistar- og myndbandasafni"
+
+#: id:20415
+msgid "Scanning for new content"
+msgstr "Leita að nýju efni"
+
+#: id:20416
+msgid "First aired"
+msgstr "Sýnt fyrst"
+
+#: id:20417
+msgid "Writer"
+msgstr "Handritshöfundur"
+
+#: id:20419
+msgid "Replace file names with library titles"
+msgstr "Sýna lýsigögn í skráarsýn"
+
+#: id:20420
+msgctxt "Auto context with id 20420"
+msgid "Never"
+msgstr "Aldrei"
+
+#: id:20421
+msgid "If only one season"
+msgstr "Bara ef ein þáttaröð"
+
+#: id:20422
+msgid "Always"
+msgstr "Alltaf"
+
+#: id:20423
+msgid "Has trailer"
+msgstr "Er með sýnishorn"
+
+#: id:20424
+msgid "False"
+msgstr "Ósatt"
+
+#: id:20425
+msgid "Fanart slideshow"
+msgstr "Myndasýning aðdáendamynda"
+
+#: id:20426
+msgid "Export to a single file or separate"
+msgstr "Flytja út í eina skrá eða aðskildar"
+
+#: id:20427
+msgid "files per entry?"
+msgstr "skrár fyrir hverja færslu?"
+
+#: id:20428
+msgid "Single file"
+msgstr "Ein skrá"
+
+#: id:20429
+msgctxt "Auto context with id 20429"
+msgid "Separate"
+msgstr "Aðskilja"
+
+#: id:20430
+msgid "Export thumbnails and fanart?"
+msgstr "Flytja út smámyndir og áðdáendamyndir?"
+
+#: id:20431
+msgid "Overwrite old files?"
+msgstr "Skrifa yfir eldri skrár?"
+
+#: id:20432
+msgid "Exclude path from library updates"
+msgstr "Undanskilja slóð frá uppfærslu á safni"
+
+#: id:20433
+msgid "Extract thumbnails and video information"
+msgstr "Ná í smámyndir og myndbandaupplýsingar"
+
+#: id:20434
+msgid "Sets"
+msgstr "Sett"
+
+#: id:20435
+msgid "Set movieset thumb"
+msgstr "Velja smámynd fyrir kvikmyndasett"
+
+#: id:20436
+msgid "Export actor thumbs?"
+msgstr "Flytja út leikaramyndir?"
+
+#: id:20437
+msgid "Choose fanart"
+msgstr "Velja aðdáendamyndir"
+
+#: id:20438
+msgid "Local fanart"
+msgstr "Staðbundnar aðdáendamyndir"
+
+#: id:20439
+msgid "No fanart"
+msgstr "Engar aðdáendamyndir"
+
+#: id:20440
+msgid "Current fanart"
+msgstr "Núverandi aðdáendamyndir"
+
+#: id:20441
+msgid "Remote fanart"
+msgstr "Fjarlægar aðdáendamyndir"
+
+#: id:20442
+msgid "Change content"
+msgstr "Breyta innihaldi"
+
+#: id:20443
+msgid "Do you want to refresh info for all"
+msgstr "Viltu uppfæra upplýsingar fyrir allt"
+
+#: id:20444
+msgid "items within this path?"
+msgstr "hlutir á þessari slóð?"
+
+#: id:20445
+msgid "Fanart"
+msgstr "Aðdáendamyndir"
+
+#: id:20446
+msgid "Locally stored information found."
+msgstr "Fann staðbundnar upplýsingar."
+
+#: id:20447
+msgid "Ignore and refresh from internet?"
+msgstr "Hunsa og endurnýja frá Internetinu?"
+
+#: id:20448
+msgid "Could not download information"
+msgstr "Gat ekki niðurhalið upplýsingum"
+
+#: id:20449
+msgid "Unable to connect to remote server"
+msgstr "Get ekki tengst við netþjón"
+
+#: id:20450
+msgid "Would you like to continue scanning?"
+msgstr "Viltu halda áfram að leita?"
+
+#: id:20451
+msgid "Countries"
+msgstr "Lönd"
+
+#: id:20452
+msgid "episode"
+msgstr "þáttur"
+
+#: id:20453
+msgid "episodes"
+msgstr "þættir"
+
+#: id:20454
+msgid "Listener"
+msgstr "Hlustandi"
+
+#: id:20455
+msgid "Listeners"
+msgstr "Hlustendur"
+
+#: id:20456
+msgid "Set movieset fanart"
+msgstr "Velja aðdáendamynd fyrir kvikmyndasett"
+
+#: id:20457
+msgid "Movie set"
+msgstr "Kvikmyndasett"
+
+#: id:20458
+msgid "Group movies in sets"
+msgstr "Hópa saman kvikmyndir í sett"
+
+#: id:21330
+msgid "Show hidden files and directories"
+msgstr "Sýna faldar skrár og möppur"
+
+#: id:21331
+msgid "TuxBox client"
+msgstr "TuxBox biðlari"
+
+#: id:21332
+msgid "WARNING: Target TuxBox device is in recording-mode!"
+msgstr "AÐVÖRUN: Valið TuxBox tæki er að taka upp!"
+
+#: id:21333
+msgid "The stream will be stopped!"
+msgstr "Straumurinn mun verða stoppaður!"
+
+#: id:21334
+msgid "Zap to channel: %s failed!"
+msgstr "Skipting á rás: %s Tókst ekki!"
+
+#: id:21335
+msgid "Are you sure to start the stream?"
+msgstr "Ertu viss um að þú viljir spila strauminn?"
+
+#: id:21336
+msgid "Connecting to: %s"
+msgstr "Tengist við: %s"
+
+#: id:21337
+msgid "TuxBox device"
+msgstr "TuxBox tæki"
+
+#: id:21359
+msgid "Add media share..."
+msgstr "Bæta við samnýtingu..."
+
+#: id:21360
+msgid "Share video and music libraries through UPnP"
+msgstr "Deila myndböndum og tónlist í gegnum UPnP"
+
+#: id:21364
+msgid "Edit media share"
+msgstr "Breyta samnýtingu"
+
+#: id:21365
+msgid "Remove media share"
+msgstr "Fjarlægja samnýtingu"
+
+#: id:21366
+msgid "Subtitle folder"
+msgstr "Sérsniðin mappa fyrir þýðingartexta"
+
+#: id:21367
+msgid "Movie & alternate subtitle directory"
+msgstr "Kvikmynda og auka mappa fyrir þýðingartexta"
+
+#: id:21368
+msgid "Override ASS/SSA subtitles fonts"
+msgstr "Hunsa ASS/SSA skjátexta leturgerð"
+
+#: id:21369
+msgid "Enable mouse and Touch Screen support"
+msgstr "Virkja stuðning við mús og snertiskjá"
+
+#: id:21370
+msgid "Play navigation sounds during media playback"
+msgstr "Leyfa leiðsagnarhljóð á meðan efni er spilað"
+
+#: id:21371
+msgid "Thumbnail"
+msgstr "Smámynd"
+
+#: id:21372
+msgid "Forced DVD player region"
+msgstr "Fastsetja svæði DVD spilara"
+
+#: id:21373
+msgid "Video output"
+msgstr "Myndbúnaður"
+
+#: id:21374
+msgid "Video aspect"
+msgstr "Sjónarhorn skjás"
+
+#: id:21375
+msgctxt "Auto context with id 21375"
+msgid "Normal"
+msgstr "Venjulegt"
+
+#: id:21376
+msgid "Letterbox"
+msgstr "Svartar rendur"
+
+#: id:21377
+msgid "Widescreen"
+msgstr "Breiðmynd"
+
+#: id:21378
+msgid "Enable 480p"
+msgstr "Virkja 480p"
+
+#: id:21379
+msgid "Enable 720p"
+msgstr "Virkja 720p"
+
+#: id:21380
+msgid "Enable 1080i"
+msgstr "Virkja 1080i"
+
+#: id:21381
+msgid "Enter name of new playlist"
+msgstr "Sláðu inn nafn á nýjum spilunarlista"
+
+#: id:21382
+msgid "Show \"Add source\" buttons in file lists"
+msgstr "Sýna \"Bæta við uppsprettu\" takka í listum"
+
+#: id:21383
+msgid "Enable scrollbars"
+msgstr "Virkja skrunrendur"
+
+#: id:21384
+msgid "Make watched filtering a toggle in video library"
+msgstr "Virkja áhorfðar myndir sem takka í myndbandasafni"
+
+#: id:21385
+msgctxt "Auto context with id 21385"
+msgid "Open"
+msgstr "Opna"
+
+#: id:21386
+msgid "Acoustic management level"
+msgstr "Hávaðastilling"
+
+#: id:21387
+msgid "Fast"
+msgstr "Hratt"
+
+#: id:21388
+msgid "Quiet"
+msgstr "Hljóðlátt"
+
+#: id:21389
+msgid "Enable custom background"
+msgstr "Virkja sérsniðinn bakgrunn"
+
+#: id:21390
+msgid "Power management level"
+msgstr "Orku stig"
+
+#: id:21391
+msgid "High power"
+msgstr "Mikil orka"
+
+#: id:21392
+msgid "Low power"
+msgstr "Lítil orka"
+
+#: id:21393
+msgid "High standby"
+msgstr "Há biðstaða"
+
+#: id:21394
+msgid "Low standby"
+msgstr "Lág biðstaða"
+
+#: id:21395
+msgid "Unable to cache files bigger than 4GB"
+msgstr "Get ekki haft stærri skrár en 4GB í flýtiminni"
+
+#: id:21396
+msgid "Chapter"
+msgstr "Kafli"
+
+#: id:21397
+msgid "High quality pixel shader v2"
+msgstr "Hágæða punkta skyggnir v2"
+
+#: id:21398
+msgid "Enable playlist at startup"
+msgstr "Virkja spilunarlista í ræsingu"
+
+#: id:21399
+msgid "Use tween animations"
+msgstr "Nota skopp hreyfimyndir"
+
+#: id:21400
+msgid "contains"
+msgstr "inniheldur"
+
+#: id:21401
+msgid "does not contain"
+msgstr "inniheldur ekki"
+
+#: id:21402
+msgid "is"
+msgstr "er"
+
+#: id:21403
+msgid "is not"
+msgstr "er ekki"
+
+#: id:21404
+msgid "starts with"
+msgstr "byrjar á"
+
+#: id:21405
+msgid "ends with"
+msgstr "endar á"
+
+#: id:21406
+msgid "greater than"
+msgstr "er stærri en"
+
+#: id:21407
+msgid "less than"
+msgstr "er minni en"
+
+#: id:21408
+msgid "after"
+msgstr "eftir"
+
+#: id:21409
+msgid "before"
+msgstr "fyrir"
+
+#: id:21410
+msgid "in the last"
+msgstr "er í seinustu"
+
+#: id:21411
+msgid "not in the last"
+msgstr "er ekki í seinustu"
+
+#: id:21412
+msgid "Scrapers"
+msgstr "Sköfur"
+
+#: id:21413
+msgid "Default movie scraper"
+msgstr "Sjálfgefin kvikmyndaskafa"
+
+#: id:21414
+msgid "Default tvshow scraper"
+msgstr "Sjálfgefin sjónvarpsþáttaskafa"
+
+#: id:21415
+msgid "Default music video scraper"
+msgstr "Sjálfgefin tónlistarmyndbandaskafa"
+
+#: id:21416
+msgid "Enable fallback based on scraper language"
+msgstr "Virkja varasköfu út frá tungumáli"
+
+#: id:21417
+msgid "- Settings"
+msgstr "- Stillingar"
+
+#: id:21418
+msgid "Multilingual"
+msgstr "Fjöltungumál"
+
+#: id:21419
+msgid "No scrapers present"
+msgstr "Engar sköfur skilgreindar"
+
+#: id:21420
+msgid "Value to match"
+msgstr "Gildi til að para"
+
+#: id:21421
+msgid "Smart playlist rule"
+msgstr "Snjöll spilunarlistaregla"
+
+#: id:21422
+msgid "Match items where"
+msgstr "Para lög þar sem"
+
+#: id:21423
+msgid "New rule..."
+msgstr "Ný regla..."
+
+#: id:21424
+msgid "Items must match"
+msgstr "Lög verða að passa"
+
+#: id:21425
+msgid "all of the rules"
+msgstr "allar reglur"
+
+#: id:21426
+msgid "one or more of the rules"
+msgstr "ein eða fleiri regla"
+
+#: id:21427
+msgid "Limit to"
+msgstr "Takmarka við"
+
+#: id:21428
+msgid "No limit"
+msgstr "Engin takmörk"
+
+#: id:21429
+msgid "Order by"
+msgstr "Raða eftir"
+
+#: id:21430
+msgid "ascending"
+msgstr "hækkandi"
+
+#: id:21431
+msgid "descending"
+msgstr "lækkandi"
+
+#: id:21432
+msgid "Edit smart playlist"
+msgstr "Breyta snjöllum spilunarlista"
+
+#: id:21433
+msgid "Name of the playlist"
+msgstr "Nafn spilunarlista"
+
+#: id:21434
+msgid "Find items where"
+msgstr "Finna hluti sem"
+
+#: id:21435
+msgid "Edit"
+msgstr "Breyta"
+
+#: id:21436
+msgid "%i items"
+msgstr "%i hlutir"
+
+#: id:21437
+msgid "New smart playlist..."
+msgstr "Nýr snjall spilunarlisti..."
+
+#: id:21438
+msgid "%c Drive"
+msgstr "%c Drif"
+
+#: id:21439
+msgid "Edit party mode rules"
+msgstr "Breyta reglum fyrir partí ham"
+
+#: id:21440
+msgid "Home folder"
+msgstr "Heimamappa"
+
+#: id:21441
+msgid "Watched count"
+msgstr "Fjöldi áhorfa"
+
+#: id:21442
+msgid "Episode title"
+msgstr "Titill þáttar"
+
+#: id:21443
+msgid "Video resolution"
+msgstr "Myndbanda upplausn"
+
+#: id:21444
+msgid "Audio channels"
+msgstr "Hljóðrásir"
+
+#: id:21445
+msgid "Video codec"
+msgstr "Myndkótari"
+
+#: id:21446
+msgid "Audio codec"
+msgstr "Hljóðkótari"
+
+#: id:21447
+msgid "Audio language"
+msgstr "Tungumál hljóðefnis"
+
+#: id:21448
+msgid "Subtitle language"
+msgstr "Tungumál þýðingartexta"
+
+#: id:21449
+msgid "Remote control sends keyboard presses"
+msgstr "Fjarstýring sendir lyklaborðsáslætti"
+
+#: id:21450
+msgid "- Edit"
+msgstr "- Breyta"
+
+#: id:21451
+msgid "Internet connection required."
+msgstr "Internet tenging er nauðsynleg."
+
+#: id:21452
+msgid "Get More..."
+msgstr "Ná í meira..."
+
+#: id:21453
+msgid "Root filesystem"
+msgstr "Rótarskráarkerfið"
+
+#: id:21454
+msgid "Cache full"
+msgstr "Skyndiminni fullt"
+
+#: id:21455
+msgid "Cache filled before reaching required amount for continous playback"
+msgstr "Skyndiminni fylltist áður en tókst að ná í nauðsynlegt magn fyrir áframhaldandi spilun"
+
+#: id:21460
+msgid "Subtitle location"
+msgstr "Staðsetning þýðingartexta"
+
+#: id:21461
+msgid "Fixed"
+msgstr "Fastur"
+
+#: id:21462
+msgid "Bottom of video"
+msgstr "Neðst á mynd"
+
+#: id:21463
+msgid "Below video"
+msgstr "Fyrir neðan mynd"
+
+#: id:21464
+msgid "Top of video"
+msgstr "Efst á mynd"
+
+#: id:21465
+msgid "Above video"
+msgstr "Fyrir ofan mynd"
+
+#: id:21800
+msgid "File name"
+msgstr "Skráarnafn"
+
+#: id:21801
+msgid "File path"
+msgstr "Skáarslóð"
+
+#: id:21802
+msgid "File size"
+msgstr "Skráarstærð"
+
+#: id:21803
+msgid "File date/time"
+msgstr "Skráardagsetning"
+
+#: id:21804
+msgid "Slide index"
+msgstr "Númer skyggnu"
+
+#: id:21805
+msgctxt "Auto context with id 21805"
+msgid "Resolution"
+msgstr "Upplausn"
+
+#: id:21806
+msgctxt "Auto context with id 21806"
+msgid "Comment"
+msgstr "Athugasemd"
+
+#: id:21807
+msgid "Colour/B&W"
+msgstr "Litur/S&H"
+
+#: id:21808
+msgid "JPEG process"
+msgstr "JPEG ferli"
+
+#: id:21820
+msgid "Date/Time"
+msgstr "Dagsetning/Tími"
+
+#: id:21821
+msgid "Description"
+msgstr "Lýsing"
+
+#: id:21822
+msgid "Camera make"
+msgstr "Nafn myndavélar"
+
+#: id:21823
+msgid "Camera model"
+msgstr "Tegund myndavélar"
+
+#: id:21824
+msgid "EXIF comment"
+msgstr "EXIF upplýsingar"
+
+#: id:21825
+msgid "Firmware"
+msgstr "Fastbúnaður"
+
+#: id:21826
+msgid "Aperture"
+msgstr "Ljósop"
+
+#: id:21827
+msgid "Focal length"
+msgstr "Linsustærð"
+
+#: id:21828
+msgid "Focus distance"
+msgstr "Fókusfjarlægð"
+
+#: id:21829
+msgid "Exposure"
+msgstr "Lýsingarmagn"
+
+#: id:21830
+msgid "Exposure time"
+msgstr "Lýsingartími"
+
+#: id:21831
+msgid "Exposure bias"
+msgstr "Bjagi lýsingarmagns"
+
+#: id:21832
+msgid "Exposure mode"
+msgstr "Lýsingarmagns hamur"
+
+#: id:21833
+msgid "Flash used"
+msgstr "Flass notað"
+
+#: id:21834
+msgid "White-balance"
+msgstr "Hvítvægi"
+
+#: id:21835
+msgid "Light source"
+msgstr "Ljósgjafi"
+
+#: id:21836
+msgid "Metering mode"
+msgstr "Mælishamur"
+
+#: id:21837
+msgid "ISO"
+msgstr "ISO"
+
+#: id:21838
+msgid "Digital zoom"
+msgstr "Stafrænt zoom"
+
+#: id:21839
+msgid "CCD width"
+msgstr "CCD breidd"
+
+#: id:21840
+msgid "GPS latitude"
+msgstr "GPS breiddargráða"
+
+#: id:21841
+msgid "GPS longitude"
+msgstr "GPS lengdarbaugur"
+
+#: id:21842
+msgid "GPS altitude"
+msgstr "GPS hæð"
+
+#: id:21843
+msgid "Orientation"
+msgstr "Stefna"
+
+#: id:21860
+msgid "Supplemental categories"
+msgstr "Viðbótar flokkar"
+
+#: id:21861
+msgid "Keywords"
+msgstr "Lykilorð"
+
+#: id:21862
+msgid "Caption"
+msgstr "Heiti"
+
+#: id:21863
+msgid "Author"
+msgstr "Höfundur"
+
+#: id:21864
+msgid "Headline"
+msgstr "Titill"
+
+#: id:21865
+msgid "Special instructions"
+msgstr "Sérstök fyrirmæli"
+
+#: id:21866
+msgid "Category"
+msgstr "Flokkur"
+
+#: id:21867
+msgid "Byline"
+msgstr "Grein"
+
+#: id:21868
+msgid "Byline title"
+msgstr "Titill greinar"
+
+#: id:21869
+msgid "Credit"
+msgstr "Þakkir"
+
+#: id:21870
+msgid "Source"
+msgstr "Uppruni"
+
+#: id:21871
+msgid "Copyright notice"
+msgstr "Höfundarréttur"
+
+#: id:21872
+msgid "Object name"
+msgstr "Nafn hlutar"
+
+#: id:21873
+msgid "City"
+msgstr "Borg"
+
+#: id:21874
+msgid "State"
+msgstr "Ríki"
+
+#: id:21875
+msgctxt "Auto context with id 21875"
+msgid "Country"
+msgstr "Land"
+
+#: id:21876
+msgid "Original Tx Reference"
+msgstr "Upprunaleg Tx tilvísun"
+
+#: id:21877
+msgid "Date created"
+msgstr "Búinn til"
+
+#: id:21878
+msgid "Copyright flag"
+msgstr "Höfundarréttarmerki"
+
+#: id:21879
+msgid "Country code"
+msgstr "Landsnúmer"
+
+#: id:21880
+msgid "Reference service"
+msgstr "Tilvísunar þjónusta"
+
+#: id:21881
+msgid "Allow control of XBMC via UPnP"
+msgstr "Leyfa stjórnun á XBMC með UPnP"
+
+#: id:21882
+msgid "Attempt to skip introduction before DVD menu"
+msgstr "Reyna að sleppa kynningarefni á undan DVD valmynd"
+
+#: id:21883
+msgid "Saved music"
+msgstr "Afritaðir tónlistardiskar"
+
+#: id:21884
+msgid "Query info for all artists"
+msgstr "Leita að upplýsingum fyrir alla tónlistarmenn"
+
+#: id:21885
+msgid "Downloading album information"
+msgstr "Hleð niður upplýsingum um hljómplötu"
+
+#: id:21886
+msgid "Downloading artist information"
+msgstr "Hleð niður upplýsingum um listamann"
+
+#: id:21887
+msgid "Biography"
+msgstr "Æviágrip"
+
+#: id:21888
+msgid "Discography"
+msgstr "Safnplata"
+
+#: id:21889
+msgid "Searching artist"
+msgstr "Leita að tónlistarmönnum"
+
+#: id:21890
+msgid "Select artist"
+msgstr "Veldu tónlistarmann"
+
+#: id:21891
+msgctxt "Auto context with id 21891"
+msgid "Artist information"
+msgstr "Upplýsingar um flytjanda"
+
+#: id:21892
+msgid "Instruments"
+msgstr "Hljóðfæri"
+
+#: id:21893
+msgid "Born"
+msgstr "Fæddur"
+
+#: id:21894
+msgid "Formed"
+msgstr "Varð til"
+
+#: id:21895
+msgid "Themes"
+msgstr "Þema"
+
+#: id:21896
+msgid "Disbanded"
+msgstr "Hætti"
+
+#: id:21897
+msgid "Died"
+msgstr "Dó"
+
+#: id:21898
+msgid "Years active"
+msgstr "Fjöldi ára virkur"
+
+#: id:21899
+msgid "Label"
+msgstr "Útgefandi"
+
+#: id:21900
+msgid "Born/Formed"
+msgstr "Fæddur/varð til"
+
+#: id:22000
+msgid "Update library on startup"
+msgstr "Uppfæra safn við ræsingu"
+
+#: id:22001
+msgid "Hide progress of library updates"
+msgstr "Uppfæra alltaf safn í bakgrunni"
+
+#: id:22002
+msgid "- DNS suffix"
+msgstr "- DNS viðskeyti"
+
+#: id:22003
+msgid "%2.3fs"
+msgstr "%2.3fs"
+
+#: id:22004
+msgid "Delayed by: %2.3fs"
+msgstr "Seinkað: %2.3fs"
+
+#: id:22005
+msgid "Ahead by: %2.3fs"
+msgstr "Á undan: %2.3fs"
+
+#: id:22006
+msgid "Subtitle offset"
+msgstr "Færsla þýðingartexta"
+
+#: id:22007
+msgid "OpenGL vendor:"
+msgstr "OpenGL framleiðandi:"
+
+#: id:22008
+msgid "OpenGL renderer:"
+msgstr "OpenGL teiknari:"
+
+#: id:22009
+msgid "OpenGL version:"
+msgstr "OpenGL útgáfa:"
+
+#: id:22010
+msgid "GPU temperature:"
+msgstr "GPU hiti:"
+
+#: id:22011
+msgid "CPU temperature:"
+msgstr "CPU hiti:"
+
+#: id:22012
+msgid "Total memory"
+msgstr "Heildarminni"
+
+#: id:22013
+msgid "Profile data"
+msgstr "Notandagögn"
+
+#: id:22014
+msgid "Use dim if paused during video playback"
+msgstr "Dekkja þegar myndband er sett í bið"
+
+#: id:22015
+msgid "All recordings"
+msgstr "Allar upptökur"
+
+#: id:22016
+msgid "By title"
+msgstr "Eftir titli"
+
+#: id:22017
+msgid "By group"
+msgstr "Eftir hópi"
+
+#: id:22018
+msgid "Live channels"
+msgstr "Beinar rásir"
+
+#: id:22019
+msgid "Recordings by title"
+msgstr "Upptökur eftir titli"
+
+#: id:22020
+msgid "Guide"
+msgstr "Leiðsagnarsíða"
+
+#: id:22021
+msgid "Allowed error in aspect ratio to minimize black bars"
+msgstr "Leyfð skekkja í hlutfalli til að minnka svartar súlur"
+
+#: id:22022
+msgid "Show video files in listings"
+msgstr "Taka myndbandaskrár með í lista"
+
+#: id:22023
+msgid "DirectX vendor:"
+msgstr "DirectX framleiðandi:"
+
+#: id:22024
+msgid "Direct3D version:"
+msgstr "Direct3D útgáfa:"
+
+#: id:22030
+msgctxt "Auto context with id 22030"
+msgid "Font"
+msgstr "Leturgerð"
+
+#: id:22031
+msgctxt "Auto context with id 22031"
+msgid "- Size"
+msgstr "- Stærð"
+
+#: id:22032
+msgctxt "Auto context with id 22032"
+msgid "- Colours"
+msgstr "- Litir"
+
+#: id:22033
+msgid "- Charset"
+msgstr "- Stafasett"
+
+#: id:22034
+msgid "Export karaoke titles as HTML"
+msgstr "Flytja út karaoke titla sem HTML"
+
+#: id:22035
+msgid "Export karaoke titles as CSV"
+msgstr "Flytja út karaoke titla sem CSV"
+
+#: id:22036
+msgid "Import karaoke titles..."
+msgstr "Flytja inn karaoke titla..."
+
+#: id:22037
+msgid "Show song selector automatically"
+msgstr "Sækja lagavalslista sjálfvirkt"
+
+#: id:22038
+msgid "Export karaoke titles..."
+msgstr "Flytja út karaoke titla..."
+
+#: id:22039
+msgid "Enter song number"
+msgstr "Sláðu inn númer lags"
+
+#: id:22040
+msgid "white/green"
+msgstr "hvítt/grænt"
+
+#: id:22041
+msgid "white/red"
+msgstr "hvítt/rautt"
+
+#: id:22042
+msgid "white/blue"
+msgstr "hvítt/blátt"
+
+#: id:22043
+msgid "black/white"
+msgstr "svart/hvítt"
+
+#: id:22079
+msgid "Default select action"
+msgstr "Sjálfgefin valaðgerð"
+
+#: id:22080
+msgid "Choose"
+msgstr "Veldu"
+
+#: id:22081
+msgid "Show Information"
+msgstr "Sýna upplýsingar"
+
+#: id:22082
+msgid "More..."
+msgstr "Meira..."
+
+#: id:22083
+msgid "Play all"
+msgstr "Spila allt"
+
+#: id:23049
+msgid "Teletext not available"
+msgstr "Textavarp ekki tiltækt"
+
+#: id:23050
+msgid "Activate Teletext"
+msgstr "Virkja textavarp"
+
+#: id:23051
+msgid "Part %i"
+msgstr "Partur %i"
+
+#: id:23052
+msgid "Buffering %i bytes"
+msgstr "Hleð inn %i bætum"
+
+#: id:23053
+msgid "Stopping"
+msgstr "Stöðva"
+
+#: id:23054
+msgid "Running"
+msgstr "Keyrir"
+
+#: id:23100
+msgid "External Player Active"
+msgstr "Ytri spilari virkur"
+
+#: id:23101
+msgid "Click OK to terminate the player"
+msgstr "Smelltu á Í lagi til að hætta í spilara"
+
+#: id:23104
+msgid "Click OK when playback has ended"
+msgstr "Smelltu á Í lagi þegar spilun er lokið"
+
+#: id:24000
+msgid "Add-on"
+msgstr "Viðbót"
+
+#: id:24001
+msgid "Add-ons"
+msgstr "Viðbætur"
+
+#: id:24002
+msgid "Add-on options"
+msgstr "Viðbótarstillingar"
+
+#: id:24003
+msgid "Add-on Information"
+msgstr "Viðbótarupplýsingar"
+
+#: id:24005
+msgctxt "Auto context with id 24005"
+msgid "Media sources"
+msgstr "Tengiforrit"
+
+#: id:24007
+msgctxt "Auto context with id 24007"
+msgid "Movie information"
+msgstr "Kvikmyndaupplýsingar"
+
+#: id:24008
+msgctxt "Auto context with id 24008"
+msgid "Screensaver"
+msgstr "Skjávari"
+
+#: id:24009
+msgid "Script"
+msgstr "Skrifta"
+
+#: id:24010
+msgctxt "Auto context with id 24010"
+msgid "Visualization"
+msgstr "Myndskreyting"
+
+#: id:24011
+msgid "Add-on repository"
+msgstr "Viðbótarsafn"
+
+#: id:24012
+msgctxt "Auto context with id 24012"
+msgid "Subtitles"
+msgstr "Þýðingartextar"
+
+#: id:24013
+msgid "Lyrics"
+msgstr "Lagatextar"
+
+#: id:24014
+msgid "TV information"
+msgstr "Sjónvarpsupplýsingar"
+
+#: id:24015
+msgctxt "Auto context with id 24015"
+msgid "Music video information"
+msgstr "Upplýsingar um tónlistarmyndband"
+
+#: id:24016
+msgctxt "Auto context with id 24016"
+msgid "Album information"
+msgstr "Hljómplötuupplýsingar"
+
+#: id:24017
+msgctxt "Auto context with id 24017"
+msgid "Artist information"
+msgstr "Upplýsingar um flytjanda"
+
+#: id:24018
+msgctxt "Auto context with id 24018"
+msgid "Services"
+msgstr "Þjónustur"
+
+#: id:24020
+msgid "Configure"
+msgstr "Stilla viðbætur"
+
+#: id:24021
+msgctxt "Auto context with id 24021"
+msgid "Disable"
+msgstr "Gera viðbót óvirka"
+
+#: id:24022
+msgid "Enable"
+msgstr "Virkja viðbót"
+
+#: id:24023
+msgid "Add-on disabled"
+msgstr "Viðbót óvirk"
+
+#: id:24027
+msgctxt "Auto context with id 24027"
+msgid "Weather"
+msgstr "Veðurþjónusta"
+
+#: id:24028
+msgid "Weather.com (standard)"
+msgstr "Weather.com (sjálfgefið)"
+
+#: id:24030
+msgid "This Add-on can not be configured"
+msgstr "Ekki er hægt að stilla þessa viðbót"
+
+#: id:24031
+msgid "Error loading settings"
+msgstr "Villa við að hlaða inn stillingum"
+
+#: id:24032
+msgid "All Add-ons"
+msgstr "Allar viðbætur"
+
+#: id:24033
+msgid "Get Add-ons"
+msgstr "Sækja viðbætur"
+
+#: id:24034
+msgid "Check for updates"
+msgstr "Leita að uppfærslum"
+
+#: id:24035
+msgid "Force refresh"
+msgstr "Þvinga endurnýjun"
+
+#: id:24036
+msgid "Change log"
+msgstr "Breytingaskrá"
+
+#: id:24037
+msgid "Uninstall"
+msgstr "Taka út"
+
+#: id:24038
+msgid "Install"
+msgstr "Setja inn"
+
+#: id:24039
+msgid "Disabled Add-ons"
+msgstr "Óvirkar viðbætur"
+
+#: id:24040
+msgid "(Clear the current setting)"
+msgstr "(Hreinsa núverandi stillingu)"
+
+#: id:24041
+msgid "Install from zip file"
+msgstr "Setja inn frá zip skrá"
+
+#: id:24042
+msgid "Downloading %i%%"
+msgstr "Niðurhaa %i%%"
+
+#: id:24043
+msgid "Available Updates"
+msgstr "Fáanlegar uppfærslur"
+
+#: id:24044
+msgid "Dependencies not met"
+msgstr "Kröfur voru ekki uppfylltar"
+
+#: id:24045
+msgid "Add-on does not have the correct structure"
+msgstr "Viðbót er ekki rétt uppsett"
+
+#: id:24046
+msgid "%s is used by the following installed add-on(s)"
+msgstr "%s er notað af eftirfarandi viðbótum"
+
+#: id:24047
+msgid "This add-on cannot be uninstalled"
+msgstr "Ekki er hægt að taka þessa viðbót út"
+
+#: id:24048
+msgid "Rollback"
+msgstr "Niðurfæra útgáfu"
+
+#: id:24050
+msgid "Available Add-ons"
+msgstr "Tiltækar viðbætur"
+
+#: id:24051
+msgid "Version:"
+msgstr "Útgáfa:"
+
+#: id:24052
+msgid "Disclaimer"
+msgstr "Skilmálar"
+
+#: id:24053
+msgid "License:"
+msgstr "Notkunarskilmálar:"
+
+#: id:24054
+msgid "Changelog"
+msgstr "Breytingaskrá"
+
+#: id:24059
+msgid "Would you like to enable this Add-on?"
+msgstr "Viltu setja inn þessa viðbót?"
+
+#: id:24060
+msgid "Would you like to disable this Add-on?"
+msgstr "Viltu gera þessa viðbót óvirka?"
+
+#: id:24061
+msgid "Add-on update available!"
+msgstr "Til er uppfærsla fyrir viðbót!"
+
+#: id:24062
+msgid "Enabled Add-ons"
+msgstr "Virkar viðbætur"
+
+#: id:24063
+msgid "Auto update"
+msgstr "Sjálfvirk uppfærsla"
+
+#: id:24064
+msgid "Add-on enabled"
+msgstr "Viðbót virkjuð"
+
+#: id:24065
+msgid "Add-on updated"
+msgstr "Viðbót uppfærð"
+
+#: id:24066
+msgid "Cancel Add-on download?"
+msgstr "Hætta við að niðurhala viðbót?"
+
+#: id:24067
+msgid "Currently downloading Add-ons"
+msgstr "Er að niðurhala viðbótum"
+
+#: id:24068
+msgid "Update available"
+msgstr "Fann uppfærslu"
+
+#: id:24069
+msgid "Update"
+msgstr "Uppfæra"
+
+#: id:24070
+msgid "Add-on could not be loaded."
+msgstr "Ekki tókst að hlaða inn viðbót."
+
+#: id:24071
+msgid "An unknown error has occurred."
+msgstr "Óþekkt villa kom upp."
+
+#: id:24072
+msgid "Settings required"
+msgstr "Nauðsynlegt er að setja stillingar"
+
+#: id:24073
+msgid "Could not connect"
+msgstr "Gat ekki tengst"
+
+#: id:24074
+msgid "Needs to restart"
+msgstr "Þarfnast endurræsingar"
+
+#: id:24075
+msgctxt "Auto context with id 24075"
+msgid "Disable"
+msgstr "Gera óvirkt"
+
+#: id:24076
+msgid "Add-on Required"
+msgstr "Þarfnast viðbótar"
+
+#: id:24080
+msgid "Try to reconnect?"
+msgstr "Reyna að tengjast aftur?"
+
+#: id:24089
+msgid "Add-on restarts"
+msgstr "Endurræsingar viðbóta"
+
+#: id:24090
+msgid "Lock Add-on manager"
+msgstr "Læsa viðbótarstjóra"
+
+#: id:24094
+msgid "(current)"
+msgstr "(núna)"
+
+#: id:24095
+msgid "(blacklisted)"
+msgstr "(á bannlista)"
+
+#: id:24096
+msgid "Add-on has been marked as broken in repository."
+msgstr "Viðbót hefur verið merkt sem biluð í safni."
+
+#: id:24097
+msgid "Would you like to disable it on your system?"
+msgstr "Viltu slökkva á henni á þínu kerfi?"
+
+#: id:24098
+msgid "Broken"
+msgstr "Biluð"
+
+#: id:24099
+msgid "Would you like to switch to this skin?"
+msgstr "Viltu skipta yfir á þetta útlit?"
+
+#: id:24100
+msgid "To use this feature you must download an Add-on:"
+msgstr "Til að nota þetta þarftu að hala niður viðbót:"
+
+#: id:24101
+msgid "Would you like to download this Add-on?"
+msgstr "Viltu hala niður þessari viðbót?"
+
+#: id:25000
+msgid "Notifications"
+msgstr "Tilkynningar"
+
+#: id:29800
+msgid "Library Mode"
+msgstr "Safnhamur"
+
+#: id:29801
+msgid "QWERTY keyboard"
+msgstr "QWERTY Lyklaborð"
+
+#: id:29802
+msgid "Passthrough Audio in use"
+msgstr "Gegnumúttakshljóð í notkun"
+
+#: id:33001
+msgid "Trailer quality"
+msgstr "Gæði kvikmyndasýnishorns"
+
+#: id:33002
+msgid "Stream"
+msgstr "Straumur"
+
+#: id:33003
+msgid "Download"
+msgstr "Hala niður"
+
+#: id:33004
+msgid "Download & play"
+msgstr "Niðurhala og spila"
+
+#: id:33005
+msgid "Download & save"
+msgstr "Niðurhala og vista"
+
+#: id:33006
+msgid "Today"
+msgstr "Í dag"
+
+#: id:33007
+msgid "Tomorrow"
+msgstr "Á morgun"
+
+#: id:33008
+msgid "Saving"
+msgstr "Vista"
+
+#: id:33009
+msgid "Copying"
+msgstr "Afritun"
+
+#: id:33010
+msgid "Set download directory"
+msgstr "Velja niðurhalsmöppu"
+
+#: id:33011
+msgid "Search duration"
+msgstr "Leitarlengd"
+
+#: id:33012
+msgid "Short"
+msgstr "Stutt"
+
+#: id:33013
+msgid "Long"
+msgstr "Langt"
+
+#: id:33014
+msgid "Use DVD player instead of regular player"
+msgstr "Nota DVD spilara í staðinn fyrir venjulegan spilara"
+
+#: id:33015
+msgid "Ask for download before playing video"
+msgstr "Spyrja um niðurhal áður en myndband er spilað"
+
+#: id:33016
+msgid "Clips"
+msgstr "Úrklippur"
+
+#: id:33017
+msgid "Restart plugin to enable"
+msgstr "Endurræstu viðbót til að gera virkt"
+
+#: id:33018
+msgid "Tonight"
+msgstr "Í kvöld"
+
+#: id:33019
+msgid "Tomorrow Night"
+msgstr "Aðra nótt"
+
+#: id:33020
+msgid "Condition"
+msgstr "Staða"
+
+#: id:33021
+msgid "Precipitation"
+msgstr "Úrkoma"
+
+#: id:33022
+msgid "Precip"
+msgstr "Úrkoma"
+
+#: id:33023
+msgid "Humid"
+msgstr "Raki"
+
+#: id:33024
+msgid "Feels"
+msgstr "Skynjast sem"
+
+#: id:33025
+msgid "Observed"
+msgstr "Sést sem"
+
+#: id:33026
+msgid "Departure from normal"
+msgstr "Frávík frá venjulegu"
+
+#: id:33027
+msgid "Sunrise"
+msgstr "Sólarupprás"
+
+#: id:33028
+msgid "Sunset"
+msgstr "Sólsetur"
+
+#: id:33029
+msgid "Details"
+msgstr "Nánar"
+
+#: id:33030
+msgid "Outlook"
+msgstr "Veðurspá"
+
+#: id:33031
+msgid "Coverflow"
+msgstr "Plötuumslag"
+
+#: id:33032
+msgid "Translate text"
+msgstr "Þýða texta"
+
+#: id:33033
+msgid "Map list %s category"
+msgstr "Stilla lista %s flokk"
+
+#: id:33034
+msgid "36 Hour"
+msgstr "36 klukkustundir"
+
+#: id:33035
+msgid "Maps"
+msgstr "Kort"
+
+#: id:33036
+msgid "Hourly"
+msgstr "Klukkustunda fresti"
+
+#: id:33037
+msgid "Weekend"
+msgstr "Helgi"
+
+#: id:33038
+msgid "%s day"
+msgstr "%s dagur"
+
+#: id:33049
+msgid "Alert"
+msgstr "Aðvörun"
+
+#: id:33050
+msgid "Alerts"
+msgstr "Viðvaranir"
+
+#: id:33051
+msgid "Choose Your"
+msgstr "Veldu þinn"
+
+#: id:33052
+msgid "Check"
+msgstr "Haka"
+
+#: id:33053
+msgctxt "Auto context with id 33053"
+msgid "Configure the"
+msgstr "Stilltu"
+
+#: id:33054
+msgid "Seasons"
+msgstr "Árstíðir"
+
+#: id:33055
+msgid "Use your"
+msgstr "Notaðu"
+
+#: id:33056
+msgid "Watch your"
+msgstr "Fylgstu með"
+
+#: id:33057
+msgid "Listen to"
+msgstr "Hlusta á"
+
+#: id:33058
+msgid "View your"
+msgstr "Skoðaðu"
+
+#: id:33059
+msgctxt "Auto context with id 33059"
+msgid "Configure the"
+msgstr "Stilltu"
+
+#: id:33060
+msgid "Power"
+msgstr "Orku"
+
+#: id:33061
+msgid "Menu"
+msgstr "Valmynd"
+
+#: id:33062
+msgid "Play the"
+msgstr "Spilaðu"
+
+#: id:33063
+msgid "Options"
+msgstr "Valkostir"
+
+#: id:33065
+msgid "Editor"
+msgstr "Ritill"
+
+#: id:33066
+msgid "About your"
+msgstr "Um"
+
+#: id:33067
+msgid "Star rating"
+msgstr "Stjörnugjöf"
+
+#: id:33068
+msgid "Background"
+msgstr "Bakgrunnur"
+
+#: id:33069
+msgid "Backgrounds"
+msgstr "Bakgrunnar"
+
+#: id:33070
+msgid "Custom background"
+msgstr "Sérsniðinn bakgrunnur"
+
+#: id:33071
+msgid "Custom backgrounds"
+msgstr "Sérsniðinn bakgrunnar"
+
+#: id:33072
+msgid "View Readme"
+msgstr "Skoða upplýsingaskrá"
+
+#: id:33073
+msgid "View Changelog"
+msgstr "Skoða breytingaannál"
+
+#: id:33074
+msgid "This version of %s requires an"
+msgstr "Þessi útgáfa af %s þarfnast"
+
+#: id:33075
+msgid "XBMC revision of %s or greater to run."
+msgstr "XBMC útgáfu %s eða hærri til að keyra."
+
+#: id:33076
+msgid "Please update XBMC."
+msgstr "Vinsamlega uppfærðu XBMC."
+
+#: id:33077
+msgid "No data found!"
+msgstr "Engin gögn fundust!"
+
+#: id:33078
+msgid "Next page"
+msgstr "Næsta síða"
+
+#: id:33079
+msgid "Love"
+msgstr "Elska"
+
+#: id:33080
+msgid "Hate"
+msgstr "Hatur"
+
+#: id:33081
+msgid "This file is stacked, select the part you want to play from."
+msgstr "Þessi skrá er stöfluð, veldu þann part sem þú vilt byrja að spila frá."
+
+#: id:33082
+msgid "Path to script"
+msgstr "Slóð á skriftu"
+
+#: id:33083
+msgid "Enable custom script button"
+msgstr "Virkja takka fyrir sérsniðna skriftu"
+
+#: id:33100
+msgid "Failed to start"
+msgstr "Tókst ekki að ræsa"
+
+#: id:33101
+msgid "Webserver"
+msgstr "Vefþjónn"
+
+#: id:33102
+msgid "Event Server"
+msgstr "Atburðaþjónn"
+
+#: id:33103
+msgid "Remote communication server"
+msgstr "Fjartengdur samskiptaþjónn"
+
+#: id:33200
+msgid "Detected New Connection"
+msgstr "Uppgötvaði nýja tengingu"
+
+#: id:34000
+msgid "Lame"
+msgstr "Lame"
+
+#: id:34001
+msgid "Vorbis"
+msgstr "Vorbis"
+
+#: id:34002
+msgid "Wav"
+msgstr "Wav"
+
+#: id:34003
+msgid "DXVA2"
+msgstr "DXVA2"
+
+#: id:34004
+msgid "VAAPI"
+msgstr "VAAPI"
+
+#: id:34005
+msgid "Flac"
+msgstr "Flac"
+
+#: id:34100
+msgid "Speaker Configuration"
+msgstr "Stillingar hátalara"
+
+#: id:34101
+msgid "2.0"
+msgstr "2.0"
+
+#: id:34102
+msgid "2.1"
+msgstr "2.1"
+
+#: id:34103
+msgid "3.0"
+msgstr "3.0"
+
+#: id:34104
+msgid "3.1"
+msgstr "3.1"
+
+#: id:34105
+msgid "4.0"
+msgstr "4.0"
+
+#: id:34106
+msgid "4.1"
+msgstr "4.1"
+
+#: id:34107
+msgid "5.0"
+msgstr "5.0"
+
+#: id:34108
+msgid "5.1"
+msgstr "5.1"
+
+#: id:34109
+msgid "7.0"
+msgstr "7.0"
+
+#: id:34110
+msgid "7.1"
+msgstr "7.1"
+
+#: id:34201
+msgid "Can't find a next item to play"
+msgstr "Finn ekki næsta hlut til að spila"
+
+#: id:34202
+msgid "Can't find a previous item to play"
+msgstr "Finn ekki fyrri hlut til að spila"
+
+#: id:34300
+msgid "Failed to start zeroconf"
+msgstr "Gat ekki ræst zeroconf"
+
+#: id:34301
+msgid "Is Apple's Bonjour Service installed? See log for more info."
+msgstr "Er Apple Bonjour þjónusta uppsett? Athugaðu atburðaskrá fyrir meiri upplýsingar."
+
+#: id:34400
+msgid "Video Rendering"
+msgstr "Skjábirting"
+
+#: id:34401
+msgid "Failed to init video filters/scalers, falling back to bilinear scaling"
+msgstr "Gat ekki frumstillt skjá síur/kvarða, fer til baka í tvílínulega kvörðun"
+
+#: id:34402
+msgid "Failed to initialize audio device"
+msgstr "Gat ekki frumstillt hljóðkerfi"
+
+#: id:34403
+msgid "Check your audiosettings"
+msgstr "Athugaðu hljóðstillingar"
+
+#: id:34404
+msgid "Use gestures for navigation:"
+msgstr ""
+
+#: id:34405
+msgid "1 finger swipe left,right,up,down for cursors"
+msgstr ""
+
+#: id:34406
+msgid "2 finger swipe left for backspace"
+msgstr ""
+
+#: id:34407
+msgid "1 finger single tap for enter"
+msgstr ""
+
+#: id:34408
+msgid "2 finger single tap for contextmenu"
+msgstr ""
+
+#: id:35000
+msgid "Peripherals"
+msgstr "Tæki"
+
+#: id:35001
+msgid "Generic HID device"
+msgstr "Almennt HID tæki"
+
+#: id:35002
+msgid "Generic network adapter"
+msgstr "Almennt netkort"
+
+#: id:35003
+msgid "Generic disk"
+msgstr "Almennur diskur"
+
+#: id:35004
+msgid "There are no settings available\nfor this peripheral."
+msgstr "Engar stillingar eru tiltækar fyrir þetta tæki."
+
+#: id:35005
+msgid "New device configured"
+msgstr "Nýtt tæki skilgreint"
+
+#: id:35006
+msgid "Device removed"
+msgstr "Tæki fjarlægt"
+
+#: id:35007
+msgid "Keymap to use for this device"
+msgstr "Lyklavörpun sem á að nota fyrir þetta tæki"
+
+#: id:35008
+msgid "Keymap enabled"
+msgstr "Lyklavörpun virk"
+
+#: id:35009
+msgid "Do not use the custom keymap for this device"
+msgstr ""
+
+#: id:35500
+msgid "Location"
+msgstr "Staðsetning"
+
+#: id:35501
+msgid "Class"
+msgstr "Klasi"
+
+#: id:35502
+msgctxt "Auto context with id 35502"
+msgid "Name"
+msgstr "Nafn"
+
+#: id:35503
+msgid "Vendor"
+msgstr "Söluaðili"
+
+#: id:35504
+msgid "Product ID"
+msgstr "Auðkenni vöru"
+
+#: id:36000
+msgid "Pulse-Eight CEC adapter"
+msgstr "Pulse-Eight CEC tengispjald"
+
+#: id:36001
+msgid "Pulse-Eight Nyxboard"
+msgstr "Pulse-Eight Nyxboard"
+
+#: id:36002
+msgid "Switch to keyboard side command"
+msgstr "Skipta yfir í hliðar lyklaborð"
+
+#: id:36003
+msgid "Switch to remote side command"
+msgstr "Skipta yfir í hliðar fjarstýringu"
+
+#: id:36004
+msgid "Press \"user\" button command"
+msgstr "Ýttu á \"user\" hnapp"
+
+#: id:36005
+msgid "Enable switch side commands"
+msgstr "Virkja að skipta á milli hliðarskipana"
+
+#: id:36006
+msgid "Could not open the adapter"
+msgstr "Gat ekki opnað tengispjald"
+
+#: id:36007
+msgid "Devices to power on when starting XBMC"
+msgstr "Kveikja á sjónvarpinu þegar XBMC er ræst"
+
+#: id:36008
+msgid "Devices to power off when stopping XBMC"
+msgstr "Slökkva á tækjum þegar slökkt er á XBMC"
+
+#: id:36009
+msgid "Put devices in standby mode when activating screensaver"
+msgstr "Setja tæki í biðstöðu þegar skjávari er virkur"
+
+#: id:36011
+msgid "Could not detect the CEC port. Set it up manually."
+msgstr "Fann ekki CEC gátt. Settu það upp handvirkt."
+
+#: id:36012
+msgid "Could not initialise the CEC adapter. Check your settings."
+msgstr "Fann ekki CEC tengispjald."
+
+#: id:36013
+msgid "Unsupported libCEC interface version. %d is greater than the version XBMC supports (%d)"
+msgstr "Þessi útgáfa af libcec er ekki studd. %d er hærri en útgáfan sem XBMC styður (%d)"
+
+#: id:36014
+msgid "Put this PC in standby mode when the TV is switched off"
+msgstr "Setja tölvuna í biðstöðu þegar slökkt er á sjónvarpinu"
+
+#: id:36015
+msgid "HDMI port number"
+msgstr "HDMI gátt"
+
+#: id:36016
+msgctxt "Auto context with id 36016"
+msgid "Connected"
+msgstr "Tengdur"
+
+#: id:36017
+msgid "Adapter found, but libCEC is not available"
+msgstr "Fann tengispjald, en libcec er ekki tiltækt"
+
+#: id:36018
+msgid "Use the TV's language setting"
+msgstr "Nota tungumál sjónvarps"
+
+#: id:36019
+msgid "Connected to HDMI device"
+msgstr ""
+
+#: id:36020
+msgid "Make XBMC the active source when starting"
+msgstr ""
+
+#: id:36021
+msgid "Physical address (overrules HDMI port)"
+msgstr ""
+
+#: id:36022
+msgid "COM port (leave empty unless needed)"
+msgstr ""
+
+#: id:36023
+msgid "Configuration updated"
+msgstr ""
+
+#: id:36024
+msgid "Failed to set the new configuration. Please check your settings."
+msgstr ""
+
+#: id:36025
+msgid "Send 'inactive source' command when stopping XBMC"
+msgstr ""
+

--- a/language/Indonesian/strings.po
+++ b/language/Indonesian/strings.po
@@ -1,0 +1,9093 @@
+# Converted from xbmc strings.xml with xbmc-xml2po (by Team-XBMC)
+msgid ""
+msgstr ""
+"Project-Id-Version: xbmc.core-FRODO_GIT3ed1604ad7\n"
+"Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
+"POT-Creation-Date: 2012-04-09 18:00+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE\n"
+"Language: id\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: id:0
+msgctxt "Auto context with id 0"
+msgid "Programs"
+msgstr "Program"
+
+#: id:1
+msgctxt "Auto context with id 1"
+msgid "Pictures"
+msgstr "Gambar"
+
+#: id:2
+msgctxt "Auto context with id 2"
+msgid "Music"
+msgstr "Musik"
+
+#: id:3
+msgctxt "Auto context with id 3"
+msgid "Videos"
+msgstr "Video"
+
+#: id:4
+msgid "TV-Guide"
+msgstr "Panduan TV"
+
+#: id:5
+msgctxt "Auto context with id 5"
+msgid "Settings"
+msgstr "Setelan"
+
+#: id:6
+msgid "XBMC SVN"
+msgstr ""
+
+#: id:7
+msgctxt "Auto context with id 7"
+msgid "File manager"
+msgstr "File"
+
+#: id:8
+msgctxt "Auto context with id 8"
+msgid "Weather"
+msgstr "Cuaca"
+
+#: id:9
+msgid "xbmc media center"
+msgstr ""
+
+#: id:11
+msgid "Monday"
+msgstr "Senin"
+
+#: id:12
+msgid "Tuesday"
+msgstr "Selasa"
+
+#: id:13
+msgid "Wednesday"
+msgstr "Rabu"
+
+#: id:14
+msgid "Thursday"
+msgstr "Kamis"
+
+#: id:15
+msgid "Friday"
+msgstr "Jumat"
+
+#: id:16
+msgid "Saturday"
+msgstr "Sabtu"
+
+#: id:17
+msgid "Sunday"
+msgstr "Minggu"
+
+#: id:21
+msgid "January"
+msgstr "Januari"
+
+#: id:22
+msgid "February"
+msgstr "Februari"
+
+#: id:23
+msgid "March"
+msgstr "Maret"
+
+#: id:24
+msgid "April"
+msgstr "April"
+
+#: id:25
+msgctxt "Auto context with id 25"
+msgid "May"
+msgstr "Mei"
+
+#: id:26
+msgid "June"
+msgstr "Juni"
+
+#: id:27
+msgid "July"
+msgstr "Juli"
+
+#: id:28
+msgid "August"
+msgstr "Agustus"
+
+#: id:29
+msgid "September"
+msgstr "September"
+
+#: id:30
+msgid "October"
+msgstr "Oktober"
+
+#: id:31
+msgid "November"
+msgstr "Nopember"
+
+#: id:32
+msgid "December"
+msgstr "Desember"
+
+#: id:41
+msgid "Mon"
+msgstr ""
+
+#: id:42
+msgid "Tue"
+msgstr ""
+
+#: id:43
+msgid "Wed"
+msgstr ""
+
+#: id:44
+msgid "Thu"
+msgstr ""
+
+#: id:45
+msgid "Fri"
+msgstr ""
+
+#: id:46
+msgid "Sat"
+msgstr ""
+
+#: id:47
+msgctxt "Auto context with id 47"
+msgid "Sun"
+msgstr ""
+
+#: id:51
+msgid "Jan"
+msgstr ""
+
+#: id:52
+msgid "Feb"
+msgstr ""
+
+#: id:53
+msgid "Mar"
+msgstr ""
+
+#: id:54
+msgid "Apr"
+msgstr ""
+
+#: id:55
+msgctxt "Auto context with id 55"
+msgid "May"
+msgstr ""
+
+#: id:56
+msgid "Jun"
+msgstr ""
+
+#: id:57
+msgid "Jul"
+msgstr ""
+
+#: id:58
+msgid "Aug"
+msgstr ""
+
+#: id:59
+msgid "Sep"
+msgstr ""
+
+#: id:60
+msgid "Oct"
+msgstr ""
+
+#: id:61
+msgid "Nov"
+msgstr ""
+
+#: id:62
+msgid "Dec"
+msgstr ""
+
+#: id:71
+msgid "N"
+msgstr ""
+
+#: id:72
+msgid "NNE"
+msgstr ""
+
+#: id:73
+msgid "NE"
+msgstr ""
+
+#: id:74
+msgid "ENE"
+msgstr ""
+
+#: id:75
+msgid "E"
+msgstr ""
+
+#: id:76
+msgid "ESE"
+msgstr ""
+
+#: id:77
+msgid "SE"
+msgstr ""
+
+#: id:78
+msgid "SSE"
+msgstr ""
+
+#: id:79
+msgid "S"
+msgstr ""
+
+#: id:80
+msgid "SSW"
+msgstr ""
+
+#: id:81
+msgid "SW"
+msgstr ""
+
+#: id:82
+msgid "WSW"
+msgstr ""
+
+#: id:83
+msgid "W"
+msgstr ""
+
+#: id:84
+msgid "WNW"
+msgstr ""
+
+#: id:85
+msgid "NW"
+msgstr ""
+
+#: id:86
+msgid "NNW"
+msgstr ""
+
+#: id:87
+msgid "VAR"
+msgstr ""
+
+#: id:98
+msgid "View: Auto"
+msgstr "Lihat: Otomatis"
+
+#: id:99
+msgid "View: Auto big"
+msgstr "Lihat Otomatis Besar"
+
+#: id:100
+msgid "View: Icons"
+msgstr "Lihat Ikon"
+
+#: id:101
+msgid "View: List"
+msgstr "Lihat Daftar"
+
+#: id:102
+msgctxt "Auto context with id 102"
+msgid "Scan"
+msgstr "Scan"
+
+#: id:103
+msgctxt "Auto context with id 103"
+msgid "Sort by: Name"
+msgstr "Sortir : Nama"
+
+#: id:104
+msgid "Sort by: Date"
+msgstr "Sortir : Tanggal"
+
+#: id:105
+msgid "Sort by: Size"
+msgstr "Sortir : Ukuran"
+
+#: id:106
+msgid "No"
+msgstr "Tidak"
+
+#: id:107
+msgid "Yes"
+msgstr "Ya"
+
+#: id:108
+msgctxt "Auto context with id 108"
+msgid "Slideshow"
+msgstr "SlideShow"
+
+#: id:109
+msgid "Create thumbs"
+msgstr "Buat Thumb"
+
+#: id:110
+msgid "Create thumbnails"
+msgstr "Buat Thumbnail"
+
+#: id:111
+msgctxt "Auto context with id 111"
+msgid "Shortcuts"
+msgstr "Jalan Pintas"
+
+#: id:112
+msgid "Paused"
+msgstr "BERHENTI"
+
+#: id:113
+msgid "Update failed"
+msgstr "File : Sumber"
+
+#: id:114
+msgid "Installation failed"
+msgstr "File : Tujuan"
+
+#: id:115
+msgid "Copy"
+msgstr "Salin"
+
+#: id:116
+msgid "Move"
+msgstr "Pindah"
+
+#: id:117
+msgid "Delete"
+msgstr "Hapus"
+
+#: id:118
+msgid "Rename"
+msgstr "Ganti Nama"
+
+#: id:119
+msgid "New folder"
+msgstr "Folder Baru"
+
+#: id:120
+msgid "Confirm file copy"
+msgstr "Konfirmasi salin file"
+
+#: id:121
+msgid "Confirm file move"
+msgstr "Konfirmasi pindah file"
+
+#: id:122
+msgid "Confirm file delete?"
+msgstr "Konfirmasi hapus file"
+
+#: id:123
+msgid "Copy these files?"
+msgstr "Salin file ini?"
+
+#: id:124
+msgid "Move these files?"
+msgstr "Pindahkan file ini?"
+
+#: id:125
+msgid "Delete these files? - Deleting files cannot be undone!"
+msgstr "Hapus file ini?"
+
+#: id:126
+msgid "Status"
+msgstr "Status"
+
+#: id:127
+msgid "Objects"
+msgstr "Objek"
+
+#: id:128
+msgctxt "Auto context with id 128"
+msgid "General"
+msgstr "Umum"
+
+#: id:129
+msgctxt "Auto context with id 129"
+msgid "Slideshow"
+msgstr "Slideshow"
+
+#: id:130
+msgctxt "Auto context with id 130"
+msgid "System info"
+msgstr "Informasi Sistem"
+
+#: id:131
+msgid "Display"
+msgstr "Layar"
+
+#: id:132
+msgid "Albums"
+msgstr "Album"
+
+#: id:133
+msgid "Artists"
+msgstr "Artis"
+
+#: id:134
+msgid "Songs"
+msgstr "Lagu"
+
+#: id:135
+msgid "Genres"
+msgstr "Aliran"
+
+#: id:136
+msgid "Playlists"
+msgstr "Daftar Main"
+
+#: id:137
+msgid "Search"
+msgstr "Cari"
+
+#: id:138
+msgid "System Information"
+msgstr "INFORMASI SISTEM"
+
+#: id:139
+msgid "Temperatures:"
+msgstr "Suhu:"
+
+#: id:140
+msgid "CPU:"
+msgstr "CPU:"
+
+#: id:141
+msgid "GPU:"
+msgstr "GPU:"
+
+#: id:142
+msgid "Time:"
+msgstr "Waktu"
+
+#: id:143
+msgid "Current:"
+msgstr "Saat ini:"
+
+#: id:144
+msgid "Build:"
+msgstr "Build:"
+
+#: id:145
+msgid "Network:"
+msgstr "Jaringan:"
+
+#: id:146
+msgid "Type:"
+msgstr "Tipe:"
+
+#: id:147
+msgid "Static"
+msgstr "Statik"
+
+#: id:148
+msgid "DHCP"
+msgstr "DHCP"
+
+#: id:149
+msgid "MAC address"
+msgstr "MAC"
+
+#: id:150
+msgctxt "Auto context with id 150"
+msgid "IP address"
+msgstr "IP"
+
+#: id:151
+msgid "Link:"
+msgstr "Link:"
+
+#: id:152
+msgid "Half duplex"
+msgstr "Setengah duplex"
+
+#: id:153
+msgid "Full duplex"
+msgstr "Dupleks Penuh"
+
+#: id:154
+msgctxt "Auto context with id 154"
+msgid "Storage"
+msgstr "Penyimpanan"
+
+#: id:155
+msgid "Drive"
+msgstr "Drive"
+
+#: id:156
+msgctxt "Auto context with id 156"
+msgid "Free"
+msgstr "Bebas"
+
+#: id:157
+msgctxt "Auto context with id 157"
+msgid "Video"
+msgstr "Video"
+
+#: id:158
+msgid "Free memory"
+msgstr "Memori Bebas"
+
+#: id:159
+msgid "No link"
+msgstr "Tidak ada link"
+
+#: id:160
+msgctxt "Auto context with id 160"
+msgid "Free"
+msgstr "Bebas"
+
+#: id:161
+msgid "Unavailable"
+msgstr "Tidak tersedia"
+
+#: id:162
+msgid "Tray open"
+msgstr "DVD Rom Terbuka"
+
+#: id:163
+msgid "Reading"
+msgstr "Baca"
+
+#: id:164
+msgid "No disc"
+msgstr "Tidak ada disk"
+
+#: id:165
+msgid "Disc present"
+msgstr "Disk Saat Ini"
+
+#: id:166
+msgid "Skin"
+msgstr "Kulit"
+
+#: id:169
+msgctxt "Auto context with id 169"
+msgid "Resolution"
+msgstr "Resolusi"
+
+#: id:170
+msgid "Adjust display refresh rate to match video"
+msgstr "Album:"
+
+#: id:172
+msgid "Release date"
+msgstr "Tanggal terbit:"
+
+#: id:173
+msgid "Display 4:3 videos as"
+msgstr "Rating:"
+
+#: id:175
+msgid "Moods"
+msgstr "Nada:"
+
+#: id:176
+msgid "Styles"
+msgstr "Gaya:"
+
+#: id:179
+msgid "Song"
+msgstr "Lagu"
+
+#: id:180
+msgid "Duration"
+msgstr "Durasi"
+
+#: id:181
+msgid "Select album"
+msgstr "Pilih album"
+
+#: id:182
+msgid "Tracks"
+msgstr "Trek"
+
+#: id:183
+msgid "Review"
+msgstr "Tinjauan"
+
+#: id:184
+msgid "Refresh"
+msgstr "Segarkan"
+
+#: id:185
+msgid "Searching album"
+msgstr "Pencarian album"
+
+#: id:186
+msgid "OK"
+msgstr "OK"
+
+#: id:187
+msgid "No albums found!"
+msgstr "Album tidak ditemukan!"
+
+#: id:188
+msgid "Select all"
+msgstr "Pilih Semua"
+
+#: id:189
+msgid "Scanning media info"
+msgstr "Memindai informasi media"
+
+#: id:190
+msgid "Save"
+msgstr "Simpan"
+
+#: id:191
+msgid "Shuffle"
+msgstr "Kocokan"
+
+#: id:192
+msgctxt "Auto context with id 192"
+msgid "Clear"
+msgstr "Kosongkan"
+
+#: id:193
+msgctxt "Auto context with id 193"
+msgid "Scan"
+msgstr "Pindai"
+
+#: id:194
+msgid "Searching..."
+msgstr "Pencarian..."
+
+#: id:195
+msgid "No info found!"
+msgstr "Informasi IMDB tidak ditemukan!"
+
+#: id:196
+msgid "Select movie:"
+msgstr "Pilih film:"
+
+#: id:197
+msgid "Querying %s info"
+msgstr "Meminta info IMDB"
+
+#: id:198
+msgid "Loading movie details"
+msgstr "Mengakses detil Film"
+
+#: id:199
+msgid "Web interface"
+msgstr "Sutradara:"
+
+#: id:202
+msgid "Tagline"
+msgstr "Tagline:"
+
+#: id:203
+msgid "Plot outline"
+msgstr "Alur Cerita:"
+
+#: id:205
+msgid "Votes"
+msgstr "Pemilihan"
+
+#: id:206
+msgid "Cast"
+msgstr "Para Pelaku"
+
+#: id:207
+msgid "Plot"
+msgstr "Alur"
+
+#: id:208
+msgctxt "Auto context with id 208"
+msgid "Play"
+msgstr "Mainkan"
+
+#: id:209
+msgid "Next"
+msgstr "Berikut"
+
+#: id:210
+msgid "Previous"
+msgstr "Sebelumnya"
+
+#: id:213
+msgid "Calibrate user interface..."
+msgstr "Tengahkan Antarmuka pengguna..."
+
+#: id:214
+msgid "Video calibration..."
+msgstr "Kalibrasi Video..."
+
+#: id:215
+msgid "Soften"
+msgstr "Lebih Lembut"
+
+#: id:216
+msgid "Zoom amount"
+msgstr "Jumlah Zoom"
+
+#: id:217
+msgid "Pixel ratio"
+msgstr "Rasio Piksel"
+
+#: id:218
+msgid "DVD drive"
+msgstr "Drive DVD"
+
+#: id:219
+msgid "Please insert disc"
+msgstr "Harap memasukan disk"
+
+#: id:220
+msgid "Remote share"
+msgstr "Remote Share"
+
+#: id:221
+msgid "Network is not connected"
+msgstr "Jaringan tidak tersambung"
+
+#: id:222
+msgid "Cancel"
+msgstr "Batal"
+
+#: id:224
+msgid "Speed"
+msgstr "Kecepatan"
+
+#: id:225
+msgid "Vertical Shift"
+msgstr "Waktu Transisi"
+
+#: id:226
+msgid "Test patterns..."
+msgstr ""
+
+#: id:227
+msgid "Lookup audio CD track names from freedb.org"
+msgstr "Aktifkan CDDB"
+
+#: id:228
+msgid "Shuffle playlist on load"
+msgstr "Kocok Daftar Main saat Memuat"
+
+#: id:229
+msgid "HDD spindown time"
+msgstr "HD Spindown Time"
+
+#: id:230
+msgid "Video filters"
+msgstr "Filter Video"
+
+#: id:231
+msgctxt "Auto context with id 231"
+msgid "None"
+msgstr "Tidak ada"
+
+#: id:232
+msgid "Point"
+msgstr "Point"
+
+#: id:233
+msgid "Linear"
+msgstr "Linear"
+
+#: id:234
+msgid "Anisotropic"
+msgstr "Anisotropic"
+
+#: id:235
+msgid "Quincunx"
+msgstr "Quincunx"
+
+#: id:236
+msgid "Gaussian cubic"
+msgstr "Gaussian Cubic"
+
+#: id:237
+msgid "Minification"
+msgstr "Minification"
+
+#: id:238
+msgid "Magnification"
+msgstr "Magnification"
+
+#: id:239
+msgid "Clear playlist on finish"
+msgstr "Kosongkan Daftar Main saat selesai"
+
+#: id:240
+msgid "Display Mode"
+msgstr "DVD-Video Mainkan Secara Otomatis"
+
+#: id:241
+msgid "Full Screen #%d"
+msgstr "VCD/SVCD Mainkan Secara Otomatis"
+
+#: id:242
+msgid "Windowed"
+msgstr "CD-Audio Mainkan Secara Otomatis"
+
+#: id:243
+msgid "Refresh Rate"
+msgstr "Permainan XBOX Mainkan Secara Otomatis"
+
+#: id:244
+msgid "Full screen"
+msgstr "Video Mainkan Secara Otomatis"
+
+#: id:245
+msgid "Sizing: (%i,%i)->(%i,%i) (Zoom x%2.2f) AR:%2.2f:1 (Pixels: %2.2f:1) (VShift: %2.2f)"
+msgstr "Musik Mainkan Secara Otomatis"
+
+#: id:247
+msgctxt "Auto context with id 247"
+msgid "Scripts"
+msgstr "Skrip"
+
+#: id:248
+msgctxt "Auto context with id 248"
+msgid "Language"
+msgstr "Bahasa"
+
+#: id:249
+msgctxt "Auto context with id 249"
+msgid "Music"
+msgstr "Musik"
+
+#: id:250
+msgctxt "Auto context with id 250"
+msgid "Visualization"
+msgstr "Visualisasi"
+
+#: id:251
+msgid "Select destination directory"
+msgstr "Pilih direktori tujuan"
+
+#: id:252
+msgid "Output stereo to all speakers"
+msgstr "Keluaran Stereo ke semua Speaker"
+
+#: id:253
+msgid "Number of channels"
+msgstr "Jumlah saluran"
+
+#: id:254
+msgid "- DTS capable receiver"
+msgstr "- Penerima berkemampuan DTS"
+
+#: id:255
+msgid "CDDB"
+msgstr "CDDB"
+
+#: id:256
+msgid "Fetching CD information"
+msgstr "Meminta freedb untuk info CDDB"
+
+#: id:257
+msgid "Error"
+msgstr "Kesalahan"
+
+#: id:258
+msgid "Enable tag reading"
+msgstr "Aktifkan Tag ID3"
+
+#: id:259
+msgid "Opening"
+msgstr "Membuka"
+
+#: id:260
+msgid "Shoutcast"
+msgstr "Shoutcast"
+
+#: id:261
+msgid "Waiting for start..."
+msgstr "Menunggu utk memulai...."
+
+#: id:262
+msgid "Scripts output"
+msgstr "Keluaran Skrip"
+
+#: id:263
+msgid "Allow control of XBMC via HTTP"
+msgstr "Aktifkan Web Server"
+
+#: id:264
+msgid "Record"
+msgstr "Rekam"
+
+#: id:265
+msgid "Stop Rec."
+msgstr "Hentikan Rek."
+
+#: id:266
+msgid "Sort by: Track"
+msgstr "Sortir : Trek"
+
+#: id:267
+msgid "Sort by: Time"
+msgstr "Sortir : Waktu"
+
+#: id:268
+msgid "Sort by: Title"
+msgstr "Sortir : Nama"
+
+#: id:269
+msgid "Sort by: Artist"
+msgstr "Sortir : Artis"
+
+#: id:270
+msgid "Sort by: Album"
+msgstr "Sortir : Album"
+
+#: id:271
+msgid "Top 100"
+msgstr "Top 100"
+
+#: id:272
+msgid "Top-Left overscan compensation"
+msgstr "Top Left Overscan Compensation"
+
+#: id:273
+msgid "Bottom-Right overscan compensation"
+msgstr "Bottom Right Overscan Compensation"
+
+#: id:274
+msgid "Subtitle positioning"
+msgstr "Posisi Terjemahan"
+
+#: id:275
+msgid "Pixel ratio adjustment"
+msgstr "Penyetelan Rasio Piksel"
+
+#: id:276
+msgid "Adjust the arrow to change the amount of overscan"
+msgstr "Pindahkan tanda panah untuk mengganti jumlah overscan"
+
+#: id:277
+msgid "Adjust the bar to change the subtitles position"
+msgstr "Pindahkan bar untuk mengganti posisi teks bawah pada film"
+
+#: id:278
+msgid "Adjust the rectangle so it is perfectly square"
+msgstr "Ganti persegi panjang sehingga menjadi persegi yang sempurna"
+
+#: id:279
+msgid "Unable to load settings"
+msgstr "Tidak dapat memuat setelan"
+
+#: id:280
+msgid "Using default settings"
+msgstr "Menggunakan Standar fallbacks"
+
+#: id:281
+msgid "Please check the XML files"
+msgstr "Harap periksa file .xml"
+
+#: id:282
+msgid "Found %i items"
+msgstr "ditemukan %i item"
+
+#: id:283
+msgid "Search results"
+msgstr "Hasil Pencarian"
+
+#: id:284
+msgid "No results found"
+msgstr "Tidak ditemukan"
+
+#: id:287
+msgctxt "Auto context with id 287"
+msgid "Subtitles"
+msgstr "Teks Film"
+
+#: id:288
+msgctxt "Auto context with id 288"
+msgid "Font"
+msgstr "Huruf"
+
+#: id:289
+msgctxt "Auto context with id 289"
+msgid "- Size"
+msgstr "- Ukuran"
+
+#: id:290
+msgid "Dynamic range compression"
+msgstr "Volume Pengerasan"
+
+#: id:291
+msgctxt "Auto context with id 291"
+msgid "Video"
+msgstr "Video"
+
+#: id:292
+msgctxt "Auto context with id 292"
+msgid "Audio"
+msgstr "Audio"
+
+#: id:293
+msgid "Browse for subtitles"
+msgstr "Teks Film"
+
+#: id:294
+msgid "Create bookmark"
+msgstr "Buat bookmark"
+
+#: id:296
+msgid "Clear bookmarks"
+msgstr "Kosongkan bookmark"
+
+#: id:297
+msgid "Audio offset"
+msgstr "AVDelay"
+
+#: id:298
+msgid "Bookmarks"
+msgstr ""
+
+#: id:299
+msgid "- AAC capable receiver"
+msgstr ""
+
+#: id:300
+msgid "- MP1 capable receiver"
+msgstr ""
+
+#: id:301
+msgid "- MP2 capable receiver"
+msgstr ""
+
+#: id:302
+msgid "- MP3 capable receiver"
+msgstr ""
+
+#: id:303
+msgid "Delay"
+msgstr "Penundaan"
+
+#: id:304
+msgctxt "Auto context with id 304"
+msgid "Language"
+msgstr "Bahasa"
+
+#: id:305
+msgctxt "Auto context with id 305"
+msgid "Enabled"
+msgstr "Aktifkan"
+
+#: id:306
+msgid "Non-interleaved"
+msgstr "Non-Interleaved"
+
+#: id:312
+msgid "(0=auto)"
+msgstr "(0=otomatis)"
+
+#: id:313
+msgid "Cleaning database"
+msgstr "Membersihkan database"
+
+#: id:314
+msgid "Preparing..."
+msgstr "Persiapan..."
+
+#: id:315
+msgid "Database error"
+msgstr "Database error"
+
+#: id:316
+msgid "Searching songs..."
+msgstr "Pencarian lagu..."
+
+#: id:317
+msgid "Cleaned database successfully"
+msgstr "Pembersihan database berhasil"
+
+#: id:318
+msgid "Cleaning songs..."
+msgstr "Pembersihan lagu..."
+
+#: id:319
+msgid "Error cleaning songs"
+msgstr "Kesalahan membersihkan lagu"
+
+#: id:320
+msgid "Cleaning artists..."
+msgstr "Pembersihan artis..."
+
+#: id:321
+msgid "Error cleaning artists"
+msgstr "Kesalahan membersihkan artis"
+
+#: id:322
+msgid "Cleaning genres..."
+msgstr "Pembersihan aliran..."
+
+#: id:323
+msgid "Error cleaning genres"
+msgstr "Kesalahan membersihkan aliran"
+
+#: id:324
+msgid "Cleaning paths..."
+msgstr "Pembersihan path..."
+
+#: id:325
+msgid "Error cleaning paths"
+msgstr "Kesalahan membersihkan path"
+
+#: id:326
+msgid "Cleaning albums..."
+msgstr "Pembersihan album..."
+
+#: id:327
+msgid "Error cleaning albums"
+msgstr "Kesalahan membersihkan album"
+
+#: id:328
+msgid "Writing changes..."
+msgstr "Menulis perubahan..."
+
+#: id:329
+msgid "Error writing changes"
+msgstr "Kesalahan menulis perubahan"
+
+#: id:330
+msgid "This may take some time..."
+msgstr "Mungkin ini akan menghabiskan beberapa saat..."
+
+#: id:331
+msgid "Compressing database..."
+msgstr "Mengkompres database..."
+
+#: id:332
+msgid "Error compressing database"
+msgstr "Kesalahan mengkompres database"
+
+#: id:333
+msgid "Do you want to clean the library?"
+msgstr "Anda ingin membersihkan pustaka musik?"
+
+#: id:334
+msgid "Clean library..."
+msgstr "Membersihkan Pustaka Musik..."
+
+#: id:335
+msgid "Start"
+msgstr "Mulai"
+
+#: id:336
+msgid "Framerate conversion"
+msgstr "Atur Framerate"
+
+#: id:337
+msgctxt "Auto context with id 337"
+msgid "Audio output"
+msgstr "Keluaran Audio"
+
+#: id:338
+msgid "Analog"
+msgstr "Analog"
+
+#: id:339
+msgid "Optical/Coax"
+msgstr "Digital"
+
+#: id:340
+msgid "Various artists"
+msgstr "Berbagai Artis"
+
+#: id:341
+msgid "Play disc"
+msgstr "Mainkan DVD"
+
+#: id:342
+msgctxt "Auto context with id 342"
+msgid "Movies"
+msgstr "Film"
+
+#: id:343
+msgid "Adjust framerate"
+msgstr "Atur Framerate"
+
+#: id:344
+msgid "Actors"
+msgstr "Aktor"
+
+#: id:345
+msgctxt "Auto context with id 345"
+msgid "Year"
+msgstr "Tahun"
+
+#: id:346
+msgid "Boost volume level on downmix"
+msgstr ""
+
+#: id:350
+msgctxt "Auto context with id 350"
+msgid "Programs"
+msgstr "Program"
+
+#: id:351
+msgctxt "Auto context with id 351"
+msgid "Off"
+msgstr "Mati"
+
+#: id:352
+msgid "Dim"
+msgstr "Dim"
+
+#: id:353
+msgid "Black"
+msgstr "Hitam"
+
+#: id:354
+msgid "Matrix trails"
+msgstr "Matrix Trails"
+
+#: id:355
+msgid "Screensaver time"
+msgstr "Waktu Tunggu Screensaver"
+
+#: id:356
+msgid "Screensaver mode"
+msgstr "Mode Screensaver"
+
+#: id:357
+msgid "Shutdown function timer"
+msgstr "Waktu Tunggu Mematikan"
+
+#: id:358
+msgid "All albums"
+msgstr "Semua album"
+
+#: id:359
+msgid "Recently added albums"
+msgstr "Album Terkini"
+
+#: id:360
+msgctxt "Auto context with id 360"
+msgid "Screensaver"
+msgstr "Screensaver"
+
+#: id:361
+msgid "R. Slideshow"
+msgstr "SlideShow B.ulang"
+
+#: id:362
+msgid "Screensaver dim level"
+msgstr "Tingkat Pudar Screensaver"
+
+#: id:363
+msgid "Sort by: File"
+msgstr "Sortir : File"
+
+#: id:364
+msgid "- Dolby Digital (AC3) capable receiver"
+msgstr "- Penerima berkemampuan AC3"
+
+#: id:365
+msgctxt "Auto context with id 365"
+msgid "Sort by: Name"
+msgstr "Sortir : Judul"
+
+#: id:366
+msgid "Sort by: Year"
+msgstr "Sortir : Tahun"
+
+#: id:367
+msgid "Sort by: Rating"
+msgstr "Sortir : Nilai"
+
+#: id:368
+msgid "IMDb"
+msgstr "IMDB"
+
+#: id:369
+msgctxt "Auto context with id 369"
+msgid "Title"
+msgstr "Judul"
+
+#: id:370
+msgid "Thunderstorms"
+msgstr "Badai"
+
+#: id:371
+msgid "Partly"
+msgstr "Sebagian"
+
+#: id:372
+msgid "Mostly"
+msgstr "Kebanyakan"
+
+#: id:373
+msgid "Sunny"
+msgstr "Cerah"
+
+#: id:374
+msgid "Cloudy"
+msgstr "Mendung"
+
+#: id:375
+msgid "Snow"
+msgstr "Salju"
+
+#: id:376
+msgid "Rain"
+msgstr "Hujan"
+
+#: id:377
+msgid "Light"
+msgstr "Ringan"
+
+#: id:378
+msgid "AM"
+msgstr "AM"
+
+#: id:379
+msgid "PM"
+msgstr "PM"
+
+#: id:380
+msgid "Showers"
+msgstr "Gerimis"
+
+#: id:381
+msgid "Few"
+msgstr "Sedikit"
+
+#: id:382
+msgid "Scattered"
+msgstr "Tersebar"
+
+#: id:383
+msgctxt "Auto context with id 383"
+msgid "Wind"
+msgstr "Angin"
+
+#: id:384
+msgid "Strong"
+msgstr "Kuat"
+
+#: id:385
+msgid "Fair"
+msgstr "Cukup"
+
+#: id:386
+msgctxt "Auto context with id 386"
+msgid "Clear"
+msgstr "Cerah"
+
+#: id:387
+msgid "Clouds"
+msgstr "Berawan"
+
+#: id:388
+msgid "Early"
+msgstr "Early"
+
+#: id:389
+msgid "Shower"
+msgstr "Gerimis"
+
+#: id:390
+msgid "Flurries"
+msgstr "Curah Hujan"
+
+#: id:391
+msgctxt "Auto context with id 391"
+msgid "Low"
+msgstr "Rendah"
+
+#: id:392
+msgctxt "Auto context with id 392"
+msgid "Medium"
+msgstr "Menengah"
+
+#: id:393
+msgctxt "Auto context with id 393"
+msgid "High"
+msgstr "Tinggi"
+
+#: id:394
+msgid "Fog"
+msgstr "Kabut"
+
+#: id:395
+msgid "Haze"
+msgstr "Kabur"
+
+#: id:396
+msgid "Select location"
+msgstr "Pilih Lokasi"
+
+#: id:397
+msgid "Refresh time"
+msgstr "Waktu Penyegaran"
+
+#: id:398
+msgid "Temperature units"
+msgstr "Unit Suhu"
+
+#: id:399
+msgid "Speed units"
+msgstr "Unit Kecepatan"
+
+#: id:400
+msgctxt "Auto context with id 400"
+msgid "Weather"
+msgstr "Cuaca"
+
+#: id:401
+msgid "Temp"
+msgstr "Suhu"
+
+#: id:402
+msgid "Feels like"
+msgstr "Terasa Seperti"
+
+#: id:403
+msgid "UV index"
+msgstr "Indeks UV"
+
+#: id:404
+msgctxt "Auto context with id 404"
+msgid "Wind"
+msgstr "Angin"
+
+#: id:405
+msgid "Dew point"
+msgstr "Titik Embun"
+
+#: id:406
+msgid "Humidity"
+msgstr "Kelembaban"
+
+#: id:409
+msgid "Defaults"
+msgstr ""
+
+#: id:410
+msgid "Accessing weather service"
+msgstr "Mengakses Weather.com"
+
+#: id:411
+msgid "Getting weather for:"
+msgstr "Mendapatkan Cuaca Untuk:"
+
+#: id:412
+msgid "Unable to get weather data"
+msgstr "Tidak bisa mendapatkan data cuaca"
+
+#: id:413
+msgid "Manual"
+msgstr "Manual"
+
+#: id:414
+msgid "No review for this album"
+msgstr "Tidak ada review album ini"
+
+#: id:415
+msgid "Downloading thumbnail..."
+msgstr "Mengunduh thumbnail..."
+
+#: id:416
+msgid "Not available"
+msgstr "Tidak tersedia"
+
+#: id:417
+msgid "View: Big icons"
+msgstr "Lihat: Ikon Besar"
+
+#: id:418
+msgctxt "Auto context with id 418"
+msgid "Low"
+msgstr "Video/Aliran"
+
+#: id:419
+msgctxt "Auto context with id 419"
+msgid "High"
+msgstr "Video/Aktor"
+
+#: id:420
+msgid "HDMI"
+msgstr "Video/Tahun"
+
+#: id:422
+msgid "Delete album info"
+msgstr "Hapus informasi Album"
+
+#: id:423
+msgid "Delete CD information"
+msgstr "Hapus informasi CDDB"
+
+#: id:424
+msgid "Select"
+msgstr "Pilih"
+
+#: id:425
+msgid "No album information found"
+msgstr "Info album tidak ditemukan."
+
+#: id:426
+msgid "No CD information found"
+msgstr "Info CDDB tidak ditemukan."
+
+#: id:427
+msgid "Disc"
+msgstr "Disk:"
+
+#: id:428
+msgid "Insert correct CD/DVD"
+msgstr "Masukkan CD/DVD yg tepat"
+
+#: id:429
+msgid "Please insert the following disc:"
+msgstr "Harap memasukan CD/DVD berikut"
+
+#: id:430
+msgid "Sort by: DVD#"
+msgstr "Sortir : DVD#"
+
+#: id:431
+msgid "No cache"
+msgstr "Tanpa Cache"
+
+#: id:432
+msgid "Remove movie from library"
+msgstr "Hapus film dari database"
+
+#: id:433
+msgid "Really remove '%s'?"
+msgstr "Anda yakin tetang menghapus"
+
+#: id:434
+msgid "From %s at %i %s"
+msgstr "film?"
+
+#: id:437
+msgid "Removable disk"
+msgstr "Durasi"
+
+#: id:438
+msgid "Opening file"
+msgstr "Buka File"
+
+#: id:439
+msgid "Cache"
+msgstr "Cache"
+
+#: id:440
+msgid "Harddisk"
+msgstr "Harddisk"
+
+#: id:441
+msgid "UDF"
+msgstr "UDF"
+
+#: id:442
+msgid "Local network"
+msgstr "LAN"
+
+#: id:443
+msgid "Internet"
+msgstr "Internet"
+
+#: id:444
+msgctxt "Auto context with id 444"
+msgid "Video"
+msgstr "Video"
+
+#: id:445
+msgctxt "Auto context with id 445"
+msgid "Audio"
+msgstr "Audio"
+
+#: id:446
+msgctxt "Auto context with id 446"
+msgid "DVD"
+msgstr "DVD"
+
+#: id:447
+msgid "Autorun media"
+msgstr "Otomatis Mainkan"
+
+#: id:448
+msgid "LCD"
+msgstr "LCD"
+
+#: id:449
+msgctxt "Auto context with id 449"
+msgid "Enabled"
+msgstr "Aktifkan"
+
+#: id:450
+msgid "Columns"
+msgstr "Kolom"
+
+#: id:451
+msgid "Row 1 address"
+msgstr "Baris 1 Alamat"
+
+#: id:452
+msgid "Row 2 address"
+msgstr "Baris 2 Alamat"
+
+#: id:453
+msgid "Row 3 address"
+msgstr "Baris 3 Alamat"
+
+#: id:454
+msgid "Row 4 address"
+msgstr "Baris 4 Alamat"
+
+#: id:455
+msgid "Rows"
+msgstr "Baris"
+
+#: id:456
+msgid "Mode"
+msgstr "Mode"
+
+#: id:457
+msgid "Switch view"
+msgstr "Ganti Tampilan"
+
+#: id:459
+msgid "Subs"
+msgstr "Subs"
+
+#: id:460
+msgid "Audio stream"
+msgstr "Audio Stream"
+
+#: id:461
+msgid "[active]"
+msgstr "[aktif]"
+
+#: id:462
+msgid "Subtitle"
+msgstr "Teks Film"
+
+#: id:463
+msgid "Backlight"
+msgstr "Backlight"
+
+#: id:464
+msgid "Brightness"
+msgstr "Kecerahan"
+
+#: id:465
+msgid "Contrast"
+msgstr "Kontras"
+
+#: id:466
+msgid "Gamma"
+msgstr "Gamma"
+
+#: id:467
+msgctxt "Auto context with id 467"
+msgid "Type"
+msgstr "Tipe"
+
+#: id:468
+msgid "Move the bar to change the OSD position"
+msgstr "Pindahkan bar untuk mengganti posisi osd"
+
+#: id:469
+msgid "OSD position"
+msgstr "Posisi OSD"
+
+#: id:470
+msgid "Credits"
+msgstr "Kredit"
+
+#: id:471
+msgid "Modchip"
+msgstr "Modchip"
+
+#: id:474
+msgctxt "Auto context with id 474"
+msgid "Off"
+msgstr "Matikan"
+
+#: id:475
+msgid "Music only"
+msgstr "Hanya Musik"
+
+#: id:476
+msgctxt "Auto context with id 476"
+msgid "Music & video"
+msgstr "Musik & Video"
+
+#: id:477
+msgid "Unable to load playlist"
+msgstr "Tidak dapat memuat Daftar Main"
+
+#: id:478
+msgid "OSD"
+msgstr "OSD"
+
+#: id:479
+msgid "Skin & language"
+msgstr "Kulit dan Bahasa"
+
+#: id:480
+msgid "Appearance"
+msgstr "Penampilan"
+
+#: id:481
+msgid "Audio options"
+msgstr "Pilihan Audio"
+
+#: id:482
+msgid "About XBMC"
+msgstr "Tentang XBMC"
+
+#: id:485
+msgid "Delete album"
+msgstr "Hapus album"
+
+#: id:486
+msgid "Repeat"
+msgstr "Berulang"
+
+#: id:487
+msgid "Repeat one"
+msgstr "Ulang sekali"
+
+#: id:488
+msgid "Repeat folder"
+msgstr "Folder Berulang"
+
+#: id:489
+msgid "Play the next song automatically"
+msgstr "Mainkan Sendiri Item Berikutnya"
+
+#: id:491
+msgid "- Use big icons"
+msgstr "- Gunakan ikon besar"
+
+#: id:492
+msgid "Resize VobSubs"
+msgstr "Ukur ulang Vobsubs"
+
+#: id:493
+msgid "Advanced options (Experts Only!)"
+msgstr "Pilihan Lebih Lanjut (Hanya Pengguna Ahli!)"
+
+#: id:494
+msgid "Overall audio headroom"
+msgstr "Keseluruhan Audio Headroom"
+
+#: id:495
+msgid "Upsample videos to GUI resolution"
+msgstr "Upsample Video ke Resolusi GUI"
+
+#: id:496
+msgid "Calibration"
+msgstr "Kalibrasi"
+
+#: id:497
+msgid "Show file extensions"
+msgstr "Sembunyikan Ekstensi Media"
+
+#: id:498
+msgid "Sort by: Type"
+msgstr "Sortir : Tipe"
+
+#: id:499
+msgid "Unable to connect to online lookup service"
+msgstr "Tidak dapat tersambung ke www.allmusic.com"
+
+#: id:500
+msgid "Downloading album information failed"
+msgstr "Mengunduh info album gagal"
+
+#: id:501
+msgid "Looking for album names..."
+msgstr "Mencari nama album..."
+
+#: id:502
+msgctxt "Auto context with id 502"
+msgid "Open"
+msgstr "Buka"
+
+#: id:503
+msgid "Busy"
+msgstr "Sibuk"
+
+#: id:504
+msgid "Empty"
+msgstr "Kosong"
+
+#: id:505
+msgid "Loading media info from files..."
+msgstr "Memuat informasi media dari file..."
+
+#: id:507
+msgid "Sort by: Usage"
+msgstr "Sortir : Pemakaian"
+
+#: id:510
+msgid "Enable visualizations"
+msgstr "Aktifkan Visualisasi"
+
+#: id:511
+msgid "Enable video mode switching"
+msgstr "Aktifkan tombol mode video"
+
+#: id:512
+msgid "Startup window"
+msgstr "Window Pembuka"
+
+#: id:513
+msgid "Home window"
+msgstr "Home Window"
+
+#: id:514
+msgid "Manual settings"
+msgstr "Setelan Manual"
+
+#: id:515
+msgid "Genre"
+msgstr "Aliran"
+
+#: id:517
+msgid "Recently played albums"
+msgstr "Album Yang Baru Saja Dimainkan"
+
+#: id:518
+msgid "Launch"
+msgstr "Jalankan"
+
+#: id:519
+msgid "Launch in..."
+msgstr "Jalankan dalam.."
+
+#: id:521
+msgid "Compilations"
+msgstr "Kompilasi"
+
+#: id:522
+msgid "Remove source"
+msgstr "Hapus Sumber"
+
+#: id:523
+msgid "Switch media"
+msgstr ""
+
+#: id:524
+msgid "Select playlist"
+msgstr ""
+
+#: id:525
+msgid "New playlist..."
+msgstr ""
+
+#: id:526
+msgid "Add to playlist"
+msgstr ""
+
+#: id:527
+msgid "Manually add to library"
+msgstr ""
+
+#: id:528
+msgid "Enter title"
+msgstr ""
+
+#: id:529
+msgid "Error: Duplicate title"
+msgstr ""
+
+#: id:530
+msgid "Select genre"
+msgstr ""
+
+#: id:531
+msgid "New genre"
+msgstr ""
+
+#: id:532
+msgid "Manual addition"
+msgstr ""
+
+#: id:533
+msgid "Enter genre"
+msgstr ""
+
+#: id:534
+msgid "View: %s"
+msgstr ""
+
+#: id:535
+msgid "List"
+msgstr ""
+
+#: id:536
+msgid "Icons"
+msgstr ""
+
+#: id:537
+msgid "Big list"
+msgstr ""
+
+#: id:538
+msgid "Big icons"
+msgstr ""
+
+#: id:539
+msgid "Wide"
+msgstr ""
+
+#: id:540
+msgid "Big wide"
+msgstr ""
+
+#: id:541
+msgid "Album icons"
+msgstr ""
+
+#: id:542
+msgid "DVD icons"
+msgstr ""
+
+#: id:543
+msgctxt "Auto context with id 543"
+msgid "DVD"
+msgstr ""
+
+#: id:544
+msgctxt "Auto context with id 544"
+msgid "Media info"
+msgstr ""
+
+#: id:545
+msgid "Audio output device"
+msgstr ""
+
+#: id:546
+msgid "Passthrough output device"
+msgstr ""
+
+#: id:547
+msgid "No biography for this artist"
+msgstr ""
+
+#: id:548
+msgid "Downmix multichannel audio to stereo"
+msgstr ""
+
+#: id:550
+msgid "Sort by: %s"
+msgstr ""
+
+#: id:551
+msgctxt "Auto context with id 551"
+msgid "Name"
+msgstr ""
+
+#: id:552
+msgid "Date"
+msgstr ""
+
+#: id:553
+msgid "Size"
+msgstr ""
+
+#: id:554
+msgid "Track"
+msgstr ""
+
+#: id:555
+msgid "Time"
+msgstr ""
+
+#: id:556
+msgctxt "Auto context with id 556"
+msgid "Title"
+msgstr ""
+
+#: id:557
+msgid "Artist"
+msgstr ""
+
+#: id:558
+msgid "Album"
+msgstr ""
+
+#: id:559
+msgid "Playlist"
+msgstr ""
+
+#: id:560
+msgid "ID"
+msgstr ""
+
+#: id:561
+msgctxt "Auto context with id 561"
+msgid "File"
+msgstr ""
+
+#: id:562
+msgctxt "Auto context with id 562"
+msgid "Year"
+msgstr ""
+
+#: id:563
+msgid "Rating"
+msgstr ""
+
+#: id:564
+msgctxt "Auto context with id 564"
+msgid "Type"
+msgstr ""
+
+#: id:565
+msgid "Usage"
+msgstr ""
+
+#: id:566
+msgid "Album artist"
+msgstr ""
+
+#: id:567
+msgid "Play count"
+msgstr ""
+
+#: id:568
+msgid "Last played"
+msgstr ""
+
+#: id:569
+msgctxt "Auto context with id 569"
+msgid "Comment"
+msgstr ""
+
+#: id:570
+msgid "Date added"
+msgstr ""
+
+#: id:571
+msgctxt "Auto context with id 571"
+msgid "Default"
+msgstr ""
+
+#: id:572
+msgid "Studio"
+msgstr ""
+
+#: id:573
+msgid "Path"
+msgstr ""
+
+#: id:574
+msgctxt "Auto context with id 574"
+msgid "Country"
+msgstr ""
+
+#: id:575
+msgid "In progress"
+msgstr ""
+
+#: id:576
+msgid "Times played"
+msgstr ""
+
+#: id:580
+msgid "Sort direction"
+msgstr ""
+
+#: id:581
+msgid "Sort method"
+msgstr ""
+
+#: id:582
+msgctxt "Auto context with id 582"
+msgid "View mode"
+msgstr ""
+
+#: id:583
+msgid "Remember views for different folders"
+msgstr ""
+
+#: id:584
+msgid "Ascending"
+msgstr ""
+
+#: id:585
+msgid "Descending"
+msgstr ""
+
+#: id:586
+msgid "Edit playlist"
+msgstr ""
+
+#: id:587
+msgid "Filter"
+msgstr ""
+
+#: id:588
+msgid "Cancel party mode"
+msgstr "Batalkan Mode Party"
+
+#: id:589
+msgid "Party mode"
+msgstr "Mode Party"
+
+#: id:590
+msgid "Random"
+msgstr "Acak"
+
+#: id:591
+msgctxt "Auto context with id 591"
+msgid "Off"
+msgstr "Matikan"
+
+#: id:592
+msgid "One"
+msgstr "Satu"
+
+#: id:593
+msgid "All"
+msgstr "Semua"
+
+#: id:594
+msgctxt "Auto context with id 594"
+msgid "Off"
+msgstr "Matikan"
+
+#: id:595
+msgid "Repeat: Off"
+msgstr "Ulang: Tidak"
+
+#: id:596
+msgid "Repeat: One"
+msgstr "Ulang: Satu"
+
+#: id:597
+msgid "Repeat: All"
+msgstr "Ulang: Semua"
+
+#: id:600
+msgid "Rip audio CD"
+msgstr "Salin CD Audio"
+
+#: id:601
+msgctxt "Auto context with id 601"
+msgid "Medium"
+msgstr "Medium"
+
+#: id:602
+msgctxt "Auto context with id 602"
+msgid "Standard"
+msgstr "Standar"
+
+#: id:603
+msgid "Extreme"
+msgstr "Ekstrim"
+
+#: id:604
+msgid "Constant bitrate"
+msgstr "Constant Bit Rate"
+
+#: id:605
+msgid "Ripping..."
+msgstr "Penyalinan..."
+
+#: id:607
+msgid "To:"
+msgstr "Ke"
+
+#: id:608
+msgid "Could not rip CD or track"
+msgstr "Tidak dapat menyalin CD or Trek"
+
+#: id:609
+msgid "CDDARipPath is not set."
+msgstr "CDDARipPath tidak diatur di sources.xml"
+
+#: id:610
+msgid "Rip audio track"
+msgstr ""
+
+#: id:611
+msgid "Enter number"
+msgstr ""
+
+#: id:612
+msgid "Bits/Sample"
+msgstr ""
+
+#: id:613
+msgid "Sample Frequency"
+msgstr ""
+
+#: id:620
+msgid "Audio CDs"
+msgstr "Ripping CD"
+
+#: id:621
+msgid "Encoder"
+msgstr "Enkoder"
+
+#: id:622
+msgid "Quality"
+msgstr "Kualitas"
+
+#: id:623
+msgid "Bitrate"
+msgstr "Bit Rate"
+
+#: id:624
+msgid "Include track number"
+msgstr "Termasuk Nomor Trek"
+
+#: id:625
+msgid "All songs of"
+msgstr "Semua lagu dari"
+
+#: id:629
+msgctxt "Auto context with id 629"
+msgid "View mode"
+msgstr "Mode Melihat"
+
+#: id:630
+msgctxt "Auto context with id 630"
+msgid "Normal"
+msgstr "Normal"
+
+#: id:631
+msgid "Zoom"
+msgstr "Zoom"
+
+#: id:632
+msgid "Stretch 4:3"
+msgstr "Rentangkan 4:3"
+
+#: id:633
+msgid "Wide Zoom"
+msgstr "Rentangkan 14:9"
+
+#: id:634
+msgid "Stretch 16:9"
+msgstr "Rentangkan 16:9"
+
+#: id:635
+msgid "Original Size"
+msgstr "Ukuran Asli"
+
+#: id:636
+msgctxt "Auto context with id 636"
+msgid "Custom"
+msgstr "Kustom"
+
+#: id:637
+msgid "Replay gain"
+msgstr "Replay Gain"
+
+#: id:638
+msgid "Replaygain volume adjustments"
+msgstr "Replay Gain Mode"
+
+#: id:639
+msgid "Use track levels"
+msgstr "Gunakan Level Trek"
+
+#: id:640
+msgid "Use album levels"
+msgstr "Gunakan Level Album"
+
+#: id:641
+msgid "PreAmp Level - Replay gained files"
+msgstr "PreAmp Level - Replay Gained Files"
+
+#: id:642
+msgid "PreAmp Level - Non replay gained files"
+msgstr "PreAmp Level - Non Replay Gained Files"
+
+#: id:643
+msgid "Avoid clipping on replay gained files"
+msgstr "Avoid Clipping on Replay Gained Files"
+
+#: id:644
+msgid "Crop black bars"
+msgstr "Potong Bar Hitam"
+
+#: id:645
+msgid "Need to unpack a big file. Continue?"
+msgstr "Memerlukan meng-cache file besar. Lanjutkan?"
+
+#: id:646
+msgid "Remove from library"
+msgstr "Hapus Nama"
+
+#: id:647
+msgid "Export video library"
+msgstr ""
+
+#: id:648
+msgid "Import video library"
+msgstr ""
+
+#: id:649
+msgid "Importing"
+msgstr ""
+
+#: id:650
+msgid "Exporting"
+msgstr ""
+
+#: id:651
+msgid "Browse for library"
+msgstr ""
+
+#: id:652
+msgid "Years"
+msgstr ""
+
+#: id:653
+msgid "Update library"
+msgstr ""
+
+#: id:654
+msgid "Show debug info"
+msgstr ""
+
+#: id:655
+msgid "Browse for executable"
+msgstr ""
+
+#: id:656
+msgid "Browse for playlist"
+msgstr ""
+
+#: id:657
+msgid "Browse for folder"
+msgstr ""
+
+#: id:658
+msgid "Song information"
+msgstr ""
+
+#: id:659
+msgid "Non-linear stretch"
+msgstr ""
+
+#: id:660
+msgid "Volume amplification"
+msgstr ""
+
+#: id:661
+msgid "Choose export folder"
+msgstr ""
+
+#: id:662
+msgid "This file is no longer available."
+msgstr ""
+
+#: id:663
+msgid "Would you like to remove it from the library?"
+msgstr ""
+
+#: id:664
+msgid "Browse for Script"
+msgstr ""
+
+#: id:665
+msgid "Compression level"
+msgstr ""
+
+#: id:700
+msgid "Cleaning up library"
+msgstr "Bersihkan Pustaka"
+
+#: id:701
+msgid "Removing old songs from the library"
+msgstr "Menghapus lagu lama dari Pustaka"
+
+#: id:702
+msgid "This path has been scanned before"
+msgstr "path ini telah di-scan sebelumnya"
+
+#: id:705
+msgctxt "Auto context with id 705"
+msgid "Network"
+msgstr "Jaringan"
+
+#: id:706
+msgid "- Server"
+msgstr "Host Proxy HTTP"
+
+#: id:708
+msgid "Use an HTTP proxy server to access the internet"
+msgstr "Aktifkan HTTP Proxy"
+
+#: id:711
+msgid "Internet Protocol (IP)"
+msgstr "Internet Protokol (IP)"
+
+#: id:712
+msgid "Invalid port specified. Value must be between 1 and 65535."
+msgstr "Port tidak valid. Nilai harus di antara 1 dan 65535."
+
+#: id:713
+msgid "HTTP proxy"
+msgstr "Proxy HTTP"
+
+#: id:715
+msgid "- Assignment"
+msgstr "Penetapan"
+
+#: id:716
+msgid "Automatic (DHCP)"
+msgstr "Otomatis (DHCP)"
+
+#: id:717
+msgid "Manual (Static)"
+msgstr "Manual (Statik)"
+
+#: id:719
+msgid "- IP address"
+msgstr "- Alamat IP"
+
+#: id:720
+msgid "- Netmask"
+msgstr "- Netmask"
+
+#: id:721
+msgid "- Default gateway"
+msgstr "- Gateway Standar"
+
+#: id:722
+msgid "- DNS server"
+msgstr "- Server DNS"
+
+#: id:723
+msgid "Save & restart"
+msgstr "Simpan & Memulai Kembali"
+
+#: id:724
+msgid "Invalid address specified. Value must be AAA.BBB.CCC.DDD"
+msgstr "Alamat tidak valid. Nilai harus AAA.BBB.CCC.DDD"
+
+#: id:725
+msgid "with numbers between 0 and 255."
+msgstr "dengan nomor antara 0 dan 255."
+
+#: id:726
+msgid "Changes not saved. Continue without saving?"
+msgstr "Perubahan tidak disimpan. Lanjutkan tanpa menyimpan?"
+
+#: id:727
+msgid "Web server"
+msgstr "Server Web"
+
+#: id:728
+msgctxt "Auto context with id 728"
+msgid "FTP server"
+msgstr "Server FTP"
+
+#: id:730
+msgid "- Port"
+msgstr "Port Server Web"
+
+#: id:732
+msgid "Save & apply"
+msgstr "Simpan & Pakai"
+
+#: id:733
+msgid "- Password"
+msgstr "Password Server Web"
+
+#: id:734
+msgid "No pass"
+msgstr "Tanpa Pass"
+
+#: id:735
+msgid "- Character set"
+msgstr "- Karakterset"
+
+#: id:736
+msgid "- Style"
+msgstr "- Gaya"
+
+#: id:737
+msgid "- Colour"
+msgstr "- Warna"
+
+#: id:738
+msgctxt "Auto context with id 738"
+msgid "Normal"
+msgstr "Normal"
+
+#: id:739
+msgid "Bold"
+msgstr "Tebal"
+
+#: id:740
+msgid "Italics"
+msgstr "Miring"
+
+#: id:741
+msgid "Bold italics"
+msgstr "Tebal Miring"
+
+#: id:742
+msgctxt "Auto context with id 742"
+msgid "White"
+msgstr "Putih"
+
+#: id:743
+msgctxt "Auto context with id 743"
+msgid "Yellow"
+msgstr "Kuning"
+
+#: id:744
+msgctxt "Auto context with id 744"
+msgid "Files"
+msgstr "File"
+
+#: id:745
+msgid "No scanned information for this view"
+msgstr "Tidak ada informasi untuk hasil scan ini"
+
+#: id:746
+msgid "Please turn off library mode"
+msgstr "Ganti ke tampilan File"
+
+#: id:747
+msgid "Error loading image"
+msgstr "Kesalahan memuat gambar"
+
+#: id:748
+msgid "Edit path"
+msgstr "Edit Path"
+
+#: id:749
+msgid "Mirror image"
+msgstr "Tambah Share"
+
+#: id:750
+msgid "Are you sure?"
+msgstr "Anda yakin?"
+
+#: id:751
+msgid "Removing source"
+msgstr "Menghapus Share"
+
+#: id:754
+msgid "Add program link"
+msgstr "Tambah Link Program"
+
+#: id:755
+msgid "Edit program path"
+msgstr "Edit Path Program"
+
+#: id:756
+msgid "Edit program name"
+msgstr "Edit Nama Program"
+
+#: id:757
+msgid "Edit path depth"
+msgstr "Edit Kedalaman Path"
+
+#: id:759
+msgid "View: Big list"
+msgstr "Lihat: Daftar Besar"
+
+#: id:760
+msgctxt "Auto context with id 760"
+msgid "Yellow"
+msgstr "Kuning"
+
+#: id:761
+msgctxt "Auto context with id 761"
+msgid "White"
+msgstr "Putih"
+
+#: id:762
+msgid "Blue"
+msgstr "Biru"
+
+#: id:763
+msgid "Bright green"
+msgstr "Hijau Terang"
+
+#: id:764
+msgid "Yellow green"
+msgstr "Kuning Hijau"
+
+#: id:765
+msgid "Cyan"
+msgstr "Cyan"
+
+#: id:766
+msgid "Light grey"
+msgstr "Dipesan"
+
+#: id:767
+msgid "Grey"
+msgstr "Dipesan"
+
+#: id:770
+msgid "Error %i: share not available"
+msgstr "Kesalahan %i: share tidak tersedia"
+
+#: id:772
+msgctxt "Auto context with id 772"
+msgid "Audio output"
+msgstr "Audio"
+
+#: id:773
+msgid "Seeking"
+msgstr "Mencari"
+
+#: id:774
+msgid "Slideshow folder"
+msgstr "Folder Slideshow"
+
+#: id:775
+msgid "Network interface"
+msgstr ""
+
+#: id:776
+msgid "- Wireless network name (ESSID)"
+msgstr ""
+
+#: id:777
+msgid "- Wireless password"
+msgstr ""
+
+#: id:778
+msgid "- Wireless security"
+msgstr ""
+
+#: id:779
+msgid "Save and apply network interface settings"
+msgstr ""
+
+#: id:780
+msgid "No encryption"
+msgstr ""
+
+#: id:781
+msgid "WEP"
+msgstr ""
+
+#: id:782
+msgid "WPA"
+msgstr ""
+
+#: id:783
+msgid "WPA2"
+msgstr ""
+
+#: id:784
+msgid "Applying network interface settings. Please wait."
+msgstr ""
+
+#: id:785
+msgid "Network interface restarted successfully."
+msgstr ""
+
+#: id:786
+msgid "Network interface did not start successfully."
+msgstr ""
+
+#: id:787
+msgid "Interface disabled"
+msgstr ""
+
+#: id:788
+msgid "Network interface disabled successfully."
+msgstr ""
+
+#: id:789
+msgid "Wireless network name (ESSID)"
+msgstr ""
+
+#: id:790
+msgid "Remote control"
+msgstr ""
+
+#: id:791
+msgid "Allow programs on this system to control XBMC"
+msgstr ""
+
+#: id:792
+msgctxt "Auto context with id 792"
+msgid "Port"
+msgstr ""
+
+#: id:793
+msgid "Port range"
+msgstr ""
+
+#: id:794
+msgid "Allow programs on other systems to control XBMC"
+msgstr ""
+
+#: id:795
+msgid "Initial repeat delay (ms)"
+msgstr ""
+
+#: id:796
+msgid "Continuous repeat delay (ms)"
+msgstr ""
+
+#: id:797
+msgid "Maximum number of clients"
+msgstr ""
+
+#: id:798
+msgid "Internet access"
+msgstr ""
+
+#: id:850
+msgid "Invalid port number entered"
+msgstr ""
+
+#: id:851
+msgid "Valid port range is 1-65535"
+msgstr ""
+
+#: id:852
+msgid "Valid port range is 1024-65535"
+msgstr ""
+
+#: id:998
+msgid "Add Music..."
+msgstr "XLink Kai"
+
+#: id:999
+msgid "Add Videos..."
+msgstr "Permainan Online"
+
+#: id:1000
+msgid "- Preview"
+msgstr "Preview Screensaver"
+
+#: id:1001
+msgid "Unable to connect"
+msgstr "Tidak bisa tersambung"
+
+#: id:1002
+msgid "XBMC was unable to connect to the network location."
+msgstr "XBMC tidak dapat tersambung ke lokasi jaringan."
+
+#: id:1003
+msgid "This could be due to the network not being connected."
+msgstr "Kemungkinan jaringan tidak tersambung."
+
+#: id:1004
+msgid "Would you like to add it anyway?"
+msgstr "Anda ingin menambahkan begitu saja?"
+
+#: id:1006
+msgctxt "Auto context with id 1006"
+msgid "IP address"
+msgstr "Alamat IP"
+
+#: id:1007
+msgid "Add network location"
+msgstr "Tambah Lokasi Jaringan"
+
+#: id:1008
+msgid "Protocol"
+msgstr "Protokol"
+
+#: id:1009
+msgid "Server address"
+msgstr "Alamat Server"
+
+#: id:1010
+msgid "Server name"
+msgstr "Nama Server"
+
+#: id:1011
+msgid "Remote path"
+msgstr "Path Remote"
+
+#: id:1012
+msgid "Shared folder"
+msgstr "Folder Yang Shared"
+
+#: id:1013
+msgctxt "Auto context with id 1013"
+msgid "Port"
+msgstr "Port"
+
+#: id:1014
+msgctxt "Auto context with id 1014"
+msgid "Username"
+msgstr "NamaPengguna"
+
+#: id:1015
+msgid "Browse for network server"
+msgstr "server jaringan"
+
+#: id:1016
+msgid "Enter the network address of the server"
+msgstr "Masukkan alamat jaringan dari server"
+
+#: id:1017
+msgid "Enter the path on the server"
+msgstr "Masukkan path pada server"
+
+#: id:1018
+msgid "Enter the port number"
+msgstr "Masukkan nomor port"
+
+#: id:1019
+msgid "Enter the username"
+msgstr "Masukkan namapengguna"
+
+#: id:1020
+msgid "Add %s source"
+msgstr "Tambah %s Sumber"
+
+#: id:1021
+msgid "Enter the paths or browse for the media locations."
+msgstr "Masukkan path atau jelajah lokasi media."
+
+#: id:1022
+msgid "Enter a name for this media Source."
+msgstr "Masukkan nama Sumber Media ini."
+
+#: id:1023
+msgid "Browse for new share"
+msgstr "Jelajah share baru"
+
+#: id:1024
+msgid "Browse"
+msgstr "Jelajah"
+
+#: id:1025
+msgid "Could not retrieve directory information."
+msgstr "Tidak bisa mengambil informasi direktori."
+
+#: id:1026
+msgid "Add source"
+msgstr "Tambah Sumber"
+
+#: id:1027
+msgid "Edit source"
+msgstr "Edit Sumber"
+
+#: id:1028
+msgid "Edit %s source"
+msgstr "Edit %s Sumber"
+
+#: id:1029
+msgid "Enter the new label"
+msgstr "Masukkan label baru"
+
+#: id:1030
+msgid "Browse for image"
+msgstr "sebuah image"
+
+#: id:1031
+msgid "Browse for image folder"
+msgstr "sebuah folder image"
+
+#: id:1032
+msgid "Add network location..."
+msgstr "Tambah Lokasi Jaringan..."
+
+#: id:1033
+msgid "Browse for file"
+msgstr ""
+
+#: id:1034
+msgid "Submenu"
+msgstr ""
+
+#: id:1035
+msgid "Enable submenu buttons"
+msgstr ""
+
+#: id:1036
+msgid "Favourites"
+msgstr ""
+
+#: id:1037
+msgid "Video Add-ons"
+msgstr ""
+
+#: id:1038
+msgid "Music Add-ons"
+msgstr ""
+
+#: id:1039
+msgid "Picture Add-ons"
+msgstr ""
+
+#: id:1040
+msgid "Loading directory"
+msgstr ""
+
+#: id:1041
+msgid "Retrieved %i items"
+msgstr ""
+
+#: id:1042
+msgid "Retrieved %i of %i items"
+msgstr ""
+
+#: id:1043
+msgid "Program Add-ons"
+msgstr ""
+
+#: id:1044
+msgid "Set plugin thumb"
+msgstr ""
+
+#: id:1045
+msgid "Add-on settings"
+msgstr ""
+
+#: id:1046
+msgid "Access points"
+msgstr ""
+
+#: id:1047
+msgid "Other..."
+msgstr ""
+
+#: id:1048
+msgid "- Username"
+msgstr ""
+
+#: id:1049
+msgid "Script settings"
+msgstr ""
+
+#: id:1050
+msgid "Singles"
+msgstr ""
+
+#: id:1051
+msgid "Enter web address"
+msgstr ""
+
+#: id:1200
+msgid "SMB client"
+msgstr "Klien SMB"
+
+#: id:1202
+msgid "Workgroup"
+msgstr "Workgroup"
+
+#: id:1203
+msgid "Default username"
+msgstr "NamaPengguna Standar"
+
+#: id:1204
+msgid "Default password"
+msgstr "Password Standar"
+
+#: id:1207
+msgid "WINS server"
+msgstr "WINS-Server"
+
+#: id:1208
+msgid "Mount SMB shares"
+msgstr ""
+
+#: id:1210
+msgctxt "Auto context with id 1210"
+msgid "Remove"
+msgstr "Hapus"
+
+#: id:1211
+msgctxt "Auto context with id 1211"
+msgid "Music"
+msgstr "Musik"
+
+#: id:1212
+msgctxt "Auto context with id 1212"
+msgid "Video"
+msgstr "Video"
+
+#: id:1213
+msgctxt "Auto context with id 1213"
+msgid "Pictures"
+msgstr "Gambar"
+
+#: id:1214
+msgctxt "Auto context with id 1214"
+msgid "Files"
+msgstr "File"
+
+#: id:1215
+msgctxt "Auto context with id 1215"
+msgid "Music & video"
+msgstr "Musik & Video"
+
+#: id:1216
+msgid "Music & pictures"
+msgstr "Musik & Gambar"
+
+#: id:1217
+msgid "Music & files"
+msgstr "Musik & File"
+
+#: id:1218
+msgid "Video & pictures"
+msgstr "Video & Gambar"
+
+#: id:1219
+msgid "Video & files"
+msgstr "Video & File"
+
+#: id:1220
+msgid "Pictures & files"
+msgstr "Gambar & File"
+
+#: id:1221
+msgid "Music & video & pictures"
+msgstr "Musik & Video & Gambar"
+
+#: id:1222
+msgid "Music & video & pictures & files"
+msgstr "Musik & Video & Gambar & File"
+
+#: id:1223
+msgctxt "Auto context with id 1223"
+msgid "Disabled"
+msgstr "Non Aktif"
+
+#: id:1226
+msgid "Files & music & video"
+msgstr "File & Musik & Video"
+
+#: id:1227
+msgid "Files & pictures & music"
+msgstr "File & Gambar & Musik"
+
+#: id:1228
+msgid "Files & pictures & video"
+msgstr "File & Gambar & Video"
+
+#: id:1229
+msgid "Music & programs"
+msgstr "Musik & Program"
+
+#: id:1230
+msgid "Video & programs"
+msgstr "Video & Program"
+
+#: id:1231
+msgid "Pictures & programs"
+msgstr "Gambar & Program"
+
+#: id:1232
+msgid "Music & video & pictures & programs"
+msgstr "Musik & Video & Gambar & Program"
+
+#: id:1233
+msgid "Programs & video & music"
+msgstr "Program & Video & Musik"
+
+#: id:1234
+msgid "Programs & pictures & music"
+msgstr "Program & Gambar & Musik"
+
+#: id:1235
+msgid "Programs & pictures & video"
+msgstr "Program & Gambar & Video"
+
+#: id:1250
+msgid "Auto-detection"
+msgstr "Otodeteksi"
+
+#: id:1251
+msgid "Auto-detect system"
+msgstr "Otodeteksi XBOX"
+
+#: id:1252
+msgid "Nickname"
+msgstr "Nama panggilan"
+
+#: id:1254
+msgid "Ask to connect"
+msgstr "Minta utk Tersambungkan"
+
+#: id:1255
+msgid "Send FTP user and password"
+msgstr "Kirim Pengguna dan Password FTP"
+
+#: id:1256
+msgid "Ping interval"
+msgstr "Jeda Ping"
+
+#: id:1257
+msgid "Would you like to connect to the auto-detected system?"
+msgstr "Apakah Anda ingin tersambung ke Otodeteksi Xbox?"
+
+#: id:1259
+msgid "Zeroconf"
+msgstr ""
+
+#: id:1260
+msgid "Announce these services to other systems via Zeroconf"
+msgstr ""
+
+#: id:1270
+msgid "Allow XBMC to receive AirPlay content"
+msgstr ""
+
+#: id:1271
+msgid "Device name"
+msgstr ""
+
+#: id:1272
+msgid "- Use password protection"
+msgstr ""
+
+#: id:1273
+msgid "AirPlay"
+msgstr ""
+
+#: id:1300
+msgid "Custom audio device"
+msgstr ""
+
+#: id:1301
+msgid "Custom passthrough device"
+msgstr ""
+
+#: id:1396
+msgid "Drifting"
+msgstr "Drifting"
+
+#: id:1397
+msgid "and"
+msgstr "dan"
+
+#: id:1398
+msgid "Freezing"
+msgstr "Membeku"
+
+#: id:1399
+msgid "Late"
+msgstr "Late"
+
+#: id:1400
+msgid "Isolated"
+msgstr "Isolated"
+
+#: id:1401
+msgid "Thundershowers"
+msgstr "T-Showers"
+
+#: id:1402
+msgid "Thunder"
+msgstr "Guntur"
+
+#: id:1403
+msgctxt "Auto context with id 1403"
+msgid "Sun"
+msgstr "Cerah"
+
+#: id:1404
+msgid "Heavy"
+msgstr "Heavy"
+
+#: id:1405
+msgid "in"
+msgstr "dalam"
+
+#: id:1406
+msgid "the"
+msgstr "the"
+
+#: id:1407
+msgid "Vicinity"
+msgstr "Vicinity"
+
+#: id:1408
+msgid "Ice"
+msgstr "Es"
+
+#: id:1409
+msgid "Crystals"
+msgstr "Kristal"
+
+#: id:1410
+msgid "Calm"
+msgstr "Tenang"
+
+#: id:1411
+msgid "with"
+msgstr "dengan"
+
+#: id:1412
+msgid "windy"
+msgstr "berangin"
+
+#: id:1413
+msgid "drizzle"
+msgstr ""
+
+#: id:1414
+msgid "Thunderstorm"
+msgstr ""
+
+#: id:1415
+msgid "Drizzle"
+msgstr ""
+
+#: id:1416
+msgid "Foggy"
+msgstr ""
+
+#: id:1417
+msgid "Grains"
+msgstr ""
+
+#: id:1418
+msgid "T-Storms"
+msgstr ""
+
+#: id:1419
+msgid "T-Showers"
+msgstr ""
+
+#: id:1420
+msgid "Moderate"
+msgstr ""
+
+#: id:1421
+msgid "Very High"
+msgstr ""
+
+#: id:1422
+msgid "Windy"
+msgstr ""
+
+#: id:1423
+msgid "Mist"
+msgstr ""
+
+#: id:1450
+msgid "Put display to sleep when idle"
+msgstr ""
+
+#: id:2050
+msgid "Runtime"
+msgstr "Durasi:"
+
+#: id:2100
+msgid "Script failed! : %s"
+msgstr ""
+
+#: id:2101
+msgid "Newer version needed - See log"
+msgstr ""
+
+#: id:4501
+msgid "Enable LCD/VFD"
+msgstr "Jenis LCD"
+
+#: id:10000
+msgid "Home"
+msgstr "Depan"
+
+#: id:10001
+msgctxt "Auto context with id 10001"
+msgid "Programs"
+msgstr "Program"
+
+#: id:10002
+msgctxt "Auto context with id 10002"
+msgid "Pictures"
+msgstr "Foto"
+
+#: id:10003
+msgctxt "Auto context with id 10003"
+msgid "File manager"
+msgstr "File"
+
+#: id:10004
+msgctxt "Auto context with id 10004"
+msgid "Settings"
+msgstr "Setelan"
+
+#: id:10005
+msgctxt "Auto context with id 10005"
+msgid "Music"
+msgstr "Musik"
+
+#: id:10006
+msgctxt "Auto context with id 10006"
+msgid "Videos"
+msgstr "Video"
+
+#: id:10007
+msgid "System information"
+msgstr "Informasi Sistem"
+
+#: id:10008
+msgid "Settings - General"
+msgstr "Setelan->Umum"
+
+#: id:10009
+msgid "Settings - Screen"
+msgstr "Setelan->Layar"
+
+#: id:10010
+msgid "Settings - Appearance - GUI Calibration"
+msgstr "Setelan->Penampilan->Kalibrasi GUI"
+
+#: id:10011
+msgid "Settings - Videos - Screen Calibration"
+msgstr "Setelan->Video->Kalibrasi Layar"
+
+#: id:10012
+msgid "Settings - Pictures"
+msgstr "Setelan->Foto"
+
+#: id:10013
+msgid "Settings - Programs"
+msgstr "Setelan->Program"
+
+#: id:10014
+msgid "Settings - Weather"
+msgstr "Setelan->Cuaca"
+
+#: id:10015
+msgid "Settings - Music"
+msgstr "Setelan->Musik"
+
+#: id:10016
+msgid "Settings - System"
+msgstr "Setelan->Sistem"
+
+#: id:10017
+msgid "Settings - Videos"
+msgstr "Setelan->Video"
+
+#: id:10018
+msgid "Settings - Network"
+msgstr "Setelan->Jaringan"
+
+#: id:10019
+msgid "Settings - Appearance"
+msgstr "Setelan->Penampilan"
+
+#: id:10020
+msgctxt "Auto context with id 10020"
+msgid "Scripts"
+msgstr "Skrip"
+
+#: id:10021
+msgid "Web Browser"
+msgstr "Video/Aliran"
+
+#: id:10025
+msgctxt "Auto context with id 10025"
+msgid "Videos"
+msgstr "Video/Judul"
+
+#: id:10028
+msgid "Videos/Playlist"
+msgstr "Video/Daftar Main"
+
+#: id:10029
+msgctxt "Auto context with id 10029"
+msgid "Login screen"
+msgstr ""
+
+#: id:10034
+msgid "Settings - Profiles"
+msgstr "Setelan->Profil"
+
+#: id:10040
+msgid "Addon browser"
+msgstr ""
+
+#: id:10100
+msgid "Yes/No dialog"
+msgstr "Dialog Ya/tidak"
+
+#: id:10101
+msgid "Progress dialog"
+msgstr "Dialog Kemajuan"
+
+#: id:10210
+msgid "Looking for subtitles..."
+msgstr ""
+
+#: id:10211
+msgid "Looking for or caching subtitles..."
+msgstr ""
+
+#: id:10212
+msgid "terminating"
+msgstr ""
+
+#: id:10213
+msgid "buffering"
+msgstr ""
+
+#: id:10214
+msgid "Opening stream"
+msgstr ""
+
+#: id:10500
+msgid "Music/Playlist"
+msgstr "Musik/Daftar Main"
+
+#: id:10501
+msgid "Music/Files"
+msgstr "Musik/File"
+
+#: id:10502
+msgid "Music/Library"
+msgstr "Musik/Pustaka"
+
+#: id:10503
+msgid "Playlist editor"
+msgstr "Musik/Top 100"
+
+#: id:10504
+msgid "Top 100 songs"
+msgstr "Top 100 Lagu"
+
+#: id:10505
+msgid "Top 100 albums"
+msgstr "Top 100 Album"
+
+#: id:10506
+msgctxt "Auto context with id 10506"
+msgid "Programs"
+msgstr "Aplikasi"
+
+#: id:10507
+msgid "Configuration"
+msgstr "Konfigurasi"
+
+#: id:10508
+msgid "Weather forecast"
+msgstr "Ramalan Cuaca"
+
+#: id:10509
+msgid "Network gaming"
+msgstr "Permainan Jaringan"
+
+#: id:10510
+msgid "Extensions"
+msgstr "Ekstensi"
+
+#: id:10511
+msgctxt "Auto context with id 10511"
+msgid "System info"
+msgstr "Informasi Sistem"
+
+#: id:10516
+msgid "Music - Library"
+msgstr "Musik - Pustaka"
+
+#: id:10517
+msgid "Now Playing - Music"
+msgstr "Musik - Sedang Dimainkan"
+
+#: id:10522
+msgid "Now Playing - Videos"
+msgstr "Video - Sedang Dimainkan"
+
+#: id:10523
+msgid "Album info"
+msgstr "Info Album"
+
+#: id:10524
+msgid "Movie info"
+msgstr "Info Film"
+
+#: id:12000
+msgid "Select dialog"
+msgstr "Pilih dialog"
+
+#: id:12001
+msgid "Music/Info"
+msgstr "Musik/info"
+
+#: id:12002
+msgid "Dialog OK"
+msgstr "Dialog OK"
+
+#: id:12003
+msgid "Videos/Info"
+msgstr "Video/Info"
+
+#: id:12004
+msgid "Scripts/Info"
+msgstr "Skrip/Info"
+
+#: id:12005
+msgid "Fullscreen video"
+msgstr "Video Tampilan Penuh"
+
+#: id:12006
+msgid "Audio visualization"
+msgstr "Visualisasi Audio"
+
+#: id:12008
+msgid "File stacking dialog"
+msgstr "Filestacking dialog"
+
+#: id:12009
+msgid "Rebuild index..."
+msgstr "Membangun kembali indeks..."
+
+#: id:12010
+msgid "Return to music window"
+msgstr "Kembali ke Musik"
+
+#: id:12011
+msgid "Return to videos window"
+msgstr "Kembali ke Video"
+
+#: id:12021
+msgid "Start from beginning"
+msgstr "Memulai dari awal"
+
+#: id:12022
+msgid "Resume from %s"
+msgstr "Mainkan lagi dari posisi akhir"
+
+#: id:12310
+msgid "0"
+msgstr "0"
+
+#: id:12311
+msgid "1"
+msgstr "1"
+
+#: id:12312
+msgid "2"
+msgstr "2"
+
+#: id:12313
+msgid "3"
+msgstr "3"
+
+#: id:12314
+msgid "4"
+msgstr "4"
+
+#: id:12315
+msgid "5"
+msgstr "5"
+
+#: id:12316
+msgid "6"
+msgstr "6"
+
+#: id:12317
+msgid "7"
+msgstr "7"
+
+#: id:12318
+msgid "8"
+msgstr "8"
+
+#: id:12319
+msgid "9"
+msgstr "9"
+
+#: id:12320
+msgid "c"
+msgstr "c"
+
+#: id:12321
+msgid "Ok"
+msgstr "ok"
+
+#: id:12322
+msgid "*"
+msgstr "*"
+
+#: id:12325
+msgid "Locked! Enter code..."
+msgstr "Dikunci Masukkan Kode..."
+
+#: id:12326
+msgid "Enter password"
+msgstr "Masukkan password"
+
+#: id:12327
+msgid "Enter master code"
+msgstr "Masukkan Kode Master"
+
+#: id:12328
+msgid "Enter unlock code"
+msgstr "Masukkan Kode Pembuka"
+
+#: id:12329
+msgid "or press C to cancel"
+msgstr "atau tekan C untuk membatalkan"
+
+#: id:12330
+msgid "Enter gamepad button combo and"
+msgstr "Masukkan tombol kombo Gamepad dan tekan Start"
+
+#: id:12331
+msgid "press OK, or Back to cancel"
+msgstr "tekan Start, atau Back utk membatalkan"
+
+#: id:12332
+msgid "Set lock"
+msgstr "Pasang Kunci"
+
+#: id:12333
+msgid "Unlock"
+msgstr "Buka Kunci"
+
+#: id:12334
+msgid "Reset lock"
+msgstr "Memasang Lagi Kunci"
+
+#: id:12335
+msgid "Remove lock"
+msgstr "Hapus Kunci"
+
+#: id:12337
+msgid "Numeric password"
+msgstr "Password Numerik"
+
+#: id:12338
+msgid "Gamepad button combo"
+msgstr "Tombol Gamepad Kombo"
+
+#: id:12339
+msgid "Full-text password"
+msgstr "Password Teks"
+
+#: id:12340
+msgid "Enter new password"
+msgstr "Masukkan password baru"
+
+#: id:12341
+msgid "Re-Enter new password"
+msgstr "Masukkan lagi password baru"
+
+#: id:12342
+msgid "Incorrect password,"
+msgstr "Password salah,"
+
+#: id:12343
+msgid "retries left"
+msgstr "sisa percobaan"
+
+#: id:12344
+msgid "Passwords entered did not match."
+msgstr "Password yg dimasukkan tidak sesuai."
+
+#: id:12345
+msgid "Access denied"
+msgstr "Akses Ditolak"
+
+#: id:12346
+msgid "Password retry limit exceeded."
+msgstr "Batas memasukan Password telah lewat."
+
+#: id:12347
+msgid "The system will now shut off."
+msgstr "XBOX akan dimatikan sekarang."
+
+#: id:12348
+msgid "Item locked"
+msgstr "Item Terkunci"
+
+#: id:12353
+msgid "Reactivate lock"
+msgstr "Pengangtifan Kunci"
+
+#: id:12356
+msgid "Change lock"
+msgstr "Ganti Kunci"
+
+#: id:12357
+msgid "Source lock"
+msgstr "Share Kunci"
+
+#: id:12358
+msgid "Password entry was blank. Try again."
+msgstr "Masukkan Password kosong. Coba lagi."
+
+#: id:12360
+msgid "Master lock"
+msgstr "Kunci Master"
+
+#: id:12362
+msgid "Shutdown system if Master Lock retries exceeded"
+msgstr "Aktifkan Shutdown"
+
+#: id:12367
+msgid "Master code is not valid"
+msgstr "Kunci Master tidak Valid!"
+
+#: id:12368
+msgid "Please enter a valid master code"
+msgstr "Harap masukkan Kode Master yang Valid!"
+
+#: id:12373
+msgid "Settings & file manager"
+msgstr "Setelan & File"
+
+#: id:12376
+msgid "Set as default for all movies"
+msgstr "Pasangkan sebagai standar untuk semua Film"
+
+#: id:12377
+msgid "This will reset any previously saved values"
+msgstr "Ini akan mengubah nilai yang telah disimpan sebelumnya"
+
+#: id:12378
+msgid "Amount of time to display each image"
+msgstr "Tampilkan setiap gambar untuk"
+
+#: id:12379
+msgid "Use pan and zoom effects"
+msgstr "Gunakan efek Pan dan Zoom"
+
+#: id:12383
+msgid "12 hour clock"
+msgstr "12 jam"
+
+#: id:12384
+msgid "24 hour clock"
+msgstr "24 jam"
+
+#: id:12385
+msgid "Day/Month"
+msgstr "Hari/Bulan"
+
+#: id:12386
+msgid "Month/Day"
+msgstr "Bulan/Hari"
+
+#: id:12390
+msgid "System uptime"
+msgstr "Sistem Berjalan"
+
+#: id:12391
+msgid "Minutes"
+msgstr "Menit"
+
+#: id:12392
+msgid "Hours"
+msgstr "Jam"
+
+#: id:12393
+msgid "Days"
+msgstr "Hari"
+
+#: id:12394
+msgid "Total uptime"
+msgstr "Total Sistem Berjalan"
+
+#: id:12395
+msgid "Battery level"
+msgstr ""
+
+#: id:12600
+msgctxt "Auto context with id 12600"
+msgid "Weather"
+msgstr "Cuaca"
+
+#: id:12900
+msgctxt "Auto context with id 12900"
+msgid "Screensaver"
+msgstr "Screensaver"
+
+#: id:12901
+msgid "Fullscreen OSD"
+msgstr "Tampilan Penuh OSD"
+
+#: id:13000
+msgid "System"
+msgstr "Sistem"
+
+#: id:13001
+msgid "Immediate HD spindown"
+msgstr "HD Spindown Seketika"
+
+#: id:13002
+msgid "Video only"
+msgstr "Hanya Video"
+
+#: id:13003
+msgid "- Delay"
+msgstr "- Penundaan"
+
+#: id:13004
+msgid "- Minimum file duration"
+msgstr "- Minimum Lamanya File"
+
+#: id:13005
+msgid "Shutdown"
+msgstr "Matikan"
+
+#: id:13008
+msgid "Shutdown function"
+msgstr ""
+
+#: id:13009
+msgid "Quit"
+msgstr ""
+
+#: id:13010
+msgid "Hibernate"
+msgstr ""
+
+#: id:13011
+msgid "Suspend"
+msgstr ""
+
+#: id:13012
+msgid "Exit"
+msgstr ""
+
+#: id:13013
+msgid "Reboot"
+msgstr ""
+
+#: id:13014
+msgid "Minimize"
+msgstr ""
+
+#: id:13015
+msgid "Power button action"
+msgstr ""
+
+#: id:13016
+msgid "Power off System"
+msgstr ""
+
+#: id:13020
+msgid "Is another session active, perhaps over ssh?"
+msgstr ""
+
+#: id:13021
+msgid "Mounted removable harddrive"
+msgstr ""
+
+#: id:13022
+msgid "Unsafe device removal"
+msgstr ""
+
+#: id:13023
+msgid "Successfully removed device"
+msgstr ""
+
+#: id:13024
+msgid "Joystick plugged"
+msgstr ""
+
+#: id:13025
+msgid "Joystick unplugged"
+msgstr ""
+
+#: id:13050
+msgid "Running low on battery"
+msgstr ""
+
+#: id:13100
+msgid "Flicker filter"
+msgstr "Filter Kedipan"
+
+#: id:13101
+msgid "Let driver choose (requires restart)"
+msgstr ""
+
+#: id:13105
+msgid "Vertical blank sync"
+msgstr ""
+
+#: id:13106
+msgctxt "Auto context with id 13106"
+msgid "Disabled"
+msgstr ""
+
+#: id:13107
+msgid "Enabled during video playback"
+msgstr ""
+
+#: id:13108
+msgctxt "Auto context with id 13108"
+msgid "Always enabled"
+msgstr ""
+
+#: id:13109
+msgid "Test & apply resolution"
+msgstr ""
+
+#: id:13110
+msgid "Save resolution?"
+msgstr ""
+
+#: id:13111
+msgid "Would you like to keep this resolution?"
+msgstr ""
+
+#: id:13112
+msgid "High quality upscaling"
+msgstr ""
+
+#: id:13113
+msgctxt "Auto context with id 13113"
+msgid "Disabled"
+msgstr ""
+
+#: id:13114
+msgid "Enabled for SD content"
+msgstr ""
+
+#: id:13115
+msgctxt "Auto context with id 13115"
+msgid "Always enabled"
+msgstr ""
+
+#: id:13116
+msgid "Upscaling method"
+msgstr ""
+
+#: id:13117
+msgctxt "Auto context with id 13117"
+msgid "Bicubic"
+msgstr ""
+
+#: id:13118
+msgid "Lanczos"
+msgstr ""
+
+#: id:13119
+msgid "Sinc"
+msgstr ""
+
+#: id:13120
+msgctxt "Auto context with id 13120"
+msgid "VDPAU"
+msgstr ""
+
+#: id:13121
+msgid "VDPAU HQ Upscaling level"
+msgstr ""
+
+#: id:13122
+msgid "VDPAU Studio level color conversion"
+msgstr ""
+
+#: id:13130
+msgid "Blank other displays"
+msgstr ""
+
+#: id:13131
+msgctxt "Auto context with id 13131"
+msgid "Disabled"
+msgstr ""
+
+#: id:13132
+msgid "Blank displays"
+msgstr ""
+
+#: id:13140
+msgid "Active connections detected!"
+msgstr ""
+
+#: id:13141
+msgid "If you proceed, you might not be able to control XBMC"
+msgstr ""
+
+#: id:13142
+msgid "any longer. Are you sure you want to stop the Event server?"
+msgstr ""
+
+#: id:13144
+msgid "Change Apple Remote mode?"
+msgstr ""
+
+#: id:13145
+msgid "If you are currently using the Apple Remote to control"
+msgstr ""
+
+#: id:13146
+msgid "XBMC, changing this setting might affect your ability"
+msgstr ""
+
+#: id:13147
+msgid "to continue controlling it. Do you want to proceed?"
+msgstr ""
+
+#: id:13159
+msgid "Subnet mask"
+msgstr "Subnet mask:"
+
+#: id:13160
+msgid "Gateway"
+msgstr "Gateway:"
+
+#: id:13161
+msgid "Primary DNS"
+msgstr "DNS"
+
+#: id:13162
+msgid "Initialize failed"
+msgstr "Gagal Inisialisasi"
+
+#: id:13170
+msgctxt "Auto context with id 13170"
+msgid "Never"
+msgstr "Tidak Pernah"
+
+#: id:13171
+msgid "Immediately"
+msgstr "Segera"
+
+#: id:13172
+msgid "After %i secs"
+msgstr "Setelah %i detik"
+
+#: id:13173
+msgid "HDD install date:"
+msgstr ""
+
+#: id:13174
+msgid "HDD power cycle count:"
+msgstr ""
+
+#: id:13200
+msgid "Profiles"
+msgstr "Profil"
+
+#: id:13201
+msgid "Delete profile '%s'?"
+msgstr "Hapus profil '%s'?"
+
+#: id:13204
+msgid "Last loaded profile:"
+msgstr "Profil terakhir dipasang:"
+
+#: id:13205
+msgid "Unknown"
+msgstr "Tidak Diketahui"
+
+#: id:13206
+msgid "Overwrite"
+msgstr "Timpa"
+
+#: id:13208
+msgid "Alarm clock"
+msgstr "Jam Alarm"
+
+#: id:13209
+msgid "Alarm clock interval (in minutes)"
+msgstr "Jeda jam Alarm (dlm menit)"
+
+#: id:13210
+msgid "Started, alarm in %im"
+msgstr "Dimulai, alarm pada %im"
+
+#: id:13211
+msgid "Alarm!"
+msgstr "Alarm!"
+
+#: id:13212
+msgid "Canceled with %im%is left"
+msgstr "Dibatalkan dengan %im%is"
+
+#: id:13213
+msgid "%2.0fm"
+msgstr ""
+
+#: id:13214
+msgid "%2.0fs"
+msgstr ""
+
+#: id:13249
+msgid "Search for subtitles in RARs"
+msgstr "Cari Teks Film dalam RARs"
+
+#: id:13250
+msgid "Browse for subtitle..."
+msgstr "Melihat-lihat teks film..."
+
+#: id:13251
+msgid "Move item"
+msgstr "Pindahkan Item"
+
+#: id:13252
+msgid "Move item here"
+msgstr "Pindahkan Item Ke Sini"
+
+#: id:13253
+msgid "Cancel move"
+msgstr "Batalkan Pemindahan"
+
+#: id:13270
+msgid "Hardware:"
+msgstr "Perangkat Keras"
+
+#: id:13271
+msgid "CPU Usage:"
+msgstr "Kecepatan CPU:"
+
+#: id:13274
+msgid "Connected, but no DNS is available."
+msgstr "Xbox Tersambung, tetapi tidak tersedia DNS."
+
+#: id:13275
+msgid "Hard Disk"
+msgstr "Hard Disk"
+
+#: id:13276
+msgid "DVD-ROM"
+msgstr "DVD-ROM"
+
+#: id:13277
+msgctxt "Auto context with id 13277"
+msgid "Storage"
+msgstr "Penyimpanan"
+
+#: id:13278
+msgctxt "Auto context with id 13278"
+msgid "Default"
+msgstr "Standar"
+
+#: id:13279
+msgctxt "Auto context with id 13279"
+msgid "Network"
+msgstr "Jaringan"
+
+#: id:13280
+msgctxt "Auto context with id 13280"
+msgid "Video"
+msgstr "Video"
+
+#: id:13281
+msgid "Hardware"
+msgstr "Perangkat Keras"
+
+#: id:13283
+msgid "Operating system:"
+msgstr "Versi Kernel:"
+
+#: id:13284
+msgid "CPU speed:"
+msgstr "Kecepatan CPU:"
+
+#: id:13286
+msgid "Video encoder:"
+msgstr "Enkoder Video:"
+
+#: id:13287
+msgid "Screen resolution:"
+msgstr "Resolusi Layar:"
+
+#: id:13292
+msgid "A/V cable:"
+msgstr "Kabel A/V:"
+
+#: id:13294
+msgid "DVD region:"
+msgstr "Region DVD:"
+
+#: id:13295
+msgid "Internet:"
+msgstr "Internet:"
+
+#: id:13296
+msgctxt "Auto context with id 13296"
+msgid "Connected"
+msgstr "Xbox sedang Tersambung"
+
+#: id:13297
+msgid "Not connected. Check network settings."
+msgstr "Xbox tidak Tersambung. Periksa setelan Jaringan."
+
+#: id:13299
+msgid "Target temperature"
+msgstr "Target Suhu"
+
+#: id:13300
+msgid "Fan speed"
+msgstr "Kecepatan Kipas"
+
+#: id:13301
+msgid "Auto temperature control"
+msgstr "Kontrol Suhu Otomatis"
+
+#: id:13302
+msgid "Fan speed override"
+msgstr "Mengesampingkan Kecepatan Kipas"
+
+#: id:13303
+msgid "- Fonts"
+msgstr "Huruf Kulit"
+
+#: id:13304
+msgid "Enable flipping bi-directional strings"
+msgstr "Aktifkan Flipping Bi-Directional Strings"
+
+#: id:13305
+msgid "Show RSS news feeds"
+msgstr "Aktifkan RSS Feeds"
+
+#: id:13306
+msgid "Show parent folder items"
+msgstr "Sembunyikan Induk Item Folder"
+
+#: id:13307
+msgid "Track naming template"
+msgstr "Template Penamaan Folder"
+
+#: id:13308
+msgid "Do you wish to reboot your system"
+msgstr "Anda yakin ingin mem-boot xbox"
+
+#: id:13309
+msgid "instead of just XBMC?"
+msgstr "daripada hanya XBMC?"
+
+#: id:13310
+msgid "Zoom effect"
+msgstr "Efek Zoom"
+
+#: id:13311
+msgid "Float effect"
+msgstr "Efek Float"
+
+#: id:13312
+msgid "Black bar reduction"
+msgstr "Pengurangan Bar Hitam"
+
+#: id:13313
+msgid "Restart"
+msgstr "Memulai Lagi"
+
+#: id:13314
+msgid "Crossfade between songs"
+msgstr "Crossfade"
+
+#: id:13315
+msgid "Regenerate thumbnails"
+msgstr "Buat Ulang Thumbnail"
+
+#: id:13316
+msgid "Recursive thumbnails"
+msgstr "Thumbnail Berulang"
+
+#: id:13317
+msgid "View slideshow"
+msgstr "Lihat Slideshow"
+
+#: id:13318
+msgid "Recursive slideshow"
+msgstr "Slideshow Berulang"
+
+#: id:13319
+msgid "Randomize"
+msgstr "Acak"
+
+#: id:13320
+msgid "Stereo"
+msgstr "Stereo"
+
+#: id:13321
+msgid "Left only"
+msgstr "Hanya Kiri"
+
+#: id:13322
+msgid "Right only"
+msgstr "Hanya Kanan"
+
+#: id:13323
+msgid "Enable karaoke support"
+msgstr "Aktifkan CD+G"
+
+#: id:13324
+msgid "Background transparency"
+msgstr "Latar Belakang Transparan"
+
+#: id:13325
+msgid "Foreground transparency"
+msgstr "Latar Depan Transparan"
+
+#: id:13326
+msgid "A/V delay"
+msgstr "penundaan A/V"
+
+#: id:13327
+msgid "Karaoke"
+msgstr "Karaoke"
+
+#: id:13328
+msgid "%s not found"
+msgstr "%s tidak ditemukan"
+
+#: id:13329
+msgid "Error opening %s"
+msgstr "Kesalahan membuka %s"
+
+#: id:13330
+msgid "Unable to load %s"
+msgstr "Tidak dapat memuat %s"
+
+#: id:13331
+msgid "Error: Out of memory"
+msgstr "Kesalahan: memori yg diperlukan terlalu besar"
+
+#: id:13332
+msgid "Move up"
+msgstr "Pindah Atas"
+
+#: id:13333
+msgid "Move down"
+msgstr "Pindah Bawah"
+
+#: id:13334
+msgid "Edit label"
+msgstr "Edit Label"
+
+#: id:13335
+msgid "Make default"
+msgstr "Buat Standar"
+
+#: id:13336
+msgid "Remove button"
+msgstr "Hapus Tombol"
+
+#: id:13340
+msgid "Leave as is"
+msgstr "Biarkan Seadanya"
+
+#: id:13341
+msgid "Green"
+msgstr "Hijau"
+
+#: id:13342
+msgid "Orange"
+msgstr "Oranye"
+
+#: id:13343
+msgid "Red"
+msgstr "Merah"
+
+#: id:13344
+msgid "Cycle"
+msgstr "Putaran"
+
+#: id:13345
+msgid "Switch LED off on playback"
+msgstr "Matikan LED saat Memainkan"
+
+#: id:13346
+msgctxt "Auto context with id 13346"
+msgid "Movie information"
+msgstr "Informasi Film"
+
+#: id:13347
+msgid "Queue item"
+msgstr "Hal Antrian"
+
+#: id:13348
+msgid "Search IMDb..."
+msgstr "Cari IMDb..."
+
+#: id:13349
+msgid "Scan for new content"
+msgstr "Cari Info Utk Semua File"
+
+#: id:13350
+msgid "Now playing..."
+msgstr "Sedang Memainkan..."
+
+#: id:13351
+msgctxt "Auto context with id 13351"
+msgid "Album information"
+msgstr "Informasi Album"
+
+#: id:13352
+msgid "Scan item to library"
+msgstr "Pindai Seluruh Database"
+
+#: id:13353
+msgid "Stop scanning"
+msgstr "Hentikan Scan"
+
+#: id:13354
+msgctxt "Auto context with id 13354"
+msgid "Render method"
+msgstr "Metode Render"
+
+#: id:13355
+msgid "Low quality pixel shader"
+msgstr "Pixel Shader Kualitas Rendah"
+
+#: id:13356
+msgid "Hardware overlays"
+msgstr "Lapisan Perangkat Keras"
+
+#: id:13357
+msgid "High quality pixel shader"
+msgstr "Pixel Shader Kualitas Tinggi"
+
+#: id:13358
+msgid "Play item"
+msgstr "Mainkan Item"
+
+#: id:13359
+msgid "Set artist thumb"
+msgstr "Pasang Thumb Artis"
+
+#: id:13360
+msgid "Automatically generate thumbnails"
+msgstr "Buat Thumb"
+
+#: id:13361
+msgid "Enable voice"
+msgstr "Aktifkan Suara"
+
+#: id:13375
+msgid "Enable device"
+msgstr "Aktifkan Perangkat"
+
+#: id:13376
+msgid "Volume"
+msgstr "Volume"
+
+#: id:13377
+msgid "Default view mode"
+msgstr "Mode Tampilan Standar"
+
+#: id:13378
+msgid "Default brightness"
+msgstr "Kecerahan Standar"
+
+#: id:13379
+msgid "Default contrast"
+msgstr "Kontras Standar"
+
+#: id:13380
+msgid "Default gamma"
+msgstr "Gamma Standar"
+
+#: id:13381
+msgid "Resume video"
+msgstr "Lanjutkan Lagi Video"
+
+#: id:13382
+msgid "Voice mask - Port 1"
+msgstr "Voice Mask - Port 1"
+
+#: id:13383
+msgid "Voice mask - Port 2"
+msgstr "Voice Mask - Port 2"
+
+#: id:13384
+msgid "Voice mask - Port 3"
+msgstr "Voice Mask - Port 3"
+
+#: id:13385
+msgid "Voice mask - Port 4"
+msgstr "Voice Mask - Port 4"
+
+#: id:13386
+msgid "Use time based seeking"
+msgstr "Gunakan Pencarian Berdasar Waktu"
+
+#: id:13387
+msgid "Track naming template - right"
+msgstr "Template Penamaan Trek Kanan"
+
+#: id:13388
+msgid "Preset"
+msgstr "Presets"
+
+#: id:13389
+msgid "There are no presets available\nfor this visualization"
+msgstr "Tidak tersedia preset utk visualisasi ini"
+
+#: id:13390
+msgid "There are no settings available\nfor this visualization"
+msgstr "Tidak tersedia setelan utk visualisasi ini"
+
+#: id:13391
+msgid "Eject/Load"
+msgstr "Keluarkan/Pasangkan"
+
+#: id:13392
+msgid "Use visualization if playing audio"
+msgstr "Gunakan Visualisasi jika memainkan audio"
+
+#: id:13393
+msgid "Calculate size"
+msgstr "Hitung Ukuran"
+
+#: id:13394
+msgid "Calculating folder size"
+msgstr "Menghitung ukuran isi folder"
+
+#: id:13395
+msgid "Video settings"
+msgstr "Setelan Video"
+
+#: id:13396
+msgid "Audio and subtitle settings"
+msgstr "Audio dan Setelan Teks Film"
+
+#: id:13397
+msgid "Enable subtitles"
+msgstr "Aktifkan Teks Film"
+
+#: id:13398
+msgctxt "Auto context with id 13398"
+msgid "Shortcuts"
+msgstr "Bookmark"
+
+#: id:13399
+msgid "Ignore articles when sorting (e.g. \"the\")"
+msgstr "Abaikan \"The\" saat penyortiran"
+
+#: id:13400
+msgid "Crossfade between songs on the same album"
+msgstr "Crossfade trek album"
+
+#: id:13401
+msgid "Browse for %s"
+msgstr "Melihat-lihat untuk %s"
+
+#: id:13402
+msgid "Show track position"
+msgstr "Tampilkan posisi trek"
+
+#: id:13403
+msgid "Clear default"
+msgstr "Kosongkan Default"
+
+#: id:13404
+msgid "Resume"
+msgstr "Lanjutkan"
+
+#: id:13405
+msgid "Get thumb"
+msgstr "Dapatkan Thumb"
+
+#: id:13406
+msgid "Picture information"
+msgstr ""
+
+#: id:13407
+msgid "%s presets"
+msgstr ""
+
+#: id:13408
+msgid "(IMDb user rating)"
+msgstr ""
+
+#: id:13409
+msgid "Top 250"
+msgstr ""
+
+#: id:13410
+msgid "Tune in on Last.fm"
+msgstr ""
+
+#: id:13411
+msgid "Minimum fan speed"
+msgstr ""
+
+#: id:13412
+msgid "Play from here"
+msgstr ""
+
+#: id:13413
+msgid "Downloading"
+msgstr ""
+
+#: id:13414
+msgid "Include artists who appear only on compilations"
+msgstr ""
+
+#: id:13415
+msgctxt "Auto context with id 13415"
+msgid "Render method"
+msgstr ""
+
+#: id:13416
+msgid "Auto detect"
+msgstr ""
+
+#: id:13417
+msgid "Basic shaders (ARB)"
+msgstr ""
+
+#: id:13418
+msgid "Advanced shaders (GLSL)"
+msgstr ""
+
+#: id:13419
+msgid "Software"
+msgstr ""
+
+#: id:13420
+msgid "Remove safely"
+msgstr ""
+
+#: id:13421
+msgctxt "Auto context with id 13421"
+msgid "VDPAU"
+msgstr ""
+
+#: id:13422
+msgid "Start slideshow here"
+msgstr ""
+
+#: id:13423
+msgid "Remember for this path"
+msgstr ""
+
+#: id:13424
+msgid "Use pixel buffer objects"
+msgstr ""
+
+#: id:13425
+msgid "Allow hardware acceleration (VDPAU)"
+msgstr ""
+
+#: id:13426
+msgid "Allow hardware acceleration (VAAPI)"
+msgstr ""
+
+#: id:13427
+msgid "Allow hardware acceleration (DXVA2)"
+msgstr ""
+
+#: id:13428
+msgid "Allow hardware acceleration (CrystalHD)"
+msgstr ""
+
+#: id:13429
+msgid "Allow hardware acceleration (VDADecoder)"
+msgstr ""
+
+#: id:13430
+msgid "Allow hardware acceleration (OpenMax)"
+msgstr ""
+
+#: id:13431
+msgid "Pixel Shaders"
+msgstr ""
+
+#: id:13432
+msgid "Allow hardware acceleration (VideoToolbox)"
+msgstr ""
+
+#: id:13500
+msgid "A/V sync method"
+msgstr ""
+
+#: id:13501
+msgid "Audio clock"
+msgstr ""
+
+#: id:13502
+msgid "Video clock (Drop/Dupe audio)"
+msgstr ""
+
+#: id:13503
+msgid "Video clock (Resample audio)"
+msgstr ""
+
+#: id:13504
+msgid "Maximum resample amount (%)"
+msgstr ""
+
+#: id:13505
+msgid "Resample quality"
+msgstr ""
+
+#: id:13506
+msgid "Low(fast)"
+msgstr ""
+
+#: id:13507
+msgctxt "Auto context with id 13507"
+msgid "Medium"
+msgstr ""
+
+#: id:13508
+msgctxt "Auto context with id 13508"
+msgid "High"
+msgstr ""
+
+#: id:13509
+msgid "Really high(slow!)"
+msgstr ""
+
+#: id:13510
+msgid "Sync playback to display"
+msgstr ""
+
+#: id:13550
+msgid "Pause during refresh rate change"
+msgstr ""
+
+#: id:13551
+msgctxt "Auto context with id 13551"
+msgid "Off"
+msgstr ""
+
+#: id:13552
+msgid "%.1f Second"
+msgstr ""
+
+#: id:13553
+msgid "%.1f Seconds"
+msgstr ""
+
+#: id:13600
+msgid "Apple remote"
+msgstr ""
+
+#: id:13602
+msgid "Allow start of XBMC using the remote"
+msgstr ""
+
+#: id:13603
+msgid "Sequence delay time"
+msgstr ""
+
+#: id:13610
+msgctxt "Auto context with id 13610"
+msgid "Disabled"
+msgstr ""
+
+#: id:13611
+msgctxt "Auto context with id 13611"
+msgid "Standard"
+msgstr ""
+
+#: id:13612
+msgid "Universal Remote"
+msgstr ""
+
+#: id:13613
+msgid "Multi Remote (Harmony)"
+msgstr ""
+
+#: id:13620
+msgid "Apple Remote Error"
+msgstr ""
+
+#: id:13621
+msgid "Apple Remote support could be enabled."
+msgstr ""
+
+#: id:14000
+msgid "Stack"
+msgstr "Stack"
+
+#: id:14001
+msgid "Unstack"
+msgstr "Unstack"
+
+#: id:14003
+msgid "Downloading playlist file..."
+msgstr "Mengunduh file Daftar Main..."
+
+#: id:14004
+msgid "Downloading streams list..."
+msgstr "Mengunduh daftar stream..."
+
+#: id:14005
+msgid "Parsing streams list..."
+msgstr "Parsing daftar stream..."
+
+#: id:14006
+msgid "Downloading streams list failed"
+msgstr "Mengunduh daftar stream gagal"
+
+#: id:14007
+msgid "Downloading playlist file failed"
+msgstr "Mengunduh file Daftar Main gagal"
+
+#: id:14009
+msgid "Games directory"
+msgstr "Direktori Permainan"
+
+#: id:14010
+msgid "Auto switch to thumbs based on"
+msgstr "Otomatis Pindah ke Thumbs"
+
+#: id:14011
+msgid "Enable auto switching to thumbs view"
+msgstr "Aktifkan Autoswitching ke Tampilan Thumbs"
+
+#: id:14012
+msgid "- Use large icons"
+msgstr "- Gunakan Ikon Besar"
+
+#: id:14013
+msgid "- Switch based on"
+msgstr "- Penggantian Berdasar"
+
+#: id:14014
+msgid "- Percentage"
+msgstr "- Persentase"
+
+#: id:14015
+msgid "No files and at least one thumb"
+msgstr "Tak ada File dan satu Thumb"
+
+#: id:14016
+msgid "At least one file and thumb"
+msgstr "Sedikitnya satu File dan Thumb"
+
+#: id:14017
+msgid "Percentage of thumbs"
+msgstr "Persentase Thumb"
+
+#: id:14018
+msgid "View options"
+msgstr "Lihat Pilihan"
+
+#: id:14019
+msgid "Change area code 1"
+msgstr "Ganti Kode Wilayah 1"
+
+#: id:14020
+msgid "Change area code 2"
+msgstr "Ganti Kode Wilayah 2"
+
+#: id:14021
+msgid "Change area code 3"
+msgstr "Ganti Kode Wilayah 3"
+
+#: id:14022
+msgctxt "Auto context with id 14022"
+msgid "Library"
+msgstr "Pustaka"
+
+#: id:14023
+msgid "No TV"
+msgstr "Tidak ada TV"
+
+#: id:14024
+msgid "Enter the nearest large town"
+msgstr "Masukkan kota besar terdekat atau kode ZIP US"
+
+#: id:14025
+msgid "Video/Audio/DVD cache - Harddisk"
+msgstr "Video/Audio/DVD Cache - Harddisk"
+
+#: id:14026
+msgid "Video cache - DVD-ROM"
+msgstr "Video Cache - DVDRom"
+
+#: id:14027
+msgctxt "Auto context with id 14027"
+msgid "- Local Network"
+msgstr "- Jaringan Lokal"
+
+#: id:14028
+msgctxt "Auto context with id 14028"
+msgid "- Internet"
+msgstr "- Internet"
+
+#: id:14030
+msgid "Audio cache - DVD-ROM"
+msgstr "Audio Cache - DVDRom"
+
+#: id:14031
+msgctxt "Auto context with id 14031"
+msgid "- Local Network"
+msgstr "- Jaringan Lokal"
+
+#: id:14032
+msgctxt "Auto context with id 14032"
+msgid "- Internet"
+msgstr "- Internet"
+
+#: id:14034
+msgid "DVD cache - DVD-ROM"
+msgstr "DVD Cache - DVDRom"
+
+#: id:14035
+msgctxt "Auto context with id 14035"
+msgid "- Local Network"
+msgstr "- Jaringan Lokal"
+
+#: id:14036
+msgctxt "Auto context with id 14036"
+msgid "Services"
+msgstr "Server"
+
+#: id:14038
+msgid "Network settings changed"
+msgstr "Setelan Jaringan berubah"
+
+#: id:14039
+msgid "XBMC requires to restart to change your"
+msgstr "XBMC harus dimulai ulang untuk mengganti"
+
+#: id:14040
+msgid "network setup. Would you like to restart now?"
+msgstr "pemasangan setelan jaringan. Anda mau lakukan sekarang?"
+
+#: id:14041
+msgid "Internet connection bandwidth limitation"
+msgstr "Post Processing"
+
+#: id:14043
+msgid "- Shutdown while playing"
+msgstr "- Matikan saat memainkan"
+
+#: id:14044
+msgid "%i min"
+msgstr "%i mnt"
+
+#: id:14045
+msgid "%i sec"
+msgstr "%i det"
+
+#: id:14046
+msgid "%i ms"
+msgstr "%i mdet"
+
+#: id:14047
+msgid "%i %%"
+msgstr "%i %%"
+
+#: id:14048
+msgid "%i kbps"
+msgstr "%i kbps"
+
+#: id:14049
+msgid "%i kb"
+msgstr "%i kb"
+
+#: id:14050
+msgid "%i.0 dB"
+msgstr "%i.0 dB"
+
+#: id:14051
+msgid "Time format"
+msgstr "Format Waktu"
+
+#: id:14052
+msgid "Date format"
+msgstr "Format Tanggal"
+
+#: id:14053
+msgid "GUI filters"
+msgstr "Filter GUI"
+
+#: id:14055
+msgid "Use background scanning"
+msgstr "Gunakan Scanning Latar"
+
+#: id:14056
+msgid "Stop scan"
+msgstr "Hentikan Scan"
+
+#: id:14057
+msgid "Not possible while scanning for media info"
+msgstr "Tidak memungkinkan saat men-scan info media"
+
+#: id:14058
+msgid "Film grain effect"
+msgstr "Efek Film Grain"
+
+#: id:14059
+msgid "Search for thumbnails on remote shares"
+msgstr "Mencari custom thumbnails pada remote shares"
+
+#: id:14060
+msgid "Unknown type cache - Internet"
+msgstr "Tipe Cache Tidak Diketahui- Internet"
+
+#: id:14061
+msgctxt "Auto context with id 14061"
+msgid "Auto"
+msgstr "Auto"
+
+#: id:14062
+msgid "Enter username for"
+msgstr "Masukkan namapengguna utk"
+
+#: id:14063
+msgid "Date & time"
+msgstr "Tanggal & Jam"
+
+#: id:14064
+msgid "Set date"
+msgstr "Pasang Tanggal"
+
+#: id:14065
+msgid "Set time"
+msgstr "Pasang Waktu"
+
+#: id:14066
+msgid "Enter the time in 24 hour HH:MM format"
+msgstr "Masukkan Waktu dalam format 24 jam HH:MM"
+
+#: id:14067
+msgid "Enter the date in DD/MM/YYYY format"
+msgstr "Masukkan Tanggal dalam format DD/MM/YYYY"
+
+#: id:14068
+msgid "Enter the IP address"
+msgstr "Masukkan Alamat IP"
+
+#: id:14069
+msgid "Apply these settings now?"
+msgstr "Anda ingin memasang setelan ini sekarang?"
+
+#: id:14070
+msgid "Apply changes now"
+msgstr "Pasang Perubahan Sekarang"
+
+#: id:14071
+msgid "Allow file renaming and deletion"
+msgstr "Mengijinkan Perubahan Nama File dan Penghapusan"
+
+#: id:14074
+msgid "Set timezone"
+msgstr ""
+
+#: id:14075
+msgid "Use daylight saving time"
+msgstr ""
+
+#: id:14076
+msgid "Add to favourites"
+msgstr ""
+
+#: id:14077
+msgid "Remove from favourites"
+msgstr ""
+
+#: id:14078
+msgctxt "Auto context with id 14078"
+msgid "- Colours"
+msgstr ""
+
+#: id:14079
+msgid "Timezone country"
+msgstr ""
+
+#: id:14080
+msgid "Timezone"
+msgstr ""
+
+#: id:14081
+msgid "File lists"
+msgstr ""
+
+#: id:14082
+msgid "Show EXIF picture information"
+msgstr ""
+
+#: id:14083
+msgid "Use a fullscreen window rather than true fullscreen"
+msgstr ""
+
+#: id:14084
+msgid "Queue songs on selection"
+msgstr ""
+
+#: id:14086
+msgid "Playback"
+msgstr ""
+
+#: id:14087
+msgid "DVDs"
+msgstr ""
+
+#: id:14088
+msgid "Play DVDs automatically"
+msgstr ""
+
+#: id:14089
+msgid "Font to use for text subtitles"
+msgstr ""
+
+#: id:14090
+msgid "International"
+msgstr ""
+
+#: id:14091
+msgid "Character set"
+msgstr ""
+
+#: id:14092
+msgid "Debugging"
+msgstr ""
+
+#: id:14093
+msgid "Security"
+msgstr ""
+
+#: id:14094
+msgid "Input devices"
+msgstr ""
+
+#: id:14095
+msgid "Power saving"
+msgstr ""
+
+#: id:14096
+msgid "Rip"
+msgstr ""
+
+#: id:14097
+msgid "Audio CD Insert Action"
+msgstr ""
+
+#: id:14098
+msgctxt "Auto context with id 14098"
+msgid "Play"
+msgstr ""
+
+#: id:14099
+msgid "Eject disc when CD ripping is complete"
+msgstr ""
+
+#: id:15015
+msgctxt "Auto context with id 15015"
+msgid "Remove"
+msgstr "Hapus"
+
+#: id:15016
+msgid "Games"
+msgstr "Permainan"
+
+#: id:15019
+msgid "Add"
+msgstr "Tambah"
+
+#: id:15052
+msgid "Password"
+msgstr "Password"
+
+#: id:15100
+msgctxt "Auto context with id 15100"
+msgid "Library"
+msgstr "Pustaka"
+
+#: id:15101
+msgid "Database"
+msgstr "Database"
+
+#: id:15102
+msgid "* All albums"
+msgstr "* Semua Album"
+
+#: id:15103
+msgid "* All artists"
+msgstr "* Semua Artis"
+
+#: id:15104
+msgid "* All songs"
+msgstr "* Semua Lagu"
+
+#: id:15105
+msgid "* All genres"
+msgstr "* Semua Aliran"
+
+#: id:15107
+msgid "Buffering..."
+msgstr "Buffering..."
+
+#: id:15108
+msgid "Navigation sounds"
+msgstr "Navigasi Suara"
+
+#: id:15109
+msgid "Skin default"
+msgstr "Kulit Standar"
+
+#: id:15111
+msgid "- Theme"
+msgstr "Tema Kulit"
+
+#: id:15112
+msgid "Default theme"
+msgstr "Kulit Standar"
+
+#: id:15200
+msgid "Last.fm"
+msgstr "LastFM"
+
+#: id:15201
+msgid "Submit songs to Last.fm"
+msgstr "Ajukan Lagu ke LastFM"
+
+#: id:15202
+msgid "Last.fm username"
+msgstr "NamaPengguna LastFM"
+
+#: id:15203
+msgid "Last.fm password"
+msgstr "Password LastFM"
+
+#: id:15204
+msgid "Unable to handshake: sleeping..."
+msgstr "Tidak bisa tersambung: sleeping..."
+
+#: id:15205
+msgid "Please update XBMC"
+msgstr "Harap Memperbaharui XBMC"
+
+#: id:15206
+msgid "Bad authorization: Check username and password"
+msgstr "Pengajuan gagal: kesalahan otorisasi."
+
+#: id:15207
+msgctxt "Auto context with id 15207"
+msgid "Connected"
+msgstr "Tersambung"
+
+#: id:15208
+msgid "Not connected"
+msgstr "Tidak Tersambung"
+
+#: id:15209
+msgid "Submit interval %i"
+msgstr "Psang Jeda %i"
+
+#: id:15210
+msgid "Cached %i songs"
+msgstr "Cached %i Lagu"
+
+#: id:15211
+msgid "Submitting..."
+msgstr "Pengajuan..."
+
+#: id:15212
+msgid "Submitting in %i secs"
+msgstr "Pengajuan dalam %i detik"
+
+#: id:15213
+msgid "Play using..."
+msgstr "Mainkan Menggunakan..."
+
+#: id:15214
+msgid "Use smoothed A/V synchronization"
+msgstr "Gunakan Sinkronisasi A/V halus"
+
+#: id:15215
+msgid "Hide file names in thumbs view"
+msgstr "Sembunyikan Nama File pada Tampilan Thumb"
+
+#: id:15216
+msgid "Play in party mode"
+msgstr ""
+
+#: id:15217
+msgid "Submit songs to Libre.fm"
+msgstr ""
+
+#: id:15218
+msgid "Libre.fm username"
+msgstr ""
+
+#: id:15219
+msgid "Libre.fm password"
+msgstr ""
+
+#: id:15220
+msgid "Libre.fm"
+msgstr ""
+
+#: id:15221
+msgid "Song submission"
+msgstr ""
+
+#: id:15250
+msgid "Submit Last.fm radio to Last.fm"
+msgstr "Ajukan Last.fm Radio ke LastFM"
+
+#: id:15251
+msgid "Connecting to Last.fm..."
+msgstr "Menyambungkan diri ke Last.fm..."
+
+#: id:15252
+msgid "Selecting station..."
+msgstr "Pilih stasiun..."
+
+#: id:15253
+msgid "Search similar artists..."
+msgstr "Cari artis serupa..."
+
+#: id:15254
+msgid "Search similar tags..."
+msgstr "Cari tag serupa..."
+
+#: id:15255
+msgid "Your profile (%name%)"
+msgstr "Profil Anda (%name%)"
+
+#: id:15256
+msgid "Overall top tags"
+msgstr "Keseluruhan top tag"
+
+#: id:15257
+msgid "Top artists for tag %name%"
+msgstr "Top artis utk tag %name%"
+
+#: id:15258
+msgid "Top albums for tag %name%"
+msgstr "Top album utk tag %name%"
+
+#: id:15259
+msgid "Top tracks for tag %name%"
+msgstr "Top trek utk tag %name%"
+
+#: id:15260
+msgid "Listen to tag %name% Last.fm radio"
+msgstr "Mendengarkan tag %name% last.fm radio"
+
+#: id:15261
+msgid "Similar artists as %name%"
+msgstr "Artis serupa %name%"
+
+#: id:15262
+msgid "Top %name% albums"
+msgstr "Top %name% album"
+
+#: id:15263
+msgid "Top %name% tracks"
+msgstr "Top %name% trek"
+
+#: id:15264
+msgid "Top %name% tags"
+msgstr "Top %name% tag"
+
+#: id:15265
+msgid "Biggest fans of %name%"
+msgstr "Biggest fans of %name%"
+
+#: id:15266
+msgid "Listen to %name% fans Last.fm radio"
+msgstr "Mendengarkan fan %name% last.fm radio"
+
+#: id:15267
+msgid "Listen to %name% similar artists Last.fm radio"
+msgstr "Mendengarkan %name% artis serupa last.fm radio"
+
+#: id:15268
+msgid "Top artists for user %name%"
+msgstr "Top artis utk pengguna %name%"
+
+#: id:15269
+msgid "Top albums for user %name%"
+msgstr "Top album utk pengguna %name%"
+
+#: id:15270
+msgid "Top tracks for user %name%"
+msgstr "Top trek utk pengguna %name%"
+
+#: id:15271
+msgid "Friends of user %name%"
+msgstr "Teman pengguna %name%"
+
+#: id:15272
+msgid "Neighbours of user %name%"
+msgstr "Tetangga pengguna %name%"
+
+#: id:15273
+msgid "Weekly artist chart for %name%"
+msgstr "Tangga artis mingguan %name%"
+
+#: id:15274
+msgid "Weekly album chart for %name%"
+msgstr "Tangga album mingguan %name%"
+
+#: id:15275
+msgid "Weekly track chart for %name%"
+msgstr "Tangga trek mingguan %name%"
+
+#: id:15276
+msgid "Listen to %name%'s neighbours Last.fm radio"
+msgstr "Mendengarkan %name%'s neighbours last.fm radio"
+
+#: id:15277
+msgid "Listen to %name%'s personal Last.fm radio"
+msgstr "Mendengarkan %name%'s personal last.fm radio"
+
+#: id:15278
+msgid "Listen to %name%'s mix Last.fm radio"
+msgstr "Mendengarkan %name%'s loved tracks last.fm radio"
+
+#: id:15279
+msgid "Retrieving list from Last.fm..."
+msgstr "Mendapatkan daftar dari last.fm..."
+
+#: id:15280
+msgid "Can't retrieve list from Last.fm..."
+msgstr "Tidak bisa mendapatkan daftar dari last.fm..."
+
+#: id:15281
+msgid "Enter an artist name to find related ones"
+msgstr "Masukkan nama artis untuk menemukan yang mirip"
+
+#: id:15282
+msgid "Enter a tag name to find similar ones"
+msgstr "Masukkan nama tag untuk menemukan yang mirip"
+
+#: id:15283
+msgid "Tracks recently listened by %name%"
+msgstr "Trek baru saja didengarkan oleh %name%"
+
+#: id:15284
+msgid "Listen to %name%'s recommendations Last.fm radio"
+msgstr ""
+
+#: id:15285
+msgid "Top tags for user %name%"
+msgstr ""
+
+#: id:15287
+msgid "Do you want to add the current track to your loved tracks?"
+msgstr ""
+
+#: id:15288
+msgid "Do you want to ban the current track?"
+msgstr ""
+
+#: id:15289
+msgid "Added to your loved tracks: '%s'."
+msgstr ""
+
+#: id:15290
+msgid "Could not add '%s' to your loved tracks."
+msgstr ""
+
+#: id:15291
+msgid "Banned: '%s'."
+msgstr ""
+
+#: id:15292
+msgid "Could not ban '%s'."
+msgstr ""
+
+#: id:15293
+msgid "Tracks recently loved by %name%"
+msgstr ""
+
+#: id:15294
+msgid "Tracks recently banned by %name%"
+msgstr ""
+
+#: id:15295
+msgid "Remove from loved tracks"
+msgstr ""
+
+#: id:15296
+msgid "Un-ban"
+msgstr ""
+
+#: id:15297
+msgid "Do you want to remove this track from your loved tracks?"
+msgstr ""
+
+#: id:15298
+msgid "Do you want to un-ban this track?"
+msgstr ""
+
+#: id:15300
+msgid "Path not found or invalid"
+msgstr "Path tidak ditemukan atau tidak valid"
+
+#: id:15301
+msgid "Could not connect to network server"
+msgstr "Tidak bisa tersambung ke jaringan server"
+
+#: id:15302
+msgid "No servers found"
+msgstr "Server tidak ditemukan"
+
+#: id:15303
+msgid "Workgroup not found"
+msgstr "Workgroup tidak ditemukan"
+
+#: id:15310
+msgid "Opening multi-path source"
+msgstr "Membuka bookmark multi-path"
+
+#: id:15311
+msgid "Path:"
+msgstr "Path:"
+
+#: id:16000
+msgctxt "Auto context with id 16000"
+msgid "General"
+msgstr "Umum"
+
+#: id:16002
+msgid "Internet lookup"
+msgstr "CDDB lookup"
+
+#: id:16003
+msgid "Player"
+msgstr "Player"
+
+#: id:16004
+msgid "Play media from disc"
+msgstr "Mainkan media dari disk"
+
+#: id:16008
+msgid "Enter new title"
+msgstr ""
+
+#: id:16009
+msgid "Enter the movie name"
+msgstr "Masukkan Judul Film"
+
+#: id:16010
+msgid "Enter the profile name"
+msgstr "Masukkan Nama Profil"
+
+#: id:16011
+msgid "Enter the album name"
+msgstr "Masukkan Nama Album"
+
+#: id:16012
+msgid "Enter the playlist name"
+msgstr "Masukkan Nama Daftar Main"
+
+#: id:16013
+msgid "Enter new filename"
+msgstr "Masukkan namafile baru"
+
+#: id:16014
+msgid "Enter folder name"
+msgstr "Masukkan nama folder"
+
+#: id:16015
+msgid "Enter directory"
+msgstr "Masukkan direktori"
+
+#: id:16016
+msgid "Available options: %A, %T, %N, %B, %D, %G, %Y, %F, %S"
+msgstr "Pilihan yg tersedia: %A, %T, %N, %B, %D, %G, %Y, %F, %S"
+
+#: id:16017
+msgid "Enter search string"
+msgstr "Masukkan Pencarian"
+
+#: id:16018
+msgctxt "Auto context with id 16018"
+msgid "None"
+msgstr "Tidak Ada"
+
+#: id:16019
+msgid "Auto select"
+msgstr "Memilih Sendiri"
+
+#: id:16020
+msgid "De-interlace"
+msgstr "DeInterlace"
+
+#: id:16021
+msgid "Bob"
+msgstr "Sinkronisasi Ganjil"
+
+#: id:16022
+msgid "Bob (inverted)"
+msgstr "Sinkronisasi Genap"
+
+#: id:16024
+msgid "Canceling..."
+msgstr "Pembatalan..."
+
+#: id:16025
+msgid "Enter the artist name"
+msgstr "Masukkan Nama Artis"
+
+#: id:16026
+msgid "Playback failed"
+msgstr "Memainkan Daftar Main dibatalkan"
+
+#: id:16027
+msgid "One or more items failed to play."
+msgstr "Terlalu banyak berturutan menggagalkan item"
+
+#: id:16028
+msgid "Enter value"
+msgstr ""
+
+#: id:16029
+msgid "Check the log file for details."
+msgstr ""
+
+#: id:16030
+msgid "Party mode aborted."
+msgstr "Mode Party dibatalkan."
+
+#: id:16031
+msgid "No matching songs in the library."
+msgstr "Tidak ada lagu yang sesuai di database."
+
+#: id:16032
+msgid "Could not initialize database."
+msgstr "Tidak bisa meng-inisilisasi database."
+
+#: id:16033
+msgid "Could not open database."
+msgstr "Tidak bisa membuka database."
+
+#: id:16034
+msgid "Could not get songs from database."
+msgstr "Tidak bisa memperoleh lagu dari database."
+
+#: id:16035
+msgid "Party mode playlist"
+msgstr ""
+
+#: id:16036
+msgid "De-interlace (Half)"
+msgstr ""
+
+#: id:16037
+msgid "Deinterlace video"
+msgstr ""
+
+#: id:16038
+msgid "Deinterlace method"
+msgstr ""
+
+#: id:16039
+msgctxt "Auto context with id 16039"
+msgid "Off"
+msgstr ""
+
+#: id:16040
+msgctxt "Auto context with id 16040"
+msgid "Auto"
+msgstr ""
+
+#: id:16041
+msgid "On"
+msgstr ""
+
+#: id:16100
+msgid "All Videos"
+msgstr "Semua Video"
+
+#: id:16101
+msgid "Unwatched"
+msgstr "Belum Ditonton"
+
+#: id:16102
+msgid "Watched"
+msgstr "Telah Ditonton"
+
+#: id:16103
+msgid "Mark as watched"
+msgstr "Tandai Telah Ditonton"
+
+#: id:16104
+msgid "Mark as unwatched"
+msgstr "Tandai Belum Ditonton"
+
+#: id:16105
+msgid "Edit title"
+msgstr "Edit Judul"
+
+#: id:16200
+msgid "Operation was aborted"
+msgstr "Operasi dibatalkan"
+
+#: id:16201
+msgid "Copy failed"
+msgstr "Penyalinan gagal"
+
+#: id:16202
+msgid "Failed to copy at least one file"
+msgstr "Gagal untuk menyalin sedikitnya satu file"
+
+#: id:16203
+msgid "Move failed"
+msgstr "Pemindahan gagal"
+
+#: id:16204
+msgid "Failed to move at least one file"
+msgstr "Gagal untuk memindahkan sedikitnya satu file"
+
+#: id:16205
+msgid "Delete failed"
+msgstr "Penghapusan gagal"
+
+#: id:16206
+msgid "Failed to delete at least one file"
+msgstr "Gagal untuk menghapus sedikitnya satu file"
+
+#: id:16300
+msgid "Video scaling method"
+msgstr ""
+
+#: id:16301
+msgid "Nearest neighbour"
+msgstr ""
+
+#: id:16302
+msgid "Bilinear"
+msgstr ""
+
+#: id:16303
+msgctxt "Auto context with id 16303"
+msgid "Bicubic"
+msgstr ""
+
+#: id:16304
+msgid "Lanczos2"
+msgstr ""
+
+#: id:16305
+msgid "Lanczos3"
+msgstr ""
+
+#: id:16306
+msgid "Sinc8"
+msgstr ""
+
+#: id:16307
+msgid "Bicubic (software)"
+msgstr ""
+
+#: id:16308
+msgid "Lanczos (software)"
+msgstr ""
+
+#: id:16309
+msgid "Sinc (software)"
+msgstr ""
+
+#: id:16310
+msgid "Temporal"
+msgstr ""
+
+#: id:16311
+msgid "Temporal/Spatial"
+msgstr ""
+
+#: id:16312
+msgid "(VDPAU)Noise Reduction"
+msgstr ""
+
+#: id:16313
+msgid "(VDPAU)Sharpness"
+msgstr ""
+
+#: id:16314
+msgid "Inverse Telecine"
+msgstr ""
+
+#: id:16315
+msgid "Lanczos3 optimized"
+msgstr ""
+
+#: id:16316
+msgctxt "Auto context with id 16316"
+msgid "Auto"
+msgstr ""
+
+#: id:16317
+msgid "Temporal (Half)"
+msgstr ""
+
+#: id:16318
+msgid "Temporal/Spatial (Half)"
+msgstr ""
+
+#: id:16319
+msgid "DXVA"
+msgstr ""
+
+#: id:16320
+msgid "DXVA Bob"
+msgstr ""
+
+#: id:16321
+msgid "DXVA Best"
+msgstr ""
+
+#: id:16322
+msgid "Spline36"
+msgstr ""
+
+#: id:16323
+msgid "Spline36 optimized"
+msgstr ""
+
+#: id:16324
+msgid "Software Blend"
+msgstr ""
+
+#: id:16400
+msgid "Post-processing"
+msgstr ""
+
+#: id:17500
+msgid "Display sleep timeout"
+msgstr ""
+
+#: id:19000
+msgid "Switch to channel"
+msgstr ""
+
+#: id:20000
+msgid "Saved music folder"
+msgstr "Folder CDDA Rip"
+
+#: id:20001
+msgid "Use external DVD player"
+msgstr "Gunakan Player DVD eksternal"
+
+#: id:20002
+msgid "External DVD player"
+msgstr "Player DVD Eksternal"
+
+#: id:20003
+msgid "Trainers folder"
+msgstr "Folder Trainer"
+
+#: id:20004
+msgid "Screenshot folder"
+msgstr "Folder Screenshot"
+
+#: id:20006
+msgid "Playlists folder"
+msgstr "Folder DaftarMain"
+
+#: id:20007
+msgid "Recordings"
+msgstr "Perekaman"
+
+#: id:20008
+msgid "Screenshots"
+msgstr "Screenshots"
+
+#: id:20009
+msgid "Use XBMC"
+msgstr "Gunakan XBMC"
+
+#: id:20011
+msgid "Music playlists"
+msgstr "DaftarMain Musik"
+
+#: id:20012
+msgid "Video playlists"
+msgstr "DaftarMain Video"
+
+#: id:20013
+msgid "Do you wish to launch the game?"
+msgstr "Anda ingin menjalankan permainan?"
+
+#: id:20014
+msgid "Sort by: Playlist"
+msgstr "Urut :DaftarMain"
+
+#: id:20015
+msgid "Remote thumb"
+msgstr "IMDb Thumb"
+
+#: id:20016
+msgid "Current thumb"
+msgstr "Thumb Saat ini"
+
+#: id:20017
+msgid "Local thumb"
+msgstr "Thumb Lokal"
+
+#: id:20018
+msgid "No thumb"
+msgstr "Tidak Ada Thumb"
+
+#: id:20019
+msgid "Choose thumbnail"
+msgstr "Pilih Thumb"
+
+#: id:20023
+msgid "Conflict"
+msgstr "Konflik"
+
+#: id:20024
+msgid "Scan new"
+msgstr "Pindai Baru"
+
+#: id:20025
+msgid "Scan all"
+msgstr "Pindai Semua"
+
+#: id:20026
+msgid "Region"
+msgstr "Wilayah"
+
+#: id:20037
+msgid "Summary"
+msgstr ""
+
+#: id:20038
+msgid "Lock music window"
+msgstr "Kunci seksi musik"
+
+#: id:20039
+msgid "Lock videos window"
+msgstr "Kunci seksi video"
+
+#: id:20040
+msgid "Lock pictures window"
+msgstr "Kunci seksi gambar"
+
+#: id:20041
+msgid "Lock programs & scripts windows"
+msgstr "Kunci seksi program dan skrip"
+
+#: id:20042
+msgid "Lock file manager"
+msgstr "Kunci Manajer Berkas"
+
+#: id:20043
+msgid "Lock settings"
+msgstr "Setting Penguncian"
+
+#: id:20044
+msgid "Start fresh"
+msgstr "Memulai Secara Fresh"
+
+#: id:20045
+msgid "Enter master mode"
+msgstr "Masuk mode mastrer"
+
+#: id:20046
+msgid "Leave master mode"
+msgstr "Meninggalkan mode master"
+
+#: id:20047
+msgid "Create profile '%s'?"
+msgstr "Buat profil '%s' ?"
+
+#: id:20048
+msgid "Start with fresh settings"
+msgstr "Mulai dengan setting fresh"
+
+#: id:20049
+msgid "Best available"
+msgstr "Terbaik yg Tersedia"
+
+#: id:20050
+msgid "Auto-switch between 16x9 and 4x3"
+msgstr "Otomatis berganti anatara 16x9 dan 4x3"
+
+#: id:20051
+msgid "Treat stacked files as single file"
+msgstr "Perlakukan file stek sebagai file tunggal"
+
+#: id:20052
+msgid "Caution"
+msgstr "Peringatan"
+
+#: id:20053
+msgid "Left master mode"
+msgstr "Tinggalkan mode master"
+
+#: id:20054
+msgid "Entered master mode"
+msgstr "Masuk mode master"
+
+#: id:20055
+msgid "Allmusic.com thumb"
+msgstr "Thumb Allmusic.com"
+
+#: id:20057
+msgid "Remove thumbnail"
+msgstr "Hapus Thumbnail"
+
+#: id:20058
+msgid "Add profile..."
+msgstr "Tambah Profil..."
+
+#: id:20059
+msgid "Query info for all albums"
+msgstr "Meminta Info Semua Album"
+
+#: id:20060
+msgctxt "Auto context with id 20060"
+msgid "Media info"
+msgstr "Informasi Media"
+
+#: id:20061
+msgctxt "Auto context with id 20061"
+msgid "Separate"
+msgstr "Pisahkan"
+
+#: id:20062
+msgid "Shares with default"
+msgstr "Berbagi dengan standar"
+
+#: id:20063
+msgid "Shares with default (read only)"
+msgstr "Berbagi dengan standar (hanya baca)"
+
+#: id:20064
+msgid "Copy default"
+msgstr "Salin standar"
+
+#: id:20065
+msgid "Profile picture"
+msgstr "Gambar Profil"
+
+#: id:20066
+msgid "Lock preferences"
+msgstr "Kunci pilihan"
+
+#: id:20067
+msgid "Edit profile"
+msgstr "Edit profil"
+
+#: id:20068
+msgid "Profile lock"
+msgstr "Kunci Profil"
+
+#: id:20069
+msgid "Could not create folder"
+msgstr "Tidak bisa membuat folder"
+
+#: id:20070
+msgid "Profile directory"
+msgstr "Direktori profil"
+
+#: id:20071
+msgid "Start with fresh media sources"
+msgstr "Mulai dengan sumber media segar"
+
+#: id:20072
+msgid "Make sure the selected folder is writable"
+msgstr "Yakinkan folder yang dipilih bisa ditulisi"
+
+#: id:20073
+msgid "and that the new folder name is valid"
+msgstr "dan nama folder baru tsb valid"
+
+#: id:20074
+msgid "MPAA rating"
+msgstr "Nilai MPAA:"
+
+#: id:20075
+msgid "Enter master lock code"
+msgstr "Masukkan kunci kode master"
+
+#: id:20076
+msgid "Ask for master lock code on startup"
+msgstr "Tanya kode master saat memulai"
+
+#: id:20077
+msgid "Skin settings"
+msgstr "Setelan Kulit"
+
+#: id:20078
+msgid "- no link set -"
+msgstr "- tak ada link dipasang -"
+
+#: id:20079
+msgid "Enable animations"
+msgstr "Membolehkan Animasi"
+
+#: id:20080
+msgid "Disable RSS during music"
+msgstr "Nonaktifkan RSS saat musik"
+
+#: id:20081
+msgid "Enable shortcut buttons"
+msgstr "Membolehkan Tombol Bookmark"
+
+#: id:20082
+msgid "Show programs in main menu"
+msgstr "Tampilkan Info XLink Kai"
+
+#: id:20083
+msgid "Show music info"
+msgstr "Tampilkan info Music"
+
+#: id:20084
+msgid "Show weather info"
+msgstr "Tampilkan info Cuaca"
+
+#: id:20085
+msgid "Show system info"
+msgstr "Tampilkan info Sistem"
+
+#: id:20086
+msgid "Show available disc space C: E: F:"
+msgstr "Tampilkan Ruang Disk Tersedia C: E: F:"
+
+#: id:20087
+msgid "Show available disc space E: F: G:"
+msgstr "Tampilkan Ruang Disk Tersedia E: F: G:"
+
+#: id:20088
+msgid "Weather info"
+msgstr "Info Cuaca"
+
+#: id:20089
+msgid "Drive space free"
+msgstr "Ruang Drive Bebas"
+
+#: id:20090
+msgid "Enter the name of an existing share"
+msgstr "Masukkan nama Share yang ada"
+
+#: id:20091
+msgid "Lock code"
+msgstr "Kode Penguncian"
+
+#: id:20092
+msgid "Load profile"
+msgstr "Muat Profil"
+
+#: id:20093
+msgid "Profile name"
+msgstr "Nama profil"
+
+#: id:20094
+msgctxt "Auto context with id 20094"
+msgid "Media sources"
+msgstr "Sumber Media"
+
+#: id:20095
+msgid "Enter profile lock code"
+msgstr "Masukkan kode kunci profil"
+
+#: id:20096
+msgctxt "Auto context with id 20096"
+msgid "Login screen"
+msgstr "Layar Masuk"
+
+#: id:20097
+msgid "Fetching album info"
+msgstr "Mengambil info album"
+
+#: id:20098
+msgid "Fetching info for album"
+msgstr "Mengambil info untuk album"
+
+#: id:20099
+msgid "Can't rip CD or track while playing from CD"
+msgstr "Tidak dapat melakukan ripping CD atau Trek saat memainkan CD"
+
+#: id:20100
+msgid "Master lock code and settings"
+msgstr "Kunci dan Kode Master"
+
+#: id:20101
+msgid "Entering master lock code always enables master mode"
+msgstr "Memasukan kode master selalu membolehkan mode master"
+
+#: id:20102
+msgid "or copy from default?"
+msgstr "atau salin dari standar"
+
+#: id:20103
+msgid "Save changes to profile?"
+msgstr "Simpan perubahan ke profil?"
+
+#: id:20104
+msgid "Old settings found."
+msgstr "Setelan lama ditemukan"
+
+#: id:20105
+msgid "Do you want to use them?"
+msgstr "Anda ingin menggunakannya?"
+
+#: id:20106
+msgid "Old media sources found."
+msgstr "Sumber media lama ditemukan."
+
+#: id:20107
+msgid "Separate (locked)"
+msgstr "Pemisahan (dikunci)"
+
+#: id:20108
+msgid "Root"
+msgstr "Akar"
+
+#: id:20109
+msgid "- Zoom"
+msgstr "Zoom Kulit"
+
+#: id:20110
+msgid "UPnP settings"
+msgstr "Klien UPnP"
+
+#: id:20111
+msgid "Autostart UPnP client"
+msgstr "Memulai Sendiri"
+
+#: id:20112
+msgid "Last login: %s"
+msgstr "Login terakhir: %s"
+
+#: id:20113
+msgid "Never logged on"
+msgstr "Tidak pernah login"
+
+#: id:20114
+msgid "Profile %i / %i"
+msgstr "Profil %i / %i"
+
+#: id:20115
+msgid "User login / Select a profile"
+msgstr "Login Pengguna / Pilih profil"
+
+#: id:20116
+msgid "Use lock on login screen"
+msgstr "Gunakan penguncian saat layar masuk"
+
+#: id:20117
+msgid "Invalid lock code."
+msgstr "Kode kunci salah"
+
+#: id:20118
+msgid "This requires the master lock to be set."
+msgstr "Melakukan ini membutuhkan pemasangan kunci master."
+
+#: id:20119
+msgid "Would you like to set it now?"
+msgstr "Anda ingin memasannya sekarang?"
+
+#: id:20120
+msgid "Loading program information"
+msgstr "Memuat informasi program"
+
+#: id:20121
+msgid "Party on!"
+msgstr "Mode Party mulai!"
+
+#: id:20122
+msgid "True"
+msgstr "Ya"
+
+#: id:20123
+msgid "Mixing drinks"
+msgstr "Mixing drinks"
+
+#: id:20124
+msgid "Filling glasses"
+msgstr "Mixing drinks"
+
+#: id:20125
+msgid "Logged on as"
+msgstr "Masuk sebagai"
+
+#: id:20126
+msgid "Log off"
+msgstr "Keluar"
+
+#: id:20128
+msgid "Go to root"
+msgstr "Kembali ke akar"
+
+#: id:20129
+msgid "Weave"
+msgstr "Tenunan"
+
+#: id:20130
+msgid "Weave (inverted)"
+msgstr "Tenunan (terbalik)"
+
+#: id:20131
+msgid "Blend"
+msgstr "Campuran"
+
+#: id:20132
+msgid "Restart video"
+msgstr "Ulang Video"
+
+#: id:20133
+msgid "Edit network location"
+msgstr "Edit Lokasi Jaringan"
+
+#: id:20134
+msgid "Remove network location"
+msgstr "Hapus Lokasi Jaringan"
+
+#: id:20135
+msgid "Do you want to scan the folder?"
+msgstr "Anda ingin memindai folder?"
+
+#: id:20136
+msgid "Memory unit"
+msgstr "Unit Memori"
+
+#: id:20137
+msgid "Memory unit mounted"
+msgstr "Unit Memori dimounting"
+
+#: id:20138
+msgid "Unable to mount memory unit"
+msgstr "Tidak dapat me-mounting MU"
+
+#: id:20139
+msgid "In port %i, slot %i"
+msgstr "Dalam port %i, slot %i"
+
+#: id:20140
+msgid "Lock screensaver"
+msgstr "Kunci Screensaver"
+
+#: id:20141
+msgid "Set"
+msgstr "Pasang"
+
+#: id:20142
+msgctxt "Auto context with id 20142"
+msgid "Username"
+msgstr "Nama"
+
+#: id:20143
+msgid "Enter password for"
+msgstr "Masukkan password utk"
+
+#: id:20144
+msgid "Shutdown timer"
+msgstr "Waktu Penghentian"
+
+#: id:20145
+msgid "Shutdown interval (in minutes)"
+msgstr "Jeda Penghentian (dlm menit)"
+
+#: id:20146
+msgid "Started, shutdown in %im"
+msgstr "Dimulai, penghentian dimulai %im"
+
+#: id:20147
+msgid "Shutdown in 30 minutes"
+msgstr "Penghentian dlm 30 menit"
+
+#: id:20148
+msgid "Shutdown in 60 minutes"
+msgstr "Penghentian dalam 60 menit"
+
+#: id:20149
+msgid "Shutdown in 120 minutes"
+msgstr "Penghentian dalam 120 menit"
+
+#: id:20150
+msgid "Custom shutdown timer"
+msgstr "Waktu Penghentian Kustom"
+
+#: id:20151
+msgid "Cancel shutdown timer"
+msgstr "Batalkan Waktu Penghentian"
+
+#: id:20152
+msgid "Lock preferences for %s"
+msgstr "Kunci pilihan untuk %s"
+
+#: id:20153
+msgid "Browse..."
+msgstr "Jelajah..."
+
+#: id:20154
+msgid "Summary information"
+msgstr "Informasi Dasar"
+
+#: id:20155
+msgid "Storage information"
+msgstr "Informasi Penyimpanan"
+
+#: id:20156
+msgid "Hard disk information"
+msgstr "Informasi Hard Disk"
+
+#: id:20157
+msgid "DVD-ROM information"
+msgstr "Informasi VD-ROM"
+
+#: id:20158
+msgid "Network information"
+msgstr "Informasi Jaringan"
+
+#: id:20159
+msgid "Video information"
+msgstr "Informasi Video"
+
+#: id:20160
+msgid "Hardware information"
+msgstr "Informasi Perangkat Keras"
+
+#: id:20161
+msgid "Total"
+msgstr "Total: %s MB, Digunakan: %s MB, Bebas: %s MB"
+
+#: id:20162
+msgid "Used"
+msgstr "Total HDD Digunakan: %u%% Bebas: %u%%"
+
+#: id:20163
+msgid "of"
+msgstr "%s: %s MB of %s MB Bebas"
+
+#: id:20164
+msgid "Locking not supported"
+msgstr "Penguncian Tidak Didukung"
+
+#: id:20165
+msgid "Not locked"
+msgstr "Tidak Dikunci"
+
+#: id:20166
+msgid "Locked"
+msgstr "Dikunci"
+
+#: id:20167
+msgid "Frozen"
+msgstr "Membeku"
+
+#: id:20168
+msgid "Requires reset"
+msgstr "Membutuhkan Reset"
+
+#: id:20169
+msgid "Week"
+msgstr "Minggu"
+
+#: id:20170
+msgid "Line"
+msgstr "Baris"
+
+#: id:20171
+msgid "Windows network (SMB)"
+msgstr "Jaringan Windows (SMB)"
+
+#: id:20172
+msgid "XBMSP server"
+msgstr "Server XBMSP"
+
+#: id:20173
+msgctxt "Auto context with id 20173"
+msgid "FTP server"
+msgstr "Server FTP"
+
+#: id:20174
+msgid "iTunes music share (DAAP)"
+msgstr "iTunes music share (DAAP)"
+
+#: id:20175
+msgid "UPnP server"
+msgstr "Server UPnP"
+
+#: id:20176
+msgid "Show video info"
+msgstr "Tampilkan Informasi Video"
+
+#: id:20177
+msgid "Done"
+msgstr "Selesai"
+
+#: id:20178
+msgid "Shift"
+msgstr "Shift"
+
+#: id:20179
+msgid "Caps Lock"
+msgstr "Caps Lock"
+
+#: id:20180
+msgid "Symbols"
+msgstr "Simbol"
+
+#: id:20181
+msgid "Backspace"
+msgstr "Backspace"
+
+#: id:20182
+msgid "Space"
+msgstr "Space"
+
+#: id:20183
+msgid "Reload skin"
+msgstr "Memuat lagi skin"
+
+#: id:20184
+msgid "Rotate pictures using EXIF information"
+msgstr "Putar menggunakan informasi EXIF"
+
+#: id:20185
+msgid "Use poster view styles for TV shows"
+msgstr "Mendeteksi Nilai Perangkat Keras"
+
+#: id:20186
+msgid "Please wait"
+msgstr "Harap Tunggu"
+
+#: id:20187
+msgid "UPnP"
+msgstr "Membaca Nilai dari EEPROM"
+
+#: id:20189
+msgid "Enable auto scrolling for plot & review"
+msgstr "Pendeteksian Selesai"
+
+#: id:20190
+msgctxt "Auto context with id 20190"
+msgid "Custom"
+msgstr "Mendeteksi Informasi Harddisk"
+
+#: id:20191
+msgid "Enable debug logging"
+msgstr "Mendeteksi Nilai HDD"
+
+#: id:20192
+msgid "Download additional information during updates"
+msgstr "Mendeteksi Kunci HDD"
+
+#: id:20193
+msgid "Default service for album information"
+msgstr "Mendeteksi Suhu HDD"
+
+#: id:20194
+msgid "Default service for artist information"
+msgstr "Mendeteksi Informasi DVD-ROM"
+
+#: id:20195
+msgid "Change scraper"
+msgstr "Mendeteksi Model/Firmware"
+
+#: id:20196
+msgid "Export music library"
+msgstr "Mendeteksi Setelan Jaringan"
+
+#: id:20197
+msgid "Import music library"
+msgstr "Mendeteksi Alamat MAC"
+
+#: id:20198
+msgid "No artist found!"
+msgstr "Mendeteksi Status Online"
+
+#: id:20199
+msgid "Downloading artist info failed"
+msgstr "Mendeteksi Versi Xbox, Serial dan CPU"
+
+#: id:20250
+msgid "Party on! (videos)"
+msgstr ""
+
+#: id:20251
+msgid "Mixing drinks (videos)"
+msgstr ""
+
+#: id:20252
+msgid "Filling glasses (videos)"
+msgstr ""
+
+#: id:20253
+msgid "WebDAV server (HTTP)"
+msgstr ""
+
+#: id:20254
+msgid "WebDAV server (HTTPS)"
+msgstr ""
+
+#: id:20255
+msgid "First logon, edit your profile"
+msgstr ""
+
+#: id:20256
+msgid "HTS Tvheadend client"
+msgstr ""
+
+#: id:20257
+msgid "VDR Streamdev client"
+msgstr ""
+
+#: id:20258
+msgid "MythTV client"
+msgstr ""
+
+#: id:20259
+msgid "Network Filesystem (NFS)"
+msgstr ""
+
+#: id:20260
+msgid "Secure Shell (SSH/SFTP)"
+msgstr ""
+
+#: id:20261
+msgid "Apple Filing Protocol (AFP)"
+msgstr ""
+
+#: id:20300
+msgid "Web server directory (HTTP)"
+msgstr "Mendeteksi Perangkat Keras Xbox"
+
+#: id:20301
+msgid "Web server directory (HTTPS)"
+msgstr "Mendeteksi ModChip"
+
+#: id:20302
+msgid "Unable to write to folder:"
+msgstr "Mendeteksi BIOS"
+
+#: id:20303
+msgid "Do you want to skip and proceed?"
+msgstr "Mendeteksi Kecepatan CPU"
+
+#: id:20304
+msgid "RSS Feed"
+msgstr "Mendeteksi Tanggal Produksi"
+
+#: id:20307
+msgid "Secondary DNS"
+msgstr "Secondary DNS"
+
+#: id:20308
+msgid "DHCP server:"
+msgstr "Server DHCP:"
+
+#: id:20309
+msgid "Make new folder"
+msgstr "Buat Folder Baru"
+
+#: id:20310
+msgid "Dim LCD on playback"
+msgstr "Dim LCD saat Playback"
+
+#: id:20311
+msgid "Unknown or onboard (protected)"
+msgstr "Tidak Dikenal atau Onboard (diproteksi)"
+
+#: id:20312
+msgid "Dim LCD on paused"
+msgstr "Dim LCD saat Jeda"
+
+#: id:20314
+msgid "Videos - Library"
+msgstr ""
+
+#: id:20316
+msgid "Sort by: ID"
+msgstr ""
+
+#: id:20324
+msgid "Play part..."
+msgstr ""
+
+#: id:20325
+msgid "Calibration reset"
+msgstr ""
+
+#: id:20326
+msgid "This will reset the calibration values for %s"
+msgstr ""
+
+#: id:20327
+msgid "to it's default values."
+msgstr ""
+
+#: id:20328
+msgid "Browse for destination"
+msgstr ""
+
+#: id:20329
+msgid "Movies are in separate folders that match the movie title"
+msgstr ""
+
+#: id:20330
+msgid "Use folder names for lookups"
+msgstr ""
+
+#: id:20331
+msgctxt "Auto context with id 20331"
+msgid "File"
+msgstr ""
+
+#: id:20332
+msgid "Use file or folder names in lookups?"
+msgstr ""
+
+#: id:20333
+msgid "Set content"
+msgstr ""
+
+#: id:20334
+msgid "Folder"
+msgstr ""
+
+#: id:20335
+msgid "Look for content recursively?"
+msgstr ""
+
+#: id:20336
+msgid "Unlock sources"
+msgstr ""
+
+#: id:20337
+msgid "Actor"
+msgstr ""
+
+#: id:20338
+msgid "Movie"
+msgstr ""
+
+#: id:20339
+msgid "Director"
+msgstr ""
+
+#: id:20340
+msgid "Do you want to remove all items within"
+msgstr ""
+
+#: id:20341
+msgid "this path from the XBMC library?"
+msgstr ""
+
+#: id:20342
+msgctxt "Auto context with id 20342"
+msgid "Movies"
+msgstr ""
+
+#: id:20343
+msgid "TV shows"
+msgstr ""
+
+#: id:20344
+msgid "This directory contains"
+msgstr ""
+
+#: id:20345
+msgid "Run automated scan"
+msgstr ""
+
+#: id:20346
+msgid "Scan recursively"
+msgstr ""
+
+#: id:20347
+msgid "as"
+msgstr ""
+
+#: id:20348
+msgid "Directors"
+msgstr ""
+
+#: id:20349
+msgid "No video files found in this path!"
+msgstr ""
+
+#: id:20350
+msgid "votes"
+msgstr ""
+
+#: id:20351
+msgid "TV show information"
+msgstr ""
+
+#: id:20352
+msgid "Episode information"
+msgstr ""
+
+#: id:20353
+msgid "Loading TV show details"
+msgstr ""
+
+#: id:20354
+msgid "Fetching episode guide"
+msgstr ""
+
+#: id:20355
+msgid "Loading info for episodes in directory"
+msgstr ""
+
+#: id:20356
+msgid "Select TV show:"
+msgstr ""
+
+#: id:20357
+msgid "Enter the TV show name"
+msgstr ""
+
+#: id:20358
+msgid "Season %i"
+msgstr ""
+
+#: id:20359
+msgid "Episode"
+msgstr ""
+
+#: id:20360
+msgid "Episodes"
+msgstr ""
+
+#: id:20361
+msgid "Loading episode details"
+msgstr ""
+
+#: id:20362
+msgid "Remove episode from library"
+msgstr ""
+
+#: id:20363
+msgid "Remove TV show from library"
+msgstr ""
+
+#: id:20364
+msgid "TV show"
+msgstr ""
+
+#: id:20365
+msgid "Episode plot"
+msgstr ""
+
+#: id:20366
+msgid "* All seasons"
+msgstr ""
+
+#: id:20367
+msgid "Hide watched"
+msgstr ""
+
+#: id:20368
+msgid "Prod code"
+msgstr ""
+
+#: id:20369
+msgid "Show plot for unwatched items"
+msgstr ""
+
+#: id:20370
+msgid "* Hidden to prevent spoilers *"
+msgstr ""
+
+#: id:20371
+msgid "Set season thumb"
+msgstr ""
+
+#: id:20372
+msgid "Season image"
+msgstr ""
+
+#: id:20373
+msgid "Season"
+msgstr ""
+
+#: id:20374
+msgid "Downloading movie information"
+msgstr ""
+
+#: id:20375
+msgid "Unassign content"
+msgstr ""
+
+#: id:20376
+msgid "Original title"
+msgstr ""
+
+#: id:20377
+msgid "Refresh TV show information"
+msgstr ""
+
+#: id:20378
+msgid "Refresh info for all episodes?"
+msgstr ""
+
+#: id:20379
+msgid "Selected folder contains a single TV show"
+msgstr ""
+
+#: id:20380
+msgid "Exclude selected folder from scans"
+msgstr ""
+
+#: id:20381
+msgid "Specials"
+msgstr ""
+
+#: id:20382
+msgid "Automatically grab season thumbs"
+msgstr ""
+
+#: id:20383
+msgid "Selected folder contains a single video"
+msgstr ""
+
+#: id:20384
+msgid "Link to TV show"
+msgstr ""
+
+#: id:20385
+msgid "Remove link to TV show"
+msgstr ""
+
+#: id:20386
+msgid "Recently added movies"
+msgstr ""
+
+#: id:20387
+msgid "Recently added episodes"
+msgstr ""
+
+#: id:20388
+msgid "Studios"
+msgstr ""
+
+#: id:20389
+msgid "Music videos"
+msgstr ""
+
+#: id:20390
+msgid "Recently added music videos"
+msgstr ""
+
+#: id:20391
+msgid "Music video"
+msgstr ""
+
+#: id:20392
+msgid "Remove music video from library"
+msgstr ""
+
+#: id:20393
+msgctxt "Auto context with id 20393"
+msgid "Music video information"
+msgstr ""
+
+#: id:20394
+msgid "Loading music video information"
+msgstr ""
+
+#: id:20395
+msgid "Mixed"
+msgstr ""
+
+#: id:20396
+msgid "Go to albums by artist"
+msgstr ""
+
+#: id:20397
+msgid "Go to album"
+msgstr ""
+
+#: id:20398
+msgid "Play song"
+msgstr ""
+
+#: id:20399
+msgid "Go to music videos from album"
+msgstr ""
+
+#: id:20400
+msgid "Go to music videos by artist"
+msgstr ""
+
+#: id:20401
+msgid "Play music video"
+msgstr ""
+
+#: id:20402
+msgid "Download actor thumbnails when adding to library"
+msgstr ""
+
+#: id:20403
+msgid "Set actor thumb"
+msgstr ""
+
+#: id:20405
+msgid "Remove episode bookmark"
+msgstr ""
+
+#: id:20406
+msgid "Set episode bookmark"
+msgstr ""
+
+#: id:20407
+msgid "Scraper settings"
+msgstr ""
+
+#: id:20408
+msgid "Downloading music video information"
+msgstr ""
+
+#: id:20409
+msgid "Downloading TV show information"
+msgstr ""
+
+#: id:20410
+msgid "Trailer"
+msgstr ""
+
+#: id:20411
+msgid "Flatten"
+msgstr ""
+
+#: id:20412
+msgid "Flatten TV shows"
+msgstr ""
+
+#: id:20413
+msgid "Get fanart"
+msgstr ""
+
+#: id:20414
+msgid "Show Fanart in video and music libraries"
+msgstr ""
+
+#: id:20415
+msgid "Scanning for new content"
+msgstr ""
+
+#: id:20416
+msgid "First aired"
+msgstr ""
+
+#: id:20417
+msgid "Writer"
+msgstr ""
+
+#: id:20419
+msgid "Replace file names with library titles"
+msgstr ""
+
+#: id:20420
+msgctxt "Auto context with id 20420"
+msgid "Never"
+msgstr ""
+
+#: id:20421
+msgid "If only one season"
+msgstr ""
+
+#: id:20422
+msgid "Always"
+msgstr ""
+
+#: id:20423
+msgid "Has trailer"
+msgstr ""
+
+#: id:20424
+msgid "False"
+msgstr ""
+
+#: id:20425
+msgid "Fanart slideshow"
+msgstr ""
+
+#: id:20426
+msgid "Export to a single file or separate"
+msgstr ""
+
+#: id:20427
+msgid "files per entry?"
+msgstr ""
+
+#: id:20428
+msgid "Single file"
+msgstr ""
+
+#: id:20429
+msgctxt "Auto context with id 20429"
+msgid "Separate"
+msgstr ""
+
+#: id:20430
+msgid "Export thumbnails and fanart?"
+msgstr ""
+
+#: id:20431
+msgid "Overwrite old files?"
+msgstr ""
+
+#: id:20432
+msgid "Exclude path from library updates"
+msgstr ""
+
+#: id:20433
+msgid "Extract thumbnails and video information"
+msgstr ""
+
+#: id:20434
+msgid "Sets"
+msgstr ""
+
+#: id:20435
+msgid "Set movieset thumb"
+msgstr ""
+
+#: id:20436
+msgid "Export actor thumbs?"
+msgstr ""
+
+#: id:20437
+msgid "Choose fanart"
+msgstr ""
+
+#: id:20438
+msgid "Local fanart"
+msgstr ""
+
+#: id:20439
+msgid "No fanart"
+msgstr ""
+
+#: id:20440
+msgid "Current fanart"
+msgstr ""
+
+#: id:20441
+msgid "Remote fanart"
+msgstr ""
+
+#: id:20442
+msgid "Change content"
+msgstr ""
+
+#: id:20443
+msgid "Do you want to refresh info for all"
+msgstr ""
+
+#: id:20444
+msgid "items within this path?"
+msgstr ""
+
+#: id:20445
+msgid "Fanart"
+msgstr ""
+
+#: id:20446
+msgid "Locally stored information found."
+msgstr ""
+
+#: id:20447
+msgid "Ignore and refresh from internet?"
+msgstr ""
+
+#: id:20448
+msgid "Could not download information"
+msgstr ""
+
+#: id:20449
+msgid "Unable to connect to remote server"
+msgstr ""
+
+#: id:20450
+msgid "Would you like to continue scanning?"
+msgstr ""
+
+#: id:20451
+msgid "Countries"
+msgstr ""
+
+#: id:20452
+msgid "episode"
+msgstr ""
+
+#: id:20453
+msgid "episodes"
+msgstr ""
+
+#: id:20454
+msgid "Listener"
+msgstr ""
+
+#: id:20455
+msgid "Listeners"
+msgstr ""
+
+#: id:20456
+msgid "Set movieset fanart"
+msgstr ""
+
+#: id:20457
+msgid "Movie set"
+msgstr ""
+
+#: id:20458
+msgid "Group movies in sets"
+msgstr ""
+
+#: id:21330
+msgid "Show hidden files and directories"
+msgstr ""
+
+#: id:21331
+msgid "TuxBox client"
+msgstr ""
+
+#: id:21332
+msgid "WARNING: Target TuxBox device is in recording-mode!"
+msgstr ""
+
+#: id:21333
+msgid "The stream will be stopped!"
+msgstr ""
+
+#: id:21334
+msgid "Zap to channel: %s failed!"
+msgstr ""
+
+#: id:21335
+msgid "Are you sure to start the stream?"
+msgstr ""
+
+#: id:21336
+msgid "Connecting to: %s"
+msgstr ""
+
+#: id:21337
+msgid "TuxBox device"
+msgstr ""
+
+#: id:21359
+msgid "Add media share..."
+msgstr ""
+
+#: id:21360
+msgid "Share video and music libraries through UPnP"
+msgstr ""
+
+#: id:21364
+msgid "Edit media share"
+msgstr ""
+
+#: id:21365
+msgid "Remove media share"
+msgstr ""
+
+#: id:21366
+msgid "Subtitle folder"
+msgstr ""
+
+#: id:21367
+msgid "Movie & alternate subtitle directory"
+msgstr ""
+
+#: id:21368
+msgid "Override ASS/SSA subtitles fonts"
+msgstr ""
+
+#: id:21369
+msgid "Enable mouse and Touch Screen support"
+msgstr ""
+
+#: id:21370
+msgid "Play navigation sounds during media playback"
+msgstr ""
+
+#: id:21371
+msgid "Thumbnail"
+msgstr ""
+
+#: id:21372
+msgid "Forced DVD player region"
+msgstr ""
+
+#: id:21373
+msgid "Video output"
+msgstr ""
+
+#: id:21374
+msgid "Video aspect"
+msgstr ""
+
+#: id:21375
+msgctxt "Auto context with id 21375"
+msgid "Normal"
+msgstr ""
+
+#: id:21376
+msgid "Letterbox"
+msgstr ""
+
+#: id:21377
+msgid "Widescreen"
+msgstr ""
+
+#: id:21378
+msgid "Enable 480p"
+msgstr ""
+
+#: id:21379
+msgid "Enable 720p"
+msgstr ""
+
+#: id:21380
+msgid "Enable 1080i"
+msgstr ""
+
+#: id:21381
+msgid "Enter name of new playlist"
+msgstr ""
+
+#: id:21382
+msgid "Show \"Add source\" buttons in file lists"
+msgstr ""
+
+#: id:21383
+msgid "Enable scrollbars"
+msgstr ""
+
+#: id:21384
+msgid "Make watched filtering a toggle in video library"
+msgstr ""
+
+#: id:21385
+msgctxt "Auto context with id 21385"
+msgid "Open"
+msgstr ""
+
+#: id:21386
+msgid "Acoustic management level"
+msgstr ""
+
+#: id:21387
+msgid "Fast"
+msgstr ""
+
+#: id:21388
+msgid "Quiet"
+msgstr ""
+
+#: id:21389
+msgid "Enable custom background"
+msgstr ""
+
+#: id:21390
+msgid "Power management level"
+msgstr ""
+
+#: id:21391
+msgid "High power"
+msgstr ""
+
+#: id:21392
+msgid "Low power"
+msgstr ""
+
+#: id:21393
+msgid "High standby"
+msgstr ""
+
+#: id:21394
+msgid "Low standby"
+msgstr ""
+
+#: id:21395
+msgid "Unable to cache files bigger than 4GB"
+msgstr ""
+
+#: id:21396
+msgid "Chapter"
+msgstr ""
+
+#: id:21397
+msgid "High quality pixel shader v2"
+msgstr ""
+
+#: id:21398
+msgid "Enable playlist at startup"
+msgstr ""
+
+#: id:21399
+msgid "Use tween animations"
+msgstr ""
+
+#: id:21400
+msgid "contains"
+msgstr ""
+
+#: id:21401
+msgid "does not contain"
+msgstr ""
+
+#: id:21402
+msgid "is"
+msgstr ""
+
+#: id:21403
+msgid "is not"
+msgstr ""
+
+#: id:21404
+msgid "starts with"
+msgstr ""
+
+#: id:21405
+msgid "ends with"
+msgstr ""
+
+#: id:21406
+msgid "greater than"
+msgstr ""
+
+#: id:21407
+msgid "less than"
+msgstr ""
+
+#: id:21408
+msgid "after"
+msgstr ""
+
+#: id:21409
+msgid "before"
+msgstr ""
+
+#: id:21410
+msgid "in the last"
+msgstr ""
+
+#: id:21411
+msgid "not in the last"
+msgstr ""
+
+#: id:21412
+msgid "Scrapers"
+msgstr ""
+
+#: id:21413
+msgid "Default movie scraper"
+msgstr ""
+
+#: id:21414
+msgid "Default tvshow scraper"
+msgstr ""
+
+#: id:21415
+msgid "Default music video scraper"
+msgstr ""
+
+#: id:21416
+msgid "Enable fallback based on scraper language"
+msgstr ""
+
+#: id:21417
+msgid "- Settings"
+msgstr ""
+
+#: id:21418
+msgid "Multilingual"
+msgstr ""
+
+#: id:21419
+msgid "No scrapers present"
+msgstr ""
+
+#: id:21420
+msgid "Value to match"
+msgstr ""
+
+#: id:21421
+msgid "Smart playlist rule"
+msgstr ""
+
+#: id:21422
+msgid "Match items where"
+msgstr ""
+
+#: id:21423
+msgid "New rule..."
+msgstr ""
+
+#: id:21424
+msgid "Items must match"
+msgstr ""
+
+#: id:21425
+msgid "all of the rules"
+msgstr ""
+
+#: id:21426
+msgid "one or more of the rules"
+msgstr ""
+
+#: id:21427
+msgid "Limit to"
+msgstr ""
+
+#: id:21428
+msgid "No limit"
+msgstr ""
+
+#: id:21429
+msgid "Order by"
+msgstr ""
+
+#: id:21430
+msgid "ascending"
+msgstr ""
+
+#: id:21431
+msgid "descending"
+msgstr ""
+
+#: id:21432
+msgid "Edit smart playlist"
+msgstr ""
+
+#: id:21433
+msgid "Name of the playlist"
+msgstr ""
+
+#: id:21434
+msgid "Find items where"
+msgstr ""
+
+#: id:21435
+msgid "Edit"
+msgstr ""
+
+#: id:21436
+msgid "%i items"
+msgstr ""
+
+#: id:21437
+msgid "New smart playlist..."
+msgstr ""
+
+#: id:21438
+msgid "%c Drive"
+msgstr ""
+
+#: id:21439
+msgid "Edit party mode rules"
+msgstr ""
+
+#: id:21440
+msgid "Home folder"
+msgstr ""
+
+#: id:21441
+msgid "Watched count"
+msgstr ""
+
+#: id:21442
+msgid "Episode title"
+msgstr ""
+
+#: id:21443
+msgid "Video resolution"
+msgstr ""
+
+#: id:21444
+msgid "Audio channels"
+msgstr ""
+
+#: id:21445
+msgid "Video codec"
+msgstr ""
+
+#: id:21446
+msgid "Audio codec"
+msgstr ""
+
+#: id:21447
+msgid "Audio language"
+msgstr ""
+
+#: id:21448
+msgid "Subtitle language"
+msgstr ""
+
+#: id:21449
+msgid "Remote control sends keyboard presses"
+msgstr ""
+
+#: id:21450
+msgid "- Edit"
+msgstr ""
+
+#: id:21451
+msgid "Internet connection required."
+msgstr ""
+
+#: id:21452
+msgid "Get More..."
+msgstr ""
+
+#: id:21453
+msgid "Root filesystem"
+msgstr ""
+
+#: id:21454
+msgid "Cache full"
+msgstr ""
+
+#: id:21455
+msgid "Cache filled before reaching required amount for continous playback"
+msgstr ""
+
+#: id:21460
+msgid "Subtitle location"
+msgstr ""
+
+#: id:21461
+msgid "Fixed"
+msgstr ""
+
+#: id:21462
+msgid "Bottom of video"
+msgstr ""
+
+#: id:21463
+msgid "Below video"
+msgstr ""
+
+#: id:21464
+msgid "Top of video"
+msgstr ""
+
+#: id:21465
+msgid "Above video"
+msgstr ""
+
+#: id:21800
+msgid "File name"
+msgstr ""
+
+#: id:21801
+msgid "File path"
+msgstr ""
+
+#: id:21802
+msgid "File size"
+msgstr ""
+
+#: id:21803
+msgid "File date/time"
+msgstr ""
+
+#: id:21804
+msgid "Slide index"
+msgstr ""
+
+#: id:21805
+msgctxt "Auto context with id 21805"
+msgid "Resolution"
+msgstr ""
+
+#: id:21806
+msgctxt "Auto context with id 21806"
+msgid "Comment"
+msgstr ""
+
+#: id:21807
+msgid "Colour/B&W"
+msgstr ""
+
+#: id:21808
+msgid "JPEG process"
+msgstr ""
+
+#: id:21820
+msgid "Date/Time"
+msgstr ""
+
+#: id:21821
+msgid "Description"
+msgstr ""
+
+#: id:21822
+msgid "Camera make"
+msgstr ""
+
+#: id:21823
+msgid "Camera model"
+msgstr ""
+
+#: id:21824
+msgid "EXIF comment"
+msgstr ""
+
+#: id:21825
+msgid "Firmware"
+msgstr ""
+
+#: id:21826
+msgid "Aperture"
+msgstr ""
+
+#: id:21827
+msgid "Focal length"
+msgstr ""
+
+#: id:21828
+msgid "Focus distance"
+msgstr ""
+
+#: id:21829
+msgid "Exposure"
+msgstr ""
+
+#: id:21830
+msgid "Exposure time"
+msgstr ""
+
+#: id:21831
+msgid "Exposure bias"
+msgstr ""
+
+#: id:21832
+msgid "Exposure mode"
+msgstr ""
+
+#: id:21833
+msgid "Flash used"
+msgstr ""
+
+#: id:21834
+msgid "White-balance"
+msgstr ""
+
+#: id:21835
+msgid "Light source"
+msgstr ""
+
+#: id:21836
+msgid "Metering mode"
+msgstr ""
+
+#: id:21837
+msgid "ISO"
+msgstr ""
+
+#: id:21838
+msgid "Digital zoom"
+msgstr ""
+
+#: id:21839
+msgid "CCD width"
+msgstr ""
+
+#: id:21840
+msgid "GPS latitude"
+msgstr ""
+
+#: id:21841
+msgid "GPS longitude"
+msgstr ""
+
+#: id:21842
+msgid "GPS altitude"
+msgstr ""
+
+#: id:21843
+msgid "Orientation"
+msgstr ""
+
+#: id:21860
+msgid "Supplemental categories"
+msgstr ""
+
+#: id:21861
+msgid "Keywords"
+msgstr ""
+
+#: id:21862
+msgid "Caption"
+msgstr ""
+
+#: id:21863
+msgid "Author"
+msgstr ""
+
+#: id:21864
+msgid "Headline"
+msgstr ""
+
+#: id:21865
+msgid "Special instructions"
+msgstr ""
+
+#: id:21866
+msgid "Category"
+msgstr ""
+
+#: id:21867
+msgid "Byline"
+msgstr ""
+
+#: id:21868
+msgid "Byline title"
+msgstr ""
+
+#: id:21869
+msgid "Credit"
+msgstr ""
+
+#: id:21870
+msgid "Source"
+msgstr ""
+
+#: id:21871
+msgid "Copyright notice"
+msgstr ""
+
+#: id:21872
+msgid "Object name"
+msgstr ""
+
+#: id:21873
+msgid "City"
+msgstr ""
+
+#: id:21874
+msgid "State"
+msgstr ""
+
+#: id:21875
+msgctxt "Auto context with id 21875"
+msgid "Country"
+msgstr ""
+
+#: id:21876
+msgid "Original Tx Reference"
+msgstr ""
+
+#: id:21877
+msgid "Date created"
+msgstr ""
+
+#: id:21878
+msgid "Copyright flag"
+msgstr ""
+
+#: id:21879
+msgid "Country code"
+msgstr ""
+
+#: id:21880
+msgid "Reference service"
+msgstr ""
+
+#: id:21881
+msgid "Allow control of XBMC via UPnP"
+msgstr ""
+
+#: id:21882
+msgid "Attempt to skip introduction before DVD menu"
+msgstr ""
+
+#: id:21883
+msgid "Saved music"
+msgstr ""
+
+#: id:21884
+msgid "Query info for all artists"
+msgstr ""
+
+#: id:21885
+msgid "Downloading album information"
+msgstr ""
+
+#: id:21886
+msgid "Downloading artist information"
+msgstr ""
+
+#: id:21887
+msgid "Biography"
+msgstr ""
+
+#: id:21888
+msgid "Discography"
+msgstr ""
+
+#: id:21889
+msgid "Searching artist"
+msgstr ""
+
+#: id:21890
+msgid "Select artist"
+msgstr ""
+
+#: id:21891
+msgctxt "Auto context with id 21891"
+msgid "Artist information"
+msgstr ""
+
+#: id:21892
+msgid "Instruments"
+msgstr ""
+
+#: id:21893
+msgid "Born"
+msgstr ""
+
+#: id:21894
+msgid "Formed"
+msgstr ""
+
+#: id:21895
+msgid "Themes"
+msgstr ""
+
+#: id:21896
+msgid "Disbanded"
+msgstr ""
+
+#: id:21897
+msgid "Died"
+msgstr ""
+
+#: id:21898
+msgid "Years active"
+msgstr ""
+
+#: id:21899
+msgid "Label"
+msgstr ""
+
+#: id:21900
+msgid "Born/Formed"
+msgstr ""
+
+#: id:22000
+msgid "Update library on startup"
+msgstr ""
+
+#: id:22001
+msgid "Hide progress of library updates"
+msgstr ""
+
+#: id:22002
+msgid "- DNS suffix"
+msgstr ""
+
+#: id:22003
+msgid "%2.3fs"
+msgstr ""
+
+#: id:22004
+msgid "Delayed by: %2.3fs"
+msgstr ""
+
+#: id:22005
+msgid "Ahead by: %2.3fs"
+msgstr ""
+
+#: id:22006
+msgid "Subtitle offset"
+msgstr ""
+
+#: id:22007
+msgid "OpenGL vendor:"
+msgstr ""
+
+#: id:22008
+msgid "OpenGL renderer:"
+msgstr ""
+
+#: id:22009
+msgid "OpenGL version:"
+msgstr ""
+
+#: id:22010
+msgid "GPU temperature:"
+msgstr ""
+
+#: id:22011
+msgid "CPU temperature:"
+msgstr ""
+
+#: id:22012
+msgid "Total memory"
+msgstr ""
+
+#: id:22013
+msgid "Profile data"
+msgstr ""
+
+#: id:22014
+msgid "Use dim if paused during video playback"
+msgstr ""
+
+#: id:22015
+msgid "All recordings"
+msgstr ""
+
+#: id:22016
+msgid "By title"
+msgstr ""
+
+#: id:22017
+msgid "By group"
+msgstr ""
+
+#: id:22018
+msgid "Live channels"
+msgstr ""
+
+#: id:22019
+msgid "Recordings by title"
+msgstr ""
+
+#: id:22020
+msgid "Guide"
+msgstr ""
+
+#: id:22021
+msgid "Allowed error in aspect ratio to minimize black bars"
+msgstr ""
+
+#: id:22022
+msgid "Show video files in listings"
+msgstr ""
+
+#: id:22023
+msgid "DirectX vendor:"
+msgstr ""
+
+#: id:22024
+msgid "Direct3D version:"
+msgstr ""
+
+#: id:22030
+msgctxt "Auto context with id 22030"
+msgid "Font"
+msgstr ""
+
+#: id:22031
+msgctxt "Auto context with id 22031"
+msgid "- Size"
+msgstr ""
+
+#: id:22032
+msgctxt "Auto context with id 22032"
+msgid "- Colours"
+msgstr ""
+
+#: id:22033
+msgid "- Charset"
+msgstr ""
+
+#: id:22034
+msgid "Export karaoke titles as HTML"
+msgstr ""
+
+#: id:22035
+msgid "Export karaoke titles as CSV"
+msgstr ""
+
+#: id:22036
+msgid "Import karaoke titles..."
+msgstr ""
+
+#: id:22037
+msgid "Show song selector automatically"
+msgstr ""
+
+#: id:22038
+msgid "Export karaoke titles..."
+msgstr ""
+
+#: id:22039
+msgid "Enter song number"
+msgstr ""
+
+#: id:22040
+msgid "white/green"
+msgstr ""
+
+#: id:22041
+msgid "white/red"
+msgstr ""
+
+#: id:22042
+msgid "white/blue"
+msgstr ""
+
+#: id:22043
+msgid "black/white"
+msgstr ""
+
+#: id:22079
+msgid "Default select action"
+msgstr ""
+
+#: id:22080
+msgid "Choose"
+msgstr ""
+
+#: id:22081
+msgid "Show Information"
+msgstr ""
+
+#: id:22082
+msgid "More..."
+msgstr ""
+
+#: id:22083
+msgid "Play all"
+msgstr ""
+
+#: id:23049
+msgid "Teletext not available"
+msgstr ""
+
+#: id:23050
+msgid "Activate Teletext"
+msgstr ""
+
+#: id:23051
+msgid "Part %i"
+msgstr ""
+
+#: id:23052
+msgid "Buffering %i bytes"
+msgstr ""
+
+#: id:23053
+msgid "Stopping"
+msgstr ""
+
+#: id:23054
+msgid "Running"
+msgstr ""
+
+#: id:23100
+msgid "External Player Active"
+msgstr ""
+
+#: id:23101
+msgid "Click OK to terminate the player"
+msgstr ""
+
+#: id:23104
+msgid "Click OK when playback has ended"
+msgstr ""
+
+#: id:24000
+msgid "Add-on"
+msgstr ""
+
+#: id:24001
+msgid "Add-ons"
+msgstr ""
+
+#: id:24002
+msgid "Add-on options"
+msgstr ""
+
+#: id:24003
+msgid "Add-on Information"
+msgstr ""
+
+#: id:24005
+msgctxt "Auto context with id 24005"
+msgid "Media sources"
+msgstr ""
+
+#: id:24007
+msgctxt "Auto context with id 24007"
+msgid "Movie information"
+msgstr ""
+
+#: id:24008
+msgctxt "Auto context with id 24008"
+msgid "Screensaver"
+msgstr ""
+
+#: id:24009
+msgid "Script"
+msgstr ""
+
+#: id:24010
+msgctxt "Auto context with id 24010"
+msgid "Visualization"
+msgstr ""
+
+#: id:24011
+msgid "Add-on repository"
+msgstr ""
+
+#: id:24012
+msgctxt "Auto context with id 24012"
+msgid "Subtitles"
+msgstr ""
+
+#: id:24013
+msgid "Lyrics"
+msgstr ""
+
+#: id:24014
+msgid "TV information"
+msgstr ""
+
+#: id:24015
+msgctxt "Auto context with id 24015"
+msgid "Music video information"
+msgstr ""
+
+#: id:24016
+msgctxt "Auto context with id 24016"
+msgid "Album information"
+msgstr ""
+
+#: id:24017
+msgctxt "Auto context with id 24017"
+msgid "Artist information"
+msgstr ""
+
+#: id:24018
+msgctxt "Auto context with id 24018"
+msgid "Services"
+msgstr ""
+
+#: id:24020
+msgid "Configure"
+msgstr ""
+
+#: id:24021
+msgctxt "Auto context with id 24021"
+msgid "Disable"
+msgstr ""
+
+#: id:24022
+msgid "Enable"
+msgstr ""
+
+#: id:24023
+msgid "Add-on disabled"
+msgstr ""
+
+#: id:24027
+msgctxt "Auto context with id 24027"
+msgid "Weather"
+msgstr ""
+
+#: id:24028
+msgid "Weather.com (standard)"
+msgstr ""
+
+#: id:24030
+msgid "This Add-on can not be configured"
+msgstr ""
+
+#: id:24031
+msgid "Error loading settings"
+msgstr ""
+
+#: id:24032
+msgid "All Add-ons"
+msgstr ""
+
+#: id:24033
+msgid "Get Add-ons"
+msgstr ""
+
+#: id:24034
+msgid "Check for updates"
+msgstr ""
+
+#: id:24035
+msgid "Force refresh"
+msgstr ""
+
+#: id:24036
+msgid "Change log"
+msgstr ""
+
+#: id:24037
+msgid "Uninstall"
+msgstr ""
+
+#: id:24038
+msgid "Install"
+msgstr ""
+
+#: id:24039
+msgid "Disabled Add-ons"
+msgstr ""
+
+#: id:24040
+msgid "(Clear the current setting)"
+msgstr ""
+
+#: id:24041
+msgid "Install from zip file"
+msgstr ""
+
+#: id:24042
+msgid "Downloading %i%%"
+msgstr ""
+
+#: id:24043
+msgid "Available Updates"
+msgstr ""
+
+#: id:24044
+msgid "Dependencies not met"
+msgstr ""
+
+#: id:24045
+msgid "Add-on does not have the correct structure"
+msgstr ""
+
+#: id:24046
+msgid "%s is used by the following installed add-on(s)"
+msgstr ""
+
+#: id:24047
+msgid "This add-on cannot be uninstalled"
+msgstr ""
+
+#: id:24048
+msgid "Rollback"
+msgstr ""
+
+#: id:24050
+msgid "Available Add-ons"
+msgstr ""
+
+#: id:24051
+msgid "Version:"
+msgstr ""
+
+#: id:24052
+msgid "Disclaimer"
+msgstr ""
+
+#: id:24053
+msgid "License:"
+msgstr ""
+
+#: id:24054
+msgid "Changelog"
+msgstr ""
+
+#: id:24059
+msgid "Would you like to enable this Add-on?"
+msgstr ""
+
+#: id:24060
+msgid "Would you like to disable this Add-on?"
+msgstr ""
+
+#: id:24061
+msgid "Add-on update available!"
+msgstr ""
+
+#: id:24062
+msgid "Enabled Add-ons"
+msgstr ""
+
+#: id:24063
+msgid "Auto update"
+msgstr ""
+
+#: id:24064
+msgid "Add-on enabled"
+msgstr ""
+
+#: id:24065
+msgid "Add-on updated"
+msgstr ""
+
+#: id:24066
+msgid "Cancel Add-on download?"
+msgstr ""
+
+#: id:24067
+msgid "Currently downloading Add-ons"
+msgstr ""
+
+#: id:24068
+msgid "Update available"
+msgstr ""
+
+#: id:24069
+msgid "Update"
+msgstr ""
+
+#: id:24070
+msgid "Add-on could not be loaded."
+msgstr ""
+
+#: id:24071
+msgid "An unknown error has occurred."
+msgstr ""
+
+#: id:24072
+msgid "Settings required"
+msgstr ""
+
+#: id:24073
+msgid "Could not connect"
+msgstr ""
+
+#: id:24074
+msgid "Needs to restart"
+msgstr ""
+
+#: id:24075
+msgctxt "Auto context with id 24075"
+msgid "Disable"
+msgstr ""
+
+#: id:24076
+msgid "Add-on Required"
+msgstr ""
+
+#: id:24080
+msgid "Try to reconnect?"
+msgstr ""
+
+#: id:24089
+msgid "Add-on restarts"
+msgstr ""
+
+#: id:24090
+msgid "Lock Add-on manager"
+msgstr ""
+
+#: id:24094
+msgid "(current)"
+msgstr ""
+
+#: id:24095
+msgid "(blacklisted)"
+msgstr ""
+
+#: id:24096
+msgid "Add-on has been marked as broken in repository."
+msgstr ""
+
+#: id:24097
+msgid "Would you like to disable it on your system?"
+msgstr ""
+
+#: id:24098
+msgid "Broken"
+msgstr ""
+
+#: id:24099
+msgid "Would you like to switch to this skin?"
+msgstr ""
+
+#: id:24100
+msgid "To use this feature you must download an Add-on:"
+msgstr ""
+
+#: id:24101
+msgid "Would you like to download this Add-on?"
+msgstr ""
+
+#: id:25000
+msgid "Notifications"
+msgstr ""
+
+#: id:29800
+msgid "Library Mode"
+msgstr ""
+
+#: id:29801
+msgid "QWERTY keyboard"
+msgstr ""
+
+#: id:29802
+msgid "Passthrough Audio in use"
+msgstr ""
+
+#: id:33001
+msgid "Trailer quality"
+msgstr ""
+
+#: id:33002
+msgid "Stream"
+msgstr ""
+
+#: id:33003
+msgid "Download"
+msgstr ""
+
+#: id:33004
+msgid "Download & play"
+msgstr ""
+
+#: id:33005
+msgid "Download & save"
+msgstr ""
+
+#: id:33006
+msgid "Today"
+msgstr ""
+
+#: id:33007
+msgid "Tomorrow"
+msgstr ""
+
+#: id:33008
+msgid "Saving"
+msgstr ""
+
+#: id:33009
+msgid "Copying"
+msgstr ""
+
+#: id:33010
+msgid "Set download directory"
+msgstr ""
+
+#: id:33011
+msgid "Search duration"
+msgstr ""
+
+#: id:33012
+msgid "Short"
+msgstr ""
+
+#: id:33013
+msgid "Long"
+msgstr ""
+
+#: id:33014
+msgid "Use DVD player instead of regular player"
+msgstr ""
+
+#: id:33015
+msgid "Ask for download before playing video"
+msgstr ""
+
+#: id:33016
+msgid "Clips"
+msgstr ""
+
+#: id:33017
+msgid "Restart plugin to enable"
+msgstr ""
+
+#: id:33018
+msgid "Tonight"
+msgstr ""
+
+#: id:33019
+msgid "Tomorrow Night"
+msgstr ""
+
+#: id:33020
+msgid "Condition"
+msgstr ""
+
+#: id:33021
+msgid "Precipitation"
+msgstr ""
+
+#: id:33022
+msgid "Precip"
+msgstr ""
+
+#: id:33023
+msgid "Humid"
+msgstr ""
+
+#: id:33024
+msgid "Feels"
+msgstr ""
+
+#: id:33025
+msgid "Observed"
+msgstr ""
+
+#: id:33026
+msgid "Departure from normal"
+msgstr ""
+
+#: id:33027
+msgid "Sunrise"
+msgstr ""
+
+#: id:33028
+msgid "Sunset"
+msgstr ""
+
+#: id:33029
+msgid "Details"
+msgstr ""
+
+#: id:33030
+msgid "Outlook"
+msgstr ""
+
+#: id:33031
+msgid "Coverflow"
+msgstr ""
+
+#: id:33032
+msgid "Translate text"
+msgstr ""
+
+#: id:33033
+msgid "Map list %s category"
+msgstr ""
+
+#: id:33034
+msgid "36 Hour"
+msgstr ""
+
+#: id:33035
+msgid "Maps"
+msgstr ""
+
+#: id:33036
+msgid "Hourly"
+msgstr ""
+
+#: id:33037
+msgid "Weekend"
+msgstr ""
+
+#: id:33038
+msgid "%s day"
+msgstr ""
+
+#: id:33049
+msgid "Alert"
+msgstr ""
+
+#: id:33050
+msgid "Alerts"
+msgstr ""
+
+#: id:33051
+msgid "Choose Your"
+msgstr ""
+
+#: id:33052
+msgid "Check"
+msgstr ""
+
+#: id:33053
+msgctxt "Auto context with id 33053"
+msgid "Configure the"
+msgstr ""
+
+#: id:33054
+msgid "Seasons"
+msgstr ""
+
+#: id:33055
+msgid "Use your"
+msgstr ""
+
+#: id:33056
+msgid "Watch your"
+msgstr ""
+
+#: id:33057
+msgid "Listen to"
+msgstr ""
+
+#: id:33058
+msgid "View your"
+msgstr ""
+
+#: id:33059
+msgctxt "Auto context with id 33059"
+msgid "Configure the"
+msgstr ""
+
+#: id:33060
+msgid "Power"
+msgstr ""
+
+#: id:33061
+msgid "Menu"
+msgstr ""
+
+#: id:33062
+msgid "Play the"
+msgstr ""
+
+#: id:33063
+msgid "Options"
+msgstr ""
+
+#: id:33065
+msgid "Editor"
+msgstr ""
+
+#: id:33066
+msgid "About your"
+msgstr ""
+
+#: id:33067
+msgid "Star rating"
+msgstr ""
+
+#: id:33068
+msgid "Background"
+msgstr ""
+
+#: id:33069
+msgid "Backgrounds"
+msgstr ""
+
+#: id:33070
+msgid "Custom background"
+msgstr ""
+
+#: id:33071
+msgid "Custom backgrounds"
+msgstr ""
+
+#: id:33072
+msgid "View Readme"
+msgstr ""
+
+#: id:33073
+msgid "View Changelog"
+msgstr ""
+
+#: id:33074
+msgid "This version of %s requires an"
+msgstr ""
+
+#: id:33075
+msgid "XBMC revision of %s or greater to run."
+msgstr ""
+
+#: id:33076
+msgid "Please update XBMC."
+msgstr ""
+
+#: id:33077
+msgid "No data found!"
+msgstr ""
+
+#: id:33078
+msgid "Next page"
+msgstr ""
+
+#: id:33079
+msgid "Love"
+msgstr ""
+
+#: id:33080
+msgid "Hate"
+msgstr ""
+
+#: id:33081
+msgid "This file is stacked, select the part you want to play from."
+msgstr ""
+
+#: id:33082
+msgid "Path to script"
+msgstr ""
+
+#: id:33083
+msgid "Enable custom script button"
+msgstr ""
+
+#: id:33100
+msgid "Failed to start"
+msgstr ""
+
+#: id:33101
+msgid "Webserver"
+msgstr ""
+
+#: id:33102
+msgid "Event Server"
+msgstr ""
+
+#: id:33103
+msgid "Remote communication server"
+msgstr ""
+
+#: id:33200
+msgid "Detected New Connection"
+msgstr ""
+
+#: id:34000
+msgid "Lame"
+msgstr ""
+
+#: id:34001
+msgid "Vorbis"
+msgstr ""
+
+#: id:34002
+msgid "Wav"
+msgstr ""
+
+#: id:34003
+msgid "DXVA2"
+msgstr ""
+
+#: id:34004
+msgid "VAAPI"
+msgstr ""
+
+#: id:34005
+msgid "Flac"
+msgstr ""
+
+#: id:34100
+msgid "Speaker Configuration"
+msgstr ""
+
+#: id:34101
+msgid "2.0"
+msgstr ""
+
+#: id:34102
+msgid "2.1"
+msgstr ""
+
+#: id:34103
+msgid "3.0"
+msgstr ""
+
+#: id:34104
+msgid "3.1"
+msgstr ""
+
+#: id:34105
+msgid "4.0"
+msgstr ""
+
+#: id:34106
+msgid "4.1"
+msgstr ""
+
+#: id:34107
+msgid "5.0"
+msgstr ""
+
+#: id:34108
+msgid "5.1"
+msgstr ""
+
+#: id:34109
+msgid "7.0"
+msgstr ""
+
+#: id:34110
+msgid "7.1"
+msgstr ""
+
+#: id:34201
+msgid "Can't find a next item to play"
+msgstr ""
+
+#: id:34202
+msgid "Can't find a previous item to play"
+msgstr ""
+
+#: id:34300
+msgid "Failed to start zeroconf"
+msgstr ""
+
+#: id:34301
+msgid "Is Apple's Bonjour Service installed? See log for more info."
+msgstr ""
+
+#: id:34400
+msgid "Video Rendering"
+msgstr ""
+
+#: id:34401
+msgid "Failed to init video filters/scalers, falling back to bilinear scaling"
+msgstr ""
+
+#: id:34402
+msgid "Failed to initialize audio device"
+msgstr ""
+
+#: id:34403
+msgid "Check your audiosettings"
+msgstr ""
+
+#: id:34404
+msgid "Use gestures for navigation:"
+msgstr ""
+
+#: id:34405
+msgid "1 finger swipe left,right,up,down for cursors"
+msgstr ""
+
+#: id:34406
+msgid "2 finger swipe left for backspace"
+msgstr ""
+
+#: id:34407
+msgid "1 finger single tap for enter"
+msgstr ""
+
+#: id:34408
+msgid "2 finger single tap for contextmenu"
+msgstr ""
+
+#: id:35000
+msgid "Peripherals"
+msgstr ""
+
+#: id:35001
+msgid "Generic HID device"
+msgstr ""
+
+#: id:35002
+msgid "Generic network adapter"
+msgstr ""
+
+#: id:35003
+msgid "Generic disk"
+msgstr ""
+
+#: id:35004
+msgid "There are no settings available\nfor this peripheral."
+msgstr ""
+
+#: id:35005
+msgid "New device configured"
+msgstr ""
+
+#: id:35006
+msgid "Device removed"
+msgstr ""
+
+#: id:35007
+msgid "Keymap to use for this device"
+msgstr ""
+
+#: id:35008
+msgid "Keymap enabled"
+msgstr ""
+
+#: id:35009
+msgid "Do not use the custom keymap for this device"
+msgstr ""
+
+#: id:35500
+msgid "Location"
+msgstr ""
+
+#: id:35501
+msgid "Class"
+msgstr ""
+
+#: id:35502
+msgctxt "Auto context with id 35502"
+msgid "Name"
+msgstr ""
+
+#: id:35503
+msgid "Vendor"
+msgstr ""
+
+#: id:35504
+msgid "Product ID"
+msgstr ""
+
+#: id:36000
+msgid "Pulse-Eight CEC adapter"
+msgstr ""
+
+#: id:36001
+msgid "Pulse-Eight Nyxboard"
+msgstr ""
+
+#: id:36002
+msgid "Switch to keyboard side command"
+msgstr ""
+
+#: id:36003
+msgid "Switch to remote side command"
+msgstr ""
+
+#: id:36004
+msgid "Press \"user\" button command"
+msgstr ""
+
+#: id:36005
+msgid "Enable switch side commands"
+msgstr ""
+
+#: id:36006
+msgid "Could not open the adapter"
+msgstr ""
+
+#: id:36007
+msgid "Devices to power on when starting XBMC"
+msgstr ""
+
+#: id:36008
+msgid "Devices to power off when stopping XBMC"
+msgstr ""
+
+#: id:36009
+msgid "Put devices in standby mode when activating screensaver"
+msgstr ""
+
+#: id:36011
+msgid "Could not detect the CEC port. Set it up manually."
+msgstr ""
+
+#: id:36012
+msgid "Could not initialise the CEC adapter. Check your settings."
+msgstr ""
+
+#: id:36013
+msgid "Unsupported libCEC interface version. %d is greater than the version XBMC supports (%d)"
+msgstr ""
+
+#: id:36014
+msgid "Put this PC in standby mode when the TV is switched off"
+msgstr ""
+
+#: id:36015
+msgid "HDMI port number"
+msgstr ""
+
+#: id:36016
+msgctxt "Auto context with id 36016"
+msgid "Connected"
+msgstr ""
+
+#: id:36017
+msgid "Adapter found, but libCEC is not available"
+msgstr ""
+
+#: id:36018
+msgid "Use the TV's language setting"
+msgstr ""
+
+#: id:36019
+msgid "Connected to HDMI device"
+msgstr ""
+
+#: id:36020
+msgid "Make XBMC the active source when starting"
+msgstr ""
+
+#: id:36021
+msgid "Physical address (overrules HDMI port)"
+msgstr ""
+
+#: id:36022
+msgid "COM port (leave empty unless needed)"
+msgstr ""
+
+#: id:36023
+msgid "Configuration updated"
+msgstr ""
+
+#: id:36024
+msgid "Failed to set the new configuration. Please check your settings."
+msgstr ""
+
+#: id:36025
+msgid "Send 'inactive source' command when stopping XBMC"
+msgstr ""
+

--- a/language/Italian/strings.po
+++ b/language/Italian/strings.po
@@ -1,0 +1,9093 @@
+# Converted from xbmc strings.xml with xbmc-xml2po (by Team-XBMC)
+msgid ""
+msgstr ""
+"Project-Id-Version: xbmc.core-FRODO_GIT3ed1604ad7\n"
+"Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
+"POT-Creation-Date: 2012-04-09 18:00+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE\n"
+"Language: it\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: id:0
+msgctxt "Auto context with id 0"
+msgid "Programs"
+msgstr "Programmi"
+
+#: id:1
+msgctxt "Auto context with id 1"
+msgid "Pictures"
+msgstr "Immagini"
+
+#: id:2
+msgctxt "Auto context with id 2"
+msgid "Music"
+msgstr "Musica"
+
+#: id:3
+msgctxt "Auto context with id 3"
+msgid "Videos"
+msgstr "Video"
+
+#: id:4
+msgid "TV-Guide"
+msgstr "Guida TV"
+
+#: id:5
+msgctxt "Auto context with id 5"
+msgid "Settings"
+msgstr "Impostazioni"
+
+#: id:6
+msgid "XBMC SVN"
+msgstr "XBMC SVN"
+
+#: id:7
+msgctxt "Auto context with id 7"
+msgid "File manager"
+msgstr "File"
+
+#: id:8
+msgctxt "Auto context with id 8"
+msgid "Weather"
+msgstr "Meteo"
+
+#: id:9
+msgid "xbmc media center"
+msgstr "xbmc media center"
+
+#: id:11
+msgid "Monday"
+msgstr "Lunedì"
+
+#: id:12
+msgid "Tuesday"
+msgstr "Martedì"
+
+#: id:13
+msgid "Wednesday"
+msgstr "Mercoledì"
+
+#: id:14
+msgid "Thursday"
+msgstr "Giovedì"
+
+#: id:15
+msgid "Friday"
+msgstr "Venerdì"
+
+#: id:16
+msgid "Saturday"
+msgstr "Sabato"
+
+#: id:17
+msgid "Sunday"
+msgstr "Domenica"
+
+#: id:21
+msgid "January"
+msgstr "Gennaio"
+
+#: id:22
+msgid "February"
+msgstr "Febbraio"
+
+#: id:23
+msgid "March"
+msgstr "Marzo"
+
+#: id:24
+msgid "April"
+msgstr "Aprile"
+
+#: id:25
+msgctxt "Auto context with id 25"
+msgid "May"
+msgstr "Maggio"
+
+#: id:26
+msgid "June"
+msgstr "Giugno"
+
+#: id:27
+msgid "July"
+msgstr "Luglio"
+
+#: id:28
+msgid "August"
+msgstr "Agosto"
+
+#: id:29
+msgid "September"
+msgstr "Settembre"
+
+#: id:30
+msgid "October"
+msgstr "Ottobre"
+
+#: id:31
+msgid "November"
+msgstr "Novembre"
+
+#: id:32
+msgid "December"
+msgstr "Dicembre"
+
+#: id:41
+msgid "Mon"
+msgstr "Lun"
+
+#: id:42
+msgid "Tue"
+msgstr "Mar"
+
+#: id:43
+msgid "Wed"
+msgstr "Mer"
+
+#: id:44
+msgid "Thu"
+msgstr "Gio"
+
+#: id:45
+msgid "Fri"
+msgstr "Ven"
+
+#: id:46
+msgid "Sat"
+msgstr "Sab"
+
+#: id:47
+msgctxt "Auto context with id 47"
+msgid "Sun"
+msgstr "Dom"
+
+#: id:51
+msgid "Jan"
+msgstr "Gen"
+
+#: id:52
+msgid "Feb"
+msgstr "Feb"
+
+#: id:53
+msgid "Mar"
+msgstr "Mar"
+
+#: id:54
+msgid "Apr"
+msgstr "Apr"
+
+#: id:55
+msgctxt "Auto context with id 55"
+msgid "May"
+msgstr "Mag"
+
+#: id:56
+msgid "Jun"
+msgstr "Giu"
+
+#: id:57
+msgid "Jul"
+msgstr "Lug"
+
+#: id:58
+msgid "Aug"
+msgstr "Ago"
+
+#: id:59
+msgid "Sep"
+msgstr "Set"
+
+#: id:60
+msgid "Oct"
+msgstr "Ott"
+
+#: id:61
+msgid "Nov"
+msgstr "Nov"
+
+#: id:62
+msgid "Dec"
+msgstr "Dic"
+
+#: id:71
+msgid "N"
+msgstr "N"
+
+#: id:72
+msgid "NNE"
+msgstr "NNE"
+
+#: id:73
+msgid "NE"
+msgstr "NE"
+
+#: id:74
+msgid "ENE"
+msgstr "ENE"
+
+#: id:75
+msgid "E"
+msgstr "E"
+
+#: id:76
+msgid "ESE"
+msgstr "ESE"
+
+#: id:77
+msgid "SE"
+msgstr "SE"
+
+#: id:78
+msgid "SSE"
+msgstr "SSE"
+
+#: id:79
+msgid "S"
+msgstr "S"
+
+#: id:80
+msgid "SSW"
+msgstr "SSO"
+
+#: id:81
+msgid "SW"
+msgstr "SO"
+
+#: id:82
+msgid "WSW"
+msgstr "OSO"
+
+#: id:83
+msgid "W"
+msgstr "O"
+
+#: id:84
+msgid "WNW"
+msgstr "ONO"
+
+#: id:85
+msgid "NW"
+msgstr "NO"
+
+#: id:86
+msgid "NNW"
+msgstr "NNO"
+
+#: id:87
+msgid "VAR"
+msgstr "VAR"
+
+#: id:98
+msgid "View: Auto"
+msgstr "Vedi: Auto"
+
+#: id:99
+msgid "View: Auto big"
+msgstr "Vedi: Auto grande"
+
+#: id:100
+msgid "View: Icons"
+msgstr "Vedi: Icone"
+
+#: id:101
+msgid "View: List"
+msgstr "Vedi: Lista"
+
+#: id:102
+msgctxt "Auto context with id 102"
+msgid "Scan"
+msgstr "Scansiona"
+
+#: id:103
+msgctxt "Auto context with id 103"
+msgid "Sort by: Name"
+msgstr "Ordina per Nome"
+
+#: id:104
+msgid "Sort by: Date"
+msgstr "Ordina per Data"
+
+#: id:105
+msgid "Sort by: Size"
+msgstr "Ordina per Dim."
+
+#: id:106
+msgid "No"
+msgstr "No"
+
+#: id:107
+msgid "Yes"
+msgstr "Si"
+
+#: id:108
+msgctxt "Auto context with id 108"
+msgid "Slideshow"
+msgstr "Presentazione"
+
+#: id:109
+msgid "Create thumbs"
+msgstr "Crea le icone"
+
+#: id:110
+msgid "Create thumbnails"
+msgstr "Crea le icone"
+
+#: id:111
+msgctxt "Auto context with id 111"
+msgid "Shortcuts"
+msgstr "Collegamenti"
+
+#: id:112
+msgid "Paused"
+msgstr "Pausa"
+
+#: id:113
+msgid "Update failed"
+msgstr "Aggiornamento fallito"
+
+#: id:114
+msgid "Installation failed"
+msgstr "Installazione fallita"
+
+#: id:115
+msgid "Copy"
+msgstr "Copia"
+
+#: id:116
+msgid "Move"
+msgstr "Sposta"
+
+#: id:117
+msgid "Delete"
+msgstr "Elimina"
+
+#: id:118
+msgid "Rename"
+msgstr "Rinomina"
+
+#: id:119
+msgid "New folder"
+msgstr "Nuova cartella"
+
+#: id:120
+msgid "Confirm file copy"
+msgstr "Confermare copia del file"
+
+#: id:121
+msgid "Confirm file move"
+msgstr "Confermare spostamento del file"
+
+#: id:122
+msgid "Confirm file delete?"
+msgstr "Confermi l'eliminazione del file?"
+
+#: id:123
+msgid "Copy these files?"
+msgstr "Copio questi files?"
+
+#: id:124
+msgid "Move these files?"
+msgstr "Muovo questi files?"
+
+#: id:125
+msgid "Delete these files? - Deleting files cannot be undone!"
+msgstr "Elimino questi file? I files non potranno essere recuperati!"
+
+#: id:126
+msgid "Status"
+msgstr "Stato"
+
+#: id:127
+msgid "Objects"
+msgstr "Elementi"
+
+#: id:128
+msgctxt "Auto context with id 128"
+msgid "General"
+msgstr "Generale"
+
+#: id:129
+msgctxt "Auto context with id 129"
+msgid "Slideshow"
+msgstr "Riproduzione immagini"
+
+#: id:130
+msgctxt "Auto context with id 130"
+msgid "System info"
+msgstr "Info sistema"
+
+#: id:131
+msgid "Display"
+msgstr "Schermo"
+
+#: id:132
+msgid "Albums"
+msgstr "Album"
+
+#: id:133
+msgid "Artists"
+msgstr "Artisti"
+
+#: id:134
+msgid "Songs"
+msgstr "Canzoni"
+
+#: id:135
+msgid "Genres"
+msgstr "Generi"
+
+#: id:136
+msgid "Playlists"
+msgstr "Playlist"
+
+#: id:137
+msgid "Search"
+msgstr "Cerca"
+
+#: id:138
+msgid "System Information"
+msgstr "Informazioni Sistema"
+
+#: id:139
+msgid "Temperatures:"
+msgstr "Temperature:"
+
+#: id:140
+msgid "CPU:"
+msgstr "CPU:"
+
+#: id:141
+msgid "GPU:"
+msgstr "GPU:"
+
+#: id:142
+msgid "Time:"
+msgstr "Orario:"
+
+#: id:143
+msgid "Current:"
+msgstr "Attuale:"
+
+#: id:144
+msgid "Build:"
+msgstr "Versione:"
+
+#: id:145
+msgid "Network:"
+msgstr "Rete:"
+
+#: id:146
+msgid "Type:"
+msgstr "Tipo:"
+
+#: id:147
+msgid "Static"
+msgstr "Statico"
+
+#: id:148
+msgid "DHCP"
+msgstr "DHCP"
+
+#: id:149
+msgid "MAC address"
+msgstr "MAC address"
+
+#: id:150
+msgctxt "Auto context with id 150"
+msgid "IP address"
+msgstr "Indirizzo IP"
+
+#: id:151
+msgid "Link:"
+msgstr "Connessione:"
+
+#: id:152
+msgid "Half duplex"
+msgstr "Half duplex"
+
+#: id:153
+msgid "Full duplex"
+msgstr "Full duplex"
+
+#: id:154
+msgctxt "Auto context with id 154"
+msgid "Storage"
+msgstr "Archivi"
+
+#: id:155
+msgid "Drive"
+msgstr "Disco"
+
+#: id:156
+msgctxt "Auto context with id 156"
+msgid "Free"
+msgstr "Liberi"
+
+#: id:157
+msgctxt "Auto context with id 157"
+msgid "Video"
+msgstr "Video"
+
+#: id:158
+msgid "Free memory"
+msgstr "Memoria disponibile"
+
+#: id:159
+msgid "No link"
+msgstr "Nessuna connessione"
+
+#: id:160
+msgctxt "Auto context with id 160"
+msgid "Free"
+msgstr "Liberi"
+
+#: id:161
+msgid "Unavailable"
+msgstr "Non disponib."
+
+#: id:162
+msgid "Tray open"
+msgstr "Lettore aperto"
+
+#: id:163
+msgid "Reading"
+msgstr "Lettura"
+
+#: id:164
+msgid "No disc"
+msgstr "Senza disco"
+
+#: id:165
+msgid "Disc present"
+msgstr "Disco presente"
+
+#: id:166
+msgid "Skin"
+msgstr "Skin"
+
+#: id:169
+msgctxt "Auto context with id 169"
+msgid "Resolution"
+msgstr "Risoluzione"
+
+#: id:170
+msgid "Adjust display refresh rate to match video"
+msgstr "Regola la frequenza di aggiornamento"
+
+#: id:172
+msgid "Release date"
+msgstr "Data di uscita:"
+
+#: id:173
+msgid "Display 4:3 videos as"
+msgstr "Mostra video 4:3 come"
+
+#: id:175
+msgid "Moods"
+msgstr "Atteggiamenti"
+
+#: id:176
+msgid "Styles"
+msgstr "Stili"
+
+#: id:179
+msgid "Song"
+msgstr "Canzone"
+
+#: id:180
+msgid "Duration"
+msgstr "Durata"
+
+#: id:181
+msgid "Select album"
+msgstr "Seleziona l'album"
+
+#: id:182
+msgid "Tracks"
+msgstr "Tracce"
+
+#: id:183
+msgid "Review"
+msgstr "Recensione"
+
+#: id:184
+msgid "Refresh"
+msgstr "Ricarica"
+
+#: id:185
+msgid "Searching album"
+msgstr "Ricerca album"
+
+#: id:186
+msgid "OK"
+msgstr "OK"
+
+#: id:187
+msgid "No albums found!"
+msgstr "Nessun album trovato!"
+
+#: id:188
+msgid "Select all"
+msgstr "Seleziona tutto"
+
+#: id:189
+msgid "Scanning media info"
+msgstr "Scansione informazioni media"
+
+#: id:190
+msgid "Save"
+msgstr "Salva"
+
+#: id:191
+msgid "Shuffle"
+msgstr "Casuale"
+
+#: id:192
+msgctxt "Auto context with id 192"
+msgid "Clear"
+msgstr "Eliminare"
+
+#: id:193
+msgctxt "Auto context with id 193"
+msgid "Scan"
+msgstr "Scansiona"
+
+#: id:194
+msgid "Searching..."
+msgstr "Ricerca..."
+
+#: id:195
+msgid "No info found!"
+msgstr "Nessuna informazione trovata!"
+
+#: id:196
+msgid "Select movie:"
+msgstr "Seleziona il film:"
+
+#: id:197
+msgid "Querying %s info"
+msgstr "Richiesta %s informazioni"
+
+#: id:198
+msgid "Loading movie details"
+msgstr "Caricamento dettagli del film"
+
+#: id:199
+msgid "Web interface"
+msgstr "Interfaccia web"
+
+#: id:202
+msgid "Tagline"
+msgstr "Tema"
+
+#: id:203
+msgid "Plot outline"
+msgstr "Sintesi"
+
+#: id:205
+msgid "Votes"
+msgstr "Voti"
+
+#: id:206
+msgid "Cast"
+msgstr "Attori"
+
+#: id:207
+msgid "Plot"
+msgstr "Trama"
+
+#: id:208
+msgctxt "Auto context with id 208"
+msgid "Play"
+msgstr "Riproduci"
+
+#: id:209
+msgid "Next"
+msgstr "Successivo"
+
+#: id:210
+msgid "Previous"
+msgstr "Precedente"
+
+#: id:213
+msgid "Calibrate user interface..."
+msgstr "Calibrazione interfaccia utente..."
+
+#: id:214
+msgid "Video calibration..."
+msgstr "Calibrazione video..."
+
+#: id:215
+msgid "Soften"
+msgstr "Ammorbidisci"
+
+#: id:216
+msgid "Zoom amount"
+msgstr "Livello di zoom"
+
+#: id:217
+msgid "Pixel ratio"
+msgstr "Pixel ratio"
+
+#: id:218
+msgid "DVD drive"
+msgstr "Lettore DVD"
+
+#: id:219
+msgid "Please insert disc"
+msgstr "Inserire il disco"
+
+#: id:220
+msgid "Remote share"
+msgstr "Condivisione remota"
+
+#: id:221
+msgid "Network is not connected"
+msgstr "Rete non connessa"
+
+#: id:222
+msgid "Cancel"
+msgstr "Annulla"
+
+#: id:224
+msgid "Speed"
+msgstr "Velocità"
+
+#: id:225
+msgid "Vertical Shift"
+msgstr "Spostamento Verticale"
+
+#: id:226
+msgid "Test patterns..."
+msgstr "Immagine di prova"
+
+#: id:227
+msgid "Lookup audio CD track names from freedb.org"
+msgstr "Cerca i nomi delle tracce audio su freedb.org"
+
+#: id:228
+msgid "Shuffle playlist on load"
+msgstr "Mescola playlist all'avvio"
+
+#: id:229
+msgid "HDD spindown time"
+msgstr "Autospegnimento disco rigido"
+
+#: id:230
+msgid "Video filters"
+msgstr "Filtri video"
+
+#: id:231
+msgctxt "Auto context with id 231"
+msgid "None"
+msgstr "Nessuno"
+
+#: id:232
+msgid "Point"
+msgstr "Puntuale"
+
+#: id:233
+msgid "Linear"
+msgstr "Lineare"
+
+#: id:234
+msgid "Anisotropic"
+msgstr "Anisotropico"
+
+#: id:235
+msgid "Quincunx"
+msgstr "Quincunx"
+
+#: id:236
+msgid "Gaussian cubic"
+msgstr "Cubico gaussiano"
+
+#: id:237
+msgid "Minification"
+msgstr "Rimpicciolimento"
+
+#: id:238
+msgid "Magnification"
+msgstr "Ingrandimento"
+
+#: id:239
+msgid "Clear playlist on finish"
+msgstr "Cancella playlist alla fine"
+
+#: id:240
+msgid "Display Mode"
+msgstr "Modalità Display"
+
+#: id:241
+msgid "Full Screen #%d"
+msgstr "Schemo Intero #%d"
+
+#: id:242
+msgid "Windowed"
+msgstr "In Finestra"
+
+#: id:243
+msgid "Refresh Rate"
+msgstr "Frequenza di Refresh"
+
+#: id:244
+msgid "Full screen"
+msgstr "Schermo intero"
+
+#: id:245
+msgid "Sizing: (%i,%i)->(%i,%i) (Zoom x%2.2f) AR:%2.2f:1 (Pixels: %2.2f:1) (VShift: %2.2f)"
+msgstr "Dimensione: (%i,%i)->(%i,%i) (Zoom x%2.2f) AR:%2.2f:1 (Pixel: %2.2f:1)"
+
+#: id:247
+msgctxt "Auto context with id 247"
+msgid "Scripts"
+msgstr "Scripts"
+
+#: id:248
+msgctxt "Auto context with id 248"
+msgid "Language"
+msgstr "Lingua"
+
+#: id:249
+msgctxt "Auto context with id 249"
+msgid "Music"
+msgstr "Musica"
+
+#: id:250
+msgctxt "Auto context with id 250"
+msgid "Visualization"
+msgstr "Effetto grafico"
+
+#: id:251
+msgid "Select destination directory"
+msgstr "Seleziona la cartella di destinazione"
+
+#: id:252
+msgid "Output stereo to all speakers"
+msgstr "Uscita stereo su tutte le casse"
+
+#: id:253
+msgid "Number of channels"
+msgstr "Numero di canali"
+
+#: id:254
+msgid "- DTS capable receiver"
+msgstr "- Amplificatore con DTS"
+
+#: id:255
+msgid "CDDB"
+msgstr "CDDB"
+
+#: id:256
+msgid "Fetching CD information"
+msgstr "Richiesta informazioni CD"
+
+#: id:257
+msgid "Error"
+msgstr "Errore"
+
+#: id:258
+msgid "Enable tag reading"
+msgstr "Abilita la lettura dell'etichetta"
+
+#: id:259
+msgid "Opening"
+msgstr "Carico"
+
+#: id:260
+msgid "Shoutcast"
+msgstr "Shoutcast"
+
+#: id:261
+msgid "Waiting for start..."
+msgstr "Aspetta un momento..."
+
+#: id:262
+msgid "Scripts output"
+msgstr "Scripts output"
+
+#: id:263
+msgid "Allow control of XBMC via HTTP"
+msgstr "Permetti il controllo di XBMC via HTTP"
+
+#: id:264
+msgid "Record"
+msgstr "Registra"
+
+#: id:265
+msgid "Stop Rec."
+msgstr "Interrompi Reg."
+
+#: id:266
+msgid "Sort by: Track"
+msgstr "Ordina per: Traccia"
+
+#: id:267
+msgid "Sort by: Time"
+msgstr "Ordina per: Durata"
+
+#: id:268
+msgid "Sort by: Title"
+msgstr "Ordina per: Nome"
+
+#: id:269
+msgid "Sort by: Artist"
+msgstr "Ordina per: Artista"
+
+#: id:270
+msgid "Sort by: Album"
+msgstr "Ordina per: Album"
+
+#: id:271
+msgid "Top 100"
+msgstr "Top 100"
+
+#: id:272
+msgid "Top-Left overscan compensation"
+msgstr "Compensazione overscan angolo alto sinistro"
+
+#: id:273
+msgid "Bottom-Right overscan compensation"
+msgstr "Compensazione overscan angolo basso destro"
+
+#: id:274
+msgid "Subtitle positioning"
+msgstr "Posizione sottotitoli"
+
+#: id:275
+msgid "Pixel ratio adjustment"
+msgstr "Regolazione pixel ratio"
+
+#: id:276
+msgid "Adjust the arrow to change the amount of overscan"
+msgstr "Muovi le frecce sul bordo per impostare l'overscan"
+
+#: id:277
+msgid "Adjust the bar to change the subtitles position"
+msgstr "Muovi la riga per la posizione dei sottotitoli"
+
+#: id:278
+msgid "Adjust the rectangle so it is perfectly square"
+msgstr "Ridimensiona il rettangolo finché non vedi un quadrato perfetto"
+
+#: id:279
+msgid "Unable to load settings"
+msgstr "Impossibile caricare le impostazioni"
+
+#: id:280
+msgid "Using default settings"
+msgstr "Utilizza le impostazioni originali"
+
+#: id:281
+msgid "Please check the XML files"
+msgstr "Ricontrolla i file .xml"
+
+#: id:282
+msgid "Found %i items"
+msgstr "Trovato/i %i elemento/i"
+
+#: id:283
+msgid "Search results"
+msgstr "Risultati della ricerca"
+
+#: id:284
+msgid "No results found"
+msgstr "Nessun risultato"
+
+#: id:287
+msgctxt "Auto context with id 287"
+msgid "Subtitles"
+msgstr "Sottotitoli"
+
+#: id:288
+msgctxt "Auto context with id 288"
+msgid "Font"
+msgstr "Carattere"
+
+#: id:289
+msgctxt "Auto context with id 289"
+msgid "- Size"
+msgstr "- Dimensione"
+
+#: id:290
+msgid "Dynamic range compression"
+msgstr "Ampiezza compressione dinamica"
+
+#: id:291
+msgctxt "Auto context with id 291"
+msgid "Video"
+msgstr "Video"
+
+#: id:292
+msgctxt "Auto context with id 292"
+msgid "Audio"
+msgstr "Audio"
+
+#: id:293
+msgid "Browse for subtitles"
+msgstr "Esplora sottotitoli"
+
+#: id:294
+msgid "Create bookmark"
+msgstr "Crea segnalibro"
+
+#: id:296
+msgid "Clear bookmarks"
+msgstr "Cancella segnalibri"
+
+#: id:297
+msgid "Audio offset"
+msgstr "Sfasamento audio"
+
+#: id:298
+msgid "Bookmarks"
+msgstr "Segnalibri"
+
+#: id:299
+msgid "- AAC capable receiver"
+msgstr "- ricevitore compatibile AAC"
+
+#: id:300
+msgid "- MP1 capable receiver"
+msgstr "- ricevitore compatibile MP1"
+
+#: id:301
+msgid "- MP2 capable receiver"
+msgstr "- ricevitore compatibile MP2"
+
+#: id:302
+msgid "- MP3 capable receiver"
+msgstr "- ricevitore compatibile MP3"
+
+#: id:303
+msgid "Delay"
+msgstr "Ritardo"
+
+#: id:304
+msgctxt "Auto context with id 304"
+msgid "Language"
+msgstr "Lingua"
+
+#: id:305
+msgctxt "Auto context with id 305"
+msgid "Enabled"
+msgstr "Attivo"
+
+#: id:306
+msgid "Non-interleaved"
+msgstr "Non-interlacciato"
+
+#: id:312
+msgid "(0=auto)"
+msgstr "(0=auto)"
+
+#: id:313
+msgid "Cleaning database"
+msgstr "Riorganizza archivio"
+
+#: id:314
+msgid "Preparing..."
+msgstr "Preparazione..."
+
+#: id:315
+msgid "Database error"
+msgstr "Errore nell'archivio"
+
+#: id:316
+msgid "Searching songs..."
+msgstr "Ricerca delle canzoni in corso..."
+
+#: id:317
+msgid "Cleaned database successfully"
+msgstr "Archivio riorganizzato con successo"
+
+#: id:318
+msgid "Cleaning songs..."
+msgstr "Riorganizzazione delle canzoni in corso..."
+
+#: id:319
+msgid "Error cleaning songs"
+msgstr "Errore nella riorganizzazione delle canzoni"
+
+#: id:320
+msgid "Cleaning artists..."
+msgstr "Riorganizzazione degli artisti in corso..."
+
+#: id:321
+msgid "Error cleaning artists"
+msgstr "Errore nella riorganizzazione artisti"
+
+#: id:322
+msgid "Cleaning genres..."
+msgstr "Riorganizzazione generi musicali in corso..."
+
+#: id:323
+msgid "Error cleaning genres"
+msgstr "Errore nella riorganizzazione dei generi musicali"
+
+#: id:324
+msgid "Cleaning paths..."
+msgstr "Riorganizzazione dei percorsi in corso..."
+
+#: id:325
+msgid "Error cleaning paths"
+msgstr "Errore nella riorganizzazione dei percorsi"
+
+#: id:326
+msgid "Cleaning albums..."
+msgstr "Riorganizzazione degli album in corso..."
+
+#: id:327
+msgid "Error cleaning albums"
+msgstr "Errore durante la riorganizzazione degli album"
+
+#: id:328
+msgid "Writing changes..."
+msgstr "Salvo le modifche..."
+
+#: id:329
+msgid "Error writing changes"
+msgstr "Errore nel salvataggio delle modifiche"
+
+#: id:330
+msgid "This may take some time..."
+msgstr "Potrebbe richiedere diversi minuti..."
+
+#: id:331
+msgid "Compressing database..."
+msgstr "Compressione archivio..."
+
+#: id:332
+msgid "Error compressing database"
+msgstr "Errore durante la compressione dell'archivio"
+
+#: id:333
+msgid "Do you want to clean the library?"
+msgstr "Vuoi riorganizzare l'archivio?"
+
+#: id:334
+msgid "Clean library..."
+msgstr "Riorganizza l'archivio..."
+
+#: id:335
+msgid "Start"
+msgstr "Avvia"
+
+#: id:336
+msgid "Framerate conversion"
+msgstr "Conversione framerate"
+
+#: id:337
+msgctxt "Auto context with id 337"
+msgid "Audio output"
+msgstr "Uscita audio"
+
+#: id:338
+msgid "Analog"
+msgstr "Analogica"
+
+#: id:339
+msgid "Optical/Coax"
+msgstr "Ottico/Coass."
+
+#: id:340
+msgid "Various artists"
+msgstr "Artisti vari"
+
+#: id:341
+msgid "Play disc"
+msgstr "Avvia disco"
+
+#: id:342
+msgctxt "Auto context with id 342"
+msgid "Movies"
+msgstr "Film"
+
+#: id:343
+msgid "Adjust framerate"
+msgstr "Correggi framerate"
+
+#: id:344
+msgid "Actors"
+msgstr "Attori"
+
+#: id:345
+msgctxt "Auto context with id 345"
+msgid "Year"
+msgstr "Anno"
+
+#: id:346
+msgid "Boost volume level on downmix"
+msgstr "Aumenta il livello del volume nella conversione"
+
+#: id:350
+msgctxt "Auto context with id 350"
+msgid "Programs"
+msgstr "Programmi"
+
+#: id:351
+msgctxt "Auto context with id 351"
+msgid "Off"
+msgstr "Off"
+
+#: id:352
+msgid "Dim"
+msgstr "Dim"
+
+#: id:353
+msgid "Black"
+msgstr "Nero"
+
+#: id:354
+msgid "Matrix trails"
+msgstr "Matrix trails"
+
+#: id:355
+msgid "Screensaver time"
+msgstr "Avvia il salvaschermo dopo"
+
+#: id:356
+msgid "Screensaver mode"
+msgstr "Tipo di salvaschermo"
+
+#: id:357
+msgid "Shutdown function timer"
+msgstr "Timer spegnimento"
+
+#: id:358
+msgid "All albums"
+msgstr "Tutti gli album"
+
+#: id:359
+msgid "Recently added albums"
+msgstr "Album aggiunti di recente"
+
+#: id:360
+msgctxt "Auto context with id 360"
+msgid "Screensaver"
+msgstr "Salvaschermo"
+
+#: id:361
+msgid "R. Slideshow"
+msgstr "R. SlideShow"
+
+#: id:362
+msgid "Screensaver dim level"
+msgstr "Livello di oscuramento salvaschermo"
+
+#: id:363
+msgid "Sort by: File"
+msgstr "Ordina per: File"
+
+#: id:364
+msgid "- Dolby Digital (AC3) capable receiver"
+msgstr "- Amplificatore con AC3"
+
+#: id:365
+msgctxt "Auto context with id 365"
+msgid "Sort by: Name"
+msgstr "Ordina per: Nome"
+
+#: id:366
+msgid "Sort by: Year"
+msgstr "Ordina per: Anno"
+
+#: id:367
+msgid "Sort by: Rating"
+msgstr "Ordina per: Voto"
+
+#: id:368
+msgid "IMDb"
+msgstr "IMDB"
+
+#: id:369
+msgctxt "Auto context with id 369"
+msgid "Title"
+msgstr "Titolo"
+
+#: id:370
+msgid "Thunderstorms"
+msgstr "Temporali"
+
+#: id:371
+msgid "Partly"
+msgstr "Parzialmente"
+
+#: id:372
+msgid "Mostly"
+msgstr "Molto"
+
+#: id:373
+msgid "Sunny"
+msgstr "Soleggiato"
+
+#: id:374
+msgid "Cloudy"
+msgstr "Nuvoloso"
+
+#: id:375
+msgid "Snow"
+msgstr "Neve"
+
+#: id:376
+msgid "Rain"
+msgstr "Pioggia"
+
+#: id:377
+msgid "Light"
+msgstr "Leggera"
+
+#: id:378
+msgid "AM"
+msgstr "AM"
+
+#: id:379
+msgid "PM"
+msgstr "PM"
+
+#: id:380
+msgid "Showers"
+msgstr "Rovesci"
+
+#: id:381
+msgid "Few"
+msgstr "Poco"
+
+#: id:382
+msgid "Scattered"
+msgstr "Sparsi"
+
+#: id:383
+msgctxt "Auto context with id 383"
+msgid "Wind"
+msgstr "Vento"
+
+#: id:384
+msgid "Strong"
+msgstr "Forte"
+
+#: id:385
+msgid "Fair"
+msgstr "Sereno"
+
+#: id:386
+msgctxt "Auto context with id 386"
+msgid "Clear"
+msgstr "Limpido"
+
+#: id:387
+msgid "Clouds"
+msgstr "Nuvoloso"
+
+#: id:388
+msgid "Early"
+msgstr "Anticipati"
+
+#: id:389
+msgid "Shower"
+msgstr "Rovescio"
+
+#: id:390
+msgid "Flurries"
+msgstr "Turbini"
+
+#: id:391
+msgctxt "Auto context with id 391"
+msgid "Low"
+msgstr "Minima"
+
+#: id:392
+msgctxt "Auto context with id 392"
+msgid "Medium"
+msgstr "Media"
+
+#: id:393
+msgctxt "Auto context with id 393"
+msgid "High"
+msgstr "Massima"
+
+#: id:394
+msgid "Fog"
+msgstr "Nebbia"
+
+#: id:395
+msgid "Haze"
+msgstr "Foschia"
+
+#: id:396
+msgid "Select location"
+msgstr "Seleziona località"
+
+#: id:397
+msgid "Refresh time"
+msgstr "Aggiornamento"
+
+#: id:398
+msgid "Temperature units"
+msgstr "Misura di temperatura"
+
+#: id:399
+msgid "Speed units"
+msgstr "Misura di velocità"
+
+#: id:400
+msgctxt "Auto context with id 400"
+msgid "Weather"
+msgstr "Meteo"
+
+#: id:401
+msgid "Temp"
+msgstr "Temperatura"
+
+#: id:402
+msgid "Feels like"
+msgstr "Percepiti"
+
+#: id:403
+msgid "UV index"
+msgstr "Indice UV"
+
+#: id:404
+msgctxt "Auto context with id 404"
+msgid "Wind"
+msgstr "Vento"
+
+#: id:405
+msgid "Dew point"
+msgstr "P. di rugiada"
+
+#: id:406
+msgid "Humidity"
+msgstr "Umidità"
+
+#: id:409
+msgid "Defaults"
+msgstr "Predefinito"
+
+#: id:410
+msgid "Accessing weather service"
+msgstr "Accesso a servizio meteo"
+
+#: id:411
+msgid "Getting weather for:"
+msgstr "Aggiorno le previsioni meteo per:"
+
+#: id:412
+msgid "Unable to get weather data"
+msgstr "Impossibile aggiornare le informazioni meteo"
+
+#: id:413
+msgid "Manual"
+msgstr "Manuale"
+
+#: id:414
+msgid "No review for this album"
+msgstr "Nessuna recensione per questo album"
+
+#: id:415
+msgid "Downloading thumbnail..."
+msgstr "Scaricamento icone..."
+
+#: id:416
+msgid "Not available"
+msgstr "Non disponibile"
+
+#: id:417
+msgid "View: Big icons"
+msgstr "Visualizza: Icone grandi"
+
+#: id:418
+msgctxt "Auto context with id 418"
+msgid "Low"
+msgstr "Basso"
+
+#: id:419
+msgctxt "Auto context with id 419"
+msgid "High"
+msgstr "Alto"
+
+#: id:420
+msgid "HDMI"
+msgstr "HDMI"
+
+#: id:422
+msgid "Delete album info"
+msgstr "Elimina le info sull'album"
+
+#: id:423
+msgid "Delete CD information"
+msgstr "Elimina info CD"
+
+#: id:424
+msgid "Select"
+msgstr "Seleziona"
+
+#: id:425
+msgid "No album information found"
+msgstr "Non è stata trovata nessuna info sull'album"
+
+#: id:426
+msgid "No CD information found"
+msgstr "Non è stata trovata nessuna info sul CD"
+
+#: id:427
+msgid "Disc"
+msgstr "Disco"
+
+#: id:428
+msgid "Insert correct CD/DVD"
+msgstr "Inserire il CD/DVD corretto"
+
+#: id:429
+msgid "Please insert the following disc:"
+msgstr "Inserire il prossimo CD/DVD"
+
+#: id:430
+msgid "Sort by: DVD#"
+msgstr "Ordina per: DVD#"
+
+#: id:431
+msgid "No cache"
+msgstr "Nessuna cache"
+
+#: id:432
+msgid "Remove movie from library"
+msgstr "Eliminare il film dal archivio"
+
+#: id:433
+msgid "Really remove '%s'?"
+msgstr "Sicuro di voler cancellare '%s'?"
+
+#: id:434
+msgid "From %s at %i %s"
+msgstr "Da %s a %i %s"
+
+#: id:437
+msgid "Removable disk"
+msgstr "Disco rimuovibile"
+
+#: id:438
+msgid "Opening file"
+msgstr "Apertura file"
+
+#: id:439
+msgid "Cache"
+msgstr "Cache"
+
+#: id:440
+msgid "Harddisk"
+msgstr "Disco rigido"
+
+#: id:441
+msgid "UDF"
+msgstr "UDF"
+
+#: id:442
+msgid "Local network"
+msgstr "Rete locale"
+
+#: id:443
+msgid "Internet"
+msgstr "Internet"
+
+#: id:444
+msgctxt "Auto context with id 444"
+msgid "Video"
+msgstr "Video"
+
+#: id:445
+msgctxt "Auto context with id 445"
+msgid "Audio"
+msgstr "Audio"
+
+#: id:446
+msgctxt "Auto context with id 446"
+msgid "DVD"
+msgstr "DVD"
+
+#: id:447
+msgid "Autorun media"
+msgstr "Avvio automatico"
+
+#: id:448
+msgid "LCD"
+msgstr "LCD"
+
+#: id:449
+msgctxt "Auto context with id 449"
+msgid "Enabled"
+msgstr "Abilitato"
+
+#: id:450
+msgid "Columns"
+msgstr "Colonne"
+
+#: id:451
+msgid "Row 1 address"
+msgstr "Indirizzo riga 1"
+
+#: id:452
+msgid "Row 2 address"
+msgstr "Indirizzo riga 2"
+
+#: id:453
+msgid "Row 3 address"
+msgstr "Indirizzo riga 3"
+
+#: id:454
+msgid "Row 4 address"
+msgstr "Indirizzo riga 4"
+
+#: id:455
+msgid "Rows"
+msgstr "Righe"
+
+#: id:456
+msgid "Mode"
+msgstr "Modalità"
+
+#: id:457
+msgid "Switch view"
+msgstr "Cambia vista"
+
+#: id:459
+msgid "Subs"
+msgstr "Subs"
+
+#: id:460
+msgid "Audio stream"
+msgstr "Traccia audio"
+
+#: id:461
+msgid "[active]"
+msgstr "[attiva]"
+
+#: id:462
+msgid "Subtitle"
+msgstr "Sottitolo"
+
+#: id:463
+msgid "Backlight"
+msgstr "Retroilluminazione"
+
+#: id:464
+msgid "Brightness"
+msgstr "Luminosità"
+
+#: id:465
+msgid "Contrast"
+msgstr "Contrasto"
+
+#: id:466
+msgid "Gamma"
+msgstr "Gamma"
+
+#: id:467
+msgctxt "Auto context with id 467"
+msgid "Type"
+msgstr "Tipo"
+
+#: id:468
+msgid "Move the bar to change the OSD position"
+msgstr "Muovi la barra per modificare la posizione dell'OSD"
+
+#: id:469
+msgid "OSD position"
+msgstr "Posizione OSD"
+
+#: id:470
+msgid "Credits"
+msgstr "Riconoscimenti"
+
+#: id:471
+msgid "Modchip"
+msgstr "Modchip"
+
+#: id:474
+msgctxt "Auto context with id 474"
+msgid "Off"
+msgstr "Spento"
+
+#: id:475
+msgid "Music only"
+msgstr "Solo musica"
+
+#: id:476
+msgctxt "Auto context with id 476"
+msgid "Music & video"
+msgstr "Musica e video"
+
+#: id:477
+msgid "Unable to load playlist"
+msgstr "Impossibile caricare la playlist"
+
+#: id:478
+msgid "OSD"
+msgstr "OSD"
+
+#: id:479
+msgid "Skin & language"
+msgstr "Skin e lingua"
+
+#: id:480
+msgid "Appearance"
+msgstr "Aspetto"
+
+#: id:481
+msgid "Audio options"
+msgstr "Opzioni audio"
+
+#: id:482
+msgid "About XBMC"
+msgstr "Informazioni su XBMC"
+
+#: id:485
+msgid "Delete album"
+msgstr "Elimina album"
+
+#: id:486
+msgid "Repeat"
+msgstr "Ripeti"
+
+#: id:487
+msgid "Repeat one"
+msgstr "Ripeti una volta"
+
+#: id:488
+msgid "Repeat folder"
+msgstr "Ripeti cartella"
+
+#: id:489
+msgid "Play the next song automatically"
+msgstr "Riproduci il file successivo automaticamente"
+
+#: id:491
+msgid "- Use big icons"
+msgstr "- Usa icone grandi"
+
+#: id:492
+msgid "Resize VobSubs"
+msgstr "Ridimensiona sottotitoli"
+
+#: id:493
+msgid "Advanced options (Experts Only!)"
+msgstr "Opzioni avanzate (Solo Esperti!)"
+
+#: id:494
+msgid "Overall audio headroom"
+msgstr "Livello audio generale"
+
+#: id:495
+msgid "Upsample videos to GUI resolution"
+msgstr "Adatta i video alle dimensioni dell'interfaccia"
+
+#: id:496
+msgid "Calibration"
+msgstr "Calibrazione"
+
+#: id:497
+msgid "Show file extensions"
+msgstr "Mostra le estensioni dei file"
+
+#: id:498
+msgid "Sort by: Type"
+msgstr "Ordina per: Tipo"
+
+#: id:499
+msgid "Unable to connect to online lookup service"
+msgstr "Impossibile collegarsi al servizio di ricerca online"
+
+#: id:500
+msgid "Downloading album information failed"
+msgstr "Impossibile scaricare le informazioni sull'album"
+
+#: id:501
+msgid "Looking for album names..."
+msgstr "Ricerca nome album in corso..."
+
+#: id:502
+msgctxt "Auto context with id 502"
+msgid "Open"
+msgstr "Aperto"
+
+#: id:503
+msgid "Busy"
+msgstr "Caricando"
+
+#: id:504
+msgid "Empty"
+msgstr "Vuoto"
+
+#: id:505
+msgid "Loading media info from files..."
+msgstr "Caricamento informazioni dai file..."
+
+#: id:507
+msgid "Sort by: Usage"
+msgstr "Ordina per: Utilizzo"
+
+#: id:510
+msgid "Enable visualizations"
+msgstr "Attiva effetto grafico"
+
+#: id:511
+msgid "Enable video mode switching"
+msgstr "Attiva cambio modalità video"
+
+#: id:512
+msgid "Startup window"
+msgstr "Schermata di partenza"
+
+#: id:513
+msgid "Home window"
+msgstr "Schermata Home"
+
+#: id:514
+msgid "Manual settings"
+msgstr "Impostazioni manuali"
+
+#: id:515
+msgid "Genre"
+msgstr "Genere"
+
+#: id:517
+msgid "Recently played albums"
+msgstr "Album riprodotti di recente"
+
+#: id:518
+msgid "Launch"
+msgstr "Avvia"
+
+#: id:519
+msgid "Launch in..."
+msgstr "Avvia in..."
+
+#: id:521
+msgid "Compilations"
+msgstr "Compilation"
+
+#: id:522
+msgid "Remove source"
+msgstr "Rimuovi sorgente"
+
+#: id:523
+msgid "Switch media"
+msgstr "Cambia media"
+
+#: id:524
+msgid "Select playlist"
+msgstr "Seleziona playlist"
+
+#: id:525
+msgid "New playlist..."
+msgstr "Nuova playlist..."
+
+#: id:526
+msgid "Add to playlist"
+msgstr "Aggiungi alla playlist"
+
+#: id:527
+msgid "Manually add to library"
+msgstr "Aggiungi all'archivio"
+
+#: id:528
+msgid "Enter title"
+msgstr "Inserire titolo"
+
+#: id:529
+msgid "Error: Duplicate title"
+msgstr "Errore: Titolo esistente"
+
+#: id:530
+msgid "Select genre"
+msgstr "Seleziona genere"
+
+#: id:531
+msgid "New genre"
+msgstr "Nuovo genere"
+
+#: id:532
+msgid "Manual addition"
+msgstr "Aggiunta manuale"
+
+#: id:533
+msgid "Enter genre"
+msgstr "Inserire genere"
+
+#: id:534
+msgid "View: %s"
+msgstr "Vedi: %s"
+
+#: id:535
+msgid "List"
+msgstr "Lista"
+
+#: id:536
+msgid "Icons"
+msgstr "Icone"
+
+#: id:537
+msgid "Big list"
+msgstr "Lista grande"
+
+#: id:538
+msgid "Big icons"
+msgstr "Icone grandi"
+
+#: id:539
+msgid "Wide"
+msgstr "Largo"
+
+#: id:540
+msgid "Big wide"
+msgstr "Molto largo"
+
+#: id:541
+msgid "Album icons"
+msgstr "Icone album"
+
+#: id:542
+msgid "DVD icons"
+msgstr "Icone DVD"
+
+#: id:543
+msgctxt "Auto context with id 543"
+msgid "DVD"
+msgstr "DVD"
+
+#: id:544
+msgctxt "Auto context with id 544"
+msgid "Media info"
+msgstr "Info media"
+
+#: id:545
+msgid "Audio output device"
+msgstr "Dispositivo d'uscita audio"
+
+#: id:546
+msgid "Passthrough output device"
+msgstr "Dispositivo d'uscita passtrough"
+
+#: id:547
+msgid "No biography for this artist"
+msgstr "Nessuna biografia per questo artista"
+
+#: id:548
+msgid "Downmix multichannel audio to stereo"
+msgstr "Converti l'audio multicanale in stereo"
+
+#: id:550
+msgid "Sort by: %s"
+msgstr "Ordina per: %s"
+
+#: id:551
+msgctxt "Auto context with id 551"
+msgid "Name"
+msgstr "Nome"
+
+#: id:552
+msgid "Date"
+msgstr "Data"
+
+#: id:553
+msgid "Size"
+msgstr "Dimensione"
+
+#: id:554
+msgid "Track"
+msgstr "Traccia"
+
+#: id:555
+msgid "Time"
+msgstr "Durata"
+
+#: id:556
+msgctxt "Auto context with id 556"
+msgid "Title"
+msgstr "Titolo"
+
+#: id:557
+msgid "Artist"
+msgstr "Artista"
+
+#: id:558
+msgid "Album"
+msgstr "Album"
+
+#: id:559
+msgid "Playlist"
+msgstr "Lista di riproduzione"
+
+#: id:560
+msgid "ID"
+msgstr "ID"
+
+#: id:561
+msgctxt "Auto context with id 561"
+msgid "File"
+msgstr "File"
+
+#: id:562
+msgctxt "Auto context with id 562"
+msgid "Year"
+msgstr "Anno"
+
+#: id:563
+msgid "Rating"
+msgstr "Voto"
+
+#: id:564
+msgctxt "Auto context with id 564"
+msgid "Type"
+msgstr "Tipo"
+
+#: id:565
+msgid "Usage"
+msgstr "Utilizzo"
+
+#: id:566
+msgid "Album artist"
+msgstr "Artista album"
+
+#: id:567
+msgid "Play count"
+msgstr "Conteggio riproduzione"
+
+#: id:568
+msgid "Last played"
+msgstr "Ultimo riprodotto"
+
+#: id:569
+msgctxt "Auto context with id 569"
+msgid "Comment"
+msgstr "Commento"
+
+#: id:570
+msgid "Date added"
+msgstr "Aggiunto in data"
+
+#: id:571
+msgctxt "Auto context with id 571"
+msgid "Default"
+msgstr "Default"
+
+#: id:572
+msgid "Studio"
+msgstr "Studio"
+
+#: id:573
+msgid "Path"
+msgstr "Percorso"
+
+#: id:574
+msgctxt "Auto context with id 574"
+msgid "Country"
+msgstr "Nazione"
+
+#: id:575
+msgid "In progress"
+msgstr "In corso"
+
+#: id:576
+msgid "Times played"
+msgstr "Numero di riproduzioni"
+
+#: id:580
+msgid "Sort direction"
+msgstr "Direzione ordinamento"
+
+#: id:581
+msgid "Sort method"
+msgstr "Metodo di ordinamento"
+
+#: id:582
+msgctxt "Auto context with id 582"
+msgid "View mode"
+msgstr "Modalità di visualizzazione"
+
+#: id:583
+msgid "Remember views for different folders"
+msgstr "Ricorda modalità di visualizzazione di ogni cartella"
+
+#: id:584
+msgid "Ascending"
+msgstr "Ascendente"
+
+#: id:585
+msgid "Descending"
+msgstr "Discendente"
+
+#: id:586
+msgid "Edit playlist"
+msgstr "Modifica playlist"
+
+#: id:587
+msgid "Filter"
+msgstr "Filtro"
+
+#: id:588
+msgid "Cancel party mode"
+msgstr "Annulla modalità party"
+
+#: id:589
+msgid "Party mode"
+msgstr "Modalità party"
+
+#: id:590
+msgid "Random"
+msgstr "Casuale"
+
+#: id:591
+msgctxt "Auto context with id 591"
+msgid "Off"
+msgstr "Off"
+
+#: id:592
+msgid "One"
+msgstr "Una"
+
+#: id:593
+msgid "All"
+msgstr "Tutto"
+
+#: id:594
+msgctxt "Auto context with id 594"
+msgid "Off"
+msgstr "Off"
+
+#: id:595
+msgid "Repeat: Off"
+msgstr "Ripeti: Inattivo"
+
+#: id:596
+msgid "Repeat: One"
+msgstr "Ripeti: Uno"
+
+#: id:597
+msgid "Repeat: All"
+msgstr "Ripeti: Tutto"
+
+#: id:600
+msgid "Rip audio CD"
+msgstr "Rip CD audio"
+
+#: id:601
+msgctxt "Auto context with id 601"
+msgid "Medium"
+msgstr "Medio"
+
+#: id:602
+msgctxt "Auto context with id 602"
+msgid "Standard"
+msgstr "Standard"
+
+#: id:603
+msgid "Extreme"
+msgstr "Estremo"
+
+#: id:604
+msgid "Constant bitrate"
+msgstr "Bit rate costante"
+
+#: id:605
+msgid "Ripping..."
+msgstr "Rip in corso..."
+
+#: id:607
+msgid "To:"
+msgstr "A:"
+
+#: id:608
+msgid "Could not rip CD or track"
+msgstr "Impossibile rip del CD o della traccia"
+
+#: id:609
+msgid "CDDARipPath is not set."
+msgstr "Il percorso CDDARip non è impostato"
+
+#: id:610
+msgid "Rip audio track"
+msgstr "Rip traccia audio"
+
+#: id:611
+msgid "Enter number"
+msgstr "Inserire numero"
+
+#: id:612
+msgid "Bits/Sample"
+msgstr "Bit/Campionamento"
+
+#: id:613
+msgid "Sample Frequency"
+msgstr "Frequenza Campionamento"
+
+#: id:620
+msgid "Audio CDs"
+msgstr "CD Audio"
+
+#: id:621
+msgid "Encoder"
+msgstr "Codificatore"
+
+#: id:622
+msgid "Quality"
+msgstr "Qualità"
+
+#: id:623
+msgid "Bitrate"
+msgstr "Bit Rate"
+
+#: id:624
+msgid "Include track number"
+msgstr "Includi numero traccia"
+
+#: id:625
+msgid "All songs of"
+msgstr "Tutte canzoni di"
+
+#: id:629
+msgctxt "Auto context with id 629"
+msgid "View mode"
+msgstr "Modalità di visione"
+
+#: id:630
+msgctxt "Auto context with id 630"
+msgid "Normal"
+msgstr "Normale"
+
+#: id:631
+msgid "Zoom"
+msgstr "Zoom"
+
+#: id:632
+msgid "Stretch 4:3"
+msgstr "Forza 4:3"
+
+#: id:633
+msgid "Wide Zoom"
+msgstr "Forza 14:9"
+
+#: id:634
+msgid "Stretch 16:9"
+msgstr "Forza 16:9"
+
+#: id:635
+msgid "Original Size"
+msgstr "Dimensione originale"
+
+#: id:636
+msgctxt "Auto context with id 636"
+msgid "Custom"
+msgstr "Personalizzata"
+
+#: id:637
+msgid "Replay gain"
+msgstr "Replay gain"
+
+#: id:638
+msgid "Replaygain volume adjustments"
+msgstr "Regolazione volume \"Replaygain\""
+
+#: id:639
+msgid "Use track levels"
+msgstr "Usa livelli traccia"
+
+#: id:640
+msgid "Use album levels"
+msgstr "Usa livelli album"
+
+#: id:641
+msgid "PreAmp Level - Replay gained files"
+msgstr "Livello PreAmp - file \"Replay gained\""
+
+#: id:642
+msgid "PreAmp Level - Non replay gained files"
+msgstr "Livello PreAmp - file \"non Replay gained\""
+
+#: id:643
+msgid "Avoid clipping on replay gained files"
+msgstr "Evita clipping nei file \"Replay gained\""
+
+#: id:644
+msgid "Crop black bars"
+msgstr "Taglia bande nere"
+
+#: id:645
+msgid "Need to unpack a big file. Continue?"
+msgstr "Devo scompattare un file grande. Continuare?"
+
+#: id:646
+msgid "Remove from library"
+msgstr "Elimina dall'archivio"
+
+#: id:647
+msgid "Export video library"
+msgstr "Esporta l'archivio video"
+
+#: id:648
+msgid "Import video library"
+msgstr "Importa l'archivio video"
+
+#: id:649
+msgid "Importing"
+msgstr "Importazione"
+
+#: id:650
+msgid "Exporting"
+msgstr "Esportazione"
+
+#: id:651
+msgid "Browse for library"
+msgstr "Cerca archivio"
+
+#: id:652
+msgid "Years"
+msgstr "Anni"
+
+#: id:653
+msgid "Update library"
+msgstr "Aggiorna archivio"
+
+#: id:654
+msgid "Show debug info"
+msgstr "Mostra informazioni debug"
+
+#: id:655
+msgid "Browse for executable"
+msgstr "Cerca eseguibile"
+
+#: id:656
+msgid "Browse for playlist"
+msgstr "Cerca playlist"
+
+#: id:657
+msgid "Browse for folder"
+msgstr "Cerca cartella"
+
+#: id:658
+msgid "Song information"
+msgstr "Informazioni canzone"
+
+#: id:659
+msgid "Non-linear stretch"
+msgstr "Adattamento non lineare"
+
+#: id:660
+msgid "Volume amplification"
+msgstr "Amplificazione volume"
+
+#: id:661
+msgid "Choose export folder"
+msgstr "Selez. cartella esportazione"
+
+#: id:662
+msgid "This file is no longer available."
+msgstr "Questo file non è più disponibile."
+
+#: id:663
+msgid "Would you like to remove it from the library?"
+msgstr "Vuoi rimuoverlo dall'archivio?"
+
+#: id:664
+msgid "Browse for Script"
+msgstr "Cerca Script"
+
+#: id:665
+msgid "Compression level"
+msgstr "Livello Compressione"
+
+#: id:700
+msgid "Cleaning up library"
+msgstr "Pulisci l'archivio"
+
+#: id:701
+msgid "Removing old songs from the library"
+msgstr "Eliminazione vecchie canzoni dall'archivio"
+
+#: id:702
+msgid "This path has been scanned before"
+msgstr "Questo percorso è già stato esaminato in precedenza."
+
+#: id:705
+msgctxt "Auto context with id 705"
+msgid "Network"
+msgstr "Rete"
+
+#: id:706
+msgid "- Server"
+msgstr "- Server"
+
+#: id:708
+msgid "Use an HTTP proxy server to access the internet"
+msgstr "Usa un server proxy HTTP per accedere a internet"
+
+#: id:711
+msgid "Internet Protocol (IP)"
+msgstr "Internet Protocol (IP)"
+
+#: id:712
+msgid "Invalid port specified. Value must be between 1 and 65535."
+msgstr "Porta specificata non valida. Inserire un valore compreso tra 1 and 65535."
+
+#: id:713
+msgid "HTTP proxy"
+msgstr "HTTP proxy"
+
+#: id:715
+msgid "- Assignment"
+msgstr "- Assegnazione"
+
+#: id:716
+msgid "Automatic (DHCP)"
+msgstr "Automatico (DHCP)"
+
+#: id:717
+msgid "Manual (Static)"
+msgstr "Manuale (Static)"
+
+#: id:719
+msgid "- IP address"
+msgstr "- Indirizzo IP"
+
+#: id:720
+msgid "- Netmask"
+msgstr "- Netmask"
+
+#: id:721
+msgid "- Default gateway"
+msgstr "- Default gateway"
+
+#: id:722
+msgid "- DNS server"
+msgstr "- DNS server"
+
+#: id:723
+msgid "Save & restart"
+msgstr "Salva e riavvia"
+
+#: id:724
+msgid "Invalid address specified. Value must be AAA.BBB.CCC.DDD"
+msgstr "Indirizzo non valido. Inserire un valore tipo AAA.BBB.CCC.DDD"
+
+#: id:725
+msgid "with numbers between 0 and 255."
+msgstr "Con cifre tra 0 and 255."
+
+#: id:726
+msgid "Changes not saved. Continue without saving?"
+msgstr "Modifiche non salvate. Continuare senza salvare?"
+
+#: id:727
+msgid "Web server"
+msgstr "Web server"
+
+#: id:728
+msgctxt "Auto context with id 728"
+msgid "FTP server"
+msgstr "FTP server"
+
+#: id:730
+msgid "- Port"
+msgstr "- Porta"
+
+#: id:732
+msgid "Save & apply"
+msgstr "Salva e applica"
+
+#: id:733
+msgid "- Password"
+msgstr "- Password"
+
+#: id:734
+msgid "No pass"
+msgstr "Nessuna password"
+
+#: id:735
+msgid "- Character set"
+msgstr "- Set caratteri"
+
+#: id:736
+msgid "- Style"
+msgstr "- Stile"
+
+#: id:737
+msgid "- Colour"
+msgstr "- Colore"
+
+#: id:738
+msgctxt "Auto context with id 738"
+msgid "Normal"
+msgstr "Normale"
+
+#: id:739
+msgid "Bold"
+msgstr "Grassetto"
+
+#: id:740
+msgid "Italics"
+msgstr "Corsivo"
+
+#: id:741
+msgid "Bold italics"
+msgstr "Grassetto corsivo"
+
+#: id:742
+msgctxt "Auto context with id 742"
+msgid "White"
+msgstr "Bianco"
+
+#: id:743
+msgctxt "Auto context with id 743"
+msgid "Yellow"
+msgstr "Giallo"
+
+#: id:744
+msgctxt "Auto context with id 744"
+msgid "Files"
+msgstr "File"
+
+#: id:745
+msgid "No scanned information for this view"
+msgstr "Nessuna informazione per questa vista"
+
+#: id:746
+msgid "Please turn off library mode"
+msgstr "Disabilita vista archivio"
+
+#: id:747
+msgid "Error loading image"
+msgstr "Errore caricando l'immagine"
+
+#: id:748
+msgid "Edit path"
+msgstr "Modifica percorso"
+
+#: id:749
+msgid "Mirror image"
+msgstr "Rifletti immagine"
+
+#: id:750
+msgid "Are you sure?"
+msgstr "Sei sicuro?"
+
+#: id:751
+msgid "Removing source"
+msgstr "Rimuovo sorgente"
+
+#: id:754
+msgid "Add program link"
+msgstr "Aggiungi collegamento"
+
+#: id:755
+msgid "Edit program path"
+msgstr "Modifica percorso"
+
+#: id:756
+msgid "Edit program name"
+msgstr "Modifica nome programma"
+
+#: id:757
+msgid "Edit path depth"
+msgstr "Modifica profondità percorso"
+
+#: id:759
+msgid "View: Big list"
+msgstr "Visualizza: Lista grande"
+
+#: id:760
+msgctxt "Auto context with id 760"
+msgid "Yellow"
+msgstr "Giallo"
+
+#: id:761
+msgctxt "Auto context with id 761"
+msgid "White"
+msgstr "Bianco"
+
+#: id:762
+msgid "Blue"
+msgstr "Blu"
+
+#: id:763
+msgid "Bright green"
+msgstr "Verde"
+
+#: id:764
+msgid "Yellow green"
+msgstr "Giallo/verde"
+
+#: id:765
+msgid "Cyan"
+msgstr "Azzurro"
+
+#: id:766
+msgid "Light grey"
+msgstr "Grigio chiaro"
+
+#: id:767
+msgid "Grey"
+msgstr "Grigio"
+
+#: id:770
+msgid "Error %i: share not available"
+msgstr "Errore %i: condivisione non disponibile"
+
+#: id:772
+msgctxt "Auto context with id 772"
+msgid "Audio output"
+msgstr "Uscita audio"
+
+#: id:773
+msgid "Seeking"
+msgstr "Cercando"
+
+#: id:774
+msgid "Slideshow folder"
+msgstr "Cartella per salvaschermo fotografico"
+
+#: id:775
+msgid "Network interface"
+msgstr "Interfaccia di rete"
+
+#: id:776
+msgid "- Wireless network name (ESSID)"
+msgstr "- Nome della rete wireless (ESSID)"
+
+#: id:777
+msgid "- Wireless password"
+msgstr "- Password wireless"
+
+#: id:778
+msgid "- Wireless security"
+msgstr "- Sicurezza wireless"
+
+#: id:779
+msgid "Save and apply network interface settings"
+msgstr "Salva ed applica le impostazioni della rete"
+
+#: id:780
+msgid "No encryption"
+msgstr "Nessuna cifratura"
+
+#: id:781
+msgid "WEP"
+msgstr "WEP"
+
+#: id:782
+msgid "WPA"
+msgstr "WPA"
+
+#: id:783
+msgid "WPA2"
+msgstr "WPA2"
+
+#: id:784
+msgid "Applying network interface settings. Please wait."
+msgstr "Applicazione impostazioni rete in corso. Attendere prego."
+
+#: id:785
+msgid "Network interface restarted successfully."
+msgstr "Interfaccia di rete riavviata con successo."
+
+#: id:786
+msgid "Network interface did not start successfully."
+msgstr "Avvio dell'interfaccia di rete fallito"
+
+#: id:787
+msgid "Interface disabled"
+msgstr "Interfaccia disabilitata"
+
+#: id:788
+msgid "Network interface disabled successfully."
+msgstr "Disabilitazione dell'interfaccia di rete effettuata con successo."
+
+#: id:789
+msgid "Wireless network name (ESSID)"
+msgstr "Nome della rete wireless (ESSID)"
+
+#: id:790
+msgid "Remote control"
+msgstr ""
+
+#: id:791
+msgid "Allow programs on this system to control XBMC"
+msgstr "Permetti ai programmi installati di controllare XBMC"
+
+#: id:792
+msgctxt "Auto context with id 792"
+msgid "Port"
+msgstr "Porta"
+
+#: id:793
+msgid "Port range"
+msgstr "Range porte"
+
+#: id:794
+msgid "Allow programs on other systems to control XBMC"
+msgstr "Permetti a programmi esterni di controllare XBMC"
+
+#: id:795
+msgid "Initial repeat delay (ms)"
+msgstr "Ritardo ripetizione iniziale (ms)"
+
+#: id:796
+msgid "Continuous repeat delay (ms)"
+msgstr "Ritardo ripetizione continuo (ms)"
+
+#: id:797
+msgid "Maximum number of clients"
+msgstr "Numero massimo di client"
+
+#: id:798
+msgid "Internet access"
+msgstr "Accesso a Internet"
+
+#: id:850
+msgid "Invalid port number entered"
+msgstr "Inserito un numero di porta non valido"
+
+#: id:851
+msgid "Valid port range is 1-65535"
+msgstr "Il numero di porta deve essere compreso tra 1-65535"
+
+#: id:852
+msgid "Valid port range is 1024-65535"
+msgstr "Il numero di porta deve essere compreso tra 1024-65535"
+
+#: id:998
+msgid "Add Music..."
+msgstr "Aggiungi Musica..."
+
+#: id:999
+msgid "Add Videos..."
+msgstr "Aggiungi Video..."
+
+#: id:1000
+msgid "- Preview"
+msgstr "- Anteprima"
+
+#: id:1001
+msgid "Unable to connect"
+msgstr "Impossibile connettersi"
+
+#: id:1002
+msgid "XBMC was unable to connect to the network location."
+msgstr "XBMC non è riuscito a connettersi all'indirizzo di rete."
+
+#: id:1003
+msgid "This could be due to the network not being connected."
+msgstr "La possibile causa potrebbe essere la rete scollegata."
+
+#: id:1004
+msgid "Would you like to add it anyway?"
+msgstr "Vuoi aggiungerlo comunque?"
+
+#: id:1006
+msgctxt "Auto context with id 1006"
+msgid "IP address"
+msgstr "Indirizzo IP"
+
+#: id:1007
+msgid "Add network location"
+msgstr "Aggiungi indirizzo di rete"
+
+#: id:1008
+msgid "Protocol"
+msgstr "Protocollo"
+
+#: id:1009
+msgid "Server address"
+msgstr "Indirizzo del server"
+
+#: id:1010
+msgid "Server name"
+msgstr "Nome del server"
+
+#: id:1011
+msgid "Remote path"
+msgstr "Percorso remoto"
+
+#: id:1012
+msgid "Shared folder"
+msgstr "Cartella condivisa"
+
+#: id:1013
+msgctxt "Auto context with id 1013"
+msgid "Port"
+msgstr "Porta"
+
+#: id:1014
+msgctxt "Auto context with id 1014"
+msgid "Username"
+msgstr "Nome utente"
+
+#: id:1015
+msgid "Browse for network server"
+msgstr "Cerca server di rete"
+
+#: id:1016
+msgid "Enter the network address of the server"
+msgstr "Inserire l'indirizzo di rete del server"
+
+#: id:1017
+msgid "Enter the path on the server"
+msgstr "Inserire il percorso sul server"
+
+#: id:1018
+msgid "Enter the port number"
+msgstr "Inserire il numero della porta"
+
+#: id:1019
+msgid "Enter the username"
+msgstr "Inserire il nome utente"
+
+#: id:1020
+msgid "Add %s source"
+msgstr "Aggiungi sorgente %s"
+
+#: id:1021
+msgid "Enter the paths or browse for the media locations."
+msgstr "Inserisci i percorsi o esplora le locazioni dei media."
+
+#: id:1022
+msgid "Enter a name for this media Source."
+msgstr "Inserire un nome per questa sorgente."
+
+#: id:1023
+msgid "Browse for new share"
+msgstr "Cerca nuove condivisioni"
+
+#: id:1024
+msgid "Browse"
+msgstr "Esplora"
+
+#: id:1025
+msgid "Could not retrieve directory information."
+msgstr "Impossibile avere informazioni sulla directory."
+
+#: id:1026
+msgid "Add source"
+msgstr "Aggiungi sorgente"
+
+#: id:1027
+msgid "Edit source"
+msgstr "Modifica sorgente"
+
+#: id:1028
+msgid "Edit %s source"
+msgstr "Modifica sorgente %s"
+
+#: id:1029
+msgid "Enter the new label"
+msgstr "Inserire nuova etichetta"
+
+#: id:1030
+msgid "Browse for image"
+msgstr "Cerca immagine"
+
+#: id:1031
+msgid "Browse for image folder"
+msgstr "Cerca cartella immagini"
+
+#: id:1032
+msgid "Add network location..."
+msgstr "Aggiungi locazione di rete..."
+
+#: id:1033
+msgid "Browse for file"
+msgstr "Cerca file"
+
+#: id:1034
+msgid "Submenu"
+msgstr "Sottomenù"
+
+#: id:1035
+msgid "Enable submenu buttons"
+msgstr "Attiva pulsanti sottomenù"
+
+#: id:1036
+msgid "Favourites"
+msgstr "Preferiti"
+
+#: id:1037
+msgid "Video Add-ons"
+msgstr "Addon Video"
+
+#: id:1038
+msgid "Music Add-ons"
+msgstr "Addon Musica"
+
+#: id:1039
+msgid "Picture Add-ons"
+msgstr "Addon Immagini"
+
+#: id:1040
+msgid "Loading directory"
+msgstr "Caricamento cartella"
+
+#: id:1041
+msgid "Retrieved %i items"
+msgstr "Trovati %i elementi"
+
+#: id:1042
+msgid "Retrieved %i of %i items"
+msgstr "Trovati %i di %i elementi"
+
+#: id:1043
+msgid "Program Add-ons"
+msgstr "Addon Programmi"
+
+#: id:1044
+msgid "Set plugin thumb"
+msgstr "Imposta icona plugin"
+
+#: id:1045
+msgid "Add-on settings"
+msgstr "Impostazioni Add-on"
+
+#: id:1046
+msgid "Access points"
+msgstr "Access point"
+
+#: id:1047
+msgid "Other..."
+msgstr "Altro..."
+
+#: id:1048
+msgid "- Username"
+msgstr "- Nome utente"
+
+#: id:1049
+msgid "Script settings"
+msgstr "Impostazioni script"
+
+#: id:1050
+msgid "Singles"
+msgstr "Singoli"
+
+#: id:1051
+msgid "Enter web address"
+msgstr "Inserisci l'indirizzo web"
+
+#: id:1200
+msgid "SMB client"
+msgstr "client SMB"
+
+#: id:1202
+msgid "Workgroup"
+msgstr "Gruppo di lavoro"
+
+#: id:1203
+msgid "Default username"
+msgstr "Nome utente di default"
+
+#: id:1204
+msgid "Default password"
+msgstr "Password di default"
+
+#: id:1207
+msgid "WINS server"
+msgstr "server WINS"
+
+#: id:1208
+msgid "Mount SMB shares"
+msgstr "Monta condivisioni SMB"
+
+#: id:1210
+msgctxt "Auto context with id 1210"
+msgid "Remove"
+msgstr "Rimuovi"
+
+#: id:1211
+msgctxt "Auto context with id 1211"
+msgid "Music"
+msgstr "Musica"
+
+#: id:1212
+msgctxt "Auto context with id 1212"
+msgid "Video"
+msgstr "Video"
+
+#: id:1213
+msgctxt "Auto context with id 1213"
+msgid "Pictures"
+msgstr "Immagini"
+
+#: id:1214
+msgctxt "Auto context with id 1214"
+msgid "Files"
+msgstr "Files"
+
+#: id:1215
+msgctxt "Auto context with id 1215"
+msgid "Music & video"
+msgstr "Musica e video"
+
+#: id:1216
+msgid "Music & pictures"
+msgstr "Musica e immagini"
+
+#: id:1217
+msgid "Music & files"
+msgstr "Musica e file"
+
+#: id:1218
+msgid "Video & pictures"
+msgstr "Video e immagini"
+
+#: id:1219
+msgid "Video & files"
+msgstr "Video e file"
+
+#: id:1220
+msgid "Pictures & files"
+msgstr "Immagini e file"
+
+#: id:1221
+msgid "Music & video & pictures"
+msgstr "Musica, video e immagini"
+
+#: id:1222
+msgid "Music & video & pictures & files"
+msgstr "Musica, video, immagini e file"
+
+#: id:1223
+msgctxt "Auto context with id 1223"
+msgid "Disabled"
+msgstr "Disattivo"
+
+#: id:1226
+msgid "Files & music & video"
+msgstr "File, musica e video"
+
+#: id:1227
+msgid "Files & pictures & music"
+msgstr "File, immagini e musica"
+
+#: id:1228
+msgid "Files & pictures & video"
+msgstr "File, immagini e video"
+
+#: id:1229
+msgid "Music & programs"
+msgstr "Musica e programmi"
+
+#: id:1230
+msgid "Video & programs"
+msgstr "Video e programmi"
+
+#: id:1231
+msgid "Pictures & programs"
+msgstr "Immagini e programmi"
+
+#: id:1232
+msgid "Music & video & pictures & programs"
+msgstr "Musica, video, immagini e programmi"
+
+#: id:1233
+msgid "Programs & video & music"
+msgstr "Programmi, video e musica"
+
+#: id:1234
+msgid "Programs & pictures & music"
+msgstr "Programmi, immagini e musica"
+
+#: id:1235
+msgid "Programs & pictures & video"
+msgstr "Programmi, immagini e video"
+
+#: id:1250
+msgid "Auto-detection"
+msgstr "Autorilevamento"
+
+#: id:1251
+msgid "Auto-detect system"
+msgstr "Autorilevamento sistema"
+
+#: id:1252
+msgid "Nickname"
+msgstr "Nick name"
+
+#: id:1254
+msgid "Ask to connect"
+msgstr "Richiedi di connettersi"
+
+#: id:1255
+msgid "Send FTP user and password"
+msgstr "Invia user e password FTP"
+
+#: id:1256
+msgid "Ping interval"
+msgstr "Intervallo ping"
+
+#: id:1257
+msgid "Would you like to connect to the auto-detected system?"
+msgstr "Vuoi connetterti al sistema rilevato?"
+
+#: id:1259
+msgid "Zeroconf"
+msgstr ""
+
+#: id:1260
+msgid "Announce these services to other systems via Zeroconf"
+msgstr "Annuncia questi servizi ad altri sistemi via Zeroconf"
+
+#: id:1270
+msgid "Allow XBMC to receive AirPlay content"
+msgstr "Permetti ad XBMC di ricevere contenuti da AirPlay"
+
+#: id:1271
+msgid "Device name"
+msgstr "Nome periferica"
+
+#: id:1272
+msgid "- Use password protection"
+msgstr "- Proteggi con password"
+
+#: id:1273
+msgid "AirPlay"
+msgstr ""
+
+#: id:1300
+msgid "Custom audio device"
+msgstr "Dispositivo audio personalizzato"
+
+#: id:1301
+msgid "Custom passthrough device"
+msgstr "Dispositivo passthrough personalizzato"
+
+#: id:1396
+msgid "Drifting"
+msgstr "Mutevole"
+
+#: id:1397
+msgid "and"
+msgstr "e"
+
+#: id:1398
+msgid "Freezing"
+msgstr "Gelata"
+
+#: id:1399
+msgid "Late"
+msgstr "Tardi"
+
+#: id:1400
+msgid "Isolated"
+msgstr "Isolati"
+
+#: id:1401
+msgid "Thundershowers"
+msgstr "Acquazzoni"
+
+#: id:1402
+msgid "Thunder"
+msgstr "Fulmini"
+
+#: id:1403
+msgctxt "Auto context with id 1403"
+msgid "Sun"
+msgstr "Sole"
+
+#: id:1404
+msgid "Heavy"
+msgstr "Intensi"
+
+#: id:1405
+msgid "in"
+msgstr "nelle"
+
+#: id:1406
+msgid "the"
+msgstr "-"
+
+#: id:1407
+msgid "Vicinity"
+msgstr "Vicinanze"
+
+#: id:1408
+msgid "Ice"
+msgstr "Ghiaccio"
+
+#: id:1409
+msgid "Crystals"
+msgstr "Cristalli"
+
+#: id:1410
+msgid "Calm"
+msgstr "Calmo"
+
+#: id:1411
+msgid "with"
+msgstr "con"
+
+#: id:1412
+msgid "windy"
+msgstr "ventilato"
+
+#: id:1413
+msgid "drizzle"
+msgstr "pioggia leggera"
+
+#: id:1414
+msgid "Thunderstorm"
+msgstr "Temporale"
+
+#: id:1415
+msgid "Drizzle"
+msgstr "Acquerugiola"
+
+#: id:1416
+msgid "Foggy"
+msgstr "Nebbie"
+
+#: id:1417
+msgid "Grains"
+msgstr "Grani"
+
+#: id:1418
+msgid "T-Storms"
+msgstr "Tempeste"
+
+#: id:1419
+msgid "T-Showers"
+msgstr "Piogge"
+
+#: id:1420
+msgid "Moderate"
+msgstr "Moderate"
+
+#: id:1421
+msgid "Very High"
+msgstr "Molto Alto"
+
+#: id:1422
+msgid "Windy"
+msgstr "Ventoso"
+
+#: id:1423
+msgid "Mist"
+msgstr "Nebbia"
+
+#: id:1450
+msgid "Put display to sleep when idle"
+msgstr "Metti lo schermo in risparmio energetico quando inattivo"
+
+#: id:2050
+msgid "Runtime"
+msgstr "Durata:"
+
+#: id:2100
+msgid "Script failed! : %s"
+msgstr "Esecuzione script non riuscita! : %s"
+
+#: id:2101
+msgid "Newer version needed - See log"
+msgstr "Necessaria una versione più recente - Controlla il log"
+
+#: id:4501
+msgid "Enable LCD/VFD"
+msgstr "Abilita LCD/VFD"
+
+#: id:10000
+msgid "Home"
+msgstr "Home"
+
+#: id:10001
+msgctxt "Auto context with id 10001"
+msgid "Programs"
+msgstr "Programmi"
+
+#: id:10002
+msgctxt "Auto context with id 10002"
+msgid "Pictures"
+msgstr "Immagini"
+
+#: id:10003
+msgctxt "Auto context with id 10003"
+msgid "File manager"
+msgstr "File"
+
+#: id:10004
+msgctxt "Auto context with id 10004"
+msgid "Settings"
+msgstr "Impostazioni"
+
+#: id:10005
+msgctxt "Auto context with id 10005"
+msgid "Music"
+msgstr "Musica"
+
+#: id:10006
+msgctxt "Auto context with id 10006"
+msgid "Videos"
+msgstr "Video"
+
+#: id:10007
+msgid "System information"
+msgstr "Informazioni sistema"
+
+#: id:10008
+msgid "Settings - General"
+msgstr "Impostazioni - Generale"
+
+#: id:10009
+msgid "Settings - Screen"
+msgstr "Impostazioni - Video"
+
+#: id:10010
+msgid "Settings - Appearance - GUI Calibration"
+msgstr "Impostazioni - Aspetto - Calibrazione GUI"
+
+#: id:10011
+msgid "Settings - Videos - Screen Calibration"
+msgstr "Impostazioni - Video - Calibrazione Schermo"
+
+#: id:10012
+msgid "Settings - Pictures"
+msgstr "Impostazioni - Immagini"
+
+#: id:10013
+msgid "Settings - Programs"
+msgstr "Impostazioni - Programmi"
+
+#: id:10014
+msgid "Settings - Weather"
+msgstr "Impostazioni - Meteo"
+
+#: id:10015
+msgid "Settings - Music"
+msgstr "Impostazioni - Musica"
+
+#: id:10016
+msgid "Settings - System"
+msgstr "Impostazioni - Sistema"
+
+#: id:10017
+msgid "Settings - Videos"
+msgstr "Impostazioni - Video"
+
+#: id:10018
+msgid "Settings - Network"
+msgstr "Impostazioni - Rete"
+
+#: id:10019
+msgid "Settings - Appearance"
+msgstr "Impostazioni - Aspetto"
+
+#: id:10020
+msgctxt "Auto context with id 10020"
+msgid "Scripts"
+msgstr "Script"
+
+#: id:10021
+msgid "Web Browser"
+msgstr "Browser Web"
+
+#: id:10025
+msgctxt "Auto context with id 10025"
+msgid "Videos"
+msgstr ""
+
+#: id:10028
+msgid "Videos/Playlist"
+msgstr "Video/Playlist"
+
+#: id:10029
+msgctxt "Auto context with id 10029"
+msgid "Login screen"
+msgstr ""
+
+#: id:10034
+msgid "Settings - Profiles"
+msgstr "Impostazioni - Profili"
+
+#: id:10040
+msgid "Addon browser"
+msgstr ""
+
+#: id:10100
+msgid "Yes/No dialog"
+msgstr "Casella di dialogo si/no"
+
+#: id:10101
+msgid "Progress dialog"
+msgstr "Casella di Progresso"
+
+#: id:10210
+msgid "Looking for subtitles..."
+msgstr "Cerco i sottotitoli..."
+
+#: id:10211
+msgid "Looking for or caching subtitles..."
+msgstr "Ricerca o memorizzazione sottotitoli..."
+
+#: id:10212
+msgid "terminating"
+msgstr "terminando"
+
+#: id:10213
+msgid "buffering"
+msgstr "buffering"
+
+#: id:10214
+msgid "Opening stream"
+msgstr "Apertura stream"
+
+#: id:10500
+msgid "Music/Playlist"
+msgstr "Musica/Playlist"
+
+#: id:10501
+msgid "Music/Files"
+msgstr "Musica/File"
+
+#: id:10502
+msgid "Music/Library"
+msgstr "Musica/Archivio"
+
+#: id:10503
+msgid "Playlist editor"
+msgstr "Editor playlist"
+
+#: id:10504
+msgid "Top 100 songs"
+msgstr "Top 100 canzoni"
+
+#: id:10505
+msgid "Top 100 albums"
+msgstr "Top 100 albums"
+
+#: id:10506
+msgctxt "Auto context with id 10506"
+msgid "Programs"
+msgstr "Programmi"
+
+#: id:10507
+msgid "Configuration"
+msgstr "Configurazione"
+
+#: id:10508
+msgid "Weather forecast"
+msgstr "Previsioni meteo"
+
+#: id:10509
+msgid "Network gaming"
+msgstr "Gioco online"
+
+#: id:10510
+msgid "Extensions"
+msgstr "Estensioni"
+
+#: id:10511
+msgctxt "Auto context with id 10511"
+msgid "System info"
+msgstr "Info sistema"
+
+#: id:10516
+msgid "Music - Library"
+msgstr "Musica - Archivio"
+
+#: id:10517
+msgid "Now Playing - Music"
+msgstr "Musica - In Riproduzione"
+
+#: id:10522
+msgid "Now Playing - Videos"
+msgstr "Video - In Riproduzione"
+
+#: id:10523
+msgid "Album info"
+msgstr "Info album"
+
+#: id:10524
+msgid "Movie info"
+msgstr "Info film"
+
+#: id:12000
+msgid "Select dialog"
+msgstr "Casella di selezione"
+
+#: id:12001
+msgid "Music/Info"
+msgstr "Musica/Info"
+
+#: id:12002
+msgid "Dialog OK"
+msgstr "Dialog OK"
+
+#: id:12003
+msgid "Videos/Info"
+msgstr "Video/Info"
+
+#: id:12004
+msgid "Scripts/Info"
+msgstr "Script/Info"
+
+#: id:12005
+msgid "Fullscreen video"
+msgstr "Video a schermo intero"
+
+#: id:12006
+msgid "Audio visualization"
+msgstr "Effetti grafici"
+
+#: id:12008
+msgid "File stacking dialog"
+msgstr "Casella di unisci"
+
+#: id:12009
+msgid "Rebuild index..."
+msgstr "Ricostruzione indice..."
+
+#: id:12010
+msgid "Return to music window"
+msgstr "Ritorna in musica"
+
+#: id:12011
+msgid "Return to videos window"
+msgstr "Ritorna in video"
+
+#: id:12021
+msgid "Start from beginning"
+msgstr "Parti dall'inizio"
+
+#: id:12022
+msgid "Resume from %s"
+msgstr "Riprendi da %s"
+
+#: id:12310
+msgid "0"
+msgstr "0"
+
+#: id:12311
+msgid "1"
+msgstr "1"
+
+#: id:12312
+msgid "2"
+msgstr "2"
+
+#: id:12313
+msgid "3"
+msgstr "3"
+
+#: id:12314
+msgid "4"
+msgstr "4"
+
+#: id:12315
+msgid "5"
+msgstr "5"
+
+#: id:12316
+msgid "6"
+msgstr "6"
+
+#: id:12317
+msgid "7"
+msgstr "7"
+
+#: id:12318
+msgid "8"
+msgstr "8"
+
+#: id:12319
+msgid "9"
+msgstr "9"
+
+#: id:12320
+msgid "c"
+msgstr "c"
+
+#: id:12321
+msgid "Ok"
+msgstr "Ok"
+
+#: id:12322
+msgid "*"
+msgstr "*"
+
+#: id:12325
+msgid "Locked! Enter code..."
+msgstr "Bloccata! Inserire codice..."
+
+#: id:12326
+msgid "Enter password"
+msgstr "Inserire password"
+
+#: id:12327
+msgid "Enter master code"
+msgstr "Inserire master code"
+
+#: id:12328
+msgid "Enter unlock code"
+msgstr "Inserire codice sblocco"
+
+#: id:12329
+msgid "or press C to cancel"
+msgstr "o premere C per annullare"
+
+#: id:12330
+msgid "Enter gamepad button combo and"
+msgstr "Inserire combinazione tasti gamepad e"
+
+#: id:12331
+msgid "press OK, or Back to cancel"
+msgstr "premere OK, oppure Back per annullare"
+
+#: id:12332
+msgid "Set lock"
+msgstr "Blocca"
+
+#: id:12333
+msgid "Unlock"
+msgstr "Sblocca"
+
+#: id:12334
+msgid "Reset lock"
+msgstr "Reset blocco"
+
+#: id:12335
+msgid "Remove lock"
+msgstr "Rimuovi blocco"
+
+#: id:12337
+msgid "Numeric password"
+msgstr "Password numerica"
+
+#: id:12338
+msgid "Gamepad button combo"
+msgstr "Sequenza tasti gamepad"
+
+#: id:12339
+msgid "Full-text password"
+msgstr "Password di solo testo"
+
+#: id:12340
+msgid "Enter new password"
+msgstr "Inserire nuova password"
+
+#: id:12341
+msgid "Re-Enter new password"
+msgstr "Re-Inserire nuova password"
+
+#: id:12342
+msgid "Incorrect password,"
+msgstr "Password errata,"
+
+#: id:12343
+msgid "retries left"
+msgstr "tentativi rimasti."
+
+#: id:12344
+msgid "Passwords entered did not match."
+msgstr "La password inserita non è corretta."
+
+#: id:12345
+msgid "Access denied"
+msgstr "Accesso negato"
+
+#: id:12346
+msgid "Password retry limit exceeded."
+msgstr "Limite di tentativi superato."
+
+#: id:12347
+msgid "The system will now shut off."
+msgstr "Il sistema ora si spegnerà."
+
+#: id:12348
+msgid "Item locked"
+msgstr "Elemento bloccato"
+
+#: id:12353
+msgid "Reactivate lock"
+msgstr "Riattiva blocco"
+
+#: id:12356
+msgid "Change lock"
+msgstr "Cambia blocco"
+
+#: id:12357
+msgid "Source lock"
+msgstr "Blocca sorgente"
+
+#: id:12358
+msgid "Password entry was blank. Try again."
+msgstr "La password inserita è vuota. Riprova."
+
+#: id:12360
+msgid "Master lock"
+msgstr "Master lock"
+
+#: id:12362
+msgid "Shutdown system if Master Lock retries exceeded"
+msgstr "Spegni sistema ad esaurimento tentativi"
+
+#: id:12367
+msgid "Master code is not valid"
+msgstr "Il master code non è valido"
+
+#: id:12368
+msgid "Please enter a valid master code"
+msgstr "Inserire un master code valido"
+
+#: id:12373
+msgid "Settings & file manager"
+msgstr "Impostazioni & file"
+
+#: id:12376
+msgid "Set as default for all movies"
+msgstr "Imposta come default per tutti i filmati"
+
+#: id:12377
+msgid "This will reset any previously saved values"
+msgstr "Questo resetterà i valori salvati in precedenza"
+
+#: id:12378
+msgid "Amount of time to display each image"
+msgstr "Tempo di visualizzazione di ogni immagine"
+
+#: id:12379
+msgid "Use pan and zoom effects"
+msgstr "Usa gli effetti pan e zoom"
+
+#: id:12383
+msgid "12 hour clock"
+msgstr "Orario in 12 ore"
+
+#: id:12384
+msgid "24 hour clock"
+msgstr "Orario in 24 ore"
+
+#: id:12385
+msgid "Day/Month"
+msgstr "Giorno/Mese"
+
+#: id:12386
+msgid "Month/Day"
+msgstr "Mese/Giorno"
+
+#: id:12390
+msgid "System uptime"
+msgstr "Tempo di vita del sistema"
+
+#: id:12391
+msgid "Minutes"
+msgstr "Minuti"
+
+#: id:12392
+msgid "Hours"
+msgstr "Ore"
+
+#: id:12393
+msgid "Days"
+msgstr "Giorni"
+
+#: id:12394
+msgid "Total uptime"
+msgstr "Tempo totale d'accensione"
+
+#: id:12395
+msgid "Battery level"
+msgstr "Livello Batteria"
+
+#: id:12600
+msgctxt "Auto context with id 12600"
+msgid "Weather"
+msgstr "Meteo"
+
+#: id:12900
+msgctxt "Auto context with id 12900"
+msgid "Screensaver"
+msgstr "Salvaschermo"
+
+#: id:12901
+msgid "Fullscreen OSD"
+msgstr "OSD a schermo intero"
+
+#: id:13000
+msgid "System"
+msgstr "Sistema"
+
+#: id:13001
+msgid "Immediate HD spindown"
+msgstr "Autospegnimento hard disk immediato"
+
+#: id:13002
+msgid "Video only"
+msgstr "Solo video"
+
+#: id:13003
+msgid "- Delay"
+msgstr "- Ritardo"
+
+#: id:13004
+msgid "- Minimum file duration"
+msgstr "- Durata minima del file"
+
+#: id:13005
+msgid "Shutdown"
+msgstr "Spegni"
+
+#: id:13008
+msgid "Shutdown function"
+msgstr "Funzionalità spegnimento"
+
+#: id:13009
+msgid "Quit"
+msgstr "Chiudi"
+
+#: id:13010
+msgid "Hibernate"
+msgstr "Iberna"
+
+#: id:13011
+msgid "Suspend"
+msgstr "Sospendi"
+
+#: id:13012
+msgid "Exit"
+msgstr "Esci"
+
+#: id:13013
+msgid "Reboot"
+msgstr "Riavvia"
+
+#: id:13014
+msgid "Minimize"
+msgstr "Riduci ad icona"
+
+#: id:13015
+msgid "Power button action"
+msgstr "Comportamento tasto power"
+
+#: id:13016
+msgid "Power off System"
+msgstr "Spegni Sistema"
+
+#: id:13020
+msgid "Is another session active, perhaps over ssh?"
+msgstr "C'è un'altra sessione attiva, forse via SSH?"
+
+#: id:13021
+msgid "Mounted removable harddrive"
+msgstr "Hard disk rimuovibile montato"
+
+#: id:13022
+msgid "Unsafe device removal"
+msgstr "Rimozione insicura"
+
+#: id:13023
+msgid "Successfully removed device"
+msgstr "Rimozione periferica effettuata"
+
+#: id:13024
+msgid "Joystick plugged"
+msgstr "Joystick inserito"
+
+#: id:13025
+msgid "Joystick unplugged"
+msgstr "Joystick disinserito"
+
+#: id:13050
+msgid "Running low on battery"
+msgstr "Batteria scarica"
+
+#: id:13100
+msgid "Flicker filter"
+msgstr "Filtro sfarfallio"
+
+#: id:13101
+msgid "Let driver choose (requires restart)"
+msgstr "Fai scegliere al driver (riavvio necessario)"
+
+#: id:13105
+msgid "Vertical blank sync"
+msgstr "Vertical blank sync"
+
+#: id:13106
+msgctxt "Auto context with id 13106"
+msgid "Disabled"
+msgstr "Disattivato"
+
+#: id:13107
+msgid "Enabled during video playback"
+msgstr "Attivo durante la riproduzione video"
+
+#: id:13108
+msgctxt "Auto context with id 13108"
+msgid "Always enabled"
+msgstr "Sempre attivo"
+
+#: id:13109
+msgid "Test & apply resolution"
+msgstr "Prova e applica risoluzione"
+
+#: id:13110
+msgid "Save resolution?"
+msgstr "Salva risoluzione?"
+
+#: id:13111
+msgid "Would you like to keep this resolution?"
+msgstr "Vuoi mantenere questa risoluzione?"
+
+#: id:13112
+msgid "High quality upscaling"
+msgstr "Ridimensionamento ad alta qualità"
+
+#: id:13113
+msgctxt "Auto context with id 13113"
+msgid "Disabled"
+msgstr "Disabilitato"
+
+#: id:13114
+msgid "Enabled for SD content"
+msgstr "Attivo per Contenuto SD"
+
+#: id:13115
+msgctxt "Auto context with id 13115"
+msgid "Always enabled"
+msgstr "Sempre attivo"
+
+#: id:13116
+msgid "Upscaling method"
+msgstr "Modalità di ridimensionamento"
+
+#: id:13117
+msgctxt "Auto context with id 13117"
+msgid "Bicubic"
+msgstr "Bicubico"
+
+#: id:13118
+msgid "Lanczos"
+msgstr "Lanczos"
+
+#: id:13119
+msgid "Sinc"
+msgstr "Sinc"
+
+#: id:13120
+msgctxt "Auto context with id 13120"
+msgid "VDPAU"
+msgstr "VDPAU"
+
+#: id:13121
+msgid "VDPAU HQ Upscaling level"
+msgstr "Livello VDPAU HQ Upscaling"
+
+#: id:13122
+msgid "VDPAU Studio level color conversion"
+msgstr "Livello di conversione colore VDPAU Studio"
+
+#: id:13130
+msgid "Blank other displays"
+msgstr "Svuota gli altri schermi"
+
+#: id:13131
+msgctxt "Auto context with id 13131"
+msgid "Disabled"
+msgstr "Disabilitato"
+
+#: id:13132
+msgid "Blank displays"
+msgstr "Schermi vuoti"
+
+#: id:13140
+msgid "Active connections detected!"
+msgstr "Rilevata connessione attiva!"
+
+#: id:13141
+msgid "If you proceed, you might not be able to control XBMC"
+msgstr "Se continui, potresti non essere in grado di controllare XBMC."
+
+#: id:13142
+msgid "any longer. Are you sure you want to stop the Event server?"
+msgstr "Sei sicuro di voler fermare l'Event server?"
+
+#: id:13144
+msgid "Change Apple Remote mode?"
+msgstr "Modifica modalità Apple Remote?"
+
+#: id:13145
+msgid "If you are currently using the Apple Remote to control"
+msgstr "Se stai usando un Apple Remote per controllare"
+
+#: id:13146
+msgid "XBMC, changing this setting might affect your ability"
+msgstr "XBMC, cambiare quest'impostazione potrebbe impedirti"
+
+#: id:13147
+msgid "to continue controlling it. Do you want to proceed?"
+msgstr "di continuare a controllarlo. Vuoi continuare?"
+
+#: id:13159
+msgid "Subnet mask"
+msgstr "Maschera subnet:"
+
+#: id:13160
+msgid "Gateway"
+msgstr "Gateway:"
+
+#: id:13161
+msgid "Primary DNS"
+msgstr "DNS Primario"
+
+#: id:13162
+msgid "Initialize failed"
+msgstr "Inizializzazione fallita"
+
+#: id:13170
+msgctxt "Auto context with id 13170"
+msgid "Never"
+msgstr "Mai"
+
+#: id:13171
+msgid "Immediately"
+msgstr "Immediatamente"
+
+#: id:13172
+msgid "After %i secs"
+msgstr "Dopo %i secondi"
+
+#: id:13173
+msgid "HDD install date:"
+msgstr "Data installazione hard disk:"
+
+#: id:13174
+msgid "HDD power cycle count:"
+msgstr "Conteggio spegnimento HDD:"
+
+#: id:13200
+msgid "Profiles"
+msgstr "Profili"
+
+#: id:13201
+msgid "Delete profile '%s'?"
+msgstr "Cancella profilo '%i'?"
+
+#: id:13204
+msgid "Last loaded profile:"
+msgstr "Ultimo profilo caricato:"
+
+#: id:13205
+msgid "Unknown"
+msgstr "Sconosciuto"
+
+#: id:13206
+msgid "Overwrite"
+msgstr "Sovrascrivi"
+
+#: id:13208
+msgid "Alarm clock"
+msgstr "Allarme sveglia"
+
+#: id:13209
+msgid "Alarm clock interval (in minutes)"
+msgstr "Intervallo allarme sveglia (in minuti)"
+
+#: id:13210
+msgid "Started, alarm in %im"
+msgstr "Partito, allarme tra %im"
+
+#: id:13211
+msgid "Alarm!"
+msgstr "Allarme!"
+
+#: id:13212
+msgid "Canceled with %im%is left"
+msgstr "Annullato con ancora %im%is"
+
+#: id:13213
+msgid "%2.0fm"
+msgstr "%2.0fm"
+
+#: id:13214
+msgid "%2.0fs"
+msgstr "%2.0fs"
+
+#: id:13249
+msgid "Search for subtitles in RARs"
+msgstr "Cerca sottotili nei file RAR"
+
+#: id:13250
+msgid "Browse for subtitle..."
+msgstr "Mostra sottotitoli..."
+
+#: id:13251
+msgid "Move item"
+msgstr "Sposta l'elemento"
+
+#: id:13252
+msgid "Move item here"
+msgstr "Sposta l'elemento qui"
+
+#: id:13253
+msgid "Cancel move"
+msgstr "Annulla spostamento"
+
+#: id:13270
+msgid "Hardware:"
+msgstr "Hardware:"
+
+#: id:13271
+msgid "CPU Usage:"
+msgstr "Utilizzo CPU:"
+
+#: id:13274
+msgid "Connected, but no DNS is available."
+msgstr "Connesso, ma non c'è nessun DNS disponibile."
+
+#: id:13275
+msgid "Hard Disk"
+msgstr "Hard Disk"
+
+#: id:13276
+msgid "DVD-ROM"
+msgstr "DVD-ROM"
+
+#: id:13277
+msgctxt "Auto context with id 13277"
+msgid "Storage"
+msgstr "Disp. di memoriz."
+
+#: id:13278
+msgctxt "Auto context with id 13278"
+msgid "Default"
+msgstr "Default"
+
+#: id:13279
+msgctxt "Auto context with id 13279"
+msgid "Network"
+msgstr "Rete"
+
+#: id:13280
+msgctxt "Auto context with id 13280"
+msgid "Video"
+msgstr "Video"
+
+#: id:13281
+msgid "Hardware"
+msgstr "Hardware"
+
+#: id:13283
+msgid "Operating system:"
+msgstr "Sistema operativo:"
+
+#: id:13284
+msgid "CPU speed:"
+msgstr "Velocità CPU:"
+
+#: id:13286
+msgid "Video encoder:"
+msgstr "Codificatore video:"
+
+#: id:13287
+msgid "Screen resolution:"
+msgstr "Risoluzione schermo:"
+
+#: id:13292
+msgid "A/V cable:"
+msgstr "Cavo A/V:"
+
+#: id:13294
+msgid "DVD region:"
+msgstr "Regione DVD:"
+
+#: id:13295
+msgid "Internet:"
+msgstr "Internet:"
+
+#: id:13296
+msgctxt "Auto context with id 13296"
+msgid "Connected"
+msgstr "Connessa"
+
+#: id:13297
+msgid "Not connected. Check network settings."
+msgstr "Non connessa. Controlla configurazione rete!"
+
+#: id:13299
+msgid "Target temperature"
+msgstr "Temperatura da raggiungere"
+
+#: id:13300
+msgid "Fan speed"
+msgstr "Velocità ventola"
+
+#: id:13301
+msgid "Auto temperature control"
+msgstr "Controllo automatico temperatura"
+
+#: id:13302
+msgid "Fan speed override"
+msgstr "Controllo velocità ventola"
+
+#: id:13303
+msgid "- Fonts"
+msgstr "- Carattere"
+
+#: id:13304
+msgid "Enable flipping bi-directional strings"
+msgstr "Abilita inversione in stringhe bidirezionali"
+
+#: id:13305
+msgid "Show RSS news feeds"
+msgstr "Mostra i feed RSS"
+
+#: id:13306
+msgid "Show parent folder items"
+msgstr "Mostra gli elementi delle cartelle superiori"
+
+#: id:13307
+msgid "Track naming template"
+msgstr "Stile della lista delle tracce"
+
+#: id:13308
+msgid "Do you wish to reboot your system"
+msgstr "Vuoi riavviare il sistema"
+
+#: id:13309
+msgid "instead of just XBMC?"
+msgstr "invece di XBMC?"
+
+#: id:13310
+msgid "Zoom effect"
+msgstr "Effetto zoom"
+
+#: id:13311
+msgid "Float effect"
+msgstr "Effetto spostamento"
+
+#: id:13312
+msgid "Black bar reduction"
+msgstr "Riduzione banda nera"
+
+#: id:13313
+msgid "Restart"
+msgstr "Riavvia"
+
+#: id:13314
+msgid "Crossfade between songs"
+msgstr "Dissolvenza tra le tracce"
+
+#: id:13315
+msgid "Regenerate thumbnails"
+msgstr "Ricrea le icone"
+
+#: id:13316
+msgid "Recursive thumbnails"
+msgstr "Icone ricorsive"
+
+#: id:13317
+msgid "View slideshow"
+msgstr "Vedi la Presentazione"
+
+#: id:13318
+msgid "Recursive slideshow"
+msgstr "Presentazione ricorsiva"
+
+#: id:13319
+msgid "Randomize"
+msgstr "Ordine sparso"
+
+#: id:13320
+msgid "Stereo"
+msgstr "Stereo"
+
+#: id:13321
+msgid "Left only"
+msgstr "Solo sinistra"
+
+#: id:13322
+msgid "Right only"
+msgstr "Solo destra"
+
+#: id:13323
+msgid "Enable karaoke support"
+msgstr "Abilita il supporto al karaoke"
+
+#: id:13324
+msgid "Background transparency"
+msgstr "Trasparenza sfondo"
+
+#: id:13325
+msgid "Foreground transparency"
+msgstr "Trasparenza primo piano"
+
+#: id:13326
+msgid "A/V delay"
+msgstr "Ritardo A/V"
+
+#: id:13327
+msgid "Karaoke"
+msgstr "Karaoke"
+
+#: id:13328
+msgid "%s not found"
+msgstr "%s non trovato."
+
+#: id:13329
+msgid "Error opening %s"
+msgstr "Errore apertura %s"
+
+#: id:13330
+msgid "Unable to load %s"
+msgstr "Impossibile caricare %s"
+
+#: id:13331
+msgid "Error: Out of memory"
+msgstr "Errore: Memoria insufficiente."
+
+#: id:13332
+msgid "Move up"
+msgstr "Muovi su"
+
+#: id:13333
+msgid "Move down"
+msgstr "Muovi giu"
+
+#: id:13334
+msgid "Edit label"
+msgstr "Edit label"
+
+#: id:13335
+msgid "Make default"
+msgstr "Imposta predefinito"
+
+#: id:13336
+msgid "Remove button"
+msgstr "Rimuovi pulsante"
+
+#: id:13340
+msgid "Leave as is"
+msgstr "Lascia com'è"
+
+#: id:13341
+msgid "Green"
+msgstr "Verde"
+
+#: id:13342
+msgid "Orange"
+msgstr "Arancione"
+
+#: id:13343
+msgid "Red"
+msgstr "Rosso"
+
+#: id:13344
+msgid "Cycle"
+msgstr "Ciclico"
+
+#: id:13345
+msgid "Switch LED off on playback"
+msgstr "Spegni il LED durante l'esecuzione"
+
+#: id:13346
+msgctxt "Auto context with id 13346"
+msgid "Movie information"
+msgstr "Informazioni film"
+
+#: id:13347
+msgid "Queue item"
+msgstr "Accoda l'elemento"
+
+#: id:13348
+msgid "Search IMDb..."
+msgstr "Cerca in IMDb..."
+
+#: id:13349
+msgid "Scan for new content"
+msgstr "Cerca info per tutti i file"
+
+#: id:13350
+msgid "Now playing..."
+msgstr "In riproduzione..."
+
+#: id:13351
+msgctxt "Auto context with id 13351"
+msgid "Album information"
+msgstr "Informazioni album"
+
+#: id:13352
+msgid "Scan item to library"
+msgstr "Scans.elemento nell'archivio"
+
+#: id:13353
+msgid "Stop scanning"
+msgstr "Ferma scansione"
+
+#: id:13354
+msgctxt "Auto context with id 13354"
+msgid "Render method"
+msgstr "Metodo di render"
+
+#: id:13355
+msgid "Low quality pixel shader"
+msgstr "Pixel shader bassa qualità"
+
+#: id:13356
+msgid "Hardware overlays"
+msgstr "Overlay hardware"
+
+#: id:13357
+msgid "High quality pixel shader"
+msgstr "Pixel shader alta qualità"
+
+#: id:13358
+msgid "Play item"
+msgstr "Play file"
+
+#: id:13359
+msgid "Set artist thumb"
+msgstr "Setta icona artista"
+
+#: id:13360
+msgid "Automatically generate thumbnails"
+msgstr "Crea le icone automaticamente"
+
+#: id:13361
+msgid "Enable voice"
+msgstr "Attiva voce"
+
+#: id:13375
+msgid "Enable device"
+msgstr "Attiva dispositivo"
+
+#: id:13376
+msgid "Volume"
+msgstr "Volume"
+
+#: id:13377
+msgid "Default view mode"
+msgstr "Modalità di visione predefinita"
+
+#: id:13378
+msgid "Default brightness"
+msgstr "Luminosità predefinita"
+
+#: id:13379
+msgid "Default contrast"
+msgstr "Contrasto predefinito"
+
+#: id:13380
+msgid "Default gamma"
+msgstr "Gamma predefinita"
+
+#: id:13381
+msgid "Resume video"
+msgstr "Riprendi video"
+
+#: id:13382
+msgid "Voice mask - Port 1"
+msgstr "Camuffa voce - Porta 1"
+
+#: id:13383
+msgid "Voice mask - Port 2"
+msgstr "Camuffa voce - Porta 2"
+
+#: id:13384
+msgid "Voice mask - Port 3"
+msgstr "Camuffa voce - Porta 3"
+
+#: id:13385
+msgid "Voice mask - Port 4"
+msgstr "Camuffa voce - Porta 4"
+
+#: id:13386
+msgid "Use time based seeking"
+msgstr "Usa ricerca basata sul tempo"
+
+#: id:13387
+msgid "Track naming template - right"
+msgstr "Descrizione della traccia - destra"
+
+#: id:13388
+msgid "Preset"
+msgstr "Preset"
+
+#: id:13389
+msgid "There are no presets available\nfor this visualization"
+msgstr "Nessun preset disponibile per questo effetto grafico"
+
+#: id:13390
+msgid "There are no settings available\nfor this visualization"
+msgstr "Nessuna impostazione disponibile per questo effetto grafico"
+
+#: id:13391
+msgid "Eject/Load"
+msgstr "Apri / Chiudi"
+
+#: id:13392
+msgid "Use visualization if playing audio"
+msgstr "Effetto grafico in automatico"
+
+#: id:13393
+msgid "Calculate size"
+msgstr "Calcola dimensione"
+
+#: id:13394
+msgid "Calculating folder size"
+msgstr "Calcolo dim. cartella"
+
+#: id:13395
+msgid "Video settings"
+msgstr "Impostazioni video"
+
+#: id:13396
+msgid "Audio and subtitle settings"
+msgstr "Impostazioni audio e sottotitoli"
+
+#: id:13397
+msgid "Enable subtitles"
+msgstr "Attiva sottotitoli"
+
+#: id:13398
+msgctxt "Auto context with id 13398"
+msgid "Shortcuts"
+msgstr "Scorciatoie"
+
+#: id:13399
+msgid "Ignore articles when sorting (e.g. \"the\")"
+msgstr "Ignora l'articolo (\"il\",\"lo\", etc.) davanti al nome nell'ordinamento"
+
+#: id:13400
+msgid "Crossfade between songs on the same album"
+msgstr "Dissolvenza tra le tracce dello steso album"
+
+#: id:13401
+msgid "Browse for %s"
+msgstr "Mostra per %s"
+
+#: id:13402
+msgid "Show track position"
+msgstr "Mostra posizione traccia"
+
+#: id:13403
+msgid "Clear default"
+msgstr "Cancella default"
+
+#: id:13404
+msgid "Resume"
+msgstr "Riprendi"
+
+#: id:13405
+msgid "Get thumb"
+msgstr "Trova icona"
+
+#: id:13406
+msgid "Picture information"
+msgstr "Informazioni immagine"
+
+#: id:13407
+msgid "%s presets"
+msgstr "%s preset"
+
+#: id:13408
+msgid "(IMDb user rating)"
+msgstr "(Valutazione utente IMDb)"
+
+#: id:13409
+msgid "Top 250"
+msgstr "Top 250"
+
+#: id:13410
+msgid "Tune in on Last.fm"
+msgstr "Sintonizzati su Last.FM"
+
+#: id:13411
+msgid "Minimum fan speed"
+msgstr "Minima vel. ventola"
+
+#: id:13412
+msgid "Play from here"
+msgstr "Riproduci da qui"
+
+#: id:13413
+msgid "Downloading"
+msgstr "Download in corso"
+
+#: id:13414
+msgid "Include artists who appear only on compilations"
+msgstr "Includi gli artisti presenti solo nelle compilation"
+
+#: id:13415
+msgctxt "Auto context with id 13415"
+msgid "Render method"
+msgstr "Metodo di render"
+
+#: id:13416
+msgid "Auto detect"
+msgstr "Automatico"
+
+#: id:13417
+msgid "Basic shaders (ARB)"
+msgstr "Sfumatura di base (ARB)"
+
+#: id:13418
+msgid "Advanced shaders (GLSL)"
+msgstr "Sfumatura avanzata (GLSL)"
+
+#: id:13419
+msgid "Software"
+msgstr "Software"
+
+#: id:13420
+msgid "Remove safely"
+msgstr "Rimozione sicura"
+
+#: id:13421
+msgctxt "Auto context with id 13421"
+msgid "VDPAU"
+msgstr "VDPAU"
+
+#: id:13422
+msgid "Start slideshow here"
+msgstr "Avvia la presentazione da qui"
+
+#: id:13423
+msgid "Remember for this path"
+msgstr "Ricorda per questo percorso"
+
+#: id:13424
+msgid "Use pixel buffer objects"
+msgstr "Usa oggetti pixel buffer"
+
+#: id:13425
+msgid "Allow hardware acceleration (VDPAU)"
+msgstr "Abilita accelerazione hardware (VDPAU)"
+
+#: id:13426
+msgid "Allow hardware acceleration (VAAPI)"
+msgstr "Abilita accelerazione hardware (VAAPI)"
+
+#: id:13427
+msgid "Allow hardware acceleration (DXVA2)"
+msgstr "Abilita accelerazione hardware (DXVA2)"
+
+#: id:13428
+msgid "Allow hardware acceleration (CrystalHD)"
+msgstr "Abilita accelerazione hardware (CrystalHD)"
+
+#: id:13429
+msgid "Allow hardware acceleration (VDADecoder)"
+msgstr "Abilita accelerazione hardware (VDADecoder)"
+
+#: id:13430
+msgid "Allow hardware acceleration (OpenMax)"
+msgstr "Abilita accelerazione hardware (OpenMax)"
+
+#: id:13431
+msgid "Pixel Shaders"
+msgstr "Pixel Shaders"
+
+#: id:13432
+msgid "Allow hardware acceleration (VideoToolbox)"
+msgstr "Abilita accelerazione hardware (VideoToolbox)"
+
+#: id:13500
+msgid "A/V sync method"
+msgstr "Metodo di sincronizzazione A/V"
+
+#: id:13501
+msgid "Audio clock"
+msgstr "Clock audio"
+
+#: id:13502
+msgid "Video clock (Drop/Dupe audio)"
+msgstr "Clock video (Lascia/Aggiungi audio)"
+
+#: id:13503
+msgid "Video clock (Resample audio)"
+msgstr "Clock video (Ricampiona audio)"
+
+#: id:13504
+msgid "Maximum resample amount (%)"
+msgstr "Ricampionamento massimo (%)"
+
+#: id:13505
+msgid "Resample quality"
+msgstr "Qualità ricampionamento"
+
+#: id:13506
+msgid "Low(fast)"
+msgstr "Bassa(veloce)"
+
+#: id:13507
+msgctxt "Auto context with id 13507"
+msgid "Medium"
+msgstr "Media"
+
+#: id:13508
+msgctxt "Auto context with id 13508"
+msgid "High"
+msgstr "Alta"
+
+#: id:13509
+msgid "Really high(slow!)"
+msgstr "Molto alta"
+
+#: id:13510
+msgid "Sync playback to display"
+msgstr "Sincronizza il suono all'immagine"
+
+#: id:13550
+msgid "Pause during refresh rate change"
+msgstr "Pausa durante il cambio di frequenza"
+
+#: id:13551
+msgctxt "Auto context with id 13551"
+msgid "Off"
+msgstr "Spento"
+
+#: id:13552
+msgid "%.1f Second"
+msgstr "%.1f Secondo"
+
+#: id:13553
+msgid "%.1f Seconds"
+msgstr "%.1f Secondi"
+
+#: id:13600
+msgid "Apple remote"
+msgstr "Telecomando Apple"
+
+#: id:13602
+msgid "Allow start of XBMC using the remote"
+msgstr "Permetti avvio di XBMC da telecomando"
+
+#: id:13603
+msgid "Sequence delay time"
+msgstr "Ritardo nella sequenza"
+
+#: id:13610
+msgctxt "Auto context with id 13610"
+msgid "Disabled"
+msgstr "Disabilitato"
+
+#: id:13611
+msgctxt "Auto context with id 13611"
+msgid "Standard"
+msgstr "Standard"
+
+#: id:13612
+msgid "Universal Remote"
+msgstr "Telecomando Universale"
+
+#: id:13613
+msgid "Multi Remote (Harmony)"
+msgstr "Telecomando Multi (Harmony)"
+
+#: id:13620
+msgid "Apple Remote Error"
+msgstr "Errore Apple Remote"
+
+#: id:13621
+msgid "Apple Remote support could be enabled."
+msgstr "Il supporto per Apple Remote non è stato attivato."
+
+#: id:14000
+msgid "Stack"
+msgstr "Unisci volumi"
+
+#: id:14001
+msgid "Unstack"
+msgstr "Dividi volumi"
+
+#: id:14003
+msgid "Downloading playlist file..."
+msgstr "Scaricamento file playlist..."
+
+#: id:14004
+msgid "Downloading streams list..."
+msgstr "Scaricamento lista streams..."
+
+#: id:14005
+msgid "Parsing streams list..."
+msgstr "Esamino lista streams..."
+
+#: id:14006
+msgid "Downloading streams list failed"
+msgstr "Scaricamento lista streams fallito"
+
+#: id:14007
+msgid "Downloading playlist file failed"
+msgstr "Scaricamento file playlist fallito"
+
+#: id:14009
+msgid "Games directory"
+msgstr "Cartella giochi"
+
+#: id:14010
+msgid "Auto switch to thumbs based on"
+msgstr "Attivazione vista ad icone per"
+
+#: id:14011
+msgid "Enable auto switching to thumbs view"
+msgstr "Auto-attivazione vista ad icone"
+
+#: id:14012
+msgid "- Use large icons"
+msgstr "- Usa icone grandi"
+
+#: id:14013
+msgid "- Switch based on"
+msgstr "- Vista ad icone per"
+
+#: id:14014
+msgid "- Percentage"
+msgstr "- Percentuale"
+
+#: id:14015
+msgid "No files and at least one thumb"
+msgstr "Nessun file ed almeno una icona"
+
+#: id:14016
+msgid "At least one file and thumb"
+msgstr "Almeno un file ed una icona"
+
+#: id:14017
+msgid "Percentage of thumbs"
+msgstr "Percentuale di icone"
+
+#: id:14018
+msgid "View options"
+msgstr "Opzioni di visione"
+
+#: id:14019
+msgid "Change area code 1"
+msgstr "Nome o codice città 1"
+
+#: id:14020
+msgid "Change area code 2"
+msgstr "Nome o codice città 2"
+
+#: id:14021
+msgid "Change area code 3"
+msgstr "Nome o codice città 3"
+
+#: id:14022
+msgctxt "Auto context with id 14022"
+msgid "Library"
+msgstr "Archivio"
+
+#: id:14023
+msgid "No TV"
+msgstr "No TV"
+
+#: id:14024
+msgid "Enter the nearest large town"
+msgstr "Inserisci la città più grande vicina a te"
+
+#: id:14025
+msgid "Video/Audio/DVD cache - Harddisk"
+msgstr "Video/Audio/DVD cache - HardDisk"
+
+#: id:14026
+msgid "Video cache - DVD-ROM"
+msgstr "cache Video - DVD-ROM"
+
+#: id:14027
+msgctxt "Auto context with id 14027"
+msgid "- Local Network"
+msgstr "- Rete Locale"
+
+#: id:14028
+msgctxt "Auto context with id 14028"
+msgid "- Internet"
+msgstr "- Internet"
+
+#: id:14030
+msgid "Audio cache - DVD-ROM"
+msgstr "cache Audio - DVD-ROM"
+
+#: id:14031
+msgctxt "Auto context with id 14031"
+msgid "- Local Network"
+msgstr "- Rete Locale"
+
+#: id:14032
+msgctxt "Auto context with id 14032"
+msgid "- Internet"
+msgstr "- Internet"
+
+#: id:14034
+msgid "DVD cache - DVD-ROM"
+msgstr "cache DVD - DVD-ROM"
+
+#: id:14035
+msgctxt "Auto context with id 14035"
+msgid "- Local Network"
+msgstr "- Rete Locale"
+
+#: id:14036
+msgctxt "Auto context with id 14036"
+msgid "Services"
+msgstr "Servizi"
+
+#: id:14038
+msgid "Network settings changed"
+msgstr "Impostazioni di rete cambiate"
+
+#: id:14039
+msgid "XBMC requires to restart to change your"
+msgstr "XBMC deve essere riavviato per cambiare le"
+
+#: id:14040
+msgid "network setup. Would you like to restart now?"
+msgstr "tue impostazioni di rete. Vuoi riavviare adesso?"
+
+#: id:14041
+msgid "Internet connection bandwidth limitation"
+msgstr "Limite di banda connessione Internet"
+
+#: id:14043
+msgid "- Shutdown while playing"
+msgstr "- Spegnimento durante l'esecuzione"
+
+#: id:14044
+msgid "%i min"
+msgstr "%i min"
+
+#: id:14045
+msgid "%i sec"
+msgstr "%i sec"
+
+#: id:14046
+msgid "%i ms"
+msgstr "%i ms"
+
+#: id:14047
+msgid "%i %%"
+msgstr "%i %%"
+
+#: id:14048
+msgid "%i kbps"
+msgstr "%i kbps"
+
+#: id:14049
+msgid "%i kb"
+msgstr "%i kb"
+
+#: id:14050
+msgid "%i.0 dB"
+msgstr "%i.0 dB"
+
+#: id:14051
+msgid "Time format"
+msgstr "Formato orario"
+
+#: id:14052
+msgid "Date format"
+msgstr "Formato data"
+
+#: id:14053
+msgid "GUI filters"
+msgstr "Filtri interfaccia"
+
+#: id:14055
+msgid "Use background scanning"
+msgstr "Usa scansione in background"
+
+#: id:14056
+msgid "Stop scan"
+msgstr "Ferma scansione"
+
+#: id:14057
+msgid "Not possible while scanning for media info"
+msgstr "Non si possono ottenere informazioni durante la scansione"
+
+#: id:14058
+msgid "Film grain effect"
+msgstr "Effetto film sgranato"
+
+#: id:14059
+msgid "Search for thumbnails on remote shares"
+msgstr "Cerca le icone nelle condivisioni remote"
+
+#: id:14060
+msgid "Unknown type cache - Internet"
+msgstr "Cache di tipo sconosciuto - Internet"
+
+#: id:14061
+msgctxt "Auto context with id 14061"
+msgid "Auto"
+msgstr "Auto"
+
+#: id:14062
+msgid "Enter username for"
+msgstr "Inserire nome utente per"
+
+#: id:14063
+msgid "Date & time"
+msgstr "Data e ora"
+
+#: id:14064
+msgid "Set date"
+msgstr "Imposta data"
+
+#: id:14065
+msgid "Set time"
+msgstr "Imposta orario"
+
+#: id:14066
+msgid "Enter the time in 24 hour HH:MM format"
+msgstr "Inserire orario in formato 24 ore HH:MM"
+
+#: id:14067
+msgid "Enter the date in DD/MM/YYYY format"
+msgstr "Inserire data in formato GG/MM/AAAA"
+
+#: id:14068
+msgid "Enter the IP address"
+msgstr "Inserire indirizzo IP"
+
+#: id:14069
+msgid "Apply these settings now?"
+msgstr "Vuoi salvare queste impostazioni adesso?"
+
+#: id:14070
+msgid "Apply changes now"
+msgstr "Salva impostazioni"
+
+#: id:14071
+msgid "Allow file renaming and deletion"
+msgstr "Consenti la rinominazione e la cancellazione dei file"
+
+#: id:14074
+msgid "Set timezone"
+msgstr "Imposta il fuso orario"
+
+#: id:14075
+msgid "Use daylight saving time"
+msgstr "Passa all'ora legale"
+
+#: id:14076
+msgid "Add to favourites"
+msgstr "Aggiungi ai preferiti"
+
+#: id:14077
+msgid "Remove from favourites"
+msgstr "Rimuovi dai preferiti"
+
+#: id:14078
+msgctxt "Auto context with id 14078"
+msgid "- Colours"
+msgstr "- Colori"
+
+#: id:14079
+msgid "Timezone country"
+msgstr "Paese del fuso orario"
+
+#: id:14080
+msgid "Timezone"
+msgstr "Fuso orario"
+
+#: id:14081
+msgid "File lists"
+msgstr "Liste file"
+
+#: id:14082
+msgid "Show EXIF picture information"
+msgstr "Mostra le informazioni EXIF delle immagini"
+
+#: id:14083
+msgid "Use a fullscreen window rather than true fullscreen"
+msgstr "Usa una finestra fullscreen invece di un vero fullscreen"
+
+#: id:14084
+msgid "Queue songs on selection"
+msgstr "Accoda le canzoni dopo la selezione"
+
+#: id:14086
+msgid "Playback"
+msgstr "Riproduzione"
+
+#: id:14087
+msgid "DVDs"
+msgstr "DVD"
+
+#: id:14088
+msgid "Play DVDs automatically"
+msgstr "Riproduci i DVD automaticamente"
+
+#: id:14089
+msgid "Font to use for text subtitles"
+msgstr "Font da usare per i sottotitoli"
+
+#: id:14090
+msgid "International"
+msgstr "Internazionale"
+
+#: id:14091
+msgid "Character set"
+msgstr "Set di caratteri"
+
+#: id:14092
+msgid "Debugging"
+msgstr "Debugging"
+
+#: id:14093
+msgid "Security"
+msgstr "Sicurezza"
+
+#: id:14094
+msgid "Input devices"
+msgstr "Dispositivi di input"
+
+#: id:14095
+msgid "Power saving"
+msgstr "Risparmio energetico"
+
+#: id:14096
+msgid "Rip"
+msgstr ""
+
+#: id:14097
+msgid "Audio CD Insert Action"
+msgstr ""
+
+#: id:14098
+msgctxt "Auto context with id 14098"
+msgid "Play"
+msgstr ""
+
+#: id:14099
+msgid "Eject disc when CD ripping is complete"
+msgstr ""
+
+#: id:15015
+msgctxt "Auto context with id 15015"
+msgid "Remove"
+msgstr "Rimuovi"
+
+#: id:15016
+msgid "Games"
+msgstr "Giochi"
+
+#: id:15019
+msgid "Add"
+msgstr "Aggiungi"
+
+#: id:15052
+msgid "Password"
+msgstr "Password"
+
+#: id:15100
+msgctxt "Auto context with id 15100"
+msgid "Library"
+msgstr "Archivio"
+
+#: id:15101
+msgid "Database"
+msgstr "Banca dati"
+
+#: id:15102
+msgid "* All albums"
+msgstr "* Tutti gli album"
+
+#: id:15103
+msgid "* All artists"
+msgstr "* Tutti gli artisti"
+
+#: id:15104
+msgid "* All songs"
+msgstr "* Tutte le canzoni"
+
+#: id:15105
+msgid "* All genres"
+msgstr "* Tutti i generi"
+
+#: id:15107
+msgid "Buffering..."
+msgstr "Caricando..."
+
+#: id:15108
+msgid "Navigation sounds"
+msgstr "Suoni di navigazione"
+
+#: id:15109
+msgid "Skin default"
+msgstr "Default della skin"
+
+#: id:15111
+msgid "- Theme"
+msgstr "- Tema"
+
+#: id:15112
+msgid "Default theme"
+msgstr "Tema di default"
+
+#: id:15200
+msgid "Last.fm"
+msgstr "Last.fm"
+
+#: id:15201
+msgid "Submit songs to Last.fm"
+msgstr "Invia le canzoni a Last.fm"
+
+#: id:15202
+msgid "Last.fm username"
+msgstr "Nome utente Last.fm"
+
+#: id:15203
+msgid "Last.fm password"
+msgstr "Password Last.fm"
+
+#: id:15204
+msgid "Unable to handshake: sleeping..."
+msgstr "Inoperabile: disattivo..."
+
+#: id:15205
+msgid "Please update XBMC"
+msgstr "Per favore aggiornare XBMC"
+
+#: id:15206
+msgid "Bad authorization: Check username and password"
+msgstr "Non autorizzato: controlla nome utente e password"
+
+#: id:15207
+msgctxt "Auto context with id 15207"
+msgid "Connected"
+msgstr "Connesso"
+
+#: id:15208
+msgid "Not connected"
+msgstr "Non connesso"
+
+#: id:15209
+msgid "Submit interval %i"
+msgstr "Intervallo invio %i"
+
+#: id:15210
+msgid "Cached %i songs"
+msgstr "%i canzoni memorizzate"
+
+#: id:15211
+msgid "Submitting..."
+msgstr "Inviando..."
+
+#: id:15212
+msgid "Submitting in %i secs"
+msgstr "Inviato in %i secondi"
+
+#: id:15213
+msgid "Play using..."
+msgstr "Riproduci con..."
+
+#: id:15214
+msgid "Use smoothed A/V synchronization"
+msgstr "Perfeziona sincronizzazione A/V"
+
+#: id:15215
+msgid "Hide file names in thumbs view"
+msgstr "Nascondi i nomi dei file in vista ad icone"
+
+#: id:15216
+msgid "Play in party mode"
+msgstr "Esegui in modalità party"
+
+#: id:15217
+msgid "Submit songs to Libre.fm"
+msgstr "Invia le canzoni a Libre.fm"
+
+#: id:15218
+msgid "Libre.fm username"
+msgstr "Nome utente di Libre.fm"
+
+#: id:15219
+msgid "Libre.fm password"
+msgstr "Password di Libre.fm"
+
+#: id:15220
+msgid "Libre.fm"
+msgstr "Libre.fm"
+
+#: id:15221
+msgid "Song submission"
+msgstr "Invio canzone"
+
+#: id:15250
+msgid "Submit Last.fm radio to Last.fm"
+msgstr "Invia la radio Last.fm a Last.fm"
+
+#: id:15251
+msgid "Connecting to Last.fm..."
+msgstr "Connessione a Last.fm..."
+
+#: id:15252
+msgid "Selecting station..."
+msgstr "Selezione stazione..."
+
+#: id:15253
+msgid "Search similar artists..."
+msgstr "Ricerca artisti simili..."
+
+#: id:15254
+msgid "Search similar tags..."
+msgstr "Ricerca etichette simili..."
+
+#: id:15255
+msgid "Your profile (%name%)"
+msgstr "Tuo profilo (%name%)"
+
+#: id:15256
+msgid "Overall top tags"
+msgstr "Etichette migliori"
+
+#: id:15257
+msgid "Top artists for tag %name%"
+msgstr "Artisti migliori con etichetta %name%"
+
+#: id:15258
+msgid "Top albums for tag %name%"
+msgstr "Album migliori con etichetta %name%"
+
+#: id:15259
+msgid "Top tracks for tag %name%"
+msgstr "Canzoni migliori con etichetta %name%"
+
+#: id:15260
+msgid "Listen to tag %name% Last.fm radio"
+msgstr "Ascolta l'etichetta %name% Last.FM radio"
+
+#: id:15261
+msgid "Similar artists as %name%"
+msgstr "Artisti simili a %name%"
+
+#: id:15262
+msgid "Top %name% albums"
+msgstr "Album %name% migliori"
+
+#: id:15263
+msgid "Top %name% tracks"
+msgstr "Canzoni %name% migliori"
+
+#: id:15264
+msgid "Top %name% tags"
+msgstr "Etichette %name% migliori"
+
+#: id:15265
+msgid "Biggest fans of %name%"
+msgstr "Più grandi fan di %name%"
+
+#: id:15266
+msgid "Listen to %name% fans Last.fm radio"
+msgstr "Ascolta %name% fans Last.fm radio"
+
+#: id:15267
+msgid "Listen to %name% similar artists Last.fm radio"
+msgstr "Ascolta %name% artisti simili Last.fm radio"
+
+#: id:15268
+msgid "Top artists for user %name%"
+msgstr "Artisti migliori per l'utente %name%"
+
+#: id:15269
+msgid "Top albums for user %name%"
+msgstr "Album migliori per l'utente %name%"
+
+#: id:15270
+msgid "Top tracks for user %name%"
+msgstr "Canzoni migliori per l'utente %name%"
+
+#: id:15271
+msgid "Friends of user %name%"
+msgstr "Amici dell'utente %name%"
+
+#: id:15272
+msgid "Neighbours of user %name%"
+msgstr "Vicini dell'utente %name%"
+
+#: id:15273
+msgid "Weekly artist chart for %name%"
+msgstr "Classifica settimanale artista per %name%"
+
+#: id:15274
+msgid "Weekly album chart for %name%"
+msgstr "Classifica settimanale album per %name%"
+
+#: id:15275
+msgid "Weekly track chart for %name%"
+msgstr "Classifica settimanale canzone per %name%"
+
+#: id:15276
+msgid "Listen to %name%'s neighbours Last.fm radio"
+msgstr "Ascolta la Last.fm radio dei vicini di %name%"
+
+#: id:15277
+msgid "Listen to %name%'s personal Last.fm radio"
+msgstr "Ascolta la Last.fm radio personale di %name%"
+
+#: id:15278
+msgid "Listen to %name%'s mix Last.fm radio"
+msgstr "Ascolta le Last.fm radio canzoni preferite di %name%"
+
+#: id:15279
+msgid "Retrieving list from Last.fm..."
+msgstr "Ricezione lista da Last.fm..."
+
+#: id:15280
+msgid "Can't retrieve list from Last.fm..."
+msgstr "Impossibile ricevere la lista da Last.fm..."
+
+#: id:15281
+msgid "Enter an artist name to find related ones"
+msgstr "Inserire il nome di un artista per trovarne i correlati"
+
+#: id:15282
+msgid "Enter a tag name to find similar ones"
+msgstr "Inserire il nome di un etichetta per trovarne di simili"
+
+#: id:15283
+msgid "Tracks recently listened by %name%"
+msgstr "Tracce recentemente ascoltate da %name%"
+
+#: id:15284
+msgid "Listen to %name%'s recommendations Last.fm radio"
+msgstr "Ascolta le %name%'s raccomandazioni Last.fm radio"
+
+#: id:15285
+msgid "Top tags for user %name%"
+msgstr "Etichette preferite per l'utente %name%"
+
+#: id:15287
+msgid "Do you want to add the current track to your loved tracks?"
+msgstr "Vuoi aggiungere la traccia corrente alle tue preferite?"
+
+#: id:15288
+msgid "Do you want to ban the current track?"
+msgstr "Vuoi vietare la traccia corrente?"
+
+#: id:15289
+msgid "Added to your loved tracks: '%s'."
+msgstr "Aggiunta alle tue traccie preferite: '%s'."
+
+#: id:15290
+msgid "Could not add '%s' to your loved tracks."
+msgstr "Impossibile aggiungere '%s' alle tue tracce preferite."
+
+#: id:15291
+msgid "Banned: '%s'."
+msgstr "Vietata: '%s'."
+
+#: id:15292
+msgid "Could not ban '%s'."
+msgstr "Impossibile vietare '%s'."
+
+#: id:15293
+msgid "Tracks recently loved by %name%"
+msgstr "Tracce recentemente preferite da %name%"
+
+#: id:15294
+msgid "Tracks recently banned by %name%"
+msgstr "Tracce recentemente vietate da %name%"
+
+#: id:15295
+msgid "Remove from loved tracks"
+msgstr "Rimuovi dalle tracce preferite"
+
+#: id:15296
+msgid "Un-ban"
+msgstr "Riammetti"
+
+#: id:15297
+msgid "Do you want to remove this track from your loved tracks?"
+msgstr "Vuoi rimuovere questa traccia dalle tracce preferite?"
+
+#: id:15298
+msgid "Do you want to un-ban this track?"
+msgstr "Vuoi togliere il divieto a questa traccia?"
+
+#: id:15300
+msgid "Path not found or invalid"
+msgstr "Percorso non trovato o invalido"
+
+#: id:15301
+msgid "Could not connect to network server"
+msgstr "Non è stato possibile connettersi al server"
+
+#: id:15302
+msgid "No servers found"
+msgstr "Nessun server trovato"
+
+#: id:15303
+msgid "Workgroup not found"
+msgstr "Nessun workgroup trovato"
+
+#: id:15310
+msgid "Opening multi-path source"
+msgstr "Apertura sorgente multipercorso"
+
+#: id:15311
+msgid "Path:"
+msgstr "Percorso:"
+
+#: id:16000
+msgctxt "Auto context with id 16000"
+msgid "General"
+msgstr "Generale"
+
+#: id:16002
+msgid "Internet lookup"
+msgstr "Ricerca Internet"
+
+#: id:16003
+msgid "Player"
+msgstr "Lettore"
+
+#: id:16004
+msgid "Play media from disc"
+msgstr "Riproduci i media dal disco"
+
+#: id:16008
+msgid "Enter new title"
+msgstr "Inserire nuovo titolo"
+
+#: id:16009
+msgid "Enter the movie name"
+msgstr "Inserire nome del film"
+
+#: id:16010
+msgid "Enter the profile name"
+msgstr "Inserire nome del profilo"
+
+#: id:16011
+msgid "Enter the album name"
+msgstr "Inserire nome dell'album"
+
+#: id:16012
+msgid "Enter the playlist name"
+msgstr "Inserire nome della playlist"
+
+#: id:16013
+msgid "Enter new filename"
+msgstr "Inserire nuovo nome del file"
+
+#: id:16014
+msgid "Enter folder name"
+msgstr "Inserire nome della cartella"
+
+#: id:16015
+msgid "Enter directory"
+msgstr "Inserire directory"
+
+#: id:16016
+msgid "Available options: %A, %T, %N, %B, %D, %G, %Y, %F, %S"
+msgstr "Opzioni disponibili: %A, %T, %N, %B, %D, %G, %Y, %F, %S"
+
+#: id:16017
+msgid "Enter search string"
+msgstr "Inserire stringa da cercare"
+
+#: id:16018
+msgctxt "Auto context with id 16018"
+msgid "None"
+msgstr "Nessuno"
+
+#: id:16019
+msgid "Auto select"
+msgstr "Auto seleziona"
+
+#: id:16020
+msgid "De-interlace"
+msgstr "DeInterlaccia"
+
+#: id:16021
+msgid "Bob"
+msgstr "Bob"
+
+#: id:16022
+msgid "Bob (inverted)"
+msgstr "Bob (invertito)"
+
+#: id:16024
+msgid "Canceling..."
+msgstr "Annullando..."
+
+#: id:16025
+msgid "Enter the artist name"
+msgstr "Inserire nome artista"
+
+#: id:16026
+msgid "Playback failed"
+msgstr "Riproduzione fallita"
+
+#: id:16027
+msgid "One or more items failed to play."
+msgstr "Troppi elementi consecutivi falliti"
+
+#: id:16028
+msgid "Enter value"
+msgstr "Inserire valore"
+
+#: id:16029
+msgid "Check the log file for details."
+msgstr "Controlla il file log per i dettagli."
+
+#: id:16030
+msgid "Party mode aborted."
+msgstr "Modalità party annullata."
+
+#: id:16031
+msgid "No matching songs in the library."
+msgstr "Nessuna canzone corrispondente nell'archivio."
+
+#: id:16032
+msgid "Could not initialize database."
+msgstr "Impossibile inizializzare il database."
+
+#: id:16033
+msgid "Could not open database."
+msgstr "Impossibile aprire il database."
+
+#: id:16034
+msgid "Could not get songs from database."
+msgstr "Impossibile ricavare canzoni dal database."
+
+#: id:16035
+msgid "Party mode playlist"
+msgstr "Playlist modalità party"
+
+#: id:16036
+msgid "De-interlace (Half)"
+msgstr "Deinterlaccia (metà)"
+
+#: id:16037
+msgid "Deinterlace video"
+msgstr "Deinterlaccia il video"
+
+#: id:16038
+msgid "Deinterlace method"
+msgstr "Metodo di deinterlacciamento"
+
+#: id:16039
+msgctxt "Auto context with id 16039"
+msgid "Off"
+msgstr "Off"
+
+#: id:16040
+msgctxt "Auto context with id 16040"
+msgid "Auto"
+msgstr "Auto"
+
+#: id:16041
+msgid "On"
+msgstr "On"
+
+#: id:16100
+msgid "All Videos"
+msgstr "Tutti i video"
+
+#: id:16101
+msgid "Unwatched"
+msgstr "Non visti"
+
+#: id:16102
+msgid "Watched"
+msgstr "Già visti"
+
+#: id:16103
+msgid "Mark as watched"
+msgstr "Segna come già visto"
+
+#: id:16104
+msgid "Mark as unwatched"
+msgstr "Segna come non visto"
+
+#: id:16105
+msgid "Edit title"
+msgstr "Modifica titolo"
+
+#: id:16200
+msgid "Operation was aborted"
+msgstr "L'operazione è stata annullata"
+
+#: id:16201
+msgid "Copy failed"
+msgstr "Copia non riuscita"
+
+#: id:16202
+msgid "Failed to copy at least one file"
+msgstr "Almeno un file non è stato copiato"
+
+#: id:16203
+msgid "Move failed"
+msgstr "Spostamento non riuscito"
+
+#: id:16204
+msgid "Failed to move at least one file"
+msgstr "Almeno un file non è stato spostato"
+
+#: id:16205
+msgid "Delete failed"
+msgstr "Cancellazione non riuscita"
+
+#: id:16206
+msgid "Failed to delete at least one file"
+msgstr "Almeno un file non è stato cancellato"
+
+#: id:16300
+msgid "Video scaling method"
+msgstr "Metodo di ridimensionamento"
+
+#: id:16301
+msgid "Nearest neighbour"
+msgstr "Più vicino"
+
+#: id:16302
+msgid "Bilinear"
+msgstr "Bilineare"
+
+#: id:16303
+msgctxt "Auto context with id 16303"
+msgid "Bicubic"
+msgstr "Bicubico"
+
+#: id:16304
+msgid "Lanczos2"
+msgstr "Lanczos2"
+
+#: id:16305
+msgid "Lanczos3"
+msgstr "Lanczos3"
+
+#: id:16306
+msgid "Sinc8"
+msgstr "Sinc8"
+
+#: id:16307
+msgid "Bicubic (software)"
+msgstr "Bicubico (software)"
+
+#: id:16308
+msgid "Lanczos (software)"
+msgstr "Lanczos (software)"
+
+#: id:16309
+msgid "Sinc (software)"
+msgstr "Sinc (software)"
+
+#: id:16310
+msgid "Temporal"
+msgstr "Temporale"
+
+#: id:16311
+msgid "Temporal/Spatial"
+msgstr "Temporale/Spaziale"
+
+#: id:16312
+msgid "(VDPAU)Noise Reduction"
+msgstr "(VDPAU)Riduzione Rumore"
+
+#: id:16313
+msgid "(VDPAU)Sharpness"
+msgstr "Nitidezza"
+
+#: id:16314
+msgid "Inverse Telecine"
+msgstr "Telecine Inverso"
+
+#: id:16315
+msgid "Lanczos3 optimized"
+msgstr "Lanczos3 ottimizzato"
+
+#: id:16316
+msgctxt "Auto context with id 16316"
+msgid "Auto"
+msgstr "Auto"
+
+#: id:16317
+msgid "Temporal (Half)"
+msgstr "Temporale (mezzo)"
+
+#: id:16318
+msgid "Temporal/Spatial (Half)"
+msgstr "Temporale/Spaziale (mezzo)"
+
+#: id:16319
+msgid "DXVA"
+msgstr "DXVA"
+
+#: id:16320
+msgid "DXVA Bob"
+msgstr "DXVA Bob"
+
+#: id:16321
+msgid "DXVA Best"
+msgstr "DXVA Best"
+
+#: id:16322
+msgid "Spline36"
+msgstr "Spline36"
+
+#: id:16323
+msgid "Spline36 optimized"
+msgstr "Spline36 ottimizzato"
+
+#: id:16324
+msgid "Software Blend"
+msgstr "Software Blend"
+
+#: id:16400
+msgid "Post-processing"
+msgstr "Video post-processing"
+
+#: id:17500
+msgid "Display sleep timeout"
+msgstr "Tempo di spegnimento display"
+
+#: id:19000
+msgid "Switch to channel"
+msgstr "Cambia al canale"
+
+#: id:20000
+msgid "Saved music folder"
+msgstr "Cartella per il salvataggio della musica"
+
+#: id:20001
+msgid "Use external DVD player"
+msgstr "Usa un player DVD esterno"
+
+#: id:20002
+msgid "External DVD player"
+msgstr "Player DVD esterno"
+
+#: id:20003
+msgid "Trainers folder"
+msgstr "Cartella dei trainer"
+
+#: id:20004
+msgid "Screenshot folder"
+msgstr "Cartella per gli screenshot"
+
+#: id:20006
+msgid "Playlists folder"
+msgstr "Cartella playlist"
+
+#: id:20007
+msgid "Recordings"
+msgstr "Registrazioni"
+
+#: id:20008
+msgid "Screenshots"
+msgstr "Screenshot"
+
+#: id:20009
+msgid "Use XBMC"
+msgstr "Usa XBMC"
+
+#: id:20011
+msgid "Music playlists"
+msgstr "Playlist musica"
+
+#: id:20012
+msgid "Video playlists"
+msgstr "Playlist video"
+
+#: id:20013
+msgid "Do you wish to launch the game?"
+msgstr "Vuoi lanciare il gioco?"
+
+#: id:20014
+msgid "Sort by: Playlist"
+msgstr "Ordina per: Playlist"
+
+#: id:20015
+msgid "Remote thumb"
+msgstr "Icona remota"
+
+#: id:20016
+msgid "Current thumb"
+msgstr "Icona attuale"
+
+#: id:20017
+msgid "Local thumb"
+msgstr "Icona locale"
+
+#: id:20018
+msgid "No thumb"
+msgstr "Nessuna icona"
+
+#: id:20019
+msgid "Choose thumbnail"
+msgstr "Seleziona icona"
+
+#: id:20023
+msgid "Conflict"
+msgstr "Conflitto"
+
+#: id:20024
+msgid "Scan new"
+msgstr "Scansiona nuovo"
+
+#: id:20025
+msgid "Scan all"
+msgstr "Scansiona tutto"
+
+#: id:20026
+msgid "Region"
+msgstr "Regione"
+
+#: id:20037
+msgid "Summary"
+msgstr "Sommario"
+
+#: id:20038
+msgid "Lock music window"
+msgstr "Blocca sezione musica"
+
+#: id:20039
+msgid "Lock videos window"
+msgstr "Blocca sezione video"
+
+#: id:20040
+msgid "Lock pictures window"
+msgstr "Blocca sezione immagini"
+
+#: id:20041
+msgid "Lock programs & scripts windows"
+msgstr "Blocca sezione programmi e script"
+
+#: id:20042
+msgid "Lock file manager"
+msgstr "Blocca filemanager"
+
+#: id:20043
+msgid "Lock settings"
+msgstr "Blocca impostazioni"
+
+#: id:20044
+msgid "Start fresh"
+msgstr "Nuova partenza"
+
+#: id:20045
+msgid "Enter master mode"
+msgstr "Entra in master mode"
+
+#: id:20046
+msgid "Leave master mode"
+msgstr "Esci da master mode"
+
+#: id:20047
+msgid "Create profile '%s'?"
+msgstr "Crea profilo '%s' ?"
+
+#: id:20048
+msgid "Start with fresh settings"
+msgstr "Parti con impostazioni nuove?"
+
+#: id:20049
+msgid "Best available"
+msgstr "Migliore disponibile"
+
+#: id:20050
+msgid "Auto-switch between 16x9 and 4x3"
+msgstr "Cambio automatico tra 16x9 e 4x3"
+
+#: id:20051
+msgid "Treat stacked files as single file"
+msgstr "Tratta i volumi come files singoli"
+
+#: id:20052
+msgid "Caution"
+msgstr "Attenzione"
+
+#: id:20053
+msgid "Left master mode"
+msgstr "Uscito da master mode"
+
+#: id:20054
+msgid "Entered master mode"
+msgstr "Entrato in master mode"
+
+#: id:20055
+msgid "Allmusic.com thumb"
+msgstr "Icona Allmusic.com"
+
+#: id:20057
+msgid "Remove thumbnail"
+msgstr "Rimuovi icona"
+
+#: id:20058
+msgid "Add profile..."
+msgstr "Aggiungi profilo..."
+
+#: id:20059
+msgid "Query info for all albums"
+msgstr "Cerca info per tutti gli album"
+
+#: id:20060
+msgctxt "Auto context with id 20060"
+msgid "Media info"
+msgstr "Media info"
+
+#: id:20061
+msgctxt "Auto context with id 20061"
+msgid "Separate"
+msgstr "Separa"
+
+#: id:20062
+msgid "Shares with default"
+msgstr "Condivisioni con default"
+
+#: id:20063
+msgid "Shares with default (read only)"
+msgstr "Condivisioni con default (solo lettura)"
+
+#: id:20064
+msgid "Copy default"
+msgstr "Copia default"
+
+#: id:20065
+msgid "Profile picture"
+msgstr "Immagine profilo"
+
+#: id:20066
+msgid "Lock preferences"
+msgstr "Blocca preferenze"
+
+#: id:20067
+msgid "Edit profile"
+msgstr "Modifica profilo"
+
+#: id:20068
+msgid "Profile lock"
+msgstr "Profilo bloccato"
+
+#: id:20069
+msgid "Could not create folder"
+msgstr "Impossibile creare la cartella"
+
+#: id:20070
+msgid "Profile directory"
+msgstr "Directory profilo"
+
+#: id:20071
+msgid "Start with fresh media sources"
+msgstr "Parti con sorgenti media nuove"
+
+#: id:20072
+msgid "Make sure the selected folder is writable"
+msgstr "Assicurati che la cartella selezionata sia scrivibile"
+
+#: id:20073
+msgid "and that the new folder name is valid"
+msgstr "ed il nuovo nome della cartella sia valido"
+
+#: id:20074
+msgid "MPAA rating"
+msgstr "Classificazione MPAA"
+
+#: id:20075
+msgid "Enter master lock code"
+msgstr "Inserisci codice master lock"
+
+#: id:20076
+msgid "Ask for master lock code on startup"
+msgstr "Richiedi codice master lock all'avvio"
+
+#: id:20077
+msgid "Skin settings"
+msgstr "Impostazioni skin"
+
+#: id:20078
+msgid "- no link set -"
+msgstr "- da impostare -"
+
+#: id:20079
+msgid "Enable animations"
+msgstr "Attiva le animazioni"
+
+#: id:20080
+msgid "Disable RSS during music"
+msgstr "Disattiva i feed RSS durante la musica"
+
+#: id:20081
+msgid "Enable shortcut buttons"
+msgstr "Attiva i pulsanti scorciatoie"
+
+#: id:20082
+msgid "Show programs in main menu"
+msgstr "Mostra il pulsante programmi nel menu principale"
+
+#: id:20083
+msgid "Show music info"
+msgstr "Mostra le informazioni per la musica"
+
+#: id:20084
+msgid "Show weather info"
+msgstr "Mostra le informazione sul meteo"
+
+#: id:20085
+msgid "Show system info"
+msgstr "Mostra le informazioni di sistema"
+
+#: id:20086
+msgid "Show available disc space C: E: F:"
+msgstr "Mostra lo spazio disponibile disco C: E: F:"
+
+#: id:20087
+msgid "Show available disc space E: F: G:"
+msgstr "Mostra lo spazio disponibile disco E: F: G:"
+
+#: id:20088
+msgid "Weather info"
+msgstr "Informazioni meteo"
+
+#: id:20089
+msgid "Drive space free"
+msgstr "Spazio libero disco"
+
+#: id:20090
+msgid "Enter the name of an existing share"
+msgstr "Inserisci il nome di una condivisione esistente"
+
+#: id:20091
+msgid "Lock code"
+msgstr "Codice di blocco"
+
+#: id:20092
+msgid "Load profile"
+msgstr "Carica profilo"
+
+#: id:20093
+msgid "Profile name"
+msgstr "Nome profilo"
+
+#: id:20094
+msgctxt "Auto context with id 20094"
+msgid "Media sources"
+msgstr "Sorgenti media"
+
+#: id:20095
+msgid "Enter profile lock code"
+msgstr "Inserisci codice di blocco profilo"
+
+#: id:20096
+msgctxt "Auto context with id 20096"
+msgid "Login screen"
+msgstr "Schermata di login"
+
+#: id:20097
+msgid "Fetching album info"
+msgstr "Esamino informazioni album"
+
+#: id:20098
+msgid "Fetching info for album"
+msgstr "Esamino info per l'album"
+
+#: id:20099
+msgid "Can't rip CD or track while playing from CD"
+msgstr "Impossibile rippare CD o traccia con CD in riproduzione"
+
+#: id:20100
+msgid "Master lock code and settings"
+msgstr "Codice master lock e blocchi"
+
+#: id:20101
+msgid "Entering master lock code always enables master mode"
+msgstr "Inserendo il codice master si attiva sempre il master mode"
+
+#: id:20102
+msgid "or copy from default?"
+msgstr "o copiare dal default?"
+
+#: id:20103
+msgid "Save changes to profile?"
+msgstr "Salvare le modifche nel profilo?"
+
+#: id:20104
+msgid "Old settings found."
+msgstr "Trovate vecchie impostazioni."
+
+#: id:20105
+msgid "Do you want to use them?"
+msgstr "Vuoi usarle?"
+
+#: id:20106
+msgid "Old media sources found."
+msgstr "Trovate vecchie sorgenti media."
+
+#: id:20107
+msgid "Separate (locked)"
+msgstr "Separa (bloccato)"
+
+#: id:20108
+msgid "Root"
+msgstr "Root"
+
+#: id:20109
+msgid "- Zoom"
+msgstr "- Zoom"
+
+#: id:20110
+msgid "UPnP settings"
+msgstr "UPnP client"
+
+#: id:20111
+msgid "Autostart UPnP client"
+msgstr "Autostart client UPnP"
+
+#: id:20112
+msgid "Last login: %s"
+msgstr "Ultimo login: %s"
+
+#: id:20113
+msgid "Never logged on"
+msgstr "Mai loggato"
+
+#: id:20114
+msgid "Profile %i / %i"
+msgstr "Profilo %i / %i"
+
+#: id:20115
+msgid "User login / Select a profile"
+msgstr "Login utente/ Seleziona un profilo"
+
+#: id:20116
+msgid "Use lock on login screen"
+msgstr "Usa blocco nella schermata di login"
+
+#: id:20117
+msgid "Invalid lock code."
+msgstr "Codice di blocco invalido."
+
+#: id:20118
+msgid "This requires the master lock to be set."
+msgstr "Questo richiede l'impostazione del codice master."
+
+#: id:20119
+msgid "Would you like to set it now?"
+msgstr "Vuoi impostarlo adesso?"
+
+#: id:20120
+msgid "Loading program information"
+msgstr "Caricando informazioni programma"
+
+#: id:20121
+msgid "Party on!"
+msgstr "Party attivo!"
+
+#: id:20122
+msgid "True"
+msgstr "Vero"
+
+#: id:20123
+msgid "Mixing drinks"
+msgstr "Mixando bevande"
+
+#: id:20124
+msgid "Filling glasses"
+msgstr "Riempiendo bicchieri"
+
+#: id:20125
+msgid "Logged on as"
+msgstr "Loggato come"
+
+#: id:20126
+msgid "Log off"
+msgstr "Scollegati"
+
+#: id:20128
+msgid "Go to root"
+msgstr "Vai al root"
+
+#: id:20129
+msgid "Weave"
+msgstr "Weave"
+
+#: id:20130
+msgid "Weave (inverted)"
+msgstr "Weave (invertito)"
+
+#: id:20131
+msgid "Blend"
+msgstr "Blend"
+
+#: id:20132
+msgid "Restart video"
+msgstr "Riavvia video"
+
+#: id:20133
+msgid "Edit network location"
+msgstr "Modifica locazione di rete"
+
+#: id:20134
+msgid "Remove network location"
+msgstr "Rimuovi locazione di rete"
+
+#: id:20135
+msgid "Do you want to scan the folder?"
+msgstr "Vuoi scansionare la cartella?"
+
+#: id:20136
+msgid "Memory unit"
+msgstr "Unità di memoria"
+
+#: id:20137
+msgid "Memory unit mounted"
+msgstr "Unità di memoria montata"
+
+#: id:20138
+msgid "Unable to mount memory unit"
+msgstr "Impossibile montare l'unità di memoria"
+
+#: id:20139
+msgid "In port %i, slot %i"
+msgstr "In porta %i, slot %i"
+
+#: id:20140
+msgid "Lock screensaver"
+msgstr "Blocca salvaschermo"
+
+#: id:20141
+msgid "Set"
+msgstr "Imposta"
+
+#: id:20142
+msgctxt "Auto context with id 20142"
+msgid "Username"
+msgstr "Nome utente"
+
+#: id:20143
+msgid "Enter password for"
+msgstr "Inserire password per"
+
+#: id:20144
+msgid "Shutdown timer"
+msgstr "Timer spegnimento"
+
+#: id:20145
+msgid "Shutdown interval (in minutes)"
+msgstr "Intervallo spegnimento (in minuti)"
+
+#: id:20146
+msgid "Started, shutdown in %im"
+msgstr "Partito, spegnimento in %im"
+
+#: id:20147
+msgid "Shutdown in 30 minutes"
+msgstr "Spegnimento in 30 minuti"
+
+#: id:20148
+msgid "Shutdown in 60 minutes"
+msgstr "Spegnimento in 60 minuti"
+
+#: id:20149
+msgid "Shutdown in 120 minutes"
+msgstr "Spegnimento in 120 minuti"
+
+#: id:20150
+msgid "Custom shutdown timer"
+msgstr "Timer spegnimento personalizzato"
+
+#: id:20151
+msgid "Cancel shutdown timer"
+msgstr "Ferma timer spegnimento"
+
+#: id:20152
+msgid "Lock preferences for %s"
+msgstr "Blocca preferenze per %s"
+
+#: id:20153
+msgid "Browse..."
+msgstr "Esplora..."
+
+#: id:20154
+msgid "Summary information"
+msgstr "Riepilogo informazioni basilari"
+
+#: id:20155
+msgid "Storage information"
+msgstr "Informazioni sui dispositivi di memorizzazione"
+
+#: id:20156
+msgid "Hard disk information"
+msgstr "Informazioni sull'hard disk"
+
+#: id:20157
+msgid "DVD-ROM information"
+msgstr "Informazioni sul lettore DVD-ROM"
+
+#: id:20158
+msgid "Network information"
+msgstr "Informazioni di rete"
+
+#: id:20159
+msgid "Video information"
+msgstr "Informazioni sull uscita video"
+
+#: id:20160
+msgid "Hardware information"
+msgstr "Informazioni generali dell'hardware"
+
+#: id:20161
+msgid "Total"
+msgstr "Totale"
+
+#: id:20162
+msgid "Used"
+msgstr "Usato"
+
+#: id:20163
+msgid "of"
+msgstr "di"
+
+#: id:20164
+msgid "Locking not supported"
+msgstr "Blocco non supportato"
+
+#: id:20165
+msgid "Not locked"
+msgstr "Non bloccato"
+
+#: id:20166
+msgid "Locked"
+msgstr "Bloccato"
+
+#: id:20167
+msgid "Frozen"
+msgstr "Ibernato"
+
+#: id:20168
+msgid "Requires reset"
+msgstr "Richiede un reset"
+
+#: id:20169
+msgid "Week"
+msgstr "Settimana"
+
+#: id:20170
+msgid "Line"
+msgstr "Linea"
+
+#: id:20171
+msgid "Windows network (SMB)"
+msgstr "Condivisione di windows (SMB)"
+
+#: id:20172
+msgid "XBMSP server"
+msgstr "XBMSP server"
+
+#: id:20173
+msgctxt "Auto context with id 20173"
+msgid "FTP server"
+msgstr "FTP server"
+
+#: id:20174
+msgid "iTunes music share (DAAP)"
+msgstr "Condivisione musica iTunes (DAAP)"
+
+#: id:20175
+msgid "UPnP server"
+msgstr "UPnP server"
+
+#: id:20176
+msgid "Show video info"
+msgstr "Mostra le informazioni dei video"
+
+#: id:20177
+msgid "Done"
+msgstr "Fatto"
+
+#: id:20178
+msgid "Shift"
+msgstr "Maiusc."
+
+#: id:20179
+msgid "Caps Lock"
+msgstr "Bloc.Maiusc."
+
+#: id:20180
+msgid "Symbols"
+msgstr "Simboli"
+
+#: id:20181
+msgid "Backspace"
+msgstr "Cancella"
+
+#: id:20182
+msgid "Space"
+msgstr "Spazio"
+
+#: id:20183
+msgid "Reload skin"
+msgstr "Ricarica skin"
+
+#: id:20184
+msgid "Rotate pictures using EXIF information"
+msgstr "Ruota le immagini usando le informazioni EXIF"
+
+#: id:20185
+msgid "Use poster view styles for TV shows"
+msgstr "Usa la vista a poster per le serie TV"
+
+#: id:20186
+msgid "Please wait"
+msgstr "Attendere Prego"
+
+#: id:20187
+msgid "UPnP"
+msgstr ""
+
+#: id:20189
+msgid "Enable auto scrolling for plot & review"
+msgstr "Attiva lo scorrimento automatico per la trama e la recensione"
+
+#: id:20190
+msgctxt "Auto context with id 20190"
+msgid "Custom"
+msgstr "Custom"
+
+#: id:20191
+msgid "Enable debug logging"
+msgstr "Attiva il debug logging"
+
+#: id:20192
+msgid "Download additional information during updates"
+msgstr "Scarica ulteriori informazioni durante gli aggiornamenti"
+
+#: id:20193
+msgid "Default service for album information"
+msgstr "Scraper per le informazioni sugli album"
+
+#: id:20194
+msgid "Default service for artist information"
+msgstr "Scraper predefinito per gli artisti"
+
+#: id:20195
+msgid "Change scraper"
+msgstr "Cambia scraper"
+
+#: id:20196
+msgid "Export music library"
+msgstr "Esporta archivio musicale"
+
+#: id:20197
+msgid "Import music library"
+msgstr "Importa archivio musicale"
+
+#: id:20198
+msgid "No artist found!"
+msgstr "Nessun artista trovato!"
+
+#: id:20199
+msgid "Downloading artist info failed"
+msgstr "Scaricamento info artista fallito"
+
+#: id:20250
+msgid "Party on! (videos)"
+msgstr "Party attivo! (video)"
+
+#: id:20251
+msgid "Mixing drinks (videos)"
+msgstr "Mixando bevande (video)"
+
+#: id:20252
+msgid "Filling glasses (videos)"
+msgstr "Riempiendo bicchieri (video)"
+
+#: id:20253
+msgid "WebDAV server (HTTP)"
+msgstr "WebDAV server (HTTP)"
+
+#: id:20254
+msgid "WebDAV server (HTTPS)"
+msgstr "WebDAV server (HTTPS)"
+
+#: id:20255
+msgid "First logon, edit your profile"
+msgstr "Primo login, edita il tuo profilo"
+
+#: id:20256
+msgid "HTS Tvheadend client"
+msgstr "HTS Tvheadend client"
+
+#: id:20257
+msgid "VDR Streamdev client"
+msgstr "VDR Streamdev client"
+
+#: id:20258
+msgid "MythTV client"
+msgstr "Client Myth TV"
+
+#: id:20259
+msgid "Network Filesystem (NFS)"
+msgstr "Network Filesystem (NFS)"
+
+#: id:20260
+msgid "Secure Shell (SSH/SFTP)"
+msgstr "Shell sicura(SSH/SFTP)"
+
+#: id:20261
+msgid "Apple Filing Protocol (AFP)"
+msgstr "Apple Filing Protocol (AFP)"
+
+#: id:20300
+msgid "Web server directory (HTTP)"
+msgstr "Web server directory (HTTP)"
+
+#: id:20301
+msgid "Web server directory (HTTPS)"
+msgstr "Web server directory (HTTPS)"
+
+#: id:20302
+msgid "Unable to write to folder:"
+msgstr "Impossibile scrivere nella cartella:"
+
+#: id:20303
+msgid "Do you want to skip and proceed?"
+msgstr "Vuoi ignorare e procedere?"
+
+#: id:20304
+msgid "RSS Feed"
+msgstr "RSS Feed"
+
+#: id:20307
+msgid "Secondary DNS"
+msgstr "DNS secondario"
+
+#: id:20308
+msgid "DHCP server:"
+msgstr "server DHCP:"
+
+#: id:20309
+msgid "Make new folder"
+msgstr "Crea nuova cartella"
+
+#: id:20310
+msgid "Dim LCD on playback"
+msgstr "Oscura LCD se in riproduzione"
+
+#: id:20311
+msgid "Unknown or onboard (protected)"
+msgstr "Sconosciuto o installato (protetto)"
+
+#: id:20312
+msgid "Dim LCD on paused"
+msgstr "Oscura LCD se in pausa"
+
+#: id:20314
+msgid "Videos - Library"
+msgstr "Video - Archivio"
+
+#: id:20316
+msgid "Sort by: ID"
+msgstr "Ordina per: ID"
+
+#: id:20324
+msgid "Play part..."
+msgstr "Play part..."
+
+#: id:20325
+msgid "Calibration reset"
+msgstr "Reset calibrazione"
+
+#: id:20326
+msgid "This will reset the calibration values for %s"
+msgstr "Questo resetterà il valore di calibrazione per %s"
+
+#: id:20327
+msgid "to it's default values."
+msgstr "al suo valore originale."
+
+#: id:20328
+msgid "Browse for destination"
+msgstr "Cerca la destinazione"
+
+#: id:20329
+msgid "Movies are in separate folders that match the movie title"
+msgstr "I film sono in cartelle separate rinominate con il titolo del film"
+
+#: id:20330
+msgid "Use folder names for lookups"
+msgstr "Usa i nomi delle cartelle per le ricerche"
+
+#: id:20331
+msgctxt "Auto context with id 20331"
+msgid "File"
+msgstr "File"
+
+#: id:20332
+msgid "Use file or folder names in lookups?"
+msgstr "Uso i nomi dei file o delle cartelle per le ricerche?"
+
+#: id:20333
+msgid "Set content"
+msgstr "Imposta il contenuto"
+
+#: id:20334
+msgid "Folder"
+msgstr "Cartella"
+
+#: id:20335
+msgid "Look for content recursively?"
+msgstr "Cerco il contenuto in modo ricorsivo?"
+
+#: id:20336
+msgid "Unlock sources"
+msgstr "Sblocca le sorgenti"
+
+#: id:20337
+msgid "Actor"
+msgstr "Attore"
+
+#: id:20338
+msgid "Movie"
+msgstr "Film"
+
+#: id:20339
+msgid "Director"
+msgstr "Regista"
+
+#: id:20340
+msgid "Do you want to remove all items within"
+msgstr "Vuoi rimuovere tutti gli elementi in"
+
+#: id:20341
+msgid "this path from the XBMC library?"
+msgstr "questo percorso dall'archivio di XBMC?"
+
+#: id:20342
+msgctxt "Auto context with id 20342"
+msgid "Movies"
+msgstr "Film"
+
+#: id:20343
+msgid "TV shows"
+msgstr "Serie TV"
+
+#: id:20344
+msgid "This directory contains"
+msgstr "Questa directory contiene"
+
+#: id:20345
+msgid "Run automated scan"
+msgstr "Avvia la scansione automatica"
+
+#: id:20346
+msgid "Scan recursively"
+msgstr "Scansione ricorsiva"
+
+#: id:20347
+msgid "as"
+msgstr "nel ruolo di"
+
+#: id:20348
+msgid "Directors"
+msgstr "Registi"
+
+#: id:20349
+msgid "No video files found in this path!"
+msgstr "Nessun file video trovato in questo percorso!"
+
+#: id:20350
+msgid "votes"
+msgstr "voti"
+
+#: id:20351
+msgid "TV show information"
+msgstr "Informazioni serie TV"
+
+#: id:20352
+msgid "Episode information"
+msgstr "Informazioni episodio"
+
+#: id:20353
+msgid "Loading TV show details"
+msgstr "Caricamento dettagli serie TV"
+
+#: id:20354
+msgid "Fetching episode guide"
+msgstr "Elaborazione guida episodi"
+
+#: id:20355
+msgid "Loading info for episodes in directory"
+msgstr "Caricamento info per gli episodi nella directory"
+
+#: id:20356
+msgid "Select TV show:"
+msgstr "Seleziona serie TV:"
+
+#: id:20357
+msgid "Enter the TV show name"
+msgstr "Inserire il nome della serie TV"
+
+#: id:20358
+msgid "Season %i"
+msgstr "Stagione %i"
+
+#: id:20359
+msgid "Episode"
+msgstr "Episodio"
+
+#: id:20360
+msgid "Episodes"
+msgstr "Episodi"
+
+#: id:20361
+msgid "Loading episode details"
+msgstr "Caricamento dettagli episodio"
+
+#: id:20362
+msgid "Remove episode from library"
+msgstr "Rimuovi episodio dall'archivio"
+
+#: id:20363
+msgid "Remove TV show from library"
+msgstr "Rimuovi serie TV dall'archivio"
+
+#: id:20364
+msgid "TV show"
+msgstr "Serie TV"
+
+#: id:20365
+msgid "Episode plot"
+msgstr "Trama episodio"
+
+#: id:20366
+msgid "* All seasons"
+msgstr "* Tutte le stagioni"
+
+#: id:20367
+msgid "Hide watched"
+msgstr "Nascondi già visti"
+
+#: id:20368
+msgid "Prod code"
+msgstr "Codice prod"
+
+#: id:20369
+msgid "Show plot for unwatched items"
+msgstr "Mostra la trama per gli elementi non visti"
+
+#: id:20370
+msgid "* Hidden to prevent spoilers *"
+msgstr "* Nascosto per prevenire gli spoilers *"
+
+#: id:20371
+msgid "Set season thumb"
+msgstr "Imposta icona stagione"
+
+#: id:20372
+msgid "Season image"
+msgstr "Immagine stagione"
+
+#: id:20373
+msgid "Season"
+msgstr "Stagione"
+
+#: id:20374
+msgid "Downloading movie information"
+msgstr "Scaricamento informazioni film"
+
+#: id:20375
+msgid "Unassign content"
+msgstr "Contenuto non assegnato"
+
+#: id:20376
+msgid "Original title"
+msgstr "Titolo originale"
+
+#: id:20377
+msgid "Refresh TV show information"
+msgstr "Aggiorna informazioni serie TV"
+
+#: id:20378
+msgid "Refresh info for all episodes?"
+msgstr "Aggiorna info per tutti gli episodi?"
+
+#: id:20379
+msgid "Selected folder contains a single TV show"
+msgstr "La cartella contiene una sola serie TV"
+
+#: id:20380
+msgid "Exclude selected folder from scans"
+msgstr "Escludi cartella dalla scansione"
+
+#: id:20381
+msgid "Specials"
+msgstr "Speciali"
+
+#: id:20382
+msgid "Automatically grab season thumbs"
+msgstr "Trova automaticamente le icone della stagione"
+
+#: id:20383
+msgid "Selected folder contains a single video"
+msgstr "La cartella contiene un solo video"
+
+#: id:20384
+msgid "Link to TV show"
+msgstr "Collega a serie TV"
+
+#: id:20385
+msgid "Remove link to TV show"
+msgstr "Rimuovi collegamento a serie TV"
+
+#: id:20386
+msgid "Recently added movies"
+msgstr "Film aggiunti di recente"
+
+#: id:20387
+msgid "Recently added episodes"
+msgstr "Episodi aggiunti di recente"
+
+#: id:20388
+msgid "Studios"
+msgstr "Studio"
+
+#: id:20389
+msgid "Music videos"
+msgstr "Video musicali"
+
+#: id:20390
+msgid "Recently added music videos"
+msgstr "Video musicali recenti"
+
+#: id:20391
+msgid "Music video"
+msgstr "Video musicale"
+
+#: id:20392
+msgid "Remove music video from library"
+msgstr "Rimuovi i video musicali dall'archivio"
+
+#: id:20393
+msgctxt "Auto context with id 20393"
+msgid "Music video information"
+msgstr "Informazioni video musicale"
+
+#: id:20394
+msgid "Loading music video information"
+msgstr "Caricamento informazioni video musicale"
+
+#: id:20395
+msgid "Mixed"
+msgstr "Mixed"
+
+#: id:20396
+msgid "Go to albums by artist"
+msgstr "Vai a album per artista"
+
+#: id:20397
+msgid "Go to album"
+msgstr "Vai a album"
+
+#: id:20398
+msgid "Play song"
+msgstr "Riproduci brano"
+
+#: id:20399
+msgid "Go to music videos from album"
+msgstr "Vai a video musicali dall'album"
+
+#: id:20400
+msgid "Go to music videos by artist"
+msgstr "Vai a video musicali per artista"
+
+#: id:20401
+msgid "Play music video"
+msgstr "Riproduci video musicale"
+
+#: id:20402
+msgid "Download actor thumbnails when adding to library"
+msgstr "Scarica le icone degli attori all'aggiunta in archivio"
+
+#: id:20403
+msgid "Set actor thumb"
+msgstr "Imposta icona attore"
+
+#: id:20405
+msgid "Remove episode bookmark"
+msgstr "Rimuovi segnalibro episodio"
+
+#: id:20406
+msgid "Set episode bookmark"
+msgstr "Imposta segnalibro episodio"
+
+#: id:20407
+msgid "Scraper settings"
+msgstr "Impostazioni scraper"
+
+#: id:20408
+msgid "Downloading music video information"
+msgstr "Scaricamento informazioni video musicale"
+
+#: id:20409
+msgid "Downloading TV show information"
+msgstr "Scaricamento informazioni serie TV"
+
+#: id:20410
+msgid "Trailer"
+msgstr "Trailer"
+
+#: id:20411
+msgid "Flatten"
+msgstr "Spiana"
+
+#: id:20412
+msgid "Flatten TV shows"
+msgstr "Spiana serie TV"
+
+#: id:20413
+msgid "Get fanart"
+msgstr "Ottieni Fanart"
+
+#: id:20414
+msgid "Show Fanart in video and music libraries"
+msgstr "Mostra Fanart nell'archivio video e musica"
+
+#: id:20415
+msgid "Scanning for new content"
+msgstr "Scansione nuovo contenuto"
+
+#: id:20416
+msgid "First aired"
+msgstr "Prima visione"
+
+#: id:20417
+msgid "Writer"
+msgstr "Scrittore"
+
+#: id:20419
+msgid "Replace file names with library titles"
+msgstr "Mostra i metadati nella vista file"
+
+#: id:20420
+msgctxt "Auto context with id 20420"
+msgid "Never"
+msgstr "Mai"
+
+#: id:20421
+msgid "If only one season"
+msgstr "Se solo una stagione"
+
+#: id:20422
+msgid "Always"
+msgstr "Sempre"
+
+#: id:20423
+msgid "Has trailer"
+msgstr "Ha trailer"
+
+#: id:20424
+msgid "False"
+msgstr "Falso"
+
+#: id:20425
+msgid "Fanart slideshow"
+msgstr "Slideshow di Fanart"
+
+#: id:20426
+msgid "Export to a single file or separate"
+msgstr "Esporta in un singolo file o in file"
+
+#: id:20427
+msgid "files per entry?"
+msgstr "separati per ogni elemento?"
+
+#: id:20428
+msgid "Single file"
+msgstr "Singolo file"
+
+#: id:20429
+msgctxt "Auto context with id 20429"
+msgid "Separate"
+msgstr "Separatamente"
+
+#: id:20430
+msgid "Export thumbnails and fanart?"
+msgstr "Esporta le immagini e i fanart?"
+
+#: id:20431
+msgid "Overwrite old files?"
+msgstr "Sovrascrivo i file?"
+
+#: id:20432
+msgid "Exclude path from library updates"
+msgstr "Escludi il percorso dagli aggiornamenti dell'archivio"
+
+#: id:20433
+msgid "Extract thumbnails and video information"
+msgstr "Estrai le immagini e le informazioni video"
+
+#: id:20434
+msgid "Sets"
+msgstr "Set"
+
+#: id:20435
+msgid "Set movieset thumb"
+msgstr "Imposta icona movieset"
+
+#: id:20436
+msgid "Export actor thumbs?"
+msgstr "Esporta immagini attori?"
+
+#: id:20437
+msgid "Choose fanart"
+msgstr "Seleziona fanart"
+
+#: id:20438
+msgid "Local fanart"
+msgstr "Fanart locale"
+
+#: id:20439
+msgid "No fanart"
+msgstr "Nessuna fanart"
+
+#: id:20440
+msgid "Current fanart"
+msgstr "Fanart attuale"
+
+#: id:20441
+msgid "Remote fanart"
+msgstr "Fanart remota"
+
+#: id:20442
+msgid "Change content"
+msgstr "Cambia contenuto"
+
+#: id:20443
+msgid "Do you want to refresh info for all"
+msgstr "Vuoi aggiornare le informazioni per tutti"
+
+#: id:20444
+msgid "items within this path?"
+msgstr "gli elementi in questo percorso?"
+
+#: id:20445
+msgid "Fanart"
+msgstr "Fanart"
+
+#: id:20446
+msgid "Locally stored information found."
+msgstr "Trovate informazioni locali già memorizzate."
+
+#: id:20447
+msgid "Ignore and refresh from internet?"
+msgstr "Ignora e aggiorna da Internet?"
+
+#: id:20448
+msgid "Could not download information"
+msgstr "Impossibile scaricare le informazioni"
+
+#: id:20449
+msgid "Unable to connect to remote server"
+msgstr "Impossibile collegarsi al server remoto"
+
+#: id:20450
+msgid "Would you like to continue scanning?"
+msgstr "Si desidera continuare la scansione?"
+
+#: id:20451
+msgid "Countries"
+msgstr "Paesi"
+
+#: id:20452
+msgid "episode"
+msgstr "episodio"
+
+#: id:20453
+msgid "episodes"
+msgstr "episodi"
+
+#: id:20454
+msgid "Listener"
+msgstr "In Ascolto"
+
+#: id:20455
+msgid "Listeners"
+msgstr "In Ascolto"
+
+#: id:20456
+msgid "Set movieset fanart"
+msgstr "Imposta l'immagine fanart per un set di filmati"
+
+#: id:20457
+msgid "Movie set"
+msgstr "imposta filmato"
+
+#: id:20458
+msgid "Group movies in sets"
+msgstr "Raggruppa film in antologie"
+
+#: id:21330
+msgid "Show hidden files and directories"
+msgstr "Mostra i files e le cartelle nascoste"
+
+#: id:21331
+msgid "TuxBox client"
+msgstr "TuxBox client"
+
+#: id:21332
+msgid "WARNING: Target TuxBox device is in recording-mode!"
+msgstr "ATTENZIONE: il dispositivo TuxBox è in modalità registrazione!"
+
+#: id:21333
+msgid "The stream will be stopped!"
+msgstr "Lo stream verrà fermato!"
+
+#: id:21334
+msgid "Zap to channel: %s failed!"
+msgstr "Salto al canale: %s fallito!"
+
+#: id:21335
+msgid "Are you sure to start the stream?"
+msgstr "Sicuro di fare partire lo stream ?"
+
+#: id:21336
+msgid "Connecting to: %s"
+msgstr "Connessione a: %s"
+
+#: id:21337
+msgid "TuxBox device"
+msgstr "Dispositivo TuxBox"
+
+#: id:21359
+msgid "Add media share..."
+msgstr "Aggiungi condivisione media..."
+
+#: id:21360
+msgid "Share video and music libraries through UPnP"
+msgstr "Condividi gli archivi musicali e video attraverso UPnP"
+
+#: id:21364
+msgid "Edit media share"
+msgstr "Modifica condivisioni media"
+
+#: id:21365
+msgid "Remove media share"
+msgstr "Rimuovi condivisioni media"
+
+#: id:21366
+msgid "Subtitle folder"
+msgstr "Cartella sottotitoli"
+
+#: id:21367
+msgid "Movie & alternate subtitle directory"
+msgstr "Film & cartella sottotitoli alternativa"
+
+#: id:21368
+msgid "Override ASS/SSA subtitles fonts"
+msgstr "Override ASS/SSA subtitles fonts"
+
+#: id:21369
+msgid "Enable mouse and Touch Screen support"
+msgstr "Abilita il mouse"
+
+#: id:21370
+msgid "Play navigation sounds during media playback"
+msgstr "Suoni di navigazione attivi durante la riproduzione"
+
+#: id:21371
+msgid "Thumbnail"
+msgstr "Icone"
+
+#: id:21372
+msgid "Forced DVD player region"
+msgstr "Forza la regione del player DVD"
+
+#: id:21373
+msgid "Video output"
+msgstr "Uscita video"
+
+#: id:21374
+msgid "Video aspect"
+msgstr "Aspetto video"
+
+#: id:21375
+msgctxt "Auto context with id 21375"
+msgid "Normal"
+msgstr "Normale"
+
+#: id:21376
+msgid "Letterbox"
+msgstr "Letterbox"
+
+#: id:21377
+msgid "Widescreen"
+msgstr "Schermo largo"
+
+#: id:21378
+msgid "Enable 480p"
+msgstr "Attiva 480p"
+
+#: id:21379
+msgid "Enable 720p"
+msgstr "Attiva 720p"
+
+#: id:21380
+msgid "Enable 1080i"
+msgstr "Attiva 1080i"
+
+#: id:21381
+msgid "Enter name of new playlist"
+msgstr "Inserire il nome di una nuova playlist"
+
+#: id:21382
+msgid "Show \"Add source\" buttons in file lists"
+msgstr "Mostra il pulsante \"Aggiungi sorgente\" nelle liste file"
+
+#: id:21383
+msgid "Enable scrollbars"
+msgstr "Attiva le barre di scorrimento"
+
+#: id:21384
+msgid "Make watched filtering a toggle in video library"
+msgstr "Rendi il filtro \"già visti\" alternabile nell'archivio video"
+
+#: id:21385
+msgctxt "Auto context with id 21385"
+msgid "Open"
+msgstr "Apri"
+
+#: id:21386
+msgid "Acoustic management level"
+msgstr "Regolazione livello acustico"
+
+#: id:21387
+msgid "Fast"
+msgstr "Veloce"
+
+#: id:21388
+msgid "Quiet"
+msgstr "Silenzioso"
+
+#: id:21389
+msgid "Enable custom background"
+msgstr "Attiva gli sfondi personalizzati"
+
+#: id:21390
+msgid "Power management level"
+msgstr "Regolazione livello potenza"
+
+#: id:21391
+msgid "High power"
+msgstr "Potenza alta"
+
+#: id:21392
+msgid "Low power"
+msgstr "Potenza bassa"
+
+#: id:21393
+msgid "High standby"
+msgstr "Standby alto"
+
+#: id:21394
+msgid "Low standby"
+msgstr "Standby basso"
+
+#: id:21395
+msgid "Unable to cache files bigger than 4GB"
+msgstr "Impossibile memorizzare files più grandi di 4 gb"
+
+#: id:21396
+msgid "Chapter"
+msgstr "Capitolo"
+
+#: id:21397
+msgid "High quality pixel shader v2"
+msgstr "Pixel shader alta qualità v2"
+
+#: id:21398
+msgid "Enable playlist at startup"
+msgstr "Attiva la playlist all'avvio"
+
+#: id:21399
+msgid "Use tween animations"
+msgstr "Usa le animazioni tween"
+
+#: id:21400
+msgid "contains"
+msgstr "contiene"
+
+#: id:21401
+msgid "does not contain"
+msgstr "non contiene"
+
+#: id:21402
+msgid "is"
+msgstr "è"
+
+#: id:21403
+msgid "is not"
+msgstr "non è"
+
+#: id:21404
+msgid "starts with"
+msgstr "comincia con"
+
+#: id:21405
+msgid "ends with"
+msgstr "finisce con"
+
+#: id:21406
+msgid "greater than"
+msgstr "più grande di"
+
+#: id:21407
+msgid "less than"
+msgstr "minore di"
+
+#: id:21408
+msgid "after"
+msgstr "dopo"
+
+#: id:21409
+msgid "before"
+msgstr "prima"
+
+#: id:21410
+msgid "in the last"
+msgstr "alla fine"
+
+#: id:21411
+msgid "not in the last"
+msgstr "non alla fine"
+
+#: id:21412
+msgid "Scrapers"
+msgstr "Scraper"
+
+#: id:21413
+msgid "Default movie scraper"
+msgstr "Scraper predefinito per i film"
+
+#: id:21414
+msgid "Default tvshow scraper"
+msgstr "Scraper predefinito per le serie TV"
+
+#: id:21415
+msgid "Default music video scraper"
+msgstr "Scraper predefinito per i video musicali"
+
+#: id:21416
+msgid "Enable fallback based on scraper language"
+msgstr "Abilita il ripiego in base alla lingua degli scraper"
+
+#: id:21417
+msgid "- Settings"
+msgstr "- Impostazioni"
+
+#: id:21418
+msgid "Multilingual"
+msgstr "Multilingua"
+
+#: id:21419
+msgid "No scrapers present"
+msgstr "Nessuno scraper disponibile"
+
+#: id:21420
+msgid "Value to match"
+msgstr "Valore da raggiungere"
+
+#: id:21421
+msgid "Smart playlist rule"
+msgstr "Regola smart playlist"
+
+#: id:21422
+msgid "Match items where"
+msgstr "Fai combaciare gli elementi dove"
+
+#: id:21423
+msgid "New rule..."
+msgstr "Nuova regola..."
+
+#: id:21424
+msgid "Items must match"
+msgstr "Gli elementi devono combaciare"
+
+#: id:21425
+msgid "all of the rules"
+msgstr "tutte le regole"
+
+#: id:21426
+msgid "one or more of the rules"
+msgstr "una o più delle regole"
+
+#: id:21427
+msgid "Limit to"
+msgstr "Limita a"
+
+#: id:21428
+msgid "No limit"
+msgstr "Nessun limite"
+
+#: id:21429
+msgid "Order by"
+msgstr "Ordina per"
+
+#: id:21430
+msgid "ascending"
+msgstr "crescente"
+
+#: id:21431
+msgid "descending"
+msgstr "descrescente"
+
+#: id:21432
+msgid "Edit smart playlist"
+msgstr "Modifica smart playlist"
+
+#: id:21433
+msgid "Name of the playlist"
+msgstr "Nome della playlist"
+
+#: id:21434
+msgid "Find items where"
+msgstr "Trova gli elementi che combaciano"
+
+#: id:21435
+msgid "Edit"
+msgstr "Modifica"
+
+#: id:21436
+msgid "%i items"
+msgstr "%i elementi"
+
+#: id:21437
+msgid "New smart playlist..."
+msgstr "Nuova smart playlist..."
+
+#: id:21438
+msgid "%c Drive"
+msgstr "%c Drive"
+
+#: id:21439
+msgid "Edit party mode rules"
+msgstr "Modifica le regole del party mode"
+
+#: id:21440
+msgid "Home folder"
+msgstr "Cartella home"
+
+#: id:21441
+msgid "Watched count"
+msgstr "Conteggio visti"
+
+#: id:21442
+msgid "Episode title"
+msgstr "Titolo episodio"
+
+#: id:21443
+msgid "Video resolution"
+msgstr "Risoluzione video"
+
+#: id:21444
+msgid "Audio channels"
+msgstr "Canali audio"
+
+#: id:21445
+msgid "Video codec"
+msgstr "Codec video"
+
+#: id:21446
+msgid "Audio codec"
+msgstr "Codec audio"
+
+#: id:21447
+msgid "Audio language"
+msgstr "Lingua audio"
+
+#: id:21448
+msgid "Subtitle language"
+msgstr "Lingua dei sottotitoli"
+
+#: id:21449
+msgid "Remote control sends keyboard presses"
+msgstr "Il telecomando simula i tasti della tastiera"
+
+#: id:21450
+msgid "- Edit"
+msgstr "- Edita"
+
+#: id:21451
+msgid "Internet connection required."
+msgstr "Richiesta connessione Internet."
+
+#: id:21452
+msgid "Get More..."
+msgstr "Altro..."
+
+#: id:21453
+msgid "Root filesystem"
+msgstr "Root filesystem"
+
+#: id:21454
+msgid "Cache full"
+msgstr "Cache piena"
+
+#: id:21455
+msgid "Cache filled before reaching required amount for continous playback"
+msgstr "Cache saturata prima di raggiungere il livello richiesto per una riproduzione fluida"
+
+#: id:21460
+msgid "Subtitle location"
+msgstr "Cartella dei sottotitoli"
+
+#: id:21461
+msgid "Fixed"
+msgstr "Fissa"
+
+#: id:21462
+msgid "Bottom of video"
+msgstr "Bordo inferiore del video"
+
+#: id:21463
+msgid "Below video"
+msgstr "Sotto il video"
+
+#: id:21464
+msgid "Top of video"
+msgstr "Bordo superiore del video"
+
+#: id:21465
+msgid "Above video"
+msgstr "Sopra il video"
+
+#: id:21800
+msgid "File name"
+msgstr "Nome file"
+
+#: id:21801
+msgid "File path"
+msgstr "Percorso file"
+
+#: id:21802
+msgid "File size"
+msgstr "Dimensione file"
+
+#: id:21803
+msgid "File date/time"
+msgstr "Data/ora file"
+
+#: id:21804
+msgid "Slide index"
+msgstr "Slide index"
+
+#: id:21805
+msgctxt "Auto context with id 21805"
+msgid "Resolution"
+msgstr "Risoluzione"
+
+#: id:21806
+msgctxt "Auto context with id 21806"
+msgid "Comment"
+msgstr "Commento"
+
+#: id:21807
+msgid "Colour/B&W"
+msgstr "Colori/bn"
+
+#: id:21808
+msgid "JPEG process"
+msgstr "Processo JPEG"
+
+#: id:21820
+msgid "Date/Time"
+msgstr "Data/Ora"
+
+#: id:21821
+msgid "Description"
+msgstr "Descrizione"
+
+#: id:21822
+msgid "Camera make"
+msgstr "Marca fotocamera"
+
+#: id:21823
+msgid "Camera model"
+msgstr "Modello fotocamera"
+
+#: id:21824
+msgid "EXIF comment"
+msgstr "Commento EXIF"
+
+#: id:21825
+msgid "Firmware"
+msgstr "Firmware"
+
+#: id:21826
+msgid "Aperture"
+msgstr "Apertura"
+
+#: id:21827
+msgid "Focal length"
+msgstr "Lunghezza focale"
+
+#: id:21828
+msgid "Focus distance"
+msgstr "Distanza di fuoco"
+
+#: id:21829
+msgid "Exposure"
+msgstr "Esposizione"
+
+#: id:21830
+msgid "Exposure time"
+msgstr "Tempo esposizione"
+
+#: id:21831
+msgid "Exposure bias"
+msgstr "Bias esposizione"
+
+#: id:21832
+msgid "Exposure mode"
+msgstr "Modalità esposizione"
+
+#: id:21833
+msgid "Flash used"
+msgstr "Flash usato"
+
+#: id:21834
+msgid "White-balance"
+msgstr "Bilanciamento del bianco"
+
+#: id:21835
+msgid "Light source"
+msgstr "Sorgente di luce"
+
+#: id:21836
+msgid "Metering mode"
+msgstr "Modalità di misura"
+
+#: id:21837
+msgid "ISO"
+msgstr "ISO"
+
+#: id:21838
+msgid "Digital zoom"
+msgstr "Zoom digitale"
+
+#: id:21839
+msgid "CCD width"
+msgstr "Ampiezza CCD"
+
+#: id:21840
+msgid "GPS latitude"
+msgstr "Latitudine GPS"
+
+#: id:21841
+msgid "GPS longitude"
+msgstr "Longitudine GPS"
+
+#: id:21842
+msgid "GPS altitude"
+msgstr "Altitudine GPS"
+
+#: id:21843
+msgid "Orientation"
+msgstr "Orientamento"
+
+#: id:21860
+msgid "Supplemental categories"
+msgstr "Categorie supplementari"
+
+#: id:21861
+msgid "Keywords"
+msgstr "Parole chiave"
+
+#: id:21862
+msgid "Caption"
+msgstr "Titolo"
+
+#: id:21863
+msgid "Author"
+msgstr "Autore"
+
+#: id:21864
+msgid "Headline"
+msgstr "Testata"
+
+#: id:21865
+msgid "Special instructions"
+msgstr "Istruzioni speciali"
+
+#: id:21866
+msgid "Category"
+msgstr "Categoria"
+
+#: id:21867
+msgid "Byline"
+msgstr "Byline"
+
+#: id:21868
+msgid "Byline title"
+msgstr "Titolo byline"
+
+#: id:21869
+msgid "Credit"
+msgstr "Crediti"
+
+#: id:21870
+msgid "Source"
+msgstr "Sorgente"
+
+#: id:21871
+msgid "Copyright notice"
+msgstr "Avviso copyright"
+
+#: id:21872
+msgid "Object name"
+msgstr "Nome elemento"
+
+#: id:21873
+msgid "City"
+msgstr "Città"
+
+#: id:21874
+msgid "State"
+msgstr "Stato"
+
+#: id:21875
+msgctxt "Auto context with id 21875"
+msgid "Country"
+msgstr "Nazione"
+
+#: id:21876
+msgid "Original Tx Reference"
+msgstr "Referenza originale Tx"
+
+#: id:21877
+msgid "Date created"
+msgstr "Data creazione"
+
+#: id:21878
+msgid "Copyright flag"
+msgstr "Copyright"
+
+#: id:21879
+msgid "Country code"
+msgstr "Codice paese"
+
+#: id:21880
+msgid "Reference service"
+msgstr "Servizio di riferimento"
+
+#: id:21881
+msgid "Allow control of XBMC via UPnP"
+msgstr "Permetti il controllo di XBMC via UPnP"
+
+#: id:21882
+msgid "Attempt to skip introduction before DVD menu"
+msgstr "Prova a saltare l'introduzione prima del menu DVD"
+
+#: id:21883
+msgid "Saved music"
+msgstr "Musica salvata"
+
+#: id:21884
+msgid "Query info for all artists"
+msgstr "Richiedi info per tutti gli artisti"
+
+#: id:21885
+msgid "Downloading album information"
+msgstr "Scaricamento informazioni album"
+
+#: id:21886
+msgid "Downloading artist information"
+msgstr "Scaricamento informazioni artista"
+
+#: id:21887
+msgid "Biography"
+msgstr "Biografia"
+
+#: id:21888
+msgid "Discography"
+msgstr "Discografia"
+
+#: id:21889
+msgid "Searching artist"
+msgstr "Ricerca artista"
+
+#: id:21890
+msgid "Select artist"
+msgstr "Seleziona artista"
+
+#: id:21891
+msgctxt "Auto context with id 21891"
+msgid "Artist information"
+msgstr "Informazioni artista"
+
+#: id:21892
+msgid "Instruments"
+msgstr "Strumenti"
+
+#: id:21893
+msgid "Born"
+msgstr "Nato"
+
+#: id:21894
+msgid "Formed"
+msgstr "Formato"
+
+#: id:21895
+msgid "Themes"
+msgstr "Temi"
+
+#: id:21896
+msgid "Disbanded"
+msgstr "Sciolto"
+
+#: id:21897
+msgid "Died"
+msgstr "Morto"
+
+#: id:21898
+msgid "Years active"
+msgstr "Anni attività"
+
+#: id:21899
+msgid "Label"
+msgstr "Etichetta"
+
+#: id:21900
+msgid "Born/Formed"
+msgstr "Nato/Formato"
+
+#: id:22000
+msgid "Update library on startup"
+msgstr "Aggiorna l'archivio all'avvio"
+
+#: id:22001
+msgid "Hide progress of library updates"
+msgstr "Nascondi avanzamento aggiornamento archivio"
+
+#: id:22002
+msgid "- DNS suffix"
+msgstr "- Suffisso DNS"
+
+#: id:22003
+msgid "%2.3fs"
+msgstr "%2.3fs"
+
+#: id:22004
+msgid "Delayed by: %2.3fs"
+msgstr "In ritardo di: %2.3fs"
+
+#: id:22005
+msgid "Ahead by: %2.3fs"
+msgstr "In anticipo di: %2.3fs"
+
+#: id:22006
+msgid "Subtitle offset"
+msgstr "Offset sottotitoli"
+
+#: id:22007
+msgid "OpenGL vendor:"
+msgstr "Marca OpenGL:"
+
+#: id:22008
+msgid "OpenGL renderer:"
+msgstr "Renderer OpenGL:"
+
+#: id:22009
+msgid "OpenGL version:"
+msgstr "Versione OpenGL:"
+
+#: id:22010
+msgid "GPU temperature:"
+msgstr "Temperatura GPU:"
+
+#: id:22011
+msgid "CPU temperature:"
+msgstr "Temperatura CPU:"
+
+#: id:22012
+msgid "Total memory"
+msgstr "Memoria totale"
+
+#: id:22013
+msgid "Profile data"
+msgstr "Dati profilo"
+
+#: id:22014
+msgid "Use dim if paused during video playback"
+msgstr "Usa \"dim\" se in pausa durante la riproduzione"
+
+#: id:22015
+msgid "All recordings"
+msgstr "Tutte le registrazioni"
+
+#: id:22016
+msgid "By title"
+msgstr "Per titolo"
+
+#: id:22017
+msgid "By group"
+msgstr "Per gruppo"
+
+#: id:22018
+msgid "Live channels"
+msgstr "Canali TV"
+
+#: id:22019
+msgid "Recordings by title"
+msgstr "Registrazioni per titolo"
+
+#: id:22020
+msgid "Guide"
+msgstr "Guida"
+
+#: id:22021
+msgid "Allowed error in aspect ratio to minimize black bars"
+msgstr "Errore proporzioni permesso per ridurre le barre nere"
+
+#: id:22022
+msgid "Show video files in listings"
+msgstr "Mostra i file video nelle liste"
+
+#: id:22023
+msgid "DirectX vendor:"
+msgstr "Fornitore DirectX:"
+
+#: id:22024
+msgid "Direct3D version:"
+msgstr "Versione Direct3D:"
+
+#: id:22030
+msgctxt "Auto context with id 22030"
+msgid "Font"
+msgstr "Carattere"
+
+#: id:22031
+msgctxt "Auto context with id 22031"
+msgid "- Size"
+msgstr "- Dimensione"
+
+#: id:22032
+msgctxt "Auto context with id 22032"
+msgid "- Colours"
+msgstr "- Colore"
+
+#: id:22033
+msgid "- Charset"
+msgstr "- Carattere di default"
+
+#: id:22034
+msgid "Export karaoke titles as HTML"
+msgstr "Esporta i titoli karaoke in HTML"
+
+#: id:22035
+msgid "Export karaoke titles as CSV"
+msgstr "Esporta i titoli karaoke in CSV"
+
+#: id:22036
+msgid "Import karaoke titles..."
+msgstr "Importa i titoli karaoke"
+
+#: id:22037
+msgid "Show song selector automatically"
+msgstr "Mostra automaticamente il selettore canzone"
+
+#: id:22038
+msgid "Export karaoke titles..."
+msgstr "Esporta i titoli karaoke"
+
+#: id:22039
+msgid "Enter song number"
+msgstr "Inserisci numero brano"
+
+#: id:22040
+msgid "white/green"
+msgstr "bianco/verde"
+
+#: id:22041
+msgid "white/red"
+msgstr "bianco/rosso"
+
+#: id:22042
+msgid "white/blue"
+msgstr "bianco/blu"
+
+#: id:22043
+msgid "black/white"
+msgstr "nero/bianco"
+
+#: id:22079
+msgid "Default select action"
+msgstr "Azione predefinita di selezione"
+
+#: id:22080
+msgid "Choose"
+msgstr "Scegli"
+
+#: id:22081
+msgid "Show Information"
+msgstr "Mostra Informazioni"
+
+#: id:22082
+msgid "More..."
+msgstr "Altro..."
+
+#: id:22083
+msgid "Play all"
+msgstr "Riproduci tutto"
+
+#: id:23049
+msgid "Teletext not available"
+msgstr "Teletext non disponibile"
+
+#: id:23050
+msgid "Activate Teletext"
+msgstr "Attiva il Teletext"
+
+#: id:23051
+msgid "Part %i"
+msgstr "Parte %i"
+
+#: id:23052
+msgid "Buffering %i bytes"
+msgstr "Buffering %i bytes"
+
+#: id:23053
+msgid "Stopping"
+msgstr "In arresto"
+
+#: id:23054
+msgid "Running"
+msgstr "In esecuzione"
+
+#: id:23100
+msgid "External Player Active"
+msgstr "Player Esterno Attivato"
+
+#: id:23101
+msgid "Click OK to terminate the player"
+msgstr "Premi OK per chiudere il player"
+
+#: id:23104
+msgid "Click OK when playback has ended"
+msgstr "Premi OK al termine della riproduzione"
+
+#: id:24000
+msgid "Add-on"
+msgstr "Add-on"
+
+#: id:24001
+msgid "Add-ons"
+msgstr "Add-ons"
+
+#: id:24002
+msgid "Add-on options"
+msgstr "Opzioni Add-on"
+
+#: id:24003
+msgid "Add-on Information"
+msgstr "Informazioni Add-on"
+
+#: id:24005
+msgctxt "Auto context with id 24005"
+msgid "Media sources"
+msgstr "Sorgenti files multimediali"
+
+#: id:24007
+msgctxt "Auto context with id 24007"
+msgid "Movie information"
+msgstr "Scraper Film"
+
+#: id:24008
+msgctxt "Auto context with id 24008"
+msgid "Screensaver"
+msgstr "Salvaschermo"
+
+#: id:24009
+msgid "Script"
+msgstr "Script"
+
+#: id:24010
+msgctxt "Auto context with id 24010"
+msgid "Visualization"
+msgstr "Visualizzazioni"
+
+#: id:24011
+msgid "Add-on repository"
+msgstr "Add-on repository"
+
+#: id:24012
+msgctxt "Auto context with id 24012"
+msgid "Subtitles"
+msgstr "Servizio Sottotitoli"
+
+#: id:24013
+msgid "Lyrics"
+msgstr "Servizio Testi"
+
+#: id:24014
+msgid "TV information"
+msgstr "Scraper Serie TV"
+
+#: id:24015
+msgctxt "Auto context with id 24015"
+msgid "Music video information"
+msgstr "Scraper Videoclip"
+
+#: id:24016
+msgctxt "Auto context with id 24016"
+msgid "Album information"
+msgstr "Scraper Album"
+
+#: id:24017
+msgctxt "Auto context with id 24017"
+msgid "Artist information"
+msgstr "Scraper Artista"
+
+#: id:24018
+msgctxt "Auto context with id 24018"
+msgid "Services"
+msgstr "Servizi"
+
+#: id:24020
+msgid "Configure"
+msgstr "Configura"
+
+#: id:24021
+msgctxt "Auto context with id 24021"
+msgid "Disable"
+msgstr "Disabilita"
+
+#: id:24022
+msgid "Enable"
+msgstr "Abilita"
+
+#: id:24023
+msgid "Add-on disabled"
+msgstr "Add-on Disabilitato"
+
+#: id:24027
+msgctxt "Auto context with id 24027"
+msgid "Weather"
+msgstr "Servizio Meteo"
+
+#: id:24028
+msgid "Weather.com (standard)"
+msgstr "Weather.com (standard)"
+
+#: id:24030
+msgid "This Add-on can not be configured"
+msgstr "Questo Add-on non può essere configurato"
+
+#: id:24031
+msgid "Error loading settings"
+msgstr "Errore nel caricamento delle impostazioni"
+
+#: id:24032
+msgid "All Add-ons"
+msgstr "Tutti gli add-on"
+
+#: id:24033
+msgid "Get Add-ons"
+msgstr "Scarica add-on"
+
+#: id:24034
+msgid "Check for updates"
+msgstr "Controlla Aggiornamenti"
+
+#: id:24035
+msgid "Force refresh"
+msgstr "Forza refresh"
+
+#: id:24036
+msgid "Change log"
+msgstr "Change log"
+
+#: id:24037
+msgid "Uninstall"
+msgstr "Disinstalla"
+
+#: id:24038
+msgid "Install"
+msgstr "Installa"
+
+#: id:24039
+msgid "Disabled Add-ons"
+msgstr "Add-on disabilitato"
+
+#: id:24040
+msgid "(Clear the current setting)"
+msgstr "(Resetta le impostazioni attuali)"
+
+#: id:24041
+msgid "Install from zip file"
+msgstr "Installa da un file zip"
+
+#: id:24042
+msgid "Downloading %i%%"
+msgstr "Scaricando %i%%"
+
+#: id:24043
+msgid "Available Updates"
+msgstr "Aggiornamenti Disponibili"
+
+#: id:24044
+msgid "Dependencies not met"
+msgstr "Dipendenze non soddisfatte"
+
+#: id:24045
+msgid "Add-on does not have the correct structure"
+msgstr "L'Add-on non ha una struttura corretta"
+
+#: id:24046
+msgid "%s is used by the following installed add-on(s)"
+msgstr "%s è usato al momento dai seguenti add-on(s)"
+
+#: id:24047
+msgid "This add-on cannot be uninstalled"
+msgstr "Questo add-on non può essere rimosso"
+
+#: id:24048
+msgid "Rollback"
+msgstr "Regredire versione"
+
+#: id:24050
+msgid "Available Add-ons"
+msgstr "Add-on disponibili"
+
+#: id:24051
+msgid "Version:"
+msgstr "Versione:"
+
+#: id:24052
+msgid "Disclaimer"
+msgstr "Informazioni"
+
+#: id:24053
+msgid "License:"
+msgstr "Licenza:"
+
+#: id:24054
+msgid "Changelog"
+msgstr "Changelog"
+
+#: id:24059
+msgid "Would you like to enable this Add-on?"
+msgstr "Vuoi abilitare questo Add-on?"
+
+#: id:24060
+msgid "Would you like to disable this Add-on?"
+msgstr "Vuoi disabilitare questo Add-on?"
+
+#: id:24061
+msgid "Add-on update available!"
+msgstr "Aggiornamento per l'Addon-on disponibile!"
+
+#: id:24062
+msgid "Enabled Add-ons"
+msgstr "Abilita Add-ons"
+
+#: id:24063
+msgid "Auto update"
+msgstr "Auto aggiornamento"
+
+#: id:24064
+msgid "Add-on enabled"
+msgstr "Abilita Add-on"
+
+#: id:24065
+msgid "Add-on updated"
+msgstr "Add-on Aggiornato"
+
+#: id:24066
+msgid "Cancel Add-on download?"
+msgstr "Cancella il download dell'Add-on?"
+
+#: id:24067
+msgid "Currently downloading Add-ons"
+msgstr "Download dell'Add-on in corso"
+
+#: id:24068
+msgid "Update available"
+msgstr "Aggiornamento disponibile"
+
+#: id:24069
+msgid "Update"
+msgstr "Aggiorna"
+
+#: id:24070
+msgid "Add-on could not be loaded."
+msgstr "L'Add-on non può essere caricato"
+
+#: id:24071
+msgid "An unknown error has occurred."
+msgstr "Si è verificato un errore sconosciuto."
+
+#: id:24072
+msgid "Settings required"
+msgstr "Impostazioni richieste"
+
+#: id:24073
+msgid "Could not connect"
+msgstr "Impossibile connettersi"
+
+#: id:24074
+msgid "Needs to restart"
+msgstr "Riavvio richiesto"
+
+#: id:24075
+msgctxt "Auto context with id 24075"
+msgid "Disable"
+msgstr "Disabilita"
+
+#: id:24076
+msgid "Add-on Required"
+msgstr "Add-on Richiesto"
+
+#: id:24080
+msgid "Try to reconnect?"
+msgstr "Provo a riconnettere?"
+
+#: id:24089
+msgid "Add-on restarts"
+msgstr "Riavvio dell'Add-on"
+
+#: id:24090
+msgid "Lock Add-on manager"
+msgstr "Blocca il manager degli Add-on"
+
+#: id:24094
+msgid "(current)"
+msgstr "(currente)"
+
+#: id:24095
+msgid "(blacklisted)"
+msgstr "(in blacklist)"
+
+#: id:24096
+msgid "Add-on has been marked as broken in repository."
+msgstr "Questo Add-on è segnalato non funzionante nel repository."
+
+#: id:24097
+msgid "Would you like to disable it on your system?"
+msgstr "Vuoi disabilitarlo nel tuo sistema?"
+
+#: id:24098
+msgid "Broken"
+msgstr "Non funzionante"
+
+#: id:24099
+msgid "Would you like to switch to this skin?"
+msgstr "Vuoi passare a questa skin?"
+
+#: id:24100
+msgid "To use this feature you must download an Add-on:"
+msgstr "Per usare questa funzione occorre scaricare un Add-on:"
+
+#: id:24101
+msgid "Would you like to download this Add-on?"
+msgstr "Vuoi scaricare questo Add-on?"
+
+#: id:25000
+msgid "Notifications"
+msgstr "Notifiche"
+
+#: id:29800
+msgid "Library Mode"
+msgstr "Modo Archivio"
+
+#: id:29801
+msgid "QWERTY keyboard"
+msgstr "Tastiera QWERTY"
+
+#: id:29802
+msgid "Passthrough Audio in use"
+msgstr "Periferica Audio passthrough utilizzata"
+
+#: id:33001
+msgid "Trailer quality"
+msgstr "Qualità trailer"
+
+#: id:33002
+msgid "Stream"
+msgstr "Stream"
+
+#: id:33003
+msgid "Download"
+msgstr "Scarica"
+
+#: id:33004
+msgid "Download & play"
+msgstr "Scarica e avvia"
+
+#: id:33005
+msgid "Download & save"
+msgstr "Scarica e salva"
+
+#: id:33006
+msgid "Today"
+msgstr "Oggi"
+
+#: id:33007
+msgid "Tomorrow"
+msgstr "Domani"
+
+#: id:33008
+msgid "Saving"
+msgstr "Salvataggio"
+
+#: id:33009
+msgid "Copying"
+msgstr "Copia"
+
+#: id:33010
+msgid "Set download directory"
+msgstr "Imposta directory download"
+
+#: id:33011
+msgid "Search duration"
+msgstr "Durata ricerca"
+
+#: id:33012
+msgid "Short"
+msgstr "Breve"
+
+#: id:33013
+msgid "Long"
+msgstr "Lungo"
+
+#: id:33014
+msgid "Use DVD player instead of regular player"
+msgstr "Usa DVD player invece del player normale"
+
+#: id:33015
+msgid "Ask for download before playing video"
+msgstr "Richiedi il download prima di avviare il video"
+
+#: id:33016
+msgid "Clips"
+msgstr "Clip"
+
+#: id:33017
+msgid "Restart plugin to enable"
+msgstr "Riavvia il plugin per abilitarlo"
+
+#: id:33018
+msgid "Tonight"
+msgstr "Stasera"
+
+#: id:33019
+msgid "Tomorrow Night"
+msgstr "Domani Sera"
+
+#: id:33020
+msgid "Condition"
+msgstr "Condizione"
+
+#: id:33021
+msgid "Precipitation"
+msgstr "Precipitazioni"
+
+#: id:33022
+msgid "Precip"
+msgstr "Precip"
+
+#: id:33023
+msgid "Humid"
+msgstr "Umidità"
+
+#: id:33024
+msgid "Feels"
+msgstr "Percepita"
+
+#: id:33025
+msgid "Observed"
+msgstr "Rilevata"
+
+#: id:33026
+msgid "Departure from normal"
+msgstr "Differenza dal normale"
+
+#: id:33027
+msgid "Sunrise"
+msgstr "Alba"
+
+#: id:33028
+msgid "Sunset"
+msgstr "Tramonto"
+
+#: id:33029
+msgid "Details"
+msgstr "Dettagli"
+
+#: id:33030
+msgid "Outlook"
+msgstr "Vista"
+
+#: id:33031
+msgid "Coverflow"
+msgstr "Coverflow"
+
+#: id:33032
+msgid "Translate text"
+msgstr "Traduci testo"
+
+#: id:33033
+msgid "Map list %s category"
+msgstr "Lista mappa %s categoria"
+
+#: id:33034
+msgid "36 Hour"
+msgstr "36 Ore"
+
+#: id:33035
+msgid "Maps"
+msgstr "Mappe"
+
+#: id:33036
+msgid "Hourly"
+msgstr "Orario"
+
+#: id:33037
+msgid "Weekend"
+msgstr "Weekend"
+
+#: id:33038
+msgid "%s day"
+msgstr "%s giorni"
+
+#: id:33049
+msgid "Alert"
+msgstr "Allarme"
+
+#: id:33050
+msgid "Alerts"
+msgstr "Allarmi"
+
+#: id:33051
+msgid "Choose Your"
+msgstr "Scegli il Tuo"
+
+#: id:33052
+msgid "Check"
+msgstr "Controlla"
+
+#: id:33053
+msgctxt "Auto context with id 33053"
+msgid "Configure the"
+msgstr "Configura le"
+
+#: id:33054
+msgid "Seasons"
+msgstr "Stagioni"
+
+#: id:33055
+msgid "Use your"
+msgstr "Usa il tuo"
+
+#: id:33056
+msgid "Watch your"
+msgstr "Guarda i tuoi"
+
+#: id:33057
+msgid "Listen to"
+msgstr "Ascolta la"
+
+#: id:33058
+msgid "View your"
+msgstr "Vedi le tue"
+
+#: id:33059
+msgctxt "Auto context with id 33059"
+msgid "Configure the"
+msgstr "Configura"
+
+#: id:33060
+msgid "Power"
+msgstr "Power"
+
+#: id:33061
+msgid "Menu"
+msgstr "Menu"
+
+#: id:33062
+msgid "Play the"
+msgstr "Avvia il"
+
+#: id:33063
+msgid "Options"
+msgstr "Opzioni"
+
+#: id:33065
+msgid "Editor"
+msgstr "Editor"
+
+#: id:33066
+msgid "About your"
+msgstr "Il tuo"
+
+#: id:33067
+msgid "Star rating"
+msgstr "Voto con stelle"
+
+#: id:33068
+msgid "Background"
+msgstr "Sfondo"
+
+#: id:33069
+msgid "Backgrounds"
+msgstr "Sfondi"
+
+#: id:33070
+msgid "Custom background"
+msgstr "Sfondo Personalizzato"
+
+#: id:33071
+msgid "Custom backgrounds"
+msgstr "Sfondi personalizzati"
+
+#: id:33072
+msgid "View Readme"
+msgstr "Visualizza Readme"
+
+#: id:33073
+msgid "View Changelog"
+msgstr "Visualizza Changelog"
+
+#: id:33074
+msgid "This version of %s requires an"
+msgstr "Questa versione di %s richiede"
+
+#: id:33075
+msgid "XBMC revision of %s or greater to run."
+msgstr "una versione di XBMC superiore a %s."
+
+#: id:33076
+msgid "Please update XBMC."
+msgstr "Aggiorna XBMC."
+
+#: id:33077
+msgid "No data found!"
+msgstr "Nessun informazione trovata!"
+
+#: id:33078
+msgid "Next page"
+msgstr "Prossima pagina"
+
+#: id:33079
+msgid "Love"
+msgstr "Amore"
+
+#: id:33080
+msgid "Hate"
+msgstr "Odio"
+
+#: id:33081
+msgid "This file is stacked, select the part you want to play from."
+msgstr "Questo file è multiplo, seleziona la parte da cui iniziare la riproduzione."
+
+#: id:33082
+msgid "Path to script"
+msgstr "Percorso per lo script"
+
+#: id:33083
+msgid "Enable custom script button"
+msgstr "Abilita il pulsante per lo script personalizzato"
+
+#: id:33100
+msgid "Failed to start"
+msgstr "Avvio fallito"
+
+#: id:33101
+msgid "Webserver"
+msgstr "Webserver"
+
+#: id:33102
+msgid "Event Server"
+msgstr "Server Eventi"
+
+#: id:33103
+msgid "Remote communication server"
+msgstr "Server comunicazione remota"
+
+#: id:33200
+msgid "Detected New Connection"
+msgstr "Rilevata una nuova connessione"
+
+#: id:34000
+msgid "Lame"
+msgstr "Lame"
+
+#: id:34001
+msgid "Vorbis"
+msgstr "Vorbis"
+
+#: id:34002
+msgid "Wav"
+msgstr "Wav"
+
+#: id:34003
+msgid "DXVA2"
+msgstr "DXVA2"
+
+#: id:34004
+msgid "VAAPI"
+msgstr "VAAPI"
+
+#: id:34005
+msgid "Flac"
+msgstr "Flac"
+
+#: id:34100
+msgid "Speaker Configuration"
+msgstr "Configurazione altoparlanti"
+
+#: id:34101
+msgid "2.0"
+msgstr "2.0"
+
+#: id:34102
+msgid "2.1"
+msgstr "2.1"
+
+#: id:34103
+msgid "3.0"
+msgstr "3.0"
+
+#: id:34104
+msgid "3.1"
+msgstr "3.1"
+
+#: id:34105
+msgid "4.0"
+msgstr "4.0"
+
+#: id:34106
+msgid "4.1"
+msgstr "4.1"
+
+#: id:34107
+msgid "5.0"
+msgstr "5.0"
+
+#: id:34108
+msgid "5.1"
+msgstr "5.1"
+
+#: id:34109
+msgid "7.0"
+msgstr "7.0"
+
+#: id:34110
+msgid "7.1"
+msgstr "7.1"
+
+#: id:34201
+msgid "Can't find a next item to play"
+msgstr "Non trovo il successivo elemento da riprodurre"
+
+#: id:34202
+msgid "Can't find a previous item to play"
+msgstr "Non trovo il precedente elemento da riprodurre"
+
+#: id:34300
+msgid "Failed to start zeroconf"
+msgstr "Avvio di zeroconf fallito"
+
+#: id:34301
+msgid "Is Apple's Bonjour Service installed? See log for more info."
+msgstr "Il servizio Apple Bonjour è installato? Controllare i log per maggiori informazioni."
+
+#: id:34400
+msgid "Video Rendering"
+msgstr "Rendering Video"
+
+#: id:34401
+msgid "Failed to init video filters/scalers, falling back to bilinear scaling"
+msgstr "Fallita l'inizializzazione dei filtri/scalers video, ritorno al bilinear scaling"
+
+#: id:34402
+msgid "Failed to initialize audio device"
+msgstr "Fallita l'inizializzazione dei dispositivi audio"
+
+#: id:34403
+msgid "Check your audiosettings"
+msgstr "Controlla le impostazioni audio"
+
+#: id:34404
+msgid "Use gestures for navigation:"
+msgstr ""
+
+#: id:34405
+msgid "1 finger swipe left,right,up,down for cursors"
+msgstr ""
+
+#: id:34406
+msgid "2 finger swipe left for backspace"
+msgstr ""
+
+#: id:34407
+msgid "1 finger single tap for enter"
+msgstr ""
+
+#: id:34408
+msgid "2 finger single tap for contextmenu"
+msgstr ""
+
+#: id:35000
+msgid "Peripherals"
+msgstr "Periferiche"
+
+#: id:35001
+msgid "Generic HID device"
+msgstr "Periferica HID generica"
+
+#: id:35002
+msgid "Generic network adapter"
+msgstr "Adattatore di rete generico"
+
+#: id:35003
+msgid "Generic disk"
+msgstr "Disco generico"
+
+#: id:35004
+msgid "There are no settings available\nfor this peripheral."
+msgstr "Non ci sono impostazioni disponibili\nper questa periferica."
+
+#: id:35005
+msgid "New device configured"
+msgstr "Nuova periferica configurata"
+
+#: id:35006
+msgid "Device removed"
+msgstr "Periferica rimossa"
+
+#: id:35007
+msgid "Keymap to use for this device"
+msgstr "Mappa dei caratteri da usare per questa periferica"
+
+#: id:35008
+msgid "Keymap enabled"
+msgstr "Mappa dei caratteri abilitata"
+
+#: id:35009
+msgid "Do not use the custom keymap for this device"
+msgstr ""
+
+#: id:35500
+msgid "Location"
+msgstr "Posizione"
+
+#: id:35501
+msgid "Class"
+msgstr "Classe"
+
+#: id:35502
+msgctxt "Auto context with id 35502"
+msgid "Name"
+msgstr "Nome"
+
+#: id:35503
+msgid "Vendor"
+msgstr "Fornitore"
+
+#: id:35504
+msgid "Product ID"
+msgstr "ID prodotto"
+
+#: id:36000
+msgid "Pulse-Eight CEC adapter"
+msgstr "Adattatore CEC Pulse-Eight"
+
+#: id:36001
+msgid "Pulse-Eight Nyxboard"
+msgstr "Pulse-Eight Nyxboard"
+
+#: id:36002
+msgid "Switch to keyboard side command"
+msgstr "Passa ai comandi da tastiera"
+
+#: id:36003
+msgid "Switch to remote side command"
+msgstr "Passa ai controlli al telecomando"
+
+#: id:36004
+msgid "Press \"user\" button command"
+msgstr "Premi il bottone \"user\""
+
+#: id:36005
+msgid "Enable switch side commands"
+msgstr "Enable switch side commands"
+
+#: id:36006
+msgid "Could not open the adapter"
+msgstr "Non riesco ad accedere all'adattatore"
+
+#: id:36007
+msgid "Devices to power on when starting XBMC"
+msgstr "Accendi la TV all'avvio di XBMC"
+
+#: id:36008
+msgid "Devices to power off when stopping XBMC"
+msgstr "Spegni la TV all'uscita da XBMC"
+
+#: id:36009
+msgid "Put devices in standby mode when activating screensaver"
+msgstr "Imposta il dispositivo in stanby all'attivazione dello screensaver"
+
+#: id:36011
+msgid "Could not detect the CEC port. Set it up manually."
+msgstr "Impossibile trovare la porta CEC. Impostala manualmente."
+
+#: id:36012
+msgid "Could not initialise the CEC adapter. Check your settings."
+msgstr "Impossibile connettersi all'adattatore CEC."
+
+#: id:36013
+msgid "Unsupported libCEC interface version. %d is greater than the version XBMC supports (%d)"
+msgstr "Versione interfaccia libcec non supportata. %d è maggiore della versione supportata da XBMC (%d)"
+
+#: id:36014
+msgid "Put this PC in standby mode when the TV is switched off"
+msgstr "Metti il pc in standby quando la TV viene spenta"
+
+#: id:36015
+msgid "HDMI port number"
+msgstr "Numero porta HDMI"
+
+#: id:36016
+msgctxt "Auto context with id 36016"
+msgid "Connected"
+msgstr "Connesso"
+
+#: id:36017
+msgid "Adapter found, but libCEC is not available"
+msgstr "Adattatore trovato, ma libcec non è disponibile"
+
+#: id:36018
+msgid "Use the TV's language setting"
+msgstr "Usa il linguaggio impostato sulla TV"
+
+#: id:36019
+msgid "Connected to HDMI device"
+msgstr ""
+
+#: id:36020
+msgid "Make XBMC the active source when starting"
+msgstr ""
+
+#: id:36021
+msgid "Physical address (overrules HDMI port)"
+msgstr ""
+
+#: id:36022
+msgid "COM port (leave empty unless needed)"
+msgstr ""
+
+#: id:36023
+msgid "Configuration updated"
+msgstr ""
+
+#: id:36024
+msgid "Failed to set the new configuration. Please check your settings."
+msgstr ""
+
+#: id:36025
+msgid "Send 'inactive source' command when stopping XBMC"
+msgstr ""
+

--- a/language/Japanese/strings.po
+++ b/language/Japanese/strings.po
@@ -1,0 +1,9093 @@
+# Converted from xbmc strings.xml with xbmc-xml2po (by Team-XBMC)
+msgid ""
+msgstr ""
+"Project-Id-Version: xbmc.core-FRODO_GIT3ed1604ad7\n"
+"Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
+"POT-Creation-Date: 2012-04-09 18:00+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE\n"
+"Language: ja\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: id:0
+msgctxt "Auto context with id 0"
+msgid "Programs"
+msgstr "プログラム"
+
+#: id:1
+msgctxt "Auto context with id 1"
+msgid "Pictures"
+msgstr "ピクチャ"
+
+#: id:2
+msgctxt "Auto context with id 2"
+msgid "Music"
+msgstr "ミュージック"
+
+#: id:3
+msgctxt "Auto context with id 3"
+msgid "Videos"
+msgstr "ビデオ"
+
+#: id:4
+msgid "TV-Guide"
+msgstr "テレビガイド"
+
+#: id:5
+msgctxt "Auto context with id 5"
+msgid "Settings"
+msgstr "設定"
+
+#: id:6
+msgid "XBMC SVN"
+msgstr "XBMC SVN"
+
+#: id:7
+msgctxt "Auto context with id 7"
+msgid "File manager"
+msgstr "ファイルマネージャー"
+
+#: id:8
+msgctxt "Auto context with id 8"
+msgid "Weather"
+msgstr "天気予報"
+
+#: id:9
+msgid "xbmc media center"
+msgstr "XBMC メディアセンター"
+
+#: id:11
+msgid "Monday"
+msgstr "月曜日"
+
+#: id:12
+msgid "Tuesday"
+msgstr "火曜日"
+
+#: id:13
+msgid "Wednesday"
+msgstr "水曜日"
+
+#: id:14
+msgid "Thursday"
+msgstr "木曜日"
+
+#: id:15
+msgid "Friday"
+msgstr "金曜日"
+
+#: id:16
+msgid "Saturday"
+msgstr "土曜日"
+
+#: id:17
+msgid "Sunday"
+msgstr "日曜日"
+
+#: id:21
+msgid "January"
+msgstr "1月"
+
+#: id:22
+msgid "February"
+msgstr "2月"
+
+#: id:23
+msgid "March"
+msgstr "3月"
+
+#: id:24
+msgid "April"
+msgstr "4月"
+
+#: id:25
+msgctxt "Auto context with id 25"
+msgid "May"
+msgstr "5月"
+
+#: id:26
+msgid "June"
+msgstr "6月"
+
+#: id:27
+msgid "July"
+msgstr "7月"
+
+#: id:28
+msgid "August"
+msgstr "8月"
+
+#: id:29
+msgid "September"
+msgstr "9月"
+
+#: id:30
+msgid "October"
+msgstr "10月"
+
+#: id:31
+msgid "November"
+msgstr "11月"
+
+#: id:32
+msgid "December"
+msgstr "12月"
+
+#: id:41
+msgid "Mon"
+msgstr "月"
+
+#: id:42
+msgid "Tue"
+msgstr "火"
+
+#: id:43
+msgid "Wed"
+msgstr "水"
+
+#: id:44
+msgid "Thu"
+msgstr "木"
+
+#: id:45
+msgid "Fri"
+msgstr "金"
+
+#: id:46
+msgid "Sat"
+msgstr "土"
+
+#: id:47
+msgctxt "Auto context with id 47"
+msgid "Sun"
+msgstr "日"
+
+#: id:51
+msgid "Jan"
+msgstr "1月"
+
+#: id:52
+msgid "Feb"
+msgstr "2月"
+
+#: id:53
+msgid "Mar"
+msgstr "3月"
+
+#: id:54
+msgid "Apr"
+msgstr "4月"
+
+#: id:55
+msgctxt "Auto context with id 55"
+msgid "May"
+msgstr "5月"
+
+#: id:56
+msgid "Jun"
+msgstr "6月"
+
+#: id:57
+msgid "Jul"
+msgstr "7月"
+
+#: id:58
+msgid "Aug"
+msgstr "8月"
+
+#: id:59
+msgid "Sep"
+msgstr "9月"
+
+#: id:60
+msgid "Oct"
+msgstr "10月"
+
+#: id:61
+msgid "Nov"
+msgstr "11月"
+
+#: id:62
+msgid "Dec"
+msgstr "12月"
+
+#: id:71
+msgid "N"
+msgstr "北"
+
+#: id:72
+msgid "NNE"
+msgstr "北北東"
+
+#: id:73
+msgid "NE"
+msgstr "北東"
+
+#: id:74
+msgid "ENE"
+msgstr "東北東"
+
+#: id:75
+msgid "E"
+msgstr "東"
+
+#: id:76
+msgid "ESE"
+msgstr "東南東"
+
+#: id:77
+msgid "SE"
+msgstr "南東"
+
+#: id:78
+msgid "SSE"
+msgstr "南南東"
+
+#: id:79
+msgid "S"
+msgstr "南"
+
+#: id:80
+msgid "SSW"
+msgstr "南南西"
+
+#: id:81
+msgid "SW"
+msgstr "南西"
+
+#: id:82
+msgid "WSW"
+msgstr "西南西"
+
+#: id:83
+msgid "W"
+msgstr "西"
+
+#: id:84
+msgid "WNW"
+msgstr "西北西"
+
+#: id:85
+msgid "NW"
+msgstr "北西"
+
+#: id:86
+msgid "NNW"
+msgstr "北北西"
+
+#: id:87
+msgid "VAR"
+msgstr "不定"
+
+#: id:98
+msgid "View: Auto"
+msgstr "表示: 自動"
+
+#: id:99
+msgid "View: Auto big"
+msgstr "表示: 自動 (大)"
+
+#: id:100
+msgid "View: Icons"
+msgstr "表示: アイコン (小)"
+
+#: id:101
+msgid "View: List"
+msgstr "表示: リスト"
+
+#: id:102
+msgctxt "Auto context with id 102"
+msgid "Scan"
+msgstr "スキャン"
+
+#: id:103
+msgctxt "Auto context with id 103"
+msgid "Sort by: Name"
+msgstr "並べ替え: 名前"
+
+#: id:104
+msgid "Sort by: Date"
+msgstr "並べ替え: 日付"
+
+#: id:105
+msgid "Sort by: Size"
+msgstr "並べ替え: サイズ"
+
+#: id:106
+msgid "No"
+msgstr "いいえ"
+
+#: id:107
+msgid "Yes"
+msgstr "はい"
+
+#: id:108
+msgctxt "Auto context with id 108"
+msgid "Slideshow"
+msgstr "スライドショー"
+
+#: id:109
+msgid "Create thumbs"
+msgstr "サムネイル作成"
+
+#: id:110
+msgid "Create thumbnails"
+msgstr "サムネイル(複数)作成"
+
+#: id:111
+msgctxt "Auto context with id 111"
+msgid "Shortcuts"
+msgstr "ショートカット"
+
+#: id:112
+msgid "Paused"
+msgstr "一時停止"
+
+#: id:113
+msgid "Update failed"
+msgstr "更新失敗"
+
+#: id:114
+msgid "Installation failed"
+msgstr "インストール失敗"
+
+#: id:115
+msgid "Copy"
+msgstr "コピー"
+
+#: id:116
+msgid "Move"
+msgstr "移動"
+
+#: id:117
+msgid "Delete"
+msgstr "削除"
+
+#: id:118
+msgid "Rename"
+msgstr "名前の変更"
+
+#: id:119
+msgid "New folder"
+msgstr "新規フォルダー"
+
+#: id:120
+msgid "Confirm file copy"
+msgstr "コピーの確認"
+
+#: id:121
+msgid "Confirm file move"
+msgstr "移動の確認"
+
+#: id:122
+msgid "Confirm file delete?"
+msgstr "削除の確認"
+
+#: id:123
+msgid "Copy these files?"
+msgstr "コピーしますか?"
+
+#: id:124
+msgid "Move these files?"
+msgstr "移動しますか?"
+
+#: id:125
+msgid "Delete these files? - Deleting files cannot be undone!"
+msgstr "削除しますか?"
+
+#: id:126
+msgid "Status"
+msgstr "ステータス"
+
+#: id:127
+msgid "Objects"
+msgstr "オブジェクト"
+
+#: id:128
+msgctxt "Auto context with id 128"
+msgid "General"
+msgstr "一般"
+
+#: id:129
+msgctxt "Auto context with id 129"
+msgid "Slideshow"
+msgstr "スライドショー"
+
+#: id:130
+msgctxt "Auto context with id 130"
+msgid "System info"
+msgstr "システム情報"
+
+#: id:131
+msgid "Display"
+msgstr "画面"
+
+#: id:132
+msgid "Albums"
+msgstr "アルバム"
+
+#: id:133
+msgid "Artists"
+msgstr "アーティスト"
+
+#: id:134
+msgid "Songs"
+msgstr "曲"
+
+#: id:135
+msgid "Genres"
+msgstr "ジャンル"
+
+#: id:136
+msgid "Playlists"
+msgstr "プレイリスト"
+
+#: id:137
+msgid "Search"
+msgstr "検索"
+
+#: id:138
+msgid "System Information"
+msgstr "システム情報"
+
+#: id:139
+msgid "Temperatures:"
+msgstr "温度:"
+
+#: id:140
+msgid "CPU:"
+msgstr "CPU:"
+
+#: id:141
+msgid "GPU:"
+msgstr "GPU:"
+
+#: id:142
+msgid "Time:"
+msgstr "時間:"
+
+#: id:143
+msgid "Current:"
+msgstr "現在:"
+
+#: id:144
+msgid "Build:"
+msgstr "ビルド:"
+
+#: id:145
+msgid "Network:"
+msgstr "ネットワーク:"
+
+#: id:146
+msgid "Type:"
+msgstr "タイプ:"
+
+#: id:147
+msgid "Static"
+msgstr "固定"
+
+#: id:148
+msgid "DHCP"
+msgstr "DHCP"
+
+#: id:149
+msgid "MAC address"
+msgstr "MAC アドレス"
+
+#: id:150
+msgctxt "Auto context with id 150"
+msgid "IP address"
+msgstr "IP アドレス"
+
+#: id:151
+msgid "Link:"
+msgstr "リンク:"
+
+#: id:152
+msgid "Half duplex"
+msgstr "半二重"
+
+#: id:153
+msgid "Full duplex"
+msgstr "全二重"
+
+#: id:154
+msgctxt "Auto context with id 154"
+msgid "Storage"
+msgstr "ストレージ"
+
+#: id:155
+msgid "Drive"
+msgstr "ドライブ"
+
+#: id:156
+msgctxt "Auto context with id 156"
+msgid "Free"
+msgstr "空き"
+
+#: id:157
+msgctxt "Auto context with id 157"
+msgid "Video"
+msgstr "ビデオ"
+
+#: id:158
+msgid "Free memory"
+msgstr "空きメモリー"
+
+#: id:159
+msgid "No link"
+msgstr "リンクしていません"
+
+#: id:160
+msgctxt "Auto context with id 160"
+msgid "Free"
+msgstr "空き"
+
+#: id:161
+msgid "Unavailable"
+msgstr "利用不可"
+
+#: id:162
+msgid "Tray open"
+msgstr "トレーが開いています"
+
+#: id:163
+msgid "Reading"
+msgstr "読み込み中..."
+
+#: id:164
+msgid "No disc"
+msgstr "ディスク無し"
+
+#: id:165
+msgid "Disc present"
+msgstr "ディスク有り"
+
+#: id:166
+msgid "Skin"
+msgstr "スキン"
+
+#: id:169
+msgctxt "Auto context with id 169"
+msgid "Resolution"
+msgstr "画面解像度"
+
+#: id:170
+msgid "Adjust display refresh rate to match video"
+msgstr "ビデオに合わせてリフレッシュレートを調整"
+
+#: id:172
+msgid "Release date"
+msgstr "発売日"
+
+#: id:173
+msgid "Display 4:3 videos as"
+msgstr "アスペクト比 4:3 のビデオの再生"
+
+#: id:175
+msgid "Moods"
+msgstr "ムード"
+
+#: id:176
+msgid "Styles"
+msgstr "スタイル"
+
+#: id:179
+msgid "Song"
+msgstr "曲"
+
+#: id:180
+msgid "Duration"
+msgstr "長さ"
+
+#: id:181
+msgid "Select album"
+msgstr "アルバムの選択"
+
+#: id:182
+msgid "Tracks"
+msgstr "トラック"
+
+#: id:183
+msgid "Review"
+msgstr "レビュー"
+
+#: id:184
+msgid "Refresh"
+msgstr "更新"
+
+#: id:185
+msgid "Searching album"
+msgstr "アルバムの検索"
+
+#: id:186
+msgid "OK"
+msgstr "OK"
+
+#: id:187
+msgid "No albums found!"
+msgstr "アルバムが見つかりません!"
+
+#: id:188
+msgid "Select all"
+msgstr "すべて選択"
+
+#: id:189
+msgid "Scanning media info"
+msgstr "メディア情報スキャン中"
+
+#: id:190
+msgid "Save"
+msgstr "保存"
+
+#: id:191
+msgid "Shuffle"
+msgstr "シャッフル"
+
+#: id:192
+msgctxt "Auto context with id 192"
+msgid "Clear"
+msgstr "クリア"
+
+#: id:193
+msgctxt "Auto context with id 193"
+msgid "Scan"
+msgstr "スキャン"
+
+#: id:194
+msgid "Searching..."
+msgstr "検索中..."
+
+#: id:195
+msgid "No info found!"
+msgstr "情報が見付かりません!"
+
+#: id:196
+msgid "Select movie:"
+msgstr "ムービーの選択:"
+
+#: id:197
+msgid "Querying %s info"
+msgstr "%s の情報を問い合わせ中"
+
+#: id:198
+msgid "Loading movie details"
+msgstr "ムービーの詳細を読込中..."
+
+#: id:199
+msgid "Web interface"
+msgstr "Web インターフェイス"
+
+#: id:202
+msgid "Tagline"
+msgstr "公開時コピー"
+
+#: id:203
+msgid "Plot outline"
+msgstr "あらすじ"
+
+#: id:205
+msgid "Votes"
+msgstr "評価"
+
+#: id:206
+msgid "Cast"
+msgstr "出演者"
+
+#: id:207
+msgid "Plot"
+msgstr "ストーリー"
+
+#: id:208
+msgctxt "Auto context with id 208"
+msgid "Play"
+msgstr "再生"
+
+#: id:209
+msgid "Next"
+msgstr "次へ"
+
+#: id:210
+msgid "Previous"
+msgstr "前へ"
+
+#: id:213
+msgid "Calibrate user interface..."
+msgstr "UI の設定..."
+
+#: id:214
+msgid "Video calibration..."
+msgstr "画面補正..."
+
+#: id:215
+msgid "Soften"
+msgstr "ソフト化"
+
+#: id:216
+msgid "Zoom amount"
+msgstr "拡大"
+
+#: id:217
+msgid "Pixel ratio"
+msgstr "ピクセル比"
+
+#: id:218
+msgid "DVD drive"
+msgstr "DVD ドライブ"
+
+#: id:219
+msgid "Please insert disc"
+msgstr "ディスクを入れて下さい"
+
+#: id:220
+msgid "Remote share"
+msgstr "リモート共有"
+
+#: id:221
+msgid "Network is not connected"
+msgstr "ネットワークに接続されていません"
+
+#: id:222
+msgid "Cancel"
+msgstr "キャンセル"
+
+#: id:224
+msgid "Speed"
+msgstr "表示時間"
+
+#: id:225
+msgid "Vertical Shift"
+msgstr "表示位置の上下微調整"
+
+#: id:226
+msgid "Test patterns..."
+msgstr "テストパターン..."
+
+#: id:227
+msgid "Lookup audio CD track names from freedb.org"
+msgstr "オーディオ CD トラック名を freedb.org で検索"
+
+#: id:228
+msgid "Shuffle playlist on load"
+msgstr "プレイリストのランダム再生"
+
+#: id:229
+msgid "HDD spindown time"
+msgstr "HDD停止までの時間(分)"
+
+#: id:230
+msgid "Video filters"
+msgstr "ビデオフィルター"
+
+#: id:231
+msgctxt "Auto context with id 231"
+msgid "None"
+msgstr "無し"
+
+#: id:232
+msgid "Point"
+msgstr "ポイントフィルタ"
+
+#: id:233
+msgid "Linear"
+msgstr "バイリニア補間(シャープ)"
+
+#: id:234
+msgid "Anisotropic"
+msgstr "異方性フィルタリング(ノーマル)"
+
+#: id:235
+msgid "Quincunx"
+msgstr "クインカンクス(ソフト)"
+
+#: id:236
+msgid "Gaussian cubic"
+msgstr "ガウスキュービック(ベリーソフト)"
+
+#: id:237
+msgid "Minification"
+msgstr "縮小フィルタリング"
+
+#: id:238
+msgid "Magnification"
+msgstr "拡大フィルタリング"
+
+#: id:239
+msgid "Clear playlist on finish"
+msgstr "終了時にプレイリストを消去"
+
+#: id:240
+msgid "Display Mode"
+msgstr "表示モード"
+
+#: id:241
+msgid "Full Screen #%d"
+msgstr "フルスクリーン #%d"
+
+#: id:242
+msgid "Windowed"
+msgstr "ウィンドウ化"
+
+#: id:243
+msgid "Refresh Rate"
+msgstr "リフレッシュレート"
+
+#: id:244
+msgid "Full screen"
+msgstr "フルスクリーン"
+
+#: id:245
+msgid "Sizing: (%i,%i)->(%i,%i) (Zoom x%2.2f) AR:%2.2f:1 (Pixels: %2.2f:1) (VShift: %2.2f)"
+msgstr "Sizing: (%i,%i)->(%i,%i) (Zoom x%2.2f) AR:%2.2f:1 (Pixels: %2.2f:1) (VShift: %2.2f)"
+
+#: id:247
+msgctxt "Auto context with id 247"
+msgid "Scripts"
+msgstr "スクリプト"
+
+#: id:248
+msgctxt "Auto context with id 248"
+msgid "Language"
+msgstr "言語"
+
+#: id:249
+msgctxt "Auto context with id 249"
+msgid "Music"
+msgstr "ミュージック"
+
+#: id:250
+msgctxt "Auto context with id 250"
+msgid "Visualization"
+msgstr "視覚エフェクト"
+
+#: id:251
+msgid "Select destination directory"
+msgstr "ディレクトリの選択"
+
+#: id:252
+msgid "Output stereo to all speakers"
+msgstr "ステレオ音声を全スピーカーから出力"
+
+#: id:253
+msgid "Number of channels"
+msgstr "チャンネル数"
+
+#: id:254
+msgid "- DTS capable receiver"
+msgstr "- DTS 対応レシーバー"
+
+#: id:255
+msgid "CDDB"
+msgstr "CDDB"
+
+#: id:256
+msgid "Fetching CD information"
+msgstr "CDDB 情報取得中"
+
+#: id:257
+msgid "Error"
+msgstr "エラー"
+
+#: id:258
+msgid "Enable tag reading"
+msgstr "タグを読み込む"
+
+#: id:259
+msgid "Opening"
+msgstr "開始"
+
+#: id:260
+msgid "Shoutcast"
+msgstr "SHOUTcast"
+
+#: id:261
+msgid "Waiting for start..."
+msgstr "お待ち下さい..."
+
+#: id:262
+msgid "Scripts output"
+msgstr "スクリプト出力"
+
+#: id:263
+msgid "Allow control of XBMC via HTTP"
+msgstr "HTTP 経由での XBMC の制御を有効に"
+
+#: id:264
+msgid "Record"
+msgstr "録音"
+
+#: id:265
+msgid "Stop Rec."
+msgstr "録音停止"
+
+#: id:266
+msgid "Sort by: Track"
+msgstr "並べ替え: トラック番号"
+
+#: id:267
+msgid "Sort by: Time"
+msgstr "並べ替え: 時間"
+
+#: id:268
+msgid "Sort by: Title"
+msgstr "並べ替え: タイトル名"
+
+#: id:269
+msgid "Sort by: Artist"
+msgstr "並べ替え: アーティスト名"
+
+#: id:270
+msgid "Sort by: Album"
+msgstr "並べ替え: アルバム名"
+
+#: id:271
+msgid "Top 100"
+msgstr "トップ 100"
+
+#: id:272
+msgid "Top-Left overscan compensation"
+msgstr "左側上部枠の補正"
+
+#: id:273
+msgid "Bottom-Right overscan compensation"
+msgstr "右側下部枠の補正"
+
+#: id:274
+msgid "Subtitle positioning"
+msgstr "字幕の位置"
+
+#: id:275
+msgid "Pixel ratio adjustment"
+msgstr "ピクセル比の調整"
+
+#: id:276
+msgid "Adjust the arrow to change the amount of overscan"
+msgstr "画面位置の調整"
+
+#: id:277
+msgid "Adjust the bar to change the subtitles position"
+msgstr "字幕位置の調整"
+
+#: id:278
+msgid "Adjust the rectangle so it is perfectly square"
+msgstr "正方形になるように調整して下さい"
+
+#: id:279
+msgid "Unable to load settings"
+msgstr "設定が読み込めません"
+
+#: id:280
+msgid "Using default settings"
+msgstr "設定の初期化"
+
+#: id:281
+msgid "Please check the XML files"
+msgstr ".xml ファイルをチェックして下さい"
+
+#: id:282
+msgid "Found %i items"
+msgstr "%i 個見つかりました"
+
+#: id:283
+msgid "Search results"
+msgstr "検索結果"
+
+#: id:284
+msgid "No results found"
+msgstr "見つかりませんでした"
+
+#: id:287
+msgctxt "Auto context with id 287"
+msgid "Subtitles"
+msgstr "字幕"
+
+#: id:288
+msgctxt "Auto context with id 288"
+msgid "Font"
+msgstr "フォント"
+
+#: id:289
+msgctxt "Auto context with id 289"
+msgid "- Size"
+msgstr "- サイズ:"
+
+#: id:290
+msgid "Dynamic range compression"
+msgstr "ダイナミックレンジの圧縮"
+
+#: id:291
+msgctxt "Auto context with id 291"
+msgid "Video"
+msgstr "ビデオ"
+
+#: id:292
+msgctxt "Auto context with id 292"
+msgid "Audio"
+msgstr "オーディオ"
+
+#: id:293
+msgid "Browse for subtitles"
+msgstr "字幕を参照"
+
+#: id:294
+msgid "Create bookmark"
+msgstr "ブックマークの作成"
+
+#: id:296
+msgid "Clear bookmarks"
+msgstr "ブックマークの削除"
+
+#: id:297
+msgid "Audio offset"
+msgstr "音声オフセット"
+
+#: id:298
+msgid "Bookmarks"
+msgstr "ブックマーク"
+
+#: id:299
+msgid "- AAC capable receiver"
+msgstr "- AAC 対応レシーバー"
+
+#: id:300
+msgid "- MP1 capable receiver"
+msgstr "- MP1 対応レシーバー"
+
+#: id:301
+msgid "- MP2 capable receiver"
+msgstr "- MP2 対応レシーバー"
+
+#: id:302
+msgid "- MP3 capable receiver"
+msgstr "- MP3 対応レシーバー"
+
+#: id:303
+msgid "Delay"
+msgstr "遅延"
+
+#: id:304
+msgctxt "Auto context with id 304"
+msgid "Language"
+msgstr "言語"
+
+#: id:305
+msgctxt "Auto context with id 305"
+msgid "Enabled"
+msgstr "有効"
+
+#: id:306
+msgid "Non-interleaved"
+msgstr "非インターリーブ"
+
+#: id:312
+msgid "(0=auto)"
+msgstr "(0=自動)"
+
+#: id:313
+msgid "Cleaning database"
+msgstr "データベースを更新中"
+
+#: id:314
+msgid "Preparing..."
+msgstr "準備中..."
+
+#: id:315
+msgid "Database error"
+msgstr "データベースエラー"
+
+#: id:316
+msgid "Searching songs..."
+msgstr "曲の検索中..."
+
+#: id:317
+msgid "Cleaned database successfully"
+msgstr "データベースの更新が完了しました"
+
+#: id:318
+msgid "Cleaning songs..."
+msgstr "曲の更新中..."
+
+#: id:319
+msgid "Error cleaning songs"
+msgstr "曲を更新できません"
+
+#: id:320
+msgid "Cleaning artists..."
+msgstr "アーティストの更新中..."
+
+#: id:321
+msgid "Error cleaning artists"
+msgstr "アーティストを更新できません"
+
+#: id:322
+msgid "Cleaning genres..."
+msgstr "ジャンルの更新中..."
+
+#: id:323
+msgid "Error cleaning genres"
+msgstr "ジャンルを更新できません"
+
+#: id:324
+msgid "Cleaning paths..."
+msgstr "パスの更新中..."
+
+#: id:325
+msgid "Error cleaning paths"
+msgstr "パスを更新できません"
+
+#: id:326
+msgid "Cleaning albums..."
+msgstr "アルバムの更新中..."
+
+#: id:327
+msgid "Error cleaning albums"
+msgstr "アルバムを更新できません"
+
+#: id:328
+msgid "Writing changes..."
+msgstr "変更を書き込み中..."
+
+#: id:329
+msgid "Error writing changes"
+msgstr "書き込みができません"
+
+#: id:330
+msgid "This may take some time..."
+msgstr "お待ち下さい..."
+
+#: id:331
+msgid "Compressing database..."
+msgstr "データベースの圧縮中..."
+
+#: id:332
+msgid "Error compressing database"
+msgstr "データベースを圧縮できません"
+
+#: id:333
+msgid "Do you want to clean the library?"
+msgstr "ライブラリを消去しますか？"
+
+#: id:334
+msgid "Clean library..."
+msgstr "ライブラリの消去..."
+
+#: id:335
+msgid "Start"
+msgstr "実行"
+
+#: id:336
+msgid "Framerate conversion"
+msgstr "フレームレートの調整"
+
+#: id:337
+msgctxt "Auto context with id 337"
+msgid "Audio output"
+msgstr "オーディオ出力"
+
+#: id:338
+msgid "Analog"
+msgstr "アナログ"
+
+#: id:339
+msgid "Optical/Coax"
+msgstr "デジタル(光/同軸)"
+
+#: id:340
+msgid "Various artists"
+msgstr "VA/オムニバス"
+
+#: id:341
+msgid "Play disc"
+msgstr "ディスクの再生"
+
+#: id:342
+msgctxt "Auto context with id 342"
+msgid "Movies"
+msgstr "ムービー"
+
+#: id:343
+msgid "Adjust framerate"
+msgstr "フレームレートの調整"
+
+#: id:344
+msgid "Actors"
+msgstr "俳優"
+
+#: id:345
+msgctxt "Auto context with id 345"
+msgid "Year"
+msgstr "公開年"
+
+#: id:346
+msgid "Boost volume level on downmix"
+msgstr "ダウンミックス時に音量ブースト"
+
+#: id:350
+msgctxt "Auto context with id 350"
+msgid "Programs"
+msgstr "プログラム"
+
+#: id:351
+msgctxt "Auto context with id 351"
+msgid "Off"
+msgstr "OFF"
+
+#: id:352
+msgid "Dim"
+msgstr "薄"
+
+#: id:353
+msgid "Black"
+msgstr "黒"
+
+#: id:354
+msgid "Matrix trails"
+msgstr "マトリックス"
+
+#: id:355
+msgid "Screensaver time"
+msgstr "スクリーンセーバー起動時間"
+
+#: id:356
+msgid "Screensaver mode"
+msgstr "スクリーンセーバーモード"
+
+#: id:357
+msgid "Shutdown function timer"
+msgstr "シャットダウンタイマー"
+
+#: id:358
+msgid "All albums"
+msgstr "すべてのアルバム"
+
+#: id:359
+msgid "Recently added albums"
+msgstr "最近追加されたアルバム"
+
+#: id:360
+msgctxt "Auto context with id 360"
+msgid "Screensaver"
+msgstr "スクリーンセーバー"
+
+#: id:361
+msgid "R. Slideshow"
+msgstr "ランダムスライドショー"
+
+#: id:362
+msgid "Screensaver dim level"
+msgstr "スクリーンセーバーの暗さ(%)"
+
+#: id:363
+msgid "Sort by: File"
+msgstr "並べ替え: ファイル名"
+
+#: id:364
+msgid "- Dolby Digital (AC3) capable receiver"
+msgstr "- Dolby Digital (AC3) 対応レシーバー"
+
+#: id:365
+msgctxt "Auto context with id 365"
+msgid "Sort by: Name"
+msgstr "並べ替え: 名前"
+
+#: id:366
+msgid "Sort by: Year"
+msgstr "並べ替え: 公開年"
+
+#: id:367
+msgid "Sort by: Rating"
+msgstr "並べ替え: 評価"
+
+#: id:368
+msgid "IMDb"
+msgstr "IMDb"
+
+#: id:369
+msgctxt "Auto context with id 369"
+msgid "Title"
+msgstr "タイトル"
+
+#: id:370
+msgid "Thunderstorms"
+msgstr "雷雨"
+
+#: id:371
+msgid "Partly"
+msgstr "時々"
+
+#: id:372
+msgid "Mostly"
+msgstr "ほぼ"
+
+#: id:373
+msgid "Sunny"
+msgstr "晴れ"
+
+#: id:374
+msgid "Cloudy"
+msgstr "曇り"
+
+#: id:375
+msgid "Snow"
+msgstr "雪"
+
+#: id:376
+msgid "Rain"
+msgstr "雨"
+
+#: id:377
+msgid "Light"
+msgstr "小"
+
+#: id:378
+msgid "AM"
+msgstr "午前中"
+
+#: id:379
+msgid "PM"
+msgstr "午後から"
+
+#: id:380
+msgid "Showers"
+msgstr "にわか雨"
+
+#: id:381
+msgid "Few"
+msgstr "わずかな"
+
+#: id:382
+msgid "Scattered"
+msgstr "所々"
+
+#: id:383
+msgctxt "Auto context with id 383"
+msgid "Wind"
+msgstr "風"
+
+#: id:384
+msgid "Strong"
+msgstr "強い"
+
+#: id:385
+msgid "Fair"
+msgstr "好天"
+
+#: id:386
+msgctxt "Auto context with id 386"
+msgid "Clear"
+msgstr "快晴"
+
+#: id:387
+msgid "Clouds"
+msgstr "曇り"
+
+#: id:388
+msgid "Early"
+msgstr "早朝"
+
+#: id:389
+msgid "Shower"
+msgstr "にわか雨"
+
+#: id:390
+msgid "Flurries"
+msgstr "曇り一時雨又は雪"
+
+#: id:391
+msgctxt "Auto context with id 391"
+msgid "Low"
+msgstr "Low"
+
+#: id:392
+msgctxt "Auto context with id 392"
+msgid "Medium"
+msgstr "Medium"
+
+#: id:393
+msgctxt "Auto context with id 393"
+msgid "High"
+msgstr "High"
+
+#: id:394
+msgid "Fog"
+msgstr "霧"
+
+#: id:395
+msgid "Haze"
+msgstr "もや"
+
+#: id:396
+msgid "Select location"
+msgstr "場所の選択"
+
+#: id:397
+msgid "Refresh time"
+msgstr "更新時間"
+
+#: id:398
+msgid "Temperature units"
+msgstr "気温単位"
+
+#: id:399
+msgid "Speed units"
+msgstr "風速単位"
+
+#: id:400
+msgctxt "Auto context with id 400"
+msgid "Weather"
+msgstr "天気"
+
+#: id:401
+msgid "Temp"
+msgstr "現在の気温"
+
+#: id:402
+msgid "Feels like"
+msgstr "体感温度"
+
+#: id:403
+msgid "UV index"
+msgstr "紫外線指数"
+
+#: id:404
+msgctxt "Auto context with id 404"
+msgid "Wind"
+msgstr "風"
+
+#: id:405
+msgid "Dew point"
+msgstr "結露点"
+
+#: id:406
+msgid "Humidity"
+msgstr "湿度"
+
+#: id:409
+msgid "Defaults"
+msgstr "デフォルト"
+
+#: id:410
+msgid "Accessing weather service"
+msgstr "天気予報サービスに接続中"
+
+#: id:411
+msgid "Getting weather for:"
+msgstr "天気を取得中:"
+
+#: id:412
+msgid "Unable to get weather data"
+msgstr "天気を取得できません"
+
+#: id:413
+msgid "Manual"
+msgstr "マニュアル"
+
+#: id:414
+msgid "No review for this album"
+msgstr "このアルバムのレビューはありません"
+
+#: id:415
+msgid "Downloading thumbnail..."
+msgstr "サムネイルの取得中..."
+
+#: id:416
+msgid "Not available"
+msgstr "利用できません"
+
+#: id:417
+msgid "View: Big icons"
+msgstr "表示: アイコン(大)"
+
+#: id:418
+msgctxt "Auto context with id 418"
+msgid "Low"
+msgstr "最低気温"
+
+#: id:419
+msgctxt "Auto context with id 419"
+msgid "High"
+msgstr "最高気温"
+
+#: id:420
+msgid "HDMI"
+msgstr "HDMI"
+
+#: id:422
+msgid "Delete album info"
+msgstr "アルバム情報の削除"
+
+#: id:423
+msgid "Delete CD information"
+msgstr "CDDB 情報の削除"
+
+#: id:424
+msgid "Select"
+msgstr "選択"
+
+#: id:425
+msgid "No album information found"
+msgstr "アルバム情報が見つかりません"
+
+#: id:426
+msgid "No CD information found"
+msgstr "CDDB 情報が見つかりません"
+
+#: id:427
+msgid "Disc"
+msgstr "ディスク"
+
+#: id:428
+msgid "Insert correct CD/DVD"
+msgstr "正しい CD/DVD を入れて下さい"
+
+#: id:429
+msgid "Please insert the following disc:"
+msgstr "次の CD/DVD を挿入して下さい:"
+
+#: id:430
+msgid "Sort by: DVD#"
+msgstr "並べ替え: DVD#"
+
+#: id:431
+msgid "No cache"
+msgstr "キャッシュしない"
+
+#: id:432
+msgid "Remove movie from library"
+msgstr "ライブラリからムービーを削除"
+
+#: id:433
+msgid "Really remove '%s'?"
+msgstr "本当に '%s' を削除しますか?"
+
+#: id:434
+msgid "From %s at %i %s"
+msgstr "%s の風 %i %s"
+
+#: id:437
+msgid "Removable disk"
+msgstr "リムーバブルディスク"
+
+#: id:438
+msgid "Opening file"
+msgstr "ファイルを開く"
+
+#: id:439
+msgid "Cache"
+msgstr "キャッシュ"
+
+#: id:440
+msgid "Harddisk"
+msgstr "ハードディスク"
+
+#: id:441
+msgid "UDF"
+msgstr "UDF"
+
+#: id:442
+msgid "Local network"
+msgstr "LAN"
+
+#: id:443
+msgid "Internet"
+msgstr "インターネット"
+
+#: id:444
+msgctxt "Auto context with id 444"
+msgid "Video"
+msgstr "ビデオ"
+
+#: id:445
+msgctxt "Auto context with id 445"
+msgid "Audio"
+msgstr "オーディオ"
+
+#: id:446
+msgctxt "Auto context with id 446"
+msgid "DVD"
+msgstr "DVD"
+
+#: id:447
+msgid "Autorun media"
+msgstr "自動再生"
+
+#: id:448
+msgid "LCD"
+msgstr "LCD"
+
+#: id:449
+msgctxt "Auto context with id 449"
+msgid "Enabled"
+msgstr "LCD有効"
+
+#: id:450
+msgid "Columns"
+msgstr "文字数"
+
+#: id:451
+msgid "Row 1 address"
+msgstr "1行目のアドレス"
+
+#: id:452
+msgid "Row 2 address"
+msgstr "2行目のアドレス"
+
+#: id:453
+msgid "Row 3 address"
+msgstr "3行目のアドレス"
+
+#: id:454
+msgid "Row 4 address"
+msgstr "4行目のアドレス"
+
+#: id:455
+msgid "Rows"
+msgstr "行数"
+
+#: id:456
+msgid "Mode"
+msgstr "モード"
+
+#: id:457
+msgid "Switch view"
+msgstr "表示切り替え"
+
+#: id:459
+msgid "Subs"
+msgstr "サブ"
+
+#: id:460
+msgid "Audio stream"
+msgstr "音声"
+
+#: id:461
+msgid "[active]"
+msgstr "[アクティブ]"
+
+#: id:462
+msgid "Subtitle"
+msgstr "字幕"
+
+#: id:463
+msgid "Backlight"
+msgstr "バックライト"
+
+#: id:464
+msgid "Brightness"
+msgstr "明るさ"
+
+#: id:465
+msgid "Contrast"
+msgstr "コントラスト"
+
+#: id:466
+msgid "Gamma"
+msgstr "ガンマ"
+
+#: id:467
+msgctxt "Auto context with id 467"
+msgid "Type"
+msgstr "タイプ"
+
+#: id:468
+msgid "Move the bar to change the OSD position"
+msgstr "OSD 位置の調節"
+
+#: id:469
+msgid "OSD position"
+msgstr "OSD の位置"
+
+#: id:470
+msgid "Credits"
+msgstr "クレジット"
+
+#: id:471
+msgid "Modchip"
+msgstr "MODチップ"
+
+#: id:474
+msgctxt "Auto context with id 474"
+msgid "Off"
+msgstr "オフ"
+
+#: id:475
+msgid "Music only"
+msgstr "ミュージックのみ"
+
+#: id:476
+msgctxt "Auto context with id 476"
+msgid "Music & video"
+msgstr "ミュージック & ビデオ"
+
+#: id:477
+msgid "Unable to load playlist"
+msgstr "プレイリストをロードできません"
+
+#: id:478
+msgid "OSD"
+msgstr "OSD"
+
+#: id:479
+msgid "Skin & language"
+msgstr "スキン & 言語"
+
+#: id:480
+msgid "Appearance"
+msgstr "外観"
+
+#: id:481
+msgid "Audio options"
+msgstr "オーディオ設定"
+
+#: id:482
+msgid "About XBMC"
+msgstr "XBMC について"
+
+#: id:485
+msgid "Delete album"
+msgstr "アルバムの削除"
+
+#: id:486
+msgid "Repeat"
+msgstr "リピート"
+
+#: id:487
+msgid "Repeat one"
+msgstr "個別リピート"
+
+#: id:488
+msgid "Repeat folder"
+msgstr "フォルダーごとのリピート"
+
+#: id:489
+msgid "Play the next song automatically"
+msgstr "次のアイテムを自動再生"
+
+#: id:491
+msgid "- Use big icons"
+msgstr "- アイコン(大)の使用"
+
+#: id:492
+msgid "Resize VobSubs"
+msgstr "字幕の大きさ"
+
+#: id:493
+msgid "Advanced options (Experts Only!)"
+msgstr "高度な設定 (エキスパート専用!)"
+
+#: id:494
+msgid "Overall audio headroom"
+msgstr "全体の音量(dB)"
+
+#: id:495
+msgid "Upsample videos to GUI resolution"
+msgstr "ビデオを GUI の解像度に合わせる"
+
+#: id:496
+msgid "Calibration"
+msgstr "設定"
+
+#: id:497
+msgid "Show file extensions"
+msgstr "拡張子を表示する"
+
+#: id:498
+msgid "Sort by: Type"
+msgstr "並べ替え: タイプ"
+
+#: id:499
+msgid "Unable to connect to online lookup service"
+msgstr "オンラインサービスに接続できません"
+
+#: id:500
+msgid "Downloading album information failed"
+msgstr "アルバム情報の取得に失敗しました"
+
+#: id:501
+msgid "Looking for album names..."
+msgstr "アルバム名を探しています..."
+
+#: id:502
+msgctxt "Auto context with id 502"
+msgid "Open"
+msgstr "開"
+
+#: id:503
+msgid "Busy"
+msgstr "ビジー"
+
+#: id:504
+msgid "Empty"
+msgstr "空"
+
+#: id:505
+msgid "Loading media info from files..."
+msgstr "ファイルからメディア情報を読み込んでいます..."
+
+#: id:507
+msgid "Sort by: Usage"
+msgstr "並べ替え: 回数"
+
+#: id:510
+msgid "Enable visualizations"
+msgstr "視覚エフェクトを有効化"
+
+#: id:511
+msgid "Enable video mode switching"
+msgstr "ビデオモードを切り替えを有効化"
+
+#: id:512
+msgid "Startup window"
+msgstr "起動画面"
+
+#: id:513
+msgid "Home window"
+msgstr "ホーム画面"
+
+#: id:514
+msgid "Manual settings"
+msgstr "手動設定"
+
+#: id:515
+msgid "Genre"
+msgstr "ジャンル"
+
+#: id:517
+msgid "Recently played albums"
+msgstr "最近再生されたアルバム"
+
+#: id:518
+msgid "Launch"
+msgstr "実行"
+
+#: id:519
+msgid "Launch in..."
+msgstr "Launch in..."
+
+#: id:521
+msgid "Compilations"
+msgstr "コンピレーション"
+
+#: id:522
+msgid "Remove source"
+msgstr "このソースを削除"
+
+#: id:523
+msgid "Switch media"
+msgstr "メディア切り替え"
+
+#: id:524
+msgid "Select playlist"
+msgstr "プレイリスト選択"
+
+#: id:525
+msgid "New playlist..."
+msgstr "新規プレイリスト..."
+
+#: id:526
+msgid "Add to playlist"
+msgstr "プレイリストに追加"
+
+#: id:527
+msgid "Manually add to library"
+msgstr "手動でライブラリに追加"
+
+#: id:528
+msgid "Enter title"
+msgstr "タイトルを入力"
+
+#: id:529
+msgid "Error: Duplicate title"
+msgstr "エラー: タイトルが重複しています"
+
+#: id:530
+msgid "Select genre"
+msgstr "ジャンルを選択"
+
+#: id:531
+msgid "New genre"
+msgstr "新規ジャンル"
+
+#: id:532
+msgid "Manual addition"
+msgstr "手動で追加"
+
+#: id:533
+msgid "Enter genre"
+msgstr "ジャンル名を入力"
+
+#: id:534
+msgid "View: %s"
+msgstr "表示: %s"
+
+#: id:535
+msgid "List"
+msgstr "リスト"
+
+#: id:536
+msgid "Icons"
+msgstr "アイコン"
+
+#: id:537
+msgid "Big list"
+msgstr "リスト(大)"
+
+#: id:538
+msgid "Big icons"
+msgstr "アイコン(大)"
+
+#: id:539
+msgid "Wide"
+msgstr "ワイド"
+
+#: id:540
+msgid "Big wide"
+msgstr "超ワイド"
+
+#: id:541
+msgid "Album icons"
+msgstr "アルバムアイコン"
+
+#: id:542
+msgid "DVD icons"
+msgstr "DVD アイコン"
+
+#: id:543
+msgctxt "Auto context with id 543"
+msgid "DVD"
+msgstr "DVD"
+
+#: id:544
+msgctxt "Auto context with id 544"
+msgid "Media info"
+msgstr "メディア情報"
+
+#: id:545
+msgid "Audio output device"
+msgstr "オーディオ出力デバイス"
+
+#: id:546
+msgid "Passthrough output device"
+msgstr "パススルー出力デバイス"
+
+#: id:547
+msgid "No biography for this artist"
+msgstr "このアーティストのバイオグラフィーがありません"
+
+#: id:548
+msgid "Downmix multichannel audio to stereo"
+msgstr ""
+
+#: id:550
+msgid "Sort by: %s"
+msgstr "並べ替え: %s"
+
+#: id:551
+msgctxt "Auto context with id 551"
+msgid "Name"
+msgstr "名前"
+
+#: id:552
+msgid "Date"
+msgstr "日付"
+
+#: id:553
+msgid "Size"
+msgstr "サイズ"
+
+#: id:554
+msgid "Track"
+msgstr "トラック"
+
+#: id:555
+msgid "Time"
+msgstr "時間"
+
+#: id:556
+msgctxt "Auto context with id 556"
+msgid "Title"
+msgstr "タイトル"
+
+#: id:557
+msgid "Artist"
+msgstr "アーティスト"
+
+#: id:558
+msgid "Album"
+msgstr "アルバム"
+
+#: id:559
+msgid "Playlist"
+msgstr "プレイリスト"
+
+#: id:560
+msgid "ID"
+msgstr "ID"
+
+#: id:561
+msgctxt "Auto context with id 561"
+msgid "File"
+msgstr "ファイル"
+
+#: id:562
+msgctxt "Auto context with id 562"
+msgid "Year"
+msgstr "公開年"
+
+#: id:563
+msgid "Rating"
+msgstr "評価"
+
+#: id:564
+msgctxt "Auto context with id 564"
+msgid "Type"
+msgstr "タイプ"
+
+#: id:565
+msgid "Usage"
+msgstr "回数"
+
+#: id:566
+msgid "Album artist"
+msgstr "アルバムアーティスト"
+
+#: id:567
+msgid "Play count"
+msgstr "再生回数"
+
+#: id:568
+msgid "Last played"
+msgstr "最後に再生した日"
+
+#: id:569
+msgctxt "Auto context with id 569"
+msgid "Comment"
+msgstr "コメント"
+
+#: id:570
+msgid "Date added"
+msgstr "追加日"
+
+#: id:571
+msgctxt "Auto context with id 571"
+msgid "Default"
+msgstr "でフォルト"
+
+#: id:572
+msgid "Studio"
+msgstr "スタジオ"
+
+#: id:573
+msgid "Path"
+msgstr "パス"
+
+#: id:574
+msgctxt "Auto context with id 574"
+msgid "Country"
+msgstr ""
+
+#: id:575
+msgid "In progress"
+msgstr "処理中"
+
+#: id:576
+msgid "Times played"
+msgstr "再生回数"
+
+#: id:580
+msgid "Sort direction"
+msgstr "並べ替え方向"
+
+#: id:581
+msgid "Sort method"
+msgstr "並べ替え方法"
+
+#: id:582
+msgctxt "Auto context with id 582"
+msgid "View mode"
+msgstr "表示モード"
+
+#: id:583
+msgid "Remember views for different folders"
+msgstr "他のフォルダでもこのビューを使用"
+
+#: id:584
+msgid "Ascending"
+msgstr "昇順"
+
+#: id:585
+msgid "Descending"
+msgstr "降順"
+
+#: id:586
+msgid "Edit playlist"
+msgstr "プレイリストを編集"
+
+#: id:587
+msgid "Filter"
+msgstr "フィルター"
+
+#: id:588
+msgid "Cancel party mode"
+msgstr "パーティーモードをキャンセル"
+
+#: id:589
+msgid "Party mode"
+msgstr "パーティーモード"
+
+#: id:590
+msgid "Random"
+msgstr "ランダム"
+
+#: id:591
+msgctxt "Auto context with id 591"
+msgid "Off"
+msgstr "オフ"
+
+#: id:592
+msgid "One"
+msgstr "1項目"
+
+#: id:593
+msgid "All"
+msgstr "すべて"
+
+#: id:594
+msgctxt "Auto context with id 594"
+msgid "Off"
+msgstr "Off"
+
+#: id:595
+msgid "Repeat: Off"
+msgstr "リピート: オフ"
+
+#: id:596
+msgid "Repeat: One"
+msgstr "リピート: 1項目"
+
+#: id:597
+msgid "Repeat: All"
+msgstr "リピート: すべて"
+
+#: id:600
+msgid "Rip audio CD"
+msgstr "オーディオ CD の読み込み"
+
+#: id:601
+msgctxt "Auto context with id 601"
+msgid "Medium"
+msgstr "ミディアム (低音質)"
+
+#: id:602
+msgctxt "Auto context with id 602"
+msgid "Standard"
+msgstr "スタンダード (中音質)"
+
+#: id:603
+msgid "Extreme"
+msgstr "エクストリーム (高音質)"
+
+#: id:604
+msgid "Constant bitrate"
+msgstr "固定ビットレート"
+
+#: id:605
+msgid "Ripping..."
+msgstr "リッピング中..."
+
+#: id:607
+msgid "To:"
+msgstr "保存先:"
+
+#: id:608
+msgid "Could not rip CD or track"
+msgstr "CD または楽曲を読み込めませんでした"
+
+#: id:609
+msgid "CDDARipPath is not set."
+msgstr "CDDARip パスが設定されていません"
+
+#: id:610
+msgid "Rip audio track"
+msgstr "オーディオトラックを読み込む"
+
+#: id:611
+msgid "Enter number"
+msgstr "番号を入力"
+
+#: id:612
+msgid "Bits/Sample"
+msgstr "ビットレート/サンプルレート"
+
+#: id:613
+msgid "Sample Frequency"
+msgstr "サンプリング周波数"
+
+#: id:620
+msgid "Audio CDs"
+msgstr "オーディオ CD"
+
+#: id:621
+msgid "Encoder"
+msgstr "エンコーダー"
+
+#: id:622
+msgid "Quality"
+msgstr "品質"
+
+#: id:623
+msgid "Bitrate"
+msgstr "ビットレート"
+
+#: id:624
+msgid "Include track number"
+msgstr "トラック番号を含む"
+
+#: id:625
+msgid "All songs of"
+msgstr "すべての曲"
+
+#: id:629
+msgctxt "Auto context with id 629"
+msgid "View mode"
+msgstr "表示モード"
+
+#: id:630
+msgctxt "Auto context with id 630"
+msgid "Normal"
+msgstr "ノーマル"
+
+#: id:631
+msgid "Zoom"
+msgstr "ズーム"
+
+#: id:632
+msgid "Stretch 4:3"
+msgstr "画面比 4:3"
+
+#: id:633
+msgid "Wide Zoom"
+msgstr "画面比 14:9"
+
+#: id:634
+msgid "Stretch 16:9"
+msgstr "画面比 16:9"
+
+#: id:635
+msgid "Original Size"
+msgstr "オリジナルサイズ"
+
+#: id:636
+msgctxt "Auto context with id 636"
+msgid "Custom"
+msgstr "カスタム"
+
+#: id:637
+msgid "Replay gain"
+msgstr "再生音量平均化"
+
+#: id:638
+msgid "Replaygain volume adjustments"
+msgstr "モード"
+
+#: id:639
+msgid "Use track levels"
+msgstr "トラックレベル使用"
+
+#: id:640
+msgid "Use album levels"
+msgstr "アルバムレベル使用"
+
+#: id:641
+msgid "PreAmp Level - Replay gained files"
+msgstr "プリアンプレベル - 平均化したファイルを基準"
+
+#: id:642
+msgid "PreAmp Level - Non replay gained files"
+msgstr "プリアンプレベル - 平均化ファイルを基準にしない"
+
+#: id:643
+msgid "Avoid clipping on replay gained files"
+msgstr "平均化したファイルのクリッピングを避ける"
+
+#: id:644
+msgid "Crop black bars"
+msgstr "黒帯部分をトリミングする"
+
+#: id:645
+msgid "Need to unpack a big file. Continue?"
+msgstr "大きなファイルを解凍する必要があります。続けますか?"
+
+#: id:646
+msgid "Remove from library"
+msgstr "ライブラリから削除"
+
+#: id:647
+msgid "Export video library"
+msgstr "ビデオライブラリをエクスポート"
+
+#: id:648
+msgid "Import video library"
+msgstr "ビデオライブラリをインポート"
+
+#: id:649
+msgid "Importing"
+msgstr "インポート"
+
+#: id:650
+msgid "Exporting"
+msgstr "エクスポート"
+
+#: id:651
+msgid "Browse for library"
+msgstr "ライブラリを参照する"
+
+#: id:652
+msgid "Years"
+msgstr "製作年"
+
+#: id:653
+msgid "Update library"
+msgstr "ライブラリを更新"
+
+#: id:654
+msgid "Show debug info"
+msgstr "デバッグ情報を表示"
+
+#: id:655
+msgid "Browse for executable"
+msgstr "実行ファイルを参照"
+
+#: id:656
+msgid "Browse for playlist"
+msgstr "プレイリストを参照"
+
+#: id:657
+msgid "Browse for folder"
+msgstr "フォルダーを参照"
+
+#: id:658
+msgid "Song information"
+msgstr "楽曲情報"
+
+#: id:659
+msgid "Non-linear stretch"
+msgstr "ノンリニアズーム"
+
+#: id:660
+msgid "Volume amplification"
+msgstr "ボリューム増幅"
+
+#: id:661
+msgid "Choose export folder"
+msgstr "エクスポートフォルダの選択"
+
+#: id:662
+msgid "This file is no longer available."
+msgstr "このファイルは存在しません。"
+
+#: id:663
+msgid "Would you like to remove it from the library?"
+msgstr "ライブラリから削除しますか?"
+
+#: id:664
+msgid "Browse for Script"
+msgstr "スクリプトを参照する"
+
+#: id:665
+msgid "Compression level"
+msgstr "圧縮レベル"
+
+#: id:700
+msgid "Cleaning up library"
+msgstr "ライブラリの整理"
+
+#: id:701
+msgid "Removing old songs from the library"
+msgstr "ライブラリから古い曲を削除します"
+
+#: id:702
+msgid "This path has been scanned before"
+msgstr "このパスは以前にスキャンしました"
+
+#: id:705
+msgctxt "Auto context with id 705"
+msgid "Network"
+msgstr "ネットワーク"
+
+#: id:706
+msgid "- Server"
+msgstr "- サーバ"
+
+#: id:708
+msgid "Use an HTTP proxy server to access the internet"
+msgstr "HTTP プロキシを使用"
+
+#: id:711
+msgid "Internet Protocol (IP)"
+msgstr "インターネット プロトコル (IP)"
+
+#: id:712
+msgid "Invalid port specified. Value must be between 1 and 65535."
+msgstr "無効なポートです。1から65535の間で設定して下さい。"
+
+#: id:713
+msgid "HTTP proxy"
+msgstr "HTTP プロキシ"
+
+#: id:715
+msgid "- Assignment"
+msgstr "- 接続方式"
+
+#: id:716
+msgid "Automatic (DHCP)"
+msgstr "自動 (DHCP)"
+
+#: id:717
+msgid "Manual (Static)"
+msgstr "手動 (固定)"
+
+#: id:719
+msgid "- IP address"
+msgstr "- IPアドレス"
+
+#: id:720
+msgid "- Netmask"
+msgstr "- ネットマスク"
+
+#: id:721
+msgid "- Default gateway"
+msgstr "- デフォルト ゲートウェイ"
+
+#: id:722
+msgid "- DNS server"
+msgstr "- DNSサーバー"
+
+#: id:723
+msgid "Save & restart"
+msgstr "設定の保存 & 再起動"
+
+#: id:724
+msgid "Invalid address specified. Value must be AAA.BBB.CCC.DDD"
+msgstr "無効なアドレスです。AAA.BBB.CCC.DDD のように記述してください。"
+
+#: id:725
+msgid "with numbers between 0 and 255."
+msgstr "0 から 255 の間から選んで下さい"
+
+#: id:726
+msgid "Changes not saved. Continue without saving?"
+msgstr "変更は保存されません 本当によろしいですか?"
+
+#: id:727
+msgid "Web server"
+msgstr "Web サーバー"
+
+#: id:728
+msgctxt "Auto context with id 728"
+msgid "FTP server"
+msgstr "FTP サーバー"
+
+#: id:730
+msgid "- Port"
+msgstr "- ポート"
+
+#: id:732
+msgid "Save & apply"
+msgstr "設定の保存"
+
+#: id:733
+msgid "- Password"
+msgstr "- パスワード"
+
+#: id:734
+msgid "No pass"
+msgstr "パスワードなし"
+
+#: id:735
+msgid "- Character set"
+msgstr "- 文字コード"
+
+#: id:736
+msgid "- Style"
+msgstr "- スタイル:"
+
+#: id:737
+msgid "- Colour"
+msgstr "- カラー:"
+
+#: id:738
+msgctxt "Auto context with id 738"
+msgid "Normal"
+msgstr "ノーマル"
+
+#: id:739
+msgid "Bold"
+msgstr "太字"
+
+#: id:740
+msgid "Italics"
+msgstr "斜体"
+
+#: id:741
+msgid "Bold italics"
+msgstr "太字+斜体"
+
+#: id:742
+msgctxt "Auto context with id 742"
+msgid "White"
+msgstr "白色"
+
+#: id:743
+msgctxt "Auto context with id 743"
+msgid "Yellow"
+msgstr "黄色"
+
+#: id:744
+msgctxt "Auto context with id 744"
+msgid "Files"
+msgstr "ファイル"
+
+#: id:745
+msgid "No scanned information for this view"
+msgstr "スキャン情報はありませんでした"
+
+#: id:746
+msgid "Please turn off library mode"
+msgstr "ライブラリモードを終了して下さい"
+
+#: id:747
+msgid "Error loading image"
+msgstr "イメージの読み込みに失敗"
+
+#: id:748
+msgid "Edit path"
+msgstr "パスの編集"
+
+#: id:749
+msgid "Mirror image"
+msgstr "Mirror Image"
+
+#: id:750
+msgid "Are you sure?"
+msgstr "よろしいですか?"
+
+#: id:751
+msgid "Removing source"
+msgstr "ソースの削除"
+
+#: id:754
+msgid "Add program link"
+msgstr "プログラムリンクの追加"
+
+#: id:755
+msgid "Edit program path"
+msgstr "プログラムパスの編集"
+
+#: id:756
+msgid "Edit program name"
+msgstr "プログラム名の編集"
+
+#: id:757
+msgid "Edit path depth"
+msgstr "パスの階層の編集"
+
+#: id:759
+msgid "View: Big list"
+msgstr "表示: リスト(大)"
+
+#: id:760
+msgctxt "Auto context with id 760"
+msgid "Yellow"
+msgstr "黄色"
+
+#: id:761
+msgctxt "Auto context with id 761"
+msgid "White"
+msgstr "白色"
+
+#: id:762
+msgid "Blue"
+msgstr "青色"
+
+#: id:763
+msgid "Bright green"
+msgstr "明るい緑色"
+
+#: id:764
+msgid "Yellow green"
+msgstr "黄緑色"
+
+#: id:765
+msgid "Cyan"
+msgstr "青緑色"
+
+#: id:766
+msgid "Light grey"
+msgstr "Reserved"
+
+#: id:767
+msgid "Grey"
+msgstr "Reserved"
+
+#: id:770
+msgid "Error %i: share not available"
+msgstr "エラー %i: 利用不可"
+
+#: id:772
+msgctxt "Auto context with id 772"
+msgid "Audio output"
+msgstr "オーディオハードウェア"
+
+#: id:773
+msgid "Seeking"
+msgstr "シーク中"
+
+#: id:774
+msgid "Slideshow folder"
+msgstr "スライドショーフォルダー"
+
+#: id:775
+msgid "Network interface"
+msgstr "ネットワークインターフェース"
+
+#: id:776
+msgid "- Wireless network name (ESSID)"
+msgstr "- ワイヤレスネットワーク名(ESSID)"
+
+#: id:777
+msgid "- Wireless password"
+msgstr "- ワイヤレスパスワード"
+
+#: id:778
+msgid "- Wireless security"
+msgstr "- ワイヤレスセキュリティ"
+
+#: id:779
+msgid "Save and apply network interface settings"
+msgstr "ネットワークインターフェース設定を保存して適用"
+
+#: id:780
+msgid "No encryption"
+msgstr ""
+
+#: id:781
+msgid "WEP"
+msgstr ""
+
+#: id:782
+msgid "WPA"
+msgstr ""
+
+#: id:783
+msgid "WPA2"
+msgstr ""
+
+#: id:784
+msgid "Applying network interface settings. Please wait."
+msgstr "ネットワークインターフェース設定を適用しています。お待ち下さい。"
+
+#: id:785
+msgid "Network interface restarted successfully."
+msgstr ""
+
+#: id:786
+msgid "Network interface did not start successfully."
+msgstr ""
+
+#: id:787
+msgid "Interface disabled"
+msgstr ""
+
+#: id:788
+msgid "Network interface disabled successfully."
+msgstr ""
+
+#: id:789
+msgid "Wireless network name (ESSID)"
+msgstr ""
+
+#: id:790
+msgid "Remote control"
+msgstr ""
+
+#: id:791
+msgid "Allow programs on this system to control XBMC"
+msgstr "システム上のプログラムによる XBMC の制御を許可"
+
+#: id:792
+msgctxt "Auto context with id 792"
+msgid "Port"
+msgstr "ポート"
+
+#: id:793
+msgid "Port range"
+msgstr "ポート番号の範囲"
+
+#: id:794
+msgid "Allow programs on other systems to control XBMC"
+msgstr "別のシステム上のプログラムによる XBMC の制御を許可"
+
+#: id:795
+msgid "Initial repeat delay (ms)"
+msgstr "Initial Repeat Delay (ms)"
+
+#: id:796
+msgid "Continuous repeat delay (ms)"
+msgstr "Continuous Repeat Delay (ms)"
+
+#: id:797
+msgid "Maximum number of clients"
+msgstr "Maximum Number of Clients"
+
+#: id:798
+msgid "Internet access"
+msgstr "インターネット接続"
+
+#: id:850
+msgid "Invalid port number entered"
+msgstr "誤ったポート番号が入力されました"
+
+#: id:851
+msgid "Valid port range is 1-65535"
+msgstr "ポート番号は 1-65535 の間から選んで下さい"
+
+#: id:852
+msgid "Valid port range is 1024-65535"
+msgstr "ポート番号は 1024-65535 の間から選んで下さい"
+
+#: id:998
+msgid "Add Music..."
+msgstr "ミュージックを追加..."
+
+#: id:999
+msgid "Add Videos..."
+msgstr "ビデオを追加..."
+
+#: id:1000
+msgid "- Preview"
+msgstr "- プレビュー"
+
+#: id:1001
+msgid "Unable to connect"
+msgstr "接続できません"
+
+#: id:1002
+msgid "XBMC was unable to connect to the network location."
+msgstr "XBMC はこのネットワーク上の場所に接続できませんでした。"
+
+#: id:1003
+msgid "This could be due to the network not being connected."
+msgstr "ネットワークに繋がっていない可能性があります。"
+
+#: id:1004
+msgid "Would you like to add it anyway?"
+msgstr "それでも追加しますか?"
+
+#: id:1006
+msgctxt "Auto context with id 1006"
+msgid "IP address"
+msgstr "IP アドレス"
+
+#: id:1007
+msgid "Add network location"
+msgstr "ネットワーク上の場所を追加"
+
+#: id:1008
+msgid "Protocol"
+msgstr "プロトコル"
+
+#: id:1009
+msgid "Server address"
+msgstr "サーバのアドレス"
+
+#: id:1010
+msgid "Server name"
+msgstr "サーバ名"
+
+#: id:1011
+msgid "Remote path"
+msgstr "リモートパス"
+
+#: id:1012
+msgid "Shared folder"
+msgstr "共有フォルダ"
+
+#: id:1013
+msgctxt "Auto context with id 1013"
+msgid "Port"
+msgstr "ポート"
+
+#: id:1014
+msgctxt "Auto context with id 1014"
+msgid "Username"
+msgstr "ユーザー名"
+
+#: id:1015
+msgid "Browse for network server"
+msgstr "ネットワークサーバを参照"
+
+#: id:1016
+msgid "Enter the network address of the server"
+msgstr "サーバのネットワークアドレスを入力"
+
+#: id:1017
+msgid "Enter the path on the server"
+msgstr "サーバ上のパスを入力"
+
+#: id:1018
+msgid "Enter the port number"
+msgstr "ポート番号を入力"
+
+#: id:1019
+msgid "Enter the username"
+msgstr "ユーザ名を入力"
+
+#: id:1020
+msgid "Add %s source"
+msgstr "%s ソースの追加"
+
+#: id:1021
+msgid "Enter the paths or browse for the media locations."
+msgstr "メディアのパスを参照するか入力してください。"
+
+#: id:1022
+msgid "Enter a name for this media Source."
+msgstr "ソースの名前を入力してください。"
+
+#: id:1023
+msgid "Browse for new share"
+msgstr "新しい共有の参照"
+
+#: id:1024
+msgid "Browse"
+msgstr "参照"
+
+#: id:1025
+msgid "Could not retrieve directory information."
+msgstr "フォルダ情報の取得に失敗"
+
+#: id:1026
+msgid "Add source"
+msgstr "ソースを追加"
+
+#: id:1027
+msgid "Edit source"
+msgstr "ソースを編集"
+
+#: id:1028
+msgid "Edit %s source"
+msgstr "%s ソースを編集"
+
+#: id:1029
+msgid "Enter the new label"
+msgstr "新しいラベルを入力"
+
+#: id:1030
+msgid "Browse for image"
+msgstr "イメージを参照"
+
+#: id:1031
+msgid "Browse for image folder"
+msgstr "イメージフォルダを参照"
+
+#: id:1032
+msgid "Add network location..."
+msgstr "ネットワーク上の場所を追加..."
+
+#: id:1033
+msgid "Browse for file"
+msgstr "ファイルを参照"
+
+#: id:1034
+msgid "Submenu"
+msgstr "サブメニュー"
+
+#: id:1035
+msgid "Enable submenu buttons"
+msgstr "サブメニューボタンを有効にする"
+
+#: id:1036
+msgid "Favourites"
+msgstr "お気に入り"
+
+#: id:1037
+msgid "Video Add-ons"
+msgstr "ビデオ アドオン"
+
+#: id:1038
+msgid "Music Add-ons"
+msgstr "ミュージック アドオン"
+
+#: id:1039
+msgid "Picture Add-ons"
+msgstr "ピクチャ アドオン"
+
+#: id:1040
+msgid "Loading directory"
+msgstr "フォルダの読み込み中"
+
+#: id:1041
+msgid "Retrieved %i items"
+msgstr "%i アイテムを取得"
+
+#: id:1042
+msgid "Retrieved %i of %i items"
+msgstr "%i アイテム (全 %i アイテム中) を取得"
+
+#: id:1043
+msgid "Program Add-ons"
+msgstr "プログラム アドオン"
+
+#: id:1044
+msgid "Set plugin thumb"
+msgstr "プラグインサムネイル指定"
+
+#: id:1045
+msgid "Add-on settings"
+msgstr "アドオン設定"
+
+#: id:1046
+msgid "Access points"
+msgstr "アクセスポイント"
+
+#: id:1047
+msgid "Other..."
+msgstr "その他..."
+
+#: id:1048
+msgid "- Username"
+msgstr "- ユーザ名"
+
+#: id:1049
+msgid "Script settings"
+msgstr "スクリプト設定"
+
+#: id:1050
+msgid "Singles"
+msgstr "シングル"
+
+#: id:1051
+msgid "Enter web address"
+msgstr "Web のアドレスを入力"
+
+#: id:1200
+msgid "SMB client"
+msgstr "SMB シェア"
+
+#: id:1202
+msgid "Workgroup"
+msgstr "SMB ワークグループ"
+
+#: id:1203
+msgid "Default username"
+msgstr "SMB ユーザー名"
+
+#: id:1204
+msgid "Default password"
+msgstr "SMB パスワード"
+
+#: id:1207
+msgid "WINS server"
+msgstr "WINSサーバー"
+
+#: id:1208
+msgid "Mount SMB shares"
+msgstr "SMB 共有のマウント"
+
+#: id:1210
+msgctxt "Auto context with id 1210"
+msgid "Remove"
+msgstr "削除"
+
+#: id:1211
+msgctxt "Auto context with id 1211"
+msgid "Music"
+msgstr "ミュージック"
+
+#: id:1212
+msgctxt "Auto context with id 1212"
+msgid "Video"
+msgstr "ビデオ"
+
+#: id:1213
+msgctxt "Auto context with id 1213"
+msgid "Pictures"
+msgstr "ピクチャ"
+
+#: id:1214
+msgctxt "Auto context with id 1214"
+msgid "Files"
+msgstr "ファイル"
+
+#: id:1215
+msgctxt "Auto context with id 1215"
+msgid "Music & video"
+msgstr "ミュージック & ビデオ"
+
+#: id:1216
+msgid "Music & pictures"
+msgstr "ミュージック & ピクチャー"
+
+#: id:1217
+msgid "Music & files"
+msgstr "ミュージック & ファイル"
+
+#: id:1218
+msgid "Video & pictures"
+msgstr "ビデオ & ピクチャー"
+
+#: id:1219
+msgid "Video & files"
+msgstr "ビデオ & ファイル"
+
+#: id:1220
+msgid "Pictures & files"
+msgstr "ピクチャー & ファイル"
+
+#: id:1221
+msgid "Music & video & pictures"
+msgstr "ミュージック & ビデオ & ピクチャー"
+
+#: id:1222
+msgid "Music & video & pictures & files"
+msgstr "ミュージック & ビデオ & ピクチャー & ファイル"
+
+#: id:1223
+msgctxt "Auto context with id 1223"
+msgid "Disabled"
+msgstr "無効"
+
+#: id:1226
+msgid "Files & music & video"
+msgstr "ファイル & ミュージック & ビデオ"
+
+#: id:1227
+msgid "Files & pictures & music"
+msgstr "ファイル & ピクチャー & ミュージック"
+
+#: id:1228
+msgid "Files & pictures & video"
+msgstr "ファイル & ピクチャー & ビデオ"
+
+#: id:1229
+msgid "Music & programs"
+msgstr "ミュージック & プログラム"
+
+#: id:1230
+msgid "Video & programs"
+msgstr "ビデオ & プログラム"
+
+#: id:1231
+msgid "Pictures & programs"
+msgstr "ピクチャー & プログラム"
+
+#: id:1232
+msgid "Music & video & pictures & programs"
+msgstr "ミュージック & ビデオ & ピクチャー & プログラム"
+
+#: id:1233
+msgid "Programs & video & music"
+msgstr "プログラム & ビデオ & ミュージック"
+
+#: id:1234
+msgid "Programs & pictures & music"
+msgstr "プログラム & ピクチャー & ミュージック"
+
+#: id:1235
+msgid "Programs & pictures & video"
+msgstr "プログラム & ピクチャー & ビデオ"
+
+#: id:1250
+msgid "Auto-detection"
+msgstr "自動検出"
+
+#: id:1251
+msgid "Auto-detect system"
+msgstr "システムにより自動検出"
+
+#: id:1252
+msgid "Nickname"
+msgstr "ニックネーム"
+
+#: id:1254
+msgid "Ask to connect"
+msgstr "接続を確認する"
+
+#: id:1255
+msgid "Send FTP user and password"
+msgstr "FTP ユーザー・パスワードを送る"
+
+#: id:1256
+msgid "Ping interval"
+msgstr "PING をかける間隔"
+
+#: id:1257
+msgid "Would you like to connect to the auto-detected system?"
+msgstr "自動検出されたシステムに接続しますか?"
+
+#: id:1259
+msgid "Zeroconf"
+msgstr "Zeroconf"
+
+#: id:1260
+msgid "Announce these services to other systems via Zeroconf"
+msgstr "本サービスを Zeroconf 経由でアナウンスする"
+
+#: id:1270
+msgid "Allow XBMC to receive AirPlay content"
+msgstr "XBMC の AirPlay コンテンツ受信を許可する"
+
+#: id:1271
+msgid "Device name"
+msgstr "デバイス名"
+
+#: id:1272
+msgid "- Use password protection"
+msgstr "- パスワード保護を使う"
+
+#: id:1273
+msgid "AirPlay"
+msgstr "AirPlay"
+
+#: id:1300
+msgid "Custom audio device"
+msgstr "カスタムオーディオデバイス"
+
+#: id:1301
+msgid "Custom passthrough device"
+msgstr "カスタムパススルーデバイス"
+
+#: id:1396
+msgid "Drifting"
+msgstr "漂う"
+
+#: id:1397
+msgid "and"
+msgstr "and"
+
+#: id:1398
+msgid "Freezing"
+msgstr "凍った"
+
+#: id:1399
+msgid "Late"
+msgstr "遅くなって"
+
+#: id:1400
+msgid "Isolated"
+msgstr "局地的な"
+
+#: id:1401
+msgid "Thundershowers"
+msgstr "雷雨"
+
+#: id:1402
+msgid "Thunder"
+msgstr "雷"
+
+#: id:1403
+msgctxt "Auto context with id 1403"
+msgid "Sun"
+msgstr "晴れ"
+
+#: id:1404
+msgid "Heavy"
+msgstr "まとまった"
+
+#: id:1405
+msgid "in"
+msgstr "近"
+
+#: id:1406
+msgid "the"
+msgstr "辺"
+
+#: id:1407
+msgid "Vicinity"
+msgstr "で"
+
+#: id:1408
+msgid "Ice"
+msgstr "氷"
+
+#: id:1409
+msgid "Crystals"
+msgstr "晶"
+
+#: id:1410
+msgid "Calm"
+msgstr "おだやか"
+
+#: id:1411
+msgid "with"
+msgstr "with"
+
+#: id:1412
+msgid "windy"
+msgstr "windy"
+
+#: id:1413
+msgid "drizzle"
+msgstr "小雨"
+
+#: id:1414
+msgid "Thunderstorm"
+msgstr "雷雨"
+
+#: id:1415
+msgid "Drizzle"
+msgstr "小雨"
+
+#: id:1416
+msgid "Foggy"
+msgstr "霧"
+
+#: id:1417
+msgid "Grains"
+msgstr "Grains"
+
+#: id:1418
+msgid "T-Storms"
+msgstr "雷・暴風"
+
+#: id:1419
+msgid "T-Showers"
+msgstr "雷・大雨"
+
+#: id:1420
+msgid "Moderate"
+msgstr "Moderate"
+
+#: id:1421
+msgid "Very High"
+msgstr "Very High"
+
+#: id:1422
+msgid "Windy"
+msgstr "Windy"
+
+#: id:1423
+msgid "Mist"
+msgstr "Mist"
+
+#: id:1450
+msgid "Put display to sleep when idle"
+msgstr "システムが右の時間以上アイドル状態が続くと画面をスリープ"
+
+#: id:2050
+msgid "Runtime"
+msgstr "上映時間"
+
+#: id:2100
+msgid "Script failed! : %s"
+msgstr "スクリプトが失敗! : %s"
+
+#: id:2101
+msgid "Newer version needed - See log"
+msgstr "新しいバージョンが必要です - ログを参照"
+
+#: id:4501
+msgid "Enable LCD/VFD"
+msgstr "LCD/VFDを有効にする"
+
+#: id:10000
+msgid "Home"
+msgstr "ホーム"
+
+#: id:10001
+msgctxt "Auto context with id 10001"
+msgid "Programs"
+msgstr "プログラム"
+
+#: id:10002
+msgctxt "Auto context with id 10002"
+msgid "Pictures"
+msgstr "ピクチャー"
+
+#: id:10003
+msgctxt "Auto context with id 10003"
+msgid "File manager"
+msgstr "ファイルマネージャー"
+
+#: id:10004
+msgctxt "Auto context with id 10004"
+msgid "Settings"
+msgstr "設定"
+
+#: id:10005
+msgctxt "Auto context with id 10005"
+msgid "Music"
+msgstr "ミュージック"
+
+#: id:10006
+msgctxt "Auto context with id 10006"
+msgid "Videos"
+msgstr "ビデオ"
+
+#: id:10007
+msgid "System information"
+msgstr "システム情報"
+
+#: id:10008
+msgid "Settings - General"
+msgstr "設定 - 一般"
+
+#: id:10009
+msgid "Settings - Screen"
+msgstr "設定 - 画面"
+
+#: id:10010
+msgid "Settings - Appearance - GUI Calibration"
+msgstr "設定 - 外観 - GUI 設定"
+
+#: id:10011
+msgid "Settings - Videos - Screen Calibration"
+msgstr "設定 - 画面 - スクリーン設定"
+
+#: id:10012
+msgid "Settings - Pictures"
+msgstr "設定 - ピクチャー"
+
+#: id:10013
+msgid "Settings - Programs"
+msgstr "設定 - プログラム"
+
+#: id:10014
+msgid "Settings - Weather"
+msgstr "設定 - 天気"
+
+#: id:10015
+msgid "Settings - Music"
+msgstr "設定 - ミュージック"
+
+#: id:10016
+msgid "Settings - System"
+msgstr "設定 - システム"
+
+#: id:10017
+msgid "Settings - Videos"
+msgstr "設定 - ビデオ"
+
+#: id:10018
+msgid "Settings - Network"
+msgstr "設定 - ネットワーク"
+
+#: id:10019
+msgid "Settings - Appearance"
+msgstr "設定 - 外観"
+
+#: id:10020
+msgctxt "Auto context with id 10020"
+msgid "Scripts"
+msgstr "スクリプト"
+
+#: id:10021
+msgid "Web Browser"
+msgstr "Webブラウザ"
+
+#: id:10025
+msgctxt "Auto context with id 10025"
+msgid "Videos"
+msgstr "ビデオ"
+
+#: id:10028
+msgid "Videos/Playlist"
+msgstr "ビデオ/プレイリスト"
+
+#: id:10029
+msgctxt "Auto context with id 10029"
+msgid "Login screen"
+msgstr "ログイン画面"
+
+#: id:10034
+msgid "Settings - Profiles"
+msgstr "設定 - プロファイル"
+
+#: id:10040
+msgid "Addon browser"
+msgstr "アドオンブラウザー"
+
+#: id:10100
+msgid "Yes/No dialog"
+msgstr "はい/いいえ ダイアログ"
+
+#: id:10101
+msgid "Progress dialog"
+msgstr "進行ダイアログ"
+
+#: id:10210
+msgid "Looking for subtitles..."
+msgstr "字幕を検索中..."
+
+#: id:10211
+msgid "Looking for or caching subtitles..."
+msgstr "字幕をキャッシュ中..."
+
+#: id:10212
+msgid "terminating"
+msgstr "終了中"
+
+#: id:10213
+msgid "buffering"
+msgstr "バッファ中"
+
+#: id:10214
+msgid "Opening stream"
+msgstr "ストリームを開いていいます"
+
+#: id:10500
+msgid "Music/Playlist"
+msgstr "ミュージック/プレイリスト"
+
+#: id:10501
+msgid "Music/Files"
+msgstr "ミュージック/ファイルリスト"
+
+#: id:10502
+msgid "Music/Library"
+msgstr "ミュージック/ライブラリ"
+
+#: id:10503
+msgid "Playlist editor"
+msgstr "プレイリストエディター"
+
+#: id:10504
+msgid "Top 100 songs"
+msgstr "Top 100 曲"
+
+#: id:10505
+msgid "Top 100 albums"
+msgstr "Top 100 アルバム"
+
+#: id:10506
+msgctxt "Auto context with id 10506"
+msgid "Programs"
+msgstr "プログラム"
+
+#: id:10507
+msgid "Configuration"
+msgstr "設定"
+
+#: id:10508
+msgid "Weather forecast"
+msgstr "天気予報"
+
+#: id:10509
+msgid "Network gaming"
+msgstr "ネットワーク・ゲーム"
+
+#: id:10510
+msgid "Extensions"
+msgstr "エクステンション"
+
+#: id:10511
+msgctxt "Auto context with id 10511"
+msgid "System info"
+msgstr "システム情報"
+
+#: id:10516
+msgid "Music - Library"
+msgstr "ミュージック - ライブラリ"
+
+#: id:10517
+msgid "Now Playing - Music"
+msgstr "ミュージック - 現在再生中"
+
+#: id:10522
+msgid "Now Playing - Videos"
+msgstr "ビデオ - 現在再生中"
+
+#: id:10523
+msgid "Album info"
+msgstr "アルバム情報"
+
+#: id:10524
+msgid "Movie info"
+msgstr "ムービー情報"
+
+#: id:12000
+msgid "Select dialog"
+msgstr "ダイアログの選択"
+
+#: id:12001
+msgid "Music/Info"
+msgstr "ミュージック/情報"
+
+#: id:12002
+msgid "Dialog OK"
+msgstr "ダイアログ OK"
+
+#: id:12003
+msgid "Videos/Info"
+msgstr "ビデオ/情報"
+
+#: id:12004
+msgid "Scripts/Info"
+msgstr "スクリプト/情報"
+
+#: id:12005
+msgid "Fullscreen video"
+msgstr "フルスクリーンビデオ"
+
+#: id:12006
+msgid "Audio visualization"
+msgstr "オーディオ視覚エフェクト"
+
+#: id:12008
+msgid "File stacking dialog"
+msgstr "ファイルスタッキング ダイアログ"
+
+#: id:12009
+msgid "Rebuild index..."
+msgstr "インデクスの再構築..."
+
+#: id:12010
+msgid "Return to music window"
+msgstr "ミュージックのウィンドウに戻る"
+
+#: id:12011
+msgid "Return to videos window"
+msgstr "ビデオのウィンドウに戻る"
+
+#: id:12021
+msgid "Start from beginning"
+msgstr "最初から再生"
+
+#: id:12022
+msgid "Resume from %s"
+msgstr "%s から再開"
+
+#: id:12310
+msgid "0"
+msgstr "0"
+
+#: id:12311
+msgid "1"
+msgstr "1"
+
+#: id:12312
+msgid "2"
+msgstr "2"
+
+#: id:12313
+msgid "3"
+msgstr "3"
+
+#: id:12314
+msgid "4"
+msgstr "4"
+
+#: id:12315
+msgid "5"
+msgstr "5"
+
+#: id:12316
+msgid "6"
+msgstr "6"
+
+#: id:12317
+msgid "7"
+msgstr "7"
+
+#: id:12318
+msgid "8"
+msgstr "8"
+
+#: id:12319
+msgid "9"
+msgstr "9"
+
+#: id:12320
+msgid "c"
+msgstr "c"
+
+#: id:12321
+msgid "Ok"
+msgstr "ok"
+
+#: id:12322
+msgid "*"
+msgstr "*"
+
+#: id:12325
+msgid "Locked! Enter code..."
+msgstr "ロック中！コードを入力してください"
+
+#: id:12326
+msgid "Enter password"
+msgstr "パスワード入力"
+
+#: id:12327
+msgid "Enter master code"
+msgstr "マスターコード入力"
+
+#: id:12328
+msgid "Enter unlock code"
+msgstr "アンロックコード入力"
+
+#: id:12329
+msgid "or press C to cancel"
+msgstr "C を押すとキャンセル"
+
+#: id:12330
+msgid "Enter gamepad button combo and"
+msgstr "ボタンパスワードを入力し"
+
+#: id:12331
+msgid "press OK, or Back to cancel"
+msgstr "Start を押してください。Back でキャンセル"
+
+#: id:12332
+msgid "Set lock"
+msgstr "セット ロック"
+
+#: id:12333
+msgid "Unlock"
+msgstr "アンロック"
+
+#: id:12334
+msgid "Reset lock"
+msgstr "リセット ロック"
+
+#: id:12335
+msgid "Remove lock"
+msgstr "ロック削除"
+
+#: id:12337
+msgid "Numeric password"
+msgstr "数字パスワード"
+
+#: id:12338
+msgid "Gamepad button combo"
+msgstr "ボタンパスワード"
+
+#: id:12339
+msgid "Full-text password"
+msgstr "テキストパスワード"
+
+#: id:12340
+msgid "Enter new password"
+msgstr "新しいパスワードを入力"
+
+#: id:12341
+msgid "Re-Enter new password"
+msgstr "新しいパスワードを再入力"
+
+#: id:12342
+msgid "Incorrect password,"
+msgstr "パスワードが正しくありません"
+
+#: id:12343
+msgid "retries left"
+msgstr "リトライ　停止"
+
+#: id:12344
+msgid "Passwords entered did not match."
+msgstr "パスワードが合いません"
+
+#: id:12345
+msgid "Access denied"
+msgstr "アクセスが否定されます"
+
+#: id:12346
+msgid "Password retry limit exceeded."
+msgstr "パスワードリトライ回数の限界を超えました"
+
+#: id:12347
+msgid "The system will now shut off."
+msgstr "システムを停止します"
+
+#: id:12348
+msgid "Item locked"
+msgstr "アイテム ロック"
+
+#: id:12353
+msgid "Reactivate lock"
+msgstr "シェアロックが復活します"
+
+#: id:12356
+msgid "Change lock"
+msgstr "ロック変更"
+
+#: id:12357
+msgid "Source lock"
+msgstr "Source Lock"
+
+#: id:12358
+msgid "Password entry was blank. Try again."
+msgstr "パスワードが未記入です 再び試みてください"
+
+#: id:12360
+msgid "Master lock"
+msgstr "マスターロック"
+
+#: id:12362
+msgid "Shutdown system if Master Lock retries exceeded"
+msgstr "パスワードリトライ回数の限界を超えたらシステムをシャットダウンする"
+
+#: id:12367
+msgid "Master code is not valid"
+msgstr "マスターコードが有効ではありません"
+
+#: id:12368
+msgid "Please enter a valid master code"
+msgstr "正しいマスターコードを入力して下さい"
+
+#: id:12373
+msgid "Settings & file manager"
+msgstr "設定 & ファイルマネージャー"
+
+#: id:12376
+msgid "Set as default for all movies"
+msgstr "全ビデオ再生のデフォルト値に設定"
+
+#: id:12377
+msgid "This will reset any previously saved values"
+msgstr "過去の設定値はリセットされます"
+
+#: id:12378
+msgid "Amount of time to display each image"
+msgstr "一枚の表示時間"
+
+#: id:12379
+msgid "Use pan and zoom effects"
+msgstr "パン/ズームエフェクトの使用"
+
+#: id:12383
+msgid "12 hour clock"
+msgstr "12時間時計"
+
+#: id:12384
+msgid "24 hour clock"
+msgstr "24時間時計"
+
+#: id:12385
+msgid "Day/Month"
+msgstr "日/月"
+
+#: id:12386
+msgid "Month/Day"
+msgstr "月/日"
+
+#: id:12390
+msgid "System uptime"
+msgstr "システム稼動時間"
+
+#: id:12391
+msgid "Minutes"
+msgstr "分"
+
+#: id:12392
+msgid "Hours"
+msgstr "時間"
+
+#: id:12393
+msgid "Days"
+msgstr "日"
+
+#: id:12394
+msgid "Total uptime"
+msgstr "合計稼働時間"
+
+#: id:12395
+msgid "Battery level"
+msgstr "バッテリーレベル"
+
+#: id:12600
+msgctxt "Auto context with id 12600"
+msgid "Weather"
+msgstr "天気予報"
+
+#: id:12900
+msgctxt "Auto context with id 12900"
+msgid "Screensaver"
+msgstr "スクリーンセーバー"
+
+#: id:12901
+msgid "Fullscreen OSD"
+msgstr "フルスクリーンOSD"
+
+#: id:13000
+msgid "System"
+msgstr "システム"
+
+#: id:13001
+msgid "Immediate HD spindown"
+msgstr "HDD の停止"
+
+#: id:13002
+msgid "Video only"
+msgstr "ビデオのみ"
+
+#: id:13003
+msgid "- Delay"
+msgstr "- 停止までの遅延時間"
+
+#: id:13004
+msgid "- Minimum file duration"
+msgstr "- この時間より長い再生は遅延時間後に停止"
+
+#: id:13005
+msgid "Shutdown"
+msgstr "シャットダウン"
+
+#: id:13008
+msgid "Shutdown function"
+msgstr "シャットダウン機能"
+
+#: id:13009
+msgid "Quit"
+msgstr "終了"
+
+#: id:13010
+msgid "Hibernate"
+msgstr "ハイバネート"
+
+#: id:13011
+msgid "Suspend"
+msgstr "サスペンド"
+
+#: id:13012
+msgid "Exit"
+msgstr "終了"
+
+#: id:13013
+msgid "Reboot"
+msgstr "再起動"
+
+#: id:13014
+msgid "Minimize"
+msgstr "最小化"
+
+#: id:13015
+msgid "Power button action"
+msgstr "電源ボタンを押した際の動作"
+
+#: id:13016
+msgid "Power off System"
+msgstr "システム終了・電源を切る"
+
+#: id:13020
+msgid "Is another session active, perhaps over ssh?"
+msgstr "別のセッションが動作中です（ssh 経由かも?)"
+
+#: id:13021
+msgid "Mounted removable harddrive"
+msgstr "リムーバブル HDD をマウントしました"
+
+#: id:13022
+msgid "Unsafe device removal"
+msgstr "安全でないデバイスの取り外し"
+
+#: id:13023
+msgid "Successfully removed device"
+msgstr "デバイスが正しく外されました"
+
+#: id:13024
+msgid "Joystick plugged"
+msgstr "ジョイスティックが接続されました"
+
+#: id:13025
+msgid "Joystick unplugged"
+msgstr "ジョイスティックが外されました"
+
+#: id:13050
+msgid "Running low on battery"
+msgstr "バッテリ残量が少なくなっています"
+
+#: id:13100
+msgid "Flicker filter"
+msgstr "フリッカーフィルタ"
+
+#: id:13101
+msgid "Let driver choose (requires restart)"
+msgstr "ドライバに任せる (再起動が必要)"
+
+#: id:13105
+msgid "Vertical blank sync"
+msgstr "Vertical Blank の同期方法"
+
+#: id:13106
+msgctxt "Auto context with id 13106"
+msgid "Disabled"
+msgstr "無効"
+
+#: id:13107
+msgid "Enabled during video playback"
+msgstr "ビデオ再生中のみ有効"
+
+#: id:13108
+msgctxt "Auto context with id 13108"
+msgid "Always enabled"
+msgstr "常に有効"
+
+#: id:13109
+msgid "Test & apply resolution"
+msgstr ""
+
+#: id:13110
+msgid "Save resolution?"
+msgstr ""
+
+#: id:13111
+msgid "Would you like to keep this resolution?"
+msgstr "この解像度を保持しますか?"
+
+#: id:13112
+msgid "High quality upscaling"
+msgstr "高品質アップコンバート"
+
+#: id:13113
+msgctxt "Auto context with id 13113"
+msgid "Disabled"
+msgstr "無効"
+
+#: id:13114
+msgid "Enabled for SD content"
+msgstr "SD 画質のコンテンツにのみ有効"
+
+#: id:13115
+msgctxt "Auto context with id 13115"
+msgid "Always enabled"
+msgstr "常に有効"
+
+#: id:13116
+msgid "Upscaling method"
+msgstr "アップコンバートの方式"
+
+#: id:13117
+msgctxt "Auto context with id 13117"
+msgid "Bicubic"
+msgstr "Bicubic"
+
+#: id:13118
+msgid "Lanczos"
+msgstr "Lanczos"
+
+#: id:13119
+msgid "Sinc"
+msgstr "Sinc"
+
+#: id:13120
+msgctxt "Auto context with id 13120"
+msgid "VDPAU"
+msgstr "VDPAU"
+
+#: id:13121
+msgid "VDPAU HQ Upscaling level"
+msgstr "VDPAU HQ Upscaling level"
+
+#: id:13122
+msgid "VDPAU Studio level color conversion"
+msgstr "VDPAU Studio level color conversion"
+
+#: id:13130
+msgid "Blank other displays"
+msgstr ""
+
+#: id:13131
+msgctxt "Auto context with id 13131"
+msgid "Disabled"
+msgstr ""
+
+#: id:13132
+msgid "Blank displays"
+msgstr ""
+
+#: id:13140
+msgid "Active connections detected!"
+msgstr "Active Connections Detected!"
+
+#: id:13141
+msgid "If you proceed, you might not be able to control XBMC"
+msgstr "If you proceed, you might not be able to control XBMC"
+
+#: id:13142
+msgid "any longer. Are you sure you want to stop the Event server?"
+msgstr "any longer. Are you sure you to stop the Event Server?"
+
+#: id:13144
+msgid "Change Apple Remote mode?"
+msgstr "Change Apple Remote Mode?"
+
+#: id:13145
+msgid "If you are currently using the Apple Remote to control"
+msgstr "If you are currently using the Apple Remote to control"
+
+#: id:13146
+msgid "XBMC, changing this setting might affect your ability"
+msgstr "XBMC, changing this setting might affect your ability"
+
+#: id:13147
+msgid "to continue controlling it. Do you want to proceed?"
+msgstr "to continue controlling it. Do you want to proceed?"
+
+#: id:13159
+msgid "Subnet mask"
+msgstr "サブネットマスク"
+
+#: id:13160
+msgid "Gateway"
+msgstr "デフォルトゲートウェイ"
+
+#: id:13161
+msgid "Primary DNS"
+msgstr "プライマリ DNS"
+
+#: id:13162
+msgid "Initialize failed"
+msgstr "初期化に失敗"
+
+#: id:13170
+msgctxt "Auto context with id 13170"
+msgid "Never"
+msgstr "Never"
+
+#: id:13171
+msgid "Immediately"
+msgstr "Immediately"
+
+#: id:13172
+msgid "After %i secs"
+msgstr "After %i secs"
+
+#: id:13173
+msgid "HDD install date:"
+msgstr "HDD Install Date:"
+
+#: id:13174
+msgid "HDD power cycle count:"
+msgstr "HDD Power Cycle Count:"
+
+#: id:13200
+msgid "Profiles"
+msgstr "プロファイル"
+
+#: id:13201
+msgid "Delete profile '%s'?"
+msgstr "プロファイル '%s' を削除しますか?"
+
+#: id:13204
+msgid "Last loaded profile:"
+msgstr "最後にロードしたプロファイル:"
+
+#: id:13205
+msgid "Unknown"
+msgstr "不明"
+
+#: id:13206
+msgid "Overwrite"
+msgstr "上書き"
+
+#: id:13208
+msgid "Alarm clock"
+msgstr "アラーム クロック"
+
+#: id:13209
+msgid "Alarm clock interval (in minutes)"
+msgstr "アラーム クロック 間隔 (分)"
+
+#: id:13210
+msgid "Started, alarm in %im"
+msgstr "%i 分後にアラームが作動します"
+
+#: id:13211
+msgid "Alarm!"
+msgstr "アラーム!"
+
+#: id:13212
+msgid "Canceled with %im%is left"
+msgstr "残り%i分%i秒でキャンセルされました"
+
+#: id:13213
+msgid "%2.0fm"
+msgstr "%2.0f分"
+
+#: id:13214
+msgid "%2.0fs"
+msgstr "%2.0f秒"
+
+#: id:13249
+msgid "Search for subtitles in RARs"
+msgstr "RARファイル内から字幕を探す"
+
+#: id:13250
+msgid "Browse for subtitle..."
+msgstr "字幕を参照する..."
+
+#: id:13251
+msgid "Move item"
+msgstr "アイテムの移動"
+
+#: id:13252
+msgid "Move item here"
+msgstr "アイテムをここに移動"
+
+#: id:13253
+msgid "Cancel move"
+msgstr "移動のキャンセル"
+
+#: id:13270
+msgid "Hardware:"
+msgstr "ハードウェア:"
+
+#: id:13271
+msgid "CPU Usage:"
+msgstr "CPU 使用率:"
+
+#: id:13274
+msgid "Connected, but no DNS is available."
+msgstr "接続しましたが、DNS がありません。"
+
+#: id:13275
+msgid "Hard Disk"
+msgstr "ハードディスク"
+
+#: id:13276
+msgid "DVD-ROM"
+msgstr "DVD-ROM"
+
+#: id:13277
+msgctxt "Auto context with id 13277"
+msgid "Storage"
+msgstr "ストレージ"
+
+#: id:13278
+msgctxt "Auto context with id 13278"
+msgid "Default"
+msgstr "デフォルト"
+
+#: id:13279
+msgctxt "Auto context with id 13279"
+msgid "Network"
+msgstr "ネットワーク"
+
+#: id:13280
+msgctxt "Auto context with id 13280"
+msgid "Video"
+msgstr "ビデオ"
+
+#: id:13281
+msgid "Hardware"
+msgstr "ハードウェア"
+
+#: id:13283
+msgid "Operating system:"
+msgstr "オペレーティング システム:"
+
+#: id:13284
+msgid "CPU speed:"
+msgstr "CPU 速度:"
+
+#: id:13286
+msgid "Video encoder:"
+msgstr "ビデオエンコーダー:"
+
+#: id:13287
+msgid "Screen resolution:"
+msgstr "画面解像度:"
+
+#: id:13292
+msgid "A/V cable:"
+msgstr "A/V ケーブル:"
+
+#: id:13294
+msgid "DVD region:"
+msgstr "DVD リージョン(地域):"
+
+#: id:13295
+msgid "Internet:"
+msgstr "インターネット:"
+
+#: id:13296
+msgctxt "Auto context with id 13296"
+msgid "Connected"
+msgstr "接続済み"
+
+#: id:13297
+msgid "Not connected. Check network settings."
+msgstr "接続されていません。ネットワーク設定を確認してください。"
+
+#: id:13299
+msgid "Target temperature"
+msgstr "目標温度"
+
+#: id:13300
+msgid "Fan speed"
+msgstr "ファンスピード"
+
+#: id:13301
+msgid "Auto temperature control"
+msgstr "自動温度コントロール"
+
+#: id:13302
+msgid "Fan speed override"
+msgstr "ファンスピード制御"
+
+#: id:13303
+msgid "- Fonts"
+msgstr "- フォント"
+
+#: id:13304
+msgid "Enable flipping bi-directional strings"
+msgstr "Flipping 双方向ストリングスを有効化"
+
+#: id:13305
+msgid "Show RSS news feeds"
+msgstr "RSS フィードを有効化"
+
+#: id:13306
+msgid "Show parent folder items"
+msgstr "親フォルダーの項目を表示する"
+
+#: id:13307
+msgid "Track naming template"
+msgstr "トラック命名テンプレート"
+
+#: id:13308
+msgid "Do you wish to reboot your system"
+msgstr "システムを再起動しますか?"
+
+#: id:13309
+msgid "instead of just XBMC?"
+msgstr "XBMC の再起動ではありません"
+
+#: id:13310
+msgid "Zoom effect"
+msgstr "ズーム エフェクト"
+
+#: id:13311
+msgid "Float effect"
+msgstr "フロート エフェクト"
+
+#: id:13312
+msgid "Black bar reduction"
+msgstr "ブラックバー 縮小"
+
+#: id:13313
+msgid "Restart"
+msgstr "リスタート"
+
+#: id:13314
+msgid "Crossfade between songs"
+msgstr "クロスフェード"
+
+#: id:13315
+msgid "Regenerate thumbnails"
+msgstr "サムネイルの再作成"
+
+#: id:13316
+msgid "Recursive thumbnails"
+msgstr "サムネイル(複数)の作成"
+
+#: id:13317
+msgid "View slideshow"
+msgstr "ビュー スライドショー"
+
+#: id:13318
+msgid "Recursive slideshow"
+msgstr "スライドショー繰返し"
+
+#: id:13319
+msgid "Randomize"
+msgstr "ランダム化"
+
+#: id:13320
+msgid "Stereo"
+msgstr "ステレオ"
+
+#: id:13321
+msgid "Left only"
+msgstr "左のみ"
+
+#: id:13322
+msgid "Right only"
+msgstr "右のみ"
+
+#: id:13323
+msgid "Enable karaoke support"
+msgstr "CD+G 再生有効化"
+
+#: id:13324
+msgid "Background transparency"
+msgstr "バックグラウンド透明"
+
+#: id:13325
+msgid "Foreground transparency"
+msgstr "フォアグラウンド透明"
+
+#: id:13326
+msgid "A/V delay"
+msgstr "A/V 遅延"
+
+#: id:13327
+msgid "Karaoke"
+msgstr "カラオケ"
+
+#: id:13328
+msgid "%s not found"
+msgstr "%s が見つかりません"
+
+#: id:13329
+msgid "Error opening %s"
+msgstr "%s を開く際にエラー"
+
+#: id:13330
+msgid "Unable to load %s"
+msgstr "％がロードできません"
+
+#: id:13331
+msgid "Error: Out of memory"
+msgstr "エラー: メモリー不足"
+
+#: id:13332
+msgid "Move up"
+msgstr "上へ"
+
+#: id:13333
+msgid "Move down"
+msgstr "下へ"
+
+#: id:13334
+msgid "Edit label"
+msgstr "ラベル編集"
+
+#: id:13335
+msgid "Make default"
+msgstr "デフォルトに設定"
+
+#: id:13336
+msgid "Remove button"
+msgstr "削除ボタン"
+
+#: id:13340
+msgid "Leave as is"
+msgstr "現状"
+
+#: id:13341
+msgid "Green"
+msgstr "緑"
+
+#: id:13342
+msgid "Orange"
+msgstr "橙"
+
+#: id:13343
+msgid "Red"
+msgstr "赤"
+
+#: id:13344
+msgid "Cycle"
+msgstr "サイクル"
+
+#: id:13345
+msgid "Switch LED off on playback"
+msgstr "再生でLED の ON/OFF をする"
+
+#: id:13346
+msgctxt "Auto context with id 13346"
+msgid "Movie information"
+msgstr "映画情報"
+
+#: id:13347
+msgid "Queue item"
+msgstr "キュー項目"
+
+#: id:13348
+msgid "Search IMDb..."
+msgstr "IMDb を検索..."
+
+#: id:13349
+msgid "Scan for new content"
+msgstr "新しいコンテンツをスキャン"
+
+#: id:13350
+msgid "Now playing..."
+msgstr "プレイ中..."
+
+#: id:13351
+msgctxt "Auto context with id 13351"
+msgid "Album information"
+msgstr "アルバム情報"
+
+#: id:13352
+msgid "Scan item to library"
+msgstr "ライブラリへ追加"
+
+#: id:13353
+msgid "Stop scanning"
+msgstr "スキャン停止"
+
+#: id:13354
+msgctxt "Auto context with id 13354"
+msgid "Render method"
+msgstr "描画方法:"
+
+#: id:13355
+msgid "Low quality pixel shader"
+msgstr "低品質ピクセルシェーダ"
+
+#: id:13356
+msgid "Hardware overlays"
+msgstr "ハードウェア オーバーレイ"
+
+#: id:13357
+msgid "High quality pixel shader"
+msgstr "高品質ピクセルシェーダ"
+
+#: id:13358
+msgid "Play item"
+msgstr "項目再生"
+
+#: id:13359
+msgid "Set artist thumb"
+msgstr "アーティストサムネイル指定"
+
+#: id:13360
+msgid "Automatically generate thumbnails"
+msgstr "サムネイルを自動で作成"
+
+#: id:13361
+msgid "Enable voice"
+msgstr "音声有効化"
+
+#: id:13375
+msgid "Enable device"
+msgstr "デバイス有効化"
+
+#: id:13376
+msgid "Volume"
+msgstr "ボリューム"
+
+#: id:13377
+msgid "Default view mode"
+msgstr "デフォルト 表示モード"
+
+#: id:13378
+msgid "Default brightness"
+msgstr "デフォルト 輝度"
+
+#: id:13379
+msgid "Default contrast"
+msgstr "デフォルト コントラスト"
+
+#: id:13380
+msgid "Default gamma"
+msgstr "デフォルト ガンマ"
+
+#: id:13381
+msgid "Resume video"
+msgstr "最後に停止した位置からビデオを再生"
+
+#: id:13382
+msgid "Voice mask - Port 1"
+msgstr "Voice Mask - Port 1"
+
+#: id:13383
+msgid "Voice mask - Port 2"
+msgstr "Voice Mask - Port 2"
+
+#: id:13384
+msgid "Voice mask - Port 3"
+msgstr "Voice Mask - Port 3"
+
+#: id:13385
+msgid "Voice mask - Port 4"
+msgstr "Voice Mask - Port 4"
+
+#: id:13386
+msgid "Use time based seeking"
+msgstr "タイムベースシーク使用"
+
+#: id:13387
+msgid "Track naming template - right"
+msgstr "トラック名 詳細情報 表示"
+
+#: id:13388
+msgid "Preset"
+msgstr "プリセット"
+
+#: id:13389
+msgid "There are no presets available\nfor this visualization"
+msgstr "プリセットが有効な視覚エフェクトではありません"
+
+#: id:13390
+msgid "There are no settings available\nfor this visualization"
+msgstr "設定が有効な視覚エフェクトではありません"
+
+#: id:13391
+msgid "Eject/Load"
+msgstr "イジェクト/ロード"
+
+#: id:13392
+msgid "Use visualization if playing audio"
+msgstr "音楽再生時 視覚エフェクト使用"
+
+#: id:13393
+msgid "Calculate size"
+msgstr "容量算出"
+
+#: id:13394
+msgid "Calculating folder size"
+msgstr "フォルダー容量算出"
+
+#: id:13395
+msgid "Video settings"
+msgstr "ビデオ 設定"
+
+#: id:13396
+msgid "Audio and subtitle settings"
+msgstr "オーディオ･字幕 設定"
+
+#: id:13397
+msgid "Enable subtitles"
+msgstr "字幕有効化"
+
+#: id:13398
+msgctxt "Auto context with id 13398"
+msgid "Shortcuts"
+msgstr "ショートカット"
+
+#: id:13399
+msgid "Ignore articles when sorting (e.g. \"the\")"
+msgstr "冠詞 (the など) を無視して並べ替えを行う"
+
+#: id:13400
+msgid "Crossfade between songs on the same album"
+msgstr "アルバム内クロスフェード"
+
+#: id:13401
+msgid "Browse for %s"
+msgstr "%s を参照"
+
+#: id:13402
+msgid "Show track position"
+msgstr "Show track position"
+
+#: id:13403
+msgid "Clear default"
+msgstr "デフォルトをクリア"
+
+#: id:13404
+msgid "Resume"
+msgstr "再開"
+
+#: id:13405
+msgid "Get thumb"
+msgstr "サムネイルを取得"
+
+#: id:13406
+msgid "Picture information"
+msgstr "画像情報"
+
+#: id:13407
+msgid "%s presets"
+msgstr "%s プリセット"
+
+#: id:13408
+msgid "(IMDb user rating)"
+msgstr "(IMDb ユーザによる評価)"
+
+#: id:13409
+msgid "Top 250"
+msgstr "Top 250"
+
+#: id:13410
+msgid "Tune in on Last.fm"
+msgstr "Tune in on Last.fm"
+
+#: id:13411
+msgid "Minimum fan speed"
+msgstr "最低ファン速度"
+
+#: id:13412
+msgid "Play from here"
+msgstr ""
+
+#: id:13413
+msgid "Downloading"
+msgstr "ダウンロード中"
+
+#: id:13414
+msgid "Include artists who appear only on compilations"
+msgstr "コンピレーションのみに登場するアーティストを含める"
+
+#: id:13415
+msgctxt "Auto context with id 13415"
+msgid "Render method"
+msgstr "レンダリング方法"
+
+#: id:13416
+msgid "Auto detect"
+msgstr "自動検出"
+
+#: id:13417
+msgid "Basic shaders (ARB)"
+msgstr "ベーシック (ARB)"
+
+#: id:13418
+msgid "Advanced shaders (GLSL)"
+msgstr "アドバンスト (GLSL)"
+
+#: id:13419
+msgid "Software"
+msgstr "ソフトウェア"
+
+#: id:13420
+msgid "Remove safely"
+msgstr "安全に削除"
+
+#: id:13421
+msgctxt "Auto context with id 13421"
+msgid "VDPAU"
+msgstr "VDPAU"
+
+#: id:13422
+msgid "Start slideshow here"
+msgstr "ここからスライドショーを開始"
+
+#: id:13423
+msgid "Remember for this path"
+msgstr "このパス用に記憶"
+
+#: id:13424
+msgid "Use pixel buffer objects"
+msgstr "ピクセルバッファーオブジェクトを使用"
+
+#: id:13425
+msgid "Allow hardware acceleration (VDPAU)"
+msgstr "ハードウェア アクセラレータを許可 (VDPAU)"
+
+#: id:13426
+msgid "Allow hardware acceleration (VAAPI)"
+msgstr "ハードウェア アクセラレータを許可 (VAAPI)"
+
+#: id:13427
+msgid "Allow hardware acceleration (DXVA2)"
+msgstr "ハードウェア アクセラレータを許可 (DXVA2)"
+
+#: id:13428
+msgid "Allow hardware acceleration (CrystalHD)"
+msgstr "ハードウェア アクセラレータを許可 (CrystalHD)"
+
+#: id:13429
+msgid "Allow hardware acceleration (VDADecoder)"
+msgstr "ハードウェア アクセラレータを許可 (VDADecoder)"
+
+#: id:13430
+msgid "Allow hardware acceleration (OpenMax)"
+msgstr "ハードウェア アクセラレータを許可 (OpenMax)"
+
+#: id:13431
+msgid "Pixel Shaders"
+msgstr "ピクセル シェーダー"
+
+#: id:13432
+msgid "Allow hardware acceleration (VideoToolbox)"
+msgstr "ハードウェア アクセラレータを許可 (VideoToolbox)"
+
+#: id:13500
+msgid "A/V sync method"
+msgstr "A/V 同期方法"
+
+#: id:13501
+msgid "Audio clock"
+msgstr "オーディオクロック"
+
+#: id:13502
+msgid "Video clock (Drop/Dupe audio)"
+msgstr "ビデオクロック (オーディオ側をあわせる)"
+
+#: id:13503
+msgid "Video clock (Resample audio)"
+msgstr "ビデオクロック (オーディオを再サンプリングする)"
+
+#: id:13504
+msgid "Maximum resample amount (%)"
+msgstr "最大再サンプリング量 (%)"
+
+#: id:13505
+msgid "Resample quality"
+msgstr "再サンプリング品質"
+
+#: id:13506
+msgid "Low(fast)"
+msgstr "低 (高速)"
+
+#: id:13507
+msgctxt "Auto context with id 13507"
+msgid "Medium"
+msgstr "中"
+
+#: id:13508
+msgctxt "Auto context with id 13508"
+msgid "High"
+msgstr "高"
+
+#: id:13509
+msgid "Really high(slow!)"
+msgstr "最高 (遅い!)"
+
+#: id:13510
+msgid "Sync playback to display"
+msgstr "ディスプレイ同期周波数に合わせて再生"
+
+#: id:13550
+msgid "Pause during refresh rate change"
+msgstr ""
+
+#: id:13551
+msgctxt "Auto context with id 13551"
+msgid "Off"
+msgstr ""
+
+#: id:13552
+msgid "%.1f Second"
+msgstr ""
+
+#: id:13553
+msgid "%.1f Seconds"
+msgstr ""
+
+#: id:13600
+msgid "Apple remote"
+msgstr "Apple Remote"
+
+#: id:13602
+msgid "Allow start of XBMC using the remote"
+msgstr "リモコンからの XBMC の起動を許可"
+
+#: id:13603
+msgid "Sequence delay time"
+msgstr "Sequence delay time"
+
+#: id:13610
+msgctxt "Auto context with id 13610"
+msgid "Disabled"
+msgstr "無効"
+
+#: id:13611
+msgctxt "Auto context with id 13611"
+msgid "Standard"
+msgstr "標準"
+
+#: id:13612
+msgid "Universal Remote"
+msgstr "汎用リモコン"
+
+#: id:13613
+msgid "Multi Remote (Harmony)"
+msgstr ""
+
+#: id:13620
+msgid "Apple Remote Error"
+msgstr "Apple Remote エラー"
+
+#: id:13621
+msgid "Apple Remote support could be enabled."
+msgstr "Apple Remote サポートを有効にできません。"
+
+#: id:14000
+msgid "Stack"
+msgstr "スタック"
+
+#: id:14001
+msgid "Unstack"
+msgstr "スタック解除"
+
+#: id:14003
+msgid "Downloading playlist file..."
+msgstr "プレイリストファイルの取得中..."
+
+#: id:14004
+msgid "Downloading streams list..."
+msgstr "ストリームリストを取得中..."
+
+#: id:14005
+msgid "Parsing streams list..."
+msgstr "ストリームリストを解析中..."
+
+#: id:14006
+msgid "Downloading streams list failed"
+msgstr "ストリームリストの取得に失敗"
+
+#: id:14007
+msgid "Downloading playlist file failed"
+msgstr "プレイリストファイルの取得に失敗"
+
+#: id:14009
+msgid "Games directory"
+msgstr "ゲームディレクトリ"
+
+#: id:14010
+msgid "Auto switch to thumbs based on"
+msgstr "サムネイル表示の自動切換"
+
+#: id:14011
+msgid "Enable auto switching to thumbs view"
+msgstr "サムネイル表示の自動切換を有効化"
+
+#: id:14012
+msgid "- Use large icons"
+msgstr "- 大きなアイコンの使用"
+
+#: id:14013
+msgid "- Switch based on"
+msgstr "- 方法"
+
+#: id:14014
+msgid "- Percentage"
+msgstr "- 割合(%)"
+
+#: id:14015
+msgid "No files and at least one thumb"
+msgstr ""
+
+#: id:14016
+msgid "At least one file and thumb"
+msgstr ""
+
+#: id:14017
+msgid "Percentage of thumbs"
+msgstr "サムネイル表示の割合"
+
+#: id:14018
+msgid "View options"
+msgstr "表示オプション"
+
+#: id:14019
+msgid "Change area code 1"
+msgstr "エリアコード 1"
+
+#: id:14020
+msgid "Change area code 2"
+msgstr "エリアコード 2"
+
+#: id:14021
+msgid "Change area code 3"
+msgstr "エリアコード 3"
+
+#: id:14022
+msgctxt "Auto context with id 14022"
+msgid "Library"
+msgstr "ライブラリ"
+
+#: id:14023
+msgid "No TV"
+msgstr "No TV"
+
+#: id:14024
+msgid "Enter the nearest large town"
+msgstr "最も近くの大都市名を入力"
+
+#: id:14025
+msgid "Video/Audio/DVD cache - Harddisk"
+msgstr "ビデオ/オーディオ/DVD キャッシュ - HDD"
+
+#: id:14026
+msgid "Video cache - DVD-ROM"
+msgstr "ビデオ キャッシュ - DVD-ROM"
+
+#: id:14027
+msgctxt "Auto context with id 14027"
+msgid "- Local Network"
+msgstr "- LAN"
+
+#: id:14028
+msgctxt "Auto context with id 14028"
+msgid "- Internet"
+msgstr "- インターネット"
+
+#: id:14030
+msgid "Audio cache - DVD-ROM"
+msgstr "オーディオ キャッシュ - DVD-ROM"
+
+#: id:14031
+msgctxt "Auto context with id 14031"
+msgid "- Local Network"
+msgstr "オーディオ キャッシュ - LAN"
+
+#: id:14032
+msgctxt "Auto context with id 14032"
+msgid "- Internet"
+msgstr "オーディオ キャッシュ - インターネット"
+
+#: id:14034
+msgid "DVD cache - DVD-ROM"
+msgstr "DVD キャッシュ - DVD-ROM"
+
+#: id:14035
+msgctxt "Auto context with id 14035"
+msgid "- Local Network"
+msgstr "DVD キャッシュ - LAN"
+
+#: id:14036
+msgctxt "Auto context with id 14036"
+msgid "Services"
+msgstr "サーバー"
+
+#: id:14038
+msgid "Network settings changed"
+msgstr "ネットワーク設定が変更されました"
+
+#: id:14039
+msgid "XBMC requires to restart to change your"
+msgstr "ネットワーク設定の変更を反映するには"
+
+#: id:14040
+msgid "network setup. Would you like to restart now?"
+msgstr "再起動が必要です。 今すぐ再始動しますか？"
+
+#: id:14041
+msgid "Internet connection bandwidth limitation"
+msgstr "インターネット接続の帯域制限"
+
+#: id:14043
+msgid "- Shutdown while playing"
+msgstr "- プレー中でもシャットダウン"
+
+#: id:14044
+msgid "%i min"
+msgstr "%i 分"
+
+#: id:14045
+msgid "%i sec"
+msgstr "%i 秒"
+
+#: id:14046
+msgid "%i ms"
+msgstr "%i ミリ秒"
+
+#: id:14047
+msgid "%i %%"
+msgstr "%i %%"
+
+#: id:14048
+msgid "%i kbps"
+msgstr "%i kbps"
+
+#: id:14049
+msgid "%i kb"
+msgstr "%i kb"
+
+#: id:14050
+msgid "%i.0 dB"
+msgstr "%i.0 dB"
+
+#: id:14051
+msgid "Time format"
+msgstr "時刻のフォーマット"
+
+#: id:14052
+msgid "Date format"
+msgstr "日付のフォーマット"
+
+#: id:14053
+msgid "GUI filters"
+msgstr "GUI フィルター"
+
+#: id:14055
+msgid "Use background scanning"
+msgstr "バックグラウンドスキャンの使用"
+
+#: id:14056
+msgid "Stop scan"
+msgstr "スキャン停止"
+
+#: id:14057
+msgid "Not possible while scanning for media info"
+msgstr "メディア情報スキャン中は不可能"
+
+#: id:14058
+msgid "Film grain effect"
+msgstr "フィルム粒子エフェクト"
+
+#: id:14059
+msgid "Search for thumbnails on remote shares"
+msgstr "リモート共有上でサムネールを使う"
+
+#: id:14060
+msgid "Unknown type cache - Internet"
+msgstr "不明なキャッシュ - インターネット"
+
+#: id:14061
+msgctxt "Auto context with id 14061"
+msgid "Auto"
+msgstr "自動"
+
+#: id:14062
+msgid "Enter username for"
+msgstr "ユーザー名入力"
+
+#: id:14063
+msgid "Date & time"
+msgstr "日付 & 時間"
+
+#: id:14064
+msgid "Set date"
+msgstr "日付の設定"
+
+#: id:14065
+msgid "Set time"
+msgstr "時刻の設定"
+
+#: id:14066
+msgid "Enter the time in 24 hour HH:MM format"
+msgstr "24時間表示 時:分 で入力"
+
+#: id:14067
+msgid "Enter the date in DD/MM/YYYY format"
+msgstr "日付 日/月/年 で入力"
+
+#: id:14068
+msgid "Enter the IP address"
+msgstr "IP アドレスを入力"
+
+#: id:14069
+msgid "Apply these settings now?"
+msgstr "この設定を適用しますか?"
+
+#: id:14070
+msgid "Apply changes now"
+msgstr "設定適用"
+
+#: id:14071
+msgid "Allow file renaming and deletion"
+msgstr "ファイル名変更・削除 許可"
+
+#: id:14074
+msgid "Set timezone"
+msgstr "タイムゾーン設定"
+
+#: id:14075
+msgid "Use daylight saving time"
+msgstr "サマータイム有効化"
+
+#: id:14076
+msgid "Add to favourites"
+msgstr "お気に入りに追加"
+
+#: id:14077
+msgid "Remove from favourites"
+msgstr "お気に入りから削除"
+
+#: id:14078
+msgctxt "Auto context with id 14078"
+msgid "- Colours"
+msgstr "- スキンカラー"
+
+#: id:14079
+msgid "Timezone country"
+msgstr "タイムゾーン(国)"
+
+#: id:14080
+msgid "Timezone"
+msgstr "タイムゾーン"
+
+#: id:14081
+msgid "File lists"
+msgstr "ファイルリスト"
+
+#: id:14082
+msgid "Show EXIF picture information"
+msgstr "EXIF 情報を表示"
+
+#: id:14083
+msgid "Use a fullscreen window rather than true fullscreen"
+msgstr "フルスクリーンウィンドウの使用 (「フルスクリーン」ではなく)"
+
+#: id:14084
+msgid "Queue songs on selection"
+msgstr "選択した曲をキューに入れる"
+
+#: id:14086
+msgid "Playback"
+msgstr "再生"
+
+#: id:14087
+msgid "DVDs"
+msgstr "DVD"
+
+#: id:14088
+msgid "Play DVDs automatically"
+msgstr "DVD を自動的に再生する"
+
+#: id:14089
+msgid "Font to use for text subtitles"
+msgstr "字幕に使用するフォント"
+
+#: id:14090
+msgid "International"
+msgstr "インターナショナル"
+
+#: id:14091
+msgid "Character set"
+msgstr "文字セット"
+
+#: id:14092
+msgid "Debugging"
+msgstr "デバッグ"
+
+#: id:14093
+msgid "Security"
+msgstr "セキュリティ"
+
+#: id:14094
+msgid "Input devices"
+msgstr "入力デバイス"
+
+#: id:14095
+msgid "Power saving"
+msgstr "省電力"
+
+#: id:14096
+msgid "Rip"
+msgstr ""
+
+#: id:14097
+msgid "Audio CD Insert Action"
+msgstr ""
+
+#: id:14098
+msgctxt "Auto context with id 14098"
+msgid "Play"
+msgstr ""
+
+#: id:14099
+msgid "Eject disc when CD ripping is complete"
+msgstr ""
+
+#: id:15015
+msgctxt "Auto context with id 15015"
+msgid "Remove"
+msgstr "削除"
+
+#: id:15016
+msgid "Games"
+msgstr "ゲーム"
+
+#: id:15019
+msgid "Add"
+msgstr "追加"
+
+#: id:15052
+msgid "Password"
+msgstr "パスワード"
+
+#: id:15100
+msgctxt "Auto context with id 15100"
+msgid "Library"
+msgstr "ライブラリ"
+
+#: id:15101
+msgid "Database"
+msgstr "データベース"
+
+#: id:15102
+msgid "* All albums"
+msgstr "* すべてのアルバム"
+
+#: id:15103
+msgid "* All artists"
+msgstr "* すべてのアーティスト"
+
+#: id:15104
+msgid "* All songs"
+msgstr "* すべての曲"
+
+#: id:15105
+msgid "* All genres"
+msgstr "* すべてのジャンル"
+
+#: id:15107
+msgid "Buffering..."
+msgstr "バッファリング..."
+
+#: id:15108
+msgid "Navigation sounds"
+msgstr "ナビゲーションサウンド"
+
+#: id:15109
+msgid "Skin default"
+msgstr "スキン デフォルト"
+
+#: id:15111
+msgid "- Theme"
+msgstr "- テーマ"
+
+#: id:15112
+msgid "Default theme"
+msgstr "デフォルトテーマ"
+
+#: id:15200
+msgid "Last.fm"
+msgstr "Last.fm"
+
+#: id:15201
+msgid "Submit songs to Last.fm"
+msgstr "Last.fm に曲を送信する"
+
+#: id:15202
+msgid "Last.fm username"
+msgstr "Last.fm ユーザ名"
+
+#: id:15203
+msgid "Last.fm password"
+msgstr "Last.fm パスワード"
+
+#: id:15204
+msgid "Unable to handshake: sleeping..."
+msgstr "操作不可: 停止中..."
+
+#: id:15205
+msgid "Please update XBMC"
+msgstr "XBMC を更新してください"
+
+#: id:15206
+msgid "Bad authorization: Check username and password"
+msgstr "認証に失敗: ユーザー名とパスワードを確認してください"
+
+#: id:15207
+msgctxt "Auto context with id 15207"
+msgid "Connected"
+msgstr "接続しました"
+
+#: id:15208
+msgid "Not connected"
+msgstr "接続できません"
+
+#: id:15209
+msgid "Submit interval %i"
+msgstr "送信間隔 %i"
+
+#: id:15210
+msgid "Cached %i songs"
+msgstr "キャッシュ済み曲 %i"
+
+#: id:15211
+msgid "Submitting..."
+msgstr "送信中..."
+
+#: id:15212
+msgid "Submitting in %i secs"
+msgstr "送信 %i 秒"
+
+#: id:15213
+msgid "Play using..."
+msgstr "...を使用して再生"
+
+#: id:15214
+msgid "Use smoothed A/V synchronization"
+msgstr "Use Smoothed A/V Synchronisation"
+
+#: id:15215
+msgid "Hide file names in thumbs view"
+msgstr "サムネールビューではファイル名を隠す"
+
+#: id:15216
+msgid "Play in party mode"
+msgstr "パーティーモードで再生"
+
+#: id:15217
+msgid "Submit songs to Libre.fm"
+msgstr ""
+
+#: id:15218
+msgid "Libre.fm username"
+msgstr "Libre.fm ユーザー名"
+
+#: id:15219
+msgid "Libre.fm password"
+msgstr "Libre.fm パスワード"
+
+#: id:15220
+msgid "Libre.fm"
+msgstr "Libre.fm"
+
+#: id:15221
+msgid "Song submission"
+msgstr "楽曲送信"
+
+#: id:15250
+msgid "Submit Last.fm radio to Last.fm"
+msgstr "Last.fm ラジオを Last.fm に送信"
+
+#: id:15251
+msgid "Connecting to Last.fm..."
+msgstr "Last.fm に接続中..."
+
+#: id:15252
+msgid "Selecting station..."
+msgstr "ラジオ局を選択中..."
+
+#: id:15253
+msgid "Search similar artists..."
+msgstr "類似アーティストを検索..."
+
+#: id:15254
+msgid "Search similar tags..."
+msgstr "類似タグを検索..."
+
+#: id:15255
+msgid "Your profile (%name%)"
+msgstr "あなたのプロフィール (%name%)"
+
+#: id:15256
+msgid "Overall top tags"
+msgstr "人気のタグ"
+
+#: id:15257
+msgid "Top artists for tag %name%"
+msgstr "タグ %name% で人気のアーティスト"
+
+#: id:15258
+msgid "Top albums for tag %name%"
+msgstr "タグ %name% で人気のアルバム"
+
+#: id:15259
+msgid "Top tracks for tag %name%"
+msgstr "タグ %name% で人気のトラック"
+
+#: id:15260
+msgid "Listen to tag %name% Last.fm radio"
+msgstr "タグ %name% の Last.fm ラジオを聴く"
+
+#: id:15261
+msgid "Similar artists as %name%"
+msgstr "%name% の類似アーティスト"
+
+#: id:15262
+msgid "Top %name% albums"
+msgstr "%name% のトップアルバム"
+
+#: id:15263
+msgid "Top %name% tracks"
+msgstr "%name% のトップトラック"
+
+#: id:15264
+msgid "Top %name% tags"
+msgstr "%name% のトップタグ"
+
+#: id:15265
+msgid "Biggest fans of %name%"
+msgstr "%name% のトップファン"
+
+#: id:15266
+msgid "Listen to %name% fans Last.fm radio"
+msgstr "%name% のファンの Last.fm ラジオを聴く"
+
+#: id:15267
+msgid "Listen to %name% similar artists Last.fm radio"
+msgstr "%name% の類似アーティストの Last.fm ラジオを聴く"
+
+#: id:15268
+msgid "Top artists for user %name%"
+msgstr "ユーザー %name% のベストアーティスト"
+
+#: id:15269
+msgid "Top albums for user %name%"
+msgstr "ユーザー %name% のベストアルバム"
+
+#: id:15270
+msgid "Top tracks for user %name%"
+msgstr "ユーザー %name% のベストトラック"
+
+#: id:15271
+msgid "Friends of user %name%"
+msgstr "ユーザー %name% の友だち"
+
+#: id:15272
+msgid "Neighbours of user %name%"
+msgstr "ユーザー %name% のご近所さん"
+
+#: id:15273
+msgid "Weekly artist chart for %name%"
+msgstr "%name% の週刊アーティストチャート"
+
+#: id:15274
+msgid "Weekly album chart for %name%"
+msgstr "%name% の週刊アルバムチャート"
+
+#: id:15275
+msgid "Weekly track chart for %name%"
+msgstr "%name% の週刊トラックチャート"
+
+#: id:15276
+msgid "Listen to %name%'s neighbours Last.fm radio"
+msgstr "%name% のご近所さんの Last.fm ラジオを聴く"
+
+#: id:15277
+msgid "Listen to %name%'s personal Last.fm radio"
+msgstr "%name% の Last.fm ラジオを聴く"
+
+#: id:15278
+msgid "Listen to %name%'s mix Last.fm radio"
+msgstr "%name% の mix Last.fm ラジオを聴く"
+
+#: id:15279
+msgid "Retrieving list from Last.fm..."
+msgstr "Last.fm からリストを取得中..."
+
+#: id:15280
+msgid "Can't retrieve list from Last.fm..."
+msgstr "Last.fm からリスト取得に失敗..."
+
+#: id:15281
+msgid "Enter an artist name to find related ones"
+msgstr "アーティスト名を入力し関連アイテム検索"
+
+#: id:15282
+msgid "Enter a tag name to find similar ones"
+msgstr "タグ名を入力し類似アイテム検索"
+
+#: id:15283
+msgid "Tracks recently listened by %name%"
+msgstr "%name% が最近聴いたトラック"
+
+#: id:15284
+msgid "Listen to %name%'s recommendations Last.fm radio"
+msgstr "%name% おすすめの Last.fm ラジオ"
+
+#: id:15285
+msgid "Top tags for user %name%"
+msgstr "ユーザー %name% のトップタグ"
+
+#: id:15287
+msgid "Do you want to add the current track to your loved tracks?"
+msgstr "現在再生中のトラックを Love トラックに追加しますか?"
+
+#: id:15288
+msgid "Do you want to ban the current track?"
+msgstr "現在再生中のトラックを Last.fm ライブラリから削除しますか?"
+
+#: id:15289
+msgid "Added to your loved tracks: '%s'."
+msgstr "Love トラックに追加: '%s'"
+
+#: id:15290
+msgid "Could not add '%s' to your loved tracks."
+msgstr "'%s' を Love トラックに追加できませんでした。"
+
+#: id:15291
+msgid "Banned: '%s'."
+msgstr "Last.fm ライブラリから削除: '%s'."
+
+#: id:15292
+msgid "Could not ban '%s'."
+msgstr "'%s' を Last.fm ライブラリから削除できませんでした。"
+
+#: id:15293
+msgid "Tracks recently loved by %name%"
+msgstr "%name% が最近 Love トラックにした曲"
+
+#: id:15294
+msgid "Tracks recently banned by %name%"
+msgstr "%name% が最近 Last.fm ライブラリから削除した曲"
+
+#: id:15295
+msgid "Remove from loved tracks"
+msgstr "Love トラックから削除"
+
+#: id:15296
+msgid "Un-ban"
+msgstr "ライブラリに戻す"
+
+#: id:15297
+msgid "Do you want to remove this track from your loved tracks?"
+msgstr "このトラックを Love トラックから削除しますか?"
+
+#: id:15298
+msgid "Do you want to un-ban this track?"
+msgstr "このトラックをライブラリに戻しますか?"
+
+#: id:15300
+msgid "Path not found or invalid"
+msgstr "パスが見つからないか、パスが無効です"
+
+#: id:15301
+msgid "Could not connect to network server"
+msgstr "サーバーに接続できません"
+
+#: id:15302
+msgid "No servers found"
+msgstr "サーバーが見つかりません"
+
+#: id:15303
+msgid "Workgroup not found"
+msgstr "ワークグループが見つかりません"
+
+#: id:15310
+msgid "Opening multi-path source"
+msgstr "Opening multi-path source"
+
+#: id:15311
+msgid "Path:"
+msgstr "パス:"
+
+#: id:16000
+msgctxt "Auto context with id 16000"
+msgid "General"
+msgstr "一般"
+
+#: id:16002
+msgid "Internet lookup"
+msgstr "インターネット検索"
+
+#: id:16003
+msgid "Player"
+msgstr "プレイヤー"
+
+#: id:16004
+msgid "Play media from disc"
+msgstr "ディスクからメディア再生"
+
+#: id:16008
+msgid "Enter new title"
+msgstr "新しいタイトルを入力"
+
+#: id:16009
+msgid "Enter the movie name"
+msgstr "動画名を入力"
+
+#: id:16010
+msgid "Enter the profile name"
+msgstr "プロファイル名を入力"
+
+#: id:16011
+msgid "Enter the album name"
+msgstr "アルバム名を入力"
+
+#: id:16012
+msgid "Enter the playlist name"
+msgstr "プレイリスト名を入力"
+
+#: id:16013
+msgid "Enter new filename"
+msgstr "新しいファイル名を入力"
+
+#: id:16014
+msgid "Enter folder name"
+msgstr "フォルダー名を入力"
+
+#: id:16015
+msgid "Enter directory"
+msgstr "ディレクトリを入力"
+
+#: id:16016
+msgid "Available options: %A, %T, %N, %B, %D, %G, %Y, %F, %S"
+msgstr "使用可能オプション: %A, %T, %N, %B, %D, %G, %Y, %F"
+
+#: id:16017
+msgid "Enter search string"
+msgstr "検索文字列を入力"
+
+#: id:16018
+msgctxt "Auto context with id 16018"
+msgid "None"
+msgstr "なし"
+
+#: id:16019
+msgid "Auto select"
+msgstr "自動選択"
+
+#: id:16020
+msgid "De-interlace"
+msgstr "インターレース解除"
+
+#: id:16021
+msgid "Bob"
+msgstr "ODD フィールド表示"
+
+#: id:16022
+msgid "Bob (inverted)"
+msgstr "EVEN フィールド表示"
+
+#: id:16024
+msgid "Canceling..."
+msgstr "キャンセル中..."
+
+#: id:16025
+msgid "Enter the artist name"
+msgstr "アーティスト名を入力"
+
+#: id:16026
+msgid "Playback failed"
+msgstr "プレイバックに失敗しました"
+
+#: id:16027
+msgid "One or more items failed to play."
+msgstr "1つ以上のアイテムの再生に失敗しました。"
+
+#: id:16028
+msgid "Enter value"
+msgstr "値を入力"
+
+#: id:16029
+msgid "Check the log file for details."
+msgstr "詳しくはログファイルを参照して下さい。"
+
+#: id:16030
+msgid "Party mode aborted."
+msgstr "パーティーモードを終了しました。"
+
+#: id:16031
+msgid "No matching songs in the library."
+msgstr "ライブラリには一致する曲はありませんでした。"
+
+#: id:16032
+msgid "Could not initialize database."
+msgstr "データベースを初期化できませんでした。"
+
+#: id:16033
+msgid "Could not open database."
+msgstr "データベースを開けませんでした。"
+
+#: id:16034
+msgid "Could not get songs from database."
+msgstr "データベースから曲を取得できませんでした。"
+
+#: id:16035
+msgid "Party mode playlist"
+msgstr "パーティモードプレイリスト"
+
+#: id:16036
+msgid "De-interlace (Half)"
+msgstr "インターレース解除 (Half)"
+
+#: id:16037
+msgid "Deinterlace video"
+msgstr "ビデオのインターレース解除"
+
+#: id:16038
+msgid "Deinterlace method"
+msgstr "インターレース解除方法"
+
+#: id:16039
+msgctxt "Auto context with id 16039"
+msgid "Off"
+msgstr "オフ"
+
+#: id:16040
+msgctxt "Auto context with id 16040"
+msgid "Auto"
+msgstr "自動"
+
+#: id:16041
+msgid "On"
+msgstr "オン"
+
+#: id:16100
+msgid "All Videos"
+msgstr "すべてのビデオ"
+
+#: id:16101
+msgid "Unwatched"
+msgstr "未視聴"
+
+#: id:16102
+msgid "Watched"
+msgstr "視聴済み"
+
+#: id:16103
+msgid "Mark as watched"
+msgstr "視聴済みにする"
+
+#: id:16104
+msgid "Mark as unwatched"
+msgstr "未視聴にする"
+
+#: id:16105
+msgid "Edit title"
+msgstr "タイトルを編集"
+
+#: id:16200
+msgid "Operation was aborted"
+msgstr "処理が中断されました"
+
+#: id:16201
+msgid "Copy failed"
+msgstr "コピーに失敗"
+
+#: id:16202
+msgid "Failed to copy at least one file"
+msgstr "1つ以上のファイルのコピーに失敗しました"
+
+#: id:16203
+msgid "Move failed"
+msgstr "移動に失敗"
+
+#: id:16204
+msgid "Failed to move at least one file"
+msgstr "1つ以上のファイルの移動に失敗しました"
+
+#: id:16205
+msgid "Delete failed"
+msgstr "削除に失敗"
+
+#: id:16206
+msgid "Failed to delete at least one file"
+msgstr "1つ以上のファイルの削除に失敗しました"
+
+#: id:16300
+msgid "Video scaling method"
+msgstr "ビデオのリサイズ方式"
+
+#: id:16301
+msgid "Nearest neighbour"
+msgstr "ニアレストネイバー"
+
+#: id:16302
+msgid "Bilinear"
+msgstr "バイリニア"
+
+#: id:16303
+msgctxt "Auto context with id 16303"
+msgid "Bicubic"
+msgstr "バイキュービック"
+
+#: id:16304
+msgid "Lanczos2"
+msgstr "Lanczos2"
+
+#: id:16305
+msgid "Lanczos3"
+msgstr "Lanczos3"
+
+#: id:16306
+msgid "Sinc8"
+msgstr "Sinc8"
+
+#: id:16307
+msgid "Bicubic (software)"
+msgstr "バイキュービック (ソフトウェア)"
+
+#: id:16308
+msgid "Lanczos (software)"
+msgstr "Lanczos (software)"
+
+#: id:16309
+msgid "Sinc (software)"
+msgstr "Sinc (software)"
+
+#: id:16310
+msgid "Temporal"
+msgstr "Temporal"
+
+#: id:16311
+msgid "Temporal/Spatial"
+msgstr "Temporal/Spatial"
+
+#: id:16312
+msgid "(VDPAU)Noise Reduction"
+msgstr "(VDPAU) ノイズリダクション"
+
+#: id:16313
+msgid "(VDPAU)Sharpness"
+msgstr "(VDPAU) シャープネス"
+
+#: id:16314
+msgid "Inverse Telecine"
+msgstr "逆テレシネ (30fps => 24fps)"
+
+#: id:16315
+msgid "Lanczos3 optimized"
+msgstr "Lanczos3 最適化"
+
+#: id:16316
+msgctxt "Auto context with id 16316"
+msgid "Auto"
+msgstr "自動"
+
+#: id:16317
+msgid "Temporal (Half)"
+msgstr "Temporal (Half)"
+
+#: id:16318
+msgid "Temporal/Spatial (Half)"
+msgstr "Temporal/Spatial (Half)"
+
+#: id:16319
+msgid "DXVA"
+msgstr "DXVA"
+
+#: id:16320
+msgid "DXVA Bob"
+msgstr "DXVA Bob"
+
+#: id:16321
+msgid "DXVA Best"
+msgstr "DXVA Best"
+
+#: id:16322
+msgid "Spline36"
+msgstr "Spline36"
+
+#: id:16323
+msgid "Spline36 optimized"
+msgstr "Spline36 optimized"
+
+#: id:16324
+msgid "Software Blend"
+msgstr "Software Blend"
+
+#: id:16400
+msgid "Post-processing"
+msgstr "後処理"
+
+#: id:17500
+msgid "Display sleep timeout"
+msgstr "ディスプレイスリープタイムアウト"
+
+#: id:19000
+msgid "Switch to channel"
+msgstr "チャンネル切り替え"
+
+#: id:20000
+msgid "Saved music folder"
+msgstr "保存されたミュージックのフォルダー"
+
+#: id:20001
+msgid "Use external DVD player"
+msgstr "外部 DVD プレーヤーを使用"
+
+#: id:20002
+msgid "External DVD player"
+msgstr "外部 DVD プレーヤーの指定"
+
+#: id:20003
+msgid "Trainers folder"
+msgstr ""
+
+#: id:20004
+msgid "Screenshot folder"
+msgstr "スクリーンショットフォルダー設定"
+
+#: id:20006
+msgid "Playlists folder"
+msgstr "プレイリストフォルダー"
+
+#: id:20007
+msgid "Recordings"
+msgstr "録音"
+
+#: id:20008
+msgid "Screenshots"
+msgstr "スクリーンショット"
+
+#: id:20009
+msgid "Use XBMC"
+msgstr "XBMC を使用"
+
+#: id:20011
+msgid "Music playlists"
+msgstr "ミュージックプレイリスト"
+
+#: id:20012
+msgid "Video playlists"
+msgstr "ビデオプレイリスト"
+
+#: id:20013
+msgid "Do you wish to launch the game?"
+msgstr "ゲームを起動しますか?"
+
+#: id:20014
+msgid "Sort by: Playlist"
+msgstr "並べ替え: プレイリスト"
+
+#: id:20015
+msgid "Remote thumb"
+msgstr "サーバ上のサムネイル"
+
+#: id:20016
+msgid "Current thumb"
+msgstr "現在のサムネイル"
+
+#: id:20017
+msgid "Local thumb"
+msgstr "ローカルサムネイル"
+
+#: id:20018
+msgid "No thumb"
+msgstr "サムネイルなし"
+
+#: id:20019
+msgid "Choose thumbnail"
+msgstr "サムネイルを選択"
+
+#: id:20023
+msgid "Conflict"
+msgstr "コンフリクト"
+
+#: id:20024
+msgid "Scan new"
+msgstr "新規スキャン"
+
+#: id:20025
+msgid "Scan all"
+msgstr "全てスキャン"
+
+#: id:20026
+msgid "Region"
+msgstr "地域"
+
+#: id:20037
+msgid "Summary"
+msgstr "概要"
+
+#: id:20038
+msgid "Lock music window"
+msgstr "ミュージックウィンドウをロック"
+
+#: id:20039
+msgid "Lock videos window"
+msgstr "ビデオウィンドウをロック"
+
+#: id:20040
+msgid "Lock pictures window"
+msgstr "ピクチャーウィンドウをロック"
+
+#: id:20041
+msgid "Lock programs & scripts windows"
+msgstr "プログラム & スクリプトウィンドウをロック"
+
+#: id:20042
+msgid "Lock file manager"
+msgstr "ファイルマネージャーをロック"
+
+#: id:20043
+msgid "Lock settings"
+msgstr "ロックの設定"
+
+#: id:20044
+msgid "Start fresh"
+msgstr "フレッシュ起動"
+
+#: id:20045
+msgid "Enter master mode"
+msgstr "マスターモードに入る"
+
+#: id:20046
+msgid "Leave master mode"
+msgstr "マスターモードから抜ける"
+
+#: id:20047
+msgid "Create profile '%s'?"
+msgstr "プロファイル '%s' を作成しますか?"
+
+#: id:20048
+msgid "Start with fresh settings"
+msgstr "全設定を初期化して起動する"
+
+#: id:20049
+msgid "Best available"
+msgstr "Best available"
+
+#: id:20050
+msgid "Auto-switch between 16x9 and 4x3"
+msgstr "16x9 と 4x3 を自動切り替え"
+
+#: id:20051
+msgid "Treat stacked files as single file"
+msgstr "Treat stacked files as single file"
+
+#: id:20052
+msgid "Caution"
+msgstr "注意"
+
+#: id:20053
+msgid "Left master mode"
+msgstr "マスターモードから抜けました"
+
+#: id:20054
+msgid "Entered master mode"
+msgstr "マスターモードに入りました"
+
+#: id:20055
+msgid "Allmusic.com thumb"
+msgstr "Allmusic.com サムネール"
+
+#: id:20057
+msgid "Remove thumbnail"
+msgstr "サムネールの削除"
+
+#: id:20058
+msgid "Add profile..."
+msgstr "プロファイルの追加..."
+
+#: id:20059
+msgid "Query info for all albums"
+msgstr "全アルバムの情報を取得"
+
+#: id:20060
+msgctxt "Auto context with id 20060"
+msgid "Media info"
+msgstr "メディア情報"
+
+#: id:20061
+msgctxt "Auto context with id 20061"
+msgid "Separate"
+msgstr "Separate"
+
+#: id:20062
+msgid "Shares with default"
+msgstr "Shares with default"
+
+#: id:20063
+msgid "Shares with default (read only)"
+msgstr "Shares with default (read only)"
+
+#: id:20064
+msgid "Copy default"
+msgstr "Copy default"
+
+#: id:20065
+msgid "Profile picture"
+msgstr "プロファイル画像"
+
+#: id:20066
+msgid "Lock preferences"
+msgstr "プロファイルをロック"
+
+#: id:20067
+msgid "Edit profile"
+msgstr "プロファイルの編集"
+
+#: id:20068
+msgid "Profile lock"
+msgstr "プロファイルのロック"
+
+#: id:20069
+msgid "Could not create folder"
+msgstr "フォルダの作成に失敗"
+
+#: id:20070
+msgid "Profile directory"
+msgstr "プロファイルフォルダー"
+
+#: id:20071
+msgid "Start with fresh media sources"
+msgstr "メディアソース設定を初期化して起動する"
+
+#: id:20072
+msgid "Make sure the selected folder is writable"
+msgstr "選択したフォルダーが書き込み可能であること、"
+
+#: id:20073
+msgid "and that the new folder name is valid"
+msgstr "新規フォルダ名が有効であることを確認してください。"
+
+#: id:20074
+msgid "MPAA rating"
+msgstr "MAPP評価"
+
+#: id:20075
+msgid "Enter master lock code"
+msgstr "マスターロックコードの入力"
+
+#: id:20076
+msgid "Ask for master lock code on startup"
+msgstr "起動時にマスターロックコードを入力させる"
+
+#: id:20077
+msgid "Skin settings"
+msgstr "スキン設定"
+
+#: id:20078
+msgid "- no link set -"
+msgstr "- 未設定 -"
+
+#: id:20079
+msgid "Enable animations"
+msgstr "アニメーション表示を有効にする"
+
+#: id:20080
+msgid "Disable RSS during music"
+msgstr "音楽再生中は RSS を停止"
+
+#: id:20081
+msgid "Enable shortcut buttons"
+msgstr "ショートカットボタンを有効にする"
+
+#: id:20082
+msgid "Show programs in main menu"
+msgstr "メインメニューに「プログラム」を表示"
+
+#: id:20083
+msgid "Show music info"
+msgstr "ミュージック情報を表示"
+
+#: id:20084
+msgid "Show weather info"
+msgstr "天気予報情報を表示"
+
+#: id:20085
+msgid "Show system info"
+msgstr "システム情報を表示"
+
+#: id:20086
+msgid "Show available disc space C: E: F:"
+msgstr "Show available disc space C: E: F:"
+
+#: id:20087
+msgid "Show available disc space E: F: G:"
+msgstr "Show available disc space E: F: G:"
+
+#: id:20088
+msgid "Weather info"
+msgstr "天気予報情報"
+
+#: id:20089
+msgid "Drive space free"
+msgstr "Drive space free"
+
+#: id:20090
+msgid "Enter the name of an existing share"
+msgstr "Enter the name of an existing share"
+
+#: id:20091
+msgid "Lock code"
+msgstr "Lock code"
+
+#: id:20092
+msgid "Load profile"
+msgstr "プロファイルの読み込み"
+
+#: id:20093
+msgid "Profile name"
+msgstr "プロファイル名"
+
+#: id:20094
+msgctxt "Auto context with id 20094"
+msgid "Media sources"
+msgstr "メディアソース"
+
+#: id:20095
+msgid "Enter profile lock code"
+msgstr "プロファイルのロックコードを入力"
+
+#: id:20096
+msgctxt "Auto context with id 20096"
+msgid "Login screen"
+msgstr "ログイン画面"
+
+#: id:20097
+msgid "Fetching album info"
+msgstr "アルバム情報の取得中"
+
+#: id:20098
+msgid "Fetching info for album"
+msgstr "アルバムの情報を取得中"
+
+#: id:20099
+msgid "Can't rip CD or track while playing from CD"
+msgstr "CD 再生中に CD やトラックの読み込みはできません"
+
+#: id:20100
+msgid "Master lock code and settings"
+msgstr "マスターロックコードと設定"
+
+#: id:20101
+msgid "Entering master lock code always enables master mode"
+msgstr "Entering master lock code always enables master mode"
+
+#: id:20102
+msgid "or copy from default?"
+msgstr "それともデフォルト値からコピーしますか?"
+
+#: id:20103
+msgid "Save changes to profile?"
+msgstr "プロファイルに変更内容を保存しますか?"
+
+#: id:20104
+msgid "Old settings found."
+msgstr "古い設定が見つかりました。"
+
+#: id:20105
+msgid "Do you want to use them?"
+msgstr "その古い設定を使いますか?"
+
+#: id:20106
+msgid "Old media sources found."
+msgstr "古いメディアソースが見つかりました。"
+
+#: id:20107
+msgid "Separate (locked)"
+msgstr "Separate (locked)"
+
+#: id:20108
+msgid "Root"
+msgstr "Root"
+
+#: id:20109
+msgid "- Zoom"
+msgstr "- Zoom"
+
+#: id:20110
+msgid "UPnP settings"
+msgstr "UPnP 設定"
+
+#: id:20111
+msgid "Autostart UPnP client"
+msgstr "UPnP クライアントの自動起動"
+
+#: id:20112
+msgid "Last login: %s"
+msgstr "最終ログイン: %s"
+
+#: id:20113
+msgid "Never logged on"
+msgstr "ログイン履歴なし"
+
+#: id:20114
+msgid "Profile %i / %i"
+msgstr "プロファイル %i / %i"
+
+#: id:20115
+msgid "User login / Select a profile"
+msgstr "ユーザーログイン / プロファイルを選択"
+
+#: id:20116
+msgid "Use lock on login screen"
+msgstr "ログインが面でロックを使用"
+
+#: id:20117
+msgid "Invalid lock code."
+msgstr "ロックコードが不正です。"
+
+#: id:20118
+msgid "This requires the master lock to be set."
+msgstr "マスターロックの設定が必要です。"
+
+#: id:20119
+msgid "Would you like to set it now?"
+msgstr "いまここで設定しますか?"
+
+#: id:20120
+msgid "Loading program information"
+msgstr "プログラム情報の読み込み中"
+
+#: id:20121
+msgid "Party on!"
+msgstr "パーティー開始！"
+
+#: id:20122
+msgid "True"
+msgstr "True"
+
+#: id:20123
+msgid "Mixing drinks"
+msgstr "Mixing drinks"
+
+#: id:20124
+msgid "Filling glasses"
+msgstr "Filling glasses"
+
+#: id:20125
+msgid "Logged on as"
+msgstr "ログイン済:"
+
+#: id:20126
+msgid "Log off"
+msgstr "ログオフ"
+
+#: id:20128
+msgid "Go to root"
+msgstr "一番上の階層へ"
+
+#: id:20129
+msgid "Weave"
+msgstr "Weave"
+
+#: id:20130
+msgid "Weave (inverted)"
+msgstr "Weave (inverted)"
+
+#: id:20131
+msgid "Blend"
+msgstr "Blend"
+
+#: id:20132
+msgid "Restart video"
+msgstr "ビデオを再起動"
+
+#: id:20133
+msgid "Edit network location"
+msgstr "ネットワーク上の場所を編集"
+
+#: id:20134
+msgid "Remove network location"
+msgstr "ネットワーク上の場所を削除"
+
+#: id:20135
+msgid "Do you want to scan the folder?"
+msgstr "フォルダをスキャンしますか?"
+
+#: id:20136
+msgid "Memory unit"
+msgstr "メモリユニット"
+
+#: id:20137
+msgid "Memory unit mounted"
+msgstr "メモリユニットがマウントされました"
+
+#: id:20138
+msgid "Unable to mount memory unit"
+msgstr "メモリユニットをマウントできませんでした"
+
+#: id:20139
+msgid "In port %i, slot %i"
+msgstr "ポート %i, スロット %i"
+
+#: id:20140
+msgid "Lock screensaver"
+msgstr "スクリーンセーバーをロック"
+
+#: id:20141
+msgid "Set"
+msgstr "Set"
+
+#: id:20142
+msgctxt "Auto context with id 20142"
+msgid "Username"
+msgstr "ユーザー名"
+
+#: id:20143
+msgid "Enter password for"
+msgstr "パスワードを設定:"
+
+#: id:20144
+msgid "Shutdown timer"
+msgstr "シャットダウンタイマー"
+
+#: id:20145
+msgid "Shutdown interval (in minutes)"
+msgstr "シャットダウンまでの時間 (単位:分)"
+
+#: id:20146
+msgid "Started, shutdown in %im"
+msgstr "タイマースタート, %i分後にシャットダウン"
+
+#: id:20147
+msgid "Shutdown in 30 minutes"
+msgstr "30分後にシャットダウン"
+
+#: id:20148
+msgid "Shutdown in 60 minutes"
+msgstr "1時間後にシャットダウン"
+
+#: id:20149
+msgid "Shutdown in 120 minutes"
+msgstr "2時間後にシャットダウン"
+
+#: id:20150
+msgid "Custom shutdown timer"
+msgstr "シャットダウンタイマーを設定"
+
+#: id:20151
+msgid "Cancel shutdown timer"
+msgstr "シャットダウンタイマーをキャンセル"
+
+#: id:20152
+msgid "Lock preferences for %s"
+msgstr "%s の設定をロック"
+
+#: id:20153
+msgid "Browse..."
+msgstr "参照..."
+
+#: id:20154
+msgid "Summary information"
+msgstr "概要情報"
+
+#: id:20155
+msgid "Storage information"
+msgstr "ストレージ情報"
+
+#: id:20156
+msgid "Hard disk information"
+msgstr "ハードディスク情報"
+
+#: id:20157
+msgid "DVD-ROM information"
+msgstr "DVD-ROM 情報"
+
+#: id:20158
+msgid "Network information"
+msgstr "ネットワーク情報"
+
+#: id:20159
+msgid "Video information"
+msgstr "ビデオ情報"
+
+#: id:20160
+msgid "Hardware information"
+msgstr "ハードウェア情報"
+
+#: id:20161
+msgid "Total"
+msgstr "合計"
+
+#: id:20162
+msgid "Used"
+msgstr "使用済"
+
+#: id:20163
+msgid "of"
+msgstr "of"
+
+#: id:20164
+msgid "Locking not supported"
+msgstr "Locking Not Supported"
+
+#: id:20165
+msgid "Not locked"
+msgstr "Not Locked"
+
+#: id:20166
+msgid "Locked"
+msgstr "Locked"
+
+#: id:20167
+msgid "Frozen"
+msgstr "Frozen"
+
+#: id:20168
+msgid "Requires reset"
+msgstr "Requires Reset"
+
+#: id:20169
+msgid "Week"
+msgstr "Week"
+
+#: id:20170
+msgid "Line"
+msgstr "Line"
+
+#: id:20171
+msgid "Windows network (SMB)"
+msgstr "Windowsネットワーク (SMB)"
+
+#: id:20172
+msgid "XBMSP server"
+msgstr "XBMSP サーバー"
+
+#: id:20173
+msgctxt "Auto context with id 20173"
+msgid "FTP server"
+msgstr "FTP サーバー"
+
+#: id:20174
+msgid "iTunes music share (DAAP)"
+msgstr "iTunes ミュージック共有 (DAAP)"
+
+#: id:20175
+msgid "UPnP server"
+msgstr "UPnP サーバー"
+
+#: id:20176
+msgid "Show video info"
+msgstr "ビデオ情報を表示"
+
+#: id:20177
+msgid "Done"
+msgstr "完了"
+
+#: id:20178
+msgid "Shift"
+msgstr "Shift"
+
+#: id:20179
+msgid "Caps Lock"
+msgstr "Caps Lock"
+
+#: id:20180
+msgid "Symbols"
+msgstr "記号"
+
+#: id:20181
+msgid "Backspace"
+msgstr "Backspace"
+
+#: id:20182
+msgid "Space"
+msgstr "Space"
+
+#: id:20183
+msgid "Reload skin"
+msgstr "スキンを再ロード"
+
+#: id:20184
+msgid "Rotate pictures using EXIF information"
+msgstr "EXIF 情報による画像の向き補正"
+
+#: id:20185
+msgid "Use poster view styles for TV shows"
+msgstr "Use Poster View Styles for TV Shows"
+
+#: id:20186
+msgid "Please wait"
+msgstr "お待ち下さい..."
+
+#: id:20187
+msgid "UPnP"
+msgstr "UPnP"
+
+#: id:20189
+msgid "Enable auto scrolling for plot & review"
+msgstr "あらすじとレビューで自動スクロールを有効化"
+
+#: id:20190
+msgctxt "Auto context with id 20190"
+msgid "Custom"
+msgstr "カスタム"
+
+#: id:20191
+msgid "Enable debug logging"
+msgstr "デバッグログ出力を有効にする"
+
+#: id:20192
+msgid "Download additional information during updates"
+msgstr "更新時に追加情報をダウンロードする"
+
+#: id:20193
+msgid "Default service for album information"
+msgstr "アルバム情報取得用デフォルトサービス"
+
+#: id:20194
+msgid "Default service for artist information"
+msgstr "アーティスト情報取得用デフォルトサービス"
+
+#: id:20195
+msgid "Change scraper"
+msgstr "スクレーパーを変更"
+
+#: id:20196
+msgid "Export music library"
+msgstr "ミュージックライブラリをエクスポート"
+
+#: id:20197
+msgid "Import music library"
+msgstr "ミュージックライブラリをインポート"
+
+#: id:20198
+msgid "No artist found!"
+msgstr "アーティストが見つかりませんでした!"
+
+#: id:20199
+msgid "Downloading artist info failed"
+msgstr "アーティスト情報の取得に失敗しました"
+
+#: id:20250
+msgid "Party on! (videos)"
+msgstr "パーティー開始！ (ビデオ)"
+
+#: id:20251
+msgid "Mixing drinks (videos)"
+msgstr "Mixing drinks (videos)"
+
+#: id:20252
+msgid "Filling glasses (videos)"
+msgstr "Filling glasses (videos)"
+
+#: id:20253
+msgid "WebDAV server (HTTP)"
+msgstr "WebDAV サーバー (HTTP)"
+
+#: id:20254
+msgid "WebDAV server (HTTPS)"
+msgstr "WebDAV サーバー (HTTPS)"
+
+#: id:20255
+msgid "First logon, edit your profile"
+msgstr "初回ログイン、プロファイルを編集して下さい"
+
+#: id:20256
+msgid "HTS Tvheadend client"
+msgstr "HTS Tvheadend クライアント"
+
+#: id:20257
+msgid "VDR Streamdev client"
+msgstr "VDR Streamdev クライアント"
+
+#: id:20258
+msgid "MythTV client"
+msgstr "MythTV クライアント"
+
+#: id:20259
+msgid "Network Filesystem (NFS)"
+msgstr "ネットワークファイルシステム (NFS)"
+
+#: id:20260
+msgid "Secure Shell (SSH/SFTP)"
+msgstr "セキュアシェル (SSH/SFTP)"
+
+#: id:20261
+msgid "Apple Filing Protocol (AFP)"
+msgstr "Apple ファイル共有プロトコル (AFP)"
+
+#: id:20300
+msgid "Web server directory (HTTP)"
+msgstr "Web サーバーディレクトリ (HTTP)"
+
+#: id:20301
+msgid "Web server directory (HTTPS)"
+msgstr "Web サーバーディレクトリ (HTTPS)"
+
+#: id:20302
+msgid "Unable to write to folder:"
+msgstr "フォルダに書き込みできません:"
+
+#: id:20303
+msgid "Do you want to skip and proceed?"
+msgstr "スキップして続けますか?"
+
+#: id:20304
+msgid "RSS Feed"
+msgstr "RSS フィード"
+
+#: id:20307
+msgid "Secondary DNS"
+msgstr "セカンダリ DNS"
+
+#: id:20308
+msgid "DHCP server:"
+msgstr "DHCP サーバ:"
+
+#: id:20309
+msgid "Make new folder"
+msgstr "新規フォルダー作成"
+
+#: id:20310
+msgid "Dim LCD on playback"
+msgstr "再生中は LCD を暗くする"
+
+#: id:20311
+msgid "Unknown or onboard (protected)"
+msgstr "不明、またはオンボード (protected)"
+
+#: id:20312
+msgid "Dim LCD on paused"
+msgstr "一時停止中に LCD を暗くする"
+
+#: id:20314
+msgid "Videos - Library"
+msgstr "ビデオ - ライブラリ"
+
+#: id:20316
+msgid "Sort by: ID"
+msgstr "並べ替え: ID"
+
+#: id:20324
+msgid "Play part..."
+msgstr "Play part..."
+
+#: id:20325
+msgid "Calibration reset"
+msgstr "設定のリセット"
+
+#: id:20326
+msgid "This will reset the calibration values for %s"
+msgstr "%s の設定値をリセットしてすべて"
+
+#: id:20327
+msgid "to it's default values."
+msgstr "デフォルト値に戻します。"
+
+#: id:20328
+msgid "Browse for destination"
+msgstr "Browse for destination"
+
+#: id:20329
+msgid "Movies are in separate folders that match the movie title"
+msgstr "Movies are in separate folders that match the movie title"
+
+#: id:20330
+msgid "Use folder names for lookups"
+msgstr "フォルダ名も検索対象にする"
+
+#: id:20331
+msgctxt "Auto context with id 20331"
+msgid "File"
+msgstr "ファイル"
+
+#: id:20332
+msgid "Use file or folder names in lookups?"
+msgstr "ファイル名・フォルダ名を検索対象にしますか?"
+
+#: id:20333
+msgid "Set content"
+msgstr "コンテンツを設定"
+
+#: id:20334
+msgid "Folder"
+msgstr "フォルダー"
+
+#: id:20335
+msgid "Look for content recursively?"
+msgstr "コンテンツを再帰的に探索しますか?"
+
+#: id:20336
+msgid "Unlock sources"
+msgstr "ソースのロック解除"
+
+#: id:20337
+msgid "Actor"
+msgstr "俳優"
+
+#: id:20338
+msgid "Movie"
+msgstr "映画"
+
+#: id:20339
+msgid "Director"
+msgstr "監督"
+
+#: id:20340
+msgid "Do you want to remove all items within"
+msgstr "Do you want to remove all items within"
+
+#: id:20341
+msgid "this path from the XBMC library?"
+msgstr ""
+
+#: id:20342
+msgctxt "Auto context with id 20342"
+msgid "Movies"
+msgstr "映画"
+
+#: id:20343
+msgid "TV shows"
+msgstr "テレビ番組"
+
+#: id:20344
+msgid "This directory contains"
+msgstr "このディレクトリが含むのは"
+
+#: id:20345
+msgid "Run automated scan"
+msgstr "自動スキャンを実行"
+
+#: id:20346
+msgid "Scan recursively"
+msgstr "再帰的スキャン"
+
+#: id:20347
+msgid "as"
+msgstr "as"
+
+#: id:20348
+msgid "Directors"
+msgstr "監督"
+
+#: id:20349
+msgid "No video files found in this path!"
+msgstr "このパスにはビデオファイルがありませんでした!"
+
+#: id:20350
+msgid "votes"
+msgstr "votes"
+
+#: id:20351
+msgid "TV show information"
+msgstr "テレビ番組情報"
+
+#: id:20352
+msgid "Episode information"
+msgstr "エピソード情報"
+
+#: id:20353
+msgid "Loading TV show details"
+msgstr "テレビ番組の詳細をロード中"
+
+#: id:20354
+msgid "Fetching episode guide"
+msgstr "エピソードガイド取得中"
+
+#: id:20355
+msgid "Loading info for episodes in directory"
+msgstr "ディレクトリ内のエピソード情報を読み込み中"
+
+#: id:20356
+msgid "Select TV show:"
+msgstr "テレビ番組を選択:"
+
+#: id:20357
+msgid "Enter the TV show name"
+msgstr "テレビ番組名を入力"
+
+#: id:20358
+msgid "Season %i"
+msgstr "シーズン %i"
+
+#: id:20359
+msgid "Episode"
+msgstr "エピソード"
+
+#: id:20360
+msgid "Episodes"
+msgstr "エピソード"
+
+#: id:20361
+msgid "Loading episode details"
+msgstr "エピソードの詳細をロード中"
+
+#: id:20362
+msgid "Remove episode from library"
+msgstr "エピソードをライブラリから削除"
+
+#: id:20363
+msgid "Remove TV show from library"
+msgstr "テレビ番組をライブラリから削除"
+
+#: id:20364
+msgid "TV show"
+msgstr "テレビ番組"
+
+#: id:20365
+msgid "Episode plot"
+msgstr "エピソードのあらすじ"
+
+#: id:20366
+msgid "* All seasons"
+msgstr "* 全シーズン"
+
+#: id:20367
+msgid "Hide watched"
+msgstr "視聴済みを除外"
+
+#: id:20368
+msgid "Prod code"
+msgstr "Prod Code"
+
+#: id:20369
+msgid "Show plot for unwatched items"
+msgstr "未視聴アイテムのあらすじを表示する"
+
+#: id:20370
+msgid "* Hidden to prevent spoilers *"
+msgstr "* あらすじ非表示 *"
+
+#: id:20371
+msgid "Set season thumb"
+msgstr "シーズンサムネイル指定"
+
+#: id:20372
+msgid "Season image"
+msgstr "シーズンイメージ"
+
+#: id:20373
+msgid "Season"
+msgstr "シーズン"
+
+#: id:20374
+msgid "Downloading movie information"
+msgstr "映画情報を取得中"
+
+#: id:20375
+msgid "Unassign content"
+msgstr "Unassign Content"
+
+#: id:20376
+msgid "Original title"
+msgstr ""
+
+#: id:20377
+msgid "Refresh TV show information"
+msgstr "テレビ番組情報を更新"
+
+#: id:20378
+msgid "Refresh info for all episodes?"
+msgstr "すべてのエピソード情報を更新しますか？"
+
+#: id:20379
+msgid "Selected folder contains a single TV show"
+msgstr "選択したフォルダーにはテレビ番組1種類のみ含まれる"
+
+#: id:20380
+msgid "Exclude selected folder from scans"
+msgstr "選択したフォルダーをスキャン対象から除外する"
+
+#: id:20381
+msgid "Specials"
+msgstr "スペシャル"
+
+#: id:20382
+msgid "Automatically grab season thumbs"
+msgstr "シーズンサムネイルの自動取得"
+
+#: id:20383
+msgid "Selected folder contains a single video"
+msgstr "選択したフォルダにはビデオが1つだけあります"
+
+#: id:20384
+msgid "Link to TV show"
+msgstr "テレビ番組とリンクを設定"
+
+#: id:20385
+msgid "Remove link to TV show"
+msgstr "テレビ番組とのリンクを解除"
+
+#: id:20386
+msgid "Recently added movies"
+msgstr "最近追加された映画"
+
+#: id:20387
+msgid "Recently added episodes"
+msgstr "最近追加されたエピソード"
+
+#: id:20388
+msgid "Studios"
+msgstr "スタジオ"
+
+#: id:20389
+msgid "Music videos"
+msgstr "音楽ビデオ"
+
+#: id:20390
+msgid "Recently added music videos"
+msgstr "最近追加された音楽ビデオ"
+
+#: id:20391
+msgid "Music video"
+msgstr "音楽ビデオ"
+
+#: id:20392
+msgid "Remove music video from library"
+msgstr "音楽ビデオをライブラリから削除"
+
+#: id:20393
+msgctxt "Auto context with id 20393"
+msgid "Music video information"
+msgstr "音楽ビデオ情報"
+
+#: id:20394
+msgid "Loading music video information"
+msgstr "音楽ビデオ情報を取得中"
+
+#: id:20395
+msgid "Mixed"
+msgstr "Mixed"
+
+#: id:20396
+msgid "Go to albums by artist"
+msgstr "アーティスト別アルバムへ"
+
+#: id:20397
+msgid "Go to album"
+msgstr "アルバムへ"
+
+#: id:20398
+msgid "Play song"
+msgstr "曲を再生"
+
+#: id:20399
+msgid "Go to music videos from album"
+msgstr "アルバムのミュージックビデオへ"
+
+#: id:20400
+msgid "Go to music videos by artist"
+msgstr "アーティストのミュージックビデオへ"
+
+#: id:20401
+msgid "Play music video"
+msgstr "ミュージックビデオを再生"
+
+#: id:20402
+msgid "Download actor thumbnails when adding to library"
+msgstr "ライブラリ追加時に俳優のサムネイルを取得する"
+
+#: id:20403
+msgid "Set actor thumb"
+msgstr "俳優のサムネイルを指定"
+
+#: id:20405
+msgid "Remove episode bookmark"
+msgstr "エピソードブックマークを削除"
+
+#: id:20406
+msgid "Set episode bookmark"
+msgstr "エピソードブックマークを設定"
+
+#: id:20407
+msgid "Scraper settings"
+msgstr "スクレーパー設定"
+
+#: id:20408
+msgid "Downloading music video information"
+msgstr "音楽ビデオ情報を取得中"
+
+#: id:20409
+msgid "Downloading TV show information"
+msgstr "テレビ番組情報を取得中"
+
+#: id:20410
+msgid "Trailer"
+msgstr "予告"
+
+#: id:20411
+msgid "Flatten"
+msgstr "フラット化"
+
+#: id:20412
+msgid "Flatten TV shows"
+msgstr "テレビ番組のフラット化"
+
+#: id:20413
+msgid "Get fanart"
+msgstr "Fanart を取得"
+
+#: id:20414
+msgid "Show Fanart in video and music libraries"
+msgstr "ビデオ及び音楽ライブラリで Fanart を表示する"
+
+#: id:20415
+msgid "Scanning for new content"
+msgstr "新しいコンテンツをスキャン中"
+
+#: id:20416
+msgid "First aired"
+msgstr "初回放映"
+
+#: id:20417
+msgid "Writer"
+msgstr "脚本家"
+
+#: id:20419
+msgid "Replace file names with library titles"
+msgstr "Replace file names with library titles"
+
+#: id:20420
+msgctxt "Auto context with id 20420"
+msgid "Never"
+msgstr "しない"
+
+#: id:20421
+msgid "If only one season"
+msgstr "1シーズンのみの場合"
+
+#: id:20422
+msgid "Always"
+msgstr "常に"
+
+#: id:20423
+msgid "Has trailer"
+msgstr "予告編あり"
+
+#: id:20424
+msgid "False"
+msgstr "False"
+
+#: id:20425
+msgid "Fanart slideshow"
+msgstr "Fanart スライドショー"
+
+#: id:20426
+msgid "Export to a single file or separate"
+msgstr "Export to a single file or separate"
+
+#: id:20427
+msgid "files per entry?"
+msgstr "files per entry?"
+
+#: id:20428
+msgid "Single file"
+msgstr "Single file"
+
+#: id:20429
+msgctxt "Auto context with id 20429"
+msgid "Separate"
+msgstr "Separate"
+
+#: id:20430
+msgid "Export thumbnails and fanart?"
+msgstr "Export thumbs and fanart?"
+
+#: id:20431
+msgid "Overwrite old files?"
+msgstr "古いファイルを上書きしますか?"
+
+#: id:20432
+msgid "Exclude path from library updates"
+msgstr "ライブラリの更新から除外"
+
+#: id:20433
+msgid "Extract thumbnails and video information"
+msgstr ""
+
+#: id:20434
+msgid "Sets"
+msgstr ""
+
+#: id:20435
+msgid "Set movieset thumb"
+msgstr ""
+
+#: id:20436
+msgid "Export actor thumbs?"
+msgstr ""
+
+#: id:20437
+msgid "Choose fanart"
+msgstr "Fanart を選択"
+
+#: id:20438
+msgid "Local fanart"
+msgstr "ローカル Fanart"
+
+#: id:20439
+msgid "No fanart"
+msgstr "Fanart なし"
+
+#: id:20440
+msgid "Current fanart"
+msgstr "現在の Fanart"
+
+#: id:20441
+msgid "Remote fanart"
+msgstr "リモート Fanart"
+
+#: id:20442
+msgid "Change content"
+msgstr "コンテンツを変更"
+
+#: id:20443
+msgid "Do you want to refresh info for all"
+msgstr "Do you want to refresh info for all"
+
+#: id:20444
+msgid "items within this path?"
+msgstr "items within this path?"
+
+#: id:20445
+msgid "Fanart"
+msgstr "Fanart"
+
+#: id:20446
+msgid "Locally stored information found."
+msgstr "Locally stored information found."
+
+#: id:20447
+msgid "Ignore and refresh from internet?"
+msgstr "Ignore and refresh from internet?"
+
+#: id:20448
+msgid "Could not download information"
+msgstr "情報を取得できませんでした"
+
+#: id:20449
+msgid "Unable to connect to remote server"
+msgstr "Unable to connect to remote server"
+
+#: id:20450
+msgid "Would you like to continue scanning?"
+msgstr "Would you like to continue scanning?"
+
+#: id:20451
+msgid "Countries"
+msgstr "Countries"
+
+#: id:20452
+msgid "episode"
+msgstr "episode"
+
+#: id:20453
+msgid "episodes"
+msgstr "episodes"
+
+#: id:20454
+msgid "Listener"
+msgstr "Listener"
+
+#: id:20455
+msgid "Listeners"
+msgstr "Listeners"
+
+#: id:20456
+msgid "Set movieset fanart"
+msgstr "Set movieset fanart"
+
+#: id:20457
+msgid "Movie set"
+msgstr "Movie set"
+
+#: id:20458
+msgid "Group movies in sets"
+msgstr "Group movies in sets"
+
+#: id:21330
+msgid "Show hidden files and directories"
+msgstr "隠しファイル/フォルダーを表示"
+
+#: id:21331
+msgid "TuxBox client"
+msgstr "TuxBox クライアント"
+
+#: id:21332
+msgid "WARNING: Target TuxBox device is in recording-mode!"
+msgstr "WARNING: Target TuxBox device is in Recording-Mode!"
+
+#: id:21333
+msgid "The stream will be stopped!"
+msgstr "The Stream will be Stopped!"
+
+#: id:21334
+msgid "Zap to channel: %s failed!"
+msgstr "Zap to Channel: %s Failed!"
+
+#: id:21335
+msgid "Are you sure to start the stream?"
+msgstr "Are you sure to start the stream?"
+
+#: id:21336
+msgid "Connecting to: %s"
+msgstr "Connecting to: %s"
+
+#: id:21337
+msgid "TuxBox device"
+msgstr "TuxBox Device"
+
+#: id:21359
+msgid "Add media share..."
+msgstr "メディア共有を追加..."
+
+#: id:21360
+msgid "Share video and music libraries through UPnP"
+msgstr "ビデオ/ミュージックライブラリを UPnP 経由で共有"
+
+#: id:21364
+msgid "Edit media share"
+msgstr "メディア共有を編集"
+
+#: id:21365
+msgid "Remove media share"
+msgstr "メディア共有を削除"
+
+#: id:21366
+msgid "Subtitle folder"
+msgstr "字幕フォルダー設定"
+
+#: id:21367
+msgid "Movie & alternate subtitle directory"
+msgstr "Movie & Alternate Subtitle Directory"
+
+#: id:21368
+msgid "Override ASS/SSA subtitles fonts"
+msgstr "Override ASS/SSA subtitles fonts"
+
+#: id:21369
+msgid "Enable mouse and Touch Screen support"
+msgstr "マウス・タッチスクリーンの有効化"
+
+#: id:21370
+msgid "Play navigation sounds during media playback"
+msgstr "再生時もナビゲーションサウンドを有効化"
+
+#: id:21371
+msgid "Thumbnail"
+msgstr "サムネール"
+
+#: id:21372
+msgid "Forced DVD player region"
+msgstr "DVD Player リージョンの強制指定"
+
+#: id:21373
+msgid "Video output"
+msgstr "ビデオ出力"
+
+#: id:21374
+msgid "Video aspect"
+msgstr "アスペクト比"
+
+#: id:21375
+msgctxt "Auto context with id 21375"
+msgid "Normal"
+msgstr "ノーマル"
+
+#: id:21376
+msgid "Letterbox"
+msgstr "レターボックス"
+
+#: id:21377
+msgid "Widescreen"
+msgstr "ワイドスクリーン"
+
+#: id:21378
+msgid "Enable 480p"
+msgstr "480p 有効化"
+
+#: id:21379
+msgid "Enable 720p"
+msgstr "720p 有効化"
+
+#: id:21380
+msgid "Enable 1080i"
+msgstr "1080i 有効化"
+
+#: id:21381
+msgid "Enter name of new playlist"
+msgstr "新規プレイリスト名を入力"
+
+#: id:21382
+msgid "Show \"Add source\" buttons in file lists"
+msgstr "ソース追加ボタンを無効"
+
+#: id:21383
+msgid "Enable scrollbars"
+msgstr "スクロールバー表示"
+
+#: id:21384
+msgid "Make watched filtering a toggle in video library"
+msgstr "視聴済み除外ボタンをビデオライブラリに追加"
+
+#: id:21385
+msgctxt "Auto context with id 21385"
+msgid "Open"
+msgstr "開く"
+
+#: id:21386
+msgid "Acoustic management level"
+msgstr "Acoustic Management Level"
+
+#: id:21387
+msgid "Fast"
+msgstr "Fast"
+
+#: id:21388
+msgid "Quiet"
+msgstr "Quiet"
+
+#: id:21389
+msgid "Enable custom background"
+msgstr "Enable Custom Background"
+
+#: id:21390
+msgid "Power management level"
+msgstr "Power Management Level"
+
+#: id:21391
+msgid "High power"
+msgstr "High Power"
+
+#: id:21392
+msgid "Low power"
+msgstr "Low Power"
+
+#: id:21393
+msgid "High standby"
+msgstr "High Standby"
+
+#: id:21394
+msgid "Low standby"
+msgstr "Low Standby"
+
+#: id:21395
+msgid "Unable to cache files bigger than 4GB"
+msgstr "4GB 以上のファイルはキャッシュできません"
+
+#: id:21396
+msgid "Chapter"
+msgstr "チャプター"
+
+#: id:21397
+msgid "High quality pixel shader v2"
+msgstr "High Quality Pixel Shader V2"
+
+#: id:21398
+msgid "Enable playlist at startup"
+msgstr "起動時後プレイリストを再生"
+
+#: id:21399
+msgid "Use tween animations"
+msgstr "Tween アニメーション有効化"
+
+#: id:21400
+msgid "contains"
+msgstr "contains"
+
+#: id:21401
+msgid "does not contain"
+msgstr "does not contain"
+
+#: id:21402
+msgid "is"
+msgstr "is"
+
+#: id:21403
+msgid "is not"
+msgstr "is not"
+
+#: id:21404
+msgid "starts with"
+msgstr "starts with"
+
+#: id:21405
+msgid "ends with"
+msgstr "ends with"
+
+#: id:21406
+msgid "greater than"
+msgstr "greater than"
+
+#: id:21407
+msgid "less than"
+msgstr "less than"
+
+#: id:21408
+msgid "after"
+msgstr "after"
+
+#: id:21409
+msgid "before"
+msgstr "before"
+
+#: id:21410
+msgid "in the last"
+msgstr "in the last"
+
+#: id:21411
+msgid "not in the last"
+msgstr "not in the last"
+
+#: id:21412
+msgid "Scrapers"
+msgstr "スクレーパー"
+
+#: id:21413
+msgid "Default movie scraper"
+msgstr "規定の映画用スクレーパー"
+
+#: id:21414
+msgid "Default tvshow scraper"
+msgstr "規定のテレビ番組用スクレーパー"
+
+#: id:21415
+msgid "Default music video scraper"
+msgstr "規定の音楽ビデオ用スクレーパー"
+
+#: id:21416
+msgid "Enable fallback based on scraper language"
+msgstr ""
+
+#: id:21417
+msgid "- Settings"
+msgstr ""
+
+#: id:21418
+msgid "Multilingual"
+msgstr ""
+
+#: id:21419
+msgid "No scrapers present"
+msgstr "スクレーパーがありません"
+
+#: id:21420
+msgid "Value to match"
+msgstr "Value to match"
+
+#: id:21421
+msgid "Smart playlist rule"
+msgstr "Smart Playlist Rule"
+
+#: id:21422
+msgid "Match items where"
+msgstr "Match items where"
+
+#: id:21423
+msgid "New rule..."
+msgstr "New Rule..."
+
+#: id:21424
+msgid "Items must match"
+msgstr "Items must match"
+
+#: id:21425
+msgid "all of the rules"
+msgstr "all of the rules"
+
+#: id:21426
+msgid "one or more of the rules"
+msgstr "one or more of the rules"
+
+#: id:21427
+msgid "Limit to"
+msgstr "Limit to"
+
+#: id:21428
+msgid "No limit"
+msgstr "No Limit"
+
+#: id:21429
+msgid "Order by"
+msgstr "並べ替え"
+
+#: id:21430
+msgid "ascending"
+msgstr "昇順"
+
+#: id:21431
+msgid "descending"
+msgstr "降順"
+
+#: id:21432
+msgid "Edit smart playlist"
+msgstr "スマートプレイリストの編集"
+
+#: id:21433
+msgid "Name of the playlist"
+msgstr "プレイリスト名"
+
+#: id:21434
+msgid "Find items where"
+msgstr "Find items where"
+
+#: id:21435
+msgid "Edit"
+msgstr "編集"
+
+#: id:21436
+msgid "%i items"
+msgstr "%i アイテム"
+
+#: id:21437
+msgid "New smart playlist..."
+msgstr "新規スマートプレイリスト..."
+
+#: id:21438
+msgid "%c Drive"
+msgstr "%c ドライブ"
+
+#: id:21439
+msgid "Edit party mode rules"
+msgstr "パーティモードルールの編集"
+
+#: id:21440
+msgid "Home folder"
+msgstr ""
+
+#: id:21441
+msgid "Watched count"
+msgstr "試聴回数"
+
+#: id:21442
+msgid "Episode title"
+msgstr "エピソードタイトル"
+
+#: id:21443
+msgid "Video resolution"
+msgstr "ビデオの解像度"
+
+#: id:21444
+msgid "Audio channels"
+msgstr "オーディオチャンネル"
+
+#: id:21445
+msgid "Video codec"
+msgstr "ビデオコーデック"
+
+#: id:21446
+msgid "Audio codec"
+msgstr "オーディオコーデック"
+
+#: id:21447
+msgid "Audio language"
+msgstr "音声言語"
+
+#: id:21448
+msgid "Subtitle language"
+msgstr "字幕言語"
+
+#: id:21449
+msgid "Remote control sends keyboard presses"
+msgstr "リモコンによるキーボード入力"
+
+#: id:21450
+msgid "- Edit"
+msgstr "- 編集"
+
+#: id:21451
+msgid "Internet connection required."
+msgstr "インターネット接続が必要です。"
+
+#: id:21452
+msgid "Get More..."
+msgstr "Get More..."
+
+#: id:21453
+msgid "Root filesystem"
+msgstr "Root filesystem"
+
+#: id:21454
+msgid "Cache full"
+msgstr "Cache full"
+
+#: id:21455
+msgid "Cache filled before reaching required amount for continous playback"
+msgstr "Cache filled before reaching required amount for continous playback"
+
+#: id:21460
+msgid "Subtitle location"
+msgstr "字幕の場所"
+
+#: id:21461
+msgid "Fixed"
+msgstr "Fixed"
+
+#: id:21462
+msgid "Bottom of video"
+msgstr "Bottom of video"
+
+#: id:21463
+msgid "Below video"
+msgstr "Below video"
+
+#: id:21464
+msgid "Top of video"
+msgstr "Top of video"
+
+#: id:21465
+msgid "Above video"
+msgstr "Above video"
+
+#: id:21800
+msgid "File name"
+msgstr "ファイル名"
+
+#: id:21801
+msgid "File path"
+msgstr "ファイルのパス"
+
+#: id:21802
+msgid "File size"
+msgstr "ファイルサイズ"
+
+#: id:21803
+msgid "File date/time"
+msgstr "ファイルの日付"
+
+#: id:21804
+msgid "Slide index"
+msgstr "Slide Index"
+
+#: id:21805
+msgctxt "Auto context with id 21805"
+msgid "Resolution"
+msgstr "解像度"
+
+#: id:21806
+msgctxt "Auto context with id 21806"
+msgid "Comment"
+msgstr "コメント"
+
+#: id:21807
+msgid "Colour/B&W"
+msgstr "カラー/白黒"
+
+#: id:21808
+msgid "JPEG process"
+msgstr "JPEG 処理"
+
+#: id:21820
+msgid "Date/Time"
+msgstr "日時"
+
+#: id:21821
+msgid "Description"
+msgstr "説明"
+
+#: id:21822
+msgid "Camera make"
+msgstr "カメラのメーカー"
+
+#: id:21823
+msgid "Camera model"
+msgstr "カメラのモデル名"
+
+#: id:21824
+msgid "EXIF comment"
+msgstr "EXIF コメント"
+
+#: id:21825
+msgid "Firmware"
+msgstr "ファームウェア"
+
+#: id:21826
+msgid "Aperture"
+msgstr "絞り"
+
+#: id:21827
+msgid "Focal length"
+msgstr "焦点距離"
+
+#: id:21828
+msgid "Focus distance"
+msgstr "ピント位置"
+
+#: id:21829
+msgid "Exposure"
+msgstr "露出"
+
+#: id:21830
+msgid "Exposure time"
+msgstr "露出時間"
+
+#: id:21831
+msgid "Exposure bias"
+msgstr "露出バイアス"
+
+#: id:21832
+msgid "Exposure mode"
+msgstr "露出モード"
+
+#: id:21833
+msgid "Flash used"
+msgstr "フラッシュの有無"
+
+#: id:21834
+msgid "White-balance"
+msgstr "ホワイトバランス"
+
+#: id:21835
+msgid "Light source"
+msgstr "光源"
+
+#: id:21836
+msgid "Metering mode"
+msgstr "測光方式"
+
+#: id:21837
+msgid "ISO"
+msgstr "ISO"
+
+#: id:21838
+msgid "Digital zoom"
+msgstr "ディジタルズーム"
+
+#: id:21839
+msgid "CCD width"
+msgstr "CCD の横幅"
+
+#: id:21840
+msgid "GPS latitude"
+msgstr "GPS 緯度"
+
+#: id:21841
+msgid "GPS longitude"
+msgstr "GPS 経度"
+
+#: id:21842
+msgid "GPS altitude"
+msgstr "GPS 高度"
+
+#: id:21843
+msgid "Orientation"
+msgstr "写真の向き"
+
+#: id:21860
+msgid "Supplemental categories"
+msgstr "追加カテゴリ"
+
+#: id:21861
+msgid "Keywords"
+msgstr "キーワード"
+
+#: id:21862
+msgid "Caption"
+msgstr "キャプション"
+
+#: id:21863
+msgid "Author"
+msgstr "作者"
+
+#: id:21864
+msgid "Headline"
+msgstr "ヘッドライン"
+
+#: id:21865
+msgid "Special instructions"
+msgstr "Special Instructions"
+
+#: id:21866
+msgid "Category"
+msgstr "カテゴリー"
+
+#: id:21867
+msgid "Byline"
+msgstr "Byline"
+
+#: id:21868
+msgid "Byline title"
+msgstr "Byline Title"
+
+#: id:21869
+msgid "Credit"
+msgstr "クレジット"
+
+#: id:21870
+msgid "Source"
+msgstr "ソース"
+
+#: id:21871
+msgid "Copyright notice"
+msgstr "著作権情報"
+
+#: id:21872
+msgid "Object name"
+msgstr "Object Name"
+
+#: id:21873
+msgid "City"
+msgstr "City"
+
+#: id:21874
+msgid "State"
+msgstr "State"
+
+#: id:21875
+msgctxt "Auto context with id 21875"
+msgid "Country"
+msgstr "Country"
+
+#: id:21876
+msgid "Original Tx Reference"
+msgstr "Original Tx Reference"
+
+#: id:21877
+msgid "Date created"
+msgstr "Date Created"
+
+#: id:21878
+msgid "Copyright flag"
+msgstr "Copyright Flag"
+
+#: id:21879
+msgid "Country code"
+msgstr "Country Code"
+
+#: id:21880
+msgid "Reference service"
+msgstr "Reference Service"
+
+#: id:21881
+msgid "Allow control of XBMC via UPnP"
+msgstr "UPnP 経由でのXBMC の操作を許可"
+
+#: id:21882
+msgid "Attempt to skip introduction before DVD menu"
+msgstr "DVD メニューより前のイントロ部分をスキップ (可能な場合)"
+
+#: id:21883
+msgid "Saved music"
+msgstr "Saved music"
+
+#: id:21884
+msgid "Query info for all artists"
+msgstr "全アーティストの情報を検索"
+
+#: id:21885
+msgid "Downloading album information"
+msgstr "アルバム情報を取得中"
+
+#: id:21886
+msgid "Downloading artist information"
+msgstr "アーティスト情報を取得中"
+
+#: id:21887
+msgid "Biography"
+msgstr "バイオグラフィー"
+
+#: id:21888
+msgid "Discography"
+msgstr "ディスコグラフィー"
+
+#: id:21889
+msgid "Searching artist"
+msgstr "アーティストの検索"
+
+#: id:21890
+msgid "Select artist"
+msgstr "アーティストを選択"
+
+#: id:21891
+msgctxt "Auto context with id 21891"
+msgid "Artist information"
+msgstr "アーティスト情報"
+
+#: id:21892
+msgid "Instruments"
+msgstr "楽器"
+
+#: id:21893
+msgid "Born"
+msgstr "生まれ"
+
+#: id:21894
+msgid "Formed"
+msgstr "結成"
+
+#: id:21895
+msgid "Themes"
+msgstr "テーマ"
+
+#: id:21896
+msgid "Disbanded"
+msgstr "解散"
+
+#: id:21897
+msgid "Died"
+msgstr "死去"
+
+#: id:21898
+msgid "Years active"
+msgstr "アクティブな期間"
+
+#: id:21899
+msgid "Label"
+msgstr "レーベル"
+
+#: id:21900
+msgid "Born/Formed"
+msgstr "生誕/結成"
+
+#: id:22000
+msgid "Update library on startup"
+msgstr "開始時にライブラリを更新"
+
+#: id:22001
+msgid "Hide progress of library updates"
+msgstr "ライブラリの更新状況を表示しない"
+
+#: id:22002
+msgid "- DNS suffix"
+msgstr "- DNSサフィックス"
+
+#: id:22003
+msgid "%2.3fs"
+msgstr "%2.3fs"
+
+#: id:22004
+msgid "Delayed by: %2.3fs"
+msgstr "Delayed by: %2.3fs"
+
+#: id:22005
+msgid "Ahead by: %2.3fs"
+msgstr "Ahead by: %2.3fs"
+
+#: id:22006
+msgid "Subtitle offset"
+msgstr "字幕オフセット"
+
+#: id:22007
+msgid "OpenGL vendor:"
+msgstr "OpenGL ベンダー:"
+
+#: id:22008
+msgid "OpenGL renderer:"
+msgstr "OpenGL レンダラー:"
+
+#: id:22009
+msgid "OpenGL version:"
+msgstr "OpenGL バージョン:"
+
+#: id:22010
+msgid "GPU temperature:"
+msgstr "GPU 温度:"
+
+#: id:22011
+msgid "CPU temperature:"
+msgstr "CPU 温度:"
+
+#: id:22012
+msgid "Total memory"
+msgstr "合計メモリー"
+
+#: id:22013
+msgid "Profile data"
+msgstr "プロファイルデータ"
+
+#: id:22014
+msgid "Use dim if paused during video playback"
+msgstr "ビデオ再生中に一時停止したら画面を暗くする"
+
+#: id:22015
+msgid "All recordings"
+msgstr "全録音"
+
+#: id:22016
+msgid "By title"
+msgstr "タイトル順"
+
+#: id:22017
+msgid "By group"
+msgstr "グループ順"
+
+#: id:22018
+msgid "Live channels"
+msgstr "ライブチャンネル"
+
+#: id:22019
+msgid "Recordings by title"
+msgstr "タイトル順録音"
+
+#: id:22020
+msgid "Guide"
+msgstr "ガイド"
+
+#: id:22021
+msgid "Allowed error in aspect ratio to minimize black bars"
+msgstr "Allowed error in aspect ratio to minimize black bars"
+
+#: id:22022
+msgid "Show video files in listings"
+msgstr "Show video files in listings"
+
+#: id:22023
+msgid "DirectX vendor:"
+msgstr "DirectX ベンダー:"
+
+#: id:22024
+msgid "Direct3D version:"
+msgstr "Direct3D バージョン:"
+
+#: id:22030
+msgctxt "Auto context with id 22030"
+msgid "Font"
+msgstr "フォント"
+
+#: id:22031
+msgctxt "Auto context with id 22031"
+msgid "- Size"
+msgstr "- サイズ"
+
+#: id:22032
+msgctxt "Auto context with id 22032"
+msgid "- Colours"
+msgstr "- 色"
+
+#: id:22033
+msgid "- Charset"
+msgstr "- 文字セット"
+
+#: id:22034
+msgid "Export karaoke titles as HTML"
+msgstr "カラオケタイトルをエクスポート (HTML)"
+
+#: id:22035
+msgid "Export karaoke titles as CSV"
+msgstr "カラオケタイトルをエクスポート (CSV)"
+
+#: id:22036
+msgid "Import karaoke titles..."
+msgstr "カラオケタイトルのインポート..."
+
+#: id:22037
+msgid "Show song selector automatically"
+msgstr "Show song selector automatically"
+
+#: id:22038
+msgid "Export karaoke titles..."
+msgstr "カラオケタイトルのエクスポート..."
+
+#: id:22039
+msgid "Enter song number"
+msgstr "Enter song number"
+
+#: id:22040
+msgid "white/green"
+msgstr "白/緑"
+
+#: id:22041
+msgid "white/red"
+msgstr "白/赤"
+
+#: id:22042
+msgid "white/blue"
+msgstr "白/青"
+
+#: id:22043
+msgid "black/white"
+msgstr "黒/白"
+
+#: id:22079
+msgid "Default select action"
+msgstr "デフォルトの動作"
+
+#: id:22080
+msgid "Choose"
+msgstr "選択"
+
+#: id:22081
+msgid "Show Information"
+msgstr "情報を表示"
+
+#: id:22082
+msgid "More..."
+msgstr "さらに..."
+
+#: id:22083
+msgid "Play all"
+msgstr "全て再生"
+
+#: id:23049
+msgid "Teletext not available"
+msgstr "Teletext not available"
+
+#: id:23050
+msgid "Activate Teletext"
+msgstr "Activate Teletext"
+
+#: id:23051
+msgid "Part %i"
+msgstr "Part %i"
+
+#: id:23052
+msgid "Buffering %i bytes"
+msgstr "Buffering %i bytes"
+
+#: id:23053
+msgid "Stopping"
+msgstr "Stopping"
+
+#: id:23054
+msgid "Running"
+msgstr "Running"
+
+#: id:23100
+msgid "External Player Active"
+msgstr "External Player Active"
+
+#: id:23101
+msgid "Click OK to terminate the player"
+msgstr "Click OK to terminate the player"
+
+#: id:23104
+msgid "Click OK when playback has ended"
+msgstr "Click OK when playback has ended"
+
+#: id:24000
+msgid "Add-on"
+msgstr "アドオン"
+
+#: id:24001
+msgid "Add-ons"
+msgstr "アドオン"
+
+#: id:24002
+msgid "Add-on options"
+msgstr "アドオン設定"
+
+#: id:24003
+msgid "Add-on Information"
+msgstr "アドオン情報"
+
+#: id:24005
+msgctxt "Auto context with id 24005"
+msgid "Media sources"
+msgstr "メディアソース"
+
+#: id:24007
+msgctxt "Auto context with id 24007"
+msgid "Movie information"
+msgstr "ムービー情報"
+
+#: id:24008
+msgctxt "Auto context with id 24008"
+msgid "Screensaver"
+msgstr "スクリーンセーバー"
+
+#: id:24009
+msgid "Script"
+msgstr "スクリプト"
+
+#: id:24010
+msgctxt "Auto context with id 24010"
+msgid "Visualization"
+msgstr "視覚エフェクト"
+
+#: id:24011
+msgid "Add-on repository"
+msgstr "字幕"
+
+#: id:24012
+msgctxt "Auto context with id 24012"
+msgid "Subtitles"
+msgstr ""
+
+#: id:24013
+msgid "Lyrics"
+msgstr "歌詞"
+
+#: id:24014
+msgid "TV information"
+msgstr "TV 情報"
+
+#: id:24015
+msgctxt "Auto context with id 24015"
+msgid "Music video information"
+msgstr "ミュージックビデオ情報"
+
+#: id:24016
+msgctxt "Auto context with id 24016"
+msgid "Album information"
+msgstr "アルバム情報"
+
+#: id:24017
+msgctxt "Auto context with id 24017"
+msgid "Artist information"
+msgstr "アーティスト情報"
+
+#: id:24018
+msgctxt "Auto context with id 24018"
+msgid "Services"
+msgstr "サービス"
+
+#: id:24020
+msgid "Configure"
+msgstr "設定"
+
+#: id:24021
+msgctxt "Auto context with id 24021"
+msgid "Disable"
+msgstr "無効"
+
+#: id:24022
+msgid "Enable"
+msgstr "有効"
+
+#: id:24023
+msgid "Add-on disabled"
+msgstr "アドオン無効"
+
+#: id:24027
+msgctxt "Auto context with id 24027"
+msgid "Weather"
+msgstr "天気"
+
+#: id:24028
+msgid "Weather.com (standard)"
+msgstr "Weather.com (標準)"
+
+#: id:24030
+msgid "This Add-on can not be configured"
+msgstr "このアドオンは設定できません"
+
+#: id:24031
+msgid "Error loading settings"
+msgstr "設定の読み込みに失敗"
+
+#: id:24032
+msgid "All Add-ons"
+msgstr "すべてのアドオン"
+
+#: id:24033
+msgid "Get Add-ons"
+msgstr "アドオン取得"
+
+#: id:24034
+msgid "Check for updates"
+msgstr "アップデートの確認"
+
+#: id:24035
+msgid "Force refresh"
+msgstr "強制的にリフレッシュ"
+
+#: id:24036
+msgid "Change log"
+msgstr "変更履歴"
+
+#: id:24037
+msgid "Uninstall"
+msgstr "アンインストール"
+
+#: id:24038
+msgid "Install"
+msgstr "インストール"
+
+#: id:24039
+msgid "Disabled Add-ons"
+msgstr "無効なアドオン"
+
+#: id:24040
+msgid "(Clear the current setting)"
+msgstr "(現在の設定をクリア)"
+
+#: id:24041
+msgid "Install from zip file"
+msgstr "zip ファイルからインストール"
+
+#: id:24042
+msgid "Downloading %i%%"
+msgstr "ダウンロード中 %i%%"
+
+#: id:24043
+msgid "Available Updates"
+msgstr "利用可能なアップデート"
+
+#: id:24044
+msgid "Dependencies not met"
+msgstr "依存関係が満たされません"
+
+#: id:24045
+msgid "Add-on does not have the correct structure"
+msgstr "アドオンが正しい構造になっていません"
+
+#: id:24046
+msgid "%s is used by the following installed add-on(s)"
+msgstr "%s は以下のインストール済のアドオンに使われています"
+
+#: id:24047
+msgid "This add-on cannot be uninstalled"
+msgstr "このアドオンはアンインストールできません"
+
+#: id:24048
+msgid "Rollback"
+msgstr "ロールバック"
+
+#: id:24050
+msgid "Available Add-ons"
+msgstr "利用可能なアドオン"
+
+#: id:24051
+msgid "Version:"
+msgstr "バージョン:"
+
+#: id:24052
+msgid "Disclaimer"
+msgstr "注意書き"
+
+#: id:24053
+msgid "License:"
+msgstr "ライセンス:"
+
+#: id:24054
+msgid "Changelog"
+msgstr "変更履歴"
+
+#: id:24059
+msgid "Would you like to enable this Add-on?"
+msgstr "このアドオンを有効にしますか？"
+
+#: id:24060
+msgid "Would you like to disable this Add-on?"
+msgstr "このアドオンを無効にしますか？"
+
+#: id:24061
+msgid "Add-on update available!"
+msgstr "アドオンのアップデートがあります!"
+
+#: id:24062
+msgid "Enabled Add-ons"
+msgstr "有効なアドオン"
+
+#: id:24063
+msgid "Auto update"
+msgstr "自動更新"
+
+#: id:24064
+msgid "Add-on enabled"
+msgstr "アドオンが有効になりました"
+
+#: id:24065
+msgid "Add-on updated"
+msgstr "アドオンが更新されました"
+
+#: id:24066
+msgid "Cancel Add-on download?"
+msgstr "アドオンのダウンロードをキャンセルしますか?"
+
+#: id:24067
+msgid "Currently downloading Add-ons"
+msgstr "現在ダウンロード中のアドオン"
+
+#: id:24068
+msgid "Update available"
+msgstr "アップデート可能"
+
+#: id:24069
+msgid "Update"
+msgstr "アップデート"
+
+#: id:24070
+msgid "Add-on could not be loaded."
+msgstr "アドオンを読み込めませんでした。"
+
+#: id:24071
+msgid "An unknown error has occurred."
+msgstr "原因不明のエラーが発生しました。"
+
+#: id:24072
+msgid "Settings required"
+msgstr "設定が必要"
+
+#: id:24073
+msgid "Could not connect"
+msgstr "接続不可"
+
+#: id:24074
+msgid "Needs to restart"
+msgstr "再起動が必要"
+
+#: id:24075
+msgctxt "Auto context with id 24075"
+msgid "Disable"
+msgstr "無効化"
+
+#: id:24076
+msgid "Add-on Required"
+msgstr "必要なアドオン"
+
+#: id:24080
+msgid "Try to reconnect?"
+msgstr "最接続しますか?"
+
+#: id:24089
+msgid "Add-on restarts"
+msgstr "アドオンの再起動"
+
+#: id:24090
+msgid "Lock Add-on manager"
+msgstr "アドオンマネージャをロック"
+
+#: id:24094
+msgid "(current)"
+msgstr "(現在)"
+
+#: id:24095
+msgid "(blacklisted)"
+msgstr "(ブラックリスト)"
+
+#: id:24096
+msgid "Add-on has been marked as broken in repository."
+msgstr "Add-on has been marked as broken in repository."
+
+#: id:24097
+msgid "Would you like to disable it on your system?"
+msgstr "このシステム上で無効にしますか?"
+
+#: id:24098
+msgid "Broken"
+msgstr "Broken"
+
+#: id:24099
+msgid "Would you like to switch to this skin?"
+msgstr "このスキンに切り替えますか?"
+
+#: id:24100
+msgid "To use this feature you must download an Add-on:"
+msgstr "この機能を使うには以下のアドオンのダウンロードが必要です:"
+
+#: id:24101
+msgid "Would you like to download this Add-on?"
+msgstr "このアドオンをダウンロードしますか?"
+
+#: id:25000
+msgid "Notifications"
+msgstr "通知"
+
+#: id:29800
+msgid "Library Mode"
+msgstr "ライブラリモード"
+
+#: id:29801
+msgid "QWERTY keyboard"
+msgstr "QWERTYキーボード"
+
+#: id:29802
+msgid "Passthrough Audio in use"
+msgstr "パススルーオーディオ使用中"
+
+#: id:33001
+msgid "Trailer quality"
+msgstr "予告編の品質"
+
+#: id:33002
+msgid "Stream"
+msgstr "ストリーム"
+
+#: id:33003
+msgid "Download"
+msgstr "ダウンロード"
+
+#: id:33004
+msgid "Download & play"
+msgstr "ダウンロードして再生"
+
+#: id:33005
+msgid "Download & save"
+msgstr "ダウンロードして保存"
+
+#: id:33006
+msgid "Today"
+msgstr "今日"
+
+#: id:33007
+msgid "Tomorrow"
+msgstr "明日"
+
+#: id:33008
+msgid "Saving"
+msgstr "Saving"
+
+#: id:33009
+msgid "Copying"
+msgstr "Copying"
+
+#: id:33010
+msgid "Set download directory"
+msgstr "ダウンロードフォルダの指定"
+
+#: id:33011
+msgid "Search duration"
+msgstr "Search duration"
+
+#: id:33012
+msgid "Short"
+msgstr "Short"
+
+#: id:33013
+msgid "Long"
+msgstr "Long"
+
+#: id:33014
+msgid "Use DVD player instead of regular player"
+msgstr "通常のプレーヤーの代わりに DVD プレーヤーを使用"
+
+#: id:33015
+msgid "Ask for download before playing video"
+msgstr "ビデオ再生前にダウンロードするか確認する"
+
+#: id:33016
+msgid "Clips"
+msgstr "クリップ"
+
+#: id:33017
+msgid "Restart plugin to enable"
+msgstr "プラグインを再起動して有効にする"
+
+#: id:33018
+msgid "Tonight"
+msgstr "今夜"
+
+#: id:33019
+msgid "Tomorrow Night"
+msgstr "明日の夜"
+
+#: id:33020
+msgid "Condition"
+msgstr "Condition"
+
+#: id:33021
+msgid "Precipitation"
+msgstr "降雨量"
+
+#: id:33022
+msgid "Precip"
+msgstr "降雨量"
+
+#: id:33023
+msgid "Humid"
+msgstr "Humid"
+
+#: id:33024
+msgid "Feels"
+msgstr "Feels"
+
+#: id:33025
+msgid "Observed"
+msgstr "Observed"
+
+#: id:33026
+msgid "Departure from normal"
+msgstr "Departure from normal"
+
+#: id:33027
+msgid "Sunrise"
+msgstr "Sunrise"
+
+#: id:33028
+msgid "Sunset"
+msgstr "日没"
+
+#: id:33029
+msgid "Details"
+msgstr "Details"
+
+#: id:33030
+msgid "Outlook"
+msgstr "Outlook"
+
+#: id:33031
+msgid "Coverflow"
+msgstr "カバーフロー"
+
+#: id:33032
+msgid "Translate text"
+msgstr "テキストを翻訳"
+
+#: id:33033
+msgid "Map list %s category"
+msgstr "Map list %s category"
+
+#: id:33034
+msgid "36 Hour"
+msgstr "36 Hour"
+
+#: id:33035
+msgid "Maps"
+msgstr "マップ"
+
+#: id:33036
+msgid "Hourly"
+msgstr "時間ごと"
+
+#: id:33037
+msgid "Weekend"
+msgstr "週末"
+
+#: id:33038
+msgid "%s day"
+msgstr "%s日"
+
+#: id:33049
+msgid "Alert"
+msgstr "アラート"
+
+#: id:33050
+msgid "Alerts"
+msgstr "アラート"
+
+#: id:33051
+msgid "Choose Your"
+msgstr "選択する:"
+
+#: id:33052
+msgid "Check"
+msgstr "チェック:"
+
+#: id:33053
+msgctxt "Auto context with id 33053"
+msgid "Configure the"
+msgstr "設定する:"
+
+#: id:33054
+msgid "Seasons"
+msgstr "シーズン"
+
+#: id:33055
+msgid "Use your"
+msgstr "使用:"
+
+#: id:33056
+msgid "Watch your"
+msgstr "観る:"
+
+#: id:33057
+msgid "Listen to"
+msgstr "聴く:"
+
+#: id:33058
+msgid "View your"
+msgstr "見る:"
+
+#: id:33059
+msgctxt "Auto context with id 33059"
+msgid "Configure the"
+msgstr "設定する:"
+
+#: id:33060
+msgid "Power"
+msgstr "Power"
+
+#: id:33061
+msgid "Menu"
+msgstr "メニュー"
+
+#: id:33062
+msgid "Play the"
+msgstr "再生する:"
+
+#: id:33063
+msgid "Options"
+msgstr "オプション"
+
+#: id:33065
+msgid "Editor"
+msgstr "エディター"
+
+#: id:33066
+msgid "About your"
+msgstr "About your"
+
+#: id:33067
+msgid "Star rating"
+msgstr "星の評価"
+
+#: id:33068
+msgid "Background"
+msgstr "バックグラウンド"
+
+#: id:33069
+msgid "Backgrounds"
+msgstr "バックグラウンド"
+
+#: id:33070
+msgid "Custom background"
+msgstr "カスタムバックグラウンド"
+
+#: id:33071
+msgid "Custom backgrounds"
+msgstr "カスタムバックグラウンド"
+
+#: id:33072
+msgid "View Readme"
+msgstr "README をみる"
+
+#: id:33073
+msgid "View Changelog"
+msgstr "Changelog をみる"
+
+#: id:33074
+msgid "This version of %s requires an"
+msgstr "このバージョンの %s は"
+
+#: id:33075
+msgid "XBMC revision of %s or greater to run."
+msgstr "XBMC リビジョン %s またはより新しい版が必要です。"
+
+#: id:33076
+msgid "Please update XBMC."
+msgstr "XBMC をアップデートしてください。"
+
+#: id:33077
+msgid "No data found!"
+msgstr "データが見つかりません!"
+
+#: id:33078
+msgid "Next page"
+msgstr "次のページ"
+
+#: id:33079
+msgid "Love"
+msgstr "Love"
+
+#: id:33080
+msgid "Hate"
+msgstr "Hate"
+
+#: id:33081
+msgid "This file is stacked, select the part you want to play from."
+msgstr "This file is stacked, select the part you want to play from."
+
+#: id:33082
+msgid "Path to script"
+msgstr "スクリプトのパス"
+
+#: id:33083
+msgid "Enable custom script button"
+msgstr "カスタムスクリプト用ボタンを有効にする"
+
+#: id:33100
+msgid "Failed to start"
+msgstr "起動に失敗しました:"
+
+#: id:33101
+msgid "Webserver"
+msgstr "Web サーバー"
+
+#: id:33102
+msgid "Event Server"
+msgstr "イベントサーバー"
+
+#: id:33103
+msgid "Remote communication server"
+msgstr "リモートコミュニケーションサーバー"
+
+#: id:33200
+msgid "Detected New Connection"
+msgstr "新規コネクションを検出"
+
+#: id:34000
+msgid "Lame"
+msgstr ""
+
+#: id:34001
+msgid "Vorbis"
+msgstr ""
+
+#: id:34002
+msgid "Wav"
+msgstr ""
+
+#: id:34003
+msgid "DXVA2"
+msgstr ""
+
+#: id:34004
+msgid "VAAPI"
+msgstr ""
+
+#: id:34005
+msgid "Flac"
+msgstr ""
+
+#: id:34100
+msgid "Speaker Configuration"
+msgstr "スピーカー設定"
+
+#: id:34101
+msgid "2.0"
+msgstr "2.0"
+
+#: id:34102
+msgid "2.1"
+msgstr "2.1"
+
+#: id:34103
+msgid "3.0"
+msgstr "3.0"
+
+#: id:34104
+msgid "3.1"
+msgstr "3.1"
+
+#: id:34105
+msgid "4.0"
+msgstr "4.0"
+
+#: id:34106
+msgid "4.1"
+msgstr "4.1"
+
+#: id:34107
+msgid "5.0"
+msgstr "5.0"
+
+#: id:34108
+msgid "5.1"
+msgstr "5.1"
+
+#: id:34109
+msgid "7.0"
+msgstr "7.0"
+
+#: id:34110
+msgid "7.1"
+msgstr "7.1"
+
+#: id:34201
+msgid "Can't find a next item to play"
+msgstr "次のアイテムがありません"
+
+#: id:34202
+msgid "Can't find a previous item to play"
+msgstr "一つ前のアイテムがありません"
+
+#: id:34300
+msgid "Failed to start zeroconf"
+msgstr "Zeroconf 起動に失敗"
+
+#: id:34301
+msgid "Is Apple's Bonjour Service installed? See log for more info."
+msgstr "Apple の Bonjour サービスはインストールされていますか? 詳しくはログを参照して下さい。"
+
+#: id:34400
+msgid "Video Rendering"
+msgstr "ビデオレンダリング"
+
+#: id:34401
+msgid "Failed to init video filters/scalers, falling back to bilinear scaling"
+msgstr "ビデオフィルタ/リサイズの初期化に失敗しました。代わりにバイリニアスケーリングを行います。"
+
+#: id:34402
+msgid "Failed to initialize audio device"
+msgstr "オーディオデバイスの初期化に失敗"
+
+#: id:34403
+msgid "Check your audiosettings"
+msgstr "オーディオ設定を見直してください"
+
+#: id:34404
+msgid "Use gestures for navigation:"
+msgstr ""
+
+#: id:34405
+msgid "1 finger swipe left,right,up,down for cursors"
+msgstr ""
+
+#: id:34406
+msgid "2 finger swipe left for backspace"
+msgstr ""
+
+#: id:34407
+msgid "1 finger single tap for enter"
+msgstr ""
+
+#: id:34408
+msgid "2 finger single tap for contextmenu"
+msgstr ""
+
+#: id:35000
+msgid "Peripherals"
+msgstr "周辺機器"
+
+#: id:35001
+msgid "Generic HID device"
+msgstr "汎用 HID デバイス"
+
+#: id:35002
+msgid "Generic network adapter"
+msgstr "汎用ネットワークアダプタ"
+
+#: id:35003
+msgid "Generic disk"
+msgstr "汎用ディスク"
+
+#: id:35004
+msgid "There are no settings available\nfor this peripheral."
+msgstr "この周辺機器用の設定はありません。"
+
+#: id:35005
+msgid "New device configured"
+msgstr "新しいデバイスが設定されました"
+
+#: id:35006
+msgid "Device removed"
+msgstr "デバイスが取り外されました"
+
+#: id:35007
+msgid "Keymap to use for this device"
+msgstr "このデバイスで使うキーマップ"
+
+#: id:35008
+msgid "Keymap enabled"
+msgstr "キーマップ有効"
+
+#: id:35009
+msgid "Do not use the custom keymap for this device"
+msgstr "このデバイスではカスタムキーマップを使わないで下さい"
+
+#: id:35500
+msgid "Location"
+msgstr "Location"
+
+#: id:35501
+msgid "Class"
+msgstr "Class"
+
+#: id:35502
+msgctxt "Auto context with id 35502"
+msgid "Name"
+msgstr "Name"
+
+#: id:35503
+msgid "Vendor"
+msgstr "Vendor"
+
+#: id:35504
+msgid "Product ID"
+msgstr "Product ID"
+
+#: id:36000
+msgid "Pulse-Eight CEC adapter"
+msgstr "Pulse-Eight CEC アダプタ"
+
+#: id:36001
+msgid "Pulse-Eight Nyxboard"
+msgstr "Pulse-Eight Nyxboard リモコン"
+
+#: id:36002
+msgid "Switch to keyboard side command"
+msgstr "Switch to keyboard side command"
+
+#: id:36003
+msgid "Switch to remote side command"
+msgstr "Switch to remote side command"
+
+#: id:36004
+msgid "Press \"user\" button command"
+msgstr "Press \"user\" button command"
+
+#: id:36005
+msgid "Enable switch side commands"
+msgstr "Enable switch side commands"
+
+#: id:36006
+msgid "Could not open the adapter"
+msgstr "アダプタをオープンできませんでした"
+
+#: id:36007
+msgid "Devices to power on when starting XBMC"
+msgstr "XBMC 起動時に電源を入れるデバイス"
+
+#: id:36008
+msgid "Devices to power off when stopping XBMC"
+msgstr "XBMC 終了時に電源を切るデバイス"
+
+#: id:36009
+msgid "Put devices in standby mode when activating screensaver"
+msgstr "スクリーンセーバー動作中にデバイスをスタンバイモードにする"
+
+#: id:36011
+msgid "Could not detect the CEC port. Set it up manually."
+msgstr "CEC ポートが検出できませんでした。手動で設定してください。"
+
+#: id:36012
+msgid "Could not initialise the CEC adapter. Check your settings."
+msgstr "CEC アダプタの初期化に失敗しました。設定を見直してください。"
+
+#: id:36013
+msgid "Unsupported libCEC interface version. %d is greater than the version XBMC supports (%d)"
+msgstr "この libCEC インターフェースバージョンは未サポートです。%d は、XBMC がサポートするバージョン %d より大きいバージョン番号です。"
+
+#: id:36014
+msgid "Put this PC in standby mode when the TV is switched off"
+msgstr "TV の電源が落とされたら PC をスタンバイモードにする"
+
+#: id:36015
+msgid "HDMI port number"
+msgstr "HDMI ポート番号"
+
+#: id:36016
+msgctxt "Auto context with id 36016"
+msgid "Connected"
+msgstr "接続完了"
+
+#: id:36017
+msgid "Adapter found, but libCEC is not available"
+msgstr "アダプタはありますが libCEC がありません"
+
+#: id:36018
+msgid "Use the TV's language setting"
+msgstr "TV の言語設定を使ってください"
+
+#: id:36019
+msgid "Connected to HDMI device"
+msgstr "HDMI デバイスに接続しました"
+
+#: id:36020
+msgid "Make XBMC the active source when starting"
+msgstr "起動時に XBMC をアクティブソースにする"
+
+#: id:36021
+msgid "Physical address (overrules HDMI port)"
+msgstr "物理アドレス (HDMI ポートを上書き)"
+
+#: id:36022
+msgid "COM port (leave empty unless needed)"
+msgstr "COM ポート (不要であれば空欄に)"
+
+#: id:36023
+msgid "Configuration updated"
+msgstr "設定が変更されました"
+
+#: id:36024
+msgid "Failed to set the new configuration. Please check your settings."
+msgstr "設定変更に失敗しました。設定内容を確認してください。"
+
+#: id:36025
+msgid "Send 'inactive source' command when stopping XBMC"
+msgstr "XBMC 終了時に'非アクティブソース'コマンドを送信"
+

--- a/language/Korean/strings.po
+++ b/language/Korean/strings.po
@@ -1,0 +1,9093 @@
+# Converted from xbmc strings.xml with xbmc-xml2po (by Team-XBMC)
+msgid ""
+msgstr ""
+"Project-Id-Version: xbmc.core-FRODO_GIT3ed1604ad7\n"
+"Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
+"POT-Creation-Date: 2012-04-09 18:00+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE\n"
+"Language: ko\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: id:0
+msgctxt "Auto context with id 0"
+msgid "Programs"
+msgstr "프로그램"
+
+#: id:1
+msgctxt "Auto context with id 1"
+msgid "Pictures"
+msgstr "사진"
+
+#: id:2
+msgctxt "Auto context with id 2"
+msgid "Music"
+msgstr "음악"
+
+#: id:3
+msgctxt "Auto context with id 3"
+msgid "Videos"
+msgstr "비디오"
+
+#: id:4
+msgid "TV-Guide"
+msgstr "TV-가이드"
+
+#: id:5
+msgctxt "Auto context with id 5"
+msgid "Settings"
+msgstr "설정"
+
+#: id:6
+msgid "XBMC SVN"
+msgstr "XBMC SVN"
+
+#: id:7
+msgctxt "Auto context with id 7"
+msgid "File manager"
+msgstr "파일 관리자"
+
+#: id:8
+msgctxt "Auto context with id 8"
+msgid "Weather"
+msgstr "날씨"
+
+#: id:9
+msgid "xbmc media center"
+msgstr "XBMC 미디어 센터"
+
+#: id:11
+msgid "Monday"
+msgstr "월요일"
+
+#: id:12
+msgid "Tuesday"
+msgstr "화요일"
+
+#: id:13
+msgid "Wednesday"
+msgstr "수요일"
+
+#: id:14
+msgid "Thursday"
+msgstr "목요일"
+
+#: id:15
+msgid "Friday"
+msgstr "금요일"
+
+#: id:16
+msgid "Saturday"
+msgstr "토요일"
+
+#: id:17
+msgid "Sunday"
+msgstr "일요일"
+
+#: id:21
+msgid "January"
+msgstr "1월"
+
+#: id:22
+msgid "February"
+msgstr "2월"
+
+#: id:23
+msgid "March"
+msgstr "3월"
+
+#: id:24
+msgid "April"
+msgstr "4월"
+
+#: id:25
+msgctxt "Auto context with id 25"
+msgid "May"
+msgstr "5월"
+
+#: id:26
+msgid "June"
+msgstr "6월"
+
+#: id:27
+msgid "July"
+msgstr "7월"
+
+#: id:28
+msgid "August"
+msgstr "8월"
+
+#: id:29
+msgid "September"
+msgstr "9월"
+
+#: id:30
+msgid "October"
+msgstr "10월"
+
+#: id:31
+msgid "November"
+msgstr "11월"
+
+#: id:32
+msgid "December"
+msgstr "12월"
+
+#: id:41
+msgid "Mon"
+msgstr "월"
+
+#: id:42
+msgid "Tue"
+msgstr "화"
+
+#: id:43
+msgid "Wed"
+msgstr "수"
+
+#: id:44
+msgid "Thu"
+msgstr "목"
+
+#: id:45
+msgid "Fri"
+msgstr "금"
+
+#: id:46
+msgid "Sat"
+msgstr "토"
+
+#: id:47
+msgctxt "Auto context with id 47"
+msgid "Sun"
+msgstr "일"
+
+#: id:51
+msgid "Jan"
+msgstr "1월"
+
+#: id:52
+msgid "Feb"
+msgstr "2월"
+
+#: id:53
+msgid "Mar"
+msgstr "3월"
+
+#: id:54
+msgid "Apr"
+msgstr "4월"
+
+#: id:55
+msgctxt "Auto context with id 55"
+msgid "May"
+msgstr "5월"
+
+#: id:56
+msgid "Jun"
+msgstr "6월"
+
+#: id:57
+msgid "Jul"
+msgstr "7월"
+
+#: id:58
+msgid "Aug"
+msgstr "8월"
+
+#: id:59
+msgid "Sep"
+msgstr "9월"
+
+#: id:60
+msgid "Oct"
+msgstr "10월"
+
+#: id:61
+msgid "Nov"
+msgstr "11월"
+
+#: id:62
+msgid "Dec"
+msgstr "12월"
+
+#: id:71
+msgid "N"
+msgstr "북"
+
+#: id:72
+msgid "NNE"
+msgstr "북북동"
+
+#: id:73
+msgid "NE"
+msgstr "북동"
+
+#: id:74
+msgid "ENE"
+msgstr "동북동"
+
+#: id:75
+msgid "E"
+msgstr "동"
+
+#: id:76
+msgid "ESE"
+msgstr "동남동"
+
+#: id:77
+msgid "SE"
+msgstr "남동"
+
+#: id:78
+msgid "SSE"
+msgstr "남남동"
+
+#: id:79
+msgid "S"
+msgstr "남"
+
+#: id:80
+msgid "SSW"
+msgstr "남남서"
+
+#: id:81
+msgid "SW"
+msgstr "남서"
+
+#: id:82
+msgid "WSW"
+msgstr "서남서"
+
+#: id:83
+msgid "W"
+msgstr "서"
+
+#: id:84
+msgid "WNW"
+msgstr "서북서"
+
+#: id:85
+msgid "NW"
+msgstr "북서"
+
+#: id:86
+msgid "NNW"
+msgstr "북북서"
+
+#: id:87
+msgid "VAR"
+msgstr "가변"
+
+#: id:98
+msgid "View: Auto"
+msgstr "보기: 자동"
+
+#: id:99
+msgid "View: Auto big"
+msgstr "보기: 자동(큰)"
+
+#: id:100
+msgid "View: Icons"
+msgstr "보기: 아이콘"
+
+#: id:101
+msgid "View: List"
+msgstr "보기: 목록"
+
+#: id:102
+msgctxt "Auto context with id 102"
+msgid "Scan"
+msgstr "검색"
+
+#: id:103
+msgctxt "Auto context with id 103"
+msgid "Sort by: Name"
+msgstr "정렬: 이름"
+
+#: id:104
+msgid "Sort by: Date"
+msgstr "정렬: 날짜"
+
+#: id:105
+msgid "Sort by: Size"
+msgstr "정렬: 크기"
+
+#: id:106
+msgid "No"
+msgstr "아니오"
+
+#: id:107
+msgid "Yes"
+msgstr "예"
+
+#: id:108
+msgctxt "Auto context with id 108"
+msgid "Slideshow"
+msgstr "슬라이드쇼"
+
+#: id:109
+msgid "Create thumbs"
+msgstr "미리보기 만들기"
+
+#: id:110
+msgid "Create thumbnails"
+msgstr "미리보기 만들기"
+
+#: id:111
+msgctxt "Auto context with id 111"
+msgid "Shortcuts"
+msgstr "바로가기"
+
+#: id:112
+msgid "Paused"
+msgstr "일시중지"
+
+#: id:113
+msgid "Update failed"
+msgstr "업데이트 실패함"
+
+#: id:114
+msgid "Installation failed"
+msgstr "설치 실패함"
+
+#: id:115
+msgid "Copy"
+msgstr "복사"
+
+#: id:116
+msgid "Move"
+msgstr "이동"
+
+#: id:117
+msgid "Delete"
+msgstr "삭제"
+
+#: id:118
+msgid "Rename"
+msgstr "이름변경"
+
+#: id:119
+msgid "New folder"
+msgstr "새 폴더"
+
+#: id:120
+msgid "Confirm file copy"
+msgstr "파일 복사 확인"
+
+#: id:121
+msgid "Confirm file move"
+msgstr "파일 이동 확인"
+
+#: id:122
+msgid "Confirm file delete?"
+msgstr "파일 삭제 확인?"
+
+#: id:123
+msgid "Copy these files?"
+msgstr "이 파일을 복사 하시겠습니까?"
+
+#: id:124
+msgid "Move these files?"
+msgstr "이 파일을 이동 하시겠습니까?"
+
+#: id:125
+msgid "Delete these files? - Deleting files cannot be undone!"
+msgstr "이 파일을 삭제 하시겠습니까? 삭제되는 파일은 되돌릴수 없음!"
+
+#: id:126
+msgid "Status"
+msgstr "상태"
+
+#: id:127
+msgid "Objects"
+msgstr "객체"
+
+#: id:128
+msgctxt "Auto context with id 128"
+msgid "General"
+msgstr "일반"
+
+#: id:129
+msgctxt "Auto context with id 129"
+msgid "Slideshow"
+msgstr "슬라이드쇼"
+
+#: id:130
+msgctxt "Auto context with id 130"
+msgid "System info"
+msgstr "시스템 정보"
+
+#: id:131
+msgid "Display"
+msgstr "화면"
+
+#: id:132
+msgid "Albums"
+msgstr "앨범"
+
+#: id:133
+msgid "Artists"
+msgstr "아티스트"
+
+#: id:134
+msgid "Songs"
+msgstr "노래"
+
+#: id:135
+msgid "Genres"
+msgstr "장르"
+
+#: id:136
+msgid "Playlists"
+msgstr "재생목록"
+
+#: id:137
+msgid "Search"
+msgstr "찾기"
+
+#: id:138
+msgid "System Information"
+msgstr "시스템 정보"
+
+#: id:139
+msgid "Temperatures:"
+msgstr "온도:"
+
+#: id:140
+msgid "CPU:"
+msgstr "CPU:"
+
+#: id:141
+msgid "GPU:"
+msgstr "GPU:"
+
+#: id:142
+msgid "Time:"
+msgstr "시간:"
+
+#: id:143
+msgid "Current:"
+msgstr "현재:"
+
+#: id:144
+msgid "Build:"
+msgstr "빌드:"
+
+#: id:145
+msgid "Network:"
+msgstr "네트워크:"
+
+#: id:146
+msgid "Type:"
+msgstr "형식:"
+
+#: id:147
+msgid "Static"
+msgstr "고정"
+
+#: id:148
+msgid "DHCP"
+msgstr "DHCP"
+
+#: id:149
+msgid "MAC address"
+msgstr "MAC 주소"
+
+#: id:150
+msgctxt "Auto context with id 150"
+msgid "IP address"
+msgstr "IP 주소"
+
+#: id:151
+msgid "Link:"
+msgstr "연결:"
+
+#: id:152
+msgid "Half duplex"
+msgstr "반이중"
+
+#: id:153
+msgid "Full duplex"
+msgstr "전이중"
+
+#: id:154
+msgctxt "Auto context with id 154"
+msgid "Storage"
+msgstr "저장장치"
+
+#: id:155
+msgid "Drive"
+msgstr "드라이브"
+
+#: id:156
+msgctxt "Auto context with id 156"
+msgid "Free"
+msgstr "여유"
+
+#: id:157
+msgctxt "Auto context with id 157"
+msgid "Video"
+msgstr "비디오"
+
+#: id:158
+msgid "Free memory"
+msgstr "여유 메모리"
+
+#: id:159
+msgid "No link"
+msgstr "연결 없음"
+
+#: id:160
+msgctxt "Auto context with id 160"
+msgid "Free"
+msgstr "사용가능"
+
+#: id:161
+msgid "Unavailable"
+msgstr "사용불가"
+
+#: id:162
+msgid "Tray open"
+msgstr "트레이 열림"
+
+#: id:163
+msgid "Reading"
+msgstr "읽기"
+
+#: id:164
+msgid "No disc"
+msgstr "디스크 없음"
+
+#: id:165
+msgid "Disc present"
+msgstr "디스크 있음"
+
+#: id:166
+msgid "Skin"
+msgstr "스킨"
+
+#: id:169
+msgctxt "Auto context with id 169"
+msgid "Resolution"
+msgstr "해상도"
+
+#: id:170
+msgid "Adjust display refresh rate to match video"
+msgstr "비디오에 맞게 화면 새로고침 비율 조정"
+
+#: id:172
+msgid "Release date"
+msgstr "개봉일"
+
+#: id:173
+msgid "Display 4:3 videos as"
+msgstr "4:3 비디오를 다음으로 표시:"
+
+#: id:175
+msgid "Moods"
+msgstr "분위기"
+
+#: id:176
+msgid "Styles"
+msgstr "스타일"
+
+#: id:179
+msgid "Song"
+msgstr "노래"
+
+#: id:180
+msgid "Duration"
+msgstr "재생시간"
+
+#: id:181
+msgid "Select album"
+msgstr "앨범 선택"
+
+#: id:182
+msgid "Tracks"
+msgstr "트랙"
+
+#: id:183
+msgid "Review"
+msgstr "리뷰"
+
+#: id:184
+msgid "Refresh"
+msgstr "새로고침"
+
+#: id:185
+msgid "Searching album"
+msgstr "앨범 찾기"
+
+#: id:186
+msgid "OK"
+msgstr "확인"
+
+#: id:187
+msgid "No albums found!"
+msgstr "앨범 찾지 못함!"
+
+#: id:188
+msgid "Select all"
+msgstr "모두 선택"
+
+#: id:189
+msgid "Scanning media info"
+msgstr "미디어 정보 검색"
+
+#: id:190
+msgid "Save"
+msgstr "저장"
+
+#: id:191
+msgid "Shuffle"
+msgstr "무작위 재생"
+
+#: id:192
+msgctxt "Auto context with id 192"
+msgid "Clear"
+msgstr "지우기"
+
+#: id:193
+msgctxt "Auto context with id 193"
+msgid "Scan"
+msgstr "검색"
+
+#: id:194
+msgid "Searching..."
+msgstr "찾는중..."
+
+#: id:195
+msgid "No info found!"
+msgstr "정보 찾지 못함!"
+
+#: id:196
+msgid "Select movie:"
+msgstr "영화 선택:"
+
+#: id:197
+msgid "Querying %s info"
+msgstr "%s 정보 요청"
+
+#: id:198
+msgid "Loading movie details"
+msgstr "영화 상세정보 읽기"
+
+#: id:199
+msgid "Web interface"
+msgstr "웹 인터페이스"
+
+#: id:202
+msgid "Tagline"
+msgstr "태그라인"
+
+#: id:203
+msgid "Plot outline"
+msgstr "줄거리 개요"
+
+#: id:205
+msgid "Votes"
+msgstr "투표:"
+
+#: id:206
+msgid "Cast"
+msgstr "배역"
+
+#: id:207
+msgid "Plot"
+msgstr "줄거리"
+
+#: id:208
+msgctxt "Auto context with id 208"
+msgid "Play"
+msgstr "재생"
+
+#: id:209
+msgid "Next"
+msgstr "다음"
+
+#: id:210
+msgid "Previous"
+msgstr "이전"
+
+#: id:213
+msgid "Calibrate user interface..."
+msgstr "사용자 인터페이스 조정..."
+
+#: id:214
+msgid "Video calibration..."
+msgstr "비디오 조정..."
+
+#: id:215
+msgid "Soften"
+msgstr "부드럽게"
+
+#: id:216
+msgid "Zoom amount"
+msgstr "축소/확대량"
+
+#: id:217
+msgid "Pixel ratio"
+msgstr "픽셀 비율"
+
+#: id:218
+msgid "DVD drive"
+msgstr "DVD 드라이브"
+
+#: id:219
+msgid "Please insert disc"
+msgstr "디스크를 넣어 주세요"
+
+#: id:220
+msgid "Remote share"
+msgstr "원격 공유"
+
+#: id:221
+msgid "Network is not connected"
+msgstr "네트워크가 연결되지 않음"
+
+#: id:222
+msgid "Cancel"
+msgstr "취소"
+
+#: id:224
+msgid "Speed"
+msgstr "속도"
+
+#: id:225
+msgid "Vertical Shift"
+msgstr "수직 이동"
+
+#: id:226
+msgid "Test patterns..."
+msgstr "패턴 테스트..."
+
+#: id:227
+msgid "Lookup audio CD track names from freedb.org"
+msgstr "freedb.org 에서 오디오 CD 트렉 이름 검색"
+
+#: id:228
+msgid "Shuffle playlist on load"
+msgstr "읽을때 재생목록 섞기"
+
+#: id:229
+msgid "HDD spindown time"
+msgstr "하드디스크 끄기 시간"
+
+#: id:230
+msgid "Video filters"
+msgstr "비디오 필터"
+
+#: id:231
+msgctxt "Auto context with id 231"
+msgid "None"
+msgstr "없음"
+
+#: id:232
+msgid "Point"
+msgstr "점형"
+
+#: id:233
+msgid "Linear"
+msgstr "선형"
+
+#: id:234
+msgid "Anisotropic"
+msgstr "이방형"
+
+#: id:235
+msgid "Quincunx"
+msgstr "오점형"
+
+#: id:236
+msgid "Gaussian cubic"
+msgstr "가우시안 큐빅"
+
+#: id:237
+msgid "Minification"
+msgstr "축소"
+
+#: id:238
+msgid "Magnification"
+msgstr "확대"
+
+#: id:239
+msgid "Clear playlist on finish"
+msgstr "종료때 재생목록 지우기"
+
+#: id:240
+msgid "Display Mode"
+msgstr "화면 모드"
+
+#: id:241
+msgid "Full Screen #%d"
+msgstr "전체 화면 #%d"
+
+#: id:242
+msgid "Windowed"
+msgstr "윈도우"
+
+#: id:243
+msgid "Refresh Rate"
+msgstr "새로고침 비율"
+
+#: id:244
+msgid "Full screen"
+msgstr "전체 화면"
+
+#: id:245
+msgid "Sizing: (%i,%i)->(%i,%i) (Zoom x%2.2f) AR:%2.2f:1 (Pixels: %2.2f:1) (VShift: %2.2f)"
+msgstr "크기: (%i,%i)->(%i,%i) (축소확대 x%2.2f) 가로세로비:%2.2f:1 (픽셀: %2.2f:1)"
+
+#: id:247
+msgctxt "Auto context with id 247"
+msgid "Scripts"
+msgstr "스크립트"
+
+#: id:248
+msgctxt "Auto context with id 248"
+msgid "Language"
+msgstr "언어"
+
+#: id:249
+msgctxt "Auto context with id 249"
+msgid "Music"
+msgstr "음악"
+
+#: id:250
+msgctxt "Auto context with id 250"
+msgid "Visualization"
+msgstr "시각화"
+
+#: id:251
+msgid "Select destination directory"
+msgstr "대상 디렉토리 선택"
+
+#: id:252
+msgid "Output stereo to all speakers"
+msgstr "모든 스피커에 스테레오 출력"
+
+#: id:253
+msgid "Number of channels"
+msgstr "채널수"
+
+#: id:254
+msgid "- DTS capable receiver"
+msgstr "- DTS 지원 리시버"
+
+#: id:255
+msgid "CDDB"
+msgstr "CDDB"
+
+#: id:256
+msgid "Fetching CD information"
+msgstr "CD 정보 가져오기"
+
+#: id:257
+msgid "Error"
+msgstr "오류"
+
+#: id:258
+msgid "Enable tag reading"
+msgstr "태그 읽기 사용"
+
+#: id:259
+msgid "Opening"
+msgstr "열기"
+
+#: id:260
+msgid "Shoutcast"
+msgstr "샤우트캐스트"
+
+#: id:261
+msgid "Waiting for start..."
+msgstr "시작 대기중...."
+
+#: id:262
+msgid "Scripts output"
+msgstr "스크립트 출력"
+
+#: id:263
+msgid "Allow control of XBMC via HTTP"
+msgstr "HTTP 를 통해 XBMC 제어 허용"
+
+#: id:264
+msgid "Record"
+msgstr "녹음"
+
+#: id:265
+msgid "Stop Rec."
+msgstr "녹음 중지"
+
+#: id:266
+msgid "Sort by: Track"
+msgstr "정렬: 트랙"
+
+#: id:267
+msgid "Sort by: Time"
+msgstr "정렬: 시간"
+
+#: id:268
+msgid "Sort by: Title"
+msgstr "정렬: 제목"
+
+#: id:269
+msgid "Sort by: Artist"
+msgstr "정렬: 아티스트"
+
+#: id:270
+msgid "Sort by: Album"
+msgstr "정렬: 앨범"
+
+#: id:271
+msgid "Top 100"
+msgstr "인기 100"
+
+#: id:272
+msgid "Top-Left overscan compensation"
+msgstr "상단-왼쪽 오버스캔 보정"
+
+#: id:273
+msgid "Bottom-Right overscan compensation"
+msgstr "하단-오른쪽 오버스캔 보정"
+
+#: id:274
+msgid "Subtitle positioning"
+msgstr "자막 위치"
+
+#: id:275
+msgid "Pixel ratio adjustment"
+msgstr "픽셀 비율 조정"
+
+#: id:276
+msgid "Adjust the arrow to change the amount of overscan"
+msgstr "오버스캔을 변경하려면 화살표를 조정하세요"
+
+#: id:277
+msgid "Adjust the bar to change the subtitles position"
+msgstr "자막 위치를 변경하려면 바를 조정하세요"
+
+#: id:278
+msgid "Adjust the rectangle so it is perfectly square"
+msgstr "사각형이 정사각형이 되도록 조정하세요"
+
+#: id:279
+msgid "Unable to load settings"
+msgstr "설정을 읽을수 없음"
+
+#: id:280
+msgid "Using default settings"
+msgstr "기본 설정 사용"
+
+#: id:281
+msgid "Please check the XML files"
+msgstr "XML 파일을 확인해 주세요"
+
+#: id:282
+msgid "Found %i items"
+msgstr "%i 항목 찾음"
+
+#: id:283
+msgid "Search results"
+msgstr "검색 결과"
+
+#: id:284
+msgid "No results found"
+msgstr "결과 찾지 못함"
+
+#: id:287
+msgctxt "Auto context with id 287"
+msgid "Subtitles"
+msgstr "자막"
+
+#: id:288
+msgctxt "Auto context with id 288"
+msgid "Font"
+msgstr "글꼴"
+
+#: id:289
+msgctxt "Auto context with id 289"
+msgid "- Size"
+msgstr "- 크기"
+
+#: id:290
+msgid "Dynamic range compression"
+msgstr "가청 범위 압축방식"
+
+#: id:291
+msgctxt "Auto context with id 291"
+msgid "Video"
+msgstr "비디오"
+
+#: id:292
+msgctxt "Auto context with id 292"
+msgid "Audio"
+msgstr "오디오"
+
+#: id:293
+msgid "Browse for subtitles"
+msgstr "자막 찾기"
+
+#: id:294
+msgid "Create bookmark"
+msgstr "북마크 만들기"
+
+#: id:296
+msgid "Clear bookmarks"
+msgstr "북마크 지우기"
+
+#: id:297
+msgid "Audio offset"
+msgstr "오디오 오프셋"
+
+#: id:298
+msgid "Bookmarks"
+msgstr "북마크"
+
+#: id:299
+msgid "- AAC capable receiver"
+msgstr "- AAC 지원 리시버"
+
+#: id:300
+msgid "- MP1 capable receiver"
+msgstr "- MP1 지원 리시버"
+
+#: id:301
+msgid "- MP2 capable receiver"
+msgstr "- MP2 지원 리시버"
+
+#: id:302
+msgid "- MP3 capable receiver"
+msgstr "- MP3 지원 리시버"
+
+#: id:303
+msgid "Delay"
+msgstr "지연"
+
+#: id:304
+msgctxt "Auto context with id 304"
+msgid "Language"
+msgstr "언어"
+
+#: id:305
+msgctxt "Auto context with id 305"
+msgid "Enabled"
+msgstr "사용함"
+
+#: id:306
+msgid "Non-interleaved"
+msgstr "논인터리브"
+
+#: id:312
+msgid "(0=auto)"
+msgstr "(0=자동)"
+
+#: id:313
+msgid "Cleaning database"
+msgstr "데이터베이스 정리"
+
+#: id:314
+msgid "Preparing..."
+msgstr "준비중..."
+
+#: id:315
+msgid "Database error"
+msgstr "데이터베이스 오류"
+
+#: id:316
+msgid "Searching songs..."
+msgstr "노래 찾는중..."
+
+#: id:317
+msgid "Cleaned database successfully"
+msgstr "정상적으로 데이터베이스 정리됨"
+
+#: id:318
+msgid "Cleaning songs..."
+msgstr "노래 정리중..."
+
+#: id:319
+msgid "Error cleaning songs"
+msgstr "노래 정리 오류"
+
+#: id:320
+msgid "Cleaning artists..."
+msgstr "아티스트 정리중..."
+
+#: id:321
+msgid "Error cleaning artists"
+msgstr "아티스트 정리 오류"
+
+#: id:322
+msgid "Cleaning genres..."
+msgstr "장르 정리중..."
+
+#: id:323
+msgid "Error cleaning genres"
+msgstr "장르 정리 오류"
+
+#: id:324
+msgid "Cleaning paths..."
+msgstr "경로 정리중..."
+
+#: id:325
+msgid "Error cleaning paths"
+msgstr "경로 정리 오류"
+
+#: id:326
+msgid "Cleaning albums..."
+msgstr "앨범 정리중..."
+
+#: id:327
+msgid "Error cleaning albums"
+msgstr "앨범 정리 오류"
+
+#: id:328
+msgid "Writing changes..."
+msgstr "변경 쓰는중..."
+
+#: id:329
+msgid "Error writing changes"
+msgstr "변경 사항 쓰기 오류"
+
+#: id:330
+msgid "This may take some time..."
+msgstr "시간이 좀 걸립니다..."
+
+#: id:331
+msgid "Compressing database..."
+msgstr "데이터베이스 압축중..."
+
+#: id:332
+msgid "Error compressing database"
+msgstr "데이터베이스 압축 오류"
+
+#: id:333
+msgid "Do you want to clean the library?"
+msgstr "라이브러리를 정리 하시겠습니까?"
+
+#: id:334
+msgid "Clean library..."
+msgstr "라이브러리 정리..."
+
+#: id:335
+msgid "Start"
+msgstr "시작"
+
+#: id:336
+msgid "Framerate conversion"
+msgstr "프레임레이트 변환"
+
+#: id:337
+msgctxt "Auto context with id 337"
+msgid "Audio output"
+msgstr "오디오 출력"
+
+#: id:338
+msgid "Analog"
+msgstr "아날로그"
+
+#: id:339
+msgid "Optical/Coax"
+msgstr "광학/동축"
+
+#: id:340
+msgid "Various artists"
+msgstr "여러 아티스트"
+
+#: id:341
+msgid "Play disc"
+msgstr "디스크 재생"
+
+#: id:342
+msgctxt "Auto context with id 342"
+msgid "Movies"
+msgstr "영화"
+
+#: id:343
+msgid "Adjust framerate"
+msgstr "프레임레이트 조정"
+
+#: id:344
+msgid "Actors"
+msgstr "배우"
+
+#: id:345
+msgctxt "Auto context with id 345"
+msgid "Year"
+msgstr "연도"
+
+#: id:346
+msgid "Boost volume level on downmix"
+msgstr "다운믹스의 음량 수준을 증폭"
+
+#: id:350
+msgctxt "Auto context with id 350"
+msgid "Programs"
+msgstr "프로그램"
+
+#: id:351
+msgctxt "Auto context with id 351"
+msgid "Off"
+msgstr "사용안함"
+
+#: id:352
+msgid "Dim"
+msgstr "흐림"
+
+#: id:353
+msgid "Black"
+msgstr "검정"
+
+#: id:354
+msgid "Matrix trails"
+msgstr "매트릭스 트레일"
+
+#: id:355
+msgid "Screensaver time"
+msgstr "화면보호기 시간"
+
+#: id:356
+msgid "Screensaver mode"
+msgstr "화면보호기 모드"
+
+#: id:357
+msgid "Shutdown function timer"
+msgstr "종료 기능 타이머"
+
+#: id:358
+msgid "All albums"
+msgstr "모든 앨범"
+
+#: id:359
+msgid "Recently added albums"
+msgstr "최근 추가된 앨범"
+
+#: id:360
+msgctxt "Auto context with id 360"
+msgid "Screensaver"
+msgstr "화면보호기"
+
+#: id:361
+msgid "R. Slideshow"
+msgstr "역 슬라이드쇼"
+
+#: id:362
+msgid "Screensaver dim level"
+msgstr "화면보호기 흐림 정도"
+
+#: id:363
+msgid "Sort by: File"
+msgstr "정렬: 파일"
+
+#: id:364
+msgid "- Dolby Digital (AC3) capable receiver"
+msgstr "- 돌비 디지털 (AC3) 지원 리시버"
+
+#: id:365
+msgctxt "Auto context with id 365"
+msgid "Sort by: Name"
+msgstr "정렬: 이름"
+
+#: id:366
+msgid "Sort by: Year"
+msgstr "정렬: 연도"
+
+#: id:367
+msgid "Sort by: Rating"
+msgstr "정렬: 평점"
+
+#: id:368
+msgid "IMDb"
+msgstr "평점"
+
+#: id:369
+msgctxt "Auto context with id 369"
+msgid "Title"
+msgstr "제목"
+
+#: id:370
+msgid "Thunderstorms"
+msgstr "뇌우"
+
+#: id:371
+msgid "Partly"
+msgstr "일부"
+
+#: id:372
+msgid "Mostly"
+msgstr "대부분"
+
+#: id:373
+msgid "Sunny"
+msgstr "화창함"
+
+#: id:374
+msgid "Cloudy"
+msgstr "흐림"
+
+#: id:375
+msgid "Snow"
+msgstr "눈"
+
+#: id:376
+msgid "Rain"
+msgstr "비"
+
+#: id:377
+msgid "Light"
+msgstr "천둥"
+
+#: id:378
+msgid "AM"
+msgstr "오전"
+
+#: id:379
+msgid "PM"
+msgstr "오후"
+
+#: id:380
+msgid "Showers"
+msgstr "소나기"
+
+#: id:381
+msgid "Few"
+msgstr "약간"
+
+#: id:382
+msgid "Scattered"
+msgstr "드문드문"
+
+#: id:383
+msgctxt "Auto context with id 383"
+msgid "Wind"
+msgstr "바람"
+
+#: id:384
+msgid "Strong"
+msgstr "강한"
+
+#: id:385
+msgid "Fair"
+msgstr "맑음"
+
+#: id:386
+msgctxt "Auto context with id 386"
+msgid "Clear"
+msgstr "맑음"
+
+#: id:387
+msgid "Clouds"
+msgstr "구름"
+
+#: id:388
+msgid "Early"
+msgstr "이른"
+
+#: id:389
+msgid "Shower"
+msgstr "소나기"
+
+#: id:390
+msgid "Flurries"
+msgstr "눈보라"
+
+#: id:391
+msgctxt "Auto context with id 391"
+msgid "Low"
+msgstr "낮음"
+
+#: id:392
+msgctxt "Auto context with id 392"
+msgid "Medium"
+msgstr "보통"
+
+#: id:393
+msgctxt "Auto context with id 393"
+msgid "High"
+msgstr "높음"
+
+#: id:394
+msgid "Fog"
+msgstr "안개"
+
+#: id:395
+msgid "Haze"
+msgstr "흐린 안개"
+
+#: id:396
+msgid "Select location"
+msgstr "지역 선택"
+
+#: id:397
+msgid "Refresh time"
+msgstr "새로고침 시간"
+
+#: id:398
+msgid "Temperature units"
+msgstr "온도 단위"
+
+#: id:399
+msgid "Speed units"
+msgstr "속도 단위"
+
+#: id:400
+msgctxt "Auto context with id 400"
+msgid "Weather"
+msgstr "날씨"
+
+#: id:401
+msgid "Temp"
+msgstr "온도"
+
+#: id:402
+msgid "Feels like"
+msgstr "체감"
+
+#: id:403
+msgid "UV index"
+msgstr "자외선 지수"
+
+#: id:404
+msgctxt "Auto context with id 404"
+msgid "Wind"
+msgstr "바람"
+
+#: id:405
+msgid "Dew point"
+msgstr "이슬점"
+
+#: id:406
+msgid "Humidity"
+msgstr "습도"
+
+#: id:409
+msgid "Defaults"
+msgstr "기본"
+
+#: id:410
+msgid "Accessing weather service"
+msgstr "날씨 서비스 접속"
+
+#: id:411
+msgid "Getting weather for:"
+msgstr "날씨 가져오기:"
+
+#: id:412
+msgid "Unable to get weather data"
+msgstr "날씨 데이터 가져올수 없음"
+
+#: id:413
+msgid "Manual"
+msgstr "수동"
+
+#: id:414
+msgid "No review for this album"
+msgstr "이 앨범의 리뷰 없음"
+
+#: id:415
+msgid "Downloading thumbnail..."
+msgstr "미리보기 다운로드중..."
+
+#: id:416
+msgid "Not available"
+msgstr "사용할수 없음"
+
+#: id:417
+msgid "View: Big icons"
+msgstr "보기: 큰 아이콘"
+
+#: id:418
+msgctxt "Auto context with id 418"
+msgid "Low"
+msgstr "최저"
+
+#: id:419
+msgctxt "Auto context with id 419"
+msgid "High"
+msgstr "최고"
+
+#: id:420
+msgid "HDMI"
+msgstr "HDMI"
+
+#: id:422
+msgid "Delete album info"
+msgstr "앨범 정보 삭제"
+
+#: id:423
+msgid "Delete CD information"
+msgstr "CD 정보 삭제"
+
+#: id:424
+msgid "Select"
+msgstr "선택"
+
+#: id:425
+msgid "No album information found"
+msgstr "앨범 정보 찾지 못함"
+
+#: id:426
+msgid "No CD information found"
+msgstr "CD 정보 찾지 못함"
+
+#: id:427
+msgid "Disc"
+msgstr "디스크"
+
+#: id:428
+msgid "Insert correct CD/DVD"
+msgstr "올바른 CD/DVD 를 넣어 주세요"
+
+#: id:429
+msgid "Please insert the following disc:"
+msgstr "다음 CD/DVD 를 넣어 주세요"
+
+#: id:430
+msgid "Sort by: DVD#"
+msgstr "정렬: DVD번호"
+
+#: id:431
+msgid "No cache"
+msgstr "캐시 없음"
+
+#: id:432
+msgid "Remove movie from library"
+msgstr "라이브러리에서 영화 제거"
+
+#: id:433
+msgid "Really remove '%s'?"
+msgstr "'%s' 를 제거 하시겠습니까?"
+
+#: id:434
+msgid "From %s at %i %s"
+msgstr "풍향 %s 풍속 %i %s"
+
+#: id:437
+msgid "Removable disk"
+msgstr "이동식 디스크"
+
+#: id:438
+msgid "Opening file"
+msgstr "파일 열기"
+
+#: id:439
+msgid "Cache"
+msgstr "캐시"
+
+#: id:440
+msgid "Harddisk"
+msgstr "하드디스크"
+
+#: id:441
+msgid "UDF"
+msgstr "UDF"
+
+#: id:442
+msgid "Local network"
+msgstr "로컬 네트워크"
+
+#: id:443
+msgid "Internet"
+msgstr "인터넷"
+
+#: id:444
+msgctxt "Auto context with id 444"
+msgid "Video"
+msgstr "비디오"
+
+#: id:445
+msgctxt "Auto context with id 445"
+msgid "Audio"
+msgstr "오디오"
+
+#: id:446
+msgctxt "Auto context with id 446"
+msgid "DVD"
+msgstr "DVD"
+
+#: id:447
+msgid "Autorun media"
+msgstr "미디어 자동실행"
+
+#: id:448
+msgid "LCD"
+msgstr "LCD"
+
+#: id:449
+msgctxt "Auto context with id 449"
+msgid "Enabled"
+msgstr "사용함"
+
+#: id:450
+msgid "Columns"
+msgstr "세로"
+
+#: id:451
+msgid "Row 1 address"
+msgstr "1번째 열 주소"
+
+#: id:452
+msgid "Row 2 address"
+msgstr "2번째 열 주소"
+
+#: id:453
+msgid "Row 3 address"
+msgstr "3번째 열 주소"
+
+#: id:454
+msgid "Row 4 address"
+msgstr "4번째 열 주소"
+
+#: id:455
+msgid "Rows"
+msgstr "가로"
+
+#: id:456
+msgid "Mode"
+msgstr "모드"
+
+#: id:457
+msgid "Switch view"
+msgstr "보기 변경"
+
+#: id:459
+msgid "Subs"
+msgstr "자막"
+
+#: id:460
+msgid "Audio stream"
+msgstr "오디오 스트림"
+
+#: id:461
+msgid "[active]"
+msgstr "[활성화]"
+
+#: id:462
+msgid "Subtitle"
+msgstr "자막"
+
+#: id:463
+msgid "Backlight"
+msgstr "백라이트"
+
+#: id:464
+msgid "Brightness"
+msgstr "밝기"
+
+#: id:465
+msgid "Contrast"
+msgstr "명암"
+
+#: id:466
+msgid "Gamma"
+msgstr "감마"
+
+#: id:467
+msgctxt "Auto context with id 467"
+msgid "Type"
+msgstr "형식"
+
+#: id:468
+msgid "Move the bar to change the OSD position"
+msgstr "바를 움직여서 OSD 위치를 변경하세요"
+
+#: id:469
+msgid "OSD position"
+msgstr "OSD 위치"
+
+#: id:470
+msgid "Credits"
+msgstr "만든 사람들"
+
+#: id:471
+msgid "Modchip"
+msgstr "모드칩"
+
+#: id:474
+msgctxt "Auto context with id 474"
+msgid "Off"
+msgstr "끄기"
+
+#: id:475
+msgid "Music only"
+msgstr "음악만"
+
+#: id:476
+msgctxt "Auto context with id 476"
+msgid "Music & video"
+msgstr "음악 & 비디오"
+
+#: id:477
+msgid "Unable to load playlist"
+msgstr "재생목록을 읽을수 없음"
+
+#: id:478
+msgid "OSD"
+msgstr "OSD"
+
+#: id:479
+msgid "Skin & language"
+msgstr "스킨 & 언어"
+
+#: id:480
+msgid "Appearance"
+msgstr "모양새"
+
+#: id:481
+msgid "Audio options"
+msgstr "오디오 옵션"
+
+#: id:482
+msgid "About XBMC"
+msgstr "XBMC 정보"
+
+#: id:485
+msgid "Delete album"
+msgstr "앨범 삭제"
+
+#: id:486
+msgid "Repeat"
+msgstr "반복"
+
+#: id:487
+msgid "Repeat one"
+msgstr "한곡 반복"
+
+#: id:488
+msgid "Repeat folder"
+msgstr "폴더 반복"
+
+#: id:489
+msgid "Play the next song automatically"
+msgstr "자동으로 다음 노래 재생"
+
+#: id:491
+msgid "- Use big icons"
+msgstr "- 큰 아이콘 사용"
+
+#: id:492
+msgid "Resize VobSubs"
+msgstr "자막 크기변경"
+
+#: id:493
+msgid "Advanced options (Experts Only!)"
+msgstr "고급 옵션 (전문가만!)"
+
+#: id:494
+msgid "Overall audio headroom"
+msgstr "전반적인 오디오 헤드룸"
+
+#: id:495
+msgid "Upsample videos to GUI resolution"
+msgstr "비디오를 GUI 해상도로 올림"
+
+#: id:496
+msgid "Calibration"
+msgstr "조정"
+
+#: id:497
+msgid "Show file extensions"
+msgstr "파일 확장자 보이기"
+
+#: id:498
+msgid "Sort by: Type"
+msgstr "정렬: 형식"
+
+#: id:499
+msgid "Unable to connect to online lookup service"
+msgstr "온라인 검색 서비스에 연결할수 없음"
+
+#: id:500
+msgid "Downloading album information failed"
+msgstr "앨범 정보 다운로드 실패"
+
+#: id:501
+msgid "Looking for album names..."
+msgstr "앨범 이름 찾는중..."
+
+#: id:502
+msgctxt "Auto context with id 502"
+msgid "Open"
+msgstr "열림"
+
+#: id:503
+msgid "Busy"
+msgstr "읽는중"
+
+#: id:504
+msgid "Empty"
+msgstr "비어있음"
+
+#: id:505
+msgid "Loading media info from files..."
+msgstr "파일에서 미디어 정보 읽는중..."
+
+#: id:507
+msgid "Sort by: Usage"
+msgstr "정렬: 사용량"
+
+#: id:510
+msgid "Enable visualizations"
+msgstr "시각화 사용"
+
+#: id:511
+msgid "Enable video mode switching"
+msgstr "비디오 모드 변경 사용"
+
+#: id:512
+msgid "Startup window"
+msgstr "시작 윈도우"
+
+#: id:513
+msgid "Home window"
+msgstr "홈 윈도우"
+
+#: id:514
+msgid "Manual settings"
+msgstr "수동 설정"
+
+#: id:515
+msgid "Genre"
+msgstr "장르"
+
+#: id:517
+msgid "Recently played albums"
+msgstr "최근 재생 앨범"
+
+#: id:518
+msgid "Launch"
+msgstr "실행"
+
+#: id:519
+msgid "Launch in..."
+msgstr "실행..."
+
+#: id:521
+msgid "Compilations"
+msgstr "컴필레이션"
+
+#: id:522
+msgid "Remove source"
+msgstr "소스 제거"
+
+#: id:523
+msgid "Switch media"
+msgstr "미디어 변경"
+
+#: id:524
+msgid "Select playlist"
+msgstr "재생목록 선택"
+
+#: id:525
+msgid "New playlist..."
+msgstr "새 재생목록..."
+
+#: id:526
+msgid "Add to playlist"
+msgstr "재생목록에 추가"
+
+#: id:527
+msgid "Manually add to library"
+msgstr "라이브러리에 수동 추가"
+
+#: id:528
+msgid "Enter title"
+msgstr "제목 입력"
+
+#: id:529
+msgid "Error: Duplicate title"
+msgstr "오류: 제목 중복"
+
+#: id:530
+msgid "Select genre"
+msgstr "장르 선택"
+
+#: id:531
+msgid "New genre"
+msgstr "새 장르"
+
+#: id:532
+msgid "Manual addition"
+msgstr "수동 추가"
+
+#: id:533
+msgid "Enter genre"
+msgstr "장르 입력"
+
+#: id:534
+msgid "View: %s"
+msgstr "보기: %s"
+
+#: id:535
+msgid "List"
+msgstr "목록"
+
+#: id:536
+msgid "Icons"
+msgstr "아이콘"
+
+#: id:537
+msgid "Big list"
+msgstr "큰 목록"
+
+#: id:538
+msgid "Big icons"
+msgstr "큰 아이콘"
+
+#: id:539
+msgid "Wide"
+msgstr "수평"
+
+#: id:540
+msgid "Big wide"
+msgstr "큰 수평"
+
+#: id:541
+msgid "Album icons"
+msgstr "앨범 아이콘"
+
+#: id:542
+msgid "DVD icons"
+msgstr "DVD 아이콘"
+
+#: id:543
+msgctxt "Auto context with id 543"
+msgid "DVD"
+msgstr "DVD"
+
+#: id:544
+msgctxt "Auto context with id 544"
+msgid "Media info"
+msgstr "미디어 정보"
+
+#: id:545
+msgid "Audio output device"
+msgstr "오디오 출력 장치"
+
+#: id:546
+msgid "Passthrough output device"
+msgstr "패스스루 출력 장치"
+
+#: id:547
+msgid "No biography for this artist"
+msgstr "아티스트 약력 없음"
+
+#: id:548
+msgid "Downmix multichannel audio to stereo"
+msgstr "다채널 오디오를 스테레오로 다운믹스"
+
+#: id:550
+msgid "Sort by: %s"
+msgstr "정렬: %s"
+
+#: id:551
+msgctxt "Auto context with id 551"
+msgid "Name"
+msgstr "이름"
+
+#: id:552
+msgid "Date"
+msgstr "날짜"
+
+#: id:553
+msgid "Size"
+msgstr "크기"
+
+#: id:554
+msgid "Track"
+msgstr "트랙"
+
+#: id:555
+msgid "Time"
+msgstr "시간"
+
+#: id:556
+msgctxt "Auto context with id 556"
+msgid "Title"
+msgstr "제목"
+
+#: id:557
+msgid "Artist"
+msgstr "아티스트"
+
+#: id:558
+msgid "Album"
+msgstr "앨범"
+
+#: id:559
+msgid "Playlist"
+msgstr "재생목록"
+
+#: id:560
+msgid "ID"
+msgstr "ID"
+
+#: id:561
+msgctxt "Auto context with id 561"
+msgid "File"
+msgstr "파일"
+
+#: id:562
+msgctxt "Auto context with id 562"
+msgid "Year"
+msgstr "연도"
+
+#: id:563
+msgid "Rating"
+msgstr "평점"
+
+#: id:564
+msgctxt "Auto context with id 564"
+msgid "Type"
+msgstr "형식"
+
+#: id:565
+msgid "Usage"
+msgstr "사용량"
+
+#: id:566
+msgid "Album artist"
+msgstr "앨범 아티스트"
+
+#: id:567
+msgid "Play count"
+msgstr "재생 횟수"
+
+#: id:568
+msgid "Last played"
+msgstr "마지막 재생"
+
+#: id:569
+msgctxt "Auto context with id 569"
+msgid "Comment"
+msgstr "설명"
+
+#: id:570
+msgid "Date added"
+msgstr "날짜 추가됨"
+
+#: id:571
+msgctxt "Auto context with id 571"
+msgid "Default"
+msgstr "기본"
+
+#: id:572
+msgid "Studio"
+msgstr "스튜디오"
+
+#: id:573
+msgid "Path"
+msgstr "경로"
+
+#: id:574
+msgctxt "Auto context with id 574"
+msgid "Country"
+msgstr "국가"
+
+#: id:575
+msgid "In progress"
+msgstr "진행중"
+
+#: id:576
+msgid "Times played"
+msgstr "재생 횟수"
+
+#: id:580
+msgid "Sort direction"
+msgstr "정렬 방향"
+
+#: id:581
+msgid "Sort method"
+msgstr "정렬 방법"
+
+#: id:582
+msgctxt "Auto context with id 582"
+msgid "View mode"
+msgstr "보기 모드"
+
+#: id:583
+msgid "Remember views for different folders"
+msgstr "각 폴더의 보기 설정 기억"
+
+#: id:584
+msgid "Ascending"
+msgstr "올림차순"
+
+#: id:585
+msgid "Descending"
+msgstr "내림차순"
+
+#: id:586
+msgid "Edit playlist"
+msgstr "재생목록 수정"
+
+#: id:587
+msgid "Filter"
+msgstr "필터"
+
+#: id:588
+msgid "Cancel party mode"
+msgstr "파티 모드 취소"
+
+#: id:589
+msgid "Party mode"
+msgstr "파티 모드"
+
+#: id:590
+msgid "Random"
+msgstr "무작위"
+
+#: id:591
+msgctxt "Auto context with id 591"
+msgid "Off"
+msgstr "끔"
+
+#: id:592
+msgid "One"
+msgstr "하나"
+
+#: id:593
+msgid "All"
+msgstr "전체"
+
+#: id:594
+msgctxt "Auto context with id 594"
+msgid "Off"
+msgstr "끔"
+
+#: id:595
+msgid "Repeat: Off"
+msgstr "반복: 끔"
+
+#: id:596
+msgid "Repeat: One"
+msgstr "반복: 하나"
+
+#: id:597
+msgid "Repeat: All"
+msgstr "반복: 전체"
+
+#: id:600
+msgid "Rip audio CD"
+msgstr "오디오 CD 추출"
+
+#: id:601
+msgctxt "Auto context with id 601"
+msgid "Medium"
+msgstr "중간"
+
+#: id:602
+msgctxt "Auto context with id 602"
+msgid "Standard"
+msgstr "표준"
+
+#: id:603
+msgid "Extreme"
+msgstr "최대"
+
+#: id:604
+msgid "Constant bitrate"
+msgstr "고정 비트레이트"
+
+#: id:605
+msgid "Ripping..."
+msgstr "추출중..."
+
+#: id:607
+msgid "To:"
+msgstr "대상:"
+
+#: id:608
+msgid "Could not rip CD or track"
+msgstr "CD나 트랙을 추출 할수 없음"
+
+#: id:609
+msgid "CDDARipPath is not set."
+msgstr "CDDA 추출 경로가 설정되지 않음."
+
+#: id:610
+msgid "Rip audio track"
+msgstr "오디오 트랙 추출"
+
+#: id:611
+msgid "Enter number"
+msgstr "번호 입력"
+
+#: id:612
+msgid "Bits/Sample"
+msgstr "비트/샘플"
+
+#: id:613
+msgid "Sample Frequency"
+msgstr "샘플 주파수"
+
+#: id:620
+msgid "Audio CDs"
+msgstr "오디오 CD"
+
+#: id:621
+msgid "Encoder"
+msgstr "인코더"
+
+#: id:622
+msgid "Quality"
+msgstr "음질"
+
+#: id:623
+msgid "Bitrate"
+msgstr "비트레이트"
+
+#: id:624
+msgid "Include track number"
+msgstr "트랙 번호 포함"
+
+#: id:625
+msgid "All songs of"
+msgstr "모든 노래"
+
+#: id:629
+msgctxt "Auto context with id 629"
+msgid "View mode"
+msgstr "보기 모드"
+
+#: id:630
+msgctxt "Auto context with id 630"
+msgid "Normal"
+msgstr "보통"
+
+#: id:631
+msgid "Zoom"
+msgstr "축소/확대"
+
+#: id:632
+msgid "Stretch 4:3"
+msgstr "4:3 늘림"
+
+#: id:633
+msgid "Wide Zoom"
+msgstr "넓게 축소/확대"
+
+#: id:634
+msgid "Stretch 16:9"
+msgstr "16:9 늘림"
+
+#: id:635
+msgid "Original Size"
+msgstr "원래 크기"
+
+#: id:636
+msgctxt "Auto context with id 636"
+msgid "Custom"
+msgstr "사용자 지정"
+
+#: id:637
+msgid "Replay gain"
+msgstr "리플레이 게인"
+
+#: id:638
+msgid "Replaygain volume adjustments"
+msgstr "리플레인 게인 음량 조정"
+
+#: id:639
+msgid "Use track levels"
+msgstr "트랙 레벨 사용"
+
+#: id:640
+msgid "Use album levels"
+msgstr "앨범 레벨 사용"
+
+#: id:641
+msgid "PreAmp Level - Replay gained files"
+msgstr "프리엠프 레벨 - 리플레이 게인 정보 있는 파일"
+
+#: id:642
+msgid "PreAmp Level - Non replay gained files"
+msgstr "프리엠프 레벨 - 리플레이 게인 정보 없는 파일"
+
+#: id:643
+msgid "Avoid clipping on replay gained files"
+msgstr "리플레이 게인 정보가 있는 파일의 클리핑 방지"
+
+#: id:644
+msgid "Crop black bars"
+msgstr "검은 여백 잘라내기"
+
+#: id:645
+msgid "Need to unpack a big file. Continue?"
+msgstr "큰 파일의 압축풀기가 필요함 . 계속 하시겠습니까?"
+
+#: id:646
+msgid "Remove from library"
+msgstr "라이브러리에서 제거"
+
+#: id:647
+msgid "Export video library"
+msgstr "비디오 라이브러리 내보내기"
+
+#: id:648
+msgid "Import video library"
+msgstr "비디오 라이브러리 가져오기"
+
+#: id:649
+msgid "Importing"
+msgstr "가져오기"
+
+#: id:650
+msgid "Exporting"
+msgstr "내보내기"
+
+#: id:651
+msgid "Browse for library"
+msgstr "라이브러리 찾기"
+
+#: id:652
+msgid "Years"
+msgstr "연도"
+
+#: id:653
+msgid "Update library"
+msgstr "라이브러리 업데이트"
+
+#: id:654
+msgid "Show debug info"
+msgstr "디버그 정보 보이기"
+
+#: id:655
+msgid "Browse for executable"
+msgstr "실행파일 찾기"
+
+#: id:656
+msgid "Browse for playlist"
+msgstr "재생목록 찾기"
+
+#: id:657
+msgid "Browse for folder"
+msgstr "폴더 찾기"
+
+#: id:658
+msgid "Song information"
+msgstr "노래 정보"
+
+#: id:659
+msgid "Non-linear stretch"
+msgstr "비-선형 늘림"
+
+#: id:660
+msgid "Volume amplification"
+msgstr "음량 증폭"
+
+#: id:661
+msgid "Choose export folder"
+msgstr "내보내기 폴더 선택"
+
+#: id:662
+msgid "This file is no longer available."
+msgstr "이 파일은 더 이상 사용할수 없습니다."
+
+#: id:663
+msgid "Would you like to remove it from the library?"
+msgstr "라이브러리에서 제거 하시겠습니까?"
+
+#: id:664
+msgid "Browse for Script"
+msgstr "스크립트 찾기"
+
+#: id:665
+msgid "Compression level"
+msgstr "압축 수준"
+
+#: id:700
+msgid "Cleaning up library"
+msgstr "라이브러리 정리"
+
+#: id:701
+msgid "Removing old songs from the library"
+msgstr "라이브러리에서 오래된 노래 제거"
+
+#: id:702
+msgid "This path has been scanned before"
+msgstr "이 경로는 이미 검색 되었습니다"
+
+#: id:705
+msgctxt "Auto context with id 705"
+msgid "Network"
+msgstr "네트워크"
+
+#: id:706
+msgid "- Server"
+msgstr "- 서버"
+
+#: id:708
+msgid "Use an HTTP proxy server to access the internet"
+msgstr "인터넷 접속에 HTTP 프록시 서버 사용"
+
+#: id:711
+msgid "Internet Protocol (IP)"
+msgstr "인터텟 프로토콜(IP)"
+
+#: id:712
+msgid "Invalid port specified. Value must be between 1 and 65535."
+msgstr "잘못된 포트를 지정했음. 1 과 65535사이의 값 이어야 합니다."
+
+#: id:713
+msgid "HTTP proxy"
+msgstr "HTTP 프록시"
+
+#: id:715
+msgid "- Assignment"
+msgstr "- 할당"
+
+#: id:716
+msgid "Automatic (DHCP)"
+msgstr "자동 (DHCP)"
+
+#: id:717
+msgid "Manual (Static)"
+msgstr "수동 (고정)"
+
+#: id:719
+msgid "- IP address"
+msgstr "- IP 주소"
+
+#: id:720
+msgid "- Netmask"
+msgstr "- 넷마스크"
+
+#: id:721
+msgid "- Default gateway"
+msgstr "- 기본 게이트웨이"
+
+#: id:722
+msgid "- DNS server"
+msgstr "- DNS 서버"
+
+#: id:723
+msgid "Save & restart"
+msgstr "저장 & 재시작"
+
+#: id:724
+msgid "Invalid address specified. Value must be AAA.BBB.CCC.DDD"
+msgstr "잘못된 주소를 지정했음. 0과 255사이의 숫자를 사용하여"
+
+#: id:725
+msgid "with numbers between 0 and 255."
+msgstr "AAA.BBB.CCC.DDD 값 이어야 합니다."
+
+#: id:726
+msgid "Changes not saved. Continue without saving?"
+msgstr "변경이 저장되지 않음. 저장않고 계속 하시겠습니까?"
+
+#: id:727
+msgid "Web server"
+msgstr "웹 서버"
+
+#: id:728
+msgctxt "Auto context with id 728"
+msgid "FTP server"
+msgstr "FTP 서버"
+
+#: id:730
+msgid "- Port"
+msgstr "- 포트"
+
+#: id:732
+msgid "Save & apply"
+msgstr "저장 & 적용"
+
+#: id:733
+msgid "- Password"
+msgstr "- 비밀번호"
+
+#: id:734
+msgid "No pass"
+msgstr "암호 없음"
+
+#: id:735
+msgid "- Character set"
+msgstr "- 문자 집합"
+
+#: id:736
+msgid "- Style"
+msgstr "- 스타일"
+
+#: id:737
+msgid "- Colour"
+msgstr "- 색깔"
+
+#: id:738
+msgctxt "Auto context with id 738"
+msgid "Normal"
+msgstr "보통"
+
+#: id:739
+msgid "Bold"
+msgstr "굵게"
+
+#: id:740
+msgid "Italics"
+msgstr "기울임꼴"
+
+#: id:741
+msgid "Bold italics"
+msgstr "굵은 기울임꼴"
+
+#: id:742
+msgctxt "Auto context with id 742"
+msgid "White"
+msgstr "하양"
+
+#: id:743
+msgctxt "Auto context with id 743"
+msgid "Yellow"
+msgstr "노랑"
+
+#: id:744
+msgctxt "Auto context with id 744"
+msgid "Files"
+msgstr "파일"
+
+#: id:745
+msgid "No scanned information for this view"
+msgstr "이 보기에서 검색된 정보가 없음"
+
+#: id:746
+msgid "Please turn off library mode"
+msgstr "라이브러리 모드를 꺼 주세요"
+
+#: id:747
+msgid "Error loading image"
+msgstr "이미지 읽기 오류"
+
+#: id:748
+msgid "Edit path"
+msgstr "경로 수정"
+
+#: id:749
+msgid "Mirror image"
+msgstr "미러 이미지"
+
+#: id:750
+msgid "Are you sure?"
+msgstr "확실합니까?"
+
+#: id:751
+msgid "Removing source"
+msgstr "소스 제거"
+
+#: id:754
+msgid "Add program link"
+msgstr "프로그램 연결 추가"
+
+#: id:755
+msgid "Edit program path"
+msgstr "프로그램 경로 수정"
+
+#: id:756
+msgid "Edit program name"
+msgstr "프로그램 이름 수정"
+
+#: id:757
+msgid "Edit path depth"
+msgstr "경로 단계 수정"
+
+#: id:759
+msgid "View: Big list"
+msgstr "보기: 큰 목록"
+
+#: id:760
+msgctxt "Auto context with id 760"
+msgid "Yellow"
+msgstr "노랑"
+
+#: id:761
+msgctxt "Auto context with id 761"
+msgid "White"
+msgstr "하양"
+
+#: id:762
+msgid "Blue"
+msgstr "파랑"
+
+#: id:763
+msgid "Bright green"
+msgstr "밝은 녹색"
+
+#: id:764
+msgid "Yellow green"
+msgstr "연두"
+
+#: id:765
+msgid "Cyan"
+msgstr "맑은 파랑"
+
+#: id:766
+msgid "Light grey"
+msgstr "밝은 회색"
+
+#: id:767
+msgid "Grey"
+msgstr "회색"
+
+#: id:770
+msgid "Error %i: share not available"
+msgstr "오류 %i: 공유를 사용할수 없음"
+
+#: id:772
+msgctxt "Auto context with id 772"
+msgid "Audio output"
+msgstr "오디오 출력"
+
+#: id:773
+msgid "Seeking"
+msgstr "검색"
+
+#: id:774
+msgid "Slideshow folder"
+msgstr "슬라이드쇼 폴더"
+
+#: id:775
+msgid "Network interface"
+msgstr "네트워크 인터페이스"
+
+#: id:776
+msgid "- Wireless network name (ESSID)"
+msgstr "- 무선 네트워크 이름 (ESSID)"
+
+#: id:777
+msgid "- Wireless password"
+msgstr "- 무선 비밀번호"
+
+#: id:778
+msgid "- Wireless security"
+msgstr "- 무선 보안"
+
+#: id:779
+msgid "Save and apply network interface settings"
+msgstr "네트워크 인터페이스 설정 저장 및 적용"
+
+#: id:780
+msgid "No encryption"
+msgstr "암호화 없음"
+
+#: id:781
+msgid "WEP"
+msgstr "WEP"
+
+#: id:782
+msgid "WPA"
+msgstr "WPA"
+
+#: id:783
+msgid "WPA2"
+msgstr "WPA2"
+
+#: id:784
+msgid "Applying network interface settings. Please wait."
+msgstr "네트워크 인터페이스 설정을 적용중. 기다려 주세요."
+
+#: id:785
+msgid "Network interface restarted successfully."
+msgstr "정상적으로 네트워크 인터페이스 재시작 되었습니다."
+
+#: id:786
+msgid "Network interface did not start successfully."
+msgstr "정상적으로 네트워크 인터페이스 시작되지 않았습니다."
+
+#: id:787
+msgid "Interface disabled"
+msgstr "인터페이스 중지됨"
+
+#: id:788
+msgid "Network interface disabled successfully."
+msgstr "정상적으로 네트워크 인터페이스가 중지 되었습니다."
+
+#: id:789
+msgid "Wireless network name (ESSID)"
+msgstr "무선 네트워크 이름 (ESSID)"
+
+#: id:790
+msgid "Remote control"
+msgstr ""
+
+#: id:791
+msgid "Allow programs on this system to control XBMC"
+msgstr "XBMC 를 제어하기 위해 이 시스템의 프로그램 허용"
+
+#: id:792
+msgctxt "Auto context with id 792"
+msgid "Port"
+msgstr "포트"
+
+#: id:793
+msgid "Port range"
+msgstr "포트 범위"
+
+#: id:794
+msgid "Allow programs on other systems to control XBMC"
+msgstr "XBMC 를 제어 하기 위해 다른 시스템의 프로그램 허용"
+
+#: id:795
+msgid "Initial repeat delay (ms)"
+msgstr "초기 반복 지연(밀리초)"
+
+#: id:796
+msgid "Continuous repeat delay (ms)"
+msgstr "연속 반복 지연(밀리초)"
+
+#: id:797
+msgid "Maximum number of clients"
+msgstr "최대 클라이언트 수"
+
+#: id:798
+msgid "Internet access"
+msgstr "인터넷 접속"
+
+#: id:850
+msgid "Invalid port number entered"
+msgstr "잘못된 포트 번호가 입력됨"
+
+#: id:851
+msgid "Valid port range is 1-65535"
+msgstr "유효한 포트 범위는 1-65535 입니다"
+
+#: id:852
+msgid "Valid port range is 1024-65535"
+msgstr "유효한 포트 범위는 1024-65535 입니다"
+
+#: id:998
+msgid "Add Music..."
+msgstr "음악 파일 위치 추가..."
+
+#: id:999
+msgid "Add Videos..."
+msgstr "비디오 추가..."
+
+#: id:1000
+msgid "- Preview"
+msgstr "- 미리보기"
+
+#: id:1001
+msgid "Unable to connect"
+msgstr "연결할수 없음"
+
+#: id:1002
+msgid "XBMC was unable to connect to the network location."
+msgstr "XBMC가 네트워크에 연결할수 없습니다."
+
+#: id:1003
+msgid "This could be due to the network not being connected."
+msgstr "네트워크가 연결되지 않아 발생했습니다."
+
+#: id:1004
+msgid "Would you like to add it anyway?"
+msgstr "그래도 추가 하시겠습니까?"
+
+#: id:1006
+msgctxt "Auto context with id 1006"
+msgid "IP address"
+msgstr "IP 주소"
+
+#: id:1007
+msgid "Add network location"
+msgstr "네트워크 추가"
+
+#: id:1008
+msgid "Protocol"
+msgstr "프로토콜"
+
+#: id:1009
+msgid "Server address"
+msgstr "서버 주소"
+
+#: id:1010
+msgid "Server name"
+msgstr "서버 이름"
+
+#: id:1011
+msgid "Remote path"
+msgstr "원격 경로"
+
+#: id:1012
+msgid "Shared folder"
+msgstr "공유 폴더"
+
+#: id:1013
+msgctxt "Auto context with id 1013"
+msgid "Port"
+msgstr "포트"
+
+#: id:1014
+msgctxt "Auto context with id 1014"
+msgid "Username"
+msgstr "사용자명"
+
+#: id:1015
+msgid "Browse for network server"
+msgstr "네트워크 서버 찾기"
+
+#: id:1016
+msgid "Enter the network address of the server"
+msgstr "서버의 네트워크 주소 입력"
+
+#: id:1017
+msgid "Enter the path on the server"
+msgstr "서버상의 경로 입력"
+
+#: id:1018
+msgid "Enter the port number"
+msgstr "포트 번호 입력"
+
+#: id:1019
+msgid "Enter the username"
+msgstr "사용자명 입력"
+
+#: id:1020
+msgid "Add %s source"
+msgstr "%s 소스 추가"
+
+#: id:1021
+msgid "Enter the paths or browse for the media locations."
+msgstr "미디어 위치의 경로를 입력하거나 찾아보세요."
+
+#: id:1022
+msgid "Enter a name for this media Source."
+msgstr "미디어 소스의 이름을 입력하세요."
+
+#: id:1023
+msgid "Browse for new share"
+msgstr "새 공유 찾기"
+
+#: id:1024
+msgid "Browse"
+msgstr "찾기"
+
+#: id:1025
+msgid "Could not retrieve directory information."
+msgstr "디렉토리 정보를 검색할수 없습니다."
+
+#: id:1026
+msgid "Add source"
+msgstr "소스 추가"
+
+#: id:1027
+msgid "Edit source"
+msgstr "소스 수정"
+
+#: id:1028
+msgid "Edit %s source"
+msgstr "%s 소스 수정"
+
+#: id:1029
+msgid "Enter the new label"
+msgstr "새 라벨 입력"
+
+#: id:1030
+msgid "Browse for image"
+msgstr "이미지 찾기"
+
+#: id:1031
+msgid "Browse for image folder"
+msgstr "이미지 폴더 찾기"
+
+#: id:1032
+msgid "Add network location..."
+msgstr "네트워크 추가..."
+
+#: id:1033
+msgid "Browse for file"
+msgstr "파일 찾기"
+
+#: id:1034
+msgid "Submenu"
+msgstr "하위메뉴"
+
+#: id:1035
+msgid "Enable submenu buttons"
+msgstr "하위메뉴 버튼 사용"
+
+#: id:1036
+msgid "Favourites"
+msgstr "즐겨찾기"
+
+#: id:1037
+msgid "Video Add-ons"
+msgstr "비디오 추가기능"
+
+#: id:1038
+msgid "Music Add-ons"
+msgstr "음악 추가기능"
+
+#: id:1039
+msgid "Picture Add-ons"
+msgstr "사진 추가기능"
+
+#: id:1040
+msgid "Loading directory"
+msgstr "디렉토리 읽기"
+
+#: id:1041
+msgid "Retrieved %i items"
+msgstr "%i 항목 검색됨"
+
+#: id:1042
+msgid "Retrieved %i of %i items"
+msgstr "%i / %i 항목 검색됨"
+
+#: id:1043
+msgid "Program Add-ons"
+msgstr "프로그램 추가기능"
+
+#: id:1044
+msgid "Set plugin thumb"
+msgstr "플러그인 미리보기 설정"
+
+#: id:1045
+msgid "Add-on settings"
+msgstr "추가기능 설정"
+
+#: id:1046
+msgid "Access points"
+msgstr "액세스 포인트"
+
+#: id:1047
+msgid "Other..."
+msgstr "기타..."
+
+#: id:1048
+msgid "- Username"
+msgstr "- 사용자명"
+
+#: id:1049
+msgid "Script settings"
+msgstr "스크립트 설정"
+
+#: id:1050
+msgid "Singles"
+msgstr "단일"
+
+#: id:1051
+msgid "Enter web address"
+msgstr "웹 주소 입력"
+
+#: id:1200
+msgid "SMB client"
+msgstr "SMB 클라이언트"
+
+#: id:1202
+msgid "Workgroup"
+msgstr "작업그룹"
+
+#: id:1203
+msgid "Default username"
+msgstr "기본 사용자명"
+
+#: id:1204
+msgid "Default password"
+msgstr "기본 비밀번호"
+
+#: id:1207
+msgid "WINS server"
+msgstr "WINS 서버"
+
+#: id:1208
+msgid "Mount SMB shares"
+msgstr "SMB 공유 장착"
+
+#: id:1210
+msgctxt "Auto context with id 1210"
+msgid "Remove"
+msgstr "제거"
+
+#: id:1211
+msgctxt "Auto context with id 1211"
+msgid "Music"
+msgstr "음악"
+
+#: id:1212
+msgctxt "Auto context with id 1212"
+msgid "Video"
+msgstr "비디오"
+
+#: id:1213
+msgctxt "Auto context with id 1213"
+msgid "Pictures"
+msgstr "사진"
+
+#: id:1214
+msgctxt "Auto context with id 1214"
+msgid "Files"
+msgstr "파일"
+
+#: id:1215
+msgctxt "Auto context with id 1215"
+msgid "Music & video"
+msgstr "음악 & 비디오"
+
+#: id:1216
+msgid "Music & pictures"
+msgstr "음악 & 사진"
+
+#: id:1217
+msgid "Music & files"
+msgstr "음악 & 파일"
+
+#: id:1218
+msgid "Video & pictures"
+msgstr "비디오 & 사진"
+
+#: id:1219
+msgid "Video & files"
+msgstr "비디오 & 파일"
+
+#: id:1220
+msgid "Pictures & files"
+msgstr "사진 & 파일"
+
+#: id:1221
+msgid "Music & video & pictures"
+msgstr "음악 & 비디오 & 사진"
+
+#: id:1222
+msgid "Music & video & pictures & files"
+msgstr "음악 & 비디오 & 사진 & 파일"
+
+#: id:1223
+msgctxt "Auto context with id 1223"
+msgid "Disabled"
+msgstr "사용안함"
+
+#: id:1226
+msgid "Files & music & video"
+msgstr "파일 & 음악 & 비디오"
+
+#: id:1227
+msgid "Files & pictures & music"
+msgstr "파일 & 사진 & 음악"
+
+#: id:1228
+msgid "Files & pictures & video"
+msgstr "파일 & 사진 & 비디오"
+
+#: id:1229
+msgid "Music & programs"
+msgstr "음악 & 프로그램"
+
+#: id:1230
+msgid "Video & programs"
+msgstr "비디오 & 프로그램"
+
+#: id:1231
+msgid "Pictures & programs"
+msgstr "사진 & 프로그램"
+
+#: id:1232
+msgid "Music & video & pictures & programs"
+msgstr "음악 & 비디오 & 사진 & 프로그램"
+
+#: id:1233
+msgid "Programs & video & music"
+msgstr "프로그램 & 비디오 & 음악"
+
+#: id:1234
+msgid "Programs & pictures & music"
+msgstr "프로그램 & 사진 & 음악"
+
+#: id:1235
+msgid "Programs & pictures & video"
+msgstr "프로그램 & 사진 & 비디오"
+
+#: id:1250
+msgid "Auto-detection"
+msgstr "자동-감지"
+
+#: id:1251
+msgid "Auto-detect system"
+msgstr "시스템 자동-감지"
+
+#: id:1252
+msgid "Nickname"
+msgstr "별명"
+
+#: id:1254
+msgid "Ask to connect"
+msgstr "연결 요청"
+
+#: id:1255
+msgid "Send FTP user and password"
+msgstr "FTP 사용자 및 비밀번호 전송"
+
+#: id:1256
+msgid "Ping interval"
+msgstr "핑 간격"
+
+#: id:1257
+msgid "Would you like to connect to the auto-detected system?"
+msgstr "자동감지된 시스템에 연결 하시겠습니까?"
+
+#: id:1259
+msgid "Zeroconf"
+msgstr ""
+
+#: id:1260
+msgid "Announce these services to other systems via Zeroconf"
+msgstr "제로컨프를 통해 이 서비스를 다른 시스템에 알림"
+
+#: id:1270
+msgid "Allow XBMC to receive AirPlay content"
+msgstr "XBMC가 에어플레이 컨텐츠를 수신하도록 허용"
+
+#: id:1271
+msgid "Device name"
+msgstr "장치 이름"
+
+#: id:1272
+msgid "- Use password protection"
+msgstr "- 비밀번호 사용"
+
+#: id:1273
+msgid "AirPlay"
+msgstr ""
+
+#: id:1300
+msgid "Custom audio device"
+msgstr "사용자 지정 오디오 장치"
+
+#: id:1301
+msgid "Custom passthrough device"
+msgstr "사용자 지정 패스스루 장치"
+
+#: id:1396
+msgid "Drifting"
+msgstr "뜬"
+
+#: id:1397
+msgid "and"
+msgstr "및"
+
+#: id:1398
+msgid "Freezing"
+msgstr "결빙"
+
+#: id:1399
+msgid "Late"
+msgstr "늦게"
+
+#: id:1400
+msgid "Isolated"
+msgstr "고립된"
+
+#: id:1401
+msgid "Thundershowers"
+msgstr "뇌우"
+
+#: id:1402
+msgid "Thunder"
+msgstr "천둥"
+
+#: id:1403
+msgctxt "Auto context with id 1403"
+msgid "Sun"
+msgstr "햇빛"
+
+#: id:1404
+msgid "Heavy"
+msgstr "많은"
+
+#: id:1405
+msgid "in"
+msgstr ":"
+
+#: id:1406
+msgid "the"
+msgstr ":"
+
+#: id:1407
+msgid "Vicinity"
+msgstr "국지적인"
+
+#: id:1408
+msgid "Ice"
+msgstr "얼음"
+
+#: id:1409
+msgid "Crystals"
+msgstr "눈"
+
+#: id:1410
+msgid "Calm"
+msgstr "고요함"
+
+#: id:1411
+msgid "with"
+msgstr "동반한"
+
+#: id:1412
+msgid "windy"
+msgstr "바람"
+
+#: id:1413
+msgid "drizzle"
+msgstr "이슬비"
+
+#: id:1414
+msgid "Thunderstorm"
+msgstr "뇌우"
+
+#: id:1415
+msgid "Drizzle"
+msgstr "이슬비"
+
+#: id:1416
+msgid "Foggy"
+msgstr "안개"
+
+#: id:1417
+msgid "Grains"
+msgstr "싸래기눈"
+
+#: id:1418
+msgid "T-Storms"
+msgstr "뇌우"
+
+#: id:1419
+msgid "T-Showers"
+msgstr "뇌우"
+
+#: id:1420
+msgid "Moderate"
+msgstr "온화함"
+
+#: id:1421
+msgid "Very High"
+msgstr "매우 높음"
+
+#: id:1422
+msgid "Windy"
+msgstr "센바람"
+
+#: id:1423
+msgid "Mist"
+msgstr "안개"
+
+#: id:1450
+msgid "Put display to sleep when idle"
+msgstr "대기일때 화면 끄기"
+
+#: id:2050
+msgid "Runtime"
+msgstr "상영시간"
+
+#: id:2100
+msgid "Script failed! : %s"
+msgstr "스크립트 실패! : %s"
+
+#: id:2101
+msgid "Newer version needed - See log"
+msgstr "새 버전이 필요함 - 로그를 보세요"
+
+#: id:4501
+msgid "Enable LCD/VFD"
+msgstr "LCD/VFD 사용"
+
+#: id:10000
+msgid "Home"
+msgstr "홈"
+
+#: id:10001
+msgctxt "Auto context with id 10001"
+msgid "Programs"
+msgstr "프로그램"
+
+#: id:10002
+msgctxt "Auto context with id 10002"
+msgid "Pictures"
+msgstr "사진"
+
+#: id:10003
+msgctxt "Auto context with id 10003"
+msgid "File manager"
+msgstr "파일 관리자"
+
+#: id:10004
+msgctxt "Auto context with id 10004"
+msgid "Settings"
+msgstr "설정"
+
+#: id:10005
+msgctxt "Auto context with id 10005"
+msgid "Music"
+msgstr "음악"
+
+#: id:10006
+msgctxt "Auto context with id 10006"
+msgid "Videos"
+msgstr "비디오"
+
+#: id:10007
+msgid "System information"
+msgstr "시스템 정보"
+
+#: id:10008
+msgid "Settings - General"
+msgstr "설정 - 일반"
+
+#: id:10009
+msgid "Settings - Screen"
+msgstr "설정 - 화면"
+
+#: id:10010
+msgid "Settings - Appearance - GUI Calibration"
+msgstr "설정 - 모양새 - GUI 조정"
+
+#: id:10011
+msgid "Settings - Videos - Screen Calibration"
+msgstr "설정 - 비디오 - 화면 조정"
+
+#: id:10012
+msgid "Settings - Pictures"
+msgstr "설정 - 사진"
+
+#: id:10013
+msgid "Settings - Programs"
+msgstr "설정 - 프로그램"
+
+#: id:10014
+msgid "Settings - Weather"
+msgstr "설정 - 날씨"
+
+#: id:10015
+msgid "Settings - Music"
+msgstr "설정 - 음악"
+
+#: id:10016
+msgid "Settings - System"
+msgstr "설정 - 시스템"
+
+#: id:10017
+msgid "Settings - Videos"
+msgstr "설정 - 비디오"
+
+#: id:10018
+msgid "Settings - Network"
+msgstr "설정 - 네트워크"
+
+#: id:10019
+msgid "Settings - Appearance"
+msgstr "설정 - 모양새"
+
+#: id:10020
+msgctxt "Auto context with id 10020"
+msgid "Scripts"
+msgstr "스크립트"
+
+#: id:10021
+msgid "Web Browser"
+msgstr "웹 브라우저"
+
+#: id:10025
+msgctxt "Auto context with id 10025"
+msgid "Videos"
+msgstr "비디오"
+
+#: id:10028
+msgid "Videos/Playlist"
+msgstr "비디오/재생목록"
+
+#: id:10029
+msgctxt "Auto context with id 10029"
+msgid "Login screen"
+msgstr "로그인 화면"
+
+#: id:10034
+msgid "Settings - Profiles"
+msgstr "설정 - 프로파일"
+
+#: id:10040
+msgid "Addon browser"
+msgstr "애드온 탐색기"
+
+#: id:10100
+msgid "Yes/No dialog"
+msgstr "예/아니오 대화창"
+
+#: id:10101
+msgid "Progress dialog"
+msgstr "진행 대화창"
+
+#: id:10210
+msgid "Looking for subtitles..."
+msgstr "자막 찾는중..."
+
+#: id:10211
+msgid "Looking for or caching subtitles..."
+msgstr "자막 찾거나 캐시중..."
+
+#: id:10212
+msgid "terminating"
+msgstr "종료"
+
+#: id:10213
+msgid "buffering"
+msgstr "버퍼링"
+
+#: id:10214
+msgid "Opening stream"
+msgstr "스트림 열기"
+
+#: id:10500
+msgid "Music/Playlist"
+msgstr "음악/재생목록"
+
+#: id:10501
+msgid "Music/Files"
+msgstr "음악/파일"
+
+#: id:10502
+msgid "Music/Library"
+msgstr "음악/라이브러리"
+
+#: id:10503
+msgid "Playlist editor"
+msgstr "재생목록 수정"
+
+#: id:10504
+msgid "Top 100 songs"
+msgstr "인기곡 100"
+
+#: id:10505
+msgid "Top 100 albums"
+msgstr "인기앨범 100"
+
+#: id:10506
+msgctxt "Auto context with id 10506"
+msgid "Programs"
+msgstr "프로그램"
+
+#: id:10507
+msgid "Configuration"
+msgstr "환경설정"
+
+#: id:10508
+msgid "Weather forecast"
+msgstr "일기예보"
+
+#: id:10509
+msgid "Network gaming"
+msgstr "네트워크 게이밍"
+
+#: id:10510
+msgid "Extensions"
+msgstr "확장"
+
+#: id:10511
+msgctxt "Auto context with id 10511"
+msgid "System info"
+msgstr "시스템 정보"
+
+#: id:10516
+msgid "Music - Library"
+msgstr "음악 - 라이브러리"
+
+#: id:10517
+msgid "Now Playing - Music"
+msgstr "지금 재생중 - 음악"
+
+#: id:10522
+msgid "Now Playing - Videos"
+msgstr "지금 재생중 - 비디오"
+
+#: id:10523
+msgid "Album info"
+msgstr "앨범 정보"
+
+#: id:10524
+msgid "Movie info"
+msgstr "영화 정보"
+
+#: id:12000
+msgid "Select dialog"
+msgstr "대화창 선택"
+
+#: id:12001
+msgid "Music/Info"
+msgstr "음악/정보"
+
+#: id:12002
+msgid "Dialog OK"
+msgstr "확인 대화창"
+
+#: id:12003
+msgid "Videos/Info"
+msgstr "비디오/정보"
+
+#: id:12004
+msgid "Scripts/Info"
+msgstr "스크립트/정보"
+
+#: id:12005
+msgid "Fullscreen video"
+msgstr "전체화면 비디오"
+
+#: id:12006
+msgid "Audio visualization"
+msgstr "오디오 시각화"
+
+#: id:12008
+msgid "File stacking dialog"
+msgstr "연결재생 대화창"
+
+#: id:12009
+msgid "Rebuild index..."
+msgstr "인텍스 재생성..."
+
+#: id:12010
+msgid "Return to music window"
+msgstr "음악 윈도우로 돌아가기"
+
+#: id:12011
+msgid "Return to videos window"
+msgstr "비디오 윈도우로 돌아가기"
+
+#: id:12021
+msgid "Start from beginning"
+msgstr "처음부터 시작"
+
+#: id:12022
+msgid "Resume from %s"
+msgstr "%s 부터 되시작"
+
+#: id:12310
+msgid "0"
+msgstr "0"
+
+#: id:12311
+msgid "1"
+msgstr "1"
+
+#: id:12312
+msgid "2"
+msgstr "2"
+
+#: id:12313
+msgid "3"
+msgstr "3"
+
+#: id:12314
+msgid "4"
+msgstr "4"
+
+#: id:12315
+msgid "5"
+msgstr "5"
+
+#: id:12316
+msgid "6"
+msgstr "6"
+
+#: id:12317
+msgid "7"
+msgstr "7"
+
+#: id:12318
+msgid "8"
+msgstr "8"
+
+#: id:12319
+msgid "9"
+msgstr "9"
+
+#: id:12320
+msgid "c"
+msgstr "취소"
+
+#: id:12321
+msgid "Ok"
+msgstr "확인"
+
+#: id:12322
+msgid "*"
+msgstr "*"
+
+#: id:12325
+msgid "Locked! Enter code..."
+msgstr "잠김! 코드를 입력하세요..."
+
+#: id:12326
+msgid "Enter password"
+msgstr "비밀번호 입력"
+
+#: id:12327
+msgid "Enter master code"
+msgstr "마스터 코드 입력"
+
+#: id:12328
+msgid "Enter unlock code"
+msgstr "잠금해제 코드 입력"
+
+#: id:12329
+msgid "or press C to cancel"
+msgstr "- C 버튼을 누르면 취소"
+
+#: id:12330
+msgid "Enter gamepad button combo and"
+msgstr "게임패드 버튼 조합을 입력한 후"
+
+#: id:12331
+msgid "press OK, or Back to cancel"
+msgstr "확인 또는, 취소하려면 뒤로 누르세요"
+
+#: id:12332
+msgid "Set lock"
+msgstr "잠금 설정"
+
+#: id:12333
+msgid "Unlock"
+msgstr "잠금해제"
+
+#: id:12334
+msgid "Reset lock"
+msgstr "잠금 초기화"
+
+#: id:12335
+msgid "Remove lock"
+msgstr "잠금 제거"
+
+#: id:12337
+msgid "Numeric password"
+msgstr "숫자 비밀번호"
+
+#: id:12338
+msgid "Gamepad button combo"
+msgstr "게임패드 버튼 조합"
+
+#: id:12339
+msgid "Full-text password"
+msgstr "문자 비밀번호"
+
+#: id:12340
+msgid "Enter new password"
+msgstr "새 비밀번호 입력"
+
+#: id:12341
+msgid "Re-Enter new password"
+msgstr "새 비밀번호 재입력"
+
+#: id:12342
+msgid "Incorrect password,"
+msgstr "잘못된 비밀번호,"
+
+#: id:12343
+msgid "retries left"
+msgstr "남은 재시도"
+
+#: id:12344
+msgid "Passwords entered did not match."
+msgstr "입력된 비밀번호가 일치하지 않습니다."
+
+#: id:12345
+msgid "Access denied"
+msgstr "접근 거부됨"
+
+#: id:12346
+msgid "Password retry limit exceeded."
+msgstr "비밀번호 재시도 제한이 초과 되었습니다."
+
+#: id:12347
+msgid "The system will now shut off."
+msgstr "지금 시스템이 종료됩니다."
+
+#: id:12348
+msgid "Item locked"
+msgstr "항목 잠김"
+
+#: id:12353
+msgid "Reactivate lock"
+msgstr "잠금 재활성화"
+
+#: id:12356
+msgid "Change lock"
+msgstr "잠금 변경"
+
+#: id:12357
+msgid "Source lock"
+msgstr "소스 잠금"
+
+#: id:12358
+msgid "Password entry was blank. Try again."
+msgstr "비밀번호가 비었습니다. 다시 시도하세요"
+
+#: id:12360
+msgid "Master lock"
+msgstr "마스터 잠금"
+
+#: id:12362
+msgid "Shutdown system if Master Lock retries exceeded"
+msgstr "마스터 잠금 재시도 초과되면 시스템 종료"
+
+#: id:12367
+msgid "Master code is not valid"
+msgstr "마스터 코드가 정확하지 않습니다"
+
+#: id:12368
+msgid "Please enter a valid master code"
+msgstr "정확한 마스터 코드를 입력해 주세요"
+
+#: id:12373
+msgid "Settings & file manager"
+msgstr "설정 & 파일 관리자"
+
+#: id:12376
+msgid "Set as default for all movies"
+msgstr "모든 영화에 기본값으로 설정"
+
+#: id:12377
+msgid "This will reset any previously saved values"
+msgstr "이전에 저장된 모든 값을 초기화합니다"
+
+#: id:12378
+msgid "Amount of time to display each image"
+msgstr "각각의 이미지를 표시할 시간"
+
+#: id:12379
+msgid "Use pan and zoom effects"
+msgstr "회전 및 축소/확대 효과 사용"
+
+#: id:12383
+msgid "12 hour clock"
+msgstr "12시간제"
+
+#: id:12384
+msgid "24 hour clock"
+msgstr "24시간제"
+
+#: id:12385
+msgid "Day/Month"
+msgstr "일/월"
+
+#: id:12386
+msgid "Month/Day"
+msgstr "월/일"
+
+#: id:12390
+msgid "System uptime"
+msgstr "시스템 가동시간"
+
+#: id:12391
+msgid "Minutes"
+msgstr "분"
+
+#: id:12392
+msgid "Hours"
+msgstr "시간"
+
+#: id:12393
+msgid "Days"
+msgstr "일"
+
+#: id:12394
+msgid "Total uptime"
+msgstr "총 가동시간"
+
+#: id:12395
+msgid "Battery level"
+msgstr "배터리 상태"
+
+#: id:12600
+msgctxt "Auto context with id 12600"
+msgid "Weather"
+msgstr "날씨"
+
+#: id:12900
+msgctxt "Auto context with id 12900"
+msgid "Screensaver"
+msgstr "화면보호기"
+
+#: id:12901
+msgid "Fullscreen OSD"
+msgstr "전체화면 OSD"
+
+#: id:13000
+msgid "System"
+msgstr "시스템"
+
+#: id:13001
+msgid "Immediate HD spindown"
+msgstr "즉시 하드디스크 끄기"
+
+#: id:13002
+msgid "Video only"
+msgstr "비디오만"
+
+#: id:13003
+msgid "- Delay"
+msgstr "- 지연"
+
+#: id:13004
+msgid "- Minimum file duration"
+msgstr "- 최소 파일 재생시간:"
+
+#: id:13005
+msgid "Shutdown"
+msgstr "종료"
+
+#: id:13008
+msgid "Shutdown function"
+msgstr "종료 기능"
+
+#: id:13009
+msgid "Quit"
+msgstr "나가기"
+
+#: id:13010
+msgid "Hibernate"
+msgstr "최대절전"
+
+#: id:13011
+msgid "Suspend"
+msgstr "대기"
+
+#: id:13012
+msgid "Exit"
+msgstr "종료"
+
+#: id:13013
+msgid "Reboot"
+msgstr "재시작"
+
+#: id:13014
+msgid "Minimize"
+msgstr "최소화"
+
+#: id:13015
+msgid "Power button action"
+msgstr "전원 버튼 동작"
+
+#: id:13016
+msgid "Power off System"
+msgstr "시스템 전원 끄기"
+
+#: id:13020
+msgid "Is another session active, perhaps over ssh?"
+msgstr "혹시 ssh 를 통해 다른 세션이 활성화되어 있습니까?"
+
+#: id:13021
+msgid "Mounted removable harddrive"
+msgstr "장착된 이동식 하드드라이브"
+
+#: id:13022
+msgid "Unsafe device removal"
+msgstr "장치 제거 안전하지 않음"
+
+#: id:13023
+msgid "Successfully removed device"
+msgstr "정상적으로 장치 제거됨"
+
+#: id:13024
+msgid "Joystick plugged"
+msgstr "조이스틱 연결됨"
+
+#: id:13025
+msgid "Joystick unplugged"
+msgstr "조이스틱 연결해제됨"
+
+#: id:13050
+msgid "Running low on battery"
+msgstr "낮은 배터리에서 실행중"
+
+#: id:13100
+msgid "Flicker filter"
+msgstr "깜박임 필터"
+
+#: id:13101
+msgid "Let driver choose (requires restart)"
+msgstr "드라이버 선택 허용 (재시작 필요)"
+
+#: id:13105
+msgid "Vertical blank sync"
+msgstr "수직동기"
+
+#: id:13106
+msgctxt "Auto context with id 13106"
+msgid "Disabled"
+msgstr "사용안함"
+
+#: id:13107
+msgid "Enabled during video playback"
+msgstr "비디오 재생중 사용함"
+
+#: id:13108
+msgctxt "Auto context with id 13108"
+msgid "Always enabled"
+msgstr "항상 사용함"
+
+#: id:13109
+msgid "Test & apply resolution"
+msgstr "해상도 테스트 & 적용"
+
+#: id:13110
+msgid "Save resolution?"
+msgstr "해상도를 저장 하시겠습니까?"
+
+#: id:13111
+msgid "Would you like to keep this resolution?"
+msgstr "현재 해상도를 유지 하시겠습니까?"
+
+#: id:13112
+msgid "High quality upscaling"
+msgstr "고품질 업스케일링"
+
+#: id:13113
+msgctxt "Auto context with id 13113"
+msgid "Disabled"
+msgstr "사용안함"
+
+#: id:13114
+msgid "Enabled for SD content"
+msgstr "SD 컨텐츠 사용함"
+
+#: id:13115
+msgctxt "Auto context with id 13115"
+msgid "Always enabled"
+msgstr "항상 사용함"
+
+#: id:13116
+msgid "Upscaling method"
+msgstr "업스케일링 방식"
+
+#: id:13117
+msgctxt "Auto context with id 13117"
+msgid "Bicubic"
+msgstr "바이큐빅"
+
+#: id:13118
+msgid "Lanczos"
+msgstr "랑초스"
+
+#: id:13119
+msgid "Sinc"
+msgstr "싱크"
+
+#: id:13120
+msgctxt "Auto context with id 13120"
+msgid "VDPAU"
+msgstr "VDPAU"
+
+#: id:13121
+msgid "VDPAU HQ Upscaling level"
+msgstr "VDPAU HQ 업스케일링 수준"
+
+#: id:13122
+msgid "VDPAU Studio level color conversion"
+msgstr "VDPAU 스튜디오 수준 색온도 변환"
+
+#: id:13130
+msgid "Blank other displays"
+msgstr "다른 화면 비우기"
+
+#: id:13131
+msgctxt "Auto context with id 13131"
+msgid "Disabled"
+msgstr "사용안함"
+
+#: id:13132
+msgid "Blank displays"
+msgstr "화면 비우기"
+
+#: id:13140
+msgid "Active connections detected!"
+msgstr "활성 연결 감지됨!"
+
+#: id:13141
+msgid "If you proceed, you might not be able to control XBMC"
+msgstr "진행할경우, XBMC 제어를 할수 없음"
+
+#: id:13142
+msgid "any longer. Are you sure you want to stop the Event server?"
+msgstr "사용안함. 이벤트 서버를 중지 하시겠습니까?"
+
+#: id:13144
+msgid "Change Apple Remote mode?"
+msgstr "애플 리모트 모드를 변경 하시겠습니까?"
+
+#: id:13145
+msgid "If you are currently using the Apple Remote to control"
+msgstr "만약 현재 XMBC 를 제어하는데 애플 리모트를"
+
+#: id:13146
+msgid "XBMC, changing this setting might affect your ability"
+msgstr "사용한다면, 이 설정의 변경은 XBMC 를 제어하는데"
+
+#: id:13147
+msgid "to continue controlling it. Do you want to proceed?"
+msgstr "영향을 주게됩니다. 진행 하시겠습니까?"
+
+#: id:13159
+msgid "Subnet mask"
+msgstr "서브넷 마스크"
+
+#: id:13160
+msgid "Gateway"
+msgstr "게이트웨이"
+
+#: id:13161
+msgid "Primary DNS"
+msgstr "기본 DNS"
+
+#: id:13162
+msgid "Initialize failed"
+msgstr "초기화 실패"
+
+#: id:13170
+msgctxt "Auto context with id 13170"
+msgid "Never"
+msgstr "안함"
+
+#: id:13171
+msgid "Immediately"
+msgstr "즉시"
+
+#: id:13172
+msgid "After %i secs"
+msgstr "%i 초 후"
+
+#: id:13173
+msgid "HDD install date:"
+msgstr "HDD 설치 날짜:"
+
+#: id:13174
+msgid "HDD power cycle count:"
+msgstr "HDD 전원 주기 횟수:"
+
+#: id:13200
+msgid "Profiles"
+msgstr "프로파일"
+
+#: id:13201
+msgid "Delete profile '%s'?"
+msgstr "'%s' 프로파일을 삭제 하시겠습니까?"
+
+#: id:13204
+msgid "Last loaded profile:"
+msgstr "마지막 읽은 프로파일:"
+
+#: id:13205
+msgid "Unknown"
+msgstr "알수없음"
+
+#: id:13206
+msgid "Overwrite"
+msgstr "덮어쓰기"
+
+#: id:13208
+msgid "Alarm clock"
+msgstr "알람 시계"
+
+#: id:13209
+msgid "Alarm clock interval (in minutes)"
+msgstr "알람 시계 간격(분)"
+
+#: id:13210
+msgid "Started, alarm in %im"
+msgstr "시작됨, %i분 후 알람"
+
+#: id:13211
+msgid "Alarm!"
+msgstr "알람!"
+
+#: id:13212
+msgid "Canceled with %im%is left"
+msgstr "%i 분 %i 초를 남겨두고 취소됨"
+
+#: id:13213
+msgid "%2.0fm"
+msgstr "%2.0f분"
+
+#: id:13214
+msgid "%2.0fs"
+msgstr "%2.0f초"
+
+#: id:13249
+msgid "Search for subtitles in RARs"
+msgstr "RAR의 자막 찾기"
+
+#: id:13250
+msgid "Browse for subtitle..."
+msgstr "자막 찾기..."
+
+#: id:13251
+msgid "Move item"
+msgstr "항목 이동"
+
+#: id:13252
+msgid "Move item here"
+msgstr "여기에 항목 이동"
+
+#: id:13253
+msgid "Cancel move"
+msgstr "이동 취소"
+
+#: id:13270
+msgid "Hardware:"
+msgstr "하드웨어:"
+
+#: id:13271
+msgid "CPU Usage:"
+msgstr "CPU 사용량:"
+
+#: id:13274
+msgid "Connected, but no DNS is available."
+msgstr "연결됨, 그러나 DNS 를 사용할수 없습니다."
+
+#: id:13275
+msgid "Hard Disk"
+msgstr "하드디스크"
+
+#: id:13276
+msgid "DVD-ROM"
+msgstr "DVD-롬"
+
+#: id:13277
+msgctxt "Auto context with id 13277"
+msgid "Storage"
+msgstr "저장장치"
+
+#: id:13278
+msgctxt "Auto context with id 13278"
+msgid "Default"
+msgstr "기본"
+
+#: id:13279
+msgctxt "Auto context with id 13279"
+msgid "Network"
+msgstr "네트워크"
+
+#: id:13280
+msgctxt "Auto context with id 13280"
+msgid "Video"
+msgstr "비디오"
+
+#: id:13281
+msgid "Hardware"
+msgstr "하드웨어"
+
+#: id:13283
+msgid "Operating system:"
+msgstr "운영체제:"
+
+#: id:13284
+msgid "CPU speed:"
+msgstr "CPU 속도:"
+
+#: id:13286
+msgid "Video encoder:"
+msgstr "비디오 인코더:"
+
+#: id:13287
+msgid "Screen resolution:"
+msgstr "화면 해상도:"
+
+#: id:13292
+msgid "A/V cable:"
+msgstr "A/V 케이블:"
+
+#: id:13294
+msgid "DVD region:"
+msgstr "DVD 지역:"
+
+#: id:13295
+msgid "Internet:"
+msgstr "인터넷:"
+
+#: id:13296
+msgctxt "Auto context with id 13296"
+msgid "Connected"
+msgstr "연결됨"
+
+#: id:13297
+msgid "Not connected. Check network settings."
+msgstr "연결안됨. 네트워크 설정을 확인하세요."
+
+#: id:13299
+msgid "Target temperature"
+msgstr "설정 온도"
+
+#: id:13300
+msgid "Fan speed"
+msgstr "팬 속도"
+
+#: id:13301
+msgid "Auto temperature control"
+msgstr "자동 온도 조절"
+
+#: id:13302
+msgid "Fan speed override"
+msgstr "팬 속도 조절"
+
+#: id:13303
+msgid "- Fonts"
+msgstr "- 글꼴"
+
+#: id:13304
+msgid "Enable flipping bi-directional strings"
+msgstr "역방향 문자열의 뒤집기 사용"
+
+#: id:13305
+msgid "Show RSS news feeds"
+msgstr "RSS 뉴스 피드 보이기"
+
+#: id:13306
+msgid "Show parent folder items"
+msgstr "상위 폴더 항목 보이기"
+
+#: id:13307
+msgid "Track naming template"
+msgstr "트랙 이름 템플릿"
+
+#: id:13308
+msgid "Do you wish to reboot your system"
+msgstr "XBMC만 재시작하는 대신에"
+
+#: id:13309
+msgid "instead of just XBMC?"
+msgstr "시스템을 재시작하기를 원하십니까?"
+
+#: id:13310
+msgid "Zoom effect"
+msgstr "축소/확대 효과"
+
+#: id:13311
+msgid "Float effect"
+msgstr "떠다니는 효과"
+
+#: id:13312
+msgid "Black bar reduction"
+msgstr "검은 여백 제거"
+
+#: id:13313
+msgid "Restart"
+msgstr "재시작"
+
+#: id:13314
+msgid "Crossfade between songs"
+msgstr "노래간에 크로스페이드"
+
+#: id:13315
+msgid "Regenerate thumbnails"
+msgstr "미리보기 다시 만들기"
+
+#: id:13316
+msgid "Recursive thumbnails"
+msgstr "순환 미리보기"
+
+#: id:13317
+msgid "View slideshow"
+msgstr "슬라이드쇼 보기"
+
+#: id:13318
+msgid "Recursive slideshow"
+msgstr "순환 슬라이드쇼"
+
+#: id:13319
+msgid "Randomize"
+msgstr "무작위"
+
+#: id:13320
+msgid "Stereo"
+msgstr "스테레오"
+
+#: id:13321
+msgid "Left only"
+msgstr "왼쪽만"
+
+#: id:13322
+msgid "Right only"
+msgstr "오른쪽만"
+
+#: id:13323
+msgid "Enable karaoke support"
+msgstr "노래방 지원 사용"
+
+#: id:13324
+msgid "Background transparency"
+msgstr "배경 투명도"
+
+#: id:13325
+msgid "Foreground transparency"
+msgstr "전경 투명도"
+
+#: id:13326
+msgid "A/V delay"
+msgstr "A/V 지연"
+
+#: id:13327
+msgid "Karaoke"
+msgstr "노래방"
+
+#: id:13328
+msgid "%s not found"
+msgstr "%s 찾지 못함"
+
+#: id:13329
+msgid "Error opening %s"
+msgstr "%s 열기 오류"
+
+#: id:13330
+msgid "Unable to load %s"
+msgstr "%s 읽을수 없음"
+
+#: id:13331
+msgid "Error: Out of memory"
+msgstr "오류: 메모리 부족"
+
+#: id:13332
+msgid "Move up"
+msgstr "위로 이동"
+
+#: id:13333
+msgid "Move down"
+msgstr "아래로 이동"
+
+#: id:13334
+msgid "Edit label"
+msgstr "라벨 수정"
+
+#: id:13335
+msgid "Make default"
+msgstr "기본값 사용"
+
+#: id:13336
+msgid "Remove button"
+msgstr "버튼 제거"
+
+#: id:13340
+msgid "Leave as is"
+msgstr "변경안함"
+
+#: id:13341
+msgid "Green"
+msgstr "녹색"
+
+#: id:13342
+msgid "Orange"
+msgstr "주황"
+
+#: id:13343
+msgid "Red"
+msgstr "빨강"
+
+#: id:13344
+msgid "Cycle"
+msgstr "순환"
+
+#: id:13345
+msgid "Switch LED off on playback"
+msgstr "재생때 LED 끄기"
+
+#: id:13346
+msgctxt "Auto context with id 13346"
+msgid "Movie information"
+msgstr "영화 정보"
+
+#: id:13347
+msgid "Queue item"
+msgstr "항목 추가"
+
+#: id:13348
+msgid "Search IMDb..."
+msgstr "IMDb 찾기..."
+
+#: id:13349
+msgid "Scan for new content"
+msgstr "새 컨텐츠 검색"
+
+#: id:13350
+msgid "Now playing..."
+msgstr "지금 재생중..."
+
+#: id:13351
+msgctxt "Auto context with id 13351"
+msgid "Album information"
+msgstr "앨범 정보"
+
+#: id:13352
+msgid "Scan item to library"
+msgstr "라이브러리에 항목 검색"
+
+#: id:13353
+msgid "Stop scanning"
+msgstr "검색 중지"
+
+#: id:13354
+msgctxt "Auto context with id 13354"
+msgid "Render method"
+msgstr "렌더링 방식"
+
+#: id:13355
+msgid "Low quality pixel shader"
+msgstr "저화질 픽셀 셰이더"
+
+#: id:13356
+msgid "Hardware overlays"
+msgstr "하드웨어 오버레이"
+
+#: id:13357
+msgid "High quality pixel shader"
+msgstr "고화질 픽셀 셰이더"
+
+#: id:13358
+msgid "Play item"
+msgstr "항목 재생"
+
+#: id:13359
+msgid "Set artist thumb"
+msgstr "아티스트 미리보기 설정"
+
+#: id:13360
+msgid "Automatically generate thumbnails"
+msgstr "자동 미리보기 생성"
+
+#: id:13361
+msgid "Enable voice"
+msgstr "음성 사용"
+
+#: id:13375
+msgid "Enable device"
+msgstr "장치 사용"
+
+#: id:13376
+msgid "Volume"
+msgstr "음량"
+
+#: id:13377
+msgid "Default view mode"
+msgstr "기본 보기 모드"
+
+#: id:13378
+msgid "Default brightness"
+msgstr "기본 밝기"
+
+#: id:13379
+msgid "Default contrast"
+msgstr "기본 명암"
+
+#: id:13380
+msgid "Default gamma"
+msgstr "기본 감마"
+
+#: id:13381
+msgid "Resume video"
+msgstr "비디오 되시작"
+
+#: id:13382
+msgid "Voice mask - Port 1"
+msgstr "음성 변조 - 포트 0"
+
+#: id:13383
+msgid "Voice mask - Port 2"
+msgstr "음성 변조 - 포트 1"
+
+#: id:13384
+msgid "Voice mask - Port 3"
+msgstr "음성 변조 - 포트 2"
+
+#: id:13385
+msgid "Voice mask - Port 4"
+msgstr "음성 변조 - 포트 3"
+
+#: id:13386
+msgid "Use time based seeking"
+msgstr "시간 기반 검색 사용"
+
+#: id:13387
+msgid "Track naming template - right"
+msgstr "트랙 이름 템플릿 - 오른쪽"
+
+#: id:13388
+msgid "Preset"
+msgstr "사전설정"
+
+#: id:13389
+msgid "There are no presets available\nfor this visualization"
+msgstr "이 시각화에 사용가능한 사전설정이 없습니다"
+
+#: id:13390
+msgid "There are no settings available\nfor this visualization"
+msgstr "이 시각화에 사용가능한 설정이 없습니다"
+
+#: id:13391
+msgid "Eject/Load"
+msgstr "꺼내기/읽기"
+
+#: id:13392
+msgid "Use visualization if playing audio"
+msgstr "오디오 재생중이면 시각화 사용"
+
+#: id:13393
+msgid "Calculate size"
+msgstr "크기 계산"
+
+#: id:13394
+msgid "Calculating folder size"
+msgstr "폴더 크기 계산"
+
+#: id:13395
+msgid "Video settings"
+msgstr "비디오 설정"
+
+#: id:13396
+msgid "Audio and subtitle settings"
+msgstr "오디오 및 자막 설정"
+
+#: id:13397
+msgid "Enable subtitles"
+msgstr "자막 사용"
+
+#: id:13398
+msgctxt "Auto context with id 13398"
+msgid "Shortcuts"
+msgstr "바로가기"
+
+#: id:13399
+msgid "Ignore articles when sorting (e.g. \"the\")"
+msgstr "정렬시 관사 무시 (예 \"the\")"
+
+#: id:13400
+msgid "Crossfade between songs on the same album"
+msgstr "같은 앨범 노래간에 크로스페이드"
+
+#: id:13401
+msgid "Browse for %s"
+msgstr "%s 찾기"
+
+#: id:13402
+msgid "Show track position"
+msgstr "트랙 위치 보이기"
+
+#: id:13403
+msgid "Clear default"
+msgstr "기본값 지우기"
+
+#: id:13404
+msgid "Resume"
+msgstr "되시작"
+
+#: id:13405
+msgid "Get thumb"
+msgstr "미리보기 가져오기"
+
+#: id:13406
+msgid "Picture information"
+msgstr "사진 정보"
+
+#: id:13407
+msgid "%s presets"
+msgstr "%s 사전설정"
+
+#: id:13408
+msgid "(IMDb user rating)"
+msgstr "(사용자 평점)"
+
+#: id:13409
+msgid "Top 250"
+msgstr "인기 250"
+
+#: id:13410
+msgid "Tune in on Last.fm"
+msgstr "Last.fm 에 채널을 맞춤"
+
+#: id:13411
+msgid "Minimum fan speed"
+msgstr "최소 팬 속도"
+
+#: id:13412
+msgid "Play from here"
+msgstr "이 항목부터 재생"
+
+#: id:13413
+msgid "Downloading"
+msgstr "다운로드"
+
+#: id:13414
+msgid "Include artists who appear only on compilations"
+msgstr "컴필레이션에만 있는 아티스트 포함"
+
+#: id:13415
+msgctxt "Auto context with id 13415"
+msgid "Render method"
+msgstr "렌더링 방식"
+
+#: id:13416
+msgid "Auto detect"
+msgstr "자동감지"
+
+#: id:13417
+msgid "Basic shaders (ARB)"
+msgstr "기본 셰이더 (ARB)"
+
+#: id:13418
+msgid "Advanced shaders (GLSL)"
+msgstr "고급 셰이더 (GLSL)"
+
+#: id:13419
+msgid "Software"
+msgstr "소프트웨어"
+
+#: id:13420
+msgid "Remove safely"
+msgstr "안전하게 제거"
+
+#: id:13421
+msgctxt "Auto context with id 13421"
+msgid "VDPAU"
+msgstr "VDPAU"
+
+#: id:13422
+msgid "Start slideshow here"
+msgstr "여기에서 슬라이드쇼 시작"
+
+#: id:13423
+msgid "Remember for this path"
+msgstr "이 경로 기억"
+
+#: id:13424
+msgid "Use pixel buffer objects"
+msgstr "픽셀 버퍼 객체 사용"
+
+#: id:13425
+msgid "Allow hardware acceleration (VDPAU)"
+msgstr "하드웨어 가속 허용 (VDPAU)"
+
+#: id:13426
+msgid "Allow hardware acceleration (VAAPI)"
+msgstr "하드웨어 가속 허용 (VAAPI)"
+
+#: id:13427
+msgid "Allow hardware acceleration (DXVA2)"
+msgstr "하드웨어 가속 허용 (DXVA2)"
+
+#: id:13428
+msgid "Allow hardware acceleration (CrystalHD)"
+msgstr "하드웨어 가속 허용 (CrystalHD)"
+
+#: id:13429
+msgid "Allow hardware acceleration (VDADecoder)"
+msgstr "하드웨어 가속 허용 (VDADecoder)"
+
+#: id:13430
+msgid "Allow hardware acceleration (OpenMax)"
+msgstr "하드웨어 가속 허용 (OpenMax)"
+
+#: id:13431
+msgid "Pixel Shaders"
+msgstr "픽셀 셰이더"
+
+#: id:13432
+msgid "Allow hardware acceleration (VideoToolbox)"
+msgstr "하드웨어 가속 사용 (VideoToolbox)"
+
+#: id:13500
+msgid "A/V sync method"
+msgstr "A/V 동기 방식"
+
+#: id:13501
+msgid "Audio clock"
+msgstr "오디오 클럭"
+
+#: id:13502
+msgid "Video clock (Drop/Dupe audio)"
+msgstr "비디오 클럭 (오디오 버림/반복)"
+
+#: id:13503
+msgid "Video clock (Resample audio)"
+msgstr "비디오 클럭 (오디오 리샘플)"
+
+#: id:13504
+msgid "Maximum resample amount (%)"
+msgstr "최대 리샘플 량 (%s)"
+
+#: id:13505
+msgid "Resample quality"
+msgstr "리샘플 품질"
+
+#: id:13506
+msgid "Low(fast)"
+msgstr "낮음(빠름)"
+
+#: id:13507
+msgctxt "Auto context with id 13507"
+msgid "Medium"
+msgstr "중간"
+
+#: id:13508
+msgctxt "Auto context with id 13508"
+msgid "High"
+msgstr "높음"
+
+#: id:13509
+msgid "Really high(slow!)"
+msgstr "매우 높음(느림!)"
+
+#: id:13510
+msgid "Sync playback to display"
+msgstr "화면에 재생 동기"
+
+#: id:13550
+msgid "Pause during refresh rate change"
+msgstr "새로고침 비율 변경시 일시중지"
+
+#: id:13551
+msgctxt "Auto context with id 13551"
+msgid "Off"
+msgstr "끄기"
+
+#: id:13552
+msgid "%.1f Second"
+msgstr "%.1f 초"
+
+#: id:13553
+msgid "%.1f Seconds"
+msgstr "%.1f 초"
+
+#: id:13600
+msgid "Apple remote"
+msgstr "애플 리모트"
+
+#: id:13602
+msgid "Allow start of XBMC using the remote"
+msgstr "리모트를 사용하여 XBMC 시작 허용"
+
+#: id:13603
+msgid "Sequence delay time"
+msgstr "순차 지연 시간"
+
+#: id:13610
+msgctxt "Auto context with id 13610"
+msgid "Disabled"
+msgstr "사용안함"
+
+#: id:13611
+msgctxt "Auto context with id 13611"
+msgid "Standard"
+msgstr "표준"
+
+#: id:13612
+msgid "Universal Remote"
+msgstr "유니버셜 리모트"
+
+#: id:13613
+msgid "Multi Remote (Harmony)"
+msgstr "멀티 리모트 (하모니)"
+
+#: id:13620
+msgid "Apple Remote Error"
+msgstr "애플 리모트 오류"
+
+#: id:13621
+msgid "Apple Remote support could be enabled."
+msgstr "애플 리모트 지원을 사용할수 있습니다."
+
+#: id:14000
+msgid "Stack"
+msgstr "연결재생"
+
+#: id:14001
+msgid "Unstack"
+msgstr "연결재생 해제"
+
+#: id:14003
+msgid "Downloading playlist file..."
+msgstr "재생목록 파일 다운로드중..."
+
+#: id:14004
+msgid "Downloading streams list..."
+msgstr "스트림 목록 다운로드중..."
+
+#: id:14005
+msgid "Parsing streams list..."
+msgstr "스트림 목록 분석중..."
+
+#: id:14006
+msgid "Downloading streams list failed"
+msgstr "스트림 목록 다운로드 실패"
+
+#: id:14007
+msgid "Downloading playlist file failed"
+msgstr "재생목록 파일 다운로드 실패"
+
+#: id:14009
+msgid "Games directory"
+msgstr "게임 디렉토리"
+
+#: id:14010
+msgid "Auto switch to thumbs based on"
+msgstr "미리보기 자동 변경"
+
+#: id:14011
+msgid "Enable auto switching to thumbs view"
+msgstr "미리보기 자동 변경 사용"
+
+#: id:14012
+msgid "- Use large icons"
+msgstr "- 큰 아이콘 사용"
+
+#: id:14013
+msgid "- Switch based on"
+msgstr "- 에 따라 변경"
+
+#: id:14014
+msgid "- Percentage"
+msgstr "- 비율"
+
+#: id:14015
+msgid "No files and at least one thumb"
+msgstr "파일없고 최소한 한개의 미리보기"
+
+#: id:14016
+msgid "At least one file and thumb"
+msgstr "최소한 한개의 파일과 미리보기"
+
+#: id:14017
+msgid "Percentage of thumbs"
+msgstr "미리보기 비율"
+
+#: id:14018
+msgid "View options"
+msgstr "보기 옵션"
+
+#: id:14019
+msgid "Change area code 1"
+msgstr "지역코드 1 변경"
+
+#: id:14020
+msgid "Change area code 2"
+msgstr "지역코드 2 변경"
+
+#: id:14021
+msgid "Change area code 3"
+msgstr "지역코드 3 변경"
+
+#: id:14022
+msgctxt "Auto context with id 14022"
+msgid "Library"
+msgstr "라이브러리"
+
+#: id:14023
+msgid "No TV"
+msgstr "TV 사용 안함"
+
+#: id:14024
+msgid "Enter the nearest large town"
+msgstr "가까운 큰 도시를 입력"
+
+#: id:14025
+msgid "Video/Audio/DVD cache - Harddisk"
+msgstr "비디오/오디오/DVD 캐시 - 하드디스크"
+
+#: id:14026
+msgid "Video cache - DVD-ROM"
+msgstr "비디오 캐시 - DVD-롬"
+
+#: id:14027
+msgctxt "Auto context with id 14027"
+msgid "- Local Network"
+msgstr "- 로컬 네트워크"
+
+#: id:14028
+msgctxt "Auto context with id 14028"
+msgid "- Internet"
+msgstr "- 인터넷"
+
+#: id:14030
+msgid "Audio cache - DVD-ROM"
+msgstr "오디오 캐시 - DVD-롬"
+
+#: id:14031
+msgctxt "Auto context with id 14031"
+msgid "- Local Network"
+msgstr "- 로컬 네트워크"
+
+#: id:14032
+msgctxt "Auto context with id 14032"
+msgid "- Internet"
+msgstr "- 인터넷"
+
+#: id:14034
+msgid "DVD cache - DVD-ROM"
+msgstr "DVD 캐시 - DVD-롬"
+
+#: id:14035
+msgctxt "Auto context with id 14035"
+msgid "- Local Network"
+msgstr "- 로컬 네트워크"
+
+#: id:14036
+msgctxt "Auto context with id 14036"
+msgid "Services"
+msgstr "서비스"
+
+#: id:14038
+msgid "Network settings changed"
+msgstr "네트워크 설정이 변경되었습니다"
+
+#: id:14039
+msgid "XBMC requires to restart to change your"
+msgstr "네트워크 설정을 변경하려면 XBMC"
+
+#: id:14040
+msgid "network setup. Would you like to restart now?"
+msgstr "재시작이 필요합니다. 지금 재시작 하시겠습니까?"
+
+#: id:14041
+msgid "Internet connection bandwidth limitation"
+msgstr "인터넷 연결 대역폭 제한"
+
+#: id:14043
+msgid "- Shutdown while playing"
+msgstr "- 재생중에도 종료"
+
+#: id:14044
+msgid "%i min"
+msgstr "%i 분"
+
+#: id:14045
+msgid "%i sec"
+msgstr "%i 초"
+
+#: id:14046
+msgid "%i ms"
+msgstr "%i 밀리초"
+
+#: id:14047
+msgid "%i %%"
+msgstr "%i %%"
+
+#: id:14048
+msgid "%i kbps"
+msgstr "%i kbps"
+
+#: id:14049
+msgid "%i kb"
+msgstr "%i kb"
+
+#: id:14050
+msgid "%i.0 dB"
+msgstr "%i.0 dB"
+
+#: id:14051
+msgid "Time format"
+msgstr "시간 형식"
+
+#: id:14052
+msgid "Date format"
+msgstr "날짜 형식"
+
+#: id:14053
+msgid "GUI filters"
+msgstr "GUI 필터"
+
+#: id:14055
+msgid "Use background scanning"
+msgstr "백그라운드 검색 사용"
+
+#: id:14056
+msgid "Stop scan"
+msgstr "검색 중지"
+
+#: id:14057
+msgid "Not possible while scanning for media info"
+msgstr "미디어 정보 검색중에는 사용 불가"
+
+#: id:14058
+msgid "Film grain effect"
+msgstr "필름 입자 효과"
+
+#: id:14059
+msgid "Search for thumbnails on remote shares"
+msgstr "원격 공유에서 미리보기 찾기"
+
+#: id:14060
+msgid "Unknown type cache - Internet"
+msgstr "알수없는 형식 캐시 - 인터넷"
+
+#: id:14061
+msgctxt "Auto context with id 14061"
+msgid "Auto"
+msgstr "자동"
+
+#: id:14062
+msgid "Enter username for"
+msgstr "사용자명 입력"
+
+#: id:14063
+msgid "Date & time"
+msgstr "날짜 & 시간"
+
+#: id:14064
+msgid "Set date"
+msgstr "날짜 설정"
+
+#: id:14065
+msgid "Set time"
+msgstr "시간 설정"
+
+#: id:14066
+msgid "Enter the time in 24 hour HH:MM format"
+msgstr "24시간 HH:MM 형식으로 시간 입력"
+
+#: id:14067
+msgid "Enter the date in DD/MM/YYYY format"
+msgstr "DD/MM/YYYY 형식으로 날짜 입력"
+
+#: id:14068
+msgid "Enter the IP address"
+msgstr "IP주소 입력"
+
+#: id:14069
+msgid "Apply these settings now?"
+msgstr "설정을 지금 적용 하시겠습니까?"
+
+#: id:14070
+msgid "Apply changes now"
+msgstr "변경을 지금 적용"
+
+#: id:14071
+msgid "Allow file renaming and deletion"
+msgstr "파일 이름변경 및 삭제 허용"
+
+#: id:14074
+msgid "Set timezone"
+msgstr "시간대 설정"
+
+#: id:14075
+msgid "Use daylight saving time"
+msgstr "일광 절약 시간 사용"
+
+#: id:14076
+msgid "Add to favourites"
+msgstr "즐겨찾기에 추가"
+
+#: id:14077
+msgid "Remove from favourites"
+msgstr "즐겨찾기에서 제거"
+
+#: id:14078
+msgctxt "Auto context with id 14078"
+msgid "- Colours"
+msgstr "- 색깔"
+
+#: id:14079
+msgid "Timezone country"
+msgstr "시간대 국가"
+
+#: id:14080
+msgid "Timezone"
+msgstr "시간대"
+
+#: id:14081
+msgid "File lists"
+msgstr "파일 목록"
+
+#: id:14082
+msgid "Show EXIF picture information"
+msgstr "EXIF 사진 정보 보이기"
+
+#: id:14083
+msgid "Use a fullscreen window rather than true fullscreen"
+msgstr "트루 전체화면 대신 전체화면 윈도우 사용"
+
+#: id:14084
+msgid "Queue songs on selection"
+msgstr "선택시 노래 대기열에 추가"
+
+#: id:14086
+msgid "Playback"
+msgstr "재생"
+
+#: id:14087
+msgid "DVDs"
+msgstr "DVD"
+
+#: id:14088
+msgid "Play DVDs automatically"
+msgstr "자동으로 DVD 재생"
+
+#: id:14089
+msgid "Font to use for text subtitles"
+msgstr "텍스트 자막에 사용할 글끌"
+
+#: id:14090
+msgid "International"
+msgstr "국제"
+
+#: id:14091
+msgid "Character set"
+msgstr "문자 집합"
+
+#: id:14092
+msgid "Debugging"
+msgstr "디버깅"
+
+#: id:14093
+msgid "Security"
+msgstr "보안"
+
+#: id:14094
+msgid "Input devices"
+msgstr "입력 장치"
+
+#: id:14095
+msgid "Power saving"
+msgstr "전원 절약"
+
+#: id:14096
+msgid "Rip"
+msgstr ""
+
+#: id:14097
+msgid "Audio CD Insert Action"
+msgstr ""
+
+#: id:14098
+msgctxt "Auto context with id 14098"
+msgid "Play"
+msgstr ""
+
+#: id:14099
+msgid "Eject disc when CD ripping is complete"
+msgstr ""
+
+#: id:15015
+msgctxt "Auto context with id 15015"
+msgid "Remove"
+msgstr "제거"
+
+#: id:15016
+msgid "Games"
+msgstr "게임"
+
+#: id:15019
+msgid "Add"
+msgstr "추가"
+
+#: id:15052
+msgid "Password"
+msgstr "비밀번호"
+
+#: id:15100
+msgctxt "Auto context with id 15100"
+msgid "Library"
+msgstr "라이브러리"
+
+#: id:15101
+msgid "Database"
+msgstr "데이타베이스"
+
+#: id:15102
+msgid "* All albums"
+msgstr "* 모든 앨범"
+
+#: id:15103
+msgid "* All artists"
+msgstr "* 모든 아티스트"
+
+#: id:15104
+msgid "* All songs"
+msgstr "* 모든 노래"
+
+#: id:15105
+msgid "* All genres"
+msgstr "* 모든 장르"
+
+#: id:15107
+msgid "Buffering..."
+msgstr "버퍼링중..."
+
+#: id:15108
+msgid "Navigation sounds"
+msgstr "네비게이션 사운드"
+
+#: id:15109
+msgid "Skin default"
+msgstr "스킨 기본값"
+
+#: id:15111
+msgid "- Theme"
+msgstr "- 테마"
+
+#: id:15112
+msgid "Default theme"
+msgstr "기본 테마"
+
+#: id:15200
+msgid "Last.fm"
+msgstr "Last.fm"
+
+#: id:15201
+msgid "Submit songs to Last.fm"
+msgstr "노래를 Last.fm 에 전송"
+
+#: id:15202
+msgid "Last.fm username"
+msgstr "Last.fm 사용자명"
+
+#: id:15203
+msgid "Last.fm password"
+msgstr "Last.fm 비밀번호"
+
+#: id:15204
+msgid "Unable to handshake: sleeping..."
+msgstr "연결할수 없음: 응답없음..."
+
+#: id:15205
+msgid "Please update XBMC"
+msgstr "XBMC를 업데이트해 주세요"
+
+#: id:15206
+msgid "Bad authorization: Check username and password"
+msgstr "인증 실패: 사용자명 및 비밀번호를 확인하세요"
+
+#: id:15207
+msgctxt "Auto context with id 15207"
+msgid "Connected"
+msgstr "연결됨"
+
+#: id:15208
+msgid "Not connected"
+msgstr "연결안됨"
+
+#: id:15209
+msgid "Submit interval %i"
+msgstr "전송 간격 %i"
+
+#: id:15210
+msgid "Cached %i songs"
+msgstr "%i 곡 캐시됨"
+
+#: id:15211
+msgid "Submitting..."
+msgstr "전송중..."
+
+#: id:15212
+msgid "Submitting in %i secs"
+msgstr "%i 초 후 전송"
+
+#: id:15213
+msgid "Play using..."
+msgstr "다른 플레이어로 재생..."
+
+#: id:15214
+msgid "Use smoothed A/V synchronization"
+msgstr "부드러운 A/V 동기화 사용"
+
+#: id:15215
+msgid "Hide file names in thumbs view"
+msgstr "미리보기에서 파일 이름 숨기기"
+
+#: id:15216
+msgid "Play in party mode"
+msgstr "파티 모드로 재생"
+
+#: id:15217
+msgid "Submit songs to Libre.fm"
+msgstr "노래를 Libre.fm 에 전송"
+
+#: id:15218
+msgid "Libre.fm username"
+msgstr "Libre.fm 사용자명"
+
+#: id:15219
+msgid "Libre.fm password"
+msgstr "Libre.fm 비밀번호"
+
+#: id:15220
+msgid "Libre.fm"
+msgstr "Libre.fm"
+
+#: id:15221
+msgid "Song submission"
+msgstr "노래 전송"
+
+#: id:15250
+msgid "Submit Last.fm radio to Last.fm"
+msgstr "Last.fm 라디오를 Last.fm 에 전송"
+
+#: id:15251
+msgid "Connecting to Last.fm..."
+msgstr "Last.fm 연결중..."
+
+#: id:15252
+msgid "Selecting station..."
+msgstr "방송국 선택중..."
+
+#: id:15253
+msgid "Search similar artists..."
+msgstr "비슷한 아티스트 찾기..."
+
+#: id:15254
+msgid "Search similar tags..."
+msgstr "비슷한 태그 찾기..."
+
+#: id:15255
+msgid "Your profile (%name%)"
+msgstr "당신의 프로파일 (%name%)"
+
+#: id:15256
+msgid "Overall top tags"
+msgstr "전체 인기 태그"
+
+#: id:15257
+msgid "Top artists for tag %name%"
+msgstr "%name% 태그에 대한 인기 아티스트"
+
+#: id:15258
+msgid "Top albums for tag %name%"
+msgstr "%name% 태그에 대한 인기 앨범"
+
+#: id:15259
+msgid "Top tracks for tag %name%"
+msgstr "%name% 태그에 대한 인기 트랙"
+
+#: id:15260
+msgid "Listen to tag %name% Last.fm radio"
+msgstr "%name% 태그의 Last.fm 라디오 듣기"
+
+#: id:15261
+msgid "Similar artists as %name%"
+msgstr "%name% 와 비슷한 아티스트"
+
+#: id:15262
+msgid "Top %name% albums"
+msgstr "%name% 인기 앨범"
+
+#: id:15263
+msgid "Top %name% tracks"
+msgstr "%name% 인기 트랙"
+
+#: id:15264
+msgid "Top %name% tags"
+msgstr "%name% 인기 태그"
+
+#: id:15265
+msgid "Biggest fans of %name%"
+msgstr "%name% 의 골수팬"
+
+#: id:15266
+msgid "Listen to %name% fans Last.fm radio"
+msgstr "%name% 팬의 Last.fm 라디오 듣기"
+
+#: id:15267
+msgid "Listen to %name% similar artists Last.fm radio"
+msgstr "%name% 비슷한 아티스트의 Last.fm 라디오 듣기"
+
+#: id:15268
+msgid "Top artists for user %name%"
+msgstr "사용자 %name% 의 인기 아티스트"
+
+#: id:15269
+msgid "Top albums for user %name%"
+msgstr "사용자 %name% 의 인기 앨범"
+
+#: id:15270
+msgid "Top tracks for user %name%"
+msgstr "사용자 %name% 의 인기 트랙"
+
+#: id:15271
+msgid "Friends of user %name%"
+msgstr "사용자 %name% 의 친구들"
+
+#: id:15272
+msgid "Neighbours of user %name%"
+msgstr "사용자 %name% 의 이웃"
+
+#: id:15273
+msgid "Weekly artist chart for %name%"
+msgstr "%name% 주간 아티스트 차트"
+
+#: id:15274
+msgid "Weekly album chart for %name%"
+msgstr "%name% 주간 앨범 차트"
+
+#: id:15275
+msgid "Weekly track chart for %name%"
+msgstr "%name% 주간 트랙 차트"
+
+#: id:15276
+msgid "Listen to %name%'s neighbours Last.fm radio"
+msgstr "%name% 의 이웃 Last.fm 라디오 듣기"
+
+#: id:15277
+msgid "Listen to %name%'s personal Last.fm radio"
+msgstr "%name% 의 개인 Last.fm 라디오 듣기"
+
+#: id:15278
+msgid "Listen to %name%'s mix Last.fm radio"
+msgstr "%name% 의 모든 Last.fm 라디오 듣기"
+
+#: id:15279
+msgid "Retrieving list from Last.fm..."
+msgstr "Last.fm 에서 목록을 검색중..."
+
+#: id:15280
+msgid "Can't retrieve list from Last.fm..."
+msgstr "Last.fm 에서 목록을 검색할수 없음..."
+
+#: id:15281
+msgid "Enter an artist name to find related ones"
+msgstr "찾을 관련 아티스트 이름을 입력"
+
+#: id:15282
+msgid "Enter a tag name to find similar ones"
+msgstr "찾을 유사 태그 이름을 입력"
+
+#: id:15283
+msgid "Tracks recently listened by %name%"
+msgstr "%name% 의 최근 들은 트랙"
+
+#: id:15284
+msgid "Listen to %name%'s recommendations Last.fm radio"
+msgstr "%name 의 추천 Last.fm 라디오 듣기"
+
+#: id:15285
+msgid "Top tags for user %name%"
+msgstr "%name% 의 인기 태그"
+
+#: id:15287
+msgid "Do you want to add the current track to your loved tracks?"
+msgstr "현재 트랙을 선호 트랙에 추가 하시겠습니까?"
+
+#: id:15288
+msgid "Do you want to ban the current track?"
+msgstr "현재 트랙을 제거 하시겠습니까?"
+
+#: id:15289
+msgid "Added to your loved tracks: '%s'."
+msgstr "선호 트랙에 추가됨: '%s'."
+
+#: id:15290
+msgid "Could not add '%s' to your loved tracks."
+msgstr "'%s' 를 선호 트랙에 추가할수 없습니다."
+
+#: id:15291
+msgid "Banned: '%s'."
+msgstr "제거됨: '%s'."
+
+#: id:15292
+msgid "Could not ban '%s'."
+msgstr "'%s' 를 제거하지못함."
+
+#: id:15293
+msgid "Tracks recently loved by %name%"
+msgstr "%name% 의 최근 선호 트랙"
+
+#: id:15294
+msgid "Tracks recently banned by %name%"
+msgstr "%name% 의 최근 제거 트랙"
+
+#: id:15295
+msgid "Remove from loved tracks"
+msgstr "선호 트랙에서 제거"
+
+#: id:15296
+msgid "Un-ban"
+msgstr "제거 취소"
+
+#: id:15297
+msgid "Do you want to remove this track from your loved tracks?"
+msgstr "이 트랙을 선호 트랙에서 제거 하시겠습니까?"
+
+#: id:15298
+msgid "Do you want to un-ban this track?"
+msgstr "이 트랙의 제거를 취소 하시겠습니까?"
+
+#: id:15300
+msgid "Path not found or invalid"
+msgstr "경로를 찾지 못하거나 잘못됨"
+
+#: id:15301
+msgid "Could not connect to network server"
+msgstr "네트워크 서버에 접속할수 없습니다"
+
+#: id:15302
+msgid "No servers found"
+msgstr "서버 찾지 못함"
+
+#: id:15303
+msgid "Workgroup not found"
+msgstr "작업그룹 찾지 못함"
+
+#: id:15310
+msgid "Opening multi-path source"
+msgstr "다중경로 소스 열기"
+
+#: id:15311
+msgid "Path:"
+msgstr "경로:"
+
+#: id:16000
+msgctxt "Auto context with id 16000"
+msgid "General"
+msgstr "일반"
+
+#: id:16002
+msgid "Internet lookup"
+msgstr "인터넷 검색"
+
+#: id:16003
+msgid "Player"
+msgstr "플레이어"
+
+#: id:16004
+msgid "Play media from disc"
+msgstr "디스크로부터 미디어 재생"
+
+#: id:16008
+msgid "Enter new title"
+msgstr "새 제목 입력"
+
+#: id:16009
+msgid "Enter the movie name"
+msgstr "동영상 이름 입력"
+
+#: id:16010
+msgid "Enter the profile name"
+msgstr "프로파일 이름 입력"
+
+#: id:16011
+msgid "Enter the album name"
+msgstr "앨범 이름 입력"
+
+#: id:16012
+msgid "Enter the playlist name"
+msgstr "재생목록 이름 입력"
+
+#: id:16013
+msgid "Enter new filename"
+msgstr "새 파일 이름 입력"
+
+#: id:16014
+msgid "Enter folder name"
+msgstr "폴더 이름 입력"
+
+#: id:16015
+msgid "Enter directory"
+msgstr "디렉토리 입력"
+
+#: id:16016
+msgid "Available options: %A, %T, %N, %B, %D, %G, %Y, %F, %S"
+msgstr "사용가능 옵션: %A, %T, %N, %B, %D, %G, %Y, %F, %S"
+
+#: id:16017
+msgid "Enter search string"
+msgstr "검색어 입력"
+
+#: id:16018
+msgctxt "Auto context with id 16018"
+msgid "None"
+msgstr "사용안함"
+
+#: id:16019
+msgid "Auto select"
+msgstr "자동 선택"
+
+#: id:16020
+msgid "De-interlace"
+msgstr "디-인터레이스"
+
+#: id:16021
+msgid "Bob"
+msgstr "Bob"
+
+#: id:16022
+msgid "Bob (inverted)"
+msgstr "Bob (반전)"
+
+#: id:16024
+msgid "Canceling..."
+msgstr "취소중..."
+
+#: id:16025
+msgid "Enter the artist name"
+msgstr "아티스트 이름 입력"
+
+#: id:16026
+msgid "Playback failed"
+msgstr "재생 실패"
+
+#: id:16027
+msgid "One or more items failed to play."
+msgstr "한개 또는 이상의 아이템 재생 실패."
+
+#: id:16028
+msgid "Enter value"
+msgstr "값 입력"
+
+#: id:16029
+msgid "Check the log file for details."
+msgstr "상세정보는 로그 파일을 확인하세요."
+
+#: id:16030
+msgid "Party mode aborted."
+msgstr "파티 모드 중지됨."
+
+#: id:16031
+msgid "No matching songs in the library."
+msgstr "일치하는 노래가 라이브러리에 없습니다."
+
+#: id:16032
+msgid "Could not initialize database."
+msgstr "데이터베이스를 초기화 할수 없습니다."
+
+#: id:16033
+msgid "Could not open database."
+msgstr "데이터이스를 열수 없습니다."
+
+#: id:16034
+msgid "Could not get songs from database."
+msgstr "데이터베이스에서 노래를 가져오지 못했습니다."
+
+#: id:16035
+msgid "Party mode playlist"
+msgstr "파티 모드 재생목록"
+
+#: id:16036
+msgid "De-interlace (Half)"
+msgstr "디인터레이스 (Half)"
+
+#: id:16037
+msgid "Deinterlace video"
+msgstr "디인터레이스 비디오"
+
+#: id:16038
+msgid "Deinterlace method"
+msgstr "디인터레이스 방법"
+
+#: id:16039
+msgctxt "Auto context with id 16039"
+msgid "Off"
+msgstr "끔"
+
+#: id:16040
+msgctxt "Auto context with id 16040"
+msgid "Auto"
+msgstr "자동"
+
+#: id:16041
+msgid "On"
+msgstr "켬"
+
+#: id:16100
+msgid "All Videos"
+msgstr "모든 비디오"
+
+#: id:16101
+msgid "Unwatched"
+msgstr "미시청"
+
+#: id:16102
+msgid "Watched"
+msgstr "시청"
+
+#: id:16103
+msgid "Mark as watched"
+msgstr "시청으로 표시"
+
+#: id:16104
+msgid "Mark as unwatched"
+msgstr "미시청으로 표시"
+
+#: id:16105
+msgid "Edit title"
+msgstr "제목 수정"
+
+#: id:16200
+msgid "Operation was aborted"
+msgstr "동작 중지됨"
+
+#: id:16201
+msgid "Copy failed"
+msgstr "복사 실패"
+
+#: id:16202
+msgid "Failed to copy at least one file"
+msgstr "최소 한개의 파일 복사 실패"
+
+#: id:16203
+msgid "Move failed"
+msgstr "이동 실패"
+
+#: id:16204
+msgid "Failed to move at least one file"
+msgstr "최소 한개의 파일 이동 실패"
+
+#: id:16205
+msgid "Delete failed"
+msgstr "삭제 실패"
+
+#: id:16206
+msgid "Failed to delete at least one file"
+msgstr "최소 한개의 파일 삭제 실패"
+
+#: id:16300
+msgid "Video scaling method"
+msgstr "비디오 스케일링 방식"
+
+#: id:16301
+msgid "Nearest neighbour"
+msgstr "최근접이웃"
+
+#: id:16302
+msgid "Bilinear"
+msgstr "이중선형"
+
+#: id:16303
+msgctxt "Auto context with id 16303"
+msgid "Bicubic"
+msgstr "바이큐빅"
+
+#: id:16304
+msgid "Lanczos2"
+msgstr "랑초스2"
+
+#: id:16305
+msgid "Lanczos3"
+msgstr "랑초스3"
+
+#: id:16306
+msgid "Sinc8"
+msgstr "싱크8"
+
+#: id:16307
+msgid "Bicubic (software)"
+msgstr "바이큐빅 (소프트웨어)"
+
+#: id:16308
+msgid "Lanczos (software)"
+msgstr "랑초스 (소프트웨어)"
+
+#: id:16309
+msgid "Sinc (software)"
+msgstr "싱크 (소프트웨어)"
+
+#: id:16310
+msgid "Temporal"
+msgstr "시간적"
+
+#: id:16311
+msgid "Temporal/Spatial"
+msgstr "시간적/공간적"
+
+#: id:16312
+msgid "(VDPAU)Noise Reduction"
+msgstr "(VDPAU)잡음 제거"
+
+#: id:16313
+msgid "(VDPAU)Sharpness"
+msgstr "(VDPAU)선명도"
+
+#: id:16314
+msgid "Inverse Telecine"
+msgstr "역 텔레시네"
+
+#: id:16315
+msgid "Lanczos3 optimized"
+msgstr "랑초스3 최적화"
+
+#: id:16316
+msgctxt "Auto context with id 16316"
+msgid "Auto"
+msgstr "자동"
+
+#: id:16317
+msgid "Temporal (Half)"
+msgstr "시간적 (반)"
+
+#: id:16318
+msgid "Temporal/Spatial (Half)"
+msgstr "시간적/공간적 (반)"
+
+#: id:16319
+msgid "DXVA"
+msgstr "DXVA"
+
+#: id:16320
+msgid "DXVA Bob"
+msgstr "DXVA Bob"
+
+#: id:16321
+msgid "DXVA Best"
+msgstr "DXVA Best"
+
+#: id:16322
+msgid "Spline36"
+msgstr "Spline36"
+
+#: id:16323
+msgid "Spline36 optimized"
+msgstr "Spline36 optimized"
+
+#: id:16324
+msgid "Software Blend"
+msgstr "Software Blend"
+
+#: id:16400
+msgid "Post-processing"
+msgstr "후처리"
+
+#: id:17500
+msgid "Display sleep timeout"
+msgstr "종료 시간제한 표시"
+
+#: id:19000
+msgid "Switch to channel"
+msgstr "채널로 변경"
+
+#: id:20000
+msgid "Saved music folder"
+msgstr "저장된 음악 폴더"
+
+#: id:20001
+msgid "Use external DVD player"
+msgstr "외부 DVD 플레이어 사용"
+
+#: id:20002
+msgid "External DVD player"
+msgstr "외부 DVD 플레이어"
+
+#: id:20003
+msgid "Trainers folder"
+msgstr "트레이너 폴더"
+
+#: id:20004
+msgid "Screenshot folder"
+msgstr "스크린샷 폴더"
+
+#: id:20006
+msgid "Playlists folder"
+msgstr "재생목록 폴더"
+
+#: id:20007
+msgid "Recordings"
+msgstr "녹음"
+
+#: id:20008
+msgid "Screenshots"
+msgstr "스크린샷"
+
+#: id:20009
+msgid "Use XBMC"
+msgstr "XBMC 사용"
+
+#: id:20011
+msgid "Music playlists"
+msgstr "음악 재생목록"
+
+#: id:20012
+msgid "Video playlists"
+msgstr "비디오 재생목록"
+
+#: id:20013
+msgid "Do you wish to launch the game?"
+msgstr "이 게임을 실행 하시겠습니까?"
+
+#: id:20014
+msgid "Sort by: Playlist"
+msgstr "정렬: 재생목록"
+
+#: id:20015
+msgid "Remote thumb"
+msgstr "원격 미리보기"
+
+#: id:20016
+msgid "Current thumb"
+msgstr "현재 미리보기"
+
+#: id:20017
+msgid "Local thumb"
+msgstr "로컬 미리보기"
+
+#: id:20018
+msgid "No thumb"
+msgstr "미리보기 없음"
+
+#: id:20019
+msgid "Choose thumbnail"
+msgstr "미리보기 선택"
+
+#: id:20023
+msgid "Conflict"
+msgstr "충돌"
+
+#: id:20024
+msgid "Scan new"
+msgstr "새로 검색"
+
+#: id:20025
+msgid "Scan all"
+msgstr "전체 검색"
+
+#: id:20026
+msgid "Region"
+msgstr "지역"
+
+#: id:20037
+msgid "Summary"
+msgstr "요약"
+
+#: id:20038
+msgid "Lock music window"
+msgstr "음악 윈도우 잠금"
+
+#: id:20039
+msgid "Lock videos window"
+msgstr "비디오 윈도우 잠금"
+
+#: id:20040
+msgid "Lock pictures window"
+msgstr "사진 윈도우 잠금"
+
+#: id:20041
+msgid "Lock programs & scripts windows"
+msgstr "프로그램 & 스크립트 윈도우 잠금"
+
+#: id:20042
+msgid "Lock file manager"
+msgstr "파일 관리자 잠금"
+
+#: id:20043
+msgid "Lock settings"
+msgstr "설정 잠금"
+
+#: id:20044
+msgid "Start fresh"
+msgstr "새로 고침 시작"
+
+#: id:20045
+msgid "Enter master mode"
+msgstr "마스터 모드 들어가기"
+
+#: id:20046
+msgid "Leave master mode"
+msgstr "마스터 모드 나가기"
+
+#: id:20047
+msgid "Create profile '%s'?"
+msgstr "프로파일 '%s' 을 만드시겠습니까?"
+
+#: id:20048
+msgid "Start with fresh settings"
+msgstr "새로운 설정으로 시작"
+
+#: id:20049
+msgid "Best available"
+msgstr "사용가능 최적"
+
+#: id:20050
+msgid "Auto-switch between 16x9 and 4x3"
+msgstr "16x9 와 4x3 자동-변경"
+
+#: id:20051
+msgid "Treat stacked files as single file"
+msgstr "연결재생 파일을 단일 파일로 취급"
+
+#: id:20052
+msgid "Caution"
+msgstr "경고"
+
+#: id:20053
+msgid "Left master mode"
+msgstr "마스터 모드 나감"
+
+#: id:20054
+msgid "Entered master mode"
+msgstr "마스터 모드 들어감"
+
+#: id:20055
+msgid "Allmusic.com thumb"
+msgstr "Allmusic.com 미리보기"
+
+#: id:20057
+msgid "Remove thumbnail"
+msgstr "미리보기 제거"
+
+#: id:20058
+msgid "Add profile..."
+msgstr "프로파일 추가..."
+
+#: id:20059
+msgid "Query info for all albums"
+msgstr "모든 앨범의 정보 요청"
+
+#: id:20060
+msgctxt "Auto context with id 20060"
+msgid "Media info"
+msgstr "미디어 정보"
+
+#: id:20061
+msgctxt "Auto context with id 20061"
+msgid "Separate"
+msgstr "분리"
+
+#: id:20062
+msgid "Shares with default"
+msgstr "기본값으로 공유"
+
+#: id:20063
+msgid "Shares with default (read only)"
+msgstr "기본값으로 공유(읽기만)"
+
+#: id:20064
+msgid "Copy default"
+msgstr "기본값 복사"
+
+#: id:20065
+msgid "Profile picture"
+msgstr "프로파일 사진"
+
+#: id:20066
+msgid "Lock preferences"
+msgstr "선택 잠금"
+
+#: id:20067
+msgid "Edit profile"
+msgstr "프로파일 수정"
+
+#: id:20068
+msgid "Profile lock"
+msgstr "프로파일 잠금"
+
+#: id:20069
+msgid "Could not create folder"
+msgstr "폴더를 만들수 없음"
+
+#: id:20070
+msgid "Profile directory"
+msgstr "프로파일 디렉토리"
+
+#: id:20071
+msgid "Start with fresh media sources"
+msgstr "시작시 미디어 소스 갱신"
+
+#: id:20072
+msgid "Make sure the selected folder is writable"
+msgstr "선택된 폴더가 쓰기 가능한지와"
+
+#: id:20073
+msgid "and that the new folder name is valid"
+msgstr "새 폴더명이 정확한지 확인하세요"
+
+#: id:20074
+msgid "MPAA rating"
+msgstr "관람등급"
+
+#: id:20075
+msgid "Enter master lock code"
+msgstr "마스터 잠금 코드 입력"
+
+#: id:20076
+msgid "Ask for master lock code on startup"
+msgstr "시작때 마스터 잠금 코드 묻기"
+
+#: id:20077
+msgid "Skin settings"
+msgstr "스킨 설정"
+
+#: id:20078
+msgid "- no link set -"
+msgstr "- 연결 설정 없음 -"
+
+#: id:20079
+msgid "Enable animations"
+msgstr "애니메이션 사용"
+
+#: id:20080
+msgid "Disable RSS during music"
+msgstr "음악재생중 RSS 사용안함"
+
+#: id:20081
+msgid "Enable shortcut buttons"
+msgstr "바로가기 버튼 사용"
+
+#: id:20082
+msgid "Show programs in main menu"
+msgstr "메인메뉴에 프로그램 보이기"
+
+#: id:20083
+msgid "Show music info"
+msgstr "음악 정보 보이기"
+
+#: id:20084
+msgid "Show weather info"
+msgstr "날씨 정보 보이기"
+
+#: id:20085
+msgid "Show system info"
+msgstr "시스템 정보 보이기"
+
+#: id:20086
+msgid "Show available disc space C: E: F:"
+msgstr "C: E: F: 디스크의 남은 공간 보이기"
+
+#: id:20087
+msgid "Show available disc space E: F: G:"
+msgstr "E: F: G: 디스크의 남은 공간 보이기"
+
+#: id:20088
+msgid "Weather info"
+msgstr "날씨 정보"
+
+#: id:20089
+msgid "Drive space free"
+msgstr "드라이브 여유 공간"
+
+#: id:20090
+msgid "Enter the name of an existing share"
+msgstr "현재 공유의 이름 입력"
+
+#: id:20091
+msgid "Lock code"
+msgstr "잠금 코드"
+
+#: id:20092
+msgid "Load profile"
+msgstr "프로파일 읽기"
+
+#: id:20093
+msgid "Profile name"
+msgstr "프로파일 이름"
+
+#: id:20094
+msgctxt "Auto context with id 20094"
+msgid "Media sources"
+msgstr "미디어 소스"
+
+#: id:20095
+msgid "Enter profile lock code"
+msgstr "프로파일 잠금 코드 입력"
+
+#: id:20096
+msgctxt "Auto context with id 20096"
+msgid "Login screen"
+msgstr "로그인 화면"
+
+#: id:20097
+msgid "Fetching album info"
+msgstr "앨범 정보 가져오기"
+
+#: id:20098
+msgid "Fetching info for album"
+msgstr "앨범 정보 가져오기"
+
+#: id:20099
+msgid "Can't rip CD or track while playing from CD"
+msgstr "CD 재생중에는 CD나 트랙을 추출할수 없음"
+
+#: id:20100
+msgid "Master lock code and settings"
+msgstr "마스터 잠금 코드 및 설정"
+
+#: id:20101
+msgid "Entering master lock code always enables master mode"
+msgstr "마스터 모드 사용시 항상 마스터 잠금 코드 입력"
+
+#: id:20102
+msgid "or copy from default?"
+msgstr "또는 기본값을 복사 하시겠습니까?"
+
+#: id:20103
+msgid "Save changes to profile?"
+msgstr "프로파일에 변경사항을 저장 하시겠습니까?"
+
+#: id:20104
+msgid "Old settings found."
+msgstr "오래된 설정을 찾았습니다."
+
+#: id:20105
+msgid "Do you want to use them?"
+msgstr "이것을 사용 하시겠습니까?"
+
+#: id:20106
+msgid "Old media sources found."
+msgstr "오래된 미디어 소스 찾았습니다."
+
+#: id:20107
+msgid "Separate (locked)"
+msgstr "분리 (잠김)"
+
+#: id:20108
+msgid "Root"
+msgstr "루트"
+
+#: id:20109
+msgid "- Zoom"
+msgstr "- 축소/확대"
+
+#: id:20110
+msgid "UPnP settings"
+msgstr "UPnP 설정"
+
+#: id:20111
+msgid "Autostart UPnP client"
+msgstr "UPnP 클라이언트 자동시작"
+
+#: id:20112
+msgid "Last login: %s"
+msgstr "마지막 로그인: %s"
+
+#: id:20113
+msgid "Never logged on"
+msgstr "로그인한적 없음"
+
+#: id:20114
+msgid "Profile %i / %i"
+msgstr "프로파일 %i / %i"
+
+#: id:20115
+msgid "User login / Select a profile"
+msgstr "사용자 로그인 / 프로파일 선택"
+
+#: id:20116
+msgid "Use lock on login screen"
+msgstr "로그인 화면에서 잠금 사용"
+
+#: id:20117
+msgid "Invalid lock code."
+msgstr "잠금 코드가 잘못 되었습니다."
+
+#: id:20118
+msgid "This requires the master lock to be set."
+msgstr "마스터 잠금이 설정이 필요합니다."
+
+#: id:20119
+msgid "Would you like to set it now?"
+msgstr "지금 설정 하시겠습니까?"
+
+#: id:20120
+msgid "Loading program information"
+msgstr "프로그램 정보 읽기"
+
+#: id:20121
+msgid "Party on!"
+msgstr "파티 모드 시작!"
+
+#: id:20122
+msgid "True"
+msgstr "사실"
+
+#: id:20123
+msgid "Mixing drinks"
+msgstr "폭탄주"
+
+#: id:20124
+msgid "Filling glasses"
+msgstr "컵 채우기"
+
+#: id:20125
+msgid "Logged on as"
+msgstr "로그온됨:"
+
+#: id:20126
+msgid "Log off"
+msgstr "로그오프"
+
+#: id:20128
+msgid "Go to root"
+msgstr "루트로 가기"
+
+#: id:20129
+msgid "Weave"
+msgstr "위브"
+
+#: id:20130
+msgid "Weave (inverted)"
+msgstr "위브 (반전)"
+
+#: id:20131
+msgid "Blend"
+msgstr "혼합"
+
+#: id:20132
+msgid "Restart video"
+msgstr "비디오 재시작"
+
+#: id:20133
+msgid "Edit network location"
+msgstr "네트워크 수정"
+
+#: id:20134
+msgid "Remove network location"
+msgstr "네트워크 제거"
+
+#: id:20135
+msgid "Do you want to scan the folder?"
+msgstr "폴더를 검색 하시겠습니까?"
+
+#: id:20136
+msgid "Memory unit"
+msgstr "메모리 유닛"
+
+#: id:20137
+msgid "Memory unit mounted"
+msgstr "장착된 메모리 유닛"
+
+#: id:20138
+msgid "Unable to mount memory unit"
+msgstr "메모리 유닛을 장착할수 없음"
+
+#: id:20139
+msgid "In port %i, slot %i"
+msgstr "%i 포트, %i 슬롯"
+
+#: id:20140
+msgid "Lock screensaver"
+msgstr "화면보호기 잠금"
+
+#: id:20141
+msgid "Set"
+msgstr "설정"
+
+#: id:20142
+msgctxt "Auto context with id 20142"
+msgid "Username"
+msgstr "사용자명"
+
+#: id:20143
+msgid "Enter password for"
+msgstr "비밀번호 입력"
+
+#: id:20144
+msgid "Shutdown timer"
+msgstr "종료 타이머"
+
+#: id:20145
+msgid "Shutdown interval (in minutes)"
+msgstr "종료 시간(분)"
+
+#: id:20146
+msgid "Started, shutdown in %im"
+msgstr "시작됨, %i분 후 종료"
+
+#: id:20147
+msgid "Shutdown in 30 minutes"
+msgstr "30분후 종료"
+
+#: id:20148
+msgid "Shutdown in 60 minutes"
+msgstr "60분후 종료"
+
+#: id:20149
+msgid "Shutdown in 120 minutes"
+msgstr "120분후 종료"
+
+#: id:20150
+msgid "Custom shutdown timer"
+msgstr "사용자 지정 종료 타이머"
+
+#: id:20151
+msgid "Cancel shutdown timer"
+msgstr "종료 타이머 취소"
+
+#: id:20152
+msgid "Lock preferences for %s"
+msgstr "%s 선택 잠금"
+
+#: id:20153
+msgid "Browse..."
+msgstr "찾기..."
+
+#: id:20154
+msgid "Summary information"
+msgstr "요약 정보"
+
+#: id:20155
+msgid "Storage information"
+msgstr "저장장치 정보"
+
+#: id:20156
+msgid "Hard disk information"
+msgstr "하드디스크 정보"
+
+#: id:20157
+msgid "DVD-ROM information"
+msgstr "DVD-롬 정보"
+
+#: id:20158
+msgid "Network information"
+msgstr "네트워크 정보"
+
+#: id:20159
+msgid "Video information"
+msgstr "비디오 정보"
+
+#: id:20160
+msgid "Hardware information"
+msgstr "하드웨어 정보"
+
+#: id:20161
+msgid "Total"
+msgstr "전체"
+
+#: id:20162
+msgid "Used"
+msgstr "사용됨"
+
+#: id:20163
+msgid "of"
+msgstr "-"
+
+#: id:20164
+msgid "Locking not supported"
+msgstr "잠금이 지원안됨"
+
+#: id:20165
+msgid "Not locked"
+msgstr "잠기지 않음"
+
+#: id:20166
+msgid "Locked"
+msgstr "잠김"
+
+#: id:20167
+msgid "Frozen"
+msgstr "정지"
+
+#: id:20168
+msgid "Requires reset"
+msgstr "초기화 필요"
+
+#: id:20169
+msgid "Week"
+msgstr "주간"
+
+#: id:20170
+msgid "Line"
+msgstr "라인"
+
+#: id:20171
+msgid "Windows network (SMB)"
+msgstr "윈도우즈 네트워크(SMB)"
+
+#: id:20172
+msgid "XBMSP server"
+msgstr "XBMSP 서버"
+
+#: id:20173
+msgctxt "Auto context with id 20173"
+msgid "FTP server"
+msgstr "FTP 서버"
+
+#: id:20174
+msgid "iTunes music share (DAAP)"
+msgstr "iTunes 음악 공유(DAAP)"
+
+#: id:20175
+msgid "UPnP server"
+msgstr "UPnP 서버"
+
+#: id:20176
+msgid "Show video info"
+msgstr "비디오 정보 보이기"
+
+#: id:20177
+msgid "Done"
+msgstr "완료"
+
+#: id:20178
+msgid "Shift"
+msgstr "쉬프트"
+
+#: id:20179
+msgid "Caps Lock"
+msgstr "대문자 잠금"
+
+#: id:20180
+msgid "Symbols"
+msgstr "기호"
+
+#: id:20181
+msgid "Backspace"
+msgstr "백스페이스"
+
+#: id:20182
+msgid "Space"
+msgstr "사이띄개"
+
+#: id:20183
+msgid "Reload skin"
+msgstr "스킨 새로고침"
+
+#: id:20184
+msgid "Rotate pictures using EXIF information"
+msgstr "EXIF 정보를 이용해 사진 회전"
+
+#: id:20185
+msgid "Use poster view styles for TV shows"
+msgstr "TV 쇼에서 포스터 보기 스타일 사용"
+
+#: id:20186
+msgid "Please wait"
+msgstr "기다려 주세요"
+
+#: id:20187
+msgid "UPnP"
+msgstr ""
+
+#: id:20189
+msgid "Enable auto scrolling for plot & review"
+msgstr "줄거리 & 리뷰에 자동 스크롤 사용"
+
+#: id:20190
+msgctxt "Auto context with id 20190"
+msgid "Custom"
+msgstr "사용자 지정"
+
+#: id:20191
+msgid "Enable debug logging"
+msgstr "디버그 로그인 사용"
+
+#: id:20192
+msgid "Download additional information during updates"
+msgstr "업데이트중에 추가 정보 다운로드"
+
+#: id:20193
+msgid "Default service for album information"
+msgstr "앨범 정보을 위한 기본 서비스"
+
+#: id:20194
+msgid "Default service for artist information"
+msgstr "아티스트 정보을 위한 기본 서비스"
+
+#: id:20195
+msgid "Change scraper"
+msgstr "자료수집기 변경"
+
+#: id:20196
+msgid "Export music library"
+msgstr "음악 라이브러리 내보내기"
+
+#: id:20197
+msgid "Import music library"
+msgstr "음악 라이브러리 가져오기"
+
+#: id:20198
+msgid "No artist found!"
+msgstr "아티스트 찾지 못함!"
+
+#: id:20199
+msgid "Downloading artist info failed"
+msgstr "아티스트 정보 다운로드 실패"
+
+#: id:20250
+msgid "Party on! (videos)"
+msgstr "파티모드 시작! (비디오)"
+
+#: id:20251
+msgid "Mixing drinks (videos)"
+msgstr "폭탄주 (비디오)"
+
+#: id:20252
+msgid "Filling glasses (videos)"
+msgstr "컵 채우기 (비디오)"
+
+#: id:20253
+msgid "WebDAV server (HTTP)"
+msgstr "WebDAV 서버 (HTTP)"
+
+#: id:20254
+msgid "WebDAV server (HTTPS)"
+msgstr "WebDAV 서버 (HTTPS)"
+
+#: id:20255
+msgid "First logon, edit your profile"
+msgstr "처음 로그인, 프로파일을 수정하세요"
+
+#: id:20256
+msgid "HTS Tvheadend client"
+msgstr "HTS Tvheadend 클라이언트"
+
+#: id:20257
+msgid "VDR Streamdev client"
+msgstr "VDR Streamdev 클라이언트"
+
+#: id:20258
+msgid "MythTV client"
+msgstr "MythTV 클라이언트"
+
+#: id:20259
+msgid "Network Filesystem (NFS)"
+msgstr "네트워크 파일시스템 (NFS)"
+
+#: id:20260
+msgid "Secure Shell (SSH/SFTP)"
+msgstr "Secure Shell (SSH/SFTP)"
+
+#: id:20261
+msgid "Apple Filing Protocol (AFP)"
+msgstr "Apple Filing Protocol (AFP)"
+
+#: id:20300
+msgid "Web server directory (HTTP)"
+msgstr "웹 서버 디렉토리 (HTTP)"
+
+#: id:20301
+msgid "Web server directory (HTTPS)"
+msgstr "웹 서버 디렉토리 (HTTPS)"
+
+#: id:20302
+msgid "Unable to write to folder:"
+msgstr "폴더에 쓸수 없음:"
+
+#: id:20303
+msgid "Do you want to skip and proceed?"
+msgstr "건너뛰고 진행 하시겠습니까?"
+
+#: id:20304
+msgid "RSS Feed"
+msgstr "RSS 피드"
+
+#: id:20307
+msgid "Secondary DNS"
+msgstr "보조 DNS 서버"
+
+#: id:20308
+msgid "DHCP server:"
+msgstr "DHCP 서버:"
+
+#: id:20309
+msgid "Make new folder"
+msgstr "새 폴더 만들기"
+
+#: id:20310
+msgid "Dim LCD on playback"
+msgstr "재생때 LCD 흐리게"
+
+#: id:20311
+msgid "Unknown or onboard (protected)"
+msgstr "알수없음 또는 온보드(보호됨)"
+
+#: id:20312
+msgid "Dim LCD on paused"
+msgstr "일시중지때 LCD 흐리게"
+
+#: id:20314
+msgid "Videos - Library"
+msgstr "비디오 - 라이브러리"
+
+#: id:20316
+msgid "Sort by: ID"
+msgstr "정렬: 아이디"
+
+#: id:20324
+msgid "Play part..."
+msgstr "부분 재생..."
+
+#: id:20325
+msgid "Calibration reset"
+msgstr "조정값 초기화"
+
+#: id:20326
+msgid "This will reset the calibration values for %s"
+msgstr "기본값으로 %s 조정값를"
+
+#: id:20327
+msgid "to it's default values."
+msgstr "초기화하게 됩니다."
+
+#: id:20328
+msgid "Browse for destination"
+msgstr "대상 찾기"
+
+#: id:20329
+msgid "Movies are in separate folders that match the movie title"
+msgstr "영화 파일들이 영화 제목과 같은 개별 폴더에 저장됨"
+
+#: id:20330
+msgid "Use folder names for lookups"
+msgstr "검색에 폴더 이름 사용"
+
+#: id:20331
+msgctxt "Auto context with id 20331"
+msgid "File"
+msgstr "파일"
+
+#: id:20332
+msgid "Use file or folder names in lookups?"
+msgstr "검색에 파일이나 폴더 이름을 사용 하시겠습니까?"
+
+#: id:20333
+msgid "Set content"
+msgstr "컨텐츠 설정"
+
+#: id:20334
+msgid "Folder"
+msgstr "폴더"
+
+#: id:20335
+msgid "Look for content recursively?"
+msgstr "컨텐츠를 순환 찾기 하시겠습니까?"
+
+#: id:20336
+msgid "Unlock sources"
+msgstr "소스 잠금해제"
+
+#: id:20337
+msgid "Actor"
+msgstr "배우"
+
+#: id:20338
+msgid "Movie"
+msgstr "영화"
+
+#: id:20339
+msgid "Director"
+msgstr "감독"
+
+#: id:20340
+msgid "Do you want to remove all items within"
+msgstr "XBMC 라이브러리에서 이 경로의"
+
+#: id:20341
+msgid "this path from the XBMC library?"
+msgstr "모든 항목을 제거 하시겠습니까?"
+
+#: id:20342
+msgctxt "Auto context with id 20342"
+msgid "Movies"
+msgstr "영화"
+
+#: id:20343
+msgid "TV shows"
+msgstr "TV 쇼"
+
+#: id:20344
+msgid "This directory contains"
+msgstr "이 디렉토리에 포함"
+
+#: id:20345
+msgid "Run automated scan"
+msgstr "자동 검색 실행"
+
+#: id:20346
+msgid "Scan recursively"
+msgstr "순환 검색"
+
+#: id:20347
+msgid "as"
+msgstr "-"
+
+#: id:20348
+msgid "Directors"
+msgstr "감독"
+
+#: id:20349
+msgid "No video files found in this path!"
+msgstr "이 경로에서 비디오 파일을 찾지 못함!"
+
+#: id:20350
+msgid "votes"
+msgstr "투표"
+
+#: id:20351
+msgid "TV show information"
+msgstr "TV 쇼 정보"
+
+#: id:20352
+msgid "Episode information"
+msgstr "에피소드 정보"
+
+#: id:20353
+msgid "Loading TV show details"
+msgstr "TV 쇼 상세정보 읽기"
+
+#: id:20354
+msgid "Fetching episode guide"
+msgstr "에피소드 가이드 가져오기"
+
+#: id:20355
+msgid "Loading info for episodes in directory"
+msgstr "디렉토리의 에피소드 정보 읽기"
+
+#: id:20356
+msgid "Select TV show:"
+msgstr "TV 쇼 선택:"
+
+#: id:20357
+msgid "Enter the TV show name"
+msgstr "TV 쇼 이름 입력"
+
+#: id:20358
+msgid "Season %i"
+msgstr "시즌 %i"
+
+#: id:20359
+msgid "Episode"
+msgstr "에피소드"
+
+#: id:20360
+msgid "Episodes"
+msgstr "에피소드"
+
+#: id:20361
+msgid "Loading episode details"
+msgstr "에피소드 상세정보 읽기"
+
+#: id:20362
+msgid "Remove episode from library"
+msgstr "라이브러리에서 에피소트 제거"
+
+#: id:20363
+msgid "Remove TV show from library"
+msgstr "라이브러리에서 TV 쇼 제거"
+
+#: id:20364
+msgid "TV show"
+msgstr "TV 쇼"
+
+#: id:20365
+msgid "Episode plot"
+msgstr "에피소드 줄거리"
+
+#: id:20366
+msgid "* All seasons"
+msgstr "* 모든 시즌"
+
+#: id:20367
+msgid "Hide watched"
+msgstr "시청한것 숨기기"
+
+#: id:20368
+msgid "Prod code"
+msgstr "제품 코드"
+
+#: id:20369
+msgid "Show plot for unwatched items"
+msgstr "미시청 항목의 줄거리 보이기"
+
+#: id:20370
+msgid "* Hidden to prevent spoilers *"
+msgstr "* 스포일러 방지위해 숨김 *"
+
+#: id:20371
+msgid "Set season thumb"
+msgstr "시즌 미리보기 설정"
+
+#: id:20372
+msgid "Season image"
+msgstr "시즌 이미지"
+
+#: id:20373
+msgid "Season"
+msgstr "시즌"
+
+#: id:20374
+msgid "Downloading movie information"
+msgstr "영화 정보 다운로드"
+
+#: id:20375
+msgid "Unassign content"
+msgstr "컨텐츠 할당해제"
+
+#: id:20376
+msgid "Original title"
+msgstr "원래 제목"
+
+#: id:20377
+msgid "Refresh TV show information"
+msgstr "TV 쇼 정보 새로고침"
+
+#: id:20378
+msgid "Refresh info for all episodes?"
+msgstr "모든 에피소트 정보를 새로고치겠습니까?"
+
+#: id:20379
+msgid "Selected folder contains a single TV show"
+msgstr "선택된 폴더는 하나의 TV 쇼 포함"
+
+#: id:20380
+msgid "Exclude selected folder from scans"
+msgstr "검색 제외 폴더"
+
+#: id:20381
+msgid "Specials"
+msgstr "스페셜"
+
+#: id:20382
+msgid "Automatically grab season thumbs"
+msgstr "자동으로 시즌 미리보기 가져오기"
+
+#: id:20383
+msgid "Selected folder contains a single video"
+msgstr "선택된 폴더는 하나의 비디오 포함"
+
+#: id:20384
+msgid "Link to TV show"
+msgstr "TV 쇼 연결"
+
+#: id:20385
+msgid "Remove link to TV show"
+msgstr "TV 쇼 연결 제거"
+
+#: id:20386
+msgid "Recently added movies"
+msgstr "최근 추가된 영화"
+
+#: id:20387
+msgid "Recently added episodes"
+msgstr "최근 추가된 에피소드"
+
+#: id:20388
+msgid "Studios"
+msgstr "스튜디오"
+
+#: id:20389
+msgid "Music videos"
+msgstr "뮤직비디오"
+
+#: id:20390
+msgid "Recently added music videos"
+msgstr "최근 추가된 뮤직비디오"
+
+#: id:20391
+msgid "Music video"
+msgstr "뮤직비디오"
+
+#: id:20392
+msgid "Remove music video from library"
+msgstr "라이브러리에서 뮤직비디오 제거"
+
+#: id:20393
+msgctxt "Auto context with id 20393"
+msgid "Music video information"
+msgstr "뮤직비디오 정보"
+
+#: id:20394
+msgid "Loading music video information"
+msgstr "뮤직비디오 정보 읽기"
+
+#: id:20395
+msgid "Mixed"
+msgstr "통합"
+
+#: id:20396
+msgid "Go to albums by artist"
+msgstr "아트스트 앨범으로 가기"
+
+#: id:20397
+msgid "Go to album"
+msgstr "앨범으로 가기"
+
+#: id:20398
+msgid "Play song"
+msgstr "노래 재생"
+
+#: id:20399
+msgid "Go to music videos from album"
+msgstr "앨범에서 뮤직비디오로 가기"
+
+#: id:20400
+msgid "Go to music videos by artist"
+msgstr "아티스트의 뮤직비디오로 가기"
+
+#: id:20401
+msgid "Play music video"
+msgstr "뮤직비디오 재생"
+
+#: id:20402
+msgid "Download actor thumbnails when adding to library"
+msgstr "라이브러리에 추가할때 배우 미리보기 다운로드"
+
+#: id:20403
+msgid "Set actor thumb"
+msgstr "배우 미리보기 설정"
+
+#: id:20405
+msgid "Remove episode bookmark"
+msgstr "에피소드 북마크 제거"
+
+#: id:20406
+msgid "Set episode bookmark"
+msgstr "에피소드 북마크 설정"
+
+#: id:20407
+msgid "Scraper settings"
+msgstr "자료수집기 설정"
+
+#: id:20408
+msgid "Downloading music video information"
+msgstr "뮤직비디오 정보 다운로드"
+
+#: id:20409
+msgid "Downloading TV show information"
+msgstr "TV 쇼 정보 다운로드"
+
+#: id:20410
+msgid "Trailer"
+msgstr "예고편"
+
+#: id:20411
+msgid "Flatten"
+msgstr "병합"
+
+#: id:20412
+msgid "Flatten TV shows"
+msgstr "TV 쇼 병합"
+
+#: id:20413
+msgid "Get fanart"
+msgstr "팬아트 가져오기"
+
+#: id:20414
+msgid "Show Fanart in video and music libraries"
+msgstr "비디오 및 음악 라이브러리에 팬아트 보이기"
+
+#: id:20415
+msgid "Scanning for new content"
+msgstr "새 컨텐츠 검색"
+
+#: id:20416
+msgid "First aired"
+msgstr "초연"
+
+#: id:20417
+msgid "Writer"
+msgstr "각본"
+
+#: id:20419
+msgid "Replace file names with library titles"
+msgstr "파일명을 라이브러리 제목으로 표시"
+
+#: id:20420
+msgctxt "Auto context with id 20420"
+msgid "Never"
+msgstr "안함"
+
+#: id:20421
+msgid "If only one season"
+msgstr "한 시즌 일때만"
+
+#: id:20422
+msgid "Always"
+msgstr "항상"
+
+#: id:20423
+msgid "Has trailer"
+msgstr "예고편 있음"
+
+#: id:20424
+msgid "False"
+msgstr "없음"
+
+#: id:20425
+msgid "Fanart slideshow"
+msgstr "팬아트 슬라이드쇼"
+
+#: id:20426
+msgid "Export to a single file or separate"
+msgstr "항목당 단일 파일로 내보낼까요 분리"
+
+#: id:20427
+msgid "files per entry?"
+msgstr "파일로 내보낼까요?"
+
+#: id:20428
+msgid "Single file"
+msgstr "단일 파일"
+
+#: id:20429
+msgctxt "Auto context with id 20429"
+msgid "Separate"
+msgstr "분리 파일"
+
+#: id:20430
+msgid "Export thumbnails and fanart?"
+msgstr "미리보기 및 팬아트를 내보내시겠습니까?"
+
+#: id:20431
+msgid "Overwrite old files?"
+msgstr "기존 파일에 덮어쓰겠습니까?"
+
+#: id:20432
+msgid "Exclude path from library updates"
+msgstr "라이브러리 업데이트 제외 경로"
+
+#: id:20433
+msgid "Extract thumbnails and video information"
+msgstr "미리보기 및 비디오 정보 추출"
+
+#: id:20434
+msgid "Sets"
+msgstr "세트"
+
+#: id:20435
+msgid "Set movieset thumb"
+msgstr "영화세트 미리보기 설정"
+
+#: id:20436
+msgid "Export actor thumbs?"
+msgstr "배우 미리보기 내보내기?"
+
+#: id:20437
+msgid "Choose fanart"
+msgstr "팬아트 선택"
+
+#: id:20438
+msgid "Local fanart"
+msgstr "로컬 팬아트"
+
+#: id:20439
+msgid "No fanart"
+msgstr "팬아트 없음"
+
+#: id:20440
+msgid "Current fanart"
+msgstr "현재 팬아트"
+
+#: id:20441
+msgid "Remote fanart"
+msgstr "원격 팬아트"
+
+#: id:20442
+msgid "Change content"
+msgstr "컨텐츠 변경"
+
+#: id:20443
+msgid "Do you want to refresh info for all"
+msgstr "이 경로의 모든 항목 정보를"
+
+#: id:20444
+msgid "items within this path?"
+msgstr "새로고치겠습니까?"
+
+#: id:20445
+msgid "Fanart"
+msgstr "팬아트"
+
+#: id:20446
+msgid "Locally stored information found."
+msgstr "로컬에 저장된 정보 찾음."
+
+#: id:20447
+msgid "Ignore and refresh from internet?"
+msgstr "무시하고 인터넷에서 새로고침 할까요?"
+
+#: id:20448
+msgid "Could not download information"
+msgstr "정보를 다운로드할수 없음"
+
+#: id:20449
+msgid "Unable to connect to remote server"
+msgstr "원격 서버에 연결할수 없음"
+
+#: id:20450
+msgid "Would you like to continue scanning?"
+msgstr "검색을 계속 하시겠습니까?"
+
+#: id:20451
+msgid "Countries"
+msgstr "국가"
+
+#: id:20452
+msgid "episode"
+msgstr "에피소드"
+
+#: id:20453
+msgid "episodes"
+msgstr "에피소드"
+
+#: id:20454
+msgid "Listener"
+msgstr "청취자"
+
+#: id:20455
+msgid "Listeners"
+msgstr "청취자"
+
+#: id:20456
+msgid "Set movieset fanart"
+msgstr "시리즈 영화 팬아트 설정"
+
+#: id:20457
+msgid "Movie set"
+msgstr "시리즈 영화"
+
+#: id:20458
+msgid "Group movies in sets"
+msgstr "시리즈 영화 묶기"
+
+#: id:21330
+msgid "Show hidden files and directories"
+msgstr "숨김 파일 및 디렉토리 보이기"
+
+#: id:21331
+msgid "TuxBox client"
+msgstr "TuxBox 클라이언트"
+
+#: id:21332
+msgid "WARNING: Target TuxBox device is in recording-mode!"
+msgstr "경고: 대상 TuxBox 장치가 녹음-모드 입니다!"
+
+#: id:21333
+msgid "The stream will be stopped!"
+msgstr "스트림이 중지됩니다!"
+
+#: id:21334
+msgid "Zap to channel: %s failed!"
+msgstr "채널 완전삭제: %s 실패!"
+
+#: id:21335
+msgid "Are you sure to start the stream?"
+msgstr "스트림을 시작 하시겠습니까?"
+
+#: id:21336
+msgid "Connecting to: %s"
+msgstr "연결: %s"
+
+#: id:21337
+msgid "TuxBox device"
+msgstr "TuxBox 장치"
+
+#: id:21359
+msgid "Add media share..."
+msgstr "미디어 공유 추가..."
+
+#: id:21360
+msgid "Share video and music libraries through UPnP"
+msgstr "UPnP 를 통해 비디오 및 음악 라이브러리 공유"
+
+#: id:21364
+msgid "Edit media share"
+msgstr "미디어 공유 수정"
+
+#: id:21365
+msgid "Remove media share"
+msgstr "미디어 공유 제거"
+
+#: id:21366
+msgid "Subtitle folder"
+msgstr "자막 폴더"
+
+#: id:21367
+msgid "Movie & alternate subtitle directory"
+msgstr "영화 & 추가 자막 디렉토리"
+
+#: id:21368
+msgid "Override ASS/SSA subtitles fonts"
+msgstr "ASS/SSA 자막 글꼴 무시"
+
+#: id:21369
+msgid "Enable mouse and Touch Screen support"
+msgstr "마우스 사용"
+
+#: id:21370
+msgid "Play navigation sounds during media playback"
+msgstr "미디어 재생중 네비게이션 사운드 사용"
+
+#: id:21371
+msgid "Thumbnail"
+msgstr "미리보기"
+
+#: id:21372
+msgid "Forced DVD player region"
+msgstr "강제된 DVD 플레이어 지역"
+
+#: id:21373
+msgid "Video output"
+msgstr "비디오 출력"
+
+#: id:21374
+msgid "Video aspect"
+msgstr "비디오 비율"
+
+#: id:21375
+msgctxt "Auto context with id 21375"
+msgid "Normal"
+msgstr "보통"
+
+#: id:21376
+msgid "Letterbox"
+msgstr "레터박스"
+
+#: id:21377
+msgid "Widescreen"
+msgstr "와이드스크린"
+
+#: id:21378
+msgid "Enable 480p"
+msgstr "480p 사용"
+
+#: id:21379
+msgid "Enable 720p"
+msgstr "720p 사용"
+
+#: id:21380
+msgid "Enable 1080i"
+msgstr "1080i 사용"
+
+#: id:21381
+msgid "Enter name of new playlist"
+msgstr "새 재생목록 이름 입력"
+
+#: id:21382
+msgid "Show \"Add source\" buttons in file lists"
+msgstr "파일 목록에서 \"소스 추가\" 버튼 보이기"
+
+#: id:21383
+msgid "Enable scrollbars"
+msgstr "스크롤바 사용"
+
+#: id:21384
+msgid "Make watched filtering a toggle in video library"
+msgstr "비디오 라이브러리에서 시청 상태 토글 사용"
+
+#: id:21385
+msgctxt "Auto context with id 21385"
+msgid "Open"
+msgstr "열기"
+
+#: id:21386
+msgid "Acoustic management level"
+msgstr "음향 구성표"
+
+#: id:21387
+msgid "Fast"
+msgstr "빠르게"
+
+#: id:21388
+msgid "Quiet"
+msgstr "끄기"
+
+#: id:21389
+msgid "Enable custom background"
+msgstr "사용자 지정 배경 사용"
+
+#: id:21390
+msgid "Power management level"
+msgstr "전원 구성표"
+
+#: id:21391
+msgid "High power"
+msgstr "최대 전원"
+
+#: id:21392
+msgid "Low power"
+msgstr "최소 전원"
+
+#: id:21393
+msgid "High standby"
+msgstr "최대 대기"
+
+#: id:21394
+msgid "Low standby"
+msgstr "최소 대기"
+
+#: id:21395
+msgid "Unable to cache files bigger than 4GB"
+msgstr "4GB 이상의 파일을 캐시할수 없음"
+
+#: id:21396
+msgid "Chapter"
+msgstr "챕터"
+
+#: id:21397
+msgid "High quality pixel shader v2"
+msgstr "고화질 픽셀 셰이더 V2"
+
+#: id:21398
+msgid "Enable playlist at startup"
+msgstr "시작시 재생목록 사용"
+
+#: id:21399
+msgid "Use tween animations"
+msgstr "트윈 애니메이션 사용"
+
+#: id:21400
+msgid "contains"
+msgstr "포함"
+
+#: id:21401
+msgid "does not contain"
+msgstr "포함안됨"
+
+#: id:21402
+msgid "is"
+msgstr "은(는)"
+
+#: id:21403
+msgid "is not"
+msgstr "은(는) 아님"
+
+#: id:21404
+msgid "starts with"
+msgstr "시작"
+
+#: id:21405
+msgid "ends with"
+msgstr "종료"
+
+#: id:21406
+msgid "greater than"
+msgstr "보다 큰"
+
+#: id:21407
+msgid "less than"
+msgstr "보다 작은"
+
+#: id:21408
+msgid "after"
+msgstr "이후"
+
+#: id:21409
+msgid "before"
+msgstr "이전"
+
+#: id:21410
+msgid "in the last"
+msgstr "마지막"
+
+#: id:21411
+msgid "not in the last"
+msgstr "마지막 아님"
+
+#: id:21412
+msgid "Scrapers"
+msgstr "자료수집기"
+
+#: id:21413
+msgid "Default movie scraper"
+msgstr "기본 영화 자료수집기"
+
+#: id:21414
+msgid "Default tvshow scraper"
+msgstr "기본 TV 쇼 자료수집기"
+
+#: id:21415
+msgid "Default music video scraper"
+msgstr "기본 뮤직비디오 자료수집기"
+
+#: id:21416
+msgid "Enable fallback based on scraper language"
+msgstr "자료수집기 언어 기반의 대체 사용"
+
+#: id:21417
+msgid "- Settings"
+msgstr "- 설정"
+
+#: id:21418
+msgid "Multilingual"
+msgstr "다국어"
+
+#: id:21419
+msgid "No scrapers present"
+msgstr "자료수집기 없음"
+
+#: id:21420
+msgid "Value to match"
+msgstr "일치하는 값"
+
+#: id:21421
+msgid "Smart playlist rule"
+msgstr "지능형 재생목록 규칙"
+
+#: id:21422
+msgid "Match items where"
+msgstr "일치하는 항목"
+
+#: id:21423
+msgid "New rule..."
+msgstr "새 규칙..."
+
+#: id:21424
+msgid "Items must match"
+msgstr "항목이 일치해야함"
+
+#: id:21425
+msgid "all of the rules"
+msgstr "모든 규칙"
+
+#: id:21426
+msgid "one or more of the rules"
+msgstr "한개 또는 그이상의 규칙"
+
+#: id:21427
+msgid "Limit to"
+msgstr "제한"
+
+#: id:21428
+msgid "No limit"
+msgstr "무제한"
+
+#: id:21429
+msgid "Order by"
+msgstr "정렬"
+
+#: id:21430
+msgid "ascending"
+msgstr "올림차순"
+
+#: id:21431
+msgid "descending"
+msgstr "내림차순"
+
+#: id:21432
+msgid "Edit smart playlist"
+msgstr "지능형 재생목록 수정"
+
+#: id:21433
+msgid "Name of the playlist"
+msgstr "재생목록 이름"
+
+#: id:21434
+msgid "Find items where"
+msgstr "찾은 항목:"
+
+#: id:21435
+msgid "Edit"
+msgstr "수정"
+
+#: id:21436
+msgid "%i items"
+msgstr "%i 항목"
+
+#: id:21437
+msgid "New smart playlist..."
+msgstr "새 지능형 재생목록..."
+
+#: id:21438
+msgid "%c Drive"
+msgstr "%c 드라이브"
+
+#: id:21439
+msgid "Edit party mode rules"
+msgstr "파티 모드 규칙 수정"
+
+#: id:21440
+msgid "Home folder"
+msgstr "홈 폴더"
+
+#: id:21441
+msgid "Watched count"
+msgstr "시청 횟수"
+
+#: id:21442
+msgid "Episode title"
+msgstr "에피소트 제목"
+
+#: id:21443
+msgid "Video resolution"
+msgstr "비디오 해상도"
+
+#: id:21444
+msgid "Audio channels"
+msgstr "오디오 채널"
+
+#: id:21445
+msgid "Video codec"
+msgstr "비디오 코덱"
+
+#: id:21446
+msgid "Audio codec"
+msgstr "오디오 코덱"
+
+#: id:21447
+msgid "Audio language"
+msgstr "오디오 언어"
+
+#: id:21448
+msgid "Subtitle language"
+msgstr "자막 언어"
+
+#: id:21449
+msgid "Remote control sends keyboard presses"
+msgstr "리모콘이 키보드 누름 보냄"
+
+#: id:21450
+msgid "- Edit"
+msgstr "- 수정"
+
+#: id:21451
+msgid "Internet connection required."
+msgstr "인터넷 연결이 필요함."
+
+#: id:21452
+msgid "Get More..."
+msgstr "더 가져오기..."
+
+#: id:21453
+msgid "Root filesystem"
+msgstr "루트 파일시스템"
+
+#: id:21454
+msgid "Cache full"
+msgstr "캐시 가득참"
+
+#: id:21455
+msgid "Cache filled before reaching required amount for continous playback"
+msgstr "연속 재생에 필요한 양에 도달하기 전에 캐시가 채워짐"
+
+#: id:21460
+msgid "Subtitle location"
+msgstr "자막 위치"
+
+#: id:21461
+msgid "Fixed"
+msgstr "고정"
+
+#: id:21462
+msgid "Bottom of video"
+msgstr "동영상 하단"
+
+#: id:21463
+msgid "Below video"
+msgstr "동영상 아래"
+
+#: id:21464
+msgid "Top of video"
+msgstr "동영상 상단"
+
+#: id:21465
+msgid "Above video"
+msgstr "동영상 위"
+
+#: id:21800
+msgid "File name"
+msgstr "파일 이름"
+
+#: id:21801
+msgid "File path"
+msgstr "파일 경로"
+
+#: id:21802
+msgid "File size"
+msgstr "파일 크기"
+
+#: id:21803
+msgid "File date/time"
+msgstr "파일 날짜/시간"
+
+#: id:21804
+msgid "Slide index"
+msgstr "슬라이드 인덱스"
+
+#: id:21805
+msgctxt "Auto context with id 21805"
+msgid "Resolution"
+msgstr "해상도"
+
+#: id:21806
+msgctxt "Auto context with id 21806"
+msgid "Comment"
+msgstr "설명"
+
+#: id:21807
+msgid "Colour/B&W"
+msgstr "컬러/흑백"
+
+#: id:21808
+msgid "JPEG process"
+msgstr "JPEG 처리"
+
+#: id:21820
+msgid "Date/Time"
+msgstr "날짜/시간"
+
+#: id:21821
+msgid "Description"
+msgstr "설명"
+
+#: id:21822
+msgid "Camera make"
+msgstr "카메라 제조사"
+
+#: id:21823
+msgid "Camera model"
+msgstr "카메라 모델"
+
+#: id:21824
+msgid "EXIF comment"
+msgstr "EXIF 주석"
+
+#: id:21825
+msgid "Firmware"
+msgstr "펌웨어"
+
+#: id:21826
+msgid "Aperture"
+msgstr "구경"
+
+#: id:21827
+msgid "Focal length"
+msgstr "초점 거리"
+
+#: id:21828
+msgid "Focus distance"
+msgstr "피사체 거리"
+
+#: id:21829
+msgid "Exposure"
+msgstr "노출"
+
+#: id:21830
+msgid "Exposure time"
+msgstr "노출 시간"
+
+#: id:21831
+msgid "Exposure bias"
+msgstr "노출 바이어스"
+
+#: id:21832
+msgid "Exposure mode"
+msgstr "노출 모드"
+
+#: id:21833
+msgid "Flash used"
+msgstr "플래시 사용"
+
+#: id:21834
+msgid "White-balance"
+msgstr "화이트-밸런스"
+
+#: id:21835
+msgid "Light source"
+msgstr "광원"
+
+#: id:21836
+msgid "Metering mode"
+msgstr "측광 모드"
+
+#: id:21837
+msgid "ISO"
+msgstr "ISO"
+
+#: id:21838
+msgid "Digital zoom"
+msgstr "디지털 축소/확대"
+
+#: id:21839
+msgid "CCD width"
+msgstr "CCD 크기"
+
+#: id:21840
+msgid "GPS latitude"
+msgstr "GPS 위도"
+
+#: id:21841
+msgid "GPS longitude"
+msgstr "GPS 경도"
+
+#: id:21842
+msgid "GPS altitude"
+msgstr "GPS 고도"
+
+#: id:21843
+msgid "Orientation"
+msgstr "방향"
+
+#: id:21860
+msgid "Supplemental categories"
+msgstr "추가 카테고리"
+
+#: id:21861
+msgid "Keywords"
+msgstr "키워드"
+
+#: id:21862
+msgid "Caption"
+msgstr "제목"
+
+#: id:21863
+msgid "Author"
+msgstr "저자"
+
+#: id:21864
+msgid "Headline"
+msgstr "헤드라인"
+
+#: id:21865
+msgid "Special instructions"
+msgstr "특별 지시"
+
+#: id:21866
+msgid "Category"
+msgstr "카테고리"
+
+#: id:21867
+msgid "Byline"
+msgstr "첫머리"
+
+#: id:21868
+msgid "Byline title"
+msgstr "첫머리 제목"
+
+#: id:21869
+msgid "Credit"
+msgstr "만든 사람들"
+
+#: id:21870
+msgid "Source"
+msgstr "소스"
+
+#: id:21871
+msgid "Copyright notice"
+msgstr "저작권 공고"
+
+#: id:21872
+msgid "Object name"
+msgstr "객체 이름"
+
+#: id:21873
+msgid "City"
+msgstr "도시"
+
+#: id:21874
+msgid "State"
+msgstr "국가"
+
+#: id:21875
+msgctxt "Auto context with id 21875"
+msgid "Country"
+msgstr "국가"
+
+#: id:21876
+msgid "Original Tx Reference"
+msgstr "Original Tx Reference"
+
+#: id:21877
+msgid "Date created"
+msgstr "제작일"
+
+#: id:21878
+msgid "Copyright flag"
+msgstr "저작권 표기"
+
+#: id:21879
+msgid "Country code"
+msgstr "국가 코드"
+
+#: id:21880
+msgid "Reference service"
+msgstr "참고 업무"
+
+#: id:21881
+msgid "Allow control of XBMC via UPnP"
+msgstr "UPnP 를 통해 XBMC 제어 허용"
+
+#: id:21882
+msgid "Attempt to skip introduction before DVD menu"
+msgstr "DVD 메뉴 전의 도입부 건너뛰기 시도"
+
+#: id:21883
+msgid "Saved music"
+msgstr "저장된 음악"
+
+#: id:21884
+msgid "Query info for all artists"
+msgstr "모든 아티스트 정보 요청"
+
+#: id:21885
+msgid "Downloading album information"
+msgstr "앨범 정보 다운로드"
+
+#: id:21886
+msgid "Downloading artist information"
+msgstr "아티스트 정보 다운로드"
+
+#: id:21887
+msgid "Biography"
+msgstr "약력"
+
+#: id:21888
+msgid "Discography"
+msgstr "목차"
+
+#: id:21889
+msgid "Searching artist"
+msgstr "아티스트 찾기"
+
+#: id:21890
+msgid "Select artist"
+msgstr "아티스트 선택"
+
+#: id:21891
+msgctxt "Auto context with id 21891"
+msgid "Artist information"
+msgstr "아티스트 정보"
+
+#: id:21892
+msgid "Instruments"
+msgstr "악기"
+
+#: id:21893
+msgid "Born"
+msgstr "출생"
+
+#: id:21894
+msgid "Formed"
+msgstr "결성"
+
+#: id:21895
+msgid "Themes"
+msgstr "테마"
+
+#: id:21896
+msgid "Disbanded"
+msgstr "해체"
+
+#: id:21897
+msgid "Died"
+msgstr "사망"
+
+#: id:21898
+msgid "Years active"
+msgstr "활동기간"
+
+#: id:21899
+msgid "Label"
+msgstr "라벨"
+
+#: id:21900
+msgid "Born/Formed"
+msgstr "출생/결성"
+
+#: id:22000
+msgid "Update library on startup"
+msgstr "시작때 라이브러리 업데이트"
+
+#: id:22001
+msgid "Hide progress of library updates"
+msgstr "라이브러리 업데이트 진행 숨기기"
+
+#: id:22002
+msgid "- DNS suffix"
+msgstr "- DNS 접미사"
+
+#: id:22003
+msgid "%2.3fs"
+msgstr "%2.3f초"
+
+#: id:22004
+msgid "Delayed by: %2.3fs"
+msgstr "%2.3f초 느리게"
+
+#: id:22005
+msgid "Ahead by: %2.3fs"
+msgstr "%2.3f초 빠르게"
+
+#: id:22006
+msgid "Subtitle offset"
+msgstr "자막 오프셋"
+
+#: id:22007
+msgid "OpenGL vendor:"
+msgstr "오픈GL 공급자:"
+
+#: id:22008
+msgid "OpenGL renderer:"
+msgstr "오픈GL 렌더러:"
+
+#: id:22009
+msgid "OpenGL version:"
+msgstr "오픈GL 버전:"
+
+#: id:22010
+msgid "GPU temperature:"
+msgstr "GPU 온도:"
+
+#: id:22011
+msgid "CPU temperature:"
+msgstr "CPU 온도:"
+
+#: id:22012
+msgid "Total memory"
+msgstr "전체 메모리"
+
+#: id:22013
+msgid "Profile data"
+msgstr "프로파일 데이터"
+
+#: id:22014
+msgid "Use dim if paused during video playback"
+msgstr "비디오 재생중 일시중지되면 흐림 사용"
+
+#: id:22015
+msgid "All recordings"
+msgstr "모든 녹음"
+
+#: id:22016
+msgid "By title"
+msgstr "제목별"
+
+#: id:22017
+msgid "By group"
+msgstr "그룹별"
+
+#: id:22018
+msgid "Live channels"
+msgstr "라이브 채널"
+
+#: id:22019
+msgid "Recordings by title"
+msgstr "제목별 녹음"
+
+#: id:22020
+msgid "Guide"
+msgstr "가이드"
+
+#: id:22021
+msgid "Allowed error in aspect ratio to minimize black bars"
+msgstr "검은 여백 최소화시 가로세로 비 허용 오류"
+
+#: id:22022
+msgid "Show video files in listings"
+msgstr "목록에 비디오 파일 보이기"
+
+#: id:22023
+msgid "DirectX vendor:"
+msgstr "DirectX 공급자:"
+
+#: id:22024
+msgid "Direct3D version:"
+msgstr "Direct3D 버전:"
+
+#: id:22030
+msgctxt "Auto context with id 22030"
+msgid "Font"
+msgstr "글꼴"
+
+#: id:22031
+msgctxt "Auto context with id 22031"
+msgid "- Size"
+msgstr "- 크기"
+
+#: id:22032
+msgctxt "Auto context with id 22032"
+msgid "- Colours"
+msgstr "- 색깔"
+
+#: id:22033
+msgid "- Charset"
+msgstr "- 문자집합"
+
+#: id:22034
+msgid "Export karaoke titles as HTML"
+msgstr "노래방 제목 HTML 로 내보내기"
+
+#: id:22035
+msgid "Export karaoke titles as CSV"
+msgstr "노래방 제목 CSV 로 내보내기"
+
+#: id:22036
+msgid "Import karaoke titles..."
+msgstr "노래방 제목 가져오기..."
+
+#: id:22037
+msgid "Show song selector automatically"
+msgstr "자동으로 노래 선택기 보이기"
+
+#: id:22038
+msgid "Export karaoke titles..."
+msgstr "노래방 제목 내보내기..."
+
+#: id:22039
+msgid "Enter song number"
+msgstr "노래 번호 입력"
+
+#: id:22040
+msgid "white/green"
+msgstr "하양/녹색"
+
+#: id:22041
+msgid "white/red"
+msgstr "하양/빨강"
+
+#: id:22042
+msgid "white/blue"
+msgstr "하양/파랑"
+
+#: id:22043
+msgid "black/white"
+msgstr "검정/하양"
+
+#: id:22079
+msgid "Default select action"
+msgstr "기본 선택 동작"
+
+#: id:22080
+msgid "Choose"
+msgstr "선택"
+
+#: id:22081
+msgid "Show Information"
+msgstr "정보 보이기"
+
+#: id:22082
+msgid "More..."
+msgstr "더 보기..."
+
+#: id:22083
+msgid "Play all"
+msgstr "모두 재생"
+
+#: id:23049
+msgid "Teletext not available"
+msgstr "문자다중방송 사용할수 없음"
+
+#: id:23050
+msgid "Activate Teletext"
+msgstr "문자다중방송 활성화"
+
+#: id:23051
+msgid "Part %i"
+msgstr "파트 %i"
+
+#: id:23052
+msgid "Buffering %i bytes"
+msgstr "%i 바이트 버퍼링"
+
+#: id:23053
+msgid "Stopping"
+msgstr "중지중"
+
+#: id:23054
+msgid "Running"
+msgstr "실행중"
+
+#: id:23100
+msgid "External Player Active"
+msgstr "외장 플레이어 활성"
+
+#: id:23101
+msgid "Click OK to terminate the player"
+msgstr "플레이어를 종료하려면 예를 누르세요"
+
+#: id:23104
+msgid "Click OK when playback has ended"
+msgstr "재생이 끝났으면 예를 누르세요"
+
+#: id:24000
+msgid "Add-on"
+msgstr "추가기능"
+
+#: id:24001
+msgid "Add-ons"
+msgstr "추가기능"
+
+#: id:24002
+msgid "Add-on options"
+msgstr "추가기능 옵션"
+
+#: id:24003
+msgid "Add-on Information"
+msgstr "추가기능 정보"
+
+#: id:24005
+msgctxt "Auto context with id 24005"
+msgid "Media sources"
+msgstr "미디어 소스"
+
+#: id:24007
+msgctxt "Auto context with id 24007"
+msgid "Movie information"
+msgstr "영화 정보"
+
+#: id:24008
+msgctxt "Auto context with id 24008"
+msgid "Screensaver"
+msgstr "화면보호기"
+
+#: id:24009
+msgid "Script"
+msgstr "스크립트"
+
+#: id:24010
+msgctxt "Auto context with id 24010"
+msgid "Visualization"
+msgstr "시각화"
+
+#: id:24011
+msgid "Add-on repository"
+msgstr "추가기능 저장소"
+
+#: id:24012
+msgctxt "Auto context with id 24012"
+msgid "Subtitles"
+msgstr "자막"
+
+#: id:24013
+msgid "Lyrics"
+msgstr "가사"
+
+#: id:24014
+msgid "TV information"
+msgstr "TV 정보"
+
+#: id:24015
+msgctxt "Auto context with id 24015"
+msgid "Music video information"
+msgstr "뮤직비디오 정보"
+
+#: id:24016
+msgctxt "Auto context with id 24016"
+msgid "Album information"
+msgstr "앨범 정보"
+
+#: id:24017
+msgctxt "Auto context with id 24017"
+msgid "Artist information"
+msgstr "아티스트 정보"
+
+#: id:24018
+msgctxt "Auto context with id 24018"
+msgid "Services"
+msgstr "서비스"
+
+#: id:24020
+msgid "Configure"
+msgstr "설정"
+
+#: id:24021
+msgctxt "Auto context with id 24021"
+msgid "Disable"
+msgstr "사용안함"
+
+#: id:24022
+msgid "Enable"
+msgstr "사용함"
+
+#: id:24023
+msgid "Add-on disabled"
+msgstr "추가기능 중지됨"
+
+#: id:24027
+msgctxt "Auto context with id 24027"
+msgid "Weather"
+msgstr "날씨"
+
+#: id:24028
+msgid "Weather.com (standard)"
+msgstr "Weather.com (표준)"
+
+#: id:24030
+msgid "This Add-on can not be configured"
+msgstr "이 추가기능은 설정할수 없음"
+
+#: id:24031
+msgid "Error loading settings"
+msgstr "설정 읽기 오류"
+
+#: id:24032
+msgid "All Add-ons"
+msgstr "모든 추가기능"
+
+#: id:24033
+msgid "Get Add-ons"
+msgstr "추가기능 가져오기"
+
+#: id:24034
+msgid "Check for updates"
+msgstr "업데이트 확인"
+
+#: id:24035
+msgid "Force refresh"
+msgstr "강제 새로고침"
+
+#: id:24036
+msgid "Change log"
+msgstr "변경 로그"
+
+#: id:24037
+msgid "Uninstall"
+msgstr "제거"
+
+#: id:24038
+msgid "Install"
+msgstr "설치"
+
+#: id:24039
+msgid "Disabled Add-ons"
+msgstr "사용되지않는 추가기능"
+
+#: id:24040
+msgid "(Clear the current setting)"
+msgstr "(현재 설정 지우기)"
+
+#: id:24041
+msgid "Install from zip file"
+msgstr "압축 파일에서 설치"
+
+#: id:24042
+msgid "Downloading %i%%"
+msgstr "%i%% 다운로드중"
+
+#: id:24043
+msgid "Available Updates"
+msgstr "사용가능한 업데이트"
+
+#: id:24044
+msgid "Dependencies not met"
+msgstr "설치 요구조건을 충족하지 않습니다"
+
+#: id:24045
+msgid "Add-on does not have the correct structure"
+msgstr "애드온의 구조가 바르지 않습니다"
+
+#: id:24046
+msgid "%s is used by the following installed add-on(s)"
+msgstr "%s 을 설치된 애드온이 사용합니다."
+
+#: id:24047
+msgid "This add-on cannot be uninstalled"
+msgstr "이 추가기능은 제거할 수 없습니다"
+
+#: id:24048
+msgid "Rollback"
+msgstr "되돌리기"
+
+#: id:24050
+msgid "Available Add-ons"
+msgstr "사용가능한 추가기능"
+
+#: id:24051
+msgid "Version:"
+msgstr "버전:"
+
+#: id:24052
+msgid "Disclaimer"
+msgstr "권리포기"
+
+#: id:24053
+msgid "License:"
+msgstr "라이센스:"
+
+#: id:24054
+msgid "Changelog"
+msgstr "변경로그"
+
+#: id:24059
+msgid "Would you like to enable this Add-on?"
+msgstr "이 추가기능을 사용함으로 하시겠습니까?"
+
+#: id:24060
+msgid "Would you like to disable this Add-on?"
+msgstr "이 추가기능을 사용안함으로 하시겠습니까?"
+
+#: id:24061
+msgid "Add-on update available!"
+msgstr "추가기능 업데이트 사용가능!"
+
+#: id:24062
+msgid "Enabled Add-ons"
+msgstr "사용하는 추가기능"
+
+#: id:24063
+msgid "Auto update"
+msgstr "자동 업데이트"
+
+#: id:24064
+msgid "Add-on enabled"
+msgstr "추가기능 사용됨"
+
+#: id:24065
+msgid "Add-on updated"
+msgstr "추가기능 업데이트됨"
+
+#: id:24066
+msgid "Cancel Add-on download?"
+msgstr "추가기능 다운로드 취소?"
+
+#: id:24067
+msgid "Currently downloading Add-ons"
+msgstr "현재 추가기능 다운로드중"
+
+#: id:24068
+msgid "Update available"
+msgstr "업데이트 사용가능"
+
+#: id:24069
+msgid "Update"
+msgstr "업데이트"
+
+#: id:24070
+msgid "Add-on could not be loaded."
+msgstr "추가기능을 읽을수 없음."
+
+#: id:24071
+msgid "An unknown error has occurred."
+msgstr "알수없는 오류 발생함."
+
+#: id:24072
+msgid "Settings required"
+msgstr "설정이 필요함"
+
+#: id:24073
+msgid "Could not connect"
+msgstr "연결할수 없음"
+
+#: id:24074
+msgid "Needs to restart"
+msgstr "재시작 필요함"
+
+#: id:24075
+msgctxt "Auto context with id 24075"
+msgid "Disable"
+msgstr "사용안함"
+
+#: id:24076
+msgid "Add-on Required"
+msgstr "추가기능 필요함"
+
+#: id:24080
+msgid "Try to reconnect?"
+msgstr "재연결 하시겠습니까?"
+
+#: id:24089
+msgid "Add-on restarts"
+msgstr "추가기능 재시작"
+
+#: id:24090
+msgid "Lock Add-on manager"
+msgstr "추가기능 관리자 잠금"
+
+#: id:24094
+msgid "(current)"
+msgstr "(현재)"
+
+#: id:24095
+msgid "(blacklisted)"
+msgstr "(차단됨)"
+
+#: id:24096
+msgid "Add-on has been marked as broken in repository."
+msgstr "추가기능이 저장소에 깨진것으로 표시되어 있습니다."
+
+#: id:24097
+msgid "Would you like to disable it on your system?"
+msgstr "시스템에서 사용안함으로 하시겠습니까?"
+
+#: id:24098
+msgid "Broken"
+msgstr "깨짐"
+
+#: id:24099
+msgid "Would you like to switch to this skin?"
+msgstr "이 스킨으로 변경 하시겠습니까?"
+
+#: id:24100
+msgid "To use this feature you must download an Add-on:"
+msgstr "이 기능을 사용하려면 추가기능을 다운로드해야 합니다:"
+
+#: id:24101
+msgid "Would you like to download this Add-on?"
+msgstr "이 추가기능을 다운로드하겠습니까?"
+
+#: id:25000
+msgid "Notifications"
+msgstr "알림"
+
+#: id:29800
+msgid "Library Mode"
+msgstr "라이브러리 모드"
+
+#: id:29801
+msgid "QWERTY keyboard"
+msgstr "쿼티 키보드"
+
+#: id:29802
+msgid "Passthrough Audio in use"
+msgstr "패스스루 오디오 사용중"
+
+#: id:33001
+msgid "Trailer quality"
+msgstr "예고편 품질"
+
+#: id:33002
+msgid "Stream"
+msgstr "스트림"
+
+#: id:33003
+msgid "Download"
+msgstr "다운로드"
+
+#: id:33004
+msgid "Download & play"
+msgstr "다운로드 & 재생"
+
+#: id:33005
+msgid "Download & save"
+msgstr "다운로드 & 저장"
+
+#: id:33006
+msgid "Today"
+msgstr "오늘"
+
+#: id:33007
+msgid "Tomorrow"
+msgstr "내일"
+
+#: id:33008
+msgid "Saving"
+msgstr "저장"
+
+#: id:33009
+msgid "Copying"
+msgstr "복사"
+
+#: id:33010
+msgid "Set download directory"
+msgstr "다운로드 디렉토리 설정"
+
+#: id:33011
+msgid "Search duration"
+msgstr "검색 기간"
+
+#: id:33012
+msgid "Short"
+msgstr "짧은"
+
+#: id:33013
+msgid "Long"
+msgstr "긴"
+
+#: id:33014
+msgid "Use DVD player instead of regular player"
+msgstr "일반 플레이어 대신 DVD 플레이어 사용"
+
+#: id:33015
+msgid "Ask for download before playing video"
+msgstr "비디오 재생전에 다운로드 묻기"
+
+#: id:33016
+msgid "Clips"
+msgstr "클립"
+
+#: id:33017
+msgid "Restart plugin to enable"
+msgstr "사용하기위해 플러그인 재시작"
+
+#: id:33018
+msgid "Tonight"
+msgstr "오늘밤"
+
+#: id:33019
+msgid "Tomorrow Night"
+msgstr "내일밤"
+
+#: id:33020
+msgid "Condition"
+msgstr "상태"
+
+#: id:33021
+msgid "Precipitation"
+msgstr "강수"
+
+#: id:33022
+msgid "Precip"
+msgstr "강수"
+
+#: id:33023
+msgid "Humid"
+msgstr "습도"
+
+#: id:33024
+msgid "Feels"
+msgstr "체감"
+
+#: id:33025
+msgid "Observed"
+msgstr "관측됨"
+
+#: id:33026
+msgid "Departure from normal"
+msgstr "편차"
+
+#: id:33027
+msgid "Sunrise"
+msgstr "해돋이"
+
+#: id:33028
+msgid "Sunset"
+msgstr "해넘이"
+
+#: id:33029
+msgid "Details"
+msgstr "상세"
+
+#: id:33030
+msgid "Outlook"
+msgstr "아웃룩"
+
+#: id:33031
+msgid "Coverflow"
+msgstr "커버플로우"
+
+#: id:33032
+msgid "Translate text"
+msgstr "문자 번역"
+
+#: id:33033
+msgid "Map list %s category"
+msgstr "%s 카테고리 지도 목록"
+
+#: id:33034
+msgid "36 Hour"
+msgstr "36 시간"
+
+#: id:33035
+msgid "Maps"
+msgstr "지도"
+
+#: id:33036
+msgid "Hourly"
+msgstr "매시"
+
+#: id:33037
+msgid "Weekend"
+msgstr "주말"
+
+#: id:33038
+msgid "%s day"
+msgstr "%s 일"
+
+#: id:33049
+msgid "Alert"
+msgstr "알림"
+
+#: id:33050
+msgid "Alerts"
+msgstr "알림"
+
+#: id:33051
+msgid "Choose Your"
+msgstr "선택하기"
+
+#: id:33052
+msgid "Check"
+msgstr "확인"
+
+#: id:33053
+msgctxt "Auto context with id 33053"
+msgid "Configure the"
+msgstr "설정하기"
+
+#: id:33054
+msgid "Seasons"
+msgstr "시즌"
+
+#: id:33055
+msgid "Use your"
+msgstr "사용하기"
+
+#: id:33056
+msgid "Watch your"
+msgstr "시청하기"
+
+#: id:33057
+msgid "Listen to"
+msgstr "들어보기"
+
+#: id:33058
+msgid "View your"
+msgstr "살펴보기"
+
+#: id:33059
+msgctxt "Auto context with id 33059"
+msgid "Configure the"
+msgstr "설정하기"
+
+#: id:33060
+msgid "Power"
+msgstr "전원"
+
+#: id:33061
+msgid "Menu"
+msgstr "메뉴"
+
+#: id:33062
+msgid "Play the"
+msgstr "재생하기"
+
+#: id:33063
+msgid "Options"
+msgstr "옵션"
+
+#: id:33065
+msgid "Editor"
+msgstr "편집기"
+
+#: id:33066
+msgid "About your"
+msgstr "정보보기"
+
+#: id:33067
+msgid "Star rating"
+msgstr "별평점"
+
+#: id:33068
+msgid "Background"
+msgstr "배경"
+
+#: id:33069
+msgid "Backgrounds"
+msgstr "배경"
+
+#: id:33070
+msgid "Custom background"
+msgstr "사용자 지정 배경"
+
+#: id:33071
+msgid "Custom backgrounds"
+msgstr "사용자 지정 배경"
+
+#: id:33072
+msgid "View Readme"
+msgstr "읽어보기 보기"
+
+#: id:33073
+msgid "View Changelog"
+msgstr "변경로그 보기"
+
+#: id:33074
+msgid "This version of %s requires an"
+msgstr "이 버전의 %s 는 실행하려면"
+
+#: id:33075
+msgid "XBMC revision of %s or greater to run."
+msgstr "XBMC 리비전 %s 또는 이상이 필요합니다"
+
+#: id:33076
+msgid "Please update XBMC."
+msgstr "XBMC 를 업데이트 하세요."
+
+#: id:33077
+msgid "No data found!"
+msgstr "데이터를 찾을수 없음!"
+
+#: id:33078
+msgid "Next page"
+msgstr "다음 페이지"
+
+#: id:33079
+msgid "Love"
+msgstr "좋아함"
+
+#: id:33080
+msgid "Hate"
+msgstr "싫어함"
+
+#: id:33081
+msgid "This file is stacked, select the part you want to play from."
+msgstr "이 파일은 연결되었습니다, 재생하고 싶은 부분을 선택하세요."
+
+#: id:33082
+msgid "Path to script"
+msgstr "스크립트 경로"
+
+#: id:33083
+msgid "Enable custom script button"
+msgstr "사용자 스크립트 버튼 사용"
+
+#: id:33100
+msgid "Failed to start"
+msgstr "시작할 수 없음"
+
+#: id:33101
+msgid "Webserver"
+msgstr "웹서버"
+
+#: id:33102
+msgid "Event Server"
+msgstr "이벤트 서버"
+
+#: id:33103
+msgid "Remote communication server"
+msgstr "원격 커뮤니케이션 서버"
+
+#: id:33200
+msgid "Detected New Connection"
+msgstr "새 연결 검색됨"
+
+#: id:34000
+msgid "Lame"
+msgstr "Lame"
+
+#: id:34001
+msgid "Vorbis"
+msgstr "Vorbis"
+
+#: id:34002
+msgid "Wav"
+msgstr "Wav"
+
+#: id:34003
+msgid "DXVA2"
+msgstr "DXVA2"
+
+#: id:34004
+msgid "VAAPI"
+msgstr "VAAPI"
+
+#: id:34005
+msgid "Flac"
+msgstr "Flac"
+
+#: id:34100
+msgid "Speaker Configuration"
+msgstr "스피커 설정"
+
+#: id:34101
+msgid "2.0"
+msgstr "2.0"
+
+#: id:34102
+msgid "2.1"
+msgstr "2.1"
+
+#: id:34103
+msgid "3.0"
+msgstr "3.0"
+
+#: id:34104
+msgid "3.1"
+msgstr "3.1"
+
+#: id:34105
+msgid "4.0"
+msgstr "4.0"
+
+#: id:34106
+msgid "4.1"
+msgstr "4.1"
+
+#: id:34107
+msgid "5.0"
+msgstr "5.0"
+
+#: id:34108
+msgid "5.1"
+msgstr "5.1"
+
+#: id:34109
+msgid "7.0"
+msgstr "7.0"
+
+#: id:34110
+msgid "7.1"
+msgstr "7.1"
+
+#: id:34201
+msgid "Can't find a next item to play"
+msgstr "재생할 다음 항목이 없습니다"
+
+#: id:34202
+msgid "Can't find a previous item to play"
+msgstr "재생할 이전 항목이 없습니다"
+
+#: id:34300
+msgid "Failed to start zeroconf"
+msgstr "제로컨프 시작 실패"
+
+#: id:34301
+msgid "Is Apple's Bonjour Service installed? See log for more info."
+msgstr "애플 봉주르 서비스가 설치되어 있습니까? 자세한 정보는 로그를 확인하세요."
+
+#: id:34400
+msgid "Video Rendering"
+msgstr "비디오 렌더링"
+
+#: id:34401
+msgid "Failed to init video filters/scalers, falling back to bilinear scaling"
+msgstr "비디오 필터/스케일러 초기화 실패. 이중선형 스케일링으로 변경합니다"
+
+#: id:34402
+msgid "Failed to initialize audio device"
+msgstr "오디오 장치 초기화 실패"
+
+#: id:34403
+msgid "Check your audiosettings"
+msgstr "오디오 설정을 확인하세요"
+
+#: id:34404
+msgid "Use gestures for navigation:"
+msgstr ""
+
+#: id:34405
+msgid "1 finger swipe left,right,up,down for cursors"
+msgstr ""
+
+#: id:34406
+msgid "2 finger swipe left for backspace"
+msgstr ""
+
+#: id:34407
+msgid "1 finger single tap for enter"
+msgstr ""
+
+#: id:34408
+msgid "2 finger single tap for contextmenu"
+msgstr ""
+
+#: id:35000
+msgid "Peripherals"
+msgstr "주변장치"
+
+#: id:35001
+msgid "Generic HID device"
+msgstr "Generic HID 장치"
+
+#: id:35002
+msgid "Generic network adapter"
+msgstr "Generic 네트워크 어댑터"
+
+#: id:35003
+msgid "Generic disk"
+msgstr "Generic 디스크"
+
+#: id:35004
+msgid "There are no settings available\nfor this peripheral."
+msgstr "이 장치에 대한 설정이 없습니다."
+
+#: id:35005
+msgid "New device configured"
+msgstr "새 장치 설정됨"
+
+#: id:35006
+msgid "Device removed"
+msgstr "장치 제거됨"
+
+#: id:35007
+msgid "Keymap to use for this device"
+msgstr "이 장치에 사용할 키맵"
+
+#: id:35008
+msgid "Keymap enabled"
+msgstr "키맵 활성화"
+
+#: id:35009
+msgid "Do not use the custom keymap for this device"
+msgstr ""
+
+#: id:35500
+msgid "Location"
+msgstr "위치"
+
+#: id:35501
+msgid "Class"
+msgstr "클래스"
+
+#: id:35502
+msgctxt "Auto context with id 35502"
+msgid "Name"
+msgstr "이름"
+
+#: id:35503
+msgid "Vendor"
+msgstr "제조업체"
+
+#: id:35504
+msgid "Product ID"
+msgstr "하드웨어 ID"
+
+#: id:36000
+msgid "Pulse-Eight CEC adapter"
+msgstr "Pulse-Eight CEC 어댑터"
+
+#: id:36001
+msgid "Pulse-Eight Nyxboard"
+msgstr "Pulse-Eight Nyxboard"
+
+#: id:36002
+msgid "Switch to keyboard side command"
+msgstr "키보드 사이드 명령으로 전환"
+
+#: id:36003
+msgid "Switch to remote side command"
+msgstr "리모콘 사이드 명령으로 전환"
+
+#: id:36004
+msgid "Press \"user\" button command"
+msgstr "\"user\" 버튼 명령 누르기"
+
+#: id:36005
+msgid "Enable switch side commands"
+msgstr "스위치 사이드 명령 사용"
+
+#: id:36006
+msgid "Could not open the adapter"
+msgstr "어댑터를 열 수 없습니다"
+
+#: id:36007
+msgid "Devices to power on when starting XBMC"
+msgstr "XBMC 시작시 TV 켜기"
+
+#: id:36008
+msgid "Devices to power off when stopping XBMC"
+msgstr "XBMC 종료시 장치 전원 끄기"
+
+#: id:36009
+msgid "Put devices in standby mode when activating screensaver"
+msgstr "화면보호기 작동시 장치를 대기모드로 설정"
+
+#: id:36011
+msgid "Could not detect the CEC port. Set it up manually."
+msgstr "CEC 포트를 찾을 수 없습니다. 수동으로 설정하세요."
+
+#: id:36012
+msgid "Could not initialise the CEC adapter. Check your settings."
+msgstr "CEC 어댑터를 찾을 수 없음."
+
+#: id:36013
+msgid "Unsupported libCEC interface version. %d is greater than the version XBMC supports (%d)"
+msgstr "지원하지 않는 libcec 인터페이스 버전입니다. %d 가 XBMC가 지원하는 버전보다 높습니다 (%d)"
+
+#: id:36014
+msgid "Put this PC in standby mode when the TV is switched off"
+msgstr "TV가 꺼지면 PC를 대기모드로 전환"
+
+#: id:36015
+msgid "HDMI port number"
+msgstr "HDMI 포트 번호"
+
+#: id:36016
+msgctxt "Auto context with id 36016"
+msgid "Connected"
+msgstr "연결됨"
+
+#: id:36017
+msgid "Adapter found, but libCEC is not available"
+msgstr "어댑터가 확인되었으나 libcec를 사용할 수 없습니다"
+
+#: id:36018
+msgid "Use the TV's language setting"
+msgstr "TV의 언어 설정 사용"
+
+#: id:36019
+msgid "Connected to HDMI device"
+msgstr ""
+
+#: id:36020
+msgid "Make XBMC the active source when starting"
+msgstr ""
+
+#: id:36021
+msgid "Physical address (overrules HDMI port)"
+msgstr ""
+
+#: id:36022
+msgid "COM port (leave empty unless needed)"
+msgstr ""
+
+#: id:36023
+msgid "Configuration updated"
+msgstr ""
+
+#: id:36024
+msgid "Failed to set the new configuration. Please check your settings."
+msgstr ""
+
+#: id:36025
+msgid "Send 'inactive source' command when stopping XBMC"
+msgstr ""
+

--- a/language/Lithuanian/strings.po
+++ b/language/Lithuanian/strings.po
@@ -1,0 +1,9093 @@
+# Converted from xbmc strings.xml with xbmc-xml2po (by Team-XBMC)
+msgid ""
+msgstr ""
+"Project-Id-Version: xbmc.core-FRODO_GIT3ed1604ad7\n"
+"Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
+"POT-Creation-Date: 2012-04-09 18:00+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE\n"
+"Language: lt\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: id:0
+msgctxt "Auto context with id 0"
+msgid "Programs"
+msgstr "Programos"
+
+#: id:1
+msgctxt "Auto context with id 1"
+msgid "Pictures"
+msgstr "Foto"
+
+#: id:2
+msgctxt "Auto context with id 2"
+msgid "Music"
+msgstr "Muzika"
+
+#: id:3
+msgctxt "Auto context with id 3"
+msgid "Videos"
+msgstr "Video"
+
+#: id:4
+msgid "TV-Guide"
+msgstr "TV-Gidas"
+
+#: id:5
+msgctxt "Auto context with id 5"
+msgid "Settings"
+msgstr "Nustatymai"
+
+#: id:6
+msgid "XBMC SVN"
+msgstr "XBMC SVN"
+
+#: id:7
+msgctxt "Auto context with id 7"
+msgid "File manager"
+msgstr "Failų menedžeris"
+
+#: id:8
+msgctxt "Auto context with id 8"
+msgid "Weather"
+msgstr "Orai"
+
+#: id:9
+msgid "xbmc media center"
+msgstr "XBMC media centras"
+
+#: id:11
+msgid "Monday"
+msgstr "Pirmadienis"
+
+#: id:12
+msgid "Tuesday"
+msgstr "Antradienis"
+
+#: id:13
+msgid "Wednesday"
+msgstr "Trečiadienis"
+
+#: id:14
+msgid "Thursday"
+msgstr "Ketvirtadienis"
+
+#: id:15
+msgid "Friday"
+msgstr "Penktadienis"
+
+#: id:16
+msgid "Saturday"
+msgstr "Šeštadienis"
+
+#: id:17
+msgid "Sunday"
+msgstr "Sekmadienis"
+
+#: id:21
+msgid "January"
+msgstr "Sausis"
+
+#: id:22
+msgid "February"
+msgstr "Vasaris"
+
+#: id:23
+msgid "March"
+msgstr "Kovas"
+
+#: id:24
+msgid "April"
+msgstr "Balandis"
+
+#: id:25
+msgctxt "Auto context with id 25"
+msgid "May"
+msgstr "Gegužė"
+
+#: id:26
+msgid "June"
+msgstr "Birželis"
+
+#: id:27
+msgid "July"
+msgstr "Liepa"
+
+#: id:28
+msgid "August"
+msgstr "Rugpjūtis"
+
+#: id:29
+msgid "September"
+msgstr "Rugsėjis"
+
+#: id:30
+msgid "October"
+msgstr "Spalis"
+
+#: id:31
+msgid "November"
+msgstr "Lapkritis"
+
+#: id:32
+msgid "December"
+msgstr "Gruodis"
+
+#: id:41
+msgid "Mon"
+msgstr "Pir"
+
+#: id:42
+msgid "Tue"
+msgstr "Ant"
+
+#: id:43
+msgid "Wed"
+msgstr "Tre"
+
+#: id:44
+msgid "Thu"
+msgstr "Ket"
+
+#: id:45
+msgid "Fri"
+msgstr "Pen"
+
+#: id:46
+msgid "Sat"
+msgstr "Šeš"
+
+#: id:47
+msgctxt "Auto context with id 47"
+msgid "Sun"
+msgstr "Sek"
+
+#: id:51
+msgid "Jan"
+msgstr "Saus"
+
+#: id:52
+msgid "Feb"
+msgstr "Vasa"
+
+#: id:53
+msgid "Mar"
+msgstr "Kova"
+
+#: id:54
+msgid "Apr"
+msgstr "Bala"
+
+#: id:55
+msgctxt "Auto context with id 55"
+msgid "May"
+msgstr "Gegu"
+
+#: id:56
+msgid "Jun"
+msgstr "Birž"
+
+#: id:57
+msgid "Jul"
+msgstr "Liep"
+
+#: id:58
+msgid "Aug"
+msgstr "Rugp"
+
+#: id:59
+msgid "Sep"
+msgstr "Rugs"
+
+#: id:60
+msgid "Oct"
+msgstr "Spal"
+
+#: id:61
+msgid "Nov"
+msgstr "Lapk"
+
+#: id:62
+msgid "Dec"
+msgstr "Gruo"
+
+#: id:71
+msgid "N"
+msgstr "N"
+
+#: id:72
+msgid "NNE"
+msgstr "NNE"
+
+#: id:73
+msgid "NE"
+msgstr "NE"
+
+#: id:74
+msgid "ENE"
+msgstr "ENE"
+
+#: id:75
+msgid "E"
+msgstr "E"
+
+#: id:76
+msgid "ESE"
+msgstr "ESE"
+
+#: id:77
+msgid "SE"
+msgstr "SE"
+
+#: id:78
+msgid "SSE"
+msgstr "SSE"
+
+#: id:79
+msgid "S"
+msgstr "S"
+
+#: id:80
+msgid "SSW"
+msgstr "SSW"
+
+#: id:81
+msgid "SW"
+msgstr "SW"
+
+#: id:82
+msgid "WSW"
+msgstr "WSW"
+
+#: id:83
+msgid "W"
+msgstr "W"
+
+#: id:84
+msgid "WNW"
+msgstr "WNW"
+
+#: id:85
+msgid "NW"
+msgstr "NW"
+
+#: id:86
+msgid "NNW"
+msgstr "NNW"
+
+#: id:87
+msgid "VAR"
+msgstr "VAR"
+
+#: id:98
+msgid "View: Auto"
+msgstr "Vaizdas: Auto"
+
+#: id:99
+msgid "View: Auto big"
+msgstr "Vaizdas: Auto didelis"
+
+#: id:100
+msgid "View: Icons"
+msgstr "Vaizdas: Ikonos"
+
+#: id:101
+msgid "View: List"
+msgstr "Vaizdas: Sąrašas"
+
+#: id:102
+msgctxt "Auto context with id 102"
+msgid "Scan"
+msgstr "Nuskaityti"
+
+#: id:103
+msgctxt "Auto context with id 103"
+msgid "Sort by: Name"
+msgstr "Rūš. pagal: Vardą"
+
+#: id:104
+msgid "Sort by: Date"
+msgstr "Rūš. pagal: Datą"
+
+#: id:105
+msgid "Sort by: Size"
+msgstr "Rūš. pagal: Dydį"
+
+#: id:106
+msgid "No"
+msgstr "Ne"
+
+#: id:107
+msgid "Yes"
+msgstr "Taip"
+
+#: id:108
+msgctxt "Auto context with id 108"
+msgid "Slideshow"
+msgstr "Prezentacija"
+
+#: id:109
+msgid "Create thumbs"
+msgstr "Sukurti miniatiūrą"
+
+#: id:110
+msgid "Create thumbnails"
+msgstr "Sukurti miniatiūras"
+
+#: id:111
+msgctxt "Auto context with id 111"
+msgid "Shortcuts"
+msgstr "Etiketės"
+
+#: id:112
+msgid "Paused"
+msgstr "Laukime"
+
+#: id:113
+msgid "Update failed"
+msgstr "Nepavyko atnaujinti"
+
+#: id:114
+msgid "Installation failed"
+msgstr "Nepavyko įdiegti"
+
+#: id:115
+msgid "Copy"
+msgstr "Kopijuoti"
+
+#: id:116
+msgid "Move"
+msgstr "Perkelti"
+
+#: id:117
+msgid "Delete"
+msgstr "Ištrynti"
+
+#: id:118
+msgid "Rename"
+msgstr "Pervadinti"
+
+#: id:119
+msgid "New folder"
+msgstr "Naujas aplankas"
+
+#: id:120
+msgid "Confirm file copy"
+msgstr "Kopijavimo patvirtinimas"
+
+#: id:121
+msgid "Confirm file move"
+msgstr "Perkėlimo patvirtinimas"
+
+#: id:122
+msgid "Confirm file delete?"
+msgstr "Išmetimo patvirtinimas?"
+
+#: id:123
+msgid "Copy these files?"
+msgstr "Kopijuoti failus?"
+
+#: id:124
+msgid "Move these files?"
+msgstr "Perkelti failus?"
+
+#: id:125
+msgid "Delete these files? - Deleting files cannot be undone!"
+msgstr "Ištrynti failus? - Atkūrimas neįmanomas"
+
+#: id:126
+msgid "Status"
+msgstr "Padėtis"
+
+#: id:127
+msgid "Objects"
+msgstr "Objektas(-ai)"
+
+#: id:128
+msgctxt "Auto context with id 128"
+msgid "General"
+msgstr "Pagrindiniai"
+
+#: id:129
+msgctxt "Auto context with id 129"
+msgid "Slideshow"
+msgstr "Prezentacija"
+
+#: id:130
+msgctxt "Auto context with id 130"
+msgid "System info"
+msgstr "Info apie sistemą"
+
+#: id:131
+msgid "Display"
+msgstr "Ekranas"
+
+#: id:132
+msgid "Albums"
+msgstr "Albumai"
+
+#: id:133
+msgid "Artists"
+msgstr "Atlikėjai"
+
+#: id:134
+msgid "Songs"
+msgstr "Dainos"
+
+#: id:135
+msgid "Genres"
+msgstr "Žanrai"
+
+#: id:136
+msgid "Playlists"
+msgstr "Grojaraščiai"
+
+#: id:137
+msgid "Search"
+msgstr "Paieška"
+
+#: id:138
+msgid "System Information"
+msgstr "Info apie sistemą"
+
+#: id:139
+msgid "Temperatures:"
+msgstr "Temperatūra:"
+
+#: id:140
+msgid "CPU:"
+msgstr "CPU:"
+
+#: id:141
+msgid "GPU:"
+msgstr "GPU:"
+
+#: id:142
+msgid "Time:"
+msgstr "Laikas:"
+
+#: id:143
+msgid "Current:"
+msgstr "Aktualus:"
+
+#: id:144
+msgid "Build:"
+msgstr "Versija:"
+
+#: id:145
+msgid "Network:"
+msgstr "Tinklas:"
+
+#: id:146
+msgid "Type:"
+msgstr "Tipas:"
+
+#: id:147
+msgid "Static"
+msgstr "Statinis"
+
+#: id:148
+msgid "DHCP"
+msgstr "DHCP"
+
+#: id:149
+msgid "MAC address"
+msgstr "MAC-adresas"
+
+#: id:150
+msgctxt "Auto context with id 150"
+msgid "IP address"
+msgstr "IP-adresas"
+
+#: id:151
+msgid "Link:"
+msgstr "Sujungimas:"
+
+#: id:152
+msgid "Half duplex"
+msgstr "Pusiau dvipusis"
+
+#: id:153
+msgid "Full duplex"
+msgstr "Pilnai dvipusis"
+
+#: id:154
+msgctxt "Auto context with id 154"
+msgid "Storage"
+msgstr "Laikmenos"
+
+#: id:155
+msgid "Drive"
+msgstr "DVD grotuvo dėtuvė"
+
+#: id:156
+msgctxt "Auto context with id 156"
+msgid "Free"
+msgstr "Laisva"
+
+#: id:157
+msgctxt "Auto context with id 157"
+msgid "Video"
+msgstr "Video"
+
+#: id:158
+msgid "Free memory"
+msgstr "Laisva atminties"
+
+#: id:159
+msgid "No link"
+msgstr "Nėra jungties"
+
+#: id:160
+msgctxt "Auto context with id 160"
+msgid "Free"
+msgstr "Laisva"
+
+#: id:161
+msgid "Unavailable"
+msgstr "Neprieinama"
+
+#: id:162
+msgid "Tray open"
+msgstr "Dėtuvė atidaryta"
+
+#: id:163
+msgid "Reading"
+msgstr "Skaitymas"
+
+#: id:164
+msgid "No disc"
+msgstr "Grotuve nėra disko"
+
+#: id:165
+msgid "Disc present"
+msgstr "Diskas grotuve"
+
+#: id:166
+msgid "Skin"
+msgstr "Viršeliai"
+
+#: id:169
+msgctxt "Auto context with id 169"
+msgid "Resolution"
+msgstr "Ekrano rezoliucija"
+
+#: id:170
+msgid "Adjust display refresh rate to match video"
+msgstr "Nustatyti ekrano atnaujinimo dažnį"
+
+#: id:172
+msgid "Release date"
+msgstr "Išleidimo data"
+
+#: id:173
+msgid "Display 4:3 videos as"
+msgstr "Rodyti formatą 4:3 kaip"
+
+#: id:175
+msgid "Moods"
+msgstr "Nustatymai"
+
+#: id:176
+msgid "Styles"
+msgstr "Stiliai"
+
+#: id:179
+msgid "Song"
+msgstr "Daina"
+
+#: id:180
+msgid "Duration"
+msgstr "Ilgis"
+
+#: id:181
+msgid "Select album"
+msgstr "Pasirinkite albumą"
+
+#: id:182
+msgid "Tracks"
+msgstr "Takeliai"
+
+#: id:183
+msgid "Review"
+msgstr "Peržiūra"
+
+#: id:184
+msgid "Refresh"
+msgstr "Atnaujinti"
+
+#: id:185
+msgid "Searching album"
+msgstr "Albumų paieška"
+
+#: id:186
+msgid "OK"
+msgstr "Gerai"
+
+#: id:187
+msgid "No albums found!"
+msgstr "Albumų nerasta!"
+
+#: id:188
+msgid "Select all"
+msgstr "Rinktis viską"
+
+#: id:189
+msgid "Scanning media info"
+msgstr "Media duomenų skenavimas"
+
+#: id:190
+msgid "Save"
+msgstr "Išsaugoti"
+
+#: id:191
+msgid "Shuffle"
+msgstr "Sumaišyti"
+
+#: id:192
+msgctxt "Auto context with id 192"
+msgid "Clear"
+msgstr "Išvalyti"
+
+#: id:193
+msgctxt "Auto context with id 193"
+msgid "Scan"
+msgstr "Skenuoti"
+
+#: id:194
+msgid "Searching..."
+msgstr "Paieška..."
+
+#: id:195
+msgid "No info found!"
+msgstr "Informacija nerasta!"
+
+#: id:196
+msgid "Select movie:"
+msgstr "Pasirinkite filmą:"
+
+#: id:197
+msgid "Querying %s info"
+msgstr "Informacijos užklausa iš %s"
+
+#: id:198
+msgid "Loading movie details"
+msgstr "Duomenų atsiuntimas apie filmą"
+
+#: id:199
+msgid "Web interface"
+msgstr "Interneto sąsajos"
+
+#: id:202
+msgid "Tagline"
+msgstr "Devizas"
+
+#: id:203
+msgid "Plot outline"
+msgstr "Siužetas"
+
+#: id:205
+msgid "Votes"
+msgstr "Balsų:"
+
+#: id:206
+msgid "Cast"
+msgstr "Artistai"
+
+#: id:207
+msgid "Plot"
+msgstr "Siužetas"
+
+#: id:208
+msgctxt "Auto context with id 208"
+msgid "Play"
+msgstr "Atkūrti"
+
+#: id:209
+msgid "Next"
+msgstr "Sekantis"
+
+#: id:210
+msgid "Previous"
+msgstr "Ankstesnis"
+
+#: id:213
+msgid "Calibrate user interface..."
+msgstr "Kalibravimo sąsaja..."
+
+#: id:214
+msgid "Video calibration..."
+msgstr "Ekrano kalibravimas..."
+
+#: id:215
+msgid "Soften"
+msgstr "Išlyginimas"
+
+#: id:216
+msgid "Zoom amount"
+msgstr "Didinimo laipsnis"
+
+#: id:217
+msgid "Pixel ratio"
+msgstr "Vaizdo atitikmuo"
+
+#: id:218
+msgid "DVD drive"
+msgstr "DVD grotuvas"
+
+#: id:219
+msgid "Please insert disc"
+msgstr "Prašom idėti diską..."
+
+#: id:220
+msgid "Remote share"
+msgstr "Nuotoliniai resursai"
+
+#: id:221
+msgid "Network is not connected"
+msgstr "Neprisijungę prie tinklo"
+
+#: id:222
+msgid "Cancel"
+msgstr "Atšaukti"
+
+#: id:224
+msgid "Speed"
+msgstr "Prezentacijos rodymo laikas"
+
+#: id:225
+msgid "Vertical Shift"
+msgstr "Vertikalus perėjimas"
+
+#: id:226
+msgid "Test patterns..."
+msgstr "Testiniai šablonai..."
+
+#: id:227
+msgid "Lookup audio CD track names from freedb.org"
+msgstr "Ieškoti info apie audio CD internete"
+
+#: id:228
+msgid "Shuffle playlist on load"
+msgstr "Maišyti grojaraštį paleidimo metu"
+
+#: id:229
+msgid "HDD spindown time"
+msgstr "Sustabdyti HDD po (min.)"
+
+#: id:230
+msgid "Video filters"
+msgstr "Video filtrai"
+
+#: id:231
+msgctxt "Auto context with id 231"
+msgid "None"
+msgstr "Tuščia"
+
+#: id:232
+msgid "Point"
+msgstr "Taškas"
+
+#: id:233
+msgid "Linear"
+msgstr "Linijinis"
+
+#: id:234
+msgid "Anisotropic"
+msgstr "Anizotropinis"
+
+#: id:235
+msgid "Quincunx"
+msgstr "Šachmatinis"
+
+#: id:236
+msgid "Gaussian cubic"
+msgstr "Kubinis pagal Gaussa"
+
+#: id:237
+msgid "Minification"
+msgstr "Mąžinimas"
+
+#: id:238
+msgid "Magnification"
+msgstr "Didinimas"
+
+#: id:239
+msgid "Clear playlist on finish"
+msgstr "Išvalyti grojaraštį po grojimo"
+
+#: id:240
+msgid "Display Mode"
+msgstr "Ekrano režimas"
+
+#: id:241
+msgid "Full Screen #%d"
+msgstr "Visas ekranas #%d"
+
+#: id:242
+msgid "Windowed"
+msgstr "Lange"
+
+#: id:243
+msgid "Refresh Rate"
+msgstr "Atnaujinimo dažnis"
+
+#: id:244
+msgid "Full screen"
+msgstr "Visas ekranas"
+
+#: id:245
+msgid "Sizing: (%i,%i)->(%i,%i) (Zoom x%2.2f) AR:%2.2f:1 (Pixels: %2.2f:1) (VShift: %2.2f)"
+msgstr "Dydis: (%i,%i)->(%i,%i) (Zoom x%2.2f) AR:%2.2f:1 (Pixels: %2.2f:1) (VShift: %2.2f)"
+
+#: id:247
+msgctxt "Auto context with id 247"
+msgid "Scripts"
+msgstr "Skriptai"
+
+#: id:248
+msgctxt "Auto context with id 248"
+msgid "Language"
+msgstr "Kalba"
+
+#: id:249
+msgctxt "Auto context with id 249"
+msgid "Music"
+msgstr "Muzika"
+
+#: id:250
+msgctxt "Auto context with id 250"
+msgid "Visualization"
+msgstr "Video efektai"
+
+#: id:251
+msgid "Select destination directory"
+msgstr "Pasirinkite paskirties aplanką"
+
+#: id:252
+msgid "Output stereo to all speakers"
+msgstr "- stereo išėjimas į visus garsiakalbius"
+
+#: id:253
+msgid "Number of channels"
+msgstr "Kanalų kiekis"
+
+#: id:254
+msgid "- DTS capable receiver"
+msgstr "- garso išėjimas formate DTS®"
+
+#: id:255
+msgid "CDDB"
+msgstr "CDDB"
+
+#: id:256
+msgid "Fetching CD information"
+msgstr "Užklausa apie CD"
+
+#: id:257
+msgid "Error"
+msgstr "Klaida"
+
+#: id:258
+msgid "Enable tag reading"
+msgstr "Skaityti informaciją iš žymės"
+
+#: id:259
+msgid "Opening"
+msgstr "Atidarymas"
+
+#: id:260
+msgid "Shoutcast"
+msgstr "Shoutcast"
+
+#: id:261
+msgid "Waiting for start..."
+msgstr "Paleidimo laukimas..."
+
+#: id:262
+msgid "Scripts output"
+msgstr "Skriptų darbo LOG"
+
+#: id:263
+msgid "Allow control of XBMC via HTTP"
+msgstr "Įjungti interneto serverį"
+
+#: id:264
+msgid "Record"
+msgstr "Įrašas"
+
+#: id:265
+msgid "Stop Rec."
+msgstr "Sustabdyti įrašą"
+
+#: id:266
+msgid "Sort by: Track"
+msgstr "Rūšiuoti pagal: Takelis"
+
+#: id:267
+msgid "Sort by: Time"
+msgstr "Rūšiuoti pagal: Laikas"
+
+#: id:268
+msgid "Sort by: Title"
+msgstr "Rūšiuoti pagal: Pavadinimas"
+
+#: id:269
+msgid "Sort by: Artist"
+msgstr "Rūšiuoti pagal: Atlikėjas"
+
+#: id:270
+msgid "Sort by: Album"
+msgstr "Rūšiuoti pagal: Albumas"
+
+#: id:271
+msgid "Top 100"
+msgstr "Top 100"
+
+#: id:272
+msgid "Top-Left overscan compensation"
+msgstr "Ekrano nustatymai (viršutinis kairysis kampas)"
+
+#: id:273
+msgid "Bottom-Right overscan compensation"
+msgstr "Ekrano nustatymai (apatinis dešinysis kampas)"
+
+#: id:274
+msgid "Subtitle positioning"
+msgstr "Subtitrų pozicija"
+
+#: id:275
+msgid "Pixel ratio adjustment"
+msgstr "Aukščio ir pločio santykio reguliavimas"
+
+#: id:276
+msgid "Adjust the arrow to change the amount of overscan"
+msgstr "Keiskite rodykles ekrano dydžio koregavimui"
+
+#: id:277
+msgid "Adjust the bar to change the subtitles position"
+msgstr "Keiskite juostelę subtitrų rodymo koregavimui"
+
+#: id:278
+msgid "Adjust the rectangle so it is perfectly square"
+msgstr "Keiskite stačiakampį taip, kad pasiekti tikslų kvadratą"
+
+#: id:279
+msgid "Unable to load settings"
+msgstr "Nepavyko įkelti nustatymų"
+
+#: id:280
+msgid "Using default settings"
+msgstr "Naudoti numatytus nustatymus"
+
+#: id:281
+msgid "Please check the XML files"
+msgstr "Prašome patikrinti XML failus"
+
+#: id:282
+msgid "Found %i items"
+msgstr "Rasta %i objektas(-ų)"
+
+#: id:283
+msgid "Search results"
+msgstr "Paieškos rezultatai"
+
+#: id:284
+msgid "No results found"
+msgstr "Nieko nerasta"
+
+#: id:287
+msgctxt "Auto context with id 287"
+msgid "Subtitles"
+msgstr "Subtitrai"
+
+#: id:288
+msgctxt "Auto context with id 288"
+msgid "Font"
+msgstr "Šriftas"
+
+#: id:289
+msgctxt "Auto context with id 289"
+msgid "- Size"
+msgstr "- Dydis"
+
+#: id:290
+msgid "Dynamic range compression"
+msgstr "Dinaminis diapazono glaudinimas"
+
+#: id:291
+msgctxt "Auto context with id 291"
+msgid "Video"
+msgstr "Video"
+
+#: id:292
+msgctxt "Auto context with id 292"
+msgid "Audio"
+msgstr "Audio"
+
+#: id:293
+msgid "Browse for subtitles"
+msgstr "Pasirinkti subtitrus"
+
+#: id:294
+msgid "Create bookmark"
+msgstr "Įdėti užsklandą"
+
+#: id:296
+msgid "Clear bookmarks"
+msgstr "Nuimti užsklandą"
+
+#: id:297
+msgid "Audio offset"
+msgstr "Garso perėjimas"
+
+#: id:298
+msgid "Bookmarks"
+msgstr "Užsklanda"
+
+#: id:299
+msgid "- AAC capable receiver"
+msgstr "- AAC garso formatas"
+
+#: id:300
+msgid "- MP1 capable receiver"
+msgstr "- MP1 garso formatas"
+
+#: id:301
+msgid "- MP2 capable receiver"
+msgstr "- MP2 garso formatas"
+
+#: id:302
+msgid "- MP3 capable receiver"
+msgstr "- MP3 garso formatas"
+
+#: id:303
+msgid "Delay"
+msgstr "Užlaikymas"
+
+#: id:304
+msgctxt "Auto context with id 304"
+msgid "Language"
+msgstr "Kalba"
+
+#: id:305
+msgctxt "Auto context with id 305"
+msgid "Enabled"
+msgstr "Įjungta"
+
+#: id:306
+msgid "Non-interleaved"
+msgstr "Ne-formatas"
+
+#: id:312
+msgid "(0=auto)"
+msgstr "(0=auto)"
+
+#: id:313
+msgid "Cleaning database"
+msgstr "Duomenų bazės valymas"
+
+#: id:314
+msgid "Preparing..."
+msgstr "Paruošimas..."
+
+#: id:315
+msgid "Database error"
+msgstr "Duomenų bazės klaida"
+
+#: id:316
+msgid "Searching songs..."
+msgstr "Dainų paieška..."
+
+#: id:317
+msgid "Cleaned database successfully"
+msgstr "Duomenų bazės valymas baigtas"
+
+#: id:318
+msgid "Cleaning songs..."
+msgstr "Dainų valymas..."
+
+#: id:319
+msgid "Error cleaning songs"
+msgstr "Dainų valymo klaida"
+
+#: id:320
+msgid "Cleaning artists..."
+msgstr "Atlikėjų valymas..."
+
+#: id:321
+msgid "Error cleaning artists"
+msgstr "Atlikėjų valymo klaida"
+
+#: id:322
+msgid "Cleaning genres..."
+msgstr "Žanro valymas..."
+
+#: id:323
+msgid "Error cleaning genres"
+msgstr "Žanrų valymo klaida"
+
+#: id:324
+msgid "Cleaning paths..."
+msgstr "Nuorodos valymas..."
+
+#: id:325
+msgid "Error cleaning paths"
+msgstr "Nuorodų valymo klaida"
+
+#: id:326
+msgid "Cleaning albums..."
+msgstr "Albumo valymas..."
+
+#: id:327
+msgid "Error cleaning albums"
+msgstr "Albumų valymo klaida"
+
+#: id:328
+msgid "Writing changes..."
+msgstr "Įrašo pakeitimai..."
+
+#: id:329
+msgid "Error writing changes"
+msgstr "Įrašų pakeitimų klaida"
+
+#: id:330
+msgid "This may take some time..."
+msgstr "Tai užtruks kelias min..."
+
+#: id:331
+msgid "Compressing database..."
+msgstr "Duomenų bazės glaudinimas..."
+
+#: id:332
+msgid "Error compressing database"
+msgstr "Duomenų bazės glaudinimo klaida"
+
+#: id:333
+msgid "Do you want to clean the library?"
+msgstr "Norite valyti biblioteką?"
+
+#: id:334
+msgid "Clean library..."
+msgstr "Valyti biblioteką..."
+
+#: id:335
+msgid "Start"
+msgstr "Pradėti"
+
+#: id:336
+msgid "Framerate conversion"
+msgstr "Kadrų dažnio konversija"
+
+#: id:337
+msgctxt "Auto context with id 337"
+msgid "Audio output"
+msgstr "Garso formatas"
+
+#: id:338
+msgid "Analog"
+msgstr "Analoginis"
+
+#: id:339
+msgid "Optical/Coax"
+msgstr "Optinis/Koaxalinis"
+
+#: id:340
+msgid "Various artists"
+msgstr "Įvairūs atlikėjai"
+
+#: id:341
+msgid "Play disc"
+msgstr "Paleisti diską"
+
+#: id:342
+msgctxt "Auto context with id 342"
+msgid "Movies"
+msgstr "Filmai"
+
+#: id:343
+msgid "Adjust framerate"
+msgstr "Pritaikyti kadrų dažnį"
+
+#: id:344
+msgid "Actors"
+msgstr "Artistai"
+
+#: id:345
+msgctxt "Auto context with id 345"
+msgid "Year"
+msgstr "Metai"
+
+#: id:346
+msgid "Boost volume level on downmix"
+msgstr "Padidinti garsą maišant"
+
+#: id:350
+msgctxt "Auto context with id 350"
+msgid "Programs"
+msgstr "Programos"
+
+#: id:351
+msgctxt "Auto context with id 351"
+msgid "Off"
+msgstr "Atjungta"
+
+#: id:352
+msgid "Dim"
+msgstr "Pritemdymas"
+
+#: id:353
+msgid "Black"
+msgstr "Juodas ekranas"
+
+#: id:354
+msgid "Matrix trails"
+msgstr "Žymės 'Matrica'"
+
+#: id:355
+msgid "Screensaver time"
+msgstr "Paleisti ekrano užsklandą..."
+
+#: id:356
+msgid "Screensaver mode"
+msgstr "Užsklanda"
+
+#: id:357
+msgid "Shutdown function timer"
+msgstr "Baigti darbą po..."
+
+#: id:358
+msgid "All albums"
+msgstr "Visi albumai"
+
+#: id:359
+msgid "Recently added albums"
+msgstr "Nauji albumai"
+
+#: id:360
+msgctxt "Auto context with id 360"
+msgid "Screensaver"
+msgstr "Užsklanda"
+
+#: id:361
+msgid "R. Slideshow"
+msgstr "Rekurs. Prezentacija"
+
+#: id:362
+msgid "Screensaver dim level"
+msgstr "Ekrano pritemdymo lygis"
+
+#: id:363
+msgid "Sort by: File"
+msgstr "Rušiuoti pagal: Failą"
+
+#: id:364
+msgid "- Dolby Digital (AC3) capable receiver"
+msgstr "- garso išėjimas formate Dolby Digital® (AC3)"
+
+#: id:365
+msgctxt "Auto context with id 365"
+msgid "Sort by: Name"
+msgstr "Rušiuoti pagal: Vardą"
+
+#: id:366
+msgid "Sort by: Year"
+msgstr "Rušiuoti pagal: Metus"
+
+#: id:367
+msgid "Sort by: Rating"
+msgstr "Rušiuoti pagal: Reitingą"
+
+#: id:368
+msgid "IMDb"
+msgstr "IMDb"
+
+#: id:369
+msgctxt "Auto context with id 369"
+msgid "Title"
+msgstr "Pavadinimas"
+
+#: id:370
+msgid "Thunderstorms"
+msgstr "Dulksna"
+
+#: id:371
+msgid "Partly"
+msgstr "Vietomis"
+
+#: id:372
+msgid "Mostly"
+msgstr "Daugiausia"
+
+#: id:373
+msgid "Sunny"
+msgstr "Saulėta"
+
+#: id:374
+msgid "Cloudy"
+msgstr "Debesuota"
+
+#: id:375
+msgid "Snow"
+msgstr "Sniegas"
+
+#: id:376
+msgid "Rain"
+msgstr "Lietus"
+
+#: id:377
+msgid "Light"
+msgstr "Nedidelis"
+
+#: id:378
+msgid "AM"
+msgstr "Ryte"
+
+#: id:379
+msgid "PM"
+msgstr "Dieną"
+
+#: id:380
+msgid "Showers"
+msgstr "Liūtis"
+
+#: id:381
+msgid "Few"
+msgstr "Nedaug"
+
+#: id:382
+msgid "Scattered"
+msgstr "Vietomis"
+
+#: id:383
+msgctxt "Auto context with id 383"
+msgid "Wind"
+msgstr "Vėjas"
+
+#: id:384
+msgid "Strong"
+msgstr "Stiprus"
+
+#: id:385
+msgid "Fair"
+msgstr "Ryški"
+
+#: id:386
+msgctxt "Auto context with id 386"
+msgid "Clear"
+msgstr "Giedra"
+
+#: id:387
+msgid "Clouds"
+msgstr "Apsiniaukę"
+
+#: id:388
+msgid "Early"
+msgstr "Anksyvi"
+
+#: id:389
+msgid "Shower"
+msgstr "Gausus"
+
+#: id:390
+msgid "Flurries"
+msgstr "Audrotas"
+
+#: id:391
+msgctxt "Auto context with id 391"
+msgid "Low"
+msgstr "Žemas"
+
+#: id:392
+msgctxt "Auto context with id 392"
+msgid "Medium"
+msgstr "Vidutinis"
+
+#: id:393
+msgctxt "Auto context with id 393"
+msgid "High"
+msgstr "Aukštas"
+
+#: id:394
+msgid "Fog"
+msgstr "Rūkas"
+
+#: id:395
+msgid "Haze"
+msgstr "Dunlksna"
+
+#: id:396
+msgid "Select location"
+msgstr "Vietomis"
+
+#: id:397
+msgid "Refresh time"
+msgstr "Laikas atnaujinti"
+
+#: id:398
+msgid "Temperature units"
+msgstr "Temperatūros matavimo vienetas"
+
+#: id:399
+msgid "Speed units"
+msgstr "Vėjo geičio matavimo vienetas"
+
+#: id:400
+msgctxt "Auto context with id 400"
+msgid "Weather"
+msgstr "Oras"
+
+#: id:401
+msgid "Temp"
+msgstr "Temperatūra"
+
+#: id:402
+msgid "Feels like"
+msgstr "Jaučiasi kaip"
+
+#: id:403
+msgid "UV index"
+msgstr "Uf lygis"
+
+#: id:404
+msgctxt "Auto context with id 404"
+msgid "Wind"
+msgstr "Vėjas"
+
+#: id:405
+msgid "Dew point"
+msgstr "Rasos taškas"
+
+#: id:406
+msgid "Humidity"
+msgstr "Drėgnumas"
+
+#: id:409
+msgid "Defaults"
+msgstr "Pagal nutilėjimą"
+
+#: id:410
+msgid "Accessing weather service"
+msgstr "Prijungimas prie Hidrometeocentro"
+
+#: id:411
+msgid "Getting weather for:"
+msgstr "Gauti orų prognozę:"
+
+#: id:412
+msgid "Unable to get weather data"
+msgstr "Neimanoma gauti orų prognozės"
+
+#: id:413
+msgid "Manual"
+msgstr "Rankiniu būdu"
+
+#: id:414
+msgid "No review for this album"
+msgstr "Nėra šio albumo aprašymo"
+
+#: id:415
+msgid "Downloading thumbnail..."
+msgstr "Gauti eskizus..."
+
+#: id:416
+msgid "Not available"
+msgstr "Nėra duomenų"
+
+#: id:417
+msgid "View: Big icons"
+msgstr "Vaizdas: Dideli ženkliukai"
+
+#: id:418
+msgctxt "Auto context with id 418"
+msgid "Low"
+msgstr "Min."
+
+#: id:419
+msgctxt "Auto context with id 419"
+msgid "High"
+msgstr "Maks."
+
+#: id:420
+msgid "HDMI"
+msgstr "HDMI"
+
+#: id:422
+msgid "Delete album info"
+msgstr "Pašalinti albumo duomenis"
+
+#: id:423
+msgid "Delete CD information"
+msgstr "Pašalinti CD duomenis"
+
+#: id:424
+msgid "Select"
+msgstr "Parinktys"
+
+#: id:425
+msgid "No album information found"
+msgstr "Duomenys apie albumą nerasti"
+
+#: id:426
+msgid "No CD information found"
+msgstr "Duomenys apie CD nerasti"
+
+#: id:427
+msgid "Disc"
+msgstr "Diskas"
+
+#: id:428
+msgid "Insert correct CD/DVD"
+msgstr "Idėkite gerą CD/DVD diską"
+
+#: id:429
+msgid "Please insert the following disc:"
+msgstr "Idėkite sekantį CD/DVD diską"
+
+#: id:430
+msgid "Sort by: DVD#"
+msgstr "Rušiuoti pagal: №DVD"
+
+#: id:431
+msgid "No cache"
+msgstr "Nėra talpyklos"
+
+#: id:432
+msgid "Remove movie from library"
+msgstr "Pašalinti filmą iš bibliotekos"
+
+#: id:433
+msgid "Really remove '%s'?"
+msgstr "Ar tikrai ištrinti '%s'?"
+
+#: id:434
+msgid "From %s at %i %s"
+msgstr "Iš %s į %i %s"
+
+#: id:437
+msgid "Removable disk"
+msgstr "Keičiamasis diskas"
+
+#: id:438
+msgid "Opening file"
+msgstr "Failo atidarymas"
+
+#: id:439
+msgid "Cache"
+msgstr "Buferizacija"
+
+#: id:440
+msgid "Harddisk"
+msgstr "HDD diskas"
+
+#: id:441
+msgid "UDF"
+msgstr "UDF"
+
+#: id:442
+msgid "Local network"
+msgstr "Vietinis tinklas"
+
+#: id:443
+msgid "Internet"
+msgstr "Internetas"
+
+#: id:444
+msgctxt "Auto context with id 444"
+msgid "Video"
+msgstr "Video"
+
+#: id:445
+msgctxt "Auto context with id 445"
+msgid "Audio"
+msgstr "Audio"
+
+#: id:446
+msgctxt "Auto context with id 446"
+msgid "DVD"
+msgstr "DVD"
+
+#: id:447
+msgid "Autorun media"
+msgstr "Auto paleidimas"
+
+#: id:448
+msgid "LCD"
+msgstr "LCD ekranas"
+
+#: id:449
+msgctxt "Auto context with id 449"
+msgid "Enabled"
+msgstr "Įjungta"
+
+#: id:450
+msgid "Columns"
+msgstr "Ženklų kiekis eilėje"
+
+#: id:451
+msgid "Row 1 address"
+msgstr "1 eilutė adresas"
+
+#: id:452
+msgid "Row 2 address"
+msgstr "2 eilutė adresas"
+
+#: id:453
+msgid "Row 3 address"
+msgstr "3 eilutė adresas"
+
+#: id:454
+msgid "Row 4 address"
+msgstr "4 eilutė adresas"
+
+#: id:455
+msgid "Rows"
+msgstr "Adresų eilių skaičius"
+
+#: id:456
+msgid "Mode"
+msgstr "Režimas"
+
+#: id:457
+msgid "Switch view"
+msgstr "Pakeisti išvaizdą"
+
+#: id:459
+msgid "Subs"
+msgstr "Subtitrai"
+
+#: id:460
+msgid "Audio stream"
+msgstr "Audio srautas"
+
+#: id:461
+msgid "[active]"
+msgstr "[dirba]"
+
+#: id:462
+msgid "Subtitle"
+msgstr "Subtitrai"
+
+#: id:463
+msgid "Backlight"
+msgstr "Foninis ryškumas"
+
+#: id:464
+msgid "Brightness"
+msgstr "Ryškumas"
+
+#: id:465
+msgid "Contrast"
+msgstr "Kontrastas"
+
+#: id:466
+msgid "Gamma"
+msgstr "Gama"
+
+#: id:467
+msgctxt "Auto context with id 467"
+msgid "Type"
+msgstr "Tipas"
+
+#: id:468
+msgid "Move the bar to change the OSD position"
+msgstr "Judinkit juostelę pozicijai pakeisti (OSD)"
+
+#: id:469
+msgid "OSD position"
+msgstr "Ekrano pozicija (OSD)"
+
+#: id:470
+msgid "Credits"
+msgstr "Kūrėjai"
+
+#: id:471
+msgid "Modchip"
+msgstr "МOD-čipas"
+
+#: id:474
+msgctxt "Auto context with id 474"
+msgid "Off"
+msgstr "Išjungta"
+
+#: id:475
+msgid "Music only"
+msgstr "Tiktai muzika"
+
+#: id:476
+msgctxt "Auto context with id 476"
+msgid "Music & video"
+msgstr "Muzika ir Video"
+
+#: id:477
+msgid "Unable to load playlist"
+msgstr "Nepavyko įkelti į grojaraštį"
+
+#: id:478
+msgid "OSD"
+msgstr "Erano meniu (OSD)"
+
+#: id:479
+msgid "Skin & language"
+msgstr "Kalba ir vaizdas"
+
+#: id:480
+msgid "Appearance"
+msgstr "Išvaizda"
+
+#: id:481
+msgid "Audio options"
+msgstr "Audio nustatymai"
+
+#: id:482
+msgid "About XBMC"
+msgstr "Apie XBMC"
+
+#: id:485
+msgid "Delete album"
+msgstr "Ištrinti albumą"
+
+#: id:486
+msgid "Repeat"
+msgstr "Kartoti"
+
+#: id:487
+msgid "Repeat one"
+msgstr "Kartoti vieną kartą"
+
+#: id:488
+msgid "Repeat folder"
+msgstr "Papkės kartojimas"
+
+#: id:489
+msgid "Play the next song automatically"
+msgstr "Groti sekantį failą automatiškai"
+
+#: id:491
+msgid "- Use big icons"
+msgstr "- naudoti didelius ženkliukus"
+
+#: id:492
+msgid "Resize VobSubs"
+msgstr "Subtitrų mastelis"
+
+#: id:493
+msgid "Advanced options (Experts Only!)"
+msgstr "Papildomi duomenys (tik ekspertams!)"
+
+#: id:494
+msgid "Overall audio headroom"
+msgstr "Bendras garso lygis patalpoje"
+
+#: id:495
+msgid "Upsample videos to GUI resolution"
+msgstr "Perskaičiuoti vaizdo rezoliuciją iki GUI"
+
+#: id:496
+msgid "Calibration"
+msgstr "Kalibravimas"
+
+#: id:497
+msgid "Show file extensions"
+msgstr "Rodyti failų plėtinius"
+
+#: id:498
+msgid "Sort by: Type"
+msgstr "Rušiuoti pagal: Tipą"
+
+#: id:499
+msgid "Unable to connect to online lookup service"
+msgstr "Nepavyko prisijungti prie paieškos serverio"
+
+#: id:500
+msgid "Downloading album information failed"
+msgstr "Nesėkmingai atsiųsti duomenys apie albumą"
+
+#: id:501
+msgid "Looking for album names..."
+msgstr "Albumų pavadinimų tikrinimas..."
+
+#: id:502
+msgctxt "Auto context with id 502"
+msgid "Open"
+msgstr "Atidarytas"
+
+#: id:503
+msgid "Busy"
+msgstr "Apdorojimas..."
+
+#: id:504
+msgid "Empty"
+msgstr "Tuščia"
+
+#: id:505
+msgid "Loading media info from files..."
+msgstr "Duomenys iš failų..."
+
+#: id:507
+msgid "Sort by: Usage"
+msgstr "Rušiuoti pagal dažnį"
+
+#: id:510
+msgid "Enable visualizations"
+msgstr "Įjungti vaizdo efektus"
+
+#: id:511
+msgid "Enable video mode switching"
+msgstr "Auto perjungimas PAL/NTSC"
+
+#: id:512
+msgid "Startup window"
+msgstr "Paleidus pereiti į menių:"
+
+#: id:513
+msgid "Home window"
+msgstr "Pagrindinis menių"
+
+#: id:514
+msgid "Manual settings"
+msgstr "Nustatymai"
+
+#: id:515
+msgid "Genre"
+msgstr "Žanras"
+
+#: id:517
+msgid "Recently played albums"
+msgstr "Nesenai perklausyti albumai"
+
+#: id:518
+msgid "Launch"
+msgstr "Paleisti"
+
+#: id:519
+msgid "Launch in..."
+msgstr "Paleisti režime..."
+
+#: id:521
+msgid "Compilations"
+msgstr "Rinkiniai"
+
+#: id:522
+msgid "Remove source"
+msgstr "Pašalinti šaltinį"
+
+#: id:523
+msgid "Switch media"
+msgstr "Pereiti į skirsnį..."
+
+#: id:524
+msgid "Select playlist"
+msgstr "Pasirinkite grojaraštį"
+
+#: id:525
+msgid "New playlist..."
+msgstr "Sukurti naują grojaraštį..."
+
+#: id:526
+msgid "Add to playlist"
+msgstr "Įdėti į grojaraštį"
+
+#: id:527
+msgid "Manually add to library"
+msgstr "Įdėti į biblioteką"
+
+#: id:528
+msgid "Enter title"
+msgstr "Įrašykite pavadinimą"
+
+#: id:529
+msgid "Error: Duplicate title"
+msgstr "Klaida: Vienodi pavadinimai"
+
+#: id:530
+msgid "Select genre"
+msgstr "Parinkite žanrą"
+
+#: id:531
+msgid "New genre"
+msgstr "Naujas žanras"
+
+#: id:532
+msgid "Manual addition"
+msgstr "Rankinis įdėjimas"
+
+#: id:533
+msgid "Enter genre"
+msgstr "Įveskite žanrą"
+
+#: id:534
+msgid "View: %s"
+msgstr "Vaizdas: %s"
+
+#: id:535
+msgid "List"
+msgstr "Sąrašas"
+
+#: id:536
+msgid "Icons"
+msgstr "Ženkliukai"
+
+#: id:537
+msgid "Big list"
+msgstr "Pilnas sąrašas"
+
+#: id:538
+msgid "Big icons"
+msgstr "Dideli ženkliukai"
+
+#: id:539
+msgid "Wide"
+msgstr "Platus"
+
+#: id:540
+msgid "Big wide"
+msgstr "Platus rieb."
+
+#: id:541
+msgid "Album icons"
+msgstr "Albumų ženkliukai"
+
+#: id:542
+msgid "DVD icons"
+msgstr "DVD ženkliukai"
+
+#: id:543
+msgctxt "Auto context with id 543"
+msgid "DVD"
+msgstr "DVD"
+
+#: id:544
+msgctxt "Auto context with id 544"
+msgid "Media info"
+msgstr "Duomenys"
+
+#: id:545
+msgid "Audio output device"
+msgstr "Garso išvesties įrenginys"
+
+#: id:546
+msgid "Passthrough output device"
+msgstr "Garso perdavimo įrenginys"
+
+#: id:547
+msgid "No biography for this artist"
+msgstr "Šio atlikėjo biografija nerasta"
+
+#: id:548
+msgid "Downmix multichannel audio to stereo"
+msgstr "Daugiakanalį garsą perdaryti i stereo"
+
+#: id:550
+msgid "Sort by: %s"
+msgstr "Ruš. pagal: %s"
+
+#: id:551
+msgctxt "Auto context with id 551"
+msgid "Name"
+msgstr "Pavadinimas"
+
+#: id:552
+msgid "Date"
+msgstr "Data"
+
+#: id:553
+msgid "Size"
+msgstr "Dydis"
+
+#: id:554
+msgid "Track"
+msgstr "Takelis"
+
+#: id:555
+msgid "Time"
+msgstr "Laikas"
+
+#: id:556
+msgctxt "Auto context with id 556"
+msgid "Title"
+msgstr "Pavadinimas"
+
+#: id:557
+msgid "Artist"
+msgstr "Atlikėjas"
+
+#: id:558
+msgid "Album"
+msgstr "Albumas"
+
+#: id:559
+msgid "Playlist"
+msgstr "Grojaraštis"
+
+#: id:560
+msgid "ID"
+msgstr "ID"
+
+#: id:561
+msgctxt "Auto context with id 561"
+msgid "File"
+msgstr "Failo vardas"
+
+#: id:562
+msgctxt "Auto context with id 562"
+msgid "Year"
+msgstr "Metai"
+
+#: id:563
+msgid "Rating"
+msgstr "Reitingas"
+
+#: id:564
+msgctxt "Auto context with id 564"
+msgid "Type"
+msgstr "Tipas"
+
+#: id:565
+msgid "Usage"
+msgstr "Dažnis"
+
+#: id:566
+msgid "Album artist"
+msgstr "Albumo atlikėjas"
+
+#: id:567
+msgid "Play count"
+msgstr "Paleidimo kartus(ų)"
+
+#: id:568
+msgid "Last played"
+msgstr "Paskutiniai groti(as)"
+
+#: id:569
+msgctxt "Auto context with id 569"
+msgid "Comment"
+msgstr "Koment."
+
+#: id:570
+msgid "Date added"
+msgstr "Įtraukimo data"
+
+#: id:571
+msgctxt "Auto context with id 571"
+msgid "Default"
+msgstr "Kaip yra"
+
+#: id:572
+msgid "Studio"
+msgstr "Kinostudija"
+
+#: id:573
+msgid "Path"
+msgstr "Kelias"
+
+#: id:574
+msgctxt "Auto context with id 574"
+msgid "Country"
+msgstr "Šalis"
+
+#: id:575
+msgid "In progress"
+msgstr "Procese"
+
+#: id:576
+msgid "Times played"
+msgstr "Grojo kartus(ų)"
+
+#: id:580
+msgid "Sort direction"
+msgstr "Rūšiavimo kryptis"
+
+#: id:581
+msgid "Sort method"
+msgstr "Rūšiavimo metodas"
+
+#: id:582
+msgctxt "Auto context with id 582"
+msgid "View mode"
+msgstr "Peržiūros režimas"
+
+#: id:583
+msgid "Remember views for different folders"
+msgstr "Atsiminti kiekvienos papkės nustatymo parametrus"
+
+#: id:584
+msgid "Ascending"
+msgstr "Pagal didėjimą"
+
+#: id:585
+msgid "Descending"
+msgstr "Pagal mažėjimą"
+
+#: id:586
+msgid "Edit playlist"
+msgstr "Taisyti grojaraštį"
+
+#: id:587
+msgid "Filter"
+msgstr "Filtras"
+
+#: id:588
+msgid "Cancel party mode"
+msgstr "Išjungti režimą 'Party'"
+
+#: id:589
+msgid "Party mode"
+msgstr "Režimas 'Party'"
+
+#: id:590
+msgid "Random"
+msgstr "Atsitiktinai"
+
+#: id:591
+msgctxt "Auto context with id 591"
+msgid "Off"
+msgstr "Išjungta"
+
+#: id:592
+msgid "One"
+msgstr "Vienas"
+
+#: id:593
+msgid "All"
+msgstr "Visi"
+
+#: id:594
+msgctxt "Auto context with id 594"
+msgid "Off"
+msgstr "Išjungta"
+
+#: id:595
+msgid "Repeat: Off"
+msgstr "Pakartot: Išjungta"
+
+#: id:596
+msgid "Repeat: One"
+msgstr "Pakartot: Vienas"
+
+#: id:597
+msgid "Repeat: All"
+msgstr "Pakartot: Visi"
+
+#: id:600
+msgid "Rip audio CD"
+msgstr "Nuskaityti audio CD"
+
+#: id:601
+msgctxt "Auto context with id 601"
+msgid "Medium"
+msgstr "Vidutinis"
+
+#: id:602
+msgctxt "Auto context with id 602"
+msgid "Standard"
+msgstr "Standartinis"
+
+#: id:603
+msgid "Extreme"
+msgstr "Ekstremalus"
+
+#: id:604
+msgid "Constant bitrate"
+msgstr "Pastovus duomenų srautas"
+
+#: id:605
+msgid "Ripping..."
+msgstr "Nuskaitymas..."
+
+#: id:607
+msgid "To:"
+msgstr "V:"
+
+#: id:608
+msgid "Could not rip CD or track"
+msgstr "Nuskaityti CD takelio negalima"
+
+#: id:609
+msgid "CDDARipPath is not set."
+msgstr "Reikšmė CD/DA/RipPath nenurodyta."
+
+#: id:610
+msgid "Rip audio track"
+msgstr "Nuskaityti audio takelį"
+
+#: id:611
+msgid "Enter number"
+msgstr "Įveskite numerį"
+
+#: id:612
+msgid "Bits/Sample"
+msgstr "Bit/Sempl"
+
+#: id:613
+msgid "Sample Frequency"
+msgstr "Sampling dažnis"
+
+#: id:620
+msgid "Audio CDs"
+msgstr "CD nuskaitymas"
+
+#: id:621
+msgid "Encoder"
+msgstr "Koduotė"
+
+#: id:622
+msgid "Quality"
+msgstr "Kokybė"
+
+#: id:623
+msgid "Bitrate"
+msgstr "Dumenų srautas"
+
+#: id:624
+msgid "Include track number"
+msgstr "Pridėti takelio numerį"
+
+#: id:625
+msgid "All songs of"
+msgstr "Visos dainos"
+
+#: id:629
+msgctxt "Auto context with id 629"
+msgid "View mode"
+msgstr "Peržiūros režimas"
+
+#: id:630
+msgctxt "Auto context with id 630"
+msgid "Normal"
+msgstr "Normalus"
+
+#: id:631
+msgid "Zoom"
+msgstr "Padidintas"
+
+#: id:632
+msgid "Stretch 4:3"
+msgstr "Ištemptas 4:3"
+
+#: id:633
+msgid "Wide Zoom"
+msgstr "Ištemptas 14:9"
+
+#: id:634
+msgid "Stretch 16:9"
+msgstr "Ištemptas 16:9"
+
+#: id:635
+msgid "Original Size"
+msgstr "Originalus dydis"
+
+#: id:636
+msgctxt "Auto context with id 636"
+msgid "Custom"
+msgstr "Ypatingas"
+
+#: id:637
+msgid "Replay gain"
+msgstr "Replay Gain"
+
+#: id:638
+msgid "Replaygain volume adjustments"
+msgstr "Režimas 'ReplayGain'"
+
+#: id:639
+msgid "Use track levels"
+msgstr "Pagal takelį"
+
+#: id:640
+msgid "Use album levels"
+msgstr "Pagal albumą"
+
+#: id:641
+msgid "PreAmp Level - Replay gained files"
+msgstr "Lygis failams su 'ReplayGain'"
+
+#: id:642
+msgid "PreAmp Level - Non replay gained files"
+msgstr "Lygis failams be 'ReplayGain'"
+
+#: id:643
+msgid "Avoid clipping on replay gained files"
+msgstr "Išvengti iškraipymų failuose su 'ReplyGain'"
+
+#: id:644
+msgid "Crop black bars"
+msgstr "Pašalinti juodas juostas"
+
+#: id:645
+msgid "Need to unpack a big file. Continue?"
+msgstr "Būtina išarchyvuoti didelį failą. Testi?"
+
+#: id:646
+msgid "Remove from library"
+msgstr "Pašalinti iš bibliotekos"
+
+#: id:647
+msgid "Export video library"
+msgstr "Eksportuoti į video biblioteką"
+
+#: id:648
+msgid "Import video library"
+msgstr "Importuoti iš video bibliotekos"
+
+#: id:649
+msgid "Importing"
+msgstr "Importas"
+
+#: id:650
+msgid "Exporting"
+msgstr "Eksportas"
+
+#: id:651
+msgid "Browse for library"
+msgstr "Nurodykite biblioteką"
+
+#: id:652
+msgid "Years"
+msgstr "Metai"
+
+#: id:653
+msgid "Update library"
+msgstr "Atnaujinti biblioteką"
+
+#: id:654
+msgid "Show debug info"
+msgstr "Rodyti derinimo informaciją"
+
+#: id:655
+msgid "Browse for executable"
+msgstr "Nurodykite programą"
+
+#: id:656
+msgid "Browse for playlist"
+msgstr "Nurodykite biblioteką"
+
+#: id:657
+msgid "Browse for folder"
+msgstr "Nurodykite papkę"
+
+#: id:658
+msgid "Song information"
+msgstr "Informacija apie dainą"
+
+#: id:659
+msgid "Non-linear stretch"
+msgstr "Nelijininis padidinimas"
+
+#: id:660
+msgid "Volume amplification"
+msgstr "Garso padidinimas"
+
+#: id:661
+msgid "Choose export folder"
+msgstr "Nurodykite papkę eksportui"
+
+#: id:662
+msgid "This file is no longer available."
+msgstr "Šis failas nepasiekiamas."
+
+#: id:663
+msgid "Would you like to remove it from the library?"
+msgstr "Norite jį pašalinti iš bibliotekos?"
+
+#: id:664
+msgid "Browse for Script"
+msgstr "Pasirinkti skriptą"
+
+#: id:665
+msgid "Compression level"
+msgstr "Suspaudimo laipsnis"
+
+#: id:700
+msgid "Cleaning up library"
+msgstr "Bibliotekos išvalymas"
+
+#: id:701
+msgid "Removing old songs from the library"
+msgstr "Senų dainų šalinimas iš bibliotekos"
+
+#: id:702
+msgid "This path has been scanned before"
+msgstr "Šis aplankas buvo patikrintas seniau"
+
+#: id:705
+msgctxt "Auto context with id 705"
+msgid "Network"
+msgstr "Tinklas"
+
+#: id:706
+msgid "- Server"
+msgstr "- Serveris"
+
+#: id:708
+msgid "Use an HTTP proxy server to access the internet"
+msgstr "Naudoti HTTP-proxy serverį"
+
+#: id:711
+msgid "Internet Protocol (IP)"
+msgstr "Interneto protokolas (IP)"
+
+#: id:712
+msgid "Invalid port specified. Value must be between 1 and 65535."
+msgstr "Neteisingas portas. Turi būti nuo 1 iki 65535."
+
+#: id:713
+msgid "HTTP proxy"
+msgstr "HTTP proksi"
+
+#: id:715
+msgid "- Assignment"
+msgstr "- Paskyrimas"
+
+#: id:716
+msgid "Automatic (DHCP)"
+msgstr "Automatiškai (DHCP)"
+
+#: id:717
+msgid "Manual (Static)"
+msgstr "Manualas (Static)"
+
+#: id:719
+msgid "- IP address"
+msgstr "- IP adresas"
+
+#: id:720
+msgid "- Netmask"
+msgstr "- Tinklo kaukė"
+
+#: id:721
+msgid "- Default gateway"
+msgstr "- Numatytas šliuzas"
+
+#: id:722
+msgid "- DNS server"
+msgstr "- ADNS serveris"
+
+#: id:723
+msgid "Save & restart"
+msgstr "Išsaugoti ir paleisti"
+
+#: id:724
+msgid "Invalid address specified. Value must be AAA.BBB.CCC.DDD"
+msgstr "Neteisingas adresas. Turėtų būti AAA.BBB.CCC.DDD"
+
+#: id:725
+msgid "with numbers between 0 and 255."
+msgstr "skaičiai nuo 0 iki 255."
+
+#: id:726
+msgid "Changes not saved. Continue without saving?"
+msgstr "Pakeitimai neišsaugoti. Vistiek tęsti?"
+
+#: id:727
+msgid "Web server"
+msgstr "Interneto serveris"
+
+#: id:728
+msgctxt "Auto context with id 728"
+msgid "FTP server"
+msgstr "FTP serveris"
+
+#: id:730
+msgid "- Port"
+msgstr "Interneto serverio portas"
+
+#: id:732
+msgid "Save & apply"
+msgstr "Išsaugoti ir pritaikyti"
+
+#: id:733
+msgid "- Password"
+msgstr "Prieigos slaptažodis prie interneto serverio"
+
+#: id:734
+msgid "No pass"
+msgstr "Be slaptažodžio"
+
+#: id:735
+msgid "- Character set"
+msgstr "- Simbolių parinkimas"
+
+#: id:736
+msgid "- Style"
+msgstr "- Stilius"
+
+#: id:737
+msgid "- Colour"
+msgstr "- Spalvos"
+
+#: id:738
+msgctxt "Auto context with id 738"
+msgid "Normal"
+msgstr "Paprastas"
+
+#: id:739
+msgid "Bold"
+msgstr "Riebus"
+
+#: id:740
+msgid "Italics"
+msgstr "Italic"
+
+#: id:741
+msgid "Bold italics"
+msgstr "Riebus Italic"
+
+#: id:742
+msgctxt "Auto context with id 742"
+msgid "White"
+msgstr "Baltas"
+
+#: id:743
+msgctxt "Auto context with id 743"
+msgid "Yellow"
+msgstr "Geltonas"
+
+#: id:744
+msgctxt "Auto context with id 744"
+msgid "Files"
+msgstr "Failai"
+
+#: id:745
+msgid "No scanned information for this view"
+msgstr "Šios rūšies duomenys nenuskaityti"
+
+#: id:746
+msgid "Please turn off library mode"
+msgstr "Prašome išjungti bibliotekos režimą"
+
+#: id:747
+msgid "Error loading image"
+msgstr "Klaida įkeliant paveikslėlį"
+
+#: id:748
+msgid "Edit path"
+msgstr "Pakeisti nuorodą"
+
+#: id:749
+msgid "Mirror image"
+msgstr "Atvaizdas"
+
+#: id:750
+msgid "Are you sure?"
+msgstr "Jūs isitikinęs?"
+
+#: id:751
+msgid "Removing source"
+msgstr "Šaltinio pašalinimas"
+
+#: id:754
+msgid "Add program link"
+msgstr "Pridėti nuorodą į programą"
+
+#: id:755
+msgid "Edit program path"
+msgstr "Pakeisti programos kelią"
+
+#: id:756
+msgid "Edit program name"
+msgstr "Pakeisti programos pavadinimą"
+
+#: id:757
+msgid "Edit path depth"
+msgstr "Pakeisti kelio dydį"
+
+#: id:759
+msgid "View: Big list"
+msgstr "Vaizdas: Didelis sąrašas"
+
+#: id:760
+msgctxt "Auto context with id 760"
+msgid "Yellow"
+msgstr "Geltonas"
+
+#: id:761
+msgctxt "Auto context with id 761"
+msgid "White"
+msgstr "Baltas"
+
+#: id:762
+msgid "Blue"
+msgstr "Mėlinas"
+
+#: id:763
+msgid "Bright green"
+msgstr "Šviesiai-žalias"
+
+#: id:764
+msgid "Yellow green"
+msgstr "Geltonai-žalias"
+
+#: id:765
+msgid "Cyan"
+msgstr "Dangiškas"
+
+#: id:766
+msgid "Light grey"
+msgstr "Šviesiai-pilkas"
+
+#: id:767
+msgid "Grey"
+msgstr "Pilkas"
+
+#: id:770
+msgid "Error %i: share not available"
+msgstr "Klaida %i: ištekliai nepasiekiami"
+
+#: id:772
+msgctxt "Auto context with id 772"
+msgid "Audio output"
+msgstr "Garso išvestis"
+
+#: id:773
+msgid "Seeking"
+msgstr "Paieška"
+
+#: id:774
+msgid "Slideshow folder"
+msgstr "Papkė prezentacijai"
+
+#: id:775
+msgid "Network interface"
+msgstr "Tinko sąsaja"
+
+#: id:776
+msgid "- Wireless network name (ESSID)"
+msgstr "- Bevielio tinklo pavadinimas (ESSID)"
+
+#: id:777
+msgid "- Wireless password"
+msgstr "- Bevielio tinklo slaptažodis"
+
+#: id:778
+msgid "- Wireless security"
+msgstr "- Bevielio tinklo saugumas"
+
+#: id:779
+msgid "Save and apply network interface settings"
+msgstr "Išsaugoti ir taikyti tinklo sąsają"
+
+#: id:780
+msgid "No encryption"
+msgstr "Be šifravimo"
+
+#: id:781
+msgid "WEP"
+msgstr "WEP"
+
+#: id:782
+msgid "WPA"
+msgstr "WPA"
+
+#: id:783
+msgid "WPA2"
+msgstr "WPA2"
+
+#: id:784
+msgid "Applying network interface settings. Please wait."
+msgstr "Tinklo sąsajos parametrai taikomi, palaukite,..."
+
+#: id:785
+msgid "Network interface restarted successfully."
+msgstr "Tinklo sąsajos sėkmingai paleistos iš naujo"
+
+#: id:786
+msgid "Network interface did not start successfully."
+msgstr "Tinklo sąsajos paleistos nesėkmingai"
+
+#: id:787
+msgid "Interface disabled"
+msgstr "Sąsaja yra išjungta"
+
+#: id:788
+msgid "Network interface disabled successfully."
+msgstr "Tinklo sąsajos sėkmingai atjungtos"
+
+#: id:789
+msgid "Wireless network name (ESSID)"
+msgstr "Bevielio tinklo pavadinimas (ESSID)"
+
+#: id:790
+msgid "Remote control"
+msgstr ""
+
+#: id:791
+msgid "Allow programs on this system to control XBMC"
+msgstr "Įjungti serverio įvikius"
+
+#: id:792
+msgctxt "Auto context with id 792"
+msgid "Port"
+msgstr "Portas"
+
+#: id:793
+msgid "Port range"
+msgstr "Portų diapazonas"
+
+#: id:794
+msgid "Allow programs on other systems to control XBMC"
+msgstr "Leisti prisijungti prie kitų kompiuterių"
+
+#: id:795
+msgid "Initial repeat delay (ms)"
+msgstr "Pirminio porto užlaikymas (ms)"
+
+#: id:796
+msgid "Continuous repeat delay (ms)"
+msgstr "Sekančių portų užlaikymas (ms)"
+
+#: id:797
+msgid "Maximum number of clients"
+msgstr "Maksimalus klientų skaičius"
+
+#: id:798
+msgid "Internet access"
+msgstr "Interneto ryšys"
+
+#: id:850
+msgid "Invalid port number entered"
+msgstr "Neteisingas porto numeris"
+
+#: id:851
+msgid "Valid port range is 1-65535"
+msgstr "Leidžiamas portų diapazonas: 1-65535"
+
+#: id:852
+msgid "Valid port range is 1024-65535"
+msgstr "Leidžiamas portų diapazonas: 1024-65535"
+
+#: id:998
+msgid "Add Music..."
+msgstr "Pridėti Muzika..."
+
+#: id:999
+msgid "Add Videos..."
+msgstr "Pridėti Video..."
+
+#: id:1000
+msgid "- Preview"
+msgstr "- Peržiūra"
+
+#: id:1001
+msgid "Unable to connect"
+msgstr "Neįmanoma prisijungti"
+
+#: id:1002
+msgid "XBMC was unable to connect to the network location."
+msgstr "XBMC negali prisijungti prie tinklo."
+
+#: id:1003
+msgid "This could be due to the network not being connected."
+msgstr "Turbūt tinklas nepajungtas."
+
+#: id:1004
+msgid "Would you like to add it anyway?"
+msgstr "Vistiek pridėti?"
+
+#: id:1006
+msgctxt "Auto context with id 1006"
+msgid "IP address"
+msgstr "IP adresas"
+
+#: id:1007
+msgid "Add network location"
+msgstr "Pridėti tinklo vietą"
+
+#: id:1008
+msgid "Protocol"
+msgstr "Protokolas"
+
+#: id:1009
+msgid "Server address"
+msgstr "Serverio adresas"
+
+#: id:1010
+msgid "Server name"
+msgstr "Serverio vardas"
+
+#: id:1011
+msgid "Remote path"
+msgstr "Tinklo kelias"
+
+#: id:1012
+msgid "Shared folder"
+msgstr "Pasiekiamas aplankalas"
+
+#: id:1013
+msgctxt "Auto context with id 1013"
+msgid "Port"
+msgstr "Portas"
+
+#: id:1014
+msgctxt "Auto context with id 1014"
+msgid "Username"
+msgstr "Vartotojo vardas"
+
+#: id:1015
+msgid "Browse for network server"
+msgstr "Nurodykite serverio tinklą"
+
+#: id:1016
+msgid "Enter the network address of the server"
+msgstr "Įveskite serverio tinklo adresą"
+
+#: id:1017
+msgid "Enter the path on the server"
+msgstr "Nurodykite kelią iki serverio"
+
+#: id:1018
+msgid "Enter the port number"
+msgstr "Įveskite porto numrį"
+
+#: id:1019
+msgid "Enter the username"
+msgstr "Įveskite vartotojo vardą"
+
+#: id:1020
+msgid "Add %s source"
+msgstr "Pridėti šaltinį %s"
+
+#: id:1021
+msgid "Enter the paths or browse for the media locations."
+msgstr "Nurodykite kelią arba pasirinkite failo vietą"
+
+#: id:1022
+msgid "Enter a name for this media Source."
+msgstr "Įveskite pavadinimą šiai bibliotekai"
+
+#: id:1023
+msgid "Browse for new share"
+msgstr "Nurodykite kitą biblioteką"
+
+#: id:1024
+msgid "Browse"
+msgstr "Peržiūra"
+
+#: id:1025
+msgid "Could not retrieve directory information."
+msgstr "Neįmanoma gauti informacijos apie papkę"
+
+#: id:1026
+msgid "Add source"
+msgstr "Pridėti šaltinį"
+
+#: id:1027
+msgid "Edit source"
+msgstr "Keisti šaltinį"
+
+#: id:1028
+msgid "Edit %s source"
+msgstr "Keisti šaltinį %s"
+
+#: id:1029
+msgid "Enter the new label"
+msgstr "Įveskite naują žymą"
+
+#: id:1030
+msgid "Browse for image"
+msgstr "Nurodykite paveikslėlį"
+
+#: id:1031
+msgid "Browse for image folder"
+msgstr "Nurodykite papkę su paveikslėlais"
+
+#: id:1032
+msgid "Add network location..."
+msgstr "Pridėti tinklo vietą..."
+
+#: id:1033
+msgid "Browse for file"
+msgstr "Nurodykite failą"
+
+#: id:1034
+msgid "Submenu"
+msgstr "Submeniu"
+
+#: id:1035
+msgid "Enable submenu buttons"
+msgstr "Įjungti punktus submeniu"
+
+#: id:1036
+msgid "Favourites"
+msgstr "Favoritas"
+
+#: id:1037
+msgid "Video Add-ons"
+msgstr "Video priedai"
+
+#: id:1038
+msgid "Music Add-ons"
+msgstr "Muzikos priedai"
+
+#: id:1039
+msgid "Picture Add-ons"
+msgstr "Foto priedai"
+
+#: id:1040
+msgid "Loading directory"
+msgstr "Atsisiųsti katalogą"
+
+#: id:1041
+msgid "Retrieved %i items"
+msgstr "Atkurta %i objektų(-ai,as)"
+
+#: id:1042
+msgid "Retrieved %i of %i items"
+msgstr "Atkurta %i iš %i objektų(-ai,as)"
+
+#: id:1043
+msgid "Program Add-ons"
+msgstr "Programinės įrangos priedai"
+
+#: id:1044
+msgid "Set plugin thumb"
+msgstr "Sukurti eskizą priedams"
+
+#: id:1045
+msgid "Add-on settings"
+msgstr "Priedų nustatymai"
+
+#: id:1046
+msgid "Access points"
+msgstr "Prieigos taškai"
+
+#: id:1047
+msgid "Other..."
+msgstr "Kita..."
+
+#: id:1048
+msgid "- Username"
+msgstr "Interneto serverio vartotojo vardas"
+
+#: id:1049
+msgid "Script settings"
+msgstr "Skriptų nustatymai"
+
+#: id:1050
+msgid "Singles"
+msgstr "Singlai"
+
+#: id:1051
+msgid "Enter web address"
+msgstr "Įveskite interneto adresą"
+
+#: id:1200
+msgid "SMB client"
+msgstr "SMB vartotojas"
+
+#: id:1202
+msgid "Workgroup"
+msgstr "Darbo grupė"
+
+#: id:1203
+msgid "Default username"
+msgstr "Numatytas vartotojo vardas"
+
+#: id:1204
+msgid "Default password"
+msgstr "Numatytas vartotojo slaptažodis"
+
+#: id:1207
+msgid "WINS server"
+msgstr "WINS serveris"
+
+#: id:1208
+msgid "Mount SMB shares"
+msgstr "Montuoti SMB resursus"
+
+#: id:1210
+msgctxt "Auto context with id 1210"
+msgid "Remove"
+msgstr "Pašalinti"
+
+#: id:1211
+msgctxt "Auto context with id 1211"
+msgid "Music"
+msgstr "Muzika"
+
+#: id:1212
+msgctxt "Auto context with id 1212"
+msgid "Video"
+msgstr "Video"
+
+#: id:1213
+msgctxt "Auto context with id 1213"
+msgid "Pictures"
+msgstr "Foto"
+
+#: id:1214
+msgctxt "Auto context with id 1214"
+msgid "Files"
+msgstr "Failai"
+
+#: id:1215
+msgctxt "Auto context with id 1215"
+msgid "Music & video"
+msgstr "Muzika ir video"
+
+#: id:1216
+msgid "Music & pictures"
+msgstr "Muzika ir foto"
+
+#: id:1217
+msgid "Music & files"
+msgstr "Muzika ir failai"
+
+#: id:1218
+msgid "Video & pictures"
+msgstr "Video ir foto"
+
+#: id:1219
+msgid "Video & files"
+msgstr "Video ir failai"
+
+#: id:1220
+msgid "Pictures & files"
+msgstr "Foto ir failai"
+
+#: id:1221
+msgid "Music & video & pictures"
+msgstr "Muzika, video ir failai"
+
+#: id:1222
+msgid "Music & video & pictures & files"
+msgstr "Muzika, video, foto ir failai"
+
+#: id:1223
+msgctxt "Auto context with id 1223"
+msgid "Disabled"
+msgstr "Atjungta"
+
+#: id:1226
+msgid "Files & music & video"
+msgstr "Failai, muzika ir video"
+
+#: id:1227
+msgid "Files & pictures & music"
+msgstr "Failai, foto ir muzika"
+
+#: id:1228
+msgid "Files & pictures & video"
+msgstr "Failai, foto ir video"
+
+#: id:1229
+msgid "Music & programs"
+msgstr "Muzika ir programos"
+
+#: id:1230
+msgid "Video & programs"
+msgstr "Video ir programos"
+
+#: id:1231
+msgid "Pictures & programs"
+msgstr "Foto ir programos"
+
+#: id:1232
+msgid "Music & video & pictures & programs"
+msgstr "Muzika, video, foto ir programos"
+
+#: id:1233
+msgid "Programs & video & music"
+msgstr "Programos, video ir muzika"
+
+#: id:1234
+msgid "Programs & pictures & music"
+msgstr "Programos, foto ir muzika"
+
+#: id:1235
+msgid "Programs & pictures & video"
+msgstr "Programos, foto ir video"
+
+#: id:1250
+msgid "Auto-detection"
+msgstr "Auto nustatymas"
+
+#: id:1251
+msgid "Auto-detect system"
+msgstr "Auto nustatymas sistemai"
+
+#: id:1252
+msgid "Nickname"
+msgstr "Slapyvardis"
+
+#: id:1254
+msgid "Ask to connect"
+msgstr "Užklausimas leidimui prisijungti"
+
+#: id:1255
+msgid "Send FTP user and password"
+msgstr "Siųsti vartotojo vardą ir slaptažodį FTP"
+
+#: id:1256
+msgid "Ping interval"
+msgstr "Komandos intervalas 'ping'"
+
+#: id:1257
+msgid "Would you like to connect to the auto-detected system?"
+msgstr "Ar norite prisijungti prie rastos sistemos?"
+
+#: id:1259
+msgid "Zeroconf"
+msgstr ""
+
+#: id:1260
+msgid "Announce these services to other systems via Zeroconf"
+msgstr "Pranešti kitoms sisitemoms apie serverius per Zeroconf"
+
+#: id:1270
+msgid "Allow XBMC to receive AirPlay content"
+msgstr "Leisti XBMC gauti AirPlay turinį"
+
+#: id:1271
+msgid "Device name"
+msgstr "Įrenginio pavadinimas"
+
+#: id:1272
+msgid "- Use password protection"
+msgstr "- Naudoti saugų slaptažodį"
+
+#: id:1273
+msgid "AirPlay"
+msgstr ""
+
+#: id:1300
+msgid "Custom audio device"
+msgstr "Kitas audio irenginys"
+
+#: id:1301
+msgid "Custom passthrough device"
+msgstr "Kitas tiesioginio garso išvesties įrenginys"
+
+#: id:1396
+msgid "Drifting"
+msgstr "Plikledis"
+
+#: id:1397
+msgid "and"
+msgstr "ir"
+
+#: id:1398
+msgid "Freezing"
+msgstr "Šalna"
+
+#: id:1399
+msgid "Late"
+msgstr "Vėlyvas"
+
+#: id:1400
+msgid "Isolated"
+msgstr "Vietomis"
+
+#: id:1401
+msgid "Thundershowers"
+msgstr "Lietus su perkūnija"
+
+#: id:1402
+msgid "Thunder"
+msgstr "Griaustinis"
+
+#: id:1403
+msgctxt "Auto context with id 1403"
+msgid "Sun"
+msgstr "Saulė"
+
+#: id:1404
+msgid "Heavy"
+msgstr "Stiprus"
+
+#: id:1405
+msgid "in"
+msgstr "į"
+
+#: id:1406
+msgid "the"
+msgstr "..."
+
+#: id:1407
+msgid "Vicinity"
+msgstr "Aplink"
+
+#: id:1408
+msgid "Ice"
+msgstr "Ledas"
+
+#: id:1409
+msgid "Crystals"
+msgstr "Kruša"
+
+#: id:1410
+msgid "Calm"
+msgstr "Ramu"
+
+#: id:1411
+msgid "with"
+msgstr "iš"
+
+#: id:1412
+msgid "windy"
+msgstr "vėjuota"
+
+#: id:1413
+msgid "drizzle"
+msgstr "lietus"
+
+#: id:1414
+msgid "Thunderstorm"
+msgstr "Audra"
+
+#: id:1415
+msgid "Drizzle"
+msgstr "Lietus"
+
+#: id:1416
+msgid "Foggy"
+msgstr "Rūkas"
+
+#: id:1417
+msgid "Grains"
+msgstr "Speiguota"
+
+#: id:1418
+msgid "T-Storms"
+msgstr "Perkūnija"
+
+#: id:1419
+msgid "T-Showers"
+msgstr "Perkūnija su lietumi"
+
+#: id:1420
+msgid "Moderate"
+msgstr "Ramus"
+
+#: id:1421
+msgid "Very High"
+msgstr "Labai Aukštas"
+
+#: id:1422
+msgid "Windy"
+msgstr "Vėjuota"
+
+#: id:1423
+msgid "Mist"
+msgstr "Rūkas"
+
+#: id:1450
+msgid "Put display to sleep when idle"
+msgstr "Prastovos metu taupyti energiją"
+
+#: id:2050
+msgid "Runtime"
+msgstr "Trukmė"
+
+#: id:2100
+msgid "Script failed! : %s"
+msgstr "Skriptas nesėkmingas! : %s"
+
+#: id:2101
+msgid "Newer version needed - See log"
+msgstr "Reikalinga naujesnė versija - Žiurėkite žurnalą"
+
+#: id:4501
+msgid "Enable LCD/VFD"
+msgstr "Įjungti LCD/VFD displėjų"
+
+#: id:10000
+msgid "Home"
+msgstr "Pagrindinis"
+
+#: id:10001
+msgctxt "Auto context with id 10001"
+msgid "Programs"
+msgstr "Programos"
+
+#: id:10002
+msgctxt "Auto context with id 10002"
+msgid "Pictures"
+msgstr "Foto"
+
+#: id:10003
+msgctxt "Auto context with id 10003"
+msgid "File manager"
+msgstr "Failų tvarkyklė"
+
+#: id:10004
+msgctxt "Auto context with id 10004"
+msgid "Settings"
+msgstr "Nustatymai"
+
+#: id:10005
+msgctxt "Auto context with id 10005"
+msgid "Music"
+msgstr "Muzika"
+
+#: id:10006
+msgctxt "Auto context with id 10006"
+msgid "Videos"
+msgstr "Video"
+
+#: id:10007
+msgid "System information"
+msgstr "Informacija apie sistemą"
+
+#: id:10008
+msgid "Settings - General"
+msgstr "Nustatymai - Pagrindiniai"
+
+#: id:10009
+msgid "Settings - Screen"
+msgstr "Nustatymai - Ekranas"
+
+#: id:10010
+msgid "Settings - Appearance - GUI Calibration"
+msgstr "Nustatymai - Išvaizda - GUI kalibruotė"
+
+#: id:10011
+msgid "Settings - Videos - Screen Calibration"
+msgstr "Nustatymai - Video - Ekrano kalibruotė"
+
+#: id:10012
+msgid "Settings - Pictures"
+msgstr "Nustatymai - Foto"
+
+#: id:10013
+msgid "Settings - Programs"
+msgstr "Nustatymai - Programos"
+
+#: id:10014
+msgid "Settings - Weather"
+msgstr "Nustatymai - Oras"
+
+#: id:10015
+msgid "Settings - Music"
+msgstr "Nustatymai - Muzika"
+
+#: id:10016
+msgid "Settings - System"
+msgstr "Nustatymai - Sistema"
+
+#: id:10017
+msgid "Settings - Videos"
+msgstr "Nustatymai - Video"
+
+#: id:10018
+msgid "Settings - Network"
+msgstr "Nustatymai - Tinklas"
+
+#: id:10019
+msgid "Settings - Appearance"
+msgstr "Nustatymai - Išvaizda"
+
+#: id:10020
+msgctxt "Auto context with id 10020"
+msgid "Scripts"
+msgstr "Skriptai"
+
+#: id:10021
+msgid "Web Browser"
+msgstr "Interneto Naršyklė"
+
+#: id:10025
+msgctxt "Auto context with id 10025"
+msgid "Videos"
+msgstr ""
+
+#: id:10028
+msgid "Videos/Playlist"
+msgstr "Video/Grojaraštis"
+
+#: id:10029
+msgctxt "Auto context with id 10029"
+msgid "Login screen"
+msgstr "Prisijungimo langas"
+
+#: id:10034
+msgid "Settings - Profiles"
+msgstr "Nustatymai - Profilis"
+
+#: id:10040
+msgid "Addon browser"
+msgstr "Priedų naršyklė"
+
+#: id:10100
+msgid "Yes/No dialog"
+msgstr "Dialogas 'Taip/Ne'"
+
+#: id:10101
+msgid "Progress dialog"
+msgstr "Dialogas Vykdymas"
+
+#: id:10210
+msgid "Looking for subtitles..."
+msgstr "Subtitrų paieška..."
+
+#: id:10211
+msgid "Looking for or caching subtitles..."
+msgstr "Paieška arba subtitrų buferizacija..."
+
+#: id:10212
+msgid "terminating"
+msgstr "užbaigimas"
+
+#: id:10213
+msgid "buffering"
+msgstr "buferizacija"
+
+#: id:10214
+msgid "Opening stream"
+msgstr "Srauto atidarymas"
+
+#: id:10500
+msgid "Music/Playlist"
+msgstr "Muzika/Grojaraštis"
+
+#: id:10501
+msgid "Music/Files"
+msgstr "Muzika/Failai"
+
+#: id:10502
+msgid "Music/Library"
+msgstr "Muzika/Biblioteka"
+
+#: id:10503
+msgid "Playlist editor"
+msgstr "Bibliotekos redagavimas"
+
+#: id:10504
+msgid "Top 100 songs"
+msgstr "Top 100 - Dainos"
+
+#: id:10505
+msgid "Top 100 albums"
+msgstr "Top 100 - Albumai"
+
+#: id:10506
+msgctxt "Auto context with id 10506"
+msgid "Programs"
+msgstr "Programos"
+
+#: id:10507
+msgid "Configuration"
+msgstr "Profilio nustatymai"
+
+#: id:10508
+msgid "Weather forecast"
+msgstr "Orai"
+
+#: id:10509
+msgid "Network gaming"
+msgstr "Tinklo žaidimas"
+
+#: id:10510
+msgid "Extensions"
+msgstr "Žymos"
+
+#: id:10511
+msgctxt "Auto context with id 10511"
+msgid "System info"
+msgstr "Informacija apie sistemą"
+
+#: id:10516
+msgid "Music - Library"
+msgstr "Muzika - Biblioteka"
+
+#: id:10517
+msgid "Now Playing - Music"
+msgstr "Muzika - Dabartinė biblioteka"
+
+#: id:10522
+msgid "Now Playing - Videos"
+msgstr "Video - Dabartinė biblioteka"
+
+#: id:10523
+msgid "Album info"
+msgstr "Informacija apie albumą"
+
+#: id:10524
+msgid "Movie info"
+msgstr "Informacija apie filmą"
+
+#: id:12000
+msgid "Select dialog"
+msgstr "Pasirinkimo dialogas"
+
+#: id:12001
+msgid "Music/Info"
+msgstr "Muzika/Duomenys"
+
+#: id:12002
+msgid "Dialog OK"
+msgstr "Dialogas 'Ok'"
+
+#: id:12003
+msgid "Videos/Info"
+msgstr "Video/Duomenys"
+
+#: id:12004
+msgid "Scripts/Info"
+msgstr "Skriptai/Duomenys"
+
+#: id:12005
+msgid "Fullscreen video"
+msgstr "Pilnaekranis video"
+
+#: id:12006
+msgid "Audio visualization"
+msgstr "Audio vizualūs efektai"
+
+#: id:12008
+msgid "File stacking dialog"
+msgstr "Dialogas failų sekai"
+
+#: id:12009
+msgid "Rebuild index..."
+msgstr "Perindeksavimas..."
+
+#: id:12010
+msgid "Return to music window"
+msgstr "Gryžti į skirsnį Muzika"
+
+#: id:12011
+msgid "Return to videos window"
+msgstr "Gryžti į skirsnį Video"
+
+#: id:12021
+msgid "Start from beginning"
+msgstr "Pradėti nuo pradžios"
+
+#: id:12022
+msgid "Resume from %s"
+msgstr "Tęsti nuo %s"
+
+#: id:12310
+msgid "0"
+msgstr "0"
+
+#: id:12311
+msgid "1"
+msgstr "1"
+
+#: id:12312
+msgid "2"
+msgstr "2"
+
+#: id:12313
+msgid "3"
+msgstr "3"
+
+#: id:12314
+msgid "4"
+msgstr "4"
+
+#: id:12315
+msgid "5"
+msgstr "5"
+
+#: id:12316
+msgid "6"
+msgstr "6"
+
+#: id:12317
+msgid "7"
+msgstr "7"
+
+#: id:12318
+msgid "8"
+msgstr "8"
+
+#: id:12319
+msgid "9"
+msgstr "9"
+
+#: id:12320
+msgid "c"
+msgstr "c"
+
+#: id:12321
+msgid "Ok"
+msgstr "Ok"
+
+#: id:12322
+msgid "*"
+msgstr "*"
+
+#: id:12325
+msgid "Locked! Enter code..."
+msgstr "Užblokuota! Įveskite kodą..."
+
+#: id:12326
+msgid "Enter password"
+msgstr "Įveskite slaptažodį"
+
+#: id:12327
+msgid "Enter master code"
+msgstr "Įveskite apsaugos kodą"
+
+#: id:12328
+msgid "Enter unlock code"
+msgstr "Įveskite atblokavimo kodą"
+
+#: id:12329
+msgid "or press C to cancel"
+msgstr "arba pasirinkite 'C' atšaukimui"
+
+#: id:12330
+msgid "Enter gamepad button combo and"
+msgstr "Paspauskite reikalingus mygtukus žaidimų svirtyje,"
+
+#: id:12331
+msgid "press OK, or Back to cancel"
+msgstr "tada 'OK', arba 'Atgal' atšaukimui"
+
+#: id:12332
+msgid "Set lock"
+msgstr "Nustatyti apsaugą"
+
+#: id:12333
+msgid "Unlock"
+msgstr "Atblokuoti"
+
+#: id:12334
+msgid "Reset lock"
+msgstr "Atmesti apsaugą"
+
+#: id:12335
+msgid "Remove lock"
+msgstr "Išvalyti apsaugą"
+
+#: id:12337
+msgid "Numeric password"
+msgstr "Skaitmeninis slaptažodis"
+
+#: id:12338
+msgid "Gamepad button combo"
+msgstr "Mygtukų kombinacija žaidimų svirtyje"
+
+#: id:12339
+msgid "Full-text password"
+msgstr "Tekstinis slaptažodis"
+
+#: id:12340
+msgid "Enter new password"
+msgstr "Įveskite naują slaptažodį"
+
+#: id:12341
+msgid "Re-Enter new password"
+msgstr "Pakartokite naują slaptažodį"
+
+#: id:12342
+msgid "Incorrect password,"
+msgstr "Netikras slaptažodis,"
+
+#: id:12343
+msgid "retries left"
+msgstr "liko bandymų"
+
+#: id:12344
+msgid "Passwords entered did not match."
+msgstr "Įvesti slaptažodžiai nesutampa."
+
+#: id:12345
+msgid "Access denied"
+msgstr "Priėjimas draudžiamas"
+
+#: id:12346
+msgid "Password retry limit exceeded."
+msgstr "Slaptažodžių bandymų skaičius išnaudotas."
+
+#: id:12347
+msgid "The system will now shut off."
+msgstr "Dabar sistema bus išjungta."
+
+#: id:12348
+msgid "Item locked"
+msgstr "Užblokuota"
+
+#: id:12353
+msgid "Reactivate lock"
+msgstr "Reaktyvuoti apsaugą"
+
+#: id:12356
+msgid "Change lock"
+msgstr "Keisti apsaugą"
+
+#: id:12357
+msgid "Source lock"
+msgstr "Apsaugos šaltinis"
+
+#: id:12358
+msgid "Password entry was blank. Try again."
+msgstr "Slaptažodžio laukas tuščias. Pakartokite."
+
+#: id:12360
+msgid "Master lock"
+msgstr "Bendra apsauga"
+
+#: id:12362
+msgid "Shutdown system if Master Lock retries exceeded"
+msgstr "Išjungite sistemą,jei bandymų skaičius yra išnaudotas"
+
+#: id:12367
+msgid "Master code is not valid"
+msgstr "Apsaugos kodas neteisingas!"
+
+#: id:12368
+msgid "Please enter a valid master code"
+msgstr "Įveskite teisingą apsaugos kodą!"
+
+#: id:12373
+msgid "Settings & file manager"
+msgstr "Parametrai ir failų tvarkyklė"
+
+#: id:12376
+msgid "Set as default for all movies"
+msgstr "Nustatyti visiems filmams"
+
+#: id:12377
+msgid "This will reset any previously saved values"
+msgstr "Tai pakeis anksčiau nustatytus parametrus."
+
+#: id:12378
+msgid "Amount of time to display each image"
+msgstr "Kiekvienos prezentacijos rodymo laikas"
+
+#: id:12379
+msgid "Use pan and zoom effects"
+msgstr "Panoramos ir didinimo efektai"
+
+#: id:12383
+msgid "12 hour clock"
+msgstr "12-kos valandų"
+
+#: id:12384
+msgid "24 hour clock"
+msgstr "24-rių valandų"
+
+#: id:12385
+msgid "Day/Month"
+msgstr "Diena/Mėnuo"
+
+#: id:12386
+msgid "Month/Day"
+msgstr "Mėnuo/Diena"
+
+#: id:12390
+msgid "System uptime"
+msgstr "Sistemos veikimo laikas"
+
+#: id:12391
+msgid "Minutes"
+msgstr "Min."
+
+#: id:12392
+msgid "Hours"
+msgstr "Val."
+
+#: id:12393
+msgid "Days"
+msgstr "Dien."
+
+#: id:12394
+msgid "Total uptime"
+msgstr "Bendras veikimo laikas"
+
+#: id:12395
+msgid "Battery level"
+msgstr "Baterijos lygis"
+
+#: id:12600
+msgctxt "Auto context with id 12600"
+msgid "Weather"
+msgstr "Oras"
+
+#: id:12900
+msgctxt "Auto context with id 12900"
+msgid "Screensaver"
+msgstr "Užsklanda"
+
+#: id:12901
+msgid "Fullscreen OSD"
+msgstr "Pilnaekranis OSD"
+
+#: id:13000
+msgid "System"
+msgstr "Sistema"
+
+#: id:13001
+msgid "Immediate HD spindown"
+msgstr "Greitas HDD sustabdymas"
+
+#: id:13002
+msgid "Video only"
+msgstr "Tiktai video"
+
+#: id:13003
+msgid "- Delay"
+msgstr "- Užlaikymas"
+
+#: id:13004
+msgid "- Minimum file duration"
+msgstr "- Minimali failo trukmė"
+
+#: id:13005
+msgid "Shutdown"
+msgstr "Išjungimas"
+
+#: id:13008
+msgid "Shutdown function"
+msgstr "Išjungimo režimas"
+
+#: id:13009
+msgid "Quit"
+msgstr "Išėjimas"
+
+#: id:13010
+msgid "Hibernate"
+msgstr "Miego rėžimas"
+
+#: id:13011
+msgid "Suspend"
+msgstr "Laukimo rėžimas"
+
+#: id:13012
+msgid "Exit"
+msgstr "Išjungti XBMC"
+
+#: id:13013
+msgid "Reboot"
+msgstr "Perkrauti kompiuterį"
+
+#: id:13014
+msgid "Minimize"
+msgstr "Suglausti"
+
+#: id:13015
+msgid "Power button action"
+msgstr "Jungties veiksmas"
+
+#: id:13016
+msgid "Power off System"
+msgstr "Išjungti sistemą"
+
+#: id:13020
+msgid "Is another session active, perhaps over ssh?"
+msgstr "Aktyvi kita sesija, gal per SSH?"
+
+#: id:13021
+msgid "Mounted removable harddrive"
+msgstr "Prijungtas nešiojamas HDD"
+
+#: id:13022
+msgid "Unsafe device removal"
+msgstr "Nesaugus įrenginio atjungimas"
+
+#: id:13023
+msgid "Successfully removed device"
+msgstr "Prietaisas sėkmingai atjungtas"
+
+#: id:13024
+msgid "Joystick plugged"
+msgstr "Žaidimų svirtis prijungta"
+
+#: id:13025
+msgid "Joystick unplugged"
+msgstr "Žaidimų svirtis atjungta"
+
+#: id:13050
+msgid "Running low on battery"
+msgstr "Žemas baterijos lygis"
+
+#: id:13100
+msgid "Flicker filter"
+msgstr "Mirgėjimo filtras"
+
+#: id:13101
+msgid "Let driver choose (requires restart)"
+msgstr "Tvarkyklių pasirinkimas (būtinas perkrovimas)"
+
+#: id:13105
+msgid "Vertical blank sync"
+msgstr "Vertikali sinchronizacija"
+
+#: id:13106
+msgctxt "Auto context with id 13106"
+msgid "Disabled"
+msgstr "Atjungta"
+
+#: id:13107
+msgid "Enabled during video playback"
+msgstr "Tik tada, kai video paleista"
+
+#: id:13108
+msgctxt "Auto context with id 13108"
+msgid "Always enabled"
+msgstr "Visada įjungta"
+
+#: id:13109
+msgid "Test & apply resolution"
+msgstr "Patikra ir rezoliucijos pritaikymas"
+
+#: id:13110
+msgid "Save resolution?"
+msgstr "Išsaugoti rezoliuciją?"
+
+#: id:13111
+msgid "Would you like to keep this resolution?"
+msgstr "Jūs norite palikti šią rezoliuciją?"
+
+#: id:13112
+msgid "High quality upscaling"
+msgstr "Aukštos kokybės mastelis"
+
+#: id:13113
+msgctxt "Auto context with id 13113"
+msgid "Disabled"
+msgstr "Atjungta"
+
+#: id:13114
+msgid "Enabled for SD content"
+msgstr "Tiktai dėl SD turinio"
+
+#: id:13115
+msgctxt "Auto context with id 13115"
+msgid "Always enabled"
+msgstr "Visada įjungta"
+
+#: id:13116
+msgid "Upscaling method"
+msgstr "Mastelio metodas"
+
+#: id:13117
+msgctxt "Auto context with id 13117"
+msgid "Bicubic"
+msgstr "Bicubic"
+
+#: id:13118
+msgid "Lanczos"
+msgstr "Lanczos"
+
+#: id:13119
+msgid "Sinc"
+msgstr "Sinc"
+
+#: id:13120
+msgctxt "Auto context with id 13120"
+msgid "VDPAU"
+msgstr "VDPAU"
+
+#: id:13121
+msgid "VDPAU HQ Upscaling level"
+msgstr "VDPAU HQ kokybės mastelis"
+
+#: id:13122
+msgid "VDPAU Studio level color conversion"
+msgstr "VDPAU spalvų konvertavimas"
+
+#: id:13130
+msgid "Blank other displays"
+msgstr "Ekrano užsklanda"
+
+#: id:13131
+msgctxt "Auto context with id 13131"
+msgid "Disabled"
+msgstr "Atjungta"
+
+#: id:13132
+msgid "Blank displays"
+msgstr "Užtemdyti ekranus"
+
+#: id:13140
+msgid "Active connections detected!"
+msgstr "Rastos aktyvios jungtys!"
+
+#: id:13141
+msgid "If you proceed, you might not be able to control XBMC"
+msgstr "Jei tęsite, Jūs prarasite sugebėjimą valdyti"
+
+#: id:13142
+msgid "any longer. Are you sure you want to stop the Event server?"
+msgstr "XBMC. Ar tikrai norite sustabdyti serverio įvykius?"
+
+#: id:13144
+msgid "Change Apple Remote mode?"
+msgstr "Redaguoti Apple pultelio režimą?"
+
+#: id:13145
+msgid "If you are currently using the Apple Remote to control"
+msgstr "Jeigu Jūs naudojate Apple pultelį"
+
+#: id:13146
+msgid "XBMC, changing this setting might affect your ability"
+msgstr "XBMC valdymui, šių nustatymų pakeitimas gali atjungti"
+
+#: id:13147
+msgid "to continue controlling it. Do you want to proceed?"
+msgstr "galimybe jais naudotis. Jūs norite tęsti?"
+
+#: id:13159
+msgid "Subnet mask"
+msgstr "Potinklio kaukė"
+
+#: id:13160
+msgid "Gateway"
+msgstr "Tinklo sąsaja"
+
+#: id:13161
+msgid "Primary DNS"
+msgstr "Pagrindinis DNS"
+
+#: id:13162
+msgid "Initialize failed"
+msgstr "Inicializacijos klaida"
+
+#: id:13170
+msgctxt "Auto context with id 13170"
+msgid "Never"
+msgstr "Niekada"
+
+#: id:13171
+msgid "Immediately"
+msgstr "Nedelsiant"
+
+#: id:13172
+msgid "After %i secs"
+msgstr "Po %i sek."
+
+#: id:13173
+msgid "HDD install date:"
+msgstr "HDD įjungimo laikas:"
+
+#: id:13174
+msgid "HDD power cycle count:"
+msgstr "HDD įjungimo ciklų skaičius:"
+
+#: id:13200
+msgid "Profiles"
+msgstr "Profiliai"
+
+#: id:13201
+msgid "Delete profile '%s'?"
+msgstr "Pašalinti profilį '%s'?"
+
+#: id:13204
+msgid "Last loaded profile:"
+msgstr "Paskutinis įkeltas profilis:"
+
+#: id:13205
+msgid "Unknown"
+msgstr "Nežinoma"
+
+#: id:13206
+msgid "Overwrite"
+msgstr "Perrašyti"
+
+#: id:13208
+msgid "Alarm clock"
+msgstr "Priminimo laikmatis"
+
+#: id:13209
+msgid "Alarm clock interval (in minutes)"
+msgstr "Laikmačio priminimo intervalas (min.)"
+
+#: id:13210
+msgid "Started, alarm in %im"
+msgstr "Paleistas, suveiks %im"
+
+#: id:13211
+msgid "Alarm!"
+msgstr "PRIMINIMAS!"
+
+#: id:13212
+msgid "Canceled with %im%is left"
+msgstr "Atšaukiama %im%is iki suveikimo"
+
+#: id:13213
+msgid "%2.0fm"
+msgstr "%2.0fm"
+
+#: id:13214
+msgid "%2.0fs"
+msgstr "%2.0fs"
+
+#: id:13249
+msgid "Search for subtitles in RARs"
+msgstr "Ieškoti subtitrų RARe"
+
+#: id:13250
+msgid "Browse for subtitle..."
+msgstr "Nurodykite subtitrus..."
+
+#: id:13251
+msgid "Move item"
+msgstr "Perkelti objektą"
+
+#: id:13252
+msgid "Move item here"
+msgstr "Perkelti objektą čia"
+
+#: id:13253
+msgid "Cancel move"
+msgstr "Atšaukti perkėlimą"
+
+#: id:13270
+msgid "Hardware:"
+msgstr "Įranga:"
+
+#: id:13271
+msgid "CPU Usage:"
+msgstr "CPU apkrova:"
+
+#: id:13274
+msgid "Connected, but no DNS is available."
+msgstr "Prijungta, bet DNS severis nepasiekiamas"
+
+#: id:13275
+msgid "Hard Disk"
+msgstr "HDD"
+
+#: id:13276
+msgid "DVD-ROM"
+msgstr "DVD grotuvas"
+
+#: id:13277
+msgctxt "Auto context with id 13277"
+msgid "Storage"
+msgstr "Saugykla"
+
+#: id:13278
+msgctxt "Auto context with id 13278"
+msgid "Default"
+msgstr "Numatytas"
+
+#: id:13279
+msgctxt "Auto context with id 13279"
+msgid "Network"
+msgstr "Tinklas"
+
+#: id:13280
+msgctxt "Auto context with id 13280"
+msgid "Video"
+msgstr "Video"
+
+#: id:13281
+msgid "Hardware"
+msgstr "Įranga"
+
+#: id:13283
+msgid "Operating system:"
+msgstr "Operacinė sistema:"
+
+#: id:13284
+msgid "CPU speed:"
+msgstr "CPU dažnis:"
+
+#: id:13286
+msgid "Video encoder:"
+msgstr "Video dekoderis:"
+
+#: id:13287
+msgid "Screen resolution:"
+msgstr "Ekrano raiška:"
+
+#: id:13292
+msgid "A/V cable:"
+msgstr "A/V kabelis:"
+
+#: id:13294
+msgid "DVD region:"
+msgstr "DVD regionas:"
+
+#: id:13295
+msgid "Internet:"
+msgstr "Internetas:"
+
+#: id:13296
+msgctxt "Auto context with id 13296"
+msgid "Connected"
+msgstr "Prijungta"
+
+#: id:13297
+msgid "Not connected. Check network settings."
+msgstr "Neprijungta. Patikrinkite tinklo nustatymus."
+
+#: id:13299
+msgid "Target temperature"
+msgstr "Išlaikyti temperatūrą"
+
+#: id:13300
+msgid "Fan speed"
+msgstr "Aušintuvo greitis"
+
+#: id:13301
+msgid "Auto temperature control"
+msgstr "Automatinė temperatūros kontrolė"
+
+#: id:13302
+msgid "Fan speed override"
+msgstr "Aušintuvo greitčio konrtolė"
+
+#: id:13303
+msgid "- Fonts"
+msgstr "- Šrifto apiforminimas"
+
+#: id:13304
+msgid "Enable flipping bi-directional strings"
+msgstr "Leisti eilutes priešinga kryptimi"
+
+#: id:13305
+msgid "Show RSS news feeds"
+msgstr "Įjungti RSS naujienas"
+
+#: id:13306
+msgid "Show parent folder items"
+msgstr "Slėpti piktogramą į aukštesnio lygio perėjimą"
+
+#: id:13307
+msgid "Track naming template"
+msgstr "Takelio pavadinimo šablonas"
+
+#: id:13308
+msgid "Do you wish to reboot your system"
+msgstr "Jūs norite perkrauti sistemą"
+
+#: id:13309
+msgid "instead of just XBMC?"
+msgstr "vietoj XBMC perkrovimo?"
+
+#: id:13310
+msgid "Zoom effect"
+msgstr "Didinimo efektas"
+
+#: id:13311
+msgid "Float effect"
+msgstr "Flotacinis efektas"
+
+#: id:13312
+msgid "Black bar reduction"
+msgstr "Juodų juostų sumažinimas"
+
+#: id:13313
+msgid "Restart"
+msgstr "Perkrauti sistemą"
+
+#: id:13314
+msgid "Crossfade between songs"
+msgstr "Takelių perėjimo laikas"
+
+#: id:13315
+msgid "Regenerate thumbnails"
+msgstr "Atnaujinti eskizus"
+
+#: id:13316
+msgid "Recursive thumbnails"
+msgstr "Eskizų rekursavimas"
+
+#: id:13317
+msgid "View slideshow"
+msgstr "Prezentacijos peržiūra"
+
+#: id:13318
+msgid "Recursive slideshow"
+msgstr "Prezentacijos rekursavimas"
+
+#: id:13319
+msgid "Randomize"
+msgstr "Atsitiktiniai"
+
+#: id:13320
+msgid "Stereo"
+msgstr "Stereo"
+
+#: id:13321
+msgid "Left only"
+msgstr "Kairys"
+
+#: id:13322
+msgid "Right only"
+msgstr "Dešinys"
+
+#: id:13323
+msgid "Enable karaoke support"
+msgstr "Leisti karaoke palaikymą (CD+G)"
+
+#: id:13324
+msgid "Background transparency"
+msgstr "Fono skaidrumas"
+
+#: id:13325
+msgid "Foreground transparency"
+msgstr "Teksto skaidrumas"
+
+#: id:13326
+msgid "A/V delay"
+msgstr "Garso vėlinimas vaizdo atžvilgiu"
+
+#: id:13327
+msgid "Karaoke"
+msgstr "Karaoke"
+
+#: id:13328
+msgid "%s not found"
+msgstr "%s nerastas"
+
+#: id:13329
+msgid "Error opening %s"
+msgstr "Atydarimo klaida %s"
+
+#: id:13330
+msgid "Unable to load %s"
+msgstr "Nepavyko įkelti %s"
+
+#: id:13331
+msgid "Error: Out of memory"
+msgstr "Klaida: neužtenka atminties"
+
+#: id:13332
+msgid "Move up"
+msgstr "Perkelti į viršų"
+
+#: id:13333
+msgid "Move down"
+msgstr "Perkelti į apačią"
+
+#: id:13334
+msgid "Edit label"
+msgstr "Pakeisti žymę"
+
+#: id:13335
+msgid "Make default"
+msgstr "Pagal nutilėjimą"
+
+#: id:13336
+msgid "Remove button"
+msgstr "Nuimti mygtuką"
+
+#: id:13340
+msgid "Leave as is"
+msgstr "Palikti kaip yra"
+
+#: id:13341
+msgid "Green"
+msgstr "Žalias"
+
+#: id:13342
+msgid "Orange"
+msgstr "Oranžinis"
+
+#: id:13343
+msgid "Red"
+msgstr "Raudonas"
+
+#: id:13344
+msgid "Cycle"
+msgstr "Ciklinis"
+
+#: id:13345
+msgid "Switch LED off on playback"
+msgstr "Perjungti LED atkūrimo metu"
+
+#: id:13346
+msgctxt "Auto context with id 13346"
+msgid "Movie information"
+msgstr "Duomenys apie filmą"
+
+#: id:13347
+msgid "Queue item"
+msgstr "Elemento eilė"
+
+#: id:13348
+msgid "Search IMDb..."
+msgstr "Rasti IMDb..."
+
+#: id:13349
+msgid "Scan for new content"
+msgstr "Nuskaityti naują turinį"
+
+#: id:13350
+msgid "Now playing..."
+msgstr "Aktualus grojaraštis..."
+
+#: id:13351
+msgctxt "Auto context with id 13351"
+msgid "Album information"
+msgstr "Duomenys apie albumą"
+
+#: id:13352
+msgid "Scan item to library"
+msgstr "Nuskaityti į biblioteką"
+
+#: id:13353
+msgid "Stop scanning"
+msgstr "Sustabdyti skaitymą"
+
+#: id:13354
+msgctxt "Auto context with id 13354"
+msgid "Render method"
+msgstr "Apdirbimo metodas"
+
+#: id:13355
+msgid "Low quality pixel shader"
+msgstr "Žemos kokybės Pixel Shader"
+
+#: id:13356
+msgid "Hardware overlays"
+msgstr "Aparatūros derinimas"
+
+#: id:13357
+msgid "High quality pixel shader"
+msgstr "Aukštos kokybės Pixel Shader"
+
+#: id:13358
+msgid "Play item"
+msgstr "Atkūrti objektą"
+
+#: id:13359
+msgid "Set artist thumb"
+msgstr "Įdiegti atlikėjo eskizą"
+
+#: id:13360
+msgid "Automatically generate thumbnails"
+msgstr "Kurti eskizus"
+
+#: id:13361
+msgid "Enable voice"
+msgstr "Įjungti mikrofoną"
+
+#: id:13375
+msgid "Enable device"
+msgstr "Įjungti prietaisą"
+
+#: id:13376
+msgid "Volume"
+msgstr "Garsas"
+
+#: id:13377
+msgid "Default view mode"
+msgstr "Pagrindinis peržiūros režimas"
+
+#: id:13378
+msgid "Default brightness"
+msgstr "Standartinis ryškumas"
+
+#: id:13379
+msgid "Default contrast"
+msgstr "Standartinis kontrastas"
+
+#: id:13380
+msgid "Default gamma"
+msgstr "Standartinė gama"
+
+#: id:13381
+msgid "Resume video"
+msgstr "Tęsti video"
+
+#: id:13382
+msgid "Voice mask - Port 1"
+msgstr "Balso keitimas - 1"
+
+#: id:13383
+msgid "Voice mask - Port 2"
+msgstr "Balso keitimas - 2"
+
+#: id:13384
+msgid "Voice mask - Port 3"
+msgstr "Balso keitimas - 3"
+
+#: id:13385
+msgid "Voice mask - Port 4"
+msgstr "Balso keitimas - 4"
+
+#: id:13386
+msgid "Use time based seeking"
+msgstr "Pozicijonavimas laike"
+
+#: id:13387
+msgid "Track naming template - right"
+msgstr "Dešnė kolonėlė sąraše"
+
+#: id:13388
+msgid "Preset"
+msgstr "Išankstinis diegimas"
+
+#: id:13389
+msgid "There are no presets available\nfor this visualization"
+msgstr "Šiai vizualizacijai išankstinių nustatymų nėra\nši vizualizacija"
+
+#: id:13390
+msgid "There are no settings available\nfor this visualization"
+msgstr "Šiai vizualizacijai parametrų nėra\nši vizualizacija"
+
+#: id:13391
+msgid "Eject/Load"
+msgstr "Atidaryti/Uždaryti"
+
+#: id:13392
+msgid "Use visualization if playing audio"
+msgstr "Paleisti vizualizaciją kai groja muzika"
+
+#: id:13393
+msgid "Calculate size"
+msgstr "Apskaičiuoti dydį"
+
+#: id:13394
+msgid "Calculating folder size"
+msgstr "Papkės dydžio apskaičiavimas"
+
+#: id:13395
+msgid "Video settings"
+msgstr "Video nustatymai"
+
+#: id:13396
+msgid "Audio and subtitle settings"
+msgstr "Subtitrų ir garso nustatymai"
+
+#: id:13397
+msgid "Enable subtitles"
+msgstr "Įjungti subtitrus"
+
+#: id:13398
+msgctxt "Auto context with id 13398"
+msgid "Shortcuts"
+msgstr "Etiketės"
+
+#: id:13399
+msgid "Ignore articles when sorting (e.g. \"the\")"
+msgstr "Ignoruoti (e.g. \"the\")"
+
+#: id:13400
+msgid "Crossfade between songs on the same album"
+msgstr "Sklandus perėjimas prie kito takelio"
+
+#: id:13401
+msgid "Browse for %s"
+msgstr "Paieška %s"
+
+#: id:13402
+msgid "Show track position"
+msgstr "Rodyti takelio poziciją"
+
+#: id:13403
+msgid "Clear default"
+msgstr "Skaidrus numatytas"
+
+#: id:13404
+msgid "Resume"
+msgstr "Tęsti"
+
+#: id:13405
+msgid "Get thumb"
+msgstr "Gauti eskizą"
+
+#: id:13406
+msgid "Picture information"
+msgstr "Duomenys apie foto"
+
+#: id:13407
+msgid "%s presets"
+msgstr "%s priešnustatymai"
+
+#: id:13408
+msgid "(IMDb user rating)"
+msgstr "(Vartotojų reitingas IMDb)"
+
+#: id:13409
+msgid "Top 250"
+msgstr "Top 250"
+
+#: id:13410
+msgid "Tune in on Last.fm"
+msgstr "Nustatymai Last.fm"
+
+#: id:13411
+msgid "Minimum fan speed"
+msgstr "Minimalus aušintuvo greitis"
+
+#: id:13412
+msgid "Play from here"
+msgstr "Groti čia"
+
+#: id:13413
+msgid "Downloading"
+msgstr "Parsisiuntimas"
+
+#: id:13414
+msgid "Include artists who appear only on compilations"
+msgstr "Nerodyti atlikėjų, rinkinuose"
+
+#: id:13415
+msgctxt "Auto context with id 13415"
+msgid "Render method"
+msgstr "Apdirbimo metodas"
+
+#: id:13416
+msgid "Auto detect"
+msgstr "Auto nustatymas"
+
+#: id:13417
+msgid "Basic shaders (ARB)"
+msgstr "Pagrindiniai pikseliniai šešėliai (ARB)"
+
+#: id:13418
+msgid "Advanced shaders (GLSL)"
+msgstr "Papildomi pikseliniai šešėliai (GLSL)"
+
+#: id:13419
+msgid "Software"
+msgstr "Programinis"
+
+#: id:13420
+msgid "Remove safely"
+msgstr "Atsargus ištrynimas"
+
+#: id:13421
+msgctxt "Auto context with id 13421"
+msgid "VDPAU"
+msgstr "VDPAU"
+
+#: id:13422
+msgid "Start slideshow here"
+msgstr "Pradėti prezentaciją nuo čia"
+
+#: id:13423
+msgid "Remember for this path"
+msgstr "Atsiminti kelią"
+
+#: id:13424
+msgid "Use pixel buffer objects"
+msgstr "Naudoti pikselių buferio objektus"
+
+#: id:13425
+msgid "Allow hardware acceleration (VDPAU)"
+msgstr "Leisti aparatūros spartinimą (VDPAU)"
+
+#: id:13426
+msgid "Allow hardware acceleration (VAAPI)"
+msgstr "Leisti aparatūros spartinimą (VAAPI)"
+
+#: id:13427
+msgid "Allow hardware acceleration (DXVA2)"
+msgstr "Leisti aparatūros spartinimą (DXVA2)"
+
+#: id:13428
+msgid "Allow hardware acceleration (CrystalHD)"
+msgstr "Leisti aparatūros spartinimą (CrystalHD)"
+
+#: id:13429
+msgid "Allow hardware acceleration (VDADecoder)"
+msgstr "Leisti aparatūros spartinimą (VDADecoder)"
+
+#: id:13430
+msgid "Allow hardware acceleration (OpenMax)"
+msgstr "Leisti aparatūros spartinimą (OpenMax)"
+
+#: id:13431
+msgid "Pixel Shaders"
+msgstr "Pikseliniai šešėliai"
+
+#: id:13432
+msgid "Allow hardware acceleration (VideoToolbox)"
+msgstr "Leisti aparatūros spartinimą (VideoToolbox)"
+
+#: id:13500
+msgid "A/V sync method"
+msgstr "Sinchr. metodas A/V"
+
+#: id:13501
+msgid "Audio clock"
+msgstr "Audio laikrodis"
+
+#: id:13502
+msgid "Video clock (Drop/Dupe audio)"
+msgstr "Video laikrodis (Drop/Dupe audio)"
+
+#: id:13503
+msgid "Video clock (Resample audio)"
+msgstr "Video laikrodis (Resample audio)"
+
+#: id:13504
+msgid "Maximum resample amount (%)"
+msgstr "Maksimalus konvertavimo dydis (%)"
+
+#: id:13505
+msgid "Resample quality"
+msgstr "Konvertavimo kokybė"
+
+#: id:13506
+msgid "Low(fast)"
+msgstr "Žema"
+
+#: id:13507
+msgctxt "Auto context with id 13507"
+msgid "Medium"
+msgstr "Vidutinė"
+
+#: id:13508
+msgctxt "Auto context with id 13508"
+msgid "High"
+msgstr "Aukšta"
+
+#: id:13509
+msgid "Really high(slow!)"
+msgstr "Labai aukšta"
+
+#: id:13510
+msgid "Sync playback to display"
+msgstr "Sinchronizuoti su ekrano dažniu"
+
+#: id:13550
+msgid "Pause during refresh rate change"
+msgstr "Pristabdyti, kai Jūs keičiate naujinimo dažnį"
+
+#: id:13551
+msgctxt "Auto context with id 13551"
+msgid "Off"
+msgstr "Išjungti"
+
+#: id:13552
+msgid "%.1f Second"
+msgstr "%.1f Sekundė"
+
+#: id:13553
+msgid "%.1f Seconds"
+msgstr "%.1f Sekundžių"
+
+#: id:13600
+msgid "Apple remote"
+msgstr "Apple pultelis"
+
+#: id:13602
+msgid "Allow start of XBMC using the remote"
+msgstr "Paleisti XBMC naudojant nuotolinį pultelį"
+
+#: id:13603
+msgid "Sequence delay time"
+msgstr "Vėlinimo laiko seka"
+
+#: id:13610
+msgctxt "Auto context with id 13610"
+msgid "Disabled"
+msgstr "Atjungta"
+
+#: id:13611
+msgctxt "Auto context with id 13611"
+msgid "Standard"
+msgstr "Standartinis"
+
+#: id:13612
+msgid "Universal Remote"
+msgstr "Universalus pultelis"
+
+#: id:13613
+msgid "Multi Remote (Harmony)"
+msgstr "Multi pultelis (Harmony)"
+
+#: id:13620
+msgid "Apple Remote Error"
+msgstr "Apple pultelio klaida"
+
+#: id:13621
+msgid "Apple Remote support could be enabled."
+msgstr "Įjungti Apple pultelio palaikymą."
+
+#: id:14000
+msgid "Stack"
+msgstr "Sugrupuoti"
+
+#: id:14001
+msgid "Unstack"
+msgstr "Išgrupuoti"
+
+#: id:14003
+msgid "Downloading playlist file..."
+msgstr "Kraunasi bibliotekos failas..."
+
+#: id:14004
+msgid "Downloading streams list..."
+msgstr "Kraunasi sąrašo srautas..."
+
+#: id:14005
+msgid "Parsing streams list..."
+msgstr "Sąrašo srauto analizė..."
+
+#: id:14006
+msgid "Downloading streams list failed"
+msgstr "Klaida įkeliant sąrašo srautą"
+
+#: id:14007
+msgid "Downloading playlist file failed"
+msgstr "Klaida įkeliant bibliotekos failą"
+
+#: id:14009
+msgid "Games directory"
+msgstr "Žaidimų direktorija"
+
+#: id:14010
+msgid "Auto switch to thumbs based on"
+msgstr "Vaizdo auto perjungimas į eskizus po"
+
+#: id:14011
+msgid "Enable auto switching to thumbs view"
+msgstr "Įjungti auto perjungimas į eskizus"
+
+#: id:14012
+msgid "- Use large icons"
+msgstr "- Naudoti didelius ženkliukus"
+
+#: id:14013
+msgid "- Switch based on"
+msgstr "- Perjungi po"
+
+#: id:14014
+msgid "- Percentage"
+msgstr "- Procentinių santykių"
+
+#: id:14015
+msgid "No files and at least one thumb"
+msgstr "Nėra failų ir nors vienas eskizas"
+
+#: id:14016
+msgid "At least one file and thumb"
+msgstr "Nors vienas failas ir eskizas"
+
+#: id:14017
+msgid "Percentage of thumbs"
+msgstr "Procentinių santykių eskizų"
+
+#: id:14018
+msgid "View options"
+msgstr "Peržiūros nustatymai"
+
+#: id:14019
+msgid "Change area code 1"
+msgstr "1-as miestas"
+
+#: id:14020
+msgid "Change area code 2"
+msgstr "2-as miestas"
+
+#: id:14021
+msgid "Change area code 3"
+msgstr "3-as miestas"
+
+#: id:14022
+msgctxt "Auto context with id 14022"
+msgid "Library"
+msgstr "Biblioteka"
+
+#: id:14023
+msgid "No TV"
+msgstr "Be TV"
+
+#: id:14024
+msgid "Enter the nearest large town"
+msgstr "Įveskite artimiausią miestą"
+
+#: id:14025
+msgid "Video/Audio/DVD cache - Harddisk"
+msgstr "Audio/Video/DVD - iš HDD"
+
+#: id:14026
+msgid "Video cache - DVD-ROM"
+msgstr "Video - iš DVD disko"
+
+#: id:14027
+msgctxt "Auto context with id 14027"
+msgid "- Local Network"
+msgstr "- iš vietinio tinklo"
+
+#: id:14028
+msgctxt "Auto context with id 14028"
+msgid "- Internet"
+msgstr "- iš interneto"
+
+#: id:14030
+msgid "Audio cache - DVD-ROM"
+msgstr "Audio - iš CD/DVD disko"
+
+#: id:14031
+msgctxt "Auto context with id 14031"
+msgid "- Local Network"
+msgstr "- iš vietinio tinklo"
+
+#: id:14032
+msgctxt "Auto context with id 14032"
+msgid "- Internet"
+msgstr "- iš interneto"
+
+#: id:14034
+msgid "DVD cache - DVD-ROM"
+msgstr "DVD kešas - iš DVD disko"
+
+#: id:14035
+msgctxt "Auto context with id 14035"
+msgid "- Local Network"
+msgstr "- iš vietinio tinklo"
+
+#: id:14036
+msgctxt "Auto context with id 14036"
+msgid "Services"
+msgstr "Servisas(paslaugos)"
+
+#: id:14038
+msgid "Network settings changed"
+msgstr "Pasikeitė tinklo nustatymai."
+
+#: id:14039
+msgid "XBMC requires to restart to change your"
+msgstr "Reikia iš naujo pakeisti jūsų tinklo sąranką"
+
+#: id:14040
+msgid "network setup. Would you like to restart now?"
+msgstr "Ar norite perkrauti XBMC dabar?"
+
+#: id:14041
+msgid "Internet connection bandwidth limitation"
+msgstr "Interneto ryšio spartos apribojimas"
+
+#: id:14043
+msgid "- Shutdown while playing"
+msgstr "- Išjungti grojant"
+
+#: id:14044
+msgid "%i min"
+msgstr "%i min"
+
+#: id:14045
+msgid "%i sec"
+msgstr "%i sek"
+
+#: id:14046
+msgid "%i ms"
+msgstr "%i ms"
+
+#: id:14047
+msgid "%i %%"
+msgstr "%i %%"
+
+#: id:14048
+msgid "%i kbps"
+msgstr "%i Kbps"
+
+#: id:14049
+msgid "%i kb"
+msgstr "%i Kb"
+
+#: id:14050
+msgid "%i.0 dB"
+msgstr "%i.0 dB"
+
+#: id:14051
+msgid "Time format"
+msgstr "Laiko formatas"
+
+#: id:14052
+msgid "Date format"
+msgstr "Datos formatas"
+
+#: id:14053
+msgid "GUI filters"
+msgstr "GUI filtrai"
+
+#: id:14055
+msgid "Use background scanning"
+msgstr "Nuskaityti fonineme režime"
+
+#: id:14056
+msgid "Stop scan"
+msgstr "Sustabdyti nuskaitymą"
+
+#: id:14057
+msgid "Not possible while scanning for media info"
+msgstr "Neimanoma, kol skaitomi failai"
+
+#: id:14058
+msgid "Film grain effect"
+msgstr "Filmo efektai"
+
+#: id:14059
+msgid "Search for thumbnails on remote shares"
+msgstr "Ieškoti eskizų išoriniuose resursuose"
+
+#: id:14060
+msgid "Unknown type cache - Internet"
+msgstr "Nežinomas talpyklos podėlis - Internetas"
+
+#: id:14061
+msgctxt "Auto context with id 14061"
+msgid "Auto"
+msgstr "Auto"
+
+#: id:14062
+msgid "Enter username for"
+msgstr "Įveskite vartotojo vardą"
+
+#: id:14063
+msgid "Date & time"
+msgstr "Data ir laikas"
+
+#: id:14064
+msgid "Set date"
+msgstr "Nustatyti datą"
+
+#: id:14065
+msgid "Set time"
+msgstr "Nustatyti laiką"
+
+#: id:14066
+msgid "Enter the time in 24 hour HH:MM format"
+msgstr "Įveskite laiką 24 valandų HH:MM"
+
+#: id:14067
+msgid "Enter the date in DD/MM/YYYY format"
+msgstr "Įveskite datos formatą DD/MM/YYYY"
+
+#: id:14068
+msgid "Enter the IP address"
+msgstr "Įveskite IP adresą"
+
+#: id:14069
+msgid "Apply these settings now?"
+msgstr "Taikyti šiuos parametrus dabar?"
+
+#: id:14070
+msgid "Apply changes now"
+msgstr "Taikyti šiuos parametrus dabar"
+
+#: id:14071
+msgid "Allow file renaming and deletion"
+msgstr "Leisti pervadinti ir ištrinti failus"
+
+#: id:14074
+msgid "Set timezone"
+msgstr "Nustatyti laiko juostą"
+
+#: id:14075
+msgid "Use daylight saving time"
+msgstr "Naudokite vasaros laiką"
+
+#: id:14076
+msgid "Add to favourites"
+msgstr "Idėti į 'Favoritas'"
+
+#: id:14077
+msgid "Remove from favourites"
+msgstr "Pašalinti iš 'Favoritas'"
+
+#: id:14078
+msgctxt "Auto context with id 14078"
+msgid "- Colours"
+msgstr "- Spalvos"
+
+#: id:14079
+msgid "Timezone country"
+msgstr "Šalis, laiko juostoje"
+
+#: id:14080
+msgid "Timezone"
+msgstr "Laiko juosta"
+
+#: id:14081
+msgid "File lists"
+msgstr "Failų sąrašas"
+
+#: id:14082
+msgid "Show EXIF picture information"
+msgstr "Rodyti EXIF vaizdo informaciją"
+
+#: id:14083
+msgid "Use a fullscreen window rather than true fullscreen"
+msgstr "Naudoti per visą ekraną, o ne tikrą vaizdą"
+
+#: id:14084
+msgid "Queue songs on selection"
+msgstr "Įtraukti takelius į eilę renkantis"
+
+#: id:14086
+msgid "Playback"
+msgstr "Atkūrimas"
+
+#: id:14087
+msgid "DVDs"
+msgstr "DVD"
+
+#: id:14088
+msgid "Play DVDs automatically"
+msgstr "Atkūrti DVD automatiškai"
+
+#: id:14089
+msgid "Font to use for text subtitles"
+msgstr "Subtitrų tekstų šriftas"
+
+#: id:14090
+msgid "International"
+msgstr "Kalbos"
+
+#: id:14091
+msgid "Character set"
+msgstr "Koduotė"
+
+#: id:14092
+msgid "Debugging"
+msgstr "Derinimo"
+
+#: id:14093
+msgid "Security"
+msgstr "Apsaugos"
+
+#: id:14094
+msgid "Input devices"
+msgstr "Jungčių"
+
+#: id:14095
+msgid "Power saving"
+msgstr "Energijos"
+
+#: id:14096
+msgid "Rip"
+msgstr ""
+
+#: id:14097
+msgid "Audio CD Insert Action"
+msgstr ""
+
+#: id:14098
+msgctxt "Auto context with id 14098"
+msgid "Play"
+msgstr ""
+
+#: id:14099
+msgid "Eject disc when CD ripping is complete"
+msgstr ""
+
+#: id:15015
+msgctxt "Auto context with id 15015"
+msgid "Remove"
+msgstr "Pašalinti"
+
+#: id:15016
+msgid "Games"
+msgstr "Žaidimai"
+
+#: id:15019
+msgid "Add"
+msgstr "Pridėti"
+
+#: id:15052
+msgid "Password"
+msgstr "Slaptažodis"
+
+#: id:15100
+msgctxt "Auto context with id 15100"
+msgid "Library"
+msgstr "Biblioteka"
+
+#: id:15101
+msgid "Database"
+msgstr "Duomenų bazė"
+
+#: id:15102
+msgid "* All albums"
+msgstr "* Visi albumai"
+
+#: id:15103
+msgid "* All artists"
+msgstr "* Visi atlikėjai"
+
+#: id:15104
+msgid "* All songs"
+msgstr "* Visos dainos"
+
+#: id:15105
+msgid "* All genres"
+msgstr "* Visi žanrai"
+
+#: id:15107
+msgid "Buffering..."
+msgstr "Buferizacija..."
+
+#: id:15108
+msgid "Navigation sounds"
+msgstr "Garsų sąsaja"
+
+#: id:15109
+msgid "Skin default"
+msgstr "Standartinis dizainas"
+
+#: id:15111
+msgid "- Theme"
+msgstr "- Tema"
+
+#: id:15112
+msgid "Default theme"
+msgstr "Standartinė tema"
+
+#: id:15200
+msgid "Last.fm"
+msgstr "Last.fm"
+
+#: id:15201
+msgid "Submit songs to Last.fm"
+msgstr "Siųsti statistiką į Last.fm"
+
+#: id:15202
+msgid "Last.fm username"
+msgstr "Vartotojo slapyvardis Last.fm"
+
+#: id:15203
+msgid "Last.fm password"
+msgstr "Slaptažodis Last.fm"
+
+#: id:15204
+msgid "Unable to handshake: sleeping..."
+msgstr "Nepavyksta prisijungti: užmiegu..."
+
+#: id:15205
+msgid "Please update XBMC"
+msgstr "Prašome atnaujinti XBMC"
+
+#: id:15206
+msgid "Bad authorization: Check username and password"
+msgstr "Neteisingas prisijungimas: Patikrinkite vartotojo slapyvardį ir slaptažodį"
+
+#: id:15207
+msgctxt "Auto context with id 15207"
+msgid "Connected"
+msgstr "Sujungtas"
+
+#: id:15208
+msgid "Not connected"
+msgstr "Nesujungtas"
+
+#: id:15209
+msgid "Submit interval %i"
+msgstr "Sujungimo intervalas %i"
+
+#: id:15210
+msgid "Cached %i songs"
+msgstr "Į talpyklą %i dainų"
+
+#: id:15211
+msgid "Submitting..."
+msgstr "Sujungimas..."
+
+#: id:15212
+msgid "Submitting in %i secs"
+msgstr "Sujungimas po %i sek."
+
+#: id:15213
+msgid "Play using..."
+msgstr "Naudoti grotuvą..."
+
+#: id:15214
+msgid "Use smoothed A/V synchronization"
+msgstr "Naudoti A/V sinchronizavimą"
+
+#: id:15215
+msgid "Hide file names in thumbs view"
+msgstr "Slėpti failų pavadinimus eskizų režime"
+
+#: id:15216
+msgid "Play in party mode"
+msgstr "Grojimo režimas 'Party'"
+
+#: id:15217
+msgid "Submit songs to Libre.fm"
+msgstr "Siųsti statistiką į Libre.fm"
+
+#: id:15218
+msgid "Libre.fm username"
+msgstr "Vartotojo slapyvardis Libre.fm"
+
+#: id:15219
+msgid "Libre.fm password"
+msgstr "Slaptažodis Libre.fm"
+
+#: id:15220
+msgid "Libre.fm"
+msgstr "Libre.fm"
+
+#: id:15221
+msgid "Song submission"
+msgstr "Dainų pateikimas"
+
+#: id:15250
+msgid "Submit Last.fm radio to Last.fm"
+msgstr "Dainų statistikos iš Last.fm"
+
+#: id:15251
+msgid "Connecting to Last.fm..."
+msgstr "Prisijungti prie Last.fm..."
+
+#: id:15252
+msgid "Selecting station..."
+msgstr "Stoties pasirinkimas..."
+
+#: id:15253
+msgid "Search similar artists..."
+msgstr "Rasti panašius atlikėjus..."
+
+#: id:15254
+msgid "Search similar tags..."
+msgstr "Rasti panašias žymas..."
+
+#: id:15255
+msgid "Your profile (%name%)"
+msgstr "Jūsų profilis (%name%)"
+
+#: id:15256
+msgid "Overall top tags"
+msgstr "Bendros Top žymos"
+
+#: id:15257
+msgid "Top artists for tag %name%"
+msgstr "Top atlikėjų pagal žymę %name%"
+
+#: id:15258
+msgid "Top albums for tag %name%"
+msgstr "Top albumų pagal žymę %name%"
+
+#: id:15259
+msgid "Top tracks for tag %name%"
+msgstr "Top kūriniai pagal žymę %name%"
+
+#: id:15260
+msgid "Listen to tag %name% Last.fm radio"
+msgstr "Klausyti(is) takelius pagal žymę %name% Last.fm"
+
+#: id:15261
+msgid "Similar artists as %name%"
+msgstr "Panašius atlikėjus į %name%"
+
+#: id:15262
+msgid "Top %name% albums"
+msgstr "Top %name% albumų"
+
+#: id:15263
+msgid "Top %name% tracks"
+msgstr "Top %name% kompozicijų"
+
+#: id:15264
+msgid "Top %name% tags"
+msgstr "Top %name% žymų"
+
+#: id:15265
+msgid "Biggest fans of %name%"
+msgstr "Didžiausi gerbėjai %name%"
+
+#: id:15266
+msgid "Listen to %name% fans Last.fm radio"
+msgstr "Klausyti(is) gerbėjų pasirinkimą %name% Last.fm"
+
+#: id:15267
+msgid "Listen to %name% similar artists Last.fm radio"
+msgstr "Klausyti(is) panašių %name% atlikėjų Last.fm"
+
+#: id:15268
+msgid "Top artists for user %name%"
+msgstr "Top atlikėjų iš %name%"
+
+#: id:15269
+msgid "Top albums for user %name%"
+msgstr "Top albumų iš %name%"
+
+#: id:15270
+msgid "Top tracks for user %name%"
+msgstr "Top kūrinių iš %name%"
+
+#: id:15271
+msgid "Friends of user %name%"
+msgstr "Draugai %name%"
+
+#: id:15272
+msgid "Neighbours of user %name%"
+msgstr "Bendrija %name%"
+
+#: id:15273
+msgid "Weekly artist chart for %name%"
+msgstr "Savaitės dainininkų diagrama %name%"
+
+#: id:15274
+msgid "Weekly album chart for %name%"
+msgstr "Savaitės albumų diagrama %name%"
+
+#: id:15275
+msgid "Weekly track chart for %name%"
+msgstr "Savaitės takelių diagrama %name%"
+
+#: id:15276
+msgid "Listen to %name%'s neighbours Last.fm radio"
+msgstr "Klausyti(is) %name%'s iš žmonių Last.fm"
+
+#: id:15277
+msgid "Listen to %name%'s personal Last.fm radio"
+msgstr "Klausyti(is) %name%'s savo Last.fm"
+
+#: id:15278
+msgid "Listen to %name%'s mix Last.fm radio"
+msgstr "Klausyti(is) %name%'s milymiausi Last.fm"
+
+#: id:15279
+msgid "Retrieving list from Last.fm..."
+msgstr "Gaukite sąrašą iš Last.fm..."
+
+#: id:15280
+msgid "Can't retrieve list from Last.fm..."
+msgstr "Negalima gauti sąrašo iš Last.fm..."
+
+#: id:15281
+msgid "Enter an artist name to find related ones"
+msgstr "Įveskite atlikėjo vardą, ieškoti panašių"
+
+#: id:15282
+msgid "Enter a tag name to find similar ones"
+msgstr "Įveskite pavadinime žymą, ieškoti panašių"
+
+#: id:15283
+msgid "Tracks recently listened by %name%"
+msgstr "Pastaruoju metu klausomos dainos %name%'"
+
+#: id:15284
+msgid "Listen to %name%'s recommendations Last.fm radio"
+msgstr "Klausyti(is) rekomenduojamų %name%' Last.fm"
+
+#: id:15285
+msgid "Top tags for user %name%"
+msgstr "Top žymos %name%"
+
+#: id:15287
+msgid "Do you want to add the current track to your loved tracks?"
+msgstr "Ar norite pridėti šį takelį į savo mėgstami kūriniai?"
+
+#: id:15288
+msgid "Do you want to ban the current track?"
+msgstr "Norite užrakinti šį takelį?"
+
+#: id:15289
+msgid "Added to your loved tracks: '%s'."
+msgstr "Pridėta prie Jūsų mėgstami kūriniai: '%s'."
+
+#: id:15290
+msgid "Could not add '%s' to your loved tracks."
+msgstr "Negalima pridėti '%s' prie Jūsų mėgstami kūriniai."
+
+#: id:15291
+msgid "Banned: '%s'."
+msgstr "Užblokuota: '%s'."
+
+#: id:15292
+msgid "Could not ban '%s'."
+msgstr "Neimanoma užblokuoti: '%s'."
+
+#: id:15293
+msgid "Tracks recently loved by %name%"
+msgstr "Jums patikę kūriniai %name%'а"
+
+#: id:15294
+msgid "Tracks recently banned by %name%"
+msgstr "Jūsų užblokuoti kūriniai %name%'а"
+
+#: id:15295
+msgid "Remove from loved tracks"
+msgstr "Šalinti iš mėgstami kūriniai"
+
+#: id:15296
+msgid "Un-ban"
+msgstr "Atblokuoti"
+
+#: id:15297
+msgid "Do you want to remove this track from your loved tracks?"
+msgstr "Jūs norite pašalinti šį kūrinį iš mėgstami kūriniai?"
+
+#: id:15298
+msgid "Do you want to un-ban this track?"
+msgstr "Norite atblokuoti šį takelį?"
+
+#: id:15300
+msgid "Path not found or invalid"
+msgstr "Blogas arba jų visai nėra"
+
+#: id:15301
+msgid "Could not connect to network server"
+msgstr "Nepavyksta prisijungti prie serverio"
+
+#: id:15302
+msgid "No servers found"
+msgstr "Serverio nerasta"
+
+#: id:15303
+msgid "Workgroup not found"
+msgstr "Darbo grupės nerasta"
+
+#: id:15310
+msgid "Opening multi-path source"
+msgstr "Atidaryti maršruto šaltinius"
+
+#: id:15311
+msgid "Path:"
+msgstr "Maršrutas:"
+
+#: id:16000
+msgctxt "Auto context with id 16000"
+msgid "General"
+msgstr "Pagrindinis"
+
+#: id:16002
+msgid "Internet lookup"
+msgstr "Paieška internete"
+
+#: id:16003
+msgid "Player"
+msgstr "Grotuvas"
+
+#: id:16004
+msgid "Play media from disc"
+msgstr "Groti failą iš disko"
+
+#: id:16008
+msgid "Enter new title"
+msgstr "Įveskite naują pavadinimą"
+
+#: id:16009
+msgid "Enter the movie name"
+msgstr "Įveskite filmo pavadinimą"
+
+#: id:16010
+msgid "Enter the profile name"
+msgstr "Įveskite profilio pavadinimą"
+
+#: id:16011
+msgid "Enter the album name"
+msgstr "Įveskite albumo pavadinimą"
+
+#: id:16012
+msgid "Enter the playlist name"
+msgstr "Įveskite grojaraščio pavadinimą"
+
+#: id:16013
+msgid "Enter new filename"
+msgstr "Įveskite naują failo pavadinimą"
+
+#: id:16014
+msgid "Enter folder name"
+msgstr "Įveskite aplanko pavadinimą"
+
+#: id:16015
+msgid "Enter directory"
+msgstr "Įveskite aplanką"
+
+#: id:16016
+msgid "Available options: %A, %T, %N, %B, %D, %G, %Y, %F, %S"
+msgstr "Galimos parinktys: %A, %T, %N, %B, %D, %G, %Y, %F, %S"
+
+#: id:16017
+msgid "Enter search string"
+msgstr "Paieškos eilutė"
+
+#: id:16018
+msgctxt "Auto context with id 16018"
+msgid "None"
+msgstr "Nieko"
+
+#: id:16019
+msgid "Auto select"
+msgstr "Auto pasirinkimas"
+
+#: id:16020
+msgid "De-interlace"
+msgstr "De-interlace"
+
+#: id:16021
+msgid "Bob"
+msgstr "Bob"
+
+#: id:16022
+msgid "Bob (inverted)"
+msgstr "Bob (inverted)"
+
+#: id:16024
+msgid "Canceling..."
+msgstr "Atšaukiama..."
+
+#: id:16025
+msgid "Enter the artist name"
+msgstr "Įveskite atlikėjo vardą"
+
+#: id:16026
+msgid "Playback failed"
+msgstr "Grojaraščio veikimas nutraukiamas"
+
+#: id:16027
+msgid "One or more items failed to play."
+msgstr "Per daug klaidų iš eilės"
+
+#: id:16028
+msgid "Enter value"
+msgstr "Įveskite reikšmę"
+
+#: id:16029
+msgid "Check the log file for details."
+msgstr "Patikrinkite žurnalo bylą išsamiai informacijai"
+
+#: id:16030
+msgid "Party mode aborted."
+msgstr "'Party' atšauktas."
+
+#: id:16031
+msgid "No matching songs in the library."
+msgstr "Nėra atitinkamų dainų bibliotekoje."
+
+#: id:16032
+msgid "Could not initialize database."
+msgstr "Nepavyko inicijuoti duomenų bazės."
+
+#: id:16033
+msgid "Could not open database."
+msgstr "Nepavyko atidaryti duomenų bazės."
+
+#: id:16034
+msgid "Could not get songs from database."
+msgstr "Nepavyko gauti dainų iš duomenų bazės."
+
+#: id:16035
+msgid "Party mode playlist"
+msgstr "Grojaraštis 'Party'"
+
+#: id:16036
+msgid "De-interlace (Half)"
+msgstr "De-interlace (Half)"
+
+#: id:16037
+msgid "Deinterlace video"
+msgstr "Deinterlace video"
+
+#: id:16038
+msgid "Deinterlace method"
+msgstr "Deinterlace method"
+
+#: id:16039
+msgctxt "Auto context with id 16039"
+msgid "Off"
+msgstr "Išj."
+
+#: id:16040
+msgctxt "Auto context with id 16040"
+msgid "Auto"
+msgstr "Auto"
+
+#: id:16041
+msgid "On"
+msgstr "Įj."
+
+#: id:16100
+msgid "All Videos"
+msgstr "Visi filmai"
+
+#: id:16101
+msgid "Unwatched"
+msgstr "Neperžiūrėta"
+
+#: id:16102
+msgid "Watched"
+msgstr "Peržiūrėta"
+
+#: id:16103
+msgid "Mark as watched"
+msgstr "Žymėti kaip peržiūrėtą"
+
+#: id:16104
+msgid "Mark as unwatched"
+msgstr "Žymėti kaip neperžiūrėtą"
+
+#: id:16105
+msgid "Edit title"
+msgstr "Pakeisti pavadinimą"
+
+#: id:16200
+msgid "Operation was aborted"
+msgstr "Operacija nutraukta"
+
+#: id:16201
+msgid "Copy failed"
+msgstr "Nepavyko nukopijuoti"
+
+#: id:16202
+msgid "Failed to copy at least one file"
+msgstr "Nepavyko nukopijuoti jokio failo"
+
+#: id:16203
+msgid "Move failed"
+msgstr "Nepavyko perkelti"
+
+#: id:16204
+msgid "Failed to move at least one file"
+msgstr "Nepavyko perkelti jokio failo"
+
+#: id:16205
+msgid "Delete failed"
+msgstr "Nepavyko pašalinti"
+
+#: id:16206
+msgid "Failed to delete at least one file"
+msgstr "Nepavyko pašalinti jokio failo"
+
+#: id:16300
+msgid "Video scaling method"
+msgstr "Vaizdo mastelio metodas"
+
+#: id:16301
+msgid "Nearest neighbour"
+msgstr "Artimiausias kitas"
+
+#: id:16302
+msgid "Bilinear"
+msgstr "Bilinear"
+
+#: id:16303
+msgctxt "Auto context with id 16303"
+msgid "Bicubic"
+msgstr "Bicubic"
+
+#: id:16304
+msgid "Lanczos2"
+msgstr "Lanczos2"
+
+#: id:16305
+msgid "Lanczos3"
+msgstr "Lanczos3"
+
+#: id:16306
+msgid "Sinc8"
+msgstr "Sinc8"
+
+#: id:16307
+msgid "Bicubic (software)"
+msgstr "Bicubic (programoje)"
+
+#: id:16308
+msgid "Lanczos (software)"
+msgstr "Lanczos (programoje)"
+
+#: id:16309
+msgid "Sinc (software)"
+msgstr "Sinc (programoje)"
+
+#: id:16310
+msgid "Temporal"
+msgstr "Laikinas"
+
+#: id:16311
+msgid "Temporal/Spatial"
+msgstr "Laikinas/Erdvinis"
+
+#: id:16312
+msgid "(VDPAU)Noise Reduction"
+msgstr "(VDPAU) Triukšmo sumažinimas"
+
+#: id:16313
+msgid "(VDPAU)Sharpness"
+msgstr "(VDPAU) Ryškumas"
+
+#: id:16314
+msgid "Inverse Telecine"
+msgstr "Atvirkštinis Telecine"
+
+#: id:16315
+msgid "Lanczos3 optimized"
+msgstr "Lanczos3 optimizuotas(i)"
+
+#: id:16316
+msgctxt "Auto context with id 16316"
+msgid "Auto"
+msgstr "Auto"
+
+#: id:16317
+msgid "Temporal (Half)"
+msgstr "Laikinas (Half)"
+
+#: id:16318
+msgid "Temporal/Spatial (Half)"
+msgstr "Laikinas/Erdvinis (Half)"
+
+#: id:16319
+msgid "DXVA"
+msgstr "DXVA"
+
+#: id:16320
+msgid "DXVA Bob"
+msgstr "DXVA Bob"
+
+#: id:16321
+msgid "DXVA Best"
+msgstr "DXVA Best"
+
+#: id:16322
+msgid "Spline36"
+msgstr "Spline36"
+
+#: id:16323
+msgid "Spline36 optimized"
+msgstr "Spline36 optimizuotas(i)"
+
+#: id:16324
+msgid "Software Blend"
+msgstr "Programinė Blend"
+
+#: id:16400
+msgid "Post-processing"
+msgstr "Vaizdo pertvarkymas"
+
+#: id:17500
+msgid "Display sleep timeout"
+msgstr "Ekranas miego režime"
+
+#: id:19000
+msgid "Switch to channel"
+msgstr "Perjungti į kanalą"
+
+#: id:20000
+msgid "Saved music folder"
+msgstr "Išsaugota muzikos kataloge"
+
+#: id:20001
+msgid "Use external DVD player"
+msgstr "Naudokite išorinį DVD grotuvą"
+
+#: id:20002
+msgid "External DVD player"
+msgstr "Išorinis DVD grotuvas"
+
+#: id:20003
+msgid "Trainers folder"
+msgstr "Trainers aplankas"
+
+#: id:20004
+msgid "Screenshot folder"
+msgstr "Ekrano vaizdo aplankas"
+
+#: id:20006
+msgid "Playlists folder"
+msgstr "Grojaraščių aplankas"
+
+#: id:20007
+msgid "Recordings"
+msgstr "Įrašai"
+
+#: id:20008
+msgid "Screenshots"
+msgstr "Užsklandos"
+
+#: id:20009
+msgid "Use XBMC"
+msgstr "Naudoti XBMC"
+
+#: id:20011
+msgid "Music playlists"
+msgstr "Muzikos grojaraščiai"
+
+#: id:20012
+msgid "Video playlists"
+msgstr "Video grojaraščiai"
+
+#: id:20013
+msgid "Do you wish to launch the game?"
+msgstr "Norite pradėti žaidimą?"
+
+#: id:20014
+msgid "Sort by: Playlist"
+msgstr "Ruš. pagal: Grojaraštį"
+
+#: id:20015
+msgid "Remote thumb"
+msgstr "Išorinis dizainas"
+
+#: id:20016
+msgid "Current thumb"
+msgstr "Aktualus dizainas"
+
+#: id:20017
+msgid "Local thumb"
+msgstr "Lokalinis dizainas"
+
+#: id:20018
+msgid "No thumb"
+msgstr "Be dizaino"
+
+#: id:20019
+msgid "Choose thumbnail"
+msgstr "Pasirinkti dizainą"
+
+#: id:20023
+msgid "Conflict"
+msgstr "Konfliktas"
+
+#: id:20024
+msgid "Scan new"
+msgstr "Nuskaityti naują"
+
+#: id:20025
+msgid "Scan all"
+msgstr "Nuskaityti viską"
+
+#: id:20026
+msgid "Region"
+msgstr "Regionas"
+
+#: id:20037
+msgid "Summary"
+msgstr "Duomenys"
+
+#: id:20038
+msgid "Lock music window"
+msgstr "Blokuoti 'Muzika'"
+
+#: id:20039
+msgid "Lock videos window"
+msgstr "Blokuoti 'Video'"
+
+#: id:20040
+msgid "Lock pictures window"
+msgstr "Blokuoti 'Foto'"
+
+#: id:20041
+msgid "Lock programs & scripts windows"
+msgstr "Blokuoti 'Programos' ir 'Skriptai'"
+
+#: id:20042
+msgid "Lock file manager"
+msgstr "Blokuoti 'Failų tvarkyklė'"
+
+#: id:20043
+msgid "Lock settings"
+msgstr "Blokuoti 'Nustatymai'"
+
+#: id:20044
+msgid "Start fresh"
+msgstr "Švari paleistis"
+
+#: id:20045
+msgid "Enter master mode"
+msgstr "Įjungti režimą 'Visiška prieiga'"
+
+#: id:20046
+msgid "Leave master mode"
+msgstr "Išjungti režimą 'Visiška prieiga'"
+
+#: id:20047
+msgid "Create profile '%s'?"
+msgstr "Sukurti profilį '%s'?"
+
+#: id:20048
+msgid "Start with fresh settings"
+msgstr "Pradėti su 'Švarūs parametrai'"
+
+#: id:20049
+msgid "Best available"
+msgstr "Geriausių prieinamų"
+
+#: id:20050
+msgid "Auto-switch between 16x9 and 4x3"
+msgstr "Automatiškai perjungti 16:9 arba 4:3"
+
+#: id:20051
+msgid "Treat stacked files as single file"
+msgstr "Žiūrėti sudėtinius failus kaip vieną failą"
+
+#: id:20052
+msgid "Caution"
+msgstr "Dėmesio"
+
+#: id:20053
+msgid "Left master mode"
+msgstr "Palikti režimą 'Visiška prieiga'"
+
+#: id:20054
+msgid "Entered master mode"
+msgstr "Įjungtas režimas 'Visiška prieiga'"
+
+#: id:20055
+msgid "Allmusic.com thumb"
+msgstr "Allmusic.com eskizas"
+
+#: id:20057
+msgid "Remove thumbnail"
+msgstr "Slėpti eskizą"
+
+#: id:20058
+msgid "Add profile..."
+msgstr "Pridėti profilį..."
+
+#: id:20059
+msgid "Query info for all albums"
+msgstr "Duomenys apie visus albumus"
+
+#: id:20060
+msgctxt "Auto context with id 20060"
+msgid "Media info"
+msgstr "Duomenys apie skaitmeninį failą"
+
+#: id:20061
+msgctxt "Auto context with id 20061"
+msgid "Separate"
+msgstr "Atskirai"
+
+#: id:20062
+msgid "Shares with default"
+msgstr "Standartiniai ištekliai"
+
+#: id:20063
+msgid "Shares with default (read only)"
+msgstr "Standartiniai ištekliai (tik skaitymas)"
+
+#: id:20064
+msgid "Copy default"
+msgstr "Kopijuoti standartinius"
+
+#: id:20065
+msgid "Profile picture"
+msgstr "Profilio nuotrauka"
+
+#: id:20066
+msgid "Lock preferences"
+msgstr "Blokuoti parinktis"
+
+#: id:20067
+msgid "Edit profile"
+msgstr "Redaguoti profilį"
+
+#: id:20068
+msgid "Profile lock"
+msgstr "Blokuoti profilį"
+
+#: id:20069
+msgid "Could not create folder"
+msgstr "Neįmanoma sukurti aplanko"
+
+#: id:20070
+msgid "Profile directory"
+msgstr "Profilio aplankas"
+
+#: id:20071
+msgid "Start with fresh media sources"
+msgstr "Paleiskite su naujais ištekliais"
+
+#: id:20072
+msgid "Make sure the selected folder is writable"
+msgstr "Įsitikinkite, kad aplankas yra atidarytas"
+
+#: id:20073
+msgid "and that the new folder name is valid"
+msgstr "ir jo pavadinimas tikras"
+
+#: id:20074
+msgid "MPAA rating"
+msgstr "Reitingas MPAA"
+
+#: id:20075
+msgid "Enter master lock code"
+msgstr "Įveskite saugos kodą"
+
+#: id:20076
+msgid "Ask for master lock code on startup"
+msgstr "Klausti saugos kodo paleidžiant"
+
+#: id:20077
+msgid "Skin settings"
+msgstr "Išvaizdos nustatymai"
+
+#: id:20078
+msgid "- no link set -"
+msgstr "- nėra ryšio -"
+
+#: id:20079
+msgid "Enable animations"
+msgstr "Naudoti animaciją"
+
+#: id:20080
+msgid "Disable RSS during music"
+msgstr "Išjungti RSS muzikos atkūrimo metu"
+
+#: id:20081
+msgid "Enable shortcut buttons"
+msgstr "*Įjungti elementus 'Nuorodos'"
+
+#: id:20082
+msgid "Show programs in main menu"
+msgstr "Rodyti elementą 'Programos' pagrindiniame meniu"
+
+#: id:20083
+msgid "Show music info"
+msgstr "Rodyti muzikos informaciją"
+
+#: id:20084
+msgid "Show weather info"
+msgstr "Rodyti orų informaciją"
+
+#: id:20085
+msgid "Show system info"
+msgstr "Rodyti sistemos informaciją"
+
+#: id:20086
+msgid "Show available disc space C: E: F:"
+msgstr "Rodyti laisvą vietą C: E: F:"
+
+#: id:20087
+msgid "Show available disc space E: F: G:"
+msgstr "Rodyti laisvą vietą E: F: G:"
+
+#: id:20088
+msgid "Weather info"
+msgstr "Orų informacija"
+
+#: id:20089
+msgid "Drive space free"
+msgstr "Laisvos vietos diske"
+
+#: id:20090
+msgid "Enter the name of an existing share"
+msgstr "Įveskite esamų išteklių pavadinimą"
+
+#: id:20091
+msgid "Lock code"
+msgstr "Apsaugos kodas"
+
+#: id:20092
+msgid "Load profile"
+msgstr "Įkelti profilį"
+
+#: id:20093
+msgid "Profile name"
+msgstr "Profilio pavadinimas"
+
+#: id:20094
+msgctxt "Auto context with id 20094"
+msgid "Media sources"
+msgstr "Media failų šaltiniai"
+
+#: id:20095
+msgid "Enter profile lock code"
+msgstr "Įveskite profilio saugos kodą"
+
+#: id:20096
+msgctxt "Auto context with id 20096"
+msgid "Login screen"
+msgstr "Prisijungimo ekranas"
+
+#: id:20097
+msgid "Fetching album info"
+msgstr "Informacijos užklausimas apie albumą"
+
+#: id:20098
+msgid "Fetching info for album"
+msgstr "Duomenų užklausimas albumui"
+
+#: id:20099
+msgid "Can't rip CD or track while playing from CD"
+msgstr "Neįmanoma perkelti į skaitmeninį formatą atkūrimo metu"
+
+#: id:20100
+msgid "Master lock code and settings"
+msgstr "Saugos kodas ir jo nustatymas"
+
+#: id:20101
+msgid "Entering master lock code always enables master mode"
+msgstr "Įvestas kodas visada persijungia į režimą 'Visiška prieiga'"
+
+#: id:20102
+msgid "or copy from default?"
+msgstr "ar kopijuoti iš standartinio?"
+
+#: id:20103
+msgid "Save changes to profile?"
+msgstr "Išsaugoti profilio pakeitimus?"
+
+#: id:20104
+msgid "Old settings found."
+msgstr "Rasti seni nustatymai."
+
+#: id:20105
+msgid "Do you want to use them?"
+msgstr "Jūs norite juos panaudoti?"
+
+#: id:20106
+msgid "Old media sources found."
+msgstr "Rasta senų media išteklių."
+
+#: id:20107
+msgid "Separate (locked)"
+msgstr "Atskirai (uždaryta)"
+
+#: id:20108
+msgid "Root"
+msgstr "- Šaknis"
+
+#: id:20109
+msgid "- Zoom"
+msgstr "- Mastelis"
+
+#: id:20110
+msgid "UPnP settings"
+msgstr "UPnP nustatymai"
+
+#: id:20111
+msgid "Autostart UPnP client"
+msgstr "UPnP automatinis kliento paleidimas"
+
+#: id:20112
+msgid "Last login: %s"
+msgstr "Paskutinis prisijungimas: %s"
+
+#: id:20113
+msgid "Never logged on"
+msgstr "Niekada nebuvo prisijungęs"
+
+#: id:20114
+msgid "Profile %i / %i"
+msgstr "Profilis %i / %i"
+
+#: id:20115
+msgid "User login / Select a profile"
+msgstr "Vartotojo prisijungimas / Profilio pasirinkimas"
+
+#: id:20116
+msgid "Use lock on login screen"
+msgstr "Naudoti apsaugą prisijungimo lange"
+
+#: id:20117
+msgid "Invalid lock code."
+msgstr "Neteisingas apsaugos kodas."
+
+#: id:20118
+msgid "This requires the master lock to be set."
+msgstr "Šiam apsaugos kodui turi būti įdiegta."
+
+#: id:20119
+msgid "Would you like to set it now?"
+msgstr "Įdiegti jį dabar?"
+
+#: id:20120
+msgid "Loading program information"
+msgstr "Duomenų įkėlimas apie programą"
+
+#: id:20121
+msgid "Party on!"
+msgstr "'Vakarėlis' prasidėjo!"
+
+#: id:20122
+msgid "True"
+msgstr "Tiesa"
+
+#: id:20123
+msgid "Mixing drinks"
+msgstr "'Gėrimų' maišymas"
+
+#: id:20124
+msgid "Filling glasses"
+msgstr "'Bokalų' pildymas"
+
+#: id:20125
+msgid "Logged on as"
+msgstr "Prisijungęs kaip"
+
+#: id:20126
+msgid "Log off"
+msgstr "Atjungimas"
+
+#: id:20128
+msgid "Go to root"
+msgstr "Eiti į viršų"
+
+#: id:20129
+msgid "Weave"
+msgstr "Laviruoti"
+
+#: id:20130
+msgid "Weave (inverted)"
+msgstr "Laviruoti (atvirkščiai)"
+
+#: id:20131
+msgid "Blend"
+msgstr "Mišinys"
+
+#: id:20132
+msgid "Restart video"
+msgstr "Perkrauti video"
+
+#: id:20133
+msgid "Edit network location"
+msgstr "Keisti tinklo vietą"
+
+#: id:20134
+msgid "Remove network location"
+msgstr "Šalinti tinklo vietą"
+
+#: id:20135
+msgid "Do you want to scan the folder?"
+msgstr "Norite nuskaityti katalogą?"
+
+#: id:20136
+msgid "Memory unit"
+msgstr "Atminties kortelė"
+
+#: id:20137
+msgid "Memory unit mounted"
+msgstr "Atminties kortelė pajungta"
+
+#: id:20138
+msgid "Unable to mount memory unit"
+msgstr "Neįmanoma pajungti atminties kortelės"
+
+#: id:20139
+msgid "In port %i, slot %i"
+msgstr "Į portą %i, slotą %i"
+
+#: id:20140
+msgid "Lock screensaver"
+msgstr "Užrakinti ekrano užsklandą"
+
+#: id:20141
+msgid "Set"
+msgstr "Įdiegti"
+
+#: id:20142
+msgctxt "Auto context with id 20142"
+msgid "Username"
+msgstr "Vartotojo slaptavardis"
+
+#: id:20143
+msgid "Enter password for"
+msgstr "Įveskite slaptažodį dėl"
+
+#: id:20144
+msgid "Shutdown timer"
+msgstr "Išjungimo laikmatis"
+
+#: id:20145
+msgid "Shutdown interval (in minutes)"
+msgstr "Išjungimo intervalas (min.)"
+
+#: id:20146
+msgid "Started, shutdown in %im"
+msgstr "Veikia, išjungti po %im"
+
+#: id:20147
+msgid "Shutdown in 30 minutes"
+msgstr "Išjungti po 30 min."
+
+#: id:20148
+msgid "Shutdown in 60 minutes"
+msgstr "Išjungti po 1 val."
+
+#: id:20149
+msgid "Shutdown in 120 minutes"
+msgstr "Išjungti po 2 val."
+
+#: id:20150
+msgid "Custom shutdown timer"
+msgstr "Išjungti nurodytu laiku"
+
+#: id:20151
+msgid "Cancel shutdown timer"
+msgstr "Atjungti išjungimo laikmatį"
+
+#: id:20152
+msgid "Lock preferences for %s"
+msgstr "Blokuoti parinktis dėl %s"
+
+#: id:20153
+msgid "Browse..."
+msgstr "Peržiūra..."
+
+#: id:20154
+msgid "Summary information"
+msgstr "Pagrindinė informacija"
+
+#: id:20155
+msgid "Storage information"
+msgstr "Talpyklos informacija"
+
+#: id:20156
+msgid "Hard disk information"
+msgstr "HDD informacija"
+
+#: id:20157
+msgid "DVD-ROM information"
+msgstr "DVD grotuvo informacija"
+
+#: id:20158
+msgid "Network information"
+msgstr "Tinklo informacija"
+
+#: id:20159
+msgid "Video information"
+msgstr "Video sistemos informacija"
+
+#: id:20160
+msgid "Hardware information"
+msgstr "Įrangos informacija"
+
+#: id:20161
+msgid "Total"
+msgstr "Viso"
+
+#: id:20162
+msgid "Used"
+msgstr "Užimta"
+
+#: id:20163
+msgid "of"
+msgstr "iš"
+
+#: id:20164
+msgid "Locking not supported"
+msgstr "Apsauga nepalaikoma"
+
+#: id:20165
+msgid "Not locked"
+msgstr "Neužblokuota"
+
+#: id:20166
+msgid "Locked"
+msgstr "Užblokuota"
+
+#: id:20167
+msgid "Frozen"
+msgstr "Įšaldytas"
+
+#: id:20168
+msgid "Requires reset"
+msgstr "Reikia atstatyti"
+
+#: id:20169
+msgid "Week"
+msgstr "Savaitė"
+
+#: id:20170
+msgid "Line"
+msgstr "Linija"
+
+#: id:20171
+msgid "Windows network (SMB)"
+msgstr "Windows tinklas (SMB)"
+
+#: id:20172
+msgid "XBMSP server"
+msgstr "XBMSP serveris"
+
+#: id:20173
+msgctxt "Auto context with id 20173"
+msgid "FTP server"
+msgstr "FTP serveris"
+
+#: id:20174
+msgid "iTunes music share (DAAP)"
+msgstr "iTunes dalytis muzika (DAAP)"
+
+#: id:20175
+msgid "UPnP server"
+msgstr "UPnP serveris"
+
+#: id:20176
+msgid "Show video info"
+msgstr "Rodyti video informaciją"
+
+#: id:20177
+msgid "Done"
+msgstr "Baigti"
+
+#: id:20178
+msgid "Shift"
+msgstr "Perkelti"
+
+#: id:20179
+msgid "Caps Lock"
+msgstr "Didžiosios"
+
+#: id:20180
+msgid "Symbols"
+msgstr "Simboliai"
+
+#: id:20181
+msgid "Backspace"
+msgstr "Atgal"
+
+#: id:20182
+msgid "Space"
+msgstr "Tarpas"
+
+#: id:20183
+msgid "Reload skin"
+msgstr "Atnaujinti išvaizdą"
+
+#: id:20184
+msgid "Rotate pictures using EXIF information"
+msgstr "Keisti nuotraukas naudojant EXIF"
+
+#: id:20185
+msgid "Use poster view styles for TV shows"
+msgstr "Naudoti afišos vaizdą serialams"
+
+#: id:20186
+msgid "Please wait"
+msgstr "Prašome palaukti"
+
+#: id:20187
+msgid "UPnP"
+msgstr ""
+
+#: id:20189
+msgid "Enable auto scrolling for plot & review"
+msgstr "Įjungti automatinį slinktį, siužetams ir peržiūroms"
+
+#: id:20190
+msgctxt "Auto context with id 20190"
+msgid "Custom"
+msgstr "Papildomai"
+
+#: id:20191
+msgid "Enable debug logging"
+msgstr "Įjungti žurnalo derinimą"
+
+#: id:20192
+msgid "Download additional information during updates"
+msgstr "Ieškoti albumo info dedant į biblioteką"
+
+#: id:20193
+msgid "Default service for album information"
+msgstr "Numatyta paslauga info apie albumą"
+
+#: id:20194
+msgid "Default service for artist information"
+msgstr "Numatyta paslauga info apie atlikėją"
+
+#: id:20195
+msgid "Change scraper"
+msgstr "Pakeisti info šaltinį"
+
+#: id:20196
+msgid "Export music library"
+msgstr "Eksportuoti muzikinę biblioteką"
+
+#: id:20197
+msgid "Import music library"
+msgstr "Importuoti muzikinę biblioteką"
+
+#: id:20198
+msgid "No artist found!"
+msgstr "Atlikėjas nerastas!"
+
+#: id:20199
+msgid "Downloading artist info failed"
+msgstr "Įkėlimas duomenų apie atlikėją"
+
+#: id:20250
+msgid "Party on! (videos)"
+msgstr "'Vakarėlis' prasidėjo!(Video)"
+
+#: id:20251
+msgid "Mixing drinks (videos)"
+msgstr "'Gėrimų' maišymas (Video)"
+
+#: id:20252
+msgid "Filling glasses (videos)"
+msgstr "'Bokalų' pildymas (Video)"
+
+#: id:20253
+msgid "WebDAV server (HTTP)"
+msgstr "WebDAV serveris (HTTP)"
+
+#: id:20254
+msgid "WebDAV server (HTTPS)"
+msgstr "WebDAV serveris (HTTPS)"
+
+#: id:20255
+msgid "First logon, edit your profile"
+msgstr "Pirmas prisijungimas, redaguoti savo profilį"
+
+#: id:20256
+msgid "HTS Tvheadend client"
+msgstr "Klientas HTS Tvheadend"
+
+#: id:20257
+msgid "VDR Streamdev client"
+msgstr "Klientas VDR Streamdev"
+
+#: id:20258
+msgid "MythTV client"
+msgstr "Klientas MythTV"
+
+#: id:20259
+msgid "Network Filesystem (NFS)"
+msgstr "Tinklo failų sistema (NFS)"
+
+#: id:20260
+msgid "Secure Shell (SSH/SFTP)"
+msgstr "Fono apsauga (SSH/SFTP)"
+
+#: id:20261
+msgid "Apple Filing Protocol (AFP)"
+msgstr "Apple Filing Protocol (AFP)"
+
+#: id:20300
+msgid "Web server directory (HTTP)"
+msgstr "Serverio katalogas (HTTP)"
+
+#: id:20301
+msgid "Web server directory (HTTPS)"
+msgstr "Serverio katalogas (HTTPS)"
+
+#: id:20302
+msgid "Unable to write to folder:"
+msgstr "Neįmanoma įrašyti į aplanką:"
+
+#: id:20303
+msgid "Do you want to skip and proceed?"
+msgstr "Norite praleisti ir tęsti?"
+
+#: id:20304
+msgid "RSS Feed"
+msgstr "RSS srautas"
+
+#: id:20307
+msgid "Secondary DNS"
+msgstr "Antrinis DNS"
+
+#: id:20308
+msgid "DHCP server:"
+msgstr "Serveris DHCP:"
+
+#: id:20309
+msgid "Make new folder"
+msgstr "Sukurti naują aplanką"
+
+#: id:20310
+msgid "Dim LCD on playback"
+msgstr "Pritemdyti LCD ekraną grojant"
+
+#: id:20311
+msgid "Unknown or onboard (protected)"
+msgstr "Nežinomas arba integruotas (apsaugotas)"
+
+#: id:20312
+msgid "Dim LCD on paused"
+msgstr "Pritemdyti LCD ekraną pauzėje"
+
+#: id:20314
+msgid "Videos - Library"
+msgstr "Video - Biblioteka"
+
+#: id:20316
+msgid "Sort by: ID"
+msgstr "Ruš. pagal: ID"
+
+#: id:20324
+msgid "Play part..."
+msgstr "Groti dalį..."
+
+#: id:20325
+msgid "Calibration reset"
+msgstr "Kalibravimo atstatymas"
+
+#: id:20326
+msgid "This will reset the calibration values for %s"
+msgstr "Tai atstatys kalibravimą %s"
+
+#: id:20327
+msgid "to it's default values."
+msgstr "pagal numatytąją reikšmę"
+
+#: id:20328
+msgid "Browse for destination"
+msgstr "Nurodykite tikslą"
+
+#: id:20329
+msgid "Movies are in separate folders that match the movie title"
+msgstr "Filmai atskiruose aplankuose, kurie atitinka filmo pavadinimą"
+
+#: id:20330
+msgid "Use folder names for lookups"
+msgstr "Naudokite aplankų pavadinimus ieškant"
+
+#: id:20331
+msgctxt "Auto context with id 20331"
+msgid "File"
+msgstr "Failo"
+
+#: id:20332
+msgid "Use file or folder names in lookups?"
+msgstr "Naudoti failų ar aplankų vardus ieškant?"
+
+#: id:20333
+msgid "Set content"
+msgstr "Turinys"
+
+#: id:20334
+msgid "Folder"
+msgstr "Papkė"
+
+#: id:20335
+msgid "Look for content recursively?"
+msgstr "Peržiūrėti papkių turinį?"
+
+#: id:20336
+msgid "Unlock sources"
+msgstr "Atblokuoti šaltinius"
+
+#: id:20337
+msgid "Actor"
+msgstr "Aktorius"
+
+#: id:20338
+msgid "Movie"
+msgstr "Filmas"
+
+#: id:20339
+msgid "Director"
+msgstr "Režisierius"
+
+#: id:20340
+msgid "Do you want to remove all items within"
+msgstr "Ar norite panaikinti"
+
+#: id:20341
+msgid "this path from the XBMC library?"
+msgstr "visus objektus iš bibliotekos?"
+
+#: id:20342
+msgctxt "Auto context with id 20342"
+msgid "Movies"
+msgstr "Filmai"
+
+#: id:20343
+msgid "TV shows"
+msgstr "Serialai"
+
+#: id:20344
+msgid "This directory contains"
+msgstr "Šiame aplanke yra"
+
+#: id:20345
+msgid "Run automated scan"
+msgstr "Paleisti auto nuskaitymą"
+
+#: id:20346
+msgid "Scan recursively"
+msgstr "Nuskaityti su pokatalogiais"
+
+#: id:20347
+msgid "as"
+msgstr "kaip"
+
+#: id:20348
+msgid "Directors"
+msgstr "Režisieriai"
+
+#: id:20349
+msgid "No video files found in this path!"
+msgstr "Šiuo maršrutu, video failų nerasta!"
+
+#: id:20350
+msgid "votes"
+msgstr "balsavo"
+
+#: id:20351
+msgid "TV show information"
+msgstr "Informacija apie serialą"
+
+#: id:20352
+msgid "Episode information"
+msgstr "Informacija apie epizodą"
+
+#: id:20353
+msgid "Loading TV show details"
+msgstr "Įkeliama informacija apie serialą"
+
+#: id:20354
+msgid "Fetching episode guide"
+msgstr "Instrukcija apie epizodo pasirinkimą"
+
+#: id:20355
+msgid "Loading info for episodes in directory"
+msgstr "Duomenų ikėlimas apie epizodus papkėse"
+
+#: id:20356
+msgid "Select TV show:"
+msgstr "Pasirinkite serijalą:"
+
+#: id:20357
+msgid "Enter the TV show name"
+msgstr "Įveskite serialo pavadinimą"
+
+#: id:20358
+msgid "Season %i"
+msgstr "Sezonas %i"
+
+#: id:20359
+msgid "Episode"
+msgstr "Epizodas"
+
+#: id:20360
+msgid "Episodes"
+msgstr "Epizodai"
+
+#: id:20361
+msgid "Loading episode details"
+msgstr "Atsiųsti informaciją apie epizodus"
+
+#: id:20362
+msgid "Remove episode from library"
+msgstr "Pašalinti iš bibliotekos epizodą"
+
+#: id:20363
+msgid "Remove TV show from library"
+msgstr "Pašalinti iš bibliotekos serialą"
+
+#: id:20364
+msgid "TV show"
+msgstr "Serialas"
+
+#: id:20365
+msgid "Episode plot"
+msgstr "Epizodo siužetas"
+
+#: id:20366
+msgid "* All seasons"
+msgstr "* Visi sezonai"
+
+#: id:20367
+msgid "Hide watched"
+msgstr "Be peržiurėtų"
+
+#: id:20368
+msgid "Prod code"
+msgstr "Produkto kodas"
+
+#: id:20369
+msgid "Show plot for unwatched items"
+msgstr "Rodyti siužetą neperžiurėtiems elementams"
+
+#: id:20370
+msgid "* Hidden to prevent spoilers *"
+msgstr "* Paslėpta, kad išvengti spoilerių *"
+
+#: id:20371
+msgid "Set season thumb"
+msgstr "Nustatyti sezono eskizus"
+
+#: id:20372
+msgid "Season image"
+msgstr "Sezono paveikslėlis"
+
+#: id:20373
+msgid "Season"
+msgstr "Sezonas"
+
+#: id:20374
+msgid "Downloading movie information"
+msgstr "Atsiųsti informaciją apie filmą"
+
+#: id:20375
+msgid "Unassign content"
+msgstr "Nenurodyti turinio"
+
+#: id:20376
+msgid "Original title"
+msgstr "Originalus pavadinimas"
+
+#: id:20377
+msgid "Refresh TV show information"
+msgstr "Atnaujinti informaciją apie serialą"
+
+#: id:20378
+msgid "Refresh info for all episodes?"
+msgstr "Atnaujinti informaciją apie visus epizodus?"
+
+#: id:20379
+msgid "Selected folder contains a single TV show"
+msgstr "Nurodytas katalogas turi atskirą serialą"
+
+#: id:20380
+msgid "Exclude selected folder from scans"
+msgstr "Neskaityti pasirinkto aplanko"
+
+#: id:20381
+msgid "Specials"
+msgstr "Ypatingas"
+
+#: id:20382
+msgid "Automatically grab season thumbs"
+msgstr "Automatiškai sukurti eskizus sezonui"
+
+#: id:20383
+msgid "Selected folder contains a single video"
+msgstr "Nurodytas katalogas turi atskirą video"
+
+#: id:20384
+msgid "Link to TV show"
+msgstr "Susieti su serialu"
+
+#: id:20385
+msgid "Remove link to TV show"
+msgstr "Atsieti nuo serialo"
+
+#: id:20386
+msgid "Recently added movies"
+msgstr "Nauji filmai"
+
+#: id:20387
+msgid "Recently added episodes"
+msgstr "Nauji epizodai"
+
+#: id:20388
+msgid "Studios"
+msgstr "Studijos"
+
+#: id:20389
+msgid "Music videos"
+msgstr "Vaizdo klipai"
+
+#: id:20390
+msgid "Recently added music videos"
+msgstr "Nauji vaizdo klipai"
+
+#: id:20391
+msgid "Music video"
+msgstr "Vaizdo klipai"
+
+#: id:20392
+msgid "Remove music video from library"
+msgstr "Pašalinti iš bibliotekos vaizdo klipus"
+
+#: id:20393
+msgctxt "Auto context with id 20393"
+msgid "Music video information"
+msgstr "Duomenys apie vaizdo klipus"
+
+#: id:20394
+msgid "Loading music video information"
+msgstr "Duomenų įkėlimas apie vaizdo klipus"
+
+#: id:20395
+msgid "Mixed"
+msgstr "Sumaišyti"
+
+#: id:20396
+msgid "Go to albums by artist"
+msgstr "Pereiti prie albumo pagal atlikėją"
+
+#: id:20397
+msgid "Go to album"
+msgstr "Pereiti prie albumo"
+
+#: id:20398
+msgid "Play song"
+msgstr "Groti dainą"
+
+#: id:20399
+msgid "Go to music videos from album"
+msgstr "Pereiti į vaizdo klipus iš albumo"
+
+#: id:20400
+msgid "Go to music videos by artist"
+msgstr "Pereiti į vaizdo klipus pagal atlikėjus"
+
+#: id:20401
+msgid "Play music video"
+msgstr "Groti vaizdo klipą"
+
+#: id:20402
+msgid "Download actor thumbnails when adding to library"
+msgstr "Automatiškai kurti miniatiūras aktoriams"
+
+#: id:20403
+msgid "Set actor thumb"
+msgstr "Nustatyti aktoriaus miniatiūrą"
+
+#: id:20405
+msgid "Remove episode bookmark"
+msgstr "Naikinti epizodo žymę"
+
+#: id:20406
+msgid "Set episode bookmark"
+msgstr "Nustatyti epizodo žymę"
+
+#: id:20407
+msgid "Scraper settings"
+msgstr "Info resurso nustatymas"
+
+#: id:20408
+msgid "Downloading music video information"
+msgstr "Atsiųsti duomenis apie vaizdo klipą"
+
+#: id:20409
+msgid "Downloading TV show information"
+msgstr "Atsiųsti duomenis apie serialą"
+
+#: id:20410
+msgid "Trailer"
+msgstr "Treileris"
+
+#: id:20411
+msgid "Flatten"
+msgstr "Sujungti"
+
+#: id:20412
+msgid "Flatten TV shows"
+msgstr "Sujungti TV šou"
+
+#: id:20413
+msgid "Get fanart"
+msgstr "Gauti Fanart"
+
+#: id:20414
+msgid "Show Fanart in video and music libraries"
+msgstr "Rodyti Fanart bibliotekoje"
+
+#: id:20415
+msgid "Scanning for new content"
+msgstr "Ieškoma naujo turinio"
+
+#: id:20416
+msgid "First aired"
+msgstr "Pirma eteryje"
+
+#: id:20417
+msgid "Writer"
+msgstr "Autorius(rašytojas)"
+
+#: id:20419
+msgid "Replace file names with library titles"
+msgstr "Rodyti metaduomenis žiurimiems failams"
+
+#: id:20420
+msgctxt "Auto context with id 20420"
+msgid "Never"
+msgstr "Niekada"
+
+#: id:20421
+msgid "If only one season"
+msgstr "Tik jeigu vienas sezonas"
+
+#: id:20422
+msgid "Always"
+msgstr "Visada"
+
+#: id:20423
+msgid "Has trailer"
+msgstr "Yra treileris"
+
+#: id:20424
+msgid "False"
+msgstr "Klaidingas"
+
+#: id:20425
+msgid "Fanart slideshow"
+msgstr "Prezentacijos Fanart"
+
+#: id:20426
+msgid "Export to a single file or separate"
+msgstr "Eksportuoti viename faile ar suskaidyti"
+
+#: id:20427
+msgid "files per entry?"
+msgstr "į atskirus failus kiekvienam įrašui?"
+
+#: id:20428
+msgid "Single file"
+msgstr "Vienu failu"
+
+#: id:20429
+msgctxt "Auto context with id 20429"
+msgid "Separate"
+msgstr "Suskaidyti"
+
+#: id:20430
+msgid "Export thumbnails and fanart?"
+msgstr "Eksportuoti eskizus ir Fanart?"
+
+#: id:20431
+msgid "Overwrite old files?"
+msgstr "Perrašyti senus failus?"
+
+#: id:20432
+msgid "Exclude path from library updates"
+msgstr "Pašalinti kelią iš atnaujintos bibliotekos"
+
+#: id:20433
+msgid "Extract thumbnails and video information"
+msgstr "Ištraukti miniatiūras iš vaizdo informacijos"
+
+#: id:20434
+msgid "Sets"
+msgstr "Rinkiniai"
+
+#: id:20435
+msgid "Set movieset thumb"
+msgstr "Nustatyti miniatiūras filmų rinkiniams"
+
+#: id:20436
+msgid "Export actor thumbs?"
+msgstr "Eksportuoti miniatiūras aktoriams?"
+
+#: id:20437
+msgid "Choose fanart"
+msgstr "Pasirinkti Fanart"
+
+#: id:20438
+msgid "Local fanart"
+msgstr "Vietinis Fanart"
+
+#: id:20439
+msgid "No fanart"
+msgstr "Be Fanart"
+
+#: id:20440
+msgid "Current fanart"
+msgstr "Aktualus Fanart"
+
+#: id:20441
+msgid "Remote fanart"
+msgstr "Išorinis Fanart"
+
+#: id:20442
+msgid "Change content"
+msgstr "Redaguoti turinį"
+
+#: id:20443
+msgid "Do you want to refresh info for all"
+msgstr "Norite atnaujinti informaciją visiems"
+
+#: id:20444
+msgid "items within this path?"
+msgstr "šio aplanko elementams?"
+
+#: id:20445
+msgid "Fanart"
+msgstr "Fanart"
+
+#: id:20446
+msgid "Locally stored information found."
+msgstr "Rasta vietoje saugoma informacija."
+
+#: id:20447
+msgid "Ignore and refresh from internet?"
+msgstr "Ignoruoti ir atnaujinti iš interneto?"
+
+#: id:20448
+msgid "Could not download information"
+msgstr "Nepavyko įkelti informacijos"
+
+#: id:20449
+msgid "Unable to connect to remote server"
+msgstr "Serveris nepasiekiamas."
+
+#: id:20450
+msgid "Would you like to continue scanning?"
+msgstr "Ar norite tęsti skenavimą?"
+
+#: id:20451
+msgid "Countries"
+msgstr "Šalis"
+
+#: id:20452
+msgid "episode"
+msgstr "Epizodas"
+
+#: id:20453
+msgid "episodes"
+msgstr "Epizodai"
+
+#: id:20454
+msgid "Listener"
+msgstr "Klausytojas"
+
+#: id:20455
+msgid "Listeners"
+msgstr "Klausytojų"
+
+#: id:20456
+msgid "Set movieset fanart"
+msgstr "Nustatyti rodomo filmo Fanart"
+
+#: id:20457
+msgid "Movie set"
+msgstr "Filmų rinkinys"
+
+#: id:20458
+msgid "Group movies in sets"
+msgstr "Grupiniai filmų rinkiniai"
+
+#: id:21330
+msgid "Show hidden files and directories"
+msgstr "Rodyti paslėptus failus ir aplankus"
+
+#: id:21331
+msgid "TuxBox client"
+msgstr "TuxBox klientas"
+
+#: id:21332
+msgid "WARNING: Target TuxBox device is in recording-mode!"
+msgstr "DĖMESIO: TuxBox yra įrašymo režime!"
+
+#: id:21333
+msgid "The stream will be stopped!"
+msgstr "Srautas bus sustabdytas!"
+
+#: id:21334
+msgid "Zap to channel: %s failed!"
+msgstr "Nesėkmingas perjungimas į kanalą %s!"
+
+#: id:21335
+msgid "Are you sure to start the stream?"
+msgstr "Ar esate tikri, kad paleisti srautą?"
+
+#: id:21336
+msgid "Connecting to: %s"
+msgstr "Prijungimas prie: %s"
+
+#: id:21337
+msgid "TuxBox device"
+msgstr "TuxBox prietaisas"
+
+#: id:21359
+msgid "Add media share..."
+msgstr "Pridėti medijos resursai..."
+
+#: id:21360
+msgid "Share video and music libraries through UPnP"
+msgstr "Prieiga prie medija resursai per UPnP"
+
+#: id:21364
+msgid "Edit media share"
+msgstr "Pakeisti media resursai"
+
+#: id:21365
+msgid "Remove media share"
+msgstr "Pašalinti media resursai"
+
+#: id:21366
+msgid "Subtitle folder"
+msgstr "Ypatingas aplankas subtitrams"
+
+#: id:21367
+msgid "Movie & alternate subtitle directory"
+msgstr "Aplankas filmams ir alternatyviems subtitrams"
+
+#: id:21368
+msgid "Override ASS/SSA subtitles fonts"
+msgstr "Nepaisyti ASS/SSA subtitrų šriftų"
+
+#: id:21369
+msgid "Enable mouse and Touch Screen support"
+msgstr "Įjungti pelę ir Touch Screen palaikymą"
+
+#: id:21370
+msgid "Play navigation sounds during media playback"
+msgstr "Garsų peržiūros metu sąsaja"
+
+#: id:21371
+msgid "Thumbnail"
+msgstr "Miniatiūros"
+
+#: id:21372
+msgid "Forced DVD player region"
+msgstr "Nustatyti regioną DVD grotuve"
+
+#: id:21373
+msgid "Video output"
+msgstr "Vaizdo"
+
+#: id:21374
+msgid "Video aspect"
+msgstr "Vaizdo aspektas"
+
+#: id:21375
+msgctxt "Auto context with id 21375"
+msgid "Normal"
+msgstr "Normalus"
+
+#: id:21376
+msgid "Letterbox"
+msgstr "Letterbox"
+
+#: id:21377
+msgid "Widescreen"
+msgstr "Plačiaekranis"
+
+#: id:21378
+msgid "Enable 480p"
+msgstr "Įjungti 480p"
+
+#: id:21379
+msgid "Enable 720p"
+msgstr "Įjungti 720p"
+
+#: id:21380
+msgid "Enable 1080i"
+msgstr "Įjungti 1080i"
+
+#: id:21381
+msgid "Enter name of new playlist"
+msgstr "Įveskite naują grojaraščio pavadinimą"
+
+#: id:21382
+msgid "Show \"Add source\" buttons in file lists"
+msgstr "Rodyti \"Pridėti kodai\" failų sąraše"
+
+#: id:21383
+msgid "Enable scrollbars"
+msgstr "Įjungti slinkties juostas"
+
+#: id:21384
+msgid "Make watched filtering a toggle in video library"
+msgstr "Žymėti varnele peržiūrėtą vaizdo įrašą bibliotekoje"
+
+#: id:21385
+msgctxt "Auto context with id 21385"
+msgid "Open"
+msgstr "Atidaryti"
+
+#: id:21386
+msgid "Acoustic management level"
+msgstr "Akustikos lygio reguliavimas"
+
+#: id:21387
+msgid "Fast"
+msgstr "Greitas"
+
+#: id:21388
+msgid "Quiet"
+msgstr "Lėtas"
+
+#: id:21389
+msgid "Enable custom background"
+msgstr "Leisti savo fono paveikslėlius"
+
+#: id:21390
+msgid "Power management level"
+msgstr "Energijos valdymas"
+
+#: id:21391
+msgid "High power"
+msgstr "Visa energija"
+
+#: id:21392
+msgid "Low power"
+msgstr "Mažiau energijos"
+
+#: id:21393
+msgid "High standby"
+msgstr "Išsamus laukimas"
+
+#: id:21394
+msgid "Low standby"
+msgstr "Sumažintas laukimas"
+
+#: id:21395
+msgid "Unable to cache files bigger than 4GB"
+msgstr "Neįmanoma įkelti failo didesnio kaip 4 GB"
+
+#: id:21396
+msgid "Chapter"
+msgstr "Skyrius"
+
+#: id:21397
+msgid "High quality pixel shader v2"
+msgstr "Aukštos kokybės Pixel Shader v2"
+
+#: id:21398
+msgid "Enable playlist at startup"
+msgstr "Įgalinti grojaraštį paleidimo metu"
+
+#: id:21399
+msgid "Use tween animations"
+msgstr "Naudokite Tween animaciją"
+
+#: id:21400
+msgid "contains"
+msgstr "sudėtyje yra"
+
+#: id:21401
+msgid "does not contain"
+msgstr "sudėtyje nėra"
+
+#: id:21402
+msgid "is"
+msgstr "yra"
+
+#: id:21403
+msgid "is not"
+msgstr "nėra"
+
+#: id:21404
+msgid "starts with"
+msgstr "prasideda nuo"
+
+#: id:21405
+msgid "ends with"
+msgstr "baigiasi"
+
+#: id:21406
+msgid "greater than"
+msgstr "daugiau negu"
+
+#: id:21407
+msgid "less than"
+msgstr "mažiau negu"
+
+#: id:21408
+msgid "after"
+msgstr "po"
+
+#: id:21409
+msgid "before"
+msgstr "prieš"
+
+#: id:21410
+msgid "in the last"
+msgstr "gale"
+
+#: id:21411
+msgid "not in the last"
+msgstr "pradžioj"
+
+#: id:21412
+msgid "Scrapers"
+msgstr "'Scrapers'"
+
+#: id:21413
+msgid "Default movie scraper"
+msgstr "Numatytasis filmų 'scraper'"
+
+#: id:21414
+msgid "Default tvshow scraper"
+msgstr "Numatytasis serialų 'scraper'"
+
+#: id:21415
+msgid "Default music video scraper"
+msgstr "Numatytasis vaizdo klipų 'scraper'"
+
+#: id:21416
+msgid "Enable fallback based on scraper language"
+msgstr "Leisti taisyti 'scraper' kalbą"
+
+#: id:21417
+msgid "- Settings"
+msgstr "- Nustatymai"
+
+#: id:21418
+msgid "Multilingual"
+msgstr "Daugiakalbis"
+
+#: id:21419
+msgid "No scrapers present"
+msgstr "Šaltinių informacija neegzistuoja"
+
+#: id:21420
+msgid "Value to match"
+msgstr "Reikšmė per didelė"
+
+#: id:21421
+msgid "Smart playlist rule"
+msgstr "Išmoningo grojaraštčio taisyklė"
+
+#: id:21422
+msgid "Match items where"
+msgstr "Pažymėkite objektus kuriuos"
+
+#: id:21423
+msgid "New rule..."
+msgstr "Nauja taisyklė..."
+
+#: id:21424
+msgid "Items must match"
+msgstr "Objektai turi atitikti"
+
+#: id:21425
+msgid "all of the rules"
+msgstr "visas taisykles"
+
+#: id:21426
+msgid "one or more of the rules"
+msgstr "vieną ar daugiau taisyklių"
+
+#: id:21427
+msgid "Limit to"
+msgstr "Riboti iki"
+
+#: id:21428
+msgid "No limit"
+msgstr "Be apribojimų"
+
+#: id:21429
+msgid "Order by"
+msgstr "Rūšiuoti pagal"
+
+#: id:21430
+msgid "ascending"
+msgstr "didėjimo tvarka"
+
+#: id:21431
+msgid "descending"
+msgstr "mažėjimo tvarka"
+
+#: id:21432
+msgid "Edit smart playlist"
+msgstr "Grojaraščio redagavimas"
+
+#: id:21433
+msgid "Name of the playlist"
+msgstr "Grojaraščio pavadinimas"
+
+#: id:21434
+msgid "Find items where"
+msgstr "Ieškoti objektų, katruose"
+
+#: id:21435
+msgid "Edit"
+msgstr "Redaguoti"
+
+#: id:21436
+msgid "%i items"
+msgstr "%i objektą(-us,ai)"
+
+#: id:21437
+msgid "New smart playlist..."
+msgstr "Naujas išmoningas grojaraštis..."
+
+#: id:21438
+msgid "%c Drive"
+msgstr "%c Diskas"
+
+#: id:21439
+msgid "Edit party mode rules"
+msgstr "Keisti režimo taisykles 'Party'"
+
+#: id:21440
+msgid "Home folder"
+msgstr "Namų papkė"
+
+#: id:21441
+msgid "Watched count"
+msgstr "Peržiūros kiekis"
+
+#: id:21442
+msgid "Episode title"
+msgstr "Epizodo pavadinimas"
+
+#: id:21443
+msgid "Video resolution"
+msgstr "Video rezoliucija"
+
+#: id:21444
+msgid "Audio channels"
+msgstr "Audio kanalai"
+
+#: id:21445
+msgid "Video codec"
+msgstr "Vaizdo koduotė"
+
+#: id:21446
+msgid "Audio codec"
+msgstr "Audio koduotė"
+
+#: id:21447
+msgid "Audio language"
+msgstr "Audio kalba"
+
+#: id:21448
+msgid "Subtitle language"
+msgstr "Subtitrų kalbos"
+
+#: id:21449
+msgid "Remote control sends keyboard presses"
+msgstr "Distancinis pultas siunčia klaviatūros kodą"
+
+#: id:21450
+msgid "- Edit"
+msgstr "- Redaguoti"
+
+#: id:21451
+msgid "Internet connection required."
+msgstr "Reikalingas interneto ryšys"
+
+#: id:21452
+msgid "Get More..."
+msgstr "Dar..."
+
+#: id:21453
+msgid "Root filesystem"
+msgstr "Šakninė FS"
+
+#: id:21454
+msgid "Cache full"
+msgstr "Talpykla pilna"
+
+#: id:21455
+msgid "Cache filled before reaching required amount for continous playback"
+msgstr "Pasiekti reikiamą lygį iki nepertraukiamo grojimo talpyklos užpildymo"
+
+#: id:21460
+msgid "Subtitle location"
+msgstr "Subtitrų vieta"
+
+#: id:21461
+msgid "Fixed"
+msgstr "Fiksuotas"
+
+#: id:21462
+msgid "Bottom of video"
+msgstr "Apačioje video"
+
+#: id:21463
+msgid "Below video"
+msgstr "Žemiau video"
+
+#: id:21464
+msgid "Top of video"
+msgstr "Į viršų video"
+
+#: id:21465
+msgid "Above video"
+msgstr "Aukštai video"
+
+#: id:21800
+msgid "File name"
+msgstr "Failo pavadinimas"
+
+#: id:21801
+msgid "File path"
+msgstr "Failo maršrutas"
+
+#: id:21802
+msgid "File size"
+msgstr "Failo dydis"
+
+#: id:21803
+msgid "File date/time"
+msgstr "Failo Data/Laikas"
+
+#: id:21804
+msgid "Slide index"
+msgstr "Prezentacijos indekas"
+
+#: id:21805
+msgctxt "Auto context with id 21805"
+msgid "Resolution"
+msgstr "Išmatavimai"
+
+#: id:21806
+msgctxt "Auto context with id 21806"
+msgid "Comment"
+msgstr "Komentaras"
+
+#: id:21807
+msgid "Colour/B&W"
+msgstr "Spalva/B&W"
+
+#: id:21808
+msgid "JPEG process"
+msgstr "JPEG eiga"
+
+#: id:21820
+msgid "Date/Time"
+msgstr "Data/Laikas"
+
+#: id:21821
+msgid "Description"
+msgstr "Aprašymas"
+
+#: id:21822
+msgid "Camera make"
+msgstr "Gamintojas"
+
+#: id:21823
+msgid "Camera model"
+msgstr "Kameros modelis"
+
+#: id:21824
+msgid "EXIF comment"
+msgstr "EXIF komentaras"
+
+#: id:21825
+msgid "Firmware"
+msgstr "Atnaujinimas"
+
+#: id:21826
+msgid "Aperture"
+msgstr "Diafragma"
+
+#: id:21827
+msgid "Focal length"
+msgstr "Fokusavimo nuotolis"
+
+#: id:21828
+msgid "Focus distance"
+msgstr "Fokusavimo atstumas"
+
+#: id:21829
+msgid "Exposure"
+msgstr "Ekspozicijos"
+
+#: id:21830
+msgid "Exposure time"
+msgstr "Ekspozicijos laikas"
+
+#: id:21831
+msgid "Exposure bias"
+msgstr "Ekspozicijos poslinkis"
+
+#: id:21832
+msgid "Exposure mode"
+msgstr "Ekspozicijos režimas"
+
+#: id:21833
+msgid "Flash used"
+msgstr "Su blykste"
+
+#: id:21834
+msgid "White-balance"
+msgstr "Baltumo balansas"
+
+#: id:21835
+msgid "Light source"
+msgstr "Šviesos šaltinis"
+
+#: id:21836
+msgid "Metering mode"
+msgstr "Matavimo režimas"
+
+#: id:21837
+msgid "ISO"
+msgstr "ISO"
+
+#: id:21838
+msgid "Digital zoom"
+msgstr "Skaitmeninis zoom"
+
+#: id:21839
+msgid "CCD width"
+msgstr "Plotis CCD"
+
+#: id:21840
+msgid "GPS latitude"
+msgstr "GPS platuma"
+
+#: id:21841
+msgid "GPS longitude"
+msgstr "GPS ilguma"
+
+#: id:21842
+msgid "GPS altitude"
+msgstr "GPS aukštis"
+
+#: id:21843
+msgid "Orientation"
+msgstr "Orientacija"
+
+#: id:21860
+msgid "Supplemental categories"
+msgstr "Daugiau kategorijų"
+
+#: id:21861
+msgid "Keywords"
+msgstr "Raktiniai žodžiai"
+
+#: id:21862
+msgid "Caption"
+msgstr "Titras"
+
+#: id:21863
+msgid "Author"
+msgstr "Autorius"
+
+#: id:21864
+msgid "Headline"
+msgstr "Antraštė"
+
+#: id:21865
+msgid "Special instructions"
+msgstr "Specialios instrukcijos"
+
+#: id:21866
+msgid "Category"
+msgstr "Kategorija"
+
+#: id:21867
+msgid "Byline"
+msgstr "Parašas"
+
+#: id:21868
+msgid "Byline title"
+msgstr "Parašo pavadinimas"
+
+#: id:21869
+msgid "Credit"
+msgstr "Autorius"
+
+#: id:21870
+msgid "Source"
+msgstr "Šaltinis"
+
+#: id:21871
+msgid "Copyright notice"
+msgstr "Autorinės teisės"
+
+#: id:21872
+msgid "Object name"
+msgstr "Objekto pavadinimas"
+
+#: id:21873
+msgid "City"
+msgstr "Miestas"
+
+#: id:21874
+msgid "State"
+msgstr "Valstybė (JAV)"
+
+#: id:21875
+msgctxt "Auto context with id 21875"
+msgid "Country"
+msgstr "Šalis"
+
+#: id:21876
+msgid "Original Tx Reference"
+msgstr "Originalus Tx Reference"
+
+#: id:21877
+msgid "Date created"
+msgstr "Sukūrimo data"
+
+#: id:21878
+msgid "Copyright flag"
+msgstr "Autorinės teisės ženklas"
+
+#: id:21879
+msgid "Country code"
+msgstr "Šalies kodas"
+
+#: id:21880
+msgid "Reference service"
+msgstr "Nuorodos tarnyba"
+
+#: id:21881
+msgid "Allow control of XBMC via UPnP"
+msgstr "Vykdyti kontrolę XBMC per UPnP"
+
+#: id:21882
+msgid "Attempt to skip introduction before DVD menu"
+msgstr "Bandyti praleisti DVD įrašą"
+
+#: id:21883
+msgid "Saved music"
+msgstr "Nuskaityti Audio CD diskai"
+
+#: id:21884
+msgid "Query info for all artists"
+msgstr "Užklausa apie visus atlikėjus"
+
+#: id:21885
+msgid "Downloading album information"
+msgstr "Atsisiunčiama albumo informacija"
+
+#: id:21886
+msgid "Downloading artist information"
+msgstr "Atsisiunčiama atlikėjo informacija"
+
+#: id:21887
+msgid "Biography"
+msgstr "Biografija"
+
+#: id:21888
+msgid "Discography"
+msgstr "Diskografija"
+
+#: id:21889
+msgid "Searching artist"
+msgstr "Ieškoti atlikėjo"
+
+#: id:21890
+msgid "Select artist"
+msgstr "Pasirinkite atlikėją"
+
+#: id:21891
+msgctxt "Auto context with id 21891"
+msgid "Artist information"
+msgstr "Atlikėjo duomenys"
+
+#: id:21892
+msgid "Instruments"
+msgstr "Instrumentai"
+
+#: id:21893
+msgid "Born"
+msgstr "Gimė"
+
+#: id:21894
+msgid "Formed"
+msgstr "Sukūrė"
+
+#: id:21895
+msgid "Themes"
+msgstr "Temos"
+
+#: id:21896
+msgid "Disbanded"
+msgstr "Iširo"
+
+#: id:21897
+msgid "Died"
+msgstr "Mirė"
+
+#: id:21898
+msgid "Years active"
+msgstr "Kurybų metai"
+
+#: id:21899
+msgid "Label"
+msgstr "Etiketė"
+
+#: id:21900
+msgid "Born/Formed"
+msgstr "Susikūrė/Susiformavo"
+
+#: id:22000
+msgid "Update library on startup"
+msgstr "Atnaujinti biblioteką paleidžiant"
+
+#: id:22001
+msgid "Hide progress of library updates"
+msgstr "Visada atnaujinti biblioteką fone"
+
+#: id:22002
+msgid "- DNS suffix"
+msgstr "- DNS suffix"
+
+#: id:22003
+msgid "%2.3fs"
+msgstr "%2.3fс"
+
+#: id:22004
+msgid "Delayed by: %2.3fs"
+msgstr "Delsimas: %2.3fс"
+
+#: id:22005
+msgid "Ahead by: %2.3fs"
+msgstr "Į priekį: %2.3fс"
+
+#: id:22006
+msgid "Subtitle offset"
+msgstr "Subtitrų poslinkis"
+
+#: id:22007
+msgid "OpenGL vendor:"
+msgstr "OpenGL vendor:"
+
+#: id:22008
+msgid "OpenGL renderer:"
+msgstr "OpenGL renderer:"
+
+#: id:22009
+msgid "OpenGL version:"
+msgstr "OpenGL versija:"
+
+#: id:22010
+msgid "GPU temperature:"
+msgstr "GPU temperatūra:"
+
+#: id:22011
+msgid "CPU temperature:"
+msgstr "CPU temperatūra:"
+
+#: id:22012
+msgid "Total memory"
+msgstr "Viso atminties"
+
+#: id:22013
+msgid "Profile data"
+msgstr "Profilio duomenys"
+
+#: id:22014
+msgid "Use dim if paused during video playback"
+msgstr "Pritemdyti, kai peržiuros metu pristabdoma"
+
+#: id:22015
+msgid "All recordings"
+msgstr "Visi įrašai"
+
+#: id:22016
+msgid "By title"
+msgstr "Pagal vardą"
+
+#: id:22017
+msgid "By group"
+msgstr "Pagal grupę"
+
+#: id:22018
+msgid "Live channels"
+msgstr "Tiesioginiai kanalai"
+
+#: id:22019
+msgid "Recordings by title"
+msgstr "Įrašai pagal pavadinimą"
+
+#: id:22020
+msgid "Guide"
+msgstr "Gidas"
+
+#: id:22021
+msgid "Allowed error in aspect ratio to minimize black bars"
+msgstr "Leidžiama proporcijos klaida juodų juostų mažinimui"
+
+#: id:22022
+msgid "Show video files in listings"
+msgstr "Rodyti vaizdo failų sąrašus"
+
+#: id:22023
+msgid "DirectX vendor:"
+msgstr "DirectX vendor:"
+
+#: id:22024
+msgid "Direct3D version:"
+msgstr "Direct3D version:"
+
+#: id:22030
+msgctxt "Auto context with id 22030"
+msgid "Font"
+msgstr "- Šriftas"
+
+#: id:22031
+msgctxt "Auto context with id 22031"
+msgid "- Size"
+msgstr "- Dydis"
+
+#: id:22032
+msgctxt "Auto context with id 22032"
+msgid "- Colours"
+msgstr "- Spalva"
+
+#: id:22033
+msgid "- Charset"
+msgstr "- Koduotė"
+
+#: id:22034
+msgid "Export karaoke titles as HTML"
+msgstr "Eksportuoti karaoke tekstą HTML formatu"
+
+#: id:22035
+msgid "Export karaoke titles as CSV"
+msgstr "Eksportuoti karaoke tekstą CSV formatu"
+
+#: id:22036
+msgid "Import karaoke titles..."
+msgstr "Importuoti karaoke tekstą..."
+
+#: id:22037
+msgid "Show song selector automatically"
+msgstr "Automatinis dainų pasirinkimas"
+
+#: id:22038
+msgid "Export karaoke titles..."
+msgstr "Eksportuoti karaoke tekstą..."
+
+#: id:22039
+msgid "Enter song number"
+msgstr "Įveskite dainos numerį"
+
+#: id:22040
+msgid "white/green"
+msgstr "baltas/žalias"
+
+#: id:22041
+msgid "white/red"
+msgstr "baltas/raudonas"
+
+#: id:22042
+msgid "white/blue"
+msgstr "baltas/mėlynas"
+
+#: id:22043
+msgid "black/white"
+msgstr "juodas/baltas"
+
+#: id:22079
+msgid "Default select action"
+msgstr "Numatytas veiksmas, kai pasirenkate"
+
+#: id:22080
+msgid "Choose"
+msgstr "Pasirinkti"
+
+#: id:22081
+msgid "Show Information"
+msgstr "Papildomai"
+
+#: id:22082
+msgid "More..."
+msgstr "Daugiau..."
+
+#: id:22083
+msgid "Play all"
+msgstr "Groti viską"
+
+#: id:23049
+msgid "Teletext not available"
+msgstr "Teletekstas negalimas"
+
+#: id:23050
+msgid "Activate Teletext"
+msgstr "Aktyvuoti teletekstą"
+
+#: id:23051
+msgid "Part %i"
+msgstr "Dalis %i"
+
+#: id:23052
+msgid "Buffering %i bytes"
+msgstr "Buferizacija %i bait"
+
+#: id:23053
+msgid "Stopping"
+msgstr "Sustabdyti"
+
+#: id:23054
+msgid "Running"
+msgstr "Paleisti"
+
+#: id:23100
+msgid "External Player Active"
+msgstr "Aktyvuotas išorės grotuvas"
+
+#: id:23101
+msgid "Click OK to terminate the player"
+msgstr "Paspauskite OK grotuvui atjungti"
+
+#: id:23104
+msgid "Click OK when playback has ended"
+msgstr "Paspauskite OK baigus groti"
+
+#: id:24000
+msgid "Add-on"
+msgstr "Priedas"
+
+#: id:24001
+msgid "Add-ons"
+msgstr "Priedai"
+
+#: id:24002
+msgid "Add-on options"
+msgstr "Priedų parinktys"
+
+#: id:24003
+msgid "Add-on Information"
+msgstr "Priedų informacija"
+
+#: id:24005
+msgctxt "Auto context with id 24005"
+msgid "Media sources"
+msgstr "Duomenų šaltiniai"
+
+#: id:24007
+msgctxt "Auto context with id 24007"
+msgid "Movie information"
+msgstr "Filmų informacija"
+
+#: id:24008
+msgctxt "Auto context with id 24008"
+msgid "Screensaver"
+msgstr "Užsklanda"
+
+#: id:24009
+msgid "Script"
+msgstr "Skriptai"
+
+#: id:24010
+msgctxt "Auto context with id 24010"
+msgid "Visualization"
+msgstr "Vizualizacija"
+
+#: id:24011
+msgid "Add-on repository"
+msgstr "Priedų saugykla"
+
+#: id:24012
+msgctxt "Auto context with id 24012"
+msgid "Subtitles"
+msgstr "Subtitrai"
+
+#: id:24013
+msgid "Lyrics"
+msgstr "Tekstai"
+
+#: id:24014
+msgid "TV information"
+msgstr "TV informacija"
+
+#: id:24015
+msgctxt "Auto context with id 24015"
+msgid "Music video information"
+msgstr "Vaizdo klipų informacija"
+
+#: id:24016
+msgctxt "Auto context with id 24016"
+msgid "Album information"
+msgstr "Albumų informacija"
+
+#: id:24017
+msgctxt "Auto context with id 24017"
+msgid "Artist information"
+msgstr "Atlikėjų informacija"
+
+#: id:24018
+msgctxt "Auto context with id 24018"
+msgid "Services"
+msgstr "Servisas"
+
+#: id:24020
+msgid "Configure"
+msgstr "Pritaikyti"
+
+#: id:24021
+msgctxt "Auto context with id 24021"
+msgid "Disable"
+msgstr "Išjungti"
+
+#: id:24022
+msgid "Enable"
+msgstr "Įjungti"
+
+#: id:24023
+msgid "Add-on disabled"
+msgstr "Priedas atjungtas"
+
+#: id:24027
+msgctxt "Auto context with id 24027"
+msgid "Weather"
+msgstr "Orai"
+
+#: id:24028
+msgid "Weather.com (standard)"
+msgstr "Weather.com (standartinis)"
+
+#: id:24030
+msgid "This Add-on can not be configured"
+msgstr "Šis priedas negali būti sukonfigūruotas"
+
+#: id:24031
+msgid "Error loading settings"
+msgstr "Klaida įkeliant nustatymus"
+
+#: id:24032
+msgid "All Add-ons"
+msgstr "Visi priedai"
+
+#: id:24033
+msgid "Get Add-ons"
+msgstr "Gauti priedus"
+
+#: id:24034
+msgid "Check for updates"
+msgstr "Patikrinti atnaujinimus"
+
+#: id:24035
+msgid "Force refresh"
+msgstr "Priverstinis atnaujinimas"
+
+#: id:24036
+msgid "Change log"
+msgstr "Pakeitimų aprašas"
+
+#: id:24037
+msgid "Uninstall"
+msgstr "Išdiegti"
+
+#: id:24038
+msgid "Install"
+msgstr "Nustatyti"
+
+#: id:24039
+msgid "Disabled Add-ons"
+msgstr "Išjungti priedus"
+
+#: id:24040
+msgid "(Clear the current setting)"
+msgstr "(Išvalyti dabartinius nustatymus)"
+
+#: id:24041
+msgid "Install from zip file"
+msgstr "Įdiegti iš failo *.zip"
+
+#: id:24042
+msgid "Downloading %i%%"
+msgstr "Atsisiųsti %i%%"
+
+#: id:24043
+msgid "Available Updates"
+msgstr "Prieinami atnaujinimai"
+
+#: id:24044
+msgid "Dependencies not met"
+msgstr "Priklausomybės neįvykdytos"
+
+#: id:24045
+msgid "Add-on does not have the correct structure"
+msgstr "Priedai neatitinka teisingos struktūros"
+
+#: id:24046
+msgid "%s is used by the following installed add-on(s)"
+msgstr "%s įdiegti taip kaip yra naudojama priedai(us)"
+
+#: id:24047
+msgid "This add-on cannot be uninstalled"
+msgstr "Šis priedas negali būti pašalintas"
+
+#: id:24048
+msgid "Rollback"
+msgstr "Gryžti"
+
+#: id:24050
+msgid "Available Add-ons"
+msgstr "Prieinami priedai"
+
+#: id:24051
+msgid "Version:"
+msgstr "Versija:"
+
+#: id:24052
+msgid "Disclaimer"
+msgstr "Atsisakymas"
+
+#: id:24053
+msgid "License:"
+msgstr "Licenzija:"
+
+#: id:24054
+msgid "Changelog"
+msgstr "Pakeitimų sąrašas"
+
+#: id:24059
+msgid "Would you like to enable this Add-on?"
+msgstr "Jūs norite įjungti priedus?"
+
+#: id:24060
+msgid "Would you like to disable this Add-on?"
+msgstr "Jūs norite išjungti priedus?"
+
+#: id:24061
+msgid "Add-on update available!"
+msgstr "Galimi priedų atnaujinimai!"
+
+#: id:24062
+msgid "Enabled Add-ons"
+msgstr "Įjungti priedus"
+
+#: id:24063
+msgid "Auto update"
+msgstr "Auto atnaujinimas"
+
+#: id:24064
+msgid "Add-on enabled"
+msgstr "Priedas įtrauktas"
+
+#: id:24065
+msgid "Add-on updated"
+msgstr "Priedas atnaujintas"
+
+#: id:24066
+msgid "Cancel Add-on download?"
+msgstr "Atšaukti priedų naujinimą?"
+
+#: id:24067
+msgid "Currently downloading Add-ons"
+msgstr "Kraunami priedai:"
+
+#: id:24068
+msgid "Update available"
+msgstr "Galimas atnaujinimas"
+
+#: id:24069
+msgid "Update"
+msgstr "Atnaujinti"
+
+#: id:24070
+msgid "Add-on could not be loaded."
+msgstr "Priedas negali būti naudojamas"
+
+#: id:24071
+msgid "An unknown error has occurred."
+msgstr "Nežinoma klaida"
+
+#: id:24072
+msgid "Settings required"
+msgstr "Reikalinga koregavimas"
+
+#: id:24073
+msgid "Could not connect"
+msgstr "Neįmanoma prisijungti"
+
+#: id:24074
+msgid "Needs to restart"
+msgstr "Reikia iš naujo paleisti"
+
+#: id:24075
+msgctxt "Auto context with id 24075"
+msgid "Disable"
+msgstr "Išjungti"
+
+#: id:24076
+msgid "Add-on Required"
+msgstr "Priedas Būtinas"
+
+#: id:24080
+msgid "Try to reconnect?"
+msgstr "Pabandyti iš naujo prisijungti?"
+
+#: id:24089
+msgid "Add-on restarts"
+msgstr "Priedas atnaujinamas"
+
+#: id:24090
+msgid "Lock Add-on manager"
+msgstr "Blokuoti Priedų menedžerį"
+
+#: id:24094
+msgid "(current)"
+msgstr "(dabar)"
+
+#: id:24095
+msgid "(blacklisted)"
+msgstr "(juod.sarašas)"
+
+#: id:24096
+msgid "Add-on has been marked as broken in repository."
+msgstr "Priedas pažymėtas kaip sugadintas."
+
+#: id:24097
+msgid "Would you like to disable it on your system?"
+msgstr "Norite atjungti jį savo sistemoje?"
+
+#: id:24098
+msgid "Broken"
+msgstr "Sugadintas"
+
+#: id:24099
+msgid "Would you like to switch to this skin?"
+msgstr "Jūs norite įjungti šį viršelį?"
+
+#: id:24100
+msgid "To use this feature you must download an Add-on:"
+msgstr "Norėdami naudotis šią funkciją, turite atsisiųsti priedą:"
+
+#: id:24101
+msgid "Would you like to download this Add-on?"
+msgstr "Ar norite atsisiųsti šį Priedą?"
+
+#: id:25000
+msgid "Notifications"
+msgstr "Pranešimai"
+
+#: id:29800
+msgid "Library Mode"
+msgstr "Bibliotekos režimas"
+
+#: id:29801
+msgid "QWERTY keyboard"
+msgstr "QWERTY komutatorius"
+
+#: id:29802
+msgid "Passthrough Audio in use"
+msgstr "Įjungtas Passthrough Audio"
+
+#: id:33001
+msgid "Trailer quality"
+msgstr "Treilerio kokybė"
+
+#: id:33002
+msgid "Stream"
+msgstr "Srautas"
+
+#: id:33003
+msgid "Download"
+msgstr "Atsisiųsti"
+
+#: id:33004
+msgid "Download & play"
+msgstr "Atsisiųsti ir groti"
+
+#: id:33005
+msgid "Download & save"
+msgstr "Atsisiųsti ir išsaugoti"
+
+#: id:33006
+msgid "Today"
+msgstr "Šiandien"
+
+#: id:33007
+msgid "Tomorrow"
+msgstr "Rytoj"
+
+#: id:33008
+msgid "Saving"
+msgstr "Išsaugojimas"
+
+#: id:33009
+msgid "Copying"
+msgstr "Kopijavimas"
+
+#: id:33010
+msgid "Set download directory"
+msgstr "Nustatyti parsisiuntimui kelią"
+
+#: id:33011
+msgid "Search duration"
+msgstr "Paieškų trukmė"
+
+#: id:33012
+msgid "Short"
+msgstr "Trumpa"
+
+#: id:33013
+msgid "Long"
+msgstr "Ilga"
+
+#: id:33014
+msgid "Use DVD player instead of regular player"
+msgstr "Naudokite DVD grotuvą vietoj..."
+
+#: id:33015
+msgid "Ask for download before playing video"
+msgstr "Atsisiųsti video prieš grojant"
+
+#: id:33016
+msgid "Clips"
+msgstr "Vaizdo klipai"
+
+#: id:33017
+msgid "Restart plugin to enable"
+msgstr "Norėdami įjungti modulį, turit iš naujo paleisti"
+
+#: id:33018
+msgid "Tonight"
+msgstr "Šį vakarą"
+
+#: id:33019
+msgid "Tomorrow Night"
+msgstr "Ryt vakare"
+
+#: id:33020
+msgid "Condition"
+msgstr "Sąlygos"
+
+#: id:33021
+msgid "Precipitation"
+msgstr "Krituliai"
+
+#: id:33022
+msgid "Precip"
+msgstr "Krituliai"
+
+#: id:33023
+msgid "Humid"
+msgstr "Drėgmė"
+
+#: id:33024
+msgid "Feels"
+msgstr "Jaučiasi"
+
+#: id:33025
+msgid "Observed"
+msgstr "Laikomasi"
+
+#: id:33026
+msgid "Departure from normal"
+msgstr "Nukrypimas nuo normos"
+
+#: id:33027
+msgid "Sunrise"
+msgstr "Saulėtekis"
+
+#: id:33028
+msgid "Sunset"
+msgstr "Saulėlydis"
+
+#: id:33029
+msgid "Details"
+msgstr "Išsamiau"
+
+#: id:33030
+msgid "Outlook"
+msgstr "Numatoma"
+
+#: id:33031
+msgid "Coverflow"
+msgstr "Albumų viršeliai"
+
+#: id:33032
+msgid "Translate text"
+msgstr "Išversti tekstą"
+
+#: id:33033
+msgid "Map list %s category"
+msgstr "Žemėlapis %s kategorija"
+
+#: id:33034
+msgid "36 Hour"
+msgstr "36 val."
+
+#: id:33035
+msgid "Maps"
+msgstr "Kortelės"
+
+#: id:33036
+msgid "Hourly"
+msgstr "Kas valandą"
+
+#: id:33037
+msgid "Weekend"
+msgstr "Savaitgalis"
+
+#: id:33038
+msgid "%s day"
+msgstr "%s diena"
+
+#: id:33049
+msgid "Alert"
+msgstr "Signalas"
+
+#: id:33050
+msgid "Alerts"
+msgstr "Signalai"
+
+#: id:33051
+msgid "Choose Your"
+msgstr "Peržiūrėti Jūsų"
+
+#: id:33052
+msgid "Check"
+msgstr "Patikrinkite"
+
+#: id:33053
+msgctxt "Auto context with id 33053"
+msgid "Configure the"
+msgstr "Nustatykite"
+
+#: id:33054
+msgid "Seasons"
+msgstr "Sezonai"
+
+#: id:33055
+msgid "Use your"
+msgstr "Naudokite"
+
+#: id:33056
+msgid "Watch your"
+msgstr "Žiurėkite"
+
+#: id:33057
+msgid "Listen to"
+msgstr "Klausykite"
+
+#: id:33058
+msgid "View your"
+msgstr "Peržiurėkite"
+
+#: id:33059
+msgctxt "Auto context with id 33059"
+msgid "Configure the"
+msgstr "Pritaikykite"
+
+#: id:33060
+msgid "Power"
+msgstr "Energija"
+
+#: id:33061
+msgid "Menu"
+msgstr "Meniu"
+
+#: id:33062
+msgid "Play the"
+msgstr "Atkūrti"
+
+#: id:33063
+msgid "Options"
+msgstr "Nustatymai"
+
+#: id:33065
+msgid "Editor"
+msgstr "Redaktorius"
+
+#: id:33066
+msgid "About your"
+msgstr "Apie Jūsų"
+
+#: id:33067
+msgid "Star rating"
+msgstr "Įvertinimas žvaigždutėmis"
+
+#: id:33068
+msgid "Background"
+msgstr "Fonas"
+
+#: id:33069
+msgid "Backgrounds"
+msgstr "Fono variantai"
+
+#: id:33070
+msgid "Custom background"
+msgstr "Jūsų fonas"
+
+#: id:33071
+msgid "Custom backgrounds"
+msgstr "Jūsų fonai"
+
+#: id:33072
+msgid "View Readme"
+msgstr "Peržiurėti Readme"
+
+#: id:33073
+msgid "View Changelog"
+msgstr "Peržiurėti Changelog"
+
+#: id:33074
+msgid "This version of %s requires an"
+msgstr "Ši versija %s reikalauja"
+
+#: id:33075
+msgid "XBMC revision of %s or greater to run."
+msgstr "XBMC versijos %s arba naujesnės."
+
+#: id:33076
+msgid "Please update XBMC."
+msgstr "Prašome atnaujinti XBMC."
+
+#: id:33077
+msgid "No data found!"
+msgstr "Duomenų nerasta!"
+
+#: id:33078
+msgid "Next page"
+msgstr "Sekantis puslapis"
+
+#: id:33079
+msgid "Love"
+msgstr "Patinka"
+
+#: id:33080
+msgid "Hate"
+msgstr "Nepatinka"
+
+#: id:33081
+msgid "This file is stacked, select the part you want to play from."
+msgstr "Šis failas susideda iš kelių, pasirinkite dalį atkurimui."
+
+#: id:33082
+msgid "Path to script"
+msgstr "Kelias iki skripto"
+
+#: id:33083
+msgid "Enable custom script button"
+msgstr "Įtraukti savo skripto mygtuką"
+
+#: id:33100
+msgid "Failed to start"
+msgstr "Nepavyko paleisti"
+
+#: id:33101
+msgid "Webserver"
+msgstr "Tinklo serveris"
+
+#: id:33102
+msgid "Event Server"
+msgstr "Serverio įvykis"
+
+#: id:33103
+msgid "Remote communication server"
+msgstr "Nuotolinio ryšio serveris"
+
+#: id:33200
+msgid "Detected New Connection"
+msgstr "Aptiktas Naujas Pajungimas"
+
+#: id:34000
+msgid "Lame"
+msgstr "Lame"
+
+#: id:34001
+msgid "Vorbis"
+msgstr "Vorbis"
+
+#: id:34002
+msgid "Wav"
+msgstr "Wav"
+
+#: id:34003
+msgid "DXVA2"
+msgstr "DXVA2"
+
+#: id:34004
+msgid "VAAPI"
+msgstr "VAAPI"
+
+#: id:34005
+msgid "Flac"
+msgstr "Flac"
+
+#: id:34100
+msgid "Speaker Configuration"
+msgstr "Garsiakalbių konfiguracija"
+
+#: id:34101
+msgid "2.0"
+msgstr "2.0"
+
+#: id:34102
+msgid "2.1"
+msgstr "2.1"
+
+#: id:34103
+msgid "3.0"
+msgstr "3.0"
+
+#: id:34104
+msgid "3.1"
+msgstr "3.1"
+
+#: id:34105
+msgid "4.0"
+msgstr "4.0"
+
+#: id:34106
+msgid "4.1"
+msgstr "4.1"
+
+#: id:34107
+msgid "5.0"
+msgstr "5.0"
+
+#: id:34108
+msgid "5.1"
+msgstr "5.1"
+
+#: id:34109
+msgid "7.0"
+msgstr "7.0"
+
+#: id:34110
+msgid "7.1"
+msgstr "7.1"
+
+#: id:34201
+msgid "Can't find a next item to play"
+msgstr "Nerasta kito failo grojimui"
+
+#: id:34202
+msgid "Can't find a previous item to play"
+msgstr "Nerasta ankstesnio failo grojimui"
+
+#: id:34300
+msgid "Failed to start zeroconf"
+msgstr "Nesėkminga paleistis zeroconf"
+
+#: id:34301
+msgid "Is Apple's Bonjour Service installed? See log for more info."
+msgstr "Ar įdiegta \"Apple Bonjour\" tarnyba? Prisijungti, gauti daugiau info."
+
+#: id:34400
+msgid "Video Rendering"
+msgstr "Vaizdo Rendering"
+
+#: id:34401
+msgid "Failed to init video filters/scalers, falling back to bilinear scaling"
+msgstr "Bilinear mastelio paleidimo klaida, pirminio paleidimo vaizdo filters/scalers"
+
+#: id:34402
+msgid "Failed to initialize audio device"
+msgstr "Nepavyko inicijuoti garso prietaiso"
+
+#: id:34403
+msgid "Check your audiosettings"
+msgstr "Patikrinkite savo garso nustatymus"
+
+#: id:34404
+msgid "Use gestures for navigation:"
+msgstr ""
+
+#: id:34405
+msgid "1 finger swipe left,right,up,down for cursors"
+msgstr ""
+
+#: id:34406
+msgid "2 finger swipe left for backspace"
+msgstr ""
+
+#: id:34407
+msgid "1 finger single tap for enter"
+msgstr ""
+
+#: id:34408
+msgid "2 finger single tap for contextmenu"
+msgstr ""
+
+#: id:35000
+msgid "Peripherals"
+msgstr "Periferija"
+
+#: id:35001
+msgid "Generic HID device"
+msgstr "Bendras HID prietaisas"
+
+#: id:35002
+msgid "Generic network adapter"
+msgstr "Bendras tinklo adapteris"
+
+#: id:35003
+msgid "Generic disk"
+msgstr "Bendras diskas"
+
+#: id:35004
+msgid "There are no settings available\nfor this peripheral."
+msgstr "Nėra jokių prieinamų nustatymų\nšiai periferijai."
+
+#: id:35005
+msgid "New device configured"
+msgstr "Naujas prietaiso konfigūravimas"
+
+#: id:35006
+msgid "Device removed"
+msgstr "Pašalinti prietaisą"
+
+#: id:35007
+msgid "Keymap to use for this device"
+msgstr "Nuoroda, kaip naudoti šį prietaisą"
+
+#: id:35008
+msgid "Keymap enabled"
+msgstr "Nuoroda atidaryta"
+
+#: id:35009
+msgid "Do not use the custom keymap for this device"
+msgstr ""
+
+#: id:35500
+msgid "Location"
+msgstr "Padėtis"
+
+#: id:35501
+msgid "Class"
+msgstr "Kategorija"
+
+#: id:35502
+msgctxt "Auto context with id 35502"
+msgid "Name"
+msgstr "Vieta"
+
+#: id:35503
+msgid "Vendor"
+msgstr "Prekyba"
+
+#: id:35504
+msgid "Product ID"
+msgstr "Produkto ID"
+
+#: id:36000
+msgid "Pulse-Eight CEC adapter"
+msgstr "Pulse-Eight CEC adpteris"
+
+#: id:36001
+msgid "Pulse-Eight Nyxboard"
+msgstr "Pulse-Eight Nyxboard"
+
+#: id:36002
+msgid "Switch to keyboard side command"
+msgstr "Perjungti į klaviatūros komandas"
+
+#: id:36003
+msgid "Switch to remote side command"
+msgstr "Perjungti į pultelio komandas"
+
+#: id:36004
+msgid "Press \"user\" button command"
+msgstr "Paspauskite mygtuką \"Vartotojas\""
+
+#: id:36005
+msgid "Enable switch side commands"
+msgstr "Perjungti šalutinį komandų jungtį"
+
+#: id:36006
+msgid "Could not open the adapter"
+msgstr "Nepavyko atidaryti adapterio"
+
+#: id:36007
+msgid "Devices to power on when starting XBMC"
+msgstr "Įjungti maitinimą įrenginiuose, paleidžiant XBMC"
+
+#: id:36008
+msgid "Devices to power off when stopping XBMC"
+msgstr "Išjungti maitinimą įrenginiuose, sustabdant XBMC"
+
+#: id:36009
+msgid "Put devices in standby mode when activating screensaver"
+msgstr "Patalpinkite prietaisus laukimo režime, kai aktyvi ekrano užsklanda"
+
+#: id:36011
+msgid "Could not detect the CEC port. Set it up manually."
+msgstr "Nepavyko aptikti CEC prievado. Nustatyti jį rankiniu būdu."
+
+#: id:36012
+msgid "Could not initialise the CEC adapter. Check your settings."
+msgstr "Nepavyko aptikti CEC adapterio."
+
+#: id:36013
+msgid "Unsupported libCEC interface version. %d is greater than the version XBMC supports (%d)"
+msgstr "Nepalaikomas 'libec' sąsajos versija.%d atsisiuskite naujesnę XBMC versiją (%d)"
+
+#: id:36014
+msgid "Put this PC in standby mode when the TV is switched off"
+msgstr "Kompiuterį budėjimo režimu, kai televizorius yra išjungtas"
+
+#: id:36015
+msgid "HDMI port number"
+msgstr "HDMI prievado numeris"
+
+#: id:36016
+msgctxt "Auto context with id 36016"
+msgid "Connected"
+msgstr "Sujungtas"
+
+#: id:36017
+msgid "Adapter found, but libCEC is not available"
+msgstr "Adapteris rastas, bet Libcec nėra"
+
+#: id:36018
+msgid "Use the TV's language setting"
+msgstr "Naudokite TV kalbos nustatymus"
+
+#: id:36019
+msgid "Connected to HDMI device"
+msgstr ""
+
+#: id:36020
+msgid "Make XBMC the active source when starting"
+msgstr ""
+
+#: id:36021
+msgid "Physical address (overrules HDMI port)"
+msgstr ""
+
+#: id:36022
+msgid "COM port (leave empty unless needed)"
+msgstr ""
+
+#: id:36023
+msgid "Configuration updated"
+msgstr ""
+
+#: id:36024
+msgid "Failed to set the new configuration. Please check your settings."
+msgstr ""
+
+#: id:36025
+msgid "Send 'inactive source' command when stopping XBMC"
+msgstr ""
+

--- a/language/Maltese/strings.po
+++ b/language/Maltese/strings.po
@@ -1,0 +1,9093 @@
+# Converted from xbmc strings.xml with xbmc-xml2po (by Team-XBMC)
+msgid ""
+msgstr ""
+"Project-Id-Version: xbmc.core-FRODO_GIT3ed1604ad7\n"
+"Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
+"POT-Creation-Date: 2012-04-09 18:00+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE\n"
+"Language: mt\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: id:0
+msgctxt "Auto context with id 0"
+msgid "Programs"
+msgstr "Programmi"
+
+#: id:1
+msgctxt "Auto context with id 1"
+msgid "Pictures"
+msgstr "Ritratti"
+
+#: id:2
+msgctxt "Auto context with id 2"
+msgid "Music"
+msgstr "Mużika"
+
+#: id:3
+msgctxt "Auto context with id 3"
+msgid "Videos"
+msgstr "Filmati"
+
+#: id:4
+msgid "TV-Guide"
+msgstr "Il-Gwida"
+
+#: id:5
+msgctxt "Auto context with id 5"
+msgid "Settings"
+msgstr "Settings"
+
+#: id:6
+msgid "XBMC SVN"
+msgstr ""
+
+#: id:7
+msgctxt "Auto context with id 7"
+msgid "File manager"
+msgstr "Fajls"
+
+#: id:8
+msgctxt "Auto context with id 8"
+msgid "Weather"
+msgstr "It-Temp"
+
+#: id:9
+msgid "xbmc media center"
+msgstr "xbmc media center"
+
+#: id:11
+msgid "Monday"
+msgstr "It-Tnejn"
+
+#: id:12
+msgid "Tuesday"
+msgstr "It-Tlieta"
+
+#: id:13
+msgid "Wednesday"
+msgstr "L-Erbgħa"
+
+#: id:14
+msgid "Thursday"
+msgstr "Il-Ħamis"
+
+#: id:15
+msgid "Friday"
+msgstr "Il-Ġimgħa"
+
+#: id:16
+msgid "Saturday"
+msgstr "Is-Sibt"
+
+#: id:17
+msgid "Sunday"
+msgstr "Il-Ħadd"
+
+#: id:21
+msgid "January"
+msgstr "Jannar"
+
+#: id:22
+msgid "February"
+msgstr "Frar"
+
+#: id:23
+msgid "March"
+msgstr "Marzu"
+
+#: id:24
+msgid "April"
+msgstr "April"
+
+#: id:25
+msgctxt "Auto context with id 25"
+msgid "May"
+msgstr "Mejju"
+
+#: id:26
+msgid "June"
+msgstr "Ġunju"
+
+#: id:27
+msgid "July"
+msgstr "Lulju"
+
+#: id:28
+msgid "August"
+msgstr "Awwissu"
+
+#: id:29
+msgid "September"
+msgstr "Settembru"
+
+#: id:30
+msgid "October"
+msgstr "Ottubru"
+
+#: id:31
+msgid "November"
+msgstr "Novembru"
+
+#: id:32
+msgid "December"
+msgstr "Diċembru"
+
+#: id:41
+msgid "Mon"
+msgstr ""
+
+#: id:42
+msgid "Tue"
+msgstr ""
+
+#: id:43
+msgid "Wed"
+msgstr ""
+
+#: id:44
+msgid "Thu"
+msgstr ""
+
+#: id:45
+msgid "Fri"
+msgstr ""
+
+#: id:46
+msgid "Sat"
+msgstr ""
+
+#: id:47
+msgctxt "Auto context with id 47"
+msgid "Sun"
+msgstr ""
+
+#: id:51
+msgid "Jan"
+msgstr ""
+
+#: id:52
+msgid "Feb"
+msgstr ""
+
+#: id:53
+msgid "Mar"
+msgstr ""
+
+#: id:54
+msgid "Apr"
+msgstr ""
+
+#: id:55
+msgctxt "Auto context with id 55"
+msgid "May"
+msgstr ""
+
+#: id:56
+msgid "Jun"
+msgstr ""
+
+#: id:57
+msgid "Jul"
+msgstr ""
+
+#: id:58
+msgid "Aug"
+msgstr ""
+
+#: id:59
+msgid "Sep"
+msgstr ""
+
+#: id:60
+msgid "Oct"
+msgstr ""
+
+#: id:61
+msgid "Nov"
+msgstr ""
+
+#: id:62
+msgid "Dec"
+msgstr ""
+
+#: id:71
+msgid "N"
+msgstr ""
+
+#: id:72
+msgid "NNE"
+msgstr ""
+
+#: id:73
+msgid "NE"
+msgstr ""
+
+#: id:74
+msgid "ENE"
+msgstr ""
+
+#: id:75
+msgid "E"
+msgstr ""
+
+#: id:76
+msgid "ESE"
+msgstr ""
+
+#: id:77
+msgid "SE"
+msgstr ""
+
+#: id:78
+msgid "SSE"
+msgstr ""
+
+#: id:79
+msgid "S"
+msgstr ""
+
+#: id:80
+msgid "SSW"
+msgstr ""
+
+#: id:81
+msgid "SW"
+msgstr ""
+
+#: id:82
+msgid "WSW"
+msgstr ""
+
+#: id:83
+msgid "W"
+msgstr ""
+
+#: id:84
+msgid "WNW"
+msgstr ""
+
+#: id:85
+msgid "NW"
+msgstr ""
+
+#: id:86
+msgid "NNW"
+msgstr ""
+
+#: id:87
+msgid "VAR"
+msgstr ""
+
+#: id:98
+msgid "View: Auto"
+msgstr "Uri: Awto"
+
+#: id:99
+msgid "View: Auto big"
+msgstr "Uri: Awto Kbar"
+
+#: id:100
+msgid "View: Icons"
+msgstr "Uri: Ajkons"
+
+#: id:101
+msgid "View: List"
+msgstr "Uri: Lista"
+
+#: id:102
+msgctxt "Auto context with id 102"
+msgid "Scan"
+msgstr "Fittex"
+
+#: id:103
+msgctxt "Auto context with id 103"
+msgid "Sort by: Name"
+msgstr "Ordni: Isem"
+
+#: id:104
+msgid "Sort by: Date"
+msgstr "Ordni: Data"
+
+#: id:105
+msgid "Sort by: Size"
+msgstr "Ordni: Kobor"
+
+#: id:106
+msgid "No"
+msgstr "Le"
+
+#: id:107
+msgid "Yes"
+msgstr "Iva"
+
+#: id:108
+msgctxt "Auto context with id 108"
+msgid "Slideshow"
+msgstr "Slajdxow"
+
+#: id:109
+msgid "Create thumbs"
+msgstr "Oħloq Kopja Zgħira"
+
+#: id:110
+msgid "Create thumbnails"
+msgstr "Oħloq Kopja Zgħira"
+
+#: id:111
+msgctxt "Auto context with id 111"
+msgid "Shortcuts"
+msgstr "Shortcuts"
+
+#: id:112
+msgid "Paused"
+msgstr "PAWSA"
+
+#: id:113
+msgid "Update failed"
+msgstr "Fajls : Sors"
+
+#: id:114
+msgid "Installation failed"
+msgstr "Fajls : Destinazzjoni"
+
+#: id:115
+msgid "Copy"
+msgstr "Ikkopja"
+
+#: id:116
+msgid "Move"
+msgstr "Mexxi"
+
+#: id:117
+msgid "Delete"
+msgstr "Ħassar"
+
+#: id:118
+msgid "Rename"
+msgstr "Semmi"
+
+#: id:119
+msgid "New folder"
+msgstr "Fowlder ġdid"
+
+#: id:120
+msgid "Confirm file copy"
+msgstr "Tikkonferma li Tikkopja"
+
+#: id:121
+msgid "Confirm file move"
+msgstr "Tikkonferma li Tmexxi"
+
+#: id:122
+msgid "Confirm file delete?"
+msgstr "Tikkonferma li Tħassar"
+
+#: id:123
+msgid "Copy these files?"
+msgstr "Tikkopja dawn il-fajls?"
+
+#: id:124
+msgid "Move these files?"
+msgstr "Tmexxi dawn il-fajls?"
+
+#: id:125
+msgid "Delete these files? - Deleting files cannot be undone!"
+msgstr "Tħassar dawn il-fajls?"
+
+#: id:126
+msgid "Status"
+msgstr "Stat"
+
+#: id:127
+msgid "Objects"
+msgstr "Oġġetti"
+
+#: id:128
+msgctxt "Auto context with id 128"
+msgid "General"
+msgstr "Ġenerali"
+
+#: id:129
+msgctxt "Auto context with id 129"
+msgid "Slideshow"
+msgstr "Slajdxow"
+
+#: id:130
+msgctxt "Auto context with id 130"
+msgid "System info"
+msgstr "Is-Sistema"
+
+#: id:131
+msgid "Display"
+msgstr "Screen"
+
+#: id:132
+msgid "Albums"
+msgstr "Albums"
+
+#: id:133
+msgid "Artists"
+msgstr "Artisti"
+
+#: id:134
+msgid "Songs"
+msgstr "Diski"
+
+#: id:135
+msgid "Genres"
+msgstr "Ġeneru"
+
+#: id:136
+msgid "Playlists"
+msgstr "Playlists"
+
+#: id:137
+msgid "Search"
+msgstr "Fittex"
+
+#: id:138
+msgid "System Information"
+msgstr "Is-Sistema"
+
+#: id:139
+msgid "Temperatures:"
+msgstr "Temperaturi:"
+
+#: id:140
+msgid "CPU:"
+msgstr "CPU:"
+
+#: id:141
+msgid "GPU:"
+msgstr "GPU:"
+
+#: id:142
+msgid "Time:"
+msgstr "Ħin:"
+
+#: id:143
+msgid "Current:"
+msgstr "Bħalissa:"
+
+#: id:144
+msgid "Build:"
+msgstr "Verżjoni:"
+
+#: id:145
+msgid "Network:"
+msgstr "Network:"
+
+#: id:146
+msgid "Type:"
+msgstr "Tip:"
+
+#: id:147
+msgid "Static"
+msgstr "Statiku"
+
+#: id:148
+msgid "DHCP"
+msgstr "DHCP"
+
+#: id:149
+msgid "MAC address"
+msgstr "MAC"
+
+#: id:150
+msgctxt "Auto context with id 150"
+msgid "IP address"
+msgstr "IP:"
+
+#: id:151
+msgid "Link:"
+msgstr "Link:"
+
+#: id:152
+msgid "Half duplex"
+msgstr "Half duplex"
+
+#: id:153
+msgid "Full duplex"
+msgstr "Full duplex"
+
+#: id:154
+msgctxt "Auto context with id 154"
+msgid "Storage"
+msgstr "Spazju"
+
+#: id:155
+msgid "Drive"
+msgstr "Diska"
+
+#: id:156
+msgctxt "Auto context with id 156"
+msgid "Free"
+msgstr "Vojt"
+
+#: id:157
+msgctxt "Auto context with id 157"
+msgid "Video"
+msgstr "Stampa"
+
+#: id:158
+msgid "Free memory"
+msgstr "Memorja Vojta"
+
+#: id:159
+msgid "No link"
+msgstr "Ebda link"
+
+#: id:160
+msgctxt "Auto context with id 160"
+msgid "Free"
+msgstr "Vojta"
+
+#: id:161
+msgid "Unavailable"
+msgstr "Mhux Disponibbli"
+
+#: id:162
+msgid "Tray open"
+msgstr "Trej Miftuħ"
+
+#: id:163
+msgid "Reading"
+msgstr "Jaqra"
+
+#: id:164
+msgid "No disc"
+msgstr "Bla Diska"
+
+#: id:165
+msgid "Disc present"
+msgstr "Diska ġewwa"
+
+#: id:166
+msgid "Skin"
+msgstr "Qoxra:"
+
+#: id:169
+msgctxt "Auto context with id 169"
+msgid "Resolution"
+msgstr "Resolution:"
+
+#: id:170
+msgid "Adjust display refresh rate to match video"
+msgstr "Album:"
+
+#: id:172
+msgid "Release date"
+msgstr "Data tal-ħrug:"
+
+#: id:173
+msgid "Display 4:3 videos as"
+msgstr "Rati:"
+
+#: id:175
+msgid "Moods"
+msgstr "Tones:"
+
+#: id:176
+msgid "Styles"
+msgstr "Stil:"
+
+#: id:179
+msgid "Song"
+msgstr "Diska"
+
+#: id:180
+msgid "Duration"
+msgstr "Tul"
+
+#: id:181
+msgid "Select album"
+msgstr "Għażel album"
+
+#: id:182
+msgid "Tracks"
+msgstr "Treks"
+
+#: id:183
+msgid "Review"
+msgstr "Irrevedi"
+
+#: id:184
+msgid "Refresh"
+msgstr "Ġedded"
+
+#: id:185
+msgid "Searching album"
+msgstr "Tfittxija għall-album"
+
+#: id:186
+msgid "OK"
+msgstr "OK"
+
+#: id:187
+msgid "No albums found!"
+msgstr "Ma nstab l-ebda album!"
+
+#: id:188
+msgid "Select all"
+msgstr "Għażel kollox"
+
+#: id:189
+msgid "Scanning media info"
+msgstr "Niskenja nformazzjoni tal-medja"
+
+#: id:190
+msgid "Save"
+msgstr "Żomm"
+
+#: id:191
+msgid "Shuffle"
+msgstr "Ħawwad"
+
+#: id:192
+msgctxt "Auto context with id 192"
+msgid "Clear"
+msgstr "Ħassar"
+
+#: id:193
+msgctxt "Auto context with id 193"
+msgid "Scan"
+msgstr "Fittex"
+
+#: id:194
+msgid "Searching..."
+msgstr "Tfittxija għal..."
+
+#: id:195
+msgid "No info found!"
+msgstr "Ma nstabet l-ebda nformazzjoni!"
+
+#: id:196
+msgid "Select movie:"
+msgstr "Għazel filmat:"
+
+#: id:197
+msgid "Querying %s info"
+msgstr "Tfittxija għall-informazzjoni minn %s"
+
+#: id:198
+msgid "Loading movie details"
+msgstr "Dettalja tal-filmat qed jinqraw"
+
+#: id:199
+msgid "Web interface"
+msgstr "Direttur:"
+
+#: id:202
+msgid "Tagline"
+msgstr "Tagline:"
+
+#: id:203
+msgid "Plot outline"
+msgstr "Fil-qosor:"
+
+#: id:205
+msgid "Votes"
+msgstr "Voti"
+
+#: id:206
+msgid "Cast"
+msgstr "Kast"
+
+#: id:207
+msgid "Plot"
+msgstr "Plot"
+
+#: id:208
+msgctxt "Auto context with id 208"
+msgid "Play"
+msgstr "Ara"
+
+#: id:209
+msgid "Next"
+msgstr "Li jmiss"
+
+#: id:210
+msgid "Previous"
+msgstr "Ta' qabel"
+
+#: id:213
+msgid "Calibrate user interface..."
+msgstr "Ikkalibra UI"
+
+#: id:214
+msgid "Video calibration..."
+msgstr "Ikkalibra Vidjo"
+
+#: id:215
+msgid "Soften"
+msgstr "Soften"
+
+#: id:216
+msgid "Zoom amount"
+msgstr "Saħħa Lenti"
+
+#: id:217
+msgid "Pixel ratio"
+msgstr "Ġebbed"
+
+#: id:218
+msgid "DVD drive"
+msgstr "Diska DVD"
+
+#: id:219
+msgid "Please insert disc"
+msgstr "Daħħal diska"
+
+#: id:220
+msgid "Remote share"
+msgstr "Remote Share"
+
+#: id:221
+msgid "Network is not connected"
+msgstr "Network mhux imqabbad"
+
+#: id:222
+msgid "Cancel"
+msgstr "Waqqaf"
+
+#: id:224
+msgid "Speed"
+msgstr "Veloċita'"
+
+#: id:225
+msgid "Vertical Shift"
+msgstr "Ħin Tranżitorju"
+
+#: id:226
+msgid "Test patterns..."
+msgstr ""
+
+#: id:227
+msgid "Lookup audio CD track names from freedb.org"
+msgstr "Uza CDDB"
+
+#: id:228
+msgid "Shuffle playlist on load"
+msgstr "Ħawwad Plejlist meta taqra"
+
+#: id:229
+msgid "HDD spindown time"
+msgstr "HD Spindown time (mins)"
+
+#: id:230
+msgid "Video filters"
+msgstr "Filters"
+
+#: id:231
+msgctxt "Auto context with id 231"
+msgid "None"
+msgstr "Xejn"
+
+#: id:232
+msgid "Point"
+msgstr "Punt"
+
+#: id:233
+msgid "Linear"
+msgstr "Linear"
+
+#: id:234
+msgid "Anisotropic"
+msgstr "Anisotropic"
+
+#: id:235
+msgid "Quincunx"
+msgstr "Quincunx"
+
+#: id:236
+msgid "Gaussian cubic"
+msgstr "Gaussian Cubic"
+
+#: id:237
+msgid "Minification"
+msgstr "Minification:"
+
+#: id:238
+msgid "Magnification"
+msgstr "Magnification:"
+
+#: id:239
+msgid "Clear playlist on finish"
+msgstr "Ħassar Playlist x'ħin tlesti"
+
+#: id:240
+msgid "Display Mode"
+msgstr "Daħħal u Ara DVD-Video"
+
+#: id:241
+msgid "Full Screen #%d"
+msgstr "Daħħal u Ara VCD/SVCD"
+
+#: id:242
+msgid "Windowed"
+msgstr "Daħħal u Isma CD Awdjo"
+
+#: id:243
+msgid "Refresh Rate"
+msgstr "Daħħal u Ilgħab Logħob tal-XBOX"
+
+#: id:244
+msgid "Full screen"
+msgstr "Daħħal u Ara Filmati"
+
+#: id:245
+msgid "Sizing: (%i,%i)->(%i,%i) (Zoom x%2.2f) AR:%2.2f:1 (Pixels: %2.2f:1) (VShift: %2.2f)"
+msgstr "Daħħal u Isma Mużika"
+
+#: id:247
+msgctxt "Auto context with id 247"
+msgid "Scripts"
+msgstr "Scripts"
+
+#: id:248
+msgctxt "Auto context with id 248"
+msgid "Language"
+msgstr "Lingwa"
+
+#: id:249
+msgctxt "Auto context with id 249"
+msgid "Music"
+msgstr "Mużika"
+
+#: id:250
+msgctxt "Auto context with id 250"
+msgid "Visualization"
+msgstr "Viżwalizzazzjoni"
+
+#: id:251
+msgid "Select destination directory"
+msgstr "Għażel destinazzjoni"
+
+#: id:252
+msgid "Output stereo to all speakers"
+msgstr "Output Speakers kollha"
+
+#: id:253
+msgid "Number of channels"
+msgstr "Numru ta' kanali"
+
+#: id:254
+msgid "- DTS capable receiver"
+msgstr "- DTS Capable Receiver"
+
+#: id:255
+msgid "CDDB"
+msgstr "CDDB"
+
+#: id:256
+msgid "Fetching CD information"
+msgstr "Tfittxija għall-informazzjoni CDDB minn freedb"
+
+#: id:257
+msgid "Error"
+msgstr "Problema"
+
+#: id:258
+msgid "Enable tag reading"
+msgstr "Uża ID3 tags"
+
+#: id:259
+msgid "Opening"
+msgstr "Niftaħ"
+
+#: id:260
+msgid "Shoutcast"
+msgstr "Shoutcast"
+
+#: id:261
+msgid "Waiting for start..."
+msgstr "stennija għall-bidu...."
+
+#: id:262
+msgid "Scripts output"
+msgstr "Output tal-iskripts"
+
+#: id:263
+msgid "Allow control of XBMC via HTTP"
+msgstr "HTTP server:"
+
+#: id:264
+msgid "Record"
+msgstr "Irrekordja"
+
+#: id:265
+msgid "Stop Rec."
+msgstr "Ieqaf Rek."
+
+#: id:266
+msgid "Sort by: Track"
+msgstr "Ordni: Trek"
+
+#: id:267
+msgid "Sort by: Time"
+msgstr "Ordni: Ħin"
+
+#: id:268
+msgid "Sort by: Title"
+msgstr "Ordni: Title"
+
+#: id:269
+msgid "Sort by: Artist"
+msgstr "Ordni: Artist"
+
+#: id:270
+msgid "Sort by: Album"
+msgstr "Ordni: Album"
+
+#: id:271
+msgid "Top 100"
+msgstr "L-ewwel 100"
+
+#: id:272
+msgid "Top-Left overscan compensation"
+msgstr "Xellug Fuq Overscan Compensation"
+
+#: id:273
+msgid "Bottom-Right overscan compensation"
+msgstr "Lemin Isfel Overscan Compensation"
+
+#: id:274
+msgid "Subtitle positioning"
+msgstr "Pożizzjoni tas-Sottotitoli"
+
+#: id:275
+msgid "Pixel ratio adjustment"
+msgstr "Pixel Ratio Adjustment"
+
+#: id:276
+msgid "Adjust the arrow to change the amount of overscan"
+msgstr "Mexxi l-vleġġa biex tbiddel l-ammont tal-overscan"
+
+#: id:277
+msgid "Adjust the bar to change the subtitles position"
+msgstr "Mexxi l-isbarra biex tbiddel il-pożizzjoni tas-Sottotitoli"
+
+#: id:278
+msgid "Adjust the rectangle so it is perfectly square"
+msgstr "Ibdel ir-rettanglu biex jigi kaxxa perfetta"
+
+#: id:279
+msgid "Unable to load settings"
+msgstr "Problema biex jinqraw is-Settings"
+
+#: id:280
+msgid "Using default settings"
+msgstr "using default fallbacks"
+
+#: id:281
+msgid "Please check the XML files"
+msgstr "Iċċekkja l-.xml fajls"
+
+#: id:282
+msgid "Found %i items"
+msgstr "instabu %i oġġetti"
+
+#: id:283
+msgid "Search results"
+msgstr "Riżultati tat-tfittxija"
+
+#: id:284
+msgid "No results found"
+msgstr "Ma nstabux riżultati"
+
+#: id:287
+msgctxt "Auto context with id 287"
+msgid "Subtitles"
+msgstr "Sottotitloi"
+
+#: id:288
+msgctxt "Auto context with id 288"
+msgid "Font"
+msgstr "Font"
+
+#: id:289
+msgctxt "Auto context with id 289"
+msgid "- Size"
+msgstr "- Kobor"
+
+#: id:290
+msgid "Dynamic range compression"
+msgstr "Dynamic Range Compression"
+
+#: id:291
+msgctxt "Auto context with id 291"
+msgid "Video"
+msgstr "Video"
+
+#: id:292
+msgctxt "Auto context with id 292"
+msgid "Audio"
+msgstr "Awdjo"
+
+#: id:293
+msgid "Browse for subtitles"
+msgstr "Fittex Sottotitoli"
+
+#: id:294
+msgid "Create bookmark"
+msgstr "Oħloq bookmark"
+
+#: id:296
+msgid "Clear bookmarks"
+msgstr "Ħassar bookmarks"
+
+#: id:297
+msgid "Audio offset"
+msgstr "Delay tal-Awdjo"
+
+#: id:298
+msgid "Bookmarks"
+msgstr "Bukmarks"
+
+#: id:299
+msgid "- AAC capable receiver"
+msgstr ""
+
+#: id:300
+msgid "- MP1 capable receiver"
+msgstr ""
+
+#: id:301
+msgid "- MP2 capable receiver"
+msgstr ""
+
+#: id:302
+msgid "- MP3 capable receiver"
+msgstr ""
+
+#: id:303
+msgid "Delay"
+msgstr "Ittardja"
+
+#: id:304
+msgctxt "Auto context with id 304"
+msgid "Language"
+msgstr "Lingwa"
+
+#: id:305
+msgctxt "Auto context with id 305"
+msgid "Enabled"
+msgstr "Jintuza"
+
+#: id:306
+msgid "Non-interleaved"
+msgstr "Non-Interleaved"
+
+#: id:312
+msgid "(0=auto)"
+msgstr "(0=awto)"
+
+#: id:313
+msgid "Cleaning database"
+msgstr "Innaddaf d-database"
+
+#: id:314
+msgid "Preparing..."
+msgstr "Preparazzjoni..."
+
+#: id:315
+msgid "Database error"
+msgstr "Problema fid-Database"
+
+#: id:316
+msgid "Searching songs..."
+msgstr "Tfittxija għal diski..."
+
+#: id:317
+msgid "Cleaned database successfully"
+msgstr "Database ġiet imnaddfa"
+
+#: id:318
+msgid "Cleaning songs..."
+msgstr "Innaddaf diski"
+
+#: id:319
+msgid "Error cleaning songs"
+msgstr "Problema fl-organizzar tad-diski"
+
+#: id:320
+msgid "Cleaning artists..."
+msgstr "Innaddaf artisti..."
+
+#: id:321
+msgid "Error cleaning artists"
+msgstr "Problema fl-organizzar tal-artisti"
+
+#: id:322
+msgid "Cleaning genres..."
+msgstr "Innaddaf Ġeneru..."
+
+#: id:323
+msgid "Error cleaning genres"
+msgstr "Problema fl-organizzar tal-Ġeneru"
+
+#: id:324
+msgid "Cleaning paths..."
+msgstr "Innaddaf paths..."
+
+#: id:325
+msgid "Error cleaning paths"
+msgstr "Problema fl-organizzar tal-paths"
+
+#: id:326
+msgid "Cleaning albums..."
+msgstr "Innaddaf albums..."
+
+#: id:327
+msgid "Error cleaning albums"
+msgstr "Problema fl-organizzar tal-albums"
+
+#: id:328
+msgid "Writing changes..."
+msgstr "Tibdiliet qed jiġu rrekordjati..."
+
+#: id:329
+msgid "Error writing changes"
+msgstr "Problema biex it-tibdiliet jiġu rrekordjati"
+
+#: id:330
+msgid "This may take some time..."
+msgstr "Dan il-proċess jista jdum..."
+
+#: id:331
+msgid "Compressing database..."
+msgstr "Database qed tiġi kkompressata..."
+
+#: id:332
+msgid "Error compressing database"
+msgstr "Problema biex id-database tiġi kkompressata"
+
+#: id:333
+msgid "Do you want to clean the library?"
+msgstr "Trid tnaddaf il-Librerija?"
+
+#: id:334
+msgid "Clean library..."
+msgstr "Innaddaf il-Librerija..."
+
+#: id:335
+msgid "Start"
+msgstr "Ibda"
+
+#: id:336
+msgid "Framerate conversion"
+msgstr "Framerate Conversion"
+
+#: id:337
+msgctxt "Auto context with id 337"
+msgid "Audio output"
+msgstr "Output Awdjo:"
+
+#: id:338
+msgid "Analog"
+msgstr "Analog"
+
+#: id:339
+msgid "Optical/Coax"
+msgstr "Diġitali"
+
+#: id:340
+msgid "Various artists"
+msgstr "Artisti Varji"
+
+#: id:341
+msgid "Play disc"
+msgstr "Ara DVD"
+
+#: id:342
+msgctxt "Auto context with id 342"
+msgid "Movies"
+msgstr "Filmati"
+
+#: id:343
+msgid "Adjust framerate"
+msgstr "Irranġa Framerate"
+
+#: id:344
+msgid "Actors"
+msgstr "Atturi"
+
+#: id:345
+msgctxt "Auto context with id 345"
+msgid "Year"
+msgstr "Sena"
+
+#: id:346
+msgid "Boost volume level on downmix"
+msgstr ""
+
+#: id:350
+msgctxt "Auto context with id 350"
+msgid "Programs"
+msgstr "Programmi"
+
+#: id:351
+msgctxt "Auto context with id 351"
+msgid "Off"
+msgstr "Mitfi"
+
+#: id:352
+msgid "Dim"
+msgstr "Baxx"
+
+#: id:353
+msgid "Black"
+msgstr "Iswed"
+
+#: id:354
+msgid "Matrix trails"
+msgstr "Matrix Trails"
+
+#: id:355
+msgid "Screensaver time"
+msgstr "Skrinsejver Idle Timeout"
+
+#: id:356
+msgid "Screensaver mode"
+msgstr "Skrinsejver Mode"
+
+#: id:357
+msgid "Shutdown function timer"
+msgstr "Shutdown Idle Timeout"
+
+#: id:358
+msgid "All albums"
+msgstr "L-albums kollha"
+
+#: id:359
+msgid "Recently added albums"
+msgstr "L-albums riċenti"
+
+#: id:360
+msgctxt "Auto context with id 360"
+msgid "Screensaver"
+msgstr "Skrinsejver"
+
+#: id:361
+msgid "R. Slideshow"
+msgstr "R. SlideShow"
+
+#: id:362
+msgid "Screensaver dim level"
+msgstr "Skrinsejver Fade Level"
+
+#: id:363
+msgid "Sort by: File"
+msgstr "Ordni: File"
+
+#: id:364
+msgid "- Dolby Digital (AC3) capable receiver"
+msgstr "- AC3 Capable Receiver"
+
+#: id:365
+msgctxt "Auto context with id 365"
+msgid "Sort by: Name"
+msgstr "Ordni: Isem"
+
+#: id:366
+msgid "Sort by: Year"
+msgstr "Ordni: Sena"
+
+#: id:367
+msgid "Sort by: Rating"
+msgstr "Ordni: Rating"
+
+#: id:368
+msgid "IMDb"
+msgstr "IMDB"
+
+#: id:369
+msgctxt "Auto context with id 369"
+msgid "Title"
+msgstr "Titlu"
+
+#: id:370
+msgid "Thunderstorms"
+msgstr "Tempesti"
+
+#: id:371
+msgid "Partly"
+msgstr "Kemxejn"
+
+#: id:372
+msgid "Mostly"
+msgstr "L-biċċa l-kbira"
+
+#: id:373
+msgid "Sunny"
+msgstr "Xemxi"
+
+#: id:374
+msgid "Cloudy"
+msgstr "Msaħħab"
+
+#: id:375
+msgid "Snow"
+msgstr "Silġ"
+
+#: id:376
+msgid "Rain"
+msgstr "Xita"
+
+#: id:377
+msgid "Light"
+msgstr "Ħafif"
+
+#: id:378
+msgid "AM"
+msgstr "AM"
+
+#: id:379
+msgid "PM"
+msgstr "PM"
+
+#: id:380
+msgid "Showers"
+msgstr "Rxiex"
+
+#: id:381
+msgid "Few"
+msgstr "Ftit"
+
+#: id:382
+msgid "Scattered"
+msgstr "Scattered"
+
+#: id:383
+msgctxt "Auto context with id 383"
+msgid "Wind"
+msgstr "Riħ"
+
+#: id:384
+msgid "Strong"
+msgstr "Qawwi"
+
+#: id:385
+msgid "Fair"
+msgstr "Ħafif"
+
+#: id:386
+msgctxt "Auto context with id 386"
+msgid "Clear"
+msgstr "Ċar"
+
+#: id:387
+msgid "Clouds"
+msgstr "Sħab"
+
+#: id:388
+msgid "Early"
+msgstr "Kmieni"
+
+#: id:389
+msgid "Shower"
+msgstr "Rxiex"
+
+#: id:390
+msgid "Flurries"
+msgstr "Borra"
+
+#: id:391
+msgctxt "Auto context with id 391"
+msgid "Low"
+msgstr "Baxx"
+
+#: id:392
+msgctxt "Auto context with id 392"
+msgid "Medium"
+msgstr "Medju"
+
+#: id:393
+msgctxt "Auto context with id 393"
+msgid "High"
+msgstr "Għoli"
+
+#: id:394
+msgid "Fog"
+msgstr "Ċpar"
+
+#: id:395
+msgid "Haze"
+msgstr "Haze"
+
+#: id:396
+msgid "Select location"
+msgstr "Għażel Lokalita'"
+
+#: id:397
+msgid "Refresh time"
+msgstr "Refresh Time"
+
+#: id:398
+msgid "Temperature units"
+msgstr "Kejl tat-Temperatura"
+
+#: id:399
+msgid "Speed units"
+msgstr "Kejl tal-Veloċita'"
+
+#: id:400
+msgctxt "Auto context with id 400"
+msgid "Weather"
+msgstr "It-Temp"
+
+#: id:401
+msgid "Temp"
+msgstr "Temp"
+
+#: id:402
+msgid "Feels like"
+msgstr "Tħossok"
+
+#: id:403
+msgid "UV index"
+msgstr "UV Index"
+
+#: id:404
+msgctxt "Auto context with id 404"
+msgid "Wind"
+msgstr "Riħ"
+
+#: id:405
+msgid "Dew point"
+msgstr "Dew Point"
+
+#: id:406
+msgid "Humidity"
+msgstr "Umdita'"
+
+#: id:409
+msgid "Defaults"
+msgstr "Difolts"
+
+#: id:410
+msgid "Accessing weather service"
+msgstr "Aċċess għall-weather.com"
+
+#: id:411
+msgid "Getting weather for:"
+msgstr "Tfittxija għat-Temp ta':"
+
+#: id:412
+msgid "Unable to get weather data"
+msgstr "Problemi biex jinkiseb it-Temp"
+
+#: id:413
+msgid "Manual"
+msgstr "Manwali"
+
+#: id:414
+msgid "No review for this album"
+msgstr "L-ebda artiklu għal dan l-album"
+
+#: id:415
+msgid "Downloading thumbnail..."
+msgstr "Inniżżel tambnejl..."
+
+#: id:416
+msgid "Not available"
+msgstr "Mhux disponibbli"
+
+#: id:417
+msgid "View: Big icons"
+msgstr "Uri: Big Ajkons"
+
+#: id:418
+msgctxt "Auto context with id 418"
+msgid "Low"
+msgstr "Filmati/Generi"
+
+#: id:419
+msgctxt "Auto context with id 419"
+msgid "High"
+msgstr "Filmati/Atturi"
+
+#: id:420
+msgid "HDMI"
+msgstr "Filmati/Snin"
+
+#: id:422
+msgid "Delete album info"
+msgstr "Ħassar informazzjoni dwar albums"
+
+#: id:423
+msgid "Delete CD information"
+msgstr "Ħassar informazzjoni min CDDB"
+
+#: id:424
+msgid "Select"
+msgstr "Għażel"
+
+#: id:425
+msgid "No album information found"
+msgstr "L-ebda album ma nstab."
+
+#: id:426
+msgid "No CD information found"
+msgstr "L-ebda CDDB info ma nstab."
+
+#: id:427
+msgid "Disc"
+msgstr "Diska:"
+
+#: id:428
+msgid "Insert correct CD/DVD"
+msgstr "Insert correct CD/DVD"
+
+#: id:429
+msgid "Please insert the following disc:"
+msgstr "Please insert the following CD/DVD"
+
+#: id:430
+msgid "Sort by: DVD#"
+msgstr "Ordni: DVD#"
+
+#: id:431
+msgid "No cache"
+msgstr "No Cache"
+
+#: id:432
+msgid "Remove movie from library"
+msgstr "Ħassar filmat mil-librerija"
+
+#: id:433
+msgid "Really remove '%s'?"
+msgstr "Żgur li trid tħassar '%s'?"
+
+#: id:434
+msgid "From %s at %i %s"
+msgstr ""
+
+#: id:437
+msgid "Removable disk"
+msgstr "Duration:"
+
+#: id:438
+msgid "Opening file"
+msgstr "Niftaħ il-fajl"
+
+#: id:439
+msgid "Cache"
+msgstr "Cache"
+
+#: id:440
+msgid "Harddisk"
+msgstr "Harddisk"
+
+#: id:441
+msgid "UDF"
+msgstr "UDF"
+
+#: id:442
+msgid "Local network"
+msgstr "LAN"
+
+#: id:443
+msgid "Internet"
+msgstr "Internet"
+
+#: id:444
+msgctxt "Auto context with id 444"
+msgid "Video"
+msgstr "Vidjo"
+
+#: id:445
+msgctxt "Auto context with id 445"
+msgid "Audio"
+msgstr "Awdjo"
+
+#: id:446
+msgctxt "Auto context with id 446"
+msgid "DVD"
+msgstr "DVD"
+
+#: id:447
+msgid "Autorun media"
+msgstr "X'jiġri"
+
+#: id:448
+msgid "LCD"
+msgstr "LCD"
+
+#: id:449
+msgctxt "Auto context with id 449"
+msgid "Enabled"
+msgstr "Jintuża"
+
+#: id:450
+msgid "Columns"
+msgstr "Kolonni"
+
+#: id:451
+msgid "Row 1 address"
+msgstr "Filliera 1 adress:"
+
+#: id:452
+msgid "Row 2 address"
+msgstr "Filliera 2 adress:"
+
+#: id:453
+msgid "Row 3 address"
+msgstr "Filliera 3 adress:"
+
+#: id:454
+msgid "Row 4 address"
+msgstr "Filliera 4 adress:"
+
+#: id:455
+msgid "Rows"
+msgstr "Fillieri :"
+
+#: id:456
+msgid "Mode"
+msgstr "Mode:"
+
+#: id:457
+msgid "Switch view"
+msgstr "Uri Differenti"
+
+#: id:459
+msgid "Subs"
+msgstr "Subs"
+
+#: id:460
+msgid "Audio stream"
+msgstr "Audio Stream"
+
+#: id:461
+msgid "[active]"
+msgstr "[attiv]"
+
+#: id:462
+msgid "Subtitle"
+msgstr "Sottotitoli"
+
+#: id:463
+msgid "Backlight"
+msgstr "Backlight"
+
+#: id:464
+msgid "Brightness"
+msgstr "Brightness"
+
+#: id:465
+msgid "Contrast"
+msgstr "Kuntrast"
+
+#: id:466
+msgid "Gamma"
+msgstr "Gamma"
+
+#: id:467
+msgctxt "Auto context with id 467"
+msgid "Type"
+msgstr "Tip"
+
+#: id:468
+msgid "Move the bar to change the OSD position"
+msgstr "Mexxi żbarra biex tibdel il-pożizzjoni tal-osd"
+
+#: id:469
+msgid "OSD position"
+msgstr "Pożizzjoni tal-OSD"
+
+#: id:470
+msgid "Credits"
+msgstr "Krediti"
+
+#: id:471
+msgid "Modchip"
+msgstr "Modchip"
+
+#: id:474
+msgctxt "Auto context with id 474"
+msgid "Off"
+msgstr "Mitfi"
+
+#: id:475
+msgid "Music only"
+msgstr "Mużika Biss"
+
+#: id:476
+msgctxt "Auto context with id 476"
+msgid "Music & video"
+msgstr "Mużika u Filmati"
+
+#: id:477
+msgid "Unable to load playlist"
+msgstr "Playlist mhux miftuħa"
+
+#: id:478
+msgid "OSD"
+msgstr "OSD"
+
+#: id:479
+msgid "Skin & language"
+msgstr "Qoxra u Lingwa"
+
+#: id:480
+msgid "Appearance"
+msgstr "Appearance"
+
+#: id:481
+msgid "Audio options"
+msgstr "Opzjoni Awdjo"
+
+#: id:482
+msgid "About XBMC"
+msgstr "Dwar XBMC"
+
+#: id:485
+msgid "Delete album"
+msgstr "Ħassar album"
+
+#: id:486
+msgid "Repeat"
+msgstr "Irrepeti"
+
+#: id:487
+msgid "Repeat one"
+msgstr "Irrepeti Waħda"
+
+#: id:488
+msgid "Repeat folder"
+msgstr "Irrepeti Fowlder playlist"
+
+#: id:489
+msgid "Play the next song automatically"
+msgstr "Uża playlist in songs"
+
+#: id:491
+msgid "- Use big icons"
+msgstr "Uża ajkons kbar"
+
+#: id:492
+msgid "Resize VobSubs"
+msgstr "Kabbar Sottotitoli"
+
+#: id:493
+msgid "Advanced options (Experts Only!)"
+msgstr "Advanced Options (Experts Biss!)"
+
+#: id:494
+msgid "Overall audio headroom"
+msgstr "Overall Audio Headroom"
+
+#: id:495
+msgid "Upsample videos to GUI resolution"
+msgstr "Kabbar filmati skond il-GUI resolution"
+
+#: id:496
+msgid "Calibration"
+msgstr "Ikkalibra"
+
+#: id:497
+msgid "Show file extensions"
+msgstr "Aħbi Media Extensions"
+
+#: id:498
+msgid "Sort by: Type"
+msgstr "Issortja: Bit-Tip"
+
+#: id:499
+msgid "Unable to connect to online lookup service"
+msgstr "Ma qbadtx ma www.allmusic.com"
+
+#: id:500
+msgid "Downloading album information failed"
+msgstr "Informazzjoni tal-album ma nizlitx"
+
+#: id:501
+msgid "Looking for album names..."
+msgstr "Infittex ismijiet tal-album"
+
+#: id:502
+msgctxt "Auto context with id 502"
+msgid "Open"
+msgstr "Miftuħa"
+
+#: id:503
+msgid "Busy"
+msgstr "Użata"
+
+#: id:504
+msgid "Empty"
+msgstr "Vojta"
+
+#: id:505
+msgid "Loading media info from files..."
+msgstr "Naqra Media Info mill-fajls"
+
+#: id:507
+msgid "Sort by: Usage"
+msgstr "Ordni: Użu"
+
+#: id:510
+msgid "Enable visualizations"
+msgstr "Enable Visualisations"
+
+#: id:511
+msgid "Enable video mode switching"
+msgstr "Enable video mode switching"
+
+#: id:512
+msgid "Startup window"
+msgstr "Startup Window"
+
+#: id:513
+msgid "Home window"
+msgstr "Home Window"
+
+#: id:514
+msgid "Manual settings"
+msgstr "Settings Manwali"
+
+#: id:515
+msgid "Genre"
+msgstr "Ġeneru"
+
+#: id:517
+msgid "Recently played albums"
+msgstr "Albums mismugħha riċentament"
+
+#: id:518
+msgid "Launch"
+msgstr "Tellaq"
+
+#: id:519
+msgid "Launch in..."
+msgstr "Tellaq ġo.."
+
+#: id:521
+msgid "Compilations"
+msgstr "Kumpilazzjoni"
+
+#: id:522
+msgid "Remove source"
+msgstr "Neħħi Sors"
+
+#: id:523
+msgid "Switch media"
+msgstr "Eqleb Media"
+
+#: id:524
+msgid "Select playlist"
+msgstr "Għażel Playlist"
+
+#: id:525
+msgid "New playlist..."
+msgstr "Plejlist ġdida"
+
+#: id:526
+msgid "Add to playlist"
+msgstr "Żid mal-Playlist"
+
+#: id:527
+msgid "Manually add to library"
+msgstr "Żid fil-Librerija manwalment"
+
+#: id:528
+msgid "Enter title"
+msgstr "Daħħal Isem"
+
+#: id:529
+msgid "Error: Duplicate title"
+msgstr "Probelma: Isem Doppju"
+
+#: id:530
+msgid "Select genre"
+msgstr "Għażel Ġeneru"
+
+#: id:531
+msgid "New genre"
+msgstr "Żid Ġeneru"
+
+#: id:532
+msgid "Manual addition"
+msgstr "Żid Manwali"
+
+#: id:533
+msgid "Enter genre"
+msgstr "Daħħal Ġeneru"
+
+#: id:534
+msgid "View: %s"
+msgstr "Ara: %s"
+
+#: id:535
+msgid "List"
+msgstr "Lista"
+
+#: id:536
+msgid "Icons"
+msgstr "Ajkons"
+
+#: id:537
+msgid "Big list"
+msgstr "Lista Kbira"
+
+#: id:538
+msgid "Big icons"
+msgstr "Ajkons Kbar"
+
+#: id:539
+msgid "Wide"
+msgstr "Wiegħsa"
+
+#: id:540
+msgid "Big wide"
+msgstr "Wiegħsa Kbir"
+
+#: id:541
+msgid "Album icons"
+msgstr "Ajkon tal-Album"
+
+#: id:542
+msgid "DVD icons"
+msgstr "Ajkon tad-DVD"
+
+#: id:543
+msgctxt "Auto context with id 543"
+msgid "DVD"
+msgstr "DVD"
+
+#: id:544
+msgctxt "Auto context with id 544"
+msgid "Media info"
+msgstr "Info tal-Media"
+
+#: id:545
+msgid "Audio output device"
+msgstr ""
+
+#: id:546
+msgid "Passthrough output device"
+msgstr ""
+
+#: id:547
+msgid "No biography for this artist"
+msgstr ""
+
+#: id:548
+msgid "Downmix multichannel audio to stereo"
+msgstr ""
+
+#: id:550
+msgid "Sort by: %s"
+msgstr "Ordni: %s"
+
+#: id:551
+msgctxt "Auto context with id 551"
+msgid "Name"
+msgstr "Isem"
+
+#: id:552
+msgid "Date"
+msgstr "Data"
+
+#: id:553
+msgid "Size"
+msgstr "Kobor"
+
+#: id:554
+msgid "Track"
+msgstr "Trekk"
+
+#: id:555
+msgid "Time"
+msgstr "Ħin"
+
+#: id:556
+msgctxt "Auto context with id 556"
+msgid "Title"
+msgstr "Titlu"
+
+#: id:557
+msgid "Artist"
+msgstr "Artist"
+
+#: id:558
+msgid "Album"
+msgstr "Album"
+
+#: id:559
+msgid "Playlist"
+msgstr "Playlist"
+
+#: id:560
+msgid "ID"
+msgstr "ID"
+
+#: id:561
+msgctxt "Auto context with id 561"
+msgid "File"
+msgstr "Fajl"
+
+#: id:562
+msgctxt "Auto context with id 562"
+msgid "Year"
+msgstr "Sena"
+
+#: id:563
+msgid "Rating"
+msgstr "Rating"
+
+#: id:564
+msgctxt "Auto context with id 564"
+msgid "Type"
+msgstr "Tip"
+
+#: id:565
+msgid "Usage"
+msgstr "Użu"
+
+#: id:566
+msgid "Album artist"
+msgstr "Artist tal-album"
+
+#: id:567
+msgid "Play count"
+msgstr "Drabi mismugħ"
+
+#: id:568
+msgid "Last played"
+msgstr "L-aħħar smajt"
+
+#: id:569
+msgctxt "Auto context with id 569"
+msgid "Comment"
+msgstr "Kumment"
+
+#: id:570
+msgid "Date added"
+msgstr "Ġie miżjud"
+
+#: id:571
+msgctxt "Auto context with id 571"
+msgid "Default"
+msgstr "Default"
+
+#: id:572
+msgid "Studio"
+msgstr "Studjo"
+
+#: id:573
+msgid "Path"
+msgstr ""
+
+#: id:574
+msgctxt "Auto context with id 574"
+msgid "Country"
+msgstr ""
+
+#: id:575
+msgid "In progress"
+msgstr ""
+
+#: id:576
+msgid "Times played"
+msgstr ""
+
+#: id:580
+msgid "Sort direction"
+msgstr "Direzzjoni tal-Ordni"
+
+#: id:581
+msgid "Sort method"
+msgstr "Metodu tal-Ordni"
+
+#: id:582
+msgctxt "Auto context with id 582"
+msgid "View mode"
+msgstr "View Mode"
+
+#: id:583
+msgid "Remember views for different folders"
+msgstr "Ftakar il-View għal kannestri differenti"
+
+#: id:584
+msgid "Ascending"
+msgstr "Żgħir għal Kbir"
+
+#: id:585
+msgid "Descending"
+msgstr "Kbir għal Żgħir"
+
+#: id:586
+msgid "Edit playlist"
+msgstr "Biddel Playlist"
+
+#: id:587
+msgid "Filter"
+msgstr "Filter"
+
+#: id:588
+msgid "Cancel party mode"
+msgstr "Ħassar Party Mode"
+
+#: id:589
+msgid "Party mode"
+msgstr "Party Mode"
+
+#: id:590
+msgid "Random"
+msgstr "Random"
+
+#: id:591
+msgctxt "Auto context with id 591"
+msgid "Off"
+msgstr "Xejn"
+
+#: id:592
+msgid "One"
+msgstr "Darba"
+
+#: id:593
+msgid "All"
+msgstr "Kollox"
+
+#: id:594
+msgctxt "Auto context with id 594"
+msgid "Off"
+msgstr "Xejn"
+
+#: id:595
+msgid "Repeat: Off"
+msgstr "Irrepeti: Xejn"
+
+#: id:596
+msgid "Repeat: One"
+msgstr "Irrepeti: Darba"
+
+#: id:597
+msgid "Repeat: All"
+msgstr "Irrepeti: Kollox"
+
+#: id:600
+msgid "Rip audio CD"
+msgstr "Rip CD Audio"
+
+#: id:601
+msgctxt "Auto context with id 601"
+msgid "Medium"
+msgstr "Medju"
+
+#: id:602
+msgctxt "Auto context with id 602"
+msgid "Standard"
+msgstr "Standard"
+
+#: id:603
+msgid "Extreme"
+msgstr "Estrem"
+
+#: id:604
+msgid "Constant bitrate"
+msgstr "Constant Bit Rate"
+
+#: id:605
+msgid "Ripping..."
+msgstr "Ripping..."
+
+#: id:607
+msgid "To:"
+msgstr "Għal:"
+
+#: id:608
+msgid "Could not rip CD or track"
+msgstr "Problema biex nirripja CD jew Trekk"
+
+#: id:609
+msgid "CDDARipPath is not set."
+msgstr "CDDARipPath mhux issettjat."
+
+#: id:610
+msgid "Rip audio track"
+msgstr "Nirripja Trekk tal-Awdjo"
+
+#: id:611
+msgid "Enter number"
+msgstr ""
+
+#: id:612
+msgid "Bits/Sample"
+msgstr ""
+
+#: id:613
+msgid "Sample Frequency"
+msgstr ""
+
+#: id:620
+msgid "Audio CDs"
+msgstr "CD Ripping"
+
+#: id:621
+msgid "Encoder"
+msgstr "Encoder"
+
+#: id:622
+msgid "Quality"
+msgstr "Kwalita"
+
+#: id:623
+msgid "Bitrate"
+msgstr "Bit Rate"
+
+#: id:624
+msgid "Include track number"
+msgstr "Inkludi numru tat-trekk"
+
+#: id:625
+msgid "All songs of"
+msgstr "Diski kollha għal"
+
+#: id:629
+msgctxt "Auto context with id 629"
+msgid "View mode"
+msgstr "View Mode"
+
+#: id:630
+msgctxt "Auto context with id 630"
+msgid "Normal"
+msgstr "Normali"
+
+#: id:631
+msgid "Zoom"
+msgstr "Lenti"
+
+#: id:632
+msgid "Stretch 4:3"
+msgstr "Ġebbed 4:3"
+
+#: id:633
+msgid "Wide Zoom"
+msgstr "Ġebbed 14:9"
+
+#: id:634
+msgid "Stretch 16:9"
+msgstr "Ġebbed 16:9"
+
+#: id:635
+msgid "Original Size"
+msgstr "Qis originali"
+
+#: id:636
+msgctxt "Auto context with id 636"
+msgid "Custom"
+msgstr "Custom"
+
+#: id:637
+msgid "Replay gain"
+msgstr "Replay Gain"
+
+#: id:638
+msgid "Replaygain volume adjustments"
+msgstr "Replay Gain Mode"
+
+#: id:639
+msgid "Use track levels"
+msgstr "Uża Track Levels"
+
+#: id:640
+msgid "Use album levels"
+msgstr "Uża Album Levels"
+
+#: id:641
+msgid "PreAmp Level - Replay gained files"
+msgstr "PreAmp Level - Replay Gained Files"
+
+#: id:642
+msgid "PreAmp Level - Non replay gained files"
+msgstr "PreAmp Level - Non Replay Gained Files"
+
+#: id:643
+msgid "Avoid clipping on replay gained files"
+msgstr "Avoid Clipping on Replay Gained Files"
+
+#: id:644
+msgid "Crop black bars"
+msgstr "Crop Black Bars"
+
+#: id:645
+msgid "Need to unpack a big file. Continue?"
+msgstr "Niftaħ fajl kbir. Inkompli?"
+
+#: id:646
+msgid "Remove from library"
+msgstr "Neħħi mil-Librerija"
+
+#: id:647
+msgid "Export video library"
+msgstr "Esporta Librerija tal-Vidjos"
+
+#: id:648
+msgid "Import video library"
+msgstr "Importa Librerija tal-Vidjos"
+
+#: id:649
+msgid "Importing"
+msgstr "Nimporta"
+
+#: id:650
+msgid "Exporting"
+msgstr "Nesporta"
+
+#: id:651
+msgid "Browse for library"
+msgstr "Ara Librerija"
+
+#: id:652
+msgid "Years"
+msgstr "Snin"
+
+#: id:653
+msgid "Update library"
+msgstr "Aġġorna Librerija"
+
+#: id:654
+msgid "Show debug info"
+msgstr "Uri Debug Info"
+
+#: id:655
+msgid "Browse for executable"
+msgstr "Fittex għal programmi"
+
+#: id:656
+msgid "Browse for playlist"
+msgstr "Fittex għal Playlist"
+
+#: id:657
+msgid "Browse for folder"
+msgstr "Fittex għal fowlder"
+
+#: id:658
+msgid "Song information"
+msgstr "Informazzjoni tad-diska"
+
+#: id:659
+msgid "Non-linear stretch"
+msgstr "Kumment:"
+
+#: id:660
+msgid "Volume amplification"
+msgstr "Amplifikazzjoni tal-Volum"
+
+#: id:661
+msgid "Choose export folder"
+msgstr "Għażel Fowlder tal-Export"
+
+#: id:662
+msgid "This file is no longer available."
+msgstr ""
+
+#: id:663
+msgid "Would you like to remove it from the library?"
+msgstr ""
+
+#: id:664
+msgid "Browse for Script"
+msgstr ""
+
+#: id:665
+msgid "Compression level"
+msgstr ""
+
+#: id:700
+msgid "Cleaning up library"
+msgstr "Cleaning up Library"
+
+#: id:701
+msgid "Removing old songs from the library"
+msgstr "Inneħħi diski qodma mill-Librerija"
+
+#: id:702
+msgid "This path has been scanned before"
+msgstr "Dan is-sors diġa proċessat qabel"
+
+#: id:705
+msgctxt "Auto context with id 705"
+msgid "Network"
+msgstr "Network"
+
+#: id:706
+msgid "- Server"
+msgstr "Ħowst tal-HTTP Proxy"
+
+#: id:708
+msgid "Use an HTTP proxy server to access the internet"
+msgstr "Attiva HTTP Proxy"
+
+#: id:711
+msgid "Internet Protocol (IP)"
+msgstr "Internet Protocol (IP)"
+
+#: id:712
+msgid "Invalid port specified. Value must be between 1 and 65535."
+msgstr "Port mhux validu. Irid ikun bejn 1 u 65535."
+
+#: id:713
+msgid "HTTP proxy"
+msgstr "HTTP Proxy"
+
+#: id:715
+msgid "- Assignment"
+msgstr "Assignment"
+
+#: id:716
+msgid "Automatic (DHCP)"
+msgstr "Awto (DHCP)"
+
+#: id:717
+msgid "Manual (Static)"
+msgstr "Manwali (Static)"
+
+#: id:719
+msgid "- IP address"
+msgstr "- IP Address"
+
+#: id:720
+msgid "- Netmask"
+msgstr "- Netmask"
+
+#: id:721
+msgid "- Default gateway"
+msgstr "- Difolt Gejtwej"
+
+#: id:722
+msgid "- DNS server"
+msgstr "- DNS Server"
+
+#: id:723
+msgid "Save & restart"
+msgstr "Issevja w irristartja"
+
+#: id:724
+msgid "Invalid address specified. Value must be AAA.BBB.CCC.DDD"
+msgstr "Indirizz mhux validu. Irid ikun AAA.BBB.CCC.DDD"
+
+#: id:725
+msgid "with numbers between 0 and 255."
+msgstr "b'numri bejn 0 u 255."
+
+#: id:726
+msgid "Changes not saved. Continue without saving?"
+msgstr "Tibdil mhux issejvjat. Tkompli bla ma tissevja?"
+
+#: id:727
+msgid "Web server"
+msgstr "Web Server"
+
+#: id:728
+msgctxt "Auto context with id 728"
+msgid "FTP server"
+msgstr "FTP Server"
+
+#: id:730
+msgid "- Port"
+msgstr "Port tal-Web Server"
+
+#: id:732
+msgid "Save & apply"
+msgstr "Issevja w Uża"
+
+#: id:733
+msgid "- Password"
+msgstr "Sigriet tal-Web Server"
+
+#: id:734
+msgid "No pass"
+msgstr "Bla Sigriet"
+
+#: id:735
+msgid "- Character set"
+msgstr "- Charset"
+
+#: id:736
+msgid "- Style"
+msgstr "- Stil"
+
+#: id:737
+msgid "- Colour"
+msgstr "- Kulur"
+
+#: id:738
+msgctxt "Auto context with id 738"
+msgid "Normal"
+msgstr "Normali"
+
+#: id:739
+msgid "Bold"
+msgstr "Bold"
+
+#: id:740
+msgid "Italics"
+msgstr "Italics"
+
+#: id:741
+msgid "Bold italics"
+msgstr "Bold Italics"
+
+#: id:742
+msgctxt "Auto context with id 742"
+msgid "White"
+msgstr "abjad"
+
+#: id:743
+msgctxt "Auto context with id 743"
+msgid "Yellow"
+msgstr "isfar"
+
+#: id:744
+msgctxt "Auto context with id 744"
+msgid "Files"
+msgstr "Fajls"
+
+#: id:745
+msgid "No scanned information for this view"
+msgstr "Ma stabux dettalji għal din il-view"
+
+#: id:746
+msgid "Please turn off library mode"
+msgstr "Eqleb għal Files view"
+
+#: id:747
+msgid "Error loading image"
+msgstr "Problema biex naqra l-istampa"
+
+#: id:748
+msgid "Edit path"
+msgstr "Edit Path"
+
+#: id:749
+msgid "Mirror image"
+msgstr ""
+
+#: id:750
+msgid "Are you sure?"
+msgstr "Tikkonferma?"
+
+#: id:751
+msgid "Removing source"
+msgstr "Inneħħi Sors"
+
+#: id:754
+msgid "Add program link"
+msgstr "Żid Link tal-Programm"
+
+#: id:755
+msgid "Edit program path"
+msgstr "Edit Program Path"
+
+#: id:756
+msgid "Edit program name"
+msgstr "Edit Program Name"
+
+#: id:757
+msgid "Edit path depth"
+msgstr "Edit Path Depth"
+
+#: id:759
+msgid "View: Big list"
+msgstr "Uri: Lista Kbira"
+
+#: id:760
+msgctxt "Auto context with id 760"
+msgid "Yellow"
+msgstr "Isfar"
+
+#: id:761
+msgctxt "Auto context with id 761"
+msgid "White"
+msgstr "Abjad"
+
+#: id:762
+msgid "Blue"
+msgstr "Ikħal"
+
+#: id:763
+msgid "Bright green"
+msgstr "Aħdar jgħajjat"
+
+#: id:764
+msgid "Yellow green"
+msgstr "Aħdar Safrani"
+
+#: id:765
+msgid "Cyan"
+msgstr "Ċelesti"
+
+#: id:766
+msgid "Light grey"
+msgstr "Riservat"
+
+#: id:767
+msgid "Grey"
+msgstr "Riservat"
+
+#: id:770
+msgid "Error %i: share not available"
+msgstr "Problema %i: share mhux disponibbli"
+
+#: id:772
+msgctxt "Auto context with id 772"
+msgid "Audio output"
+msgstr "Audio Hardware"
+
+#: id:773
+msgid "Seeking"
+msgstr "Seeking"
+
+#: id:774
+msgid "Slideshow folder"
+msgstr "Slideshow Folder"
+
+#: id:775
+msgid "Network interface"
+msgstr ""
+
+#: id:776
+msgid "- Wireless network name (ESSID)"
+msgstr ""
+
+#: id:777
+msgid "- Wireless password"
+msgstr ""
+
+#: id:778
+msgid "- Wireless security"
+msgstr ""
+
+#: id:779
+msgid "Save and apply network interface settings"
+msgstr ""
+
+#: id:780
+msgid "No encryption"
+msgstr ""
+
+#: id:781
+msgid "WEP"
+msgstr ""
+
+#: id:782
+msgid "WPA"
+msgstr ""
+
+#: id:783
+msgid "WPA2"
+msgstr ""
+
+#: id:784
+msgid "Applying network interface settings. Please wait."
+msgstr ""
+
+#: id:785
+msgid "Network interface restarted successfully."
+msgstr ""
+
+#: id:786
+msgid "Network interface did not start successfully."
+msgstr ""
+
+#: id:787
+msgid "Interface disabled"
+msgstr ""
+
+#: id:788
+msgid "Network interface disabled successfully."
+msgstr ""
+
+#: id:789
+msgid "Wireless network name (ESSID)"
+msgstr ""
+
+#: id:790
+msgid "Remote control"
+msgstr "Remote Events"
+
+#: id:791
+msgid "Allow programs on this system to control XBMC"
+msgstr "Attiva Remote Events"
+
+#: id:792
+msgctxt "Auto context with id 792"
+msgid "Port"
+msgstr "Port tar-Remote Events"
+
+#: id:793
+msgid "Port range"
+msgstr "Port Range tar-Remote Events"
+
+#: id:794
+msgid "Allow programs on other systems to control XBMC"
+msgstr "Irċievi events minn kompjuters oħra"
+
+#: id:795
+msgid "Initial repeat delay (ms)"
+msgstr ""
+
+#: id:796
+msgid "Continuous repeat delay (ms)"
+msgstr ""
+
+#: id:797
+msgid "Maximum number of clients"
+msgstr ""
+
+#: id:798
+msgid "Internet access"
+msgstr ""
+
+#: id:850
+msgid "Invalid port number entered"
+msgstr ""
+
+#: id:851
+msgid "Valid port range is 1-65535"
+msgstr ""
+
+#: id:852
+msgid "Valid port range is 1024-65535"
+msgstr ""
+
+#: id:998
+msgid "Add Music..."
+msgstr "XLink Kai"
+
+#: id:999
+msgid "Add Videos..."
+msgstr "Online Gaming"
+
+#: id:1000
+msgid "- Preview"
+msgstr "Screensaver Preview"
+
+#: id:1001
+msgid "Unable to connect"
+msgstr "Unable to connect"
+
+#: id:1002
+msgid "XBMC was unable to connect to the network location."
+msgstr "XBMC ma rnexxielux jaqbad mad-destinazzjoni tan-network."
+
+#: id:1003
+msgid "This could be due to the network not being connected."
+msgstr "Dan jista jkun minħabba li n-network mhux imqabbad."
+
+#: id:1004
+msgid "Would you like to add it anyway?"
+msgstr "Trid iżżidha xorta waħda?"
+
+#: id:1006
+msgctxt "Auto context with id 1006"
+msgid "IP address"
+msgstr "IP Address"
+
+#: id:1007
+msgid "Add network location"
+msgstr "Żid Network Location"
+
+#: id:1008
+msgid "Protocol"
+msgstr "Protokol"
+
+#: id:1009
+msgid "Server address"
+msgstr "Indirizz tas-Server"
+
+#: id:1010
+msgid "Server name"
+msgstr "Isem tas-Server"
+
+#: id:1011
+msgid "Remote path"
+msgstr "Remote Path"
+
+#: id:1012
+msgid "Shared folder"
+msgstr "Shared Folder"
+
+#: id:1013
+msgctxt "Auto context with id 1013"
+msgid "Port"
+msgstr "Port"
+
+#: id:1014
+msgctxt "Auto context with id 1014"
+msgid "Username"
+msgstr "Username"
+
+#: id:1015
+msgid "Browse for network server"
+msgstr "Fittex network server"
+
+#: id:1016
+msgid "Enter the network address of the server"
+msgstr "Daħħal in-network address tas-server"
+
+#: id:1017
+msgid "Enter the path on the server"
+msgstr "Daħħal il-fowlder fuq is-server"
+
+#: id:1018
+msgid "Enter the port number"
+msgstr "Daħħal in-numru tal-port"
+
+#: id:1019
+msgid "Enter the username"
+msgstr "Daħħal username"
+
+#: id:1020
+msgid "Add %s source"
+msgstr "Żid Sors: %s"
+
+#: id:1021
+msgid "Enter the paths or browse for the media locations."
+msgstr "Daħħal il-kannestri jew browżja għal sorsi ta' media."
+
+#: id:1022
+msgid "Enter a name for this media Source."
+msgstr "Daħħal isem għal dan is-sors ta' media."
+
+#: id:1023
+msgid "Browse for new share"
+msgstr "Fittex għal share ġdid"
+
+#: id:1024
+msgid "Browse"
+msgstr "Fittex"
+
+#: id:1025
+msgid "Could not retrieve directory information."
+msgstr "Ma nstabux dettalji tal-fowlder."
+
+#: id:1026
+msgid "Add source"
+msgstr "Żid Sors"
+
+#: id:1027
+msgid "Edit source"
+msgstr "Biddel Sors"
+
+#: id:1028
+msgid "Edit %s source"
+msgstr "Żid Sors: %s"
+
+#: id:1029
+msgid "Enter the new label"
+msgstr "Daħħal l-isem il-ġdid"
+
+#: id:1030
+msgid "Browse for image"
+msgstr "Fittex Stampa"
+
+#: id:1031
+msgid "Browse for image folder"
+msgstr "Fittex Fowlder tal-istampi"
+
+#: id:1032
+msgid "Add network location..."
+msgstr "Żid Sors tan-Network..."
+
+#: id:1033
+msgid "Browse for file"
+msgstr "Fittex għal fajl"
+
+#: id:1034
+msgid "Submenu"
+msgstr "Menu Sekondarju"
+
+#: id:1035
+msgid "Enable submenu buttons"
+msgstr "Attiva Buttuni tal-Menu Sekondarju"
+
+#: id:1036
+msgid "Favourites"
+msgstr "Favoriti"
+
+#: id:1037
+msgid "Video Add-ons"
+msgstr "Plagins tal-Vidjo"
+
+#: id:1038
+msgid "Music Add-ons"
+msgstr "Plagins tal-Mużika"
+
+#: id:1039
+msgid "Picture Add-ons"
+msgstr "Plagins tal-iStampi"
+
+#: id:1040
+msgid "Loading directory"
+msgstr "Naqra fowlder"
+
+#: id:1041
+msgid "Retrieved %i items"
+msgstr "Ġibt %i oġġetti"
+
+#: id:1042
+msgid "Retrieved %i of %i items"
+msgstr "Ġibt %i oġġetti minn %i"
+
+#: id:1043
+msgid "Program Add-ons"
+msgstr "Plagins tal-Programmi"
+
+#: id:1044
+msgid "Set plugin thumb"
+msgstr "Isettja Tambnejl tal-Plagin"
+
+#: id:1045
+msgid "Add-on settings"
+msgstr "Settings tal-Plagin"
+
+#: id:1046
+msgid "Access points"
+msgstr ""
+
+#: id:1047
+msgid "Other..."
+msgstr ""
+
+#: id:1048
+msgid "- Username"
+msgstr ""
+
+#: id:1049
+msgid "Script settings"
+msgstr ""
+
+#: id:1050
+msgid "Singles"
+msgstr ""
+
+#: id:1051
+msgid "Enter web address"
+msgstr ""
+
+#: id:1200
+msgid "SMB client"
+msgstr "SMB Client"
+
+#: id:1202
+msgid "Workgroup"
+msgstr "Workgroup"
+
+#: id:1203
+msgid "Default username"
+msgstr "Default Username"
+
+#: id:1204
+msgid "Default password"
+msgstr "Sigriet Difolt"
+
+#: id:1207
+msgid "WINS server"
+msgstr "WINS-Server"
+
+#: id:1208
+msgid "Mount SMB shares"
+msgstr ""
+
+#: id:1210
+msgctxt "Auto context with id 1210"
+msgid "Remove"
+msgstr "Neħħi"
+
+#: id:1211
+msgctxt "Auto context with id 1211"
+msgid "Music"
+msgstr "Mużika"
+
+#: id:1212
+msgctxt "Auto context with id 1212"
+msgid "Video"
+msgstr "Vidjo"
+
+#: id:1213
+msgctxt "Auto context with id 1213"
+msgid "Pictures"
+msgstr "Ritratti"
+
+#: id:1214
+msgctxt "Auto context with id 1214"
+msgid "Files"
+msgstr "Fajls"
+
+#: id:1215
+msgctxt "Auto context with id 1215"
+msgid "Music & video"
+msgstr "Mużika w Vidjo"
+
+#: id:1216
+msgid "Music & pictures"
+msgstr "Mużika w Ritratti"
+
+#: id:1217
+msgid "Music & files"
+msgstr "Mużika w Fajls"
+
+#: id:1218
+msgid "Video & pictures"
+msgstr "Vidjo w Ritratti"
+
+#: id:1219
+msgid "Video & files"
+msgstr "Vidjo and Fajls"
+
+#: id:1220
+msgid "Pictures & files"
+msgstr "Ritratti w Fajls"
+
+#: id:1221
+msgid "Music & video & pictures"
+msgstr "Mużika w Vidjo w Ritratti"
+
+#: id:1222
+msgid "Music & video & pictures & files"
+msgstr "Mużika w Vidjo w Ritratti w Fajls"
+
+#: id:1223
+msgctxt "Auto context with id 1223"
+msgid "Disabled"
+msgstr "Mhux attiv"
+
+#: id:1226
+msgid "Files & music & video"
+msgstr "Fajls, Mużika u Films"
+
+#: id:1227
+msgid "Files & pictures & music"
+msgstr "Fajls, Stampi u Mużika"
+
+#: id:1228
+msgid "Files & pictures & video"
+msgstr "Fajla, Stampi u Films"
+
+#: id:1229
+msgid "Music & programs"
+msgstr "Mużika u Programmi"
+
+#: id:1230
+msgid "Video & programs"
+msgstr "Films u Programmi"
+
+#: id:1231
+msgid "Pictures & programs"
+msgstr "Stampi u Programmi"
+
+#: id:1232
+msgid "Music & video & pictures & programs"
+msgstr "Programmi, Films, Mużika u Stampi"
+
+#: id:1233
+msgid "Programs & video & music"
+msgstr "Programmi, Films u Mużika"
+
+#: id:1234
+msgid "Programs & pictures & music"
+msgstr "Programmi, Stampi u Mużika"
+
+#: id:1235
+msgid "Programs & pictures & video"
+msgstr "Programmi, Stampi u Films"
+
+#: id:1250
+msgid "Auto-detection"
+msgstr "Qari Awtomatiku"
+
+#: id:1251
+msgid "Auto-detect system"
+msgstr "Qari Awtomatiku tal-Xbox"
+
+#: id:1252
+msgid "Nickname"
+msgstr "Laqam"
+
+#: id:1254
+msgid "Ask to connect"
+msgstr "Staqsi biex taqbad"
+
+#: id:1255
+msgid "Send FTP user and password"
+msgstr "Ibgħat FTP User u Sigriet"
+
+#: id:1256
+msgid "Ping interval"
+msgstr "Ping Interval"
+
+#: id:1257
+msgid "Would you like to connect to the auto-detected system?"
+msgstr "Trid taqbad biex taqra dettalji tal-Xbox awtomatikament?"
+
+#: id:1259
+msgid "Zeroconf"
+msgstr ""
+
+#: id:1260
+msgid "Announce these services to other systems via Zeroconf"
+msgstr ""
+
+#: id:1270
+msgid "Allow XBMC to receive AirPlay content"
+msgstr ""
+
+#: id:1271
+msgid "Device name"
+msgstr ""
+
+#: id:1272
+msgid "- Use password protection"
+msgstr ""
+
+#: id:1273
+msgid "AirPlay"
+msgstr ""
+
+#: id:1300
+msgid "Custom audio device"
+msgstr ""
+
+#: id:1301
+msgid "Custom passthrough device"
+msgstr ""
+
+#: id:1396
+msgid "Drifting"
+msgstr "Drifting"
+
+#: id:1397
+msgid "and"
+msgstr "u"
+
+#: id:1398
+msgid "Freezing"
+msgstr "Freezing"
+
+#: id:1399
+msgid "Late"
+msgstr "Tard"
+
+#: id:1400
+msgid "Isolated"
+msgstr "Iżolati"
+
+#: id:1401
+msgid "Thundershowers"
+msgstr "T-Showers"
+
+#: id:1402
+msgid "Thunder"
+msgstr "Ragħad"
+
+#: id:1403
+msgctxt "Auto context with id 1403"
+msgid "Sun"
+msgstr "Xemx"
+
+#: id:1404
+msgid "Heavy"
+msgstr "Qalil"
+
+#: id:1405
+msgid "in"
+msgstr "fil-"
+
+#: id:1406
+msgid "the"
+msgstr "il-"
+
+#: id:1407
+msgid "Vicinity"
+msgstr "Viċinanza"
+
+#: id:1408
+msgid "Ice"
+msgstr "Silġ"
+
+#: id:1409
+msgid "Crystals"
+msgstr "Crystals"
+
+#: id:1410
+msgid "Calm"
+msgstr "Kalm"
+
+#: id:1411
+msgid "with"
+msgstr "bil-"
+
+#: id:1412
+msgid "windy"
+msgstr "bir-riħ"
+
+#: id:1413
+msgid "drizzle"
+msgstr "rxiex"
+
+#: id:1414
+msgid "Thunderstorm"
+msgstr "T-Storm"
+
+#: id:1415
+msgid "Drizzle"
+msgstr ""
+
+#: id:1416
+msgid "Foggy"
+msgstr ""
+
+#: id:1417
+msgid "Grains"
+msgstr ""
+
+#: id:1418
+msgid "T-Storms"
+msgstr ""
+
+#: id:1419
+msgid "T-Showers"
+msgstr ""
+
+#: id:1420
+msgid "Moderate"
+msgstr ""
+
+#: id:1421
+msgid "Very High"
+msgstr ""
+
+#: id:1422
+msgid "Windy"
+msgstr ""
+
+#: id:1423
+msgid "Mist"
+msgstr ""
+
+#: id:1450
+msgid "Put display to sleep when idle"
+msgstr ""
+
+#: id:2050
+msgid "Runtime"
+msgstr "Tul:"
+
+#: id:2100
+msgid "Script failed! : %s"
+msgstr ""
+
+#: id:2101
+msgid "Newer version needed - See log"
+msgstr ""
+
+#: id:4501
+msgid "Enable LCD/VFD"
+msgstr "Tip tal-LCD"
+
+#: id:10000
+msgid "Home"
+msgstr "Dħul"
+
+#: id:10001
+msgctxt "Auto context with id 10001"
+msgid "Programs"
+msgstr "Programmi"
+
+#: id:10002
+msgctxt "Auto context with id 10002"
+msgid "Pictures"
+msgstr "Stampi"
+
+#: id:10003
+msgctxt "Auto context with id 10003"
+msgid "File manager"
+msgstr "Fajls"
+
+#: id:10004
+msgctxt "Auto context with id 10004"
+msgid "Settings"
+msgstr "Settings"
+
+#: id:10005
+msgctxt "Auto context with id 10005"
+msgid "Music"
+msgstr "Mużika"
+
+#: id:10006
+msgctxt "Auto context with id 10006"
+msgid "Videos"
+msgstr "Filmati"
+
+#: id:10007
+msgid "System information"
+msgstr "Informazzjoni tas-Sistema"
+
+#: id:10008
+msgid "Settings - General"
+msgstr "Settings->Ġenerali"
+
+#: id:10009
+msgid "Settings - Screen"
+msgstr "Settings->Screen"
+
+#: id:10010
+msgid "Settings - Appearance - GUI Calibration"
+msgstr "Settings->Screen->UI Calibration"
+
+#: id:10011
+msgid "Settings - Videos - Screen Calibration"
+msgstr "Settings->Screen->Screen Calibration"
+
+#: id:10012
+msgid "Settings - Pictures"
+msgstr "Settings->SlideShow"
+
+#: id:10013
+msgid "Settings - Programs"
+msgstr "Settings->Screen->Filters"
+
+#: id:10014
+msgid "Settings - Weather"
+msgstr "Settings->Mużika"
+
+#: id:10015
+msgid "Settings - Music"
+msgstr "Settings->Screen->Sottotitloi"
+
+#: id:10016
+msgid "Settings - System"
+msgstr "Settings->Screen->Skrinsejver"
+
+#: id:10017
+msgid "Settings - Videos"
+msgstr "Settings->Temp"
+
+#: id:10018
+msgid "Settings - Network"
+msgstr "Settings->Network"
+
+#: id:10019
+msgid "Settings - Appearance"
+msgstr "Settings->Apparenza"
+
+#: id:10020
+msgctxt "Auto context with id 10020"
+msgid "Scripts"
+msgstr "Settings->Scripts"
+
+#: id:10021
+msgid "Web Browser"
+msgstr "Filmati/Ġeneru"
+
+#: id:10025
+msgctxt "Auto context with id 10025"
+msgid "Videos"
+msgstr "Filmati/titlu"
+
+#: id:10028
+msgid "Videos/Playlist"
+msgstr "Filmati/plejlist"
+
+#: id:10029
+msgctxt "Auto context with id 10029"
+msgid "Login screen"
+msgstr ""
+
+#: id:10034
+msgid "Settings - Profiles"
+msgstr "Settings->Profili"
+
+#: id:10040
+msgid "Addon browser"
+msgstr ""
+
+#: id:10100
+msgid "Yes/No dialog"
+msgstr "Kaxxa Iva/Le"
+
+#: id:10101
+msgid "Progress dialog"
+msgstr "Kaxxa Progress"
+
+#: id:10210
+msgid "Looking for subtitles..."
+msgstr ""
+
+#: id:10211
+msgid "Looking for or caching subtitles..."
+msgstr ""
+
+#: id:10212
+msgid "terminating"
+msgstr ""
+
+#: id:10213
+msgid "buffering"
+msgstr ""
+
+#: id:10214
+msgid "Opening stream"
+msgstr ""
+
+#: id:10500
+msgid "Music/Playlist"
+msgstr "Diski/plejlist"
+
+#: id:10501
+msgid "Music/Files"
+msgstr "Diski/fajls"
+
+#: id:10502
+msgid "Music/Library"
+msgstr "Diski/albums"
+
+#: id:10503
+msgid "Playlist editor"
+msgstr "Plejlist Editor"
+
+#: id:10504
+msgid "Top 100 songs"
+msgstr "L-aqwa 100 diska"
+
+#: id:10505
+msgid "Top 100 albums"
+msgstr "L-aqwa 100 Album"
+
+#: id:10506
+msgctxt "Auto context with id 10506"
+msgid "Programs"
+msgstr "Programmi"
+
+#: id:10507
+msgid "Configuration"
+msgstr "Konfigurazzjoni"
+
+#: id:10508
+msgid "Weather forecast"
+msgstr "Previżżjoni tat-temp"
+
+#: id:10509
+msgid "Network gaming"
+msgstr "Network Gaming"
+
+#: id:10510
+msgid "Extensions"
+msgstr "Estensjonijiet"
+
+#: id:10511
+msgctxt "Auto context with id 10511"
+msgid "System info"
+msgstr "Info tas-sistema"
+
+#: id:10516
+msgid "Music - Library"
+msgstr "Diski - Librerija"
+
+#: id:10517
+msgid "Now Playing - Music"
+msgstr "Qed Indoqq - Diski"
+
+#: id:10522
+msgid "Now Playing - Videos"
+msgstr "Qed nuri - Vidjo"
+
+#: id:10523
+msgid "Album info"
+msgstr "Info tal-Album"
+
+#: id:10524
+msgid "Movie info"
+msgstr "Info tal-Filmat"
+
+#: id:12000
+msgid "Select dialog"
+msgstr "Għażel kaxxa"
+
+#: id:12001
+msgid "Music/Info"
+msgstr "Diski/info"
+
+#: id:12002
+msgid "Dialog OK"
+msgstr "Kaxxa OK"
+
+#: id:12003
+msgid "Videos/Info"
+msgstr "Filmati/Info"
+
+#: id:12004
+msgid "Scripts/Info"
+msgstr "Programmi/Info"
+
+#: id:12005
+msgid "Fullscreen video"
+msgstr "Stampa Sħiħa"
+
+#: id:12006
+msgid "Audio visualization"
+msgstr "Viżwalizzazzjoni"
+
+#: id:12008
+msgid "File stacking dialog"
+msgstr "Kaxxa Filestacking"
+
+#: id:12009
+msgid "Rebuild index..."
+msgstr "Erġa Ibni l-indiċi..."
+
+#: id:12010
+msgid "Return to music window"
+msgstr "Lura għal My Music"
+
+#: id:12011
+msgid "Return to videos window"
+msgstr "Lura għal My Video"
+
+#: id:12021
+msgid "Start from beginning"
+msgstr "Ibda mill-bidu"
+
+#: id:12022
+msgid "Resume from %s"
+msgstr "Kompli mill-aħħar"
+
+#: id:12310
+msgid "0"
+msgstr "0"
+
+#: id:12311
+msgid "1"
+msgstr "1"
+
+#: id:12312
+msgid "2"
+msgstr "2"
+
+#: id:12313
+msgid "3"
+msgstr "3"
+
+#: id:12314
+msgid "4"
+msgstr "4"
+
+#: id:12315
+msgid "5"
+msgstr "5"
+
+#: id:12316
+msgid "6"
+msgstr "6"
+
+#: id:12317
+msgid "7"
+msgstr "7"
+
+#: id:12318
+msgid "8"
+msgstr "8"
+
+#: id:12319
+msgid "9"
+msgstr "9"
+
+#: id:12320
+msgid "c"
+msgstr "c"
+
+#: id:12321
+msgid "Ok"
+msgstr "ok"
+
+#: id:12322
+msgid "*"
+msgstr "*"
+
+#: id:12325
+msgid "Locked! Enter code..."
+msgstr "Maqful! Daħħal il-Kowd..."
+
+#: id:12326
+msgid "Enter password"
+msgstr "Daħħal sigriet"
+
+#: id:12327
+msgid "Enter master code"
+msgstr "Daħħal Master Kowd"
+
+#: id:12328
+msgid "Enter unlock code"
+msgstr "Daħħal Unlock Kowd"
+
+#: id:12329
+msgid "or press C to cancel"
+msgstr "jew għafas C biex tikkanċċella"
+
+#: id:12330
+msgid "Enter gamepad button combo and"
+msgstr "Daħħal Gamepad button combo u għafas Start"
+
+#: id:12331
+msgid "press OK, or Back to cancel"
+msgstr "għafas Start, jew Back biex tikkanċċella"
+
+#: id:12332
+msgid "Set lock"
+msgstr "Issettja il-Lock"
+
+#: id:12333
+msgid "Unlock"
+msgstr "Neħħi l-Lock"
+
+#: id:12334
+msgid "Reset lock"
+msgstr "Erġa ssettja il-Lock"
+
+#: id:12335
+msgid "Remove lock"
+msgstr "Neħħi Lock"
+
+#: id:12337
+msgid "Numeric password"
+msgstr "Numeric Sigriet"
+
+#: id:12338
+msgid "Gamepad button combo"
+msgstr "Gamepad button combo"
+
+#: id:12339
+msgid "Full-text password"
+msgstr "Sigriet Sħiħ"
+
+#: id:12340
+msgid "Enter new password"
+msgstr "Daħħal Sigriet ġdid"
+
+#: id:12341
+msgid "Re-Enter new password"
+msgstr "Erġa daħħal Sigriet ġdid"
+
+#: id:12342
+msgid "Incorrect password,"
+msgstr "Sigriet Ħażin,"
+
+#: id:12343
+msgid "retries left"
+msgstr "ċansijiet"
+
+#: id:12344
+msgid "Passwords entered did not match."
+msgstr "Sigrieti mdaħħla mhux l-istess."
+
+#: id:12345
+msgid "Access denied"
+msgstr "Aċċess Miżmum"
+
+#: id:12346
+msgid "Password retry limit exceeded."
+msgstr "Ċansijiet tas-sigriet użati kollha."
+
+#: id:12347
+msgid "The system will now shut off."
+msgstr "L-Xbox ser tintefa."
+
+#: id:12348
+msgid "Item locked"
+msgstr "Item Locked"
+
+#: id:12353
+msgid "Reactivate lock"
+msgstr "Erġa ttiva l-Lock"
+
+#: id:12356
+msgid "Change lock"
+msgstr "Ibdel il-Lock"
+
+#: id:12357
+msgid "Source lock"
+msgstr "Qassam il-Lock"
+
+#: id:12358
+msgid "Password entry was blank. Try again."
+msgstr "Sigriet ma jistax ikun vojt. Erġa pprova."
+
+#: id:12360
+msgid "Master lock"
+msgstr "Master Lock"
+
+#: id:12362
+msgid "Shutdown system if Master Lock retries exceeded"
+msgstr "Shutdown Xbox if Master Lock retries exceeded"
+
+#: id:12367
+msgid "Master code is not valid"
+msgstr "Master Code is not valid!"
+
+#: id:12368
+msgid "Please enter a valid master code"
+msgstr "Jekk jogħoġbok Daħħal Master Kowd tajjeb!"
+
+#: id:12373
+msgid "Settings & file manager"
+msgstr "Settings and My Files"
+
+#: id:12376
+msgid "Set as default for all movies"
+msgstr "Set as default for all Movies"
+
+#: id:12377
+msgid "This will reset any previously saved values"
+msgstr "This will reset any previously saved values"
+
+#: id:12378
+msgid "Amount of time to display each image"
+msgstr "Uri kull stampa għal"
+
+#: id:12379
+msgid "Use pan and zoom effects"
+msgstr "Uża Pan and Zoom effects"
+
+#: id:12383
+msgid "12 hour clock"
+msgstr "Arloġġ 12 hour"
+
+#: id:12384
+msgid "24 hour clock"
+msgstr "Arloġġ 24 hour"
+
+#: id:12385
+msgid "Day/Month"
+msgstr "Ġurnata/Xahar"
+
+#: id:12386
+msgid "Month/Day"
+msgstr "Xahar/Ġurnata"
+
+#: id:12390
+msgid "System uptime"
+msgstr "Ħin Mixgħul"
+
+#: id:12391
+msgid "Minutes"
+msgstr "Minuti"
+
+#: id:12392
+msgid "Hours"
+msgstr "Sigħat"
+
+#: id:12393
+msgid "Days"
+msgstr "Ġranet"
+
+#: id:12394
+msgid "Total uptime"
+msgstr "Total ta' ħin mixgħul"
+
+#: id:12395
+msgid "Battery level"
+msgstr ""
+
+#: id:12600
+msgctxt "Auto context with id 12600"
+msgid "Weather"
+msgstr "It-temp"
+
+#: id:12900
+msgctxt "Auto context with id 12900"
+msgid "Screensaver"
+msgstr "Skrinsejver"
+
+#: id:12901
+msgid "Fullscreen OSD"
+msgstr "OSD Sħiħ"
+
+#: id:13000
+msgid "System"
+msgstr "Sistema"
+
+#: id:13001
+msgid "Immediate HD spindown"
+msgstr "Spindown tal-HD immedjata"
+
+#: id:13002
+msgid "Video only"
+msgstr "Vidjo Biss"
+
+#: id:13003
+msgid "- Delay"
+msgstr "- Stennija"
+
+#: id:13004
+msgid "- Minimum file duration"
+msgstr "- L-anqas zmien tal-fajl"
+
+#: id:13005
+msgid "Shutdown"
+msgstr "Itfi"
+
+#: id:13008
+msgid "Shutdown function"
+msgstr ""
+
+#: id:13009
+msgid "Quit"
+msgstr ""
+
+#: id:13010
+msgid "Hibernate"
+msgstr ""
+
+#: id:13011
+msgid "Suspend"
+msgstr ""
+
+#: id:13012
+msgid "Exit"
+msgstr ""
+
+#: id:13013
+msgid "Reboot"
+msgstr ""
+
+#: id:13014
+msgid "Minimize"
+msgstr ""
+
+#: id:13015
+msgid "Power button action"
+msgstr ""
+
+#: id:13016
+msgid "Power off System"
+msgstr ""
+
+#: id:13020
+msgid "Is another session active, perhaps over ssh?"
+msgstr ""
+
+#: id:13021
+msgid "Mounted removable harddrive"
+msgstr ""
+
+#: id:13022
+msgid "Unsafe device removal"
+msgstr ""
+
+#: id:13023
+msgid "Successfully removed device"
+msgstr ""
+
+#: id:13024
+msgid "Joystick plugged"
+msgstr ""
+
+#: id:13025
+msgid "Joystick unplugged"
+msgstr ""
+
+#: id:13050
+msgid "Running low on battery"
+msgstr ""
+
+#: id:13100
+msgid "Flicker filter"
+msgstr "Filter Teptip"
+
+#: id:13101
+msgid "Let driver choose (requires restart)"
+msgstr ""
+
+#: id:13105
+msgid "Vertical blank sync"
+msgstr ""
+
+#: id:13106
+msgctxt "Auto context with id 13106"
+msgid "Disabled"
+msgstr "Mhux attiv"
+
+#: id:13107
+msgid "Enabled during video playback"
+msgstr "Attiva waqt li tara l-Vidjo"
+
+#: id:13108
+msgctxt "Auto context with id 13108"
+msgid "Always enabled"
+msgstr "Dejjem attiv"
+
+#: id:13109
+msgid "Test & apply resolution"
+msgstr ""
+
+#: id:13110
+msgid "Save resolution?"
+msgstr ""
+
+#: id:13111
+msgid "Would you like to keep this resolution?"
+msgstr ""
+
+#: id:13112
+msgid "High quality upscaling"
+msgstr ""
+
+#: id:13113
+msgctxt "Auto context with id 13113"
+msgid "Disabled"
+msgstr ""
+
+#: id:13114
+msgid "Enabled for SD content"
+msgstr ""
+
+#: id:13115
+msgctxt "Auto context with id 13115"
+msgid "Always enabled"
+msgstr ""
+
+#: id:13116
+msgid "Upscaling method"
+msgstr ""
+
+#: id:13117
+msgctxt "Auto context with id 13117"
+msgid "Bicubic"
+msgstr ""
+
+#: id:13118
+msgid "Lanczos"
+msgstr ""
+
+#: id:13119
+msgid "Sinc"
+msgstr ""
+
+#: id:13120
+msgctxt "Auto context with id 13120"
+msgid "VDPAU"
+msgstr ""
+
+#: id:13121
+msgid "VDPAU HQ Upscaling level"
+msgstr ""
+
+#: id:13122
+msgid "VDPAU Studio level color conversion"
+msgstr ""
+
+#: id:13130
+msgid "Blank other displays"
+msgstr ""
+
+#: id:13131
+msgctxt "Auto context with id 13131"
+msgid "Disabled"
+msgstr ""
+
+#: id:13132
+msgid "Blank displays"
+msgstr ""
+
+#: id:13140
+msgid "Active connections detected!"
+msgstr ""
+
+#: id:13141
+msgid "If you proceed, you might not be able to control XBMC"
+msgstr ""
+
+#: id:13142
+msgid "any longer. Are you sure you want to stop the Event server?"
+msgstr ""
+
+#: id:13144
+msgid "Change Apple Remote mode?"
+msgstr ""
+
+#: id:13145
+msgid "If you are currently using the Apple Remote to control"
+msgstr ""
+
+#: id:13146
+msgid "XBMC, changing this setting might affect your ability"
+msgstr ""
+
+#: id:13147
+msgid "to continue controlling it. Do you want to proceed?"
+msgstr ""
+
+#: id:13159
+msgid "Subnet mask"
+msgstr "Subnet Mask:"
+
+#: id:13160
+msgid "Gateway"
+msgstr "Gateway:"
+
+#: id:13161
+msgid "Primary DNS"
+msgstr "Primary DNS"
+
+#: id:13162
+msgid "Initialize failed"
+msgstr "Ma ġiex imtella"
+
+#: id:13170
+msgctxt "Auto context with id 13170"
+msgid "Never"
+msgstr "Qatt"
+
+#: id:13171
+msgid "Immediately"
+msgstr "Immedjatament"
+
+#: id:13172
+msgid "After %i secs"
+msgstr "wara %i sek."
+
+#: id:13173
+msgid "HDD install date:"
+msgstr "HDD ġie nstallat"
+
+#: id:13174
+msgid "HDD power cycle count:"
+msgstr "HDD Power Cycle Count:"
+
+#: id:13200
+msgid "Profiles"
+msgstr "Profil"
+
+#: id:13201
+msgid "Delete profile '%s'?"
+msgstr "Ħassar profil '%s'?"
+
+#: id:13204
+msgid "Last loaded profile:"
+msgstr "L-aħħar Profil użat:"
+
+#: id:13205
+msgid "Unknown"
+msgstr "Ma nafx"
+
+#: id:13206
+msgid "Overwrite"
+msgstr "Ikteb fuq"
+
+#: id:13208
+msgid "Alarm clock"
+msgstr "Alarm clock"
+
+#: id:13209
+msgid "Alarm clock interval (in minutes)"
+msgstr "Alarm clock interval (in minutes)"
+
+#: id:13210
+msgid "Started, alarm in %im"
+msgstr "Started, alarm in %im"
+
+#: id:13211
+msgid "Alarm!"
+msgstr "Alarm!"
+
+#: id:13212
+msgid "Canceled with %im%is left"
+msgstr "Canceled with %im%is left"
+
+#: id:13213
+msgid "%2.0fm"
+msgstr ""
+
+#: id:13214
+msgid "%2.0fs"
+msgstr ""
+
+#: id:13249
+msgid "Search for subtitles in RARs"
+msgstr "Search for Subtitles in RARs"
+
+#: id:13250
+msgid "Browse for subtitle..."
+msgstr "Browse for subtitle..."
+
+#: id:13251
+msgid "Move item"
+msgstr "Mexxi"
+
+#: id:13252
+msgid "Move item here"
+msgstr "Mexxi Hawn"
+
+#: id:13253
+msgid "Cancel move"
+msgstr "Tmexxiex"
+
+#: id:13270
+msgid "Hardware:"
+msgstr "Hardware:"
+
+#: id:13271
+msgid "CPU Usage:"
+msgstr "Veloċita’ tas-CPU:"
+
+#: id:13274
+msgid "Connected, but no DNS is available."
+msgstr "Xbox imqabbda imma DNS mhux disponibbli."
+
+#: id:13275
+msgid "Hard Disk"
+msgstr "Hard Disk"
+
+#: id:13276
+msgid "DVD-ROM"
+msgstr "DVD-ROM"
+
+#: id:13277
+msgctxt "Auto context with id 13277"
+msgid "Storage"
+msgstr "Spazju"
+
+#: id:13278
+msgctxt "Auto context with id 13278"
+msgid "Default"
+msgstr "Difolt"
+
+#: id:13279
+msgctxt "Auto context with id 13279"
+msgid "Network"
+msgstr "Network"
+
+#: id:13280
+msgctxt "Auto context with id 13280"
+msgid "Video"
+msgstr "Vidjo"
+
+#: id:13281
+msgid "Hardware"
+msgstr "Hardware"
+
+#: id:13283
+msgid "Operating system:"
+msgstr "Verżjoni tal-Kernel:"
+
+#: id:13284
+msgid "CPU speed:"
+msgstr "Veloċita’ tas-CPU:"
+
+#: id:13286
+msgid "Video encoder:"
+msgstr "Video Encoder:"
+
+#: id:13287
+msgid "Screen resolution:"
+msgstr "Screen Resolution:"
+
+#: id:13292
+msgid "A/V cable:"
+msgstr "A/V Cable:"
+
+#: id:13294
+msgid "DVD region:"
+msgstr "DVD Region:"
+
+#: id:13295
+msgid "Internet:"
+msgstr "Internet:"
+
+#: id:13296
+msgctxt "Auto context with id 13296"
+msgid "Connected"
+msgstr "Xbox Imqabbda"
+
+#: id:13297
+msgid "Not connected. Check network settings."
+msgstr "Xbox mhux imqabbda. Iċċekkja Settings tan-Network"
+
+#: id:13299
+msgid "Target temperature"
+msgstr "Target Temperature"
+
+#: id:13300
+msgid "Fan speed"
+msgstr "Veloċita’ tal-Fan:"
+
+#: id:13301
+msgid "Auto temperature control"
+msgstr "Ikkontralla t-temperatura Awtomatikament"
+
+#: id:13302
+msgid "Fan speed override"
+msgstr "Kontroll veloċita’ tal-Fan"
+
+#: id:13303
+msgid "- Fonts"
+msgstr "Fonts tal-Qoxra"
+
+#: id:13304
+msgid "Enable flipping bi-directional strings"
+msgstr ""
+
+#: id:13305
+msgid "Show RSS news feeds"
+msgstr "Attiva RSS Feeds"
+
+#: id:13306
+msgid "Show parent folder items"
+msgstr "Aħbi Kannestri Predeċessuri"
+
+#: id:13307
+msgid "Track naming template"
+msgstr ""
+
+#: id:13308
+msgid "Do you wish to reboot your system"
+msgstr "Tixtieq tirributja l-xbox"
+
+#: id:13309
+msgid "instead of just XBMC?"
+msgstr "minflok l-XBMC biss?"
+
+#: id:13310
+msgid "Zoom effect"
+msgstr "Effett Zoom"
+
+#: id:13311
+msgid "Float effect"
+msgstr "Effett Float"
+
+#: id:13312
+msgid "Black bar reduction"
+msgstr "Riduzzjoni Black Bar"
+
+#: id:13313
+msgid "Restart"
+msgstr "Erġa Ibda"
+
+#: id:13314
+msgid "Crossfade between songs"
+msgstr "Crossfade"
+
+#: id:13315
+msgid "Regenerate thumbnails"
+msgstr "Regenerate Tambnejs"
+
+#: id:13316
+msgid "Recursive thumbnails"
+msgstr "Recursive Tambnejs"
+
+#: id:13317
+msgid "View slideshow"
+msgstr "Ara slajdxow"
+
+#: id:13318
+msgid "Recursive slideshow"
+msgstr "Ara slajdxow suċċessivi"
+
+#: id:13319
+msgid "Randomize"
+msgstr ""
+
+#: id:13320
+msgid "Stereo"
+msgstr "Sterjo"
+
+#: id:13321
+msgid "Left only"
+msgstr "Xellug biss"
+
+#: id:13322
+msgid "Right only"
+msgstr "Lemin biss"
+
+#: id:13323
+msgid "Enable karaoke support"
+msgstr "Attiva CD+G"
+
+#: id:13324
+msgid "Background transparency"
+msgstr "Background Transparenti"
+
+#: id:13325
+msgid "Foreground transparency"
+msgstr "Foreground Transparenti"
+
+#: id:13326
+msgid "A/V delay"
+msgstr "A/V delay"
+
+#: id:13327
+msgid "Karaoke"
+msgstr "Karaoke"
+
+#: id:13328
+msgid "%s not found"
+msgstr "%s ma nstabx"
+
+#: id:13329
+msgid "Error opening %s"
+msgstr "Ma stajtx niftah %s"
+
+#: id:13330
+msgid "Unable to load %s"
+msgstr "Ma stajtx ntella %s"
+
+#: id:13331
+msgid "Error: Out of memory"
+msgstr "Problema: spiċċat il-memorja"
+
+#: id:13332
+msgid "Move up"
+msgstr "Tella l'fuq"
+
+#: id:13333
+msgid "Move down"
+msgstr "Niżżel l'isfel"
+
+#: id:13334
+msgid "Edit label"
+msgstr "Biddel l-Label"
+
+#: id:13335
+msgid "Make default"
+msgstr "Uża dejjem"
+
+#: id:13336
+msgid "Remove button"
+msgstr "Neħħi l-Buttona"
+
+#: id:13340
+msgid "Leave as is"
+msgstr "Ħalli kif inhu"
+
+#: id:13341
+msgid "Green"
+msgstr "Ahdar"
+
+#: id:13342
+msgid "Orange"
+msgstr "Orangjo"
+
+#: id:13343
+msgid "Red"
+msgstr "Ahmar"
+
+#: id:13344
+msgid "Cycle"
+msgstr "Dawwar"
+
+#: id:13345
+msgid "Switch LED off on playback"
+msgstr "Itfi LED waqt Filmat"
+
+#: id:13346
+msgctxt "Auto context with id 13346"
+msgid "Movie information"
+msgstr "Informazzjoni tal-Filmat"
+
+#: id:13347
+msgid "Queue item"
+msgstr "Itfa fil-Queue"
+
+#: id:13348
+msgid "Search IMDb..."
+msgstr "Fittex IMDb..."
+
+#: id:13349
+msgid "Scan for new content"
+msgstr "Fittex għal kontenut ġdid"
+
+#: id:13350
+msgid "Now playing..."
+msgstr "Indoqq bħalissa..."
+
+#: id:13351
+msgctxt "Auto context with id 13351"
+msgid "Album information"
+msgstr "Informazzjoni dwar l-album"
+
+#: id:13352
+msgid "Scan item to library"
+msgstr "Fittex fid-Database kollha"
+
+#: id:13353
+msgid "Stop scanning"
+msgstr "Ieqaf Fittex"
+
+#: id:13354
+msgctxt "Auto context with id 13354"
+msgid "Render method"
+msgstr "Metodu ta' Render"
+
+#: id:13355
+msgid "Low quality pixel shader"
+msgstr "Pixel Shader - Kwalita Baxxa"
+
+#: id:13356
+msgid "Hardware overlays"
+msgstr "Hardware Overlays"
+
+#: id:13357
+msgid "High quality pixel shader"
+msgstr "Pixel Shader - Kwalita Għolja"
+
+#: id:13358
+msgid "Play item"
+msgstr "Doqq din"
+
+#: id:13359
+msgid "Set artist thumb"
+msgstr "Issettja Tambnejl tal-Artist"
+
+#: id:13360
+msgid "Automatically generate thumbnails"
+msgstr "Oħloq Tambnejls"
+
+#: id:13361
+msgid "Enable voice"
+msgstr "Attiva l-Vuċi"
+
+#: id:13375
+msgid "Enable device"
+msgstr "Attiva l-apparat"
+
+#: id:13376
+msgid "Volume"
+msgstr "Volum"
+
+#: id:13377
+msgid "Default view mode"
+msgstr "Default View Mode"
+
+#: id:13378
+msgid "Default brightness"
+msgstr "Default Brightness"
+
+#: id:13379
+msgid "Default contrast"
+msgstr "Default Contrast"
+
+#: id:13380
+msgid "Default gamma"
+msgstr "Default Gamma"
+
+#: id:13381
+msgid "Resume video"
+msgstr "Resume Video"
+
+#: id:13382
+msgid "Voice mask - Port 1"
+msgstr "Voice Mask - Port 1"
+
+#: id:13383
+msgid "Voice mask - Port 2"
+msgstr "Voice Mask - Port 2"
+
+#: id:13384
+msgid "Voice mask - Port 3"
+msgstr "Voice Mask - Port 3"
+
+#: id:13385
+msgid "Voice mask - Port 4"
+msgstr "Voice Mask - Port 4"
+
+#: id:13386
+msgid "Use time based seeking"
+msgstr "Uża Time Based Seeking"
+
+#: id:13387
+msgid "Track naming template - right"
+msgstr "Track Naming Template Right"
+
+#: id:13388
+msgid "Preset"
+msgstr "Presets"
+
+#: id:13389
+msgid "There are no presets available\nfor this visualization"
+msgstr "There are no presets available for this visualisation"
+
+#: id:13390
+msgid "There are no settings available\nfor this visualization"
+msgstr "There are no settings available for this visualisation"
+
+#: id:13391
+msgid "Eject/Load"
+msgstr "Eject/Load"
+
+#: id:13392
+msgid "Use visualization if playing audio"
+msgstr "Uża Visualisation if playing audio"
+
+#: id:13393
+msgid "Calculate size"
+msgstr "Ikkalkula l-kobor"
+
+#: id:13394
+msgid "Calculating folder size"
+msgstr "Ikkalkula l-kobor tal-Fowlder"
+
+#: id:13395
+msgid "Video settings"
+msgstr "Video Settings"
+
+#: id:13396
+msgid "Audio and subtitle settings"
+msgstr "Awdjo u Sottotitoli Settings"
+
+#: id:13397
+msgid "Enable subtitles"
+msgstr "Attiva Sottotitoli"
+
+#: id:13398
+msgctxt "Auto context with id 13398"
+msgid "Shortcuts"
+msgstr "Bookmarks"
+
+#: id:13399
+msgid "Ignore articles when sorting (e.g. \"the\")"
+msgstr "Ignore \"The\" when sorting"
+
+#: id:13400
+msgid "Crossfade between songs on the same album"
+msgstr "Crossfade albumtracks"
+
+#: id:13401
+msgid "Browse for %s"
+msgstr "Browse for %s"
+
+#: id:13402
+msgid "Show track position"
+msgstr "Uri track position"
+
+#: id:13403
+msgid "Clear default"
+msgstr "Ħassar Difolt"
+
+#: id:13404
+msgid "Resume"
+msgstr "Kompli"
+
+#: id:13405
+msgid "Get thumb"
+msgstr "Ġib Tambnejl"
+
+#: id:13406
+msgid "Picture information"
+msgstr "Imformazzjoni dwar l-istampa"
+
+#: id:13407
+msgid "%s presets"
+msgstr "Preset %s"
+
+#: id:13408
+msgid "(IMDb user rating)"
+msgstr "(Rati tal-utenti IMDb)"
+
+#: id:13409
+msgid "Top 250"
+msgstr "L-ewwel 250:"
+
+#: id:13410
+msgid "Tune in on Last.fm"
+msgstr ""
+
+#: id:13411
+msgid "Minimum fan speed"
+msgstr "fanspeed minimu"
+
+#: id:13412
+msgid "Play from here"
+msgstr ""
+
+#: id:13413
+msgid "Downloading"
+msgstr ""
+
+#: id:13414
+msgid "Include artists who appear only on compilations"
+msgstr ""
+
+#: id:13415
+msgctxt "Auto context with id 13415"
+msgid "Render method"
+msgstr ""
+
+#: id:13416
+msgid "Auto detect"
+msgstr ""
+
+#: id:13417
+msgid "Basic shaders (ARB)"
+msgstr ""
+
+#: id:13418
+msgid "Advanced shaders (GLSL)"
+msgstr ""
+
+#: id:13419
+msgid "Software"
+msgstr ""
+
+#: id:13420
+msgid "Remove safely"
+msgstr ""
+
+#: id:13421
+msgctxt "Auto context with id 13421"
+msgid "VDPAU"
+msgstr ""
+
+#: id:13422
+msgid "Start slideshow here"
+msgstr ""
+
+#: id:13423
+msgid "Remember for this path"
+msgstr ""
+
+#: id:13424
+msgid "Use pixel buffer objects"
+msgstr ""
+
+#: id:13425
+msgid "Allow hardware acceleration (VDPAU)"
+msgstr ""
+
+#: id:13426
+msgid "Allow hardware acceleration (VAAPI)"
+msgstr ""
+
+#: id:13427
+msgid "Allow hardware acceleration (DXVA2)"
+msgstr ""
+
+#: id:13428
+msgid "Allow hardware acceleration (CrystalHD)"
+msgstr ""
+
+#: id:13429
+msgid "Allow hardware acceleration (VDADecoder)"
+msgstr ""
+
+#: id:13430
+msgid "Allow hardware acceleration (OpenMax)"
+msgstr ""
+
+#: id:13431
+msgid "Pixel Shaders"
+msgstr ""
+
+#: id:13432
+msgid "Allow hardware acceleration (VideoToolbox)"
+msgstr ""
+
+#: id:13500
+msgid "A/V sync method"
+msgstr ""
+
+#: id:13501
+msgid "Audio clock"
+msgstr ""
+
+#: id:13502
+msgid "Video clock (Drop/Dupe audio)"
+msgstr ""
+
+#: id:13503
+msgid "Video clock (Resample audio)"
+msgstr ""
+
+#: id:13504
+msgid "Maximum resample amount (%)"
+msgstr ""
+
+#: id:13505
+msgid "Resample quality"
+msgstr ""
+
+#: id:13506
+msgid "Low(fast)"
+msgstr ""
+
+#: id:13507
+msgctxt "Auto context with id 13507"
+msgid "Medium"
+msgstr ""
+
+#: id:13508
+msgctxt "Auto context with id 13508"
+msgid "High"
+msgstr ""
+
+#: id:13509
+msgid "Really high(slow!)"
+msgstr ""
+
+#: id:13510
+msgid "Sync playback to display"
+msgstr ""
+
+#: id:13550
+msgid "Pause during refresh rate change"
+msgstr ""
+
+#: id:13551
+msgctxt "Auto context with id 13551"
+msgid "Off"
+msgstr ""
+
+#: id:13552
+msgid "%.1f Second"
+msgstr ""
+
+#: id:13553
+msgid "%.1f Seconds"
+msgstr ""
+
+#: id:13600
+msgid "Apple remote"
+msgstr ""
+
+#: id:13602
+msgid "Allow start of XBMC using the remote"
+msgstr ""
+
+#: id:13603
+msgid "Sequence delay time"
+msgstr ""
+
+#: id:13610
+msgctxt "Auto context with id 13610"
+msgid "Disabled"
+msgstr ""
+
+#: id:13611
+msgctxt "Auto context with id 13611"
+msgid "Standard"
+msgstr ""
+
+#: id:13612
+msgid "Universal Remote"
+msgstr ""
+
+#: id:13613
+msgid "Multi Remote (Harmony)"
+msgstr ""
+
+#: id:13620
+msgid "Apple Remote Error"
+msgstr ""
+
+#: id:13621
+msgid "Apple Remote support could be enabled."
+msgstr ""
+
+#: id:14000
+msgid "Stack"
+msgstr "Stack"
+
+#: id:14001
+msgid "Unstack"
+msgstr "Unstack"
+
+#: id:14003
+msgid "Downloading playlist file..."
+msgstr "Inniżżel playlist file..."
+
+#: id:14004
+msgid "Downloading streams list..."
+msgstr "Inniżżel streams list..."
+
+#: id:14005
+msgid "Parsing streams list..."
+msgstr "Neżamina streams list..."
+
+#: id:14006
+msgid "Downloading streams list failed"
+msgstr "Streams list ma niżlitx"
+
+#: id:14007
+msgid "Downloading playlist file failed"
+msgstr "Playlist file ma niżilx"
+
+#: id:14009
+msgid "Games directory"
+msgstr "Fowlder tal-Logħob"
+
+#: id:14010
+msgid "Auto switch to thumbs based on"
+msgstr "Autoswitch to Thumbs based on"
+
+#: id:14011
+msgid "Enable auto switching to thumbs view"
+msgstr "Enable Autoswitching to Thumbs View"
+
+#: id:14012
+msgid "- Use large icons"
+msgstr "- Uri Ajkons Kbar"
+
+#: id:14013
+msgid "- Switch based on"
+msgstr "- Switch Based on"
+
+#: id:14014
+msgid "- Percentage"
+msgstr "- Percentage"
+
+#: id:14015
+msgid "No files and at least one thumb"
+msgstr "No Files and at least one Thumb"
+
+#: id:14016
+msgid "At least one file and thumb"
+msgstr "At least one File and Thumb"
+
+#: id:14017
+msgid "Percentage of thumbs"
+msgstr "Percentage of Thumbs"
+
+#: id:14018
+msgid "View options"
+msgstr "View Options"
+
+#: id:14019
+msgid "Change area code 1"
+msgstr "Ibdel Area Code 1"
+
+#: id:14020
+msgid "Change area code 2"
+msgstr "Ibdel Area Code 2"
+
+#: id:14021
+msgid "Change area code 3"
+msgstr "Ibdel Area Code 3"
+
+#: id:14022
+msgctxt "Auto context with id 14022"
+msgid "Library"
+msgstr "Librerija"
+
+#: id:14023
+msgid "No TV"
+msgstr "No TV"
+
+#: id:14024
+msgid "Enter the nearest large town"
+msgstr "Daħħal l-aktar Villaġġ qrib tiegħek"
+
+#: id:14025
+msgid "Video/Audio/DVD cache - Harddisk"
+msgstr "Video/Audio/DVD Cache - Harddisk"
+
+#: id:14026
+msgid "Video cache - DVD-ROM"
+msgstr "Video Cache - DVDRom"
+
+#: id:14027
+msgctxt "Auto context with id 14027"
+msgid "- Local Network"
+msgstr "- Network Lokali"
+
+#: id:14028
+msgctxt "Auto context with id 14028"
+msgid "- Internet"
+msgstr "- Internet"
+
+#: id:14030
+msgid "Audio cache - DVD-ROM"
+msgstr "Audio Cache - DVDRom"
+
+#: id:14031
+msgctxt "Auto context with id 14031"
+msgid "- Local Network"
+msgstr "- Network Lokali"
+
+#: id:14032
+msgctxt "Auto context with id 14032"
+msgid "- Internet"
+msgstr "- Internet"
+
+#: id:14034
+msgid "DVD cache - DVD-ROM"
+msgstr "DVD Cache - DVDRom"
+
+#: id:14035
+msgctxt "Auto context with id 14035"
+msgid "- Local Network"
+msgstr "- Network Lokali"
+
+#: id:14036
+msgctxt "Auto context with id 14036"
+msgid "Services"
+msgstr "Servers"
+
+#: id:14038
+msgid "Network settings changed"
+msgstr "Settings tan-network mibdula"
+
+#: id:14039
+msgid "XBMC requires to restart to change your"
+msgstr "XBMC tinhtieg reboot biex jigu affettwati"
+
+#: id:14040
+msgid "network setup. Would you like to restart now?"
+msgstr "tibdiliet fin-network setup. Tagħmel restart issa?"
+
+#: id:14041
+msgid "Internet connection bandwidth limitation"
+msgstr "Post Processing"
+
+#: id:14043
+msgid "- Shutdown while playing"
+msgstr "- Itfi waqt li ddoqq"
+
+#: id:14044
+msgid "%i min"
+msgstr "%i min"
+
+#: id:14045
+msgid "%i sec"
+msgstr "%i sek"
+
+#: id:14046
+msgid "%i ms"
+msgstr "%i ms"
+
+#: id:14047
+msgid "%i %%"
+msgstr "%i %%"
+
+#: id:14048
+msgid "%i kbps"
+msgstr "%i kbps"
+
+#: id:14049
+msgid "%i kb"
+msgstr "%i kb"
+
+#: id:14050
+msgid "%i.0 dB"
+msgstr "%i.0 dB"
+
+#: id:14051
+msgid "Time format"
+msgstr "Format tal-ħin"
+
+#: id:14052
+msgid "Date format"
+msgstr "Format tad-Data"
+
+#: id:14053
+msgid "GUI filters"
+msgstr "GUI Filters"
+
+#: id:14055
+msgid "Use background scanning"
+msgstr "Fittex fil-background"
+
+#: id:14056
+msgid "Stop scan"
+msgstr "Ieqaf Fittex"
+
+#: id:14057
+msgid "Not possible while scanning for media info"
+msgstr "Mhux permess waqt tfittxija għall-informazzjoni tal-media"
+
+#: id:14058
+msgid "Film grain effect"
+msgstr "Film Grain Effect"
+
+#: id:14059
+msgid "Search for thumbnails on remote shares"
+msgstr "Fittex għal tambnejs personali fuq shares esterni"
+
+#: id:14060
+msgid "Unknown type cache - Internet"
+msgstr "Tip mhux magħruf Cache - Internet"
+
+#: id:14061
+msgctxt "Auto context with id 14061"
+msgid "Auto"
+msgstr "Awto"
+
+#: id:14062
+msgid "Enter username for"
+msgstr "Daħħal username għal"
+
+#: id:14063
+msgid "Date & time"
+msgstr "Data u Ħin"
+
+#: id:14064
+msgid "Set date"
+msgstr "Irranga id-Data"
+
+#: id:14065
+msgid "Set time"
+msgstr "Irranga il-Ħin"
+
+#: id:14066
+msgid "Enter the time in 24 hour HH:MM format"
+msgstr "Daħħal il-Ħin bil-format 24 hour HH:MM"
+
+#: id:14067
+msgid "Enter the date in DD/MM/YYYY format"
+msgstr "Daħħal id-Data bil-format DD/MM/YYYY"
+
+#: id:14068
+msgid "Enter the IP address"
+msgstr "Daħħal l-IP address"
+
+#: id:14069
+msgid "Apply these settings now?"
+msgstr "Trid tapplika dawn it-tibdiliet?"
+
+#: id:14070
+msgid "Apply changes now"
+msgstr "Applika tibdiliet issa"
+
+#: id:14071
+msgid "Allow file renaming and deletion"
+msgstr "Ħalli fajls jinbidlilhom isimhom jew jigu mhassra"
+
+#: id:14074
+msgid "Set timezone"
+msgstr "Issetja Tajmzown"
+
+#: id:14075
+msgid "Use daylight saving time"
+msgstr "Uża Daylight Saving Time"
+
+#: id:14076
+msgid "Add to favourites"
+msgstr "Żid mal-Favoriti"
+
+#: id:14077
+msgid "Remove from favourites"
+msgstr "Neħħi mill-Favoriti"
+
+#: id:14078
+msgctxt "Auto context with id 14078"
+msgid "- Colours"
+msgstr "Kuluri tal-qoxra"
+
+#: id:14079
+msgid "Timezone country"
+msgstr ""
+
+#: id:14080
+msgid "Timezone"
+msgstr ""
+
+#: id:14081
+msgid "File lists"
+msgstr ""
+
+#: id:14082
+msgid "Show EXIF picture information"
+msgstr ""
+
+#: id:14083
+msgid "Use a fullscreen window rather than true fullscreen"
+msgstr ""
+
+#: id:14084
+msgid "Queue songs on selection"
+msgstr ""
+
+#: id:14086
+msgid "Playback"
+msgstr ""
+
+#: id:14087
+msgid "DVDs"
+msgstr ""
+
+#: id:14088
+msgid "Play DVDs automatically"
+msgstr ""
+
+#: id:14089
+msgid "Font to use for text subtitles"
+msgstr ""
+
+#: id:14090
+msgid "International"
+msgstr ""
+
+#: id:14091
+msgid "Character set"
+msgstr ""
+
+#: id:14092
+msgid "Debugging"
+msgstr ""
+
+#: id:14093
+msgid "Security"
+msgstr ""
+
+#: id:14094
+msgid "Input devices"
+msgstr ""
+
+#: id:14095
+msgid "Power saving"
+msgstr ""
+
+#: id:14096
+msgid "Rip"
+msgstr ""
+
+#: id:14097
+msgid "Audio CD Insert Action"
+msgstr ""
+
+#: id:14098
+msgctxt "Auto context with id 14098"
+msgid "Play"
+msgstr ""
+
+#: id:14099
+msgid "Eject disc when CD ripping is complete"
+msgstr ""
+
+#: id:15015
+msgctxt "Auto context with id 15015"
+msgid "Remove"
+msgstr "Neħħi"
+
+#: id:15016
+msgid "Games"
+msgstr "Logħob"
+
+#: id:15019
+msgid "Add"
+msgstr "Zid"
+
+#: id:15052
+msgid "Password"
+msgstr "Sigriet"
+
+#: id:15100
+msgctxt "Auto context with id 15100"
+msgid "Library"
+msgstr "Library"
+
+#: id:15101
+msgid "Database"
+msgstr "Database"
+
+#: id:15102
+msgid "* All albums"
+msgstr "* Albums Kollha"
+
+#: id:15103
+msgid "* All artists"
+msgstr "* Artisti Kollha"
+
+#: id:15104
+msgid "* All songs"
+msgstr "* Diski Kollha"
+
+#: id:15105
+msgid "* All genres"
+msgstr "* Generi kollha"
+
+#: id:15107
+msgid "Buffering..."
+msgstr "Buffering..."
+
+#: id:15108
+msgid "Navigation sounds"
+msgstr "Navigation Sounds"
+
+#: id:15109
+msgid "Skin default"
+msgstr "Qoxra Default"
+
+#: id:15111
+msgid "- Theme"
+msgstr "Theme tal-Qoxra"
+
+#: id:15112
+msgid "Default theme"
+msgstr "Default Theme"
+
+#: id:15200
+msgid "Last.fm"
+msgstr "LastFM"
+
+#: id:15201
+msgid "Submit songs to Last.fm"
+msgstr "Ibgħat Diski lil LastFM"
+
+#: id:15202
+msgid "Last.fm username"
+msgstr "LastFM Username"
+
+#: id:15203
+msgid "Last.fm password"
+msgstr "LastFM Sigriet"
+
+#: id:15204
+msgid "Unable to handshake: sleeping..."
+msgstr "Handshake ma saritx: sleeping..."
+
+#: id:15205
+msgid "Please update XBMC"
+msgstr "Jekk jogħogbok aġġorna l-XBMC"
+
+#: id:15206
+msgid "Bad authorization: Check username and password"
+msgstr "Mhux awtorizzat: Iċċekkja l-isem u l-sigriet"
+
+#: id:15207
+msgctxt "Auto context with id 15207"
+msgid "Connected"
+msgstr "Imqabbad"
+
+#: id:15208
+msgid "Not connected"
+msgstr "Mhux imqabbad"
+
+#: id:15209
+msgid "Submit interval %i"
+msgstr "Submit Interval %i"
+
+#: id:15210
+msgid "Cached %i songs"
+msgstr "Cached %i Songs"
+
+#: id:15211
+msgid "Submitting..."
+msgstr "Submitting..."
+
+#: id:15212
+msgid "Submitting in %i secs"
+msgstr "Submitting in %i secs"
+
+#: id:15213
+msgid "Play using..."
+msgstr "Isma bil-..."
+
+#: id:15214
+msgid "Use smoothed A/V synchronization"
+msgstr "Uża Smoothed A/V Syncronization"
+
+#: id:15215
+msgid "Hide file names in thumbs view"
+msgstr "Aħbi l-ismijiet tal-fajls meta tara Thumbs"
+
+#: id:15216
+msgid "Play in party mode"
+msgstr "Doqq fil-Partymode"
+
+#: id:15217
+msgid "Submit songs to Libre.fm"
+msgstr ""
+
+#: id:15218
+msgid "Libre.fm username"
+msgstr ""
+
+#: id:15219
+msgid "Libre.fm password"
+msgstr ""
+
+#: id:15220
+msgid "Libre.fm"
+msgstr ""
+
+#: id:15221
+msgid "Song submission"
+msgstr ""
+
+#: id:15250
+msgid "Submit Last.fm radio to Last.fm"
+msgstr "Ibgħat Last.fm Radio lil LastFM"
+
+#: id:15251
+msgid "Connecting to Last.fm..."
+msgstr "Nippova naqbad ma Last.fm..."
+
+#: id:15252
+msgid "Selecting station..."
+msgstr "Selecting station..."
+
+#: id:15253
+msgid "Search similar artists..."
+msgstr "Fittex artisti simili..."
+
+#: id:15254
+msgid "Search similar tags..."
+msgstr "Fittex taqs simili..."
+
+#: id:15255
+msgid "Your profile (%name%)"
+msgstr "Profil (%name%)"
+
+#: id:15256
+msgid "Overall top tags"
+msgstr "L-aqwa tags minn kollox"
+
+#: id:15257
+msgid "Top artists for tag %name%"
+msgstr "L-aħjar artisti għat-tag %name%"
+
+#: id:15258
+msgid "Top albums for tag %name%"
+msgstr "L-aħjar albums għat-tag %name%"
+
+#: id:15259
+msgid "Top tracks for tag %name%"
+msgstr "L-aħjar diski għat-tag %name%"
+
+#: id:15260
+msgid "Listen to tag %name% Last.fm radio"
+msgstr "Isma tag %name% last.fm radio"
+
+#: id:15261
+msgid "Similar artists as %name%"
+msgstr "Artisti Simili għal %name%"
+
+#: id:15262
+msgid "Top %name% albums"
+msgstr "L-aqwa %name% albums"
+
+#: id:15263
+msgid "Top %name% tracks"
+msgstr "L-aqwa %name% diski"
+
+#: id:15264
+msgid "Top %name% tags"
+msgstr "L-aqwa %name% tags"
+
+#: id:15265
+msgid "Biggest fans of %name%"
+msgstr "L-akbar fans ta %name%"
+
+#: id:15266
+msgid "Listen to %name% fans Last.fm radio"
+msgstr "Isma %name% fans last.fm radio"
+
+#: id:15267
+msgid "Listen to %name% similar artists Last.fm radio"
+msgstr "Isma %name% similar artists last.fm radio"
+
+#: id:15268
+msgid "Top artists for user %name%"
+msgstr "L-aħjar artisti magħżula minn %name%"
+
+#: id:15269
+msgid "Top albums for user %name%"
+msgstr "L-aħjar albums magħżula minn %name%"
+
+#: id:15270
+msgid "Top tracks for user %name%"
+msgstr "L-aħjar diski magħżula minn %name%"
+
+#: id:15271
+msgid "Friends of user %name%"
+msgstr "Ħbieb ta' %name%"
+
+#: id:15272
+msgid "Neighbours of user %name%"
+msgstr "Ġirien ta' %name%"
+
+#: id:15273
+msgid "Weekly artist chart for %name%"
+msgstr "Chart tal-artist tal-ġimgħa għal %name%"
+
+#: id:15274
+msgid "Weekly album chart for %name%"
+msgstr "Chart tal-album tal-ġimgħa għal %name%"
+
+#: id:15275
+msgid "Weekly track chart for %name%"
+msgstr "Chart tad-diska tal-ġimgħa għal %name%"
+
+#: id:15276
+msgid "Listen to %name%'s neighbours Last.fm radio"
+msgstr "Isma last.fm radio tal-girien ta' %name%"
+
+#: id:15277
+msgid "Listen to %name%'s personal Last.fm radio"
+msgstr "Isma last.fm radio personali ta' %name%"
+
+#: id:15278
+msgid "Listen to %name%'s mix Last.fm radio"
+msgstr "Isma last.fm radio preferiti ta' %name%"
+
+#: id:15279
+msgid "Retrieving list from Last.fm..."
+msgstr "Inniżżel lista minn last.fm..."
+
+#: id:15280
+msgid "Can't retrieve list from Last.fm..."
+msgstr "Lista minn last.fm ma nizlitx..."
+
+#: id:15281
+msgid "Enter an artist name to find related ones"
+msgstr "Daħħal isem ta' artist biex issib oħrajn relatati"
+
+#: id:15282
+msgid "Enter a tag name to find similar ones"
+msgstr "Daħħal tag name biex tfittex oħrajn simili"
+
+#: id:15283
+msgid "Tracks recently listened by %name%"
+msgstr "Diski li sema %name% ricentament"
+
+#: id:15284
+msgid "Listen to %name%'s recommendations Last.fm radio"
+msgstr "Isma l-għażla ta' %name% Last.FM radio"
+
+#: id:15285
+msgid "Top tags for user %name%"
+msgstr "L-aqwa tags għal utent %name%"
+
+#: id:15287
+msgid "Do you want to add the current track to your loved tracks?"
+msgstr "Trid iżżid din it-trekk mal-lista ta’ treks li tħobb?"
+
+#: id:15288
+msgid "Do you want to ban the current track?"
+msgstr "Trid tagħmel bojkott li din it-trekk?"
+
+#: id:15289
+msgid "Added to your loved tracks: '%s'."
+msgstr "Miżjud mat-treks li tħobb: '%s'."
+
+#: id:15290
+msgid "Could not add '%s' to your loved tracks."
+msgstr "Problema biex iżżid '%s' mal-lista ta’ treks li tħobb."
+
+#: id:15291
+msgid "Banned: '%s'."
+msgstr "Bojkott: '%s'."
+
+#: id:15292
+msgid "Could not ban '%s'."
+msgstr "Problema biex tagħmel bojkott lil '%s'."
+
+#: id:15293
+msgid "Tracks recently loved by %name%"
+msgstr "Treks li %name% sar iħobb riċentament"
+
+#: id:15294
+msgid "Tracks recently banned by %name%"
+msgstr "Treks li %name% ibbojkotja riċentament"
+
+#: id:15295
+msgid "Remove from loved tracks"
+msgstr "Neħħi mit-treks li tħobb"
+
+#: id:15296
+msgid "Un-ban"
+msgstr "Neħħi bojkott"
+
+#: id:15297
+msgid "Do you want to remove this track from your loved tracks?"
+msgstr "Trid tneħħi din it-trekk mil-lista ta' treks li tħobb?"
+
+#: id:15298
+msgid "Do you want to un-ban this track?"
+msgstr "Trid tneħħi l-bojkott fuq din it-trek?"
+
+#: id:15300
+msgid "Path not found or invalid"
+msgstr "Path not found or invalid"
+
+#: id:15301
+msgid "Could not connect to network server"
+msgstr "Mhux mqabbad man-network server"
+
+#: id:15302
+msgid "No servers found"
+msgstr "Ma nstab l-ebda server"
+
+#: id:15303
+msgid "Workgroup not found"
+msgstr "Workgroup ma nstabx"
+
+#: id:15310
+msgid "Opening multi-path source"
+msgstr "Opening multi-path bookmark"
+
+#: id:15311
+msgid "Path:"
+msgstr "Path:"
+
+#: id:16000
+msgctxt "Auto context with id 16000"
+msgid "General"
+msgstr "Ġenerali"
+
+#: id:16002
+msgid "Internet lookup"
+msgstr "Fittex CDDB"
+
+#: id:16003
+msgid "Player"
+msgstr "Player"
+
+#: id:16004
+msgid "Play media from disc"
+msgstr "Doqq diski mid-diska"
+
+#: id:16008
+msgid "Enter new title"
+msgstr "Daħħal titlu ġdid"
+
+#: id:16009
+msgid "Enter the movie name"
+msgstr "Daħħal l-isem tal-Filmat"
+
+#: id:16010
+msgid "Enter the profile name"
+msgstr "Daħħal l-isem tal-Profil"
+
+#: id:16011
+msgid "Enter the album name"
+msgstr "Daħħal l-isem tal-album"
+
+#: id:16012
+msgid "Enter the playlist name"
+msgstr "Daħħal l-isem tal-Playlist"
+
+#: id:16013
+msgid "Enter new filename"
+msgstr "Daħħal isem ġdid tal-fajl"
+
+#: id:16014
+msgid "Enter folder name"
+msgstr "Daħħal l-isem tal-Fowlder"
+
+#: id:16015
+msgid "Enter directory"
+msgstr "Daħħal fowlder"
+
+#: id:16016
+msgid "Available options: %A, %T, %N, %B, %D, %G, %Y, %F, %S"
+msgstr "Available options: %A, %T, %N, %B, %D, %G, %Y, %F, %S"
+
+#: id:16017
+msgid "Enter search string"
+msgstr "Daħħal Search String"
+
+#: id:16018
+msgctxt "Auto context with id 16018"
+msgid "None"
+msgstr "Xejn"
+
+#: id:16019
+msgid "Auto select"
+msgstr "Għażel Awtomatikament"
+
+#: id:16020
+msgid "De-interlace"
+msgstr "DeInterlace"
+
+#: id:16021
+msgid "Bob"
+msgstr "Bob"
+
+#: id:16022
+msgid "Bob (inverted)"
+msgstr "Bob (Inverted)"
+
+#: id:16024
+msgid "Canceling..."
+msgstr "Qed nikkanċella..."
+
+#: id:16025
+msgid "Enter the artist name"
+msgstr "Daħħal l-isem tal-Artist"
+
+#: id:16026
+msgid "Playback failed"
+msgstr "Playlist playback aborted"
+
+#: id:16027
+msgid "One or more items failed to play."
+msgstr "Ħafna problemi konsekuttivi"
+
+#: id:16028
+msgid "Enter value"
+msgstr ""
+
+#: id:16029
+msgid "Check the log file for details."
+msgstr ""
+
+#: id:16030
+msgid "Party mode aborted."
+msgstr "Ħriġt minn Party Mode."
+
+#: id:16031
+msgid "No matching songs in the library."
+msgstr "Tfittxija fid-database bla riżultat."
+
+#: id:16032
+msgid "Could not initialize database."
+msgstr "Ma stajtx ntella d-database."
+
+#: id:16033
+msgid "Could not open database."
+msgstr "Ma stajtx niftaħ id-database."
+
+#: id:16034
+msgid "Could not get songs from database."
+msgstr "Ma stajtx ingib id-diska mid-database."
+
+#: id:16035
+msgid "Party mode playlist"
+msgstr "Plejlist Partymode"
+
+#: id:16036
+msgid "De-interlace (Half)"
+msgstr ""
+
+#: id:16037
+msgid "Deinterlace video"
+msgstr ""
+
+#: id:16038
+msgid "Deinterlace method"
+msgstr ""
+
+#: id:16039
+msgctxt "Auto context with id 16039"
+msgid "Off"
+msgstr ""
+
+#: id:16040
+msgctxt "Auto context with id 16040"
+msgid "Auto"
+msgstr ""
+
+#: id:16041
+msgid "On"
+msgstr ""
+
+#: id:16100
+msgid "All Videos"
+msgstr "Filmati Kollha"
+
+#: id:16101
+msgid "Unwatched"
+msgstr "Ma Rajtx"
+
+#: id:16102
+msgid "Watched"
+msgstr "Rajt"
+
+#: id:16103
+msgid "Mark as watched"
+msgstr "Immarka li rajt"
+
+#: id:16104
+msgid "Mark as unwatched"
+msgstr "Immarka li ma rajtx"
+
+#: id:16105
+msgid "Edit title"
+msgstr "Biddel it-Titlu"
+
+#: id:16200
+msgid "Operation was aborted"
+msgstr "Hidma giet ikkanċellata"
+
+#: id:16201
+msgid "Copy failed"
+msgstr "Problema - Mhux ikkuppjat"
+
+#: id:16202
+msgid "Failed to copy at least one file"
+msgstr "Problema - Tal-inqas Fajl wieħed mhux ikkuppjat"
+
+#: id:16203
+msgid "Move failed"
+msgstr "Problema - Mhux imċaqlaq."
+
+#: id:16204
+msgid "Failed to move at least one file"
+msgstr "Problema - Tal-inqas Fajl wieħed mhux imċaqlaq"
+
+#: id:16205
+msgid "Delete failed"
+msgstr "Problema - Mhux imħassar."
+
+#: id:16206
+msgid "Failed to delete at least one file"
+msgstr "Problema - Tal-inqas Fajl wieħed mhux iħassar"
+
+#: id:16300
+msgid "Video scaling method"
+msgstr ""
+
+#: id:16301
+msgid "Nearest neighbour"
+msgstr ""
+
+#: id:16302
+msgid "Bilinear"
+msgstr ""
+
+#: id:16303
+msgctxt "Auto context with id 16303"
+msgid "Bicubic"
+msgstr ""
+
+#: id:16304
+msgid "Lanczos2"
+msgstr ""
+
+#: id:16305
+msgid "Lanczos3"
+msgstr ""
+
+#: id:16306
+msgid "Sinc8"
+msgstr ""
+
+#: id:16307
+msgid "Bicubic (software)"
+msgstr ""
+
+#: id:16308
+msgid "Lanczos (software)"
+msgstr ""
+
+#: id:16309
+msgid "Sinc (software)"
+msgstr ""
+
+#: id:16310
+msgid "Temporal"
+msgstr ""
+
+#: id:16311
+msgid "Temporal/Spatial"
+msgstr ""
+
+#: id:16312
+msgid "(VDPAU)Noise Reduction"
+msgstr ""
+
+#: id:16313
+msgid "(VDPAU)Sharpness"
+msgstr ""
+
+#: id:16314
+msgid "Inverse Telecine"
+msgstr ""
+
+#: id:16315
+msgid "Lanczos3 optimized"
+msgstr ""
+
+#: id:16316
+msgctxt "Auto context with id 16316"
+msgid "Auto"
+msgstr ""
+
+#: id:16317
+msgid "Temporal (Half)"
+msgstr ""
+
+#: id:16318
+msgid "Temporal/Spatial (Half)"
+msgstr ""
+
+#: id:16319
+msgid "DXVA"
+msgstr ""
+
+#: id:16320
+msgid "DXVA Bob"
+msgstr ""
+
+#: id:16321
+msgid "DXVA Best"
+msgstr ""
+
+#: id:16322
+msgid "Spline36"
+msgstr ""
+
+#: id:16323
+msgid "Spline36 optimized"
+msgstr ""
+
+#: id:16324
+msgid "Software Blend"
+msgstr ""
+
+#: id:16400
+msgid "Post-processing"
+msgstr ""
+
+#: id:17500
+msgid "Display sleep timeout"
+msgstr ""
+
+#: id:19000
+msgid "Switch to channel"
+msgstr ""
+
+#: id:20000
+msgid "Saved music folder"
+msgstr "CDDA Rip Fowlder"
+
+#: id:20001
+msgid "Use external DVD player"
+msgstr "Uża DVD Player alternattiv"
+
+#: id:20002
+msgid "External DVD player"
+msgstr "DVD Player alternattiv"
+
+#: id:20003
+msgid "Trainers folder"
+msgstr "Fowlder tal-Gwida"
+
+#: id:20004
+msgid "Screenshot folder"
+msgstr "Fowlder tal-iScreenshot"
+
+#: id:20006
+msgid "Playlists folder"
+msgstr "Fowlder tal-Playlists"
+
+#: id:20007
+msgid "Recordings"
+msgstr "Recordings"
+
+#: id:20008
+msgid "Screenshots"
+msgstr "Screenshots"
+
+#: id:20009
+msgid "Use XBMC"
+msgstr "Uża XBMC"
+
+#: id:20011
+msgid "Music playlists"
+msgstr "Playlists Mużikali"
+
+#: id:20012
+msgid "Video playlists"
+msgstr "Playlists Viżivi"
+
+#: id:20013
+msgid "Do you wish to launch the game?"
+msgstr "Trid tibda l-logħba?"
+
+#: id:20014
+msgid "Sort by: Playlist"
+msgstr "Ordni: Playlist"
+
+#: id:20015
+msgid "Remote thumb"
+msgstr "Tambnejl remot"
+
+#: id:20016
+msgid "Current thumb"
+msgstr "Tambnejl Attawali"
+
+#: id:20017
+msgid "Local thumb"
+msgstr "Tambnejl Lokali"
+
+#: id:20018
+msgid "No thumb"
+msgstr "Tużax Tambnejl"
+
+#: id:20019
+msgid "Choose thumbnail"
+msgstr "Għażel Tambnejl"
+
+#: id:20023
+msgid "Conflict"
+msgstr "Kunflitt"
+
+#: id:20024
+msgid "Scan new"
+msgstr "Tfittxija Ġdida"
+
+#: id:20025
+msgid "Scan all"
+msgstr "Fittex Kollox"
+
+#: id:20026
+msgid "Region"
+msgstr "Reġjun"
+
+#: id:20037
+msgid "Summary"
+msgstr ""
+
+#: id:20038
+msgid "Lock music window"
+msgstr "Aqfel sezzjoni tal-mużika"
+
+#: id:20039
+msgid "Lock videos window"
+msgstr "Aqfel sezzjoni tal-Filmati"
+
+#: id:20040
+msgid "Lock pictures window"
+msgstr "Aqfel sezzjoni tal-istampi"
+
+#: id:20041
+msgid "Lock programs & scripts windows"
+msgstr "Aqfel sezzjoni tal-programmi u scripts"
+
+#: id:20042
+msgid "Lock file manager"
+msgstr "Aqfel filemanager"
+
+#: id:20043
+msgid "Lock settings"
+msgstr "Settings tal-Aċċess"
+
+#: id:20044
+msgid "Start fresh"
+msgstr "Ibda Ġdid"
+
+#: id:20045
+msgid "Enter master mode"
+msgstr "Idħol Master Mode"
+
+#: id:20046
+msgid "Leave master mode"
+msgstr "Oħroġ minn Master Mode"
+
+#: id:20047
+msgid "Create profile '%s'?"
+msgstr "Oħloq profil '%s' ?"
+
+#: id:20048
+msgid "Start with fresh settings"
+msgstr "Ibda b'settings ġodda"
+
+#: id:20049
+msgid "Best available"
+msgstr "L-aħjar li jeżistu"
+
+#: id:20050
+msgid "Auto-switch between 16x9 and 4x3"
+msgstr "Ibdel bejn 16x9 u 4x3 awtomatikament"
+
+#: id:20051
+msgid "Treat stacked files as single file"
+msgstr "Treat stacked files as single file"
+
+#: id:20052
+msgid "Caution"
+msgstr "Attent"
+
+#: id:20053
+msgid "Left master mode"
+msgstr "Ħriġt minn Master Mode"
+
+#: id:20054
+msgid "Entered master mode"
+msgstr "Dħalt Master Mode"
+
+#: id:20055
+msgid "Allmusic.com thumb"
+msgstr "Allmusic.com Thumb"
+
+#: id:20057
+msgid "Remove thumbnail"
+msgstr "Neħħi Tambnejl"
+
+#: id:20058
+msgid "Add profile..."
+msgstr "Zid Profil..."
+
+#: id:20059
+msgid "Query info for all albums"
+msgstr "Query Info For All Albums"
+
+#: id:20060
+msgctxt "Auto context with id 20060"
+msgid "Media info"
+msgstr "Media info"
+
+#: id:20061
+msgctxt "Auto context with id 20061"
+msgid "Separate"
+msgstr "Separati"
+
+#: id:20062
+msgid "Shares with default"
+msgstr "Shares with default"
+
+#: id:20063
+msgid "Shares with default (read only)"
+msgstr "Shares with default (read only)"
+
+#: id:20064
+msgid "Copy default"
+msgstr "Ikkopja default"
+
+#: id:20065
+msgid "Profile picture"
+msgstr "Stampa tal-profil"
+
+#: id:20066
+msgid "Lock preferences"
+msgstr "Aqfel preferenzi"
+
+#: id:20067
+msgid "Edit profile"
+msgstr "Ibdel il-profil"
+
+#: id:20068
+msgid "Profile lock"
+msgstr "Aċċess tal-Profil"
+
+#: id:20069
+msgid "Could not create folder"
+msgstr "Ma jistax jinħoloq il-Fowlder"
+
+#: id:20070
+msgid "Profile directory"
+msgstr "Fowlder tal-Profil"
+
+#: id:20071
+msgid "Start with fresh media sources"
+msgstr "Ibda bl-istess gdida ta' sorsi tal-media"
+
+#: id:20072
+msgid "Make sure the selected folder is writable"
+msgstr "Kun ċert li tista tikteb fil-fowlder"
+
+#: id:20073
+msgid "and that the new folder name is valid"
+msgstr "u li l-isem il-ġdid tal-fowlder huwa validu"
+
+#: id:20074
+msgid "MPAA rating"
+msgstr "MPAA Rating:"
+
+#: id:20075
+msgid "Enter master lock code"
+msgstr "Daħħal kowd tal-Master Lock"
+
+#: id:20076
+msgid "Ask for master lock code on startup"
+msgstr "Itlob għall-kowd tal-Master Lock meta tixghel"
+
+#: id:20077
+msgid "Skin settings"
+msgstr "Settings tal-Qoxra"
+
+#: id:20078
+msgid "- no link set -"
+msgstr "- link mhux issettjata -"
+
+#: id:20079
+msgid "Enable animations"
+msgstr "Uża Animations"
+
+#: id:20080
+msgid "Disable RSS during music"
+msgstr "Itfi RSS waqt il-Mużika"
+
+#: id:20081
+msgid "Enable shortcut buttons"
+msgstr "Uża Buttuni tal-Bookmark"
+
+#: id:20082
+msgid "Show programs in main menu"
+msgstr "Uri Info ta' XLink Kai"
+
+#: id:20083
+msgid "Show music info"
+msgstr "Uri info tal-Mużika"
+
+#: id:20084
+msgid "Show weather info"
+msgstr "Uri info tat-Temp"
+
+#: id:20085
+msgid "Show system info"
+msgstr "Uri info tas-Sistema"
+
+#: id:20086
+msgid "Show available disc space C: E: F:"
+msgstr "Uri Spazju disponibbli fuq C: E: F:"
+
+#: id:20087
+msgid "Show available disc space E: F: G:"
+msgstr "Uri Spazju disponibbli fuq E: F: G:"
+
+#: id:20088
+msgid "Weather info"
+msgstr "Weather Info"
+
+#: id:20089
+msgid "Drive space free"
+msgstr "Spazju Disponibbli fuq Diska"
+
+#: id:20090
+msgid "Enter the name of an existing share"
+msgstr "Daħħal l-isem ta' Share eżistenti"
+
+#: id:20091
+msgid "Lock code"
+msgstr "Kowd tal-Lock"
+
+#: id:20092
+msgid "Load profile"
+msgstr "Aqra profil"
+
+#: id:20093
+msgid "Profile name"
+msgstr "Isem tal-Profil"
+
+#: id:20094
+msgctxt "Auto context with id 20094"
+msgid "Media sources"
+msgstr "Sorsi tal-Media"
+
+#: id:20095
+msgid "Enter profile lock code"
+msgstr "Daħħal il-kowd tal-Aċċess għall-profil"
+
+#: id:20096
+msgctxt "Auto context with id 20096"
+msgid "Login screen"
+msgstr "Login screen"
+
+#: id:20097
+msgid "Fetching album info"
+msgstr "Fetching album info"
+
+#: id:20098
+msgid "Fetching info for album"
+msgstr "Fetching info for album"
+
+#: id:20099
+msgid "Can't rip CD or track while playing from CD"
+msgstr "Rip mhux permess meta CD qieghda tintuża"
+
+#: id:20100
+msgid "Master lock code and settings"
+msgstr "Kowd tal-Master Lock u Settings"
+
+#: id:20101
+msgid "Entering master lock code always enables master mode"
+msgstr "Tattiva Master Mode kull meta ddaħħal Kowd tal-Master Lock"
+
+#: id:20102
+msgid "or copy from default?"
+msgstr "jew ikkopja mid-default?"
+
+#: id:20103
+msgid "Save changes to profile?"
+msgstr "Żomm it-tibdil tal-profil?"
+
+#: id:20104
+msgid "Old settings found."
+msgstr "Settings qodma misjuba."
+
+#: id:20105
+msgid "Do you want to use them?"
+msgstr "Trid tużahom?"
+
+#: id:20106
+msgid "Old media sources found."
+msgstr "Instabu sorsi tal-media antiki."
+
+#: id:20107
+msgid "Separate (locked)"
+msgstr "Separati (maqful)"
+
+#: id:20108
+msgid "Root"
+msgstr "Root"
+
+#: id:20109
+msgid "- Zoom"
+msgstr "Qis tal-Qoxra"
+
+#: id:20110
+msgid "UPnP settings"
+msgstr "UPnP Client"
+
+#: id:20111
+msgid "Autostart UPnP client"
+msgstr "Ibda awtomatikament"
+
+#: id:20112
+msgid "Last login: %s"
+msgstr "L-aħħar li dħalt: %s"
+
+#: id:20113
+msgid "Never logged on"
+msgstr "Qatt ma dħalt"
+
+#: id:20114
+msgid "Profile %i / %i"
+msgstr "Profil %i / %i"
+
+#: id:20115
+msgid "User login / Select a profile"
+msgstr "User Login / Għazel Profil"
+
+#: id:20116
+msgid "Use lock on login screen"
+msgstr "Uża lock meta tilloggja"
+
+#: id:20117
+msgid "Invalid lock code."
+msgstr "Lock Kowd Ħażin."
+
+#: id:20118
+msgid "This requires the master lock to be set."
+msgstr "Hemm bzonn li Master Lock tkun issettjata."
+
+#: id:20119
+msgid "Would you like to set it now?"
+msgstr "Trid tissettja issa?"
+
+#: id:20120
+msgid "Loading program information"
+msgstr "Jiftaħ informazzjoni tal-program"
+
+#: id:20121
+msgid "Party on!"
+msgstr "Party beda!"
+
+#: id:20122
+msgid "True"
+msgstr "Veru"
+
+#: id:20123
+msgid "Mixing drinks"
+msgstr "Iħawwad ix-xorb"
+
+#: id:20124
+msgid "Filling glasses"
+msgstr "Jimla t-Tazzi"
+
+#: id:20125
+msgid "Logged on as"
+msgstr "Maghruf bħala"
+
+#: id:20126
+msgid "Log off"
+msgstr "Ohrog"
+
+#: id:20128
+msgid "Go to root"
+msgstr "Mur Root"
+
+#: id:20129
+msgid "Weave"
+msgstr "Weave"
+
+#: id:20130
+msgid "Weave (inverted)"
+msgstr "Weave (inverted)"
+
+#: id:20131
+msgid "Blend"
+msgstr "Blend"
+
+#: id:20132
+msgid "Restart video"
+msgstr "Restart Video"
+
+#: id:20133
+msgid "Edit network location"
+msgstr "Ibdel Network Location"
+
+#: id:20134
+msgid "Remove network location"
+msgstr "Neħħi Network Location"
+
+#: id:20135
+msgid "Do you want to scan the folder?"
+msgstr "Trid tfittex fil-Fowlder?"
+
+#: id:20136
+msgid "Memory unit"
+msgstr "Memory Unit"
+
+#: id:20137
+msgid "Memory unit mounted"
+msgstr "Memory Unit mounted"
+
+#: id:20138
+msgid "Unable to mount memory unit"
+msgstr "Unable to mount Memory Unit"
+
+#: id:20139
+msgid "In port %i, slot %i"
+msgstr "In port %i, slot %i"
+
+#: id:20140
+msgid "Lock screensaver"
+msgstr "Aqfel Skrinsejver"
+
+#: id:20141
+msgid "Set"
+msgstr "Issettja"
+
+#: id:20142
+msgctxt "Auto context with id 20142"
+msgid "Username"
+msgstr "Username"
+
+#: id:20143
+msgid "Enter password for"
+msgstr "Daħħal sigriet għal"
+
+#: id:20144
+msgid "Shutdown timer"
+msgstr "Ħin biex jintefa"
+
+#: id:20145
+msgid "Shutdown interval (in minutes)"
+msgstr "interval (minuti)"
+
+#: id:20146
+msgid "Started, shutdown in %im"
+msgstr "Jintefa f'%im"
+
+#: id:20147
+msgid "Shutdown in 30 minutes"
+msgstr "Jintefa fi 30 minuta"
+
+#: id:20148
+msgid "Shutdown in 60 minutes"
+msgstr "Jintefa fi 60 minuta"
+
+#: id:20149
+msgid "Shutdown in 120 minutes"
+msgstr "Jintefa fi 120 minuta"
+
+#: id:20150
+msgid "Custom shutdown timer"
+msgstr "Arloġġ ieħor biex jintefa"
+
+#: id:20151
+msgid "Cancel shutdown timer"
+msgstr "Waqqaf l-arloġġ u titfiex"
+
+#: id:20152
+msgid "Lock preferences for %s"
+msgstr "Aqfel il-preferenzi għal %s"
+
+#: id:20153
+msgid "Browse..."
+msgstr "Browżja..."
+
+#: id:20154
+msgid "Summary information"
+msgstr "Informazzjoni Bażika"
+
+#: id:20155
+msgid "Storage information"
+msgstr "Informazzjoni Spazju"
+
+#: id:20156
+msgid "Hard disk information"
+msgstr "Informazzjoni Hard Disk"
+
+#: id:20157
+msgid "DVD-ROM information"
+msgstr "Informazzjoni DVD-ROM"
+
+#: id:20158
+msgid "Network information"
+msgstr "Informazzjoni Network"
+
+#: id:20159
+msgid "Video information"
+msgstr "Informazzjoni Vidjo"
+
+#: id:20160
+msgid "Hardware information"
+msgstr "Informazzjoni Hardware"
+
+#: id:20161
+msgid "Total"
+msgstr "Total: %s MB, Użat: %s MB, Mhux Użat: %s MB"
+
+#: id:20162
+msgid "Used"
+msgstr "Total HDD Użat: %u%% Mhux Użat: %u%%"
+
+#: id:20163
+msgid "of"
+msgstr "%s: %s MB of %s MB Vojta"
+
+#: id:20164
+msgid "Locking not supported"
+msgstr "Ma jistax jinqafel"
+
+#: id:20165
+msgid "Not locked"
+msgstr "Mhux maqful"
+
+#: id:20166
+msgid "Locked"
+msgstr "Maqful"
+
+#: id:20167
+msgid "Frozen"
+msgstr "Wieqaf"
+
+#: id:20168
+msgid "Requires reset"
+msgstr "Bżonn ta' Reset"
+
+#: id:20169
+msgid "Week"
+msgstr "Ġimgħa"
+
+#: id:20170
+msgid "Line"
+msgstr "Linja"
+
+#: id:20171
+msgid "Windows network (SMB)"
+msgstr "Windows Network (SMB)"
+
+#: id:20172
+msgid "XBMSP server"
+msgstr "XBMSP Server"
+
+#: id:20173
+msgctxt "Auto context with id 20173"
+msgid "FTP server"
+msgstr "FTP Server"
+
+#: id:20174
+msgid "iTunes music share (DAAP)"
+msgstr "iTunes music share (DAAP)"
+
+#: id:20175
+msgid "UPnP server"
+msgstr "UPnP Server"
+
+#: id:20176
+msgid "Show video info"
+msgstr "Uri Info tal-Vidjo"
+
+#: id:20177
+msgid "Done"
+msgstr "Lest"
+
+#: id:20178
+msgid "Shift"
+msgstr "Kbar"
+
+#: id:20179
+msgid "Caps Lock"
+msgstr "Żomm Kbar"
+
+#: id:20180
+msgid "Symbols"
+msgstr "Karattri"
+
+#: id:20181
+msgid "Backspace"
+msgstr "Ħassar"
+
+#: id:20182
+msgid "Space"
+msgstr "Spazju"
+
+#: id:20183
+msgid "Reload skin"
+msgstr "Erġa iftaħ Qoxra"
+
+#: id:20184
+msgid "Rotate pictures using EXIF information"
+msgstr "Dawwar a'bażi tal-informazzjoni EXIF"
+
+#: id:20185
+msgid "Use poster view styles for TV shows"
+msgstr "Qari Values tal-Hardware"
+
+#: id:20186
+msgid "Please wait"
+msgstr "Stenna jekk jogħogbok"
+
+#: id:20187
+msgid "UPnP"
+msgstr "Qari Values minn EEPROM"
+
+#: id:20189
+msgid "Enable auto scrolling for plot & review"
+msgstr ""
+
+#: id:20190
+msgctxt "Auto context with id 20190"
+msgid "Custom"
+msgstr "Custom"
+
+#: id:20191
+msgid "Enable debug logging"
+msgstr ""
+
+#: id:20192
+msgid "Download additional information during updates"
+msgstr ""
+
+#: id:20193
+msgid "Default service for album information"
+msgstr ""
+
+#: id:20194
+msgid "Default service for artist information"
+msgstr "Scraper Regolari"
+
+#: id:20195
+msgid "Change scraper"
+msgstr "Biddel Scraper"
+
+#: id:20196
+msgid "Export music library"
+msgstr "Esporta librerija tal-Mużika"
+
+#: id:20197
+msgid "Import music library"
+msgstr "Importa librerija tal-Mużika"
+
+#: id:20198
+msgid "No artist found!"
+msgstr "Ma nstab l-ebda Artist!"
+
+#: id:20199
+msgid "Downloading artist info failed"
+msgstr "Problem inniżżel informazzjoni tal-artist"
+
+#: id:20250
+msgid "Party on! (videos)"
+msgstr "Beda l-Party! (vidjos)"
+
+#: id:20251
+msgid "Mixing drinks (videos)"
+msgstr "Nħallat xorb (vidjos)"
+
+#: id:20252
+msgid "Filling glasses (videos)"
+msgstr "Nimla t-tazzi (vidjos)"
+
+#: id:20253
+msgid "WebDAV server (HTTP)"
+msgstr ""
+
+#: id:20254
+msgid "WebDAV server (HTTPS)"
+msgstr ""
+
+#: id:20255
+msgid "First logon, edit your profile"
+msgstr ""
+
+#: id:20256
+msgid "HTS Tvheadend client"
+msgstr ""
+
+#: id:20257
+msgid "VDR Streamdev client"
+msgstr ""
+
+#: id:20258
+msgid "MythTV client"
+msgstr ""
+
+#: id:20259
+msgid "Network Filesystem (NFS)"
+msgstr ""
+
+#: id:20260
+msgid "Secure Shell (SSH/SFTP)"
+msgstr ""
+
+#: id:20261
+msgid "Apple Filing Protocol (AFP)"
+msgstr ""
+
+#: id:20300
+msgid "Web server directory (HTTP)"
+msgstr "Qari Xbox Hardware"
+
+#: id:20301
+msgid "Web server directory (HTTPS)"
+msgstr "Qari ModChip"
+
+#: id:20302
+msgid "Unable to write to folder:"
+msgstr "Qari BIOS"
+
+#: id:20303
+msgid "Do you want to skip and proceed?"
+msgstr "Qari CPU Veloċita’"
+
+#: id:20304
+msgid "RSS Feed"
+msgstr "Qari Data tal-produzzjoni"
+
+#: id:20307
+msgid "Secondary DNS"
+msgstr "Secondary DNS"
+
+#: id:20308
+msgid "DHCP server:"
+msgstr "DHCP Server:"
+
+#: id:20309
+msgid "Make new folder"
+msgstr "Oħloq Fowlder ġdid"
+
+#: id:20310
+msgid "Dim LCD on playback"
+msgstr "Dallam LCD on Playback"
+
+#: id:20311
+msgid "Unknown or onboard (protected)"
+msgstr "Mhux magħruf jew OnBoard (Protetta)"
+
+#: id:20312
+msgid "Dim LCD on paused"
+msgstr "Dallam LCD fil-Pawza"
+
+#: id:20314
+msgid "Videos - Library"
+msgstr "Filmati - Librerija"
+
+#: id:20316
+msgid "Sort by: ID"
+msgstr "Ordni: ID"
+
+#: id:20324
+msgid "Play part..."
+msgstr "Ara parti..."
+
+#: id:20325
+msgid "Calibration reset"
+msgstr "Kalibbrazzjoni Risetjata"
+
+#: id:20326
+msgid "This will reset the calibration values for %s"
+msgstr "Din tirrisetja l-valuri tal-kalibrazzjoni ta' %s"
+
+#: id:20327
+msgid "to it's default values."
+msgstr "għad-difolt."
+
+#: id:20328
+msgid "Browse for destination"
+msgstr "lokazzjoni biex tikkopja ġo"
+
+#: id:20329
+msgid "Movies are in separate folders that match the movie title"
+msgstr "lokazzjoni biex tmexxi ġo"
+
+#: id:20330
+msgid "Use folder names for lookups"
+msgstr "Use Folder Names For Lookups"
+
+#: id:20331
+msgctxt "Auto context with id 20331"
+msgid "File"
+msgstr "Fajl"
+
+#: id:20332
+msgid "Use file or folder names in lookups?"
+msgstr "Use folder or file names in lookups?"
+
+#: id:20333
+msgid "Set content"
+msgstr "Set Content"
+
+#: id:20334
+msgid "Folder"
+msgstr "Fowlder"
+
+#: id:20335
+msgid "Look for content recursively?"
+msgstr "Look for content recursively?"
+
+#: id:20336
+msgid "Unlock sources"
+msgstr "Unlock Sorss"
+
+#: id:20337
+msgid "Actor"
+msgstr "Attur"
+
+#: id:20338
+msgid "Movie"
+msgstr "Film"
+
+#: id:20339
+msgid "Director"
+msgstr "Direttur"
+
+#: id:20340
+msgid "Do you want to remove all items within"
+msgstr "Trid tneħħi l-affarijiet kollha li qiegħdin ġo"
+
+#: id:20341
+msgid "this path from the XBMC library?"
+msgstr "dan il-path min ġewwa d-database?"
+
+#: id:20342
+msgctxt "Auto context with id 20342"
+msgid "Movies"
+msgstr "Filmati"
+
+#: id:20343
+msgid "TV shows"
+msgstr "Xow Televiżiv"
+
+#: id:20344
+msgid "This directory contains"
+msgstr "Dan il-fowlder fih"
+
+#: id:20345
+msgid "Run automated scan"
+msgstr "Tellaq Sken Awtomatika"
+
+#: id:20346
+msgid "Scan recursively"
+msgstr "Scan Recursively"
+
+#: id:20347
+msgid "as"
+msgstr "bħala"
+
+#: id:20348
+msgid "Directors"
+msgstr "Diretturi"
+
+#: id:20349
+msgid "No video files found in this path!"
+msgstr "Ma nstab l-ebda fajl ġo dan is-sors!"
+
+#: id:20350
+msgid "votes"
+msgstr "voti"
+
+#: id:20351
+msgid "TV show information"
+msgstr "Dettalji fuq programm tat-TV"
+
+#: id:20352
+msgid "Episode information"
+msgstr "Informazzjoni tal-Episodju"
+
+#: id:20353
+msgid "Loading TV show details"
+msgstr "Naqra dettalji ta' Programmi tat-TV"
+
+#: id:20354
+msgid "Fetching episode guide"
+msgstr "Infittex Gwida tal-Episodju"
+
+#: id:20355
+msgid "Loading info for episodes in directory"
+msgstr "Naqra dettalji tal-Episodju ġewwa l-Fowlder"
+
+#: id:20356
+msgid "Select TV show:"
+msgstr "Għażel Programm Televiżiv"
+
+#: id:20357
+msgid "Enter the TV show name"
+msgstr "Daħħal l-isem tal-Programm Televiżiv"
+
+#: id:20358
+msgid "Season %i"
+msgstr "Staġun %i"
+
+#: id:20359
+msgid "Episode"
+msgstr "Episodju"
+
+#: id:20360
+msgid "Episodes"
+msgstr "Episodji"
+
+#: id:20361
+msgid "Loading episode details"
+msgstr "Naqra dettalji tal-Episodju"
+
+#: id:20362
+msgid "Remove episode from library"
+msgstr "Neħħi Episodju mill-Librerija"
+
+#: id:20363
+msgid "Remove TV show from library"
+msgstr "Neħħi Programm Televiżiv mill-Librerija"
+
+#: id:20364
+msgid "TV show"
+msgstr "Programm Televiziv"
+
+#: id:20365
+msgid "Episode plot"
+msgstr "Plot tal-Episodju"
+
+#: id:20366
+msgid "* All seasons"
+msgstr "* L-istaġun kollu"
+
+#: id:20367
+msgid "Hide watched"
+msgstr "Aħbi li rajt"
+
+#: id:20368
+msgid "Prod code"
+msgstr "Kodiċi tal-Prodott"
+
+#: id:20369
+msgid "Show plot for unwatched items"
+msgstr "Aħbi plot tal-oġġetti li ma rajtx"
+
+#: id:20370
+msgid "* Hidden to prevent spoilers *"
+msgstr ""
+
+#: id:20371
+msgid "Set season thumb"
+msgstr "Issettja Tambnejl tal-iStaġun"
+
+#: id:20372
+msgid "Season image"
+msgstr "Ritratt tal-iStaġun"
+
+#: id:20373
+msgid "Season"
+msgstr "Staġun"
+
+#: id:20374
+msgid "Downloading movie information"
+msgstr "Inniżżel dettalji tal-Vidjo"
+
+#: id:20375
+msgid "Unassign content"
+msgstr "Kontenut mhux klassifikat"
+
+#: id:20376
+msgid "Original title"
+msgstr "Muri l-ewwel:"
+
+#: id:20377
+msgid "Refresh TV show information"
+msgstr "Aġġorna dettalji tal-Programm Televiżiv"
+
+#: id:20378
+msgid "Refresh info for all episodes?"
+msgstr "Aġġorna dettalji tal-Episodji kollha?"
+
+#: id:20379
+msgid "Selected folder contains a single TV show"
+msgstr "Fowlder fiħ Programm Televiziv wieħed"
+
+#: id:20380
+msgid "Exclude selected folder from scans"
+msgstr "Tiskenjax dan il-fowlder"
+
+#: id:20381
+msgid "Specials"
+msgstr "Speċjali"
+
+#: id:20382
+msgid "Automatically grab season thumbs"
+msgstr "Ġib tambnejl tal-istaġun awtomatikament"
+
+#: id:20383
+msgid "Selected folder contains a single video"
+msgstr "Fowlder fiħ Vidjo wieħed"
+
+#: id:20384
+msgid "Link to TV show"
+msgstr "Illinkja ma Programm Televiżiv"
+
+#: id:20385
+msgid "Remove link to TV show"
+msgstr "Neħħi link mal-Programm Televiżiv"
+
+#: id:20386
+msgid "Recently added movies"
+msgstr "Filmati miżjuda Riċentament"
+
+#: id:20387
+msgid "Recently added episodes"
+msgstr "Episodji miżjuda Riċentament"
+
+#: id:20388
+msgid "Studios"
+msgstr "Studjos"
+
+#: id:20389
+msgid "Music videos"
+msgstr "Vidjos tal-Mużika"
+
+#: id:20390
+msgid "Recently added music videos"
+msgstr "Vidjos tal-Mużika miżjuda Riċentament"
+
+#: id:20391
+msgid "Music video"
+msgstr "Vidjo tal-Mużika"
+
+#: id:20392
+msgid "Remove music video from library"
+msgstr "Neħħi Vidjo tal-Mużika mil-librerija"
+
+#: id:20393
+msgctxt "Auto context with id 20393"
+msgid "Music video information"
+msgstr "Dettalji tal-Vidjo tal-Mużika"
+
+#: id:20394
+msgid "Loading music video information"
+msgstr "Naqra Dettalji tal-Vidjo tal-Mużika"
+
+#: id:20395
+msgid "Mixed"
+msgstr "Imħallat"
+
+#: id:20396
+msgid "Go to albums by artist"
+msgstr "Mur fl-Albums tal-Artist"
+
+#: id:20397
+msgid "Go to album"
+msgstr "Mur għall-album"
+
+#: id:20398
+msgid "Play song"
+msgstr "Doqq id-diska"
+
+#: id:20399
+msgid "Go to music videos from album"
+msgstr "Mur fil-Vidjos tal-Mużika mill-Album"
+
+#: id:20400
+msgid "Go to music videos by artist"
+msgstr "Mur fil-Vidjos tal-Mużika tal-Artist"
+
+#: id:20401
+msgid "Play music video"
+msgstr "Ara Vidjo tal-Mużika"
+
+#: id:20402
+msgid "Download actor thumbnails when adding to library"
+msgstr "Ġib tambnejl tal-awtur awtomatikament"
+
+#: id:20403
+msgid "Set actor thumb"
+msgstr "Issettja Tambnejl tal-Awtur"
+
+#: id:20405
+msgid "Remove episode bookmark"
+msgstr "Neħħi Bookmark tal-Episodju"
+
+#: id:20406
+msgid "Set episode bookmark"
+msgstr "Issettja Bookmark tal-Episodju"
+
+#: id:20407
+msgid "Scraper settings"
+msgstr ""
+
+#: id:20408
+msgid "Downloading music video information"
+msgstr ""
+
+#: id:20409
+msgid "Downloading TV show information"
+msgstr ""
+
+#: id:20410
+msgid "Trailer"
+msgstr ""
+
+#: id:20411
+msgid "Flatten"
+msgstr "Flatten"
+
+#: id:20412
+msgid "Flatten TV shows"
+msgstr ""
+
+#: id:20413
+msgid "Get fanart"
+msgstr ""
+
+#: id:20414
+msgid "Show Fanart in video and music libraries"
+msgstr ""
+
+#: id:20415
+msgid "Scanning for new content"
+msgstr ""
+
+#: id:20416
+msgid "First aired"
+msgstr ""
+
+#: id:20417
+msgid "Writer"
+msgstr ""
+
+#: id:20419
+msgid "Replace file names with library titles"
+msgstr ""
+
+#: id:20420
+msgctxt "Auto context with id 20420"
+msgid "Never"
+msgstr ""
+
+#: id:20421
+msgid "If only one season"
+msgstr ""
+
+#: id:20422
+msgid "Always"
+msgstr ""
+
+#: id:20423
+msgid "Has trailer"
+msgstr ""
+
+#: id:20424
+msgid "False"
+msgstr ""
+
+#: id:20425
+msgid "Fanart slideshow"
+msgstr ""
+
+#: id:20426
+msgid "Export to a single file or separate"
+msgstr ""
+
+#: id:20427
+msgid "files per entry?"
+msgstr ""
+
+#: id:20428
+msgid "Single file"
+msgstr ""
+
+#: id:20429
+msgctxt "Auto context with id 20429"
+msgid "Separate"
+msgstr ""
+
+#: id:20430
+msgid "Export thumbnails and fanart?"
+msgstr ""
+
+#: id:20431
+msgid "Overwrite old files?"
+msgstr ""
+
+#: id:20432
+msgid "Exclude path from library updates"
+msgstr ""
+
+#: id:20433
+msgid "Extract thumbnails and video information"
+msgstr ""
+
+#: id:20434
+msgid "Sets"
+msgstr ""
+
+#: id:20435
+msgid "Set movieset thumb"
+msgstr ""
+
+#: id:20436
+msgid "Export actor thumbs?"
+msgstr ""
+
+#: id:20437
+msgid "Choose fanart"
+msgstr ""
+
+#: id:20438
+msgid "Local fanart"
+msgstr ""
+
+#: id:20439
+msgid "No fanart"
+msgstr ""
+
+#: id:20440
+msgid "Current fanart"
+msgstr ""
+
+#: id:20441
+msgid "Remote fanart"
+msgstr ""
+
+#: id:20442
+msgid "Change content"
+msgstr ""
+
+#: id:20443
+msgid "Do you want to refresh info for all"
+msgstr ""
+
+#: id:20444
+msgid "items within this path?"
+msgstr ""
+
+#: id:20445
+msgid "Fanart"
+msgstr ""
+
+#: id:20446
+msgid "Locally stored information found."
+msgstr ""
+
+#: id:20447
+msgid "Ignore and refresh from internet?"
+msgstr ""
+
+#: id:20448
+msgid "Could not download information"
+msgstr ""
+
+#: id:20449
+msgid "Unable to connect to remote server"
+msgstr ""
+
+#: id:20450
+msgid "Would you like to continue scanning?"
+msgstr ""
+
+#: id:20451
+msgid "Countries"
+msgstr ""
+
+#: id:20452
+msgid "episode"
+msgstr ""
+
+#: id:20453
+msgid "episodes"
+msgstr ""
+
+#: id:20454
+msgid "Listener"
+msgstr ""
+
+#: id:20455
+msgid "Listeners"
+msgstr ""
+
+#: id:20456
+msgid "Set movieset fanart"
+msgstr ""
+
+#: id:20457
+msgid "Movie set"
+msgstr ""
+
+#: id:20458
+msgid "Group movies in sets"
+msgstr ""
+
+#: id:21330
+msgid "Show hidden files and directories"
+msgstr "Uri kannestri u fajls moħbija"
+
+#: id:21331
+msgid "TuxBox client"
+msgstr "Tuxbox Client"
+
+#: id:21332
+msgid "WARNING: Target TuxBox device is in recording-mode!"
+msgstr "ATTENZJONI: Target Tuxbox device qiegħda Recording-Mode!"
+
+#: id:21333
+msgid "The stream will be stopped!"
+msgstr "L-istream jieqaf!"
+
+#: id:21334
+msgid "Zap to channel: %s failed!"
+msgstr "Zap to Channel: %s Failed!"
+
+#: id:21335
+msgid "Are you sure to start the stream?"
+msgstr "Trid tibda l-istream?"
+
+#: id:21336
+msgid "Connecting to: %s"
+msgstr "Naqbad ma: %s"
+
+#: id:21337
+msgid "TuxBox device"
+msgstr "TuxBox Device"
+
+#: id:21359
+msgid "Add media share..."
+msgstr "Żid Media Share"
+
+#: id:21360
+msgid "Share video and music libraries through UPnP"
+msgstr "Attiva UPnP Server"
+
+#: id:21364
+msgid "Edit media share"
+msgstr "Biddel Media Share"
+
+#: id:21365
+msgid "Remove media share"
+msgstr "Neħħi Media Share"
+
+#: id:21366
+msgid "Subtitle folder"
+msgstr "Fowlder Preferut tas-sottutitoli"
+
+#: id:21367
+msgid "Movie & alternate subtitle directory"
+msgstr "Fowlder Alternattiv ghas-sottotitoli u filmati"
+
+#: id:21368
+msgid "Override ASS/SSA subtitles fonts"
+msgstr ""
+
+#: id:21369
+msgid "Enable mouse and Touch Screen support"
+msgstr "Attiva l-Maws"
+
+#: id:21370
+msgid "Play navigation sounds during media playback"
+msgstr ""
+
+#: id:21371
+msgid "Thumbnail"
+msgstr "Tambnejl"
+
+#: id:21372
+msgid "Forced DVD player region"
+msgstr "DVD Player Region Forzat"
+
+#: id:21373
+msgid "Video output"
+msgstr "Hardware tal-Vidjo"
+
+#: id:21374
+msgid "Video aspect"
+msgstr "Aspett tal-Vidjo"
+
+#: id:21375
+msgctxt "Auto context with id 21375"
+msgid "Normal"
+msgstr "Normali"
+
+#: id:21376
+msgid "Letterbox"
+msgstr "Kaxxa tal-ittri"
+
+#: id:21377
+msgid "Widescreen"
+msgstr "Wajdskrin"
+
+#: id:21378
+msgid "Enable 480p"
+msgstr "Attiva 480p"
+
+#: id:21379
+msgid "Enable 720p"
+msgstr "Attiva 720p"
+
+#: id:21380
+msgid "Enable 1080i"
+msgstr "Attiva 1080i"
+
+#: id:21381
+msgid "Enter name of new playlist"
+msgstr "Daħħal Isem għall-Playlist il-Ġdida"
+
+#: id:21382
+msgid "Show \"Add source\" buttons in file lists"
+msgstr "Neħħi buttuna Żid Sors mill-listi tal-files"
+
+#: id:21383
+msgid "Enable scrollbars"
+msgstr "Attiva Żbarri"
+
+#: id:21384
+msgid "Make watched filtering a toggle in video library"
+msgstr ""
+
+#: id:21385
+msgctxt "Auto context with id 21385"
+msgid "Open"
+msgstr "Iftaħ"
+
+#: id:21386
+msgid "Acoustic management level"
+msgstr ""
+
+#: id:21387
+msgid "Fast"
+msgstr "Mgħaġġel"
+
+#: id:21388
+msgid "Quiet"
+msgstr "Kwiet"
+
+#: id:21389
+msgid "Enable custom background"
+msgstr "Attiva Bakgrawnd Preferut"
+
+#: id:21390
+msgid "Power management level"
+msgstr "Livell tal-immaniġġjar tad-dawl"
+
+#: id:21391
+msgid "High power"
+msgstr "Power għoli"
+
+#: id:21392
+msgid "Low power"
+msgstr "Power baxx"
+
+#: id:21393
+msgid "High standby"
+msgstr "Standbaj Għoli"
+
+#: id:21394
+msgid "Low standby"
+msgstr "Standbaj baxx"
+
+#: id:21395
+msgid "Unable to cache files bigger than 4GB"
+msgstr "Unable to cache files bigger than 4 gb"
+
+#: id:21396
+msgid "Chapter"
+msgstr "Kapitolu"
+
+#: id:21397
+msgid "High quality pixel shader v2"
+msgstr ""
+
+#: id:21398
+msgid "Enable playlist at startup"
+msgstr "Attiva plejlist meta tibda"
+
+#: id:21399
+msgid "Use tween animations"
+msgstr "Uża Tween Animations"
+
+#: id:21400
+msgid "contains"
+msgstr "fiħ"
+
+#: id:21401
+msgid "does not contain"
+msgstr "ma fiħx"
+
+#: id:21402
+msgid "is"
+msgstr "hu"
+
+#: id:21403
+msgid "is not"
+msgstr "mhux"
+
+#: id:21404
+msgid "starts with"
+msgstr "jibda bi"
+
+#: id:21405
+msgid "ends with"
+msgstr "jispicca bi"
+
+#: id:21406
+msgid "greater than"
+msgstr "ikbar minn"
+
+#: id:21407
+msgid "less than"
+msgstr "iżgħar minn"
+
+#: id:21408
+msgid "after"
+msgstr "wara"
+
+#: id:21409
+msgid "before"
+msgstr "qabel"
+
+#: id:21410
+msgid "in the last"
+msgstr "fl-aħħar"
+
+#: id:21411
+msgid "not in the last"
+msgstr "mhux fl-aħħar"
+
+#: id:21412
+msgid "Scrapers"
+msgstr ""
+
+#: id:21413
+msgid "Default movie scraper"
+msgstr ""
+
+#: id:21414
+msgid "Default tvshow scraper"
+msgstr ""
+
+#: id:21415
+msgid "Default music video scraper"
+msgstr ""
+
+#: id:21416
+msgid "Enable fallback based on scraper language"
+msgstr ""
+
+#: id:21417
+msgid "- Settings"
+msgstr ""
+
+#: id:21418
+msgid "Multilingual"
+msgstr ""
+
+#: id:21419
+msgid "No scrapers present"
+msgstr ""
+
+#: id:21420
+msgid "Value to match"
+msgstr "Valur jixbaħ"
+
+#: id:21421
+msgid "Smart playlist rule"
+msgstr "Regola tal-Plejlist Smart"
+
+#: id:21422
+msgid "Match items where"
+msgstr "Xebbaħ diski fejn"
+
+#: id:21423
+msgid "New rule..."
+msgstr "Rule Ġdida"
+
+#: id:21424
+msgid "Items must match"
+msgstr "Diska trid tixbaħ"
+
+#: id:21425
+msgid "all of the rules"
+msgstr "Rules kollha"
+
+#: id:21426
+msgid "one or more of the rules"
+msgstr "Rule waħda jew aktar"
+
+#: id:21427
+msgid "Limit to"
+msgstr "Illimita għal"
+
+#: id:21428
+msgid "No limit"
+msgstr "Neħħi Limiti"
+
+#: id:21429
+msgid "Order by"
+msgstr "Issortja"
+
+#: id:21430
+msgid "ascending"
+msgstr "Żgħir għal-Kbir"
+
+#: id:21431
+msgid "descending"
+msgstr "Kbir għaż-Żgħir"
+
+#: id:21432
+msgid "Edit smart playlist"
+msgstr "Biddel Plejlist Smart"
+
+#: id:21433
+msgid "Name of the playlist"
+msgstr "Isem tal-plejlist"
+
+#: id:21434
+msgid "Find items where"
+msgstr "Sib diski jisbħu"
+
+#: id:21435
+msgid "Edit"
+msgstr "Biddel"
+
+#: id:21436
+msgid "%i items"
+msgstr "%i diski"
+
+#: id:21437
+msgid "New smart playlist..."
+msgstr "Plejlist Smart Ġdida"
+
+#: id:21438
+msgid "%c Drive"
+msgstr "Drive %c"
+
+#: id:21439
+msgid "Edit party mode rules"
+msgstr "Biddel Regoli tal-Party Mode"
+
+#: id:21440
+msgid "Home folder"
+msgstr ""
+
+#: id:21441
+msgid "Watched count"
+msgstr ""
+
+#: id:21442
+msgid "Episode title"
+msgstr ""
+
+#: id:21443
+msgid "Video resolution"
+msgstr ""
+
+#: id:21444
+msgid "Audio channels"
+msgstr ""
+
+#: id:21445
+msgid "Video codec"
+msgstr ""
+
+#: id:21446
+msgid "Audio codec"
+msgstr ""
+
+#: id:21447
+msgid "Audio language"
+msgstr ""
+
+#: id:21448
+msgid "Subtitle language"
+msgstr ""
+
+#: id:21449
+msgid "Remote control sends keyboard presses"
+msgstr ""
+
+#: id:21450
+msgid "- Edit"
+msgstr ""
+
+#: id:21451
+msgid "Internet connection required."
+msgstr ""
+
+#: id:21452
+msgid "Get More..."
+msgstr ""
+
+#: id:21453
+msgid "Root filesystem"
+msgstr ""
+
+#: id:21454
+msgid "Cache full"
+msgstr ""
+
+#: id:21455
+msgid "Cache filled before reaching required amount for continous playback"
+msgstr ""
+
+#: id:21460
+msgid "Subtitle location"
+msgstr ""
+
+#: id:21461
+msgid "Fixed"
+msgstr ""
+
+#: id:21462
+msgid "Bottom of video"
+msgstr ""
+
+#: id:21463
+msgid "Below video"
+msgstr ""
+
+#: id:21464
+msgid "Top of video"
+msgstr ""
+
+#: id:21465
+msgid "Above video"
+msgstr ""
+
+#: id:21800
+msgid "File name"
+msgstr "Isem tal-Fajl"
+
+#: id:21801
+msgid "File path"
+msgstr "Lokazzjoni tal-Fajl"
+
+#: id:21802
+msgid "File size"
+msgstr "Kobor tal-Fajl"
+
+#: id:21803
+msgid "File date/time"
+msgstr "Data/Ħin tal-Fajl"
+
+#: id:21804
+msgid "Slide index"
+msgstr ""
+
+#: id:21805
+msgctxt "Auto context with id 21805"
+msgid "Resolution"
+msgstr "Riżoluzzjoni"
+
+#: id:21806
+msgctxt "Auto context with id 21806"
+msgid "Comment"
+msgstr "Kumment"
+
+#: id:21807
+msgid "Colour/B&W"
+msgstr "Kulur / BW"
+
+#: id:21808
+msgid "JPEG process"
+msgstr "Niproċessa Jpeg"
+
+#: id:21820
+msgid "Date/Time"
+msgstr "Data/Ħin"
+
+#: id:21821
+msgid "Description"
+msgstr "Deskrizzjoni"
+
+#: id:21822
+msgid "Camera make"
+msgstr "Għamla tal-Kamera"
+
+#: id:21823
+msgid "Camera model"
+msgstr "Mudell tal-Kamera"
+
+#: id:21824
+msgid "EXIF comment"
+msgstr "Kumment tal-Exif"
+
+#: id:21825
+msgid "Firmware"
+msgstr "Firmware"
+
+#: id:21826
+msgid "Aperture"
+msgstr "Aperture"
+
+#: id:21827
+msgid "Focal length"
+msgstr "Tul Fokali"
+
+#: id:21828
+msgid "Focus distance"
+msgstr "Distanza Fokali"
+
+#: id:21829
+msgid "Exposure"
+msgstr ""
+
+#: id:21830
+msgid "Exposure time"
+msgstr ""
+
+#: id:21831
+msgid "Exposure bias"
+msgstr ""
+
+#: id:21832
+msgid "Exposure mode"
+msgstr ""
+
+#: id:21833
+msgid "Flash used"
+msgstr "Bil-flexx"
+
+#: id:21834
+msgid "White-balance"
+msgstr ""
+
+#: id:21835
+msgid "Light source"
+msgstr "Sors tad-dawl"
+
+#: id:21836
+msgid "Metering mode"
+msgstr "Metering Mode"
+
+#: id:21837
+msgid "ISO"
+msgstr "ISO"
+
+#: id:21838
+msgid "Digital zoom"
+msgstr "Zoom Diġitali"
+
+#: id:21839
+msgid "CCD width"
+msgstr "Wisgħa tas-CCD"
+
+#: id:21840
+msgid "GPS latitude"
+msgstr "GPS Latitudinali"
+
+#: id:21841
+msgid "GPS longitude"
+msgstr "GPS Longitidunali"
+
+#: id:21842
+msgid "GPS altitude"
+msgstr "Għoli tal-GPS"
+
+#: id:21843
+msgid "Orientation"
+msgstr "Orjentazzjoni"
+
+#: id:21860
+msgid "Supplemental categories"
+msgstr "Kategoriji Supplimentari"
+
+#: id:21861
+msgid "Keywords"
+msgstr ""
+
+#: id:21862
+msgid "Caption"
+msgstr "Titlu"
+
+#: id:21863
+msgid "Author"
+msgstr "Awtur"
+
+#: id:21864
+msgid "Headline"
+msgstr "Titlu fir-Ras"
+
+#: id:21865
+msgid "Special instructions"
+msgstr "Istruzzjoni Speċjali"
+
+#: id:21866
+msgid "Category"
+msgstr "Kategorija"
+
+#: id:21867
+msgid "Byline"
+msgstr ""
+
+#: id:21868
+msgid "Byline title"
+msgstr ""
+
+#: id:21869
+msgid "Credit"
+msgstr "Kreditu"
+
+#: id:21870
+msgid "Source"
+msgstr "Sors"
+
+#: id:21871
+msgid "Copyright notice"
+msgstr "Avviż dwar drittijiet tal-Awtur"
+
+#: id:21872
+msgid "Object name"
+msgstr "Isem tal-oġġett"
+
+#: id:21873
+msgid "City"
+msgstr "Belt/Raħal"
+
+#: id:21874
+msgid "State"
+msgstr "Stat"
+
+#: id:21875
+msgctxt "Auto context with id 21875"
+msgid "Country"
+msgstr "Pajjiż"
+
+#: id:21876
+msgid "Original Tx Reference"
+msgstr "Tx Reference Oriġinali"
+
+#: id:21877
+msgid "Date created"
+msgstr "Data maħluq"
+
+#: id:21878
+msgid "Copyright flag"
+msgstr "Sinjal tad-Drittijiet tal-Awtur"
+
+#: id:21879
+msgid "Country code"
+msgstr "Kowd tal-pajjiż"
+
+#: id:21880
+msgid "Reference service"
+msgstr "Servizz ta' Riferenza"
+
+#: id:21881
+msgid "Allow control of XBMC via UPnP"
+msgstr "Attiva UPnP Renderer"
+
+#: id:21882
+msgid "Attempt to skip introduction before DVD menu"
+msgstr "Ipprova aqbeż l-introduzzjoni qabel il-Menu tad-DVD"
+
+#: id:21883
+msgid "Saved music"
+msgstr "Audio CDs irrippjati"
+
+#: id:21884
+msgid "Query info for all artists"
+msgstr "Fittext Informazzjoni fuq l-Artisti Kollha"
+
+#: id:21885
+msgid "Downloading album information"
+msgstr "Inniżżel Informazzjoni tal-Album"
+
+#: id:21886
+msgid "Downloading artist information"
+msgstr "Inniżżel Informazzjoni tal-Artist"
+
+#: id:21887
+msgid "Biography"
+msgstr "Biografija"
+
+#: id:21888
+msgid "Discography"
+msgstr "Diskografija"
+
+#: id:21889
+msgid "Searching artist"
+msgstr "Infittex Artist"
+
+#: id:21890
+msgid "Select artist"
+msgstr "Għażel Artist"
+
+#: id:21891
+msgctxt "Auto context with id 21891"
+msgid "Artist information"
+msgstr "Informazzjoni tal-Artist"
+
+#: id:21892
+msgid "Instruments"
+msgstr "Strumenti:"
+
+#: id:21893
+msgid "Born"
+msgstr "Twelid:"
+
+#: id:21894
+msgid "Formed"
+msgstr "Iffurmat:"
+
+#: id:21895
+msgid "Themes"
+msgstr "Temi:"
+
+#: id:21896
+msgid "Disbanded"
+msgstr "Żarmat:"
+
+#: id:21897
+msgid "Died"
+msgstr "Miet:"
+
+#: id:21898
+msgid "Years active"
+msgstr "Snin Attiv:"
+
+#: id:21899
+msgid "Label"
+msgstr "Isem:"
+
+#: id:21900
+msgid "Born/Formed"
+msgstr "Twelid/Iffurmat:"
+
+#: id:22000
+msgid "Update library on startup"
+msgstr "Aġġorna librerija meta tibda"
+
+#: id:22001
+msgid "Hide progress of library updates"
+msgstr "Dejjem aġġorna librerija wara l-kwinti"
+
+#: id:22002
+msgid "- DNS suffix"
+msgstr "- DNS Suffix"
+
+#: id:22003
+msgid "%2.3fs"
+msgstr ""
+
+#: id:22004
+msgid "Delayed by: %2.3fs"
+msgstr ""
+
+#: id:22005
+msgid "Ahead by: %2.3fs"
+msgstr ""
+
+#: id:22006
+msgid "Subtitle offset"
+msgstr ""
+
+#: id:22007
+msgid "OpenGL vendor:"
+msgstr ""
+
+#: id:22008
+msgid "OpenGL renderer:"
+msgstr ""
+
+#: id:22009
+msgid "OpenGL version:"
+msgstr ""
+
+#: id:22010
+msgid "GPU temperature:"
+msgstr ""
+
+#: id:22011
+msgid "CPU temperature:"
+msgstr ""
+
+#: id:22012
+msgid "Total memory"
+msgstr ""
+
+#: id:22013
+msgid "Profile data"
+msgstr ""
+
+#: id:22014
+msgid "Use dim if paused during video playback"
+msgstr ""
+
+#: id:22015
+msgid "All recordings"
+msgstr ""
+
+#: id:22016
+msgid "By title"
+msgstr ""
+
+#: id:22017
+msgid "By group"
+msgstr ""
+
+#: id:22018
+msgid "Live channels"
+msgstr ""
+
+#: id:22019
+msgid "Recordings by title"
+msgstr ""
+
+#: id:22020
+msgid "Guide"
+msgstr ""
+
+#: id:22021
+msgid "Allowed error in aspect ratio to minimize black bars"
+msgstr ""
+
+#: id:22022
+msgid "Show video files in listings"
+msgstr ""
+
+#: id:22023
+msgid "DirectX vendor:"
+msgstr ""
+
+#: id:22024
+msgid "Direct3D version:"
+msgstr ""
+
+#: id:22030
+msgctxt "Auto context with id 22030"
+msgid "Font"
+msgstr ""
+
+#: id:22031
+msgctxt "Auto context with id 22031"
+msgid "- Size"
+msgstr ""
+
+#: id:22032
+msgctxt "Auto context with id 22032"
+msgid "- Colours"
+msgstr ""
+
+#: id:22033
+msgid "- Charset"
+msgstr ""
+
+#: id:22034
+msgid "Export karaoke titles as HTML"
+msgstr ""
+
+#: id:22035
+msgid "Export karaoke titles as CSV"
+msgstr ""
+
+#: id:22036
+msgid "Import karaoke titles..."
+msgstr ""
+
+#: id:22037
+msgid "Show song selector automatically"
+msgstr ""
+
+#: id:22038
+msgid "Export karaoke titles..."
+msgstr ""
+
+#: id:22039
+msgid "Enter song number"
+msgstr ""
+
+#: id:22040
+msgid "white/green"
+msgstr ""
+
+#: id:22041
+msgid "white/red"
+msgstr ""
+
+#: id:22042
+msgid "white/blue"
+msgstr ""
+
+#: id:22043
+msgid "black/white"
+msgstr ""
+
+#: id:22079
+msgid "Default select action"
+msgstr ""
+
+#: id:22080
+msgid "Choose"
+msgstr ""
+
+#: id:22081
+msgid "Show Information"
+msgstr ""
+
+#: id:22082
+msgid "More..."
+msgstr ""
+
+#: id:22083
+msgid "Play all"
+msgstr ""
+
+#: id:23049
+msgid "Teletext not available"
+msgstr ""
+
+#: id:23050
+msgid "Activate Teletext"
+msgstr ""
+
+#: id:23051
+msgid "Part %i"
+msgstr ""
+
+#: id:23052
+msgid "Buffering %i bytes"
+msgstr ""
+
+#: id:23053
+msgid "Stopping"
+msgstr ""
+
+#: id:23054
+msgid "Running"
+msgstr ""
+
+#: id:23100
+msgid "External Player Active"
+msgstr ""
+
+#: id:23101
+msgid "Click OK to terminate the player"
+msgstr ""
+
+#: id:23104
+msgid "Click OK when playback has ended"
+msgstr ""
+
+#: id:24000
+msgid "Add-on"
+msgstr ""
+
+#: id:24001
+msgid "Add-ons"
+msgstr ""
+
+#: id:24002
+msgid "Add-on options"
+msgstr ""
+
+#: id:24003
+msgid "Add-on Information"
+msgstr ""
+
+#: id:24005
+msgctxt "Auto context with id 24005"
+msgid "Media sources"
+msgstr ""
+
+#: id:24007
+msgctxt "Auto context with id 24007"
+msgid "Movie information"
+msgstr ""
+
+#: id:24008
+msgctxt "Auto context with id 24008"
+msgid "Screensaver"
+msgstr ""
+
+#: id:24009
+msgid "Script"
+msgstr ""
+
+#: id:24010
+msgctxt "Auto context with id 24010"
+msgid "Visualization"
+msgstr ""
+
+#: id:24011
+msgid "Add-on repository"
+msgstr ""
+
+#: id:24012
+msgctxt "Auto context with id 24012"
+msgid "Subtitles"
+msgstr ""
+
+#: id:24013
+msgid "Lyrics"
+msgstr ""
+
+#: id:24014
+msgid "TV information"
+msgstr ""
+
+#: id:24015
+msgctxt "Auto context with id 24015"
+msgid "Music video information"
+msgstr ""
+
+#: id:24016
+msgctxt "Auto context with id 24016"
+msgid "Album information"
+msgstr ""
+
+#: id:24017
+msgctxt "Auto context with id 24017"
+msgid "Artist information"
+msgstr ""
+
+#: id:24018
+msgctxt "Auto context with id 24018"
+msgid "Services"
+msgstr ""
+
+#: id:24020
+msgid "Configure"
+msgstr ""
+
+#: id:24021
+msgctxt "Auto context with id 24021"
+msgid "Disable"
+msgstr ""
+
+#: id:24022
+msgid "Enable"
+msgstr ""
+
+#: id:24023
+msgid "Add-on disabled"
+msgstr ""
+
+#: id:24027
+msgctxt "Auto context with id 24027"
+msgid "Weather"
+msgstr ""
+
+#: id:24028
+msgid "Weather.com (standard)"
+msgstr ""
+
+#: id:24030
+msgid "This Add-on can not be configured"
+msgstr ""
+
+#: id:24031
+msgid "Error loading settings"
+msgstr ""
+
+#: id:24032
+msgid "All Add-ons"
+msgstr ""
+
+#: id:24033
+msgid "Get Add-ons"
+msgstr ""
+
+#: id:24034
+msgid "Check for updates"
+msgstr ""
+
+#: id:24035
+msgid "Force refresh"
+msgstr ""
+
+#: id:24036
+msgid "Change log"
+msgstr ""
+
+#: id:24037
+msgid "Uninstall"
+msgstr ""
+
+#: id:24038
+msgid "Install"
+msgstr ""
+
+#: id:24039
+msgid "Disabled Add-ons"
+msgstr ""
+
+#: id:24040
+msgid "(Clear the current setting)"
+msgstr ""
+
+#: id:24041
+msgid "Install from zip file"
+msgstr ""
+
+#: id:24042
+msgid "Downloading %i%%"
+msgstr ""
+
+#: id:24043
+msgid "Available Updates"
+msgstr ""
+
+#: id:24044
+msgid "Dependencies not met"
+msgstr ""
+
+#: id:24045
+msgid "Add-on does not have the correct structure"
+msgstr ""
+
+#: id:24046
+msgid "%s is used by the following installed add-on(s)"
+msgstr ""
+
+#: id:24047
+msgid "This add-on cannot be uninstalled"
+msgstr ""
+
+#: id:24048
+msgid "Rollback"
+msgstr ""
+
+#: id:24050
+msgid "Available Add-ons"
+msgstr ""
+
+#: id:24051
+msgid "Version:"
+msgstr ""
+
+#: id:24052
+msgid "Disclaimer"
+msgstr ""
+
+#: id:24053
+msgid "License:"
+msgstr ""
+
+#: id:24054
+msgid "Changelog"
+msgstr ""
+
+#: id:24059
+msgid "Would you like to enable this Add-on?"
+msgstr ""
+
+#: id:24060
+msgid "Would you like to disable this Add-on?"
+msgstr ""
+
+#: id:24061
+msgid "Add-on update available!"
+msgstr ""
+
+#: id:24062
+msgid "Enabled Add-ons"
+msgstr ""
+
+#: id:24063
+msgid "Auto update"
+msgstr ""
+
+#: id:24064
+msgid "Add-on enabled"
+msgstr ""
+
+#: id:24065
+msgid "Add-on updated"
+msgstr ""
+
+#: id:24066
+msgid "Cancel Add-on download?"
+msgstr ""
+
+#: id:24067
+msgid "Currently downloading Add-ons"
+msgstr ""
+
+#: id:24068
+msgid "Update available"
+msgstr ""
+
+#: id:24069
+msgid "Update"
+msgstr ""
+
+#: id:24070
+msgid "Add-on could not be loaded."
+msgstr ""
+
+#: id:24071
+msgid "An unknown error has occurred."
+msgstr ""
+
+#: id:24072
+msgid "Settings required"
+msgstr ""
+
+#: id:24073
+msgid "Could not connect"
+msgstr ""
+
+#: id:24074
+msgid "Needs to restart"
+msgstr ""
+
+#: id:24075
+msgctxt "Auto context with id 24075"
+msgid "Disable"
+msgstr ""
+
+#: id:24076
+msgid "Add-on Required"
+msgstr ""
+
+#: id:24080
+msgid "Try to reconnect?"
+msgstr ""
+
+#: id:24089
+msgid "Add-on restarts"
+msgstr ""
+
+#: id:24090
+msgid "Lock Add-on manager"
+msgstr ""
+
+#: id:24094
+msgid "(current)"
+msgstr ""
+
+#: id:24095
+msgid "(blacklisted)"
+msgstr ""
+
+#: id:24096
+msgid "Add-on has been marked as broken in repository."
+msgstr ""
+
+#: id:24097
+msgid "Would you like to disable it on your system?"
+msgstr ""
+
+#: id:24098
+msgid "Broken"
+msgstr ""
+
+#: id:24099
+msgid "Would you like to switch to this skin?"
+msgstr ""
+
+#: id:24100
+msgid "To use this feature you must download an Add-on:"
+msgstr ""
+
+#: id:24101
+msgid "Would you like to download this Add-on?"
+msgstr ""
+
+#: id:25000
+msgid "Notifications"
+msgstr ""
+
+#: id:29800
+msgid "Library Mode"
+msgstr ""
+
+#: id:29801
+msgid "QWERTY keyboard"
+msgstr ""
+
+#: id:29802
+msgid "Passthrough Audio in use"
+msgstr ""
+
+#: id:33001
+msgid "Trailer quality"
+msgstr ""
+
+#: id:33002
+msgid "Stream"
+msgstr ""
+
+#: id:33003
+msgid "Download"
+msgstr ""
+
+#: id:33004
+msgid "Download & play"
+msgstr ""
+
+#: id:33005
+msgid "Download & save"
+msgstr ""
+
+#: id:33006
+msgid "Today"
+msgstr ""
+
+#: id:33007
+msgid "Tomorrow"
+msgstr ""
+
+#: id:33008
+msgid "Saving"
+msgstr ""
+
+#: id:33009
+msgid "Copying"
+msgstr ""
+
+#: id:33010
+msgid "Set download directory"
+msgstr ""
+
+#: id:33011
+msgid "Search duration"
+msgstr ""
+
+#: id:33012
+msgid "Short"
+msgstr ""
+
+#: id:33013
+msgid "Long"
+msgstr ""
+
+#: id:33014
+msgid "Use DVD player instead of regular player"
+msgstr ""
+
+#: id:33015
+msgid "Ask for download before playing video"
+msgstr ""
+
+#: id:33016
+msgid "Clips"
+msgstr ""
+
+#: id:33017
+msgid "Restart plugin to enable"
+msgstr ""
+
+#: id:33018
+msgid "Tonight"
+msgstr ""
+
+#: id:33019
+msgid "Tomorrow Night"
+msgstr ""
+
+#: id:33020
+msgid "Condition"
+msgstr ""
+
+#: id:33021
+msgid "Precipitation"
+msgstr ""
+
+#: id:33022
+msgid "Precip"
+msgstr ""
+
+#: id:33023
+msgid "Humid"
+msgstr ""
+
+#: id:33024
+msgid "Feels"
+msgstr ""
+
+#: id:33025
+msgid "Observed"
+msgstr ""
+
+#: id:33026
+msgid "Departure from normal"
+msgstr ""
+
+#: id:33027
+msgid "Sunrise"
+msgstr ""
+
+#: id:33028
+msgid "Sunset"
+msgstr ""
+
+#: id:33029
+msgid "Details"
+msgstr ""
+
+#: id:33030
+msgid "Outlook"
+msgstr ""
+
+#: id:33031
+msgid "Coverflow"
+msgstr ""
+
+#: id:33032
+msgid "Translate text"
+msgstr ""
+
+#: id:33033
+msgid "Map list %s category"
+msgstr ""
+
+#: id:33034
+msgid "36 Hour"
+msgstr ""
+
+#: id:33035
+msgid "Maps"
+msgstr ""
+
+#: id:33036
+msgid "Hourly"
+msgstr ""
+
+#: id:33037
+msgid "Weekend"
+msgstr ""
+
+#: id:33038
+msgid "%s day"
+msgstr ""
+
+#: id:33049
+msgid "Alert"
+msgstr ""
+
+#: id:33050
+msgid "Alerts"
+msgstr ""
+
+#: id:33051
+msgid "Choose Your"
+msgstr ""
+
+#: id:33052
+msgid "Check"
+msgstr ""
+
+#: id:33053
+msgctxt "Auto context with id 33053"
+msgid "Configure the"
+msgstr ""
+
+#: id:33054
+msgid "Seasons"
+msgstr ""
+
+#: id:33055
+msgid "Use your"
+msgstr ""
+
+#: id:33056
+msgid "Watch your"
+msgstr ""
+
+#: id:33057
+msgid "Listen to"
+msgstr ""
+
+#: id:33058
+msgid "View your"
+msgstr ""
+
+#: id:33059
+msgctxt "Auto context with id 33059"
+msgid "Configure the"
+msgstr ""
+
+#: id:33060
+msgid "Power"
+msgstr ""
+
+#: id:33061
+msgid "Menu"
+msgstr ""
+
+#: id:33062
+msgid "Play the"
+msgstr ""
+
+#: id:33063
+msgid "Options"
+msgstr ""
+
+#: id:33065
+msgid "Editor"
+msgstr ""
+
+#: id:33066
+msgid "About your"
+msgstr ""
+
+#: id:33067
+msgid "Star rating"
+msgstr ""
+
+#: id:33068
+msgid "Background"
+msgstr ""
+
+#: id:33069
+msgid "Backgrounds"
+msgstr ""
+
+#: id:33070
+msgid "Custom background"
+msgstr ""
+
+#: id:33071
+msgid "Custom backgrounds"
+msgstr ""
+
+#: id:33072
+msgid "View Readme"
+msgstr ""
+
+#: id:33073
+msgid "View Changelog"
+msgstr ""
+
+#: id:33074
+msgid "This version of %s requires an"
+msgstr ""
+
+#: id:33075
+msgid "XBMC revision of %s or greater to run."
+msgstr ""
+
+#: id:33076
+msgid "Please update XBMC."
+msgstr ""
+
+#: id:33077
+msgid "No data found!"
+msgstr ""
+
+#: id:33078
+msgid "Next page"
+msgstr ""
+
+#: id:33079
+msgid "Love"
+msgstr ""
+
+#: id:33080
+msgid "Hate"
+msgstr ""
+
+#: id:33081
+msgid "This file is stacked, select the part you want to play from."
+msgstr ""
+
+#: id:33082
+msgid "Path to script"
+msgstr ""
+
+#: id:33083
+msgid "Enable custom script button"
+msgstr ""
+
+#: id:33100
+msgid "Failed to start"
+msgstr ""
+
+#: id:33101
+msgid "Webserver"
+msgstr ""
+
+#: id:33102
+msgid "Event Server"
+msgstr ""
+
+#: id:33103
+msgid "Remote communication server"
+msgstr ""
+
+#: id:33200
+msgid "Detected New Connection"
+msgstr ""
+
+#: id:34000
+msgid "Lame"
+msgstr ""
+
+#: id:34001
+msgid "Vorbis"
+msgstr ""
+
+#: id:34002
+msgid "Wav"
+msgstr ""
+
+#: id:34003
+msgid "DXVA2"
+msgstr ""
+
+#: id:34004
+msgid "VAAPI"
+msgstr ""
+
+#: id:34005
+msgid "Flac"
+msgstr ""
+
+#: id:34100
+msgid "Speaker Configuration"
+msgstr ""
+
+#: id:34101
+msgid "2.0"
+msgstr ""
+
+#: id:34102
+msgid "2.1"
+msgstr ""
+
+#: id:34103
+msgid "3.0"
+msgstr ""
+
+#: id:34104
+msgid "3.1"
+msgstr ""
+
+#: id:34105
+msgid "4.0"
+msgstr ""
+
+#: id:34106
+msgid "4.1"
+msgstr ""
+
+#: id:34107
+msgid "5.0"
+msgstr ""
+
+#: id:34108
+msgid "5.1"
+msgstr ""
+
+#: id:34109
+msgid "7.0"
+msgstr ""
+
+#: id:34110
+msgid "7.1"
+msgstr ""
+
+#: id:34201
+msgid "Can't find a next item to play"
+msgstr ""
+
+#: id:34202
+msgid "Can't find a previous item to play"
+msgstr ""
+
+#: id:34300
+msgid "Failed to start zeroconf"
+msgstr ""
+
+#: id:34301
+msgid "Is Apple's Bonjour Service installed? See log for more info."
+msgstr ""
+
+#: id:34400
+msgid "Video Rendering"
+msgstr ""
+
+#: id:34401
+msgid "Failed to init video filters/scalers, falling back to bilinear scaling"
+msgstr ""
+
+#: id:34402
+msgid "Failed to initialize audio device"
+msgstr ""
+
+#: id:34403
+msgid "Check your audiosettings"
+msgstr ""
+
+#: id:34404
+msgid "Use gestures for navigation:"
+msgstr ""
+
+#: id:34405
+msgid "1 finger swipe left,right,up,down for cursors"
+msgstr ""
+
+#: id:34406
+msgid "2 finger swipe left for backspace"
+msgstr ""
+
+#: id:34407
+msgid "1 finger single tap for enter"
+msgstr ""
+
+#: id:34408
+msgid "2 finger single tap for contextmenu"
+msgstr ""
+
+#: id:35000
+msgid "Peripherals"
+msgstr ""
+
+#: id:35001
+msgid "Generic HID device"
+msgstr ""
+
+#: id:35002
+msgid "Generic network adapter"
+msgstr ""
+
+#: id:35003
+msgid "Generic disk"
+msgstr ""
+
+#: id:35004
+msgid "There are no settings available\nfor this peripheral."
+msgstr ""
+
+#: id:35005
+msgid "New device configured"
+msgstr ""
+
+#: id:35006
+msgid "Device removed"
+msgstr ""
+
+#: id:35007
+msgid "Keymap to use for this device"
+msgstr ""
+
+#: id:35008
+msgid "Keymap enabled"
+msgstr ""
+
+#: id:35009
+msgid "Do not use the custom keymap for this device"
+msgstr ""
+
+#: id:35500
+msgid "Location"
+msgstr ""
+
+#: id:35501
+msgid "Class"
+msgstr ""
+
+#: id:35502
+msgctxt "Auto context with id 35502"
+msgid "Name"
+msgstr ""
+
+#: id:35503
+msgid "Vendor"
+msgstr ""
+
+#: id:35504
+msgid "Product ID"
+msgstr ""
+
+#: id:36000
+msgid "Pulse-Eight CEC adapter"
+msgstr ""
+
+#: id:36001
+msgid "Pulse-Eight Nyxboard"
+msgstr ""
+
+#: id:36002
+msgid "Switch to keyboard side command"
+msgstr ""
+
+#: id:36003
+msgid "Switch to remote side command"
+msgstr ""
+
+#: id:36004
+msgid "Press \"user\" button command"
+msgstr ""
+
+#: id:36005
+msgid "Enable switch side commands"
+msgstr ""
+
+#: id:36006
+msgid "Could not open the adapter"
+msgstr ""
+
+#: id:36007
+msgid "Devices to power on when starting XBMC"
+msgstr ""
+
+#: id:36008
+msgid "Devices to power off when stopping XBMC"
+msgstr ""
+
+#: id:36009
+msgid "Put devices in standby mode when activating screensaver"
+msgstr ""
+
+#: id:36011
+msgid "Could not detect the CEC port. Set it up manually."
+msgstr ""
+
+#: id:36012
+msgid "Could not initialise the CEC adapter. Check your settings."
+msgstr ""
+
+#: id:36013
+msgid "Unsupported libCEC interface version. %d is greater than the version XBMC supports (%d)"
+msgstr ""
+
+#: id:36014
+msgid "Put this PC in standby mode when the TV is switched off"
+msgstr ""
+
+#: id:36015
+msgid "HDMI port number"
+msgstr ""
+
+#: id:36016
+msgctxt "Auto context with id 36016"
+msgid "Connected"
+msgstr ""
+
+#: id:36017
+msgid "Adapter found, but libCEC is not available"
+msgstr ""
+
+#: id:36018
+msgid "Use the TV's language setting"
+msgstr ""
+
+#: id:36019
+msgid "Connected to HDMI device"
+msgstr ""
+
+#: id:36020
+msgid "Make XBMC the active source when starting"
+msgstr ""
+
+#: id:36021
+msgid "Physical address (overrules HDMI port)"
+msgstr ""
+
+#: id:36022
+msgid "COM port (leave empty unless needed)"
+msgstr ""
+
+#: id:36023
+msgid "Configuration updated"
+msgstr ""
+
+#: id:36024
+msgid "Failed to set the new configuration. Please check your settings."
+msgstr ""
+
+#: id:36025
+msgid "Send 'inactive source' command when stopping XBMC"
+msgstr ""
+

--- a/language/Norwegian/strings.po
+++ b/language/Norwegian/strings.po
@@ -1,0 +1,9093 @@
+# Converted from xbmc strings.xml with xbmc-xml2po (by Team-XBMC)
+msgid ""
+msgstr ""
+"Project-Id-Version: xbmc.core-FRODO_GIT3ed1604ad7\n"
+"Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
+"POT-Creation-Date: 2012-04-09 18:00+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE\n"
+"Language: no\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: id:0
+msgctxt "Auto context with id 0"
+msgid "Programs"
+msgstr "Programmer"
+
+#: id:1
+msgctxt "Auto context with id 1"
+msgid "Pictures"
+msgstr "Bilder"
+
+#: id:2
+msgctxt "Auto context with id 2"
+msgid "Music"
+msgstr "Musikk"
+
+#: id:3
+msgctxt "Auto context with id 3"
+msgid "Videos"
+msgstr "Videoer"
+
+#: id:4
+msgid "TV-Guide"
+msgstr "TV-guide"
+
+#: id:5
+msgctxt "Auto context with id 5"
+msgid "Settings"
+msgstr "Innstillinger"
+
+#: id:6
+msgid "XBMC SVN"
+msgstr "XBMC SVN"
+
+#: id:7
+msgctxt "Auto context with id 7"
+msgid "File manager"
+msgstr "Filbehandler"
+
+#: id:8
+msgctxt "Auto context with id 8"
+msgid "Weather"
+msgstr "Vær"
+
+#: id:9
+msgid "xbmc media center"
+msgstr "xbmc media center"
+
+#: id:11
+msgid "Monday"
+msgstr "Mandag"
+
+#: id:12
+msgid "Tuesday"
+msgstr "Tirsdag"
+
+#: id:13
+msgid "Wednesday"
+msgstr "Onsdag"
+
+#: id:14
+msgid "Thursday"
+msgstr "Torsdag"
+
+#: id:15
+msgid "Friday"
+msgstr "Fredag"
+
+#: id:16
+msgid "Saturday"
+msgstr "Lørdag"
+
+#: id:17
+msgid "Sunday"
+msgstr "Søndag"
+
+#: id:21
+msgid "January"
+msgstr "januar"
+
+#: id:22
+msgid "February"
+msgstr "februar"
+
+#: id:23
+msgid "March"
+msgstr "mars"
+
+#: id:24
+msgid "April"
+msgstr "april"
+
+#: id:25
+msgctxt "Auto context with id 25"
+msgid "May"
+msgstr "mai"
+
+#: id:26
+msgid "June"
+msgstr "juni"
+
+#: id:27
+msgid "July"
+msgstr "juli"
+
+#: id:28
+msgid "August"
+msgstr "august"
+
+#: id:29
+msgid "September"
+msgstr "september"
+
+#: id:30
+msgid "October"
+msgstr "oktober"
+
+#: id:31
+msgid "November"
+msgstr "november"
+
+#: id:32
+msgid "December"
+msgstr "desember"
+
+#: id:41
+msgid "Mon"
+msgstr "Man"
+
+#: id:42
+msgid "Tue"
+msgstr "Tir"
+
+#: id:43
+msgid "Wed"
+msgstr "Ons"
+
+#: id:44
+msgid "Thu"
+msgstr "Tor"
+
+#: id:45
+msgid "Fri"
+msgstr "Fre"
+
+#: id:46
+msgid "Sat"
+msgstr "Lør"
+
+#: id:47
+msgctxt "Auto context with id 47"
+msgid "Sun"
+msgstr "Søn"
+
+#: id:51
+msgid "Jan"
+msgstr "Jan"
+
+#: id:52
+msgid "Feb"
+msgstr "Feb"
+
+#: id:53
+msgid "Mar"
+msgstr "Mar"
+
+#: id:54
+msgid "Apr"
+msgstr "Apr"
+
+#: id:55
+msgctxt "Auto context with id 55"
+msgid "May"
+msgstr "Mai"
+
+#: id:56
+msgid "Jun"
+msgstr "Jun"
+
+#: id:57
+msgid "Jul"
+msgstr "Jul"
+
+#: id:58
+msgid "Aug"
+msgstr "Aug"
+
+#: id:59
+msgid "Sep"
+msgstr "Sep"
+
+#: id:60
+msgid "Oct"
+msgstr "Okt"
+
+#: id:61
+msgid "Nov"
+msgstr "Nov"
+
+#: id:62
+msgid "Dec"
+msgstr "Des"
+
+#: id:71
+msgid "N"
+msgstr "N"
+
+#: id:72
+msgid "NNE"
+msgstr "NNØ"
+
+#: id:73
+msgid "NE"
+msgstr "NØ"
+
+#: id:74
+msgid "ENE"
+msgstr "ØNØ"
+
+#: id:75
+msgid "E"
+msgstr "Ø"
+
+#: id:76
+msgid "ESE"
+msgstr "ØSØ"
+
+#: id:77
+msgid "SE"
+msgstr "SØ"
+
+#: id:78
+msgid "SSE"
+msgstr "SSØ"
+
+#: id:79
+msgid "S"
+msgstr "S"
+
+#: id:80
+msgid "SSW"
+msgstr "SSV"
+
+#: id:81
+msgid "SW"
+msgstr "SV"
+
+#: id:82
+msgid "WSW"
+msgstr "VSV"
+
+#: id:83
+msgid "W"
+msgstr "V"
+
+#: id:84
+msgid "WNW"
+msgstr "VNV"
+
+#: id:85
+msgid "NW"
+msgstr "NV"
+
+#: id:86
+msgid "NNW"
+msgstr "NNV"
+
+#: id:87
+msgid "VAR"
+msgstr "VAR"
+
+#: id:98
+msgid "View: Auto"
+msgstr "Visning: Auto"
+
+#: id:99
+msgid "View: Auto big"
+msgstr "Visning: Auto stor"
+
+#: id:100
+msgid "View: Icons"
+msgstr "Visning: Ikoner"
+
+#: id:101
+msgid "View: List"
+msgstr "Visning: Liste"
+
+#: id:102
+msgctxt "Auto context with id 102"
+msgid "Scan"
+msgstr "Skann"
+
+#: id:103
+msgctxt "Auto context with id 103"
+msgid "Sort by: Name"
+msgstr "Sorter etter: Navn"
+
+#: id:104
+msgid "Sort by: Date"
+msgstr "Sorter etter: Dato"
+
+#: id:105
+msgid "Sort by: Size"
+msgstr "Sorter etter: Størr."
+
+#: id:106
+msgid "No"
+msgstr "Nei"
+
+#: id:107
+msgid "Yes"
+msgstr "Ja"
+
+#: id:108
+msgctxt "Auto context with id 108"
+msgid "Slideshow"
+msgstr "Bildefremvisning"
+
+#: id:109
+msgid "Create thumbs"
+msgstr "Lag miniatyrer"
+
+#: id:110
+msgid "Create thumbnails"
+msgstr "Lag miniatyrbilder"
+
+#: id:111
+msgctxt "Auto context with id 111"
+msgid "Shortcuts"
+msgstr "Snarveier"
+
+#: id:112
+msgid "Paused"
+msgstr "Pause"
+
+#: id:113
+msgid "Update failed"
+msgstr "Oppdatering feilet"
+
+#: id:114
+msgid "Installation failed"
+msgstr "Installering feilet"
+
+#: id:115
+msgid "Copy"
+msgstr "Kopier"
+
+#: id:116
+msgid "Move"
+msgstr "Flytt"
+
+#: id:117
+msgid "Delete"
+msgstr "Slett"
+
+#: id:118
+msgid "Rename"
+msgstr "Nytt navn"
+
+#: id:119
+msgid "New folder"
+msgstr "Ny mappe"
+
+#: id:120
+msgid "Confirm file copy"
+msgstr "Bekreft kopiering"
+
+#: id:121
+msgid "Confirm file move"
+msgstr "Bekreft flytting"
+
+#: id:122
+msgid "Confirm file delete?"
+msgstr "Bekrefte sletting av fil?"
+
+#: id:123
+msgid "Copy these files?"
+msgstr "Kopier disse filene?"
+
+#: id:124
+msgid "Move these files?"
+msgstr "Flytt disse filene?"
+
+#: id:125
+msgid "Delete these files? - Deleting files cannot be undone!"
+msgstr "Slett disse filene? Dette kan ikke angres."
+
+#: id:126
+msgid "Status"
+msgstr "Status"
+
+#: id:127
+msgid "Objects"
+msgstr "objekter"
+
+#: id:128
+msgctxt "Auto context with id 128"
+msgid "General"
+msgstr "Generelt"
+
+#: id:129
+msgctxt "Auto context with id 129"
+msgid "Slideshow"
+msgstr "Bildefremvisning"
+
+#: id:130
+msgctxt "Auto context with id 130"
+msgid "System info"
+msgstr "Systeminformasjon"
+
+#: id:131
+msgid "Display"
+msgstr "Skjerm"
+
+#: id:132
+msgid "Albums"
+msgstr "Album"
+
+#: id:133
+msgid "Artists"
+msgstr "Artister"
+
+#: id:134
+msgid "Songs"
+msgstr "Sanger"
+
+#: id:135
+msgid "Genres"
+msgstr "Sjanger"
+
+#: id:136
+msgid "Playlists"
+msgstr "Spillelister"
+
+#: id:137
+msgid "Search"
+msgstr "Søk"
+
+#: id:138
+msgid "System Information"
+msgstr "Systeminformasjon"
+
+#: id:139
+msgid "Temperatures:"
+msgstr "Temperaturer:"
+
+#: id:140
+msgid "CPU:"
+msgstr "CPU:"
+
+#: id:141
+msgid "GPU:"
+msgstr "GPU:"
+
+#: id:142
+msgid "Time:"
+msgstr "Tid:"
+
+#: id:143
+msgid "Current:"
+msgstr "Nå:"
+
+#: id:144
+msgid "Build:"
+msgstr "Byggeversjon:"
+
+#: id:145
+msgid "Network:"
+msgstr "Nettverk:"
+
+#: id:146
+msgid "Type:"
+msgstr "Type:"
+
+#: id:147
+msgid "Static"
+msgstr "Statisk"
+
+#: id:148
+msgid "DHCP"
+msgstr "DHCP"
+
+#: id:149
+msgid "MAC address"
+msgstr "MAC-adresse"
+
+#: id:150
+msgctxt "Auto context with id 150"
+msgid "IP address"
+msgstr "IP-adresse"
+
+#: id:151
+msgid "Link:"
+msgstr "Forbindelse:"
+
+#: id:152
+msgid "Half duplex"
+msgstr "Halv dupleks"
+
+#: id:153
+msgid "Full duplex"
+msgstr "Full dupleks"
+
+#: id:154
+msgctxt "Auto context with id 154"
+msgid "Storage"
+msgstr "Lagring"
+
+#: id:155
+msgid "Drive"
+msgstr "Stasjon"
+
+#: id:156
+msgctxt "Auto context with id 156"
+msgid "Free"
+msgstr "Ledig"
+
+#: id:157
+msgctxt "Auto context with id 157"
+msgid "Video"
+msgstr "Video"
+
+#: id:158
+msgid "Free memory"
+msgstr "Ledig minne"
+
+#: id:159
+msgid "No link"
+msgstr "Ingen forbindelse"
+
+#: id:160
+msgctxt "Auto context with id 160"
+msgid "Free"
+msgstr "Ledig"
+
+#: id:161
+msgid "Unavailable"
+msgstr "Utilgjengelig"
+
+#: id:162
+msgid "Tray open"
+msgstr "Skuff åpen"
+
+#: id:163
+msgid "Reading"
+msgstr "Leser"
+
+#: id:164
+msgid "No disc"
+msgstr "Ingen disk"
+
+#: id:165
+msgid "Disc present"
+msgstr "Disk tilstede"
+
+#: id:166
+msgid "Skin"
+msgstr "Skinn"
+
+#: id:169
+msgctxt "Auto context with id 169"
+msgid "Resolution"
+msgstr "Oppløsning"
+
+#: id:170
+msgid "Adjust display refresh rate to match video"
+msgstr "Sett oppdateringsfrekvens til å samsvare med video"
+
+#: id:172
+msgid "Release date"
+msgstr "Utgitt"
+
+#: id:173
+msgid "Display 4:3 videos as"
+msgstr "Vis 4:3-videoer som"
+
+#: id:175
+msgid "Moods"
+msgstr "Stemninger"
+
+#: id:176
+msgid "Styles"
+msgstr "Stiler"
+
+#: id:179
+msgid "Song"
+msgstr "Sang"
+
+#: id:180
+msgid "Duration"
+msgstr "Lengde"
+
+#: id:181
+msgid "Select album"
+msgstr "Velg album"
+
+#: id:182
+msgid "Tracks"
+msgstr "Spor"
+
+#: id:183
+msgid "Review"
+msgstr "Anmeldelse"
+
+#: id:184
+msgid "Refresh"
+msgstr "Oppdater"
+
+#: id:185
+msgid "Searching album"
+msgstr "Søker i album"
+
+#: id:186
+msgid "OK"
+msgstr "OK"
+
+#: id:187
+msgid "No albums found!"
+msgstr "Ingen album funnet!"
+
+#: id:188
+msgid "Select all"
+msgstr "Merk alt"
+
+#: id:189
+msgid "Scanning media info"
+msgstr "Skanner mediainformasjon"
+
+#: id:190
+msgid "Save"
+msgstr "Lagre"
+
+#: id:191
+msgid "Shuffle"
+msgstr "Bland"
+
+#: id:192
+msgctxt "Auto context with id 192"
+msgid "Clear"
+msgstr "Fjern"
+
+#: id:193
+msgctxt "Auto context with id 193"
+msgid "Scan"
+msgstr "Skann"
+
+#: id:194
+msgid "Searching..."
+msgstr "Søker..."
+
+#: id:195
+msgid "No info found!"
+msgstr "Ingen informasjon funnet!"
+
+#: id:196
+msgid "Select movie:"
+msgstr "Velg film:"
+
+#: id:197
+msgid "Querying %s info"
+msgstr "Spør etter %s informasjon"
+
+#: id:198
+msgid "Loading movie details"
+msgstr "Laster filmdetaljer"
+
+#: id:199
+msgid "Web interface"
+msgstr "Webgrensesnitt"
+
+#: id:202
+msgid "Tagline"
+msgstr "Slagord"
+
+#: id:203
+msgid "Plot outline"
+msgstr "Handling"
+
+#: id:205
+msgid "Votes"
+msgstr "Stemmer"
+
+#: id:206
+msgid "Cast"
+msgstr "Skuesp."
+
+#: id:207
+msgid "Plot"
+msgstr "Plott"
+
+#: id:208
+msgctxt "Auto context with id 208"
+msgid "Play"
+msgstr "Spill"
+
+#: id:209
+msgid "Next"
+msgstr "Neste"
+
+#: id:210
+msgid "Previous"
+msgstr "Forrige"
+
+#: id:213
+msgid "Calibrate user interface..."
+msgstr "Kalibrer grensesnitt..."
+
+#: id:214
+msgid "Video calibration..."
+msgstr "Kalibrer bilde..."
+
+#: id:215
+msgid "Soften"
+msgstr "Gjør mykere"
+
+#: id:216
+msgid "Zoom amount"
+msgstr "Zoom"
+
+#: id:217
+msgid "Pixel ratio"
+msgstr "Pikselforhold"
+
+#: id:218
+msgid "DVD drive"
+msgstr "DVD-stasjon"
+
+#: id:219
+msgid "Please insert disc"
+msgstr "Vennligst sett inn plate"
+
+#: id:220
+msgid "Remote share"
+msgstr "Nettverksstasjon"
+
+#: id:221
+msgid "Network is not connected"
+msgstr "Ingen nettverkstilkobling"
+
+#: id:222
+msgid "Cancel"
+msgstr "Avbryt"
+
+#: id:224
+msgid "Speed"
+msgstr "Hastighet"
+
+#: id:225
+msgid "Vertical Shift"
+msgstr "Vertikalt skift"
+
+#: id:226
+msgid "Test patterns..."
+msgstr "Testbilder..."
+
+#: id:227
+msgid "Lookup audio CD track names from freedb.org"
+msgstr "Hent CD-informasjon fra freedb.org"
+
+#: id:228
+msgid "Shuffle playlist on load"
+msgstr "Bland spillelisten ved lasting"
+
+#: id:229
+msgid "HDD spindown time"
+msgstr "Tid før harddisk spinner ned (min)"
+
+#: id:230
+msgid "Video filters"
+msgstr "Videofiltre"
+
+#: id:231
+msgctxt "Auto context with id 231"
+msgid "None"
+msgstr "Ingen"
+
+#: id:232
+msgid "Point"
+msgstr "Punkt"
+
+#: id:233
+msgid "Linear"
+msgstr "Lineært"
+
+#: id:234
+msgid "Anisotropic"
+msgstr "Anisotropisk"
+
+#: id:235
+msgid "Quincunx"
+msgstr "Quincunx"
+
+#: id:236
+msgid "Gaussian cubic"
+msgstr "Gaussisk kubisk"
+
+#: id:237
+msgid "Minification"
+msgstr "Forminsking"
+
+#: id:238
+msgid "Magnification"
+msgstr "Forstørring"
+
+#: id:239
+msgid "Clear playlist on finish"
+msgstr "Tøm spilleliste når ferdigspilt"
+
+#: id:240
+msgid "Display Mode"
+msgstr "Visningsmodus"
+
+#: id:241
+msgid "Full Screen #%d"
+msgstr "Fullskjerm #%d"
+
+#: id:242
+msgid "Windowed"
+msgstr "Vindu"
+
+#: id:243
+msgid "Refresh Rate"
+msgstr "Oppdateringsfrekvens"
+
+#: id:244
+msgid "Full screen"
+msgstr "Fullskjerm"
+
+#: id:245
+msgid "Sizing: (%i,%i)->(%i,%i) (Zoom x%2.2f) AR:%2.2f:1 (Pixels: %2.2f:1) (VShift: %2.2f)"
+msgstr "Skalering: (%i,%i)->(%i,%i) (Zoom x%2.2f) AR:%2.2f:1 (Piksler: %2.2f:1) (Vskift: %2.2f)"
+
+#: id:247
+msgctxt "Auto context with id 247"
+msgid "Scripts"
+msgstr "Skript"
+
+#: id:248
+msgctxt "Auto context with id 248"
+msgid "Language"
+msgstr "Språk"
+
+#: id:249
+msgctxt "Auto context with id 249"
+msgid "Music"
+msgstr "Musikk"
+
+#: id:250
+msgctxt "Auto context with id 250"
+msgid "Visualization"
+msgstr "Visualisering"
+
+#: id:251
+msgid "Select destination directory"
+msgstr "Velg destinasjonsmappe"
+
+#: id:252
+msgid "Output stereo to all speakers"
+msgstr "Send stereolyd til alle høyttalere"
+
+#: id:253
+msgid "Number of channels"
+msgstr "Antall kanaler"
+
+#: id:254
+msgid "- DTS capable receiver"
+msgstr "- Forsterker med DTS"
+
+#: id:255
+msgid "CDDB"
+msgstr "CDDB"
+
+#: id:256
+msgid "Fetching CD information"
+msgstr "Henter CD-informasjon"
+
+#: id:257
+msgid "Error"
+msgstr "Feil"
+
+#: id:258
+msgid "Enable tag reading"
+msgstr "Aktiver tagginformasjon"
+
+#: id:259
+msgid "Opening"
+msgstr "Åpner"
+
+#: id:260
+msgid "Shoutcast"
+msgstr "Internettradio"
+
+#: id:261
+msgid "Waiting for start..."
+msgstr "Venter på oppstart...."
+
+#: id:262
+msgid "Scripts output"
+msgstr "Utskrift fra skript"
+
+#: id:263
+msgid "Allow control of XBMC via HTTP"
+msgstr "Tillat å styre XBMC via HTTP"
+
+#: id:264
+msgid "Record"
+msgstr "Opptak"
+
+#: id:265
+msgid "Stop Rec."
+msgstr "Stopp opptak"
+
+#: id:266
+msgid "Sort by: Track"
+msgstr "Sorter etter: Spor"
+
+#: id:267
+msgid "Sort by: Time"
+msgstr "Sorter etter: Tid"
+
+#: id:268
+msgid "Sort by: Title"
+msgstr "Sorter etter: Tittel"
+
+#: id:269
+msgid "Sort by: Artist"
+msgstr "Sorter etter: Artist"
+
+#: id:270
+msgid "Sort by: Album"
+msgstr "Sorter etter: Album"
+
+#: id:271
+msgid "Top 100"
+msgstr "Topp 100"
+
+#: id:272
+msgid "Top-Left overscan compensation"
+msgstr "Venstre hjørne oppe"
+
+#: id:273
+msgid "Bottom-Right overscan compensation"
+msgstr "Høyre hjørne nede"
+
+#: id:274
+msgid "Subtitle positioning"
+msgstr "Plassering av undertekst"
+
+#: id:275
+msgid "Pixel ratio adjustment"
+msgstr "Justering av pikselforhold"
+
+#: id:276
+msgid "Adjust the arrow to change the amount of overscan"
+msgstr "Juster pilen for å endre overskanning"
+
+#: id:277
+msgid "Adjust the bar to change the subtitles position"
+msgstr "Juster linjen for å endre plassering av undertekster"
+
+#: id:278
+msgid "Adjust the rectangle so it is perfectly square"
+msgstr "Juster firkanten til den blir helt kvadratisk"
+
+#: id:279
+msgid "Unable to load settings"
+msgstr "Kunne ikke laste innstillinger"
+
+#: id:280
+msgid "Using default settings"
+msgstr "Bruker standardinnstillinger"
+
+#: id:281
+msgid "Please check the XML files"
+msgstr "Vennligst sjekk XML-filene"
+
+#: id:282
+msgid "Found %i items"
+msgstr "Fant %i treff"
+
+#: id:283
+msgid "Search results"
+msgstr "Søkeresultater"
+
+#: id:284
+msgid "No results found"
+msgstr "Ingen resultater funnet"
+
+#: id:287
+msgctxt "Auto context with id 287"
+msgid "Subtitles"
+msgstr "Undertekster"
+
+#: id:288
+msgctxt "Auto context with id 288"
+msgid "Font"
+msgstr "Font"
+
+#: id:289
+msgctxt "Auto context with id 289"
+msgid "- Size"
+msgstr "- Størrelse"
+
+#: id:290
+msgid "Dynamic range compression"
+msgstr "Volumutjevning (DNR)"
+
+#: id:291
+msgctxt "Auto context with id 291"
+msgid "Video"
+msgstr "Video"
+
+#: id:292
+msgctxt "Auto context with id 292"
+msgid "Audio"
+msgstr "Lyd"
+
+#: id:293
+msgid "Browse for subtitles"
+msgstr "Bla etter undertekster"
+
+#: id:294
+msgid "Create bookmark"
+msgstr "Lag bokmerke"
+
+#: id:296
+msgid "Clear bookmarks"
+msgstr "Slett bokmerker"
+
+#: id:297
+msgid "Audio offset"
+msgstr "Lydforsinkelse"
+
+#: id:298
+msgid "Bookmarks"
+msgstr "Bokmerker"
+
+#: id:299
+msgid "- AAC capable receiver"
+msgstr "- Forsterker kan håndtere AAC"
+
+#: id:300
+msgid "- MP1 capable receiver"
+msgstr "- Forsterker kan håndtere MP1"
+
+#: id:301
+msgid "- MP2 capable receiver"
+msgstr "- Forsterker kan håndtere MP2"
+
+#: id:302
+msgid "- MP3 capable receiver"
+msgstr "- Forsterker kan håndtere MP3"
+
+#: id:303
+msgid "Delay"
+msgstr "Forsinkelse"
+
+#: id:304
+msgctxt "Auto context with id 304"
+msgid "Language"
+msgstr "Språk"
+
+#: id:305
+msgctxt "Auto context with id 305"
+msgid "Enabled"
+msgstr "Aktivert"
+
+#: id:306
+msgid "Non-interleaved"
+msgstr "Ikke-innfelt"
+
+#: id:312
+msgid "(0=auto)"
+msgstr "(0=auto)"
+
+#: id:313
+msgid "Cleaning database"
+msgstr "Renser database"
+
+#: id:314
+msgid "Preparing..."
+msgstr "Forbereder..."
+
+#: id:315
+msgid "Database error"
+msgstr "Databasefeil"
+
+#: id:316
+msgid "Searching songs..."
+msgstr "Søker i sanger..."
+
+#: id:317
+msgid "Cleaned database successfully"
+msgstr "Opprensking av database fullført"
+
+#: id:318
+msgid "Cleaning songs..."
+msgstr "Renser opp i sanger"
+
+#: id:319
+msgid "Error cleaning songs"
+msgstr "Feil ved rensing av sanger"
+
+#: id:320
+msgid "Cleaning artists..."
+msgstr "Renser opp i artister"
+
+#: id:321
+msgid "Error cleaning artists"
+msgstr "Feil ved rensing av artister"
+
+#: id:322
+msgid "Cleaning genres..."
+msgstr "Renser opp i sjangre"
+
+#: id:323
+msgid "Error cleaning genres"
+msgstr "Feil ved rensing av sjangre"
+
+#: id:324
+msgid "Cleaning paths..."
+msgstr "Renser opp i filstier"
+
+#: id:325
+msgid "Error cleaning paths"
+msgstr "Feil ved rensing av filstier"
+
+#: id:326
+msgid "Cleaning albums..."
+msgstr "Renser opp i album"
+
+#: id:327
+msgid "Error cleaning albums"
+msgstr "Feil ved rensing av album"
+
+#: id:328
+msgid "Writing changes..."
+msgstr "Skriver endringer..."
+
+#: id:329
+msgid "Error writing changes"
+msgstr "Feil under skriving"
+
+#: id:330
+msgid "This may take some time..."
+msgstr "Dette kan ta en stund..."
+
+#: id:331
+msgid "Compressing database..."
+msgstr "Komprimerer database..."
+
+#: id:332
+msgid "Error compressing database"
+msgstr "Feil under komprimering av database"
+
+#: id:333
+msgid "Do you want to clean the library?"
+msgstr "Vil du rense biblioteket?"
+
+#: id:334
+msgid "Clean library..."
+msgstr "Rens biblioteket"
+
+#: id:335
+msgid "Start"
+msgstr "Start"
+
+#: id:336
+msgid "Framerate conversion"
+msgstr "Konverter bildefrekvens"
+
+#: id:337
+msgctxt "Auto context with id 337"
+msgid "Audio output"
+msgstr "Lydutgang"
+
+#: id:338
+msgid "Analog"
+msgstr "Analog"
+
+#: id:339
+msgid "Optical/Coax"
+msgstr "Optisk/koaks"
+
+#: id:340
+msgid "Various artists"
+msgstr "Diverse artister"
+
+#: id:341
+msgid "Play disc"
+msgstr "Spill plate"
+
+#: id:342
+msgctxt "Auto context with id 342"
+msgid "Movies"
+msgstr "Filmer"
+
+#: id:343
+msgid "Adjust framerate"
+msgstr "Juster bildehastighet"
+
+#: id:344
+msgid "Actors"
+msgstr "Skuespillere"
+
+#: id:345
+msgctxt "Auto context with id 345"
+msgid "Year"
+msgstr "År"
+
+#: id:346
+msgid "Boost volume level on downmix"
+msgstr "Øk volumet ved nedmiks"
+
+#: id:350
+msgctxt "Auto context with id 350"
+msgid "Programs"
+msgstr "Programmer"
+
+#: id:351
+msgctxt "Auto context with id 351"
+msgid "Off"
+msgstr "Av"
+
+#: id:352
+msgid "Dim"
+msgstr "Dimme"
+
+#: id:353
+msgid "Black"
+msgstr "Svart"
+
+#: id:354
+msgid "Matrix trails"
+msgstr "Matrise"
+
+#: id:355
+msgid "Screensaver time"
+msgstr "Aktiver skjermbeskytter etter"
+
+#: id:356
+msgid "Screensaver mode"
+msgstr "Skjermbeskyttermodus"
+
+#: id:357
+msgid "Shutdown function timer"
+msgstr "Skru av automatisk etter"
+
+#: id:358
+msgid "All albums"
+msgstr "Alle album"
+
+#: id:359
+msgid "Recently added albums"
+msgstr "Album nylig lagt til"
+
+#: id:360
+msgctxt "Auto context with id 360"
+msgid "Screensaver"
+msgstr "Skjermbeskytter"
+
+#: id:361
+msgid "R. Slideshow"
+msgstr "Bildefremvisning"
+
+#: id:362
+msgid "Screensaver dim level"
+msgstr "Uttoningsnivå på skjermbeskytter (%)"
+
+#: id:363
+msgid "Sort by: File"
+msgstr "Sorter etter: Fil"
+
+#: id:364
+msgid "- Dolby Digital (AC3) capable receiver"
+msgstr "- Forsterker med Dolby Digital (AC3)"
+
+#: id:365
+msgctxt "Auto context with id 365"
+msgid "Sort by: Name"
+msgstr "Sorter etter: Navn"
+
+#: id:366
+msgid "Sort by: Year"
+msgstr "Sorter etter: År"
+
+#: id:367
+msgid "Sort by: Rating"
+msgstr "Sorter etter: Vurdering"
+
+#: id:368
+msgid "IMDb"
+msgstr "IMDb"
+
+#: id:369
+msgctxt "Auto context with id 369"
+msgid "Title"
+msgstr "Tittel"
+
+#: id:370
+msgid "Thunderstorms"
+msgstr "lyn og torden"
+
+#: id:371
+msgid "Partly"
+msgstr "delvis"
+
+#: id:372
+msgid "Mostly"
+msgstr "stort sett"
+
+#: id:373
+msgid "Sunny"
+msgstr "sol"
+
+#: id:374
+msgid "Cloudy"
+msgstr "skyet"
+
+#: id:375
+msgid "Snow"
+msgstr "snø"
+
+#: id:376
+msgid "Rain"
+msgstr "regn"
+
+#: id:377
+msgid "Light"
+msgstr "lett"
+
+#: id:378
+msgid "AM"
+msgstr "formiddag"
+
+#: id:379
+msgid "PM"
+msgstr "ettermiddag"
+
+#: id:380
+msgid "Showers"
+msgstr "byger"
+
+#: id:381
+msgid "Few"
+msgstr "få"
+
+#: id:382
+msgid "Scattered"
+msgstr "spredte"
+
+#: id:383
+msgctxt "Auto context with id 383"
+msgid "Wind"
+msgstr "vind"
+
+#: id:384
+msgid "Strong"
+msgstr "sterk"
+
+#: id:385
+msgid "Fair"
+msgstr "lettskyet"
+
+#: id:386
+msgctxt "Auto context with id 386"
+msgid "Clear"
+msgstr "klart"
+
+#: id:387
+msgid "Clouds"
+msgstr "skyer"
+
+#: id:388
+msgid "Early"
+msgstr "tidlig"
+
+#: id:389
+msgid "Shower"
+msgstr "byge"
+
+#: id:390
+msgid "Flurries"
+msgstr "snøbyger"
+
+#: id:391
+msgctxt "Auto context with id 391"
+msgid "Low"
+msgstr "Lav"
+
+#: id:392
+msgctxt "Auto context with id 392"
+msgid "Medium"
+msgstr "Middels"
+
+#: id:393
+msgctxt "Auto context with id 393"
+msgid "High"
+msgstr "Høy"
+
+#: id:394
+msgid "Fog"
+msgstr "Tåke"
+
+#: id:395
+msgid "Haze"
+msgstr "Dis"
+
+#: id:396
+msgid "Select location"
+msgstr "Velg sted"
+
+#: id:397
+msgid "Refresh time"
+msgstr "Oppdateringsintervall"
+
+#: id:398
+msgid "Temperature units"
+msgstr "Temperaturskala"
+
+#: id:399
+msgid "Speed units"
+msgstr "Hastighetskala"
+
+#: id:400
+msgctxt "Auto context with id 400"
+msgid "Weather"
+msgstr "Vær"
+
+#: id:401
+msgid "Temp"
+msgstr "Temperatur"
+
+#: id:402
+msgid "Feels like"
+msgstr "Føles som"
+
+#: id:403
+msgid "UV index"
+msgstr "UV-indeks"
+
+#: id:404
+msgctxt "Auto context with id 404"
+msgid "Wind"
+msgstr "Vind"
+
+#: id:405
+msgid "Dew point"
+msgstr "Duggpunkt"
+
+#: id:406
+msgid "Humidity"
+msgstr "Fuktighet"
+
+#: id:409
+msgid "Defaults"
+msgstr "Standard"
+
+#: id:410
+msgid "Accessing weather service"
+msgstr "Kobler til værtjeneste"
+
+#: id:411
+msgid "Getting weather for:"
+msgstr "Henter værdata for:"
+
+#: id:412
+msgid "Unable to get weather data"
+msgstr "Kunne ikke hente værdata"
+
+#: id:413
+msgid "Manual"
+msgstr "Manuelt"
+
+#: id:414
+msgid "No review for this album"
+msgstr "Ingen anmeldelse av dette albumet"
+
+#: id:415
+msgid "Downloading thumbnail..."
+msgstr "Laster ned miniatyrbilde..."
+
+#: id:416
+msgid "Not available"
+msgstr "Ikke tilgjengelig"
+
+#: id:417
+msgid "View: Big icons"
+msgstr "Viser: Store ikoner"
+
+#: id:418
+msgctxt "Auto context with id 418"
+msgid "Low"
+msgstr "Lav"
+
+#: id:419
+msgctxt "Auto context with id 419"
+msgid "High"
+msgstr "Høy"
+
+#: id:420
+msgid "HDMI"
+msgstr "HDMI"
+
+#: id:422
+msgid "Delete album info"
+msgstr "Slett albuminformasjon"
+
+#: id:423
+msgid "Delete CD information"
+msgstr "Slett CD-informasjon"
+
+#: id:424
+msgid "Select"
+msgstr "Velg"
+
+#: id:425
+msgid "No album information found"
+msgstr "Ingen albuminformasjon funnet."
+
+#: id:426
+msgid "No CD information found"
+msgstr "Ingen CD-informasjon funnet."
+
+#: id:427
+msgid "Disc"
+msgstr "Disk"
+
+#: id:428
+msgid "Insert correct CD/DVD"
+msgstr "Sett inn riktig CD/DVD"
+
+#: id:429
+msgid "Please insert the following disc:"
+msgstr "Vennligst sett i følgende CD/DVD"
+
+#: id:430
+msgid "Sort by: DVD#"
+msgstr "Sorter etter: DVD#"
+
+#: id:431
+msgid "No cache"
+msgstr "Ingen mellomlagring"
+
+#: id:432
+msgid "Remove movie from library"
+msgstr "Slett film fra bibliotek"
+
+#: id:433
+msgid "Really remove '%s'?"
+msgstr "Er du sikker på at du vil slette '%s'?"
+
+#: id:434
+msgid "From %s at %i %s"
+msgstr "Fra %s, %i %s"
+
+#: id:437
+msgid "Removable disk"
+msgstr "Flyttbar media"
+
+#: id:438
+msgid "Opening file"
+msgstr "Åpner filen"
+
+#: id:439
+msgid "Cache"
+msgstr "Mellomlagring"
+
+#: id:440
+msgid "Harddisk"
+msgstr "Harddisk"
+
+#: id:441
+msgid "UDF"
+msgstr "UDF"
+
+#: id:442
+msgid "Local network"
+msgstr "Lokalt nettverk"
+
+#: id:443
+msgid "Internet"
+msgstr "Internett"
+
+#: id:444
+msgctxt "Auto context with id 444"
+msgid "Video"
+msgstr "Film"
+
+#: id:445
+msgctxt "Auto context with id 445"
+msgid "Audio"
+msgstr "Lyd"
+
+#: id:446
+msgctxt "Auto context with id 446"
+msgid "DVD"
+msgstr "DVD"
+
+#: id:447
+msgid "Autorun media"
+msgstr "Autokjør"
+
+#: id:448
+msgid "LCD"
+msgstr "LCD"
+
+#: id:449
+msgctxt "Auto context with id 449"
+msgid "Enabled"
+msgstr "Aktivert"
+
+#: id:450
+msgid "Columns"
+msgstr "Kolonner"
+
+#: id:451
+msgid "Row 1 address"
+msgstr "Rad 1 adresse"
+
+#: id:452
+msgid "Row 2 address"
+msgstr "Rad 2 adresse"
+
+#: id:453
+msgid "Row 3 address"
+msgstr "Rad 3 adresse"
+
+#: id:454
+msgid "Row 4 address"
+msgstr "Rad 4 adresse"
+
+#: id:455
+msgid "Rows"
+msgstr "Rader"
+
+#: id:456
+msgid "Mode"
+msgstr "Modus"
+
+#: id:457
+msgid "Switch view"
+msgstr "Skift visning"
+
+#: id:459
+msgid "Subs"
+msgstr "Undertekster"
+
+#: id:460
+msgid "Audio stream"
+msgstr "Lydkilde"
+
+#: id:461
+msgid "[active]"
+msgstr "[aktiv]"
+
+#: id:462
+msgid "Subtitle"
+msgstr "Undertekst"
+
+#: id:463
+msgid "Backlight"
+msgstr "Bakgrunnslys"
+
+#: id:464
+msgid "Brightness"
+msgstr "Lysstyrke"
+
+#: id:465
+msgid "Contrast"
+msgstr "Kontrast"
+
+#: id:466
+msgid "Gamma"
+msgstr "Gamma"
+
+#: id:467
+msgctxt "Auto context with id 467"
+msgid "Type"
+msgstr "Type"
+
+#: id:468
+msgid "Move the bar to change the OSD position"
+msgstr "Flytt linjen for å endre OSD-plassering"
+
+#: id:469
+msgid "OSD position"
+msgstr "OSD-plassering"
+
+#: id:470
+msgid "Credits"
+msgstr "Anerkjennelser"
+
+#: id:471
+msgid "Modchip"
+msgstr "Modchip"
+
+#: id:474
+msgctxt "Auto context with id 474"
+msgid "Off"
+msgstr "Av"
+
+#: id:475
+msgid "Music only"
+msgstr "Bare musikk"
+
+#: id:476
+msgctxt "Auto context with id 476"
+msgid "Music & video"
+msgstr "Musikk og film"
+
+#: id:477
+msgid "Unable to load playlist"
+msgstr "Kan ikke laste spilleliste"
+
+#: id:478
+msgid "OSD"
+msgstr "OSD"
+
+#: id:479
+msgid "Skin & language"
+msgstr "Skinn og språk"
+
+#: id:480
+msgid "Appearance"
+msgstr "Utseende"
+
+#: id:481
+msgid "Audio options"
+msgstr "Lydinnstillinger"
+
+#: id:482
+msgid "About XBMC"
+msgstr "Om XBMC"
+
+#: id:485
+msgid "Delete album"
+msgstr "Slett album"
+
+#: id:486
+msgid "Repeat"
+msgstr "Gjenta"
+
+#: id:487
+msgid "Repeat one"
+msgstr "Gjenta én"
+
+#: id:488
+msgid "Repeat folder"
+msgstr "Gjenta mapper"
+
+#: id:489
+msgid "Play the next song automatically"
+msgstr "Spill automatisk av neste fil"
+
+#: id:491
+msgid "- Use big icons"
+msgstr "- Bruke store ikoner"
+
+#: id:492
+msgid "Resize VobSubs"
+msgstr "Endre størrelse på VobSub"
+
+#: id:493
+msgid "Advanced options (Experts Only!)"
+msgstr "Avanserte innstillinger (kun eksperter)"
+
+#: id:494
+msgid "Overall audio headroom"
+msgstr "Gjennomsnittlig headroom (dB)"
+
+#: id:495
+msgid "Upsample videos to GUI resolution"
+msgstr "Oppskaler film til grensesnittets oppløsning"
+
+#: id:496
+msgid "Calibration"
+msgstr "Kalibrering"
+
+#: id:497
+msgid "Show file extensions"
+msgstr "Skjul filtetternavn"
+
+#: id:498
+msgid "Sort by: Type"
+msgstr "Sorter etter: Type"
+
+#: id:499
+msgid "Unable to connect to online lookup service"
+msgstr "Kunne ikke koble til oppslagstjeneste"
+
+#: id:500
+msgid "Downloading album information failed"
+msgstr "Nedlasting av albuminformasjon mislyktes"
+
+#: id:501
+msgid "Looking for album names..."
+msgstr "Søker etter albumnavn..."
+
+#: id:502
+msgctxt "Auto context with id 502"
+msgid "Open"
+msgstr "Åpne"
+
+#: id:503
+msgid "Busy"
+msgstr "Opptatt"
+
+#: id:504
+msgid "Empty"
+msgstr "Tom"
+
+#: id:505
+msgid "Loading media info from files..."
+msgstr "Laster informasjon fra filer..."
+
+#: id:507
+msgid "Sort by: Usage"
+msgstr "Sorter etter: Bruk"
+
+#: id:510
+msgid "Enable visualizations"
+msgstr "Aktiver visualisering"
+
+#: id:511
+msgid "Enable video mode switching"
+msgstr "Muliggjør bytting av videoformat"
+
+#: id:512
+msgid "Startup window"
+msgstr "Oppstartsmeny"
+
+#: id:513
+msgid "Home window"
+msgstr "Hovedmeny"
+
+#: id:514
+msgid "Manual settings"
+msgstr "Manuelle innstillinger"
+
+#: id:515
+msgid "Genre"
+msgstr "Sjanger"
+
+#: id:517
+msgid "Recently played albums"
+msgstr "Nylig spilte album"
+
+#: id:518
+msgid "Launch"
+msgstr "Start"
+
+#: id:519
+msgid "Launch in..."
+msgstr "Start som.."
+
+#: id:521
+msgid "Compilations"
+msgstr "Samlinger"
+
+#: id:522
+msgid "Remove source"
+msgstr "Fjern kilde"
+
+#: id:523
+msgid "Switch media"
+msgstr "Bytt media"
+
+#: id:524
+msgid "Select playlist"
+msgstr "Velg spilleliste"
+
+#: id:525
+msgid "New playlist..."
+msgstr "Ny spilleliste"
+
+#: id:526
+msgid "Add to playlist"
+msgstr "Legg til i spilleliste"
+
+#: id:527
+msgid "Manually add to library"
+msgstr "Legg til i biblioteket manuelt"
+
+#: id:528
+msgid "Enter title"
+msgstr "Skriv inn tittel"
+
+#: id:529
+msgid "Error: Duplicate title"
+msgstr "Feil: Eksisterende tittel"
+
+#: id:530
+msgid "Select genre"
+msgstr "Velg sjanger"
+
+#: id:531
+msgid "New genre"
+msgstr "Ny sjanger"
+
+#: id:532
+msgid "Manual addition"
+msgstr "Manuelt tillegg"
+
+#: id:533
+msgid "Enter genre"
+msgstr "Skriv inn sjanger"
+
+#: id:534
+msgid "View: %s"
+msgstr "Visning: %s"
+
+#: id:535
+msgid "List"
+msgstr "Liste"
+
+#: id:536
+msgid "Icons"
+msgstr "Ikoner"
+
+#: id:537
+msgid "Big list"
+msgstr "Stor liste"
+
+#: id:538
+msgid "Big icons"
+msgstr "Store ikoner"
+
+#: id:539
+msgid "Wide"
+msgstr "Bred"
+
+#: id:540
+msgid "Big wide"
+msgstr "Stor og bred"
+
+#: id:541
+msgid "Album icons"
+msgstr "Albumikoner"
+
+#: id:542
+msgid "DVD icons"
+msgstr "DVD-ikoner"
+
+#: id:543
+msgctxt "Auto context with id 543"
+msgid "DVD"
+msgstr "DVD"
+
+#: id:544
+msgctxt "Auto context with id 544"
+msgid "Media info"
+msgstr "Mediainfo"
+
+#: id:545
+msgid "Audio output device"
+msgstr "Lydenhet"
+
+#: id:546
+msgid "Passthrough output device"
+msgstr "Passthrough lydenhet"
+
+#: id:547
+msgid "No biography for this artist"
+msgstr "Ingen biografi for denne artist"
+
+#: id:548
+msgid "Downmix multichannel audio to stereo"
+msgstr "Miks multikanals audio til stereo"
+
+#: id:550
+msgid "Sort by: %s"
+msgstr "Sort.: %s"
+
+#: id:551
+msgctxt "Auto context with id 551"
+msgid "Name"
+msgstr "Navn"
+
+#: id:552
+msgid "Date"
+msgstr "Dato"
+
+#: id:553
+msgid "Size"
+msgstr "Størrelse"
+
+#: id:554
+msgid "Track"
+msgstr "Spor"
+
+#: id:555
+msgid "Time"
+msgstr "Tid"
+
+#: id:556
+msgctxt "Auto context with id 556"
+msgid "Title"
+msgstr "Tittel"
+
+#: id:557
+msgid "Artist"
+msgstr "Artist"
+
+#: id:558
+msgid "Album"
+msgstr "Album"
+
+#: id:559
+msgid "Playlist"
+msgstr "Spilleliste"
+
+#: id:560
+msgid "ID"
+msgstr "ID"
+
+#: id:561
+msgctxt "Auto context with id 561"
+msgid "File"
+msgstr "Fil"
+
+#: id:562
+msgctxt "Auto context with id 562"
+msgid "Year"
+msgstr "År"
+
+#: id:563
+msgid "Rating"
+msgstr "Vurdering"
+
+#: id:564
+msgctxt "Auto context with id 564"
+msgid "Type"
+msgstr "Type"
+
+#: id:565
+msgid "Usage"
+msgstr "Bruk"
+
+#: id:566
+msgid "Album artist"
+msgstr "Albumartist"
+
+#: id:567
+msgid "Play count"
+msgstr "Antall avspillinger"
+
+#: id:568
+msgid "Last played"
+msgstr "Sist avspilt"
+
+#: id:569
+msgctxt "Auto context with id 569"
+msgid "Comment"
+msgstr "Kommentar"
+
+#: id:570
+msgid "Date added"
+msgstr "Dato lagt til"
+
+#: id:571
+msgctxt "Auto context with id 571"
+msgid "Default"
+msgstr "Standard"
+
+#: id:572
+msgid "Studio"
+msgstr "Studio"
+
+#: id:573
+msgid "Path"
+msgstr "Sti"
+
+#: id:574
+msgctxt "Auto context with id 574"
+msgid "Country"
+msgstr "Land"
+
+#: id:575
+msgid "In progress"
+msgstr "Pågår"
+
+#: id:576
+msgid "Times played"
+msgstr "Ganger spilt"
+
+#: id:580
+msgid "Sort direction"
+msgstr "Sorteringsretning"
+
+#: id:581
+msgid "Sort method"
+msgstr "Sorteringsmetode"
+
+#: id:582
+msgctxt "Auto context with id 582"
+msgid "View mode"
+msgstr "Visningsmodus"
+
+#: id:583
+msgid "Remember views for different folders"
+msgstr "Husk visninger for forskjellige mapper"
+
+#: id:584
+msgid "Ascending"
+msgstr "Stigende"
+
+#: id:585
+msgid "Descending"
+msgstr "Synkende"
+
+#: id:586
+msgid "Edit playlist"
+msgstr "Rediger spilleliste"
+
+#: id:587
+msgid "Filter"
+msgstr "Filtrer"
+
+#: id:588
+msgid "Cancel party mode"
+msgstr "Avbryt partymodus"
+
+#: id:589
+msgid "Party mode"
+msgstr "Partymodus"
+
+#: id:590
+msgid "Random"
+msgstr "Tilfeldig"
+
+#: id:591
+msgctxt "Auto context with id 591"
+msgid "Off"
+msgstr "Av"
+
+#: id:592
+msgid "One"
+msgstr "En"
+
+#: id:593
+msgid "All"
+msgstr "Alle"
+
+#: id:594
+msgctxt "Auto context with id 594"
+msgid "Off"
+msgstr "Av"
+
+#: id:595
+msgid "Repeat: Off"
+msgstr "Gjenta: Av"
+
+#: id:596
+msgid "Repeat: One"
+msgstr "Gjenta: En"
+
+#: id:597
+msgid "Repeat: All"
+msgstr "Gjenta: Alle"
+
+#: id:600
+msgid "Rip audio CD"
+msgstr "Ripp musikk-CD"
+
+#: id:601
+msgctxt "Auto context with id 601"
+msgid "Medium"
+msgstr "Middels"
+
+#: id:602
+msgctxt "Auto context with id 602"
+msgid "Standard"
+msgstr "Standard"
+
+#: id:603
+msgid "Extreme"
+msgstr "Ekstrem"
+
+#: id:604
+msgid "Constant bitrate"
+msgstr "Konstant bitrate"
+
+#: id:605
+msgid "Ripping..."
+msgstr "Ripper fra CD..."
+
+#: id:607
+msgid "To:"
+msgstr "Til:"
+
+#: id:608
+msgid "Could not rip CD or track"
+msgstr "Kunne ikke rippe CD eller spor"
+
+#: id:609
+msgid "CDDARipPath is not set."
+msgstr "CDDA-sti for ripping er ikke satt"
+
+#: id:610
+msgid "Rip audio track"
+msgstr "Ripp musikkspor"
+
+#: id:611
+msgid "Enter number"
+msgstr "Skriv inn nummer"
+
+#: id:612
+msgid "Bits/Sample"
+msgstr "Bits/Sample"
+
+#: id:613
+msgid "Sample Frequency"
+msgstr "Samplingsfrekvens"
+
+#: id:620
+msgid "Audio CDs"
+msgstr "CD-ripping"
+
+#: id:621
+msgid "Encoder"
+msgstr "Koder"
+
+#: id:622
+msgid "Quality"
+msgstr "Kvalitet"
+
+#: id:623
+msgid "Bitrate"
+msgstr "Bitrate"
+
+#: id:624
+msgid "Include track number"
+msgstr "Inkluder spornummer"
+
+#: id:625
+msgid "All songs of"
+msgstr "Alle sanger fra"
+
+#: id:629
+msgctxt "Auto context with id 629"
+msgid "View mode"
+msgstr "Visningsmodus"
+
+#: id:630
+msgctxt "Auto context with id 630"
+msgid "Normal"
+msgstr "Normal"
+
+#: id:631
+msgid "Zoom"
+msgstr "Zoom"
+
+#: id:632
+msgid "Stretch 4:3"
+msgstr "Strekk 4:3"
+
+#: id:633
+msgid "Wide Zoom"
+msgstr "Bred zoom"
+
+#: id:634
+msgid "Stretch 16:9"
+msgstr "Strekk 16:9"
+
+#: id:635
+msgid "Original Size"
+msgstr "Originalstørrelse"
+
+#: id:636
+msgctxt "Auto context with id 636"
+msgid "Custom"
+msgstr "Egendefinert"
+
+#: id:637
+msgid "Replay gain"
+msgstr "Replay Gain"
+
+#: id:638
+msgid "Replaygain volume adjustments"
+msgstr "Replay Gain-modus"
+
+#: id:639
+msgid "Use track levels"
+msgstr "Bruk spornivåer"
+
+#: id:640
+msgid "Use album levels"
+msgstr "Bruk albumnivåer"
+
+#: id:641
+msgid "PreAmp Level - Replay gained files"
+msgstr "PreAmp nivå - filer med Replay Gain"
+
+#: id:642
+msgid "PreAmp Level - Non replay gained files"
+msgstr "PreAmp nivå - filer uten Replay Gain"
+
+#: id:643
+msgid "Avoid clipping on replay gained files"
+msgstr "Unngå klipping i filer med Replay Gain"
+
+#: id:644
+msgid "Crop black bars"
+msgstr "Fjern sorte felt"
+
+#: id:645
+msgid "Need to unpack a big file. Continue?"
+msgstr "Må pakke opp en stor fil. Fortsette?"
+
+#: id:646
+msgid "Remove from library"
+msgstr "Fjern fra bibliotek"
+
+#: id:647
+msgid "Export video library"
+msgstr "Eksporter filmbibliotek"
+
+#: id:648
+msgid "Import video library"
+msgstr "Importer filmbibliotek"
+
+#: id:649
+msgid "Importing"
+msgstr "Importerer"
+
+#: id:650
+msgid "Exporting"
+msgstr "Eksporterer"
+
+#: id:651
+msgid "Browse for library"
+msgstr "Bla etter bibliotek"
+
+#: id:652
+msgid "Years"
+msgstr "År"
+
+#: id:653
+msgid "Update library"
+msgstr "Oppdater bibliotek"
+
+#: id:654
+msgid "Show debug info"
+msgstr "Vis feilsøkingsinformasjon"
+
+#: id:655
+msgid "Browse for executable"
+msgstr "Bla etter kjørbar fil"
+
+#: id:656
+msgid "Browse for playlist"
+msgstr "Bla etter spilleliste"
+
+#: id:657
+msgid "Browse for folder"
+msgstr "Bla etter mappe"
+
+#: id:658
+msgid "Song information"
+msgstr "Sanginformasjon"
+
+#: id:659
+msgid "Non-linear stretch"
+msgstr "Ikke-lineær strekking"
+
+#: id:660
+msgid "Volume amplification"
+msgstr "Lydforsterkning"
+
+#: id:661
+msgid "Choose export folder"
+msgstr "Velg eksportmappe"
+
+#: id:662
+msgid "This file is no longer available."
+msgstr "Denne filen er ikke lenger tilgjengelig."
+
+#: id:663
+msgid "Would you like to remove it from the library?"
+msgstr "Vil du fjerne den fra biblioteket?"
+
+#: id:664
+msgid "Browse for Script"
+msgstr "Let etter script"
+
+#: id:665
+msgid "Compression level"
+msgstr "Komprimeringsnivå"
+
+#: id:700
+msgid "Cleaning up library"
+msgstr "Renser bibliotek"
+
+#: id:701
+msgid "Removing old songs from the library"
+msgstr "Fjerner gamle sanger fra biblioteket"
+
+#: id:702
+msgid "This path has been scanned before"
+msgstr "Denne katalogen har blitt skannet før"
+
+#: id:705
+msgctxt "Auto context with id 705"
+msgid "Network"
+msgstr "Nettverk"
+
+#: id:706
+msgid "- Server"
+msgstr "- Server"
+
+#: id:708
+msgid "Use an HTTP proxy server to access the internet"
+msgstr "Bruk HTTP proxy for å få tilgang til Internett"
+
+#: id:711
+msgid "Internet Protocol (IP)"
+msgstr "Internettprotokoll (IP)"
+
+#: id:712
+msgid "Invalid port specified. Value must be between 1 and 65535."
+msgstr "Ugyldig port spesifisert. Verdien må være mellom 1 og 65535."
+
+#: id:713
+msgid "HTTP proxy"
+msgstr "HTTP proxy"
+
+#: id:715
+msgid "- Assignment"
+msgstr "- Tilordning"
+
+#: id:716
+msgid "Automatic (DHCP)"
+msgstr "Automatisk (DHCP)"
+
+#: id:717
+msgid "Manual (Static)"
+msgstr "Manuell (statisk)"
+
+#: id:719
+msgid "- IP address"
+msgstr "- IP adresse"
+
+#: id:720
+msgid "- Netmask"
+msgstr "- Nettmaske"
+
+#: id:721
+msgid "- Default gateway"
+msgstr "- Standard gateway"
+
+#: id:722
+msgid "- DNS server"
+msgstr "- DNS server"
+
+#: id:723
+msgid "Save & restart"
+msgstr "Lagre og starte på nytt"
+
+#: id:724
+msgid "Invalid address specified. Value must be AAA.BBB.CCC.DDD"
+msgstr "Ugyldig adresse spesifisert. Verdien må være på formen AAA.BBB.CCC.DDD"
+
+#: id:725
+msgid "with numbers between 0 and 255."
+msgstr "med tall mellom 0 og 255."
+
+#: id:726
+msgid "Changes not saved. Continue without saving?"
+msgstr "Forandringer er ikke lagret. Vil du fortsette uten å lagre?"
+
+#: id:727
+msgid "Web server"
+msgstr "Webserver"
+
+#: id:728
+msgctxt "Auto context with id 728"
+msgid "FTP server"
+msgstr "FTP-server"
+
+#: id:730
+msgid "- Port"
+msgstr "- Port"
+
+#: id:732
+msgid "Save & apply"
+msgstr "Lagre og aktiver"
+
+#: id:733
+msgid "- Password"
+msgstr "- Passord"
+
+#: id:734
+msgid "No pass"
+msgstr "Intet passord"
+
+#: id:735
+msgid "- Character set"
+msgstr "- Tegnsett"
+
+#: id:736
+msgid "- Style"
+msgstr "- Stil"
+
+#: id:737
+msgid "- Colour"
+msgstr "- Farge"
+
+#: id:738
+msgctxt "Auto context with id 738"
+msgid "Normal"
+msgstr "Normal"
+
+#: id:739
+msgid "Bold"
+msgstr "Fet"
+
+#: id:740
+msgid "Italics"
+msgstr "Kursiv"
+
+#: id:741
+msgid "Bold italics"
+msgstr "Fet kursiv"
+
+#: id:742
+msgctxt "Auto context with id 742"
+msgid "White"
+msgstr "Hvit"
+
+#: id:743
+msgctxt "Auto context with id 743"
+msgid "Yellow"
+msgstr "Gul"
+
+#: id:744
+msgctxt "Auto context with id 744"
+msgid "Files"
+msgstr "Filer"
+
+#: id:745
+msgid "No scanned information for this view"
+msgstr "Ingen skannet informasjon for denne visningen"
+
+#: id:746
+msgid "Please turn off library mode"
+msgstr "Skru av biblioteksmodus"
+
+#: id:747
+msgid "Error loading image"
+msgstr "Feil ved lasting av bilde"
+
+#: id:748
+msgid "Edit path"
+msgstr "Endre sti"
+
+#: id:749
+msgid "Mirror image"
+msgstr "Speil bilde"
+
+#: id:750
+msgid "Are you sure?"
+msgstr "Er du sikker?"
+
+#: id:751
+msgid "Removing source"
+msgstr "Fjerner kilde"
+
+#: id:754
+msgid "Add program link"
+msgstr "Legg til programlenke"
+
+#: id:755
+msgid "Edit program path"
+msgstr "Rediger programsti"
+
+#: id:756
+msgid "Edit program name"
+msgstr "Rediger programnavn"
+
+#: id:757
+msgid "Edit path depth"
+msgstr "Rediger stidybden"
+
+#: id:759
+msgid "View: Big list"
+msgstr "Vis: Stor liste"
+
+#: id:760
+msgctxt "Auto context with id 760"
+msgid "Yellow"
+msgstr "Gul"
+
+#: id:761
+msgctxt "Auto context with id 761"
+msgid "White"
+msgstr "Hvit"
+
+#: id:762
+msgid "Blue"
+msgstr "Blå"
+
+#: id:763
+msgid "Bright green"
+msgstr "Lysegrønn"
+
+#: id:764
+msgid "Yellow green"
+msgstr "Gul/grønn"
+
+#: id:765
+msgid "Cyan"
+msgstr "Blå/grønn"
+
+#: id:766
+msgid "Light grey"
+msgstr "Lys grå"
+
+#: id:767
+msgid "Grey"
+msgstr "Grå"
+
+#: id:770
+msgid "Error %i: share not available"
+msgstr "Feil %i: delt mappe ikke tilgjengelig"
+
+#: id:772
+msgctxt "Auto context with id 772"
+msgid "Audio output"
+msgstr "Lydmaskinvare"
+
+#: id:773
+msgid "Seeking"
+msgstr "Søker"
+
+#: id:774
+msgid "Slideshow folder"
+msgstr "Mappe for bildefremvisning"
+
+#: id:775
+msgid "Network interface"
+msgstr "Nettverksenhet"
+
+#: id:776
+msgid "- Wireless network name (ESSID)"
+msgstr "- Trådløst nettverksnavn (ESSID)"
+
+#: id:777
+msgid "- Wireless password"
+msgstr "- Trådløst passord"
+
+#: id:778
+msgid "- Wireless security"
+msgstr "- Trådløst sikkerhet"
+
+#: id:779
+msgid "Save and apply network interface settings"
+msgstr "Lagre og bruk nettverksinnstillingene"
+
+#: id:780
+msgid "No encryption"
+msgstr "Ingen kryptering"
+
+#: id:781
+msgid "WEP"
+msgstr "WEP"
+
+#: id:782
+msgid "WPA"
+msgstr "WPA"
+
+#: id:783
+msgid "WPA2"
+msgstr "WPA2"
+
+#: id:784
+msgid "Applying network interface settings. Please wait."
+msgstr "Lagrer innstillingene for nettverksenheten. Vennligst vent."
+
+#: id:785
+msgid "Network interface restarted successfully."
+msgstr "Nettverksenheten startet uten feil."
+
+#: id:786
+msgid "Network interface did not start successfully."
+msgstr "Nettverksenheten startet ikke korrekt."
+
+#: id:787
+msgid "Interface disabled"
+msgstr "Enheten deaktivert"
+
+#: id:788
+msgid "Network interface disabled successfully."
+msgstr "Nettverksenheten deaktivert uten feil."
+
+#: id:789
+msgid "Wireless network name (ESSID)"
+msgstr "Trådløst nettverknavn (ESSID)"
+
+#: id:790
+msgid "Remote control"
+msgstr ""
+
+#: id:791
+msgid "Allow programs on this system to control XBMC"
+msgstr "Tillat programmer på dette systemet å styre XBMC"
+
+#: id:792
+msgctxt "Auto context with id 792"
+msgid "Port"
+msgstr "Port"
+
+#: id:793
+msgid "Port range"
+msgstr "Portområde"
+
+#: id:794
+msgid "Allow programs on other systems to control XBMC"
+msgstr "Tillat programmer på andre systemer å styre XBMC"
+
+#: id:795
+msgid "Initial repeat delay (ms)"
+msgstr "Forsinkelse for innledende repetisjon (ms)"
+
+#: id:796
+msgid "Continuous repeat delay (ms)"
+msgstr "Forsinkelse for kontinuerlig repetisjon (ms)"
+
+#: id:797
+msgid "Maximum number of clients"
+msgstr "Maksimalt antall klienter"
+
+#: id:798
+msgid "Internet access"
+msgstr "Internettilgang"
+
+#: id:850
+msgid "Invalid port number entered"
+msgstr "Ugyldig portnummer"
+
+#: id:851
+msgid "Valid port range is 1-65535"
+msgstr "Gyldig område er 1-65535"
+
+#: id:852
+msgid "Valid port range is 1024-65535"
+msgstr "Gyldig område er 1024-65535"
+
+#: id:998
+msgid "Add Music..."
+msgstr "Legg til musikk.."
+
+#: id:999
+msgid "Add Videos..."
+msgstr "Legg til video.."
+
+#: id:1000
+msgid "- Preview"
+msgstr "Forhåndsvisning"
+
+#: id:1001
+msgid "Unable to connect"
+msgstr "Kan ikke koble til"
+
+#: id:1002
+msgid "XBMC was unable to connect to the network location."
+msgstr "XBMC kunne ikke koble til nettverksplasseringen."
+
+#: id:1003
+msgid "This could be due to the network not being connected."
+msgstr "Dette kan være fordi nettverket ikke er tilkoblet."
+
+#: id:1004
+msgid "Would you like to add it anyway?"
+msgstr "Ønsker du å legge den til likevel?"
+
+#: id:1006
+msgctxt "Auto context with id 1006"
+msgid "IP address"
+msgstr "IP-adresse"
+
+#: id:1007
+msgid "Add network location"
+msgstr "Legg til nettverksplassering"
+
+#: id:1008
+msgid "Protocol"
+msgstr "Protokoll"
+
+#: id:1009
+msgid "Server address"
+msgstr "Serveradresse"
+
+#: id:1010
+msgid "Server name"
+msgstr "Servernavn"
+
+#: id:1011
+msgid "Remote path"
+msgstr "Nettverkssti"
+
+#: id:1012
+msgid "Shared folder"
+msgstr "Delt mappe"
+
+#: id:1013
+msgctxt "Auto context with id 1013"
+msgid "Port"
+msgstr "Port"
+
+#: id:1014
+msgctxt "Auto context with id 1014"
+msgid "Username"
+msgstr "Brukernavn"
+
+#: id:1015
+msgid "Browse for network server"
+msgstr "Bla etter nettverksserver"
+
+#: id:1016
+msgid "Enter the network address of the server"
+msgstr "Skriv inn adressen til serveren"
+
+#: id:1017
+msgid "Enter the path on the server"
+msgstr "Skriv inn stien til serveren"
+
+#: id:1018
+msgid "Enter the port number"
+msgstr "Skriv inn portnummeret"
+
+#: id:1019
+msgid "Enter the username"
+msgstr "Skriv inn brukernavn"
+
+#: id:1020
+msgid "Add %s source"
+msgstr "Legg til %s kilde"
+
+#: id:1021
+msgid "Enter the paths or browse for the media locations."
+msgstr "Skriv inn stiene eller let etter plassering."
+
+#: id:1022
+msgid "Enter a name for this media Source."
+msgstr "Skriv inn et navn for denne kilden."
+
+#: id:1023
+msgid "Browse for new share"
+msgstr "Bla etter ny delt mappe"
+
+#: id:1024
+msgid "Browse"
+msgstr "Bla"
+
+#: id:1025
+msgid "Could not retrieve directory information."
+msgstr "Kunne ikke hente mappeinformasjon."
+
+#: id:1026
+msgid "Add source"
+msgstr "Legg til kilde"
+
+#: id:1027
+msgid "Edit source"
+msgstr "Rediger kilde"
+
+#: id:1028
+msgid "Edit %s source"
+msgstr "Rediger %s kilde"
+
+#: id:1029
+msgid "Enter the new label"
+msgstr "Skriv inn et nytt navn"
+
+#: id:1030
+msgid "Browse for image"
+msgstr "Bla etter bilde"
+
+#: id:1031
+msgid "Browse for image folder"
+msgstr "Bla etter bildemappe"
+
+#: id:1032
+msgid "Add network location..."
+msgstr "Legg til nettverkssted..."
+
+#: id:1033
+msgid "Browse for file"
+msgstr "Bla etter fil"
+
+#: id:1034
+msgid "Submenu"
+msgstr "Undermeny"
+
+#: id:1035
+msgid "Enable submenu buttons"
+msgstr "Aktiver undermenyknapper"
+
+#: id:1036
+msgid "Favourites"
+msgstr "Favoritter"
+
+#: id:1037
+msgid "Video Add-ons"
+msgstr "Videotillegg"
+
+#: id:1038
+msgid "Music Add-ons"
+msgstr "Musikktillegg"
+
+#: id:1039
+msgid "Picture Add-ons"
+msgstr "Bildetillegg"
+
+#: id:1040
+msgid "Loading directory"
+msgstr "Laster katalog"
+
+#: id:1041
+msgid "Retrieved %i items"
+msgstr "Gjenopprettet %i deler"
+
+#: id:1042
+msgid "Retrieved %i of %i items"
+msgstr "Gjenopprettet %i av %i deler"
+
+#: id:1043
+msgid "Program Add-ons"
+msgstr "Programtillegg"
+
+#: id:1044
+msgid "Set plugin thumb"
+msgstr "Velg miniatyrbilde for tillegg"
+
+#: id:1045
+msgid "Add-on settings"
+msgstr "Innstillinger for tillegg"
+
+#: id:1046
+msgid "Access points"
+msgstr "Aksesspunkt"
+
+#: id:1047
+msgid "Other..."
+msgstr "Andre.."
+
+#: id:1048
+msgid "- Username"
+msgstr "- Brukernavn"
+
+#: id:1049
+msgid "Script settings"
+msgstr "Skript-innstillinger"
+
+#: id:1050
+msgid "Singles"
+msgstr "Singler"
+
+#: id:1051
+msgid "Enter web address"
+msgstr "Skriv inn webadresse"
+
+#: id:1200
+msgid "SMB client"
+msgstr "SMB-klient"
+
+#: id:1202
+msgid "Workgroup"
+msgstr "Arbeidsgruppe"
+
+#: id:1203
+msgid "Default username"
+msgstr "Standard brukernavn"
+
+#: id:1204
+msgid "Default password"
+msgstr "Standard passord"
+
+#: id:1207
+msgid "WINS server"
+msgstr "WINS-server"
+
+#: id:1208
+msgid "Mount SMB shares"
+msgstr "Monter delte SMB-mapper"
+
+#: id:1210
+msgctxt "Auto context with id 1210"
+msgid "Remove"
+msgstr "Fjern"
+
+#: id:1211
+msgctxt "Auto context with id 1211"
+msgid "Music"
+msgstr "Musikk"
+
+#: id:1212
+msgctxt "Auto context with id 1212"
+msgid "Video"
+msgstr "Video"
+
+#: id:1213
+msgctxt "Auto context with id 1213"
+msgid "Pictures"
+msgstr "Bilder"
+
+#: id:1214
+msgctxt "Auto context with id 1214"
+msgid "Files"
+msgstr "Filer"
+
+#: id:1215
+msgctxt "Auto context with id 1215"
+msgid "Music & video"
+msgstr "Musikk & video"
+
+#: id:1216
+msgid "Music & pictures"
+msgstr "Musikk & bilder"
+
+#: id:1217
+msgid "Music & files"
+msgstr "Musikk & filer"
+
+#: id:1218
+msgid "Video & pictures"
+msgstr "Video & bilder"
+
+#: id:1219
+msgid "Video & files"
+msgstr "Video & filer"
+
+#: id:1220
+msgid "Pictures & files"
+msgstr "Bilder & filer"
+
+#: id:1221
+msgid "Music & video & pictures"
+msgstr "Musikk & video & bilder"
+
+#: id:1222
+msgid "Music & video & pictures & files"
+msgstr "Musikk & video & bilder & filer"
+
+#: id:1223
+msgctxt "Auto context with id 1223"
+msgid "Disabled"
+msgstr "Skrudd av"
+
+#: id:1226
+msgid "Files & music & video"
+msgstr "Filer & musikk & video"
+
+#: id:1227
+msgid "Files & pictures & music"
+msgstr "Filer & bilder & musikk"
+
+#: id:1228
+msgid "Files & pictures & video"
+msgstr "Filer & bilder & video"
+
+#: id:1229
+msgid "Music & programs"
+msgstr "Musikk & programmer"
+
+#: id:1230
+msgid "Video & programs"
+msgstr "Video & programmer"
+
+#: id:1231
+msgid "Pictures & programs"
+msgstr "Bilder & programmer"
+
+#: id:1232
+msgid "Music & video & pictures & programs"
+msgstr "Musikk & video & bilder & programmer"
+
+#: id:1233
+msgid "Programs & video & music"
+msgstr "Programmer & video & musikk"
+
+#: id:1234
+msgid "Programs & pictures & music"
+msgstr "Programmer & bilder & musikk"
+
+#: id:1235
+msgid "Programs & pictures & video"
+msgstr "Programmer & bilder & video"
+
+#: id:1250
+msgid "Auto-detection"
+msgstr "Autooppdagelse"
+
+#: id:1251
+msgid "Auto-detect system"
+msgstr "Autooppdag system"
+
+#: id:1252
+msgid "Nickname"
+msgstr "Kallenavn"
+
+#: id:1254
+msgid "Ask to connect"
+msgstr "Spør om det skal kobles til"
+
+#: id:1255
+msgid "Send FTP user and password"
+msgstr "Send FTP brukernavn og passord"
+
+#: id:1256
+msgid "Ping interval"
+msgstr "Ping-intervall"
+
+#: id:1257
+msgid "Would you like to connect to the auto-detected system?"
+msgstr "Ønsker du å koble til det oppdagede systemet?"
+
+#: id:1259
+msgid "Zeroconf"
+msgstr ""
+
+#: id:1260
+msgid "Announce these services to other systems via Zeroconf"
+msgstr "Annonser disse tjenestene med Zeroconf"
+
+#: id:1270
+msgid "Allow XBMC to receive AirPlay content"
+msgstr "Tillat XBMC å motta AirPlay-innhold"
+
+#: id:1271
+msgid "Device name"
+msgstr "Enhetsnavn"
+
+#: id:1272
+msgid "- Use password protection"
+msgstr ""
+
+#: id:1273
+msgid "AirPlay"
+msgstr ""
+
+#: id:1300
+msgid "Custom audio device"
+msgstr "Egendefinert lydenhet"
+
+#: id:1301
+msgid "Custom passthrough device"
+msgstr "Egendefinert passthrough-enhet"
+
+#: id:1396
+msgid "Drifting"
+msgstr "forbigående"
+
+#: id:1397
+msgid "and"
+msgstr "og"
+
+#: id:1398
+msgid "Freezing"
+msgstr "kjølig"
+
+#: id:1399
+msgid "Late"
+msgstr "sent"
+
+#: id:1400
+msgid "Isolated"
+msgstr "isolerte"
+
+#: id:1401
+msgid "Thundershowers"
+msgstr "tordenbyger"
+
+#: id:1402
+msgid "Thunder"
+msgstr "torden"
+
+#: id:1403
+msgctxt "Auto context with id 1403"
+msgid "Sun"
+msgstr "sol"
+
+#: id:1404
+msgid "Heavy"
+msgstr "mye"
+
+#: id:1405
+msgid "in"
+msgstr "i"
+
+#: id:1406
+msgid "the"
+msgstr ""
+
+#: id:1407
+msgid "Vicinity"
+msgstr "nærheten"
+
+#: id:1408
+msgid "Ice"
+msgstr "is"
+
+#: id:1409
+msgid "Crystals"
+msgstr "krystaller"
+
+#: id:1410
+msgid "Calm"
+msgstr "stille"
+
+#: id:1411
+msgid "with"
+msgstr "med"
+
+#: id:1412
+msgid "windy"
+msgstr "vind"
+
+#: id:1413
+msgid "drizzle"
+msgstr "yr"
+
+#: id:1414
+msgid "Thunderstorm"
+msgstr "lyn og torden"
+
+#: id:1415
+msgid "Drizzle"
+msgstr "duskregn"
+
+#: id:1416
+msgid "Foggy"
+msgstr "tåkete"
+
+#: id:1417
+msgid "Grains"
+msgstr "kornete"
+
+#: id:1418
+msgid "T-Storms"
+msgstr "tordenvær"
+
+#: id:1419
+msgid "T-Showers"
+msgstr "tordenvær"
+
+#: id:1420
+msgid "Moderate"
+msgstr "moderat"
+
+#: id:1421
+msgid "Very High"
+msgstr "mye"
+
+#: id:1422
+msgid "Windy"
+msgstr "vind"
+
+#: id:1423
+msgid "Mist"
+msgstr "disig"
+
+#: id:1450
+msgid "Put display to sleep when idle"
+msgstr "Slukk skjerm når ikke i bruk"
+
+#: id:2050
+msgid "Runtime"
+msgstr "Spilletid"
+
+#: id:2100
+msgid "Script failed! : %s"
+msgstr "Skript mislyktes! : %s"
+
+#: id:2101
+msgid "Newer version needed - See log"
+msgstr "Nyere versjon trengs - se logg"
+
+#: id:4501
+msgid "Enable LCD/VFD"
+msgstr "Aktiver LCD/VFD"
+
+#: id:10000
+msgid "Home"
+msgstr "Hjem"
+
+#: id:10001
+msgctxt "Auto context with id 10001"
+msgid "Programs"
+msgstr "Programmer"
+
+#: id:10002
+msgctxt "Auto context with id 10002"
+msgid "Pictures"
+msgstr "Bilder"
+
+#: id:10003
+msgctxt "Auto context with id 10003"
+msgid "File manager"
+msgstr "Filbehandler"
+
+#: id:10004
+msgctxt "Auto context with id 10004"
+msgid "Settings"
+msgstr "Innstillinger"
+
+#: id:10005
+msgctxt "Auto context with id 10005"
+msgid "Music"
+msgstr "Musikk"
+
+#: id:10006
+msgctxt "Auto context with id 10006"
+msgid "Videos"
+msgstr "Videoer"
+
+#: id:10007
+msgid "System information"
+msgstr "Systeminformasjon"
+
+#: id:10008
+msgid "Settings - General"
+msgstr "Innstillinger - Generelt"
+
+#: id:10009
+msgid "Settings - Screen"
+msgstr "Innstillinger - Skjerm"
+
+#: id:10010
+msgid "Settings - Appearance - GUI Calibration"
+msgstr "Innstillinger - Utseende - GUI-kalibrering"
+
+#: id:10011
+msgid "Settings - Videos - Screen Calibration"
+msgstr "Innstillinger - Videoer - Kalibrering av skjerm"
+
+#: id:10012
+msgid "Settings - Pictures"
+msgstr "Innstillinger - Bilder"
+
+#: id:10013
+msgid "Settings - Programs"
+msgstr "Innstillinger - Programmer"
+
+#: id:10014
+msgid "Settings - Weather"
+msgstr "Innstillinger - Været"
+
+#: id:10015
+msgid "Settings - Music"
+msgstr "Innstillinger - Musikk"
+
+#: id:10016
+msgid "Settings - System"
+msgstr "Innstillinger - System"
+
+#: id:10017
+msgid "Settings - Videos"
+msgstr "Innstillinger - Videoer"
+
+#: id:10018
+msgid "Settings - Network"
+msgstr "Innstillinger - Nettverk"
+
+#: id:10019
+msgid "Settings - Appearance"
+msgstr "Innstillinger - Utseende"
+
+#: id:10020
+msgctxt "Auto context with id 10020"
+msgid "Scripts"
+msgstr "Skript"
+
+#: id:10021
+msgid "Web Browser"
+msgstr "Nettleser"
+
+#: id:10025
+msgctxt "Auto context with id 10025"
+msgid "Videos"
+msgstr ""
+
+#: id:10028
+msgid "Videos/Playlist"
+msgstr "Videoer/Spilleliste"
+
+#: id:10029
+msgctxt "Auto context with id 10029"
+msgid "Login screen"
+msgstr ""
+
+#: id:10034
+msgid "Settings - Profiles"
+msgstr "Innstillinger - Profiler"
+
+#: id:10040
+msgid "Addon browser"
+msgstr ""
+
+#: id:10100
+msgid "Yes/No dialog"
+msgstr "Ja/Nei dialog"
+
+#: id:10101
+msgid "Progress dialog"
+msgstr "Forløpsdialgboks"
+
+#: id:10210
+msgid "Looking for subtitles..."
+msgstr "Leter etter undertekster..."
+
+#: id:10211
+msgid "Looking for or caching subtitles..."
+msgstr "Leter etter eller henter undertekster..."
+
+#: id:10212
+msgid "terminating"
+msgstr "avslutter"
+
+#: id:10213
+msgid "buffering"
+msgstr "mellomlagrer"
+
+#: id:10214
+msgid "Opening stream"
+msgstr "Åpner datastrøm"
+
+#: id:10500
+msgid "Music/Playlist"
+msgstr "Musikk/Spilleliste"
+
+#: id:10501
+msgid "Music/Files"
+msgstr "Musikk/Filer"
+
+#: id:10502
+msgid "Music/Library"
+msgstr "Musikk/Bibliotek"
+
+#: id:10503
+msgid "Playlist editor"
+msgstr "Spillelisteredigering"
+
+#: id:10504
+msgid "Top 100 songs"
+msgstr "Topp 100 sanger"
+
+#: id:10505
+msgid "Top 100 albums"
+msgstr "Topp 100 album"
+
+#: id:10506
+msgctxt "Auto context with id 10506"
+msgid "Programs"
+msgstr "Programmer"
+
+#: id:10507
+msgid "Configuration"
+msgstr "Konfigurasjon"
+
+#: id:10508
+msgid "Weather forecast"
+msgstr "Værmelding"
+
+#: id:10509
+msgid "Network gaming"
+msgstr "Spilling over nettverk"
+
+#: id:10510
+msgid "Extensions"
+msgstr "Tillegg"
+
+#: id:10511
+msgctxt "Auto context with id 10511"
+msgid "System info"
+msgstr "Systeminformasjon"
+
+#: id:10516
+msgid "Music - Library"
+msgstr "Musikk - bibliotek"
+
+#: id:10517
+msgid "Now Playing - Music"
+msgstr "Spilles nå - Musikk"
+
+#: id:10522
+msgid "Now Playing - Videos"
+msgstr "Spilles nå - Videoer"
+
+#: id:10523
+msgid "Album info"
+msgstr "Albuminformasjon"
+
+#: id:10524
+msgid "Movie info"
+msgstr "Informasjon om film"
+
+#: id:12000
+msgid "Select dialog"
+msgstr "Velg dialog"
+
+#: id:12001
+msgid "Music/Info"
+msgstr "Musikk/Info"
+
+#: id:12002
+msgid "Dialog OK"
+msgstr "Dialog OK"
+
+#: id:12003
+msgid "Videos/Info"
+msgstr "Videoer/Info"
+
+#: id:12004
+msgid "Scripts/Info"
+msgstr "Skript/Info"
+
+#: id:12005
+msgid "Fullscreen video"
+msgstr "Fullskjermsvideo"
+
+#: id:12006
+msgid "Audio visualization"
+msgstr "Lydvisualisering"
+
+#: id:12008
+msgid "File stacking dialog"
+msgstr "Filstablingsdialog"
+
+#: id:12009
+msgid "Rebuild index..."
+msgstr "Gjenoppbygg indeks..."
+
+#: id:12010
+msgid "Return to music window"
+msgstr "Returner til musikkvindu"
+
+#: id:12011
+msgid "Return to videos window"
+msgstr "Returner til videovindu"
+
+#: id:12021
+msgid "Start from beginning"
+msgstr "Start fra begynnelsen"
+
+#: id:12022
+msgid "Resume from %s"
+msgstr "Fortsett fra %s"
+
+#: id:12310
+msgid "0"
+msgstr "0"
+
+#: id:12311
+msgid "1"
+msgstr "1"
+
+#: id:12312
+msgid "2"
+msgstr "2"
+
+#: id:12313
+msgid "3"
+msgstr "3"
+
+#: id:12314
+msgid "4"
+msgstr "4"
+
+#: id:12315
+msgid "5"
+msgstr "5"
+
+#: id:12316
+msgid "6"
+msgstr "6"
+
+#: id:12317
+msgid "7"
+msgstr "7"
+
+#: id:12318
+msgid "8"
+msgstr "8"
+
+#: id:12319
+msgid "9"
+msgstr "9"
+
+#: id:12320
+msgid "c"
+msgstr "c"
+
+#: id:12321
+msgid "Ok"
+msgstr "Ok"
+
+#: id:12322
+msgid "*"
+msgstr "*"
+
+#: id:12325
+msgid "Locked! Enter code..."
+msgstr "Låst! Skriv inn kode..."
+
+#: id:12326
+msgid "Enter password"
+msgstr "Skriv inn passord"
+
+#: id:12327
+msgid "Enter master code"
+msgstr "Skriv inn masterkode"
+
+#: id:12328
+msgid "Enter unlock code"
+msgstr "Skriv inn kode"
+
+#: id:12329
+msgid "or press C to cancel"
+msgstr "eller trykk C for å avbryte"
+
+#: id:12330
+msgid "Enter gamepad button combo and"
+msgstr "Skriv inn knappekombinasjon og trykk start"
+
+#: id:12331
+msgid "press OK, or Back to cancel"
+msgstr "trykk Ok, eller Tilbake for å avbryte"
+
+#: id:12332
+msgid "Set lock"
+msgstr "Lås"
+
+#: id:12333
+msgid "Unlock"
+msgstr "Lås opp"
+
+#: id:12334
+msgid "Reset lock"
+msgstr "Nullstill lås"
+
+#: id:12335
+msgid "Remove lock"
+msgstr "Fjern lås"
+
+#: id:12337
+msgid "Numeric password"
+msgstr "Numerisk passord"
+
+#: id:12338
+msgid "Gamepad button combo"
+msgstr "Knappekombinasjon"
+
+#: id:12339
+msgid "Full-text password"
+msgstr "Fulltekstpassord"
+
+#: id:12340
+msgid "Enter new password"
+msgstr "Skriv inn nytt passord"
+
+#: id:12341
+msgid "Re-Enter new password"
+msgstr "Skriv det nye passordet om igjen"
+
+#: id:12342
+msgid "Incorrect password,"
+msgstr "Feil passord,"
+
+#: id:12343
+msgid "retries left"
+msgstr "forsøk igjen"
+
+#: id:12344
+msgid "Passwords entered did not match."
+msgstr "Passordene samsvarer ikke."
+
+#: id:12345
+msgid "Access denied"
+msgstr "Tilgang nektet"
+
+#: id:12346
+msgid "Password retry limit exceeded."
+msgstr "Grense for antall forsøk er nådd."
+
+#: id:12347
+msgid "The system will now shut off."
+msgstr "Systemet skrur seg nå av."
+
+#: id:12348
+msgid "Item locked"
+msgstr "Låst oppføring"
+
+#: id:12353
+msgid "Reactivate lock"
+msgstr "Reaktiver lås"
+
+#: id:12356
+msgid "Change lock"
+msgstr "Endre lås"
+
+#: id:12357
+msgid "Source lock"
+msgstr "Lås"
+
+#: id:12358
+msgid "Password entry was blank. Try again."
+msgstr "Blankt passord. Prøv igjen."
+
+#: id:12360
+msgid "Master lock"
+msgstr "Masterlås"
+
+#: id:12362
+msgid "Shutdown system if Master Lock retries exceeded"
+msgstr "Skru av maskin hvis masterlåsen forsøkes for mange ganger"
+
+#: id:12367
+msgid "Master code is not valid"
+msgstr "Masterkoden er ikke gyldig!"
+
+#: id:12368
+msgid "Please enter a valid master code"
+msgstr "Vennligst skriv inn en gyldig masterkode!"
+
+#: id:12373
+msgid "Settings & file manager"
+msgstr "Innstillinger & filbehandler"
+
+#: id:12376
+msgid "Set as default for all movies"
+msgstr "Sett som standard for alle filmer"
+
+#: id:12377
+msgid "This will reset any previously saved values"
+msgstr "Dette vil slette alle tidligere innstillinger"
+
+#: id:12378
+msgid "Amount of time to display each image"
+msgstr "Vis hvert bilde i"
+
+#: id:12379
+msgid "Use pan and zoom effects"
+msgstr "Bruk effekter med panorering og zooming"
+
+#: id:12383
+msgid "12 hour clock"
+msgstr "12-timers klokke"
+
+#: id:12384
+msgid "24 hour clock"
+msgstr "24-timers klokke"
+
+#: id:12385
+msgid "Day/Month"
+msgstr "Dag/måned"
+
+#: id:12386
+msgid "Month/Day"
+msgstr "Måned/dag"
+
+#: id:12390
+msgid "System uptime"
+msgstr "Systemets oppetid"
+
+#: id:12391
+msgid "Minutes"
+msgstr "Minutter"
+
+#: id:12392
+msgid "Hours"
+msgstr "Timer"
+
+#: id:12393
+msgid "Days"
+msgstr "Dager"
+
+#: id:12394
+msgid "Total uptime"
+msgstr "Total oppetid"
+
+#: id:12395
+msgid "Battery level"
+msgstr "Batterinivå"
+
+#: id:12600
+msgctxt "Auto context with id 12600"
+msgid "Weather"
+msgstr "Vær"
+
+#: id:12900
+msgctxt "Auto context with id 12900"
+msgid "Screensaver"
+msgstr "Skjermbeskytter"
+
+#: id:12901
+msgid "Fullscreen OSD"
+msgstr "Fullskjerm OSD"
+
+#: id:13000
+msgid "System"
+msgstr "System"
+
+#: id:13001
+msgid "Immediate HD spindown"
+msgstr "Spinn ned harddisk umiddelbart"
+
+#: id:13002
+msgid "Video only"
+msgstr "Kun video"
+
+#: id:13003
+msgid "- Delay"
+msgstr "- Forsinkelse"
+
+#: id:13004
+msgid "- Minimum file duration"
+msgstr "- Minimum filvarighet"
+
+#: id:13005
+msgid "Shutdown"
+msgstr "Slå av"
+
+#: id:13008
+msgid "Shutdown function"
+msgstr "Standardinnstilling for avslutning"
+
+#: id:13009
+msgid "Quit"
+msgstr "Avslutt"
+
+#: id:13010
+msgid "Hibernate"
+msgstr "Dvalemodus"
+
+#: id:13011
+msgid "Suspend"
+msgstr "Ventemodus"
+
+#: id:13012
+msgid "Exit"
+msgstr "Avslutt"
+
+#: id:13013
+msgid "Reboot"
+msgstr "Omstart"
+
+#: id:13014
+msgid "Minimize"
+msgstr "Minimer"
+
+#: id:13015
+msgid "Power button action"
+msgstr "Av/på-knapp funksjon"
+
+#: id:13016
+msgid "Power off System"
+msgstr "Slå av system"
+
+#: id:13020
+msgid "Is another session active, perhaps over ssh?"
+msgstr "Er en annen sesjon aktiv, kanskje over ssh?"
+
+#: id:13021
+msgid "Mounted removable harddrive"
+msgstr "Montert utskiftbar harddisk"
+
+#: id:13022
+msgid "Unsafe device removal"
+msgstr "Usikker fjerning av enhet"
+
+#: id:13023
+msgid "Successfully removed device"
+msgstr "Enhet ble fjernet"
+
+#: id:13024
+msgid "Joystick plugged"
+msgstr "Joystick ble plugget inn"
+
+#: id:13025
+msgid "Joystick unplugged"
+msgstr "Joystick ble plugget ut"
+
+#: id:13050
+msgid "Running low on battery"
+msgstr "Lavt batterinivå"
+
+#: id:13100
+msgid "Flicker filter"
+msgstr "Flimmerfilter"
+
+#: id:13101
+msgid "Let driver choose (requires restart)"
+msgstr "La skjermdriver velge (krever omstart)"
+
+#: id:13105
+msgid "Vertical blank sync"
+msgstr "Vertical blank sync"
+
+#: id:13106
+msgctxt "Auto context with id 13106"
+msgid "Disabled"
+msgstr "Deaktivert"
+
+#: id:13107
+msgid "Enabled during video playback"
+msgstr "Aktivert under filmavspilling"
+
+#: id:13108
+msgctxt "Auto context with id 13108"
+msgid "Always enabled"
+msgstr "Alltid aktivert"
+
+#: id:13109
+msgid "Test & apply resolution"
+msgstr "Test oppløsning"
+
+#: id:13110
+msgid "Save resolution?"
+msgstr "Lagre oppløsning?"
+
+#: id:13111
+msgid "Would you like to keep this resolution?"
+msgstr "Vil du beholde denne oppløsningen?"
+
+#: id:13112
+msgid "High quality upscaling"
+msgstr "Høy kvalitet oppskalering"
+
+#: id:13113
+msgctxt "Auto context with id 13113"
+msgid "Disabled"
+msgstr "Deaktivert"
+
+#: id:13114
+msgid "Enabled for SD content"
+msgstr "Aktivert for SD materiale"
+
+#: id:13115
+msgctxt "Auto context with id 13115"
+msgid "Always enabled"
+msgstr "Alltid aktivert"
+
+#: id:13116
+msgid "Upscaling method"
+msgstr "Oppskaleringsmetode"
+
+#: id:13117
+msgctxt "Auto context with id 13117"
+msgid "Bicubic"
+msgstr "Bikubisk"
+
+#: id:13118
+msgid "Lanczos"
+msgstr "Lanczos"
+
+#: id:13119
+msgid "Sinc"
+msgstr "Sinc"
+
+#: id:13120
+msgctxt "Auto context with id 13120"
+msgid "VDPAU"
+msgstr "VDPAU-"
+
+#: id:13121
+msgid "VDPAU HQ Upscaling level"
+msgstr "VDPAU HQ oppskaleringsnivå"
+
+#: id:13122
+msgid "VDPAU Studio level color conversion"
+msgstr "VDPAU studionivå fargekonvertering"
+
+#: id:13130
+msgid "Blank other displays"
+msgstr "Blank andre skjermer"
+
+#: id:13131
+msgctxt "Auto context with id 13131"
+msgid "Disabled"
+msgstr "Deaktivert"
+
+#: id:13132
+msgid "Blank displays"
+msgstr "Blank skjermer"
+
+#: id:13140
+msgid "Active connections detected!"
+msgstr "Aktive tilkoblinger oppdaget!"
+
+#: id:13141
+msgid "If you proceed, you might not be able to control XBMC"
+msgstr "Om du fortsetter kan det hende du ikke greier kontrollere XBMC"
+
+#: id:13142
+msgid "any longer. Are you sure you want to stop the Event server?"
+msgstr "lengre. Er du sikker på du vil stoppe hendelseserveren?"
+
+#: id:13144
+msgid "Change Apple Remote mode?"
+msgstr "Endre Apple fjernkontrollmodus?"
+
+#: id:13145
+msgid "If you are currently using the Apple Remote to control"
+msgstr "Hvis du bruker Apple fjernkontroll til å styre"
+
+#: id:13146
+msgid "XBMC, changing this setting might affect your ability"
+msgstr "XBMC nå, kan denne innstillingen påvirke muligheten"
+
+#: id:13147
+msgid "to continue controlling it. Do you want to proceed?"
+msgstr "for fortsette styring. Ønsker du å gå videre?"
+
+#: id:13159
+msgid "Subnet mask"
+msgstr "Nettverksmaske"
+
+#: id:13160
+msgid "Gateway"
+msgstr "Gateway"
+
+#: id:13161
+msgid "Primary DNS"
+msgstr "Primær DNS"
+
+#: id:13162
+msgid "Initialize failed"
+msgstr "Initialisering mislyktes"
+
+#: id:13170
+msgctxt "Auto context with id 13170"
+msgid "Never"
+msgstr "Aldri"
+
+#: id:13171
+msgid "Immediately"
+msgstr "Umiddelbart"
+
+#: id:13172
+msgid "After %i secs"
+msgstr "Etter %i sek"
+
+#: id:13173
+msgid "HDD install date:"
+msgstr "Harddisk installert dato:"
+
+#: id:13174
+msgid "HDD power cycle count:"
+msgstr "Harddisk antall oppstarter:"
+
+#: id:13200
+msgid "Profiles"
+msgstr "Profiler"
+
+#: id:13201
+msgid "Delete profile '%s'?"
+msgstr "Slett profil '%s'?"
+
+#: id:13204
+msgid "Last loaded profile:"
+msgstr "Sist lastede profil:"
+
+#: id:13205
+msgid "Unknown"
+msgstr "Ukjent"
+
+#: id:13206
+msgid "Overwrite"
+msgstr "Overskriv"
+
+#: id:13208
+msgid "Alarm clock"
+msgstr "Alarm"
+
+#: id:13209
+msgid "Alarm clock interval (in minutes)"
+msgstr "Alarmintervall (i minutter)"
+
+#: id:13210
+msgid "Started, alarm in %im"
+msgstr "Startet, alarm om %im"
+
+#: id:13211
+msgid "Alarm!"
+msgstr "Alarm!"
+
+#: id:13212
+msgid "Canceled with %im%is left"
+msgstr "Avbrutt med %im%is igjen"
+
+#: id:13213
+msgid "%2.0fm"
+msgstr "%2.0fm"
+
+#: id:13214
+msgid "%2.0fs"
+msgstr "%2.0fs"
+
+#: id:13249
+msgid "Search for subtitles in RARs"
+msgstr "Søk etter undertekster i RAR-filer"
+
+#: id:13250
+msgid "Browse for subtitle..."
+msgstr "Bla etter undertekst..."
+
+#: id:13251
+msgid "Move item"
+msgstr "Flytt oppføring"
+
+#: id:13252
+msgid "Move item here"
+msgstr "Flytt hit"
+
+#: id:13253
+msgid "Cancel move"
+msgstr "Avbryt flytting"
+
+#: id:13270
+msgid "Hardware:"
+msgstr "Maskinvare:"
+
+#: id:13271
+msgid "CPU Usage:"
+msgstr "Prosessorbruk:"
+
+#: id:13274
+msgid "Connected, but no DNS is available."
+msgstr "Tilkoblet, men ingen DNS er tilgjengelig."
+
+#: id:13275
+msgid "Hard Disk"
+msgstr "Harddisk"
+
+#: id:13276
+msgid "DVD-ROM"
+msgstr "DVD spiller"
+
+#: id:13277
+msgctxt "Auto context with id 13277"
+msgid "Storage"
+msgstr "Lagring"
+
+#: id:13278
+msgctxt "Auto context with id 13278"
+msgid "Default"
+msgstr "Standard"
+
+#: id:13279
+msgctxt "Auto context with id 13279"
+msgid "Network"
+msgstr "Nettverk"
+
+#: id:13280
+msgctxt "Auto context with id 13280"
+msgid "Video"
+msgstr "Skjermkort"
+
+#: id:13281
+msgid "Hardware"
+msgstr "Maskinvare"
+
+#: id:13283
+msgid "Operating system:"
+msgstr "Operativsystem:"
+
+#: id:13284
+msgid "CPU speed:"
+msgstr "Prosessorhastighet:"
+
+#: id:13286
+msgid "Video encoder:"
+msgstr "Videoprosessor:"
+
+#: id:13287
+msgid "Screen resolution:"
+msgstr "Skjermoppløsning:"
+
+#: id:13292
+msgid "A/V cable:"
+msgstr "A/V kabel:"
+
+#: id:13294
+msgid "DVD region:"
+msgstr "DVD region:"
+
+#: id:13295
+msgid "Internet:"
+msgstr "Internett:"
+
+#: id:13296
+msgctxt "Auto context with id 13296"
+msgid "Connected"
+msgstr "Tilkoblet"
+
+#: id:13297
+msgid "Not connected. Check network settings."
+msgstr "Ikke tilkoblet. Sjekk nettverksinnstillinger."
+
+#: id:13299
+msgid "Target temperature"
+msgstr "Temperaturmål"
+
+#: id:13300
+msgid "Fan speed"
+msgstr "Viftehastighet"
+
+#: id:13301
+msgid "Auto temperature control"
+msgstr "Automatisk temperaturkontroll"
+
+#: id:13302
+msgid "Fan speed override"
+msgstr "Hastighetskontroll for vifte"
+
+#: id:13303
+msgid "- Fonts"
+msgstr "- Fonter"
+
+#: id:13304
+msgid "Enable flipping bi-directional strings"
+msgstr "Snu tekststrenger"
+
+#: id:13305
+msgid "Show RSS news feeds"
+msgstr "Vis RSS-nyhetsstrømmer"
+
+#: id:13306
+msgid "Show parent folder items"
+msgstr "Vis oppføring i overordnet mappe"
+
+#: id:13307
+msgid "Track naming template"
+msgstr "Spornavnformat"
+
+#: id:13308
+msgid "Do you wish to reboot your system"
+msgstr "Ønsker du å starte systemet på nytt"
+
+#: id:13309
+msgid "instead of just XBMC?"
+msgstr "istedenfor bare XBMC?"
+
+#: id:13310
+msgid "Zoom effect"
+msgstr "Zoomeffekt"
+
+#: id:13311
+msgid "Float effect"
+msgstr "Flyteffekt"
+
+#: id:13312
+msgid "Black bar reduction"
+msgstr "Reduksjon av sort felt"
+
+#: id:13313
+msgid "Restart"
+msgstr "Omstart"
+
+#: id:13314
+msgid "Crossfade between songs"
+msgstr "Overtoning"
+
+#: id:13315
+msgid "Regenerate thumbnails"
+msgstr "Regenerer miniatyrbilder"
+
+#: id:13316
+msgid "Recursive thumbnails"
+msgstr "Rekursive miniatyrbilder"
+
+#: id:13317
+msgid "View slideshow"
+msgstr "Vis bildefremvisning"
+
+#: id:13318
+msgid "Recursive slideshow"
+msgstr "Rekursiv bildefremvisning"
+
+#: id:13319
+msgid "Randomize"
+msgstr "Tilfeldig"
+
+#: id:13320
+msgid "Stereo"
+msgstr "Stereo"
+
+#: id:13321
+msgid "Left only"
+msgstr "Kun venstre"
+
+#: id:13322
+msgid "Right only"
+msgstr "Kun høyre"
+
+#: id:13323
+msgid "Enable karaoke support"
+msgstr "Aktiver karaokestøtte"
+
+#: id:13324
+msgid "Background transparency"
+msgstr "Gjennomsiktighet bakgrunn"
+
+#: id:13325
+msgid "Foreground transparency"
+msgstr "Gjennomsiktighet forgrunn"
+
+#: id:13326
+msgid "A/V delay"
+msgstr "A/V forsinkelse"
+
+#: id:13327
+msgid "Karaoke"
+msgstr "Karaoke"
+
+#: id:13328
+msgid "%s not found"
+msgstr "%s ikke funnet"
+
+#: id:13329
+msgid "Error opening %s"
+msgstr "Feil ved åpning av %s"
+
+#: id:13330
+msgid "Unable to load %s"
+msgstr "Kunne ikke laste %s"
+
+#: id:13331
+msgid "Error: Out of memory"
+msgstr "Feil: Tom for minne"
+
+#: id:13332
+msgid "Move up"
+msgstr "Flytt opp"
+
+#: id:13333
+msgid "Move down"
+msgstr "Flytt ned"
+
+#: id:13334
+msgid "Edit label"
+msgstr "Rediger knapp"
+
+#: id:13335
+msgid "Make default"
+msgstr "Gjør til standard"
+
+#: id:13336
+msgid "Remove button"
+msgstr "Fjern knapp"
+
+#: id:13340
+msgid "Leave as is"
+msgstr "Standard"
+
+#: id:13341
+msgid "Green"
+msgstr "Grønn"
+
+#: id:13342
+msgid "Orange"
+msgstr "Oransje"
+
+#: id:13343
+msgid "Red"
+msgstr "Rød"
+
+#: id:13344
+msgid "Cycle"
+msgstr "Varier"
+
+#: id:13345
+msgid "Switch LED off on playback"
+msgstr "Skru av LED ved avspilling"
+
+#: id:13346
+msgctxt "Auto context with id 13346"
+msgid "Movie information"
+msgstr "Informasjon om film"
+
+#: id:13347
+msgid "Queue item"
+msgstr "Legg i kø"
+
+#: id:13348
+msgid "Search IMDb..."
+msgstr "Søk IMDb..."
+
+#: id:13349
+msgid "Scan for new content"
+msgstr "Søk etter nytt innhold"
+
+#: id:13350
+msgid "Now playing..."
+msgstr "Nå spilles..."
+
+#: id:13351
+msgctxt "Auto context with id 13351"
+msgid "Album information"
+msgstr "Albuminformasjon"
+
+#: id:13352
+msgid "Scan item to library"
+msgstr "Skann til bibliotek"
+
+#: id:13353
+msgid "Stop scanning"
+msgstr "Stopp skanning"
+
+#: id:13354
+msgctxt "Auto context with id 13354"
+msgid "Render method"
+msgstr "Rendringsmetode"
+
+#: id:13355
+msgid "Low quality pixel shader"
+msgstr "Lavkvalitets pikselshader"
+
+#: id:13356
+msgid "Hardware overlays"
+msgstr "Hardware overlays"
+
+#: id:13357
+msgid "High quality pixel shader"
+msgstr "Høykvalitets pikselshader"
+
+#: id:13358
+msgid "Play item"
+msgstr "Spill av"
+
+#: id:13359
+msgid "Set artist thumb"
+msgstr "Sett artistbilde"
+
+#: id:13360
+msgid "Automatically generate thumbnails"
+msgstr "Generer miniatyrbilder automatisk"
+
+#: id:13361
+msgid "Enable voice"
+msgstr "Aktiver tale"
+
+#: id:13375
+msgid "Enable device"
+msgstr "Aktiver enhet"
+
+#: id:13376
+msgid "Volume"
+msgstr "Volum"
+
+#: id:13377
+msgid "Default view mode"
+msgstr "Standard visningsmodus"
+
+#: id:13378
+msgid "Default brightness"
+msgstr "Standard lysstyrke"
+
+#: id:13379
+msgid "Default contrast"
+msgstr "Standard kontrast"
+
+#: id:13380
+msgid "Default gamma"
+msgstr "Standard gamma"
+
+#: id:13381
+msgid "Resume video"
+msgstr "Fortsett avspilling"
+
+#: id:13382
+msgid "Voice mask - Port 1"
+msgstr "Voice mask - Port 1"
+
+#: id:13383
+msgid "Voice mask - Port 2"
+msgstr "Voice mask - Port 2"
+
+#: id:13384
+msgid "Voice mask - Port 3"
+msgstr "Voice mask - Port 3"
+
+#: id:13385
+msgid "Voice mask - Port 4"
+msgstr "Voice mask - Port 4"
+
+#: id:13386
+msgid "Use time based seeking"
+msgstr "Bruk tidsbasert søking"
+
+#: id:13387
+msgid "Track naming template - right"
+msgstr "Format på høyre del av musikkliste"
+
+#: id:13388
+msgid "Preset"
+msgstr "%s forhåndsinnstillinger"
+
+#: id:13389
+msgid "There are no presets available\nfor this visualization"
+msgstr "Det er ingen forhåndsinnstillinger tilgjengelig&#10;for denne visualiseringen"
+
+#: id:13390
+msgid "There are no settings available\nfor this visualization"
+msgstr "Det er ingen innstillinger tilgjengelige&#10;for denne visualiseringen"
+
+#: id:13391
+msgid "Eject/Load"
+msgstr "Løs ut/last inn"
+
+#: id:13392
+msgid "Use visualization if playing audio"
+msgstr "Bruk visualisering ved musikkavspilling"
+
+#: id:13393
+msgid "Calculate size"
+msgstr "Kalkuler størrelse"
+
+#: id:13394
+msgid "Calculating folder size"
+msgstr "Kalkulerer mappestørrelse"
+
+#: id:13395
+msgid "Video settings"
+msgstr "Filminnstillinger"
+
+#: id:13396
+msgid "Audio and subtitle settings"
+msgstr "Lyd- og tekstinnstillinger"
+
+#: id:13397
+msgid "Enable subtitles"
+msgstr "Aktiver undertekster"
+
+#: id:13398
+msgctxt "Auto context with id 13398"
+msgid "Shortcuts"
+msgstr "Snarveier"
+
+#: id:13399
+msgid "Ignore articles when sorting (e.g. \"the\")"
+msgstr "Ignorer \"the\" ved sortering"
+
+#: id:13400
+msgid "Crossfade between songs on the same album"
+msgstr "Overtoning for spor av samme album"
+
+#: id:13401
+msgid "Browse for %s"
+msgstr "Bla etter %s"
+
+#: id:13402
+msgid "Show track position"
+msgstr "Vis sporposisjon"
+
+#: id:13403
+msgid "Clear default"
+msgstr "Fjern standard"
+
+#: id:13404
+msgid "Resume"
+msgstr "Fortsett"
+
+#: id:13405
+msgid "Get thumb"
+msgstr "Hent miniatyr"
+
+#: id:13406
+msgid "Picture information"
+msgstr "Bildeinformasjon"
+
+#: id:13407
+msgid "%s presets"
+msgstr "%s forhåndsinnstillinger"
+
+#: id:13408
+msgid "(IMDb user rating)"
+msgstr "(IMDb brukervurdering)"
+
+#: id:13409
+msgid "Top 250"
+msgstr "Topp 250"
+
+#: id:13410
+msgid "Tune in on Last.fm"
+msgstr "Still inn på Last.FM"
+
+#: id:13411
+msgid "Minimum fan speed"
+msgstr "Minimum viftehastighet"
+
+#: id:13412
+msgid "Play from here"
+msgstr "Spill herfra"
+
+#: id:13413
+msgid "Downloading"
+msgstr "Laster ned"
+
+#: id:13414
+msgid "Include artists who appear only on compilations"
+msgstr "Inkluder artister som bare opptrer i samlinger"
+
+#: id:13415
+msgctxt "Auto context with id 13415"
+msgid "Render method"
+msgstr "Rendringsmetode"
+
+#: id:13416
+msgid "Auto detect"
+msgstr "Oppdag automatisk"
+
+#: id:13417
+msgid "Basic shaders (ARB)"
+msgstr "Basic shaders (ARB)"
+
+#: id:13418
+msgid "Advanced shaders (GLSL)"
+msgstr "Advanced shaders (GLSL)"
+
+#: id:13419
+msgid "Software"
+msgstr "Programvare"
+
+#: id:13420
+msgid "Remove safely"
+msgstr "Sikker fjerning"
+
+#: id:13421
+msgctxt "Auto context with id 13421"
+msgid "VDPAU"
+msgstr "VDPAU"
+
+#: id:13422
+msgid "Start slideshow here"
+msgstr "Start bildefremvisning her"
+
+#: id:13423
+msgid "Remember for this path"
+msgstr "Husk for denne katalogen"
+
+#: id:13424
+msgid "Use pixel buffer objects"
+msgstr "Bruk 'Pixel buffer objects'"
+
+#: id:13425
+msgid "Allow hardware acceleration (VDPAU)"
+msgstr "Tillat maskinvareakselerasjon (VDPAU)"
+
+#: id:13426
+msgid "Allow hardware acceleration (VAAPI)"
+msgstr "Tillat maskinvareakselerasjon (VAAPI)"
+
+#: id:13427
+msgid "Allow hardware acceleration (DXVA2)"
+msgstr "Tillat maskinvareakselerasjon (DXVA2)"
+
+#: id:13428
+msgid "Allow hardware acceleration (CrystalHD)"
+msgstr "Tillat maskinvareakselerasjon (CrystalHD)"
+
+#: id:13429
+msgid "Allow hardware acceleration (VDADecoder)"
+msgstr "Tillat maskinvareakselerasjon (VDADecoder)"
+
+#: id:13430
+msgid "Allow hardware acceleration (OpenMax)"
+msgstr "Tillat maskinvareakselerasjon (OpenMax)"
+
+#: id:13431
+msgid "Pixel Shaders"
+msgstr "Piksel Shaders"
+
+#: id:13432
+msgid "Allow hardware acceleration (VideoToolbox)"
+msgstr "Tillat maskinvareakselerasjon (VideoToolbox)"
+
+#: id:13500
+msgid "A/V sync method"
+msgstr "A/V synkmetode"
+
+#: id:13501
+msgid "Audio clock"
+msgstr "Lydklokking"
+
+#: id:13502
+msgid "Video clock (Drop/Dupe audio)"
+msgstr "Videoklokking (dropp/dupliser lyd)"
+
+#: id:13503
+msgid "Video clock (Resample audio)"
+msgstr "Videoklokking (resample lyd)"
+
+#: id:13504
+msgid "Maximum resample amount (%)"
+msgstr "Maksimum resamplingsnivå (%)"
+
+#: id:13505
+msgid "Resample quality"
+msgstr "Resamplingskvalitet"
+
+#: id:13506
+msgid "Low(fast)"
+msgstr "Lav (rask)"
+
+#: id:13507
+msgctxt "Auto context with id 13507"
+msgid "Medium"
+msgstr "Medium"
+
+#: id:13508
+msgctxt "Auto context with id 13508"
+msgid "High"
+msgstr "Høy"
+
+#: id:13509
+msgid "Really high(slow!)"
+msgstr "Veldig høy (treg!)"
+
+#: id:13510
+msgid "Sync playback to display"
+msgstr "Synkroniser avspilling til skjerm"
+
+#: id:13550
+msgid "Pause during refresh rate change"
+msgstr "Pause under endring av oppdateringsfrekvens"
+
+#: id:13551
+msgctxt "Auto context with id 13551"
+msgid "Off"
+msgstr "Av"
+
+#: id:13552
+msgid "%.1f Second"
+msgstr "%.1f sekund"
+
+#: id:13553
+msgid "%.1f Seconds"
+msgstr "%.1f sekunder"
+
+#: id:13600
+msgid "Apple remote"
+msgstr "Apple fjernkontroll"
+
+#: id:13602
+msgid "Allow start of XBMC using the remote"
+msgstr "Tillat oppstart av XBMC fra fjernkontrollen"
+
+#: id:13603
+msgid "Sequence delay time"
+msgstr "Sekvensforsinkelse"
+
+#: id:13610
+msgctxt "Auto context with id 13610"
+msgid "Disabled"
+msgstr "Deaktivert"
+
+#: id:13611
+msgctxt "Auto context with id 13611"
+msgid "Standard"
+msgstr "Standard"
+
+#: id:13612
+msgid "Universal Remote"
+msgstr "Universal fjernkontroll"
+
+#: id:13613
+msgid "Multi Remote (Harmony)"
+msgstr "Multifjernkontroll (Harmony)"
+
+#: id:13620
+msgid "Apple Remote Error"
+msgstr "Feil med Apple fjernkontroll"
+
+#: id:13621
+msgid "Apple Remote support could be enabled."
+msgstr "Apple fjernkontroll kunne aktiveres"
+
+#: id:14000
+msgid "Stack"
+msgstr "Stable"
+
+#: id:14001
+msgid "Unstack"
+msgstr "Avstable"
+
+#: id:14003
+msgid "Downloading playlist file..."
+msgstr "Laster ned spilleliste..."
+
+#: id:14004
+msgid "Downloading streams list..."
+msgstr "Laster ned liste av strømmer..."
+
+#: id:14005
+msgid "Parsing streams list..."
+msgstr "Analyserer liste av strømmer..."
+
+#: id:14006
+msgid "Downloading streams list failed"
+msgstr "Kunne ikke laste ned liste av strømmer"
+
+#: id:14007
+msgid "Downloading playlist file failed"
+msgstr "Kunne ikke laste ned spilleliste"
+
+#: id:14009
+msgid "Games directory"
+msgstr "Spillmappe"
+
+#: id:14010
+msgid "Auto switch to thumbs based on"
+msgstr "Bytt automatisk til miniatyrbilder ved"
+
+#: id:14011
+msgid "Enable auto switching to thumbs view"
+msgstr "Aktiver automatisk bytte til miniatyrvisning"
+
+#: id:14012
+msgid "- Use large icons"
+msgstr "- Bruk store ikoner"
+
+#: id:14013
+msgid "- Switch based on"
+msgstr "- Bytte basert på"
+
+#: id:14014
+msgid "- Percentage"
+msgstr "- Prosent"
+
+#: id:14015
+msgid "No files and at least one thumb"
+msgstr "Ingen filer og minst et miniatyrbilde"
+
+#: id:14016
+msgid "At least one file and thumb"
+msgstr "Minst én fil og et miniatyrbilde"
+
+#: id:14017
+msgid "Percentage of thumbs"
+msgstr "Prosentandel av miniatyrbilder"
+
+#: id:14018
+msgid "View options"
+msgstr "Visningsalt."
+
+#: id:14019
+msgid "Change area code 1"
+msgstr "Endre retningsnummer 1"
+
+#: id:14020
+msgid "Change area code 2"
+msgstr "Endre retningsnummer 2"
+
+#: id:14021
+msgid "Change area code 3"
+msgstr "Endre retningsnummer 3"
+
+#: id:14022
+msgctxt "Auto context with id 14022"
+msgid "Library"
+msgstr "Bibliotek"
+
+#: id:14023
+msgid "No TV"
+msgstr "Ingen TV"
+
+#: id:14024
+msgid "Enter the nearest large town"
+msgstr "Skriv inn nærmeste store by"
+
+#: id:14025
+msgid "Video/Audio/DVD cache - Harddisk"
+msgstr "Video/Lyd/DVD mellomlager - Harddisk"
+
+#: id:14026
+msgid "Video cache - DVD-ROM"
+msgstr "Video mellomlager - DVD-spiller"
+
+#: id:14027
+msgctxt "Auto context with id 14027"
+msgid "- Local Network"
+msgstr "- Lokalt nettverk"
+
+#: id:14028
+msgctxt "Auto context with id 14028"
+msgid "- Internet"
+msgstr "- Internett"
+
+#: id:14030
+msgid "Audio cache - DVD-ROM"
+msgstr "Lyd-mellomlager - DVD-spiller"
+
+#: id:14031
+msgctxt "Auto context with id 14031"
+msgid "- Local Network"
+msgstr "- Lokalt nettverk"
+
+#: id:14032
+msgctxt "Auto context with id 14032"
+msgid "- Internet"
+msgstr "- Internett"
+
+#: id:14034
+msgid "DVD cache - DVD-ROM"
+msgstr "DVD-mellomlager - DVD-spiller"
+
+#: id:14035
+msgctxt "Auto context with id 14035"
+msgid "- Local Network"
+msgstr "- Lokalt nettverk"
+
+#: id:14036
+msgctxt "Auto context with id 14036"
+msgid "Services"
+msgstr "Tjenester"
+
+#: id:14038
+msgid "Network settings changed"
+msgstr "Nettverksinnstillingene er forandret"
+
+#: id:14039
+msgid "XBMC requires to restart to change your"
+msgstr "XBMC må starte på nytt for å forandre"
+
+#: id:14040
+msgid "network setup. Would you like to restart now?"
+msgstr "nettverksinnstillingene. Vil du starte på nytt nå?"
+
+#: id:14041
+msgid "Internet connection bandwidth limitation"
+msgstr "Båndbreddebegrensning"
+
+#: id:14043
+msgid "- Shutdown while playing"
+msgstr "- Skru av maskin under spilling"
+
+#: id:14044
+msgid "%i min"
+msgstr "%i min"
+
+#: id:14045
+msgid "%i sec"
+msgstr "%i sek"
+
+#: id:14046
+msgid "%i ms"
+msgstr "%i ms"
+
+#: id:14047
+msgid "%i %%"
+msgstr "%i %%"
+
+#: id:14048
+msgid "%i kbps"
+msgstr "%i kbps"
+
+#: id:14049
+msgid "%i kb"
+msgstr "%i kb"
+
+#: id:14050
+msgid "%i.0 dB"
+msgstr "%i.0 dB"
+
+#: id:14051
+msgid "Time format"
+msgstr "Tidsformat"
+
+#: id:14052
+msgid "Date format"
+msgstr "Datoformat"
+
+#: id:14053
+msgid "GUI filters"
+msgstr "GUI-filtre"
+
+#: id:14055
+msgid "Use background scanning"
+msgstr "Bruk bakgrunnsskanning"
+
+#: id:14056
+msgid "Stop scan"
+msgstr "Stopp skanning"
+
+#: id:14057
+msgid "Not possible while scanning for media info"
+msgstr "Ikke mulig når det skannes etter mediainformasjon"
+
+#: id:14058
+msgid "Film grain effect"
+msgstr "Filmstøyeffekt"
+
+#: id:14059
+msgid "Search for thumbnails on remote shares"
+msgstr "Se etter miniatyrbilder i nettverksmapper"
+
+#: id:14060
+msgid "Unknown type cache - Internet"
+msgstr "Mellomlager med ukjent type - Internett"
+
+#: id:14061
+msgctxt "Auto context with id 14061"
+msgid "Auto"
+msgstr "Auto"
+
+#: id:14062
+msgid "Enter username for"
+msgstr "Skriv inn brukernavn for"
+
+#: id:14063
+msgid "Date & time"
+msgstr "Dato & tid"
+
+#: id:14064
+msgid "Set date"
+msgstr "Sett dato"
+
+#: id:14065
+msgid "Set time"
+msgstr "Sett tid"
+
+#: id:14066
+msgid "Enter the time in 24 hour HH:MM format"
+msgstr "Skriv inn tiden i 24 timers HH:MM format"
+
+#: id:14067
+msgid "Enter the date in DD/MM/YYYY format"
+msgstr "Skriv inn datoen i DD/MM/ÅÅÅÅ format"
+
+#: id:14068
+msgid "Enter the IP address"
+msgstr "Skriv inn IP-adressen"
+
+#: id:14069
+msgid "Apply these settings now?"
+msgstr "Bruk disse innstillingene nå?"
+
+#: id:14070
+msgid "Apply changes now"
+msgstr "Lagre endringer nå"
+
+#: id:14071
+msgid "Allow file renaming and deletion"
+msgstr "Tillat endring av filnavn og sletting"
+
+#: id:14074
+msgid "Set timezone"
+msgstr "Sett tidssone"
+
+#: id:14075
+msgid "Use daylight saving time"
+msgstr "Bruk sommertid"
+
+#: id:14076
+msgid "Add to favourites"
+msgstr "Legg til favoritter"
+
+#: id:14077
+msgid "Remove from favourites"
+msgstr "Fjern fra favoritter"
+
+#: id:14078
+msgctxt "Auto context with id 14078"
+msgid "- Colours"
+msgstr "- Farger"
+
+#: id:14079
+msgid "Timezone country"
+msgstr "Tidssone land"
+
+#: id:14080
+msgid "Timezone"
+msgstr "Tidssone"
+
+#: id:14081
+msgid "File lists"
+msgstr "Fillister"
+
+#: id:14082
+msgid "Show EXIF picture information"
+msgstr "Vis EXIF-bildeinformasjon"
+
+#: id:14083
+msgid "Use a fullscreen window rather than true fullscreen"
+msgstr "Bruk ett fullskjermsvindu istedenfor sann fullskjerm"
+
+#: id:14084
+msgid "Queue songs on selection"
+msgstr "Kø sanger ved valg"
+
+#: id:14086
+msgid "Playback"
+msgstr "Avspilling"
+
+#: id:14087
+msgid "DVDs"
+msgstr "DVD-er"
+
+#: id:14088
+msgid "Play DVDs automatically"
+msgstr "Spill DVD-er automatisk"
+
+#: id:14089
+msgid "Font to use for text subtitles"
+msgstr "Skrifttype for undertekster"
+
+#: id:14090
+msgid "International"
+msgstr "Språk og lokalisering"
+
+#: id:14091
+msgid "Character set"
+msgstr "Tegnsett"
+
+#: id:14092
+msgid "Debugging"
+msgstr "Debugging"
+
+#: id:14093
+msgid "Security"
+msgstr "Sikkerhet"
+
+#: id:14094
+msgid "Input devices"
+msgstr "Inn-enheter"
+
+#: id:14095
+msgid "Power saving"
+msgstr "Strømsparing"
+
+#: id:14096
+msgid "Rip"
+msgstr ""
+
+#: id:14097
+msgid "Audio CD Insert Action"
+msgstr ""
+
+#: id:14098
+msgctxt "Auto context with id 14098"
+msgid "Play"
+msgstr ""
+
+#: id:14099
+msgid "Eject disc when CD ripping is complete"
+msgstr ""
+
+#: id:15015
+msgctxt "Auto context with id 15015"
+msgid "Remove"
+msgstr "Fjern"
+
+#: id:15016
+msgid "Games"
+msgstr "Spill"
+
+#: id:15019
+msgid "Add"
+msgstr "Legg til"
+
+#: id:15052
+msgid "Password"
+msgstr "Passord"
+
+#: id:15100
+msgctxt "Auto context with id 15100"
+msgid "Library"
+msgstr "Bibliotek"
+
+#: id:15101
+msgid "Database"
+msgstr "Database"
+
+#: id:15102
+msgid "* All albums"
+msgstr "* Alle album"
+
+#: id:15103
+msgid "* All artists"
+msgstr "* Alle artister"
+
+#: id:15104
+msgid "* All songs"
+msgstr "* Alle sanger"
+
+#: id:15105
+msgid "* All genres"
+msgstr "* Alle sjangre"
+
+#: id:15107
+msgid "Buffering..."
+msgstr "Mellomlagrer..."
+
+#: id:15108
+msgid "Navigation sounds"
+msgstr "Navigasjonslyder"
+
+#: id:15109
+msgid "Skin default"
+msgstr "Standard for skinnet"
+
+#: id:15111
+msgid "- Theme"
+msgstr "- Tema"
+
+#: id:15112
+msgid "Default theme"
+msgstr "Standardtema"
+
+#: id:15200
+msgid "Last.fm"
+msgstr "Last.fm"
+
+#: id:15201
+msgid "Submit songs to Last.fm"
+msgstr "Send sanger til Last.fm"
+
+#: id:15202
+msgid "Last.fm username"
+msgstr "Last.fm brukernavn"
+
+#: id:15203
+msgid "Last.fm password"
+msgstr "Last.fm passord"
+
+#: id:15204
+msgid "Unable to handshake: sleeping..."
+msgstr "Kunne ikke utføre håndtrykk: i dvale..."
+
+#: id:15205
+msgid "Please update XBMC"
+msgstr "Vennligst oppdater XBMC"
+
+#: id:15206
+msgid "Bad authorization: Check username and password"
+msgstr "Feil ved autorisasjon: Sjekk brukernavn og passord"
+
+#: id:15207
+msgctxt "Auto context with id 15207"
+msgid "Connected"
+msgstr "Tilkoblet"
+
+#: id:15208
+msgid "Not connected"
+msgstr "Ikke tilkoblet"
+
+#: id:15209
+msgid "Submit interval %i"
+msgstr "Innsendingsintervall %i"
+
+#: id:15210
+msgid "Cached %i songs"
+msgstr "Cachet %i sanger"
+
+#: id:15211
+msgid "Submitting..."
+msgstr "Sender..."
+
+#: id:15212
+msgid "Submitting in %i secs"
+msgstr "Sender om %i sekunder"
+
+#: id:15213
+msgid "Play using..."
+msgstr "Spill med..."
+
+#: id:15214
+msgid "Use smoothed A/V synchronization"
+msgstr "Bruk utjevnet A/V synkronisering"
+
+#: id:15215
+msgid "Hide file names in thumbs view"
+msgstr "Skjul filnavn i miniatyrvisning"
+
+#: id:15216
+msgid "Play in party mode"
+msgstr "Spill av i partymodus"
+
+#: id:15217
+msgid "Submit songs to Libre.fm"
+msgstr "Send inn sanger til Libre.fm"
+
+#: id:15218
+msgid "Libre.fm username"
+msgstr "Libre.fm brukernavn"
+
+#: id:15219
+msgid "Libre.fm password"
+msgstr "Libre.fm passord"
+
+#: id:15220
+msgid "Libre.fm"
+msgstr "Libre.fm"
+
+#: id:15221
+msgid "Song submission"
+msgstr "Innsending av sang"
+
+#: id:15250
+msgid "Submit Last.fm radio to Last.fm"
+msgstr "Send inn Last.fm-radio til Last.fm"
+
+#: id:15251
+msgid "Connecting to Last.fm..."
+msgstr "Kobler til Last.fm..."
+
+#: id:15252
+msgid "Selecting station..."
+msgstr "Velger stasjon..."
+
+#: id:15253
+msgid "Search similar artists..."
+msgstr "Søk etter liknende artister..."
+
+#: id:15254
+msgid "Search similar tags..."
+msgstr "Søk etter liknende tagger..."
+
+#: id:15255
+msgid "Your profile (%name%)"
+msgstr "Din profil (%name%)"
+
+#: id:15256
+msgid "Overall top tags"
+msgstr "Mest brukte tagger generelt"
+
+#: id:15257
+msgid "Top artists for tag %name%"
+msgstr "Høyest rangerte artister for tagg %name%"
+
+#: id:15258
+msgid "Top albums for tag %name%"
+msgstr "Høyest rangerte albumer for tagg %name%"
+
+#: id:15259
+msgid "Top tracks for tag %name%"
+msgstr "Høyest rangerte spor for tagg %name%"
+
+#: id:15260
+msgid "Listen to tag %name% Last.fm radio"
+msgstr "Hør på tagg %name% Last.fm radio"
+
+#: id:15261
+msgid "Similar artists as %name%"
+msgstr "Liknende artister som %name%"
+
+#: id:15262
+msgid "Top %name% albums"
+msgstr "Topp %name% album"
+
+#: id:15263
+msgid "Top %name% tracks"
+msgstr "Topp %name% spor"
+
+#: id:15264
+msgid "Top %name% tags"
+msgstr "Topp %name% tagger"
+
+#: id:15265
+msgid "Biggest fans of %name%"
+msgstr "Største fans av %name%"
+
+#: id:15266
+msgid "Listen to %name% fans Last.fm radio"
+msgstr "Hør på fans av %name% fra Last.fm"
+
+#: id:15267
+msgid "Listen to %name% similar artists Last.fm radio"
+msgstr "Hør på artister som likner på %name% fra Last.fm"
+
+#: id:15268
+msgid "Top artists for user %name%"
+msgstr "Toppartister for bruker %name%"
+
+#: id:15269
+msgid "Top albums for user %name%"
+msgstr "Toppalbum for bruker %name%"
+
+#: id:15270
+msgid "Top tracks for user %name%"
+msgstr "Toppspor for bruker %name%"
+
+#: id:15271
+msgid "Friends of user %name%"
+msgstr "Venner av bruker %name%"
+
+#: id:15272
+msgid "Neighbours of user %name%"
+msgstr "Naboer av bruker %name%"
+
+#: id:15273
+msgid "Weekly artist chart for %name%"
+msgstr "Ukentlig artistliste for %name%"
+
+#: id:15274
+msgid "Weekly album chart for %name%"
+msgstr "Ukentlig albumliste for %name%"
+
+#: id:15275
+msgid "Weekly track chart for %name%"
+msgstr "Ukentlig sporliste for %name%"
+
+#: id:15276
+msgid "Listen to %name%'s neighbours Last.fm radio"
+msgstr "Hør på %name%'s nabo fra Last.fm"
+
+#: id:15277
+msgid "Listen to %name%'s personal Last.fm radio"
+msgstr "Hør på %name%'s personlige Last.fm"
+
+#: id:15278
+msgid "Listen to %name%'s mix Last.fm radio"
+msgstr "Hør på %name%'s favorittspor Last.fm"
+
+#: id:15279
+msgid "Retrieving list from Last.fm..."
+msgstr "Mottar liste fra Last.fm..."
+
+#: id:15280
+msgid "Can't retrieve list from Last.fm..."
+msgstr "Kan ikke motta liste fra Last.fm..."
+
+#: id:15281
+msgid "Enter an artist name to find related ones"
+msgstr "Skriv inn et artistnavn for å finne relaterte"
+
+#: id:15282
+msgid "Enter a tag name to find similar ones"
+msgstr "Skriv inn et tagg-navn for å finne liknende"
+
+#: id:15283
+msgid "Tracks recently listened by %name%"
+msgstr "Spor nylig lyttet til av %name%"
+
+#: id:15284
+msgid "Listen to %name%'s recommendations Last.fm radio"
+msgstr "Hør på %name%'s anbefalinger for Last.fm radio"
+
+#: id:15285
+msgid "Top tags for user %name%"
+msgstr "Topp tagger for bruker %name%"
+
+#: id:15287
+msgid "Do you want to add the current track to your loved tracks?"
+msgstr "Legge valgte sang til favoritter?"
+
+#: id:15288
+msgid "Do you want to ban the current track?"
+msgstr "Vil du sperre valgte sang?"
+
+#: id:15289
+msgid "Added to your loved tracks: '%s'."
+msgstr "Lagt til dine favoritter: '%s'."
+
+#: id:15290
+msgid "Could not add '%s' to your loved tracks."
+msgstr "Kunne ikke legge '%s' til dine favoritter."
+
+#: id:15291
+msgid "Banned: '%s'."
+msgstr "Sperret: '%s'."
+
+#: id:15292
+msgid "Could not ban '%s'."
+msgstr "Kunne ikke sperre '%s'."
+
+#: id:15293
+msgid "Tracks recently loved by %name%"
+msgstr "Nylig favoritt til %name%"
+
+#: id:15294
+msgid "Tracks recently banned by %name%"
+msgstr "Nylig sperret av %name%"
+
+#: id:15295
+msgid "Remove from loved tracks"
+msgstr "Fjern fra favoritter."
+
+#: id:15296
+msgid "Un-ban"
+msgstr "Opphev sperre."
+
+#: id:15297
+msgid "Do you want to remove this track from your loved tracks?"
+msgstr "Ønsker du å fjerne denne sangen fra dine favoritter?"
+
+#: id:15298
+msgid "Do you want to un-ban this track?"
+msgstr "Ønsker du å oppheve sperringen av denne sangen?"
+
+#: id:15300
+msgid "Path not found or invalid"
+msgstr "Sti ble ikke funnet eller er ugyldig"
+
+#: id:15301
+msgid "Could not connect to network server"
+msgstr "Kunne ikke koble til nettverksserver"
+
+#: id:15302
+msgid "No servers found"
+msgstr "Ingen servere funnet"
+
+#: id:15303
+msgid "Workgroup not found"
+msgstr "Arbeidsgruppe ikke funnet"
+
+#: id:15310
+msgid "Opening multi-path source"
+msgstr "Åpner kilde med flere stier"
+
+#: id:15311
+msgid "Path:"
+msgstr "Sti:"
+
+#: id:16000
+msgctxt "Auto context with id 16000"
+msgid "General"
+msgstr "Generelt"
+
+#: id:16002
+msgid "Internet lookup"
+msgstr "Internettoppslag"
+
+#: id:16003
+msgid "Player"
+msgstr "Spiller"
+
+#: id:16004
+msgid "Play media from disc"
+msgstr "Spill media fra plate"
+
+#: id:16008
+msgid "Enter new title"
+msgstr "Skriv inn ny tittel"
+
+#: id:16009
+msgid "Enter the movie name"
+msgstr "Skriv inn filmens navn"
+
+#: id:16010
+msgid "Enter the profile name"
+msgstr "Skriv inn profilnavnet"
+
+#: id:16011
+msgid "Enter the album name"
+msgstr "Skriv inn albumets navn"
+
+#: id:16012
+msgid "Enter the playlist name"
+msgstr "Skriv inn navnet på spillelisten"
+
+#: id:16013
+msgid "Enter new filename"
+msgstr "Skriv inn nytt filnavn"
+
+#: id:16014
+msgid "Enter folder name"
+msgstr "Skriv inn mappennavn"
+
+#: id:16015
+msgid "Enter directory"
+msgstr "Skriv inn katalog"
+
+#: id:16016
+msgid "Available options: %A, %T, %N, %B, %D, %G, %Y, %F, %S"
+msgstr "Tilgjengelige valg: %A, %T, %N, %B, %D, %G, %Y, %F, %S"
+
+#: id:16017
+msgid "Enter search string"
+msgstr "Skriv inn søketekst"
+
+#: id:16018
+msgctxt "Auto context with id 16018"
+msgid "None"
+msgstr "Ingen"
+
+#: id:16019
+msgid "Auto select"
+msgstr "Velg automatisk"
+
+#: id:16020
+msgid "De-interlace"
+msgstr "Fjern sammenfletting"
+
+#: id:16021
+msgid "Bob"
+msgstr "Bob"
+
+#: id:16022
+msgid "Bob (inverted)"
+msgstr "Bob (invertert)"
+
+#: id:16024
+msgid "Canceling..."
+msgstr "Avbryter..."
+
+#: id:16025
+msgid "Enter the artist name"
+msgstr "Skriv inn artistnavn"
+
+#: id:16026
+msgid "Playback failed"
+msgstr "Avspilling mislyktes"
+
+#: id:16027
+msgid "One or more items failed to play."
+msgstr "En eller flere elementer kunne ikke spilles"
+
+#: id:16028
+msgid "Enter value"
+msgstr "Skriv inn verdi"
+
+#: id:16029
+msgid "Check the log file for details."
+msgstr "Sjekk loggfilen for detaljer"
+
+#: id:16030
+msgid "Party mode aborted."
+msgstr "Partymodus avbrutt."
+
+#: id:16031
+msgid "No matching songs in the library."
+msgstr "Ingen samsvarende sanger i bibliotek."
+
+#: id:16032
+msgid "Could not initialize database."
+msgstr "Kunne ikke initialisere databasen."
+
+#: id:16033
+msgid "Could not open database."
+msgstr "Kunne ikke åpne databasen."
+
+#: id:16034
+msgid "Could not get songs from database."
+msgstr "Kunne ikke hente sanger fra databasen."
+
+#: id:16035
+msgid "Party mode playlist"
+msgstr "Partymode spilleliste"
+
+#: id:16036
+msgid "De-interlace (Half)"
+msgstr "De-interlace (Halve)"
+
+#: id:16037
+msgid "Deinterlace video"
+msgstr ""
+
+#: id:16038
+msgid "Deinterlace method"
+msgstr ""
+
+#: id:16039
+msgctxt "Auto context with id 16039"
+msgid "Off"
+msgstr ""
+
+#: id:16040
+msgctxt "Auto context with id 16040"
+msgid "Auto"
+msgstr ""
+
+#: id:16041
+msgid "On"
+msgstr ""
+
+#: id:16100
+msgid "All Videos"
+msgstr "Alle filmer"
+
+#: id:16101
+msgid "Unwatched"
+msgstr "Usette"
+
+#: id:16102
+msgid "Watched"
+msgstr "Sette"
+
+#: id:16103
+msgid "Mark as watched"
+msgstr "Merk som sett"
+
+#: id:16104
+msgid "Mark as unwatched"
+msgstr "Merk som usett"
+
+#: id:16105
+msgid "Edit title"
+msgstr "Rediger tittel"
+
+#: id:16200
+msgid "Operation was aborted"
+msgstr "Handlingen ble avbrutt"
+
+#: id:16201
+msgid "Copy failed"
+msgstr "Kopiering mislykket"
+
+#: id:16202
+msgid "Failed to copy at least one file"
+msgstr "Kunne ikke kopiere en eller flere filer"
+
+#: id:16203
+msgid "Move failed"
+msgstr "Flytting mislykket"
+
+#: id:16204
+msgid "Failed to move at least one file"
+msgstr "Kunne ikke flytte en eller flere filer"
+
+#: id:16205
+msgid "Delete failed"
+msgstr "Sletting mislykket"
+
+#: id:16206
+msgid "Failed to delete at least one file"
+msgstr "Kunne ikke slette en eller flere filer"
+
+#: id:16300
+msgid "Video scaling method"
+msgstr "Videoskaleringsmetode"
+
+#: id:16301
+msgid "Nearest neighbour"
+msgstr "Nærmeste nabo"
+
+#: id:16302
+msgid "Bilinear"
+msgstr "Bilineær"
+
+#: id:16303
+msgctxt "Auto context with id 16303"
+msgid "Bicubic"
+msgstr "Bikubisk"
+
+#: id:16304
+msgid "Lanczos2"
+msgstr "Lanczos2"
+
+#: id:16305
+msgid "Lanczos3"
+msgstr "Lanczos3"
+
+#: id:16306
+msgid "Sinc8"
+msgstr "Sinc8"
+
+#: id:16307
+msgid "Bicubic (software)"
+msgstr "Bikubisk (programvare)"
+
+#: id:16308
+msgid "Lanczos (software)"
+msgstr "Lanczos (programvare)"
+
+#: id:16309
+msgid "Sinc (software)"
+msgstr "Sinc (programvare)"
+
+#: id:16310
+msgid "Temporal"
+msgstr "Temporær"
+
+#: id:16311
+msgid "Temporal/Spatial"
+msgstr "Temporær/romlig"
+
+#: id:16312
+msgid "(VDPAU)Noise Reduction"
+msgstr "(VDPAU)Støyreduksjon"
+
+#: id:16313
+msgid "(VDPAU)Sharpness"
+msgstr "(VDPAU)Skarphet"
+
+#: id:16314
+msgid "Inverse Telecine"
+msgstr "Omvendt telecine"
+
+#: id:16315
+msgid "Lanczos3 optimized"
+msgstr "Lanczos3-optimalisert"
+
+#: id:16316
+msgctxt "Auto context with id 16316"
+msgid "Auto"
+msgstr "Automatisk"
+
+#: id:16317
+msgid "Temporal (Half)"
+msgstr "Temporær (halv)"
+
+#: id:16318
+msgid "Temporal/Spatial (Half)"
+msgstr "Temporær/romlig (halv)"
+
+#: id:16319
+msgid "DXVA"
+msgstr "DXVA"
+
+#: id:16320
+msgid "DXVA Bob"
+msgstr "DXVA Bob"
+
+#: id:16321
+msgid "DXVA Best"
+msgstr "DXVA Best"
+
+#: id:16322
+msgid "Spline36"
+msgstr "Spline36"
+
+#: id:16323
+msgid "Spline36 optimized"
+msgstr "Spline36 optimert"
+
+#: id:16324
+msgid "Software Blend"
+msgstr ""
+
+#: id:16400
+msgid "Post-processing"
+msgstr "Post-prosessering"
+
+#: id:17500
+msgid "Display sleep timeout"
+msgstr "Slå av skjerm etter"
+
+#: id:19000
+msgid "Switch to channel"
+msgstr "Bytt til kanal"
+
+#: id:20000
+msgid "Saved music folder"
+msgstr "Mappe for lagret musikk"
+
+#: id:20001
+msgid "Use external DVD player"
+msgstr "Bruk ekstern DVD-spiller"
+
+#: id:20002
+msgid "External DVD player"
+msgstr "Ekstern DVD-spiller"
+
+#: id:20003
+msgid "Trainers folder"
+msgstr "Mappe for trainere"
+
+#: id:20004
+msgid "Screenshot folder"
+msgstr "Mappe for skjermbilder"
+
+#: id:20006
+msgid "Playlists folder"
+msgstr "Mappe for spillelister"
+
+#: id:20007
+msgid "Recordings"
+msgstr "Opptak"
+
+#: id:20008
+msgid "Screenshots"
+msgstr "Skjermbilder"
+
+#: id:20009
+msgid "Use XBMC"
+msgstr "Bruk XBMC"
+
+#: id:20011
+msgid "Music playlists"
+msgstr "Musikkspillelister"
+
+#: id:20012
+msgid "Video playlists"
+msgstr "Videospillelister"
+
+#: id:20013
+msgid "Do you wish to launch the game?"
+msgstr "Ønsker du å starte spillet?"
+
+#: id:20014
+msgid "Sort by: Playlist"
+msgstr "Sorter etter: Spilleliste"
+
+#: id:20015
+msgid "Remote thumb"
+msgstr "Ekstern miniatyr"
+
+#: id:20016
+msgid "Current thumb"
+msgstr "Nåværende miniatyr"
+
+#: id:20017
+msgid "Local thumb"
+msgstr "Lokal miniatyr"
+
+#: id:20018
+msgid "No thumb"
+msgstr "Ingen miniatyr"
+
+#: id:20019
+msgid "Choose thumbnail"
+msgstr "Velg miniatyr"
+
+#: id:20023
+msgid "Conflict"
+msgstr "Konflikt"
+
+#: id:20024
+msgid "Scan new"
+msgstr "Skann nye"
+
+#: id:20025
+msgid "Scan all"
+msgstr "Skann alle"
+
+#: id:20026
+msgid "Region"
+msgstr "Region"
+
+#: id:20037
+msgid "Summary"
+msgstr "Sammendrag"
+
+#: id:20038
+msgid "Lock music window"
+msgstr "Lås musikksekjson"
+
+#: id:20039
+msgid "Lock videos window"
+msgstr "Lås filmseksjon"
+
+#: id:20040
+msgid "Lock pictures window"
+msgstr "Lås bildeseksjon"
+
+#: id:20041
+msgid "Lock programs & scripts windows"
+msgstr "Lås program- og scriptseksjon"
+
+#: id:20042
+msgid "Lock file manager"
+msgstr "Lås filbehandler"
+
+#: id:20043
+msgid "Lock settings"
+msgstr "Lås innstillinger"
+
+#: id:20044
+msgid "Start fresh"
+msgstr "Start på nytt"
+
+#: id:20045
+msgid "Enter master mode"
+msgstr "Gå i mastermodus"
+
+#: id:20046
+msgid "Leave master mode"
+msgstr "Forlat mastermodus"
+
+#: id:20047
+msgid "Create profile '%s'?"
+msgstr "Lag profil '%s' ?"
+
+#: id:20048
+msgid "Start with fresh settings"
+msgstr "Start med ferske innstillinger"
+
+#: id:20049
+msgid "Best available"
+msgstr "Beste tilgjengelige"
+
+#: id:20050
+msgid "Auto-switch between 16x9 and 4x3"
+msgstr "Bytt automatisk mellom 16x9 og 4x3"
+
+#: id:20051
+msgid "Treat stacked files as single file"
+msgstr "Behandle stablede filer som én fil"
+
+#: id:20052
+msgid "Caution"
+msgstr "Advarsel"
+
+#: id:20053
+msgid "Left master mode"
+msgstr "Forlot mastermodus"
+
+#: id:20054
+msgid "Entered master mode"
+msgstr "Gikk i mastermodus"
+
+#: id:20055
+msgid "Allmusic.com thumb"
+msgstr "Allmusic.com miniatyr"
+
+#: id:20057
+msgid "Remove thumbnail"
+msgstr "Fjern miniatyrbilde"
+
+#: id:20058
+msgid "Add profile..."
+msgstr "Legg til profil..."
+
+#: id:20059
+msgid "Query info for all albums"
+msgstr "Spør etter info for alle album"
+
+#: id:20060
+msgctxt "Auto context with id 20060"
+msgid "Media info"
+msgstr "Mediainfo"
+
+#: id:20061
+msgctxt "Auto context with id 20061"
+msgid "Separate"
+msgstr "Separate"
+
+#: id:20062
+msgid "Shares with default"
+msgstr "Delte filer med standard"
+
+#: id:20063
+msgid "Shares with default (read only)"
+msgstr "Delte filer med standard (kun lesing)"
+
+#: id:20064
+msgid "Copy default"
+msgstr "Kopier standard"
+
+#: id:20065
+msgid "Profile picture"
+msgstr "Profilbilde"
+
+#: id:20066
+msgid "Lock preferences"
+msgstr "Lås innstillinger"
+
+#: id:20067
+msgid "Edit profile"
+msgstr "Rediger profil"
+
+#: id:20068
+msgid "Profile lock"
+msgstr "Profillås"
+
+#: id:20069
+msgid "Could not create folder"
+msgstr "Kunne ikke lage mappe"
+
+#: id:20070
+msgid "Profile directory"
+msgstr "Profilmappe"
+
+#: id:20071
+msgid "Start with fresh media sources"
+msgstr "Start med nye mediakilder"
+
+#: id:20072
+msgid "Make sure the selected folder is writable"
+msgstr "Sørg for at den valgte mappen er skrivbar"
+
+#: id:20073
+msgid "and that the new folder name is valid"
+msgstr "og at det nye mappenavnet er gyldig"
+
+#: id:20074
+msgid "MPAA rating"
+msgstr "Aldersgrense"
+
+#: id:20075
+msgid "Enter master lock code"
+msgstr "Skriv inn masterlåskode"
+
+#: id:20076
+msgid "Ask for master lock code on startup"
+msgstr "Spør etter masterlåskode ved oppstart"
+
+#: id:20077
+msgid "Skin settings"
+msgstr "Skinn-innstillinger"
+
+#: id:20078
+msgid "- no link set -"
+msgstr "- ingen link satt -"
+
+#: id:20079
+msgid "Enable animations"
+msgstr "Aktiver animasjoner"
+
+#: id:20080
+msgid "Disable RSS during music"
+msgstr "Deaktiver RSS ved musikkavspilling"
+
+#: id:20081
+msgid "Enable shortcut buttons"
+msgstr "Aktiver knapper for snarveier"
+
+#: id:20082
+msgid "Show programs in main menu"
+msgstr "Vis programmer i hovedmeny"
+
+#: id:20083
+msgid "Show music info"
+msgstr "Vis musikkinformasjon"
+
+#: id:20084
+msgid "Show weather info"
+msgstr "Vis værinformasjon"
+
+#: id:20085
+msgid "Show system info"
+msgstr "Vis systeminformasjon"
+
+#: id:20086
+msgid "Show available disc space C: E: F:"
+msgstr "Vis tilgjengelig diskplass C: E: F:"
+
+#: id:20087
+msgid "Show available disc space E: F: G:"
+msgstr "Vis tilgjengelig diskplass E: F: G:"
+
+#: id:20088
+msgid "Weather info"
+msgstr "Værinformasjon"
+
+#: id:20089
+msgid "Drive space free"
+msgstr "Ledig diskplass"
+
+#: id:20090
+msgid "Enter the name of an existing share"
+msgstr "Skriv inn navnet på en eksisterende delt mappe"
+
+#: id:20091
+msgid "Lock code"
+msgstr "Låskode"
+
+#: id:20092
+msgid "Load profile"
+msgstr "Last profil"
+
+#: id:20093
+msgid "Profile name"
+msgstr "Profilnavn"
+
+#: id:20094
+msgctxt "Auto context with id 20094"
+msgid "Media sources"
+msgstr "Mediakilder"
+
+#: id:20095
+msgid "Enter profile lock code"
+msgstr "Skriv inn profillåskode"
+
+#: id:20096
+msgctxt "Auto context with id 20096"
+msgid "Login screen"
+msgstr "Innloggingsbilde"
+
+#: id:20097
+msgid "Fetching album info"
+msgstr "Henter albuminfo"
+
+#: id:20098
+msgid "Fetching info for album"
+msgstr "Henter info for album"
+
+#: id:20099
+msgid "Can't rip CD or track while playing from CD"
+msgstr "Kan ikke rippe CD eller spor ved avspilling av CD"
+
+#: id:20100
+msgid "Master lock code and settings"
+msgstr "Masterkode og låser"
+
+#: id:20101
+msgid "Entering master lock code always enables master mode"
+msgstr "Angivelse av masterkode aktiverer alltid mastermodus"
+
+#: id:20102
+msgid "or copy from default?"
+msgstr "eller kopier fra standard?"
+
+#: id:20103
+msgid "Save changes to profile?"
+msgstr "Lagre innstillinger i profil?"
+
+#: id:20104
+msgid "Old settings found."
+msgstr "Gamle innstillinger funnet."
+
+#: id:20105
+msgid "Do you want to use them?"
+msgstr "Vil du bruke dem?"
+
+#: id:20106
+msgid "Old media sources found."
+msgstr "Gamle mediakilder funnet."
+
+#: id:20107
+msgid "Separate (locked)"
+msgstr "Separer (låst)"
+
+#: id:20108
+msgid "Root"
+msgstr "Rot"
+
+#: id:20109
+msgid "- Zoom"
+msgstr "- Zoom"
+
+#: id:20110
+msgid "UPnP settings"
+msgstr "UPnP-innstillinger"
+
+#: id:20111
+msgid "Autostart UPnP client"
+msgstr "Start UPnP-klient automatisk"
+
+#: id:20112
+msgid "Last login: %s"
+msgstr "Siste innlogging: %s"
+
+#: id:20113
+msgid "Never logged on"
+msgstr "Aldri pålogget"
+
+#: id:20114
+msgid "Profile %i / %i"
+msgstr "Profil %i / %i"
+
+#: id:20115
+msgid "User login / Select a profile"
+msgstr "Brukerpålogging / Velg en profil"
+
+#: id:20116
+msgid "Use lock on login screen"
+msgstr "Bruk lås på innloggingsbildet"
+
+#: id:20117
+msgid "Invalid lock code."
+msgstr "Ugyldig kode."
+
+#: id:20118
+msgid "This requires the master lock to be set."
+msgstr "Dette krever at masterkoden blir satt."
+
+#: id:20119
+msgid "Would you like to set it now?"
+msgstr "Vil du angi den nå?"
+
+#: id:20120
+msgid "Loading program information"
+msgstr "Laster programinformasjon"
+
+#: id:20121
+msgid "Party on!"
+msgstr "Party on!"
+
+#: id:20122
+msgid "True"
+msgstr "Sant"
+
+#: id:20123
+msgid "Mixing drinks"
+msgstr "Mikser drinker"
+
+#: id:20124
+msgid "Filling glasses"
+msgstr "Fyller glass"
+
+#: id:20125
+msgid "Logged on as"
+msgstr "Logget på som"
+
+#: id:20126
+msgid "Log off"
+msgstr "Logg av"
+
+#: id:20128
+msgid "Go to root"
+msgstr "Gå til rot"
+
+#: id:20129
+msgid "Weave"
+msgstr "Weave"
+
+#: id:20130
+msgid "Weave (inverted)"
+msgstr "Weave (invertert)"
+
+#: id:20131
+msgid "Blend"
+msgstr "Blend"
+
+#: id:20132
+msgid "Restart video"
+msgstr "Start video på nytt"
+
+#: id:20133
+msgid "Edit network location"
+msgstr "Endre nettverkssteder"
+
+#: id:20134
+msgid "Remove network location"
+msgstr "Fjern nettverkssted"
+
+#: id:20135
+msgid "Do you want to scan the folder?"
+msgstr "Vil du skanne mappen?"
+
+#: id:20136
+msgid "Memory unit"
+msgstr "Minneenhet"
+
+#: id:20137
+msgid "Memory unit mounted"
+msgstr "Minneenhet montert"
+
+#: id:20138
+msgid "Unable to mount memory unit"
+msgstr "Kan ikke montere minneenhet"
+
+#: id:20139
+msgid "In port %i, slot %i"
+msgstr "I port %i, plass %i"
+
+#: id:20140
+msgid "Lock screensaver"
+msgstr "Lås skjermbeskytter"
+
+#: id:20141
+msgid "Set"
+msgstr "Sett"
+
+#: id:20142
+msgctxt "Auto context with id 20142"
+msgid "Username"
+msgstr "Brukernavn"
+
+#: id:20143
+msgid "Enter password for"
+msgstr "Skriv inn passord for"
+
+#: id:20144
+msgid "Shutdown timer"
+msgstr "Slå-av-timer"
+
+#: id:20145
+msgid "Shutdown interval (in minutes)"
+msgstr "Slå-av intervall (i minutter)"
+
+#: id:20146
+msgid "Started, shutdown in %im"
+msgstr "Startet, slår av om %im"
+
+#: id:20147
+msgid "Shutdown in 30 minutes"
+msgstr "Slår av om 30 minutter"
+
+#: id:20148
+msgid "Shutdown in 60 minutes"
+msgstr "Slår av om 60 minutter"
+
+#: id:20149
+msgid "Shutdown in 120 minutes"
+msgstr "Slår av om 120 minutter"
+
+#: id:20150
+msgid "Custom shutdown timer"
+msgstr "Egendefinert slå-av-timer"
+
+#: id:20151
+msgid "Cancel shutdown timer"
+msgstr "Avbryt slå-av-timer"
+
+#: id:20152
+msgid "Lock preferences for %s"
+msgstr "Lås innstillinger for %s"
+
+#: id:20153
+msgid "Browse..."
+msgstr "Bla..."
+
+#: id:20154
+msgid "Summary information"
+msgstr "Grunnleggende informasjon"
+
+#: id:20155
+msgid "Storage information"
+msgstr "Lagringsinformasjon"
+
+#: id:20156
+msgid "Hard disk information"
+msgstr "Harddiskinformasjon"
+
+#: id:20157
+msgid "DVD-ROM information"
+msgstr "DVD-spillerinformasjon"
+
+#: id:20158
+msgid "Network information"
+msgstr "Nettverksinformasjon"
+
+#: id:20159
+msgid "Video information"
+msgstr "Videoinformasjon"
+
+#: id:20160
+msgid "Hardware information"
+msgstr "Maskinvareinformasjon"
+
+#: id:20161
+msgid "Total"
+msgstr "Totalt"
+
+#: id:20162
+msgid "Used"
+msgstr "Brukt"
+
+#: id:20163
+msgid "of"
+msgstr "av"
+
+#: id:20164
+msgid "Locking not supported"
+msgstr "Låsing ikke støttet"
+
+#: id:20165
+msgid "Not locked"
+msgstr "Ikke låst"
+
+#: id:20166
+msgid "Locked"
+msgstr "Låst"
+
+#: id:20167
+msgid "Frozen"
+msgstr "Fryst"
+
+#: id:20168
+msgid "Requires reset"
+msgstr "Krever omstart"
+
+#: id:20169
+msgid "Week"
+msgstr "Uke"
+
+#: id:20170
+msgid "Line"
+msgstr "Serie"
+
+#: id:20171
+msgid "Windows network (SMB)"
+msgstr "Windows nettverk (SMB)"
+
+#: id:20172
+msgid "XBMSP server"
+msgstr "XBMSP server"
+
+#: id:20173
+msgctxt "Auto context with id 20173"
+msgid "FTP server"
+msgstr "FTP server"
+
+#: id:20174
+msgid "iTunes music share (DAAP)"
+msgstr "iTunes musikkdeling (DAAP)"
+
+#: id:20175
+msgid "UPnP server"
+msgstr "UPnP server"
+
+#: id:20176
+msgid "Show video info"
+msgstr "Vis informasjon om film"
+
+#: id:20177
+msgid "Done"
+msgstr "Ferdig"
+
+#: id:20178
+msgid "Shift"
+msgstr "Shift"
+
+#: id:20179
+msgid "Caps Lock"
+msgstr "Caps Lock"
+
+#: id:20180
+msgid "Symbols"
+msgstr "Symboler"
+
+#: id:20181
+msgid "Backspace"
+msgstr "Tilbake"
+
+#: id:20182
+msgid "Space"
+msgstr "Mellomrom"
+
+#: id:20183
+msgid "Reload skin"
+msgstr "Last skinn på ny"
+
+#: id:20184
+msgid "Rotate pictures using EXIF information"
+msgstr "Roter bilde i henhold til EXIF-informasjon"
+
+#: id:20185
+msgid "Use poster view styles for TV shows"
+msgstr "Bruk plakatvisninger for TV-serier"
+
+#: id:20186
+msgid "Please wait"
+msgstr "Vennligst vent"
+
+#: id:20187
+msgid "UPnP"
+msgstr ""
+
+#: id:20189
+msgid "Enable auto scrolling for plot & review"
+msgstr "Aktiver autorulling for plott og anmeldelse"
+
+#: id:20190
+msgctxt "Auto context with id 20190"
+msgid "Custom"
+msgstr "Egendefinert"
+
+#: id:20191
+msgid "Enable debug logging"
+msgstr "Aktiver feilsøkingslogging"
+
+#: id:20192
+msgid "Download additional information during updates"
+msgstr "Last ned ekstra informasjon under oppdateringer"
+
+#: id:20193
+msgid "Default service for album information"
+msgstr "Standardtjener for albuminformasjon"
+
+#: id:20194
+msgid "Default service for artist information"
+msgstr "Standardtjener for artistinformasjon"
+
+#: id:20195
+msgid "Change scraper"
+msgstr "Bytt skraper"
+
+#: id:20196
+msgid "Export music library"
+msgstr "Eksporter musikkbibliotek"
+
+#: id:20197
+msgid "Import music library"
+msgstr "Importer musikkbibliotek"
+
+#: id:20198
+msgid "No artist found!"
+msgstr "Ingen artist funnet!"
+
+#: id:20199
+msgid "Downloading artist info failed"
+msgstr "Nedlasting av artistinfo mislyktes"
+
+#: id:20250
+msgid "Party on! (videos)"
+msgstr "Party on! (filmer)"
+
+#: id:20251
+msgid "Mixing drinks (videos)"
+msgstr "Mikser drinker (filmer)"
+
+#: id:20252
+msgid "Filling glasses (videos)"
+msgstr "Fyller glassene (filmer)"
+
+#: id:20253
+msgid "WebDAV server (HTTP)"
+msgstr "WebDAV-server (HTTP)"
+
+#: id:20254
+msgid "WebDAV server (HTTPS)"
+msgstr "WebDAV-server (HTTPS)"
+
+#: id:20255
+msgid "First logon, edit your profile"
+msgstr "Første pålogging, editer profilen din"
+
+#: id:20256
+msgid "HTS Tvheadend client"
+msgstr "HTS Tvheadend-klient"
+
+#: id:20257
+msgid "VDR Streamdev client"
+msgstr "VDR Streamdev-klient"
+
+#: id:20258
+msgid "MythTV client"
+msgstr "MythTV-klient"
+
+#: id:20259
+msgid "Network Filesystem (NFS)"
+msgstr "Nettverksfilsystem (NFS)"
+
+#: id:20260
+msgid "Secure Shell (SSH/SFTP)"
+msgstr "Secure Shell (SSH/SFTP)"
+
+#: id:20261
+msgid "Apple Filing Protocol (AFP)"
+msgstr "Apple Filprotokoll (AFP)"
+
+#: id:20300
+msgid "Web server directory (HTTP)"
+msgstr "Webserverkatalog (HTTP)"
+
+#: id:20301
+msgid "Web server directory (HTTPS)"
+msgstr "Webserverkatalog (HTTPS)"
+
+#: id:20302
+msgid "Unable to write to folder:"
+msgstr "Kunne ikke skrive til mappe:"
+
+#: id:20303
+msgid "Do you want to skip and proceed?"
+msgstr "Vil du ignorere og fortsette?"
+
+#: id:20304
+msgid "RSS Feed"
+msgstr "RSS-strøm"
+
+#: id:20307
+msgid "Secondary DNS"
+msgstr "Sekundær DNS"
+
+#: id:20308
+msgid "DHCP server:"
+msgstr "DHCP-server:"
+
+#: id:20309
+msgid "Make new folder"
+msgstr "Lag ny mappe"
+
+#: id:20310
+msgid "Dim LCD on playback"
+msgstr "Dim LCD ved avspilling"
+
+#: id:20311
+msgid "Unknown or onboard (protected)"
+msgstr "Ukjent eller integrert (beskyttet)"
+
+#: id:20312
+msgid "Dim LCD on paused"
+msgstr "Dim LCD ved pause"
+
+#: id:20314
+msgid "Videos - Library"
+msgstr "Videoer - Bibliotek"
+
+#: id:20316
+msgid "Sort by: ID"
+msgstr "Sorter etter: ID"
+
+#: id:20324
+msgid "Play part..."
+msgstr "Spill del..."
+
+#: id:20325
+msgid "Calibration reset"
+msgstr "Nullstill kalibrering"
+
+#: id:20326
+msgid "This will reset the calibration values for %s"
+msgstr "Dette vil sette kalibreringen for %s"
+
+#: id:20327
+msgid "to it's default values."
+msgstr "til standardverdiene."
+
+#: id:20328
+msgid "Browse for destination"
+msgstr "Bla etter mål"
+
+#: id:20329
+msgid "Movies are in separate folders that match the movie title"
+msgstr ""
+
+#: id:20330
+msgid "Use folder names for lookups"
+msgstr "Bruk mappenavn ved oppslag"
+
+#: id:20331
+msgctxt "Auto context with id 20331"
+msgid "File"
+msgstr "Fil"
+
+#: id:20332
+msgid "Use file or folder names in lookups?"
+msgstr "Bruk fil- eller mappenavn ved oppslag?"
+
+#: id:20333
+msgid "Set content"
+msgstr "Sett innhold"
+
+#: id:20334
+msgid "Folder"
+msgstr "Mappe"
+
+#: id:20335
+msgid "Look for content recursively?"
+msgstr "Søk etter innhold rekursivt?"
+
+#: id:20336
+msgid "Unlock sources"
+msgstr "Lås opp kilder"
+
+#: id:20337
+msgid "Actor"
+msgstr "Skuespiller"
+
+#: id:20338
+msgid "Movie"
+msgstr "Film"
+
+#: id:20339
+msgid "Director"
+msgstr "Regissør"
+
+#: id:20340
+msgid "Do you want to remove all items within"
+msgstr "Vil du slette alle oppføringer fra"
+
+#: id:20341
+msgid "this path from the XBMC library?"
+msgstr "denne stien fra XBMC-biblioteket?"
+
+#: id:20342
+msgctxt "Auto context with id 20342"
+msgid "Movies"
+msgstr "Filmer"
+
+#: id:20343
+msgid "TV shows"
+msgstr "TV-serier"
+
+#: id:20344
+msgid "This directory contains"
+msgstr "Denne mappen inneholder"
+
+#: id:20345
+msgid "Run automated scan"
+msgstr "Kjør automatisk skanning"
+
+#: id:20346
+msgid "Scan recursively"
+msgstr "Søk rekursivt"
+
+#: id:20347
+msgid "as"
+msgstr "som"
+
+#: id:20348
+msgid "Directors"
+msgstr "Regissører"
+
+#: id:20349
+msgid "No video files found in this path!"
+msgstr "Ingen videofiler funnet i denne mappen!"
+
+#: id:20350
+msgid "votes"
+msgstr "stemmer"
+
+#: id:20351
+msgid "TV show information"
+msgstr "Informasjon om TV-serier"
+
+#: id:20352
+msgid "Episode information"
+msgstr "Informasjon om episode"
+
+#: id:20353
+msgid "Loading TV show details"
+msgstr "Laster TV-seriedetaljer"
+
+#: id:20354
+msgid "Fetching episode guide"
+msgstr "Henter episodeguide"
+
+#: id:20355
+msgid "Loading info for episodes in directory"
+msgstr "Laster info for episoder i mappen"
+
+#: id:20356
+msgid "Select TV show:"
+msgstr "Velg TV-serie:"
+
+#: id:20357
+msgid "Enter the TV show name"
+msgstr "Skriv inn navn på TV-serie"
+
+#: id:20358
+msgid "Season %i"
+msgstr "Sesong %i"
+
+#: id:20359
+msgid "Episode"
+msgstr "Episode"
+
+#: id:20360
+msgid "Episodes"
+msgstr "Episoder"
+
+#: id:20361
+msgid "Loading episode details"
+msgstr "Laster episodedetaljer"
+
+#: id:20362
+msgid "Remove episode from library"
+msgstr "Fjern episode fra bibliotek"
+
+#: id:20363
+msgid "Remove TV show from library"
+msgstr "Fjern TV-serie fra bibliotek"
+
+#: id:20364
+msgid "TV show"
+msgstr "TV-serie"
+
+#: id:20365
+msgid "Episode plot"
+msgstr "Episodeplott"
+
+#: id:20366
+msgid "* All seasons"
+msgstr "* Alle sesonger"
+
+#: id:20367
+msgid "Hide watched"
+msgstr "Skjul sette"
+
+#: id:20368
+msgid "Prod code"
+msgstr "Prod. kode"
+
+#: id:20369
+msgid "Show plot for unwatched items"
+msgstr "Vis omtale for videoer som ikke er sett"
+
+#: id:20370
+msgid "* Hidden to prevent spoilers *"
+msgstr "* Skjult for ikke å røpe handling *"
+
+#: id:20371
+msgid "Set season thumb"
+msgstr "Sett miniatyrbilde for sesong"
+
+#: id:20372
+msgid "Season image"
+msgstr "Bilde for sesong"
+
+#: id:20373
+msgid "Season"
+msgstr "Sesong"
+
+#: id:20374
+msgid "Downloading movie information"
+msgstr "Laster ned informasjon om film"
+
+#: id:20375
+msgid "Unassign content"
+msgstr "Opphev tilordning av innhold"
+
+#: id:20376
+msgid "Original title"
+msgstr "Original tittel"
+
+#: id:20377
+msgid "Refresh TV show information"
+msgstr "Oppdater informasjon om TV-serie"
+
+#: id:20378
+msgid "Refresh info for all episodes?"
+msgstr "Oppdater informasjon for alle episoder?"
+
+#: id:20379
+msgid "Selected folder contains a single TV show"
+msgstr "Valgt mappe inneholder kun én TV-serie"
+
+#: id:20380
+msgid "Exclude selected folder from scans"
+msgstr "Ekskluder valgt mappe fra skanning"
+
+#: id:20381
+msgid "Specials"
+msgstr "Ekstra"
+
+#: id:20382
+msgid "Automatically grab season thumbs"
+msgstr "Hent miniatyrer for sesong automatisk"
+
+#: id:20383
+msgid "Selected folder contains a single video"
+msgstr "Valgt mappe inneholder kun én film"
+
+#: id:20384
+msgid "Link to TV show"
+msgstr "Linke til TV-serie"
+
+#: id:20385
+msgid "Remove link to TV show"
+msgstr "Fjern link til TV-serie"
+
+#: id:20386
+msgid "Recently added movies"
+msgstr "Filmer nylig lagt til"
+
+#: id:20387
+msgid "Recently added episodes"
+msgstr "Episoder nylig lagt til"
+
+#: id:20388
+msgid "Studios"
+msgstr "Studioer"
+
+#: id:20389
+msgid "Music videos"
+msgstr "Musikkvideoer"
+
+#: id:20390
+msgid "Recently added music videos"
+msgstr "Musikkvideoer nylig lagt til"
+
+#: id:20391
+msgid "Music video"
+msgstr "Musikkvideo"
+
+#: id:20392
+msgid "Remove music video from library"
+msgstr "Fjern musikkvideo fra bibliotek"
+
+#: id:20393
+msgctxt "Auto context with id 20393"
+msgid "Music video information"
+msgstr "Informasjon om musikkvideo"
+
+#: id:20394
+msgid "Loading music video information"
+msgstr "Laster musikkvideoinformasjon"
+
+#: id:20395
+msgid "Mixed"
+msgstr "Mikset"
+
+#: id:20396
+msgid "Go to albums by artist"
+msgstr "Gå til album av artist"
+
+#: id:20397
+msgid "Go to album"
+msgstr "Gå til album"
+
+#: id:20398
+msgid "Play song"
+msgstr "Spill sang"
+
+#: id:20399
+msgid "Go to music videos from album"
+msgstr "Gå til musikkvideoer fra album"
+
+#: id:20400
+msgid "Go to music videos by artist"
+msgstr "Gå til musikkvideoer av artist"
+
+#: id:20401
+msgid "Play music video"
+msgstr "Spill musikkvideo"
+
+#: id:20402
+msgid "Download actor thumbnails when adding to library"
+msgstr "Hent bilder for skuespiller automatisk når en legger til i bibliotek"
+
+#: id:20403
+msgid "Set actor thumb"
+msgstr "Sett miniatyr for skuespiller"
+
+#: id:20405
+msgid "Remove episode bookmark"
+msgstr "Fjern bokmerke for episode"
+
+#: id:20406
+msgid "Set episode bookmark"
+msgstr "Sett bokmerke for episode"
+
+#: id:20407
+msgid "Scraper settings"
+msgstr "Skraperinnstillinger"
+
+#: id:20408
+msgid "Downloading music video information"
+msgstr "Last ned musikkvideoinformasjon"
+
+#: id:20409
+msgid "Downloading TV show information"
+msgstr "Laster ned informasjon om TV-serie"
+
+#: id:20410
+msgid "Trailer"
+msgstr "Trailer"
+
+#: id:20411
+msgid "Flatten"
+msgstr "Flate ut"
+
+#: id:20412
+msgid "Flatten TV shows"
+msgstr "Flat ut TV-serier"
+
+#: id:20413
+msgid "Get fanart"
+msgstr "Hent FanArt"
+
+#: id:20414
+msgid "Show Fanart in video and music libraries"
+msgstr "Vis FanArt i video- og musikkbibliotek"
+
+#: id:20415
+msgid "Scanning for new content"
+msgstr "Søker etter nytt innhold"
+
+#: id:20416
+msgid "First aired"
+msgstr "Første gang sendt"
+
+#: id:20417
+msgid "Writer"
+msgstr "Forfatter"
+
+#: id:20419
+msgid "Replace file names with library titles"
+msgstr "Vis metadata i filvisning"
+
+#: id:20420
+msgctxt "Auto context with id 20420"
+msgid "Never"
+msgstr "Aldri"
+
+#: id:20421
+msgid "If only one season"
+msgstr "Bare hvis én sesong"
+
+#: id:20422
+msgid "Always"
+msgstr "Alltid"
+
+#: id:20423
+msgid "Has trailer"
+msgstr "Har trailer"
+
+#: id:20424
+msgid "False"
+msgstr "Usann"
+
+#: id:20425
+msgid "Fanart slideshow"
+msgstr "Bildefremvisning av FanArt"
+
+#: id:20426
+msgid "Export to a single file or separate"
+msgstr "Eksporter til én fil, eller én"
+
+#: id:20427
+msgid "files per entry?"
+msgstr "separat fil for hvert oppføring?"
+
+#: id:20428
+msgid "Single file"
+msgstr "Én fil"
+
+#: id:20429
+msgctxt "Auto context with id 20429"
+msgid "Separate"
+msgstr "Separer"
+
+#: id:20430
+msgid "Export thumbnails and fanart?"
+msgstr "Eksporter miniatyrbilder og FanArt?"
+
+#: id:20431
+msgid "Overwrite old files?"
+msgstr "Overskriv gamle filer?"
+
+#: id:20432
+msgid "Exclude path from library updates"
+msgstr "Ekskluder sti fra biblioteksoppdateringer"
+
+#: id:20433
+msgid "Extract thumbnails and video information"
+msgstr "Ekstraher miniatyrer og videoinformasjon"
+
+#: id:20434
+msgid "Sets"
+msgstr "Sett"
+
+#: id:20435
+msgid "Set movieset thumb"
+msgstr "Sett filmsettminiatyr"
+
+#: id:20436
+msgid "Export actor thumbs?"
+msgstr "Eksporter skuespiller bilder?"
+
+#: id:20437
+msgid "Choose fanart"
+msgstr "Velg FanArt"
+
+#: id:20438
+msgid "Local fanart"
+msgstr "Lokal FanArt"
+
+#: id:20439
+msgid "No fanart"
+msgstr "Ingen FanArt"
+
+#: id:20440
+msgid "Current fanart"
+msgstr "Nåværende FanArt"
+
+#: id:20441
+msgid "Remote fanart"
+msgstr "Ekstern FanArt"
+
+#: id:20442
+msgid "Change content"
+msgstr "Endre innhold"
+
+#: id:20443
+msgid "Do you want to refresh info for all"
+msgstr "Ønsker du å fornye info for alle"
+
+#: id:20444
+msgid "items within this path?"
+msgstr "elementer innenfor denne stien?"
+
+#: id:20445
+msgid "Fanart"
+msgstr "FanArt"
+
+#: id:20446
+msgid "Locally stored information found."
+msgstr "Lokalt lagret informasjon funnet."
+
+#: id:20447
+msgid "Ignore and refresh from internet?"
+msgstr "Ignorer og hent på nytt fra internett?"
+
+#: id:20448
+msgid "Could not download information"
+msgstr "Kunne ikke laste ned informasjon"
+
+#: id:20449
+msgid "Unable to connect to remote server"
+msgstr "Fikk ikke kontakt med tjener."
+
+#: id:20450
+msgid "Would you like to continue scanning?"
+msgstr "Vil du fortsette skanning?"
+
+#: id:20451
+msgid "Countries"
+msgstr "Land"
+
+#: id:20452
+msgid "episode"
+msgstr "episode"
+
+#: id:20453
+msgid "episodes"
+msgstr "episoder"
+
+#: id:20454
+msgid "Listener"
+msgstr ""
+
+#: id:20455
+msgid "Listeners"
+msgstr ""
+
+#: id:20456
+msgid "Set movieset fanart"
+msgstr "Sett FanArt for filmsett"
+
+#: id:20457
+msgid "Movie set"
+msgstr "Filmsett"
+
+#: id:20458
+msgid "Group movies in sets"
+msgstr ""
+
+#: id:21330
+msgid "Show hidden files and directories"
+msgstr "Vis skjulte filer og mapper"
+
+#: id:21331
+msgid "TuxBox client"
+msgstr "TuxBox klient"
+
+#: id:21332
+msgid "WARNING: Target TuxBox device is in recording-mode!"
+msgstr "ADVARSEL: TuxBoxen er i opptaksmodus!"
+
+#: id:21333
+msgid "The stream will be stopped!"
+msgstr "Streamingen vil bli stoppet!"
+
+#: id:21334
+msgid "Zap to channel: %s failed!"
+msgstr "Zap til kanal: %s mislyktes!"
+
+#: id:21335
+msgid "Are you sure to start the stream?"
+msgstr "Vil du starte streamingen?"
+
+#: id:21336
+msgid "Connecting to: %s"
+msgstr "Kobler til: %s"
+
+#: id:21337
+msgid "TuxBox device"
+msgstr "TuxBox enhet"
+
+#: id:21359
+msgid "Add media share..."
+msgstr "Legg til delt media...."
+
+#: id:21360
+msgid "Share video and music libraries through UPnP"
+msgstr "Del video- og musikkbibliotek gjennom UPnP"
+
+#: id:21364
+msgid "Edit media share"
+msgstr "Rediger delt media"
+
+#: id:21365
+msgid "Remove media share"
+msgstr "Fjern delt media"
+
+#: id:21366
+msgid "Subtitle folder"
+msgstr "Mappe for undertekst"
+
+#: id:21367
+msgid "Movie & alternate subtitle directory"
+msgstr "Film & alternativ mappe for undertekst"
+
+#: id:21368
+msgid "Override ASS/SSA subtitles fonts"
+msgstr ""
+
+#: id:21369
+msgid "Enable mouse and Touch Screen support"
+msgstr "Aktiver mus"
+
+#: id:21370
+msgid "Play navigation sounds during media playback"
+msgstr "Aktiver navigasjonslyder under medieavspilling"
+
+#: id:21371
+msgid "Thumbnail"
+msgstr "Miniatyr"
+
+#: id:21372
+msgid "Forced DVD player region"
+msgstr "Tving DVD-spillerens regionkoding"
+
+#: id:21373
+msgid "Video output"
+msgstr "Utgående video"
+
+#: id:21374
+msgid "Video aspect"
+msgstr "Høyde/bredde-forhold"
+
+#: id:21375
+msgctxt "Auto context with id 21375"
+msgid "Normal"
+msgstr "Normal"
+
+#: id:21376
+msgid "Letterbox"
+msgstr "Letterbox"
+
+#: id:21377
+msgid "Widescreen"
+msgstr "Widescreen"
+
+#: id:21378
+msgid "Enable 480p"
+msgstr "Aktiver 480p"
+
+#: id:21379
+msgid "Enable 720p"
+msgstr "Aktiver 720p"
+
+#: id:21380
+msgid "Enable 1080i"
+msgstr "Aktiver 1080i"
+
+#: id:21381
+msgid "Enter name of new playlist"
+msgstr "Skriv inn navn på ny spilleliste"
+
+#: id:21382
+msgid "Show \"Add source\" buttons in file lists"
+msgstr "Vis \"Legg til kilde\" i fillisten"
+
+#: id:21383
+msgid "Enable scrollbars"
+msgstr "Aktiver rullefelt"
+
+#: id:21384
+msgid "Make watched filtering a toggle in video library"
+msgstr "Aktiver av/på-knapp for 'sett/ikke sett' i videobiblioteket"
+
+#: id:21385
+msgctxt "Auto context with id 21385"
+msgid "Open"
+msgstr "Åpne"
+
+#: id:21386
+msgid "Acoustic management level"
+msgstr "Acoustic management level"
+
+#: id:21387
+msgid "Fast"
+msgstr "Rask"
+
+#: id:21388
+msgid "Quiet"
+msgstr "Stille"
+
+#: id:21389
+msgid "Enable custom background"
+msgstr "Aktiver egendefinert bakgrunn"
+
+#: id:21390
+msgid "Power management level"
+msgstr "Strøminnstillingsnivå"
+
+#: id:21391
+msgid "High power"
+msgstr "Høyt nivå"
+
+#: id:21392
+msgid "Low power"
+msgstr "Lavt nivå"
+
+#: id:21393
+msgid "High standby"
+msgstr "Ventemodus høyt"
+
+#: id:21394
+msgid "Low standby"
+msgstr "Ventemodus lavt"
+
+#: id:21395
+msgid "Unable to cache files bigger than 4GB"
+msgstr "Ikke i stand til å mellomlagre filer større en 4GB"
+
+#: id:21396
+msgid "Chapter"
+msgstr "Kapittel"
+
+#: id:21397
+msgid "High quality pixel shader v2"
+msgstr "Høykvalitets pikselshader v2"
+
+#: id:21398
+msgid "Enable playlist at startup"
+msgstr "Aktiver spilleliste ved oppstart"
+
+#: id:21399
+msgid "Use tween animations"
+msgstr "Bruk tween-animasjoner"
+
+#: id:21400
+msgid "contains"
+msgstr "inneholder"
+
+#: id:21401
+msgid "does not contain"
+msgstr "inneholder ikke"
+
+#: id:21402
+msgid "is"
+msgstr "er"
+
+#: id:21403
+msgid "is not"
+msgstr "er ikke"
+
+#: id:21404
+msgid "starts with"
+msgstr "starter med"
+
+#: id:21405
+msgid "ends with"
+msgstr "ender med"
+
+#: id:21406
+msgid "greater than"
+msgstr "større en"
+
+#: id:21407
+msgid "less than"
+msgstr "mindre en"
+
+#: id:21408
+msgid "after"
+msgstr "etter"
+
+#: id:21409
+msgid "before"
+msgstr "før"
+
+#: id:21410
+msgid "in the last"
+msgstr "etter siste"
+
+#: id:21411
+msgid "not in the last"
+msgstr "ikke etter siste"
+
+#: id:21412
+msgid "Scrapers"
+msgstr "Skrapere"
+
+#: id:21413
+msgid "Default movie scraper"
+msgstr "Standardskraper for film"
+
+#: id:21414
+msgid "Default tvshow scraper"
+msgstr "Standardskraper for TV-serie"
+
+#: id:21415
+msgid "Default music video scraper"
+msgstr "Standardskraper for musikkvideo"
+
+#: id:21416
+msgid "Enable fallback based on scraper language"
+msgstr "Aktiver fallback basert på skraper-språk"
+
+#: id:21417
+msgid "- Settings"
+msgstr "- Innstillinger"
+
+#: id:21418
+msgid "Multilingual"
+msgstr "Flerspråklig"
+
+#: id:21419
+msgid "No scrapers present"
+msgstr "Ingen skrapere tilstede"
+
+#: id:21420
+msgid "Value to match"
+msgstr "Verdi å sammenligne"
+
+#: id:21421
+msgid "Smart playlist rule"
+msgstr "Smart spillelisteoppsett"
+
+#: id:21422
+msgid "Match items where"
+msgstr "Sammenligne oppføringer hvor"
+
+#: id:21423
+msgid "New rule..."
+msgstr "Ny søkeregel"
+
+#: id:21424
+msgid "Items must match"
+msgstr "Oppføring må samsvare med"
+
+#: id:21425
+msgid "all of the rules"
+msgstr "alle søkekriteriene"
+
+#: id:21426
+msgid "one or more of the rules"
+msgstr "en av søkekriteriene"
+
+#: id:21427
+msgid "Limit to"
+msgstr "Begrens til"
+
+#: id:21428
+msgid "No limit"
+msgstr "Ingen begrensninger"
+
+#: id:21429
+msgid "Order by"
+msgstr "Sorter etter"
+
+#: id:21430
+msgid "ascending"
+msgstr "stigende"
+
+#: id:21431
+msgid "descending"
+msgstr "synkende"
+
+#: id:21432
+msgid "Edit smart playlist"
+msgstr "Rediger smart spilleliste"
+
+#: id:21433
+msgid "Name of the playlist"
+msgstr "Navn på spilleliste"
+
+#: id:21434
+msgid "Find items where"
+msgstr "Finn oppføring der"
+
+#: id:21435
+msgid "Edit"
+msgstr "Rediger"
+
+#: id:21436
+msgid "%i items"
+msgstr "%i oppføringer"
+
+#: id:21437
+msgid "New smart playlist..."
+msgstr "Ny smart spilleliste"
+
+#: id:21438
+msgid "%c Drive"
+msgstr "%c Stasjon"
+
+#: id:21439
+msgid "Edit party mode rules"
+msgstr "Rediger regler for partymodus"
+
+#: id:21440
+msgid "Home folder"
+msgstr "Hjem-mappen"
+
+#: id:21441
+msgid "Watched count"
+msgstr "Antall ganger sett"
+
+#: id:21442
+msgid "Episode title"
+msgstr "Episodetittel"
+
+#: id:21443
+msgid "Video resolution"
+msgstr "Videooppløsning"
+
+#: id:21444
+msgid "Audio channels"
+msgstr "Lydkanalers"
+
+#: id:21445
+msgid "Video codec"
+msgstr "Videokodek"
+
+#: id:21446
+msgid "Audio codec"
+msgstr "Lydkodek"
+
+#: id:21447
+msgid "Audio language"
+msgstr "Lydspråk"
+
+#: id:21448
+msgid "Subtitle language"
+msgstr "Språk for undertekster"
+
+#: id:21449
+msgid "Remote control sends keyboard presses"
+msgstr "Fjernkontroll sender tastetrykk (tastatur)"
+
+#: id:21450
+msgid "- Edit"
+msgstr "- Editer"
+
+#: id:21451
+msgid "Internet connection required."
+msgstr "Internettilkobling kreves."
+
+#: id:21452
+msgid "Get More..."
+msgstr "Hent flere..."
+
+#: id:21453
+msgid "Root filesystem"
+msgstr "Rotfilsystem"
+
+#: id:21454
+msgid "Cache full"
+msgstr ""
+
+#: id:21455
+msgid "Cache filled before reaching required amount for continous playback"
+msgstr ""
+
+#: id:21460
+msgid "Subtitle location"
+msgstr "Plassering av undertittel"
+
+#: id:21461
+msgid "Fixed"
+msgstr "Fikset"
+
+#: id:21462
+msgid "Bottom of video"
+msgstr "Bunnen av video"
+
+#: id:21463
+msgid "Below video"
+msgstr "Under video"
+
+#: id:21464
+msgid "Top of video"
+msgstr "Toppen av video"
+
+#: id:21465
+msgid "Above video"
+msgstr "Over video"
+
+#: id:21800
+msgid "File name"
+msgstr "Filnavn"
+
+#: id:21801
+msgid "File path"
+msgstr "Filsti"
+
+#: id:21802
+msgid "File size"
+msgstr "Filstørrelse"
+
+#: id:21803
+msgid "File date/time"
+msgstr "Fildato/filtid"
+
+#: id:21804
+msgid "Slide index"
+msgstr "Glideindeks"
+
+#: id:21805
+msgctxt "Auto context with id 21805"
+msgid "Resolution"
+msgstr "Oppløsning"
+
+#: id:21806
+msgctxt "Auto context with id 21806"
+msgid "Comment"
+msgstr "Kommentar"
+
+#: id:21807
+msgid "Colour/B&W"
+msgstr "Farge/svart-hvit"
+
+#: id:21808
+msgid "JPEG process"
+msgstr "JPEG-prosess"
+
+#: id:21820
+msgid "Date/Time"
+msgstr "Dato/tid"
+
+#: id:21821
+msgid "Description"
+msgstr "Beskrivelse"
+
+#: id:21822
+msgid "Camera make"
+msgstr "Kameramerke"
+
+#: id:21823
+msgid "Camera model"
+msgstr "Kameramodell"
+
+#: id:21824
+msgid "EXIF comment"
+msgstr "EXIF-kommentar"
+
+#: id:21825
+msgid "Firmware"
+msgstr "Fastvare"
+
+#: id:21826
+msgid "Aperture"
+msgstr "Blenderåpning"
+
+#: id:21827
+msgid "Focal length"
+msgstr "Brennvidde"
+
+#: id:21828
+msgid "Focus distance"
+msgstr "Fokusdistanse"
+
+#: id:21829
+msgid "Exposure"
+msgstr "Eksponering"
+
+#: id:21830
+msgid "Exposure time"
+msgstr "Eksponeringstid"
+
+#: id:21831
+msgid "Exposure bias"
+msgstr "Eksponeringsvinkel"
+
+#: id:21832
+msgid "Exposure mode"
+msgstr "Eksponeringsmetode"
+
+#: id:21833
+msgid "Flash used"
+msgstr "Blits brukt"
+
+#: id:21834
+msgid "White-balance"
+msgstr "Hvitbalanse"
+
+#: id:21835
+msgid "Light source"
+msgstr "Lyskilde"
+
+#: id:21836
+msgid "Metering mode"
+msgstr "Målemetode"
+
+#: id:21837
+msgid "ISO"
+msgstr "ISO"
+
+#: id:21838
+msgid "Digital zoom"
+msgstr "Digital zoom"
+
+#: id:21839
+msgid "CCD width"
+msgstr "CCD-bredde"
+
+#: id:21840
+msgid "GPS latitude"
+msgstr "Breddegrad (GPS)"
+
+#: id:21841
+msgid "GPS longitude"
+msgstr "Lengdegrad (GPS)"
+
+#: id:21842
+msgid "GPS altitude"
+msgstr "Høyde over havet (GPS)"
+
+#: id:21843
+msgid "Orientation"
+msgstr "Orientering"
+
+#: id:21860
+msgid "Supplemental categories"
+msgstr "Tilleggskategorier"
+
+#: id:21861
+msgid "Keywords"
+msgstr "Nøkkelord"
+
+#: id:21862
+msgid "Caption"
+msgstr "Bildetekst"
+
+#: id:21863
+msgid "Author"
+msgstr "Forfatter"
+
+#: id:21864
+msgid "Headline"
+msgstr "Overskrift"
+
+#: id:21865
+msgid "Special instructions"
+msgstr "Spesielle opplysninger"
+
+#: id:21866
+msgid "Category"
+msgstr "Kategori"
+
+#: id:21867
+msgid "Byline"
+msgstr "Signatur"
+
+#: id:21868
+msgid "Byline title"
+msgstr "Signaturtittel"
+
+#: id:21869
+msgid "Credit"
+msgstr "Kreditering"
+
+#: id:21870
+msgid "Source"
+msgstr "Kilde"
+
+#: id:21871
+msgid "Copyright notice"
+msgstr "Opphavsrettproklama"
+
+#: id:21872
+msgid "Object name"
+msgstr "Objektnavn"
+
+#: id:21873
+msgid "City"
+msgstr "By"
+
+#: id:21874
+msgid "State"
+msgstr "Region"
+
+#: id:21875
+msgctxt "Auto context with id 21875"
+msgid "Country"
+msgstr "Land"
+
+#: id:21876
+msgid "Original Tx Reference"
+msgstr "Original Tx Referanse"
+
+#: id:21877
+msgid "Date created"
+msgstr "Dato opprettet"
+
+#: id:21878
+msgid "Copyright flag"
+msgstr "Opphavsrettflagg"
+
+#: id:21879
+msgid "Country code"
+msgstr "Landskode"
+
+#: id:21880
+msgid "Reference service"
+msgstr "Referansetjeneste"
+
+#: id:21881
+msgid "Allow control of XBMC via UPnP"
+msgstr "Tillat styring av XBMC via UPnP"
+
+#: id:21882
+msgid "Attempt to skip introduction before DVD menu"
+msgstr "Prøv å hoppe over intro før DVD-menyen"
+
+#: id:21883
+msgid "Saved music"
+msgstr "Lagret musikk"
+
+#: id:21884
+msgid "Query info for all artists"
+msgstr "Spør etter info for alle artister"
+
+#: id:21885
+msgid "Downloading album information"
+msgstr "Laster ned albuminformasjon"
+
+#: id:21886
+msgid "Downloading artist information"
+msgstr "Laster ned artistinformasjon"
+
+#: id:21887
+msgid "Biography"
+msgstr "Biografi"
+
+#: id:21888
+msgid "Discography"
+msgstr "Diskografi"
+
+#: id:21889
+msgid "Searching artist"
+msgstr "Søker etter artist"
+
+#: id:21890
+msgid "Select artist"
+msgstr "Velg artist"
+
+#: id:21891
+msgctxt "Auto context with id 21891"
+msgid "Artist information"
+msgstr "Artistinformasjon"
+
+#: id:21892
+msgid "Instruments"
+msgstr "Instrumenter"
+
+#: id:21893
+msgid "Born"
+msgstr "Født"
+
+#: id:21894
+msgid "Formed"
+msgstr "Startet"
+
+#: id:21895
+msgid "Themes"
+msgstr "Tema"
+
+#: id:21896
+msgid "Disbanded"
+msgstr "Oppløst"
+
+#: id:21897
+msgid "Died"
+msgstr "Døde"
+
+#: id:21898
+msgid "Years active"
+msgstr "År aktiv"
+
+#: id:21899
+msgid "Label"
+msgstr "Plateselskap"
+
+#: id:21900
+msgid "Born/Formed"
+msgstr "Etablert/startet"
+
+#: id:22000
+msgid "Update library on startup"
+msgstr "Oppdater bibliotek ved oppstart"
+
+#: id:22001
+msgid "Hide progress of library updates"
+msgstr "Ikke vis biblioteksoppdateringer som skjer i bakgrunnen"
+
+#: id:22002
+msgid "- DNS suffix"
+msgstr "- DNS suffiks"
+
+#: id:22003
+msgid "%2.3fs"
+msgstr "%2.3fs"
+
+#: id:22004
+msgid "Delayed by: %2.3fs"
+msgstr "Forsinket med: %2.3fs"
+
+#: id:22005
+msgid "Ahead by: %2.3fs"
+msgstr "Fremskyndet: %2.3fs"
+
+#: id:22006
+msgid "Subtitle offset"
+msgstr "Tidsforskyvning for undertekst"
+
+#: id:22007
+msgid "OpenGL vendor:"
+msgstr "OpenGL leverandør:"
+
+#: id:22008
+msgid "OpenGL renderer:"
+msgstr "OpenGL renderer:"
+
+#: id:22009
+msgid "OpenGL version:"
+msgstr "OpenGL versjon:"
+
+#: id:22010
+msgid "GPU temperature:"
+msgstr "GPU-temperatur:"
+
+#: id:22011
+msgid "CPU temperature:"
+msgstr "CPU-temperatur:"
+
+#: id:22012
+msgid "Total memory"
+msgstr "Totalt minne"
+
+#: id:22013
+msgid "Profile data"
+msgstr "Profildata"
+
+#: id:22014
+msgid "Use dim if paused during video playback"
+msgstr "Dim ned hvis pause under filmavspilling"
+
+#: id:22015
+msgid "All recordings"
+msgstr "Alle innspillinger"
+
+#: id:22016
+msgid "By title"
+msgstr "Etter tittel"
+
+#: id:22017
+msgid "By group"
+msgstr "Etter gruppe"
+
+#: id:22018
+msgid "Live channels"
+msgstr "Live-kanaler"
+
+#: id:22019
+msgid "Recordings by title"
+msgstr "Innspillinger etter tittel"
+
+#: id:22020
+msgid "Guide"
+msgstr "Guide"
+
+#: id:22021
+msgid "Allowed error in aspect ratio to minimize black bars"
+msgstr "Tillatt avvik i høyde/bredde-forhold for reduksjon av sort felt"
+
+#: id:22022
+msgid "Show video files in listings"
+msgstr "Vis filmfiler i lister"
+
+#: id:22023
+msgid "DirectX vendor:"
+msgstr "DirectX forhandler:"
+
+#: id:22024
+msgid "Direct3D version:"
+msgstr "Direct3D versjon:"
+
+#: id:22030
+msgctxt "Auto context with id 22030"
+msgid "Font"
+msgstr "Font"
+
+#: id:22031
+msgctxt "Auto context with id 22031"
+msgid "- Size"
+msgstr "- Størrelse"
+
+#: id:22032
+msgctxt "Auto context with id 22032"
+msgid "- Colours"
+msgstr "- Farger"
+
+#: id:22033
+msgid "- Charset"
+msgstr "- Tegnsett"
+
+#: id:22034
+msgid "Export karaoke titles as HTML"
+msgstr "Eksporter karaoketitler som HTML"
+
+#: id:22035
+msgid "Export karaoke titles as CSV"
+msgstr "Eksporter karaoketitler som CSV"
+
+#: id:22036
+msgid "Import karaoke titles..."
+msgstr "Importer karaoketitler..."
+
+#: id:22037
+msgid "Show song selector automatically"
+msgstr "Automatisk sprett-opp-sangvelger"
+
+#: id:22038
+msgid "Export karaoke titles..."
+msgstr "Eksporter karaoketitler..."
+
+#: id:22039
+msgid "Enter song number"
+msgstr "Skriv inn sangnummer"
+
+#: id:22040
+msgid "white/green"
+msgstr "hvitt/grønt"
+
+#: id:22041
+msgid "white/red"
+msgstr "hvitt/rødt"
+
+#: id:22042
+msgid "white/blue"
+msgstr "hvitt/blått"
+
+#: id:22043
+msgid "black/white"
+msgstr "svart/hvitt"
+
+#: id:22079
+msgid "Default select action"
+msgstr "Standardhandling for «velg»"
+
+#: id:22080
+msgid "Choose"
+msgstr "Velg"
+
+#: id:22081
+msgid "Show Information"
+msgstr "Vis informasjon"
+
+#: id:22082
+msgid "More..."
+msgstr "Mer..."
+
+#: id:22083
+msgid "Play all"
+msgstr "Spill alle"
+
+#: id:23049
+msgid "Teletext not available"
+msgstr "Tekst-tv utilgjengelig"
+
+#: id:23050
+msgid "Activate Teletext"
+msgstr "Aktiver tekst-tv"
+
+#: id:23051
+msgid "Part %i"
+msgstr "Del %i"
+
+#: id:23052
+msgid "Buffering %i bytes"
+msgstr "Bufrer %i byte"
+
+#: id:23053
+msgid "Stopping"
+msgstr "Stopper"
+
+#: id:23054
+msgid "Running"
+msgstr "Kjører"
+
+#: id:23100
+msgid "External Player Active"
+msgstr "Ekstern spiller aktiv"
+
+#: id:23101
+msgid "Click OK to terminate the player"
+msgstr "Trykk OK for å avslutte spilleren"
+
+#: id:23104
+msgid "Click OK when playback has ended"
+msgstr "Trykk OK når avspilling er ferdig"
+
+#: id:24000
+msgid "Add-on"
+msgstr "Tillegg"
+
+#: id:24001
+msgid "Add-ons"
+msgstr "Tillegg"
+
+#: id:24002
+msgid "Add-on options"
+msgstr "Alternativer for tillegg"
+
+#: id:24003
+msgid "Add-on Information"
+msgstr "Informasjon om tillegg"
+
+#: id:24005
+msgctxt "Auto context with id 24005"
+msgid "Media sources"
+msgstr "Mediekilder"
+
+#: id:24007
+msgctxt "Auto context with id 24007"
+msgid "Movie information"
+msgstr "Filminformasjon"
+
+#: id:24008
+msgctxt "Auto context with id 24008"
+msgid "Screensaver"
+msgstr "Skjermsparer"
+
+#: id:24009
+msgid "Script"
+msgstr "Skript"
+
+#: id:24010
+msgctxt "Auto context with id 24010"
+msgid "Visualization"
+msgstr "Visualisering"
+
+#: id:24011
+msgid "Add-on repository"
+msgstr "Pakkebrønn for tillegg"
+
+#: id:24012
+msgctxt "Auto context with id 24012"
+msgid "Subtitles"
+msgstr "Undertekster"
+
+#: id:24013
+msgid "Lyrics"
+msgstr "Sangtekster"
+
+#: id:24014
+msgid "TV information"
+msgstr "TV-informasjon"
+
+#: id:24015
+msgctxt "Auto context with id 24015"
+msgid "Music video information"
+msgstr "Musikkvideoinformasjon"
+
+#: id:24016
+msgctxt "Auto context with id 24016"
+msgid "Album information"
+msgstr "Albuminformasjon"
+
+#: id:24017
+msgctxt "Auto context with id 24017"
+msgid "Artist information"
+msgstr "Artistinformasjon"
+
+#: id:24018
+msgctxt "Auto context with id 24018"
+msgid "Services"
+msgstr "Tjenester"
+
+#: id:24020
+msgid "Configure"
+msgstr "Konfigurer"
+
+#: id:24021
+msgctxt "Auto context with id 24021"
+msgid "Disable"
+msgstr "Deaktiver"
+
+#: id:24022
+msgid "Enable"
+msgstr "Aktiver"
+
+#: id:24023
+msgid "Add-on disabled"
+msgstr "Tillegg deaktivert"
+
+#: id:24027
+msgctxt "Auto context with id 24027"
+msgid "Weather"
+msgstr "Vær"
+
+#: id:24028
+msgid "Weather.com (standard)"
+msgstr "Weather.com (standard)"
+
+#: id:24030
+msgid "This Add-on can not be configured"
+msgstr "Dette tillegget kan ikke konfigureres"
+
+#: id:24031
+msgid "Error loading settings"
+msgstr "Feil ved henting av innstillinger"
+
+#: id:24032
+msgid "All Add-ons"
+msgstr "Alle tillegg"
+
+#: id:24033
+msgid "Get Add-ons"
+msgstr "Hent tillegg"
+
+#: id:24034
+msgid "Check for updates"
+msgstr "Se etter oppdateringer"
+
+#: id:24035
+msgid "Force refresh"
+msgstr "Tvungen oppdatering"
+
+#: id:24036
+msgid "Change log"
+msgstr "Endringslogg"
+
+#: id:24037
+msgid "Uninstall"
+msgstr "Avinstaller"
+
+#: id:24038
+msgid "Install"
+msgstr "Installer"
+
+#: id:24039
+msgid "Disabled Add-ons"
+msgstr "Deaktiverte tillegg"
+
+#: id:24040
+msgid "(Clear the current setting)"
+msgstr "(Tilbakestill innstilling)"
+
+#: id:24041
+msgid "Install from zip file"
+msgstr "Installer fra zip-fil"
+
+#: id:24042
+msgid "Downloading %i%%"
+msgstr "Laster ned %i%%"
+
+#: id:24043
+msgid "Available Updates"
+msgstr "Tilgjengelige oppdateringer"
+
+#: id:24044
+msgid "Dependencies not met"
+msgstr "Programkrav ikke møtt"
+
+#: id:24045
+msgid "Add-on does not have the correct structure"
+msgstr "Tillegg har ikke den korrekte strukturen"
+
+#: id:24046
+msgid "%s is used by the following installed add-on(s)"
+msgstr "%s benyttes av følgende tillegg"
+
+#: id:24047
+msgid "This add-on cannot be uninstalled"
+msgstr "Dette tillegget kan ikke bli avinstallert"
+
+#: id:24048
+msgid "Rollback"
+msgstr "Tilbakestill"
+
+#: id:24050
+msgid "Available Add-ons"
+msgstr "Tilgjengelige tillegg"
+
+#: id:24051
+msgid "Version:"
+msgstr "Versjon:"
+
+#: id:24052
+msgid "Disclaimer"
+msgstr "Fraskrivelse:"
+
+#: id:24053
+msgid "License:"
+msgstr "Lisens:"
+
+#: id:24054
+msgid "Changelog"
+msgstr "Endringslogg"
+
+#: id:24059
+msgid "Would you like to enable this Add-on?"
+msgstr "Vil du aktivere dette tillegget?"
+
+#: id:24060
+msgid "Would you like to disable this Add-on?"
+msgstr "Vil du deaktivere dette tillegget?"
+
+#: id:24061
+msgid "Add-on update available!"
+msgstr "Oppdatering for tillegg tilgjengelig!"
+
+#: id:24062
+msgid "Enabled Add-ons"
+msgstr "Aktiverte tillegg"
+
+#: id:24063
+msgid "Auto update"
+msgstr "Automatisk oppdatering"
+
+#: id:24064
+msgid "Add-on enabled"
+msgstr "Tillegg aktivert"
+
+#: id:24065
+msgid "Add-on updated"
+msgstr "Tillegg oppdatert"
+
+#: id:24066
+msgid "Cancel Add-on download?"
+msgstr "Avbryt nedlasting av tillegg?"
+
+#: id:24067
+msgid "Currently downloading Add-ons"
+msgstr "Laster ned tillegg"
+
+#: id:24068
+msgid "Update available"
+msgstr "Oppdatering tilgjengelig"
+
+#: id:24069
+msgid "Update"
+msgstr "Oppdater"
+
+#: id:24070
+msgid "Add-on could not be loaded."
+msgstr "Tillegg kunne ikke lastes inn."
+
+#: id:24071
+msgid "An unknown error has occurred."
+msgstr "En ukjent feil har oppstått."
+
+#: id:24072
+msgid "Settings required"
+msgstr "Innstillinger påkrevet"
+
+#: id:24073
+msgid "Could not connect"
+msgstr "Kunne ikke koble til"
+
+#: id:24074
+msgid "Needs to restart"
+msgstr "Må startes på nytt"
+
+#: id:24075
+msgctxt "Auto context with id 24075"
+msgid "Disable"
+msgstr "Deaktivere"
+
+#: id:24076
+msgid "Add-on Required"
+msgstr ""
+
+#: id:24080
+msgid "Try to reconnect?"
+msgstr "Forsøk ny oppkobling?"
+
+#: id:24089
+msgid "Add-on restarts"
+msgstr "Tillegg starter på nytt"
+
+#: id:24090
+msgid "Lock Add-on manager"
+msgstr "Lås tilleggsbehandler"
+
+#: id:24094
+msgid "(current)"
+msgstr "(nåværende)"
+
+#: id:24095
+msgid "(blacklisted)"
+msgstr "(svartelistet)"
+
+#: id:24096
+msgid "Add-on has been marked as broken in repository."
+msgstr "Tillegget er markert som ødelagt i pakkebrønnen."
+
+#: id:24097
+msgid "Would you like to disable it on your system?"
+msgstr "Vil du deaktivere tillegget?"
+
+#: id:24098
+msgid "Broken"
+msgstr "Ødelagt"
+
+#: id:24099
+msgid "Would you like to switch to this skin?"
+msgstr "Ønsker du å bytte til dette skinnet nå?"
+
+#: id:24100
+msgid "To use this feature you must download an Add-on:"
+msgstr ""
+
+#: id:24101
+msgid "Would you like to download this Add-on?"
+msgstr ""
+
+#: id:25000
+msgid "Notifications"
+msgstr "Varslinger"
+
+#: id:29800
+msgid "Library Mode"
+msgstr "Biblioteksmodus"
+
+#: id:29801
+msgid "QWERTY keyboard"
+msgstr "QWERTY-tastatur"
+
+#: id:29802
+msgid "Passthrough Audio in use"
+msgstr "Passthrough-lyd i bruk"
+
+#: id:33001
+msgid "Trailer quality"
+msgstr "Kvalitet på trailer"
+
+#: id:33002
+msgid "Stream"
+msgstr "Strøm"
+
+#: id:33003
+msgid "Download"
+msgstr "Last ned"
+
+#: id:33004
+msgid "Download & play"
+msgstr "Last ned og spill av"
+
+#: id:33005
+msgid "Download & save"
+msgstr "Last ned og lagre"
+
+#: id:33006
+msgid "Today"
+msgstr "I dag"
+
+#: id:33007
+msgid "Tomorrow"
+msgstr "I morgen"
+
+#: id:33008
+msgid "Saving"
+msgstr "Lagrer"
+
+#: id:33009
+msgid "Copying"
+msgstr "Kopierer"
+
+#: id:33010
+msgid "Set download directory"
+msgstr "Sett nedlastingsmappe"
+
+#: id:33011
+msgid "Search duration"
+msgstr "Søkelengde"
+
+#: id:33012
+msgid "Short"
+msgstr "Kort"
+
+#: id:33013
+msgid "Long"
+msgstr "Lang"
+
+#: id:33014
+msgid "Use DVD player instead of regular player"
+msgstr "Bruk DVD-avspiller i stedet for vanlig avspiller"
+
+#: id:33015
+msgid "Ask for download before playing video"
+msgstr "Spør om nedlasting før filmer spilles"
+
+#: id:33016
+msgid "Clips"
+msgstr "Klipp"
+
+#: id:33017
+msgid "Restart plugin to enable"
+msgstr "Omstart tillegg for å aktivere"
+
+#: id:33018
+msgid "Tonight"
+msgstr "I kveld"
+
+#: id:33019
+msgid "Tomorrow Night"
+msgstr "I morgen kveld"
+
+#: id:33020
+msgid "Condition"
+msgstr "Forhold"
+
+#: id:33021
+msgid "Precipitation"
+msgstr "Nedbør"
+
+#: id:33022
+msgid "Precip"
+msgstr "Nedbør"
+
+#: id:33023
+msgid "Humid"
+msgstr "Fuktig"
+
+#: id:33024
+msgid "Feels"
+msgstr "Føles"
+
+#: id:33025
+msgid "Observed"
+msgstr "Observert"
+
+#: id:33026
+msgid "Departure from normal"
+msgstr "Avvik fra normal"
+
+#: id:33027
+msgid "Sunrise"
+msgstr "Soloppgang"
+
+#: id:33028
+msgid "Sunset"
+msgstr "Solnedgang"
+
+#: id:33029
+msgid "Details"
+msgstr "Detaljer"
+
+#: id:33030
+msgid "Outlook"
+msgstr "Outlook"
+
+#: id:33031
+msgid "Coverflow"
+msgstr "Coverflow"
+
+#: id:33032
+msgid "Translate text"
+msgstr "Oversett tekst"
+
+#: id:33033
+msgid "Map list %s category"
+msgstr "Kartliste %s kategori"
+
+#: id:33034
+msgid "36 Hour"
+msgstr "36 timer"
+
+#: id:33035
+msgid "Maps"
+msgstr "Kart"
+
+#: id:33036
+msgid "Hourly"
+msgstr "Pr. time"
+
+#: id:33037
+msgid "Weekend"
+msgstr "Helg"
+
+#: id:33038
+msgid "%s day"
+msgstr "%s dag"
+
+#: id:33049
+msgid "Alert"
+msgstr "Alarm"
+
+#: id:33050
+msgid "Alerts"
+msgstr "Alarmer"
+
+#: id:33051
+msgid "Choose Your"
+msgstr "Velg dine"
+
+#: id:33052
+msgid "Check"
+msgstr "Kontroller"
+
+#: id:33053
+msgctxt "Auto context with id 33053"
+msgid "Configure the"
+msgstr "Konfigurer"
+
+#: id:33054
+msgid "Seasons"
+msgstr "Sesonger"
+
+#: id:33055
+msgid "Use your"
+msgstr "Bruk din"
+
+#: id:33056
+msgid "Watch your"
+msgstr "Se dine"
+
+#: id:33057
+msgid "Listen to"
+msgstr "Hør på"
+
+#: id:33058
+msgid "View your"
+msgstr "Vis dine"
+
+#: id:33059
+msgctxt "Auto context with id 33059"
+msgid "Configure the"
+msgstr "Konfigurer"
+
+#: id:33060
+msgid "Power"
+msgstr "Strøm"
+
+#: id:33061
+msgid "Menu"
+msgstr "Meny"
+
+#: id:33062
+msgid "Play the"
+msgstr "Spill"
+
+#: id:33063
+msgid "Options"
+msgstr "Valg"
+
+#: id:33065
+msgid "Editor"
+msgstr "Editor"
+
+#: id:33066
+msgid "About your"
+msgstr "Om din"
+
+#: id:33067
+msgid "Star rating"
+msgstr "Stjernerangering"
+
+#: id:33068
+msgid "Background"
+msgstr "Bakgrunn"
+
+#: id:33069
+msgid "Backgrounds"
+msgstr "Bakgrunner"
+
+#: id:33070
+msgid "Custom background"
+msgstr "Egendefinert bakgrunn"
+
+#: id:33071
+msgid "Custom backgrounds"
+msgstr "Egendefinerte bakgrunner"
+
+#: id:33072
+msgid "View Readme"
+msgstr "Vis Lesmeg"
+
+#: id:33073
+msgid "View Changelog"
+msgstr "Vis endringslogg"
+
+#: id:33074
+msgid "This version of %s requires an"
+msgstr "Denne versjonen av %s krever XBMC"
+
+#: id:33075
+msgid "XBMC revision of %s or greater to run."
+msgstr "versjon %s eller høyere for å kunne kjøre."
+
+#: id:33076
+msgid "Please update XBMC."
+msgstr "Vennligst oppdater XBMC."
+
+#: id:33077
+msgid "No data found!"
+msgstr "Fant ingen data!"
+
+#: id:33078
+msgid "Next page"
+msgstr "Neste side"
+
+#: id:33079
+msgid "Love"
+msgstr "Elsker"
+
+#: id:33080
+msgid "Hate"
+msgstr "Hater"
+
+#: id:33081
+msgid "This file is stacked, select the part you want to play from."
+msgstr "Denne filen er stablet, velg den delen du vil spille fra."
+
+#: id:33082
+msgid "Path to script"
+msgstr "Sti til skript"
+
+#: id:33083
+msgid "Enable custom script button"
+msgstr "Aktiver knapp for egendefinert skript"
+
+#: id:33100
+msgid "Failed to start"
+msgstr "Kunne ikke starte"
+
+#: id:33101
+msgid "Webserver"
+msgstr "Webserver"
+
+#: id:33102
+msgid "Event Server"
+msgstr "Event Server"
+
+#: id:33103
+msgid "Remote communication server"
+msgstr "Remote communication server"
+
+#: id:33200
+msgid "Detected New Connection"
+msgstr ""
+
+#: id:34000
+msgid "Lame"
+msgstr "Lame"
+
+#: id:34001
+msgid "Vorbis"
+msgstr "Vorbis"
+
+#: id:34002
+msgid "Wav"
+msgstr "Wav"
+
+#: id:34003
+msgid "DXVA2"
+msgstr "DXVA2"
+
+#: id:34004
+msgid "VAAPI"
+msgstr "VAAPI"
+
+#: id:34005
+msgid "Flac"
+msgstr "Flac"
+
+#: id:34100
+msgid "Speaker Configuration"
+msgstr "Høyttalerkonfigurasjon"
+
+#: id:34101
+msgid "2.0"
+msgstr "2.0"
+
+#: id:34102
+msgid "2.1"
+msgstr "2.1"
+
+#: id:34103
+msgid "3.0"
+msgstr "3.0"
+
+#: id:34104
+msgid "3.1"
+msgstr "3.1"
+
+#: id:34105
+msgid "4.0"
+msgstr "4.0"
+
+#: id:34106
+msgid "4.1"
+msgstr "4.1"
+
+#: id:34107
+msgid "5.0"
+msgstr "5.0"
+
+#: id:34108
+msgid "5.1"
+msgstr "5.1"
+
+#: id:34109
+msgid "7.0"
+msgstr "7,0"
+
+#: id:34110
+msgid "7.1"
+msgstr "7.1"
+
+#: id:34201
+msgid "Can't find a next item to play"
+msgstr "Kan ikke finne neste ting å spille"
+
+#: id:34202
+msgid "Can't find a previous item to play"
+msgstr "Kan ikke finne tidligere ting å spille"
+
+#: id:34300
+msgid "Failed to start zeroconf"
+msgstr ""
+
+#: id:34301
+msgid "Is Apple's Bonjour Service installed? See log for more info."
+msgstr ""
+
+#: id:34400
+msgid "Video Rendering"
+msgstr ""
+
+#: id:34401
+msgid "Failed to init video filters/scalers, falling back to bilinear scaling"
+msgstr ""
+
+#: id:34402
+msgid "Failed to initialize audio device"
+msgstr ""
+
+#: id:34403
+msgid "Check your audiosettings"
+msgstr ""
+
+#: id:34404
+msgid "Use gestures for navigation:"
+msgstr ""
+
+#: id:34405
+msgid "1 finger swipe left,right,up,down for cursors"
+msgstr ""
+
+#: id:34406
+msgid "2 finger swipe left for backspace"
+msgstr ""
+
+#: id:34407
+msgid "1 finger single tap for enter"
+msgstr ""
+
+#: id:34408
+msgid "2 finger single tap for contextmenu"
+msgstr ""
+
+#: id:35000
+msgid "Peripherals"
+msgstr ""
+
+#: id:35001
+msgid "Generic HID device"
+msgstr ""
+
+#: id:35002
+msgid "Generic network adapter"
+msgstr ""
+
+#: id:35003
+msgid "Generic disk"
+msgstr ""
+
+#: id:35004
+msgid "There are no settings available\nfor this peripheral."
+msgstr ""
+
+#: id:35005
+msgid "New device configured"
+msgstr ""
+
+#: id:35006
+msgid "Device removed"
+msgstr ""
+
+#: id:35007
+msgid "Keymap to use for this device"
+msgstr ""
+
+#: id:35008
+msgid "Keymap enabled"
+msgstr ""
+
+#: id:35009
+msgid "Do not use the custom keymap for this device"
+msgstr ""
+
+#: id:35500
+msgid "Location"
+msgstr ""
+
+#: id:35501
+msgid "Class"
+msgstr ""
+
+#: id:35502
+msgctxt "Auto context with id 35502"
+msgid "Name"
+msgstr ""
+
+#: id:35503
+msgid "Vendor"
+msgstr ""
+
+#: id:35504
+msgid "Product ID"
+msgstr ""
+
+#: id:36000
+msgid "Pulse-Eight CEC adapter"
+msgstr ""
+
+#: id:36001
+msgid "Pulse-Eight Nyxboard"
+msgstr ""
+
+#: id:36002
+msgid "Switch to keyboard side command"
+msgstr ""
+
+#: id:36003
+msgid "Switch to remote side command"
+msgstr ""
+
+#: id:36004
+msgid "Press \"user\" button command"
+msgstr ""
+
+#: id:36005
+msgid "Enable switch side commands"
+msgstr ""
+
+#: id:36006
+msgid "Could not open the adapter"
+msgstr ""
+
+#: id:36007
+msgid "Devices to power on when starting XBMC"
+msgstr ""
+
+#: id:36008
+msgid "Devices to power off when stopping XBMC"
+msgstr ""
+
+#: id:36009
+msgid "Put devices in standby mode when activating screensaver"
+msgstr ""
+
+#: id:36011
+msgid "Could not detect the CEC port. Set it up manually."
+msgstr ""
+
+#: id:36012
+msgid "Could not initialise the CEC adapter. Check your settings."
+msgstr ""
+
+#: id:36013
+msgid "Unsupported libCEC interface version. %d is greater than the version XBMC supports (%d)"
+msgstr ""
+
+#: id:36014
+msgid "Put this PC in standby mode when the TV is switched off"
+msgstr ""
+
+#: id:36015
+msgid "HDMI port number"
+msgstr ""
+
+#: id:36016
+msgctxt "Auto context with id 36016"
+msgid "Connected"
+msgstr ""
+
+#: id:36017
+msgid "Adapter found, but libCEC is not available"
+msgstr ""
+
+#: id:36018
+msgid "Use the TV's language setting"
+msgstr ""
+
+#: id:36019
+msgid "Connected to HDMI device"
+msgstr ""
+
+#: id:36020
+msgid "Make XBMC the active source when starting"
+msgstr ""
+
+#: id:36021
+msgid "Physical address (overrules HDMI port)"
+msgstr ""
+
+#: id:36022
+msgid "COM port (leave empty unless needed)"
+msgstr ""
+
+#: id:36023
+msgid "Configuration updated"
+msgstr ""
+
+#: id:36024
+msgid "Failed to set the new configuration. Please check your settings."
+msgstr ""
+
+#: id:36025
+msgid "Send 'inactive source' command when stopping XBMC"
+msgstr ""
+

--- a/language/Polish/strings.po
+++ b/language/Polish/strings.po
@@ -1,0 +1,9093 @@
+# Converted from xbmc strings.xml with xbmc-xml2po (by Team-XBMC)
+msgid ""
+msgstr ""
+"Project-Id-Version: xbmc.core-FRODO_GIT3ed1604ad7\n"
+"Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
+"POT-Creation-Date: 2012-04-09 18:00+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE\n"
+"Language: pl\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: id:0
+msgctxt "Auto context with id 0"
+msgid "Programs"
+msgstr "Programy"
+
+#: id:1
+msgctxt "Auto context with id 1"
+msgid "Pictures"
+msgstr "Zdjęcia"
+
+#: id:2
+msgctxt "Auto context with id 2"
+msgid "Music"
+msgstr "Muzyka"
+
+#: id:3
+msgctxt "Auto context with id 3"
+msgid "Videos"
+msgstr "Wideo"
+
+#: id:4
+msgid "TV-Guide"
+msgstr "Program TV"
+
+#: id:5
+msgctxt "Auto context with id 5"
+msgid "Settings"
+msgstr "Ustawienia"
+
+#: id:6
+msgid "XBMC SVN"
+msgstr ""
+
+#: id:7
+msgctxt "Auto context with id 7"
+msgid "File manager"
+msgstr "Eksplorator"
+
+#: id:8
+msgctxt "Auto context with id 8"
+msgid "Weather"
+msgstr "Pogoda"
+
+#: id:9
+msgid "xbmc media center"
+msgstr "xbmc media center"
+
+#: id:11
+msgid "Monday"
+msgstr "Poniedziałek"
+
+#: id:12
+msgid "Tuesday"
+msgstr "Wtorek"
+
+#: id:13
+msgid "Wednesday"
+msgstr "Środa"
+
+#: id:14
+msgid "Thursday"
+msgstr "Czwartek"
+
+#: id:15
+msgid "Friday"
+msgstr "Piątek"
+
+#: id:16
+msgid "Saturday"
+msgstr "Sobota"
+
+#: id:17
+msgid "Sunday"
+msgstr "Niedziela"
+
+#: id:21
+msgid "January"
+msgstr "Stycznia"
+
+#: id:22
+msgid "February"
+msgstr "Lutego"
+
+#: id:23
+msgid "March"
+msgstr "Marca"
+
+#: id:24
+msgid "April"
+msgstr "Kwietnia"
+
+#: id:25
+msgctxt "Auto context with id 25"
+msgid "May"
+msgstr "Maja"
+
+#: id:26
+msgid "June"
+msgstr "Czerwca"
+
+#: id:27
+msgid "July"
+msgstr "Lipca"
+
+#: id:28
+msgid "August"
+msgstr "Sierpnia"
+
+#: id:29
+msgid "September"
+msgstr "Września"
+
+#: id:30
+msgid "October"
+msgstr "Października"
+
+#: id:31
+msgid "November"
+msgstr "Listopada"
+
+#: id:32
+msgid "December"
+msgstr "Grudnia"
+
+#: id:41
+msgid "Mon"
+msgstr "Pon."
+
+#: id:42
+msgid "Tue"
+msgstr "Wt."
+
+#: id:43
+msgid "Wed"
+msgstr "Śr."
+
+#: id:44
+msgid "Thu"
+msgstr "Czw."
+
+#: id:45
+msgid "Fri"
+msgstr "Pt."
+
+#: id:46
+msgid "Sat"
+msgstr "Sob."
+
+#: id:47
+msgctxt "Auto context with id 47"
+msgid "Sun"
+msgstr "Niedz."
+
+#: id:51
+msgid "Jan"
+msgstr "Sty"
+
+#: id:52
+msgid "Feb"
+msgstr "Lut"
+
+#: id:53
+msgid "Mar"
+msgstr "Mar"
+
+#: id:54
+msgid "Apr"
+msgstr "Kwi"
+
+#: id:55
+msgctxt "Auto context with id 55"
+msgid "May"
+msgstr "Maj"
+
+#: id:56
+msgid "Jun"
+msgstr "Cze"
+
+#: id:57
+msgid "Jul"
+msgstr "Lip"
+
+#: id:58
+msgid "Aug"
+msgstr "Sie"
+
+#: id:59
+msgid "Sep"
+msgstr "Wrz"
+
+#: id:60
+msgid "Oct"
+msgstr "Paź"
+
+#: id:61
+msgid "Nov"
+msgstr "Lis"
+
+#: id:62
+msgid "Dec"
+msgstr "Gru"
+
+#: id:71
+msgid "N"
+msgstr "N"
+
+#: id:72
+msgid "NNE"
+msgstr "NNE"
+
+#: id:73
+msgid "NE"
+msgstr "NE"
+
+#: id:74
+msgid "ENE"
+msgstr "ENE"
+
+#: id:75
+msgid "E"
+msgstr "E"
+
+#: id:76
+msgid "ESE"
+msgstr "ESE"
+
+#: id:77
+msgid "SE"
+msgstr "SE"
+
+#: id:78
+msgid "SSE"
+msgstr "SSE"
+
+#: id:79
+msgid "S"
+msgstr "S"
+
+#: id:80
+msgid "SSW"
+msgstr "SSW"
+
+#: id:81
+msgid "SW"
+msgstr "SW"
+
+#: id:82
+msgid "WSW"
+msgstr "WSW"
+
+#: id:83
+msgid "W"
+msgstr "W"
+
+#: id:84
+msgid "WNW"
+msgstr "WNW"
+
+#: id:85
+msgid "NW"
+msgstr "NW"
+
+#: id:86
+msgid "NNW"
+msgstr "NNW"
+
+#: id:87
+msgid "VAR"
+msgstr "VAR"
+
+#: id:98
+msgid "View: Auto"
+msgstr "Widok: Auto"
+
+#: id:99
+msgid "View: Auto big"
+msgstr "Widok: Auto duże"
+
+#: id:100
+msgid "View: Icons"
+msgstr "Widok: Ikony"
+
+#: id:101
+msgid "View: List"
+msgstr "Widok: Lista"
+
+#: id:102
+msgctxt "Auto context with id 102"
+msgid "Scan"
+msgstr "Skanuj"
+
+#: id:103
+msgctxt "Auto context with id 103"
+msgid "Sort by: Name"
+msgstr "Sortuj: Nazwa"
+
+#: id:104
+msgid "Sort by: Date"
+msgstr "Sortuj: Data"
+
+#: id:105
+msgid "Sort by: Size"
+msgstr "Sortuj: Rozmiar"
+
+#: id:106
+msgid "No"
+msgstr "Nie"
+
+#: id:107
+msgid "Yes"
+msgstr "Tak"
+
+#: id:108
+msgctxt "Auto context with id 108"
+msgid "Slideshow"
+msgstr "Pokaz slajdów"
+
+#: id:109
+msgid "Create thumbs"
+msgstr "Utwórz ikony"
+
+#: id:110
+msgid "Create thumbnails"
+msgstr "Utwórz miniaturki"
+
+#: id:111
+msgctxt "Auto context with id 111"
+msgid "Shortcuts"
+msgstr "Skróty"
+
+#: id:112
+msgid "Paused"
+msgstr "Pauza"
+
+#: id:113
+msgid "Update failed"
+msgstr "Błąd aktualizacji"
+
+#: id:114
+msgid "Installation failed"
+msgstr "Błąd instalacji"
+
+#: id:115
+msgid "Copy"
+msgstr "Kopiuj"
+
+#: id:116
+msgid "Move"
+msgstr "Przenieś"
+
+#: id:117
+msgid "Delete"
+msgstr "Usuń"
+
+#: id:118
+msgid "Rename"
+msgstr "Zmień nazwę"
+
+#: id:119
+msgid "New folder"
+msgstr "Nowy folder"
+
+#: id:120
+msgid "Confirm file copy"
+msgstr "Potwierdź kopiowanie pliku"
+
+#: id:121
+msgid "Confirm file move"
+msgstr "Potwierdź przenoszenie pliku"
+
+#: id:122
+msgid "Confirm file delete?"
+msgstr "Czy rzeczywiście chcesz usunąć plik?"
+
+#: id:123
+msgid "Copy these files?"
+msgstr "Skopiować wybrane pliki?"
+
+#: id:124
+msgid "Move these files?"
+msgstr "Przenieść wybrane pliki?"
+
+#: id:125
+msgid "Delete these files? - Deleting files cannot be undone!"
+msgstr "Usunąć wybrane pliki? - Po usunięciu pliki są nie do odzyskania!"
+
+#: id:126
+msgid "Status"
+msgstr "Polecenie w toku"
+
+#: id:127
+msgid "Objects"
+msgstr "pozycji"
+
+#: id:128
+msgctxt "Auto context with id 128"
+msgid "General"
+msgstr "Ogólne"
+
+#: id:129
+msgctxt "Auto context with id 129"
+msgid "Slideshow"
+msgstr "Pokaz slajdów"
+
+#: id:130
+msgctxt "Auto context with id 130"
+msgid "System info"
+msgstr "Informacje o systemie"
+
+#: id:131
+msgid "Display"
+msgstr "Ekran"
+
+#: id:132
+msgid "Albums"
+msgstr "Albumy"
+
+#: id:133
+msgid "Artists"
+msgstr "Wykonawcy"
+
+#: id:134
+msgid "Songs"
+msgstr "Utwory"
+
+#: id:135
+msgid "Genres"
+msgstr "Gatunki"
+
+#: id:136
+msgid "Playlists"
+msgstr "Playlisty"
+
+#: id:137
+msgid "Search"
+msgstr "Szukaj"
+
+#: id:138
+msgid "System Information"
+msgstr "Informacje o systemie"
+
+#: id:139
+msgid "Temperatures:"
+msgstr "Temperatura:"
+
+#: id:140
+msgid "CPU:"
+msgstr "CPU:"
+
+#: id:141
+msgid "GPU:"
+msgstr "GPU:"
+
+#: id:142
+msgid "Time:"
+msgstr "Czas:"
+
+#: id:143
+msgid "Current:"
+msgstr "Obecnie:"
+
+#: id:144
+msgid "Build:"
+msgstr "Build:"
+
+#: id:145
+msgid "Network:"
+msgstr "Sieć:"
+
+#: id:146
+msgid "Type:"
+msgstr "Typ:"
+
+#: id:147
+msgid "Static"
+msgstr "Statyczny"
+
+#: id:148
+msgid "DHCP"
+msgstr "DHCP"
+
+#: id:149
+msgid "MAC address"
+msgstr "MAC adres"
+
+#: id:150
+msgctxt "Auto context with id 150"
+msgid "IP address"
+msgstr "Adres IP"
+
+#: id:151
+msgid "Link:"
+msgstr "Połączenie:"
+
+#: id:152
+msgid "Half duplex"
+msgstr "Półdupleks"
+
+#: id:153
+msgid "Full duplex"
+msgstr "Pełny dupleks"
+
+#: id:154
+msgctxt "Auto context with id 154"
+msgid "Storage"
+msgstr "Partycje"
+
+#: id:155
+msgid "Drive"
+msgstr "Dysk"
+
+#: id:156
+msgctxt "Auto context with id 156"
+msgid "Free"
+msgstr "dostępne"
+
+#: id:157
+msgctxt "Auto context with id 157"
+msgid "Video"
+msgstr "Wideo"
+
+#: id:158
+msgid "Free memory"
+msgstr "Wolnej pamięci"
+
+#: id:159
+msgid "No link"
+msgstr "Brak połączenia"
+
+#: id:160
+msgctxt "Auto context with id 160"
+msgid "Free"
+msgstr "dostępne"
+
+#: id:161
+msgid "Unavailable"
+msgstr "Niedostępny"
+
+#: id:162
+msgid "Tray open"
+msgstr "Wysunięta tacka napędu"
+
+#: id:163
+msgid "Reading"
+msgstr "Czytam"
+
+#: id:164
+msgid "No disc"
+msgstr "Brak płyty w napędzie"
+
+#: id:165
+msgid "Disc present"
+msgstr "Płyta w napędzie"
+
+#: id:166
+msgid "Skin"
+msgstr "Skóra"
+
+#: id:169
+msgctxt "Auto context with id 169"
+msgid "Resolution"
+msgstr "Rozdzielczość"
+
+#: id:170
+msgid "Adjust display refresh rate to match video"
+msgstr "Dopasuj częstotliwość odświeżania do odtwarzanego materiału"
+
+#: id:172
+msgid "Release date"
+msgstr "Data wydania"
+
+#: id:173
+msgid "Display 4:3 videos as"
+msgstr "Wyświetlaj wideo 4:3 jako"
+
+#: id:175
+msgid "Moods"
+msgstr "Nastrój"
+
+#: id:176
+msgid "Styles"
+msgstr "Style"
+
+#: id:179
+msgid "Song"
+msgstr "Utwór"
+
+#: id:180
+msgid "Duration"
+msgstr "Czas trwania"
+
+#: id:181
+msgid "Select album"
+msgstr "Wybierz album"
+
+#: id:182
+msgid "Tracks"
+msgstr "Ścieżki"
+
+#: id:183
+msgid "Review"
+msgstr "Przegląd"
+
+#: id:184
+msgid "Refresh"
+msgstr "Odśwież"
+
+#: id:185
+msgid "Searching album"
+msgstr "Szukam albumu"
+
+#: id:186
+msgid "OK"
+msgstr "OK"
+
+#: id:187
+msgid "No albums found!"
+msgstr "Nie znaleziono albumu!"
+
+#: id:188
+msgid "Select all"
+msgstr "Zaznacz wszystko"
+
+#: id:189
+msgid "Scanning media info"
+msgstr "Wyszukuję informacje"
+
+#: id:190
+msgid "Save"
+msgstr "Zapisz"
+
+#: id:191
+msgid "Shuffle"
+msgstr "Losowo"
+
+#: id:192
+msgctxt "Auto context with id 192"
+msgid "Clear"
+msgstr "Wyczyść"
+
+#: id:193
+msgctxt "Auto context with id 193"
+msgid "Scan"
+msgstr "Skanuj"
+
+#: id:194
+msgid "Searching..."
+msgstr "Szukam..."
+
+#: id:195
+msgid "No info found!"
+msgstr "Nie znaleziono informacji"
+
+#: id:196
+msgid "Select movie:"
+msgstr "Wybierz film:"
+
+#: id:197
+msgid "Querying %s info"
+msgstr "Szukam informacji o %s"
+
+#: id:198
+msgid "Loading movie details"
+msgstr "Wczytuję informacje o filmie"
+
+#: id:199
+msgid "Web interface"
+msgstr "Interfejs WWW"
+
+#: id:202
+msgid "Tagline"
+msgstr "O filmie"
+
+#: id:203
+msgid "Plot outline"
+msgstr "Krótki opis"
+
+#: id:205
+msgid "Votes"
+msgstr "Głosy"
+
+#: id:206
+msgid "Cast"
+msgstr "Obsada"
+
+#: id:207
+msgid "Plot"
+msgstr "Opis"
+
+#: id:208
+msgctxt "Auto context with id 208"
+msgid "Play"
+msgstr "Odtwarzaj"
+
+#: id:209
+msgid "Next"
+msgstr "Następny"
+
+#: id:210
+msgid "Previous"
+msgstr "Poprzedni"
+
+#: id:213
+msgid "Calibrate user interface..."
+msgstr "Kalibracja interfejsu"
+
+#: id:214
+msgid "Video calibration..."
+msgstr "Kalibracja ekranu"
+
+#: id:215
+msgid "Soften"
+msgstr "Wygładź"
+
+#: id:216
+msgid "Zoom amount"
+msgstr "Powiększ"
+
+#: id:217
+msgid "Pixel ratio"
+msgstr "Proporcja pikseli"
+
+#: id:218
+msgid "DVD drive"
+msgstr "Napęd DVD"
+
+#: id:219
+msgid "Please insert disc"
+msgstr "Proszę włożyć dysk"
+
+#: id:220
+msgid "Remote share"
+msgstr "Zdalny udział"
+
+#: id:221
+msgid "Network is not connected"
+msgstr "Sieć nie jest podłączona"
+
+#: id:222
+msgid "Cancel"
+msgstr "Anuluj"
+
+#: id:224
+msgid "Speed"
+msgstr "Szybkość"
+
+#: id:225
+msgid "Vertical Shift"
+msgstr "Przesunięcie w pionie"
+
+#: id:226
+msgid "Test patterns..."
+msgstr "Wzorce testowe..."
+
+#: id:227
+msgid "Lookup audio CD track names from freedb.org"
+msgstr "Szukaj tytułów CD na freedb.org"
+
+#: id:228
+msgid "Shuffle playlist on load"
+msgstr "Losuj utwory podczas wczytywania"
+
+#: id:229
+msgid "HDD spindown time"
+msgstr "Wyłącz dysk po upływie"
+
+#: id:230
+msgid "Video filters"
+msgstr "Filtry"
+
+#: id:231
+msgctxt "Auto context with id 231"
+msgid "None"
+msgstr "Żaden"
+
+#: id:232
+msgid "Point"
+msgstr "Punktowy"
+
+#: id:233
+msgid "Linear"
+msgstr "Liniowy"
+
+#: id:234
+msgid "Anisotropic"
+msgstr "Anizotropowy"
+
+#: id:235
+msgid "Quincunx"
+msgstr "Quincunx"
+
+#: id:236
+msgid "Gaussian cubic"
+msgstr "Gaussian cubic"
+
+#: id:237
+msgid "Minification"
+msgstr "Pomniejszenie"
+
+#: id:238
+msgid "Magnification"
+msgstr "Powiększenie"
+
+#: id:239
+msgid "Clear playlist on finish"
+msgstr "Wyczyść po zakończeniu odtwarzania"
+
+#: id:240
+msgid "Display Mode"
+msgstr "Tryb wyświetlania"
+
+#: id:241
+msgid "Full Screen #%d"
+msgstr "Pełny ekran #%d"
+
+#: id:242
+msgid "Windowed"
+msgstr "Tryb okienkowy"
+
+#: id:243
+msgid "Refresh Rate"
+msgstr "Częstotliwość odświeżania"
+
+#: id:244
+msgid "Full screen"
+msgstr "Pełny ekran"
+
+#: id:245
+msgid "Sizing: (%i,%i)->(%i,%i) (Zoom x%2.2f) AR:%2.2f:1 (Pixels: %2.2f:1) (VShift: %2.2f)"
+msgstr "Rozmiar: (%i,%i)->(%i,%i) (Powiększenie x%2.2f) AR:%2.2f:1 (Piksele: %2.2f:1)"
+
+#: id:247
+msgctxt "Auto context with id 247"
+msgid "Scripts"
+msgstr "Skrypty"
+
+#: id:248
+msgctxt "Auto context with id 248"
+msgid "Language"
+msgstr "Język"
+
+#: id:249
+msgctxt "Auto context with id 249"
+msgid "Music"
+msgstr "Muzyka"
+
+#: id:250
+msgctxt "Auto context with id 250"
+msgid "Visualization"
+msgstr "Wizualizacja"
+
+#: id:251
+msgid "Select destination directory"
+msgstr "Wybierz katalog docelowy"
+
+#: id:252
+msgid "Output stereo to all speakers"
+msgstr "Wyjście stereo na wszystkie głośniki"
+
+#: id:253
+msgid "Number of channels"
+msgstr "Ilość kanałów"
+
+#: id:254
+msgid "- DTS capable receiver"
+msgstr "- Odbiornik obsługuje DTS"
+
+#: id:255
+msgid "CDDB"
+msgstr "CDDB"
+
+#: id:256
+msgid "Fetching CD information"
+msgstr "Pobieram informację o CD"
+
+#: id:257
+msgid "Error"
+msgstr "Błąd"
+
+#: id:258
+msgid "Enable tag reading"
+msgstr "Włącz obsługę tagów (metadanych)"
+
+#: id:259
+msgid "Opening"
+msgstr "Otwieram"
+
+#: id:260
+msgid "Shoutcast"
+msgstr "Shoutcast"
+
+#: id:261
+msgid "Waiting for start..."
+msgstr "Oczekuję na rozpoczęcie..."
+
+#: id:262
+msgid "Scripts output"
+msgstr "Monitor działania skryptów"
+
+#: id:263
+msgid "Allow control of XBMC via HTTP"
+msgstr "Sterowanie XBMC poprzez HTTP"
+
+#: id:264
+msgid "Record"
+msgstr "Nagrywaj"
+
+#: id:265
+msgid "Stop Rec."
+msgstr "Zatrzymaj nagranie"
+
+#: id:266
+msgid "Sort by: Track"
+msgstr "Sortuj: Utwór"
+
+#: id:267
+msgid "Sort by: Time"
+msgstr "Sortuj: Czas"
+
+#: id:268
+msgid "Sort by: Title"
+msgstr "Sortuj: Tytuł"
+
+#: id:269
+msgid "Sort by: Artist"
+msgstr "Sortuj: Artysta"
+
+#: id:270
+msgid "Sort by: Album"
+msgstr "Sortuj: Album"
+
+#: id:271
+msgid "Top 100"
+msgstr "Top 100"
+
+#: id:272
+msgid "Top-Left overscan compensation"
+msgstr "Overscan lewego górnego rogu ekranu"
+
+#: id:273
+msgid "Bottom-Right overscan compensation"
+msgstr "Overscan prawego dolnego rogu ekranu"
+
+#: id:274
+msgid "Subtitle positioning"
+msgstr "Pozycja napisów"
+
+#: id:275
+msgid "Pixel ratio adjustment"
+msgstr "Ustawienie proporcji pikseli"
+
+#: id:276
+msgid "Adjust the arrow to change the amount of overscan"
+msgstr "Poruszaj strzałką, aby zmieniać wielkość overscanu"
+
+#: id:277
+msgid "Adjust the bar to change the subtitles position"
+msgstr "Przesuń linię, aby zmieniać pozycję napisów"
+
+#: id:278
+msgid "Adjust the rectangle so it is perfectly square"
+msgstr "Zmień prostokąt w idealny kwadrat"
+
+#: id:279
+msgid "Unable to load settings"
+msgstr "Nie mogę wczytać ustawień"
+
+#: id:280
+msgid "Using default settings"
+msgstr "Zostaną użyte ustawienia domyślne"
+
+#: id:281
+msgid "Please check the XML files"
+msgstr "Proszę sprawdzić pliki XML"
+
+#: id:282
+msgid "Found %i items"
+msgstr "Znaleziono %i pozycji"
+
+#: id:283
+msgid "Search results"
+msgstr "Rezultaty wyszukiwania"
+
+#: id:284
+msgid "No results found"
+msgstr "Brak wyników"
+
+#: id:287
+msgctxt "Auto context with id 287"
+msgid "Subtitles"
+msgstr "Napisy"
+
+#: id:288
+msgctxt "Auto context with id 288"
+msgid "Font"
+msgstr "Czcionka"
+
+#: id:289
+msgctxt "Auto context with id 289"
+msgid "- Size"
+msgstr "- Rozmiar"
+
+#: id:290
+msgid "Dynamic range compression"
+msgstr "Dynamiczna kontrola zakresu"
+
+#: id:291
+msgctxt "Auto context with id 291"
+msgid "Video"
+msgstr "Wideo"
+
+#: id:292
+msgctxt "Auto context with id 292"
+msgid "Audio"
+msgstr "Dźwięk"
+
+#: id:293
+msgid "Browse for subtitles"
+msgstr "Wskaż napisy"
+
+#: id:294
+msgid "Create bookmark"
+msgstr "Utwórz zakładkę"
+
+#: id:296
+msgid "Clear bookmarks"
+msgstr "Wyczyść zakładki"
+
+#: id:297
+msgid "Audio offset"
+msgstr "Przesunięcie dźwięku"
+
+#: id:298
+msgid "Bookmarks"
+msgstr "Zakładki"
+
+#: id:299
+msgid "- AAC capable receiver"
+msgstr "- Odbiornik obsługuje AAC"
+
+#: id:300
+msgid "- MP1 capable receiver"
+msgstr "- Odbiornik obsługuje MP1"
+
+#: id:301
+msgid "- MP2 capable receiver"
+msgstr "- Odbiornik obsługuje MP2"
+
+#: id:302
+msgid "- MP3 capable receiver"
+msgstr "- Odbiornik obsługuje MP3"
+
+#: id:303
+msgid "Delay"
+msgstr "Opóźnienie"
+
+#: id:304
+msgctxt "Auto context with id 304"
+msgid "Language"
+msgstr "Język"
+
+#: id:305
+msgctxt "Auto context with id 305"
+msgid "Enabled"
+msgstr "Włączony"
+
+#: id:306
+msgid "Non-interleaved"
+msgstr "Bez przeplotu"
+
+#: id:312
+msgid "(0=auto)"
+msgstr "(0=auto)"
+
+#: id:313
+msgid "Cleaning database"
+msgstr "Czyszczenie bazy danych"
+
+#: id:314
+msgid "Preparing..."
+msgstr "Przygotowuję..."
+
+#: id:315
+msgid "Database error"
+msgstr "Błąd bazy danych"
+
+#: id:316
+msgid "Searching songs..."
+msgstr "Przeszukuję utwory..."
+
+#: id:317
+msgid "Cleaned database successfully"
+msgstr "Czyszczenie bazy danych zakończone"
+
+#: id:318
+msgid "Cleaning songs..."
+msgstr "Czyszczę skasowane utwory..."
+
+#: id:319
+msgid "Error cleaning songs"
+msgstr "Błąd przy czyszczeniu skasowanych utworów"
+
+#: id:320
+msgid "Cleaning artists..."
+msgstr "Przeszukuję artystów..."
+
+#: id:321
+msgid "Error cleaning artists"
+msgstr "Błąd przy aktualizacji listy artystów"
+
+#: id:322
+msgid "Cleaning genres..."
+msgstr "Przeszukuję gatunki..."
+
+#: id:323
+msgid "Error cleaning genres"
+msgstr "Błąd przy aktualizacji listy gatunków"
+
+#: id:324
+msgid "Cleaning paths..."
+msgstr "Przeszukuję ścieżki..."
+
+#: id:325
+msgid "Error cleaning paths"
+msgstr "Błąd przy aktualizacji listy ścieżek"
+
+#: id:326
+msgid "Cleaning albums..."
+msgstr "Przeszukuję albumy..."
+
+#: id:327
+msgid "Error cleaning albums"
+msgstr "Błąd przy aktualizacji listy albumów"
+
+#: id:328
+msgid "Writing changes..."
+msgstr "Zapisuję zmiany..."
+
+#: id:329
+msgid "Error writing changes"
+msgstr "Błąd zapisu zmian"
+
+#: id:330
+msgid "This may take some time..."
+msgstr "Proszę czekać..."
+
+#: id:331
+msgid "Compressing database..."
+msgstr "Kompresuję bazę danych..."
+
+#: id:332
+msgid "Error compressing database"
+msgstr "Błąd kompresji bazy"
+
+#: id:333
+msgid "Do you want to clean the library?"
+msgstr "Czy chcesz wyczyścić bibliotekę?"
+
+#: id:334
+msgid "Clean library..."
+msgstr "Czyszczenie biblioteki...."
+
+#: id:335
+msgid "Start"
+msgstr "Rozpocznij"
+
+#: id:336
+msgid "Framerate conversion"
+msgstr "Konwertuj liczbę klatek"
+
+#: id:337
+msgctxt "Auto context with id 337"
+msgid "Audio output"
+msgstr "Wyjście dźwięku"
+
+#: id:338
+msgid "Analog"
+msgstr "Analogowe"
+
+#: id:339
+msgid "Optical/Coax"
+msgstr "Cyfrowe"
+
+#: id:340
+msgid "Various artists"
+msgstr "Różni artyści"
+
+#: id:341
+msgid "Play disc"
+msgstr "Odtwarzaj płytę"
+
+#: id:342
+msgctxt "Auto context with id 342"
+msgid "Movies"
+msgstr "Filmy"
+
+#: id:343
+msgid "Adjust framerate"
+msgstr "Dostosuj liczbę klatek"
+
+#: id:344
+msgid "Actors"
+msgstr "Obsada"
+
+#: id:345
+msgctxt "Auto context with id 345"
+msgid "Year"
+msgstr "Rok"
+
+#: id:346
+msgid "Boost volume level on downmix"
+msgstr "Wzmocnij głośność przy downmixie"
+
+#: id:350
+msgctxt "Auto context with id 350"
+msgid "Programs"
+msgstr "Programy"
+
+#: id:351
+msgctxt "Auto context with id 351"
+msgid "Off"
+msgstr "Wyłączone"
+
+#: id:352
+msgid "Dim"
+msgstr "Przyciemnienie"
+
+#: id:353
+msgid "Black"
+msgstr "Czarny ekran"
+
+#: id:354
+msgid "Matrix trails"
+msgstr "Matrix"
+
+#: id:355
+msgid "Screensaver time"
+msgstr "Włącz wygaszacz po upływie"
+
+#: id:356
+msgid "Screensaver mode"
+msgstr "Tryb wygaszacza"
+
+#: id:357
+msgid "Shutdown function timer"
+msgstr "Wyłączenie planowane"
+
+#: id:358
+msgid "All albums"
+msgstr "Wszystkie albumy"
+
+#: id:359
+msgid "Recently added albums"
+msgstr "Ostatnio dodane albumy"
+
+#: id:360
+msgctxt "Auto context with id 360"
+msgid "Screensaver"
+msgstr "Wygaszacz"
+
+#: id:361
+msgid "R. Slideshow"
+msgstr "z podkatalogami"
+
+#: id:362
+msgid "Screensaver dim level"
+msgstr "Poziom przyciemnienia"
+
+#: id:363
+msgid "Sort by: File"
+msgstr "Sortuj: Plik"
+
+#: id:364
+msgid "- Dolby Digital (AC3) capable receiver"
+msgstr "- Odbiornik obsługuje Dolby Digital (AC3)"
+
+#: id:365
+msgctxt "Auto context with id 365"
+msgid "Sort by: Name"
+msgstr "Sortuj: Nazwa"
+
+#: id:366
+msgid "Sort by: Year"
+msgstr "Sortuj: Rok"
+
+#: id:367
+msgid "Sort by: Rating"
+msgstr "Sortuj: Ocena"
+
+#: id:368
+msgid "IMDb"
+msgstr "IMDb"
+
+#: id:369
+msgctxt "Auto context with id 369"
+msgid "Title"
+msgstr "Tytuł"
+
+#: id:370
+msgid "Thunderstorms"
+msgstr "wichura"
+
+#: id:371
+msgid "Partly"
+msgstr "częściowo"
+
+#: id:372
+msgid "Mostly"
+msgstr "w większości"
+
+#: id:373
+msgid "Sunny"
+msgstr "słonecznie"
+
+#: id:374
+msgid "Cloudy"
+msgstr "pochmurnie"
+
+#: id:375
+msgid "Snow"
+msgstr "śnieg"
+
+#: id:376
+msgid "Rain"
+msgstr "deszcz"
+
+#: id:377
+msgid "Light"
+msgstr "niewielki"
+
+#: id:378
+msgid "AM"
+msgstr "rano"
+
+#: id:379
+msgid "PM"
+msgstr "wieczorem"
+
+#: id:380
+msgid "Showers"
+msgstr "opady"
+
+#: id:381
+msgid "Few"
+msgstr "niewielkie"
+
+#: id:382
+msgid "Scattered"
+msgstr "sporadyczne"
+
+#: id:383
+msgctxt "Auto context with id 383"
+msgid "Wind"
+msgstr "Wiatr"
+
+#: id:384
+msgid "Strong"
+msgstr "silny"
+
+#: id:385
+msgid "Fair"
+msgstr "pogodnie"
+
+#: id:386
+msgctxt "Auto context with id 386"
+msgid "Clear"
+msgstr "bezchmurnie"
+
+#: id:387
+msgid "Clouds"
+msgstr "pochmurnie"
+
+#: id:388
+msgid "Early"
+msgstr "wcześnie"
+
+#: id:389
+msgid "Shower"
+msgstr "drobny"
+
+#: id:390
+msgid "Flurries"
+msgstr "ulewa"
+
+#: id:391
+msgctxt "Auto context with id 391"
+msgid "Low"
+msgstr "min."
+
+#: id:392
+msgctxt "Auto context with id 392"
+msgid "Medium"
+msgstr "średnie"
+
+#: id:393
+msgctxt "Auto context with id 393"
+msgid "High"
+msgstr "maks."
+
+#: id:394
+msgid "Fog"
+msgstr "mgła"
+
+#: id:395
+msgid "Haze"
+msgstr "zamglenie"
+
+#: id:396
+msgid "Select location"
+msgstr "Wybierz miasto"
+
+#: id:397
+msgid "Refresh time"
+msgstr "Czas odświeżania"
+
+#: id:398
+msgid "Temperature units"
+msgstr "Jednostka temperatury"
+
+#: id:399
+msgid "Speed units"
+msgstr "Jednostka prędkości"
+
+#: id:400
+msgctxt "Auto context with id 400"
+msgid "Weather"
+msgstr "Pogoda"
+
+#: id:401
+msgid "Temp"
+msgstr "Temperatura"
+
+#: id:402
+msgid "Feels like"
+msgstr "Odczuwalna"
+
+#: id:403
+msgid "UV index"
+msgstr "Wskaźnik UV"
+
+#: id:404
+msgctxt "Auto context with id 404"
+msgid "Wind"
+msgstr "Wiatr"
+
+#: id:405
+msgid "Dew point"
+msgstr "Punkt rosy"
+
+#: id:406
+msgid "Humidity"
+msgstr "Wilgotność"
+
+#: id:409
+msgid "Defaults"
+msgstr "Domyślne"
+
+#: id:410
+msgid "Accessing weather service"
+msgstr "Łączę się z usługą pogody"
+
+#: id:411
+msgid "Getting weather for:"
+msgstr "Pobieram pogodę dla:"
+
+#: id:412
+msgid "Unable to get weather data"
+msgstr "Nie mogę uzyskać danych pogodowych"
+
+#: id:413
+msgid "Manual"
+msgstr "Ręcznie"
+
+#: id:414
+msgid "No review for this album"
+msgstr "Brak recenzji tego albumu"
+
+#: id:415
+msgid "Downloading thumbnail..."
+msgstr "Pobieram miniaturkę..."
+
+#: id:416
+msgid "Not available"
+msgstr "Niedostępne"
+
+#: id:417
+msgid "View: Big icons"
+msgstr "Widok: Duże ikony"
+
+#: id:418
+msgctxt "Auto context with id 418"
+msgid "Low"
+msgstr "min."
+
+#: id:419
+msgctxt "Auto context with id 419"
+msgid "High"
+msgstr "maks."
+
+#: id:420
+msgid "HDMI"
+msgstr ""
+
+#: id:422
+msgid "Delete album info"
+msgstr "Usuń informacje o albumach"
+
+#: id:423
+msgid "Delete CD information"
+msgstr "Usuń informacje o CD"
+
+#: id:424
+msgid "Select"
+msgstr "Zaznacz"
+
+#: id:425
+msgid "No album information found"
+msgstr "Nie znaleziono informacji o albumie"
+
+#: id:426
+msgid "No CD information found"
+msgstr "Nie znaleziono informacji o CD"
+
+#: id:427
+msgid "Disc"
+msgstr "Dysk"
+
+#: id:428
+msgid "Insert correct CD/DVD"
+msgstr "Proszę włożyć właściwy CD/DVD"
+
+#: id:429
+msgid "Please insert the following disc:"
+msgstr "Proszę włożyć następujący CD/DVD"
+
+#: id:430
+msgid "Sort by: DVD#"
+msgstr "Sortuj: DVD#"
+
+#: id:431
+msgid "No cache"
+msgstr "Bez pamięci podręcznej"
+
+#: id:432
+msgid "Remove movie from library"
+msgstr "Usuń film z biblioteki"
+
+#: id:433
+msgid "Really remove '%s'?"
+msgstr "Jesteś pewny, że chcesz usunąć '%s'?"
+
+#: id:434
+msgid "From %s at %i %s"
+msgstr "Z %s do %i %s"
+
+#: id:437
+msgid "Removable disk"
+msgstr "Dysk wymienny"
+
+#: id:438
+msgid "Opening file"
+msgstr "Otwieram plik"
+
+#: id:439
+msgid "Cache"
+msgstr "Pamięć podręczna"
+
+#: id:440
+msgid "Harddisk"
+msgstr "Dysk twardy"
+
+#: id:441
+msgid "UDF"
+msgstr ""
+
+#: id:442
+msgid "Local network"
+msgstr "Sieć lokalna"
+
+#: id:443
+msgid "Internet"
+msgstr "Internet"
+
+#: id:444
+msgctxt "Auto context with id 444"
+msgid "Video"
+msgstr "Wideo"
+
+#: id:445
+msgctxt "Auto context with id 445"
+msgid "Audio"
+msgstr "Dźwięk"
+
+#: id:446
+msgctxt "Auto context with id 446"
+msgid "DVD"
+msgstr ""
+
+#: id:447
+msgid "Autorun media"
+msgstr "Autoodtwarzanie"
+
+#: id:448
+msgid "LCD"
+msgstr ""
+
+#: id:449
+msgctxt "Auto context with id 449"
+msgid "Enabled"
+msgstr "Włączone"
+
+#: id:450
+msgid "Columns"
+msgstr "Kolumn"
+
+#: id:451
+msgid "Row 1 address"
+msgstr "Adres 1 rzędu"
+
+#: id:452
+msgid "Row 2 address"
+msgstr "Adres 2 rzędu"
+
+#: id:453
+msgid "Row 3 address"
+msgstr "Adres 3 rzędu"
+
+#: id:454
+msgid "Row 4 address"
+msgstr "Adres 4 rzędu"
+
+#: id:455
+msgid "Rows"
+msgstr "Ilość rzędów"
+
+#: id:456
+msgid "Mode"
+msgstr "Tryb"
+
+#: id:457
+msgid "Switch view"
+msgstr "Przełącz widok"
+
+#: id:459
+msgid "Subs"
+msgstr "Napisy"
+
+#: id:460
+msgid "Audio stream"
+msgstr "Strumień audio"
+
+#: id:461
+msgid "[active]"
+msgstr "[aktywny]"
+
+#: id:462
+msgid "Subtitle"
+msgstr "Napisy"
+
+#: id:463
+msgid "Backlight"
+msgstr "Podświetlanie"
+
+#: id:464
+msgid "Brightness"
+msgstr "Jasność"
+
+#: id:465
+msgid "Contrast"
+msgstr "Kontrast"
+
+#: id:466
+msgid "Gamma"
+msgstr "Gamma"
+
+#: id:467
+msgctxt "Auto context with id 467"
+msgid "Type"
+msgstr "Typ"
+
+#: id:468
+msgid "Move the bar to change the OSD position"
+msgstr "Przesuń linię, aby zmienić pozycję OSD"
+
+#: id:469
+msgid "OSD position"
+msgstr "Pozycja OSD"
+
+#: id:470
+msgid "Credits"
+msgstr "Autorzy"
+
+#: id:471
+msgid "Modchip"
+msgstr "Modchip"
+
+#: id:474
+msgctxt "Auto context with id 474"
+msgid "Off"
+msgstr "Wyłącz"
+
+#: id:475
+msgid "Music only"
+msgstr "Tylko Muzyka"
+
+#: id:476
+msgctxt "Auto context with id 476"
+msgid "Music & video"
+msgstr "Muzyka i Wideo"
+
+#: id:477
+msgid "Unable to load playlist"
+msgstr "Nie mogę wczytać playlisty"
+
+#: id:478
+msgid "OSD"
+msgstr "OSD"
+
+#: id:479
+msgid "Skin & language"
+msgstr "Skóry i język"
+
+#: id:480
+msgid "Appearance"
+msgstr "Wygląd"
+
+#: id:481
+msgid "Audio options"
+msgstr "Opcje dźwięku"
+
+#: id:482
+msgid "About XBMC"
+msgstr "O XBMC"
+
+#: id:485
+msgid "Delete album"
+msgstr "Usuń Album"
+
+#: id:486
+msgid "Repeat"
+msgstr "Powtarzaj"
+
+#: id:487
+msgid "Repeat one"
+msgstr "Powtórz raz"
+
+#: id:488
+msgid "Repeat folder"
+msgstr "Powtarzaj utwory z jednego katalogu"
+
+#: id:489
+msgid "Play the next song automatically"
+msgstr "Automatycznie odtwarzaj kolejny utwór"
+
+#: id:491
+msgid "- Use big icons"
+msgstr "- Użyj dużych ikon"
+
+#: id:492
+msgid "Resize VobSubs"
+msgstr "Zmień rozmiar napisów"
+
+#: id:493
+msgid "Advanced options (Experts Only!)"
+msgstr "Zaawansowane ustawienia"
+
+#: id:494
+msgid "Overall audio headroom"
+msgstr ""
+
+#: id:495
+msgid "Upsample videos to GUI resolution"
+msgstr "Przeskaluj wideo do rozdzielczości interfejsu"
+
+#: id:496
+msgid "Calibration"
+msgstr "Kalibracja"
+
+#: id:497
+msgid "Show file extensions"
+msgstr "Pokazuj rozszerzenia plików"
+
+#: id:498
+msgid "Sort by: Type"
+msgstr "Sortuj: Typ"
+
+#: id:499
+msgid "Unable to connect to online lookup service"
+msgstr "Nie mogę połączyć się z serwisem"
+
+#: id:500
+msgid "Downloading album information failed"
+msgstr "Ściąganie informacji albumu nie powiodło się"
+
+#: id:501
+msgid "Looking for album names..."
+msgstr "Szukanie nazw albumu..."
+
+#: id:502
+msgctxt "Auto context with id 502"
+msgid "Open"
+msgstr "Otwarty"
+
+#: id:503
+msgid "Busy"
+msgstr "Zajęty"
+
+#: id:504
+msgid "Empty"
+msgstr "Pusty"
+
+#: id:505
+msgid "Loading media info from files..."
+msgstr "Wczytuję informacje o mediach z plików..."
+
+#: id:507
+msgid "Sort by: Usage"
+msgstr "Sortuj: Użycie"
+
+#: id:510
+msgid "Enable visualizations"
+msgstr "Włącz wizualizacje"
+
+#: id:511
+msgid "Enable video mode switching"
+msgstr "Tryb wyświetlania w zależności od regionu gry"
+
+#: id:512
+msgid "Startup window"
+msgstr "Okno startowe"
+
+#: id:513
+msgid "Home window"
+msgstr "Ekran główny"
+
+#: id:514
+msgid "Manual settings"
+msgstr "Ustawienia ręczne"
+
+#: id:515
+msgid "Genre"
+msgstr "Gatunek"
+
+#: id:517
+msgid "Recently played albums"
+msgstr "Ostatnio odtwarzane albumy"
+
+#: id:518
+msgid "Launch"
+msgstr "Uruchom"
+
+#: id:519
+msgid "Launch in..."
+msgstr "Uruchom w..."
+
+#: id:521
+msgid "Compilations"
+msgstr "Kompilacje"
+
+#: id:522
+msgid "Remove source"
+msgstr "Usuń źródło"
+
+#: id:523
+msgid "Switch media"
+msgstr "Przełącz media"
+
+#: id:524
+msgid "Select playlist"
+msgstr "Wybierz playlistę"
+
+#: id:525
+msgid "New playlist..."
+msgstr "Nowa playlista..."
+
+#: id:526
+msgid "Add to playlist"
+msgstr "Dodaj do playlisty"
+
+#: id:527
+msgid "Manually add to library"
+msgstr "Dodaj ręcznie do biblioteki"
+
+#: id:528
+msgid "Enter title"
+msgstr "Wprowadź tytuł"
+
+#: id:529
+msgid "Error: Duplicate title"
+msgstr "Błąd: Tytuł już istnieje"
+
+#: id:530
+msgid "Select genre"
+msgstr "Wybierz gatunek"
+
+#: id:531
+msgid "New genre"
+msgstr "Nowy gatunek"
+
+#: id:532
+msgid "Manual addition"
+msgstr "Ręcznie dodane"
+
+#: id:533
+msgid "Enter genre"
+msgstr "Wprowadź gatunek"
+
+#: id:534
+msgid "View: %s"
+msgstr "Widok: %s"
+
+#: id:535
+msgid "List"
+msgstr "Lista"
+
+#: id:536
+msgid "Icons"
+msgstr "Ikony"
+
+#: id:537
+msgid "Big list"
+msgstr "Duża lista"
+
+#: id:538
+msgid "Big icons"
+msgstr "Duże ikony"
+
+#: id:539
+msgid "Wide"
+msgstr "Baner"
+
+#: id:540
+msgid "Big wide"
+msgstr "Duży baner"
+
+#: id:541
+msgid "Album icons"
+msgstr "Ikony albumów"
+
+#: id:542
+msgid "DVD icons"
+msgstr "Ikony DVD"
+
+#: id:543
+msgctxt "Auto context with id 543"
+msgid "DVD"
+msgstr ""
+
+#: id:544
+msgctxt "Auto context with id 544"
+msgid "Media info"
+msgstr "O mediach"
+
+#: id:545
+msgid "Audio output device"
+msgstr "Wyjściowe urządzenie audio"
+
+#: id:546
+msgid "Passthrough output device"
+msgstr "Urządzenie przejścia dźwięku"
+
+#: id:547
+msgid "No biography for this artist"
+msgstr "Biografia artysty niedostępna"
+
+#: id:548
+msgid "Downmix multichannel audio to stereo"
+msgstr "Dźwięk wielokanałowy konwertuj do stereo"
+
+#: id:550
+msgid "Sort by: %s"
+msgstr "Sortuj: %s"
+
+#: id:551
+msgctxt "Auto context with id 551"
+msgid "Name"
+msgstr "Nazwa"
+
+#: id:552
+msgid "Date"
+msgstr "Data"
+
+#: id:553
+msgid "Size"
+msgstr "Rozmiar"
+
+#: id:554
+msgid "Track"
+msgstr "Utwór"
+
+#: id:555
+msgid "Time"
+msgstr "Czas"
+
+#: id:556
+msgctxt "Auto context with id 556"
+msgid "Title"
+msgstr "Tytuł"
+
+#: id:557
+msgid "Artist"
+msgstr "Artysta"
+
+#: id:558
+msgid "Album"
+msgstr "Album"
+
+#: id:559
+msgid "Playlist"
+msgstr "Playlista"
+
+#: id:560
+msgid "ID"
+msgstr "ID"
+
+#: id:561
+msgctxt "Auto context with id 561"
+msgid "File"
+msgstr "Plik"
+
+#: id:562
+msgctxt "Auto context with id 562"
+msgid "Year"
+msgstr "Rok"
+
+#: id:563
+msgid "Rating"
+msgstr "Ocena"
+
+#: id:564
+msgctxt "Auto context with id 564"
+msgid "Type"
+msgstr "Typ"
+
+#: id:565
+msgid "Usage"
+msgstr "Użycie"
+
+#: id:566
+msgid "Album artist"
+msgstr "Album Artysta"
+
+#: id:567
+msgid "Play count"
+msgstr "Ilość odtworzeń"
+
+#: id:568
+msgid "Last played"
+msgstr "Ostatnio odtwarzany"
+
+#: id:569
+msgctxt "Auto context with id 569"
+msgid "Comment"
+msgstr "Komentarz"
+
+#: id:570
+msgid "Date added"
+msgstr "Data dodania"
+
+#: id:571
+msgctxt "Auto context with id 571"
+msgid "Default"
+msgstr "Domyślny"
+
+#: id:572
+msgid "Studio"
+msgstr "Wytwórnia"
+
+#: id:573
+msgid "Path"
+msgstr "Ścieżka"
+
+#: id:574
+msgctxt "Auto context with id 574"
+msgid "Country"
+msgstr "Kraj"
+
+#: id:575
+msgid "In progress"
+msgstr "W toku"
+
+#: id:576
+msgid "Times played"
+msgstr "Odtworzeń"
+
+#: id:580
+msgid "Sort direction"
+msgstr "Kierunek sortowania"
+
+#: id:581
+msgid "Sort method"
+msgstr "Metoda sortowania"
+
+#: id:582
+msgctxt "Auto context with id 582"
+msgid "View mode"
+msgstr "Tryby widoku"
+
+#: id:583
+msgid "Remember views for different folders"
+msgstr "Zapamiętaj tryb widoku dla różnych folderów"
+
+#: id:584
+msgid "Ascending"
+msgstr "Rosnąco"
+
+#: id:585
+msgid "Descending"
+msgstr "Malejąco"
+
+#: id:586
+msgid "Edit playlist"
+msgstr "Edytuj playlistę"
+
+#: id:587
+msgid "Filter"
+msgstr "Filtr"
+
+#: id:588
+msgid "Cancel party mode"
+msgstr "Wyłącz Tryb Imprezy"
+
+#: id:589
+msgid "Party mode"
+msgstr "Tryb Imprezy"
+
+#: id:590
+msgid "Random"
+msgstr "Losowo"
+
+#: id:591
+msgctxt "Auto context with id 591"
+msgid "Off"
+msgstr "Wyłączone"
+
+#: id:592
+msgid "One"
+msgstr "Jeden"
+
+#: id:593
+msgid "All"
+msgstr "Wszystko"
+
+#: id:594
+msgctxt "Auto context with id 594"
+msgid "Off"
+msgstr "Wyłączone"
+
+#: id:595
+msgid "Repeat: Off"
+msgstr "Powtórz: Nic"
+
+#: id:596
+msgid "Repeat: One"
+msgstr "Powtórz: Jeden"
+
+#: id:597
+msgid "Repeat: All"
+msgstr "Powtórz: Wszystko"
+
+#: id:600
+msgid "Rip audio CD"
+msgstr "Zgraj Audio CD"
+
+#: id:601
+msgctxt "Auto context with id 601"
+msgid "Medium"
+msgstr "Średnia"
+
+#: id:602
+msgctxt "Auto context with id 602"
+msgid "Standard"
+msgstr "Standardowa"
+
+#: id:603
+msgid "Extreme"
+msgstr "Najwyższa"
+
+#: id:604
+msgid "Constant bitrate"
+msgstr "Stały bitrate"
+
+#: id:605
+msgid "Ripping..."
+msgstr "Zgrywanie muzyki..."
+
+#: id:607
+msgid "To:"
+msgstr "Zgrywaj do:"
+
+#: id:608
+msgid "Could not rip CD or track"
+msgstr "Nie mogę zgrać CD lub utworu"
+
+#: id:609
+msgid "CDDARipPath is not set."
+msgstr "Ścieżka do katalogu nie jest ustawiona."
+
+#: id:610
+msgid "Rip audio track"
+msgstr "Zgraj utwór"
+
+#: id:611
+msgid "Enter number"
+msgstr "Wprowadź numer"
+
+#: id:612
+msgid "Bits/Sample"
+msgstr "Bitów/Próbkę"
+
+#: id:613
+msgid "Sample Frequency"
+msgstr "Próbkowanie"
+
+#: id:620
+msgid "Audio CDs"
+msgstr "Płyty CD"
+
+#: id:621
+msgid "Encoder"
+msgstr "Koder"
+
+#: id:622
+msgid "Quality"
+msgstr "Jakość"
+
+#: id:623
+msgid "Bitrate"
+msgstr "Bitrate"
+
+#: id:624
+msgid "Include track number"
+msgstr "Dołączaj numer utworu"
+
+#: id:625
+msgid "All songs of"
+msgstr "Wszystkie utwory"
+
+#: id:629
+msgctxt "Auto context with id 629"
+msgid "View mode"
+msgstr "Tryb wyświetlania"
+
+#: id:630
+msgctxt "Auto context with id 630"
+msgid "Normal"
+msgstr "Normalny"
+
+#: id:631
+msgid "Zoom"
+msgstr "Powiększenie"
+
+#: id:632
+msgid "Stretch 4:3"
+msgstr "Proporcje 4:3"
+
+#: id:633
+msgid "Wide Zoom"
+msgstr "Proporcje 14:9"
+
+#: id:634
+msgid "Stretch 16:9"
+msgstr "Proporcje 16:9"
+
+#: id:635
+msgid "Original Size"
+msgstr "Oryginalny rozmiar"
+
+#: id:636
+msgctxt "Auto context with id 636"
+msgid "Custom"
+msgstr "Własny"
+
+#: id:637
+msgid "Replay gain"
+msgstr "Replay Gain"
+
+#: id:638
+msgid "Replaygain volume adjustments"
+msgstr "Ustawienie głośności Replay Gain"
+
+#: id:639
+msgid "Use track levels"
+msgstr "Użyj poziom utworu"
+
+#: id:640
+msgid "Use album levels"
+msgstr "Użyj poziom albumu"
+
+#: id:641
+msgid "PreAmp Level - Replay gained files"
+msgstr "Wzmocnienie plików z Replay Gain"
+
+#: id:642
+msgid "PreAmp Level - Non replay gained files"
+msgstr "Wzmocnienie plików bez Replay Gain"
+
+#: id:643
+msgid "Avoid clipping on replay gained files"
+msgstr "Unikaj przesterowania w plikach z Replay Gain"
+
+#: id:644
+msgid "Crop black bars"
+msgstr "Przycinaj czarne pasy"
+
+#: id:645
+msgid "Need to unpack a big file. Continue?"
+msgstr "Muszę rozpakować duży plik. Kontynuować?"
+
+#: id:646
+msgid "Remove from library"
+msgstr "Usuń z biblioteki"
+
+#: id:647
+msgid "Export video library"
+msgstr "Eksport bazy danych"
+
+#: id:648
+msgid "Import video library"
+msgstr "Import bazy danych"
+
+#: id:649
+msgid "Importing"
+msgstr "Importowanie"
+
+#: id:650
+msgid "Exporting"
+msgstr "Eksportowanie"
+
+#: id:651
+msgid "Browse for library"
+msgstr "Wskaż bibliotekę"
+
+#: id:652
+msgid "Years"
+msgstr "Lata"
+
+#: id:653
+msgid "Update library"
+msgstr "Aktualizuj bibliotekę"
+
+#: id:654
+msgid "Show debug info"
+msgstr "Pokaż logi (debug)"
+
+#: id:655
+msgid "Browse for executable"
+msgstr "Wskaż plik rozruchowy"
+
+#: id:656
+msgid "Browse for playlist"
+msgstr "Wskaż playlistę"
+
+#: id:657
+msgid "Browse for folder"
+msgstr "Wskaż katalog"
+
+#: id:658
+msgid "Song information"
+msgstr "Informacje o utworze"
+
+#: id:659
+msgid "Non-linear stretch"
+msgstr "Rozciągaj nieliniowo"
+
+#: id:660
+msgid "Volume amplification"
+msgstr "Wzmocnienie głośności"
+
+#: id:661
+msgid "Choose export folder"
+msgstr "Wybierz katalog eksportu"
+
+#: id:662
+msgid "This file is no longer available."
+msgstr "Plik został prawdopodobnie usunięty."
+
+#: id:663
+msgid "Would you like to remove it from the library?"
+msgstr "Chcesz usunąć pozycję z biblioteki?"
+
+#: id:664
+msgid "Browse for Script"
+msgstr "Wskaż skrypt"
+
+#: id:665
+msgid "Compression level"
+msgstr "Poziom kompresji"
+
+#: id:700
+msgid "Cleaning up library"
+msgstr "Czyszczenie bazy danych"
+
+#: id:701
+msgid "Removing old songs from the library"
+msgstr "Usuwanie starych utworów z bazy danych"
+
+#: id:702
+msgid "This path has been scanned before"
+msgstr "Ta ścieżka była już skanowana"
+
+#: id:705
+msgctxt "Auto context with id 705"
+msgid "Network"
+msgstr "Sieć"
+
+#: id:706
+msgid "- Server"
+msgstr "- Serwer"
+
+#: id:708
+msgid "Use an HTTP proxy server to access the internet"
+msgstr "Dostęp do Internetu poprzez HTTP Proxy serwer"
+
+#: id:711
+msgid "Internet Protocol (IP)"
+msgstr "Ustawienia sieci (IP)"
+
+#: id:712
+msgid "Invalid port specified. Value must be between 1 and 65535."
+msgstr "Wprowadzono nieprawidłowy port. Wartość musi być z przedziału 1-65535."
+
+#: id:713
+msgid "HTTP proxy"
+msgstr "Ustawienia Proxy"
+
+#: id:715
+msgid "- Assignment"
+msgstr "- Przypisanie"
+
+#: id:716
+msgid "Automatic (DHCP)"
+msgstr "Automatyczny (DHCP)"
+
+#: id:717
+msgid "Manual (Static)"
+msgstr "Ręczny (Static)"
+
+#: id:719
+msgid "- IP address"
+msgstr "- Adres IP"
+
+#: id:720
+msgid "- Netmask"
+msgstr "- Maska podsieci"
+
+#: id:721
+msgid "- Default gateway"
+msgstr "- Brama domyślna"
+
+#: id:722
+msgid "- DNS server"
+msgstr "- Serwer DNS"
+
+#: id:723
+msgid "Save & restart"
+msgstr "Zapisz i zresetuj"
+
+#: id:724
+msgid "Invalid address specified. Value must be AAA.BBB.CCC.DDD"
+msgstr "Wprowadzono nieprawidłowy adres. Wartość musi być w formacie AAA.BBB.CCC.DDD"
+
+#: id:725
+msgid "with numbers between 0 and 255."
+msgstr "z liczbami z przedziału 0 do 255."
+
+#: id:726
+msgid "Changes not saved. Continue without saving?"
+msgstr "Zmiany nie zostały zapisane. Kontynuować bez zapisywania?"
+
+#: id:727
+msgid "Web server"
+msgstr "Serwer WWW"
+
+#: id:728
+msgctxt "Auto context with id 728"
+msgid "FTP server"
+msgstr "Serwer FTP"
+
+#: id:730
+msgid "- Port"
+msgstr "- Port"
+
+#: id:732
+msgid "Save & apply"
+msgstr "Zastosuj i zapisz"
+
+#: id:733
+msgid "- Password"
+msgstr "- Hasło"
+
+#: id:734
+msgid "No pass"
+msgstr "Bez hasła"
+
+#: id:735
+msgid "- Character set"
+msgstr "- Zestaw znaków"
+
+#: id:736
+msgid "- Style"
+msgstr "- Styl"
+
+#: id:737
+msgid "- Colour"
+msgstr "- Kolor"
+
+#: id:738
+msgctxt "Auto context with id 738"
+msgid "Normal"
+msgstr "Normalna"
+
+#: id:739
+msgid "Bold"
+msgstr "Pogrubiona"
+
+#: id:740
+msgid "Italics"
+msgstr "Kursywa"
+
+#: id:741
+msgid "Bold italics"
+msgstr "Pogrubiona kursywa"
+
+#: id:742
+msgctxt "Auto context with id 742"
+msgid "White"
+msgstr "Biały"
+
+#: id:743
+msgctxt "Auto context with id 743"
+msgid "Yellow"
+msgstr "Żółty"
+
+#: id:744
+msgctxt "Auto context with id 744"
+msgid "Files"
+msgstr "Pliki"
+
+#: id:745
+msgid "No scanned information for this view"
+msgstr "Nie ma danych dla tego widoku"
+
+#: id:746
+msgid "Please turn off library mode"
+msgstr "Proszę wyłącz tryb biblioteki"
+
+#: id:747
+msgid "Error loading image"
+msgstr "Błąd wczytywania obrazka"
+
+#: id:748
+msgid "Edit path"
+msgstr "Edytuj ścieżkę"
+
+#: id:749
+msgid "Mirror image"
+msgstr "Odbicie lustrzane obrazka"
+
+#: id:750
+msgid "Are you sure?"
+msgstr "Czy jesteś pewny?"
+
+#: id:751
+msgid "Removing source"
+msgstr "Usuń źródło"
+
+#: id:754
+msgid "Add program link"
+msgstr "Dodaj ścieżkę do programu"
+
+#: id:755
+msgid "Edit program path"
+msgstr "Edytuj ścieżkę do programu"
+
+#: id:756
+msgid "Edit program name"
+msgstr "Edytuj nazwę programu"
+
+#: id:757
+msgid "Edit path depth"
+msgstr "Edytuj głębokość ścieżki"
+
+#: id:759
+msgid "View: Big list"
+msgstr "Widok: Duża Lista"
+
+#: id:760
+msgctxt "Auto context with id 760"
+msgid "Yellow"
+msgstr "Żółty"
+
+#: id:761
+msgctxt "Auto context with id 761"
+msgid "White"
+msgstr "Biały"
+
+#: id:762
+msgid "Blue"
+msgstr "Niebieski"
+
+#: id:763
+msgid "Bright green"
+msgstr "Jasnozielony"
+
+#: id:764
+msgid "Yellow green"
+msgstr "Żółtozielony"
+
+#: id:765
+msgid "Cyan"
+msgstr "Turkusowy"
+
+#: id:766
+msgid "Light grey"
+msgstr "Jasny szary"
+
+#: id:767
+msgid "Grey"
+msgstr "Szary"
+
+#: id:770
+msgid "Error %i: share not available"
+msgstr "Błąd %i: udział niedostępny"
+
+#: id:772
+msgctxt "Auto context with id 772"
+msgid "Audio output"
+msgstr "Wyjście audio"
+
+#: id:773
+msgid "Seeking"
+msgstr "Przeszukiwanie"
+
+#: id:774
+msgid "Slideshow folder"
+msgstr "Katalog ze zdjęciami dla wygaszacza"
+
+#: id:775
+msgid "Network interface"
+msgstr "Interfejs sieciowy"
+
+#: id:776
+msgid "- Wireless network name (ESSID)"
+msgstr "- Nazwa sieci (ESSID)"
+
+#: id:777
+msgid "- Wireless password"
+msgstr "- Hasło dostępu"
+
+#: id:778
+msgid "- Wireless security"
+msgstr "- Tryb zabezpieczeń"
+
+#: id:779
+msgid "Save and apply network interface settings"
+msgstr "Zapisz i zastosuj ustawienia interfejsu sieciowego"
+
+#: id:780
+msgid "No encryption"
+msgstr "Bez szyfrowania"
+
+#: id:781
+msgid "WEP"
+msgstr ""
+
+#: id:782
+msgid "WPA"
+msgstr ""
+
+#: id:783
+msgid "WPA2"
+msgstr ""
+
+#: id:784
+msgid "Applying network interface settings. Please wait."
+msgstr "Zmiana ustawień interfejsu sieciowego. Proszę czekać."
+
+#: id:785
+msgid "Network interface restarted successfully."
+msgstr "Ponowne uruchomienie interfejsu sieciowego powiodło się."
+
+#: id:786
+msgid "Network interface did not start successfully."
+msgstr "Ponowne uruchomienie interfejsu sieciowego nie powiodło się."
+
+#: id:787
+msgid "Interface disabled"
+msgstr "Interfejs wyłączony"
+
+#: id:788
+msgid "Network interface disabled successfully."
+msgstr "Wyłączenie interfejsu sieciowego powiodło się."
+
+#: id:789
+msgid "Wireless network name (ESSID)"
+msgstr "Nazwa sieci bezprzewodowej (ESSID)"
+
+#: id:790
+msgid "Remote control"
+msgstr ""
+
+#: id:791
+msgid "Allow programs on this system to control XBMC"
+msgstr "Zezwalaj lokalnym programom na sterowanie XBMC"
+
+#: id:792
+msgctxt "Auto context with id 792"
+msgid "Port"
+msgstr ""
+
+#: id:793
+msgid "Port range"
+msgstr "Zakres portów"
+
+#: id:794
+msgid "Allow programs on other systems to control XBMC"
+msgstr "Zezwalaj na odbiór poleceń z innych programów"
+
+#: id:795
+msgid "Initial repeat delay (ms)"
+msgstr "Wstępna przerwa przed powtórzeniem (ms)"
+
+#: id:796
+msgid "Continuous repeat delay (ms)"
+msgstr "Właściwa przerwa przed powtórzeniem (ms)"
+
+#: id:797
+msgid "Maximum number of clients"
+msgstr "Maksymalna liczba klientów"
+
+#: id:798
+msgid "Internet access"
+msgstr "Internet"
+
+#: id:850
+msgid "Invalid port number entered"
+msgstr "Wprowadzono nieprawidłowy port"
+
+#: id:851
+msgid "Valid port range is 1-65535"
+msgstr "Wartość musi być z przedziału 1-65535"
+
+#: id:852
+msgid "Valid port range is 1024-65535"
+msgstr "Wartość musi być z przedziału 1024-65535"
+
+#: id:998
+msgid "Add Music..."
+msgstr "Dodaj muzykę..."
+
+#: id:999
+msgid "Add Videos..."
+msgstr "Dodaj wideo..."
+
+#: id:1000
+msgid "- Preview"
+msgstr "- Podgląd"
+
+#: id:1001
+msgid "Unable to connect"
+msgstr "Nie można połączyć"
+
+#: id:1002
+msgid "XBMC was unable to connect to the network location."
+msgstr "XBMC nie mógł nawiązać połączenia sieciowego."
+
+#: id:1003
+msgid "This could be due to the network not being connected."
+msgstr "Może to być spowodowane brakiem dostępu do sieci."
+
+#: id:1004
+msgid "Would you like to add it anyway?"
+msgstr "Czy chcesz mimo to kontynuować?"
+
+#: id:1006
+msgctxt "Auto context with id 1006"
+msgid "IP address"
+msgstr "Adres IP"
+
+#: id:1007
+msgid "Add network location"
+msgstr "Dodaj miejsce sieciowe"
+
+#: id:1008
+msgid "Protocol"
+msgstr "Protokół"
+
+#: id:1009
+msgid "Server address"
+msgstr "Adres serwera"
+
+#: id:1010
+msgid "Server name"
+msgstr "Nazwa serwera"
+
+#: id:1011
+msgid "Remote path"
+msgstr "Zdalna ścieżka"
+
+#: id:1012
+msgid "Shared folder"
+msgstr "Folder współdzielony"
+
+#: id:1013
+msgctxt "Auto context with id 1013"
+msgid "Port"
+msgstr ""
+
+#: id:1014
+msgctxt "Auto context with id 1014"
+msgid "Username"
+msgstr "Nazwa użytkownika"
+
+#: id:1015
+msgid "Browse for network server"
+msgstr "Wskaż serwer sieciowy"
+
+#: id:1016
+msgid "Enter the network address of the server"
+msgstr "Wprowadź adres sieciowy serwera"
+
+#: id:1017
+msgid "Enter the path on the server"
+msgstr "Wprowadź ścieżkę do serwera"
+
+#: id:1018
+msgid "Enter the port number"
+msgstr "Wprowadź numer portu"
+
+#: id:1019
+msgid "Enter the username"
+msgstr "Wprowadź nazwę użytkownika"
+
+#: id:1020
+msgid "Add %s source"
+msgstr "Dodaj źródło %s"
+
+#: id:1021
+msgid "Enter the paths or browse for the media locations."
+msgstr "Wprowadź ścieżki lub przeglądaj."
+
+#: id:1022
+msgid "Enter a name for this media Source."
+msgstr "Wprowadź nazwę dla tego źródła mediów."
+
+#: id:1023
+msgid "Browse for new share"
+msgstr "Wskaż nowe udziały"
+
+#: id:1024
+msgid "Browse"
+msgstr "Przeglądaj"
+
+#: id:1025
+msgid "Could not retrieve directory information."
+msgstr "Nie można uzyskać informacji o katalogu."
+
+#: id:1026
+msgid "Add source"
+msgstr "Dodaj źródło"
+
+#: id:1027
+msgid "Edit source"
+msgstr "Edytuj źródło"
+
+#: id:1028
+msgid "Edit %s source"
+msgstr "Edytuj źródło %s"
+
+#: id:1029
+msgid "Enter the new label"
+msgstr "Wprowadź nową etykietę"
+
+#: id:1030
+msgid "Browse for image"
+msgstr "Wskaż zdjęcie"
+
+#: id:1031
+msgid "Browse for image folder"
+msgstr "Wskaż katalog ze zdjęciami"
+
+#: id:1032
+msgid "Add network location..."
+msgstr "Dodaj miejsce sieciowe..."
+
+#: id:1033
+msgid "Browse for file"
+msgstr "Wskaż plik"
+
+#: id:1034
+msgid "Submenu"
+msgstr "Podmenu"
+
+#: id:1035
+msgid "Enable submenu buttons"
+msgstr "Uaktywnij przyciski podmenu"
+
+#: id:1036
+msgid "Favourites"
+msgstr "Ulubione"
+
+#: id:1037
+msgid "Video Add-ons"
+msgstr "Wtyczki filmów"
+
+#: id:1038
+msgid "Music Add-ons"
+msgstr "Wtyczki muzyki"
+
+#: id:1039
+msgid "Picture Add-ons"
+msgstr "Wtyczki zdjęć"
+
+#: id:1040
+msgid "Loading directory"
+msgstr "Wczytuję katalogi"
+
+#: id:1041
+msgid "Retrieved %i items"
+msgstr "Uzyskano %i pozycji"
+
+#: id:1042
+msgid "Retrieved %i of %i items"
+msgstr "Uzyskano %i z %i pozycji"
+
+#: id:1043
+msgid "Program Add-ons"
+msgstr "Wtyczki programów"
+
+#: id:1044
+msgid "Set plugin thumb"
+msgstr "Ustaw ikonę wtyczki"
+
+#: id:1045
+msgid "Add-on settings"
+msgstr "Ustawienia wtyczki"
+
+#: id:1046
+msgid "Access points"
+msgstr "Punkty dostępowe"
+
+#: id:1047
+msgid "Other..."
+msgstr "Inne..."
+
+#: id:1048
+msgid "- Username"
+msgstr "- Użytkownik"
+
+#: id:1049
+msgid "Script settings"
+msgstr "Ustawienia skryptu"
+
+#: id:1050
+msgid "Singles"
+msgstr "Single"
+
+#: id:1051
+msgid "Enter web address"
+msgstr "Wprowadź adres"
+
+#: id:1200
+msgid "SMB client"
+msgstr "Klient SMB"
+
+#: id:1202
+msgid "Workgroup"
+msgstr "Grupa robocza"
+
+#: id:1203
+msgid "Default username"
+msgstr "Domyślny użytkownik"
+
+#: id:1204
+msgid "Default password"
+msgstr "Domyślne hasło"
+
+#: id:1207
+msgid "WINS server"
+msgstr "Serwer WINS"
+
+#: id:1208
+msgid "Mount SMB shares"
+msgstr "Podłącz udziały SMB"
+
+#: id:1210
+msgctxt "Auto context with id 1210"
+msgid "Remove"
+msgstr "Usuń"
+
+#: id:1211
+msgctxt "Auto context with id 1211"
+msgid "Music"
+msgstr "Muzyka"
+
+#: id:1212
+msgctxt "Auto context with id 1212"
+msgid "Video"
+msgstr "Wideo"
+
+#: id:1213
+msgctxt "Auto context with id 1213"
+msgid "Pictures"
+msgstr "Zdjęcia"
+
+#: id:1214
+msgctxt "Auto context with id 1214"
+msgid "Files"
+msgstr "Pliki"
+
+#: id:1215
+msgctxt "Auto context with id 1215"
+msgid "Music & video"
+msgstr "Muzyka i wideo"
+
+#: id:1216
+msgid "Music & pictures"
+msgstr "Muzyka i zdjęcia"
+
+#: id:1217
+msgid "Music & files"
+msgstr "Muzyka i pliki"
+
+#: id:1218
+msgid "Video & pictures"
+msgstr "Wideo i zdjęcia"
+
+#: id:1219
+msgid "Video & files"
+msgstr "Wideo i pliki"
+
+#: id:1220
+msgid "Pictures & files"
+msgstr "Zdjęcia i pliki"
+
+#: id:1221
+msgid "Music & video & pictures"
+msgstr "Muzyka, wideo i zdjęcia"
+
+#: id:1222
+msgid "Music & video & pictures & files"
+msgstr "Muzyka, wideo, zdjęcia i pliki"
+
+#: id:1223
+msgctxt "Auto context with id 1223"
+msgid "Disabled"
+msgstr "Wyłączony"
+
+#: id:1226
+msgid "Files & music & video"
+msgstr "Pliki, muzyka i wideo"
+
+#: id:1227
+msgid "Files & pictures & music"
+msgstr "Pliki, zdjęcia i muzyka"
+
+#: id:1228
+msgid "Files & pictures & video"
+msgstr "Pliki, zdjęcia i wideo"
+
+#: id:1229
+msgid "Music & programs"
+msgstr "Muzyka, gry i programy"
+
+#: id:1230
+msgid "Video & programs"
+msgstr "Wideo, gry i programy"
+
+#: id:1231
+msgid "Pictures & programs"
+msgstr "Zdjęcia, gry i programy"
+
+#: id:1232
+msgid "Music & video & pictures & programs"
+msgstr "Muzyka, wideo, zdjęcia i programy"
+
+#: id:1233
+msgid "Programs & video & music"
+msgstr "Programy, wideo i muzyka"
+
+#: id:1234
+msgid "Programs & pictures & music"
+msgstr "Programy, zdjęcia i muzyka"
+
+#: id:1235
+msgid "Programs & pictures & video"
+msgstr "Programy, zdjęcia i wideo"
+
+#: id:1250
+msgid "Auto-detection"
+msgstr "Autodetekcja"
+
+#: id:1251
+msgid "Auto-detect system"
+msgstr "Wykrywaj system"
+
+#: id:1252
+msgid "Nickname"
+msgstr "Ksywa"
+
+#: id:1254
+msgid "Ask to connect"
+msgstr "Pytaj czy połączyć"
+
+#: id:1255
+msgid "Send FTP user and password"
+msgstr "Wysyłaj nazwę użytkownika i hasło FTP"
+
+#: id:1256
+msgid "Ping interval"
+msgstr "Interwał pingu"
+
+#: id:1257
+msgid "Would you like to connect to the auto-detected system?"
+msgstr "Połączyć z wykrytym systemem?"
+
+#: id:1259
+msgid "Zeroconf"
+msgstr ""
+
+#: id:1260
+msgid "Announce these services to other systems via Zeroconf"
+msgstr "Rozgłoś usługi do innych systemów poprzez Zeroconf"
+
+#: id:1270
+msgid "Allow XBMC to receive AirPlay content"
+msgstr "Zezwól XBMC na odbiór treści przez AirPlay"
+
+#: id:1271
+msgid "Device name"
+msgstr "Nazwa urządzenia"
+
+#: id:1272
+msgid "- Use password protection"
+msgstr "- Użyj ochrony hasłem"
+
+#: id:1273
+msgid "AirPlay"
+msgstr ""
+
+#: id:1300
+msgid "Custom audio device"
+msgstr "Inne urządzenie audio"
+
+#: id:1301
+msgid "Custom passthrough device"
+msgstr "Inne urządzenie przejścia"
+
+#: id:1396
+msgid "Drifting"
+msgstr "zamiecie"
+
+#: id:1397
+msgid "and"
+msgstr "i"
+
+#: id:1398
+msgid "Freezing"
+msgstr "śnieżyce"
+
+#: id:1399
+msgid "Late"
+msgstr "późno"
+
+#: id:1400
+msgid "Isolated"
+msgstr "pojedyncze"
+
+#: id:1401
+msgid "Thundershowers"
+msgstr "burze"
+
+#: id:1402
+msgid "Thunder"
+msgstr "pioruny"
+
+#: id:1403
+msgctxt "Auto context with id 1403"
+msgid "Sun"
+msgstr "słonecznie"
+
+#: id:1404
+msgid "Heavy"
+msgstr "silne"
+
+#: id:1405
+msgid "in"
+msgstr "w"
+
+#: id:1406
+msgid "the"
+msgstr ""
+
+#: id:1407
+msgid "Vicinity"
+msgstr "w pobliżu"
+
+#: id:1408
+msgid "Ice"
+msgstr "lód"
+
+#: id:1409
+msgid "Crystals"
+msgstr "kryształki"
+
+#: id:1410
+msgid "Calm"
+msgstr "spokojnie"
+
+#: id:1411
+msgid "with"
+msgstr "z"
+
+#: id:1412
+msgid "windy"
+msgstr "wietrznie"
+
+#: id:1413
+msgid "drizzle"
+msgstr "mżawka"
+
+#: id:1414
+msgid "Thunderstorm"
+msgstr "burza z piorunami"
+
+#: id:1415
+msgid "Drizzle"
+msgstr "mżawka"
+
+#: id:1416
+msgid "Foggy"
+msgstr "mgliście"
+
+#: id:1417
+msgid "Grains"
+msgstr "granulki"
+
+#: id:1418
+msgid "T-Storms"
+msgstr "burze z piorunami"
+
+#: id:1419
+msgid "T-Showers"
+msgstr "deszcze z piorunami"
+
+#: id:1420
+msgid "Moderate"
+msgstr "Umiarkowanie"
+
+#: id:1421
+msgid "Very High"
+msgstr "B.wysoka"
+
+#: id:1422
+msgid "Windy"
+msgstr "Wietrznie"
+
+#: id:1423
+msgid "Mist"
+msgstr "Mgła"
+
+#: id:1450
+msgid "Put display to sleep when idle"
+msgstr "Wygaś monitor podczas bezczynności"
+
+#: id:2050
+msgid "Runtime"
+msgstr "Czas trwania"
+
+#: id:2100
+msgid "Script failed! : %s"
+msgstr "Błąd skryptu! : %s"
+
+#: id:2101
+msgid "Newer version needed - See log"
+msgstr "Wymagana nowsza wersje - zobacz dziennik (log)"
+
+#: id:4501
+msgid "Enable LCD/VFD"
+msgstr "Włącz LCD/VFD"
+
+#: id:10000
+msgid "Home"
+msgstr "Ekran główny"
+
+#: id:10001
+msgctxt "Auto context with id 10001"
+msgid "Programs"
+msgstr "Programy"
+
+#: id:10002
+msgctxt "Auto context with id 10002"
+msgid "Pictures"
+msgstr "Zdjęcia"
+
+#: id:10003
+msgctxt "Auto context with id 10003"
+msgid "File manager"
+msgstr "Eksplorator"
+
+#: id:10004
+msgctxt "Auto context with id 10004"
+msgid "Settings"
+msgstr "Ustawienia"
+
+#: id:10005
+msgctxt "Auto context with id 10005"
+msgid "Music"
+msgstr "Muzyka"
+
+#: id:10006
+msgctxt "Auto context with id 10006"
+msgid "Videos"
+msgstr "Wideo"
+
+#: id:10007
+msgid "System information"
+msgstr "O systemie"
+
+#: id:10008
+msgid "Settings - General"
+msgstr "Ustawienia - Ogólne"
+
+#: id:10009
+msgid "Settings - Screen"
+msgstr "Ustawienia - Ekran"
+
+#: id:10010
+msgid "Settings - Appearance - GUI Calibration"
+msgstr "Ustawienia - Interfejs - Kalibracja interfejsu"
+
+#: id:10011
+msgid "Settings - Videos - Screen Calibration"
+msgstr "Ustawienia - Wideo - Kalibracja ekranu"
+
+#: id:10012
+msgid "Settings - Pictures"
+msgstr "Ustawienia - Zdjęcia"
+
+#: id:10013
+msgid "Settings - Programs"
+msgstr "Ustawienia - Programy"
+
+#: id:10014
+msgid "Settings - Weather"
+msgstr "Ustawienia - Pogoda"
+
+#: id:10015
+msgid "Settings - Music"
+msgstr "Ustawienia - Muzyka"
+
+#: id:10016
+msgid "Settings - System"
+msgstr "Ustawienia - System"
+
+#: id:10017
+msgid "Settings - Videos"
+msgstr "Ustawienia - Wideo"
+
+#: id:10018
+msgid "Settings - Network"
+msgstr "Ustawienia - Sieć"
+
+#: id:10019
+msgid "Settings - Appearance"
+msgstr "Ustawienia - Wygląd"
+
+#: id:10020
+msgctxt "Auto context with id 10020"
+msgid "Scripts"
+msgstr "Skrypty"
+
+#: id:10021
+msgid "Web Browser"
+msgstr "Przeglądarka"
+
+#: id:10025
+msgctxt "Auto context with id 10025"
+msgid "Videos"
+msgstr "Pliki wideo"
+
+#: id:10028
+msgid "Videos/Playlist"
+msgstr "Wideo/Playlista"
+
+#: id:10029
+msgctxt "Auto context with id 10029"
+msgid "Login screen"
+msgstr "Ekran logowania"
+
+#: id:10034
+msgid "Settings - Profiles"
+msgstr "Ustawienia - Profile"
+
+#: id:10040
+msgid "Addon browser"
+msgstr "Przeglądarka wtyczek"
+
+#: id:10100
+msgid "Yes/No dialog"
+msgstr "Dialog Tak/Nie"
+
+#: id:10101
+msgid "Progress dialog"
+msgstr "Okno postępu"
+
+#: id:10210
+msgid "Looking for subtitles..."
+msgstr "Szukam napisów..."
+
+#: id:10211
+msgid "Looking for or caching subtitles..."
+msgstr "Szukanie lub wgrywanie napisów..."
+
+#: id:10212
+msgid "terminating"
+msgstr "przerywanie"
+
+#: id:10213
+msgid "buffering"
+msgstr "buforowanie"
+
+#: id:10214
+msgid "Opening stream"
+msgstr "Otwieram strumień"
+
+#: id:10500
+msgid "Music/Playlist"
+msgstr "Muzyka/Playlista"
+
+#: id:10501
+msgid "Music/Files"
+msgstr "Muzyka/Pliki"
+
+#: id:10502
+msgid "Music/Library"
+msgstr "Muzyka/Biblioteka"
+
+#: id:10503
+msgid "Playlist editor"
+msgstr "Edytor playlisty"
+
+#: id:10504
+msgid "Top 100 songs"
+msgstr "Top 100 piosenek"
+
+#: id:10505
+msgid "Top 100 albums"
+msgstr "Top 100 albumów"
+
+#: id:10506
+msgctxt "Auto context with id 10506"
+msgid "Programs"
+msgstr "Programy"
+
+#: id:10507
+msgid "Configuration"
+msgstr "Konfiguracja"
+
+#: id:10508
+msgid "Weather forecast"
+msgstr "Prognoza pogody"
+
+#: id:10509
+msgid "Network gaming"
+msgstr "Gry sieciowe"
+
+#: id:10510
+msgid "Extensions"
+msgstr "Rozszerzenia"
+
+#: id:10511
+msgctxt "Auto context with id 10511"
+msgid "System info"
+msgstr "Informacje o systemie"
+
+#: id:10516
+msgid "Music - Library"
+msgstr "Muzyka - Biblioteka"
+
+#: id:10517
+msgid "Now Playing - Music"
+msgstr "Teraz odtwarzane - Muzyka"
+
+#: id:10522
+msgid "Now Playing - Videos"
+msgstr "Teraz odtwarzane - Wideo"
+
+#: id:10523
+msgid "Album info"
+msgstr "Info o albumie"
+
+#: id:10524
+msgid "Movie info"
+msgstr "Info o filmie"
+
+#: id:12000
+msgid "Select dialog"
+msgstr "Dialog wyboru"
+
+#: id:12001
+msgid "Music/Info"
+msgstr "Muzyka/Info"
+
+#: id:12002
+msgid "Dialog OK"
+msgstr "Dialog OK"
+
+#: id:12003
+msgid "Videos/Info"
+msgstr "Filmy/Info"
+
+#: id:12004
+msgid "Scripts/Info"
+msgstr "Skrypty/Info"
+
+#: id:12005
+msgid "Fullscreen video"
+msgstr "Tryb pełnoekranowy"
+
+#: id:12006
+msgid "Audio visualization"
+msgstr "Wizualizacja audio"
+
+#: id:12008
+msgid "File stacking dialog"
+msgstr "Dialog łączenia plików"
+
+#: id:12009
+msgid "Rebuild index..."
+msgstr "Przebudowywanie indeksu..."
+
+#: id:12010
+msgid "Return to music window"
+msgstr "Wróć do okna muzyki"
+
+#: id:12011
+msgid "Return to videos window"
+msgstr "Wróć do okna filmów"
+
+#: id:12021
+msgid "Start from beginning"
+msgstr "Zacznij od początku"
+
+#: id:12022
+msgid "Resume from %s"
+msgstr "Wznów od %s"
+
+#: id:12310
+msgid "0"
+msgstr ""
+
+#: id:12311
+msgid "1"
+msgstr ""
+
+#: id:12312
+msgid "2"
+msgstr ""
+
+#: id:12313
+msgid "3"
+msgstr ""
+
+#: id:12314
+msgid "4"
+msgstr ""
+
+#: id:12315
+msgid "5"
+msgstr ""
+
+#: id:12316
+msgid "6"
+msgstr ""
+
+#: id:12317
+msgid "7"
+msgstr ""
+
+#: id:12318
+msgid "8"
+msgstr ""
+
+#: id:12319
+msgid "9"
+msgstr ""
+
+#: id:12320
+msgid "c"
+msgstr ""
+
+#: id:12321
+msgid "Ok"
+msgstr ""
+
+#: id:12322
+msgid "*"
+msgstr ""
+
+#: id:12325
+msgid "Locked! Enter code..."
+msgstr "Dostęp zablokowany"
+
+#: id:12326
+msgid "Enter password"
+msgstr "Podaj hasło"
+
+#: id:12327
+msgid "Enter master code"
+msgstr "Wprowadź główne hasło"
+
+#: id:12328
+msgid "Enter unlock code"
+msgstr "Wprowadź kod odblokowujący"
+
+#: id:12329
+msgid "or press C to cancel"
+msgstr "albo naciśnij C, aby anulować"
+
+#: id:12330
+msgid "Enter gamepad button combo and"
+msgstr "Wprowadź kombinację przycisków na padzie"
+
+#: id:12331
+msgid "press OK, or Back to cancel"
+msgstr "i naciśnij Start, aby zatwierdzić lub naciśnij Back, aby anulować."
+
+#: id:12332
+msgid "Set lock"
+msgstr "Ustaw zabezpieczenie"
+
+#: id:12333
+msgid "Unlock"
+msgstr "Odblokuj"
+
+#: id:12334
+msgid "Reset lock"
+msgstr "Wyzeruj zabezpieczenie"
+
+#: id:12335
+msgid "Remove lock"
+msgstr "Usuń zabezpieczenie"
+
+#: id:12337
+msgid "Numeric password"
+msgstr "Hasło numeryczne"
+
+#: id:12338
+msgid "Gamepad button combo"
+msgstr "Kombinacja przycisków na padzie"
+
+#: id:12339
+msgid "Full-text password"
+msgstr "Hasło w trybie tekstowym"
+
+#: id:12340
+msgid "Enter new password"
+msgstr "Wprowadź nowe hasło"
+
+#: id:12341
+msgid "Re-Enter new password"
+msgstr "Potwierdź nowe hasło"
+
+#: id:12342
+msgid "Incorrect password,"
+msgstr "Nieprawidłowe hasło,"
+
+#: id:12343
+msgid "retries left"
+msgstr "pozostałych prób"
+
+#: id:12344
+msgid "Passwords entered did not match."
+msgstr "Wprowadzone hasło nie jest prawidłowe."
+
+#: id:12345
+msgid "Access denied"
+msgstr "Odmowa dostępu"
+
+#: id:12346
+msgid "Password retry limit exceeded."
+msgstr "Limit prób wpisania hasła został wyczerpany."
+
+#: id:12347
+msgid "The system will now shut off."
+msgstr "System wyłączy się teraz."
+
+#: id:12348
+msgid "Item locked"
+msgstr "Zablokowany"
+
+#: id:12353
+msgid "Reactivate lock"
+msgstr "Reaktywuj blokadę"
+
+#: id:12356
+msgid "Change lock"
+msgstr "Zmień blokadę"
+
+#: id:12357
+msgid "Source lock"
+msgstr "Zablokuj źródło"
+
+#: id:12358
+msgid "Password entry was blank. Try again."
+msgstr "Hasło było puste. Spróbuj ponownie."
+
+#: id:12360
+msgid "Master lock"
+msgstr "Zabezpieczenie"
+
+#: id:12362
+msgid "Shutdown system if Master Lock retries exceeded"
+msgstr "Wyłącz system, gdy ilość prób logowania zostanie przekroczona"
+
+#: id:12367
+msgid "Master code is not valid"
+msgstr "Nieprawidłowe hasło główne"
+
+#: id:12368
+msgid "Please enter a valid master code"
+msgstr "Wpisz hasło główne"
+
+#: id:12373
+msgid "Settings & file manager"
+msgstr "Ustawienia i eksplorator"
+
+#: id:12376
+msgid "Set as default for all movies"
+msgstr "Ustaw jako domyślny dla wszystkich filmów"
+
+#: id:12377
+msgid "This will reset any previously saved values"
+msgstr "Wszystkie wcześniejsze ustawienia zostaną wyczyszczone"
+
+#: id:12378
+msgid "Amount of time to display each image"
+msgstr "Czas wyświetlania zdjęcia w pokazie"
+
+#: id:12379
+msgid "Use pan and zoom effects"
+msgstr "Używaj efektu zbliżania i przesuwania"
+
+#: id:12383
+msgid "12 hour clock"
+msgstr "Zegar 12 godzinny"
+
+#: id:12384
+msgid "24 hour clock"
+msgstr "Zegar 24 godzinny"
+
+#: id:12385
+msgid "Day/Month"
+msgstr "Dzień/Miesiąc"
+
+#: id:12386
+msgid "Month/Day"
+msgstr "Miesiąc/Dzień"
+
+#: id:12390
+msgid "System uptime"
+msgstr "System pracuje"
+
+#: id:12391
+msgid "Minutes"
+msgstr "minut"
+
+#: id:12392
+msgid "Hours"
+msgstr "godzin"
+
+#: id:12393
+msgid "Days"
+msgstr "dni"
+
+#: id:12394
+msgid "Total uptime"
+msgstr "Całkowity czas pracy"
+
+#: id:12395
+msgid "Battery level"
+msgstr "Poziom baterii"
+
+#: id:12600
+msgctxt "Auto context with id 12600"
+msgid "Weather"
+msgstr "Pogoda"
+
+#: id:12900
+msgctxt "Auto context with id 12900"
+msgid "Screensaver"
+msgstr "Wygaszacz ekranu"
+
+#: id:12901
+msgid "Fullscreen OSD"
+msgstr "OSD w trybie pełnoekranowym"
+
+#: id:13000
+msgid "System"
+msgstr "System"
+
+#: id:13001
+msgid "Immediate HD spindown"
+msgstr "Natychmiastowe wyłączenie dysku"
+
+#: id:13002
+msgid "Video only"
+msgstr "Tylko filmy"
+
+#: id:13003
+msgid "- Delay"
+msgstr "- Opóźnienie"
+
+#: id:13004
+msgid "- Minimum file duration"
+msgstr "- Minimalny czas trwania pliku"
+
+#: id:13005
+msgid "Shutdown"
+msgstr "Wyłącz"
+
+#: id:13008
+msgid "Shutdown function"
+msgstr "Tryby wyłączania"
+
+#: id:13009
+msgid "Quit"
+msgstr "Wyjdź"
+
+#: id:13010
+msgid "Hibernate"
+msgstr "Hibernacja"
+
+#: id:13011
+msgid "Suspend"
+msgstr "Wstrzymaj"
+
+#: id:13012
+msgid "Exit"
+msgstr "Wyjście"
+
+#: id:13013
+msgid "Reboot"
+msgstr "Uruchom ponownie"
+
+#: id:13014
+msgid "Minimize"
+msgstr "Minimalizuj"
+
+#: id:13015
+msgid "Power button action"
+msgstr "Działanie przycisku zasilania"
+
+#: id:13016
+msgid "Power off System"
+msgstr "Wyłącz system"
+
+#: id:13020
+msgid "Is another session active, perhaps over ssh?"
+msgstr "Czy inna sesja jest aktywna, może przez ssh?"
+
+#: id:13021
+msgid "Mounted removable harddrive"
+msgstr "Podłączono dysk przenośny"
+
+#: id:13022
+msgid "Unsafe device removal"
+msgstr "Niebezpieczne odłączenie urządzenia"
+
+#: id:13023
+msgid "Successfully removed device"
+msgstr "Bezpiecznie odłączono urządzenie"
+
+#: id:13024
+msgid "Joystick plugged"
+msgstr "Podłączono joystick"
+
+#: id:13025
+msgid "Joystick unplugged"
+msgstr "Odłączono joystick"
+
+#: id:13050
+msgid "Running low on battery"
+msgstr "Kończy się bateria"
+
+#: id:13100
+msgid "Flicker filter"
+msgstr "Filtr migotania"
+
+#: id:13101
+msgid "Let driver choose (requires restart)"
+msgstr "Wybiera sterownik karty (potrzebny restart)"
+
+#: id:13105
+msgid "Vertical blank sync"
+msgstr "Synchronizacja pionowa"
+
+#: id:13106
+msgctxt "Auto context with id 13106"
+msgid "Disabled"
+msgstr "Wyłączona"
+
+#: id:13107
+msgid "Enabled during video playback"
+msgstr "Włączona podczas odtwarzania filmów"
+
+#: id:13108
+msgctxt "Auto context with id 13108"
+msgid "Always enabled"
+msgstr "Zawsze włączona"
+
+#: id:13109
+msgid "Test & apply resolution"
+msgstr "Test rozdzielczości"
+
+#: id:13110
+msgid "Save resolution?"
+msgstr "Zapisać rozdzielczość?"
+
+#: id:13111
+msgid "Would you like to keep this resolution?"
+msgstr "Czy chcesz zachować te ustawienia?"
+
+#: id:13112
+msgid "High quality upscaling"
+msgstr "Upscaling wysokiej jakości"
+
+#: id:13113
+msgctxt "Auto context with id 13113"
+msgid "Disabled"
+msgstr "Wyłączone"
+
+#: id:13114
+msgid "Enabled for SD content"
+msgstr "Włącz dla zawartości SD"
+
+#: id:13115
+msgctxt "Auto context with id 13115"
+msgid "Always enabled"
+msgstr "Zawsze włączone"
+
+#: id:13116
+msgid "Upscaling method"
+msgstr "Metody skalowania"
+
+#: id:13117
+msgctxt "Auto context with id 13117"
+msgid "Bicubic"
+msgstr "Bicubic"
+
+#: id:13118
+msgid "Lanczos"
+msgstr "Lanczos"
+
+#: id:13119
+msgid "Sinc"
+msgstr "Sinc"
+
+#: id:13120
+msgctxt "Auto context with id 13120"
+msgid "VDPAU"
+msgstr "VDPAU"
+
+#: id:13121
+msgid "VDPAU HQ Upscaling level"
+msgstr "VDPAU poziom skalowania HQ"
+
+#: id:13122
+msgid "VDPAU Studio level color conversion"
+msgstr "VDPAU korekcja poziomu kolorów (YCbCr i RGB)"
+
+#: id:13130
+msgid "Blank other displays"
+msgstr "Wygaszaj inne ekrany"
+
+#: id:13131
+msgctxt "Auto context with id 13131"
+msgid "Disabled"
+msgstr "Wyłączone"
+
+#: id:13132
+msgid "Blank displays"
+msgstr "Wygaszaj ekrany"
+
+#: id:13140
+msgid "Active connections detected!"
+msgstr "Wykryto aktywne połączenie!"
+
+#: id:13141
+msgid "If you proceed, you might not be able to control XBMC"
+msgstr "Kontynuując możesz stracić możliwość kontrolowania XBMC."
+
+#: id:13142
+msgid "any longer. Are you sure you want to stop the Event server?"
+msgstr "Chcesz zatrzymać serwer zdalnego sterowania?"
+
+#: id:13144
+msgid "Change Apple Remote mode?"
+msgstr "Zmienić tryb pilota Apple?"
+
+#: id:13145
+msgid "If you are currently using the Apple Remote to control"
+msgstr "Jeżeli aktualnie używasz pilota Apple zmiana tych"
+
+#: id:13146
+msgid "XBMC, changing this setting might affect your ability"
+msgstr "ustawień może doprowadzić do niemożliwości"
+
+#: id:13147
+msgid "to continue controlling it. Do you want to proceed?"
+msgstr "dalszego kontrolowania XBMC. Kontynuować?"
+
+#: id:13159
+msgid "Subnet mask"
+msgstr "Maska podsieci"
+
+#: id:13160
+msgid "Gateway"
+msgstr "Brama"
+
+#: id:13161
+msgid "Primary DNS"
+msgstr "Główny DNS"
+
+#: id:13162
+msgid "Initialize failed"
+msgstr "Inicjalizacja nie udała się"
+
+#: id:13170
+msgctxt "Auto context with id 13170"
+msgid "Never"
+msgstr "Nigdy"
+
+#: id:13171
+msgid "Immediately"
+msgstr "Natychmiast"
+
+#: id:13172
+msgid "After %i secs"
+msgstr "Po %i sekundach"
+
+#: id:13173
+msgid "HDD install date:"
+msgstr "Data zainstalowania:"
+
+#: id:13174
+msgid "HDD power cycle count:"
+msgstr "Ilość operacji start/stop:"
+
+#: id:13200
+msgid "Profiles"
+msgstr "Profile"
+
+#: id:13201
+msgid "Delete profile '%s'?"
+msgstr "Usunąć profil '%s'?"
+
+#: id:13204
+msgid "Last loaded profile:"
+msgstr "Ostatni załadowany profil:"
+
+#: id:13205
+msgid "Unknown"
+msgstr "Nieznany"
+
+#: id:13206
+msgid "Overwrite"
+msgstr "Zastąp"
+
+#: id:13208
+msgid "Alarm clock"
+msgstr "Alarm"
+
+#: id:13209
+msgid "Alarm clock interval (in minutes)"
+msgstr "Interwał alarmu (w minutach)"
+
+#: id:13210
+msgid "Started, alarm in %im"
+msgstr "Rozpoczęto, alarm za %im"
+
+#: id:13211
+msgid "Alarm!"
+msgstr ""
+
+#: id:13212
+msgid "Canceled with %im%is left"
+msgstr "Anulowano na %im%is do końca"
+
+#: id:13213
+msgid "%2.0fm"
+msgstr "%2.0fm"
+
+#: id:13214
+msgid "%2.0fs"
+msgstr "%2.0fs"
+
+#: id:13249
+msgid "Search for subtitles in RARs"
+msgstr "Szukaj napisów w archiwach (RAR)"
+
+#: id:13250
+msgid "Browse for subtitle..."
+msgstr "Wskaż napisy..."
+
+#: id:13251
+msgid "Move item"
+msgstr "Przenieś"
+
+#: id:13252
+msgid "Move item here"
+msgstr "Przenieś tutaj"
+
+#: id:13253
+msgid "Cancel move"
+msgstr "Anuluj przeniesienie"
+
+#: id:13270
+msgid "Hardware:"
+msgstr "Sprzęt:"
+
+#: id:13271
+msgid "CPU Usage:"
+msgstr "Użycie procesora:"
+
+#: id:13274
+msgid "Connected, but no DNS is available."
+msgstr "Połączony, ale DNS nie jest ustawiony."
+
+#: id:13275
+msgid "Hard Disk"
+msgstr "Dysk twardy"
+
+#: id:13276
+msgid "DVD-ROM"
+msgstr ""
+
+#: id:13277
+msgctxt "Auto context with id 13277"
+msgid "Storage"
+msgstr "Partycje"
+
+#: id:13278
+msgctxt "Auto context with id 13278"
+msgid "Default"
+msgstr "Domyślne"
+
+#: id:13279
+msgctxt "Auto context with id 13279"
+msgid "Network"
+msgstr "Sieć"
+
+#: id:13280
+msgctxt "Auto context with id 13280"
+msgid "Video"
+msgstr "Wideo"
+
+#: id:13281
+msgid "Hardware"
+msgstr "Sprzęt"
+
+#: id:13283
+msgid "Operating system:"
+msgstr "System operacyjny:"
+
+#: id:13284
+msgid "CPU speed:"
+msgstr "Prędkość CPU:"
+
+#: id:13286
+msgid "Video encoder:"
+msgstr "Koder Wideo:"
+
+#: id:13287
+msgid "Screen resolution:"
+msgstr "Rozdzielczość ekranu:"
+
+#: id:13292
+msgid "A/V cable:"
+msgstr "Kabel A/V:"
+
+#: id:13294
+msgid "DVD region:"
+msgstr "Region DVD:"
+
+#: id:13295
+msgid "Internet:"
+msgstr "Internet:"
+
+#: id:13296
+msgctxt "Auto context with id 13296"
+msgid "Connected"
+msgstr "Podłączony"
+
+#: id:13297
+msgid "Not connected. Check network settings."
+msgstr "Brak połączenia. Sprawdź ustawienia sieci."
+
+#: id:13299
+msgid "Target temperature"
+msgstr "Docelowa temperatura"
+
+#: id:13300
+msgid "Fan speed"
+msgstr "Obroty wentylatora"
+
+#: id:13301
+msgid "Auto temperature control"
+msgstr "Auto kontrola temperatury"
+
+#: id:13302
+msgid "Fan speed override"
+msgstr "Kontrola obrotów wentylatora"
+
+#: id:13303
+msgid "- Fonts"
+msgstr "- Czcionki"
+
+#: id:13304
+msgid "Enable flipping bi-directional strings"
+msgstr "Włącz odwrócone napisy (język arabski, hebrajski, ...)"
+
+#: id:13305
+msgid "Show RSS news feeds"
+msgstr "Pokazuj wiadomości RSS"
+
+#: id:13306
+msgid "Show parent folder items"
+msgstr "Pokazuj folder nadrzędny (..)"
+
+#: id:13307
+msgid "Track naming template"
+msgstr "Szablon nazewnictwa utworu"
+
+#: id:13308
+msgid "Do you wish to reboot your system"
+msgstr "Czy chcesz wykonać restart systemu"
+
+#: id:13309
+msgid "instead of just XBMC?"
+msgstr "zamiast ponownego uruchomienia XBMC?"
+
+#: id:13310
+msgid "Zoom effect"
+msgstr "Efekt powiększenia"
+
+#: id:13311
+msgid "Float effect"
+msgstr "Efekt unoszenia"
+
+#: id:13312
+msgid "Black bar reduction"
+msgstr "Redukcja czarnego paska"
+
+#: id:13313
+msgid "Restart"
+msgstr ""
+
+#: id:13314
+msgid "Crossfade between songs"
+msgstr "Płynne przejścia między utworami"
+
+#: id:13315
+msgid "Regenerate thumbnails"
+msgstr "Odśwież miniatury"
+
+#: id:13316
+msgid "Recursive thumbnails"
+msgstr "Miniatury rekursywnie"
+
+#: id:13317
+msgid "View slideshow"
+msgstr "Rozpocznij pokaz"
+
+#: id:13318
+msgid "Recursive slideshow"
+msgstr "uwzględniając podkatalogi"
+
+#: id:13319
+msgid "Randomize"
+msgstr "Wybieraj losowo"
+
+#: id:13320
+msgid "Stereo"
+msgstr ""
+
+#: id:13321
+msgid "Left only"
+msgstr "Tylko Lewy"
+
+#: id:13322
+msgid "Right only"
+msgstr "Tylko prawy"
+
+#: id:13323
+msgid "Enable karaoke support"
+msgstr "Włącz obsługę karaoke"
+
+#: id:13324
+msgid "Background transparency"
+msgstr "Przezroczystość tła"
+
+#: id:13325
+msgid "Foreground transparency"
+msgstr "Przezroczystość napisów"
+
+#: id:13326
+msgid "A/V delay"
+msgstr "Opóźnienie A/V"
+
+#: id:13327
+msgid "Karaoke"
+msgstr ""
+
+#: id:13328
+msgid "%s not found"
+msgstr "Nie znaleziono %s"
+
+#: id:13329
+msgid "Error opening %s"
+msgstr "Błąd otwierania %s"
+
+#: id:13330
+msgid "Unable to load %s"
+msgstr "Błąd wczytywania %s"
+
+#: id:13331
+msgid "Error: Out of memory"
+msgstr "Błąd: brak pamięci"
+
+#: id:13332
+msgid "Move up"
+msgstr "Przesuń do góry"
+
+#: id:13333
+msgid "Move down"
+msgstr "Przesuń na dół"
+
+#: id:13334
+msgid "Edit label"
+msgstr "Zmień opis"
+
+#: id:13335
+msgid "Make default"
+msgstr "Ustaw jako domyślny"
+
+#: id:13336
+msgid "Remove button"
+msgstr "Usuń przycisk"
+
+#: id:13340
+msgid "Leave as is"
+msgstr "Zostaw jak jest"
+
+#: id:13341
+msgid "Green"
+msgstr "Zielona"
+
+#: id:13342
+msgid "Orange"
+msgstr "Pomarańczowa"
+
+#: id:13343
+msgid "Red"
+msgstr "Czerwona"
+
+#: id:13344
+msgid "Cycle"
+msgstr "Mrugająca"
+
+#: id:13345
+msgid "Switch LED off on playback"
+msgstr "Wyłącz diodę podczas odtwarzania"
+
+#: id:13346
+msgctxt "Auto context with id 13346"
+msgid "Movie information"
+msgstr "Informacje o filmie"
+
+#: id:13347
+msgid "Queue item"
+msgstr "Dodaj do kolejki"
+
+#: id:13348
+msgid "Search IMDb..."
+msgstr "Szukaj w IMDb..."
+
+#: id:13349
+msgid "Scan for new content"
+msgstr "Przeszukaj nowe materiały"
+
+#: id:13350
+msgid "Now playing..."
+msgstr "Teraz odtwarzane..."
+
+#: id:13351
+msgctxt "Auto context with id 13351"
+msgid "Album information"
+msgstr "Informacje o albumie"
+
+#: id:13352
+msgid "Scan item to library"
+msgstr "Dodaj pozycję do biblioteki"
+
+#: id:13353
+msgid "Stop scanning"
+msgstr "Zatrzymaj skanowanie"
+
+#: id:13354
+msgctxt "Auto context with id 13354"
+msgid "Render method"
+msgstr "Metody renderowania"
+
+#: id:13355
+msgid "Low quality pixel shader"
+msgstr "Pixel Shader (niska jakość)"
+
+#: id:13356
+msgid "Hardware overlays"
+msgstr "Overlay (sprzętowy)"
+
+#: id:13357
+msgid "High quality pixel shader"
+msgstr "Pixel Shader (wysoka jakość)"
+
+#: id:13358
+msgid "Play item"
+msgstr "Odtwarzaj"
+
+#: id:13359
+msgid "Set artist thumb"
+msgstr "Ustaw ikonę artysty"
+
+#: id:13360
+msgid "Automatically generate thumbnails"
+msgstr "Automatycznie twórz miniatury"
+
+#: id:13361
+msgid "Enable voice"
+msgstr "Włącz głos"
+
+#: id:13375
+msgid "Enable device"
+msgstr "Włącz urządzenie"
+
+#: id:13376
+msgid "Volume"
+msgstr "Głośność"
+
+#: id:13377
+msgid "Default view mode"
+msgstr "Domyślny tryb wyświetlania"
+
+#: id:13378
+msgid "Default brightness"
+msgstr "Domyślna jasność"
+
+#: id:13379
+msgid "Default contrast"
+msgstr "Domyślny kontrast"
+
+#: id:13380
+msgid "Default gamma"
+msgstr "Domyślna gamma"
+
+#: id:13381
+msgid "Resume video"
+msgstr "Wznów odtwarzanie"
+
+#: id:13382
+msgid "Voice mask - Port 1"
+msgstr "Maskowanie głosu - port 1"
+
+#: id:13383
+msgid "Voice mask - Port 2"
+msgstr "Maskowanie głosu - port 2"
+
+#: id:13384
+msgid "Voice mask - Port 3"
+msgstr "Maskowanie głosu - port 3"
+
+#: id:13385
+msgid "Voice mask - Port 4"
+msgstr "Maskowanie głosu - port 4"
+
+#: id:13386
+msgid "Use time based seeking"
+msgstr "Przewijanie oparte na czasie"
+
+#: id:13387
+msgid "Track naming template - right"
+msgstr "Szablon nazewnictwa utworu - prawa strona"
+
+#: id:13388
+msgid "Preset"
+msgstr "Ustawienie"
+
+#: id:13389
+msgid "There are no presets available\nfor this visualization"
+msgstr "Nie ma dostępnych efektów dla tej wizualizacji"
+
+#: id:13390
+msgid "There are no settings available\nfor this visualization"
+msgstr "Nie ma dostępnych opcji dla tej wizualizacji"
+
+#: id:13391
+msgid "Eject/Load"
+msgstr "Wysuń/Wsuń"
+
+#: id:13392
+msgid "Use visualization if playing audio"
+msgstr "Wizualizacja podczas odtwarzania muzyki"
+
+#: id:13393
+msgid "Calculate size"
+msgstr "Oblicz wielkość"
+
+#: id:13394
+msgid "Calculating folder size"
+msgstr "Oblicz wielkość katalogu"
+
+#: id:13395
+msgid "Video settings"
+msgstr "Ustawienia obrazu"
+
+#: id:13396
+msgid "Audio and subtitle settings"
+msgstr "Ustawienia dźwięku i napisów"
+
+#: id:13397
+msgid "Enable subtitles"
+msgstr "Włącz napisy"
+
+#: id:13398
+msgctxt "Auto context with id 13398"
+msgid "Shortcuts"
+msgstr "Skróty"
+
+#: id:13399
+msgid "Ignore articles when sorting (e.g. \"the\")"
+msgstr "Sortuj bez przedimków w nazwie (np. \"the\")"
+
+#: id:13400
+msgid "Crossfade between songs on the same album"
+msgstr "Płynne przejścia między utworami z tej samej płyty"
+
+#: id:13401
+msgid "Browse for %s"
+msgstr "Wskaż %s"
+
+#: id:13402
+msgid "Show track position"
+msgstr "Pokazuj pozycję utworu"
+
+#: id:13403
+msgid "Clear default"
+msgstr "Przywróć domyślne"
+
+#: id:13404
+msgid "Resume"
+msgstr "Wznów"
+
+#: id:13405
+msgid "Get thumb"
+msgstr "Pobierz ikonę"
+
+#: id:13406
+msgid "Picture information"
+msgstr "Informacje o zdjęciu"
+
+#: id:13407
+msgid "%s presets"
+msgstr "%s - zdefiniowane ustawienia"
+
+#: id:13408
+msgid "(IMDb user rating)"
+msgstr "(Ocena użytkowników IMDb)"
+
+#: id:13409
+msgid "Top 250"
+msgstr "Top 250"
+
+#: id:13410
+msgid "Tune in on Last.fm"
+msgstr "Podłącz do Last.fm"
+
+#: id:13411
+msgid "Minimum fan speed"
+msgstr "Minimalne obroty wentylatora"
+
+#: id:13412
+msgid "Play from here"
+msgstr "Odtwórz z tego miejsca"
+
+#: id:13413
+msgid "Downloading"
+msgstr "Pobieranie"
+
+#: id:13414
+msgid "Include artists who appear only on compilations"
+msgstr "Pokazuj artystów występujących tylko w składankach"
+
+#: id:13415
+msgctxt "Auto context with id 13415"
+msgid "Render method"
+msgstr "Metoda renderowania"
+
+#: id:13416
+msgid "Auto detect"
+msgstr "Wykryj automatycznie"
+
+#: id:13417
+msgid "Basic shaders (ARB)"
+msgstr "podstawowe shadery (ARB)"
+
+#: id:13418
+msgid "Advanced shaders (GLSL)"
+msgstr "zaawansowane shadery (GLSL)"
+
+#: id:13419
+msgid "Software"
+msgstr "programowo"
+
+#: id:13420
+msgid "Remove safely"
+msgstr "Usuń bezpiecznie"
+
+#: id:13421
+msgctxt "Auto context with id 13421"
+msgid "VDPAU"
+msgstr ""
+
+#: id:13422
+msgid "Start slideshow here"
+msgstr "Rozpocznij pokaz slajdów tutaj"
+
+#: id:13423
+msgid "Remember for this path"
+msgstr "Zapamiętaj dla tej ścieżki"
+
+#: id:13424
+msgid "Use pixel buffer objects"
+msgstr ""
+
+#: id:13425
+msgid "Allow hardware acceleration (VDPAU)"
+msgstr "Sprzętowa akceleracja (VDPAU)"
+
+#: id:13426
+msgid "Allow hardware acceleration (VAAPI)"
+msgstr "Sprzętowa akceleracja (VAAPI)"
+
+#: id:13427
+msgid "Allow hardware acceleration (DXVA2)"
+msgstr "Sprzętowa akceleracja (DXVA2)"
+
+#: id:13428
+msgid "Allow hardware acceleration (CrystalHD)"
+msgstr "Sprzętowa akceleracja (CrystalHD)"
+
+#: id:13429
+msgid "Allow hardware acceleration (VDADecoder)"
+msgstr "Sprzętowa akceleracja (VDADecoder)"
+
+#: id:13430
+msgid "Allow hardware acceleration (OpenMax)"
+msgstr "Sprzętowa akceleracja (OpenMax)"
+
+#: id:13431
+msgid "Pixel Shaders"
+msgstr "Pixel shadery"
+
+#: id:13432
+msgid "Allow hardware acceleration (VideoToolbox)"
+msgstr "Zezwól na akceleracją sprzętową (Video Toolbox)"
+
+#: id:13500
+msgid "A/V sync method"
+msgstr "Metoda synchronizacji A/V"
+
+#: id:13501
+msgid "Audio clock"
+msgstr "Zegar audio"
+
+#: id:13502
+msgid "Video clock (Drop/Dupe audio)"
+msgstr "Zegar wideo (porzucaj/duplikuj dźwięk)"
+
+#: id:13503
+msgid "Video clock (Resample audio)"
+msgstr "Zegar wideo (resampluj dźwięk)"
+
+#: id:13504
+msgid "Maximum resample amount (%)"
+msgstr "Maks. wielkość resamplingu (%)"
+
+#: id:13505
+msgid "Resample quality"
+msgstr "Jakoś resamplingu"
+
+#: id:13506
+msgid "Low(fast)"
+msgstr "Niska (szybkie)"
+
+#: id:13507
+msgctxt "Auto context with id 13507"
+msgid "Medium"
+msgstr "Średnia"
+
+#: id:13508
+msgctxt "Auto context with id 13508"
+msgid "High"
+msgstr "Wysoka"
+
+#: id:13509
+msgid "Really high(slow!)"
+msgstr "Bardzo wysoka (wolne!)"
+
+#: id:13510
+msgid "Sync playback to display"
+msgstr "Synchronizuj odtwarzanie z ekranem"
+
+#: id:13550
+msgid "Pause during refresh rate change"
+msgstr "Pauza podczas zmiany odświeżania"
+
+#: id:13551
+msgctxt "Auto context with id 13551"
+msgid "Off"
+msgstr "Wyłącz"
+
+#: id:13552
+msgid "%.1f Second"
+msgstr "%.1f sekunda"
+
+#: id:13553
+msgid "%.1f Seconds"
+msgstr "%.1f sekund(y)"
+
+#: id:13600
+msgid "Apple remote"
+msgstr "Pilot Apple"
+
+#: id:13602
+msgid "Allow start of XBMC using the remote"
+msgstr "Zezwalaj na start XBMC za pomocą pilota"
+
+#: id:13603
+msgid "Sequence delay time"
+msgstr "Opóźnienie sekwencji"
+
+#: id:13610
+msgctxt "Auto context with id 13610"
+msgid "Disabled"
+msgstr "Wyłączony"
+
+#: id:13611
+msgctxt "Auto context with id 13611"
+msgid "Standard"
+msgstr "Standardowy"
+
+#: id:13612
+msgid "Universal Remote"
+msgstr "Pilot uniwersalny"
+
+#: id:13613
+msgid "Multi Remote (Harmony)"
+msgstr "Multi pilot (Harmony)"
+
+#: id:13620
+msgid "Apple Remote Error"
+msgstr "Błąd Pilota Apple"
+
+#: id:13621
+msgid "Apple Remote support could be enabled."
+msgstr "Możliwe włączenie obsługi pilota Apple"
+
+#: id:14000
+msgid "Stack"
+msgstr "Złącz części"
+
+#: id:14001
+msgid "Unstack"
+msgstr "Złącz: tak"
+
+#: id:14003
+msgid "Downloading playlist file..."
+msgstr "Pobieranie pliku playlisty..."
+
+#: id:14004
+msgid "Downloading streams list..."
+msgstr "Pobieranie listy strumieni..."
+
+#: id:14005
+msgid "Parsing streams list..."
+msgstr "Przetwarzanie listy strumieni..."
+
+#: id:14006
+msgid "Downloading streams list failed"
+msgstr "Nie można pobrać listy strumieni"
+
+#: id:14007
+msgid "Downloading playlist file failed"
+msgstr "Nie można pobrać pliku playlisty"
+
+#: id:14009
+msgid "Games directory"
+msgstr "Katalog z grami"
+
+#: id:14010
+msgid "Auto switch to thumbs based on"
+msgstr "Opcje automatycznego przełączania"
+
+#: id:14011
+msgid "Enable auto switching to thumbs view"
+msgstr "Automatyczne przełączanie widoku"
+
+#: id:14012
+msgid "- Use large icons"
+msgstr "- Duże ikony"
+
+#: id:14013
+msgid "- Switch based on"
+msgstr "- Metoda"
+
+#: id:14014
+msgid "- Percentage"
+msgstr "- Procent"
+
+#: id:14015
+msgid "No files and at least one thumb"
+msgstr "Miniaturki, jeżeli nie ma plików"
+
+#: id:14016
+msgid "At least one file and thumb"
+msgstr "Lista, jeżeli nie ma katalogów"
+
+#: id:14017
+msgid "Percentage of thumbs"
+msgstr "Procentowo miniaturki"
+
+#: id:14018
+msgid "View options"
+msgstr "Opcje widoku"
+
+#: id:14019
+msgid "Change area code 1"
+msgstr "Ustaw miasto 1"
+
+#: id:14020
+msgid "Change area code 2"
+msgstr "Ustaw miasto 2"
+
+#: id:14021
+msgid "Change area code 3"
+msgstr "Ustaw miasto 3"
+
+#: id:14022
+msgctxt "Auto context with id 14022"
+msgid "Library"
+msgstr "Biblioteka"
+
+#: id:14023
+msgid "No TV"
+msgstr "Bez TV"
+
+#: id:14024
+msgid "Enter the nearest large town"
+msgstr "Wpisz nazwę miasta (bez polskich znaków)"
+
+#: id:14025
+msgid "Video/Audio/DVD cache - Harddisk"
+msgstr "Wideo/Audio/DVD z twardego dysku"
+
+#: id:14026
+msgid "Video cache - DVD-ROM"
+msgstr "Wideo z - napędu DVD"
+
+#: id:14027
+msgctxt "Auto context with id 14027"
+msgid "- Local Network"
+msgstr "- sieci lokalnej"
+
+#: id:14028
+msgctxt "Auto context with id 14028"
+msgid "- Internet"
+msgstr "- Internetu"
+
+#: id:14030
+msgid "Audio cache - DVD-ROM"
+msgstr "Audio z - napędu DVD"
+
+#: id:14031
+msgctxt "Auto context with id 14031"
+msgid "- Local Network"
+msgstr "- sieci lokalnej"
+
+#: id:14032
+msgctxt "Auto context with id 14032"
+msgid "- Internet"
+msgstr "- Internetu"
+
+#: id:14034
+msgid "DVD cache - DVD-ROM"
+msgstr "DVD z - napędu DVD"
+
+#: id:14035
+msgctxt "Auto context with id 14035"
+msgid "- Local Network"
+msgstr "- sieci lokalnej"
+
+#: id:14036
+msgctxt "Auto context with id 14036"
+msgid "Services"
+msgstr "Usługi"
+
+#: id:14038
+msgid "Network settings changed"
+msgstr "Zmieniono ustawienia sieci"
+
+#: id:14039
+msgid "XBMC requires to restart to change your"
+msgstr "Wprowadzone zmiany wymagają ponownego uruchomienia."
+
+#: id:14040
+msgid "network setup. Would you like to restart now?"
+msgstr "Chcesz teraz ponownie uruchomić XBMC?"
+
+#: id:14041
+msgid "Internet connection bandwidth limitation"
+msgstr "Ograniczenie pasma połączenia Internetowego"
+
+#: id:14043
+msgid "- Shutdown while playing"
+msgstr "- Wyłącz w trakcie odtwarzania"
+
+#: id:14044
+msgid "%i min"
+msgstr "%i min"
+
+#: id:14045
+msgid "%i sec"
+msgstr "%i s"
+
+#: id:14046
+msgid "%i ms"
+msgstr "%i ms"
+
+#: id:14047
+msgid "%i %%"
+msgstr "%i %%"
+
+#: id:14048
+msgid "%i kbps"
+msgstr "%i kbps"
+
+#: id:14049
+msgid "%i kb"
+msgstr "%i kb"
+
+#: id:14050
+msgid "%i.0 dB"
+msgstr "%i.0 dB"
+
+#: id:14051
+msgid "Time format"
+msgstr "Zegar w formacie"
+
+#: id:14052
+msgid "Date format"
+msgstr "Data w formacie"
+
+#: id:14053
+msgid "GUI filters"
+msgstr "Filtry GUI"
+
+#: id:14055
+msgid "Use background scanning"
+msgstr "Skanuj w tle"
+
+#: id:14056
+msgid "Stop scan"
+msgstr "Zatrzymaj skanowanie"
+
+#: id:14057
+msgid "Not possible while scanning for media info"
+msgstr "Nie możliwe podczas zbierania info o mediach"
+
+#: id:14058
+msgid "Film grain effect"
+msgstr "Efekt ziarnistości"
+
+#: id:14059
+msgid "Search for thumbnails on remote shares"
+msgstr "Szukaj miniaturek w udziałach sieciowych"
+
+#: id:14060
+msgid "Unknown type cache - Internet"
+msgstr "Nieznany - Internet"
+
+#: id:14061
+msgctxt "Auto context with id 14061"
+msgid "Auto"
+msgstr ""
+
+#: id:14062
+msgid "Enter username for"
+msgstr "Podaj użytkownika dla"
+
+#: id:14063
+msgid "Date & time"
+msgstr "Data i czas"
+
+#: id:14064
+msgid "Set date"
+msgstr "Ustaw datę"
+
+#: id:14065
+msgid "Set time"
+msgstr "Ustaw godzinę"
+
+#: id:14066
+msgid "Enter the time in 24 hour HH:MM format"
+msgstr "Wprowadź godzinę (GG:MM)"
+
+#: id:14067
+msgid "Enter the date in DD/MM/YYYY format"
+msgstr "Wprowadź datę (DD/MM/RRRR)"
+
+#: id:14068
+msgid "Enter the IP address"
+msgstr "Wprowadź adres IP"
+
+#: id:14069
+msgid "Apply these settings now?"
+msgstr "Chcesz zapisać swoje ustawienia?"
+
+#: id:14070
+msgid "Apply changes now"
+msgstr "Zastosuj i zapisz"
+
+#: id:14071
+msgid "Allow file renaming and deletion"
+msgstr "Zezwalaj na zmianę nazwy i kasowanie plików"
+
+#: id:14074
+msgid "Set timezone"
+msgstr "Ustaw strefę czasu"
+
+#: id:14075
+msgid "Use daylight saving time"
+msgstr "Synchronizacja czasu z uwzględnieniem czasu letniego"
+
+#: id:14076
+msgid "Add to favourites"
+msgstr "Dodaj do ulubionych"
+
+#: id:14077
+msgid "Remove from favourites"
+msgstr "Usuń z ulubionych"
+
+#: id:14078
+msgctxt "Auto context with id 14078"
+msgid "- Colours"
+msgstr "Kolor skóry"
+
+#: id:14079
+msgid "Timezone country"
+msgstr "Kraj strefy czasowej"
+
+#: id:14080
+msgid "Timezone"
+msgstr "Strefa czasowa"
+
+#: id:14081
+msgid "File lists"
+msgstr "Listy plików"
+
+#: id:14082
+msgid "Show EXIF picture information"
+msgstr "Wyświetlaj dane EXIF"
+
+#: id:14083
+msgid "Use a fullscreen window rather than true fullscreen"
+msgstr "Używaj pełnego okna zamiast pełnego ekranu"
+
+#: id:14084
+msgid "Queue songs on selection"
+msgstr "Zaznaczone utwory dodawaj do kolejki"
+
+#: id:14086
+msgid "Playback"
+msgstr "Odtwarzanie"
+
+#: id:14087
+msgid "DVDs"
+msgstr "DVD"
+
+#: id:14088
+msgid "Play DVDs automatically"
+msgstr "Automatycznie odtwarzaj płyty DVD"
+
+#: id:14089
+msgid "Font to use for text subtitles"
+msgstr "Czcionka używana do napisów"
+
+#: id:14090
+msgid "International"
+msgstr "Język"
+
+#: id:14091
+msgid "Character set"
+msgstr "Zestaw znaków"
+
+#: id:14092
+msgid "Debugging"
+msgstr "Debugowanie"
+
+#: id:14093
+msgid "Security"
+msgstr "Ochrona"
+
+#: id:14094
+msgid "Input devices"
+msgstr "Urządzenia wejściowe"
+
+#: id:14095
+msgid "Power saving"
+msgstr "Oszczędzanie energii"
+
+#: id:14096
+msgid "Rip"
+msgstr ""
+
+#: id:14097
+msgid "Audio CD Insert Action"
+msgstr ""
+
+#: id:14098
+msgctxt "Auto context with id 14098"
+msgid "Play"
+msgstr ""
+
+#: id:14099
+msgid "Eject disc when CD ripping is complete"
+msgstr ""
+
+#: id:15015
+msgctxt "Auto context with id 15015"
+msgid "Remove"
+msgstr "Usuń"
+
+#: id:15016
+msgid "Games"
+msgstr "Gry"
+
+#: id:15019
+msgid "Add"
+msgstr "Dodaj"
+
+#: id:15052
+msgid "Password"
+msgstr "Hasło"
+
+#: id:15100
+msgctxt "Auto context with id 15100"
+msgid "Library"
+msgstr "Płytoteka"
+
+#: id:15101
+msgid "Database"
+msgstr "Baza danych"
+
+#: id:15102
+msgid "* All albums"
+msgstr "* Wszystkie albumy"
+
+#: id:15103
+msgid "* All artists"
+msgstr "* Wszyscy artyści"
+
+#: id:15104
+msgid "* All songs"
+msgstr "* Wszystkie utwory"
+
+#: id:15105
+msgid "* All genres"
+msgstr "* Wszystkie gatunki"
+
+#: id:15107
+msgid "Buffering..."
+msgstr "Buforowanie..."
+
+#: id:15108
+msgid "Navigation sounds"
+msgstr "Dźwięki nawigacji"
+
+#: id:15109
+msgid "Skin default"
+msgstr "Domyślne"
+
+#: id:15111
+msgid "- Theme"
+msgstr "Motyw skóry"
+
+#: id:15112
+msgid "Default theme"
+msgstr "Domyślny"
+
+#: id:15200
+msgid "Last.fm"
+msgstr "Last.fm"
+
+#: id:15201
+msgid "Submit songs to Last.fm"
+msgstr "Publikuj odtwarzane utwory do Last.fm"
+
+#: id:15202
+msgid "Last.fm username"
+msgstr "Użytkownik"
+
+#: id:15203
+msgid "Last.fm password"
+msgstr "Hasło"
+
+#: id:15204
+msgid "Unable to handshake: sleeping..."
+msgstr "Stan czuwania..."
+
+#: id:15205
+msgid "Please update XBMC"
+msgstr "Proszę uaktualnić XBMC"
+
+#: id:15206
+msgid "Bad authorization: Check username and password"
+msgstr "Błąd autoryzacji: sprawdź użytkownika i hasło"
+
+#: id:15207
+msgctxt "Auto context with id 15207"
+msgid "Connected"
+msgstr "Połączony"
+
+#: id:15208
+msgid "Not connected"
+msgstr "Niepołączony"
+
+#: id:15209
+msgid "Submit interval %i"
+msgstr "Opóźnienie między powtórzeniami %i"
+
+#: id:15210
+msgid "Cached %i songs"
+msgstr "%i utworów w buforze"
+
+#: id:15211
+msgid "Submitting..."
+msgstr "Przesyłam..."
+
+#: id:15212
+msgid "Submitting in %i secs"
+msgstr "Przesłano w %i sekund"
+
+#: id:15213
+msgid "Play using..."
+msgstr "Użyj do odtwarzania..."
+
+#: id:15214
+msgid "Use smoothed A/V synchronization"
+msgstr "Użyj płynniejszej synchronizacji A/V"
+
+#: id:15215
+msgid "Hide file names in thumbs view"
+msgstr "Ukrywaj nazwy plików w widoku miniatur"
+
+#: id:15216
+msgid "Play in party mode"
+msgstr "Odtwarzaj w Trybie Imprezy"
+
+#: id:15217
+msgid "Submit songs to Libre.fm"
+msgstr "Publikuj odtwarzane utwory do Libre.fm"
+
+#: id:15218
+msgid "Libre.fm username"
+msgstr "Użytkownik Libre.fm"
+
+#: id:15219
+msgid "Libre.fm password"
+msgstr "Hasło Libre.fm"
+
+#: id:15220
+msgid "Libre.fm"
+msgstr "Libre.fm"
+
+#: id:15221
+msgid "Song submission"
+msgstr "Publikacja piosenek"
+
+#: id:15250
+msgid "Submit Last.fm radio to Last.fm"
+msgstr "Publikuj odtwarzane radio Last.fm"
+
+#: id:15251
+msgid "Connecting to Last.fm..."
+msgstr "Łączenie z Last.fm..."
+
+#: id:15252
+msgid "Selecting station..."
+msgstr "Wybór stacji..."
+
+#: id:15253
+msgid "Search similar artists..."
+msgstr "Wykonawcy podobni do..."
+
+#: id:15254
+msgid "Search similar tags..."
+msgstr "Muzyka otagowana..."
+
+#: id:15255
+msgid "Your profile (%name%)"
+msgstr "Twój profil (%name%)"
+
+#: id:15256
+msgid "Overall top tags"
+msgstr "Najpopularniejsze tagi"
+
+#: id:15257
+msgid "Top artists for tag %name%"
+msgstr "Artyści najczęściej tagowani jako %name%"
+
+#: id:15258
+msgid "Top albums for tag %name%"
+msgstr "Albumy najczęściej tagowane jako %name%"
+
+#: id:15259
+msgid "Top tracks for tag %name%"
+msgstr "Utwory najczęściej tagowane jako %name%"
+
+#: id:15260
+msgid "Listen to tag %name% Last.fm radio"
+msgstr "Słuchaj radia tag %name% z Last.fm"
+
+#: id:15261
+msgid "Similar artists as %name%"
+msgstr "Artyści podobni do %name%"
+
+#: id:15262
+msgid "Top %name% albums"
+msgstr "Top albumy %name%"
+
+#: id:15263
+msgid "Top %name% tracks"
+msgstr "Top utwory %name%"
+
+#: id:15264
+msgid "Top %name% tags"
+msgstr "Top tagi dla %name%"
+
+#: id:15265
+msgid "Biggest fans of %name%"
+msgstr "Najwięksi fani %name%"
+
+#: id:15266
+msgid "Listen to %name% fans Last.fm radio"
+msgstr "Słuchaj Radio fanów %name% z Last.fm"
+
+#: id:15267
+msgid "Listen to %name% similar artists Last.fm radio"
+msgstr "Słuchaj wykonawców podobnych do %name% z Last.fm"
+
+#: id:15268
+msgid "Top artists for user %name%"
+msgstr "Top artyści dla %name%"
+
+#: id:15269
+msgid "Top albums for user %name%"
+msgstr "Top albumy dla %name%"
+
+#: id:15270
+msgid "Top tracks for user %name%"
+msgstr "Top utwory dla %name%"
+
+#: id:15271
+msgid "Friends of user %name%"
+msgstr "Znajomi %name%"
+
+#: id:15272
+msgid "Neighbours of user %name%"
+msgstr "Sąsiedzi %name%"
+
+#: id:15273
+msgid "Weekly artist chart for %name%"
+msgstr "Tygodniowy ranking artystów dla %name%"
+
+#: id:15274
+msgid "Weekly album chart for %name%"
+msgstr "Tygodniowy ranking albumów dla %name%"
+
+#: id:15275
+msgid "Weekly track chart for %name%"
+msgstr "Tygodniowy ranking utworów dla %name%"
+
+#: id:15276
+msgid "Listen to %name%'s neighbours Last.fm radio"
+msgstr "Słuchaj radia sąsiadów %name% z Last.fm"
+
+#: id:15277
+msgid "Listen to %name%'s personal Last.fm radio"
+msgstr "Słuchaj osobistego radia %name% z Last.fm"
+
+#: id:15278
+msgid "Listen to %name%'s mix Last.fm radio"
+msgstr "Słuchaj ulubionych utworów %name% z Last.fm"
+
+#: id:15279
+msgid "Retrieving list from Last.fm..."
+msgstr "Pobieranie listy z Last.fm..."
+
+#: id:15280
+msgid "Can't retrieve list from Last.fm..."
+msgstr "Nie można pobrać listy z Last.fm..."
+
+#: id:15281
+msgid "Enter an artist name to find related ones"
+msgstr "Wpisz nazwę wykonawcy, aby wyszukać pokrewnych"
+
+#: id:15282
+msgid "Enter a tag name to find similar ones"
+msgstr "Wpisz tag, aby znaleźć podobne"
+
+#: id:15283
+msgid "Tracks recently listened by %name%"
+msgstr "Utwory ostatnio odtwarzane przez %name%"
+
+#: id:15284
+msgid "Listen to %name%'s recommendations Last.fm radio"
+msgstr "Słuchaj Radia %name% Poleca z Last.fm"
+
+#: id:15285
+msgid "Top tags for user %name%"
+msgstr "Top tagi dla %name%"
+
+#: id:15287
+msgid "Do you want to add the current track to your loved tracks?"
+msgstr "Na pewno chcesz dodać ten utwór do ulubionych?"
+
+#: id:15288
+msgid "Do you want to ban the current track?"
+msgstr "Na pewno chcesz zablokować ten utwór?"
+
+#: id:15289
+msgid "Added to your loved tracks: '%s'."
+msgstr "Dodano do ulubionych: '%s'."
+
+#: id:15290
+msgid "Could not add '%s' to your loved tracks."
+msgstr "Nie można dodać '%s' do ulubionych."
+
+#: id:15291
+msgid "Banned: '%s'."
+msgstr "Zablokowano: '%s'."
+
+#: id:15292
+msgid "Could not ban '%s'."
+msgstr "Nie można zablokować '%s'."
+
+#: id:15293
+msgid "Tracks recently loved by %name%"
+msgstr "Utwory ostatnie ulubione przez %name%"
+
+#: id:15294
+msgid "Tracks recently banned by %name%"
+msgstr "Utwory ostatnie zablokowane przez %name%"
+
+#: id:15295
+msgid "Remove from loved tracks"
+msgstr "Usuń z ulubionych utworów"
+
+#: id:15296
+msgid "Un-ban"
+msgstr "Odblokuj"
+
+#: id:15297
+msgid "Do you want to remove this track from your loved tracks?"
+msgstr "Czy na pewno chcesz usunąć ten utwór z listy ulubionych?"
+
+#: id:15298
+msgid "Do you want to un-ban this track?"
+msgstr "Czy na pewno chcesz odblokować ten utwór?"
+
+#: id:15300
+msgid "Path not found or invalid"
+msgstr "Niepoprawna ścieżka"
+
+#: id:15301
+msgid "Could not connect to network server"
+msgstr "Nie mogę połączyć się z serwerem"
+
+#: id:15302
+msgid "No servers found"
+msgstr "Nie znaleziono żadnego serwera"
+
+#: id:15303
+msgid "Workgroup not found"
+msgstr "Grupa robocza nie została odnaleziona"
+
+#: id:15310
+msgid "Opening multi-path source"
+msgstr "Otwieranie wielościeżkowego źródła"
+
+#: id:15311
+msgid "Path:"
+msgstr "Ścieżka:"
+
+#: id:16000
+msgctxt "Auto context with id 16000"
+msgid "General"
+msgstr "Ogólne"
+
+#: id:16002
+msgid "Internet lookup"
+msgstr "Przeszukuję w Internecie"
+
+#: id:16003
+msgid "Player"
+msgstr "Odtwarzacz"
+
+#: id:16004
+msgid "Play media from disc"
+msgstr "Odtwarzaj z płyty"
+
+#: id:16008
+msgid "Enter new title"
+msgstr "Wpisz nowy tytuł"
+
+#: id:16009
+msgid "Enter the movie name"
+msgstr "Wpisz nazwę filmu"
+
+#: id:16010
+msgid "Enter the profile name"
+msgstr "Wpisz nazwę profilu"
+
+#: id:16011
+msgid "Enter the album name"
+msgstr "Wpisz nazwę albumu"
+
+#: id:16012
+msgid "Enter the playlist name"
+msgstr "Wpisz nazwę playlisty"
+
+#: id:16013
+msgid "Enter new filename"
+msgstr "Wpisz nową nazwę pliku"
+
+#: id:16014
+msgid "Enter folder name"
+msgstr "Wpisz nazwę katalogu"
+
+#: id:16015
+msgid "Enter directory"
+msgstr "Wejdź w katalog"
+
+#: id:16016
+msgid "Available options: %A, %T, %N, %B, %D, %G, %Y, %F, %S"
+msgstr "Dostępne: %A , %T , %N , %B , %D , %G , %Y , %F , %S"
+
+#: id:16017
+msgid "Enter search string"
+msgstr "Wprowadź tekst do wyszukania"
+
+#: id:16018
+msgctxt "Auto context with id 16018"
+msgid "None"
+msgstr "Brak"
+
+#: id:16019
+msgid "Auto select"
+msgstr "Auto wybór"
+
+#: id:16020
+msgid "De-interlace"
+msgstr "Usuń przeplot"
+
+#: id:16021
+msgid "Bob"
+msgstr "Bob"
+
+#: id:16022
+msgid "Bob (inverted)"
+msgstr "Bob (odwrócony)"
+
+#: id:16024
+msgid "Canceling..."
+msgstr "Anulowanie..."
+
+#: id:16025
+msgid "Enter the artist name"
+msgstr "Wpisz nazwę artysty"
+
+#: id:16026
+msgid "Playback failed"
+msgstr "Odtwarzanie zakończone błędem"
+
+#: id:16027
+msgid "One or more items failed to play."
+msgstr "Nie udało się odtworzyć jednego lub więcej plików."
+
+#: id:16028
+msgid "Enter value"
+msgstr "Wprowadź wartość"
+
+#: id:16029
+msgid "Check the log file for details."
+msgstr "Przejrzyj plik dziennika (log)."
+
+#: id:16030
+msgid "Party mode aborted."
+msgstr "Tryb Imprezy przerwany."
+
+#: id:16031
+msgid "No matching songs in the library."
+msgstr "Nie ma utworów spełniających twoje kryteria."
+
+#: id:16032
+msgid "Could not initialize database."
+msgstr "Nie można utworzyć bazy danych."
+
+#: id:16033
+msgid "Could not open database."
+msgstr "Nie można otworzyć bazy danych."
+
+#: id:16034
+msgid "Could not get songs from database."
+msgstr "Nie można pobrać utworów z bazy danych."
+
+#: id:16035
+msgid "Party mode playlist"
+msgstr "Playlista Trybu Imprezy"
+
+#: id:16036
+msgid "De-interlace (Half)"
+msgstr "Usuń przeplot (Half)"
+
+#: id:16037
+msgid "Deinterlace video"
+msgstr "Usuń przeplot z wideo"
+
+#: id:16038
+msgid "Deinterlace method"
+msgstr "Metoda usuwania przeplotu"
+
+#: id:16039
+msgctxt "Auto context with id 16039"
+msgid "Off"
+msgstr "Wyłącz"
+
+#: id:16040
+msgctxt "Auto context with id 16040"
+msgid "Auto"
+msgstr ""
+
+#: id:16041
+msgid "On"
+msgstr "Włącz"
+
+#: id:16100
+msgid "All Videos"
+msgstr "Wszystkie filmy"
+
+#: id:16101
+msgid "Unwatched"
+msgstr "Nieoglądane"
+
+#: id:16102
+msgid "Watched"
+msgstr "Oglądane"
+
+#: id:16103
+msgid "Mark as watched"
+msgstr "Oznacz jako oglądane"
+
+#: id:16104
+msgid "Mark as unwatched"
+msgstr "Oznacz jako nieoglądane"
+
+#: id:16105
+msgid "Edit title"
+msgstr "Edytuj tytuł"
+
+#: id:16200
+msgid "Operation was aborted"
+msgstr "Polecenie przerwane"
+
+#: id:16201
+msgid "Copy failed"
+msgstr "Kopiowanie nie powiodło się"
+
+#: id:16202
+msgid "Failed to copy at least one file"
+msgstr "Przynajmniej jeden plik nie został skopiowany"
+
+#: id:16203
+msgid "Move failed"
+msgstr "Przeniesienie nie powiodło się"
+
+#: id:16204
+msgid "Failed to move at least one file"
+msgstr "Przynajmniej jeden plik nie został przeniesiony"
+
+#: id:16205
+msgid "Delete failed"
+msgstr "Usuwanie nie powiodło się"
+
+#: id:16206
+msgid "Failed to delete at least one file"
+msgstr "Przynajmniej jeden plik nie został usunięty"
+
+#: id:16300
+msgid "Video scaling method"
+msgstr "Metody skalowania wideo"
+
+#: id:16301
+msgid "Nearest neighbour"
+msgstr ""
+
+#: id:16302
+msgid "Bilinear"
+msgstr ""
+
+#: id:16303
+msgctxt "Auto context with id 16303"
+msgid "Bicubic"
+msgstr ""
+
+#: id:16304
+msgid "Lanczos2"
+msgstr "Lanczos2"
+
+#: id:16305
+msgid "Lanczos3"
+msgstr "Lanczos3"
+
+#: id:16306
+msgid "Sinc8"
+msgstr "Sinc8"
+
+#: id:16307
+msgid "Bicubic (software)"
+msgstr "Bicubic (programowo)"
+
+#: id:16308
+msgid "Lanczos (software)"
+msgstr "Lanczosz (programowo)"
+
+#: id:16309
+msgid "Sinc (software)"
+msgstr "Sinc (programowo)"
+
+#: id:16310
+msgid "Temporal"
+msgstr ""
+
+#: id:16311
+msgid "Temporal/Spatial"
+msgstr ""
+
+#: id:16312
+msgid "(VDPAU)Noise Reduction"
+msgstr "(VDPAU)Redukcja szumu"
+
+#: id:16313
+msgid "(VDPAU)Sharpness"
+msgstr "(VDPAU)Ostrość"
+
+#: id:16314
+msgid "Inverse Telecine"
+msgstr ""
+
+#: id:16315
+msgid "Lanczos3 optimized"
+msgstr "Lanczos3 (zoptymalizowany)"
+
+#: id:16316
+msgctxt "Auto context with id 16316"
+msgid "Auto"
+msgstr "Auto"
+
+#: id:16317
+msgid "Temporal (Half)"
+msgstr ""
+
+#: id:16318
+msgid "Temporal/Spatial (Half)"
+msgstr ""
+
+#: id:16319
+msgid "DXVA"
+msgstr ""
+
+#: id:16320
+msgid "DXVA Bob"
+msgstr ""
+
+#: id:16321
+msgid "DXVA Best"
+msgstr ""
+
+#: id:16322
+msgid "Spline36"
+msgstr ""
+
+#: id:16323
+msgid "Spline36 optimized"
+msgstr ""
+
+#: id:16324
+msgid "Software Blend"
+msgstr ""
+
+#: id:16400
+msgid "Post-processing"
+msgstr ""
+
+#: id:17500
+msgid "Display sleep timeout"
+msgstr "Wyświetlaj odliczanie czasu uśpienia"
+
+#: id:19000
+msgid "Switch to channel"
+msgstr "Wybierz kanał"
+
+#: id:20000
+msgid "Saved music folder"
+msgstr "Katalog zapisywanej muzyki"
+
+#: id:20001
+msgid "Use external DVD player"
+msgstr "Użyj zewnętrznego odtwarzacza DVD"
+
+#: id:20002
+msgid "External DVD player"
+msgstr "Zewnętrzny odtwarzacz DVD"
+
+#: id:20003
+msgid "Trainers folder"
+msgstr "Katalog z trainerami"
+
+#: id:20004
+msgid "Screenshot folder"
+msgstr "Katalog ze zrzutami ekranu"
+
+#: id:20006
+msgid "Playlists folder"
+msgstr "Katalog z playlistami"
+
+#: id:20007
+msgid "Recordings"
+msgstr "Nagrania"
+
+#: id:20008
+msgid "Screenshots"
+msgstr "Zrzuty ekranu"
+
+#: id:20009
+msgid "Use XBMC"
+msgstr "Użyj XBMC"
+
+#: id:20011
+msgid "Music playlists"
+msgstr "Playlisty muzyczne"
+
+#: id:20012
+msgid "Video playlists"
+msgstr "Playlisty wideo"
+
+#: id:20013
+msgid "Do you wish to launch the game?"
+msgstr "Uruchomić grę?"
+
+#: id:20014
+msgid "Sort by: Playlist"
+msgstr "Sortuj: Playlista"
+
+#: id:20015
+msgid "Remote thumb"
+msgstr "Ikona z Internetu"
+
+#: id:20016
+msgid "Current thumb"
+msgstr "Aktualna ikona"
+
+#: id:20017
+msgid "Local thumb"
+msgstr "Lokalna ikona"
+
+#: id:20018
+msgid "No thumb"
+msgstr "Brak ikony"
+
+#: id:20019
+msgid "Choose thumbnail"
+msgstr "Wybierz miniaturkę"
+
+#: id:20023
+msgid "Conflict"
+msgstr "Konflikt"
+
+#: id:20024
+msgid "Scan new"
+msgstr "Nowe skanowanie"
+
+#: id:20025
+msgid "Scan all"
+msgstr "Skanuj wszystko"
+
+#: id:20026
+msgid "Region"
+msgstr "Region"
+
+#: id:20037
+msgid "Summary"
+msgstr "Podsumowanie"
+
+#: id:20038
+msgid "Lock music window"
+msgstr "Zablokuj dostęp do muzyki"
+
+#: id:20039
+msgid "Lock videos window"
+msgstr "Zablokuj dostęp do wideo"
+
+#: id:20040
+msgid "Lock pictures window"
+msgstr "Zablokuj dostęp do zdjęć"
+
+#: id:20041
+msgid "Lock programs & scripts windows"
+msgstr "Zablokuj dostęp do programów i skryptów"
+
+#: id:20042
+msgid "Lock file manager"
+msgstr "Zablokuj dostęp do eksploratora"
+
+#: id:20043
+msgid "Lock settings"
+msgstr "Zablokuj dostęp do ustawień"
+
+#: id:20044
+msgid "Start fresh"
+msgstr "Od nowa"
+
+#: id:20045
+msgid "Enter master mode"
+msgstr "Wejdź w tryb administratora"
+
+#: id:20046
+msgid "Leave master mode"
+msgstr "Opuść tryb administratora"
+
+#: id:20047
+msgid "Create profile '%s'?"
+msgstr "Stworzyć profil '%s' ?"
+
+#: id:20048
+msgid "Start with fresh settings"
+msgstr "Rozpocznij od nowa z domyślnymi ustawieniami"
+
+#: id:20049
+msgid "Best available"
+msgstr "Najlepszy z dostępnych"
+
+#: id:20050
+msgid "Auto-switch between 16x9 and 4x3"
+msgstr "Automatyczne przełączanie pomiędzy 16x9 i 4x3"
+
+#: id:20051
+msgid "Treat stacked files as single file"
+msgstr "Traktuj złączone pliki jako jeden"
+
+#: id:20052
+msgid "Caution"
+msgstr "Uwaga"
+
+#: id:20053
+msgid "Left master mode"
+msgstr "Opuszczono tryb administratora"
+
+#: id:20054
+msgid "Entered master mode"
+msgstr "Aktywny tryb administratora"
+
+#: id:20055
+msgid "Allmusic.com thumb"
+msgstr "Ikona z Allmusic.com"
+
+#: id:20057
+msgid "Remove thumbnail"
+msgstr "Usuń miniaturę"
+
+#: id:20058
+msgid "Add profile..."
+msgstr "Dodaj profil..."
+
+#: id:20059
+msgid "Query info for all albums"
+msgstr "Info do wszystkich albumów"
+
+#: id:20060
+msgctxt "Auto context with id 20060"
+msgid "Media info"
+msgstr "o mediach"
+
+#: id:20061
+msgctxt "Auto context with id 20061"
+msgid "Separate"
+msgstr ""
+
+#: id:20062
+msgid "Shares with default"
+msgstr "Współdzieli z domyślnymi"
+
+#: id:20063
+msgid "Shares with default (read only)"
+msgstr "Współdzieli z domyślnymi (tylko odczyt)"
+
+#: id:20064
+msgid "Copy default"
+msgstr "Skopiuj domyślne"
+
+#: id:20065
+msgid "Profile picture"
+msgstr "Awatar profilu"
+
+#: id:20066
+msgid "Lock preferences"
+msgstr "Ustawienia blokad dostępu"
+
+#: id:20067
+msgid "Edit profile"
+msgstr "Edytuj profil"
+
+#: id:20068
+msgid "Profile lock"
+msgstr "Profil zablokowany"
+
+#: id:20069
+msgid "Could not create folder"
+msgstr "Nie mogę utworzyć katalogu"
+
+#: id:20070
+msgid "Profile directory"
+msgstr "Katalog z profilami"
+
+#: id:20071
+msgid "Start with fresh media sources"
+msgstr "Chcesz wprowadzać źródła mediów zupełnie od nowa"
+
+#: id:20072
+msgid "Make sure the selected folder is writable"
+msgstr "Upewnij się, czy w tym katalogu można zapisywać"
+
+#: id:20073
+msgid "and that the new folder name is valid"
+msgstr "i czy jego nazwa jest prawidłowa"
+
+#: id:20074
+msgid "MPAA rating"
+msgstr "Ocena MPAA"
+
+#: id:20075
+msgid "Enter master lock code"
+msgstr "Wprowadź hasło główne"
+
+#: id:20076
+msgid "Ask for master lock code on startup"
+msgstr "Pytaj o hasło główne na starcie"
+
+#: id:20077
+msgid "Skin settings"
+msgstr "Ustawienia skóry"
+
+#: id:20078
+msgid "- no link set -"
+msgstr "- nieprzypisany -"
+
+#: id:20079
+msgid "Enable animations"
+msgstr "Włącz animacje"
+
+#: id:20080
+msgid "Disable RSS during music"
+msgstr "Wyłącz wiadomości RSS podczas odtwarzania muzyki"
+
+#: id:20081
+msgid "Enable shortcut buttons"
+msgstr "Włącz przycisków skrótów"
+
+#: id:20082
+msgid "Show programs in main menu"
+msgstr "Dostęp do zakładki programy w głównym menu"
+
+#: id:20083
+msgid "Show music info"
+msgstr "Pokazuj info o muzyce"
+
+#: id:20084
+msgid "Show weather info"
+msgstr "Pokazuj info o pogodzie"
+
+#: id:20085
+msgid "Show system info"
+msgstr "Pokazuj info o systemie"
+
+#: id:20086
+msgid "Show available disc space C: E: F:"
+msgstr "Pokazuj wolne miejsce dla C: E: F:"
+
+#: id:20087
+msgid "Show available disc space E: F: G:"
+msgstr "Pokazuj wolne miejsce dla E: F: G:"
+
+#: id:20088
+msgid "Weather info"
+msgstr "Info o pogodzie"
+
+#: id:20089
+msgid "Drive space free"
+msgstr "Wolne miejsce na dyskach"
+
+#: id:20090
+msgid "Enter the name of an existing share"
+msgstr "Wprowadź nazwę istniejącego udziału"
+
+#: id:20091
+msgid "Lock code"
+msgstr "Hasło"
+
+#: id:20092
+msgid "Load profile"
+msgstr "Załaduj profil"
+
+#: id:20093
+msgid "Profile name"
+msgstr "Nazwa profilu"
+
+#: id:20094
+msgctxt "Auto context with id 20094"
+msgid "Media sources"
+msgstr "Źródła mediów"
+
+#: id:20095
+msgid "Enter profile lock code"
+msgstr "Wprowadź hasło"
+
+#: id:20096
+msgctxt "Auto context with id 20096"
+msgid "Login screen"
+msgstr "Ekran logowania"
+
+#: id:20097
+msgid "Fetching album info"
+msgstr "Pobieram informacje o albumie"
+
+#: id:20098
+msgid "Fetching info for album"
+msgstr "Pobieram informacje o albumie"
+
+#: id:20099
+msgid "Can't rip CD or track while playing from CD"
+msgstr "Jednoczesne zgrywanie i odtwarzanie płyty CD jest niemożliwe"
+
+#: id:20100
+msgid "Master lock code and settings"
+msgstr "Hasło główne i ustawiania"
+
+#: id:20101
+msgid "Entering master lock code always enables master mode"
+msgstr "Wprowadzenie hasła głównego uaktywnia tryb administratora"
+
+#: id:20102
+msgid "or copy from default?"
+msgstr "czy może raczej skopiować je z profilu domyślnego?"
+
+#: id:20103
+msgid "Save changes to profile?"
+msgstr "Zapisać zmiany w profilu?"
+
+#: id:20104
+msgid "Old settings found."
+msgstr "Znaleziono poprzednie ustawienia."
+
+#: id:20105
+msgid "Do you want to use them?"
+msgstr "Czy chcesz je przywrócić?"
+
+#: id:20106
+msgid "Old media sources found."
+msgstr "Znaleziono poprzednie źródła mediów."
+
+#: id:20107
+msgid "Separate (locked)"
+msgstr ""
+
+#: id:20108
+msgid "Root"
+msgstr "Główny"
+
+#: id:20109
+msgid "- Zoom"
+msgstr "- Powiększenie"
+
+#: id:20110
+msgid "UPnP settings"
+msgstr "Ustawienia UPnP"
+
+#: id:20111
+msgid "Autostart UPnP client"
+msgstr "Autostart klienta UPnP"
+
+#: id:20112
+msgid "Last login: %s"
+msgstr "Ostatnie logowanie: %s"
+
+#: id:20113
+msgid "Never logged on"
+msgstr "Nigdy nie zalogowano"
+
+#: id:20114
+msgid "Profile %i / %i"
+msgstr "Profil %i / %i"
+
+#: id:20115
+msgid "User login / Select a profile"
+msgstr "Logowanie / Wybierz profil"
+
+#: id:20116
+msgid "Use lock on login screen"
+msgstr "Blokada dostępu na ekran logowania"
+
+#: id:20117
+msgid "Invalid lock code."
+msgstr "Nieprawidłowe hasło."
+
+#: id:20118
+msgid "This requires the master lock to be set."
+msgstr "Wymagane hasło główne, aby zmienić te ustawienia."
+
+#: id:20119
+msgid "Would you like to set it now?"
+msgstr "Ustawić teraz?"
+
+#: id:20120
+msgid "Loading program information"
+msgstr "Wczytuję informacje o programie"
+
+#: id:20121
+msgid "Party on!"
+msgstr "Imprezujemy!"
+
+#: id:20122
+msgid "True"
+msgstr "Prawda"
+
+#: id:20123
+msgid "Mixing drinks"
+msgstr "Robię drinki"
+
+#: id:20124
+msgid "Filling glasses"
+msgstr "Napełniam szklaneczki"
+
+#: id:20125
+msgid "Logged on as"
+msgstr "Zalogowano jako"
+
+#: id:20126
+msgid "Log off"
+msgstr "Wyloguj"
+
+#: id:20128
+msgid "Go to root"
+msgstr "Powrót na górę"
+
+#: id:20129
+msgid "Weave"
+msgstr ""
+
+#: id:20130
+msgid "Weave (inverted)"
+msgstr ""
+
+#: id:20131
+msgid "Blend"
+msgstr ""
+
+#: id:20132
+msgid "Restart video"
+msgstr "Uruchom ponownie wideo"
+
+#: id:20133
+msgid "Edit network location"
+msgstr "Edytuj miejsce sieciowe"
+
+#: id:20134
+msgid "Remove network location"
+msgstr "Usuń miejsce sieciowe"
+
+#: id:20135
+msgid "Do you want to scan the folder?"
+msgstr "Skanować ten katalog?"
+
+#: id:20136
+msgid "Memory unit"
+msgstr "Karta pamięci"
+
+#: id:20137
+msgid "Memory unit mounted"
+msgstr "Karta pamięci podłączona"
+
+#: id:20138
+msgid "Unable to mount memory unit"
+msgstr "Podłączenie karty pamięci niemożliwe"
+
+#: id:20139
+msgid "In port %i, slot %i"
+msgstr "w porcie %i, slot %i"
+
+#: id:20140
+msgid "Lock screensaver"
+msgstr "Zablokuj wygaszacz"
+
+#: id:20141
+msgid "Set"
+msgstr "Ustaw"
+
+#: id:20142
+msgctxt "Auto context with id 20142"
+msgid "Username"
+msgstr "Użytkownik"
+
+#: id:20143
+msgid "Enter password for"
+msgstr "Wprowadź hasło dla"
+
+#: id:20144
+msgid "Shutdown timer"
+msgstr "Timer wyłączenia"
+
+#: id:20145
+msgid "Shutdown interval (in minutes)"
+msgstr "Interwał wyłączenia (w minutach)"
+
+#: id:20146
+msgid "Started, shutdown in %im"
+msgstr "Uruchomiono, wyłączenie za %im"
+
+#: id:20147
+msgid "Shutdown in 30 minutes"
+msgstr "Wyłączenie za 30 minut"
+
+#: id:20148
+msgid "Shutdown in 60 minutes"
+msgstr "Wyłączenie za 60 minut"
+
+#: id:20149
+msgid "Shutdown in 120 minutes"
+msgstr "Wyłączenie za 120 minut"
+
+#: id:20150
+msgid "Custom shutdown timer"
+msgstr "Własny timer wyłączenia"
+
+#: id:20151
+msgid "Cancel shutdown timer"
+msgstr "Anuluj timer wyłączenia"
+
+#: id:20152
+msgid "Lock preferences for %s"
+msgstr "Zablokuj ustawienia dla %s"
+
+#: id:20153
+msgid "Browse..."
+msgstr "Przeglądaj..."
+
+#: id:20154
+msgid "Summary information"
+msgstr "Informacje podstawowe"
+
+#: id:20155
+msgid "Storage information"
+msgstr "Informacje o partycjach"
+
+#: id:20156
+msgid "Hard disk information"
+msgstr "Informacje o dysku"
+
+#: id:20157
+msgid "DVD-ROM information"
+msgstr "Informacje o napędzie DVD-ROM"
+
+#: id:20158
+msgid "Network information"
+msgstr "Informacje o sieci"
+
+#: id:20159
+msgid "Video information"
+msgstr "Informacje o karcie graficznej"
+
+#: id:20160
+msgid "Hardware information"
+msgstr "Informacje o sprzęcie"
+
+#: id:20161
+msgid "Total"
+msgstr "Razem"
+
+#: id:20162
+msgid "Used"
+msgstr "zajęte"
+
+#: id:20163
+msgid "of"
+msgstr "z"
+
+#: id:20164
+msgid "Locking not supported"
+msgstr "Blokowanie niedostępne"
+
+#: id:20165
+msgid "Not locked"
+msgstr "Nie zablokowany"
+
+#: id:20166
+msgid "Locked"
+msgstr "Zablokowany"
+
+#: id:20167
+msgid "Frozen"
+msgstr "Zamrożony"
+
+#: id:20168
+msgid "Requires reset"
+msgstr "Wymagany reset"
+
+#: id:20169
+msgid "Week"
+msgstr "Tydzień"
+
+#: id:20170
+msgid "Line"
+msgstr "Linia"
+
+#: id:20171
+msgid "Windows network (SMB)"
+msgstr "Otoczenie sieciowe Windows (SMB)"
+
+#: id:20172
+msgid "XBMSP server"
+msgstr "Serwer XBMSP"
+
+#: id:20173
+msgctxt "Auto context with id 20173"
+msgid "FTP server"
+msgstr "Serwer FTP"
+
+#: id:20174
+msgid "iTunes music share (DAAP)"
+msgstr "iTunes (DAAP)"
+
+#: id:20175
+msgid "UPnP server"
+msgstr "Serwer UPnP"
+
+#: id:20176
+msgid "Show video info"
+msgstr "Pokazuj info o filmie"
+
+#: id:20177
+msgid "Done"
+msgstr "Gotowe"
+
+#: id:20178
+msgid "Shift"
+msgstr "Shift"
+
+#: id:20179
+msgid "Caps Lock"
+msgstr "Caps Lock"
+
+#: id:20180
+msgid "Symbols"
+msgstr "Symbole"
+
+#: id:20181
+msgid "Backspace"
+msgstr "Backspace"
+
+#: id:20182
+msgid "Space"
+msgstr "Spacja"
+
+#: id:20183
+msgid "Reload skin"
+msgstr "Przeładuj skórę"
+
+#: id:20184
+msgid "Rotate pictures using EXIF information"
+msgstr "Obracaj zdjęcia na bazie danych EXIF"
+
+#: id:20185
+msgid "Use poster view styles for TV shows"
+msgstr "Używaj widoku plakatu dla seriali TV"
+
+#: id:20186
+msgid "Please wait"
+msgstr "Proszę czekać"
+
+#: id:20187
+msgid "UPnP"
+msgstr ""
+
+#: id:20189
+msgid "Enable auto scrolling for plot & review"
+msgstr "Automatyczne przewijanie opisu i fabuły"
+
+#: id:20190
+msgctxt "Auto context with id 20190"
+msgid "Custom"
+msgstr "Własne"
+
+#: id:20191
+msgid "Enable debug logging"
+msgstr "Włącz logowanie (debug)"
+
+#: id:20192
+msgid "Download additional information during updates"
+msgstr "Pobierz dodatkowe informacje wraz z aktualizacjami"
+
+#: id:20193
+msgid "Default service for album information"
+msgstr "Domyślne źródło informacji o albumach"
+
+#: id:20194
+msgid "Default service for artist information"
+msgstr "Domyślne źródło informacji o artystach"
+
+#: id:20195
+msgid "Change scraper"
+msgstr "Zmień scraper"
+
+#: id:20196
+msgid "Export music library"
+msgstr "Eksportuj bibliotekę muzyki"
+
+#: id:20197
+msgid "Import music library"
+msgstr "Importuj bibliotekę muzyki"
+
+#: id:20198
+msgid "No artist found!"
+msgstr "Nie znaleziono artysty!"
+
+#: id:20199
+msgid "Downloading artist info failed"
+msgstr "Pobieranie informacji o artyście nie powiodło się"
+
+#: id:20250
+msgid "Party on! (videos)"
+msgstr "Imprezujemy! (wideo)"
+
+#: id:20251
+msgid "Mixing drinks (videos)"
+msgstr "Robię drinki (wideo)"
+
+#: id:20252
+msgid "Filling glasses (videos)"
+msgstr "Napełniam szklaneczki (wideo)"
+
+#: id:20253
+msgid "WebDAV server (HTTP)"
+msgstr "Serwer WebDAV (HTTP)"
+
+#: id:20254
+msgid "WebDAV server (HTTPS)"
+msgstr "Serwer WebDAV (HTTPS)"
+
+#: id:20255
+msgid "First logon, edit your profile"
+msgstr "Pierwsze logowanie, ustaw swój profil"
+
+#: id:20256
+msgid "HTS Tvheadend client"
+msgstr "Klient HTS Tvheadend"
+
+#: id:20257
+msgid "VDR Streamdev client"
+msgstr "Klient VDR Streamdev"
+
+#: id:20258
+msgid "MythTV client"
+msgstr "Klient MythTV"
+
+#: id:20259
+msgid "Network Filesystem (NFS)"
+msgstr "System plików NFS"
+
+#: id:20260
+msgid "Secure Shell (SSH/SFTP)"
+msgstr "SSH/SFTP"
+
+#: id:20261
+msgid "Apple Filing Protocol (AFP)"
+msgstr "Protokół AFP"
+
+#: id:20300
+msgid "Web server directory (HTTP)"
+msgstr "Katalog serwera web (HTTP)"
+
+#: id:20301
+msgid "Web server directory (HTTPS)"
+msgstr "Katalog serwera web (HTTPS)"
+
+#: id:20302
+msgid "Unable to write to folder:"
+msgstr "Nie powiódł się zapis do folderu:"
+
+#: id:20303
+msgid "Do you want to skip and proceed?"
+msgstr "Pominąć i kontynuować?"
+
+#: id:20304
+msgid "RSS Feed"
+msgstr "Kanały RSS"
+
+#: id:20307
+msgid "Secondary DNS"
+msgstr "Dodatkowe DNS"
+
+#: id:20308
+msgid "DHCP server:"
+msgstr "Serwery DHCP:"
+
+#: id:20309
+msgid "Make new folder"
+msgstr "Utwórz nowy folder"
+
+#: id:20310
+msgid "Dim LCD on playback"
+msgstr "Przyciemnij LCD podczas odtwarzania"
+
+#: id:20311
+msgid "Unknown or onboard (protected)"
+msgstr "Nieznany lub zintegrowany (zabezpieczony)"
+
+#: id:20312
+msgid "Dim LCD on paused"
+msgstr "Przyciemnij LCD podczas pauzy"
+
+#: id:20314
+msgid "Videos - Library"
+msgstr "Wideo - Biblioteka"
+
+#: id:20316
+msgid "Sort by: ID"
+msgstr "Sortuj: ID"
+
+#: id:20324
+msgid "Play part..."
+msgstr "Odtwarzaj część..."
+
+#: id:20325
+msgid "Calibration reset"
+msgstr "Resetowanie kalibracji"
+
+#: id:20326
+msgid "This will reset the calibration values for %s"
+msgstr "Spowoduje to reset ustawień kalibracji dla %s"
+
+#: id:20327
+msgid "to it's default values."
+msgstr "i zostaną przywrócone wartości domyślne."
+
+#: id:20328
+msgid "Browse for destination"
+msgstr "Wskaż katalog docelowy"
+
+#: id:20329
+msgid "Movies are in separate folders that match the movie title"
+msgstr "Filmy są w oddzielnych katalogach, z nazwami tytułu filmu"
+
+#: id:20330
+msgid "Use folder names for lookups"
+msgstr "Nazwa folderu jako podstawa szukania"
+
+#: id:20331
+msgctxt "Auto context with id 20331"
+msgid "File"
+msgstr "Plik"
+
+#: id:20332
+msgid "Use file or folder names in lookups?"
+msgstr "Użyć nazwy pliku lub folderu jako podstawy szukania?"
+
+#: id:20333
+msgid "Set content"
+msgstr "Określ zawartość"
+
+#: id:20334
+msgid "Folder"
+msgstr "Folder"
+
+#: id:20335
+msgid "Look for content recursively?"
+msgstr "Uwzględnić zawartość podkatalogów?"
+
+#: id:20336
+msgid "Unlock sources"
+msgstr "Odblokuj źródła"
+
+#: id:20337
+msgid "Actor"
+msgstr "Aktor"
+
+#: id:20338
+msgid "Movie"
+msgstr "Film"
+
+#: id:20339
+msgid "Director"
+msgstr "Reżyser"
+
+#: id:20340
+msgid "Do you want to remove all items within"
+msgstr "Usunąć z biblioteki XBMC wszystkie pozycje"
+
+#: id:20341
+msgid "this path from the XBMC library?"
+msgstr "związane z tą ścieżką?"
+
+#: id:20342
+msgctxt "Auto context with id 20342"
+msgid "Movies"
+msgstr "Filmy"
+
+#: id:20343
+msgid "TV shows"
+msgstr "Seriale TV"
+
+#: id:20344
+msgid "This directory contains"
+msgstr "Zawartość katalogu"
+
+#: id:20345
+msgid "Run automated scan"
+msgstr "Uruchom automatyczne skanowanie"
+
+#: id:20346
+msgid "Scan recursively"
+msgstr "z uwzględnieniem podkatalogów"
+
+#: id:20347
+msgid "as"
+msgstr "jako"
+
+#: id:20348
+msgid "Directors"
+msgstr "Reżyserzy"
+
+#: id:20349
+msgid "No video files found in this path!"
+msgstr "Ta ścieżka nie zawiera żadnych plików video!"
+
+#: id:20350
+msgid "votes"
+msgstr "głosów"
+
+#: id:20351
+msgid "TV show information"
+msgstr "Info o Serialu"
+
+#: id:20352
+msgid "Episode information"
+msgstr "Informacje o odcinku"
+
+#: id:20353
+msgid "Loading TV show details"
+msgstr "Wczytuję informacje o serialu"
+
+#: id:20354
+msgid "Fetching episode guide"
+msgstr "Pobieranie opisów odcinków"
+
+#: id:20355
+msgid "Loading info for episodes in directory"
+msgstr "Wczytuję informacje o odcinkach w katalogu"
+
+#: id:20356
+msgid "Select TV show:"
+msgstr "Wybierz Serial:"
+
+#: id:20357
+msgid "Enter the TV show name"
+msgstr "Wprowadź tytuł serialu"
+
+#: id:20358
+msgid "Season %i"
+msgstr "Sezon %i"
+
+#: id:20359
+msgid "Episode"
+msgstr "Odcinek"
+
+#: id:20360
+msgid "Episodes"
+msgstr "Odcinki"
+
+#: id:20361
+msgid "Loading episode details"
+msgstr "Wczytuję informacje o odcinkach"
+
+#: id:20362
+msgid "Remove episode from library"
+msgstr "Usuń odcinek z biblioteki"
+
+#: id:20363
+msgid "Remove TV show from library"
+msgstr "Usuń serial z biblioteki"
+
+#: id:20364
+msgid "TV show"
+msgstr "Serial TV"
+
+#: id:20365
+msgid "Episode plot"
+msgstr "Opis odcinka"
+
+#: id:20366
+msgid "* All seasons"
+msgstr "* Wszystkie sezony"
+
+#: id:20367
+msgid "Hide watched"
+msgstr "Ukryj oglądane"
+
+#: id:20368
+msgid "Prod code"
+msgstr "Kod Prod."
+
+#: id:20369
+msgid "Show plot for unwatched items"
+msgstr "Pokazuj opis dla nieoglądanych pozycji"
+
+#: id:20370
+msgid "* Hidden to prevent spoilers *"
+msgstr "* Ukryte. Poznanie fabuły psuje przyjemność oglądania *"
+
+#: id:20371
+msgid "Set season thumb"
+msgstr "Ustaw ikonę sezonu"
+
+#: id:20372
+msgid "Season image"
+msgstr "Miniaturka dla sezonu"
+
+#: id:20373
+msgid "Season"
+msgstr "Sezon"
+
+#: id:20374
+msgid "Downloading movie information"
+msgstr "Pobieram informacje o filmie"
+
+#: id:20375
+msgid "Unassign content"
+msgstr "Nieokreślona zawartość"
+
+#: id:20376
+msgid "Original title"
+msgstr "Tytuł oryginalny"
+
+#: id:20377
+msgid "Refresh TV show information"
+msgstr "Odśwież informację o serialu"
+
+#: id:20378
+msgid "Refresh info for all episodes?"
+msgstr "Odświeżyć dane dla wszystkich odcinków?"
+
+#: id:20379
+msgid "Selected folder contains a single TV show"
+msgstr "Wybrany katalog zawiera jeden serial"
+
+#: id:20380
+msgid "Exclude selected folder from scans"
+msgstr "Wyklucz wybrane katalogi ze skanowania"
+
+#: id:20381
+msgid "Specials"
+msgstr "Specjalne"
+
+#: id:20382
+msgid "Automatically grab season thumbs"
+msgstr "Automatycznie pobieraj ikony sezonu"
+
+#: id:20383
+msgid "Selected folder contains a single video"
+msgstr "Wybrany katalog zawiera jeden plik wideo"
+
+#: id:20384
+msgid "Link to TV show"
+msgstr "Link do serialu"
+
+#: id:20385
+msgid "Remove link to TV show"
+msgstr "Usuń link do serialu"
+
+#: id:20386
+msgid "Recently added movies"
+msgstr "Ostatnio dodane filmy"
+
+#: id:20387
+msgid "Recently added episodes"
+msgstr "Ostatnio dodane odcinki"
+
+#: id:20388
+msgid "Studios"
+msgstr "Wytwórnia"
+
+#: id:20389
+msgid "Music videos"
+msgstr "Teledyski"
+
+#: id:20390
+msgid "Recently added music videos"
+msgstr "Ostatnio dodane teledyski"
+
+#: id:20391
+msgid "Music video"
+msgstr "Teledysk"
+
+#: id:20392
+msgid "Remove music video from library"
+msgstr "Usuń teledysk z biblioteki"
+
+#: id:20393
+msgctxt "Auto context with id 20393"
+msgid "Music video information"
+msgstr "Info o teledysku"
+
+#: id:20394
+msgid "Loading music video information"
+msgstr "Wczytuję informacje o teledysku"
+
+#: id:20395
+msgid "Mixed"
+msgstr "Mieszany"
+
+#: id:20396
+msgid "Go to albums by artist"
+msgstr "Przejdź do albumów tego artysty"
+
+#: id:20397
+msgid "Go to album"
+msgstr "Przejdź do albumu"
+
+#: id:20398
+msgid "Play song"
+msgstr "Odtwarzaj utwór"
+
+#: id:20399
+msgid "Go to music videos from album"
+msgstr "Przejdź do teledysków z tego albumu"
+
+#: id:20400
+msgid "Go to music videos by artist"
+msgstr "Przejdź do teledysków tego artysty"
+
+#: id:20401
+msgid "Play music video"
+msgstr "Odtwarzaj teledysk"
+
+#: id:20402
+msgid "Download actor thumbnails when adding to library"
+msgstr "Pobieraj zdjęcia aktorów dodając film do biblioteki"
+
+#: id:20403
+msgid "Set actor thumb"
+msgstr "Ustaw zdjęcie aktora"
+
+#: id:20405
+msgid "Remove episode bookmark"
+msgstr "Odcinek - usuń zakładkę"
+
+#: id:20406
+msgid "Set episode bookmark"
+msgstr "Odcinek - ustaw zakładkę"
+
+#: id:20407
+msgid "Scraper settings"
+msgstr "Ustawienia scrapera"
+
+#: id:20408
+msgid "Downloading music video information"
+msgstr "Pobieram informację o teledysku"
+
+#: id:20409
+msgid "Downloading TV show information"
+msgstr "Pobieram informację o serialu"
+
+#: id:20410
+msgid "Trailer"
+msgstr "Zwiastun"
+
+#: id:20411
+msgid "Flatten"
+msgstr "Tylko tytuły"
+
+#: id:20412
+msgid "Flatten TV shows"
+msgstr "Pomiń podział na sezony"
+
+#: id:20413
+msgid "Get fanart"
+msgstr "Pobierz Fanart"
+
+#: id:20414
+msgid "Show Fanart in video and music libraries"
+msgstr "Fanart jako tło w trybie biblioteki"
+
+#: id:20415
+msgid "Scanning for new content"
+msgstr "Wyszukiwanie nowych pozycji"
+
+#: id:20416
+msgid "First aired"
+msgstr "Premiera"
+
+#: id:20417
+msgid "Writer"
+msgstr "Scenariusz"
+
+#: id:20419
+msgid "Replace file names with library titles"
+msgstr "Pokaż metadane w widoku plików"
+
+#: id:20420
+msgctxt "Auto context with id 20420"
+msgid "Never"
+msgstr "nigdy"
+
+#: id:20421
+msgid "If only one season"
+msgstr "dla jednosezonowych seriali"
+
+#: id:20422
+msgid "Always"
+msgstr "zawsze"
+
+#: id:20423
+msgid "Has trailer"
+msgstr "ma zwiastun"
+
+#: id:20424
+msgid "False"
+msgstr "Fałsz"
+
+#: id:20425
+msgid "Fanart slideshow"
+msgstr "Pokaz slajdów z fanartami"
+
+#: id:20426
+msgid "Export to a single file or separate"
+msgstr "Eksportować do pojedynczego pliku"
+
+#: id:20427
+msgid "files per entry?"
+msgstr "czy rozdzielić pliki?"
+
+#: id:20428
+msgid "Single file"
+msgstr "Jeden plik"
+
+#: id:20429
+msgctxt "Auto context with id 20429"
+msgid "Separate"
+msgstr "Oddziel"
+
+#: id:20430
+msgid "Export thumbnails and fanart?"
+msgstr "Eksportować miniatury i fanart?"
+
+#: id:20431
+msgid "Overwrite old files?"
+msgstr "Nadpisać istniejące pliki?"
+
+#: id:20432
+msgid "Exclude path from library updates"
+msgstr "Pomijaj ten katalog podczas aktualizacji biblioteki"
+
+#: id:20433
+msgid "Extract thumbnails and video information"
+msgstr "Twórz miniatury i pobieraj informacje o pliku wideo"
+
+#: id:20434
+msgid "Sets"
+msgstr "Serie"
+
+#: id:20435
+msgid "Set movieset thumb"
+msgstr "Ustaw ikonę serii filmów"
+
+#: id:20436
+msgid "Export actor thumbs?"
+msgstr "Eksportuj ikony aktorów"
+
+#: id:20437
+msgid "Choose fanart"
+msgstr "Wybierz fanart"
+
+#: id:20438
+msgid "Local fanart"
+msgstr "Lokalny fanart"
+
+#: id:20439
+msgid "No fanart"
+msgstr "Brak fanartu"
+
+#: id:20440
+msgid "Current fanart"
+msgstr "Aktualny fanart"
+
+#: id:20441
+msgid "Remote fanart"
+msgstr "Fanart z Internetu"
+
+#: id:20442
+msgid "Change content"
+msgstr "Zmień typ zawartości"
+
+#: id:20443
+msgid "Do you want to refresh info for all"
+msgstr "Odświeżyć informacje dla wszystkich"
+
+#: id:20444
+msgid "items within this path?"
+msgstr "pozycji związanych z tą ścieżką?"
+
+#: id:20445
+msgid "Fanart"
+msgstr "Fanart"
+
+#: id:20446
+msgid "Locally stored information found."
+msgstr "Informacja lokalna znaleziona."
+
+#: id:20447
+msgid "Ignore and refresh from internet?"
+msgstr "Zignorować i odświeżyć z Internetu?"
+
+#: id:20448
+msgid "Could not download information"
+msgstr "Nie można było pobrać informacji"
+
+#: id:20449
+msgid "Unable to connect to remote server"
+msgstr "Błąd łączenia ze zdalnym serwerem"
+
+#: id:20450
+msgid "Would you like to continue scanning?"
+msgstr "Kontynuować skanowanie?"
+
+#: id:20451
+msgid "Countries"
+msgstr "Kraje"
+
+#: id:20452
+msgid "episode"
+msgstr "odcinek"
+
+#: id:20453
+msgid "episodes"
+msgstr "odcinki"
+
+#: id:20454
+msgid "Listener"
+msgstr "Słuchacz"
+
+#: id:20455
+msgid "Listeners"
+msgstr "Słuchaczy"
+
+#: id:20456
+msgid "Set movieset fanart"
+msgstr "Ustaw fanart dla kolekcji filmów"
+
+#: id:20457
+msgid "Movie set"
+msgstr "Kolekcja filmów"
+
+#: id:20458
+msgid "Group movies in sets"
+msgstr "Grupuj filmy w kolekcje"
+
+#: id:21330
+msgid "Show hidden files and directories"
+msgstr "Pokazuj ukryte pliki i foldery"
+
+#: id:21331
+msgid "TuxBox client"
+msgstr "Klient TuxBox"
+
+#: id:21332
+msgid "WARNING: Target TuxBox device is in recording-mode!"
+msgstr "UWAGA: Urządzenie TuxBox jest w trybie nagrywania!"
+
+#: id:21333
+msgid "The stream will be stopped!"
+msgstr "Strumień zostanie zatrzymany!"
+
+#: id:21334
+msgid "Zap to channel: %s failed!"
+msgstr "Dołączenie do kanału: %s nie powiodło się!"
+
+#: id:21335
+msgid "Are you sure to start the stream?"
+msgstr "Chcesz rozpocząć odtwarzanie strumienia?"
+
+#: id:21336
+msgid "Connecting to: %s"
+msgstr "Łączenie z: %s"
+
+#: id:21337
+msgid "TuxBox device"
+msgstr "Urządzenie TuxBox"
+
+#: id:21359
+msgid "Add media share..."
+msgstr "Dodaj udział ..."
+
+#: id:21360
+msgid "Share video and music libraries through UPnP"
+msgstr "Udostępniaj bibliotekę poprzez UPnP"
+
+#: id:21364
+msgid "Edit media share"
+msgstr "Edytuj udział"
+
+#: id:21365
+msgid "Remove media share"
+msgstr "Usuń udział"
+
+#: id:21366
+msgid "Subtitle folder"
+msgstr "Katalog z napisami"
+
+#: id:21367
+msgid "Movie & alternate subtitle directory"
+msgstr "Filmy i alternatywny katalog dla napisów"
+
+#: id:21368
+msgid "Override ASS/SSA subtitles fonts"
+msgstr "Pomiń ustawienia czcionek napisów ASS/SSA"
+
+#: id:21369
+msgid "Enable mouse and Touch Screen support"
+msgstr "Włącz obsługę myszy"
+
+#: id:21370
+msgid "Play navigation sounds during media playback"
+msgstr "Dźwięki nawigacyjne podczas odtwarzania mediów"
+
+#: id:21371
+msgid "Thumbnail"
+msgstr "Miniaturka"
+
+#: id:21372
+msgid "Forced DVD player region"
+msgstr "Narzuć region dla DVD"
+
+#: id:21373
+msgid "Video output"
+msgstr "Wyjście wideo"
+
+#: id:21374
+msgid "Video aspect"
+msgstr "Proporcje obrazu"
+
+#: id:21375
+msgctxt "Auto context with id 21375"
+msgid "Normal"
+msgstr "Zwykły"
+
+#: id:21376
+msgid "Letterbox"
+msgstr "Letterbox"
+
+#: id:21377
+msgid "Widescreen"
+msgstr "Panoramiczny"
+
+#: id:21378
+msgid "Enable 480p"
+msgstr "Uaktywnij 480p"
+
+#: id:21379
+msgid "Enable 720p"
+msgstr "Uaktywnij 720p"
+
+#: id:21380
+msgid "Enable 1080i"
+msgstr "Uaktywnij 1080i"
+
+#: id:21381
+msgid "Enter name of new playlist"
+msgstr "Wprowadź nazwę nowej playlisty"
+
+#: id:21382
+msgid "Show \"Add source\" buttons in file lists"
+msgstr "Pokaż przycisk \"Dodaj źródło\" w liście plików"
+
+#: id:21383
+msgid "Enable scrollbars"
+msgstr "Pokazuj pasek przewijania"
+
+#: id:21384
+msgid "Make watched filtering a toggle in video library"
+msgstr "Filtrowanie oglądanych pozycji jako przełącznik w trybie biblioteki"
+
+#: id:21385
+msgctxt "Auto context with id 21385"
+msgid "Open"
+msgstr "Otwórz"
+
+#: id:21386
+msgid "Acoustic management level"
+msgstr "Poziomem głośności pracy"
+
+#: id:21387
+msgid "Fast"
+msgstr "Szybki"
+
+#: id:21388
+msgid "Quiet"
+msgstr "Cichy"
+
+#: id:21389
+msgid "Enable custom background"
+msgstr "Ustaw własne zdjęcie jako tło"
+
+#: id:21390
+msgid "Power management level"
+msgstr "Zarządzanie poziomem użycia energii"
+
+#: id:21391
+msgid "High power"
+msgstr "wysokie zużycie"
+
+#: id:21392
+msgid "Low power"
+msgstr "niskie zużycie"
+
+#: id:21393
+msgid "High standby"
+msgstr ""
+
+#: id:21394
+msgid "Low standby"
+msgstr ""
+
+#: id:21395
+msgid "Unable to cache files bigger than 4GB"
+msgstr "Nie mogę trzymać w pamięci podręcznej plików powyżej 4 GB"
+
+#: id:21396
+msgid "Chapter"
+msgstr "Rozdział"
+
+#: id:21397
+msgid "High quality pixel shader v2"
+msgstr "Pixel shader v2 HQ"
+
+#: id:21398
+msgid "Enable playlist at startup"
+msgstr "Włącz playlistę na starcie"
+
+#: id:21399
+msgid "Use tween animations"
+msgstr "Używaj animacji przejściowych"
+
+#: id:21400
+msgid "contains"
+msgstr "zawiera"
+
+#: id:21401
+msgid "does not contain"
+msgstr "nie zawiera"
+
+#: id:21402
+msgid "is"
+msgstr "jest"
+
+#: id:21403
+msgid "is not"
+msgstr "nie jest"
+
+#: id:21404
+msgid "starts with"
+msgstr "zaczyna od"
+
+#: id:21405
+msgid "ends with"
+msgstr "kończy na"
+
+#: id:21406
+msgid "greater than"
+msgstr "więcej niż"
+
+#: id:21407
+msgid "less than"
+msgstr "mniej niż"
+
+#: id:21408
+msgid "after"
+msgstr "po"
+
+#: id:21409
+msgid "before"
+msgstr "przed"
+
+#: id:21410
+msgid "in the last"
+msgstr "w ostatnich"
+
+#: id:21411
+msgid "not in the last"
+msgstr "nie w ostatnich"
+
+#: id:21412
+msgid "Scrapers"
+msgstr "Scrapery"
+
+#: id:21413
+msgid "Default movie scraper"
+msgstr "Domyślny dla filmów"
+
+#: id:21414
+msgid "Default tvshow scraper"
+msgstr "Domyślny dla seriali"
+
+#: id:21415
+msgid "Default music video scraper"
+msgstr "Domyślny dla teledysków"
+
+#: id:21416
+msgid "Enable fallback based on scraper language"
+msgstr "Włącz powrót bazując na języku scrapera"
+
+#: id:21417
+msgid "- Settings"
+msgstr "- Ustawienia"
+
+#: id:21418
+msgid "Multilingual"
+msgstr "wielojęzyczny"
+
+#: id:21419
+msgid "No scrapers present"
+msgstr "Brak scraperów"
+
+#: id:21420
+msgid "Value to match"
+msgstr "Wartości do spełnienia"
+
+#: id:21421
+msgid "Smart playlist rule"
+msgstr "Kryteria playlisty (smart)"
+
+#: id:21422
+msgid "Match items where"
+msgstr "Dopasuj pozycje gdzie"
+
+#: id:21423
+msgid "New rule..."
+msgstr "Nowe kryterium..."
+
+#: id:21424
+msgid "Items must match"
+msgstr "Pozycje muszą spełniać"
+
+#: id:21425
+msgid "all of the rules"
+msgstr "wszystkie kryteria"
+
+#: id:21426
+msgid "one or more of the rules"
+msgstr "przynajmniej jedno kryterium"
+
+#: id:21427
+msgid "Limit to"
+msgstr "ogranicz do"
+
+#: id:21428
+msgid "No limit"
+msgstr "bez ograniczeń"
+
+#: id:21429
+msgid "Order by"
+msgstr "Sortuj"
+
+#: id:21430
+msgid "ascending"
+msgstr "rosnąco"
+
+#: id:21431
+msgid "descending"
+msgstr "malejąco"
+
+#: id:21432
+msgid "Edit smart playlist"
+msgstr "Edytuj playlistę (smart)"
+
+#: id:21433
+msgid "Name of the playlist"
+msgstr "Nazwa playlisty"
+
+#: id:21434
+msgid "Find items where"
+msgstr "Znajdź pozycje gdzie"
+
+#: id:21435
+msgid "Edit"
+msgstr "- Edytuj"
+
+#: id:21436
+msgid "%i items"
+msgstr "%i pozycji"
+
+#: id:21437
+msgid "New smart playlist..."
+msgstr "Nowa playlista (smart)"
+
+#: id:21438
+msgid "%c Drive"
+msgstr "Dysk %c"
+
+#: id:21439
+msgid "Edit party mode rules"
+msgstr "Edytuj kryteria dla Trybu Imprezy"
+
+#: id:21440
+msgid "Home folder"
+msgstr "Katalog domowy"
+
+#: id:21441
+msgid "Watched count"
+msgstr "Oglądnięć"
+
+#: id:21442
+msgid "Episode title"
+msgstr "Tytuł odcinka"
+
+#: id:21443
+msgid "Video resolution"
+msgstr "Rozdzielczość wideo"
+
+#: id:21444
+msgid "Audio channels"
+msgstr "Kanały audio"
+
+#: id:21445
+msgid "Video codec"
+msgstr "Kodek wideo"
+
+#: id:21446
+msgid "Audio codec"
+msgstr "Kodek audio"
+
+#: id:21447
+msgid "Audio language"
+msgstr "Język dialogów"
+
+#: id:21448
+msgid "Subtitle language"
+msgstr "Język napisów"
+
+#: id:21449
+msgid "Remote control sends keyboard presses"
+msgstr "Przyciski pilota emulują naciśnięcia klawiszy"
+
+#: id:21450
+msgid "- Edit"
+msgstr "- Edytuj"
+
+#: id:21451
+msgid "Internet connection required."
+msgstr "Wymagane połączenie z Internetem."
+
+#: id:21452
+msgid "Get More..."
+msgstr "Pobierz więcej..."
+
+#: id:21453
+msgid "Root filesystem"
+msgstr "Główny system plików"
+
+#: id:21454
+msgid "Cache full"
+msgstr "Pełny bufor"
+
+#: id:21455
+msgid "Cache filled before reaching required amount for continous playback"
+msgstr "Bufor wypełniany zanim osiągnie wymagany poziom do ciągłego odtwarzania"
+
+#: id:21460
+msgid "Subtitle location"
+msgstr "Położenie napisów"
+
+#: id:21461
+msgid "Fixed"
+msgstr "Stałe"
+
+#: id:21462
+msgid "Bottom of video"
+msgstr "Dół wideo"
+
+#: id:21463
+msgid "Below video"
+msgstr "Poniżej wideo"
+
+#: id:21464
+msgid "Top of video"
+msgstr "Góra wideo"
+
+#: id:21465
+msgid "Above video"
+msgstr "Powyżej wideo"
+
+#: id:21800
+msgid "File name"
+msgstr "Nazwa pliku"
+
+#: id:21801
+msgid "File path"
+msgstr "Lokalizacja"
+
+#: id:21802
+msgid "File size"
+msgstr "Rozmiar"
+
+#: id:21803
+msgid "File date/time"
+msgstr "Data/czas pliku"
+
+#: id:21804
+msgid "Slide index"
+msgstr "Indeks slajdu"
+
+#: id:21805
+msgctxt "Auto context with id 21805"
+msgid "Resolution"
+msgstr "Rozdzielczość"
+
+#: id:21806
+msgctxt "Auto context with id 21806"
+msgid "Comment"
+msgstr "Komentarz"
+
+#: id:21807
+msgid "Colour/B&W"
+msgstr "Kolorowe/czarno-białe"
+
+#: id:21808
+msgid "JPEG process"
+msgstr ""
+
+#: id:21820
+msgid "Date/Time"
+msgstr "Data/godzina"
+
+#: id:21821
+msgid "Description"
+msgstr "Opis"
+
+#: id:21822
+msgid "Camera make"
+msgstr "Marka aparatu"
+
+#: id:21823
+msgid "Camera model"
+msgstr "Model aparatu"
+
+#: id:21824
+msgid "EXIF comment"
+msgstr "Komentarz Exif"
+
+#: id:21825
+msgid "Firmware"
+msgstr "Oprogramowanie"
+
+#: id:21826
+msgid "Aperture"
+msgstr "Przesłona"
+
+#: id:21827
+msgid "Focal length"
+msgstr "Ogniskowa"
+
+#: id:21828
+msgid "Focus distance"
+msgstr "Nastawiona ostrość"
+
+#: id:21829
+msgid "Exposure"
+msgstr "Ekspozycja"
+
+#: id:21830
+msgid "Exposure time"
+msgstr "Czas ekspozycji"
+
+#: id:21831
+msgid "Exposure bias"
+msgstr "Korekta ekspozycji"
+
+#: id:21832
+msgid "Exposure mode"
+msgstr "Tryb ekspozycji"
+
+#: id:21833
+msgid "Flash used"
+msgstr "Lampa błyskowa"
+
+#: id:21834
+msgid "White-balance"
+msgstr "Balans bieli"
+
+#: id:21835
+msgid "Light source"
+msgstr "Źródło światła"
+
+#: id:21836
+msgid "Metering mode"
+msgstr "Tryb pomiaru"
+
+#: id:21837
+msgid "ISO"
+msgstr "Czułość ISO"
+
+#: id:21838
+msgid "Digital zoom"
+msgstr "Cyfrowy zoom"
+
+#: id:21839
+msgid "CCD width"
+msgstr "Szerokość CCD"
+
+#: id:21840
+msgid "GPS latitude"
+msgstr "Szerokość geograficzna (GPS)"
+
+#: id:21841
+msgid "GPS longitude"
+msgstr "Długość geograficzna (GPS)"
+
+#: id:21842
+msgid "GPS altitude"
+msgstr "Wysokość bezwzględna (GPS)"
+
+#: id:21843
+msgid "Orientation"
+msgstr "Orientacja"
+
+#: id:21860
+msgid "Supplemental categories"
+msgstr "Kategorie dodatkowe"
+
+#: id:21861
+msgid "Keywords"
+msgstr "Słowa kluczowe"
+
+#: id:21862
+msgid "Caption"
+msgstr "Podpis"
+
+#: id:21863
+msgid "Author"
+msgstr "Autor"
+
+#: id:21864
+msgid "Headline"
+msgstr "Nagłówek"
+
+#: id:21865
+msgid "Special instructions"
+msgstr "Specjalne instrukcje"
+
+#: id:21866
+msgid "Category"
+msgstr "Kategoria"
+
+#: id:21867
+msgid "Byline"
+msgstr "Łącze autora"
+
+#: id:21868
+msgid "Byline title"
+msgstr "Nazwa łącza"
+
+#: id:21869
+msgid "Credit"
+msgstr "Lista zasług"
+
+#: id:21870
+msgid "Source"
+msgstr "Źródło"
+
+#: id:21871
+msgid "Copyright notice"
+msgstr "Prawa autorskie"
+
+#: id:21872
+msgid "Object name"
+msgstr "Nazwa obiektu"
+
+#: id:21873
+msgid "City"
+msgstr "Miasto"
+
+#: id:21874
+msgid "State"
+msgstr "Prowincja/stan"
+
+#: id:21875
+msgctxt "Auto context with id 21875"
+msgid "Country"
+msgstr "Kraj"
+
+#: id:21876
+msgid "Original Tx Reference"
+msgstr "Wybór odwołania do źródła"
+
+#: id:21877
+msgid "Date created"
+msgstr "Data utworzenia"
+
+#: id:21878
+msgid "Copyright flag"
+msgstr "Identyfikator przynależności"
+
+#: id:21879
+msgid "Country code"
+msgstr "Kod kraju"
+
+#: id:21880
+msgid "Reference service"
+msgstr "Odwołanie do usługi"
+
+#: id:21881
+msgid "Allow control of XBMC via UPnP"
+msgstr "Zezwalaj na sterowanie XBMC poprzez UPnP"
+
+#: id:21882
+msgid "Attempt to skip introduction before DVD menu"
+msgstr "Próbuj przeskoczyć wstęp przed menu DVD"
+
+#: id:21883
+msgid "Saved music"
+msgstr "Zapisana muzyka"
+
+#: id:21884
+msgid "Query info for all artists"
+msgstr "Info do wszystkich artystów"
+
+#: id:21885
+msgid "Downloading album information"
+msgstr "Pobieram informacje o albumie"
+
+#: id:21886
+msgid "Downloading artist information"
+msgstr "Pobieram informacje o artyście"
+
+#: id:21887
+msgid "Biography"
+msgstr "Biografia"
+
+#: id:21888
+msgid "Discography"
+msgstr "Dyskografia"
+
+#: id:21889
+msgid "Searching artist"
+msgstr "Szukam artysty"
+
+#: id:21890
+msgid "Select artist"
+msgstr "Wybierz artystę"
+
+#: id:21891
+msgctxt "Auto context with id 21891"
+msgid "Artist information"
+msgstr "Info o artyście"
+
+#: id:21892
+msgid "Instruments"
+msgstr "Instrumenty"
+
+#: id:21893
+msgid "Born"
+msgstr "Data urodzenia"
+
+#: id:21894
+msgid "Formed"
+msgstr "Data powstania"
+
+#: id:21895
+msgid "Themes"
+msgstr "Motywy"
+
+#: id:21896
+msgid "Disbanded"
+msgstr "Rozwiązana"
+
+#: id:21897
+msgid "Died"
+msgstr "Data śmierci"
+
+#: id:21898
+msgid "Years active"
+msgstr "Lata aktywności"
+
+#: id:21899
+msgid "Label"
+msgstr "Identyfikator"
+
+#: id:21900
+msgid "Born/Formed"
+msgstr "Data urodzenia/powstania"
+
+#: id:22000
+msgid "Update library on startup"
+msgstr "Aktualizuj bibliotekę na starcie"
+
+#: id:22001
+msgid "Hide progress of library updates"
+msgstr "Ukryj postęp aktualizacji biblioteki"
+
+#: id:22002
+msgid "- DNS suffix"
+msgstr "- Sufiks DNS"
+
+#: id:22003
+msgid "%2.3fs"
+msgstr "%2.3fs"
+
+#: id:22004
+msgid "Delayed by: %2.3fs"
+msgstr "Opóźnij o: %2.3fs"
+
+#: id:22005
+msgid "Ahead by: %2.3fs"
+msgstr "Przyspiesz o: %2.3fs"
+
+#: id:22006
+msgid "Subtitle offset"
+msgstr "Przesunięcie napisów"
+
+#: id:22007
+msgid "OpenGL vendor:"
+msgstr "Dostawca OpenGL:"
+
+#: id:22008
+msgid "OpenGL renderer:"
+msgstr "Renderer OpenGL:"
+
+#: id:22009
+msgid "OpenGL version:"
+msgstr "Wersja OpenGL:"
+
+#: id:22010
+msgid "GPU temperature:"
+msgstr "Temperatura GPU:"
+
+#: id:22011
+msgid "CPU temperature:"
+msgstr "Temperatura CPU:"
+
+#: id:22012
+msgid "Total memory"
+msgstr "Całkowity rozmiar pamięci"
+
+#: id:22013
+msgid "Profile data"
+msgstr "Dane profilu"
+
+#: id:22014
+msgid "Use dim if paused during video playback"
+msgstr "Przyciemniaj podczas pauzy w odtwarzaniu"
+
+#: id:22015
+msgid "All recordings"
+msgstr "Wszystkie nagrania"
+
+#: id:22016
+msgid "By title"
+msgstr "po tytułach"
+
+#: id:22017
+msgid "By group"
+msgstr "po grupach"
+
+#: id:22018
+msgid "Live channels"
+msgstr "Kanały \"na żywo\""
+
+#: id:22019
+msgid "Recordings by title"
+msgstr "Nagrania po tytułach"
+
+#: id:22020
+msgid "Guide"
+msgstr "Program"
+
+#: id:22021
+msgid "Allowed error in aspect ratio to minimize black bars"
+msgstr "Dopuszczaj błąd w proporcji obrazu i minimalizuj czarne pasy"
+
+#: id:22022
+msgid "Show video files in listings"
+msgstr "Pokazuj pliki wideo w listach"
+
+#: id:22023
+msgid "DirectX vendor:"
+msgstr "Dostawca DirectX:"
+
+#: id:22024
+msgid "Direct3D version:"
+msgstr "Wersja Direct3D:"
+
+#: id:22030
+msgctxt "Auto context with id 22030"
+msgid "Font"
+msgstr "Czcionka"
+
+#: id:22031
+msgctxt "Auto context with id 22031"
+msgid "- Size"
+msgstr "- Rozmiar"
+
+#: id:22032
+msgctxt "Auto context with id 22032"
+msgid "- Colours"
+msgstr "- Kolor"
+
+#: id:22033
+msgid "- Charset"
+msgstr "- Zestaw znaków"
+
+#: id:22034
+msgid "Export karaoke titles as HTML"
+msgstr "Eksportuj tytuły karaoke jako HTML"
+
+#: id:22035
+msgid "Export karaoke titles as CSV"
+msgstr "Eksportuj tytuły karaoke jako CSV"
+
+#: id:22036
+msgid "Import karaoke titles..."
+msgstr "Importuj tytuły karaoke.."
+
+#: id:22037
+msgid "Show song selector automatically"
+msgstr "Automatycznie pokazuj okno wyboru utworu"
+
+#: id:22038
+msgid "Export karaoke titles..."
+msgstr "Eksportuj tytuły karaoke..."
+
+#: id:22039
+msgid "Enter song number"
+msgstr "Wprowadź numer utworu"
+
+#: id:22040
+msgid "white/green"
+msgstr "biało/zielona"
+
+#: id:22041
+msgid "white/red"
+msgstr "biało/czerwona"
+
+#: id:22042
+msgid "white/blue"
+msgstr "biało/niebieska"
+
+#: id:22043
+msgid "black/white"
+msgstr "czarno/biała"
+
+#: id:22079
+msgid "Default select action"
+msgstr "Domyślna akcja wyboru"
+
+#: id:22080
+msgid "Choose"
+msgstr "Wybierz"
+
+#: id:22081
+msgid "Show Information"
+msgstr "Pokaż informacje"
+
+#: id:22082
+msgid "More..."
+msgstr "Więcej..."
+
+#: id:22083
+msgid "Play all"
+msgstr "Odtwórz wszystko"
+
+#: id:23049
+msgid "Teletext not available"
+msgstr "Teletekst niedostępny"
+
+#: id:23050
+msgid "Activate Teletext"
+msgstr "Włącz Teletekst"
+
+#: id:23051
+msgid "Part %i"
+msgstr "Część %i"
+
+#: id:23052
+msgid "Buffering %i bytes"
+msgstr "Ładowanie %i bajtów"
+
+#: id:23053
+msgid "Stopping"
+msgstr "Zatrzymuję"
+
+#: id:23054
+msgid "Running"
+msgstr "Uruchomiony"
+
+#: id:23100
+msgid "External Player Active"
+msgstr "Działa zewnętrzny odtwarzacz"
+
+#: id:23101
+msgid "Click OK to terminate the player"
+msgstr "Naciśnij OK, aby wyłączyć odtwarzacz"
+
+#: id:23104
+msgid "Click OK when playback has ended"
+msgstr "Naciśnij OK po zakończeniu odtwarzania"
+
+#: id:24000
+msgid "Add-on"
+msgstr "Wtyczka"
+
+#: id:24001
+msgid "Add-ons"
+msgstr "Wtyczki"
+
+#: id:24002
+msgid "Add-on options"
+msgstr "Opcje wtyczki"
+
+#: id:24003
+msgid "Add-on Information"
+msgstr "O wtyczce"
+
+#: id:24005
+msgctxt "Auto context with id 24005"
+msgid "Media sources"
+msgstr "Źródła mediów"
+
+#: id:24007
+msgctxt "Auto context with id 24007"
+msgid "Movie information"
+msgstr "O filmie"
+
+#: id:24008
+msgctxt "Auto context with id 24008"
+msgid "Screensaver"
+msgstr "Wygaszacz ekranu"
+
+#: id:24009
+msgid "Script"
+msgstr "Skrypt"
+
+#: id:24010
+msgctxt "Auto context with id 24010"
+msgid "Visualization"
+msgstr "Wizualizacja"
+
+#: id:24011
+msgid "Add-on repository"
+msgstr "Repozytorium wtyczek"
+
+#: id:24012
+msgctxt "Auto context with id 24012"
+msgid "Subtitles"
+msgstr "Napisy"
+
+#: id:24013
+msgid "Lyrics"
+msgstr "Tekst piosenki"
+
+#: id:24014
+msgid "TV information"
+msgstr "O TV"
+
+#: id:24015
+msgctxt "Auto context with id 24015"
+msgid "Music video information"
+msgstr "O teledysku"
+
+#: id:24016
+msgctxt "Auto context with id 24016"
+msgid "Album information"
+msgstr "O albumie"
+
+#: id:24017
+msgctxt "Auto context with id 24017"
+msgid "Artist information"
+msgstr "O artyście"
+
+#: id:24018
+msgctxt "Auto context with id 24018"
+msgid "Services"
+msgstr "Usługi"
+
+#: id:24020
+msgid "Configure"
+msgstr "Ustaw"
+
+#: id:24021
+msgctxt "Auto context with id 24021"
+msgid "Disable"
+msgstr "Wyłącz"
+
+#: id:24022
+msgid "Enable"
+msgstr "Włącz"
+
+#: id:24023
+msgid "Add-on disabled"
+msgstr "Wtyczka wyłączona"
+
+#: id:24027
+msgctxt "Auto context with id 24027"
+msgid "Weather"
+msgstr "Pogoda"
+
+#: id:24028
+msgid "Weather.com (standard)"
+msgstr "Weather.com (standard)"
+
+#: id:24030
+msgid "This Add-on can not be configured"
+msgstr "Ta wtyczka nie może być skonfigurowana"
+
+#: id:24031
+msgid "Error loading settings"
+msgstr "Błąd wczytywania ustawień"
+
+#: id:24032
+msgid "All Add-ons"
+msgstr "Wszystkie wtyczki"
+
+#: id:24033
+msgid "Get Add-ons"
+msgstr "Pobierz wtyczki"
+
+#: id:24034
+msgid "Check for updates"
+msgstr "Sprawdź aktualizacje"
+
+#: id:24035
+msgid "Force refresh"
+msgstr "Wymuś odświeżenie"
+
+#: id:24036
+msgid "Change log"
+msgstr "Lista zmian"
+
+#: id:24037
+msgid "Uninstall"
+msgstr "Usuń"
+
+#: id:24038
+msgid "Install"
+msgstr "Instaluj"
+
+#: id:24039
+msgid "Disabled Add-ons"
+msgstr "Wyłączone wtyczki"
+
+#: id:24040
+msgid "(Clear the current setting)"
+msgstr "(Wyczyść bieżące ustawienie)"
+
+#: id:24041
+msgid "Install from zip file"
+msgstr "Instaluj z pliku zip"
+
+#: id:24042
+msgid "Downloading %i%%"
+msgstr "Pobieram %i%%"
+
+#: id:24043
+msgid "Available Updates"
+msgstr "Dostępne aktualizacje"
+
+#: id:24044
+msgid "Dependencies not met"
+msgstr "Zależności nie są spełnione"
+
+#: id:24045
+msgid "Add-on does not have the correct structure"
+msgstr "Wtyczka nie ma właściwej struktury"
+
+#: id:24046
+msgid "%s is used by the following installed add-on(s)"
+msgstr "%s jest używany przez następujące zainstalowane wtyczki"
+
+#: id:24047
+msgid "This add-on cannot be uninstalled"
+msgstr "Ta wtyczka nie może zostać usunięta"
+
+#: id:24048
+msgid "Rollback"
+msgstr "Przywróć"
+
+#: id:24050
+msgid "Available Add-ons"
+msgstr "Dostępne wtyczki"
+
+#: id:24051
+msgid "Version:"
+msgstr "Wersja:"
+
+#: id:24052
+msgid "Disclaimer"
+msgstr "Uwagi"
+
+#: id:24053
+msgid "License:"
+msgstr "Licencja:"
+
+#: id:24054
+msgid "Changelog"
+msgstr "Lista zmian"
+
+#: id:24059
+msgid "Would you like to enable this Add-on?"
+msgstr "Czy chcesz włączyć tę wtyczkę?"
+
+#: id:24060
+msgid "Would you like to disable this Add-on?"
+msgstr "Czy chcesz wyłączyć tę wtyczkę?"
+
+#: id:24061
+msgid "Add-on update available!"
+msgstr "Dostępna aktualizacja wtyczki!"
+
+#: id:24062
+msgid "Enabled Add-ons"
+msgstr "Włączone wtyczki"
+
+#: id:24063
+msgid "Auto update"
+msgstr "Auto aktualizacja"
+
+#: id:24064
+msgid "Add-on enabled"
+msgstr "Wtyczka włączona"
+
+#: id:24065
+msgid "Add-on updated"
+msgstr "Wtyczka zaktualizowana"
+
+#: id:24066
+msgid "Cancel Add-on download?"
+msgstr "Anulować pobieranie wtyczek?"
+
+#: id:24067
+msgid "Currently downloading Add-ons"
+msgstr "Aktualnie pobierane wtyczki"
+
+#: id:24068
+msgid "Update available"
+msgstr "Aktualizacja jest dostępna"
+
+#: id:24069
+msgid "Update"
+msgstr "Aktualizacja"
+
+#: id:24070
+msgid "Add-on could not be loaded."
+msgstr "Błąd ładowania wtyczki."
+
+#: id:24071
+msgid "An unknown error has occurred."
+msgstr "Wystąpił nieznany błąd."
+
+#: id:24072
+msgid "Settings required"
+msgstr "Wymagane ustawienia"
+
+#: id:24073
+msgid "Could not connect"
+msgstr "Nie mogę się połączyć"
+
+#: id:24074
+msgid "Needs to restart"
+msgstr "Potrzebny restart"
+
+#: id:24075
+msgctxt "Auto context with id 24075"
+msgid "Disable"
+msgstr "Wyłącz"
+
+#: id:24076
+msgid "Add-on Required"
+msgstr "Wymagany wtyczka"
+
+#: id:24080
+msgid "Try to reconnect?"
+msgstr "Ponowić próbę połączenia?"
+
+#: id:24089
+msgid "Add-on restarts"
+msgstr "Restart wtyczki"
+
+#: id:24090
+msgid "Lock Add-on manager"
+msgstr "Zablokuj menedżer wtyczek"
+
+#: id:24094
+msgid "(current)"
+msgstr "(bieżący)"
+
+#: id:24095
+msgid "(blacklisted)"
+msgstr "(zablokowany)"
+
+#: id:24096
+msgid "Add-on has been marked as broken in repository."
+msgstr "Wtyczkę oznaczono jako uszkodzona w repozytorium."
+
+#: id:24097
+msgid "Would you like to disable it on your system?"
+msgstr "Czy chcesz ją wyłączyć?"
+
+#: id:24098
+msgid "Broken"
+msgstr "Uszkodzona"
+
+#: id:24099
+msgid "Would you like to switch to this skin?"
+msgstr "Chcesz przełączyć się na tę skórę?"
+
+#: id:24100
+msgid "To use this feature you must download an Add-on:"
+msgstr "Aby użyć tej funkcji musisz pobrać:"
+
+#: id:24101
+msgid "Would you like to download this Add-on?"
+msgstr "Czy chcesz pobrać tę wtyczkę?"
+
+#: id:25000
+msgid "Notifications"
+msgstr "Powiadomienia"
+
+#: id:29800
+msgid "Library Mode"
+msgstr "Tryb biblioteki"
+
+#: id:29801
+msgid "QWERTY keyboard"
+msgstr "Klawiatura QWERTY"
+
+#: id:29802
+msgid "Passthrough Audio in use"
+msgstr "Używasz bezpośredniego przejścia dźwięku"
+
+#: id:33001
+msgid "Trailer quality"
+msgstr "Jakość zwiastunu"
+
+#: id:33002
+msgid "Stream"
+msgstr "Strumieniuj"
+
+#: id:33003
+msgid "Download"
+msgstr "Pobierz"
+
+#: id:33004
+msgid "Download & play"
+msgstr "Pobierz i odtwarzaj"
+
+#: id:33005
+msgid "Download & save"
+msgstr "Pobierz i zapisz"
+
+#: id:33006
+msgid "Today"
+msgstr "Dzisiaj"
+
+#: id:33007
+msgid "Tomorrow"
+msgstr "Jutro"
+
+#: id:33008
+msgid "Saving"
+msgstr "Zapisywanie"
+
+#: id:33009
+msgid "Copying"
+msgstr "Kopiowanie"
+
+#: id:33010
+msgid "Set download directory"
+msgstr "Zapisz do"
+
+#: id:33011
+msgid "Search duration"
+msgstr "Czas przeszukiwania"
+
+#: id:33012
+msgid "Short"
+msgstr "Krótki"
+
+#: id:33013
+msgid "Long"
+msgstr "Długi"
+
+#: id:33014
+msgid "Use DVD player instead of regular player"
+msgstr "Użyj odtwarzacza DVD zamiast zwykłego"
+
+#: id:33015
+msgid "Ask for download before playing video"
+msgstr "Przed odtwarzaniem zapytaj czy pobrać"
+
+#: id:33016
+msgid "Clips"
+msgstr "Klipy"
+
+#: id:33017
+msgid "Restart plugin to enable"
+msgstr "Wtyczka wymaga restartu"
+
+#: id:33018
+msgid "Tonight"
+msgstr "Wieczorem"
+
+#: id:33019
+msgid "Tomorrow Night"
+msgstr "Jutro wieczorem"
+
+#: id:33020
+msgid "Condition"
+msgstr "Warunki"
+
+#: id:33021
+msgid "Precipitation"
+msgstr "opady"
+
+#: id:33022
+msgid "Precip"
+msgstr "opadów"
+
+#: id:33023
+msgid "Humid"
+msgstr "Wilgotno"
+
+#: id:33024
+msgid "Feels"
+msgstr "Odczuwalna"
+
+#: id:33025
+msgid "Observed"
+msgstr "Obserwowany"
+
+#: id:33026
+msgid "Departure from normal"
+msgstr ""
+
+#: id:33027
+msgid "Sunrise"
+msgstr "wschód"
+
+#: id:33028
+msgid "Sunset"
+msgstr "zachód"
+
+#: id:33029
+msgid "Details"
+msgstr "Szczegóły"
+
+#: id:33030
+msgid "Outlook"
+msgstr "Prognoza"
+
+#: id:33031
+msgid "Coverflow"
+msgstr ""
+
+#: id:33032
+msgid "Translate text"
+msgstr "Przetłumacz tekst"
+
+#: id:33033
+msgid "Map list %s category"
+msgstr ""
+
+#: id:33034
+msgid "36 Hour"
+msgstr "36 godzin"
+
+#: id:33035
+msgid "Maps"
+msgstr "Mapy"
+
+#: id:33036
+msgid "Hourly"
+msgstr "Co godzinę"
+
+#: id:33037
+msgid "Weekend"
+msgstr "Weekend"
+
+#: id:33038
+msgid "%s day"
+msgstr "%s dzień"
+
+#: id:33049
+msgid "Alert"
+msgstr "Alarm"
+
+#: id:33050
+msgid "Alerts"
+msgstr "Alarmy"
+
+#: id:33051
+msgid "Choose Your"
+msgstr "Wybierz"
+
+#: id:33052
+msgid "Check"
+msgstr "Sprawdź"
+
+#: id:33053
+msgctxt "Auto context with id 33053"
+msgid "Configure the"
+msgstr "Skonfiguruj"
+
+#: id:33054
+msgid "Seasons"
+msgstr "Sezony"
+
+#: id:33055
+msgid "Use your"
+msgstr ""
+
+#: id:33056
+msgid "Watch your"
+msgstr "Oglądaj"
+
+#: id:33057
+msgid "Listen to"
+msgstr "Słuchaj"
+
+#: id:33058
+msgid "View your"
+msgstr "Przeglądaj"
+
+#: id:33059
+msgctxt "Auto context with id 33059"
+msgid "Configure the"
+msgstr "Skonfiguruj"
+
+#: id:33060
+msgid "Power"
+msgstr "Zasilanie"
+
+#: id:33061
+msgid "Menu"
+msgstr "Menu"
+
+#: id:33062
+msgid "Play the"
+msgstr "Odtwarzaj"
+
+#: id:33063
+msgid "Options"
+msgstr "Opcje"
+
+#: id:33065
+msgid "Editor"
+msgstr "Edytor"
+
+#: id:33066
+msgid "About your"
+msgstr "O"
+
+#: id:33067
+msgid "Star rating"
+msgstr "Ocena \"gwiazdkowa\""
+
+#: id:33068
+msgid "Background"
+msgstr "Tło"
+
+#: id:33069
+msgid "Backgrounds"
+msgstr "Tła"
+
+#: id:33070
+msgid "Custom background"
+msgstr "Własne tło"
+
+#: id:33071
+msgid "Custom backgrounds"
+msgstr "Własne tła"
+
+#: id:33072
+msgid "View Readme"
+msgstr "Przeglądaj Readme"
+
+#: id:33073
+msgid "View Changelog"
+msgstr "Przeglądaj Changelog"
+
+#: id:33074
+msgid "This version of %s requires an"
+msgstr "Ta wersja %s wymaga"
+
+#: id:33075
+msgid "XBMC revision of %s or greater to run."
+msgstr "Wymagany XBMC w wydaniu %s lub wyższym."
+
+#: id:33076
+msgid "Please update XBMC."
+msgstr "Zaktualizuj XBMC."
+
+#: id:33077
+msgid "No data found!"
+msgstr "Dane niedostępne!"
+
+#: id:33078
+msgid "Next page"
+msgstr "Następna strona"
+
+#: id:33079
+msgid "Love"
+msgstr "Lubię"
+
+#: id:33080
+msgid "Hate"
+msgstr "Nie lubię"
+
+#: id:33081
+msgid "This file is stacked, select the part you want to play from."
+msgstr "Plik znajduje się w stosie, wybierz część którą chcesz odtwarzać."
+
+#: id:33082
+msgid "Path to script"
+msgstr "Ścieżka do skryptu"
+
+#: id:33083
+msgid "Enable custom script button"
+msgstr "Włącz przycisk własnego skryptu"
+
+#: id:33100
+msgid "Failed to start"
+msgstr "Błąd przy uruchomieniu"
+
+#: id:33101
+msgid "Webserver"
+msgstr "Serwer WWW"
+
+#: id:33102
+msgid "Event Server"
+msgstr "Serwer zdarzeń"
+
+#: id:33103
+msgid "Remote communication server"
+msgstr "Serwer zdalnej komunikacji"
+
+#: id:33200
+msgid "Detected New Connection"
+msgstr "Wykryto nowe połączenie"
+
+#: id:34000
+msgid "Lame"
+msgstr ""
+
+#: id:34001
+msgid "Vorbis"
+msgstr ""
+
+#: id:34002
+msgid "Wav"
+msgstr ""
+
+#: id:34003
+msgid "DXVA2"
+msgstr ""
+
+#: id:34004
+msgid "VAAPI"
+msgstr ""
+
+#: id:34005
+msgid "Flac"
+msgstr ""
+
+#: id:34100
+msgid "Speaker Configuration"
+msgstr "System głośników"
+
+#: id:34101
+msgid "2.0"
+msgstr ""
+
+#: id:34102
+msgid "2.1"
+msgstr ""
+
+#: id:34103
+msgid "3.0"
+msgstr ""
+
+#: id:34104
+msgid "3.1"
+msgstr ""
+
+#: id:34105
+msgid "4.0"
+msgstr ""
+
+#: id:34106
+msgid "4.1"
+msgstr ""
+
+#: id:34107
+msgid "5.0"
+msgstr ""
+
+#: id:34108
+msgid "5.1"
+msgstr ""
+
+#: id:34109
+msgid "7.0"
+msgstr ""
+
+#: id:34110
+msgid "7.1"
+msgstr ""
+
+#: id:34201
+msgid "Can't find a next item to play"
+msgstr "Nie mogę znaleźć następnej pozycji do odtworzenia"
+
+#: id:34202
+msgid "Can't find a previous item to play"
+msgstr "Nie mogę znaleźć poprzedniej pozycji do odtworzenia"
+
+#: id:34300
+msgid "Failed to start zeroconf"
+msgstr "Błąd podczas startu zeroconf"
+
+#: id:34301
+msgid "Is Apple's Bonjour Service installed? See log for more info."
+msgstr "Usługa Apple Bonjour jest zainstalowana? Sprawdź log."
+
+#: id:34400
+msgid "Video Rendering"
+msgstr "Rendering wideo"
+
+#: id:34401
+msgid "Failed to init video filters/scalers, falling back to bilinear scaling"
+msgstr "Błąd inicjalizacji filtrów/skalerów wideo, powracam do skalowania bilinearnego"
+
+#: id:34402
+msgid "Failed to initialize audio device"
+msgstr "Błąd inicjalizacji urządzenia audio"
+
+#: id:34403
+msgid "Check your audiosettings"
+msgstr "Sprawdź ustawienia dźwięku"
+
+#: id:34404
+msgid "Use gestures for navigation:"
+msgstr ""
+
+#: id:34405
+msgid "1 finger swipe left,right,up,down for cursors"
+msgstr ""
+
+#: id:34406
+msgid "2 finger swipe left for backspace"
+msgstr ""
+
+#: id:34407
+msgid "1 finger single tap for enter"
+msgstr ""
+
+#: id:34408
+msgid "2 finger single tap for contextmenu"
+msgstr ""
+
+#: id:35000
+msgid "Peripherals"
+msgstr "Peryferia"
+
+#: id:35001
+msgid "Generic HID device"
+msgstr "Standardowe urządzenie HID"
+
+#: id:35002
+msgid "Generic network adapter"
+msgstr "Standardowy adapter sieciowy"
+
+#: id:35003
+msgid "Generic disk"
+msgstr "Standardowy dysk"
+
+#: id:35004
+msgid "There are no settings available\nfor this peripheral."
+msgstr "To urządzenie nie ma ustawień."
+
+#: id:35005
+msgid "New device configured"
+msgstr "Skonfigurowano nowe urządzenie"
+
+#: id:35006
+msgid "Device removed"
+msgstr "Usunięto urządzenie"
+
+#: id:35007
+msgid "Keymap to use for this device"
+msgstr "Mapa klawiszy do użycia z tym urządzeniem"
+
+#: id:35008
+msgid "Keymap enabled"
+msgstr "Mapa klawiszy włączona"
+
+#: id:35009
+msgid "Do not use the custom keymap for this device"
+msgstr ""
+
+#: id:35500
+msgid "Location"
+msgstr "Położenie"
+
+#: id:35501
+msgid "Class"
+msgstr "Klasa"
+
+#: id:35502
+msgctxt "Auto context with id 35502"
+msgid "Name"
+msgstr "Nazwa"
+
+#: id:35503
+msgid "Vendor"
+msgstr "Dostawca"
+
+#: id:35504
+msgid "Product ID"
+msgstr "ID produktu"
+
+#: id:36000
+msgid "Pulse-Eight CEC adapter"
+msgstr "Adapter Pulse-Eight CEC"
+
+#: id:36001
+msgid "Pulse-Eight Nyxboard"
+msgstr ""
+
+#: id:36002
+msgid "Switch to keyboard side command"
+msgstr ""
+
+#: id:36003
+msgid "Switch to remote side command"
+msgstr ""
+
+#: id:36004
+msgid "Press \"user\" button command"
+msgstr ""
+
+#: id:36005
+msgid "Enable switch side commands"
+msgstr ""
+
+#: id:36006
+msgid "Could not open the adapter"
+msgstr "Nie mogę połączyć się z adapterem"
+
+#: id:36007
+msgid "Devices to power on when starting XBMC"
+msgstr "Włącz TV, kiedy uruchomiany jest XBMC"
+
+#: id:36008
+msgid "Devices to power off when stopping XBMC"
+msgstr "Wyłącz TV, kiedy wyłączany jest XBMC"
+
+#: id:36009
+msgid "Put devices in standby mode when activating screensaver"
+msgstr "Włącz tryb czuwania w urządzeniach, kiedy aktywny jest wygaszacz ekranu"
+
+#: id:36011
+msgid "Could not detect the CEC port. Set it up manually."
+msgstr "Nie mogę wykryć portu CEC. Ustaw go ręcznie."
+
+#: id:36012
+msgid "Could not initialise the CEC adapter. Check your settings."
+msgstr "Nie mogę wykryć adaptera CEC."
+
+#: id:36013
+msgid "Unsupported libCEC interface version. %d is greater than the version XBMC supports (%d)"
+msgstr "Nieaktualna wersja interfejsu libcec. %d jest wyższy niż wersja wspierana przez XBMC (%d)"
+
+#: id:36014
+msgid "Put this PC in standby mode when the TV is switched off"
+msgstr "Włącz tryb czuwania tego PC, kiedy TV jest wyłączony"
+
+#: id:36015
+msgid "HDMI port number"
+msgstr "Numer portu HDMI"
+
+#: id:36016
+msgctxt "Auto context with id 36016"
+msgid "Connected"
+msgstr "Połączono"
+
+#: id:36017
+msgid "Adapter found, but libCEC is not available"
+msgstr "Znaleziono adapter, ale brak biblioteki libcec"
+
+#: id:36018
+msgid "Use the TV's language setting"
+msgstr "Użyj ustawienia języka z TV"
+
+#: id:36019
+msgid "Connected to HDMI device"
+msgstr ""
+
+#: id:36020
+msgid "Make XBMC the active source when starting"
+msgstr ""
+
+#: id:36021
+msgid "Physical address (overrules HDMI port)"
+msgstr ""
+
+#: id:36022
+msgid "COM port (leave empty unless needed)"
+msgstr ""
+
+#: id:36023
+msgid "Configuration updated"
+msgstr ""
+
+#: id:36024
+msgid "Failed to set the new configuration. Please check your settings."
+msgstr ""
+
+#: id:36025
+msgid "Send 'inactive source' command when stopping XBMC"
+msgstr ""
+

--- a/language/Portuguese (Brazil)/strings.po
+++ b/language/Portuguese (Brazil)/strings.po
@@ -1,0 +1,9093 @@
+# Converted from xbmc strings.xml with xbmc-xml2po (by Team-XBMC)
+msgid ""
+msgstr ""
+"Project-Id-Version: xbmc.core-FRODO_GIT3ed1604ad7\n"
+"Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
+"POT-Creation-Date: 2012-04-09 18:00+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE\n"
+"Language: pt_BR\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: id:0
+msgctxt "Auto context with id 0"
+msgid "Programs"
+msgstr "Programas"
+
+#: id:1
+msgctxt "Auto context with id 1"
+msgid "Pictures"
+msgstr "Imagens"
+
+#: id:2
+msgctxt "Auto context with id 2"
+msgid "Music"
+msgstr "Músicas"
+
+#: id:3
+msgctxt "Auto context with id 3"
+msgid "Videos"
+msgstr "Vídeos"
+
+#: id:4
+msgid "TV-Guide"
+msgstr "Guia de TV"
+
+#: id:5
+msgctxt "Auto context with id 5"
+msgid "Settings"
+msgstr "Opções"
+
+#: id:6
+msgid "XBMC SVN"
+msgstr "XBMC SVN"
+
+#: id:7
+msgctxt "Auto context with id 7"
+msgid "File manager"
+msgstr "Arquivos"
+
+#: id:8
+msgctxt "Auto context with id 8"
+msgid "Weather"
+msgstr "Tempo"
+
+#: id:9
+msgid "xbmc media center"
+msgstr "xbmc media center"
+
+#: id:11
+msgid "Monday"
+msgstr "Segunda"
+
+#: id:12
+msgid "Tuesday"
+msgstr "Terça"
+
+#: id:13
+msgid "Wednesday"
+msgstr "Quarta"
+
+#: id:14
+msgid "Thursday"
+msgstr "Quinta"
+
+#: id:15
+msgid "Friday"
+msgstr "Sexta"
+
+#: id:16
+msgid "Saturday"
+msgstr "Sábado"
+
+#: id:17
+msgid "Sunday"
+msgstr "Domingo"
+
+#: id:21
+msgid "January"
+msgstr "Janeiro"
+
+#: id:22
+msgid "February"
+msgstr "Fevereiro"
+
+#: id:23
+msgid "March"
+msgstr "Março"
+
+#: id:24
+msgid "April"
+msgstr "Abril"
+
+#: id:25
+msgctxt "Auto context with id 25"
+msgid "May"
+msgstr "Maio"
+
+#: id:26
+msgid "June"
+msgstr "Junho"
+
+#: id:27
+msgid "July"
+msgstr "Julho"
+
+#: id:28
+msgid "August"
+msgstr "Agosto"
+
+#: id:29
+msgid "September"
+msgstr "Setembro"
+
+#: id:30
+msgid "October"
+msgstr "Outubro"
+
+#: id:31
+msgid "November"
+msgstr "Novembro"
+
+#: id:32
+msgid "December"
+msgstr "Dezembro"
+
+#: id:41
+msgid "Mon"
+msgstr "Seg"
+
+#: id:42
+msgid "Tue"
+msgstr "Ter"
+
+#: id:43
+msgid "Wed"
+msgstr "Qua"
+
+#: id:44
+msgid "Thu"
+msgstr "Qui"
+
+#: id:45
+msgid "Fri"
+msgstr "Sex"
+
+#: id:46
+msgid "Sat"
+msgstr "Sab"
+
+#: id:47
+msgctxt "Auto context with id 47"
+msgid "Sun"
+msgstr "Dom"
+
+#: id:51
+msgid "Jan"
+msgstr "Jan"
+
+#: id:52
+msgid "Feb"
+msgstr "Fev"
+
+#: id:53
+msgid "Mar"
+msgstr "Mar"
+
+#: id:54
+msgid "Apr"
+msgstr "Abr"
+
+#: id:55
+msgctxt "Auto context with id 55"
+msgid "May"
+msgstr "Mai"
+
+#: id:56
+msgid "Jun"
+msgstr "Jun"
+
+#: id:57
+msgid "Jul"
+msgstr "Jul"
+
+#: id:58
+msgid "Aug"
+msgstr "Ago"
+
+#: id:59
+msgid "Sep"
+msgstr "Set"
+
+#: id:60
+msgid "Oct"
+msgstr "Out"
+
+#: id:61
+msgid "Nov"
+msgstr "Nov"
+
+#: id:62
+msgid "Dec"
+msgstr "Dez"
+
+#: id:71
+msgid "N"
+msgstr "N"
+
+#: id:72
+msgid "NNE"
+msgstr "NNE"
+
+#: id:73
+msgid "NE"
+msgstr "NO"
+
+#: id:74
+msgid "ENE"
+msgstr "ONO"
+
+#: id:75
+msgid "E"
+msgstr "O"
+
+#: id:76
+msgid "ESE"
+msgstr "OSO"
+
+#: id:77
+msgid "SE"
+msgstr "SO"
+
+#: id:78
+msgid "SSE"
+msgstr "SSO"
+
+#: id:79
+msgid "S"
+msgstr "S"
+
+#: id:80
+msgid "SSW"
+msgstr "SSL"
+
+#: id:81
+msgid "SW"
+msgstr "SL"
+
+#: id:82
+msgid "WSW"
+msgstr "LSL"
+
+#: id:83
+msgid "W"
+msgstr "L"
+
+#: id:84
+msgid "WNW"
+msgstr "LNL"
+
+#: id:85
+msgid "NW"
+msgstr "NL"
+
+#: id:86
+msgid "NNW"
+msgstr "NNL"
+
+#: id:87
+msgid "VAR"
+msgstr "VAR"
+
+#: id:98
+msgid "View: Auto"
+msgstr "Ver: Auto"
+
+#: id:99
+msgid "View: Auto big"
+msgstr "Ver: Auto grande"
+
+#: id:100
+msgid "View: Icons"
+msgstr "Ver: Icones"
+
+#: id:101
+msgid "View: List"
+msgstr "Ver: Lista"
+
+#: id:102
+msgctxt "Auto context with id 102"
+msgid "Scan"
+msgstr "Examinar"
+
+#: id:103
+msgctxt "Auto context with id 103"
+msgid "Sort by: Name"
+msgstr "Ordenar por: Nome"
+
+#: id:104
+msgid "Sort by: Date"
+msgstr "Ordenar por: Data"
+
+#: id:105
+msgid "Sort by: Size"
+msgstr "Ordenar por: Tamanho"
+
+#: id:106
+msgid "No"
+msgstr "Não"
+
+#: id:107
+msgid "Yes"
+msgstr "Sim"
+
+#: id:108
+msgctxt "Auto context with id 108"
+msgid "Slideshow"
+msgstr "Apresentação"
+
+#: id:109
+msgid "Create thumbs"
+msgstr "Criar ícones"
+
+#: id:110
+msgid "Create thumbnails"
+msgstr "Criar ícones"
+
+#: id:111
+msgctxt "Auto context with id 111"
+msgid "Shortcuts"
+msgstr "Atalhos"
+
+#: id:112
+msgid "Paused"
+msgstr "Pausado"
+
+#: id:113
+msgid "Update failed"
+msgstr "Atualização falhou"
+
+#: id:114
+msgid "Installation failed"
+msgstr "Instalação falhou"
+
+#: id:115
+msgid "Copy"
+msgstr "Copiar"
+
+#: id:116
+msgid "Move"
+msgstr "Mover"
+
+#: id:117
+msgid "Delete"
+msgstr "Excluir"
+
+#: id:118
+msgid "Rename"
+msgstr "Renomear"
+
+#: id:119
+msgid "New folder"
+msgstr "Nova pasta"
+
+#: id:120
+msgid "Confirm file copy"
+msgstr "Confirma copiar arquivos?"
+
+#: id:121
+msgid "Confirm file move"
+msgstr "Confirma mover arquivos?"
+
+#: id:122
+msgid "Confirm file delete?"
+msgstr "Confirma excluir arquivos?"
+
+#: id:123
+msgid "Copy these files?"
+msgstr "Copiar estes arquivos?"
+
+#: id:124
+msgid "Move these files?"
+msgstr "Mover estes arquivos?"
+
+#: id:125
+msgid "Delete these files? - Deleting files cannot be undone!"
+msgstr "Excluir estes arquivos? - A exclusão não pode ser desfeita!"
+
+#: id:126
+msgid "Status"
+msgstr "Estado"
+
+#: id:127
+msgid "Objects"
+msgstr "Objetos"
+
+#: id:128
+msgctxt "Auto context with id 128"
+msgid "General"
+msgstr "Geral"
+
+#: id:129
+msgctxt "Auto context with id 129"
+msgid "Slideshow"
+msgstr "Apresentação"
+
+#: id:130
+msgctxt "Auto context with id 130"
+msgid "System info"
+msgstr "Informação do Sistema"
+
+#: id:131
+msgid "Display"
+msgstr "Tela"
+
+#: id:132
+msgid "Albums"
+msgstr "Álbuns"
+
+#: id:133
+msgid "Artists"
+msgstr "Artistas"
+
+#: id:134
+msgid "Songs"
+msgstr "Músicas"
+
+#: id:135
+msgid "Genres"
+msgstr "Gêneros"
+
+#: id:136
+msgid "Playlists"
+msgstr "Listas de reprodução (playlist)"
+
+#: id:137
+msgid "Search"
+msgstr "Procurar"
+
+#: id:138
+msgid "System Information"
+msgstr "Informação do Sistema"
+
+#: id:139
+msgid "Temperatures:"
+msgstr "Temperaturas:"
+
+#: id:140
+msgid "CPU:"
+msgstr "CPU:"
+
+#: id:141
+msgid "GPU:"
+msgstr "GPU:"
+
+#: id:142
+msgid "Time:"
+msgstr "Hora:"
+
+#: id:143
+msgid "Current:"
+msgstr "Atual:"
+
+#: id:144
+msgid "Build:"
+msgstr "Versão:"
+
+#: id:145
+msgid "Network:"
+msgstr "Rede:"
+
+#: id:146
+msgid "Type:"
+msgstr "Tipo:"
+
+#: id:147
+msgid "Static"
+msgstr "Estático"
+
+#: id:148
+msgid "DHCP"
+msgstr "DHCP"
+
+#: id:149
+msgid "MAC address"
+msgstr "Endereço MAC"
+
+#: id:150
+msgctxt "Auto context with id 150"
+msgid "IP address"
+msgstr "Endereço IP"
+
+#: id:151
+msgid "Link:"
+msgstr "Conexão:"
+
+#: id:152
+msgid "Half duplex"
+msgstr "Half duplex"
+
+#: id:153
+msgid "Full duplex"
+msgstr "Full duplex"
+
+#: id:154
+msgctxt "Auto context with id 154"
+msgid "Storage"
+msgstr "Armazenamento"
+
+#: id:155
+msgid "Drive"
+msgstr "Drive"
+
+#: id:156
+msgctxt "Auto context with id 156"
+msgid "Free"
+msgstr "Livre"
+
+#: id:157
+msgctxt "Auto context with id 157"
+msgid "Video"
+msgstr "Vídeo"
+
+#: id:158
+msgid "Free memory"
+msgstr "Memória livre"
+
+#: id:159
+msgid "No link"
+msgstr "Sem conexão"
+
+#: id:160
+msgctxt "Auto context with id 160"
+msgid "Free"
+msgstr "Livre"
+
+#: id:161
+msgid "Unavailable"
+msgstr "Indisponível"
+
+#: id:162
+msgid "Tray open"
+msgstr "Drive aberto"
+
+#: id:163
+msgid "Reading"
+msgstr "Lendo"
+
+#: id:164
+msgid "No disc"
+msgstr "Sem disco"
+
+#: id:165
+msgid "Disc present"
+msgstr "Disco presente"
+
+#: id:166
+msgid "Skin"
+msgstr "Skin"
+
+#: id:169
+msgctxt "Auto context with id 169"
+msgid "Resolution"
+msgstr "Resolução"
+
+#: id:170
+msgid "Adjust display refresh rate to match video"
+msgstr "Ajustar taxa de atualização para mesma da tela"
+
+#: id:172
+msgid "Release date"
+msgstr "Data de lançamento:"
+
+#: id:173
+msgid "Display 4:3 videos as"
+msgstr "Exibir videos 4:3 como"
+
+#: id:175
+msgid "Moods"
+msgstr "Modos"
+
+#: id:176
+msgid "Styles"
+msgstr "Estilos"
+
+#: id:179
+msgid "Song"
+msgstr "Música"
+
+#: id:180
+msgid "Duration"
+msgstr "Duração"
+
+#: id:181
+msgid "Select album"
+msgstr "Selecionar álbum"
+
+#: id:182
+msgid "Tracks"
+msgstr "Faixas"
+
+#: id:183
+msgid "Review"
+msgstr "Crítica"
+
+#: id:184
+msgid "Refresh"
+msgstr "Atualizar"
+
+#: id:185
+msgid "Searching album"
+msgstr "Procurando álbum"
+
+#: id:186
+msgid "OK"
+msgstr "OK"
+
+#: id:187
+msgid "No albums found!"
+msgstr "Nenhum álbum encontrado!"
+
+#: id:188
+msgid "Select all"
+msgstr "Selecionar todos"
+
+#: id:189
+msgid "Scanning media info"
+msgstr "Procurando informações da mídia"
+
+#: id:190
+msgid "Save"
+msgstr "Salvar"
+
+#: id:191
+msgid "Shuffle"
+msgstr "Aleatório"
+
+#: id:192
+msgctxt "Auto context with id 192"
+msgid "Clear"
+msgstr "Limpar"
+
+#: id:193
+msgctxt "Auto context with id 193"
+msgid "Scan"
+msgstr "Examinar"
+
+#: id:194
+msgid "Searching..."
+msgstr "Procurando..."
+
+#: id:195
+msgid "No info found!"
+msgstr "Nenhuma informação encontrada!"
+
+#: id:196
+msgid "Select movie:"
+msgstr "Selecione o filme:"
+
+#: id:197
+msgid "Querying %s info"
+msgstr "Procurando informação de %s"
+
+#: id:198
+msgid "Loading movie details"
+msgstr "Carregando detalhes do filme"
+
+#: id:199
+msgid "Web interface"
+msgstr "Interface web"
+
+#: id:202
+msgid "Tagline"
+msgstr "Título:"
+
+#: id:203
+msgid "Plot outline"
+msgstr "Sinopse:"
+
+#: id:205
+msgid "Votes"
+msgstr "Votos"
+
+#: id:206
+msgid "Cast"
+msgstr "Elenco"
+
+#: id:207
+msgid "Plot"
+msgstr "Enredo"
+
+#: id:208
+msgctxt "Auto context with id 208"
+msgid "Play"
+msgstr "Tocar"
+
+#: id:209
+msgid "Next"
+msgstr "Próximo"
+
+#: id:210
+msgid "Previous"
+msgstr "Anterior"
+
+#: id:213
+msgid "Calibrate user interface..."
+msgstr "Ajustar interface..."
+
+#: id:214
+msgid "Video calibration..."
+msgstr "Ajustar tela..."
+
+#: id:215
+msgid "Soften"
+msgstr "Suavizar"
+
+#: id:216
+msgid "Zoom amount"
+msgstr "Nível de Zoom"
+
+#: id:217
+msgid "Pixel ratio"
+msgstr "Proporção de pixels"
+
+#: id:218
+msgid "DVD drive"
+msgstr "Drive de DVD"
+
+#: id:219
+msgid "Please insert disc"
+msgstr "Por favor inserir disco"
+
+#: id:220
+msgid "Remote share"
+msgstr "Compartilhamento remoto"
+
+#: id:221
+msgid "Network is not connected"
+msgstr "Rede não está conectada"
+
+#: id:222
+msgid "Cancel"
+msgstr "Cancelar"
+
+#: id:224
+msgid "Speed"
+msgstr "Velocidade"
+
+#: id:225
+msgid "Vertical Shift"
+msgstr "Deslocamento Vertical"
+
+#: id:226
+msgid "Test patterns..."
+msgstr "Padrões de teste...."
+
+#: id:227
+msgid "Lookup audio CD track names from freedb.org"
+msgstr "Procurar CDs de áudio na Internet"
+
+#: id:228
+msgid "Shuffle playlist on load"
+msgstr "Misturar lista de reprodução ao carregar"
+
+#: id:229
+msgid "HDD spindown time"
+msgstr "Tempo para parada do HDD"
+
+#: id:230
+msgid "Video filters"
+msgstr "Filtros de vídeo"
+
+#: id:231
+msgctxt "Auto context with id 231"
+msgid "None"
+msgstr "Nenhum"
+
+#: id:232
+msgid "Point"
+msgstr "Ponto"
+
+#: id:233
+msgid "Linear"
+msgstr "Linear"
+
+#: id:234
+msgid "Anisotropic"
+msgstr "Anisotrópico"
+
+#: id:235
+msgid "Quincunx"
+msgstr "Quincuncial"
+
+#: id:236
+msgid "Gaussian cubic"
+msgstr "Cúbico gaussian"
+
+#: id:237
+msgid "Minification"
+msgstr "Redução"
+
+#: id:238
+msgid "Magnification"
+msgstr "Ampliação"
+
+#: id:239
+msgid "Clear playlist on finish"
+msgstr "Limpar a lista de reprodução ao terminar"
+
+#: id:240
+msgid "Display Mode"
+msgstr "Modo de Exibição"
+
+#: id:241
+msgid "Full Screen #%d"
+msgstr "Tela Cheia #%d"
+
+#: id:242
+msgid "Windowed"
+msgstr "Janela"
+
+#: id:243
+msgid "Refresh Rate"
+msgstr "Taxa de Atualização"
+
+#: id:244
+msgid "Full screen"
+msgstr "Tela Cheia"
+
+#: id:245
+msgid "Sizing: (%i,%i)->(%i,%i) (Zoom x%2.2f) AR:%2.2f:1 (Pixels: %2.2f:1) (VShift: %2.2f)"
+msgstr "Dimensionando: (%i,%i)->(%i,%i) (Zoom x%2.2f) AR:%2.2f:1 (Pixels: %2.2f:1)"
+
+#: id:247
+msgctxt "Auto context with id 247"
+msgid "Scripts"
+msgstr "Scripts"
+
+#: id:248
+msgctxt "Auto context with id 248"
+msgid "Language"
+msgstr "Idioma"
+
+#: id:249
+msgctxt "Auto context with id 249"
+msgid "Music"
+msgstr "Música"
+
+#: id:250
+msgctxt "Auto context with id 250"
+msgid "Visualization"
+msgstr "Visualização"
+
+#: id:251
+msgid "Select destination directory"
+msgstr "Selecionar diretório de destino"
+
+#: id:252
+msgid "Output stereo to all speakers"
+msgstr "Saída estéreo em todos os alto-falantes"
+
+#: id:253
+msgid "Number of channels"
+msgstr "Número de canais"
+
+#: id:254
+msgid "- DTS capable receiver"
+msgstr "- Receiver com suporte a DTS"
+
+#: id:255
+msgid "CDDB"
+msgstr "CDDB"
+
+#: id:256
+msgid "Fetching CD information"
+msgstr "Recuperando informações sobre o CD"
+
+#: id:257
+msgid "Error"
+msgstr "Erro"
+
+#: id:258
+msgid "Enable tag reading"
+msgstr "Ativar leitura de etiquetas ID3"
+
+#: id:259
+msgid "Opening"
+msgstr "Abrindo"
+
+#: id:260
+msgid "Shoutcast"
+msgstr "Shoutcast"
+
+#: id:261
+msgid "Waiting for start..."
+msgstr "Aguardando início...."
+
+#: id:262
+msgid "Scripts output"
+msgstr "Saída de scripts"
+
+#: id:263
+msgid "Allow control of XBMC via HTTP"
+msgstr "Permitir controle do XBMC por HTTP"
+
+#: id:264
+msgid "Record"
+msgstr "Gravar"
+
+#: id:265
+msgid "Stop Rec."
+msgstr "Parar grav."
+
+#: id:266
+msgid "Sort by: Track"
+msgstr "Ordenar por: faixa"
+
+#: id:267
+msgid "Sort by: Time"
+msgstr "Ordenar por: tempo"
+
+#: id:268
+msgid "Sort by: Title"
+msgstr "Ordenar por: título"
+
+#: id:269
+msgid "Sort by: Artist"
+msgstr "Ordenar por: artista"
+
+#: id:270
+msgid "Sort by: Album"
+msgstr "Ordenar por: álbum"
+
+#: id:271
+msgid "Top 100"
+msgstr "Top 100"
+
+#: id:272
+msgid "Top-Left overscan compensation"
+msgstr "Ajuste do canto superior esquerdo"
+
+#: id:273
+msgid "Bottom-Right overscan compensation"
+msgstr "Ajuste do canto inferior direito"
+
+#: id:274
+msgid "Subtitle positioning"
+msgstr "Posição das legendas"
+
+#: id:275
+msgid "Pixel ratio adjustment"
+msgstr "Ajuste da proporção de pixels"
+
+#: id:276
+msgid "Adjust the arrow to change the amount of overscan"
+msgstr "Mova a seta para modificar o tamanho da tela"
+
+#: id:277
+msgid "Adjust the bar to change the subtitles position"
+msgstr "Mova a barra para modificar a posição das legendas"
+
+#: id:278
+msgid "Adjust the rectangle so it is perfectly square"
+msgstr "Ajuste até que fique um quadrado perfeito"
+
+#: id:279
+msgid "Unable to load settings"
+msgstr "Nao foi possível carregar as configurações"
+
+#: id:280
+msgid "Using default settings"
+msgstr "Usando configuração padrão"
+
+#: id:281
+msgid "Please check the XML files"
+msgstr "Por favor verificar os arquivos XML"
+
+#: id:282
+msgid "Found %i items"
+msgstr "Encontrado(s) %i item(s)"
+
+#: id:283
+msgid "Search results"
+msgstr "Resultado(s) da busca"
+
+#: id:284
+msgid "No results found"
+msgstr "Nenhum resultado encontrado"
+
+#: id:287
+msgctxt "Auto context with id 287"
+msgid "Subtitles"
+msgstr "Legendas"
+
+#: id:288
+msgctxt "Auto context with id 288"
+msgid "Font"
+msgstr "Fonte"
+
+#: id:289
+msgctxt "Auto context with id 289"
+msgid "- Size"
+msgstr "- Tamanho"
+
+#: id:290
+msgid "Dynamic range compression"
+msgstr "Faixa de compressão dinâmica"
+
+#: id:291
+msgctxt "Auto context with id 291"
+msgid "Video"
+msgstr "Vídeo"
+
+#: id:292
+msgctxt "Auto context with id 292"
+msgid "Audio"
+msgstr "Áudio"
+
+#: id:293
+msgid "Browse for subtitles"
+msgstr "Procurar legendas"
+
+#: id:294
+msgid "Create bookmark"
+msgstr "Criar marcador"
+
+#: id:296
+msgid "Clear bookmarks"
+msgstr "Limpar marcadores"
+
+#: id:297
+msgid "Audio offset"
+msgstr "Atraso de áudio"
+
+#: id:298
+msgid "Bookmarks"
+msgstr "Marcadores"
+
+#: id:299
+msgid "- AAC capable receiver"
+msgstr "- Receiver com suporte a AAC"
+
+#: id:300
+msgid "- MP1 capable receiver"
+msgstr "- Receiver com suporte a MP1"
+
+#: id:301
+msgid "- MP2 capable receiver"
+msgstr "- Receiver com suporte a MP2"
+
+#: id:302
+msgid "- MP3 capable receiver"
+msgstr "- Receiver com suporte a MP3"
+
+#: id:303
+msgid "Delay"
+msgstr "Atraso"
+
+#: id:304
+msgctxt "Auto context with id 304"
+msgid "Language"
+msgstr "Idioma"
+
+#: id:305
+msgctxt "Auto context with id 305"
+msgid "Enabled"
+msgstr "Ativado"
+
+#: id:306
+msgid "Non-interleaved"
+msgstr "Não-intercalado"
+
+#: id:312
+msgid "(0=auto)"
+msgstr "(0=auto)"
+
+#: id:313
+msgid "Cleaning database"
+msgstr "Excluindo banco de dados"
+
+#: id:314
+msgid "Preparing..."
+msgstr "Preparando..."
+
+#: id:315
+msgid "Database error"
+msgstr "Erro no banco de dados"
+
+#: id:316
+msgid "Searching songs..."
+msgstr "Procurando músicas..."
+
+#: id:317
+msgid "Cleaned database successfully"
+msgstr "Banco de dados excluído com sucesso"
+
+#: id:318
+msgid "Cleaning songs..."
+msgstr "Excluindo músicas..."
+
+#: id:319
+msgid "Error cleaning songs"
+msgstr "Erro ao excluir músicas"
+
+#: id:320
+msgid "Cleaning artists..."
+msgstr "Excluindo artistas..."
+
+#: id:321
+msgid "Error cleaning artists"
+msgstr "Erro ao excluir artistas"
+
+#: id:322
+msgid "Cleaning genres..."
+msgstr "Excluindo gêneros..."
+
+#: id:323
+msgid "Error cleaning genres"
+msgstr "Erro ao excluir gêneros"
+
+#: id:324
+msgid "Cleaning paths..."
+msgstr "Excluindo caminhos..."
+
+#: id:325
+msgid "Error cleaning paths"
+msgstr "Erro ao excluir caminhos"
+
+#: id:326
+msgid "Cleaning albums..."
+msgstr "Excluindo álbuns..."
+
+#: id:327
+msgid "Error cleaning albums"
+msgstr "Erro ao excluir álbuns"
+
+#: id:328
+msgid "Writing changes..."
+msgstr "Gravando alterações..."
+
+#: id:329
+msgid "Error writing changes"
+msgstr "Erro ao gravar as alterações"
+
+#: id:330
+msgid "This may take some time..."
+msgstr "Isto pode demorar um pouco..."
+
+#: id:331
+msgid "Compressing database..."
+msgstr "Compactando o banco de dados..."
+
+#: id:332
+msgid "Error compressing database"
+msgstr "Erro ao compactar o banco de dados"
+
+#: id:333
+msgid "Do you want to clean the library?"
+msgstr "Deseja limpar a coleção?"
+
+#: id:334
+msgid "Clean library..."
+msgstr "Limpar a coleção..."
+
+#: id:335
+msgid "Start"
+msgstr "Iniciar"
+
+#: id:336
+msgid "Framerate conversion"
+msgstr "Conversão de quadros/seg."
+
+#: id:337
+msgctxt "Auto context with id 337"
+msgid "Audio output"
+msgstr "Saída de áudio"
+
+#: id:338
+msgid "Analog"
+msgstr "Analógico"
+
+#: id:339
+msgid "Optical/Coax"
+msgstr "Digital"
+
+#: id:340
+msgid "Various artists"
+msgstr "Vários Artistas"
+
+#: id:341
+msgid "Play disc"
+msgstr "Iniciar DVD/CD"
+
+#: id:342
+msgctxt "Auto context with id 342"
+msgid "Movies"
+msgstr "Filmes"
+
+#: id:343
+msgid "Adjust framerate"
+msgstr "Ajustar quadros/seg."
+
+#: id:344
+msgid "Actors"
+msgstr "Atores"
+
+#: id:345
+msgctxt "Auto context with id 345"
+msgid "Year"
+msgstr "Ano"
+
+#: id:346
+msgid "Boost volume level on downmix"
+msgstr "Aumentar nível do volume no downmix"
+
+#: id:350
+msgctxt "Auto context with id 350"
+msgid "Programs"
+msgstr "Programas"
+
+#: id:351
+msgctxt "Auto context with id 351"
+msgid "Off"
+msgstr "Desligado"
+
+#: id:352
+msgid "Dim"
+msgstr "Escurecer"
+
+#: id:353
+msgid "Black"
+msgstr "Tela preta"
+
+#: id:354
+msgid "Matrix trails"
+msgstr "Estilo matrix"
+
+#: id:355
+msgid "Screensaver time"
+msgstr "Tempo para proteção de tela"
+
+#: id:356
+msgid "Screensaver mode"
+msgstr "Modo de proteção de tela"
+
+#: id:357
+msgid "Shutdown function timer"
+msgstr "Desligar XBOX inativo em"
+
+#: id:358
+msgid "All albums"
+msgstr "Todos os álbuns"
+
+#: id:359
+msgid "Recently added albums"
+msgstr "Álbuns adicionados recentemente"
+
+#: id:360
+msgctxt "Auto context with id 360"
+msgid "Screensaver"
+msgstr "Proteção de tela"
+
+#: id:361
+msgid "R. Slideshow"
+msgstr "Apresentação recursiva"
+
+#: id:362
+msgid "Screensaver dim level"
+msgstr "Nível de escurecimento da proteção de tela"
+
+#: id:363
+msgid "Sort by: File"
+msgstr "Ordenar por: arquivo"
+
+#: id:364
+msgid "- Dolby Digital (AC3) capable receiver"
+msgstr "- Receiver com suporte a Dolby Digital (AC3)"
+
+#: id:365
+msgctxt "Auto context with id 365"
+msgid "Sort by: Name"
+msgstr "Ordenar por: nome"
+
+#: id:366
+msgid "Sort by: Year"
+msgstr "Ordenar por: ano"
+
+#: id:367
+msgid "Sort by: Rating"
+msgstr "Ordenar por: votação"
+
+#: id:368
+msgid "IMDb"
+msgstr "IMDb"
+
+#: id:369
+msgctxt "Auto context with id 369"
+msgid "Title"
+msgstr "Título"
+
+#: id:370
+msgid "Thunderstorms"
+msgstr "Trovoadas"
+
+#: id:371
+msgid "Partly"
+msgstr "Parcial."
+
+#: id:372
+msgid "Mostly"
+msgstr "Predom."
+
+#: id:373
+msgid "Sunny"
+msgstr "Ensolarado"
+
+#: id:374
+msgid "Cloudy"
+msgstr "Nublado"
+
+#: id:375
+msgid "Snow"
+msgstr "Neve"
+
+#: id:376
+msgid "Rain"
+msgstr "Chuva"
+
+#: id:377
+msgid "Light"
+msgstr "Leve"
+
+#: id:378
+msgid "AM"
+msgstr "AM"
+
+#: id:379
+msgid "PM"
+msgstr "PM"
+
+#: id:380
+msgid "Showers"
+msgstr "Chuvas rápidas"
+
+#: id:381
+msgid "Few"
+msgstr "Pouco"
+
+#: id:382
+msgid "Scattered"
+msgstr "Dispersas"
+
+#: id:383
+msgctxt "Auto context with id 383"
+msgid "Wind"
+msgstr "Vento"
+
+#: id:384
+msgid "Strong"
+msgstr "Forte"
+
+#: id:385
+msgid "Fair"
+msgstr "Claro"
+
+#: id:386
+msgctxt "Auto context with id 386"
+msgid "Clear"
+msgstr "Limpo"
+
+#: id:387
+msgid "Clouds"
+msgstr "Encoberto"
+
+#: id:388
+msgid "Early"
+msgstr "Cedo"
+
+#: id:389
+msgid "Shower"
+msgstr "Pancada de chuva"
+
+#: id:390
+msgid "Flurries"
+msgstr "Nevada forte"
+
+#: id:391
+msgctxt "Auto context with id 391"
+msgid "Low"
+msgstr "Mínima"
+
+#: id:392
+msgctxt "Auto context with id 392"
+msgid "Medium"
+msgstr "Média"
+
+#: id:393
+msgctxt "Auto context with id 393"
+msgid "High"
+msgstr "Máxima"
+
+#: id:394
+msgid "Fog"
+msgstr "Nevoeiro"
+
+#: id:395
+msgid "Haze"
+msgstr "Neblina"
+
+#: id:396
+msgid "Select location"
+msgstr "Selecione local"
+
+#: id:397
+msgid "Refresh time"
+msgstr "Tempo de atualização"
+
+#: id:398
+msgid "Temperature units"
+msgstr "Unidade de temperatura"
+
+#: id:399
+msgid "Speed units"
+msgstr "Unidade de velocidade"
+
+#: id:400
+msgctxt "Auto context with id 400"
+msgid "Weather"
+msgstr "Tempo"
+
+#: id:401
+msgid "Temp"
+msgstr "Temperatura"
+
+#: id:402
+msgid "Feels like"
+msgstr "Ambiente"
+
+#: id:403
+msgid "UV index"
+msgstr "Índice UV"
+
+#: id:404
+msgctxt "Auto context with id 404"
+msgid "Wind"
+msgstr "Vento"
+
+#: id:405
+msgid "Dew point"
+msgstr "Pt. de orvalho"
+
+#: id:406
+msgid "Humidity"
+msgstr "Umidade"
+
+#: id:409
+msgid "Defaults"
+msgstr "Padrões"
+
+#: id:410
+msgid "Accessing weather service"
+msgstr "Acessando o serviço de meteorologia"
+
+#: id:411
+msgid "Getting weather for:"
+msgstr "Obtendo informações de tempo para:"
+
+#: id:412
+msgid "Unable to get weather data"
+msgstr "Não foi possível obter dados da previsão do tempo"
+
+#: id:413
+msgid "Manual"
+msgstr "Manual"
+
+#: id:414
+msgid "No review for this album"
+msgstr "Sem crítica para este álbum"
+
+#: id:415
+msgid "Downloading thumbnail..."
+msgstr "Baixando ícone..."
+
+#: id:416
+msgid "Not available"
+msgstr "Não disponível"
+
+#: id:417
+msgid "View: Big icons"
+msgstr "Ver: Ícones grandes"
+
+#: id:418
+msgctxt "Auto context with id 418"
+msgid "Low"
+msgstr "Baixo"
+
+#: id:419
+msgctxt "Auto context with id 419"
+msgid "High"
+msgstr "Alto"
+
+#: id:420
+msgid "HDMI"
+msgstr "HDMI"
+
+#: id:422
+msgid "Delete album info"
+msgstr "Excluir informações do álbum"
+
+#: id:423
+msgid "Delete CD information"
+msgstr "Excluir informações do CD"
+
+#: id:424
+msgid "Select"
+msgstr "Selecionar"
+
+#: id:425
+msgid "No album information found"
+msgstr "Nenhuma informação do álbum encontrada."
+
+#: id:426
+msgid "No CD information found"
+msgstr "Nenhuma informação no CD encontrada."
+
+#: id:427
+msgid "Disc"
+msgstr "Disco"
+
+#: id:428
+msgid "Insert correct CD/DVD"
+msgstr "Insira o CD/DVD correto"
+
+#: id:429
+msgid "Please insert the following disc:"
+msgstr "Por favor insira o seguinte CD/DVD"
+
+#: id:430
+msgid "Sort by: DVD#"
+msgstr "Ordenar por: DVD#"
+
+#: id:431
+msgid "No cache"
+msgstr "Sem cache"
+
+#: id:432
+msgid "Remove movie from library"
+msgstr "Excluir filme da coleção"
+
+#: id:433
+msgid "Really remove '%s'?"
+msgstr "Deseja excluir '%s'?"
+
+#: id:434
+msgid "From %s at %i %s"
+msgstr "De %s até %i %s"
+
+#: id:437
+msgid "Removable disk"
+msgstr "Disco removível"
+
+#: id:438
+msgid "Opening file"
+msgstr "Abrindo arquivo"
+
+#: id:439
+msgid "Cache"
+msgstr "Cache"
+
+#: id:440
+msgid "Harddisk"
+msgstr "Disco rígido"
+
+#: id:441
+msgid "UDF"
+msgstr "UDF"
+
+#: id:442
+msgid "Local network"
+msgstr "Rede Local"
+
+#: id:443
+msgid "Internet"
+msgstr "Internet"
+
+#: id:444
+msgctxt "Auto context with id 444"
+msgid "Video"
+msgstr "Vídeo"
+
+#: id:445
+msgctxt "Auto context with id 445"
+msgid "Audio"
+msgstr "Áudio"
+
+#: id:446
+msgctxt "Auto context with id 446"
+msgid "DVD"
+msgstr "DVD"
+
+#: id:447
+msgid "Autorun media"
+msgstr "Auto executar"
+
+#: id:448
+msgid "LCD"
+msgstr "LCD"
+
+#: id:449
+msgctxt "Auto context with id 449"
+msgid "Enabled"
+msgstr "Ativado"
+
+#: id:450
+msgid "Columns"
+msgstr "Colunas"
+
+#: id:451
+msgid "Row 1 address"
+msgstr "Endereço linha 1"
+
+#: id:452
+msgid "Row 2 address"
+msgstr "Endereço linha 2"
+
+#: id:453
+msgid "Row 3 address"
+msgstr "Endereço linha 3"
+
+#: id:454
+msgid "Row 4 address"
+msgstr "Endereço linha 4"
+
+#: id:455
+msgid "Rows"
+msgstr "Linhas"
+
+#: id:456
+msgid "Mode"
+msgstr "Modo"
+
+#: id:457
+msgid "Switch view"
+msgstr "Troca visualização"
+
+#: id:459
+msgid "Subs"
+msgstr "Legendas"
+
+#: id:460
+msgid "Audio stream"
+msgstr "Canal de áudio"
+
+#: id:461
+msgid "[active]"
+msgstr "[ativo]"
+
+#: id:462
+msgid "Subtitle"
+msgstr "Legenda"
+
+#: id:463
+msgid "Backlight"
+msgstr "Luz de fundo"
+
+#: id:464
+msgid "Brightness"
+msgstr "Brilho"
+
+#: id:465
+msgid "Contrast"
+msgstr "Contraste"
+
+#: id:466
+msgid "Gamma"
+msgstr "Gamma"
+
+#: id:467
+msgctxt "Auto context with id 467"
+msgid "Type"
+msgstr "Tipo"
+
+#: id:468
+msgid "Move the bar to change the OSD position"
+msgstr "Mova a barra para reposicionar o OSD"
+
+#: id:469
+msgid "OSD position"
+msgstr "Posição do painel OSD"
+
+#: id:470
+msgid "Credits"
+msgstr "Créditos"
+
+#: id:471
+msgid "Modchip"
+msgstr "Modchip"
+
+#: id:474
+msgctxt "Auto context with id 474"
+msgid "Off"
+msgstr "Desligado"
+
+#: id:475
+msgid "Music only"
+msgstr "Só músicas"
+
+#: id:476
+msgctxt "Auto context with id 476"
+msgid "Music & video"
+msgstr "Música & vídeo"
+
+#: id:477
+msgid "Unable to load playlist"
+msgstr "Impossível carregar a lista de reprodução"
+
+#: id:478
+msgid "OSD"
+msgstr "OSD"
+
+#: id:479
+msgid "Skin & language"
+msgstr "Skin e idioma"
+
+#: id:480
+msgid "Appearance"
+msgstr "Aparência"
+
+#: id:481
+msgid "Audio options"
+msgstr "Opções de Áudio"
+
+#: id:482
+msgid "About XBMC"
+msgstr "Sobre o XBMC"
+
+#: id:485
+msgid "Delete album"
+msgstr "Excluir álbum"
+
+#: id:486
+msgid "Repeat"
+msgstr "Repetir"
+
+#: id:487
+msgid "Repeat one"
+msgstr "Repetir uma"
+
+#: id:488
+msgid "Repeat folder"
+msgstr "Repetir pastas"
+
+#: id:489
+msgid "Play the next song automatically"
+msgstr "Auto executar próxima música"
+
+#: id:491
+msgid "- Use big icons"
+msgstr "- Usar ícones grandes"
+
+#: id:492
+msgid "Resize VobSubs"
+msgstr "Aumentar legendas"
+
+#: id:493
+msgid "Advanced options (Experts Only!)"
+msgstr "Opções avançadas (apenas para experts!)"
+
+#: id:494
+msgid "Overall audio headroom"
+msgstr "Margem total de áudio (dB)"
+
+#: id:495
+msgid "Upsample videos to GUI resolution"
+msgstr "Ampliar área do vídeo para a mesma resolução da tela"
+
+#: id:496
+msgid "Calibration"
+msgstr "Calibragem"
+
+#: id:497
+msgid "Show file extensions"
+msgstr "Exibir extensão dos arquivos"
+
+#: id:498
+msgid "Sort by: Type"
+msgstr "Ordenar por: tipo"
+
+#: id:499
+msgid "Unable to connect to online lookup service"
+msgstr "Impossível conectar com serviço online de busca"
+
+#: id:500
+msgid "Downloading album information failed"
+msgstr "A recuperação de informação do álbum falhou"
+
+#: id:501
+msgid "Looking for album names..."
+msgstr "Procurando nomes do álbum..."
+
+#: id:502
+msgctxt "Auto context with id 502"
+msgid "Open"
+msgstr "Aberto"
+
+#: id:503
+msgid "Busy"
+msgstr "Ocupado"
+
+#: id:504
+msgid "Empty"
+msgstr "Vazio"
+
+#: id:505
+msgid "Loading media info from files..."
+msgstr "Carregando informações de mídia a partir de arquivos..."
+
+#: id:507
+msgid "Sort by: Usage"
+msgstr "Ordenar por: uso"
+
+#: id:510
+msgid "Enable visualizations"
+msgstr "Ativar visualizações"
+
+#: id:511
+msgid "Enable video mode switching"
+msgstr "Ativar troca do modo de vídeo"
+
+#: id:512
+msgid "Startup window"
+msgstr "Janela inicial"
+
+#: id:513
+msgid "Home window"
+msgstr "Janela principal"
+
+#: id:514
+msgid "Manual settings"
+msgstr "Configurações manuais"
+
+#: id:515
+msgid "Genre"
+msgstr "Gênero"
+
+#: id:517
+msgid "Recently played albums"
+msgstr "Álbuns reproduzidos recentemente"
+
+#: id:518
+msgid "Launch"
+msgstr "Iniciar"
+
+#: id:519
+msgid "Launch in..."
+msgstr "Iniciar em.."
+
+#: id:521
+msgid "Compilations"
+msgstr "Compilações"
+
+#: id:522
+msgid "Remove source"
+msgstr "Remover origem"
+
+#: id:523
+msgid "Switch media"
+msgstr "Trocar mídia"
+
+#: id:524
+msgid "Select playlist"
+msgstr "Selecionar lista de reprodução"
+
+#: id:525
+msgid "New playlist..."
+msgstr "Nova lista de reprodução"
+
+#: id:526
+msgid "Add to playlist"
+msgstr "Adicionar à lista"
+
+#: id:527
+msgid "Manually add to library"
+msgstr "Adicionar à coleção manualmente"
+
+#: id:528
+msgid "Enter title"
+msgstr "Digite o título"
+
+#: id:529
+msgid "Error: Duplicate title"
+msgstr "Erro: título duplicado"
+
+#: id:530
+msgid "Select genre"
+msgstr "Selecione o gênero"
+
+#: id:531
+msgid "New genre"
+msgstr "Novo gênero"
+
+#: id:532
+msgid "Manual addition"
+msgstr "Adição manual"
+
+#: id:533
+msgid "Enter genre"
+msgstr "Adicione o gênero"
+
+#: id:534
+msgid "View: %s"
+msgstr "Ver: %s"
+
+#: id:535
+msgid "List"
+msgstr "Lista"
+
+#: id:536
+msgid "Icons"
+msgstr "Ícones"
+
+#: id:537
+msgid "Big list"
+msgstr "Lista grande"
+
+#: id:538
+msgid "Big icons"
+msgstr "Ícones grandes"
+
+#: id:539
+msgid "Wide"
+msgstr "Largo"
+
+#: id:540
+msgid "Big wide"
+msgstr "Bem largo"
+
+#: id:541
+msgid "Album icons"
+msgstr "Álbuns"
+
+#: id:542
+msgid "DVD icons"
+msgstr "Ícones DVD"
+
+#: id:543
+msgctxt "Auto context with id 543"
+msgid "DVD"
+msgstr "DVD"
+
+#: id:544
+msgctxt "Auto context with id 544"
+msgid "Media info"
+msgstr "Mídia/info."
+
+#: id:545
+msgid "Audio output device"
+msgstr "Dispositivo de saída de áudio"
+
+#: id:546
+msgid "Passthrough output device"
+msgstr "Dispositivo de saída de passagem"
+
+#: id:547
+msgid "No biography for this artist"
+msgstr "Sem biografia para este artista"
+
+#: id:548
+msgid "Downmix multichannel audio to stereo"
+msgstr "Converter áudio multicanal para estéreo"
+
+#: id:550
+msgid "Sort by: %s"
+msgstr "Ordenar por: %s"
+
+#: id:551
+msgctxt "Auto context with id 551"
+msgid "Name"
+msgstr "Nome"
+
+#: id:552
+msgid "Date"
+msgstr "Data"
+
+#: id:553
+msgid "Size"
+msgstr "Tamanho"
+
+#: id:554
+msgid "Track"
+msgstr "Faixa"
+
+#: id:555
+msgid "Time"
+msgstr "Duração"
+
+#: id:556
+msgctxt "Auto context with id 556"
+msgid "Title"
+msgstr "Título"
+
+#: id:557
+msgid "Artist"
+msgstr "Artista"
+
+#: id:558
+msgid "Album"
+msgstr "Álbum"
+
+#: id:559
+msgid "Playlist"
+msgstr "Playlist"
+
+#: id:560
+msgid "ID"
+msgstr "ID"
+
+#: id:561
+msgctxt "Auto context with id 561"
+msgid "File"
+msgstr "Arquivo"
+
+#: id:562
+msgctxt "Auto context with id 562"
+msgid "Year"
+msgstr "Ano"
+
+#: id:563
+msgid "Rating"
+msgstr "Classif."
+
+#: id:564
+msgctxt "Auto context with id 564"
+msgid "Type"
+msgstr "Tipo"
+
+#: id:565
+msgid "Usage"
+msgstr "Uso"
+
+#: id:566
+msgid "Album artist"
+msgstr "Artista"
+
+#: id:567
+msgid "Play count"
+msgstr "Execuções"
+
+#: id:568
+msgid "Last played"
+msgstr "Última vez"
+
+#: id:569
+msgctxt "Auto context with id 569"
+msgid "Comment"
+msgstr "Comentário"
+
+#: id:570
+msgid "Date added"
+msgstr "Adicionado"
+
+#: id:571
+msgctxt "Auto context with id 571"
+msgid "Default"
+msgstr "Padrão"
+
+#: id:572
+msgid "Studio"
+msgstr "Estúdio"
+
+#: id:573
+msgid "Path"
+msgstr "Caminho"
+
+#: id:574
+msgctxt "Auto context with id 574"
+msgid "Country"
+msgstr "País"
+
+#: id:575
+msgid "In progress"
+msgstr "Em progresso"
+
+#: id:576
+msgid "Times played"
+msgstr "Quantidade de vezes tocado"
+
+#: id:580
+msgid "Sort direction"
+msgstr "Direção de ordenação"
+
+#: id:581
+msgid "Sort method"
+msgstr "Método de ordenação"
+
+#: id:582
+msgctxt "Auto context with id 582"
+msgid "View mode"
+msgstr "Modo de exibição"
+
+#: id:583
+msgid "Remember views for different folders"
+msgstr "Lembrar modo de exibição para pastas diferentes"
+
+#: id:584
+msgid "Ascending"
+msgstr "Crescente"
+
+#: id:585
+msgid "Descending"
+msgstr "Decrescente"
+
+#: id:586
+msgid "Edit playlist"
+msgstr "Editar lista"
+
+#: id:587
+msgid "Filter"
+msgstr "Filtro"
+
+#: id:588
+msgid "Cancel party mode"
+msgstr "Cancelar modo-festa"
+
+#: id:589
+msgid "Party mode"
+msgstr "Modo-festa"
+
+#: id:590
+msgid "Random"
+msgstr "Aleatório"
+
+#: id:591
+msgctxt "Auto context with id 591"
+msgid "Off"
+msgstr "Desligado"
+
+#: id:592
+msgid "One"
+msgstr "Uma"
+
+#: id:593
+msgid "All"
+msgstr "Todos"
+
+#: id:594
+msgctxt "Auto context with id 594"
+msgid "Off"
+msgstr "Desligado"
+
+#: id:595
+msgid "Repeat: Off"
+msgstr "Repetir: desl."
+
+#: id:596
+msgid "Repeat: One"
+msgstr "Repetir: uma"
+
+#: id:597
+msgid "Repeat: All"
+msgstr "Repetir: todos"
+
+#: id:600
+msgid "Rip audio CD"
+msgstr "Extrair CD de áudio"
+
+#: id:601
+msgctxt "Auto context with id 601"
+msgid "Medium"
+msgstr "Média"
+
+#: id:602
+msgctxt "Auto context with id 602"
+msgid "Standard"
+msgstr "Padrão"
+
+#: id:603
+msgid "Extreme"
+msgstr "Extrema"
+
+#: id:604
+msgid "Constant bitrate"
+msgstr "Taxa de bits constante"
+
+#: id:605
+msgid "Ripping..."
+msgstr "Extraindo..."
+
+#: id:607
+msgid "To:"
+msgstr "Para:"
+
+#: id:608
+msgid "Could not rip CD or track"
+msgstr "Não foi possível extrair o CD ou faixa"
+
+#: id:609
+msgid "CDDARipPath is not set."
+msgstr "CDDARipPath não foi definido."
+
+#: id:610
+msgid "Rip audio track"
+msgstr "Extrair faixa de áudio"
+
+#: id:611
+msgid "Enter number"
+msgstr "Digite número"
+
+#: id:612
+msgid "Bits/Sample"
+msgstr "Bits/Amostra"
+
+#: id:613
+msgid "Sample Frequency"
+msgstr "Frequencia de amostra"
+
+#: id:620
+msgid "Audio CDs"
+msgstr "CDs de áudio"
+
+#: id:621
+msgid "Encoder"
+msgstr "Codificador"
+
+#: id:622
+msgid "Quality"
+msgstr "Qualidade"
+
+#: id:623
+msgid "Bitrate"
+msgstr "Taxa de bits"
+
+#: id:624
+msgid "Include track number"
+msgstr "Incluir o número da faixa"
+
+#: id:625
+msgid "All songs of"
+msgstr "Todas as músicas de"
+
+#: id:629
+msgctxt "Auto context with id 629"
+msgid "View mode"
+msgstr "Modo de visualização"
+
+#: id:630
+msgctxt "Auto context with id 630"
+msgid "Normal"
+msgstr "Normal"
+
+#: id:631
+msgid "Zoom"
+msgstr "Zoom"
+
+#: id:632
+msgid "Stretch 4:3"
+msgstr "Mudar para 4:3"
+
+#: id:633
+msgid "Wide Zoom"
+msgstr "Wide Zoom"
+
+#: id:634
+msgid "Stretch 16:9"
+msgstr "Mudar para 16:9"
+
+#: id:635
+msgid "Original Size"
+msgstr "Tamanho original"
+
+#: id:636
+msgctxt "Auto context with id 636"
+msgid "Custom"
+msgstr "Personalizado"
+
+#: id:637
+msgid "Replay gain"
+msgstr "Ajuste de volume"
+
+#: id:638
+msgid "Replaygain volume adjustments"
+msgstr "Modo de ajuste de volume"
+
+#: id:639
+msgid "Use track levels"
+msgstr "Usar nível da faixa"
+
+#: id:640
+msgid "Use album levels"
+msgstr "Usar níveis do álbum"
+
+#: id:641
+msgid "PreAmp Level - Replay gained files"
+msgstr "PreAmp: arquivos com ajuste de volume"
+
+#: id:642
+msgid "PreAmp Level - Non replay gained files"
+msgstr "PreAmp: arquivos sem ajuste de volume"
+
+#: id:643
+msgid "Avoid clipping on replay gained files"
+msgstr "Evitar cortes em arquivos com ajuste de volume"
+
+#: id:644
+msgid "Crop black bars"
+msgstr "Cortar barras pretas"
+
+#: id:645
+msgid "Need to unpack a big file. Continue?"
+msgstr "É preciso descompactar um arquivo grande. Continuar?"
+
+#: id:646
+msgid "Remove from library"
+msgstr "Remover da coleção"
+
+#: id:647
+msgid "Export video library"
+msgstr "Exportar coleção de vídeos"
+
+#: id:648
+msgid "Import video library"
+msgstr "Importar coleção de vídeos"
+
+#: id:649
+msgid "Importing"
+msgstr "Importando"
+
+#: id:650
+msgid "Exporting"
+msgstr "Exportando"
+
+#: id:651
+msgid "Browse for library"
+msgstr "Busca por coleção"
+
+#: id:652
+msgid "Years"
+msgstr "Anos"
+
+#: id:653
+msgid "Update library"
+msgstr "Atualizar coleção"
+
+#: id:654
+msgid "Show debug info"
+msgstr "Exibir depuração"
+
+#: id:655
+msgid "Browse for executable"
+msgstr "Busca por executável"
+
+#: id:656
+msgid "Browse for playlist"
+msgstr "Busca lista de reprodução"
+
+#: id:657
+msgid "Browse for folder"
+msgstr "Busca pasta"
+
+#: id:658
+msgid "Song information"
+msgstr "Informação da música"
+
+#: id:659
+msgid "Non-linear stretch"
+msgstr "Expansão não-linear"
+
+#: id:660
+msgid "Volume amplification"
+msgstr "Amplificação de volume"
+
+#: id:661
+msgid "Choose export folder"
+msgstr "Pasta de exportação"
+
+#: id:662
+msgid "This file is no longer available."
+msgstr "Este arquivo não está mais disponível."
+
+#: id:663
+msgid "Would you like to remove it from the library?"
+msgstr "Gostaria de remover da coleção?"
+
+#: id:664
+msgid "Browse for Script"
+msgstr "Busca Script"
+
+#: id:665
+msgid "Compression level"
+msgstr "Nível de Compressão"
+
+#: id:700
+msgid "Cleaning up library"
+msgstr "Limpando a coleção"
+
+#: id:701
+msgid "Removing old songs from the library"
+msgstr "Removendo músicas antigas da coleção"
+
+#: id:702
+msgid "This path has been scanned before"
+msgstr "Este caminho já foi examinado anteriormente"
+
+#: id:705
+msgctxt "Auto context with id 705"
+msgid "Network"
+msgstr "Rede"
+
+#: id:706
+msgid "- Server"
+msgstr "- Servidor"
+
+#: id:708
+msgid "Use an HTTP proxy server to access the internet"
+msgstr "Ativar proxy HTTP"
+
+#: id:711
+msgid "Internet Protocol (IP)"
+msgstr "Internet Protocol (IP)"
+
+#: id:712
+msgid "Invalid port specified. Value must be between 1 and 65535."
+msgstr "Porta inválida. O valor deve ser entre 1 e 65535."
+
+#: id:713
+msgid "HTTP proxy"
+msgstr "Proxy HTTP"
+
+#: id:715
+msgid "- Assignment"
+msgstr "- Atribuição"
+
+#: id:716
+msgid "Automatic (DHCP)"
+msgstr "Automático (DHCP)"
+
+#: id:717
+msgid "Manual (Static)"
+msgstr "Manual (estático)"
+
+#: id:719
+msgid "- IP address"
+msgstr "- Endereço IP:"
+
+#: id:720
+msgid "- Netmask"
+msgstr "- Máscara de sub-rede:"
+
+#: id:721
+msgid "- Default gateway"
+msgstr "- Gateway padrão:"
+
+#: id:722
+msgid "- DNS server"
+msgstr "- Servidor DNS:"
+
+#: id:723
+msgid "Save & restart"
+msgstr "Salvar & reiniciar"
+
+#: id:724
+msgid "Invalid address specified. Value must be AAA.BBB.CCC.DDD"
+msgstr "Endereço IP inválido. O valor deve ser AAA.BBB.CCC.DDD"
+
+#: id:725
+msgid "with numbers between 0 and 255."
+msgstr "Com números entre 0 e 255."
+
+#: id:726
+msgid "Changes not saved. Continue without saving?"
+msgstr "As mudanças não foram salvas. Deseja continuar mesmo assim?"
+
+#: id:727
+msgid "Web server"
+msgstr "Servidor Web"
+
+#: id:728
+msgctxt "Auto context with id 728"
+msgid "FTP server"
+msgstr "Servidor FTP"
+
+#: id:730
+msgid "- Port"
+msgstr "- Porta"
+
+#: id:732
+msgid "Save & apply"
+msgstr "Salvar & aplicar"
+
+#: id:733
+msgid "- Password"
+msgstr "- Senha"
+
+#: id:734
+msgid "No pass"
+msgstr "Sem senha"
+
+#: id:735
+msgid "- Character set"
+msgstr "- Codificação"
+
+#: id:736
+msgid "- Style"
+msgstr "- Estilo"
+
+#: id:737
+msgid "- Colour"
+msgstr "- Cor"
+
+#: id:738
+msgctxt "Auto context with id 738"
+msgid "Normal"
+msgstr "Normal"
+
+#: id:739
+msgid "Bold"
+msgstr "Negrito"
+
+#: id:740
+msgid "Italics"
+msgstr "Itálico"
+
+#: id:741
+msgid "Bold italics"
+msgstr "Negrito itálico"
+
+#: id:742
+msgctxt "Auto context with id 742"
+msgid "White"
+msgstr "Branco"
+
+#: id:743
+msgctxt "Auto context with id 743"
+msgid "Yellow"
+msgstr "Amarelo"
+
+#: id:744
+msgctxt "Auto context with id 744"
+msgid "Files"
+msgstr "Arquivos"
+
+#: id:745
+msgid "No scanned information for this view"
+msgstr "Não há informação para essa visualização"
+
+#: id:746
+msgid "Please turn off library mode"
+msgstr "Desative modo de coleção"
+
+#: id:747
+msgid "Error loading image"
+msgstr "Erro ao carregar imagem"
+
+#: id:748
+msgid "Edit path"
+msgstr "Editar caminho"
+
+#: id:749
+msgid "Mirror image"
+msgstr "Espelhar imagem"
+
+#: id:750
+msgid "Are you sure?"
+msgstr "Tem certeza?"
+
+#: id:751
+msgid "Removing source"
+msgstr "Removendo origem"
+
+#: id:754
+msgid "Add program link"
+msgstr "Adicionar link de programa"
+
+#: id:755
+msgid "Edit program path"
+msgstr "Editar caminho do programa"
+
+#: id:756
+msgid "Edit program name"
+msgstr "Editar nome do programa"
+
+#: id:757
+msgid "Edit path depth"
+msgstr "Editar a profundidade do caminho"
+
+#: id:759
+msgid "View: Big list"
+msgstr "Ver: lista grande"
+
+#: id:760
+msgctxt "Auto context with id 760"
+msgid "Yellow"
+msgstr "Amarelo"
+
+#: id:761
+msgctxt "Auto context with id 761"
+msgid "White"
+msgstr "Branco"
+
+#: id:762
+msgid "Blue"
+msgstr "Azul"
+
+#: id:763
+msgid "Bright green"
+msgstr "Verde claro"
+
+#: id:764
+msgid "Yellow green"
+msgstr "Verde amarelado"
+
+#: id:765
+msgid "Cyan"
+msgstr "Ciano"
+
+#: id:766
+msgid "Light grey"
+msgstr "Cinza claro"
+
+#: id:767
+msgid "Grey"
+msgstr "Cinza"
+
+#: id:770
+msgid "Error %i: share not available"
+msgstr "Erro %i: compartilhamento não disponível"
+
+#: id:772
+msgctxt "Auto context with id 772"
+msgid "Audio output"
+msgstr "Saída de áudio"
+
+#: id:773
+msgid "Seeking"
+msgstr "Procurando"
+
+#: id:774
+msgid "Slideshow folder"
+msgstr "Pasta de apresentação (slideshow)"
+
+#: id:775
+msgid "Network interface"
+msgstr "Interface de rede"
+
+#: id:776
+msgid "- Wireless network name (ESSID)"
+msgstr "- Nome da rede sem fio (ESSID)"
+
+#: id:777
+msgid "- Wireless password"
+msgstr "- Senha da rede sem fio"
+
+#: id:778
+msgid "- Wireless security"
+msgstr "- Segurança da rede sem fio"
+
+#: id:779
+msgid "Save and apply network interface settings"
+msgstr "Salvar e aplicar configurações de rede"
+
+#: id:780
+msgid "No encryption"
+msgstr "Sem criptografia"
+
+#: id:781
+msgid "WEP"
+msgstr "WEP"
+
+#: id:782
+msgid "WPA"
+msgstr "WPA"
+
+#: id:783
+msgid "WPA2"
+msgstr "WPA2"
+
+#: id:784
+msgid "Applying network interface settings. Please wait."
+msgstr "Aplicando configurações de rede. Por favor, aguarde."
+
+#: id:785
+msgid "Network interface restarted successfully."
+msgstr "Interface de rede reinicializada com sucesso."
+
+#: id:786
+msgid "Network interface did not start successfully."
+msgstr "Interface de rede não pode ser inicializada."
+
+#: id:787
+msgid "Interface disabled"
+msgstr "Interface de rede desabilitada"
+
+#: id:788
+msgid "Network interface disabled successfully."
+msgstr "Interface de rede desabilitada com sucesso."
+
+#: id:789
+msgid "Wireless network name (ESSID)"
+msgstr "Nome da rede sem fio (ESSID)"
+
+#: id:790
+msgid "Remote control"
+msgstr ""
+
+#: id:791
+msgid "Allow programs on this system to control XBMC"
+msgstr "Permitir programas locais controlar o XBMC"
+
+#: id:792
+msgctxt "Auto context with id 792"
+msgid "Port"
+msgstr "Porta"
+
+#: id:793
+msgid "Port range"
+msgstr "Intervalo de portas"
+
+#: id:794
+msgid "Allow programs on other systems to control XBMC"
+msgstr "Permitir programas remotos controlar o XBMC"
+
+#: id:795
+msgid "Initial repeat delay (ms)"
+msgstr "Atraso de repetição inicial (ms)"
+
+#: id:796
+msgid "Continuous repeat delay (ms)"
+msgstr "Atraso de repetição contínuo (ms)"
+
+#: id:797
+msgid "Maximum number of clients"
+msgstr "Número máximo de clientes"
+
+#: id:798
+msgid "Internet access"
+msgstr "Acesso internet"
+
+#: id:850
+msgid "Invalid port number entered"
+msgstr "Número de porta inválido"
+
+#: id:851
+msgid "Valid port range is 1-65535"
+msgstr "Intervalor de portas válido 1-65535"
+
+#: id:852
+msgid "Valid port range is 1024-65535"
+msgstr "Intervalor de portas válido 1024-65535"
+
+#: id:998
+msgid "Add Music..."
+msgstr "Adicione Música..."
+
+#: id:999
+msgid "Add Videos..."
+msgstr "Adicione Vídeos..."
+
+#: id:1000
+msgid "- Preview"
+msgstr "- Previsualização"
+
+#: id:1001
+msgid "Unable to connect"
+msgstr "Incapaz de conectar"
+
+#: id:1002
+msgid "XBMC was unable to connect to the network location."
+msgstr "O XBMC foi incapaz de conectar ao local de rede"
+
+#: id:1003
+msgid "This could be due to the network not being connected."
+msgstr "Isto pode ser devido a rede não estar conectada."
+
+#: id:1004
+msgid "Would you like to add it anyway?"
+msgstr "Gostaria de adicionar assim mesmo?"
+
+#: id:1006
+msgctxt "Auto context with id 1006"
+msgid "IP address"
+msgstr "Endereço IP"
+
+#: id:1007
+msgid "Add network location"
+msgstr "Adicionar Local de rede"
+
+#: id:1008
+msgid "Protocol"
+msgstr "Protocolo"
+
+#: id:1009
+msgid "Server address"
+msgstr "Endereço do servidor"
+
+#: id:1010
+msgid "Server name"
+msgstr "Nome do servidor"
+
+#: id:1011
+msgid "Remote path"
+msgstr "Caminho remoto"
+
+#: id:1012
+msgid "Shared folder"
+msgstr "Pasta compartilhada"
+
+#: id:1013
+msgctxt "Auto context with id 1013"
+msgid "Port"
+msgstr "Porta"
+
+#: id:1014
+msgctxt "Auto context with id 1014"
+msgid "Username"
+msgstr "Nome de usuário"
+
+#: id:1015
+msgid "Browse for network server"
+msgstr "Buscar servidor de rede"
+
+#: id:1016
+msgid "Enter the network address of the server"
+msgstr "Digite o endereço de rede do servidor"
+
+#: id:1017
+msgid "Enter the path on the server"
+msgstr "Digite o caminho no servidor"
+
+#: id:1018
+msgid "Enter the port number"
+msgstr "Digite o número da porta"
+
+#: id:1019
+msgid "Enter the username"
+msgstr "Digite o nome de usuário"
+
+#: id:1020
+msgid "Add %s source"
+msgstr "Adicionar origem %s"
+
+#: id:1021
+msgid "Enter the paths or browse for the media locations."
+msgstr "Digite o caminho ou busque a localização de mídia."
+
+#: id:1022
+msgid "Enter a name for this media Source."
+msgstr "Digite um nome para a mídia de origem."
+
+#: id:1023
+msgid "Browse for new share"
+msgstr "Buscar por novo compartilhamento"
+
+#: id:1024
+msgid "Browse"
+msgstr "Buscar"
+
+#: id:1025
+msgid "Could not retrieve directory information."
+msgstr "Não foi possível encontrar informações do diretório."
+
+#: id:1026
+msgid "Add source"
+msgstr "Adicionar origem"
+
+#: id:1027
+msgid "Edit source"
+msgstr "Editar origem"
+
+#: id:1028
+msgid "Edit %s source"
+msgstr "Editar origem %s"
+
+#: id:1029
+msgid "Enter the new label"
+msgstr "Digite o novo nome"
+
+#: id:1030
+msgid "Browse for image"
+msgstr "Procurar imagem"
+
+#: id:1031
+msgid "Browse for image folder"
+msgstr "Procurar pasta de imagem"
+
+#: id:1032
+msgid "Add network location..."
+msgstr "Adicionar local de rede..."
+
+#: id:1033
+msgid "Browse for file"
+msgstr "Procurar por arquivo"
+
+#: id:1034
+msgid "Submenu"
+msgstr "Sub-menu"
+
+#: id:1035
+msgid "Enable submenu buttons"
+msgstr "Habilitar botões de sub-menu"
+
+#: id:1036
+msgid "Favourites"
+msgstr "Favoritos"
+
+#: id:1037
+msgid "Video Add-ons"
+msgstr "Add-ons de vídeo"
+
+#: id:1038
+msgid "Music Add-ons"
+msgstr "Add-ons de música"
+
+#: id:1039
+msgid "Picture Add-ons"
+msgstr "Add-ons de imagens"
+
+#: id:1040
+msgid "Loading directory"
+msgstr "Carregando diretório"
+
+#: id:1041
+msgid "Retrieved %i items"
+msgstr "Recuperados %i items"
+
+#: id:1042
+msgid "Retrieved %i of %i items"
+msgstr "Recuperados %i de %i items"
+
+#: id:1043
+msgid "Program Add-ons"
+msgstr "Add-ons de programas"
+
+#: id:1044
+msgid "Set plugin thumb"
+msgstr "Selecionar ícone de plugin"
+
+#: id:1045
+msgid "Add-on settings"
+msgstr "Opções do addon"
+
+#: id:1046
+msgid "Access points"
+msgstr "Pontos de acesso (sem fio)"
+
+#: id:1047
+msgid "Other..."
+msgstr "Outros..."
+
+#: id:1048
+msgid "- Username"
+msgstr "- Usuário"
+
+#: id:1049
+msgid "Script settings"
+msgstr "Opções do Script"
+
+#: id:1050
+msgid "Singles"
+msgstr "Singles"
+
+#: id:1051
+msgid "Enter web address"
+msgstr "Digite a URL"
+
+#: id:1200
+msgid "SMB client"
+msgstr "Cliente SMB"
+
+#: id:1202
+msgid "Workgroup"
+msgstr "Grupo de trabalho"
+
+#: id:1203
+msgid "Default username"
+msgstr "Usuário padrão"
+
+#: id:1204
+msgid "Default password"
+msgstr "Senha padrão"
+
+#: id:1207
+msgid "WINS server"
+msgstr "Servidor WINS"
+
+#: id:1208
+msgid "Mount SMB shares"
+msgstr "Montar compartilhamento SMB"
+
+#: id:1210
+msgctxt "Auto context with id 1210"
+msgid "Remove"
+msgstr "Remover"
+
+#: id:1211
+msgctxt "Auto context with id 1211"
+msgid "Music"
+msgstr "Música"
+
+#: id:1212
+msgctxt "Auto context with id 1212"
+msgid "Video"
+msgstr "Vídeo"
+
+#: id:1213
+msgctxt "Auto context with id 1213"
+msgid "Pictures"
+msgstr "Imagens"
+
+#: id:1214
+msgctxt "Auto context with id 1214"
+msgid "Files"
+msgstr "Arquivos"
+
+#: id:1215
+msgctxt "Auto context with id 1215"
+msgid "Music & video"
+msgstr "Música & vídeo"
+
+#: id:1216
+msgid "Music & pictures"
+msgstr "Música & imagens"
+
+#: id:1217
+msgid "Music & files"
+msgstr "Música & arquivos"
+
+#: id:1218
+msgid "Video & pictures"
+msgstr "Vídeo & imagens"
+
+#: id:1219
+msgid "Video & files"
+msgstr "Vídeo & arquivos"
+
+#: id:1220
+msgid "Pictures & files"
+msgstr "Imagens & arquivos"
+
+#: id:1221
+msgid "Music & video & pictures"
+msgstr "Música & vídeo & imag."
+
+#: id:1222
+msgid "Music & video & pictures & files"
+msgstr "Todos"
+
+#: id:1223
+msgctxt "Auto context with id 1223"
+msgid "Disabled"
+msgstr "Desativado"
+
+#: id:1226
+msgid "Files & music & video"
+msgstr "Arquivo & música & vídeo"
+
+#: id:1227
+msgid "Files & pictures & music"
+msgstr "Arquivo & imagem & música"
+
+#: id:1228
+msgid "Files & pictures & video"
+msgstr "Arquivo & imagem & vídeo"
+
+#: id:1229
+msgid "Music & programs"
+msgstr "Música & programas"
+
+#: id:1230
+msgid "Video & programs"
+msgstr "Vídeo & programas"
+
+#: id:1231
+msgid "Pictures & programs"
+msgstr "Imagens & programas"
+
+#: id:1232
+msgid "Music & video & pictures & programs"
+msgstr "Música & vídeo & imagens & programas"
+
+#: id:1233
+msgid "Programs & video & music"
+msgstr "Programas & vídeo & música"
+
+#: id:1234
+msgid "Programs & pictures & music"
+msgstr "Programas & imagens & música"
+
+#: id:1235
+msgid "Programs & pictures & video"
+msgstr "Programas & imagens & vídeo"
+
+#: id:1250
+msgid "Auto-detection"
+msgstr "Auto detecção"
+
+#: id:1251
+msgid "Auto-detect system"
+msgstr "Auto detectar sistemas"
+
+#: id:1252
+msgid "Nickname"
+msgstr "Apelido"
+
+#: id:1254
+msgid "Ask to connect"
+msgstr "Perguntar para conectar"
+
+#: id:1255
+msgid "Send FTP user and password"
+msgstr "Enviar usuário e senha de FTP"
+
+#: id:1256
+msgid "Ping interval"
+msgstr "Intervalo de ping"
+
+#: id:1257
+msgid "Would you like to connect to the auto-detected system?"
+msgstr "Gostaria de conectar ao sistema auto detectado?"
+
+#: id:1259
+msgid "Zeroconf"
+msgstr ""
+
+#: id:1260
+msgid "Announce these services to other systems via Zeroconf"
+msgstr "Anunciar estes serviços para outros sistemas via Zeroconf"
+
+#: id:1270
+msgid "Allow XBMC to receive AirPlay content"
+msgstr "Permitir ao XBMC receber conteúdo AirPlay"
+
+#: id:1271
+msgid "Device name"
+msgstr "Nome Equipamento"
+
+#: id:1272
+msgid "- Use password protection"
+msgstr "- Usar senha para proteção"
+
+#: id:1273
+msgid "AirPlay"
+msgstr ""
+
+#: id:1300
+msgid "Custom audio device"
+msgstr "Dispositivo de áudio personalizado"
+
+#: id:1301
+msgid "Custom passthrough device"
+msgstr "Dispositivo de passagem personalizado"
+
+#: id:1396
+msgid "Drifting"
+msgstr "Correntes de ar"
+
+#: id:1397
+msgid "and"
+msgstr "e"
+
+#: id:1398
+msgid "Freezing"
+msgstr "Congelando"
+
+#: id:1399
+msgid "Late"
+msgstr "Tarde"
+
+#: id:1400
+msgid "Isolated"
+msgstr "Isoladas"
+
+#: id:1401
+msgid "Thundershowers"
+msgstr "Chuva com trovoadas"
+
+#: id:1402
+msgid "Thunder"
+msgstr "Trovão"
+
+#: id:1403
+msgctxt "Auto context with id 1403"
+msgid "Sun"
+msgstr "Sol"
+
+#: id:1404
+msgid "Heavy"
+msgstr "Grossa"
+
+#: id:1405
+msgid "in"
+msgstr "no(a)"
+
+#: id:1406
+msgid "the"
+msgstr "o(a)"
+
+#: id:1407
+msgid "Vicinity"
+msgstr "Arredores"
+
+#: id:1408
+msgid "Ice"
+msgstr "Gelo"
+
+#: id:1409
+msgid "Crystals"
+msgstr "Cristais"
+
+#: id:1410
+msgid "Calm"
+msgstr "Calmo"
+
+#: id:1411
+msgid "with"
+msgstr "com"
+
+#: id:1412
+msgid "windy"
+msgstr "ventoso"
+
+#: id:1413
+msgid "drizzle"
+msgstr "chuvisco"
+
+#: id:1414
+msgid "Thunderstorm"
+msgstr "Trovoada"
+
+#: id:1415
+msgid "Drizzle"
+msgstr "Chuvisco"
+
+#: id:1416
+msgid "Foggy"
+msgstr "Enevoado"
+
+#: id:1417
+msgid "Grains"
+msgstr "Partículas"
+
+#: id:1418
+msgid "T-Storms"
+msgstr "Temporais"
+
+#: id:1419
+msgid "T-Showers"
+msgstr "Temporais"
+
+#: id:1420
+msgid "Moderate"
+msgstr "Moderado"
+
+#: id:1421
+msgid "Very High"
+msgstr "Muito Alto"
+
+#: id:1422
+msgid "Windy"
+msgstr "Ventoso"
+
+#: id:1423
+msgid "Mist"
+msgstr "Névoa"
+
+#: id:1450
+msgid "Put display to sleep when idle"
+msgstr "Colocar tela em descanso quando inativo"
+
+#: id:2050
+msgid "Runtime"
+msgstr "Executável"
+
+#: id:2100
+msgid "Script failed! : %s"
+msgstr "Falha no Script! : %s"
+
+#: id:2101
+msgid "Newer version needed - See log"
+msgstr "Necessário versão mais nova - Veja o log"
+
+#: id:4501
+msgid "Enable LCD/VFD"
+msgstr "Habilitar LCD/VFD"
+
+#: id:10000
+msgid "Home"
+msgstr "Home"
+
+#: id:10001
+msgctxt "Auto context with id 10001"
+msgid "Programs"
+msgstr "Programas"
+
+#: id:10002
+msgctxt "Auto context with id 10002"
+msgid "Pictures"
+msgstr "Imagens"
+
+#: id:10003
+msgctxt "Auto context with id 10003"
+msgid "File manager"
+msgstr "Arquivos"
+
+#: id:10004
+msgctxt "Auto context with id 10004"
+msgid "Settings"
+msgstr "Configurações"
+
+#: id:10005
+msgctxt "Auto context with id 10005"
+msgid "Music"
+msgstr "Música"
+
+#: id:10006
+msgctxt "Auto context with id 10006"
+msgid "Videos"
+msgstr "Vídeos"
+
+#: id:10007
+msgid "System information"
+msgstr "Informação do sistema"
+
+#: id:10008
+msgid "Settings - General"
+msgstr "Configurações - Geral"
+
+#: id:10009
+msgid "Settings - Screen"
+msgstr "Configurações - Tela"
+
+#: id:10010
+msgid "Settings - Appearance - GUI Calibration"
+msgstr "Configurações - Aparência - Ajustar Interface"
+
+#: id:10011
+msgid "Settings - Videos - Screen Calibration"
+msgstr "Configurações- Vídeos - Ajustar Tela"
+
+#: id:10012
+msgid "Settings - Pictures"
+msgstr "Configurações - Imagens"
+
+#: id:10013
+msgid "Settings - Programs"
+msgstr "Configurações - Programas"
+
+#: id:10014
+msgid "Settings - Weather"
+msgstr "Configurações - Tempo"
+
+#: id:10015
+msgid "Settings - Music"
+msgstr "Configurações - Músicas"
+
+#: id:10016
+msgid "Settings - System"
+msgstr "Configurações - Sistema"
+
+#: id:10017
+msgid "Settings - Videos"
+msgstr "Configurações - Vídeos"
+
+#: id:10018
+msgid "Settings - Network"
+msgstr "Configurações - Rede"
+
+#: id:10019
+msgid "Settings - Appearance"
+msgstr "Configurações - Aparência"
+
+#: id:10020
+msgctxt "Auto context with id 10020"
+msgid "Scripts"
+msgstr "Scripts"
+
+#: id:10021
+msgid "Web Browser"
+msgstr "Navegador Web"
+
+#: id:10025
+msgctxt "Auto context with id 10025"
+msgid "Videos"
+msgstr ""
+
+#: id:10028
+msgid "Videos/Playlist"
+msgstr "Vídeos/lista de reprodução"
+
+#: id:10029
+msgctxt "Auto context with id 10029"
+msgid "Login screen"
+msgstr "Tela de Login"
+
+#: id:10034
+msgid "Settings - Profiles"
+msgstr "Configurações - Perfil"
+
+#: id:10040
+msgid "Addon browser"
+msgstr "Addon-Navegador"
+
+#: id:10100
+msgid "Yes/No dialog"
+msgstr "Janela sim/não"
+
+#: id:10101
+msgid "Progress dialog"
+msgstr "Janela de progresso"
+
+#: id:10210
+msgid "Looking for subtitles..."
+msgstr "Procurando legendas..."
+
+#: id:10211
+msgid "Looking for or caching subtitles..."
+msgstr "Procurando ou armazenando legendas"
+
+#: id:10212
+msgid "terminating"
+msgstr "terminando"
+
+#: id:10213
+msgid "buffering"
+msgstr "carregando"
+
+#: id:10214
+msgid "Opening stream"
+msgstr "Abrindo sinal"
+
+#: id:10500
+msgid "Music/Playlist"
+msgstr "Música/lista de reprodução"
+
+#: id:10501
+msgid "Music/Files"
+msgstr "Música/arquivos"
+
+#: id:10502
+msgid "Music/Library"
+msgstr "Música/coleção"
+
+#: id:10503
+msgid "Playlist editor"
+msgstr "Editor de coleção"
+
+#: id:10504
+msgid "Top 100 songs"
+msgstr "As 100 melhores músicas"
+
+#: id:10505
+msgid "Top 100 albums"
+msgstr "Os 100 melhores álbuns"
+
+#: id:10506
+msgctxt "Auto context with id 10506"
+msgid "Programs"
+msgstr "Programas"
+
+#: id:10507
+msgid "Configuration"
+msgstr "Configurações"
+
+#: id:10508
+msgid "Weather forecast"
+msgstr "Previsão do tempo"
+
+#: id:10509
+msgid "Network gaming"
+msgstr "Jogos em rede"
+
+#: id:10510
+msgid "Extensions"
+msgstr "Extensões"
+
+#: id:10511
+msgctxt "Auto context with id 10511"
+msgid "System info"
+msgstr "Informações do sistema"
+
+#: id:10516
+msgid "Music - Library"
+msgstr "Músicas - Coleção"
+
+#: id:10517
+msgid "Now Playing - Music"
+msgstr "Tocando agora - Músicas"
+
+#: id:10522
+msgid "Now Playing - Videos"
+msgstr "Tocando agora - Vídeos"
+
+#: id:10523
+msgid "Album info"
+msgstr "Informação do álbum"
+
+#: id:10524
+msgid "Movie info"
+msgstr "Informação do filme"
+
+#: id:12000
+msgid "Select dialog"
+msgstr "Selec. janela"
+
+#: id:12001
+msgid "Music/Info"
+msgstr "Música/informação"
+
+#: id:12002
+msgid "Dialog OK"
+msgstr "Janela OK"
+
+#: id:12003
+msgid "Videos/Info"
+msgstr "Vídeos/informação"
+
+#: id:12004
+msgid "Scripts/Info"
+msgstr "Scripts/informação"
+
+#: id:12005
+msgid "Fullscreen video"
+msgstr "Vídeo em tela-cheia"
+
+#: id:12006
+msgid "Audio visualization"
+msgstr "Visualização de áudio"
+
+#: id:12008
+msgid "File stacking dialog"
+msgstr "Janela agrupamento de arquivos"
+
+#: id:12009
+msgid "Rebuild index..."
+msgstr "Reconstruindo índice..."
+
+#: id:12010
+msgid "Return to music window"
+msgstr "Voltar para janela de músicas"
+
+#: id:12011
+msgid "Return to videos window"
+msgstr "Voltar para janela de vídeos"
+
+#: id:12021
+msgid "Start from beginning"
+msgstr "Iniciar/Reiniciar"
+
+#: id:12022
+msgid "Resume from %s"
+msgstr "Retomar da posição %s"
+
+#: id:12310
+msgid "0"
+msgstr "0"
+
+#: id:12311
+msgid "1"
+msgstr "1"
+
+#: id:12312
+msgid "2"
+msgstr "2"
+
+#: id:12313
+msgid "3"
+msgstr "3"
+
+#: id:12314
+msgid "4"
+msgstr "4"
+
+#: id:12315
+msgid "5"
+msgstr "5"
+
+#: id:12316
+msgid "6"
+msgstr "6"
+
+#: id:12317
+msgid "7"
+msgstr "7"
+
+#: id:12318
+msgid "8"
+msgstr "8"
+
+#: id:12319
+msgid "9"
+msgstr "9"
+
+#: id:12320
+msgid "c"
+msgstr "c"
+
+#: id:12321
+msgid "Ok"
+msgstr "ok"
+
+#: id:12322
+msgid "*"
+msgstr "*"
+
+#: id:12325
+msgid "Locked! Enter code..."
+msgstr "Bloqueada! Digite o código..."
+
+#: id:12326
+msgid "Enter password"
+msgstr "Entre com a senha"
+
+#: id:12327
+msgid "Enter master code"
+msgstr "Entre com o código-mestre"
+
+#: id:12328
+msgid "Enter unlock code"
+msgstr "Entre com o código de desbloqueio"
+
+#: id:12329
+msgid "or press C to cancel"
+msgstr "ou pressione C para cancelar"
+
+#: id:12330
+msgid "Enter gamepad button combo and"
+msgstr "Selecione a combinação de botões e"
+
+#: id:12331
+msgid "press OK, or Back to cancel"
+msgstr "pressione OK ou Back para cancelar"
+
+#: id:12332
+msgid "Set lock"
+msgstr "Configurar bloqueio"
+
+#: id:12333
+msgid "Unlock"
+msgstr "Desbloquear"
+
+#: id:12334
+msgid "Reset lock"
+msgstr "Zerar bloqueio"
+
+#: id:12335
+msgid "Remove lock"
+msgstr "Remover bloqueio"
+
+#: id:12337
+msgid "Numeric password"
+msgstr "Senha numérica"
+
+#: id:12338
+msgid "Gamepad button combo"
+msgstr "Combinação de botões"
+
+#: id:12339
+msgid "Full-text password"
+msgstr "Senha com texto"
+
+#: id:12340
+msgid "Enter new password"
+msgstr "Entre com a nova senha"
+
+#: id:12341
+msgid "Re-Enter new password"
+msgstr "Re-digite a nova senha"
+
+#: id:12342
+msgid "Incorrect password,"
+msgstr "Senha incorreta,"
+
+#: id:12343
+msgid "retries left"
+msgstr "tentativas restantes"
+
+#: id:12344
+msgid "Passwords entered did not match."
+msgstr "As senhas digitadas são diferentes."
+
+#: id:12345
+msgid "Access denied"
+msgstr "Acesso negado"
+
+#: id:12346
+msgid "Password retry limit exceeded."
+msgstr "O limite de tentativas de senha foi excedido."
+
+#: id:12347
+msgid "The system will now shut off."
+msgstr "O sistema será desligado agora."
+
+#: id:12348
+msgid "Item locked"
+msgstr "Item bloqueado"
+
+#: id:12353
+msgid "Reactivate lock"
+msgstr "Reativar bloqueio"
+
+#: id:12356
+msgid "Change lock"
+msgstr "Alterar bloqueio"
+
+#: id:12357
+msgid "Source lock"
+msgstr "Bloqueio de origem"
+
+#: id:12358
+msgid "Password entry was blank. Try again."
+msgstr "A senha digitada estava em branco. Tente novamente."
+
+#: id:12360
+msgid "Master lock"
+msgstr "Bloqueio-mestre"
+
+#: id:12362
+msgid "Shutdown system if Master Lock retries exceeded"
+msgstr "Desligar sistema se o número de tentativas for excedido"
+
+#: id:12367
+msgid "Master code is not valid"
+msgstr "Código-mestre não é válido!"
+
+#: id:12368
+msgid "Please enter a valid master code"
+msgstr "Digite um código-mestre válido!"
+
+#: id:12373
+msgid "Settings & file manager"
+msgstr "Configurações & arquivos"
+
+#: id:12376
+msgid "Set as default for all movies"
+msgstr "Definir como padrão para todos os filmes"
+
+#: id:12377
+msgid "This will reset any previously saved values"
+msgstr "Isto irá zerar qualquer valor previamente salvo"
+
+#: id:12378
+msgid "Amount of time to display each image"
+msgstr "Exibir cada imagem por"
+
+#: id:12379
+msgid "Use pan and zoom effects"
+msgstr "Usar efeitos de pan e zoom"
+
+#: id:12383
+msgid "12 hour clock"
+msgstr "relógio 12 horas"
+
+#: id:12384
+msgid "24 hour clock"
+msgstr "relógio 24 horas"
+
+#: id:12385
+msgid "Day/Month"
+msgstr "Dia/Mês"
+
+#: id:12386
+msgid "Month/Day"
+msgstr "Mês/Dia"
+
+#: id:12390
+msgid "System uptime"
+msgstr "Uptime do sistema"
+
+#: id:12391
+msgid "Minutes"
+msgstr "Minutos"
+
+#: id:12392
+msgid "Hours"
+msgstr "Horas"
+
+#: id:12393
+msgid "Days"
+msgstr "Dias"
+
+#: id:12394
+msgid "Total uptime"
+msgstr "Uptime total"
+
+#: id:12395
+msgid "Battery level"
+msgstr "Nível Bateria"
+
+#: id:12600
+msgctxt "Auto context with id 12600"
+msgid "Weather"
+msgstr "Tempo"
+
+#: id:12900
+msgctxt "Auto context with id 12900"
+msgid "Screensaver"
+msgstr "Proteção de tela"
+
+#: id:12901
+msgid "Fullscreen OSD"
+msgstr "OSD em tela-cheia"
+
+#: id:13000
+msgid "System"
+msgstr "Sistema"
+
+#: id:13001
+msgid "Immediate HD spindown"
+msgstr "Diminuir rotação do HD"
+
+#: id:13002
+msgid "Video only"
+msgstr "Somente vídeos"
+
+#: id:13003
+msgid "- Delay"
+msgstr "- Atraso"
+
+#: id:13004
+msgid "- Minimum file duration"
+msgstr "- Tempo mínimo de duração"
+
+#: id:13005
+msgid "Shutdown"
+msgstr "Desligar"
+
+#: id:13008
+msgid "Shutdown function"
+msgstr "Modo de desligamento"
+
+#: id:13009
+msgid "Quit"
+msgstr "Terminar"
+
+#: id:13010
+msgid "Hibernate"
+msgstr "Hibernar"
+
+#: id:13011
+msgid "Suspend"
+msgstr "Suspender"
+
+#: id:13012
+msgid "Exit"
+msgstr "Sair"
+
+#: id:13013
+msgid "Reboot"
+msgstr "Reinicializar"
+
+#: id:13014
+msgid "Minimize"
+msgstr "Minimizar"
+
+#: id:13015
+msgid "Power button action"
+msgstr "Ação do botão de Liga/Desliga"
+
+#: id:13016
+msgid "Power off System"
+msgstr "Desligar o sistema"
+
+#: id:13020
+msgid "Is another session active, perhaps over ssh?"
+msgstr "Tem outra sessão ativa, talvez por ssh?"
+
+#: id:13021
+msgid "Mounted removable harddrive"
+msgstr "Disco rígido removível montado"
+
+#: id:13022
+msgid "Unsafe device removal"
+msgstr "Remoção insegura de dispositivo"
+
+#: id:13023
+msgid "Successfully removed device"
+msgstr "Dispositivo removido com sucesso"
+
+#: id:13024
+msgid "Joystick plugged"
+msgstr "Joystick conectado"
+
+#: id:13025
+msgid "Joystick unplugged"
+msgstr "Joystick desconectado"
+
+#: id:13050
+msgid "Running low on battery"
+msgstr "Bateria fraca"
+
+#: id:13100
+msgid "Flicker filter"
+msgstr "Filtro de anti-oscilação"
+
+#: id:13101
+msgid "Let driver choose (requires restart)"
+msgstr "Deixe driver escolher (necessita reinicializar)"
+
+#: id:13105
+msgid "Vertical blank sync"
+msgstr "Sincronização vertical"
+
+#: id:13106
+msgctxt "Auto context with id 13106"
+msgid "Disabled"
+msgstr "Desabilitado"
+
+#: id:13107
+msgid "Enabled during video playback"
+msgstr "Habilitado durante execução de vídeo"
+
+#: id:13108
+msgctxt "Auto context with id 13108"
+msgid "Always enabled"
+msgstr "Sempre habilitado"
+
+#: id:13109
+msgid "Test & apply resolution"
+msgstr "Testar e aplicar resolução"
+
+#: id:13110
+msgid "Save resolution?"
+msgstr "Salvar resolução?"
+
+#: id:13111
+msgid "Would you like to keep this resolution?"
+msgstr "Manter esta resolução?"
+
+#: id:13112
+msgid "High quality upscaling"
+msgstr "Aumento de resolução em alta qualidade"
+
+#: id:13113
+msgctxt "Auto context with id 13113"
+msgid "Disabled"
+msgstr "Desabilitado"
+
+#: id:13114
+msgid "Enabled for SD content"
+msgstr "Habilitado para conteúdo SD"
+
+#: id:13115
+msgctxt "Auto context with id 13115"
+msgid "Always enabled"
+msgstr "Sempre habilitado"
+
+#: id:13116
+msgid "Upscaling method"
+msgstr "Método de aumento de resolução"
+
+#: id:13117
+msgctxt "Auto context with id 13117"
+msgid "Bicubic"
+msgstr "Bicúbico"
+
+#: id:13118
+msgid "Lanczos"
+msgstr "Lanczos"
+
+#: id:13119
+msgid "Sinc"
+msgstr "Sinc"
+
+#: id:13120
+msgctxt "Auto context with id 13120"
+msgid "VDPAU"
+msgstr "VDPAU"
+
+#: id:13121
+msgid "VDPAU HQ Upscaling level"
+msgstr "Nível VDPAU HQ Upscaling"
+
+#: id:13122
+msgid "VDPAU Studio level color conversion"
+msgstr "Nível de conversão de cores VDPAU Studio"
+
+#: id:13130
+msgid "Blank other displays"
+msgstr "Escurecer outras telas"
+
+#: id:13131
+msgctxt "Auto context with id 13131"
+msgid "Disabled"
+msgstr "Desabilitado"
+
+#: id:13132
+msgid "Blank displays"
+msgstr "Limpar telas"
+
+#: id:13140
+msgid "Active connections detected!"
+msgstr "Detectadas coneções ativas!"
+
+#: id:13141
+msgid "If you proceed, you might not be able to control XBMC"
+msgstr "Se continuar, poderá perder o controle do XBMC"
+
+#: id:13142
+msgid "any longer. Are you sure you want to stop the Event server?"
+msgstr "Tem certeza que quer parar o servidor de Eventos?"
+
+#: id:13144
+msgid "Change Apple Remote mode?"
+msgstr "Trocar o modo \"Apple Remote\"?"
+
+#: id:13145
+msgid "If you are currently using the Apple Remote to control"
+msgstr "Se está utilizando o \"Apple Remote\" agora para controlar"
+
+#: id:13146
+msgid "XBMC, changing this setting might affect your ability"
+msgstr "XBMC, trocar esta configuração pode afetar sua habilidade"
+
+#: id:13147
+msgid "to continue controlling it. Do you want to proceed?"
+msgstr "de continuar controlando ele. Você deseja prosseguir?"
+
+#: id:13159
+msgid "Subnet mask"
+msgstr "Máscara de sub-rede"
+
+#: id:13160
+msgid "Gateway"
+msgstr "Gateway"
+
+#: id:13161
+msgid "Primary DNS"
+msgstr "DNS primário"
+
+#: id:13162
+msgid "Initialize failed"
+msgstr "Falha na inicialização"
+
+#: id:13170
+msgctxt "Auto context with id 13170"
+msgid "Never"
+msgstr "Nunca"
+
+#: id:13171
+msgid "Immediately"
+msgstr "Imediatamente"
+
+#: id:13172
+msgid "After %i secs"
+msgstr "Depois de %i segs"
+
+#: id:13173
+msgid "HDD install date:"
+msgstr "Data de instalação do HDD:"
+
+#: id:13174
+msgid "HDD power cycle count:"
+msgstr "Re-ligamentos do HDD:"
+
+#: id:13200
+msgid "Profiles"
+msgstr "Perfis"
+
+#: id:13201
+msgid "Delete profile '%s'?"
+msgstr "Excluir perfil '%s'?"
+
+#: id:13204
+msgid "Last loaded profile:"
+msgstr "Último perfil utilizado:"
+
+#: id:13205
+msgid "Unknown"
+msgstr "Desconhecido"
+
+#: id:13206
+msgid "Overwrite"
+msgstr "Sobrescrever"
+
+#: id:13208
+msgid "Alarm clock"
+msgstr "Alarme do relógio"
+
+#: id:13209
+msgid "Alarm clock interval (in minutes)"
+msgstr "Intervalo do alarme (em minutos)"
+
+#: id:13210
+msgid "Started, alarm in %im"
+msgstr "Iniciado, alarmar em %im"
+
+#: id:13211
+msgid "Alarm!"
+msgstr "Alarme!"
+
+#: id:13212
+msgid "Canceled with %im%is left"
+msgstr "Cancelado restando %im%is"
+
+#: id:13213
+msgid "%2.0fm"
+msgstr "%2.0fm"
+
+#: id:13214
+msgid "%2.0fs"
+msgstr "%2.0fs"
+
+#: id:13249
+msgid "Search for subtitles in RARs"
+msgstr "Procurar por legendas em RARs"
+
+#: id:13250
+msgid "Browse for subtitle..."
+msgstr "Buscar por legendas..."
+
+#: id:13251
+msgid "Move item"
+msgstr "Mover item"
+
+#: id:13252
+msgid "Move item here"
+msgstr "Mover item aqui"
+
+#: id:13253
+msgid "Cancel move"
+msgstr "Cancelar mover"
+
+#: id:13270
+msgid "Hardware:"
+msgstr "Hardware:"
+
+#: id:13271
+msgid "CPU Usage:"
+msgstr "Uso da CPU:"
+
+#: id:13274
+msgid "Connected, but no DNS is available."
+msgstr "Conectado, mas nenhum DNS disponível."
+
+#: id:13275
+msgid "Hard Disk"
+msgstr "Disco rígido"
+
+#: id:13276
+msgid "DVD-ROM"
+msgstr "DVD-ROM"
+
+#: id:13277
+msgctxt "Auto context with id 13277"
+msgid "Storage"
+msgstr "Armazenamento"
+
+#: id:13278
+msgctxt "Auto context with id 13278"
+msgid "Default"
+msgstr "Padrão"
+
+#: id:13279
+msgctxt "Auto context with id 13279"
+msgid "Network"
+msgstr "Rede"
+
+#: id:13280
+msgctxt "Auto context with id 13280"
+msgid "Video"
+msgstr "Vídeo"
+
+#: id:13281
+msgid "Hardware"
+msgstr "Hardware"
+
+#: id:13283
+msgid "Operating system:"
+msgstr "Sistema Operacional:"
+
+#: id:13284
+msgid "CPU speed:"
+msgstr "Velocidade da CPU:"
+
+#: id:13286
+msgid "Video encoder:"
+msgstr "Encoder de vídeo:"
+
+#: id:13287
+msgid "Screen resolution:"
+msgstr "Resolução de tela:"
+
+#: id:13292
+msgid "A/V cable:"
+msgstr "Cabo A/V:"
+
+#: id:13294
+msgid "DVD region:"
+msgstr "Região do DVD:"
+
+#: id:13295
+msgid "Internet:"
+msgstr "Internet:"
+
+#: id:13296
+msgctxt "Auto context with id 13296"
+msgid "Connected"
+msgstr "Conectado"
+
+#: id:13297
+msgid "Not connected. Check network settings."
+msgstr "Desconectado. Verifique as opções de rede."
+
+#: id:13299
+msgid "Target temperature"
+msgstr "Temperatura desejada:"
+
+#: id:13300
+msgid "Fan speed"
+msgstr "Velocidade do ventilador"
+
+#: id:13301
+msgid "Auto temperature control"
+msgstr "Controle automático de temperatura"
+
+#: id:13302
+msgid "Fan speed override"
+msgstr "Controle da velocidade do ventilador"
+
+#: id:13303
+msgid "- Fonts"
+msgstr "- Fontes"
+
+#: id:13304
+msgid "Enable flipping bi-directional strings"
+msgstr "Ativar legendas da direita para esquerda"
+
+#: id:13305
+msgid "Show RSS news feeds"
+msgstr "Exibir notícias RSS"
+
+#: id:13306
+msgid "Show parent folder items"
+msgstr "Exibir pasta superior"
+
+#: id:13307
+msgid "Track naming template"
+msgstr "Formato do nome das faixas"
+
+#: id:13308
+msgid "Do you wish to reboot your system"
+msgstr "Deseja reiniciar o sistema"
+
+#: id:13309
+msgid "instead of just XBMC?"
+msgstr "ao invés do XBMC?"
+
+#: id:13310
+msgid "Zoom effect"
+msgstr "Efeito de zoom"
+
+#: id:13311
+msgid "Float effect"
+msgstr "Efeito de flutuação"
+
+#: id:13312
+msgid "Black bar reduction"
+msgstr "Redução de borda preta"
+
+#: id:13313
+msgid "Restart"
+msgstr "Reiniciar"
+
+#: id:13314
+msgid "Crossfade between songs"
+msgstr "Transição suave entre músicas"
+
+#: id:13315
+msgid "Regenerate thumbnails"
+msgstr "Refazer ícones"
+
+#: id:13316
+msgid "Recursive thumbnails"
+msgstr "Ícones recursivos"
+
+#: id:13317
+msgid "View slideshow"
+msgstr "Ver apresentação"
+
+#: id:13318
+msgid "Recursive slideshow"
+msgstr "Apresentação recursiva"
+
+#: id:13319
+msgid "Randomize"
+msgstr "Aleatório"
+
+#: id:13320
+msgid "Stereo"
+msgstr "Estéreo"
+
+#: id:13321
+msgid "Left only"
+msgstr "Apenas esquerda"
+
+#: id:13322
+msgid "Right only"
+msgstr "Apenas direita"
+
+#: id:13323
+msgid "Enable karaoke support"
+msgstr "Habilitar suporte ao karaokê"
+
+#: id:13324
+msgid "Background transparency"
+msgstr "Transparência do fundo"
+
+#: id:13325
+msgid "Foreground transparency"
+msgstr "Transparência do primeiro plano"
+
+#: id:13326
+msgid "A/V delay"
+msgstr "Atraso A/V"
+
+#: id:13327
+msgid "Karaoke"
+msgstr "Karaokê"
+
+#: id:13328
+msgid "%s not found"
+msgstr "%s não encontrado."
+
+#: id:13329
+msgid "Error opening %s"
+msgstr "Erro ao abrir %s"
+
+#: id:13330
+msgid "Unable to load %s"
+msgstr "Erro ao carregar %s"
+
+#: id:13331
+msgid "Error: Out of memory"
+msgstr "Erro: sem memória."
+
+#: id:13332
+msgid "Move up"
+msgstr "Mover acima"
+
+#: id:13333
+msgid "Move down"
+msgstr "Mover abaixo"
+
+#: id:13334
+msgid "Edit label"
+msgstr "Editar etiqueta"
+
+#: id:13335
+msgid "Make default"
+msgstr "Tornar padrão"
+
+#: id:13336
+msgid "Remove button"
+msgstr "Remover botão"
+
+#: id:13340
+msgid "Leave as is"
+msgstr "Deixar como está"
+
+#: id:13341
+msgid "Green"
+msgstr "Verde"
+
+#: id:13342
+msgid "Orange"
+msgstr "Laranja"
+
+#: id:13343
+msgid "Red"
+msgstr "Vermelho"
+
+#: id:13344
+msgid "Cycle"
+msgstr "Alternar"
+
+#: id:13345
+msgid "Switch LED off on playback"
+msgstr "Desligar o LED durante a execução"
+
+#: id:13346
+msgctxt "Auto context with id 13346"
+msgid "Movie information"
+msgstr "Informação do filme"
+
+#: id:13347
+msgid "Queue item"
+msgstr "Adicionar item"
+
+#: id:13348
+msgid "Search IMDb..."
+msgstr "Pesquisar no IMDb..."
+
+#: id:13349
+msgid "Scan for new content"
+msgstr "Pesquisar por novas informações"
+
+#: id:13350
+msgid "Now playing..."
+msgstr "Agora executando..."
+
+#: id:13351
+msgctxt "Auto context with id 13351"
+msgid "Album information"
+msgstr "Informação do álbum"
+
+#: id:13352
+msgid "Scan item to library"
+msgstr "Examinar para a coleção"
+
+#: id:13353
+msgid "Stop scanning"
+msgstr "Parar procura"
+
+#: id:13354
+msgctxt "Auto context with id 13354"
+msgid "Render method"
+msgstr "Método de Render"
+
+#: id:13355
+msgid "Low quality pixel shader"
+msgstr "Pixel shader de baixa qualidade"
+
+#: id:13356
+msgid "Hardware overlays"
+msgstr "Overlay de hardware"
+
+#: id:13357
+msgid "High quality pixel shader"
+msgstr "Pixel shader de alta qualidade"
+
+#: id:13358
+msgid "Play item"
+msgstr "Reproduzir item"
+
+#: id:13359
+msgid "Set artist thumb"
+msgstr "Definir ícone do artista"
+
+#: id:13360
+msgid "Automatically generate thumbnails"
+msgstr "Gerar ícones automaticamente"
+
+#: id:13361
+msgid "Enable voice"
+msgstr "Ativar voz"
+
+#: id:13375
+msgid "Enable device"
+msgstr "Ativar dispositivo"
+
+#: id:13376
+msgid "Volume"
+msgstr "Volume"
+
+#: id:13377
+msgid "Default view mode"
+msgstr "Modo de visualização padrão"
+
+#: id:13378
+msgid "Default brightness"
+msgstr "Brilho padrão"
+
+#: id:13379
+msgid "Default contrast"
+msgstr "Contraste padrão"
+
+#: id:13380
+msgid "Default gamma"
+msgstr "Gamma padrão"
+
+#: id:13381
+msgid "Resume video"
+msgstr "Reiniciar vídeo"
+
+#: id:13382
+msgid "Voice mask - Port 1"
+msgstr "Máscara de voz - porta 1"
+
+#: id:13383
+msgid "Voice mask - Port 2"
+msgstr "Máscara de voz - porta 2"
+
+#: id:13384
+msgid "Voice mask - Port 3"
+msgstr "Máscara de voz - porta 3"
+
+#: id:13385
+msgid "Voice mask - Port 4"
+msgstr "Máscara de voz - porta 4"
+
+#: id:13386
+msgid "Use time based seeking"
+msgstr "Utilizar avanço/retorno baseados em tempo"
+
+#: id:13387
+msgid "Track naming template - right"
+msgstr "Gabarito para nome de faixa - direita"
+
+#: id:13388
+msgid "Preset"
+msgstr "Pré-ajustes"
+
+#: id:13389
+msgid "There are no presets available\nfor this visualization"
+msgstr "Não há pré-ajustes disponíveis para esta visualização"
+
+#: id:13390
+msgid "There are no settings available\nfor this visualization"
+msgstr "Não há configurações disponíveis para esta visualização"
+
+#: id:13391
+msgid "Eject/Load"
+msgstr "Ejetar/carregar"
+
+#: id:13392
+msgid "Use visualization if playing audio"
+msgstr "Usar visualização durante reprodução de áudio"
+
+#: id:13393
+msgid "Calculate size"
+msgstr "Calcular tamanho"
+
+#: id:13394
+msgid "Calculating folder size"
+msgstr "Calculando tamanho da pasta"
+
+#: id:13395
+msgid "Video settings"
+msgstr "Configurações de vídeo"
+
+#: id:13396
+msgid "Audio and subtitle settings"
+msgstr "Configurações de áudio e legendas"
+
+#: id:13397
+msgid "Enable subtitles"
+msgstr "Ativar legendas"
+
+#: id:13398
+msgctxt "Auto context with id 13398"
+msgid "Shortcuts"
+msgstr "Atalhos"
+
+#: id:13399
+msgid "Ignore articles when sorting (e.g. \"the\")"
+msgstr "Ignorar artigos (o/a/os/as/the) quando organizar"
+
+#: id:13400
+msgid "Crossfade between songs on the same album"
+msgstr "Transição suave nas faixas do mesmo álbum"
+
+#: id:13401
+msgid "Browse for %s"
+msgstr "Procurar por %s"
+
+#: id:13402
+msgid "Show track position"
+msgstr "Mostrar posição da faixa"
+
+#: id:13403
+msgid "Clear default"
+msgstr "Limpar padrão"
+
+#: id:13404
+msgid "Resume"
+msgstr "Reiniciar"
+
+#: id:13405
+msgid "Get thumb"
+msgstr "Obter ícone"
+
+#: id:13406
+msgid "Picture information"
+msgstr "Informação da imagem"
+
+#: id:13407
+msgid "%s presets"
+msgstr "%s Pré-ajustes"
+
+#: id:13408
+msgid "(IMDb user rating)"
+msgstr "(Qualificação de usuário IMDb)"
+
+#: id:13409
+msgid "Top 250"
+msgstr "Top 250"
+
+#: id:13410
+msgid "Tune in on Last.fm"
+msgstr "Sintonizar com Last.fm"
+
+#: id:13411
+msgid "Minimum fan speed"
+msgstr "Velocidade mínima do ventilador"
+
+#: id:13412
+msgid "Play from here"
+msgstr ""
+
+#: id:13413
+msgid "Downloading"
+msgstr "Baixando"
+
+#: id:13414
+msgid "Include artists who appear only on compilations"
+msgstr "Incluir artistas que só aparecem em compilações"
+
+#: id:13415
+msgctxt "Auto context with id 13415"
+msgid "Render method"
+msgstr "Método de renderização"
+
+#: id:13416
+msgid "Auto detect"
+msgstr "Auto detectar"
+
+#: id:13417
+msgid "Basic shaders (ARB)"
+msgstr "Sombreamento básico (ARB)"
+
+#: id:13418
+msgid "Advanced shaders (GLSL)"
+msgstr "Sombreamento avançado (GLSL)"
+
+#: id:13419
+msgid "Software"
+msgstr "Software"
+
+#: id:13420
+msgid "Remove safely"
+msgstr "Desconectar com segurança"
+
+#: id:13421
+msgctxt "Auto context with id 13421"
+msgid "VDPAU"
+msgstr "VDPAU"
+
+#: id:13422
+msgid "Start slideshow here"
+msgstr "Iniciar apresentação aqui"
+
+#: id:13423
+msgid "Remember for this path"
+msgstr "Relembrar para este caminho"
+
+#: id:13424
+msgid "Use pixel buffer objects"
+msgstr "Usar objetos buffer de pixel"
+
+#: id:13425
+msgid "Allow hardware acceleration (VDPAU)"
+msgstr "Permitir aceleração por hardware (VDPAU)"
+
+#: id:13426
+msgid "Allow hardware acceleration (VAAPI)"
+msgstr "Permitir aceleração por hardware (VAAPI)"
+
+#: id:13427
+msgid "Allow hardware acceleration (DXVA2)"
+msgstr "Permitir aceleração por hardware (DXVA2)"
+
+#: id:13428
+msgid "Allow hardware acceleration (CrystalHD)"
+msgstr "Permitir aceleração por hardware (CrystalHD)"
+
+#: id:13429
+msgid "Allow hardware acceleration (VDADecoder)"
+msgstr "Permitir aceleração por hardware (VDADecoder)"
+
+#: id:13430
+msgid "Allow hardware acceleration (OpenMax)"
+msgstr "Permitir aceleração por hardware (OpenMax)"
+
+#: id:13431
+msgid "Pixel Shaders"
+msgstr "Pixel Shaders"
+
+#: id:13432
+msgid "Allow hardware acceleration (VideoToolbox)"
+msgstr "Permitir aceleração por hardware (VideoToolbox)"
+
+#: id:13500
+msgid "A/V sync method"
+msgstr "Método de syncronização de A/V"
+
+#: id:13501
+msgid "Audio clock"
+msgstr "Relógio de áudio"
+
+#: id:13502
+msgid "Video clock (Drop/Dupe audio)"
+msgstr "Relógio de vídeo (cortar/ignorar áudio)"
+
+#: id:13503
+msgid "Video clock (Resample audio)"
+msgstr "Relógio de vídeo (reamostragem de áudio)"
+
+#: id:13504
+msgid "Maximum resample amount (%)"
+msgstr "Máximo (%) de reamostragem"
+
+#: id:13505
+msgid "Resample quality"
+msgstr "Qualidade de reamostragem"
+
+#: id:13506
+msgid "Low(fast)"
+msgstr "Baixo(rápido)"
+
+#: id:13507
+msgctxt "Auto context with id 13507"
+msgid "Medium"
+msgstr "Médio"
+
+#: id:13508
+msgctxt "Auto context with id 13508"
+msgid "High"
+msgstr "Alto"
+
+#: id:13509
+msgid "Really high(slow!)"
+msgstr "Realmente alto(lento!)"
+
+#: id:13510
+msgid "Sync playback to display"
+msgstr "Sincronizar reprodução com a exibição"
+
+#: id:13550
+msgid "Pause during refresh rate change"
+msgstr "Pausa durante alteração na taxa de atualização"
+
+#: id:13551
+msgctxt "Auto context with id 13551"
+msgid "Off"
+msgstr "Desligado"
+
+#: id:13552
+msgid "%.1f Second"
+msgstr "%.1f Segundo"
+
+#: id:13553
+msgid "%.1f Seconds"
+msgstr "%.1f Segundos"
+
+#: id:13600
+msgid "Apple remote"
+msgstr "Controle Remoto Apple"
+
+#: id:13602
+msgid "Allow start of XBMC using the remote"
+msgstr "Permite iniciar o XBMC através do Controle Remoto"
+
+#: id:13603
+msgid "Sequence delay time"
+msgstr "Tempo de espera para sequenciamento"
+
+#: id:13610
+msgctxt "Auto context with id 13610"
+msgid "Disabled"
+msgstr "Desabilitado"
+
+#: id:13611
+msgctxt "Auto context with id 13611"
+msgid "Standard"
+msgstr "Padrão"
+
+#: id:13612
+msgid "Universal Remote"
+msgstr "Controle Remoto Universal"
+
+#: id:13613
+msgid "Multi Remote (Harmony)"
+msgstr "Controle Remoto universal (Harmony)"
+
+#: id:13620
+msgid "Apple Remote Error"
+msgstr "Erro Controle Remoto Apple"
+
+#: id:13621
+msgid "Apple Remote support could be enabled."
+msgstr "Suporte ao Controle Remoto Apple pode ser habilitado."
+
+#: id:14000
+msgid "Stack"
+msgstr "Agrupar"
+
+#: id:14001
+msgid "Unstack"
+msgstr "Desagrupar"
+
+#: id:14003
+msgid "Downloading playlist file..."
+msgstr "Baixando lista de execução..."
+
+#: id:14004
+msgid "Downloading streams list..."
+msgstr "Recebendo lista de canais..."
+
+#: id:14005
+msgid "Parsing streams list..."
+msgstr "Interpretando lista de canais..."
+
+#: id:14006
+msgid "Downloading streams list failed"
+msgstr "Recebimento da lista de canais falhou"
+
+#: id:14007
+msgid "Downloading playlist file failed"
+msgstr "Recebimento de lista de execução falhou"
+
+#: id:14009
+msgid "Games directory"
+msgstr "Diretório de jogos"
+
+#: id:14010
+msgid "Auto switch to thumbs based on"
+msgstr "Troca automática para ícones baseado em"
+
+#: id:14011
+msgid "Enable auto switching to thumbs view"
+msgstr "Ativar troca automática para ícones"
+
+#: id:14012
+msgid "- Use large icons"
+msgstr "- Usar ícones grandes"
+
+#: id:14013
+msgid "- Switch based on"
+msgstr "- Trocar baseado em"
+
+#: id:14014
+msgid "- Percentage"
+msgstr "- Porcentagem"
+
+#: id:14015
+msgid "No files and at least one thumb"
+msgstr "Sem arquivos e pelo menos um ícone"
+
+#: id:14016
+msgid "At least one file and thumb"
+msgstr "Ao menos um arquivo e um ícone"
+
+#: id:14017
+msgid "Percentage of thumbs"
+msgstr "Porcentagem de ícones"
+
+#: id:14018
+msgid "View options"
+msgstr "Visualização"
+
+#: id:14019
+msgid "Change area code 1"
+msgstr "Mudar área de código 1"
+
+#: id:14020
+msgid "Change area code 2"
+msgstr "Mudar área de código 2"
+
+#: id:14021
+msgid "Change area code 3"
+msgstr "Mudar área de código 3"
+
+#: id:14022
+msgctxt "Auto context with id 14022"
+msgid "Library"
+msgstr "Coleção"
+
+#: id:14023
+msgid "No TV"
+msgstr "Sem TV"
+
+#: id:14024
+msgid "Enter the nearest large town"
+msgstr "Digite a cidade (grande) mais próxima"
+
+#: id:14025
+msgid "Video/Audio/DVD cache - Harddisk"
+msgstr "Cache de vídeo/áudio/DVD - Disco rígido"
+
+#: id:14026
+msgid "Video cache - DVD-ROM"
+msgstr "Cache de vídeo - DVD-ROM"
+
+#: id:14027
+msgctxt "Auto context with id 14027"
+msgid "- Local Network"
+msgstr "- Rede local"
+
+#: id:14028
+msgctxt "Auto context with id 14028"
+msgid "- Internet"
+msgstr "- Internet"
+
+#: id:14030
+msgid "Audio cache - DVD-ROM"
+msgstr "Cache de áudio - DVD-ROM"
+
+#: id:14031
+msgctxt "Auto context with id 14031"
+msgid "- Local Network"
+msgstr "- Rede local"
+
+#: id:14032
+msgctxt "Auto context with id 14032"
+msgid "- Internet"
+msgstr "- Internet"
+
+#: id:14034
+msgid "DVD cache - DVD-ROM"
+msgstr "Cache do DVD - DVD-ROM"
+
+#: id:14035
+msgctxt "Auto context with id 14035"
+msgid "- Local Network"
+msgstr "- Rede local"
+
+#: id:14036
+msgctxt "Auto context with id 14036"
+msgid "Services"
+msgstr "Serviços"
+
+#: id:14038
+msgid "Network settings changed"
+msgstr "Configurações de rede modificadas"
+
+#: id:14039
+msgid "XBMC requires to restart to change your"
+msgstr "O XBMC precisa reiniciar para aplicar as suas"
+
+#: id:14040
+msgid "network setup. Would you like to restart now?"
+msgstr "configurações de rede. Deseja reiniciar agora?"
+
+#: id:14041
+msgid "Internet connection bandwidth limitation"
+msgstr "Limitação de banda de Internet"
+
+#: id:14043
+msgid "- Shutdown while playing"
+msgstr "- Desligar durante a execução"
+
+#: id:14044
+msgid "%i min"
+msgstr "%i mins"
+
+#: id:14045
+msgid "%i sec"
+msgstr "%i segs"
+
+#: id:14046
+msgid "%i ms"
+msgstr "%i ms"
+
+#: id:14047
+msgid "%i %%"
+msgstr "%i %%"
+
+#: id:14048
+msgid "%i kbps"
+msgstr "%i kbps"
+
+#: id:14049
+msgid "%i kb"
+msgstr "%i kb"
+
+#: id:14050
+msgid "%i.0 dB"
+msgstr "%i.0 dB"
+
+#: id:14051
+msgid "Time format"
+msgstr "Formato da hora"
+
+#: id:14052
+msgid "Date format"
+msgstr "Formato da data"
+
+#: id:14053
+msgid "GUI filters"
+msgstr "Filtros de interface"
+
+#: id:14055
+msgid "Use background scanning"
+msgstr "Usar busca em segundo plano"
+
+#: id:14056
+msgid "Stop scan"
+msgstr "Parar busca"
+
+#: id:14057
+msgid "Not possible while scanning for media info"
+msgstr "Impossível enquanto estiver buscando informações da mídia"
+
+#: id:14058
+msgid "Film grain effect"
+msgstr "Efeito granulado de filme"
+
+#: id:14059
+msgid "Search for thumbnails on remote shares"
+msgstr "Procurar ícones em compartilhamentos remotos"
+
+#: id:14060
+msgid "Unknown type cache - Internet"
+msgstr "Tipo de cache desconhecido - internet"
+
+#: id:14061
+msgctxt "Auto context with id 14061"
+msgid "Auto"
+msgstr "Auto"
+
+#: id:14062
+msgid "Enter username for"
+msgstr "Entre nome de usuário para"
+
+#: id:14063
+msgid "Date & time"
+msgstr "Data & hora"
+
+#: id:14064
+msgid "Set date"
+msgstr "Definir data"
+
+#: id:14065
+msgid "Set time"
+msgstr "Definir hora"
+
+#: id:14066
+msgid "Enter the time in 24 hour HH:MM format"
+msgstr "Digite a hora no formato 24 horas HH:MM"
+
+#: id:14067
+msgid "Enter the date in DD/MM/YYYY format"
+msgstr "Digite a data no formato DD/MM/AAAA"
+
+#: id:14068
+msgid "Enter the IP address"
+msgstr "Digite o endereço IP"
+
+#: id:14069
+msgid "Apply these settings now?"
+msgstr "Aplicar as configurações agora?"
+
+#: id:14070
+msgid "Apply changes now"
+msgstr "Aplicar mudanças agora"
+
+#: id:14071
+msgid "Allow file renaming and deletion"
+msgstr "Permitir renomear e excluir arquivos"
+
+#: id:14074
+msgid "Set timezone"
+msgstr "Selecionar fuso horário"
+
+#: id:14075
+msgid "Use daylight saving time"
+msgstr "Ajustar para horário de verão"
+
+#: id:14076
+msgid "Add to favourites"
+msgstr "Adicionar a favoritos"
+
+#: id:14077
+msgid "Remove from favourites"
+msgstr "Remover de favoritos"
+
+#: id:14078
+msgctxt "Auto context with id 14078"
+msgid "- Colours"
+msgstr "- Cores"
+
+#: id:14079
+msgid "Timezone country"
+msgstr "País do Fuso horário"
+
+#: id:14080
+msgid "Timezone"
+msgstr "Fuso horário"
+
+#: id:14081
+msgid "File lists"
+msgstr "Listas de arquivos"
+
+#: id:14082
+msgid "Show EXIF picture information"
+msgstr "Exibir informações EXIF de imagens"
+
+#: id:14083
+msgid "Use a fullscreen window rather than true fullscreen"
+msgstr "Usar janela maximizada ao invés de tela cheia"
+
+#: id:14084
+msgid "Queue songs on selection"
+msgstr "Enfileirar músicas ao selecionar"
+
+#: id:14086
+msgid "Playback"
+msgstr "Reproduzir"
+
+#: id:14087
+msgid "DVDs"
+msgstr "DVDs"
+
+#: id:14088
+msgid "Play DVDs automatically"
+msgstr "Reproduzir DVDs automaticamente"
+
+#: id:14089
+msgid "Font to use for text subtitles"
+msgstr "Fonte para uso em legendas de texto"
+
+#: id:14090
+msgid "International"
+msgstr "Internacional"
+
+#: id:14091
+msgid "Character set"
+msgstr "Conjunto de caracteres"
+
+#: id:14092
+msgid "Debugging"
+msgstr "Depurando"
+
+#: id:14093
+msgid "Security"
+msgstr "Segurança"
+
+#: id:14094
+msgid "Input devices"
+msgstr "Disp. de Entrada"
+
+#: id:14095
+msgid "Power saving"
+msgstr "Econ. de energia"
+
+#: id:14096
+msgid "Rip"
+msgstr "Ripar"
+
+#: id:14097
+msgid "Audio CD Insert Action"
+msgstr "Ação ao Inserir Áudio CD"
+
+#: id:14098
+msgctxt "Auto context with id 14098"
+msgid "Play"
+msgstr "Reproduzir"
+
+#: id:14099
+msgid "Eject disc when CD ripping is complete"
+msgstr "Ejetar o disco quando ripar CD tiver sido concluído"
+
+#: id:15015
+msgctxt "Auto context with id 15015"
+msgid "Remove"
+msgstr "Remove"
+
+#: id:15016
+msgid "Games"
+msgstr "Jogos"
+
+#: id:15019
+msgid "Add"
+msgstr "Adicionar"
+
+#: id:15052
+msgid "Password"
+msgstr "Senha"
+
+#: id:15100
+msgctxt "Auto context with id 15100"
+msgid "Library"
+msgstr "Coleção"
+
+#: id:15101
+msgid "Database"
+msgstr "Banco de dados"
+
+#: id:15102
+msgid "* All albums"
+msgstr "* Todos álbuns"
+
+#: id:15103
+msgid "* All artists"
+msgstr "* Todos artistas"
+
+#: id:15104
+msgid "* All songs"
+msgstr "* Todas as músicas"
+
+#: id:15105
+msgid "* All genres"
+msgstr "* Todos gêneros"
+
+#: id:15107
+msgid "Buffering..."
+msgstr "Carregando..."
+
+#: id:15108
+msgid "Navigation sounds"
+msgstr "Sons de navegação"
+
+#: id:15109
+msgid "Skin default"
+msgstr "Skin padrão"
+
+#: id:15111
+msgid "- Theme"
+msgstr "- Tema"
+
+#: id:15112
+msgid "Default theme"
+msgstr "Tema padrão"
+
+#: id:15200
+msgid "Last.fm"
+msgstr "Last.fm"
+
+#: id:15201
+msgid "Submit songs to Last.fm"
+msgstr "Enviar músicas para o Last.fm"
+
+#: id:15202
+msgid "Last.fm username"
+msgstr "Nome de usuário Last.fm"
+
+#: id:15203
+msgid "Last.fm password"
+msgstr "Senha Last.fm"
+
+#: id:15204
+msgid "Unable to handshake: sleeping..."
+msgstr "Incapaz de negociar: descansando..."
+
+#: id:15205
+msgid "Please update XBMC"
+msgstr "Por favor atualize o XBMC"
+
+#: id:15206
+msgid "Bad authorization: Check username and password"
+msgstr "Autorização incorreta: Verifique usuário e senha"
+
+#: id:15207
+msgctxt "Auto context with id 15207"
+msgid "Connected"
+msgstr "Conectado"
+
+#: id:15208
+msgid "Not connected"
+msgstr "Não conectado"
+
+#: id:15209
+msgid "Submit interval %i"
+msgstr "Intervalo de envio %i"
+
+#: id:15210
+msgid "Cached %i songs"
+msgstr "%i músicas em cache"
+
+#: id:15211
+msgid "Submitting..."
+msgstr "Enviando..."
+
+#: id:15212
+msgid "Submitting in %i secs"
+msgstr "Enviando em %i segs"
+
+#: id:15213
+msgid "Play using..."
+msgstr "Reproduzir usando..."
+
+#: id:15214
+msgid "Use smoothed A/V synchronization"
+msgstr "Usar sincronização para A/V suavizada"
+
+#: id:15215
+msgid "Hide file names in thumbs view"
+msgstr "Ocultar nomes de arquivos na visualização de ícones"
+
+#: id:15216
+msgid "Play in party mode"
+msgstr "Reproduzir em modo-festa"
+
+#: id:15217
+msgid "Submit songs to Libre.fm"
+msgstr "Enviar músicas para o Libre.fm"
+
+#: id:15218
+msgid "Libre.fm username"
+msgstr "Nome de usuário do Libre.fm"
+
+#: id:15219
+msgid "Libre.fm password"
+msgstr "Senha do Libre.fm"
+
+#: id:15220
+msgid "Libre.fm"
+msgstr "Libre.fm"
+
+#: id:15221
+msgid "Song submission"
+msgstr "Scrobbler"
+
+#: id:15250
+msgid "Submit Last.fm radio to Last.fm"
+msgstr "Enviar a rádio para o Last.fm"
+
+#: id:15251
+msgid "Connecting to Last.fm..."
+msgstr "Conectando ao Last.fm..."
+
+#: id:15252
+msgid "Selecting station..."
+msgstr "Selecionando estação..."
+
+#: id:15253
+msgid "Search similar artists..."
+msgstr "Procurar por artistas similares..."
+
+#: id:15254
+msgid "Search similar tags..."
+msgstr "Procurar por gêneros similares..."
+
+#: id:15255
+msgid "Your profile (%name%)"
+msgstr "Seu perfil (%name%)"
+
+#: id:15256
+msgid "Overall top tags"
+msgstr "O melhor de todos os gêneros"
+
+#: id:15257
+msgid "Top artists for tag %name%"
+msgstr "Os melhores artistas do gênero %name%"
+
+#: id:15258
+msgid "Top albums for tag %name%"
+msgstr "Os melhores álbuns do gênero %name%"
+
+#: id:15259
+msgid "Top tracks for tag %name%"
+msgstr "Ás melhores músicas do gênero %name%"
+
+#: id:15260
+msgid "Listen to tag %name% Last.fm radio"
+msgstr "Ouvir gênero %name% no Last.fm"
+
+#: id:15261
+msgid "Similar artists as %name%"
+msgstr "Artistas similares a %name%"
+
+#: id:15262
+msgid "Top %name% albums"
+msgstr "Os melhores álbuns de %name%"
+
+#: id:15263
+msgid "Top %name% tracks"
+msgstr "As melhores músicas de %name%"
+
+#: id:15264
+msgid "Top %name% tags"
+msgstr "Os melhores gêneros de %name%"
+
+#: id:15265
+msgid "Biggest fans of %name%"
+msgstr "Os maiores fãs de %name%"
+
+#: id:15266
+msgid "Listen to %name% fans Last.fm radio"
+msgstr "Ouvir radios dos fãs de %name% no Last.fm"
+
+#: id:15267
+msgid "Listen to %name% similar artists Last.fm radio"
+msgstr "Ouvir por artistas similares a %name% na Last.fm"
+
+#: id:15268
+msgid "Top artists for user %name%"
+msgstr "Os melhores artistas para o usuário %name%"
+
+#: id:15269
+msgid "Top albums for user %name%"
+msgstr "Os melhores álbuns para o usuário %name%"
+
+#: id:15270
+msgid "Top tracks for user %name%"
+msgstr "As melhores músicas para o usuário %name%"
+
+#: id:15271
+msgid "Friends of user %name%"
+msgstr "Amigos do usuário %name%"
+
+#: id:15272
+msgid "Neighbours of user %name%"
+msgstr "Vizinhos do usuário %name%"
+
+#: id:15273
+msgid "Weekly artist chart for %name%"
+msgstr "Gráfico semanal do artista para %name%"
+
+#: id:15274
+msgid "Weekly album chart for %name%"
+msgstr "Gráfico semanal do álbum para %name%"
+
+#: id:15275
+msgid "Weekly track chart for %name%"
+msgstr "Gráfico semanal da música para %name%"
+
+#: id:15276
+msgid "Listen to %name%'s neighbours Last.fm radio"
+msgstr "Ouvir vizinhos de %name%'s no Last.fm"
+
+#: id:15277
+msgid "Listen to %name%'s personal Last.fm radio"
+msgstr "Ouvir músicas pessoais de %name%'s no Last.fm"
+
+#: id:15278
+msgid "Listen to %name%'s mix Last.fm radio"
+msgstr "Ouvir pelas mais pedidas de %name%'s no Last.fm"
+
+#: id:15279
+msgid "Retrieving list from Last.fm..."
+msgstr "Restaurando lista do Last.fm..."
+
+#: id:15280
+msgid "Can't retrieve list from Last.fm..."
+msgstr "Não pude recuperar lista do Last.fm..."
+
+#: id:15281
+msgid "Enter an artist name to find related ones"
+msgstr "Digite o nome do artista para encontrar outros similares"
+
+#: id:15282
+msgid "Enter a tag name to find similar ones"
+msgstr "Digite um gênero para encontrar similares"
+
+#: id:15283
+msgid "Tracks recently listened by %name%"
+msgstr "Faixas ouvidas recentemente por %name%"
+
+#: id:15284
+msgid "Listen to %name%'s recommendations Last.fm radio"
+msgstr "Ouça recomendações de %name%'s no Last.fm"
+
+#: id:15285
+msgid "Top tags for user %name%"
+msgstr "Melhores gêneros para usuário %name%"
+
+#: id:15287
+msgid "Do you want to add the current track to your loved tracks?"
+msgstr "Você quer adicionar a faixa atual para as suas faixas prediletas?"
+
+#: id:15288
+msgid "Do you want to ban the current track?"
+msgstr "Você quer banir a faixa atual?"
+
+#: id:15289
+msgid "Added to your loved tracks: '%s'."
+msgstr "Adicionado às suas faixas prediletas: '%s'."
+
+#: id:15290
+msgid "Could not add '%s' to your loved tracks."
+msgstr "Não foi possível adicionar '%s' em suas faixas prediletas."
+
+#: id:15291
+msgid "Banned: '%s'."
+msgstr "Banida: '%s'."
+
+#: id:15292
+msgid "Could not ban '%s'."
+msgstr "Não foi possível banir '%s'."
+
+#: id:15293
+msgid "Tracks recently loved by %name%"
+msgstr "Faixas recentemente prediletadas por %name%"
+
+#: id:15294
+msgid "Tracks recently banned by %name%"
+msgstr "Faixas recentemente banidas por %name%"
+
+#: id:15295
+msgid "Remove from loved tracks"
+msgstr "Remover de faixas prediletas"
+
+#: id:15296
+msgid "Un-ban"
+msgstr "Desbanir"
+
+#: id:15297
+msgid "Do you want to remove this track from your loved tracks?"
+msgstr "Você quer remover esta faixa de suas faixas prediletas?"
+
+#: id:15298
+msgid "Do you want to un-ban this track?"
+msgstr "Você quer desbanir esta faixa?"
+
+#: id:15300
+msgid "Path not found or invalid"
+msgstr "Caminho não encontrado ou inválido"
+
+#: id:15301
+msgid "Could not connect to network server"
+msgstr "Não foi possível conectar ao servidor da rede"
+
+#: id:15302
+msgid "No servers found"
+msgstr "Não encontrou servidores"
+
+#: id:15303
+msgid "Workgroup not found"
+msgstr "Grupo de trabalho não encontrado"
+
+#: id:15310
+msgid "Opening multi-path source"
+msgstr "Abrindo múltiplos caminhos para os marcadores"
+
+#: id:15311
+msgid "Path:"
+msgstr "Caminho:"
+
+#: id:16000
+msgctxt "Auto context with id 16000"
+msgid "General"
+msgstr "Geral"
+
+#: id:16002
+msgid "Internet lookup"
+msgstr "Busca na internet"
+
+#: id:16003
+msgid "Player"
+msgstr "Reprodutor"
+
+#: id:16004
+msgid "Play media from disc"
+msgstr "Reproduzir mídia do disco"
+
+#: id:16008
+msgid "Enter new title"
+msgstr "Digite um novo título"
+
+#: id:16009
+msgid "Enter the movie name"
+msgstr "Nome do filme"
+
+#: id:16010
+msgid "Enter the profile name"
+msgstr "Nome do perfil"
+
+#: id:16011
+msgid "Enter the album name"
+msgstr "Nome do álbum"
+
+#: id:16012
+msgid "Enter the playlist name"
+msgstr "Nome da lista de execução"
+
+#: id:16013
+msgid "Enter new filename"
+msgstr "Entre novo nome de arquivo"
+
+#: id:16014
+msgid "Enter folder name"
+msgstr "Nome da pasta"
+
+#: id:16015
+msgid "Enter directory"
+msgstr "Escolha o diretório"
+
+#: id:16016
+msgid "Available options: %A, %T, %N, %B, %D, %G, %Y, %F, %S"
+msgstr "Opções disponíveis: %A, %T, %N, %B, %D, %G, %Y, %F, %S"
+
+#: id:16017
+msgid "Enter search string"
+msgstr "Entre palavra a ser procurada"
+
+#: id:16018
+msgctxt "Auto context with id 16018"
+msgid "None"
+msgstr "Nenhum"
+
+#: id:16019
+msgid "Auto select"
+msgstr "Seleção automática"
+
+#: id:16020
+msgid "De-interlace"
+msgstr "Desentrelaçar"
+
+#: id:16021
+msgid "Bob"
+msgstr "Sincronização irregular"
+
+#: id:16022
+msgid "Bob (inverted)"
+msgstr "Sincronização plana"
+
+#: id:16024
+msgid "Canceling..."
+msgstr "Cancelando..."
+
+#: id:16025
+msgid "Enter the artist name"
+msgstr "Coloque o nome do artista"
+
+#: id:16026
+msgid "Playback failed"
+msgstr "Reprodução falhou"
+
+#: id:16027
+msgid "One or more items failed to play."
+msgstr "Um ou mais itens falharam na execução."
+
+#: id:16028
+msgid "Enter value"
+msgstr "Digite valor"
+
+#: id:16029
+msgid "Check the log file for details."
+msgstr "Para detalhes verifique o arquivo de logs."
+
+#: id:16030
+msgid "Party mode aborted."
+msgstr "Modo-festa cancelado."
+
+#: id:16031
+msgid "No matching songs in the library."
+msgstr "Nenhuma música encontrada na coleção."
+
+#: id:16032
+msgid "Could not initialize database."
+msgstr "Não pôde inicializar banco de dados."
+
+#: id:16033
+msgid "Could not open database."
+msgstr "Não pôde abrir banco de dados."
+
+#: id:16034
+msgid "Could not get songs from database."
+msgstr "Não pôde obter músicas do banco de dados."
+
+#: id:16035
+msgid "Party mode playlist"
+msgstr "Lista de execução em modo-festa"
+
+#: id:16036
+msgid "De-interlace (Half)"
+msgstr "De-interlace (Half)"
+
+#: id:16037
+msgid "Deinterlace video"
+msgstr "Desentrelaçamento video"
+
+#: id:16038
+msgid "Deinterlace method"
+msgstr "Método de Desentrelaçamento"
+
+#: id:16039
+msgctxt "Auto context with id 16039"
+msgid "Off"
+msgstr "Desligado"
+
+#: id:16040
+msgctxt "Auto context with id 16040"
+msgid "Auto"
+msgstr "Auto"
+
+#: id:16041
+msgid "On"
+msgstr "Ligado"
+
+#: id:16100
+msgid "All Videos"
+msgstr "Todos os vídeos"
+
+#: id:16101
+msgid "Unwatched"
+msgstr "Não-vistos"
+
+#: id:16102
+msgid "Watched"
+msgstr "Vistos"
+
+#: id:16103
+msgid "Mark as watched"
+msgstr "Marcar como visto"
+
+#: id:16104
+msgid "Mark as unwatched"
+msgstr "Marcar como não-visto"
+
+#: id:16105
+msgid "Edit title"
+msgstr "Editar título"
+
+#: id:16200
+msgid "Operation was aborted"
+msgstr "Operação foi cancelada"
+
+#: id:16201
+msgid "Copy failed"
+msgstr "Cópia falhou"
+
+#: id:16202
+msgid "Failed to copy at least one file"
+msgstr "Falha ao copiar pelo menos um arquivo"
+
+#: id:16203
+msgid "Move failed"
+msgstr "Mover falhou"
+
+#: id:16204
+msgid "Failed to move at least one file"
+msgstr "Falha ao mover pelo menos um arquivo"
+
+#: id:16205
+msgid "Delete failed"
+msgstr "Remover falhou"
+
+#: id:16206
+msgid "Failed to delete at least one file"
+msgstr "Falha ao remover pelo menos um arquivo"
+
+#: id:16300
+msgid "Video scaling method"
+msgstr "Método para escalamento de vídeo"
+
+#: id:16301
+msgid "Nearest neighbour"
+msgstr "Vizinho mais próximo"
+
+#: id:16302
+msgid "Bilinear"
+msgstr "Bilinear"
+
+#: id:16303
+msgctxt "Auto context with id 16303"
+msgid "Bicubic"
+msgstr "Bicúbico"
+
+#: id:16304
+msgid "Lanczos2"
+msgstr "Lanczos2"
+
+#: id:16305
+msgid "Lanczos3"
+msgstr "Lanczos3"
+
+#: id:16306
+msgid "Sinc8"
+msgstr "Sinc8"
+
+#: id:16307
+msgid "Bicubic (software)"
+msgstr "Bicubic (software)"
+
+#: id:16308
+msgid "Lanczos (software)"
+msgstr "Lanczos (software)"
+
+#: id:16309
+msgid "Sinc (software)"
+msgstr "Sinc (software)"
+
+#: id:16310
+msgid "Temporal"
+msgstr "Temporal"
+
+#: id:16311
+msgid "Temporal/Spatial"
+msgstr "Temporal/Espacial"
+
+#: id:16312
+msgid "(VDPAU)Noise Reduction"
+msgstr "(VDPAU)Noise Reduction"
+
+#: id:16313
+msgid "(VDPAU)Sharpness"
+msgstr "(VDPAU)Sharpness"
+
+#: id:16314
+msgid "Inverse Telecine"
+msgstr "Inverse Telecine"
+
+#: id:16315
+msgid "Lanczos3 optimized"
+msgstr "Lanczos3 optimized"
+
+#: id:16316
+msgctxt "Auto context with id 16316"
+msgid "Auto"
+msgstr "Auto"
+
+#: id:16317
+msgid "Temporal (Half)"
+msgstr "Temporal (Half)"
+
+#: id:16318
+msgid "Temporal/Spatial (Half)"
+msgstr "Temporal/Spatial (Half)"
+
+#: id:16319
+msgid "DXVA"
+msgstr "DXVA"
+
+#: id:16320
+msgid "DXVA Bob"
+msgstr "DXVA Bob"
+
+#: id:16321
+msgid "DXVA Best"
+msgstr "DXVA Best"
+
+#: id:16322
+msgid "Spline36"
+msgstr "Spline36"
+
+#: id:16323
+msgid "Spline36 optimized"
+msgstr "Spline36 otimizado"
+
+#: id:16324
+msgid "Software Blend"
+msgstr "Software Blend"
+
+#: id:16400
+msgid "Post-processing"
+msgstr "Pós-processamento de video"
+
+#: id:17500
+msgid "Display sleep timeout"
+msgstr "Exibir intervalo para descanso"
+
+#: id:19000
+msgid "Switch to channel"
+msgstr "Trocar para canal"
+
+#: id:20000
+msgid "Saved music folder"
+msgstr "Pasta de músicas salvas"
+
+#: id:20001
+msgid "Use external DVD player"
+msgstr "Usar DVD-player externo"
+
+#: id:20002
+msgid "External DVD player"
+msgstr "DVD-player externo"
+
+#: id:20003
+msgid "Trainers folder"
+msgstr "Pasta de trainers"
+
+#: id:20004
+msgid "Screenshot folder"
+msgstr "Pasta para captura de tela"
+
+#: id:20006
+msgid "Playlists folder"
+msgstr "Pasta lista de reprodução"
+
+#: id:20007
+msgid "Recordings"
+msgstr "Gravações"
+
+#: id:20008
+msgid "Screenshots"
+msgstr "Screenshots"
+
+#: id:20009
+msgid "Use XBMC"
+msgstr "Usar XBMC"
+
+#: id:20011
+msgid "Music playlists"
+msgstr "Lista de reprodução de músicas"
+
+#: id:20012
+msgid "Video playlists"
+msgstr "Lista de reprodução de vídeos"
+
+#: id:20013
+msgid "Do you wish to launch the game?"
+msgstr "Você gostaria de iniciar o jogo?"
+
+#: id:20014
+msgid "Sort by: Playlist"
+msgstr "Ver: lista de reprodução"
+
+#: id:20015
+msgid "Remote thumb"
+msgstr "Ícone remoto"
+
+#: id:20016
+msgid "Current thumb"
+msgstr "Ícone atual"
+
+#: id:20017
+msgid "Local thumb"
+msgstr "Ícone local"
+
+#: id:20018
+msgid "No thumb"
+msgstr "Nenhum ícone"
+
+#: id:20019
+msgid "Choose thumbnail"
+msgstr "Selecionar ícone"
+
+#: id:20023
+msgid "Conflict"
+msgstr "Conflito"
+
+#: id:20024
+msgid "Scan new"
+msgstr "Examinar novo"
+
+#: id:20025
+msgid "Scan all"
+msgstr "Examinar todos"
+
+#: id:20026
+msgid "Region"
+msgstr "Região"
+
+#: id:20037
+msgid "Summary"
+msgstr "Resumo"
+
+#: id:20038
+msgid "Lock music window"
+msgstr "Bloquear seção de música"
+
+#: id:20039
+msgid "Lock videos window"
+msgstr "Bloquear seção de vídeo"
+
+#: id:20040
+msgid "Lock pictures window"
+msgstr "Bloquear seção de imagens"
+
+#: id:20041
+msgid "Lock programs & scripts windows"
+msgstr "Bloquear janela de programas & scripts"
+
+#: id:20042
+msgid "Lock file manager"
+msgstr "Bloquear gerenciador de arquivos"
+
+#: id:20043
+msgid "Lock settings"
+msgstr "Bloquear configurações"
+
+#: id:20044
+msgid "Start fresh"
+msgstr "Iniciar de novo"
+
+#: id:20045
+msgid "Enter master mode"
+msgstr "Entrar em modo-mestre"
+
+#: id:20046
+msgid "Leave master mode"
+msgstr "Sair do modo-mestre"
+
+#: id:20047
+msgid "Create profile '%s'?"
+msgstr "Criar perfil '%s' ?"
+
+#: id:20048
+msgid "Start with fresh settings"
+msgstr "Iniciar com configurações novas"
+
+#: id:20049
+msgid "Best available"
+msgstr "Melhor disponível"
+
+#: id:20050
+msgid "Auto-switch between 16x9 and 4x3"
+msgstr "Trocar automaticamente entre 16x9 e 4x3"
+
+#: id:20051
+msgid "Treat stacked files as single file"
+msgstr "Tratar arquivos agrupados como um arquivo único"
+
+#: id:20052
+msgid "Caution"
+msgstr "Atenção"
+
+#: id:20053
+msgid "Left master mode"
+msgstr "Sair do modo-mestre"
+
+#: id:20054
+msgid "Entered master mode"
+msgstr "Entrou no modo-mestre"
+
+#: id:20055
+msgid "Allmusic.com thumb"
+msgstr "Ícone Allmusic.com"
+
+#: id:20057
+msgid "Remove thumbnail"
+msgstr "Remover ícone"
+
+#: id:20058
+msgid "Add profile..."
+msgstr "Adicionar perfil..."
+
+#: id:20059
+msgid "Query info for all albums"
+msgstr "Obter informação para todos os álbuns"
+
+#: id:20060
+msgctxt "Auto context with id 20060"
+msgid "Media info"
+msgstr "Informação de mídia"
+
+#: id:20061
+msgctxt "Auto context with id 20061"
+msgid "Separate"
+msgstr "Separado"
+
+#: id:20062
+msgid "Shares with default"
+msgstr "Compartilhamentos com padrão"
+
+#: id:20063
+msgid "Shares with default (read only)"
+msgstr "Compartilhamentos com padrão (apenas leitura)"
+
+#: id:20064
+msgid "Copy default"
+msgstr "Copiar padrão"
+
+#: id:20065
+msgid "Profile picture"
+msgstr "Imagem do perfil"
+
+#: id:20066
+msgid "Lock preferences"
+msgstr "Bloquear preferências"
+
+#: id:20067
+msgid "Edit profile"
+msgstr "Editar perfil"
+
+#: id:20068
+msgid "Profile lock"
+msgstr "Bloquear perfil"
+
+#: id:20069
+msgid "Could not create folder"
+msgstr "Não foi possível criar a pasta"
+
+#: id:20070
+msgid "Profile directory"
+msgstr "Diretório do perfil"
+
+#: id:20071
+msgid "Start with fresh media sources"
+msgstr "Iniciar com novas origens de mídia"
+
+#: id:20072
+msgid "Make sure the selected folder is writable"
+msgstr "Esteja certo de que a pasta selecionada possa ser escrita"
+
+#: id:20073
+msgid "and that the new folder name is valid"
+msgstr "e que o novo nome da pasta é válido"
+
+#: id:20074
+msgid "MPAA rating"
+msgstr "Classificação MPAA:"
+
+#: id:20075
+msgid "Enter master lock code"
+msgstr "Digite o código-mestre de bloqueio"
+
+#: id:20076
+msgid "Ask for master lock code on startup"
+msgstr "Pedir o código-mestre na inicialização"
+
+#: id:20077
+msgid "Skin settings"
+msgstr "Opções da skin"
+
+#: id:20078
+msgid "- no link set -"
+msgstr "- link não definido -"
+
+#: id:20079
+msgid "Enable animations"
+msgstr "Ativar animações"
+
+#: id:20080
+msgid "Disable RSS during music"
+msgstr "Desabilitar RSS durante músicas"
+
+#: id:20081
+msgid "Enable shortcut buttons"
+msgstr "Ativar botões de atalho"
+
+#: id:20082
+msgid "Show programs in main menu"
+msgstr "Mostrar informações do XLink Kai"
+
+#: id:20083
+msgid "Show music info"
+msgstr "Mostrar informações da música"
+
+#: id:20084
+msgid "Show weather info"
+msgstr "Mostrar informações do tempo"
+
+#: id:20085
+msgid "Show system info"
+msgstr "Mostrar informações do sistema"
+
+#: id:20086
+msgid "Show available disc space C: E: F:"
+msgstr "Mostrar espaço livre nos discos C: E: F:"
+
+#: id:20087
+msgid "Show available disc space E: F: G:"
+msgstr "Mostrar espaço livre nos discos E: F: G:"
+
+#: id:20088
+msgid "Weather info"
+msgstr "Informações do tempo"
+
+#: id:20089
+msgid "Drive space free"
+msgstr "Espaço livre em disco"
+
+#: id:20090
+msgid "Enter the name of an existing share"
+msgstr "Nome de um compartilhamento existente"
+
+#: id:20091
+msgid "Lock code"
+msgstr "Código de bloqueio"
+
+#: id:20092
+msgid "Load profile"
+msgstr "Carregar perfil"
+
+#: id:20093
+msgid "Profile name"
+msgstr "Nome do Perfil"
+
+#: id:20094
+msgctxt "Auto context with id 20094"
+msgid "Media sources"
+msgstr "Origens de mídia"
+
+#: id:20095
+msgid "Enter profile lock code"
+msgstr "Digite o código de bloqueio do perfil"
+
+#: id:20096
+msgctxt "Auto context with id 20096"
+msgid "Login screen"
+msgstr "Tela de login"
+
+#: id:20097
+msgid "Fetching album info"
+msgstr "Obtendo informações do álbum"
+
+#: id:20098
+msgid "Fetching info for album"
+msgstr "Obtendo informações para o álbum"
+
+#: id:20099
+msgid "Can't rip CD or track while playing from CD"
+msgstr "Não posso copiar (rip) CD ou faixa enquanto executa"
+
+#: id:20100
+msgid "Master lock code and settings"
+msgstr "Código-mestre e bloqueios"
+
+#: id:20101
+msgid "Entering master lock code always enables master mode"
+msgstr "Digitar código-mestre sempre ativa modo-mestre"
+
+#: id:20102
+msgid "or copy from default?"
+msgstr "ou copiar do padrão?"
+
+#: id:20103
+msgid "Save changes to profile?"
+msgstr "Salvar alterações para o perfil?"
+
+#: id:20104
+msgid "Old settings found."
+msgstr "Opções antigas encontradas."
+
+#: id:20105
+msgid "Do you want to use them?"
+msgstr "Você deseja usá-las?"
+
+#: id:20106
+msgid "Old media sources found."
+msgstr "Fontes antigas de mídia encontradas."
+
+#: id:20107
+msgid "Separate (locked)"
+msgstr "Separado (bloqueado)"
+
+#: id:20108
+msgid "Root"
+msgstr "Raiz"
+
+#: id:20109
+msgid "- Zoom"
+msgstr "- Zoom"
+
+#: id:20110
+msgid "UPnP settings"
+msgstr "Configurações UPnP"
+
+#: id:20111
+msgid "Autostart UPnP client"
+msgstr "Auto iniciar cliente UPnP"
+
+#: id:20112
+msgid "Last login: %s"
+msgstr "Último login: %s"
+
+#: id:20113
+msgid "Never logged on"
+msgstr "Nunca conectou"
+
+#: id:20114
+msgid "Profile %i / %i"
+msgstr "Perfil %i / %i"
+
+#: id:20115
+msgid "User login / Select a profile"
+msgstr "Login de usuário / Selecionar um perfil"
+
+#: id:20116
+msgid "Use lock on login screen"
+msgstr "Usar bloqueio na tela de login"
+
+#: id:20117
+msgid "Invalid lock code."
+msgstr "Código de bloqueio inválido."
+
+#: id:20118
+msgid "This requires the master lock to be set."
+msgstr "Isto requer o bloqueio-mestre para ser usado."
+
+#: id:20119
+msgid "Would you like to set it now?"
+msgstr "Você quer definir isso agora?"
+
+#: id:20120
+msgid "Loading program information"
+msgstr "Carregando informações do programa"
+
+#: id:20121
+msgid "Party on!"
+msgstr "Festa ativa!"
+
+#: id:20122
+msgid "True"
+msgstr "Verdadeiro"
+
+#: id:20123
+msgid "Mixing drinks"
+msgstr "Preparando drinks"
+
+#: id:20124
+msgid "Filling glasses"
+msgstr "Enchendo os copos"
+
+#: id:20125
+msgid "Logged on as"
+msgstr "Conectado como"
+
+#: id:20126
+msgid "Log off"
+msgstr "Desconectar"
+
+#: id:20128
+msgid "Go to root"
+msgstr "Ir para raiz"
+
+#: id:20129
+msgid "Weave"
+msgstr "Estruturar"
+
+#: id:20130
+msgid "Weave (inverted)"
+msgstr "Estruturar (invertido)"
+
+#: id:20131
+msgid "Blend"
+msgstr "Homogêneo"
+
+#: id:20132
+msgid "Restart video"
+msgstr "Reiniciar vídeo"
+
+#: id:20133
+msgid "Edit network location"
+msgstr "Editar locais de rede"
+
+#: id:20134
+msgid "Remove network location"
+msgstr "Remover locais de rede"
+
+#: id:20135
+msgid "Do you want to scan the folder?"
+msgstr "Você quer examinar a pasta?"
+
+#: id:20136
+msgid "Memory unit"
+msgstr "Unidade de memória"
+
+#: id:20137
+msgid "Memory unit mounted"
+msgstr "Unidade de memória montada"
+
+#: id:20138
+msgid "Unable to mount memory unit"
+msgstr "Impossível montar unidade de memória"
+
+#: id:20139
+msgid "In port %i, slot %i"
+msgstr "Na porta %i, slot %i"
+
+#: id:20140
+msgid "Lock screensaver"
+msgstr "Bloquear proteção de tela"
+
+#: id:20141
+msgid "Set"
+msgstr "Definir"
+
+#: id:20142
+msgctxt "Auto context with id 20142"
+msgid "Username"
+msgstr "Nome de usuário"
+
+#: id:20143
+msgid "Enter password for"
+msgstr "Digite senha para"
+
+#: id:20144
+msgid "Shutdown timer"
+msgstr "Cronômetro de desligamento"
+
+#: id:20145
+msgid "Shutdown interval (in minutes)"
+msgstr "Intervalo do desligamento (em minutos)"
+
+#: id:20146
+msgid "Started, shutdown in %im"
+msgstr "Iniciado, desligando em %im"
+
+#: id:20147
+msgid "Shutdown in 30 minutes"
+msgstr "Desligamento em 30 minutos"
+
+#: id:20148
+msgid "Shutdown in 60 minutes"
+msgstr "Desligamento em 60 minutos"
+
+#: id:20149
+msgid "Shutdown in 120 minutes"
+msgstr "Desligamento em 120 minutos"
+
+#: id:20150
+msgid "Custom shutdown timer"
+msgstr "Cronômetro personalizado"
+
+#: id:20151
+msgid "Cancel shutdown timer"
+msgstr "Cancelar cronômetro"
+
+#: id:20152
+msgid "Lock preferences for %s"
+msgstr "Bloquear preferências para %s"
+
+#: id:20153
+msgid "Browse..."
+msgstr "Buscar..."
+
+#: id:20154
+msgid "Summary information"
+msgstr "Informação resumida"
+
+#: id:20155
+msgid "Storage information"
+msgstr "Informação de armazenamento"
+
+#: id:20156
+msgid "Hard disk information"
+msgstr "Informação do disco rígido"
+
+#: id:20157
+msgid "DVD-ROM information"
+msgstr "Informação do DVD-ROM"
+
+#: id:20158
+msgid "Network information"
+msgstr "Informação de rede"
+
+#: id:20159
+msgid "Video information"
+msgstr "Informação de vídeo"
+
+#: id:20160
+msgid "Hardware information"
+msgstr "Informação de hardware"
+
+#: id:20161
+msgid "Total"
+msgstr "Total"
+
+#: id:20162
+msgid "Used"
+msgstr "Usado"
+
+#: id:20163
+msgid "of"
+msgstr "de"
+
+#: id:20164
+msgid "Locking not supported"
+msgstr "Bloqueio não suportado"
+
+#: id:20165
+msgid "Not locked"
+msgstr "Não bloqueado"
+
+#: id:20166
+msgid "Locked"
+msgstr "Bloqueado"
+
+#: id:20167
+msgid "Frozen"
+msgstr "Congelado"
+
+#: id:20168
+msgid "Requires reset"
+msgstr "Requer reinicialização"
+
+#: id:20169
+msgid "Week"
+msgstr "Semana"
+
+#: id:20170
+msgid "Line"
+msgstr "Linha"
+
+#: id:20171
+msgid "Windows network (SMB)"
+msgstr "Rede Windows (SMB)"
+
+#: id:20172
+msgid "XBMSP server"
+msgstr "Servidor XBMSP"
+
+#: id:20173
+msgctxt "Auto context with id 20173"
+msgid "FTP server"
+msgstr "Servidor FTP"
+
+#: id:20174
+msgid "iTunes music share (DAAP)"
+msgstr "Compartilhamento iTunes (DAAP)"
+
+#: id:20175
+msgid "UPnP server"
+msgstr "Servidor UPnP"
+
+#: id:20176
+msgid "Show video info"
+msgstr "Mostrar informações de vídeo"
+
+#: id:20177
+msgid "Done"
+msgstr "Feito"
+
+#: id:20178
+msgid "Shift"
+msgstr "Shift"
+
+#: id:20179
+msgid "Caps Lock"
+msgstr "Caps Lock"
+
+#: id:20180
+msgid "Symbols"
+msgstr "Símbolos"
+
+#: id:20181
+msgid "Backspace"
+msgstr "Backspace"
+
+#: id:20182
+msgid "Space"
+msgstr "Espaço"
+
+#: id:20183
+msgid "Reload skin"
+msgstr "Reiniciar skin"
+
+#: id:20184
+msgid "Rotate pictures using EXIF information"
+msgstr "Rotacionar imagens usando informação do EXIF"
+
+#: id:20185
+msgid "Use poster view styles for TV shows"
+msgstr "Usar estilo de visualização poster para seriados"
+
+#: id:20186
+msgid "Please wait"
+msgstr "Por favor aguarde"
+
+#: id:20187
+msgid "UPnP"
+msgstr ""
+
+#: id:20189
+msgid "Enable auto scrolling for plot & review"
+msgstr "Habilitar auto rolagem para enredo & crítica"
+
+#: id:20190
+msgctxt "Auto context with id 20190"
+msgid "Custom"
+msgstr "Personalizado"
+
+#: id:20191
+msgid "Enable debug logging"
+msgstr "Habilitar registro de depuração"
+
+#: id:20192
+msgid "Download additional information during updates"
+msgstr "Baixar informação adicional durante atualizações"
+
+#: id:20193
+msgid "Default service for album information"
+msgstr "Serviço padrão para informação de album"
+
+#: id:20194
+msgid "Default service for artist information"
+msgstr "Serviço padrão para informações de músicas"
+
+#: id:20195
+msgid "Change scraper"
+msgstr "Mudar resumo"
+
+#: id:20196
+msgid "Export music library"
+msgstr "Exportar coleção de música"
+
+#: id:20197
+msgid "Import music library"
+msgstr "Importar coleção de música"
+
+#: id:20198
+msgid "No artist found!"
+msgstr "Artista não encontrado!"
+
+#: id:20199
+msgid "Downloading artist info failed"
+msgstr "Erro ao baixar informação de artista"
+
+#: id:20250
+msgid "Party on! (videos)"
+msgstr "Ativo! (vídeos)"
+
+#: id:20251
+msgid "Mixing drinks (videos)"
+msgstr "Misturando bebidas (vídeos)"
+
+#: id:20252
+msgid "Filling glasses (videos)"
+msgstr "Enchendo os copos (vídeos)"
+
+#: id:20253
+msgid "WebDAV server (HTTP)"
+msgstr "Servidor WebDAV (HTTP)"
+
+#: id:20254
+msgid "WebDAV server (HTTPS)"
+msgstr "Servidor WebDAV (HTTPS)"
+
+#: id:20255
+msgid "First logon, edit your profile"
+msgstr "Primeiro logon, editar seu perfil"
+
+#: id:20256
+msgid "HTS Tvheadend client"
+msgstr "Cliente HTS Tvheadend"
+
+#: id:20257
+msgid "VDR Streamdev client"
+msgstr "Cliente VDR Streamdev"
+
+#: id:20258
+msgid "MythTV client"
+msgstr "Cliente MythTV"
+
+#: id:20259
+msgid "Network Filesystem (NFS)"
+msgstr "Sistema Arquivos Rede(NFS)"
+
+#: id:20260
+msgid "Secure Shell (SSH/SFTP)"
+msgstr "Secure Shell (SSH/SFTP)"
+
+#: id:20261
+msgid "Apple Filing Protocol (AFP)"
+msgstr "Apple Filing Protocol (AFP)"
+
+#: id:20300
+msgid "Web server directory (HTTP)"
+msgstr "Diretório do servidor Web (HTTP)"
+
+#: id:20301
+msgid "Web server directory (HTTPS)"
+msgstr "Diretório do servidor Web (HTTPS)"
+
+#: id:20302
+msgid "Unable to write to folder:"
+msgstr "Impossível gravar na pasta:"
+
+#: id:20303
+msgid "Do you want to skip and proceed?"
+msgstr "Quer cancelar e prosseguir?"
+
+#: id:20304
+msgid "RSS Feed"
+msgstr "Feed RSS"
+
+#: id:20307
+msgid "Secondary DNS"
+msgstr "DNS secundário"
+
+#: id:20308
+msgid "DHCP server:"
+msgstr "Servidor DHCP:"
+
+#: id:20309
+msgid "Make new folder"
+msgstr "Criar nova pasta"
+
+#: id:20310
+msgid "Dim LCD on playback"
+msgstr "Escurecer LCD na reprodução"
+
+#: id:20311
+msgid "Unknown or onboard (protected)"
+msgstr "Desconhecido ou onboard (protegido)"
+
+#: id:20312
+msgid "Dim LCD on paused"
+msgstr "Escurecer LCD na pausa"
+
+#: id:20314
+msgid "Videos - Library"
+msgstr "Vídeos - Coleção"
+
+#: id:20316
+msgid "Sort by: ID"
+msgstr "Ordenar por: ID"
+
+#: id:20324
+msgid "Play part..."
+msgstr "Reproduzir parte..."
+
+#: id:20325
+msgid "Calibration reset"
+msgstr "Restaurar valores da calibração"
+
+#: id:20326
+msgid "This will reset the calibration values for %s"
+msgstr "Isto irá restaurar os valores da calibração para %s"
+
+#: id:20327
+msgid "to it's default values."
+msgstr "para os valores padrões."
+
+#: id:20328
+msgid "Browse for destination"
+msgstr "Procurar destino"
+
+#: id:20329
+msgid "Movies are in separate folders that match the movie title"
+msgstr "Filmes em pastas separadas que combinam com o título do filme"
+
+#: id:20330
+msgid "Use folder names for lookups"
+msgstr "Usar nomes de pastas para busca"
+
+#: id:20331
+msgctxt "Auto context with id 20331"
+msgid "File"
+msgstr "Arquivo"
+
+#: id:20332
+msgid "Use file or folder names in lookups?"
+msgstr "Usar pasta ou nomes de arquivos em buscas?"
+
+#: id:20333
+msgid "Set content"
+msgstr "Defina conteúdo"
+
+#: id:20334
+msgid "Folder"
+msgstr "Pasta"
+
+#: id:20335
+msgid "Look for content recursively?"
+msgstr "Buscar por conteúdo recursivamente?"
+
+#: id:20336
+msgid "Unlock sources"
+msgstr "Desbloquear fontes"
+
+#: id:20337
+msgid "Actor"
+msgstr "Ator"
+
+#: id:20338
+msgid "Movie"
+msgstr "Filme"
+
+#: id:20339
+msgid "Director"
+msgstr "Diretor"
+
+#: id:20340
+msgid "Do you want to remove all items within"
+msgstr "Deseja remover todos os itens dentro"
+
+#: id:20341
+msgid "this path from the XBMC library?"
+msgstr "deste caminho da biblioteca do XBMC?"
+
+#: id:20342
+msgctxt "Auto context with id 20342"
+msgid "Movies"
+msgstr "Filmes"
+
+#: id:20343
+msgid "TV shows"
+msgstr "Seriados"
+
+#: id:20344
+msgid "This directory contains"
+msgstr "Este diretório contém"
+
+#: id:20345
+msgid "Run automated scan"
+msgstr "Executar exame automatizado"
+
+#: id:20346
+msgid "Scan recursively"
+msgstr "Examinar recursivamente"
+
+#: id:20347
+msgid "as"
+msgstr "como"
+
+#: id:20348
+msgid "Directors"
+msgstr "Diretores"
+
+#: id:20349
+msgid "No video files found in this path!"
+msgstr "Nenhum arquivo de vídeo encontrado neste caminho!"
+
+#: id:20350
+msgid "votes"
+msgstr "votos"
+
+#: id:20351
+msgid "TV show information"
+msgstr "Informação do seriado"
+
+#: id:20352
+msgid "Episode information"
+msgstr "Informação do episódio"
+
+#: id:20353
+msgid "Loading TV show details"
+msgstr "Carregando detalhes do seriado"
+
+#: id:20354
+msgid "Fetching episode guide"
+msgstr "Obtendo guia do episódio"
+
+#: id:20355
+msgid "Loading info for episodes in directory"
+msgstr "Carregando informações para episódios no diretório"
+
+#: id:20356
+msgid "Select TV show:"
+msgstr "Selecione o seriado:"
+
+#: id:20357
+msgid "Enter the TV show name"
+msgstr "Digite o nome do seriado"
+
+#: id:20358
+msgid "Season %i"
+msgstr "Temporada %i"
+
+#: id:20359
+msgid "Episode"
+msgstr "Episódio"
+
+#: id:20360
+msgid "Episodes"
+msgstr "Episódios"
+
+#: id:20361
+msgid "Loading episode details"
+msgstr "Carregando detalhes do episódio"
+
+#: id:20362
+msgid "Remove episode from library"
+msgstr "Remover episódio da coleção"
+
+#: id:20363
+msgid "Remove TV show from library"
+msgstr "Remover seriado da coleção"
+
+#: id:20364
+msgid "TV show"
+msgstr "Seriado"
+
+#: id:20365
+msgid "Episode plot"
+msgstr "Enredo do episódio"
+
+#: id:20366
+msgid "* All seasons"
+msgstr "* Todas as temporadas"
+
+#: id:20367
+msgid "Hide watched"
+msgstr "Ocultar vistos"
+
+#: id:20368
+msgid "Prod code"
+msgstr "Código de prod."
+
+#: id:20369
+msgid "Show plot for unwatched items"
+msgstr "Exibir enredo para itens não-vistos"
+
+#: id:20370
+msgid "* Hidden to prevent spoilers *"
+msgstr "* Escondido para prevenir créditos (spoilers) *"
+
+#: id:20371
+msgid "Set season thumb"
+msgstr "Selecionar ícone da temporada"
+
+#: id:20372
+msgid "Season image"
+msgstr "Imagem da temporada"
+
+#: id:20373
+msgid "Season"
+msgstr "Temporada"
+
+#: id:20374
+msgid "Downloading movie information"
+msgstr "Baixando informação do filme"
+
+#: id:20375
+msgid "Unassign content"
+msgstr "Desmarcar conteúdo"
+
+#: id:20376
+msgid "Original title"
+msgstr "Título original"
+
+#: id:20377
+msgid "Refresh TV show information"
+msgstr "Atualizar informações de seriado"
+
+#: id:20378
+msgid "Refresh info for all episodes?"
+msgstr "Recarregar informações para todos os episódios?"
+
+#: id:20379
+msgid "Selected folder contains a single TV show"
+msgstr "Pasta contém um único seriado"
+
+#: id:20380
+msgid "Exclude selected folder from scans"
+msgstr "Excluir pasta da lista de procura"
+
+#: id:20381
+msgid "Specials"
+msgstr "Especiais"
+
+#: id:20382
+msgid "Automatically grab season thumbs"
+msgstr "Auto buscar ícones de temporadas"
+
+#: id:20383
+msgid "Selected folder contains a single video"
+msgstr "Pasta contém um único vídeo"
+
+#: id:20384
+msgid "Link to TV show"
+msgstr "Link para seriado"
+
+#: id:20385
+msgid "Remove link to TV show"
+msgstr "Remover link para seriado"
+
+#: id:20386
+msgid "Recently added movies"
+msgstr "Filmes adicionados recentemente"
+
+#: id:20387
+msgid "Recently added episodes"
+msgstr "Episódios adicionados recentemente"
+
+#: id:20388
+msgid "Studios"
+msgstr "Estúdios"
+
+#: id:20389
+msgid "Music videos"
+msgstr "Vídeos musicais"
+
+#: id:20390
+msgid "Recently added music videos"
+msgstr "Vídeos musicais adicionados recentemente"
+
+#: id:20391
+msgid "Music video"
+msgstr "Vídeo musical"
+
+#: id:20392
+msgid "Remove music video from library"
+msgstr "Remover vídeo musical da coleção"
+
+#: id:20393
+msgctxt "Auto context with id 20393"
+msgid "Music video information"
+msgstr "Informação do vídeo musical"
+
+#: id:20394
+msgid "Loading music video information"
+msgstr "Carregando informação de vídeo musical"
+
+#: id:20395
+msgid "Mixed"
+msgstr "Misturado"
+
+#: id:20396
+msgid "Go to albums by artist"
+msgstr "Ir para álbuns por artista"
+
+#: id:20397
+msgid "Go to album"
+msgstr "Ir para álbum"
+
+#: id:20398
+msgid "Play song"
+msgstr "Reproduzir música"
+
+#: id:20399
+msgid "Go to music videos from album"
+msgstr "Ir para vídeos musicais do álbum"
+
+#: id:20400
+msgid "Go to music videos by artist"
+msgstr "Ir para vídeos musicais do artista"
+
+#: id:20401
+msgid "Play music video"
+msgstr "Reproduzir vídeo musical"
+
+#: id:20402
+msgid "Download actor thumbnails when adding to library"
+msgstr "Baixar ícones de atores ao criar a coleção"
+
+#: id:20403
+msgid "Set actor thumb"
+msgstr "Selecionar ícone de ator"
+
+#: id:20405
+msgid "Remove episode bookmark"
+msgstr "Remover marcador do episódio"
+
+#: id:20406
+msgid "Set episode bookmark"
+msgstr "Definir marcador do episódio"
+
+#: id:20407
+msgid "Scraper settings"
+msgstr "Opções de scraper"
+
+#: id:20408
+msgid "Downloading music video information"
+msgstr "Recebendo informação de vídeo musical"
+
+#: id:20409
+msgid "Downloading TV show information"
+msgstr "Recebendo informação de seriado"
+
+#: id:20410
+msgid "Trailer"
+msgstr "Trailer"
+
+#: id:20411
+msgid "Flatten"
+msgstr "Unificar"
+
+#: id:20412
+msgid "Flatten TV shows"
+msgstr "Unificar seriados com temporada única"
+
+#: id:20413
+msgid "Get fanart"
+msgstr "Obter Fanart"
+
+#: id:20414
+msgid "Show Fanart in video and music libraries"
+msgstr "Exibir Fanart nas coleções de video e música"
+
+#: id:20415
+msgid "Scanning for new content"
+msgstr "Procurando por conteúdo novo"
+
+#: id:20416
+msgid "First aired"
+msgstr "Primeira exibição"
+
+#: id:20417
+msgid "Writer"
+msgstr "Escritor"
+
+#: id:20419
+msgid "Replace file names with library titles"
+msgstr "Substituir nome do arquivo pelo título da biblioteca"
+
+#: id:20420
+msgctxt "Auto context with id 20420"
+msgid "Never"
+msgstr "Nunca"
+
+#: id:20421
+msgid "If only one season"
+msgstr "Se só uma temporada"
+
+#: id:20422
+msgid "Always"
+msgstr "Sempre"
+
+#: id:20423
+msgid "Has trailer"
+msgstr "Tem trailer"
+
+#: id:20424
+msgid "False"
+msgstr "Falso"
+
+#: id:20425
+msgid "Fanart slideshow"
+msgstr "Apresentação de Fanart"
+
+#: id:20426
+msgid "Export to a single file or separate"
+msgstr "Exportar para um único arquivo ou separar"
+
+#: id:20427
+msgid "files per entry?"
+msgstr "arquivos por entrada?"
+
+#: id:20428
+msgid "Single file"
+msgstr "Só um arquivo"
+
+#: id:20429
+msgctxt "Auto context with id 20429"
+msgid "Separate"
+msgstr "Separar"
+
+#: id:20430
+msgid "Export thumbnails and fanart?"
+msgstr "Exportar icones e Fanart?"
+
+#: id:20431
+msgid "Overwrite old files?"
+msgstr "Sobreescrever arquivos antigos?"
+
+#: id:20432
+msgid "Exclude path from library updates"
+msgstr "Excluir caminho da atualização de coleções"
+
+#: id:20433
+msgid "Extract thumbnails and video information"
+msgstr "Extrair ícones e etiquetas"
+
+#: id:20434
+msgid "Sets"
+msgstr "Conjuntos"
+
+#: id:20435
+msgid "Set movieset thumb"
+msgstr "Definir ícone do conjunto de filmes"
+
+#: id:20436
+msgid "Export actor thumbs?"
+msgstr "Exportar ícones de atores"
+
+#: id:20437
+msgid "Choose fanart"
+msgstr "Selecione fanart"
+
+#: id:20438
+msgid "Local fanart"
+msgstr "Fanart local"
+
+#: id:20439
+msgid "No fanart"
+msgstr "Sem fanart"
+
+#: id:20440
+msgid "Current fanart"
+msgstr "Fanart atual"
+
+#: id:20441
+msgid "Remote fanart"
+msgstr "Fanart remoto"
+
+#: id:20442
+msgid "Change content"
+msgstr "Alterar conteúdo"
+
+#: id:20443
+msgid "Do you want to refresh info for all"
+msgstr "Quer atualizar informação para todos"
+
+#: id:20444
+msgid "items within this path?"
+msgstr "Itens incluídos neste caminho?"
+
+#: id:20445
+msgid "Fanart"
+msgstr "Fanart"
+
+#: id:20446
+msgid "Locally stored information found."
+msgstr "Foram encontradas informações armazenadas localmente."
+
+#: id:20447
+msgid "Ignore and refresh from internet?"
+msgstr "Ignorar e atualizar da Internet?"
+
+#: id:20448
+msgid "Could not download information"
+msgstr "Não é possível baixar as informações"
+
+#: id:20449
+msgid "Unable to connect to remote server"
+msgstr "Incapaz de conectar ao servidor remoto"
+
+#: id:20450
+msgid "Would you like to continue scanning?"
+msgstr "Deseja continuar a procura?"
+
+#: id:20451
+msgid "Countries"
+msgstr "Paises"
+
+#: id:20452
+msgid "episode"
+msgstr "episódio"
+
+#: id:20453
+msgid "episodes"
+msgstr "episódios"
+
+#: id:20454
+msgid "Listener"
+msgstr "Ouvinte"
+
+#: id:20455
+msgid "Listeners"
+msgstr "Ouvintes"
+
+#: id:20456
+msgid "Set movieset fanart"
+msgstr "Setar fanart coleções filmes"
+
+#: id:20457
+msgid "Movie set"
+msgstr "Conjunto de filmes"
+
+#: id:20458
+msgid "Group movies in sets"
+msgstr "Agrupar filmes em conjuntos"
+
+#: id:21330
+msgid "Show hidden files and directories"
+msgstr "Exibir arquivos e diretórios ocultos"
+
+#: id:21331
+msgid "TuxBox client"
+msgstr "Cliente TuxBox"
+
+#: id:21332
+msgid "WARNING: Target TuxBox device is in recording-mode!"
+msgstr "AVISO: dispositivo TuxBox está em modo de gravação!"
+
+#: id:21333
+msgid "The stream will be stopped!"
+msgstr "Este canal será interrompido!"
+
+#: id:21334
+msgid "Zap to channel: %s failed!"
+msgstr "Mudar para canal: %s falhou!"
+
+#: id:21335
+msgid "Are you sure to start the stream?"
+msgstr "Tem certeza que deseja iniciar o canal?"
+
+#: id:21336
+msgid "Connecting to: %s"
+msgstr "Conectando a: %s"
+
+#: id:21337
+msgid "TuxBox device"
+msgstr "Dispositivo TuxBox"
+
+#: id:21359
+msgid "Add media share..."
+msgstr "Adicionar compartilhamento de mídia..."
+
+#: id:21360
+msgid "Share video and music libraries through UPnP"
+msgstr "Compartilhar coleções de vídeo e música através do UPnP"
+
+#: id:21364
+msgid "Edit media share"
+msgstr "Editar compartilhamento de mídia"
+
+#: id:21365
+msgid "Remove media share"
+msgstr "Remover compartilhamento de mídia"
+
+#: id:21366
+msgid "Subtitle folder"
+msgstr "Pasta de legendas"
+
+#: id:21367
+msgid "Movie & alternate subtitle directory"
+msgstr "Filme & diretório de legenda alternativo"
+
+#: id:21368
+msgid "Override ASS/SSA subtitles fonts"
+msgstr "Substituir fontes da legendas em formato ASS/SSA"
+
+#: id:21369
+msgid "Enable mouse and Touch Screen support"
+msgstr "Ativar mouse"
+
+#: id:21370
+msgid "Play navigation sounds during media playback"
+msgstr "Permitir sons de navegação durante reprodução"
+
+#: id:21371
+msgid "Thumbnail"
+msgstr "Ícone"
+
+#: id:21372
+msgid "Forced DVD player region"
+msgstr "Forçar região do DVD-player"
+
+#: id:21373
+msgid "Video output"
+msgstr "Saída de vídeo"
+
+#: id:21374
+msgid "Video aspect"
+msgstr "Aspecto de vídeo"
+
+#: id:21375
+msgctxt "Auto context with id 21375"
+msgid "Normal"
+msgstr "Normal"
+
+#: id:21376
+msgid "Letterbox"
+msgstr "Letterbox"
+
+#: id:21377
+msgid "Widescreen"
+msgstr "Widescreen"
+
+#: id:21378
+msgid "Enable 480p"
+msgstr "Habilitar 480p"
+
+#: id:21379
+msgid "Enable 720p"
+msgstr "Habilitar 720p"
+
+#: id:21380
+msgid "Enable 1080i"
+msgstr "Habilitar 1080i"
+
+#: id:21381
+msgid "Enter name of new playlist"
+msgstr "Nome da lista de reprodução"
+
+#: id:21382
+msgid "Show \"Add source\" buttons in file lists"
+msgstr "Exibir botões \"adicionar origem\" em listas"
+
+#: id:21383
+msgid "Enable scrollbars"
+msgstr "Ativar barras-de-rolagem"
+
+#: id:21384
+msgid "Make watched filtering a toggle in video library"
+msgstr "Usar \"vistos\" como filtro liga/desliga na coleção de vídeo"
+
+#: id:21385
+msgctxt "Auto context with id 21385"
+msgid "Open"
+msgstr "Abrir"
+
+#: id:21386
+msgid "Acoustic management level"
+msgstr "Nível de ajuste acústico"
+
+#: id:21387
+msgid "Fast"
+msgstr "Rápido"
+
+#: id:21388
+msgid "Quiet"
+msgstr "Silencioso"
+
+#: id:21389
+msgid "Enable custom background"
+msgstr "Ativar papel de parede"
+
+#: id:21390
+msgid "Power management level"
+msgstr "Nível do gerenciador de energia"
+
+#: id:21391
+msgid "High power"
+msgstr "Alta potência"
+
+#: id:21392
+msgid "Low power"
+msgstr "Baixa potência"
+
+#: id:21393
+msgid "High standby"
+msgstr "Hibernar (alto)"
+
+#: id:21394
+msgid "Low standby"
+msgstr "Hibernar (baixo)"
+
+#: id:21395
+msgid "Unable to cache files bigger than 4GB"
+msgstr "Incapaz de armazenar arquivos maiores que 4GB"
+
+#: id:21396
+msgid "Chapter"
+msgstr "Capítulo"
+
+#: id:21397
+msgid "High quality pixel shader v2"
+msgstr "Alta qualidade de pixel shader (V2)"
+
+#: id:21398
+msgid "Enable playlist at startup"
+msgstr "Habilitar lista de reprodução ao iniciar"
+
+#: id:21399
+msgid "Use tween animations"
+msgstr "Usar animações do tipo \"tween\""
+
+#: id:21400
+msgid "contains"
+msgstr "contém"
+
+#: id:21401
+msgid "does not contain"
+msgstr "não contém"
+
+#: id:21402
+msgid "is"
+msgstr "é"
+
+#: id:21403
+msgid "is not"
+msgstr "não é"
+
+#: id:21404
+msgid "starts with"
+msgstr "começa com"
+
+#: id:21405
+msgid "ends with"
+msgstr "termina com"
+
+#: id:21406
+msgid "greater than"
+msgstr "maior que"
+
+#: id:21407
+msgid "less than"
+msgstr "menor que"
+
+#: id:21408
+msgid "after"
+msgstr "depois"
+
+#: id:21409
+msgid "before"
+msgstr "antes"
+
+#: id:21410
+msgid "in the last"
+msgstr "em último"
+
+#: id:21411
+msgid "not in the last"
+msgstr "não em último"
+
+#: id:21412
+msgid "Scrapers"
+msgstr "Resumos"
+
+#: id:21413
+msgid "Default movie scraper"
+msgstr "Scraper padrão de filmes"
+
+#: id:21414
+msgid "Default tvshow scraper"
+msgstr "Scraper padrão de seriados"
+
+#: id:21415
+msgid "Default music video scraper"
+msgstr "Scraper padrão para vídeo músical (clipe)"
+
+#: id:21416
+msgid "Enable fallback based on scraper language"
+msgstr "Permitir alternativa baseado no idioma do scraper"
+
+#: id:21417
+msgid "- Settings"
+msgstr "- Configurações"
+
+#: id:21418
+msgid "Multilingual"
+msgstr "Multi-idioma"
+
+#: id:21419
+msgid "No scrapers present"
+msgstr "Nenhum scraper disponível"
+
+#: id:21420
+msgid "Value to match"
+msgstr "Valor para encontrar"
+
+#: id:21421
+msgid "Smart playlist rule"
+msgstr "Regra de lista de reprodução inteligente"
+
+#: id:21422
+msgid "Match items where"
+msgstr "Encontrar músicas onde"
+
+#: id:21423
+msgid "New rule..."
+msgstr "Nova regra..."
+
+#: id:21424
+msgid "Items must match"
+msgstr "Itens devem conter"
+
+#: id:21425
+msgid "all of the rules"
+msgstr "todas as regras"
+
+#: id:21426
+msgid "one or more of the rules"
+msgstr "uma regra ou mais"
+
+#: id:21427
+msgid "Limit to"
+msgstr "Limitar em"
+
+#: id:21428
+msgid "No limit"
+msgstr "Sem limite"
+
+#: id:21429
+msgid "Order by"
+msgstr "Ordenar por"
+
+#: id:21430
+msgid "ascending"
+msgstr "ascendente"
+
+#: id:21431
+msgid "descending"
+msgstr "descendente"
+
+#: id:21432
+msgid "Edit smart playlist"
+msgstr "Editar lista de reprodução inteligente"
+
+#: id:21433
+msgid "Name of the playlist"
+msgstr "Nome da lista de reprodução"
+
+#: id:21434
+msgid "Find items where"
+msgstr "Encontrar itens onde"
+
+#: id:21435
+msgid "Edit"
+msgstr "- Editar"
+
+#: id:21436
+msgid "%i items"
+msgstr "%i músicas"
+
+#: id:21437
+msgid "New smart playlist..."
+msgstr "Nova lista de reprodução inteligente..."
+
+#: id:21438
+msgid "%c Drive"
+msgstr "Drive %c"
+
+#: id:21439
+msgid "Edit party mode rules"
+msgstr "Editar regras do modo-festa"
+
+#: id:21440
+msgid "Home folder"
+msgstr "Pasta raíz/padrão"
+
+#: id:21441
+msgid "Watched count"
+msgstr "Contador de exibição"
+
+#: id:21442
+msgid "Episode title"
+msgstr "Título do episódio"
+
+#: id:21443
+msgid "Video resolution"
+msgstr "Resolução do vídeo"
+
+#: id:21444
+msgid "Audio channels"
+msgstr "Canais de áudio"
+
+#: id:21445
+msgid "Video codec"
+msgstr "Codec de vídeo"
+
+#: id:21446
+msgid "Audio codec"
+msgstr "Codec de áudio"
+
+#: id:21447
+msgid "Audio language"
+msgstr "Idioma do áudio"
+
+#: id:21448
+msgid "Subtitle language"
+msgstr "Idioma da legenda"
+
+#: id:21449
+msgid "Remote control sends keyboard presses"
+msgstr "Controle Remoto envia aperto de teclas"
+
+#: id:21450
+msgid "- Edit"
+msgstr "- Editar"
+
+#: id:21451
+msgid "Internet connection required."
+msgstr "Necessário conexão com a Internet."
+
+#: id:21452
+msgid "Get More..."
+msgstr "Obter Mais"
+
+#: id:21453
+msgid "Root filesystem"
+msgstr "Raiz"
+
+#: id:21454
+msgid "Cache full"
+msgstr "Cache cheio"
+
+#: id:21455
+msgid "Cache filled before reaching required amount for continous playback"
+msgstr "Cache cheio antes de chegar a quantidade necessária para reprodução contínua"
+
+#: id:21460
+msgid "Subtitle location"
+msgstr "Local da Legenda"
+
+#: id:21461
+msgid "Fixed"
+msgstr "Fixado"
+
+#: id:21462
+msgid "Bottom of video"
+msgstr "Rodapé do vídeo"
+
+#: id:21463
+msgid "Below video"
+msgstr "Na barra abaixo do vídeo"
+
+#: id:21464
+msgid "Top of video"
+msgstr "No topo do vídeo"
+
+#: id:21465
+msgid "Above video"
+msgstr "Na barra acima do vídeo"
+
+#: id:21800
+msgid "File name"
+msgstr "Nome do arquivo"
+
+#: id:21801
+msgid "File path"
+msgstr "Caminho do arquivo"
+
+#: id:21802
+msgid "File size"
+msgstr "Tamanho do arquivo"
+
+#: id:21803
+msgid "File date/time"
+msgstr "Data/hora do arquivo"
+
+#: id:21804
+msgid "Slide index"
+msgstr "Índice de apresentação"
+
+#: id:21805
+msgctxt "Auto context with id 21805"
+msgid "Resolution"
+msgstr "Resolução"
+
+#: id:21806
+msgctxt "Auto context with id 21806"
+msgid "Comment"
+msgstr "Comentário"
+
+#: id:21807
+msgid "Colour/B&W"
+msgstr "Colorido/B&W"
+
+#: id:21808
+msgid "JPEG process"
+msgstr "Processamento JPEG"
+
+#: id:21820
+msgid "Date/Time"
+msgstr "Data/Hora"
+
+#: id:21821
+msgid "Description"
+msgstr "Descrição"
+
+#: id:21822
+msgid "Camera make"
+msgstr "Fabricante da câmera"
+
+#: id:21823
+msgid "Camera model"
+msgstr "Modelo de câmera"
+
+#: id:21824
+msgid "EXIF comment"
+msgstr "Comentários do EXIF"
+
+#: id:21825
+msgid "Firmware"
+msgstr "Firmware"
+
+#: id:21826
+msgid "Aperture"
+msgstr "Abertura"
+
+#: id:21827
+msgid "Focal length"
+msgstr "Dimensão do foco"
+
+#: id:21828
+msgid "Focus distance"
+msgstr "Distância do foco"
+
+#: id:21829
+msgid "Exposure"
+msgstr "Exposição"
+
+#: id:21830
+msgid "Exposure time"
+msgstr "Tempo de exposição"
+
+#: id:21831
+msgid "Exposure bias"
+msgstr "Tendência da exposição"
+
+#: id:21832
+msgid "Exposure mode"
+msgstr "Modo de exposição"
+
+#: id:21833
+msgid "Flash used"
+msgstr "Flash utilizado"
+
+#: id:21834
+msgid "White-balance"
+msgstr "Temperatura da cor"
+
+#: id:21835
+msgid "Light source"
+msgstr "Fonte de luz"
+
+#: id:21836
+msgid "Metering mode"
+msgstr "Modo de medida"
+
+#: id:21837
+msgid "ISO"
+msgstr "ISO"
+
+#: id:21838
+msgid "Digital zoom"
+msgstr "Zoom digital"
+
+#: id:21839
+msgid "CCD width"
+msgstr "Largura do CCD"
+
+#: id:21840
+msgid "GPS latitude"
+msgstr "Latitude do GPS"
+
+#: id:21841
+msgid "GPS longitude"
+msgstr "Longitude do GPS"
+
+#: id:21842
+msgid "GPS altitude"
+msgstr "Altitude do GPS"
+
+#: id:21843
+msgid "Orientation"
+msgstr "Orientação"
+
+#: id:21860
+msgid "Supplemental categories"
+msgstr "Categorias suplementares"
+
+#: id:21861
+msgid "Keywords"
+msgstr "Palavras-chave"
+
+#: id:21862
+msgid "Caption"
+msgstr "Sub-título"
+
+#: id:21863
+msgid "Author"
+msgstr "Autor"
+
+#: id:21864
+msgid "Headline"
+msgstr "Título"
+
+#: id:21865
+msgid "Special instructions"
+msgstr "Instruções especiais"
+
+#: id:21866
+msgid "Category"
+msgstr "Categoria"
+
+#: id:21867
+msgid "Byline"
+msgstr "Cabeçalho"
+
+#: id:21868
+msgid "Byline title"
+msgstr "Título do cabeçalho"
+
+#: id:21869
+msgid "Credit"
+msgstr "Crédito"
+
+#: id:21870
+msgid "Source"
+msgstr "Origem"
+
+#: id:21871
+msgid "Copyright notice"
+msgstr "Aviso de copyright"
+
+#: id:21872
+msgid "Object name"
+msgstr "Nome do objeto"
+
+#: id:21873
+msgid "City"
+msgstr "Cidade"
+
+#: id:21874
+msgid "State"
+msgstr "Estado"
+
+#: id:21875
+msgctxt "Auto context with id 21875"
+msgid "Country"
+msgstr "País"
+
+#: id:21876
+msgid "Original Tx Reference"
+msgstr "Referência Tx original"
+
+#: id:21877
+msgid "Date created"
+msgstr "Data de criação"
+
+#: id:21878
+msgid "Copyright flag"
+msgstr "Sinal de copyright"
+
+#: id:21879
+msgid "Country code"
+msgstr "Código do país"
+
+#: id:21880
+msgid "Reference service"
+msgstr "Serviço de referência"
+
+#: id:21881
+msgid "Allow control of XBMC via UPnP"
+msgstr "Permitir controle do XBMC via UPnP"
+
+#: id:21882
+msgid "Attempt to skip introduction before DVD menu"
+msgstr "Tentar saltar introdução antes do menu do DVD"
+
+#: id:21883
+msgid "Saved music"
+msgstr "Música salva"
+
+#: id:21884
+msgid "Query info for all artists"
+msgstr "Buscar informações para todos os artistas"
+
+#: id:21885
+msgid "Downloading album information"
+msgstr "Baixando informações do album"
+
+#: id:21886
+msgid "Downloading artist information"
+msgstr "Baixando informação do artista"
+
+#: id:21887
+msgid "Biography"
+msgstr "Biografia"
+
+#: id:21888
+msgid "Discography"
+msgstr "Discografia"
+
+#: id:21889
+msgid "Searching artist"
+msgstr "Procurando artista"
+
+#: id:21890
+msgid "Select artist"
+msgstr "Selecione o artista"
+
+#: id:21891
+msgctxt "Auto context with id 21891"
+msgid "Artist information"
+msgstr "Informação do artista"
+
+#: id:21892
+msgid "Instruments"
+msgstr "Instrumentos"
+
+#: id:21893
+msgid "Born"
+msgstr "Nascido"
+
+#: id:21894
+msgid "Formed"
+msgstr "Formado"
+
+#: id:21895
+msgid "Themes"
+msgstr "Temas"
+
+#: id:21896
+msgid "Disbanded"
+msgstr "Dispensado(sem banda?)"
+
+#: id:21897
+msgid "Died"
+msgstr "Falecido"
+
+#: id:21898
+msgid "Years active"
+msgstr "Anos de atividade"
+
+#: id:21899
+msgid "Label"
+msgstr "Gravadora/marca"
+
+#: id:21900
+msgid "Born/Formed"
+msgstr "Nascido/formado"
+
+#: id:22000
+msgid "Update library on startup"
+msgstr "Atualizar coleção ao iniciar"
+
+#: id:22001
+msgid "Hide progress of library updates"
+msgstr "Ocultar progresso de atualizações de coleção"
+
+#: id:22002
+msgid "- DNS suffix"
+msgstr "- Sufixo de DNS"
+
+#: id:22003
+msgid "%2.3fs"
+msgstr "%2.3fs"
+
+#: id:22004
+msgid "Delayed by: %2.3fs"
+msgstr "Atrasado em: %2.3fs"
+
+#: id:22005
+msgid "Ahead by: %2.3fs"
+msgstr "Adiantado em: %2.3fs"
+
+#: id:22006
+msgid "Subtitle offset"
+msgstr "Posição da legenda"
+
+#: id:22007
+msgid "OpenGL vendor:"
+msgstr "Fabricante OpenGL:"
+
+#: id:22008
+msgid "OpenGL renderer:"
+msgstr "Renderizador OpenGL:"
+
+#: id:22009
+msgid "OpenGL version:"
+msgstr "Versão OpenGL:"
+
+#: id:22010
+msgid "GPU temperature:"
+msgstr "Temperatura GPU:"
+
+#: id:22011
+msgid "CPU temperature:"
+msgstr "Temperatura CPU:"
+
+#: id:22012
+msgid "Total memory"
+msgstr "Memória total:"
+
+#: id:22013
+msgid "Profile data"
+msgstr "Dados do perfil"
+
+#: id:22014
+msgid "Use dim if paused during video playback"
+msgstr "Escurecer a tela se pausar o video durante execução"
+
+#: id:22015
+msgid "All recordings"
+msgstr "Todas as gravações"
+
+#: id:22016
+msgid "By title"
+msgstr "Por Título"
+
+#: id:22017
+msgid "By group"
+msgstr "Por grupo"
+
+#: id:22018
+msgid "Live channels"
+msgstr "Canais ao vivo"
+
+#: id:22019
+msgid "Recordings by title"
+msgstr "Gravações por título"
+
+#: id:22020
+msgid "Guide"
+msgstr "Guia"
+
+#: id:22021
+msgid "Allowed error in aspect ratio to minimize black bars"
+msgstr "Erro (%) permitido na proporção de aspecto"
+
+#: id:22022
+msgid "Show video files in listings"
+msgstr "Incluir arquivos de vídeo nas listagens"
+
+#: id:22023
+msgid "DirectX vendor:"
+msgstr "Fabricante DirectX:"
+
+#: id:22024
+msgid "Direct3D version:"
+msgstr "Versão Direct3D:"
+
+#: id:22030
+msgctxt "Auto context with id 22030"
+msgid "Font"
+msgstr "Fonte"
+
+#: id:22031
+msgctxt "Auto context with id 22031"
+msgid "- Size"
+msgstr "- Tamanho"
+
+#: id:22032
+msgctxt "Auto context with id 22032"
+msgid "- Colours"
+msgstr "- Cores"
+
+#: id:22033
+msgid "- Charset"
+msgstr "- Conjunto de Caracteres"
+
+#: id:22034
+msgid "Export karaoke titles as HTML"
+msgstr "Exportar itens de karaokê em HTML"
+
+#: id:22035
+msgid "Export karaoke titles as CSV"
+msgstr "Exportar itens de karaokê em CSV"
+
+#: id:22036
+msgid "Import karaoke titles..."
+msgstr "Importar itens de karaokê..."
+
+#: id:22037
+msgid "Show song selector automatically"
+msgstr "Auto exibir seletor de música"
+
+#: id:22038
+msgid "Export karaoke titles..."
+msgstr "Exportar itens de karaokê..."
+
+#: id:22039
+msgid "Enter song number"
+msgstr "Informe número da música"
+
+#: id:22040
+msgid "white/green"
+msgstr "branco/verde"
+
+#: id:22041
+msgid "white/red"
+msgstr "branco/vermelho"
+
+#: id:22042
+msgid "white/blue"
+msgstr "branco/azul"
+
+#: id:22043
+msgid "black/white"
+msgstr "preto/branco"
+
+#: id:22079
+msgid "Default select action"
+msgstr "Selecionar ação padrão"
+
+#: id:22080
+msgid "Choose"
+msgstr "Escolher"
+
+#: id:22081
+msgid "Show Information"
+msgstr "Mostrar Informação"
+
+#: id:22082
+msgid "More..."
+msgstr "Mais..."
+
+#: id:22083
+msgid "Play all"
+msgstr "Tocar Tudo"
+
+#: id:23049
+msgid "Teletext not available"
+msgstr "Teletext indisponível"
+
+#: id:23050
+msgid "Activate Teletext"
+msgstr "Ativar Teletext"
+
+#: id:23051
+msgid "Part %i"
+msgstr "Parte %i"
+
+#: id:23052
+msgid "Buffering %i bytes"
+msgstr "Acumulando %i bytes"
+
+#: id:23053
+msgid "Stopping"
+msgstr "Parando"
+
+#: id:23054
+msgid "Running"
+msgstr "Executando"
+
+#: id:23100
+msgid "External Player Active"
+msgstr "Player externo ativo"
+
+#: id:23101
+msgid "Click OK to terminate the player"
+msgstr "Clique OK para sair do player"
+
+#: id:23104
+msgid "Click OK when playback has ended"
+msgstr "Clique OK quando execução tiver terminado"
+
+#: id:24000
+msgid "Add-on"
+msgstr "Add-on"
+
+#: id:24001
+msgid "Add-ons"
+msgstr "Add-ons"
+
+#: id:24002
+msgid "Add-on options"
+msgstr "Opções Add-on"
+
+#: id:24003
+msgid "Add-on Information"
+msgstr "Informação do Add-on"
+
+#: id:24005
+msgctxt "Auto context with id 24005"
+msgid "Media sources"
+msgstr "Locais de Midia"
+
+#: id:24007
+msgctxt "Auto context with id 24007"
+msgid "Movie information"
+msgstr "Informação do Filme"
+
+#: id:24008
+msgctxt "Auto context with id 24008"
+msgid "Screensaver"
+msgstr "Proteção de Tela"
+
+#: id:24009
+msgid "Script"
+msgstr "Script"
+
+#: id:24010
+msgctxt "Auto context with id 24010"
+msgid "Visualization"
+msgstr "Visualização"
+
+#: id:24011
+msgid "Add-on repository"
+msgstr "Repositório de Add-on"
+
+#: id:24012
+msgctxt "Auto context with id 24012"
+msgid "Subtitles"
+msgstr "Legendas"
+
+#: id:24013
+msgid "Lyrics"
+msgstr "Letras"
+
+#: id:24014
+msgid "TV information"
+msgstr "Informação de TV"
+
+#: id:24015
+msgctxt "Auto context with id 24015"
+msgid "Music video information"
+msgstr "Informação de Video Musical (clipe)"
+
+#: id:24016
+msgctxt "Auto context with id 24016"
+msgid "Album information"
+msgstr "Informação de Album"
+
+#: id:24017
+msgctxt "Auto context with id 24017"
+msgid "Artist information"
+msgstr "Informação de Artista"
+
+#: id:24018
+msgctxt "Auto context with id 24018"
+msgid "Services"
+msgstr "Serviços"
+
+#: id:24020
+msgid "Configure"
+msgstr "Configurar"
+
+#: id:24021
+msgctxt "Auto context with id 24021"
+msgid "Disable"
+msgstr "Desativar"
+
+#: id:24022
+msgid "Enable"
+msgstr "Ativar"
+
+#: id:24023
+msgid "Add-on disabled"
+msgstr "Add-on desativado"
+
+#: id:24027
+msgctxt "Auto context with id 24027"
+msgid "Weather"
+msgstr "Tempo"
+
+#: id:24028
+msgid "Weather.com (standard)"
+msgstr "Weather.com (padrão)"
+
+#: id:24030
+msgid "This Add-on can not be configured"
+msgstr "Este Add-on não pode ser configurado"
+
+#: id:24031
+msgid "Error loading settings"
+msgstr "Erro ao carregar as configurações"
+
+#: id:24032
+msgid "All Add-ons"
+msgstr "Todos Add-ons"
+
+#: id:24033
+msgid "Get Add-ons"
+msgstr "Obter Add-ons"
+
+#: id:24034
+msgid "Check for updates"
+msgstr "Checar por atualizações"
+
+#: id:24035
+msgid "Force refresh"
+msgstr "Forçar atualização"
+
+#: id:24036
+msgid "Change log"
+msgstr "Log de mudança"
+
+#: id:24037
+msgid "Uninstall"
+msgstr "Desinstalar"
+
+#: id:24038
+msgid "Install"
+msgstr "Instalar"
+
+#: id:24039
+msgid "Disabled Add-ons"
+msgstr "Add-ons Desativados"
+
+#: id:24040
+msgid "(Clear the current setting)"
+msgstr "(Limpar configuração atual)"
+
+#: id:24041
+msgid "Install from zip file"
+msgstr "Instalar a partir de um arquivo ZIP"
+
+#: id:24042
+msgid "Downloading %i%%"
+msgstr "Baixando %i%%"
+
+#: id:24043
+msgid "Available Updates"
+msgstr "Atualizações Disponíveis"
+
+#: id:24044
+msgid "Dependencies not met"
+msgstr "Dependencias não conhecidas"
+
+#: id:24045
+msgid "Add-on does not have the correct structure"
+msgstr "Add-on não possui uma estrutura válida"
+
+#: id:24046
+msgid "%s is used by the following installed add-on(s)"
+msgstr "%s é usado pelo seguinte add-on(s) instalado(s)"
+
+#: id:24047
+msgid "This add-on cannot be uninstalled"
+msgstr "Este add-on não pode ser desinstalado"
+
+#: id:24048
+msgid "Rollback"
+msgstr "Desfazer"
+
+#: id:24050
+msgid "Available Add-ons"
+msgstr "Add-ons Disponíveis"
+
+#: id:24051
+msgid "Version:"
+msgstr "Versão:"
+
+#: id:24052
+msgid "Disclaimer"
+msgstr "Declaração"
+
+#: id:24053
+msgid "License:"
+msgstr "Licença:"
+
+#: id:24054
+msgid "Changelog"
+msgstr "Histórico de Alterações"
+
+#: id:24059
+msgid "Would you like to enable this Add-on?"
+msgstr "Deseja ativar este Add-on?"
+
+#: id:24060
+msgid "Would you like to disable this Add-on?"
+msgstr "Deseja desativar este Add-on?"
+
+#: id:24061
+msgid "Add-on update available!"
+msgstr "Atualização do Add-on Disponível!"
+
+#: id:24062
+msgid "Enabled Add-ons"
+msgstr "Add-ons Ativados"
+
+#: id:24063
+msgid "Auto update"
+msgstr "Atualização Automática"
+
+#: id:24064
+msgid "Add-on enabled"
+msgstr "Add-on ativado"
+
+#: id:24065
+msgid "Add-on updated"
+msgstr "Add-on atualizado"
+
+#: id:24066
+msgid "Cancel Add-on download?"
+msgstr "Cancelar download do Add-on?"
+
+#: id:24067
+msgid "Currently downloading Add-ons"
+msgstr "Baixando Add-ons"
+
+#: id:24068
+msgid "Update available"
+msgstr "Atualização Disponível"
+
+#: id:24069
+msgid "Update"
+msgstr "Atualizar"
+
+#: id:24070
+msgid "Add-on could not be loaded."
+msgstr "Add-on não utilizado"
+
+#: id:24071
+msgid "An unknown error has occurred."
+msgstr "Ocorreu um erro desconhecido"
+
+#: id:24072
+msgid "Settings required"
+msgstr "Necessário configurações"
+
+#: id:24073
+msgid "Could not connect"
+msgstr "Não é possível conectar"
+
+#: id:24074
+msgid "Needs to restart"
+msgstr "Necessário reiniciar"
+
+#: id:24075
+msgctxt "Auto context with id 24075"
+msgid "Disable"
+msgstr "Desativar"
+
+#: id:24076
+msgid "Add-on Required"
+msgstr "Add-on Necessário"
+
+#: id:24080
+msgid "Try to reconnect?"
+msgstr "Reconectar?"
+
+#: id:24089
+msgid "Add-on restarts"
+msgstr "Add-on reiniciado"
+
+#: id:24090
+msgid "Lock Add-on manager"
+msgstr "Bloquear Gerenciador de Add-on"
+
+#: id:24094
+msgid "(current)"
+msgstr "(atual)"
+
+#: id:24095
+msgid "(blacklisted)"
+msgstr "(na lista negra)"
+
+#: id:24096
+msgid "Add-on has been marked as broken in repository."
+msgstr "O Add-on foi marcado como indisponível no repositório."
+
+#: id:24097
+msgid "Would you like to disable it on your system?"
+msgstr "Você deseja desabilitar em seu sistema?"
+
+#: id:24098
+msgid "Broken"
+msgstr "Indisponível"
+
+#: id:24099
+msgid "Would you like to switch to this skin?"
+msgstr "Gostaria de trocar para esta skin?"
+
+#: id:24100
+msgid "To use this feature you must download an Add-on:"
+msgstr ""
+
+#: id:24101
+msgid "Would you like to download this Add-on?"
+msgstr ""
+
+#: id:25000
+msgid "Notifications"
+msgstr "Notificações"
+
+#: id:29800
+msgid "Library Mode"
+msgstr "Modo de coleção"
+
+#: id:29801
+msgid "QWERTY keyboard"
+msgstr "Teclado QWERTY"
+
+#: id:29802
+msgid "Passthrough Audio in use"
+msgstr "Utilizando áudio em passthrough"
+
+#: id:33001
+msgid "Trailer quality"
+msgstr "Qualidade do trailer"
+
+#: id:33002
+msgid "Stream"
+msgstr "Canal/sinal"
+
+#: id:33003
+msgid "Download"
+msgstr "Baixar"
+
+#: id:33004
+msgid "Download & play"
+msgstr "Baixar & tocar"
+
+#: id:33005
+msgid "Download & save"
+msgstr "Baixar & salvar"
+
+#: id:33006
+msgid "Today"
+msgstr "Hoje"
+
+#: id:33007
+msgid "Tomorrow"
+msgstr "Amanhã"
+
+#: id:33008
+msgid "Saving"
+msgstr "Salvando"
+
+#: id:33009
+msgid "Copying"
+msgstr "Copiando"
+
+#: id:33010
+msgid "Set download directory"
+msgstr "Definir diretório para download"
+
+#: id:33011
+msgid "Search duration"
+msgstr "Duração da busca"
+
+#: id:33012
+msgid "Short"
+msgstr "Curto"
+
+#: id:33013
+msgid "Long"
+msgstr "Longo"
+
+#: id:33014
+msgid "Use DVD player instead of regular player"
+msgstr "Utilizar tocador de DVD ao invés de tocador regular"
+
+#: id:33015
+msgid "Ask for download before playing video"
+msgstr "Pergunte para baixar antes de tocar vídeo"
+
+#: id:33016
+msgid "Clips"
+msgstr "Clipes"
+
+#: id:33017
+msgid "Restart plugin to enable"
+msgstr "Reiniciar plugin para ativar"
+
+#: id:33018
+msgid "Tonight"
+msgstr "Hoje a noite"
+
+#: id:33019
+msgid "Tomorrow Night"
+msgstr "Amanhã a noite"
+
+#: id:33020
+msgid "Condition"
+msgstr "Condição"
+
+#: id:33021
+msgid "Precipitation"
+msgstr "Precipitação"
+
+#: id:33022
+msgid "Precip"
+msgstr "Precip"
+
+#: id:33023
+msgid "Humid"
+msgstr "Úmido"
+
+#: id:33024
+msgid "Feels"
+msgstr "Parece"
+
+#: id:33025
+msgid "Observed"
+msgstr "Observado"
+
+#: id:33026
+msgid "Departure from normal"
+msgstr "Saída do normal"
+
+#: id:33027
+msgid "Sunrise"
+msgstr "Nascer-do-sol"
+
+#: id:33028
+msgid "Sunset"
+msgstr "Pôr-do-sol"
+
+#: id:33029
+msgid "Details"
+msgstr "Detalhes"
+
+#: id:33030
+msgid "Outlook"
+msgstr "Previsão"
+
+#: id:33031
+msgid "Coverflow"
+msgstr "Coverflow"
+
+#: id:33032
+msgid "Translate text"
+msgstr "Traduza texto"
+
+#: id:33033
+msgid "Map list %s category"
+msgstr "Categoria %s Lista de Mapas"
+
+#: id:33034
+msgid "36 Hour"
+msgstr "36 horas"
+
+#: id:33035
+msgid "Maps"
+msgstr "Mapas"
+
+#: id:33036
+msgid "Hourly"
+msgstr "Hora em Hora"
+
+#: id:33037
+msgid "Weekend"
+msgstr "Final de semana"
+
+#: id:33038
+msgid "%s day"
+msgstr "Dia %s"
+
+#: id:33049
+msgid "Alert"
+msgstr "Alerta"
+
+#: id:33050
+msgid "Alerts"
+msgstr "Alertas"
+
+#: id:33051
+msgid "Choose Your"
+msgstr "Escolha seu"
+
+#: id:33052
+msgid "Check"
+msgstr "Verifique"
+
+#: id:33053
+msgctxt "Auto context with id 33053"
+msgid "Configure the"
+msgstr "Configure o"
+
+#: id:33054
+msgid "Seasons"
+msgstr "Temporadas"
+
+#: id:33055
+msgid "Use your"
+msgstr "Use o seu"
+
+#: id:33056
+msgid "Watch your"
+msgstr "Asista seu"
+
+#: id:33057
+msgid "Listen to"
+msgstr "Escute ao"
+
+#: id:33058
+msgid "View your"
+msgstr "Veja seu"
+
+#: id:33059
+msgctxt "Auto context with id 33059"
+msgid "Configure the"
+msgstr "Configure o"
+
+#: id:33060
+msgid "Power"
+msgstr "Energia"
+
+#: id:33061
+msgid "Menu"
+msgstr "Menu"
+
+#: id:33062
+msgid "Play the"
+msgstr "Tocar o"
+
+#: id:33063
+msgid "Options"
+msgstr "Opções"
+
+#: id:33065
+msgid "Editor"
+msgstr "Editor"
+
+#: id:33066
+msgid "About your"
+msgstr "Sobre você"
+
+#: id:33067
+msgid "Star rating"
+msgstr "Classificação estrela"
+
+#: id:33068
+msgid "Background"
+msgstr "Fundo"
+
+#: id:33069
+msgid "Backgrounds"
+msgstr "Fundos"
+
+#: id:33070
+msgid "Custom background"
+msgstr "Fundo personalizado"
+
+#: id:33071
+msgid "Custom backgrounds"
+msgstr "Fundos personalizados"
+
+#: id:33072
+msgid "View Readme"
+msgstr "Ver o Readme/Leia-me"
+
+#: id:33073
+msgid "View Changelog"
+msgstr "Ver Changelog (alterações)"
+
+#: id:33074
+msgid "This version of %s requires an"
+msgstr "Esta versão de %s requer um"
+
+#: id:33075
+msgid "XBMC revision of %s or greater to run."
+msgstr "XBMC revisão %s ou maior para executar"
+
+#: id:33076
+msgid "Please update XBMC."
+msgstr "Por favor, atualize o XBMC"
+
+#: id:33077
+msgid "No data found!"
+msgstr "Nenhum dado encontrado!"
+
+#: id:33078
+msgid "Next page"
+msgstr "Próxima página"
+
+#: id:33079
+msgid "Love"
+msgstr "Amor"
+
+#: id:33080
+msgid "Hate"
+msgstr "Ódio"
+
+#: id:33081
+msgid "This file is stacked, select the part you want to play from."
+msgstr "Este arquivo está empilhado, selecione a parte que quer tocar."
+
+#: id:33082
+msgid "Path to script"
+msgstr "Caminho para o script"
+
+#: id:33083
+msgid "Enable custom script button"
+msgstr "Habilitar botão de script personalizado"
+
+#: id:33100
+msgid "Failed to start"
+msgstr "Falha ao Iniciar"
+
+#: id:33101
+msgid "Webserver"
+msgstr "Webserver"
+
+#: id:33102
+msgid "Event Server"
+msgstr "Servidor de Eventos"
+
+#: id:33103
+msgid "Remote communication server"
+msgstr "Servidor de Comunicação Remota"
+
+#: id:33200
+msgid "Detected New Connection"
+msgstr "Detectado Nova Conexão"
+
+#: id:34000
+msgid "Lame"
+msgstr ""
+
+#: id:34001
+msgid "Vorbis"
+msgstr ""
+
+#: id:34002
+msgid "Wav"
+msgstr ""
+
+#: id:34003
+msgid "DXVA2"
+msgstr ""
+
+#: id:34004
+msgid "VAAPI"
+msgstr ""
+
+#: id:34005
+msgid "Flac"
+msgstr ""
+
+#: id:34100
+msgid "Speaker Configuration"
+msgstr "Configurar alto-falantes"
+
+#: id:34101
+msgid "2.0"
+msgstr "2.0"
+
+#: id:34102
+msgid "2.1"
+msgstr "2.1"
+
+#: id:34103
+msgid "3.0"
+msgstr "3.0"
+
+#: id:34104
+msgid "3.1"
+msgstr "3.1"
+
+#: id:34105
+msgid "4.0"
+msgstr "4.0"
+
+#: id:34106
+msgid "4.1"
+msgstr "4.1"
+
+#: id:34107
+msgid "5.0"
+msgstr "5.0"
+
+#: id:34108
+msgid "5.1"
+msgstr "5.1"
+
+#: id:34109
+msgid "7.0"
+msgstr "7.0"
+
+#: id:34110
+msgid "7.1"
+msgstr "7.1"
+
+#: id:34201
+msgid "Can't find a next item to play"
+msgstr "Não foi possível encontrar um item posterior para tocar"
+
+#: id:34202
+msgid "Can't find a previous item to play"
+msgstr "Não foi possível encontrar um item anterior para tocar"
+
+#: id:34300
+msgid "Failed to start zeroconf"
+msgstr "Falha ao iniciar zeroconf"
+
+#: id:34301
+msgid "Is Apple's Bonjour Service installed? See log for more info."
+msgstr "Se serviço Apple's Bonjour estiver instalado? Veja log para maiores informações."
+
+#: id:34400
+msgid "Video Rendering"
+msgstr "Renderização de Video"
+
+#: id:34401
+msgid "Failed to init video filters/scalers, falling back to bilinear scaling"
+msgstr "Falha para inciar filtros e scalers de vídeo, voltando a usar bilinear scaling"
+
+#: id:34402
+msgid "Failed to initialize audio device"
+msgstr "Falha para inicializar o dispositivo de áudio"
+
+#: id:34403
+msgid "Check your audiosettings"
+msgstr "Verifique suas configurações de áudio"
+
+#: id:34404
+msgid "Use gestures for navigation:"
+msgstr ""
+
+#: id:34405
+msgid "1 finger swipe left,right,up,down for cursors"
+msgstr ""
+
+#: id:34406
+msgid "2 finger swipe left for backspace"
+msgstr ""
+
+#: id:34407
+msgid "1 finger single tap for enter"
+msgstr ""
+
+#: id:34408
+msgid "2 finger single tap for contextmenu"
+msgstr ""
+
+#: id:35000
+msgid "Peripherals"
+msgstr "Periféricos"
+
+#: id:35001
+msgid "Generic HID device"
+msgstr "Disposito HID Genérico"
+
+#: id:35002
+msgid "Generic network adapter"
+msgstr "Adaptador de Rede Genérico"
+
+#: id:35003
+msgid "Generic disk"
+msgstr "Disco Genérico"
+
+#: id:35004
+msgid "There are no settings available\nfor this peripheral."
+msgstr "Não existe ajustes disponíveis\npara este periférico."
+
+#: id:35005
+msgid "New device configured"
+msgstr "Novo dispositivo configurado"
+
+#: id:35006
+msgid "Device removed"
+msgstr "Dispositivo removido"
+
+#: id:35007
+msgid "Keymap to use for this device"
+msgstr "Keymap para uso com este dispositivo"
+
+#: id:35008
+msgid "Keymap enabled"
+msgstr "Keymap ativado"
+
+#: id:35009
+msgid "Do not use the custom keymap for this device"
+msgstr ""
+
+#: id:35500
+msgid "Location"
+msgstr "Local"
+
+#: id:35501
+msgid "Class"
+msgstr "Classe"
+
+#: id:35502
+msgctxt "Auto context with id 35502"
+msgid "Name"
+msgstr "Nome"
+
+#: id:35503
+msgid "Vendor"
+msgstr "Fabricante"
+
+#: id:35504
+msgid "Product ID"
+msgstr "Produto ID"
+
+#: id:36000
+msgid "Pulse-Eight CEC adapter"
+msgstr "Adaptador CEC Pulse-Eight"
+
+#: id:36001
+msgid "Pulse-Eight Nyxboard"
+msgstr "Nyxboard Pulse-Eight"
+
+#: id:36002
+msgid "Switch to keyboard side command"
+msgstr "Trocar o comando para o lado do teclado"
+
+#: id:36003
+msgid "Switch to remote side command"
+msgstr "Trocar o comando para o lado do remoto"
+
+#: id:36004
+msgid "Press \"user\" button command"
+msgstr "Pressione botão de comando \"usuário\""
+
+#: id:36005
+msgid "Enable switch side commands"
+msgstr "Enable switch side commands"
+
+#: id:36006
+msgid "Could not open the adapter"
+msgstr "Não pude abrir o adaptador"
+
+#: id:36007
+msgid "Devices to power on when starting XBMC"
+msgstr "Ligar a TV ou projetor quando inicializar o XBMC"
+
+#: id:36008
+msgid "Devices to power off when stopping XBMC"
+msgstr "Desligar equipamentos quando parar o XBMC"
+
+#: id:36009
+msgid "Put devices in standby mode when activating screensaver"
+msgstr "Colocar os equipamentos em modo de espera quando ativando proteção de tela"
+
+#: id:36011
+msgid "Could not detect the CEC port. Set it up manually."
+msgstr "Não pude detectar a porta CEC. Seta manualmente."
+
+#: id:36012
+msgid "Could not initialise the CEC adapter. Check your settings."
+msgstr "Não pude detectar o adaptador CEC."
+
+#: id:36013
+msgid "Unsupported libCEC interface version. %d is greater than the version XBMC supports (%d)"
+msgstr "Versãod libcec da interface não suportada. %d é superior a versão que o XBMC suporta (%d)"
+
+#: id:36014
+msgid "Put this PC in standby mode when the TV is switched off"
+msgstr "Passar este PC para modo standby, quando a TV for desligada"
+
+#: id:36015
+msgid "HDMI port number"
+msgstr "Número da porta HDMI"
+
+#: id:36016
+msgctxt "Auto context with id 36016"
+msgid "Connected"
+msgstr "Conectado"
+
+#: id:36017
+msgid "Adapter found, but libCEC is not available"
+msgstr "Adaptador encontrado, mas libcec não esta disponível"
+
+#: id:36018
+msgid "Use the TV's language setting"
+msgstr "Usar os ajustes de linguagem da TV"
+
+#: id:36019
+msgid "Connected to HDMI device"
+msgstr ""
+
+#: id:36020
+msgid "Make XBMC the active source when starting"
+msgstr ""
+
+#: id:36021
+msgid "Physical address (overrules HDMI port)"
+msgstr ""
+
+#: id:36022
+msgid "COM port (leave empty unless needed)"
+msgstr ""
+
+#: id:36023
+msgid "Configuration updated"
+msgstr ""
+
+#: id:36024
+msgid "Failed to set the new configuration. Please check your settings."
+msgstr ""
+
+#: id:36025
+msgid "Send 'inactive source' command when stopping XBMC"
+msgstr ""
+

--- a/language/Portuguese/strings.po
+++ b/language/Portuguese/strings.po
@@ -1,0 +1,9093 @@
+# Converted from xbmc strings.xml with xbmc-xml2po (by Team-XBMC)
+msgid ""
+msgstr ""
+"Project-Id-Version: xbmc.core-FRODO_GIT3ed1604ad7\n"
+"Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
+"POT-Creation-Date: 2012-04-09 18:00+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE\n"
+"Language: pt\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: id:0
+msgctxt "Auto context with id 0"
+msgid "Programs"
+msgstr "Programas"
+
+#: id:1
+msgctxt "Auto context with id 1"
+msgid "Pictures"
+msgstr "Fotos"
+
+#: id:2
+msgctxt "Auto context with id 2"
+msgid "Music"
+msgstr "Música"
+
+#: id:3
+msgctxt "Auto context with id 3"
+msgid "Videos"
+msgstr "Filmes"
+
+#: id:4
+msgid "TV-Guide"
+msgstr "Guia de TV"
+
+#: id:5
+msgctxt "Auto context with id 5"
+msgid "Settings"
+msgstr "Configurações"
+
+#: id:6
+msgid "XBMC SVN"
+msgstr "XBMC SVN"
+
+#: id:7
+msgctxt "Auto context with id 7"
+msgid "File manager"
+msgstr "Gestor de ficheiros"
+
+#: id:8
+msgctxt "Auto context with id 8"
+msgid "Weather"
+msgstr "Tempo"
+
+#: id:9
+msgid "xbmc media center"
+msgstr "XBMC Media Center"
+
+#: id:11
+msgid "Monday"
+msgstr "Segunda"
+
+#: id:12
+msgid "Tuesday"
+msgstr "Terça"
+
+#: id:13
+msgid "Wednesday"
+msgstr "Quarta"
+
+#: id:14
+msgid "Thursday"
+msgstr "Quinta"
+
+#: id:15
+msgid "Friday"
+msgstr "Sexta"
+
+#: id:16
+msgid "Saturday"
+msgstr "Sábado"
+
+#: id:17
+msgid "Sunday"
+msgstr "Domingo"
+
+#: id:21
+msgid "January"
+msgstr "Janeiro"
+
+#: id:22
+msgid "February"
+msgstr "Fevereiro"
+
+#: id:23
+msgid "March"
+msgstr "Março"
+
+#: id:24
+msgid "April"
+msgstr "Abril"
+
+#: id:25
+msgctxt "Auto context with id 25"
+msgid "May"
+msgstr "Maio"
+
+#: id:26
+msgid "June"
+msgstr "Junho"
+
+#: id:27
+msgid "July"
+msgstr "Julho"
+
+#: id:28
+msgid "August"
+msgstr "Agosto"
+
+#: id:29
+msgid "September"
+msgstr "Setembro"
+
+#: id:30
+msgid "October"
+msgstr "Outubro"
+
+#: id:31
+msgid "November"
+msgstr "Novembro"
+
+#: id:32
+msgid "December"
+msgstr "Dezembro"
+
+#: id:41
+msgid "Mon"
+msgstr "Segunda"
+
+#: id:42
+msgid "Tue"
+msgstr "Terça"
+
+#: id:43
+msgid "Wed"
+msgstr "Quarta"
+
+#: id:44
+msgid "Thu"
+msgstr "Quinta"
+
+#: id:45
+msgid "Fri"
+msgstr "Sexta"
+
+#: id:46
+msgid "Sat"
+msgstr "Sábado"
+
+#: id:47
+msgctxt "Auto context with id 47"
+msgid "Sun"
+msgstr "Domingo"
+
+#: id:51
+msgid "Jan"
+msgstr "Janeiro"
+
+#: id:52
+msgid "Feb"
+msgstr "Fevereiro"
+
+#: id:53
+msgid "Mar"
+msgstr "Março"
+
+#: id:54
+msgid "Apr"
+msgstr "Abril"
+
+#: id:55
+msgctxt "Auto context with id 55"
+msgid "May"
+msgstr "Maio"
+
+#: id:56
+msgid "Jun"
+msgstr "Junho"
+
+#: id:57
+msgid "Jul"
+msgstr "Julho"
+
+#: id:58
+msgid "Aug"
+msgstr "Agosto"
+
+#: id:59
+msgid "Sep"
+msgstr "Setembro"
+
+#: id:60
+msgid "Oct"
+msgstr "Outubro"
+
+#: id:61
+msgid "Nov"
+msgstr "Novembro"
+
+#: id:62
+msgid "Dec"
+msgstr "Dezembro"
+
+#: id:71
+msgid "N"
+msgstr "N"
+
+#: id:72
+msgid "NNE"
+msgstr "NNE"
+
+#: id:73
+msgid "NE"
+msgstr "NE"
+
+#: id:74
+msgid "ENE"
+msgstr "ENE"
+
+#: id:75
+msgid "E"
+msgstr "E"
+
+#: id:76
+msgid "ESE"
+msgstr "ESE"
+
+#: id:77
+msgid "SE"
+msgstr "SE"
+
+#: id:78
+msgid "SSE"
+msgstr "SSE"
+
+#: id:79
+msgid "S"
+msgstr "S"
+
+#: id:80
+msgid "SSW"
+msgstr "SSW"
+
+#: id:81
+msgid "SW"
+msgstr "SW"
+
+#: id:82
+msgid "WSW"
+msgstr "WSW"
+
+#: id:83
+msgid "W"
+msgstr "W"
+
+#: id:84
+msgid "WNW"
+msgstr "WNW"
+
+#: id:85
+msgid "NW"
+msgstr "NW"
+
+#: id:86
+msgid "NNW"
+msgstr "NNW"
+
+#: id:87
+msgid "VAR"
+msgstr "VAR"
+
+#: id:98
+msgid "View: Auto"
+msgstr "Ver: Auto"
+
+#: id:99
+msgid "View: Auto big"
+msgstr "Ver: Auto grande"
+
+#: id:100
+msgid "View: Icons"
+msgstr "Ver: Ícones"
+
+#: id:101
+msgid "View: List"
+msgstr "Ver: Lista"
+
+#: id:102
+msgctxt "Auto context with id 102"
+msgid "Scan"
+msgstr "Procurar"
+
+#: id:103
+msgctxt "Auto context with id 103"
+msgid "Sort by: Name"
+msgstr "Ordenar por: Nome"
+
+#: id:104
+msgid "Sort by: Date"
+msgstr "Ordenar por: Data"
+
+#: id:105
+msgid "Sort by: Size"
+msgstr "Ordenar por: Tamanho"
+
+#: id:106
+msgid "No"
+msgstr "Não"
+
+#: id:107
+msgid "Yes"
+msgstr "Sim"
+
+#: id:108
+msgctxt "Auto context with id 108"
+msgid "Slideshow"
+msgstr "Apresentação"
+
+#: id:109
+msgid "Create thumbs"
+msgstr "Criar miniaturas"
+
+#: id:110
+msgid "Create thumbnails"
+msgstr "Criar miniaturas"
+
+#: id:111
+msgctxt "Auto context with id 111"
+msgid "Shortcuts"
+msgstr "Atalhos"
+
+#: id:112
+msgid "Paused"
+msgstr "Pausa"
+
+#: id:113
+msgid "Update failed"
+msgstr "Actualização falhou"
+
+#: id:114
+msgid "Installation failed"
+msgstr "Instalação falhou"
+
+#: id:115
+msgid "Copy"
+msgstr "Copiar"
+
+#: id:116
+msgid "Move"
+msgstr "Mover"
+
+#: id:117
+msgid "Delete"
+msgstr "Apagar"
+
+#: id:118
+msgid "Rename"
+msgstr "Renomear"
+
+#: id:119
+msgid "New folder"
+msgstr "Nova pasta"
+
+#: id:120
+msgid "Confirm file copy"
+msgstr "Confirmar: Copiar"
+
+#: id:121
+msgid "Confirm file move"
+msgstr "Confirmar: Mover"
+
+#: id:122
+msgid "Confirm file delete?"
+msgstr "Confirmar: Apagar"
+
+#: id:123
+msgid "Copy these files?"
+msgstr "Copiar este(s) ficheiro(s)?"
+
+#: id:124
+msgid "Move these files?"
+msgstr "Mover este(s) ficheiro(s)?"
+
+#: id:125
+msgid "Delete these files? - Deleting files cannot be undone!"
+msgstr "Apagar este(s) ficheiro(s)?"
+
+#: id:126
+msgid "Status"
+msgstr "Estado"
+
+#: id:127
+msgid "Objects"
+msgstr "Objectos"
+
+#: id:128
+msgctxt "Auto context with id 128"
+msgid "General"
+msgstr "Geral"
+
+#: id:129
+msgctxt "Auto context with id 129"
+msgid "Slideshow"
+msgstr "Apresentação"
+
+#: id:130
+msgctxt "Auto context with id 130"
+msgid "System info"
+msgstr "Informação do sistema"
+
+#: id:131
+msgid "Display"
+msgstr "Ecrã"
+
+#: id:132
+msgid "Albums"
+msgstr "Álbuns"
+
+#: id:133
+msgid "Artists"
+msgstr "Artistas"
+
+#: id:134
+msgid "Songs"
+msgstr "Músicas"
+
+#: id:135
+msgid "Genres"
+msgstr "Géneros"
+
+#: id:136
+msgid "Playlists"
+msgstr "Listas de reprodução"
+
+#: id:137
+msgid "Search"
+msgstr "Procurar"
+
+#: id:138
+msgid "System Information"
+msgstr "Informação do sistema"
+
+#: id:139
+msgid "Temperatures:"
+msgstr "Temperaturas:"
+
+#: id:140
+msgid "CPU:"
+msgstr "CPU:"
+
+#: id:141
+msgid "GPU:"
+msgstr "GPU:"
+
+#: id:142
+msgid "Time:"
+msgstr "Hora:"
+
+#: id:143
+msgid "Current:"
+msgstr "Actual:"
+
+#: id:144
+msgid "Build:"
+msgstr "Versão:"
+
+#: id:145
+msgid "Network:"
+msgstr "Rede:"
+
+#: id:146
+msgid "Type:"
+msgstr "Tipo:"
+
+#: id:147
+msgid "Static"
+msgstr "Estática"
+
+#: id:148
+msgid "DHCP"
+msgstr "DHCP"
+
+#: id:149
+msgid "MAC address"
+msgstr "Endereço MAC"
+
+#: id:150
+msgctxt "Auto context with id 150"
+msgid "IP address"
+msgstr "Endereço IP"
+
+#: id:151
+msgid "Link:"
+msgstr "Ligação:"
+
+#: id:152
+msgid "Half duplex"
+msgstr "Half-duplex"
+
+#: id:153
+msgid "Full duplex"
+msgstr "Full-duplex"
+
+#: id:154
+msgctxt "Auto context with id 154"
+msgid "Storage"
+msgstr "Drives"
+
+#: id:155
+msgid "Drive"
+msgstr "Drive"
+
+#: id:156
+msgctxt "Auto context with id 156"
+msgid "Free"
+msgstr "Livre"
+
+#: id:157
+msgctxt "Auto context with id 157"
+msgid "Video"
+msgstr "Vídeo"
+
+#: id:158
+msgid "Free memory"
+msgstr "Memória livre"
+
+#: id:159
+msgid "No link"
+msgstr "Sem ligação!"
+
+#: id:160
+msgctxt "Auto context with id 160"
+msgid "Free"
+msgstr "Livre"
+
+#: id:161
+msgid "Unavailable"
+msgstr "Indisponível"
+
+#: id:162
+msgid "Tray open"
+msgstr "Drive aberta"
+
+#: id:163
+msgid "Reading"
+msgstr "Carregando..."
+
+#: id:164
+msgid "No disc"
+msgstr "Sem disco"
+
+#: id:165
+msgid "Disc present"
+msgstr "Disco Presente"
+
+#: id:166
+msgid "Skin"
+msgstr "Tema"
+
+#: id:169
+msgctxt "Auto context with id 169"
+msgid "Resolution"
+msgstr "Resolução"
+
+#: id:170
+msgid "Adjust display refresh rate to match video"
+msgstr "Ajustar taxa de refrescamento para condizer com vídeo"
+
+#: id:172
+msgid "Release date"
+msgstr "Data de lançamento"
+
+#: id:173
+msgid "Display 4:3 videos as"
+msgstr "Mostrar vídeo 4:3 como"
+
+#: id:175
+msgid "Moods"
+msgstr "Sonoridades"
+
+#: id:176
+msgid "Styles"
+msgstr "Estilos"
+
+#: id:179
+msgid "Song"
+msgstr "Música"
+
+#: id:180
+msgid "Duration"
+msgstr "Duração"
+
+#: id:181
+msgid "Select album"
+msgstr "Selecção de álbum"
+
+#: id:182
+msgid "Tracks"
+msgstr "Faixas"
+
+#: id:183
+msgid "Review"
+msgstr "Crítica"
+
+#: id:184
+msgid "Refresh"
+msgstr "Actualizar"
+
+#: id:185
+msgid "Searching album"
+msgstr "À procura do álbum"
+
+#: id:186
+msgid "OK"
+msgstr "OK"
+
+#: id:187
+msgid "No albums found!"
+msgstr "Álbuns não encontrados!"
+
+#: id:188
+msgid "Select all"
+msgstr "Seleccionar todos"
+
+#: id:189
+msgid "Scanning media info"
+msgstr "À procura de informação"
+
+#: id:190
+msgid "Save"
+msgstr "Guardar"
+
+#: id:191
+msgid "Shuffle"
+msgstr "Aleatório"
+
+#: id:192
+msgctxt "Auto context with id 192"
+msgid "Clear"
+msgstr "Limpar"
+
+#: id:193
+msgctxt "Auto context with id 193"
+msgid "Scan"
+msgstr "Procurar"
+
+#: id:194
+msgid "Searching..."
+msgstr "À procura..."
+
+#: id:195
+msgid "No info found!"
+msgstr "Informação não encontrada!"
+
+#: id:196
+msgid "Select movie:"
+msgstr "Seleccionar vídeo:"
+
+#: id:197
+msgid "Querying %s info"
+msgstr "A pedir informação"
+
+#: id:198
+msgid "Loading movie details"
+msgstr "A carregar detalhes do vídeo"
+
+#: id:199
+msgid "Web interface"
+msgstr "Interface Web"
+
+#: id:202
+msgid "Tagline"
+msgstr "Tagline"
+
+#: id:203
+msgid "Plot outline"
+msgstr "Sinópse"
+
+#: id:205
+msgid "Votes"
+msgstr "Votos"
+
+#: id:206
+msgid "Cast"
+msgstr "Elenco"
+
+#: id:207
+msgid "Plot"
+msgstr "Trama"
+
+#: id:208
+msgctxt "Auto context with id 208"
+msgid "Play"
+msgstr "Reproduzir"
+
+#: id:209
+msgid "Next"
+msgstr "Seguinte"
+
+#: id:210
+msgid "Previous"
+msgstr "Anterior"
+
+#: id:213
+msgid "Calibrate user interface..."
+msgstr "Calibrar interface do utilizador"
+
+#: id:214
+msgid "Video calibration..."
+msgstr "Calibrar ecrã"
+
+#: id:215
+msgid "Soften"
+msgstr "Suavizar"
+
+#: id:216
+msgid "Zoom amount"
+msgstr "Nível de ampliação"
+
+#: id:217
+msgid "Pixel ratio"
+msgstr "Ajustar rácio de píxel"
+
+#: id:218
+msgid "DVD drive"
+msgstr "Drive de DVD"
+
+#: id:219
+msgid "Please insert disc"
+msgstr "Insira o disco"
+
+#: id:220
+msgid "Remote share"
+msgstr "Partilha remota"
+
+#: id:221
+msgid "Network is not connected"
+msgstr "Impossível ligar à rede"
+
+#: id:222
+msgid "Cancel"
+msgstr "Cancelar"
+
+#: id:224
+msgid "Speed"
+msgstr "Velocidade"
+
+#: id:225
+msgid "Vertical Shift"
+msgstr ""
+
+#: id:226
+msgid "Test patterns..."
+msgstr "Padrões de teste"
+
+#: id:227
+msgid "Lookup audio CD track names from freedb.org"
+msgstr "Procurar informação de CDs de áudio em freedb.org"
+
+#: id:228
+msgid "Shuffle playlist on load"
+msgstr "Lista de reprodução aleatória ao carregar"
+
+#: id:229
+msgid "HDD spindown time"
+msgstr "Tempo de paragem do HDD"
+
+#: id:230
+msgid "Video filters"
+msgstr "Filtros de vídeo"
+
+#: id:231
+msgctxt "Auto context with id 231"
+msgid "None"
+msgstr "Nenhum"
+
+#: id:232
+msgid "Point"
+msgstr "Ponto"
+
+#: id:233
+msgid "Linear"
+msgstr "Linear"
+
+#: id:234
+msgid "Anisotropic"
+msgstr "Anisotrópico"
+
+#: id:235
+msgid "Quincunx"
+msgstr "Quincunx"
+
+#: id:236
+msgid "Gaussian cubic"
+msgstr "Cúbico Gaussiano"
+
+#: id:237
+msgid "Minification"
+msgstr "Minimização"
+
+#: id:238
+msgid "Magnification"
+msgstr "Magnificação"
+
+#: id:239
+msgid "Clear playlist on finish"
+msgstr "Limpar a lista de reprodução ao terminar"
+
+#: id:240
+msgid "Display Mode"
+msgstr "Modo de visualização"
+
+#: id:241
+msgid "Full Screen #%d"
+msgstr "Ecrã completo #%d"
+
+#: id:242
+msgid "Windowed"
+msgstr "Em janela"
+
+#: id:243
+msgid "Refresh Rate"
+msgstr "Taxa de refrescamento"
+
+#: id:244
+msgid "Full screen"
+msgstr "Ecrã completo"
+
+#: id:245
+msgid "Sizing: (%i,%i)->(%i,%i) (Zoom x%2.2f) AR:%2.2f:1 (Pixels: %2.2f:1) (VShift: %2.2f)"
+msgstr "Tamanho: (%i,%i)->(%i,%i) (Zoom x%2.2f) AR:%2.2f:1 (Pixels: %2.2f:1)"
+
+#: id:247
+msgctxt "Auto context with id 247"
+msgid "Scripts"
+msgstr "Scripts"
+
+#: id:248
+msgctxt "Auto context with id 248"
+msgid "Language"
+msgstr "Idioma"
+
+#: id:249
+msgctxt "Auto context with id 249"
+msgid "Music"
+msgstr "Música"
+
+#: id:250
+msgctxt "Auto context with id 250"
+msgid "Visualization"
+msgstr "Visualização"
+
+#: id:251
+msgid "Select destination directory"
+msgstr "Seleccionar pasta de destino"
+
+#: id:252
+msgid "Output stereo to all speakers"
+msgstr "Saída por todas as colunas"
+
+#: id:253
+msgid "Number of channels"
+msgstr "Número de canais"
+
+#: id:254
+msgid "- DTS capable receiver"
+msgstr "Receptor DTS"
+
+#: id:255
+msgid "CDDB"
+msgstr "CDDB"
+
+#: id:256
+msgid "Fetching CD information"
+msgstr "A pesquisar informação do CD"
+
+#: id:257
+msgid "Error"
+msgstr "Erro"
+
+#: id:258
+msgid "Enable tag reading"
+msgstr "Activar leitura de etiquetas ID3"
+
+#: id:259
+msgid "Opening"
+msgstr "A abrir"
+
+#: id:260
+msgid "Shoutcast"
+msgstr "Shoutcast"
+
+#: id:261
+msgid "Waiting for start..."
+msgstr "Aguardando início..."
+
+#: id:262
+msgid "Scripts output"
+msgstr "Output dos scripts"
+
+#: id:263
+msgid "Allow control of XBMC via HTTP"
+msgstr "Activar controlo do XBMC por HTTP"
+
+#: id:264
+msgid "Record"
+msgstr "Gravar"
+
+#: id:265
+msgid "Stop Rec."
+msgstr "Parar gravação"
+
+#: id:266
+msgid "Sort by: Track"
+msgstr "Ordenar por: Faixa"
+
+#: id:267
+msgid "Sort by: Time"
+msgstr "Ordenar por: Tempo"
+
+#: id:268
+msgid "Sort by: Title"
+msgstr "Ordenar por: Título"
+
+#: id:269
+msgid "Sort by: Artist"
+msgstr "Ordenar por: Artista"
+
+#: id:270
+msgid "Sort by: Album"
+msgstr "Ordenar por: Álbum"
+
+#: id:271
+msgid "Top 100"
+msgstr "100 melhores"
+
+#: id:272
+msgid "Top-Left overscan compensation"
+msgstr "Compensação de overscan do canto superior esquerdo"
+
+#: id:273
+msgid "Bottom-Right overscan compensation"
+msgstr "Compensação de overscan do canto inferior direito"
+
+#: id:274
+msgid "Subtitle positioning"
+msgstr "Posição das legendas"
+
+#: id:275
+msgid "Pixel ratio adjustment"
+msgstr "Ajuste de rácio de píxel"
+
+#: id:276
+msgid "Adjust the arrow to change the amount of overscan"
+msgstr "Mova a seta para alterar o tamanho de overscan"
+
+#: id:277
+msgid "Adjust the bar to change the subtitles position"
+msgstr "Mova a barra para alterar a posição das legendas"
+
+#: id:278
+msgid "Adjust the rectangle so it is perfectly square"
+msgstr "Ajuste o rectângulo para ficar um quadrado perfeito"
+
+#: id:279
+msgid "Unable to load settings"
+msgstr "Não foi possível carregar as configurações"
+
+#: id:280
+msgid "Using default settings"
+msgstr "Usando as configurações originais"
+
+#: id:281
+msgid "Please check the XML files"
+msgstr "Confira os ficheiros XML"
+
+#: id:282
+msgid "Found %i items"
+msgstr "Encontrados %i itens"
+
+#: id:283
+msgid "Search results"
+msgstr "Resultado da procura"
+
+#: id:284
+msgid "No results found"
+msgstr "Sem resultados"
+
+#: id:287
+msgctxt "Auto context with id 287"
+msgid "Subtitles"
+msgstr "Legendas"
+
+#: id:288
+msgctxt "Auto context with id 288"
+msgid "Font"
+msgstr "Fonte"
+
+#: id:289
+msgctxt "Auto context with id 289"
+msgid "- Size"
+msgstr "- Tamanho"
+
+#: id:290
+msgid "Dynamic range compression"
+msgstr "Amplificação de volume (dB)"
+
+#: id:291
+msgctxt "Auto context with id 291"
+msgid "Video"
+msgstr "Vídeo"
+
+#: id:292
+msgctxt "Auto context with id 292"
+msgid "Audio"
+msgstr "Áudio"
+
+#: id:293
+msgid "Browse for subtitles"
+msgstr "Procurar legendas"
+
+#: id:294
+msgid "Create bookmark"
+msgstr "Criar favorito"
+
+#: id:296
+msgid "Clear bookmarks"
+msgstr "Limpar favoritos"
+
+#: id:297
+msgid "Audio offset"
+msgstr "Atraso do áudio"
+
+#: id:298
+msgid "Bookmarks"
+msgstr "Favoritos"
+
+#: id:299
+msgid "- AAC capable receiver"
+msgstr "- Receptor compatível com AAC"
+
+#: id:300
+msgid "- MP1 capable receiver"
+msgstr "- Receptor compatível com MP1"
+
+#: id:301
+msgid "- MP2 capable receiver"
+msgstr "- Receptor compatível com MP2"
+
+#: id:302
+msgid "- MP3 capable receiver"
+msgstr "- Receptor compatível com MP3"
+
+#: id:303
+msgid "Delay"
+msgstr "Atraso"
+
+#: id:304
+msgctxt "Auto context with id 304"
+msgid "Language"
+msgstr "Idioma"
+
+#: id:305
+msgctxt "Auto context with id 305"
+msgid "Enabled"
+msgstr "Activado"
+
+#: id:306
+msgid "Non-interleaved"
+msgstr "Não interlaçado"
+
+#: id:312
+msgid "(0=auto)"
+msgstr "(0=auto)"
+
+#: id:313
+msgid "Cleaning database"
+msgstr "A limpar a base de dados"
+
+#: id:314
+msgid "Preparing..."
+msgstr "Preparando..."
+
+#: id:315
+msgid "Database error"
+msgstr "Erro na base de dados"
+
+#: id:316
+msgid "Searching songs..."
+msgstr "À procura de músicas..."
+
+#: id:317
+msgid "Cleaned database successfully"
+msgstr "Músicas eliminadas da base de dados"
+
+#: id:318
+msgid "Cleaning songs..."
+msgstr "Apagando músicas..."
+
+#: id:319
+msgid "Error cleaning songs"
+msgstr "Erro ao apagar as músicas"
+
+#: id:320
+msgid "Cleaning artists..."
+msgstr "Apagando artistas..."
+
+#: id:321
+msgid "Error cleaning artists"
+msgstr "Erro ao apagar os artistas"
+
+#: id:322
+msgid "Cleaning genres..."
+msgstr "Apagando géneros..."
+
+#: id:323
+msgid "Error cleaning genres"
+msgstr "Erro ao apagar géneros"
+
+#: id:324
+msgid "Cleaning paths..."
+msgstr "Limpando caminhos..."
+
+#: id:325
+msgid "Error cleaning paths"
+msgstr "Erro ao limpar caminhos"
+
+#: id:326
+msgid "Cleaning albums..."
+msgstr "Apagando álbuns..."
+
+#: id:327
+msgid "Error cleaning albums"
+msgstr "Erro ao apagar os álbuns"
+
+#: id:328
+msgid "Writing changes..."
+msgstr "Guardando alterações..."
+
+#: id:329
+msgid "Error writing changes"
+msgstr "Erro ao guardar alterações"
+
+#: id:330
+msgid "This may take some time..."
+msgstr "Isto pode demorar algum tempo..."
+
+#: id:331
+msgid "Compressing database..."
+msgstr "Comprimindo base de dados..."
+
+#: id:332
+msgid "Error compressing database"
+msgstr "Erro ao comprimir base de dados"
+
+#: id:333
+msgid "Do you want to clean the library?"
+msgstr "Deseja limpar a Biblioteca?"
+
+#: id:334
+msgid "Clean library..."
+msgstr "Apagar Biblioteca..."
+
+#: id:335
+msgid "Start"
+msgstr "Iniciar"
+
+#: id:336
+msgid "Framerate conversion"
+msgstr "Ajustar taxa de refrescamento"
+
+#: id:337
+msgctxt "Auto context with id 337"
+msgid "Audio output"
+msgstr "Saída áudio"
+
+#: id:338
+msgid "Analog"
+msgstr "Analógico"
+
+#: id:339
+msgid "Optical/Coax"
+msgstr "Optical/Coax"
+
+#: id:340
+msgid "Various artists"
+msgstr "Colectânea"
+
+#: id:341
+msgid "Play disc"
+msgstr "Iniciar disco"
+
+#: id:342
+msgctxt "Auto context with id 342"
+msgid "Movies"
+msgstr "Filmes"
+
+#: id:343
+msgid "Adjust framerate"
+msgstr "Ajustar taxa de refrescamento"
+
+#: id:344
+msgid "Actors"
+msgstr "Actores"
+
+#: id:345
+msgctxt "Auto context with id 345"
+msgid "Year"
+msgstr "Ano"
+
+#: id:346
+msgid "Boost volume level on downmix"
+msgstr "Aumentar nível de som no downmix"
+
+#: id:350
+msgctxt "Auto context with id 350"
+msgid "Programs"
+msgstr "Programas"
+
+#: id:351
+msgctxt "Auto context with id 351"
+msgid "Off"
+msgstr "Desligado"
+
+#: id:352
+msgid "Dim"
+msgstr "Fade"
+
+#: id:353
+msgid "Black"
+msgstr "Preto"
+
+#: id:354
+msgid "Matrix trails"
+msgstr "Matrix Trails"
+
+#: id:355
+msgid "Screensaver time"
+msgstr "Início da protecção de ecrã"
+
+#: id:356
+msgid "Screensaver mode"
+msgstr "Modo da protecção de ecrã"
+
+#: id:357
+msgid "Shutdown function timer"
+msgstr "Tempo para encerramento"
+
+#: id:358
+msgid "All albums"
+msgstr "Todos os álbuns"
+
+#: id:359
+msgid "Recently added albums"
+msgstr "Álbuns recentes"
+
+#: id:360
+msgctxt "Auto context with id 360"
+msgid "Screensaver"
+msgstr "Protecção do ecrã"
+
+#: id:361
+msgid "R. Slideshow"
+msgstr "Apresentação recursiva"
+
+#: id:362
+msgid "Screensaver dim level"
+msgstr "Nível de fade da protecção de ecrã"
+
+#: id:363
+msgid "Sort by: File"
+msgstr "Ordenar por: Ficheiro"
+
+#: id:364
+msgid "- Dolby Digital (AC3) capable receiver"
+msgstr "- Receptor AC3"
+
+#: id:365
+msgctxt "Auto context with id 365"
+msgid "Sort by: Name"
+msgstr "Ordenar por: Nome"
+
+#: id:366
+msgid "Sort by: Year"
+msgstr "Ordenar por: Ano"
+
+#: id:367
+msgid "Sort by: Rating"
+msgstr "Ordenar por: Cotação"
+
+#: id:368
+msgid "IMDb"
+msgstr "IMDb"
+
+#: id:369
+msgctxt "Auto context with id 369"
+msgid "Title"
+msgstr "Título"
+
+#: id:370
+msgid "Thunderstorms"
+msgstr "Trovoada"
+
+#: id:371
+msgid "Partly"
+msgstr "Parcialmente"
+
+#: id:372
+msgid "Mostly"
+msgstr "Normalmente"
+
+#: id:373
+msgid "Sunny"
+msgstr "Sol"
+
+#: id:374
+msgid "Cloudy"
+msgstr "Nublado"
+
+#: id:375
+msgid "Snow"
+msgstr "Neve"
+
+#: id:376
+msgid "Rain"
+msgstr "Chuva"
+
+#: id:377
+msgid "Light"
+msgstr "Leve"
+
+#: id:378
+msgid "AM"
+msgstr "AM"
+
+#: id:379
+msgid "PM"
+msgstr "PM"
+
+#: id:380
+msgid "Showers"
+msgstr "Chuvadas"
+
+#: id:381
+msgid "Few"
+msgstr "Pouco"
+
+#: id:382
+msgid "Scattered"
+msgstr "Disperso"
+
+#: id:383
+msgctxt "Auto context with id 383"
+msgid "Wind"
+msgstr "Vento"
+
+#: id:384
+msgid "Strong"
+msgstr "Forte"
+
+#: id:385
+msgid "Fair"
+msgstr "Calmo"
+
+#: id:386
+msgctxt "Auto context with id 386"
+msgid "Clear"
+msgstr "Limpo"
+
+#: id:387
+msgid "Clouds"
+msgstr "Nuvens"
+
+#: id:388
+msgid "Early"
+msgstr "Cedo"
+
+#: id:389
+msgid "Shower"
+msgstr "Chuvoso"
+
+#: id:390
+msgid "Flurries"
+msgstr "Instável"
+
+#: id:391
+msgctxt "Auto context with id 391"
+msgid "Low"
+msgstr "Mínima"
+
+#: id:392
+msgctxt "Auto context with id 392"
+msgid "Medium"
+msgstr "Média"
+
+#: id:393
+msgctxt "Auto context with id 393"
+msgid "High"
+msgstr "Máxima"
+
+#: id:394
+msgid "Fog"
+msgstr "Nevoeiro"
+
+#: id:395
+msgid "Haze"
+msgstr "Nébula"
+
+#: id:396
+msgid "Select location"
+msgstr "Seleccione o local"
+
+#: id:397
+msgid "Refresh time"
+msgstr "Tempo entre actualizações:"
+
+#: id:398
+msgid "Temperature units"
+msgstr "Temperatura medida em:"
+
+#: id:399
+msgid "Speed units"
+msgstr "Velocidade medida em:"
+
+#: id:400
+msgctxt "Auto context with id 400"
+msgid "Weather"
+msgstr "Tempo"
+
+#: id:401
+msgid "Temp"
+msgstr "Temperatura"
+
+#: id:402
+msgid "Feels like"
+msgstr "Semelhante a"
+
+#: id:403
+msgid "UV index"
+msgstr "Índice UV"
+
+#: id:404
+msgctxt "Auto context with id 404"
+msgid "Wind"
+msgstr "Vento"
+
+#: id:405
+msgid "Dew point"
+msgstr "Condensação aos"
+
+#: id:406
+msgid "Humidity"
+msgstr "Humidade"
+
+#: id:409
+msgid "Defaults"
+msgstr "Definições padrão"
+
+#: id:410
+msgid "Accessing weather service"
+msgstr "A aceder a www.weather.com"
+
+#: id:411
+msgid "Getting weather for:"
+msgstr "Obtendo a previsão do tempo para:"
+
+#: id:412
+msgid "Unable to get weather data"
+msgstr "Impossível obter dados do tempo."
+
+#: id:413
+msgid "Manual"
+msgstr "Manual"
+
+#: id:414
+msgid "No review for this album"
+msgstr "Não existe crítica para este álbum."
+
+#: id:415
+msgid "Downloading thumbnail..."
+msgstr "Transferindo miniaturas ..."
+
+#: id:416
+msgid "Not available"
+msgstr "Indisponível"
+
+#: id:417
+msgid "View: Big icons"
+msgstr "Ver: Ícones grandes"
+
+#: id:418
+msgctxt "Auto context with id 418"
+msgid "Low"
+msgstr "Baixo"
+
+#: id:419
+msgctxt "Auto context with id 419"
+msgid "High"
+msgstr "Alto"
+
+#: id:420
+msgid "HDMI"
+msgstr "HDMI"
+
+#: id:422
+msgid "Delete album info"
+msgstr "Apagar informação do álbum"
+
+#: id:423
+msgid "Delete CD information"
+msgstr "Apagar informação do CD"
+
+#: id:424
+msgid "Select"
+msgstr "Seleccionar"
+
+#: id:425
+msgid "No album information found"
+msgstr "Informação do álbum não encontrada."
+
+#: id:426
+msgid "No CD information found"
+msgstr "Informação do CD não encontrada."
+
+#: id:427
+msgid "Disc"
+msgstr "Disco"
+
+#: id:428
+msgid "Insert correct CD/DVD"
+msgstr "Inserir CD/DVD correcto"
+
+#: id:429
+msgid "Please insert the following disc:"
+msgstr "Insira o seguinte CD/DVD"
+
+#: id:430
+msgid "Sort by: DVD#"
+msgstr "Ordenar por: DVD#"
+
+#: id:431
+msgid "No cache"
+msgstr "Sem cache"
+
+#: id:432
+msgid "Remove movie from library"
+msgstr "Remover vídeo da Biblioteca"
+
+#: id:433
+msgid "Really remove '%s'?"
+msgstr "Tem a certeza que quer apagar '%s'?"
+
+#: id:434
+msgid "From %s at %i %s"
+msgstr "De %s a %i %s"
+
+#: id:437
+msgid "Removable disk"
+msgstr "Disco removível"
+
+#: id:438
+msgid "Opening file"
+msgstr "A abrir ficheiro"
+
+#: id:439
+msgid "Cache"
+msgstr "Cache"
+
+#: id:440
+msgid "Harddisk"
+msgstr "Disco"
+
+#: id:441
+msgid "UDF"
+msgstr "UDF"
+
+#: id:442
+msgid "Local network"
+msgstr "Rede local"
+
+#: id:443
+msgid "Internet"
+msgstr "Internet"
+
+#: id:444
+msgctxt "Auto context with id 444"
+msgid "Video"
+msgstr "Vídeo"
+
+#: id:445
+msgctxt "Auto context with id 445"
+msgid "Audio"
+msgstr "Áudio"
+
+#: id:446
+msgctxt "Auto context with id 446"
+msgid "DVD"
+msgstr "DVD"
+
+#: id:447
+msgid "Autorun media"
+msgstr "Início automático"
+
+#: id:448
+msgid "LCD"
+msgstr "LCD"
+
+#: id:449
+msgctxt "Auto context with id 449"
+msgid "Enabled"
+msgstr "Activado"
+
+#: id:450
+msgid "Columns"
+msgstr "Colunas"
+
+#: id:451
+msgid "Row 1 address"
+msgstr "Endereço da linha 1"
+
+#: id:452
+msgid "Row 2 address"
+msgstr "Endereço da linha 2"
+
+#: id:453
+msgid "Row 3 address"
+msgstr "Endereço da linha 3"
+
+#: id:454
+msgid "Row 4 address"
+msgstr "Endereço da linha 4"
+
+#: id:455
+msgid "Rows"
+msgstr "Linhas"
+
+#: id:456
+msgid "Mode"
+msgstr "Modo"
+
+#: id:457
+msgid "Switch view"
+msgstr "Trocar de vista"
+
+#: id:459
+msgid "Subs"
+msgstr "Legendas"
+
+#: id:460
+msgid "Audio stream"
+msgstr "Pista de áudio"
+
+#: id:461
+msgid "[active]"
+msgstr "[activo]"
+
+#: id:462
+msgid "Subtitle"
+msgstr "Legenda"
+
+#: id:463
+msgid "Backlight"
+msgstr "Luz de fundo"
+
+#: id:464
+msgid "Brightness"
+msgstr "Brilho"
+
+#: id:465
+msgid "Contrast"
+msgstr "Contraste"
+
+#: id:466
+msgid "Gamma"
+msgstr "Gamma"
+
+#: id:467
+msgctxt "Auto context with id 467"
+msgid "Type"
+msgstr "Tipo"
+
+#: id:468
+msgid "Move the bar to change the OSD position"
+msgstr "Mova a barra para mudar a posição do OSD"
+
+#: id:469
+msgid "OSD position"
+msgstr "Posição do OSD"
+
+#: id:470
+msgid "Credits"
+msgstr "Créditos"
+
+#: id:471
+msgid "Modchip"
+msgstr "Modchip"
+
+#: id:474
+msgctxt "Auto context with id 474"
+msgid "Off"
+msgstr "Desligado"
+
+#: id:475
+msgid "Music only"
+msgstr "Música apenas"
+
+#: id:476
+msgctxt "Auto context with id 476"
+msgid "Music & video"
+msgstr "Música & Vídeo"
+
+#: id:477
+msgid "Unable to load playlist"
+msgstr "Impossível carregar a lista de reprodução"
+
+#: id:478
+msgid "OSD"
+msgstr "OSD"
+
+#: id:479
+msgid "Skin & language"
+msgstr "Tema & Linguagem"
+
+#: id:480
+msgid "Appearance"
+msgstr "Aspecto visual"
+
+#: id:481
+msgid "Audio options"
+msgstr "Opções de áudio"
+
+#: id:482
+msgid "About XBMC"
+msgstr "Sobre o XBMC"
+
+#: id:485
+msgid "Delete album"
+msgstr "Apagar álbum"
+
+#: id:486
+msgid "Repeat"
+msgstr "Repetir"
+
+#: id:487
+msgid "Repeat one"
+msgstr "Repetir uma vez"
+
+#: id:488
+msgid "Repeat folder"
+msgstr "Repetir a pasta"
+
+#: id:489
+msgid "Play the next song automatically"
+msgstr "Reproduzir automaticamente a próxima música"
+
+#: id:491
+msgid "- Use big icons"
+msgstr "- Usar ícones grandes"
+
+#: id:492
+msgid "Resize VobSubs"
+msgstr "Redimensionar legendas"
+
+#: id:493
+msgid "Advanced options (Experts Only!)"
+msgstr "Opções avançadas (apenas mestres!)"
+
+#: id:494
+msgid "Overall audio headroom"
+msgstr "Total de volume áudio (dB)"
+
+#: id:495
+msgid "Upsample videos to GUI resolution"
+msgstr "Escalar vídeos para resolução da GUI"
+
+#: id:496
+msgid "Calibration"
+msgstr "Calibração"
+
+#: id:497
+msgid "Show file extensions"
+msgstr "Mostrar extensões"
+
+#: id:498
+msgid "Sort by: Type"
+msgstr "Ordenar por: Tipo"
+
+#: id:499
+msgid "Unable to connect to online lookup service"
+msgstr "Impossível ligar ao serviço de informação online"
+
+#: id:500
+msgid "Downloading album information failed"
+msgstr "A transferência da informação do álbum falhou"
+
+#: id:501
+msgid "Looking for album names..."
+msgstr "À procura de nomes de álbuns..."
+
+#: id:502
+msgctxt "Auto context with id 502"
+msgid "Open"
+msgstr "Aberta"
+
+#: id:503
+msgid "Busy"
+msgstr "Ocupada"
+
+#: id:504
+msgid "Empty"
+msgstr "Sem disco"
+
+#: id:505
+msgid "Loading media info from files..."
+msgstr "A carregar informação do ficheiro..."
+
+#: id:507
+msgid "Sort by: Usage"
+msgstr "Ordenar por: Uso"
+
+#: id:510
+msgid "Enable visualizations"
+msgstr "Activar visualizações"
+
+#: id:511
+msgid "Enable video mode switching"
+msgstr "Activar troca do modo de vídeo"
+
+#: id:512
+msgid "Startup window"
+msgstr "Janela de arranque"
+
+#: id:513
+msgid "Home window"
+msgstr "Janela principal"
+
+#: id:514
+msgid "Manual settings"
+msgstr "Configuração manual"
+
+#: id:515
+msgid "Genre"
+msgstr "Género"
+
+#: id:517
+msgid "Recently played albums"
+msgstr "Álbuns reproduzidos recentemente"
+
+#: id:518
+msgid "Launch"
+msgstr "Executar"
+
+#: id:519
+msgid "Launch in..."
+msgstr "Executar em..."
+
+#: id:521
+msgid "Compilations"
+msgstr "Compilação"
+
+#: id:522
+msgid "Remove source"
+msgstr "Remover fonte"
+
+#: id:523
+msgid "Switch media"
+msgstr "Trocar de média"
+
+#: id:524
+msgid "Select playlist"
+msgstr "Seleccionar lista de reprodução"
+
+#: id:525
+msgid "New playlist..."
+msgstr "Nova lista de reprodução..."
+
+#: id:526
+msgid "Add to playlist"
+msgstr "Adicionar à lista de reprodução"
+
+#: id:527
+msgid "Manually add to library"
+msgstr "Adicionar manualmente à Biblioteca"
+
+#: id:528
+msgid "Enter title"
+msgstr "Introduzir título"
+
+#: id:529
+msgid "Error: Duplicate title"
+msgstr "Erro: Título duplicado"
+
+#: id:530
+msgid "Select genre"
+msgstr "Seleccione género"
+
+#: id:531
+msgid "New genre"
+msgstr "Novo género"
+
+#: id:532
+msgid "Manual addition"
+msgstr "Adição manual"
+
+#: id:533
+msgid "Enter genre"
+msgstr "Introduzir género"
+
+#: id:534
+msgid "View: %s"
+msgstr "Ver: %s"
+
+#: id:535
+msgid "List"
+msgstr "Lista"
+
+#: id:536
+msgid "Icons"
+msgstr "Ícones"
+
+#: id:537
+msgid "Big list"
+msgstr "Lista grande"
+
+#: id:538
+msgid "Big icons"
+msgstr "Ícones grandes"
+
+#: id:539
+msgid "Wide"
+msgstr "Largo"
+
+#: id:540
+msgid "Big wide"
+msgstr "Muito largo"
+
+#: id:541
+msgid "Album icons"
+msgstr "Ícones de álbum"
+
+#: id:542
+msgid "DVD icons"
+msgstr "Ícones de DVD"
+
+#: id:543
+msgctxt "Auto context with id 543"
+msgid "DVD"
+msgstr "DVD"
+
+#: id:544
+msgctxt "Auto context with id 544"
+msgid "Media info"
+msgstr "Informação de média"
+
+#: id:545
+msgid "Audio output device"
+msgstr "Dispositivo de saída de áudio"
+
+#: id:546
+msgid "Passthrough output device"
+msgstr "Dispositivo de passagem"
+
+#: id:547
+msgid "No biography for this artist"
+msgstr "Artista sem biografia"
+
+#: id:548
+msgid "Downmix multichannel audio to stereo"
+msgstr "Downmix áudio multicanal para estéreo"
+
+#: id:550
+msgid "Sort by: %s"
+msgstr "Ordenar por: %s"
+
+#: id:551
+msgctxt "Auto context with id 551"
+msgid "Name"
+msgstr "Nome"
+
+#: id:552
+msgid "Date"
+msgstr "Data"
+
+#: id:553
+msgid "Size"
+msgstr "Tamanho"
+
+#: id:554
+msgid "Track"
+msgstr "Faixa"
+
+#: id:555
+msgid "Time"
+msgstr "Tempo"
+
+#: id:556
+msgctxt "Auto context with id 556"
+msgid "Title"
+msgstr "Título"
+
+#: id:557
+msgid "Artist"
+msgstr "Artista"
+
+#: id:558
+msgid "Album"
+msgstr "Álbum"
+
+#: id:559
+msgid "Playlist"
+msgstr "Lista de reprodução"
+
+#: id:560
+msgid "ID"
+msgstr "ID"
+
+#: id:561
+msgctxt "Auto context with id 561"
+msgid "File"
+msgstr "Ficheiro"
+
+#: id:562
+msgctxt "Auto context with id 562"
+msgid "Year"
+msgstr "Ano"
+
+#: id:563
+msgid "Rating"
+msgstr "Cotação"
+
+#: id:564
+msgctxt "Auto context with id 564"
+msgid "Type"
+msgstr "Tipo"
+
+#: id:565
+msgid "Usage"
+msgstr "Utilização"
+
+#: id:566
+msgid "Album artist"
+msgstr "Álbum artista"
+
+#: id:567
+msgid "Play count"
+msgstr "Contador de reprodução"
+
+#: id:568
+msgid "Last played"
+msgstr "Última reprodução"
+
+#: id:569
+msgctxt "Auto context with id 569"
+msgid "Comment"
+msgstr "Comentário"
+
+#: id:570
+msgid "Date added"
+msgstr "Data de adição"
+
+#: id:571
+msgctxt "Auto context with id 571"
+msgid "Default"
+msgstr "Padrão"
+
+#: id:572
+msgid "Studio"
+msgstr "Estúdio"
+
+#: id:573
+msgid "Path"
+msgstr "Caminho"
+
+#: id:574
+msgctxt "Auto context with id 574"
+msgid "Country"
+msgstr "País"
+
+#: id:575
+msgid "In progress"
+msgstr "Em progresso"
+
+#: id:576
+msgid "Times played"
+msgstr ""
+
+#: id:580
+msgid "Sort direction"
+msgstr "Sentido de ordenação"
+
+#: id:581
+msgid "Sort method"
+msgstr "Método de ordenação"
+
+#: id:582
+msgctxt "Auto context with id 582"
+msgid "View mode"
+msgstr "Modo de visualização"
+
+#: id:583
+msgid "Remember views for different folders"
+msgstr "Recordar vistas para diferentes pastas"
+
+#: id:584
+msgid "Ascending"
+msgstr "Ascendente"
+
+#: id:585
+msgid "Descending"
+msgstr "Descendente"
+
+#: id:586
+msgid "Edit playlist"
+msgstr "Editar lista de reprodução"
+
+#: id:587
+msgid "Filter"
+msgstr "Filtrar"
+
+#: id:588
+msgid "Cancel party mode"
+msgstr "Cancelar modo de festa"
+
+#: id:589
+msgid "Party mode"
+msgstr "Modo de festa"
+
+#: id:590
+msgid "Random"
+msgstr "Aleatório"
+
+#: id:591
+msgctxt "Auto context with id 591"
+msgid "Off"
+msgstr "Desligar"
+
+#: id:592
+msgid "One"
+msgstr "Um"
+
+#: id:593
+msgid "All"
+msgstr "Todos"
+
+#: id:594
+msgctxt "Auto context with id 594"
+msgid "Off"
+msgstr "Desligar"
+
+#: id:595
+msgid "Repeat: Off"
+msgstr "Repetir: Desligado"
+
+#: id:596
+msgid "Repeat: One"
+msgstr "Repetir: Uma vez"
+
+#: id:597
+msgid "Repeat: All"
+msgstr "Repetir: Todos"
+
+#: id:600
+msgid "Rip audio CD"
+msgstr "Ripar CD de áudio"
+
+#: id:601
+msgctxt "Auto context with id 601"
+msgid "Medium"
+msgstr "Média"
+
+#: id:602
+msgctxt "Auto context with id 602"
+msgid "Standard"
+msgstr "Normal"
+
+#: id:603
+msgid "Extreme"
+msgstr "Máxima"
+
+#: id:604
+msgid "Constant bitrate"
+msgstr "Bitrate constante"
+
+#: id:605
+msgid "Ripping..."
+msgstr "A ripar CD..."
+
+#: id:607
+msgid "To:"
+msgstr "Para:"
+
+#: id:608
+msgid "Could not rip CD or track"
+msgstr "Impossível ripar o CD ou a faixa"
+
+#: id:609
+msgid "CDDARipPath is not set."
+msgstr "CDDARipPath não está definido."
+
+#: id:610
+msgid "Rip audio track"
+msgstr "Ripar faixa de áudio"
+
+#: id:611
+msgid "Enter number"
+msgstr "Insira número"
+
+#: id:612
+msgid "Bits/Sample"
+msgstr "Bits/Amostra"
+
+#: id:613
+msgid "Sample Frequency"
+msgstr "Frequência da amostra"
+
+#: id:620
+msgid "Audio CDs"
+msgstr "CDs de áudio"
+
+#: id:621
+msgid "Encoder"
+msgstr "Codificação"
+
+#: id:622
+msgid "Quality"
+msgstr "Qualidade"
+
+#: id:623
+msgid "Bitrate"
+msgstr "Bitrate"
+
+#: id:624
+msgid "Include track number"
+msgstr "Incluir o número de faixas"
+
+#: id:625
+msgid "All songs of"
+msgstr "Todas as músicas de"
+
+#: id:629
+msgctxt "Auto context with id 629"
+msgid "View mode"
+msgstr "Modo de vista"
+
+#: id:630
+msgctxt "Auto context with id 630"
+msgid "Normal"
+msgstr "Normal"
+
+#: id:631
+msgid "Zoom"
+msgstr "Ampliação"
+
+#: id:632
+msgid "Stretch 4:3"
+msgstr "Esticado 4:3"
+
+#: id:633
+msgid "Wide Zoom"
+msgstr "Esticado 14:9"
+
+#: id:634
+msgid "Stretch 16:9"
+msgstr "Esticado 16:9"
+
+#: id:635
+msgid "Original Size"
+msgstr "Tamanho original"
+
+#: id:636
+msgctxt "Auto context with id 636"
+msgid "Custom"
+msgstr "Personalizado"
+
+#: id:637
+msgid "Replay gain"
+msgstr "Ganho de reprodução"
+
+#: id:638
+msgid "Replaygain volume adjustments"
+msgstr "Modo de ganho de reprodução"
+
+#: id:639
+msgid "Use track levels"
+msgstr "Usar níveis da faixa"
+
+#: id:640
+msgid "Use album levels"
+msgstr "Usar níveis do álbum"
+
+#: id:641
+msgid "PreAmp Level - Replay gained files"
+msgstr "Nível PreAmp - Tocar ficheiros normalizados"
+
+#: id:642
+msgid "PreAmp Level - Non replay gained files"
+msgstr "Nível PreAmp - Não tocar ficheiros normalizados"
+
+#: id:643
+msgid "Avoid clipping on replay gained files"
+msgstr "Evitar corte em ficheiros normalizados"
+
+#: id:644
+msgid "Crop black bars"
+msgstr "Cortar barras pretas"
+
+#: id:645
+msgid "Need to unpack a big file. Continue?"
+msgstr "É necessário descompactar um ficheiro grande. Continuo?"
+
+#: id:646
+msgid "Remove from library"
+msgstr "Remover da Biblioteca"
+
+#: id:647
+msgid "Export video library"
+msgstr "Exportar Biblioteca de Filmes"
+
+#: id:648
+msgid "Import video library"
+msgstr "Importar Biblioteca de Filmes"
+
+#: id:649
+msgid "Importing"
+msgstr "Importando"
+
+#: id:650
+msgid "Exporting"
+msgstr "Exportando"
+
+#: id:651
+msgid "Browse for library"
+msgstr "Procurar Biblioteca"
+
+#: id:652
+msgid "Years"
+msgstr "Anos"
+
+#: id:653
+msgid "Update library"
+msgstr "Actualizar Biblioteca"
+
+#: id:654
+msgid "Show debug info"
+msgstr "Mostrar informação de depuração"
+
+#: id:655
+msgid "Browse for executable"
+msgstr "Procurar executável"
+
+#: id:656
+msgid "Browse for playlist"
+msgstr "Procurar lista de reprodução"
+
+#: id:657
+msgid "Browse for folder"
+msgstr "Procurar pasta"
+
+#: id:658
+msgid "Song information"
+msgstr "Informação da música"
+
+#: id:659
+msgid "Non-linear stretch"
+msgstr "Esticar de forma não-linear"
+
+#: id:660
+msgid "Volume amplification"
+msgstr "Amplificação de volume"
+
+#: id:661
+msgid "Choose export folder"
+msgstr "Escolha a pasta de exportação"
+
+#: id:662
+msgid "This file is no longer available."
+msgstr "O ficheiro já não se encontra disponível."
+
+#: id:663
+msgid "Would you like to remove it from the library?"
+msgstr "Deseja removê-lo da Biblioteca?"
+
+#: id:664
+msgid "Browse for Script"
+msgstr "Procurar script"
+
+#: id:665
+msgid "Compression level"
+msgstr "Nível de compressão"
+
+#: id:700
+msgid "Cleaning up library"
+msgstr "A limpar a Biblioteca"
+
+#: id:701
+msgid "Removing old songs from the library"
+msgstr "A apagar músicas antigas da Biblioteca"
+
+#: id:702
+msgid "This path has been scanned before"
+msgstr "Já procurou neste caminho antes"
+
+#: id:705
+msgctxt "Auto context with id 705"
+msgid "Network"
+msgstr "Rede"
+
+#: id:706
+msgid "- Server"
+msgstr "- Servidor"
+
+#: id:708
+msgid "Use an HTTP proxy server to access the internet"
+msgstr "Usar um servidor proxy para aceder à Internet"
+
+#: id:711
+msgid "Internet Protocol (IP)"
+msgstr "Protocolo de Internet (IP)"
+
+#: id:712
+msgid "Invalid port specified. Value must be between 1 and 65535."
+msgstr "Porta de rede inválida. Valor válido entre 1 e 65535."
+
+#: id:713
+msgid "HTTP proxy"
+msgstr "HTTP Proxy"
+
+#: id:715
+msgid "- Assignment"
+msgstr "- Atribuição"
+
+#: id:716
+msgid "Automatic (DHCP)"
+msgstr "Automático (DHCP)"
+
+#: id:717
+msgid "Manual (Static)"
+msgstr "Manual (Estático)"
+
+#: id:719
+msgid "- IP address"
+msgstr "Endereço IP"
+
+#: id:720
+msgid "- Netmask"
+msgstr "Máscara de Rede"
+
+#: id:721
+msgid "- Default gateway"
+msgstr "Gateway padrão"
+
+#: id:722
+msgid "- DNS server"
+msgstr "Servidor DNS"
+
+#: id:723
+msgid "Save & restart"
+msgstr "Salvar & Iniciar"
+
+#: id:724
+msgid "Invalid address specified. Value must be AAA.BBB.CCC.DDD"
+msgstr "Endereço IP inválido. Valor tem que ser AAA.BBB.CCC.DDD"
+
+#: id:725
+msgid "with numbers between 0 and 255."
+msgstr "com números entre 0 e 255."
+
+#: id:726
+msgid "Changes not saved. Continue without saving?"
+msgstr "Alterações não foram guardadas! Continuar sem guardar?"
+
+#: id:727
+msgid "Web server"
+msgstr "Servidor Web"
+
+#: id:728
+msgctxt "Auto context with id 728"
+msgid "FTP server"
+msgstr "Servidor FTP"
+
+#: id:730
+msgid "- Port"
+msgstr "- Porta"
+
+#: id:732
+msgid "Save & apply"
+msgstr "Salvar & Aplicar"
+
+#: id:733
+msgid "- Password"
+msgstr "- Palavra-passe"
+
+#: id:734
+msgid "No pass"
+msgstr "Sem Pass"
+
+#: id:735
+msgid "- Character set"
+msgstr "- Código de caracteres"
+
+#: id:736
+msgid "- Style"
+msgstr "- Estilo"
+
+#: id:737
+msgid "- Colour"
+msgstr "- Cor"
+
+#: id:738
+msgctxt "Auto context with id 738"
+msgid "Normal"
+msgstr "Normal"
+
+#: id:739
+msgid "Bold"
+msgstr "Negrito"
+
+#: id:740
+msgid "Italics"
+msgstr "Itálico"
+
+#: id:741
+msgid "Bold italics"
+msgstr "Negrito e Itálico"
+
+#: id:742
+msgctxt "Auto context with id 742"
+msgid "White"
+msgstr "Branco"
+
+#: id:743
+msgctxt "Auto context with id 743"
+msgid "Yellow"
+msgstr "Amarelo"
+
+#: id:744
+msgctxt "Auto context with id 744"
+msgid "Files"
+msgstr "Ficheiros"
+
+#: id:745
+msgid "No scanned information for this view"
+msgstr "Não foi encontrada informação para esta vista"
+
+#: id:746
+msgid "Please turn off library mode"
+msgstr "Por favor desligue o modo de Biblioteca"
+
+#: id:747
+msgid "Error loading image"
+msgstr "Erro ao carregar imagem"
+
+#: id:748
+msgid "Edit path"
+msgstr "Editar caminho"
+
+#: id:749
+msgid "Mirror image"
+msgstr "Imagem espelhada"
+
+#: id:750
+msgid "Are you sure?"
+msgstr "Tem a certeza?"
+
+#: id:751
+msgid "Removing source"
+msgstr "A remover partilha"
+
+#: id:754
+msgid "Add program link"
+msgstr "Adicionar atalho para aplicação"
+
+#: id:755
+msgid "Edit program path"
+msgstr "Editar caminho para aplicação"
+
+#: id:756
+msgid "Edit program name"
+msgstr "Editar nome da aplicação"
+
+#: id:757
+msgid "Edit path depth"
+msgstr "Editar profundidade do caminho"
+
+#: id:759
+msgid "View: Big list"
+msgstr "Ver: Lista grande"
+
+#: id:760
+msgctxt "Auto context with id 760"
+msgid "Yellow"
+msgstr "Amarelo"
+
+#: id:761
+msgctxt "Auto context with id 761"
+msgid "White"
+msgstr "Branco"
+
+#: id:762
+msgid "Blue"
+msgstr "Azul"
+
+#: id:763
+msgid "Bright green"
+msgstr "Verde brilhante"
+
+#: id:764
+msgid "Yellow green"
+msgstr "Amarelo esverdeado"
+
+#: id:765
+msgid "Cyan"
+msgstr "Ciano"
+
+#: id:766
+msgid "Light grey"
+msgstr "Azul claro"
+
+#: id:767
+msgid "Grey"
+msgstr "Cinzento"
+
+#: id:770
+msgid "Error %i: share not available"
+msgstr "Erro %i: Partilha indisponível"
+
+#: id:772
+msgctxt "Auto context with id 772"
+msgid "Audio output"
+msgstr "Saída de áudio"
+
+#: id:773
+msgid "Seeking"
+msgstr "Procurando"
+
+#: id:774
+msgid "Slideshow folder"
+msgstr "Pasta de apresentações"
+
+#: id:775
+msgid "Network interface"
+msgstr "Interface de rede"
+
+#: id:776
+msgid "- Wireless network name (ESSID)"
+msgstr "- Nome da rede sem fios (ESSID)"
+
+#: id:777
+msgid "- Wireless password"
+msgstr "- Palavra-passe da rede sem fios"
+
+#: id:778
+msgid "- Wireless security"
+msgstr "- Segurança da rede sem fios"
+
+#: id:779
+msgid "Save and apply network interface settings"
+msgstr "Guardar e aplicar configurações da rede sem fios"
+
+#: id:780
+msgid "No encryption"
+msgstr "Sem encriptação"
+
+#: id:781
+msgid "WEP"
+msgstr "WEP"
+
+#: id:782
+msgid "WPA"
+msgstr "WPA"
+
+#: id:783
+msgid "WPA2"
+msgstr "WPA2"
+
+#: id:784
+msgid "Applying network interface settings. Please wait."
+msgstr "A aplicar configurações de rede. Por favor aguarde."
+
+#: id:785
+msgid "Network interface restarted successfully."
+msgstr "Interface de rede reiniciada com sucesso."
+
+#: id:786
+msgid "Network interface did not start successfully."
+msgstr "Interface de rede não reiniciou com sucesso."
+
+#: id:787
+msgid "Interface disabled"
+msgstr "Interface desligada"
+
+#: id:788
+msgid "Network interface disabled successfully."
+msgstr "Interface de rede desligada com sucesso."
+
+#: id:789
+msgid "Wireless network name (ESSID)"
+msgstr "Nome da rede sem fios (ESSID)"
+
+#: id:790
+msgid "Remote control"
+msgstr ""
+
+#: id:791
+msgid "Allow programs on this system to control XBMC"
+msgstr "Permitir que aplicações neste sistema controlem o XBMC"
+
+#: id:792
+msgctxt "Auto context with id 792"
+msgid "Port"
+msgstr "Porta"
+
+#: id:793
+msgid "Port range"
+msgstr "Intervalo de portas"
+
+#: id:794
+msgid "Allow programs on other systems to control XBMC"
+msgstr "Permitir que aplicações noutros sistemas controlem o XBMC"
+
+#: id:795
+msgid "Initial repeat delay (ms)"
+msgstr "Atraso inicial de repetição (ms)"
+
+#: id:796
+msgid "Continuous repeat delay (ms)"
+msgstr "Atraso contínuo de repetição (ms)"
+
+#: id:797
+msgid "Maximum number of clients"
+msgstr "Número máximo de clientes"
+
+#: id:798
+msgid "Internet access"
+msgstr "Acesso à Internet"
+
+#: id:850
+msgid "Invalid port number entered"
+msgstr "Porta introduzida inválida"
+
+#: id:851
+msgid "Valid port range is 1-65535"
+msgstr "Portas válidas de 1 a 65535"
+
+#: id:852
+msgid "Valid port range is 1024-65535"
+msgstr "Portas válidas de 1024 a 65535"
+
+#: id:998
+msgid "Add Music..."
+msgstr ""
+
+#: id:999
+msgid "Add Videos..."
+msgstr ""
+
+#: id:1000
+msgid "- Preview"
+msgstr "- Ver"
+
+#: id:1001
+msgid "Unable to connect"
+msgstr "Incapaz de ligar"
+
+#: id:1002
+msgid "XBMC was unable to connect to the network location."
+msgstr "XBMC não foi capaz de ligar ao local de rede."
+
+#: id:1003
+msgid "This could be due to the network not being connected."
+msgstr "Isto pode dever-se à rede não estar ligada."
+
+#: id:1004
+msgid "Would you like to add it anyway?"
+msgstr "Deseja adicionar de qualquer modo?"
+
+#: id:1006
+msgctxt "Auto context with id 1006"
+msgid "IP address"
+msgstr "Endereço de IP"
+
+#: id:1007
+msgid "Add network location"
+msgstr "Adicionar localização de rede"
+
+#: id:1008
+msgid "Protocol"
+msgstr "Protocolo"
+
+#: id:1009
+msgid "Server address"
+msgstr "Endereço do servidor"
+
+#: id:1010
+msgid "Server name"
+msgstr "Nome do servidor"
+
+#: id:1011
+msgid "Remote path"
+msgstr "Caminho remoto"
+
+#: id:1012
+msgid "Shared folder"
+msgstr "Pasta partilhada"
+
+#: id:1013
+msgctxt "Auto context with id 1013"
+msgid "Port"
+msgstr "Porta"
+
+#: id:1014
+msgctxt "Auto context with id 1014"
+msgid "Username"
+msgstr "Utilizador"
+
+#: id:1015
+msgid "Browse for network server"
+msgstr "Procurar servidor na rede"
+
+#: id:1016
+msgid "Enter the network address of the server"
+msgstr "Introduzir o endereço de rede para o servidor"
+
+#: id:1017
+msgid "Enter the path on the server"
+msgstr "Introduzir o caminho no servidor"
+
+#: id:1018
+msgid "Enter the port number"
+msgstr "Introduzir o número da porta"
+
+#: id:1019
+msgid "Enter the username"
+msgstr "Introduzir o utilizador"
+
+#: id:1020
+msgid "Add %s source"
+msgstr "Adicionar %s fonte"
+
+#: id:1021
+msgid "Enter the paths or browse for the media locations."
+msgstr "Introduza o caminho ou procure a localização da média."
+
+#: id:1022
+msgid "Enter a name for this media Source."
+msgstr "Introduzir o nome para este fonte de média."
+
+#: id:1023
+msgid "Browse for new share"
+msgstr "Procurar nova partilha"
+
+#: id:1024
+msgid "Browse"
+msgstr "Procurar"
+
+#: id:1025
+msgid "Could not retrieve directory information."
+msgstr "Impossível recuperar a informação da pasta."
+
+#: id:1026
+msgid "Add source"
+msgstr "Adicionar fonte"
+
+#: id:1027
+msgid "Edit source"
+msgstr "Editar fonte"
+
+#: id:1028
+msgid "Edit %s source"
+msgstr "Editar %s fonte"
+
+#: id:1029
+msgid "Enter the new label"
+msgstr "Introduza a nova etiqueta"
+
+#: id:1030
+msgid "Browse for image"
+msgstr "Procurar imagem"
+
+#: id:1031
+msgid "Browse for image folder"
+msgstr "Procurar pasta de imagens"
+
+#: id:1032
+msgid "Add network location..."
+msgstr "Adicionar localização de rede..."
+
+#: id:1033
+msgid "Browse for file"
+msgstr "Procurar ficheiro"
+
+#: id:1034
+msgid "Submenu"
+msgstr "Submenu"
+
+#: id:1035
+msgid "Enable submenu buttons"
+msgstr "Activar botões de submenu"
+
+#: id:1036
+msgid "Favourites"
+msgstr "Favoritos"
+
+#: id:1037
+msgid "Video Add-ons"
+msgstr "Add-ons de Vídeo"
+
+#: id:1038
+msgid "Music Add-ons"
+msgstr "Add-ons de Música"
+
+#: id:1039
+msgid "Picture Add-ons"
+msgstr "Add-ons de Imagem"
+
+#: id:1040
+msgid "Loading directory"
+msgstr "A carregar pasta"
+
+#: id:1041
+msgid "Retrieved %i items"
+msgstr "A recolher %i itens"
+
+#: id:1042
+msgid "Retrieved %i of %i items"
+msgstr "Recolhidos %i itens de %i"
+
+#: id:1043
+msgid "Program Add-ons"
+msgstr "Add-ons de Programas"
+
+#: id:1044
+msgid "Set plugin thumb"
+msgstr "Definir miniatura para plugin"
+
+#: id:1045
+msgid "Add-on settings"
+msgstr "Definições do add-on"
+
+#: id:1046
+msgid "Access points"
+msgstr "Pontos de acesso"
+
+#: id:1047
+msgid "Other..."
+msgstr "Outro..."
+
+#: id:1048
+msgid "- Username"
+msgstr "- Utilizador"
+
+#: id:1049
+msgid "Script settings"
+msgstr "Definições do script"
+
+#: id:1050
+msgid "Singles"
+msgstr "Faixas"
+
+#: id:1051
+msgid "Enter web address"
+msgstr "Introduza endereço de Internet"
+
+#: id:1200
+msgid "SMB client"
+msgstr "Cliente SMB"
+
+#: id:1202
+msgid "Workgroup"
+msgstr "Grupo de trabalho"
+
+#: id:1203
+msgid "Default username"
+msgstr "Utilizador por omissão"
+
+#: id:1204
+msgid "Default password"
+msgstr "Palavra-passe por omissão"
+
+#: id:1207
+msgid "WINS server"
+msgstr "Servidor WINS"
+
+#: id:1208
+msgid "Mount SMB shares"
+msgstr "Montar partilhas de SMB"
+
+#: id:1210
+msgctxt "Auto context with id 1210"
+msgid "Remove"
+msgstr "Remover"
+
+#: id:1211
+msgctxt "Auto context with id 1211"
+msgid "Music"
+msgstr "Música"
+
+#: id:1212
+msgctxt "Auto context with id 1212"
+msgid "Video"
+msgstr "Vídeo"
+
+#: id:1213
+msgctxt "Auto context with id 1213"
+msgid "Pictures"
+msgstr "Imagens"
+
+#: id:1214
+msgctxt "Auto context with id 1214"
+msgid "Files"
+msgstr "Ficheiros"
+
+#: id:1215
+msgctxt "Auto context with id 1215"
+msgid "Music & video"
+msgstr "Música & Vídeo"
+
+#: id:1216
+msgid "Music & pictures"
+msgstr "Música & Imagens"
+
+#: id:1217
+msgid "Music & files"
+msgstr "Música & Ficheiros"
+
+#: id:1218
+msgid "Video & pictures"
+msgstr "Vídeo & Imagens"
+
+#: id:1219
+msgid "Video & files"
+msgstr "Vídeo & Ficheiros"
+
+#: id:1220
+msgid "Pictures & files"
+msgstr "Imagens & Ficheiros"
+
+#: id:1221
+msgid "Music & video & pictures"
+msgstr "Música, Vídeo & Imagens"
+
+#: id:1222
+msgid "Music & video & pictures & files"
+msgstr "Música, Vídeo, Imagens & Ficheiros"
+
+#: id:1223
+msgctxt "Auto context with id 1223"
+msgid "Disabled"
+msgstr "Desligado"
+
+#: id:1226
+msgid "Files & music & video"
+msgstr "Ficheiros, Música & Vídeo"
+
+#: id:1227
+msgid "Files & pictures & music"
+msgstr "Ficheiros, Imagens & Música"
+
+#: id:1228
+msgid "Files & pictures & video"
+msgstr "Ficheiros, Imagens & Vídeo"
+
+#: id:1229
+msgid "Music & programs"
+msgstr "Musica & Programas"
+
+#: id:1230
+msgid "Video & programs"
+msgstr "Vídeo & Programas"
+
+#: id:1231
+msgid "Pictures & programs"
+msgstr "Imagens & Programas"
+
+#: id:1232
+msgid "Music & video & pictures & programs"
+msgstr "Música, Vídeo, Imagens & Programas"
+
+#: id:1233
+msgid "Programs & video & music"
+msgstr "Programas, Vídeo & Música"
+
+#: id:1234
+msgid "Programs & pictures & music"
+msgstr "Programas, Imagens & Música"
+
+#: id:1235
+msgid "Programs & pictures & video"
+msgstr "Programas, Imagens & Vídeo"
+
+#: id:1250
+msgid "Auto-detection"
+msgstr "Detecção automática"
+
+#: id:1251
+msgid "Auto-detect system"
+msgstr "Detecção automática de sistema"
+
+#: id:1252
+msgid "Nickname"
+msgstr "Alcunha"
+
+#: id:1254
+msgid "Ask to connect"
+msgstr "Perguntar para ligar"
+
+#: id:1255
+msgid "Send FTP user and password"
+msgstr "Enviar utilizador e palavra-passe de FTP"
+
+#: id:1256
+msgid "Ping interval"
+msgstr "Intervalo de PING"
+
+#: id:1257
+msgid "Would you like to connect to the auto-detected system?"
+msgstr "Deseja ligar a detecção automática de sistema?"
+
+#: id:1259
+msgid "Zeroconf"
+msgstr ""
+
+#: id:1260
+msgid "Announce these services to other systems via Zeroconf"
+msgstr "Anunciar estes serviços a outros sistemas via Zeroconf"
+
+#: id:1270
+msgid "Allow XBMC to receive AirPlay content"
+msgstr ""
+
+#: id:1271
+msgid "Device name"
+msgstr ""
+
+#: id:1272
+msgid "- Use password protection"
+msgstr ""
+
+#: id:1273
+msgid "AirPlay"
+msgstr ""
+
+#: id:1300
+msgid "Custom audio device"
+msgstr "Dispositivo áudio personalizado"
+
+#: id:1301
+msgid "Custom passthrough device"
+msgstr "Dispositivo de passagem personalizado"
+
+#: id:1396
+msgid "Drifting"
+msgstr "Derrapando"
+
+#: id:1397
+msgid "and"
+msgstr "e"
+
+#: id:1398
+msgid "Freezing"
+msgstr "Congelando"
+
+#: id:1399
+msgid "Late"
+msgstr "no fim do dia"
+
+#: id:1400
+msgid "Isolated"
+msgstr "Isolado"
+
+#: id:1401
+msgid "Thundershowers"
+msgstr "Chuvadas"
+
+#: id:1402
+msgid "Thunder"
+msgstr "Trovões"
+
+#: id:1403
+msgctxt "Auto context with id 1403"
+msgid "Sun"
+msgstr "Sol"
+
+#: id:1404
+msgid "Heavy"
+msgstr "Pesado"
+
+#: id:1405
+msgid "in"
+msgstr "em"
+
+#: id:1406
+msgid "the"
+msgstr "o (a)"
+
+#: id:1407
+msgid "Vicinity"
+msgstr "Vizinhança"
+
+#: id:1408
+msgid "Ice"
+msgstr "Gelo"
+
+#: id:1409
+msgid "Crystals"
+msgstr "Cristais"
+
+#: id:1410
+msgid "Calm"
+msgstr "Calmo"
+
+#: id:1411
+msgid "with"
+msgstr "com"
+
+#: id:1412
+msgid "windy"
+msgstr "Ventoso"
+
+#: id:1413
+msgid "drizzle"
+msgstr "Chuvoso"
+
+#: id:1414
+msgid "Thunderstorm"
+msgstr "Tempestade"
+
+#: id:1415
+msgid "Drizzle"
+msgstr "Aguaceiro"
+
+#: id:1416
+msgid "Foggy"
+msgstr "Nevoeiro"
+
+#: id:1417
+msgid "Grains"
+msgstr "Grãos"
+
+#: id:1418
+msgid "T-Storms"
+msgstr "Trovoadas"
+
+#: id:1419
+msgid "T-Showers"
+msgstr "Chuvadas"
+
+#: id:1420
+msgid "Moderate"
+msgstr "Moderado"
+
+#: id:1421
+msgid "Very High"
+msgstr "Muito alto"
+
+#: id:1422
+msgid "Windy"
+msgstr "Ventoso"
+
+#: id:1423
+msgid "Mist"
+msgstr "Neblina"
+
+#: id:1450
+msgid "Put display to sleep when idle"
+msgstr "Desligar ecrã quando em repouso"
+
+#: id:2050
+msgid "Runtime"
+msgstr "Duração"
+
+#: id:2100
+msgid "Script failed! : %s"
+msgstr "Script falhou!: %s"
+
+#: id:2101
+msgid "Newer version needed - See log"
+msgstr "Versão nova necessária - Ver log"
+
+#: id:4501
+msgid "Enable LCD/VFD"
+msgstr "Ligar LCD/VFD"
+
+#: id:10000
+msgid "Home"
+msgstr "Início"
+
+#: id:10001
+msgctxt "Auto context with id 10001"
+msgid "Programs"
+msgstr "Programas"
+
+#: id:10002
+msgctxt "Auto context with id 10002"
+msgid "Pictures"
+msgstr "Imagens"
+
+#: id:10003
+msgctxt "Auto context with id 10003"
+msgid "File manager"
+msgstr "Ficheiros"
+
+#: id:10004
+msgctxt "Auto context with id 10004"
+msgid "Settings"
+msgstr "Configurações"
+
+#: id:10005
+msgctxt "Auto context with id 10005"
+msgid "Music"
+msgstr "Música"
+
+#: id:10006
+msgctxt "Auto context with id 10006"
+msgid "Videos"
+msgstr "Filmes"
+
+#: id:10007
+msgid "System information"
+msgstr "Informação do sistema"
+
+#: id:10008
+msgid "Settings - General"
+msgstr "Configurar -> Geral"
+
+#: id:10009
+msgid "Settings - Screen"
+msgstr "Configurar -> Ecrã"
+
+#: id:10010
+msgid "Settings - Appearance - GUI Calibration"
+msgstr "Configurar -> Aspecto-> Calibrar UI"
+
+#: id:10011
+msgid "Settings - Videos - Screen Calibration"
+msgstr "Configurar -> Filmes-> Calibrar ecrã"
+
+#: id:10012
+msgid "Settings - Pictures"
+msgstr "Configurar -> Fotos"
+
+#: id:10013
+msgid "Settings - Programs"
+msgstr "Configurar -> Programas"
+
+#: id:10014
+msgid "Settings - Weather"
+msgstr "Configurar -> Tempo"
+
+#: id:10015
+msgid "Settings - Music"
+msgstr "Configurar -> Música"
+
+#: id:10016
+msgid "Settings - System"
+msgstr "Configurar -> Sistema"
+
+#: id:10017
+msgid "Settings - Videos"
+msgstr "Configurar -> Filmes"
+
+#: id:10018
+msgid "Settings - Network"
+msgstr "Configurar -> Rede"
+
+#: id:10019
+msgid "Settings - Appearance"
+msgstr "Configurar -> Aspecto"
+
+#: id:10020
+msgctxt "Auto context with id 10020"
+msgid "Scripts"
+msgstr "Scripts"
+
+#: id:10021
+msgid "Web Browser"
+msgstr "Navegador de Internet"
+
+#: id:10025
+msgctxt "Auto context with id 10025"
+msgid "Videos"
+msgstr ""
+
+#: id:10028
+msgid "Videos/Playlist"
+msgstr "Vídeos/Lista de reprodução"
+
+#: id:10029
+msgctxt "Auto context with id 10029"
+msgid "Login screen"
+msgstr ""
+
+#: id:10034
+msgid "Settings - Profiles"
+msgstr "Configurações -> Perfis"
+
+#: id:10040
+msgid "Addon browser"
+msgstr ""
+
+#: id:10100
+msgid "Yes/No dialog"
+msgstr "Sim/Não diálogo"
+
+#: id:10101
+msgid "Progress dialog"
+msgstr "Progresso diálogo"
+
+#: id:10210
+msgid "Looking for subtitles..."
+msgstr "À procura de legendas..."
+
+#: id:10211
+msgid "Looking for or caching subtitles..."
+msgstr "A procurar ou colocar legendas em cache..."
+
+#: id:10212
+msgid "terminating"
+msgstr "A terminar"
+
+#: id:10213
+msgid "buffering"
+msgstr "A criar buffer"
+
+#: id:10214
+msgid "Opening stream"
+msgstr "A abrir pista"
+
+#: id:10500
+msgid "Music/Playlist"
+msgstr "Música/Lista de reprodução"
+
+#: id:10501
+msgid "Music/Files"
+msgstr "Música/Ficheiros"
+
+#: id:10502
+msgid "Music/Library"
+msgstr "Música/Biblioteca"
+
+#: id:10503
+msgid "Playlist editor"
+msgstr "Editor de lista de reprodução"
+
+#: id:10504
+msgid "Top 100 songs"
+msgstr "As 100 melhores músicas"
+
+#: id:10505
+msgid "Top 100 albums"
+msgstr "Os 100 melhores álbuns"
+
+#: id:10506
+msgctxt "Auto context with id 10506"
+msgid "Programs"
+msgstr "Programas"
+
+#: id:10507
+msgid "Configuration"
+msgstr "Configuração"
+
+#: id:10508
+msgid "Weather forecast"
+msgstr "Previsão do Tempo"
+
+#: id:10509
+msgid "Network gaming"
+msgstr "Jogos em Rede"
+
+#: id:10510
+msgid "Extensions"
+msgstr "Extensões"
+
+#: id:10511
+msgctxt "Auto context with id 10511"
+msgid "System info"
+msgstr "Informação de sistema"
+
+#: id:10516
+msgid "Music - Library"
+msgstr "Música - Biblioteca"
+
+#: id:10517
+msgid "Now Playing - Music"
+msgstr "A Reproduzir - Música"
+
+#: id:10522
+msgid "Now Playing - Videos"
+msgstr "A Reproduzir - Vídeo"
+
+#: id:10523
+msgid "Album info"
+msgstr "Informação do álbum"
+
+#: id:10524
+msgid "Movie info"
+msgstr "Informação do vídeo"
+
+#: id:12000
+msgid "Select dialog"
+msgstr "Seleccione diálogo"
+
+#: id:12001
+msgid "Music/Info"
+msgstr "Música/Informação"
+
+#: id:12002
+msgid "Dialog OK"
+msgstr "Diálogo OK"
+
+#: id:12003
+msgid "Videos/Info"
+msgstr "Vídeos/Informação"
+
+#: id:12004
+msgid "Scripts/Info"
+msgstr "Scripts/Informação"
+
+#: id:12005
+msgid "Fullscreen video"
+msgstr "Vídeo em ecrã completo"
+
+#: id:12006
+msgid "Audio visualization"
+msgstr "Visualização áudio"
+
+#: id:12008
+msgid "File stacking dialog"
+msgstr "Diálogo da fila de ficheiros"
+
+#: id:12009
+msgid "Rebuild index..."
+msgstr "Reconstruindo o índice ..."
+
+#: id:12010
+msgid "Return to music window"
+msgstr "Voltar à janela da música"
+
+#: id:12011
+msgid "Return to videos window"
+msgstr "Voltar à janela de vídeos"
+
+#: id:12021
+msgid "Start from beginning"
+msgstr "Começar do início"
+
+#: id:12022
+msgid "Resume from %s"
+msgstr "Continuar da %s"
+
+#: id:12310
+msgid "0"
+msgstr "0"
+
+#: id:12311
+msgid "1"
+msgstr "1"
+
+#: id:12312
+msgid "2"
+msgstr "2"
+
+#: id:12313
+msgid "3"
+msgstr "3"
+
+#: id:12314
+msgid "4"
+msgstr "4"
+
+#: id:12315
+msgid "5"
+msgstr "5"
+
+#: id:12316
+msgid "6"
+msgstr "6"
+
+#: id:12317
+msgid "7"
+msgstr "7"
+
+#: id:12318
+msgid "8"
+msgstr "8"
+
+#: id:12319
+msgid "9"
+msgstr "9"
+
+#: id:12320
+msgid "c"
+msgstr "c"
+
+#: id:12321
+msgid "Ok"
+msgstr "OK"
+
+#: id:12322
+msgid "*"
+msgstr "*"
+
+#: id:12325
+msgid "Locked! Enter code..."
+msgstr "Bloqueado! Introduza código ..."
+
+#: id:12326
+msgid "Enter password"
+msgstr "Introduza palavra-passe"
+
+#: id:12327
+msgid "Enter master code"
+msgstr "Introduza código mestre"
+
+#: id:12328
+msgid "Enter unlock code"
+msgstr "Introduza código de desbloqueio"
+
+#: id:12329
+msgid "or press C to cancel"
+msgstr "ou pressione C para cancelar"
+
+#: id:12330
+msgid "Enter gamepad button combo and"
+msgstr "Introduza combinação de botões do comando de jogos e"
+
+#: id:12331
+msgid "press OK, or Back to cancel"
+msgstr "pressione Start. Se quiser cancelar pressione Back"
+
+#: id:12332
+msgid "Set lock"
+msgstr "Definir bloqueio"
+
+#: id:12333
+msgid "Unlock"
+msgstr "Desbloquear"
+
+#: id:12334
+msgid "Reset lock"
+msgstr "Predefinição de bloqueio"
+
+#: id:12335
+msgid "Remove lock"
+msgstr "Remover bloqueio"
+
+#: id:12337
+msgid "Numeric password"
+msgstr "Palavra-passe numérica"
+
+#: id:12338
+msgid "Gamepad button combo"
+msgstr "Combinação de botões do comando de jogos"
+
+#: id:12339
+msgid "Full-text password"
+msgstr "Palavra-passe de texto"
+
+#: id:12340
+msgid "Enter new password"
+msgstr "Introduza nova palavra-passe"
+
+#: id:12341
+msgid "Re-Enter new password"
+msgstr "Reintroduza a palavra-passe"
+
+#: id:12342
+msgid "Incorrect password,"
+msgstr "Palavra-passe incorrecta,"
+
+#: id:12343
+msgid "retries left"
+msgstr "tentativas restantes"
+
+#: id:12344
+msgid "Passwords entered did not match."
+msgstr "As palavras-passe introduzidas não coincidem."
+
+#: id:12345
+msgid "Access denied"
+msgstr "Acesso negado"
+
+#: id:12346
+msgid "Password retry limit exceeded."
+msgstr "Limite de tentativas da palavra-passe atingido."
+
+#: id:12347
+msgid "The system will now shut off."
+msgstr "O sistema vai desligar."
+
+#: id:12348
+msgid "Item locked"
+msgstr "Item bloqueado"
+
+#: id:12353
+msgid "Reactivate lock"
+msgstr "Reactivar bloqueio"
+
+#: id:12356
+msgid "Change lock"
+msgstr "Alterar bloqueio"
+
+#: id:12357
+msgid "Source lock"
+msgstr "Bloqueio de partilha"
+
+#: id:12358
+msgid "Password entry was blank. Try again."
+msgstr "Entrada da palavra-passe vazia. Volte a tentar."
+
+#: id:12360
+msgid "Master lock"
+msgstr "Bloqueio mestre"
+
+#: id:12362
+msgid "Shutdown system if Master Lock retries exceeded"
+msgstr "Desligar sistema se as tentativas de bloqueio mestre ultrapassarem"
+
+#: id:12367
+msgid "Master code is not valid"
+msgstr "Código mestre inválido"
+
+#: id:12368
+msgid "Please enter a valid master code"
+msgstr "Por favor introduza um código mestre válido!"
+
+#: id:12373
+msgid "Settings & file manager"
+msgstr "Configurações & Gestão de ficheiros"
+
+#: id:12376
+msgid "Set as default for all movies"
+msgstr "Definir como padrão para todos os filmes"
+
+#: id:12377
+msgid "This will reset any previously saved values"
+msgstr "Isto apagará os valores previamente guardados"
+
+#: id:12378
+msgid "Amount of time to display each image"
+msgstr "Tempo para mostrar cada imagem"
+
+#: id:12379
+msgid "Use pan and zoom effects"
+msgstr "Utilizar efeitos de deslocamento e ampliação"
+
+#: id:12383
+msgid "12 hour clock"
+msgstr "Relógio de 12 horas"
+
+#: id:12384
+msgid "24 hour clock"
+msgstr "Relógio de 24 horas"
+
+#: id:12385
+msgid "Day/Month"
+msgstr "Dia/Mês"
+
+#: id:12386
+msgid "Month/Day"
+msgstr "Mês/Dia"
+
+#: id:12390
+msgid "System uptime"
+msgstr "Tempo de ligação do sistema"
+
+#: id:12391
+msgid "Minutes"
+msgstr "Minutos"
+
+#: id:12392
+msgid "Hours"
+msgstr "Horas"
+
+#: id:12393
+msgid "Days"
+msgstr "Dias"
+
+#: id:12394
+msgid "Total uptime"
+msgstr "Tempo total de sistema ligado"
+
+#: id:12395
+msgid "Battery level"
+msgstr ""
+
+#: id:12600
+msgctxt "Auto context with id 12600"
+msgid "Weather"
+msgstr "Tempo"
+
+#: id:12900
+msgctxt "Auto context with id 12900"
+msgid "Screensaver"
+msgstr "Protecção de ecrã"
+
+#: id:12901
+msgid "Fullscreen OSD"
+msgstr "OSD em ecrã inteiro"
+
+#: id:13000
+msgid "System"
+msgstr "Sistema"
+
+#: id:13001
+msgid "Immediate HD spindown"
+msgstr "Desligar imediatamente o disco rígido"
+
+#: id:13002
+msgid "Video only"
+msgstr "Vídeo apenas"
+
+#: id:13003
+msgid "- Delay"
+msgstr "- Atraso"
+
+#: id:13004
+msgid "- Minimum file duration"
+msgstr "- Duração mínima do ficheiro"
+
+#: id:13005
+msgid "Shutdown"
+msgstr "Desligar"
+
+#: id:13008
+msgid "Shutdown function"
+msgstr "Modo de desligar"
+
+#: id:13009
+msgid "Quit"
+msgstr "Sair"
+
+#: id:13010
+msgid "Hibernate"
+msgstr "Hibernar"
+
+#: id:13011
+msgid "Suspend"
+msgstr "Suspender"
+
+#: id:13012
+msgid "Exit"
+msgstr "Sair"
+
+#: id:13013
+msgid "Reboot"
+msgstr "Reiniciar"
+
+#: id:13014
+msgid "Minimize"
+msgstr "Minimizar"
+
+#: id:13015
+msgid "Power button action"
+msgstr "Acção do botão desligar"
+
+#: id:13016
+msgid "Power off System"
+msgstr "Desligar sistema"
+
+#: id:13020
+msgid "Is another session active, perhaps over ssh?"
+msgstr "Estará outra sessão activa, talvez em ssh?"
+
+#: id:13021
+msgid "Mounted removable harddrive"
+msgstr "Disco rígido amovível montado"
+
+#: id:13022
+msgid "Unsafe device removal"
+msgstr "Remoção insegura de dispositivo"
+
+#: id:13023
+msgid "Successfully removed device"
+msgstr "Dispositivo removido com sucesso"
+
+#: id:13024
+msgid "Joystick plugged"
+msgstr "Joystick ligado"
+
+#: id:13025
+msgid "Joystick unplugged"
+msgstr "Joystick desligado"
+
+#: id:13050
+msgid "Running low on battery"
+msgstr "Bateria a acabar"
+
+#: id:13100
+msgid "Flicker filter"
+msgstr "Filtro 'Flicker'"
+
+#: id:13101
+msgid "Let driver choose (requires restart)"
+msgstr "Deixar o dispositivo escolher (requer reiniciar)"
+
+#: id:13105
+msgid "Vertical blank sync"
+msgstr "Sincronização vertical em branco"
+
+#: id:13106
+msgctxt "Auto context with id 13106"
+msgid "Disabled"
+msgstr "Desligado"
+
+#: id:13107
+msgid "Enabled during video playback"
+msgstr "Ligado durante a reprodução de vídeo"
+
+#: id:13108
+msgctxt "Auto context with id 13108"
+msgid "Always enabled"
+msgstr "Sempre ligado"
+
+#: id:13109
+msgid "Test & apply resolution"
+msgstr "Testar & Aplicar resolução"
+
+#: id:13110
+msgid "Save resolution?"
+msgstr "Salvar resolução?"
+
+#: id:13111
+msgid "Would you like to keep this resolution?"
+msgstr "Quer manter esta resolução?"
+
+#: id:13112
+msgid "High quality upscaling"
+msgstr "Escalonamento de alta qualidade"
+
+#: id:13113
+msgctxt "Auto context with id 13113"
+msgid "Disabled"
+msgstr "Desligado"
+
+#: id:13114
+msgid "Enabled for SD content"
+msgstr "Ligado para conteúdos SD"
+
+#: id:13115
+msgctxt "Auto context with id 13115"
+msgid "Always enabled"
+msgstr "Sempre ligado"
+
+#: id:13116
+msgid "Upscaling method"
+msgstr "Método de escalonamento"
+
+#: id:13117
+msgctxt "Auto context with id 13117"
+msgid "Bicubic"
+msgstr "Bicubic"
+
+#: id:13118
+msgid "Lanczos"
+msgstr "Lanczos"
+
+#: id:13119
+msgid "Sinc"
+msgstr "Sinc"
+
+#: id:13120
+msgctxt "Auto context with id 13120"
+msgid "VDPAU"
+msgstr "VDPAU"
+
+#: id:13121
+msgid "VDPAU HQ Upscaling level"
+msgstr "Nível de escalonamento do VDPAU HQ"
+
+#: id:13122
+msgid "VDPAU Studio level color conversion"
+msgstr "Nível de conversão de cor do VDPAU Studio"
+
+#: id:13130
+msgid "Blank other displays"
+msgstr "Desligar outros ecrãs"
+
+#: id:13131
+msgctxt "Auto context with id 13131"
+msgid "Disabled"
+msgstr "Desligado"
+
+#: id:13132
+msgid "Blank displays"
+msgstr "Ecrãs brancos"
+
+#: id:13140
+msgid "Active connections detected!"
+msgstr "Ligações activas detectadas!"
+
+#: id:13141
+msgid "If you proceed, you might not be able to control XBMC"
+msgstr "Se continuar, pode não conseguir continuar a controlar o"
+
+#: id:13142
+msgid "any longer. Are you sure you want to stop the Event server?"
+msgstr "XBMC. Tem a certeza que quer parar o servidor de eventos?"
+
+#: id:13144
+msgid "Change Apple Remote mode?"
+msgstr "Mudar modo do comando Apple?"
+
+#: id:13145
+msgid "If you are currently using the Apple Remote to control"
+msgstr "Se neste momento está a usar o comando remoto da Apple"
+
+#: id:13146
+msgid "XBMC, changing this setting might affect your ability"
+msgstr "para controlar o XBMC, mudar esta configuração pode impedir"
+
+#: id:13147
+msgid "to continue controlling it. Do you want to proceed?"
+msgstr "o seu uso daqui para a frente. Quer continuar?"
+
+#: id:13159
+msgid "Subnet mask"
+msgstr "Máscara de subrede"
+
+#: id:13160
+msgid "Gateway"
+msgstr "Gateway"
+
+#: id:13161
+msgid "Primary DNS"
+msgstr "DNS primário"
+
+#: id:13162
+msgid "Initialize failed"
+msgstr "Inicialização falhou"
+
+#: id:13170
+msgctxt "Auto context with id 13170"
+msgid "Never"
+msgstr "Nunca"
+
+#: id:13171
+msgid "Immediately"
+msgstr "Imediatamente"
+
+#: id:13172
+msgid "After %i secs"
+msgstr "Após %i segundos"
+
+#: id:13173
+msgid "HDD install date:"
+msgstr "Data de instalação HDD:"
+
+#: id:13174
+msgid "HDD power cycle count:"
+msgstr "Contagem do ciclos do HDD:"
+
+#: id:13200
+msgid "Profiles"
+msgstr "Perfis"
+
+#: id:13201
+msgid "Delete profile '%s'?"
+msgstr "Apagar perfil '%s'?"
+
+#: id:13204
+msgid "Last loaded profile:"
+msgstr "Último perfil carregado:"
+
+#: id:13205
+msgid "Unknown"
+msgstr "Desconhecido"
+
+#: id:13206
+msgid "Overwrite"
+msgstr "Escrever por cima"
+
+#: id:13208
+msgid "Alarm clock"
+msgstr "Alarme"
+
+#: id:13209
+msgid "Alarm clock interval (in minutes)"
+msgstr "Intervalo de alarme (em minutos)"
+
+#: id:13210
+msgid "Started, alarm in %im"
+msgstr "Iniciar alarme em %m"
+
+#: id:13211
+msgid "Alarm!"
+msgstr "Alarme!"
+
+#: id:13212
+msgid "Canceled with %im%is left"
+msgstr "Cancelar quando faltar %m%is"
+
+#: id:13213
+msgid "%2.0fm"
+msgstr "%2.0fm"
+
+#: id:13214
+msgid "%2.0fs"
+msgstr "%2.0fs"
+
+#: id:13249
+msgid "Search for subtitles in RARs"
+msgstr "Procurar legendas em RARs"
+
+#: id:13250
+msgid "Browse for subtitle..."
+msgstr "Procurar legenda ..."
+
+#: id:13251
+msgid "Move item"
+msgstr "Mover item"
+
+#: id:13252
+msgid "Move item here"
+msgstr "Mover item para aqui"
+
+#: id:13253
+msgid "Cancel move"
+msgstr "Cancelar mover"
+
+#: id:13270
+msgid "Hardware:"
+msgstr "Hardware:"
+
+#: id:13271
+msgid "CPU Usage:"
+msgstr "Utilização de CPU:"
+
+#: id:13274
+msgid "Connected, but no DNS is available."
+msgstr "Ligado, mas DNS indisponível."
+
+#: id:13275
+msgid "Hard Disk"
+msgstr "Disco rígido:"
+
+#: id:13276
+msgid "DVD-ROM"
+msgstr "DVD-ROM"
+
+#: id:13277
+msgctxt "Auto context with id 13277"
+msgid "Storage"
+msgstr "Espaço de armazenamento"
+
+#: id:13278
+msgctxt "Auto context with id 13278"
+msgid "Default"
+msgstr "Por defeito"
+
+#: id:13279
+msgctxt "Auto context with id 13279"
+msgid "Network"
+msgstr "Rede"
+
+#: id:13280
+msgctxt "Auto context with id 13280"
+msgid "Video"
+msgstr "Vídeo"
+
+#: id:13281
+msgid "Hardware"
+msgstr "Hardware"
+
+#: id:13283
+msgid "Operating system:"
+msgstr "Sistema operativo:"
+
+#: id:13284
+msgid "CPU speed:"
+msgstr "Velocidade do CPU:"
+
+#: id:13286
+msgid "Video encoder:"
+msgstr "Codificador de vídeo:"
+
+#: id:13287
+msgid "Screen resolution:"
+msgstr "Resolução de ecrã:"
+
+#: id:13292
+msgid "A/V cable:"
+msgstr "Cabo A/V:"
+
+#: id:13294
+msgid "DVD region:"
+msgstr "Região DVD:"
+
+#: id:13295
+msgid "Internet:"
+msgstr "Internet:"
+
+#: id:13296
+msgctxt "Auto context with id 13296"
+msgid "Connected"
+msgstr "Ligado"
+
+#: id:13297
+msgid "Not connected. Check network settings."
+msgstr "Desligado. Verifique a configuração de rede."
+
+#: id:13299
+msgid "Target temperature"
+msgstr "Temperatura definida:"
+
+#: id:13300
+msgid "Fan speed"
+msgstr "Velocidade da ventoinha:"
+
+#: id:13301
+msgid "Auto temperature control"
+msgstr "Controlo da temperatura auto"
+
+#: id:13302
+msgid "Fan speed override"
+msgstr "Controlo da velocidade da ventoinha"
+
+#: id:13303
+msgid "- Fonts"
+msgstr "- Fontes"
+
+#: id:13304
+msgid "Enable flipping bi-directional strings"
+msgstr "Activar a troca de strings bidireccionais"
+
+#: id:13305
+msgid "Show RSS news feeds"
+msgstr "Mostrar notícias (Feeds RSS)"
+
+#: id:13306
+msgid "Show parent folder items"
+msgstr "Mostrar itens da pasta mãe"
+
+#: id:13307
+msgid "Track naming template"
+msgstr "Modelo para nome da faixa"
+
+#: id:13308
+msgid "Do you wish to reboot your system"
+msgstr "Quer reiniciar o sistema em vez"
+
+#: id:13309
+msgid "instead of just XBMC?"
+msgstr "de apenas o XBMC?"
+
+#: id:13310
+msgid "Zoom effect"
+msgstr "Efeito de ampliação"
+
+#: id:13311
+msgid "Float effect"
+msgstr "Efeito flutuante"
+
+#: id:13312
+msgid "Black bar reduction"
+msgstr "Redução de barras pretas"
+
+#: id:13313
+msgid "Restart"
+msgstr "Reiniciar"
+
+#: id:13314
+msgid "Crossfade between songs"
+msgstr "Sobreposição entre músicas"
+
+#: id:13315
+msgid "Regenerate thumbnails"
+msgstr "Regenerar miniaturas"
+
+#: id:13316
+msgid "Recursive thumbnails"
+msgstr "Miniaturas recursivas"
+
+#: id:13317
+msgid "View slideshow"
+msgstr "Ver apresentação"
+
+#: id:13318
+msgid "Recursive slideshow"
+msgstr "Apresentação recursiva"
+
+#: id:13319
+msgid "Randomize"
+msgstr "Aleatório"
+
+#: id:13320
+msgid "Stereo"
+msgstr "Estéreo"
+
+#: id:13321
+msgid "Left only"
+msgstr "Só esquerda"
+
+#: id:13322
+msgid "Right only"
+msgstr "Só direita"
+
+#: id:13323
+msgid "Enable karaoke support"
+msgstr "Ligar suporte de karaoke"
+
+#: id:13324
+msgid "Background transparency"
+msgstr "Transparência do fundo"
+
+#: id:13325
+msgid "Foreground transparency"
+msgstr "Transparência da janela activa"
+
+#: id:13326
+msgid "A/V delay"
+msgstr "Atraso A/V"
+
+#: id:13327
+msgid "Karaoke"
+msgstr "Karaoke"
+
+#: id:13328
+msgid "%s not found"
+msgstr "%s não encontrado"
+
+#: id:13329
+msgid "Error opening %s"
+msgstr "Erro ao abrir %s"
+
+#: id:13330
+msgid "Unable to load %s"
+msgstr "Incapaz de carregar %s"
+
+#: id:13331
+msgid "Error: Out of memory"
+msgstr "Erro: Sem memória"
+
+#: id:13332
+msgid "Move up"
+msgstr "Mover para cima"
+
+#: id:13333
+msgid "Move down"
+msgstr "Mover para baixo"
+
+#: id:13334
+msgid "Edit label"
+msgstr "Editar etiqueta"
+
+#: id:13335
+msgid "Make default"
+msgstr "Guardar como padrão"
+
+#: id:13336
+msgid "Remove button"
+msgstr "Remover botão"
+
+#: id:13340
+msgid "Leave as is"
+msgstr "Deixar como está"
+
+#: id:13341
+msgid "Green"
+msgstr "Verde"
+
+#: id:13342
+msgid "Orange"
+msgstr "Laranja"
+
+#: id:13343
+msgid "Red"
+msgstr "Vermelho"
+
+#: id:13344
+msgid "Cycle"
+msgstr "Ciclo"
+
+#: id:13345
+msgid "Switch LED off on playback"
+msgstr "Desligar o LED durante a reprodução"
+
+#: id:13346
+msgctxt "Auto context with id 13346"
+msgid "Movie information"
+msgstr "Informação do vídeo"
+
+#: id:13347
+msgid "Queue item"
+msgstr "Colocar item em fila"
+
+#: id:13348
+msgid "Search IMDb..."
+msgstr "Procurar IMDb..."
+
+#: id:13349
+msgid "Scan for new content"
+msgstr "Procurar novo conteúdo"
+
+#: id:13350
+msgid "Now playing..."
+msgstr "A reproduzir neste momento..."
+
+#: id:13351
+msgctxt "Auto context with id 13351"
+msgid "Album information"
+msgstr "Informação do álbum"
+
+#: id:13352
+msgid "Scan item to library"
+msgstr "Inserir item na Biblioteca"
+
+#: id:13353
+msgid "Stop scanning"
+msgstr "Parar de procurar"
+
+#: id:13354
+msgctxt "Auto context with id 13354"
+msgid "Render method"
+msgstr "Método de renderização"
+
+#: id:13355
+msgid "Low quality pixel shader"
+msgstr "Pixel Shader de baixa qualidade"
+
+#: id:13356
+msgid "Hardware overlays"
+msgstr "Sobreposições por hardware"
+
+#: id:13357
+msgid "High quality pixel shader"
+msgstr "Pixel Shader de alta qualidade"
+
+#: id:13358
+msgid "Play item"
+msgstr "Reproduzir item"
+
+#: id:13359
+msgid "Set artist thumb"
+msgstr "Definir miniatura do artista"
+
+#: id:13360
+msgid "Automatically generate thumbnails"
+msgstr "Regenerando miniaturas automaticamente"
+
+#: id:13361
+msgid "Enable voice"
+msgstr "Activar voz"
+
+#: id:13375
+msgid "Enable device"
+msgstr "Activar dispositivo"
+
+#: id:13376
+msgid "Volume"
+msgstr "Volume"
+
+#: id:13377
+msgid "Default view mode"
+msgstr "Modo de visualização por defeito"
+
+#: id:13378
+msgid "Default brightness"
+msgstr "Brilho por defeito"
+
+#: id:13379
+msgid "Default contrast"
+msgstr "Contraste por defeito"
+
+#: id:13380
+msgid "Default gamma"
+msgstr "Gamma por defeito"
+
+#: id:13381
+msgid "Resume video"
+msgstr "Resumir Vídeo"
+
+#: id:13382
+msgid "Voice mask - Port 1"
+msgstr "Máscara de Voz - Porta 1"
+
+#: id:13383
+msgid "Voice mask - Port 2"
+msgstr "Máscara de Voz - Porta 2"
+
+#: id:13384
+msgid "Voice mask - Port 3"
+msgstr "Máscara de Voz - Porta 3"
+
+#: id:13385
+msgid "Voice mask - Port 4"
+msgstr "Máscara de Voz - Porta 4"
+
+#: id:13386
+msgid "Use time based seeking"
+msgstr "Utilizar procura baseada no tempo"
+
+#: id:13387
+msgid "Track naming template - right"
+msgstr "Modelo para nome de faixa - correcto"
+
+#: id:13388
+msgid "Preset"
+msgstr "Predefinições"
+
+#: id:13389
+msgid "There are no presets available\nfor this visualization"
+msgstr "Não existem predefinições disponíveis para esta visualização"
+
+#: id:13390
+msgid "There are no settings available\nfor this visualization"
+msgstr "Não existem configurações disponíveis para esta visualização"
+
+#: id:13391
+msgid "Eject/Load"
+msgstr "Ejectar/Carregar"
+
+#: id:13392
+msgid "Use visualization if playing audio"
+msgstr "Utilizar visualização quando reproduz áudio"
+
+#: id:13393
+msgid "Calculate size"
+msgstr "Calcular tamanho"
+
+#: id:13394
+msgid "Calculating folder size"
+msgstr "Calculando tamanho da pasta"
+
+#: id:13395
+msgid "Video settings"
+msgstr "Configurações de vídeo"
+
+#: id:13396
+msgid "Audio and subtitle settings"
+msgstr "Configurações de áudio e legendas"
+
+#: id:13397
+msgid "Enable subtitles"
+msgstr "Activar legendas"
+
+#: id:13398
+msgctxt "Auto context with id 13398"
+msgid "Shortcuts"
+msgstr "Atalhos"
+
+#: id:13399
+msgid "Ignore articles when sorting (e.g. \"the\")"
+msgstr "Ignorar pronomes quando ordenar"
+
+#: id:13400
+msgid "Crossfade between songs on the same album"
+msgstr "Sobreposição de faixas do mesmo álbum"
+
+#: id:13401
+msgid "Browse for %s"
+msgstr "Procurar por %s"
+
+#: id:13402
+msgid "Show track position"
+msgstr "Mostrar posição da pista"
+
+#: id:13403
+msgid "Clear default"
+msgstr "Limpar definições padrão"
+
+#: id:13404
+msgid "Resume"
+msgstr "Resumir"
+
+#: id:13405
+msgid "Get thumb"
+msgstr "Buscar miniatura"
+
+#: id:13406
+msgid "Picture information"
+msgstr "Informação da imagem"
+
+#: id:13407
+msgid "%s presets"
+msgstr "%s Predefinições"
+
+#: id:13408
+msgid "(IMDb user rating)"
+msgstr "(Nota do IMDB)"
+
+#: id:13409
+msgid "Top 250"
+msgstr "As Melhores 250"
+
+#: id:13410
+msgid "Tune in on Last.fm"
+msgstr "Ligar a Last.fm"
+
+#: id:13411
+msgid "Minimum fan speed"
+msgstr "Velocidade mínima da ventoinha"
+
+#: id:13412
+msgid "Play from here"
+msgstr ""
+
+#: id:13413
+msgid "Downloading"
+msgstr "A descarregar"
+
+#: id:13414
+msgid "Include artists who appear only on compilations"
+msgstr "Incluir artistas que apenas aparecem em compilações"
+
+#: id:13415
+msgctxt "Auto context with id 13415"
+msgid "Render method"
+msgstr "Método de renderização"
+
+#: id:13416
+msgid "Auto detect"
+msgstr "Auto detectar"
+
+#: id:13417
+msgid "Basic shaders (ARB)"
+msgstr "Shaders básicos (ARB)"
+
+#: id:13418
+msgid "Advanced shaders (GLSL)"
+msgstr "Shaders avançados (GLSL)"
+
+#: id:13419
+msgid "Software"
+msgstr "Software"
+
+#: id:13420
+msgid "Remove safely"
+msgstr "Remover com segurança"
+
+#: id:13421
+msgctxt "Auto context with id 13421"
+msgid "VDPAU"
+msgstr "VDPAU"
+
+#: id:13422
+msgid "Start slideshow here"
+msgstr "Começar apresentação aqui"
+
+#: id:13423
+msgid "Remember for this path"
+msgstr "Lembrar este caminho"
+
+#: id:13424
+msgid "Use pixel buffer objects"
+msgstr "Usar pixel buffer objects"
+
+#: id:13425
+msgid "Allow hardware acceleration (VDPAU)"
+msgstr "Permitir aceleração por hardware (VDPAU)"
+
+#: id:13426
+msgid "Allow hardware acceleration (VAAPI)"
+msgstr "Permitir aceleração por hardware (VAAPI)"
+
+#: id:13427
+msgid "Allow hardware acceleration (DXVA2)"
+msgstr "Permitir aceleração por hardware (DXVA2)"
+
+#: id:13428
+msgid "Allow hardware acceleration (CrystalHD)"
+msgstr "Permitir aceleração por hardware (CrystalHD)"
+
+#: id:13429
+msgid "Allow hardware acceleration (VDADecoder)"
+msgstr "Permitir aceleração por hardware (VDADecoder)"
+
+#: id:13430
+msgid "Allow hardware acceleration (OpenMax)"
+msgstr "Permitir aceleração por hardware (OpenMax)"
+
+#: id:13431
+msgid "Pixel Shaders"
+msgstr "Pixel Shaders"
+
+#: id:13432
+msgid "Allow hardware acceleration (VideoToolbox)"
+msgstr ""
+
+#: id:13500
+msgid "A/V sync method"
+msgstr "Método de sincronia A/V"
+
+#: id:13501
+msgid "Audio clock"
+msgstr "Relógio Áudio"
+
+#: id:13502
+msgid "Video clock (Drop/Dupe audio)"
+msgstr "Relógio Vídeo (Baixar/Enganar áudio)"
+
+#: id:13503
+msgid "Video clock (Resample audio)"
+msgstr "Relógio Vídeo (Remasterizar áudio)"
+
+#: id:13504
+msgid "Maximum resample amount (%)"
+msgstr "Percentagem máxima de remasterização (%)"
+
+#: id:13505
+msgid "Resample quality"
+msgstr "Qualidade de remasterização"
+
+#: id:13506
+msgid "Low(fast)"
+msgstr "Baixa (Rápido)"
+
+#: id:13507
+msgctxt "Auto context with id 13507"
+msgid "Medium"
+msgstr "Média"
+
+#: id:13508
+msgctxt "Auto context with id 13508"
+msgid "High"
+msgstr "Alta"
+
+#: id:13509
+msgid "Really high(slow!)"
+msgstr "Muito Alta (Lento)"
+
+#: id:13510
+msgid "Sync playback to display"
+msgstr "Sincronizar vídeo com ecrã"
+
+#: id:13550
+msgid "Pause during refresh rate change"
+msgstr "Pausar durante mudança de taxa de actualização"
+
+#: id:13551
+msgctxt "Auto context with id 13551"
+msgid "Off"
+msgstr "Off"
+
+#: id:13552
+msgid "%.1f Second"
+msgstr "%.1f Segundo"
+
+#: id:13553
+msgid "%.1f Seconds"
+msgstr "%.1f Segundos"
+
+#: id:13600
+msgid "Apple remote"
+msgstr "Comando da Apple"
+
+#: id:13602
+msgid "Allow start of XBMC using the remote"
+msgstr "Permitir início do XBMC com controlo remoto"
+
+#: id:13603
+msgid "Sequence delay time"
+msgstr "Atraso do tempo da sequência"
+
+#: id:13610
+msgctxt "Auto context with id 13610"
+msgid "Disabled"
+msgstr "Desligado"
+
+#: id:13611
+msgctxt "Auto context with id 13611"
+msgid "Standard"
+msgstr "Predefinido"
+
+#: id:13612
+msgid "Universal Remote"
+msgstr "Comando universal"
+
+#: id:13613
+msgid "Multi Remote (Harmony)"
+msgstr "Comando múltiplo (Harmony)"
+
+#: id:13620
+msgid "Apple Remote Error"
+msgstr "Erro do comando Apple"
+
+#: id:13621
+msgid "Apple Remote support could be enabled."
+msgstr "Não foi possível instalar o comando Apple"
+
+#: id:14000
+msgid "Stack"
+msgstr "Agregar"
+
+#: id:14001
+msgid "Unstack"
+msgstr "Desagregar"
+
+#: id:14003
+msgid "Downloading playlist file..."
+msgstr "A descarregar lista de reprodução..."
+
+#: id:14004
+msgid "Downloading streams list..."
+msgstr "A descarregar lista de pistas..."
+
+#: id:14005
+msgid "Parsing streams list..."
+msgstr "A analisar lista de pistas..."
+
+#: id:14006
+msgid "Downloading streams list failed"
+msgstr "Transferência de lista de pistas falhou"
+
+#: id:14007
+msgid "Downloading playlist file failed"
+msgstr "Transferência de lista de reprodução falhou"
+
+#: id:14009
+msgid "Games directory"
+msgstr "Pasta de jogos"
+
+#: id:14010
+msgid "Auto switch to thumbs based on"
+msgstr "Troca automática para miniaturas baseada em"
+
+#: id:14011
+msgid "Enable auto switching to thumbs view"
+msgstr "Activar troca automática para vista de miniaturas"
+
+#: id:14012
+msgid "- Use large icons"
+msgstr "- Utilizar ícones grandes"
+
+#: id:14013
+msgid "- Switch based on"
+msgstr "- Trocar baseado em"
+
+#: id:14014
+msgid "- Percentage"
+msgstr "- Percentagem"
+
+#: id:14015
+msgid "No files and at least one thumb"
+msgstr "Nenhum ficheiro e pelo menos uma miniatura"
+
+#: id:14016
+msgid "At least one file and thumb"
+msgstr "Pelo menos um ficheiro e uma miniatura"
+
+#: id:14017
+msgid "Percentage of thumbs"
+msgstr "Percentagem de miniaturas"
+
+#: id:14018
+msgid "View options"
+msgstr "Opções visuais"
+
+#: id:14019
+msgid "Change area code 1"
+msgstr "Alterar código de área 1"
+
+#: id:14020
+msgid "Change area code 2"
+msgstr "Alterar código de área 2"
+
+#: id:14021
+msgid "Change area code 3"
+msgstr "Alterar código de área 3"
+
+#: id:14022
+msgctxt "Auto context with id 14022"
+msgid "Library"
+msgstr "Biblioteca"
+
+#: id:14023
+msgid "No TV"
+msgstr "Sem TV"
+
+#: id:14024
+msgid "Enter the nearest large town"
+msgstr "Introduza a cidade mais próxima"
+
+#: id:14025
+msgid "Video/Audio/DVD cache - Harddisk"
+msgstr "Cache Vídeo/Áudio/DVD - HDD"
+
+#: id:14026
+msgid "Video cache - DVD-ROM"
+msgstr "Cache Vídeo - DVD-ROM"
+
+#: id:14027
+msgctxt "Auto context with id 14027"
+msgid "- Local Network"
+msgstr "- Rede local"
+
+#: id:14028
+msgctxt "Auto context with id 14028"
+msgid "- Internet"
+msgstr "- Internet"
+
+#: id:14030
+msgid "Audio cache - DVD-ROM"
+msgstr "Cache Áudio - DVD-ROM"
+
+#: id:14031
+msgctxt "Auto context with id 14031"
+msgid "- Local Network"
+msgstr "- Rede local"
+
+#: id:14032
+msgctxt "Auto context with id 14032"
+msgid "- Internet"
+msgstr "- Internet"
+
+#: id:14034
+msgid "DVD cache - DVD-ROM"
+msgstr "Cache DVD - DVD-ROM"
+
+#: id:14035
+msgctxt "Auto context with id 14035"
+msgid "- Local Network"
+msgstr "- Rede local"
+
+#: id:14036
+msgctxt "Auto context with id 14036"
+msgid "Services"
+msgstr "Serviços"
+
+#: id:14038
+msgid "Network settings changed"
+msgstr "Configuração de rede alterada"
+
+#: id:14039
+msgid "XBMC requires to restart to change your"
+msgstr "XBMC necessita de reiniciar para alterar a sua"
+
+#: id:14040
+msgid "network setup. Would you like to restart now?"
+msgstr "configuração de rede. Deseja reiniciar agora?"
+
+#: id:14041
+msgid "Internet connection bandwidth limitation"
+msgstr "Limitação da largura de banda da Internet"
+
+#: id:14043
+msgid "- Shutdown while playing"
+msgstr "- Desligar durante os jogos"
+
+#: id:14044
+msgid "%i min"
+msgstr "%i min"
+
+#: id:14045
+msgid "%i sec"
+msgstr "%i seg"
+
+#: id:14046
+msgid "%i ms"
+msgstr "%i ms"
+
+#: id:14047
+msgid "%i %%"
+msgstr "%i %%"
+
+#: id:14048
+msgid "%i kbps"
+msgstr "%i kbps"
+
+#: id:14049
+msgid "%i kb"
+msgstr "%i kb"
+
+#: id:14050
+msgid "%i.0 dB"
+msgstr "%i.0 dB"
+
+#: id:14051
+msgid "Time format"
+msgstr "Formato de hora"
+
+#: id:14052
+msgid "Date format"
+msgstr "Formato de data"
+
+#: id:14053
+msgid "GUI filters"
+msgstr "Filtros da GUI"
+
+#: id:14055
+msgid "Use background scanning"
+msgstr "Procurar em segundo plano"
+
+#: id:14056
+msgid "Stop scan"
+msgstr "Parar a procura"
+
+#: id:14057
+msgid "Not possible while scanning for media info"
+msgstr "Impossível enquanto a Biblioteca está em actualização"
+
+#: id:14058
+msgid "Film grain effect"
+msgstr "Efeito de grão no vídeo"
+
+#: id:14059
+msgid "Search for thumbnails on remote shares"
+msgstr "Procurar miniaturas nas partilhas remotas"
+
+#: id:14060
+msgid "Unknown type cache - Internet"
+msgstr "Tipo de cache desconhecido - Internet"
+
+#: id:14061
+msgctxt "Auto context with id 14061"
+msgid "Auto"
+msgstr "Auto"
+
+#: id:14062
+msgid "Enter username for"
+msgstr "Introduza utilizador para"
+
+#: id:14063
+msgid "Date & time"
+msgstr "Data & Hora"
+
+#: id:14064
+msgid "Set date"
+msgstr "Definir Data"
+
+#: id:14065
+msgid "Set time"
+msgstr "Definir Hora"
+
+#: id:14066
+msgid "Enter the time in 24 hour HH:MM format"
+msgstr "Introduza a hora no formato 24 horas (HH:MM)"
+
+#: id:14067
+msgid "Enter the date in DD/MM/YYYY format"
+msgstr "Introduza a Data no formato DD/MM/YYYY"
+
+#: id:14068
+msgid "Enter the IP address"
+msgstr "Introduza o endereço IP"
+
+#: id:14069
+msgid "Apply these settings now?"
+msgstr "Aplicar configurações agora?"
+
+#: id:14070
+msgid "Apply changes now"
+msgstr "Aplicar alterações agora"
+
+#: id:14071
+msgid "Allow file renaming and deletion"
+msgstr "Permitir renomear e remover ficheiros"
+
+#: id:14074
+msgid "Set timezone"
+msgstr "Definir fuso horário"
+
+#: id:14075
+msgid "Use daylight saving time"
+msgstr "Usar a hora de verão"
+
+#: id:14076
+msgid "Add to favourites"
+msgstr "Adicionar aos favoritos"
+
+#: id:14077
+msgid "Remove from favourites"
+msgstr "Remover dos favoritos"
+
+#: id:14078
+msgctxt "Auto context with id 14078"
+msgid "- Colours"
+msgstr "Cores do tema"
+
+#: id:14079
+msgid "Timezone country"
+msgstr "País do fuso horário"
+
+#: id:14080
+msgid "Timezone"
+msgstr "Fuso horário"
+
+#: id:14081
+msgid "File lists"
+msgstr "Lista de ficheiros"
+
+#: id:14082
+msgid "Show EXIF picture information"
+msgstr "Mostrar informação EXIF da fotografia"
+
+#: id:14083
+msgid "Use a fullscreen window rather than true fullscreen"
+msgstr "Usar janela fullscreen em vez de verdadeiro fullscreen"
+
+#: id:14084
+msgid "Queue songs on selection"
+msgstr "Colocar músicas em fila ao seleccionar"
+
+#: id:14086
+msgid "Playback"
+msgstr "Reproduzir"
+
+#: id:14087
+msgid "DVDs"
+msgstr "DVDs"
+
+#: id:14088
+msgid "Play DVDs automatically"
+msgstr "Reproduzir DVDs automaticamente"
+
+#: id:14089
+msgid "Font to use for text subtitles"
+msgstr "Fonte para as legendas"
+
+#: id:14090
+msgid "International"
+msgstr "Internacional"
+
+#: id:14091
+msgid "Character set"
+msgstr "Código de página"
+
+#: id:14092
+msgid "Debugging"
+msgstr "Depurando"
+
+#: id:14093
+msgid "Security"
+msgstr "Segurança"
+
+#: id:14094
+msgid "Input devices"
+msgstr "Dispositivos"
+
+#: id:14095
+msgid "Power saving"
+msgstr "Poupança de energia"
+
+#: id:14096
+msgid "Rip"
+msgstr ""
+
+#: id:14097
+msgid "Audio CD Insert Action"
+msgstr ""
+
+#: id:14098
+msgctxt "Auto context with id 14098"
+msgid "Play"
+msgstr ""
+
+#: id:14099
+msgid "Eject disc when CD ripping is complete"
+msgstr ""
+
+#: id:15015
+msgctxt "Auto context with id 15015"
+msgid "Remove"
+msgstr "Remover"
+
+#: id:15016
+msgid "Games"
+msgstr "Jogos"
+
+#: id:15019
+msgid "Add"
+msgstr "Adicionar"
+
+#: id:15052
+msgid "Password"
+msgstr "Palavra-passe"
+
+#: id:15100
+msgctxt "Auto context with id 15100"
+msgid "Library"
+msgstr "Biblioteca"
+
+#: id:15101
+msgid "Database"
+msgstr "Base de Dados"
+
+#: id:15102
+msgid "* All albums"
+msgstr "* Todos os álbuns"
+
+#: id:15103
+msgid "* All artists"
+msgstr "* Todos os artistas"
+
+#: id:15104
+msgid "* All songs"
+msgstr "* Todas as músicas"
+
+#: id:15105
+msgid "* All genres"
+msgstr "* Todos os géneros"
+
+#: id:15107
+msgid "Buffering..."
+msgstr "Buffering..."
+
+#: id:15108
+msgid "Navigation sounds"
+msgstr "Sons ao navegar"
+
+#: id:15109
+msgid "Skin default"
+msgstr "Tema por defeito"
+
+#: id:15111
+msgid "- Theme"
+msgstr "- Tema"
+
+#: id:15112
+msgid "Default theme"
+msgstr "Tema por defeito"
+
+#: id:15200
+msgid "Last.fm"
+msgstr "Last.fm"
+
+#: id:15201
+msgid "Submit songs to Last.fm"
+msgstr "Enviar músicas para Last.fm"
+
+#: id:15202
+msgid "Last.fm username"
+msgstr "Utilizador Last.fm"
+
+#: id:15203
+msgid "Last.fm password"
+msgstr "Palavra-passe Last.fm"
+
+#: id:15204
+msgid "Unable to handshake: sleeping..."
+msgstr "Incapaz de ligar: a adormecer..."
+
+#: id:15205
+msgid "Please update XBMC"
+msgstr "Por favor actualize o XBMC"
+
+#: id:15206
+msgid "Bad authorization: Check username and password"
+msgstr "Autorização errada: Verifique o utilizador e palavra-passe"
+
+#: id:15207
+msgctxt "Auto context with id 15207"
+msgid "Connected"
+msgstr "Ligado"
+
+#: id:15208
+msgid "Not connected"
+msgstr "Desligado"
+
+#: id:15209
+msgid "Submit interval %i"
+msgstr "Intervalo para submeter %i"
+
+#: id:15210
+msgid "Cached %i songs"
+msgstr "Colocar em cache %i músicas"
+
+#: id:15211
+msgid "Submitting..."
+msgstr "Submetendo ..."
+
+#: id:15212
+msgid "Submitting in %i secs"
+msgstr "Submetendo em %i segundos"
+
+#: id:15213
+msgid "Play using..."
+msgstr "Reproduzir utilizando..."
+
+#: id:15214
+msgid "Use smoothed A/V synchronization"
+msgstr "Utilizar sincronização de A/V suave"
+
+#: id:15215
+msgid "Hide file names in thumbs view"
+msgstr "Esconder nome dos ficheiros na vista de miniaturas"
+
+#: id:15216
+msgid "Play in party mode"
+msgstr "Reproduzir em modo de festa"
+
+#: id:15217
+msgid "Submit songs to Libre.fm"
+msgstr "Enviar músicas para Libre.fm"
+
+#: id:15218
+msgid "Libre.fm username"
+msgstr "Utilizador Libre.fm"
+
+#: id:15219
+msgid "Libre.fm password"
+msgstr "Palavra-passe Libre.fm"
+
+#: id:15220
+msgid "Libre.fm"
+msgstr "Libre.fm"
+
+#: id:15221
+msgid "Song submission"
+msgstr "Envio de música"
+
+#: id:15250
+msgid "Submit Last.fm radio to Last.fm"
+msgstr "Submeter o rádio Last.fm a Last.fm"
+
+#: id:15251
+msgid "Connecting to Last.fm..."
+msgstr "A Ligar a Last.fm..."
+
+#: id:15252
+msgid "Selecting station..."
+msgstr "A escolher a estação..."
+
+#: id:15253
+msgid "Search similar artists..."
+msgstr "Procurar artistas similares ..."
+
+#: id:15254
+msgid "Search similar tags..."
+msgstr "Procurar etiquetas similares..."
+
+#: id:15255
+msgid "Your profile (%name%)"
+msgstr "O seu perfil (%name%)"
+
+#: id:15256
+msgid "Overall top tags"
+msgstr "Top de todas as etiquetas"
+
+#: id:15257
+msgid "Top artists for tag %name%"
+msgstr "Top de artistas para a etiqueta %name%"
+
+#: id:15258
+msgid "Top albums for tag %name%"
+msgstr "Top de álbuns para a etiqueta %name%"
+
+#: id:15259
+msgid "Top tracks for tag %name%"
+msgstr "Top de faixas para a etiqueta %name%"
+
+#: id:15260
+msgid "Listen to tag %name% Last.fm radio"
+msgstr "Ouvir a etiqueta %name% na rádio da Last.fm"
+
+#: id:15261
+msgid "Similar artists as %name%"
+msgstr "Artistas parecidos com %name%"
+
+#: id:15262
+msgid "Top %name% albums"
+msgstr "Top de álbuns %name%"
+
+#: id:15263
+msgid "Top %name% tracks"
+msgstr "Top de faixas %name%"
+
+#: id:15264
+msgid "Top %name% tags"
+msgstr "Top de etiquetas %name%"
+
+#: id:15265
+msgid "Biggest fans of %name%"
+msgstr "Maiores fans de %name%"
+
+#: id:15266
+msgid "Listen to %name% fans Last.fm radio"
+msgstr "Ouvir %name% fans na rádio Last.fm"
+
+#: id:15267
+msgid "Listen to %name% similar artists Last.fm radio"
+msgstr "Ouvir artistas semelhantes a %name% na rádio Last.fm"
+
+#: id:15268
+msgid "Top artists for user %name%"
+msgstr "Top de artistas para o utilizador %name%"
+
+#: id:15269
+msgid "Top albums for user %name%"
+msgstr "Top de álbuns para o utilizador %name%"
+
+#: id:15270
+msgid "Top tracks for user %name%"
+msgstr "Top de faixas para o utilizador %name%"
+
+#: id:15271
+msgid "Friends of user %name%"
+msgstr "Amigos do utilizador %name%"
+
+#: id:15272
+msgid "Neighbours of user %name%"
+msgstr "Vizinhos do utilizador %name%"
+
+#: id:15273
+msgid "Weekly artist chart for %name%"
+msgstr "Gráfico semanal do artista %name%"
+
+#: id:15274
+msgid "Weekly album chart for %name%"
+msgstr "Gráfico semanal do álbum %name%"
+
+#: id:15275
+msgid "Weekly track chart for %name%"
+msgstr "Gráfico semanal da faixa %name%"
+
+#: id:15276
+msgid "Listen to %name%'s neighbours Last.fm radio"
+msgstr "Ouvir rádio do vizinho %name% na Last.fm"
+
+#: id:15277
+msgid "Listen to %name%'s personal Last.fm radio"
+msgstr "Ouvir rádio pessoal de %name% na Last.fm"
+
+#: id:15278
+msgid "Listen to %name%'s mix Last.fm radio"
+msgstr "Ouvir mix de rádio %name% na Last.fm"
+
+#: id:15279
+msgid "Retrieving list from Last.fm..."
+msgstr "A obter lista a partir da Last.fm..."
+
+#: id:15280
+msgid "Can't retrieve list from Last.fm..."
+msgstr "Impossível obter lista a partir da Last.fm..."
+
+#: id:15281
+msgid "Enter an artist name to find related ones"
+msgstr "Introduza um nome de artista para encontrar relacionados"
+
+#: id:15282
+msgid "Enter a tag name to find similar ones"
+msgstr "Introduza um nome de etiqueta para encontrar semelhantes"
+
+#: id:15283
+msgid "Tracks recently listened by %name%"
+msgstr "Faixas recentemente ouvidas por %name%"
+
+#: id:15284
+msgid "Listen to %name%'s recommendations Last.fm radio"
+msgstr "Ouvir as recomendações de %name% na rádio do Last.fm"
+
+#: id:15285
+msgid "Top tags for user %name%"
+msgstr "As melhores etiquetas do utilizador %name%"
+
+#: id:15287
+msgid "Do you want to add the current track to your loved tracks?"
+msgstr "Deseja adicionar a faixa às favoritas?"
+
+#: id:15288
+msgid "Do you want to ban the current track?"
+msgstr "Deseja banir a faixa actual?"
+
+#: id:15289
+msgid "Added to your loved tracks: '%s'."
+msgstr "Adicionado às faixas favoritas: '%s'."
+
+#: id:15290
+msgid "Could not add '%s' to your loved tracks."
+msgstr "Não foi possível adicionar '%s' às faixas favoritas."
+
+#: id:15291
+msgid "Banned: '%s'."
+msgstr "Banida: '%s'."
+
+#: id:15292
+msgid "Could not ban '%s'."
+msgstr "Impossível banir '%s'."
+
+#: id:15293
+msgid "Tracks recently loved by %name%"
+msgstr "Faixas favoritas recentes de %name%"
+
+#: id:15294
+msgid "Tracks recently banned by %name%"
+msgstr "Faixas recentes banidas por %name%"
+
+#: id:15295
+msgid "Remove from loved tracks"
+msgstr "Remover das faixas favoritas"
+
+#: id:15296
+msgid "Un-ban"
+msgstr "Remover da lista de faixas banidas"
+
+#: id:15297
+msgid "Do you want to remove this track from your loved tracks?"
+msgstr "Deseja remover esta faixa das favoritas?"
+
+#: id:15298
+msgid "Do you want to un-ban this track?"
+msgstr "Remover esta faixa da lista de faixas banidas?"
+
+#: id:15300
+msgid "Path not found or invalid"
+msgstr "Caminho não encontrado ou inválido"
+
+#: id:15301
+msgid "Could not connect to network server"
+msgstr "Impossível ligar ao servidor de rede"
+
+#: id:15302
+msgid "No servers found"
+msgstr "Não foram encontrados servidores"
+
+#: id:15303
+msgid "Workgroup not found"
+msgstr "Grupo de trabalho não encontrado"
+
+#: id:15310
+msgid "Opening multi-path source"
+msgstr "Abrir fonte multi-caminho"
+
+#: id:15311
+msgid "Path:"
+msgstr "Caminho:"
+
+#: id:16000
+msgctxt "Auto context with id 16000"
+msgid "General"
+msgstr "Geral"
+
+#: id:16002
+msgid "Internet lookup"
+msgstr "Pesquisa Internet"
+
+#: id:16003
+msgid "Player"
+msgstr "Reprodutor"
+
+#: id:16004
+msgid "Play media from disc"
+msgstr "Reproduzir média do disco"
+
+#: id:16008
+msgid "Enter new title"
+msgstr "Introduza título novo"
+
+#: id:16009
+msgid "Enter the movie name"
+msgstr "Introduza o nome do vídeo"
+
+#: id:16010
+msgid "Enter the profile name"
+msgstr "Introduza o nome do perfil"
+
+#: id:16011
+msgid "Enter the album name"
+msgstr "Introduza o nome do álbum"
+
+#: id:16012
+msgid "Enter the playlist name"
+msgstr "Introduza o nome da lista de reprodução"
+
+#: id:16013
+msgid "Enter new filename"
+msgstr "Introduza o nome do novo ficheiro"
+
+#: id:16014
+msgid "Enter folder name"
+msgstr "Introduza o nome da pasta"
+
+#: id:16015
+msgid "Enter directory"
+msgstr "Entre na pasta"
+
+#: id:16016
+msgid "Available options: %A, %T, %N, %B, %D, %G, %Y, %F, %S"
+msgstr "Opções disponíveis: %A, %T, %N, %B, %D, %G, %Y, %F, %S"
+
+#: id:16017
+msgid "Enter search string"
+msgstr "Introduza texto a procurar"
+
+#: id:16018
+msgctxt "Auto context with id 16018"
+msgid "None"
+msgstr "Nada"
+
+#: id:16019
+msgid "Auto select"
+msgstr "Selecção automática"
+
+#: id:16020
+msgid "De-interlace"
+msgstr "Desinterlaçar"
+
+#: id:16021
+msgid "Bob"
+msgstr "Bob"
+
+#: id:16022
+msgid "Bob (inverted)"
+msgstr "Bob (invertido)"
+
+#: id:16024
+msgid "Canceling..."
+msgstr "A cancelar..."
+
+#: id:16025
+msgid "Enter the artist name"
+msgstr "Introduza o nome do artista"
+
+#: id:16026
+msgid "Playback failed"
+msgstr "Reprodução falhou"
+
+#: id:16027
+msgid "One or more items failed to play."
+msgstr "Reprodução de um ou mais itens falhou."
+
+#: id:16028
+msgid "Enter value"
+msgstr "Introduza o valor"
+
+#: id:16029
+msgid "Check the log file for details."
+msgstr "Verifique o ficheiro de log para detalhes."
+
+#: id:16030
+msgid "Party mode aborted."
+msgstr "Modo de festa abortado."
+
+#: id:16031
+msgid "No matching songs in the library."
+msgstr "Não existem músicas coincidentes na Biblioteca."
+
+#: id:16032
+msgid "Could not initialize database."
+msgstr "Não é possível iniciar a base de dados."
+
+#: id:16033
+msgid "Could not open database."
+msgstr "Não é possível abrir a base de dados."
+
+#: id:16034
+msgid "Could not get songs from database."
+msgstr "Não é possível obter músicas da base de dados."
+
+#: id:16035
+msgid "Party mode playlist"
+msgstr "Lista de reprodução do modo de festa"
+
+#: id:16036
+msgid "De-interlace (Half)"
+msgstr ""
+
+#: id:16037
+msgid "Deinterlace video"
+msgstr ""
+
+#: id:16038
+msgid "Deinterlace method"
+msgstr ""
+
+#: id:16039
+msgctxt "Auto context with id 16039"
+msgid "Off"
+msgstr ""
+
+#: id:16040
+msgctxt "Auto context with id 16040"
+msgid "Auto"
+msgstr ""
+
+#: id:16041
+msgid "On"
+msgstr ""
+
+#: id:16100
+msgid "All Videos"
+msgstr "Todos os vídeos"
+
+#: id:16101
+msgid "Unwatched"
+msgstr "Não vistos"
+
+#: id:16102
+msgid "Watched"
+msgstr "Vistos"
+
+#: id:16103
+msgid "Mark as watched"
+msgstr "Marcar como visto"
+
+#: id:16104
+msgid "Mark as unwatched"
+msgstr "Marcar como não visto"
+
+#: id:16105
+msgid "Edit title"
+msgstr "Editar título"
+
+#: id:16200
+msgid "Operation was aborted"
+msgstr "A operação foi abortada"
+
+#: id:16201
+msgid "Copy failed"
+msgstr "A copia falhou"
+
+#: id:16202
+msgid "Failed to copy at least one file"
+msgstr "A copia falhou pelo menos num ficheiro"
+
+#: id:16203
+msgid "Move failed"
+msgstr "Mover falhou"
+
+#: id:16204
+msgid "Failed to move at least one file"
+msgstr "Mover falhou pelo menos num ficheiro"
+
+#: id:16205
+msgid "Delete failed"
+msgstr "Apagar falhou"
+
+#: id:16206
+msgid "Failed to delete at least one file"
+msgstr "Apagar falhou pelo menos num ficheiro"
+
+#: id:16300
+msgid "Video scaling method"
+msgstr "Método de escalonamento de vídeo"
+
+#: id:16301
+msgid "Nearest neighbour"
+msgstr "Nearest neighbour"
+
+#: id:16302
+msgid "Bilinear"
+msgstr "Bilinear"
+
+#: id:16303
+msgctxt "Auto context with id 16303"
+msgid "Bicubic"
+msgstr "Bicubic"
+
+#: id:16304
+msgid "Lanczos2"
+msgstr "Lanczos2"
+
+#: id:16305
+msgid "Lanczos3"
+msgstr "Lanczos3"
+
+#: id:16306
+msgid "Sinc8"
+msgstr "Sinc8"
+
+#: id:16307
+msgid "Bicubic (software)"
+msgstr "Bicubic (software)"
+
+#: id:16308
+msgid "Lanczos (software)"
+msgstr "Lanczos (software)"
+
+#: id:16309
+msgid "Sinc (software)"
+msgstr "Sinc (software)"
+
+#: id:16310
+msgid "Temporal"
+msgstr "Temporal"
+
+#: id:16311
+msgid "Temporal/Spatial"
+msgstr "Temporal/Spatial"
+
+#: id:16312
+msgid "(VDPAU)Noise Reduction"
+msgstr "(VDPAU)Noise Reduction"
+
+#: id:16313
+msgid "(VDPAU)Sharpness"
+msgstr "(VDPAU)Sharpness"
+
+#: id:16314
+msgid "Inverse Telecine"
+msgstr "Inverse Telecine"
+
+#: id:16315
+msgid "Lanczos3 optimized"
+msgstr "Lanczos3 optimized"
+
+#: id:16316
+msgctxt "Auto context with id 16316"
+msgid "Auto"
+msgstr "Auto"
+
+#: id:16317
+msgid "Temporal (Half)"
+msgstr "Temporal (Half)"
+
+#: id:16318
+msgid "Temporal/Spatial (Half)"
+msgstr "Temporal/Spatial (Half)"
+
+#: id:16319
+msgid "DXVA"
+msgstr "DXVA"
+
+#: id:16320
+msgid "DXVA Bob"
+msgstr ""
+
+#: id:16321
+msgid "DXVA Best"
+msgstr ""
+
+#: id:16322
+msgid "Spline36"
+msgstr ""
+
+#: id:16323
+msgid "Spline36 optimized"
+msgstr ""
+
+#: id:16324
+msgid "Software Blend"
+msgstr ""
+
+#: id:16400
+msgid "Post-processing"
+msgstr "Pós-processamento"
+
+#: id:17500
+msgid "Display sleep timeout"
+msgstr "Temporizador do ecrã acabou"
+
+#: id:19000
+msgid "Switch to channel"
+msgstr "Mudar para canal"
+
+#: id:20000
+msgid "Saved music folder"
+msgstr "Pasta de gravação de música"
+
+#: id:20001
+msgid "Use external DVD player"
+msgstr "Usar reprodutor DVD externo"
+
+#: id:20002
+msgid "External DVD player"
+msgstr "Reprodutor DVD externo"
+
+#: id:20003
+msgid "Trainers folder"
+msgstr "Pasta de instrutores"
+
+#: id:20004
+msgid "Screenshot folder"
+msgstr "Pasta de capturas de ecrã"
+
+#: id:20006
+msgid "Playlists folder"
+msgstr "Pasta de listas de reprodução"
+
+#: id:20007
+msgid "Recordings"
+msgstr "Gravações"
+
+#: id:20008
+msgid "Screenshots"
+msgstr "Capturas de ecrã"
+
+#: id:20009
+msgid "Use XBMC"
+msgstr "Usar XBMC"
+
+#: id:20011
+msgid "Music playlists"
+msgstr "Lista de reprodução de música"
+
+#: id:20012
+msgid "Video playlists"
+msgstr "Lista de reprodução de vídeo"
+
+#: id:20013
+msgid "Do you wish to launch the game?"
+msgstr "Deseja iniciar o jogo?"
+
+#: id:20014
+msgid "Sort by: Playlist"
+msgstr "Ordenar por: Lista de reprodução"
+
+#: id:20015
+msgid "Remote thumb"
+msgstr "Miniatura remota"
+
+#: id:20016
+msgid "Current thumb"
+msgstr "Miniatura actual"
+
+#: id:20017
+msgid "Local thumb"
+msgstr "Miniatura local"
+
+#: id:20018
+msgid "No thumb"
+msgstr "Sem miniatura"
+
+#: id:20019
+msgid "Choose thumbnail"
+msgstr "Escolha miniatura"
+
+#: id:20023
+msgid "Conflict"
+msgstr "Conflito"
+
+#: id:20024
+msgid "Scan new"
+msgstr "Procurar novos"
+
+#: id:20025
+msgid "Scan all"
+msgstr "Procurar tudo"
+
+#: id:20026
+msgid "Region"
+msgstr "Região"
+
+#: id:20037
+msgid "Summary"
+msgstr "Sumário"
+
+#: id:20038
+msgid "Lock music window"
+msgstr "Bloquear janela de Músicas"
+
+#: id:20039
+msgid "Lock videos window"
+msgstr "Bloquear janela de Vídeos"
+
+#: id:20040
+msgid "Lock pictures window"
+msgstr "Bloquear janela de Imagens"
+
+#: id:20041
+msgid "Lock programs & scripts windows"
+msgstr "Bloquear janela de Programas & Scripts"
+
+#: id:20042
+msgid "Lock file manager"
+msgstr "Bloquear gestor de ficheiros"
+
+#: id:20043
+msgid "Lock settings"
+msgstr "Bloquear configurações"
+
+#: id:20044
+msgid "Start fresh"
+msgstr "Reiniciar"
+
+#: id:20045
+msgid "Enter master mode"
+msgstr "Entrar em modo mestre"
+
+#: id:20046
+msgid "Leave master mode"
+msgstr "Sair do modo mestre"
+
+#: id:20047
+msgid "Create profile '%s'?"
+msgstr "Criar perfil '%s' ?"
+
+#: id:20048
+msgid "Start with fresh settings"
+msgstr "Iniciar com configuração nova"
+
+#: id:20049
+msgid "Best available"
+msgstr "O melhor disponível"
+
+#: id:20050
+msgid "Auto-switch between 16x9 and 4x3"
+msgstr "Troca automática entre 16x9 e 4x3"
+
+#: id:20051
+msgid "Treat stacked files as single file"
+msgstr "Ficheiros empilhados como um único ficheiro"
+
+#: id:20052
+msgid "Caution"
+msgstr "Precaução"
+
+#: id:20053
+msgid "Left master mode"
+msgstr "Deixar modo mestre"
+
+#: id:20054
+msgid "Entered master mode"
+msgstr "Entrou em modo mestre"
+
+#: id:20055
+msgid "Allmusic.com thumb"
+msgstr "Miniatura do Allmusic.com"
+
+#: id:20057
+msgid "Remove thumbnail"
+msgstr "Remover miniatura"
+
+#: id:20058
+msgid "Add profile..."
+msgstr "Adicionar perfil ..."
+
+#: id:20059
+msgid "Query info for all albums"
+msgstr "Procurar informação para todos os álbuns"
+
+#: id:20060
+msgctxt "Auto context with id 20060"
+msgid "Media info"
+msgstr "Informação do conteúdo"
+
+#: id:20061
+msgctxt "Auto context with id 20061"
+msgid "Separate"
+msgstr "Separar"
+
+#: id:20062
+msgid "Shares with default"
+msgstr "Partilhas com definições padrão"
+
+#: id:20063
+msgid "Shares with default (read only)"
+msgstr "Partilhas com definições padrão (modo só leitura)"
+
+#: id:20064
+msgid "Copy default"
+msgstr "Copiar definição padrão"
+
+#: id:20065
+msgid "Profile picture"
+msgstr "Imagem do perfil"
+
+#: id:20066
+msgid "Lock preferences"
+msgstr "Bloquear preferências"
+
+#: id:20067
+msgid "Edit profile"
+msgstr "Editar perfil"
+
+#: id:20068
+msgid "Profile lock"
+msgstr "Bloquear perfil"
+
+#: id:20069
+msgid "Could not create folder"
+msgstr "Impossível criar a pasta"
+
+#: id:20070
+msgid "Profile directory"
+msgstr "Pasta de perfis"
+
+#: id:20071
+msgid "Start with fresh media sources"
+msgstr "Iniciar com fontes de conteúdo novas"
+
+#: id:20072
+msgid "Make sure the selected folder is writable"
+msgstr "Verifique se a pasta escolhida pode ser escrita"
+
+#: id:20073
+msgid "and that the new folder name is valid"
+msgstr "e que o novo nome para a pasta é válido"
+
+#: id:20074
+msgid "MPAA rating"
+msgstr "Avaliação MPAA"
+
+#: id:20075
+msgid "Enter master lock code"
+msgstr "Introduza código de bloqueio mestre"
+
+#: id:20076
+msgid "Ask for master lock code on startup"
+msgstr "Perguntar código de bloqueio mestre no arranque"
+
+#: id:20077
+msgid "Skin settings"
+msgstr "Configurações do tema"
+
+#: id:20078
+msgid "- no link set -"
+msgstr "- não foi definido link -"
+
+#: id:20079
+msgid "Enable animations"
+msgstr "Activar animações"
+
+#: id:20080
+msgid "Disable RSS during music"
+msgstr "Desactivar RSS durante a música"
+
+#: id:20081
+msgid "Enable shortcut buttons"
+msgstr "Activar botões de atalho"
+
+#: id:20082
+msgid "Show programs in main menu"
+msgstr "Mostrar programas no menu principal"
+
+#: id:20083
+msgid "Show music info"
+msgstr "Mostrar informação musical"
+
+#: id:20084
+msgid "Show weather info"
+msgstr "Mostrar informação do tempo"
+
+#: id:20085
+msgid "Show system info"
+msgstr "Mostrar informação do sistema"
+
+#: id:20086
+msgid "Show available disc space C: E: F:"
+msgstr "Mostrar espaço disponível do disco C: E: F:"
+
+#: id:20087
+msgid "Show available disc space E: F: G:"
+msgstr "Mostrar espaço disponível do disco E: F: G:"
+
+#: id:20088
+msgid "Weather info"
+msgstr "Informação de tempo"
+
+#: id:20089
+msgid "Drive space free"
+msgstr "Espaço livre no disco"
+
+#: id:20090
+msgid "Enter the name of an existing share"
+msgstr "Introduza o nome de uma partilha existente"
+
+#: id:20091
+msgid "Lock code"
+msgstr "Código de bloqueio"
+
+#: id:20092
+msgid "Load profile"
+msgstr "Carregar perfil"
+
+#: id:20093
+msgid "Profile name"
+msgstr "Nome do perfil"
+
+#: id:20094
+msgctxt "Auto context with id 20094"
+msgid "Media sources"
+msgstr "Fontes de média"
+
+#: id:20095
+msgid "Enter profile lock code"
+msgstr "Introduza código de bloqueio do perfil"
+
+#: id:20096
+msgctxt "Auto context with id 20096"
+msgid "Login screen"
+msgstr "Ecrã de ligação"
+
+#: id:20097
+msgid "Fetching album info"
+msgstr "Procurando informação do álbum"
+
+#: id:20098
+msgid "Fetching info for album"
+msgstr "Procurando informação para o álbum"
+
+#: id:20099
+msgid "Can't rip CD or track while playing from CD"
+msgstr "Impossível ripar o CD ou faixa durante a reprodução do CD"
+
+#: id:20100
+msgid "Master lock code and settings"
+msgstr "Código de bloqueio mestre e configurações"
+
+#: id:20101
+msgid "Entering master lock code always enables master mode"
+msgstr "Introduzir código de bloqueio mestre activa sempre o modo mestre"
+
+#: id:20102
+msgid "or copy from default?"
+msgstr "ou copiar a partir da definição padrão?"
+
+#: id:20103
+msgid "Save changes to profile?"
+msgstr "Gravar alterações no perfil?"
+
+#: id:20104
+msgid "Old settings found."
+msgstr "Configurações antigas encontradas."
+
+#: id:20105
+msgid "Do you want to use them?"
+msgstr "Deseja usá-las?"
+
+#: id:20106
+msgid "Old media sources found."
+msgstr "Fontes de conteúdo antigas encontradas."
+
+#: id:20107
+msgid "Separate (locked)"
+msgstr "Separado (bloqueado)"
+
+#: id:20108
+msgid "Root"
+msgstr "Raiz"
+
+#: id:20109
+msgid "- Zoom"
+msgstr "- Zoom"
+
+#: id:20110
+msgid "UPnP settings"
+msgstr "Configurações UPnP"
+
+#: id:20111
+msgid "Autostart UPnP client"
+msgstr "Auto iniciar cliente UPnP"
+
+#: id:20112
+msgid "Last login: %s"
+msgstr "Última ligação: %s"
+
+#: id:20113
+msgid "Never logged on"
+msgstr "Nunca ligou"
+
+#: id:20114
+msgid "Profile %i / %i"
+msgstr "Perfil %i / %i"
+
+#: id:20115
+msgid "User login / Select a profile"
+msgstr "Ligação do utilizador / Seleccionar perfil"
+
+#: id:20116
+msgid "Use lock on login screen"
+msgstr "Usar bloqueio no ecrã de ligação"
+
+#: id:20117
+msgid "Invalid lock code."
+msgstr "Código de bloqueio inválido."
+
+#: id:20118
+msgid "This requires the master lock to be set."
+msgstr "Isto requer a definição do bloqueio mestre"
+
+#: id:20119
+msgid "Would you like to set it now?"
+msgstr "Deseja defini-lo agora?"
+
+#: id:20120
+msgid "Loading program information"
+msgstr "Carregando informação do programa"
+
+#: id:20121
+msgid "Party on!"
+msgstr "Que a festa comece!"
+
+#: id:20122
+msgid "True"
+msgstr "Verdadeiro"
+
+#: id:20123
+msgid "Mixing drinks"
+msgstr "A misturar bebidas"
+
+#: id:20124
+msgid "Filling glasses"
+msgstr "A encher os copos"
+
+#: id:20125
+msgid "Logged on as"
+msgstr "Ligado como"
+
+#: id:20126
+msgid "Log off"
+msgstr "Desligar"
+
+#: id:20128
+msgid "Go to root"
+msgstr "Ir para a raiz"
+
+#: id:20129
+msgid "Weave"
+msgstr "Onda"
+
+#: id:20130
+msgid "Weave (inverted)"
+msgstr "Onda (Invertida)"
+
+#: id:20131
+msgid "Blend"
+msgstr "Mistura"
+
+#: id:20132
+msgid "Restart video"
+msgstr "Reiniciar vídeo"
+
+#: id:20133
+msgid "Edit network location"
+msgstr "Editar localização de rede"
+
+#: id:20134
+msgid "Remove network location"
+msgstr "Remover localização de rede"
+
+#: id:20135
+msgid "Do you want to scan the folder?"
+msgstr "Quer procurar nesta pasta?"
+
+#: id:20136
+msgid "Memory unit"
+msgstr "Unidade de memória"
+
+#: id:20137
+msgid "Memory unit mounted"
+msgstr "Unidade de memória montada"
+
+#: id:20138
+msgid "Unable to mount memory unit"
+msgstr "Incapaz de montar unidade de memoria"
+
+#: id:20139
+msgid "In port %i, slot %i"
+msgstr "Na porta %i, slot %i"
+
+#: id:20140
+msgid "Lock screensaver"
+msgstr "Bloquear protecção de ecrã"
+
+#: id:20141
+msgid "Set"
+msgstr "Definir"
+
+#: id:20142
+msgctxt "Auto context with id 20142"
+msgid "Username"
+msgstr "Utilizador"
+
+#: id:20143
+msgid "Enter password for"
+msgstr "Introduza palavra-passe para"
+
+#: id:20144
+msgid "Shutdown timer"
+msgstr "Temporizador para desligar"
+
+#: id:20145
+msgid "Shutdown interval (in minutes)"
+msgstr "Intervalo para desligar automaticamente (em minutos)"
+
+#: id:20146
+msgid "Started, shutdown in %im"
+msgstr "Iniciado, desligar em %m"
+
+#: id:20147
+msgid "Shutdown in 30 minutes"
+msgstr "Desligar em 30 minutos"
+
+#: id:20148
+msgid "Shutdown in 60 minutes"
+msgstr "Desligar em 60 minutos"
+
+#: id:20149
+msgid "Shutdown in 120 minutes"
+msgstr "Desligar em 120 minutos"
+
+#: id:20150
+msgid "Custom shutdown timer"
+msgstr "Tempo para desligar personalizado"
+
+#: id:20151
+msgid "Cancel shutdown timer"
+msgstr "Cancelar temporizador para desligar"
+
+#: id:20152
+msgid "Lock preferences for %s"
+msgstr "Bloquear preferências para %s"
+
+#: id:20153
+msgid "Browse..."
+msgstr "Procurar..."
+
+#: id:20154
+msgid "Summary information"
+msgstr "Informação básica"
+
+#: id:20155
+msgid "Storage information"
+msgstr "Informação do armazenamento"
+
+#: id:20156
+msgid "Hard disk information"
+msgstr "Informação do disco rígido"
+
+#: id:20157
+msgid "DVD-ROM information"
+msgstr "Informação do DVD-ROM"
+
+#: id:20158
+msgid "Network information"
+msgstr "Informação da rede"
+
+#: id:20159
+msgid "Video information"
+msgstr "Informação de vídeo"
+
+#: id:20160
+msgid "Hardware information"
+msgstr "Informação do hardware"
+
+#: id:20161
+msgid "Total"
+msgstr "Total"
+
+#: id:20162
+msgid "Used"
+msgstr "Usado"
+
+#: id:20163
+msgid "of"
+msgstr "de"
+
+#: id:20164
+msgid "Locking not supported"
+msgstr "Bloqueio não suportado"
+
+#: id:20165
+msgid "Not locked"
+msgstr "Não bloqueado"
+
+#: id:20166
+msgid "Locked"
+msgstr "Bloqueado"
+
+#: id:20167
+msgid "Frozen"
+msgstr "Congelado"
+
+#: id:20168
+msgid "Requires reset"
+msgstr "Requer reiniciar"
+
+#: id:20169
+msgid "Week"
+msgstr "Semana"
+
+#: id:20170
+msgid "Line"
+msgstr "Linha"
+
+#: id:20171
+msgid "Windows network (SMB)"
+msgstr "Rede Windows (SMB)"
+
+#: id:20172
+msgid "XBMSP server"
+msgstr "Servidor XBMSP"
+
+#: id:20173
+msgctxt "Auto context with id 20173"
+msgid "FTP server"
+msgstr "Servidor FTP"
+
+#: id:20174
+msgid "iTunes music share (DAAP)"
+msgstr "Partilha de música iTunes (DAAP)"
+
+#: id:20175
+msgid "UPnP server"
+msgstr "Servidor UPnP"
+
+#: id:20176
+msgid "Show video info"
+msgstr "Mostrar informação do vídeo"
+
+#: id:20177
+msgid "Done"
+msgstr "Validar"
+
+#: id:20178
+msgid "Shift"
+msgstr "Shift"
+
+#: id:20179
+msgid "Caps Lock"
+msgstr "Caps Lock"
+
+#: id:20180
+msgid "Symbols"
+msgstr "Símbolos"
+
+#: id:20181
+msgid "Backspace"
+msgstr "Backspace"
+
+#: id:20182
+msgid "Space"
+msgstr "Espaço"
+
+#: id:20183
+msgid "Reload skin"
+msgstr "Recarregar o tema"
+
+#: id:20184
+msgid "Rotate pictures using EXIF information"
+msgstr "Rodar utilizando informação EXIF"
+
+#: id:20185
+msgid "Use poster view styles for TV shows"
+msgstr "Usar visualização de posters para séries de TV"
+
+#: id:20186
+msgid "Please wait"
+msgstr "Aguarde por favor"
+
+#: id:20187
+msgid "UPnP"
+msgstr ""
+
+#: id:20189
+msgid "Enable auto scrolling for plot & review"
+msgstr "Ligar deslocamento automático para Sinópse % Crítica"
+
+#: id:20190
+msgctxt "Auto context with id 20190"
+msgid "Custom"
+msgstr "Personalizado"
+
+#: id:20191
+msgid "Enable debug logging"
+msgstr "Ligar o registo de depuração"
+
+#: id:20192
+msgid "Download additional information during updates"
+msgstr "Obter informação extra durante actualizações"
+
+#: id:20193
+msgid "Default service for album information"
+msgstr "Serviço padrão para informação do álbum"
+
+#: id:20194
+msgid "Default service for artist information"
+msgstr "Serviço padrão para informação do artista"
+
+#: id:20195
+msgid "Change scraper"
+msgstr "Mudar serviço de busca"
+
+#: id:20196
+msgid "Export music library"
+msgstr "Exportar Biblioteca de música"
+
+#: id:20197
+msgid "Import music library"
+msgstr "Importar Biblioteca de música"
+
+#: id:20198
+msgid "No artist found!"
+msgstr "Não foi encontrado artista!"
+
+#: id:20199
+msgid "Downloading artist info failed"
+msgstr "Impossível descarregar informação do artista"
+
+#: id:20250
+msgid "Party on! (videos)"
+msgstr "A festa começou! (Vídeos)"
+
+#: id:20251
+msgid "Mixing drinks (videos)"
+msgstr "A misturar bebidas (Vídeos)"
+
+#: id:20252
+msgid "Filling glasses (videos)"
+msgstr "A encher os copos (Vídeos)"
+
+#: id:20253
+msgid "WebDAV server (HTTP)"
+msgstr "Servidor WebDAV (HTTP)"
+
+#: id:20254
+msgid "WebDAV server (HTTPS)"
+msgstr "Servidor WebDAV (HTTPS)"
+
+#: id:20255
+msgid "First logon, edit your profile"
+msgstr "Primeira vez que liga, edite o seu perfil"
+
+#: id:20256
+msgid "HTS Tvheadend client"
+msgstr "Cliente HTS Tvheadend"
+
+#: id:20257
+msgid "VDR Streamdev client"
+msgstr "Cliente VDR Streamdev"
+
+#: id:20258
+msgid "MythTV client"
+msgstr "Cliente MythTV"
+
+#: id:20259
+msgid "Network Filesystem (NFS)"
+msgstr ""
+
+#: id:20260
+msgid "Secure Shell (SSH/SFTP)"
+msgstr ""
+
+#: id:20261
+msgid "Apple Filing Protocol (AFP)"
+msgstr ""
+
+#: id:20300
+msgid "Web server directory (HTTP)"
+msgstr "Pasta do servidor Web (HTTP)"
+
+#: id:20301
+msgid "Web server directory (HTTPS)"
+msgstr "Pasta do servidor Web (HTTPS)"
+
+#: id:20302
+msgid "Unable to write to folder:"
+msgstr "Impossível escrever na pasta:"
+
+#: id:20303
+msgid "Do you want to skip and proceed?"
+msgstr "Deseja cancelar e continuar?"
+
+#: id:20304
+msgid "RSS Feed"
+msgstr "Feed RSS"
+
+#: id:20307
+msgid "Secondary DNS"
+msgstr "DNS secundário"
+
+#: id:20308
+msgid "DHCP server:"
+msgstr "Servidor DHCP:"
+
+#: id:20309
+msgid "Make new folder"
+msgstr "Criar nova pasta"
+
+#: id:20310
+msgid "Dim LCD on playback"
+msgstr "Desvanecer LCD ao reproduzir"
+
+#: id:20311
+msgid "Unknown or onboard (protected)"
+msgstr "Desconhecido ou onboard (protegido)"
+
+#: id:20312
+msgid "Dim LCD on paused"
+msgstr "Desvanecer LCD ao pausar"
+
+#: id:20314
+msgid "Videos - Library"
+msgstr "Vídeos - Biblioteca"
+
+#: id:20316
+msgid "Sort by: ID"
+msgstr "Ordenar por: ID"
+
+#: id:20324
+msgid "Play part..."
+msgstr "Jogar parte ..."
+
+#: id:20325
+msgid "Calibration reset"
+msgstr "Reiniciar calibração"
+
+#: id:20326
+msgid "This will reset the calibration values for %s"
+msgstr "Isto vai repor os valores de calibração para %s"
+
+#: id:20327
+msgid "to it's default values."
+msgstr "para os valores padrão."
+
+#: id:20328
+msgid "Browse for destination"
+msgstr "Procurar por destino"
+
+#: id:20329
+msgid "Movies are in separate folders that match the movie title"
+msgstr ""
+
+#: id:20330
+msgid "Use folder names for lookups"
+msgstr "Utilizar nome das pastas na procura"
+
+#: id:20331
+msgctxt "Auto context with id 20331"
+msgid "File"
+msgstr "Ficheiro"
+
+#: id:20332
+msgid "Use file or folder names in lookups?"
+msgstr "Utilizar nome dos ficheiros ou das pastas na procura?"
+
+#: id:20333
+msgid "Set content"
+msgstr "Definir conteúdo"
+
+#: id:20334
+msgid "Folder"
+msgstr "Pasta"
+
+#: id:20335
+msgid "Look for content recursively?"
+msgstr "Procurar conteúdo recursivamente?"
+
+#: id:20336
+msgid "Unlock sources"
+msgstr "Desbloquear fontes"
+
+#: id:20337
+msgid "Actor"
+msgstr "Actor"
+
+#: id:20338
+msgid "Movie"
+msgstr "Vídeo"
+
+#: id:20339
+msgid "Director"
+msgstr "Director"
+
+#: id:20340
+msgid "Do you want to remove all items within"
+msgstr "Quer remover todos os itens neste"
+
+#: id:20341
+msgid "this path from the XBMC library?"
+msgstr "caminho da Biblioteca?"
+
+#: id:20342
+msgctxt "Auto context with id 20342"
+msgid "Movies"
+msgstr "Filmes"
+
+#: id:20343
+msgid "TV shows"
+msgstr "Séries de TV"
+
+#: id:20344
+msgid "This directory contains"
+msgstr "Esta pasta contém"
+
+#: id:20345
+msgid "Run automated scan"
+msgstr "Executar procura automática"
+
+#: id:20346
+msgid "Scan recursively"
+msgstr "Procurar recursivamente"
+
+#: id:20347
+msgid "as"
+msgstr "como"
+
+#: id:20348
+msgid "Directors"
+msgstr "Directores"
+
+#: id:20349
+msgid "No video files found in this path!"
+msgstr "Não foram encontrados ficheiros de vídeo neste caminho!"
+
+#: id:20350
+msgid "votes"
+msgstr "votos"
+
+#: id:20351
+msgid "TV show information"
+msgstr "Informação da série de TV"
+
+#: id:20352
+msgid "Episode information"
+msgstr "Informação do episódio"
+
+#: id:20353
+msgid "Loading TV show details"
+msgstr "A carregar detalhes da série de TV"
+
+#: id:20354
+msgid "Fetching episode guide"
+msgstr "A procurar guia do episódio"
+
+#: id:20355
+msgid "Loading info for episodes in directory"
+msgstr "A carregar informação dos episódios na pasta"
+
+#: id:20356
+msgid "Select TV show:"
+msgstr "Seleccione a série de TV:"
+
+#: id:20357
+msgid "Enter the TV show name"
+msgstr "Introduza o nome da série de TV"
+
+#: id:20358
+msgid "Season %i"
+msgstr "Temporada %i"
+
+#: id:20359
+msgid "Episode"
+msgstr "Episódio"
+
+#: id:20360
+msgid "Episodes"
+msgstr "Episódios"
+
+#: id:20361
+msgid "Loading episode details"
+msgstr "A carregar detalhes do episódio"
+
+#: id:20362
+msgid "Remove episode from library"
+msgstr "Remover episódio da Biblioteca"
+
+#: id:20363
+msgid "Remove TV show from library"
+msgstr "Remover série de TV da Biblioteca"
+
+#: id:20364
+msgid "TV show"
+msgstr "Série de TV"
+
+#: id:20365
+msgid "Episode plot"
+msgstr "Trama do episódio"
+
+#: id:20366
+msgid "* All seasons"
+msgstr "* Todas as temporadas"
+
+#: id:20367
+msgid "Hide watched"
+msgstr "Esconder vistos"
+
+#: id:20368
+msgid "Prod code"
+msgstr "Código de produto"
+
+#: id:20369
+msgid "Show plot for unwatched items"
+msgstr "Mostrar trama para itens não vistos"
+
+#: id:20370
+msgid "* Hidden to prevent spoilers *"
+msgstr "* Escondido para prevenir spoilers *"
+
+#: id:20371
+msgid "Set season thumb"
+msgstr "Definir miniatura da temporada"
+
+#: id:20372
+msgid "Season image"
+msgstr "Imagem da temporada"
+
+#: id:20373
+msgid "Season"
+msgstr "Temporada"
+
+#: id:20374
+msgid "Downloading movie information"
+msgstr "A carregar informação de vídeo"
+
+#: id:20375
+msgid "Unassign content"
+msgstr "Conteúdo não atribuído"
+
+#: id:20376
+msgid "Original title"
+msgstr "Título original"
+
+#: id:20377
+msgid "Refresh TV show information"
+msgstr "Actualizar informação da série de TV"
+
+#: id:20378
+msgid "Refresh info for all episodes?"
+msgstr "Actualizar informação de todos os episódios?"
+
+#: id:20379
+msgid "Selected folder contains a single TV show"
+msgstr "A pasta contém apenas uma série de TV"
+
+#: id:20380
+msgid "Exclude selected folder from scans"
+msgstr "Excluir esta pasta das procuras"
+
+#: id:20381
+msgid "Specials"
+msgstr "Especiais"
+
+#: id:20382
+msgid "Automatically grab season thumbs"
+msgstr "Auto descarregar as miniaturas das temporadas"
+
+#: id:20383
+msgid "Selected folder contains a single video"
+msgstr "A pasta contém apenas um vídeo"
+
+#: id:20384
+msgid "Link to TV show"
+msgstr "Ligar a série de TV"
+
+#: id:20385
+msgid "Remove link to TV show"
+msgstr "Remover ligação para série de TV"
+
+#: id:20386
+msgid "Recently added movies"
+msgstr "Filmes adicionados recentemente"
+
+#: id:20387
+msgid "Recently added episodes"
+msgstr "Episódios adicionados recentemente"
+
+#: id:20388
+msgid "Studios"
+msgstr "Estúdios"
+
+#: id:20389
+msgid "Music videos"
+msgstr "Vídeoclipes"
+
+#: id:20390
+msgid "Recently added music videos"
+msgstr "Vídeoclipes adicionados recentemente"
+
+#: id:20391
+msgid "Music video"
+msgstr "Vídeoclipe"
+
+#: id:20392
+msgid "Remove music video from library"
+msgstr "Remover vídeoclipe da Biblioteca"
+
+#: id:20393
+msgctxt "Auto context with id 20393"
+msgid "Music video information"
+msgstr "Informação do vídeoclipe"
+
+#: id:20394
+msgid "Loading music video information"
+msgstr "A carregar informação do vídeoclipe"
+
+#: id:20395
+msgid "Mixed"
+msgstr "Mistura"
+
+#: id:20396
+msgid "Go to albums by artist"
+msgstr "Ir para álbuns por artista"
+
+#: id:20397
+msgid "Go to album"
+msgstr "Ir para o álbum"
+
+#: id:20398
+msgid "Play song"
+msgstr "Reproduzir música"
+
+#: id:20399
+msgid "Go to music videos from album"
+msgstr "Ir para vídeoclipes do álbum"
+
+#: id:20400
+msgid "Go to music videos by artist"
+msgstr "Ir para vídeoclipes por artista"
+
+#: id:20401
+msgid "Play music video"
+msgstr "Reproduzir vídeoclipe"
+
+#: id:20402
+msgid "Download actor thumbnails when adding to library"
+msgstr "Auto descarregar as miniaturas dos actores"
+
+#: id:20403
+msgid "Set actor thumb"
+msgstr "Definir miniatura do actor"
+
+#: id:20405
+msgid "Remove episode bookmark"
+msgstr "Remover marcação do episódio"
+
+#: id:20406
+msgid "Set episode bookmark"
+msgstr "Definir marcação do episódio"
+
+#: id:20407
+msgid "Scraper settings"
+msgstr "Definições do motor de busca"
+
+#: id:20408
+msgid "Downloading music video information"
+msgstr "A descarregar informação do vídeoclipe"
+
+#: id:20409
+msgid "Downloading TV show information"
+msgstr "A descarregar informação da série de TV"
+
+#: id:20410
+msgid "Trailer"
+msgstr "Trailer"
+
+#: id:20411
+msgid "Flatten"
+msgstr "Agrupar"
+
+#: id:20412
+msgid "Flatten TV shows"
+msgstr "Agrupar séries de TV"
+
+#: id:20413
+msgid "Get fanart"
+msgstr "Escolher Fanart"
+
+#: id:20414
+msgid "Show Fanart in video and music libraries"
+msgstr "Mostrar Fanart na Biblioteca de Vídeo e Música"
+
+#: id:20415
+msgid "Scanning for new content"
+msgstr "A procurar novo conteúdo"
+
+#: id:20416
+msgid "First aired"
+msgstr "Estreia"
+
+#: id:20417
+msgid "Writer"
+msgstr "Argumentista"
+
+#: id:20419
+msgid "Replace file names with library titles"
+msgstr ""
+
+#: id:20420
+msgctxt "Auto context with id 20420"
+msgid "Never"
+msgstr "Nunca"
+
+#: id:20421
+msgid "If only one season"
+msgstr "Se apenas uma temporada"
+
+#: id:20422
+msgid "Always"
+msgstr "Sempre"
+
+#: id:20423
+msgid "Has trailer"
+msgstr "Tem trailer"
+
+#: id:20424
+msgid "False"
+msgstr "Falso"
+
+#: id:20425
+msgid "Fanart slideshow"
+msgstr "Apresentação de Fanart"
+
+#: id:20426
+msgid "Export to a single file or separate"
+msgstr "Exportar para ficheiro único ou separar"
+
+#: id:20427
+msgid "files per entry?"
+msgstr "ficheiros por entrada?"
+
+#: id:20428
+msgid "Single file"
+msgstr "Ficheiro único"
+
+#: id:20429
+msgctxt "Auto context with id 20429"
+msgid "Separate"
+msgstr "Separar"
+
+#: id:20430
+msgid "Export thumbnails and fanart?"
+msgstr "Exportar miniaturas e Fanart?"
+
+#: id:20431
+msgid "Overwrite old files?"
+msgstr "Escrever por cima de ficheiros antigos?"
+
+#: id:20432
+msgid "Exclude path from library updates"
+msgstr "Excluir caminho da actualização da Biblioteca"
+
+#: id:20433
+msgid "Extract thumbnails and video information"
+msgstr "Extrair miniaturas e informação do vídeo"
+
+#: id:20434
+msgid "Sets"
+msgstr "Definições"
+
+#: id:20435
+msgid "Set movieset thumb"
+msgstr "Definir miniatura do filme"
+
+#: id:20436
+msgid "Export actor thumbs?"
+msgstr "Exportar miniaturas do actor"
+
+#: id:20437
+msgid "Choose fanart"
+msgstr "Escolher Fanart"
+
+#: id:20438
+msgid "Local fanart"
+msgstr "Fanart local"
+
+#: id:20439
+msgid "No fanart"
+msgstr "Sem Fanart"
+
+#: id:20440
+msgid "Current fanart"
+msgstr "Fanart corrente"
+
+#: id:20441
+msgid "Remote fanart"
+msgstr "Fanart remoto"
+
+#: id:20442
+msgid "Change content"
+msgstr "Mudar conteúdo"
+
+#: id:20443
+msgid "Do you want to refresh info for all"
+msgstr "Deseja actualizar a informação para todos"
+
+#: id:20444
+msgid "items within this path?"
+msgstr "os itens nesta localização?"
+
+#: id:20445
+msgid "Fanart"
+msgstr "Fanart"
+
+#: id:20446
+msgid "Locally stored information found."
+msgstr "Informação armazenada localmente encontrada."
+
+#: id:20447
+msgid "Ignore and refresh from internet?"
+msgstr "Ignorar e actualizar da Internet?"
+
+#: id:20448
+msgid "Could not download information"
+msgstr "Download de informação não foi possível."
+
+#: id:20449
+msgid "Unable to connect to remote server"
+msgstr "Impossível ligar ao servidor remoto"
+
+#: id:20450
+msgid "Would you like to continue scanning?"
+msgstr "Deseja continuar a actualizar?"
+
+#: id:20451
+msgid "Countries"
+msgstr "Países"
+
+#: id:20452
+msgid "episode"
+msgstr "episódio"
+
+#: id:20453
+msgid "episodes"
+msgstr "episódios"
+
+#: id:20454
+msgid "Listener"
+msgstr "Ouvinte"
+
+#: id:20455
+msgid "Listeners"
+msgstr "Ouvintes"
+
+#: id:20456
+msgid "Set movieset fanart"
+msgstr ""
+
+#: id:20457
+msgid "Movie set"
+msgstr ""
+
+#: id:20458
+msgid "Group movies in sets"
+msgstr ""
+
+#: id:21330
+msgid "Show hidden files and directories"
+msgstr "Mostrar ficheiros e pastas escondidas"
+
+#: id:21331
+msgid "TuxBox client"
+msgstr "Cliente TuxBox"
+
+#: id:21332
+msgid "WARNING: Target TuxBox device is in recording-mode!"
+msgstr "AVISO: Dispositivo TuxBox alvo esta em modo de gravação!"
+
+#: id:21333
+msgid "The stream will be stopped!"
+msgstr "A reprodução vai ser parada!"
+
+#: id:21334
+msgid "Zap to channel: %s failed!"
+msgstr "Mudar para o canal %s falhou!"
+
+#: id:21335
+msgid "Are you sure to start the stream?"
+msgstr "Tem a certeza que quer iniciar a reprodução?"
+
+#: id:21336
+msgid "Connecting to: %s"
+msgstr "Ligando a: %s"
+
+#: id:21337
+msgid "TuxBox device"
+msgstr "Dispositivo TuxBox"
+
+#: id:21359
+msgid "Add media share..."
+msgstr "Adicionar partilha de conteúdo"
+
+#: id:21360
+msgid "Share video and music libraries through UPnP"
+msgstr "Partilhar vídeos e música através de UPnP"
+
+#: id:21364
+msgid "Edit media share"
+msgstr "Editar partilha de conteúdo"
+
+#: id:21365
+msgid "Remove media share"
+msgstr "Remover partilha de conteúdo"
+
+#: id:21366
+msgid "Subtitle folder"
+msgstr "Pasta de legendas personalizada"
+
+#: id:21367
+msgid "Movie & alternate subtitle directory"
+msgstr "Vídeo & Pasta alternativa de legendas"
+
+#: id:21368
+msgid "Override ASS/SSA subtitles fonts"
+msgstr ""
+
+#: id:21369
+msgid "Enable mouse and Touch Screen support"
+msgstr "Ligar rato"
+
+#: id:21370
+msgid "Play navigation sounds during media playback"
+msgstr "Reproduzir sons de navegação durante reprodução de conteúdos"
+
+#: id:21371
+msgid "Thumbnail"
+msgstr "Miniatura"
+
+#: id:21372
+msgid "Forced DVD player region"
+msgstr "Forçar região do leitor de DVD"
+
+#: id:21373
+msgid "Video output"
+msgstr "Saída de vídeo"
+
+#: id:21374
+msgid "Video aspect"
+msgstr "Aspecto do vídeo"
+
+#: id:21375
+msgctxt "Auto context with id 21375"
+msgid "Normal"
+msgstr "Normal"
+
+#: id:21376
+msgid "Letterbox"
+msgstr "Letterbox"
+
+#: id:21377
+msgid "Widescreen"
+msgstr "Widescreen"
+
+#: id:21378
+msgid "Enable 480p"
+msgstr "Activar 480p"
+
+#: id:21379
+msgid "Enable 720p"
+msgstr "Activar 720p"
+
+#: id:21380
+msgid "Enable 1080i"
+msgstr "Activar 1080i"
+
+#: id:21381
+msgid "Enter name of new playlist"
+msgstr "Introduza o nome da nova lista de reprodução"
+
+#: id:21382
+msgid "Show \"Add source\" buttons in file lists"
+msgstr "Mostrar botão \"Adicionar fonte\" nas listas de ficheiros"
+
+#: id:21383
+msgid "Enable scrollbars"
+msgstr "Activar barras de deslocação"
+
+#: id:21384
+msgid "Make watched filtering a toggle in video library"
+msgstr "Ligar filtro \"Vistos/Não vistos\" na Biblioteca de vídeo"
+
+#: id:21385
+msgctxt "Auto context with id 21385"
+msgid "Open"
+msgstr "Abrir"
+
+#: id:21386
+msgid "Acoustic management level"
+msgstr "Gestão do nível acústico"
+
+#: id:21387
+msgid "Fast"
+msgstr "Rápido"
+
+#: id:21388
+msgid "Quiet"
+msgstr "Silencioso"
+
+#: id:21389
+msgid "Enable custom background"
+msgstr "Ligar fundo personalizado"
+
+#: id:21390
+msgid "Power management level"
+msgstr "Gestão do nível de energia"
+
+#: id:21391
+msgid "High power"
+msgstr "Energia alta"
+
+#: id:21392
+msgid "Low power"
+msgstr "Energia baixa"
+
+#: id:21393
+msgid "High standby"
+msgstr "Modo de espera alto"
+
+#: id:21394
+msgid "Low standby"
+msgstr "Modo de espera baixo"
+
+#: id:21395
+msgid "Unable to cache files bigger than 4GB"
+msgstr "Incapaz de colocar em cache ficheiros maiores que 4GB"
+
+#: id:21396
+msgid "Chapter"
+msgstr "Capítulo"
+
+#: id:21397
+msgid "High quality pixel shader v2"
+msgstr "Pixel Shader V2 de alta qualidade"
+
+#: id:21398
+msgid "Enable playlist at startup"
+msgstr "Activar lista de reprodução no arranque"
+
+#: id:21399
+msgid "Use tween animations"
+msgstr "Usar animações de transição"
+
+#: id:21400
+msgid "contains"
+msgstr "contém"
+
+#: id:21401
+msgid "does not contain"
+msgstr "não contém"
+
+#: id:21402
+msgid "is"
+msgstr "é"
+
+#: id:21403
+msgid "is not"
+msgstr "não é"
+
+#: id:21404
+msgid "starts with"
+msgstr "inicia com"
+
+#: id:21405
+msgid "ends with"
+msgstr "acaba com"
+
+#: id:21406
+msgid "greater than"
+msgstr "maior que"
+
+#: id:21407
+msgid "less than"
+msgstr "menor que"
+
+#: id:21408
+msgid "after"
+msgstr "depois"
+
+#: id:21409
+msgid "before"
+msgstr "antes"
+
+#: id:21410
+msgid "in the last"
+msgstr "na última"
+
+#: id:21411
+msgid "not in the last"
+msgstr "não na última"
+
+#: id:21412
+msgid "Scrapers"
+msgstr "Scrapers"
+
+#: id:21413
+msgid "Default movie scraper"
+msgstr "Scraper pré-definido para Filmes"
+
+#: id:21414
+msgid "Default tvshow scraper"
+msgstr "Scraper pré-definido para Séries"
+
+#: id:21415
+msgid "Default music video scraper"
+msgstr "Scraper pré-definido para vídeoclipes"
+
+#: id:21416
+msgid "Enable fallback based on scraper language"
+msgstr "Ligar reserva baseado na linguagem"
+
+#: id:21417
+msgid "- Settings"
+msgstr "- Definições"
+
+#: id:21418
+msgid "Multilingual"
+msgstr "Multilinguagem"
+
+#: id:21419
+msgid "No scrapers present"
+msgstr "Não há scrapers presentes"
+
+#: id:21420
+msgid "Value to match"
+msgstr "Valor a combinar"
+
+#: id:21421
+msgid "Smart playlist rule"
+msgstr "Regra para lista de reprodução inteligente"
+
+#: id:21422
+msgid "Match items where"
+msgstr "Combinar músicas onde"
+
+#: id:21423
+msgid "New rule..."
+msgstr "Nova regra..."
+
+#: id:21424
+msgid "Items must match"
+msgstr "As músicas têm de combinar"
+
+#: id:21425
+msgid "all of the rules"
+msgstr "todas as regras"
+
+#: id:21426
+msgid "one or more of the rules"
+msgstr "uma ou mais regras"
+
+#: id:21427
+msgid "Limit to"
+msgstr "Limitado a"
+
+#: id:21428
+msgid "No limit"
+msgstr "Sem limite"
+
+#: id:21429
+msgid "Order by"
+msgstr "Ordenar por"
+
+#: id:21430
+msgid "ascending"
+msgstr "ascendente"
+
+#: id:21431
+msgid "descending"
+msgstr "descendente"
+
+#: id:21432
+msgid "Edit smart playlist"
+msgstr "Editar lista de reprodução inteligente"
+
+#: id:21433
+msgid "Name of the playlist"
+msgstr "Nome da lista de reprodução"
+
+#: id:21434
+msgid "Find items where"
+msgstr "Encontrar itens que"
+
+#: id:21435
+msgid "Edit"
+msgstr "Editar"
+
+#: id:21436
+msgid "%i items"
+msgstr "%i itens"
+
+#: id:21437
+msgid "New smart playlist..."
+msgstr "Nova lista de reprodução inteligente..."
+
+#: id:21438
+msgid "%c Drive"
+msgstr "Drive %c"
+
+#: id:21439
+msgid "Edit party mode rules"
+msgstr "Definir regras para modo de festa"
+
+#: id:21440
+msgid "Home folder"
+msgstr "Pasta principal"
+
+#: id:21441
+msgid "Watched count"
+msgstr "Contagem de vistos"
+
+#: id:21442
+msgid "Episode title"
+msgstr "Título do episódio"
+
+#: id:21443
+msgid "Video resolution"
+msgstr "Resolução de vídeo"
+
+#: id:21444
+msgid "Audio channels"
+msgstr "Canais de áudio"
+
+#: id:21445
+msgid "Video codec"
+msgstr "Codec de vídeo"
+
+#: id:21446
+msgid "Audio codec"
+msgstr "Codec de áudio"
+
+#: id:21447
+msgid "Audio language"
+msgstr "Linguagem do áudio"
+
+#: id:21448
+msgid "Subtitle language"
+msgstr "Linguagem da legenda"
+
+#: id:21449
+msgid "Remote control sends keyboard presses"
+msgstr "Controlo remoto envia códigos de teclado"
+
+#: id:21450
+msgid "- Edit"
+msgstr "- Editar"
+
+#: id:21451
+msgid "Internet connection required."
+msgstr "Ligação à Internet necessária"
+
+#: id:21452
+msgid "Get More..."
+msgstr "Buscar mais..."
+
+#: id:21453
+msgid "Root filesystem"
+msgstr "Raiz do sistema"
+
+#: id:21454
+msgid "Cache full"
+msgstr ""
+
+#: id:21455
+msgid "Cache filled before reaching required amount for continous playback"
+msgstr ""
+
+#: id:21460
+msgid "Subtitle location"
+msgstr ""
+
+#: id:21461
+msgid "Fixed"
+msgstr ""
+
+#: id:21462
+msgid "Bottom of video"
+msgstr ""
+
+#: id:21463
+msgid "Below video"
+msgstr ""
+
+#: id:21464
+msgid "Top of video"
+msgstr ""
+
+#: id:21465
+msgid "Above video"
+msgstr ""
+
+#: id:21800
+msgid "File name"
+msgstr "Nome do ficheiro"
+
+#: id:21801
+msgid "File path"
+msgstr "Caminho do ficheiro"
+
+#: id:21802
+msgid "File size"
+msgstr "Tamanho do ficheiro"
+
+#: id:21803
+msgid "File date/time"
+msgstr "Data/Hora do ficheiro"
+
+#: id:21804
+msgid "Slide index"
+msgstr "Índice da apresentação"
+
+#: id:21805
+msgctxt "Auto context with id 21805"
+msgid "Resolution"
+msgstr "Resolução"
+
+#: id:21806
+msgctxt "Auto context with id 21806"
+msgid "Comment"
+msgstr "Comentário"
+
+#: id:21807
+msgid "Colour/B&W"
+msgstr "Cores/PB"
+
+#: id:21808
+msgid "JPEG process"
+msgstr "Método de JPEG"
+
+#: id:21820
+msgid "Date/Time"
+msgstr "Data/Hora"
+
+#: id:21821
+msgid "Description"
+msgstr "Descrição"
+
+#: id:21822
+msgid "Camera make"
+msgstr "Marca da câmara"
+
+#: id:21823
+msgid "Camera model"
+msgstr "Modelo da câmara"
+
+#: id:21824
+msgid "EXIF comment"
+msgstr "Comentário EXIF"
+
+#: id:21825
+msgid "Firmware"
+msgstr "Firmware"
+
+#: id:21826
+msgid "Aperture"
+msgstr "Abertura"
+
+#: id:21827
+msgid "Focal length"
+msgstr "Comprimento focal"
+
+#: id:21828
+msgid "Focus distance"
+msgstr "Distância focal"
+
+#: id:21829
+msgid "Exposure"
+msgstr "Exposição"
+
+#: id:21830
+msgid "Exposure time"
+msgstr "Tempo de exposição"
+
+#: id:21831
+msgid "Exposure bias"
+msgstr "Desvio de exposição"
+
+#: id:21832
+msgid "Exposure mode"
+msgstr "Modo de exposição"
+
+#: id:21833
+msgid "Flash used"
+msgstr "Uso de flash"
+
+#: id:21834
+msgid "White-balance"
+msgstr "Balanço de brancos"
+
+#: id:21835
+msgid "Light source"
+msgstr "Fonte de luz"
+
+#: id:21836
+msgid "Metering mode"
+msgstr "Método de medição"
+
+#: id:21837
+msgid "ISO"
+msgstr "ISO"
+
+#: id:21838
+msgid "Digital zoom"
+msgstr "Ampliação digital"
+
+#: id:21839
+msgid "CCD width"
+msgstr "Largura do CCD"
+
+#: id:21840
+msgid "GPS latitude"
+msgstr "Latitude (GPS)"
+
+#: id:21841
+msgid "GPS longitude"
+msgstr "Longitude (GPS)"
+
+#: id:21842
+msgid "GPS altitude"
+msgstr "Altitude (GPS)"
+
+#: id:21843
+msgid "Orientation"
+msgstr "Orientação"
+
+#: id:21860
+msgid "Supplemental categories"
+msgstr "Categorias adicionais"
+
+#: id:21861
+msgid "Keywords"
+msgstr "Palavras-chave"
+
+#: id:21862
+msgid "Caption"
+msgstr "Descrição"
+
+#: id:21863
+msgid "Author"
+msgstr "Autor"
+
+#: id:21864
+msgid "Headline"
+msgstr "Título"
+
+#: id:21865
+msgid "Special instructions"
+msgstr "Instruções especiais"
+
+#: id:21866
+msgid "Category"
+msgstr "Categoria"
+
+#: id:21867
+msgid "Byline"
+msgstr "Sumário"
+
+#: id:21868
+msgid "Byline title"
+msgstr "Título do sumário"
+
+#: id:21869
+msgid "Credit"
+msgstr "Crédito"
+
+#: id:21870
+msgid "Source"
+msgstr "Fonte"
+
+#: id:21871
+msgid "Copyright notice"
+msgstr "Direitos de autor"
+
+#: id:21872
+msgid "Object name"
+msgstr "Nome do objecto"
+
+#: id:21873
+msgid "City"
+msgstr "Cidade"
+
+#: id:21874
+msgid "State"
+msgstr "Estado"
+
+#: id:21875
+msgctxt "Auto context with id 21875"
+msgid "Country"
+msgstr "País"
+
+#: id:21876
+msgid "Original Tx Reference"
+msgstr "Referência Tx original"
+
+#: id:21877
+msgid "Date created"
+msgstr "Data de criação"
+
+#: id:21878
+msgid "Copyright flag"
+msgstr "Etiqueta de direito de autor"
+
+#: id:21879
+msgid "Country code"
+msgstr "Código do país"
+
+#: id:21880
+msgid "Reference service"
+msgstr "Serviço de referência"
+
+#: id:21881
+msgid "Allow control of XBMC via UPnP"
+msgstr "Permitir controlo do XBMC por UPnP"
+
+#: id:21882
+msgid "Attempt to skip introduction before DVD menu"
+msgstr "Tentar saltar introdução antes do menu do DVD"
+
+#: id:21883
+msgid "Saved music"
+msgstr "Música guardada"
+
+#: id:21884
+msgid "Query info for all artists"
+msgstr "Procurar informação para todos os artistas"
+
+#: id:21885
+msgid "Downloading album information"
+msgstr "A descarregar informação do álbum"
+
+#: id:21886
+msgid "Downloading artist information"
+msgstr "A descarregar informação do artista"
+
+#: id:21887
+msgid "Biography"
+msgstr "Biografia"
+
+#: id:21888
+msgid "Discography"
+msgstr "Discografia"
+
+#: id:21889
+msgid "Searching artist"
+msgstr "À procura do artista"
+
+#: id:21890
+msgid "Select artist"
+msgstr "Escolha o artista"
+
+#: id:21891
+msgctxt "Auto context with id 21891"
+msgid "Artist information"
+msgstr "Informação do artista"
+
+#: id:21892
+msgid "Instruments"
+msgstr "Instrumentos"
+
+#: id:21893
+msgid "Born"
+msgstr "Naturalidade"
+
+#: id:21894
+msgid "Formed"
+msgstr "Formação"
+
+#: id:21895
+msgid "Themes"
+msgstr "Temas"
+
+#: id:21896
+msgid "Disbanded"
+msgstr "Separação"
+
+#: id:21897
+msgid "Died"
+msgstr "Falecido(s)"
+
+#: id:21898
+msgid "Years active"
+msgstr "Anos activo(s)"
+
+#: id:21899
+msgid "Label"
+msgstr "Editora"
+
+#: id:21900
+msgid "Born/Formed"
+msgstr "Nascimento/Formação"
+
+#: id:22000
+msgid "Update library on startup"
+msgstr "Actualizar Biblioteca ao iniciar"
+
+#: id:22001
+msgid "Hide progress of library updates"
+msgstr "Esconder progresso de actualização da biblioteca"
+
+#: id:22002
+msgid "- DNS suffix"
+msgstr "- Sufixo de DNS"
+
+#: id:22003
+msgid "%2.3fs"
+msgstr "%2.3fs"
+
+#: id:22004
+msgid "Delayed by: %2.3fs"
+msgstr "Atrasado por: %2.3fs"
+
+#: id:22005
+msgid "Ahead by: %2.3fs"
+msgstr "Adiantado por: %2.3fs"
+
+#: id:22006
+msgid "Subtitle offset"
+msgstr "Deslocação das legendas"
+
+#: id:22007
+msgid "OpenGL vendor:"
+msgstr "Fabricante do OpenGL:"
+
+#: id:22008
+msgid "OpenGL renderer:"
+msgstr "Descodificador de OpenGL:"
+
+#: id:22009
+msgid "OpenGL version:"
+msgstr "Versão de OpenGL:"
+
+#: id:22010
+msgid "GPU temperature:"
+msgstr "Temperatura do GPU:"
+
+#: id:22011
+msgid "CPU temperature:"
+msgstr "Temperatura do CPU:"
+
+#: id:22012
+msgid "Total memory"
+msgstr "Memória total"
+
+#: id:22013
+msgid "Profile data"
+msgstr "Dados do perfil"
+
+#: id:22014
+msgid "Use dim if paused during video playback"
+msgstr "Usar desvanecer se em pausa durante a reprodução"
+
+#: id:22015
+msgid "All recordings"
+msgstr "Todas as gravações"
+
+#: id:22016
+msgid "By title"
+msgstr "Por título"
+
+#: id:22017
+msgid "By group"
+msgstr "Por grupo"
+
+#: id:22018
+msgid "Live channels"
+msgstr "Canais ao vivo"
+
+#: id:22019
+msgid "Recordings by title"
+msgstr "Gravações por título"
+
+#: id:22020
+msgid "Guide"
+msgstr "Guia"
+
+#: id:22021
+msgid "Allowed error in aspect ratio to minimize black bars"
+msgstr "Erro permitido no rácio de aspecto para minimizar barras pretas"
+
+#: id:22022
+msgid "Show video files in listings"
+msgstr "Mostrar ficheiros de vídeo em listagens"
+
+#: id:22023
+msgid "DirectX vendor:"
+msgstr "Fabricante DirectX:"
+
+#: id:22024
+msgid "Direct3D version:"
+msgstr "Versão Direct3D:"
+
+#: id:22030
+msgctxt "Auto context with id 22030"
+msgid "Font"
+msgstr "Fonte"
+
+#: id:22031
+msgctxt "Auto context with id 22031"
+msgid "- Size"
+msgstr "- Tamanho"
+
+#: id:22032
+msgctxt "Auto context with id 22032"
+msgid "- Colours"
+msgstr "- Cores"
+
+#: id:22033
+msgid "- Charset"
+msgstr "- Código de página"
+
+#: id:22034
+msgid "Export karaoke titles as HTML"
+msgstr "Exportar títulos de karaoke em HTML"
+
+#: id:22035
+msgid "Export karaoke titles as CSV"
+msgstr "Exportar títulos de karaoke em CVS"
+
+#: id:22036
+msgid "Import karaoke titles..."
+msgstr "Importar títulos de karaoke..."
+
+#: id:22037
+msgid "Show song selector automatically"
+msgstr "Mostrar automaticamente selector de músicas"
+
+#: id:22038
+msgid "Export karaoke titles..."
+msgstr "Exportar títulos de karaoke..."
+
+#: id:22039
+msgid "Enter song number"
+msgstr "Introduza número da música"
+
+#: id:22040
+msgid "white/green"
+msgstr "branco/verde"
+
+#: id:22041
+msgid "white/red"
+msgstr "branco/vermelho"
+
+#: id:22042
+msgid "white/blue"
+msgstr "branco/azul"
+
+#: id:22043
+msgid "black/white"
+msgstr "preto/branco"
+
+#: id:22079
+msgid "Default select action"
+msgstr "Acção por defeito"
+
+#: id:22080
+msgid "Choose"
+msgstr "Escolher"
+
+#: id:22081
+msgid "Show Information"
+msgstr "Mostrar informação"
+
+#: id:22082
+msgid "More..."
+msgstr "Mais..."
+
+#: id:22083
+msgid "Play all"
+msgstr "Reproduzir todas"
+
+#: id:23049
+msgid "Teletext not available"
+msgstr "Teletexto indisponível"
+
+#: id:23050
+msgid "Activate Teletext"
+msgstr "Activar teletexto"
+
+#: id:23051
+msgid "Part %i"
+msgstr "Parte %i"
+
+#: id:23052
+msgid "Buffering %i bytes"
+msgstr "A guardar %i bytes"
+
+#: id:23053
+msgid "Stopping"
+msgstr "A parar"
+
+#: id:23054
+msgid "Running"
+msgstr "A reproduzir"
+
+#: id:23100
+msgid "External Player Active"
+msgstr "Reprodutor externo activo"
+
+#: id:23101
+msgid "Click OK to terminate the player"
+msgstr "Seleccione OK para encerrar reprodutor"
+
+#: id:23104
+msgid "Click OK when playback has ended"
+msgstr "Seleccione OK quando a reprodução terminar"
+
+#: id:24000
+msgid "Add-on"
+msgstr "Add-on"
+
+#: id:24001
+msgid "Add-ons"
+msgstr "Add-ons"
+
+#: id:24002
+msgid "Add-on options"
+msgstr "Opções do Add-on"
+
+#: id:24003
+msgid "Add-on Information"
+msgstr "Informação de Add-on"
+
+#: id:24005
+msgctxt "Auto context with id 24005"
+msgid "Media sources"
+msgstr "Fontes de média"
+
+#: id:24007
+msgctxt "Auto context with id 24007"
+msgid "Movie information"
+msgstr "Informação de vídeos"
+
+#: id:24008
+msgctxt "Auto context with id 24008"
+msgid "Screensaver"
+msgstr "Protecção de ecrã"
+
+#: id:24009
+msgid "Script"
+msgstr "Script"
+
+#: id:24010
+msgctxt "Auto context with id 24010"
+msgid "Visualization"
+msgstr "Visualização"
+
+#: id:24011
+msgid "Add-on repository"
+msgstr "Repositório de add-ons"
+
+#: id:24012
+msgctxt "Auto context with id 24012"
+msgid "Subtitles"
+msgstr "Legendas"
+
+#: id:24013
+msgid "Lyrics"
+msgstr "Letras de músicas"
+
+#: id:24014
+msgid "TV information"
+msgstr "Informação de TV"
+
+#: id:24015
+msgctxt "Auto context with id 24015"
+msgid "Music video information"
+msgstr "Informação de vídeoclipes"
+
+#: id:24016
+msgctxt "Auto context with id 24016"
+msgid "Album information"
+msgstr "Informação de álbuns"
+
+#: id:24017
+msgctxt "Auto context with id 24017"
+msgid "Artist information"
+msgstr "Informação de artistas"
+
+#: id:24018
+msgctxt "Auto context with id 24018"
+msgid "Services"
+msgstr ""
+
+#: id:24020
+msgid "Configure"
+msgstr "Configurar"
+
+#: id:24021
+msgctxt "Auto context with id 24021"
+msgid "Disable"
+msgstr "Desligar"
+
+#: id:24022
+msgid "Enable"
+msgstr "Ligar"
+
+#: id:24023
+msgid "Add-on disabled"
+msgstr "Add-on desligado"
+
+#: id:24027
+msgctxt "Auto context with id 24027"
+msgid "Weather"
+msgstr "Serviço do tempo"
+
+#: id:24028
+msgid "Weather.com (standard)"
+msgstr "Weather.com (padrão)"
+
+#: id:24030
+msgid "This Add-on can not be configured"
+msgstr "Este add-on não pode ser configurado"
+
+#: id:24031
+msgid "Error loading settings"
+msgstr "Erro a carregar definições"
+
+#: id:24032
+msgid "All Add-ons"
+msgstr "Todos os add-ons"
+
+#: id:24033
+msgid "Get Add-ons"
+msgstr "Descarregar add-ons"
+
+#: id:24034
+msgid "Check for updates"
+msgstr "Verificar actualizações"
+
+#: id:24035
+msgid "Force refresh"
+msgstr "Forçar actualização"
+
+#: id:24036
+msgid "Change log"
+msgstr "Log de alterações"
+
+#: id:24037
+msgid "Uninstall"
+msgstr "Desinstalar"
+
+#: id:24038
+msgid "Install"
+msgstr "Instalar"
+
+#: id:24039
+msgid "Disabled Add-ons"
+msgstr "Desligar add-ons"
+
+#: id:24040
+msgid "(Clear the current setting)"
+msgstr "(Apagar definição existente)"
+
+#: id:24041
+msgid "Install from zip file"
+msgstr "Instalar a partir de ficheiro zip"
+
+#: id:24042
+msgid "Downloading %i%%"
+msgstr "A descarregar %i%%"
+
+#: id:24043
+msgid "Available Updates"
+msgstr "Actualizações disponíveis"
+
+#: id:24044
+msgid "Dependencies not met"
+msgstr ""
+
+#: id:24045
+msgid "Add-on does not have the correct structure"
+msgstr ""
+
+#: id:24046
+msgid "%s is used by the following installed add-on(s)"
+msgstr ""
+
+#: id:24047
+msgid "This add-on cannot be uninstalled"
+msgstr ""
+
+#: id:24048
+msgid "Rollback"
+msgstr ""
+
+#: id:24050
+msgid "Available Add-ons"
+msgstr "Add-ons disponíveis"
+
+#: id:24051
+msgid "Version:"
+msgstr "Versão:"
+
+#: id:24052
+msgid "Disclaimer"
+msgstr "Sobre:"
+
+#: id:24053
+msgid "License:"
+msgstr "Licença:"
+
+#: id:24054
+msgid "Changelog"
+msgstr "Changelog"
+
+#: id:24059
+msgid "Would you like to enable this Add-on?"
+msgstr "Deseja ligar este add-on?"
+
+#: id:24060
+msgid "Would you like to disable this Add-on?"
+msgstr "Deseja desligar este add-on?"
+
+#: id:24061
+msgid "Add-on update available!"
+msgstr "Actualização para add-on disponível!"
+
+#: id:24062
+msgid "Enabled Add-ons"
+msgstr "Ligar add-ons"
+
+#: id:24063
+msgid "Auto update"
+msgstr "Auto actualizar"
+
+#: id:24064
+msgid "Add-on enabled"
+msgstr "Add-on ligado"
+
+#: id:24065
+msgid "Add-on updated"
+msgstr "Add-on actualizado"
+
+#: id:24066
+msgid "Cancel Add-on download?"
+msgstr "Cancelar download do add-on?"
+
+#: id:24067
+msgid "Currently downloading Add-ons"
+msgstr "A descarregar add-ons"
+
+#: id:24068
+msgid "Update available"
+msgstr "Actualização disponível"
+
+#: id:24069
+msgid "Update"
+msgstr "Actualização"
+
+#: id:24070
+msgid "Add-on could not be loaded."
+msgstr "Add-on não pode ser carregado"
+
+#: id:24071
+msgid "An unknown error has occurred."
+msgstr "Ocorreu um erro desconhecido."
+
+#: id:24072
+msgid "Settings required"
+msgstr "Configurações necessárias"
+
+#: id:24073
+msgid "Could not connect"
+msgstr "Não foi possível ligar"
+
+#: id:24074
+msgid "Needs to restart"
+msgstr "É necessário reiniciar"
+
+#: id:24075
+msgctxt "Auto context with id 24075"
+msgid "Disable"
+msgstr "Desligar"
+
+#: id:24076
+msgid "Add-on Required"
+msgstr ""
+
+#: id:24080
+msgid "Try to reconnect?"
+msgstr "Tentar ligar novamente?"
+
+#: id:24089
+msgid "Add-on restarts"
+msgstr "Reiniciar add-on"
+
+#: id:24090
+msgid "Lock Add-on manager"
+msgstr "Bloquear gestor de add-ons"
+
+#: id:24094
+msgid "(current)"
+msgstr ""
+
+#: id:24095
+msgid "(blacklisted)"
+msgstr ""
+
+#: id:24096
+msgid "Add-on has been marked as broken in repository."
+msgstr "O Add-on foi marcado como danificado no repositório."
+
+#: id:24097
+msgid "Would you like to disable it on your system?"
+msgstr "Deseja desliga-lo no seu sistema?"
+
+#: id:24098
+msgid "Broken"
+msgstr "Danificado"
+
+#: id:24099
+msgid "Would you like to switch to this skin?"
+msgstr "Gostaria de mudar para este tema?"
+
+#: id:24100
+msgid "To use this feature you must download an Add-on:"
+msgstr ""
+
+#: id:24101
+msgid "Would you like to download this Add-on?"
+msgstr ""
+
+#: id:25000
+msgid "Notifications"
+msgstr "Notificações"
+
+#: id:29800
+msgid "Library Mode"
+msgstr "Modo de Biblioteca"
+
+#: id:29801
+msgid "QWERTY keyboard"
+msgstr "Teclado QWERTY"
+
+#: id:29802
+msgid "Passthrough Audio in use"
+msgstr "Passagem de áudio em utilização"
+
+#: id:33001
+msgid "Trailer quality"
+msgstr "Qualidade do trailer"
+
+#: id:33002
+msgid "Stream"
+msgstr "Stream"
+
+#: id:33003
+msgid "Download"
+msgstr "Descarregar"
+
+#: id:33004
+msgid "Download & play"
+msgstr "Descarregar & Reproduzir"
+
+#: id:33005
+msgid "Download & save"
+msgstr "Descarregar & Guardar"
+
+#: id:33006
+msgid "Today"
+msgstr "Hoje"
+
+#: id:33007
+msgid "Tomorrow"
+msgstr "Amanhã"
+
+#: id:33008
+msgid "Saving"
+msgstr "A guardar"
+
+#: id:33009
+msgid "Copying"
+msgstr "A copiar"
+
+#: id:33010
+msgid "Set download directory"
+msgstr "Definir pasta para descarregar"
+
+#: id:33011
+msgid "Search duration"
+msgstr "Tempo de busca"
+
+#: id:33012
+msgid "Short"
+msgstr "Curto"
+
+#: id:33013
+msgid "Long"
+msgstr "Longo"
+
+#: id:33014
+msgid "Use DVD player instead of regular player"
+msgstr "Usar reprodutor de DVD em vez do reprodutor normal"
+
+#: id:33015
+msgid "Ask for download before playing video"
+msgstr "Perguntar se pode descarregar antes de reproduzir vídeo"
+
+#: id:33016
+msgid "Clips"
+msgstr "Vídeoclipes"
+
+#: id:33017
+msgid "Restart plugin to enable"
+msgstr "Reiniciar plugin para ligar"
+
+#: id:33018
+msgid "Tonight"
+msgstr "Esta noite"
+
+#: id:33019
+msgid "Tomorrow Night"
+msgstr "Amanha à noite"
+
+#: id:33020
+msgid "Condition"
+msgstr "Condição"
+
+#: id:33021
+msgid "Precipitation"
+msgstr "Precipitação"
+
+#: id:33022
+msgid "Precip"
+msgstr "Precip"
+
+#: id:33023
+msgid "Humid"
+msgstr "Húmido"
+
+#: id:33024
+msgid "Feels"
+msgstr "Parece"
+
+#: id:33025
+msgid "Observed"
+msgstr "Observado"
+
+#: id:33026
+msgid "Departure from normal"
+msgstr "Além do normal"
+
+#: id:33027
+msgid "Sunrise"
+msgstr "Nascer do Sol"
+
+#: id:33028
+msgid "Sunset"
+msgstr "Pôr-do-Sol"
+
+#: id:33029
+msgid "Details"
+msgstr "Detalhes"
+
+#: id:33030
+msgid "Outlook"
+msgstr "Previsão"
+
+#: id:33031
+msgid "Coverflow"
+msgstr "Fluxo de capas"
+
+#: id:33032
+msgid "Translate text"
+msgstr "Traduzir texto"
+
+#: id:33033
+msgid "Map list %s category"
+msgstr "Mapear lista %s à categoria"
+
+#: id:33034
+msgid "36 Hour"
+msgstr "36 horas"
+
+#: id:33035
+msgid "Maps"
+msgstr "Mapas"
+
+#: id:33036
+msgid "Hourly"
+msgstr "De hora a hora"
+
+#: id:33037
+msgid "Weekend"
+msgstr "Fim-de-semana"
+
+#: id:33038
+msgid "%s day"
+msgstr "%s dia"
+
+#: id:33049
+msgid "Alert"
+msgstr "Alerta"
+
+#: id:33050
+msgid "Alerts"
+msgstr "Alertas"
+
+#: id:33051
+msgid "Choose Your"
+msgstr "Escolha o seu"
+
+#: id:33052
+msgid "Check"
+msgstr "Verificar"
+
+#: id:33053
+msgctxt "Auto context with id 33053"
+msgid "Configure the"
+msgstr "Configurar o"
+
+#: id:33054
+msgid "Seasons"
+msgstr "Estações"
+
+#: id:33055
+msgid "Use your"
+msgstr "Usar o seu"
+
+#: id:33056
+msgid "Watch your"
+msgstr "Ver o seu"
+
+#: id:33057
+msgid "Listen to"
+msgstr "Ouvir"
+
+#: id:33058
+msgid "View your"
+msgstr "Ver o seu"
+
+#: id:33059
+msgctxt "Auto context with id 33059"
+msgid "Configure the"
+msgstr "Configurar o"
+
+#: id:33060
+msgid "Power"
+msgstr "Power"
+
+#: id:33061
+msgid "Menu"
+msgstr "Menu"
+
+#: id:33062
+msgid "Play the"
+msgstr "Tocar o"
+
+#: id:33063
+msgid "Options"
+msgstr "Opções"
+
+#: id:33065
+msgid "Editor"
+msgstr "Editor"
+
+#: id:33066
+msgid "About your"
+msgstr "Sobre o seu"
+
+#: id:33067
+msgid "Star rating"
+msgstr "Classificação por estrelas"
+
+#: id:33068
+msgid "Background"
+msgstr "Fundo"
+
+#: id:33069
+msgid "Backgrounds"
+msgstr "Fundos"
+
+#: id:33070
+msgid "Custom background"
+msgstr "Fundo personalizado"
+
+#: id:33071
+msgid "Custom backgrounds"
+msgstr "Fundos personalizados"
+
+#: id:33072
+msgid "View Readme"
+msgstr "Ver Readme"
+
+#: id:33073
+msgid "View Changelog"
+msgstr "Ver mudanças"
+
+#: id:33074
+msgid "This version of %s requires an"
+msgstr "Esta versão do %s requer uma"
+
+#: id:33075
+msgid "XBMC revision of %s or greater to run."
+msgstr "revisão do XBMC %s ou maior para correr."
+
+#: id:33076
+msgid "Please update XBMC."
+msgstr "Por favor faça um update ao XBMC."
+
+#: id:33077
+msgid "No data found!"
+msgstr "Dados não encontrados!"
+
+#: id:33078
+msgid "Next page"
+msgstr "Próxima página"
+
+#: id:33079
+msgid "Love"
+msgstr "Adoro"
+
+#: id:33080
+msgid "Hate"
+msgstr "Odeio"
+
+#: id:33081
+msgid "This file is stacked, select the part you want to play from."
+msgstr "Ficheiro multi-parte. Escolha a parte que quer ver."
+
+#: id:33082
+msgid "Path to script"
+msgstr "Caminho para o script"
+
+#: id:33083
+msgid "Enable custom script button"
+msgstr "Ligar botão personalizado de scripts"
+
+#: id:33100
+msgid "Failed to start"
+msgstr ""
+
+#: id:33101
+msgid "Webserver"
+msgstr ""
+
+#: id:33102
+msgid "Event Server"
+msgstr ""
+
+#: id:33103
+msgid "Remote communication server"
+msgstr ""
+
+#: id:33200
+msgid "Detected New Connection"
+msgstr ""
+
+#: id:34000
+msgid "Lame"
+msgstr "Lame"
+
+#: id:34001
+msgid "Vorbis"
+msgstr "Vorbis"
+
+#: id:34002
+msgid "Wav"
+msgstr "Wav"
+
+#: id:34003
+msgid "DXVA2"
+msgstr "DXVA2"
+
+#: id:34004
+msgid "VAAPI"
+msgstr "VAAPI"
+
+#: id:34005
+msgid "Flac"
+msgstr "Flac"
+
+#: id:34100
+msgid "Speaker Configuration"
+msgstr "Configuração de Colunas"
+
+#: id:34101
+msgid "2.0"
+msgstr "2.0"
+
+#: id:34102
+msgid "2.1"
+msgstr "2.1"
+
+#: id:34103
+msgid "3.0"
+msgstr "3.0"
+
+#: id:34104
+msgid "3.1"
+msgstr "3.1"
+
+#: id:34105
+msgid "4.0"
+msgstr "4.0"
+
+#: id:34106
+msgid "4.1"
+msgstr "4.1"
+
+#: id:34107
+msgid "5.0"
+msgstr "5.0"
+
+#: id:34108
+msgid "5.1"
+msgstr "5.1"
+
+#: id:34109
+msgid "7.0"
+msgstr "7.0"
+
+#: id:34110
+msgid "7.1"
+msgstr "7.1"
+
+#: id:34201
+msgid "Can't find a next item to play"
+msgstr ""
+
+#: id:34202
+msgid "Can't find a previous item to play"
+msgstr ""
+
+#: id:34300
+msgid "Failed to start zeroconf"
+msgstr ""
+
+#: id:34301
+msgid "Is Apple's Bonjour Service installed? See log for more info."
+msgstr ""
+
+#: id:34400
+msgid "Video Rendering"
+msgstr ""
+
+#: id:34401
+msgid "Failed to init video filters/scalers, falling back to bilinear scaling"
+msgstr ""
+
+#: id:34402
+msgid "Failed to initialize audio device"
+msgstr ""
+
+#: id:34403
+msgid "Check your audiosettings"
+msgstr ""
+
+#: id:34404
+msgid "Use gestures for navigation:"
+msgstr ""
+
+#: id:34405
+msgid "1 finger swipe left,right,up,down for cursors"
+msgstr ""
+
+#: id:34406
+msgid "2 finger swipe left for backspace"
+msgstr ""
+
+#: id:34407
+msgid "1 finger single tap for enter"
+msgstr ""
+
+#: id:34408
+msgid "2 finger single tap for contextmenu"
+msgstr ""
+
+#: id:35000
+msgid "Peripherals"
+msgstr ""
+
+#: id:35001
+msgid "Generic HID device"
+msgstr ""
+
+#: id:35002
+msgid "Generic network adapter"
+msgstr ""
+
+#: id:35003
+msgid "Generic disk"
+msgstr ""
+
+#: id:35004
+msgid "There are no settings available\nfor this peripheral."
+msgstr ""
+
+#: id:35005
+msgid "New device configured"
+msgstr ""
+
+#: id:35006
+msgid "Device removed"
+msgstr ""
+
+#: id:35007
+msgid "Keymap to use for this device"
+msgstr ""
+
+#: id:35008
+msgid "Keymap enabled"
+msgstr ""
+
+#: id:35009
+msgid "Do not use the custom keymap for this device"
+msgstr ""
+
+#: id:35500
+msgid "Location"
+msgstr ""
+
+#: id:35501
+msgid "Class"
+msgstr ""
+
+#: id:35502
+msgctxt "Auto context with id 35502"
+msgid "Name"
+msgstr ""
+
+#: id:35503
+msgid "Vendor"
+msgstr ""
+
+#: id:35504
+msgid "Product ID"
+msgstr ""
+
+#: id:36000
+msgid "Pulse-Eight CEC adapter"
+msgstr ""
+
+#: id:36001
+msgid "Pulse-Eight Nyxboard"
+msgstr ""
+
+#: id:36002
+msgid "Switch to keyboard side command"
+msgstr ""
+
+#: id:36003
+msgid "Switch to remote side command"
+msgstr ""
+
+#: id:36004
+msgid "Press \"user\" button command"
+msgstr ""
+
+#: id:36005
+msgid "Enable switch side commands"
+msgstr ""
+
+#: id:36006
+msgid "Could not open the adapter"
+msgstr ""
+
+#: id:36007
+msgid "Devices to power on when starting XBMC"
+msgstr ""
+
+#: id:36008
+msgid "Devices to power off when stopping XBMC"
+msgstr ""
+
+#: id:36009
+msgid "Put devices in standby mode when activating screensaver"
+msgstr ""
+
+#: id:36011
+msgid "Could not detect the CEC port. Set it up manually."
+msgstr ""
+
+#: id:36012
+msgid "Could not initialise the CEC adapter. Check your settings."
+msgstr ""
+
+#: id:36013
+msgid "Unsupported libCEC interface version. %d is greater than the version XBMC supports (%d)"
+msgstr ""
+
+#: id:36014
+msgid "Put this PC in standby mode when the TV is switched off"
+msgstr ""
+
+#: id:36015
+msgid "HDMI port number"
+msgstr ""
+
+#: id:36016
+msgctxt "Auto context with id 36016"
+msgid "Connected"
+msgstr ""
+
+#: id:36017
+msgid "Adapter found, but libCEC is not available"
+msgstr ""
+
+#: id:36018
+msgid "Use the TV's language setting"
+msgstr ""
+
+#: id:36019
+msgid "Connected to HDMI device"
+msgstr ""
+
+#: id:36020
+msgid "Make XBMC the active source when starting"
+msgstr ""
+
+#: id:36021
+msgid "Physical address (overrules HDMI port)"
+msgstr ""
+
+#: id:36022
+msgid "COM port (leave empty unless needed)"
+msgstr ""
+
+#: id:36023
+msgid "Configuration updated"
+msgstr ""
+
+#: id:36024
+msgid "Failed to set the new configuration. Please check your settings."
+msgstr ""
+
+#: id:36025
+msgid "Send 'inactive source' command when stopping XBMC"
+msgstr ""
+

--- a/language/Romanian/strings.po
+++ b/language/Romanian/strings.po
@@ -1,0 +1,9093 @@
+# Converted from xbmc strings.xml with xbmc-xml2po (by Team-XBMC)
+msgid ""
+msgstr ""
+"Project-Id-Version: xbmc.core-FRODO_GIT3ed1604ad7\n"
+"Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
+"POT-Creation-Date: 2012-04-09 18:00+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE\n"
+"Language: ro\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: id:0
+msgctxt "Auto context with id 0"
+msgid "Programs"
+msgstr "Programe"
+
+#: id:1
+msgctxt "Auto context with id 1"
+msgid "Pictures"
+msgstr "Imagini"
+
+#: id:2
+msgctxt "Auto context with id 2"
+msgid "Music"
+msgstr "Muzică"
+
+#: id:3
+msgctxt "Auto context with id 3"
+msgid "Videos"
+msgstr "Video"
+
+#: id:4
+msgid "TV-Guide"
+msgstr "Ghid TV"
+
+#: id:5
+msgctxt "Auto context with id 5"
+msgid "Settings"
+msgstr "Setări"
+
+#: id:6
+msgid "XBMC SVN"
+msgstr "SVN XBMC"
+
+#: id:7
+msgctxt "Auto context with id 7"
+msgid "File manager"
+msgstr "Gestionar de fișiere"
+
+#: id:8
+msgctxt "Auto context with id 8"
+msgid "Weather"
+msgstr "Meteo"
+
+#: id:9
+msgid "xbmc media center"
+msgstr "centru media xbmc"
+
+#: id:11
+msgid "Monday"
+msgstr "Luni"
+
+#: id:12
+msgid "Tuesday"
+msgstr "Marți"
+
+#: id:13
+msgid "Wednesday"
+msgstr "Miercuri"
+
+#: id:14
+msgid "Thursday"
+msgstr "Joi"
+
+#: id:15
+msgid "Friday"
+msgstr "Vineri"
+
+#: id:16
+msgid "Saturday"
+msgstr "Sâmbătă"
+
+#: id:17
+msgid "Sunday"
+msgstr "Duminică"
+
+#: id:21
+msgid "January"
+msgstr "ianuarie"
+
+#: id:22
+msgid "February"
+msgstr "februarie"
+
+#: id:23
+msgid "March"
+msgstr "martie"
+
+#: id:24
+msgid "April"
+msgstr "aprilie"
+
+#: id:25
+msgctxt "Auto context with id 25"
+msgid "May"
+msgstr "mai"
+
+#: id:26
+msgid "June"
+msgstr "iunie"
+
+#: id:27
+msgid "July"
+msgstr "iulie"
+
+#: id:28
+msgid "August"
+msgstr "august"
+
+#: id:29
+msgid "September"
+msgstr "septembrie"
+
+#: id:30
+msgid "October"
+msgstr "octombrie"
+
+#: id:31
+msgid "November"
+msgstr "noiembrie"
+
+#: id:32
+msgid "December"
+msgstr "decembrie"
+
+#: id:41
+msgid "Mon"
+msgstr "Lun"
+
+#: id:42
+msgid "Tue"
+msgstr "Mar"
+
+#: id:43
+msgid "Wed"
+msgstr "Mie"
+
+#: id:44
+msgid "Thu"
+msgstr "Joi"
+
+#: id:45
+msgid "Fri"
+msgstr "Vin"
+
+#: id:46
+msgid "Sat"
+msgstr "Sâm"
+
+#: id:47
+msgctxt "Auto context with id 47"
+msgid "Sun"
+msgstr "Dum"
+
+#: id:51
+msgid "Jan"
+msgstr "ian"
+
+#: id:52
+msgid "Feb"
+msgstr "feb"
+
+#: id:53
+msgid "Mar"
+msgstr "mar"
+
+#: id:54
+msgid "Apr"
+msgstr "apr"
+
+#: id:55
+msgctxt "Auto context with id 55"
+msgid "May"
+msgstr "mai"
+
+#: id:56
+msgid "Jun"
+msgstr "iun"
+
+#: id:57
+msgid "Jul"
+msgstr "iul"
+
+#: id:58
+msgid "Aug"
+msgstr "aug"
+
+#: id:59
+msgid "Sep"
+msgstr "sep"
+
+#: id:60
+msgid "Oct"
+msgstr "oct"
+
+#: id:61
+msgid "Nov"
+msgstr "nov"
+
+#: id:62
+msgid "Dec"
+msgstr "dec"
+
+#: id:71
+msgid "N"
+msgstr "N"
+
+#: id:72
+msgid "NNE"
+msgstr "NNE"
+
+#: id:73
+msgid "NE"
+msgstr "NE"
+
+#: id:74
+msgid "ENE"
+msgstr "ENE"
+
+#: id:75
+msgid "E"
+msgstr "E"
+
+#: id:76
+msgid "ESE"
+msgstr "ESE"
+
+#: id:77
+msgid "SE"
+msgstr "SE"
+
+#: id:78
+msgid "SSE"
+msgstr "SSE"
+
+#: id:79
+msgid "S"
+msgstr "S"
+
+#: id:80
+msgid "SSW"
+msgstr "SSV"
+
+#: id:81
+msgid "SW"
+msgstr "SV"
+
+#: id:82
+msgid "WSW"
+msgstr "VSV"
+
+#: id:83
+msgid "W"
+msgstr "V"
+
+#: id:84
+msgid "WNW"
+msgstr "VNV"
+
+#: id:85
+msgid "NW"
+msgstr "NV"
+
+#: id:86
+msgid "NNW"
+msgstr "NNV"
+
+#: id:87
+msgid "VAR"
+msgstr "VAR"
+
+#: id:98
+msgid "View: Auto"
+msgstr "Vizualizare: Automat"
+
+#: id:99
+msgid "View: Auto big"
+msgstr "Vizualizare: Automat mare"
+
+#: id:100
+msgid "View: Icons"
+msgstr "Vizualizare: Pictograme"
+
+#: id:101
+msgid "View: List"
+msgstr "Vizualizare: Listă"
+
+#: id:102
+msgctxt "Auto context with id 102"
+msgid "Scan"
+msgstr "Scanare"
+
+#: id:103
+msgctxt "Auto context with id 103"
+msgid "Sort by: Name"
+msgstr "Sort. după: Nume"
+
+#: id:104
+msgid "Sort by: Date"
+msgstr "Sort. după: Dată"
+
+#: id:105
+msgid "Sort by: Size"
+msgstr "Sort. după: Mărime"
+
+#: id:106
+msgid "No"
+msgstr "Nu"
+
+#: id:107
+msgid "Yes"
+msgstr "Da"
+
+#: id:108
+msgctxt "Auto context with id 108"
+msgid "Slideshow"
+msgstr "Start diapozitive"
+
+#: id:109
+msgid "Create thumbs"
+msgstr "Creează afișe"
+
+#: id:110
+msgid "Create thumbnails"
+msgstr "Creează miniaturi"
+
+#: id:111
+msgctxt "Auto context with id 111"
+msgid "Shortcuts"
+msgstr "Scurtături"
+
+#: id:112
+msgid "Paused"
+msgstr "Pauză"
+
+#: id:113
+msgid "Update failed"
+msgstr "Actualizarea a eșuat"
+
+#: id:114
+msgid "Installation failed"
+msgstr "Instalarea a eșuat"
+
+#: id:115
+msgid "Copy"
+msgstr "Copiază"
+
+#: id:116
+msgid "Move"
+msgstr "Mută"
+
+#: id:117
+msgid "Delete"
+msgstr "Șterge"
+
+#: id:118
+msgid "Rename"
+msgstr "Redenumește"
+
+#: id:119
+msgid "New folder"
+msgstr "Dosar nou"
+
+#: id:120
+msgid "Confirm file copy"
+msgstr "Confirmare copiere fișier"
+
+#: id:121
+msgid "Confirm file move"
+msgstr "Confirmare mutare fișier"
+
+#: id:122
+msgid "Confirm file delete?"
+msgstr "Confirmare ștergere fișier"
+
+#: id:123
+msgid "Copy these files?"
+msgstr "Copiați aceste fișiere?"
+
+#: id:124
+msgid "Move these files?"
+msgstr "Mutați aceste fișiere?"
+
+#: id:125
+msgid "Delete these files? - Deleting files cannot be undone!"
+msgstr "Sigur doriți să ștergeți acest fișier?\nATENȚIE: Ștergerea fișierelor nu poate fi anulată!"
+
+#: id:126
+msgid "Status"
+msgstr "Stare"
+
+#: id:127
+msgid "Objects"
+msgstr "Obiecte"
+
+#: id:128
+msgctxt "Auto context with id 128"
+msgid "General"
+msgstr "Generale"
+
+#: id:129
+msgctxt "Auto context with id 129"
+msgid "Slideshow"
+msgstr "Prezentare diapozitive"
+
+#: id:130
+msgctxt "Auto context with id 130"
+msgid "System info"
+msgstr "Informații sistem"
+
+#: id:131
+msgid "Display"
+msgstr "Ecran"
+
+#: id:132
+msgid "Albums"
+msgstr "Albume"
+
+#: id:133
+msgid "Artists"
+msgstr "Artiști"
+
+#: id:134
+msgid "Songs"
+msgstr "Cântece"
+
+#: id:135
+msgid "Genres"
+msgstr "Gen"
+
+#: id:136
+msgid "Playlists"
+msgstr "Liste de redare"
+
+#: id:137
+msgid "Search"
+msgstr "Caută"
+
+#: id:138
+msgid "System Information"
+msgstr "Informații sistem"
+
+#: id:139
+msgid "Temperatures:"
+msgstr "Temperaturi:"
+
+#: id:140
+msgid "CPU:"
+msgstr "CPU:"
+
+#: id:141
+msgid "GPU:"
+msgstr "GPU:"
+
+#: id:142
+msgid "Time:"
+msgstr "Oră:"
+
+#: id:143
+msgid "Current:"
+msgstr "Curent:"
+
+#: id:144
+msgid "Build:"
+msgstr "Versiune:"
+
+#: id:145
+msgid "Network:"
+msgstr "Rețea:"
+
+#: id:146
+msgid "Type:"
+msgstr "Tip:"
+
+#: id:147
+msgid "Static"
+msgstr "Static"
+
+#: id:148
+msgid "DHCP"
+msgstr "DHCP"
+
+#: id:149
+msgid "MAC address"
+msgstr "Adresă MAC"
+
+#: id:150
+msgctxt "Auto context with id 150"
+msgid "IP address"
+msgstr "Adresă IP"
+
+#: id:151
+msgid "Link:"
+msgstr "Legătură:"
+
+#: id:152
+msgid "Half duplex"
+msgstr "Half duplex"
+
+#: id:153
+msgid "Full duplex"
+msgstr "Full duplex"
+
+#: id:154
+msgctxt "Auto context with id 154"
+msgid "Storage"
+msgstr "Stocare"
+
+#: id:155
+msgid "Drive"
+msgstr "Drive"
+
+#: id:156
+msgctxt "Auto context with id 156"
+msgid "Free"
+msgstr "Liberă"
+
+#: id:157
+msgctxt "Auto context with id 157"
+msgid "Video"
+msgstr "Video"
+
+#: id:158
+msgid "Free memory"
+msgstr "Memorie liberă"
+
+#: id:159
+msgid "No link"
+msgstr "Fără legărură"
+
+#: id:160
+msgctxt "Auto context with id 160"
+msgid "Free"
+msgstr "liberi"
+
+#: id:161
+msgid "Unavailable"
+msgstr "Indisponibil"
+
+#: id:162
+msgid "Tray open"
+msgstr "Compartiment disc deschis"
+
+#: id:163
+msgid "Reading"
+msgstr "Se citește"
+
+#: id:164
+msgid "No disc"
+msgstr "Niciun disc"
+
+#: id:165
+msgid "Disc present"
+msgstr "Disc prezent"
+
+#: id:166
+msgid "Skin"
+msgstr "Costum"
+
+#: id:169
+msgctxt "Auto context with id 169"
+msgid "Resolution"
+msgstr "Rezoluție"
+
+#: id:170
+msgid "Adjust display refresh rate to match video"
+msgstr "Ajustează rată reîmprospătare ecran pentru potrivire cu video"
+
+#: id:172
+msgid "Release date"
+msgstr "Dată de lansare"
+
+#: id:173
+msgid "Display 4:3 videos as"
+msgstr "Afișează filmele 4:3 ca"
+
+#: id:175
+msgid "Moods"
+msgstr "Tonuri"
+
+#: id:176
+msgid "Styles"
+msgstr "Stiluri"
+
+#: id:179
+msgid "Song"
+msgstr "Cântec"
+
+#: id:180
+msgid "Duration"
+msgstr "Durată"
+
+#: id:181
+msgid "Select album"
+msgstr "Selectați album"
+
+#: id:182
+msgid "Tracks"
+msgstr "Piste"
+
+#: id:183
+msgid "Review"
+msgstr "Prezentare"
+
+#: id:184
+msgid "Refresh"
+msgstr "Actualizează"
+
+#: id:185
+msgid "Searching album"
+msgstr "Căutare album"
+
+#: id:186
+msgid "OK"
+msgstr "OK"
+
+#: id:187
+msgid "No albums found!"
+msgstr "Nu a fost găsit niciun album!"
+
+#: id:188
+msgid "Select all"
+msgstr "Selectează toate"
+
+#: id:189
+msgid "Scanning media info"
+msgstr "Se scanează informații media"
+
+#: id:190
+msgid "Save"
+msgstr "Salvează"
+
+#: id:191
+msgid "Shuffle"
+msgstr "Amestecă"
+
+#: id:192
+msgctxt "Auto context with id 192"
+msgid "Clear"
+msgstr "Golește"
+
+#: id:193
+msgctxt "Auto context with id 193"
+msgid "Scan"
+msgstr "Scanează"
+
+#: id:194
+msgid "Searching..."
+msgstr "Se caută..."
+
+#: id:195
+msgid "No info found!"
+msgstr "Nu s-au găsit informații!"
+
+#: id:196
+msgid "Select movie:"
+msgstr "Selectați filmul:"
+
+#: id:197
+msgid "Querying %s info"
+msgstr "Se cer informații pe %s"
+
+#: id:198
+msgid "Loading movie details"
+msgstr "Încărcare informații film"
+
+#: id:199
+msgid "Web interface"
+msgstr "Interfață web"
+
+#: id:202
+msgid "Tagline"
+msgstr "Citat"
+
+#: id:203
+msgid "Plot outline"
+msgstr "Scurtă descriere"
+
+#: id:205
+msgid "Votes"
+msgstr "Voturi"
+
+#: id:206
+msgid "Cast"
+msgstr "Distribuție"
+
+#: id:207
+msgid "Plot"
+msgstr "Intrigă"
+
+#: id:208
+msgctxt "Auto context with id 208"
+msgid "Play"
+msgstr "Redă"
+
+#: id:209
+msgid "Next"
+msgstr "Următorul"
+
+#: id:210
+msgid "Previous"
+msgstr "Precedentul"
+
+#: id:213
+msgid "Calibrate user interface..."
+msgstr "Calibrare interfață utilizator..."
+
+#: id:214
+msgid "Video calibration..."
+msgstr "Calibrare video..."
+
+#: id:215
+msgid "Soften"
+msgstr "Atenuare"
+
+#: id:216
+msgid "Zoom amount"
+msgstr "Grad de mărire"
+
+#: id:217
+msgid "Pixel ratio"
+msgstr "Raport pixel"
+
+#: id:218
+msgid "DVD drive"
+msgstr "Unitate DVD"
+
+#: id:219
+msgid "Please insert disc"
+msgstr "Inserați discul"
+
+#: id:220
+msgid "Remote share"
+msgstr "Partajare la distanță"
+
+#: id:221
+msgid "Network is not connected"
+msgstr "Nu există conectare la rețea"
+
+#: id:222
+msgid "Cancel"
+msgstr "Renunță"
+
+#: id:224
+msgid "Speed"
+msgstr "Viteză"
+
+#: id:225
+msgid "Vertical Shift"
+msgstr "Deplasare verticală"
+
+#: id:226
+msgid "Test patterns..."
+msgstr "Modele de testare..."
+
+#: id:227
+msgid "Lookup audio CD track names from freedb.org"
+msgstr "Caută nume piste CD audio pe freedb.org"
+
+#: id:228
+msgid "Shuffle playlist on load"
+msgstr "Amestecă lista de redare la încărcare"
+
+#: id:229
+msgid "HDD spindown time"
+msgstr "Timp încetinire HDD"
+
+#: id:230
+msgid "Video filters"
+msgstr "Filtre video"
+
+#: id:231
+msgctxt "Auto context with id 231"
+msgid "None"
+msgstr "Niciuna"
+
+#: id:232
+msgid "Point"
+msgstr "Punct"
+
+#: id:233
+msgid "Linear"
+msgstr "Liniar"
+
+#: id:234
+msgid "Anisotropic"
+msgstr "Anisotropic"
+
+#: id:235
+msgid "Quincunx"
+msgstr "Quincunx"
+
+#: id:236
+msgid "Gaussian cubic"
+msgstr "Gaussian cubic"
+
+#: id:237
+msgid "Minification"
+msgstr "Micșorare"
+
+#: id:238
+msgid "Magnification"
+msgstr "Mărire"
+
+#: id:239
+msgid "Clear playlist on finish"
+msgstr "La sfârșit curăță lista"
+
+#: id:240
+msgid "Display Mode"
+msgstr "Mod de afișare"
+
+#: id:241
+msgid "Full Screen #%d"
+msgstr "Ecran complet #%d"
+
+#: id:242
+msgid "Windowed"
+msgstr "În fereastră"
+
+#: id:243
+msgid "Refresh Rate"
+msgstr "Rată de reîmprospătare"
+
+#: id:244
+msgid "Full screen"
+msgstr "Ecran complet"
+
+#: id:245
+msgid "Sizing: (%i,%i)->(%i,%i) (Zoom x%2.2f) AR:%2.2f:1 (Pixels: %2.2f:1) (VShift: %2.2f)"
+msgstr "Dimensionare: (%i,%i)->(%i,%i) (zoom x%2.2f) AR:%2.2f:1 (pixeli: %2.2f:1) (DeplasareV: %2.2f)"
+
+#: id:247
+msgctxt "Auto context with id 247"
+msgid "Scripts"
+msgstr "Scripturi"
+
+#: id:248
+msgctxt "Auto context with id 248"
+msgid "Language"
+msgstr "Limbă"
+
+#: id:249
+msgctxt "Auto context with id 249"
+msgid "Music"
+msgstr "Muzică"
+
+#: id:250
+msgctxt "Auto context with id 250"
+msgid "Visualization"
+msgstr "Vizualizare"
+
+#: id:251
+msgid "Select destination directory"
+msgstr "Selectează dosarul destinație"
+
+#: id:252
+msgid "Output stereo to all speakers"
+msgstr "Scoate stereo în toate difuzoarele"
+
+#: id:253
+msgid "Number of channels"
+msgstr "Număr de canale"
+
+#: id:254
+msgid "- DTS capable receiver"
+msgstr "- Receptor capabil DTS"
+
+#: id:255
+msgid "CDDB"
+msgstr "CDDB"
+
+#: id:256
+msgid "Fetching CD information"
+msgstr "Culegere informații CD"
+
+#: id:257
+msgid "Error"
+msgstr "Eroare"
+
+#: id:258
+msgid "Enable tag reading"
+msgstr "Activează citire etichete"
+
+#: id:259
+msgid "Opening"
+msgstr "Se deschide"
+
+#: id:260
+msgid "Shoutcast"
+msgstr "Shoutcast"
+
+#: id:261
+msgid "Waiting for start..."
+msgstr "Se așteaptă începerea..."
+
+#: id:262
+msgid "Scripts output"
+msgstr "Ieșire scripturi"
+
+#: id:263
+msgid "Allow control of XBMC via HTTP"
+msgstr "Permite controlul XBMC prin HTTP"
+
+#: id:264
+msgid "Record"
+msgstr "Înregistrează"
+
+#: id:265
+msgid "Stop Rec."
+msgstr "Oprește înreg."
+
+#: id:266
+msgid "Sort by: Track"
+msgstr "Sort. după: Pistă"
+
+#: id:267
+msgid "Sort by: Time"
+msgstr "Sort. după: Timp"
+
+#: id:268
+msgid "Sort by: Title"
+msgstr "Sort. după: Titlu"
+
+#: id:269
+msgid "Sort by: Artist"
+msgstr "Sort. după: Artist"
+
+#: id:270
+msgid "Sort by: Album"
+msgstr "Sort. după: Album"
+
+#: id:271
+msgid "Top 100"
+msgstr "Top 100"
+
+#: id:272
+msgid "Top-Left overscan compensation"
+msgstr "Compensare suprascanare stânga-sus"
+
+#: id:273
+msgid "Bottom-Right overscan compensation"
+msgstr "Compensare suprascanare dreapta-jos"
+
+#: id:274
+msgid "Subtitle positioning"
+msgstr "Poziționare subtitrare"
+
+#: id:275
+msgid "Pixel ratio adjustment"
+msgstr "Ajustare raport pixel"
+
+#: id:276
+msgid "Adjust the arrow to change the amount of overscan"
+msgstr "Ajustați săgeata pentru a modifica gradul de suprascanare"
+
+#: id:277
+msgid "Adjust the bar to change the subtitles position"
+msgstr "Ajustați bara pe verticală pentru a modifica poziția afișării subtitrărilor"
+
+#: id:278
+msgid "Adjust the rectangle so it is perfectly square"
+msgstr "Ajustați dreptunghiul până ce devine un pătrat perfect"
+
+#: id:279
+msgid "Unable to load settings"
+msgstr "Nu s-au putut încărca setăriile"
+
+#: id:280
+msgid "Using default settings"
+msgstr "Se folosesc setările implicite"
+
+#: id:281
+msgid "Please check the XML files"
+msgstr "Verificați fișierele XML"
+
+#: id:282
+msgid "Found %i items"
+msgstr "S-au găsit %i elemente"
+
+#: id:283
+msgid "Search results"
+msgstr "Rezultate căutare"
+
+#: id:284
+msgid "No results found"
+msgstr "Nu s-au găsit rezultate."
+
+#: id:287
+msgctxt "Auto context with id 287"
+msgid "Subtitles"
+msgstr "Subtitrări"
+
+#: id:288
+msgctxt "Auto context with id 288"
+msgid "Font"
+msgstr "Font"
+
+#: id:289
+msgctxt "Auto context with id 289"
+msgid "- Size"
+msgstr "- Dimensiune"
+
+#: id:290
+msgid "Dynamic range compression"
+msgstr "Comprimare interval dinamic"
+
+#: id:291
+msgctxt "Auto context with id 291"
+msgid "Video"
+msgstr "Video"
+
+#: id:292
+msgctxt "Auto context with id 292"
+msgid "Audio"
+msgstr "Audio"
+
+#: id:293
+msgid "Browse for subtitles"
+msgstr "Alegere subtitrare"
+
+#: id:294
+msgid "Create bookmark"
+msgstr "Creează semn de carte"
+
+#: id:296
+msgid "Clear bookmarks"
+msgstr "Elimină semne de carte"
+
+#: id:297
+msgid "Audio offset"
+msgstr "Decalaj audio"
+
+#: id:298
+msgid "Bookmarks"
+msgstr "Semne de carte"
+
+#: id:299
+msgid "- AAC capable receiver"
+msgstr "- Receptor capabil AAC"
+
+#: id:300
+msgid "- MP1 capable receiver"
+msgstr "- Receptor capabil MP1"
+
+#: id:301
+msgid "- MP2 capable receiver"
+msgstr "- Receptor capabil MP2"
+
+#: id:302
+msgid "- MP3 capable receiver"
+msgstr "- Receptor capabil MP3"
+
+#: id:303
+msgid "Delay"
+msgstr "Întârziere"
+
+#: id:304
+msgctxt "Auto context with id 304"
+msgid "Language"
+msgstr "Limbă"
+
+#: id:305
+msgctxt "Auto context with id 305"
+msgid "Enabled"
+msgstr "Activat"
+
+#: id:306
+msgid "Non-interleaved"
+msgstr "Non-intercalat"
+
+#: id:312
+msgid "(0=auto)"
+msgstr "(0=automat)"
+
+#: id:313
+msgid "Cleaning database"
+msgstr "Curățare bază de date"
+
+#: id:314
+msgid "Preparing..."
+msgstr "Pregătire..."
+
+#: id:315
+msgid "Database error"
+msgstr "Eroare bază de date"
+
+#: id:316
+msgid "Searching songs..."
+msgstr "Se caută cântece..."
+
+#: id:317
+msgid "Cleaned database successfully"
+msgstr "Reorganizarea bazei de date s-a încheiat cu succes"
+
+#: id:318
+msgid "Cleaning songs..."
+msgstr "Reorganizare cântece..."
+
+#: id:319
+msgid "Error cleaning songs"
+msgstr "Eroare reorganizare cântece"
+
+#: id:320
+msgid "Cleaning artists..."
+msgstr "Reorganizare artiști..."
+
+#: id:321
+msgid "Error cleaning artists"
+msgstr "Eroare reorganizare artiști"
+
+#: id:322
+msgid "Cleaning genres..."
+msgstr "Reorganizare genuri..."
+
+#: id:323
+msgid "Error cleaning genres"
+msgstr "Eroare reorganizare genuri"
+
+#: id:324
+msgid "Cleaning paths..."
+msgstr "Reorganizare căi..."
+
+#: id:325
+msgid "Error cleaning paths"
+msgstr "Eroare reorganizare căi"
+
+#: id:326
+msgid "Cleaning albums..."
+msgstr "Reorganizare albume..."
+
+#: id:327
+msgid "Error cleaning albums"
+msgstr "Eroare reorganizare albume"
+
+#: id:328
+msgid "Writing changes..."
+msgstr "Se scriu modificările..."
+
+#: id:329
+msgid "Error writing changes"
+msgstr "Eroare la scriere modificări"
+
+#: id:330
+msgid "This may take some time..."
+msgstr "S-ar putea să dureze ceva timp..."
+
+#: id:331
+msgid "Compressing database..."
+msgstr "Se comprimă baza de date..."
+
+#: id:332
+msgid "Error compressing database"
+msgstr "Eroare comprimare bază de date"
+
+#: id:333
+msgid "Do you want to clean the library?"
+msgstr "Doriți să curățați mediateca?"
+
+#: id:334
+msgid "Clean library..."
+msgstr "Curățare mediatecă..."
+
+#: id:335
+msgid "Start"
+msgstr "Pornește"
+
+#: id:336
+msgid "Framerate conversion"
+msgstr "Conversie rată de cadre"
+
+#: id:337
+msgctxt "Auto context with id 337"
+msgid "Audio output"
+msgstr "Ieșire audio"
+
+#: id:338
+msgid "Analog"
+msgstr "Analog"
+
+#: id:339
+msgid "Optical/Coax"
+msgstr "Optical/Coax"
+
+#: id:340
+msgid "Various artists"
+msgstr "Artiști diferiți"
+
+#: id:341
+msgid "Play disc"
+msgstr "Redă discul"
+
+#: id:342
+msgctxt "Auto context with id 342"
+msgid "Movies"
+msgstr "Filme"
+
+#: id:343
+msgid "Adjust framerate"
+msgstr "Ajustează rata de cadre"
+
+#: id:344
+msgid "Actors"
+msgstr "Actori"
+
+#: id:345
+msgctxt "Auto context with id 345"
+msgid "Year"
+msgstr "An"
+
+#: id:346
+msgid "Boost volume level on downmix"
+msgstr "Amplifică volumul când numărul de canale este micșorat"
+
+#: id:350
+msgctxt "Auto context with id 350"
+msgid "Programs"
+msgstr "Programe"
+
+#: id:351
+msgctxt "Auto context with id 351"
+msgid "Off"
+msgstr "Oprit"
+
+#: id:352
+msgid "Dim"
+msgstr "Întunecat"
+
+#: id:353
+msgid "Black"
+msgstr "Negru"
+
+#: id:354
+msgid "Matrix trails"
+msgstr "Matrix"
+
+#: id:355
+msgid "Screensaver time"
+msgstr "Așteptare pentru activare protector ecran"
+
+#: id:356
+msgid "Screensaver mode"
+msgstr "Protector ecran"
+
+#: id:357
+msgid "Shutdown function timer"
+msgstr "Timp de așteptare pentru închidere"
+
+#: id:358
+msgid "All albums"
+msgstr "Toate albumele"
+
+#: id:359
+msgid "Recently added albums"
+msgstr "Albume adăugate recent"
+
+#: id:360
+msgctxt "Auto context with id 360"
+msgid "Screensaver"
+msgstr "Protector ecran"
+
+#: id:361
+msgid "R. Slideshow"
+msgstr "Prezentare recurs."
+
+#: id:362
+msgid "Screensaver dim level"
+msgstr "Nivel de întunecare protector ecran"
+
+#: id:363
+msgid "Sort by: File"
+msgstr "Sortează după: Fișier"
+
+#: id:364
+msgid "- Dolby Digital (AC3) capable receiver"
+msgstr "- Receptor capabil Dolby Digital (AC3)"
+
+#: id:365
+msgctxt "Auto context with id 365"
+msgid "Sort by: Name"
+msgstr "Sortează după: Nume"
+
+#: id:366
+msgid "Sort by: Year"
+msgstr "Sortează după: An"
+
+#: id:367
+msgid "Sort by: Rating"
+msgstr "Sortează după: Notă"
+
+#: id:368
+msgid "IMDb"
+msgstr "IMDb"
+
+#: id:369
+msgctxt "Auto context with id 369"
+msgid "Title"
+msgstr "Nume"
+
+#: id:370
+msgid "Thunderstorms"
+msgstr "furtuni(cu trăznete)"
+
+#: id:371
+msgid "Partly"
+msgstr "parțial"
+
+#: id:372
+msgid "Mostly"
+msgstr "în general"
+
+#: id:373
+msgid "Sunny"
+msgstr "însorit"
+
+#: id:374
+msgid "Cloudy"
+msgstr "înnorat"
+
+#: id:375
+msgid "Snow"
+msgstr "ninsoare"
+
+#: id:376
+msgid "Rain"
+msgstr "ploaie"
+
+#: id:377
+msgid "Light"
+msgstr "slab"
+
+#: id:378
+msgid "AM"
+msgstr "AM"
+
+#: id:379
+msgid "PM"
+msgstr "PM"
+
+#: id:380
+msgid "Showers"
+msgstr "averse de ploaie"
+
+#: id:381
+msgid "Few"
+msgstr "slab"
+
+#: id:382
+msgid "Scattered"
+msgstr "pe alocuri"
+
+#: id:383
+msgctxt "Auto context with id 383"
+msgid "Wind"
+msgstr "vânt"
+
+#: id:384
+msgid "Strong"
+msgstr "puternic"
+
+#: id:385
+msgid "Fair"
+msgstr "senin"
+
+#: id:386
+msgctxt "Auto context with id 386"
+msgid "Clear"
+msgstr "senin"
+
+#: id:387
+msgid "Clouds"
+msgstr "nori"
+
+#: id:388
+msgid "Early"
+msgstr "devreme"
+
+#: id:389
+msgid "Shower"
+msgstr "aversă de ploaie"
+
+#: id:390
+msgid "Flurries"
+msgstr "ninsoare"
+
+#: id:391
+msgctxt "Auto context with id 391"
+msgid "Low"
+msgstr "scăzut"
+
+#: id:392
+msgctxt "Auto context with id 392"
+msgid "Medium"
+msgstr "mediu"
+
+#: id:393
+msgctxt "Auto context with id 393"
+msgid "High"
+msgstr "ridicat"
+
+#: id:394
+msgid "Fog"
+msgstr "ceață"
+
+#: id:395
+msgid "Haze"
+msgstr "ceață ușoară"
+
+#: id:396
+msgid "Select location"
+msgstr "Selectați locație"
+
+#: id:397
+msgid "Refresh time"
+msgstr "Interval de reîmprospătare"
+
+#: id:398
+msgid "Temperature units"
+msgstr "Unități de măsurare temperatură"
+
+#: id:399
+msgid "Speed units"
+msgstr "Unități de măsurare viteză"
+
+#: id:400
+msgctxt "Auto context with id 400"
+msgid "Weather"
+msgstr "Meteo"
+
+#: id:401
+msgid "Temp"
+msgstr "Temp"
+
+#: id:402
+msgid "Feels like"
+msgstr "Se simte"
+
+#: id:403
+msgid "UV index"
+msgstr "Index UV"
+
+#: id:404
+msgctxt "Auto context with id 404"
+msgid "Wind"
+msgstr "Vânt"
+
+#: id:405
+msgid "Dew point"
+msgstr "Punct de rouă"
+
+#: id:406
+msgid "Humidity"
+msgstr "Umiditate"
+
+#: id:409
+msgid "Defaults"
+msgstr "Implicit"
+
+#: id:410
+msgid "Accessing weather service"
+msgstr "Se accesează serviciul de prognoză"
+
+#: id:411
+msgid "Getting weather for:"
+msgstr "Se obține prognoza pentru:"
+
+#: id:412
+msgid "Unable to get weather data"
+msgstr "Nu se pot obține date despre vreme."
+
+#: id:413
+msgid "Manual"
+msgstr "Manual"
+
+#: id:414
+msgid "No review for this album"
+msgstr "Nicio prezentare pentru acest album."
+
+#: id:415
+msgid "Downloading thumbnail..."
+msgstr "Se descarcă miniatura..."
+
+#: id:416
+msgid "Not available"
+msgstr "Indisponibil"
+
+#: id:417
+msgid "View: Big icons"
+msgstr "Afișare: Pictograme mari"
+
+#: id:418
+msgctxt "Auto context with id 418"
+msgid "Low"
+msgstr "Minim"
+
+#: id:419
+msgctxt "Auto context with id 419"
+msgid "High"
+msgstr "Maxim"
+
+#: id:420
+msgid "HDMI"
+msgstr "HDMI"
+
+#: id:422
+msgid "Delete album info"
+msgstr "Șterge informații album"
+
+#: id:423
+msgid "Delete CD information"
+msgstr "Șterge informații CD"
+
+#: id:424
+msgid "Select"
+msgstr "Selectează"
+
+#: id:425
+msgid "No album information found"
+msgstr "Nu s-au găsit informații album"
+
+#: id:426
+msgid "No CD information found"
+msgstr "Nu s-au găsit informații CD"
+
+#: id:427
+msgid "Disc"
+msgstr "Disc"
+
+#: id:428
+msgid "Insert correct CD/DVD"
+msgstr "Inserați CD-ul/DVD-ul corect"
+
+#: id:429
+msgid "Please insert the following disc:"
+msgstr "Inserați următorul disc:"
+
+#: id:430
+msgid "Sort by: DVD#"
+msgstr "Sortează după: DVD#"
+
+#: id:431
+msgid "No cache"
+msgstr "Fără cache"
+
+#: id:432
+msgid "Remove movie from library"
+msgstr "Eliminare film din mediatecă"
+
+#: id:433
+msgid "Really remove '%s'?"
+msgstr "Sigur eliminați '%s'?"
+
+#: id:434
+msgid "From %s at %i %s"
+msgstr "Dinspre %s cu %i %s"
+
+#: id:437
+msgid "Removable disk"
+msgstr "Disc detașabil"
+
+#: id:438
+msgid "Opening file"
+msgstr "Se deschide fișierul"
+
+#: id:439
+msgid "Cache"
+msgstr "Stocare în avans"
+
+#: id:440
+msgid "Harddisk"
+msgstr "Disc dur"
+
+#: id:441
+msgid "UDF"
+msgstr "UDF"
+
+#: id:442
+msgid "Local network"
+msgstr "Rețea locală"
+
+#: id:443
+msgid "Internet"
+msgstr "Internet"
+
+#: id:444
+msgctxt "Auto context with id 444"
+msgid "Video"
+msgstr "Video"
+
+#: id:445
+msgctxt "Auto context with id 445"
+msgid "Audio"
+msgstr "Audio"
+
+#: id:446
+msgctxt "Auto context with id 446"
+msgid "DVD"
+msgstr "DVD"
+
+#: id:447
+msgid "Autorun media"
+msgstr "Redare media automat"
+
+#: id:448
+msgid "LCD"
+msgstr "LCD"
+
+#: id:449
+msgctxt "Auto context with id 449"
+msgid "Enabled"
+msgstr "Activat"
+
+#: id:450
+msgid "Columns"
+msgstr "Coloane"
+
+#: id:451
+msgid "Row 1 address"
+msgstr "Adresă rând 1"
+
+#: id:452
+msgid "Row 2 address"
+msgstr "Adresă rând 2"
+
+#: id:453
+msgid "Row 3 address"
+msgstr "Adresă rând 3"
+
+#: id:454
+msgid "Row 4 address"
+msgstr "Adresă rând 4"
+
+#: id:455
+msgid "Rows"
+msgstr "Rânduri"
+
+#: id:456
+msgid "Mode"
+msgstr "Mod"
+
+#: id:457
+msgid "Switch view"
+msgstr "Schimbă vizualizarea"
+
+#: id:459
+msgid "Subs"
+msgstr "Subtitrări"
+
+#: id:460
+msgid "Audio stream"
+msgstr "Flux audio"
+
+#: id:461
+msgid "[active]"
+msgstr "[activ]"
+
+#: id:462
+msgid "Subtitle"
+msgstr "Subtitrare"
+
+#: id:463
+msgid "Backlight"
+msgstr "Iluminare din spate"
+
+#: id:464
+msgid "Brightness"
+msgstr "Luminozitate"
+
+#: id:465
+msgid "Contrast"
+msgstr "Contrast"
+
+#: id:466
+msgid "Gamma"
+msgstr "Gamma"
+
+#: id:467
+msgctxt "Auto context with id 467"
+msgid "Type"
+msgstr "Tip"
+
+#: id:468
+msgid "Move the bar to change the OSD position"
+msgstr "Mutați bara pentru schimbarea poziției OSD"
+
+#: id:469
+msgid "OSD position"
+msgstr "Poziție OSD"
+
+#: id:470
+msgid "Credits"
+msgstr "Autori"
+
+#: id:471
+msgid "Modchip"
+msgstr "Modchip"
+
+#: id:474
+msgctxt "Auto context with id 474"
+msgid "Off"
+msgstr "Oprit"
+
+#: id:475
+msgid "Music only"
+msgstr "Doar muzică"
+
+#: id:476
+msgctxt "Auto context with id 476"
+msgid "Music & video"
+msgstr "Muzică și video"
+
+#: id:477
+msgid "Unable to load playlist"
+msgstr "Nu s-a putut încărca lista de redare"
+
+#: id:478
+msgid "OSD"
+msgstr "OSD"
+
+#: id:479
+msgid "Skin & language"
+msgstr "Costum și limbă"
+
+#: id:480
+msgid "Appearance"
+msgstr "Aspect"
+
+#: id:481
+msgid "Audio options"
+msgstr "Opțiuni audio"
+
+#: id:482
+msgid "About XBMC"
+msgstr "Despre XBMC"
+
+#: id:485
+msgid "Delete album"
+msgstr "Șterge album"
+
+#: id:486
+msgid "Repeat"
+msgstr "Repetă"
+
+#: id:487
+msgid "Repeat one"
+msgstr "Repetă odată"
+
+#: id:488
+msgid "Repeat folder"
+msgstr "Repetă dosar"
+
+#: id:489
+msgid "Play the next song automatically"
+msgstr "Redă automat următorul cântec"
+
+#: id:491
+msgid "- Use big icons"
+msgstr "- Folosește pictograme mari"
+
+#: id:492
+msgid "Resize VobSubs"
+msgstr "Redimensionază VobSubs"
+
+#: id:493
+msgid "Advanced options (Experts Only!)"
+msgstr "Opțiuni avansate (Doar experții!)"
+
+#: id:494
+msgid "Overall audio headroom"
+msgstr "Headroom audio per total"
+
+#: id:495
+msgid "Upsample videos to GUI resolution"
+msgstr "Mărește fișierele videos pâna la rezoluția GUI"
+
+#: id:496
+msgid "Calibration"
+msgstr "Calibrare"
+
+#: id:497
+msgid "Show file extensions"
+msgstr "Arată extensiile fișierelor"
+
+#: id:498
+msgid "Sort by: Type"
+msgstr "Sortează după: Tip"
+
+#: id:499
+msgid "Unable to connect to online lookup service"
+msgstr "Imposibil de conectat la serviciul de căutare online"
+
+#: id:500
+msgid "Downloading album information failed"
+msgstr "Descărcarea informațiilor album a eșuat"
+
+#: id:501
+msgid "Looking for album names..."
+msgstr "Se caută nume albume..."
+
+#: id:502
+msgctxt "Auto context with id 502"
+msgid "Open"
+msgstr "Deschide"
+
+#: id:503
+msgid "Busy"
+msgstr "se verifică"
+
+#: id:504
+msgid "Empty"
+msgstr "Gol"
+
+#: id:505
+msgid "Loading media info from files..."
+msgstr "Extragere informații media din fișiere..."
+
+#: id:507
+msgid "Sort by: Usage"
+msgstr "Sortează după: Utilizare"
+
+#: id:510
+msgid "Enable visualizations"
+msgstr "Activează vizualizări"
+
+#: id:511
+msgid "Enable video mode switching"
+msgstr "Activează schimbare mod video"
+
+#: id:512
+msgid "Startup window"
+msgstr "Fereastră de pornire"
+
+#: id:513
+msgid "Home window"
+msgstr "Fereastră inițială"
+
+#: id:514
+msgid "Manual settings"
+msgstr "Setări manuale"
+
+#: id:515
+msgid "Genre"
+msgstr "Gen"
+
+#: id:517
+msgid "Recently played albums"
+msgstr "Albume redate recent"
+
+#: id:518
+msgid "Launch"
+msgstr "Lansează"
+
+#: id:519
+msgid "Launch in..."
+msgstr "Lansează în..."
+
+#: id:521
+msgid "Compilations"
+msgstr "Compilații"
+
+#: id:522
+msgid "Remove source"
+msgstr "Elimină sursa"
+
+#: id:523
+msgid "Switch media"
+msgstr "Schimbă media"
+
+#: id:524
+msgid "Select playlist"
+msgstr "Selectează lista de redare"
+
+#: id:525
+msgid "New playlist..."
+msgstr "Listă de redare nouă..."
+
+#: id:526
+msgid "Add to playlist"
+msgstr "Adaugă în lista de redare"
+
+#: id:527
+msgid "Manually add to library"
+msgstr "Adaugă în mediatecă manual"
+
+#: id:528
+msgid "Enter title"
+msgstr "Introduceți titlu"
+
+#: id:529
+msgid "Error: Duplicate title"
+msgstr "Eroare: Titlu duplicat"
+
+#: id:530
+msgid "Select genre"
+msgstr "Selectați gen"
+
+#: id:531
+msgid "New genre"
+msgstr "Gen nou"
+
+#: id:532
+msgid "Manual addition"
+msgstr "Adăugare manuală"
+
+#: id:533
+msgid "Enter genre"
+msgstr "Introduceți gen"
+
+#: id:534
+msgid "View: %s"
+msgstr "Afișare: %s"
+
+#: id:535
+msgid "List"
+msgstr "Listă"
+
+#: id:536
+msgid "Icons"
+msgstr "Imagini"
+
+#: id:537
+msgid "Big list"
+msgstr "Listă mare"
+
+#: id:538
+msgid "Big icons"
+msgstr "Pictograme mari"
+
+#: id:539
+msgid "Wide"
+msgstr "Lat"
+
+#: id:540
+msgid "Big wide"
+msgstr "Lat mare"
+
+#: id:541
+msgid "Album icons"
+msgstr "Pictograme album"
+
+#: id:542
+msgid "DVD icons"
+msgstr "Pictograme DVD"
+
+#: id:543
+msgctxt "Auto context with id 543"
+msgid "DVD"
+msgstr "DVD"
+
+#: id:544
+msgctxt "Auto context with id 544"
+msgid "Media info"
+msgstr "Info media"
+
+#: id:545
+msgid "Audio output device"
+msgstr "Dispozitiv de ieșire audio"
+
+#: id:546
+msgid "Passthrough output device"
+msgstr "Dispozitiv prin care trece audio"
+
+#: id:547
+msgid "No biography for this artist"
+msgstr "Nu există biografie pentru acest artist."
+
+#: id:548
+msgid "Downmix multichannel audio to stereo"
+msgstr "Micșorează audio multi-canal către stereo"
+
+#: id:550
+msgid "Sort by: %s"
+msgstr "Sort. după: %s"
+
+#: id:551
+msgctxt "Auto context with id 551"
+msgid "Name"
+msgstr "Nume"
+
+#: id:552
+msgid "Date"
+msgstr "Dată"
+
+#: id:553
+msgid "Size"
+msgstr "Mărime"
+
+#: id:554
+msgid "Track"
+msgstr "Pistă"
+
+#: id:555
+msgid "Time"
+msgstr "Durată"
+
+#: id:556
+msgctxt "Auto context with id 556"
+msgid "Title"
+msgstr "Titlu"
+
+#: id:557
+msgid "Artist"
+msgstr "Artist"
+
+#: id:558
+msgid "Album"
+msgstr "Album"
+
+#: id:559
+msgid "Playlist"
+msgstr "Listă de redare"
+
+#: id:560
+msgid "ID"
+msgstr "ID"
+
+#: id:561
+msgctxt "Auto context with id 561"
+msgid "File"
+msgstr "Fișier"
+
+#: id:562
+msgctxt "Auto context with id 562"
+msgid "Year"
+msgstr "An"
+
+#: id:563
+msgid "Rating"
+msgstr "Notă"
+
+#: id:564
+msgctxt "Auto context with id 564"
+msgid "Type"
+msgstr "Tip"
+
+#: id:565
+msgid "Usage"
+msgstr "Utilizare"
+
+#: id:566
+msgid "Album artist"
+msgstr "Artist album"
+
+#: id:567
+msgid "Play count"
+msgstr "Număr de redări"
+
+#: id:568
+msgid "Last played"
+msgstr "Ultima redare"
+
+#: id:569
+msgctxt "Auto context with id 569"
+msgid "Comment"
+msgstr "Comentariu"
+
+#: id:570
+msgid "Date added"
+msgstr "Data adăugării"
+
+#: id:571
+msgctxt "Auto context with id 571"
+msgid "Default"
+msgstr "Implicit"
+
+#: id:572
+msgid "Studio"
+msgstr "Studio"
+
+#: id:573
+msgid "Path"
+msgstr "Cale"
+
+#: id:574
+msgctxt "Auto context with id 574"
+msgid "Country"
+msgstr "Țară"
+
+#: id:575
+msgid "In progress"
+msgstr "În progres"
+
+#: id:576
+msgid "Times played"
+msgstr "Număr redări"
+
+#: id:580
+msgid "Sort direction"
+msgstr "Direcție de sortare"
+
+#: id:581
+msgid "Sort method"
+msgstr "Metodă de sortare"
+
+#: id:582
+msgctxt "Auto context with id 582"
+msgid "View mode"
+msgstr "Mod de vizualizare"
+
+#: id:583
+msgid "Remember views for different folders"
+msgstr "Memorează vizualizările pentru dosare diferite"
+
+#: id:584
+msgid "Ascending"
+msgstr "Ascendent"
+
+#: id:585
+msgid "Descending"
+msgstr "Descendent"
+
+#: id:586
+msgid "Edit playlist"
+msgstr "Modifică lista de redare"
+
+#: id:587
+msgid "Filter"
+msgstr "Filtrează"
+
+#: id:588
+msgid "Cancel party mode"
+msgstr "Renunță la mod petrecere"
+
+#: id:589
+msgid "Party mode"
+msgstr "Mod petrecere"
+
+#: id:590
+msgid "Random"
+msgstr "Aleator"
+
+#: id:591
+msgctxt "Auto context with id 591"
+msgid "Off"
+msgstr "Oprit"
+
+#: id:592
+msgid "One"
+msgstr "una"
+
+#: id:593
+msgid "All"
+msgstr "toate"
+
+#: id:594
+msgctxt "Auto context with id 594"
+msgid "Off"
+msgstr "oprit"
+
+#: id:595
+msgid "Repeat: Off"
+msgstr "Repetă: oprit"
+
+#: id:596
+msgid "Repeat: One"
+msgstr "Repetă: una"
+
+#: id:597
+msgid "Repeat: All"
+msgstr "Repetă: toate"
+
+#: id:600
+msgid "Rip audio CD"
+msgstr "Copiază CD audio"
+
+#: id:601
+msgctxt "Auto context with id 601"
+msgid "Medium"
+msgstr "medie"
+
+#: id:602
+msgctxt "Auto context with id 602"
+msgid "Standard"
+msgstr "standard"
+
+#: id:603
+msgid "Extreme"
+msgstr "extremă"
+
+#: id:604
+msgid "Constant bitrate"
+msgstr "rată de biți constantă"
+
+#: id:605
+msgid "Ripping..."
+msgstr "Se copiază..."
+
+#: id:607
+msgid "To:"
+msgstr "Către:"
+
+#: id:608
+msgid "Could not rip CD or track"
+msgstr "Nu se poate copia CD-ul sau pista"
+
+#: id:609
+msgid "CDDARipPath is not set."
+msgstr "CDDARipPath nu este setat."
+
+#: id:610
+msgid "Rip audio track"
+msgstr "Copiază pistă audio"
+
+#: id:611
+msgid "Enter number"
+msgstr "Introduceți număr"
+
+#: id:612
+msgid "Bits/Sample"
+msgstr "Biți/Eșantion"
+
+#: id:613
+msgid "Sample Frequency"
+msgstr "Frecvență de eșantionare"
+
+#: id:620
+msgid "Audio CDs"
+msgstr "CD-uri audio"
+
+#: id:621
+msgid "Encoder"
+msgstr "Codor"
+
+#: id:622
+msgid "Quality"
+msgstr "Calitate"
+
+#: id:623
+msgid "Bitrate"
+msgstr "Rată de biți"
+
+#: id:624
+msgid "Include track number"
+msgstr "Include număr pistă"
+
+#: id:625
+msgid "All songs of"
+msgstr "Toate cântecele din"
+
+#: id:629
+msgctxt "Auto context with id 629"
+msgid "View mode"
+msgstr "Mod de vizualizare"
+
+#: id:630
+msgctxt "Auto context with id 630"
+msgid "Normal"
+msgstr "Normal"
+
+#: id:631
+msgid "Zoom"
+msgstr "Zoom"
+
+#: id:632
+msgid "Stretch 4:3"
+msgstr "Întinde la 4:3"
+
+#: id:633
+msgid "Wide Zoom"
+msgstr "Zoom lat"
+
+#: id:634
+msgid "Stretch 16:9"
+msgstr "Întinde la 16:9"
+
+#: id:635
+msgid "Original Size"
+msgstr "Dimensiune originală"
+
+#: id:636
+msgctxt "Auto context with id 636"
+msgid "Custom"
+msgstr "Particularizat"
+
+#: id:637
+msgid "Replay gain"
+msgstr "Normalizare sunet"
+
+#: id:638
+msgid "Replaygain volume adjustments"
+msgstr "Ajustări volum normalizare sunet"
+
+#: id:639
+msgid "Use track levels"
+msgstr "Folosește nivele pistă"
+
+#: id:640
+msgid "Use album levels"
+msgstr "Folosește nivele album"
+
+#: id:641
+msgid "PreAmp Level - Replay gained files"
+msgstr "Nivel PreAmp - Fișiere normalizate audio"
+
+#: id:642
+msgid "PreAmp Level - Non replay gained files"
+msgstr "Nivel PreAmp - Fișiere ne-normalizate audio"
+
+#: id:643
+msgid "Avoid clipping on replay gained files"
+msgstr "Evită distorsiunile în fișierele normalizate audio"
+
+#: id:644
+msgid "Crop black bars"
+msgstr "Elimină benzile negre"
+
+#: id:645
+msgid "Need to unpack a big file. Continue?"
+msgstr "Un fișier mare trebuie dezarhivat. Continuați?"
+
+#: id:646
+msgid "Remove from library"
+msgstr "Elimină din mediatecă"
+
+#: id:647
+msgid "Export video library"
+msgstr "Exportă mediateca video"
+
+#: id:648
+msgid "Import video library"
+msgstr "Importă mediatecă"
+
+#: id:649
+msgid "Importing"
+msgstr "Se importă"
+
+#: id:650
+msgid "Exporting"
+msgstr "Se exportă"
+
+#: id:651
+msgid "Browse for library"
+msgstr "Alegere mediatecă"
+
+#: id:652
+msgid "Years"
+msgstr "An"
+
+#: id:653
+msgid "Update library"
+msgstr "Actualizează mediateca"
+
+#: id:654
+msgid "Show debug info"
+msgstr "Arată informații de depanare"
+
+#: id:655
+msgid "Browse for executable"
+msgstr "Alegere executabil"
+
+#: id:656
+msgid "Browse for playlist"
+msgstr "Alegere listă de redare"
+
+#: id:657
+msgid "Browse for folder"
+msgstr "Alegere dosar"
+
+#: id:658
+msgid "Song information"
+msgstr "Informații cântec"
+
+#: id:659
+msgid "Non-linear stretch"
+msgstr "Întindere non-liniară"
+
+#: id:660
+msgid "Volume amplification"
+msgstr "Amplificare volum"
+
+#: id:661
+msgid "Choose export folder"
+msgstr "Alegere dosar de export"
+
+#: id:662
+msgid "This file is no longer available."
+msgstr "Acest fișier nu mai este disponibil."
+
+#: id:663
+msgid "Would you like to remove it from the library?"
+msgstr "Doriți să îl eliminați din mediatecă?"
+
+#: id:664
+msgid "Browse for Script"
+msgstr "Caută script"
+
+#: id:665
+msgid "Compression level"
+msgstr "Nivel de comprimare"
+
+#: id:700
+msgid "Cleaning up library"
+msgstr "Se curăță mediateca"
+
+#: id:701
+msgid "Removing old songs from the library"
+msgstr "Se elimină cântecele vechi din mediatecă"
+
+#: id:702
+msgid "This path has been scanned before"
+msgstr "Această cale a mai fost scanată"
+
+#: id:705
+msgctxt "Auto context with id 705"
+msgid "Network"
+msgstr "Rețea"
+
+#: id:706
+msgid "- Server"
+msgstr "- Server"
+
+#: id:708
+msgid "Use an HTTP proxy server to access the internet"
+msgstr "Folosește un server proxy HTTP pentru accesul la Internet"
+
+#: id:711
+msgid "Internet Protocol (IP)"
+msgstr "Internet Protocol (IP)"
+
+#: id:712
+msgid "Invalid port specified. Value must be between 1 and 65535."
+msgstr "Portul specificat nu este valid. Valoarea trebuie să fie între 1 și 65535."
+
+#: id:713
+msgid "HTTP proxy"
+msgstr "Proxy HTTP"
+
+#: id:715
+msgid "- Assignment"
+msgstr "- Atribuire"
+
+#: id:716
+msgid "Automatic (DHCP)"
+msgstr "Automat (DHCP)"
+
+#: id:717
+msgid "Manual (Static)"
+msgstr "Manual (static)"
+
+#: id:719
+msgid "- IP address"
+msgstr "- Adresă IP"
+
+#: id:720
+msgid "- Netmask"
+msgstr "- Mască de rețea"
+
+#: id:721
+msgid "- Default gateway"
+msgstr "- Gateway implicit"
+
+#: id:722
+msgid "- DNS server"
+msgstr "- Server DNS"
+
+#: id:723
+msgid "Save & restart"
+msgstr "Salvează și repornește"
+
+#: id:724
+msgid "Invalid address specified. Value must be AAA.BBB.CCC.DDD"
+msgstr "Adresa specificată nu este validă. Standardul este AAA.BBB.CCC.DDD"
+
+#: id:725
+msgid "with numbers between 0 and 255."
+msgstr "cu numere între 0 și 255."
+
+#: id:726
+msgid "Changes not saved. Continue without saving?"
+msgstr "Modificările nu au fost salvate. Continuați fără a le salva?"
+
+#: id:727
+msgid "Web server"
+msgstr "Server Web"
+
+#: id:728
+msgctxt "Auto context with id 728"
+msgid "FTP server"
+msgstr "Server FTP"
+
+#: id:730
+msgid "- Port"
+msgstr "- Port"
+
+#: id:732
+msgid "Save & apply"
+msgstr "Salvează și aplică"
+
+#: id:733
+msgid "- Password"
+msgstr "- Parolă"
+
+#: id:734
+msgid "No pass"
+msgstr "Nicio parolă"
+
+#: id:735
+msgid "- Character set"
+msgstr "- Set de caractere"
+
+#: id:736
+msgid "- Style"
+msgstr "- Stil"
+
+#: id:737
+msgid "- Colour"
+msgstr "- Culoare"
+
+#: id:738
+msgctxt "Auto context with id 738"
+msgid "Normal"
+msgstr "Normal"
+
+#: id:739
+msgid "Bold"
+msgstr "Aldin"
+
+#: id:740
+msgid "Italics"
+msgstr "Cursiv"
+
+#: id:741
+msgid "Bold italics"
+msgstr "Cursiv aldin"
+
+#: id:742
+msgctxt "Auto context with id 742"
+msgid "White"
+msgstr "Alb"
+
+#: id:743
+msgctxt "Auto context with id 743"
+msgid "Yellow"
+msgstr "Galben"
+
+#: id:744
+msgctxt "Auto context with id 744"
+msgid "Files"
+msgstr "Fișiere"
+
+#: id:745
+msgid "No scanned information for this view"
+msgstr "Nicio informație scanată pentru această săptămână"
+
+#: id:746
+msgid "Please turn off library mode"
+msgstr "Vă rugăm opriți modul mediatecă"
+
+#: id:747
+msgid "Error loading image"
+msgstr "Eroare la încărcarea imaginii"
+
+#: id:748
+msgid "Edit path"
+msgstr "Modifică cale"
+
+#: id:749
+msgid "Mirror image"
+msgstr "Oglindire imagine"
+
+#: id:750
+msgid "Are you sure?"
+msgstr "Sigur doriți acest lucru?"
+
+#: id:751
+msgid "Removing source"
+msgstr "Eliminare sursă"
+
+#: id:754
+msgid "Add program link"
+msgstr "Adaugă legătură program"
+
+#: id:755
+msgid "Edit program path"
+msgstr "Modifică cale program"
+
+#: id:756
+msgid "Edit program name"
+msgstr "Modifică nume program"
+
+#: id:757
+msgid "Edit path depth"
+msgstr "Modifică adâncime cale"
+
+#: id:759
+msgid "View: Big list"
+msgstr "Vizualizare: Listă mare"
+
+#: id:760
+msgctxt "Auto context with id 760"
+msgid "Yellow"
+msgstr "Galben"
+
+#: id:761
+msgctxt "Auto context with id 761"
+msgid "White"
+msgstr "Alb"
+
+#: id:762
+msgid "Blue"
+msgstr "Albastru"
+
+#: id:763
+msgid "Bright green"
+msgstr "Verde deschis"
+
+#: id:764
+msgid "Yellow green"
+msgstr "Verde galben"
+
+#: id:765
+msgid "Cyan"
+msgstr "Cyan"
+
+#: id:766
+msgid "Light grey"
+msgstr "Gri deschis"
+
+#: id:767
+msgid "Grey"
+msgstr "Gri"
+
+#: id:770
+msgid "Error %i: share not available"
+msgstr "Eroare %i: partajarea nu este disponibilă"
+
+#: id:772
+msgctxt "Auto context with id 772"
+msgid "Audio output"
+msgstr "Ieșire audio"
+
+#: id:773
+msgid "Seeking"
+msgstr "Salt"
+
+#: id:774
+msgid "Slideshow folder"
+msgstr "Dosar prezentare diapozitive"
+
+#: id:775
+msgid "Network interface"
+msgstr "Interfață rețea"
+
+#: id:776
+msgid "- Wireless network name (ESSID)"
+msgstr "- Nume rețea fără fir (ESSID)"
+
+#: id:777
+msgid "- Wireless password"
+msgstr "- Parolă rețea fără fir"
+
+#: id:778
+msgid "- Wireless security"
+msgstr "- Securitate rețea fără fir"
+
+#: id:779
+msgid "Save and apply network interface settings"
+msgstr "Salvează și aplică setările interfeței rețea"
+
+#: id:780
+msgid "No encryption"
+msgstr "Fără criptare"
+
+#: id:781
+msgid "WEP"
+msgstr "WEP"
+
+#: id:782
+msgid "WPA"
+msgstr "WPA"
+
+#: id:783
+msgid "WPA2"
+msgstr "WPA2"
+
+#: id:784
+msgid "Applying network interface settings. Please wait."
+msgstr "Se aplică setările interfeței de rețea. Vă rugăm, așteptați."
+
+#: id:785
+msgid "Network interface restarted successfully."
+msgstr "Interfața de rețea a fost repornită cu succes."
+
+#: id:786
+msgid "Network interface did not start successfully."
+msgstr "Interfața de rețea nu a pornit cu succes."
+
+#: id:787
+msgid "Interface disabled"
+msgstr "Interfață dezactivată"
+
+#: id:788
+msgid "Network interface disabled successfully."
+msgstr "Interfață rețea dezactivată cu succes."
+
+#: id:789
+msgid "Wireless network name (ESSID)"
+msgstr "Nume rețea fără fir (ESSID)"
+
+#: id:790
+msgid "Remote control"
+msgstr ""
+
+#: id:791
+msgid "Allow programs on this system to control XBMC"
+msgstr "Permite programelor din acest sistem să controleze XBMC"
+
+#: id:792
+msgctxt "Auto context with id 792"
+msgid "Port"
+msgstr "Port"
+
+#: id:793
+msgid "Port range"
+msgstr "Interval porturi"
+
+#: id:794
+msgid "Allow programs on other systems to control XBMC"
+msgstr "Permite programelor din alte sisteme să controleze XBMC"
+
+#: id:795
+msgid "Initial repeat delay (ms)"
+msgstr "Înârziere la repetare inițială (ms)"
+
+#: id:796
+msgid "Continuous repeat delay (ms)"
+msgstr "Întârziere la repetare continuă (ms)"
+
+#: id:797
+msgid "Maximum number of clients"
+msgstr "Număr maxim de clienți"
+
+#: id:798
+msgid "Internet access"
+msgstr "Acces la Internet"
+
+#: id:850
+msgid "Invalid port number entered"
+msgstr "Număr portului nu este valid"
+
+#: id:851
+msgid "Valid port range is 1-65535"
+msgstr "Interval valid de porturi este 1-65535"
+
+#: id:852
+msgid "Valid port range is 1024-65535"
+msgstr "Interval valid de porturi este 1024-65535"
+
+#: id:998
+msgid "Add Music..."
+msgstr "Adaugă muzică..."
+
+#: id:999
+msgid "Add Videos..."
+msgstr "Adaugă filme..."
+
+#: id:1000
+msgid "- Preview"
+msgstr "- Previzualizare"
+
+#: id:1001
+msgid "Unable to connect"
+msgstr "Imposibil de conectat"
+
+#: id:1002
+msgid "XBMC was unable to connect to the network location."
+msgstr "XBMC nu s-a putut conecta la locația rețelei."
+
+#: id:1003
+msgid "This could be due to the network not being connected."
+msgstr "Este posibil ca rețeaua să nu fie conectată."
+
+#: id:1004
+msgid "Would you like to add it anyway?"
+msgstr "Doriți să îl adăugați oricum?"
+
+#: id:1006
+msgctxt "Auto context with id 1006"
+msgid "IP address"
+msgstr "Adresă IP"
+
+#: id:1007
+msgid "Add network location"
+msgstr "Adăugare locație rețea"
+
+#: id:1008
+msgid "Protocol"
+msgstr "Protocol"
+
+#: id:1009
+msgid "Server address"
+msgstr "Adresă server"
+
+#: id:1010
+msgid "Server name"
+msgstr "Nume server"
+
+#: id:1011
+msgid "Remote path"
+msgstr "Cale la distanță"
+
+#: id:1012
+msgid "Shared folder"
+msgstr "Dosar partajat"
+
+#: id:1013
+msgctxt "Auto context with id 1013"
+msgid "Port"
+msgstr "Port"
+
+#: id:1014
+msgctxt "Auto context with id 1014"
+msgid "Username"
+msgstr "Utilizator"
+
+#: id:1015
+msgid "Browse for network server"
+msgstr "Alegere server rețea"
+
+#: id:1016
+msgid "Enter the network address of the server"
+msgstr "Introduceți adresa de rețea a serverului"
+
+#: id:1017
+msgid "Enter the path on the server"
+msgstr "Introduceți calea de pe server"
+
+#: id:1018
+msgid "Enter the port number"
+msgstr "Introduceți număr port"
+
+#: id:1019
+msgid "Enter the username"
+msgstr "Introduceți nume utilizator"
+
+#: id:1020
+msgid "Add %s source"
+msgstr "Adăugare sursă %s"
+
+#: id:1021
+msgid "Enter the paths or browse for the media locations."
+msgstr "Introduceți căi sau alegeți locații media."
+
+#: id:1022
+msgid "Enter a name for this media Source."
+msgstr "Introduceți un nume pentru această sursă media."
+
+#: id:1023
+msgid "Browse for new share"
+msgstr "Alegere partajare nouă"
+
+#: id:1024
+msgid "Browse"
+msgstr "Alege"
+
+#: id:1025
+msgid "Could not retrieve directory information."
+msgstr "Nu se pot obține informații dosar."
+
+#: id:1026
+msgid "Add source"
+msgstr "Adaugă sursă"
+
+#: id:1027
+msgid "Edit source"
+msgstr "Modifică sursa"
+
+#: id:1028
+msgid "Edit %s source"
+msgstr "Modificare sursă %s"
+
+#: id:1029
+msgid "Enter the new label"
+msgstr "Introduceți noua etichetă"
+
+#: id:1030
+msgid "Browse for image"
+msgstr "Alegere imagine"
+
+#: id:1031
+msgid "Browse for image folder"
+msgstr "Alegere dosar de imagini"
+
+#: id:1032
+msgid "Add network location..."
+msgstr "Adaugă locație rețea..."
+
+#: id:1033
+msgid "Browse for file"
+msgstr "Căutare fișier"
+
+#: id:1034
+msgid "Submenu"
+msgstr "Submeniu"
+
+#: id:1035
+msgid "Enable submenu buttons"
+msgstr "Activează butoane submeniu"
+
+#: id:1036
+msgid "Favourites"
+msgstr "Favorite"
+
+#: id:1037
+msgid "Video Add-ons"
+msgstr "Suplimente video"
+
+#: id:1038
+msgid "Music Add-ons"
+msgstr "Suplimente audio"
+
+#: id:1039
+msgid "Picture Add-ons"
+msgstr "Suplimente imagini"
+
+#: id:1040
+msgid "Loading directory"
+msgstr "Se încarcă directorul"
+
+#: id:1041
+msgid "Retrieved %i items"
+msgstr "S-au obținut %i elemente"
+
+#: id:1042
+msgid "Retrieved %i of %i items"
+msgstr "S-au obținut %i din %i elemente"
+
+#: id:1043
+msgid "Program Add-ons"
+msgstr "Suplimente programe"
+
+#: id:1044
+msgid "Set plugin thumb"
+msgstr "Alege miniatură supliment"
+
+#: id:1045
+msgid "Add-on settings"
+msgstr "Configurare supliment"
+
+#: id:1046
+msgid "Access points"
+msgstr "Puncte de acces"
+
+#: id:1047
+msgid "Other..."
+msgstr "Altele..."
+
+#: id:1048
+msgid "- Username"
+msgstr "- Utilizator"
+
+#: id:1049
+msgid "Script settings"
+msgstr "Setări script"
+
+#: id:1050
+msgid "Singles"
+msgstr "Individuale"
+
+#: id:1051
+msgid "Enter web address"
+msgstr "Introduceți adresă web"
+
+#: id:1200
+msgid "SMB client"
+msgstr "Client SMB"
+
+#: id:1202
+msgid "Workgroup"
+msgstr "Grup de lucru"
+
+#: id:1203
+msgid "Default username"
+msgstr "Nume utilizator implicit"
+
+#: id:1204
+msgid "Default password"
+msgstr "Parolă implicită"
+
+#: id:1207
+msgid "WINS server"
+msgstr "Server WINS"
+
+#: id:1208
+msgid "Mount SMB shares"
+msgstr "Monteză partajări SMB"
+
+#: id:1210
+msgctxt "Auto context with id 1210"
+msgid "Remove"
+msgstr "Elimină"
+
+#: id:1211
+msgctxt "Auto context with id 1211"
+msgid "Music"
+msgstr "Muzică"
+
+#: id:1212
+msgctxt "Auto context with id 1212"
+msgid "Video"
+msgstr "Video"
+
+#: id:1213
+msgctxt "Auto context with id 1213"
+msgid "Pictures"
+msgstr "Imagini"
+
+#: id:1214
+msgctxt "Auto context with id 1214"
+msgid "Files"
+msgstr "Fișiere"
+
+#: id:1215
+msgctxt "Auto context with id 1215"
+msgid "Music & video"
+msgstr "Muzică și video"
+
+#: id:1216
+msgid "Music & pictures"
+msgstr "Muzică și imagini"
+
+#: id:1217
+msgid "Music & files"
+msgstr "Muzică și fișiere"
+
+#: id:1218
+msgid "Video & pictures"
+msgstr "Video și imagini"
+
+#: id:1219
+msgid "Video & files"
+msgstr "Video și fișiere"
+
+#: id:1220
+msgid "Pictures & files"
+msgstr "Imagini și fișiere"
+
+#: id:1221
+msgid "Music & video & pictures"
+msgstr "Muzică, video și imagini"
+
+#: id:1222
+msgid "Music & video & pictures & files"
+msgstr "Muzică, video, imagini și fișiere"
+
+#: id:1223
+msgctxt "Auto context with id 1223"
+msgid "Disabled"
+msgstr "Dezactivat"
+
+#: id:1226
+msgid "Files & music & video"
+msgstr "Fișiere, muzică și video"
+
+#: id:1227
+msgid "Files & pictures & music"
+msgstr "Fișiere, imagini și muzică"
+
+#: id:1228
+msgid "Files & pictures & video"
+msgstr "Fișiere, imagini și video"
+
+#: id:1229
+msgid "Music & programs"
+msgstr "Muzică și programe"
+
+#: id:1230
+msgid "Video & programs"
+msgstr "Video și programe"
+
+#: id:1231
+msgid "Pictures & programs"
+msgstr "Imagini și programe"
+
+#: id:1232
+msgid "Music & video & pictures & programs"
+msgstr "Muzică, video, imagini și programe"
+
+#: id:1233
+msgid "Programs & video & music"
+msgstr "Programe, video și muzică"
+
+#: id:1234
+msgid "Programs & pictures & music"
+msgstr "Programe, imagini și muzică"
+
+#: id:1235
+msgid "Programs & pictures & video"
+msgstr "Programe, imagini și video"
+
+#: id:1250
+msgid "Auto-detection"
+msgstr "Detectare automată"
+
+#: id:1251
+msgid "Auto-detect system"
+msgstr "Detectează automat sistemul"
+
+#: id:1252
+msgid "Nickname"
+msgstr "Pseudonim"
+
+#: id:1254
+msgid "Ask to connect"
+msgstr "Întreabă pentru conectare"
+
+#: id:1255
+msgid "Send FTP user and password"
+msgstr "Trimite utilizator și parolă FTP"
+
+#: id:1256
+msgid "Ping interval"
+msgstr "Interval ping"
+
+#: id:1257
+msgid "Would you like to connect to the auto-detected system?"
+msgstr "Doriți să vă conectați cu sistemul detectat automat?"
+
+#: id:1259
+msgid "Zeroconf"
+msgstr ""
+
+#: id:1260
+msgid "Announce these services to other systems via Zeroconf"
+msgstr "Anunță aceste servicii către celelalte sisteme prin Zeroconf"
+
+#: id:1270
+msgid "Allow XBMC to receive AirPlay content"
+msgstr "Permite XBMC să primească conținut AirPlay"
+
+#: id:1271
+msgid "Device name"
+msgstr "Nume dispozitiv"
+
+#: id:1272
+msgid "- Use password protection"
+msgstr "- Folosește protecție prin parolă"
+
+#: id:1273
+msgid "AirPlay"
+msgstr ""
+
+#: id:1300
+msgid "Custom audio device"
+msgstr "Dispozitiv audio specific"
+
+#: id:1301
+msgid "Custom passthrough device"
+msgstr "Dispozitiv de traversare specific"
+
+#: id:1396
+msgid "Drifting"
+msgstr "curenți"
+
+#: id:1397
+msgid "and"
+msgstr "și"
+
+#: id:1398
+msgid "Freezing"
+msgstr "îngheț"
+
+#: id:1399
+msgid "Late"
+msgstr "mai târziu"
+
+#: id:1400
+msgid "Isolated"
+msgstr "izolat"
+
+#: id:1401
+msgid "Thundershowers"
+msgstr "ploi cu tunete"
+
+#: id:1402
+msgid "Thunder"
+msgstr "tunet"
+
+#: id:1403
+msgctxt "Auto context with id 1403"
+msgid "Sun"
+msgstr "soare"
+
+#: id:1404
+msgid "Heavy"
+msgstr "puternic"
+
+#: id:1405
+msgid "in"
+msgstr "în"
+
+#: id:1406
+msgid "the"
+msgstr ""
+
+#: id:1407
+msgid "Vicinity"
+msgstr "apropiere"
+
+#: id:1408
+msgid "Ice"
+msgstr "gheață"
+
+#: id:1409
+msgid "Crystals"
+msgstr "cristale"
+
+#: id:1410
+msgid "Calm"
+msgstr "calm"
+
+#: id:1411
+msgid "with"
+msgstr "cu"
+
+#: id:1412
+msgid "windy"
+msgstr "mult vânt"
+
+#: id:1413
+msgid "drizzle"
+msgstr "burniță"
+
+#: id:1414
+msgid "Thunderstorm"
+msgstr "furtună cu trăznete"
+
+#: id:1415
+msgid "Drizzle"
+msgstr "burniță"
+
+#: id:1416
+msgid "Foggy"
+msgstr "încețoșat"
+
+#: id:1417
+msgid "Grains"
+msgstr "picățele"
+
+#: id:1418
+msgid "T-Storms"
+msgstr "furtuni"
+
+#: id:1419
+msgid "T-Showers"
+msgstr "averse"
+
+#: id:1420
+msgid "Moderate"
+msgstr "moderat"
+
+#: id:1421
+msgid "Very High"
+msgstr "foarte ridicat"
+
+#: id:1422
+msgid "Windy"
+msgstr "mult vânt"
+
+#: id:1423
+msgid "Mist"
+msgstr "ceață"
+
+#: id:1450
+msgid "Put display to sleep when idle"
+msgstr "Pune ecranul în repaus în perioada de inactivitate"
+
+#: id:2050
+msgid "Runtime"
+msgstr "Durată"
+
+#: id:2100
+msgid "Script failed! : %s"
+msgstr "Scriptul a eșuat! : %s"
+
+#: id:2101
+msgid "Newer version needed - See log"
+msgstr "Este necesară o versiune mai nouă - Vedeți istoric modificări"
+
+#: id:4501
+msgid "Enable LCD/VFD"
+msgstr "Activează LCD / VFD"
+
+#: id:10000
+msgid "Home"
+msgstr "Acasă"
+
+#: id:10001
+msgctxt "Auto context with id 10001"
+msgid "Programs"
+msgstr "Programe"
+
+#: id:10002
+msgctxt "Auto context with id 10002"
+msgid "Pictures"
+msgstr "Imagini"
+
+#: id:10003
+msgctxt "Auto context with id 10003"
+msgid "File manager"
+msgstr "Gestionar de fișiere"
+
+#: id:10004
+msgctxt "Auto context with id 10004"
+msgid "Settings"
+msgstr "Setări"
+
+#: id:10005
+msgctxt "Auto context with id 10005"
+msgid "Music"
+msgstr "Muzică"
+
+#: id:10006
+msgctxt "Auto context with id 10006"
+msgid "Videos"
+msgstr "Filme"
+
+#: id:10007
+msgid "System information"
+msgstr "Informații sistem"
+
+#: id:10008
+msgid "Settings - General"
+msgstr "Setări - Generale"
+
+#: id:10009
+msgid "Settings - Screen"
+msgstr "Setări - Ecran"
+
+#: id:10010
+msgid "Settings - Appearance - GUI Calibration"
+msgstr "Setări - Aspect - Calibrare GUI"
+
+#: id:10011
+msgid "Settings - Videos - Screen Calibration"
+msgstr "Setări - Filme - Calibrare ecran"
+
+#: id:10012
+msgid "Settings - Pictures"
+msgstr "Setări - Imagini"
+
+#: id:10013
+msgid "Settings - Programs"
+msgstr "Setări - Programe"
+
+#: id:10014
+msgid "Settings - Weather"
+msgstr "Setări - Meteo"
+
+#: id:10015
+msgid "Settings - Music"
+msgstr "Setări - Muzică"
+
+#: id:10016
+msgid "Settings - System"
+msgstr "Setări - Sistem"
+
+#: id:10017
+msgid "Settings - Videos"
+msgstr "Setări - Filme"
+
+#: id:10018
+msgid "Settings - Network"
+msgstr "Setări - Rețea"
+
+#: id:10019
+msgid "Settings - Appearance"
+msgstr "Setări - Aspect"
+
+#: id:10020
+msgctxt "Auto context with id 10020"
+msgid "Scripts"
+msgstr "Scripturi"
+
+#: id:10021
+msgid "Web Browser"
+msgstr "Navigator web"
+
+#: id:10025
+msgctxt "Auto context with id 10025"
+msgid "Videos"
+msgstr "Filme"
+
+#: id:10028
+msgid "Videos/Playlist"
+msgstr "Filme/Listă de redare"
+
+#: id:10029
+msgctxt "Auto context with id 10029"
+msgid "Login screen"
+msgstr "Ecran de autentificare"
+
+#: id:10034
+msgid "Settings - Profiles"
+msgstr "Setări - Profile"
+
+#: id:10040
+msgid "Addon browser"
+msgstr "Navigator de suplimente"
+
+#: id:10100
+msgid "Yes/No dialog"
+msgstr "Dialog Da/Nu"
+
+#: id:10101
+msgid "Progress dialog"
+msgstr "Dialog de progres"
+
+#: id:10210
+msgid "Looking for subtitles..."
+msgstr "Se caută subtitrări..."
+
+#: id:10211
+msgid "Looking for or caching subtitles..."
+msgstr "Se caută sau se pun în memorie subtitrări..."
+
+#: id:10212
+msgid "terminating"
+msgstr "se oprește"
+
+#: id:10213
+msgid "buffering"
+msgstr "se preîncarcă"
+
+#: id:10214
+msgid "Opening stream"
+msgstr "Se deschide fluxul"
+
+#: id:10500
+msgid "Music/Playlist"
+msgstr "Muzică/Listă de redare"
+
+#: id:10501
+msgid "Music/Files"
+msgstr "Muzică/Fișiere"
+
+#: id:10502
+msgid "Music/Library"
+msgstr "Muzică/Mediatecă"
+
+#: id:10503
+msgid "Playlist editor"
+msgstr "Editor listă de redare"
+
+#: id:10504
+msgid "Top 100 songs"
+msgstr "Top 100 de cântece"
+
+#: id:10505
+msgid "Top 100 albums"
+msgstr "Top 100 de albume"
+
+#: id:10506
+msgctxt "Auto context with id 10506"
+msgid "Programs"
+msgstr "Programe"
+
+#: id:10507
+msgid "Configuration"
+msgstr "Configurație"
+
+#: id:10508
+msgid "Weather forecast"
+msgstr "Previziune meteo"
+
+#: id:10509
+msgid "Network gaming"
+msgstr "Jocuri în rețea"
+
+#: id:10510
+msgid "Extensions"
+msgstr "Extensii"
+
+#: id:10511
+msgctxt "Auto context with id 10511"
+msgid "System info"
+msgstr "Informații sistem"
+
+#: id:10516
+msgid "Music - Library"
+msgstr "Mediatecă audio"
+
+#: id:10517
+msgid "Now Playing - Music"
+msgstr "Muzică acum în redare"
+
+#: id:10522
+msgid "Now Playing - Videos"
+msgstr "Video acum în redare"
+
+#: id:10523
+msgid "Album info"
+msgstr "Info album"
+
+#: id:10524
+msgid "Movie info"
+msgstr "Informații film"
+
+#: id:12000
+msgid "Select dialog"
+msgstr "Selectează dialog"
+
+#: id:12001
+msgid "Music/Info"
+msgstr "Muzică/Informații"
+
+#: id:12002
+msgid "Dialog OK"
+msgstr "Dialog OK"
+
+#: id:12003
+msgid "Videos/Info"
+msgstr "Filme/Informații"
+
+#: id:12004
+msgid "Scripts/Info"
+msgstr "Scripturi/Informații"
+
+#: id:12005
+msgid "Fullscreen video"
+msgstr "Video pe tot ecranul"
+
+#: id:12006
+msgid "Audio visualization"
+msgstr "Vizualizare audio"
+
+#: id:12008
+msgid "File stacking dialog"
+msgstr "Dialog așezare fișiere"
+
+#: id:12009
+msgid "Rebuild index..."
+msgstr "Se reface indexul..."
+
+#: id:12010
+msgid "Return to music window"
+msgstr "Revino la fereastra de muzică"
+
+#: id:12011
+msgid "Return to videos window"
+msgstr "Revino la fereastra de filme"
+
+#: id:12021
+msgid "Start from beginning"
+msgstr "Pornește de la început"
+
+#: id:12022
+msgid "Resume from %s"
+msgstr "Reia de la %s"
+
+#: id:12310
+msgid "0"
+msgstr "0"
+
+#: id:12311
+msgid "1"
+msgstr "1"
+
+#: id:12312
+msgid "2"
+msgstr "2"
+
+#: id:12313
+msgid "3"
+msgstr "3"
+
+#: id:12314
+msgid "4"
+msgstr "4"
+
+#: id:12315
+msgid "5"
+msgstr "5"
+
+#: id:12316
+msgid "6"
+msgstr "6"
+
+#: id:12317
+msgid "7"
+msgstr "7"
+
+#: id:12318
+msgid "8"
+msgstr "8"
+
+#: id:12319
+msgid "9"
+msgstr "9"
+
+#: id:12320
+msgid "c"
+msgstr "c"
+
+#: id:12321
+msgid "Ok"
+msgstr "Ok"
+
+#: id:12322
+msgid "*"
+msgstr "*"
+
+#: id:12325
+msgid "Locked! Enter code..."
+msgstr "Blocat! Introduceți codul..."
+
+#: id:12326
+msgid "Enter password"
+msgstr "Introduceți parola"
+
+#: id:12327
+msgid "Enter master code"
+msgstr "Introduceți codul principal"
+
+#: id:12328
+msgid "Enter unlock code"
+msgstr "Introduceți codul de deblocare"
+
+#: id:12329
+msgid "or press C to cancel"
+msgstr "sau apăsați C pentru a renunța"
+
+#: id:12330
+msgid "Enter gamepad button combo and"
+msgstr "Introduceți combinație de butoane gamepad"
+
+#: id:12331
+msgid "press OK, or Back to cancel"
+msgstr "apăsați OK, sau Înapoi pentru a renunța"
+
+#: id:12332
+msgid "Set lock"
+msgstr "Setează blocare"
+
+#: id:12333
+msgid "Unlock"
+msgstr "Deblochează"
+
+#: id:12334
+msgid "Reset lock"
+msgstr "Resetează blocare"
+
+#: id:12335
+msgid "Remove lock"
+msgstr "Elimină blocare"
+
+#: id:12337
+msgid "Numeric password"
+msgstr "Parolă numerică"
+
+#: id:12338
+msgid "Gamepad button combo"
+msgstr "Combinație butoane gamepad"
+
+#: id:12339
+msgid "Full-text password"
+msgstr "Parolă completă"
+
+#: id:12340
+msgid "Enter new password"
+msgstr "Introduceți noua parolă"
+
+#: id:12341
+msgid "Re-Enter new password"
+msgstr "Reintroduceți noua parolă"
+
+#: id:12342
+msgid "Incorrect password,"
+msgstr "Parola nu este corectă,"
+
+#: id:12343
+msgid "retries left"
+msgstr "încercări rămase"
+
+#: id:12344
+msgid "Passwords entered did not match."
+msgstr "Parolele introduse nu se potrivesc."
+
+#: id:12345
+msgid "Access denied"
+msgstr "Acces refuzat"
+
+#: id:12346
+msgid "Password retry limit exceeded."
+msgstr "S-a ajuns la limita de încercări."
+
+#: id:12347
+msgid "The system will now shut off."
+msgstr "Sistemul se închide."
+
+#: id:12348
+msgid "Item locked"
+msgstr "Element blocat"
+
+#: id:12353
+msgid "Reactivate lock"
+msgstr "Reactivează blocarea"
+
+#: id:12356
+msgid "Change lock"
+msgstr "Schimbă blocare"
+
+#: id:12357
+msgid "Source lock"
+msgstr "Blocare sursă"
+
+#: id:12358
+msgid "Password entry was blank. Try again."
+msgstr "Parola nu a fost introdusă. Încercați din nou."
+
+#: id:12360
+msgid "Master lock"
+msgstr "Blocare principală"
+
+#: id:12362
+msgid "Shutdown system if Master Lock retries exceeded"
+msgstr "Oprește sistemul dacă s-a ajuns la limita încercărilor pentru Blocarea principală"
+
+#: id:12367
+msgid "Master code is not valid"
+msgstr "Codul principal nu este valid"
+
+#: id:12368
+msgid "Please enter a valid master code"
+msgstr "Introduceți un cod principal valid"
+
+#: id:12373
+msgid "Settings & file manager"
+msgstr "Setări și gestionar de fișiere"
+
+#: id:12376
+msgid "Set as default for all movies"
+msgstr "Setează ca implicit pentru toate filmele"
+
+#: id:12377
+msgid "This will reset any previously saved values"
+msgstr "Vor fi resetate toate valorile salvate anterior."
+
+#: id:12378
+msgid "Amount of time to display each image"
+msgstr "Durată de afișare pentru fiecare imagine"
+
+#: id:12379
+msgid "Use pan and zoom effects"
+msgstr "Folosește efecte de mișcare și mărire"
+
+#: id:12383
+msgid "12 hour clock"
+msgstr "Ceas 12 ore"
+
+#: id:12384
+msgid "24 hour clock"
+msgstr "Ceas 24 ore"
+
+#: id:12385
+msgid "Day/Month"
+msgstr "Zi/Lună"
+
+#: id:12386
+msgid "Month/Day"
+msgstr "Lună/Zi"
+
+#: id:12390
+msgid "System uptime"
+msgstr "Sistem pornit de"
+
+#: id:12391
+msgid "Minutes"
+msgstr "minute"
+
+#: id:12392
+msgid "Hours"
+msgstr "ore"
+
+#: id:12393
+msgid "Days"
+msgstr "zile"
+
+#: id:12394
+msgid "Total uptime"
+msgstr "Timp total de funcționare"
+
+#: id:12395
+msgid "Battery level"
+msgstr "Nivel baterie"
+
+#: id:12600
+msgctxt "Auto context with id 12600"
+msgid "Weather"
+msgstr "Meteo"
+
+#: id:12900
+msgctxt "Auto context with id 12900"
+msgid "Screensaver"
+msgstr "Protector ecran"
+
+#: id:12901
+msgid "Fullscreen OSD"
+msgstr "OSD în mod ecran complet"
+
+#: id:13000
+msgid "System"
+msgstr "Sistem"
+
+#: id:13001
+msgid "Immediate HD spindown"
+msgstr "Încetinire imediată HD"
+
+#: id:13002
+msgid "Video only"
+msgstr "Doar video"
+
+#: id:13003
+msgid "- Delay"
+msgstr "- Întârziere"
+
+#: id:13004
+msgid "- Minimum file duration"
+msgstr "- Durată minimă fișier"
+
+#: id:13005
+msgid "Shutdown"
+msgstr "Închidere"
+
+#: id:13008
+msgid "Shutdown function"
+msgstr "Tip de închidere"
+
+#: id:13009
+msgid "Quit"
+msgstr "Ieșire"
+
+#: id:13010
+msgid "Hibernate"
+msgstr "Hibernare"
+
+#: id:13011
+msgid "Suspend"
+msgstr "Repaus"
+
+#: id:13012
+msgid "Exit"
+msgstr "Ieșire"
+
+#: id:13013
+msgid "Reboot"
+msgstr "Repornire"
+
+#: id:13014
+msgid "Minimize"
+msgstr "Minimizare"
+
+#: id:13015
+msgid "Power button action"
+msgstr "Acțiune buton de pornire (power)"
+
+#: id:13016
+msgid "Power off System"
+msgstr "Închidere sistem"
+
+#: id:13020
+msgid "Is another session active, perhaps over ssh?"
+msgstr "Este activă o altă sesiune, poate peste ssh?"
+
+#: id:13021
+msgid "Mounted removable harddrive"
+msgstr "Disc dur detașabil montat"
+
+#: id:13022
+msgid "Unsafe device removal"
+msgstr "Eliminare dispozitiv nesigură"
+
+#: id:13023
+msgid "Successfully removed device"
+msgstr "Dispozitiv eliminat cu succes"
+
+#: id:13024
+msgid "Joystick plugged"
+msgstr "Joystick conectat"
+
+#: id:13025
+msgid "Joystick unplugged"
+msgstr "Joystick deconectat"
+
+#: id:13050
+msgid "Running low on battery"
+msgstr "Energie baterie scăzută"
+
+#: id:13100
+msgid "Flicker filter"
+msgstr "Filtru pâlpâire"
+
+#: id:13101
+msgid "Let driver choose (requires restart)"
+msgstr "Permite driverului să aleagă (necesită repornire)"
+
+#: id:13105
+msgid "Vertical blank sync"
+msgstr "Sincronizare verticală goală"
+
+#: id:13106
+msgctxt "Auto context with id 13106"
+msgid "Disabled"
+msgstr "Dezactivat"
+
+#: id:13107
+msgid "Enabled during video playback"
+msgstr "Activată în timpul redării video"
+
+#: id:13108
+msgctxt "Auto context with id 13108"
+msgid "Always enabled"
+msgstr "Activat întotdeauna"
+
+#: id:13109
+msgid "Test & apply resolution"
+msgstr "Testare și aplicare rezoluție"
+
+#: id:13110
+msgid "Save resolution?"
+msgstr "Salvare rezoluție"
+
+#: id:13111
+msgid "Would you like to keep this resolution?"
+msgstr "Doriți să păstrați această rezoluție?"
+
+#: id:13112
+msgid "High quality upscaling"
+msgstr "Mărire cu calitate înaltă"
+
+#: id:13113
+msgctxt "Auto context with id 13113"
+msgid "Disabled"
+msgstr "Dezactivat"
+
+#: id:13114
+msgid "Enabled for SD content"
+msgstr "Activat pentru conținut SD"
+
+#: id:13115
+msgctxt "Auto context with id 13115"
+msgid "Always enabled"
+msgstr "Activat întotdeauna"
+
+#: id:13116
+msgid "Upscaling method"
+msgstr "Metodă de mărire (upscaling)"
+
+#: id:13117
+msgctxt "Auto context with id 13117"
+msgid "Bicubic"
+msgstr "Bicubic"
+
+#: id:13118
+msgid "Lanczos"
+msgstr "Lanczos"
+
+#: id:13119
+msgid "Sinc"
+msgstr "Sinc"
+
+#: id:13120
+msgctxt "Auto context with id 13120"
+msgid "VDPAU"
+msgstr "VDPAU"
+
+#: id:13121
+msgid "VDPAU HQ Upscaling level"
+msgstr "Nivel de mărire VDPAU HQ"
+
+#: id:13122
+msgid "VDPAU Studio level color conversion"
+msgstr "Nivel de conversie culoare VDPAU Studio"
+
+#: id:13130
+msgid "Blank other displays"
+msgstr "Întunecă celelalte ecrane"
+
+#: id:13131
+msgctxt "Auto context with id 13131"
+msgid "Disabled"
+msgstr "Dezactivat"
+
+#: id:13132
+msgid "Blank displays"
+msgstr "Întunecă ecrane"
+
+#: id:13140
+msgid "Active connections detected!"
+msgstr "Au fost detectate conexiuni active!"
+
+#: id:13141
+msgid "If you proceed, you might not be able to control XBMC"
+msgstr "Dacă continuați, există posibilitatea să nu mai puteți controla XBMC"
+
+#: id:13142
+msgid "any longer. Are you sure you want to stop the Event server?"
+msgstr "Sigur doriți să opriți serverul Event?"
+
+#: id:13144
+msgid "Change Apple Remote mode?"
+msgstr "Schimbați modul Apple Remote?"
+
+#: id:13145
+msgid "If you are currently using the Apple Remote to control"
+msgstr "Dacă în acest moment folosiți Apple Remote pentru a controla"
+
+#: id:13146
+msgid "XBMC, changing this setting might affect your ability"
+msgstr "XBMC, modificând această setare vă poate afecta abilitatea"
+
+#: id:13147
+msgid "to continue controlling it. Do you want to proceed?"
+msgstr "de a continua să îl controlați. Doriți să continuați?"
+
+#: id:13159
+msgid "Subnet mask"
+msgstr "Mască de rețea"
+
+#: id:13160
+msgid "Gateway"
+msgstr "Gateway"
+
+#: id:13161
+msgid "Primary DNS"
+msgstr "DNS primar"
+
+#: id:13162
+msgid "Initialize failed"
+msgstr "Inițializarea a eșuat"
+
+#: id:13170
+msgctxt "Auto context with id 13170"
+msgid "Never"
+msgstr "Niciodată"
+
+#: id:13171
+msgid "Immediately"
+msgstr "Imediat"
+
+#: id:13172
+msgid "After %i secs"
+msgstr "După %i secunde"
+
+#: id:13173
+msgid "HDD install date:"
+msgstr "Dată instalare HDD:"
+
+#: id:13174
+msgid "HDD power cycle count:"
+msgstr "Număr de porniri HDD:"
+
+#: id:13200
+msgid "Profiles"
+msgstr "Profile"
+
+#: id:13201
+msgid "Delete profile '%s'?"
+msgstr "Ștergeți profilul '%s'?"
+
+#: id:13204
+msgid "Last loaded profile:"
+msgstr "Ultimul profil încărcat:"
+
+#: id:13205
+msgid "Unknown"
+msgstr "Necunoscut"
+
+#: id:13206
+msgid "Overwrite"
+msgstr "Suprascrie"
+
+#: id:13208
+msgid "Alarm clock"
+msgstr "Ceas alarmă"
+
+#: id:13209
+msgid "Alarm clock interval (in minutes)"
+msgstr "Interval ceas alarmă (în minute)"
+
+#: id:13210
+msgid "Started, alarm in %im"
+msgstr "Pornit, alarmă în %i minute"
+
+#: id:13211
+msgid "Alarm!"
+msgstr "Alarmă!"
+
+#: id:13212
+msgid "Canceled with %im%is left"
+msgstr "Anulat cu %i m și %i s rămase"
+
+#: id:13213
+msgid "%2.0fm"
+msgstr "%2.0f m"
+
+#: id:13214
+msgid "%2.0fs"
+msgstr "%2.0f s"
+
+#: id:13249
+msgid "Search for subtitles in RARs"
+msgstr "Caută subtitrări în arhive RAR"
+
+#: id:13250
+msgid "Browse for subtitle..."
+msgstr "Alegere subtitrare..."
+
+#: id:13251
+msgid "Move item"
+msgstr "Mută elementul"
+
+#: id:13252
+msgid "Move item here"
+msgstr "Mută elementul aici"
+
+#: id:13253
+msgid "Cancel move"
+msgstr "Renunță la mutare"
+
+#: id:13270
+msgid "Hardware:"
+msgstr "Hardware:"
+
+#: id:13271
+msgid "CPU Usage:"
+msgstr "Utilizare procesor:"
+
+#: id:13274
+msgid "Connected, but no DNS is available."
+msgstr "Conectat, dar niciun server DNS disponibil."
+
+#: id:13275
+msgid "Hard Disk"
+msgstr "Disc dur"
+
+#: id:13276
+msgid "DVD-ROM"
+msgstr "DVD-ROM"
+
+#: id:13277
+msgctxt "Auto context with id 13277"
+msgid "Storage"
+msgstr "Stocare"
+
+#: id:13278
+msgctxt "Auto context with id 13278"
+msgid "Default"
+msgstr "Implicit"
+
+#: id:13279
+msgctxt "Auto context with id 13279"
+msgid "Network"
+msgstr "Rețea"
+
+#: id:13280
+msgctxt "Auto context with id 13280"
+msgid "Video"
+msgstr "Video"
+
+#: id:13281
+msgid "Hardware"
+msgstr "Componente"
+
+#: id:13283
+msgid "Operating system:"
+msgstr "Sistem de operare:"
+
+#: id:13284
+msgid "CPU speed:"
+msgstr "Viteză CPU:"
+
+#: id:13286
+msgid "Video encoder:"
+msgstr "Codor video:"
+
+#: id:13287
+msgid "Screen resolution:"
+msgstr "Rezoluție ecran:"
+
+#: id:13292
+msgid "A/V cable:"
+msgstr "Cablu A/V:"
+
+#: id:13294
+msgid "DVD region:"
+msgstr "Regiune DVD:"
+
+#: id:13295
+msgid "Internet:"
+msgstr "Internet:"
+
+#: id:13296
+msgctxt "Auto context with id 13296"
+msgid "Connected"
+msgstr "conectat"
+
+#: id:13297
+msgid "Not connected. Check network settings."
+msgstr "Neconectat. Verificați setările rețelei."
+
+#: id:13299
+msgid "Target temperature"
+msgstr "Temperatură țintă"
+
+#: id:13300
+msgid "Fan speed"
+msgstr "Viteză ventilator"
+
+#: id:13301
+msgid "Auto temperature control"
+msgstr "Control temperatură automat"
+
+#: id:13302
+msgid "Fan speed override"
+msgstr "Înlocuire viteză ventilator"
+
+#: id:13303
+msgid "- Fonts"
+msgstr "- Fonturi"
+
+#: id:13304
+msgid "Enable flipping bi-directional strings"
+msgstr "Activează inversare pentru textele bi-direcționale"
+
+#: id:13305
+msgid "Show RSS news feeds"
+msgstr "Afișează fluxuri de știri RSS"
+
+#: id:13306
+msgid "Show parent folder items"
+msgstr "Arată elementele dosarului părinte"
+
+#: id:13307
+msgid "Track naming template"
+msgstr "Model de numire piste"
+
+#: id:13308
+msgid "Do you wish to reboot your system"
+msgstr "Doriți să reporniți sistemul"
+
+#: id:13309
+msgid "instead of just XBMC?"
+msgstr "în loc de XBMC?"
+
+#: id:13310
+msgid "Zoom effect"
+msgstr "Efect de zoom"
+
+#: id:13311
+msgid "Float effect"
+msgstr "Efect de plutire"
+
+#: id:13312
+msgid "Black bar reduction"
+msgstr "Reducere bări negre"
+
+#: id:13313
+msgid "Restart"
+msgstr "Repornire"
+
+#: id:13314
+msgid "Crossfade between songs"
+msgstr "Suprapune cântece"
+
+#: id:13315
+msgid "Regenerate thumbnails"
+msgstr "Generează miniaturi din nou"
+
+#: id:13316
+msgid "Recursive thumbnails"
+msgstr "Miniaturi recursive"
+
+#: id:13317
+msgid "View slideshow"
+msgstr "Prezentare diapozitive"
+
+#: id:13318
+msgid "Recursive slideshow"
+msgstr "Prezentare diapozitive recursivă"
+
+#: id:13319
+msgid "Randomize"
+msgstr "Amestecă"
+
+#: id:13320
+msgid "Stereo"
+msgstr "Stereo"
+
+#: id:13321
+msgid "Left only"
+msgstr "Doar în stânga"
+
+#: id:13322
+msgid "Right only"
+msgstr "Doar în dreapta"
+
+#: id:13323
+msgid "Enable karaoke support"
+msgstr "Activează karaoke"
+
+#: id:13324
+msgid "Background transparency"
+msgstr "Transparență fundal"
+
+#: id:13325
+msgid "Foreground transparency"
+msgstr "Transparență prim plan"
+
+#: id:13326
+msgid "A/V delay"
+msgstr "Întârziere A/V"
+
+#: id:13327
+msgid "Karaoke"
+msgstr "Karaoke"
+
+#: id:13328
+msgid "%s not found"
+msgstr "%s nu s-a găsit"
+
+#: id:13329
+msgid "Error opening %s"
+msgstr "Eroare la deschiderea %s"
+
+#: id:13330
+msgid "Unable to load %s"
+msgstr "Nu se poate încărca %s"
+
+#: id:13331
+msgid "Error: Out of memory"
+msgstr "Eroare: Memorie insuficientă"
+
+#: id:13332
+msgid "Move up"
+msgstr "Mută în sus"
+
+#: id:13333
+msgid "Move down"
+msgstr "Mută în jos"
+
+#: id:13334
+msgid "Edit label"
+msgstr "Modifică eticheta"
+
+#: id:13335
+msgid "Make default"
+msgstr "Setează ca implicit"
+
+#: id:13336
+msgid "Remove button"
+msgstr "Elimină buton"
+
+#: id:13340
+msgid "Leave as is"
+msgstr "Lasă-l așa"
+
+#: id:13341
+msgid "Green"
+msgstr "Verde"
+
+#: id:13342
+msgid "Orange"
+msgstr "Portocaliu"
+
+#: id:13343
+msgid "Red"
+msgstr "Roșu"
+
+#: id:13344
+msgid "Cycle"
+msgstr "Ciclu"
+
+#: id:13345
+msgid "Switch LED off on playback"
+msgstr "Oprește LED-ul la redare"
+
+#: id:13346
+msgctxt "Auto context with id 13346"
+msgid "Movie information"
+msgstr "Informații film"
+
+#: id:13347
+msgid "Queue item"
+msgstr "Adaugă la coadă"
+
+#: id:13348
+msgid "Search IMDb..."
+msgstr "Caută pe IMDb..."
+
+#: id:13349
+msgid "Scan for new content"
+msgstr "Scanează pentru conținut nou"
+
+#: id:13350
+msgid "Now playing..."
+msgstr "Acum în redare..."
+
+#: id:13351
+msgctxt "Auto context with id 13351"
+msgid "Album information"
+msgstr "Informații album"
+
+#: id:13352
+msgid "Scan item to library"
+msgstr "Scanează în mediatecă"
+
+#: id:13353
+msgid "Stop scanning"
+msgstr "Oprește scanarea"
+
+#: id:13354
+msgctxt "Auto context with id 13354"
+msgid "Render method"
+msgstr "Metodă de redare"
+
+#: id:13355
+msgid "Low quality pixel shader"
+msgstr "Pixel shader de calitate slabă"
+
+#: id:13356
+msgid "Hardware overlays"
+msgstr "Suprapuneri hardware"
+
+#: id:13357
+msgid "High quality pixel shader"
+msgstr "Pixel shader de calitate înaltă"
+
+#: id:13358
+msgid "Play item"
+msgstr "Redă element"
+
+#: id:13359
+msgid "Set artist thumb"
+msgstr "Setează poză artist"
+
+#: id:13360
+msgid "Automatically generate thumbnails"
+msgstr "Generează miniaturi automat"
+
+#: id:13361
+msgid "Enable voice"
+msgstr "Activează voce"
+
+#: id:13375
+msgid "Enable device"
+msgstr "Activează dispozitiv"
+
+#: id:13376
+msgid "Volume"
+msgstr "Volum"
+
+#: id:13377
+msgid "Default view mode"
+msgstr "Mod de vizualizare implicit"
+
+#: id:13378
+msgid "Default brightness"
+msgstr "Luminozitate implicită"
+
+#: id:13379
+msgid "Default contrast"
+msgstr "Contrast implicit"
+
+#: id:13380
+msgid "Default gamma"
+msgstr "Gamma implicită"
+
+#: id:13381
+msgid "Resume video"
+msgstr "Reia video"
+
+#: id:13382
+msgid "Voice mask - Port 1"
+msgstr "Mascare voce - Port 1"
+
+#: id:13383
+msgid "Voice mask - Port 2"
+msgstr "Mascare voce - Port 2"
+
+#: id:13384
+msgid "Voice mask - Port 3"
+msgstr "Mascare voce - Port 3"
+
+#: id:13385
+msgid "Voice mask - Port 4"
+msgstr "Mascare voce - Port 4"
+
+#: id:13386
+msgid "Use time based seeking"
+msgstr "Folosește saltul bazat pe timp"
+
+#: id:13387
+msgid "Track naming template - right"
+msgstr "Model de numire pistă - dreapta"
+
+#: id:13388
+msgid "Preset"
+msgstr "Predefinit"
+
+#: id:13389
+msgid "There are no presets available\nfor this visualization"
+msgstr "Nu există vizualizări predefinite disponibile"
+
+#: id:13390
+msgid "There are no settings available\nfor this visualization"
+msgstr "Nu există setări disponibile\npentru această vizualizare"
+
+#: id:13391
+msgid "Eject/Load"
+msgstr "Scoate/Încarcă"
+
+#: id:13392
+msgid "Use visualization if playing audio"
+msgstr "Folosește vizualizarea dacă se redă audio"
+
+#: id:13393
+msgid "Calculate size"
+msgstr "Calculează dimensiune"
+
+#: id:13394
+msgid "Calculating folder size"
+msgstr "Se calculează dimensiune dosar"
+
+#: id:13395
+msgid "Video settings"
+msgstr "Setări video"
+
+#: id:13396
+msgid "Audio and subtitle settings"
+msgstr "Setări audio și setări subtitrare"
+
+#: id:13397
+msgid "Enable subtitles"
+msgstr "Activare subtitrări"
+
+#: id:13398
+msgctxt "Auto context with id 13398"
+msgid "Shortcuts"
+msgstr "Scurtături"
+
+#: id:13399
+msgid "Ignore articles when sorting (e.g. \"the\")"
+msgstr "Ignoră articolele la sortare (ex: „the”)"
+
+#: id:13400
+msgid "Crossfade between songs on the same album"
+msgstr "Suprapune cântece din același album"
+
+#: id:13401
+msgid "Browse for %s"
+msgstr "Alegere %s"
+
+#: id:13402
+msgid "Show track position"
+msgstr "Arată poziția pistei"
+
+#: id:13403
+msgid "Clear default"
+msgstr "Elimină implicit"
+
+#: id:13404
+msgid "Resume"
+msgstr "Reia"
+
+#: id:13405
+msgid "Get thumb"
+msgstr "Obține afiș"
+
+#: id:13406
+msgid "Picture information"
+msgstr "Informații imagine"
+
+#: id:13407
+msgid "%s presets"
+msgstr "%s predefiniri"
+
+#: id:13408
+msgid "(IMDb user rating)"
+msgstr "(IMDb aprecieri utilizatori)"
+
+#: id:13409
+msgid "Top 250"
+msgstr "Top 250"
+
+#: id:13410
+msgid "Tune in on Last.fm"
+msgstr "Prinde radio Last.fm"
+
+#: id:13411
+msgid "Minimum fan speed"
+msgstr "Viteză minimă ventilator"
+
+#: id:13412
+msgid "Play from here"
+msgstr "Redă începând de aici"
+
+#: id:13413
+msgid "Downloading"
+msgstr "Se descarcă"
+
+#: id:13414
+msgid "Include artists who appear only on compilations"
+msgstr "Include artiști care apar doar pe compilații"
+
+#: id:13415
+msgctxt "Auto context with id 13415"
+msgid "Render method"
+msgstr "Metodă de redare"
+
+#: id:13416
+msgid "Auto detect"
+msgstr "Detectare automată"
+
+#: id:13417
+msgid "Basic shaders (ARB)"
+msgstr "Shaderi de bază (ARB)"
+
+#: id:13418
+msgid "Advanced shaders (GLSL)"
+msgstr "Shaderi avansați (GLSL)"
+
+#: id:13419
+msgid "Software"
+msgstr "Software"
+
+#: id:13420
+msgid "Remove safely"
+msgstr "Elimină în siguranță"
+
+#: id:13421
+msgctxt "Auto context with id 13421"
+msgid "VDPAU"
+msgstr "VDPAU"
+
+#: id:13422
+msgid "Start slideshow here"
+msgstr "Pornește diapozitive de aici"
+
+#: id:13423
+msgid "Remember for this path"
+msgstr "Memorează pentru această cale"
+
+#: id:13424
+msgid "Use pixel buffer objects"
+msgstr "Folosește obiecte de preîncărcare pixel"
+
+#: id:13425
+msgid "Allow hardware acceleration (VDPAU)"
+msgstr "Permite accelerare hardware (VDPAU)"
+
+#: id:13426
+msgid "Allow hardware acceleration (VAAPI)"
+msgstr "Permite accelerare hardware (VAAPI)"
+
+#: id:13427
+msgid "Allow hardware acceleration (DXVA2)"
+msgstr "Permite accelerare hardware (DXVA2)"
+
+#: id:13428
+msgid "Allow hardware acceleration (CrystalHD)"
+msgstr "Permite accelerare hardware (CrystalHD)"
+
+#: id:13429
+msgid "Allow hardware acceleration (VDADecoder)"
+msgstr "Permite accelerare hardware (VDADecoder)"
+
+#: id:13430
+msgid "Allow hardware acceleration (OpenMax)"
+msgstr "Permite accelerare hardware (OpenMax)"
+
+#: id:13431
+msgid "Pixel Shaders"
+msgstr "Pixel shaders"
+
+#: id:13432
+msgid "Allow hardware acceleration (VideoToolbox)"
+msgstr "Permite accelerare hardware (VideoToolbox)"
+
+#: id:13500
+msgid "A/V sync method"
+msgstr "Metodă sincronizare A/V"
+
+#: id:13501
+msgid "Audio clock"
+msgstr "ceas audio"
+
+#: id:13502
+msgid "Video clock (Drop/Dupe audio)"
+msgstr "ceas video (aruncă/duplică audio)"
+
+#: id:13503
+msgid "Video clock (Resample audio)"
+msgstr "ceas video (reeșantionează audio)"
+
+#: id:13504
+msgid "Maximum resample amount (%)"
+msgstr "Grad maxim de reeșantionare (%)"
+
+#: id:13505
+msgid "Resample quality"
+msgstr "Calitate reeșantionare"
+
+#: id:13506
+msgid "Low(fast)"
+msgstr "Jos(rapid)"
+
+#: id:13507
+msgctxt "Auto context with id 13507"
+msgid "Medium"
+msgstr "Mediu"
+
+#: id:13508
+msgctxt "Auto context with id 13508"
+msgid "High"
+msgstr "Înalt"
+
+#: id:13509
+msgid "Really high(slow!)"
+msgstr "Foarte înalt(încet!)"
+
+#: id:13510
+msgid "Sync playback to display"
+msgstr "Sincronizează redarea cu reîmprospătarea ecranului"
+
+#: id:13550
+msgid "Pause during refresh rate change"
+msgstr "Pauză în timp ce se schimbă rata de reîmprospătare"
+
+#: id:13551
+msgctxt "Auto context with id 13551"
+msgid "Off"
+msgstr "Oprit"
+
+#: id:13552
+msgid "%.1f Second"
+msgstr "%.1f secundă"
+
+#: id:13553
+msgid "%.1f Seconds"
+msgstr "%.1f secunde"
+
+#: id:13600
+msgid "Apple remote"
+msgstr "Telecomandă Apple"
+
+#: id:13602
+msgid "Allow start of XBMC using the remote"
+msgstr "Permite pornirea XBMC folosind telecomanda"
+
+#: id:13603
+msgid "Sequence delay time"
+msgstr "Timp secvență de întârziere"
+
+#: id:13610
+msgctxt "Auto context with id 13610"
+msgid "Disabled"
+msgstr "Dezactivat"
+
+#: id:13611
+msgctxt "Auto context with id 13611"
+msgid "Standard"
+msgstr "Standard"
+
+#: id:13612
+msgid "Universal Remote"
+msgstr "Telecomandă universală"
+
+#: id:13613
+msgid "Multi Remote (Harmony)"
+msgstr "Multi-telecomandă (Harmony)"
+
+#: id:13620
+msgid "Apple Remote Error"
+msgstr "Eroare telecomandă Apple"
+
+#: id:13621
+msgid "Apple Remote support could be enabled."
+msgstr "Compatibilitate telecomandă Apple poate fi activată."
+
+#: id:14000
+msgid "Stack"
+msgstr "Stivă"
+
+#: id:14001
+msgid "Unstack"
+msgstr "Scoate din stivă"
+
+#: id:14003
+msgid "Downloading playlist file..."
+msgstr "Se descarcă fișierul listă de redare..."
+
+#: id:14004
+msgid "Downloading streams list..."
+msgstr "Se descarcă lista de fluxuri..."
+
+#: id:14005
+msgid "Parsing streams list..."
+msgstr "Se analizează lista de fluxuri..."
+
+#: id:14006
+msgid "Downloading streams list failed"
+msgstr "Descărcarea listei de fluxuri a eșuat"
+
+#: id:14007
+msgid "Downloading playlist file failed"
+msgstr "Descărcarea fișierului listă de redare a eșuat"
+
+#: id:14009
+msgid "Games directory"
+msgstr "Director de jocuri"
+
+#: id:14010
+msgid "Auto switch to thumbs based on"
+msgstr "Comutare automată a miniaturilor bazată pe"
+
+#: id:14011
+msgid "Enable auto switching to thumbs view"
+msgstr "Activează comutare automată către vizualizare miniaturi"
+
+#: id:14012
+msgid "- Use large icons"
+msgstr "- Folosește pictrograme mari"
+
+#: id:14013
+msgid "- Switch based on"
+msgstr "- Comutare bazată pe"
+
+#: id:14014
+msgid "- Percentage"
+msgstr "- Procentaj"
+
+#: id:14015
+msgid "No files and at least one thumb"
+msgstr "Niciun fișier și cel puțin o miniatură"
+
+#: id:14016
+msgid "At least one file and thumb"
+msgstr "Cel puțin un fișier și o miniatură"
+
+#: id:14017
+msgid "Percentage of thumbs"
+msgstr "Percentaj miniaturi"
+
+#: id:14018
+msgid "View options"
+msgstr "Opțiuni de afișare"
+
+#: id:14019
+msgid "Change area code 1"
+msgstr "Schimbare cod regiune 1"
+
+#: id:14020
+msgid "Change area code 2"
+msgstr "Schimbare cod regiune 2"
+
+#: id:14021
+msgid "Change area code 3"
+msgstr "Schimbare cod regiune 3"
+
+#: id:14022
+msgctxt "Auto context with id 14022"
+msgid "Library"
+msgstr "Mediatecă"
+
+#: id:14023
+msgid "No TV"
+msgstr "Fără TV"
+
+#: id:14024
+msgid "Enter the nearest large town"
+msgstr "Introduceți cel mai mare oraș apropiat"
+
+#: id:14025
+msgid "Video/Audio/DVD cache - Harddisk"
+msgstr "Preîncărcare Video/Audio/DVD - Disc dur"
+
+#: id:14026
+msgid "Video cache - DVD-ROM"
+msgstr "Preîncărcare video - DVD-ROM"
+
+#: id:14027
+msgctxt "Auto context with id 14027"
+msgid "- Local Network"
+msgstr "- Rețea locală"
+
+#: id:14028
+msgctxt "Auto context with id 14028"
+msgid "- Internet"
+msgstr "- Internet"
+
+#: id:14030
+msgid "Audio cache - DVD-ROM"
+msgstr "Preîncărcare audio - DVD-ROM"
+
+#: id:14031
+msgctxt "Auto context with id 14031"
+msgid "- Local Network"
+msgstr "- Rețea locală"
+
+#: id:14032
+msgctxt "Auto context with id 14032"
+msgid "- Internet"
+msgstr "- Internet"
+
+#: id:14034
+msgid "DVD cache - DVD-ROM"
+msgstr "Preîncărcare DVD - DVD-ROM"
+
+#: id:14035
+msgctxt "Auto context with id 14035"
+msgid "- Local Network"
+msgstr "- Rețea locală"
+
+#: id:14036
+msgctxt "Auto context with id 14036"
+msgid "Services"
+msgstr "Servicii"
+
+#: id:14038
+msgid "Network settings changed"
+msgstr "Setările de rețea au fost schimbate"
+
+#: id:14039
+msgid "XBMC requires to restart to change your"
+msgstr "XBMC trebuie repornit pentru a putea modifica"
+
+#: id:14040
+msgid "network setup. Would you like to restart now?"
+msgstr "setăriile rețelei. Doriți să reporniți XBMC acum?"
+
+#: id:14041
+msgid "Internet connection bandwidth limitation"
+msgstr "Limitare bandă conexiune Internet"
+
+#: id:14043
+msgid "- Shutdown while playing"
+msgstr "- Oprire în timpul redării"
+
+#: id:14044
+msgid "%i min"
+msgstr "%i min"
+
+#: id:14045
+msgid "%i sec"
+msgstr "%i sec"
+
+#: id:14046
+msgid "%i ms"
+msgstr "%i ms"
+
+#: id:14047
+msgid "%i %%"
+msgstr "%i %%"
+
+#: id:14048
+msgid "%i kbps"
+msgstr "%i kbps"
+
+#: id:14049
+msgid "%i kb"
+msgstr "%i kb"
+
+#: id:14050
+msgid "%i.0 dB"
+msgstr "%i.0 dB"
+
+#: id:14051
+msgid "Time format"
+msgstr "Format oră"
+
+#: id:14052
+msgid "Date format"
+msgstr "Format dată"
+
+#: id:14053
+msgid "GUI filters"
+msgstr "Filtre GUI"
+
+#: id:14055
+msgid "Use background scanning"
+msgstr "Folosește scanarea pe fundal"
+
+#: id:14056
+msgid "Stop scan"
+msgstr "Oprește scanarea"
+
+#: id:14057
+msgid "Not possible while scanning for media info"
+msgstr "Imposibil în timpul scanării pentru informații media"
+
+#: id:14058
+msgid "Film grain effect"
+msgstr "Efect granularitate film"
+
+#: id:14059
+msgid "Search for thumbnails on remote shares"
+msgstr "Caută miniaturi pe partajări la distanță"
+
+#: id:14060
+msgid "Unknown type cache - Internet"
+msgstr "Preîncărcare tip necunoscut - Internet"
+
+#: id:14061
+msgctxt "Auto context with id 14061"
+msgid "Auto"
+msgstr "Automat"
+
+#: id:14062
+msgid "Enter username for"
+msgstr "Introduceți nume utilizator pentru"
+
+#: id:14063
+msgid "Date & time"
+msgstr "Dată & oră"
+
+#: id:14064
+msgid "Set date"
+msgstr "Setează dată"
+
+#: id:14065
+msgid "Set time"
+msgstr "Setează oră"
+
+#: id:14066
+msgid "Enter the time in 24 hour HH:MM format"
+msgstr "Introduceți ora în format 24 ore HH:MM"
+
+#: id:14067
+msgid "Enter the date in DD/MM/YYYY format"
+msgstr "Introduceți data în format DD/MM/YYYY"
+
+#: id:14068
+msgid "Enter the IP address"
+msgstr "Introduceți adresa IP"
+
+#: id:14069
+msgid "Apply these settings now?"
+msgstr "Aplicați aceste setări acum?"
+
+#: id:14070
+msgid "Apply changes now"
+msgstr "Aplică modificările acum"
+
+#: id:14071
+msgid "Allow file renaming and deletion"
+msgstr "Permite redenumirea și ștergerea fișierelor"
+
+#: id:14074
+msgid "Set timezone"
+msgstr "Setează zona de timp"
+
+#: id:14075
+msgid "Use daylight saving time"
+msgstr "Folosește ora de vară"
+
+#: id:14076
+msgid "Add to favourites"
+msgstr "Adaugă la favorite"
+
+#: id:14077
+msgid "Remove from favourites"
+msgstr "Elimină din favorite"
+
+#: id:14078
+msgctxt "Auto context with id 14078"
+msgid "- Colours"
+msgstr "- Culori"
+
+#: id:14079
+msgid "Timezone country"
+msgstr "Țară fus orar"
+
+#: id:14080
+msgid "Timezone"
+msgstr "Fus orar"
+
+#: id:14081
+msgid "File lists"
+msgstr "Liste de fișiere"
+
+#: id:14082
+msgid "Show EXIF picture information"
+msgstr "Arată informațiile EXIF ale imaginilor"
+
+#: id:14083
+msgid "Use a fullscreen window rather than true fullscreen"
+msgstr "Folosește o fereastră pe tot ecranul în loc de ecran complet adevărat"
+
+#: id:14084
+msgid "Queue songs on selection"
+msgstr "La selectare pune cântecele la coadă"
+
+#: id:14086
+msgid "Playback"
+msgstr "Redare"
+
+#: id:14087
+msgid "DVDs"
+msgstr "DVD-uri"
+
+#: id:14088
+msgid "Play DVDs automatically"
+msgstr "Redă DVD-urile automat"
+
+#: id:14089
+msgid "Font to use for text subtitles"
+msgstr "Font utilizat în subtitrăriile text"
+
+#: id:14090
+msgid "International"
+msgstr "Internațional"
+
+#: id:14091
+msgid "Character set"
+msgstr "Set de caractere"
+
+#: id:14092
+msgid "Debugging"
+msgstr "Depanare"
+
+#: id:14093
+msgid "Security"
+msgstr "Securitate"
+
+#: id:14094
+msgid "Input devices"
+msgstr "Dispozitive intrare"
+
+#: id:14095
+msgid "Power saving"
+msgstr "Reducere consum"
+
+#: id:14096
+msgid "Rip"
+msgstr ""
+
+#: id:14097
+msgid "Audio CD Insert Action"
+msgstr ""
+
+#: id:14098
+msgctxt "Auto context with id 14098"
+msgid "Play"
+msgstr ""
+
+#: id:14099
+msgid "Eject disc when CD ripping is complete"
+msgstr ""
+
+#: id:15015
+msgctxt "Auto context with id 15015"
+msgid "Remove"
+msgstr "Elimină"
+
+#: id:15016
+msgid "Games"
+msgstr "Jocuri"
+
+#: id:15019
+msgid "Add"
+msgstr "Adaugă"
+
+#: id:15052
+msgid "Password"
+msgstr "Parolă"
+
+#: id:15100
+msgctxt "Auto context with id 15100"
+msgid "Library"
+msgstr "Mediatecă"
+
+#: id:15101
+msgid "Database"
+msgstr "Bază de date"
+
+#: id:15102
+msgid "* All albums"
+msgstr "* Toate albumele"
+
+#: id:15103
+msgid "* All artists"
+msgstr "* Toți artiștii"
+
+#: id:15104
+msgid "* All songs"
+msgstr "* Toate cântecele"
+
+#: id:15105
+msgid "* All genres"
+msgstr "* Toate genurile"
+
+#: id:15107
+msgid "Buffering..."
+msgstr "Preîncărcare..."
+
+#: id:15108
+msgid "Navigation sounds"
+msgstr "Sunete navigare"
+
+#: id:15109
+msgid "Skin default"
+msgstr "Standard pentru costum"
+
+#: id:15111
+msgid "- Theme"
+msgstr "- Temă"
+
+#: id:15112
+msgid "Default theme"
+msgstr "Temă implicită"
+
+#: id:15200
+msgid "Last.fm"
+msgstr "Last.fm"
+
+#: id:15201
+msgid "Submit songs to Last.fm"
+msgstr "Trimite cântece către Last.fm"
+
+#: id:15202
+msgid "Last.fm username"
+msgstr "Utilizator Last.fm"
+
+#: id:15203
+msgid "Last.fm password"
+msgstr "Parolă Last.fm"
+
+#: id:15204
+msgid "Unable to handshake: sleeping..."
+msgstr "Imposibil de conectat: repaus..."
+
+#: id:15205
+msgid "Please update XBMC"
+msgstr "Vă rugăm actualizați XBMC"
+
+#: id:15206
+msgid "Bad authorization: Check username and password"
+msgstr "Permisiune refuzată: Verificați numele de utilizator și parola"
+
+#: id:15207
+msgctxt "Auto context with id 15207"
+msgid "Connected"
+msgstr "conectat"
+
+#: id:15208
+msgid "Not connected"
+msgstr "Neconectat"
+
+#: id:15209
+msgid "Submit interval %i"
+msgstr "Interval de trimitere %i"
+
+#: id:15210
+msgid "Cached %i songs"
+msgstr "%i cântece preîncărcate"
+
+#: id:15211
+msgid "Submitting..."
+msgstr "Se trimite..."
+
+#: id:15212
+msgid "Submitting in %i secs"
+msgstr "Se trimite în %i secunde"
+
+#: id:15213
+msgid "Play using..."
+msgstr "Redă folosind..."
+
+#: id:15214
+msgid "Use smoothed A/V synchronization"
+msgstr "Folosește sincronizare A/V fină"
+
+#: id:15215
+msgid "Hide file names in thumbs view"
+msgstr "Ascunde numele fișierelor în vizualizare miniaturi"
+
+#: id:15216
+msgid "Play in party mode"
+msgstr "Redă în mod petrecere"
+
+#: id:15217
+msgid "Submit songs to Libre.fm"
+msgstr "Trimite cântece către Libre.fm"
+
+#: id:15218
+msgid "Libre.fm username"
+msgstr "Utilizator Libre.fm"
+
+#: id:15219
+msgid "Libre.fm password"
+msgstr "Parolă Libre.fm"
+
+#: id:15220
+msgid "Libre.fm"
+msgstr "Libre.fm"
+
+#: id:15221
+msgid "Song submission"
+msgstr "Trimitere cântece"
+
+#: id:15250
+msgid "Submit Last.fm radio to Last.fm"
+msgstr "Trimite cântece radio Last.fm către Last.fm"
+
+#: id:15251
+msgid "Connecting to Last.fm..."
+msgstr "Se conectează cu Last.fm..."
+
+#: id:15252
+msgid "Selecting station..."
+msgstr "Se selectează stația..."
+
+#: id:15253
+msgid "Search similar artists..."
+msgstr "Caută artiști similari..."
+
+#: id:15254
+msgid "Search similar tags..."
+msgstr "Caută etichete similare..."
+
+#: id:15255
+msgid "Your profile (%name%)"
+msgstr "Profilul tău (%name%)"
+
+#: id:15256
+msgid "Overall top tags"
+msgstr "Top etichete per total"
+
+#: id:15257
+msgid "Top artists for tag %name%"
+msgstr "Top artiști pentru eticheta %name%"
+
+#: id:15258
+msgid "Top albums for tag %name%"
+msgstr "Top top albume pentru eticheta %name%"
+
+#: id:15259
+msgid "Top tracks for tag %name%"
+msgstr "Top piste pentru eticheta %name%"
+
+#: id:15260
+msgid "Listen to tag %name% Last.fm radio"
+msgstr "Ascultă cu eticheta %name% radio Last.fm"
+
+#: id:15261
+msgid "Similar artists as %name%"
+msgstr "Artiști similari cu %name%"
+
+#: id:15262
+msgid "Top %name% albums"
+msgstr "Top %name% albume"
+
+#: id:15263
+msgid "Top %name% tracks"
+msgstr "Top %name% piste"
+
+#: id:15264
+msgid "Top %name% tags"
+msgstr "Top %name% etichete"
+
+#: id:15265
+msgid "Biggest fans of %name%"
+msgstr "Cei mai mari fani ai lui %name%"
+
+#: id:15266
+msgid "Listen to %name% fans Last.fm radio"
+msgstr "Ascultă fanii %name% radio Last.fm"
+
+#: id:15267
+msgid "Listen to %name% similar artists Last.fm radio"
+msgstr "Ascultă %name% artiști similari radio Last.fm"
+
+#: id:15268
+msgid "Top artists for user %name%"
+msgstr "Top artiști pentru utilizator %name%"
+
+#: id:15269
+msgid "Top albums for user %name%"
+msgstr "Top albume pentru utilizator %name%"
+
+#: id:15270
+msgid "Top tracks for user %name%"
+msgstr "Top piste pentru utilizator %name%"
+
+#: id:15271
+msgid "Friends of user %name%"
+msgstr "Prieteni cu utilizatorul %name%"
+
+#: id:15272
+msgid "Neighbours of user %name%"
+msgstr "Vecini cu utilizatorul %name%"
+
+#: id:15273
+msgid "Weekly artist chart for %name%"
+msgstr "Grafic artiști săptămânal pentru %name%"
+
+#: id:15274
+msgid "Weekly album chart for %name%"
+msgstr "Grafic albume săptămânal pentru %name%"
+
+#: id:15275
+msgid "Weekly track chart for %name%"
+msgstr "Grafic piste săptămânal pentru %name%"
+
+#: id:15276
+msgid "Listen to %name%'s neighbours Last.fm radio"
+msgstr "Ascultă radio Last.fm al veciniilor lui %name%"
+
+#: id:15277
+msgid "Listen to %name%'s personal Last.fm radio"
+msgstr "Ascultă radio personal Last.fm al lui %name%'s"
+
+#: id:15278
+msgid "Listen to %name%'s mix Last.fm radio"
+msgstr "Ascultă radio Last.fm mix %name%"
+
+#: id:15279
+msgid "Retrieving list from Last.fm..."
+msgstr "Se obține lista de la Last.fm..."
+
+#: id:15280
+msgid "Can't retrieve list from Last.fm..."
+msgstr "Nu se poate obține lista de la Last.fm..."
+
+#: id:15281
+msgid "Enter an artist name to find related ones"
+msgstr "Introduceți un nume de artist pentru a găsii artiști similari"
+
+#: id:15282
+msgid "Enter a tag name to find similar ones"
+msgstr "Introduceți o etichetă pentru a găsii si altele similare"
+
+#: id:15283
+msgid "Tracks recently listened by %name%"
+msgstr "Piese ascultate recent de %name%"
+
+#: id:15284
+msgid "Listen to %name%'s recommendations Last.fm radio"
+msgstr "Ascultă recomandăriile lui %name% pe radio Last.fm"
+
+#: id:15285
+msgid "Top tags for user %name%"
+msgstr "Top etichete pentru utilizator %name%"
+
+#: id:15287
+msgid "Do you want to add the current track to your loved tracks?"
+msgstr "Doriți să adăugați piesa curentă la piesele îndrăgite?"
+
+#: id:15288
+msgid "Do you want to ban the current track?"
+msgstr "Doriți să blocați piesa curentă?"
+
+#: id:15289
+msgid "Added to your loved tracks: '%s'."
+msgstr "Adaugată la piesele îndrăgite: '%s'."
+
+#: id:15290
+msgid "Could not add '%s' to your loved tracks."
+msgstr "Nu se poate adăuga '%s' la piesele dumneavoastră îndrăgite."
+
+#: id:15291
+msgid "Banned: '%s'."
+msgstr "Blocată: '%s'."
+
+#: id:15292
+msgid "Could not ban '%s'."
+msgstr "Nu se poate bloca '%s'."
+
+#: id:15293
+msgid "Tracks recently loved by %name%"
+msgstr "Piese îndrăgite recent de %name%"
+
+#: id:15294
+msgid "Tracks recently banned by %name%"
+msgstr "Piese blocate recent de %name%"
+
+#: id:15295
+msgid "Remove from loved tracks"
+msgstr "Elimină din piesele îndrăgite"
+
+#: id:15296
+msgid "Un-ban"
+msgstr "Deblochează"
+
+#: id:15297
+msgid "Do you want to remove this track from your loved tracks?"
+msgstr "Doriți să eliminați această piesă din piesele îndrăgite?"
+
+#: id:15298
+msgid "Do you want to un-ban this track?"
+msgstr "Doriți să deblocați această piesă?"
+
+#: id:15300
+msgid "Path not found or invalid"
+msgstr "Calea nu a putut fi găsită sau nu este validă."
+
+#: id:15301
+msgid "Could not connect to network server"
+msgstr "Nu se poate realiza conexiunea cu serverul de rețea."
+
+#: id:15302
+msgid "No servers found"
+msgstr "Niciun server găsit."
+
+#: id:15303
+msgid "Workgroup not found"
+msgstr "Grupul de lucru nu a fost gasit."
+
+#: id:15310
+msgid "Opening multi-path source"
+msgstr "Se deschide sursă multi-căi"
+
+#: id:15311
+msgid "Path:"
+msgstr "Cale:"
+
+#: id:16000
+msgctxt "Auto context with id 16000"
+msgid "General"
+msgstr "General"
+
+#: id:16002
+msgid "Internet lookup"
+msgstr "Căutare Internet"
+
+#: id:16003
+msgid "Player"
+msgstr "Redor"
+
+#: id:16004
+msgid "Play media from disc"
+msgstr "Redă media de pe disc"
+
+#: id:16008
+msgid "Enter new title"
+msgstr "Introduceți titlu nou"
+
+#: id:16009
+msgid "Enter the movie name"
+msgstr "Introduceți nume film"
+
+#: id:16010
+msgid "Enter the profile name"
+msgstr "Introduceți nume profil"
+
+#: id:16011
+msgid "Enter the album name"
+msgstr "Introduceți nume album"
+
+#: id:16012
+msgid "Enter the playlist name"
+msgstr "Introduceți nume listă de redare"
+
+#: id:16013
+msgid "Enter new filename"
+msgstr "Introduceți nume nou fișier"
+
+#: id:16014
+msgid "Enter folder name"
+msgstr "Introduceți nume dosar"
+
+#: id:16015
+msgid "Enter directory"
+msgstr "Introduceți director"
+
+#: id:16016
+msgid "Available options: %A, %T, %N, %B, %D, %G, %Y, %F, %S"
+msgstr "Opțiuni disponibile: %A, %T, %N, %B, %D, %G, %Y, %F, %S"
+
+#: id:16017
+msgid "Enter search string"
+msgstr "Introduceți șir de căutare"
+
+#: id:16018
+msgctxt "Auto context with id 16018"
+msgid "None"
+msgstr "Niciuna"
+
+#: id:16019
+msgid "Auto select"
+msgstr "Selectare automată"
+
+#: id:16020
+msgid "De-interlace"
+msgstr "De-întrețesere"
+
+#: id:16021
+msgid "Bob"
+msgstr "Bob"
+
+#: id:16022
+msgid "Bob (inverted)"
+msgstr "Bob (inversat)"
+
+#: id:16024
+msgid "Canceling..."
+msgstr "Renunțare..."
+
+#: id:16025
+msgid "Enter the artist name"
+msgstr "Introduceți nume artist"
+
+#: id:16026
+msgid "Playback failed"
+msgstr "Redarea a eșuat"
+
+#: id:16027
+msgid "One or more items failed to play."
+msgstr "Redarea unuia sau a mai multor elemente a eșuat."
+
+#: id:16028
+msgid "Enter value"
+msgstr "Introduceți valoare"
+
+#: id:16029
+msgid "Check the log file for details."
+msgstr "Verificați fișierul jurnal pentru detalii."
+
+#: id:16030
+msgid "Party mode aborted."
+msgstr "Mod petrecere anulat."
+
+#: id:16031
+msgid "No matching songs in the library."
+msgstr "Niciun cântec care să se potrivească în mediatecă."
+
+#: id:16032
+msgid "Could not initialize database."
+msgstr "Baza de date nu poate fi inițializată."
+
+#: id:16033
+msgid "Could not open database."
+msgstr "Baza de date nu poate fi deschisă."
+
+#: id:16034
+msgid "Could not get songs from database."
+msgstr "Nu pot fi preluate cântece din baza de date."
+
+#: id:16035
+msgid "Party mode playlist"
+msgstr "Listă de redare mod petrecere"
+
+#: id:16036
+msgid "De-interlace (Half)"
+msgstr "Deîntrețesere (jumătate)"
+
+#: id:16037
+msgid "Deinterlace video"
+msgstr "Deîntrețesere video"
+
+#: id:16038
+msgid "Deinterlace method"
+msgstr "Metodă de deîntrețesere"
+
+#: id:16039
+msgctxt "Auto context with id 16039"
+msgid "Off"
+msgstr "Oprită"
+
+#: id:16040
+msgctxt "Auto context with id 16040"
+msgid "Auto"
+msgstr "Automat"
+
+#: id:16041
+msgid "On"
+msgstr "Pornită"
+
+#: id:16100
+msgid "All Videos"
+msgstr "Toate filmele"
+
+#: id:16101
+msgid "Unwatched"
+msgstr "neprivite"
+
+#: id:16102
+msgid "Watched"
+msgstr "privite"
+
+#: id:16103
+msgid "Mark as watched"
+msgstr "Marchează ca privit"
+
+#: id:16104
+msgid "Mark as unwatched"
+msgstr "Marchează ca neprivit"
+
+#: id:16105
+msgid "Edit title"
+msgstr "Modifică numele"
+
+#: id:16200
+msgid "Operation was aborted"
+msgstr "Operațiunea a fost anulată"
+
+#: id:16201
+msgid "Copy failed"
+msgstr "Copierea a eșuat"
+
+#: id:16202
+msgid "Failed to copy at least one file"
+msgstr "Cel puțin un fișier nu a putut fi copiat"
+
+#: id:16203
+msgid "Move failed"
+msgstr "Mutarea a eșuat"
+
+#: id:16204
+msgid "Failed to move at least one file"
+msgstr "Cel puțin un fișier nu a putut fi mutat"
+
+#: id:16205
+msgid "Delete failed"
+msgstr "Ștergerea a eșuat"
+
+#: id:16206
+msgid "Failed to delete at least one file"
+msgstr "Cel puțin un fișier nu a putut fi șters"
+
+#: id:16300
+msgid "Video scaling method"
+msgstr "Metodă de scalare video"
+
+#: id:16301
+msgid "Nearest neighbour"
+msgstr "Nearest neighbour"
+
+#: id:16302
+msgid "Bilinear"
+msgstr "Bilinear"
+
+#: id:16303
+msgctxt "Auto context with id 16303"
+msgid "Bicubic"
+msgstr "Bicubic"
+
+#: id:16304
+msgid "Lanczos2"
+msgstr "Lanczos2"
+
+#: id:16305
+msgid "Lanczos3"
+msgstr "Lanczos3"
+
+#: id:16306
+msgid "Sinc8"
+msgstr "Sinc8"
+
+#: id:16307
+msgid "Bicubic (software)"
+msgstr "Bicubic (software)"
+
+#: id:16308
+msgid "Lanczos (software)"
+msgstr "Lanczos (software)"
+
+#: id:16309
+msgid "Sinc (software)"
+msgstr "Sinc (software)"
+
+#: id:16310
+msgid "Temporal"
+msgstr "Temporal"
+
+#: id:16311
+msgid "Temporal/Spatial"
+msgstr "Temporal/Spațial"
+
+#: id:16312
+msgid "(VDPAU)Noise Reduction"
+msgstr "(VDPAU) Reducere zgomot"
+
+#: id:16313
+msgid "(VDPAU)Sharpness"
+msgstr "(VDPAU) Claritate"
+
+#: id:16314
+msgid "Inverse Telecine"
+msgstr "Inverse Telecine"
+
+#: id:16315
+msgid "Lanczos3 optimized"
+msgstr "Lanczos3 optimizat"
+
+#: id:16316
+msgctxt "Auto context with id 16316"
+msgid "Auto"
+msgstr "Automat"
+
+#: id:16317
+msgid "Temporal (Half)"
+msgstr "Temporal (jumătate)"
+
+#: id:16318
+msgid "Temporal/Spatial (Half)"
+msgstr "Temporal/Spațial (jumătate)"
+
+#: id:16319
+msgid "DXVA"
+msgstr "DXVA"
+
+#: id:16320
+msgid "DXVA Bob"
+msgstr "DXVA Bob"
+
+#: id:16321
+msgid "DXVA Best"
+msgstr "DXVA maxim"
+
+#: id:16322
+msgid "Spline36"
+msgstr "Spline36"
+
+#: id:16323
+msgid "Spline36 optimized"
+msgstr "Spline36 optimizat"
+
+#: id:16324
+msgid "Software Blend"
+msgstr "Software Blend"
+
+#: id:16400
+msgid "Post-processing"
+msgstr "Post-procesare video"
+
+#: id:17500
+msgid "Display sleep timeout"
+msgstr "Timp de așteptare repaus ecran"
+
+#: id:19000
+msgid "Switch to channel"
+msgstr "Comută pe canalul"
+
+#: id:20000
+msgid "Saved music folder"
+msgstr "Dosar muzică salvată"
+
+#: id:20001
+msgid "Use external DVD player"
+msgstr "Folosește redor DVD extern"
+
+#: id:20002
+msgid "External DVD player"
+msgstr "Redor DVD extern"
+
+#: id:20003
+msgid "Trainers folder"
+msgstr "Dosar trainers"
+
+#: id:20004
+msgid "Screenshot folder"
+msgstr "Dosar capturi de ecran"
+
+#: id:20006
+msgid "Playlists folder"
+msgstr "Dosar liste de redare"
+
+#: id:20007
+msgid "Recordings"
+msgstr "Înregistrări"
+
+#: id:20008
+msgid "Screenshots"
+msgstr "Capturi de ecran"
+
+#: id:20009
+msgid "Use XBMC"
+msgstr "Folosește XBMC"
+
+#: id:20011
+msgid "Music playlists"
+msgstr "Liste de redare muzică"
+
+#: id:20012
+msgid "Video playlists"
+msgstr "Liste de redare video"
+
+#: id:20013
+msgid "Do you wish to launch the game?"
+msgstr "Doriți să lansați acest joc?"
+
+#: id:20014
+msgid "Sort by: Playlist"
+msgstr "Sortează după: Listă de redare"
+
+#: id:20015
+msgid "Remote thumb"
+msgstr "Imagine la distanță"
+
+#: id:20016
+msgid "Current thumb"
+msgstr "Imagine curentă"
+
+#: id:20017
+msgid "Local thumb"
+msgstr "Imagine locală"
+
+#: id:20018
+msgid "No thumb"
+msgstr "Nicio imagine"
+
+#: id:20019
+msgid "Choose thumbnail"
+msgstr "Alegere imagine"
+
+#: id:20023
+msgid "Conflict"
+msgstr "Conflict"
+
+#: id:20024
+msgid "Scan new"
+msgstr "Scanează noi"
+
+#: id:20025
+msgid "Scan all"
+msgstr "Scanează toate"
+
+#: id:20026
+msgid "Region"
+msgstr "Regiune"
+
+#: id:20037
+msgid "Summary"
+msgstr "Rezumat"
+
+#: id:20038
+msgid "Lock music window"
+msgstr "Blochează fereastra de muzică"
+
+#: id:20039
+msgid "Lock videos window"
+msgstr "Blochează fereastra de video"
+
+#: id:20040
+msgid "Lock pictures window"
+msgstr "Blochează fereastra de imagini"
+
+#: id:20041
+msgid "Lock programs & scripts windows"
+msgstr "Blochează ferestrele programe și scripturi"
+
+#: id:20042
+msgid "Lock file manager"
+msgstr "Blochează gestionarul de fișiere"
+
+#: id:20043
+msgid "Lock settings"
+msgstr "Configurare blocare"
+
+#: id:20044
+msgid "Start fresh"
+msgstr "Pornește nou"
+
+#: id:20045
+msgid "Enter master mode"
+msgstr "Intrare în modul principal"
+
+#: id:20046
+msgid "Leave master mode"
+msgstr "Părăsire mod principal"
+
+#: id:20047
+msgid "Create profile '%s'?"
+msgstr "Creați profilul '%s'?"
+
+#: id:20048
+msgid "Start with fresh settings"
+msgstr "Porniți cu setări noi"
+
+#: id:20049
+msgid "Best available"
+msgstr "Cel mai bun disponibil"
+
+#: id:20050
+msgid "Auto-switch between 16x9 and 4x3"
+msgstr "Schimbă automat între 16:9 și 4:3"
+
+#: id:20051
+msgid "Treat stacked files as single file"
+msgstr "Tratează fișierele în stivă ca fișiere singulare"
+
+#: id:20052
+msgid "Caution"
+msgstr "Atenție"
+
+#: id:20053
+msgid "Left master mode"
+msgstr "Am părăsit modul principal"
+
+#: id:20054
+msgid "Entered master mode"
+msgstr "Am intrat în modul principal"
+
+#: id:20055
+msgid "Allmusic.com thumb"
+msgstr "Miniatură Allmusic.com"
+
+#: id:20057
+msgid "Remove thumbnail"
+msgstr "Elimină miniatură"
+
+#: id:20058
+msgid "Add profile..."
+msgstr "Adaugă profil..."
+
+#: id:20059
+msgid "Query info for all albums"
+msgstr "Cere info pt. toate albumele"
+
+#: id:20060
+msgctxt "Auto context with id 20060"
+msgid "Media info"
+msgstr "Informații media"
+
+#: id:20061
+msgctxt "Auto context with id 20061"
+msgid "Separate"
+msgstr "Separă"
+
+#: id:20062
+msgid "Shares with default"
+msgstr "Partajări implicite"
+
+#: id:20063
+msgid "Shares with default (read only)"
+msgstr "Partajări implicite (doar citire)"
+
+#: id:20064
+msgid "Copy default"
+msgstr "Copiază implicit"
+
+#: id:20065
+msgid "Profile picture"
+msgstr "Imagine profil"
+
+#: id:20066
+msgid "Lock preferences"
+msgstr "Preferințe blocare"
+
+#: id:20067
+msgid "Edit profile"
+msgstr "Modificare profil"
+
+#: id:20068
+msgid "Profile lock"
+msgstr "Blocare profil"
+
+#: id:20069
+msgid "Could not create folder"
+msgstr "Dosarul nu poate fi creat"
+
+#: id:20070
+msgid "Profile directory"
+msgstr "Director profil"
+
+#: id:20071
+msgid "Start with fresh media sources"
+msgstr "Porniți cu surse media noi"
+
+#: id:20072
+msgid "Make sure the selected folder is writable"
+msgstr "Verificați dacă în dosarul selectat se poate scrie."
+
+#: id:20073
+msgid "and that the new folder name is valid"
+msgstr "și dacă noul nume al dosarului este valid"
+
+#: id:20074
+msgid "MPAA rating"
+msgstr "Clasă MPAA"
+
+#: id:20075
+msgid "Enter master lock code"
+msgstr "Introduceți codul de blocare principal"
+
+#: id:20076
+msgid "Ask for master lock code on startup"
+msgstr "Cere codul principal la pornire"
+
+#: id:20077
+msgid "Skin settings"
+msgstr "Setări costum"
+
+#: id:20078
+msgid "- no link set -"
+msgstr "- nicio legătură setată -"
+
+#: id:20079
+msgid "Enable animations"
+msgstr "Activează animații"
+
+#: id:20080
+msgid "Disable RSS during music"
+msgstr "Dezactivează RSS în timpul redării audio"
+
+#: id:20081
+msgid "Enable shortcut buttons"
+msgstr "Activează butoanele scurtături"
+
+#: id:20082
+msgid "Show programs in main menu"
+msgstr "Afișează programe în meniul principal"
+
+#: id:20083
+msgid "Show music info"
+msgstr "Arată informații despre muzică"
+
+#: id:20084
+msgid "Show weather info"
+msgstr "Arată informații despre vreme"
+
+#: id:20085
+msgid "Show system info"
+msgstr "Afișează informații despre sistem"
+
+#: id:20086
+msgid "Show available disc space C: E: F:"
+msgstr "Afișează spațiul disponibil pe disc C: E: F:"
+
+#: id:20087
+msgid "Show available disc space E: F: G:"
+msgstr "Afișează spațiul disponibil pe disc E: F: G:"
+
+#: id:20088
+msgid "Weather info"
+msgstr "Informații despre vreme"
+
+#: id:20089
+msgid "Drive space free"
+msgstr "Spațiu liber pe disc"
+
+#: id:20090
+msgid "Enter the name of an existing share"
+msgstr "Introduceți numele unei partajări existente"
+
+#: id:20091
+msgid "Lock code"
+msgstr "Cod de blocare"
+
+#: id:20092
+msgid "Load profile"
+msgstr "Încarcă profilul"
+
+#: id:20093
+msgid "Profile name"
+msgstr "Nume profil"
+
+#: id:20094
+msgctxt "Auto context with id 20094"
+msgid "Media sources"
+msgstr "Surse media"
+
+#: id:20095
+msgid "Enter profile lock code"
+msgstr "Introduceți codul de blocare profil"
+
+#: id:20096
+msgctxt "Auto context with id 20096"
+msgid "Login screen"
+msgstr "Autentificare"
+
+#: id:20097
+msgid "Fetching album info"
+msgstr "Se extrag informații album"
+
+#: id:20098
+msgid "Fetching info for album"
+msgstr "Se extrag informații pentru album"
+
+#: id:20099
+msgid "Can't rip CD or track while playing from CD"
+msgstr "CD-ul sau pista nu pot fi copiate în timp ce se redă de pe CD"
+
+#: id:20100
+msgid "Master lock code and settings"
+msgstr "Cod de blocare principal și setări"
+
+#: id:20101
+msgid "Entering master lock code always enables master mode"
+msgstr "Introducând codul de blocare principal activează întotdeauna modul principal"
+
+#: id:20102
+msgid "or copy from default?"
+msgstr "sau copiați de la implicit?"
+
+#: id:20103
+msgid "Save changes to profile?"
+msgstr "Salvați modificările în profil?"
+
+#: id:20104
+msgid "Old settings found."
+msgstr "Au fost găsite setăriile vechi."
+
+#: id:20105
+msgid "Do you want to use them?"
+msgstr "Doriți să le folosiți?"
+
+#: id:20106
+msgid "Old media sources found."
+msgstr "Sursele media vechi au fost găsite."
+
+#: id:20107
+msgid "Separate (locked)"
+msgstr "Separă (blocat)"
+
+#: id:20108
+msgid "Root"
+msgstr "Rădăcină"
+
+#: id:20109
+msgid "- Zoom"
+msgstr "- Zoom"
+
+#: id:20110
+msgid "UPnP settings"
+msgstr "Setări UPnP"
+
+#: id:20111
+msgid "Autostart UPnP client"
+msgstr "Pornește client UPnP automat"
+
+#: id:20112
+msgid "Last login: %s"
+msgstr "Ultima autentificare: %s"
+
+#: id:20113
+msgid "Never logged on"
+msgstr "Niciodată autentificat"
+
+#: id:20114
+msgid "Profile %i / %i"
+msgstr "Profil %i / %i"
+
+#: id:20115
+msgid "User login / Select a profile"
+msgstr "Autentificare utilizator / Selectați un profil"
+
+#: id:20116
+msgid "Use lock on login screen"
+msgstr "Folosește blocare în ecranul de autentificare"
+
+#: id:20117
+msgid "Invalid lock code."
+msgstr "Codul de blocare nu este valid."
+
+#: id:20118
+msgid "This requires the master lock to be set."
+msgstr "Aceasta necesită ca blocarea principală să fie setată."
+
+#: id:20119
+msgid "Would you like to set it now?"
+msgstr "Doriți să o setați acum?"
+
+#: id:20120
+msgid "Loading program information"
+msgstr "Se încarcă informații program"
+
+#: id:20121
+msgid "Party on!"
+msgstr "Petrecere activată!"
+
+#: id:20122
+msgid "True"
+msgstr "Adevărat"
+
+#: id:20123
+msgid "Mixing drinks"
+msgstr "Amestecare băuturi"
+
+#: id:20124
+msgid "Filling glasses"
+msgstr "Umplere pahare"
+
+#: id:20125
+msgid "Logged on as"
+msgstr "Autentificat ca"
+
+#: id:20126
+msgid "Log off"
+msgstr "Dezautentificare"
+
+#: id:20128
+msgid "Go to root"
+msgstr "Du-te la rădăcină"
+
+#: id:20129
+msgid "Weave"
+msgstr "Weave"
+
+#: id:20130
+msgid "Weave (inverted)"
+msgstr "Weave (inverted)"
+
+#: id:20131
+msgid "Blend"
+msgstr "Blend"
+
+#: id:20132
+msgid "Restart video"
+msgstr "Repornește video"
+
+#: id:20133
+msgid "Edit network location"
+msgstr "Modifică locație rețea"
+
+#: id:20134
+msgid "Remove network location"
+msgstr "Elimină locație rețea"
+
+#: id:20135
+msgid "Do you want to scan the folder?"
+msgstr "Doriți să scanați dosarul?"
+
+#: id:20136
+msgid "Memory unit"
+msgstr "Unitate de memorie"
+
+#: id:20137
+msgid "Memory unit mounted"
+msgstr "Unitate de memorie montată"
+
+#: id:20138
+msgid "Unable to mount memory unit"
+msgstr "Nu se poate monta unitatea de memorie"
+
+#: id:20139
+msgid "In port %i, slot %i"
+msgstr "În port %i, slot %i"
+
+#: id:20140
+msgid "Lock screensaver"
+msgstr "Blochează protector ecran"
+
+#: id:20141
+msgid "Set"
+msgstr "Setează"
+
+#: id:20142
+msgctxt "Auto context with id 20142"
+msgid "Username"
+msgstr "Nume utilizator"
+
+#: id:20143
+msgid "Enter password for"
+msgstr "Introduceți parola pentru"
+
+#: id:20144
+msgid "Shutdown timer"
+msgstr "Planificare închidere"
+
+#: id:20145
+msgid "Shutdown interval (in minutes)"
+msgstr "Planificare închidere\n(în minute)"
+
+#: id:20146
+msgid "Started, shutdown in %im"
+msgstr "Pornită, închidere în %i minute"
+
+#: id:20147
+msgid "Shutdown in 30 minutes"
+msgstr "Închidere în 30 de minute"
+
+#: id:20148
+msgid "Shutdown in 60 minutes"
+msgstr "Închidere în 60 de minute"
+
+#: id:20149
+msgid "Shutdown in 120 minutes"
+msgstr "Închidere în 120 de minute"
+
+#: id:20150
+msgid "Custom shutdown timer"
+msgstr "Planificare închidere"
+
+#: id:20151
+msgid "Cancel shutdown timer"
+msgstr "Renunță la plan. închidere"
+
+#: id:20152
+msgid "Lock preferences for %s"
+msgstr "Blochează preferințele pentru %s"
+
+#: id:20153
+msgid "Browse..."
+msgstr "Alege..."
+
+#: id:20154
+msgid "Summary information"
+msgstr "Rezumat informații"
+
+#: id:20155
+msgid "Storage information"
+msgstr "Informații stocare"
+
+#: id:20156
+msgid "Hard disk information"
+msgstr "Informații disc dur (hard disk)"
+
+#: id:20157
+msgid "DVD-ROM information"
+msgstr "Informații DVD-ROM"
+
+#: id:20158
+msgid "Network information"
+msgstr "Informații rețea"
+
+#: id:20159
+msgid "Video information"
+msgstr "Informații video"
+
+#: id:20160
+msgid "Hardware information"
+msgstr "Informații componente (hardware)"
+
+#: id:20161
+msgid "Total"
+msgstr "Total"
+
+#: id:20162
+msgid "Used"
+msgstr "Folosit"
+
+#: id:20163
+msgid "of"
+msgstr "din"
+
+#: id:20164
+msgid "Locking not supported"
+msgstr "Blocarea nu poate fi activată"
+
+#: id:20165
+msgid "Not locked"
+msgstr "Neblocat"
+
+#: id:20166
+msgid "Locked"
+msgstr "Blocat"
+
+#: id:20167
+msgid "Frozen"
+msgstr "Înghețat"
+
+#: id:20168
+msgid "Requires reset"
+msgstr "Necesită resetare"
+
+#: id:20169
+msgid "Week"
+msgstr "Slab"
+
+#: id:20170
+msgid "Line"
+msgstr "Linie"
+
+#: id:20171
+msgid "Windows network (SMB)"
+msgstr "Rețea Windows (SMB)"
+
+#: id:20172
+msgid "XBMSP server"
+msgstr "Server XBMSP"
+
+#: id:20173
+msgctxt "Auto context with id 20173"
+msgid "FTP server"
+msgstr "Server FTP"
+
+#: id:20174
+msgid "iTunes music share (DAAP)"
+msgstr "Partajare muzică iTunes (DAAP)"
+
+#: id:20175
+msgid "UPnP server"
+msgstr "Server UPnP"
+
+#: id:20176
+msgid "Show video info"
+msgstr "Arată informații video"
+
+#: id:20177
+msgid "Done"
+msgstr "Gata"
+
+#: id:20178
+msgid "Shift"
+msgstr "Shift"
+
+#: id:20179
+msgid "Caps Lock"
+msgstr "Majuscule"
+
+#: id:20180
+msgid "Symbols"
+msgstr "Simbloluri"
+
+#: id:20181
+msgid "Backspace"
+msgstr "Șterge"
+
+#: id:20182
+msgid "Space"
+msgstr "Spațiu"
+
+#: id:20183
+msgid "Reload skin"
+msgstr "Reîncarcă costum"
+
+#: id:20184
+msgid "Rotate pictures using EXIF information"
+msgstr "Rotește imaginile folosind informațiile EXIF"
+
+#: id:20185
+msgid "Use poster view styles for TV shows"
+msgstr "Folosește stiluri vizualizare afiș pentru serialele TV"
+
+#: id:20186
+msgid "Please wait"
+msgstr "Vă rugăm așteptați"
+
+#: id:20187
+msgid "UPnP"
+msgstr ""
+
+#: id:20189
+msgid "Enable auto scrolling for plot & review"
+msgstr "Activează derulare automată pentru intrigă și recenzie"
+
+#: id:20190
+msgctxt "Auto context with id 20190"
+msgid "Custom"
+msgstr "Particularizat"
+
+#: id:20191
+msgid "Enable debug logging"
+msgstr "Activează jurnalizare depanare"
+
+#: id:20192
+msgid "Download additional information during updates"
+msgstr "Descarcă informații adiționale în timpul actualizărilor"
+
+#: id:20193
+msgid "Default service for album information"
+msgstr "Serviciu implicit pentru informații albume"
+
+#: id:20194
+msgid "Default service for artist information"
+msgstr "Serviciu implicit pentru informații artiști"
+
+#: id:20195
+msgid "Change scraper"
+msgstr "Schimbă catalogul"
+
+#: id:20196
+msgid "Export music library"
+msgstr "Exportă mediateca audio"
+
+#: id:20197
+msgid "Import music library"
+msgstr "Importă mediatecă"
+
+#: id:20198
+msgid "No artist found!"
+msgstr "Niciun artist găsit!"
+
+#: id:20199
+msgid "Downloading artist info failed"
+msgstr "Descărcarea informațiilor despre artist a eșuat"
+
+#: id:20250
+msgid "Party on! (videos)"
+msgstr "Petrecere pornită! (video)"
+
+#: id:20251
+msgid "Mixing drinks (videos)"
+msgstr "Amestecare băuturi (video)"
+
+#: id:20252
+msgid "Filling glasses (videos)"
+msgstr "Umplere pahare (video)"
+
+#: id:20253
+msgid "WebDAV server (HTTP)"
+msgstr "Server WebDAV (HTTP)"
+
+#: id:20254
+msgid "WebDAV server (HTTPS)"
+msgstr "Server WebDAV (HTTPS)"
+
+#: id:20255
+msgid "First logon, edit your profile"
+msgstr "Prima autentificare, modificați-vă profilul"
+
+#: id:20256
+msgid "HTS Tvheadend client"
+msgstr "Client HTS Tvheadend"
+
+#: id:20257
+msgid "VDR Streamdev client"
+msgstr "Client VDR Streamdev"
+
+#: id:20258
+msgid "MythTV client"
+msgstr "Client MythTV"
+
+#: id:20259
+msgid "Network Filesystem (NFS)"
+msgstr "Network Filesystem (NFS)"
+
+#: id:20260
+msgid "Secure Shell (SSH/SFTP)"
+msgstr "Secure Shell (SSH/SFTP)"
+
+#: id:20261
+msgid "Apple Filing Protocol (AFP)"
+msgstr "Apple Filing Protocol (AFP)"
+
+#: id:20300
+msgid "Web server directory (HTTP)"
+msgstr "Director server Web (HTTP)"
+
+#: id:20301
+msgid "Web server directory (HTTPS)"
+msgstr "Director server Web (HTTPS)"
+
+#: id:20302
+msgid "Unable to write to folder:"
+msgstr "Nu se poate scrie în dosarul:"
+
+#: id:20303
+msgid "Do you want to skip and proceed?"
+msgstr "Doriți să săriți și să continuați?"
+
+#: id:20304
+msgid "RSS Feed"
+msgstr "Flux RSS"
+
+#: id:20307
+msgid "Secondary DNS"
+msgstr "DNS secundar"
+
+#: id:20308
+msgid "DHCP server:"
+msgstr "Server DHCP:"
+
+#: id:20309
+msgid "Make new folder"
+msgstr "Creează dosar nou"
+
+#: id:20310
+msgid "Dim LCD on playback"
+msgstr "Întunecă LCD la redare"
+
+#: id:20311
+msgid "Unknown or onboard (protected)"
+msgstr "Necunoscut sau integrat (protejat)"
+
+#: id:20312
+msgid "Dim LCD on paused"
+msgstr "Întunecă LCD în pauză"
+
+#: id:20314
+msgid "Videos - Library"
+msgstr "Mediatecă video"
+
+#: id:20316
+msgid "Sort by: ID"
+msgstr "Sort. după: ID"
+
+#: id:20324
+msgid "Play part..."
+msgstr "Redă parte..."
+
+#: id:20325
+msgid "Calibration reset"
+msgstr "Resetare calibrare"
+
+#: id:20326
+msgid "This will reset the calibration values for %s"
+msgstr "Vor fi resetate valorile de calibrare pentru %s"
+
+#: id:20327
+msgid "to it's default values."
+msgstr "către valorile implicite."
+
+#: id:20328
+msgid "Browse for destination"
+msgstr "Alege destinație"
+
+#: id:20329
+msgid "Movies are in separate folders that match the movie title"
+msgstr "Filmele sunt în dosare separate care se potrivesc cu numele filmului"
+
+#: id:20330
+msgid "Use folder names for lookups"
+msgstr "Folosește nume dosare la căutări"
+
+#: id:20331
+msgctxt "Auto context with id 20331"
+msgid "File"
+msgstr "Fișier"
+
+#: id:20332
+msgid "Use file or folder names in lookups?"
+msgstr "Folosește nume fișier sau nume dosar la căutări?"
+
+#: id:20333
+msgid "Set content"
+msgstr "Alegere conținut"
+
+#: id:20334
+msgid "Folder"
+msgstr "Dosar"
+
+#: id:20335
+msgid "Look for content recursively?"
+msgstr "Caută conținut recursiv?"
+
+#: id:20336
+msgid "Unlock sources"
+msgstr "Deblochează surse"
+
+#: id:20337
+msgid "Actor"
+msgstr "Actor"
+
+#: id:20338
+msgid "Movie"
+msgstr "Film"
+
+#: id:20339
+msgid "Director"
+msgstr "Regizor"
+
+#: id:20340
+msgid "Do you want to remove all items within"
+msgstr "Doriți să eliminați toate elementele din interiorul"
+
+#: id:20341
+msgid "this path from the XBMC library?"
+msgstr "acestei căi din mediateca XBMC?"
+
+#: id:20342
+msgctxt "Auto context with id 20342"
+msgid "Movies"
+msgstr "Filme"
+
+#: id:20343
+msgid "TV shows"
+msgstr "Seriale"
+
+#: id:20344
+msgid "This directory contains"
+msgstr "Acest dosar conține"
+
+#: id:20345
+msgid "Run automated scan"
+msgstr "Execută scanare automată"
+
+#: id:20346
+msgid "Scan recursively"
+msgstr "Scanează recursiv"
+
+#: id:20347
+msgid "as"
+msgstr "ca"
+
+#: id:20348
+msgid "Directors"
+msgstr "Regizori"
+
+#: id:20349
+msgid "No video files found in this path!"
+msgstr "Nu a fost găsit niciun fișier video în această cale!"
+
+#: id:20350
+msgid "votes"
+msgstr "voturi"
+
+#: id:20351
+msgid "TV show information"
+msgstr "Informații serial"
+
+#: id:20352
+msgid "Episode information"
+msgstr "Informații episod"
+
+#: id:20353
+msgid "Loading TV show details"
+msgstr "Încărcare informații serial"
+
+#: id:20354
+msgid "Fetching episode guide"
+msgstr "Se obține ghid episoade"
+
+#: id:20355
+msgid "Loading info for episodes in directory"
+msgstr "Se descarcă informații pentru episoadele din director"
+
+#: id:20356
+msgid "Select TV show:"
+msgstr "Selectați serial:"
+
+#: id:20357
+msgid "Enter the TV show name"
+msgstr "Introduceți numele serialului"
+
+#: id:20358
+msgid "Season %i"
+msgstr "Sezonul %i"
+
+#: id:20359
+msgid "Episode"
+msgstr "Episod"
+
+#: id:20360
+msgid "Episodes"
+msgstr "Episoade"
+
+#: id:20361
+msgid "Loading episode details"
+msgstr "Se descarcă informații episod"
+
+#: id:20362
+msgid "Remove episode from library"
+msgstr "Eliminare episod din mediatecă"
+
+#: id:20363
+msgid "Remove TV show from library"
+msgstr "Eliminare serial din mediatecă"
+
+#: id:20364
+msgid "TV show"
+msgstr "Serial"
+
+#: id:20365
+msgid "Episode plot"
+msgstr "Intrigă episod"
+
+#: id:20366
+msgid "* All seasons"
+msgstr "* Toate sezoanele"
+
+#: id:20367
+msgid "Hide watched"
+msgstr "Ascunde privite"
+
+#: id:20368
+msgid "Prod code"
+msgstr "Cod producție"
+
+#: id:20369
+msgid "Show plot for unwatched items"
+msgstr "Arată intrigă pentru elementele neprivite"
+
+#: id:20370
+msgid "* Hidden to prevent spoilers *"
+msgstr "* Ascuns pentru a preveni descoperirea acțiunii *"
+
+#: id:20371
+msgid "Set season thumb"
+msgstr "Alegere afiș sezon"
+
+#: id:20372
+msgid "Season image"
+msgstr "Imagine sezon"
+
+#: id:20373
+msgid "Season"
+msgstr "Sezon"
+
+#: id:20374
+msgid "Downloading movie information"
+msgstr "Descărcare informații filme"
+
+#: id:20375
+msgid "Unassign content"
+msgstr "Eliminare atribuire conținut"
+
+#: id:20376
+msgid "Original title"
+msgstr "Nume original"
+
+#: id:20377
+msgid "Refresh TV show information"
+msgstr "Actualizare informații serial"
+
+#: id:20378
+msgid "Refresh info for all episodes?"
+msgstr "Actualizați informațiile pentru toate episoadele?"
+
+#: id:20379
+msgid "Selected folder contains a single TV show"
+msgstr "Dosarul selectat conține un singur serial"
+
+#: id:20380
+msgid "Exclude selected folder from scans"
+msgstr "Exclude dosarul selectat la scanări"
+
+#: id:20381
+msgid "Specials"
+msgstr "Speciale"
+
+#: id:20382
+msgid "Automatically grab season thumbs"
+msgstr "Obține miniaturi sezon automat"
+
+#: id:20383
+msgid "Selected folder contains a single video"
+msgstr "Dosarul selectat conține un singur fișier video"
+
+#: id:20384
+msgid "Link to TV show"
+msgstr "Legătură către serial"
+
+#: id:20385
+msgid "Remove link to TV show"
+msgstr "Elimină legătură către serial"
+
+#: id:20386
+msgid "Recently added movies"
+msgstr "Filme adăugate recent"
+
+#: id:20387
+msgid "Recently added episodes"
+msgstr "Episoade adăugate recent"
+
+#: id:20388
+msgid "Studios"
+msgstr "Studiouri"
+
+#: id:20389
+msgid "Music videos"
+msgstr "Videoclipuri"
+
+#: id:20390
+msgid "Recently added music videos"
+msgstr "Videoclipuri adăugate recent"
+
+#: id:20391
+msgid "Music video"
+msgstr "Videoclip"
+
+#: id:20392
+msgid "Remove music video from library"
+msgstr "Eliminare videoclip din mediatecă"
+
+#: id:20393
+msgctxt "Auto context with id 20393"
+msgid "Music video information"
+msgstr "Informații videoclip"
+
+#: id:20394
+msgid "Loading music video information"
+msgstr "Încărcare informații videoclip"
+
+#: id:20395
+msgid "Mixed"
+msgstr "Amestecat"
+
+#: id:20396
+msgid "Go to albums by artist"
+msgstr "Du-te la albume după artist"
+
+#: id:20397
+msgid "Go to album"
+msgstr "Du-te la album"
+
+#: id:20398
+msgid "Play song"
+msgstr "Redă cântec"
+
+#: id:20399
+msgid "Go to music videos from album"
+msgstr "Du-te la videoclipuri din album"
+
+#: id:20400
+msgid "Go to music videos by artist"
+msgstr "Du-te la videoclipuri după artist"
+
+#: id:20401
+msgid "Play music video"
+msgstr "Redă videoclip"
+
+#: id:20402
+msgid "Download actor thumbnails when adding to library"
+msgstr "Descarcă miniaturi actori la adăugare în mediatecă"
+
+#: id:20403
+msgid "Set actor thumb"
+msgstr "Alege fotografie actor"
+
+#: id:20405
+msgid "Remove episode bookmark"
+msgstr "Elimină semn de carte episod"
+
+#: id:20406
+msgid "Set episode bookmark"
+msgstr "Setează semn de carte episod"
+
+#: id:20407
+msgid "Scraper settings"
+msgstr "Setări scraper"
+
+#: id:20408
+msgid "Downloading music video information"
+msgstr "Descărcare informații videoclipuri"
+
+#: id:20409
+msgid "Downloading TV show information"
+msgstr "Descărcare informații serial"
+
+#: id:20410
+msgid "Trailer"
+msgstr "Secvențe"
+
+#: id:20411
+msgid "Flatten"
+msgstr "Netezește"
+
+#: id:20412
+msgid "Flatten TV shows"
+msgstr "Netezește seriale"
+
+#: id:20413
+msgid "Get fanart"
+msgstr "Obține fundal"
+
+#: id:20414
+msgid "Show Fanart in video and music libraries"
+msgstr "Arată fundale în mediateciile de filme și muzică"
+
+#: id:20415
+msgid "Scanning for new content"
+msgstr "Se scanează pentru conținut nou"
+
+#: id:20416
+msgid "First aired"
+msgstr "Prima difuzare"
+
+#: id:20417
+msgid "Writer"
+msgstr "Scenarist"
+
+#: id:20419
+msgid "Replace file names with library titles"
+msgstr "Înlocuiește numele fișierelor cu titlurile din mediatecă"
+
+#: id:20420
+msgctxt "Auto context with id 20420"
+msgid "Never"
+msgstr "niciodată"
+
+#: id:20421
+msgid "If only one season"
+msgstr "doar dacă este un singur sezon"
+
+#: id:20422
+msgid "Always"
+msgstr "întotdeauna"
+
+#: id:20423
+msgid "Has trailer"
+msgstr "Are trailer"
+
+#: id:20424
+msgid "False"
+msgstr "Fals"
+
+#: id:20425
+msgid "Fanart slideshow"
+msgstr "Prezentare diapozitive Fanart"
+
+#: id:20426
+msgid "Export to a single file or separate"
+msgstr "Exportați către un singur fișier sau"
+
+#: id:20427
+msgid "files per entry?"
+msgstr "fișiere separate pentru fiecare intrare?"
+
+#: id:20428
+msgid "Single file"
+msgstr "Un singur fișier"
+
+#: id:20429
+msgctxt "Auto context with id 20429"
+msgid "Separate"
+msgstr "Separat"
+
+#: id:20430
+msgid "Export thumbnails and fanart?"
+msgstr "Exportare miniaturi și Fanart?"
+
+#: id:20431
+msgid "Overwrite old files?"
+msgstr "Suprascrie fișierele vechi?"
+
+#: id:20432
+msgid "Exclude path from library updates"
+msgstr "Exclude calea din actualizăriile mediatecii"
+
+#: id:20433
+msgid "Extract thumbnails and video information"
+msgstr "Extrage miniaturi și informații video"
+
+#: id:20434
+msgid "Sets"
+msgstr "Seturi"
+
+#: id:20435
+msgid "Set movieset thumb"
+msgstr "Alege miniatură set de filme"
+
+#: id:20436
+msgid "Export actor thumbs?"
+msgstr "Exportare miniaturi actor?"
+
+#: id:20437
+msgid "Choose fanart"
+msgstr "Alegere Fanart"
+
+#: id:20438
+msgid "Local fanart"
+msgstr "Fanart local"
+
+#: id:20439
+msgid "No fanart"
+msgstr "Fără Fanart"
+
+#: id:20440
+msgid "Current fanart"
+msgstr "Fanart curent"
+
+#: id:20441
+msgid "Remote fanart"
+msgstr "Fanart la distanță"
+
+#: id:20442
+msgid "Change content"
+msgstr "Schimbare conținut"
+
+#: id:20443
+msgid "Do you want to refresh info for all"
+msgstr "Doriți să reîmprospătați informațiile pentru toate"
+
+#: id:20444
+msgid "items within this path?"
+msgstr "elementele din această cale?"
+
+#: id:20445
+msgid "Fanart"
+msgstr "Fanart"
+
+#: id:20446
+msgid "Locally stored information found."
+msgstr "Au fost găsite informații stocate local."
+
+#: id:20447
+msgid "Ignore and refresh from internet?"
+msgstr "Ignorați și reîmprospătați de pe Internet?"
+
+#: id:20448
+msgid "Could not download information"
+msgstr "Nu se pot descărca informații"
+
+#: id:20449
+msgid "Unable to connect to remote server"
+msgstr "Imposibil de conectat cu serverul la distanță."
+
+#: id:20450
+msgid "Would you like to continue scanning?"
+msgstr "Doriți să continuați scanarea?"
+
+#: id:20451
+msgid "Countries"
+msgstr "Țări"
+
+#: id:20452
+msgid "episode"
+msgstr "episod"
+
+#: id:20453
+msgid "episodes"
+msgstr "episoade"
+
+#: id:20454
+msgid "Listener"
+msgstr "Ascultător"
+
+#: id:20455
+msgid "Listeners"
+msgstr "Ascultători"
+
+#: id:20456
+msgid "Set movieset fanart"
+msgstr "Alege fundal set de filme"
+
+#: id:20457
+msgid "Movie set"
+msgstr "Set de filme"
+
+#: id:20458
+msgid "Group movies in sets"
+msgstr "Grupează filmele în seturi"
+
+#: id:21330
+msgid "Show hidden files and directories"
+msgstr "Arată dosarele și fișierele ascunse"
+
+#: id:21331
+msgid "TuxBox client"
+msgstr "Client TuxBox"
+
+#: id:21332
+msgid "WARNING: Target TuxBox device is in recording-mode!"
+msgstr "AVERTISMENT: Dispozitivul țintă TuxBox este în modul înregistrare!"
+
+#: id:21333
+msgid "The stream will be stopped!"
+msgstr "Fluxul va fi oprit!"
+
+#: id:21334
+msgid "Zap to channel: %s failed!"
+msgstr "Alegere canal: %s a eșuat!"
+
+#: id:21335
+msgid "Are you sure to start the stream?"
+msgstr "Sigur doriți să porniți fluxul?"
+
+#: id:21336
+msgid "Connecting to: %s"
+msgstr "Se conectează la: %s"
+
+#: id:21337
+msgid "TuxBox device"
+msgstr "Dispozitiv TuxBox"
+
+#: id:21359
+msgid "Add media share..."
+msgstr "Adaugă partajare media..."
+
+#: id:21360
+msgid "Share video and music libraries through UPnP"
+msgstr "Partajează mediateca video și audio prin UPnP"
+
+#: id:21364
+msgid "Edit media share"
+msgstr "Modifică partajare media"
+
+#: id:21365
+msgid "Remove media share"
+msgstr "Elimină partajare media"
+
+#: id:21366
+msgid "Subtitle folder"
+msgstr "Dosar de subtitrări"
+
+#: id:21367
+msgid "Movie & alternate subtitle directory"
+msgstr "Director de film și subtitrare alternativă"
+
+#: id:21368
+msgid "Override ASS/SSA subtitles fonts"
+msgstr "Ignoră fonturi subtitrări ASS/SSA"
+
+#: id:21369
+msgid "Enable mouse and Touch Screen support"
+msgstr "Activează suport mouse și ecran sensibil la atingere"
+
+#: id:21370
+msgid "Play navigation sounds during media playback"
+msgstr "Emite sunete de navigare în timpul redării media"
+
+#: id:21371
+msgid "Thumbnail"
+msgstr "Miniaturi"
+
+#: id:21372
+msgid "Forced DVD player region"
+msgstr "Regiune forțată lector DVD"
+
+#: id:21373
+msgid "Video output"
+msgstr "Ieșire video"
+
+#: id:21374
+msgid "Video aspect"
+msgstr "Aspect video"
+
+#: id:21375
+msgctxt "Auto context with id 21375"
+msgid "Normal"
+msgstr "Normal"
+
+#: id:21376
+msgid "Letterbox"
+msgstr "Cutie de scrisori"
+
+#: id:21377
+msgid "Widescreen"
+msgstr "Ecran lat"
+
+#: id:21378
+msgid "Enable 480p"
+msgstr "Activează 480p"
+
+#: id:21379
+msgid "Enable 720p"
+msgstr "Activează 720p"
+
+#: id:21380
+msgid "Enable 1080i"
+msgstr "Activează 1080i"
+
+#: id:21381
+msgid "Enter name of new playlist"
+msgstr "Introduceți nume pentru listă de redare nouă"
+
+#: id:21382
+msgid "Show \"Add source\" buttons in file lists"
+msgstr "Arată buton „Adaugă sursă” în listele de fișiere"
+
+#: id:21383
+msgid "Enable scrollbars"
+msgstr "Activează bări de derulare"
+
+#: id:21384
+msgid "Make watched filtering a toggle in video library"
+msgstr "Afișare filtrare privite ca un comutator în mediateca video"
+
+#: id:21385
+msgctxt "Auto context with id 21385"
+msgid "Open"
+msgstr "Deschide"
+
+#: id:21386
+msgid "Acoustic management level"
+msgstr "Nivel administrare acustică"
+
+#: id:21387
+msgid "Fast"
+msgstr "Rapid"
+
+#: id:21388
+msgid "Quiet"
+msgstr "Silențios"
+
+#: id:21389
+msgid "Enable custom background"
+msgstr "Activează fundal personalizat"
+
+#: id:21390
+msgid "Power management level"
+msgstr "Nivel gestionare energie"
+
+#: id:21391
+msgid "High power"
+msgstr "Putere ridicată"
+
+#: id:21392
+msgid "Low power"
+msgstr "Putere scăzută"
+
+#: id:21393
+msgid "High standby"
+msgstr "Stare de veghe înaltă"
+
+#: id:21394
+msgid "Low standby"
+msgstr "Stare de veghe joasă"
+
+#: id:21395
+msgid "Unable to cache files bigger than 4GB"
+msgstr "Nu se pot preîncărca fișiere mai mari de 4 GB"
+
+#: id:21396
+msgid "Chapter"
+msgstr "Capitolul"
+
+#: id:21397
+msgid "High quality pixel shader v2"
+msgstr "Pixel shader de calitate înaltă v2"
+
+#: id:21398
+msgid "Enable playlist at startup"
+msgstr "Activează lista de redare la pornire"
+
+#: id:21399
+msgid "Use tween animations"
+msgstr "Folosește animații tween"
+
+#: id:21400
+msgid "contains"
+msgstr "conține"
+
+#: id:21401
+msgid "does not contain"
+msgstr "nu conține"
+
+#: id:21402
+msgid "is"
+msgstr "este"
+
+#: id:21403
+msgid "is not"
+msgstr "nu este"
+
+#: id:21404
+msgid "starts with"
+msgstr "începe cu"
+
+#: id:21405
+msgid "ends with"
+msgstr "se termină cu"
+
+#: id:21406
+msgid "greater than"
+msgstr "mai mare decât"
+
+#: id:21407
+msgid "less than"
+msgstr "mai mică decât"
+
+#: id:21408
+msgid "after"
+msgstr "după"
+
+#: id:21409
+msgid "before"
+msgstr "înainte"
+
+#: id:21410
+msgid "in the last"
+msgstr "în ultimul"
+
+#: id:21411
+msgid "not in the last"
+msgstr "nu în ultimul"
+
+#: id:21412
+msgid "Scrapers"
+msgstr "Cataloage"
+
+#: id:21413
+msgid "Default movie scraper"
+msgstr "Catalog (scraper) implicit pentru filme"
+
+#: id:21414
+msgid "Default tvshow scraper"
+msgstr "Catalog (scraper) implicit pentru seriale tv"
+
+#: id:21415
+msgid "Default music video scraper"
+msgstr "Catalog (scraper) implicit pentru videoclipuri"
+
+#: id:21416
+msgid "Enable fallback based on scraper language"
+msgstr "Activează revenire bazată pe limbă catalog"
+
+#: id:21417
+msgid "- Settings"
+msgstr "- Setări"
+
+#: id:21418
+msgid "Multilingual"
+msgstr "Multilingual"
+
+#: id:21419
+msgid "No scrapers present"
+msgstr "Niciun scraper prezent"
+
+#: id:21420
+msgid "Value to match"
+msgstr "Valoare pentru potrivire"
+
+#: id:21421
+msgid "Smart playlist rule"
+msgstr "Regulă listă de redare inteligentă"
+
+#: id:21422
+msgid "Match items where"
+msgstr "Potrivește elemente unde"
+
+#: id:21423
+msgid "New rule..."
+msgstr "Regulă nouă..."
+
+#: id:21424
+msgid "Items must match"
+msgstr "Elementele trebuie să respecte"
+
+#: id:21425
+msgid "all of the rules"
+msgstr "toate regulile"
+
+#: id:21426
+msgid "one or more of the rules"
+msgstr "una sau mai multe reguli"
+
+#: id:21427
+msgid "Limit to"
+msgstr "Limitează la"
+
+#: id:21428
+msgid "No limit"
+msgstr "fără limită"
+
+#: id:21429
+msgid "Order by"
+msgstr "Sortează după"
+
+#: id:21430
+msgid "ascending"
+msgstr "ascendent"
+
+#: id:21431
+msgid "descending"
+msgstr "descendent"
+
+#: id:21432
+msgid "Edit smart playlist"
+msgstr "Modificare listă de redare inteligentă"
+
+#: id:21433
+msgid "Name of the playlist"
+msgstr "Nume listă de redare"
+
+#: id:21434
+msgid "Find items where"
+msgstr "Găsește elemente unde"
+
+#: id:21435
+msgid "Edit"
+msgstr "Modifică"
+
+#: id:21436
+msgid "%i items"
+msgstr "%i elemente"
+
+#: id:21437
+msgid "New smart playlist..."
+msgstr "Listă de redare inteligentă nouă..."
+
+#: id:21438
+msgid "%c Drive"
+msgstr "%c Unitate"
+
+#: id:21439
+msgid "Edit party mode rules"
+msgstr "Modifică reguli mod petrecere"
+
+#: id:21440
+msgid "Home folder"
+msgstr "Dosar principal"
+
+#: id:21441
+msgid "Watched count"
+msgstr "Număr vizionate"
+
+#: id:21442
+msgid "Episode title"
+msgstr "Titlu episod"
+
+#: id:21443
+msgid "Video resolution"
+msgstr "Rezoluție video"
+
+#: id:21444
+msgid "Audio channels"
+msgstr "Canale audio"
+
+#: id:21445
+msgid "Video codec"
+msgstr "Codec video"
+
+#: id:21446
+msgid "Audio codec"
+msgstr "Codec audio"
+
+#: id:21447
+msgid "Audio language"
+msgstr "Limbă audio"
+
+#: id:21448
+msgid "Subtitle language"
+msgstr "Limbă subtitrare"
+
+#: id:21449
+msgid "Remote control sends keyboard presses"
+msgstr "Telecomanda trimite apăsări de taste"
+
+#: id:21450
+msgid "- Edit"
+msgstr "- Modificare"
+
+#: id:21451
+msgid "Internet connection required."
+msgstr "Este necesară o conexiune la Internet."
+
+#: id:21452
+msgid "Get More..."
+msgstr "Obține mai multe..."
+
+#: id:21453
+msgid "Root filesystem"
+msgstr "Sistem de fișiere rădăcină"
+
+#: id:21454
+msgid "Cache full"
+msgstr "Cache plin"
+
+#: id:21455
+msgid "Cache filled before reaching required amount for continous playback"
+msgstr "Cache împlinit înainte de a ajunge la nivelul necesar pentru redare continuă"
+
+#: id:21460
+msgid "Subtitle location"
+msgstr "Locație subtitrare"
+
+#: id:21461
+msgid "Fixed"
+msgstr "Fixă"
+
+#: id:21462
+msgid "Bottom of video"
+msgstr "Jos pe video"
+
+#: id:21463
+msgid "Below video"
+msgstr "Jos sub video"
+
+#: id:21464
+msgid "Top of video"
+msgstr "Sus pe video"
+
+#: id:21465
+msgid "Above video"
+msgstr "Sus peste video"
+
+#: id:21800
+msgid "File name"
+msgstr "Nume fișier"
+
+#: id:21801
+msgid "File path"
+msgstr "Cale fișier"
+
+#: id:21802
+msgid "File size"
+msgstr "Mărime fișier"
+
+#: id:21803
+msgid "File date/time"
+msgstr "Dată fișier"
+
+#: id:21804
+msgid "Slide index"
+msgstr "Index diapozitiv"
+
+#: id:21805
+msgctxt "Auto context with id 21805"
+msgid "Resolution"
+msgstr "Rezoluție"
+
+#: id:21806
+msgctxt "Auto context with id 21806"
+msgid "Comment"
+msgstr "Comentariu"
+
+#: id:21807
+msgid "Colour/B&W"
+msgstr "Color/Alb-negru"
+
+#: id:21808
+msgid "JPEG process"
+msgstr "Proces JPEG"
+
+#: id:21820
+msgid "Date/Time"
+msgstr "Dată/Oră"
+
+#: id:21821
+msgid "Description"
+msgstr "Descriere"
+
+#: id:21822
+msgid "Camera make"
+msgstr "Aparat foto"
+
+#: id:21823
+msgid "Camera model"
+msgstr "Model aparat"
+
+#: id:21824
+msgid "EXIF comment"
+msgstr "Comentariu EXIF"
+
+#: id:21825
+msgid "Firmware"
+msgstr "Microcod"
+
+#: id:21826
+msgid "Aperture"
+msgstr "Deschidere"
+
+#: id:21827
+msgid "Focal length"
+msgstr "Distanță focală"
+
+#: id:21828
+msgid "Focus distance"
+msgstr "Distanță de focalizare"
+
+#: id:21829
+msgid "Exposure"
+msgstr "Expunere"
+
+#: id:21830
+msgid "Exposure time"
+msgstr "Durată expunere"
+
+#: id:21831
+msgid "Exposure bias"
+msgstr "Favorizare expunere"
+
+#: id:21832
+msgid "Exposure mode"
+msgstr "Mod de expunere"
+
+#: id:21833
+msgid "Flash used"
+msgstr "Bliț folosit"
+
+#: id:21834
+msgid "White-balance"
+msgstr "Balanță de alb"
+
+#: id:21835
+msgid "Light source"
+msgstr "Sursă de lumină"
+
+#: id:21836
+msgid "Metering mode"
+msgstr "Mod măsurare"
+
+#: id:21837
+msgid "ISO"
+msgstr "Viteză ISO"
+
+#: id:21838
+msgid "Digital zoom"
+msgstr "Zoom digital"
+
+#: id:21839
+msgid "CCD width"
+msgstr "Lățime CCD"
+
+#: id:21840
+msgid "GPS latitude"
+msgstr "Latitudine GPS"
+
+#: id:21841
+msgid "GPS longitude"
+msgstr "Longitudine GPS"
+
+#: id:21842
+msgid "GPS altitude"
+msgstr "Altitudine GPS"
+
+#: id:21843
+msgid "Orientation"
+msgstr "Orientare"
+
+#: id:21860
+msgid "Supplemental categories"
+msgstr "Categorii suplimentare"
+
+#: id:21861
+msgid "Keywords"
+msgstr "Cuvinte cheie"
+
+#: id:21862
+msgid "Caption"
+msgstr "Titlu"
+
+#: id:21863
+msgid "Author"
+msgstr "Autor"
+
+#: id:21864
+msgid "Headline"
+msgstr "Titlu de ziar"
+
+#: id:21865
+msgid "Special instructions"
+msgstr "Instrucțiuni speciale"
+
+#: id:21866
+msgid "Category"
+msgstr "Categorie"
+
+#: id:21867
+msgid "Byline"
+msgstr "Autor"
+
+#: id:21868
+msgid "Byline title"
+msgstr "Titlu autor"
+
+#: id:21869
+msgid "Credit"
+msgstr "Mulțumiri"
+
+#: id:21870
+msgid "Source"
+msgstr "Sursă"
+
+#: id:21871
+msgid "Copyright notice"
+msgstr "Drept de autor"
+
+#: id:21872
+msgid "Object name"
+msgstr "Nume obiect"
+
+#: id:21873
+msgid "City"
+msgstr "Oraș"
+
+#: id:21874
+msgid "State"
+msgstr "Stat"
+
+#: id:21875
+msgctxt "Auto context with id 21875"
+msgid "Country"
+msgstr "Țară"
+
+#: id:21876
+msgid "Original Tx Reference"
+msgstr "Referință Tx originală"
+
+#: id:21877
+msgid "Date created"
+msgstr "Dată creare"
+
+#: id:21878
+msgid "Copyright flag"
+msgstr "Indicator drept de autor"
+
+#: id:21879
+msgid "Country code"
+msgstr "Cod țară"
+
+#: id:21880
+msgid "Reference service"
+msgstr "Serviciu referință"
+
+#: id:21881
+msgid "Allow control of XBMC via UPnP"
+msgstr "Permite controlul XBMC prin UPnP"
+
+#: id:21882
+msgid "Attempt to skip introduction before DVD menu"
+msgstr "Încearcă să sari peste introducere înainte de meniul DVD"
+
+#: id:21883
+msgid "Saved music"
+msgstr "Muzică salvată"
+
+#: id:21884
+msgid "Query info for all artists"
+msgstr "Cere info pt. toți artiștii"
+
+#: id:21885
+msgid "Downloading album information"
+msgstr "Descărcare informații albume"
+
+#: id:21886
+msgid "Downloading artist information"
+msgstr "Descărcare informații artiști"
+
+#: id:21887
+msgid "Biography"
+msgstr "Biografie"
+
+#: id:21888
+msgid "Discography"
+msgstr "Discografie"
+
+#: id:21889
+msgid "Searching artist"
+msgstr "Se caută artist"
+
+#: id:21890
+msgid "Select artist"
+msgstr "Selectați artist"
+
+#: id:21891
+msgctxt "Auto context with id 21891"
+msgid "Artist information"
+msgstr "Informații artist"
+
+#: id:21892
+msgid "Instruments"
+msgstr "Instrumente"
+
+#: id:21893
+msgid "Born"
+msgstr "Născut"
+
+#: id:21894
+msgid "Formed"
+msgstr "Formată"
+
+#: id:21895
+msgid "Themes"
+msgstr "Teme"
+
+#: id:21896
+msgid "Disbanded"
+msgstr "Desființată"
+
+#: id:21897
+msgid "Died"
+msgstr "Mort"
+
+#: id:21898
+msgid "Years active"
+msgstr "Ani activi"
+
+#: id:21899
+msgid "Label"
+msgstr "Etichetă"
+
+#: id:21900
+msgid "Born/Formed"
+msgstr "Născut/Format"
+
+#: id:22000
+msgid "Update library on startup"
+msgstr "Actualizează mediateca la pornire"
+
+#: id:22001
+msgid "Hide progress of library updates"
+msgstr "Ascunde progresul când se actualizează mediateca"
+
+#: id:22002
+msgid "- DNS suffix"
+msgstr "- Sufix DNS"
+
+#: id:22003
+msgid "%2.3fs"
+msgstr "%2.3fs"
+
+#: id:22004
+msgid "Delayed by: %2.3fs"
+msgstr "în urmă cu: %2.3fs"
+
+#: id:22005
+msgid "Ahead by: %2.3fs"
+msgstr "în avans cu: %2.3fs"
+
+#: id:22006
+msgid "Subtitle offset"
+msgstr "Decalaj subtitrare"
+
+#: id:22007
+msgid "OpenGL vendor:"
+msgstr "Furnizor OpenGL:"
+
+#: id:22008
+msgid "OpenGL renderer:"
+msgstr "Randor OpenGL:"
+
+#: id:22009
+msgid "OpenGL version:"
+msgstr "Versiune OpenGL:"
+
+#: id:22010
+msgid "GPU temperature:"
+msgstr "Temperatură GPU:"
+
+#: id:22011
+msgid "CPU temperature:"
+msgstr "Temperatură CPU:"
+
+#: id:22012
+msgid "Total memory"
+msgstr "Memorie totală"
+
+#: id:22013
+msgid "Profile data"
+msgstr "Date profil"
+
+#: id:22014
+msgid "Use dim if paused during video playback"
+msgstr "Folosește întunecare dacă se pune pauză în timpul redării video"
+
+#: id:22015
+msgid "All recordings"
+msgstr "Toate înregistrăriile"
+
+#: id:22016
+msgid "By title"
+msgstr "După titlu"
+
+#: id:22017
+msgid "By group"
+msgstr "După grup"
+
+#: id:22018
+msgid "Live channels"
+msgstr "Canale live"
+
+#: id:22019
+msgid "Recordings by title"
+msgstr "Înregistrări după titlu"
+
+#: id:22020
+msgid "Guide"
+msgstr "Ghid"
+
+#: id:22021
+msgid "Allowed error in aspect ratio to minimize black bars"
+msgstr "Eroare permisă raport aspect pt. minimizare bări negre"
+
+#: id:22022
+msgid "Show video files in listings"
+msgstr "Arată fișierele video la listare"
+
+#: id:22023
+msgid "DirectX vendor:"
+msgstr "Furnizor DirectX:"
+
+#: id:22024
+msgid "Direct3D version:"
+msgstr "Versiune Direct3D:"
+
+#: id:22030
+msgctxt "Auto context with id 22030"
+msgid "Font"
+msgstr "Font"
+
+#: id:22031
+msgctxt "Auto context with id 22031"
+msgid "- Size"
+msgstr "- Dimensiune"
+
+#: id:22032
+msgctxt "Auto context with id 22032"
+msgid "- Colours"
+msgstr "- Culori"
+
+#: id:22033
+msgid "- Charset"
+msgstr "- Set de caractere"
+
+#: id:22034
+msgid "Export karaoke titles as HTML"
+msgstr "Exportă titluri karaoke ca HTML"
+
+#: id:22035
+msgid "Export karaoke titles as CSV"
+msgstr "Exportă titluri karaoke ca CSV"
+
+#: id:22036
+msgid "Import karaoke titles..."
+msgstr "Importă titluri karaoke..."
+
+#: id:22037
+msgid "Show song selector automatically"
+msgstr "Arată automat selector cântec"
+
+#: id:22038
+msgid "Export karaoke titles..."
+msgstr "Exportă titluri karaoke..."
+
+#: id:22039
+msgid "Enter song number"
+msgstr "Introduceți număr cântec"
+
+#: id:22040
+msgid "white/green"
+msgstr "alb/verde"
+
+#: id:22041
+msgid "white/red"
+msgstr "alb/roșu"
+
+#: id:22042
+msgid "white/blue"
+msgstr "alb/albastru"
+
+#: id:22043
+msgid "black/white"
+msgstr "negru/alb"
+
+#: id:22079
+msgid "Default select action"
+msgstr "Acțiune standard la selectare"
+
+#: id:22080
+msgid "Choose"
+msgstr "Alege"
+
+#: id:22081
+msgid "Show Information"
+msgstr "Arată informații"
+
+#: id:22082
+msgid "More..."
+msgstr "Mai multe..."
+
+#: id:22083
+msgid "Play all"
+msgstr "Redă toate"
+
+#: id:23049
+msgid "Teletext not available"
+msgstr "Teletextul nu este disponibil!"
+
+#: id:23050
+msgid "Activate Teletext"
+msgstr "Activează Teletext"
+
+#: id:23051
+msgid "Part %i"
+msgstr "Parte %i"
+
+#: id:23052
+msgid "Buffering %i bytes"
+msgstr "Preîncărcare %i octeți"
+
+#: id:23053
+msgid "Stopping"
+msgstr "Se oprește"
+
+#: id:23054
+msgid "Running"
+msgstr "În execuție"
+
+#: id:23100
+msgid "External Player Active"
+msgstr "Lector extern activ"
+
+#: id:23101
+msgid "Click OK to terminate the player"
+msgstr "Clic OK pentru a închide lectorul"
+
+#: id:23104
+msgid "Click OK when playback has ended"
+msgstr "Clic OK când redarea s-a terminat"
+
+#: id:24000
+msgid "Add-on"
+msgstr "Supliment"
+
+#: id:24001
+msgid "Add-ons"
+msgstr "Suplimente"
+
+#: id:24002
+msgid "Add-on options"
+msgstr "Opțiuni suplimente"
+
+#: id:24003
+msgid "Add-on Information"
+msgstr "Informații supliment"
+
+#: id:24005
+msgctxt "Auto context with id 24005"
+msgid "Media sources"
+msgstr "Surse media"
+
+#: id:24007
+msgctxt "Auto context with id 24007"
+msgid "Movie information"
+msgstr "Informații filme"
+
+#: id:24008
+msgctxt "Auto context with id 24008"
+msgid "Screensaver"
+msgstr "Protector ecran"
+
+#: id:24009
+msgid "Script"
+msgstr "Script"
+
+#: id:24010
+msgctxt "Auto context with id 24010"
+msgid "Visualization"
+msgstr "Vizualizare"
+
+#: id:24011
+msgid "Add-on repository"
+msgstr "Depozit de suplimente"
+
+#: id:24012
+msgctxt "Auto context with id 24012"
+msgid "Subtitles"
+msgstr "Subtitrări"
+
+#: id:24013
+msgid "Lyrics"
+msgstr "Versuri"
+
+#: id:24014
+msgid "TV information"
+msgstr "Informații seriale"
+
+#: id:24015
+msgctxt "Auto context with id 24015"
+msgid "Music video information"
+msgstr "Informații videoclipuri"
+
+#: id:24016
+msgctxt "Auto context with id 24016"
+msgid "Album information"
+msgstr "Informații albume"
+
+#: id:24017
+msgctxt "Auto context with id 24017"
+msgid "Artist information"
+msgstr "Informații artiști"
+
+#: id:24018
+msgctxt "Auto context with id 24018"
+msgid "Services"
+msgstr "Servicii"
+
+#: id:24020
+msgid "Configure"
+msgstr "Configurează"
+
+#: id:24021
+msgctxt "Auto context with id 24021"
+msgid "Disable"
+msgstr "Dezactivează"
+
+#: id:24022
+msgid "Enable"
+msgstr "Activează"
+
+#: id:24023
+msgid "Add-on disabled"
+msgstr "Supliment dezactivat"
+
+#: id:24027
+msgctxt "Auto context with id 24027"
+msgid "Weather"
+msgstr "Meteo"
+
+#: id:24028
+msgid "Weather.com (standard)"
+msgstr "Weather.com (standard)"
+
+#: id:24030
+msgid "This Add-on can not be configured"
+msgstr "Acest supliment nu poate fi configurat."
+
+#: id:24031
+msgid "Error loading settings"
+msgstr "Eroare la încărcarea setăriilor"
+
+#: id:24032
+msgid "All Add-ons"
+msgstr "Toate suplimentele"
+
+#: id:24033
+msgid "Get Add-ons"
+msgstr "Obținere suplimente"
+
+#: id:24034
+msgid "Check for updates"
+msgstr "Caută actualizări"
+
+#: id:24035
+msgid "Force refresh"
+msgstr "Forțează reîmprospătare"
+
+#: id:24036
+msgid "Change log"
+msgstr "Istoric modificări"
+
+#: id:24037
+msgid "Uninstall"
+msgstr "Dezinstalează"
+
+#: id:24038
+msgid "Install"
+msgstr "Instalează"
+
+#: id:24039
+msgid "Disabled Add-ons"
+msgstr "Suplimente dezactivate"
+
+#: id:24040
+msgid "(Clear the current setting)"
+msgstr "(Elimină setarea curentă)"
+
+#: id:24041
+msgid "Install from zip file"
+msgstr "Instalare din fișier zip"
+
+#: id:24042
+msgid "Downloading %i%%"
+msgstr "Se descarcă %i%%"
+
+#: id:24043
+msgid "Available Updates"
+msgstr "Actualizări disponibile"
+
+#: id:24044
+msgid "Dependencies not met"
+msgstr "Dependențele nu au fost îndeplinite"
+
+#: id:24045
+msgid "Add-on does not have the correct structure"
+msgstr "Suplimentul nu are structura corectă"
+
+#: id:24046
+msgid "%s is used by the following installed add-on(s)"
+msgstr "%s este folosit de următoarele suplimente instalate"
+
+#: id:24047
+msgid "This add-on cannot be uninstalled"
+msgstr "Acest supliment nu poate fi dezinstalat"
+
+#: id:24048
+msgid "Rollback"
+msgstr "Revino"
+
+#: id:24050
+msgid "Available Add-ons"
+msgstr "Suplimente disponibile"
+
+#: id:24051
+msgid "Version:"
+msgstr "Versiune:"
+
+#: id:24052
+msgid "Disclaimer"
+msgstr "Neasumare responsabilitate"
+
+#: id:24053
+msgid "License:"
+msgstr "Licență:"
+
+#: id:24054
+msgid "Changelog"
+msgstr "Istoric modificări"
+
+#: id:24059
+msgid "Would you like to enable this Add-on?"
+msgstr "Doriți să activați acest supliment?"
+
+#: id:24060
+msgid "Would you like to disable this Add-on?"
+msgstr "Doriți să dezactivați acest supliment?"
+
+#: id:24061
+msgid "Add-on update available!"
+msgstr "Actualizare supliment disponibilă!"
+
+#: id:24062
+msgid "Enabled Add-ons"
+msgstr "Suplimente activate"
+
+#: id:24063
+msgid "Auto update"
+msgstr "Auto-actualizare"
+
+#: id:24064
+msgid "Add-on enabled"
+msgstr "Supliment activat"
+
+#: id:24065
+msgid "Add-on updated"
+msgstr "Supliment actualizat"
+
+#: id:24066
+msgid "Cancel Add-on download?"
+msgstr "Renunțați la descărcarea suplimentului?"
+
+#: id:24067
+msgid "Currently downloading Add-ons"
+msgstr "Suplimente în descărcare"
+
+#: id:24068
+msgid "Update available"
+msgstr "Actualizare disponibilă"
+
+#: id:24069
+msgid "Update"
+msgstr "Actualizează"
+
+#: id:24070
+msgid "Add-on could not be loaded."
+msgstr "Suplimentul nu a putut fi încărcat."
+
+#: id:24071
+msgid "An unknown error has occurred."
+msgstr "S-a produs o eroare necunoscută."
+
+#: id:24072
+msgid "Settings required"
+msgstr "Sunt necesare setări"
+
+#: id:24073
+msgid "Could not connect"
+msgstr "Imposibil de conectat"
+
+#: id:24074
+msgid "Needs to restart"
+msgstr "Trebuie să fie repornit"
+
+#: id:24075
+msgctxt "Auto context with id 24075"
+msgid "Disable"
+msgstr "Dezactivează"
+
+#: id:24076
+msgid "Add-on Required"
+msgstr "Supliment necesar"
+
+#: id:24080
+msgid "Try to reconnect?"
+msgstr "Încercați reconectarea?"
+
+#: id:24089
+msgid "Add-on restarts"
+msgstr "Reporniri supliment"
+
+#: id:24090
+msgid "Lock Add-on manager"
+msgstr "Blochează gestionarul de suplimente"
+
+#: id:24094
+msgid "(current)"
+msgstr "(curent)"
+
+#: id:24095
+msgid "(blacklisted)"
+msgstr "(pe lista neagră)"
+
+#: id:24096
+msgid "Add-on has been marked as broken in repository."
+msgstr "Suplimentul a fost marcat ca defect în depozit."
+
+#: id:24097
+msgid "Would you like to disable it on your system?"
+msgstr "Doriți să îl dezactivați pe sistemul dumneavoastră?"
+
+#: id:24098
+msgid "Broken"
+msgstr "Defect"
+
+#: id:24099
+msgid "Would you like to switch to this skin?"
+msgstr "Doriți să folosiți acest costum?"
+
+#: id:24100
+msgid "To use this feature you must download an Add-on:"
+msgstr "Pentru aceasta trebuie să descărcați un supliment:"
+
+#: id:24101
+msgid "Would you like to download this Add-on?"
+msgstr "Doriți să descărcați acest supliment?"
+
+#: id:25000
+msgid "Notifications"
+msgstr "Notificări"
+
+#: id:29800
+msgid "Library Mode"
+msgstr "Mod mediatecă"
+
+#: id:29801
+msgid "QWERTY keyboard"
+msgstr "Tastatură QWERTY"
+
+#: id:29802
+msgid "Passthrough Audio in use"
+msgstr "Traversare Audio în folosință"
+
+#: id:33001
+msgid "Trailer quality"
+msgstr "Calitate secvențe"
+
+#: id:33002
+msgid "Stream"
+msgstr "Flux"
+
+#: id:33003
+msgid "Download"
+msgstr "Descarcă"
+
+#: id:33004
+msgid "Download & play"
+msgstr "Descarcă și redă"
+
+#: id:33005
+msgid "Download & save"
+msgstr "Descarcă și salvează"
+
+#: id:33006
+msgid "Today"
+msgstr "Astăzi"
+
+#: id:33007
+msgid "Tomorrow"
+msgstr "Mâine"
+
+#: id:33008
+msgid "Saving"
+msgstr "Se salvează"
+
+#: id:33009
+msgid "Copying"
+msgstr "Se copiază"
+
+#: id:33010
+msgid "Set download directory"
+msgstr "Alegere dosar de descărcare"
+
+#: id:33011
+msgid "Search duration"
+msgstr "Durată căutare"
+
+#: id:33012
+msgid "Short"
+msgstr "Scurt"
+
+#: id:33013
+msgid "Long"
+msgstr "Lung"
+
+#: id:33014
+msgid "Use DVD player instead of regular player"
+msgstr "Folosește lector DVD în loc de lector normal"
+
+#: id:33015
+msgid "Ask for download before playing video"
+msgstr "Întreabă pentru descărcare înainte de a reda video"
+
+#: id:33016
+msgid "Clips"
+msgstr "Clipuri"
+
+#: id:33017
+msgid "Restart plugin to enable"
+msgstr "Reporniți modulul pentru activare"
+
+#: id:33018
+msgid "Tonight"
+msgstr "La noapte"
+
+#: id:33019
+msgid "Tomorrow Night"
+msgstr "Mâine noapte"
+
+#: id:33020
+msgid "Condition"
+msgstr "Condiție"
+
+#: id:33021
+msgid "Precipitation"
+msgstr "Precipitație"
+
+#: id:33022
+msgid "Precip"
+msgstr "Precip"
+
+#: id:33023
+msgid "Humid"
+msgstr "Umiditate"
+
+#: id:33024
+msgid "Feels"
+msgstr "Se simte"
+
+#: id:33025
+msgid "Observed"
+msgstr "Observat"
+
+#: id:33026
+msgid "Departure from normal"
+msgstr "Plecare de la normal"
+
+#: id:33027
+msgid "Sunrise"
+msgstr "Răsărit"
+
+#: id:33028
+msgid "Sunset"
+msgstr "Apus"
+
+#: id:33029
+msgid "Details"
+msgstr "Detalii"
+
+#: id:33030
+msgid "Outlook"
+msgstr "Perspectivă"
+
+#: id:33031
+msgid "Coverflow"
+msgstr "Acoperire"
+
+#: id:33032
+msgid "Translate text"
+msgstr "Traduce text"
+
+#: id:33033
+msgid "Map list %s category"
+msgstr "Listă hartă categorie %s"
+
+#: id:33034
+msgid "36 Hour"
+msgstr "36 ore"
+
+#: id:33035
+msgid "Maps"
+msgstr "Hărți"
+
+#: id:33036
+msgid "Hourly"
+msgstr "La fiecare oră"
+
+#: id:33037
+msgid "Weekend"
+msgstr "Sfârșit de săptămână"
+
+#: id:33038
+msgid "%s day"
+msgstr "%s zi"
+
+#: id:33049
+msgid "Alert"
+msgstr "Alertă"
+
+#: id:33050
+msgid "Alerts"
+msgstr "Alerte"
+
+#: id:33051
+msgid "Choose Your"
+msgstr "Alegeți"
+
+#: id:33052
+msgid "Check"
+msgstr "Verifică"
+
+#: id:33053
+msgctxt "Auto context with id 33053"
+msgid "Configure the"
+msgstr "Configurează"
+
+#: id:33054
+msgid "Seasons"
+msgstr "Anotimpuri"
+
+#: id:33055
+msgid "Use your"
+msgstr "Foloseșteți"
+
+#: id:33056
+msgid "Watch your"
+msgstr "Fi atent la"
+
+#: id:33057
+msgid "Listen to"
+msgstr "Ascultă"
+
+#: id:33058
+msgid "View your"
+msgstr "Vezi"
+
+#: id:33059
+msgctxt "Auto context with id 33059"
+msgid "Configure the"
+msgstr "Configurează"
+
+#: id:33060
+msgid "Power"
+msgstr "Energie"
+
+#: id:33061
+msgid "Menu"
+msgstr "Meniu"
+
+#: id:33062
+msgid "Play the"
+msgstr "Redă"
+
+#: id:33063
+msgid "Options"
+msgstr "Opțiuni"
+
+#: id:33065
+msgid "Editor"
+msgstr "Editor"
+
+#: id:33066
+msgid "About your"
+msgstr "Despre"
+
+#: id:33067
+msgid "Star rating"
+msgstr "Apreciere cu stele"
+
+#: id:33068
+msgid "Background"
+msgstr "Fundal"
+
+#: id:33069
+msgid "Backgrounds"
+msgstr "Fundaluri"
+
+#: id:33070
+msgid "Custom background"
+msgstr "Fundal personalizat"
+
+#: id:33071
+msgid "Custom backgrounds"
+msgstr "Fundale personalizate"
+
+#: id:33072
+msgid "View Readme"
+msgstr "Vedeți Citește-mă"
+
+#: id:33073
+msgid "View Changelog"
+msgstr "Vedeți Istoric modificări"
+
+#: id:33074
+msgid "This version of %s requires an"
+msgstr "Această versiune de %s necesită o"
+
+#: id:33075
+msgid "XBMC revision of %s or greater to run."
+msgstr "revizie XBMC egală cu %s sau mai mare pentru a rula."
+
+#: id:33076
+msgid "Please update XBMC."
+msgstr "Vă rugăm actualizați XBMC."
+
+#: id:33077
+msgid "No data found!"
+msgstr "Nu au fost găsite date!"
+
+#: id:33078
+msgid "Next page"
+msgstr "Pagina următoare"
+
+#: id:33079
+msgid "Love"
+msgstr "Iubire"
+
+#: id:33080
+msgid "Hate"
+msgstr "Ură"
+
+#: id:33081
+msgid "This file is stacked, select the part you want to play from."
+msgstr "Acest fișier este în stivă, selectați partea pe care vreți să o redați."
+
+#: id:33082
+msgid "Path to script"
+msgstr "Cale către script"
+
+#: id:33083
+msgid "Enable custom script button"
+msgstr "Activează buton personalizat script"
+
+#: id:33100
+msgid "Failed to start"
+msgstr "Nu poate fi pornit"
+
+#: id:33101
+msgid "Webserver"
+msgstr "Server web"
+
+#: id:33102
+msgid "Event Server"
+msgstr "Server evenimente"
+
+#: id:33103
+msgid "Remote communication server"
+msgstr "Server comunicare la distanță"
+
+#: id:33200
+msgid "Detected New Connection"
+msgstr "Conexiune nouă detectată"
+
+#: id:34000
+msgid "Lame"
+msgstr "Lame"
+
+#: id:34001
+msgid "Vorbis"
+msgstr "Vorbis"
+
+#: id:34002
+msgid "Wav"
+msgstr "Wav"
+
+#: id:34003
+msgid "DXVA2"
+msgstr "DXVA2"
+
+#: id:34004
+msgid "VAAPI"
+msgstr "VAAPI"
+
+#: id:34005
+msgid "Flac"
+msgstr "Flac"
+
+#: id:34100
+msgid "Speaker Configuration"
+msgstr "Configurație difuzoare"
+
+#: id:34101
+msgid "2.0"
+msgstr "2.0"
+
+#: id:34102
+msgid "2.1"
+msgstr "2.1"
+
+#: id:34103
+msgid "3.0"
+msgstr "3.0"
+
+#: id:34104
+msgid "3.1"
+msgstr "3.1"
+
+#: id:34105
+msgid "4.0"
+msgstr "4.0"
+
+#: id:34106
+msgid "4.1"
+msgstr "4.1"
+
+#: id:34107
+msgid "5.0"
+msgstr "5.0"
+
+#: id:34108
+msgid "5.1"
+msgstr "5.1"
+
+#: id:34109
+msgid "7.0"
+msgstr "7.0"
+
+#: id:34110
+msgid "7.1"
+msgstr "7.1"
+
+#: id:34201
+msgid "Can't find a next item to play"
+msgstr "Următorul element de redat nu poate fi găsit"
+
+#: id:34202
+msgid "Can't find a previous item to play"
+msgstr "Elementul anterior de redat nu poate fi găsit"
+
+#: id:34300
+msgid "Failed to start zeroconf"
+msgstr "Zeroconf nu poate fi pornit"
+
+#: id:34301
+msgid "Is Apple's Bonjour Service installed? See log for more info."
+msgstr "Serviciul Bonjour de la Apple este instalat? Vedeți jurnalul pentru mai multe informații."
+
+#: id:34400
+msgid "Video Rendering"
+msgstr "Randare video"
+
+#: id:34401
+msgid "Failed to init video filters/scalers, falling back to bilinear scaling"
+msgstr "Filtre/scalori video nu pot fi inițializați, revenim la scalare bilineară"
+
+#: id:34402
+msgid "Failed to initialize audio device"
+msgstr "Dispozitivul audio nu poate fi inițializat"
+
+#: id:34403
+msgid "Check your audiosettings"
+msgstr "Verificați setările audio"
+
+#: id:34404
+msgid "Use gestures for navigation:"
+msgstr ""
+
+#: id:34405
+msgid "1 finger swipe left,right,up,down for cursors"
+msgstr ""
+
+#: id:34406
+msgid "2 finger swipe left for backspace"
+msgstr ""
+
+#: id:34407
+msgid "1 finger single tap for enter"
+msgstr ""
+
+#: id:34408
+msgid "2 finger single tap for contextmenu"
+msgstr ""
+
+#: id:35000
+msgid "Peripherals"
+msgstr "Periferice"
+
+#: id:35001
+msgid "Generic HID device"
+msgstr "Dispozitiv HID generic"
+
+#: id:35002
+msgid "Generic network adapter"
+msgstr "Adaptor de rețea generic"
+
+#: id:35003
+msgid "Generic disk"
+msgstr "Disc generic"
+
+#: id:35004
+msgid "There are no settings available\nfor this peripheral."
+msgstr "Nu există setări disponibile\npentru acest periferic."
+
+#: id:35005
+msgid "New device configured"
+msgstr "Dispozitiv nou configurat"
+
+#: id:35006
+msgid "Device removed"
+msgstr "Dispozitiv eliminat"
+
+#: id:35007
+msgid "Keymap to use for this device"
+msgstr "Hartă de taste de folosit pentru acest dispozitiv"
+
+#: id:35008
+msgid "Keymap enabled"
+msgstr "Hartă de taste activată"
+
+#: id:35009
+msgid "Do not use the custom keymap for this device"
+msgstr ""
+
+#: id:35500
+msgid "Location"
+msgstr "Locație"
+
+#: id:35501
+msgid "Class"
+msgstr "Clasă"
+
+#: id:35502
+msgctxt "Auto context with id 35502"
+msgid "Name"
+msgstr "Nume"
+
+#: id:35503
+msgid "Vendor"
+msgstr "Furnizor"
+
+#: id:35504
+msgid "Product ID"
+msgstr "ID produs"
+
+#: id:36000
+msgid "Pulse-Eight CEC adapter"
+msgstr "Adaptor Pulse-Eight CEC"
+
+#: id:36001
+msgid "Pulse-Eight Nyxboard"
+msgstr "Pulse-Eight Nyxboard"
+
+#: id:36002
+msgid "Switch to keyboard side command"
+msgstr "Comandă de comutare la parte tastatură"
+
+#: id:36003
+msgid "Switch to remote side command"
+msgstr "Comandă de comutare la parte telecomandă"
+
+#: id:36004
+msgid "Press \"user\" button command"
+msgstr "Comandă apasă buton „utilizator”"
+
+#: id:36005
+msgid "Enable switch side commands"
+msgstr "Activează comenzi de schimbare a părții"
+
+#: id:36006
+msgid "Could not open the adapter"
+msgstr "Adapotorul nu poate fi deschis"
+
+#: id:36007
+msgid "Devices to power on when starting XBMC"
+msgstr "Aprinde televizorul atunci când XBMC este pornit"
+
+#: id:36008
+msgid "Devices to power off when stopping XBMC"
+msgstr "Oprește dispozitivele atunci când XBMC este oprit"
+
+#: id:36009
+msgid "Put devices in standby mode when activating screensaver"
+msgstr "Pune dispozitivele în modul repaus când protector ecran este activat"
+
+#: id:36011
+msgid "Could not detect the CEC port. Set it up manually."
+msgstr "Portul CEC nu poate fi detectat. Setați-l manual."
+
+#: id:36012
+msgid "Could not initialise the CEC adapter. Check your settings."
+msgstr "Adaptorul CEC nu poate fi detectat."
+
+#: id:36013
+msgid "Unsupported libCEC interface version. %d is greater than the version XBMC supports (%d)"
+msgstr "Versiune interfață libcec nesuportată. %d este mai mare decât versiunea pe care XBMC o suportă (%d)"
+
+#: id:36014
+msgid "Put this PC in standby mode when the TV is switched off"
+msgstr "Pune acest calculator în repaus când televizorul este oprit"
+
+#: id:36015
+msgid "HDMI port number"
+msgstr "Număr port HDMI"
+
+#: id:36016
+msgctxt "Auto context with id 36016"
+msgid "Connected"
+msgstr "Conectat"
+
+#: id:36017
+msgid "Adapter found, but libCEC is not available"
+msgstr "Adaptor găsit, dar librăria libcec nu este disponibilă"
+
+#: id:36018
+msgid "Use the TV's language setting"
+msgstr "Folosește setările de limbă ale televizorului"
+
+#: id:36019
+msgid "Connected to HDMI device"
+msgstr ""
+
+#: id:36020
+msgid "Make XBMC the active source when starting"
+msgstr ""
+
+#: id:36021
+msgid "Physical address (overrules HDMI port)"
+msgstr ""
+
+#: id:36022
+msgid "COM port (leave empty unless needed)"
+msgstr ""
+
+#: id:36023
+msgid "Configuration updated"
+msgstr ""
+
+#: id:36024
+msgid "Failed to set the new configuration. Please check your settings."
+msgstr ""
+
+#: id:36025
+msgid "Send 'inactive source' command when stopping XBMC"
+msgstr ""
+

--- a/language/Russian/strings.po
+++ b/language/Russian/strings.po
@@ -1,0 +1,9093 @@
+# Converted from xbmc strings.xml with xbmc-xml2po (by Team-XBMC)
+msgid ""
+msgstr ""
+"Project-Id-Version: xbmc.core-FRODO_GIT3ed1604ad7\n"
+"Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
+"POT-Creation-Date: 2012-04-09 18:00+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE\n"
+"Language: ru\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: id:0
+msgctxt "Auto context with id 0"
+msgid "Programs"
+msgstr "Программы"
+
+#: id:1
+msgctxt "Auto context with id 1"
+msgid "Pictures"
+msgstr "Фотографии"
+
+#: id:2
+msgctxt "Auto context with id 2"
+msgid "Music"
+msgstr "Музыка"
+
+#: id:3
+msgctxt "Auto context with id 3"
+msgid "Videos"
+msgstr "Видео"
+
+#: id:4
+msgid "TV-Guide"
+msgstr "ТВ-гид"
+
+#: id:5
+msgctxt "Auto context with id 5"
+msgid "Settings"
+msgstr "Настройки"
+
+#: id:6
+msgid "XBMC SVN"
+msgstr "XBMC SVN"
+
+#: id:7
+msgctxt "Auto context with id 7"
+msgid "File manager"
+msgstr "Файл-менеджер"
+
+#: id:8
+msgctxt "Auto context with id 8"
+msgid "Weather"
+msgstr "Погода"
+
+#: id:9
+msgid "xbmc media center"
+msgstr "Медиацентр XBMC"
+
+#: id:11
+msgid "Monday"
+msgstr "Понедельник"
+
+#: id:12
+msgid "Tuesday"
+msgstr "Вторник"
+
+#: id:13
+msgid "Wednesday"
+msgstr "Среда"
+
+#: id:14
+msgid "Thursday"
+msgstr "Четверг"
+
+#: id:15
+msgid "Friday"
+msgstr "Пятница"
+
+#: id:16
+msgid "Saturday"
+msgstr "Суббота"
+
+#: id:17
+msgid "Sunday"
+msgstr "Воскресенье"
+
+#: id:21
+msgid "January"
+msgstr "января"
+
+#: id:22
+msgid "February"
+msgstr "февраля"
+
+#: id:23
+msgid "March"
+msgstr "марта"
+
+#: id:24
+msgid "April"
+msgstr "апреля"
+
+#: id:25
+msgctxt "Auto context with id 25"
+msgid "May"
+msgstr "мая"
+
+#: id:26
+msgid "June"
+msgstr "июня"
+
+#: id:27
+msgid "July"
+msgstr "июля"
+
+#: id:28
+msgid "August"
+msgstr "августа"
+
+#: id:29
+msgid "September"
+msgstr "сентября"
+
+#: id:30
+msgid "October"
+msgstr "октября"
+
+#: id:31
+msgid "November"
+msgstr "ноября"
+
+#: id:32
+msgid "December"
+msgstr "декабря"
+
+#: id:41
+msgid "Mon"
+msgstr "Пн"
+
+#: id:42
+msgid "Tue"
+msgstr "Вт"
+
+#: id:43
+msgid "Wed"
+msgstr "Ср"
+
+#: id:44
+msgid "Thu"
+msgstr "Чт"
+
+#: id:45
+msgid "Fri"
+msgstr "Пт"
+
+#: id:46
+msgid "Sat"
+msgstr "Сб"
+
+#: id:47
+msgctxt "Auto context with id 47"
+msgid "Sun"
+msgstr "Вс"
+
+#: id:51
+msgid "Jan"
+msgstr "янв."
+
+#: id:52
+msgid "Feb"
+msgstr "фев."
+
+#: id:53
+msgid "Mar"
+msgstr "марта"
+
+#: id:54
+msgid "Apr"
+msgstr "апр."
+
+#: id:55
+msgctxt "Auto context with id 55"
+msgid "May"
+msgstr "мая"
+
+#: id:56
+msgid "Jun"
+msgstr "июня"
+
+#: id:57
+msgid "Jul"
+msgstr "июля"
+
+#: id:58
+msgid "Aug"
+msgstr "авг."
+
+#: id:59
+msgid "Sep"
+msgstr "сент."
+
+#: id:60
+msgid "Oct"
+msgstr "окт."
+
+#: id:61
+msgid "Nov"
+msgstr "нояб."
+
+#: id:62
+msgid "Dec"
+msgstr "дек."
+
+#: id:71
+msgid "N"
+msgstr "С"
+
+#: id:72
+msgid "NNE"
+msgstr "ССВ"
+
+#: id:73
+msgid "NE"
+msgstr "СВ"
+
+#: id:74
+msgid "ENE"
+msgstr "ВСВ"
+
+#: id:75
+msgid "E"
+msgstr "В"
+
+#: id:76
+msgid "ESE"
+msgstr "ВЮВ"
+
+#: id:77
+msgid "SE"
+msgstr "ЮВ"
+
+#: id:78
+msgid "SSE"
+msgstr "ЮЮВ"
+
+#: id:79
+msgid "S"
+msgstr "Ю"
+
+#: id:80
+msgid "SSW"
+msgstr "ЮЮЗ"
+
+#: id:81
+msgid "SW"
+msgstr "ЮЗ"
+
+#: id:82
+msgid "WSW"
+msgstr "ЗЮЗ"
+
+#: id:83
+msgid "W"
+msgstr "З"
+
+#: id:84
+msgid "WNW"
+msgstr "ЗСЗ"
+
+#: id:85
+msgid "NW"
+msgstr "СЗ"
+
+#: id:86
+msgid "NNW"
+msgstr "ССЗ"
+
+#: id:87
+msgid "VAR"
+msgstr "Перем."
+
+#: id:98
+msgid "View: Auto"
+msgstr "Вид: авто"
+
+#: id:99
+msgid "View: Auto big"
+msgstr "Вид: авто крупн."
+
+#: id:100
+msgid "View: Icons"
+msgstr "Вид: значки"
+
+#: id:101
+msgid "View: List"
+msgstr "Вид: список"
+
+#: id:102
+msgctxt "Auto context with id 102"
+msgid "Scan"
+msgstr "Сканировать"
+
+#: id:103
+msgctxt "Auto context with id 103"
+msgid "Sort by: Name"
+msgstr "Сорт. по имени"
+
+#: id:104
+msgid "Sort by: Date"
+msgstr "Сорт. по дате"
+
+#: id:105
+msgid "Sort by: Size"
+msgstr "Сорт. по размеру"
+
+#: id:106
+msgid "No"
+msgstr "Нет"
+
+#: id:107
+msgid "Yes"
+msgstr "Да"
+
+#: id:108
+msgctxt "Auto context with id 108"
+msgid "Slideshow"
+msgstr "Слайд-шоу"
+
+#: id:109
+msgid "Create thumbs"
+msgstr "Создавать эскизы"
+
+#: id:110
+msgid "Create thumbnails"
+msgstr "Создавать эскизы"
+
+#: id:111
+msgctxt "Auto context with id 111"
+msgid "Shortcuts"
+msgstr "Ярлыки"
+
+#: id:112
+msgid "Paused"
+msgstr "Пауза"
+
+#: id:113
+msgid "Update failed"
+msgstr "Не удалось обновить"
+
+#: id:114
+msgid "Installation failed"
+msgstr "Не удалось установить"
+
+#: id:115
+msgid "Copy"
+msgstr "Копировать"
+
+#: id:116
+msgid "Move"
+msgstr "Переместить"
+
+#: id:117
+msgid "Delete"
+msgstr "Удалить"
+
+#: id:118
+msgid "Rename"
+msgstr "Переименовать"
+
+#: id:119
+msgid "New folder"
+msgstr "Новая папка"
+
+#: id:120
+msgid "Confirm file copy"
+msgstr "Подтверждение копирования"
+
+#: id:121
+msgid "Confirm file move"
+msgstr "Подтверждение перемещения"
+
+#: id:122
+msgid "Confirm file delete?"
+msgstr "Удалить файл?"
+
+#: id:123
+msgid "Copy these files?"
+msgstr "Копировать файлы?"
+
+#: id:124
+msgid "Move these files?"
+msgstr "Переместить файлы?"
+
+#: id:125
+msgid "Delete these files? - Deleting files cannot be undone!"
+msgstr "Удалить файлы? Восстановление будет невозможно!"
+
+#: id:126
+msgid "Status"
+msgstr "Состояние"
+
+#: id:127
+msgid "Objects"
+msgstr "Объектов"
+
+#: id:128
+msgctxt "Auto context with id 128"
+msgid "General"
+msgstr "Общие"
+
+#: id:129
+msgctxt "Auto context with id 129"
+msgid "Slideshow"
+msgstr "Слайд-шоу"
+
+#: id:130
+msgctxt "Auto context with id 130"
+msgid "System info"
+msgstr "Сведения о системе"
+
+#: id:131
+msgid "Display"
+msgstr "Экран"
+
+#: id:132
+msgid "Albums"
+msgstr "Альбомы"
+
+#: id:133
+msgid "Artists"
+msgstr "Исполнители"
+
+#: id:134
+msgid "Songs"
+msgstr "Песни"
+
+#: id:135
+msgid "Genres"
+msgstr "Жанры"
+
+#: id:136
+msgid "Playlists"
+msgstr "Плейлисты"
+
+#: id:137
+msgid "Search"
+msgstr "Поиск"
+
+#: id:138
+msgid "System Information"
+msgstr "Сведения о системе"
+
+#: id:139
+msgid "Temperatures:"
+msgstr "Температура:"
+
+#: id:140
+msgid "CPU:"
+msgstr "CPU:"
+
+#: id:141
+msgid "GPU:"
+msgstr "GPU:"
+
+#: id:142
+msgid "Time:"
+msgstr "Время:"
+
+#: id:143
+msgid "Current:"
+msgstr "Сейчас:"
+
+#: id:144
+msgid "Build:"
+msgstr "Версия:"
+
+#: id:145
+msgid "Network:"
+msgstr "Сеть:"
+
+#: id:146
+msgid "Type:"
+msgstr "Тип:"
+
+#: id:147
+msgid "Static"
+msgstr "Статический"
+
+#: id:148
+msgid "DHCP"
+msgstr "DHCP"
+
+#: id:149
+msgid "MAC address"
+msgstr "MAC-адрес"
+
+#: id:150
+msgctxt "Auto context with id 150"
+msgid "IP address"
+msgstr "IP-адрес"
+
+#: id:151
+msgid "Link:"
+msgstr "Соединение:"
+
+#: id:152
+msgid "Half duplex"
+msgstr "Полудуплекс"
+
+#: id:153
+msgid "Full duplex"
+msgstr "Полный дуплекс"
+
+#: id:154
+msgctxt "Auto context with id 154"
+msgid "Storage"
+msgstr "Накопители"
+
+#: id:155
+msgid "Drive"
+msgstr "Диск"
+
+#: id:156
+msgctxt "Auto context with id 156"
+msgid "Free"
+msgstr "Свободно"
+
+#: id:157
+msgctxt "Auto context with id 157"
+msgid "Video"
+msgstr "Видео"
+
+#: id:158
+msgid "Free memory"
+msgstr "Свободно памяти"
+
+#: id:159
+msgid "No link"
+msgstr "Нет соединения"
+
+#: id:160
+msgctxt "Auto context with id 160"
+msgid "Free"
+msgstr "Свободно"
+
+#: id:161
+msgid "Unavailable"
+msgstr "Недоступно"
+
+#: id:162
+msgid "Tray open"
+msgstr "Лоток открыт"
+
+#: id:163
+msgid "Reading"
+msgstr "Чтение…"
+
+#: id:164
+msgid "No disc"
+msgstr "Нет диска в приводе"
+
+#: id:165
+msgid "Disc present"
+msgstr "Диск в приводе"
+
+#: id:166
+msgid "Skin"
+msgstr "Обложка"
+
+#: id:169
+msgctxt "Auto context with id 169"
+msgid "Resolution"
+msgstr "Разрешение"
+
+#: id:170
+msgid "Adjust display refresh rate to match video"
+msgstr "Настроить частоту дисплея согласно видео"
+
+#: id:172
+msgid "Release date"
+msgstr "Дата выпуска"
+
+#: id:173
+msgid "Display 4:3 videos as"
+msgstr "Режим показа видео формата 4:3"
+
+#: id:175
+msgid "Moods"
+msgstr "Настроение"
+
+#: id:176
+msgid "Styles"
+msgstr "Стили"
+
+#: id:179
+msgid "Song"
+msgstr "Песня"
+
+#: id:180
+msgid "Duration"
+msgstr "Длительность"
+
+#: id:181
+msgid "Select album"
+msgstr "Выберите альбом"
+
+#: id:182
+msgid "Tracks"
+msgstr "Треки"
+
+#: id:183
+msgid "Review"
+msgstr "Обзор"
+
+#: id:184
+msgid "Refresh"
+msgstr "Обновить"
+
+#: id:185
+msgid "Searching album"
+msgstr "Поиск альбома"
+
+#: id:186
+msgid "OK"
+msgstr "ОК"
+
+#: id:187
+msgid "No albums found!"
+msgstr "Альбомы не найдены!"
+
+#: id:188
+msgid "Select all"
+msgstr "Выбрать все"
+
+#: id:189
+msgid "Scanning media info"
+msgstr "Получение информации…"
+
+#: id:190
+msgid "Save"
+msgstr "Сохранить"
+
+#: id:191
+msgid "Shuffle"
+msgstr "Перемешать"
+
+#: id:192
+msgctxt "Auto context with id 192"
+msgid "Clear"
+msgstr "Очистить"
+
+#: id:193
+msgctxt "Auto context with id 193"
+msgid "Scan"
+msgstr "Сканировать"
+
+#: id:194
+msgid "Searching..."
+msgstr "Поиск…"
+
+#: id:195
+msgid "No info found!"
+msgstr "Информация не найдена."
+
+#: id:196
+msgid "Select movie:"
+msgstr "Выберите фильм:"
+
+#: id:197
+msgid "Querying %s info"
+msgstr "Запрос информации от %s"
+
+#: id:198
+msgid "Loading movie details"
+msgstr "Загрузка данных о фильме"
+
+#: id:199
+msgid "Web interface"
+msgstr "Веб-интерфейс"
+
+#: id:202
+msgid "Tagline"
+msgstr "Девиз"
+
+#: id:203
+msgid "Plot outline"
+msgstr "Описание"
+
+#: id:205
+msgid "Votes"
+msgstr "Голосов"
+
+#: id:206
+msgid "Cast"
+msgstr "В ролях"
+
+#: id:207
+msgid "Plot"
+msgstr "Сюжет"
+
+#: id:208
+msgctxt "Auto context with id 208"
+msgid "Play"
+msgstr "Проиграть"
+
+#: id:209
+msgid "Next"
+msgstr "Следующий"
+
+#: id:210
+msgid "Previous"
+msgstr "Предыдущий"
+
+#: id:213
+msgid "Calibrate user interface..."
+msgstr "Калибровка интерфейса…"
+
+#: id:214
+msgid "Video calibration..."
+msgstr "Калибровка дисплея…"
+
+#: id:215
+msgid "Soften"
+msgstr "Сглаживание"
+
+#: id:216
+msgid "Zoom amount"
+msgstr "Степень увеличения"
+
+#: id:217
+msgid "Pixel ratio"
+msgstr "Соотношение сторон"
+
+#: id:218
+msgid "DVD drive"
+msgstr "DVD-привод"
+
+#: id:219
+msgid "Please insert disc"
+msgstr "Вставьте диск"
+
+#: id:220
+msgid "Remote share"
+msgstr "Удаленный ресурс"
+
+#: id:221
+msgid "Network is not connected"
+msgstr "Нет подключения к сети"
+
+#: id:222
+msgid "Cancel"
+msgstr "Отмена"
+
+#: id:224
+msgid "Speed"
+msgstr "Скорость"
+
+#: id:225
+msgid "Vertical Shift"
+msgstr "Вертикальное смещение"
+
+#: id:226
+msgid "Test patterns..."
+msgstr "Тестовые шаблоны…"
+
+#: id:227
+msgid "Lookup audio CD track names from freedb.org"
+msgstr "Искать имена треков аудио-CD на freedb.org"
+
+#: id:228
+msgid "Shuffle playlist on load"
+msgstr "Перемешать плейлист при загрузке"
+
+#: id:229
+msgid "HDD spindown time"
+msgstr "Останавливать HDD через (мин.)"
+
+#: id:230
+msgid "Video filters"
+msgstr "Видеофильтры"
+
+#: id:231
+msgctxt "Auto context with id 231"
+msgid "None"
+msgstr "Нет"
+
+#: id:232
+msgid "Point"
+msgstr "Точка"
+
+#: id:233
+msgid "Linear"
+msgstr "Линейный"
+
+#: id:234
+msgid "Anisotropic"
+msgstr "Анизотропный"
+
+#: id:235
+msgid "Quincunx"
+msgstr "Шахматный"
+
+#: id:236
+msgid "Gaussian cubic"
+msgstr "Кубический по Гауссу"
+
+#: id:237
+msgid "Minification"
+msgstr "Уменьшение"
+
+#: id:238
+msgid "Magnification"
+msgstr "Увеличение"
+
+#: id:239
+msgid "Clear playlist on finish"
+msgstr "Очищать плейлист после проигрывания"
+
+#: id:240
+msgid "Display Mode"
+msgstr "Режим дисплея"
+
+#: id:241
+msgid "Full Screen #%d"
+msgstr "Полный экран #%d"
+
+#: id:242
+msgid "Windowed"
+msgstr "В окне"
+
+#: id:243
+msgid "Refresh Rate"
+msgstr "Частота обновления"
+
+#: id:244
+msgid "Full screen"
+msgstr "Полный экран"
+
+#: id:245
+msgid "Sizing: (%i,%i)->(%i,%i) (Zoom x%2.2f) AR:%2.2f:1 (Pixels: %2.2f:1) (VShift: %2.2f)"
+msgstr "Размер: (%i,%i)->(%i,%i) (Увеличение x%2.2f) Соотношение:%2.2f:1 (Пикселей: %2.2f:1) (Верт. смещение: %2.2f)"
+
+#: id:247
+msgctxt "Auto context with id 247"
+msgid "Scripts"
+msgstr "Скрипты"
+
+#: id:248
+msgctxt "Auto context with id 248"
+msgid "Language"
+msgstr "Язык"
+
+#: id:249
+msgctxt "Auto context with id 249"
+msgid "Music"
+msgstr "Музыка"
+
+#: id:250
+msgctxt "Auto context with id 250"
+msgid "Visualization"
+msgstr "Визуализация"
+
+#: id:251
+msgid "Select destination directory"
+msgstr "Выберите папку назначения"
+
+#: id:252
+msgid "Output stereo to all speakers"
+msgstr "Выводить стерео на все динамики"
+
+#: id:253
+msgid "Number of channels"
+msgstr "Количество каналов"
+
+#: id:254
+msgid "- DTS capable receiver"
+msgstr "- Выводить звук в формате DTS"
+
+#: id:255
+msgid "CDDB"
+msgstr "CDDB"
+
+#: id:256
+msgid "Fetching CD information"
+msgstr "Получение данных о CD…"
+
+#: id:257
+msgid "Error"
+msgstr "Ошибка"
+
+#: id:258
+msgid "Enable tag reading"
+msgstr "Читать информацию из тэгов"
+
+#: id:259
+msgid "Opening"
+msgstr "Открытие…"
+
+#: id:260
+msgid "Shoutcast"
+msgstr "Shoutcast"
+
+#: id:261
+msgid "Waiting for start..."
+msgstr "Ожидание запуска…"
+
+#: id:262
+msgid "Scripts output"
+msgstr "Журнал работы скриптов"
+
+#: id:263
+msgid "Allow control of XBMC via HTTP"
+msgstr "Разрешить управление XBMC по HTTP"
+
+#: id:264
+msgid "Record"
+msgstr "Запись"
+
+#: id:265
+msgid "Stop Rec."
+msgstr "Остановить запись"
+
+#: id:266
+msgid "Sort by: Track"
+msgstr "Сорт. по трекам"
+
+#: id:267
+msgid "Sort by: Time"
+msgstr "Сорт. по времени"
+
+#: id:268
+msgid "Sort by: Title"
+msgstr "Сорт. по названию"
+
+#: id:269
+msgid "Sort by: Artist"
+msgstr "Сорт. по исполнителю"
+
+#: id:270
+msgid "Sort by: Album"
+msgstr "Сорт. по альбомам"
+
+#: id:271
+msgid "Top 100"
+msgstr "Топ 100"
+
+#: id:272
+msgid "Top-Left overscan compensation"
+msgstr "Настройка размеров экрана (левый верхний угол)"
+
+#: id:273
+msgid "Bottom-Right overscan compensation"
+msgstr "Настройка размеров экрана (правый нижний угол)"
+
+#: id:274
+msgid "Subtitle positioning"
+msgstr "Позиция субтитров"
+
+#: id:275
+msgid "Pixel ratio adjustment"
+msgstr "Регулировка соотношения высоты и ширины"
+
+#: id:276
+msgid "Adjust the arrow to change the amount of overscan"
+msgstr "Двигайте стрелки для регулировки размеров экрана"
+
+#: id:277
+msgid "Adjust the bar to change the subtitles position"
+msgstr "Двигайте полоску, чтобы изменить позицию субтитров"
+
+#: id:278
+msgid "Adjust the rectangle so it is perfectly square"
+msgstr "Измените прямоугольник так, чтобы добиться идеального квадрата"
+
+#: id:279
+msgid "Unable to load settings"
+msgstr "Не удалось загрузить настройки"
+
+#: id:280
+msgid "Using default settings"
+msgstr "Используются стандартные настройки"
+
+#: id:281
+msgid "Please check the XML files"
+msgstr "Проверьте файлы XML"
+
+#: id:282
+msgid "Found %i items"
+msgstr "Найдено объектов: %i"
+
+#: id:283
+msgid "Search results"
+msgstr "Результаты поиска"
+
+#: id:284
+msgid "No results found"
+msgstr "Ничего не найдено"
+
+#: id:287
+msgctxt "Auto context with id 287"
+msgid "Subtitles"
+msgstr "Субтитры"
+
+#: id:288
+msgctxt "Auto context with id 288"
+msgid "Font"
+msgstr "Шрифт"
+
+#: id:289
+msgctxt "Auto context with id 289"
+msgid "- Size"
+msgstr "- Размер"
+
+#: id:290
+msgid "Dynamic range compression"
+msgstr "Сжатие динамического диапазона"
+
+#: id:291
+msgctxt "Auto context with id 291"
+msgid "Video"
+msgstr "Видео"
+
+#: id:292
+msgctxt "Auto context with id 292"
+msgid "Audio"
+msgstr "Аудио"
+
+#: id:293
+msgid "Browse for subtitles"
+msgstr "Выбрать субтитры"
+
+#: id:294
+msgid "Create bookmark"
+msgstr "Создать закладку"
+
+#: id:296
+msgid "Clear bookmarks"
+msgstr "Очистить закладки"
+
+#: id:297
+msgid "Audio offset"
+msgstr "Смещение звука"
+
+#: id:298
+msgid "Bookmarks"
+msgstr "Закладки"
+
+#: id:299
+msgid "- AAC capable receiver"
+msgstr "- Выводить звук в формате AAC"
+
+#: id:300
+msgid "- MP1 capable receiver"
+msgstr "- Выводить звук в формате MP1"
+
+#: id:301
+msgid "- MP2 capable receiver"
+msgstr "- Выводить звук в формате MP2"
+
+#: id:302
+msgid "- MP3 capable receiver"
+msgstr "- Выводить звук в формате MP3"
+
+#: id:303
+msgid "Delay"
+msgstr "Задержка"
+
+#: id:304
+msgctxt "Auto context with id 304"
+msgid "Language"
+msgstr "Язык"
+
+#: id:305
+msgctxt "Auto context with id 305"
+msgid "Enabled"
+msgstr "Вкл."
+
+#: id:306
+msgid "Non-interleaved"
+msgstr "Без чередования"
+
+#: id:312
+msgid "(0=auto)"
+msgstr "(0=авто)"
+
+#: id:313
+msgid "Cleaning database"
+msgstr "Очистка базы данных…"
+
+#: id:314
+msgid "Preparing..."
+msgstr "Подготовка…"
+
+#: id:315
+msgid "Database error"
+msgstr "Ошибка базы данных"
+
+#: id:316
+msgid "Searching songs..."
+msgstr "Поиск песен…"
+
+#: id:317
+msgid "Cleaned database successfully"
+msgstr "Очистка базы данных выполнена"
+
+#: id:318
+msgid "Cleaning songs..."
+msgstr "Очистка песен…"
+
+#: id:319
+msgid "Error cleaning songs"
+msgstr "Ошибка очистки песен"
+
+#: id:320
+msgid "Cleaning artists..."
+msgstr "Очистка исполнителей…"
+
+#: id:321
+msgid "Error cleaning artists"
+msgstr "Ошибка очистки исполнителей"
+
+#: id:322
+msgid "Cleaning genres..."
+msgstr "Очистка жанров…"
+
+#: id:323
+msgid "Error cleaning genres"
+msgstr "Ошибка очистки жанров"
+
+#: id:324
+msgid "Cleaning paths..."
+msgstr "Очистка путей..."
+
+#: id:325
+msgid "Error cleaning paths"
+msgstr "Ошибка очистки путей"
+
+#: id:326
+msgid "Cleaning albums..."
+msgstr "Очистка альбомов…"
+
+#: id:327
+msgid "Error cleaning albums"
+msgstr "Ошибка очистки альбомов"
+
+#: id:328
+msgid "Writing changes..."
+msgstr "Запись изменений…"
+
+#: id:329
+msgid "Error writing changes"
+msgstr "Ошибка записи изменений"
+
+#: id:330
+msgid "This may take some time..."
+msgstr "Это займет некоторое время…"
+
+#: id:331
+msgid "Compressing database..."
+msgstr "Сжатие базы данных…"
+
+#: id:332
+msgid "Error compressing database"
+msgstr "Ошибка сжатия базы данных"
+
+#: id:333
+msgid "Do you want to clean the library?"
+msgstr "Очистить медиатеку?"
+
+#: id:334
+msgid "Clean library..."
+msgstr "Очистка медиатеки…"
+
+#: id:335
+msgid "Start"
+msgstr "Старт"
+
+#: id:336
+msgid "Framerate conversion"
+msgstr "Преобразование частоты кадров"
+
+#: id:337
+msgctxt "Auto context with id 337"
+msgid "Audio output"
+msgstr "Вывод звука"
+
+#: id:338
+msgid "Analog"
+msgstr "Аналоговый"
+
+#: id:339
+msgid "Optical/Coax"
+msgstr "Цифровой"
+
+#: id:340
+msgid "Various artists"
+msgstr "Различные исполнители"
+
+#: id:341
+msgid "Play disc"
+msgstr "Проиграть диск"
+
+#: id:342
+msgctxt "Auto context with id 342"
+msgid "Movies"
+msgstr "Фильмы"
+
+#: id:343
+msgid "Adjust framerate"
+msgstr "Настроить частоту кадров"
+
+#: id:344
+msgid "Actors"
+msgstr "Актеры"
+
+#: id:345
+msgctxt "Auto context with id 345"
+msgid "Year"
+msgstr "Год"
+
+#: id:346
+msgid "Boost volume level on downmix"
+msgstr "Повышать громкость при смешивании"
+
+#: id:350
+msgctxt "Auto context with id 350"
+msgid "Programs"
+msgstr "Программы"
+
+#: id:351
+msgctxt "Auto context with id 351"
+msgid "Off"
+msgstr "Выкл."
+
+#: id:352
+msgid "Dim"
+msgstr "Затемнение"
+
+#: id:353
+msgid "Black"
+msgstr "Черный экран"
+
+#: id:354
+msgid "Matrix trails"
+msgstr "Следы \"Матрицы\""
+
+#: id:355
+msgid "Screensaver time"
+msgstr "Включать заставку через"
+
+#: id:356
+msgid "Screensaver mode"
+msgstr "Заставка"
+
+#: id:357
+msgid "Shutdown function timer"
+msgstr "Завершить работу через"
+
+#: id:358
+msgid "All albums"
+msgstr "Все альбомы"
+
+#: id:359
+msgid "Recently added albums"
+msgstr "Последние альбомы"
+
+#: id:360
+msgctxt "Auto context with id 360"
+msgid "Screensaver"
+msgstr "Заставка"
+
+#: id:361
+msgid "R. Slideshow"
+msgstr "Рекурс. слайд-шоу"
+
+#: id:362
+msgid "Screensaver dim level"
+msgstr "Уровень затемнения экрана"
+
+#: id:363
+msgid "Sort by: File"
+msgstr "Сорт. по файлам"
+
+#: id:364
+msgid "- Dolby Digital (AC3) capable receiver"
+msgstr "- Выводить звук в формате Dolby Digital (AC3)"
+
+#: id:365
+msgctxt "Auto context with id 365"
+msgid "Sort by: Name"
+msgstr "Сорт. по имени"
+
+#: id:366
+msgid "Sort by: Year"
+msgstr "Сорт. по году"
+
+#: id:367
+msgid "Sort by: Rating"
+msgstr "Сорт. по рейтингу"
+
+#: id:368
+msgid "IMDb"
+msgstr "IMDb"
+
+#: id:369
+msgctxt "Auto context with id 369"
+msgid "Title"
+msgstr "Название"
+
+#: id:370
+msgid "Thunderstorms"
+msgstr "грозы"
+
+#: id:371
+msgid "Partly"
+msgstr "местами"
+
+#: id:372
+msgid "Mostly"
+msgstr "преимущественно"
+
+#: id:373
+msgid "Sunny"
+msgstr "солнечно"
+
+#: id:374
+msgid "Cloudy"
+msgstr "облачно"
+
+#: id:375
+msgid "Snow"
+msgstr "снег"
+
+#: id:376
+msgid "Rain"
+msgstr "дождь"
+
+#: id:377
+msgid "Light"
+msgstr "небольш."
+
+#: id:378
+msgid "AM"
+msgstr "Утром"
+
+#: id:379
+msgid "PM"
+msgstr "Днем"
+
+#: id:380
+msgid "Showers"
+msgstr ""
+
+#: id:381
+msgid "Few"
+msgstr "немного"
+
+#: id:382
+msgid "Scattered"
+msgstr "местами"
+
+#: id:383
+msgctxt "Auto context with id 383"
+msgid "Wind"
+msgstr "ветер"
+
+#: id:384
+msgid "Strong"
+msgstr "сильный"
+
+#: id:385
+msgid "Fair"
+msgstr "безоблачно"
+
+#: id:386
+msgctxt "Auto context with id 386"
+msgid "Clear"
+msgstr "ясно"
+
+#: id:387
+msgid "Clouds"
+msgstr "облачно"
+
+#: id:388
+msgid "Early"
+msgstr "ранние"
+
+#: id:389
+msgid "Shower"
+msgstr "ливень"
+
+#: id:390
+msgid "Flurries"
+msgstr "снегопад"
+
+#: id:391
+msgctxt "Auto context with id 391"
+msgid "Low"
+msgstr "Мин."
+
+#: id:392
+msgctxt "Auto context with id 392"
+msgid "Medium"
+msgstr "Средн."
+
+#: id:393
+msgctxt "Auto context with id 393"
+msgid "High"
+msgstr "Макс."
+
+#: id:394
+msgid "Fog"
+msgstr "туман"
+
+#: id:395
+msgid "Haze"
+msgstr "дымка"
+
+#: id:396
+msgid "Select location"
+msgstr "Выберите местность"
+
+#: id:397
+msgid "Refresh time"
+msgstr "Время обновления"
+
+#: id:398
+msgid "Temperature units"
+msgstr "Единица измерения температуры"
+
+#: id:399
+msgid "Speed units"
+msgstr "Единица измерения скорости ветра"
+
+#: id:400
+msgctxt "Auto context with id 400"
+msgid "Weather"
+msgstr "Погода"
+
+#: id:401
+msgid "Temp"
+msgstr "Температура"
+
+#: id:402
+msgid "Feels like"
+msgstr "Ощущается"
+
+#: id:403
+msgid "UV index"
+msgstr "Уровень УФ"
+
+#: id:404
+msgctxt "Auto context with id 404"
+msgid "Wind"
+msgstr "Ветер"
+
+#: id:405
+msgid "Dew point"
+msgstr "Точка росы"
+
+#: id:406
+msgid "Humidity"
+msgstr "Влажность"
+
+#: id:409
+msgid "Defaults"
+msgstr "По умолчанию"
+
+#: id:410
+msgid "Accessing weather service"
+msgstr "Подключение к службе погоды…"
+
+#: id:411
+msgid "Getting weather for:"
+msgstr "Получение прогноза для:"
+
+#: id:412
+msgid "Unable to get weather data"
+msgstr "Не удалось получить прогноз"
+
+#: id:413
+msgid "Manual"
+msgstr "Вручную"
+
+#: id:414
+msgid "No review for this album"
+msgstr "Нет описания этого альбома"
+
+#: id:415
+msgid "Downloading thumbnail..."
+msgstr "Загрузка эскизов…"
+
+#: id:416
+msgid "Not available"
+msgstr "Нет данных"
+
+#: id:417
+msgid "View: Big icons"
+msgstr "Вид: крупн. значки"
+
+#: id:418
+msgctxt "Auto context with id 418"
+msgid "Low"
+msgstr "Мин."
+
+#: id:419
+msgctxt "Auto context with id 419"
+msgid "High"
+msgstr "Макс."
+
+#: id:420
+msgid "HDMI"
+msgstr "HDMI"
+
+#: id:422
+msgid "Delete album info"
+msgstr "Удалить сведения об альбоме"
+
+#: id:423
+msgid "Delete CD information"
+msgstr "Удалить сведения о CD"
+
+#: id:424
+msgid "Select"
+msgstr "Выбор"
+
+#: id:425
+msgid "No album information found"
+msgstr "Сведения об альбоме не найдены"
+
+#: id:426
+msgid "No CD information found"
+msgstr "Сведения о CD не найдены"
+
+#: id:427
+msgid "Disc"
+msgstr "Диск"
+
+#: id:428
+msgid "Insert correct CD/DVD"
+msgstr "Вставьте правильный CD/DVD-диск"
+
+#: id:429
+msgid "Please insert the following disc:"
+msgstr "Вставьте следующий диск:"
+
+#: id:430
+msgid "Sort by: DVD#"
+msgstr "Сорт. по № DVD"
+
+#: id:431
+msgid "No cache"
+msgstr "Не кэшировать"
+
+#: id:432
+msgid "Remove movie from library"
+msgstr "Удалить фильм из медиатеки"
+
+#: id:433
+msgid "Really remove '%s'?"
+msgstr "Действительно удалить[CR]\"%s\"?"
+
+#: id:434
+msgid "From %s at %i %s"
+msgstr "%s, %i %s"
+
+#: id:437
+msgid "Removable disk"
+msgstr "Съемный диск"
+
+#: id:438
+msgid "Opening file"
+msgstr "Открытие файла…"
+
+#: id:439
+msgid "Cache"
+msgstr "Буферизация"
+
+#: id:440
+msgid "Harddisk"
+msgstr "Жесткий диск"
+
+#: id:441
+msgid "UDF"
+msgstr "UDF"
+
+#: id:442
+msgid "Local network"
+msgstr "Локальная сеть"
+
+#: id:443
+msgid "Internet"
+msgstr "Интернет"
+
+#: id:444
+msgctxt "Auto context with id 444"
+msgid "Video"
+msgstr "Видео"
+
+#: id:445
+msgctxt "Auto context with id 445"
+msgid "Audio"
+msgstr "Аудио"
+
+#: id:446
+msgctxt "Auto context with id 446"
+msgid "DVD"
+msgstr "DVD"
+
+#: id:447
+msgid "Autorun media"
+msgstr "Автозапуск"
+
+#: id:448
+msgid "LCD"
+msgstr "LCD-экран"
+
+#: id:449
+msgctxt "Auto context with id 449"
+msgid "Enabled"
+msgstr "Вкл."
+
+#: id:450
+msgid "Columns"
+msgstr "Количество знакомест в строке"
+
+#: id:451
+msgid "Row 1 address"
+msgstr "Адрес 1-ой строки"
+
+#: id:452
+msgid "Row 2 address"
+msgstr "Адрес 2-ой строки"
+
+#: id:453
+msgid "Row 3 address"
+msgstr "Адрес 3-ой строки"
+
+#: id:454
+msgid "Row 4 address"
+msgstr "Адрес 4-ой строки"
+
+#: id:455
+msgid "Rows"
+msgstr "Количество строк"
+
+#: id:456
+msgid "Mode"
+msgstr "Режим"
+
+#: id:457
+msgid "Switch view"
+msgstr "Сменить вид"
+
+#: id:459
+msgid "Subs"
+msgstr "Субтитры"
+
+#: id:460
+msgid "Audio stream"
+msgstr "Аудиопоток"
+
+#: id:461
+msgid "[active]"
+msgstr "[работает]"
+
+#: id:462
+msgid "Subtitle"
+msgstr "Субтитры"
+
+#: id:463
+msgid "Backlight"
+msgstr "Яркость подсветки"
+
+#: id:464
+msgid "Brightness"
+msgstr "Яркость"
+
+#: id:465
+msgid "Contrast"
+msgstr "Контрастность"
+
+#: id:466
+msgid "Gamma"
+msgstr "Гамма"
+
+#: id:467
+msgctxt "Auto context with id 467"
+msgid "Type"
+msgstr "Тип"
+
+#: id:468
+msgid "Move the bar to change the OSD position"
+msgstr "Двигайте полоску, чтобы изменить положение экранного меню (OSD)"
+
+#: id:469
+msgid "OSD position"
+msgstr "Положение экранного меню (OSD)"
+
+#: id:470
+msgid "Credits"
+msgstr "Создатели"
+
+#: id:471
+msgid "Modchip"
+msgstr "МOD-чип"
+
+#: id:474
+msgctxt "Auto context with id 474"
+msgid "Off"
+msgstr "Выкл."
+
+#: id:475
+msgid "Music only"
+msgstr "Только музыка"
+
+#: id:476
+msgctxt "Auto context with id 476"
+msgid "Music & video"
+msgstr "Музыка и видео"
+
+#: id:477
+msgid "Unable to load playlist"
+msgstr "Не удалось загрузить плейлист"
+
+#: id:478
+msgid "OSD"
+msgstr "Экранное меню (OSD)"
+
+#: id:479
+msgid "Skin & language"
+msgstr "Обложка и язык"
+
+#: id:480
+msgid "Appearance"
+msgstr "Внешний вид"
+
+#: id:481
+msgid "Audio options"
+msgstr "Параметры аудио"
+
+#: id:482
+msgid "About XBMC"
+msgstr "О XBMC"
+
+#: id:485
+msgid "Delete album"
+msgstr "Удалить альбом"
+
+#: id:486
+msgid "Repeat"
+msgstr "Повторять"
+
+#: id:487
+msgid "Repeat one"
+msgstr "Повторить 1 раз"
+
+#: id:488
+msgid "Repeat folder"
+msgstr "Повтор папки"
+
+#: id:489
+msgid "Play the next song automatically"
+msgstr "Проигрывать следующий файл автоматически"
+
+#: id:491
+msgid "- Use big icons"
+msgstr "- Использовать большие значки"
+
+#: id:492
+msgid "Resize VobSubs"
+msgstr "Масштабировать субтитры"
+
+#: id:493
+msgid "Advanced options (Experts Only!)"
+msgstr "Расширенные параметры (только для экспертов!)"
+
+#: id:494
+msgid "Overall audio headroom"
+msgstr "Общий уровень шума в комнате (dB)"
+
+#: id:495
+msgid "Upsample videos to GUI resolution"
+msgstr "Масштабировать видео до разрешения GUI"
+
+#: id:496
+msgid "Calibration"
+msgstr "Калибровка"
+
+#: id:497
+msgid "Show file extensions"
+msgstr "Показывать расширения файлов"
+
+#: id:498
+msgid "Sort by: Type"
+msgstr "Сорт. по типу"
+
+#: id:499
+msgid "Unable to connect to online lookup service"
+msgstr "Не удалось подключиться к поисковой службе"
+
+#: id:500
+msgid "Downloading album information failed"
+msgstr "Не удалось загрузить данные об альбоме"
+
+#: id:501
+msgid "Looking for album names..."
+msgstr "Поиск названий альбомов…"
+
+#: id:502
+msgctxt "Auto context with id 502"
+msgid "Open"
+msgstr "Открыть"
+
+#: id:503
+msgid "Busy"
+msgstr "Ждите…"
+
+#: id:504
+msgid "Empty"
+msgstr "Пуст"
+
+#: id:505
+msgid "Loading media info from files..."
+msgstr "Загрузка информации из файлов…"
+
+#: id:507
+msgid "Sort by: Usage"
+msgstr "Сорт. по частоте"
+
+#: id:510
+msgid "Enable visualizations"
+msgstr "Включить визуализацию"
+
+#: id:511
+msgid "Enable video mode switching"
+msgstr "Автопереключение видеорежима"
+
+#: id:512
+msgid "Startup window"
+msgstr "Стартовое окно"
+
+#: id:513
+msgid "Home window"
+msgstr "Главное меню"
+
+#: id:514
+msgid "Manual settings"
+msgstr "Настройки"
+
+#: id:515
+msgid "Genre"
+msgstr "Жанр"
+
+#: id:517
+msgid "Recently played albums"
+msgstr "Недавно прослушанные альбомы"
+
+#: id:518
+msgid "Launch"
+msgstr "Запустить"
+
+#: id:519
+msgid "Launch in..."
+msgstr "Запустить в режиме…"
+
+#: id:521
+msgid "Compilations"
+msgstr "Сборники"
+
+#: id:522
+msgid "Remove source"
+msgstr "Удалить источник"
+
+#: id:523
+msgid "Switch media"
+msgstr "Перейти к разделу…"
+
+#: id:524
+msgid "Select playlist"
+msgstr "Выбрать плейлист"
+
+#: id:525
+msgid "New playlist..."
+msgstr "Создать новый плейлист…"
+
+#: id:526
+msgid "Add to playlist"
+msgstr "Добавить в плейлист"
+
+#: id:527
+msgid "Manually add to library"
+msgstr "Добавить в медиатеку"
+
+#: id:528
+msgid "Enter title"
+msgstr "Введите название"
+
+#: id:529
+msgid "Error: Duplicate title"
+msgstr "Ошибка: одинаковые названия"
+
+#: id:530
+msgid "Select genre"
+msgstr "Выберите жанр"
+
+#: id:531
+msgid "New genre"
+msgstr "Новый жанр"
+
+#: id:532
+msgid "Manual addition"
+msgstr "Ручное добавление"
+
+#: id:533
+msgid "Enter genre"
+msgstr "Введите жанр"
+
+#: id:534
+msgid "View: %s"
+msgstr "Вид: %s"
+
+#: id:535
+msgid "List"
+msgstr "Список"
+
+#: id:536
+msgid "Icons"
+msgstr "Значки"
+
+#: id:537
+msgid "Big list"
+msgstr "Широкий список"
+
+#: id:538
+msgid "Big icons"
+msgstr "Крупные значки"
+
+#: id:539
+msgid "Wide"
+msgstr "Широкий"
+
+#: id:540
+msgid "Big wide"
+msgstr "Широкий крупн."
+
+#: id:541
+msgid "Album icons"
+msgstr "Значки альбомов"
+
+#: id:542
+msgid "DVD icons"
+msgstr "Значки DVD"
+
+#: id:543
+msgctxt "Auto context with id 543"
+msgid "DVD"
+msgstr "DVD"
+
+#: id:544
+msgctxt "Auto context with id 544"
+msgid "Media info"
+msgstr "Информация"
+
+#: id:545
+msgid "Audio output device"
+msgstr "Устройство вывода звука"
+
+#: id:546
+msgid "Passthrough output device"
+msgstr "Устройство прямого вывода звука"
+
+#: id:547
+msgid "No biography for this artist"
+msgstr "Для этого исполнителя нет биографии"
+
+#: id:548
+msgid "Downmix multichannel audio to stereo"
+msgstr "Сводить многоканальный звук в стерео"
+
+#: id:550
+msgid "Sort by: %s"
+msgstr "Сорт. по: %s"
+
+#: id:551
+msgctxt "Auto context with id 551"
+msgid "Name"
+msgstr "Название"
+
+#: id:552
+msgid "Date"
+msgstr "Дата"
+
+#: id:553
+msgid "Size"
+msgstr "Размер"
+
+#: id:554
+msgid "Track"
+msgstr "№ трека"
+
+#: id:555
+msgid "Time"
+msgstr "Время"
+
+#: id:556
+msgctxt "Auto context with id 556"
+msgid "Title"
+msgstr "Название"
+
+#: id:557
+msgid "Artist"
+msgstr "Исполнитель"
+
+#: id:558
+msgid "Album"
+msgstr "Альбом"
+
+#: id:559
+msgid "Playlist"
+msgstr "Плейлист"
+
+#: id:560
+msgid "ID"
+msgstr "ID"
+
+#: id:561
+msgctxt "Auto context with id 561"
+msgid "File"
+msgstr "Файл"
+
+#: id:562
+msgctxt "Auto context with id 562"
+msgid "Year"
+msgstr "Год"
+
+#: id:563
+msgid "Rating"
+msgstr "Рейтинг"
+
+#: id:564
+msgctxt "Auto context with id 564"
+msgid "Type"
+msgstr "Тип"
+
+#: id:565
+msgid "Usage"
+msgstr "Частота"
+
+#: id:566
+msgid "Album artist"
+msgstr "Исполнитель альбома"
+
+#: id:567
+msgid "Play count"
+msgstr "Кол-во проигрываний"
+
+#: id:568
+msgid "Last played"
+msgstr "Последнее проигрывание"
+
+#: id:569
+msgctxt "Auto context with id 569"
+msgid "Comment"
+msgstr "Комментарий"
+
+#: id:570
+msgid "Date added"
+msgstr "Дата добавления"
+
+#: id:571
+msgctxt "Auto context with id 571"
+msgid "Default"
+msgstr "По умолчанию"
+
+#: id:572
+msgid "Studio"
+msgstr "Студия"
+
+#: id:573
+msgid "Path"
+msgstr "Путь"
+
+#: id:574
+msgctxt "Auto context with id 574"
+msgid "Country"
+msgstr "Страна"
+
+#: id:575
+msgid "In progress"
+msgstr "Неоконченные"
+
+#: id:576
+msgid "Times played"
+msgstr "Кол-во проигрываний"
+
+#: id:580
+msgid "Sort direction"
+msgstr "Направление сортировки"
+
+#: id:581
+msgid "Sort method"
+msgstr "Метод сортировки"
+
+#: id:582
+msgctxt "Auto context with id 582"
+msgid "View mode"
+msgstr "Режим просмотра"
+
+#: id:583
+msgid "Remember views for different folders"
+msgstr "Помнить параметры отображения каждой папки"
+
+#: id:584
+msgid "Ascending"
+msgstr "По возрастанию"
+
+#: id:585
+msgid "Descending"
+msgstr "По убыванию"
+
+#: id:586
+msgid "Edit playlist"
+msgstr "Изменить плейлист"
+
+#: id:587
+msgid "Filter"
+msgstr "Фильтр"
+
+#: id:588
+msgid "Cancel party mode"
+msgstr "Отключить режим \"party\""
+
+#: id:589
+msgid "Party mode"
+msgstr "Режим \"party\""
+
+#: id:590
+msgid "Random"
+msgstr "Случайно"
+
+#: id:591
+msgctxt "Auto context with id 591"
+msgid "Off"
+msgstr "Выкл."
+
+#: id:592
+msgid "One"
+msgstr "Один трек"
+
+#: id:593
+msgid "All"
+msgstr "Все треки"
+
+#: id:594
+msgctxt "Auto context with id 594"
+msgid "Off"
+msgstr "Выкл."
+
+#: id:595
+msgid "Repeat: Off"
+msgstr "Повтор: выкл."
+
+#: id:596
+msgid "Repeat: One"
+msgstr "Повтор: один трек"
+
+#: id:597
+msgid "Repeat: All"
+msgstr "Повтор: все треки"
+
+#: id:600
+msgid "Rip audio CD"
+msgstr "Оцифровать аудио-CD"
+
+#: id:601
+msgctxt "Auto context with id 601"
+msgid "Medium"
+msgstr "Среднее"
+
+#: id:602
+msgctxt "Auto context with id 602"
+msgid "Standard"
+msgstr "Стандартное"
+
+#: id:603
+msgid "Extreme"
+msgstr "Максимальное"
+
+#: id:604
+msgid "Constant bitrate"
+msgstr "Постоянный битрейт"
+
+#: id:605
+msgid "Ripping..."
+msgstr "Оцифровка…"
+
+#: id:607
+msgid "To:"
+msgstr "В:"
+
+#: id:608
+msgid "Could not rip CD or track"
+msgstr "Не удалось оцифровать CD или трек"
+
+#: id:609
+msgid "CDDARipPath is not set."
+msgstr "Путь для оцифровки CD не задан"
+
+#: id:610
+msgid "Rip audio track"
+msgstr "Оцифровать аудиотрек"
+
+#: id:611
+msgid "Enter number"
+msgstr "Введите номер"
+
+#: id:612
+msgid "Bits/Sample"
+msgstr "Бит/сэмпл"
+
+#: id:613
+msgid "Sample Frequency"
+msgstr "Частота сэмплирования"
+
+#: id:620
+msgid "Audio CDs"
+msgstr "Аудио-CD"
+
+#: id:621
+msgid "Encoder"
+msgstr "Кодировщик"
+
+#: id:622
+msgid "Quality"
+msgstr "Качество"
+
+#: id:623
+msgid "Bitrate"
+msgstr "Битрейт"
+
+#: id:624
+msgid "Include track number"
+msgstr "Добавить номер трека"
+
+#: id:625
+msgid "All songs of"
+msgstr "Все песни"
+
+#: id:629
+msgctxt "Auto context with id 629"
+msgid "View mode"
+msgstr "Режим просмотра"
+
+#: id:630
+msgctxt "Auto context with id 630"
+msgid "Normal"
+msgstr "Нормальный"
+
+#: id:631
+msgid "Zoom"
+msgstr "Увеличенный"
+
+#: id:632
+msgid "Stretch 4:3"
+msgstr "Растянутый 4:3"
+
+#: id:633
+msgid "Wide Zoom"
+msgstr "Растянутый"
+
+#: id:634
+msgid "Stretch 16:9"
+msgstr "Растянутый 16:9"
+
+#: id:635
+msgid "Original Size"
+msgstr "Оригинальный размер"
+
+#: id:636
+msgctxt "Auto context with id 636"
+msgid "Custom"
+msgstr "Заданный"
+
+#: id:637
+msgid "Replay gain"
+msgstr "Replay Gain"
+
+#: id:638
+msgid "Replaygain volume adjustments"
+msgstr "Режим \"Replay Gain\""
+
+#: id:639
+msgid "Use track levels"
+msgstr "По уровням трека"
+
+#: id:640
+msgid "Use album levels"
+msgstr "По уровням альбома"
+
+#: id:641
+msgid "PreAmp Level - Replay gained files"
+msgstr "Уровень для файлов с Replay Gain"
+
+#: id:642
+msgid "PreAmp Level - Non replay gained files"
+msgstr "Уровень для файлов без Replay Gain"
+
+#: id:643
+msgid "Avoid clipping on replay gained files"
+msgstr "Избегать искажений для файлов с Reply Gain"
+
+#: id:644
+msgid "Crop black bars"
+msgstr "Удалять черные полосы"
+
+#: id:645
+msgid "Need to unpack a big file. Continue?"
+msgstr "Необходимо распаковать большой файл. Продолжить?"
+
+#: id:646
+msgid "Remove from library"
+msgstr "Удалить из медиатеки"
+
+#: id:647
+msgid "Export video library"
+msgstr "Экспортировать видео медиатеку"
+
+#: id:648
+msgid "Import video library"
+msgstr "Импортировать видео медиатеку"
+
+#: id:649
+msgid "Importing"
+msgstr "Импорт…"
+
+#: id:650
+msgid "Exporting"
+msgstr "Экспорт…"
+
+#: id:651
+msgid "Browse for library"
+msgstr "Укажите медиатеку"
+
+#: id:652
+msgid "Years"
+msgstr "Годы"
+
+#: id:653
+msgid "Update library"
+msgstr "Обновить медиатеку"
+
+#: id:654
+msgid "Show debug info"
+msgstr "Показать отладочные данные"
+
+#: id:655
+msgid "Browse for executable"
+msgstr "Укажите программу"
+
+#: id:656
+msgid "Browse for playlist"
+msgstr "Укажите плейлист"
+
+#: id:657
+msgid "Browse for folder"
+msgstr "Укажите папку"
+
+#: id:658
+msgid "Song information"
+msgstr "Сведения о песне"
+
+#: id:659
+msgid "Non-linear stretch"
+msgstr "Нелинейное увеличение"
+
+#: id:660
+msgid "Volume amplification"
+msgstr "Усиление громкости"
+
+#: id:661
+msgid "Choose export folder"
+msgstr "Укажите папку для экспорта"
+
+#: id:662
+msgid "This file is no longer available."
+msgstr "Этот файл больше не доступен."
+
+#: id:663
+msgid "Would you like to remove it from the library?"
+msgstr "Удалить его из медиатеки?"
+
+#: id:664
+msgid "Browse for Script"
+msgstr "Выбрать скрипт"
+
+#: id:665
+msgid "Compression level"
+msgstr "Степень сжатия"
+
+#: id:700
+msgid "Cleaning up library"
+msgstr "Очистка медиатеки…"
+
+#: id:701
+msgid "Removing old songs from the library"
+msgstr "Удаление старых песен из медиатеки…"
+
+#: id:702
+msgid "This path has been scanned before"
+msgstr "Эта папка была просканирована ранее"
+
+#: id:705
+msgctxt "Auto context with id 705"
+msgid "Network"
+msgstr "Сеть"
+
+#: id:706
+msgid "- Server"
+msgstr "- Сервер"
+
+#: id:708
+msgid "Use an HTTP proxy server to access the internet"
+msgstr "Использовать HTTP-прокси для доступа к Интернету"
+
+#: id:711
+msgid "Internet Protocol (IP)"
+msgstr "Интернет-протокол (IP)"
+
+#: id:712
+msgid "Invalid port specified. Value must be between 1 and 65535."
+msgstr "Неправильный порт. Введите значение от 1 до 65535."
+
+#: id:713
+msgid "HTTP proxy"
+msgstr "HTTP-прокси"
+
+#: id:715
+msgid "- Assignment"
+msgstr "- Назначение"
+
+#: id:716
+msgid "Automatic (DHCP)"
+msgstr "Автоматически (DHCP)"
+
+#: id:717
+msgid "Manual (Static)"
+msgstr "Вручную (статический)"
+
+#: id:719
+msgid "- IP address"
+msgstr "- IP-адрес"
+
+#: id:720
+msgid "- Netmask"
+msgstr "- Маска подсети"
+
+#: id:721
+msgid "- Default gateway"
+msgstr "- Шлюз по умолчанию"
+
+#: id:722
+msgid "- DNS server"
+msgstr "- DNS-сервер"
+
+#: id:723
+msgid "Save & restart"
+msgstr "Сохранить и перезапустить"
+
+#: id:724
+msgid "Invalid address specified. Value must be AAA.BBB.CCC.DDD"
+msgstr "Неправильный адрес. Введите значение в виде AAA.BBB.CCC.DDD"
+
+#: id:725
+msgid "with numbers between 0 and 255."
+msgstr "с числами от 0 до 255."
+
+#: id:726
+msgid "Changes not saved. Continue without saving?"
+msgstr "Изменения не сохранены. Продолжить без сохранения?"
+
+#: id:727
+msgid "Web server"
+msgstr "Веб-сервер"
+
+#: id:728
+msgctxt "Auto context with id 728"
+msgid "FTP server"
+msgstr "FTP-сервер"
+
+#: id:730
+msgid "- Port"
+msgstr "- Порт"
+
+#: id:732
+msgid "Save & apply"
+msgstr "Сохранить и применить"
+
+#: id:733
+msgid "- Password"
+msgstr "- Пароль"
+
+#: id:734
+msgid "No pass"
+msgstr "Без пароля"
+
+#: id:735
+msgid "- Character set"
+msgstr "- Кодировка"
+
+#: id:736
+msgid "- Style"
+msgstr "- Стиль"
+
+#: id:737
+msgid "- Colour"
+msgstr "- Цвет"
+
+#: id:738
+msgctxt "Auto context with id 738"
+msgid "Normal"
+msgstr "Нормальный"
+
+#: id:739
+msgid "Bold"
+msgstr "Жирный"
+
+#: id:740
+msgid "Italics"
+msgstr "Курсив"
+
+#: id:741
+msgid "Bold italics"
+msgstr "Жирный курсив"
+
+#: id:742
+msgctxt "Auto context with id 742"
+msgid "White"
+msgstr "Белый"
+
+#: id:743
+msgctxt "Auto context with id 743"
+msgid "Yellow"
+msgstr "Желтый"
+
+#: id:744
+msgctxt "Auto context with id 744"
+msgid "Files"
+msgstr "Файлы"
+
+#: id:745
+msgid "No scanned information for this view"
+msgstr "Нет сканированных данных для этого вида"
+
+#: id:746
+msgid "Please turn off library mode"
+msgstr "Выключите режим медиатеки"
+
+#: id:747
+msgid "Error loading image"
+msgstr "Ошибка загрузки картинки"
+
+#: id:748
+msgid "Edit path"
+msgstr "Изменить путь"
+
+#: id:749
+msgid "Mirror image"
+msgstr "Зеркально"
+
+#: id:750
+msgid "Are you sure?"
+msgstr "Вы уверены?"
+
+#: id:751
+msgid "Removing source"
+msgstr "Удаление источника"
+
+#: id:754
+msgid "Add program link"
+msgstr "Добавить ссылку на программу"
+
+#: id:755
+msgid "Edit program path"
+msgstr "Изменить путь программы"
+
+#: id:756
+msgid "Edit program name"
+msgstr "Изменить название программы"
+
+#: id:757
+msgid "Edit path depth"
+msgstr "Изменить глубину пути"
+
+#: id:759
+msgid "View: Big list"
+msgstr "Вид: широкий список"
+
+#: id:760
+msgctxt "Auto context with id 760"
+msgid "Yellow"
+msgstr "Желтый"
+
+#: id:761
+msgctxt "Auto context with id 761"
+msgid "White"
+msgstr "Белый"
+
+#: id:762
+msgid "Blue"
+msgstr "Синий"
+
+#: id:763
+msgid "Bright green"
+msgstr "Светло-зеленый"
+
+#: id:764
+msgid "Yellow green"
+msgstr "Желто-зеленый"
+
+#: id:765
+msgid "Cyan"
+msgstr "Голубой"
+
+#: id:766
+msgid "Light grey"
+msgstr "Светло-серый"
+
+#: id:767
+msgid "Grey"
+msgstr "Серый"
+
+#: id:770
+msgid "Error %i: share not available"
+msgstr "Ошибка %i: ресурс недоступен"
+
+#: id:772
+msgctxt "Auto context with id 772"
+msgid "Audio output"
+msgstr "Вывод звука"
+
+#: id:773
+msgid "Seeking"
+msgstr "Поиск…"
+
+#: id:774
+msgid "Slideshow folder"
+msgstr "Папка для слайд-шоу"
+
+#: id:775
+msgid "Network interface"
+msgstr "Сетевой интерфейс"
+
+#: id:776
+msgid "- Wireless network name (ESSID)"
+msgstr "- Имя беспроводной сети (ESSID)"
+
+#: id:777
+msgid "- Wireless password"
+msgstr "- Пароль беспроводной сети"
+
+#: id:778
+msgid "- Wireless security"
+msgstr "- Безопасность беспроводной сети"
+
+#: id:779
+msgid "Save and apply network interface settings"
+msgstr "Сохранить и применить настройки сетевого интерфейса"
+
+#: id:780
+msgid "No encryption"
+msgstr "Без шифрования"
+
+#: id:781
+msgid "WEP"
+msgstr "WEP"
+
+#: id:782
+msgid "WPA"
+msgstr "WPA"
+
+#: id:783
+msgid "WPA2"
+msgstr "WPA2"
+
+#: id:784
+msgid "Applying network interface settings. Please wait."
+msgstr "Применение сетевых настроек. Подождите…"
+
+#: id:785
+msgid "Network interface restarted successfully."
+msgstr "Сетевой интерфейс перезапущен."
+
+#: id:786
+msgid "Network interface did not start successfully."
+msgstr "Не удалось запустить сетевой интерфейс."
+
+#: id:787
+msgid "Interface disabled"
+msgstr "Интерфейс отключен"
+
+#: id:788
+msgid "Network interface disabled successfully."
+msgstr "Сетевой интерфейс отключен."
+
+#: id:789
+msgid "Wireless network name (ESSID)"
+msgstr "Имя беспроводной сети (ESSID)"
+
+#: id:790
+msgid "Remote control"
+msgstr ""
+
+#: id:791
+msgid "Allow programs on this system to control XBMC"
+msgstr "Разрешить программам на этой системе управлять XBMC"
+
+#: id:792
+msgctxt "Auto context with id 792"
+msgid "Port"
+msgstr "Порт"
+
+#: id:793
+msgid "Port range"
+msgstr "Диапазон портов"
+
+#: id:794
+msgid "Allow programs on other systems to control XBMC"
+msgstr "Разрешить программам на других системах управлять XBMC"
+
+#: id:795
+msgid "Initial repeat delay (ms)"
+msgstr "Задержка начального повтора (мс)"
+
+#: id:796
+msgid "Continuous repeat delay (ms)"
+msgstr "Задержка последующих повторов (мс)"
+
+#: id:797
+msgid "Maximum number of clients"
+msgstr "Максимальное количество клиентов"
+
+#: id:798
+msgid "Internet access"
+msgstr "Доступ[CR]в Интернет"
+
+#: id:850
+msgid "Invalid port number entered"
+msgstr "Неправильный номер порта."
+
+#: id:851
+msgid "Valid port range is 1-65535"
+msgstr "Доступный диапазон портов: 1–65535"
+
+#: id:852
+msgid "Valid port range is 1024-65535"
+msgstr "Доступный диапазон портов: 1024–65535"
+
+#: id:998
+msgid "Add Music..."
+msgstr "Добавить музыку…"
+
+#: id:999
+msgid "Add Videos..."
+msgstr "Добавить видео…"
+
+#: id:1000
+msgid "- Preview"
+msgstr "- Просмотр"
+
+#: id:1001
+msgid "Unable to connect"
+msgstr "Не удалось подключиться"
+
+#: id:1002
+msgid "XBMC was unable to connect to the network location."
+msgstr "XBMC не удалось подключиться к сети."
+
+#: id:1003
+msgid "This could be due to the network not being connected."
+msgstr "Возможно, сеть не подключена."
+
+#: id:1004
+msgid "Would you like to add it anyway?"
+msgstr "Все равно добавить?"
+
+#: id:1006
+msgctxt "Auto context with id 1006"
+msgid "IP address"
+msgstr "IP-адрес"
+
+#: id:1007
+msgid "Add network location"
+msgstr "Добавить сетевой адрес"
+
+#: id:1008
+msgid "Protocol"
+msgstr "Протокол"
+
+#: id:1009
+msgid "Server address"
+msgstr "Адрес сервера"
+
+#: id:1010
+msgid "Server name"
+msgstr "Имя сервера"
+
+#: id:1011
+msgid "Remote path"
+msgstr "Сетевой путь"
+
+#: id:1012
+msgid "Shared folder"
+msgstr "Общая папка"
+
+#: id:1013
+msgctxt "Auto context with id 1013"
+msgid "Port"
+msgstr "Порт"
+
+#: id:1014
+msgctxt "Auto context with id 1014"
+msgid "Username"
+msgstr "Имя пользователя"
+
+#: id:1015
+msgid "Browse for network server"
+msgstr "Укажите сетевой сервер"
+
+#: id:1016
+msgid "Enter the network address of the server"
+msgstr "Введите адрес сервера"
+
+#: id:1017
+msgid "Enter the path on the server"
+msgstr "Введите путь на сервере"
+
+#: id:1018
+msgid "Enter the port number"
+msgstr "Введите номер порта"
+
+#: id:1019
+msgid "Enter the username"
+msgstr "Введите имя пользователя"
+
+#: id:1020
+msgid "Add %s source"
+msgstr "Добавление источника - %s"
+
+#: id:1021
+msgid "Enter the paths or browse for the media locations."
+msgstr "Введите путь или укажите расположение файлов"
+
+#: id:1022
+msgid "Enter a name for this media Source."
+msgstr "Введите имя медиа-источника."
+
+#: id:1023
+msgid "Browse for new share"
+msgstr "Укажите новый ресурс"
+
+#: id:1024
+msgid "Browse"
+msgstr "Обзор"
+
+#: id:1025
+msgid "Could not retrieve directory information."
+msgstr "Не удалось получить информацию о папке"
+
+#: id:1026
+msgid "Add source"
+msgstr "Добавить источник…"
+
+#: id:1027
+msgid "Edit source"
+msgstr "Изменить источник…"
+
+#: id:1028
+msgid "Edit %s source"
+msgstr "Изменение источника - %s"
+
+#: id:1029
+msgid "Enter the new label"
+msgstr "Введите новое название"
+
+#: id:1030
+msgid "Browse for image"
+msgstr "Укажите картинку"
+
+#: id:1031
+msgid "Browse for image folder"
+msgstr "Укажите папку с картинками"
+
+#: id:1032
+msgid "Add network location..."
+msgstr "Добавить сетевой адрес…"
+
+#: id:1033
+msgid "Browse for file"
+msgstr "Укажите файл"
+
+#: id:1034
+msgid "Submenu"
+msgstr "Подменю"
+
+#: id:1035
+msgid "Enable submenu buttons"
+msgstr "Включить пункты подменю"
+
+#: id:1036
+msgid "Favourites"
+msgstr "Избранное"
+
+#: id:1037
+msgid "Video Add-ons"
+msgstr "Видео дополнения"
+
+#: id:1038
+msgid "Music Add-ons"
+msgstr "Музыкальные дополнения"
+
+#: id:1039
+msgid "Picture Add-ons"
+msgstr "Фото дополнения"
+
+#: id:1040
+msgid "Loading directory"
+msgstr "Загрузка папки…"
+
+#: id:1041
+msgid "Retrieved %i items"
+msgstr "Получено объектов: %i"
+
+#: id:1042
+msgid "Retrieved %i of %i items"
+msgstr "Получено объектов: %i из %i"
+
+#: id:1043
+msgid "Program Add-ons"
+msgstr "Программные дополнения"
+
+#: id:1044
+msgid "Set plugin thumb"
+msgstr "Задать эскиз для дополнения"
+
+#: id:1045
+msgid "Add-on settings"
+msgstr "Настройки дополнения"
+
+#: id:1046
+msgid "Access points"
+msgstr "Точки доступа"
+
+#: id:1047
+msgid "Other..."
+msgstr "Прочее…"
+
+#: id:1048
+msgid "- Username"
+msgstr "- Имя пользователя"
+
+#: id:1049
+msgid "Script settings"
+msgstr "Настройки скриптов"
+
+#: id:1050
+msgid "Singles"
+msgstr "Синглы"
+
+#: id:1051
+msgid "Enter web address"
+msgstr "Введите веб-адрес"
+
+#: id:1200
+msgid "SMB client"
+msgstr "SMB-клиент"
+
+#: id:1202
+msgid "Workgroup"
+msgstr "Рабочая группа"
+
+#: id:1203
+msgid "Default username"
+msgstr "Имя пользователя по умолчанию"
+
+#: id:1204
+msgid "Default password"
+msgstr "Пароль пользователя по умолчанию"
+
+#: id:1207
+msgid "WINS server"
+msgstr "WINS-сервер"
+
+#: id:1208
+msgid "Mount SMB shares"
+msgstr "Монтировать SMB-ресурсы"
+
+#: id:1210
+msgctxt "Auto context with id 1210"
+msgid "Remove"
+msgstr "Удалить"
+
+#: id:1211
+msgctxt "Auto context with id 1211"
+msgid "Music"
+msgstr "Музыка"
+
+#: id:1212
+msgctxt "Auto context with id 1212"
+msgid "Video"
+msgstr "Видео"
+
+#: id:1213
+msgctxt "Auto context with id 1213"
+msgid "Pictures"
+msgstr "Фотографии"
+
+#: id:1214
+msgctxt "Auto context with id 1214"
+msgid "Files"
+msgstr "Файлы"
+
+#: id:1215
+msgctxt "Auto context with id 1215"
+msgid "Music & video"
+msgstr "Музыка и видео"
+
+#: id:1216
+msgid "Music & pictures"
+msgstr "Музыка и фото"
+
+#: id:1217
+msgid "Music & files"
+msgstr "Музыка и файлы"
+
+#: id:1218
+msgid "Video & pictures"
+msgstr "Видео и фото"
+
+#: id:1219
+msgid "Video & files"
+msgstr "Видео и файлы"
+
+#: id:1220
+msgid "Pictures & files"
+msgstr "Фото и файлы"
+
+#: id:1221
+msgid "Music & video & pictures"
+msgstr "Музыка, видео и фото"
+
+#: id:1222
+msgid "Music & video & pictures & files"
+msgstr "Музыка, видео, фото и файлы"
+
+#: id:1223
+msgctxt "Auto context with id 1223"
+msgid "Disabled"
+msgstr "Отключено"
+
+#: id:1226
+msgid "Files & music & video"
+msgstr "Файлы, музыка и видео"
+
+#: id:1227
+msgid "Files & pictures & music"
+msgstr "Файлы, фото и музыка"
+
+#: id:1228
+msgid "Files & pictures & video"
+msgstr "Файлы, фото и видео"
+
+#: id:1229
+msgid "Music & programs"
+msgstr "Музыка и программы"
+
+#: id:1230
+msgid "Video & programs"
+msgstr "Видео и программы"
+
+#: id:1231
+msgid "Pictures & programs"
+msgstr "Фото и программы"
+
+#: id:1232
+msgid "Music & video & pictures & programs"
+msgstr "Музыка, видео, фото и программы"
+
+#: id:1233
+msgid "Programs & video & music"
+msgstr "Программы, видео и музыка"
+
+#: id:1234
+msgid "Programs & pictures & music"
+msgstr "Программы, фото и музыка"
+
+#: id:1235
+msgid "Programs & pictures & video"
+msgstr "Программы, фото и видео"
+
+#: id:1250
+msgid "Auto-detection"
+msgstr "Автоопределение"
+
+#: id:1251
+msgid "Auto-detect system"
+msgstr "Автоопределение системы"
+
+#: id:1252
+msgid "Nickname"
+msgstr "Псевдоним"
+
+#: id:1254
+msgid "Ask to connect"
+msgstr "Запрашивать разрешение на подключение"
+
+#: id:1255
+msgid "Send FTP user and password"
+msgstr "Использовать логин и пароль для FTP"
+
+#: id:1256
+msgid "Ping interval"
+msgstr "Интервал опроса"
+
+#: id:1257
+msgid "Would you like to connect to the auto-detected system?"
+msgstr "Подключиться к найденной системе?"
+
+#: id:1259
+msgid "Zeroconf"
+msgstr ""
+
+#: id:1260
+msgid "Announce these services to other systems via Zeroconf"
+msgstr "Объявлять эти сервисы другим системам по Zeroconf"
+
+#: id:1270
+msgid "Allow XBMC to receive AirPlay content"
+msgstr "Разрешить XBMC получать содержимое AirPlay"
+
+#: id:1271
+msgid "Device name"
+msgstr "Имя устройства"
+
+#: id:1272
+msgid "- Use password protection"
+msgstr "- Использовать пароль"
+
+#: id:1273
+msgid "AirPlay"
+msgstr ""
+
+#: id:1300
+msgid "Custom audio device"
+msgstr "Другое аудио устройство"
+
+#: id:1301
+msgid "Custom passthrough device"
+msgstr "Другое устройство прямого вывода звука"
+
+#: id:1396
+msgid "Drifting"
+msgstr "гололед"
+
+#: id:1397
+msgid "and"
+msgstr "и"
+
+#: id:1398
+msgid "Freezing"
+msgstr "заморозки"
+
+#: id:1399
+msgid "Late"
+msgstr "поздний"
+
+#: id:1400
+msgid "Isolated"
+msgstr "местами"
+
+#: id:1401
+msgid "Thundershowers"
+msgstr "ливень с грозами"
+
+#: id:1402
+msgid "Thunder"
+msgstr "гроза"
+
+#: id:1403
+msgctxt "Auto context with id 1403"
+msgid "Sun"
+msgstr "солнце"
+
+#: id:1404
+msgid "Heavy"
+msgstr "сильный"
+
+#: id:1405
+msgid "in"
+msgstr "в"
+
+#: id:1406
+msgid "the"
+msgstr ""
+
+#: id:1407
+msgid "Vicinity"
+msgstr "окрестностях"
+
+#: id:1408
+msgid "Ice"
+msgstr "лед"
+
+#: id:1409
+msgid "Crystals"
+msgstr "кристаллы"
+
+#: id:1410
+msgid "Calm"
+msgstr "спокойно"
+
+#: id:1411
+msgid "with"
+msgstr "с"
+
+#: id:1412
+msgid "windy"
+msgstr "ветрено"
+
+#: id:1413
+msgid "drizzle"
+msgstr "дождь"
+
+#: id:1414
+msgid "Thunderstorm"
+msgstr "гроза"
+
+#: id:1415
+msgid "Drizzle"
+msgstr "дождь"
+
+#: id:1416
+msgid "Foggy"
+msgstr "туманно"
+
+#: id:1417
+msgid "Grains"
+msgstr "град"
+
+#: id:1418
+msgid "T-Storms"
+msgstr "грозы"
+
+#: id:1419
+msgid "T-Showers"
+msgstr "Ливни с грозами"
+
+#: id:1420
+msgid "Moderate"
+msgstr "умеренный"
+
+#: id:1421
+msgid "Very High"
+msgstr "очень высокий"
+
+#: id:1422
+msgid "Windy"
+msgstr "ветрено"
+
+#: id:1423
+msgid "Mist"
+msgstr "туман"
+
+#: id:1450
+msgid "Put display to sleep when idle"
+msgstr "Выключать экран во время простоя"
+
+#: id:2050
+msgid "Runtime"
+msgstr "Длительность"
+
+#: id:2100
+msgid "Script failed! : %s"
+msgstr "Ошибка скрипта: %s"
+
+#: id:2101
+msgid "Newer version needed - See log"
+msgstr "Требуется более новая версия; см. журнал"
+
+#: id:4501
+msgid "Enable LCD/VFD"
+msgstr "Включить LCD/VFD-дисплей"
+
+#: id:10000
+msgid "Home"
+msgstr "Главное меню"
+
+#: id:10001
+msgctxt "Auto context with id 10001"
+msgid "Programs"
+msgstr "Программы"
+
+#: id:10002
+msgctxt "Auto context with id 10002"
+msgid "Pictures"
+msgstr "Фотографии"
+
+#: id:10003
+msgctxt "Auto context with id 10003"
+msgid "File manager"
+msgstr "Файл-менеджер"
+
+#: id:10004
+msgctxt "Auto context with id 10004"
+msgid "Settings"
+msgstr "Настройки"
+
+#: id:10005
+msgctxt "Auto context with id 10005"
+msgid "Music"
+msgstr "Музыка"
+
+#: id:10006
+msgctxt "Auto context with id 10006"
+msgid "Videos"
+msgstr "Видео"
+
+#: id:10007
+msgid "System information"
+msgstr "Сведения о системе"
+
+#: id:10008
+msgid "Settings - General"
+msgstr "Настройки - Основные"
+
+#: id:10009
+msgid "Settings - Screen"
+msgstr "Настройки - Экран"
+
+#: id:10010
+msgid "Settings - Appearance - GUI Calibration"
+msgstr "Настройки - Внешний вид - Калибровка интерфейса"
+
+#: id:10011
+msgid "Settings - Videos - Screen Calibration"
+msgstr "Настройки - Видео - Калибровка дисплея"
+
+#: id:10012
+msgid "Settings - Pictures"
+msgstr "Настройки - Фотографии"
+
+#: id:10013
+msgid "Settings - Programs"
+msgstr "Настройки - Программы"
+
+#: id:10014
+msgid "Settings - Weather"
+msgstr "Настройки - Погода"
+
+#: id:10015
+msgid "Settings - Music"
+msgstr "Настройки - Музыка"
+
+#: id:10016
+msgid "Settings - System"
+msgstr "Настройки - Система"
+
+#: id:10017
+msgid "Settings - Videos"
+msgstr "Настройки - Видео"
+
+#: id:10018
+msgid "Settings - Network"
+msgstr "Настройки - Сеть"
+
+#: id:10019
+msgid "Settings - Appearance"
+msgstr "Настройки - Внешний вид"
+
+#: id:10020
+msgctxt "Auto context with id 10020"
+msgid "Scripts"
+msgstr "Скрипты"
+
+#: id:10021
+msgid "Web Browser"
+msgstr "Веб-браузер"
+
+#: id:10025
+msgctxt "Auto context with id 10025"
+msgid "Videos"
+msgstr "Видео"
+
+#: id:10028
+msgid "Videos/Playlist"
+msgstr "Видео/плейлист"
+
+#: id:10029
+msgctxt "Auto context with id 10029"
+msgid "Login screen"
+msgstr "Экран входа"
+
+#: id:10034
+msgid "Settings - Profiles"
+msgstr "Настройки - Профили"
+
+#: id:10040
+msgid "Addon browser"
+msgstr "Браузер дополнений"
+
+#: id:10100
+msgid "Yes/No dialog"
+msgstr "Диалог \"Да/Нет\""
+
+#: id:10101
+msgid "Progress dialog"
+msgstr "Диалог выполнения"
+
+#: id:10210
+msgid "Looking for subtitles..."
+msgstr "Поиск субтитров…"
+
+#: id:10211
+msgid "Looking for or caching subtitles..."
+msgstr "Поиск или кэширование субтитров…"
+
+#: id:10212
+msgid "terminating"
+msgstr "завершение…"
+
+#: id:10213
+msgid "buffering"
+msgstr "буферизация…"
+
+#: id:10214
+msgid "Opening stream"
+msgstr "Открытие потока"
+
+#: id:10500
+msgid "Music/Playlist"
+msgstr "Музыка/плейлист"
+
+#: id:10501
+msgid "Music/Files"
+msgstr "Музыка/файлы"
+
+#: id:10502
+msgid "Music/Library"
+msgstr "Музыка/медиатека"
+
+#: id:10503
+msgid "Playlist editor"
+msgstr "Редактор плейлиста"
+
+#: id:10504
+msgid "Top 100 songs"
+msgstr "Топ 100 - песни"
+
+#: id:10505
+msgid "Top 100 albums"
+msgstr "Топ 100 - альбомы"
+
+#: id:10506
+msgctxt "Auto context with id 10506"
+msgid "Programs"
+msgstr "Программы"
+
+#: id:10507
+msgid "Configuration"
+msgstr "Настройка"
+
+#: id:10508
+msgid "Weather forecast"
+msgstr "Прогноз погоды"
+
+#: id:10509
+msgid "Network gaming"
+msgstr "Сетевая игра"
+
+#: id:10510
+msgid "Extensions"
+msgstr "Дополнения"
+
+#: id:10511
+msgctxt "Auto context with id 10511"
+msgid "System info"
+msgstr "Сведения о системе"
+
+#: id:10516
+msgid "Music - Library"
+msgstr "Музыка - Медиатека"
+
+#: id:10517
+msgid "Now Playing - Music"
+msgstr "Музыка - Текущий плейлист"
+
+#: id:10522
+msgid "Now Playing - Videos"
+msgstr "Видео - Текущий плейлист"
+
+#: id:10523
+msgid "Album info"
+msgstr "Сведения об альбоме"
+
+#: id:10524
+msgid "Movie info"
+msgstr "Сведения о фильме"
+
+#: id:12000
+msgid "Select dialog"
+msgstr "Диалог выбора"
+
+#: id:12001
+msgid "Music/Info"
+msgstr "Музыка/данные"
+
+#: id:12002
+msgid "Dialog OK"
+msgstr "Диалог \"ОК\""
+
+#: id:12003
+msgid "Videos/Info"
+msgstr "Видео/данные"
+
+#: id:12004
+msgid "Scripts/Info"
+msgstr "Скрипты/данные"
+
+#: id:12005
+msgid "Fullscreen video"
+msgstr "Полноэкранное видео"
+
+#: id:12006
+msgid "Audio visualization"
+msgstr "Визуализация аудио"
+
+#: id:12008
+msgid "File stacking dialog"
+msgstr "Диалог объединения файлов"
+
+#: id:12009
+msgid "Rebuild index..."
+msgstr "Переиндексация…"
+
+#: id:12010
+msgid "Return to music window"
+msgstr "Вернуться в раздел \"Музыка\""
+
+#: id:12011
+msgid "Return to videos window"
+msgstr "Вернуться в раздел \"Видео\""
+
+#: id:12021
+msgid "Start from beginning"
+msgstr "Начать с начала"
+
+#: id:12022
+msgid "Resume from %s"
+msgstr "Продолжить с %s"
+
+#: id:12310
+msgid "0"
+msgstr "0"
+
+#: id:12311
+msgid "1"
+msgstr "1"
+
+#: id:12312
+msgid "2"
+msgstr "2"
+
+#: id:12313
+msgid "3"
+msgstr "3"
+
+#: id:12314
+msgid "4"
+msgstr "4"
+
+#: id:12315
+msgid "5"
+msgstr "5"
+
+#: id:12316
+msgid "6"
+msgstr "6"
+
+#: id:12317
+msgid "7"
+msgstr "7"
+
+#: id:12318
+msgid "8"
+msgstr "8"
+
+#: id:12319
+msgid "9"
+msgstr "9"
+
+#: id:12320
+msgid "c"
+msgstr "c"
+
+#: id:12321
+msgid "Ok"
+msgstr "Ок"
+
+#: id:12322
+msgid "*"
+msgstr "*"
+
+#: id:12325
+msgid "Locked! Enter code..."
+msgstr "Заблокировано. Введите код…"
+
+#: id:12326
+msgid "Enter password"
+msgstr "Введите пароль"
+
+#: id:12327
+msgid "Enter master code"
+msgstr "Введите код защиты"
+
+#: id:12328
+msgid "Enter unlock code"
+msgstr "Введите код разблокирования"
+
+#: id:12329
+msgid "or press C to cancel"
+msgstr "или нажмите \"C\" для отмены"
+
+#: id:12330
+msgid "Enter gamepad button combo and"
+msgstr "Нажмите нужные кнопки на джойстике,"
+
+#: id:12331
+msgid "press OK, or Back to cancel"
+msgstr "а затем \"ОК\" или \"Назад\" для отмены"
+
+#: id:12332
+msgid "Set lock"
+msgstr "Установить защиту"
+
+#: id:12333
+msgid "Unlock"
+msgstr "Разблокировать"
+
+#: id:12334
+msgid "Reset lock"
+msgstr "Сбросить защиту"
+
+#: id:12335
+msgid "Remove lock"
+msgstr "Удалить защиту"
+
+#: id:12337
+msgid "Numeric password"
+msgstr "Цифровой пароль"
+
+#: id:12338
+msgid "Gamepad button combo"
+msgstr "Комбинация кнопок на джойстике"
+
+#: id:12339
+msgid "Full-text password"
+msgstr "Текстовый пароль"
+
+#: id:12340
+msgid "Enter new password"
+msgstr "Введите новый пароль"
+
+#: id:12341
+msgid "Re-Enter new password"
+msgstr "Повторите новый пароль"
+
+#: id:12342
+msgid "Incorrect password,"
+msgstr "Неверный пароль,"
+
+#: id:12343
+msgid "retries left"
+msgstr "осталось попыток"
+
+#: id:12344
+msgid "Passwords entered did not match."
+msgstr "Введенные пароли не совпадают."
+
+#: id:12345
+msgid "Access denied"
+msgstr "Доступ запрещен"
+
+#: id:12346
+msgid "Password retry limit exceeded."
+msgstr "Количество попыток ввода пароля исчерпано."
+
+#: id:12347
+msgid "The system will now shut off."
+msgstr "Система будет выключена."
+
+#: id:12348
+msgid "Item locked"
+msgstr "Заблокировано"
+
+#: id:12353
+msgid "Reactivate lock"
+msgstr "Переустановить защиту"
+
+#: id:12356
+msgid "Change lock"
+msgstr "Сменить защиту"
+
+#: id:12357
+msgid "Source lock"
+msgstr "Защита источника"
+
+#: id:12358
+msgid "Password entry was blank. Try again."
+msgstr "Пустой пароль. Повторите ввод."
+
+#: id:12360
+msgid "Master lock"
+msgstr "Общая защита"
+
+#: id:12362
+msgid "Shutdown system if Master Lock retries exceeded"
+msgstr "Выключить систему, если количество неудачных попыток исчерпано"
+
+#: id:12367
+msgid "Master code is not valid"
+msgstr "Неправильный код защиты"
+
+#: id:12368
+msgid "Please enter a valid master code"
+msgstr "Введите правильный код защиты"
+
+#: id:12373
+msgid "Settings & file manager"
+msgstr "Настройки и файл-менеджер"
+
+#: id:12376
+msgid "Set as default for all movies"
+msgstr "Установить для всех фильмов"
+
+#: id:12377
+msgid "This will reset any previously saved values"
+msgstr "Это сбросит сохраненные ранее значения."
+
+#: id:12378
+msgid "Amount of time to display each image"
+msgstr "Время показа каждого слайда"
+
+#: id:12379
+msgid "Use pan and zoom effects"
+msgstr "Эффекты панорамы и увеличения"
+
+#: id:12383
+msgid "12 hour clock"
+msgstr "12-часовой"
+
+#: id:12384
+msgid "24 hour clock"
+msgstr "24-часовой"
+
+#: id:12385
+msgid "Day/Month"
+msgstr "День/месяц"
+
+#: id:12386
+msgid "Month/Day"
+msgstr "Месяц/день"
+
+#: id:12390
+msgid "System uptime"
+msgstr "Время работы системы"
+
+#: id:12391
+msgid "Minutes"
+msgstr "мин."
+
+#: id:12392
+msgid "Hours"
+msgstr "ч."
+
+#: id:12393
+msgid "Days"
+msgstr "дн."
+
+#: id:12394
+msgid "Total uptime"
+msgstr "Общее время работы"
+
+#: id:12395
+msgid "Battery level"
+msgstr "Уровень батареи"
+
+#: id:12600
+msgctxt "Auto context with id 12600"
+msgid "Weather"
+msgstr "Погода"
+
+#: id:12900
+msgctxt "Auto context with id 12900"
+msgid "Screensaver"
+msgstr "Заставка"
+
+#: id:12901
+msgid "Fullscreen OSD"
+msgstr "Полноэкранный OSD"
+
+#: id:13000
+msgid "System"
+msgstr "Система"
+
+#: id:13001
+msgid "Immediate HD spindown"
+msgstr "Немедленная остановка HDD"
+
+#: id:13002
+msgid "Video only"
+msgstr "Только видео"
+
+#: id:13003
+msgid "- Delay"
+msgstr "- Задержка"
+
+#: id:13004
+msgid "- Minimum file duration"
+msgstr "- Минимальная длительность файла"
+
+#: id:13005
+msgid "Shutdown"
+msgstr "Выключение"
+
+#: id:13008
+msgid "Shutdown function"
+msgstr "Режим выключения"
+
+#: id:13009
+msgid "Quit"
+msgstr "Выход"
+
+#: id:13010
+msgid "Hibernate"
+msgstr "Спящий режим"
+
+#: id:13011
+msgid "Suspend"
+msgstr "Ждущий режим"
+
+#: id:13012
+msgid "Exit"
+msgstr "Выход"
+
+#: id:13013
+msgid "Reboot"
+msgstr "Перезагрузка"
+
+#: id:13014
+msgid "Minimize"
+msgstr "Свернуть"
+
+#: id:13015
+msgid "Power button action"
+msgstr "Реакция на кнопку питания"
+
+#: id:13016
+msgid "Power off System"
+msgstr "Выключить систему"
+
+#: id:13020
+msgid "Is another session active, perhaps over ssh?"
+msgstr "Проверьте, не активна ли другая сессия (напр., SSH)."
+
+#: id:13021
+msgid "Mounted removable harddrive"
+msgstr "Подключен переносной жесткий диск"
+
+#: id:13022
+msgid "Unsafe device removal"
+msgstr "Небезопасное отключение устройства"
+
+#: id:13023
+msgid "Successfully removed device"
+msgstr "Устройство отключено успешно"
+
+#: id:13024
+msgid "Joystick plugged"
+msgstr "Джойстик подключен"
+
+#: id:13025
+msgid "Joystick unplugged"
+msgstr "Джойстик отключен"
+
+#: id:13050
+msgid "Running low on battery"
+msgstr "Низкий заряд батареи"
+
+#: id:13100
+msgid "Flicker filter"
+msgstr "Фильтр мерцания"
+
+#: id:13101
+msgid "Let driver choose (requires restart)"
+msgstr "По выбору драйвера (требуется перезапуск)"
+
+#: id:13105
+msgid "Vertical blank sync"
+msgstr "Вертикальная синхронизация"
+
+#: id:13106
+msgctxt "Auto context with id 13106"
+msgid "Disabled"
+msgstr "Отключена"
+
+#: id:13107
+msgid "Enabled during video playback"
+msgstr "Только при просмотре видео"
+
+#: id:13108
+msgctxt "Auto context with id 13108"
+msgid "Always enabled"
+msgstr "Всегда включена"
+
+#: id:13109
+msgid "Test & apply resolution"
+msgstr "Проверить и применить разрешение"
+
+#: id:13110
+msgid "Save resolution?"
+msgstr "Сохранить разрешение?"
+
+#: id:13111
+msgid "Would you like to keep this resolution?"
+msgstr "Оставить это разрешение?"
+
+#: id:13112
+msgid "High quality upscaling"
+msgstr "Высококачественное масштабирование"
+
+#: id:13113
+msgctxt "Auto context with id 13113"
+msgid "Disabled"
+msgstr "Отключено"
+
+#: id:13114
+msgid "Enabled for SD content"
+msgstr "Только для SD-содержимого"
+
+#: id:13115
+msgctxt "Auto context with id 13115"
+msgid "Always enabled"
+msgstr "Всегда включено"
+
+#: id:13116
+msgid "Upscaling method"
+msgstr "Метод масштабирования"
+
+#: id:13117
+msgctxt "Auto context with id 13117"
+msgid "Bicubic"
+msgstr "Bicubic"
+
+#: id:13118
+msgid "Lanczos"
+msgstr "Lanczos"
+
+#: id:13119
+msgid "Sinc"
+msgstr "Sinc"
+
+#: id:13120
+msgctxt "Auto context with id 13120"
+msgid "VDPAU"
+msgstr "VDPAU"
+
+#: id:13121
+msgid "VDPAU HQ Upscaling level"
+msgstr "Высококачественное масштабирование VDPAU"
+
+#: id:13122
+msgid "VDPAU Studio level color conversion"
+msgstr "Преобразование цветов в VDPAU"
+
+#: id:13130
+msgid "Blank other displays"
+msgstr "Гасить другие дисплеи"
+
+#: id:13131
+msgctxt "Auto context with id 13131"
+msgid "Disabled"
+msgstr "Отключено"
+
+#: id:13132
+msgid "Blank displays"
+msgstr "Погасить дисплеи"
+
+#: id:13140
+msgid "Active connections detected!"
+msgstr "Обнаружены активные соединения."
+
+#: id:13141
+msgid "If you proceed, you might not be able to control XBMC"
+msgstr "В случае продолжения возможна потеря управления"
+
+#: id:13142
+msgid "any longer. Are you sure you want to stop the Event server?"
+msgstr "XBMC. Остановить сервер событий?"
+
+#: id:13144
+msgid "Change Apple Remote mode?"
+msgstr "Изменить режим пульта Apple?"
+
+#: id:13145
+msgid "If you are currently using the Apple Remote to control"
+msgstr "Если вы используете пульт Apple для управления"
+
+#: id:13146
+msgid "XBMC, changing this setting might affect your ability"
+msgstr "XBMC, изменение этих настроек может отключить"
+
+#: id:13147
+msgid "to continue controlling it. Do you want to proceed?"
+msgstr "возможность управления. Продолжить?"
+
+#: id:13159
+msgid "Subnet mask"
+msgstr "Маска подсети"
+
+#: id:13160
+msgid "Gateway"
+msgstr "Шлюз"
+
+#: id:13161
+msgid "Primary DNS"
+msgstr "Основной DNS"
+
+#: id:13162
+msgid "Initialize failed"
+msgstr "Не удалось инициализировать"
+
+#: id:13170
+msgctxt "Auto context with id 13170"
+msgid "Never"
+msgstr "Никогда"
+
+#: id:13171
+msgid "Immediately"
+msgstr "Немедленно"
+
+#: id:13172
+msgid "After %i secs"
+msgstr "Через %i с."
+
+#: id:13173
+msgid "HDD install date:"
+msgstr "Дата установки HDD:"
+
+#: id:13174
+msgid "HDD power cycle count:"
+msgstr "Кол-во циклов включения/выключения HDD:"
+
+#: id:13200
+msgid "Profiles"
+msgstr "Профили"
+
+#: id:13201
+msgid "Delete profile '%s'?"
+msgstr "Удалить профиль \"%s\"?"
+
+#: id:13204
+msgid "Last loaded profile:"
+msgstr "Последний загруженный профиль:"
+
+#: id:13205
+msgid "Unknown"
+msgstr "Неизвестно"
+
+#: id:13206
+msgid "Overwrite"
+msgstr "Перезаписать"
+
+#: id:13208
+msgid "Alarm clock"
+msgstr "Таймер напоминаний"
+
+#: id:13209
+msgid "Alarm clock interval (in minutes)"
+msgstr "Период таймера напоминаний (в мин.)"
+
+#: id:13210
+msgid "Started, alarm in %im"
+msgstr "Запущен; сработает через %i мин."
+
+#: id:13211
+msgid "Alarm!"
+msgstr "НАПОМИНАНИЕ!"
+
+#: id:13212
+msgid "Canceled with %im%is left"
+msgstr "Отменено за %i мин. %i с. до срабатывания"
+
+#: id:13213
+msgid "%2.0fm"
+msgstr "%2.0f мин."
+
+#: id:13214
+msgid "%2.0fs"
+msgstr "%2.0f с."
+
+#: id:13249
+msgid "Search for subtitles in RARs"
+msgstr "Искать субтитры в архивах RAR"
+
+#: id:13250
+msgid "Browse for subtitle..."
+msgstr "Выбрать субтитры…"
+
+#: id:13251
+msgid "Move item"
+msgstr "Переместить объект"
+
+#: id:13252
+msgid "Move item here"
+msgstr "Переместить объект сюда"
+
+#: id:13253
+msgid "Cancel move"
+msgstr "Отменить перемещение"
+
+#: id:13270
+msgid "Hardware:"
+msgstr "Оборудование:"
+
+#: id:13271
+msgid "CPU Usage:"
+msgstr "Загрузка CPU:"
+
+#: id:13274
+msgid "Connected, but no DNS is available."
+msgstr "Подключено, но DNS-сервер недоступен."
+
+#: id:13275
+msgid "Hard Disk"
+msgstr "Жесткий диск"
+
+#: id:13276
+msgid "DVD-ROM"
+msgstr "Привод DVD"
+
+#: id:13277
+msgctxt "Auto context with id 13277"
+msgid "Storage"
+msgstr "Накопители"
+
+#: id:13278
+msgctxt "Auto context with id 13278"
+msgid "Default"
+msgstr "По умолчанию"
+
+#: id:13279
+msgctxt "Auto context with id 13279"
+msgid "Network"
+msgstr "Сеть"
+
+#: id:13280
+msgctxt "Auto context with id 13280"
+msgid "Video"
+msgstr "Видео"
+
+#: id:13281
+msgid "Hardware"
+msgstr "Оборудование"
+
+#: id:13283
+msgid "Operating system:"
+msgstr "Операционная система:"
+
+#: id:13284
+msgid "CPU speed:"
+msgstr "Частота CPU:"
+
+#: id:13286
+msgid "Video encoder:"
+msgstr "Видеокодировщик:"
+
+#: id:13287
+msgid "Screen resolution:"
+msgstr "Разрешение экрана:"
+
+#: id:13292
+msgid "A/V cable:"
+msgstr "Кабель А/В:"
+
+#: id:13294
+msgid "DVD region:"
+msgstr "Регион DVD:"
+
+#: id:13295
+msgid "Internet:"
+msgstr "Интернет:"
+
+#: id:13296
+msgctxt "Auto context with id 13296"
+msgid "Connected"
+msgstr "подключен"
+
+#: id:13297
+msgid "Not connected. Check network settings."
+msgstr "не подключен. Проверьте настройки сети."
+
+#: id:13299
+msgid "Target temperature"
+msgstr "Поддерживать температуру"
+
+#: id:13300
+msgid "Fan speed"
+msgstr "Скорость вентилятора"
+
+#: id:13301
+msgid "Auto temperature control"
+msgstr "Автоматический контроль температуры"
+
+#: id:13302
+msgid "Fan speed override"
+msgstr "Управление скоростью вентилятора"
+
+#: id:13303
+msgid "- Fonts"
+msgstr "- Шрифты"
+
+#: id:13304
+msgid "Enable flipping bi-directional strings"
+msgstr "Разрешить обратное направление строк"
+
+#: id:13305
+msgid "Show RSS news feeds"
+msgstr "Включить RSS-новости"
+
+#: id:13306
+msgid "Show parent folder items"
+msgstr "Показывать значок родительской папки"
+
+#: id:13307
+msgid "Track naming template"
+msgstr "Шаблон для имени трека"
+
+#: id:13308
+msgid "Do you wish to reboot your system"
+msgstr "Перезагрузить систему"
+
+#: id:13309
+msgid "instead of just XBMC?"
+msgstr "вместо перезапуска XBMC?"
+
+#: id:13310
+msgid "Zoom effect"
+msgstr "Эффект увеличения"
+
+#: id:13311
+msgid "Float effect"
+msgstr "Эффект скольжения"
+
+#: id:13312
+msgid "Black bar reduction"
+msgstr "Уменьшение черных полос"
+
+#: id:13313
+msgid "Restart"
+msgstr "Перезапуск"
+
+#: id:13314
+msgid "Crossfade between songs"
+msgstr "Плавный переход между песнями"
+
+#: id:13315
+msgid "Regenerate thumbnails"
+msgstr "Обновить эскизы"
+
+#: id:13316
+msgid "Recursive thumbnails"
+msgstr "Рекурсивные эскизы"
+
+#: id:13317
+msgid "View slideshow"
+msgstr "Просмотр слайд-шоу"
+
+#: id:13318
+msgid "Recursive slideshow"
+msgstr "Рекурсивное слайд-шоу"
+
+#: id:13319
+msgid "Randomize"
+msgstr "Случайно"
+
+#: id:13320
+msgid "Stereo"
+msgstr "Стерео"
+
+#: id:13321
+msgid "Left only"
+msgstr "Только левый"
+
+#: id:13322
+msgid "Right only"
+msgstr "Только правый"
+
+#: id:13323
+msgid "Enable karaoke support"
+msgstr "Разрешить поддержку караоке"
+
+#: id:13324
+msgid "Background transparency"
+msgstr "Уровень прозрачности фона"
+
+#: id:13325
+msgid "Foreground transparency"
+msgstr "Уровень прозрачности текста"
+
+#: id:13326
+msgid "A/V delay"
+msgstr "Задержка звука относительно изображения"
+
+#: id:13327
+msgid "Karaoke"
+msgstr "Караоке"
+
+#: id:13328
+msgid "%s not found"
+msgstr "%s не найден"
+
+#: id:13329
+msgid "Error opening %s"
+msgstr "Ошибка открытия %s"
+
+#: id:13330
+msgid "Unable to load %s"
+msgstr "Не удалось загрузить %s"
+
+#: id:13331
+msgid "Error: Out of memory"
+msgstr "Ошибка: недостаточно памяти"
+
+#: id:13332
+msgid "Move up"
+msgstr "Переместить вверх"
+
+#: id:13333
+msgid "Move down"
+msgstr "Переместить вниз"
+
+#: id:13334
+msgid "Edit label"
+msgstr "Изменить название"
+
+#: id:13335
+msgid "Make default"
+msgstr "Сделать по умолчанию"
+
+#: id:13336
+msgid "Remove button"
+msgstr "Убрать кнопку"
+
+#: id:13340
+msgid "Leave as is"
+msgstr "Оставить как есть"
+
+#: id:13341
+msgid "Green"
+msgstr "Зеленый"
+
+#: id:13342
+msgid "Orange"
+msgstr "Оранжевый"
+
+#: id:13343
+msgid "Red"
+msgstr "Красный"
+
+#: id:13344
+msgid "Cycle"
+msgstr "Циклически"
+
+#: id:13345
+msgid "Switch LED off on playback"
+msgstr "Выключать индикатор при проигрывании"
+
+#: id:13346
+msgctxt "Auto context with id 13346"
+msgid "Movie information"
+msgstr "Сведения о фильме"
+
+#: id:13347
+msgid "Queue item"
+msgstr "Добавить в плейлист"
+
+#: id:13348
+msgid "Search IMDb..."
+msgstr "Поиск в IMDb…"
+
+#: id:13349
+msgid "Scan for new content"
+msgstr "Сканировать содержимое"
+
+#: id:13350
+msgid "Now playing..."
+msgstr "Текущий плейлист…"
+
+#: id:13351
+msgctxt "Auto context with id 13351"
+msgid "Album information"
+msgstr "Сведения об альбоме"
+
+#: id:13352
+msgid "Scan item to library"
+msgstr "Сканировать в медиатеку"
+
+#: id:13353
+msgid "Stop scanning"
+msgstr "Остановить сканирование"
+
+#: id:13354
+msgctxt "Auto context with id 13354"
+msgid "Render method"
+msgstr "Метод обработки"
+
+#: id:13355
+msgid "Low quality pixel shader"
+msgstr "Пикс. шейдер низк. качества"
+
+#: id:13356
+msgid "Hardware overlays"
+msgstr "Аппаратное наложение"
+
+#: id:13357
+msgid "High quality pixel shader"
+msgstr "Пикс. шейдер высок. качества"
+
+#: id:13358
+msgid "Play item"
+msgstr "Проиграть объект"
+
+#: id:13359
+msgid "Set artist thumb"
+msgstr "Выбрать эскиз исполнителя"
+
+#: id:13360
+msgid "Automatically generate thumbnails"
+msgstr "Создавать эскизы"
+
+#: id:13361
+msgid "Enable voice"
+msgstr "Включить микрофон"
+
+#: id:13375
+msgid "Enable device"
+msgstr "Включить устройство"
+
+#: id:13376
+msgid "Volume"
+msgstr "Громкость"
+
+#: id:13377
+msgid "Default view mode"
+msgstr "Основной режим просмотра"
+
+#: id:13378
+msgid "Default brightness"
+msgstr "Стандартная яркость"
+
+#: id:13379
+msgid "Default contrast"
+msgstr "Стандартная контрастность"
+
+#: id:13380
+msgid "Default gamma"
+msgstr "Стандартная гамма"
+
+#: id:13381
+msgid "Resume video"
+msgstr "Продолжить видео"
+
+#: id:13382
+msgid "Voice mask - Port 1"
+msgstr "Маска для голоса 1"
+
+#: id:13383
+msgid "Voice mask - Port 2"
+msgstr "Маска для голоса 2"
+
+#: id:13384
+msgid "Voice mask - Port 3"
+msgstr "Маска для голоса 3"
+
+#: id:13385
+msgid "Voice mask - Port 4"
+msgstr "Маска для голоса 4"
+
+#: id:13386
+msgid "Use time based seeking"
+msgstr "Позиционировать по времени"
+
+#: id:13387
+msgid "Track naming template - right"
+msgstr "Правая колонка в списке"
+
+#: id:13388
+msgid "Preset"
+msgstr "Предустановка"
+
+#: id:13389
+msgid "There are no presets available\nfor this visualization"
+msgstr "Нет предустановок\nдля этой визуализации"
+
+#: id:13390
+msgid "There are no settings available\nfor this visualization"
+msgstr "Нет настроек\nдля этой визуализации"
+
+#: id:13391
+msgid "Eject/Load"
+msgstr "Открыть/закрыть"
+
+#: id:13392
+msgid "Use visualization if playing audio"
+msgstr "Включить визуализацию при проигрывании музыки"
+
+#: id:13393
+msgid "Calculate size"
+msgstr "Вычислить размер"
+
+#: id:13394
+msgid "Calculating folder size"
+msgstr "Вычисляется размер папки…"
+
+#: id:13395
+msgid "Video settings"
+msgstr "Настройки видео"
+
+#: id:13396
+msgid "Audio and subtitle settings"
+msgstr "Настройки звука и субтитров"
+
+#: id:13397
+msgid "Enable subtitles"
+msgstr "Включить субтитры"
+
+#: id:13398
+msgctxt "Auto context with id 13398"
+msgid "Shortcuts"
+msgstr "Ярлыки"
+
+#: id:13399
+msgid "Ignore articles when sorting (e.g. \"the\")"
+msgstr "Не учитывать артикли при сортировке (напр., \"the\")"
+
+#: id:13400
+msgid "Crossfade between songs on the same album"
+msgstr "Переход между песнями в том же альбоме"
+
+#: id:13401
+msgid "Browse for %s"
+msgstr "Выбрать %s"
+
+#: id:13402
+msgid "Show track position"
+msgstr "Показать позицию трека"
+
+#: id:13403
+msgid "Clear default"
+msgstr "Очистить по умолчанию"
+
+#: id:13404
+msgid "Resume"
+msgstr "Продолжить"
+
+#: id:13405
+msgid "Get thumb"
+msgstr "Эскиз"
+
+#: id:13406
+msgid "Picture information"
+msgstr "Сведения о фотографии"
+
+#: id:13407
+msgid "%s presets"
+msgstr "Предустановок: %s"
+
+#: id:13408
+msgid "(IMDb user rating)"
+msgstr "(Рейтинг пользователей IMDb)"
+
+#: id:13409
+msgid "Top 250"
+msgstr "Топ 250"
+
+#: id:13410
+msgid "Tune in on Last.fm"
+msgstr "Настройки Last.fm"
+
+#: id:13411
+msgid "Minimum fan speed"
+msgstr "Минимальная скорость вентиляторов"
+
+#: id:13412
+msgid "Play from here"
+msgstr "Проигрывать отсюда"
+
+#: id:13413
+msgid "Downloading"
+msgstr "Загрузка…"
+
+#: id:13414
+msgid "Include artists who appear only on compilations"
+msgstr "Включать исполнителей из сборников"
+
+#: id:13415
+msgctxt "Auto context with id 13415"
+msgid "Render method"
+msgstr "Метод обработки"
+
+#: id:13416
+msgid "Auto detect"
+msgstr "Автоопределение"
+
+#: id:13417
+msgid "Basic shaders (ARB)"
+msgstr "Базовые шейдеры (ARB)"
+
+#: id:13418
+msgid "Advanced shaders (GLSL)"
+msgstr "Расширенные шейдеры (GLSL)"
+
+#: id:13419
+msgid "Software"
+msgstr "Программный"
+
+#: id:13420
+msgid "Remove safely"
+msgstr "Безопасное удаление"
+
+#: id:13421
+msgctxt "Auto context with id 13421"
+msgid "VDPAU"
+msgstr "VDPAU"
+
+#: id:13422
+msgid "Start slideshow here"
+msgstr "Начать слайдшоу отсюда"
+
+#: id:13423
+msgid "Remember for this path"
+msgstr "Запомнить путь"
+
+#: id:13424
+msgid "Use pixel buffer objects"
+msgstr "Использовать объекты пиксельного буфера"
+
+#: id:13425
+msgid "Allow hardware acceleration (VDPAU)"
+msgstr "Включить аппаратное ускорение (VDPAU)"
+
+#: id:13426
+msgid "Allow hardware acceleration (VAAPI)"
+msgstr "Включить аппаратное ускорение (VAAPI)"
+
+#: id:13427
+msgid "Allow hardware acceleration (DXVA2)"
+msgstr "Включить аппаратное ускорение (DXVA2)"
+
+#: id:13428
+msgid "Allow hardware acceleration (CrystalHD)"
+msgstr "Включить аппаратное ускорение (CrystalHD)"
+
+#: id:13429
+msgid "Allow hardware acceleration (VDADecoder)"
+msgstr "Включить аппаратное ускорение (VDADecoder)"
+
+#: id:13430
+msgid "Allow hardware acceleration (OpenMax)"
+msgstr "Включить аппаратное ускорение (OpenMax)"
+
+#: id:13431
+msgid "Pixel Shaders"
+msgstr "Пиксельные шейдеры"
+
+#: id:13432
+msgid "Allow hardware acceleration (VideoToolbox)"
+msgstr "Включить аппаратное ускорение (VideoToolbox)"
+
+#: id:13500
+msgid "A/V sync method"
+msgstr "Синхронизация А/В"
+
+#: id:13501
+msgid "Audio clock"
+msgstr "По частоте звука"
+
+#: id:13502
+msgid "Video clock (Drop/Dupe audio)"
+msgstr "По частоте видео (пропуск/дублирование звука)"
+
+#: id:13503
+msgid "Video clock (Resample audio)"
+msgstr "По частоте видео (преобразование звука)"
+
+#: id:13504
+msgid "Maximum resample amount (%)"
+msgstr "Максимальная величина преобразования (%)"
+
+#: id:13505
+msgid "Resample quality"
+msgstr "Качество преобразования"
+
+#: id:13506
+msgid "Low(fast)"
+msgstr "Низкое (быстро)"
+
+#: id:13507
+msgctxt "Auto context with id 13507"
+msgid "Medium"
+msgstr "Среднее"
+
+#: id:13508
+msgctxt "Auto context with id 13508"
+msgid "High"
+msgstr "Высокое"
+
+#: id:13509
+msgid "Really high(slow!)"
+msgstr "Очень высокое (медленно!)"
+
+#: id:13510
+msgid "Sync playback to display"
+msgstr "Синхронизировать видео с частотой дисплея"
+
+#: id:13550
+msgid "Pause during refresh rate change"
+msgstr "Пауза для смены частоты дисплея"
+
+#: id:13551
+msgctxt "Auto context with id 13551"
+msgid "Off"
+msgstr "Выкл."
+
+#: id:13552
+msgid "%.1f Second"
+msgstr "%.1f с."
+
+#: id:13553
+msgid "%.1f Seconds"
+msgstr "%.1f с."
+
+#: id:13600
+msgid "Apple remote"
+msgstr "ДУ Apple"
+
+#: id:13602
+msgid "Allow start of XBMC using the remote"
+msgstr "Разрешить запуск XBMC с ДУ"
+
+#: id:13603
+msgid "Sequence delay time"
+msgstr "Интервал последовательности"
+
+#: id:13610
+msgctxt "Auto context with id 13610"
+msgid "Disabled"
+msgstr "Откл."
+
+#: id:13611
+msgctxt "Auto context with id 13611"
+msgid "Standard"
+msgstr "Стандартный"
+
+#: id:13612
+msgid "Universal Remote"
+msgstr "Универсальный пульт ДУ"
+
+#: id:13613
+msgid "Multi Remote (Harmony)"
+msgstr "Мульти-ДУ (Harmony)"
+
+#: id:13620
+msgid "Apple Remote Error"
+msgstr "Ошибка ДУ Apple"
+
+#: id:13621
+msgid "Apple Remote support could be enabled."
+msgstr "Можно включить поддержку ДУ Apple."
+
+#: id:14000
+msgid "Stack"
+msgstr "Сгруппировать"
+
+#: id:14001
+msgid "Unstack"
+msgstr "Разгруппировать"
+
+#: id:14003
+msgid "Downloading playlist file..."
+msgstr "Загружается файл плейлиста…"
+
+#: id:14004
+msgid "Downloading streams list..."
+msgstr "Загружается список потоков…"
+
+#: id:14005
+msgid "Parsing streams list..."
+msgstr "Анализ списка потоков…"
+
+#: id:14006
+msgid "Downloading streams list failed"
+msgstr "Не удалось загрузить список потоков"
+
+#: id:14007
+msgid "Downloading playlist file failed"
+msgstr "Не удалось загрузить файл плейлиста"
+
+#: id:14009
+msgid "Games directory"
+msgstr "Папка с играми"
+
+#: id:14010
+msgid "Auto switch to thumbs based on"
+msgstr "Автопереключение вида на эскизы по"
+
+#: id:14011
+msgid "Enable auto switching to thumbs view"
+msgstr "Включить автопереключение вида на эскизы"
+
+#: id:14012
+msgid "- Use large icons"
+msgstr "- Использовать большие значки"
+
+#: id:14013
+msgid "- Switch based on"
+msgstr "- Переключать по"
+
+#: id:14014
+msgid "- Percentage"
+msgstr "- Процентное соотношение"
+
+#: id:14015
+msgid "No files and at least one thumb"
+msgstr "Нет файлов и хотя бы один эскиз"
+
+#: id:14016
+msgid "At least one file and thumb"
+msgstr "Хотя бы один файл и эскиз"
+
+#: id:14017
+msgid "Percentage of thumbs"
+msgstr "Процентное соотношение эскизов"
+
+#: id:14018
+msgid "View options"
+msgstr "Настройки просмотра"
+
+#: id:14019
+msgid "Change area code 1"
+msgstr "Местность 1"
+
+#: id:14020
+msgid "Change area code 2"
+msgstr "Местность 2"
+
+#: id:14021
+msgid "Change area code 3"
+msgstr "Местность 3"
+
+#: id:14022
+msgctxt "Auto context with id 14022"
+msgid "Library"
+msgstr "Медиатека"
+
+#: id:14023
+msgid "No TV"
+msgstr "Без ТВ"
+
+#: id:14024
+msgid "Enter the nearest large town"
+msgstr "Введите ближайший крупный город"
+
+#: id:14025
+msgid "Video/Audio/DVD cache - Harddisk"
+msgstr "Кэш аудио/видео/DVD - с ЖД"
+
+#: id:14026
+msgid "Video cache - DVD-ROM"
+msgstr "Кэш видео - с DVD-диска"
+
+#: id:14027
+msgctxt "Auto context with id 14027"
+msgid "- Local Network"
+msgstr "- Из локальной сети"
+
+#: id:14028
+msgctxt "Auto context with id 14028"
+msgid "- Internet"
+msgstr "- из Интернета"
+
+#: id:14030
+msgid "Audio cache - DVD-ROM"
+msgstr "Кэш аудио - с DVD-диска"
+
+#: id:14031
+msgctxt "Auto context with id 14031"
+msgid "- Local Network"
+msgstr "- Из локальной сети"
+
+#: id:14032
+msgctxt "Auto context with id 14032"
+msgid "- Internet"
+msgstr "- из Интернета"
+
+#: id:14034
+msgid "DVD cache - DVD-ROM"
+msgstr "Кэш DVD - с DVD-диска"
+
+#: id:14035
+msgctxt "Auto context with id 14035"
+msgid "- Local Network"
+msgstr "- Из локальной сети"
+
+#: id:14036
+msgctxt "Auto context with id 14036"
+msgid "Services"
+msgstr "Службы"
+
+#: id:14038
+msgid "Network settings changed"
+msgstr "Настройки локальной сети изменены."
+
+#: id:14039
+msgid "XBMC requires to restart to change your"
+msgstr "Для изменения настроек сети требуется"
+
+#: id:14040
+msgid "network setup. Would you like to restart now?"
+msgstr "перезапуск XBMC. Перезапустить сейчас?"
+
+#: id:14041
+msgid "Internet connection bandwidth limitation"
+msgstr "Ограничение скорости интернет-соединения"
+
+#: id:14043
+msgid "- Shutdown while playing"
+msgstr "- Выключать во время проигрывания"
+
+#: id:14044
+msgid "%i min"
+msgstr "%i мин."
+
+#: id:14045
+msgid "%i sec"
+msgstr "%i с."
+
+#: id:14046
+msgid "%i ms"
+msgstr "%i мс"
+
+#: id:14047
+msgid "%i %%"
+msgstr "%i %%"
+
+#: id:14048
+msgid "%i kbps"
+msgstr "%i Кбит/с"
+
+#: id:14049
+msgid "%i kb"
+msgstr "%i Кбит"
+
+#: id:14050
+msgid "%i.0 dB"
+msgstr "%i.0 дБ"
+
+#: id:14051
+msgid "Time format"
+msgstr "Формат времени"
+
+#: id:14052
+msgid "Date format"
+msgstr "Формат даты"
+
+#: id:14053
+msgid "GUI filters"
+msgstr "Фильтры интерфейса"
+
+#: id:14055
+msgid "Use background scanning"
+msgstr "Сканировать в фоновом режиме"
+
+#: id:14056
+msgid "Stop scan"
+msgstr "Остановить сканирование"
+
+#: id:14057
+msgid "Not possible while scanning for media info"
+msgstr "Невозможно, пока сканируются файлы"
+
+#: id:14058
+msgid "Film grain effect"
+msgstr "Эффект кинопленки"
+
+#: id:14059
+msgid "Search for thumbnails on remote shares"
+msgstr "Искать эскизы на внешних ресурсах"
+
+#: id:14060
+msgid "Unknown type cache - Internet"
+msgstr "Кэш неизвестных файлов - из Интернета"
+
+#: id:14061
+msgctxt "Auto context with id 14061"
+msgid "Auto"
+msgstr "Авто"
+
+#: id:14062
+msgid "Enter username for"
+msgstr "Введите имя пользователя для"
+
+#: id:14063
+msgid "Date & time"
+msgstr "Дата и время"
+
+#: id:14064
+msgid "Set date"
+msgstr "Установить дату"
+
+#: id:14065
+msgid "Set time"
+msgstr "Установить время"
+
+#: id:14066
+msgid "Enter the time in 24 hour HH:MM format"
+msgstr "Введите время в 24-часовом формате ЧЧ:ММ"
+
+#: id:14067
+msgid "Enter the date in DD/MM/YYYY format"
+msgstr "Введите дату в формате ДД/ММ/ГГГГ"
+
+#: id:14068
+msgid "Enter the IP address"
+msgstr "Введите IP-адрес"
+
+#: id:14069
+msgid "Apply these settings now?"
+msgstr "Применить эти настройки сейчас?"
+
+#: id:14070
+msgid "Apply changes now"
+msgstr "Применить изменения сейчас"
+
+#: id:14071
+msgid "Allow file renaming and deletion"
+msgstr "Разрешить переименование и удаление файлов"
+
+#: id:14074
+msgid "Set timezone"
+msgstr "Выбрать часовой пояс"
+
+#: id:14075
+msgid "Use daylight saving time"
+msgstr "Учитывать летнее/зимнее время"
+
+#: id:14076
+msgid "Add to favourites"
+msgstr "Добавить в \"Избранное\""
+
+#: id:14077
+msgid "Remove from favourites"
+msgstr "Удалить из \"Избранного\""
+
+#: id:14078
+msgctxt "Auto context with id 14078"
+msgid "- Colours"
+msgstr "- Цвета"
+
+#: id:14079
+msgid "Timezone country"
+msgstr "Страна в часовом поясе"
+
+#: id:14080
+msgid "Timezone"
+msgstr "Часовой пояс"
+
+#: id:14081
+msgid "File lists"
+msgstr "Списки файлов"
+
+#: id:14082
+msgid "Show EXIF picture information"
+msgstr "Показывать сведения о фото из EXIF"
+
+#: id:14083
+msgid "Use a fullscreen window rather than true fullscreen"
+msgstr "Использовать окно на весь экран вместо полного экрана"
+
+#: id:14084
+msgid "Queue songs on selection"
+msgstr "Добавлять треки в очередь при выборе"
+
+#: id:14086
+msgid "Playback"
+msgstr "Воспроизведение"
+
+#: id:14087
+msgid "DVDs"
+msgstr "DVD"
+
+#: id:14088
+msgid "Play DVDs automatically"
+msgstr "Воспроизводить DVD автоматически"
+
+#: id:14089
+msgid "Font to use for text subtitles"
+msgstr "Шрифт текстовых субтитров"
+
+#: id:14090
+msgid "International"
+msgstr "Язык[CR]и стандарты"
+
+#: id:14091
+msgid "Character set"
+msgstr "Кодировка"
+
+#: id:14092
+msgid "Debugging"
+msgstr "Отладка"
+
+#: id:14093
+msgid "Security"
+msgstr "Безопасность"
+
+#: id:14094
+msgid "Input devices"
+msgstr "Устройства ввода"
+
+#: id:14095
+msgid "Power saving"
+msgstr "Экономия[CR]энергии"
+
+#: id:14096
+msgid "Rip"
+msgstr ""
+
+#: id:14097
+msgid "Audio CD Insert Action"
+msgstr ""
+
+#: id:14098
+msgctxt "Auto context with id 14098"
+msgid "Play"
+msgstr ""
+
+#: id:14099
+msgid "Eject disc when CD ripping is complete"
+msgstr ""
+
+#: id:15015
+msgctxt "Auto context with id 15015"
+msgid "Remove"
+msgstr "Удалить"
+
+#: id:15016
+msgid "Games"
+msgstr "Игры"
+
+#: id:15019
+msgid "Add"
+msgstr "Добавить"
+
+#: id:15052
+msgid "Password"
+msgstr "Пароль"
+
+#: id:15100
+msgctxt "Auto context with id 15100"
+msgid "Library"
+msgstr "Медиатека"
+
+#: id:15101
+msgid "Database"
+msgstr "База данных"
+
+#: id:15102
+msgid "* All albums"
+msgstr "* Все альбомы"
+
+#: id:15103
+msgid "* All artists"
+msgstr "* Все исполнители"
+
+#: id:15104
+msgid "* All songs"
+msgstr "* Все песни"
+
+#: id:15105
+msgid "* All genres"
+msgstr "* Все жанры"
+
+#: id:15107
+msgid "Buffering..."
+msgstr "Буферизация…"
+
+#: id:15108
+msgid "Navigation sounds"
+msgstr "Звуки интерфейса"
+
+#: id:15109
+msgid "Skin default"
+msgstr "Стандартн."
+
+#: id:15111
+msgid "- Theme"
+msgstr "- Тема"
+
+#: id:15112
+msgid "Default theme"
+msgstr "Стандартная тема"
+
+#: id:15200
+msgid "Last.fm"
+msgstr "Last.fm"
+
+#: id:15201
+msgid "Submit songs to Last.fm"
+msgstr "Отправлять статистику на Last.fm"
+
+#: id:15202
+msgid "Last.fm username"
+msgstr "Имя пользователя для Last.fm"
+
+#: id:15203
+msgid "Last.fm password"
+msgstr "Пароль для Last.fm"
+
+#: id:15204
+msgid "Unable to handshake: sleeping..."
+msgstr "Не удалось связаться: ожидание…"
+
+#: id:15205
+msgid "Please update XBMC"
+msgstr "Обновите XBMC"
+
+#: id:15206
+msgid "Bad authorization: Check username and password"
+msgstr "Ошибка авторизации: проверьте имя пользователя и пароль"
+
+#: id:15207
+msgctxt "Auto context with id 15207"
+msgid "Connected"
+msgstr "Подключено"
+
+#: id:15208
+msgid "Not connected"
+msgstr "Не подключено"
+
+#: id:15209
+msgid "Submit interval %i"
+msgstr "Интервал подключения %i"
+
+#: id:15210
+msgid "Cached %i songs"
+msgstr "Песен в кэше: %i"
+
+#: id:15211
+msgid "Submitting..."
+msgstr "Подключение…"
+
+#: id:15212
+msgid "Submitting in %i secs"
+msgstr "Подключение через %i с."
+
+#: id:15213
+msgid "Play using..."
+msgstr "Проиграть с помощью…"
+
+#: id:15214
+msgid "Use smoothed A/V synchronization"
+msgstr "Плавная синхронизация звука и видео"
+
+#: id:15215
+msgid "Hide file names in thumbs view"
+msgstr "Скрывать имена файлов в режиме эскизов"
+
+#: id:15216
+msgid "Play in party mode"
+msgstr "Играть в режиме \"party\""
+
+#: id:15217
+msgid "Submit songs to Libre.fm"
+msgstr "Отправлять статистику на Libre.fm"
+
+#: id:15218
+msgid "Libre.fm username"
+msgstr "Имя пользователя для Libre.fm"
+
+#: id:15219
+msgid "Libre.fm password"
+msgstr "Пароль для Libre.fm"
+
+#: id:15220
+msgid "Libre.fm"
+msgstr "Libre.fm"
+
+#: id:15221
+msgid "Song submission"
+msgstr "Отправка[CR]статистики"
+
+#: id:15250
+msgid "Submit Last.fm radio to Last.fm"
+msgstr "Отправлять радио Last.fm на Last.fm"
+
+#: id:15251
+msgid "Connecting to Last.fm..."
+msgstr "Подключение к Last.fm…"
+
+#: id:15252
+msgid "Selecting station..."
+msgstr "Выбор станции…"
+
+#: id:15253
+msgid "Search similar artists..."
+msgstr "Поиск похожих исполнителей…"
+
+#: id:15254
+msgid "Search similar tags..."
+msgstr "Поиск похожих тэгов…"
+
+#: id:15255
+msgid "Your profile (%name%)"
+msgstr "Ваш профиль (%name%)"
+
+#: id:15256
+msgid "Overall top tags"
+msgstr "Общий топ тэгов"
+
+#: id:15257
+msgid "Top artists for tag %name%"
+msgstr "Топ исполнителей по тэгу %name%"
+
+#: id:15258
+msgid "Top albums for tag %name%"
+msgstr "Топ альбомов по тэгу %name%"
+
+#: id:15259
+msgid "Top tracks for tag %name%"
+msgstr "Топ треков по тэгу %name%"
+
+#: id:15260
+msgid "Listen to tag %name% Last.fm radio"
+msgstr "Слушать треки по тэгу %name% на Last.fm"
+
+#: id:15261
+msgid "Similar artists as %name%"
+msgstr "Исполнители, похожие на %name%"
+
+#: id:15262
+msgid "Top %name% albums"
+msgstr "Топ альбомов %name%"
+
+#: id:15263
+msgid "Top %name% tracks"
+msgstr "Топ треков %name%"
+
+#: id:15264
+msgid "Top %name% tags"
+msgstr "Топ тэгов %name%"
+
+#: id:15265
+msgid "Biggest fans of %name%"
+msgstr "Самые преданные фаны %name%"
+
+#: id:15266
+msgid "Listen to %name% fans Last.fm radio"
+msgstr "Слушать выбор фанов %name% на Last.fm"
+
+#: id:15267
+msgid "Listen to %name% similar artists Last.fm radio"
+msgstr "Слушать похожих на %name% исполнителей на Last.fm"
+
+#: id:15268
+msgid "Top artists for user %name%"
+msgstr "Топ исполнителей от %name%"
+
+#: id:15269
+msgid "Top albums for user %name%"
+msgstr "Топ альбомов от %name%"
+
+#: id:15270
+msgid "Top tracks for user %name%"
+msgstr "Топ треков от %name%"
+
+#: id:15271
+msgid "Friends of user %name%"
+msgstr "Друзья %name%"
+
+#: id:15272
+msgid "Neighbours of user %name%"
+msgstr "Сообщества %name%"
+
+#: id:15273
+msgid "Weekly artist chart for %name%"
+msgstr "Недельный чарт исполнителей %name%"
+
+#: id:15274
+msgid "Weekly album chart for %name%"
+msgstr "Недельный чарт альбомов %name%"
+
+#: id:15275
+msgid "Weekly track chart for %name%"
+msgstr "Недельный чарт треков %name%"
+
+#: id:15276
+msgid "Listen to %name%'s neighbours Last.fm radio"
+msgstr "Слушать выбор сообществ %name% на Last.fm"
+
+#: id:15277
+msgid "Listen to %name%'s personal Last.fm radio"
+msgstr "Слушать личный выбор %name% на Last.fm"
+
+#: id:15278
+msgid "Listen to %name%'s mix Last.fm radio"
+msgstr "Слушать любимые треки %name% на Last.fm"
+
+#: id:15279
+msgid "Retrieving list from Last.fm..."
+msgstr "Получение списка от Last.fm…"
+
+#: id:15280
+msgid "Can't retrieve list from Last.fm..."
+msgstr "Не удается получить список от Last.fm…"
+
+#: id:15281
+msgid "Enter an artist name to find related ones"
+msgstr "Введите имя исполнителя для поиска похожих"
+
+#: id:15282
+msgid "Enter a tag name to find similar ones"
+msgstr "Введите название тэга для поиска похожих"
+
+#: id:15283
+msgid "Tracks recently listened by %name%"
+msgstr "Треки, недавно прослушанные %name%"
+
+#: id:15284
+msgid "Listen to %name%'s recommendations Last.fm radio"
+msgstr "Слушать рекомендации %name% на Last.fm"
+
+#: id:15285
+msgid "Top tags for user %name%"
+msgstr "Топ тэгов пользователя %name%"
+
+#: id:15287
+msgid "Do you want to add the current track to your loved tracks?"
+msgstr "Добавить этот трек к вашим любимым трекам?"
+
+#: id:15288
+msgid "Do you want to ban the current track?"
+msgstr "Заблокировать этот трек?"
+
+#: id:15289
+msgid "Added to your loved tracks: '%s'."
+msgstr "Добавлено к вашим любимым трекам: \"%s\"."
+
+#: id:15290
+msgid "Could not add '%s' to your loved tracks."
+msgstr "Не удалось добавить \"%s\" к вашим любимым трекам."
+
+#: id:15291
+msgid "Banned: '%s'."
+msgstr "Заблокировано: \"%s\"."
+
+#: id:15292
+msgid "Could not ban '%s'."
+msgstr "Не удалось заблокировать \"%s\"."
+
+#: id:15293
+msgid "Tracks recently loved by %name%"
+msgstr "Недавно полюбившиеся треки %name%"
+
+#: id:15294
+msgid "Tracks recently banned by %name%"
+msgstr "Недавно заблокированные треки %name%"
+
+#: id:15295
+msgid "Remove from loved tracks"
+msgstr "Удалить из любимых треков"
+
+#: id:15296
+msgid "Un-ban"
+msgstr "Разблокировать"
+
+#: id:15297
+msgid "Do you want to remove this track from your loved tracks?"
+msgstr "Удалить этот трек из ваших любимых треков?"
+
+#: id:15298
+msgid "Do you want to un-ban this track?"
+msgstr "Разблокировать этот трек?"
+
+#: id:15300
+msgid "Path not found or invalid"
+msgstr "Неверный или несуществующий путь"
+
+#: id:15301
+msgid "Could not connect to network server"
+msgstr "Не удалось подключиться к серверу"
+
+#: id:15302
+msgid "No servers found"
+msgstr "Серверы не найдены"
+
+#: id:15303
+msgid "Workgroup not found"
+msgstr "Рабочая группа не найдена"
+
+#: id:15310
+msgid "Opening multi-path source"
+msgstr "Открытие источника с множеством путей"
+
+#: id:15311
+msgid "Path:"
+msgstr "Путь:"
+
+#: id:16000
+msgctxt "Auto context with id 16000"
+msgid "General"
+msgstr "Общие"
+
+#: id:16002
+msgid "Internet lookup"
+msgstr "Поиск в Интернете"
+
+#: id:16003
+msgid "Player"
+msgstr "Проигрыватель"
+
+#: id:16004
+msgid "Play media from disc"
+msgstr "Проиграть файл с диска"
+
+#: id:16008
+msgid "Enter new title"
+msgstr "Введите новое название"
+
+#: id:16009
+msgid "Enter the movie name"
+msgstr "Введите название фильма"
+
+#: id:16010
+msgid "Enter the profile name"
+msgstr "Введите название профиля"
+
+#: id:16011
+msgid "Enter the album name"
+msgstr "Введите название альбома"
+
+#: id:16012
+msgid "Enter the playlist name"
+msgstr "Введите название плейлиста"
+
+#: id:16013
+msgid "Enter new filename"
+msgstr "Введите новое имя файла"
+
+#: id:16014
+msgid "Enter folder name"
+msgstr "Введите название папки"
+
+#: id:16015
+msgid "Enter directory"
+msgstr "Введите папку"
+
+#: id:16016
+msgid "Available options: %A, %T, %N, %B, %D, %G, %Y, %F, %S"
+msgstr "Доступные значения: %A, %T, %N, %B, %D, %G, %Y, %F, %S"
+
+#: id:16017
+msgid "Enter search string"
+msgstr "Строка поиска"
+
+#: id:16018
+msgctxt "Auto context with id 16018"
+msgid "None"
+msgstr "Нет"
+
+#: id:16019
+msgid "Auto select"
+msgstr "Автовыбор"
+
+#: id:16020
+msgid "De-interlace"
+msgstr "Деинтерлейсинг"
+
+#: id:16021
+msgid "Bob"
+msgstr "Bob"
+
+#: id:16022
+msgid "Bob (inverted)"
+msgstr "Bob (обратный)"
+
+#: id:16024
+msgid "Canceling..."
+msgstr "Отмена…"
+
+#: id:16025
+msgid "Enter the artist name"
+msgstr "Введите имя исполнителя"
+
+#: id:16026
+msgid "Playback failed"
+msgstr "Проигрывание плейлиста прервано"
+
+#: id:16027
+msgid "One or more items failed to play."
+msgstr "Не удалось проиграть как минимум один файл."
+
+#: id:16028
+msgid "Enter value"
+msgstr "Введите значение"
+
+#: id:16029
+msgid "Check the log file for details."
+msgstr "Для получения доп. сведений просмотрите журнал."
+
+#: id:16030
+msgid "Party mode aborted."
+msgstr "Режим \"party\" отключен."
+
+#: id:16031
+msgid "No matching songs in the library."
+msgstr "Нет похожих песен в медиатеке."
+
+#: id:16032
+msgid "Could not initialize database."
+msgstr "Не удалось инициализировать базу данных."
+
+#: id:16033
+msgid "Could not open database."
+msgstr "Не удалось открыть базу данных."
+
+#: id:16034
+msgid "Could not get songs from database."
+msgstr "Не удалось получить песни из базы данных."
+
+#: id:16035
+msgid "Party mode playlist"
+msgstr "Плейлист режима \"party\""
+
+#: id:16036
+msgid "De-interlace (Half)"
+msgstr "Деинтерлейсинг (1 поле)"
+
+#: id:16037
+msgid "Deinterlace video"
+msgstr "Деинтерлейсинг"
+
+#: id:16038
+msgid "Deinterlace method"
+msgstr "Метод деинтерлейсинга"
+
+#: id:16039
+msgctxt "Auto context with id 16039"
+msgid "Off"
+msgstr "Выкл."
+
+#: id:16040
+msgctxt "Auto context with id 16040"
+msgid "Auto"
+msgstr "Авто"
+
+#: id:16041
+msgid "On"
+msgstr "Вкл."
+
+#: id:16100
+msgid "All Videos"
+msgstr "Все видео"
+
+#: id:16101
+msgid "Unwatched"
+msgstr "Не просмотрено"
+
+#: id:16102
+msgid "Watched"
+msgstr "Просмотрено"
+
+#: id:16103
+msgid "Mark as watched"
+msgstr "В просмотренные"
+
+#: id:16104
+msgid "Mark as unwatched"
+msgstr "В непросмотренные"
+
+#: id:16105
+msgid "Edit title"
+msgstr "Изменить название"
+
+#: id:16200
+msgid "Operation was aborted"
+msgstr "Операция прервана"
+
+#: id:16201
+msgid "Copy failed"
+msgstr "Не удалось скопировать"
+
+#: id:16202
+msgid "Failed to copy at least one file"
+msgstr "Не удалось скопировать как минимум один файл"
+
+#: id:16203
+msgid "Move failed"
+msgstr "Не удалось переместить"
+
+#: id:16204
+msgid "Failed to move at least one file"
+msgstr "Не удалось переместить как минимум один файл"
+
+#: id:16205
+msgid "Delete failed"
+msgstr "Не удалось удалить"
+
+#: id:16206
+msgid "Failed to delete at least one file"
+msgstr "Не удалось удалить как минимум один файл"
+
+#: id:16300
+msgid "Video scaling method"
+msgstr "Метод масштабирования видео"
+
+#: id:16301
+msgid "Nearest neighbour"
+msgstr "Nearest neighbour"
+
+#: id:16302
+msgid "Bilinear"
+msgstr "Bilinear"
+
+#: id:16303
+msgctxt "Auto context with id 16303"
+msgid "Bicubic"
+msgstr "Bicubic"
+
+#: id:16304
+msgid "Lanczos2"
+msgstr "Lanczos2"
+
+#: id:16305
+msgid "Lanczos3"
+msgstr "Lanczos3"
+
+#: id:16306
+msgid "Sinc8"
+msgstr "Sinc8"
+
+#: id:16307
+msgid "Bicubic (software)"
+msgstr "Bicubic (программный)"
+
+#: id:16308
+msgid "Lanczos (software)"
+msgstr "Lanczos (программный)"
+
+#: id:16309
+msgid "Sinc (software)"
+msgstr "Sinc (программный)"
+
+#: id:16310
+msgid "Temporal"
+msgstr "Temporal"
+
+#: id:16311
+msgid "Temporal/Spatial"
+msgstr "Temporal/Spatial"
+
+#: id:16312
+msgid "(VDPAU)Noise Reduction"
+msgstr "Шумоподавление (VDPAU)"
+
+#: id:16313
+msgid "(VDPAU)Sharpness"
+msgstr "Резкость (VDPAU)"
+
+#: id:16314
+msgid "Inverse Telecine"
+msgstr "Обратный пуллдаун (3:2)"
+
+#: id:16315
+msgid "Lanczos3 optimized"
+msgstr "Оптимизир. Lanczos3"
+
+#: id:16316
+msgctxt "Auto context with id 16316"
+msgid "Auto"
+msgstr "Авто"
+
+#: id:16317
+msgid "Temporal (Half)"
+msgstr "Temporal (1 поле)"
+
+#: id:16318
+msgid "Temporal/Spatial (Half)"
+msgstr "Temporal/Spatial (1 поле)"
+
+#: id:16319
+msgid "DXVA"
+msgstr "DXVA"
+
+#: id:16320
+msgid "DXVA Bob"
+msgstr "Bob DXVA"
+
+#: id:16321
+msgid "DXVA Best"
+msgstr "Лучший DXVA"
+
+#: id:16322
+msgid "Spline36"
+msgstr "Spline36"
+
+#: id:16323
+msgid "Spline36 optimized"
+msgstr "Оптимизир. Spline36"
+
+#: id:16324
+msgid "Software Blend"
+msgstr "Blend (программный)"
+
+#: id:16400
+msgid "Post-processing"
+msgstr "Постобработка"
+
+#: id:17500
+msgid "Display sleep timeout"
+msgstr "Переход дисплея в спящий режим через"
+
+#: id:19000
+msgid "Switch to channel"
+msgstr "Переключиться на канал"
+
+#: id:20000
+msgid "Saved music folder"
+msgstr "Папка сохраненной музыки"
+
+#: id:20001
+msgid "Use external DVD player"
+msgstr "Использовать внешний проигрыватель DVD"
+
+#: id:20002
+msgid "External DVD player"
+msgstr "Внешний проигрыватель DVD"
+
+#: id:20003
+msgid "Trainers folder"
+msgstr "Папка для трейнеров"
+
+#: id:20004
+msgid "Screenshot folder"
+msgstr "Папка для скриншотов"
+
+#: id:20006
+msgid "Playlists folder"
+msgstr "Папка для плейлистов"
+
+#: id:20007
+msgid "Recordings"
+msgstr "Записи"
+
+#: id:20008
+msgid "Screenshots"
+msgstr "Скриншоты"
+
+#: id:20009
+msgid "Use XBMC"
+msgstr "Использовать XBMC"
+
+#: id:20011
+msgid "Music playlists"
+msgstr "Музыкальные плейлисты"
+
+#: id:20012
+msgid "Video playlists"
+msgstr "Плейлисты видео"
+
+#: id:20013
+msgid "Do you wish to launch the game?"
+msgstr "Запустить игру?"
+
+#: id:20014
+msgid "Sort by: Playlist"
+msgstr "Сорт. по плейлисту"
+
+#: id:20015
+msgid "Remote thumb"
+msgstr "Внешний эскиз"
+
+#: id:20016
+msgid "Current thumb"
+msgstr "Текущий эскиз"
+
+#: id:20017
+msgid "Local thumb"
+msgstr "Локальный эскиз"
+
+#: id:20018
+msgid "No thumb"
+msgstr "Без эскиза"
+
+#: id:20019
+msgid "Choose thumbnail"
+msgstr "Выбрать эскиз"
+
+#: id:20023
+msgid "Conflict"
+msgstr "Конфликт"
+
+#: id:20024
+msgid "Scan new"
+msgstr "Сканировать новое"
+
+#: id:20025
+msgid "Scan all"
+msgstr "Сканировать все"
+
+#: id:20026
+msgid "Region"
+msgstr "Регион"
+
+#: id:20037
+msgid "Summary"
+msgstr "Сведения"
+
+#: id:20038
+msgid "Lock music window"
+msgstr "Заблокировать раздел \"Музыка\""
+
+#: id:20039
+msgid "Lock videos window"
+msgstr "Заблокировать раздел \"Видео\""
+
+#: id:20040
+msgid "Lock pictures window"
+msgstr "Заблокировать раздел \"Фотографии\""
+
+#: id:20041
+msgid "Lock programs & scripts windows"
+msgstr "Заблокировать разделы \"Программы\" и \"Скрипты\""
+
+#: id:20042
+msgid "Lock file manager"
+msgstr "Заблокировать \"Файл-менеджер\""
+
+#: id:20043
+msgid "Lock settings"
+msgstr "Заблокировать \"Настройки\""
+
+#: id:20044
+msgid "Start fresh"
+msgstr "Чистый старт"
+
+#: id:20045
+msgid "Enter master mode"
+msgstr "Включить режим полного доступа"
+
+#: id:20046
+msgid "Leave master mode"
+msgstr "Выключить режим полного доступа"
+
+#: id:20047
+msgid "Create profile '%s'?"
+msgstr "Создать профиль \"%s\"?"
+
+#: id:20048
+msgid "Start with fresh settings"
+msgstr "Запустить с чистыми параметрами"
+
+#: id:20049
+msgid "Best available"
+msgstr "Лучший из доступных"
+
+#: id:20050
+msgid "Auto-switch between 16x9 and 4x3"
+msgstr "Автоматический выбор 16:9 или 4:3"
+
+#: id:20051
+msgid "Treat stacked files as single file"
+msgstr "Рассматривать составные файлы как единый файл"
+
+#: id:20052
+msgid "Caution"
+msgstr "Внимание"
+
+#: id:20053
+msgid "Left master mode"
+msgstr "Отключен режим полного доступа"
+
+#: id:20054
+msgid "Entered master mode"
+msgstr "Включен режим полного доступа"
+
+#: id:20055
+msgid "Allmusic.com thumb"
+msgstr "Эскиз с Allmusic.com"
+
+#: id:20057
+msgid "Remove thumbnail"
+msgstr "Удалить эскиз"
+
+#: id:20058
+msgid "Add profile..."
+msgstr "Добавить профиль…"
+
+#: id:20059
+msgid "Query info for all albums"
+msgstr "Получить сведения обо всех альбомах"
+
+#: id:20060
+msgctxt "Auto context with id 20060"
+msgid "Media info"
+msgstr "Информация"
+
+#: id:20061
+msgctxt "Auto context with id 20061"
+msgid "Separate"
+msgstr "Разделять"
+
+#: id:20062
+msgid "Shares with default"
+msgstr "Стандартные ресурсы"
+
+#: id:20063
+msgid "Shares with default (read only)"
+msgstr "Стандартные ресурсы (только чтение)"
+
+#: id:20064
+msgid "Copy default"
+msgstr "Копировать стандартные"
+
+#: id:20065
+msgid "Profile picture"
+msgstr "Картинка профиля"
+
+#: id:20066
+msgid "Lock preferences"
+msgstr "Заблокировать предпочтения"
+
+#: id:20067
+msgid "Edit profile"
+msgstr "Изменить профиль"
+
+#: id:20068
+msgid "Profile lock"
+msgstr "Заблокировать профиль"
+
+#: id:20069
+msgid "Could not create folder"
+msgstr "Не удалось создать папку"
+
+#: id:20070
+msgid "Profile directory"
+msgstr "Папка профиля"
+
+#: id:20071
+msgid "Start with fresh media sources"
+msgstr "Стартовать с новыми источниками"
+
+#: id:20072
+msgid "Make sure the selected folder is writable"
+msgstr "Убедитесь, что выбранная папка доступна для записи"
+
+#: id:20073
+msgid "and that the new folder name is valid"
+msgstr "и указано правильное имя новой папки"
+
+#: id:20074
+msgid "MPAA rating"
+msgstr "Рейтинг MPAA"
+
+#: id:20075
+msgid "Enter master lock code"
+msgstr "Введите код защиты"
+
+#: id:20076
+msgid "Ask for master lock code on startup"
+msgstr "Запрашивать код защиты при старте"
+
+#: id:20077
+msgid "Skin settings"
+msgstr "Настройки обложки"
+
+#: id:20078
+msgid "- no link set -"
+msgstr "- нет связи -"
+
+#: id:20079
+msgid "Enable animations"
+msgstr "Использовать анимацию"
+
+#: id:20080
+msgid "Disable RSS during music"
+msgstr "Отключить RSS-ленту во время воспроизведения музыки"
+
+#: id:20081
+msgid "Enable shortcut buttons"
+msgstr "Включить кнопки ярлыков"
+
+#: id:20082
+msgid "Show programs in main menu"
+msgstr "Показывать \"Программы\" в главном меню"
+
+#: id:20083
+msgid "Show music info"
+msgstr "Показывать сведения о музыке"
+
+#: id:20084
+msgid "Show weather info"
+msgstr "Показывать сведения о погоде"
+
+#: id:20085
+msgid "Show system info"
+msgstr "Показывать сведения о системе"
+
+#: id:20086
+msgid "Show available disc space C: E: F:"
+msgstr "Показывать свободное место на дисках C: E: F:"
+
+#: id:20087
+msgid "Show available disc space E: F: G:"
+msgstr "Показывать свободное место на дисках E: F: G:"
+
+#: id:20088
+msgid "Weather info"
+msgstr "Погода"
+
+#: id:20089
+msgid "Drive space free"
+msgstr "Свободное место на диске"
+
+#: id:20090
+msgid "Enter the name of an existing share"
+msgstr "Введите имя существующего ресурса"
+
+#: id:20091
+msgid "Lock code"
+msgstr "Код защиты"
+
+#: id:20092
+msgid "Load profile"
+msgstr "Загрузить профиль"
+
+#: id:20093
+msgid "Profile name"
+msgstr "Название профиля"
+
+#: id:20094
+msgctxt "Auto context with id 20094"
+msgid "Media sources"
+msgstr "Источники данных"
+
+#: id:20095
+msgid "Enter profile lock code"
+msgstr "Введите код защиты профиля"
+
+#: id:20096
+msgctxt "Auto context with id 20096"
+msgid "Login screen"
+msgstr "Экран входа"
+
+#: id:20097
+msgid "Fetching album info"
+msgstr "Запрос данных об альбоме…"
+
+#: id:20098
+msgid "Fetching info for album"
+msgstr "Запрос данных для альбома…"
+
+#: id:20099
+msgid "Can't rip CD or track while playing from CD"
+msgstr "Невозможно оцифровывать во время проигрывания"
+
+#: id:20100
+msgid "Master lock code and settings"
+msgstr "Код защиты и его настройки"
+
+#: id:20101
+msgid "Entering master lock code always enables master mode"
+msgstr "Ввод кода защиты всегда переключает в режим полного доступа"
+
+#: id:20102
+msgid "or copy from default?"
+msgstr "или копировать из стандартного?"
+
+#: id:20103
+msgid "Save changes to profile?"
+msgstr "Сохранить изменения профиля?"
+
+#: id:20104
+msgid "Old settings found."
+msgstr "Найдены старые настройки"
+
+#: id:20105
+msgid "Do you want to use them?"
+msgstr "Использовать их?"
+
+#: id:20106
+msgid "Old media sources found."
+msgstr "Найдены старые ресурсы"
+
+#: id:20107
+msgid "Separate (locked)"
+msgstr "Раздельно (закрыто)"
+
+#: id:20108
+msgid "Root"
+msgstr "Корень"
+
+#: id:20109
+msgid "- Zoom"
+msgstr "- Масштаб"
+
+#: id:20110
+msgid "UPnP settings"
+msgstr "Настройки UPnP"
+
+#: id:20111
+msgid "Autostart UPnP client"
+msgstr "Автозапуск клиента UPnP"
+
+#: id:20112
+msgid "Last login: %s"
+msgstr "Последний вход: %s"
+
+#: id:20113
+msgid "Never logged on"
+msgstr "Не входил никогда"
+
+#: id:20114
+msgid "Profile %i / %i"
+msgstr "Профиль %i / %i"
+
+#: id:20115
+msgid "User login / Select a profile"
+msgstr "Вход пользователя / выбор профиля"
+
+#: id:20116
+msgid "Use lock on login screen"
+msgstr "Использовать защиту экрана входа"
+
+#: id:20117
+msgid "Invalid lock code."
+msgstr "Неверный код защиты."
+
+#: id:20118
+msgid "This requires the master lock to be set."
+msgstr "Необходимо установить код защиты."
+
+#: id:20119
+msgid "Would you like to set it now?"
+msgstr "Установить его сейчас?"
+
+#: id:20120
+msgid "Loading program information"
+msgstr "Загрузка сведений о программе…"
+
+#: id:20121
+msgid "Party on!"
+msgstr "Вечеринка началась!"
+
+#: id:20122
+msgid "True"
+msgstr "Да"
+
+#: id:20123
+msgid "Mixing drinks"
+msgstr "Смешивание напитков"
+
+#: id:20124
+msgid "Filling glasses"
+msgstr "Наполнение бокалов"
+
+#: id:20125
+msgid "Logged on as"
+msgstr "Текущий пользователь"
+
+#: id:20126
+msgid "Log off"
+msgstr "Выход"
+
+#: id:20128
+msgid "Go to root"
+msgstr "Перейти в корневую папку"
+
+#: id:20129
+msgid "Weave"
+msgstr "Weave"
+
+#: id:20130
+msgid "Weave (inverted)"
+msgstr "Weave (обратный)"
+
+#: id:20131
+msgid "Blend"
+msgstr "Blend"
+
+#: id:20132
+msgid "Restart video"
+msgstr "Перезапустить видео"
+
+#: id:20133
+msgid "Edit network location"
+msgstr "Изменить сетевой ресурс"
+
+#: id:20134
+msgid "Remove network location"
+msgstr "Удалить сетевой ресурс"
+
+#: id:20135
+msgid "Do you want to scan the folder?"
+msgstr "Сканировать папку?"
+
+#: id:20136
+msgid "Memory unit"
+msgstr "Карта памяти"
+
+#: id:20137
+msgid "Memory unit mounted"
+msgstr "Карта памяти подключена"
+
+#: id:20138
+msgid "Unable to mount memory unit"
+msgstr "Не удалось подключить карту памяти"
+
+#: id:20139
+msgid "In port %i, slot %i"
+msgstr "в порт %i, слот %i"
+
+#: id:20140
+msgid "Lock screensaver"
+msgstr "Заблокировать хранитель экрана"
+
+#: id:20141
+msgid "Set"
+msgstr "Установить"
+
+#: id:20142
+msgctxt "Auto context with id 20142"
+msgid "Username"
+msgstr "Имя пользователя"
+
+#: id:20143
+msgid "Enter password for"
+msgstr "Введите пароль для"
+
+#: id:20144
+msgid "Shutdown timer"
+msgstr "Таймер выключения"
+
+#: id:20145
+msgid "Shutdown interval (in minutes)"
+msgstr "Интервал выключения (мин.)"
+
+#: id:20146
+msgid "Started, shutdown in %im"
+msgstr "Запущен, выключение через %i мин."
+
+#: id:20147
+msgid "Shutdown in 30 minutes"
+msgstr "Выключение через 30 мин."
+
+#: id:20148
+msgid "Shutdown in 60 minutes"
+msgstr "Выключение через 60 мин."
+
+#: id:20149
+msgid "Shutdown in 120 minutes"
+msgstr "Выключение через 120 мин."
+
+#: id:20150
+msgid "Custom shutdown timer"
+msgstr "Выключение по таймеру"
+
+#: id:20151
+msgid "Cancel shutdown timer"
+msgstr "Отменить таймер выключения"
+
+#: id:20152
+msgid "Lock preferences for %s"
+msgstr "Заблокировать предпочтения для %s"
+
+#: id:20153
+msgid "Browse..."
+msgstr "Просмотр…"
+
+#: id:20154
+msgid "Summary information"
+msgstr "Основные сведения"
+
+#: id:20155
+msgid "Storage information"
+msgstr "Сведения о накопителях"
+
+#: id:20156
+msgid "Hard disk information"
+msgstr "Сведения о ЖД"
+
+#: id:20157
+msgid "DVD-ROM information"
+msgstr "Сведения о DVD-ROM"
+
+#: id:20158
+msgid "Network information"
+msgstr "Сведения о сети"
+
+#: id:20159
+msgid "Video information"
+msgstr "Сведения о видеоподсистеме"
+
+#: id:20160
+msgid "Hardware information"
+msgstr "Сведения об оборудовании"
+
+#: id:20161
+msgid "Total"
+msgstr "Всего"
+
+#: id:20162
+msgid "Used"
+msgstr "Занято"
+
+#: id:20163
+msgid "of"
+msgstr "из"
+
+#: id:20164
+msgid "Locking not supported"
+msgstr "Защита не поддерживается"
+
+#: id:20165
+msgid "Not locked"
+msgstr "Не заблокировано"
+
+#: id:20166
+msgid "Locked"
+msgstr "Заблокировано"
+
+#: id:20167
+msgid "Frozen"
+msgstr "Заморожен"
+
+#: id:20168
+msgid "Requires reset"
+msgstr "Требуется сброс"
+
+#: id:20169
+msgid "Week"
+msgstr "Неделя"
+
+#: id:20170
+msgid "Line"
+msgstr "Линия"
+
+#: id:20171
+msgid "Windows network (SMB)"
+msgstr "Сеть Windows (SMB)"
+
+#: id:20172
+msgid "XBMSP server"
+msgstr "XBMSP-сервер"
+
+#: id:20173
+msgctxt "Auto context with id 20173"
+msgid "FTP server"
+msgstr "FTP-сервер"
+
+#: id:20174
+msgid "iTunes music share (DAAP)"
+msgstr "Ресурс iTunes (DAAP)"
+
+#: id:20175
+msgid "UPnP server"
+msgstr "UPnP-сервер"
+
+#: id:20176
+msgid "Show video info"
+msgstr "Показывать сведения о видео"
+
+#: id:20177
+msgid "Done"
+msgstr "Готово"
+
+#: id:20178
+msgid "Shift"
+msgstr "Shift"
+
+#: id:20179
+msgid "Caps Lock"
+msgstr "Caps Lock"
+
+#: id:20180
+msgid "Symbols"
+msgstr "Символы"
+
+#: id:20181
+msgid "Backspace"
+msgstr "<- Backspace"
+
+#: id:20182
+msgid "Space"
+msgstr "Пробел"
+
+#: id:20183
+msgid "Reload skin"
+msgstr "Обновить обложку"
+
+#: id:20184
+msgid "Rotate pictures using EXIF information"
+msgstr "Поворачивать фото по информации из EXIF"
+
+#: id:20185
+msgid "Use poster view styles for TV shows"
+msgstr "Использовать представления с постерами для сериалов"
+
+#: id:20186
+msgid "Please wait"
+msgstr "Подождите…"
+
+#: id:20187
+msgid "UPnP"
+msgstr ""
+
+#: id:20189
+msgid "Enable auto scrolling for plot & review"
+msgstr "Включить автопрокрутку для сюжетов и обзоров"
+
+#: id:20190
+msgctxt "Auto context with id 20190"
+msgid "Custom"
+msgstr "Дополнительно"
+
+#: id:20191
+msgid "Enable debug logging"
+msgstr "Включить журнал отладки"
+
+#: id:20192
+msgid "Download additional information during updates"
+msgstr "Загружать доп. информацию во время обновлений"
+
+#: id:20193
+msgid "Default service for album information"
+msgstr "Служба по умолчанию для альбомов"
+
+#: id:20194
+msgid "Default service for artist information"
+msgstr "Служба по умолчанию для исполнителей"
+
+#: id:20195
+msgid "Change scraper"
+msgstr "Изменить инфоресурс"
+
+#: id:20196
+msgid "Export music library"
+msgstr "Экспортировать музыкальную медиатеку"
+
+#: id:20197
+msgid "Import music library"
+msgstr "Импортировать музыкальную медиатеку"
+
+#: id:20198
+msgid "No artist found!"
+msgstr "Исполнитель не найден."
+
+#: id:20199
+msgid "Downloading artist info failed"
+msgstr "Не удалось загрузить сведения об исполнителе"
+
+#: id:20250
+msgid "Party on! (videos)"
+msgstr "Вечеринка началась! (Видео)"
+
+#: id:20251
+msgid "Mixing drinks (videos)"
+msgstr "Смешивание напитков (видео)"
+
+#: id:20252
+msgid "Filling glasses (videos)"
+msgstr "Наполнение бокалов (видео)"
+
+#: id:20253
+msgid "WebDAV server (HTTP)"
+msgstr "WebDAV-сервер (HTTP)"
+
+#: id:20254
+msgid "WebDAV server (HTTPS)"
+msgstr "WebDAV-сервер (HTTPS)"
+
+#: id:20255
+msgid "First logon, edit your profile"
+msgstr "Первый вход; настройте свой профиль"
+
+#: id:20256
+msgid "HTS Tvheadend client"
+msgstr "Клиент HTS Tvheadend"
+
+#: id:20257
+msgid "VDR Streamdev client"
+msgstr "Клиент VDR Streamdev"
+
+#: id:20258
+msgid "MythTV client"
+msgstr "Клиент MythTV"
+
+#: id:20259
+msgid "Network Filesystem (NFS)"
+msgstr "Протокол NFS"
+
+#: id:20260
+msgid "Secure Shell (SSH/SFTP)"
+msgstr "Протокол SSH/SFTP"
+
+#: id:20261
+msgid "Apple Filing Protocol (AFP)"
+msgstr "Протокол AFP"
+
+#: id:20300
+msgid "Web server directory (HTTP)"
+msgstr "Папка веб-сервера (HTTP)"
+
+#: id:20301
+msgid "Web server directory (HTTPS)"
+msgstr "Папка веб-сервера (HTTPS)"
+
+#: id:20302
+msgid "Unable to write to folder:"
+msgstr "Не удалось записать в папку:"
+
+#: id:20303
+msgid "Do you want to skip and proceed?"
+msgstr "Пропустить и продолжить?"
+
+#: id:20304
+msgid "RSS Feed"
+msgstr "RSS-лента"
+
+#: id:20307
+msgid "Secondary DNS"
+msgstr "Дополнительный DNS"
+
+#: id:20308
+msgid "DHCP server:"
+msgstr "Сервер DHCP:"
+
+#: id:20309
+msgid "Make new folder"
+msgstr "Создать новую папку"
+
+#: id:20310
+msgid "Dim LCD on playback"
+msgstr "Затемнять LCD-экран при проигрывании"
+
+#: id:20311
+msgid "Unknown or onboard (protected)"
+msgstr "Неизвестный или встроенный (защищенный)"
+
+#: id:20312
+msgid "Dim LCD on paused"
+msgstr "Затемнять LCD-экран на паузе"
+
+#: id:20314
+msgid "Videos - Library"
+msgstr "Видео - Медиатека"
+
+#: id:20316
+msgid "Sort by: ID"
+msgstr "Сорт. по ID"
+
+#: id:20324
+msgid "Play part..."
+msgstr "Играть часть…"
+
+#: id:20325
+msgid "Calibration reset"
+msgstr "Сброс калибровки"
+
+#: id:20326
+msgid "This will reset the calibration values for %s"
+msgstr "Это сбросит калибровочные значения для %s"
+
+#: id:20327
+msgid "to it's default values."
+msgstr "до значений по умолчанию"
+
+#: id:20328
+msgid "Browse for destination"
+msgstr "Укажите назначение"
+
+#: id:20329
+msgid "Movies are in separate folders that match the movie title"
+msgstr "Файлы в отдельных папках с названием фильма"
+
+#: id:20330
+msgid "Use folder names for lookups"
+msgstr "Использовать имена папок для поиска"
+
+#: id:20331
+msgctxt "Auto context with id 20331"
+msgid "File"
+msgstr "Файл"
+
+#: id:20332
+msgid "Use file or folder names in lookups?"
+msgstr "Использовать имена файлов или папок для поиска?"
+
+#: id:20333
+msgid "Set content"
+msgstr "Выбрать тип содержимого"
+
+#: id:20334
+msgid "Folder"
+msgstr "Папка"
+
+#: id:20335
+msgid "Look for content recursively?"
+msgstr "Просматривать содержимое вложенных папок?"
+
+#: id:20336
+msgid "Unlock sources"
+msgstr "Разблокировать источники"
+
+#: id:20337
+msgid "Actor"
+msgstr "Актер"
+
+#: id:20338
+msgid "Movie"
+msgstr "Фильм"
+
+#: id:20339
+msgid "Director"
+msgstr "Режиссер"
+
+#: id:20340
+msgid "Do you want to remove all items within"
+msgstr "Удалить все объекты внутри"
+
+#: id:20341
+msgid "this path from the XBMC library?"
+msgstr "этого пути из медиатеки?"
+
+#: id:20342
+msgctxt "Auto context with id 20342"
+msgid "Movies"
+msgstr "Фильмы"
+
+#: id:20343
+msgid "TV shows"
+msgstr "Сериалы"
+
+#: id:20344
+msgid "This directory contains"
+msgstr "Эта папка содержит"
+
+#: id:20345
+msgid "Run automated scan"
+msgstr "Запустить автоматическое сканирование"
+
+#: id:20346
+msgid "Scan recursively"
+msgstr "Сканировать с подпапками"
+
+#: id:20347
+msgid "as"
+msgstr "в роли"
+
+#: id:20348
+msgid "Directors"
+msgstr "Режиссеры"
+
+#: id:20349
+msgid "No video files found in this path!"
+msgstr "Не найдено видеофайлов по этому пути."
+
+#: id:20350
+msgid "votes"
+msgstr "проголосовало"
+
+#: id:20351
+msgid "TV show information"
+msgstr "Сведения о сериале"
+
+#: id:20352
+msgid "Episode information"
+msgstr "Сведения о серии"
+
+#: id:20353
+msgid "Loading TV show details"
+msgstr "Загрузка сведений о сериале…"
+
+#: id:20354
+msgid "Fetching episode guide"
+msgstr "Получение расписания серий…"
+
+#: id:20355
+msgid "Loading info for episodes in directory"
+msgstr "Загрузка сведений о сериях в папке…"
+
+#: id:20356
+msgid "Select TV show:"
+msgstr "Выберите сериал:"
+
+#: id:20357
+msgid "Enter the TV show name"
+msgstr "Введите название сериала"
+
+#: id:20358
+msgid "Season %i"
+msgstr "Сезон %i"
+
+#: id:20359
+msgid "Episode"
+msgstr "Серия"
+
+#: id:20360
+msgid "Episodes"
+msgstr "Серии"
+
+#: id:20361
+msgid "Loading episode details"
+msgstr "Загрузка сведений о серии…"
+
+#: id:20362
+msgid "Remove episode from library"
+msgstr "Удалить серию из медиатеки"
+
+#: id:20363
+msgid "Remove TV show from library"
+msgstr "Удалить сериал из медиатеки"
+
+#: id:20364
+msgid "TV show"
+msgstr "Сериал"
+
+#: id:20365
+msgid "Episode plot"
+msgstr "Сюжет серии"
+
+#: id:20366
+msgid "* All seasons"
+msgstr "* Все сезоны"
+
+#: id:20367
+msgid "Hide watched"
+msgstr "Без просмотренных"
+
+#: id:20368
+msgid "Prod code"
+msgstr "Код продукта"
+
+#: id:20369
+msgid "Show plot for unwatched items"
+msgstr "Показывать сюжет для непросмотренного"
+
+#: id:20370
+msgid "* Hidden to prevent spoilers *"
+msgstr "* Скрыто, чтобы избежать спойлеров *"
+
+#: id:20371
+msgid "Set season thumb"
+msgstr "Выбрать эскиз для сезона"
+
+#: id:20372
+msgid "Season image"
+msgstr "Картинка сезона"
+
+#: id:20373
+msgid "Season"
+msgstr "Сезон"
+
+#: id:20374
+msgid "Downloading movie information"
+msgstr "Загрузка сведений о фильме…"
+
+#: id:20375
+msgid "Unassign content"
+msgstr "Не указывать содержимое"
+
+#: id:20376
+msgid "Original title"
+msgstr "Оригинальное название"
+
+#: id:20377
+msgid "Refresh TV show information"
+msgstr "Обновить сведения о сериале"
+
+#: id:20378
+msgid "Refresh info for all episodes?"
+msgstr "Обновить сведения обо всех сериях?"
+
+#: id:20379
+msgid "Selected folder contains a single TV show"
+msgstr "Указанная папка содержит отдельный сериал"
+
+#: id:20380
+msgid "Exclude selected folder from scans"
+msgstr "Не сканировать выбранную папку"
+
+#: id:20381
+msgid "Specials"
+msgstr "Дополнения"
+
+#: id:20382
+msgid "Automatically grab season thumbs"
+msgstr "Автоматически загружать эскизы для сезонов"
+
+#: id:20383
+msgid "Selected folder contains a single video"
+msgstr "Указанная папка содержит отдельный видеофайл"
+
+#: id:20384
+msgid "Link to TV show"
+msgstr "Связать с сериалом"
+
+#: id:20385
+msgid "Remove link to TV show"
+msgstr "Убрать связь с сериалом"
+
+#: id:20386
+msgid "Recently added movies"
+msgstr "Последние фильмы"
+
+#: id:20387
+msgid "Recently added episodes"
+msgstr "Последние серии"
+
+#: id:20388
+msgid "Studios"
+msgstr "Студии"
+
+#: id:20389
+msgid "Music videos"
+msgstr "Муз. клипы"
+
+#: id:20390
+msgid "Recently added music videos"
+msgstr "Последние клипы"
+
+#: id:20391
+msgid "Music video"
+msgstr "Музыкальный клип"
+
+#: id:20392
+msgid "Remove music video from library"
+msgstr "Удалить музыкальный клип из медиатеки"
+
+#: id:20393
+msgctxt "Auto context with id 20393"
+msgid "Music video information"
+msgstr "Сведения о клипе"
+
+#: id:20394
+msgid "Loading music video information"
+msgstr "Загрузка сведений о клипе…"
+
+#: id:20395
+msgid "Mixed"
+msgstr "Смешанный"
+
+#: id:20396
+msgid "Go to albums by artist"
+msgstr "Перейти к альбомам по исполнителям"
+
+#: id:20397
+msgid "Go to album"
+msgstr "Перейти к альбому"
+
+#: id:20398
+msgid "Play song"
+msgstr "Играть песню"
+
+#: id:20399
+msgid "Go to music videos from album"
+msgstr "Перейти к музыкальным клипам из альбома"
+
+#: id:20400
+msgid "Go to music videos by artist"
+msgstr "Перейти к музыкальным клипам по исполнителю"
+
+#: id:20401
+msgid "Play music video"
+msgstr "Играть музыкальный клип"
+
+#: id:20402
+msgid "Download actor thumbnails when adding to library"
+msgstr "Автоматически загружать эскизы для актеров"
+
+#: id:20403
+msgid "Set actor thumb"
+msgstr "Выбрать эскиз для актера"
+
+#: id:20405
+msgid "Remove episode bookmark"
+msgstr "Удалить закладку серии"
+
+#: id:20406
+msgid "Set episode bookmark"
+msgstr "Создать закладку серии"
+
+#: id:20407
+msgid "Scraper settings"
+msgstr "Настройки инфоресурса"
+
+#: id:20408
+msgid "Downloading music video information"
+msgstr "Загрузка сведений о музыкальном клипе…"
+
+#: id:20409
+msgid "Downloading TV show information"
+msgstr "Загрузка сведений о сериале…"
+
+#: id:20410
+msgid "Trailer"
+msgstr "Трейлер"
+
+#: id:20411
+msgid "Flatten"
+msgstr "Без категорий"
+
+#: id:20412
+msgid "Flatten TV shows"
+msgstr "Не объединять серии сериалов в сезоны"
+
+#: id:20413
+msgid "Get fanart"
+msgstr "Фанарт"
+
+#: id:20414
+msgid "Show Fanart in video and music libraries"
+msgstr "Показывать фанарт в медиатеке"
+
+#: id:20415
+msgid "Scanning for new content"
+msgstr "Сканирование нового содержимого…"
+
+#: id:20416
+msgid "First aired"
+msgstr "Премьера"
+
+#: id:20417
+msgid "Writer"
+msgstr "Сценарий"
+
+#: id:20419
+msgid "Replace file names with library titles"
+msgstr "Показывать названия из медиатеки вместо имен файлов"
+
+#: id:20420
+msgctxt "Auto context with id 20420"
+msgid "Never"
+msgstr "Никогда"
+
+#: id:20421
+msgid "If only one season"
+msgstr "Если один сезон"
+
+#: id:20422
+msgid "Always"
+msgstr "Всегда"
+
+#: id:20423
+msgid "Has trailer"
+msgstr "Есть трейлер"
+
+#: id:20424
+msgid "False"
+msgstr "Нет"
+
+#: id:20425
+msgid "Fanart slideshow"
+msgstr "Слайд-шоу фанартов"
+
+#: id:20426
+msgid "Export to a single file or separate"
+msgstr "Экспортировать одним файлом или разделять"
+
+#: id:20427
+msgid "files per entry?"
+msgstr "на отдельные файлы для каждой записи?"
+
+#: id:20428
+msgid "Single file"
+msgstr "Одним файлом"
+
+#: id:20429
+msgctxt "Auto context with id 20429"
+msgid "Separate"
+msgstr "Разделять"
+
+#: id:20430
+msgid "Export thumbnails and fanart?"
+msgstr "Экспортировать эскизы и фанарт?"
+
+#: id:20431
+msgid "Overwrite old files?"
+msgstr "Перезаписать файлы?"
+
+#: id:20432
+msgid "Exclude path from library updates"
+msgstr "Исключить путь из обновлений медиатеки"
+
+#: id:20433
+msgid "Extract thumbnails and video information"
+msgstr "Извлекать метаданные из медиафайлов"
+
+#: id:20434
+msgid "Sets"
+msgstr "Киноциклы"
+
+#: id:20435
+msgid "Set movieset thumb"
+msgstr "Выбрать эскиз киноцикла"
+
+#: id:20436
+msgid "Export actor thumbs?"
+msgstr "Экспортировать эскизы актеров?"
+
+#: id:20437
+msgid "Choose fanart"
+msgstr "Выбрать фанарт"
+
+#: id:20438
+msgid "Local fanart"
+msgstr "Локальный фанарт"
+
+#: id:20439
+msgid "No fanart"
+msgstr "Без фанарта"
+
+#: id:20440
+msgid "Current fanart"
+msgstr "Текущий фанарт"
+
+#: id:20441
+msgid "Remote fanart"
+msgstr "Внешний фанарт"
+
+#: id:20442
+msgid "Change content"
+msgstr "Изменить тип содержимого"
+
+#: id:20443
+msgid "Do you want to refresh info for all"
+msgstr "Обновить сведения для всех"
+
+#: id:20444
+msgid "items within this path?"
+msgstr "объектов в данной папке?"
+
+#: id:20445
+msgid "Fanart"
+msgstr "Фанарт"
+
+#: id:20446
+msgid "Locally stored information found."
+msgstr "Найдены локальные сведения."
+
+#: id:20447
+msgid "Ignore and refresh from internet?"
+msgstr "Игнорировать и обновить из Интернета?"
+
+#: id:20448
+msgid "Could not download information"
+msgstr "Не удалось загрузить сведения"
+
+#: id:20449
+msgid "Unable to connect to remote server"
+msgstr "Сервер недоступен."
+
+#: id:20450
+msgid "Would you like to continue scanning?"
+msgstr "Продолжить сканирование?"
+
+#: id:20451
+msgid "Countries"
+msgstr "Страны"
+
+#: id:20452
+msgid "episode"
+msgstr "серия"
+
+#: id:20453
+msgid "episodes"
+msgstr "серий"
+
+#: id:20454
+msgid "Listener"
+msgstr "Слушатель"
+
+#: id:20455
+msgid "Listeners"
+msgstr "Слушателей"
+
+#: id:20456
+msgid "Set movieset fanart"
+msgstr "Выбрать фанарт киноцикла"
+
+#: id:20457
+msgid "Movie set"
+msgstr "Киноцикл"
+
+#: id:20458
+msgid "Group movies in sets"
+msgstr "Объединять фильмы в циклы"
+
+#: id:21330
+msgid "Show hidden files and directories"
+msgstr "Показывать скрытые файлы и папки"
+
+#: id:21331
+msgid "TuxBox client"
+msgstr "Клиент TuxBox"
+
+#: id:21332
+msgid "WARNING: Target TuxBox device is in recording-mode!"
+msgstr "ВНИМАНИЕ. Целевое устройство TuxBox находится в режиме записи!"
+
+#: id:21333
+msgid "The stream will be stopped!"
+msgstr "Поток будет остановлен!"
+
+#: id:21334
+msgid "Zap to channel: %s failed!"
+msgstr "Не удалось переключиться на канал %s."
+
+#: id:21335
+msgid "Are you sure to start the stream?"
+msgstr "Включить поток?"
+
+#: id:21336
+msgid "Connecting to: %s"
+msgstr "Подключение к: %s"
+
+#: id:21337
+msgid "TuxBox device"
+msgstr "Устройство TuxBox"
+
+#: id:21359
+msgid "Add media share..."
+msgstr "Добавить медиаресурс…"
+
+#: id:21360
+msgid "Share video and music libraries through UPnP"
+msgstr "Включить доступ к медиатеке по UPnP"
+
+#: id:21364
+msgid "Edit media share"
+msgstr "Изменить медиаресурс"
+
+#: id:21365
+msgid "Remove media share"
+msgstr "Удалить медиаресурс"
+
+#: id:21366
+msgid "Subtitle folder"
+msgstr "Папка субтитров"
+
+#: id:21367
+msgid "Movie & alternate subtitle directory"
+msgstr "Папка для фильмов и альтернативных субтитров"
+
+#: id:21368
+msgid "Override ASS/SSA subtitles fonts"
+msgstr "Игнорировать шрифты субтитров ASS/SSA"
+
+#: id:21369
+msgid "Enable mouse and Touch Screen support"
+msgstr "Включить мышь и сенсорный экран"
+
+#: id:21370
+msgid "Play navigation sounds during media playback"
+msgstr "Звуки интерфейса во время проигрывания"
+
+#: id:21371
+msgid "Thumbnail"
+msgstr "Эскизы"
+
+#: id:21372
+msgid "Forced DVD player region"
+msgstr "Установить регион DVD-проигрывателя"
+
+#: id:21373
+msgid "Video output"
+msgstr "Вывод видео"
+
+#: id:21374
+msgid "Video aspect"
+msgstr "Соотношение сторон видео"
+
+#: id:21375
+msgctxt "Auto context with id 21375"
+msgid "Normal"
+msgstr "Нормальное"
+
+#: id:21376
+msgid "Letterbox"
+msgstr "4:3"
+
+#: id:21377
+msgid "Widescreen"
+msgstr "Широкоформатное"
+
+#: id:21378
+msgid "Enable 480p"
+msgstr "Включить 480p"
+
+#: id:21379
+msgid "Enable 720p"
+msgstr "Включить 720p"
+
+#: id:21380
+msgid "Enable 1080i"
+msgstr "Включить 1080i"
+
+#: id:21381
+msgid "Enter name of new playlist"
+msgstr "Введите имя нового плейлиста"
+
+#: id:21382
+msgid "Show \"Add source\" buttons in file lists"
+msgstr "Показывать \"Добавить источник\" в списках файлов"
+
+#: id:21383
+msgid "Enable scrollbars"
+msgstr "Включить полосы прокрутки"
+
+#: id:21384
+msgid "Make watched filtering a toggle in video library"
+msgstr "Отмечать просмотренное видео в медиатеке"
+
+#: id:21385
+msgctxt "Auto context with id 21385"
+msgid "Open"
+msgstr "Открыть"
+
+#: id:21386
+msgid "Acoustic management level"
+msgstr "Управление уровнем шума"
+
+#: id:21387
+msgid "Fast"
+msgstr "Скорость"
+
+#: id:21388
+msgid "Quiet"
+msgstr "Тишина"
+
+#: id:21389
+msgid "Enable custom background"
+msgstr "Разрешить выбор фоновых изображений"
+
+#: id:21390
+msgid "Power management level"
+msgstr "Управление питанием"
+
+#: id:21391
+msgid "High power"
+msgstr "Полная мощность"
+
+#: id:21392
+msgid "Low power"
+msgstr "Пониженная мощность"
+
+#: id:21393
+msgid "High standby"
+msgstr "Полное ожидание"
+
+#: id:21394
+msgid "Low standby"
+msgstr "Пониженное ожидание"
+
+#: id:21395
+msgid "Unable to cache files bigger than 4GB"
+msgstr "Не удалось кэшировать файлы размером более 4 ГБ"
+
+#: id:21396
+msgid "Chapter"
+msgstr "Глава"
+
+#: id:21397
+msgid "High quality pixel shader v2"
+msgstr "Качественные пиксельные шейдеры в. 2"
+
+#: id:21398
+msgid "Enable playlist at startup"
+msgstr "Проигрывать плейлист при запуске"
+
+#: id:21399
+msgid "Use tween animations"
+msgstr "Анимация отскакивания панелей"
+
+#: id:21400
+msgid "contains"
+msgstr "содержит"
+
+#: id:21401
+msgid "does not contain"
+msgstr "не содержит"
+
+#: id:21402
+msgid "is"
+msgstr "равно"
+
+#: id:21403
+msgid "is not"
+msgstr "не"
+
+#: id:21404
+msgid "starts with"
+msgstr "начинается с"
+
+#: id:21405
+msgid "ends with"
+msgstr "заканчивается на"
+
+#: id:21406
+msgid "greater than"
+msgstr "больше, чем"
+
+#: id:21407
+msgid "less than"
+msgstr "меньше, чем"
+
+#: id:21408
+msgid "after"
+msgstr "после"
+
+#: id:21409
+msgid "before"
+msgstr "перед"
+
+#: id:21410
+msgid "in the last"
+msgstr "в конце"
+
+#: id:21411
+msgid "not in the last"
+msgstr "не в конце"
+
+#: id:21412
+msgid "Scrapers"
+msgstr "Инфоресурсы"
+
+#: id:21413
+msgid "Default movie scraper"
+msgstr "Инфоресурс для фильмов по умолчанию"
+
+#: id:21414
+msgid "Default tvshow scraper"
+msgstr "Инфоресурс для сериалов по умолчанию"
+
+#: id:21415
+msgid "Default music video scraper"
+msgstr "Инфоресурс для клипов по умолчанию"
+
+#: id:21416
+msgid "Enable fallback based on scraper language"
+msgstr "Использовать язык инфоресурса при недоступности основного"
+
+#: id:21417
+msgid "- Settings"
+msgstr "- Настройки"
+
+#: id:21418
+msgid "Multilingual"
+msgstr "Многоязычность"
+
+#: id:21419
+msgid "No scrapers present"
+msgstr "Инфоресурсы отсутствуют"
+
+#: id:21420
+msgid "Value to match"
+msgstr "Значение для поиска"
+
+#: id:21421
+msgid "Smart playlist rule"
+msgstr "Правило смарт-плейлиста"
+
+#: id:21422
+msgid "Match items where"
+msgstr "Выбрать объекты, в которых"
+
+#: id:21423
+msgid "New rule..."
+msgstr "Новое правило…"
+
+#: id:21424
+msgid "Items must match"
+msgstr "Объекты должны соответствовать"
+
+#: id:21425
+msgid "all of the rules"
+msgstr "всем правилам"
+
+#: id:21426
+msgid "one or more of the rules"
+msgstr "одному или более правилам"
+
+#: id:21427
+msgid "Limit to"
+msgstr "Ограничить до"
+
+#: id:21428
+msgid "No limit"
+msgstr "Без ограничений"
+
+#: id:21429
+msgid "Order by"
+msgstr "Упорядочить по"
+
+#: id:21430
+msgid "ascending"
+msgstr "возрастанию"
+
+#: id:21431
+msgid "descending"
+msgstr "убыванию"
+
+#: id:21432
+msgid "Edit smart playlist"
+msgstr "Изменить смарт-плейлист"
+
+#: id:21433
+msgid "Name of the playlist"
+msgstr "Название плейлиста"
+
+#: id:21434
+msgid "Find items where"
+msgstr "Найти объекты, у которых"
+
+#: id:21435
+msgid "Edit"
+msgstr "Изменить"
+
+#: id:21436
+msgid "%i items"
+msgstr "Объектов: %i"
+
+#: id:21437
+msgid "New smart playlist..."
+msgstr "Новый смарт-плейлист"
+
+#: id:21438
+msgid "%c Drive"
+msgstr "Диск %c"
+
+#: id:21439
+msgid "Edit party mode rules"
+msgstr "Изменить правила режима \"party\""
+
+#: id:21440
+msgid "Home folder"
+msgstr "Домашняя папка"
+
+#: id:21441
+msgid "Watched count"
+msgstr "Количество просмотров"
+
+#: id:21442
+msgid "Episode title"
+msgstr "Название серии"
+
+#: id:21443
+msgid "Video resolution"
+msgstr "Разрешение видео"
+
+#: id:21444
+msgid "Audio channels"
+msgstr "Каналов аудио"
+
+#: id:21445
+msgid "Video codec"
+msgstr "Кодек видео"
+
+#: id:21446
+msgid "Audio codec"
+msgstr "Кодек аудио"
+
+#: id:21447
+msgid "Audio language"
+msgstr "Язык аудио"
+
+#: id:21448
+msgid "Subtitle language"
+msgstr "Язык субтитров"
+
+#: id:21449
+msgid "Remote control sends keyboard presses"
+msgstr "Пульт ДУ посылает коды нажатий клавиш"
+
+#: id:21450
+msgid "- Edit"
+msgstr "- Изменить"
+
+#: id:21451
+msgid "Internet connection required."
+msgstr "Требуется подключение к Интернету."
+
+#: id:21452
+msgid "Get More..."
+msgstr "Еще…"
+
+#: id:21453
+msgid "Root filesystem"
+msgstr "Корневая ФС"
+
+#: id:21454
+msgid "Cache full"
+msgstr "Кэш заполнен"
+
+#: id:21455
+msgid "Cache filled before reaching required amount for continous playback"
+msgstr "Объем кэша недостаточен для непрерывного проигрывания"
+
+#: id:21460
+msgid "Subtitle location"
+msgstr "Расположение субтитров"
+
+#: id:21461
+msgid "Fixed"
+msgstr "Фиксированное"
+
+#: id:21462
+msgid "Bottom of video"
+msgstr "Снизу видео"
+
+#: id:21463
+msgid "Below video"
+msgstr "Под видео"
+
+#: id:21464
+msgid "Top of video"
+msgstr "Сверху видео"
+
+#: id:21465
+msgid "Above video"
+msgstr "Над видео"
+
+#: id:21800
+msgid "File name"
+msgstr "Имя файла"
+
+#: id:21801
+msgid "File path"
+msgstr "Путь к файлу"
+
+#: id:21802
+msgid "File size"
+msgstr "Размер файла"
+
+#: id:21803
+msgid "File date/time"
+msgstr "Дата и время файла"
+
+#: id:21804
+msgid "Slide index"
+msgstr "№ в слайдшоу"
+
+#: id:21805
+msgctxt "Auto context with id 21805"
+msgid "Resolution"
+msgstr "Разрешение"
+
+#: id:21806
+msgctxt "Auto context with id 21806"
+msgid "Comment"
+msgstr "Комментарий"
+
+#: id:21807
+msgid "Colour/B&W"
+msgstr "Цвет / Ч-Б"
+
+#: id:21808
+msgid "JPEG process"
+msgstr "Алгоритм JPEG"
+
+#: id:21820
+msgid "Date/Time"
+msgstr "Дата/время"
+
+#: id:21821
+msgid "Description"
+msgstr "Описание"
+
+#: id:21822
+msgid "Camera make"
+msgstr "Производитель"
+
+#: id:21823
+msgid "Camera model"
+msgstr "Модель фотоаппарата"
+
+#: id:21824
+msgid "EXIF comment"
+msgstr "Комментарий EXIF"
+
+#: id:21825
+msgid "Firmware"
+msgstr "Прошивка"
+
+#: id:21826
+msgid "Aperture"
+msgstr "Диафрагма"
+
+#: id:21827
+msgid "Focal length"
+msgstr "Фокусное расстояние"
+
+#: id:21828
+msgid "Focus distance"
+msgstr "Дистанция фокусировки"
+
+#: id:21829
+msgid "Exposure"
+msgstr "Экспозиция"
+
+#: id:21830
+msgid "Exposure time"
+msgstr "Время экспозиции"
+
+#: id:21831
+msgid "Exposure bias"
+msgstr "Сдвиг экспозиции"
+
+#: id:21832
+msgid "Exposure mode"
+msgstr "Режим экспозиции"
+
+#: id:21833
+msgid "Flash used"
+msgstr "Со вспышкой"
+
+#: id:21834
+msgid "White-balance"
+msgstr "Баланс белого"
+
+#: id:21835
+msgid "Light source"
+msgstr "Источник света"
+
+#: id:21836
+msgid "Metering mode"
+msgstr "Режим измерения"
+
+#: id:21837
+msgid "ISO"
+msgstr "Чувствительность ISO"
+
+#: id:21838
+msgid "Digital zoom"
+msgstr "Цифровое увеличение"
+
+#: id:21839
+msgid "CCD width"
+msgstr "Ширина CCD"
+
+#: id:21840
+msgid "GPS latitude"
+msgstr "Широта GPS"
+
+#: id:21841
+msgid "GPS longitude"
+msgstr "Долгота GPS"
+
+#: id:21842
+msgid "GPS altitude"
+msgstr "Высота GPS"
+
+#: id:21843
+msgid "Orientation"
+msgstr "Ориентация"
+
+#: id:21860
+msgid "Supplemental categories"
+msgstr "Дополнительные категории"
+
+#: id:21861
+msgid "Keywords"
+msgstr "Ключевые слова"
+
+#: id:21862
+msgid "Caption"
+msgstr "Заголовок"
+
+#: id:21863
+msgid "Author"
+msgstr "Автор"
+
+#: id:21864
+msgid "Headline"
+msgstr "Рубрика"
+
+#: id:21865
+msgid "Special instructions"
+msgstr "Специальные инструкции"
+
+#: id:21866
+msgid "Category"
+msgstr "Категория"
+
+#: id:21867
+msgid "Byline"
+msgstr "Подпись"
+
+#: id:21868
+msgid "Byline title"
+msgstr "Название подписи"
+
+#: id:21869
+msgid "Credit"
+msgstr "Создатель"
+
+#: id:21870
+msgid "Source"
+msgstr "Источник"
+
+#: id:21871
+msgid "Copyright notice"
+msgstr "Авторское право"
+
+#: id:21872
+msgid "Object name"
+msgstr "Название объекта"
+
+#: id:21873
+msgid "City"
+msgstr "Город"
+
+#: id:21874
+msgid "State"
+msgstr "Область"
+
+#: id:21875
+msgctxt "Auto context with id 21875"
+msgid "Country"
+msgstr "Страна"
+
+#: id:21876
+msgid "Original Tx Reference"
+msgstr "Оригинальный Tx Reference"
+
+#: id:21877
+msgid "Date created"
+msgstr "Дата создания"
+
+#: id:21878
+msgid "Copyright flag"
+msgstr "Признак авторского права"
+
+#: id:21879
+msgid "Country code"
+msgstr "Код страны"
+
+#: id:21880
+msgid "Reference service"
+msgstr "Справочная служба"
+
+#: id:21881
+msgid "Allow control of XBMC via UPnP"
+msgstr "Разрешить управление XBMC по UPnP"
+
+#: id:21882
+msgid "Attempt to skip introduction before DVD menu"
+msgstr "Пытаться пропустить вступление перед меню DVD"
+
+#: id:21883
+msgid "Saved music"
+msgstr "Оцифрованные аудио-CD"
+
+#: id:21884
+msgid "Query info for all artists"
+msgstr "Данные обо всех исполнителях"
+
+#: id:21885
+msgid "Downloading album information"
+msgstr "Загрузка данных об альбоме…"
+
+#: id:21886
+msgid "Downloading artist information"
+msgstr "Загрузка данных об исполнителе…"
+
+#: id:21887
+msgid "Biography"
+msgstr "Биография"
+
+#: id:21888
+msgid "Discography"
+msgstr "Дискография"
+
+#: id:21889
+msgid "Searching artist"
+msgstr "Поиск исполнителя…"
+
+#: id:21890
+msgid "Select artist"
+msgstr "Выберите исполнителя"
+
+#: id:21891
+msgctxt "Auto context with id 21891"
+msgid "Artist information"
+msgstr "Сведения об исполнителе"
+
+#: id:21892
+msgid "Instruments"
+msgstr "Инструменты"
+
+#: id:21893
+msgid "Born"
+msgstr "Рождение"
+
+#: id:21894
+msgid "Formed"
+msgstr "Формирование"
+
+#: id:21895
+msgid "Themes"
+msgstr "Темы"
+
+#: id:21896
+msgid "Disbanded"
+msgstr "Распад"
+
+#: id:21897
+msgid "Died"
+msgstr "Смерть"
+
+#: id:21898
+msgid "Years active"
+msgstr "Годы активности"
+
+#: id:21899
+msgid "Label"
+msgstr "Студия"
+
+#: id:21900
+msgid "Born/Formed"
+msgstr "Рождение/формирование"
+
+#: id:22000
+msgid "Update library on startup"
+msgstr "Обновлять медиатеку при запуске"
+
+#: id:22001
+msgid "Hide progress of library updates"
+msgstr "Скрывать состояние обновления медиатеки"
+
+#: id:22002
+msgid "- DNS suffix"
+msgstr "- Суффикс DNS"
+
+#: id:22003
+msgid "%2.3fs"
+msgstr "%2.3f с."
+
+#: id:22004
+msgid "Delayed by: %2.3fs"
+msgstr "Задержка на %2.3f с."
+
+#: id:22005
+msgid "Ahead by: %2.3fs"
+msgstr "Опережение на %2.3f с."
+
+#: id:22006
+msgid "Subtitle offset"
+msgstr "Смещение субтитров"
+
+#: id:22007
+msgid "OpenGL vendor:"
+msgstr "Производитель OpenGL:"
+
+#: id:22008
+msgid "OpenGL renderer:"
+msgstr "Обработчик OpenGL:"
+
+#: id:22009
+msgid "OpenGL version:"
+msgstr "Версия OpenGL:"
+
+#: id:22010
+msgid "GPU temperature:"
+msgstr "Температура GPU:"
+
+#: id:22011
+msgid "CPU temperature:"
+msgstr "Температура CPU:"
+
+#: id:22012
+msgid "Total memory"
+msgstr "Всего памяти"
+
+#: id:22013
+msgid "Profile data"
+msgstr "Данные профиля"
+
+#: id:22014
+msgid "Use dim if paused during video playback"
+msgstr "Затемнять при паузе во время просмотра видео"
+
+#: id:22015
+msgid "All recordings"
+msgstr "Все записи"
+
+#: id:22016
+msgid "By title"
+msgstr "По имени"
+
+#: id:22017
+msgid "By group"
+msgstr "По группе"
+
+#: id:22018
+msgid "Live channels"
+msgstr "Каналы прямой трансляции"
+
+#: id:22019
+msgid "Recordings by title"
+msgstr "Записи по имени"
+
+#: id:22020
+msgid "Guide"
+msgstr "Программа"
+
+#: id:22021
+msgid "Allowed error in aspect ratio to minimize black bars"
+msgstr "Допустимое искажение для уменьшения черных полос"
+
+#: id:22022
+msgid "Show video files in listings"
+msgstr "Показывать видеофайлы в списках"
+
+#: id:22023
+msgid "DirectX vendor:"
+msgstr "Производитель DirectX:"
+
+#: id:22024
+msgid "Direct3D version:"
+msgstr "Версия Direct3D:"
+
+#: id:22030
+msgctxt "Auto context with id 22030"
+msgid "Font"
+msgstr "Шрифт"
+
+#: id:22031
+msgctxt "Auto context with id 22031"
+msgid "- Size"
+msgstr "- Размер"
+
+#: id:22032
+msgctxt "Auto context with id 22032"
+msgid "- Colours"
+msgstr "- Цвета"
+
+#: id:22033
+msgid "- Charset"
+msgstr "- Кодировка"
+
+#: id:22034
+msgid "Export karaoke titles as HTML"
+msgstr "Экспорт в формате HTML"
+
+#: id:22035
+msgid "Export karaoke titles as CSV"
+msgstr "Экспорт в формате CSV"
+
+#: id:22036
+msgid "Import karaoke titles..."
+msgstr "Импортировать текст караоке…"
+
+#: id:22037
+msgid "Show song selector automatically"
+msgstr "Показывать выбор песни автоматически"
+
+#: id:22038
+msgid "Export karaoke titles..."
+msgstr "Экспортировать текст караоке…"
+
+#: id:22039
+msgid "Enter song number"
+msgstr "Введите номер песни"
+
+#: id:22040
+msgid "white/green"
+msgstr "белый/зеленый"
+
+#: id:22041
+msgid "white/red"
+msgstr "белый/красный"
+
+#: id:22042
+msgid "white/blue"
+msgstr "белый/синий"
+
+#: id:22043
+msgid "black/white"
+msgstr "черный/белый"
+
+#: id:22079
+msgid "Default select action"
+msgstr "Действие по умолчанию при выборе"
+
+#: id:22080
+msgid "Choose"
+msgstr "Выбрать"
+
+#: id:22081
+msgid "Show Information"
+msgstr "Показать сведения"
+
+#: id:22082
+msgid "More..."
+msgstr "Еще…"
+
+#: id:22083
+msgid "Play all"
+msgstr "Играть все"
+
+#: id:23049
+msgid "Teletext not available"
+msgstr "Телетекст недоступен"
+
+#: id:23050
+msgid "Activate Teletext"
+msgstr "Активировать телетекст"
+
+#: id:23051
+msgid "Part %i"
+msgstr "Часть %i"
+
+#: id:23052
+msgid "Buffering %i bytes"
+msgstr "Буферизация: %i байт"
+
+#: id:23053
+msgid "Stopping"
+msgstr "Остановка…"
+
+#: id:23054
+msgid "Running"
+msgstr "Запуск…"
+
+#: id:23100
+msgid "External Player Active"
+msgstr "Активирован внешний проигрыватель"
+
+#: id:23101
+msgid "Click OK to terminate the player"
+msgstr "Нажмите ОК, чтобы закрыть проигрыватель"
+
+#: id:23104
+msgid "Click OK when playback has ended"
+msgstr "Нажмите ОК, когда проигрывание завершится"
+
+#: id:24000
+msgid "Add-on"
+msgstr "Дополнение"
+
+#: id:24001
+msgid "Add-ons"
+msgstr "Дополнения"
+
+#: id:24002
+msgid "Add-on options"
+msgstr "Параметры дополнения"
+
+#: id:24003
+msgid "Add-on Information"
+msgstr "Сведения о дополнении"
+
+#: id:24005
+msgctxt "Auto context with id 24005"
+msgid "Media sources"
+msgstr "Источники данных"
+
+#: id:24007
+msgctxt "Auto context with id 24007"
+msgid "Movie information"
+msgstr "Сведения о фильмах"
+
+#: id:24008
+msgctxt "Auto context with id 24008"
+msgid "Screensaver"
+msgstr "Заставка"
+
+#: id:24009
+msgid "Script"
+msgstr "Скрипт"
+
+#: id:24010
+msgctxt "Auto context with id 24010"
+msgid "Visualization"
+msgstr "Визуализация"
+
+#: id:24011
+msgid "Add-on repository"
+msgstr "Репозиторий дополнений"
+
+#: id:24012
+msgctxt "Auto context with id 24012"
+msgid "Subtitles"
+msgstr "Субтитры"
+
+#: id:24013
+msgid "Lyrics"
+msgstr "Тексты песен"
+
+#: id:24014
+msgid "TV information"
+msgstr "Сведения о сериалах"
+
+#: id:24015
+msgctxt "Auto context with id 24015"
+msgid "Music video information"
+msgstr "Сведения о муз. клипах"
+
+#: id:24016
+msgctxt "Auto context with id 24016"
+msgid "Album information"
+msgstr "Сведения об альбомах"
+
+#: id:24017
+msgctxt "Auto context with id 24017"
+msgid "Artist information"
+msgstr "Сведения об исполнителях"
+
+#: id:24018
+msgctxt "Auto context with id 24018"
+msgid "Services"
+msgstr "Службы"
+
+#: id:24020
+msgid "Configure"
+msgstr "Настроить"
+
+#: id:24021
+msgctxt "Auto context with id 24021"
+msgid "Disable"
+msgstr "Отключить"
+
+#: id:24022
+msgid "Enable"
+msgstr "Включить"
+
+#: id:24023
+msgid "Add-on disabled"
+msgstr "Дополнение отключено"
+
+#: id:24027
+msgctxt "Auto context with id 24027"
+msgid "Weather"
+msgstr "Погода"
+
+#: id:24028
+msgid "Weather.com (standard)"
+msgstr "Weather.com (стандартно)"
+
+#: id:24030
+msgid "This Add-on can not be configured"
+msgstr "Невозможно настроить данное дополнение"
+
+#: id:24031
+msgid "Error loading settings"
+msgstr "Ошибка при загрузке настроек"
+
+#: id:24032
+msgid "All Add-ons"
+msgstr "Все дополнения"
+
+#: id:24033
+msgid "Get Add-ons"
+msgstr "Загрузить дополнения"
+
+#: id:24034
+msgid "Check for updates"
+msgstr "Проверить обновления"
+
+#: id:24035
+msgid "Force refresh"
+msgstr "Принудительное обновление"
+
+#: id:24036
+msgid "Change log"
+msgstr "Список изменений"
+
+#: id:24037
+msgid "Uninstall"
+msgstr "Удалить"
+
+#: id:24038
+msgid "Install"
+msgstr "Установить"
+
+#: id:24039
+msgid "Disabled Add-ons"
+msgstr "Отключенные дополнения"
+
+#: id:24040
+msgid "(Clear the current setting)"
+msgstr "(Очистить текущие настройки)"
+
+#: id:24041
+msgid "Install from zip file"
+msgstr "Установить из файла ZIP"
+
+#: id:24042
+msgid "Downloading %i%%"
+msgstr "Загружается: %i%%…"
+
+#: id:24043
+msgid "Available Updates"
+msgstr "Доступные обновления"
+
+#: id:24044
+msgid "Dependencies not met"
+msgstr "Отсутствуют нужные компоненты"
+
+#: id:24045
+msgid "Add-on does not have the correct structure"
+msgstr "Неправильная структура дополнения"
+
+#: id:24046
+msgid "%s is used by the following installed add-on(s)"
+msgstr "%s используется установленными дополнениями"
+
+#: id:24047
+msgid "This add-on cannot be uninstalled"
+msgstr "Невозможно удалить дополнение"
+
+#: id:24048
+msgid "Rollback"
+msgstr "Вернуть"
+
+#: id:24050
+msgid "Available Add-ons"
+msgstr "Доступные дополнения"
+
+#: id:24051
+msgid "Version:"
+msgstr "Версия:"
+
+#: id:24052
+msgid "Disclaimer"
+msgstr "Соглашение"
+
+#: id:24053
+msgid "License:"
+msgstr "Лицензия:"
+
+#: id:24054
+msgid "Changelog"
+msgstr "Список изменений"
+
+#: id:24059
+msgid "Would you like to enable this Add-on?"
+msgstr "Включить это дополнение?"
+
+#: id:24060
+msgid "Would you like to disable this Add-on?"
+msgstr "Отключить это дополнение?"
+
+#: id:24061
+msgid "Add-on update available!"
+msgstr "Доступны обновления для дополнений."
+
+#: id:24062
+msgid "Enabled Add-ons"
+msgstr "Включенные дополнения"
+
+#: id:24063
+msgid "Auto update"
+msgstr "Автообновление"
+
+#: id:24064
+msgid "Add-on enabled"
+msgstr "Дополнение включено"
+
+#: id:24065
+msgid "Add-on updated"
+msgstr "Дополнение обновлено"
+
+#: id:24066
+msgid "Cancel Add-on download?"
+msgstr "Отменить загрузку дополнений?"
+
+#: id:24067
+msgid "Currently downloading Add-ons"
+msgstr "Загружаемые дополнения"
+
+#: id:24068
+msgid "Update available"
+msgstr "Доступно обновление"
+
+#: id:24069
+msgid "Update"
+msgstr "Обновить"
+
+#: id:24070
+msgid "Add-on could not be loaded."
+msgstr "Не удалось загрузить дополнение"
+
+#: id:24071
+msgid "An unknown error has occurred."
+msgstr "Неизвестная ошибка."
+
+#: id:24072
+msgid "Settings required"
+msgstr "Требуется настройка"
+
+#: id:24073
+msgid "Could not connect"
+msgstr "Не удалось подключиться"
+
+#: id:24074
+msgid "Needs to restart"
+msgstr "Требуется перезапуск"
+
+#: id:24075
+msgctxt "Auto context with id 24075"
+msgid "Disable"
+msgstr "Отключить"
+
+#: id:24076
+msgid "Add-on Required"
+msgstr "Требуемое дополнение"
+
+#: id:24080
+msgid "Try to reconnect?"
+msgstr "Подключиться повторно?"
+
+#: id:24089
+msgid "Add-on restarts"
+msgstr "Дополнение перезапускается"
+
+#: id:24090
+msgid "Lock Add-on manager"
+msgstr "Заблокировать менеджер дополнений"
+
+#: id:24094
+msgid "(current)"
+msgstr "(текущ.)"
+
+#: id:24095
+msgid "(blacklisted)"
+msgstr "(заблокирован.)"
+
+#: id:24096
+msgid "Add-on has been marked as broken in repository."
+msgstr "Дополнение помечено в репозитории как испорченное."
+
+#: id:24097
+msgid "Would you like to disable it on your system?"
+msgstr "Отключить его в системе?"
+
+#: id:24098
+msgid "Broken"
+msgstr "Испорчено"
+
+#: id:24099
+msgid "Would you like to switch to this skin?"
+msgstr "Переключиться на эту обложку?"
+
+#: id:24100
+msgid "To use this feature you must download an Add-on:"
+msgstr "Для данной функции требуется дополнение:"
+
+#: id:24101
+msgid "Would you like to download this Add-on?"
+msgstr "Загрузить это дополнение?"
+
+#: id:25000
+msgid "Notifications"
+msgstr "Уведомления"
+
+#: id:29800
+msgid "Library Mode"
+msgstr "Режим медиатеки"
+
+#: id:29801
+msgid "QWERTY keyboard"
+msgstr "Клавиатура QWERTY"
+
+#: id:29802
+msgid "Passthrough Audio in use"
+msgstr "Прямой вывод звука"
+
+#: id:33001
+msgid "Trailer quality"
+msgstr "Качество трейлера"
+
+#: id:33002
+msgid "Stream"
+msgstr "Поток"
+
+#: id:33003
+msgid "Download"
+msgstr "Загрузить"
+
+#: id:33004
+msgid "Download & play"
+msgstr "Загрузить и проиграть"
+
+#: id:33005
+msgid "Download & save"
+msgstr "Загрузить и сохранить"
+
+#: id:33006
+msgid "Today"
+msgstr "Сегодня"
+
+#: id:33007
+msgid "Tomorrow"
+msgstr "Завтра"
+
+#: id:33008
+msgid "Saving"
+msgstr "Сохранение…"
+
+#: id:33009
+msgid "Copying"
+msgstr "Копирование…"
+
+#: id:33010
+msgid "Set download directory"
+msgstr "Выбрать папку для загрузки"
+
+#: id:33011
+msgid "Search duration"
+msgstr "Длительность поиска"
+
+#: id:33012
+msgid "Short"
+msgstr "Короткая"
+
+#: id:33013
+msgid "Long"
+msgstr "Длинная"
+
+#: id:33014
+msgid "Use DVD player instead of regular player"
+msgstr "Использовать проигрыватель DVD вместо обычного"
+
+#: id:33015
+msgid "Ask for download before playing video"
+msgstr "Предлагать загрузку видео перед проигрыванием"
+
+#: id:33016
+msgid "Clips"
+msgstr "Клипы"
+
+#: id:33017
+msgid "Restart plugin to enable"
+msgstr "Перезапустите дополнение, чтобы включить его"
+
+#: id:33018
+msgid "Tonight"
+msgstr "Сегодня вечером"
+
+#: id:33019
+msgid "Tomorrow Night"
+msgstr "Завтра вечером"
+
+#: id:33020
+msgid "Condition"
+msgstr "Условия"
+
+#: id:33021
+msgid "Precipitation"
+msgstr "Осадки"
+
+#: id:33022
+msgid "Precip"
+msgstr "Осадки"
+
+#: id:33023
+msgid "Humid"
+msgstr "Влажность"
+
+#: id:33024
+msgid "Feels"
+msgstr "Ощущается"
+
+#: id:33025
+msgid "Observed"
+msgstr "Наблюдается"
+
+#: id:33026
+msgid "Departure from normal"
+msgstr "Отклонение от нормы"
+
+#: id:33027
+msgid "Sunrise"
+msgstr "Восход"
+
+#: id:33028
+msgid "Sunset"
+msgstr "Закат"
+
+#: id:33029
+msgid "Details"
+msgstr "Сведения"
+
+#: id:33030
+msgid "Outlook"
+msgstr "Наблюдение"
+
+#: id:33031
+msgid "Coverflow"
+msgstr "Карусель постеров"
+
+#: id:33032
+msgid "Translate text"
+msgstr "Перевести текст"
+
+#: id:33033
+msgid "Map list %s category"
+msgstr "Категория списка карт: %s"
+
+#: id:33034
+msgid "36 Hour"
+msgstr "36 часов"
+
+#: id:33035
+msgid "Maps"
+msgstr "Карты"
+
+#: id:33036
+msgid "Hourly"
+msgstr "Ежечасно"
+
+#: id:33037
+msgid "Weekend"
+msgstr "Выходные"
+
+#: id:33038
+msgid "%s day"
+msgstr "%s дн."
+
+#: id:33049
+msgid "Alert"
+msgstr "Предупреждение"
+
+#: id:33050
+msgid "Alerts"
+msgstr "Предупреждения"
+
+#: id:33051
+msgid "Choose Your"
+msgstr "Выберите"
+
+#: id:33052
+msgid "Check"
+msgstr "Проверить"
+
+#: id:33053
+msgctxt "Auto context with id 33053"
+msgid "Configure the"
+msgstr "Настройте"
+
+#: id:33054
+msgid "Seasons"
+msgstr "Сезоны"
+
+#: id:33055
+msgid "Use your"
+msgstr "Используйте"
+
+#: id:33056
+msgid "Watch your"
+msgstr "Смотрите"
+
+#: id:33057
+msgid "Listen to"
+msgstr "Слушайте"
+
+#: id:33058
+msgid "View your"
+msgstr "Просматривайте"
+
+#: id:33059
+msgctxt "Auto context with id 33059"
+msgid "Configure the"
+msgstr "Настройте"
+
+#: id:33060
+msgid "Power"
+msgstr "Вкл./выкл."
+
+#: id:33061
+msgid "Menu"
+msgstr "Меню"
+
+#: id:33062
+msgid "Play the"
+msgstr "Воспроизводите"
+
+#: id:33063
+msgid "Options"
+msgstr "Параметры"
+
+#: id:33065
+msgid "Editor"
+msgstr "Редактор"
+
+#: id:33066
+msgid "About your"
+msgstr "Сведения о"
+
+#: id:33067
+msgid "Star rating"
+msgstr "Рейтинг"
+
+#: id:33068
+msgid "Background"
+msgstr "Фон"
+
+#: id:33069
+msgid "Backgrounds"
+msgstr "Варианты фона"
+
+#: id:33070
+msgid "Custom background"
+msgstr "Свой фон"
+
+#: id:33071
+msgid "Custom backgrounds"
+msgstr "Свои фоны"
+
+#: id:33072
+msgid "View Readme"
+msgstr "Просмотреть информацию"
+
+#: id:33073
+msgid "View Changelog"
+msgstr "Просмотреть список изменений"
+
+#: id:33074
+msgid "This version of %s requires an"
+msgstr "Для данной версии %s требуется"
+
+#: id:33075
+msgid "XBMC revision of %s or greater to run."
+msgstr "версия XBMC %s или новее."
+
+#: id:33076
+msgid "Please update XBMC."
+msgstr "Обновите XBMC."
+
+#: id:33077
+msgid "No data found!"
+msgstr "Данных не найдено."
+
+#: id:33078
+msgid "Next page"
+msgstr "Следующая страница"
+
+#: id:33079
+msgid "Love"
+msgstr "Нравится"
+
+#: id:33080
+msgid "Hate"
+msgstr "Не нравится"
+
+#: id:33081
+msgid "This file is stacked, select the part you want to play from."
+msgstr "Составной файл; выберите часть для проигрывания."
+
+#: id:33082
+msgid "Path to script"
+msgstr "Путь к скрипту"
+
+#: id:33083
+msgid "Enable custom script button"
+msgstr "Включить кнопку выбранного скрипта"
+
+#: id:33100
+msgid "Failed to start"
+msgstr "Не удалось запустить"
+
+#: id:33101
+msgid "Webserver"
+msgstr "Веб-сервер"
+
+#: id:33102
+msgid "Event Server"
+msgstr "Сервер событий"
+
+#: id:33103
+msgid "Remote communication server"
+msgstr "Сервер удаленного доступа"
+
+#: id:33200
+msgid "Detected New Connection"
+msgstr "Обнаружено новое подключение"
+
+#: id:34000
+msgid "Lame"
+msgstr "Lame"
+
+#: id:34001
+msgid "Vorbis"
+msgstr "Vorbis"
+
+#: id:34002
+msgid "Wav"
+msgstr "Wav"
+
+#: id:34003
+msgid "DXVA2"
+msgstr "DXVA2"
+
+#: id:34004
+msgid "VAAPI"
+msgstr "VAAPI"
+
+#: id:34005
+msgid "Flac"
+msgstr "Flac"
+
+#: id:34100
+msgid "Speaker Configuration"
+msgstr "Конфигурация динамиков"
+
+#: id:34101
+msgid "2.0"
+msgstr "2.0"
+
+#: id:34102
+msgid "2.1"
+msgstr "2.1"
+
+#: id:34103
+msgid "3.0"
+msgstr "3.0"
+
+#: id:34104
+msgid "3.1"
+msgstr "3.1"
+
+#: id:34105
+msgid "4.0"
+msgstr "4.0"
+
+#: id:34106
+msgid "4.1"
+msgstr "4.1"
+
+#: id:34107
+msgid "5.0"
+msgstr "5.0"
+
+#: id:34108
+msgid "5.1"
+msgstr "5.1"
+
+#: id:34109
+msgid "7.0"
+msgstr "7.0"
+
+#: id:34110
+msgid "7.1"
+msgstr "7.1"
+
+#: id:34201
+msgid "Can't find a next item to play"
+msgstr "Не удается найти следующий файл"
+
+#: id:34202
+msgid "Can't find a previous item to play"
+msgstr "Не удается найти предыдущий файл"
+
+#: id:34300
+msgid "Failed to start zeroconf"
+msgstr "Не удалось запустить zeroconf"
+
+#: id:34301
+msgid "Is Apple's Bonjour Service installed? See log for more info."
+msgstr "Проверьте, установлена ли служба Apple Bonjour. См. журнал."
+
+#: id:34400
+msgid "Video Rendering"
+msgstr "Обработчик видео"
+
+#: id:34401
+msgid "Failed to init video filters/scalers, falling back to bilinear scaling"
+msgstr "Не удалось активировать фильтры видео. Используется масштабирование bilinear."
+
+#: id:34402
+msgid "Failed to initialize audio device"
+msgstr "Не удалось активировать аудиоустройство"
+
+#: id:34403
+msgid "Check your audiosettings"
+msgstr "Проверьте настройки аудио"
+
+#: id:34404
+msgid "Use gestures for navigation:"
+msgstr ""
+
+#: id:34405
+msgid "1 finger swipe left,right,up,down for cursors"
+msgstr ""
+
+#: id:34406
+msgid "2 finger swipe left for backspace"
+msgstr ""
+
+#: id:34407
+msgid "1 finger single tap for enter"
+msgstr ""
+
+#: id:34408
+msgid "2 finger single tap for contextmenu"
+msgstr ""
+
+#: id:35000
+msgid "Peripherals"
+msgstr "Периферия"
+
+#: id:35001
+msgid "Generic HID device"
+msgstr "Типовое HID-устройство"
+
+#: id:35002
+msgid "Generic network adapter"
+msgstr "Типовой сетевой адаптер"
+
+#: id:35003
+msgid "Generic disk"
+msgstr "Типовой диск"
+
+#: id:35004
+msgid "There are no settings available\nfor this peripheral."
+msgstr "Для этой периферии\nнет настроек."
+
+#: id:35005
+msgid "New device configured"
+msgstr "Настроено новое устройство"
+
+#: id:35006
+msgid "Device removed"
+msgstr "Устройство удалено"
+
+#: id:35007
+msgid "Keymap to use for this device"
+msgstr "Раскладка для этого устройства"
+
+#: id:35008
+msgid "Keymap enabled"
+msgstr "Раскладка включена"
+
+#: id:35009
+msgid "Do not use the custom keymap for this device"
+msgstr ""
+
+#: id:35500
+msgid "Location"
+msgstr "Расположение"
+
+#: id:35501
+msgid "Class"
+msgstr "Класс"
+
+#: id:35502
+msgctxt "Auto context with id 35502"
+msgid "Name"
+msgstr "Название"
+
+#: id:35503
+msgid "Vendor"
+msgstr "Производитель"
+
+#: id:35504
+msgid "Product ID"
+msgstr "ID продукта"
+
+#: id:36000
+msgid "Pulse-Eight CEC adapter"
+msgstr "Адаптер Pulse-Eight CEC"
+
+#: id:36001
+msgid "Pulse-Eight Nyxboard"
+msgstr "Pulse-Eight Nyxboard"
+
+#: id:36002
+msgid "Switch to keyboard side command"
+msgstr "Включить дополнительные команды клавиатуры"
+
+#: id:36003
+msgid "Switch to remote side command"
+msgstr "Включить дополнительные команды ДУ"
+
+#: id:36004
+msgid "Press \"user\" button command"
+msgstr "Нажмите настраиваемую кнопку \"user\""
+
+#: id:36005
+msgid "Enable switch side commands"
+msgstr "Включить дополнительные команды"
+
+#: id:36006
+msgid "Could not open the adapter"
+msgstr "Не удалось открыть адаптер"
+
+#: id:36007
+msgid "Devices to power on when starting XBMC"
+msgstr "Включать ТВ при старте XBMC"
+
+#: id:36008
+msgid "Devices to power off when stopping XBMC"
+msgstr "Выключать устройства при выходе из XBMC"
+
+#: id:36009
+msgid "Put devices in standby mode when activating screensaver"
+msgstr "Переводить устройства в спящий режим при активной заставке"
+
+#: id:36011
+msgid "Could not detect the CEC port. Set it up manually."
+msgstr "Не удалось обнаружить порт CEC. Настройте его вручную."
+
+#: id:36012
+msgid "Could not initialise the CEC adapter. Check your settings."
+msgstr "Не удалось обнаружить адаптер CEC."
+
+#: id:36013
+msgid "Unsupported libCEC interface version. %d is greater than the version XBMC supports (%d)"
+msgstr "Неподдерживаемая версия интерфейса libcec. %d выше, чем версия, поддерживаемая XBMC (%d)"
+
+#: id:36014
+msgid "Put this PC in standby mode when the TV is switched off"
+msgstr "Переводить этот ПК в режим ожидания при выключении ТВ"
+
+#: id:36015
+msgid "HDMI port number"
+msgstr "Номер порта HDMI"
+
+#: id:36016
+msgctxt "Auto context with id 36016"
+msgid "Connected"
+msgstr "Подключено"
+
+#: id:36017
+msgid "Adapter found, but libCEC is not available"
+msgstr "Адаптер найден, но libcec недоступен"
+
+#: id:36018
+msgid "Use the TV's language setting"
+msgstr "Использовать языковые настройки ТВ"
+
+#: id:36019
+msgid "Connected to HDMI device"
+msgstr ""
+
+#: id:36020
+msgid "Make XBMC the active source when starting"
+msgstr ""
+
+#: id:36021
+msgid "Physical address (overrules HDMI port)"
+msgstr ""
+
+#: id:36022
+msgid "COM port (leave empty unless needed)"
+msgstr ""
+
+#: id:36023
+msgid "Configuration updated"
+msgstr ""
+
+#: id:36024
+msgid "Failed to set the new configuration. Please check your settings."
+msgstr ""
+
+#: id:36025
+msgid "Send 'inactive source' command when stopping XBMC"
+msgstr ""
+

--- a/language/Serbian (Cyrillic)/strings.po
+++ b/language/Serbian (Cyrillic)/strings.po
@@ -1,0 +1,9093 @@
+# Converted from xbmc strings.xml with xbmc-xml2po (by Team-XBMC)
+msgid ""
+msgstr ""
+"Project-Id-Version: xbmc.core-FRODO_GIT3ed1604ad7\n"
+"Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
+"POT-Creation-Date: 2012-04-09 18:00+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE\n"
+"Language: sr_RS\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: id:0
+msgctxt "Auto context with id 0"
+msgid "Programs"
+msgstr "Програми"
+
+#: id:1
+msgctxt "Auto context with id 1"
+msgid "Pictures"
+msgstr "Слике"
+
+#: id:2
+msgctxt "Auto context with id 2"
+msgid "Music"
+msgstr "Музика"
+
+#: id:3
+msgctxt "Auto context with id 3"
+msgid "Videos"
+msgstr "Филмови"
+
+#: id:4
+msgid "TV-Guide"
+msgstr "ТВ водич"
+
+#: id:5
+msgctxt "Auto context with id 5"
+msgid "Settings"
+msgstr "Поставке"
+
+#: id:6
+msgid "XBMC SVN"
+msgstr "XBMC SVN"
+
+#: id:7
+msgctxt "Auto context with id 7"
+msgid "File manager"
+msgstr "Упр. датотекама"
+
+#: id:8
+msgctxt "Auto context with id 8"
+msgid "Weather"
+msgstr "Време"
+
+#: id:9
+msgid "xbmc media center"
+msgstr "xbmc медија центар"
+
+#: id:11
+msgid "Monday"
+msgstr "Понедељак"
+
+#: id:12
+msgid "Tuesday"
+msgstr "Уторак"
+
+#: id:13
+msgid "Wednesday"
+msgstr "Среда"
+
+#: id:14
+msgid "Thursday"
+msgstr "Четвртак"
+
+#: id:15
+msgid "Friday"
+msgstr "Петак"
+
+#: id:16
+msgid "Saturday"
+msgstr "Субота"
+
+#: id:17
+msgid "Sunday"
+msgstr "Недеља"
+
+#: id:21
+msgid "January"
+msgstr "јануар"
+
+#: id:22
+msgid "February"
+msgstr "фебруар"
+
+#: id:23
+msgid "March"
+msgstr "март"
+
+#: id:24
+msgid "April"
+msgstr "април"
+
+#: id:25
+msgctxt "Auto context with id 25"
+msgid "May"
+msgstr "мај"
+
+#: id:26
+msgid "June"
+msgstr "јун"
+
+#: id:27
+msgid "July"
+msgstr "јул"
+
+#: id:28
+msgid "August"
+msgstr "август"
+
+#: id:29
+msgid "September"
+msgstr "септембар"
+
+#: id:30
+msgid "October"
+msgstr "октобар"
+
+#: id:31
+msgid "November"
+msgstr "новембар"
+
+#: id:32
+msgid "December"
+msgstr "децембар"
+
+#: id:41
+msgid "Mon"
+msgstr "пон"
+
+#: id:42
+msgid "Tue"
+msgstr "уто"
+
+#: id:43
+msgid "Wed"
+msgstr "сре"
+
+#: id:44
+msgid "Thu"
+msgstr "чет"
+
+#: id:45
+msgid "Fri"
+msgstr "пет"
+
+#: id:46
+msgid "Sat"
+msgstr "суб"
+
+#: id:47
+msgctxt "Auto context with id 47"
+msgid "Sun"
+msgstr "нед"
+
+#: id:51
+msgid "Jan"
+msgstr "јан"
+
+#: id:52
+msgid "Feb"
+msgstr "феб"
+
+#: id:53
+msgid "Mar"
+msgstr "мар"
+
+#: id:54
+msgid "Apr"
+msgstr "апр"
+
+#: id:55
+msgctxt "Auto context with id 55"
+msgid "May"
+msgstr "мај"
+
+#: id:56
+msgid "Jun"
+msgstr "јун"
+
+#: id:57
+msgid "Jul"
+msgstr "јул"
+
+#: id:58
+msgid "Aug"
+msgstr "авг"
+
+#: id:59
+msgid "Sep"
+msgstr "сеп"
+
+#: id:60
+msgid "Oct"
+msgstr "окт"
+
+#: id:61
+msgid "Nov"
+msgstr "нов"
+
+#: id:62
+msgid "Dec"
+msgstr "дец"
+
+#: id:71
+msgid "N"
+msgstr ""
+
+#: id:72
+msgid "NNE"
+msgstr ""
+
+#: id:73
+msgid "NE"
+msgstr ""
+
+#: id:74
+msgid "ENE"
+msgstr ""
+
+#: id:75
+msgid "E"
+msgstr ""
+
+#: id:76
+msgid "ESE"
+msgstr ""
+
+#: id:77
+msgid "SE"
+msgstr ""
+
+#: id:78
+msgid "SSE"
+msgstr ""
+
+#: id:79
+msgid "S"
+msgstr ""
+
+#: id:80
+msgid "SSW"
+msgstr ""
+
+#: id:81
+msgid "SW"
+msgstr ""
+
+#: id:82
+msgid "WSW"
+msgstr ""
+
+#: id:83
+msgid "W"
+msgstr ""
+
+#: id:84
+msgid "WNW"
+msgstr ""
+
+#: id:85
+msgid "NW"
+msgstr ""
+
+#: id:86
+msgid "NNW"
+msgstr ""
+
+#: id:87
+msgid "VAR"
+msgstr ""
+
+#: id:98
+msgid "View: Auto"
+msgstr "Приказ: Аутом."
+
+#: id:99
+msgid "View: Auto big"
+msgstr "Приказ: Аутом. велико"
+
+#: id:100
+msgid "View: Icons"
+msgstr "Приказ: Иконе"
+
+#: id:101
+msgid "View: List"
+msgstr "Приказ: Списак"
+
+#: id:102
+msgctxt "Auto context with id 102"
+msgid "Scan"
+msgstr "Анализирај"
+
+#: id:103
+msgctxt "Auto context with id 103"
+msgid "Sort by: Name"
+msgstr "Сложи по: Имену"
+
+#: id:104
+msgid "Sort by: Date"
+msgstr "Сложи по: Датуму"
+
+#: id:105
+msgid "Sort by: Size"
+msgstr "Сложи по: Вели."
+
+#: id:106
+msgid "No"
+msgstr "Не"
+
+#: id:107
+msgid "Yes"
+msgstr "Да"
+
+#: id:108
+msgctxt "Auto context with id 108"
+msgid "Slideshow"
+msgstr "Репрод. слајдова"
+
+#: id:109
+msgid "Create thumbs"
+msgstr "Направи омоте"
+
+#: id:110
+msgid "Create thumbnails"
+msgstr "Направи сличице"
+
+#: id:111
+msgctxt "Auto context with id 111"
+msgid "Shortcuts"
+msgstr "Пречице"
+
+#: id:112
+msgid "Paused"
+msgstr "Паузирано"
+
+#: id:113
+msgid "Update failed"
+msgstr ""
+
+#: id:114
+msgid "Installation failed"
+msgstr ""
+
+#: id:115
+msgid "Copy"
+msgstr "Копирај"
+
+#: id:116
+msgid "Move"
+msgstr "Премести"
+
+#: id:117
+msgid "Delete"
+msgstr "Избриши"
+
+#: id:118
+msgid "Rename"
+msgstr "Преименуј"
+
+#: id:119
+msgid "New folder"
+msgstr "Нова фасцикла"
+
+#: id:120
+msgid "Confirm file copy"
+msgstr "Потврдите копирање"
+
+#: id:121
+msgid "Confirm file move"
+msgstr "Потврдите премештање"
+
+#: id:122
+msgid "Confirm file delete?"
+msgstr "Потврђујете ли брисање?"
+
+#: id:123
+msgid "Copy these files?"
+msgstr "Копирање ових датотека?"
+
+#: id:124
+msgid "Move these files?"
+msgstr "Премештање ових датотека?"
+
+#: id:125
+msgid "Delete these files? - Deleting files cannot be undone!"
+msgstr "Брисање ових датотека? - Након брисања, датотеке није могуће повратити!"
+
+#: id:126
+msgid "Status"
+msgstr "Стање"
+
+#: id:127
+msgid "Objects"
+msgstr "Објеката"
+
+#: id:128
+msgctxt "Auto context with id 128"
+msgid "General"
+msgstr "Опште"
+
+#: id:129
+msgctxt "Auto context with id 129"
+msgid "Slideshow"
+msgstr "Пројекција слајдова"
+
+#: id:130
+msgctxt "Auto context with id 130"
+msgid "System info"
+msgstr "Подаци о систему"
+
+#: id:131
+msgid "Display"
+msgstr "Приказ"
+
+#: id:132
+msgid "Albums"
+msgstr "Албуми"
+
+#: id:133
+msgid "Artists"
+msgstr "Извођачи"
+
+#: id:134
+msgid "Songs"
+msgstr "Нумере"
+
+#: id:135
+msgid "Genres"
+msgstr "Жанрови"
+
+#: id:136
+msgid "Playlists"
+msgstr "Спискови за репро."
+
+#: id:137
+msgid "Search"
+msgstr "Претражи"
+
+#: id:138
+msgid "System Information"
+msgstr "Подаци о систему"
+
+#: id:139
+msgid "Temperatures:"
+msgstr "Температуре:"
+
+#: id:140
+msgid "CPU:"
+msgstr "Централног процесора:"
+
+#: id:141
+msgid "GPU:"
+msgstr "Графичког процесора:"
+
+#: id:142
+msgid "Time:"
+msgstr "Време:"
+
+#: id:143
+msgid "Current:"
+msgstr "Тренутно:"
+
+#: id:144
+msgid "Build:"
+msgstr "Издање:"
+
+#: id:145
+msgid "Network:"
+msgstr "Мрежа:"
+
+#: id:146
+msgid "Type:"
+msgstr "Тип:"
+
+#: id:147
+msgid "Static"
+msgstr "Статички"
+
+#: id:148
+msgid "DHCP"
+msgstr "DHCP"
+
+#: id:149
+msgid "MAC address"
+msgstr "MAC адреса"
+
+#: id:150
+msgctxt "Auto context with id 150"
+msgid "IP address"
+msgstr "IP адреса"
+
+#: id:151
+msgid "Link:"
+msgstr "Веза:"
+
+#: id:152
+msgid "Half duplex"
+msgstr "Полу дуплекс"
+
+#: id:153
+msgid "Full duplex"
+msgstr "Пуни дуплекс"
+
+#: id:154
+msgctxt "Auto context with id 154"
+msgid "Storage"
+msgstr "Складишта"
+
+#: id:155
+msgid "Drive"
+msgstr "Уређај"
+
+#: id:156
+msgctxt "Auto context with id 156"
+msgid "Free"
+msgstr "Слободно"
+
+#: id:157
+msgctxt "Auto context with id 157"
+msgid "Video"
+msgstr "Видео"
+
+#: id:158
+msgid "Free memory"
+msgstr "Слободна меморија"
+
+#: id:159
+msgid "No link"
+msgstr "није успостављена"
+
+#: id:160
+msgctxt "Auto context with id 160"
+msgid "Free"
+msgstr "слободно"
+
+#: id:161
+msgid "Unavailable"
+msgstr "Недоступно"
+
+#: id:162
+msgid "Tray open"
+msgstr "Врата отворена"
+
+#: id:163
+msgid "Reading"
+msgstr "Читање"
+
+#: id:164
+msgid "No disc"
+msgstr "Диск није уметнут"
+
+#: id:165
+msgid "Disc present"
+msgstr "Диск је препознат"
+
+#: id:166
+msgid "Skin"
+msgstr "Маска"
+
+#: id:169
+msgctxt "Auto context with id 169"
+msgid "Resolution"
+msgstr "Резолуција"
+
+#: id:170
+msgid "Adjust display refresh rate to match video"
+msgstr "Прилагоди брзину освежавања монитору"
+
+#: id:172
+msgid "Release date"
+msgstr "Датум издавања"
+
+#: id:173
+msgid "Display 4:3 videos as"
+msgstr "Прикажи 4:3 видео материјал као"
+
+#: id:175
+msgid "Moods"
+msgstr "Расположења"
+
+#: id:176
+msgid "Styles"
+msgstr "Стилови"
+
+#: id:179
+msgid "Song"
+msgstr "Песма"
+
+#: id:180
+msgid "Duration"
+msgstr "Трајање"
+
+#: id:181
+msgid "Select album"
+msgstr "Изаберите албум"
+
+#: id:182
+msgid "Tracks"
+msgstr "Нумере"
+
+#: id:183
+msgid "Review"
+msgstr "Преглед"
+
+#: id:184
+msgid "Refresh"
+msgstr "Освежи"
+
+#: id:185
+msgid "Searching album"
+msgstr "Претраживање албума"
+
+#: id:186
+msgid "OK"
+msgstr "У реду"
+
+#: id:187
+msgid "No albums found!"
+msgstr "Ни један албум није пронађен!"
+
+#: id:188
+msgid "Select all"
+msgstr "Изабери све"
+
+#: id:189
+msgid "Scanning media info"
+msgstr "Анализирање информација"
+
+#: id:190
+msgid "Save"
+msgstr "Сачувај"
+
+#: id:191
+msgid "Shuffle"
+msgstr "Насумично"
+
+#: id:192
+msgctxt "Auto context with id 192"
+msgid "Clear"
+msgstr "Поништи"
+
+#: id:193
+msgctxt "Auto context with id 193"
+msgid "Scan"
+msgstr "Анализирај"
+
+#: id:194
+msgid "Searching..."
+msgstr "Претраживање..."
+
+#: id:195
+msgid "No info found!"
+msgstr "Нису пронађене информације!"
+
+#: id:196
+msgid "Select movie:"
+msgstr "Изаберите филм:"
+
+#: id:197
+msgid "Querying %s info"
+msgstr "Захтевање података о %s"
+
+#: id:198
+msgid "Loading movie details"
+msgstr "Учитавање података о филму"
+
+#: id:199
+msgid "Web interface"
+msgstr ""
+
+#: id:202
+msgid "Tagline"
+msgstr "Tagline"
+
+#: id:203
+msgid "Plot outline"
+msgstr "Кратак опис"
+
+#: id:205
+msgid "Votes"
+msgstr "Гласова"
+
+#: id:206
+msgid "Cast"
+msgstr "Улоге"
+
+#: id:207
+msgid "Plot"
+msgstr "Опис"
+
+#: id:208
+msgctxt "Auto context with id 208"
+msgid "Play"
+msgstr "Репродукуј"
+
+#: id:209
+msgid "Next"
+msgstr "Следеће"
+
+#: id:210
+msgid "Previous"
+msgstr "Претходно"
+
+#: id:213
+msgid "Calibrate user interface..."
+msgstr "Прилагодите корисничко окружење..."
+
+#: id:214
+msgid "Video calibration..."
+msgstr "Калибрација слике..."
+
+#: id:215
+msgid "Soften"
+msgstr "Омекшано"
+
+#: id:216
+msgid "Zoom amount"
+msgstr "Ниво увећања"
+
+#: id:217
+msgid "Pixel ratio"
+msgstr "Однос пикселизације"
+
+#: id:218
+msgid "DVD drive"
+msgstr "DVD уређај"
+
+#: id:219
+msgid "Please insert disc"
+msgstr "Молимо, уметните диск"
+
+#: id:220
+msgid "Remote share"
+msgstr "Даљинско дељење"
+
+#: id:221
+msgid "Network is not connected"
+msgstr "Мрежа није повезана"
+
+#: id:222
+msgid "Cancel"
+msgstr "Откажи"
+
+#: id:224
+msgid "Speed"
+msgstr "Брзина"
+
+#: id:225
+msgid "Vertical Shift"
+msgstr ""
+
+#: id:226
+msgid "Test patterns..."
+msgstr "Испробај шаблон..."
+
+#: id:227
+msgid "Lookup audio CD track names from freedb.org"
+msgstr "Потражи имена нумера, музичког CD-а, на freedb.org"
+
+#: id:228
+msgid "Shuffle playlist on load"
+msgstr "Измешај списак при учитавању"
+
+#: id:229
+msgid "HDD spindown time"
+msgstr "Време успорења HDD-а"
+
+#: id:230
+msgid "Video filters"
+msgstr "Видео филтери"
+
+#: id:231
+msgctxt "Auto context with id 231"
+msgid "None"
+msgstr "Ништа"
+
+#: id:232
+msgid "Point"
+msgstr "Тачка"
+
+#: id:233
+msgid "Linear"
+msgstr "Линеарно"
+
+#: id:234
+msgid "Anisotropic"
+msgstr "Анизотропија"
+
+#: id:235
+msgid "Quincunx"
+msgstr "Quincunx"
+
+#: id:236
+msgid "Gaussian cubic"
+msgstr "Gaussian cubic"
+
+#: id:237
+msgid "Minification"
+msgstr "Умањење"
+
+#: id:238
+msgid "Magnification"
+msgstr "Увеличање"
+
+#: id:239
+msgid "Clear playlist on finish"
+msgstr "Поништи списак по завршетку"
+
+#: id:240
+msgid "Display Mode"
+msgstr ""
+
+#: id:241
+msgid "Full Screen #%d"
+msgstr ""
+
+#: id:242
+msgid "Windowed"
+msgstr ""
+
+#: id:243
+msgid "Refresh Rate"
+msgstr ""
+
+#: id:244
+msgid "Full screen"
+msgstr ""
+
+#: id:245
+msgid "Sizing: (%i,%i)->(%i,%i) (Zoom x%2.2f) AR:%2.2f:1 (Pixels: %2.2f:1) (VShift: %2.2f)"
+msgstr ""
+
+#: id:247
+msgctxt "Auto context with id 247"
+msgid "Scripts"
+msgstr "Скрипте"
+
+#: id:248
+msgctxt "Auto context with id 248"
+msgid "Language"
+msgstr "Језик"
+
+#: id:249
+msgctxt "Auto context with id 249"
+msgid "Music"
+msgstr "Музика"
+
+#: id:250
+msgctxt "Auto context with id 250"
+msgid "Visualization"
+msgstr "Визуализација"
+
+#: id:251
+msgid "Select destination directory"
+msgstr "Изаберите одредишну фасциклу"
+
+#: id:252
+msgid "Output stereo to all speakers"
+msgstr "Стерео излаз ка свим звучницима"
+
+#: id:253
+msgid "Number of channels"
+msgstr "Број канала"
+
+#: id:254
+msgid "- DTS capable receiver"
+msgstr "- Способан DTS пријемник"
+
+#: id:255
+msgid "CDDB"
+msgstr "CDDB"
+
+#: id:256
+msgid "Fetching CD information"
+msgstr "Преузимање CD информација"
+
+#: id:257
+msgid "Error"
+msgstr "Грешка"
+
+#: id:258
+msgid "Enable tag reading"
+msgstr "Омогући читање ознака"
+
+#: id:259
+msgid "Opening"
+msgstr "Отварање"
+
+#: id:260
+msgid "Shoutcast"
+msgstr "Интернет радио"
+
+#: id:261
+msgid "Waiting for start..."
+msgstr "Чекање на почетак..."
+
+#: id:262
+msgid "Scripts output"
+msgstr "Излазне скрипте"
+
+#: id:263
+msgid "Allow control of XBMC via HTTP"
+msgstr "Дозволи контролу XBMC апликације путем HTTP протокола"
+
+#: id:264
+msgid "Record"
+msgstr "Сними"
+
+#: id:265
+msgid "Stop Rec."
+msgstr "Заустави сним."
+
+#: id:266
+msgid "Sort by: Track"
+msgstr "Сложи по: Нумери"
+
+#: id:267
+msgid "Sort by: Time"
+msgstr "Сложи по: Времену"
+
+#: id:268
+msgid "Sort by: Title"
+msgstr "Сложи по: Наслову"
+
+#: id:269
+msgid "Sort by: Artist"
+msgstr "Сложи по: Извођачу"
+
+#: id:270
+msgid "Sort by: Album"
+msgstr "Сложи по: Албуму"
+
+#: id:271
+msgid "Top 100"
+msgstr "Најбољих 100"
+
+#: id:272
+msgid "Top-Left overscan compensation"
+msgstr "Горња лева ивица екрана"
+
+#: id:273
+msgid "Bottom-Right overscan compensation"
+msgstr "Доња десна ивица екрана"
+
+#: id:274
+msgid "Subtitle positioning"
+msgstr "Позиционирање титла"
+
+#: id:275
+msgid "Pixel ratio adjustment"
+msgstr "Прилагођавање односа страна"
+
+#: id:276
+msgid "Adjust the arrow to change the amount of overscan"
+msgstr "Померајте стрелицу како бисте променили величину екрана"
+
+#: id:277
+msgid "Adjust the bar to change the subtitles position"
+msgstr "Померајте линију како бисте променили позицију титлова"
+
+#: id:278
+msgid "Adjust the rectangle so it is perfectly square"
+msgstr "Обликујте правоугаоник тако да добијете савршени квадрат"
+
+#: id:279
+msgid "Unable to load settings"
+msgstr "Није могуће учитати поставке"
+
+#: id:280
+msgid "Using default settings"
+msgstr "Коришћење подразумеваних поставки"
+
+#: id:281
+msgid "Please check the XML files"
+msgstr "Молимо, проверите XML датотеке"
+
+#: id:282
+msgid "Found %i items"
+msgstr "Пронађено %i ставки"
+
+#: id:283
+msgid "Search results"
+msgstr "Резултати претраге"
+
+#: id:284
+msgid "No results found"
+msgstr "Без резултата"
+
+#: id:287
+msgctxt "Auto context with id 287"
+msgid "Subtitles"
+msgstr "Титлови"
+
+#: id:288
+msgctxt "Auto context with id 288"
+msgid "Font"
+msgstr "Слова"
+
+#: id:289
+msgctxt "Auto context with id 289"
+msgid "- Size"
+msgstr "- Величина"
+
+#: id:290
+msgid "Dynamic range compression"
+msgstr "Динамички опсег компресије"
+
+#: id:291
+msgctxt "Auto context with id 291"
+msgid "Video"
+msgstr "Видео"
+
+#: id:292
+msgctxt "Auto context with id 292"
+msgid "Audio"
+msgstr "Звук"
+
+#: id:293
+msgid "Browse for subtitles"
+msgstr "Потражи титлове"
+
+#: id:294
+msgid "Create bookmark"
+msgstr "Направи обележ."
+
+#: id:296
+msgid "Clear bookmarks"
+msgstr "Поништи обележ."
+
+#: id:297
+msgid "Audio offset"
+msgstr "Померај звука у времену"
+
+#: id:298
+msgid "Bookmarks"
+msgstr "Обележивачи"
+
+#: id:299
+msgid "- AAC capable receiver"
+msgstr "- Способан AAC пријемник"
+
+#: id:300
+msgid "- MP1 capable receiver"
+msgstr "- Способан MP1 пријемник"
+
+#: id:301
+msgid "- MP2 capable receiver"
+msgstr "- Способан MP2 пријемник"
+
+#: id:302
+msgid "- MP3 capable receiver"
+msgstr "- Способан MP3 пријемник"
+
+#: id:303
+msgid "Delay"
+msgstr "Кашњење"
+
+#: id:304
+msgctxt "Auto context with id 304"
+msgid "Language"
+msgstr "Језик"
+
+#: id:305
+msgctxt "Auto context with id 305"
+msgid "Enabled"
+msgstr "Омогућено"
+
+#: id:306
+msgid "Non-interleaved"
+msgstr "Нестандардни"
+
+#: id:312
+msgid "(0=auto)"
+msgstr "(0=аутом.)"
+
+#: id:313
+msgid "Cleaning database"
+msgstr "Чишћење базе"
+
+#: id:314
+msgid "Preparing..."
+msgstr "Припремање..."
+
+#: id:315
+msgid "Database error"
+msgstr "Грешка базе података"
+
+#: id:316
+msgid "Searching songs..."
+msgstr "Претраживање песама..."
+
+#: id:317
+msgid "Cleaned database successfully"
+msgstr "База података је успешно очишћена"
+
+#: id:318
+msgid "Cleaning songs..."
+msgstr "Чишћење песама..."
+
+#: id:319
+msgid "Error cleaning songs"
+msgstr "Грешка чишћења песама"
+
+#: id:320
+msgid "Cleaning artists..."
+msgstr "Чишћење извођача..."
+
+#: id:321
+msgid "Error cleaning artists"
+msgstr "Грешка чишћења извођача"
+
+#: id:322
+msgid "Cleaning genres..."
+msgstr "Чишћење жанрова..."
+
+#: id:323
+msgid "Error cleaning genres"
+msgstr "Грешка чишћења жанрова"
+
+#: id:324
+msgid "Cleaning paths..."
+msgstr "Чишћење путања..."
+
+#: id:325
+msgid "Error cleaning paths"
+msgstr "Грешка чишћења путања"
+
+#: id:326
+msgid "Cleaning albums..."
+msgstr "Чишћење албума..."
+
+#: id:327
+msgid "Error cleaning albums"
+msgstr "Грешка чишћења албума"
+
+#: id:328
+msgid "Writing changes..."
+msgstr "Уписивање промена..."
+
+#: id:329
+msgid "Error writing changes"
+msgstr "Грешка уписивања промена"
+
+#: id:330
+msgid "This may take some time..."
+msgstr "Ово може потрајати неко време..."
+
+#: id:331
+msgid "Compressing database..."
+msgstr "Компримовање базе података..."
+
+#: id:332
+msgid "Error compressing database"
+msgstr "Грешка компримовања базе података"
+
+#: id:333
+msgid "Do you want to clean the library?"
+msgstr "Желите ли заиста да очистите библиотеку?"
+
+#: id:334
+msgid "Clean library..."
+msgstr "Чишћење библиотеке..."
+
+#: id:335
+msgid "Start"
+msgstr "Покрени"
+
+#: id:336
+msgid "Framerate conversion"
+msgstr "Конверзија брзине сличица"
+
+#: id:337
+msgctxt "Auto context with id 337"
+msgid "Audio output"
+msgstr "Излаз звука"
+
+#: id:338
+msgid "Analog"
+msgstr "Аналогни"
+
+#: id:339
+msgid "Optical/Coax"
+msgstr "Дигитални"
+
+#: id:340
+msgid "Various artists"
+msgstr "Различити извођачи"
+
+#: id:341
+msgid "Play disc"
+msgstr "Репродукуј диск"
+
+#: id:342
+msgctxt "Auto context with id 342"
+msgid "Movies"
+msgstr "Филмови"
+
+#: id:343
+msgid "Adjust framerate"
+msgstr "Прилагоди брзину сличица"
+
+#: id:344
+msgid "Actors"
+msgstr "Глумци"
+
+#: id:345
+msgctxt "Auto context with id 345"
+msgid "Year"
+msgstr "Година"
+
+#: id:346
+msgid "Boost volume level on downmix"
+msgstr "Појачај ниво звука при пребацивању у мањи бр. канала"
+
+#: id:350
+msgctxt "Auto context with id 350"
+msgid "Programs"
+msgstr "Програми"
+
+#: id:351
+msgctxt "Auto context with id 351"
+msgid "Off"
+msgstr "Искљ."
+
+#: id:352
+msgid "Dim"
+msgstr "Затамни"
+
+#: id:353
+msgid "Black"
+msgstr "Црно"
+
+#: id:354
+msgid "Matrix trails"
+msgstr "Matrix трагови"
+
+#: id:355
+msgid "Screensaver time"
+msgstr "Време покретања чувара екрана"
+
+#: id:356
+msgid "Screensaver mode"
+msgstr "Режим чувара екрана"
+
+#: id:357
+msgid "Shutdown function timer"
+msgstr "Функционисање тајмера искључивања"
+
+#: id:358
+msgid "All albums"
+msgstr "Сви албуми"
+
+#: id:359
+msgid "Recently added albums"
+msgstr "Недавно додати албуми"
+
+#: id:360
+msgctxt "Auto context with id 360"
+msgid "Screensaver"
+msgstr "Чувар екрана"
+
+#: id:361
+msgid "R. Slideshow"
+msgstr "Насум. реп. слај."
+
+#: id:362
+msgid "Screensaver dim level"
+msgstr "Ниво затамљења чувара екрана"
+
+#: id:363
+msgid "Sort by: File"
+msgstr "Сложи по: Дато."
+
+#: id:364
+msgid "- Dolby Digital (AC3) capable receiver"
+msgstr "- Способан Dolby Digital (AC3) пријемник"
+
+#: id:365
+msgctxt "Auto context with id 365"
+msgid "Sort by: Name"
+msgstr "Сложи по: Имену"
+
+#: id:366
+msgid "Sort by: Year"
+msgstr "Сложи по: Години"
+
+#: id:367
+msgid "Sort by: Rating"
+msgstr "Сложи по: Популарности"
+
+#: id:368
+msgid "IMDb"
+msgstr "IMDb"
+
+#: id:369
+msgctxt "Auto context with id 369"
+msgid "Title"
+msgstr "Назив"
+
+#: id:370
+msgid "Thunderstorms"
+msgstr "грмљавина"
+
+#: id:371
+msgid "Partly"
+msgstr "делимично"
+
+#: id:372
+msgid "Mostly"
+msgstr "углавном"
+
+#: id:373
+msgid "Sunny"
+msgstr "сунчано"
+
+#: id:374
+msgid "Cloudy"
+msgstr "облачно"
+
+#: id:375
+msgid "Snow"
+msgstr "снег"
+
+#: id:376
+msgid "Rain"
+msgstr "киша"
+
+#: id:377
+msgid "Light"
+msgstr "слаб(а)"
+
+#: id:378
+msgid "AM"
+msgstr "ујутро"
+
+#: id:379
+msgid "PM"
+msgstr "поподне"
+
+#: id:380
+msgid "Showers"
+msgstr "пљускови"
+
+#: id:381
+msgid "Few"
+msgstr "неколико"
+
+#: id:382
+msgid "Scattered"
+msgstr "местимично"
+
+#: id:383
+msgctxt "Auto context with id 383"
+msgid "Wind"
+msgstr "ветровито"
+
+#: id:384
+msgid "Strong"
+msgstr "изузетно"
+
+#: id:385
+msgid "Fair"
+msgstr "умерено"
+
+#: id:386
+msgctxt "Auto context with id 386"
+msgid "Clear"
+msgstr "ведро"
+
+#: id:387
+msgid "Clouds"
+msgstr "облачно"
+
+#: id:388
+msgid "Early"
+msgstr "рани"
+
+#: id:389
+msgid "Shower"
+msgstr "пљусак"
+
+#: id:390
+msgid "Flurries"
+msgstr "Суснежица"
+
+#: id:391
+msgctxt "Auto context with id 391"
+msgid "Low"
+msgstr "низак"
+
+#: id:392
+msgctxt "Auto context with id 392"
+msgid "Medium"
+msgstr "умерен"
+
+#: id:393
+msgctxt "Auto context with id 393"
+msgid "High"
+msgstr "висок"
+
+#: id:394
+msgid "Fog"
+msgstr "магла"
+
+#: id:395
+msgid "Haze"
+msgstr "измаглица"
+
+#: id:396
+msgid "Select location"
+msgstr "Избор локације"
+
+#: id:397
+msgid "Refresh time"
+msgstr "Учесталост освежавања"
+
+#: id:398
+msgid "Temperature units"
+msgstr "Јединице за температуру"
+
+#: id:399
+msgid "Speed units"
+msgstr "Јединице за брзину"
+
+#: id:400
+msgctxt "Auto context with id 400"
+msgid "Weather"
+msgstr "Време"
+
+#: id:401
+msgid "Temp"
+msgstr "Темпер."
+
+#: id:402
+msgid "Feels like"
+msgstr "Као да је"
+
+#: id:403
+msgid "UV index"
+msgstr "UV индекс"
+
+#: id:404
+msgctxt "Auto context with id 404"
+msgid "Wind"
+msgstr "Ветар"
+
+#: id:405
+msgid "Dew point"
+msgstr "Тачка росе"
+
+#: id:406
+msgid "Humidity"
+msgstr "Влажност"
+
+#: id:409
+msgid "Defaults"
+msgstr "Подразумевано"
+
+#: id:410
+msgid "Accessing weather service"
+msgstr "Приступање услузи врем. прогнозе"
+
+#: id:411
+msgid "Getting weather for:"
+msgstr "Преузимање прогнозе за:"
+
+#: id:412
+msgid "Unable to get weather data"
+msgstr "Није могуће преузети податке о прогнози"
+
+#: id:413
+msgid "Manual"
+msgstr "Ручно"
+
+#: id:414
+msgid "No review for this album"
+msgstr "Не постоји рецензија за овај албум"
+
+#: id:415
+msgid "Downloading thumbnail..."
+msgstr "Преузимање..."
+
+#: id:416
+msgid "Not available"
+msgstr "Није доступно"
+
+#: id:417
+msgid "View: Big icons"
+msgstr "Приказ: Велике иконе"
+
+#: id:418
+msgctxt "Auto context with id 418"
+msgid "Low"
+msgstr "Мин."
+
+#: id:419
+msgctxt "Auto context with id 419"
+msgid "High"
+msgstr "Макс."
+
+#: id:420
+msgid "HDMI"
+msgstr ""
+
+#: id:422
+msgid "Delete album info"
+msgstr "Избриши податке о албуму"
+
+#: id:423
+msgid "Delete CD information"
+msgstr "Избриши CD податке"
+
+#: id:424
+msgid "Select"
+msgstr "Изабери"
+
+#: id:425
+msgid "No album information found"
+msgstr "Нису пронађени подаци о албуму"
+
+#: id:426
+msgid "No CD information found"
+msgstr "Нису пронађени CD подаци"
+
+#: id:427
+msgid "Disc"
+msgstr "Диск"
+
+#: id:428
+msgid "Insert correct CD/DVD"
+msgstr "Уметните исправан CD/DVD"
+
+#: id:429
+msgid "Please insert the following disc:"
+msgstr "Молимо, уметните следећи CD/DVD"
+
+#: id:430
+msgid "Sort by: DVD#"
+msgstr "Сложи по: DVD#"
+
+#: id:431
+msgid "No cache"
+msgstr "Без кеша"
+
+#: id:432
+msgid "Remove movie from library"
+msgstr "Уклони филм из библиотеке"
+
+#: id:433
+msgid "Really remove '%s'?"
+msgstr "Заиста желите да уклоните „%s“?"
+
+#: id:434
+msgid "From %s at %i %s"
+msgstr ""
+
+#: id:437
+msgid "Removable disk"
+msgstr "Преносиви диск"
+
+#: id:438
+msgid "Opening file"
+msgstr "Отварање датотеке"
+
+#: id:439
+msgid "Cache"
+msgstr "Кеш"
+
+#: id:440
+msgid "Harddisk"
+msgstr "Чврсти диск"
+
+#: id:441
+msgid "UDF"
+msgstr "UDF"
+
+#: id:442
+msgid "Local network"
+msgstr "Локална мрежа"
+
+#: id:443
+msgid "Internet"
+msgstr "Интернет"
+
+#: id:444
+msgctxt "Auto context with id 444"
+msgid "Video"
+msgstr "Видео"
+
+#: id:445
+msgctxt "Auto context with id 445"
+msgid "Audio"
+msgstr "Звук"
+
+#: id:446
+msgctxt "Auto context with id 446"
+msgid "DVD"
+msgstr "DVD"
+
+#: id:447
+msgid "Autorun media"
+msgstr "Аутоматска репрод. медија"
+
+#: id:448
+msgid "LCD"
+msgstr "LCD"
+
+#: id:449
+msgctxt "Auto context with id 449"
+msgid "Enabled"
+msgstr "Омогућено"
+
+#: id:450
+msgid "Columns"
+msgstr "Колоне"
+
+#: id:451
+msgid "Row 1 address"
+msgstr "1. ред адресе"
+
+#: id:452
+msgid "Row 2 address"
+msgstr "2. ред адресе"
+
+#: id:453
+msgid "Row 3 address"
+msgstr "3. ред адресе"
+
+#: id:454
+msgid "Row 4 address"
+msgstr "4. ред адресе"
+
+#: id:455
+msgid "Rows"
+msgstr "Редови"
+
+#: id:456
+msgid "Mode"
+msgstr "Режим"
+
+#: id:457
+msgid "Switch view"
+msgstr "Промени приказ"
+
+#: id:459
+msgid "Subs"
+msgstr "Титлови"
+
+#: id:460
+msgid "Audio stream"
+msgstr "Звучни запис"
+
+#: id:461
+msgid "[active]"
+msgstr "[активно]"
+
+#: id:462
+msgid "Subtitle"
+msgstr "Титл"
+
+#: id:463
+msgid "Backlight"
+msgstr "Позадинско осветљење"
+
+#: id:464
+msgid "Brightness"
+msgstr "Светлина"
+
+#: id:465
+msgid "Contrast"
+msgstr "Контраст"
+
+#: id:466
+msgid "Gamma"
+msgstr "Опсег боје"
+
+#: id:467
+msgctxt "Auto context with id 467"
+msgid "Type"
+msgstr "Тип"
+
+#: id:468
+msgid "Move the bar to change the OSD position"
+msgstr "Померајте линију да бисте променили OSD позицију"
+
+#: id:469
+msgid "OSD position"
+msgstr "OSD позиција"
+
+#: id:470
+msgid "Credits"
+msgstr "Заслуге"
+
+#: id:471
+msgid "Modchip"
+msgstr "Изме. чип"
+
+#: id:474
+msgctxt "Auto context with id 474"
+msgid "Off"
+msgstr "Искљ."
+
+#: id:475
+msgid "Music only"
+msgstr "Само музика"
+
+#: id:476
+msgctxt "Auto context with id 476"
+msgid "Music & video"
+msgstr "Музика и видео"
+
+#: id:477
+msgid "Unable to load playlist"
+msgstr "Није могуће учитати списак за репродукцију"
+
+#: id:478
+msgid "OSD"
+msgstr "OSD"
+
+#: id:479
+msgid "Skin & language"
+msgstr "Маска и језик"
+
+#: id:480
+msgid "Appearance"
+msgstr "Приказивање"
+
+#: id:481
+msgid "Audio options"
+msgstr "Опције звука"
+
+#: id:482
+msgid "About XBMC"
+msgstr "О систему XBMC"
+
+#: id:485
+msgid "Delete album"
+msgstr "Избриши албум"
+
+#: id:486
+msgid "Repeat"
+msgstr "Понови"
+
+#: id:487
+msgid "Repeat one"
+msgstr "Понови једном"
+
+#: id:488
+msgid "Repeat folder"
+msgstr "Понови фасциклу"
+
+#: id:489
+msgid "Play the next song automatically"
+msgstr "Аутоматски репродукуј следећу песму"
+
+#: id:491
+msgid "- Use big icons"
+msgstr "- Користи велике иконе"
+
+#: id:492
+msgid "Resize VobSubs"
+msgstr "Промени величину за VobSubs"
+
+#: id:493
+msgid "Advanced options (Experts Only!)"
+msgstr "Напредне опције (само за стручњаке!)"
+
+#: id:494
+msgid "Overall audio headroom"
+msgstr "Свеобухватан звучни слободан простор"
+
+#: id:495
+msgid "Upsample videos to GUI resolution"
+msgstr "Поистовети видео и GUI резолуцију"
+
+#: id:496
+msgid "Calibration"
+msgstr "Калибрација"
+
+#: id:497
+msgid "Show file extensions"
+msgstr "Прикажи типове датотека"
+
+#: id:498
+msgid "Sort by: Type"
+msgstr "Сложи по: Типу"
+
+#: id:499
+msgid "Unable to connect to online lookup service"
+msgstr "Није могуће повезивање и претрага мрежне услуге"
+
+#: id:500
+msgid "Downloading album information failed"
+msgstr "Неуспешно преузимање података о албуму"
+
+#: id:501
+msgid "Looking for album names..."
+msgstr "Тражење назива албума..."
+
+#: id:502
+msgctxt "Auto context with id 502"
+msgid "Open"
+msgstr "Отвори"
+
+#: id:503
+msgid "Busy"
+msgstr "Заузето"
+
+#: id:504
+msgid "Empty"
+msgstr "Празно"
+
+#: id:505
+msgid "Loading media info from files..."
+msgstr "Учитавање података о медију из датотека..."
+
+#: id:507
+msgid "Sort by: Usage"
+msgstr "Сложи по: Употреби"
+
+#: id:510
+msgid "Enable visualizations"
+msgstr "Омогући визуализације"
+
+#: id:511
+msgid "Enable video mode switching"
+msgstr "Омогући промену режима видеа"
+
+#: id:512
+msgid "Startup window"
+msgstr "Стартни екран"
+
+#: id:513
+msgid "Home window"
+msgstr "Почетни екран"
+
+#: id:514
+msgid "Manual settings"
+msgstr "Ручне поставке"
+
+#: id:515
+msgid "Genre"
+msgstr "Жанр"
+
+#: id:517
+msgid "Recently played albums"
+msgstr "Недавно репродуковани албуми"
+
+#: id:518
+msgid "Launch"
+msgstr "Покрени"
+
+#: id:519
+msgid "Launch in..."
+msgstr "Покрени у..."
+
+#: id:521
+msgid "Compilations"
+msgstr "Компилације"
+
+#: id:522
+msgid "Remove source"
+msgstr "Уклони извор"
+
+#: id:523
+msgid "Switch media"
+msgstr "Промени медиј"
+
+#: id:524
+msgid "Select playlist"
+msgstr "Изаберите списак за репродукцију"
+
+#: id:525
+msgid "New playlist..."
+msgstr "Нови списак за репродукцију..."
+
+#: id:526
+msgid "Add to playlist"
+msgstr "Додај у списак за репродукцију"
+
+#: id:527
+msgid "Manually add to library"
+msgstr "Ручно додајте у библиотеку"
+
+#: id:528
+msgid "Enter title"
+msgstr "Унесите наслов"
+
+#: id:529
+msgid "Error: Duplicate title"
+msgstr "Грешка: Дуплиран наслов"
+
+#: id:530
+msgid "Select genre"
+msgstr "Изаберите жанр"
+
+#: id:531
+msgid "New genre"
+msgstr "Нови жанр"
+
+#: id:532
+msgid "Manual addition"
+msgstr "Ручно додавање"
+
+#: id:533
+msgid "Enter genre"
+msgstr "Унесите жанр"
+
+#: id:534
+msgid "View: %s"
+msgstr "Приказ: %s"
+
+#: id:535
+msgid "List"
+msgstr "Списак"
+
+#: id:536
+msgid "Icons"
+msgstr "Иконе"
+
+#: id:537
+msgid "Big list"
+msgstr "Вел. спис."
+
+#: id:538
+msgid "Big icons"
+msgstr "Вел. иконе"
+
+#: id:539
+msgid "Wide"
+msgstr "Широки"
+
+#: id:540
+msgid "Big wide"
+msgstr "Веома широки"
+
+#: id:541
+msgid "Album icons"
+msgstr "Иконе албума"
+
+#: id:542
+msgid "DVD icons"
+msgstr "DVD иконе"
+
+#: id:543
+msgctxt "Auto context with id 543"
+msgid "DVD"
+msgstr "DVD"
+
+#: id:544
+msgctxt "Auto context with id 544"
+msgid "Media info"
+msgstr "Подаци о медију"
+
+#: id:545
+msgid "Audio output device"
+msgstr "Звучни излазни уређај"
+
+#: id:546
+msgid "Passthrough output device"
+msgstr "Пролазни излазни уређај"
+
+#: id:547
+msgid "No biography for this artist"
+msgstr "Овај извођач нема попуњену биографију"
+
+#: id:548
+msgid "Downmix multichannel audio to stereo"
+msgstr "Претвори вишеканални звук у стерео"
+
+#: id:550
+msgid "Sort by: %s"
+msgstr "Сложи по: %s"
+
+#: id:551
+msgctxt "Auto context with id 551"
+msgid "Name"
+msgstr "Име"
+
+#: id:552
+msgid "Date"
+msgstr "Датум"
+
+#: id:553
+msgid "Size"
+msgstr "Велич."
+
+#: id:554
+msgid "Track"
+msgstr "Нумера"
+
+#: id:555
+msgid "Time"
+msgstr "Трајање"
+
+#: id:556
+msgctxt "Auto context with id 556"
+msgid "Title"
+msgstr "Наслов"
+
+#: id:557
+msgid "Artist"
+msgstr "Извођач"
+
+#: id:558
+msgid "Album"
+msgstr "Албум"
+
+#: id:559
+msgid "Playlist"
+msgstr "Списак за реп."
+
+#: id:560
+msgid "ID"
+msgstr "ID"
+
+#: id:561
+msgctxt "Auto context with id 561"
+msgid "File"
+msgstr "Датоте."
+
+#: id:562
+msgctxt "Auto context with id 562"
+msgid "Year"
+msgstr "Година"
+
+#: id:563
+msgid "Rating"
+msgstr "Оцена"
+
+#: id:564
+msgctxt "Auto context with id 564"
+msgid "Type"
+msgstr "Тип"
+
+#: id:565
+msgid "Usage"
+msgstr "Кориш."
+
+#: id:566
+msgid "Album artist"
+msgstr "Извођач на албуму"
+
+#: id:567
+msgid "Play count"
+msgstr "Број репродукција"
+
+#: id:568
+msgid "Last played"
+msgstr "Последња репродукција"
+
+#: id:569
+msgctxt "Auto context with id 569"
+msgid "Comment"
+msgstr "Коментар"
+
+#: id:570
+msgid "Date added"
+msgstr "Датум додавања"
+
+#: id:571
+msgctxt "Auto context with id 571"
+msgid "Default"
+msgstr "Подразумевано"
+
+#: id:572
+msgid "Studio"
+msgstr "Студио"
+
+#: id:573
+msgid "Path"
+msgstr "Путања"
+
+#: id:574
+msgctxt "Auto context with id 574"
+msgid "Country"
+msgstr ""
+
+#: id:575
+msgid "In progress"
+msgstr ""
+
+#: id:576
+msgid "Times played"
+msgstr ""
+
+#: id:580
+msgid "Sort direction"
+msgstr "Смер слагања"
+
+#: id:581
+msgid "Sort method"
+msgstr "Начин слагања"
+
+#: id:582
+msgctxt "Auto context with id 582"
+msgid "View mode"
+msgstr "Режим приказа"
+
+#: id:583
+msgid "Remember views for different folders"
+msgstr "Запамти приказе различитих фасцикли"
+
+#: id:584
+msgid "Ascending"
+msgstr "Узлазно"
+
+#: id:585
+msgid "Descending"
+msgstr "Силазно"
+
+#: id:586
+msgid "Edit playlist"
+msgstr "Уреди списак за реп."
+
+#: id:587
+msgid "Filter"
+msgstr "Филтер"
+
+#: id:588
+msgid "Cancel party mode"
+msgstr "Откажи режим журке"
+
+#: id:589
+msgid "Party mode"
+msgstr "Режим журке"
+
+#: id:590
+msgid "Random"
+msgstr "Насумично"
+
+#: id:591
+msgctxt "Auto context with id 591"
+msgid "Off"
+msgstr "Искљ."
+
+#: id:592
+msgid "One"
+msgstr "Једном"
+
+#: id:593
+msgid "All"
+msgstr "Све"
+
+#: id:594
+msgctxt "Auto context with id 594"
+msgid "Off"
+msgstr "Искљ."
+
+#: id:595
+msgid "Repeat: Off"
+msgstr "Понови: Искљ."
+
+#: id:596
+msgid "Repeat: One"
+msgstr "Понови: Једном"
+
+#: id:597
+msgid "Repeat: All"
+msgstr "Понови: Све"
+
+#: id:600
+msgid "Rip audio CD"
+msgstr "Рипуј музички CD"
+
+#: id:601
+msgctxt "Auto context with id 601"
+msgid "Medium"
+msgstr "Средње"
+
+#: id:602
+msgctxt "Auto context with id 602"
+msgid "Standard"
+msgstr "Уобичајено"
+
+#: id:603
+msgid "Extreme"
+msgstr "Екстремно"
+
+#: id:604
+msgid "Constant bitrate"
+msgstr "Непроменљива брзина"
+
+#: id:605
+msgid "Ripping..."
+msgstr "Риповање..."
+
+#: id:607
+msgid "To:"
+msgstr "За:"
+
+#: id:608
+msgid "Could not rip CD or track"
+msgstr "Није могуће риповати CD или нумеру"
+
+#: id:609
+msgid "CDDARipPath is not set."
+msgstr "CDDARipPath није постављен."
+
+#: id:610
+msgid "Rip audio track"
+msgstr "Рипуј музичку нумеру"
+
+#: id:611
+msgid "Enter number"
+msgstr "Унесите број"
+
+#: id:612
+msgid "Bits/Sample"
+msgstr ""
+
+#: id:613
+msgid "Sample Frequency"
+msgstr ""
+
+#: id:620
+msgid "Audio CDs"
+msgstr "Музички CD-ови"
+
+#: id:621
+msgid "Encoder"
+msgstr "Кодер"
+
+#: id:622
+msgid "Quality"
+msgstr "Квалитет"
+
+#: id:623
+msgid "Bitrate"
+msgstr "Брзина протока"
+
+#: id:624
+msgid "Include track number"
+msgstr "Укључи број нумере"
+
+#: id:625
+msgid "All songs of"
+msgstr "Све песме од"
+
+#: id:629
+msgctxt "Auto context with id 629"
+msgid "View mode"
+msgstr "Режим приказа"
+
+#: id:630
+msgctxt "Auto context with id 630"
+msgid "Normal"
+msgstr "Нормалан"
+
+#: id:631
+msgid "Zoom"
+msgstr "Увеличан"
+
+#: id:632
+msgid "Stretch 4:3"
+msgstr "Развучено 4:3"
+
+#: id:633
+msgid "Wide Zoom"
+msgstr "Развучено 14:9"
+
+#: id:634
+msgid "Stretch 16:9"
+msgstr "Развучено 16:9"
+
+#: id:635
+msgid "Original Size"
+msgstr "Првобитна величина"
+
+#: id:636
+msgctxt "Auto context with id 636"
+msgid "Custom"
+msgstr "Прилагођено"
+
+#: id:637
+msgid "Replay gain"
+msgstr "Нормализација"
+
+#: id:638
+msgid "Replaygain volume adjustments"
+msgstr "Подеш. гласноће нормализ. звука"
+
+#: id:639
+msgid "Use track levels"
+msgstr "Користи на нивоу нумере"
+
+#: id:640
+msgid "Use album levels"
+msgstr "Користи на нивоу албума"
+
+#: id:641
+msgid "PreAmp Level - Replay gained files"
+msgstr "Ниво предпојачања - са нормализацијом датотека"
+
+#: id:642
+msgid "PreAmp Level - Non replay gained files"
+msgstr "Ниво предпојачања - без нормализације датотека"
+
+#: id:643
+msgid "Avoid clipping on replay gained files"
+msgstr "Избегни исечке при нормализацији датотека"
+
+#: id:644
+msgid "Crop black bars"
+msgstr "Исеци црне траке"
+
+#: id:645
+msgid "Need to unpack a big file. Continue?"
+msgstr "Потребно је распакивање велике датотеке. Наставити?"
+
+#: id:646
+msgid "Remove from library"
+msgstr "Уклони из библиотеке"
+
+#: id:647
+msgid "Export video library"
+msgstr "Извези библиотеку филмова"
+
+#: id:648
+msgid "Import video library"
+msgstr "Увези библиотеку филмова"
+
+#: id:649
+msgid "Importing"
+msgstr "Увоз је у току"
+
+#: id:650
+msgid "Exporting"
+msgstr "Извоз је у току"
+
+#: id:651
+msgid "Browse for library"
+msgstr "Потражи библиотеку"
+
+#: id:652
+msgid "Years"
+msgstr "Година"
+
+#: id:653
+msgid "Update library"
+msgstr "Ажурирај библиотеку"
+
+#: id:654
+msgid "Show debug info"
+msgstr "Прикажи под. о укла. грешака"
+
+#: id:655
+msgid "Browse for executable"
+msgstr "Потражи извршне датотеке"
+
+#: id:656
+msgid "Browse for playlist"
+msgstr "Потражи списак за репродукцију"
+
+#: id:657
+msgid "Browse for folder"
+msgstr "Потражи фасциклу"
+
+#: id:658
+msgid "Song information"
+msgstr "Подаци о песми"
+
+#: id:659
+msgid "Non-linear stretch"
+msgstr "Нелинеарно истезање"
+
+#: id:660
+msgid "Volume amplification"
+msgstr "Појачавање звука"
+
+#: id:661
+msgid "Choose export folder"
+msgstr "Изаберите излазну фасциклу"
+
+#: id:662
+msgid "This file is no longer available."
+msgstr "Ова датотека више није доступна."
+
+#: id:663
+msgid "Would you like to remove it from the library?"
+msgstr "Желите ли ово да уклоните из библиотеке?"
+
+#: id:664
+msgid "Browse for Script"
+msgstr "Потражи скрипту"
+
+#: id:665
+msgid "Compression level"
+msgstr ""
+
+#: id:700
+msgid "Cleaning up library"
+msgstr "Чишћење библиотеке"
+
+#: id:701
+msgid "Removing old songs from the library"
+msgstr "Уклањање старих песама из библиотеке"
+
+#: id:702
+msgid "This path has been scanned before"
+msgstr "Ова путања је већ анализирана"
+
+#: id:705
+msgctxt "Auto context with id 705"
+msgid "Network"
+msgstr "Мрежа"
+
+#: id:706
+msgid "- Server"
+msgstr "- Сервер"
+
+#: id:708
+msgid "Use an HTTP proxy server to access the internet"
+msgstr "Користи посреднички HTTP сервер за приступ Интернету"
+
+#: id:711
+msgid "Internet Protocol (IP)"
+msgstr "Интернет протокол (IP)"
+
+#: id:712
+msgid "Invalid port specified. Value must be between 1 and 65535."
+msgstr "Одредили сте неисправан прикључак. Вредност мора бити између 1 и 65535."
+
+#: id:713
+msgid "HTTP proxy"
+msgstr "HTTP посредник"
+
+#: id:715
+msgid "- Assignment"
+msgstr "- Задатак"
+
+#: id:716
+msgid "Automatic (DHCP)"
+msgstr "Аутоматски (DHCP)"
+
+#: id:717
+msgid "Manual (Static)"
+msgstr "Ручно (статичка)"
+
+#: id:719
+msgid "- IP address"
+msgstr "- IP адреса"
+
+#: id:720
+msgid "- Netmask"
+msgstr "- Мрежна маска"
+
+#: id:721
+msgid "- Default gateway"
+msgstr "- Мрежни пролаз"
+
+#: id:722
+msgid "- DNS server"
+msgstr "- DNS сервер"
+
+#: id:723
+msgid "Save & restart"
+msgstr "Сачувај и поново покрени"
+
+#: id:724
+msgid "Invalid address specified. Value must be AAA.BBB.CCC.DDD"
+msgstr "Одредили сте неисправну адресу. Вредност мора бити AAA.BBB.CCC.DDD"
+
+#: id:725
+msgid "with numbers between 0 and 255."
+msgstr "са бројевима између 0 и 255."
+
+#: id:726
+msgid "Changes not saved. Continue without saving?"
+msgstr "Промене нису сачуване. Наставити без чувања?"
+
+#: id:727
+msgid "Web server"
+msgstr "Web сервер"
+
+#: id:728
+msgctxt "Auto context with id 728"
+msgid "FTP server"
+msgstr "FTP сервер"
+
+#: id:730
+msgid "- Port"
+msgstr "- Прикључак"
+
+#: id:732
+msgid "Save & apply"
+msgstr "Сачувај и примени"
+
+#: id:733
+msgid "- Password"
+msgstr "- Лозинка"
+
+#: id:734
+msgid "No pass"
+msgstr "Без лозинке"
+
+#: id:735
+msgid "- Character set"
+msgstr "- Скуп знакова"
+
+#: id:736
+msgid "- Style"
+msgstr "- Стил"
+
+#: id:737
+msgid "- Colour"
+msgstr "- Боја"
+
+#: id:738
+msgctxt "Auto context with id 738"
+msgid "Normal"
+msgstr "Нормалан"
+
+#: id:739
+msgid "Bold"
+msgstr "Подебљан"
+
+#: id:740
+msgid "Italics"
+msgstr "Курзив"
+
+#: id:741
+msgid "Bold italics"
+msgstr "Подебљани курзив"
+
+#: id:742
+msgctxt "Auto context with id 742"
+msgid "White"
+msgstr "Бела"
+
+#: id:743
+msgctxt "Auto context with id 743"
+msgid "Yellow"
+msgstr "Жута"
+
+#: id:744
+msgctxt "Auto context with id 744"
+msgid "Files"
+msgstr "Датотеке"
+
+#: id:745
+msgid "No scanned information for this view"
+msgstr "Нема анализираних података за овај приказ"
+
+#: id:746
+msgid "Please turn off library mode"
+msgstr "Молимо, искључите режим библиотеке"
+
+#: id:747
+msgid "Error loading image"
+msgstr "Грешка учитавања слике"
+
+#: id:748
+msgid "Edit path"
+msgstr "Уреди путању"
+
+#: id:749
+msgid "Mirror image"
+msgstr "Копија слике"
+
+#: id:750
+msgid "Are you sure?"
+msgstr "Да ли сте сигурни?"
+
+#: id:751
+msgid "Removing source"
+msgstr "Уклањање извора"
+
+#: id:754
+msgid "Add program link"
+msgstr "Додај везу ка програму"
+
+#: id:755
+msgid "Edit program path"
+msgstr "Уреди путању програма"
+
+#: id:756
+msgid "Edit program name"
+msgstr "Уреди име програма"
+
+#: id:757
+msgid "Edit path depth"
+msgstr "Уреди дубину путање"
+
+#: id:759
+msgid "View: Big list"
+msgstr "Приказ: Вел. списак"
+
+#: id:760
+msgctxt "Auto context with id 760"
+msgid "Yellow"
+msgstr "Жута"
+
+#: id:761
+msgctxt "Auto context with id 761"
+msgid "White"
+msgstr "Бела"
+
+#: id:762
+msgid "Blue"
+msgstr "Плава"
+
+#: id:763
+msgid "Bright green"
+msgstr "Светло зелена"
+
+#: id:764
+msgid "Yellow green"
+msgstr "Жутозелена"
+
+#: id:765
+msgid "Cyan"
+msgstr "Азурно плава"
+
+#: id:766
+msgid "Light grey"
+msgstr "Светло сива"
+
+#: id:767
+msgid "Grey"
+msgstr "Сива"
+
+#: id:770
+msgid "Error %i: share not available"
+msgstr "Грешка %i: дељење није доступно"
+
+#: id:772
+msgctxt "Auto context with id 772"
+msgid "Audio output"
+msgstr "Звучни излаз"
+
+#: id:773
+msgid "Seeking"
+msgstr "Позиционирање"
+
+#: id:774
+msgid "Slideshow folder"
+msgstr "Фасцикла репрод. слајдова"
+
+#: id:775
+msgid "Network interface"
+msgstr "Мрежни интерфејс"
+
+#: id:776
+msgid "- Wireless network name (ESSID)"
+msgstr "- Име бежичне мреже (ESSID)"
+
+#: id:777
+msgid "- Wireless password"
+msgstr "- Лозинка за приступ бежичној мрежи"
+
+#: id:778
+msgid "- Wireless security"
+msgstr "- Безбедност бежичне мреже"
+
+#: id:779
+msgid "Save and apply network interface settings"
+msgstr "Сачувај и примени поставке мрежног интрефејса"
+
+#: id:780
+msgid "No encryption"
+msgstr "Без заштите"
+
+#: id:781
+msgid "WEP"
+msgstr "WEP"
+
+#: id:782
+msgid "WPA"
+msgstr "WPA"
+
+#: id:783
+msgid "WPA2"
+msgstr "WPA2"
+
+#: id:784
+msgid "Applying network interface settings. Please wait."
+msgstr "Примењивање поставки мрежног интерфејса. Молимо сачекајте."
+
+#: id:785
+msgid "Network interface restarted successfully."
+msgstr "Успешно је обављено поновно покретање мрежног интерфејса."
+
+#: id:786
+msgid "Network interface did not start successfully."
+msgstr "Није успело покретање мрежног интерфејса."
+
+#: id:787
+msgid "Interface disabled"
+msgstr "Интерфејс је онемогућен"
+
+#: id:788
+msgid "Network interface disabled successfully."
+msgstr "Успешно је онемогућен мрежни интерфејс."
+
+#: id:789
+msgid "Wireless network name (ESSID)"
+msgstr "Име бежичне мреже (ESSID)"
+
+#: id:790
+msgid "Remote control"
+msgstr ""
+
+#: id:791
+msgid "Allow programs on this system to control XBMC"
+msgstr "Дозволи програмима на овом систему да управљају XBMC-ом"
+
+#: id:792
+msgctxt "Auto context with id 792"
+msgid "Port"
+msgstr "Прикључак"
+
+#: id:793
+msgid "Port range"
+msgstr "Опсег прикључака"
+
+#: id:794
+msgid "Allow programs on other systems to control XBMC"
+msgstr "Дозволи програмима са других система да управљају XBMC-ом"
+
+#: id:795
+msgid "Initial repeat delay (ms)"
+msgstr "Иницијално кашњење понављања (ms)"
+
+#: id:796
+msgid "Continuous repeat delay (ms)"
+msgstr "Непрекидно кашњење понављања (ms)"
+
+#: id:797
+msgid "Maximum number of clients"
+msgstr "Максималан број клијената"
+
+#: id:798
+msgid "Internet access"
+msgstr "Приступ Интернету"
+
+#: id:850
+msgid "Invalid port number entered"
+msgstr "Унели сте погрешан број прикључка"
+
+#: id:851
+msgid "Valid port range is 1-65535"
+msgstr "Исправан опсег прикључака је од 1 до 65535"
+
+#: id:852
+msgid "Valid port range is 1024-65535"
+msgstr "Исправан опсег прикључака је од 1024 до 65535"
+
+#: id:998
+msgid "Add Music..."
+msgstr ""
+
+#: id:999
+msgid "Add Videos..."
+msgstr ""
+
+#: id:1000
+msgid "- Preview"
+msgstr "Преглед чувара екрана"
+
+#: id:1001
+msgid "Unable to connect"
+msgstr "Није могуће повезивање"
+
+#: id:1002
+msgid "XBMC was unable to connect to the network location."
+msgstr "XBMC није успео да се повеже на мрежну локацију."
+
+#: id:1003
+msgid "This could be due to the network not being connected."
+msgstr "Разлог овоме може бити да мрежа није повезана."
+
+#: id:1004
+msgid "Would you like to add it anyway?"
+msgstr "Да ли и даље желите да је додате?"
+
+#: id:1006
+msgctxt "Auto context with id 1006"
+msgid "IP address"
+msgstr "IP адреса"
+
+#: id:1007
+msgid "Add network location"
+msgstr "Додај мрежну локацију"
+
+#: id:1008
+msgid "Protocol"
+msgstr "Протокол"
+
+#: id:1009
+msgid "Server address"
+msgstr "Адреса сервера"
+
+#: id:1010
+msgid "Server name"
+msgstr "Име сервера"
+
+#: id:1011
+msgid "Remote path"
+msgstr "Удаљена путања"
+
+#: id:1012
+msgid "Shared folder"
+msgstr "Дељена фасцикла"
+
+#: id:1013
+msgctxt "Auto context with id 1013"
+msgid "Port"
+msgstr "Прикључак"
+
+#: id:1014
+msgctxt "Auto context with id 1014"
+msgid "Username"
+msgstr "Корисничко име"
+
+#: id:1015
+msgid "Browse for network server"
+msgstr "Потражи мрежни сервер"
+
+#: id:1016
+msgid "Enter the network address of the server"
+msgstr "Унесите мрежну адресу сервера"
+
+#: id:1017
+msgid "Enter the path on the server"
+msgstr "Унесите путању на серверу"
+
+#: id:1018
+msgid "Enter the port number"
+msgstr "Унесите број прикључка"
+
+#: id:1019
+msgid "Enter the username"
+msgstr "Унесите корисничко име"
+
+#: id:1020
+msgid "Add %s source"
+msgstr "Додај %s извор"
+
+#: id:1021
+msgid "Enter the paths or browse for the media locations."
+msgstr "Унесите путање или потражите локације медија."
+
+#: id:1022
+msgid "Enter a name for this media Source."
+msgstr "Унесите име за овај извор медија."
+
+#: id:1023
+msgid "Browse for new share"
+msgstr "Потражи ново дељење"
+
+#: id:1024
+msgid "Browse"
+msgstr "Потражи"
+
+#: id:1025
+msgid "Could not retrieve directory information."
+msgstr "Није могуће преузети податке директоријума."
+
+#: id:1026
+msgid "Add source"
+msgstr "Додај извор"
+
+#: id:1027
+msgid "Edit source"
+msgstr "Уреди извор"
+
+#: id:1028
+msgid "Edit %s source"
+msgstr "Уреди %s извор"
+
+#: id:1029
+msgid "Enter the new label"
+msgstr "Унеси нову ознаку"
+
+#: id:1030
+msgid "Browse for image"
+msgstr "Потражи слику"
+
+#: id:1031
+msgid "Browse for image folder"
+msgstr "Потражи фасциклу са сликама"
+
+#: id:1032
+msgid "Add network location..."
+msgstr "Додај мрежну локацију..."
+
+#: id:1033
+msgid "Browse for file"
+msgstr "Потражи датотеку"
+
+#: id:1034
+msgid "Submenu"
+msgstr "Подмени"
+
+#: id:1035
+msgid "Enable submenu buttons"
+msgstr "Омогући тастере подменија"
+
+#: id:1036
+msgid "Favourites"
+msgstr "Омиљено"
+
+#: id:1037
+msgid "Video Add-ons"
+msgstr "Додаци за видео"
+
+#: id:1038
+msgid "Music Add-ons"
+msgstr "Додаци за музику"
+
+#: id:1039
+msgid "Picture Add-ons"
+msgstr "Додаци за слику"
+
+#: id:1040
+msgid "Loading directory"
+msgstr "Учитавање директоријума"
+
+#: id:1041
+msgid "Retrieved %i items"
+msgstr "Примљено %i ставки"
+
+#: id:1042
+msgid "Retrieved %i of %i items"
+msgstr "Примљено %i од %i ставки"
+
+#: id:1043
+msgid "Program Add-ons"
+msgstr "Додаци за програм"
+
+#: id:1044
+msgid "Set plugin thumb"
+msgstr "Постави сличицу додатка"
+
+#: id:1045
+msgid "Add-on settings"
+msgstr "Поставке додатка"
+
+#: id:1046
+msgid "Access points"
+msgstr "Приступна тачка"
+
+#: id:1047
+msgid "Other..."
+msgstr "Остало..."
+
+#: id:1048
+msgid "- Username"
+msgstr "- Корисничко име"
+
+#: id:1049
+msgid "Script settings"
+msgstr "Поставке скрипте"
+
+#: id:1050
+msgid "Singles"
+msgstr "Појединачни"
+
+#: id:1051
+msgid "Enter web address"
+msgstr "Унесите интернет адресу"
+
+#: id:1200
+msgid "SMB client"
+msgstr "SMB клијент"
+
+#: id:1202
+msgid "Workgroup"
+msgstr "Радна група"
+
+#: id:1203
+msgid "Default username"
+msgstr "Подразумевано корисничко име"
+
+#: id:1204
+msgid "Default password"
+msgstr "Подразумевана лозинка"
+
+#: id:1207
+msgid "WINS server"
+msgstr "WINS сервер"
+
+#: id:1208
+msgid "Mount SMB shares"
+msgstr "Подигни SMB дељења"
+
+#: id:1210
+msgctxt "Auto context with id 1210"
+msgid "Remove"
+msgstr "Уклони"
+
+#: id:1211
+msgctxt "Auto context with id 1211"
+msgid "Music"
+msgstr "Музика"
+
+#: id:1212
+msgctxt "Auto context with id 1212"
+msgid "Video"
+msgstr "Филмови"
+
+#: id:1213
+msgctxt "Auto context with id 1213"
+msgid "Pictures"
+msgstr "Слике"
+
+#: id:1214
+msgctxt "Auto context with id 1214"
+msgid "Files"
+msgstr "Датотеке"
+
+#: id:1215
+msgctxt "Auto context with id 1215"
+msgid "Music & video"
+msgstr "Музика и филмови"
+
+#: id:1216
+msgid "Music & pictures"
+msgstr "Музика и слике"
+
+#: id:1217
+msgid "Music & files"
+msgstr "Музика и датотеке"
+
+#: id:1218
+msgid "Video & pictures"
+msgstr "Филмови и слике"
+
+#: id:1219
+msgid "Video & files"
+msgstr "Филмови и датотеке"
+
+#: id:1220
+msgid "Pictures & files"
+msgstr "Слике и датотеке"
+
+#: id:1221
+msgid "Music & video & pictures"
+msgstr "Музика, филмови и слике"
+
+#: id:1222
+msgid "Music & video & pictures & files"
+msgstr "Музика, филмови, слике и датотеке"
+
+#: id:1223
+msgctxt "Auto context with id 1223"
+msgid "Disabled"
+msgstr "Онемогућено"
+
+#: id:1226
+msgid "Files & music & video"
+msgstr "Датотеке, музика и филмови"
+
+#: id:1227
+msgid "Files & pictures & music"
+msgstr "Датотеке, слике и музика"
+
+#: id:1228
+msgid "Files & pictures & video"
+msgstr "Датотеке, слике и филмови"
+
+#: id:1229
+msgid "Music & programs"
+msgstr "Музика и програми"
+
+#: id:1230
+msgid "Video & programs"
+msgstr "Филмови и програми"
+
+#: id:1231
+msgid "Pictures & programs"
+msgstr "Слике и програми"
+
+#: id:1232
+msgid "Music & video & pictures & programs"
+msgstr "Музика, филмови, слике и програми"
+
+#: id:1233
+msgid "Programs & video & music"
+msgstr "Програми, филмови и музика"
+
+#: id:1234
+msgid "Programs & pictures & music"
+msgstr "Програми, слике и музика"
+
+#: id:1235
+msgid "Programs & pictures & video"
+msgstr "Програми, слике и филмови"
+
+#: id:1250
+msgid "Auto-detection"
+msgstr "Аутом. откривање"
+
+#: id:1251
+msgid "Auto-detect system"
+msgstr "Аутом. откривање система"
+
+#: id:1252
+msgid "Nickname"
+msgstr "Надимак"
+
+#: id:1254
+msgid "Ask to connect"
+msgstr "Питај за повезивање"
+
+#: id:1255
+msgid "Send FTP user and password"
+msgstr "Пошаљи FTP корисничко име и лозинку"
+
+#: id:1256
+msgid "Ping interval"
+msgstr "Интервал пробног сигнала"
+
+#: id:1257
+msgid "Would you like to connect to the auto-detected system?"
+msgstr "Желите ли да се повежете са аутом. откривањем система?"
+
+#: id:1259
+msgid "Zeroconf"
+msgstr ""
+
+#: id:1260
+msgid "Announce these services to other systems via Zeroconf"
+msgstr "Огласи ове услуге осталим системима путем Zeroconf"
+
+#: id:1270
+msgid "Allow XBMC to receive AirPlay content"
+msgstr ""
+
+#: id:1271
+msgid "Device name"
+msgstr ""
+
+#: id:1272
+msgid "- Use password protection"
+msgstr ""
+
+#: id:1273
+msgid "AirPlay"
+msgstr ""
+
+#: id:1300
+msgid "Custom audio device"
+msgstr "Прилагођен звучни уређај"
+
+#: id:1301
+msgid "Custom passthrough device"
+msgstr "Прилагођен пролазни уређај"
+
+#: id:1396
+msgid "Drifting"
+msgstr "клизаво"
+
+#: id:1397
+msgid "and"
+msgstr "и"
+
+#: id:1398
+msgid "Freezing"
+msgstr "поледица"
+
+#: id:1399
+msgid "Late"
+msgstr "закаснели"
+
+#: id:1400
+msgid "Isolated"
+msgstr "изоловани"
+
+#: id:1401
+msgid "Thundershowers"
+msgstr "пљускови са грмљавином"
+
+#: id:1402
+msgid "Thunder"
+msgstr "грмљавина"
+
+#: id:1403
+msgctxt "Auto context with id 1403"
+msgid "Sun"
+msgstr "сунчано"
+
+#: id:1404
+msgid "Heavy"
+msgstr "јак(а)"
+
+#: id:1405
+msgid "in"
+msgstr "у"
+
+#: id:1406
+msgid "the"
+msgstr ""
+
+#: id:1407
+msgid "Vicinity"
+msgstr "близини"
+
+#: id:1408
+msgid "Ice"
+msgstr "лед"
+
+#: id:1409
+msgid "Crystals"
+msgstr "кристали"
+
+#: id:1410
+msgid "Calm"
+msgstr "благо"
+
+#: id:1411
+msgid "with"
+msgstr "са"
+
+#: id:1412
+msgid "windy"
+msgstr "ветровито"
+
+#: id:1413
+msgid "drizzle"
+msgstr "ромињање"
+
+#: id:1414
+msgid "Thunderstorm"
+msgstr "олуја"
+
+#: id:1415
+msgid "Drizzle"
+msgstr "ромињање"
+
+#: id:1416
+msgid "Foggy"
+msgstr "магловито"
+
+#: id:1417
+msgid "Grains"
+msgstr "град"
+
+#: id:1418
+msgid "T-Storms"
+msgstr "олује"
+
+#: id:1419
+msgid "T-Showers"
+msgstr "пљускови са грмљавином"
+
+#: id:1420
+msgid "Moderate"
+msgstr ""
+
+#: id:1421
+msgid "Very High"
+msgstr ""
+
+#: id:1422
+msgid "Windy"
+msgstr ""
+
+#: id:1423
+msgid "Mist"
+msgstr ""
+
+#: id:1450
+msgid "Put display to sleep when idle"
+msgstr "Постави екран „на спавање“, када се не користи"
+
+#: id:2050
+msgid "Runtime"
+msgstr "Трајање"
+
+#: id:2100
+msgid "Script failed! : %s"
+msgstr "Скрипта је „пукла“! : %s"
+
+#: id:2101
+msgid "Newer version needed - See log"
+msgstr ""
+
+#: id:4501
+msgid "Enable LCD/VFD"
+msgstr "Омогући LCD/VFD"
+
+#: id:10000
+msgid "Home"
+msgstr "Почетна страна"
+
+#: id:10001
+msgctxt "Auto context with id 10001"
+msgid "Programs"
+msgstr "Програми"
+
+#: id:10002
+msgctxt "Auto context with id 10002"
+msgid "Pictures"
+msgstr "Слике"
+
+#: id:10003
+msgctxt "Auto context with id 10003"
+msgid "File manager"
+msgstr "Упр. датотекама"
+
+#: id:10004
+msgctxt "Auto context with id 10004"
+msgid "Settings"
+msgstr "Поставке"
+
+#: id:10005
+msgctxt "Auto context with id 10005"
+msgid "Music"
+msgstr "Музика"
+
+#: id:10006
+msgctxt "Auto context with id 10006"
+msgid "Videos"
+msgstr "Филмови"
+
+#: id:10007
+msgid "System information"
+msgstr "Подаци о систему"
+
+#: id:10008
+msgid "Settings - General"
+msgstr "Поставке - Опште"
+
+#: id:10009
+msgid "Settings - Screen"
+msgstr "Поставке - Екран"
+
+#: id:10010
+msgid "Settings - Appearance - GUI Calibration"
+msgstr "Поставке - Изглед - GUI калибрација"
+
+#: id:10011
+msgid "Settings - Videos - Screen Calibration"
+msgstr "Поставке - Филмови - Калибрација екрана"
+
+#: id:10012
+msgid "Settings - Pictures"
+msgstr "Поставке - Слике"
+
+#: id:10013
+msgid "Settings - Programs"
+msgstr "Поставке - Програми"
+
+#: id:10014
+msgid "Settings - Weather"
+msgstr "Поставке - Временска прогноза"
+
+#: id:10015
+msgid "Settings - Music"
+msgstr "Поставке - Музика"
+
+#: id:10016
+msgid "Settings - System"
+msgstr "Поставке - Систем"
+
+#: id:10017
+msgid "Settings - Videos"
+msgstr "Поставке - Филмови"
+
+#: id:10018
+msgid "Settings - Network"
+msgstr "Поставке - Мрежа"
+
+#: id:10019
+msgid "Settings - Appearance"
+msgstr "Поставке - Изглед"
+
+#: id:10020
+msgctxt "Auto context with id 10020"
+msgid "Scripts"
+msgstr "Скрипте"
+
+#: id:10021
+msgid "Web Browser"
+msgstr "Читач интернет страна"
+
+#: id:10025
+msgctxt "Auto context with id 10025"
+msgid "Videos"
+msgstr ""
+
+#: id:10028
+msgid "Videos/Playlist"
+msgstr "Филмови/Списак за реп."
+
+#: id:10029
+msgctxt "Auto context with id 10029"
+msgid "Login screen"
+msgstr ""
+
+#: id:10034
+msgid "Settings - Profiles"
+msgstr "Поставке - Профили"
+
+#: id:10040
+msgid "Addon browser"
+msgstr ""
+
+#: id:10100
+msgid "Yes/No dialog"
+msgstr "Да/Не прозор"
+
+#: id:10101
+msgid "Progress dialog"
+msgstr "Прозор напретка"
+
+#: id:10210
+msgid "Looking for subtitles..."
+msgstr "Тражење титлова..."
+
+#: id:10211
+msgid "Looking for or caching subtitles..."
+msgstr "Тражење титлова у кешу..."
+
+#: id:10212
+msgid "terminating"
+msgstr "прекидање"
+
+#: id:10213
+msgid "buffering"
+msgstr "предмеморисање"
+
+#: id:10214
+msgid "Opening stream"
+msgstr "Отварање записа"
+
+#: id:10500
+msgid "Music/Playlist"
+msgstr "Музика/Списак за репрод."
+
+#: id:10501
+msgid "Music/Files"
+msgstr "Музика/Датотеке"
+
+#: id:10502
+msgid "Music/Library"
+msgstr "Музика/Библиотека"
+
+#: id:10503
+msgid "Playlist editor"
+msgstr "Уређивач списка за репродукцију"
+
+#: id:10504
+msgid "Top 100 songs"
+msgstr "100 најбољих песама"
+
+#: id:10505
+msgid "Top 100 albums"
+msgstr "100 најбољих албума"
+
+#: id:10506
+msgctxt "Auto context with id 10506"
+msgid "Programs"
+msgstr "Програми"
+
+#: id:10507
+msgid "Configuration"
+msgstr "Конфигурација"
+
+#: id:10508
+msgid "Weather forecast"
+msgstr "Временска прогноза"
+
+#: id:10509
+msgid "Network gaming"
+msgstr "Мрежно играње"
+
+#: id:10510
+msgid "Extensions"
+msgstr "Проширења"
+
+#: id:10511
+msgctxt "Auto context with id 10511"
+msgid "System info"
+msgstr "Подаци о систему"
+
+#: id:10516
+msgid "Music - Library"
+msgstr "Музичка библиоте."
+
+#: id:10517
+msgid "Now Playing - Music"
+msgstr "Тренутна репродукција - Музика"
+
+#: id:10522
+msgid "Now Playing - Videos"
+msgstr "Тренутна репродукција - Филм"
+
+#: id:10523
+msgid "Album info"
+msgstr "Подаци о албуму"
+
+#: id:10524
+msgid "Movie info"
+msgstr "Подаци о филму"
+
+#: id:12000
+msgid "Select dialog"
+msgstr "Изаберите дијалог"
+
+#: id:12001
+msgid "Music/Info"
+msgstr "Музика/Подаци"
+
+#: id:12002
+msgid "Dialog OK"
+msgstr "Дијалог у реду"
+
+#: id:12003
+msgid "Videos/Info"
+msgstr "Филмови/Подаци"
+
+#: id:12004
+msgid "Scripts/Info"
+msgstr "Скрипте/Подаци"
+
+#: id:12005
+msgid "Fullscreen video"
+msgstr "Филм преко читавог екрана"
+
+#: id:12006
+msgid "Audio visualization"
+msgstr "Визуализација звука"
+
+#: id:12008
+msgid "File stacking dialog"
+msgstr "Дијалог слагања датотека"
+
+#: id:12009
+msgid "Rebuild index..."
+msgstr "Реиндексирање..."
+
+#: id:12010
+msgid "Return to music window"
+msgstr "Повратак на прозор са музиком"
+
+#: id:12011
+msgid "Return to videos window"
+msgstr "Повратак на прозор са филмовима"
+
+#: id:12021
+msgid "Start from beginning"
+msgstr "Почни испочетка"
+
+#: id:12022
+msgid "Resume from %s"
+msgstr "Настави од %s"
+
+#: id:12310
+msgid "0"
+msgstr "0"
+
+#: id:12311
+msgid "1"
+msgstr "1"
+
+#: id:12312
+msgid "2"
+msgstr "2"
+
+#: id:12313
+msgid "3"
+msgstr "3"
+
+#: id:12314
+msgid "4"
+msgstr "4"
+
+#: id:12315
+msgid "5"
+msgstr "5"
+
+#: id:12316
+msgid "6"
+msgstr "6"
+
+#: id:12317
+msgid "7"
+msgstr "7"
+
+#: id:12318
+msgid "8"
+msgstr "8"
+
+#: id:12319
+msgid "9"
+msgstr "9"
+
+#: id:12320
+msgid "c"
+msgstr "c"
+
+#: id:12321
+msgid "Ok"
+msgstr "У реду"
+
+#: id:12322
+msgid "*"
+msgstr "*"
+
+#: id:12325
+msgid "Locked! Enter code..."
+msgstr "Закључано! Унесите кôд..."
+
+#: id:12326
+msgid "Enter password"
+msgstr "Унесите лозинку"
+
+#: id:12327
+msgid "Enter master code"
+msgstr "Унесите главни кôд"
+
+#: id:12328
+msgid "Enter unlock code"
+msgstr "Унесите кôд за откључавање"
+
+#: id:12329
+msgid "or press C to cancel"
+msgstr "или притисните C за отказивање"
+
+#: id:12330
+msgid "Enter gamepad button combo and"
+msgstr "Унесите комбинацију тастера управљача за игре"
+
+#: id:12331
+msgid "press OK, or Back to cancel"
+msgstr "и притисните Старт, или Назад за отказивање"
+
+#: id:12332
+msgid "Set lock"
+msgstr "Закључај"
+
+#: id:12333
+msgid "Unlock"
+msgstr "Откључај"
+
+#: id:12334
+msgid "Reset lock"
+msgstr "Поништи кôд"
+
+#: id:12335
+msgid "Remove lock"
+msgstr "Уклони кôд"
+
+#: id:12337
+msgid "Numeric password"
+msgstr "Нумеричка лозинка"
+
+#: id:12338
+msgid "Gamepad button combo"
+msgstr "Комбинација тастера управљача за игре"
+
+#: id:12339
+msgid "Full-text password"
+msgstr "Лозинка са свим знацима"
+
+#: id:12340
+msgid "Enter new password"
+msgstr "Унесите нову лозинку"
+
+#: id:12341
+msgid "Re-Enter new password"
+msgstr "Поновите унос нове лозинке"
+
+#: id:12342
+msgid "Incorrect password,"
+msgstr "Лозинка није исправна,"
+
+#: id:12343
+msgid "retries left"
+msgstr "покушаја су преостала"
+
+#: id:12344
+msgid "Passwords entered did not match."
+msgstr "Унете лозинке се не поклапају."
+
+#: id:12345
+msgid "Access denied"
+msgstr "Приступ одбијен"
+
+#: id:12346
+msgid "Password retry limit exceeded."
+msgstr "Прекомерни број покушаја уноса лозинке."
+
+#: id:12347
+msgid "The system will now shut off."
+msgstr "Систем ће сада бити искључен."
+
+#: id:12348
+msgid "Item locked"
+msgstr "Ставка је закључана"
+
+#: id:12353
+msgid "Reactivate lock"
+msgstr "Поново активирај кôд"
+
+#: id:12356
+msgid "Change lock"
+msgstr "Промени кôд"
+
+#: id:12357
+msgid "Source lock"
+msgstr "Порекло кôда"
+
+#: id:12358
+msgid "Password entry was blank. Try again."
+msgstr "Лозинка не може бити празна. Покушајте поново."
+
+#: id:12360
+msgid "Master lock"
+msgstr "Главни кôд"
+
+#: id:12362
+msgid "Shutdown system if Master Lock retries exceeded"
+msgstr "Искључи систем уколико Главни кôд више пута буде погрешно унет"
+
+#: id:12367
+msgid "Master code is not valid"
+msgstr "Главни кôд није исправан"
+
+#: id:12368
+msgid "Please enter a valid master code"
+msgstr "Молимо, унесите исправан главни кôд"
+
+#: id:12373
+msgid "Settings & file manager"
+msgstr "Поставке и упр. датотекама"
+
+#: id:12376
+msgid "Set as default for all movies"
+msgstr "Постави као подразумевано за све филмове"
+
+#: id:12377
+msgid "This will reset any previously saved values"
+msgstr "Ово ће поништити претходно сачуване вредности"
+
+#: id:12378
+msgid "Amount of time to display each image"
+msgstr "Време приказивања сваке слике"
+
+#: id:12379
+msgid "Use pan and zoom effects"
+msgstr "Користи ефекат померања и увеличавања"
+
+#: id:12383
+msgid "12 hour clock"
+msgstr "12 часовни приказ времена"
+
+#: id:12384
+msgid "24 hour clock"
+msgstr "24 часовни приказ времена"
+
+#: id:12385
+msgid "Day/Month"
+msgstr "Дан, па месец"
+
+#: id:12386
+msgid "Month/Day"
+msgstr "Месец, па дан"
+
+#: id:12390
+msgid "System uptime"
+msgstr "Систем је активан"
+
+#: id:12391
+msgid "Minutes"
+msgstr "минута"
+
+#: id:12392
+msgid "Hours"
+msgstr "часова"
+
+#: id:12393
+msgid "Days"
+msgstr "дана"
+
+#: id:12394
+msgid "Total uptime"
+msgstr "Укупно време"
+
+#: id:12395
+msgid "Battery level"
+msgstr ""
+
+#: id:12600
+msgctxt "Auto context with id 12600"
+msgid "Weather"
+msgstr "Временска прогноза"
+
+#: id:12900
+msgctxt "Auto context with id 12900"
+msgid "Screensaver"
+msgstr "Чувар екрана"
+
+#: id:12901
+msgid "Fullscreen OSD"
+msgstr "OSD преко читавог екрана"
+
+#: id:13000
+msgid "System"
+msgstr "Систем"
+
+#: id:13001
+msgid "Immediate HD spindown"
+msgstr "Непосредно HD ротирање"
+
+#: id:13002
+msgid "Video only"
+msgstr "Само филмови"
+
+#: id:13003
+msgid "- Delay"
+msgstr "- Кашњење"
+
+#: id:13004
+msgid "- Minimum file duration"
+msgstr "- Минимално трајање датотеке"
+
+#: id:13005
+msgid "Shutdown"
+msgstr "Искључи"
+
+#: id:13008
+msgid "Shutdown function"
+msgstr "Акција при искључивању"
+
+#: id:13009
+msgid "Quit"
+msgstr "Изађи"
+
+#: id:13010
+msgid "Hibernate"
+msgstr "Хибернација"
+
+#: id:13011
+msgid "Suspend"
+msgstr "Стање спавања"
+
+#: id:13012
+msgid "Exit"
+msgstr "Изађи из"
+
+#: id:13013
+msgid "Reboot"
+msgstr "Поново покрени"
+
+#: id:13014
+msgid "Minimize"
+msgstr "Умањи"
+
+#: id:13015
+msgid "Power button action"
+msgstr "Акција дугмета за укључивање"
+
+#: id:13016
+msgid "Power off System"
+msgstr ""
+
+#: id:13020
+msgid "Is another session active, perhaps over ssh?"
+msgstr "Да ли је друга сесија активна, можда путем ssh?"
+
+#: id:13021
+msgid "Mounted removable harddrive"
+msgstr "Постављен преносиви чврсти уређај"
+
+#: id:13022
+msgid "Unsafe device removal"
+msgstr "Небезбедно уклањање уређаја"
+
+#: id:13023
+msgid "Successfully removed device"
+msgstr "Успешно уклоњен уређај"
+
+#: id:13024
+msgid "Joystick plugged"
+msgstr "Управљачка палица је прикључена"
+
+#: id:13025
+msgid "Joystick unplugged"
+msgstr "Управљачка палица је раскачена"
+
+#: id:13050
+msgid "Running low on battery"
+msgstr ""
+
+#: id:13100
+msgid "Flicker filter"
+msgstr "Flicker филтер"
+
+#: id:13101
+msgid "Let driver choose (requires restart)"
+msgstr "Препусти избор управ. програму (неопходно поновно покретање)"
+
+#: id:13105
+msgid "Vertical blank sync"
+msgstr "Размак вертикалне синхронизације"
+
+#: id:13106
+msgctxt "Auto context with id 13106"
+msgid "Disabled"
+msgstr "Онемогућено"
+
+#: id:13107
+msgid "Enabled during video playback"
+msgstr "Омогућено током репродукције филма"
+
+#: id:13108
+msgctxt "Auto context with id 13108"
+msgid "Always enabled"
+msgstr "Увек је омогућено"
+
+#: id:13109
+msgid "Test & apply resolution"
+msgstr "Испробај и примени резолуцију"
+
+#: id:13110
+msgid "Save resolution?"
+msgstr "Сачувати резолуцију?"
+
+#: id:13111
+msgid "Would you like to keep this resolution?"
+msgstr "Желите ли да задржите ову резолуцију?"
+
+#: id:13112
+msgid "High quality upscaling"
+msgstr "Висок квалитет увећања"
+
+#: id:13113
+msgctxt "Auto context with id 13113"
+msgid "Disabled"
+msgstr "Онемогућен"
+
+#: id:13114
+msgid "Enabled for SD content"
+msgstr "Омогућен за SD садржај"
+
+#: id:13115
+msgctxt "Auto context with id 13115"
+msgid "Always enabled"
+msgstr "Увек је омогућен"
+
+#: id:13116
+msgid "Upscaling method"
+msgstr "Начин увећања"
+
+#: id:13117
+msgctxt "Auto context with id 13117"
+msgid "Bicubic"
+msgstr "Bicubic"
+
+#: id:13118
+msgid "Lanczos"
+msgstr "Lanczos"
+
+#: id:13119
+msgid "Sinc"
+msgstr "Sinc"
+
+#: id:13120
+msgctxt "Auto context with id 13120"
+msgid "VDPAU"
+msgstr "VDPAU"
+
+#: id:13121
+msgid "VDPAU HQ Upscaling level"
+msgstr "VDPAU HQ Upscaling level"
+
+#: id:13122
+msgid "VDPAU Studio level color conversion"
+msgstr "VDPAU Studio level color conversion"
+
+#: id:13130
+msgid "Blank other displays"
+msgstr "Зацрни остале екране"
+
+#: id:13131
+msgctxt "Auto context with id 13131"
+msgid "Disabled"
+msgstr "Онемогућено"
+
+#: id:13132
+msgid "Blank displays"
+msgstr "Зацрни екране"
+
+#: id:13140
+msgid "Active connections detected!"
+msgstr "Откривене су активне везе!"
+
+#: id:13141
+msgid "If you proceed, you might not be able to control XBMC"
+msgstr "Уколико наставите даље, можда нећете моћи да управљате XBMC"
+
+#: id:13142
+msgid "any longer. Are you sure you want to stop the Event server?"
+msgstr "апликацијом. Да ли сте сигурни да желите да зауставите Сервер за догађаје?"
+
+#: id:13144
+msgid "Change Apple Remote mode?"
+msgstr "Промени Apple Remote режим?"
+
+#: id:13145
+msgid "If you are currently using the Apple Remote to control"
+msgstr "Уколико тренутно користите Apple Remote да управљате"
+
+#: id:13146
+msgid "XBMC, changing this setting might affect your ability"
+msgstr "XBMC апликацијом, променом ове поставаке можда промените"
+
+#: id:13147
+msgid "to continue controlling it. Do you want to proceed?"
+msgstr "могућност контролисања апликације. Настављате ли даље?"
+
+#: id:13159
+msgid "Subnet mask"
+msgstr "Мрежна подмаска"
+
+#: id:13160
+msgid "Gateway"
+msgstr "Мрежни пролаз"
+
+#: id:13161
+msgid "Primary DNS"
+msgstr "Примарни DNS"
+
+#: id:13162
+msgid "Initialize failed"
+msgstr "Није успела иницијализација"
+
+#: id:13170
+msgctxt "Auto context with id 13170"
+msgid "Never"
+msgstr "Никада"
+
+#: id:13171
+msgid "Immediately"
+msgstr "Одмах"
+
+#: id:13172
+msgid "After %i secs"
+msgstr "Након %i сек."
+
+#: id:13173
+msgid "HDD install date:"
+msgstr "Датум постављања HDD-а:"
+
+#: id:13174
+msgid "HDD power cycle count:"
+msgstr "HDD power cycle count:"
+
+#: id:13200
+msgid "Profiles"
+msgstr "Профили"
+
+#: id:13201
+msgid "Delete profile '%s'?"
+msgstr "Избрисати „%s“ профил?"
+
+#: id:13204
+msgid "Last loaded profile:"
+msgstr "Последњи учитан профил:"
+
+#: id:13205
+msgid "Unknown"
+msgstr "Непознато"
+
+#: id:13206
+msgid "Overwrite"
+msgstr "Препиши"
+
+#: id:13208
+msgid "Alarm clock"
+msgstr "Будилник"
+
+#: id:13209
+msgid "Alarm clock interval (in minutes)"
+msgstr "Интервал за поновну активацију будилника(у мин.)"
+
+#: id:13210
+msgid "Started, alarm in %im"
+msgstr "Покренуто, аларм за %im"
+
+#: id:13211
+msgid "Alarm!"
+msgstr "Аларм!"
+
+#: id:13212
+msgid "Canceled with %im%is left"
+msgstr "Отказано при %iмин. %iсек. до краја"
+
+#: id:13213
+msgid "%2.0fm"
+msgstr ""
+
+#: id:13214
+msgid "%2.0fs"
+msgstr ""
+
+#: id:13249
+msgid "Search for subtitles in RARs"
+msgstr "Претражи титлове у RAR-овима"
+
+#: id:13250
+msgid "Browse for subtitle..."
+msgstr "Потражи титл..."
+
+#: id:13251
+msgid "Move item"
+msgstr "Премести ставку"
+
+#: id:13252
+msgid "Move item here"
+msgstr "Премести ставку овде"
+
+#: id:13253
+msgid "Cancel move"
+msgstr "Откажи премештање"
+
+#: id:13270
+msgid "Hardware:"
+msgstr "Хардвер:"
+
+#: id:13271
+msgid "CPU Usage:"
+msgstr "Искоришћеност процесора:"
+
+#: id:13274
+msgid "Connected, but no DNS is available."
+msgstr "Повезано, али DNS није доступан."
+
+#: id:13275
+msgid "Hard Disk"
+msgstr "Чврсти диск"
+
+#: id:13276
+msgid "DVD-ROM"
+msgstr "DVD-ROM"
+
+#: id:13277
+msgctxt "Auto context with id 13277"
+msgid "Storage"
+msgstr "Складиште"
+
+#: id:13278
+msgctxt "Auto context with id 13278"
+msgid "Default"
+msgstr "Подразумевано"
+
+#: id:13279
+msgctxt "Auto context with id 13279"
+msgid "Network"
+msgstr "Мрежа"
+
+#: id:13280
+msgctxt "Auto context with id 13280"
+msgid "Video"
+msgstr "Видео"
+
+#: id:13281
+msgid "Hardware"
+msgstr "Хардвер"
+
+#: id:13283
+msgid "Operating system:"
+msgstr "Оперативни систем:"
+
+#: id:13284
+msgid "CPU speed:"
+msgstr "Брзина процесора:"
+
+#: id:13286
+msgid "Video encoder:"
+msgstr "Видео кодер:"
+
+#: id:13287
+msgid "Screen resolution:"
+msgstr "Резолуција екрана:"
+
+#: id:13292
+msgid "A/V cable:"
+msgstr "A/V кабл:"
+
+#: id:13294
+msgid "DVD region:"
+msgstr "DVD регија:"
+
+#: id:13295
+msgid "Internet:"
+msgstr "Интернет:"
+
+#: id:13296
+msgctxt "Auto context with id 13296"
+msgid "Connected"
+msgstr "Повезано"
+
+#: id:13297
+msgid "Not connected. Check network settings."
+msgstr "Није повезано. Проверите мрежне поставке."
+
+#: id:13299
+msgid "Target temperature"
+msgstr "Жељена температура"
+
+#: id:13300
+msgid "Fan speed"
+msgstr "Брзина вентилатора"
+
+#: id:13301
+msgid "Auto temperature control"
+msgstr "Аутомат. контролисање температуре"
+
+#: id:13302
+msgid "Fan speed override"
+msgstr "Наметни брзину вентилатора"
+
+#: id:13303
+msgid "- Fonts"
+msgstr "- Слова"
+
+#: id:13304
+msgid "Enable flipping bi-directional strings"
+msgstr "Омогући обртање би-дирекционих стрингова"
+
+#: id:13305
+msgid "Show RSS news feeds"
+msgstr "Прикажи RSS новости"
+
+#: id:13306
+msgid "Show parent folder items"
+msgstr "Прикажи ставке родитељске фасцикле"
+
+#: id:13307
+msgid "Track naming template"
+msgstr "Шаблон именовања нумера"
+
+#: id:13308
+msgid "Do you wish to reboot your system"
+msgstr "Желите ли да поново покренете"
+
+#: id:13309
+msgid "instead of just XBMC?"
+msgstr "цео систем, а не само XBMC апликацију?"
+
+#: id:13310
+msgid "Zoom effect"
+msgstr "Ефекат увеличавања"
+
+#: id:13311
+msgid "Float effect"
+msgstr "Ефекат плутања"
+
+#: id:13312
+msgid "Black bar reduction"
+msgstr "Смањење црних трака"
+
+#: id:13313
+msgid "Restart"
+msgstr "Поново покрени"
+
+#: id:13314
+msgid "Crossfade between songs"
+msgstr "Фини прелаз (преклапање) између песама"
+
+#: id:13315
+msgid "Regenerate thumbnails"
+msgstr "Обнављање сличица"
+
+#: id:13316
+msgid "Recursive thumbnails"
+msgstr "Рекурзивне сличице"
+
+#: id:13317
+msgid "View slideshow"
+msgstr "Прикажи репродук. слајдова"
+
+#: id:13318
+msgid "Recursive slideshow"
+msgstr "Рекурзивна репрод. слајдова"
+
+#: id:13319
+msgid "Randomize"
+msgstr "Насумично"
+
+#: id:13320
+msgid "Stereo"
+msgstr "Стерео"
+
+#: id:13321
+msgid "Left only"
+msgstr "Само леви"
+
+#: id:13322
+msgid "Right only"
+msgstr "Само десни"
+
+#: id:13323
+msgid "Enable karaoke support"
+msgstr "Омогући подршку за караоке"
+
+#: id:13324
+msgid "Background transparency"
+msgstr "Провидност позадине"
+
+#: id:13325
+msgid "Foreground transparency"
+msgstr "Провидност предњег плана"
+
+#: id:13326
+msgid "A/V delay"
+msgstr "A/V кашњење"
+
+#: id:13327
+msgid "Karaoke"
+msgstr "Караоке"
+
+#: id:13328
+msgid "%s not found"
+msgstr "%s није пронађен"
+
+#: id:13329
+msgid "Error opening %s"
+msgstr "Грешка приликом отварања %s"
+
+#: id:13330
+msgid "Unable to load %s"
+msgstr "Није могуће учитати %s"
+
+#: id:13331
+msgid "Error: Out of memory"
+msgstr "Грешка: Недовољно меморије"
+
+#: id:13332
+msgid "Move up"
+msgstr "Премести горе"
+
+#: id:13333
+msgid "Move down"
+msgstr "Премести доле"
+
+#: id:13334
+msgid "Edit label"
+msgstr "Уреди натпис"
+
+#: id:13335
+msgid "Make default"
+msgstr "Пост. подразумеваним"
+
+#: id:13336
+msgid "Remove button"
+msgstr "Уклони тастер"
+
+#: id:13340
+msgid "Leave as is"
+msgstr "Остави како јесте"
+
+#: id:13341
+msgid "Green"
+msgstr "Зелена"
+
+#: id:13342
+msgid "Orange"
+msgstr "Наранџаста"
+
+#: id:13343
+msgid "Red"
+msgstr "Црвена"
+
+#: id:13344
+msgid "Cycle"
+msgstr "Циклус"
+
+#: id:13345
+msgid "Switch LED off on playback"
+msgstr "Искључи LED приликом репродукције"
+
+#: id:13346
+msgctxt "Auto context with id 13346"
+msgid "Movie information"
+msgstr "Подаци о филму"
+
+#: id:13347
+msgid "Queue item"
+msgstr "Стави у ред за репрод."
+
+#: id:13348
+msgid "Search IMDb..."
+msgstr "Претражи IMDb..."
+
+#: id:13349
+msgid "Scan for new content"
+msgstr "Потражи нови садржај"
+
+#: id:13350
+msgid "Now playing..."
+msgstr "Тренутно се репродукује..."
+
+#: id:13351
+msgctxt "Auto context with id 13351"
+msgid "Album information"
+msgstr "Подаци о албуму"
+
+#: id:13352
+msgid "Scan item to library"
+msgstr "Анализ. ставке у библиотеци"
+
+#: id:13353
+msgid "Stop scanning"
+msgstr "Заустави анализирање"
+
+#: id:13354
+msgctxt "Auto context with id 13354"
+msgid "Render method"
+msgstr "Начин представљања"
+
+#: id:13355
+msgid "Low quality pixel shader"
+msgstr "Низак квалитет сенчења пиксела"
+
+#: id:13356
+msgid "Hardware overlays"
+msgstr "Хардверска преклапања"
+
+#: id:13357
+msgid "High quality pixel shader"
+msgstr "Висок квалитет сенчења пиксела"
+
+#: id:13358
+msgid "Play item"
+msgstr "Репродукуј ставку"
+
+#: id:13359
+msgid "Set artist thumb"
+msgstr "Постави сличицу извођача"
+
+#: id:13360
+msgid "Automatically generate thumbnails"
+msgstr "Аутоматски направи сличице"
+
+#: id:13361
+msgid "Enable voice"
+msgstr "Омогући глас"
+
+#: id:13375
+msgid "Enable device"
+msgstr "Омогући уређај"
+
+#: id:13376
+msgid "Volume"
+msgstr "Јачина звука"
+
+#: id:13377
+msgid "Default view mode"
+msgstr "Подразумевани режим приказа"
+
+#: id:13378
+msgid "Default brightness"
+msgstr "Подразумевана светлина"
+
+#: id:13379
+msgid "Default contrast"
+msgstr "Подразумевани контраст"
+
+#: id:13380
+msgid "Default gamma"
+msgstr "Подразумевани опсег боја"
+
+#: id:13381
+msgid "Resume video"
+msgstr "Настави филм"
+
+#: id:13382
+msgid "Voice mask - Port 1"
+msgstr "Гласовна маска - Прикључак 1"
+
+#: id:13383
+msgid "Voice mask - Port 2"
+msgstr "Гласовна маска - Прикључак 2"
+
+#: id:13384
+msgid "Voice mask - Port 3"
+msgstr "Гласовна маска - Прикључак 3"
+
+#: id:13385
+msgid "Voice mask - Port 4"
+msgstr "Гласовна маска - Прикључак 4"
+
+#: id:13386
+msgid "Use time based seeking"
+msgstr "Користи тражење засновано на времену"
+
+#: id:13387
+msgid "Track naming template - right"
+msgstr "Шаблон именовања нумера - десно"
+
+#: id:13388
+msgid "Preset"
+msgstr "Унапред задато"
+
+#: id:13389
+msgid "There are no presets available\nfor this visualization"
+msgstr "Не постоје унапред задате поставке\nза ову визуализацију"
+
+#: id:13390
+msgid "There are no settings available\nfor this visualization"
+msgstr "Не постоје доступне поставке\nза ову визуализацију"
+
+#: id:13391
+msgid "Eject/Load"
+msgstr "Избаци/Убаци"
+
+#: id:13392
+msgid "Use visualization if playing audio"
+msgstr "Користи визуализацију, уколико се репродукује звук"
+
+#: id:13393
+msgid "Calculate size"
+msgstr "Израчунај величину"
+
+#: id:13394
+msgid "Calculating folder size"
+msgstr "Рачунање величине фасцикле"
+
+#: id:13395
+msgid "Video settings"
+msgstr "Поставке филма"
+
+#: id:13396
+msgid "Audio and subtitle settings"
+msgstr "Поставке звука и титла"
+
+#: id:13397
+msgid "Enable subtitles"
+msgstr "Омогући титлове"
+
+#: id:13398
+msgctxt "Auto context with id 13398"
+msgid "Shortcuts"
+msgstr "Пречице"
+
+#: id:13399
+msgid "Ignore articles when sorting (e.g. \"the\")"
+msgstr "Игнориши ставке приликом слагања (нпр. „the“ и сл.)"
+
+#: id:13400
+msgid "Crossfade between songs on the same album"
+msgstr "Фини прелаз између песама истог албума"
+
+#: id:13401
+msgid "Browse for %s"
+msgstr "Потражи %s"
+
+#: id:13402
+msgid "Show track position"
+msgstr "Прикажи позицију нумере"
+
+#: id:13403
+msgid "Clear default"
+msgstr "Очисти подразумевано"
+
+#: id:13404
+msgid "Resume"
+msgstr "Настави"
+
+#: id:13405
+msgid "Get thumb"
+msgstr "Преузми омот"
+
+#: id:13406
+msgid "Picture information"
+msgstr "Подаци о слици"
+
+#: id:13407
+msgid "%s presets"
+msgstr "%s унап. зад. поставки"
+
+#: id:13408
+msgid "(IMDb user rating)"
+msgstr "(IMDb оцена корисника)"
+
+#: id:13409
+msgid "Top 250"
+msgstr "Најбољих 250"
+
+#: id:13410
+msgid "Tune in on Last.fm"
+msgstr "Намести на Last.fm"
+
+#: id:13411
+msgid "Minimum fan speed"
+msgstr "Минимална брзина вентилатора"
+
+#: id:13412
+msgid "Play from here"
+msgstr ""
+
+#: id:13413
+msgid "Downloading"
+msgstr "Преузимање"
+
+#: id:13414
+msgid "Include artists who appear only on compilations"
+msgstr "Укључи извођаче који се појављују само на компилацијама"
+
+#: id:13415
+msgctxt "Auto context with id 13415"
+msgid "Render method"
+msgstr "Начин представљања"
+
+#: id:13416
+msgid "Auto detect"
+msgstr "Аутом. откриј"
+
+#: id:13417
+msgid "Basic shaders (ARB)"
+msgstr "Основна сенчења (ARB)"
+
+#: id:13418
+msgid "Advanced shaders (GLSL)"
+msgstr "Напредна сенчења (GLSL)"
+
+#: id:13419
+msgid "Software"
+msgstr "Софтвер"
+
+#: id:13420
+msgid "Remove safely"
+msgstr "Безбедно уклони"
+
+#: id:13421
+msgctxt "Auto context with id 13421"
+msgid "VDPAU"
+msgstr "VDPAU"
+
+#: id:13422
+msgid "Start slideshow here"
+msgstr "Покрени реп. слајд. одавде"
+
+#: id:13423
+msgid "Remember for this path"
+msgstr "Запамти ову путању"
+
+#: id:13424
+msgid "Use pixel buffer objects"
+msgstr "Користи пикселно предмеморисање објеката"
+
+#: id:13425
+msgid "Allow hardware acceleration (VDPAU)"
+msgstr "Broadcom Crystal HD"
+
+#: id:13426
+msgid "Allow hardware acceleration (VAAPI)"
+msgstr ""
+
+#: id:13427
+msgid "Allow hardware acceleration (DXVA2)"
+msgstr ""
+
+#: id:13428
+msgid "Allow hardware acceleration (CrystalHD)"
+msgstr ""
+
+#: id:13429
+msgid "Allow hardware acceleration (VDADecoder)"
+msgstr ""
+
+#: id:13430
+msgid "Allow hardware acceleration (OpenMax)"
+msgstr ""
+
+#: id:13431
+msgid "Pixel Shaders"
+msgstr ""
+
+#: id:13432
+msgid "Allow hardware acceleration (VideoToolbox)"
+msgstr ""
+
+#: id:13500
+msgid "A/V sync method"
+msgstr "A/V начин синхрон."
+
+#: id:13501
+msgid "Audio clock"
+msgstr "Часовник звука"
+
+#: id:13502
+msgid "Video clock (Drop/Dupe audio)"
+msgstr "Часовник филма (Drop/Dupe звук)"
+
+#: id:13503
+msgid "Video clock (Resample audio)"
+msgstr "Часовник филма (Понов. одаб. звука)"
+
+#: id:13504
+msgid "Maximum resample amount (%)"
+msgstr "Максимална количина пон. одабир. (%)"
+
+#: id:13505
+msgid "Resample quality"
+msgstr "Квалитет понов. одаб."
+
+#: id:13506
+msgid "Low(fast)"
+msgstr "Низак (брзо)"
+
+#: id:13507
+msgctxt "Auto context with id 13507"
+msgid "Medium"
+msgstr "Средње"
+
+#: id:13508
+msgctxt "Auto context with id 13508"
+msgid "High"
+msgstr "Висок"
+
+#: id:13509
+msgid "Really high(slow!)"
+msgstr "Заиста висок (споро!)"
+
+#: id:13510
+msgid "Sync playback to display"
+msgstr "Синхронизуј репродукцију према приказу"
+
+#: id:13550
+msgid "Pause during refresh rate change"
+msgstr ""
+
+#: id:13551
+msgctxt "Auto context with id 13551"
+msgid "Off"
+msgstr ""
+
+#: id:13552
+msgid "%.1f Second"
+msgstr ""
+
+#: id:13553
+msgid "%.1f Seconds"
+msgstr ""
+
+#: id:13600
+msgid "Apple remote"
+msgstr "Apple даљински управљач"
+
+#: id:13602
+msgid "Allow start of XBMC using the remote"
+msgstr "Дозволи покретање XBMC аплик. коришћењем даљинског"
+
+#: id:13603
+msgid "Sequence delay time"
+msgstr "Време кашњења секвенце"
+
+#: id:13610
+msgctxt "Auto context with id 13610"
+msgid "Disabled"
+msgstr "Онемогућено"
+
+#: id:13611
+msgctxt "Auto context with id 13611"
+msgid "Standard"
+msgstr "Уобичајено"
+
+#: id:13612
+msgid "Universal Remote"
+msgstr "Универзални даљински"
+
+#: id:13613
+msgid "Multi Remote (Harmony)"
+msgstr "Вишеструки даљински (Сложно)"
+
+#: id:13620
+msgid "Apple Remote Error"
+msgstr "Грешка Apple даљинског управљача"
+
+#: id:13621
+msgid "Apple Remote support could be enabled."
+msgstr "Подршка за Apple даљ. управљач може бити омогућена."
+
+#: id:14000
+msgid "Stack"
+msgstr "Постави на складиште"
+
+#: id:14001
+msgid "Unstack"
+msgstr "Уклони са складишта"
+
+#: id:14003
+msgid "Downloading playlist file..."
+msgstr "Преузимање датотеке списк. за реп..."
+
+#: id:14004
+msgid "Downloading streams list..."
+msgstr "Преузимање списка протока података..."
+
+#: id:14005
+msgid "Parsing streams list..."
+msgstr "Разлучивање (разлагање) списка протока података..."
+
+#: id:14006
+msgid "Downloading streams list failed"
+msgstr "Није успело преузимање списка протока података"
+
+#: id:14007
+msgid "Downloading playlist file failed"
+msgstr "Није успело преузимање датотеке списка за репродукцију"
+
+#: id:14009
+msgid "Games directory"
+msgstr "Каталог игара"
+
+#: id:14010
+msgid "Auto switch to thumbs based on"
+msgstr "Аутом. пребаци на сличице засновано на"
+
+#: id:14011
+msgid "Enable auto switching to thumbs view"
+msgstr "Омогући аутоматско пребацивање на приказ омота"
+
+#: id:14012
+msgid "- Use large icons"
+msgstr "- Користи велике иконе"
+
+#: id:14013
+msgid "- Switch based on"
+msgstr "- Пребацивање засновано на"
+
+#: id:14014
+msgid "- Percentage"
+msgstr "- Постотак"
+
+#: id:14015
+msgid "No files and at least one thumb"
+msgstr "Без датотека и бар једне сличице"
+
+#: id:14016
+msgid "At least one file and thumb"
+msgstr "Бар једна датотека и сличица"
+
+#: id:14017
+msgid "Percentage of thumbs"
+msgstr "Проценат сличица"
+
+#: id:14018
+msgid "View options"
+msgstr "Прикажи опције"
+
+#: id:14019
+msgid "Change area code 1"
+msgstr "Промени кôд подручја 1"
+
+#: id:14020
+msgid "Change area code 2"
+msgstr "Промени кôд подручја 2"
+
+#: id:14021
+msgid "Change area code 3"
+msgstr "Промени кôд подручја 3"
+
+#: id:14022
+msgctxt "Auto context with id 14022"
+msgid "Library"
+msgstr "Библиотека"
+
+#: id:14023
+msgid "No TV"
+msgstr "Без TV пријемника"
+
+#: id:14024
+msgid "Enter the nearest large town"
+msgstr "Унесите најближи већи град"
+
+#: id:14025
+msgid "Video/Audio/DVD cache - Harddisk"
+msgstr "Видео/Звучни/DVD кеш - чврсти диск"
+
+#: id:14026
+msgid "Video cache - DVD-ROM"
+msgstr "Видео кеш - DVD-ROM"
+
+#: id:14027
+msgctxt "Auto context with id 14027"
+msgid "- Local Network"
+msgstr "- Локална мрежа"
+
+#: id:14028
+msgctxt "Auto context with id 14028"
+msgid "- Internet"
+msgstr "- Интернет"
+
+#: id:14030
+msgid "Audio cache - DVD-ROM"
+msgstr "Кеш звука - DVD-ROM"
+
+#: id:14031
+msgctxt "Auto context with id 14031"
+msgid "- Local Network"
+msgstr "- Локална мрежа"
+
+#: id:14032
+msgctxt "Auto context with id 14032"
+msgid "- Internet"
+msgstr "- Интернет"
+
+#: id:14034
+msgid "DVD cache - DVD-ROM"
+msgstr "DVD кеш - DVD-ROM"
+
+#: id:14035
+msgctxt "Auto context with id 14035"
+msgid "- Local Network"
+msgstr "- Локална мрежа"
+
+#: id:14036
+msgctxt "Auto context with id 14036"
+msgid "Services"
+msgstr "Услуге"
+
+#: id:14038
+msgid "Network settings changed"
+msgstr "Промењене су мрежне поставке"
+
+#: id:14039
+msgid "XBMC requires to restart to change your"
+msgstr "XBMC захтева поновно покретање ради промене"
+
+#: id:14040
+msgid "network setup. Would you like to restart now?"
+msgstr "мрежних поставки. Желите ли одмах да поново покренете?"
+
+#: id:14041
+msgid "Internet connection bandwidth limitation"
+msgstr "Накнадна обрада"
+
+#: id:14043
+msgid "- Shutdown while playing"
+msgstr "- Искључи док се репродукује"
+
+#: id:14044
+msgid "%i min"
+msgstr "%i мин."
+
+#: id:14045
+msgid "%i sec"
+msgstr "%i сек."
+
+#: id:14046
+msgid "%i ms"
+msgstr "%i ms"
+
+#: id:14047
+msgid "%i %%"
+msgstr "%i %%"
+
+#: id:14048
+msgid "%i kbps"
+msgstr "%i kbps"
+
+#: id:14049
+msgid "%i kb"
+msgstr "%i kb"
+
+#: id:14050
+msgid "%i.0 dB"
+msgstr "%i.0 dB"
+
+#: id:14051
+msgid "Time format"
+msgstr "Приказ времена"
+
+#: id:14052
+msgid "Date format"
+msgstr "Приказ датума"
+
+#: id:14053
+msgid "GUI filters"
+msgstr "GUI филтери"
+
+#: id:14055
+msgid "Use background scanning"
+msgstr "Користи анализирање у позадини"
+
+#: id:14056
+msgid "Stop scan"
+msgstr "Заустави анализирање"
+
+#: id:14057
+msgid "Not possible while scanning for media info"
+msgstr "Није могуће док је у току анализирање података о медију"
+
+#: id:14058
+msgid "Film grain effect"
+msgstr "Зрнасти ефекат приказа"
+
+#: id:14059
+msgid "Search for thumbnails on remote shares"
+msgstr "Потражи сличице на дељеним локацијама"
+
+#: id:14060
+msgid "Unknown type cache - Internet"
+msgstr "Непознат тип кеша - Интернет"
+
+#: id:14061
+msgctxt "Auto context with id 14061"
+msgid "Auto"
+msgstr "Аутом."
+
+#: id:14062
+msgid "Enter username for"
+msgstr "Унесите корисничко име за"
+
+#: id:14063
+msgid "Date & time"
+msgstr "Датум и време"
+
+#: id:14064
+msgid "Set date"
+msgstr "Постави датум"
+
+#: id:14065
+msgid "Set time"
+msgstr "Постави време"
+
+#: id:14066
+msgid "Enter the time in 24 hour HH:MM format"
+msgstr "Унесите време у облику 24 часа; ЧЧ:ММ"
+
+#: id:14067
+msgid "Enter the date in DD/MM/YYYY format"
+msgstr "Унесите датум у облику ДД/ММ/ГГГГ"
+
+#: id:14068
+msgid "Enter the IP address"
+msgstr "Унесите IP адресу"
+
+#: id:14069
+msgid "Apply these settings now?"
+msgstr "Одмах применити поставке?"
+
+#: id:14070
+msgid "Apply changes now"
+msgstr "Одмах примени промене"
+
+#: id:14071
+msgid "Allow file renaming and deletion"
+msgstr "Дозволи преименовање и брисање датотеке"
+
+#: id:14074
+msgid "Set timezone"
+msgstr "Постави временску зону"
+
+#: id:14075
+msgid "Use daylight saving time"
+msgstr "Користи летње рачунање времена"
+
+#: id:14076
+msgid "Add to favourites"
+msgstr "Додај у омиљено"
+
+#: id:14077
+msgid "Remove from favourites"
+msgstr "Уклони из омиљеног"
+
+#: id:14078
+msgctxt "Auto context with id 14078"
+msgid "- Colours"
+msgstr "- Боје"
+
+#: id:14079
+msgid "Timezone country"
+msgstr "Земља временске зоне"
+
+#: id:14080
+msgid "Timezone"
+msgstr "Временска зона"
+
+#: id:14081
+msgid "File lists"
+msgstr "Спискови датотека"
+
+#: id:14082
+msgid "Show EXIF picture information"
+msgstr "Прикажи EXIF спецификацију слике"
+
+#: id:14083
+msgid "Use a fullscreen window rather than true fullscreen"
+msgstr "Радије користи приказ читавог екрана у прозору"
+
+#: id:14084
+msgid "Queue songs on selection"
+msgstr "Стави песму у ред приликом избора"
+
+#: id:14086
+msgid "Playback"
+msgstr "Репродукција"
+
+#: id:14087
+msgid "DVDs"
+msgstr "DVD-ови"
+
+#: id:14088
+msgid "Play DVDs automatically"
+msgstr "Аутоматски репродукуј DVD-ове"
+
+#: id:14089
+msgid "Font to use for text subtitles"
+msgstr "Облик слова за титлове"
+
+#: id:14090
+msgid "International"
+msgstr "Међународно"
+
+#: id:14091
+msgid "Character set"
+msgstr "Скуп знакова"
+
+#: id:14092
+msgid "Debugging"
+msgstr "Тражење грешака"
+
+#: id:14093
+msgid "Security"
+msgstr "Безбедност"
+
+#: id:14094
+msgid "Input devices"
+msgstr "Улазни уређаји"
+
+#: id:14095
+msgid "Power saving"
+msgstr "Уштеда енергије"
+
+#: id:14096
+msgid "Rip"
+msgstr ""
+
+#: id:14097
+msgid "Audio CD Insert Action"
+msgstr ""
+
+#: id:14098
+msgctxt "Auto context with id 14098"
+msgid "Play"
+msgstr ""
+
+#: id:14099
+msgid "Eject disc when CD ripping is complete"
+msgstr ""
+
+#: id:15015
+msgctxt "Auto context with id 15015"
+msgid "Remove"
+msgstr "Уклони"
+
+#: id:15016
+msgid "Games"
+msgstr "Игре"
+
+#: id:15019
+msgid "Add"
+msgstr "Додај"
+
+#: id:15052
+msgid "Password"
+msgstr "Лозинка"
+
+#: id:15100
+msgctxt "Auto context with id 15100"
+msgid "Library"
+msgstr "Библиотека"
+
+#: id:15101
+msgid "Database"
+msgstr "База података"
+
+#: id:15102
+msgid "* All albums"
+msgstr "* Сви албуми"
+
+#: id:15103
+msgid "* All artists"
+msgstr "* Сви извођачи"
+
+#: id:15104
+msgid "* All songs"
+msgstr "* Све песме"
+
+#: id:15105
+msgid "* All genres"
+msgstr "* Сви жанрови"
+
+#: id:15107
+msgid "Buffering..."
+msgstr "Предмеморисање..."
+
+#: id:15108
+msgid "Navigation sounds"
+msgstr "Навигациони звукови"
+
+#: id:15109
+msgid "Skin default"
+msgstr "Подразумевана маска"
+
+#: id:15111
+msgid "- Theme"
+msgstr "- Тема"
+
+#: id:15112
+msgid "Default theme"
+msgstr "Подразумевана тема"
+
+#: id:15200
+msgid "Last.fm"
+msgstr "Last.fm"
+
+#: id:15201
+msgid "Submit songs to Last.fm"
+msgstr "Пошаљи песме на Last.fm"
+
+#: id:15202
+msgid "Last.fm username"
+msgstr "Last.fm корисничко име"
+
+#: id:15203
+msgid "Last.fm password"
+msgstr "Last.fm лозинка"
+
+#: id:15204
+msgid "Unable to handshake: sleeping..."
+msgstr "Није могуће усаглашавање: стање спавања..."
+
+#: id:15205
+msgid "Please update XBMC"
+msgstr "Молимо, ажурирајте XBMC"
+
+#: id:15206
+msgid "Bad authorization: Check username and password"
+msgstr "Погрешна ауторизација: Проверите корисничко име и лозинку"
+
+#: id:15207
+msgctxt "Auto context with id 15207"
+msgid "Connected"
+msgstr "Повезано"
+
+#: id:15208
+msgid "Not connected"
+msgstr "Није повезано"
+
+#: id:15209
+msgid "Submit interval %i"
+msgstr "Учесталост слања %i"
+
+#: id:15210
+msgid "Cached %i songs"
+msgstr "Кеширано %i песама"
+
+#: id:15211
+msgid "Submitting..."
+msgstr "Слање је у току..."
+
+#: id:15212
+msgid "Submitting in %i secs"
+msgstr "Слање за %i секунди"
+
+#: id:15213
+msgid "Play using..."
+msgstr "Репродукуј помоћу..."
+
+#: id:15214
+msgid "Use smoothed A/V synchronization"
+msgstr "Користи умекшану A/V синхронизацију"
+
+#: id:15215
+msgid "Hide file names in thumbs view"
+msgstr "Сакриј називе датотека приликом приказа омота"
+
+#: id:15216
+msgid "Play in party mode"
+msgstr "Репродукуј у режиму журке"
+
+#: id:15217
+msgid "Submit songs to Libre.fm"
+msgstr "Пошаљи песме на Libre.fm"
+
+#: id:15218
+msgid "Libre.fm username"
+msgstr "Libre.fm корисничко име"
+
+#: id:15219
+msgid "Libre.fm password"
+msgstr "Libre.fm лозинка"
+
+#: id:15220
+msgid "Libre.fm"
+msgstr "Libre.fm"
+
+#: id:15221
+msgid "Song submission"
+msgstr "Слање песме"
+
+#: id:15250
+msgid "Submit Last.fm radio to Last.fm"
+msgstr "Пошаљи Last.fm радио на Last.fm"
+
+#: id:15251
+msgid "Connecting to Last.fm..."
+msgstr "Повезивање са Last.fm..."
+
+#: id:15252
+msgid "Selecting station..."
+msgstr "Бирање станице..."
+
+#: id:15253
+msgid "Search similar artists..."
+msgstr "Пронађи сличне извођаче..."
+
+#: id:15254
+msgid "Search similar tags..."
+msgstr "Пронађи сличне ознаке..."
+
+#: id:15255
+msgid "Your profile (%name%)"
+msgstr "Ваш профил (%name%)"
+
+#: id:15256
+msgid "Overall top tags"
+msgstr "Свеобухватно најбоље ознаке"
+
+#: id:15257
+msgid "Top artists for tag %name%"
+msgstr "Најбољи извођачи са ознаком %name%"
+
+#: id:15258
+msgid "Top albums for tag %name%"
+msgstr "Најбољи албуми са ознаком %name%"
+
+#: id:15259
+msgid "Top tracks for tag %name%"
+msgstr "Најбоље нумере са ознаком %name%"
+
+#: id:15260
+msgid "Listen to tag %name% Last.fm radio"
+msgstr "Слушај ознаку %name% Last.fm радија"
+
+#: id:15261
+msgid "Similar artists as %name%"
+msgstr "Извођачи који су слични са %name%"
+
+#: id:15262
+msgid "Top %name% albums"
+msgstr "Најбољи %name% албуми"
+
+#: id:15263
+msgid "Top %name% tracks"
+msgstr "Најбоље %name% нумере"
+
+#: id:15264
+msgid "Top %name% tags"
+msgstr "Најбоље %name% ознаке"
+
+#: id:15265
+msgid "Biggest fans of %name%"
+msgstr "Највећи %name% обожаваоци"
+
+#: id:15266
+msgid "Listen to %name% fans Last.fm radio"
+msgstr "Слушај обожаваоце %name%, Last.fm радија"
+
+#: id:15267
+msgid "Listen to %name% similar artists Last.fm radio"
+msgstr "Слушај сличне извођаче као што је %name% на Last.fm радију"
+
+#: id:15268
+msgid "Top artists for user %name%"
+msgstr "Најбољи извођачи корисника %name%"
+
+#: id:15269
+msgid "Top albums for user %name%"
+msgstr "Најбољи албуми корисника %name%"
+
+#: id:15270
+msgid "Top tracks for user %name%"
+msgstr "Најбоље нумере корисника %name%"
+
+#: id:15271
+msgid "Friends of user %name%"
+msgstr "Пријатељи корисника %name%"
+
+#: id:15272
+msgid "Neighbours of user %name%"
+msgstr "Комшије корисника %name%"
+
+#: id:15273
+msgid "Weekly artist chart for %name%"
+msgstr "Недељни списак најбољих извођача корисника %name%"
+
+#: id:15274
+msgid "Weekly album chart for %name%"
+msgstr "Недељни списак најбољих албума корисника %name%"
+
+#: id:15275
+msgid "Weekly track chart for %name%"
+msgstr "Недељни списак најбољих нумера корисника %name%"
+
+#: id:15276
+msgid "Listen to %name%'s neighbours Last.fm radio"
+msgstr "Слушај комшијин Last.fm радио корисника %name%"
+
+#: id:15277
+msgid "Listen to %name%'s personal Last.fm radio"
+msgstr "Слушај лични Last.fm радио корисника %name%"
+
+#: id:15278
+msgid "Listen to %name%'s mix Last.fm radio"
+msgstr "Слушај вољене нумере Last.fm радија корисника %name%"
+
+#: id:15279
+msgid "Retrieving list from Last.fm..."
+msgstr "Преузимање списка са Last.fm..."
+
+#: id:15280
+msgid "Can't retrieve list from Last.fm..."
+msgstr "Није могуће преузети списак са Last.fm..."
+
+#: id:15281
+msgid "Enter an artist name to find related ones"
+msgstr "Унесите назив извођача како бисте пронашли сличне"
+
+#: id:15282
+msgid "Enter a tag name to find similar ones"
+msgstr "Унесите ознаку за проналажење сличних"
+
+#: id:15283
+msgid "Tracks recently listened by %name%"
+msgstr "Недавно одслушане нумере корисника %name%"
+
+#: id:15284
+msgid "Listen to %name%'s recommendations Last.fm radio"
+msgstr "Слушај по препоруци Last.fm радио корисника %name%"
+
+#: id:15285
+msgid "Top tags for user %name%"
+msgstr "Најбоље ознаке за корисника %name%"
+
+#: id:15287
+msgid "Do you want to add the current track to your loved tracks?"
+msgstr "Желите ли да додате тренутну нумеру у ваше вољене нумере?"
+
+#: id:15288
+msgid "Do you want to ban the current track?"
+msgstr "Желите ли да забраните тренутну нумеру?"
+
+#: id:15289
+msgid "Added to your loved tracks: '%s'."
+msgstr "Додато у ваше вољене нумере: „%s“."
+
+#: id:15290
+msgid "Could not add '%s' to your loved tracks."
+msgstr "Није могуће додати „%s“ у ваше вољене нумере."
+
+#: id:15291
+msgid "Banned: '%s'."
+msgstr "Забрањено: „%s“."
+
+#: id:15292
+msgid "Could not ban '%s'."
+msgstr "Није могуће забранити „%s“."
+
+#: id:15293
+msgid "Tracks recently loved by %name%"
+msgstr "Нумере које је недавно заволео %name%"
+
+#: id:15294
+msgid "Tracks recently banned by %name%"
+msgstr "Нумере које је недавно забранио %name%"
+
+#: id:15295
+msgid "Remove from loved tracks"
+msgstr "Уклоњено из вољених нумера"
+
+#: id:15296
+msgid "Un-ban"
+msgstr "Опозови забрану"
+
+#: id:15297
+msgid "Do you want to remove this track from your loved tracks?"
+msgstr "Желите ли да уклоните ову нумеру из вољених нумера?"
+
+#: id:15298
+msgid "Do you want to un-ban this track?"
+msgstr "Желите ли да опозовете забрану за ову нумеру?"
+
+#: id:15300
+msgid "Path not found or invalid"
+msgstr "Путања није пронађена или је неважећа"
+
+#: id:15301
+msgid "Could not connect to network server"
+msgstr "Није могуће повезивање са мрежним сервером"
+
+#: id:15302
+msgid "No servers found"
+msgstr "Ни један сервер није пронађен"
+
+#: id:15303
+msgid "Workgroup not found"
+msgstr "Радна група није пронађена"
+
+#: id:15310
+msgid "Opening multi-path source"
+msgstr "Отварање извора са више путања"
+
+#: id:15311
+msgid "Path:"
+msgstr "Путања:"
+
+#: id:16000
+msgctxt "Auto context with id 16000"
+msgid "General"
+msgstr "Опште"
+
+#: id:16002
+msgid "Internet lookup"
+msgstr "Претраживање интернета"
+
+#: id:16003
+msgid "Player"
+msgstr "Уређај за репродукцију"
+
+#: id:16004
+msgid "Play media from disc"
+msgstr "Репродукуј медиј са диска"
+
+#: id:16008
+msgid "Enter new title"
+msgstr "Унесите нови наслов"
+
+#: id:16009
+msgid "Enter the movie name"
+msgstr "Унесите име филма"
+
+#: id:16010
+msgid "Enter the profile name"
+msgstr "Унесите име профила"
+
+#: id:16011
+msgid "Enter the album name"
+msgstr "Унесите име албума"
+
+#: id:16012
+msgid "Enter the playlist name"
+msgstr "Унесите име списка за реп."
+
+#: id:16013
+msgid "Enter new filename"
+msgstr "Унесите ново име датотеке"
+
+#: id:16014
+msgid "Enter folder name"
+msgstr "Унесите име фасцикле"
+
+#: id:16015
+msgid "Enter directory"
+msgstr "Унесите фасциклу"
+
+#: id:16016
+msgid "Available options: %A, %T, %N, %B, %D, %G, %Y, %F, %S"
+msgstr "Доступне опције: %A, %T, %N, %B, %D, %G, %Y, %F, %S"
+
+#: id:16017
+msgid "Enter search string"
+msgstr "Унесите реч за претрагу"
+
+#: id:16018
+msgctxt "Auto context with id 16018"
+msgid "None"
+msgstr "Ништа"
+
+#: id:16019
+msgid "Auto select"
+msgstr "Аутоматски избор"
+
+#: id:16020
+msgid "De-interlace"
+msgstr "Уклони преплитање слике"
+
+#: id:16021
+msgid "Bob"
+msgstr "Bob"
+
+#: id:16022
+msgid "Bob (inverted)"
+msgstr "Bob (обратно)"
+
+#: id:16024
+msgid "Canceling..."
+msgstr "Отказивање..."
+
+#: id:16025
+msgid "Enter the artist name"
+msgstr "Унеси име извођача"
+
+#: id:16026
+msgid "Playback failed"
+msgstr "Неуспешна репродукција"
+
+#: id:16027
+msgid "One or more items failed to play."
+msgstr "Једну или више ставки није могуће репродуковати."
+
+#: id:16028
+msgid "Enter value"
+msgstr "Унесите вредност"
+
+#: id:16029
+msgid "Check the log file for details."
+msgstr "Проверите датотеку евиденције за детаље."
+
+#: id:16030
+msgid "Party mode aborted."
+msgstr "Режим журке је прекинут."
+
+#: id:16031
+msgid "No matching songs in the library."
+msgstr "Нема подударајућих песама у библиотеци."
+
+#: id:16032
+msgid "Could not initialize database."
+msgstr "Није могуће покренути базу података."
+
+#: id:16033
+msgid "Could not open database."
+msgstr "Није могуће отворити базу података."
+
+#: id:16034
+msgid "Could not get songs from database."
+msgstr "Није могуће преузети песме из базе података."
+
+#: id:16035
+msgid "Party mode playlist"
+msgstr "Списак за реп. режима журке"
+
+#: id:16036
+msgid "De-interlace (Half)"
+msgstr ""
+
+#: id:16037
+msgid "Deinterlace video"
+msgstr ""
+
+#: id:16038
+msgid "Deinterlace method"
+msgstr ""
+
+#: id:16039
+msgctxt "Auto context with id 16039"
+msgid "Off"
+msgstr ""
+
+#: id:16040
+msgctxt "Auto context with id 16040"
+msgid "Auto"
+msgstr ""
+
+#: id:16041
+msgid "On"
+msgstr ""
+
+#: id:16100
+msgid "All Videos"
+msgstr "Сви филмови"
+
+#: id:16101
+msgid "Unwatched"
+msgstr "неодгледаних"
+
+#: id:16102
+msgid "Watched"
+msgstr "одгледаних"
+
+#: id:16103
+msgid "Mark as watched"
+msgstr "Обележи као одгледано"
+
+#: id:16104
+msgid "Mark as unwatched"
+msgstr "Обележи као неодгледано"
+
+#: id:16105
+msgid "Edit title"
+msgstr "Уреди наслов"
+
+#: id:16200
+msgid "Operation was aborted"
+msgstr "Операција је прекинута"
+
+#: id:16201
+msgid "Copy failed"
+msgstr "Копирање није успело"
+
+#: id:16202
+msgid "Failed to copy at least one file"
+msgstr "Није успело копирање барем једне датотеке"
+
+#: id:16203
+msgid "Move failed"
+msgstr "Премештање није успело"
+
+#: id:16204
+msgid "Failed to move at least one file"
+msgstr "Није успело премештање барем једне датотеке"
+
+#: id:16205
+msgid "Delete failed"
+msgstr "Брисање није успело"
+
+#: id:16206
+msgid "Failed to delete at least one file"
+msgstr "Није успело брисање барем једне датотеке"
+
+#: id:16300
+msgid "Video scaling method"
+msgstr "Режим видео размере"
+
+#: id:16301
+msgid "Nearest neighbour"
+msgstr "Најближи комшија"
+
+#: id:16302
+msgid "Bilinear"
+msgstr "Bilinear"
+
+#: id:16303
+msgctxt "Auto context with id 16303"
+msgid "Bicubic"
+msgstr "Bicubic"
+
+#: id:16304
+msgid "Lanczos2"
+msgstr "Lanczos2"
+
+#: id:16305
+msgid "Lanczos3"
+msgstr "Lanczos3"
+
+#: id:16306
+msgid "Sinc8"
+msgstr "Sinc8"
+
+#: id:16307
+msgid "Bicubic (software)"
+msgstr "Bicubic (софтверски)"
+
+#: id:16308
+msgid "Lanczos (software)"
+msgstr "Lanczos (софтверски)"
+
+#: id:16309
+msgid "Sinc (software)"
+msgstr "Sinc (софтверски)"
+
+#: id:16310
+msgid "Temporal"
+msgstr "Временски"
+
+#: id:16311
+msgid "Temporal/Spatial"
+msgstr "Временски/просторни"
+
+#: id:16312
+msgid "(VDPAU)Noise Reduction"
+msgstr "(VDPAU) Смањење шума"
+
+#: id:16313
+msgid "(VDPAU)Sharpness"
+msgstr "(VDPAU) Оштрина"
+
+#: id:16314
+msgid "Inverse Telecine"
+msgstr "Обрнути Telecine"
+
+#: id:16315
+msgid "Lanczos3 optimized"
+msgstr "Оптимизовани Lanczos3"
+
+#: id:16316
+msgctxt "Auto context with id 16316"
+msgid "Auto"
+msgstr "Аутоматски"
+
+#: id:16317
+msgid "Temporal (Half)"
+msgstr "Временски (половично)"
+
+#: id:16318
+msgid "Temporal/Spatial (Half)"
+msgstr "Временски/просторни (половично)"
+
+#: id:16319
+msgid "DXVA"
+msgstr ""
+
+#: id:16320
+msgid "DXVA Bob"
+msgstr ""
+
+#: id:16321
+msgid "DXVA Best"
+msgstr ""
+
+#: id:16322
+msgid "Spline36"
+msgstr ""
+
+#: id:16323
+msgid "Spline36 optimized"
+msgstr ""
+
+#: id:16324
+msgid "Software Blend"
+msgstr ""
+
+#: id:16400
+msgid "Post-processing"
+msgstr ""
+
+#: id:17500
+msgid "Display sleep timeout"
+msgstr "Време након ког ће екран прећи у стање спавања"
+
+#: id:19000
+msgid "Switch to channel"
+msgstr "Пребаци на канал"
+
+#: id:20000
+msgid "Saved music folder"
+msgstr "Фасцикла са сачуваном музиком"
+
+#: id:20001
+msgid "Use external DVD player"
+msgstr "Користи спољни DVD уређај за реп."
+
+#: id:20002
+msgid "External DVD player"
+msgstr "Спољни DVD уређај за реп."
+
+#: id:20003
+msgid "Trainers folder"
+msgstr "Фасцикла модификатора игара"
+
+#: id:20004
+msgid "Screenshot folder"
+msgstr "Фасцикла са сликама екрана"
+
+#: id:20006
+msgid "Playlists folder"
+msgstr "Фасцикла са списковима за реп."
+
+#: id:20007
+msgid "Recordings"
+msgstr "Снимци"
+
+#: id:20008
+msgid "Screenshots"
+msgstr "Слике екрана"
+
+#: id:20009
+msgid "Use XBMC"
+msgstr "Користи XBMC"
+
+#: id:20011
+msgid "Music playlists"
+msgstr "Спискови за репрод. музике"
+
+#: id:20012
+msgid "Video playlists"
+msgstr "Спискови за репрод. филмова"
+
+#: id:20013
+msgid "Do you wish to launch the game?"
+msgstr "Желите ли да покренете игру?"
+
+#: id:20014
+msgid "Sort by: Playlist"
+msgstr "Сложи по: Спис. за реп."
+
+#: id:20015
+msgid "Remote thumb"
+msgstr "Удаљена сличица"
+
+#: id:20016
+msgid "Current thumb"
+msgstr "Тренутна сличица"
+
+#: id:20017
+msgid "Local thumb"
+msgstr "Локална сличица"
+
+#: id:20018
+msgid "No thumb"
+msgstr "Нема сличице"
+
+#: id:20019
+msgid "Choose thumbnail"
+msgstr "Изабери сличицу"
+
+#: id:20023
+msgid "Conflict"
+msgstr "Неусаглашеност"
+
+#: id:20024
+msgid "Scan new"
+msgstr "Претраживање нових"
+
+#: id:20025
+msgid "Scan all"
+msgstr "Претраживање свих"
+
+#: id:20026
+msgid "Region"
+msgstr "Регија"
+
+#: id:20037
+msgid "Summary"
+msgstr "Кратак преглед"
+
+#: id:20038
+msgid "Lock music window"
+msgstr "Закључај прозор са музиком"
+
+#: id:20039
+msgid "Lock videos window"
+msgstr "Закључај прозор са филмовима"
+
+#: id:20040
+msgid "Lock pictures window"
+msgstr "Закључај прозор са сликама"
+
+#: id:20041
+msgid "Lock programs & scripts windows"
+msgstr "Закључај прозор са програмима и скриптама"
+
+#: id:20042
+msgid "Lock file manager"
+msgstr "Закључај управљача датотекама"
+
+#: id:20043
+msgid "Lock settings"
+msgstr "Закључај поставке"
+
+#: id:20044
+msgid "Start fresh"
+msgstr "Нови почетак"
+
+#: id:20045
+msgid "Enter master mode"
+msgstr "Уђи у главни режим"
+
+#: id:20046
+msgid "Leave master mode"
+msgstr "Напусти главни режим"
+
+#: id:20047
+msgid "Create profile '%s'?"
+msgstr "Направити профил „%s“?"
+
+#: id:20048
+msgid "Start with fresh settings"
+msgstr "Покрени са новим поставкама"
+
+#: id:20049
+msgid "Best available"
+msgstr "Најбоље могуће"
+
+#: id:20050
+msgid "Auto-switch between 16x9 and 4x3"
+msgstr "Аутоматско пребацивање између 16x9 и 4x3"
+
+#: id:20051
+msgid "Treat stacked files as single file"
+msgstr "Сматрај компримоване датотеке као једну"
+
+#: id:20052
+msgid "Caution"
+msgstr "Опрез"
+
+#: id:20053
+msgid "Left master mode"
+msgstr "Напуштен главни режим"
+
+#: id:20054
+msgid "Entered master mode"
+msgstr "Приступљено главном режиму"
+
+#: id:20055
+msgid "Allmusic.com thumb"
+msgstr "Омот са Allmusic.com"
+
+#: id:20057
+msgid "Remove thumbnail"
+msgstr "Уклони сличицу"
+
+#: id:20058
+msgid "Add profile..."
+msgstr "Додај профил..."
+
+#: id:20059
+msgid "Query info for all albums"
+msgstr "Захтевај податке за све албуме"
+
+#: id:20060
+msgctxt "Auto context with id 20060"
+msgid "Media info"
+msgstr "Подаци о медију"
+
+#: id:20061
+msgctxt "Auto context with id 20061"
+msgid "Separate"
+msgstr "Одвојено"
+
+#: id:20062
+msgid "Shares with default"
+msgstr "Подразумевано дељење"
+
+#: id:20063
+msgid "Shares with default (read only)"
+msgstr "Подразумевано дељење (само читање)"
+
+#: id:20064
+msgid "Copy default"
+msgstr "Подразумевано копирање"
+
+#: id:20065
+msgid "Profile picture"
+msgstr "Слика профила"
+
+#: id:20066
+msgid "Lock preferences"
+msgstr "Закључај поставке"
+
+#: id:20067
+msgid "Edit profile"
+msgstr "Уреди профил"
+
+#: id:20068
+msgid "Profile lock"
+msgstr "Закључај профил"
+
+#: id:20069
+msgid "Could not create folder"
+msgstr "Није могуће направити фасциклу"
+
+#: id:20070
+msgid "Profile directory"
+msgstr "Фасцикла профила"
+
+#: id:20071
+msgid "Start with fresh media sources"
+msgstr "Покрени са новим извором медија"
+
+#: id:20072
+msgid "Make sure the selected folder is writable"
+msgstr "Уверите се да у изабрану фасциклу можете"
+
+#: id:20073
+msgid "and that the new folder name is valid"
+msgstr "уписивати и да је ново име фасцикле исправно"
+
+#: id:20074
+msgid "MPAA rating"
+msgstr "MPAA оцена"
+
+#: id:20075
+msgid "Enter master lock code"
+msgstr "Унесите главни кôд за откључавање"
+
+#: id:20076
+msgid "Ask for master lock code on startup"
+msgstr "Питај за главни кôд приликом покретања апл."
+
+#: id:20077
+msgid "Skin settings"
+msgstr "Поставке маске"
+
+#: id:20078
+msgid "- no link set -"
+msgstr "- веза није постављена -"
+
+#: id:20079
+msgid "Enable animations"
+msgstr "Омогући анимације"
+
+#: id:20080
+msgid "Disable RSS during music"
+msgstr "Онемогући RSS новости током репродукције музике"
+
+#: id:20081
+msgid "Enable shortcut buttons"
+msgstr "Омогући пречице"
+
+#: id:20082
+msgid "Show programs in main menu"
+msgstr "Прикажи програме у главном менију"
+
+#: id:20083
+msgid "Show music info"
+msgstr "Прикажи податке о музици"
+
+#: id:20084
+msgid "Show weather info"
+msgstr "Прикажи податке о времену"
+
+#: id:20085
+msgid "Show system info"
+msgstr "Прикажи податке о систему"
+
+#: id:20086
+msgid "Show available disc space C: E: F:"
+msgstr "Прикажи слободан простор на диску C: E: F:"
+
+#: id:20087
+msgid "Show available disc space E: F: G:"
+msgstr "Прикажи слободан простор на диску E: F: G:"
+
+#: id:20088
+msgid "Weather info"
+msgstr "Подаци о времену"
+
+#: id:20089
+msgid "Drive space free"
+msgstr "Слободан простор на диску"
+
+#: id:20090
+msgid "Enter the name of an existing share"
+msgstr "Унесите име постојећег дељеног ресурса"
+
+#: id:20091
+msgid "Lock code"
+msgstr "Кôд за закључавање"
+
+#: id:20092
+msgid "Load profile"
+msgstr "Учитај профил"
+
+#: id:20093
+msgid "Profile name"
+msgstr "Име профила"
+
+#: id:20094
+msgctxt "Auto context with id 20094"
+msgid "Media sources"
+msgstr "Медија извори"
+
+#: id:20095
+msgid "Enter profile lock code"
+msgstr "Унесите кôд за откључавање профила"
+
+#: id:20096
+msgctxt "Auto context with id 20096"
+msgid "Login screen"
+msgstr "Екран за пријаву"
+
+#: id:20097
+msgid "Fetching album info"
+msgstr "Преузимање података о албуму"
+
+#: id:20098
+msgid "Fetching info for album"
+msgstr "Преузимање података за албум"
+
+#: id:20099
+msgid "Can't rip CD or track while playing from CD"
+msgstr "Није могуће риповати музички CD током репродукције са CD-а"
+
+#: id:20100
+msgid "Master lock code and settings"
+msgstr "Главни кôд за закључавање и поставке"
+
+#: id:20101
+msgid "Entering master lock code always enables master mode"
+msgstr "Уносом главног кôда увек омогућавате главни режим рада"
+
+#: id:20102
+msgid "or copy from default?"
+msgstr "или копирање од подразумеваног?"
+
+#: id:20103
+msgid "Save changes to profile?"
+msgstr "Сачувати промене у профил?"
+
+#: id:20104
+msgid "Old settings found."
+msgstr "Пронађене су старе поставке."
+
+#: id:20105
+msgid "Do you want to use them?"
+msgstr "Желите ли да их користите?"
+
+#: id:20106
+msgid "Old media sources found."
+msgstr "Пронађени стари извори медија."
+
+#: id:20107
+msgid "Separate (locked)"
+msgstr "Раздвајање (закључано)"
+
+#: id:20108
+msgid "Root"
+msgstr "Корена фасцикла"
+
+#: id:20109
+msgid "- Zoom"
+msgstr "- Увеличавање"
+
+#: id:20110
+msgid "UPnP settings"
+msgstr "UPnP поставке"
+
+#: id:20111
+msgid "Autostart UPnP client"
+msgstr "Аутом. покретање UPnP клијента"
+
+#: id:20112
+msgid "Last login: %s"
+msgstr "Последња пријава: %s"
+
+#: id:20113
+msgid "Never logged on"
+msgstr "Није било пријаве до сада"
+
+#: id:20114
+msgid "Profile %i / %i"
+msgstr "Профил %i / %i"
+
+#: id:20115
+msgid "User login / Select a profile"
+msgstr "Пријава корисника / Изаберите профил"
+
+#: id:20116
+msgid "Use lock on login screen"
+msgstr "Користи закључавање екрана за пријаву"
+
+#: id:20117
+msgid "Invalid lock code."
+msgstr "Кôд није исправан."
+
+#: id:20118
+msgid "This requires the master lock to be set."
+msgstr "Ово захтева унос главног кôда."
+
+#: id:20119
+msgid "Would you like to set it now?"
+msgstr "Желите ли одмах да поставите?"
+
+#: id:20120
+msgid "Loading program information"
+msgstr "Учитавање података о програму"
+
+#: id:20121
+msgid "Party on!"
+msgstr "Журка!"
+
+#: id:20122
+msgid "True"
+msgstr "Исправно"
+
+#: id:20123
+msgid "Mixing drinks"
+msgstr "Мешање пића"
+
+#: id:20124
+msgid "Filling glasses"
+msgstr "Пуњење чаша"
+
+#: id:20125
+msgid "Logged on as"
+msgstr "Пријављен као"
+
+#: id:20126
+msgid "Log off"
+msgstr "Одјави се"
+
+#: id:20128
+msgid "Go to root"
+msgstr "Иди у корену фасц."
+
+#: id:20129
+msgid "Weave"
+msgstr "Таласи"
+
+#: id:20130
+msgid "Weave (inverted)"
+msgstr "Таласи (обрнути)"
+
+#: id:20131
+msgid "Blend"
+msgstr "Мешовито"
+
+#: id:20132
+msgid "Restart video"
+msgstr "Поново покрени филм"
+
+#: id:20133
+msgid "Edit network location"
+msgstr "Уреди мрежну локацију"
+
+#: id:20134
+msgid "Remove network location"
+msgstr "Уклони мрежну локацију"
+
+#: id:20135
+msgid "Do you want to scan the folder?"
+msgstr "Желите ли да анализирате фасциклу?"
+
+#: id:20136
+msgid "Memory unit"
+msgstr "Јединица меморије"
+
+#: id:20137
+msgid "Memory unit mounted"
+msgstr "Јединица меморије је постављена"
+
+#: id:20138
+msgid "Unable to mount memory unit"
+msgstr "Није могуће поставити јединицу меморије"
+
+#: id:20139
+msgid "In port %i, slot %i"
+msgstr "у прикључку %i, конектор %i"
+
+#: id:20140
+msgid "Lock screensaver"
+msgstr "Закључај чувара екрана"
+
+#: id:20141
+msgid "Set"
+msgstr "Постави"
+
+#: id:20142
+msgctxt "Auto context with id 20142"
+msgid "Username"
+msgstr "Корисничко име"
+
+#: id:20143
+msgid "Enter password for"
+msgstr "Унесите лозинку за"
+
+#: id:20144
+msgid "Shutdown timer"
+msgstr "Одбројавање до искључивања"
+
+#: id:20145
+msgid "Shutdown interval (in minutes)"
+msgstr "Интервал искључивања (у минутима)"
+
+#: id:20146
+msgid "Started, shutdown in %im"
+msgstr "Покренуто, искључивање за %i мин."
+
+#: id:20147
+msgid "Shutdown in 30 minutes"
+msgstr "Искључи за 30 минута"
+
+#: id:20148
+msgid "Shutdown in 60 minutes"
+msgstr "Искључи за 60 минута"
+
+#: id:20149
+msgid "Shutdown in 120 minutes"
+msgstr "Искључи за 120 минута"
+
+#: id:20150
+msgid "Custom shutdown timer"
+msgstr "Прилагођено одбројавање до искључења"
+
+#: id:20151
+msgid "Cancel shutdown timer"
+msgstr "Откажи одбројавање"
+
+#: id:20152
+msgid "Lock preferences for %s"
+msgstr "Закључај подешавања за %s"
+
+#: id:20153
+msgid "Browse..."
+msgstr "Потражи..."
+
+#: id:20154
+msgid "Summary information"
+msgstr "Кратак преглед информација"
+
+#: id:20155
+msgid "Storage information"
+msgstr "Подаци о складишту"
+
+#: id:20156
+msgid "Hard disk information"
+msgstr "Подаци о чврстом диску"
+
+#: id:20157
+msgid "DVD-ROM information"
+msgstr "Подаци о DVD-ROM уређају"
+
+#: id:20158
+msgid "Network information"
+msgstr "Подаци о мрежи"
+
+#: id:20159
+msgid "Video information"
+msgstr "Подаци о видеу"
+
+#: id:20160
+msgid "Hardware information"
+msgstr "Подаци о хардверу"
+
+#: id:20161
+msgid "Total"
+msgstr "Укупно"
+
+#: id:20162
+msgid "Used"
+msgstr "Искоришћено"
+
+#: id:20163
+msgid "of"
+msgstr "од"
+
+#: id:20164
+msgid "Locking not supported"
+msgstr "Закључавање није подржано"
+
+#: id:20165
+msgid "Not locked"
+msgstr "Није закључано"
+
+#: id:20166
+msgid "Locked"
+msgstr "Закључано"
+
+#: id:20167
+msgid "Frozen"
+msgstr "Замрзнуто"
+
+#: id:20168
+msgid "Requires reset"
+msgstr "Захтева поновно покретање"
+
+#: id:20169
+msgid "Week"
+msgstr "Недеља"
+
+#: id:20170
+msgid "Line"
+msgstr "Линија"
+
+#: id:20171
+msgid "Windows network (SMB)"
+msgstr "Windows мрежа (SMB)"
+
+#: id:20172
+msgid "XBMSP server"
+msgstr "XBMSP сервер"
+
+#: id:20173
+msgctxt "Auto context with id 20173"
+msgid "FTP server"
+msgstr "FTP сервер"
+
+#: id:20174
+msgid "iTunes music share (DAAP)"
+msgstr "iTunes дељена музика (DAAP)"
+
+#: id:20175
+msgid "UPnP server"
+msgstr "UPnP сервер"
+
+#: id:20176
+msgid "Show video info"
+msgstr "Прикажи податке о филму"
+
+#: id:20177
+msgid "Done"
+msgstr "Заврши"
+
+#: id:20178
+msgid "Shift"
+msgstr "Shift"
+
+#: id:20179
+msgid "Caps Lock"
+msgstr "Вел. слова"
+
+#: id:20180
+msgid "Symbols"
+msgstr "Симболи"
+
+#: id:20181
+msgid "Backspace"
+msgstr "Брисање уназад"
+
+#: id:20182
+msgid "Space"
+msgstr "Размак"
+
+#: id:20183
+msgid "Reload skin"
+msgstr "Поново учитај маску"
+
+#: id:20184
+msgid "Rotate pictures using EXIF information"
+msgstr "Ротирај слике на основу EXIF података"
+
+#: id:20185
+msgid "Use poster view styles for TV shows"
+msgstr "Користи стил приказа постера за TV серије"
+
+#: id:20186
+msgid "Please wait"
+msgstr "Молимо сачекајте"
+
+#: id:20187
+msgid "UPnP"
+msgstr "Прављење рез. копије EEPROM-а"
+
+#: id:20189
+msgid "Enable auto scrolling for plot & review"
+msgstr "Омогући аутом. померање описа и рецензија (синонописа)"
+
+#: id:20190
+msgctxt "Auto context with id 20190"
+msgid "Custom"
+msgstr "Прилагођено"
+
+#: id:20191
+msgid "Enable debug logging"
+msgstr "Омогући бележење грешака"
+
+#: id:20192
+msgid "Download additional information during updates"
+msgstr "Преузми додатне податке приликом ажурирања"
+
+#: id:20193
+msgid "Default service for album information"
+msgstr ""
+
+#: id:20194
+msgid "Default service for artist information"
+msgstr "Подразумевани даваоц података о музици"
+
+#: id:20195
+msgid "Change scraper"
+msgstr "Промени даваоца података"
+
+#: id:20196
+msgid "Export music library"
+msgstr "Извоз музичке библиотеке"
+
+#: id:20197
+msgid "Import music library"
+msgstr "Увоз музичке библиотеке"
+
+#: id:20198
+msgid "No artist found!"
+msgstr "Извођач није пронађен!"
+
+#: id:20199
+msgid "Downloading artist info failed"
+msgstr "Није успело преузимање података о извођачу"
+
+#: id:20250
+msgid "Party on! (videos)"
+msgstr "Журка! (филмови)"
+
+#: id:20251
+msgid "Mixing drinks (videos)"
+msgstr "Мешање пића (филмови)"
+
+#: id:20252
+msgid "Filling glasses (videos)"
+msgstr "Пуњење чаша (филмови)"
+
+#: id:20253
+msgid "WebDAV server (HTTP)"
+msgstr "WebDAV сервер (HTTP)"
+
+#: id:20254
+msgid "WebDAV server (HTTPS)"
+msgstr "WebDAV сервер (HTTPS)"
+
+#: id:20255
+msgid "First logon, edit your profile"
+msgstr "Измените ваш профил приликом првог пријављивања"
+
+#: id:20256
+msgid "HTS Tvheadend client"
+msgstr ""
+
+#: id:20257
+msgid "VDR Streamdev client"
+msgstr ""
+
+#: id:20258
+msgid "MythTV client"
+msgstr ""
+
+#: id:20259
+msgid "Network Filesystem (NFS)"
+msgstr ""
+
+#: id:20260
+msgid "Secure Shell (SSH/SFTP)"
+msgstr ""
+
+#: id:20261
+msgid "Apple Filing Protocol (AFP)"
+msgstr ""
+
+#: id:20300
+msgid "Web server directory (HTTP)"
+msgstr "Фасцикла Web сервера (HTTP)"
+
+#: id:20301
+msgid "Web server directory (HTTPS)"
+msgstr "Фасцикла Web сервера (HTTPS)"
+
+#: id:20302
+msgid "Unable to write to folder:"
+msgstr "Није могуће уписивање у фасциклу:"
+
+#: id:20303
+msgid "Do you want to skip and proceed?"
+msgstr "Желите ли да прескочите и наставите?"
+
+#: id:20304
+msgid "RSS Feed"
+msgstr "RSS новости"
+
+#: id:20307
+msgid "Secondary DNS"
+msgstr "Алтернативни DNS"
+
+#: id:20308
+msgid "DHCP server:"
+msgstr "DHCP сервер:"
+
+#: id:20309
+msgid "Make new folder"
+msgstr "Направи нову фасциклу"
+
+#: id:20310
+msgid "Dim LCD on playback"
+msgstr "Затамни LCD приликом репродукције"
+
+#: id:20311
+msgid "Unknown or onboard (protected)"
+msgstr "Непознато или је уграђен на плочи (заштићено)"
+
+#: id:20312
+msgid "Dim LCD on paused"
+msgstr "Затамни LCD приликом паузе"
+
+#: id:20314
+msgid "Videos - Library"
+msgstr "Филмска Библиоте."
+
+#: id:20316
+msgid "Sort by: ID"
+msgstr "Сложи по: ID"
+
+#: id:20324
+msgid "Play part..."
+msgstr "Репродукуј део..."
+
+#: id:20325
+msgid "Calibration reset"
+msgstr "Поновна калибрација"
+
+#: id:20326
+msgid "This will reset the calibration values for %s"
+msgstr "Овим ћете поништити вредности калибрације за %s"
+
+#: id:20327
+msgid "to it's default values."
+msgstr "на подразумеване вредности."
+
+#: id:20328
+msgid "Browse for destination"
+msgstr "Потражи одредиште"
+
+#: id:20329
+msgid "Movies are in separate folders that match the movie title"
+msgstr ""
+
+#: id:20330
+msgid "Use folder names for lookups"
+msgstr "Користи имена фасцикли за претрагу"
+
+#: id:20331
+msgctxt "Auto context with id 20331"
+msgid "File"
+msgstr "Датотеке"
+
+#: id:20332
+msgid "Use file or folder names in lookups?"
+msgstr "Коришћење имена датотеке или фасцикле за претрагу?"
+
+#: id:20333
+msgid "Set content"
+msgstr "Постави садржај"
+
+#: id:20334
+msgid "Folder"
+msgstr "Фасцикле"
+
+#: id:20335
+msgid "Look for content recursively?"
+msgstr "Рекурзивна претрага садржаја?"
+
+#: id:20336
+msgid "Unlock sources"
+msgstr "Откључај изворе"
+
+#: id:20337
+msgid "Actor"
+msgstr "Глумац"
+
+#: id:20338
+msgid "Movie"
+msgstr "Филм"
+
+#: id:20339
+msgid "Director"
+msgstr "Режисер"
+
+#: id:20340
+msgid "Do you want to remove all items within"
+msgstr "Желите ли да уклоните све ставке у оквиру"
+
+#: id:20341
+msgid "this path from the XBMC library?"
+msgstr "ове путање из XBMC библиотеке?"
+
+#: id:20342
+msgctxt "Auto context with id 20342"
+msgid "Movies"
+msgstr "Филмови"
+
+#: id:20343
+msgid "TV shows"
+msgstr "TV серије"
+
+#: id:20344
+msgid "This directory contains"
+msgstr "Ова фасцикла садржи"
+
+#: id:20345
+msgid "Run automated scan"
+msgstr "Покрени аутоматску анализу"
+
+#: id:20346
+msgid "Scan recursively"
+msgstr "Рекурзивна анализа"
+
+#: id:20347
+msgid "as"
+msgstr "као"
+
+#: id:20348
+msgid "Directors"
+msgstr "Режисери"
+
+#: id:20349
+msgid "No video files found in this path!"
+msgstr "На овој путањи не постоје видео датотеке!"
+
+#: id:20350
+msgid "votes"
+msgstr "гласова"
+
+#: id:20351
+msgid "TV show information"
+msgstr "Подаци о TV серији"
+
+#: id:20352
+msgid "Episode information"
+msgstr "Подаци о епизодама"
+
+#: id:20353
+msgid "Loading TV show details"
+msgstr "Учитавање детаља TV серије"
+
+#: id:20354
+msgid "Fetching episode guide"
+msgstr "Проналажење водича епизода"
+
+#: id:20355
+msgid "Loading info for episodes in directory"
+msgstr "Учитавање описа епизоде у фасцикли"
+
+#: id:20356
+msgid "Select TV show:"
+msgstr "Изаберите TV серију:"
+
+#: id:20357
+msgid "Enter the TV show name"
+msgstr "Унесите назив TV серије"
+
+#: id:20358
+msgid "Season %i"
+msgstr "Сезона %i"
+
+#: id:20359
+msgid "Episode"
+msgstr "Епизода"
+
+#: id:20360
+msgid "Episodes"
+msgstr "Епизода"
+
+#: id:20361
+msgid "Loading episode details"
+msgstr "Учитавање детаља епизоде"
+
+#: id:20362
+msgid "Remove episode from library"
+msgstr "Уклони епизоду из библиотеке"
+
+#: id:20363
+msgid "Remove TV show from library"
+msgstr "Уклони TV серију из библиотеке"
+
+#: id:20364
+msgid "TV show"
+msgstr "TV серија"
+
+#: id:20365
+msgid "Episode plot"
+msgstr "Опис епизоде"
+
+#: id:20366
+msgid "* All seasons"
+msgstr "* Све сезоне"
+
+#: id:20367
+msgid "Hide watched"
+msgstr "Сакр. одглед."
+
+#: id:20368
+msgid "Prod code"
+msgstr "Шифра производа"
+
+#: id:20369
+msgid "Show plot for unwatched items"
+msgstr "Прикажи опис за неодгледане ставке"
+
+#: id:20370
+msgid "* Hidden to prevent spoilers *"
+msgstr "* Скривено због спречавања непрописне употребе *"
+
+#: id:20371
+msgid "Set season thumb"
+msgstr "Постави сличицу за сезону"
+
+#: id:20372
+msgid "Season image"
+msgstr "Слика за сезону"
+
+#: id:20373
+msgid "Season"
+msgstr "Сезона"
+
+#: id:20374
+msgid "Downloading movie information"
+msgstr "Преузимање података о филму"
+
+#: id:20375
+msgid "Unassign content"
+msgstr "Неодређен садржај"
+
+#: id:20376
+msgid "Original title"
+msgstr ""
+
+#: id:20377
+msgid "Refresh TV show information"
+msgstr "Освежи податке TV серије"
+
+#: id:20378
+msgid "Refresh info for all episodes?"
+msgstr "Освежити податке за све епизоде?"
+
+#: id:20379
+msgid "Selected folder contains a single TV show"
+msgstr "Изабрана фасцикла садржи једну TV серију"
+
+#: id:20380
+msgid "Exclude selected folder from scans"
+msgstr "Изузми изабрану фасциклу из анализирања"
+
+#: id:20381
+msgid "Specials"
+msgstr "Посебне емисије"
+
+#: id:20382
+msgid "Automatically grab season thumbs"
+msgstr "Аутоматски преузми сличицу сезоне"
+
+#: id:20383
+msgid "Selected folder contains a single video"
+msgstr "Изабрана фасцикла садржи један филм"
+
+#: id:20384
+msgid "Link to TV show"
+msgstr "Веза ка TV серији"
+
+#: id:20385
+msgid "Remove link to TV show"
+msgstr "Уклони везу ка TV серији"
+
+#: id:20386
+msgid "Recently added movies"
+msgstr "Недав. додати филм."
+
+#: id:20387
+msgid "Recently added episodes"
+msgstr "Недав. додате епизоде"
+
+#: id:20388
+msgid "Studios"
+msgstr "Студији"
+
+#: id:20389
+msgid "Music videos"
+msgstr "Музичке спотове"
+
+#: id:20390
+msgid "Recently added music videos"
+msgstr "Недавно додати музички спотови"
+
+#: id:20391
+msgid "Music video"
+msgstr "Музички спот"
+
+#: id:20392
+msgid "Remove music video from library"
+msgstr "Уклони музички спот из библиотеке"
+
+#: id:20393
+msgctxt "Auto context with id 20393"
+msgid "Music video information"
+msgstr "Подаци о музичком споту"
+
+#: id:20394
+msgid "Loading music video information"
+msgstr "Учитавање података о музичком споту"
+
+#: id:20395
+msgid "Mixed"
+msgstr "Мешано"
+
+#: id:20396
+msgid "Go to albums by artist"
+msgstr "Иди на албуме извођача"
+
+#: id:20397
+msgid "Go to album"
+msgstr "Иди на албум"
+
+#: id:20398
+msgid "Play song"
+msgstr "Репродукуј песму"
+
+#: id:20399
+msgid "Go to music videos from album"
+msgstr "Иди на музичке спотове из албума"
+
+#: id:20400
+msgid "Go to music videos by artist"
+msgstr "Иди на музичке спотове извођача"
+
+#: id:20401
+msgid "Play music video"
+msgstr "Репродукуј музички спот"
+
+#: id:20402
+msgid "Download actor thumbnails when adding to library"
+msgstr "Преузми сличице глумаца приликом додавања у библиотеку"
+
+#: id:20403
+msgid "Set actor thumb"
+msgstr "Постави слику глумца"
+
+#: id:20405
+msgid "Remove episode bookmark"
+msgstr "Уклони обележивач епизоде"
+
+#: id:20406
+msgid "Set episode bookmark"
+msgstr "Постави обележивач епизоде"
+
+#: id:20407
+msgid "Scraper settings"
+msgstr "Поставке даваоца података"
+
+#: id:20408
+msgid "Downloading music video information"
+msgstr "Преузимање података о музичком споту"
+
+#: id:20409
+msgid "Downloading TV show information"
+msgstr "Преузимање података о TV серији"
+
+#: id:20410
+msgid "Trailer"
+msgstr "Најава"
+
+#: id:20411
+msgid "Flatten"
+msgstr "Поравнат списак"
+
+#: id:20412
+msgid "Flatten TV shows"
+msgstr "Поравнат списак TV серија"
+
+#: id:20413
+msgid "Get fanart"
+msgstr "Заним. слика"
+
+#: id:20414
+msgid "Show Fanart in video and music libraries"
+msgstr "Прикажи занимљиву слику у филмским и музичким библиотекама"
+
+#: id:20415
+msgid "Scanning for new content"
+msgstr "Трањеже новог садржаја"
+
+#: id:20416
+msgid "First aired"
+msgstr "Премијера"
+
+#: id:20417
+msgid "Writer"
+msgstr "Сценариста"
+
+#: id:20419
+msgid "Replace file names with library titles"
+msgstr ""
+
+#: id:20420
+msgctxt "Auto context with id 20420"
+msgid "Never"
+msgstr "Никада"
+
+#: id:20421
+msgid "If only one season"
+msgstr "Уколико је само једна сезона"
+
+#: id:20422
+msgid "Always"
+msgstr "Увек"
+
+#: id:20423
+msgid "Has trailer"
+msgstr "Има најаву филма"
+
+#: id:20424
+msgid "False"
+msgstr "Нетачно"
+
+#: id:20425
+msgid "Fanart slideshow"
+msgstr "Пројекција занимљивих слика"
+
+#: id:20426
+msgid "Export to a single file or separate"
+msgstr "Извоз у једну или засебне"
+
+#: id:20427
+msgid "files per entry?"
+msgstr "датотеке по уносу?"
+
+#: id:20428
+msgid "Single file"
+msgstr "Једна датотека"
+
+#: id:20429
+msgctxt "Auto context with id 20429"
+msgid "Separate"
+msgstr "Засебно"
+
+#: id:20430
+msgid "Export thumbnails and fanart?"
+msgstr "Извоз сличица и занимљивих слика?"
+
+#: id:20431
+msgid "Overwrite old files?"
+msgstr "Заменити старе датотеке?"
+
+#: id:20432
+msgid "Exclude path from library updates"
+msgstr "Изузми путању приликом ажурирања библиотеке"
+
+#: id:20433
+msgid "Extract thumbnails and video information"
+msgstr "Извези сличице и податке филма"
+
+#: id:20434
+msgid "Sets"
+msgstr "Поставке сцене"
+
+#: id:20435
+msgid "Set movieset thumb"
+msgstr "Постави слике са снимања филма"
+
+#: id:20436
+msgid "Export actor thumbs?"
+msgstr "Извоз сличица глумца?"
+
+#: id:20437
+msgid "Choose fanart"
+msgstr "Изаберите занимљиву слику"
+
+#: id:20438
+msgid "Local fanart"
+msgstr "Локална занимљива слика"
+
+#: id:20439
+msgid "No fanart"
+msgstr "Без занимљиве слике"
+
+#: id:20440
+msgid "Current fanart"
+msgstr "Тренутна занимљива слика"
+
+#: id:20441
+msgid "Remote fanart"
+msgstr "Удаљена занимљива слика"
+
+#: id:20442
+msgid "Change content"
+msgstr "Промени садржај"
+
+#: id:20443
+msgid "Do you want to refresh info for all"
+msgstr "Желите ли да освежите податке свих"
+
+#: id:20444
+msgid "items within this path?"
+msgstr "ставки са ове путање?"
+
+#: id:20445
+msgid "Fanart"
+msgstr "Занимљива слика"
+
+#: id:20446
+msgid "Locally stored information found."
+msgstr "Пронађени су локално сачувани подаци."
+
+#: id:20447
+msgid "Ignore and refresh from internet?"
+msgstr "Занемарити их и освежити исте са подацима са Интернета?"
+
+#: id:20448
+msgid "Could not download information"
+msgstr "Није могуће преузети податке"
+
+#: id:20449
+msgid "Unable to connect to remote server"
+msgstr "Сервер је највероватније недоступан."
+
+#: id:20450
+msgid "Would you like to continue scanning?"
+msgstr "Желите ли да наставите анализирање?"
+
+#: id:20451
+msgid "Countries"
+msgstr ""
+
+#: id:20452
+msgid "episode"
+msgstr ""
+
+#: id:20453
+msgid "episodes"
+msgstr ""
+
+#: id:20454
+msgid "Listener"
+msgstr ""
+
+#: id:20455
+msgid "Listeners"
+msgstr ""
+
+#: id:20456
+msgid "Set movieset fanart"
+msgstr ""
+
+#: id:20457
+msgid "Movie set"
+msgstr ""
+
+#: id:20458
+msgid "Group movies in sets"
+msgstr ""
+
+#: id:21330
+msgid "Show hidden files and directories"
+msgstr "Прикажи скривене датотеке и фасцикле"
+
+#: id:21331
+msgid "TuxBox client"
+msgstr "TuxBox клијент"
+
+#: id:21332
+msgid "WARNING: Target TuxBox device is in recording-mode!"
+msgstr "ПАЖЊА: Изабрани TuxBox уређај тренутно снима!"
+
+#: id:21333
+msgid "The stream will be stopped!"
+msgstr "Биће заустављен запис тока података!"
+
+#: id:21334
+msgid "Zap to channel: %s failed!"
+msgstr "Пребацивање на канал: %s није успело!"
+
+#: id:21335
+msgid "Are you sure to start the stream?"
+msgstr "Сигурни сте да желите да покренете ток података?"
+
+#: id:21336
+msgid "Connecting to: %s"
+msgstr "Повезивање са: %s"
+
+#: id:21337
+msgid "TuxBox device"
+msgstr "TuxBox уређај"
+
+#: id:21359
+msgid "Add media share..."
+msgstr "Додај дељену локацију медија..."
+
+#: id:21360
+msgid "Share video and music libraries through UPnP"
+msgstr "Дели филмску и музичку библиотеку путем UPnP протокола"
+
+#: id:21364
+msgid "Edit media share"
+msgstr "Уреди дељену локацију медија"
+
+#: id:21365
+msgid "Remove media share"
+msgstr "Уклони дељену локацију медија"
+
+#: id:21366
+msgid "Subtitle folder"
+msgstr "Фасцикла са титловима"
+
+#: id:21367
+msgid "Movie & alternate subtitle directory"
+msgstr "Фасцикла филмова и алтернативних титлова"
+
+#: id:21368
+msgid "Override ASS/SSA subtitles fonts"
+msgstr ""
+
+#: id:21369
+msgid "Enable mouse and Touch Screen support"
+msgstr "Омогући коришћење миша"
+
+#: id:21370
+msgid "Play navigation sounds during media playback"
+msgstr "Репродукуј навигационе звукове приликом репродукције медија"
+
+#: id:21371
+msgid "Thumbnail"
+msgstr "Сличица"
+
+#: id:21372
+msgid "Forced DVD player region"
+msgstr "Наметнута регија DVD уређаја за репродукцију"
+
+#: id:21373
+msgid "Video output"
+msgstr "Видео излаз"
+
+#: id:21374
+msgid "Video aspect"
+msgstr "Размера слике"
+
+#: id:21375
+msgctxt "Auto context with id 21375"
+msgid "Normal"
+msgstr "Нормално"
+
+#: id:21376
+msgid "Letterbox"
+msgstr "Letterbox"
+
+#: id:21377
+msgid "Widescreen"
+msgstr "Широки екран"
+
+#: id:21378
+msgid "Enable 480p"
+msgstr "Омогући 480p"
+
+#: id:21379
+msgid "Enable 720p"
+msgstr "Омогући 720p"
+
+#: id:21380
+msgid "Enable 1080i"
+msgstr "Омогући 1080i"
+
+#: id:21381
+msgid "Enter name of new playlist"
+msgstr "Унесите име новог списка за репродукцију"
+
+#: id:21382
+msgid "Show \"Add source\" buttons in file lists"
+msgstr "Прикажи дугме „Додај извор“ у списку датотека"
+
+#: id:21383
+msgid "Enable scrollbars"
+msgstr "Омогући траке за померање"
+
+#: id:21384
+msgid "Make watched filtering a toggle in video library"
+msgstr "Исфилтрирај одгледане филмове у библиотеци филмова"
+
+#: id:21385
+msgctxt "Auto context with id 21385"
+msgid "Open"
+msgstr "Отвори"
+
+#: id:21386
+msgid "Acoustic management level"
+msgstr "Управљање нивоом акустичности"
+
+#: id:21387
+msgid "Fast"
+msgstr "Брзо"
+
+#: id:21388
+msgid "Quiet"
+msgstr "Тихо"
+
+#: id:21389
+msgid "Enable custom background"
+msgstr "Омогући прилагођену позадину"
+
+#: id:21390
+msgid "Power management level"
+msgstr "Управљање нивоом потрошње"
+
+#: id:21391
+msgid "High power"
+msgstr "Виша потрошња"
+
+#: id:21392
+msgid "Low power"
+msgstr "Нижа потрошња"
+
+#: id:21393
+msgid "High standby"
+msgstr "High standby"
+
+#: id:21394
+msgid "Low standby"
+msgstr "Low standby"
+
+#: id:21395
+msgid "Unable to cache files bigger than 4GB"
+msgstr "Није могуће кеширати датотеке веће од 4GB"
+
+#: id:21396
+msgid "Chapter"
+msgstr "Поглавље"
+
+#: id:21397
+msgid "High quality pixel shader v2"
+msgstr "Високо квалитетно сенчење пиксела v2"
+
+#: id:21398
+msgid "Enable playlist at startup"
+msgstr "Омогући списак за репродукцију при укључивању XBMC-а"
+
+#: id:21399
+msgid "Use tween animations"
+msgstr "Користи међукораке у анимацији"
+
+#: id:21400
+msgid "contains"
+msgstr "садржи"
+
+#: id:21401
+msgid "does not contain"
+msgstr "не садржи"
+
+#: id:21402
+msgid "is"
+msgstr "је"
+
+#: id:21403
+msgid "is not"
+msgstr "није"
+
+#: id:21404
+msgid "starts with"
+msgstr "почиње са"
+
+#: id:21405
+msgid "ends with"
+msgstr "завршава са"
+
+#: id:21406
+msgid "greater than"
+msgstr "је веће од"
+
+#: id:21407
+msgid "less than"
+msgstr "је мање од"
+
+#: id:21408
+msgid "after"
+msgstr "након"
+
+#: id:21409
+msgid "before"
+msgstr "пре"
+
+#: id:21410
+msgid "in the last"
+msgstr "у последњих"
+
+#: id:21411
+msgid "not in the last"
+msgstr "није у последњих"
+
+#: id:21412
+msgid "Scrapers"
+msgstr "Добављачи подат."
+
+#: id:21413
+msgid "Default movie scraper"
+msgstr "Подраз. добављач података за филмове"
+
+#: id:21414
+msgid "Default tvshow scraper"
+msgstr "Подраз. добављач података за TV серије"
+
+#: id:21415
+msgid "Default music video scraper"
+msgstr "Подраз. добављач података за музичке спотове"
+
+#: id:21416
+msgid "Enable fallback based on scraper language"
+msgstr "Омогући преузимање на основу језика добављача података"
+
+#: id:21417
+msgid "- Settings"
+msgstr "- Поставке"
+
+#: id:21418
+msgid "Multilingual"
+msgstr "Вишејезично"
+
+#: id:21419
+msgid "No scrapers present"
+msgstr "Нема присутних добављача"
+
+#: id:21420
+msgid "Value to match"
+msgstr "Вредности се не подударају"
+
+#: id:21421
+msgid "Smart playlist rule"
+msgstr "Правило паметног спис. за реп."
+
+#: id:21422
+msgid "Match items where"
+msgstr "Подудари ставке где"
+
+#: id:21423
+msgid "New rule..."
+msgstr "Ново правило..."
+
+#: id:21424
+msgid "Items must match"
+msgstr "Ставке се морају подударати"
+
+#: id:21425
+msgid "all of the rules"
+msgstr "су сва правила"
+
+#: id:21426
+msgid "one or more of the rules"
+msgstr "је једно или више правила"
+
+#: id:21427
+msgid "Limit to"
+msgstr "Ограничи на"
+
+#: id:21428
+msgid "No limit"
+msgstr "Без ограничења"
+
+#: id:21429
+msgid "Order by"
+msgstr "Сложи по"
+
+#: id:21430
+msgid "ascending"
+msgstr "растућем реду"
+
+#: id:21431
+msgid "descending"
+msgstr "опадајућем реду"
+
+#: id:21432
+msgid "Edit smart playlist"
+msgstr "Уреди паметни спис. за реп."
+
+#: id:21433
+msgid "Name of the playlist"
+msgstr "Име спис. за реп."
+
+#: id:21434
+msgid "Find items where"
+msgstr "Пронађи ставке где"
+
+#: id:21435
+msgid "Edit"
+msgstr "Уреди"
+
+#: id:21436
+msgid "%i items"
+msgstr "%i ставки"
+
+#: id:21437
+msgid "New smart playlist..."
+msgstr "Нови паметни спис. за реп..."
+
+#: id:21438
+msgid "%c Drive"
+msgstr "%c уређај"
+
+#: id:21439
+msgid "Edit party mode rules"
+msgstr "Уреди правила режима журке"
+
+#: id:21440
+msgid "Home folder"
+msgstr "Почетна фасцикла"
+
+#: id:21441
+msgid "Watched count"
+msgstr "Бројач одгледаних"
+
+#: id:21442
+msgid "Episode title"
+msgstr "Наслов епизоде"
+
+#: id:21443
+msgid "Video resolution"
+msgstr "Резолуција видеа"
+
+#: id:21444
+msgid "Audio channels"
+msgstr "Звучних канала"
+
+#: id:21445
+msgid "Video codec"
+msgstr "Видео кодек"
+
+#: id:21446
+msgid "Audio codec"
+msgstr "Кодек звука"
+
+#: id:21447
+msgid "Audio language"
+msgstr "Језик звука"
+
+#: id:21448
+msgid "Subtitle language"
+msgstr "Језик титла"
+
+#: id:21449
+msgid "Remote control sends keyboard presses"
+msgstr "Даљински управљач шаље кôдове тастатуре"
+
+#: id:21450
+msgid "- Edit"
+msgstr "- Уреди"
+
+#: id:21451
+msgid "Internet connection required."
+msgstr ""
+
+#: id:21452
+msgid "Get More..."
+msgstr ""
+
+#: id:21453
+msgid "Root filesystem"
+msgstr ""
+
+#: id:21454
+msgid "Cache full"
+msgstr ""
+
+#: id:21455
+msgid "Cache filled before reaching required amount for continous playback"
+msgstr ""
+
+#: id:21460
+msgid "Subtitle location"
+msgstr ""
+
+#: id:21461
+msgid "Fixed"
+msgstr ""
+
+#: id:21462
+msgid "Bottom of video"
+msgstr ""
+
+#: id:21463
+msgid "Below video"
+msgstr ""
+
+#: id:21464
+msgid "Top of video"
+msgstr ""
+
+#: id:21465
+msgid "Above video"
+msgstr ""
+
+#: id:21800
+msgid "File name"
+msgstr "Име датотеке"
+
+#: id:21801
+msgid "File path"
+msgstr "Путања датотеке"
+
+#: id:21802
+msgid "File size"
+msgstr "Величина датотеке"
+
+#: id:21803
+msgid "File date/time"
+msgstr "Датум/време стварања датотеке"
+
+#: id:21804
+msgid "Slide index"
+msgstr "Индекс слајдова"
+
+#: id:21805
+msgctxt "Auto context with id 21805"
+msgid "Resolution"
+msgstr "Резолуција"
+
+#: id:21806
+msgctxt "Auto context with id 21806"
+msgid "Comment"
+msgstr "Коментар"
+
+#: id:21807
+msgid "Colour/B&W"
+msgstr "Боја/Црно-бело"
+
+#: id:21808
+msgid "JPEG process"
+msgstr "Обрада JPEG-а"
+
+#: id:21820
+msgid "Date/Time"
+msgstr "Датум/време"
+
+#: id:21821
+msgid "Description"
+msgstr "Опис"
+
+#: id:21822
+msgid "Camera make"
+msgstr "Марка фотоапарата"
+
+#: id:21823
+msgid "Camera model"
+msgstr "Тип камере"
+
+#: id:21824
+msgid "EXIF comment"
+msgstr "EXIF коментар"
+
+#: id:21825
+msgid "Firmware"
+msgstr "Систем"
+
+#: id:21826
+msgid "Aperture"
+msgstr "Бленда"
+
+#: id:21827
+msgid "Focal length"
+msgstr "Фокусно растојање"
+
+#: id:21828
+msgid "Focus distance"
+msgstr "Жижна даљина"
+
+#: id:21829
+msgid "Exposure"
+msgstr "Експозиција"
+
+#: id:21830
+msgid "Exposure time"
+msgstr "Време експозиције"
+
+#: id:21831
+msgid "Exposure bias"
+msgstr "Одступање експозиције"
+
+#: id:21832
+msgid "Exposure mode"
+msgstr "Режим експозиције"
+
+#: id:21833
+msgid "Flash used"
+msgstr "Коришћење блица"
+
+#: id:21834
+msgid "White-balance"
+msgstr "Баланс белог"
+
+#: id:21835
+msgid "Light source"
+msgstr "Извор светла"
+
+#: id:21836
+msgid "Metering mode"
+msgstr "Режим мерења количине светла"
+
+#: id:21837
+msgid "ISO"
+msgstr "ISO"
+
+#: id:21838
+msgid "Digital zoom"
+msgstr "Дигитални зум"
+
+#: id:21839
+msgid "CCD width"
+msgstr "CCD ширина"
+
+#: id:21840
+msgid "GPS latitude"
+msgstr "GPS гео. ширина"
+
+#: id:21841
+msgid "GPS longitude"
+msgstr "GPS гео. дужина"
+
+#: id:21842
+msgid "GPS altitude"
+msgstr "GPS гео. висина"
+
+#: id:21843
+msgid "Orientation"
+msgstr "Оријентација"
+
+#: id:21860
+msgid "Supplemental categories"
+msgstr "Додатне категорије"
+
+#: id:21861
+msgid "Keywords"
+msgstr "Кључне речи"
+
+#: id:21862
+msgid "Caption"
+msgstr "Наслов"
+
+#: id:21863
+msgid "Author"
+msgstr "Аутор"
+
+#: id:21864
+msgid "Headline"
+msgstr "Главна улога"
+
+#: id:21865
+msgid "Special instructions"
+msgstr "Посебна упутства"
+
+#: id:21866
+msgid "Category"
+msgstr "Категорија"
+
+#: id:21867
+msgid "Byline"
+msgstr "Потпис аутора"
+
+#: id:21868
+msgid "Byline title"
+msgstr "Потпис аутора наслова"
+
+#: id:21869
+msgid "Credit"
+msgstr "Заслуга"
+
+#: id:21870
+msgid "Source"
+msgstr "Извор"
+
+#: id:21871
+msgid "Copyright notice"
+msgstr "Ауторска права"
+
+#: id:21872
+msgid "Object name"
+msgstr "Име објекта"
+
+#: id:21873
+msgid "City"
+msgstr "Град"
+
+#: id:21874
+msgid "State"
+msgstr "Покрајина"
+
+#: id:21875
+msgctxt "Auto context with id 21875"
+msgid "Country"
+msgstr "Држава"
+
+#: id:21876
+msgid "Original Tx Reference"
+msgstr "Original Tx Reference"
+
+#: id:21877
+msgid "Date created"
+msgstr "Датум прављења"
+
+#: id:21878
+msgid "Copyright flag"
+msgstr "Ознака ауторског права"
+
+#: id:21879
+msgid "Country code"
+msgstr "Кôд државе"
+
+#: id:21880
+msgid "Reference service"
+msgstr "Препоручен сервис"
+
+#: id:21881
+msgid "Allow control of XBMC via UPnP"
+msgstr "Омогући контролу XBMC апликације путем UPnP протокола"
+
+#: id:21882
+msgid "Attempt to skip introduction before DVD menu"
+msgstr "Покушај да прескочиш уводни део пре DVD менија"
+
+#: id:21883
+msgid "Saved music"
+msgstr "Сачувана музика"
+
+#: id:21884
+msgid "Query info for all artists"
+msgstr "Захтевање података за све извођаче"
+
+#: id:21885
+msgid "Downloading album information"
+msgstr "Преузимање података о албуму"
+
+#: id:21886
+msgid "Downloading artist information"
+msgstr "Преузимање података о извођачу"
+
+#: id:21887
+msgid "Biography"
+msgstr "Биографија"
+
+#: id:21888
+msgid "Discography"
+msgstr "Дискографија"
+
+#: id:21889
+msgid "Searching artist"
+msgstr "Проналажење извођача"
+
+#: id:21890
+msgid "Select artist"
+msgstr "Изаберите извођача"
+
+#: id:21891
+msgctxt "Auto context with id 21891"
+msgid "Artist information"
+msgstr "Подаци о извођачу"
+
+#: id:21892
+msgid "Instruments"
+msgstr "Инструменти"
+
+#: id:21893
+msgid "Born"
+msgstr "Рођен"
+
+#: id:21894
+msgid "Formed"
+msgstr "Оформљено"
+
+#: id:21895
+msgid "Themes"
+msgstr "Теме"
+
+#: id:21896
+msgid "Disbanded"
+msgstr "Расформирано"
+
+#: id:21897
+msgid "Died"
+msgstr "Преминуо"
+
+#: id:21898
+msgid "Years active"
+msgstr "Година активан"
+
+#: id:21899
+msgid "Label"
+msgstr "Етикета"
+
+#: id:21900
+msgid "Born/Formed"
+msgstr "Рођ./оформ."
+
+#: id:22000
+msgid "Update library on startup"
+msgstr "Ажурирај библиотеку приликом укључивања"
+
+#: id:22001
+msgid "Hide progress of library updates"
+msgstr "Увек ажурирај библиотеку у позадини"
+
+#: id:22002
+msgid "- DNS suffix"
+msgstr "- DNS суфикс"
+
+#: id:22003
+msgid "%2.3fs"
+msgstr ""
+
+#: id:22004
+msgid "Delayed by: %2.3fs"
+msgstr "Успорено за: %2.3f сек."
+
+#: id:22005
+msgid "Ahead by: %2.3fs"
+msgstr "Убрзано за: %2.3f сек."
+
+#: id:22006
+msgid "Subtitle offset"
+msgstr "Померај титла у времену"
+
+#: id:22007
+msgid "OpenGL vendor:"
+msgstr "OpenGL произвођач:"
+
+#: id:22008
+msgid "OpenGL renderer:"
+msgstr "OpenGL renderer:"
+
+#: id:22009
+msgid "OpenGL version:"
+msgstr "OpenGL верзија:"
+
+#: id:22010
+msgid "GPU temperature:"
+msgstr "GPU температура:"
+
+#: id:22011
+msgid "CPU temperature:"
+msgstr "CPU температура:"
+
+#: id:22012
+msgid "Total memory"
+msgstr "Укупна меморија"
+
+#: id:22013
+msgid "Profile data"
+msgstr "Подаци профила"
+
+#: id:22014
+msgid "Use dim if paused during video playback"
+msgstr "Користи затамљење уколико се паузира приликом репрод. филма"
+
+#: id:22015
+msgid "All recordings"
+msgstr "Сва снимања"
+
+#: id:22016
+msgid "By title"
+msgstr "По називу"
+
+#: id:22017
+msgid "By group"
+msgstr "По групи"
+
+#: id:22018
+msgid "Live channels"
+msgstr "Канали уживо"
+
+#: id:22019
+msgid "Recordings by title"
+msgstr "Снимци по називу"
+
+#: id:22020
+msgid "Guide"
+msgstr "Водич"
+
+#: id:22021
+msgid "Allowed error in aspect ratio to minimize black bars"
+msgstr "Дозв. грешка у односу, ради смањења црних трака"
+
+#: id:22022
+msgid "Show video files in listings"
+msgstr "Прикажи видео датотеке у списковима"
+
+#: id:22023
+msgid "DirectX vendor:"
+msgstr "DirectX произвођач:"
+
+#: id:22024
+msgid "Direct3D version:"
+msgstr "Direct3D верзија:"
+
+#: id:22030
+msgctxt "Auto context with id 22030"
+msgid "Font"
+msgstr "Слова"
+
+#: id:22031
+msgctxt "Auto context with id 22031"
+msgid "- Size"
+msgstr "- Величина"
+
+#: id:22032
+msgctxt "Auto context with id 22032"
+msgid "- Colours"
+msgstr "- Боја"
+
+#: id:22033
+msgid "- Charset"
+msgstr "- Знакови"
+
+#: id:22034
+msgid "Export karaoke titles as HTML"
+msgstr "Извоз караоке наслова као HTML"
+
+#: id:22035
+msgid "Export karaoke titles as CSV"
+msgstr "Извоз караоке наслова као CSV"
+
+#: id:22036
+msgid "Import karaoke titles..."
+msgstr "Увоз караоке наслова..."
+
+#: id:22037
+msgid "Show song selector automatically"
+msgstr "Аутоматски прикажи бирач песме"
+
+#: id:22038
+msgid "Export karaoke titles..."
+msgstr "Извоз караоке наслова..."
+
+#: id:22039
+msgid "Enter song number"
+msgstr "Унесите број песме"
+
+#: id:22040
+msgid "white/green"
+msgstr "бело/зелено"
+
+#: id:22041
+msgid "white/red"
+msgstr "бело/црвено"
+
+#: id:22042
+msgid "white/blue"
+msgstr "бело/право"
+
+#: id:22043
+msgid "black/white"
+msgstr "црно/бело"
+
+#: id:22079
+msgid "Default select action"
+msgstr ""
+
+#: id:22080
+msgid "Choose"
+msgstr ""
+
+#: id:22081
+msgid "Show Information"
+msgstr ""
+
+#: id:22082
+msgid "More..."
+msgstr ""
+
+#: id:22083
+msgid "Play all"
+msgstr ""
+
+#: id:23049
+msgid "Teletext not available"
+msgstr "Телетекст није доступан"
+
+#: id:23050
+msgid "Activate Teletext"
+msgstr "Активирај телетекст"
+
+#: id:23051
+msgid "Part %i"
+msgstr "Део %i"
+
+#: id:23052
+msgid "Buffering %i bytes"
+msgstr "Предмеморисање %i бајтова"
+
+#: id:23053
+msgid "Stopping"
+msgstr "Заустављање"
+
+#: id:23054
+msgid "Running"
+msgstr "Покретање"
+
+#: id:23100
+msgid "External Player Active"
+msgstr "Спољни активни уређај за репродукцију"
+
+#: id:23101
+msgid "Click OK to terminate the player"
+msgstr "Кликните на „У реду“ да прекинете репродукцију"
+
+#: id:23104
+msgid "Click OK when playback has ended"
+msgstr "Кликните на „У реду“ када се репродукција заврши"
+
+#: id:24000
+msgid "Add-on"
+msgstr "Додатни прог."
+
+#: id:24001
+msgid "Add-ons"
+msgstr "Додатни прог."
+
+#: id:24002
+msgid "Add-on options"
+msgstr "Опције додатног прог."
+
+#: id:24003
+msgid "Add-on Information"
+msgstr ""
+
+#: id:24005
+msgctxt "Auto context with id 24005"
+msgid "Media sources"
+msgstr "Додатак"
+
+#: id:24007
+msgctxt "Auto context with id 24007"
+msgid "Movie information"
+msgstr "Добављач"
+
+#: id:24008
+msgctxt "Auto context with id 24008"
+msgid "Screensaver"
+msgstr "Чувар екрана"
+
+#: id:24009
+msgid "Script"
+msgstr "Скрипта"
+
+#: id:24010
+msgctxt "Auto context with id 24010"
+msgid "Visualization"
+msgstr "Визуализација"
+
+#: id:24011
+msgid "Add-on repository"
+msgstr "Спремиште додатног прог."
+
+#: id:24012
+msgctxt "Auto context with id 24012"
+msgid "Subtitles"
+msgstr ""
+
+#: id:24013
+msgid "Lyrics"
+msgstr ""
+
+#: id:24014
+msgid "TV information"
+msgstr ""
+
+#: id:24015
+msgctxt "Auto context with id 24015"
+msgid "Music video information"
+msgstr ""
+
+#: id:24016
+msgctxt "Auto context with id 24016"
+msgid "Album information"
+msgstr ""
+
+#: id:24017
+msgctxt "Auto context with id 24017"
+msgid "Artist information"
+msgstr ""
+
+#: id:24018
+msgctxt "Auto context with id 24018"
+msgid "Services"
+msgstr ""
+
+#: id:24020
+msgid "Configure"
+msgstr "Подешавање додатног прог."
+
+#: id:24021
+msgctxt "Auto context with id 24021"
+msgid "Disable"
+msgstr "Онемогући додатни прог."
+
+#: id:24022
+msgid "Enable"
+msgstr "Омогући додатни прог."
+
+#: id:24023
+msgid "Add-on disabled"
+msgstr "Додатни прог. је онемогућен"
+
+#: id:24027
+msgctxt "Auto context with id 24027"
+msgid "Weather"
+msgstr "Услуге временске прогнозе"
+
+#: id:24028
+msgid "Weather.com (standard)"
+msgstr "Weather.com (стандардан)"
+
+#: id:24030
+msgid "This Add-on can not be configured"
+msgstr "Овај додатни прог. није могуће подесити"
+
+#: id:24031
+msgid "Error loading settings"
+msgstr "Грешка приликом учитавања подешавања"
+
+#: id:24032
+msgid "All Add-ons"
+msgstr ""
+
+#: id:24033
+msgid "Get Add-ons"
+msgstr ""
+
+#: id:24034
+msgid "Check for updates"
+msgstr ""
+
+#: id:24035
+msgid "Force refresh"
+msgstr ""
+
+#: id:24036
+msgid "Change log"
+msgstr ""
+
+#: id:24037
+msgid "Uninstall"
+msgstr ""
+
+#: id:24038
+msgid "Install"
+msgstr ""
+
+#: id:24039
+msgid "Disabled Add-ons"
+msgstr ""
+
+#: id:24040
+msgid "(Clear the current setting)"
+msgstr ""
+
+#: id:24041
+msgid "Install from zip file"
+msgstr ""
+
+#: id:24042
+msgid "Downloading %i%%"
+msgstr ""
+
+#: id:24043
+msgid "Available Updates"
+msgstr ""
+
+#: id:24044
+msgid "Dependencies not met"
+msgstr ""
+
+#: id:24045
+msgid "Add-on does not have the correct structure"
+msgstr ""
+
+#: id:24046
+msgid "%s is used by the following installed add-on(s)"
+msgstr ""
+
+#: id:24047
+msgid "This add-on cannot be uninstalled"
+msgstr ""
+
+#: id:24048
+msgid "Rollback"
+msgstr ""
+
+#: id:24050
+msgid "Available Add-ons"
+msgstr "Доступни додатни програми"
+
+#: id:24051
+msgid "Version:"
+msgstr "Верзија:"
+
+#: id:24052
+msgid "Disclaimer"
+msgstr "Одрицање:"
+
+#: id:24053
+msgid "License:"
+msgstr "Лиценца:"
+
+#: id:24054
+msgid "Changelog"
+msgstr ""
+
+#: id:24059
+msgid "Would you like to enable this Add-on?"
+msgstr "Да ли желите да омогућите овај додатни прог.?"
+
+#: id:24060
+msgid "Would you like to disable this Add-on?"
+msgstr "Да ли желите да онемогућите овај додатни прог.?"
+
+#: id:24061
+msgid "Add-on update available!"
+msgstr "Надоградња додатног прог. је доступна!"
+
+#: id:24062
+msgid "Enabled Add-ons"
+msgstr "Омогућени додатни програми"
+
+#: id:24063
+msgid "Auto update"
+msgstr "Аутоматско ажурирање"
+
+#: id:24064
+msgid "Add-on enabled"
+msgstr "Додатни прог. је омогућен"
+
+#: id:24065
+msgid "Add-on updated"
+msgstr "Додатни прог. је ажуриран"
+
+#: id:24066
+msgid "Cancel Add-on download?"
+msgstr "Да прекинем преузимање додатног прог.?"
+
+#: id:24067
+msgid "Currently downloading Add-ons"
+msgstr "Тренутно преузимам додатне програме"
+
+#: id:24068
+msgid "Update available"
+msgstr ""
+
+#: id:24069
+msgid "Update"
+msgstr ""
+
+#: id:24070
+msgid "Add-on could not be loaded."
+msgstr "Додатни програм није употребљив"
+
+#: id:24071
+msgid "An unknown error has occurred."
+msgstr "Догодила се непозната грешка"
+
+#: id:24072
+msgid "Settings required"
+msgstr "Подешавање је неопходно"
+
+#: id:24073
+msgid "Could not connect"
+msgstr "Не могу се повезати"
+
+#: id:24074
+msgid "Needs to restart"
+msgstr "Поновно покретање је неопходно"
+
+#: id:24075
+msgctxt "Auto context with id 24075"
+msgid "Disable"
+msgstr ""
+
+#: id:24076
+msgid "Add-on Required"
+msgstr ""
+
+#: id:24080
+msgid "Try to reconnect?"
+msgstr "Да покушам поновно успостављање везе?"
+
+#: id:24089
+msgid "Add-on restarts"
+msgstr "Додатни прог. се поновно покреће"
+
+#: id:24090
+msgid "Lock Add-on manager"
+msgstr "Закључај управљач додатног прог."
+
+#: id:24094
+msgid "(current)"
+msgstr "Омогући хардверско убрзање (CrystalHD)"
+
+#: id:24095
+msgid "(blacklisted)"
+msgstr ""
+
+#: id:24096
+msgid "Add-on has been marked as broken in repository."
+msgstr ""
+
+#: id:24097
+msgid "Would you like to disable it on your system?"
+msgstr ""
+
+#: id:24098
+msgid "Broken"
+msgstr ""
+
+#: id:24099
+msgid "Would you like to switch to this skin?"
+msgstr ""
+
+#: id:24100
+msgid "To use this feature you must download an Add-on:"
+msgstr ""
+
+#: id:24101
+msgid "Would you like to download this Add-on?"
+msgstr ""
+
+#: id:25000
+msgid "Notifications"
+msgstr ""
+
+#: id:29800
+msgid "Library Mode"
+msgstr "Режим библиотеке"
+
+#: id:29801
+msgid "QWERTY keyboard"
+msgstr "QWERTY тастатура"
+
+#: id:29802
+msgid "Passthrough Audio in use"
+msgstr "Пролазни звук у употреби"
+
+#: id:33001
+msgid "Trailer quality"
+msgstr "Квалитет најаве"
+
+#: id:33002
+msgid "Stream"
+msgstr "Запис"
+
+#: id:33003
+msgid "Download"
+msgstr "Преузми"
+
+#: id:33004
+msgid "Download & play"
+msgstr "Преузми и репродукуј"
+
+#: id:33005
+msgid "Download & save"
+msgstr "Преузми и сачувај"
+
+#: id:33006
+msgid "Today"
+msgstr "Данас"
+
+#: id:33007
+msgid "Tomorrow"
+msgstr "Сутра"
+
+#: id:33008
+msgid "Saving"
+msgstr "Чување"
+
+#: id:33009
+msgid "Copying"
+msgstr "Копирање"
+
+#: id:33010
+msgid "Set download directory"
+msgstr "Постави фасциклу за преузимање"
+
+#: id:33011
+msgid "Search duration"
+msgstr ""
+
+#: id:33012
+msgid "Short"
+msgstr "Кратко"
+
+#: id:33013
+msgid "Long"
+msgstr "Дугачко"
+
+#: id:33014
+msgid "Use DVD player instead of regular player"
+msgstr "Користи DVD плејер уместо обичног плејера"
+
+#: id:33015
+msgid "Ask for download before playing video"
+msgstr "Питај за преузимање пре репродукције филма"
+
+#: id:33016
+msgid "Clips"
+msgstr "Клипови"
+
+#: id:33017
+msgid "Restart plugin to enable"
+msgstr "Поново покрените додатак за активирање"
+
+#: id:33018
+msgid "Tonight"
+msgstr "Ноћас"
+
+#: id:33019
+msgid "Tomorrow Night"
+msgstr "Сутра увече"
+
+#: id:33020
+msgid "Condition"
+msgstr "Стање"
+
+#: id:33021
+msgid "Precipitation"
+msgstr "Обилне падавине"
+
+#: id:33022
+msgid "Precip"
+msgstr "Precip"
+
+#: id:33023
+msgid "Humid"
+msgstr "Влажно"
+
+#: id:33024
+msgid "Feels"
+msgstr "Као да је"
+
+#: id:33025
+msgid "Observed"
+msgstr "Посматрано"
+
+#: id:33026
+msgid "Departure from normal"
+msgstr "Одступање од просека"
+
+#: id:33027
+msgid "Sunrise"
+msgstr "Излазак сунца"
+
+#: id:33028
+msgid "Sunset"
+msgstr "Залазак сунца"
+
+#: id:33029
+msgid "Details"
+msgstr "Детаљи"
+
+#: id:33030
+msgid "Outlook"
+msgstr "Видик"
+
+#: id:33031
+msgid "Coverflow"
+msgstr "Прекривен"
+
+#: id:33032
+msgid "Translate text"
+msgstr "Преведи текст"
+
+#: id:33033
+msgid "Map list %s category"
+msgstr "Map list %s category"
+
+#: id:33034
+msgid "36 Hour"
+msgstr "36 часовна"
+
+#: id:33035
+msgid "Maps"
+msgstr "Карта"
+
+#: id:33036
+msgid "Hourly"
+msgstr "Из часа у час"
+
+#: id:33037
+msgid "Weekend"
+msgstr "Викенд"
+
+#: id:33038
+msgid "%s day"
+msgstr "%s дневна"
+
+#: id:33049
+msgid "Alert"
+msgstr "Узбуна"
+
+#: id:33050
+msgid "Alerts"
+msgstr "Упозорења"
+
+#: id:33051
+msgid "Choose Your"
+msgstr "Изаберите ваш"
+
+#: id:33052
+msgid "Check"
+msgstr "Провери"
+
+#: id:33053
+msgctxt "Auto context with id 33053"
+msgid "Configure the"
+msgstr "Конфигуриши"
+
+#: id:33054
+msgid "Seasons"
+msgstr "Годишња доба"
+
+#: id:33055
+msgid "Use your"
+msgstr "Користите ваш"
+
+#: id:33056
+msgid "Watch your"
+msgstr "Гледајте ваш"
+
+#: id:33057
+msgid "Listen to"
+msgstr "Слушајте"
+
+#: id:33058
+msgid "View your"
+msgstr "Прикажите ваш"
+
+#: id:33059
+msgctxt "Auto context with id 33059"
+msgid "Configure the"
+msgstr "Конфигуриши"
+
+#: id:33060
+msgid "Power"
+msgstr "Снага"
+
+#: id:33061
+msgid "Menu"
+msgstr "Мени"
+
+#: id:33062
+msgid "Play the"
+msgstr "Репродукуј"
+
+#: id:33063
+msgid "Options"
+msgstr "Опције"
+
+#: id:33065
+msgid "Editor"
+msgstr "Уређивач"
+
+#: id:33066
+msgid "About your"
+msgstr "О вашем"
+
+#: id:33067
+msgid "Star rating"
+msgstr "Оцена звездицама"
+
+#: id:33068
+msgid "Background"
+msgstr "Позадина"
+
+#: id:33069
+msgid "Backgrounds"
+msgstr "Позадине"
+
+#: id:33070
+msgid "Custom background"
+msgstr "Прилагођена позадина"
+
+#: id:33071
+msgid "Custom backgrounds"
+msgstr "Прилагођене позадине"
+
+#: id:33072
+msgid "View Readme"
+msgstr "Прикажи „Прочитај ме“"
+
+#: id:33073
+msgid "View Changelog"
+msgstr "Прикажи „Евиденцију измена“"
+
+#: id:33074
+msgid "This version of %s requires an"
+msgstr "Ова верзија за покретање захтева %s"
+
+#: id:33075
+msgid "XBMC revision of %s or greater to run."
+msgstr "XBMC издање или %s јаче."
+
+#: id:33076
+msgid "Please update XBMC."
+msgstr "Молимо, ажурирајте XBMC апликацију."
+
+#: id:33077
+msgid "No data found!"
+msgstr "Подаци нису пронађени!"
+
+#: id:33078
+msgid "Next page"
+msgstr "Следећа страна"
+
+#: id:33079
+msgid "Love"
+msgstr "Љубав"
+
+#: id:33080
+msgid "Hate"
+msgstr "Мржња"
+
+#: id:33081
+msgid "This file is stacked, select the part you want to play from."
+msgstr "Ова датотека је сложена, изаберите који део желите да репродукујете из ње."
+
+#: id:33082
+msgid "Path to script"
+msgstr "Путања до скрипте"
+
+#: id:33083
+msgid "Enable custom script button"
+msgstr "Омогући прилагођени тастер за сјруоту"
+
+#: id:33100
+msgid "Failed to start"
+msgstr ""
+
+#: id:33101
+msgid "Webserver"
+msgstr ""
+
+#: id:33102
+msgid "Event Server"
+msgstr ""
+
+#: id:33103
+msgid "Remote communication server"
+msgstr ""
+
+#: id:33200
+msgid "Detected New Connection"
+msgstr ""
+
+#: id:34000
+msgid "Lame"
+msgstr "Lame"
+
+#: id:34001
+msgid "Vorbis"
+msgstr "Vorbis"
+
+#: id:34002
+msgid "Wav"
+msgstr "Wav"
+
+#: id:34003
+msgid "DXVA2"
+msgstr "DXVA"
+
+#: id:34004
+msgid "VAAPI"
+msgstr ""
+
+#: id:34005
+msgid "Flac"
+msgstr ""
+
+#: id:34100
+msgid "Speaker Configuration"
+msgstr "Конфигурација звучника"
+
+#: id:34101
+msgid "2.0"
+msgstr "2.0"
+
+#: id:34102
+msgid "2.1"
+msgstr "2.1"
+
+#: id:34103
+msgid "3.0"
+msgstr "3.0"
+
+#: id:34104
+msgid "3.1"
+msgstr "3.1"
+
+#: id:34105
+msgid "4.0"
+msgstr "4.0"
+
+#: id:34106
+msgid "4.1"
+msgstr "4.1"
+
+#: id:34107
+msgid "5.0"
+msgstr "5.0"
+
+#: id:34108
+msgid "5.1"
+msgstr "5.1"
+
+#: id:34109
+msgid "7.0"
+msgstr "7.0"
+
+#: id:34110
+msgid "7.1"
+msgstr "7.1"
+
+#: id:34201
+msgid "Can't find a next item to play"
+msgstr ""
+
+#: id:34202
+msgid "Can't find a previous item to play"
+msgstr ""
+
+#: id:34300
+msgid "Failed to start zeroconf"
+msgstr ""
+
+#: id:34301
+msgid "Is Apple's Bonjour Service installed? See log for more info."
+msgstr ""
+
+#: id:34400
+msgid "Video Rendering"
+msgstr ""
+
+#: id:34401
+msgid "Failed to init video filters/scalers, falling back to bilinear scaling"
+msgstr ""
+
+#: id:34402
+msgid "Failed to initialize audio device"
+msgstr ""
+
+#: id:34403
+msgid "Check your audiosettings"
+msgstr ""
+
+#: id:34404
+msgid "Use gestures for navigation:"
+msgstr ""
+
+#: id:34405
+msgid "1 finger swipe left,right,up,down for cursors"
+msgstr ""
+
+#: id:34406
+msgid "2 finger swipe left for backspace"
+msgstr ""
+
+#: id:34407
+msgid "1 finger single tap for enter"
+msgstr ""
+
+#: id:34408
+msgid "2 finger single tap for contextmenu"
+msgstr ""
+
+#: id:35000
+msgid "Peripherals"
+msgstr ""
+
+#: id:35001
+msgid "Generic HID device"
+msgstr ""
+
+#: id:35002
+msgid "Generic network adapter"
+msgstr ""
+
+#: id:35003
+msgid "Generic disk"
+msgstr ""
+
+#: id:35004
+msgid "There are no settings available\nfor this peripheral."
+msgstr ""
+
+#: id:35005
+msgid "New device configured"
+msgstr ""
+
+#: id:35006
+msgid "Device removed"
+msgstr ""
+
+#: id:35007
+msgid "Keymap to use for this device"
+msgstr ""
+
+#: id:35008
+msgid "Keymap enabled"
+msgstr ""
+
+#: id:35009
+msgid "Do not use the custom keymap for this device"
+msgstr ""
+
+#: id:35500
+msgid "Location"
+msgstr ""
+
+#: id:35501
+msgid "Class"
+msgstr ""
+
+#: id:35502
+msgctxt "Auto context with id 35502"
+msgid "Name"
+msgstr ""
+
+#: id:35503
+msgid "Vendor"
+msgstr ""
+
+#: id:35504
+msgid "Product ID"
+msgstr ""
+
+#: id:36000
+msgid "Pulse-Eight CEC adapter"
+msgstr ""
+
+#: id:36001
+msgid "Pulse-Eight Nyxboard"
+msgstr ""
+
+#: id:36002
+msgid "Switch to keyboard side command"
+msgstr ""
+
+#: id:36003
+msgid "Switch to remote side command"
+msgstr ""
+
+#: id:36004
+msgid "Press \"user\" button command"
+msgstr ""
+
+#: id:36005
+msgid "Enable switch side commands"
+msgstr ""
+
+#: id:36006
+msgid "Could not open the adapter"
+msgstr ""
+
+#: id:36007
+msgid "Devices to power on when starting XBMC"
+msgstr ""
+
+#: id:36008
+msgid "Devices to power off when stopping XBMC"
+msgstr ""
+
+#: id:36009
+msgid "Put devices in standby mode when activating screensaver"
+msgstr ""
+
+#: id:36011
+msgid "Could not detect the CEC port. Set it up manually."
+msgstr ""
+
+#: id:36012
+msgid "Could not initialise the CEC adapter. Check your settings."
+msgstr ""
+
+#: id:36013
+msgid "Unsupported libCEC interface version. %d is greater than the version XBMC supports (%d)"
+msgstr ""
+
+#: id:36014
+msgid "Put this PC in standby mode when the TV is switched off"
+msgstr ""
+
+#: id:36015
+msgid "HDMI port number"
+msgstr ""
+
+#: id:36016
+msgctxt "Auto context with id 36016"
+msgid "Connected"
+msgstr ""
+
+#: id:36017
+msgid "Adapter found, but libCEC is not available"
+msgstr ""
+
+#: id:36018
+msgid "Use the TV's language setting"
+msgstr ""
+
+#: id:36019
+msgid "Connected to HDMI device"
+msgstr ""
+
+#: id:36020
+msgid "Make XBMC the active source when starting"
+msgstr ""
+
+#: id:36021
+msgid "Physical address (overrules HDMI port)"
+msgstr ""
+
+#: id:36022
+msgid "COM port (leave empty unless needed)"
+msgstr ""
+
+#: id:36023
+msgid "Configuration updated"
+msgstr ""
+
+#: id:36024
+msgid "Failed to set the new configuration. Please check your settings."
+msgstr ""
+
+#: id:36025
+msgid "Send 'inactive source' command when stopping XBMC"
+msgstr ""
+

--- a/language/Serbian/strings.po
+++ b/language/Serbian/strings.po
@@ -1,0 +1,9093 @@
+# Converted from xbmc strings.xml with xbmc-xml2po (by Team-XBMC)
+msgid ""
+msgstr ""
+"Project-Id-Version: xbmc.core-FRODO_GIT3ed1604ad7\n"
+"Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
+"POT-Creation-Date: 2012-04-09 18:00+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE\n"
+"Language: sr\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: id:0
+msgctxt "Auto context with id 0"
+msgid "Programs"
+msgstr "Programi"
+
+#: id:1
+msgctxt "Auto context with id 1"
+msgid "Pictures"
+msgstr "Slike"
+
+#: id:2
+msgctxt "Auto context with id 2"
+msgid "Music"
+msgstr "Muzika"
+
+#: id:3
+msgctxt "Auto context with id 3"
+msgid "Videos"
+msgstr "Filmovi"
+
+#: id:4
+msgid "TV-Guide"
+msgstr "TV vodič"
+
+#: id:5
+msgctxt "Auto context with id 5"
+msgid "Settings"
+msgstr "Postavke"
+
+#: id:6
+msgid "XBMC SVN"
+msgstr "XBMC SVN"
+
+#: id:7
+msgctxt "Auto context with id 7"
+msgid "File manager"
+msgstr "Upr. datotekama"
+
+#: id:8
+msgctxt "Auto context with id 8"
+msgid "Weather"
+msgstr "Vreme"
+
+#: id:9
+msgid "xbmc media center"
+msgstr "xbmc medija centar"
+
+#: id:11
+msgid "Monday"
+msgstr "Ponedeljak"
+
+#: id:12
+msgid "Tuesday"
+msgstr "Utorak"
+
+#: id:13
+msgid "Wednesday"
+msgstr "Sreda"
+
+#: id:14
+msgid "Thursday"
+msgstr "Četvrtak"
+
+#: id:15
+msgid "Friday"
+msgstr "Petak"
+
+#: id:16
+msgid "Saturday"
+msgstr "Subota"
+
+#: id:17
+msgid "Sunday"
+msgstr "Nedelja"
+
+#: id:21
+msgid "January"
+msgstr "januar"
+
+#: id:22
+msgid "February"
+msgstr "februar"
+
+#: id:23
+msgid "March"
+msgstr "mart"
+
+#: id:24
+msgid "April"
+msgstr "april"
+
+#: id:25
+msgctxt "Auto context with id 25"
+msgid "May"
+msgstr "maj"
+
+#: id:26
+msgid "June"
+msgstr "jun"
+
+#: id:27
+msgid "July"
+msgstr "jul"
+
+#: id:28
+msgid "August"
+msgstr "avgust"
+
+#: id:29
+msgid "September"
+msgstr "septembar"
+
+#: id:30
+msgid "October"
+msgstr "oktobar"
+
+#: id:31
+msgid "November"
+msgstr "novembar"
+
+#: id:32
+msgid "December"
+msgstr "decembar"
+
+#: id:41
+msgid "Mon"
+msgstr "pon"
+
+#: id:42
+msgid "Tue"
+msgstr "uto"
+
+#: id:43
+msgid "Wed"
+msgstr "sre"
+
+#: id:44
+msgid "Thu"
+msgstr "čet"
+
+#: id:45
+msgid "Fri"
+msgstr "pet"
+
+#: id:46
+msgid "Sat"
+msgstr "sub"
+
+#: id:47
+msgctxt "Auto context with id 47"
+msgid "Sun"
+msgstr "ned"
+
+#: id:51
+msgid "Jan"
+msgstr "jan"
+
+#: id:52
+msgid "Feb"
+msgstr "feb"
+
+#: id:53
+msgid "Mar"
+msgstr "mar"
+
+#: id:54
+msgid "Apr"
+msgstr "apr"
+
+#: id:55
+msgctxt "Auto context with id 55"
+msgid "May"
+msgstr "maj"
+
+#: id:56
+msgid "Jun"
+msgstr "jun"
+
+#: id:57
+msgid "Jul"
+msgstr "jul"
+
+#: id:58
+msgid "Aug"
+msgstr "avg"
+
+#: id:59
+msgid "Sep"
+msgstr "sep"
+
+#: id:60
+msgid "Oct"
+msgstr "okt"
+
+#: id:61
+msgid "Nov"
+msgstr "nov"
+
+#: id:62
+msgid "Dec"
+msgstr "dec"
+
+#: id:71
+msgid "N"
+msgstr ""
+
+#: id:72
+msgid "NNE"
+msgstr ""
+
+#: id:73
+msgid "NE"
+msgstr ""
+
+#: id:74
+msgid "ENE"
+msgstr ""
+
+#: id:75
+msgid "E"
+msgstr ""
+
+#: id:76
+msgid "ESE"
+msgstr ""
+
+#: id:77
+msgid "SE"
+msgstr ""
+
+#: id:78
+msgid "SSE"
+msgstr ""
+
+#: id:79
+msgid "S"
+msgstr ""
+
+#: id:80
+msgid "SSW"
+msgstr ""
+
+#: id:81
+msgid "SW"
+msgstr ""
+
+#: id:82
+msgid "WSW"
+msgstr ""
+
+#: id:83
+msgid "W"
+msgstr ""
+
+#: id:84
+msgid "WNW"
+msgstr ""
+
+#: id:85
+msgid "NW"
+msgstr ""
+
+#: id:86
+msgid "NNW"
+msgstr ""
+
+#: id:87
+msgid "VAR"
+msgstr ""
+
+#: id:98
+msgid "View: Auto"
+msgstr "Prikaz: Autom."
+
+#: id:99
+msgid "View: Auto big"
+msgstr "Prikaz: Autom. veliko"
+
+#: id:100
+msgid "View: Icons"
+msgstr "Prikaz: Ikone"
+
+#: id:101
+msgid "View: List"
+msgstr "Prikaz: Spisak"
+
+#: id:102
+msgctxt "Auto context with id 102"
+msgid "Scan"
+msgstr "Analiziraj"
+
+#: id:103
+msgctxt "Auto context with id 103"
+msgid "Sort by: Name"
+msgstr "Složi po: Imenu"
+
+#: id:104
+msgid "Sort by: Date"
+msgstr "Složi po: Datumu"
+
+#: id:105
+msgid "Sort by: Size"
+msgstr "Složi po: Veli."
+
+#: id:106
+msgid "No"
+msgstr "Ne"
+
+#: id:107
+msgid "Yes"
+msgstr "Da"
+
+#: id:108
+msgctxt "Auto context with id 108"
+msgid "Slideshow"
+msgstr "Reprod. slajdova"
+
+#: id:109
+msgid "Create thumbs"
+msgstr "Napravi omote"
+
+#: id:110
+msgid "Create thumbnails"
+msgstr "Napravi sličice"
+
+#: id:111
+msgctxt "Auto context with id 111"
+msgid "Shortcuts"
+msgstr "Prečice"
+
+#: id:112
+msgid "Paused"
+msgstr "Pauzirano"
+
+#: id:113
+msgid "Update failed"
+msgstr ""
+
+#: id:114
+msgid "Installation failed"
+msgstr ""
+
+#: id:115
+msgid "Copy"
+msgstr "Kopiraj"
+
+#: id:116
+msgid "Move"
+msgstr "Premesti"
+
+#: id:117
+msgid "Delete"
+msgstr "Izbriši"
+
+#: id:118
+msgid "Rename"
+msgstr "Preimenuj"
+
+#: id:119
+msgid "New folder"
+msgstr "Nova fascikla"
+
+#: id:120
+msgid "Confirm file copy"
+msgstr "Potvrdite kopiranje"
+
+#: id:121
+msgid "Confirm file move"
+msgstr "Potvrdite premeštanje"
+
+#: id:122
+msgid "Confirm file delete?"
+msgstr "Potvrđujete li brisanje?"
+
+#: id:123
+msgid "Copy these files?"
+msgstr "Kopiranje ovih datoteka?"
+
+#: id:124
+msgid "Move these files?"
+msgstr "Premeštanje ovih datoteka?"
+
+#: id:125
+msgid "Delete these files? - Deleting files cannot be undone!"
+msgstr "Brisanje ovih datoteka? - Nakon brisanja, datoteke nije moguće povratiti!"
+
+#: id:126
+msgid "Status"
+msgstr "Stanje"
+
+#: id:127
+msgid "Objects"
+msgstr "Objekata"
+
+#: id:128
+msgctxt "Auto context with id 128"
+msgid "General"
+msgstr "Opšte"
+
+#: id:129
+msgctxt "Auto context with id 129"
+msgid "Slideshow"
+msgstr "Projekcija slajdova"
+
+#: id:130
+msgctxt "Auto context with id 130"
+msgid "System info"
+msgstr "Podaci o sistemu"
+
+#: id:131
+msgid "Display"
+msgstr "Prikaz"
+
+#: id:132
+msgid "Albums"
+msgstr "Albumi"
+
+#: id:133
+msgid "Artists"
+msgstr "Izvođači"
+
+#: id:134
+msgid "Songs"
+msgstr "Numere"
+
+#: id:135
+msgid "Genres"
+msgstr "Žanrovi"
+
+#: id:136
+msgid "Playlists"
+msgstr "Spiskovi za repro."
+
+#: id:137
+msgid "Search"
+msgstr "Pretraži"
+
+#: id:138
+msgid "System Information"
+msgstr "Podaci o sistemu"
+
+#: id:139
+msgid "Temperatures:"
+msgstr "Temperature:"
+
+#: id:140
+msgid "CPU:"
+msgstr "Centralnog procesora:"
+
+#: id:141
+msgid "GPU:"
+msgstr "Grafičkog procesora:"
+
+#: id:142
+msgid "Time:"
+msgstr "Vreme:"
+
+#: id:143
+msgid "Current:"
+msgstr "Trenutno:"
+
+#: id:144
+msgid "Build:"
+msgstr "Izdanje:"
+
+#: id:145
+msgid "Network:"
+msgstr "Mreža:"
+
+#: id:146
+msgid "Type:"
+msgstr "Tip:"
+
+#: id:147
+msgid "Static"
+msgstr "Statički"
+
+#: id:148
+msgid "DHCP"
+msgstr "DHCP"
+
+#: id:149
+msgid "MAC address"
+msgstr "MAC adresa"
+
+#: id:150
+msgctxt "Auto context with id 150"
+msgid "IP address"
+msgstr "IP adresa"
+
+#: id:151
+msgid "Link:"
+msgstr "Veza:"
+
+#: id:152
+msgid "Half duplex"
+msgstr "Polu dupleks"
+
+#: id:153
+msgid "Full duplex"
+msgstr "Puni dupleks"
+
+#: id:154
+msgctxt "Auto context with id 154"
+msgid "Storage"
+msgstr "Skladišta"
+
+#: id:155
+msgid "Drive"
+msgstr "Uređaj"
+
+#: id:156
+msgctxt "Auto context with id 156"
+msgid "Free"
+msgstr "Slobodno"
+
+#: id:157
+msgctxt "Auto context with id 157"
+msgid "Video"
+msgstr "Video"
+
+#: id:158
+msgid "Free memory"
+msgstr "Slobodna memorija"
+
+#: id:159
+msgid "No link"
+msgstr "nije uspostavljena"
+
+#: id:160
+msgctxt "Auto context with id 160"
+msgid "Free"
+msgstr "slobodno"
+
+#: id:161
+msgid "Unavailable"
+msgstr "Nedostupno"
+
+#: id:162
+msgid "Tray open"
+msgstr "Vrata otvorena"
+
+#: id:163
+msgid "Reading"
+msgstr "Čitanje"
+
+#: id:164
+msgid "No disc"
+msgstr "Disk nije umetnut"
+
+#: id:165
+msgid "Disc present"
+msgstr "Disk je prepoznat"
+
+#: id:166
+msgid "Skin"
+msgstr "Maska"
+
+#: id:169
+msgctxt "Auto context with id 169"
+msgid "Resolution"
+msgstr "Rezolucija"
+
+#: id:170
+msgid "Adjust display refresh rate to match video"
+msgstr "Prilagodi brzinu osvežavanja monitoru"
+
+#: id:172
+msgid "Release date"
+msgstr "Datum izdavanja"
+
+#: id:173
+msgid "Display 4:3 videos as"
+msgstr "Prikaži 4:3 video materijal kao"
+
+#: id:175
+msgid "Moods"
+msgstr "Raspoloženja"
+
+#: id:176
+msgid "Styles"
+msgstr "Stilovi"
+
+#: id:179
+msgid "Song"
+msgstr "Pesma"
+
+#: id:180
+msgid "Duration"
+msgstr "Trajanje"
+
+#: id:181
+msgid "Select album"
+msgstr "Izaberite album"
+
+#: id:182
+msgid "Tracks"
+msgstr "Numere"
+
+#: id:183
+msgid "Review"
+msgstr "Pregled"
+
+#: id:184
+msgid "Refresh"
+msgstr "Osveži"
+
+#: id:185
+msgid "Searching album"
+msgstr "Pretraživanje albuma"
+
+#: id:186
+msgid "OK"
+msgstr "U redu"
+
+#: id:187
+msgid "No albums found!"
+msgstr "Ni jedan album nije pronađen!"
+
+#: id:188
+msgid "Select all"
+msgstr "Izaberi sve"
+
+#: id:189
+msgid "Scanning media info"
+msgstr "Analiziranje informacija"
+
+#: id:190
+msgid "Save"
+msgstr "Sačuvaj"
+
+#: id:191
+msgid "Shuffle"
+msgstr "Nasumično"
+
+#: id:192
+msgctxt "Auto context with id 192"
+msgid "Clear"
+msgstr "Poništi"
+
+#: id:193
+msgctxt "Auto context with id 193"
+msgid "Scan"
+msgstr "Analiziraj"
+
+#: id:194
+msgid "Searching..."
+msgstr "Pretraživanje..."
+
+#: id:195
+msgid "No info found!"
+msgstr "Nisu pronađene informacije!"
+
+#: id:196
+msgid "Select movie:"
+msgstr "Izaberite film:"
+
+#: id:197
+msgid "Querying %s info"
+msgstr "Zahtevanje podataka o %s"
+
+#: id:198
+msgid "Loading movie details"
+msgstr "Učitavanje podataka o filmu"
+
+#: id:199
+msgid "Web interface"
+msgstr ""
+
+#: id:202
+msgid "Tagline"
+msgstr "Tagline"
+
+#: id:203
+msgid "Plot outline"
+msgstr "Kratak opis"
+
+#: id:205
+msgid "Votes"
+msgstr "Glasova"
+
+#: id:206
+msgid "Cast"
+msgstr "Uloge"
+
+#: id:207
+msgid "Plot"
+msgstr "Opis"
+
+#: id:208
+msgctxt "Auto context with id 208"
+msgid "Play"
+msgstr "Reprodukuj"
+
+#: id:209
+msgid "Next"
+msgstr "Sledeće"
+
+#: id:210
+msgid "Previous"
+msgstr "Prethodno"
+
+#: id:213
+msgid "Calibrate user interface..."
+msgstr "Prilagodite korisničko okruženje..."
+
+#: id:214
+msgid "Video calibration..."
+msgstr "Kalibracija slike..."
+
+#: id:215
+msgid "Soften"
+msgstr "Omekšano"
+
+#: id:216
+msgid "Zoom amount"
+msgstr "Nivo uvećanja"
+
+#: id:217
+msgid "Pixel ratio"
+msgstr "Odnos pikselizacije"
+
+#: id:218
+msgid "DVD drive"
+msgstr "DVD uređaj"
+
+#: id:219
+msgid "Please insert disc"
+msgstr "Molimo, umetnite disk"
+
+#: id:220
+msgid "Remote share"
+msgstr "Daljinsko deljenje"
+
+#: id:221
+msgid "Network is not connected"
+msgstr "Mreža nije povezana"
+
+#: id:222
+msgid "Cancel"
+msgstr "Otkaži"
+
+#: id:224
+msgid "Speed"
+msgstr "Brzina"
+
+#: id:225
+msgid "Vertical Shift"
+msgstr ""
+
+#: id:226
+msgid "Test patterns..."
+msgstr "Isprobaj šablon..."
+
+#: id:227
+msgid "Lookup audio CD track names from freedb.org"
+msgstr "Potraži imena numera, muzičkog CD-a, na freedb.org"
+
+#: id:228
+msgid "Shuffle playlist on load"
+msgstr "Izmešaj spisak pri učitavanju"
+
+#: id:229
+msgid "HDD spindown time"
+msgstr "Vreme usporenja HDD-a"
+
+#: id:230
+msgid "Video filters"
+msgstr "Video filteri"
+
+#: id:231
+msgctxt "Auto context with id 231"
+msgid "None"
+msgstr "Ništa"
+
+#: id:232
+msgid "Point"
+msgstr "Tačka"
+
+#: id:233
+msgid "Linear"
+msgstr "Linearno"
+
+#: id:234
+msgid "Anisotropic"
+msgstr "Anizotropija"
+
+#: id:235
+msgid "Quincunx"
+msgstr "Quincunx"
+
+#: id:236
+msgid "Gaussian cubic"
+msgstr "Gaussian cubic"
+
+#: id:237
+msgid "Minification"
+msgstr "Umanjenje"
+
+#: id:238
+msgid "Magnification"
+msgstr "Uveličanje"
+
+#: id:239
+msgid "Clear playlist on finish"
+msgstr "Poništi spisak po završetku"
+
+#: id:240
+msgid "Display Mode"
+msgstr ""
+
+#: id:241
+msgid "Full Screen #%d"
+msgstr ""
+
+#: id:242
+msgid "Windowed"
+msgstr ""
+
+#: id:243
+msgid "Refresh Rate"
+msgstr ""
+
+#: id:244
+msgid "Full screen"
+msgstr ""
+
+#: id:245
+msgid "Sizing: (%i,%i)->(%i,%i) (Zoom x%2.2f) AR:%2.2f:1 (Pixels: %2.2f:1) (VShift: %2.2f)"
+msgstr ""
+
+#: id:247
+msgctxt "Auto context with id 247"
+msgid "Scripts"
+msgstr "Skripte"
+
+#: id:248
+msgctxt "Auto context with id 248"
+msgid "Language"
+msgstr "Jezik"
+
+#: id:249
+msgctxt "Auto context with id 249"
+msgid "Music"
+msgstr "Muzika"
+
+#: id:250
+msgctxt "Auto context with id 250"
+msgid "Visualization"
+msgstr "Vizualizacija"
+
+#: id:251
+msgid "Select destination directory"
+msgstr "Izaberite odredišnu fasciklu"
+
+#: id:252
+msgid "Output stereo to all speakers"
+msgstr "Stereo izlaz ka svim zvučnicima"
+
+#: id:253
+msgid "Number of channels"
+msgstr "Broj kanala"
+
+#: id:254
+msgid "- DTS capable receiver"
+msgstr "- Sposoban DTS prijemnik"
+
+#: id:255
+msgid "CDDB"
+msgstr "CDDB"
+
+#: id:256
+msgid "Fetching CD information"
+msgstr "Preuzimanje CD informacija"
+
+#: id:257
+msgid "Error"
+msgstr "Greška"
+
+#: id:258
+msgid "Enable tag reading"
+msgstr "Omogući čitanje oznaka"
+
+#: id:259
+msgid "Opening"
+msgstr "Otvaranje"
+
+#: id:260
+msgid "Shoutcast"
+msgstr "Internet radio"
+
+#: id:261
+msgid "Waiting for start..."
+msgstr "Čekanje na početak..."
+
+#: id:262
+msgid "Scripts output"
+msgstr "Izlazne skripte"
+
+#: id:263
+msgid "Allow control of XBMC via HTTP"
+msgstr "Dozvoli kontrolu XBMC aplikacije putem HTTP protokola"
+
+#: id:264
+msgid "Record"
+msgstr "Snimi"
+
+#: id:265
+msgid "Stop Rec."
+msgstr "Zaustavi snim."
+
+#: id:266
+msgid "Sort by: Track"
+msgstr "Složi po: Numeri"
+
+#: id:267
+msgid "Sort by: Time"
+msgstr "Složi po: Vremenu"
+
+#: id:268
+msgid "Sort by: Title"
+msgstr "Složi po: Naslovu"
+
+#: id:269
+msgid "Sort by: Artist"
+msgstr "Složi po: Izvođaču"
+
+#: id:270
+msgid "Sort by: Album"
+msgstr "Složi po: Albumu"
+
+#: id:271
+msgid "Top 100"
+msgstr "Najboljih 100"
+
+#: id:272
+msgid "Top-Left overscan compensation"
+msgstr "Gornja leva ivica ekrana"
+
+#: id:273
+msgid "Bottom-Right overscan compensation"
+msgstr "Donja desna ivica ekrana"
+
+#: id:274
+msgid "Subtitle positioning"
+msgstr "Pozicioniranje titla"
+
+#: id:275
+msgid "Pixel ratio adjustment"
+msgstr "Prilagođavanje odnosa strana"
+
+#: id:276
+msgid "Adjust the arrow to change the amount of overscan"
+msgstr "Pomerajte strelicu kako biste promenili veličinu ekrana"
+
+#: id:277
+msgid "Adjust the bar to change the subtitles position"
+msgstr "Pomerajte liniju kako biste promenili poziciju titlova"
+
+#: id:278
+msgid "Adjust the rectangle so it is perfectly square"
+msgstr "Oblikujte pravougaonik tako da dobijete savršeni kvadrat"
+
+#: id:279
+msgid "Unable to load settings"
+msgstr "Nije moguće učitati postavke"
+
+#: id:280
+msgid "Using default settings"
+msgstr "Korišćenje podrazumevanih postavki"
+
+#: id:281
+msgid "Please check the XML files"
+msgstr "Molimo, proverite XML datoteke"
+
+#: id:282
+msgid "Found %i items"
+msgstr "Pronađeno %i stavki"
+
+#: id:283
+msgid "Search results"
+msgstr "Rezultati pretrage"
+
+#: id:284
+msgid "No results found"
+msgstr "Bez rezultata"
+
+#: id:287
+msgctxt "Auto context with id 287"
+msgid "Subtitles"
+msgstr "Titlovi"
+
+#: id:288
+msgctxt "Auto context with id 288"
+msgid "Font"
+msgstr "Slova"
+
+#: id:289
+msgctxt "Auto context with id 289"
+msgid "- Size"
+msgstr "- Veličina"
+
+#: id:290
+msgid "Dynamic range compression"
+msgstr "Dinamički opseg kompresije"
+
+#: id:291
+msgctxt "Auto context with id 291"
+msgid "Video"
+msgstr "Video"
+
+#: id:292
+msgctxt "Auto context with id 292"
+msgid "Audio"
+msgstr "Zvuk"
+
+#: id:293
+msgid "Browse for subtitles"
+msgstr "Potraži titlove"
+
+#: id:294
+msgid "Create bookmark"
+msgstr "Napravi obelež."
+
+#: id:296
+msgid "Clear bookmarks"
+msgstr "Poništi obelež."
+
+#: id:297
+msgid "Audio offset"
+msgstr "Pomeraj zvuka u vremenu"
+
+#: id:298
+msgid "Bookmarks"
+msgstr "Obeleživači"
+
+#: id:299
+msgid "- AAC capable receiver"
+msgstr "- Sposoban AAC prijemnik"
+
+#: id:300
+msgid "- MP1 capable receiver"
+msgstr "- Sposoban MP1 prijemnik"
+
+#: id:301
+msgid "- MP2 capable receiver"
+msgstr "- Sposoban MP2 prijemnik"
+
+#: id:302
+msgid "- MP3 capable receiver"
+msgstr "- Sposoban MP3 prijemnik"
+
+#: id:303
+msgid "Delay"
+msgstr "Kašnjenje"
+
+#: id:304
+msgctxt "Auto context with id 304"
+msgid "Language"
+msgstr "Jezik"
+
+#: id:305
+msgctxt "Auto context with id 305"
+msgid "Enabled"
+msgstr "Omogućeno"
+
+#: id:306
+msgid "Non-interleaved"
+msgstr "Nestandardni"
+
+#: id:312
+msgid "(0=auto)"
+msgstr "(0=autom.)"
+
+#: id:313
+msgid "Cleaning database"
+msgstr "Čišćenje baze"
+
+#: id:314
+msgid "Preparing..."
+msgstr "Pripremanje..."
+
+#: id:315
+msgid "Database error"
+msgstr "Greška baze podataka"
+
+#: id:316
+msgid "Searching songs..."
+msgstr "Pretraživanje pesama..."
+
+#: id:317
+msgid "Cleaned database successfully"
+msgstr "Baza podataka je uspešno očišćena"
+
+#: id:318
+msgid "Cleaning songs..."
+msgstr "Čišćenje pesama..."
+
+#: id:319
+msgid "Error cleaning songs"
+msgstr "Greška čišćenja pesama"
+
+#: id:320
+msgid "Cleaning artists..."
+msgstr "Čišćenje izvođača..."
+
+#: id:321
+msgid "Error cleaning artists"
+msgstr "Greška čišćenja izvođača"
+
+#: id:322
+msgid "Cleaning genres..."
+msgstr "Čišćenje žanrova..."
+
+#: id:323
+msgid "Error cleaning genres"
+msgstr "Greška čišćenja žanrova"
+
+#: id:324
+msgid "Cleaning paths..."
+msgstr "Čišćenje putanja..."
+
+#: id:325
+msgid "Error cleaning paths"
+msgstr "Greška čišćenja putanja"
+
+#: id:326
+msgid "Cleaning albums..."
+msgstr "Čišćenje albuma..."
+
+#: id:327
+msgid "Error cleaning albums"
+msgstr "Greška čišćenja albuma"
+
+#: id:328
+msgid "Writing changes..."
+msgstr "Upisivanje promena..."
+
+#: id:329
+msgid "Error writing changes"
+msgstr "Greška upisivanja promena"
+
+#: id:330
+msgid "This may take some time..."
+msgstr "Ovo može potrajati neko vreme..."
+
+#: id:331
+msgid "Compressing database..."
+msgstr "Komprimovanje baze podataka..."
+
+#: id:332
+msgid "Error compressing database"
+msgstr "Greška komprimovanja baze podataka"
+
+#: id:333
+msgid "Do you want to clean the library?"
+msgstr "Želite li zaista da očistite biblioteku?"
+
+#: id:334
+msgid "Clean library..."
+msgstr "Čišćenje biblioteke..."
+
+#: id:335
+msgid "Start"
+msgstr "Pokreni"
+
+#: id:336
+msgid "Framerate conversion"
+msgstr "Konverzija brzine sličica"
+
+#: id:337
+msgctxt "Auto context with id 337"
+msgid "Audio output"
+msgstr "Izlaz zvuka"
+
+#: id:338
+msgid "Analog"
+msgstr "Analogni"
+
+#: id:339
+msgid "Optical/Coax"
+msgstr "Digitalni"
+
+#: id:340
+msgid "Various artists"
+msgstr "Različiti izvođači"
+
+#: id:341
+msgid "Play disc"
+msgstr "Reprodukuj disk"
+
+#: id:342
+msgctxt "Auto context with id 342"
+msgid "Movies"
+msgstr "Filmovi"
+
+#: id:343
+msgid "Adjust framerate"
+msgstr "Prilagodi brzinu sličica"
+
+#: id:344
+msgid "Actors"
+msgstr "Glumci"
+
+#: id:345
+msgctxt "Auto context with id 345"
+msgid "Year"
+msgstr "Godina"
+
+#: id:346
+msgid "Boost volume level on downmix"
+msgstr "Pojačaj nivo zvuka pri prebacivanju u manji br. kanala"
+
+#: id:350
+msgctxt "Auto context with id 350"
+msgid "Programs"
+msgstr "Programi"
+
+#: id:351
+msgctxt "Auto context with id 351"
+msgid "Off"
+msgstr "Isklj."
+
+#: id:352
+msgid "Dim"
+msgstr "Zatamni"
+
+#: id:353
+msgid "Black"
+msgstr "Crno"
+
+#: id:354
+msgid "Matrix trails"
+msgstr "Matrix tragovi"
+
+#: id:355
+msgid "Screensaver time"
+msgstr "Vreme pokretanja čuvara ekrana"
+
+#: id:356
+msgid "Screensaver mode"
+msgstr "Režim čuvara ekrana"
+
+#: id:357
+msgid "Shutdown function timer"
+msgstr "Funkcionisanje tajmera isključivanja"
+
+#: id:358
+msgid "All albums"
+msgstr "Svi albumi"
+
+#: id:359
+msgid "Recently added albums"
+msgstr "Nedavno dodati albumi"
+
+#: id:360
+msgctxt "Auto context with id 360"
+msgid "Screensaver"
+msgstr "Čuvar ekrana"
+
+#: id:361
+msgid "R. Slideshow"
+msgstr "Nasum. rep. slaj."
+
+#: id:362
+msgid "Screensaver dim level"
+msgstr "Nivo zatamljenja čuvara ekrana"
+
+#: id:363
+msgid "Sort by: File"
+msgstr "Složi po: Dato."
+
+#: id:364
+msgid "- Dolby Digital (AC3) capable receiver"
+msgstr "- Sposoban Dolby Digital (AC3) prijemnik"
+
+#: id:365
+msgctxt "Auto context with id 365"
+msgid "Sort by: Name"
+msgstr "Složi po: Imenu"
+
+#: id:366
+msgid "Sort by: Year"
+msgstr "Složi po: Godini"
+
+#: id:367
+msgid "Sort by: Rating"
+msgstr "Složi po: Popularnosti"
+
+#: id:368
+msgid "IMDb"
+msgstr "IMDb"
+
+#: id:369
+msgctxt "Auto context with id 369"
+msgid "Title"
+msgstr "Naziv"
+
+#: id:370
+msgid "Thunderstorms"
+msgstr "grmljavina"
+
+#: id:371
+msgid "Partly"
+msgstr "delimično"
+
+#: id:372
+msgid "Mostly"
+msgstr "uglavnom"
+
+#: id:373
+msgid "Sunny"
+msgstr "sunčano"
+
+#: id:374
+msgid "Cloudy"
+msgstr "oblačno"
+
+#: id:375
+msgid "Snow"
+msgstr "sneg"
+
+#: id:376
+msgid "Rain"
+msgstr "kiša"
+
+#: id:377
+msgid "Light"
+msgstr "slab(a)"
+
+#: id:378
+msgid "AM"
+msgstr "ujutro"
+
+#: id:379
+msgid "PM"
+msgstr "popodne"
+
+#: id:380
+msgid "Showers"
+msgstr "pljuskovi"
+
+#: id:381
+msgid "Few"
+msgstr "nekoliko"
+
+#: id:382
+msgid "Scattered"
+msgstr "mestimično"
+
+#: id:383
+msgctxt "Auto context with id 383"
+msgid "Wind"
+msgstr "vetrovito"
+
+#: id:384
+msgid "Strong"
+msgstr "izuzetno"
+
+#: id:385
+msgid "Fair"
+msgstr "umereno"
+
+#: id:386
+msgctxt "Auto context with id 386"
+msgid "Clear"
+msgstr "vedro"
+
+#: id:387
+msgid "Clouds"
+msgstr "oblačno"
+
+#: id:388
+msgid "Early"
+msgstr "rani"
+
+#: id:389
+msgid "Shower"
+msgstr "pljusak"
+
+#: id:390
+msgid "Flurries"
+msgstr "Susnežica"
+
+#: id:391
+msgctxt "Auto context with id 391"
+msgid "Low"
+msgstr "nizak"
+
+#: id:392
+msgctxt "Auto context with id 392"
+msgid "Medium"
+msgstr "umeren"
+
+#: id:393
+msgctxt "Auto context with id 393"
+msgid "High"
+msgstr "visok"
+
+#: id:394
+msgid "Fog"
+msgstr "magla"
+
+#: id:395
+msgid "Haze"
+msgstr "izmaglica"
+
+#: id:396
+msgid "Select location"
+msgstr "Izbor lokacije"
+
+#: id:397
+msgid "Refresh time"
+msgstr "Učestalost osvežavanja"
+
+#: id:398
+msgid "Temperature units"
+msgstr "Jedinice za temperaturu"
+
+#: id:399
+msgid "Speed units"
+msgstr "Jedinice za brzinu"
+
+#: id:400
+msgctxt "Auto context with id 400"
+msgid "Weather"
+msgstr "Vreme"
+
+#: id:401
+msgid "Temp"
+msgstr "Temper."
+
+#: id:402
+msgid "Feels like"
+msgstr "Kao da je"
+
+#: id:403
+msgid "UV index"
+msgstr "UV indeks"
+
+#: id:404
+msgctxt "Auto context with id 404"
+msgid "Wind"
+msgstr "Vetar"
+
+#: id:405
+msgid "Dew point"
+msgstr "Tačka rose"
+
+#: id:406
+msgid "Humidity"
+msgstr "Vlažnost"
+
+#: id:409
+msgid "Defaults"
+msgstr "Podrazumevano"
+
+#: id:410
+msgid "Accessing weather service"
+msgstr "Pristupanje usluzi vrem. prognoze"
+
+#: id:411
+msgid "Getting weather for:"
+msgstr "Preuzimanje prognoze za:"
+
+#: id:412
+msgid "Unable to get weather data"
+msgstr "Nije moguće preuzeti podatke o prognozi"
+
+#: id:413
+msgid "Manual"
+msgstr "Ručno"
+
+#: id:414
+msgid "No review for this album"
+msgstr "Ne postoji recenzija za ovaj album"
+
+#: id:415
+msgid "Downloading thumbnail..."
+msgstr "Preuzimanje..."
+
+#: id:416
+msgid "Not available"
+msgstr "Nije dostupno"
+
+#: id:417
+msgid "View: Big icons"
+msgstr "Prikaz: Velike ikone"
+
+#: id:418
+msgctxt "Auto context with id 418"
+msgid "Low"
+msgstr "Min."
+
+#: id:419
+msgctxt "Auto context with id 419"
+msgid "High"
+msgstr "Maks."
+
+#: id:420
+msgid "HDMI"
+msgstr ""
+
+#: id:422
+msgid "Delete album info"
+msgstr "Izbriši podatke o albumu"
+
+#: id:423
+msgid "Delete CD information"
+msgstr "Izbriši CD podatke"
+
+#: id:424
+msgid "Select"
+msgstr "Izaberi"
+
+#: id:425
+msgid "No album information found"
+msgstr "Nisu pronađeni podaci o albumu"
+
+#: id:426
+msgid "No CD information found"
+msgstr "Nisu pronađeni CD podaci"
+
+#: id:427
+msgid "Disc"
+msgstr "Disk"
+
+#: id:428
+msgid "Insert correct CD/DVD"
+msgstr "Umetnite ispravan CD/DVD"
+
+#: id:429
+msgid "Please insert the following disc:"
+msgstr "Molimo, umetnite sledeći CD/DVD"
+
+#: id:430
+msgid "Sort by: DVD#"
+msgstr "Složi po: DVD#"
+
+#: id:431
+msgid "No cache"
+msgstr "Bez keša"
+
+#: id:432
+msgid "Remove movie from library"
+msgstr "Ukloni film iz biblioteke"
+
+#: id:433
+msgid "Really remove '%s'?"
+msgstr "Zaista želite da uklonite „%s“?"
+
+#: id:434
+msgid "From %s at %i %s"
+msgstr ""
+
+#: id:437
+msgid "Removable disk"
+msgstr "Prenosivi disk"
+
+#: id:438
+msgid "Opening file"
+msgstr "Otvaranje datoteke"
+
+#: id:439
+msgid "Cache"
+msgstr "Keš"
+
+#: id:440
+msgid "Harddisk"
+msgstr "Čvrsti disk"
+
+#: id:441
+msgid "UDF"
+msgstr "UDF"
+
+#: id:442
+msgid "Local network"
+msgstr "Lokalna mreža"
+
+#: id:443
+msgid "Internet"
+msgstr "Internet"
+
+#: id:444
+msgctxt "Auto context with id 444"
+msgid "Video"
+msgstr "Video"
+
+#: id:445
+msgctxt "Auto context with id 445"
+msgid "Audio"
+msgstr "Zvuk"
+
+#: id:446
+msgctxt "Auto context with id 446"
+msgid "DVD"
+msgstr "DVD"
+
+#: id:447
+msgid "Autorun media"
+msgstr "Automatska reprod. medija"
+
+#: id:448
+msgid "LCD"
+msgstr "LCD"
+
+#: id:449
+msgctxt "Auto context with id 449"
+msgid "Enabled"
+msgstr "Omogućeno"
+
+#: id:450
+msgid "Columns"
+msgstr "Kolone"
+
+#: id:451
+msgid "Row 1 address"
+msgstr "1. red adrese"
+
+#: id:452
+msgid "Row 2 address"
+msgstr "2. red adrese"
+
+#: id:453
+msgid "Row 3 address"
+msgstr "3. red adrese"
+
+#: id:454
+msgid "Row 4 address"
+msgstr "4. red adrese"
+
+#: id:455
+msgid "Rows"
+msgstr "Redovi"
+
+#: id:456
+msgid "Mode"
+msgstr "Režim"
+
+#: id:457
+msgid "Switch view"
+msgstr "Promeni prikaz"
+
+#: id:459
+msgid "Subs"
+msgstr "Titlovi"
+
+#: id:460
+msgid "Audio stream"
+msgstr "Zvučni zapis"
+
+#: id:461
+msgid "[active]"
+msgstr "[aktivno]"
+
+#: id:462
+msgid "Subtitle"
+msgstr "Titl"
+
+#: id:463
+msgid "Backlight"
+msgstr "Pozadinsko osvetljenje"
+
+#: id:464
+msgid "Brightness"
+msgstr "Svetlina"
+
+#: id:465
+msgid "Contrast"
+msgstr "Kontrast"
+
+#: id:466
+msgid "Gamma"
+msgstr "Opseg boje"
+
+#: id:467
+msgctxt "Auto context with id 467"
+msgid "Type"
+msgstr "Tip"
+
+#: id:468
+msgid "Move the bar to change the OSD position"
+msgstr "Pomerajte liniju da biste promenili OSD poziciju"
+
+#: id:469
+msgid "OSD position"
+msgstr "OSD pozicija"
+
+#: id:470
+msgid "Credits"
+msgstr "Zasluge"
+
+#: id:471
+msgid "Modchip"
+msgstr "Izme. čip"
+
+#: id:474
+msgctxt "Auto context with id 474"
+msgid "Off"
+msgstr "Isklj."
+
+#: id:475
+msgid "Music only"
+msgstr "Samo muzika"
+
+#: id:476
+msgctxt "Auto context with id 476"
+msgid "Music & video"
+msgstr "Muzika i video"
+
+#: id:477
+msgid "Unable to load playlist"
+msgstr "Nije moguće učitati spisak za reprodukciju"
+
+#: id:478
+msgid "OSD"
+msgstr "OSD"
+
+#: id:479
+msgid "Skin & language"
+msgstr "Maska i jezik"
+
+#: id:480
+msgid "Appearance"
+msgstr "Prikazivanje"
+
+#: id:481
+msgid "Audio options"
+msgstr "Opcije zvuka"
+
+#: id:482
+msgid "About XBMC"
+msgstr "O sistemu XBMC"
+
+#: id:485
+msgid "Delete album"
+msgstr "Izbriši album"
+
+#: id:486
+msgid "Repeat"
+msgstr "Ponovi"
+
+#: id:487
+msgid "Repeat one"
+msgstr "Ponovi jednom"
+
+#: id:488
+msgid "Repeat folder"
+msgstr "Ponovi fasciklu"
+
+#: id:489
+msgid "Play the next song automatically"
+msgstr "Automatski reprodukuj sledeću pesmu"
+
+#: id:491
+msgid "- Use big icons"
+msgstr "- Koristi velike ikone"
+
+#: id:492
+msgid "Resize VobSubs"
+msgstr "Promeni veličinu za VobSubs"
+
+#: id:493
+msgid "Advanced options (Experts Only!)"
+msgstr "Napredne opcije (samo za stručnjake!)"
+
+#: id:494
+msgid "Overall audio headroom"
+msgstr "Sveobuhvatan zvučni slobodan prostor"
+
+#: id:495
+msgid "Upsample videos to GUI resolution"
+msgstr "Poistoveti video i GUI rezoluciju"
+
+#: id:496
+msgid "Calibration"
+msgstr "Kalibracija"
+
+#: id:497
+msgid "Show file extensions"
+msgstr "Prikaži tipove datoteka"
+
+#: id:498
+msgid "Sort by: Type"
+msgstr "Složi po: Tipu"
+
+#: id:499
+msgid "Unable to connect to online lookup service"
+msgstr "Nije moguće povezivanje i pretraga mrežne usluge"
+
+#: id:500
+msgid "Downloading album information failed"
+msgstr "Neuspešno preuzimanje podataka o albumu"
+
+#: id:501
+msgid "Looking for album names..."
+msgstr "Traženje naziva albuma..."
+
+#: id:502
+msgctxt "Auto context with id 502"
+msgid "Open"
+msgstr "Otvori"
+
+#: id:503
+msgid "Busy"
+msgstr "Zauzeto"
+
+#: id:504
+msgid "Empty"
+msgstr "Prazno"
+
+#: id:505
+msgid "Loading media info from files..."
+msgstr "Učitavanje podataka o mediju iz datoteka..."
+
+#: id:507
+msgid "Sort by: Usage"
+msgstr "Složi po: Upotrebi"
+
+#: id:510
+msgid "Enable visualizations"
+msgstr "Omogući vizualizacije"
+
+#: id:511
+msgid "Enable video mode switching"
+msgstr "Omogući promenu režima videa"
+
+#: id:512
+msgid "Startup window"
+msgstr "Startni ekran"
+
+#: id:513
+msgid "Home window"
+msgstr "Početni ekran"
+
+#: id:514
+msgid "Manual settings"
+msgstr "Ručne postavke"
+
+#: id:515
+msgid "Genre"
+msgstr "Žanr"
+
+#: id:517
+msgid "Recently played albums"
+msgstr "Nedavno reprodukovani albumi"
+
+#: id:518
+msgid "Launch"
+msgstr "Pokreni"
+
+#: id:519
+msgid "Launch in..."
+msgstr "Pokreni u..."
+
+#: id:521
+msgid "Compilations"
+msgstr "Kompilacije"
+
+#: id:522
+msgid "Remove source"
+msgstr "Ukloni izvor"
+
+#: id:523
+msgid "Switch media"
+msgstr "Promeni medij"
+
+#: id:524
+msgid "Select playlist"
+msgstr "Izaberite spisak za reprodukciju"
+
+#: id:525
+msgid "New playlist..."
+msgstr "Novi spisak za reprodukciju..."
+
+#: id:526
+msgid "Add to playlist"
+msgstr "Dodaj u spisak za reprodukciju"
+
+#: id:527
+msgid "Manually add to library"
+msgstr "Ručno dodajte u biblioteku"
+
+#: id:528
+msgid "Enter title"
+msgstr "Unesite naslov"
+
+#: id:529
+msgid "Error: Duplicate title"
+msgstr "Greška: Dupliran naslov"
+
+#: id:530
+msgid "Select genre"
+msgstr "Izaberite žanr"
+
+#: id:531
+msgid "New genre"
+msgstr "Novi žanr"
+
+#: id:532
+msgid "Manual addition"
+msgstr "Ručno dodavanje"
+
+#: id:533
+msgid "Enter genre"
+msgstr "Unesite žanr"
+
+#: id:534
+msgid "View: %s"
+msgstr "Prikaz: %s"
+
+#: id:535
+msgid "List"
+msgstr "Spisak"
+
+#: id:536
+msgid "Icons"
+msgstr "Ikone"
+
+#: id:537
+msgid "Big list"
+msgstr "Vel. spis."
+
+#: id:538
+msgid "Big icons"
+msgstr "Vel. ikone"
+
+#: id:539
+msgid "Wide"
+msgstr "Široki"
+
+#: id:540
+msgid "Big wide"
+msgstr "Veoma široki"
+
+#: id:541
+msgid "Album icons"
+msgstr "Ikone albuma"
+
+#: id:542
+msgid "DVD icons"
+msgstr "DVD ikone"
+
+#: id:543
+msgctxt "Auto context with id 543"
+msgid "DVD"
+msgstr "DVD"
+
+#: id:544
+msgctxt "Auto context with id 544"
+msgid "Media info"
+msgstr "Podaci o mediju"
+
+#: id:545
+msgid "Audio output device"
+msgstr "Zvučni izlazni uređaj"
+
+#: id:546
+msgid "Passthrough output device"
+msgstr "Prolazni izlazni uređaj"
+
+#: id:547
+msgid "No biography for this artist"
+msgstr "Ovaj izvođač nema popunjenu biografiju"
+
+#: id:548
+msgid "Downmix multichannel audio to stereo"
+msgstr "Pretvori višekanalni zvuk u stereo"
+
+#: id:550
+msgid "Sort by: %s"
+msgstr "Složi po: %s"
+
+#: id:551
+msgctxt "Auto context with id 551"
+msgid "Name"
+msgstr "Ime"
+
+#: id:552
+msgid "Date"
+msgstr "Datum"
+
+#: id:553
+msgid "Size"
+msgstr "Velič."
+
+#: id:554
+msgid "Track"
+msgstr "Numera"
+
+#: id:555
+msgid "Time"
+msgstr "Trajanje"
+
+#: id:556
+msgctxt "Auto context with id 556"
+msgid "Title"
+msgstr "Naslov"
+
+#: id:557
+msgid "Artist"
+msgstr "Izvođač"
+
+#: id:558
+msgid "Album"
+msgstr "Album"
+
+#: id:559
+msgid "Playlist"
+msgstr "Spisak za rep."
+
+#: id:560
+msgid "ID"
+msgstr "ID"
+
+#: id:561
+msgctxt "Auto context with id 561"
+msgid "File"
+msgstr "Datote."
+
+#: id:562
+msgctxt "Auto context with id 562"
+msgid "Year"
+msgstr "Godina"
+
+#: id:563
+msgid "Rating"
+msgstr "Ocena"
+
+#: id:564
+msgctxt "Auto context with id 564"
+msgid "Type"
+msgstr "Tip"
+
+#: id:565
+msgid "Usage"
+msgstr "Koriš."
+
+#: id:566
+msgid "Album artist"
+msgstr "Izvođač na albumu"
+
+#: id:567
+msgid "Play count"
+msgstr "Broj reprodukcija"
+
+#: id:568
+msgid "Last played"
+msgstr "Poslednja reprodukcija"
+
+#: id:569
+msgctxt "Auto context with id 569"
+msgid "Comment"
+msgstr "Komentar"
+
+#: id:570
+msgid "Date added"
+msgstr "Datum dodavanja"
+
+#: id:571
+msgctxt "Auto context with id 571"
+msgid "Default"
+msgstr "Podrazumevano"
+
+#: id:572
+msgid "Studio"
+msgstr "Studio"
+
+#: id:573
+msgid "Path"
+msgstr "Putanja"
+
+#: id:574
+msgctxt "Auto context with id 574"
+msgid "Country"
+msgstr ""
+
+#: id:575
+msgid "In progress"
+msgstr ""
+
+#: id:576
+msgid "Times played"
+msgstr ""
+
+#: id:580
+msgid "Sort direction"
+msgstr "Smer slaganja"
+
+#: id:581
+msgid "Sort method"
+msgstr "Način slaganja"
+
+#: id:582
+msgctxt "Auto context with id 582"
+msgid "View mode"
+msgstr "Režim prikaza"
+
+#: id:583
+msgid "Remember views for different folders"
+msgstr "Zapamti prikaze različitih fascikli"
+
+#: id:584
+msgid "Ascending"
+msgstr "Uzlazno"
+
+#: id:585
+msgid "Descending"
+msgstr "Silazno"
+
+#: id:586
+msgid "Edit playlist"
+msgstr "Uredi spisak za rep."
+
+#: id:587
+msgid "Filter"
+msgstr "Filter"
+
+#: id:588
+msgid "Cancel party mode"
+msgstr "Otkaži režim žurke"
+
+#: id:589
+msgid "Party mode"
+msgstr "Režim žurke"
+
+#: id:590
+msgid "Random"
+msgstr "Nasumično"
+
+#: id:591
+msgctxt "Auto context with id 591"
+msgid "Off"
+msgstr "Isklj."
+
+#: id:592
+msgid "One"
+msgstr "Jednom"
+
+#: id:593
+msgid "All"
+msgstr "Sve"
+
+#: id:594
+msgctxt "Auto context with id 594"
+msgid "Off"
+msgstr "Isklj."
+
+#: id:595
+msgid "Repeat: Off"
+msgstr "Ponovi: Isklj."
+
+#: id:596
+msgid "Repeat: One"
+msgstr "Ponovi: Jednom"
+
+#: id:597
+msgid "Repeat: All"
+msgstr "Ponovi: Sve"
+
+#: id:600
+msgid "Rip audio CD"
+msgstr "Ripuj muzički CD"
+
+#: id:601
+msgctxt "Auto context with id 601"
+msgid "Medium"
+msgstr "Srednje"
+
+#: id:602
+msgctxt "Auto context with id 602"
+msgid "Standard"
+msgstr "Uobičajeno"
+
+#: id:603
+msgid "Extreme"
+msgstr "Ekstremno"
+
+#: id:604
+msgid "Constant bitrate"
+msgstr "Nepromenljiva brzina"
+
+#: id:605
+msgid "Ripping..."
+msgstr "Ripovanje..."
+
+#: id:607
+msgid "To:"
+msgstr "Za:"
+
+#: id:608
+msgid "Could not rip CD or track"
+msgstr "Nije moguće ripovati CD ili numeru"
+
+#: id:609
+msgid "CDDARipPath is not set."
+msgstr "CDDARipPath nije postavljen."
+
+#: id:610
+msgid "Rip audio track"
+msgstr "Ripuj muzičku numeru"
+
+#: id:611
+msgid "Enter number"
+msgstr "Unesite broj"
+
+#: id:612
+msgid "Bits/Sample"
+msgstr ""
+
+#: id:613
+msgid "Sample Frequency"
+msgstr ""
+
+#: id:620
+msgid "Audio CDs"
+msgstr "Muzički CD-ovi"
+
+#: id:621
+msgid "Encoder"
+msgstr "Koder"
+
+#: id:622
+msgid "Quality"
+msgstr "Kvalitet"
+
+#: id:623
+msgid "Bitrate"
+msgstr "Brzina protoka"
+
+#: id:624
+msgid "Include track number"
+msgstr "Uključi broj numere"
+
+#: id:625
+msgid "All songs of"
+msgstr "Sve pesme od"
+
+#: id:629
+msgctxt "Auto context with id 629"
+msgid "View mode"
+msgstr "Režim prikaza"
+
+#: id:630
+msgctxt "Auto context with id 630"
+msgid "Normal"
+msgstr "Normalan"
+
+#: id:631
+msgid "Zoom"
+msgstr "Uveličan"
+
+#: id:632
+msgid "Stretch 4:3"
+msgstr "Razvučeno 4:3"
+
+#: id:633
+msgid "Wide Zoom"
+msgstr "Razvučeno 14:9"
+
+#: id:634
+msgid "Stretch 16:9"
+msgstr "Razvučeno 16:9"
+
+#: id:635
+msgid "Original Size"
+msgstr "Prvobitna veličina"
+
+#: id:636
+msgctxt "Auto context with id 636"
+msgid "Custom"
+msgstr "Prilagođeno"
+
+#: id:637
+msgid "Replay gain"
+msgstr "Normalizacija"
+
+#: id:638
+msgid "Replaygain volume adjustments"
+msgstr "Podeš. glasnoće normaliz. zvuka"
+
+#: id:639
+msgid "Use track levels"
+msgstr "Koristi na nivou numere"
+
+#: id:640
+msgid "Use album levels"
+msgstr "Koristi na nivou albuma"
+
+#: id:641
+msgid "PreAmp Level - Replay gained files"
+msgstr "Nivo predpojačanja - sa normalizacijom datoteka"
+
+#: id:642
+msgid "PreAmp Level - Non replay gained files"
+msgstr "Nivo predpojačanja - bez normalizacije datoteka"
+
+#: id:643
+msgid "Avoid clipping on replay gained files"
+msgstr "Izbegni isečke pri normalizaciji datoteka"
+
+#: id:644
+msgid "Crop black bars"
+msgstr "Iseci crne trake"
+
+#: id:645
+msgid "Need to unpack a big file. Continue?"
+msgstr "Potrebno je raspakivanje velike datoteke. Nastaviti?"
+
+#: id:646
+msgid "Remove from library"
+msgstr "Ukloni iz biblioteke"
+
+#: id:647
+msgid "Export video library"
+msgstr "Izvezi biblioteku filmova"
+
+#: id:648
+msgid "Import video library"
+msgstr "Uvezi biblioteku filmova"
+
+#: id:649
+msgid "Importing"
+msgstr "Uvoz je u toku"
+
+#: id:650
+msgid "Exporting"
+msgstr "Izvoz je u toku"
+
+#: id:651
+msgid "Browse for library"
+msgstr "Potraži biblioteku"
+
+#: id:652
+msgid "Years"
+msgstr "Godina"
+
+#: id:653
+msgid "Update library"
+msgstr "Ažuriraj biblioteku"
+
+#: id:654
+msgid "Show debug info"
+msgstr "Prikaži pod. o ukla. grešaka"
+
+#: id:655
+msgid "Browse for executable"
+msgstr "Potraži izvršne datoteke"
+
+#: id:656
+msgid "Browse for playlist"
+msgstr "Potraži spisak za reprodukciju"
+
+#: id:657
+msgid "Browse for folder"
+msgstr "Potraži fasciklu"
+
+#: id:658
+msgid "Song information"
+msgstr "Podaci o pesmi"
+
+#: id:659
+msgid "Non-linear stretch"
+msgstr "Nelinearno istezanje"
+
+#: id:660
+msgid "Volume amplification"
+msgstr "Pojačavanje zvuka"
+
+#: id:661
+msgid "Choose export folder"
+msgstr "Izaberite izlaznu fasciklu"
+
+#: id:662
+msgid "This file is no longer available."
+msgstr "Ova datoteka više nije dostupna."
+
+#: id:663
+msgid "Would you like to remove it from the library?"
+msgstr "Želite li ovo da uklonite iz biblioteke?"
+
+#: id:664
+msgid "Browse for Script"
+msgstr "Potraži skriptu"
+
+#: id:665
+msgid "Compression level"
+msgstr ""
+
+#: id:700
+msgid "Cleaning up library"
+msgstr "Čišćenje biblioteke"
+
+#: id:701
+msgid "Removing old songs from the library"
+msgstr "Uklanjanje starih pesama iz biblioteke"
+
+#: id:702
+msgid "This path has been scanned before"
+msgstr "Ova putanja je već analizirana"
+
+#: id:705
+msgctxt "Auto context with id 705"
+msgid "Network"
+msgstr "Mreža"
+
+#: id:706
+msgid "- Server"
+msgstr "- Server"
+
+#: id:708
+msgid "Use an HTTP proxy server to access the internet"
+msgstr "Koristi posrednički HTTP server za pristup Internetu"
+
+#: id:711
+msgid "Internet Protocol (IP)"
+msgstr "Internet protokol (IP)"
+
+#: id:712
+msgid "Invalid port specified. Value must be between 1 and 65535."
+msgstr "Odredili ste neispravan priključak. Vrednost mora biti između 1 i 65535."
+
+#: id:713
+msgid "HTTP proxy"
+msgstr "HTTP posrednik"
+
+#: id:715
+msgid "- Assignment"
+msgstr "- Zadatak"
+
+#: id:716
+msgid "Automatic (DHCP)"
+msgstr "Automatski (DHCP)"
+
+#: id:717
+msgid "Manual (Static)"
+msgstr "Ručno (statička)"
+
+#: id:719
+msgid "- IP address"
+msgstr "- IP adresa"
+
+#: id:720
+msgid "- Netmask"
+msgstr "- Mrežna maska"
+
+#: id:721
+msgid "- Default gateway"
+msgstr "- Mrežni prolaz"
+
+#: id:722
+msgid "- DNS server"
+msgstr "- DNS server"
+
+#: id:723
+msgid "Save & restart"
+msgstr "Sačuvaj i ponovo pokreni"
+
+#: id:724
+msgid "Invalid address specified. Value must be AAA.BBB.CCC.DDD"
+msgstr "Odredili ste neispravnu adresu. Vrednost mora biti AAA.BBB.CCC.DDD"
+
+#: id:725
+msgid "with numbers between 0 and 255."
+msgstr "sa brojevima između 0 i 255."
+
+#: id:726
+msgid "Changes not saved. Continue without saving?"
+msgstr "Promene nisu sačuvane. Nastaviti bez čuvanja?"
+
+#: id:727
+msgid "Web server"
+msgstr "Web server"
+
+#: id:728
+msgctxt "Auto context with id 728"
+msgid "FTP server"
+msgstr "FTP server"
+
+#: id:730
+msgid "- Port"
+msgstr "- Priključak"
+
+#: id:732
+msgid "Save & apply"
+msgstr "Sačuvaj i primeni"
+
+#: id:733
+msgid "- Password"
+msgstr "- Lozinka"
+
+#: id:734
+msgid "No pass"
+msgstr "Bez lozinke"
+
+#: id:735
+msgid "- Character set"
+msgstr "- Skup znakova"
+
+#: id:736
+msgid "- Style"
+msgstr "- Stil"
+
+#: id:737
+msgid "- Colour"
+msgstr "- Boja"
+
+#: id:738
+msgctxt "Auto context with id 738"
+msgid "Normal"
+msgstr "Normalan"
+
+#: id:739
+msgid "Bold"
+msgstr "Podebljan"
+
+#: id:740
+msgid "Italics"
+msgstr "Kurziv"
+
+#: id:741
+msgid "Bold italics"
+msgstr "Podebljani kurziv"
+
+#: id:742
+msgctxt "Auto context with id 742"
+msgid "White"
+msgstr "Bela"
+
+#: id:743
+msgctxt "Auto context with id 743"
+msgid "Yellow"
+msgstr "Žuta"
+
+#: id:744
+msgctxt "Auto context with id 744"
+msgid "Files"
+msgstr "Datoteke"
+
+#: id:745
+msgid "No scanned information for this view"
+msgstr "Nema analiziranih podataka za ovaj prikaz"
+
+#: id:746
+msgid "Please turn off library mode"
+msgstr "Molimo, isključite režim biblioteke"
+
+#: id:747
+msgid "Error loading image"
+msgstr "Greška učitavanja slike"
+
+#: id:748
+msgid "Edit path"
+msgstr "Uredi putanju"
+
+#: id:749
+msgid "Mirror image"
+msgstr "Kopija slike"
+
+#: id:750
+msgid "Are you sure?"
+msgstr "Da li ste sigurni?"
+
+#: id:751
+msgid "Removing source"
+msgstr "Uklanjanje izvora"
+
+#: id:754
+msgid "Add program link"
+msgstr "Dodaj vezu ka programu"
+
+#: id:755
+msgid "Edit program path"
+msgstr "Uredi putanju programa"
+
+#: id:756
+msgid "Edit program name"
+msgstr "Uredi ime programa"
+
+#: id:757
+msgid "Edit path depth"
+msgstr "Uredi dubinu putanje"
+
+#: id:759
+msgid "View: Big list"
+msgstr "Prikaz: Vel. spisak"
+
+#: id:760
+msgctxt "Auto context with id 760"
+msgid "Yellow"
+msgstr "Žuta"
+
+#: id:761
+msgctxt "Auto context with id 761"
+msgid "White"
+msgstr "Bela"
+
+#: id:762
+msgid "Blue"
+msgstr "Plava"
+
+#: id:763
+msgid "Bright green"
+msgstr "Svetlo zelena"
+
+#: id:764
+msgid "Yellow green"
+msgstr "Žutozelena"
+
+#: id:765
+msgid "Cyan"
+msgstr "Azurno plava"
+
+#: id:766
+msgid "Light grey"
+msgstr "Svetlo siva"
+
+#: id:767
+msgid "Grey"
+msgstr "Siva"
+
+#: id:770
+msgid "Error %i: share not available"
+msgstr "Greška %i: deljenje nije dostupno"
+
+#: id:772
+msgctxt "Auto context with id 772"
+msgid "Audio output"
+msgstr "Zvučni izlaz"
+
+#: id:773
+msgid "Seeking"
+msgstr "Pozicioniranje"
+
+#: id:774
+msgid "Slideshow folder"
+msgstr "Fascikla reprod. slajdova"
+
+#: id:775
+msgid "Network interface"
+msgstr "Mrežni interfejs"
+
+#: id:776
+msgid "- Wireless network name (ESSID)"
+msgstr "- Ime bežične mreže (ESSID)"
+
+#: id:777
+msgid "- Wireless password"
+msgstr "- Lozinka za pristup bežičnoj mreži"
+
+#: id:778
+msgid "- Wireless security"
+msgstr "- Bezbednost bežične mreže"
+
+#: id:779
+msgid "Save and apply network interface settings"
+msgstr "Sačuvaj i primeni postavke mrežnog intrefejsa"
+
+#: id:780
+msgid "No encryption"
+msgstr "Bez zaštite"
+
+#: id:781
+msgid "WEP"
+msgstr "WEP"
+
+#: id:782
+msgid "WPA"
+msgstr "WPA"
+
+#: id:783
+msgid "WPA2"
+msgstr "WPA2"
+
+#: id:784
+msgid "Applying network interface settings. Please wait."
+msgstr "Primenjivanje postavki mrežnog interfejsa. Molimo sačekajte."
+
+#: id:785
+msgid "Network interface restarted successfully."
+msgstr "Uspešno je obavljeno ponovno pokretanje mrežnog interfejsa."
+
+#: id:786
+msgid "Network interface did not start successfully."
+msgstr "Nije uspelo pokretanje mrežnog interfejsa."
+
+#: id:787
+msgid "Interface disabled"
+msgstr "Interfejs je onemogućen"
+
+#: id:788
+msgid "Network interface disabled successfully."
+msgstr "Uspešno je onemogućen mrežni interfejs."
+
+#: id:789
+msgid "Wireless network name (ESSID)"
+msgstr "Ime bežične mreže (ESSID)"
+
+#: id:790
+msgid "Remote control"
+msgstr ""
+
+#: id:791
+msgid "Allow programs on this system to control XBMC"
+msgstr "Dozvoli programima na ovom sistemu da upravljaju XBMC-om"
+
+#: id:792
+msgctxt "Auto context with id 792"
+msgid "Port"
+msgstr "Priključak"
+
+#: id:793
+msgid "Port range"
+msgstr "Opseg priključaka"
+
+#: id:794
+msgid "Allow programs on other systems to control XBMC"
+msgstr "Dozvoli programima sa drugih sistema da upravljaju XBMC-om"
+
+#: id:795
+msgid "Initial repeat delay (ms)"
+msgstr "Inicijalno kašnjenje ponavljanja (ms)"
+
+#: id:796
+msgid "Continuous repeat delay (ms)"
+msgstr "Neprekidno kašnjenje ponavljanja (ms)"
+
+#: id:797
+msgid "Maximum number of clients"
+msgstr "Maksimalan broj klijenata"
+
+#: id:798
+msgid "Internet access"
+msgstr "Pristup Internetu"
+
+#: id:850
+msgid "Invalid port number entered"
+msgstr "Uneli ste pogrešan broj priključka"
+
+#: id:851
+msgid "Valid port range is 1-65535"
+msgstr "Ispravan opseg priključaka je od 1 do 65535"
+
+#: id:852
+msgid "Valid port range is 1024-65535"
+msgstr "Ispravan opseg priključaka je od 1024 do 65535"
+
+#: id:998
+msgid "Add Music..."
+msgstr ""
+
+#: id:999
+msgid "Add Videos..."
+msgstr ""
+
+#: id:1000
+msgid "- Preview"
+msgstr "Pregled čuvara ekrana"
+
+#: id:1001
+msgid "Unable to connect"
+msgstr "Nije moguće povezivanje"
+
+#: id:1002
+msgid "XBMC was unable to connect to the network location."
+msgstr "XBMC nije uspeo da se poveže na mrežnu lokaciju."
+
+#: id:1003
+msgid "This could be due to the network not being connected."
+msgstr "Razlog ovome može biti da mreža nije povezana."
+
+#: id:1004
+msgid "Would you like to add it anyway?"
+msgstr "Da li i dalje želite da je dodate?"
+
+#: id:1006
+msgctxt "Auto context with id 1006"
+msgid "IP address"
+msgstr "IP adresa"
+
+#: id:1007
+msgid "Add network location"
+msgstr "Dodaj mrežnu lokaciju"
+
+#: id:1008
+msgid "Protocol"
+msgstr "Protokol"
+
+#: id:1009
+msgid "Server address"
+msgstr "Adresa servera"
+
+#: id:1010
+msgid "Server name"
+msgstr "Ime servera"
+
+#: id:1011
+msgid "Remote path"
+msgstr "Udaljena putanja"
+
+#: id:1012
+msgid "Shared folder"
+msgstr "Deljena fascikla"
+
+#: id:1013
+msgctxt "Auto context with id 1013"
+msgid "Port"
+msgstr "Priključak"
+
+#: id:1014
+msgctxt "Auto context with id 1014"
+msgid "Username"
+msgstr "Korisničko ime"
+
+#: id:1015
+msgid "Browse for network server"
+msgstr "Potraži mrežni server"
+
+#: id:1016
+msgid "Enter the network address of the server"
+msgstr "Unesite mrežnu adresu servera"
+
+#: id:1017
+msgid "Enter the path on the server"
+msgstr "Unesite putanju na serveru"
+
+#: id:1018
+msgid "Enter the port number"
+msgstr "Unesite broj priključka"
+
+#: id:1019
+msgid "Enter the username"
+msgstr "Unesite korisničko ime"
+
+#: id:1020
+msgid "Add %s source"
+msgstr "Dodaj %s izvor"
+
+#: id:1021
+msgid "Enter the paths or browse for the media locations."
+msgstr "Unesite putanje ili potražite lokacije medija."
+
+#: id:1022
+msgid "Enter a name for this media Source."
+msgstr "Unesite ime za ovaj izvor medija."
+
+#: id:1023
+msgid "Browse for new share"
+msgstr "Potraži novo deljenje"
+
+#: id:1024
+msgid "Browse"
+msgstr "Potraži"
+
+#: id:1025
+msgid "Could not retrieve directory information."
+msgstr "Nije moguće preuzeti podatke direktorijuma."
+
+#: id:1026
+msgid "Add source"
+msgstr "Dodaj izvor"
+
+#: id:1027
+msgid "Edit source"
+msgstr "Uredi izvor"
+
+#: id:1028
+msgid "Edit %s source"
+msgstr "Uredi %s izvor"
+
+#: id:1029
+msgid "Enter the new label"
+msgstr "Unesi novu oznaku"
+
+#: id:1030
+msgid "Browse for image"
+msgstr "Potraži sliku"
+
+#: id:1031
+msgid "Browse for image folder"
+msgstr "Potraži fasciklu sa slikama"
+
+#: id:1032
+msgid "Add network location..."
+msgstr "Dodaj mrežnu lokaciju..."
+
+#: id:1033
+msgid "Browse for file"
+msgstr "Potraži datoteku"
+
+#: id:1034
+msgid "Submenu"
+msgstr "Podmeni"
+
+#: id:1035
+msgid "Enable submenu buttons"
+msgstr "Omogući tastere podmenija"
+
+#: id:1036
+msgid "Favourites"
+msgstr "Omiljeno"
+
+#: id:1037
+msgid "Video Add-ons"
+msgstr "Dodaci za video"
+
+#: id:1038
+msgid "Music Add-ons"
+msgstr "Dodaci za muziku"
+
+#: id:1039
+msgid "Picture Add-ons"
+msgstr "Dodaci za sliku"
+
+#: id:1040
+msgid "Loading directory"
+msgstr "Učitavanje direktorijuma"
+
+#: id:1041
+msgid "Retrieved %i items"
+msgstr "Primljeno %i stavki"
+
+#: id:1042
+msgid "Retrieved %i of %i items"
+msgstr "Primljeno %i od %i stavki"
+
+#: id:1043
+msgid "Program Add-ons"
+msgstr "Dodaci za program"
+
+#: id:1044
+msgid "Set plugin thumb"
+msgstr "Postavi sličicu dodatka"
+
+#: id:1045
+msgid "Add-on settings"
+msgstr "Postavke dodatka"
+
+#: id:1046
+msgid "Access points"
+msgstr "Pristupna tačka"
+
+#: id:1047
+msgid "Other..."
+msgstr "Ostalo..."
+
+#: id:1048
+msgid "- Username"
+msgstr "- Korisničko ime"
+
+#: id:1049
+msgid "Script settings"
+msgstr "Postavke skripte"
+
+#: id:1050
+msgid "Singles"
+msgstr "Pojedinačni"
+
+#: id:1051
+msgid "Enter web address"
+msgstr "Unesite internet adresu"
+
+#: id:1200
+msgid "SMB client"
+msgstr "SMB klijent"
+
+#: id:1202
+msgid "Workgroup"
+msgstr "Radna grupa"
+
+#: id:1203
+msgid "Default username"
+msgstr "Podrazumevano korisničko ime"
+
+#: id:1204
+msgid "Default password"
+msgstr "Podrazumevana lozinka"
+
+#: id:1207
+msgid "WINS server"
+msgstr "WINS server"
+
+#: id:1208
+msgid "Mount SMB shares"
+msgstr "Podigni SMB deljenja"
+
+#: id:1210
+msgctxt "Auto context with id 1210"
+msgid "Remove"
+msgstr "Ukloni"
+
+#: id:1211
+msgctxt "Auto context with id 1211"
+msgid "Music"
+msgstr "Muzika"
+
+#: id:1212
+msgctxt "Auto context with id 1212"
+msgid "Video"
+msgstr "Filmovi"
+
+#: id:1213
+msgctxt "Auto context with id 1213"
+msgid "Pictures"
+msgstr "Slike"
+
+#: id:1214
+msgctxt "Auto context with id 1214"
+msgid "Files"
+msgstr "Datoteke"
+
+#: id:1215
+msgctxt "Auto context with id 1215"
+msgid "Music & video"
+msgstr "Muzika i filmovi"
+
+#: id:1216
+msgid "Music & pictures"
+msgstr "Muzika i slike"
+
+#: id:1217
+msgid "Music & files"
+msgstr "Muzika i datoteke"
+
+#: id:1218
+msgid "Video & pictures"
+msgstr "Filmovi i slike"
+
+#: id:1219
+msgid "Video & files"
+msgstr "Filmovi i datoteke"
+
+#: id:1220
+msgid "Pictures & files"
+msgstr "Slike i datoteke"
+
+#: id:1221
+msgid "Music & video & pictures"
+msgstr "Muzika, filmovi i slike"
+
+#: id:1222
+msgid "Music & video & pictures & files"
+msgstr "Muzika, filmovi, slike i datoteke"
+
+#: id:1223
+msgctxt "Auto context with id 1223"
+msgid "Disabled"
+msgstr "Onemogućeno"
+
+#: id:1226
+msgid "Files & music & video"
+msgstr "Datoteke, muzika i filmovi"
+
+#: id:1227
+msgid "Files & pictures & music"
+msgstr "Datoteke, slike i muzika"
+
+#: id:1228
+msgid "Files & pictures & video"
+msgstr "Datoteke, slike i filmovi"
+
+#: id:1229
+msgid "Music & programs"
+msgstr "Muzika i programi"
+
+#: id:1230
+msgid "Video & programs"
+msgstr "Filmovi i programi"
+
+#: id:1231
+msgid "Pictures & programs"
+msgstr "Slike i programi"
+
+#: id:1232
+msgid "Music & video & pictures & programs"
+msgstr "Muzika, filmovi, slike i programi"
+
+#: id:1233
+msgid "Programs & video & music"
+msgstr "Programi, filmovi i muzika"
+
+#: id:1234
+msgid "Programs & pictures & music"
+msgstr "Programi, slike i muzika"
+
+#: id:1235
+msgid "Programs & pictures & video"
+msgstr "Programi, slike i filmovi"
+
+#: id:1250
+msgid "Auto-detection"
+msgstr "Autom. otkrivanje"
+
+#: id:1251
+msgid "Auto-detect system"
+msgstr "Autom. otkrivanje sistema"
+
+#: id:1252
+msgid "Nickname"
+msgstr "Nadimak"
+
+#: id:1254
+msgid "Ask to connect"
+msgstr "Pitaj za povezivanje"
+
+#: id:1255
+msgid "Send FTP user and password"
+msgstr "Pošalji FTP korisničko ime i lozinku"
+
+#: id:1256
+msgid "Ping interval"
+msgstr "Interval probnog signala"
+
+#: id:1257
+msgid "Would you like to connect to the auto-detected system?"
+msgstr "Želite li da se povežete sa autom. otkrivanjem sistema?"
+
+#: id:1259
+msgid "Zeroconf"
+msgstr ""
+
+#: id:1260
+msgid "Announce these services to other systems via Zeroconf"
+msgstr "Oglasi ove usluge ostalim sistemima putem Zeroconf"
+
+#: id:1270
+msgid "Allow XBMC to receive AirPlay content"
+msgstr ""
+
+#: id:1271
+msgid "Device name"
+msgstr ""
+
+#: id:1272
+msgid "- Use password protection"
+msgstr ""
+
+#: id:1273
+msgid "AirPlay"
+msgstr ""
+
+#: id:1300
+msgid "Custom audio device"
+msgstr "Prilagođen zvučni uređaj"
+
+#: id:1301
+msgid "Custom passthrough device"
+msgstr "Prilagođen prolazni uređaj"
+
+#: id:1396
+msgid "Drifting"
+msgstr "klizavo"
+
+#: id:1397
+msgid "and"
+msgstr "i"
+
+#: id:1398
+msgid "Freezing"
+msgstr "poledica"
+
+#: id:1399
+msgid "Late"
+msgstr "zakasneli"
+
+#: id:1400
+msgid "Isolated"
+msgstr "izolovani"
+
+#: id:1401
+msgid "Thundershowers"
+msgstr "pljuskovi sa grmljavinom"
+
+#: id:1402
+msgid "Thunder"
+msgstr "grmljavina"
+
+#: id:1403
+msgctxt "Auto context with id 1403"
+msgid "Sun"
+msgstr "sunčano"
+
+#: id:1404
+msgid "Heavy"
+msgstr "jak(a)"
+
+#: id:1405
+msgid "in"
+msgstr "u"
+
+#: id:1406
+msgid "the"
+msgstr ""
+
+#: id:1407
+msgid "Vicinity"
+msgstr "blizini"
+
+#: id:1408
+msgid "Ice"
+msgstr "led"
+
+#: id:1409
+msgid "Crystals"
+msgstr "kristali"
+
+#: id:1410
+msgid "Calm"
+msgstr "blago"
+
+#: id:1411
+msgid "with"
+msgstr "sa"
+
+#: id:1412
+msgid "windy"
+msgstr "vetrovito"
+
+#: id:1413
+msgid "drizzle"
+msgstr "rominjanje"
+
+#: id:1414
+msgid "Thunderstorm"
+msgstr "oluja"
+
+#: id:1415
+msgid "Drizzle"
+msgstr "rominjanje"
+
+#: id:1416
+msgid "Foggy"
+msgstr "maglovito"
+
+#: id:1417
+msgid "Grains"
+msgstr "grad"
+
+#: id:1418
+msgid "T-Storms"
+msgstr "oluje"
+
+#: id:1419
+msgid "T-Showers"
+msgstr "pljuskovi sa grmljavinom"
+
+#: id:1420
+msgid "Moderate"
+msgstr ""
+
+#: id:1421
+msgid "Very High"
+msgstr ""
+
+#: id:1422
+msgid "Windy"
+msgstr ""
+
+#: id:1423
+msgid "Mist"
+msgstr ""
+
+#: id:1450
+msgid "Put display to sleep when idle"
+msgstr "Postavi ekran „na spavanje“, kada se ne koristi"
+
+#: id:2050
+msgid "Runtime"
+msgstr "Trajanje"
+
+#: id:2100
+msgid "Script failed! : %s"
+msgstr "Skripta je „pukla“! : %s"
+
+#: id:2101
+msgid "Newer version needed - See log"
+msgstr ""
+
+#: id:4501
+msgid "Enable LCD/VFD"
+msgstr "Omogući LCD/VFD"
+
+#: id:10000
+msgid "Home"
+msgstr "Početna strana"
+
+#: id:10001
+msgctxt "Auto context with id 10001"
+msgid "Programs"
+msgstr "Programi"
+
+#: id:10002
+msgctxt "Auto context with id 10002"
+msgid "Pictures"
+msgstr "Slike"
+
+#: id:10003
+msgctxt "Auto context with id 10003"
+msgid "File manager"
+msgstr "Upr. datotekama"
+
+#: id:10004
+msgctxt "Auto context with id 10004"
+msgid "Settings"
+msgstr "Postavke"
+
+#: id:10005
+msgctxt "Auto context with id 10005"
+msgid "Music"
+msgstr "Muzika"
+
+#: id:10006
+msgctxt "Auto context with id 10006"
+msgid "Videos"
+msgstr "Filmovi"
+
+#: id:10007
+msgid "System information"
+msgstr "Podaci o sistemu"
+
+#: id:10008
+msgid "Settings - General"
+msgstr "Postavke - Opšte"
+
+#: id:10009
+msgid "Settings - Screen"
+msgstr "Postavke - Ekran"
+
+#: id:10010
+msgid "Settings - Appearance - GUI Calibration"
+msgstr "Postavke - Izgled - GUI kalibracija"
+
+#: id:10011
+msgid "Settings - Videos - Screen Calibration"
+msgstr "Postavke - Filmovi - Kalibracija ekrana"
+
+#: id:10012
+msgid "Settings - Pictures"
+msgstr "Postavke - Slike"
+
+#: id:10013
+msgid "Settings - Programs"
+msgstr "Postavke - Programi"
+
+#: id:10014
+msgid "Settings - Weather"
+msgstr "Postavke - Vremenska prognoza"
+
+#: id:10015
+msgid "Settings - Music"
+msgstr "Postavke - Muzika"
+
+#: id:10016
+msgid "Settings - System"
+msgstr "Postavke - Sistem"
+
+#: id:10017
+msgid "Settings - Videos"
+msgstr "Postavke - Filmovi"
+
+#: id:10018
+msgid "Settings - Network"
+msgstr "Postavke - Mreža"
+
+#: id:10019
+msgid "Settings - Appearance"
+msgstr "Postavke - Izgled"
+
+#: id:10020
+msgctxt "Auto context with id 10020"
+msgid "Scripts"
+msgstr "Skripte"
+
+#: id:10021
+msgid "Web Browser"
+msgstr "Čitač internet strana"
+
+#: id:10025
+msgctxt "Auto context with id 10025"
+msgid "Videos"
+msgstr ""
+
+#: id:10028
+msgid "Videos/Playlist"
+msgstr "Filmovi/Spisak za rep."
+
+#: id:10029
+msgctxt "Auto context with id 10029"
+msgid "Login screen"
+msgstr ""
+
+#: id:10034
+msgid "Settings - Profiles"
+msgstr "Postavke - Profili"
+
+#: id:10040
+msgid "Addon browser"
+msgstr ""
+
+#: id:10100
+msgid "Yes/No dialog"
+msgstr "Da/Ne prozor"
+
+#: id:10101
+msgid "Progress dialog"
+msgstr "Prozor napretka"
+
+#: id:10210
+msgid "Looking for subtitles..."
+msgstr "Traženje titlova..."
+
+#: id:10211
+msgid "Looking for or caching subtitles..."
+msgstr "Traženje titlova u kešu..."
+
+#: id:10212
+msgid "terminating"
+msgstr "prekidanje"
+
+#: id:10213
+msgid "buffering"
+msgstr "predmemorisanje"
+
+#: id:10214
+msgid "Opening stream"
+msgstr "Otvaranje zapisa"
+
+#: id:10500
+msgid "Music/Playlist"
+msgstr "Muzika/Spisak za reprod."
+
+#: id:10501
+msgid "Music/Files"
+msgstr "Muzika/Datoteke"
+
+#: id:10502
+msgid "Music/Library"
+msgstr "Muzika/Biblioteka"
+
+#: id:10503
+msgid "Playlist editor"
+msgstr "Uređivač spiska za reprodukciju"
+
+#: id:10504
+msgid "Top 100 songs"
+msgstr "100 najboljih pesama"
+
+#: id:10505
+msgid "Top 100 albums"
+msgstr "100 najboljih albuma"
+
+#: id:10506
+msgctxt "Auto context with id 10506"
+msgid "Programs"
+msgstr "Programi"
+
+#: id:10507
+msgid "Configuration"
+msgstr "Konfiguracija"
+
+#: id:10508
+msgid "Weather forecast"
+msgstr "Vremenska prognoza"
+
+#: id:10509
+msgid "Network gaming"
+msgstr "Mrežno igranje"
+
+#: id:10510
+msgid "Extensions"
+msgstr "Proširenja"
+
+#: id:10511
+msgctxt "Auto context with id 10511"
+msgid "System info"
+msgstr "Podaci o sistemu"
+
+#: id:10516
+msgid "Music - Library"
+msgstr "Muzička bibliote."
+
+#: id:10517
+msgid "Now Playing - Music"
+msgstr "Trenutna reprodukcija - Muzika"
+
+#: id:10522
+msgid "Now Playing - Videos"
+msgstr "Trenutna reprodukcija - Film"
+
+#: id:10523
+msgid "Album info"
+msgstr "Podaci o albumu"
+
+#: id:10524
+msgid "Movie info"
+msgstr "Podaci o filmu"
+
+#: id:12000
+msgid "Select dialog"
+msgstr "Izaberite dijalog"
+
+#: id:12001
+msgid "Music/Info"
+msgstr "Muzika/Podaci"
+
+#: id:12002
+msgid "Dialog OK"
+msgstr "Dijalog u redu"
+
+#: id:12003
+msgid "Videos/Info"
+msgstr "Filmovi/Podaci"
+
+#: id:12004
+msgid "Scripts/Info"
+msgstr "Skripte/Podaci"
+
+#: id:12005
+msgid "Fullscreen video"
+msgstr "Film preko čitavog ekrana"
+
+#: id:12006
+msgid "Audio visualization"
+msgstr "Vizualizacija zvuka"
+
+#: id:12008
+msgid "File stacking dialog"
+msgstr "Dijalog slaganja datoteka"
+
+#: id:12009
+msgid "Rebuild index..."
+msgstr "Reindeksiranje..."
+
+#: id:12010
+msgid "Return to music window"
+msgstr "Povratak na prozor sa muzikom"
+
+#: id:12011
+msgid "Return to videos window"
+msgstr "Povratak na prozor sa filmovima"
+
+#: id:12021
+msgid "Start from beginning"
+msgstr "Počni ispočetka"
+
+#: id:12022
+msgid "Resume from %s"
+msgstr "Nastavi od %s"
+
+#: id:12310
+msgid "0"
+msgstr "0"
+
+#: id:12311
+msgid "1"
+msgstr "1"
+
+#: id:12312
+msgid "2"
+msgstr "2"
+
+#: id:12313
+msgid "3"
+msgstr "3"
+
+#: id:12314
+msgid "4"
+msgstr "4"
+
+#: id:12315
+msgid "5"
+msgstr "5"
+
+#: id:12316
+msgid "6"
+msgstr "6"
+
+#: id:12317
+msgid "7"
+msgstr "7"
+
+#: id:12318
+msgid "8"
+msgstr "8"
+
+#: id:12319
+msgid "9"
+msgstr "9"
+
+#: id:12320
+msgid "c"
+msgstr "c"
+
+#: id:12321
+msgid "Ok"
+msgstr "U redu"
+
+#: id:12322
+msgid "*"
+msgstr "*"
+
+#: id:12325
+msgid "Locked! Enter code..."
+msgstr "Zaključano! Unesite kôd..."
+
+#: id:12326
+msgid "Enter password"
+msgstr "Unesite lozinku"
+
+#: id:12327
+msgid "Enter master code"
+msgstr "Unesite glavni kôd"
+
+#: id:12328
+msgid "Enter unlock code"
+msgstr "Unesite kôd za otključavanje"
+
+#: id:12329
+msgid "or press C to cancel"
+msgstr "ili pritisnite C za otkazivanje"
+
+#: id:12330
+msgid "Enter gamepad button combo and"
+msgstr "Unesite kombinaciju tastera upravljača za igre"
+
+#: id:12331
+msgid "press OK, or Back to cancel"
+msgstr "i pritisnite Start, ili Nazad za otkazivanje"
+
+#: id:12332
+msgid "Set lock"
+msgstr "Zaključaj"
+
+#: id:12333
+msgid "Unlock"
+msgstr "Otključaj"
+
+#: id:12334
+msgid "Reset lock"
+msgstr "Poništi kôd"
+
+#: id:12335
+msgid "Remove lock"
+msgstr "Ukloni kôd"
+
+#: id:12337
+msgid "Numeric password"
+msgstr "Numerička lozinka"
+
+#: id:12338
+msgid "Gamepad button combo"
+msgstr "Kombinacija tastera upravljača za igre"
+
+#: id:12339
+msgid "Full-text password"
+msgstr "Lozinka sa svim znacima"
+
+#: id:12340
+msgid "Enter new password"
+msgstr "Unesite novu lozinku"
+
+#: id:12341
+msgid "Re-Enter new password"
+msgstr "Ponovite unos nove lozinke"
+
+#: id:12342
+msgid "Incorrect password,"
+msgstr "Lozinka nije ispravna,"
+
+#: id:12343
+msgid "retries left"
+msgstr "pokušaja su preostala"
+
+#: id:12344
+msgid "Passwords entered did not match."
+msgstr "Unete lozinke se ne poklapaju."
+
+#: id:12345
+msgid "Access denied"
+msgstr "Pristup odbijen"
+
+#: id:12346
+msgid "Password retry limit exceeded."
+msgstr "Prekomerni broj pokušaja unosa lozinke."
+
+#: id:12347
+msgid "The system will now shut off."
+msgstr "Sistem će sada biti isključen."
+
+#: id:12348
+msgid "Item locked"
+msgstr "Stavka je zaključana"
+
+#: id:12353
+msgid "Reactivate lock"
+msgstr "Ponovo aktiviraj kôd"
+
+#: id:12356
+msgid "Change lock"
+msgstr "Promeni kôd"
+
+#: id:12357
+msgid "Source lock"
+msgstr "Poreklo kôda"
+
+#: id:12358
+msgid "Password entry was blank. Try again."
+msgstr "Lozinka ne može biti prazna. Pokušajte ponovo."
+
+#: id:12360
+msgid "Master lock"
+msgstr "Glavni kôd"
+
+#: id:12362
+msgid "Shutdown system if Master Lock retries exceeded"
+msgstr "Isključi sistem ukoliko Glavni kôd više puta bude pogrešno unet"
+
+#: id:12367
+msgid "Master code is not valid"
+msgstr "Glavni kôd nije ispravan"
+
+#: id:12368
+msgid "Please enter a valid master code"
+msgstr "Molimo, unesite ispravan glavni kôd"
+
+#: id:12373
+msgid "Settings & file manager"
+msgstr "Postavke i upr. datotekama"
+
+#: id:12376
+msgid "Set as default for all movies"
+msgstr "Postavi kao podrazumevano za sve filmove"
+
+#: id:12377
+msgid "This will reset any previously saved values"
+msgstr "Ovo će poništiti prethodno sačuvane vrednosti"
+
+#: id:12378
+msgid "Amount of time to display each image"
+msgstr "Vreme prikazivanja svake slike"
+
+#: id:12379
+msgid "Use pan and zoom effects"
+msgstr "Koristi efekat pomeranja i uveličavanja"
+
+#: id:12383
+msgid "12 hour clock"
+msgstr "12 časovni prikaz vremena"
+
+#: id:12384
+msgid "24 hour clock"
+msgstr "24 časovni prikaz vremena"
+
+#: id:12385
+msgid "Day/Month"
+msgstr "Dan, pa mesec"
+
+#: id:12386
+msgid "Month/Day"
+msgstr "Mesec, pa dan"
+
+#: id:12390
+msgid "System uptime"
+msgstr "Sistem je aktivan"
+
+#: id:12391
+msgid "Minutes"
+msgstr "minuta"
+
+#: id:12392
+msgid "Hours"
+msgstr "časova"
+
+#: id:12393
+msgid "Days"
+msgstr "dana"
+
+#: id:12394
+msgid "Total uptime"
+msgstr "Ukupno vreme"
+
+#: id:12395
+msgid "Battery level"
+msgstr ""
+
+#: id:12600
+msgctxt "Auto context with id 12600"
+msgid "Weather"
+msgstr "Vremenska prognoza"
+
+#: id:12900
+msgctxt "Auto context with id 12900"
+msgid "Screensaver"
+msgstr "Čuvar ekrana"
+
+#: id:12901
+msgid "Fullscreen OSD"
+msgstr "OSD preko čitavog ekrana"
+
+#: id:13000
+msgid "System"
+msgstr "Sistem"
+
+#: id:13001
+msgid "Immediate HD spindown"
+msgstr "Neposredno HD rotiranje"
+
+#: id:13002
+msgid "Video only"
+msgstr "Samo filmovi"
+
+#: id:13003
+msgid "- Delay"
+msgstr "- Kašnjenje"
+
+#: id:13004
+msgid "- Minimum file duration"
+msgstr "- Minimalno trajanje datoteke"
+
+#: id:13005
+msgid "Shutdown"
+msgstr "Isključi"
+
+#: id:13008
+msgid "Shutdown function"
+msgstr "Akcija pri isključivanju"
+
+#: id:13009
+msgid "Quit"
+msgstr "Izađi"
+
+#: id:13010
+msgid "Hibernate"
+msgstr "Hibernacija"
+
+#: id:13011
+msgid "Suspend"
+msgstr "Stanje spavanja"
+
+#: id:13012
+msgid "Exit"
+msgstr "Izađi iz"
+
+#: id:13013
+msgid "Reboot"
+msgstr "Ponovo pokreni"
+
+#: id:13014
+msgid "Minimize"
+msgstr "Umanji"
+
+#: id:13015
+msgid "Power button action"
+msgstr "Akcija dugmeta za uključivanje"
+
+#: id:13016
+msgid "Power off System"
+msgstr ""
+
+#: id:13020
+msgid "Is another session active, perhaps over ssh?"
+msgstr "Da li je druga sesija aktivna, možda putem ssh?"
+
+#: id:13021
+msgid "Mounted removable harddrive"
+msgstr "Postavljen prenosivi čvrsti uređaj"
+
+#: id:13022
+msgid "Unsafe device removal"
+msgstr "Nebezbedno uklanjanje uređaja"
+
+#: id:13023
+msgid "Successfully removed device"
+msgstr "Uspešno uklonjen uređaj"
+
+#: id:13024
+msgid "Joystick plugged"
+msgstr "Upravljačka palica je priključena"
+
+#: id:13025
+msgid "Joystick unplugged"
+msgstr "Upravljačka palica je raskačena"
+
+#: id:13050
+msgid "Running low on battery"
+msgstr ""
+
+#: id:13100
+msgid "Flicker filter"
+msgstr "Flicker filter"
+
+#: id:13101
+msgid "Let driver choose (requires restart)"
+msgstr "Prepusti izbor uprav. programu (neophodno ponovno pokretanje)"
+
+#: id:13105
+msgid "Vertical blank sync"
+msgstr "Razmak vertikalne sinhronizacije"
+
+#: id:13106
+msgctxt "Auto context with id 13106"
+msgid "Disabled"
+msgstr "Onemogućeno"
+
+#: id:13107
+msgid "Enabled during video playback"
+msgstr "Omogućeno tokom reprodukcije filma"
+
+#: id:13108
+msgctxt "Auto context with id 13108"
+msgid "Always enabled"
+msgstr "Uvek je omogućeno"
+
+#: id:13109
+msgid "Test & apply resolution"
+msgstr "Isprobaj i primeni rezoluciju"
+
+#: id:13110
+msgid "Save resolution?"
+msgstr "Sačuvati rezoluciju?"
+
+#: id:13111
+msgid "Would you like to keep this resolution?"
+msgstr "Želite li da zadržite ovu rezoluciju?"
+
+#: id:13112
+msgid "High quality upscaling"
+msgstr "Visok kvalitet uvećanja"
+
+#: id:13113
+msgctxt "Auto context with id 13113"
+msgid "Disabled"
+msgstr "Onemogućen"
+
+#: id:13114
+msgid "Enabled for SD content"
+msgstr "Omogućen za SD sadržaj"
+
+#: id:13115
+msgctxt "Auto context with id 13115"
+msgid "Always enabled"
+msgstr "Uvek je omogućen"
+
+#: id:13116
+msgid "Upscaling method"
+msgstr "Način uvećanja"
+
+#: id:13117
+msgctxt "Auto context with id 13117"
+msgid "Bicubic"
+msgstr "Bicubic"
+
+#: id:13118
+msgid "Lanczos"
+msgstr "Lanczos"
+
+#: id:13119
+msgid "Sinc"
+msgstr "Sinc"
+
+#: id:13120
+msgctxt "Auto context with id 13120"
+msgid "VDPAU"
+msgstr "VDPAU"
+
+#: id:13121
+msgid "VDPAU HQ Upscaling level"
+msgstr "VDPAU HQ Upscaling level"
+
+#: id:13122
+msgid "VDPAU Studio level color conversion"
+msgstr "VDPAU Studio level color conversion"
+
+#: id:13130
+msgid "Blank other displays"
+msgstr "Zacrni ostale ekrane"
+
+#: id:13131
+msgctxt "Auto context with id 13131"
+msgid "Disabled"
+msgstr "Onemogućeno"
+
+#: id:13132
+msgid "Blank displays"
+msgstr "Zacrni ekrane"
+
+#: id:13140
+msgid "Active connections detected!"
+msgstr "Otkrivene su aktivne veze!"
+
+#: id:13141
+msgid "If you proceed, you might not be able to control XBMC"
+msgstr "Ukoliko nastavite dalje, možda nećete moći da upravljate XBMC"
+
+#: id:13142
+msgid "any longer. Are you sure you want to stop the Event server?"
+msgstr "aplikacijom. Da li ste sigurni da želite da zaustavite Server za događaje?"
+
+#: id:13144
+msgid "Change Apple Remote mode?"
+msgstr "Promeni Apple Remote režim?"
+
+#: id:13145
+msgid "If you are currently using the Apple Remote to control"
+msgstr "Ukoliko trenutno koristite Apple Remote da upravljate"
+
+#: id:13146
+msgid "XBMC, changing this setting might affect your ability"
+msgstr "XBMC aplikacijom, promenom ove postavake možda promenite"
+
+#: id:13147
+msgid "to continue controlling it. Do you want to proceed?"
+msgstr "mogućnost kontrolisanja aplikacije. Nastavljate li dalje?"
+
+#: id:13159
+msgid "Subnet mask"
+msgstr "Mrežna podmaska"
+
+#: id:13160
+msgid "Gateway"
+msgstr "Mrežni prolaz"
+
+#: id:13161
+msgid "Primary DNS"
+msgstr "Primarni DNS"
+
+#: id:13162
+msgid "Initialize failed"
+msgstr "Nije uspela inicijalizacija"
+
+#: id:13170
+msgctxt "Auto context with id 13170"
+msgid "Never"
+msgstr "Nikada"
+
+#: id:13171
+msgid "Immediately"
+msgstr "Odmah"
+
+#: id:13172
+msgid "After %i secs"
+msgstr "Nakon %i sek."
+
+#: id:13173
+msgid "HDD install date:"
+msgstr "Datum postavljanja HDD-a:"
+
+#: id:13174
+msgid "HDD power cycle count:"
+msgstr "HDD power cycle count:"
+
+#: id:13200
+msgid "Profiles"
+msgstr "Profili"
+
+#: id:13201
+msgid "Delete profile '%s'?"
+msgstr "Izbrisati „%s“ profil?"
+
+#: id:13204
+msgid "Last loaded profile:"
+msgstr "Poslednji učitan profil:"
+
+#: id:13205
+msgid "Unknown"
+msgstr "Nepoznato"
+
+#: id:13206
+msgid "Overwrite"
+msgstr "Prepiši"
+
+#: id:13208
+msgid "Alarm clock"
+msgstr "Budilnik"
+
+#: id:13209
+msgid "Alarm clock interval (in minutes)"
+msgstr "Interval za ponovnu aktivaciju budilnika(u min.)"
+
+#: id:13210
+msgid "Started, alarm in %im"
+msgstr "Pokrenuto, alarm za %im"
+
+#: id:13211
+msgid "Alarm!"
+msgstr "Alarm!"
+
+#: id:13212
+msgid "Canceled with %im%is left"
+msgstr "Otkazano pri %imin. %isek. do kraja"
+
+#: id:13213
+msgid "%2.0fm"
+msgstr ""
+
+#: id:13214
+msgid "%2.0fs"
+msgstr ""
+
+#: id:13249
+msgid "Search for subtitles in RARs"
+msgstr "Pretraži titlove u RAR-ovima"
+
+#: id:13250
+msgid "Browse for subtitle..."
+msgstr "Potraži titl..."
+
+#: id:13251
+msgid "Move item"
+msgstr "Premesti stavku"
+
+#: id:13252
+msgid "Move item here"
+msgstr "Premesti stavku ovde"
+
+#: id:13253
+msgid "Cancel move"
+msgstr "Otkaži premeštanje"
+
+#: id:13270
+msgid "Hardware:"
+msgstr "Hardver:"
+
+#: id:13271
+msgid "CPU Usage:"
+msgstr "Iskorišćenost procesora:"
+
+#: id:13274
+msgid "Connected, but no DNS is available."
+msgstr "Povezano, ali DNS nije dostupan."
+
+#: id:13275
+msgid "Hard Disk"
+msgstr "Čvrsti disk"
+
+#: id:13276
+msgid "DVD-ROM"
+msgstr "DVD-ROM"
+
+#: id:13277
+msgctxt "Auto context with id 13277"
+msgid "Storage"
+msgstr "Skladište"
+
+#: id:13278
+msgctxt "Auto context with id 13278"
+msgid "Default"
+msgstr "Podrazumevano"
+
+#: id:13279
+msgctxt "Auto context with id 13279"
+msgid "Network"
+msgstr "Mreža"
+
+#: id:13280
+msgctxt "Auto context with id 13280"
+msgid "Video"
+msgstr "Video"
+
+#: id:13281
+msgid "Hardware"
+msgstr "Hardver"
+
+#: id:13283
+msgid "Operating system:"
+msgstr "Operativni sistem:"
+
+#: id:13284
+msgid "CPU speed:"
+msgstr "Brzina procesora:"
+
+#: id:13286
+msgid "Video encoder:"
+msgstr "Video koder:"
+
+#: id:13287
+msgid "Screen resolution:"
+msgstr "Rezolucija ekrana:"
+
+#: id:13292
+msgid "A/V cable:"
+msgstr "A/V kabl:"
+
+#: id:13294
+msgid "DVD region:"
+msgstr "DVD regija:"
+
+#: id:13295
+msgid "Internet:"
+msgstr "Internet:"
+
+#: id:13296
+msgctxt "Auto context with id 13296"
+msgid "Connected"
+msgstr "Povezano"
+
+#: id:13297
+msgid "Not connected. Check network settings."
+msgstr "Nije povezano. Proverite mrežne postavke."
+
+#: id:13299
+msgid "Target temperature"
+msgstr "Željena temperatura"
+
+#: id:13300
+msgid "Fan speed"
+msgstr "Brzina ventilatora"
+
+#: id:13301
+msgid "Auto temperature control"
+msgstr "Automat. kontrolisanje temperature"
+
+#: id:13302
+msgid "Fan speed override"
+msgstr "Nametni brzinu ventilatora"
+
+#: id:13303
+msgid "- Fonts"
+msgstr "- Slova"
+
+#: id:13304
+msgid "Enable flipping bi-directional strings"
+msgstr "Omogući obrtanje bi-direkcionih stringova"
+
+#: id:13305
+msgid "Show RSS news feeds"
+msgstr "Prikaži RSS novosti"
+
+#: id:13306
+msgid "Show parent folder items"
+msgstr "Prikaži stavke roditeljske fascikle"
+
+#: id:13307
+msgid "Track naming template"
+msgstr "Šablon imenovanja numera"
+
+#: id:13308
+msgid "Do you wish to reboot your system"
+msgstr "Želite li da ponovo pokrenete"
+
+#: id:13309
+msgid "instead of just XBMC?"
+msgstr "ceo sistem, a ne samo XBMC aplikaciju?"
+
+#: id:13310
+msgid "Zoom effect"
+msgstr "Efekat uveličavanja"
+
+#: id:13311
+msgid "Float effect"
+msgstr "Efekat plutanja"
+
+#: id:13312
+msgid "Black bar reduction"
+msgstr "Smanjenje crnih traka"
+
+#: id:13313
+msgid "Restart"
+msgstr "Ponovo pokreni"
+
+#: id:13314
+msgid "Crossfade between songs"
+msgstr "Fini prelaz (preklapanje) između pesama"
+
+#: id:13315
+msgid "Regenerate thumbnails"
+msgstr "Obnavljanje sličica"
+
+#: id:13316
+msgid "Recursive thumbnails"
+msgstr "Rekurzivne sličice"
+
+#: id:13317
+msgid "View slideshow"
+msgstr "Prikaži reproduk. slajdova"
+
+#: id:13318
+msgid "Recursive slideshow"
+msgstr "Rekurzivna reprod. slajdova"
+
+#: id:13319
+msgid "Randomize"
+msgstr "Nasumično"
+
+#: id:13320
+msgid "Stereo"
+msgstr "Stereo"
+
+#: id:13321
+msgid "Left only"
+msgstr "Samo levi"
+
+#: id:13322
+msgid "Right only"
+msgstr "Samo desni"
+
+#: id:13323
+msgid "Enable karaoke support"
+msgstr "Omogući podršku za karaoke"
+
+#: id:13324
+msgid "Background transparency"
+msgstr "Providnost pozadine"
+
+#: id:13325
+msgid "Foreground transparency"
+msgstr "Providnost prednjeg plana"
+
+#: id:13326
+msgid "A/V delay"
+msgstr "A/V kašnjenje"
+
+#: id:13327
+msgid "Karaoke"
+msgstr "Karaoke"
+
+#: id:13328
+msgid "%s not found"
+msgstr "%s nije pronađen"
+
+#: id:13329
+msgid "Error opening %s"
+msgstr "Greška prilikom otvaranja %s"
+
+#: id:13330
+msgid "Unable to load %s"
+msgstr "Nije moguće učitati %s"
+
+#: id:13331
+msgid "Error: Out of memory"
+msgstr "Greška: Nedovoljno memorije"
+
+#: id:13332
+msgid "Move up"
+msgstr "Premesti gore"
+
+#: id:13333
+msgid "Move down"
+msgstr "Premesti dole"
+
+#: id:13334
+msgid "Edit label"
+msgstr "Uredi natpis"
+
+#: id:13335
+msgid "Make default"
+msgstr "Post. podrazumevanim"
+
+#: id:13336
+msgid "Remove button"
+msgstr "Ukloni taster"
+
+#: id:13340
+msgid "Leave as is"
+msgstr "Ostavi kako jeste"
+
+#: id:13341
+msgid "Green"
+msgstr "Zelena"
+
+#: id:13342
+msgid "Orange"
+msgstr "Narandžasta"
+
+#: id:13343
+msgid "Red"
+msgstr "Crvena"
+
+#: id:13344
+msgid "Cycle"
+msgstr "Ciklus"
+
+#: id:13345
+msgid "Switch LED off on playback"
+msgstr "Isključi LED prilikom reprodukcije"
+
+#: id:13346
+msgctxt "Auto context with id 13346"
+msgid "Movie information"
+msgstr "Podaci o filmu"
+
+#: id:13347
+msgid "Queue item"
+msgstr "Stavi u red za reprod."
+
+#: id:13348
+msgid "Search IMDb..."
+msgstr "Pretraži IMDb..."
+
+#: id:13349
+msgid "Scan for new content"
+msgstr "Potraži novi sadržaj"
+
+#: id:13350
+msgid "Now playing..."
+msgstr "Trenutno se reprodukuje..."
+
+#: id:13351
+msgctxt "Auto context with id 13351"
+msgid "Album information"
+msgstr "Podaci o albumu"
+
+#: id:13352
+msgid "Scan item to library"
+msgstr "Analiz. stavke u biblioteci"
+
+#: id:13353
+msgid "Stop scanning"
+msgstr "Zaustavi analiziranje"
+
+#: id:13354
+msgctxt "Auto context with id 13354"
+msgid "Render method"
+msgstr "Način predstavljanja"
+
+#: id:13355
+msgid "Low quality pixel shader"
+msgstr "Nizak kvalitet senčenja piksela"
+
+#: id:13356
+msgid "Hardware overlays"
+msgstr "Hardverska preklapanja"
+
+#: id:13357
+msgid "High quality pixel shader"
+msgstr "Visok kvalitet senčenja piksela"
+
+#: id:13358
+msgid "Play item"
+msgstr "Reprodukuj stavku"
+
+#: id:13359
+msgid "Set artist thumb"
+msgstr "Postavi sličicu izvođača"
+
+#: id:13360
+msgid "Automatically generate thumbnails"
+msgstr "Automatski napravi sličice"
+
+#: id:13361
+msgid "Enable voice"
+msgstr "Omogući glas"
+
+#: id:13375
+msgid "Enable device"
+msgstr "Omogući uređaj"
+
+#: id:13376
+msgid "Volume"
+msgstr "Jačina zvuka"
+
+#: id:13377
+msgid "Default view mode"
+msgstr "Podrazumevani režim prikaza"
+
+#: id:13378
+msgid "Default brightness"
+msgstr "Podrazumevana svetlina"
+
+#: id:13379
+msgid "Default contrast"
+msgstr "Podrazumevani kontrast"
+
+#: id:13380
+msgid "Default gamma"
+msgstr "Podrazumevani opseg boja"
+
+#: id:13381
+msgid "Resume video"
+msgstr "Nastavi film"
+
+#: id:13382
+msgid "Voice mask - Port 1"
+msgstr "Glasovna maska - Priključak 1"
+
+#: id:13383
+msgid "Voice mask - Port 2"
+msgstr "Glasovna maska - Priključak 2"
+
+#: id:13384
+msgid "Voice mask - Port 3"
+msgstr "Glasovna maska - Priključak 3"
+
+#: id:13385
+msgid "Voice mask - Port 4"
+msgstr "Glasovna maska - Priključak 4"
+
+#: id:13386
+msgid "Use time based seeking"
+msgstr "Koristi traženje zasnovano na vremenu"
+
+#: id:13387
+msgid "Track naming template - right"
+msgstr "Šablon imenovanja numera - desno"
+
+#: id:13388
+msgid "Preset"
+msgstr "Unapred zadato"
+
+#: id:13389
+msgid "There are no presets available\nfor this visualization"
+msgstr "Ne postoje unapred zadate postavke\nza ovu vizualizaciju"
+
+#: id:13390
+msgid "There are no settings available\nfor this visualization"
+msgstr "Ne postoje dostupne postavke\nza ovu vizualizaciju"
+
+#: id:13391
+msgid "Eject/Load"
+msgstr "Izbaci/Ubaci"
+
+#: id:13392
+msgid "Use visualization if playing audio"
+msgstr "Koristi vizualizaciju, ukoliko se reprodukuje zvuk"
+
+#: id:13393
+msgid "Calculate size"
+msgstr "Izračunaj veličinu"
+
+#: id:13394
+msgid "Calculating folder size"
+msgstr "Računanje veličine fascikle"
+
+#: id:13395
+msgid "Video settings"
+msgstr "Postavke filma"
+
+#: id:13396
+msgid "Audio and subtitle settings"
+msgstr "Postavke zvuka i titla"
+
+#: id:13397
+msgid "Enable subtitles"
+msgstr "Omogući titlove"
+
+#: id:13398
+msgctxt "Auto context with id 13398"
+msgid "Shortcuts"
+msgstr "Prečice"
+
+#: id:13399
+msgid "Ignore articles when sorting (e.g. \"the\")"
+msgstr "Ignoriši stavke prilikom slaganja (npr. „the“ i sl.)"
+
+#: id:13400
+msgid "Crossfade between songs on the same album"
+msgstr "Fini prelaz između pesama istog albuma"
+
+#: id:13401
+msgid "Browse for %s"
+msgstr "Potraži %s"
+
+#: id:13402
+msgid "Show track position"
+msgstr "Prikaži poziciju numere"
+
+#: id:13403
+msgid "Clear default"
+msgstr "Očisti podrazumevano"
+
+#: id:13404
+msgid "Resume"
+msgstr "Nastavi"
+
+#: id:13405
+msgid "Get thumb"
+msgstr "Preuzmi omot"
+
+#: id:13406
+msgid "Picture information"
+msgstr "Podaci o slici"
+
+#: id:13407
+msgid "%s presets"
+msgstr "%s unap. zad. postavki"
+
+#: id:13408
+msgid "(IMDb user rating)"
+msgstr "(IMDb ocena korisnika)"
+
+#: id:13409
+msgid "Top 250"
+msgstr "Najboljih 250"
+
+#: id:13410
+msgid "Tune in on Last.fm"
+msgstr "Namesti na Last.fm"
+
+#: id:13411
+msgid "Minimum fan speed"
+msgstr "Minimalna brzina ventilatora"
+
+#: id:13412
+msgid "Play from here"
+msgstr ""
+
+#: id:13413
+msgid "Downloading"
+msgstr "Preuzimanje"
+
+#: id:13414
+msgid "Include artists who appear only on compilations"
+msgstr "Uključi izvođače koji se pojavljuju samo na kompilacijama"
+
+#: id:13415
+msgctxt "Auto context with id 13415"
+msgid "Render method"
+msgstr "Način predstavljanja"
+
+#: id:13416
+msgid "Auto detect"
+msgstr "Autom. otkrij"
+
+#: id:13417
+msgid "Basic shaders (ARB)"
+msgstr "Osnovna senčenja (ARB)"
+
+#: id:13418
+msgid "Advanced shaders (GLSL)"
+msgstr "Napredna senčenja (GLSL)"
+
+#: id:13419
+msgid "Software"
+msgstr "Softver"
+
+#: id:13420
+msgid "Remove safely"
+msgstr "Bezbedno ukloni"
+
+#: id:13421
+msgctxt "Auto context with id 13421"
+msgid "VDPAU"
+msgstr "VDPAU"
+
+#: id:13422
+msgid "Start slideshow here"
+msgstr "Pokreni rep. slajd. odavde"
+
+#: id:13423
+msgid "Remember for this path"
+msgstr "Zapamti ovu putanju"
+
+#: id:13424
+msgid "Use pixel buffer objects"
+msgstr "Koristi pikselno predmemorisanje objekata"
+
+#: id:13425
+msgid "Allow hardware acceleration (VDPAU)"
+msgstr "Broadcom Crystal HD"
+
+#: id:13426
+msgid "Allow hardware acceleration (VAAPI)"
+msgstr ""
+
+#: id:13427
+msgid "Allow hardware acceleration (DXVA2)"
+msgstr ""
+
+#: id:13428
+msgid "Allow hardware acceleration (CrystalHD)"
+msgstr ""
+
+#: id:13429
+msgid "Allow hardware acceleration (VDADecoder)"
+msgstr ""
+
+#: id:13430
+msgid "Allow hardware acceleration (OpenMax)"
+msgstr ""
+
+#: id:13431
+msgid "Pixel Shaders"
+msgstr ""
+
+#: id:13432
+msgid "Allow hardware acceleration (VideoToolbox)"
+msgstr ""
+
+#: id:13500
+msgid "A/V sync method"
+msgstr "A/V način sinhron."
+
+#: id:13501
+msgid "Audio clock"
+msgstr "Časovnik zvuka"
+
+#: id:13502
+msgid "Video clock (Drop/Dupe audio)"
+msgstr "Časovnik filma (Drop/Dupe zvuk)"
+
+#: id:13503
+msgid "Video clock (Resample audio)"
+msgstr "Časovnik filma (Ponov. odab. zvuka)"
+
+#: id:13504
+msgid "Maximum resample amount (%)"
+msgstr "Maksimalna količina pon. odabir. (%)"
+
+#: id:13505
+msgid "Resample quality"
+msgstr "Kvalitet ponov. odab."
+
+#: id:13506
+msgid "Low(fast)"
+msgstr "Nizak (brzo)"
+
+#: id:13507
+msgctxt "Auto context with id 13507"
+msgid "Medium"
+msgstr "Srednje"
+
+#: id:13508
+msgctxt "Auto context with id 13508"
+msgid "High"
+msgstr "Visok"
+
+#: id:13509
+msgid "Really high(slow!)"
+msgstr "Zaista visok (sporo!)"
+
+#: id:13510
+msgid "Sync playback to display"
+msgstr "Sinhronizuj reprodukciju prema prikazu"
+
+#: id:13550
+msgid "Pause during refresh rate change"
+msgstr ""
+
+#: id:13551
+msgctxt "Auto context with id 13551"
+msgid "Off"
+msgstr ""
+
+#: id:13552
+msgid "%.1f Second"
+msgstr ""
+
+#: id:13553
+msgid "%.1f Seconds"
+msgstr ""
+
+#: id:13600
+msgid "Apple remote"
+msgstr "Apple daljinski upravljač"
+
+#: id:13602
+msgid "Allow start of XBMC using the remote"
+msgstr "Dozvoli pokretanje XBMC aplik. korišćenjem daljinskog"
+
+#: id:13603
+msgid "Sequence delay time"
+msgstr "Vreme kašnjenja sekvence"
+
+#: id:13610
+msgctxt "Auto context with id 13610"
+msgid "Disabled"
+msgstr "Onemogućeno"
+
+#: id:13611
+msgctxt "Auto context with id 13611"
+msgid "Standard"
+msgstr "Uobičajeno"
+
+#: id:13612
+msgid "Universal Remote"
+msgstr "Univerzalni daljinski"
+
+#: id:13613
+msgid "Multi Remote (Harmony)"
+msgstr "Višestruki daljinski (Složno)"
+
+#: id:13620
+msgid "Apple Remote Error"
+msgstr "Greška Apple daljinskog upravljača"
+
+#: id:13621
+msgid "Apple Remote support could be enabled."
+msgstr "Podrška za Apple dalj. upravljač može biti omogućena."
+
+#: id:14000
+msgid "Stack"
+msgstr "Postavi na skladište"
+
+#: id:14001
+msgid "Unstack"
+msgstr "Ukloni sa skladišta"
+
+#: id:14003
+msgid "Downloading playlist file..."
+msgstr "Preuzimanje datoteke spisk. za rep..."
+
+#: id:14004
+msgid "Downloading streams list..."
+msgstr "Preuzimanje spiska protoka podataka..."
+
+#: id:14005
+msgid "Parsing streams list..."
+msgstr "Razlučivanje (razlaganje) spiska protoka podataka..."
+
+#: id:14006
+msgid "Downloading streams list failed"
+msgstr "Nije uspelo preuzimanje spiska protoka podataka"
+
+#: id:14007
+msgid "Downloading playlist file failed"
+msgstr "Nije uspelo preuzimanje datoteke spiska za reprodukciju"
+
+#: id:14009
+msgid "Games directory"
+msgstr "Katalog igara"
+
+#: id:14010
+msgid "Auto switch to thumbs based on"
+msgstr "Autom. prebaci na sličice zasnovano na"
+
+#: id:14011
+msgid "Enable auto switching to thumbs view"
+msgstr "Omogući automatsko prebacivanje na prikaz omota"
+
+#: id:14012
+msgid "- Use large icons"
+msgstr "- Koristi velike ikone"
+
+#: id:14013
+msgid "- Switch based on"
+msgstr "- Prebacivanje zasnovano na"
+
+#: id:14014
+msgid "- Percentage"
+msgstr "- Postotak"
+
+#: id:14015
+msgid "No files and at least one thumb"
+msgstr "Bez datoteka i bar jedne sličice"
+
+#: id:14016
+msgid "At least one file and thumb"
+msgstr "Bar jedna datoteka i sličica"
+
+#: id:14017
+msgid "Percentage of thumbs"
+msgstr "Procenat sličica"
+
+#: id:14018
+msgid "View options"
+msgstr "Prikaži opcije"
+
+#: id:14019
+msgid "Change area code 1"
+msgstr "Promeni kôd područja 1"
+
+#: id:14020
+msgid "Change area code 2"
+msgstr "Promeni kôd područja 2"
+
+#: id:14021
+msgid "Change area code 3"
+msgstr "Promeni kôd područja 3"
+
+#: id:14022
+msgctxt "Auto context with id 14022"
+msgid "Library"
+msgstr "Biblioteka"
+
+#: id:14023
+msgid "No TV"
+msgstr "Bez TV prijemnika"
+
+#: id:14024
+msgid "Enter the nearest large town"
+msgstr "Unesite najbliži veći grad"
+
+#: id:14025
+msgid "Video/Audio/DVD cache - Harddisk"
+msgstr "Video/Zvučni/DVD keš - čvrsti disk"
+
+#: id:14026
+msgid "Video cache - DVD-ROM"
+msgstr "Video keš - DVD-ROM"
+
+#: id:14027
+msgctxt "Auto context with id 14027"
+msgid "- Local Network"
+msgstr "- Lokalna mreža"
+
+#: id:14028
+msgctxt "Auto context with id 14028"
+msgid "- Internet"
+msgstr "- Internet"
+
+#: id:14030
+msgid "Audio cache - DVD-ROM"
+msgstr "Keš zvuka - DVD-ROM"
+
+#: id:14031
+msgctxt "Auto context with id 14031"
+msgid "- Local Network"
+msgstr "- Lokalna mreža"
+
+#: id:14032
+msgctxt "Auto context with id 14032"
+msgid "- Internet"
+msgstr "- Internet"
+
+#: id:14034
+msgid "DVD cache - DVD-ROM"
+msgstr "DVD keš - DVD-ROM"
+
+#: id:14035
+msgctxt "Auto context with id 14035"
+msgid "- Local Network"
+msgstr "- Lokalna mreža"
+
+#: id:14036
+msgctxt "Auto context with id 14036"
+msgid "Services"
+msgstr "Usluge"
+
+#: id:14038
+msgid "Network settings changed"
+msgstr "Promenjene su mrežne postavke"
+
+#: id:14039
+msgid "XBMC requires to restart to change your"
+msgstr "XBMC zahteva ponovno pokretanje radi promene"
+
+#: id:14040
+msgid "network setup. Would you like to restart now?"
+msgstr "mrežnih postavki. Želite li odmah da ponovo pokrenete?"
+
+#: id:14041
+msgid "Internet connection bandwidth limitation"
+msgstr "Naknadna obrada"
+
+#: id:14043
+msgid "- Shutdown while playing"
+msgstr "- Isključi dok se reprodukuje"
+
+#: id:14044
+msgid "%i min"
+msgstr "%i min."
+
+#: id:14045
+msgid "%i sec"
+msgstr "%i sek."
+
+#: id:14046
+msgid "%i ms"
+msgstr "%i ms"
+
+#: id:14047
+msgid "%i %%"
+msgstr "%i %%"
+
+#: id:14048
+msgid "%i kbps"
+msgstr "%i kbps"
+
+#: id:14049
+msgid "%i kb"
+msgstr "%i kb"
+
+#: id:14050
+msgid "%i.0 dB"
+msgstr "%i.0 dB"
+
+#: id:14051
+msgid "Time format"
+msgstr "Prikaz vremena"
+
+#: id:14052
+msgid "Date format"
+msgstr "Prikaz datuma"
+
+#: id:14053
+msgid "GUI filters"
+msgstr "GUI filteri"
+
+#: id:14055
+msgid "Use background scanning"
+msgstr "Koristi analiziranje u pozadini"
+
+#: id:14056
+msgid "Stop scan"
+msgstr "Zaustavi analiziranje"
+
+#: id:14057
+msgid "Not possible while scanning for media info"
+msgstr "Nije moguće dok je u toku analiziranje podataka o mediju"
+
+#: id:14058
+msgid "Film grain effect"
+msgstr "Zrnasti efekat prikaza"
+
+#: id:14059
+msgid "Search for thumbnails on remote shares"
+msgstr "Potraži sličice na deljenim lokacijama"
+
+#: id:14060
+msgid "Unknown type cache - Internet"
+msgstr "Nepoznat tip keša - Internet"
+
+#: id:14061
+msgctxt "Auto context with id 14061"
+msgid "Auto"
+msgstr "Autom."
+
+#: id:14062
+msgid "Enter username for"
+msgstr "Unesite korisničko ime za"
+
+#: id:14063
+msgid "Date & time"
+msgstr "Datum i vreme"
+
+#: id:14064
+msgid "Set date"
+msgstr "Postavi datum"
+
+#: id:14065
+msgid "Set time"
+msgstr "Postavi vreme"
+
+#: id:14066
+msgid "Enter the time in 24 hour HH:MM format"
+msgstr "Unesite vreme u obliku 24 časa; ČČ:MM"
+
+#: id:14067
+msgid "Enter the date in DD/MM/YYYY format"
+msgstr "Unesite datum u obliku DD/MM/GGGG"
+
+#: id:14068
+msgid "Enter the IP address"
+msgstr "Unesite IP adresu"
+
+#: id:14069
+msgid "Apply these settings now?"
+msgstr "Odmah primeniti postavke?"
+
+#: id:14070
+msgid "Apply changes now"
+msgstr "Odmah primeni promene"
+
+#: id:14071
+msgid "Allow file renaming and deletion"
+msgstr "Dozvoli preimenovanje i brisanje datoteke"
+
+#: id:14074
+msgid "Set timezone"
+msgstr "Postavi vremensku zonu"
+
+#: id:14075
+msgid "Use daylight saving time"
+msgstr "Koristi letnje računanje vremena"
+
+#: id:14076
+msgid "Add to favourites"
+msgstr "Dodaj u omiljeno"
+
+#: id:14077
+msgid "Remove from favourites"
+msgstr "Ukloni iz omiljenog"
+
+#: id:14078
+msgctxt "Auto context with id 14078"
+msgid "- Colours"
+msgstr "- Boje"
+
+#: id:14079
+msgid "Timezone country"
+msgstr "Zemlja vremenske zone"
+
+#: id:14080
+msgid "Timezone"
+msgstr "Vremenska zona"
+
+#: id:14081
+msgid "File lists"
+msgstr "Spiskovi datoteka"
+
+#: id:14082
+msgid "Show EXIF picture information"
+msgstr "Prikaži EXIF specifikaciju slike"
+
+#: id:14083
+msgid "Use a fullscreen window rather than true fullscreen"
+msgstr "Radije koristi prikaz čitavog ekrana u prozoru"
+
+#: id:14084
+msgid "Queue songs on selection"
+msgstr "Stavi pesmu u red prilikom izbora"
+
+#: id:14086
+msgid "Playback"
+msgstr "Reprodukcija"
+
+#: id:14087
+msgid "DVDs"
+msgstr "DVD-ovi"
+
+#: id:14088
+msgid "Play DVDs automatically"
+msgstr "Automatski reprodukuj DVD-ove"
+
+#: id:14089
+msgid "Font to use for text subtitles"
+msgstr "Oblik slova za titlove"
+
+#: id:14090
+msgid "International"
+msgstr "Međunarodno"
+
+#: id:14091
+msgid "Character set"
+msgstr "Skup znakova"
+
+#: id:14092
+msgid "Debugging"
+msgstr "Traženje grešaka"
+
+#: id:14093
+msgid "Security"
+msgstr "Bezbednost"
+
+#: id:14094
+msgid "Input devices"
+msgstr "Ulazni uređaji"
+
+#: id:14095
+msgid "Power saving"
+msgstr "Ušteda energije"
+
+#: id:14096
+msgid "Rip"
+msgstr ""
+
+#: id:14097
+msgid "Audio CD Insert Action"
+msgstr ""
+
+#: id:14098
+msgctxt "Auto context with id 14098"
+msgid "Play"
+msgstr ""
+
+#: id:14099
+msgid "Eject disc when CD ripping is complete"
+msgstr ""
+
+#: id:15015
+msgctxt "Auto context with id 15015"
+msgid "Remove"
+msgstr "Ukloni"
+
+#: id:15016
+msgid "Games"
+msgstr "Igre"
+
+#: id:15019
+msgid "Add"
+msgstr "Dodaj"
+
+#: id:15052
+msgid "Password"
+msgstr "Lozinka"
+
+#: id:15100
+msgctxt "Auto context with id 15100"
+msgid "Library"
+msgstr "Biblioteka"
+
+#: id:15101
+msgid "Database"
+msgstr "Baza podataka"
+
+#: id:15102
+msgid "* All albums"
+msgstr "* Svi albumi"
+
+#: id:15103
+msgid "* All artists"
+msgstr "* Svi izvođači"
+
+#: id:15104
+msgid "* All songs"
+msgstr "* Sve pesme"
+
+#: id:15105
+msgid "* All genres"
+msgstr "* Svi žanrovi"
+
+#: id:15107
+msgid "Buffering..."
+msgstr "Predmemorisanje..."
+
+#: id:15108
+msgid "Navigation sounds"
+msgstr "Navigacioni zvukovi"
+
+#: id:15109
+msgid "Skin default"
+msgstr "Podrazumevana maska"
+
+#: id:15111
+msgid "- Theme"
+msgstr "- Tema"
+
+#: id:15112
+msgid "Default theme"
+msgstr "Podrazumevana tema"
+
+#: id:15200
+msgid "Last.fm"
+msgstr "Last.fm"
+
+#: id:15201
+msgid "Submit songs to Last.fm"
+msgstr "Pošalji pesme na Last.fm"
+
+#: id:15202
+msgid "Last.fm username"
+msgstr "Last.fm korisničko ime"
+
+#: id:15203
+msgid "Last.fm password"
+msgstr "Last.fm lozinka"
+
+#: id:15204
+msgid "Unable to handshake: sleeping..."
+msgstr "Nije moguće usaglašavanje: stanje spavanja..."
+
+#: id:15205
+msgid "Please update XBMC"
+msgstr "Molimo, ažurirajte XBMC"
+
+#: id:15206
+msgid "Bad authorization: Check username and password"
+msgstr "Pogrešna autorizacija: Proverite korisničko ime i lozinku"
+
+#: id:15207
+msgctxt "Auto context with id 15207"
+msgid "Connected"
+msgstr "Povezano"
+
+#: id:15208
+msgid "Not connected"
+msgstr "Nije povezano"
+
+#: id:15209
+msgid "Submit interval %i"
+msgstr "Učestalost slanja %i"
+
+#: id:15210
+msgid "Cached %i songs"
+msgstr "Keširano %i pesama"
+
+#: id:15211
+msgid "Submitting..."
+msgstr "Slanje je u toku..."
+
+#: id:15212
+msgid "Submitting in %i secs"
+msgstr "Slanje za %i sekundi"
+
+#: id:15213
+msgid "Play using..."
+msgstr "Reprodukuj pomoću..."
+
+#: id:15214
+msgid "Use smoothed A/V synchronization"
+msgstr "Koristi umekšanu A/V sinhronizaciju"
+
+#: id:15215
+msgid "Hide file names in thumbs view"
+msgstr "Sakrij nazive datoteka prilikom prikaza omota"
+
+#: id:15216
+msgid "Play in party mode"
+msgstr "Reprodukuj u režimu žurke"
+
+#: id:15217
+msgid "Submit songs to Libre.fm"
+msgstr "Pošalji pesme na Libre.fm"
+
+#: id:15218
+msgid "Libre.fm username"
+msgstr "Libre.fm korisničko ime"
+
+#: id:15219
+msgid "Libre.fm password"
+msgstr "Libre.fm lozinka"
+
+#: id:15220
+msgid "Libre.fm"
+msgstr "Libre.fm"
+
+#: id:15221
+msgid "Song submission"
+msgstr "Slanje pesme"
+
+#: id:15250
+msgid "Submit Last.fm radio to Last.fm"
+msgstr "Pošalji Last.fm radio na Last.fm"
+
+#: id:15251
+msgid "Connecting to Last.fm..."
+msgstr "Povezivanje sa Last.fm..."
+
+#: id:15252
+msgid "Selecting station..."
+msgstr "Biranje stanice..."
+
+#: id:15253
+msgid "Search similar artists..."
+msgstr "Pronađi slične izvođače..."
+
+#: id:15254
+msgid "Search similar tags..."
+msgstr "Pronađi slične oznake..."
+
+#: id:15255
+msgid "Your profile (%name%)"
+msgstr "Vaš profil (%name%)"
+
+#: id:15256
+msgid "Overall top tags"
+msgstr "Sveobuhvatno najbolje oznake"
+
+#: id:15257
+msgid "Top artists for tag %name%"
+msgstr "Najbolji izvođači sa oznakom %name%"
+
+#: id:15258
+msgid "Top albums for tag %name%"
+msgstr "Najbolji albumi sa oznakom %name%"
+
+#: id:15259
+msgid "Top tracks for tag %name%"
+msgstr "Najbolje numere sa oznakom %name%"
+
+#: id:15260
+msgid "Listen to tag %name% Last.fm radio"
+msgstr "Slušaj oznaku %name% Last.fm radija"
+
+#: id:15261
+msgid "Similar artists as %name%"
+msgstr "Izvođači koji su slični sa %name%"
+
+#: id:15262
+msgid "Top %name% albums"
+msgstr "Najbolji %name% albumi"
+
+#: id:15263
+msgid "Top %name% tracks"
+msgstr "Najbolje %name% numere"
+
+#: id:15264
+msgid "Top %name% tags"
+msgstr "Najbolje %name% oznake"
+
+#: id:15265
+msgid "Biggest fans of %name%"
+msgstr "Najveći %name% obožavaoci"
+
+#: id:15266
+msgid "Listen to %name% fans Last.fm radio"
+msgstr "Slušaj obožavaoce %name%, Last.fm radija"
+
+#: id:15267
+msgid "Listen to %name% similar artists Last.fm radio"
+msgstr "Slušaj slične izvođače kao što je %name% na Last.fm radiju"
+
+#: id:15268
+msgid "Top artists for user %name%"
+msgstr "Najbolji izvođači korisnika %name%"
+
+#: id:15269
+msgid "Top albums for user %name%"
+msgstr "Najbolji albumi korisnika %name%"
+
+#: id:15270
+msgid "Top tracks for user %name%"
+msgstr "Najbolje numere korisnika %name%"
+
+#: id:15271
+msgid "Friends of user %name%"
+msgstr "Prijatelji korisnika %name%"
+
+#: id:15272
+msgid "Neighbours of user %name%"
+msgstr "Komšije korisnika %name%"
+
+#: id:15273
+msgid "Weekly artist chart for %name%"
+msgstr "Nedeljni spisak najboljih izvođača korisnika %name%"
+
+#: id:15274
+msgid "Weekly album chart for %name%"
+msgstr "Nedeljni spisak najboljih albuma korisnika %name%"
+
+#: id:15275
+msgid "Weekly track chart for %name%"
+msgstr "Nedeljni spisak najboljih numera korisnika %name%"
+
+#: id:15276
+msgid "Listen to %name%'s neighbours Last.fm radio"
+msgstr "Slušaj komšijin Last.fm radio korisnika %name%"
+
+#: id:15277
+msgid "Listen to %name%'s personal Last.fm radio"
+msgstr "Slušaj lični Last.fm radio korisnika %name%"
+
+#: id:15278
+msgid "Listen to %name%'s mix Last.fm radio"
+msgstr "Slušaj voljene numere Last.fm radija korisnika %name%"
+
+#: id:15279
+msgid "Retrieving list from Last.fm..."
+msgstr "Preuzimanje spiska sa Last.fm..."
+
+#: id:15280
+msgid "Can't retrieve list from Last.fm..."
+msgstr "Nije moguće preuzeti spisak sa Last.fm..."
+
+#: id:15281
+msgid "Enter an artist name to find related ones"
+msgstr "Unesite naziv izvođača kako biste pronašli slične"
+
+#: id:15282
+msgid "Enter a tag name to find similar ones"
+msgstr "Unesite oznaku za pronalaženje sličnih"
+
+#: id:15283
+msgid "Tracks recently listened by %name%"
+msgstr "Nedavno odslušane numere korisnika %name%"
+
+#: id:15284
+msgid "Listen to %name%'s recommendations Last.fm radio"
+msgstr "Slušaj po preporuci Last.fm radio korisnika %name%"
+
+#: id:15285
+msgid "Top tags for user %name%"
+msgstr "Najbolje oznake za korisnika %name%"
+
+#: id:15287
+msgid "Do you want to add the current track to your loved tracks?"
+msgstr "Želite li da dodate trenutnu numeru u vaše voljene numere?"
+
+#: id:15288
+msgid "Do you want to ban the current track?"
+msgstr "Želite li da zabranite trenutnu numeru?"
+
+#: id:15289
+msgid "Added to your loved tracks: '%s'."
+msgstr "Dodato u vaše voljene numere: „%s“."
+
+#: id:15290
+msgid "Could not add '%s' to your loved tracks."
+msgstr "Nije moguće dodati „%s“ u vaše voljene numere."
+
+#: id:15291
+msgid "Banned: '%s'."
+msgstr "Zabranjeno: „%s“."
+
+#: id:15292
+msgid "Could not ban '%s'."
+msgstr "Nije moguće zabraniti „%s“."
+
+#: id:15293
+msgid "Tracks recently loved by %name%"
+msgstr "Numere koje je nedavno zavoleo %name%"
+
+#: id:15294
+msgid "Tracks recently banned by %name%"
+msgstr "Numere koje je nedavno zabranio %name%"
+
+#: id:15295
+msgid "Remove from loved tracks"
+msgstr "Uklonjeno iz voljenih numera"
+
+#: id:15296
+msgid "Un-ban"
+msgstr "Opozovi zabranu"
+
+#: id:15297
+msgid "Do you want to remove this track from your loved tracks?"
+msgstr "Želite li da uklonite ovu numeru iz voljenih numera?"
+
+#: id:15298
+msgid "Do you want to un-ban this track?"
+msgstr "Želite li da opozovete zabranu za ovu numeru?"
+
+#: id:15300
+msgid "Path not found or invalid"
+msgstr "Putanja nije pronađena ili je nevažeća"
+
+#: id:15301
+msgid "Could not connect to network server"
+msgstr "Nije moguće povezivanje sa mrežnim serverom"
+
+#: id:15302
+msgid "No servers found"
+msgstr "Ni jedan server nije pronađen"
+
+#: id:15303
+msgid "Workgroup not found"
+msgstr "Radna grupa nije pronađena"
+
+#: id:15310
+msgid "Opening multi-path source"
+msgstr "Otvaranje izvora sa više putanja"
+
+#: id:15311
+msgid "Path:"
+msgstr "Putanja:"
+
+#: id:16000
+msgctxt "Auto context with id 16000"
+msgid "General"
+msgstr "Opšte"
+
+#: id:16002
+msgid "Internet lookup"
+msgstr "Pretraživanje interneta"
+
+#: id:16003
+msgid "Player"
+msgstr "Uređaj za reprodukciju"
+
+#: id:16004
+msgid "Play media from disc"
+msgstr "Reprodukuj medij sa diska"
+
+#: id:16008
+msgid "Enter new title"
+msgstr "Unesite novi naslov"
+
+#: id:16009
+msgid "Enter the movie name"
+msgstr "Unesite ime filma"
+
+#: id:16010
+msgid "Enter the profile name"
+msgstr "Unesite ime profila"
+
+#: id:16011
+msgid "Enter the album name"
+msgstr "Unesite ime albuma"
+
+#: id:16012
+msgid "Enter the playlist name"
+msgstr "Unesite ime spiska za rep."
+
+#: id:16013
+msgid "Enter new filename"
+msgstr "Unesite novo ime datoteke"
+
+#: id:16014
+msgid "Enter folder name"
+msgstr "Unesite ime fascikle"
+
+#: id:16015
+msgid "Enter directory"
+msgstr "Unesite fasciklu"
+
+#: id:16016
+msgid "Available options: %A, %T, %N, %B, %D, %G, %Y, %F, %S"
+msgstr "Dostupne opcije: %A, %T, %N, %B, %D, %G, %Y, %F, %S"
+
+#: id:16017
+msgid "Enter search string"
+msgstr "Unesite reč za pretragu"
+
+#: id:16018
+msgctxt "Auto context with id 16018"
+msgid "None"
+msgstr "Ništa"
+
+#: id:16019
+msgid "Auto select"
+msgstr "Automatski izbor"
+
+#: id:16020
+msgid "De-interlace"
+msgstr "Ukloni preplitanje slike"
+
+#: id:16021
+msgid "Bob"
+msgstr "Bob"
+
+#: id:16022
+msgid "Bob (inverted)"
+msgstr "Bob (obratno)"
+
+#: id:16024
+msgid "Canceling..."
+msgstr "Otkazivanje..."
+
+#: id:16025
+msgid "Enter the artist name"
+msgstr "Unesi ime izvođača"
+
+#: id:16026
+msgid "Playback failed"
+msgstr "Neuspešna reprodukcija"
+
+#: id:16027
+msgid "One or more items failed to play."
+msgstr "Jednu ili više stavki nije moguće reprodukovati."
+
+#: id:16028
+msgid "Enter value"
+msgstr "Unesite vrednost"
+
+#: id:16029
+msgid "Check the log file for details."
+msgstr "Proverite datoteku evidencije za detalje."
+
+#: id:16030
+msgid "Party mode aborted."
+msgstr "Režim žurke je prekinut."
+
+#: id:16031
+msgid "No matching songs in the library."
+msgstr "Nema podudarajućih pesama u biblioteci."
+
+#: id:16032
+msgid "Could not initialize database."
+msgstr "Nije moguće pokrenuti bazu podataka."
+
+#: id:16033
+msgid "Could not open database."
+msgstr "Nije moguće otvoriti bazu podataka."
+
+#: id:16034
+msgid "Could not get songs from database."
+msgstr "Nije moguće preuzeti pesme iz baze podataka."
+
+#: id:16035
+msgid "Party mode playlist"
+msgstr "Spisak za rep. režima žurke"
+
+#: id:16036
+msgid "De-interlace (Half)"
+msgstr ""
+
+#: id:16037
+msgid "Deinterlace video"
+msgstr ""
+
+#: id:16038
+msgid "Deinterlace method"
+msgstr ""
+
+#: id:16039
+msgctxt "Auto context with id 16039"
+msgid "Off"
+msgstr ""
+
+#: id:16040
+msgctxt "Auto context with id 16040"
+msgid "Auto"
+msgstr ""
+
+#: id:16041
+msgid "On"
+msgstr ""
+
+#: id:16100
+msgid "All Videos"
+msgstr "Svi filmovi"
+
+#: id:16101
+msgid "Unwatched"
+msgstr "neodgledanih"
+
+#: id:16102
+msgid "Watched"
+msgstr "odgledanih"
+
+#: id:16103
+msgid "Mark as watched"
+msgstr "Obeleži kao odgledano"
+
+#: id:16104
+msgid "Mark as unwatched"
+msgstr "Obeleži kao neodgledano"
+
+#: id:16105
+msgid "Edit title"
+msgstr "Uredi naslov"
+
+#: id:16200
+msgid "Operation was aborted"
+msgstr "Operacija je prekinuta"
+
+#: id:16201
+msgid "Copy failed"
+msgstr "Kopiranje nije uspelo"
+
+#: id:16202
+msgid "Failed to copy at least one file"
+msgstr "Nije uspelo kopiranje barem jedne datoteke"
+
+#: id:16203
+msgid "Move failed"
+msgstr "Premeštanje nije uspelo"
+
+#: id:16204
+msgid "Failed to move at least one file"
+msgstr "Nije uspelo premeštanje barem jedne datoteke"
+
+#: id:16205
+msgid "Delete failed"
+msgstr "Brisanje nije uspelo"
+
+#: id:16206
+msgid "Failed to delete at least one file"
+msgstr "Nije uspelo brisanje barem jedne datoteke"
+
+#: id:16300
+msgid "Video scaling method"
+msgstr "Režim video razmere"
+
+#: id:16301
+msgid "Nearest neighbour"
+msgstr "Najbliži komšija"
+
+#: id:16302
+msgid "Bilinear"
+msgstr "Bilinear"
+
+#: id:16303
+msgctxt "Auto context with id 16303"
+msgid "Bicubic"
+msgstr "Bicubic"
+
+#: id:16304
+msgid "Lanczos2"
+msgstr "Lanczos2"
+
+#: id:16305
+msgid "Lanczos3"
+msgstr "Lanczos3"
+
+#: id:16306
+msgid "Sinc8"
+msgstr "Sinc8"
+
+#: id:16307
+msgid "Bicubic (software)"
+msgstr "Bicubic (softverski)"
+
+#: id:16308
+msgid "Lanczos (software)"
+msgstr "Lanczos (softverski)"
+
+#: id:16309
+msgid "Sinc (software)"
+msgstr "Sinc (softverski)"
+
+#: id:16310
+msgid "Temporal"
+msgstr "Vremenski"
+
+#: id:16311
+msgid "Temporal/Spatial"
+msgstr "Vremenski/prostorni"
+
+#: id:16312
+msgid "(VDPAU)Noise Reduction"
+msgstr "(VDPAU) Smanjenje šuma"
+
+#: id:16313
+msgid "(VDPAU)Sharpness"
+msgstr "(VDPAU) Oštrina"
+
+#: id:16314
+msgid "Inverse Telecine"
+msgstr "Obrnuti Telecine"
+
+#: id:16315
+msgid "Lanczos3 optimized"
+msgstr "Optimizovani Lanczos3"
+
+#: id:16316
+msgctxt "Auto context with id 16316"
+msgid "Auto"
+msgstr "Automatski"
+
+#: id:16317
+msgid "Temporal (Half)"
+msgstr "Vremenski (polovično)"
+
+#: id:16318
+msgid "Temporal/Spatial (Half)"
+msgstr "Vremenski/prostorni (polovično)"
+
+#: id:16319
+msgid "DXVA"
+msgstr ""
+
+#: id:16320
+msgid "DXVA Bob"
+msgstr ""
+
+#: id:16321
+msgid "DXVA Best"
+msgstr ""
+
+#: id:16322
+msgid "Spline36"
+msgstr ""
+
+#: id:16323
+msgid "Spline36 optimized"
+msgstr ""
+
+#: id:16324
+msgid "Software Blend"
+msgstr ""
+
+#: id:16400
+msgid "Post-processing"
+msgstr ""
+
+#: id:17500
+msgid "Display sleep timeout"
+msgstr "Vreme nakon kog će ekran preći u stanje spavanja"
+
+#: id:19000
+msgid "Switch to channel"
+msgstr "Prebaci na kanal"
+
+#: id:20000
+msgid "Saved music folder"
+msgstr "Fascikla sa sačuvanom muzikom"
+
+#: id:20001
+msgid "Use external DVD player"
+msgstr "Koristi spoljni DVD uređaj za rep."
+
+#: id:20002
+msgid "External DVD player"
+msgstr "Spoljni DVD uređaj za rep."
+
+#: id:20003
+msgid "Trainers folder"
+msgstr "Fascikla modifikatora igara"
+
+#: id:20004
+msgid "Screenshot folder"
+msgstr "Fascikla sa slikama ekrana"
+
+#: id:20006
+msgid "Playlists folder"
+msgstr "Fascikla sa spiskovima za rep."
+
+#: id:20007
+msgid "Recordings"
+msgstr "Snimci"
+
+#: id:20008
+msgid "Screenshots"
+msgstr "Slike ekrana"
+
+#: id:20009
+msgid "Use XBMC"
+msgstr "Koristi XBMC"
+
+#: id:20011
+msgid "Music playlists"
+msgstr "Spiskovi za reprod. muzike"
+
+#: id:20012
+msgid "Video playlists"
+msgstr "Spiskovi za reprod. filmova"
+
+#: id:20013
+msgid "Do you wish to launch the game?"
+msgstr "Želite li da pokrenete igru?"
+
+#: id:20014
+msgid "Sort by: Playlist"
+msgstr "Složi po: Spis. za rep."
+
+#: id:20015
+msgid "Remote thumb"
+msgstr "Udaljena sličica"
+
+#: id:20016
+msgid "Current thumb"
+msgstr "Trenutna sličica"
+
+#: id:20017
+msgid "Local thumb"
+msgstr "Lokalna sličica"
+
+#: id:20018
+msgid "No thumb"
+msgstr "Nema sličice"
+
+#: id:20019
+msgid "Choose thumbnail"
+msgstr "Izaberi sličicu"
+
+#: id:20023
+msgid "Conflict"
+msgstr "Neusaglašenost"
+
+#: id:20024
+msgid "Scan new"
+msgstr "Pretraživanje novih"
+
+#: id:20025
+msgid "Scan all"
+msgstr "Pretraživanje svih"
+
+#: id:20026
+msgid "Region"
+msgstr "Regija"
+
+#: id:20037
+msgid "Summary"
+msgstr "Kratak pregled"
+
+#: id:20038
+msgid "Lock music window"
+msgstr "Zaključaj prozor sa muzikom"
+
+#: id:20039
+msgid "Lock videos window"
+msgstr "Zaključaj prozor sa filmovima"
+
+#: id:20040
+msgid "Lock pictures window"
+msgstr "Zaključaj prozor sa slikama"
+
+#: id:20041
+msgid "Lock programs & scripts windows"
+msgstr "Zaključaj prozor sa programima i skriptama"
+
+#: id:20042
+msgid "Lock file manager"
+msgstr "Zaključaj upravljača datotekama"
+
+#: id:20043
+msgid "Lock settings"
+msgstr "Zaključaj postavke"
+
+#: id:20044
+msgid "Start fresh"
+msgstr "Novi početak"
+
+#: id:20045
+msgid "Enter master mode"
+msgstr "Uđi u glavni režim"
+
+#: id:20046
+msgid "Leave master mode"
+msgstr "Napusti glavni režim"
+
+#: id:20047
+msgid "Create profile '%s'?"
+msgstr "Napraviti profil „%s“?"
+
+#: id:20048
+msgid "Start with fresh settings"
+msgstr "Pokreni sa novim postavkama"
+
+#: id:20049
+msgid "Best available"
+msgstr "Najbolje moguće"
+
+#: id:20050
+msgid "Auto-switch between 16x9 and 4x3"
+msgstr "Automatsko prebacivanje između 16x9 i 4x3"
+
+#: id:20051
+msgid "Treat stacked files as single file"
+msgstr "Smatraj komprimovane datoteke kao jednu"
+
+#: id:20052
+msgid "Caution"
+msgstr "Oprez"
+
+#: id:20053
+msgid "Left master mode"
+msgstr "Napušten glavni režim"
+
+#: id:20054
+msgid "Entered master mode"
+msgstr "Pristupljeno glavnom režimu"
+
+#: id:20055
+msgid "Allmusic.com thumb"
+msgstr "Omot sa Allmusic.com"
+
+#: id:20057
+msgid "Remove thumbnail"
+msgstr "Ukloni sličicu"
+
+#: id:20058
+msgid "Add profile..."
+msgstr "Dodaj profil..."
+
+#: id:20059
+msgid "Query info for all albums"
+msgstr "Zahtevaj podatke za sve albume"
+
+#: id:20060
+msgctxt "Auto context with id 20060"
+msgid "Media info"
+msgstr "Podaci o mediju"
+
+#: id:20061
+msgctxt "Auto context with id 20061"
+msgid "Separate"
+msgstr "Odvojeno"
+
+#: id:20062
+msgid "Shares with default"
+msgstr "Podrazumevano deljenje"
+
+#: id:20063
+msgid "Shares with default (read only)"
+msgstr "Podrazumevano deljenje (samo čitanje)"
+
+#: id:20064
+msgid "Copy default"
+msgstr "Podrazumevano kopiranje"
+
+#: id:20065
+msgid "Profile picture"
+msgstr "Slika profila"
+
+#: id:20066
+msgid "Lock preferences"
+msgstr "Zaključaj postavke"
+
+#: id:20067
+msgid "Edit profile"
+msgstr "Uredi profil"
+
+#: id:20068
+msgid "Profile lock"
+msgstr "Zaključaj profil"
+
+#: id:20069
+msgid "Could not create folder"
+msgstr "Nije moguće napraviti fasciklu"
+
+#: id:20070
+msgid "Profile directory"
+msgstr "Fascikla profila"
+
+#: id:20071
+msgid "Start with fresh media sources"
+msgstr "Pokreni sa novim izvorom medija"
+
+#: id:20072
+msgid "Make sure the selected folder is writable"
+msgstr "Uverite se da u izabranu fasciklu možete"
+
+#: id:20073
+msgid "and that the new folder name is valid"
+msgstr "upisivati i da je novo ime fascikle ispravno"
+
+#: id:20074
+msgid "MPAA rating"
+msgstr "MPAA ocena"
+
+#: id:20075
+msgid "Enter master lock code"
+msgstr "Unesite glavni kôd za otključavanje"
+
+#: id:20076
+msgid "Ask for master lock code on startup"
+msgstr "Pitaj za glavni kôd prilikom pokretanja apl."
+
+#: id:20077
+msgid "Skin settings"
+msgstr "Postavke maske"
+
+#: id:20078
+msgid "- no link set -"
+msgstr "- veza nije postavljena -"
+
+#: id:20079
+msgid "Enable animations"
+msgstr "Omogući animacije"
+
+#: id:20080
+msgid "Disable RSS during music"
+msgstr "Onemogući RSS novosti tokom reprodukcije muzike"
+
+#: id:20081
+msgid "Enable shortcut buttons"
+msgstr "Omogući prečice"
+
+#: id:20082
+msgid "Show programs in main menu"
+msgstr "Prikaži programe u glavnom meniju"
+
+#: id:20083
+msgid "Show music info"
+msgstr "Prikaži podatke o muzici"
+
+#: id:20084
+msgid "Show weather info"
+msgstr "Prikaži podatke o vremenu"
+
+#: id:20085
+msgid "Show system info"
+msgstr "Prikaži podatke o sistemu"
+
+#: id:20086
+msgid "Show available disc space C: E: F:"
+msgstr "Prikaži slobodan prostor na disku C: E: F:"
+
+#: id:20087
+msgid "Show available disc space E: F: G:"
+msgstr "Prikaži slobodan prostor na disku E: F: G:"
+
+#: id:20088
+msgid "Weather info"
+msgstr "Podaci o vremenu"
+
+#: id:20089
+msgid "Drive space free"
+msgstr "Slobodan prostor na disku"
+
+#: id:20090
+msgid "Enter the name of an existing share"
+msgstr "Unesite ime postojećeg deljenog resursa"
+
+#: id:20091
+msgid "Lock code"
+msgstr "Kôd za zaključavanje"
+
+#: id:20092
+msgid "Load profile"
+msgstr "Učitaj profil"
+
+#: id:20093
+msgid "Profile name"
+msgstr "Ime profila"
+
+#: id:20094
+msgctxt "Auto context with id 20094"
+msgid "Media sources"
+msgstr "Medija izvori"
+
+#: id:20095
+msgid "Enter profile lock code"
+msgstr "Unesite kôd za otključavanje profila"
+
+#: id:20096
+msgctxt "Auto context with id 20096"
+msgid "Login screen"
+msgstr "Ekran za prijavu"
+
+#: id:20097
+msgid "Fetching album info"
+msgstr "Preuzimanje podataka o albumu"
+
+#: id:20098
+msgid "Fetching info for album"
+msgstr "Preuzimanje podataka za album"
+
+#: id:20099
+msgid "Can't rip CD or track while playing from CD"
+msgstr "Nije moguće ripovati muzički CD tokom reprodukcije sa CD-a"
+
+#: id:20100
+msgid "Master lock code and settings"
+msgstr "Glavni kôd za zaključavanje i postavke"
+
+#: id:20101
+msgid "Entering master lock code always enables master mode"
+msgstr "Unosom glavnog kôda uvek omogućavate glavni režim rada"
+
+#: id:20102
+msgid "or copy from default?"
+msgstr "ili kopiranje od podrazumevanog?"
+
+#: id:20103
+msgid "Save changes to profile?"
+msgstr "Sačuvati promene u profil?"
+
+#: id:20104
+msgid "Old settings found."
+msgstr "Pronađene su stare postavke."
+
+#: id:20105
+msgid "Do you want to use them?"
+msgstr "Želite li da ih koristite?"
+
+#: id:20106
+msgid "Old media sources found."
+msgstr "Pronađeni stari izvori medija."
+
+#: id:20107
+msgid "Separate (locked)"
+msgstr "Razdvajanje (zaključano)"
+
+#: id:20108
+msgid "Root"
+msgstr "Korena fascikla"
+
+#: id:20109
+msgid "- Zoom"
+msgstr "- Uveličavanje"
+
+#: id:20110
+msgid "UPnP settings"
+msgstr "UPnP postavke"
+
+#: id:20111
+msgid "Autostart UPnP client"
+msgstr "Autom. pokretanje UPnP klijenta"
+
+#: id:20112
+msgid "Last login: %s"
+msgstr "Poslednja prijava: %s"
+
+#: id:20113
+msgid "Never logged on"
+msgstr "Nije bilo prijave do sada"
+
+#: id:20114
+msgid "Profile %i / %i"
+msgstr "Profil %i / %i"
+
+#: id:20115
+msgid "User login / Select a profile"
+msgstr "Prijava korisnika / Izaberite profil"
+
+#: id:20116
+msgid "Use lock on login screen"
+msgstr "Koristi zaključavanje ekrana za prijavu"
+
+#: id:20117
+msgid "Invalid lock code."
+msgstr "Kôd nije ispravan."
+
+#: id:20118
+msgid "This requires the master lock to be set."
+msgstr "Ovo zahteva unos glavnog kôda."
+
+#: id:20119
+msgid "Would you like to set it now?"
+msgstr "Želite li odmah da postavite?"
+
+#: id:20120
+msgid "Loading program information"
+msgstr "Učitavanje podataka o programu"
+
+#: id:20121
+msgid "Party on!"
+msgstr "Žurka!"
+
+#: id:20122
+msgid "True"
+msgstr "Ispravno"
+
+#: id:20123
+msgid "Mixing drinks"
+msgstr "Mešanje pića"
+
+#: id:20124
+msgid "Filling glasses"
+msgstr "Punjenje čaša"
+
+#: id:20125
+msgid "Logged on as"
+msgstr "Prijavljen kao"
+
+#: id:20126
+msgid "Log off"
+msgstr "Odjavi se"
+
+#: id:20128
+msgid "Go to root"
+msgstr "Idi u korenu fasc."
+
+#: id:20129
+msgid "Weave"
+msgstr "Talasi"
+
+#: id:20130
+msgid "Weave (inverted)"
+msgstr "Talasi (obrnuti)"
+
+#: id:20131
+msgid "Blend"
+msgstr "Mešovito"
+
+#: id:20132
+msgid "Restart video"
+msgstr "Ponovo pokreni film"
+
+#: id:20133
+msgid "Edit network location"
+msgstr "Uredi mrežnu lokaciju"
+
+#: id:20134
+msgid "Remove network location"
+msgstr "Ukloni mrežnu lokaciju"
+
+#: id:20135
+msgid "Do you want to scan the folder?"
+msgstr "Želite li da analizirate fasciklu?"
+
+#: id:20136
+msgid "Memory unit"
+msgstr "Jedinica memorije"
+
+#: id:20137
+msgid "Memory unit mounted"
+msgstr "Jedinica memorije je postavljena"
+
+#: id:20138
+msgid "Unable to mount memory unit"
+msgstr "Nije moguće postaviti jedinicu memorije"
+
+#: id:20139
+msgid "In port %i, slot %i"
+msgstr "u priključku %i, konektor %i"
+
+#: id:20140
+msgid "Lock screensaver"
+msgstr "Zaključaj čuvara ekrana"
+
+#: id:20141
+msgid "Set"
+msgstr "Postavi"
+
+#: id:20142
+msgctxt "Auto context with id 20142"
+msgid "Username"
+msgstr "Korisničko ime"
+
+#: id:20143
+msgid "Enter password for"
+msgstr "Unesite lozinku za"
+
+#: id:20144
+msgid "Shutdown timer"
+msgstr "Odbrojavanje do isključivanja"
+
+#: id:20145
+msgid "Shutdown interval (in minutes)"
+msgstr "Interval isključivanja (u minutima)"
+
+#: id:20146
+msgid "Started, shutdown in %im"
+msgstr "Pokrenuto, isključivanje za %i min."
+
+#: id:20147
+msgid "Shutdown in 30 minutes"
+msgstr "Isključi za 30 minuta"
+
+#: id:20148
+msgid "Shutdown in 60 minutes"
+msgstr "Isključi za 60 minuta"
+
+#: id:20149
+msgid "Shutdown in 120 minutes"
+msgstr "Isključi za 120 minuta"
+
+#: id:20150
+msgid "Custom shutdown timer"
+msgstr "Prilagođeno odbrojavanje do isključenja"
+
+#: id:20151
+msgid "Cancel shutdown timer"
+msgstr "Otkaži odbrojavanje"
+
+#: id:20152
+msgid "Lock preferences for %s"
+msgstr "Zaključaj podešavanja za %s"
+
+#: id:20153
+msgid "Browse..."
+msgstr "Potraži..."
+
+#: id:20154
+msgid "Summary information"
+msgstr "Kratak pregled informacija"
+
+#: id:20155
+msgid "Storage information"
+msgstr "Podaci o skladištu"
+
+#: id:20156
+msgid "Hard disk information"
+msgstr "Podaci o čvrstom disku"
+
+#: id:20157
+msgid "DVD-ROM information"
+msgstr "Podaci o DVD-ROM uređaju"
+
+#: id:20158
+msgid "Network information"
+msgstr "Podaci o mreži"
+
+#: id:20159
+msgid "Video information"
+msgstr "Podaci o videu"
+
+#: id:20160
+msgid "Hardware information"
+msgstr "Podaci o hardveru"
+
+#: id:20161
+msgid "Total"
+msgstr "Ukupno"
+
+#: id:20162
+msgid "Used"
+msgstr "Iskorišćeno"
+
+#: id:20163
+msgid "of"
+msgstr "od"
+
+#: id:20164
+msgid "Locking not supported"
+msgstr "Zaključavanje nije podržano"
+
+#: id:20165
+msgid "Not locked"
+msgstr "Nije zaključano"
+
+#: id:20166
+msgid "Locked"
+msgstr "Zaključano"
+
+#: id:20167
+msgid "Frozen"
+msgstr "Zamrznuto"
+
+#: id:20168
+msgid "Requires reset"
+msgstr "Zahteva ponovno pokretanje"
+
+#: id:20169
+msgid "Week"
+msgstr "Nedelja"
+
+#: id:20170
+msgid "Line"
+msgstr "Linija"
+
+#: id:20171
+msgid "Windows network (SMB)"
+msgstr "Windows mreža (SMB)"
+
+#: id:20172
+msgid "XBMSP server"
+msgstr "XBMSP server"
+
+#: id:20173
+msgctxt "Auto context with id 20173"
+msgid "FTP server"
+msgstr "FTP server"
+
+#: id:20174
+msgid "iTunes music share (DAAP)"
+msgstr "iTunes deljena muzika (DAAP)"
+
+#: id:20175
+msgid "UPnP server"
+msgstr "UPnP server"
+
+#: id:20176
+msgid "Show video info"
+msgstr "Prikaži podatke o filmu"
+
+#: id:20177
+msgid "Done"
+msgstr "Završi"
+
+#: id:20178
+msgid "Shift"
+msgstr "Shift"
+
+#: id:20179
+msgid "Caps Lock"
+msgstr "Vel. slova"
+
+#: id:20180
+msgid "Symbols"
+msgstr "Simboli"
+
+#: id:20181
+msgid "Backspace"
+msgstr "Brisanje unazad"
+
+#: id:20182
+msgid "Space"
+msgstr "Razmak"
+
+#: id:20183
+msgid "Reload skin"
+msgstr "Ponovo učitaj masku"
+
+#: id:20184
+msgid "Rotate pictures using EXIF information"
+msgstr "Rotiraj slike na osnovu EXIF podataka"
+
+#: id:20185
+msgid "Use poster view styles for TV shows"
+msgstr "Koristi stil prikaza postera za TV serije"
+
+#: id:20186
+msgid "Please wait"
+msgstr "Molimo sačekajte"
+
+#: id:20187
+msgid "UPnP"
+msgstr "Pravljenje rez. kopije EEPROM-a"
+
+#: id:20189
+msgid "Enable auto scrolling for plot & review"
+msgstr "Omogući autom. pomeranje opisa i recenzija (sinonopisa)"
+
+#: id:20190
+msgctxt "Auto context with id 20190"
+msgid "Custom"
+msgstr "Prilagođeno"
+
+#: id:20191
+msgid "Enable debug logging"
+msgstr "Omogući beleženje grešaka"
+
+#: id:20192
+msgid "Download additional information during updates"
+msgstr "Preuzmi dodatne podatke prilikom ažuriranja"
+
+#: id:20193
+msgid "Default service for album information"
+msgstr ""
+
+#: id:20194
+msgid "Default service for artist information"
+msgstr "Podrazumevani davaoc podataka o muzici"
+
+#: id:20195
+msgid "Change scraper"
+msgstr "Promeni davaoca podataka"
+
+#: id:20196
+msgid "Export music library"
+msgstr "Izvoz muzičke biblioteke"
+
+#: id:20197
+msgid "Import music library"
+msgstr "Uvoz muzičke biblioteke"
+
+#: id:20198
+msgid "No artist found!"
+msgstr "Izvođač nije pronađen!"
+
+#: id:20199
+msgid "Downloading artist info failed"
+msgstr "Nije uspelo preuzimanje podataka o izvođaču"
+
+#: id:20250
+msgid "Party on! (videos)"
+msgstr "Žurka! (filmovi)"
+
+#: id:20251
+msgid "Mixing drinks (videos)"
+msgstr "Mešanje pića (filmovi)"
+
+#: id:20252
+msgid "Filling glasses (videos)"
+msgstr "Punjenje čaša (filmovi)"
+
+#: id:20253
+msgid "WebDAV server (HTTP)"
+msgstr "WebDAV server (HTTP)"
+
+#: id:20254
+msgid "WebDAV server (HTTPS)"
+msgstr "WebDAV server (HTTPS)"
+
+#: id:20255
+msgid "First logon, edit your profile"
+msgstr "Izmenite vaš profil prilikom prvog prijavljivanja"
+
+#: id:20256
+msgid "HTS Tvheadend client"
+msgstr ""
+
+#: id:20257
+msgid "VDR Streamdev client"
+msgstr ""
+
+#: id:20258
+msgid "MythTV client"
+msgstr ""
+
+#: id:20259
+msgid "Network Filesystem (NFS)"
+msgstr ""
+
+#: id:20260
+msgid "Secure Shell (SSH/SFTP)"
+msgstr ""
+
+#: id:20261
+msgid "Apple Filing Protocol (AFP)"
+msgstr ""
+
+#: id:20300
+msgid "Web server directory (HTTP)"
+msgstr "Fascikla Web servera (HTTP)"
+
+#: id:20301
+msgid "Web server directory (HTTPS)"
+msgstr "Fascikla Web servera (HTTPS)"
+
+#: id:20302
+msgid "Unable to write to folder:"
+msgstr "Nije moguće upisivanje u fasciklu:"
+
+#: id:20303
+msgid "Do you want to skip and proceed?"
+msgstr "Želite li da preskočite i nastavite?"
+
+#: id:20304
+msgid "RSS Feed"
+msgstr "RSS novosti"
+
+#: id:20307
+msgid "Secondary DNS"
+msgstr "Alternativni DNS"
+
+#: id:20308
+msgid "DHCP server:"
+msgstr "DHCP server:"
+
+#: id:20309
+msgid "Make new folder"
+msgstr "Napravi novu fasciklu"
+
+#: id:20310
+msgid "Dim LCD on playback"
+msgstr "Zatamni LCD prilikom reprodukcije"
+
+#: id:20311
+msgid "Unknown or onboard (protected)"
+msgstr "Nepoznato ili je ugrađen na ploči (zaštićeno)"
+
+#: id:20312
+msgid "Dim LCD on paused"
+msgstr "Zatamni LCD prilikom pauze"
+
+#: id:20314
+msgid "Videos - Library"
+msgstr "Filmska Bibliote."
+
+#: id:20316
+msgid "Sort by: ID"
+msgstr "Složi po: ID"
+
+#: id:20324
+msgid "Play part..."
+msgstr "Reprodukuj deo..."
+
+#: id:20325
+msgid "Calibration reset"
+msgstr "Ponovna kalibracija"
+
+#: id:20326
+msgid "This will reset the calibration values for %s"
+msgstr "Ovim ćete poništiti vrednosti kalibracije za %s"
+
+#: id:20327
+msgid "to it's default values."
+msgstr "na podrazumevane vrednosti."
+
+#: id:20328
+msgid "Browse for destination"
+msgstr "Potraži odredište"
+
+#: id:20329
+msgid "Movies are in separate folders that match the movie title"
+msgstr ""
+
+#: id:20330
+msgid "Use folder names for lookups"
+msgstr "Koristi imena fascikli za pretragu"
+
+#: id:20331
+msgctxt "Auto context with id 20331"
+msgid "File"
+msgstr "Datoteke"
+
+#: id:20332
+msgid "Use file or folder names in lookups?"
+msgstr "Korišćenje imena datoteke ili fascikle za pretragu?"
+
+#: id:20333
+msgid "Set content"
+msgstr "Postavi sadržaj"
+
+#: id:20334
+msgid "Folder"
+msgstr "Fascikle"
+
+#: id:20335
+msgid "Look for content recursively?"
+msgstr "Rekurzivna pretraga sadržaja?"
+
+#: id:20336
+msgid "Unlock sources"
+msgstr "Otključaj izvore"
+
+#: id:20337
+msgid "Actor"
+msgstr "Glumac"
+
+#: id:20338
+msgid "Movie"
+msgstr "Film"
+
+#: id:20339
+msgid "Director"
+msgstr "Režiser"
+
+#: id:20340
+msgid "Do you want to remove all items within"
+msgstr "Želite li da uklonite sve stavke u okviru"
+
+#: id:20341
+msgid "this path from the XBMC library?"
+msgstr "ove putanje iz XBMC biblioteke?"
+
+#: id:20342
+msgctxt "Auto context with id 20342"
+msgid "Movies"
+msgstr "Filmovi"
+
+#: id:20343
+msgid "TV shows"
+msgstr "TV serije"
+
+#: id:20344
+msgid "This directory contains"
+msgstr "Ova fascikla sadrži"
+
+#: id:20345
+msgid "Run automated scan"
+msgstr "Pokreni automatsku analizu"
+
+#: id:20346
+msgid "Scan recursively"
+msgstr "Rekurzivna analiza"
+
+#: id:20347
+msgid "as"
+msgstr "kao"
+
+#: id:20348
+msgid "Directors"
+msgstr "Režiseri"
+
+#: id:20349
+msgid "No video files found in this path!"
+msgstr "Na ovoj putanji ne postoje video datoteke!"
+
+#: id:20350
+msgid "votes"
+msgstr "glasova"
+
+#: id:20351
+msgid "TV show information"
+msgstr "Podaci o TV seriji"
+
+#: id:20352
+msgid "Episode information"
+msgstr "Podaci o epizodama"
+
+#: id:20353
+msgid "Loading TV show details"
+msgstr "Učitavanje detalja TV serije"
+
+#: id:20354
+msgid "Fetching episode guide"
+msgstr "Pronalaženje vodiča epizoda"
+
+#: id:20355
+msgid "Loading info for episodes in directory"
+msgstr "Učitavanje opisa epizode u fascikli"
+
+#: id:20356
+msgid "Select TV show:"
+msgstr "Izaberite TV seriju:"
+
+#: id:20357
+msgid "Enter the TV show name"
+msgstr "Unesite naziv TV serije"
+
+#: id:20358
+msgid "Season %i"
+msgstr "Sezona %i"
+
+#: id:20359
+msgid "Episode"
+msgstr "Epizoda"
+
+#: id:20360
+msgid "Episodes"
+msgstr "Epizoda"
+
+#: id:20361
+msgid "Loading episode details"
+msgstr "Učitavanje detalja epizode"
+
+#: id:20362
+msgid "Remove episode from library"
+msgstr "Ukloni epizodu iz biblioteke"
+
+#: id:20363
+msgid "Remove TV show from library"
+msgstr "Ukloni TV seriju iz biblioteke"
+
+#: id:20364
+msgid "TV show"
+msgstr "TV serija"
+
+#: id:20365
+msgid "Episode plot"
+msgstr "Opis epizode"
+
+#: id:20366
+msgid "* All seasons"
+msgstr "* Sve sezone"
+
+#: id:20367
+msgid "Hide watched"
+msgstr "Sakr. odgled."
+
+#: id:20368
+msgid "Prod code"
+msgstr "Šifra proizvoda"
+
+#: id:20369
+msgid "Show plot for unwatched items"
+msgstr "Prikaži opis za neodgledane stavke"
+
+#: id:20370
+msgid "* Hidden to prevent spoilers *"
+msgstr "* Skriveno zbog sprečavanja nepropisne upotrebe *"
+
+#: id:20371
+msgid "Set season thumb"
+msgstr "Postavi sličicu za sezonu"
+
+#: id:20372
+msgid "Season image"
+msgstr "Slika za sezonu"
+
+#: id:20373
+msgid "Season"
+msgstr "Sezona"
+
+#: id:20374
+msgid "Downloading movie information"
+msgstr "Preuzimanje podataka o filmu"
+
+#: id:20375
+msgid "Unassign content"
+msgstr "Neodređen sadržaj"
+
+#: id:20376
+msgid "Original title"
+msgstr ""
+
+#: id:20377
+msgid "Refresh TV show information"
+msgstr "Osveži podatke TV serije"
+
+#: id:20378
+msgid "Refresh info for all episodes?"
+msgstr "Osvežiti podatke za sve epizode?"
+
+#: id:20379
+msgid "Selected folder contains a single TV show"
+msgstr "Izabrana fascikla sadrži jednu TV seriju"
+
+#: id:20380
+msgid "Exclude selected folder from scans"
+msgstr "Izuzmi izabranu fasciklu iz analiziranja"
+
+#: id:20381
+msgid "Specials"
+msgstr "Posebne emisije"
+
+#: id:20382
+msgid "Automatically grab season thumbs"
+msgstr "Automatski preuzmi sličicu sezone"
+
+#: id:20383
+msgid "Selected folder contains a single video"
+msgstr "Izabrana fascikla sadrži jedan film"
+
+#: id:20384
+msgid "Link to TV show"
+msgstr "Veza ka TV seriji"
+
+#: id:20385
+msgid "Remove link to TV show"
+msgstr "Ukloni vezu ka TV seriji"
+
+#: id:20386
+msgid "Recently added movies"
+msgstr "Nedav. dodati film."
+
+#: id:20387
+msgid "Recently added episodes"
+msgstr "Nedav. dodate epizode"
+
+#: id:20388
+msgid "Studios"
+msgstr "Studiji"
+
+#: id:20389
+msgid "Music videos"
+msgstr "Muzičke spotove"
+
+#: id:20390
+msgid "Recently added music videos"
+msgstr "Nedavno dodati muzički spotovi"
+
+#: id:20391
+msgid "Music video"
+msgstr "Muzički spot"
+
+#: id:20392
+msgid "Remove music video from library"
+msgstr "Ukloni muzički spot iz biblioteke"
+
+#: id:20393
+msgctxt "Auto context with id 20393"
+msgid "Music video information"
+msgstr "Podaci o muzičkom spotu"
+
+#: id:20394
+msgid "Loading music video information"
+msgstr "Učitavanje podataka o muzičkom spotu"
+
+#: id:20395
+msgid "Mixed"
+msgstr "Mešano"
+
+#: id:20396
+msgid "Go to albums by artist"
+msgstr "Idi na albume izvođača"
+
+#: id:20397
+msgid "Go to album"
+msgstr "Idi na album"
+
+#: id:20398
+msgid "Play song"
+msgstr "Reprodukuj pesmu"
+
+#: id:20399
+msgid "Go to music videos from album"
+msgstr "Idi na muzičke spotove iz albuma"
+
+#: id:20400
+msgid "Go to music videos by artist"
+msgstr "Idi na muzičke spotove izvođača"
+
+#: id:20401
+msgid "Play music video"
+msgstr "Reprodukuj muzički spot"
+
+#: id:20402
+msgid "Download actor thumbnails when adding to library"
+msgstr "Preuzmi sličice glumaca prilikom dodavanja u biblioteku"
+
+#: id:20403
+msgid "Set actor thumb"
+msgstr "Postavi sliku glumca"
+
+#: id:20405
+msgid "Remove episode bookmark"
+msgstr "Ukloni obeleživač epizode"
+
+#: id:20406
+msgid "Set episode bookmark"
+msgstr "Postavi obeleživač epizode"
+
+#: id:20407
+msgid "Scraper settings"
+msgstr "Postavke davaoca podataka"
+
+#: id:20408
+msgid "Downloading music video information"
+msgstr "Preuzimanje podataka o muzičkom spotu"
+
+#: id:20409
+msgid "Downloading TV show information"
+msgstr "Preuzimanje podataka o TV seriji"
+
+#: id:20410
+msgid "Trailer"
+msgstr "Najava"
+
+#: id:20411
+msgid "Flatten"
+msgstr "Poravnat spisak"
+
+#: id:20412
+msgid "Flatten TV shows"
+msgstr "Poravnat spisak TV serija"
+
+#: id:20413
+msgid "Get fanart"
+msgstr "Zanim. slika"
+
+#: id:20414
+msgid "Show Fanart in video and music libraries"
+msgstr "Prikaži zanimljivu sliku u filmskim i muzičkim bibliotekama"
+
+#: id:20415
+msgid "Scanning for new content"
+msgstr "Tranježe novog sadržaja"
+
+#: id:20416
+msgid "First aired"
+msgstr "Premijera"
+
+#: id:20417
+msgid "Writer"
+msgstr "Scenarista"
+
+#: id:20419
+msgid "Replace file names with library titles"
+msgstr ""
+
+#: id:20420
+msgctxt "Auto context with id 20420"
+msgid "Never"
+msgstr "Nikada"
+
+#: id:20421
+msgid "If only one season"
+msgstr "Ukoliko je samo jedna sezona"
+
+#: id:20422
+msgid "Always"
+msgstr "Uvek"
+
+#: id:20423
+msgid "Has trailer"
+msgstr "Ima najavu filma"
+
+#: id:20424
+msgid "False"
+msgstr "Netačno"
+
+#: id:20425
+msgid "Fanart slideshow"
+msgstr "Projekcija zanimljivih slika"
+
+#: id:20426
+msgid "Export to a single file or separate"
+msgstr "Izvoz u jednu ili zasebne"
+
+#: id:20427
+msgid "files per entry?"
+msgstr "datoteke po unosu?"
+
+#: id:20428
+msgid "Single file"
+msgstr "Jedna datoteka"
+
+#: id:20429
+msgctxt "Auto context with id 20429"
+msgid "Separate"
+msgstr "Zasebno"
+
+#: id:20430
+msgid "Export thumbnails and fanart?"
+msgstr "Izvoz sličica i zanimljivih slika?"
+
+#: id:20431
+msgid "Overwrite old files?"
+msgstr "Zameniti stare datoteke?"
+
+#: id:20432
+msgid "Exclude path from library updates"
+msgstr "Izuzmi putanju prilikom ažuriranja biblioteke"
+
+#: id:20433
+msgid "Extract thumbnails and video information"
+msgstr "Izvezi sličice i podatke filma"
+
+#: id:20434
+msgid "Sets"
+msgstr "Postavke scene"
+
+#: id:20435
+msgid "Set movieset thumb"
+msgstr "Postavi slike sa snimanja filma"
+
+#: id:20436
+msgid "Export actor thumbs?"
+msgstr "Izvoz sličica glumca?"
+
+#: id:20437
+msgid "Choose fanart"
+msgstr "Izaberite zanimljivu sliku"
+
+#: id:20438
+msgid "Local fanart"
+msgstr "Lokalna zanimljiva slika"
+
+#: id:20439
+msgid "No fanart"
+msgstr "Bez zanimljive slike"
+
+#: id:20440
+msgid "Current fanart"
+msgstr "Trenutna zanimljiva slika"
+
+#: id:20441
+msgid "Remote fanart"
+msgstr "Udaljena zanimljiva slika"
+
+#: id:20442
+msgid "Change content"
+msgstr "Promeni sadržaj"
+
+#: id:20443
+msgid "Do you want to refresh info for all"
+msgstr "Želite li da osvežite podatke svih"
+
+#: id:20444
+msgid "items within this path?"
+msgstr "stavki sa ove putanje?"
+
+#: id:20445
+msgid "Fanart"
+msgstr "Zanimljiva slika"
+
+#: id:20446
+msgid "Locally stored information found."
+msgstr "Pronađeni su lokalno sačuvani podaci."
+
+#: id:20447
+msgid "Ignore and refresh from internet?"
+msgstr "Zanemariti ih i osvežiti iste sa podacima sa Interneta?"
+
+#: id:20448
+msgid "Could not download information"
+msgstr "Nije moguće preuzeti podatke"
+
+#: id:20449
+msgid "Unable to connect to remote server"
+msgstr "Server je najverovatnije nedostupan."
+
+#: id:20450
+msgid "Would you like to continue scanning?"
+msgstr "Želite li da nastavite analiziranje?"
+
+#: id:20451
+msgid "Countries"
+msgstr ""
+
+#: id:20452
+msgid "episode"
+msgstr ""
+
+#: id:20453
+msgid "episodes"
+msgstr ""
+
+#: id:20454
+msgid "Listener"
+msgstr ""
+
+#: id:20455
+msgid "Listeners"
+msgstr ""
+
+#: id:20456
+msgid "Set movieset fanart"
+msgstr ""
+
+#: id:20457
+msgid "Movie set"
+msgstr ""
+
+#: id:20458
+msgid "Group movies in sets"
+msgstr ""
+
+#: id:21330
+msgid "Show hidden files and directories"
+msgstr "Prikaži skrivene datoteke i fascikle"
+
+#: id:21331
+msgid "TuxBox client"
+msgstr "TuxBox klijent"
+
+#: id:21332
+msgid "WARNING: Target TuxBox device is in recording-mode!"
+msgstr "PAŽNjA: Izabrani TuxBox uređaj trenutno snima!"
+
+#: id:21333
+msgid "The stream will be stopped!"
+msgstr "Biće zaustavljen zapis toka podataka!"
+
+#: id:21334
+msgid "Zap to channel: %s failed!"
+msgstr "Prebacivanje na kanal: %s nije uspelo!"
+
+#: id:21335
+msgid "Are you sure to start the stream?"
+msgstr "Sigurni ste da želite da pokrenete tok podataka?"
+
+#: id:21336
+msgid "Connecting to: %s"
+msgstr "Povezivanje sa: %s"
+
+#: id:21337
+msgid "TuxBox device"
+msgstr "TuxBox uređaj"
+
+#: id:21359
+msgid "Add media share..."
+msgstr "Dodaj deljenu lokaciju medija..."
+
+#: id:21360
+msgid "Share video and music libraries through UPnP"
+msgstr "Deli filmsku i muzičku biblioteku putem UPnP protokola"
+
+#: id:21364
+msgid "Edit media share"
+msgstr "Uredi deljenu lokaciju medija"
+
+#: id:21365
+msgid "Remove media share"
+msgstr "Ukloni deljenu lokaciju medija"
+
+#: id:21366
+msgid "Subtitle folder"
+msgstr "Fascikla sa titlovima"
+
+#: id:21367
+msgid "Movie & alternate subtitle directory"
+msgstr "Fascikla filmova i alternativnih titlova"
+
+#: id:21368
+msgid "Override ASS/SSA subtitles fonts"
+msgstr ""
+
+#: id:21369
+msgid "Enable mouse and Touch Screen support"
+msgstr "Omogući korišćenje miša"
+
+#: id:21370
+msgid "Play navigation sounds during media playback"
+msgstr "Reprodukuj navigacione zvukove prilikom reprodukcije medija"
+
+#: id:21371
+msgid "Thumbnail"
+msgstr "Sličica"
+
+#: id:21372
+msgid "Forced DVD player region"
+msgstr "Nametnuta regija DVD uređaja za reprodukciju"
+
+#: id:21373
+msgid "Video output"
+msgstr "Video izlaz"
+
+#: id:21374
+msgid "Video aspect"
+msgstr "Razmera slike"
+
+#: id:21375
+msgctxt "Auto context with id 21375"
+msgid "Normal"
+msgstr "Normalno"
+
+#: id:21376
+msgid "Letterbox"
+msgstr "Letterbox"
+
+#: id:21377
+msgid "Widescreen"
+msgstr "Široki ekran"
+
+#: id:21378
+msgid "Enable 480p"
+msgstr "Omogući 480p"
+
+#: id:21379
+msgid "Enable 720p"
+msgstr "Omogući 720p"
+
+#: id:21380
+msgid "Enable 1080i"
+msgstr "Omogući 1080i"
+
+#: id:21381
+msgid "Enter name of new playlist"
+msgstr "Unesite ime novog spiska za reprodukciju"
+
+#: id:21382
+msgid "Show \"Add source\" buttons in file lists"
+msgstr "Prikaži dugme „Dodaj izvor“ u spisku datoteka"
+
+#: id:21383
+msgid "Enable scrollbars"
+msgstr "Omogući trake za pomeranje"
+
+#: id:21384
+msgid "Make watched filtering a toggle in video library"
+msgstr "Isfiltriraj odgledane filmove u biblioteci filmova"
+
+#: id:21385
+msgctxt "Auto context with id 21385"
+msgid "Open"
+msgstr "Otvori"
+
+#: id:21386
+msgid "Acoustic management level"
+msgstr "Upravljanje nivoom akustičnosti"
+
+#: id:21387
+msgid "Fast"
+msgstr "Brzo"
+
+#: id:21388
+msgid "Quiet"
+msgstr "Tiho"
+
+#: id:21389
+msgid "Enable custom background"
+msgstr "Omogući prilagođenu pozadinu"
+
+#: id:21390
+msgid "Power management level"
+msgstr "Upravljanje nivoom potrošnje"
+
+#: id:21391
+msgid "High power"
+msgstr "Viša potrošnja"
+
+#: id:21392
+msgid "Low power"
+msgstr "Niža potrošnja"
+
+#: id:21393
+msgid "High standby"
+msgstr "High standby"
+
+#: id:21394
+msgid "Low standby"
+msgstr "Low standby"
+
+#: id:21395
+msgid "Unable to cache files bigger than 4GB"
+msgstr "Nije moguće keširati datoteke veće od 4GB"
+
+#: id:21396
+msgid "Chapter"
+msgstr "Poglavlje"
+
+#: id:21397
+msgid "High quality pixel shader v2"
+msgstr "Visoko kvalitetno senčenje piksela v2"
+
+#: id:21398
+msgid "Enable playlist at startup"
+msgstr "Omogući spisak za reprodukciju pri uključivanju XBMC-a"
+
+#: id:21399
+msgid "Use tween animations"
+msgstr "Koristi međukorake u animaciji"
+
+#: id:21400
+msgid "contains"
+msgstr "sadrži"
+
+#: id:21401
+msgid "does not contain"
+msgstr "ne sadrži"
+
+#: id:21402
+msgid "is"
+msgstr "je"
+
+#: id:21403
+msgid "is not"
+msgstr "nije"
+
+#: id:21404
+msgid "starts with"
+msgstr "počinje sa"
+
+#: id:21405
+msgid "ends with"
+msgstr "završava sa"
+
+#: id:21406
+msgid "greater than"
+msgstr "je veće od"
+
+#: id:21407
+msgid "less than"
+msgstr "je manje od"
+
+#: id:21408
+msgid "after"
+msgstr "nakon"
+
+#: id:21409
+msgid "before"
+msgstr "pre"
+
+#: id:21410
+msgid "in the last"
+msgstr "u poslednjih"
+
+#: id:21411
+msgid "not in the last"
+msgstr "nije u poslednjih"
+
+#: id:21412
+msgid "Scrapers"
+msgstr "Dobavljači podat."
+
+#: id:21413
+msgid "Default movie scraper"
+msgstr "Podraz. dobavljač podataka za filmove"
+
+#: id:21414
+msgid "Default tvshow scraper"
+msgstr "Podraz. dobavljač podataka za TV serije"
+
+#: id:21415
+msgid "Default music video scraper"
+msgstr "Podraz. dobavljač podataka za muzičke spotove"
+
+#: id:21416
+msgid "Enable fallback based on scraper language"
+msgstr "Omogući preuzimanje na osnovu jezika dobavljača podataka"
+
+#: id:21417
+msgid "- Settings"
+msgstr "- Postavke"
+
+#: id:21418
+msgid "Multilingual"
+msgstr "Višejezično"
+
+#: id:21419
+msgid "No scrapers present"
+msgstr "Nema prisutnih dobavljača"
+
+#: id:21420
+msgid "Value to match"
+msgstr "Vrednosti se ne podudaraju"
+
+#: id:21421
+msgid "Smart playlist rule"
+msgstr "Pravilo pametnog spis. za rep."
+
+#: id:21422
+msgid "Match items where"
+msgstr "Podudari stavke gde"
+
+#: id:21423
+msgid "New rule..."
+msgstr "Novo pravilo..."
+
+#: id:21424
+msgid "Items must match"
+msgstr "Stavke se moraju podudarati"
+
+#: id:21425
+msgid "all of the rules"
+msgstr "su sva pravila"
+
+#: id:21426
+msgid "one or more of the rules"
+msgstr "je jedno ili više pravila"
+
+#: id:21427
+msgid "Limit to"
+msgstr "Ograniči na"
+
+#: id:21428
+msgid "No limit"
+msgstr "Bez ograničenja"
+
+#: id:21429
+msgid "Order by"
+msgstr "Složi po"
+
+#: id:21430
+msgid "ascending"
+msgstr "rastućem redu"
+
+#: id:21431
+msgid "descending"
+msgstr "opadajućem redu"
+
+#: id:21432
+msgid "Edit smart playlist"
+msgstr "Uredi pametni spis. za rep."
+
+#: id:21433
+msgid "Name of the playlist"
+msgstr "Ime spis. za rep."
+
+#: id:21434
+msgid "Find items where"
+msgstr "Pronađi stavke gde"
+
+#: id:21435
+msgid "Edit"
+msgstr "Uredi"
+
+#: id:21436
+msgid "%i items"
+msgstr "%i stavki"
+
+#: id:21437
+msgid "New smart playlist..."
+msgstr "Novi pametni spis. za rep..."
+
+#: id:21438
+msgid "%c Drive"
+msgstr "%c uređaj"
+
+#: id:21439
+msgid "Edit party mode rules"
+msgstr "Uredi pravila režima žurke"
+
+#: id:21440
+msgid "Home folder"
+msgstr "Početna fascikla"
+
+#: id:21441
+msgid "Watched count"
+msgstr "Brojač odgledanih"
+
+#: id:21442
+msgid "Episode title"
+msgstr "Naslov epizode"
+
+#: id:21443
+msgid "Video resolution"
+msgstr "Rezolucija videa"
+
+#: id:21444
+msgid "Audio channels"
+msgstr "Zvučnih kanala"
+
+#: id:21445
+msgid "Video codec"
+msgstr "Video kodek"
+
+#: id:21446
+msgid "Audio codec"
+msgstr "Kodek zvuka"
+
+#: id:21447
+msgid "Audio language"
+msgstr "Jezik zvuka"
+
+#: id:21448
+msgid "Subtitle language"
+msgstr "Jezik titla"
+
+#: id:21449
+msgid "Remote control sends keyboard presses"
+msgstr "Daljinski upravljač šalje kôdove tastature"
+
+#: id:21450
+msgid "- Edit"
+msgstr "- Uredi"
+
+#: id:21451
+msgid "Internet connection required."
+msgstr ""
+
+#: id:21452
+msgid "Get More..."
+msgstr ""
+
+#: id:21453
+msgid "Root filesystem"
+msgstr ""
+
+#: id:21454
+msgid "Cache full"
+msgstr ""
+
+#: id:21455
+msgid "Cache filled before reaching required amount for continous playback"
+msgstr ""
+
+#: id:21460
+msgid "Subtitle location"
+msgstr ""
+
+#: id:21461
+msgid "Fixed"
+msgstr ""
+
+#: id:21462
+msgid "Bottom of video"
+msgstr ""
+
+#: id:21463
+msgid "Below video"
+msgstr ""
+
+#: id:21464
+msgid "Top of video"
+msgstr ""
+
+#: id:21465
+msgid "Above video"
+msgstr ""
+
+#: id:21800
+msgid "File name"
+msgstr "Ime datoteke"
+
+#: id:21801
+msgid "File path"
+msgstr "Putanja datoteke"
+
+#: id:21802
+msgid "File size"
+msgstr "Veličina datoteke"
+
+#: id:21803
+msgid "File date/time"
+msgstr "Datum/vreme stvaranja datoteke"
+
+#: id:21804
+msgid "Slide index"
+msgstr "Indeks slajdova"
+
+#: id:21805
+msgctxt "Auto context with id 21805"
+msgid "Resolution"
+msgstr "Rezolucija"
+
+#: id:21806
+msgctxt "Auto context with id 21806"
+msgid "Comment"
+msgstr "Komentar"
+
+#: id:21807
+msgid "Colour/B&W"
+msgstr "Boja/Crno-belo"
+
+#: id:21808
+msgid "JPEG process"
+msgstr "Obrada JPEG-a"
+
+#: id:21820
+msgid "Date/Time"
+msgstr "Datum/vreme"
+
+#: id:21821
+msgid "Description"
+msgstr "Opis"
+
+#: id:21822
+msgid "Camera make"
+msgstr "Marka fotoaparata"
+
+#: id:21823
+msgid "Camera model"
+msgstr "Tip kamere"
+
+#: id:21824
+msgid "EXIF comment"
+msgstr "EXIF komentar"
+
+#: id:21825
+msgid "Firmware"
+msgstr "Sistem"
+
+#: id:21826
+msgid "Aperture"
+msgstr "Blenda"
+
+#: id:21827
+msgid "Focal length"
+msgstr "Fokusno rastojanje"
+
+#: id:21828
+msgid "Focus distance"
+msgstr "Žižna daljina"
+
+#: id:21829
+msgid "Exposure"
+msgstr "Ekspozicija"
+
+#: id:21830
+msgid "Exposure time"
+msgstr "Vreme ekspozicije"
+
+#: id:21831
+msgid "Exposure bias"
+msgstr "Odstupanje ekspozicije"
+
+#: id:21832
+msgid "Exposure mode"
+msgstr "Režim ekspozicije"
+
+#: id:21833
+msgid "Flash used"
+msgstr "Korišćenje blica"
+
+#: id:21834
+msgid "White-balance"
+msgstr "Balans belog"
+
+#: id:21835
+msgid "Light source"
+msgstr "Izvor svetla"
+
+#: id:21836
+msgid "Metering mode"
+msgstr "Režim merenja količine svetla"
+
+#: id:21837
+msgid "ISO"
+msgstr "ISO"
+
+#: id:21838
+msgid "Digital zoom"
+msgstr "Digitalni zum"
+
+#: id:21839
+msgid "CCD width"
+msgstr "CCD širina"
+
+#: id:21840
+msgid "GPS latitude"
+msgstr "GPS geo. širina"
+
+#: id:21841
+msgid "GPS longitude"
+msgstr "GPS geo. dužina"
+
+#: id:21842
+msgid "GPS altitude"
+msgstr "GPS geo. visina"
+
+#: id:21843
+msgid "Orientation"
+msgstr "Orijentacija"
+
+#: id:21860
+msgid "Supplemental categories"
+msgstr "Dodatne kategorije"
+
+#: id:21861
+msgid "Keywords"
+msgstr "Ključne reči"
+
+#: id:21862
+msgid "Caption"
+msgstr "Naslov"
+
+#: id:21863
+msgid "Author"
+msgstr "Autor"
+
+#: id:21864
+msgid "Headline"
+msgstr "Glavna uloga"
+
+#: id:21865
+msgid "Special instructions"
+msgstr "Posebna uputstva"
+
+#: id:21866
+msgid "Category"
+msgstr "Kategorija"
+
+#: id:21867
+msgid "Byline"
+msgstr "Potpis autora"
+
+#: id:21868
+msgid "Byline title"
+msgstr "Potpis autora naslova"
+
+#: id:21869
+msgid "Credit"
+msgstr "Zasluga"
+
+#: id:21870
+msgid "Source"
+msgstr "Izvor"
+
+#: id:21871
+msgid "Copyright notice"
+msgstr "Autorska prava"
+
+#: id:21872
+msgid "Object name"
+msgstr "Ime objekta"
+
+#: id:21873
+msgid "City"
+msgstr "Grad"
+
+#: id:21874
+msgid "State"
+msgstr "Pokrajina"
+
+#: id:21875
+msgctxt "Auto context with id 21875"
+msgid "Country"
+msgstr "Država"
+
+#: id:21876
+msgid "Original Tx Reference"
+msgstr "Original Tx Reference"
+
+#: id:21877
+msgid "Date created"
+msgstr "Datum pravljenja"
+
+#: id:21878
+msgid "Copyright flag"
+msgstr "Oznaka autorskog prava"
+
+#: id:21879
+msgid "Country code"
+msgstr "Kôd države"
+
+#: id:21880
+msgid "Reference service"
+msgstr "Preporučen servis"
+
+#: id:21881
+msgid "Allow control of XBMC via UPnP"
+msgstr "Omogući kontrolu XBMC aplikacije putem UPnP protokola"
+
+#: id:21882
+msgid "Attempt to skip introduction before DVD menu"
+msgstr "Pokušaj da preskočiš uvodni deo pre DVD menija"
+
+#: id:21883
+msgid "Saved music"
+msgstr "Sačuvana muzika"
+
+#: id:21884
+msgid "Query info for all artists"
+msgstr "Zahtevanje podataka za sve izvođače"
+
+#: id:21885
+msgid "Downloading album information"
+msgstr "Preuzimanje podataka o albumu"
+
+#: id:21886
+msgid "Downloading artist information"
+msgstr "Preuzimanje podataka o izvođaču"
+
+#: id:21887
+msgid "Biography"
+msgstr "Biografija"
+
+#: id:21888
+msgid "Discography"
+msgstr "Diskografija"
+
+#: id:21889
+msgid "Searching artist"
+msgstr "Pronalaženje izvođača"
+
+#: id:21890
+msgid "Select artist"
+msgstr "Izaberite izvođača"
+
+#: id:21891
+msgctxt "Auto context with id 21891"
+msgid "Artist information"
+msgstr "Podaci o izvođaču"
+
+#: id:21892
+msgid "Instruments"
+msgstr "Instrumenti"
+
+#: id:21893
+msgid "Born"
+msgstr "Rođen"
+
+#: id:21894
+msgid "Formed"
+msgstr "Oformljeno"
+
+#: id:21895
+msgid "Themes"
+msgstr "Teme"
+
+#: id:21896
+msgid "Disbanded"
+msgstr "Rasformirano"
+
+#: id:21897
+msgid "Died"
+msgstr "Preminuo"
+
+#: id:21898
+msgid "Years active"
+msgstr "Godina aktivan"
+
+#: id:21899
+msgid "Label"
+msgstr "Etiketa"
+
+#: id:21900
+msgid "Born/Formed"
+msgstr "Rođ./oform."
+
+#: id:22000
+msgid "Update library on startup"
+msgstr "Ažuriraj biblioteku prilikom uključivanja"
+
+#: id:22001
+msgid "Hide progress of library updates"
+msgstr "Uvek ažuriraj biblioteku u pozadini"
+
+#: id:22002
+msgid "- DNS suffix"
+msgstr "- DNS sufiks"
+
+#: id:22003
+msgid "%2.3fs"
+msgstr ""
+
+#: id:22004
+msgid "Delayed by: %2.3fs"
+msgstr "Usporeno za: %2.3f sek."
+
+#: id:22005
+msgid "Ahead by: %2.3fs"
+msgstr "Ubrzano za: %2.3f sek."
+
+#: id:22006
+msgid "Subtitle offset"
+msgstr "Pomeraj titla u vremenu"
+
+#: id:22007
+msgid "OpenGL vendor:"
+msgstr "OpenGL proizvođač:"
+
+#: id:22008
+msgid "OpenGL renderer:"
+msgstr "OpenGL renderer:"
+
+#: id:22009
+msgid "OpenGL version:"
+msgstr "OpenGL verzija:"
+
+#: id:22010
+msgid "GPU temperature:"
+msgstr "GPU temperatura:"
+
+#: id:22011
+msgid "CPU temperature:"
+msgstr "CPU temperatura:"
+
+#: id:22012
+msgid "Total memory"
+msgstr "Ukupna memorija"
+
+#: id:22013
+msgid "Profile data"
+msgstr "Podaci profila"
+
+#: id:22014
+msgid "Use dim if paused during video playback"
+msgstr "Koristi zatamljenje ukoliko se pauzira prilikom reprod. filma"
+
+#: id:22015
+msgid "All recordings"
+msgstr "Sva snimanja"
+
+#: id:22016
+msgid "By title"
+msgstr "Po nazivu"
+
+#: id:22017
+msgid "By group"
+msgstr "Po grupi"
+
+#: id:22018
+msgid "Live channels"
+msgstr "Kanali uživo"
+
+#: id:22019
+msgid "Recordings by title"
+msgstr "Snimci po nazivu"
+
+#: id:22020
+msgid "Guide"
+msgstr "Vodič"
+
+#: id:22021
+msgid "Allowed error in aspect ratio to minimize black bars"
+msgstr "Dozv. greška u odnosu, radi smanjenja crnih traka"
+
+#: id:22022
+msgid "Show video files in listings"
+msgstr "Prikaži video datoteke u spiskovima"
+
+#: id:22023
+msgid "DirectX vendor:"
+msgstr "DirectX proizvođač:"
+
+#: id:22024
+msgid "Direct3D version:"
+msgstr "Direct3D verzija:"
+
+#: id:22030
+msgctxt "Auto context with id 22030"
+msgid "Font"
+msgstr "Slova"
+
+#: id:22031
+msgctxt "Auto context with id 22031"
+msgid "- Size"
+msgstr "- Veličina"
+
+#: id:22032
+msgctxt "Auto context with id 22032"
+msgid "- Colours"
+msgstr "- Boja"
+
+#: id:22033
+msgid "- Charset"
+msgstr "- Znakovi"
+
+#: id:22034
+msgid "Export karaoke titles as HTML"
+msgstr "Izvoz karaoke naslova kao HTML"
+
+#: id:22035
+msgid "Export karaoke titles as CSV"
+msgstr "Izvoz karaoke naslova kao CSV"
+
+#: id:22036
+msgid "Import karaoke titles..."
+msgstr "Uvoz karaoke naslova..."
+
+#: id:22037
+msgid "Show song selector automatically"
+msgstr "Automatski prikaži birač pesme"
+
+#: id:22038
+msgid "Export karaoke titles..."
+msgstr "Izvoz karaoke naslova..."
+
+#: id:22039
+msgid "Enter song number"
+msgstr "Unesite broj pesme"
+
+#: id:22040
+msgid "white/green"
+msgstr "belo/zeleno"
+
+#: id:22041
+msgid "white/red"
+msgstr "belo/crveno"
+
+#: id:22042
+msgid "white/blue"
+msgstr "belo/pravo"
+
+#: id:22043
+msgid "black/white"
+msgstr "crno/belo"
+
+#: id:22079
+msgid "Default select action"
+msgstr ""
+
+#: id:22080
+msgid "Choose"
+msgstr ""
+
+#: id:22081
+msgid "Show Information"
+msgstr ""
+
+#: id:22082
+msgid "More..."
+msgstr ""
+
+#: id:22083
+msgid "Play all"
+msgstr ""
+
+#: id:23049
+msgid "Teletext not available"
+msgstr "Teletekst nije dostupan"
+
+#: id:23050
+msgid "Activate Teletext"
+msgstr "Aktiviraj teletekst"
+
+#: id:23051
+msgid "Part %i"
+msgstr "Deo %i"
+
+#: id:23052
+msgid "Buffering %i bytes"
+msgstr "Predmemorisanje %i bajtova"
+
+#: id:23053
+msgid "Stopping"
+msgstr "Zaustavljanje"
+
+#: id:23054
+msgid "Running"
+msgstr "Pokretanje"
+
+#: id:23100
+msgid "External Player Active"
+msgstr "Spoljni aktivni uređaj za reprodukciju"
+
+#: id:23101
+msgid "Click OK to terminate the player"
+msgstr "Kliknite na „U redu“ da prekinete reprodukciju"
+
+#: id:23104
+msgid "Click OK when playback has ended"
+msgstr "Kliknite na „U redu“ kada se reprodukcija završi"
+
+#: id:24000
+msgid "Add-on"
+msgstr "Dodatni prog."
+
+#: id:24001
+msgid "Add-ons"
+msgstr "Dodatni prog."
+
+#: id:24002
+msgid "Add-on options"
+msgstr "Opcije dodatnog prog."
+
+#: id:24003
+msgid "Add-on Information"
+msgstr ""
+
+#: id:24005
+msgctxt "Auto context with id 24005"
+msgid "Media sources"
+msgstr "Dodatak"
+
+#: id:24007
+msgctxt "Auto context with id 24007"
+msgid "Movie information"
+msgstr "Dobavljač"
+
+#: id:24008
+msgctxt "Auto context with id 24008"
+msgid "Screensaver"
+msgstr "Čuvar ekrana"
+
+#: id:24009
+msgid "Script"
+msgstr "Skripta"
+
+#: id:24010
+msgctxt "Auto context with id 24010"
+msgid "Visualization"
+msgstr "Vizualizacija"
+
+#: id:24011
+msgid "Add-on repository"
+msgstr "Spremište dodatnog prog."
+
+#: id:24012
+msgctxt "Auto context with id 24012"
+msgid "Subtitles"
+msgstr ""
+
+#: id:24013
+msgid "Lyrics"
+msgstr ""
+
+#: id:24014
+msgid "TV information"
+msgstr ""
+
+#: id:24015
+msgctxt "Auto context with id 24015"
+msgid "Music video information"
+msgstr ""
+
+#: id:24016
+msgctxt "Auto context with id 24016"
+msgid "Album information"
+msgstr ""
+
+#: id:24017
+msgctxt "Auto context with id 24017"
+msgid "Artist information"
+msgstr ""
+
+#: id:24018
+msgctxt "Auto context with id 24018"
+msgid "Services"
+msgstr ""
+
+#: id:24020
+msgid "Configure"
+msgstr "Podešavanje dodatnog prog."
+
+#: id:24021
+msgctxt "Auto context with id 24021"
+msgid "Disable"
+msgstr "Onemogući dodatni prog."
+
+#: id:24022
+msgid "Enable"
+msgstr "Omogući dodatni prog."
+
+#: id:24023
+msgid "Add-on disabled"
+msgstr "Dodatni prog. je onemogućen"
+
+#: id:24027
+msgctxt "Auto context with id 24027"
+msgid "Weather"
+msgstr "Usluge vremenske prognoze"
+
+#: id:24028
+msgid "Weather.com (standard)"
+msgstr "Weather.com (standardan)"
+
+#: id:24030
+msgid "This Add-on can not be configured"
+msgstr "Ovaj dodatni prog. nije moguće podesiti"
+
+#: id:24031
+msgid "Error loading settings"
+msgstr "Greška prilikom učitavanja podešavanja"
+
+#: id:24032
+msgid "All Add-ons"
+msgstr ""
+
+#: id:24033
+msgid "Get Add-ons"
+msgstr ""
+
+#: id:24034
+msgid "Check for updates"
+msgstr ""
+
+#: id:24035
+msgid "Force refresh"
+msgstr ""
+
+#: id:24036
+msgid "Change log"
+msgstr ""
+
+#: id:24037
+msgid "Uninstall"
+msgstr ""
+
+#: id:24038
+msgid "Install"
+msgstr ""
+
+#: id:24039
+msgid "Disabled Add-ons"
+msgstr ""
+
+#: id:24040
+msgid "(Clear the current setting)"
+msgstr ""
+
+#: id:24041
+msgid "Install from zip file"
+msgstr ""
+
+#: id:24042
+msgid "Downloading %i%%"
+msgstr ""
+
+#: id:24043
+msgid "Available Updates"
+msgstr ""
+
+#: id:24044
+msgid "Dependencies not met"
+msgstr ""
+
+#: id:24045
+msgid "Add-on does not have the correct structure"
+msgstr ""
+
+#: id:24046
+msgid "%s is used by the following installed add-on(s)"
+msgstr ""
+
+#: id:24047
+msgid "This add-on cannot be uninstalled"
+msgstr ""
+
+#: id:24048
+msgid "Rollback"
+msgstr ""
+
+#: id:24050
+msgid "Available Add-ons"
+msgstr "Dostupni dodatni programi"
+
+#: id:24051
+msgid "Version:"
+msgstr "Verzija:"
+
+#: id:24052
+msgid "Disclaimer"
+msgstr "Odricanje:"
+
+#: id:24053
+msgid "License:"
+msgstr "Licenca:"
+
+#: id:24054
+msgid "Changelog"
+msgstr ""
+
+#: id:24059
+msgid "Would you like to enable this Add-on?"
+msgstr "Da li želite da omogućite ovaj dodatni prog.?"
+
+#: id:24060
+msgid "Would you like to disable this Add-on?"
+msgstr "Da li želite da onemogućite ovaj dodatni prog.?"
+
+#: id:24061
+msgid "Add-on update available!"
+msgstr "Nadogradnja dodatnog prog. je dostupna!"
+
+#: id:24062
+msgid "Enabled Add-ons"
+msgstr "Omogućeni dodatni programi"
+
+#: id:24063
+msgid "Auto update"
+msgstr "Automatsko ažuriranje"
+
+#: id:24064
+msgid "Add-on enabled"
+msgstr "Dodatni prog. je omogućen"
+
+#: id:24065
+msgid "Add-on updated"
+msgstr "Dodatni prog. je ažuriran"
+
+#: id:24066
+msgid "Cancel Add-on download?"
+msgstr "Da prekinem preuzimanje dodatnog prog.?"
+
+#: id:24067
+msgid "Currently downloading Add-ons"
+msgstr "Trenutno preuzimam dodatne programe"
+
+#: id:24068
+msgid "Update available"
+msgstr ""
+
+#: id:24069
+msgid "Update"
+msgstr ""
+
+#: id:24070
+msgid "Add-on could not be loaded."
+msgstr "Dodatni program nije upotrebljiv"
+
+#: id:24071
+msgid "An unknown error has occurred."
+msgstr "Dogodila se nepoznata greška"
+
+#: id:24072
+msgid "Settings required"
+msgstr "Podešavanje je neophodno"
+
+#: id:24073
+msgid "Could not connect"
+msgstr "Ne mogu se povezati"
+
+#: id:24074
+msgid "Needs to restart"
+msgstr "Ponovno pokretanje je neophodno"
+
+#: id:24075
+msgctxt "Auto context with id 24075"
+msgid "Disable"
+msgstr ""
+
+#: id:24076
+msgid "Add-on Required"
+msgstr ""
+
+#: id:24080
+msgid "Try to reconnect?"
+msgstr "Da pokušam ponovno uspostavljanje veze?"
+
+#: id:24089
+msgid "Add-on restarts"
+msgstr "Dodatni prog. se ponovno pokreće"
+
+#: id:24090
+msgid "Lock Add-on manager"
+msgstr "Zaključaj upravljač dodatnog prog."
+
+#: id:24094
+msgid "(current)"
+msgstr "Omogući hardversko ubrzanje (CrystalHD)"
+
+#: id:24095
+msgid "(blacklisted)"
+msgstr ""
+
+#: id:24096
+msgid "Add-on has been marked as broken in repository."
+msgstr ""
+
+#: id:24097
+msgid "Would you like to disable it on your system?"
+msgstr ""
+
+#: id:24098
+msgid "Broken"
+msgstr ""
+
+#: id:24099
+msgid "Would you like to switch to this skin?"
+msgstr ""
+
+#: id:24100
+msgid "To use this feature you must download an Add-on:"
+msgstr ""
+
+#: id:24101
+msgid "Would you like to download this Add-on?"
+msgstr ""
+
+#: id:25000
+msgid "Notifications"
+msgstr ""
+
+#: id:29800
+msgid "Library Mode"
+msgstr "Režim biblioteke"
+
+#: id:29801
+msgid "QWERTY keyboard"
+msgstr "QWERTY tastatura"
+
+#: id:29802
+msgid "Passthrough Audio in use"
+msgstr "Prolazni zvuk u upotrebi"
+
+#: id:33001
+msgid "Trailer quality"
+msgstr "Kvalitet najave"
+
+#: id:33002
+msgid "Stream"
+msgstr "Zapis"
+
+#: id:33003
+msgid "Download"
+msgstr "Preuzmi"
+
+#: id:33004
+msgid "Download & play"
+msgstr "Preuzmi i reprodukuj"
+
+#: id:33005
+msgid "Download & save"
+msgstr "Preuzmi i sačuvaj"
+
+#: id:33006
+msgid "Today"
+msgstr "Danas"
+
+#: id:33007
+msgid "Tomorrow"
+msgstr "Sutra"
+
+#: id:33008
+msgid "Saving"
+msgstr "Čuvanje"
+
+#: id:33009
+msgid "Copying"
+msgstr "Kopiranje"
+
+#: id:33010
+msgid "Set download directory"
+msgstr "Postavi fasciklu za preuzimanje"
+
+#: id:33011
+msgid "Search duration"
+msgstr ""
+
+#: id:33012
+msgid "Short"
+msgstr "Kratko"
+
+#: id:33013
+msgid "Long"
+msgstr "Dugačko"
+
+#: id:33014
+msgid "Use DVD player instead of regular player"
+msgstr "Koristi DVD plejer umesto običnog plejera"
+
+#: id:33015
+msgid "Ask for download before playing video"
+msgstr "Pitaj za preuzimanje pre reprodukcije filma"
+
+#: id:33016
+msgid "Clips"
+msgstr "Klipovi"
+
+#: id:33017
+msgid "Restart plugin to enable"
+msgstr "Ponovo pokrenite dodatak za aktiviranje"
+
+#: id:33018
+msgid "Tonight"
+msgstr "Noćas"
+
+#: id:33019
+msgid "Tomorrow Night"
+msgstr "Sutra uveče"
+
+#: id:33020
+msgid "Condition"
+msgstr "Stanje"
+
+#: id:33021
+msgid "Precipitation"
+msgstr "Obilne padavine"
+
+#: id:33022
+msgid "Precip"
+msgstr "Precip"
+
+#: id:33023
+msgid "Humid"
+msgstr "Vlažno"
+
+#: id:33024
+msgid "Feels"
+msgstr "Kao da je"
+
+#: id:33025
+msgid "Observed"
+msgstr "Posmatrano"
+
+#: id:33026
+msgid "Departure from normal"
+msgstr "Odstupanje od proseka"
+
+#: id:33027
+msgid "Sunrise"
+msgstr "Izlazak sunca"
+
+#: id:33028
+msgid "Sunset"
+msgstr "Zalazak sunca"
+
+#: id:33029
+msgid "Details"
+msgstr "Detalji"
+
+#: id:33030
+msgid "Outlook"
+msgstr "Vidik"
+
+#: id:33031
+msgid "Coverflow"
+msgstr "Prekriven"
+
+#: id:33032
+msgid "Translate text"
+msgstr "Prevedi tekst"
+
+#: id:33033
+msgid "Map list %s category"
+msgstr "Map list %s category"
+
+#: id:33034
+msgid "36 Hour"
+msgstr "36 časovna"
+
+#: id:33035
+msgid "Maps"
+msgstr "Karta"
+
+#: id:33036
+msgid "Hourly"
+msgstr "Iz časa u čas"
+
+#: id:33037
+msgid "Weekend"
+msgstr "Vikend"
+
+#: id:33038
+msgid "%s day"
+msgstr "%s dnevna"
+
+#: id:33049
+msgid "Alert"
+msgstr "Uzbuna"
+
+#: id:33050
+msgid "Alerts"
+msgstr "Upozorenja"
+
+#: id:33051
+msgid "Choose Your"
+msgstr "Izaberite vaš"
+
+#: id:33052
+msgid "Check"
+msgstr "Proveri"
+
+#: id:33053
+msgctxt "Auto context with id 33053"
+msgid "Configure the"
+msgstr "Konfiguriši"
+
+#: id:33054
+msgid "Seasons"
+msgstr "Godišnja doba"
+
+#: id:33055
+msgid "Use your"
+msgstr "Koristite vaš"
+
+#: id:33056
+msgid "Watch your"
+msgstr "Gledajte vaš"
+
+#: id:33057
+msgid "Listen to"
+msgstr "Slušajte"
+
+#: id:33058
+msgid "View your"
+msgstr "Prikažite vaš"
+
+#: id:33059
+msgctxt "Auto context with id 33059"
+msgid "Configure the"
+msgstr "Konfiguriši"
+
+#: id:33060
+msgid "Power"
+msgstr "Snaga"
+
+#: id:33061
+msgid "Menu"
+msgstr "Meni"
+
+#: id:33062
+msgid "Play the"
+msgstr "Reprodukuj"
+
+#: id:33063
+msgid "Options"
+msgstr "Opcije"
+
+#: id:33065
+msgid "Editor"
+msgstr "Uređivač"
+
+#: id:33066
+msgid "About your"
+msgstr "O vašem"
+
+#: id:33067
+msgid "Star rating"
+msgstr "Ocena zvezdicama"
+
+#: id:33068
+msgid "Background"
+msgstr "Pozadina"
+
+#: id:33069
+msgid "Backgrounds"
+msgstr "Pozadine"
+
+#: id:33070
+msgid "Custom background"
+msgstr "Prilagođena pozadina"
+
+#: id:33071
+msgid "Custom backgrounds"
+msgstr "Prilagođene pozadine"
+
+#: id:33072
+msgid "View Readme"
+msgstr "Prikaži „Pročitaj me“"
+
+#: id:33073
+msgid "View Changelog"
+msgstr "Prikaži „Evidenciju izmena“"
+
+#: id:33074
+msgid "This version of %s requires an"
+msgstr "Ova verzija za pokretanje zahteva %s"
+
+#: id:33075
+msgid "XBMC revision of %s or greater to run."
+msgstr "XBMC izdanje ili %s jače."
+
+#: id:33076
+msgid "Please update XBMC."
+msgstr "Molimo, ažurirajte XBMC aplikaciju."
+
+#: id:33077
+msgid "No data found!"
+msgstr "Podaci nisu pronađeni!"
+
+#: id:33078
+msgid "Next page"
+msgstr "Sledeća strana"
+
+#: id:33079
+msgid "Love"
+msgstr "Ljubav"
+
+#: id:33080
+msgid "Hate"
+msgstr "Mržnja"
+
+#: id:33081
+msgid "This file is stacked, select the part you want to play from."
+msgstr "Ova datoteka je složena, izaberite koji deo želite da reprodukujete iz nje."
+
+#: id:33082
+msgid "Path to script"
+msgstr "Putanja do skripte"
+
+#: id:33083
+msgid "Enable custom script button"
+msgstr "Omogući prilagođeni taster za sjruotu"
+
+#: id:33100
+msgid "Failed to start"
+msgstr ""
+
+#: id:33101
+msgid "Webserver"
+msgstr ""
+
+#: id:33102
+msgid "Event Server"
+msgstr ""
+
+#: id:33103
+msgid "Remote communication server"
+msgstr ""
+
+#: id:33200
+msgid "Detected New Connection"
+msgstr ""
+
+#: id:34000
+msgid "Lame"
+msgstr "Lame"
+
+#: id:34001
+msgid "Vorbis"
+msgstr "Vorbis"
+
+#: id:34002
+msgid "Wav"
+msgstr "Wav"
+
+#: id:34003
+msgid "DXVA2"
+msgstr "DXVA"
+
+#: id:34004
+msgid "VAAPI"
+msgstr ""
+
+#: id:34005
+msgid "Flac"
+msgstr ""
+
+#: id:34100
+msgid "Speaker Configuration"
+msgstr "Konfiguracija zvučnika"
+
+#: id:34101
+msgid "2.0"
+msgstr "2.0"
+
+#: id:34102
+msgid "2.1"
+msgstr "2.1"
+
+#: id:34103
+msgid "3.0"
+msgstr "3.0"
+
+#: id:34104
+msgid "3.1"
+msgstr "3.1"
+
+#: id:34105
+msgid "4.0"
+msgstr "4.0"
+
+#: id:34106
+msgid "4.1"
+msgstr "4.1"
+
+#: id:34107
+msgid "5.0"
+msgstr "5.0"
+
+#: id:34108
+msgid "5.1"
+msgstr "5.1"
+
+#: id:34109
+msgid "7.0"
+msgstr "7.0"
+
+#: id:34110
+msgid "7.1"
+msgstr "7.1"
+
+#: id:34201
+msgid "Can't find a next item to play"
+msgstr ""
+
+#: id:34202
+msgid "Can't find a previous item to play"
+msgstr ""
+
+#: id:34300
+msgid "Failed to start zeroconf"
+msgstr ""
+
+#: id:34301
+msgid "Is Apple's Bonjour Service installed? See log for more info."
+msgstr ""
+
+#: id:34400
+msgid "Video Rendering"
+msgstr ""
+
+#: id:34401
+msgid "Failed to init video filters/scalers, falling back to bilinear scaling"
+msgstr ""
+
+#: id:34402
+msgid "Failed to initialize audio device"
+msgstr ""
+
+#: id:34403
+msgid "Check your audiosettings"
+msgstr ""
+
+#: id:34404
+msgid "Use gestures for navigation:"
+msgstr ""
+
+#: id:34405
+msgid "1 finger swipe left,right,up,down for cursors"
+msgstr ""
+
+#: id:34406
+msgid "2 finger swipe left for backspace"
+msgstr ""
+
+#: id:34407
+msgid "1 finger single tap for enter"
+msgstr ""
+
+#: id:34408
+msgid "2 finger single tap for contextmenu"
+msgstr ""
+
+#: id:35000
+msgid "Peripherals"
+msgstr ""
+
+#: id:35001
+msgid "Generic HID device"
+msgstr ""
+
+#: id:35002
+msgid "Generic network adapter"
+msgstr ""
+
+#: id:35003
+msgid "Generic disk"
+msgstr ""
+
+#: id:35004
+msgid "There are no settings available\nfor this peripheral."
+msgstr ""
+
+#: id:35005
+msgid "New device configured"
+msgstr ""
+
+#: id:35006
+msgid "Device removed"
+msgstr ""
+
+#: id:35007
+msgid "Keymap to use for this device"
+msgstr ""
+
+#: id:35008
+msgid "Keymap enabled"
+msgstr ""
+
+#: id:35009
+msgid "Do not use the custom keymap for this device"
+msgstr ""
+
+#: id:35500
+msgid "Location"
+msgstr ""
+
+#: id:35501
+msgid "Class"
+msgstr ""
+
+#: id:35502
+msgctxt "Auto context with id 35502"
+msgid "Name"
+msgstr ""
+
+#: id:35503
+msgid "Vendor"
+msgstr ""
+
+#: id:35504
+msgid "Product ID"
+msgstr ""
+
+#: id:36000
+msgid "Pulse-Eight CEC adapter"
+msgstr ""
+
+#: id:36001
+msgid "Pulse-Eight Nyxboard"
+msgstr ""
+
+#: id:36002
+msgid "Switch to keyboard side command"
+msgstr ""
+
+#: id:36003
+msgid "Switch to remote side command"
+msgstr ""
+
+#: id:36004
+msgid "Press \"user\" button command"
+msgstr ""
+
+#: id:36005
+msgid "Enable switch side commands"
+msgstr ""
+
+#: id:36006
+msgid "Could not open the adapter"
+msgstr ""
+
+#: id:36007
+msgid "Devices to power on when starting XBMC"
+msgstr ""
+
+#: id:36008
+msgid "Devices to power off when stopping XBMC"
+msgstr ""
+
+#: id:36009
+msgid "Put devices in standby mode when activating screensaver"
+msgstr ""
+
+#: id:36011
+msgid "Could not detect the CEC port. Set it up manually."
+msgstr ""
+
+#: id:36012
+msgid "Could not initialise the CEC adapter. Check your settings."
+msgstr ""
+
+#: id:36013
+msgid "Unsupported libCEC interface version. %d is greater than the version XBMC supports (%d)"
+msgstr ""
+
+#: id:36014
+msgid "Put this PC in standby mode when the TV is switched off"
+msgstr ""
+
+#: id:36015
+msgid "HDMI port number"
+msgstr ""
+
+#: id:36016
+msgctxt "Auto context with id 36016"
+msgid "Connected"
+msgstr ""
+
+#: id:36017
+msgid "Adapter found, but libCEC is not available"
+msgstr ""
+
+#: id:36018
+msgid "Use the TV's language setting"
+msgstr ""
+
+#: id:36019
+msgid "Connected to HDMI device"
+msgstr ""
+
+#: id:36020
+msgid "Make XBMC the active source when starting"
+msgstr ""
+
+#: id:36021
+msgid "Physical address (overrules HDMI port)"
+msgstr ""
+
+#: id:36022
+msgid "COM port (leave empty unless needed)"
+msgstr ""
+
+#: id:36023
+msgid "Configuration updated"
+msgstr ""
+
+#: id:36024
+msgid "Failed to set the new configuration. Please check your settings."
+msgstr ""
+
+#: id:36025
+msgid "Send 'inactive source' command when stopping XBMC"
+msgstr ""
+

--- a/language/Slovak/strings.po
+++ b/language/Slovak/strings.po
@@ -1,0 +1,9093 @@
+# Converted from xbmc strings.xml with xbmc-xml2po (by Team-XBMC)
+msgid ""
+msgstr ""
+"Project-Id-Version: xbmc.core-FRODO_GIT3ed1604ad7\n"
+"Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
+"POT-Creation-Date: 2012-04-09 18:00+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE\n"
+"Language: sk\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: id:0
+msgctxt "Auto context with id 0"
+msgid "Programs"
+msgstr "Programy"
+
+#: id:1
+msgctxt "Auto context with id 1"
+msgid "Pictures"
+msgstr "Obrázky"
+
+#: id:2
+msgctxt "Auto context with id 2"
+msgid "Music"
+msgstr "Hudba"
+
+#: id:3
+msgctxt "Auto context with id 3"
+msgid "Videos"
+msgstr "Video"
+
+#: id:4
+msgid "TV-Guide"
+msgstr "TV program"
+
+#: id:5
+msgctxt "Auto context with id 5"
+msgid "Settings"
+msgstr "Nastavenia"
+
+#: id:6
+msgid "XBMC SVN"
+msgstr ""
+
+#: id:7
+msgctxt "Auto context with id 7"
+msgid "File manager"
+msgstr "Správca súborov"
+
+#: id:8
+msgctxt "Auto context with id 8"
+msgid "Weather"
+msgstr "Počasie"
+
+#: id:9
+msgid "xbmc media center"
+msgstr "xbmc media center"
+
+#: id:11
+msgid "Monday"
+msgstr "Pondelok"
+
+#: id:12
+msgid "Tuesday"
+msgstr "Utorok"
+
+#: id:13
+msgid "Wednesday"
+msgstr "Streda"
+
+#: id:14
+msgid "Thursday"
+msgstr "Štvrtok"
+
+#: id:15
+msgid "Friday"
+msgstr "Piatok"
+
+#: id:16
+msgid "Saturday"
+msgstr "Sobota"
+
+#: id:17
+msgid "Sunday"
+msgstr "Nedeľa"
+
+#: id:21
+msgid "January"
+msgstr "Január"
+
+#: id:22
+msgid "February"
+msgstr "Február"
+
+#: id:23
+msgid "March"
+msgstr "Marec"
+
+#: id:24
+msgid "April"
+msgstr "Apríl"
+
+#: id:25
+msgctxt "Auto context with id 25"
+msgid "May"
+msgstr "Máj"
+
+#: id:26
+msgid "June"
+msgstr "Jún"
+
+#: id:27
+msgid "July"
+msgstr "Júl"
+
+#: id:28
+msgid "August"
+msgstr "August"
+
+#: id:29
+msgid "September"
+msgstr "September"
+
+#: id:30
+msgid "October"
+msgstr "Október"
+
+#: id:31
+msgid "November"
+msgstr "November"
+
+#: id:32
+msgid "December"
+msgstr "December"
+
+#: id:41
+msgid "Mon"
+msgstr "Po"
+
+#: id:42
+msgid "Tue"
+msgstr "Ut"
+
+#: id:43
+msgid "Wed"
+msgstr "St"
+
+#: id:44
+msgid "Thu"
+msgstr "Št"
+
+#: id:45
+msgid "Fri"
+msgstr "Pi"
+
+#: id:46
+msgid "Sat"
+msgstr "So"
+
+#: id:47
+msgctxt "Auto context with id 47"
+msgid "Sun"
+msgstr "Ne"
+
+#: id:51
+msgid "Jan"
+msgstr "Jan"
+
+#: id:52
+msgid "Feb"
+msgstr "Feb"
+
+#: id:53
+msgid "Mar"
+msgstr "Mar"
+
+#: id:54
+msgid "Apr"
+msgstr "Apr"
+
+#: id:55
+msgctxt "Auto context with id 55"
+msgid "May"
+msgstr "Máj"
+
+#: id:56
+msgid "Jun"
+msgstr "Jún"
+
+#: id:57
+msgid "Jul"
+msgstr "Júl"
+
+#: id:58
+msgid "Aug"
+msgstr "Aug"
+
+#: id:59
+msgid "Sep"
+msgstr "Sep"
+
+#: id:60
+msgid "Oct"
+msgstr "Okt"
+
+#: id:61
+msgid "Nov"
+msgstr "Nov"
+
+#: id:62
+msgid "Dec"
+msgstr "Dec"
+
+#: id:71
+msgid "N"
+msgstr "S"
+
+#: id:72
+msgid "NNE"
+msgstr "SSV"
+
+#: id:73
+msgid "NE"
+msgstr "SV"
+
+#: id:74
+msgid "ENE"
+msgstr "VSV"
+
+#: id:75
+msgid "E"
+msgstr "V"
+
+#: id:76
+msgid "ESE"
+msgstr "VJV"
+
+#: id:77
+msgid "SE"
+msgstr "JV"
+
+#: id:78
+msgid "SSE"
+msgstr "JJV"
+
+#: id:79
+msgid "S"
+msgstr "J"
+
+#: id:80
+msgid "SSW"
+msgstr "JJZ"
+
+#: id:81
+msgid "SW"
+msgstr "JZ"
+
+#: id:82
+msgid "WSW"
+msgstr "ZJZ"
+
+#: id:83
+msgid "W"
+msgstr "Z"
+
+#: id:84
+msgid "WNW"
+msgstr "ZSZ"
+
+#: id:85
+msgid "NW"
+msgstr "SZ"
+
+#: id:86
+msgid "NNW"
+msgstr "SSZ"
+
+#: id:87
+msgid "VAR"
+msgstr "premenlivé"
+
+#: id:98
+msgid "View: Auto"
+msgstr "Zobrazenie: Auto"
+
+#: id:99
+msgid "View: Auto big"
+msgstr "Zobrazenie: Auto veľké"
+
+#: id:100
+msgid "View: Icons"
+msgstr "Zobrazenie: Ikony"
+
+#: id:101
+msgid "View: List"
+msgstr "Zobrazenie: Zoznam"
+
+#: id:102
+msgctxt "Auto context with id 102"
+msgid "Scan"
+msgstr "Prezrieť"
+
+#: id:103
+msgctxt "Auto context with id 103"
+msgid "Sort by: Name"
+msgstr "Usporiadať: Názov"
+
+#: id:104
+msgid "Sort by: Date"
+msgstr "Usporiadať: Dátum"
+
+#: id:105
+msgid "Sort by: Size"
+msgstr "Usporiadať: Veľkosť"
+
+#: id:106
+msgid "No"
+msgstr "Nie"
+
+#: id:107
+msgid "Yes"
+msgstr "Áno"
+
+#: id:108
+msgctxt "Auto context with id 108"
+msgid "Slideshow"
+msgstr "Prezentácia"
+
+#: id:109
+msgid "Create thumbs"
+msgstr "Vytvoriť náhľady"
+
+#: id:110
+msgid "Create thumbnails"
+msgstr "Vytvoriť náhľady"
+
+#: id:111
+msgctxt "Auto context with id 111"
+msgid "Shortcuts"
+msgstr "Skratky"
+
+#: id:112
+msgid "Paused"
+msgstr "PAUZA"
+
+#: id:113
+msgid "Update failed"
+msgstr "Akualizácia sa nepodarila"
+
+#: id:114
+msgid "Installation failed"
+msgstr "Inštalácia sa nepodarila"
+
+#: id:115
+msgid "Copy"
+msgstr "Kopírovať"
+
+#: id:116
+msgid "Move"
+msgstr "Presunúť"
+
+#: id:117
+msgid "Delete"
+msgstr "Vymazať"
+
+#: id:118
+msgid "Rename"
+msgstr "Premenovať"
+
+#: id:119
+msgid "New folder"
+msgstr "Nový priečinok"
+
+#: id:120
+msgid "Confirm file copy"
+msgstr "Potvrdenie kopírovania"
+
+#: id:121
+msgid "Confirm file move"
+msgstr "Potvrdenie presunutia"
+
+#: id:122
+msgid "Confirm file delete?"
+msgstr "Potvrdenie vymazania"
+
+#: id:123
+msgid "Copy these files?"
+msgstr "Kopírovať tieto súbory?"
+
+#: id:124
+msgid "Move these files?"
+msgstr "Presunúť tieto súbory?"
+
+#: id:125
+msgid "Delete these files? - Deleting files cannot be undone!"
+msgstr "Vymazať tieto súbory?"
+
+#: id:126
+msgid "Status"
+msgstr "Stav"
+
+#: id:127
+msgid "Objects"
+msgstr "Objekty"
+
+#: id:128
+msgctxt "Auto context with id 128"
+msgid "General"
+msgstr "Všeobecné"
+
+#: id:129
+msgctxt "Auto context with id 129"
+msgid "Slideshow"
+msgstr "Prezentácia"
+
+#: id:130
+msgctxt "Auto context with id 130"
+msgid "System info"
+msgstr "Systémové informácie"
+
+#: id:131
+msgid "Display"
+msgstr "Obrazovka"
+
+#: id:132
+msgid "Albums"
+msgstr "Album"
+
+#: id:133
+msgid "Artists"
+msgstr "Interprét"
+
+#: id:134
+msgid "Songs"
+msgstr "Skladba"
+
+#: id:135
+msgid "Genres"
+msgstr "Štýl/Žáner"
+
+#: id:136
+msgid "Playlists"
+msgstr "Playlist-y"
+
+#: id:137
+msgid "Search"
+msgstr "Hľadať"
+
+#: id:138
+msgid "System Information"
+msgstr "SYSTÉMOVÉ INFORMÁCIE"
+
+#: id:139
+msgid "Temperatures:"
+msgstr "Teploty:"
+
+#: id:140
+msgid "CPU:"
+msgstr "CPU:"
+
+#: id:141
+msgid "GPU:"
+msgstr "GPU:"
+
+#: id:142
+msgid "Time:"
+msgstr "Čas:"
+
+#: id:143
+msgid "Current:"
+msgstr "Aktuálny stav:"
+
+#: id:144
+msgid "Build:"
+msgstr "Build:"
+
+#: id:145
+msgid "Network:"
+msgstr "Sieť:"
+
+#: id:146
+msgid "Type:"
+msgstr "Typ:"
+
+#: id:147
+msgid "Static"
+msgstr "Statická"
+
+#: id:148
+msgid "DHCP"
+msgstr "DHCP"
+
+#: id:149
+msgid "MAC address"
+msgstr "MAC"
+
+#: id:150
+msgctxt "Auto context with id 150"
+msgid "IP address"
+msgstr "IP"
+
+#: id:151
+msgid "Link:"
+msgstr "Prepojenie:"
+
+#: id:152
+msgid "Half duplex"
+msgstr "Polovičný duplex"
+
+#: id:153
+msgid "Full duplex"
+msgstr "Plný duplex"
+
+#: id:154
+msgctxt "Auto context with id 154"
+msgid "Storage"
+msgstr "Úložisko"
+
+#: id:155
+msgid "Drive"
+msgstr "Jednotka"
+
+#: id:156
+msgctxt "Auto context with id 156"
+msgid "Free"
+msgstr "Voľných"
+
+#: id:157
+msgctxt "Auto context with id 157"
+msgid "Video"
+msgstr "Video"
+
+#: id:158
+msgid "Free memory"
+msgstr "Voľná pamäť"
+
+#: id:159
+msgid "No link"
+msgstr "Žiadne prepojenie"
+
+#: id:160
+msgctxt "Auto context with id 160"
+msgid "Free"
+msgstr "Voľné"
+
+#: id:161
+msgid "Unavailable"
+msgstr "Nedostupný"
+
+#: id:162
+msgid "Tray open"
+msgstr "Vysunúť disk"
+
+#: id:163
+msgid "Reading"
+msgstr "Čítam"
+
+#: id:164
+msgid "No disc"
+msgstr "Žiaden disk"
+
+#: id:165
+msgid "Disc present"
+msgstr "Disk dostupný"
+
+#: id:166
+msgid "Skin"
+msgstr "Vzhľad"
+
+#: id:169
+msgctxt "Auto context with id 169"
+msgid "Resolution"
+msgstr "Rozlíšenie"
+
+#: id:170
+msgid "Adjust display refresh rate to match video"
+msgstr "Prispôsobiť obnovovaciu frekvenciu obrazovky k videu"
+
+#: id:172
+msgid "Release date"
+msgstr "Dátum vydania:"
+
+#: id:173
+msgid "Display 4:3 videos as"
+msgstr "Zobrazenie 4:3 videa"
+
+#: id:175
+msgid "Moods"
+msgstr "Charakter:"
+
+#: id:176
+msgid "Styles"
+msgstr "Štýly"
+
+#: id:179
+msgid "Song"
+msgstr "Skladba"
+
+#: id:180
+msgid "Duration"
+msgstr "Dĺžka"
+
+#: id:181
+msgid "Select album"
+msgstr "Výber albumu"
+
+#: id:182
+msgid "Tracks"
+msgstr "Stopy"
+
+#: id:183
+msgid "Review"
+msgstr "Recenzia"
+
+#: id:184
+msgid "Refresh"
+msgstr "Obnoviť"
+
+#: id:185
+msgid "Searching album"
+msgstr "Vyhľadávanie albumu"
+
+#: id:186
+msgid "OK"
+msgstr "OK"
+
+#: id:187
+msgid "No albums found!"
+msgstr "Albumy nenájdené!"
+
+#: id:188
+msgid "Select all"
+msgstr "Vybrať všetko"
+
+#: id:189
+msgid "Scanning media info"
+msgstr "Získavanie informácií o médiu"
+
+#: id:190
+msgid "Save"
+msgstr "Uložiť"
+
+#: id:191
+msgid "Shuffle"
+msgstr "Náhodné"
+
+#: id:192
+msgctxt "Auto context with id 192"
+msgid "Clear"
+msgstr "Vyčistiť"
+
+#: id:193
+msgctxt "Auto context with id 193"
+msgid "Scan"
+msgstr "Prehľadať"
+
+#: id:194
+msgid "Searching..."
+msgstr "Vyhľadávam..."
+
+#: id:195
+msgid "No info found!"
+msgstr "Bez informácií!"
+
+#: id:196
+msgid "Select movie:"
+msgstr "Výber filmu:"
+
+#: id:197
+msgid "Querying %s info"
+msgstr "Zisťujem informácie o %s"
+
+#: id:198
+msgid "Loading movie details"
+msgstr "Načítanie detailov o filme"
+
+#: id:199
+msgid "Web interface"
+msgstr "Webové rozhranie"
+
+#: id:202
+msgid "Tagline"
+msgstr "Obsah"
+
+#: id:203
+msgid "Plot outline"
+msgstr "Popis"
+
+#: id:205
+msgid "Votes"
+msgstr "Hlasov"
+
+#: id:206
+msgid "Cast"
+msgstr "Herci"
+
+#: id:207
+msgid "Plot"
+msgstr "Obsah"
+
+#: id:208
+msgctxt "Auto context with id 208"
+msgid "Play"
+msgstr "Prehrať"
+
+#: id:209
+msgid "Next"
+msgstr "Ďalší"
+
+#: id:210
+msgid "Previous"
+msgstr "Predchádzajúci"
+
+#: id:213
+msgid "Calibrate user interface..."
+msgstr "Kalibrácia rozhrania..."
+
+#: id:214
+msgid "Video calibration..."
+msgstr "Kalibrácia videa..."
+
+#: id:215
+msgid "Soften"
+msgstr "Zmäkčenie"
+
+#: id:216
+msgid "Zoom amount"
+msgstr "Veľkosť priblíženia"
+
+#: id:217
+msgid "Pixel ratio"
+msgstr "Pomer strán"
+
+#: id:218
+msgid "DVD drive"
+msgstr "DVD disk"
+
+#: id:219
+msgid "Please insert disc"
+msgstr "Prosím vložte disk"
+
+#: id:220
+msgid "Remote share"
+msgstr "Vzdialené zdieľanie"
+
+#: id:221
+msgid "Network is not connected"
+msgstr "Sieť nie je pripojená"
+
+#: id:222
+msgid "Cancel"
+msgstr "Zrušiť"
+
+#: id:224
+msgid "Speed"
+msgstr "Rýchlosť"
+
+#: id:225
+msgid "Vertical Shift"
+msgstr "Vertikálny posun"
+
+#: id:226
+msgid "Test patterns..."
+msgstr "Testovací obraz..."
+
+#: id:227
+msgid "Lookup audio CD track names from freedb.org"
+msgstr "Vyhľadať audio CD na freedb"
+
+#: id:228
+msgid "Shuffle playlist on load"
+msgstr "Nahodný playlist pri otvorení"
+
+#: id:229
+msgid "HDD spindown time"
+msgstr "Zastaviť disk"
+
+#: id:230
+msgid "Video filters"
+msgstr "Video filtre"
+
+#: id:231
+msgctxt "Auto context with id 231"
+msgid "None"
+msgstr "Žiadne"
+
+#: id:232
+msgid "Point"
+msgstr "Bodový"
+
+#: id:233
+msgid "Linear"
+msgstr "Lineárny"
+
+#: id:234
+msgid "Anisotropic"
+msgstr "Anizotropický"
+
+#: id:235
+msgid "Quincunx"
+msgstr "Quincunx"
+
+#: id:236
+msgid "Gaussian cubic"
+msgstr "Gaussovsko kubický"
+
+#: id:237
+msgid "Minification"
+msgstr "Zmenšenie"
+
+#: id:238
+msgid "Magnification"
+msgstr "Zväčšenie"
+
+#: id:239
+msgid "Clear playlist on finish"
+msgstr "Vymazať playlist pri ukončení"
+
+#: id:240
+msgid "Display Mode"
+msgstr "Vybrať zobrazenie"
+
+#: id:241
+msgid "Full Screen #%d"
+msgstr "Celá obrazovka #%d"
+
+#: id:242
+msgid "Windowed"
+msgstr "Okno"
+
+#: id:243
+msgid "Refresh Rate"
+msgstr "Obnovovacia frekvencia"
+
+#: id:244
+msgid "Full screen"
+msgstr "Celá obrazovka"
+
+#: id:245
+msgid "Sizing: (%i,%i)->(%i,%i) (Zoom x%2.2f) AR:%2.2f:1 (Pixels: %2.2f:1) (VShift: %2.2f)"
+msgstr "Kalibrácia: (%i,%i)->(%i,%i) (Zoom x%2.2f) AR:%2.2f:1 (Pixels: %2.2f:1) (VShift: %2.2f)"
+
+#: id:247
+msgctxt "Auto context with id 247"
+msgid "Scripts"
+msgstr "Skripty"
+
+#: id:248
+msgctxt "Auto context with id 248"
+msgid "Language"
+msgstr "Jazyk"
+
+#: id:249
+msgctxt "Auto context with id 249"
+msgid "Music"
+msgstr "Hudba"
+
+#: id:250
+msgctxt "Auto context with id 250"
+msgid "Visualization"
+msgstr "Vizualizácie"
+
+#: id:251
+msgid "Select destination directory"
+msgstr "Nastaviť cieľový adresár"
+
+#: id:252
+msgid "Output stereo to all speakers"
+msgstr "Stereo výstup do všetkých reproduktorov"
+
+#: id:253
+msgid "Number of channels"
+msgstr "Počet kanálov"
+
+#: id:254
+msgid "- DTS capable receiver"
+msgstr "- DTS kompatibilný receiver"
+
+#: id:255
+msgid "CDDB"
+msgstr "CDDB"
+
+#: id:256
+msgid "Fetching CD information"
+msgstr "Dotazujem freedb pre CDDB info"
+
+#: id:257
+msgid "Error"
+msgstr "Chyba"
+
+#: id:258
+msgid "Enable tag reading"
+msgstr "Povoliť čítanie tagov"
+
+#: id:259
+msgid "Opening"
+msgstr "Otváranie"
+
+#: id:260
+msgid "Shoutcast"
+msgstr "Shoutcast"
+
+#: id:261
+msgid "Waiting for start..."
+msgstr "Čakanie na štart..."
+
+#: id:262
+msgid "Scripts output"
+msgstr "Výstup skript"
+
+#: id:263
+msgid "Allow control of XBMC via HTTP"
+msgstr "Povoliť ovládanie XBMC cez HTTP"
+
+#: id:264
+msgid "Record"
+msgstr "Nahrávanie"
+
+#: id:265
+msgid "Stop Rec."
+msgstr "Stop Náhr."
+
+#: id:266
+msgid "Sort by: Track"
+msgstr "Usporiadať: Stopa"
+
+#: id:267
+msgid "Sort by: Time"
+msgstr "Usporiadať: Čas"
+
+#: id:268
+msgid "Sort by: Title"
+msgstr "Usporiadať: Názov"
+
+#: id:269
+msgid "Sort by: Artist"
+msgstr "Usporiadať: Interprét"
+
+#: id:270
+msgid "Sort by: Album"
+msgstr "Usporiadať: Album"
+
+#: id:271
+msgid "Top 100"
+msgstr "Naj 100"
+
+#: id:272
+msgid "Top-Left overscan compensation"
+msgstr "Vrchná ľavá kompenzácia presnímania"
+
+#: id:273
+msgid "Bottom-Right overscan compensation"
+msgstr "Spodná pravá kompenzácia presnímania"
+
+#: id:274
+msgid "Subtitle positioning"
+msgstr "Pozícia titulkov"
+
+#: id:275
+msgid "Pixel ratio adjustment"
+msgstr "Úprava Pixel Ratia"
+
+#: id:276
+msgid "Adjust the arrow to change the amount of overscan"
+msgstr "Posunom šipiek zmeníte veľkosť presnímania"
+
+#: id:277
+msgid "Adjust the bar to change the subtitles position"
+msgstr "Posuňte čiaru pre zmenu pozície titulkov"
+
+#: id:278
+msgid "Adjust the rectangle so it is perfectly square"
+msgstr "Zmeňte pravouholník nech je štvorec"
+
+#: id:279
+msgid "Unable to load settings"
+msgstr "Nie je možné otvoriť nastavenia"
+
+#: id:280
+msgid "Using default settings"
+msgstr "Použitie predvolených nastavení"
+
+#: id:281
+msgid "Please check the XML files"
+msgstr "Prosím skontrolujte .xml súbory"
+
+#: id:282
+msgid "Found %i items"
+msgstr "nájdených %i položiek"
+
+#: id:283
+msgid "Search results"
+msgstr "Výsledky hľadania"
+
+#: id:284
+msgid "No results found"
+msgstr "Žiadny výsledok"
+
+#: id:287
+msgctxt "Auto context with id 287"
+msgid "Subtitles"
+msgstr "Titulky"
+
+#: id:288
+msgctxt "Auto context with id 288"
+msgid "Font"
+msgstr "Písmo"
+
+#: id:289
+msgctxt "Auto context with id 289"
+msgid "- Size"
+msgstr "- Veľkosť"
+
+#: id:290
+msgid "Dynamic range compression"
+msgstr "Kompresia dynamického rozsahu"
+
+#: id:291
+msgctxt "Auto context with id 291"
+msgid "Video"
+msgstr "Obraz"
+
+#: id:292
+msgctxt "Auto context with id 292"
+msgid "Audio"
+msgstr "Zvuk"
+
+#: id:293
+msgid "Browse for subtitles"
+msgstr "Vybrať titulky"
+
+#: id:294
+msgid "Create bookmark"
+msgstr "Vytvoriť záložku"
+
+#: id:296
+msgid "Clear bookmarks"
+msgstr "Vymazať záložku"
+
+#: id:297
+msgid "Audio offset"
+msgstr "Oneskorenie zvuku"
+
+#: id:298
+msgid "Bookmarks"
+msgstr "Záložky"
+
+#: id:299
+msgid "- AAC capable receiver"
+msgstr "- AAC kompatibilný receiver"
+
+#: id:300
+msgid "- MP1 capable receiver"
+msgstr "- MP1 kompatibilný receiver"
+
+#: id:301
+msgid "- MP2 capable receiver"
+msgstr "- MP2 kompatibilný receiver"
+
+#: id:302
+msgid "- MP3 capable receiver"
+msgstr "- MP3 kompatibilný receiver"
+
+#: id:303
+msgid "Delay"
+msgstr "Oneskorenie"
+
+#: id:304
+msgctxt "Auto context with id 304"
+msgid "Language"
+msgstr "Jazyk"
+
+#: id:305
+msgctxt "Auto context with id 305"
+msgid "Enabled"
+msgstr "Aktivované"
+
+#: id:306
+msgid "Non-interleaved"
+msgstr "Neprekladaný"
+
+#: id:312
+msgid "(0=auto)"
+msgstr "(0=auto)"
+
+#: id:313
+msgid "Cleaning database"
+msgstr "Čistenie databázy"
+
+#: id:314
+msgid "Preparing..."
+msgstr "Pripravujem..."
+
+#: id:315
+msgid "Database error"
+msgstr "Chyba databázy"
+
+#: id:316
+msgid "Searching songs..."
+msgstr "Vyhľadávam skladby..."
+
+#: id:317
+msgid "Cleaned database successfully"
+msgstr "Vyčistenie databázy úspešné"
+
+#: id:318
+msgid "Cleaning songs..."
+msgstr "Čistenie skladieb..."
+
+#: id:319
+msgid "Error cleaning songs"
+msgstr "Chyba pri čistení skladieb"
+
+#: id:320
+msgid "Cleaning artists..."
+msgstr "Čistenie interprétov..."
+
+#: id:321
+msgid "Error cleaning artists"
+msgstr "Chyba pri čistení interprétov"
+
+#: id:322
+msgid "Cleaning genres..."
+msgstr "Čistenie žánrov..."
+
+#: id:323
+msgid "Error cleaning genres"
+msgstr "Chyba pri čistení žánrov"
+
+#: id:324
+msgid "Cleaning paths..."
+msgstr "Čistenie ciest..."
+
+#: id:325
+msgid "Error cleaning paths"
+msgstr "Chyba pri čistení ciest"
+
+#: id:326
+msgid "Cleaning albums..."
+msgstr "Čistenie albumov..."
+
+#: id:327
+msgid "Error cleaning albums"
+msgstr "Chyba pri čistení albumov"
+
+#: id:328
+msgid "Writing changes..."
+msgstr "Zapisujem zmeny..."
+
+#: id:329
+msgid "Error writing changes"
+msgstr "Chyba pri zapisovaní zmien"
+
+#: id:330
+msgid "This may take some time..."
+msgstr "Toto môže chvíľku trvať..."
+
+#: id:331
+msgid "Compressing database..."
+msgstr "Komprimujem databázu..."
+
+#: id:332
+msgid "Error compressing database"
+msgstr "Chyba pri komprimácii databázy"
+
+#: id:333
+msgid "Do you want to clean the library?"
+msgstr "Chcete vyčistiť knižnicu?"
+
+#: id:334
+msgid "Clean library..."
+msgstr "Čistenie knižnice..."
+
+#: id:335
+msgid "Start"
+msgstr "Štart"
+
+#: id:336
+msgid "Framerate conversion"
+msgstr "Konverzia snímkovania"
+
+#: id:337
+msgctxt "Auto context with id 337"
+msgid "Audio output"
+msgstr "Audio výstup"
+
+#: id:338
+msgid "Analog"
+msgstr "Analógový"
+
+#: id:339
+msgid "Optical/Coax"
+msgstr "Digitálny"
+
+#: id:340
+msgid "Various artists"
+msgstr "Rôzny interpréti"
+
+#: id:341
+msgid "Play disc"
+msgstr "CD/DVD"
+
+#: id:342
+msgctxt "Auto context with id 342"
+msgid "Movies"
+msgstr "Filmy"
+
+#: id:343
+msgid "Adjust framerate"
+msgstr "Prispôsobenie snímkovania"
+
+#: id:344
+msgid "Actors"
+msgstr "Herec"
+
+#: id:345
+msgctxt "Auto context with id 345"
+msgid "Year"
+msgstr "Rok"
+
+#: id:346
+msgid "Boost volume level on downmix"
+msgstr "Zvyšovať hlasitosť pri downmixe"
+
+#: id:350
+msgctxt "Auto context with id 350"
+msgid "Programs"
+msgstr "Programy"
+
+#: id:351
+msgctxt "Auto context with id 351"
+msgid "Off"
+msgstr "Vypnúť"
+
+#: id:352
+msgid "Dim"
+msgstr "Zahmliť"
+
+#: id:353
+msgid "Black"
+msgstr "Čierna"
+
+#: id:354
+msgid "Matrix trails"
+msgstr "Matrix Trails"
+
+#: id:355
+msgid "Screensaver time"
+msgstr "Čas nečinnosti pre šetrič obrazovky"
+
+#: id:356
+msgid "Screensaver mode"
+msgstr "Šetrič obrazovky"
+
+#: id:357
+msgid "Shutdown function timer"
+msgstr "Čas nečinnosti pre vypnutie"
+
+#: id:358
+msgid "All albums"
+msgstr "Všetky albumy"
+
+#: id:359
+msgid "Recently added albums"
+msgstr "Nedávno pridané albumy"
+
+#: id:360
+msgctxt "Auto context with id 360"
+msgid "Screensaver"
+msgstr "Šetrič obrazovky"
+
+#: id:361
+msgid "R. Slideshow"
+msgstr "Ceľková prezentácia"
+
+#: id:362
+msgid "Screensaver dim level"
+msgstr "Hladina blednutia šetriča obrazovky"
+
+#: id:363
+msgid "Sort by: File"
+msgstr "Usporiadať: Súbor"
+
+#: id:364
+msgid "- Dolby Digital (AC3) capable receiver"
+msgstr "- Dolby Digital (AC3) kompatibilný reciever"
+
+#: id:365
+msgctxt "Auto context with id 365"
+msgid "Sort by: Name"
+msgstr "Usporiadať: Názov"
+
+#: id:366
+msgid "Sort by: Year"
+msgstr "Usporiadať: Rok"
+
+#: id:367
+msgid "Sort by: Rating"
+msgstr "Usporiadať: Hodnotenie"
+
+#: id:368
+msgid "IMDb"
+msgstr "IMDb"
+
+#: id:369
+msgctxt "Auto context with id 369"
+msgid "Title"
+msgstr "Názov"
+
+#: id:370
+msgid "Thunderstorms"
+msgstr "búrka"
+
+#: id:371
+msgid "Partly"
+msgstr "čiastočne"
+
+#: id:372
+msgid "Mostly"
+msgstr "prevažne"
+
+#: id:373
+msgid "Sunny"
+msgstr "slnečno"
+
+#: id:374
+msgid "Cloudy"
+msgstr "zamračene"
+
+#: id:375
+msgid "Snow"
+msgstr "sneženie"
+
+#: id:376
+msgid "Rain"
+msgstr "dážď"
+
+#: id:377
+msgid "Light"
+msgstr "slabý"
+
+#: id:378
+msgid "AM"
+msgstr "dop."
+
+#: id:379
+msgid "PM"
+msgstr "pop."
+
+#: id:380
+msgid "Showers"
+msgstr "prehánky"
+
+#: id:381
+msgid "Few"
+msgstr "občas"
+
+#: id:382
+msgid "Scattered"
+msgstr "premenlivé"
+
+#: id:383
+msgctxt "Auto context with id 383"
+msgid "Wind"
+msgstr "veterno"
+
+#: id:384
+msgid "Strong"
+msgstr "silný"
+
+#: id:385
+msgid "Fair"
+msgstr "pekne"
+
+#: id:386
+msgctxt "Auto context with id 386"
+msgid "Clear"
+msgstr "jasno"
+
+#: id:387
+msgid "Clouds"
+msgstr "oblačno"
+
+#: id:388
+msgid "Early"
+msgstr "ranné"
+
+#: id:389
+msgid "Shower"
+msgstr "prehánky"
+
+#: id:390
+msgid "Flurries"
+msgstr "veterno"
+
+#: id:391
+msgctxt "Auto context with id 391"
+msgid "Low"
+msgstr "min."
+
+#: id:392
+msgctxt "Auto context with id 392"
+msgid "Medium"
+msgstr "stred"
+
+#: id:393
+msgctxt "Auto context with id 393"
+msgid "High"
+msgstr "max."
+
+#: id:394
+msgid "Fog"
+msgstr "hmla"
+
+#: id:395
+msgid "Haze"
+msgstr "mrholenie"
+
+#: id:396
+msgid "Select location"
+msgstr "Vyberte miesto"
+
+#: id:397
+msgid "Refresh time"
+msgstr "Obnoviť po"
+
+#: id:398
+msgid "Temperature units"
+msgstr "Jednotky teploty"
+
+#: id:399
+msgid "Speed units"
+msgstr "Jednotky rýchlosti"
+
+#: id:400
+msgctxt "Auto context with id 400"
+msgid "Weather"
+msgstr "Počasie"
+
+#: id:401
+msgid "Temp"
+msgstr "Teplota"
+
+#: id:402
+msgid "Feels like"
+msgstr "Ovzdušie"
+
+#: id:403
+msgid "UV index"
+msgstr "UV Index"
+
+#: id:404
+msgctxt "Auto context with id 404"
+msgid "Wind"
+msgstr "Vietor"
+
+#: id:405
+msgid "Dew point"
+msgstr "Rosný bod"
+
+#: id:406
+msgid "Humidity"
+msgstr "Vlhkosť"
+
+#: id:409
+msgid "Defaults"
+msgstr "Predvolené"
+
+#: id:410
+msgid "Accessing weather service"
+msgstr "Pristupujem k weather.com"
+
+#: id:411
+msgid "Getting weather for:"
+msgstr "Čítam počasie pre:"
+
+#: id:412
+msgid "Unable to get weather data"
+msgstr "Nie je možné načítať dáta pre počasie"
+
+#: id:413
+msgid "Manual"
+msgstr "Manuálne"
+
+#: id:414
+msgid "No review for this album"
+msgstr "Pre tento album nie je žiadna recenzia"
+
+#: id:415
+msgid "Downloading thumbnail..."
+msgstr "Sťahujem náhľad..."
+
+#: id:416
+msgid "Not available"
+msgstr "Nie je prístupné"
+
+#: id:417
+msgid "View: Big icons"
+msgstr "Zobrazenie: Veľké ikony"
+
+#: id:418
+msgctxt "Auto context with id 418"
+msgid "Low"
+msgstr "Povoliť knižnicu"
+
+#: id:419
+msgctxt "Auto context with id 419"
+msgid "High"
+msgstr "Vysoké"
+
+#: id:420
+msgid "HDMI"
+msgstr "HDMI"
+
+#: id:422
+msgid "Delete album info"
+msgstr "Odstrániť informácie o albume"
+
+#: id:423
+msgid "Delete CD information"
+msgstr "Odstrániť CDDB info"
+
+#: id:424
+msgid "Select"
+msgstr "Vybrať"
+
+#: id:425
+msgid "No album information found"
+msgstr "Neboli nájdené informácie pre album."
+
+#: id:426
+msgid "No CD information found"
+msgstr "Nebolo nájdené CDDB informácie."
+
+#: id:427
+msgid "Disc"
+msgstr "Disk"
+
+#: id:428
+msgid "Insert correct CD/DVD"
+msgstr "Vložte správne CD/DVD"
+
+#: id:429
+msgid "Please insert the following disc:"
+msgstr "Prosím vložte ďalšie CD/DVD"
+
+#: id:430
+msgid "Sort by: DVD#"
+msgstr "Usporiadať: DVD#"
+
+#: id:431
+msgid "No cache"
+msgstr "Žiadna medzipamäť"
+
+#: id:432
+msgid "Remove movie from library"
+msgstr "Odstrániť film z knižnice"
+
+#: id:433
+msgid "Really remove '%s'?"
+msgstr "Naozaj odstrániť '%s'?"
+
+#: id:434
+msgid "From %s at %i %s"
+msgstr "Z %s rychlosti %i %s"
+
+#: id:437
+msgid "Removable disk"
+msgstr "Externý disk"
+
+#: id:438
+msgid "Opening file"
+msgstr "Otváranie súboru"
+
+#: id:439
+msgid "Cache"
+msgstr "Medzipamäť"
+
+#: id:440
+msgid "Harddisk"
+msgstr "Harddisk"
+
+#: id:441
+msgid "UDF"
+msgstr "UDF"
+
+#: id:442
+msgid "Local network"
+msgstr "LAN"
+
+#: id:443
+msgid "Internet"
+msgstr "Internet"
+
+#: id:444
+msgctxt "Auto context with id 444"
+msgid "Video"
+msgstr "Video"
+
+#: id:445
+msgctxt "Auto context with id 445"
+msgid "Audio"
+msgstr "Audio"
+
+#: id:446
+msgctxt "Auto context with id 446"
+msgid "DVD"
+msgstr "DVD"
+
+#: id:447
+msgid "Autorun media"
+msgstr "Automatické spustenie"
+
+#: id:448
+msgid "LCD"
+msgstr "LCD"
+
+#: id:449
+msgctxt "Auto context with id 449"
+msgid "Enabled"
+msgstr "Povolené"
+
+#: id:450
+msgid "Columns"
+msgstr "Stĺpcov"
+
+#: id:451
+msgid "Row 1 address"
+msgstr "Adresa riadku 1"
+
+#: id:452
+msgid "Row 2 address"
+msgstr "Adresa riadku 2"
+
+#: id:453
+msgid "Row 3 address"
+msgstr "Adresa riadku 3"
+
+#: id:454
+msgid "Row 4 address"
+msgstr "Adresa riadku 4"
+
+#: id:455
+msgid "Rows"
+msgstr "Riadky"
+
+#: id:456
+msgid "Mode"
+msgstr "Mód"
+
+#: id:457
+msgid "Switch view"
+msgstr "Prepnúť zobrazenie"
+
+#: id:459
+msgid "Subs"
+msgstr "Titulky"
+
+#: id:460
+msgid "Audio stream"
+msgstr "Zvuková stopa"
+
+#: id:461
+msgid "[active]"
+msgstr "[aktívny]"
+
+#: id:462
+msgid "Subtitle"
+msgstr "Titulky"
+
+#: id:463
+msgid "Backlight"
+msgstr "Podsvietenie"
+
+#: id:464
+msgid "Brightness"
+msgstr "Jas"
+
+#: id:465
+msgid "Contrast"
+msgstr "Kontrast"
+
+#: id:466
+msgid "Gamma"
+msgstr "Gamma"
+
+#: id:467
+msgctxt "Auto context with id 467"
+msgid "Type"
+msgstr "Typ"
+
+#: id:468
+msgid "Move the bar to change the OSD position"
+msgstr "OSD pozíciu zmeníte posunom čiary"
+
+#: id:469
+msgid "OSD position"
+msgstr "Pozícia OSD"
+
+#: id:470
+msgid "Credits"
+msgstr "Autori"
+
+#: id:471
+msgid "Modchip"
+msgstr "Modčip"
+
+#: id:474
+msgctxt "Auto context with id 474"
+msgid "Off"
+msgstr "Vypnúť"
+
+#: id:475
+msgid "Music only"
+msgstr "Iba hudba"
+
+#: id:476
+msgctxt "Auto context with id 476"
+msgid "Music & video"
+msgstr "Hudba a Video"
+
+#: id:477
+msgid "Unable to load playlist"
+msgstr "Nedá sa otvoriť playlist"
+
+#: id:478
+msgid "OSD"
+msgstr "OSD"
+
+#: id:479
+msgid "Skin & language"
+msgstr "Vzhľad a jazyk"
+
+#: id:480
+msgid "Appearance"
+msgstr "Prostredie"
+
+#: id:481
+msgid "Audio options"
+msgstr "Nastavenia zvuk"
+
+#: id:482
+msgid "About XBMC"
+msgstr "O XBMC"
+
+#: id:485
+msgid "Delete album"
+msgstr "Odstrániť album"
+
+#: id:486
+msgid "Repeat"
+msgstr "Opakovať"
+
+#: id:487
+msgid "Repeat one"
+msgstr "Opakovať jeden"
+
+#: id:488
+msgid "Repeat folder"
+msgstr "Opakovať priečinok"
+
+#: id:489
+msgid "Play the next song automatically"
+msgstr "Automaticky prehrať ďalšiu skladbu"
+
+#: id:491
+msgid "- Use big icons"
+msgstr "- Použiť veľké ikony"
+
+#: id:492
+msgid "Resize VobSubs"
+msgstr "Velkosť vobsubs"
+
+#: id:493
+msgid "Advanced options (Experts Only!)"
+msgstr "Pokročilé nastavenia (iba expert!)"
+
+#: id:494
+msgid "Overall audio headroom"
+msgstr "Celková hlasitosť"
+
+#: id:495
+msgid "Upsample videos to GUI resolution"
+msgstr "Prepočítavať videa do rozlíšenia GUI"
+
+#: id:496
+msgid "Calibration"
+msgstr "Kalibrácia"
+
+#: id:497
+msgid "Show file extensions"
+msgstr "Schovať prípony médií"
+
+#: id:498
+msgid "Sort by: Type"
+msgstr "Usporiadať: Typ"
+
+#: id:499
+msgid "Unable to connect to online lookup service"
+msgstr "Nedá sa pripojiť k www.allmusic.com"
+
+#: id:500
+msgid "Downloading album information failed"
+msgstr "Sťahovanie informácií o albume zlyhalo"
+
+#: id:501
+msgid "Looking for album names..."
+msgstr "Hľadanie názvov albumov..."
+
+#: id:502
+msgctxt "Auto context with id 502"
+msgid "Open"
+msgstr "Otvoriť"
+
+#: id:503
+msgid "Busy"
+msgstr "Pracujem"
+
+#: id:504
+msgid "Empty"
+msgstr "Prázdny"
+
+#: id:505
+msgid "Loading media info from files..."
+msgstr "Načítanie informácií o médiu zo súborov..."
+
+#: id:507
+msgid "Sort by: Usage"
+msgstr "Usporiadať: Použitie"
+
+#: id:510
+msgid "Enable visualizations"
+msgstr "Povoliť vizualizácie"
+
+#: id:511
+msgid "Enable video mode switching"
+msgstr "Povoliť zmenu video módu"
+
+#: id:512
+msgid "Startup window"
+msgstr "Úvodné okno"
+
+#: id:513
+msgid "Home window"
+msgstr "Domáce okno"
+
+#: id:514
+msgid "Manual settings"
+msgstr "Manuálne nastavenia"
+
+#: id:515
+msgid "Genre"
+msgstr "Žáner"
+
+#: id:517
+msgid "Recently played albums"
+msgstr "Nedávno prehrávané albumy"
+
+#: id:518
+msgid "Launch"
+msgstr "Spustiť"
+
+#: id:519
+msgid "Launch in..."
+msgstr "Spustiť..."
+
+#: id:521
+msgid "Compilations"
+msgstr "Kompilácie"
+
+#: id:522
+msgid "Remove source"
+msgstr "Odstrániť zdroj"
+
+#: id:523
+msgid "Switch media"
+msgstr "Zmena média"
+
+#: id:524
+msgid "Select playlist"
+msgstr "Vybrať playlist"
+
+#: id:525
+msgid "New playlist..."
+msgstr "Nový playlist..."
+
+#: id:526
+msgid "Add to playlist"
+msgstr "Pridať do playlist-u"
+
+#: id:527
+msgid "Manually add to library"
+msgstr "Manuálne pridať do knižnice"
+
+#: id:528
+msgid "Enter title"
+msgstr "Napíšte názov"
+
+#: id:529
+msgid "Error: Duplicate title"
+msgstr "Chyba: Duplicitný názov"
+
+#: id:530
+msgid "Select genre"
+msgstr "Vybrať žáner"
+
+#: id:531
+msgid "New genre"
+msgstr "Nový žáner"
+
+#: id:532
+msgid "Manual addition"
+msgstr "Manuálne pridanie"
+
+#: id:533
+msgid "Enter genre"
+msgstr "Vložiť žáner"
+
+#: id:534
+msgid "View: %s"
+msgstr "Zobrazenie: %s"
+
+#: id:535
+msgid "List"
+msgstr "Zoznam"
+
+#: id:536
+msgid "Icons"
+msgstr "Ikony"
+
+#: id:537
+msgid "Big list"
+msgstr "Veľký zoznam"
+
+#: id:538
+msgid "Big icons"
+msgstr "Veľké ikony"
+
+#: id:539
+msgid "Wide"
+msgstr "Široký"
+
+#: id:540
+msgid "Big wide"
+msgstr "Veľmi široký"
+
+#: id:541
+msgid "Album icons"
+msgstr "Ikony albumov"
+
+#: id:542
+msgid "DVD icons"
+msgstr "Ikony DVD"
+
+#: id:543
+msgctxt "Auto context with id 543"
+msgid "DVD"
+msgstr "DVD"
+
+#: id:544
+msgctxt "Auto context with id 544"
+msgid "Media info"
+msgstr "Info o médiu"
+
+#: id:545
+msgid "Audio output device"
+msgstr "Zariadenie pre výstup zvuku"
+
+#: id:546
+msgid "Passthrough output device"
+msgstr "Zariadenie pre prestup zvuku"
+
+#: id:547
+msgid "No biography for this artist"
+msgstr "Životopis pre tohoto interpréta nie je dostupný"
+
+#: id:548
+msgid "Downmix multichannel audio to stereo"
+msgstr "Prevádzať viackanálový zvuk na stereo"
+
+#: id:550
+msgid "Sort by: %s"
+msgstr "Usporiadať: %s"
+
+#: id:551
+msgctxt "Auto context with id 551"
+msgid "Name"
+msgstr "Názov"
+
+#: id:552
+msgid "Date"
+msgstr "Dátum"
+
+#: id:553
+msgid "Size"
+msgstr "Veľkosť"
+
+#: id:554
+msgid "Track"
+msgstr "Stopa"
+
+#: id:555
+msgid "Time"
+msgstr "Čas"
+
+#: id:556
+msgctxt "Auto context with id 556"
+msgid "Title"
+msgstr "Názov"
+
+#: id:557
+msgid "Artist"
+msgstr "Interprét"
+
+#: id:558
+msgid "Album"
+msgstr "Album"
+
+#: id:559
+msgid "Playlist"
+msgstr "Playlist"
+
+#: id:560
+msgid "ID"
+msgstr "ID"
+
+#: id:561
+msgctxt "Auto context with id 561"
+msgid "File"
+msgstr "Súbor"
+
+#: id:562
+msgctxt "Auto context with id 562"
+msgid "Year"
+msgstr "Rok"
+
+#: id:563
+msgid "Rating"
+msgstr "Hodnotenie"
+
+#: id:564
+msgctxt "Auto context with id 564"
+msgid "Type"
+msgstr "Typ"
+
+#: id:565
+msgid "Usage"
+msgstr "Použitie"
+
+#: id:566
+msgid "Album artist"
+msgstr "Autor albumu"
+
+#: id:567
+msgid "Play count"
+msgstr "Počet prehraní"
+
+#: id:568
+msgid "Last played"
+msgstr "Poslednéhé prehranie"
+
+#: id:569
+msgctxt "Auto context with id 569"
+msgid "Comment"
+msgstr "Komentár"
+
+#: id:570
+msgid "Date added"
+msgstr "Dátum pridania"
+
+#: id:571
+msgctxt "Auto context with id 571"
+msgid "Default"
+msgstr "Predvolené"
+
+#: id:572
+msgid "Studio"
+msgstr "Štúdio"
+
+#: id:573
+msgid "Path"
+msgstr "Cesta"
+
+#: id:574
+msgctxt "Auto context with id 574"
+msgid "Country"
+msgstr "Krajina"
+
+#: id:575
+msgid "In progress"
+msgstr "Práve prebieha"
+
+#: id:576
+msgid "Times played"
+msgstr "Krát hrané"
+
+#: id:580
+msgid "Sort direction"
+msgstr "Smer usporiadania"
+
+#: id:581
+msgid "Sort method"
+msgstr "Spôsob usporiadania"
+
+#: id:582
+msgctxt "Auto context with id 582"
+msgid "View mode"
+msgstr "Mód zobrazenia"
+
+#: id:583
+msgid "Remember views for different folders"
+msgstr "Pamätať si zobrazenie pre každý priečinok"
+
+#: id:584
+msgid "Ascending"
+msgstr "Stúpajúci"
+
+#: id:585
+msgid "Descending"
+msgstr "Klesajúci"
+
+#: id:586
+msgid "Edit playlist"
+msgstr "Upraviť playlist"
+
+#: id:587
+msgid "Filter"
+msgstr "Filter"
+
+#: id:588
+msgid "Cancel party mode"
+msgstr "Zrušiť párty mód"
+
+#: id:589
+msgid "Party mode"
+msgstr "Párty mód"
+
+#: id:590
+msgid "Random"
+msgstr "Náhodne"
+
+#: id:591
+msgctxt "Auto context with id 591"
+msgid "Off"
+msgstr "Vypnuté"
+
+#: id:592
+msgid "One"
+msgstr "Jeden"
+
+#: id:593
+msgid "All"
+msgstr "Všetky"
+
+#: id:594
+msgctxt "Auto context with id 594"
+msgid "Off"
+msgstr "Vypnuté"
+
+#: id:595
+msgid "Repeat: Off"
+msgstr "Opakovať: Vypnuté"
+
+#: id:596
+msgid "Repeat: One"
+msgstr "Opakovať: Jedno"
+
+#: id:597
+msgid "Repeat: All"
+msgstr "Opakovať: Všetko"
+
+#: id:600
+msgid "Rip audio CD"
+msgstr "Stiahnuť audio CD"
+
+#: id:601
+msgctxt "Auto context with id 601"
+msgid "Medium"
+msgstr "Stredná"
+
+#: id:602
+msgctxt "Auto context with id 602"
+msgid "Standard"
+msgstr "Štandardná"
+
+#: id:603
+msgid "Extreme"
+msgstr "Extrémna"
+
+#: id:604
+msgid "Constant bitrate"
+msgstr "Konštantný datový tok"
+
+#: id:605
+msgid "Ripping..."
+msgstr "Sťahujem..."
+
+#: id:607
+msgid "To:"
+msgstr "Do:"
+
+#: id:608
+msgid "Could not rip CD or track"
+msgstr "Nie je možné stiahnuť CD alebo stopu"
+
+#: id:609
+msgid "CDDARipPath is not set."
+msgstr "CDDA cesta nie je nastavená."
+
+#: id:610
+msgid "Rip audio track"
+msgstr "Stiahnuť audio stopu"
+
+#: id:611
+msgid "Enter number"
+msgstr "Zadaj číslo"
+
+#: id:612
+msgid "Bits/Sample"
+msgstr "Bitov/Vzorka"
+
+#: id:613
+msgid "Sample Frequency"
+msgstr "Vzorkovacia frekvencia"
+
+#: id:620
+msgid "Audio CDs"
+msgstr "CD sťahovanie"
+
+#: id:621
+msgid "Encoder"
+msgstr "Enkodér"
+
+#: id:622
+msgid "Quality"
+msgstr "Kvalita"
+
+#: id:623
+msgid "Bitrate"
+msgstr "Datový tok"
+
+#: id:624
+msgid "Include track number"
+msgstr "Zahrnúť číslo stopy"
+
+#: id:625
+msgid "All songs of"
+msgstr "Všetky skladby od"
+
+#: id:629
+msgctxt "Auto context with id 629"
+msgid "View mode"
+msgstr "Režim obrazu"
+
+#: id:630
+msgctxt "Auto context with id 630"
+msgid "Normal"
+msgstr "Normálne"
+
+#: id:631
+msgid "Zoom"
+msgstr "Zväčšiť"
+
+#: id:632
+msgid "Stretch 4:3"
+msgstr "Natiahnuť 4:3"
+
+#: id:633
+msgid "Wide Zoom"
+msgstr "Natiahnuť 14:9"
+
+#: id:634
+msgid "Stretch 16:9"
+msgstr "Natiahnuť 16:9"
+
+#: id:635
+msgid "Original Size"
+msgstr "Pôvodná veľkosť"
+
+#: id:636
+msgctxt "Auto context with id 636"
+msgid "Custom"
+msgstr "Vlastný"
+
+#: id:637
+msgid "Replay gain"
+msgstr "Úprava zosilnenia"
+
+#: id:638
+msgid "Replaygain volume adjustments"
+msgstr "Spôsob úpravy zosilnenia"
+
+#: id:639
+msgid "Use track levels"
+msgstr "Používať úroveň stopy"
+
+#: id:640
+msgid "Use album levels"
+msgstr "Používať úroveň albumu"
+
+#: id:641
+msgid "PreAmp Level - Replay gained files"
+msgstr "Úroveň predzosilenia - Súbory s úpravou zosilnenia"
+
+#: id:642
+msgid "PreAmp Level - Non replay gained files"
+msgstr "Úroveň predzosilenia - Súbory bez úpravy zosilnenia"
+
+#: id:643
+msgid "Avoid clipping on replay gained files"
+msgstr "Zakázať odrezanie pri súboroch s úpravou zosilnenia"
+
+#: id:644
+msgid "Crop black bars"
+msgstr "Orezať čierne okraje"
+
+#: id:645
+msgid "Need to unpack a big file. Continue?"
+msgstr "Treba rozbaliť veľký súbor. Pokračovať?"
+
+#: id:646
+msgid "Remove from library"
+msgstr "Odstrániť z knižnice"
+
+#: id:647
+msgid "Export video library"
+msgstr "Export video knižnice"
+
+#: id:648
+msgid "Import video library"
+msgstr "Import video knižnice"
+
+#: id:649
+msgid "Importing"
+msgstr "Prebieha import"
+
+#: id:650
+msgid "Exporting"
+msgstr "Prebieha export"
+
+#: id:651
+msgid "Browse for library"
+msgstr "Vybrať knižnicu"
+
+#: id:652
+msgid "Years"
+msgstr "Rok"
+
+#: id:653
+msgid "Update library"
+msgstr "Aktualizácia knižnice"
+
+#: id:654
+msgid "Show debug info"
+msgstr "Zobraziť ladiace informácie"
+
+#: id:655
+msgid "Browse for executable"
+msgstr "Vybrať spúšťací súbor"
+
+#: id:656
+msgid "Browse for playlist"
+msgstr "Vybrať playlist"
+
+#: id:657
+msgid "Browse for folder"
+msgstr "Vybrať priečinok"
+
+#: id:658
+msgid "Song information"
+msgstr "Informácie o skladbe"
+
+#: id:659
+msgid "Non-linear stretch"
+msgstr "Nelineárne roztiahnutie"
+
+#: id:660
+msgid "Volume amplification"
+msgstr "Zosilnenie hlasitosti"
+
+#: id:661
+msgid "Choose export folder"
+msgstr "Vyberte priečinok pre export"
+
+#: id:662
+msgid "This file is no longer available."
+msgstr "Súbor už nieje dostupný."
+
+#: id:663
+msgid "Would you like to remove it from the library?"
+msgstr "Želáte si ho odstrániť z knižnice?"
+
+#: id:664
+msgid "Browse for Script"
+msgstr "Vyberte Skript"
+
+#: id:665
+msgid "Compression level"
+msgstr "Úroveň kompresie"
+
+#: id:700
+msgid "Cleaning up library"
+msgstr "Vyčistiť knižnicu"
+
+#: id:701
+msgid "Removing old songs from the library"
+msgstr "Odstraňujem staré skladby z knižnice"
+
+#: id:702
+msgid "This path has been scanned before"
+msgstr "Táto cesta bola už skenovaná"
+
+#: id:705
+msgctxt "Auto context with id 705"
+msgid "Network"
+msgstr "Sieť"
+
+#: id:706
+msgid "- Server"
+msgstr "- Server"
+
+#: id:708
+msgid "Use an HTTP proxy server to access the internet"
+msgstr "Použiť HTTP proxy server pre prístup na internet"
+
+#: id:711
+msgid "Internet Protocol (IP)"
+msgstr "Internet protokol (IP)"
+
+#: id:712
+msgid "Invalid port specified. Value must be between 1 and 65535."
+msgstr "Nesprávny port. Hodnota musí byť medzi 1 a 65535."
+
+#: id:713
+msgid "HTTP proxy"
+msgstr "HTTP Proxy"
+
+#: id:715
+msgid "- Assignment"
+msgstr "Priradenie"
+
+#: id:716
+msgid "Automatic (DHCP)"
+msgstr "Automatický (DHCP)"
+
+#: id:717
+msgid "Manual (Static)"
+msgstr "Manuálne (Statický)"
+
+#: id:719
+msgid "- IP address"
+msgstr "- IP Adresa"
+
+#: id:720
+msgid "- Netmask"
+msgstr "- Sieťová maska"
+
+#: id:721
+msgid "- Default gateway"
+msgstr "- Predvolená brána"
+
+#: id:722
+msgid "- DNS server"
+msgstr "- DNS server"
+
+#: id:723
+msgid "Save & restart"
+msgstr "Uložiť a reštartovať"
+
+#: id:724
+msgid "Invalid address specified. Value must be AAA.BBB.CCC.DDD"
+msgstr "Nesprávna adresa. Hodnota musí byť AAA.BBB.CCC.DDD"
+
+#: id:725
+msgid "with numbers between 0 and 255."
+msgstr "s číslami v rozsahu 0 a 255."
+
+#: id:726
+msgid "Changes not saved. Continue without saving?"
+msgstr "Zmeny neboli uložené. Pokračovať bez uloženia?"
+
+#: id:727
+msgid "Web server"
+msgstr "Web server"
+
+#: id:728
+msgctxt "Auto context with id 728"
+msgid "FTP server"
+msgstr "FTP server"
+
+#: id:730
+msgid "- Port"
+msgstr "- Port"
+
+#: id:732
+msgid "Save & apply"
+msgstr "Uložiť a použiť"
+
+#: id:733
+msgid "- Password"
+msgstr "- Heslo"
+
+#: id:734
+msgid "No pass"
+msgstr "Žiadne heslo"
+
+#: id:735
+msgid "- Character set"
+msgstr "- Písmo"
+
+#: id:736
+msgid "- Style"
+msgstr "- Štýl"
+
+#: id:737
+msgid "- Colour"
+msgstr "- Farba"
+
+#: id:738
+msgctxt "Auto context with id 738"
+msgid "Normal"
+msgstr "Obyčajné"
+
+#: id:739
+msgid "Bold"
+msgstr "Tučné"
+
+#: id:740
+msgid "Italics"
+msgstr "Kurzíva"
+
+#: id:741
+msgid "Bold italics"
+msgstr "Tučné kurzíva"
+
+#: id:742
+msgctxt "Auto context with id 742"
+msgid "White"
+msgstr "Biele"
+
+#: id:743
+msgctxt "Auto context with id 743"
+msgid "Yellow"
+msgstr "Žlté"
+
+#: id:744
+msgctxt "Auto context with id 744"
+msgid "Files"
+msgstr "Súbory"
+
+#: id:745
+msgid "No scanned information for this view"
+msgstr "Žiadna zoskenovaná informácia pre toto zobrazenie"
+
+#: id:746
+msgid "Please turn off library mode"
+msgstr "Prepnúť do súborového zobrazenia"
+
+#: id:747
+msgid "Error loading image"
+msgstr "Chyba pri načítaní obrázku"
+
+#: id:748
+msgid "Edit path"
+msgstr "Upraviť cestu"
+
+#: id:749
+msgid "Mirror image"
+msgstr "Otočiť"
+
+#: id:750
+msgid "Are you sure?"
+msgstr "Ste si istý?"
+
+#: id:751
+msgid "Removing source"
+msgstr "Odstraňovanie zdroju"
+
+#: id:754
+msgid "Add program link"
+msgstr "Pridať zástupcu programu"
+
+#: id:755
+msgid "Edit program path"
+msgstr "Upraviť cestu programu"
+
+#: id:756
+msgid "Edit program name"
+msgstr "Upraviť názov programu"
+
+#: id:757
+msgid "Edit path depth"
+msgstr "Upraviť hĺbku pre cestu"
+
+#: id:759
+msgid "View: Big list"
+msgstr "Zobrazenie: Veľké ikony"
+
+#: id:760
+msgctxt "Auto context with id 760"
+msgid "Yellow"
+msgstr "Žltá"
+
+#: id:761
+msgctxt "Auto context with id 761"
+msgid "White"
+msgstr "Biela"
+
+#: id:762
+msgid "Blue"
+msgstr "Modrá"
+
+#: id:763
+msgid "Bright green"
+msgstr "Svetlozelená"
+
+#: id:764
+msgid "Yellow green"
+msgstr "Žltozelená"
+
+#: id:765
+msgid "Cyan"
+msgstr "Ružová"
+
+#: id:766
+msgid "Light grey"
+msgstr "Rezervované"
+
+#: id:767
+msgid "Grey"
+msgstr "Rezervované"
+
+#: id:770
+msgid "Error %i: share not available"
+msgstr "Chyba %i: zdieľanie nie je prístupné"
+
+#: id:772
+msgctxt "Auto context with id 772"
+msgid "Audio output"
+msgstr "Audio zariadenie"
+
+#: id:773
+msgid "Seeking"
+msgstr "Vyhľadávam"
+
+#: id:774
+msgid "Slideshow folder"
+msgstr "Priečinok prezentácie"
+
+#: id:775
+msgid "Network interface"
+msgstr "Sieťové rozhranie"
+
+#: id:776
+msgid "- Wireless network name (ESSID)"
+msgstr "- Názov bezdrôtovej siete (ESSID)"
+
+#: id:777
+msgid "- Wireless password"
+msgstr "- Heslo bezdrôtovej siete"
+
+#: id:778
+msgid "- Wireless security"
+msgstr "- Bezpečnost bezdrôtovej siete"
+
+#: id:779
+msgid "Save and apply network interface settings"
+msgstr "Uložiť a použiť nastavenie siete"
+
+#: id:780
+msgid "No encryption"
+msgstr "Bez šifrovania"
+
+#: id:781
+msgid "WEP"
+msgstr "WEP"
+
+#: id:782
+msgid "WPA"
+msgstr "WPA"
+
+#: id:783
+msgid "WPA2"
+msgstr "WPA2"
+
+#: id:784
+msgid "Applying network interface settings. Please wait."
+msgstr "Prebieha použitie zmien nastavenia siete. Počkajte prosím."
+
+#: id:785
+msgid "Network interface restarted successfully."
+msgstr "Reštart sieťového rozhrania bol úspešný."
+
+#: id:786
+msgid "Network interface did not start successfully."
+msgstr "Štart sieťového rozhrania bol neúspešný."
+
+#: id:787
+msgid "Interface disabled"
+msgstr "Rozhranie zakázané"
+
+#: id:788
+msgid "Network interface disabled successfully."
+msgstr "Sieťové rozhranie bolo zakázané."
+
+#: id:789
+msgid "Wireless network name (ESSID)"
+msgstr "Názov bezdrôtovej siete (ESSID)"
+
+#: id:790
+msgid "Remote control"
+msgstr ""
+
+#: id:791
+msgid "Allow programs on this system to control XBMC"
+msgstr "Povoliť ovládanie XBMC aplikáciami na tomto systéme"
+
+#: id:792
+msgctxt "Auto context with id 792"
+msgid "Port"
+msgstr "Port"
+
+#: id:793
+msgid "Port range"
+msgstr "Rozsah portov"
+
+#: id:794
+msgid "Allow programs on other systems to control XBMC"
+msgstr "Povoliť ovládanie XBMC aplikáciami z iného systému"
+
+#: id:795
+msgid "Initial repeat delay (ms)"
+msgstr "Oneskorenie odozvy pre prvý stisk (ms)"
+
+#: id:796
+msgid "Continuous repeat delay (ms)"
+msgstr "Oneskorenie odozvy pre dlhý stisk (ms)"
+
+#: id:797
+msgid "Maximum number of clients"
+msgstr "Maximálny počet klientov"
+
+#: id:798
+msgid "Internet access"
+msgstr "Internetový prístup"
+
+#: id:850
+msgid "Invalid port number entered"
+msgstr "Bolo zadané nesprávne číslo portu"
+
+#: id:851
+msgid "Valid port range is 1-65535"
+msgstr "Povolený rozsah portu je 1-65535"
+
+#: id:852
+msgid "Valid port range is 1024-65535"
+msgstr "Povolený rozsah portu je 1024-65535"
+
+#: id:998
+msgid "Add Music..."
+msgstr "Pridať Hudbu..."
+
+#: id:999
+msgid "Add Videos..."
+msgstr "Pridať Videá..."
+
+#: id:1000
+msgid "- Preview"
+msgstr "Ukážka šetriča obrazovky"
+
+#: id:1001
+msgid "Unable to connect"
+msgstr "Nedá sa pripojiť"
+
+#: id:1002
+msgid "XBMC was unable to connect to the network location."
+msgstr "XBMC sa nemohol pripojiť na sieťové miesto."
+
+#: id:1003
+msgid "This could be due to the network not being connected."
+msgstr "Toto môže byť kvôli nedostupnosti siete."
+
+#: id:1004
+msgid "Would you like to add it anyway?"
+msgstr "Radi by ste to aj tak pridali?"
+
+#: id:1006
+msgctxt "Auto context with id 1006"
+msgid "IP address"
+msgstr "IP adresa"
+
+#: id:1007
+msgid "Add network location"
+msgstr "Pridať sieťové miesto"
+
+#: id:1008
+msgid "Protocol"
+msgstr "Protokol"
+
+#: id:1009
+msgid "Server address"
+msgstr "Adresa servera"
+
+#: id:1010
+msgid "Server name"
+msgstr "Názov servera"
+
+#: id:1011
+msgid "Remote path"
+msgstr "Vzdialená cesta"
+
+#: id:1012
+msgid "Shared folder"
+msgstr "Zdieľaný priečinok"
+
+#: id:1013
+msgctxt "Auto context with id 1013"
+msgid "Port"
+msgstr "Port"
+
+#: id:1014
+msgctxt "Auto context with id 1014"
+msgid "Username"
+msgstr "Meno"
+
+#: id:1015
+msgid "Browse for network server"
+msgstr "Vybrať sieťový server"
+
+#: id:1016
+msgid "Enter the network address of the server"
+msgstr "Napíšte sieťovú adresu servera"
+
+#: id:1017
+msgid "Enter the path on the server"
+msgstr "Napíšte cestu na serveri"
+
+#: id:1018
+msgid "Enter the port number"
+msgstr "Napíšte číslo portu"
+
+#: id:1019
+msgid "Enter the username"
+msgstr "Napíšte meno"
+
+#: id:1020
+msgid "Add %s source"
+msgstr "Pridať %s zdroj"
+
+#: id:1021
+msgid "Enter the paths or browse for the media locations."
+msgstr "Vložte cestu, alebo vyberte lokalitu média."
+
+#: id:1022
+msgid "Enter a name for this media Source."
+msgstr "Napíšte názov pre tento média zdroj."
+
+#: id:1023
+msgid "Browse for new share"
+msgstr "Vybrať nové zdieľanie"
+
+#: id:1024
+msgid "Browse"
+msgstr "Vybrať"
+
+#: id:1025
+msgid "Could not retrieve directory information."
+msgstr "Nie je možné načítať informácie priečinku."
+
+#: id:1026
+msgid "Add source"
+msgstr "Pridať zdroj"
+
+#: id:1027
+msgid "Edit source"
+msgstr "Upraviť zdroj"
+
+#: id:1028
+msgid "Edit %s source"
+msgstr "Upraviť %s zdroj"
+
+#: id:1029
+msgid "Enter the new label"
+msgstr "Napíšte nový názov"
+
+#: id:1030
+msgid "Browse for image"
+msgstr "Vybrať obrázok"
+
+#: id:1031
+msgid "Browse for image folder"
+msgstr "Vybrať priečinok s obrázkami"
+
+#: id:1032
+msgid "Add network location..."
+msgstr "Pridať sieťové miesto..."
+
+#: id:1033
+msgid "Browse for file"
+msgstr "Vybrať súbor"
+
+#: id:1034
+msgid "Submenu"
+msgstr "Podmenu"
+
+#: id:1035
+msgid "Enable submenu buttons"
+msgstr "Povoliť tlačítka podmenu"
+
+#: id:1036
+msgid "Favourites"
+msgstr "Obľúbené"
+
+#: id:1037
+msgid "Video Add-ons"
+msgstr "Doplnky - Video"
+
+#: id:1038
+msgid "Music Add-ons"
+msgstr "Doplnky - Hudba"
+
+#: id:1039
+msgid "Picture Add-ons"
+msgstr "Doplnky - Obrázky"
+
+#: id:1040
+msgid "Loading directory"
+msgstr "Prebieha načítanie priečinku"
+
+#: id:1041
+msgid "Retrieved %i items"
+msgstr "Načítaných %i položiek"
+
+#: id:1042
+msgid "Retrieved %i of %i items"
+msgstr "Načítaných %i z %i položiek"
+
+#: id:1043
+msgid "Program Add-ons"
+msgstr "Doplnky - Programy"
+
+#: id:1044
+msgid "Set plugin thumb"
+msgstr "Nastavenie náhľadu doplnku"
+
+#: id:1045
+msgid "Add-on settings"
+msgstr "Nastavenie doplnku"
+
+#: id:1046
+msgid "Access points"
+msgstr "Prístupové body (AP)"
+
+#: id:1047
+msgid "Other..."
+msgstr "Ostatné ..."
+
+#: id:1048
+msgid "- Username"
+msgstr "- Užívateľské meno"
+
+#: id:1049
+msgid "Script settings"
+msgstr "Nastavenia skriptu"
+
+#: id:1050
+msgid "Singles"
+msgstr "Single"
+
+#: id:1051
+msgid "Enter web address"
+msgstr "Zadajte webovú adresu"
+
+#: id:1200
+msgid "SMB client"
+msgstr "SMB klient"
+
+#: id:1202
+msgid "Workgroup"
+msgstr "Pracovná skupina"
+
+#: id:1203
+msgid "Default username"
+msgstr "Predvolené meno"
+
+#: id:1204
+msgid "Default password"
+msgstr "Predvolené heslo"
+
+#: id:1207
+msgid "WINS server"
+msgstr "WINS server"
+
+#: id:1208
+msgid "Mount SMB shares"
+msgstr "Pripojiť SMB zdieľané priečinky"
+
+#: id:1210
+msgctxt "Auto context with id 1210"
+msgid "Remove"
+msgstr "Odstrániť"
+
+#: id:1211
+msgctxt "Auto context with id 1211"
+msgid "Music"
+msgstr "Hudba"
+
+#: id:1212
+msgctxt "Auto context with id 1212"
+msgid "Video"
+msgstr "Video"
+
+#: id:1213
+msgctxt "Auto context with id 1213"
+msgid "Pictures"
+msgstr "Obrázky"
+
+#: id:1214
+msgctxt "Auto context with id 1214"
+msgid "Files"
+msgstr "Súbory"
+
+#: id:1215
+msgctxt "Auto context with id 1215"
+msgid "Music & video"
+msgstr "Hudba a Video"
+
+#: id:1216
+msgid "Music & pictures"
+msgstr "Hudba a Obrázky"
+
+#: id:1217
+msgid "Music & files"
+msgstr "Hudba a Súbory"
+
+#: id:1218
+msgid "Video & pictures"
+msgstr "Video a Obrázky"
+
+#: id:1219
+msgid "Video & files"
+msgstr "Video a Súbory"
+
+#: id:1220
+msgid "Pictures & files"
+msgstr "Obrázky a Súbory"
+
+#: id:1221
+msgid "Music & video & pictures"
+msgstr "Hudba a Video a Obrázky"
+
+#: id:1222
+msgid "Music & video & pictures & files"
+msgstr "Hudba a Video a Obrázky a Súbory"
+
+#: id:1223
+msgctxt "Auto context with id 1223"
+msgid "Disabled"
+msgstr "Zakázané"
+
+#: id:1226
+msgid "Files & music & video"
+msgstr "Súbory a Hudba a Video"
+
+#: id:1227
+msgid "Files & pictures & music"
+msgstr "Súbory a Obrázky a Hudba"
+
+#: id:1228
+msgid "Files & pictures & video"
+msgstr "Súbory a Obrázky a Video"
+
+#: id:1229
+msgid "Music & programs"
+msgstr "Hudba a Programy"
+
+#: id:1230
+msgid "Video & programs"
+msgstr "Video a Programy"
+
+#: id:1231
+msgid "Pictures & programs"
+msgstr "Obrázky a Programy"
+
+#: id:1232
+msgid "Music & video & pictures & programs"
+msgstr "Hudba a Video a Obrázky a Programy"
+
+#: id:1233
+msgid "Programs & video & music"
+msgstr "Programy a Video a Hudba"
+
+#: id:1234
+msgid "Programs & pictures & music"
+msgstr "Programy a Obrázky a Hudba"
+
+#: id:1235
+msgid "Programs & pictures & video"
+msgstr "Programy a Obrázky a Video"
+
+#: id:1250
+msgid "Auto-detection"
+msgstr "Autodetekcia"
+
+#: id:1251
+msgid "Auto-detect system"
+msgstr "Autodetekcia systému"
+
+#: id:1252
+msgid "Nickname"
+msgstr "Prezývka"
+
+#: id:1254
+msgid "Ask to connect"
+msgstr "Opýtať sa na pripojenie"
+
+#: id:1255
+msgid "Send FTP user and password"
+msgstr "Poslať FTP meno a heslo"
+
+#: id:1256
+msgid "Ping interval"
+msgstr "Ping interval"
+
+#: id:1257
+msgid "Would you like to connect to the auto-detected system?"
+msgstr "Chcete sa pripojiť na autodetekovaný system?"
+
+#: id:1259
+msgid "Zeroconf"
+msgstr ""
+
+#: id:1260
+msgid "Announce these services to other systems via Zeroconf"
+msgstr "Oznamovať tieto služby ďalším počítačom cez Zeroconf"
+
+#: id:1270
+msgid "Allow XBMC to receive AirPlay content"
+msgstr "Povoliť XBMC príjem AirPlay obsahu"
+
+#: id:1271
+msgid "Device name"
+msgstr "Názov zariadenia"
+
+#: id:1272
+msgid "- Use password protection"
+msgstr "- Použiť ochranu heslom"
+
+#: id:1273
+msgid "AirPlay"
+msgstr ""
+
+#: id:1300
+msgid "Custom audio device"
+msgstr "Vlastné zariadenie pre výstup audia"
+
+#: id:1301
+msgid "Custom passthrough device"
+msgstr "Vlastné zariadenie pre passthrough zvuku"
+
+#: id:1396
+msgid "Drifting"
+msgstr "ustupujúci"
+
+#: id:1397
+msgid "and"
+msgstr "a"
+
+#: id:1398
+msgid "Freezing"
+msgstr "mrznúci"
+
+#: id:1399
+msgid "Late"
+msgstr "neskôr"
+
+#: id:1400
+msgid "Isolated"
+msgstr "ojedinele"
+
+#: id:1401
+msgid "Thundershowers"
+msgstr "prehánky"
+
+#: id:1402
+msgid "Thunder"
+msgstr "búrky"
+
+#: id:1403
+msgctxt "Auto context with id 1403"
+msgid "Sun"
+msgstr "slnečno"
+
+#: id:1404
+msgid "Heavy"
+msgstr "zatiahnuté"
+
+#: id:1405
+msgid "in"
+msgstr "v"
+
+#: id:1406
+msgid "the"
+msgstr "blízkom"
+
+#: id:1407
+msgid "Vicinity"
+msgstr "okolí"
+
+#: id:1408
+msgid "Ice"
+msgstr "ľadové"
+
+#: id:1409
+msgid "Crystals"
+msgstr "krištáliky"
+
+#: id:1410
+msgid "Calm"
+msgstr "bezvetrie"
+
+#: id:1411
+msgid "with"
+msgstr "s"
+
+#: id:1412
+msgid "windy"
+msgstr "veterno"
+
+#: id:1413
+msgid "drizzle"
+msgstr "mrholenie"
+
+#: id:1414
+msgid "Thunderstorm"
+msgstr "silná búrka"
+
+#: id:1415
+msgid "Drizzle"
+msgstr "mrholenie"
+
+#: id:1416
+msgid "Foggy"
+msgstr "zahmlené"
+
+#: id:1417
+msgid "Grains"
+msgstr "Krupy"
+
+#: id:1418
+msgid "T-Storms"
+msgstr "Búrky"
+
+#: id:1419
+msgid "T-Showers"
+msgstr "Búrky s prehánkami"
+
+#: id:1420
+msgid "Moderate"
+msgstr "Stredné"
+
+#: id:1421
+msgid "Very High"
+msgstr "Velmi vysoké"
+
+#: id:1422
+msgid "Windy"
+msgstr "Veterno"
+
+#: id:1423
+msgid "Mist"
+msgstr "Hmla"
+
+#: id:1450
+msgid "Put display to sleep when idle"
+msgstr "Aktivovať úsporný režim pri nečinnosti"
+
+#: id:2050
+msgid "Runtime"
+msgstr "Dĺžka"
+
+#: id:2100
+msgid "Script failed! : %s"
+msgstr "Chyba skriptu! : %s"
+
+#: id:2101
+msgid "Newer version needed - See log"
+msgstr "Je vyžadovaná novšia verzia - Viac informácií v logu"
+
+#: id:4501
+msgid "Enable LCD/VFD"
+msgstr "Typ LCD"
+
+#: id:10000
+msgid "Home"
+msgstr "Domov"
+
+#: id:10001
+msgctxt "Auto context with id 10001"
+msgid "Programs"
+msgstr "Programy"
+
+#: id:10002
+msgctxt "Auto context with id 10002"
+msgid "Pictures"
+msgstr "Obrázky"
+
+#: id:10003
+msgctxt "Auto context with id 10003"
+msgid "File manager"
+msgstr "Správca súborov"
+
+#: id:10004
+msgctxt "Auto context with id 10004"
+msgid "Settings"
+msgstr "Nastavenie"
+
+#: id:10005
+msgctxt "Auto context with id 10005"
+msgid "Music"
+msgstr "Hudba"
+
+#: id:10006
+msgctxt "Auto context with id 10006"
+msgid "Videos"
+msgstr "Video"
+
+#: id:10007
+msgid "System information"
+msgstr "Systémové informácie"
+
+#: id:10008
+msgid "Settings - General"
+msgstr "Nastavenia - Hlavné"
+
+#: id:10009
+msgid "Settings - Screen"
+msgstr "Nastavenia - Obrazovky"
+
+#: id:10010
+msgid "Settings - Appearance - GUI Calibration"
+msgstr "Nastavenia - Zobrazenie - Kalibrácia GUI"
+
+#: id:10011
+msgid "Settings - Videos - Screen Calibration"
+msgstr "Nastavenia - Video - Kalibrácia obrazovky"
+
+#: id:10012
+msgid "Settings - Pictures"
+msgstr "Nastavenia - Obrázky"
+
+#: id:10013
+msgid "Settings - Programs"
+msgstr "Nastavenia - Programy"
+
+#: id:10014
+msgid "Settings - Weather"
+msgstr "Nastavenia - Počasie"
+
+#: id:10015
+msgid "Settings - Music"
+msgstr "Nastavenia - Hudba"
+
+#: id:10016
+msgid "Settings - System"
+msgstr "Nastavenia - Systém"
+
+#: id:10017
+msgid "Settings - Videos"
+msgstr "Nastavenia - Videá"
+
+#: id:10018
+msgid "Settings - Network"
+msgstr "Nastavenia - Sieť"
+
+#: id:10019
+msgid "Settings - Appearance"
+msgstr "Nastavenia - Zobrazenie"
+
+#: id:10020
+msgctxt "Auto context with id 10020"
+msgid "Scripts"
+msgstr "Skripty"
+
+#: id:10021
+msgid "Web Browser"
+msgstr "Webový prehliadač"
+
+#: id:10025
+msgctxt "Auto context with id 10025"
+msgid "Videos"
+msgstr ""
+
+#: id:10028
+msgid "Videos/Playlist"
+msgstr "Videá/Playlist"
+
+#: id:10029
+msgctxt "Auto context with id 10029"
+msgid "Login screen"
+msgstr ""
+
+#: id:10034
+msgid "Settings - Profiles"
+msgstr "Nastavenia - Profily"
+
+#: id:10040
+msgid "Addon browser"
+msgstr ""
+
+#: id:10100
+msgid "Yes/No dialog"
+msgstr "Áno/Nie dialog"
+
+#: id:10101
+msgid "Progress dialog"
+msgstr "Dialóg spracovania"
+
+#: id:10210
+msgid "Looking for subtitles..."
+msgstr "Prebieha vyhľadávanie titulkov..."
+
+#: id:10211
+msgid "Looking for or caching subtitles..."
+msgstr "Prebieha načítavanie titulkov..."
+
+#: id:10212
+msgid "terminating"
+msgstr "prerušenie"
+
+#: id:10213
+msgid "buffering"
+msgstr "načítanie do medzipamäte"
+
+#: id:10214
+msgid "Opening stream"
+msgstr "Otváranie streamu"
+
+#: id:10500
+msgid "Music/Playlist"
+msgstr "Hudba/Playlist"
+
+#: id:10501
+msgid "Music/Files"
+msgstr "Hudba/Súbory"
+
+#: id:10502
+msgid "Music/Library"
+msgstr "Hudba/Knižnica"
+
+#: id:10503
+msgid "Playlist editor"
+msgstr "Playlist editor"
+
+#: id:10504
+msgid "Top 100 songs"
+msgstr "Naj 100 skladieb"
+
+#: id:10505
+msgid "Top 100 albums"
+msgstr "Naj 100 Albumov"
+
+#: id:10506
+msgctxt "Auto context with id 10506"
+msgid "Programs"
+msgstr "Programy"
+
+#: id:10507
+msgid "Configuration"
+msgstr "Konfigurácia"
+
+#: id:10508
+msgid "Weather forecast"
+msgstr "Predpoveď počasia"
+
+#: id:10509
+msgid "Network gaming"
+msgstr "Hranie po sieti"
+
+#: id:10510
+msgid "Extensions"
+msgstr "Rozšírenia"
+
+#: id:10511
+msgctxt "Auto context with id 10511"
+msgid "System info"
+msgstr "Systémové informácie"
+
+#: id:10516
+msgid "Music - Library"
+msgstr "Hudba - Knižnica"
+
+#: id:10517
+msgid "Now Playing - Music"
+msgstr "Teraz hrá - Hudba"
+
+#: id:10522
+msgid "Now Playing - Videos"
+msgstr "Teraz hrá - Video"
+
+#: id:10523
+msgid "Album info"
+msgstr "Informácie o albume"
+
+#: id:10524
+msgid "Movie info"
+msgstr "Informácie o filme"
+
+#: id:12000
+msgid "Select dialog"
+msgstr "Výberový dialóg"
+
+#: id:12001
+msgid "Music/Info"
+msgstr "Hudba/Info"
+
+#: id:12002
+msgid "Dialog OK"
+msgstr "Dialóg OK"
+
+#: id:12003
+msgid "Videos/Info"
+msgstr "Video/Info"
+
+#: id:12004
+msgid "Scripts/Info"
+msgstr "Skripty/Info"
+
+#: id:12005
+msgid "Fullscreen video"
+msgstr "Video na celú obrazovku"
+
+#: id:12006
+msgid "Audio visualization"
+msgstr "Audio vizualizácie"
+
+#: id:12008
+msgid "File stacking dialog"
+msgstr "Dialóg pre súbory dokopy"
+
+#: id:12009
+msgid "Rebuild index..."
+msgstr "Prerábam index..."
+
+#: id:12010
+msgid "Return to music window"
+msgstr "Vrátiť sa do hudby"
+
+#: id:12011
+msgid "Return to videos window"
+msgstr "Vrátiť sa do videa"
+
+#: id:12021
+msgid "Start from beginning"
+msgstr "Štart od začiatku"
+
+#: id:12022
+msgid "Resume from %s"
+msgstr "Pokračovať od poslednej pozície"
+
+#: id:12310
+msgid "0"
+msgstr "0"
+
+#: id:12311
+msgid "1"
+msgstr "1"
+
+#: id:12312
+msgid "2"
+msgstr "2"
+
+#: id:12313
+msgid "3"
+msgstr "3"
+
+#: id:12314
+msgid "4"
+msgstr "4"
+
+#: id:12315
+msgid "5"
+msgstr "5"
+
+#: id:12316
+msgid "6"
+msgstr "6"
+
+#: id:12317
+msgid "7"
+msgstr "7"
+
+#: id:12318
+msgid "8"
+msgstr "8"
+
+#: id:12319
+msgid "9"
+msgstr "9"
+
+#: id:12320
+msgid "c"
+msgstr "c"
+
+#: id:12321
+msgid "Ok"
+msgstr "ok"
+
+#: id:12322
+msgid "*"
+msgstr "*"
+
+#: id:12325
+msgid "Locked! Enter code..."
+msgstr "Zamknuté! Vložte kód..."
+
+#: id:12326
+msgid "Enter password"
+msgstr "Zadajte heslo"
+
+#: id:12327
+msgid "Enter master code"
+msgstr "Zadajte hlavný kód"
+
+#: id:12328
+msgid "Enter unlock code"
+msgstr "Zadajte odomykací kód"
+
+#: id:12329
+msgid "or press C to cancel"
+msgstr "alebo stlačte C pre zrušenie"
+
+#: id:12330
+msgid "Enter gamepad button combo and"
+msgstr "Vložte kombináciu tlačidiel a"
+
+#: id:12331
+msgid "press OK, or Back to cancel"
+msgstr "stlačte Start alebo Back pre zrušenie"
+
+#: id:12332
+msgid "Set lock"
+msgstr "Nastaviť zámok"
+
+#: id:12333
+msgid "Unlock"
+msgstr "Odomknúť"
+
+#: id:12334
+msgid "Reset lock"
+msgstr "Resetnúť zámok"
+
+#: id:12335
+msgid "Remove lock"
+msgstr "Odstrániť zámok"
+
+#: id:12337
+msgid "Numeric password"
+msgstr "Číselné Heslo"
+
+#: id:12338
+msgid "Gamepad button combo"
+msgstr "Kombinácie tlačidiel na Gamepad-e"
+
+#: id:12339
+msgid "Full-text password"
+msgstr "Textové Heslo"
+
+#: id:12340
+msgid "Enter new password"
+msgstr "Napíšte nové heslo"
+
+#: id:12341
+msgid "Re-Enter new password"
+msgstr "Znovu napíšte nové heslo"
+
+#: id:12342
+msgid "Incorrect password,"
+msgstr "Nesprávne heslo,"
+
+#: id:12343
+msgid "retries left"
+msgstr "možností ostáva"
+
+#: id:12344
+msgid "Passwords entered did not match."
+msgstr "Napísané heslá nie sú totožné."
+
+#: id:12345
+msgid "Access denied"
+msgstr "Vstup Nepovolený"
+
+#: id:12346
+msgid "Password retry limit exceeded."
+msgstr "Limit pre opakovanie bol prekročený."
+
+#: id:12347
+msgid "The system will now shut off."
+msgstr "Systém sa teraz vypne."
+
+#: id:12348
+msgid "Item locked"
+msgstr "Položka zamknutá"
+
+#: id:12353
+msgid "Reactivate lock"
+msgstr "Reaktivovať zámok"
+
+#: id:12356
+msgid "Change lock"
+msgstr "Zmeniť zámok"
+
+#: id:12357
+msgid "Source lock"
+msgstr "Zdieľať zámok"
+
+#: id:12358
+msgid "Password entry was blank. Try again."
+msgstr "Heslo bolo prázdne. Skúste znova."
+
+#: id:12360
+msgid "Master lock"
+msgstr "Hlavný zámok"
+
+#: id:12362
+msgid "Shutdown system if Master Lock retries exceeded"
+msgstr "Vypnúť systém ak boli prekročené pokusy na hlavný zámok"
+
+#: id:12367
+msgid "Master code is not valid"
+msgstr "Hlavný kľúč nie je správny!"
+
+#: id:12368
+msgid "Please enter a valid master code"
+msgstr "Prosím vložte správny hlavný kľúč!"
+
+#: id:12373
+msgid "Settings & file manager"
+msgstr "Nastavenia a Správca súborov"
+
+#: id:12376
+msgid "Set as default for all movies"
+msgstr "Nastaviť ako predvolené pre všetky filmy"
+
+#: id:12377
+msgid "This will reset any previously saved values"
+msgstr "Toto vymaže všetky uložené hodnoty"
+
+#: id:12378
+msgid "Amount of time to display each image"
+msgstr "Čas zobrazenia obrázku"
+
+#: id:12379
+msgid "Use pan and zoom effects"
+msgstr "Použiť efekty priblíženia a posunutia obrázku"
+
+#: id:12383
+msgid "12 hour clock"
+msgstr "12 hodinový formát"
+
+#: id:12384
+msgid "24 hour clock"
+msgstr "24 hodinový formát"
+
+#: id:12385
+msgid "Day/Month"
+msgstr "Deň/Mesiac"
+
+#: id:12386
+msgid "Month/Day"
+msgstr "Mesiac/Deň"
+
+#: id:12390
+msgid "System uptime"
+msgstr "Systém žije"
+
+#: id:12391
+msgid "Minutes"
+msgstr "Minúty"
+
+#: id:12392
+msgid "Hours"
+msgstr "Hodiny"
+
+#: id:12393
+msgid "Days"
+msgstr "Dni"
+
+#: id:12394
+msgid "Total uptime"
+msgstr "Celkovo žije"
+
+#: id:12395
+msgid "Battery level"
+msgstr "Stav batérie"
+
+#: id:12600
+msgctxt "Auto context with id 12600"
+msgid "Weather"
+msgstr "Počasie"
+
+#: id:12900
+msgctxt "Auto context with id 12900"
+msgid "Screensaver"
+msgstr "Šetrič obrazovky"
+
+#: id:12901
+msgid "Fullscreen OSD"
+msgstr "OSD na celú obrazovku"
+
+#: id:13000
+msgid "System"
+msgstr "Systém"
+
+#: id:13001
+msgid "Immediate HD spindown"
+msgstr "Okamžitý HD Spindown"
+
+#: id:13002
+msgid "Video only"
+msgstr "Len Video"
+
+#: id:13003
+msgid "- Delay"
+msgstr "- Oneskorenie"
+
+#: id:13004
+msgid "- Minimum file duration"
+msgstr "- Minimálna dĺžka súboru"
+
+#: id:13005
+msgid "Shutdown"
+msgstr "Vypnúť"
+
+#: id:13008
+msgid "Shutdown function"
+msgstr "Predvolený spôsob vypnutia"
+
+#: id:13009
+msgid "Quit"
+msgstr "Ukončiť"
+
+#: id:13010
+msgid "Hibernate"
+msgstr "Dlhodobý spánok"
+
+#: id:13011
+msgid "Suspend"
+msgstr "Úsporný režim"
+
+#: id:13012
+msgid "Exit"
+msgstr "Ukončiť"
+
+#: id:13013
+msgid "Reboot"
+msgstr "Reštartovať"
+
+#: id:13014
+msgid "Minimize"
+msgstr "Minimalizovať"
+
+#: id:13015
+msgid "Power button action"
+msgstr "Funkcia tlačítka pre vypnutie"
+
+#: id:13016
+msgid "Power off System"
+msgstr "Vypnúť systém"
+
+#: id:13020
+msgid "Is another session active, perhaps over ssh?"
+msgstr "Existuje nejaké aktívne pripojenie, (napr. cez SSH) ?"
+
+#: id:13021
+msgid "Mounted removable harddrive"
+msgstr "Pripojený vymeniteľný pevný disk"
+
+#: id:13022
+msgid "Unsafe device removal"
+msgstr "Nebezpečne odobrať zariadenie"
+
+#: id:13023
+msgid "Successfully removed device"
+msgstr "Zariadenie bolo úspšne odobrané"
+
+#: id:13024
+msgid "Joystick plugged"
+msgstr "Joystick bol pripojený"
+
+#: id:13025
+msgid "Joystick unplugged"
+msgstr "Joystick bol odpojený"
+
+#: id:13050
+msgid "Running low on battery"
+msgstr "Nízka úroveň batérie"
+
+#: id:13100
+msgid "Flicker filter"
+msgstr "Blikací filter"
+
+#: id:13101
+msgid "Let driver choose (requires restart)"
+msgstr "Nastavené ovladačom (vyžaduje reštart)"
+
+#: id:13105
+msgid "Vertical blank sync"
+msgstr "Vertikálna synchronizácia obrazovky (V-Sync)"
+
+#: id:13106
+msgctxt "Auto context with id 13106"
+msgid "Disabled"
+msgstr "Zakázané"
+
+#: id:13107
+msgid "Enabled during video playback"
+msgstr "Povolené počas prehrávania videa"
+
+#: id:13108
+msgctxt "Auto context with id 13108"
+msgid "Always enabled"
+msgstr "Vždy povolené"
+
+#: id:13109
+msgid "Test & apply resolution"
+msgstr "Test rozlíšenia"
+
+#: id:13110
+msgid "Save resolution?"
+msgstr "Uložiť rozlíšenie?"
+
+#: id:13111
+msgid "Would you like to keep this resolution?"
+msgstr "Chcete ponechať toto rozlíšenie?"
+
+#: id:13112
+msgid "High quality upscaling"
+msgstr "Vysoko kvalitný softwarový prepočet"
+
+#: id:13113
+msgctxt "Auto context with id 13113"
+msgid "Disabled"
+msgstr "Zakázané"
+
+#: id:13114
+msgid "Enabled for SD content"
+msgstr "Povolené pre SD videa"
+
+#: id:13115
+msgctxt "Auto context with id 13115"
+msgid "Always enabled"
+msgstr "Vždy povolené"
+
+#: id:13116
+msgid "Upscaling method"
+msgstr "Metóda prepočtu"
+
+#: id:13117
+msgctxt "Auto context with id 13117"
+msgid "Bicubic"
+msgstr "Bicubic"
+
+#: id:13118
+msgid "Lanczos"
+msgstr "Lanczos"
+
+#: id:13119
+msgid "Sinc"
+msgstr "Sinc"
+
+#: id:13120
+msgctxt "Auto context with id 13120"
+msgid "VDPAU"
+msgstr "VDPAU"
+
+#: id:13121
+msgid "VDPAU HQ Upscaling level"
+msgstr "VDPAU HQ prepočet (upscaling)"
+
+#: id:13122
+msgid "VDPAU Studio level color conversion"
+msgstr "VDPAU farebná konverzia - Studio level"
+
+#: id:13130
+msgid "Blank other displays"
+msgstr "Stmavovať ostatné obrazovky"
+
+#: id:13131
+msgctxt "Auto context with id 13131"
+msgid "Disabled"
+msgstr "Zakázané"
+
+#: id:13132
+msgid "Blank displays"
+msgstr "Vypni obrazovku"
+
+#: id:13140
+msgid "Active connections detected!"
+msgstr "Zistené aktívne spojenie!"
+
+#: id:13141
+msgid "If you proceed, you might not be able to control XBMC"
+msgstr "Ak budete pokračovať, môžeťe stratiť ovládanie XBMC"
+
+#: id:13142
+msgid "any longer. Are you sure you want to stop the Event server?"
+msgstr "natrvalo. Určiťe chcete zastaviť event server?"
+
+#: id:13144
+msgid "Change Apple Remote mode?"
+msgstr "Zmeniť mód diaľkového ovládania Apple?"
+
+#: id:13145
+msgid "If you are currently using the Apple Remote to control"
+msgstr "Ak práve používate diaľkové ovládanie Apple na ovládanie"
+
+#: id:13146
+msgid "XBMC, changing this setting might affect your ability"
+msgstr "XBMC, zmenou nastavenia možete ovplyvniť vašu"
+
+#: id:13147
+msgid "to continue controlling it. Do you want to proceed?"
+msgstr "schopnosť ovládať ho. Chcete pokračovať?"
+
+#: id:13159
+msgid "Subnet mask"
+msgstr "Maska siete:"
+
+#: id:13160
+msgid "Gateway"
+msgstr "Brána"
+
+#: id:13161
+msgid "Primary DNS"
+msgstr "Primárny DNS"
+
+#: id:13162
+msgid "Initialize failed"
+msgstr "Inicializácia zlyhala"
+
+#: id:13170
+msgctxt "Auto context with id 13170"
+msgid "Never"
+msgstr "Nikdy"
+
+#: id:13171
+msgid "Immediately"
+msgstr "Ihneď"
+
+#: id:13172
+msgid "After %i secs"
+msgstr "Po %i sekundách"
+
+#: id:13173
+msgid "HDD install date:"
+msgstr "Dátum inštalácie disku:"
+
+#: id:13174
+msgid "HDD power cycle count:"
+msgstr "Počet zapnutí disku"
+
+#: id:13200
+msgid "Profiles"
+msgstr "Profily"
+
+#: id:13201
+msgid "Delete profile '%s'?"
+msgstr "Vymazať profil '%s'?"
+
+#: id:13204
+msgid "Last loaded profile:"
+msgstr "Posledný otvorený profil:"
+
+#: id:13205
+msgid "Unknown"
+msgstr "Neznámy"
+
+#: id:13206
+msgid "Overwrite"
+msgstr "Prepísať"
+
+#: id:13208
+msgid "Alarm clock"
+msgstr "Budík"
+
+#: id:13209
+msgid "Alarm clock interval (in minutes)"
+msgstr "Budíkový interval (v minútach)"
+
+#: id:13210
+msgid "Started, alarm in %im"
+msgstr "Načasovaný, budík o %im"
+
+#: id:13211
+msgid "Alarm!"
+msgstr "Budík!"
+
+#: id:13212
+msgid "Canceled with %im%is left"
+msgstr "Zrušené (zostávalo %im%is)"
+
+#: id:13213
+msgid "%2.0fm"
+msgstr "%2.0fm"
+
+#: id:13214
+msgid "%2.0fs"
+msgstr "%2.0fs"
+
+#: id:13249
+msgid "Search for subtitles in RARs"
+msgstr "Hľadať titulky v RARoch"
+
+#: id:13250
+msgid "Browse for subtitle..."
+msgstr "Hľadať titulky..."
+
+#: id:13251
+msgid "Move item"
+msgstr "Presunúť položku"
+
+#: id:13252
+msgid "Move item here"
+msgstr "Presunúť položku sem"
+
+#: id:13253
+msgid "Cancel move"
+msgstr "Zrušiť presunutie"
+
+#: id:13270
+msgid "Hardware:"
+msgstr "Hardware:"
+
+#: id:13271
+msgid "CPU Usage:"
+msgstr "Záťaž CPU:"
+
+#: id:13274
+msgid "Connected, but no DNS is available."
+msgstr "Pripojený, ale DNS je nedostupný"
+
+#: id:13275
+msgid "Hard Disk"
+msgstr "Hard Disk"
+
+#: id:13276
+msgid "DVD-ROM"
+msgstr "DVD-ROM"
+
+#: id:13277
+msgctxt "Auto context with id 13277"
+msgid "Storage"
+msgstr "Úložisko"
+
+#: id:13278
+msgctxt "Auto context with id 13278"
+msgid "Default"
+msgstr "Predvolené"
+
+#: id:13279
+msgctxt "Auto context with id 13279"
+msgid "Network"
+msgstr "Sieť"
+
+#: id:13280
+msgctxt "Auto context with id 13280"
+msgid "Video"
+msgstr "Video"
+
+#: id:13281
+msgid "Hardware"
+msgstr "Hardware"
+
+#: id:13283
+msgid "Operating system:"
+msgstr "Operačný systém"
+
+#: id:13284
+msgid "CPU speed:"
+msgstr "Rýchlosť CPU:"
+
+#: id:13286
+msgid "Video encoder:"
+msgstr "Video enkodér:"
+
+#: id:13287
+msgid "Screen resolution:"
+msgstr "Rozlíšenie obrazovky:"
+
+#: id:13292
+msgid "A/V cable:"
+msgstr "A/V Kábel:"
+
+#: id:13294
+msgid "DVD region:"
+msgstr "DVD Región:"
+
+#: id:13295
+msgid "Internet:"
+msgstr "Internet:"
+
+#: id:13296
+msgctxt "Auto context with id 13296"
+msgid "Connected"
+msgstr "Pripojený"
+
+#: id:13297
+msgid "Not connected. Check network settings."
+msgstr "Nie je Pripojený. Skontrolujte sieťové nastavenia."
+
+#: id:13299
+msgid "Target temperature"
+msgstr "Cieľová teplota"
+
+#: id:13300
+msgid "Fan speed"
+msgstr "Otáčky ventilátora"
+
+#: id:13301
+msgid "Auto temperature control"
+msgstr "Automatické regulovanie teploty"
+
+#: id:13302
+msgid "Fan speed override"
+msgstr "Nastavenie otáčok ventilátora"
+
+#: id:13303
+msgid "- Fonts"
+msgstr "Písmo vzhľadu"
+
+#: id:13304
+msgid "Enable flipping bi-directional strings"
+msgstr "Povoliť preklápanie obojsmerných reťazcov"
+
+#: id:13305
+msgid "Show RSS news feeds"
+msgstr "Povoliť RSS spravodajstvo"
+
+#: id:13306
+msgid "Show parent folder items"
+msgstr "Schovať rodičovský priečinok"
+
+#: id:13307
+msgid "Track naming template"
+msgstr "Šablóna názvu stopy"
+
+#: id:13308
+msgid "Do you wish to reboot your system"
+msgstr "Naozaj chcete reštartovať systém"
+
+#: id:13309
+msgid "instead of just XBMC?"
+msgstr "alebo len XBMC?"
+
+#: id:13310
+msgid "Zoom effect"
+msgstr "Efekt zväčšenia"
+
+#: id:13311
+msgid "Float effect"
+msgstr "Efekt splynutia"
+
+#: id:13312
+msgid "Black bar reduction"
+msgstr "Redukcia čiernych okrajov"
+
+#: id:13313
+msgid "Restart"
+msgstr "Reštart"
+
+#: id:13314
+msgid "Crossfade between songs"
+msgstr "Prelínanie"
+
+#: id:13315
+msgid "Regenerate thumbnails"
+msgstr "Aktualizovať náhľady"
+
+#: id:13316
+msgid "Recursive thumbnails"
+msgstr "Náhľady rekurzívne"
+
+#: id:13317
+msgid "View slideshow"
+msgstr "Prezentácia"
+
+#: id:13318
+msgid "Recursive slideshow"
+msgstr "Prezentácia rekurzívna"
+
+#: id:13319
+msgid "Randomize"
+msgstr "Náhodne"
+
+#: id:13320
+msgid "Stereo"
+msgstr "Stereo"
+
+#: id:13321
+msgid "Left only"
+msgstr "Len ľavý"
+
+#: id:13322
+msgid "Right only"
+msgstr "Len pravý"
+
+#: id:13323
+msgid "Enable karaoke support"
+msgstr "Povoliť podporu karaoke"
+
+#: id:13324
+msgid "Background transparency"
+msgstr "Priehľadnosť pozadia"
+
+#: id:13325
+msgid "Foreground transparency"
+msgstr "Priehľadnosť popredia"
+
+#: id:13326
+msgid "A/V delay"
+msgstr "A/V oneskorenie"
+
+#: id:13327
+msgid "Karaoke"
+msgstr "Karaoke"
+
+#: id:13328
+msgid "%s not found"
+msgstr "%s nebolo nájdené"
+
+#: id:13329
+msgid "Error opening %s"
+msgstr "Chyba pri otváraní %s"
+
+#: id:13330
+msgid "Unable to load %s"
+msgstr "Nie je možné otvoriť %s"
+
+#: id:13331
+msgid "Error: Out of memory"
+msgstr "Chyba: nedostatok pamäte"
+
+#: id:13332
+msgid "Move up"
+msgstr "Premiestniť hore"
+
+#: id:13333
+msgid "Move down"
+msgstr "Premiestniť dole"
+
+#: id:13334
+msgid "Edit label"
+msgstr "Upraviť názov"
+
+#: id:13335
+msgid "Make default"
+msgstr "Spraviť predvolené"
+
+#: id:13336
+msgid "Remove button"
+msgstr "Odstrániť tlačidlo"
+
+#: id:13340
+msgid "Leave as is"
+msgstr "Nechať tak ako je"
+
+#: id:13341
+msgid "Green"
+msgstr "Zelená"
+
+#: id:13342
+msgid "Orange"
+msgstr "Oranžová"
+
+#: id:13343
+msgid "Red"
+msgstr "Červená"
+
+#: id:13344
+msgid "Cycle"
+msgstr "Cyklovať"
+
+#: id:13345
+msgid "Switch LED off on playback"
+msgstr "Vypnúť LED pri prehrávaní"
+
+#: id:13346
+msgctxt "Auto context with id 13346"
+msgid "Movie information"
+msgstr "Informácie o filme"
+
+#: id:13347
+msgid "Queue item"
+msgstr "Položka do zásoby"
+
+#: id:13348
+msgid "Search IMDb..."
+msgstr "Hľadať v IMDb..."
+
+#: id:13349
+msgid "Scan for new content"
+msgstr "Hľadať nový obsah"
+
+#: id:13350
+msgid "Now playing..."
+msgstr "Teraz hrá..."
+
+#: id:13351
+msgctxt "Auto context with id 13351"
+msgid "Album information"
+msgstr "Informácie o albume"
+
+#: id:13352
+msgid "Scan item to library"
+msgstr "Skenovať položku do knižnice"
+
+#: id:13353
+msgid "Stop scanning"
+msgstr "Zastaviť skenovanie"
+
+#: id:13354
+msgctxt "Auto context with id 13354"
+msgid "Render method"
+msgstr "Vykresľovacia metóda"
+
+#: id:13355
+msgid "Low quality pixel shader"
+msgstr "Nízkokvalitný Pixel Shader"
+
+#: id:13356
+msgid "Hardware overlays"
+msgstr "Hardvérové prekrývanie"
+
+#: id:13357
+msgid "High quality pixel shader"
+msgstr "Vysokokvalitný Pixel Shader"
+
+#: id:13358
+msgid "Play item"
+msgstr "Prehrať položku"
+
+#: id:13359
+msgid "Set artist thumb"
+msgstr "Nastaviť náhľad pre interpréta"
+
+#: id:13360
+msgid "Automatically generate thumbnails"
+msgstr "Vytvoriť náhľady"
+
+#: id:13361
+msgid "Enable voice"
+msgstr "Povoliť hlas"
+
+#: id:13375
+msgid "Enable device"
+msgstr "Povoliť zariadenie"
+
+#: id:13376
+msgid "Volume"
+msgstr "Hlasitosť"
+
+#: id:13377
+msgid "Default view mode"
+msgstr "Predvolený zobrazovací mód"
+
+#: id:13378
+msgid "Default brightness"
+msgstr "Predvolený jas"
+
+#: id:13379
+msgid "Default contrast"
+msgstr "Predvolený kontrast"
+
+#: id:13380
+msgid "Default gamma"
+msgstr "Predvolená gamma"
+
+#: id:13381
+msgid "Resume video"
+msgstr "Pokračovať"
+
+#: id:13382
+msgid "Voice mask - Port 1"
+msgstr "Maska hlasu - port 1"
+
+#: id:13383
+msgid "Voice mask - Port 2"
+msgstr "Maska hlasu - port 2"
+
+#: id:13384
+msgid "Voice mask - Port 3"
+msgstr "Maska hlasu - port 3"
+
+#: id:13385
+msgid "Voice mask - Port 4"
+msgstr "Maska hlasu - port 4"
+
+#: id:13386
+msgid "Use time based seeking"
+msgstr "Použiť vyhľadávanie na základe času"
+
+#: id:13387
+msgid "Track naming template - right"
+msgstr "Šablóna názvu stopy - vpravo"
+
+#: id:13388
+msgid "Preset"
+msgstr "Predvoľby"
+
+#: id:13389
+msgid "There are no presets available\nfor this visualization"
+msgstr "Pre túto vizualizáciu\nnie sú k dispozícii žiadne predvoľby"
+
+#: id:13390
+msgid "There are no settings available\nfor this visualization"
+msgstr "Pre túto vizualizáciu\nnie sú k dispozícii žiadne nastavenia"
+
+#: id:13391
+msgid "Eject/Load"
+msgstr "Vysunúť/Zasunúť"
+
+#: id:13392
+msgid "Use visualization if playing audio"
+msgstr "Použiť vizualizácie pri prehrávaní hudby"
+
+#: id:13393
+msgid "Calculate size"
+msgstr "Vypočítať veľkosť"
+
+#: id:13394
+msgid "Calculating folder size"
+msgstr "Počítanie veľkosti priečinka"
+
+#: id:13395
+msgid "Video settings"
+msgstr "Nastavenia videa"
+
+#: id:13396
+msgid "Audio and subtitle settings"
+msgstr "Nastavenie hudby a titulkov"
+
+#: id:13397
+msgid "Enable subtitles"
+msgstr "Povoliť titulky"
+
+#: id:13398
+msgctxt "Auto context with id 13398"
+msgid "Shortcuts"
+msgstr "Záložky"
+
+#: id:13399
+msgid "Ignore articles when sorting (e.g. \"the\")"
+msgstr "Ignorovať \"The\" pri usporiadaní"
+
+#: id:13400
+msgid "Crossfade between songs on the same album"
+msgstr "Stišovať stopy"
+
+#: id:13401
+msgid "Browse for %s"
+msgstr "Vybrať pre %s"
+
+#: id:13402
+msgid "Show track position"
+msgstr "Zobraziť pozíciu stopy"
+
+#: id:13403
+msgid "Clear default"
+msgstr "Vymazať predvolené"
+
+#: id:13404
+msgid "Resume"
+msgstr "Pokračovať"
+
+#: id:13405
+msgid "Get thumb"
+msgstr "Náhľady"
+
+#: id:13406
+msgid "Picture information"
+msgstr "Informácie o obrázku"
+
+#: id:13407
+msgid "%s presets"
+msgstr "%s predvolieb"
+
+#: id:13408
+msgid "(IMDb user rating)"
+msgstr "(Hodnotenie užívateľov IMDb)"
+
+#: id:13409
+msgid "Top 250"
+msgstr "Naj 250"
+
+#: id:13410
+msgid "Tune in on Last.fm"
+msgstr "Naladiť na Last.FM"
+
+#: id:13411
+msgid "Minimum fan speed"
+msgstr "Minimálna rýchlosť ventilátora"
+
+#: id:13412
+msgid "Play from here"
+msgstr "Pustiť odtiaľto"
+
+#: id:13413
+msgid "Downloading"
+msgstr "Sťahujem"
+
+#: id:13414
+msgid "Include artists who appear only on compilations"
+msgstr "Schovať interprétov bez kompilácii"
+
+#: id:13415
+msgctxt "Auto context with id 13415"
+msgid "Render method"
+msgstr "Vykresľovacia metóda"
+
+#: id:13416
+msgid "Auto detect"
+msgstr "Zistiť automaticky"
+
+#: id:13417
+msgid "Basic shaders (ARB)"
+msgstr "Jednoduchý shader (ARB)"
+
+#: id:13418
+msgid "Advanced shaders (GLSL)"
+msgstr "Pokročilý shader (GLSL)"
+
+#: id:13419
+msgid "Software"
+msgstr "Softvér"
+
+#: id:13420
+msgid "Remove safely"
+msgstr "Bezpečne odobrať"
+
+#: id:13421
+msgctxt "Auto context with id 13421"
+msgid "VDPAU"
+msgstr "VDPAU"
+
+#: id:13422
+msgid "Start slideshow here"
+msgstr "Začať slideshow tu"
+
+#: id:13423
+msgid "Remember for this path"
+msgstr "Zapamätať pre túto cestu"
+
+#: id:13424
+msgid "Use pixel buffer objects"
+msgstr "Použiť objekty vyrovnávacej pamäte pixelu"
+
+#: id:13425
+msgid "Allow hardware acceleration (VDPAU)"
+msgstr "Aktivovať hardwarovú akceleráciu (VAAPI)"
+
+#: id:13426
+msgid "Allow hardware acceleration (VAAPI)"
+msgstr "Povoliť hardwarovú akceleráciu (VAAPI)"
+
+#: id:13427
+msgid "Allow hardware acceleration (DXVA2)"
+msgstr "Povoliť hardwarovú akceleráciu (DXVA2)"
+
+#: id:13428
+msgid "Allow hardware acceleration (CrystalHD)"
+msgstr "Povoliť hardwarovú akceleráciu (CrystalHD)"
+
+#: id:13429
+msgid "Allow hardware acceleration (VDADecoder)"
+msgstr "Povoliť hardwarovú akceleráciu (VDADecoder)"
+
+#: id:13430
+msgid "Allow hardware acceleration (OpenMax)"
+msgstr "Povoliť hardwarovú akceleráciu (OpenMax)"
+
+#: id:13431
+msgid "Pixel Shaders"
+msgstr "Pixel Shadery"
+
+#: id:13432
+msgid "Allow hardware acceleration (VideoToolbox)"
+msgstr "Povoliť hardwarovú akceleráciu (Video Toolbox)"
+
+#: id:13500
+msgid "A/V sync method"
+msgstr "Spôsob synchronizácie A/V"
+
+#: id:13501
+msgid "Audio clock"
+msgstr "podľa audia"
+
+#: id:13502
+msgid "Video clock (Drop/Dupe audio)"
+msgstr "podľa videa (vynechať/duplikovať audio)"
+
+#: id:13503
+msgid "Video clock (Resample audio)"
+msgstr "podľa videa (prispôsobiť rýchlosť audia)"
+
+#: id:13504
+msgid "Maximum resample amount (%)"
+msgstr "Maximálna zmena rýchlosti (%)"
+
+#: id:13505
+msgid "Resample quality"
+msgstr "Kvalita zmeny rýchlosti"
+
+#: id:13506
+msgid "Low(fast)"
+msgstr "Nízka (rýchla)"
+
+#: id:13507
+msgctxt "Auto context with id 13507"
+msgid "Medium"
+msgstr "Stredná"
+
+#: id:13508
+msgctxt "Auto context with id 13508"
+msgid "High"
+msgstr "Vysoká"
+
+#: id:13509
+msgid "Really high(slow!)"
+msgstr "Veľmi vysoká (pomalé!)"
+
+#: id:13510
+msgid "Sync playback to display"
+msgstr "Synchronizovať prehrávanie videa k obrazovke"
+
+#: id:13550
+msgid "Pause during refresh rate change"
+msgstr "Pozastaviť prehrávanie pri zmene obnovovacej frekvencie"
+
+#: id:13551
+msgctxt "Auto context with id 13551"
+msgid "Off"
+msgstr "Vypnuté"
+
+#: id:13552
+msgid "%.1f Second"
+msgstr "%.1f Sekunda"
+
+#: id:13553
+msgid "%.1f Seconds"
+msgstr "%.1f Sekúnd"
+
+#: id:13600
+msgid "Apple remote"
+msgstr "Diaľkové ovládanie Apple"
+
+#: id:13602
+msgid "Allow start of XBMC using the remote"
+msgstr "Vždy spustené"
+
+#: id:13603
+msgid "Sequence delay time"
+msgstr "Čas oneskorenia sekvencie"
+
+#: id:13610
+msgctxt "Auto context with id 13610"
+msgid "Disabled"
+msgstr "Zakázaný"
+
+#: id:13611
+msgctxt "Auto context with id 13611"
+msgid "Standard"
+msgstr "Štandardný"
+
+#: id:13612
+msgid "Universal Remote"
+msgstr "Univerzálne diaľkové ovládanie"
+
+#: id:13613
+msgid "Multi Remote (Harmony)"
+msgstr "Multifunkčné diaľkové ovládanie (Harmony)"
+
+#: id:13620
+msgid "Apple Remote Error"
+msgstr "Ovládač pre ovládanie Apple je nainštalovaný."
+
+#: id:13621
+msgid "Apple Remote support could be enabled."
+msgstr "Podporu pre ovládanie Apple nie je možné povoliť."
+
+#: id:14000
+msgid "Stack"
+msgstr "Spolu"
+
+#: id:14001
+msgid "Unstack"
+msgstr "Samostatne"
+
+#: id:14003
+msgid "Downloading playlist file..."
+msgstr "Sťahujem playlist súbor..."
+
+#: id:14004
+msgid "Downloading streams list..."
+msgstr "Sťahujem zoznam streamov..."
+
+#: id:14005
+msgid "Parsing streams list..."
+msgstr "Parsujem zoznam streamov..."
+
+#: id:14006
+msgid "Downloading streams list failed"
+msgstr "Sťahovanie zoznamu streamov zlyhalo"
+
+#: id:14007
+msgid "Downloading playlist file failed"
+msgstr "Sťahovanie súboru playlist-u zlyhalo"
+
+#: id:14009
+msgid "Games directory"
+msgstr "Priečinok s hrami"
+
+#: id:14010
+msgid "Auto switch to thumbs based on"
+msgstr "Autoprepínanie pre náhľady založené na"
+
+#: id:14011
+msgid "Enable auto switching to thumbs view"
+msgstr "Povoliť autoprepínanie na náhľady"
+
+#: id:14012
+msgid "- Use large icons"
+msgstr "- Používať veľké ikony"
+
+#: id:14013
+msgid "- Switch based on"
+msgstr "- Prepínanie založené na"
+
+#: id:14014
+msgid "- Percentage"
+msgstr "- Percentá"
+
+#: id:14015
+msgid "No files and at least one thumb"
+msgstr "Žiadne súbory a najmenej jeden náhľad"
+
+#: id:14016
+msgid "At least one file and thumb"
+msgstr "Aspoň jeden súbor a jeden náhľad"
+
+#: id:14017
+msgid "Percentage of thumbs"
+msgstr "Podiel náhľadov"
+
+#: id:14018
+msgid "View options"
+msgstr "Zobrazenie"
+
+#: id:14019
+msgid "Change area code 1"
+msgstr "Zmeniť kód oblasti 1"
+
+#: id:14020
+msgid "Change area code 2"
+msgstr "Zmeniť kód oblasti 2"
+
+#: id:14021
+msgid "Change area code 3"
+msgstr "Zmeniť kód oblasti 3"
+
+#: id:14022
+msgctxt "Auto context with id 14022"
+msgid "Library"
+msgstr "Knižnica"
+
+#: id:14023
+msgid "No TV"
+msgstr "Žiadna TV"
+
+#: id:14024
+msgid "Enter the nearest large town"
+msgstr "Napíšte najbližšie veľké mesto"
+
+#: id:14025
+msgid "Video/Audio/DVD cache - Harddisk"
+msgstr "Medzipamäť - Video/Audio/DVD - HDD"
+
+#: id:14026
+msgid "Video cache - DVD-ROM"
+msgstr "Medzipamäť - Video - DVDRom"
+
+#: id:14027
+msgctxt "Auto context with id 14027"
+msgid "- Local Network"
+msgstr "- Lokálna sieť"
+
+#: id:14028
+msgctxt "Auto context with id 14028"
+msgid "- Internet"
+msgstr "- Internet"
+
+#: id:14030
+msgid "Audio cache - DVD-ROM"
+msgstr "Medzipamäť - Audio - DVDRom"
+
+#: id:14031
+msgctxt "Auto context with id 14031"
+msgid "- Local Network"
+msgstr "- Lokálna sieť"
+
+#: id:14032
+msgctxt "Auto context with id 14032"
+msgid "- Internet"
+msgstr "- Internet"
+
+#: id:14034
+msgid "DVD cache - DVD-ROM"
+msgstr "Medzipamäť - DVD - DVDRom"
+
+#: id:14035
+msgctxt "Auto context with id 14035"
+msgid "- Local Network"
+msgstr "- Lokálna sieť"
+
+#: id:14036
+msgctxt "Auto context with id 14036"
+msgid "Services"
+msgstr "Servery"
+
+#: id:14038
+msgid "Network settings changed"
+msgstr "Sieťové nastavenia boli zmenené"
+
+#: id:14039
+msgid "XBMC requires to restart to change your"
+msgstr "XBMC vyžaduje reštart pre zmenu"
+
+#: id:14040
+msgid "network setup. Would you like to restart now?"
+msgstr "sieťových nastavení. Reštartovať?"
+
+#: id:14041
+msgid "Internet connection bandwidth limitation"
+msgstr "Limitovať rýchlosť internetového pripojenia"
+
+#: id:14043
+msgid "- Shutdown while playing"
+msgstr "- Vypínanie počas prehrávania"
+
+#: id:14044
+msgid "%i min"
+msgstr "%i min"
+
+#: id:14045
+msgid "%i sec"
+msgstr "%i sek"
+
+#: id:14046
+msgid "%i ms"
+msgstr "%i ms"
+
+#: id:14047
+msgid "%i %%"
+msgstr "%i %%"
+
+#: id:14048
+msgid "%i kbps"
+msgstr "%i kbps"
+
+#: id:14049
+msgid "%i kb"
+msgstr "%i kb"
+
+#: id:14050
+msgid "%i.0 dB"
+msgstr "%i.0 dB"
+
+#: id:14051
+msgid "Time format"
+msgstr "Formát Času"
+
+#: id:14052
+msgid "Date format"
+msgstr "Formát Dátumu"
+
+#: id:14053
+msgid "GUI filters"
+msgstr "GUI Filtre"
+
+#: id:14055
+msgid "Use background scanning"
+msgstr "Používať skenovanie na pozadí"
+
+#: id:14056
+msgid "Stop scan"
+msgstr "Zastaviť skenovanie"
+
+#: id:14057
+msgid "Not possible while scanning for media info"
+msgstr "Nie je možne zoskenovať informácie pre médiá"
+
+#: id:14058
+msgid "Film grain effect"
+msgstr "Krupicový efekt na film"
+
+#: id:14059
+msgid "Search for thumbnails on remote shares"
+msgstr "Hľadať náhľady na vzdialených zložkách"
+
+#: id:14060
+msgid "Unknown type cache - Internet"
+msgstr "Medzipamäť - Ostatné - Internet"
+
+#: id:14061
+msgctxt "Auto context with id 14061"
+msgid "Auto"
+msgstr "Automatický"
+
+#: id:14062
+msgid "Enter username for"
+msgstr "Napíšte meno pre"
+
+#: id:14063
+msgid "Date & time"
+msgstr "Dátum a čas"
+
+#: id:14064
+msgid "Set date"
+msgstr "Nastaviť Dátum"
+
+#: id:14065
+msgid "Set time"
+msgstr "Nastaviť Čas"
+
+#: id:14066
+msgid "Enter the time in 24 hour HH:MM format"
+msgstr "Napíšte čas v 24 hodinovom formáte HH:MM"
+
+#: id:14067
+msgid "Enter the date in DD/MM/YYYY format"
+msgstr "Napíšte dátum v DD/MM/YYYY formáte"
+
+#: id:14068
+msgid "Enter the IP address"
+msgstr "Napíšte IP adresu"
+
+#: id:14069
+msgid "Apply these settings now?"
+msgstr "Použiť tieto nastavenia teraz?"
+
+#: id:14070
+msgid "Apply changes now"
+msgstr "Teraz použiť zmeny"
+
+#: id:14071
+msgid "Allow file renaming and deletion"
+msgstr "Povoliť premenovanie a mazanie súborov"
+
+#: id:14074
+msgid "Set timezone"
+msgstr "Nastaviť časové pásmo"
+
+#: id:14075
+msgid "Use daylight saving time"
+msgstr "Automaticky upraviť hodiny na letný čas"
+
+#: id:14076
+msgid "Add to favourites"
+msgstr "Pridať medzi obľúbené"
+
+#: id:14077
+msgid "Remove from favourites"
+msgstr "Odstrániť z obľúbených"
+
+#: id:14078
+msgctxt "Auto context with id 14078"
+msgid "- Colours"
+msgstr "Farby vzhľadu"
+
+#: id:14079
+msgid "Timezone country"
+msgstr "Časové pásmo - krajiny"
+
+#: id:14080
+msgid "Timezone"
+msgstr "Časové pásmo"
+
+#: id:14081
+msgid "File lists"
+msgstr "Zoznam súborov"
+
+#: id:14082
+msgid "Show EXIF picture information"
+msgstr "Zobraziť EXIF informácie o obrázku"
+
+#: id:14083
+msgid "Use a fullscreen window rather than true fullscreen"
+msgstr "Uprednostniť režim okna celej obrazovky pred skutočnou celou obrazovkou"
+
+#: id:14084
+msgid "Queue songs on selection"
+msgstr "Pridávať skladby do fronty pri ich výbere"
+
+#: id:14086
+msgid "Playback"
+msgstr "Prehrávanie"
+
+#: id:14087
+msgid "DVDs"
+msgstr "DVD"
+
+#: id:14088
+msgid "Play DVDs automatically"
+msgstr "Automaticky prehrať DVD"
+
+#: id:14089
+msgid "Font to use for text subtitles"
+msgstr "Font pre textové titulky"
+
+#: id:14090
+msgid "International"
+msgstr "Oblasť a jazyk"
+
+#: id:14091
+msgid "Character set"
+msgstr "Znaková sada"
+
+#: id:14092
+msgid "Debugging"
+msgstr "Ladenie / Debug"
+
+#: id:14093
+msgid "Security"
+msgstr "Bezpečnosť"
+
+#: id:14094
+msgid "Input devices"
+msgstr "Vstupné zariadenia"
+
+#: id:14095
+msgid "Power saving"
+msgstr "Napájanie"
+
+#: id:14096
+msgid "Rip"
+msgstr ""
+
+#: id:14097
+msgid "Audio CD Insert Action"
+msgstr ""
+
+#: id:14098
+msgctxt "Auto context with id 14098"
+msgid "Play"
+msgstr ""
+
+#: id:14099
+msgid "Eject disc when CD ripping is complete"
+msgstr ""
+
+#: id:15015
+msgctxt "Auto context with id 15015"
+msgid "Remove"
+msgstr "Odstrániť"
+
+#: id:15016
+msgid "Games"
+msgstr "Hry"
+
+#: id:15019
+msgid "Add"
+msgstr "Pridať"
+
+#: id:15052
+msgid "Password"
+msgstr "Heslo"
+
+#: id:15100
+msgctxt "Auto context with id 15100"
+msgid "Library"
+msgstr "Knižnica"
+
+#: id:15101
+msgid "Database"
+msgstr "Databáza"
+
+#: id:15102
+msgid "* All albums"
+msgstr "* Všetky albumy"
+
+#: id:15103
+msgid "* All artists"
+msgstr "* Všetci interpréti"
+
+#: id:15104
+msgid "* All songs"
+msgstr "* Všetky skladby"
+
+#: id:15105
+msgid "* All genres"
+msgstr "* Všetky žánre"
+
+#: id:15107
+msgid "Buffering..."
+msgstr "Buferujem..."
+
+#: id:15108
+msgid "Navigation sounds"
+msgstr "Zvuky navigácie"
+
+#: id:15109
+msgid "Skin default"
+msgstr "Predvolený vzhľad"
+
+#: id:15111
+msgid "- Theme"
+msgstr "Téma vzhľadu"
+
+#: id:15112
+msgid "Default theme"
+msgstr "Predvolená téma"
+
+#: id:15200
+msgid "Last.fm"
+msgstr "Last.FM"
+
+#: id:15201
+msgid "Submit songs to Last.fm"
+msgstr "Last.FM - Odosielať informácie o skladbách"
+
+#: id:15202
+msgid "Last.fm username"
+msgstr "Last.FM meno"
+
+#: id:15203
+msgid "Last.fm password"
+msgstr "Last.FM heslo"
+
+#: id:15204
+msgid "Unable to handshake: sleeping..."
+msgstr "Nedá sa nadviazať spojenie: spím..."
+
+#: id:15205
+msgid "Please update XBMC"
+msgstr "Prosím aktualizujte XBMC"
+
+#: id:15206
+msgid "Bad authorization: Check username and password"
+msgstr "Zlá autorizácia: Skontrolujte meno a heslo"
+
+#: id:15207
+msgctxt "Auto context with id 15207"
+msgid "Connected"
+msgstr "Pripojený"
+
+#: id:15208
+msgid "Not connected"
+msgstr "Odpojený"
+
+#: id:15209
+msgid "Submit interval %i"
+msgstr "Interval pre posielanie %i"
+
+#: id:15210
+msgid "Cached %i songs"
+msgstr "Načítaných %i skladieb"
+
+#: id:15211
+msgid "Submitting..."
+msgstr "Posielam..."
+
+#: id:15212
+msgid "Submitting in %i secs"
+msgstr "Pošlem za %i sekund"
+
+#: id:15213
+msgid "Play using..."
+msgstr "Prehrať použitím..."
+
+#: id:15214
+msgid "Use smoothed A/V synchronization"
+msgstr "Používať hladkú A/V synchornizáciu"
+
+#: id:15215
+msgid "Hide file names in thumbs view"
+msgstr "Schovať názvy súborov v náhľadoch"
+
+#: id:15216
+msgid "Play in party mode"
+msgstr "Prehrať v párty móde"
+
+#: id:15217
+msgid "Submit songs to Libre.fm"
+msgstr "Libre.fm - Odosielať informácie o skladbách"
+
+#: id:15218
+msgid "Libre.fm username"
+msgstr "Libre.fm - Užívateľské meno"
+
+#: id:15219
+msgid "Libre.fm password"
+msgstr "Libre.fm - Heslo"
+
+#: id:15220
+msgid "Libre.fm"
+msgstr "Libre.fm"
+
+#: id:15221
+msgid "Song submission"
+msgstr "Online služby"
+
+#: id:15250
+msgid "Submit Last.fm radio to Last.fm"
+msgstr "Last.FM - Odosielať informácie o rádiách"
+
+#: id:15251
+msgid "Connecting to Last.fm..."
+msgstr "Spájam sa s Last.FM..."
+
+#: id:15252
+msgid "Selecting station..."
+msgstr "Nastavujem stanicu..."
+
+#: id:15253
+msgid "Search similar artists..."
+msgstr "Hľadať podobných interprétov..."
+
+#: id:15254
+msgid "Search similar tags..."
+msgstr "Hľadať podobné značky..."
+
+#: id:15255
+msgid "Your profile (%name%)"
+msgstr "Váš profil (%name%)"
+
+#: id:15256
+msgid "Overall top tags"
+msgstr "Najpoužívanejšie značky"
+
+#: id:15257
+msgid "Top artists for tag %name%"
+msgstr "Najlepší interpréti pre značku %name%"
+
+#: id:15258
+msgid "Top albums for tag %name%"
+msgstr "Najlepšie albumy pre značku %name%"
+
+#: id:15259
+msgid "Top tracks for tag %name%"
+msgstr "Najlepšie piesne pre značku %name%"
+
+#: id:15260
+msgid "Listen to tag %name% Last.fm radio"
+msgstr "Počúvať značku %name% na Last.FM radiu"
+
+#: id:15261
+msgid "Similar artists as %name%"
+msgstr "Podobní interpréti ako %name%"
+
+#: id:15262
+msgid "Top %name% albums"
+msgstr "Najlepšie %name% albumy"
+
+#: id:15263
+msgid "Top %name% tracks"
+msgstr "Najlepšie %name% piesne"
+
+#: id:15264
+msgid "Top %name% tags"
+msgstr "Najpoužívanejšie %name% tagy"
+
+#: id:15265
+msgid "Biggest fans of %name%"
+msgstr "Najväčší fanúškovia %name%"
+
+#: id:15266
+msgid "Listen to %name% fans Last.fm radio"
+msgstr "Počúvať %name% fanúškov Last.FM radiu"
+
+#: id:15267
+msgid "Listen to %name% similar artists Last.fm radio"
+msgstr "Počúvať %name% podobných interprétov na Last.FM radiu"
+
+#: id:15268
+msgid "Top artists for user %name%"
+msgstr "Najlepší interpréti pre užívateľa %name%"
+
+#: id:15269
+msgid "Top albums for user %name%"
+msgstr "Najlepšie albumy pre užívateľa %name%"
+
+#: id:15270
+msgid "Top tracks for user %name%"
+msgstr "Najlepšie piesne pre užívateľa %name%"
+
+#: id:15271
+msgid "Friends of user %name%"
+msgstr "Kamaráti užívateľa %name%"
+
+#: id:15272
+msgid "Neighbours of user %name%"
+msgstr "Susedia užívateľa %name%"
+
+#: id:15273
+msgid "Weekly artist chart for %name%"
+msgstr "Týždenné rebríčky interprétov pre %name%"
+
+#: id:15274
+msgid "Weekly album chart for %name%"
+msgstr "Týždenné rebríčky albumov pre %name%"
+
+#: id:15275
+msgid "Weekly track chart for %name%"
+msgstr "Týždenné rebríčky piesní pre %name%"
+
+#: id:15276
+msgid "Listen to %name%'s neighbours Last.fm radio"
+msgstr "Počúvať %name% susedov Last.FM radiu"
+
+#: id:15277
+msgid "Listen to %name%'s personal Last.fm radio"
+msgstr "Počúvať %name% osobný Last.FM radiu"
+
+#: id:15278
+msgid "Listen to %name%'s mix Last.fm radio"
+msgstr "Počúvať %name% obľúbene piesne Last.FM radiu"
+
+#: id:15279
+msgid "Retrieving list from Last.fm..."
+msgstr "Sťahujem zoznam z Last.FM..."
+
+#: id:15280
+msgid "Can't retrieve list from Last.fm..."
+msgstr "Nie je možné stiahnuť zoznam z Last.FM..."
+
+#: id:15281
+msgid "Enter an artist name to find related ones"
+msgstr "Napíšte meno interpréta pre hľadanie podobných"
+
+#: id:15282
+msgid "Enter a tag name to find similar ones"
+msgstr "Napíšte značku pre hľadanie podobných"
+
+#: id:15283
+msgid "Tracks recently listened by %name%"
+msgstr "Piesne nedávno počúvané užívateľom %name%"
+
+#: id:15284
+msgid "Listen to %name%'s recommendations Last.fm radio"
+msgstr "Počúvať %name% odporúčania Last.FM radio"
+
+#: id:15285
+msgid "Top tags for user %name%"
+msgstr "Obľúbené tagy užívateľa %name%"
+
+#: id:15287
+msgid "Do you want to add the current track to your loved tracks?"
+msgstr "Chcete pridať túto skladbu k vaším obľúbeným?"
+
+#: id:15288
+msgid "Do you want to ban the current track?"
+msgstr "Chcete zakázať túto skladbu?"
+
+#: id:15289
+msgid "Added to your loved tracks: '%s'."
+msgstr "Skladba pridaná k vaším obľúbeným: '%s'."
+
+#: id:15290
+msgid "Could not add '%s' to your loved tracks."
+msgstr "Skladbu '%s' sa nepodarilo pridať k vaším obľúbeným."
+
+#: id:15291
+msgid "Banned: '%s'."
+msgstr "Zakázané: '%s'."
+
+#: id:15292
+msgid "Could not ban '%s'."
+msgstr "Nepodarilo sa zakázať '%s'."
+
+#: id:15293
+msgid "Tracks recently loved by %name%"
+msgstr "Ostatné obľúbené skladby užívateľa %name%"
+
+#: id:15294
+msgid "Tracks recently banned by %name%"
+msgstr "Ostatné zakázané skladby užívateľa %name%"
+
+#: id:15295
+msgid "Remove from loved tracks"
+msgstr "Odstrániť z obľúbených skladieb?"
+
+#: id:15296
+msgid "Un-ban"
+msgstr "Povoliť zakázanú"
+
+#: id:15297
+msgid "Do you want to remove this track from your loved tracks?"
+msgstr "Chcete odstrániť túto skladbu z vašich obľúbených?"
+
+#: id:15298
+msgid "Do you want to un-ban this track?"
+msgstr "Chcete opäť povoliť túto zakázanú skladbu?"
+
+#: id:15300
+msgid "Path not found or invalid"
+msgstr "Cesta nenájdená alebo nesprávna"
+
+#: id:15301
+msgid "Could not connect to network server"
+msgstr "Nie je možné spojenie zo sieťovým serverom"
+
+#: id:15302
+msgid "No servers found"
+msgstr "Servery neboli nájdené"
+
+#: id:15303
+msgid "Workgroup not found"
+msgstr "Skupina nebola nájdená"
+
+#: id:15310
+msgid "Opening multi-path source"
+msgstr "Otváranie multi-cestového zdroja"
+
+#: id:15311
+msgid "Path:"
+msgstr "Cesta:"
+
+#: id:16000
+msgctxt "Auto context with id 16000"
+msgid "General"
+msgstr "Všeobecné"
+
+#: id:16002
+msgid "Internet lookup"
+msgstr "Hľadanie CDDB"
+
+#: id:16003
+msgid "Player"
+msgstr "Prehrávač"
+
+#: id:16004
+msgid "Play media from disc"
+msgstr "Prehrať médiá z disku"
+
+#: id:16008
+msgid "Enter new title"
+msgstr "Zadajte nový názov"
+
+#: id:16009
+msgid "Enter the movie name"
+msgstr "Napíšte názov filmu"
+
+#: id:16010
+msgid "Enter the profile name"
+msgstr "Napíšte názov profilu"
+
+#: id:16011
+msgid "Enter the album name"
+msgstr "Napíšte názov albumu"
+
+#: id:16012
+msgid "Enter the playlist name"
+msgstr "Napíšte názov playlist-u"
+
+#: id:16013
+msgid "Enter new filename"
+msgstr "Napíšte názov súboru"
+
+#: id:16014
+msgid "Enter folder name"
+msgstr "Napíšte názov priečinka"
+
+#: id:16015
+msgid "Enter directory"
+msgstr "Vložte adresár"
+
+#: id:16016
+msgid "Available options: %A, %T, %N, %B, %D, %G, %Y, %F, %S"
+msgstr "Dostupné možnosti: %A, %T, %N, %B, %D, %G, %Y, %F, %S"
+
+#: id:16017
+msgid "Enter search string"
+msgstr "Napíšte hľadaný výraz"
+
+#: id:16018
+msgctxt "Auto context with id 16018"
+msgid "None"
+msgstr "Žiadne"
+
+#: id:16019
+msgid "Auto select"
+msgstr "Auto Výber"
+
+#: id:16020
+msgid "De-interlace"
+msgstr "Deinterlácia"
+
+#: id:16021
+msgid "Bob"
+msgstr "Bob"
+
+#: id:16022
+msgid "Bob (inverted)"
+msgstr "Bob (Opačný)"
+
+#: id:16024
+msgid "Canceling..."
+msgstr "Prerušujem..."
+
+#: id:16025
+msgid "Enter the artist name"
+msgstr "Napíšte meno interpréta"
+
+#: id:16026
+msgid "Playback failed"
+msgstr "Prehrávanie playlist-u zrušené"
+
+#: id:16027
+msgid "One or more items failed to play."
+msgstr "Príliš veľa nasledujúcich položiek zlyhalo"
+
+#: id:16028
+msgid "Enter value"
+msgstr "Zadajte hodnotu"
+
+#: id:16029
+msgid "Check the log file for details."
+msgstr "Skontrolujte Log súbor pre viac informácií."
+
+#: id:16030
+msgid "Party mode aborted."
+msgstr "Párty mód prerušený."
+
+#: id:16031
+msgid "No matching songs in the library."
+msgstr "Žiadne skladby neboli nájdené v knižnici."
+
+#: id:16032
+msgid "Could not initialize database."
+msgstr "Nedá sa inicializovať databáza."
+
+#: id:16033
+msgid "Could not open database."
+msgstr "Nedá sa otvoriť databáza."
+
+#: id:16034
+msgid "Could not get songs from database."
+msgstr "Nedajú sa načítať skladby z databázy."
+
+#: id:16035
+msgid "Party mode playlist"
+msgstr "Párty mód playlist"
+
+#: id:16036
+msgid "De-interlace (Half)"
+msgstr "De-interlácia (Polovičná)"
+
+#: id:16037
+msgid "Deinterlace video"
+msgstr "Deinterlácia videa"
+
+#: id:16038
+msgid "Deinterlace method"
+msgstr "Spôsob deinterlácie"
+
+#: id:16039
+msgctxt "Auto context with id 16039"
+msgid "Off"
+msgstr "Vypnuté"
+
+#: id:16040
+msgctxt "Auto context with id 16040"
+msgid "Auto"
+msgstr "Automaticky"
+
+#: id:16041
+msgid "On"
+msgstr "Zapnuté"
+
+#: id:16100
+msgid "All Videos"
+msgstr "Všetky Videá"
+
+#: id:16101
+msgid "Unwatched"
+msgstr "Nevidené"
+
+#: id:16102
+msgid "Watched"
+msgstr "Videné"
+
+#: id:16103
+msgid "Mark as watched"
+msgstr "Označiť ako videné"
+
+#: id:16104
+msgid "Mark as unwatched"
+msgstr "Označiť ako nevidené"
+
+#: id:16105
+msgid "Edit title"
+msgstr "Upraviť titul"
+
+#: id:16200
+msgid "Operation was aborted"
+msgstr "Operácia bola prerušená"
+
+#: id:16201
+msgid "Copy failed"
+msgstr "Kopírovanie zlyhalo"
+
+#: id:16202
+msgid "Failed to copy at least one file"
+msgstr "Zlyhalo kopírovanie najmenej jedného súboru"
+
+#: id:16203
+msgid "Move failed"
+msgstr "Presunutie zlyhalo"
+
+#: id:16204
+msgid "Failed to move at least one file"
+msgstr "Zlyhal presun najmenej jedného súboru"
+
+#: id:16205
+msgid "Delete failed"
+msgstr "Mazanie zlyhalo"
+
+#: id:16206
+msgid "Failed to delete at least one file"
+msgstr "Zlyhalo zmazanie najmenej jedného súboru"
+
+#: id:16300
+msgid "Video scaling method"
+msgstr "Spôsob úpravy videa"
+
+#: id:16301
+msgid "Nearest neighbour"
+msgstr "Nearest Neighbour"
+
+#: id:16302
+msgid "Bilinear"
+msgstr "Bilinear"
+
+#: id:16303
+msgctxt "Auto context with id 16303"
+msgid "Bicubic"
+msgstr "Bicubic"
+
+#: id:16304
+msgid "Lanczos2"
+msgstr "Lanczos2"
+
+#: id:16305
+msgid "Lanczos3"
+msgstr "Lanczos3"
+
+#: id:16306
+msgid "Sinc8"
+msgstr "Sinc8"
+
+#: id:16307
+msgid "Bicubic (software)"
+msgstr "Bicubic (software)"
+
+#: id:16308
+msgid "Lanczos (software)"
+msgstr "Lanczos (software)"
+
+#: id:16309
+msgid "Sinc (software)"
+msgstr "Sinc (software)"
+
+#: id:16310
+msgid "Temporal"
+msgstr "Dočasný"
+
+#: id:16311
+msgid "Temporal/Spatial"
+msgstr "Dočasný/Spatial"
+
+#: id:16312
+msgid "(VDPAU)Noise Reduction"
+msgstr "(VDPAU) Redukcia šumu"
+
+#: id:16313
+msgid "(VDPAU)Sharpness"
+msgstr "(VDPAU) Ostrosť"
+
+#: id:16314
+msgid "Inverse Telecine"
+msgstr "Inverzný Telecine"
+
+#: id:16315
+msgid "Lanczos3 optimized"
+msgstr "Lanczos3 optimalizovaný"
+
+#: id:16316
+msgctxt "Auto context with id 16316"
+msgid "Auto"
+msgstr "Automaticky"
+
+#: id:16317
+msgid "Temporal (Half)"
+msgstr "Dočasný (Polovičný)"
+
+#: id:16318
+msgid "Temporal/Spatial (Half)"
+msgstr "Dočasný/Spatial (polovičný)"
+
+#: id:16319
+msgid "DXVA"
+msgstr "DXVA"
+
+#: id:16320
+msgid "DXVA Bob"
+msgstr "DXVA Bob"
+
+#: id:16321
+msgid "DXVA Best"
+msgstr "DXVA Best"
+
+#: id:16322
+msgid "Spline36"
+msgstr "Spline36"
+
+#: id:16323
+msgid "Spline36 optimized"
+msgstr "Spline36 optimalizovaná"
+
+#: id:16324
+msgid "Software Blend"
+msgstr ""
+
+#: id:16400
+msgid "Post-processing"
+msgstr "Post-processing"
+
+#: id:17500
+msgid "Display sleep timeout"
+msgstr "Zobraziť odpočet do uspania"
+
+#: id:19000
+msgid "Switch to channel"
+msgstr "Prepnúť na kanál"
+
+#: id:20000
+msgid "Saved music folder"
+msgstr "Priečinok pre sťahovanie CDDA"
+
+#: id:20001
+msgid "Use external DVD player"
+msgstr "Použiť externý prehrávač"
+
+#: id:20002
+msgid "External DVD player"
+msgstr "Externý DVD prehrávač"
+
+#: id:20003
+msgid "Trainers folder"
+msgstr "Priečinok s trainermi"
+
+#: id:20004
+msgid "Screenshot folder"
+msgstr "Priečinok screenshotov"
+
+#: id:20006
+msgid "Playlists folder"
+msgstr "Priečinok playlist-ov"
+
+#: id:20007
+msgid "Recordings"
+msgstr "Nahrávky"
+
+#: id:20008
+msgid "Screenshots"
+msgstr "Screenshoty"
+
+#: id:20009
+msgid "Use XBMC"
+msgstr "Použiť XBMC"
+
+#: id:20011
+msgid "Music playlists"
+msgstr "Hudobné playlist-y"
+
+#: id:20012
+msgid "Video playlists"
+msgstr "Video playlist-y"
+
+#: id:20013
+msgid "Do you wish to launch the game?"
+msgstr "Chcete spustiť túto hru?"
+
+#: id:20014
+msgid "Sort by: Playlist"
+msgstr "Usporiadať: Playlist"
+
+#: id:20015
+msgid "Remote thumb"
+msgstr "IMDb náhľad"
+
+#: id:20016
+msgid "Current thumb"
+msgstr "Súčasný náhľad"
+
+#: id:20017
+msgid "Local thumb"
+msgstr "Lokálny náhľad"
+
+#: id:20018
+msgid "No thumb"
+msgstr "Žiaden náhľad"
+
+#: id:20019
+msgid "Choose thumbnail"
+msgstr "Zvoliť náhľad"
+
+#: id:20023
+msgid "Conflict"
+msgstr "Konflikt"
+
+#: id:20024
+msgid "Scan new"
+msgstr "Skenovať nové"
+
+#: id:20025
+msgid "Scan all"
+msgstr "Skenovať všetko"
+
+#: id:20026
+msgid "Region"
+msgstr "Región"
+
+#: id:20037
+msgid "Summary"
+msgstr "Sumár"
+
+#: id:20038
+msgid "Lock music window"
+msgstr "Zamknúť hudbu"
+
+#: id:20039
+msgid "Lock videos window"
+msgstr "Zamknúť video"
+
+#: id:20040
+msgid "Lock pictures window"
+msgstr "Zamknúť obrázky"
+
+#: id:20041
+msgid "Lock programs & scripts windows"
+msgstr "Zamknúť programy, uloženia a skripty"
+
+#: id:20042
+msgid "Lock file manager"
+msgstr "Zamknúť správcu súborov"
+
+#: id:20043
+msgid "Lock settings"
+msgstr "Zamknúť nastavenia"
+
+#: id:20044
+msgid "Start fresh"
+msgstr "Načisto naštartovať"
+
+#: id:20045
+msgid "Enter master mode"
+msgstr "Vstúpiť do admin módu"
+
+#: id:20046
+msgid "Leave master mode"
+msgstr "Opustiť admin mód"
+
+#: id:20047
+msgid "Create profile '%s'?"
+msgstr "Vytvoriť profil '%s' ?"
+
+#: id:20048
+msgid "Start with fresh settings"
+msgstr "Štartovať s prázdnymi nastaveniami"
+
+#: id:20049
+msgid "Best available"
+msgstr "Najlepšie možné"
+
+#: id:20050
+msgid "Auto-switch between 16x9 and 4x3"
+msgstr "Autoprepínanie medzi 16x9 a 4x3"
+
+#: id:20051
+msgid "Treat stacked files as single file"
+msgstr "Považovať zlúčené súbory za jeden súbor"
+
+#: id:20052
+msgid "Caution"
+msgstr "Výstraha"
+
+#: id:20053
+msgid "Left master mode"
+msgstr "Admin mód deaktivovaný"
+
+#: id:20054
+msgid "Entered master mode"
+msgstr "Admin mód aktivovaný"
+
+#: id:20055
+msgid "Allmusic.com thumb"
+msgstr "Allmusic.com náhľad"
+
+#: id:20057
+msgid "Remove thumbnail"
+msgstr "Odstrániť náhľad"
+
+#: id:20058
+msgid "Add profile..."
+msgstr "Pridať profil..."
+
+#: id:20059
+msgid "Query info for all albums"
+msgstr "Stiahnuť informácie pre všetky albumy"
+
+#: id:20060
+msgctxt "Auto context with id 20060"
+msgid "Media info"
+msgstr "Informácie o médiu"
+
+#: id:20061
+msgctxt "Auto context with id 20061"
+msgid "Separate"
+msgstr "Oddelený"
+
+#: id:20062
+msgid "Shares with default"
+msgstr "Zdieľať s predvoleným"
+
+#: id:20063
+msgid "Shares with default (read only)"
+msgstr "Zdieľať s predvoleným (len čítanie)"
+
+#: id:20064
+msgid "Copy default"
+msgstr "Kopírovať predvolené"
+
+#: id:20065
+msgid "Profile picture"
+msgstr "Obrázok profilu"
+
+#: id:20066
+msgid "Lock preferences"
+msgstr "Nastavenia zámku"
+
+#: id:20067
+msgid "Edit profile"
+msgstr "Upraviť profil"
+
+#: id:20068
+msgid "Profile lock"
+msgstr "Zamknutie profilu"
+
+#: id:20069
+msgid "Could not create folder"
+msgstr "Priečinok nie je možné vytvoriť"
+
+#: id:20070
+msgid "Profile directory"
+msgstr "Adresár profilov"
+
+#: id:20071
+msgid "Start with fresh media sources"
+msgstr "Štartovať s čistými zdrojmi médií"
+
+#: id:20072
+msgid "Make sure the selected folder is writable"
+msgstr "Ubezpečte sa, že zvolený priečinok je zapisovateľný"
+
+#: id:20073
+msgid "and that the new folder name is valid"
+msgstr "a nový názov priečinku je korektný"
+
+#: id:20074
+msgid "MPAA rating"
+msgstr "MPAA Hodnotenie:"
+
+#: id:20075
+msgid "Enter master lock code"
+msgstr "Napíšte hlavný kód"
+
+#: id:20076
+msgid "Ask for master lock code on startup"
+msgstr "Pýtať sa na hlavný kód pri štarte"
+
+#: id:20077
+msgid "Skin settings"
+msgstr "Nastavenie vzhľadu"
+
+#: id:20078
+msgid "- no link set -"
+msgstr "- žiadny link -"
+
+#: id:20079
+msgid "Enable animations"
+msgstr "Povoliť animácie"
+
+#: id:20080
+msgid "Disable RSS during music"
+msgstr "Zakázať RSS počas hudby"
+
+#: id:20081
+msgid "Enable shortcut buttons"
+msgstr "Povoliť záložkové tlačítka"
+
+#: id:20082
+msgid "Show programs in main menu"
+msgstr "Zobraziť XLink Kai informácie"
+
+#: id:20083
+msgid "Show music info"
+msgstr "Zobraziť informácie o hudbe"
+
+#: id:20084
+msgid "Show weather info"
+msgstr "Zobraziť informácie o počasí"
+
+#: id:20085
+msgid "Show system info"
+msgstr "Zobraziť systémové informácie"
+
+#: id:20086
+msgid "Show available disc space C: E: F:"
+msgstr "Zobraziť voľné miesto na C: E: F:"
+
+#: id:20087
+msgid "Show available disc space E: F: G:"
+msgstr "Zobraziť voľné miesto na E: F: G:"
+
+#: id:20088
+msgid "Weather info"
+msgstr "Predpoveď počasia"
+
+#: id:20089
+msgid "Drive space free"
+msgstr "Voľné miesto"
+
+#: id:20090
+msgid "Enter the name of an existing share"
+msgstr "Napíšte názov existujúceho zdieľania"
+
+#: id:20091
+msgid "Lock code"
+msgstr "Kód"
+
+#: id:20092
+msgid "Load profile"
+msgstr "Otvoriť profil"
+
+#: id:20093
+msgid "Profile name"
+msgstr "Názov profilu"
+
+#: id:20094
+msgctxt "Auto context with id 20094"
+msgid "Media sources"
+msgstr "Zdroje médií"
+
+#: id:20095
+msgid "Enter profile lock code"
+msgstr "Napíšte kód pre uzamknutie profilu"
+
+#: id:20096
+msgctxt "Auto context with id 20096"
+msgid "Login screen"
+msgstr "Prihlásenie"
+
+#: id:20097
+msgid "Fetching album info"
+msgstr "Získavam informácie o albume"
+
+#: id:20098
+msgid "Fetching info for album"
+msgstr "Získavam informácie pre albume"
+
+#: id:20099
+msgid "Can't rip CD or track while playing from CD"
+msgstr "Nie je možné stiahnuť CD alebo stopu počas prehrávania CD"
+
+#: id:20100
+msgid "Master lock code and settings"
+msgstr "Hlavný kód a nastavenia"
+
+#: id:20101
+msgid "Entering master lock code always enables master mode"
+msgstr "Vloženie hlavného kódu vždy povolí admin mód"
+
+#: id:20102
+msgid "or copy from default?"
+msgstr "alebo kopírovať z predvoleného?"
+
+#: id:20103
+msgid "Save changes to profile?"
+msgstr "Uložiť zmeny do profilu?"
+
+#: id:20104
+msgid "Old settings found."
+msgstr "Staré nastavenia nájdené."
+
+#: id:20105
+msgid "Do you want to use them?"
+msgstr "Chcete ich použiť?"
+
+#: id:20106
+msgid "Old media sources found."
+msgstr "Staré zdroje médií nájdené."
+
+#: id:20107
+msgid "Separate (locked)"
+msgstr "Oddelený (zamknuté)"
+
+#: id:20108
+msgid "Root"
+msgstr "Hlavný"
+
+#: id:20109
+msgid "- Zoom"
+msgstr "Zväčšenie vzhľadu"
+
+#: id:20110
+msgid "UPnP settings"
+msgstr "UPnP Klient"
+
+#: id:20111
+msgid "Autostart UPnP client"
+msgstr "Autoštart"
+
+#: id:20112
+msgid "Last login: %s"
+msgstr "Posledné prihlásenie: %s"
+
+#: id:20113
+msgid "Never logged on"
+msgstr "Nikdy neprihlásený"
+
+#: id:20114
+msgid "Profile %i / %i"
+msgstr "Profil %i / %i"
+
+#: id:20115
+msgid "User login / Select a profile"
+msgstr "Prihlásenie / Výber profilu"
+
+#: id:20116
+msgid "Use lock on login screen"
+msgstr "Použiť zámok na prihlasovacej obrazovke"
+
+#: id:20117
+msgid "Invalid lock code."
+msgstr "Nesprávny kód."
+
+#: id:20118
+msgid "This requires the master lock to be set."
+msgstr "Toto vyžaduje aby bol nastavený admin zámok."
+
+#: id:20119
+msgid "Would you like to set it now?"
+msgstr "Chcete to nastaviť teraz?"
+
+#: id:20120
+msgid "Loading program information"
+msgstr "Načítanie informácie o programe"
+
+#: id:20121
+msgid "Party on!"
+msgstr "Párty sa začína!"
+
+#: id:20122
+msgid "True"
+msgstr "Pravda"
+
+#: id:20123
+msgid "Mixing drinks"
+msgstr "Miešam nápoje"
+
+#: id:20124
+msgid "Filling glasses"
+msgstr "Plním poháre"
+
+#: id:20125
+msgid "Logged on as"
+msgstr "Prihlásený ako"
+
+#: id:20126
+msgid "Log off"
+msgstr "Odhlásiť"
+
+#: id:20128
+msgid "Go to root"
+msgstr "Prejsť do hlavného"
+
+#: id:20129
+msgid "Weave"
+msgstr "Vlna"
+
+#: id:20130
+msgid "Weave (inverted)"
+msgstr "Vlna (naopak)"
+
+#: id:20131
+msgid "Blend"
+msgstr "Miešať"
+
+#: id:20132
+msgid "Restart video"
+msgstr "Reštartovať video"
+
+#: id:20133
+msgid "Edit network location"
+msgstr "Upraviť sieťové miesto"
+
+#: id:20134
+msgid "Remove network location"
+msgstr "Odstrániť sieťové miesto"
+
+#: id:20135
+msgid "Do you want to scan the folder?"
+msgstr "Chcete skenovať priečinok?"
+
+#: id:20136
+msgid "Memory unit"
+msgstr "Pamäťová karta"
+
+#: id:20137
+msgid "Memory unit mounted"
+msgstr "Pamäťová karta nainštalovaná"
+
+#: id:20138
+msgid "Unable to mount memory unit"
+msgstr "Nie je možné nainštalovať pamäťovú kartu"
+
+#: id:20139
+msgid "In port %i, slot %i"
+msgstr "V porte %i, slote %i"
+
+#: id:20140
+msgid "Lock screensaver"
+msgstr "Zamknúť šetrič obrazovky"
+
+#: id:20141
+msgid "Set"
+msgstr "Nastaviť"
+
+#: id:20142
+msgctxt "Auto context with id 20142"
+msgid "Username"
+msgstr "Meno"
+
+#: id:20143
+msgid "Enter password for"
+msgstr "Napíšte heslo pre"
+
+#: id:20144
+msgid "Shutdown timer"
+msgstr "Časovač vypnutia"
+
+#: id:20145
+msgid "Shutdown interval (in minutes)"
+msgstr "Vypnúť za (v minútach)"
+
+#: id:20146
+msgid "Started, shutdown in %im"
+msgstr "Naštartované, vypnutie za %im"
+
+#: id:20147
+msgid "Shutdown in 30 minutes"
+msgstr "Vypnutie za 30 minút"
+
+#: id:20148
+msgid "Shutdown in 60 minutes"
+msgstr "Vypnutie za 60 minút"
+
+#: id:20149
+msgid "Shutdown in 120 minutes"
+msgstr "Vypnutie za 120 minút"
+
+#: id:20150
+msgid "Custom shutdown timer"
+msgstr "Vlastný časovač vypnutia"
+
+#: id:20151
+msgid "Cancel shutdown timer"
+msgstr "Zrušiť časovač vypnutia"
+
+#: id:20152
+msgid "Lock preferences for %s"
+msgstr "Zamknúť nastavenia pre %s"
+
+#: id:20153
+msgid "Browse..."
+msgstr "Vybrať..."
+
+#: id:20154
+msgid "Summary information"
+msgstr "Informácie základné"
+
+#: id:20155
+msgid "Storage information"
+msgstr "Informácie o úložisku"
+
+#: id:20156
+msgid "Hard disk information"
+msgstr "Informácie o harddisku"
+
+#: id:20157
+msgid "DVD-ROM information"
+msgstr "Informácie o DVD-ROM"
+
+#: id:20158
+msgid "Network information"
+msgstr "Informácie o sieti"
+
+#: id:20159
+msgid "Video information"
+msgstr "Informácie o videu"
+
+#: id:20160
+msgid "Hardware information"
+msgstr "Informácie o hardware"
+
+#: id:20161
+msgid "Total"
+msgstr "Celkom: %s MB, použitých: %s MB, voľných: %s MB"
+
+#: id:20162
+msgid "Used"
+msgstr "Celkom HDD používaných: %u%% voľných: %u%%"
+
+#: id:20163
+msgid "of"
+msgstr "%s: %s MB of %s MB voľných"
+
+#: id:20164
+msgid "Locking not supported"
+msgstr "Zamknutie nie je podporované"
+
+#: id:20165
+msgid "Not locked"
+msgstr "Odomknutý"
+
+#: id:20166
+msgid "Locked"
+msgstr "Zamknutý"
+
+#: id:20167
+msgid "Frozen"
+msgstr "Zamrznutý"
+
+#: id:20168
+msgid "Requires reset"
+msgstr "Vyžaduje reset"
+
+#: id:20169
+msgid "Week"
+msgstr "Týždeň"
+
+#: id:20170
+msgid "Line"
+msgstr "Linka"
+
+#: id:20171
+msgid "Windows network (SMB)"
+msgstr "Windows sieť (SMB)"
+
+#: id:20172
+msgid "XBMSP server"
+msgstr "XBMSP server"
+
+#: id:20173
+msgctxt "Auto context with id 20173"
+msgid "FTP server"
+msgstr "FTP server"
+
+#: id:20174
+msgid "iTunes music share (DAAP)"
+msgstr "iTunes zdieľanie hudby (DAAP)"
+
+#: id:20175
+msgid "UPnP server"
+msgstr "UPnP Server"
+
+#: id:20176
+msgid "Show video info"
+msgstr "Zobraziť informácie o videu"
+
+#: id:20177
+msgid "Done"
+msgstr "V poriadku"
+
+#: id:20178
+msgid "Shift"
+msgstr "Shift"
+
+#: id:20179
+msgid "Caps Lock"
+msgstr "Caps Lock"
+
+#: id:20180
+msgid "Symbols"
+msgstr "Symboly"
+
+#: id:20181
+msgid "Backspace"
+msgstr "Backspace"
+
+#: id:20182
+msgid "Space"
+msgstr "Space"
+
+#: id:20183
+msgid "Reload skin"
+msgstr "Obnoviť vzhľad"
+
+#: id:20184
+msgid "Rotate pictures using EXIF information"
+msgstr "Otočiť podľa EXIF informácií"
+
+#: id:20185
+msgid "Use poster view styles for TV shows"
+msgstr "Detekovanie hardwarových hodnôt"
+
+#: id:20186
+msgid "Please wait"
+msgstr "Prosím čakajte"
+
+#: id:20187
+msgid "UPnP"
+msgstr ""
+
+#: id:20189
+msgid "Enable auto scrolling for plot & review"
+msgstr "Povoliť automatické rolovanie obsahu a recenzie"
+
+#: id:20190
+msgctxt "Auto context with id 20190"
+msgid "Custom"
+msgstr "Vlastné"
+
+#: id:20191
+msgid "Enable debug logging"
+msgstr "Povoliť ladenie / debug log"
+
+#: id:20192
+msgid "Download additional information during updates"
+msgstr "Získať informácie o albume, keď sa pridáva do knižnice"
+
+#: id:20193
+msgid "Default service for album information"
+msgstr "Získať informácie o interprétovy, keď sa pridáva do knižnice"
+
+#: id:20194
+msgid "Default service for artist information"
+msgstr "Predvolený sťahovač pre hudbu"
+
+#: id:20195
+msgid "Change scraper"
+msgstr "Zmeniť Sťahovač"
+
+#: id:20196
+msgid "Export music library"
+msgstr "Export knižnice hudby"
+
+#: id:20197
+msgid "Import music library"
+msgstr "Import knižnice hudby"
+
+#: id:20198
+msgid "No artist found!"
+msgstr "Interprét nenájdený!"
+
+#: id:20199
+msgid "Downloading artist info failed"
+msgstr "Sťahovanie informácií o interprétovy zlyhalo"
+
+#: id:20250
+msgid "Party on! (videos)"
+msgstr "Párty zahájená! (videa)"
+
+#: id:20251
+msgid "Mixing drinks (videos)"
+msgstr "Miešam nápoje (videa)"
+
+#: id:20252
+msgid "Filling glasses (videos)"
+msgstr "Nalievam poháre (videa)"
+
+#: id:20253
+msgid "WebDAV server (HTTP)"
+msgstr "WebDAV server (HTTP)"
+
+#: id:20254
+msgid "WebDAV server (HTTPS)"
+msgstr "WebDAV server (HTTPS)"
+
+#: id:20255
+msgid "First logon, edit your profile"
+msgstr "Prvé prihlásenie, editujte svoj profil"
+
+#: id:20256
+msgid "HTS Tvheadend client"
+msgstr "HTS Tvheadend klient"
+
+#: id:20257
+msgid "VDR Streamdev client"
+msgstr "VDR Streamdev klient"
+
+#: id:20258
+msgid "MythTV client"
+msgstr "MythTV klient"
+
+#: id:20259
+msgid "Network Filesystem (NFS)"
+msgstr "Sieťový Systém Súborov (NFS)"
+
+#: id:20260
+msgid "Secure Shell (SSH/SFTP)"
+msgstr "Secure Shell (SSH/SFTP)"
+
+#: id:20261
+msgid "Apple Filing Protocol (AFP)"
+msgstr "Protokol súboru Apple (AFP)"
+
+#: id:20300
+msgid "Web server directory (HTTP)"
+msgstr "Web server zložka (HTTP)"
+
+#: id:20301
+msgid "Web server directory (HTTPS)"
+msgstr "Web server zložka (HTTPS)"
+
+#: id:20302
+msgid "Unable to write to folder:"
+msgstr "Nie je možné zapísať do priečinka:"
+
+#: id:20303
+msgid "Do you want to skip and proceed?"
+msgstr "Želáte si preskočiť a prejsť ďalej?"
+
+#: id:20304
+msgid "RSS Feed"
+msgstr "RSS Spravodajstvo"
+
+#: id:20307
+msgid "Secondary DNS"
+msgstr "Sekundárne DNS"
+
+#: id:20308
+msgid "DHCP server:"
+msgstr "DHCP Server:"
+
+#: id:20309
+msgid "Make new folder"
+msgstr "Vytvoriť nový priečinok"
+
+#: id:20310
+msgid "Dim LCD on playback"
+msgstr "Stmaviť LCD pri prehrávaní"
+
+#: id:20311
+msgid "Unknown or onboard (protected)"
+msgstr "Neznámy alebo na Doske (chránený)"
+
+#: id:20312
+msgid "Dim LCD on paused"
+msgstr "Stmaviť LCD pri pauze"
+
+#: id:20314
+msgid "Videos - Library"
+msgstr "Video - Knižnica"
+
+#: id:20316
+msgid "Sort by: ID"
+msgstr "Usporiadať: ID"
+
+#: id:20324
+msgid "Play part..."
+msgstr "Hrať časť..."
+
+#: id:20325
+msgid "Calibration reset"
+msgstr "Časť %i / %i"
+
+#: id:20326
+msgid "This will reset the calibration values for %s"
+msgstr "Tímto zmažete uložené hodnoty kalibrácie pre %s"
+
+#: id:20327
+msgid "to it's default values."
+msgstr "na predvolené hodnoty."
+
+#: id:20328
+msgid "Browse for destination"
+msgstr "Vybrať cieľ"
+
+#: id:20329
+msgid "Movies are in separate folders that match the movie title"
+msgstr ""
+
+#: id:20330
+msgid "Use folder names for lookups"
+msgstr "Vyhľadávať podľa názvu priečinku"
+
+#: id:20331
+msgctxt "Auto context with id 20331"
+msgid "File"
+msgstr "Súbor"
+
+#: id:20332
+msgid "Use file or folder names in lookups?"
+msgstr "Chcete vyhľadávať podľa názvu súboru alebo priečinku?"
+
+#: id:20333
+msgid "Set content"
+msgstr "Nastaviť obsah"
+
+#: id:20334
+msgid "Folder"
+msgstr "Priečinok"
+
+#: id:20335
+msgid "Look for content recursively?"
+msgstr "Vyhľadávať v podpriečinkoch?"
+
+#: id:20336
+msgid "Unlock sources"
+msgstr "Odomknúť zdroje"
+
+#: id:20337
+msgid "Actor"
+msgstr "Herec"
+
+#: id:20338
+msgid "Movie"
+msgstr "Film"
+
+#: id:20339
+msgid "Director"
+msgstr "Režisér"
+
+#: id:20340
+msgid "Do you want to remove all items within"
+msgstr "Chcete odstrániť všetky položky v"
+
+#: id:20341
+msgid "this path from the XBMC library?"
+msgstr "tejto ceste z knižnice?"
+
+#: id:20342
+msgctxt "Auto context with id 20342"
+msgid "Movies"
+msgstr "Filmy"
+
+#: id:20343
+msgid "TV shows"
+msgstr "Seriály"
+
+#: id:20344
+msgid "This directory contains"
+msgstr "Tento priečinok obsahuje"
+
+#: id:20345
+msgid "Run automated scan"
+msgstr "Spustiť automatické prehľadanie"
+
+#: id:20346
+msgid "Scan recursively"
+msgstr "Vyhľadávať v podpriečinkoch"
+
+#: id:20347
+msgid "as"
+msgstr "ako"
+
+#: id:20348
+msgid "Directors"
+msgstr "Režisér"
+
+#: id:20349
+msgid "No video files found in this path!"
+msgstr "Na tejto ceste nebol nájdený žiadny video súbor!"
+
+#: id:20350
+msgid "votes"
+msgstr "hlasov"
+
+#: id:20351
+msgid "TV show information"
+msgstr "Informácie o seriáli"
+
+#: id:20352
+msgid "Episode information"
+msgstr "Informácie o epizóde"
+
+#: id:20353
+msgid "Loading TV show details"
+msgstr "Načítanie detailov o seriáli"
+
+#: id:20354
+msgid "Fetching episode guide"
+msgstr "Získavanie informácií o epizódach"
+
+#: id:20355
+msgid "Loading info for episodes in directory"
+msgstr "Načítanie informácií o epizódach v priečinku"
+
+#: id:20356
+msgid "Select TV show:"
+msgstr "Vyberte seriál:"
+
+#: id:20357
+msgid "Enter the TV show name"
+msgstr "Zadajte názov seriálu"
+
+#: id:20358
+msgid "Season %i"
+msgstr "Sezóna %i"
+
+#: id:20359
+msgid "Episode"
+msgstr "Epizóda"
+
+#: id:20360
+msgid "Episodes"
+msgstr "Epizódy"
+
+#: id:20361
+msgid "Loading episode details"
+msgstr "Načítanie detailov o epizóde"
+
+#: id:20362
+msgid "Remove episode from library"
+msgstr "Odstrániť epizódu z knižnice"
+
+#: id:20363
+msgid "Remove TV show from library"
+msgstr "Odstrániť seriál z knižnice"
+
+#: id:20364
+msgid "TV show"
+msgstr "Seriál"
+
+#: id:20365
+msgid "Episode plot"
+msgstr "Obsah epizódy"
+
+#: id:20366
+msgid "* All seasons"
+msgstr "* Všetky sezóny"
+
+#: id:20367
+msgid "Hide watched"
+msgstr "Schovať sledované"
+
+#: id:20368
+msgid "Prod code"
+msgstr "Kód produkcie"
+
+#: id:20369
+msgid "Show plot for unwatched items"
+msgstr "Zobraziť obsah pre nevidené videá"
+
+#: id:20370
+msgid "* Hidden to prevent spoilers *"
+msgstr "* nezobrazené pre spoilery *"
+
+#: id:20371
+msgid "Set season thumb"
+msgstr "Priradiť náhľad k sezóne"
+
+#: id:20372
+msgid "Season image"
+msgstr "Obrázok sezóny"
+
+#: id:20373
+msgid "Season"
+msgstr "Sezóna"
+
+#: id:20374
+msgid "Downloading movie information"
+msgstr "Sťahovanie informácií o filme"
+
+#: id:20375
+msgid "Unassign content"
+msgstr "Odobrať obsah"
+
+#: id:20376
+msgid "Original title"
+msgstr "Pôvodný názov"
+
+#: id:20377
+msgid "Refresh TV show information"
+msgstr "Obnoviť informácie o seriáli"
+
+#: id:20378
+msgid "Refresh info for all episodes?"
+msgstr "Obnoviť informácie pre všetky epizódy?"
+
+#: id:20379
+msgid "Selected folder contains a single TV show"
+msgstr "Priečinok obsahuje jeden seriál"
+
+#: id:20380
+msgid "Exclude selected folder from scans"
+msgstr "Vylúčiť priečinok z prehľadávania"
+
+#: id:20381
+msgid "Specials"
+msgstr "Špeciál"
+
+#: id:20382
+msgid "Automatically grab season thumbs"
+msgstr "Automaticky sťiahnúť náhľad k sezónam"
+
+#: id:20383
+msgid "Selected folder contains a single video"
+msgstr "Priečinok obsahuje jedno video"
+
+#: id:20384
+msgid "Link to TV show"
+msgstr "Spojiť so seriálom"
+
+#: id:20385
+msgid "Remove link to TV show"
+msgstr "Odstrániť spojenie so seriálom"
+
+#: id:20386
+msgid "Recently added movies"
+msgstr "Naposledy pridané filmy"
+
+#: id:20387
+msgid "Recently added episodes"
+msgstr "Naposledy pridané epizódy"
+
+#: id:20388
+msgid "Studios"
+msgstr "Štúdio"
+
+#: id:20389
+msgid "Music videos"
+msgstr "Videoklipy"
+
+#: id:20390
+msgid "Recently added music videos"
+msgstr "Naposledy pridané videoklipy"
+
+#: id:20391
+msgid "Music video"
+msgstr "Videoklip"
+
+#: id:20392
+msgid "Remove music video from library"
+msgstr "Odstrániť videoklip z knižnice"
+
+#: id:20393
+msgctxt "Auto context with id 20393"
+msgid "Music video information"
+msgstr "Informácie o videoklipe"
+
+#: id:20394
+msgid "Loading music video information"
+msgstr "Načítanie informácií o videoklipe"
+
+#: id:20395
+msgid "Mixed"
+msgstr "Zmiešané"
+
+#: id:20396
+msgid "Go to albums by artist"
+msgstr "Prejsť na albumy podľa interpréta"
+
+#: id:20397
+msgid "Go to album"
+msgstr "Prejsť na album"
+
+#: id:20398
+msgid "Play song"
+msgstr "Prehrať skladbu"
+
+#: id:20399
+msgid "Go to music videos from album"
+msgstr "Prejsť na videoklipy z albumu"
+
+#: id:20400
+msgid "Go to music videos by artist"
+msgstr "Prejsť na videoklipy od interpréta"
+
+#: id:20401
+msgid "Play music video"
+msgstr "Prehrať videoklip"
+
+#: id:20402
+msgid "Download actor thumbnails when adding to library"
+msgstr "Automaticky stiahnuť náhľady hercov"
+
+#: id:20403
+msgid "Set actor thumb"
+msgstr "Nastaviť náhľad hercov"
+
+#: id:20405
+msgid "Remove episode bookmark"
+msgstr "Odstrániť záložku epizódy"
+
+#: id:20406
+msgid "Set episode bookmark"
+msgstr "Nastaviť záložku epizódy"
+
+#: id:20407
+msgid "Scraper settings"
+msgstr "Nastavenie Sťahovača"
+
+#: id:20408
+msgid "Downloading music video information"
+msgstr "Sťahujem informácie o videoklipe"
+
+#: id:20409
+msgid "Downloading TV show information"
+msgstr "Sťahujem informácie o seriáli"
+
+#: id:20410
+msgid "Trailer"
+msgstr "Ukážka"
+
+#: id:20411
+msgid "Flatten"
+msgstr "Jednoduchý mód"
+
+#: id:20412
+msgid "Flatten TV shows"
+msgstr "Zobraziť TV seriály zjednodušene"
+
+#: id:20413
+msgid "Get fanart"
+msgstr "FanArt-y"
+
+#: id:20414
+msgid "Show Fanart in video and music libraries"
+msgstr "Zobraziť FanArt vo video knižnici"
+
+#: id:20415
+msgid "Scanning for new content"
+msgstr "Hľadá sa nový obsah"
+
+#: id:20416
+msgid "First aired"
+msgstr "Premiéra"
+
+#: id:20417
+msgid "Writer"
+msgstr "Autor"
+
+#: id:20419
+msgid "Replace file names with library titles"
+msgstr "Zobraziť metadata v súboroch"
+
+#: id:20420
+msgctxt "Auto context with id 20420"
+msgid "Never"
+msgstr "Nikdy"
+
+#: id:20421
+msgid "If only one season"
+msgstr "Iba ak jedna sezóna"
+
+#: id:20422
+msgid "Always"
+msgstr "Vždy"
+
+#: id:20423
+msgid "Has trailer"
+msgstr "Má ukážku"
+
+#: id:20424
+msgid "False"
+msgstr "Nie"
+
+#: id:20425
+msgid "Fanart slideshow"
+msgstr "Fanart prezentácia"
+
+#: id:20426
+msgid "Export to a single file or separate"
+msgstr "Exportovať všetko do jedného súboru alebo"
+
+#: id:20427
+msgid "files per entry?"
+msgstr "každú položku do samostatného súboru?"
+
+#: id:20428
+msgid "Single file"
+msgstr "1 súbor"
+
+#: id:20429
+msgctxt "Auto context with id 20429"
+msgid "Separate"
+msgstr "Oddelene"
+
+#: id:20430
+msgid "Export thumbnails and fanart?"
+msgstr "Exportovať náhľady a FanArt?"
+
+#: id:20431
+msgid "Overwrite old files?"
+msgstr "Prepísať staré súbory?"
+
+#: id:20432
+msgid "Exclude path from library updates"
+msgstr "Nezahrňovať položky v tomto umiestnení pri aktualizácii knižnice"
+
+#: id:20433
+msgid "Extract thumbnails and video information"
+msgstr "Získavať náhľady a informácie o videu zo súboru"
+
+#: id:20434
+msgid "Sets"
+msgstr "Sady"
+
+#: id:20435
+msgid "Set movieset thumb"
+msgstr "Priradiť náhľad sade filmov"
+
+#: id:20436
+msgid "Export actor thumbs?"
+msgstr "Exportovať náhľady hercov?"
+
+#: id:20437
+msgid "Choose fanart"
+msgstr "Vyberte FanArt"
+
+#: id:20438
+msgid "Local fanart"
+msgstr "Lokálny FanArt"
+
+#: id:20439
+msgid "No fanart"
+msgstr "Žiadny FanArt"
+
+#: id:20440
+msgid "Current fanart"
+msgstr "Aktuálny FanArt"
+
+#: id:20441
+msgid "Remote fanart"
+msgstr "Internetový FanArt"
+
+#: id:20442
+msgid "Change content"
+msgstr "Zmeniť obsah"
+
+#: id:20443
+msgid "Do you want to refresh info for all"
+msgstr "Prajete si aktualizovať informácie pre"
+
+#: id:20444
+msgid "items within this path?"
+msgstr "všetky položky v tomto umiestnení?"
+
+#: id:20445
+msgid "Fanart"
+msgstr "FanArt"
+
+#: id:20446
+msgid "Locally stored information found."
+msgstr "Lokálne uložené informácie nájdené."
+
+#: id:20447
+msgid "Ignore and refresh from internet?"
+msgstr "Ignorovať a aktualizovať z internetu?"
+
+#: id:20448
+msgid "Could not download information"
+msgstr "Nie je možné stiahnuť informácie"
+
+#: id:20449
+msgid "Unable to connect to remote server"
+msgstr "Server je pravdepodobne nedostupný"
+
+#: id:20450
+msgid "Would you like to continue scanning?"
+msgstr "Chcete pokračovať v aktualizácii?"
+
+#: id:20451
+msgid "Countries"
+msgstr "Krajina"
+
+#: id:20452
+msgid "episode"
+msgstr "epizóda"
+
+#: id:20453
+msgid "episodes"
+msgstr "epizódy"
+
+#: id:20454
+msgid "Listener"
+msgstr "Poslucháč"
+
+#: id:20455
+msgid "Listeners"
+msgstr "Poslucháči"
+
+#: id:20456
+msgid "Set movieset fanart"
+msgstr "Nastaviť fanart setu filmov"
+
+#: id:20457
+msgid "Movie set"
+msgstr "Set filmov"
+
+#: id:20458
+msgid "Group movies in sets"
+msgstr ""
+
+#: id:21330
+msgid "Show hidden files and directories"
+msgstr "Zobraziť skryté súbory a priečinky"
+
+#: id:21331
+msgid "TuxBox client"
+msgstr "TuxBox klient"
+
+#: id:21332
+msgid "WARNING: Target TuxBox device is in recording-mode!"
+msgstr "POZOR: CieľovéTuxBox zariadenie je v nahrávacom móde!"
+
+#: id:21333
+msgid "The stream will be stopped!"
+msgstr "Stream bude zastavený!"
+
+#: id:21334
+msgid "Zap to channel: %s failed!"
+msgstr "Prepnutie na kanál: %s zlyhalo!"
+
+#: id:21335
+msgid "Are you sure to start the stream?"
+msgstr "Chcete spustiť stream?"
+
+#: id:21336
+msgid "Connecting to: %s"
+msgstr "Pripájam k: %s"
+
+#: id:21337
+msgid "TuxBox device"
+msgstr "TuxBox zariadenie"
+
+#: id:21359
+msgid "Add media share..."
+msgstr "Pridať zdieľané médiá..."
+
+#: id:21360
+msgid "Share video and music libraries through UPnP"
+msgstr "Zdielať video a hudobné knižnice pomocou UPnP"
+
+#: id:21364
+msgid "Edit media share"
+msgstr "Upraviť zdieľanie média"
+
+#: id:21365
+msgid "Remove media share"
+msgstr "Odstrániť zdieľanie média"
+
+#: id:21366
+msgid "Subtitle folder"
+msgstr "Priečinok s titulkami"
+
+#: id:21367
+msgid "Movie & alternate subtitle directory"
+msgstr "Film a alternatívny priečinok s titulkami"
+
+#: id:21368
+msgid "Override ASS/SSA subtitles fonts"
+msgstr ""
+
+#: id:21369
+msgid "Enable mouse and Touch Screen support"
+msgstr "Povoliť myš"
+
+#: id:21370
+msgid "Play navigation sounds during media playback"
+msgstr "Hrať zvuky navigácie počas prehrávania média"
+
+#: id:21371
+msgid "Thumbnail"
+msgstr "Náhľad"
+
+#: id:21372
+msgid "Forced DVD player region"
+msgstr "Vnútiť prehrávaču DVD región"
+
+#: id:21373
+msgid "Video output"
+msgstr "Video zariadenie"
+
+#: id:21374
+msgid "Video aspect"
+msgstr "Video vzhľad"
+
+#: id:21375
+msgctxt "Auto context with id 21375"
+msgid "Normal"
+msgstr "Normálny"
+
+#: id:21376
+msgid "Letterbox"
+msgstr "Letterbox"
+
+#: id:21377
+msgid "Widescreen"
+msgstr "Širokouhlý"
+
+#: id:21378
+msgid "Enable 480p"
+msgstr "Povoliť 480p"
+
+#: id:21379
+msgid "Enable 720p"
+msgstr "Povoliť 720p"
+
+#: id:21380
+msgid "Enable 1080i"
+msgstr "Povoliť 1080i"
+
+#: id:21381
+msgid "Enter name of new playlist"
+msgstr "Zadaj názov nového playlist-u"
+
+#: id:21382
+msgid "Show \"Add source\" buttons in file lists"
+msgstr "Zobraziť tlačítko \"Pridať zdroj\" v zozname súborov"
+
+#: id:21383
+msgid "Enable scrollbars"
+msgstr "Povoliť rolovacie pruhy"
+
+#: id:21384
+msgid "Make watched filtering a toggle in video library"
+msgstr "Vytvoriť filtrovanie podľa sledovania vo video knižnici"
+
+#: id:21385
+msgctxt "Auto context with id 21385"
+msgid "Open"
+msgstr "Otvoriť"
+
+#: id:21386
+msgid "Acoustic management level"
+msgstr "Úroveň akustickej správy"
+
+#: id:21387
+msgid "Fast"
+msgstr "Rýchly"
+
+#: id:21388
+msgid "Quiet"
+msgstr "Tichý"
+
+#: id:21389
+msgid "Enable custom background"
+msgstr "Povoliť vlastné pozadie"
+
+#: id:21390
+msgid "Power management level"
+msgstr "Úroveň správy napájania"
+
+#: id:21391
+msgid "High power"
+msgstr "Veľa energie"
+
+#: id:21392
+msgid "Low power"
+msgstr "Málo energie"
+
+#: id:21393
+msgid "High standby"
+msgstr "Veľká pohotovosť"
+
+#: id:21394
+msgid "Low standby"
+msgstr "Malá pohotovosť"
+
+#: id:21395
+msgid "Unable to cache files bigger than 4GB"
+msgstr "Súbory väčšie ako 4GB sa nedajú načítať do vyrovnávacej pamäte"
+
+#: id:21396
+msgid "Chapter"
+msgstr "Kapitola"
+
+#: id:21397
+msgid "High quality pixel shader v2"
+msgstr "Vysoko kvalitý Pixel Shader V2"
+
+#: id:21398
+msgid "Enable playlist at startup"
+msgstr "Povoliť playlist pri štarte"
+
+#: id:21399
+msgid "Use tween animations"
+msgstr "Použi trasúce animácie"
+
+#: id:21400
+msgid "contains"
+msgstr "obsahje"
+
+#: id:21401
+msgid "does not contain"
+msgstr "neobsahuje"
+
+#: id:21402
+msgid "is"
+msgstr "je"
+
+#: id:21403
+msgid "is not"
+msgstr "nie je"
+
+#: id:21404
+msgid "starts with"
+msgstr "začína s"
+
+#: id:21405
+msgid "ends with"
+msgstr "končí s"
+
+#: id:21406
+msgid "greater than"
+msgstr "viac ako"
+
+#: id:21407
+msgid "less than"
+msgstr "menej ako"
+
+#: id:21408
+msgid "after"
+msgstr "potom"
+
+#: id:21409
+msgid "before"
+msgstr "predtým"
+
+#: id:21410
+msgid "in the last"
+msgstr "nakoniec"
+
+#: id:21411
+msgid "not in the last"
+msgstr "vôbec nie"
+
+#: id:21412
+msgid "Scrapers"
+msgstr "Sťahovače"
+
+#: id:21413
+msgid "Default movie scraper"
+msgstr "Predvolený sťahovač pre filmy"
+
+#: id:21414
+msgid "Default tvshow scraper"
+msgstr "Predvolený sťahovač pre TV seriály"
+
+#: id:21415
+msgid "Default music video scraper"
+msgstr "Predvolený sťahovač pre klipy"
+
+#: id:21416
+msgid "Enable fallback based on scraper language"
+msgstr "Povoliť odpoveď na základe jazyka sťahovača"
+
+#: id:21417
+msgid "- Settings"
+msgstr "- Nastavenia"
+
+#: id:21418
+msgid "Multilingual"
+msgstr "Viacjazyčný"
+
+#: id:21419
+msgid "No scrapers present"
+msgstr "Žiadne sťahovače nie sú k dispozícii"
+
+#: id:21420
+msgid "Value to match"
+msgstr "Nájst hodnotu"
+
+#: id:21421
+msgid "Smart playlist rule"
+msgstr "Pravidlá inteligentného playlist-u"
+
+#: id:21422
+msgid "Match items where"
+msgstr "Zhodné položky kde"
+
+#: id:21423
+msgid "New rule..."
+msgstr "Nové pravidlo..."
+
+#: id:21424
+msgid "Items must match"
+msgstr "Položky sa musia zhodovať"
+
+#: id:21425
+msgid "all of the rules"
+msgstr "všetky pravidlá"
+
+#: id:21426
+msgid "one or more of the rules"
+msgstr "jedno alebo viac pravidiel"
+
+#: id:21427
+msgid "Limit to"
+msgstr "S limitom"
+
+#: id:21428
+msgid "No limit"
+msgstr "Bez limitu"
+
+#: id:21429
+msgid "Order by"
+msgstr "Usporiadať podľa"
+
+#: id:21430
+msgid "ascending"
+msgstr "stúpajúci"
+
+#: id:21431
+msgid "descending"
+msgstr "klesajúci"
+
+#: id:21432
+msgid "Edit smart playlist"
+msgstr "Upraviť inteligentný playlist"
+
+#: id:21433
+msgid "Name of the playlist"
+msgstr "Názov playlist-u"
+
+#: id:21434
+msgid "Find items where"
+msgstr "Hľadaj položky kde"
+
+#: id:21435
+msgid "Edit"
+msgstr "Upraviť"
+
+#: id:21436
+msgid "%i items"
+msgstr "%i položiek"
+
+#: id:21437
+msgid "New smart playlist..."
+msgstr "Nový inteligentný playlist..."
+
+#: id:21438
+msgid "%c Drive"
+msgstr "%c disk"
+
+#: id:21439
+msgid "Edit party mode rules"
+msgstr "Upraviť párty mód pravidlá"
+
+#: id:21440
+msgid "Home folder"
+msgstr "Domáci priečinok"
+
+#: id:21441
+msgid "Watched count"
+msgstr "Počet sledovaní"
+
+#: id:21442
+msgid "Episode title"
+msgstr "Názov epizódy"
+
+#: id:21443
+msgid "Video resolution"
+msgstr "Rozlíšenie videa"
+
+#: id:21444
+msgid "Audio channels"
+msgstr "Počet audio kanálov"
+
+#: id:21445
+msgid "Video codec"
+msgstr "Kodek videa"
+
+#: id:21446
+msgid "Audio codec"
+msgstr "Koded audia"
+
+#: id:21447
+msgid "Audio language"
+msgstr "Jayzk audia"
+
+#: id:21448
+msgid "Subtitle language"
+msgstr "Jazyk titulkov"
+
+#: id:21449
+msgid "Remote control sends keyboard presses"
+msgstr "Diaľkový ovládač emuluje stlačenia klávesnice"
+
+#: id:21450
+msgid "- Edit"
+msgstr "- Upraviť"
+
+#: id:21451
+msgid "Internet connection required."
+msgstr "Je vyžadované internetové pripojenie."
+
+#: id:21452
+msgid "Get More..."
+msgstr "Získať Viac..."
+
+#: id:21453
+msgid "Root filesystem"
+msgstr "Koreňový adresár súborového systému"
+
+#: id:21454
+msgid "Cache full"
+msgstr ""
+
+#: id:21455
+msgid "Cache filled before reaching required amount for continous playback"
+msgstr ""
+
+#: id:21460
+msgid "Subtitle location"
+msgstr "Umiestnenie titulkov"
+
+#: id:21461
+msgid "Fixed"
+msgstr "Fixné"
+
+#: id:21462
+msgid "Bottom of video"
+msgstr "V spodnej časti videa"
+
+#: id:21463
+msgid "Below video"
+msgstr "Pod videom"
+
+#: id:21464
+msgid "Top of video"
+msgstr "V hornej časti videa"
+
+#: id:21465
+msgid "Above video"
+msgstr "Nad videom"
+
+#: id:21800
+msgid "File name"
+msgstr "Názov súboru"
+
+#: id:21801
+msgid "File path"
+msgstr "Cesta k súboru"
+
+#: id:21802
+msgid "File size"
+msgstr "Veľkosť súboru"
+
+#: id:21803
+msgid "File date/time"
+msgstr "Dátum/čas súboru"
+
+#: id:21804
+msgid "Slide index"
+msgstr "Číslo stránky"
+
+#: id:21805
+msgctxt "Auto context with id 21805"
+msgid "Resolution"
+msgstr "Rozlíšenie"
+
+#: id:21806
+msgctxt "Auto context with id 21806"
+msgid "Comment"
+msgstr "Poznámka"
+
+#: id:21807
+msgid "Colour/B&W"
+msgstr "Farba/čb"
+
+#: id:21808
+msgid "JPEG process"
+msgstr "Jpeg spracovanie"
+
+#: id:21820
+msgid "Date/Time"
+msgstr "Dátum/čas"
+
+#: id:21821
+msgid "Description"
+msgstr "Popis"
+
+#: id:21822
+msgid "Camera make"
+msgstr "Značka fotoaparátu"
+
+#: id:21823
+msgid "Camera model"
+msgstr "Typ fotoaparátu"
+
+#: id:21824
+msgid "EXIF comment"
+msgstr "Poznámka exif"
+
+#: id:21825
+msgid "Firmware"
+msgstr "Firmware"
+
+#: id:21826
+msgid "Aperture"
+msgstr "Clona"
+
+#: id:21827
+msgid "Focal length"
+msgstr "Ohnisková vzdialenosť"
+
+#: id:21828
+msgid "Focus distance"
+msgstr "Vzdialenosť ohniska"
+
+#: id:21829
+msgid "Exposure"
+msgstr "Expozícia"
+
+#: id:21830
+msgid "Exposure time"
+msgstr "Čas expozície"
+
+#: id:21831
+msgid "Exposure bias"
+msgstr "Úprava expozície"
+
+#: id:21832
+msgid "Exposure mode"
+msgstr "Spôsob expozície"
+
+#: id:21833
+msgid "Flash used"
+msgstr "Použitý blesk"
+
+#: id:21834
+msgid "White-balance"
+msgstr "Vyváženie bielej"
+
+#: id:21835
+msgid "Light source"
+msgstr "Zdroj svetla"
+
+#: id:21836
+msgid "Metering mode"
+msgstr "Režim merania"
+
+#: id:21837
+msgid "ISO"
+msgstr "ISO"
+
+#: id:21838
+msgid "Digital zoom"
+msgstr "Digitálne priblíženie"
+
+#: id:21839
+msgid "CCD width"
+msgstr "CCD šírka"
+
+#: id:21840
+msgid "GPS latitude"
+msgstr "GPS šírka"
+
+#: id:21841
+msgid "GPS longitude"
+msgstr "GPS dĺžka"
+
+#: id:21842
+msgid "GPS altitude"
+msgstr "GPS výška"
+
+#: id:21843
+msgid "Orientation"
+msgstr "Orientácia"
+
+#: id:21860
+msgid "Supplemental categories"
+msgstr "Doplnkové kategórie"
+
+#: id:21861
+msgid "Keywords"
+msgstr "Kľučové slová"
+
+#: id:21862
+msgid "Caption"
+msgstr "Titul"
+
+#: id:21863
+msgid "Author"
+msgstr "Autor"
+
+#: id:21864
+msgid "Headline"
+msgstr "Titulok"
+
+#: id:21865
+msgid "Special instructions"
+msgstr "Špeciálne inštrukcie"
+
+#: id:21866
+msgid "Category"
+msgstr "Kategória"
+
+#: id:21867
+msgid "Byline"
+msgstr "Podtitul"
+
+#: id:21868
+msgid "Byline title"
+msgstr "Podtitul titulu"
+
+#: id:21869
+msgid "Credit"
+msgstr "Hodnotenie"
+
+#: id:21870
+msgid "Source"
+msgstr "Zdroj"
+
+#: id:21871
+msgid "Copyright notice"
+msgstr "Upozornenie o autorských právach"
+
+#: id:21872
+msgid "Object name"
+msgstr "Názov objektu"
+
+#: id:21873
+msgid "City"
+msgstr "Mesto"
+
+#: id:21874
+msgid "State"
+msgstr "Štát"
+
+#: id:21875
+msgctxt "Auto context with id 21875"
+msgid "Country"
+msgstr "Krajina"
+
+#: id:21876
+msgid "Original Tx Reference"
+msgstr "Oficiálny text distribútora"
+
+#: id:21877
+msgid "Date created"
+msgstr "Dátum vytvorenia"
+
+#: id:21878
+msgid "Copyright flag"
+msgstr "Označenie autorských práv"
+
+#: id:21879
+msgid "Country code"
+msgstr "Kód krajiny"
+
+#: id:21880
+msgid "Reference service"
+msgstr "Referenčná služba"
+
+#: id:21881
+msgid "Allow control of XBMC via UPnP"
+msgstr "Povoliť ovládanie XBMC cez UPnP"
+
+#: id:21882
+msgid "Attempt to skip introduction before DVD menu"
+msgstr "Pokus o preskočenie úvodu pred DVD menu"
+
+#: id:21883
+msgid "Saved music"
+msgstr "Skopírované audio CD"
+
+#: id:21884
+msgid "Query info for all artists"
+msgstr "Vyhľadať informácie o všetkých interprétoch"
+
+#: id:21885
+msgid "Downloading album information"
+msgstr "Sťahujem informácie o albume"
+
+#: id:21886
+msgid "Downloading artist information"
+msgstr "Sťahujem informácie o interprétovy"
+
+#: id:21887
+msgid "Biography"
+msgstr "Životopis"
+
+#: id:21888
+msgid "Discography"
+msgstr "Diskografia"
+
+#: id:21889
+msgid "Searching artist"
+msgstr "Hľadanie interpréta"
+
+#: id:21890
+msgid "Select artist"
+msgstr "Výber interpréta"
+
+#: id:21891
+msgctxt "Auto context with id 21891"
+msgid "Artist information"
+msgstr "Informácie interpréta"
+
+#: id:21892
+msgid "Instruments"
+msgstr "Nástroje"
+
+#: id:21893
+msgid "Born"
+msgstr "Narodený"
+
+#: id:21894
+msgid "Formed"
+msgstr "Založený"
+
+#: id:21895
+msgid "Themes"
+msgstr "Žánre"
+
+#: id:21896
+msgid "Disbanded"
+msgstr "Rozpadnutý"
+
+#: id:21897
+msgid "Died"
+msgstr "Zomrel"
+
+#: id:21898
+msgid "Years active"
+msgstr "Aktívne roky"
+
+#: id:21899
+msgid "Label"
+msgstr "Názov"
+
+#: id:21900
+msgid "Born/Formed"
+msgstr "Narodený/Založený"
+
+#: id:22000
+msgid "Update library on startup"
+msgstr "Aktualizovať knižnicu pri štarte"
+
+#: id:22001
+msgid "Hide progress of library updates"
+msgstr "Vždy aktualizovať knižnicu na pozadí"
+
+#: id:22002
+msgid "- DNS suffix"
+msgstr "- DNS prípona"
+
+#: id:22003
+msgid "%2.3fs"
+msgstr "%2.3fs"
+
+#: id:22004
+msgid "Delayed by: %2.3fs"
+msgstr "Oneskorené o %2.3fs"
+
+#: id:22005
+msgid "Ahead by: %2.3fs"
+msgstr "Vpredu o %2.3fs"
+
+#: id:22006
+msgid "Subtitle offset"
+msgstr "Oneskorenie titulkov"
+
+#: id:22007
+msgid "OpenGL vendor:"
+msgstr "OpenGL výrobca:"
+
+#: id:22008
+msgid "OpenGL renderer:"
+msgstr "OpenGL karta:"
+
+#: id:22009
+msgid "OpenGL version:"
+msgstr "OpenGL verzia:"
+
+#: id:22010
+msgid "GPU temperature:"
+msgstr "Teplota GPU"
+
+#: id:22011
+msgid "CPU temperature:"
+msgstr "Teplota CPU"
+
+#: id:22012
+msgid "Total memory"
+msgstr "Celková Pamäť"
+
+#: id:22013
+msgid "Profile data"
+msgstr "Údaje profilu"
+
+#: id:22014
+msgid "Use dim if paused during video playback"
+msgstr "Povoliť stlmenie obrazovky počas pauzy videa"
+
+#: id:22015
+msgid "All recordings"
+msgstr "Všetky nahrávky"
+
+#: id:22016
+msgid "By title"
+msgstr "Podľa názvu"
+
+#: id:22017
+msgid "By group"
+msgstr "Podľa skupiny"
+
+#: id:22018
+msgid "Live channels"
+msgstr "Živé kanály"
+
+#: id:22019
+msgid "Recordings by title"
+msgstr "Nahrávky podľa názvu"
+
+#: id:22020
+msgid "Guide"
+msgstr "Návod"
+
+#: id:22021
+msgid "Allowed error in aspect ratio to minimize black bars"
+msgstr "Odchylka pomeru strán k minimalizácii čiernych okrajov"
+
+#: id:22022
+msgid "Show video files in listings"
+msgstr "Zobraziť videá v zozname súborov"
+
+#: id:22023
+msgid "DirectX vendor:"
+msgstr "DirectX výrobca:"
+
+#: id:22024
+msgid "Direct3D version:"
+msgstr "Direct3D verzia:"
+
+#: id:22030
+msgctxt "Auto context with id 22030"
+msgid "Font"
+msgstr "Font"
+
+#: id:22031
+msgctxt "Auto context with id 22031"
+msgid "- Size"
+msgstr "- Veľkosť"
+
+#: id:22032
+msgctxt "Auto context with id 22032"
+msgid "- Colours"
+msgstr "- Farba"
+
+#: id:22033
+msgid "- Charset"
+msgstr "- Znaková sada"
+
+#: id:22034
+msgid "Export karaoke titles as HTML"
+msgstr "Exportovať do HTML"
+
+#: id:22035
+msgid "Export karaoke titles as CSV"
+msgstr "Exportovať do CSV"
+
+#: id:22036
+msgid "Import karaoke titles..."
+msgstr "Importovať karaoke tituly..."
+
+#: id:22037
+msgid "Show song selector automatically"
+msgstr "Automaticky zobraziť dialóg pre výber skladby"
+
+#: id:22038
+msgid "Export karaoke titles..."
+msgstr "Exportovať karaoke tituly..."
+
+#: id:22039
+msgid "Enter song number"
+msgstr "Vyber číslo skladby"
+
+#: id:22040
+msgid "white/green"
+msgstr "biela/zelená"
+
+#: id:22041
+msgid "white/red"
+msgstr "biela/červená"
+
+#: id:22042
+msgid "white/blue"
+msgstr "biela/modrá"
+
+#: id:22043
+msgid "black/white"
+msgstr "čierna/biela"
+
+#: id:22079
+msgid "Default select action"
+msgstr "Predvolené akcie pri výbere položky"
+
+#: id:22080
+msgid "Choose"
+msgstr "Zobraziť ponuku"
+
+#: id:22081
+msgid "Show Information"
+msgstr "Zobraziť informácie"
+
+#: id:22082
+msgid "More..."
+msgstr "Viac..."
+
+#: id:22083
+msgid "Play all"
+msgstr "Prehrať všetko"
+
+#: id:23049
+msgid "Teletext not available"
+msgstr "Teletext nie je k dispozícii"
+
+#: id:23050
+msgid "Activate Teletext"
+msgstr "Povoliť teletext"
+
+#: id:23051
+msgid "Part %i"
+msgstr "Časť %i"
+
+#: id:23052
+msgid "Buffering %i bytes"
+msgstr "Prebieha načítanie %i bajtov"
+
+#: id:23053
+msgid "Stopping"
+msgstr "Prebieheha ukončovanie"
+
+#: id:23054
+msgid "Running"
+msgstr "Prebieha spustenie"
+
+#: id:23100
+msgid "External Player Active"
+msgstr "Externý Prehrávač Je Aktívny"
+
+#: id:23101
+msgid "Click OK to terminate the player"
+msgstr "Kliknite OK pre zatvorenie prehrávača"
+
+#: id:23104
+msgid "Click OK when playback has ended"
+msgstr "Kliknite OK po ukončení prehrávania"
+
+#: id:24000
+msgid "Add-on"
+msgstr "Doplnok"
+
+#: id:24001
+msgid "Add-ons"
+msgstr "Doplnky"
+
+#: id:24002
+msgid "Add-on options"
+msgstr "Nastavenia doplnku"
+
+#: id:24003
+msgid "Add-on Information"
+msgstr "Informácie doplnku"
+
+#: id:24005
+msgctxt "Auto context with id 24005"
+msgid "Media sources"
+msgstr "Zdroje médií"
+
+#: id:24007
+msgctxt "Auto context with id 24007"
+msgid "Movie information"
+msgstr "Informácie o filme"
+
+#: id:24008
+msgctxt "Auto context with id 24008"
+msgid "Screensaver"
+msgstr "Šetrič obrazovky"
+
+#: id:24009
+msgid "Script"
+msgstr "Skript"
+
+#: id:24010
+msgctxt "Auto context with id 24010"
+msgid "Visualization"
+msgstr "Vizualizácia"
+
+#: id:24011
+msgid "Add-on repository"
+msgstr "Repozitár doplnkov"
+
+#: id:24012
+msgctxt "Auto context with id 24012"
+msgid "Subtitles"
+msgstr "Titulky"
+
+#: id:24013
+msgid "Lyrics"
+msgstr "Texty skladieb"
+
+#: id:24014
+msgid "TV information"
+msgstr "Informácie o TV seriáli"
+
+#: id:24015
+msgctxt "Auto context with id 24015"
+msgid "Music video information"
+msgstr "Informácie o klipe"
+
+#: id:24016
+msgctxt "Auto context with id 24016"
+msgid "Album information"
+msgstr "Informácie o albume"
+
+#: id:24017
+msgctxt "Auto context with id 24017"
+msgid "Artist information"
+msgstr "Informácie o interprétovy"
+
+#: id:24018
+msgctxt "Auto context with id 24018"
+msgid "Services"
+msgstr "Služby"
+
+#: id:24020
+msgid "Configure"
+msgstr "Nastavenie"
+
+#: id:24021
+msgctxt "Auto context with id 24021"
+msgid "Disable"
+msgstr "Deaktivovať"
+
+#: id:24022
+msgid "Enable"
+msgstr "Aktivovať"
+
+#: id:24023
+msgid "Add-on disabled"
+msgstr "Doplnok je deaktivovaný"
+
+#: id:24027
+msgctxt "Auto context with id 24027"
+msgid "Weather"
+msgstr "Počasie"
+
+#: id:24028
+msgid "Weather.com (standard)"
+msgstr "Weather.com (štandardný)"
+
+#: id:24030
+msgid "This Add-on can not be configured"
+msgstr "Tento doplnok nejde konfigurovať"
+
+#: id:24031
+msgid "Error loading settings"
+msgstr "Chyba pri načítaní konfigurácie nastavenia"
+
+#: id:24032
+msgid "All Add-ons"
+msgstr "Všetky Doplnky"
+
+#: id:24033
+msgid "Get Add-ons"
+msgstr "Získať Doplnky"
+
+#: id:24034
+msgid "Check for updates"
+msgstr "Skontrolovať aktualizácie"
+
+#: id:24035
+msgid "Force refresh"
+msgstr "Vynútiť obnovu"
+
+#: id:24036
+msgid "Change log"
+msgstr "Zmeny"
+
+#: id:24037
+msgid "Uninstall"
+msgstr "Odinštalovať"
+
+#: id:24038
+msgid "Install"
+msgstr "Nainštalovať"
+
+#: id:24039
+msgid "Disabled Add-ons"
+msgstr "Deaktivované Doplnky"
+
+#: id:24040
+msgid "(Clear the current setting)"
+msgstr "(Vyčistiť aktuálne nastavenia)"
+
+#: id:24041
+msgid "Install from zip file"
+msgstr "Inštalovať doplnky zo zip archívu"
+
+#: id:24042
+msgid "Downloading %i%%"
+msgstr "Stiahnuté %i%%"
+
+#: id:24043
+msgid "Available Updates"
+msgstr "Dostupné aktualizácie"
+
+#: id:24044
+msgid "Dependencies not met"
+msgstr "Závislosti sa nestretli"
+
+#: id:24045
+msgid "Add-on does not have the correct structure"
+msgstr "Doplnok nemá správnu štruktúru"
+
+#: id:24046
+msgid "%s is used by the following installed add-on(s)"
+msgstr "%s je použitá následovným nainštalovaným doplnkom"
+
+#: id:24047
+msgid "This add-on cannot be uninstalled"
+msgstr "Tento doplnok sa nedá odinštalovať"
+
+#: id:24048
+msgid "Rollback"
+msgstr "Návrat"
+
+#: id:24050
+msgid "Available Add-ons"
+msgstr "Dostupné doplnky"
+
+#: id:24051
+msgid "Version:"
+msgstr "Verzia:"
+
+#: id:24052
+msgid "Disclaimer"
+msgstr "Upozornenie"
+
+#: id:24053
+msgid "License:"
+msgstr "Licencia:"
+
+#: id:24054
+msgid "Changelog"
+msgstr "Zmeny"
+
+#: id:24059
+msgid "Would you like to enable this Add-on?"
+msgstr "Želáte si aktivovať tento doplnok?"
+
+#: id:24060
+msgid "Would you like to disable this Add-on?"
+msgstr "Želáte si deaktivovať tento doplnok?"
+
+#: id:24061
+msgid "Add-on update available!"
+msgstr "Je k dispozícii aktualizácia doplnku!"
+
+#: id:24062
+msgid "Enabled Add-ons"
+msgstr "Aktivované Doplnky"
+
+#: id:24063
+msgid "Auto update"
+msgstr "Auto. aktualizácie"
+
+#: id:24064
+msgid "Add-on enabled"
+msgstr "Doplnok bol aktivovaný"
+
+#: id:24065
+msgid "Add-on updated"
+msgstr "Doplnok bol aktualizovaný"
+
+#: id:24066
+msgid "Cancel Add-on download?"
+msgstr "Naozaj chcete zrušiť sťahovanie doplnku?"
+
+#: id:24067
+msgid "Currently downloading Add-ons"
+msgstr "Momentálne sťahované doplnky"
+
+#: id:24068
+msgid "Update available"
+msgstr "Aktualizácia k dispozícii"
+
+#: id:24069
+msgid "Update"
+msgstr "Aktualizovať"
+
+#: id:24070
+msgid "Add-on could not be loaded."
+msgstr "Načítanie doplnku sa nepodarilo."
+
+#: id:24071
+msgid "An unknown error has occurred."
+msgstr "Objavila sa neznáma chyba."
+
+#: id:24072
+msgid "Settings required"
+msgstr "Vyžadovaná zmena nastavení"
+
+#: id:24073
+msgid "Could not connect"
+msgstr "Nedá sa pripojiť"
+
+#: id:24074
+msgid "Needs to restart"
+msgstr "Je vyžadovaný reštart"
+
+#: id:24075
+msgctxt "Auto context with id 24075"
+msgid "Disable"
+msgstr "Deaktivovať"
+
+#: id:24076
+msgid "Add-on Required"
+msgstr "Potrebný doplnok"
+
+#: id:24080
+msgid "Try to reconnect?"
+msgstr "Pokúsiť sa o opätovné pripojenie?"
+
+#: id:24089
+msgid "Add-on restarts"
+msgstr "Doplnok sa reštartuje"
+
+#: id:24090
+msgid "Lock Add-on manager"
+msgstr "Uzamknutie správcu doplnkov"
+
+#: id:24094
+msgid "(current)"
+msgstr "(aktuálny)"
+
+#: id:24095
+msgid "(blacklisted)"
+msgstr "(na čiernej listine)"
+
+#: id:24096
+msgid "Add-on has been marked as broken in repository."
+msgstr "Doplnok bol v repozitáry označený ako nefunkčný."
+
+#: id:24097
+msgid "Would you like to disable it on your system?"
+msgstr "Chcete ho deaktivovať?"
+
+#: id:24098
+msgid "Broken"
+msgstr "Nefunkčný"
+
+#: id:24099
+msgid "Would you like to switch to this skin?"
+msgstr "Želáte si použiť tento skin?"
+
+#: id:24100
+msgid "To use this feature you must download an Add-on:"
+msgstr "Pre použite tejto funkcie potrebujete stiahnuť Doplnok:"
+
+#: id:24101
+msgid "Would you like to download this Add-on?"
+msgstr "Želáte si stiahnuť tento doplnok?"
+
+#: id:25000
+msgid "Notifications"
+msgstr "Notifikácie"
+
+#: id:29800
+msgid "Library Mode"
+msgstr "Knižničný mód"
+
+#: id:29801
+msgid "QWERTY keyboard"
+msgstr "QWERTY klávesnica"
+
+#: id:29802
+msgid "Passthrough Audio in use"
+msgstr "Audio je preposielané receiveru"
+
+#: id:33001
+msgid "Trailer quality"
+msgstr "Kvalita traileru"
+
+#: id:33002
+msgid "Stream"
+msgstr "Streamovať"
+
+#: id:33003
+msgid "Download"
+msgstr "Stiahnuť"
+
+#: id:33004
+msgid "Download & play"
+msgstr "Stiahnuť a prehrať"
+
+#: id:33005
+msgid "Download & save"
+msgstr "Stiahnuť a uložiť"
+
+#: id:33006
+msgid "Today"
+msgstr "Dnes"
+
+#: id:33007
+msgid "Tomorrow"
+msgstr "Zajtra"
+
+#: id:33008
+msgid "Saving"
+msgstr "Prebieha ukladanie"
+
+#: id:33009
+msgid "Copying"
+msgstr "Prebieha kopírovanie"
+
+#: id:33010
+msgid "Set download directory"
+msgstr "Nastaviť adresár pre sťahovanie"
+
+#: id:33011
+msgid "Search duration"
+msgstr "Doba vyhladávania"
+
+#: id:33012
+msgid "Short"
+msgstr "Krátky"
+
+#: id:33013
+msgid "Long"
+msgstr "Dlhý"
+
+#: id:33014
+msgid "Use DVD player instead of regular player"
+msgstr "Použiť DVD prehrávač namiesto bežného prehrávača"
+
+#: id:33015
+msgid "Ask for download before playing video"
+msgstr "Pred prehrávaním videa sa spýtať na jeho stiahnutie"
+
+#: id:33016
+msgid "Clips"
+msgstr "Klipy"
+
+#: id:33017
+msgid "Restart plugin to enable"
+msgstr "Pre aktiváciu reštartujte doplnok"
+
+#: id:33018
+msgid "Tonight"
+msgstr "Dnes večer"
+
+#: id:33019
+msgid "Tomorrow Night"
+msgstr "Zajtra večer"
+
+#: id:33020
+msgid "Condition"
+msgstr "Stav"
+
+#: id:33021
+msgid "Precipitation"
+msgstr "Zrážky"
+
+#: id:33022
+msgid "Precip"
+msgstr "Zrážky"
+
+#: id:33023
+msgid "Humid"
+msgstr "Vlhkosť"
+
+#: id:33024
+msgid "Feels"
+msgstr "zdá sa ako"
+
+#: id:33025
+msgid "Observed"
+msgstr "Pozorované"
+
+#: id:33026
+msgid "Departure from normal"
+msgstr "Odchylka od normálu"
+
+#: id:33027
+msgid "Sunrise"
+msgstr "Východ slnka"
+
+#: id:33028
+msgid "Sunset"
+msgstr "Západ slnka"
+
+#: id:33029
+msgid "Details"
+msgstr "Detaily"
+
+#: id:33030
+msgid "Outlook"
+msgstr "Outlook"
+
+#: id:33031
+msgid "Coverflow"
+msgstr "Coverflow"
+
+#: id:33032
+msgid "Translate text"
+msgstr "Preložiť text"
+
+#: id:33033
+msgid "Map list %s category"
+msgstr "Namapovať zoznam %s kategórie"
+
+#: id:33034
+msgid "36 Hour"
+msgstr "36 Hodín"
+
+#: id:33035
+msgid "Maps"
+msgstr "Mapy"
+
+#: id:33036
+msgid "Hourly"
+msgstr "Hodinu"
+
+#: id:33037
+msgid "Weekend"
+msgstr "Víkend"
+
+#: id:33038
+msgid "%s day"
+msgstr "%s deň"
+
+#: id:33049
+msgid "Alert"
+msgstr "Upozornenie"
+
+#: id:33050
+msgid "Alerts"
+msgstr "Upozornenia"
+
+#: id:33051
+msgid "Choose Your"
+msgstr "Vyberte Vašu"
+
+#: id:33052
+msgid "Check"
+msgstr "Zkontrolovať"
+
+#: id:33053
+msgctxt "Auto context with id 33053"
+msgid "Configure the"
+msgstr "Nastaviť"
+
+#: id:33054
+msgid "Seasons"
+msgstr "Sezóny"
+
+#: id:33055
+msgid "Use your"
+msgstr "Použiť"
+
+#: id:33056
+msgid "Watch your"
+msgstr "Sledovať"
+
+#: id:33057
+msgid "Listen to"
+msgstr "Počúvať"
+
+#: id:33058
+msgid "View your"
+msgstr "Prezerať"
+
+#: id:33059
+msgctxt "Auto context with id 33059"
+msgid "Configure the"
+msgstr "Konfigurovať"
+
+#: id:33060
+msgid "Power"
+msgstr "Vypnutie"
+
+#: id:33061
+msgid "Menu"
+msgstr "Menu"
+
+#: id:33062
+msgid "Play the"
+msgstr "Prehrať"
+
+#: id:33063
+msgid "Options"
+msgstr "Nastavenia"
+
+#: id:33065
+msgid "Editor"
+msgstr "Editor"
+
+#: id:33066
+msgid "About your"
+msgstr "O. . ."
+
+#: id:33067
+msgid "Star rating"
+msgstr "Hodnotenie"
+
+#: id:33068
+msgid "Background"
+msgstr "Pozadie"
+
+#: id:33069
+msgid "Backgrounds"
+msgstr "Pozadia"
+
+#: id:33070
+msgid "Custom background"
+msgstr "Vlastné pozadie"
+
+#: id:33071
+msgid "Custom backgrounds"
+msgstr "Vlastné pozadia"
+
+#: id:33072
+msgid "View Readme"
+msgstr "Zobraziť Readme"
+
+#: id:33073
+msgid "View Changelog"
+msgstr "Zobraziť Históriu zmien"
+
+#: id:33074
+msgid "This version of %s requires an"
+msgstr "Pre spustenie tejto verzie %s je vyžadovaná"
+
+#: id:33075
+msgid "XBMC revision of %s or greater to run."
+msgstr "XBMC revízia %s alebo vyššia."
+
+#: id:33076
+msgid "Please update XBMC."
+msgstr "Prosím aktualizujte XBMC."
+
+#: id:33077
+msgid "No data found!"
+msgstr "Žiadne dáta neboly nájdené!"
+
+#: id:33078
+msgid "Next page"
+msgstr "Ďalšia strana"
+
+#: id:33079
+msgid "Love"
+msgstr "Milovať"
+
+#: id:33080
+msgid "Hate"
+msgstr "Nenávidieť"
+
+#: id:33081
+msgid "This file is stacked, select the part you want to play from."
+msgstr "Tento súbor sa skladá z viac častí. Vyberte tu, od ktorej chcete spustit prehrávanie."
+
+#: id:33082
+msgid "Path to script"
+msgstr "Cesta ku skriptu"
+
+#: id:33083
+msgid "Enable custom script button"
+msgstr "Povoliť vlastné tlačítko skriptu"
+
+#: id:33100
+msgid "Failed to start"
+msgstr "Nepodarilo sa začať"
+
+#: id:33101
+msgid "Webserver"
+msgstr "Webserver"
+
+#: id:33102
+msgid "Event Server"
+msgstr "Server Udalostí"
+
+#: id:33103
+msgid "Remote communication server"
+msgstr "Vzdialený komunikačný server"
+
+#: id:33200
+msgid "Detected New Connection"
+msgstr ""
+
+#: id:34000
+msgid "Lame"
+msgstr "Lame"
+
+#: id:34001
+msgid "Vorbis"
+msgstr "Vorbis"
+
+#: id:34002
+msgid "Wav"
+msgstr "Wav"
+
+#: id:34003
+msgid "DXVA2"
+msgstr "DXVA2"
+
+#: id:34004
+msgid "VAAPI"
+msgstr "VAAPI"
+
+#: id:34005
+msgid "Flac"
+msgstr "Flac"
+
+#: id:34100
+msgid "Speaker Configuration"
+msgstr "Nastavenie Reproduktorov"
+
+#: id:34101
+msgid "2.0"
+msgstr "2.0"
+
+#: id:34102
+msgid "2.1"
+msgstr "2.1"
+
+#: id:34103
+msgid "3.0"
+msgstr "3.0"
+
+#: id:34104
+msgid "3.1"
+msgstr "3.1"
+
+#: id:34105
+msgid "4.0"
+msgstr "4.0"
+
+#: id:34106
+msgid "4.1"
+msgstr "4.1"
+
+#: id:34107
+msgid "5.0"
+msgstr "5.0"
+
+#: id:34108
+msgid "5.1"
+msgstr "5.1"
+
+#: id:34109
+msgid "7.0"
+msgstr "7.0"
+
+#: id:34110
+msgid "7.1"
+msgstr "7.1"
+
+#: id:34201
+msgid "Can't find a next item to play"
+msgstr "Nie je možné nájsť ďalšiu položku pre prehratie"
+
+#: id:34202
+msgid "Can't find a previous item to play"
+msgstr "Nie je možné nájsť predošlú položku pre prehratie"
+
+#: id:34300
+msgid "Failed to start zeroconf"
+msgstr ""
+
+#: id:34301
+msgid "Is Apple's Bonjour Service installed? See log for more info."
+msgstr ""
+
+#: id:34400
+msgid "Video Rendering"
+msgstr ""
+
+#: id:34401
+msgid "Failed to init video filters/scalers, falling back to bilinear scaling"
+msgstr ""
+
+#: id:34402
+msgid "Failed to initialize audio device"
+msgstr ""
+
+#: id:34403
+msgid "Check your audiosettings"
+msgstr ""
+
+#: id:34404
+msgid "Use gestures for navigation:"
+msgstr ""
+
+#: id:34405
+msgid "1 finger swipe left,right,up,down for cursors"
+msgstr ""
+
+#: id:34406
+msgid "2 finger swipe left for backspace"
+msgstr ""
+
+#: id:34407
+msgid "1 finger single tap for enter"
+msgstr ""
+
+#: id:34408
+msgid "2 finger single tap for contextmenu"
+msgstr ""
+
+#: id:35000
+msgid "Peripherals"
+msgstr ""
+
+#: id:35001
+msgid "Generic HID device"
+msgstr ""
+
+#: id:35002
+msgid "Generic network adapter"
+msgstr ""
+
+#: id:35003
+msgid "Generic disk"
+msgstr ""
+
+#: id:35004
+msgid "There are no settings available\nfor this peripheral."
+msgstr ""
+
+#: id:35005
+msgid "New device configured"
+msgstr ""
+
+#: id:35006
+msgid "Device removed"
+msgstr ""
+
+#: id:35007
+msgid "Keymap to use for this device"
+msgstr ""
+
+#: id:35008
+msgid "Keymap enabled"
+msgstr ""
+
+#: id:35009
+msgid "Do not use the custom keymap for this device"
+msgstr ""
+
+#: id:35500
+msgid "Location"
+msgstr ""
+
+#: id:35501
+msgid "Class"
+msgstr ""
+
+#: id:35502
+msgctxt "Auto context with id 35502"
+msgid "Name"
+msgstr ""
+
+#: id:35503
+msgid "Vendor"
+msgstr ""
+
+#: id:35504
+msgid "Product ID"
+msgstr ""
+
+#: id:36000
+msgid "Pulse-Eight CEC adapter"
+msgstr ""
+
+#: id:36001
+msgid "Pulse-Eight Nyxboard"
+msgstr ""
+
+#: id:36002
+msgid "Switch to keyboard side command"
+msgstr ""
+
+#: id:36003
+msgid "Switch to remote side command"
+msgstr ""
+
+#: id:36004
+msgid "Press \"user\" button command"
+msgstr ""
+
+#: id:36005
+msgid "Enable switch side commands"
+msgstr ""
+
+#: id:36006
+msgid "Could not open the adapter"
+msgstr ""
+
+#: id:36007
+msgid "Devices to power on when starting XBMC"
+msgstr ""
+
+#: id:36008
+msgid "Devices to power off when stopping XBMC"
+msgstr ""
+
+#: id:36009
+msgid "Put devices in standby mode when activating screensaver"
+msgstr ""
+
+#: id:36011
+msgid "Could not detect the CEC port. Set it up manually."
+msgstr ""
+
+#: id:36012
+msgid "Could not initialise the CEC adapter. Check your settings."
+msgstr ""
+
+#: id:36013
+msgid "Unsupported libCEC interface version. %d is greater than the version XBMC supports (%d)"
+msgstr ""
+
+#: id:36014
+msgid "Put this PC in standby mode when the TV is switched off"
+msgstr ""
+
+#: id:36015
+msgid "HDMI port number"
+msgstr ""
+
+#: id:36016
+msgctxt "Auto context with id 36016"
+msgid "Connected"
+msgstr ""
+
+#: id:36017
+msgid "Adapter found, but libCEC is not available"
+msgstr ""
+
+#: id:36018
+msgid "Use the TV's language setting"
+msgstr ""
+
+#: id:36019
+msgid "Connected to HDMI device"
+msgstr ""
+
+#: id:36020
+msgid "Make XBMC the active source when starting"
+msgstr ""
+
+#: id:36021
+msgid "Physical address (overrules HDMI port)"
+msgstr ""
+
+#: id:36022
+msgid "COM port (leave empty unless needed)"
+msgstr ""
+
+#: id:36023
+msgid "Configuration updated"
+msgstr ""
+
+#: id:36024
+msgid "Failed to set the new configuration. Please check your settings."
+msgstr ""
+
+#: id:36025
+msgid "Send 'inactive source' command when stopping XBMC"
+msgstr ""
+

--- a/language/Slovenian/strings.po
+++ b/language/Slovenian/strings.po
@@ -1,0 +1,9093 @@
+# Converted from xbmc strings.xml with xbmc-xml2po (by Team-XBMC)
+msgid ""
+msgstr ""
+"Project-Id-Version: xbmc.core-FRODO_GIT3ed1604ad7\n"
+"Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
+"POT-Creation-Date: 2012-04-09 18:00+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE\n"
+"Language: sl\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: id:0
+msgctxt "Auto context with id 0"
+msgid "Programs"
+msgstr "Programi"
+
+#: id:1
+msgctxt "Auto context with id 1"
+msgid "Pictures"
+msgstr "Slike"
+
+#: id:2
+msgctxt "Auto context with id 2"
+msgid "Music"
+msgstr "Glasba"
+
+#: id:3
+msgctxt "Auto context with id 3"
+msgid "Videos"
+msgstr "Video"
+
+#: id:4
+msgid "TV-Guide"
+msgstr "TV vodič"
+
+#: id:5
+msgctxt "Auto context with id 5"
+msgid "Settings"
+msgstr "Nastavitve"
+
+#: id:6
+msgid "XBMC SVN"
+msgstr "XBMC SVN"
+
+#: id:7
+msgctxt "Auto context with id 7"
+msgid "File manager"
+msgstr "Moje datoteke"
+
+#: id:8
+msgctxt "Auto context with id 8"
+msgid "Weather"
+msgstr "Vreme"
+
+#: id:9
+msgid "xbmc media center"
+msgstr "XBMC Media Center"
+
+#: id:11
+msgid "Monday"
+msgstr "Ponedeljek"
+
+#: id:12
+msgid "Tuesday"
+msgstr "Torek"
+
+#: id:13
+msgid "Wednesday"
+msgstr "Sreda"
+
+#: id:14
+msgid "Thursday"
+msgstr "Četrtek"
+
+#: id:15
+msgid "Friday"
+msgstr "Petek"
+
+#: id:16
+msgid "Saturday"
+msgstr "Sobota"
+
+#: id:17
+msgid "Sunday"
+msgstr "Nedelja"
+
+#: id:21
+msgid "January"
+msgstr "Januar"
+
+#: id:22
+msgid "February"
+msgstr "Februar"
+
+#: id:23
+msgid "March"
+msgstr "Marec"
+
+#: id:24
+msgid "April"
+msgstr "April"
+
+#: id:25
+msgctxt "Auto context with id 25"
+msgid "May"
+msgstr "Maj"
+
+#: id:26
+msgid "June"
+msgstr "Junij"
+
+#: id:27
+msgid "July"
+msgstr "Julij"
+
+#: id:28
+msgid "August"
+msgstr "Avgust"
+
+#: id:29
+msgid "September"
+msgstr "September"
+
+#: id:30
+msgid "October"
+msgstr "Oktober"
+
+#: id:31
+msgid "November"
+msgstr "November"
+
+#: id:32
+msgid "December"
+msgstr "December"
+
+#: id:41
+msgid "Mon"
+msgstr "Pon"
+
+#: id:42
+msgid "Tue"
+msgstr "Tor"
+
+#: id:43
+msgid "Wed"
+msgstr "Sre"
+
+#: id:44
+msgid "Thu"
+msgstr "Čet"
+
+#: id:45
+msgid "Fri"
+msgstr "Pet"
+
+#: id:46
+msgid "Sat"
+msgstr "Sob"
+
+#: id:47
+msgctxt "Auto context with id 47"
+msgid "Sun"
+msgstr "Ned"
+
+#: id:51
+msgid "Jan"
+msgstr "Jan"
+
+#: id:52
+msgid "Feb"
+msgstr "Feb"
+
+#: id:53
+msgid "Mar"
+msgstr "Mar"
+
+#: id:54
+msgid "Apr"
+msgstr "Apr"
+
+#: id:55
+msgctxt "Auto context with id 55"
+msgid "May"
+msgstr "Maj"
+
+#: id:56
+msgid "Jun"
+msgstr "Jun"
+
+#: id:57
+msgid "Jul"
+msgstr "Jul"
+
+#: id:58
+msgid "Aug"
+msgstr "Avg"
+
+#: id:59
+msgid "Sep"
+msgstr "Sep"
+
+#: id:60
+msgid "Oct"
+msgstr "Okt"
+
+#: id:61
+msgid "Nov"
+msgstr "Nov"
+
+#: id:62
+msgid "Dec"
+msgstr "Dec"
+
+#: id:71
+msgid "N"
+msgstr "S"
+
+#: id:72
+msgid "NNE"
+msgstr "SSV"
+
+#: id:73
+msgid "NE"
+msgstr "SV"
+
+#: id:74
+msgid "ENE"
+msgstr "VSV"
+
+#: id:75
+msgid "E"
+msgstr "V"
+
+#: id:76
+msgid "ESE"
+msgstr "VJV"
+
+#: id:77
+msgid "SE"
+msgstr "JV"
+
+#: id:78
+msgid "SSE"
+msgstr "JJV"
+
+#: id:79
+msgid "S"
+msgstr "J"
+
+#: id:80
+msgid "SSW"
+msgstr "JJZ"
+
+#: id:81
+msgid "SW"
+msgstr "JZ"
+
+#: id:82
+msgid "WSW"
+msgstr "ZJZ"
+
+#: id:83
+msgid "W"
+msgstr "Z"
+
+#: id:84
+msgid "WNW"
+msgstr "ZSZ"
+
+#: id:85
+msgid "NW"
+msgstr "SZ"
+
+#: id:86
+msgid "NNW"
+msgstr "SSZ"
+
+#: id:87
+msgid "VAR"
+msgstr "VAR"
+
+#: id:98
+msgid "View: Auto"
+msgstr "Pogled: Samodejno"
+
+#: id:99
+msgid "View: Auto big"
+msgstr "Pogled: Samodejna velikost"
+
+#: id:100
+msgid "View: Icons"
+msgstr "Pogled: Ikone"
+
+#: id:101
+msgid "View: List"
+msgstr "Pogled: Seznam"
+
+#: id:102
+msgctxt "Auto context with id 102"
+msgid "Scan"
+msgstr "Preišči"
+
+#: id:103
+msgctxt "Auto context with id 103"
+msgid "Sort by: Name"
+msgstr "Razvrsti: Ime"
+
+#: id:104
+msgid "Sort by: Date"
+msgstr "Razvrsti: Datum"
+
+#: id:105
+msgid "Sort by: Size"
+msgstr "Razvrsti: Velikost"
+
+#: id:106
+msgid "No"
+msgstr "Ne"
+
+#: id:107
+msgid "Yes"
+msgstr "Da"
+
+#: id:108
+msgctxt "Auto context with id 108"
+msgid "Slideshow"
+msgstr "Projekcija slik"
+
+#: id:109
+msgid "Create thumbs"
+msgstr "Ustvari sličico"
+
+#: id:110
+msgid "Create thumbnails"
+msgstr "Ustvari sličice"
+
+#: id:111
+msgctxt "Auto context with id 111"
+msgid "Shortcuts"
+msgstr "Bližnjice"
+
+#: id:112
+msgid "Paused"
+msgstr "Pavza"
+
+#: id:113
+msgid "Update failed"
+msgstr "Posodobitev ni uspela"
+
+#: id:114
+msgid "Installation failed"
+msgstr "Namestitev ni uspela"
+
+#: id:115
+msgid "Copy"
+msgstr "Kopiraj"
+
+#: id:116
+msgid "Move"
+msgstr "Premakni"
+
+#: id:117
+msgid "Delete"
+msgstr "Izbriši"
+
+#: id:118
+msgid "Rename"
+msgstr "Preimenuj"
+
+#: id:119
+msgid "New folder"
+msgstr "Nova mapa"
+
+#: id:120
+msgid "Confirm file copy"
+msgstr "Potrdi kopiranje datotek"
+
+#: id:121
+msgid "Confirm file move"
+msgstr "Potrdi premikanje datotek"
+
+#: id:122
+msgid "Confirm file delete?"
+msgstr "Potrdi brisanje datotek?"
+
+#: id:123
+msgid "Copy these files?"
+msgstr "Ali naj kopiram datoteke?"
+
+#: id:124
+msgid "Move these files?"
+msgstr "Ali naj prenesem datoteke?"
+
+#: id:125
+msgid "Delete these files? - Deleting files cannot be undone!"
+msgstr "Ali naj izbrišem datoteke? - Izbris datotek ne more biti razveljavljen!"
+
+#: id:126
+msgid "Status"
+msgstr "Status"
+
+#: id:127
+msgid "Objects"
+msgstr "Elementi"
+
+#: id:128
+msgctxt "Auto context with id 128"
+msgid "General"
+msgstr "Splošno"
+
+#: id:129
+msgctxt "Auto context with id 129"
+msgid "Slideshow"
+msgstr "Projekcija slik"
+
+#: id:130
+msgctxt "Auto context with id 130"
+msgid "System info"
+msgstr "Sistemske informacije"
+
+#: id:131
+msgid "Display"
+msgstr "Zaslon"
+
+#: id:132
+msgid "Albums"
+msgstr "Albumi"
+
+#: id:133
+msgid "Artists"
+msgstr "Izvajalci"
+
+#: id:134
+msgid "Songs"
+msgstr "Pesmi"
+
+#: id:135
+msgid "Genres"
+msgstr "Žanri"
+
+#: id:136
+msgid "Playlists"
+msgstr "Predvajalni seznami"
+
+#: id:137
+msgid "Search"
+msgstr "Iskanje"
+
+#: id:138
+msgid "System Information"
+msgstr "Sistemske informacije"
+
+#: id:139
+msgid "Temperatures:"
+msgstr "Temperature:"
+
+#: id:140
+msgid "CPU:"
+msgstr "CPU:"
+
+#: id:141
+msgid "GPU:"
+msgstr "GPU:"
+
+#: id:142
+msgid "Time:"
+msgstr "Čas:"
+
+#: id:143
+msgid "Current:"
+msgstr "Trenutno:"
+
+#: id:144
+msgid "Build:"
+msgstr "Različica:"
+
+#: id:145
+msgid "Network:"
+msgstr "Omrežje:"
+
+#: id:146
+msgid "Type:"
+msgstr "Tip:"
+
+#: id:147
+msgid "Static"
+msgstr "Statičen"
+
+#: id:148
+msgid "DHCP"
+msgstr "DHCP"
+
+#: id:149
+msgid "MAC address"
+msgstr "MAC naslov"
+
+#: id:150
+msgctxt "Auto context with id 150"
+msgid "IP address"
+msgstr "IP naslov"
+
+#: id:151
+msgid "Link:"
+msgstr "Povezava:"
+
+#: id:152
+msgid "Half duplex"
+msgstr "Polovični duplex"
+
+#: id:153
+msgid "Full duplex"
+msgstr "Celotni duplex"
+
+#: id:154
+msgctxt "Auto context with id 154"
+msgid "Storage"
+msgstr "Shramba"
+
+#: id:155
+msgid "Drive"
+msgstr "Pogon"
+
+#: id:156
+msgctxt "Auto context with id 156"
+msgid "Free"
+msgstr "Prosto"
+
+#: id:157
+msgctxt "Auto context with id 157"
+msgid "Video"
+msgstr "Video"
+
+#: id:158
+msgid "Free memory"
+msgstr "Prosti pomnilnik"
+
+#: id:159
+msgid "No link"
+msgstr "Ni povezave"
+
+#: id:160
+msgctxt "Auto context with id 160"
+msgid "Free"
+msgstr "Prosto"
+
+#: id:161
+msgid "Unavailable"
+msgstr "Ni dosegljiv"
+
+#: id:162
+msgid "Tray open"
+msgstr "DVD vratca odprta"
+
+#: id:163
+msgid "Reading"
+msgstr "Berem"
+
+#: id:164
+msgid "No disc"
+msgstr "Ni medija"
+
+#: id:165
+msgid "Disc present"
+msgstr "Medij prisoten"
+
+#: id:166
+msgid "Skin"
+msgstr "Preobleka"
+
+#: id:169
+msgctxt "Auto context with id 169"
+msgid "Resolution"
+msgstr "Ločljivost"
+
+#: id:170
+msgid "Adjust display refresh rate to match video"
+msgstr "Prilagodi osveževanje zaslona videu"
+
+#: id:172
+msgid "Release date"
+msgstr "Datum izdaje"
+
+#: id:173
+msgid "Display 4:3 videos as"
+msgstr "Prikaži video v razmerju 4:3 kot"
+
+#: id:175
+msgid "Moods"
+msgstr "Razpoloženja"
+
+#: id:176
+msgid "Styles"
+msgstr "Stili"
+
+#: id:179
+msgid "Song"
+msgstr "Pesem"
+
+#: id:180
+msgid "Duration"
+msgstr "Trajanje"
+
+#: id:181
+msgid "Select album"
+msgstr "Izberi Album"
+
+#: id:182
+msgid "Tracks"
+msgstr "Posnetki"
+
+#: id:183
+msgid "Review"
+msgstr "Ocena"
+
+#: id:184
+msgid "Refresh"
+msgstr "Osveži"
+
+#: id:185
+msgid "Searching album"
+msgstr "Iščem Album"
+
+#: id:186
+msgid "OK"
+msgstr "OK"
+
+#: id:187
+msgid "No albums found!"
+msgstr "Ne najdem albumov!"
+
+#: id:188
+msgid "Select all"
+msgstr "Izberi vse"
+
+#: id:189
+msgid "Scanning media info"
+msgstr "Pregledujem informacije o mediju"
+
+#: id:190
+msgid "Save"
+msgstr "Shrani"
+
+#: id:191
+msgid "Shuffle"
+msgstr "Naključno"
+
+#: id:192
+msgctxt "Auto context with id 192"
+msgid "Clear"
+msgstr "Počisti"
+
+#: id:193
+msgctxt "Auto context with id 193"
+msgid "Scan"
+msgstr "Preišči"
+
+#: id:194
+msgid "Searching..."
+msgstr "Poizvedujem..."
+
+#: id:195
+msgid "No info found!"
+msgstr "Ne najdem informacije!"
+
+#: id:196
+msgid "Select movie:"
+msgstr "Izberi film:"
+
+#: id:197
+msgid "Querying %s info"
+msgstr "Poizvedujem informacije o %s"
+
+#: id:198
+msgid "Loading movie details"
+msgstr "Nalagam podrobnosti o filmu"
+
+#: id:199
+msgid "Web interface"
+msgstr "Spletni vmesnik"
+
+#: id:202
+msgid "Tagline"
+msgstr "Moto"
+
+#: id:203
+msgid "Plot outline"
+msgstr "Oris zgodbe"
+
+#: id:205
+msgid "Votes"
+msgstr "Ocene"
+
+#: id:206
+msgid "Cast"
+msgstr "Igralci"
+
+#: id:207
+msgid "Plot"
+msgstr "Zgodba"
+
+#: id:208
+msgctxt "Auto context with id 208"
+msgid "Play"
+msgstr "Predvajaj"
+
+#: id:209
+msgid "Next"
+msgstr "Naslednji"
+
+#: id:210
+msgid "Previous"
+msgstr "Prejšnji"
+
+#: id:213
+msgid "Calibrate user interface..."
+msgstr "Kalibriraj uporabniški vmesnik..."
+
+#: id:214
+msgid "Video calibration..."
+msgstr "Prilagoditve slike..."
+
+#: id:215
+msgid "Soften"
+msgstr "Mehčanje"
+
+#: id:216
+msgid "Zoom amount"
+msgstr "Povečava"
+
+#: id:217
+msgid "Pixel ratio"
+msgstr "Količina pikslov"
+
+#: id:218
+msgid "DVD drive"
+msgstr "DVD pogon"
+
+#: id:219
+msgid "Please insert disc"
+msgstr "Prosim vstavite medij"
+
+#: id:220
+msgid "Remote share"
+msgstr "Skupna raba"
+
+#: id:221
+msgid "Network is not connected"
+msgstr "Omrežje ni povezano"
+
+#: id:222
+msgid "Cancel"
+msgstr "Prekliči"
+
+#: id:224
+msgid "Speed"
+msgstr "Hitrost"
+
+#: id:225
+msgid "Vertical Shift"
+msgstr "Vertical Shift"
+
+#: id:226
+msgid "Test patterns..."
+msgstr "Testni vzorci..."
+
+#: id:227
+msgid "Lookup audio CD track names from freedb.org"
+msgstr "Poizvedi za imena pesmi na CD-ju na freedb.org"
+
+#: id:228
+msgid "Shuffle playlist on load"
+msgstr "Naključni predvajalni seznam ob zagonu"
+
+#: id:229
+msgid "HDD spindown time"
+msgstr "Čas ustavitve HDD"
+
+#: id:230
+msgid "Video filters"
+msgstr "Video filtri"
+
+#: id:231
+msgctxt "Auto context with id 231"
+msgid "None"
+msgstr "Brez"
+
+#: id:232
+msgid "Point"
+msgstr "Točka"
+
+#: id:233
+msgid "Linear"
+msgstr "Linearno"
+
+#: id:234
+msgid "Anisotropic"
+msgstr "Antisotropično"
+
+#: id:235
+msgid "Quincunx"
+msgstr "Quincunx"
+
+#: id:236
+msgid "Gaussian cubic"
+msgstr "Gaussovo kubično"
+
+#: id:237
+msgid "Minification"
+msgstr "Pomanševanje"
+
+#: id:238
+msgid "Magnification"
+msgstr "Povečevanje"
+
+#: id:239
+msgid "Clear playlist on finish"
+msgstr "Počisti predvajalni seznam na koncu"
+
+#: id:240
+msgid "Display Mode"
+msgstr "Tip prikaza"
+
+#: id:241
+msgid "Full Screen #%d"
+msgstr "Celozaslonsko #%d"
+
+#: id:242
+msgid "Windowed"
+msgstr "V oknu"
+
+#: id:243
+msgid "Refresh Rate"
+msgstr "Stopnja osveževanja"
+
+#: id:244
+msgid "Full screen"
+msgstr "Celozaslonsko"
+
+#: id:245
+msgid "Sizing: (%i,%i)->(%i,%i) (Zoom x%2.2f) AR:%2.2f:1 (Pixels: %2.2f:1) (VShift: %2.2f)"
+msgstr "Spr. velikosti: (%i,%i)->(%i,%i) (Povečava x%2.2f) AR:%2.2f:1 (Piksli: %2.2f:1) (VShift: %2.2f)"
+
+#: id:247
+msgctxt "Auto context with id 247"
+msgid "Scripts"
+msgstr "Skripte"
+
+#: id:248
+msgctxt "Auto context with id 248"
+msgid "Language"
+msgstr "Jezik"
+
+#: id:249
+msgctxt "Auto context with id 249"
+msgid "Music"
+msgstr "Glasba"
+
+#: id:250
+msgctxt "Auto context with id 250"
+msgid "Visualization"
+msgstr "Vizualizacija"
+
+#: id:251
+msgid "Select destination directory"
+msgstr "Izberi ciljno mapo"
+
+#: id:252
+msgid "Output stereo to all speakers"
+msgstr "Stereo zvok na vse zvočnike"
+
+#: id:253
+msgid "Number of channels"
+msgstr "Število kanalov"
+
+#: id:254
+msgid "- DTS capable receiver"
+msgstr "- DTS sprejemnik"
+
+#: id:255
+msgid "CDDB"
+msgstr "CDDB"
+
+#: id:256
+msgid "Fetching CD information"
+msgstr "Pridobivam informacije o CD-ju"
+
+#: id:257
+msgid "Error"
+msgstr "Napaka"
+
+#: id:258
+msgid "Enable tag reading"
+msgstr "Vključi branje oznak"
+
+#: id:259
+msgid "Opening"
+msgstr "Odpiranje"
+
+#: id:260
+msgid "Shoutcast"
+msgstr "Shoutcast"
+
+#: id:261
+msgid "Waiting for start..."
+msgstr "Čakam na začetek..."
+
+#: id:262
+msgid "Scripts output"
+msgstr "Izhodne skripte"
+
+#: id:263
+msgid "Allow control of XBMC via HTTP"
+msgstr "Dovoli upravljanje z XBMC preko HTTP"
+
+#: id:264
+msgid "Record"
+msgstr "Snemaj"
+
+#: id:265
+msgid "Stop Rec."
+msgstr "Ustavi snemanje"
+
+#: id:266
+msgid "Sort by: Track"
+msgstr "Razvrsti: Posnetek"
+
+#: id:267
+msgid "Sort by: Time"
+msgstr "Razvrsti: Čas"
+
+#: id:268
+msgid "Sort by: Title"
+msgstr "Razvrsti: Naslov"
+
+#: id:269
+msgid "Sort by: Artist"
+msgstr "Razvrsti: Izvajalec"
+
+#: id:270
+msgid "Sort by: Album"
+msgstr "Razvrsti: Album"
+
+#: id:271
+msgid "Top 100"
+msgstr "Top 100"
+
+#: id:272
+msgid "Top-Left overscan compensation"
+msgstr "Prilagajanje zaslona zgoraj levo"
+
+#: id:273
+msgid "Bottom-Right overscan compensation"
+msgstr "Prilagajanje zaslona spodaj desno"
+
+#: id:274
+msgid "Subtitle positioning"
+msgstr "Položaj podnapisov"
+
+#: id:275
+msgid "Pixel ratio adjustment"
+msgstr "Nastavitev količine pixlov"
+
+#: id:276
+msgid "Adjust the arrow to change the amount of overscan"
+msgstr "Premakni puščico za prilagoditev zaslonu"
+
+#: id:277
+msgid "Adjust the bar to change the subtitles position"
+msgstr "Premakni črto za nastavitev položaja podnapisov"
+
+#: id:278
+msgid "Adjust the rectangle so it is perfectly square"
+msgstr "Preoblikuj pravokotnik v popolni kvadrat"
+
+#: id:279
+msgid "Unable to load settings"
+msgstr "Nastavitev ni mogoče prebrati"
+
+#: id:280
+msgid "Using default settings"
+msgstr "Uporabljam privzete nastavitve"
+
+#: id:281
+msgid "Please check the XML files"
+msgstr "Preverite XML datoteke"
+
+#: id:282
+msgid "Found %i items"
+msgstr "Najdeno %i datotek"
+
+#: id:283
+msgid "Search results"
+msgstr "Rezultati iskanja"
+
+#: id:284
+msgid "No results found"
+msgstr "Ni rezultatov"
+
+#: id:287
+msgctxt "Auto context with id 287"
+msgid "Subtitles"
+msgstr "Podnapisi"
+
+#: id:288
+msgctxt "Auto context with id 288"
+msgid "Font"
+msgstr "Pisava"
+
+#: id:289
+msgctxt "Auto context with id 289"
+msgid "- Size"
+msgstr "- Velikost"
+
+#: id:290
+msgid "Dynamic range compression"
+msgstr "Dinamična kompresija"
+
+#: id:291
+msgctxt "Auto context with id 291"
+msgid "Video"
+msgstr "Slika"
+
+#: id:292
+msgctxt "Auto context with id 292"
+msgid "Audio"
+msgstr "Zvok"
+
+#: id:293
+msgid "Browse for subtitles"
+msgstr "Prebrskaj za podnapise"
+
+#: id:294
+msgid "Create bookmark"
+msgstr "Ustvari zaznamek"
+
+#: id:296
+msgid "Clear bookmarks"
+msgstr "Izbriši zaznamke"
+
+#: id:297
+msgid "Audio offset"
+msgstr "Zamik zvoka"
+
+#: id:298
+msgid "Bookmarks"
+msgstr "Zaznamki"
+
+#: id:299
+msgid "- AAC capable receiver"
+msgstr "- AAC sprejemnik"
+
+#: id:300
+msgid "- MP1 capable receiver"
+msgstr "- MP1 sprejemnik"
+
+#: id:301
+msgid "- MP2 capable receiver"
+msgstr "- MP2 sprejemnik"
+
+#: id:302
+msgid "- MP3 capable receiver"
+msgstr "- MP3 sprejemnik"
+
+#: id:303
+msgid "Delay"
+msgstr "Zamik"
+
+#: id:304
+msgctxt "Auto context with id 304"
+msgid "Language"
+msgstr "Jezik"
+
+#: id:305
+msgctxt "Auto context with id 305"
+msgid "Enabled"
+msgstr "Vključeno"
+
+#: id:306
+msgid "Non-interleaved"
+msgstr "Brez prepletanja"
+
+#: id:312
+msgid "(0=auto)"
+msgstr "(0=auto)"
+
+#: id:313
+msgid "Cleaning database"
+msgstr "Čiščenje baze podatkov"
+
+#: id:314
+msgid "Preparing..."
+msgstr "Pripravljanje..."
+
+#: id:315
+msgid "Database error"
+msgstr "Napaka v podatkovni bazi"
+
+#: id:316
+msgid "Searching songs..."
+msgstr "Poizvedujem za pesmimi..."
+
+#: id:317
+msgid "Cleaned database successfully"
+msgstr "Podatkovna baza je uspešno očiščena"
+
+#: id:318
+msgid "Cleaning songs..."
+msgstr "Brišem pesmi..."
+
+#: id:319
+msgid "Error cleaning songs"
+msgstr "Napaka pri brisanju pesmi"
+
+#: id:320
+msgid "Cleaning artists..."
+msgstr "Brišem izvajalce..."
+
+#: id:321
+msgid "Error cleaning artists"
+msgstr "Napaka pri brisanju izvajalcev"
+
+#: id:322
+msgid "Cleaning genres..."
+msgstr "Brišem žanre..."
+
+#: id:323
+msgid "Error cleaning genres"
+msgstr "Napaka pri brisanju žanrov"
+
+#: id:324
+msgid "Cleaning paths..."
+msgstr "Brišem poti...."
+
+#: id:325
+msgid "Error cleaning paths"
+msgstr "Napaka pri brisanju poti"
+
+#: id:326
+msgid "Cleaning albums..."
+msgstr "Brišem albume..."
+
+#: id:327
+msgid "Error cleaning albums"
+msgstr "Napaka pri brisanju albumov"
+
+#: id:328
+msgid "Writing changes..."
+msgstr "Zapisujem spremembe..."
+
+#: id:329
+msgid "Error writing changes"
+msgstr "Napaka pri zapisovanju sprememb"
+
+#: id:330
+msgid "This may take some time..."
+msgstr "Dejanje bo vzelo nekaj časa..."
+
+#: id:331
+msgid "Compressing database..."
+msgstr "Stiskam podatkovno bazo...."
+
+#: id:332
+msgid "Error compressing database"
+msgstr "Napaka pri stiskanju podatkovne baze"
+
+#: id:333
+msgid "Do you want to clean the library?"
+msgstr "Želite očistiti knjižnico?"
+
+#: id:334
+msgid "Clean library..."
+msgstr "Očisti knjižnico"
+
+#: id:335
+msgid "Start"
+msgstr "Začni"
+
+#: id:336
+msgid "Framerate conversion"
+msgstr "Pretvorba izrisa"
+
+#: id:337
+msgctxt "Auto context with id 337"
+msgid "Audio output"
+msgstr "Zvočni izhod"
+
+#: id:338
+msgid "Analog"
+msgstr "Analogno"
+
+#: id:339
+msgid "Optical/Coax"
+msgstr "Optično/Coax"
+
+#: id:340
+msgid "Various artists"
+msgstr "Različni izvajalci"
+
+#: id:341
+msgid "Play disc"
+msgstr "Predvajaj medij"
+
+#: id:342
+msgctxt "Auto context with id 342"
+msgid "Movies"
+msgstr "Filmi"
+
+#: id:343
+msgid "Adjust framerate"
+msgstr "Prilagodi hitrost sličic"
+
+#: id:344
+msgid "Actors"
+msgstr "Igralci"
+
+#: id:345
+msgctxt "Auto context with id 345"
+msgid "Year"
+msgstr "Leto"
+
+#: id:346
+msgid "Boost volume level on downmix"
+msgstr "Ojačaj zvok pri združevanju kanalov"
+
+#: id:350
+msgctxt "Auto context with id 350"
+msgid "Programs"
+msgstr "Programi"
+
+#: id:351
+msgctxt "Auto context with id 351"
+msgid "Off"
+msgstr "Izključeno"
+
+#: id:352
+msgid "Dim"
+msgstr "Zamegljeno"
+
+#: id:353
+msgid "Black"
+msgstr "Črno"
+
+#: id:354
+msgid "Matrix trails"
+msgstr "Sledi matrice"
+
+#: id:355
+msgid "Screensaver time"
+msgstr "Zamik ohranjevalnika zaslona"
+
+#: id:356
+msgid "Screensaver mode"
+msgstr "Način ohranjevalnika zaslona"
+
+#: id:357
+msgid "Shutdown function timer"
+msgstr "Način zakasnjenega izklopa"
+
+#: id:358
+msgid "All albums"
+msgstr "Vsi albumi"
+
+#: id:359
+msgid "Recently added albums"
+msgstr "Nedavno dodani albumi"
+
+#: id:360
+msgctxt "Auto context with id 360"
+msgid "Screensaver"
+msgstr "Ohranjevalnik"
+
+#: id:361
+msgid "R. Slideshow"
+msgstr "R. proj. slik"
+
+#: id:362
+msgid "Screensaver dim level"
+msgstr "Zameglitev ohranjevalnika zaslona"
+
+#: id:363
+msgid "Sort by: File"
+msgstr "Razvrsti: Datoteka"
+
+#: id:364
+msgid "- Dolby Digital (AC3) capable receiver"
+msgstr "- Dolby Digital (AC3) sprejemnik"
+
+#: id:365
+msgctxt "Auto context with id 365"
+msgid "Sort by: Name"
+msgstr "Razvrsti: Ime"
+
+#: id:366
+msgid "Sort by: Year"
+msgstr "Razvrsti: Leto"
+
+#: id:367
+msgid "Sort by: Rating"
+msgstr "Razvrsti: Ocena"
+
+#: id:368
+msgid "IMDb"
+msgstr "IMDb"
+
+#: id:369
+msgctxt "Auto context with id 369"
+msgid "Title"
+msgstr "Naslov"
+
+#: id:370
+msgid "Thunderstorms"
+msgstr "nevihte"
+
+#: id:371
+msgid "Partly"
+msgstr "delno"
+
+#: id:372
+msgid "Mostly"
+msgstr "pretežno"
+
+#: id:373
+msgid "Sunny"
+msgstr "jasno"
+
+#: id:374
+msgid "Cloudy"
+msgstr "oblačno"
+
+#: id:375
+msgid "Snow"
+msgstr "sneg"
+
+#: id:376
+msgid "Rain"
+msgstr "dež"
+
+#: id:377
+msgid "Light"
+msgstr "rahel"
+
+#: id:378
+msgid "AM"
+msgstr "dopoldan"
+
+#: id:379
+msgid "PM"
+msgstr "popoldan"
+
+#: id:380
+msgid "Showers"
+msgstr "plohe"
+
+#: id:381
+msgid "Few"
+msgstr "nekaj"
+
+#: id:382
+msgid "Scattered"
+msgstr "razpršene"
+
+#: id:383
+msgctxt "Auto context with id 383"
+msgid "Wind"
+msgstr "veter"
+
+#: id:384
+msgid "Strong"
+msgstr "močan"
+
+#: id:385
+msgid "Fair"
+msgstr "šibak"
+
+#: id:386
+msgctxt "Auto context with id 386"
+msgid "Clear"
+msgstr "jasno"
+
+#: id:387
+msgid "Clouds"
+msgstr "oblaki"
+
+#: id:388
+msgid "Early"
+msgstr "zgodaj"
+
+#: id:389
+msgid "Shower"
+msgstr "ploha"
+
+#: id:390
+msgid "Flurries"
+msgstr "nalivi"
+
+#: id:391
+msgctxt "Auto context with id 391"
+msgid "Low"
+msgstr "nizko"
+
+#: id:392
+msgctxt "Auto context with id 392"
+msgid "Medium"
+msgstr "srednje"
+
+#: id:393
+msgctxt "Auto context with id 393"
+msgid "High"
+msgstr "visoko"
+
+#: id:394
+msgid "Fog"
+msgstr "megla"
+
+#: id:395
+msgid "Haze"
+msgstr "toča"
+
+#: id:396
+msgid "Select location"
+msgstr "Izberi lokacijo"
+
+#: id:397
+msgid "Refresh time"
+msgstr "Čas osveževanja"
+
+#: id:398
+msgid "Temperature units"
+msgstr "Temperaturne enote"
+
+#: id:399
+msgid "Speed units"
+msgstr "Hitrostne enote"
+
+#: id:400
+msgctxt "Auto context with id 400"
+msgid "Weather"
+msgstr "Vreme"
+
+#: id:401
+msgid "Temp"
+msgstr "Temp."
+
+#: id:402
+msgid "Feels like"
+msgstr "Občuti se kot"
+
+#: id:403
+msgid "UV index"
+msgstr "UV indeks"
+
+#: id:404
+msgctxt "Auto context with id 404"
+msgid "Wind"
+msgstr "Veter"
+
+#: id:405
+msgid "Dew point"
+msgstr "Rosišče"
+
+#: id:406
+msgid "Humidity"
+msgstr "Vlažnost"
+
+#: id:409
+msgid "Defaults"
+msgstr "Privzeto"
+
+#: id:410
+msgid "Accessing weather service"
+msgstr "Povezujem se z vremenskim strežnikom"
+
+#: id:411
+msgid "Getting weather for:"
+msgstr "Pridobivam vremensko napoved za:"
+
+#: id:412
+msgid "Unable to get weather data"
+msgstr "Vremenske napovedi ni mogoče prejeti"
+
+#: id:413
+msgid "Manual"
+msgstr "Ročno"
+
+#: id:414
+msgid "No review for this album"
+msgstr "Ni recenzije za izbrani album"
+
+#: id:415
+msgid "Downloading thumbnail..."
+msgstr "Prenašam sličice..."
+
+#: id:416
+msgid "Not available"
+msgstr "Ni na voljo"
+
+#: id:417
+msgid "View: Big icons"
+msgstr "Pogled: Velike Ikone"
+
+#: id:418
+msgctxt "Auto context with id 418"
+msgid "Low"
+msgstr "Min."
+
+#: id:419
+msgctxt "Auto context with id 419"
+msgid "High"
+msgstr "Maks."
+
+#: id:420
+msgid "HDMI"
+msgstr "HDMI"
+
+#: id:422
+msgid "Delete album info"
+msgstr "Izbriši informacije o albumu"
+
+#: id:423
+msgid "Delete CD information"
+msgstr "Izbriši informacije o CD-ju"
+
+#: id:424
+msgid "Select"
+msgstr "Izberi"
+
+#: id:425
+msgid "No album information found"
+msgstr "Ni informacij o albumu"
+
+#: id:426
+msgid "No CD information found"
+msgstr "Ni informacij o CD-ju"
+
+#: id:427
+msgid "Disc"
+msgstr "Medij"
+
+#: id:428
+msgid "Insert correct CD/DVD"
+msgstr "Vstavi pravilen CD/DVD"
+
+#: id:429
+msgid "Please insert the following disc:"
+msgstr "Prosim vstavi naslednji CD/DVD:"
+
+#: id:430
+msgid "Sort by: DVD#"
+msgstr "Razvrsti: DVD#"
+
+#: id:431
+msgid "No cache"
+msgstr "Brez začasnega pomnilnika"
+
+#: id:432
+msgid "Remove movie from library"
+msgstr "Izbriši film iz baze"
+
+#: id:433
+msgid "Really remove '%s'?"
+msgstr "Resnično odstrani '%s'?"
+
+#: id:434
+msgid "From %s at %i %s"
+msgstr "%s s hitrostjo %i %s"
+
+#: id:437
+msgid "Removable disk"
+msgstr "Odstranljivi medij"
+
+#: id:438
+msgid "Opening file"
+msgstr "Odpiram datoteko"
+
+#: id:439
+msgid "Cache"
+msgstr "Začasni pomnilnik"
+
+#: id:440
+msgid "Harddisk"
+msgstr "Trdi disk"
+
+#: id:441
+msgid "UDF"
+msgstr "UDF"
+
+#: id:442
+msgid "Local network"
+msgstr "Krajevno omrežje"
+
+#: id:443
+msgid "Internet"
+msgstr "Internet"
+
+#: id:444
+msgctxt "Auto context with id 444"
+msgid "Video"
+msgstr "Video"
+
+#: id:445
+msgctxt "Auto context with id 445"
+msgid "Audio"
+msgstr "Glasba"
+
+#: id:446
+msgctxt "Auto context with id 446"
+msgid "DVD"
+msgstr "DVD"
+
+#: id:447
+msgid "Autorun media"
+msgstr "Samodejni zagon"
+
+#: id:448
+msgid "LCD"
+msgstr "LCD"
+
+#: id:449
+msgctxt "Auto context with id 449"
+msgid "Enabled"
+msgstr "Vključen"
+
+#: id:450
+msgid "Columns"
+msgstr "Stolpci"
+
+#: id:451
+msgid "Row 1 address"
+msgstr "Vrstica 1 naslov"
+
+#: id:452
+msgid "Row 2 address"
+msgstr "Vrstica 2 naslov"
+
+#: id:453
+msgid "Row 3 address"
+msgstr "Vrstica 3 naslov"
+
+#: id:454
+msgid "Row 4 address"
+msgstr "Vrstica 4 naslov"
+
+#: id:455
+msgid "Rows"
+msgstr "Vrstice"
+
+#: id:456
+msgid "Mode"
+msgstr "Način"
+
+#: id:457
+msgid "Switch view"
+msgstr "Preklopi pogled"
+
+#: id:459
+msgid "Subs"
+msgstr "Podnapisi"
+
+#: id:460
+msgid "Audio stream"
+msgstr "Zvočna sled"
+
+#: id:461
+msgid "[active]"
+msgstr "[aktiven]"
+
+#: id:462
+msgid "Subtitle"
+msgstr "Podnapisi"
+
+#: id:463
+msgid "Backlight"
+msgstr "Osvelitev ozadja"
+
+#: id:464
+msgid "Brightness"
+msgstr "Osvetlitev"
+
+#: id:465
+msgid "Contrast"
+msgstr "Kontrast"
+
+#: id:466
+msgid "Gamma"
+msgstr "Gama jakost"
+
+#: id:467
+msgctxt "Auto context with id 467"
+msgid "Type"
+msgstr "Tip"
+
+#: id:468
+msgid "Move the bar to change the OSD position"
+msgstr "Premakni kurzor za spremembo položaja OSD-ja"
+
+#: id:469
+msgid "OSD position"
+msgstr "OSD položaj"
+
+#: id:470
+msgid "Credits"
+msgstr "Zasluge"
+
+#: id:471
+msgid "Modchip"
+msgstr "Modčip"
+
+#: id:474
+msgctxt "Auto context with id 474"
+msgid "Off"
+msgstr "Izključi"
+
+#: id:475
+msgid "Music only"
+msgstr "Samo glasba"
+
+#: id:476
+msgctxt "Auto context with id 476"
+msgid "Music & video"
+msgstr "Glasba & video"
+
+#: id:477
+msgid "Unable to load playlist"
+msgstr "Ne morem naložiti predvajalnega seznama"
+
+#: id:478
+msgid "OSD"
+msgstr "OSD"
+
+#: id:479
+msgid "Skin & language"
+msgstr "Preobleka & jezik"
+
+#: id:480
+msgid "Appearance"
+msgstr "Izgled"
+
+#: id:481
+msgid "Audio options"
+msgstr "Zvočne nastavitve"
+
+#: id:482
+msgid "About XBMC"
+msgstr "O XBMC"
+
+#: id:485
+msgid "Delete album"
+msgstr "Izbriši album"
+
+#: id:486
+msgid "Repeat"
+msgstr "Ponovi"
+
+#: id:487
+msgid "Repeat one"
+msgstr "Ponovi enkrat"
+
+#: id:488
+msgid "Repeat folder"
+msgstr "Ponovi mapo"
+
+#: id:489
+msgid "Play the next song automatically"
+msgstr "Samodejno predvajanje naslednje datoteke"
+
+#: id:491
+msgid "- Use big icons"
+msgstr "- Uporabi velike ikone"
+
+#: id:492
+msgid "Resize VobSubs"
+msgstr "Sprememba velikosti Vobsubs"
+
+#: id:493
+msgid "Advanced options (Experts Only!)"
+msgstr "Napredne nastavitve (Samo za strokovnjake!)"
+
+#: id:494
+msgid "Overall audio headroom"
+msgstr "Overall audio headroom"
+
+#: id:495
+msgid "Upsample videos to GUI resolution"
+msgstr "Povečaj video na ločljivost GUI"
+
+#: id:496
+msgid "Calibration"
+msgstr "Prilagajanje"
+
+#: id:497
+msgid "Show file extensions"
+msgstr "Prikaži končnice datotek"
+
+#: id:498
+msgid "Sort by: Type"
+msgstr "Razvrsti: Tip"
+
+#: id:499
+msgid "Unable to connect to online lookup service"
+msgstr "Ne morem se povezati s spletno storitvijo"
+
+#: id:500
+msgid "Downloading album information failed"
+msgstr "Neuspel prenos informacije o albumu"
+
+#: id:501
+msgid "Looking for album names..."
+msgstr "Iščem imena albumov..."
+
+#: id:502
+msgctxt "Auto context with id 502"
+msgid "Open"
+msgstr "Odprt"
+
+#: id:503
+msgid "Busy"
+msgstr "Zaseden"
+
+#: id:504
+msgid "Empty"
+msgstr "Prazen"
+
+#: id:505
+msgid "Loading media info from files..."
+msgstr "Nalagam informacije iz datotek..."
+
+#: id:507
+msgid "Sort by: Usage"
+msgstr "Razvrsti: Uporaba"
+
+#: id:510
+msgid "Enable visualizations"
+msgstr "Vključi vizualizacijo"
+
+#: id:511
+msgid "Enable video mode switching"
+msgstr "Vključi preklop med načini slike"
+
+#: id:512
+msgid "Startup window"
+msgstr "Začetno okno"
+
+#: id:513
+msgid "Home window"
+msgstr "Domače okno"
+
+#: id:514
+msgid "Manual settings"
+msgstr "Ročne nastavitve"
+
+#: id:515
+msgid "Genre"
+msgstr "Žanr"
+
+#: id:517
+msgid "Recently played albums"
+msgstr "Nazadnje predvajani Albumi"
+
+#: id:518
+msgid "Launch"
+msgstr "Zaženi"
+
+#: id:519
+msgid "Launch in..."
+msgstr "Zaženi v..."
+
+#: id:521
+msgid "Compilations"
+msgstr "Kompilacije"
+
+#: id:522
+msgid "Remove source"
+msgstr "Odstrani izvor"
+
+#: id:523
+msgid "Switch media"
+msgstr "Zamenjaj medij"
+
+#: id:524
+msgid "Select playlist"
+msgstr "Izberi predvajalni seznam"
+
+#: id:525
+msgid "New playlist..."
+msgstr "Nov predvajalni seznam..."
+
+#: id:526
+msgid "Add to playlist"
+msgstr "Dodaj v predvajalni seznam"
+
+#: id:527
+msgid "Manually add to library"
+msgstr "Ročno dodaj v knjižnico"
+
+#: id:528
+msgid "Enter title"
+msgstr "Vnesi naslov"
+
+#: id:529
+msgid "Error: Duplicate title"
+msgstr "Napaka: Podvojen naslov"
+
+#: id:530
+msgid "Select genre"
+msgstr "Izberi žanr"
+
+#: id:531
+msgid "New genre"
+msgstr "Nov žanr"
+
+#: id:532
+msgid "Manual addition"
+msgstr "Ročni vnos"
+
+#: id:533
+msgid "Enter genre"
+msgstr "Vnesi žanr"
+
+#: id:534
+msgid "View: %s"
+msgstr "Pogled: %s"
+
+#: id:535
+msgid "List"
+msgstr "Seznam"
+
+#: id:536
+msgid "Icons"
+msgstr "Ikone"
+
+#: id:537
+msgid "Big list"
+msgstr "Velik seznam"
+
+#: id:538
+msgid "Big icons"
+msgstr "Velike ikone"
+
+#: id:539
+msgid "Wide"
+msgstr "Široko"
+
+#: id:540
+msgid "Big wide"
+msgstr "Veliko in široko"
+
+#: id:541
+msgid "Album icons"
+msgstr "Ikone albumov"
+
+#: id:542
+msgid "DVD icons"
+msgstr "Ikone DVD"
+
+#: id:543
+msgctxt "Auto context with id 543"
+msgid "DVD"
+msgstr "DVD"
+
+#: id:544
+msgctxt "Auto context with id 544"
+msgid "Media info"
+msgstr "Informacije o mediju"
+
+#: id:545
+msgid "Audio output device"
+msgstr "Zvočna izhodna naprava"
+
+#: id:546
+msgid "Passthrough output device"
+msgstr "Naprava za preusmeritev zvoka"
+
+#: id:547
+msgid "No biography for this artist"
+msgstr "Ni biografije za tega izvajalca"
+
+#: id:548
+msgid "Downmix multichannel audio to stereo"
+msgstr "Pretvori večkanalni zvok v stereo"
+
+#: id:550
+msgid "Sort by: %s"
+msgstr "Razvrsti: %s"
+
+#: id:551
+msgctxt "Auto context with id 551"
+msgid "Name"
+msgstr "Ime"
+
+#: id:552
+msgid "Date"
+msgstr "Datum"
+
+#: id:553
+msgid "Size"
+msgstr "Velikost"
+
+#: id:554
+msgid "Track"
+msgstr "Posnetek"
+
+#: id:555
+msgid "Time"
+msgstr "Čas"
+
+#: id:556
+msgctxt "Auto context with id 556"
+msgid "Title"
+msgstr "Naslov"
+
+#: id:557
+msgid "Artist"
+msgstr "Izvajalec"
+
+#: id:558
+msgid "Album"
+msgstr "Album"
+
+#: id:559
+msgid "Playlist"
+msgstr "Predvajalni seznam"
+
+#: id:560
+msgid "ID"
+msgstr "ID"
+
+#: id:561
+msgctxt "Auto context with id 561"
+msgid "File"
+msgstr "Datoteka"
+
+#: id:562
+msgctxt "Auto context with id 562"
+msgid "Year"
+msgstr "Leto"
+
+#: id:563
+msgid "Rating"
+msgstr "Ocena"
+
+#: id:564
+msgctxt "Auto context with id 564"
+msgid "Type"
+msgstr "Tip"
+
+#: id:565
+msgid "Usage"
+msgstr "Uporaba"
+
+#: id:566
+msgid "Album artist"
+msgstr "Izvajalec albuma"
+
+#: id:567
+msgid "Play count"
+msgstr "Števec predvajanj"
+
+#: id:568
+msgid "Last played"
+msgstr "Nazadnje predvajano"
+
+#: id:569
+msgctxt "Auto context with id 569"
+msgid "Comment"
+msgstr "Komentar"
+
+#: id:570
+msgid "Date added"
+msgstr "Datum vnosa"
+
+#: id:571
+msgctxt "Auto context with id 571"
+msgid "Default"
+msgstr "Privzeto"
+
+#: id:572
+msgid "Studio"
+msgstr "Studio"
+
+#: id:573
+msgid "Path"
+msgstr "Pot"
+
+#: id:574
+msgctxt "Auto context with id 574"
+msgid "Country"
+msgstr "Država"
+
+#: id:575
+msgid "In progress"
+msgstr "Napredek"
+
+#: id:576
+msgid "Times played"
+msgstr "Količina predvajanj"
+
+#: id:580
+msgid "Sort direction"
+msgstr "Smer razvrščanja"
+
+#: id:581
+msgid "Sort method"
+msgstr "Način razvrščanja"
+
+#: id:582
+msgctxt "Auto context with id 582"
+msgid "View mode"
+msgstr "Pogled"
+
+#: id:583
+msgid "Remember views for different folders"
+msgstr "Zapomni si pogled za različne mape"
+
+#: id:584
+msgid "Ascending"
+msgstr "Naraščajoče"
+
+#: id:585
+msgid "Descending"
+msgstr "Padajoče"
+
+#: id:586
+msgid "Edit playlist"
+msgstr "Uredi predvajalni seznam"
+
+#: id:587
+msgid "Filter"
+msgstr "Filter"
+
+#: id:588
+msgid "Cancel party mode"
+msgstr "Ustavi zabavni način"
+
+#: id:589
+msgid "Party mode"
+msgstr "Zabavni način"
+
+#: id:590
+msgid "Random"
+msgstr "Naključno"
+
+#: id:591
+msgctxt "Auto context with id 591"
+msgid "Off"
+msgstr "Izključi"
+
+#: id:592
+msgid "One"
+msgstr "Eno"
+
+#: id:593
+msgid "All"
+msgstr "Vse"
+
+#: id:594
+msgctxt "Auto context with id 594"
+msgid "Off"
+msgstr "Izključi"
+
+#: id:595
+msgid "Repeat: Off"
+msgstr "Ponovi: Izključen"
+
+#: id:596
+msgid "Repeat: One"
+msgstr "Ponovi: Enkrat"
+
+#: id:597
+msgid "Repeat: All"
+msgstr "Ponovi: Vse"
+
+#: id:600
+msgid "Rip audio CD"
+msgstr "Pretvori zvočni CD"
+
+#: id:601
+msgctxt "Auto context with id 601"
+msgid "Medium"
+msgstr "Srednji"
+
+#: id:602
+msgctxt "Auto context with id 602"
+msgid "Standard"
+msgstr "Standardni"
+
+#: id:603
+msgid "Extreme"
+msgstr "Ekstremni"
+
+#: id:604
+msgid "Constant bitrate"
+msgstr "Konstantna bitna hitrost"
+
+#: id:605
+msgid "Ripping..."
+msgstr "Pretvarjanje..."
+
+#: id:607
+msgid "To:"
+msgstr "Do:"
+
+#: id:608
+msgid "Could not rip CD or track"
+msgstr "Ne morem pretvoriti CD-ja ali zapisa"
+
+#: id:609
+msgid "CDDARipPath is not set."
+msgstr "CDDARipPath ni nastavljen."
+
+#: id:610
+msgid "Rip audio track"
+msgstr "Pretvori zvočni posnetek"
+
+#: id:611
+msgid "Enter number"
+msgstr "Vnesi število"
+
+#: id:612
+msgid "Bits/Sample"
+msgstr "Bits/Sample"
+
+#: id:613
+msgid "Sample Frequency"
+msgstr "Sample Frequency"
+
+#: id:620
+msgid "Audio CDs"
+msgstr "Zvočni CD-ji"
+
+#: id:621
+msgid "Encoder"
+msgstr "Enkoder"
+
+#: id:622
+msgid "Quality"
+msgstr "Kvaliteta"
+
+#: id:623
+msgid "Bitrate"
+msgstr "Bitna hitrost"
+
+#: id:624
+msgid "Include track number"
+msgstr "Vključi številko pesmi"
+
+#: id:625
+msgid "All songs of"
+msgstr "Vse pesmi od"
+
+#: id:629
+msgctxt "Auto context with id 629"
+msgid "View mode"
+msgstr "Pogled"
+
+#: id:630
+msgctxt "Auto context with id 630"
+msgid "Normal"
+msgstr "Normalno"
+
+#: id:631
+msgid "Zoom"
+msgstr "Povečaj"
+
+#: id:632
+msgid "Stretch 4:3"
+msgstr "Razpotegni 4:3"
+
+#: id:633
+msgid "Wide Zoom"
+msgstr "Široka povečava"
+
+#: id:634
+msgid "Stretch 16:9"
+msgstr "Razpotegni 16:9"
+
+#: id:635
+msgid "Original Size"
+msgstr "Originalna velikost"
+
+#: id:636
+msgctxt "Auto context with id 636"
+msgid "Custom"
+msgstr "Po meri"
+
+#: id:637
+msgid "Replay gain"
+msgstr "Poenotenje glasnosti"
+
+#: id:638
+msgid "Replaygain volume adjustments"
+msgstr "Nastavitve poenotenja glasnosti"
+
+#: id:639
+msgid "Use track levels"
+msgstr "Uporabi nivoje posnetkov"
+
+#: id:640
+msgid "Use album levels"
+msgstr "Uporabi nivoje albuma"
+
+#: id:641
+msgid "PreAmp Level - Replay gained files"
+msgstr "PreAmp nivo - Poenoti glasnost dobljenih datotek"
+
+#: id:642
+msgid "PreAmp Level - Non replay gained files"
+msgstr "PreAmp nivo - Ne poenoti glasnosti dobljenih datotek"
+
+#: id:643
+msgid "Avoid clipping on replay gained files"
+msgstr "Prepreči stikanje poenotenih datotek"
+
+#: id:644
+msgid "Crop black bars"
+msgstr "Obreži črne robove"
+
+#: id:645
+msgid "Need to unpack a big file. Continue?"
+msgstr "Potrebno je razpakirati velike datoteke. Nadaljujem?"
+
+#: id:646
+msgid "Remove from library"
+msgstr "Odstrani iz knjižnice"
+
+#: id:647
+msgid "Export video library"
+msgstr "Izvozi video knjižnico"
+
+#: id:648
+msgid "Import video library"
+msgstr "Uvozi video knjižnico"
+
+#: id:649
+msgid "Importing"
+msgstr "Uvažam"
+
+#: id:650
+msgid "Exporting"
+msgstr "Izvažam"
+
+#: id:651
+msgid "Browse for library"
+msgstr "Prebrskaj za knjižnico"
+
+#: id:652
+msgid "Years"
+msgstr "Leta"
+
+#: id:653
+msgid "Update library"
+msgstr "Posodobi knjižnico"
+
+#: id:654
+msgid "Show debug info"
+msgstr "Prikaži razhroščevalne informacije"
+
+#: id:655
+msgid "Browse for executable"
+msgstr "Prebrskaj za program"
+
+#: id:656
+msgid "Browse for playlist"
+msgstr "Prebrskaj za predvajalni seznam"
+
+#: id:657
+msgid "Browse for folder"
+msgstr "Prebrskaj za mapo"
+
+#: id:658
+msgid "Song information"
+msgstr "Informacija o pesmi"
+
+#: id:659
+msgid "Non-linear stretch"
+msgstr "Nelinearni razteg"
+
+#: id:660
+msgid "Volume amplification"
+msgstr "Ojačitev glasnosti"
+
+#: id:661
+msgid "Choose export folder"
+msgstr "Izberi mapo za izvoz"
+
+#: id:662
+msgid "This file is no longer available."
+msgstr "Datoteka ni več na voljo."
+
+#: id:663
+msgid "Would you like to remove it from the library?"
+msgstr "Ali jo želiš odstraniti iz knjižnice?"
+
+#: id:664
+msgid "Browse for Script"
+msgstr "Prebrskaj za skripto"
+
+#: id:665
+msgid "Compression level"
+msgstr "Nivo stiskanja"
+
+#: id:700
+msgid "Cleaning up library"
+msgstr "Čiščenje knjižnice"
+
+#: id:701
+msgid "Removing old songs from the library"
+msgstr "Odstrani stare pesmi iz knjižnice"
+
+#: id:702
+msgid "This path has been scanned before"
+msgstr "Ta pot je že bila preiskana"
+
+#: id:705
+msgctxt "Auto context with id 705"
+msgid "Network"
+msgstr "Omrežje"
+
+#: id:706
+msgid "- Server"
+msgstr "- Strežnik"
+
+#: id:708
+msgid "Use an HTTP proxy server to access the internet"
+msgstr "Uporabi HTTP proxy strežnik za povezavo do interneta"
+
+#: id:711
+msgid "Internet Protocol (IP)"
+msgstr "Internetni Protokol (IP)"
+
+#: id:712
+msgid "Invalid port specified. Value must be between 1 and 65535."
+msgstr "Izbrana napačna vrata. Vrednost mora biti med 1 in 65535."
+
+#: id:713
+msgid "HTTP proxy"
+msgstr "HTTP proxy"
+
+#: id:715
+msgid "- Assignment"
+msgstr "- Nastavitev"
+
+#: id:716
+msgid "Automatic (DHCP)"
+msgstr "Samodejno (DHCP)"
+
+#: id:717
+msgid "Manual (Static)"
+msgstr "Ročno (Statično)"
+
+#: id:719
+msgid "- IP address"
+msgstr "- IP naslov"
+
+#: id:720
+msgid "- Netmask"
+msgstr "- Maska podomrežja"
+
+#: id:721
+msgid "- Default gateway"
+msgstr "- Privzeti prehod"
+
+#: id:722
+msgid "- DNS server"
+msgstr "- DNS strežnik"
+
+#: id:723
+msgid "Save & restart"
+msgstr "Shrani & ponovno zaženi"
+
+#: id:724
+msgid "Invalid address specified. Value must be AAA.BBB.CCC.DDD"
+msgstr "Vnešen je bil napačen naslov. Vrednosti morajo biti oblike AAA.BBB.CCC.DDD"
+
+#: id:725
+msgid "with numbers between 0 and 255."
+msgstr "z vrednostmi od 0 do 255."
+
+#: id:726
+msgid "Changes not saved. Continue without saving?"
+msgstr "Spremembe niso shranjene. Nadaljujem brez shranjevanja?"
+
+#: id:727
+msgid "Web server"
+msgstr "Spletni strežnik"
+
+#: id:728
+msgctxt "Auto context with id 728"
+msgid "FTP server"
+msgstr "FTP strežnik"
+
+#: id:730
+msgid "- Port"
+msgstr "- Vrata"
+
+#: id:732
+msgid "Save & apply"
+msgstr "Shrani & uporabi"
+
+#: id:733
+msgid "- Password"
+msgstr "- Geslo"
+
+#: id:734
+msgid "No pass"
+msgstr "Brez"
+
+#: id:735
+msgid "- Character set"
+msgstr "- Nabor znakov"
+
+#: id:736
+msgid "- Style"
+msgstr "- Stil"
+
+#: id:737
+msgid "- Colour"
+msgstr "- Barva"
+
+#: id:738
+msgctxt "Auto context with id 738"
+msgid "Normal"
+msgstr "Normalno"
+
+#: id:739
+msgid "Bold"
+msgstr "Krepko"
+
+#: id:740
+msgid "Italics"
+msgstr "Poševno"
+
+#: id:741
+msgid "Bold italics"
+msgstr "Poševno ojačano"
+
+#: id:742
+msgctxt "Auto context with id 742"
+msgid "White"
+msgstr "Bela"
+
+#: id:743
+msgctxt "Auto context with id 743"
+msgid "Yellow"
+msgstr "Rumena"
+
+#: id:744
+msgctxt "Auto context with id 744"
+msgid "Files"
+msgstr "Datoteke"
+
+#: id:745
+msgid "No scanned information for this view"
+msgstr "Ni preiskanih informacij za ta pogled"
+
+#: id:746
+msgid "Please turn off library mode"
+msgstr "Izključi način knjižnice"
+
+#: id:747
+msgid "Error loading image"
+msgstr "Napaka pri nalaganju slike"
+
+#: id:748
+msgid "Edit path"
+msgstr "Uredi pot"
+
+#: id:749
+msgid "Mirror image"
+msgstr "Zrcali sliko"
+
+#: id:750
+msgid "Are you sure?"
+msgstr "Ali ste prepričani?"
+
+#: id:751
+msgid "Removing source"
+msgstr "Odstranjujem vir"
+
+#: id:754
+msgid "Add program link"
+msgstr "Dodaj bljižnico do programa"
+
+#: id:755
+msgid "Edit program path"
+msgstr "Uredi pot programa"
+
+#: id:756
+msgid "Edit program name"
+msgstr "Uredi ime programa"
+
+#: id:757
+msgid "Edit path depth"
+msgstr "Uredi globino poti"
+
+#: id:759
+msgid "View: Big list"
+msgstr "Pogled: Velik seznam"
+
+#: id:760
+msgctxt "Auto context with id 760"
+msgid "Yellow"
+msgstr "Rumena"
+
+#: id:761
+msgctxt "Auto context with id 761"
+msgid "White"
+msgstr "Bela"
+
+#: id:762
+msgid "Blue"
+msgstr "Modra"
+
+#: id:763
+msgid "Bright green"
+msgstr "Svetlo zelena"
+
+#: id:764
+msgid "Yellow green"
+msgstr "Rumeno zelena"
+
+#: id:765
+msgid "Cyan"
+msgstr "Turkizna"
+
+#: id:766
+msgid "Light grey"
+msgstr "Svetlo siva"
+
+#: id:767
+msgid "Grey"
+msgstr "Siva"
+
+#: id:770
+msgid "Error %i: share not available"
+msgstr "Napaka %i: skupna raba ni dostopna"
+
+#: id:772
+msgctxt "Auto context with id 772"
+msgid "Audio output"
+msgstr "Zvočni izhod"
+
+#: id:773
+msgid "Seeking"
+msgstr "Iščem"
+
+#: id:774
+msgid "Slideshow folder"
+msgstr "Mapa za projekcijo slik"
+
+#: id:775
+msgid "Network interface"
+msgstr "Omrežna povezava"
+
+#: id:776
+msgid "- Wireless network name (ESSID)"
+msgstr "- Ime brezžičnega omrežja (ESSID)"
+
+#: id:777
+msgid "- Wireless password"
+msgstr "- Geslo brezžičnega omrežja"
+
+#: id:778
+msgid "- Wireless security"
+msgstr "- Varnost brezžičnega omrežja"
+
+#: id:779
+msgid "Save and apply network interface settings"
+msgstr "Shrani in uveljavi nastavitve omrežne povezave"
+
+#: id:780
+msgid "No encryption"
+msgstr "Brez enkripcije"
+
+#: id:781
+msgid "WEP"
+msgstr "WEP"
+
+#: id:782
+msgid "WPA"
+msgstr "WPA"
+
+#: id:783
+msgid "WPA2"
+msgstr "WPA2"
+
+#: id:784
+msgid "Applying network interface settings. Please wait."
+msgstr "Uveljavljam nastavitve omrežne povezave. Prosim počakajte trenutek."
+
+#: id:785
+msgid "Network interface restarted successfully."
+msgstr "Omrežna povezava se je uspešno zagnala."
+
+#: id:786
+msgid "Network interface did not start successfully."
+msgstr "Omrežne povezave ni bilo mogoče zagnati."
+
+#: id:787
+msgid "Interface disabled"
+msgstr "Povezava je onemogočena"
+
+#: id:788
+msgid "Network interface disabled successfully."
+msgstr "Omrežna povezava se je uspešno izključila."
+
+#: id:789
+msgid "Wireless network name (ESSID)"
+msgstr "Ime brezžičnega omrežja (ESSID)"
+
+#: id:790
+msgid "Remote control"
+msgstr ""
+
+#: id:791
+msgid "Allow programs on this system to control XBMC"
+msgstr "Dovoli programom na tem sistemu, da upravljajo z XBMC"
+
+#: id:792
+msgctxt "Auto context with id 792"
+msgid "Port"
+msgstr "Vrata"
+
+#: id:793
+msgid "Port range"
+msgstr "Območje vrat"
+
+#: id:794
+msgid "Allow programs on other systems to control XBMC"
+msgstr "Dovoli programom na drugih sistemih, da upravljajo z XBMC"
+
+#: id:795
+msgid "Initial repeat delay (ms)"
+msgstr "Osnovni zamik (ms)"
+
+#: id:796
+msgid "Continuous repeat delay (ms)"
+msgstr "Nadaljevalni zamik (ms)"
+
+#: id:797
+msgid "Maximum number of clients"
+msgstr "Največje število povezav"
+
+#: id:798
+msgid "Internet access"
+msgstr "Internetni dostop"
+
+#: id:850
+msgid "Invalid port number entered"
+msgstr "Vnešena je nepravilna številka vrat"
+
+#: id:851
+msgid "Valid port range is 1-65535"
+msgstr "Veljavno območje vrat je 1-65535"
+
+#: id:852
+msgid "Valid port range is 1024-65535"
+msgstr "Veljavno območje vrat je 1024-65535"
+
+#: id:998
+msgid "Add Music..."
+msgstr "Dodaj glasbo..."
+
+#: id:999
+msgid "Add Videos..."
+msgstr "Dodaj video..."
+
+#: id:1000
+msgid "- Preview"
+msgstr "- Predogled"
+
+#: id:1001
+msgid "Unable to connect"
+msgstr "Povezava ni mogoča"
+
+#: id:1002
+msgid "XBMC was unable to connect to the network location."
+msgstr "XBMC se ni mogel povezati na omrežno lokacijo."
+
+#: id:1003
+msgid "This could be due to the network not being connected."
+msgstr "Problem je lahko nastal zaradi nepovezanosti z omrežjem."
+
+#: id:1004
+msgid "Would you like to add it anyway?"
+msgstr "Želite vseeno dodati vsebino?"
+
+#: id:1006
+msgctxt "Auto context with id 1006"
+msgid "IP address"
+msgstr "IP naslov"
+
+#: id:1007
+msgid "Add network location"
+msgstr "Dodaj omrežno lokacijo"
+
+#: id:1008
+msgid "Protocol"
+msgstr "Protokol"
+
+#: id:1009
+msgid "Server address"
+msgstr "Naslov strežnika"
+
+#: id:1010
+msgid "Server name"
+msgstr "Ime strežnika"
+
+#: id:1011
+msgid "Remote path"
+msgstr "Oddaljena pot"
+
+#: id:1012
+msgid "Shared folder"
+msgstr "Mapa skupne rabe"
+
+#: id:1013
+msgctxt "Auto context with id 1013"
+msgid "Port"
+msgstr "Vrata"
+
+#: id:1014
+msgctxt "Auto context with id 1014"
+msgid "Username"
+msgstr "Uporabniško ime"
+
+#: id:1015
+msgid "Browse for network server"
+msgstr "Prebrskaj za omrežni strežnik"
+
+#: id:1016
+msgid "Enter the network address of the server"
+msgstr "Vnesite omrežni naslov strežnika"
+
+#: id:1017
+msgid "Enter the path on the server"
+msgstr "Vnesite pot do strežnika"
+
+#: id:1018
+msgid "Enter the port number"
+msgstr "Vnesite številko vrat"
+
+#: id:1019
+msgid "Enter the username"
+msgstr "Vnesite uporabniško ime"
+
+#: id:1020
+msgid "Add %s source"
+msgstr "Dodaj %s izvor"
+
+#: id:1021
+msgid "Enter the paths or browse for the media locations."
+msgstr "Vnesi poti ali prebrskaj za lokacijo medija."
+
+#: id:1022
+msgid "Enter a name for this media Source."
+msgstr "Vnesi ime za ta izvor."
+
+#: id:1023
+msgid "Browse for new share"
+msgstr "Prebrskaj za novo skupno rabo"
+
+#: id:1024
+msgid "Browse"
+msgstr "Prebrskaj"
+
+#: id:1025
+msgid "Could not retrieve directory information."
+msgstr "Ne morem priklicati informacij o mapi."
+
+#: id:1026
+msgid "Add source"
+msgstr "Dodaj izvor"
+
+#: id:1027
+msgid "Edit source"
+msgstr "Uredi izvor"
+
+#: id:1028
+msgid "Edit %s source"
+msgstr "Uredi %s izvor"
+
+#: id:1029
+msgid "Enter the new label"
+msgstr "Vnesi novo oznako"
+
+#: id:1030
+msgid "Browse for image"
+msgstr "Prebrskaj za sliko"
+
+#: id:1031
+msgid "Browse for image folder"
+msgstr "Prebrskaj za mapo slik"
+
+#: id:1032
+msgid "Add network location..."
+msgstr "Dodaj omrežno lokacijo..."
+
+#: id:1033
+msgid "Browse for file"
+msgstr "Prebrskaj za datoteko"
+
+#: id:1034
+msgid "Submenu"
+msgstr "Podmenu"
+
+#: id:1035
+msgid "Enable submenu buttons"
+msgstr "Vključi gumbe podmenuja"
+
+#: id:1036
+msgid "Favourites"
+msgstr "Priljubljene"
+
+#: id:1037
+msgid "Video Add-ons"
+msgstr "Video dodatki"
+
+#: id:1038
+msgid "Music Add-ons"
+msgstr "Glasbeni dodatki"
+
+#: id:1039
+msgid "Picture Add-ons"
+msgstr "Slikovni dodatki"
+
+#: id:1040
+msgid "Loading directory"
+msgstr "Nalagam mapo"
+
+#: id:1041
+msgid "Retrieved %i items"
+msgstr "Prenešenih %i elementov"
+
+#: id:1042
+msgid "Retrieved %i of %i items"
+msgstr "Prenešenih %i od %i elementov"
+
+#: id:1043
+msgid "Program Add-ons"
+msgstr "Programski dodatki"
+
+#: id:1044
+msgid "Set plugin thumb"
+msgstr "Nastavi sličico dodatku"
+
+#: id:1045
+msgid "Add-on settings"
+msgstr "Nastavitve dodatka"
+
+#: id:1046
+msgid "Access points"
+msgstr "Dostopne točke"
+
+#: id:1047
+msgid "Other..."
+msgstr "Drugo..."
+
+#: id:1048
+msgid "- Username"
+msgstr "- Uporabniško ime"
+
+#: id:1049
+msgid "Script settings"
+msgstr "Nastavitve skripte"
+
+#: id:1050
+msgid "Singles"
+msgstr "Singli"
+
+#: id:1051
+msgid "Enter web address"
+msgstr "Vnesite spletni naslov"
+
+#: id:1200
+msgid "SMB client"
+msgstr "SMB odjemalec"
+
+#: id:1202
+msgid "Workgroup"
+msgstr "Delovna skupina"
+
+#: id:1203
+msgid "Default username"
+msgstr "Privzeto uporabniško ime"
+
+#: id:1204
+msgid "Default password"
+msgstr "Privzeto geslo"
+
+#: id:1207
+msgid "WINS server"
+msgstr "WINS strežnik"
+
+#: id:1208
+msgid "Mount SMB shares"
+msgstr "Odpri SMB skupno rabo"
+
+#: id:1210
+msgctxt "Auto context with id 1210"
+msgid "Remove"
+msgstr "Odstrani"
+
+#: id:1211
+msgctxt "Auto context with id 1211"
+msgid "Music"
+msgstr "Glasba"
+
+#: id:1212
+msgctxt "Auto context with id 1212"
+msgid "Video"
+msgstr "Video"
+
+#: id:1213
+msgctxt "Auto context with id 1213"
+msgid "Pictures"
+msgstr "Slike"
+
+#: id:1214
+msgctxt "Auto context with id 1214"
+msgid "Files"
+msgstr "Datoteke"
+
+#: id:1215
+msgctxt "Auto context with id 1215"
+msgid "Music & video"
+msgstr "Glasba & video"
+
+#: id:1216
+msgid "Music & pictures"
+msgstr "Glasba & slike"
+
+#: id:1217
+msgid "Music & files"
+msgstr "Glasba & datoteke"
+
+#: id:1218
+msgid "Video & pictures"
+msgstr "Video & slike"
+
+#: id:1219
+msgid "Video & files"
+msgstr "Video & datoteke"
+
+#: id:1220
+msgid "Pictures & files"
+msgstr "Slike & datoteke"
+
+#: id:1221
+msgid "Music & video & pictures"
+msgstr "Glasba, video & slike"
+
+#: id:1222
+msgid "Music & video & pictures & files"
+msgstr "Glasba, video, slike & datoteke"
+
+#: id:1223
+msgctxt "Auto context with id 1223"
+msgid "Disabled"
+msgstr "Izključeno"
+
+#: id:1226
+msgid "Files & music & video"
+msgstr "Datoteke, glasba & video"
+
+#: id:1227
+msgid "Files & pictures & music"
+msgstr "Datoteke, slike & glasba"
+
+#: id:1228
+msgid "Files & pictures & video"
+msgstr "Datoteke, slike & video"
+
+#: id:1229
+msgid "Music & programs"
+msgstr "Glasba & programi"
+
+#: id:1230
+msgid "Video & programs"
+msgstr "Video & programi"
+
+#: id:1231
+msgid "Pictures & programs"
+msgstr "Slike & programi"
+
+#: id:1232
+msgid "Music & video & pictures & programs"
+msgstr "Glasba, video, slike & programi"
+
+#: id:1233
+msgid "Programs & video & music"
+msgstr "Programi, video & glasba"
+
+#: id:1234
+msgid "Programs & pictures & music"
+msgstr "Programi, slike & glasba"
+
+#: id:1235
+msgid "Programs & pictures & video"
+msgstr "Programi, slike & video"
+
+#: id:1250
+msgid "Auto-detection"
+msgstr "Samodejna zaznava"
+
+#: id:1251
+msgid "Auto-detect system"
+msgstr "Samodejno zaznaj sistem"
+
+#: id:1252
+msgid "Nickname"
+msgstr "Vzdevek"
+
+#: id:1254
+msgid "Ask to connect"
+msgstr "Vprašaj za povezavo"
+
+#: id:1255
+msgid "Send FTP user and password"
+msgstr "Pošlji FTP uporabniško ime in geslo"
+
+#: id:1256
+msgid "Ping interval"
+msgstr "Ping interval"
+
+#: id:1257
+msgid "Would you like to connect to the auto-detected system?"
+msgstr "Povežem z samodejno zaznanim sistemom?"
+
+#: id:1259
+msgid "Zeroconf"
+msgstr ""
+
+#: id:1260
+msgid "Announce these services to other systems via Zeroconf"
+msgstr "Oznani storitve drugim sistemom preko Zeroconf"
+
+#: id:1270
+msgid "Allow XBMC to receive AirPlay content"
+msgstr "Dovoli XBMC sprejemanje vsebin AirPlay"
+
+#: id:1271
+msgid "Device name"
+msgstr "Ime naprave"
+
+#: id:1272
+msgid "- Use password protection"
+msgstr "- Zaščiti z geslom"
+
+#: id:1273
+msgid "AirPlay"
+msgstr ""
+
+#: id:1300
+msgid "Custom audio device"
+msgstr "Poljubna zvočna naprava"
+
+#: id:1301
+msgid "Custom passthrough device"
+msgstr "Poljubna naprava za preusmeritev zvoka"
+
+#: id:1396
+msgid "Drifting"
+msgstr "zameti"
+
+#: id:1397
+msgid "and"
+msgstr "in"
+
+#: id:1398
+msgid "Freezing"
+msgstr "zmrzovanje"
+
+#: id:1399
+msgid "Late"
+msgstr "pozne"
+
+#: id:1400
+msgid "Isolated"
+msgstr "izolirane"
+
+#: id:1401
+msgid "Thundershowers"
+msgstr "nevihte"
+
+#: id:1402
+msgid "Thunder"
+msgstr "grom"
+
+#: id:1403
+msgctxt "Auto context with id 1403"
+msgid "Sun"
+msgstr "sončno"
+
+#: id:1404
+msgid "Heavy"
+msgstr "močan"
+
+#: id:1405
+msgid "in"
+msgstr "v"
+
+#: id:1406
+msgid "the"
+msgstr ""
+
+#: id:1407
+msgid "Vicinity"
+msgstr "bližini"
+
+#: id:1408
+msgid "Ice"
+msgstr "led"
+
+#: id:1409
+msgid "Crystals"
+msgstr "kristali"
+
+#: id:1410
+msgid "Calm"
+msgstr "mirno"
+
+#: id:1411
+msgid "with"
+msgstr "z"
+
+#: id:1412
+msgid "windy"
+msgstr "vetrovno"
+
+#: id:1413
+msgid "drizzle"
+msgstr "pršenje"
+
+#: id:1414
+msgid "Thunderstorm"
+msgstr "nevihta"
+
+#: id:1415
+msgid "Drizzle"
+msgstr "pršenje"
+
+#: id:1416
+msgid "Foggy"
+msgstr "megleno"
+
+#: id:1417
+msgid "Grains"
+msgstr "toča"
+
+#: id:1418
+msgid "T-Storms"
+msgstr "nevihte"
+
+#: id:1419
+msgid "T-Showers"
+msgstr "plohe"
+
+#: id:1420
+msgid "Moderate"
+msgstr "zmerno"
+
+#: id:1421
+msgid "Very High"
+msgstr "zelo visoko"
+
+#: id:1422
+msgid "Windy"
+msgstr "vetrovno"
+
+#: id:1423
+msgid "Mist"
+msgstr "meglice"
+
+#: id:1450
+msgid "Put display to sleep when idle"
+msgstr "Postavi zaslon v pripravljenost, ko ni dejaven"
+
+#: id:2050
+msgid "Runtime"
+msgstr "Čas delovanja"
+
+#: id:2100
+msgid "Script failed! : %s"
+msgstr "Napaka v skripti! : %s"
+
+#: id:2101
+msgid "Newer version needed - See log"
+msgstr "Potrebna je nova različica - Glej zapisnik"
+
+#: id:4501
+msgid "Enable LCD/VFD"
+msgstr "Vključi LCD/VFD"
+
+#: id:10000
+msgid "Home"
+msgstr "Domov"
+
+#: id:10001
+msgctxt "Auto context with id 10001"
+msgid "Programs"
+msgstr "Programi"
+
+#: id:10002
+msgctxt "Auto context with id 10002"
+msgid "Pictures"
+msgstr "Slike"
+
+#: id:10003
+msgctxt "Auto context with id 10003"
+msgid "File manager"
+msgstr "Datoteke"
+
+#: id:10004
+msgctxt "Auto context with id 10004"
+msgid "Settings"
+msgstr "Nastavitve"
+
+#: id:10005
+msgctxt "Auto context with id 10005"
+msgid "Music"
+msgstr "Glasba"
+
+#: id:10006
+msgctxt "Auto context with id 10006"
+msgid "Videos"
+msgstr "Video"
+
+#: id:10007
+msgid "System information"
+msgstr "Sistemske informacije"
+
+#: id:10008
+msgid "Settings - General"
+msgstr "Nastavitve - Splošno"
+
+#: id:10009
+msgid "Settings - Screen"
+msgstr "Nastavitve - Zaslon"
+
+#: id:10010
+msgid "Settings - Appearance - GUI Calibration"
+msgstr "Nastavitve - Izgled - Prilagajanje GUI"
+
+#: id:10011
+msgid "Settings - Videos - Screen Calibration"
+msgstr "Nastavitve - Video - Prilagajanje zaslona"
+
+#: id:10012
+msgid "Settings - Pictures"
+msgstr "Nastavitve - Slike"
+
+#: id:10013
+msgid "Settings - Programs"
+msgstr "Nastavitve - Programi"
+
+#: id:10014
+msgid "Settings - Weather"
+msgstr "Nastavitve - Vreme"
+
+#: id:10015
+msgid "Settings - Music"
+msgstr "Nastavitve - Glasba"
+
+#: id:10016
+msgid "Settings - System"
+msgstr "Nastavitve - Sistem"
+
+#: id:10017
+msgid "Settings - Videos"
+msgstr "Nastavitve - Video"
+
+#: id:10018
+msgid "Settings - Network"
+msgstr "Nastavitve - Omrežje"
+
+#: id:10019
+msgid "Settings - Appearance"
+msgstr "Nastavitve - Izgled"
+
+#: id:10020
+msgctxt "Auto context with id 10020"
+msgid "Scripts"
+msgstr "Skripte"
+
+#: id:10021
+msgid "Web Browser"
+msgstr "Spletni brskalnik"
+
+#: id:10025
+msgctxt "Auto context with id 10025"
+msgid "Videos"
+msgstr "Videi"
+
+#: id:10028
+msgid "Videos/Playlist"
+msgstr "Video/Predvajalni seznam"
+
+#: id:10029
+msgctxt "Auto context with id 10029"
+msgid "Login screen"
+msgstr "Prijavno okno"
+
+#: id:10034
+msgid "Settings - Profiles"
+msgstr "Nastavitve - Profili"
+
+#: id:10040
+msgid "Addon browser"
+msgstr "Brskalnik dodatkov"
+
+#: id:10100
+msgid "Yes/No dialog"
+msgstr "Da/Ne dialog"
+
+#: id:10101
+msgid "Progress dialog"
+msgstr "Dialog napredka"
+
+#: id:10210
+msgid "Looking for subtitles..."
+msgstr "Iščem podnapise..."
+
+#: id:10211
+msgid "Looking for or caching subtitles..."
+msgstr "Iščem ali začasno shranjujem podnapise..."
+
+#: id:10212
+msgid "terminating"
+msgstr "končujem"
+
+#: id:10213
+msgid "buffering"
+msgstr "medpomnenje"
+
+#: id:10214
+msgid "Opening stream"
+msgstr "Odpiram pretok"
+
+#: id:10500
+msgid "Music/Playlist"
+msgstr "Glasba/Predvajalni seznam"
+
+#: id:10501
+msgid "Music/Files"
+msgstr "Glasba/Datoteke"
+
+#: id:10502
+msgid "Music/Library"
+msgstr "Glasba/Knjižnica"
+
+#: id:10503
+msgid "Playlist editor"
+msgstr "Urejevalnik predvajalnega seznama"
+
+#: id:10504
+msgid "Top 100 songs"
+msgstr "Top 100 pesmi"
+
+#: id:10505
+msgid "Top 100 albums"
+msgstr "Top 100 albumov"
+
+#: id:10506
+msgctxt "Auto context with id 10506"
+msgid "Programs"
+msgstr "Programi"
+
+#: id:10507
+msgid "Configuration"
+msgstr "Nastavitve"
+
+#: id:10508
+msgid "Weather forecast"
+msgstr "Vremenska napoved"
+
+#: id:10509
+msgid "Network gaming"
+msgstr "Omrežno igranje"
+
+#: id:10510
+msgid "Extensions"
+msgstr "Razširitve"
+
+#: id:10511
+msgctxt "Auto context with id 10511"
+msgid "System info"
+msgstr "Sistemske informacije"
+
+#: id:10516
+msgid "Music - Library"
+msgstr "Glasba - Knjižnica"
+
+#: id:10517
+msgid "Now Playing - Music"
+msgstr "Trenutno predvajam - Glasba"
+
+#: id:10522
+msgid "Now Playing - Videos"
+msgstr "Trenutno predvajam - Video"
+
+#: id:10523
+msgid "Album info"
+msgstr "Informacije o albumu"
+
+#: id:10524
+msgid "Movie info"
+msgstr "Informacije o filmu"
+
+#: id:12000
+msgid "Select dialog"
+msgstr "Izberi"
+
+#: id:12001
+msgid "Music/Info"
+msgstr "Glasba/Informacije"
+
+#: id:12002
+msgid "Dialog OK"
+msgstr "Potrdi"
+
+#: id:12003
+msgid "Videos/Info"
+msgstr "Video/Informacije"
+
+#: id:12004
+msgid "Scripts/Info"
+msgstr "Skripte/Informacije"
+
+#: id:12005
+msgid "Fullscreen video"
+msgstr "Celozaslonska slika"
+
+#: id:12006
+msgid "Audio visualization"
+msgstr "Vizualizacija glasbe"
+
+#: id:12008
+msgid "File stacking dialog"
+msgstr "Združevanje datotek v skupine"
+
+#: id:12009
+msgid "Rebuild index..."
+msgstr "Ponovno indeksiranje..."
+
+#: id:12010
+msgid "Return to music window"
+msgstr "Vrni se na glasbeni pogled"
+
+#: id:12011
+msgid "Return to videos window"
+msgstr "Vrni se na video pogled"
+
+#: id:12021
+msgid "Start from beginning"
+msgstr "Začni na začetku"
+
+#: id:12022
+msgid "Resume from %s"
+msgstr "Začni na %s"
+
+#: id:12310
+msgid "0"
+msgstr "0"
+
+#: id:12311
+msgid "1"
+msgstr "1"
+
+#: id:12312
+msgid "2"
+msgstr "2"
+
+#: id:12313
+msgid "3"
+msgstr "3"
+
+#: id:12314
+msgid "4"
+msgstr "4"
+
+#: id:12315
+msgid "5"
+msgstr "5"
+
+#: id:12316
+msgid "6"
+msgstr "6"
+
+#: id:12317
+msgid "7"
+msgstr "7"
+
+#: id:12318
+msgid "8"
+msgstr "8"
+
+#: id:12319
+msgid "9"
+msgstr "9"
+
+#: id:12320
+msgid "c"
+msgstr "c"
+
+#: id:12321
+msgid "Ok"
+msgstr "Ok"
+
+#: id:12322
+msgid "*"
+msgstr "*"
+
+#: id:12325
+msgid "Locked! Enter code..."
+msgstr "Zaklenjeno! Vnesi geslo..."
+
+#: id:12326
+msgid "Enter password"
+msgstr "Vnesi geslo"
+
+#: id:12327
+msgid "Enter master code"
+msgstr "Vnesi glavno geslo"
+
+#: id:12328
+msgid "Enter unlock code"
+msgstr "Vnesi geslo za odklep"
+
+#: id:12329
+msgid "or press C to cancel"
+msgstr "ali pritisni C za izhod"
+
+#: id:12330
+msgid "Enter gamepad button combo and"
+msgstr "Pritisni kombinacijo tipk na ploščku in"
+
+#: id:12331
+msgid "press OK, or Back to cancel"
+msgstr "pritisni OK ali Nazaj za prekinitev"
+
+#: id:12332
+msgid "Set lock"
+msgstr "Nastavi zaščito"
+
+#: id:12333
+msgid "Unlock"
+msgstr "Odkleni"
+
+#: id:12334
+msgid "Reset lock"
+msgstr "Resetiraj zaščito"
+
+#: id:12335
+msgid "Remove lock"
+msgstr "Odstrani zaščito"
+
+#: id:12337
+msgid "Numeric password"
+msgstr "Številčno geslo"
+
+#: id:12338
+msgid "Gamepad button combo"
+msgstr "Kombinacija tipk na ploščku"
+
+#: id:12339
+msgid "Full-text password"
+msgstr "Celotno geslo"
+
+#: id:12340
+msgid "Enter new password"
+msgstr "Vnesi novo geslo"
+
+#: id:12341
+msgid "Re-Enter new password"
+msgstr "Ponovno vnesi novo geslo"
+
+#: id:12342
+msgid "Incorrect password,"
+msgstr "Geslo je napačno,"
+
+#: id:12343
+msgid "retries left"
+msgstr "ponovnih poizkusov"
+
+#: id:12344
+msgid "Passwords entered did not match."
+msgstr "Vnešeni gesli se ne ujemata."
+
+#: id:12345
+msgid "Access denied"
+msgstr "Dostop zavrnjen"
+
+#: id:12346
+msgid "Password retry limit exceeded."
+msgstr "Število ponovnih vnosov gesla je preseženo."
+
+#: id:12347
+msgid "The system will now shut off."
+msgstr "Sistem se bo sedaj izključil."
+
+#: id:12348
+msgid "Item locked"
+msgstr "Predmet zaklenjen"
+
+#: id:12353
+msgid "Reactivate lock"
+msgstr "Ponovno aktiviraj zaščito"
+
+#: id:12356
+msgid "Change lock"
+msgstr "Spremeni zaščito"
+
+#: id:12357
+msgid "Source lock"
+msgstr "Vir zaščite"
+
+#: id:12358
+msgid "Password entry was blank. Try again."
+msgstr "Vnos je prazen. Poskusi znova"
+
+#: id:12360
+msgid "Master lock"
+msgstr "Glavno geslo"
+
+#: id:12362
+msgid "Shutdown system if Master Lock retries exceeded"
+msgstr "Ugasni sistem, če se preseže število ponovnih vnosov"
+
+#: id:12367
+msgid "Master code is not valid"
+msgstr "Glavno geslo ni veljavno"
+
+#: id:12368
+msgid "Please enter a valid master code"
+msgstr "Prosim vnesite pravilno glavno geslo"
+
+#: id:12373
+msgid "Settings & file manager"
+msgstr "Nastavitve & moje datoteke"
+
+#: id:12376
+msgid "Set as default for all movies"
+msgstr "Nastavi kot privzeto za vse filme"
+
+#: id:12377
+msgid "This will reset any previously saved values"
+msgstr "To dejanje bo razveljavilo vse prejšnje nastavitve"
+
+#: id:12378
+msgid "Amount of time to display each image"
+msgstr "Čas prikaza vsake slike"
+
+#: id:12379
+msgid "Use pan and zoom effects"
+msgstr "Uporabi pan in zoom efekt"
+
+#: id:12383
+msgid "12 hour clock"
+msgstr "12 urni časovni prikaz"
+
+#: id:12384
+msgid "24 hour clock"
+msgstr "24 urni časovni prikaz"
+
+#: id:12385
+msgid "Day/Month"
+msgstr "Dan/Mesec"
+
+#: id:12386
+msgid "Month/Day"
+msgstr "Mesec/Dan"
+
+#: id:12390
+msgid "System uptime"
+msgstr "Čas delovanja sistema"
+
+#: id:12391
+msgid "Minutes"
+msgstr "Minute"
+
+#: id:12392
+msgid "Hours"
+msgstr "Ure"
+
+#: id:12393
+msgid "Days"
+msgstr "Dnevi"
+
+#: id:12394
+msgid "Total uptime"
+msgstr "Skupni čas delovanja"
+
+#: id:12395
+msgid "Battery level"
+msgstr "Nivo baterije"
+
+#: id:12600
+msgctxt "Auto context with id 12600"
+msgid "Weather"
+msgstr "Vreme"
+
+#: id:12900
+msgctxt "Auto context with id 12900"
+msgid "Screensaver"
+msgstr "Ohranjevalnik zaslona"
+
+#: id:12901
+msgid "Fullscreen OSD"
+msgstr "Celozaslonski OSD"
+
+#: id:13000
+msgid "System"
+msgstr "Sistem"
+
+#: id:13001
+msgid "Immediate HD spindown"
+msgstr "Takojšnja ustavitev trdega diska"
+
+#: id:13002
+msgid "Video only"
+msgstr "Samo slika"
+
+#: id:13003
+msgid "- Delay"
+msgstr "- Zakasnitev"
+
+#: id:13004
+msgid "- Minimum file duration"
+msgstr "- Najkrajše trajanje datoteke"
+
+#: id:13005
+msgid "Shutdown"
+msgstr "Ugasni"
+
+#: id:13008
+msgid "Shutdown function"
+msgstr "Funkcija ugašanja"
+
+#: id:13009
+msgid "Quit"
+msgstr "Izhod"
+
+#: id:13010
+msgid "Hibernate"
+msgstr "Zaustavi"
+
+#: id:13011
+msgid "Suspend"
+msgstr "V pripravljenost"
+
+#: id:13012
+msgid "Exit"
+msgstr "Izhod"
+
+#: id:13013
+msgid "Reboot"
+msgstr "Ponovni zagon"
+
+#: id:13014
+msgid "Minimize"
+msgstr "Pomanjšaj"
+
+#: id:13015
+msgid "Power button action"
+msgstr "Ukaz gumba za izklop"
+
+#: id:13016
+msgid "Power off System"
+msgstr "Izključi sistem"
+
+#: id:13020
+msgid "Is another session active, perhaps over ssh?"
+msgstr "Je druga seja aktivna, ssh?"
+
+#: id:13021
+msgid "Mounted removable harddrive"
+msgstr "Priključen zunanji trdi disk"
+
+#: id:13022
+msgid "Unsafe device removal"
+msgstr "Nepravilna odstranitev naprave"
+
+#: id:13023
+msgid "Successfully removed device"
+msgstr "Naprava je uspešno izključena"
+
+#: id:13024
+msgid "Joystick plugged"
+msgstr "Vključena igralna palica"
+
+#: id:13025
+msgid "Joystick unplugged"
+msgstr "Izključena igralna palica"
+
+#: id:13050
+msgid "Running low on battery"
+msgstr "Nivo baterije je nizek"
+
+#: id:13100
+msgid "Flicker filter"
+msgstr "Filter proti utripanju"
+
+#: id:13101
+msgid "Let driver choose (requires restart)"
+msgstr "Izbere gonilnik (zahteva ponovni zagon)"
+
+#: id:13105
+msgid "Vertical blank sync"
+msgstr "Vertikalna sinhronizacija"
+
+#: id:13106
+msgctxt "Auto context with id 13106"
+msgid "Disabled"
+msgstr "Onemogočeno"
+
+#: id:13107
+msgid "Enabled during video playback"
+msgstr "Vključeno med predvajanjem videa"
+
+#: id:13108
+msgctxt "Auto context with id 13108"
+msgid "Always enabled"
+msgstr "Vedno vključeno"
+
+#: id:13109
+msgid "Test & apply resolution"
+msgstr "Preveri & uveljavi ločljivost"
+
+#: id:13110
+msgid "Save resolution?"
+msgstr "Shrani ločljivost?"
+
+#: id:13111
+msgid "Would you like to keep this resolution?"
+msgstr "Ali želiš obdržati ločljivost?"
+
+#: id:13112
+msgid "High quality upscaling"
+msgstr "Zviševanje ločljivosti visoke kvalitete"
+
+#: id:13113
+msgctxt "Auto context with id 13113"
+msgid "Disabled"
+msgstr "Onemogočeno"
+
+#: id:13114
+msgid "Enabled for SD content"
+msgstr "Vključeno za SD vsebine"
+
+#: id:13115
+msgctxt "Auto context with id 13115"
+msgid "Always enabled"
+msgstr "Vedno vključeno"
+
+#: id:13116
+msgid "Upscaling method"
+msgstr "Način zviševanja ločljivosti"
+
+#: id:13117
+msgctxt "Auto context with id 13117"
+msgid "Bicubic"
+msgstr "Bicubic"
+
+#: id:13118
+msgid "Lanczos"
+msgstr "Lanczos"
+
+#: id:13119
+msgid "Sinc"
+msgstr "Sinc"
+
+#: id:13120
+msgctxt "Auto context with id 13120"
+msgid "VDPAU"
+msgstr "VDPAU"
+
+#: id:13121
+msgid "VDPAU HQ Upscaling level"
+msgstr "VDPAU HQ nivo zviševanja ločljivosti"
+
+#: id:13122
+msgid "VDPAU Studio level color conversion"
+msgstr "VDPAU studijska pretvorba barv"
+
+#: id:13130
+msgid "Blank other displays"
+msgstr "Izključi ostale zaslone"
+
+#: id:13131
+msgctxt "Auto context with id 13131"
+msgid "Disabled"
+msgstr "Onemogočeno"
+
+#: id:13132
+msgid "Blank displays"
+msgstr "Izključi zaslone"
+
+#: id:13140
+msgid "Active connections detected!"
+msgstr "Zaznane so aktivne povezave!"
+
+#: id:13141
+msgid "If you proceed, you might not be able to control XBMC"
+msgstr "Če nadaljujete, mogoče ne boste več mogli upravljati z XBMC"
+
+#: id:13142
+msgid "any longer. Are you sure you want to stop the Event server?"
+msgstr ". Ste prepričani, da želite ustaviti strežnik Dogodkov?"
+
+#: id:13144
+msgid "Change Apple Remote mode?"
+msgstr "Spremeni način Apple Remote?"
+
+#: id:13145
+msgid "If you are currently using the Apple Remote to control"
+msgstr "Če trenutno uporabljate Apple Remote za upravljanje"
+
+#: id:13146
+msgid "XBMC, changing this setting might affect your ability"
+msgstr "XBMC, lahko spremeba teh nastavitev vpliva na zmožnost"
+
+#: id:13147
+msgid "to continue controlling it. Do you want to proceed?"
+msgstr "nadaljnega upravljanja. Želite nadaljevati?"
+
+#: id:13159
+msgid "Subnet mask"
+msgstr "Maska podomrežja:"
+
+#: id:13160
+msgid "Gateway"
+msgstr "Prehod:"
+
+#: id:13161
+msgid "Primary DNS"
+msgstr "Primarni DNS"
+
+#: id:13162
+msgid "Initialize failed"
+msgstr "Neuspešna inicializacija"
+
+#: id:13170
+msgctxt "Auto context with id 13170"
+msgid "Never"
+msgstr "Nikoli"
+
+#: id:13171
+msgid "Immediately"
+msgstr "Takoj"
+
+#: id:13172
+msgid "After %i secs"
+msgstr "Čez %i sek"
+
+#: id:13173
+msgid "HDD install date:"
+msgstr "HDD datum namestitve:"
+
+#: id:13174
+msgid "HDD power cycle count:"
+msgstr "HDD števec vrtljajev:"
+
+#: id:13200
+msgid "Profiles"
+msgstr "Profili"
+
+#: id:13201
+msgid "Delete profile '%s'?"
+msgstr "Izbriši profil '%s'?"
+
+#: id:13204
+msgid "Last loaded profile:"
+msgstr "Zadnji naložen profil:"
+
+#: id:13205
+msgid "Unknown"
+msgstr "Neznano"
+
+#: id:13206
+msgid "Overwrite"
+msgstr "Prepiši"
+
+#: id:13208
+msgid "Alarm clock"
+msgstr "Budilka"
+
+#: id:13209
+msgid "Alarm clock interval (in minutes)"
+msgstr "Interval budilke (v minutah)"
+
+#: id:13210
+msgid "Started, alarm in %im"
+msgstr "Zagon, alarm v %im"
+
+#: id:13211
+msgid "Alarm!"
+msgstr "Alarm!"
+
+#: id:13212
+msgid "Canceled with %im%is left"
+msgstr "Odpovedano s preostalimi %im%is"
+
+#: id:13213
+msgid "%2.0fm"
+msgstr "%2.0fm"
+
+#: id:13214
+msgid "%2.0fs"
+msgstr "%2.0fs"
+
+#: id:13249
+msgid "Search for subtitles in RARs"
+msgstr "Poišči podnapise v RAR datotekah"
+
+#: id:13250
+msgid "Browse for subtitle..."
+msgstr "Prebrskaj za podnapise..."
+
+#: id:13251
+msgid "Move item"
+msgstr "Premakni predmet"
+
+#: id:13252
+msgid "Move item here"
+msgstr "Premakni predmet sem"
+
+#: id:13253
+msgid "Cancel move"
+msgstr "Prekliči premik"
+
+#: id:13270
+msgid "Hardware:"
+msgstr "Strojna oprema:"
+
+#: id:13271
+msgid "CPU Usage:"
+msgstr "Zasedenost CPU:"
+
+#: id:13274
+msgid "Connected, but no DNS is available."
+msgstr "Povezava je vzpostavljena, vendar DNS ni na voljo."
+
+#: id:13275
+msgid "Hard Disk"
+msgstr "Trdi disk"
+
+#: id:13276
+msgid "DVD-ROM"
+msgstr "DVD-ROM"
+
+#: id:13277
+msgctxt "Auto context with id 13277"
+msgid "Storage"
+msgstr "Shramba"
+
+#: id:13278
+msgctxt "Auto context with id 13278"
+msgid "Default"
+msgstr "Privzeto"
+
+#: id:13279
+msgctxt "Auto context with id 13279"
+msgid "Network"
+msgstr "Omrežje"
+
+#: id:13280
+msgctxt "Auto context with id 13280"
+msgid "Video"
+msgstr "Video"
+
+#: id:13281
+msgid "Hardware"
+msgstr "Strojna oprema"
+
+#: id:13283
+msgid "Operating system:"
+msgstr "Operacijski sistem:"
+
+#: id:13284
+msgid "CPU speed:"
+msgstr "Hitrost CPU:"
+
+#: id:13286
+msgid "Video encoder:"
+msgstr "Video enkoder:"
+
+#: id:13287
+msgid "Screen resolution:"
+msgstr "Ločljivost zaslona:"
+
+#: id:13292
+msgid "A/V cable:"
+msgstr "A/V kabel:"
+
+#: id:13294
+msgid "DVD region:"
+msgstr "DVD regija:"
+
+#: id:13295
+msgid "Internet:"
+msgstr "Internet:"
+
+#: id:13296
+msgctxt "Auto context with id 13296"
+msgid "Connected"
+msgstr "Povezava je vzpostavljena"
+
+#: id:13297
+msgid "Not connected. Check network settings."
+msgstr "Povezava ni vzpostavljena. Preverite omrežne nastavitve."
+
+#: id:13299
+msgid "Target temperature"
+msgstr "Željena temperatura"
+
+#: id:13300
+msgid "Fan speed"
+msgstr "Hitrost ventilatorja"
+
+#: id:13301
+msgid "Auto temperature control"
+msgstr "Samodejna kontrola temperature"
+
+#: id:13302
+msgid "Fan speed override"
+msgstr "Ročna nastavitev hitrosti ventilatorja"
+
+#: id:13303
+msgid "- Fonts"
+msgstr "- Pisave"
+
+#: id:13304
+msgid "Enable flipping bi-directional strings"
+msgstr "Vključi flipping bi-directional strings"
+
+#: id:13305
+msgid "Show RSS news feeds"
+msgstr "Prikaži RSS"
+
+#: id:13306
+msgid "Show parent folder items"
+msgstr "Prikaži datoteke v starševski mapi"
+
+#: id:13307
+msgid "Track naming template"
+msgstr "Način poimenovanja pesmi"
+
+#: id:13308
+msgid "Do you wish to reboot your system"
+msgstr "Želite ponovno zagnati sistem"
+
+#: id:13309
+msgid "instead of just XBMC?"
+msgstr "namesto samo XBMC?"
+
+#: id:13310
+msgid "Zoom effect"
+msgstr "Efekt povečave"
+
+#: id:13311
+msgid "Float effect"
+msgstr "Efekt lebdenja"
+
+#: id:13312
+msgid "Black bar reduction"
+msgstr "Odprava črnih robov"
+
+#: id:13313
+msgid "Restart"
+msgstr "Ponovno zaženi"
+
+#: id:13314
+msgid "Crossfade between songs"
+msgstr "Navzkrižni prehod"
+
+#: id:13315
+msgid "Regenerate thumbnails"
+msgstr "Regeneriraj sličice"
+
+#: id:13316
+msgid "Recursive thumbnails"
+msgstr "Rekurzivne sličice"
+
+#: id:13317
+msgid "View slideshow"
+msgstr "Poglej projekcijo slik"
+
+#: id:13318
+msgid "Recursive slideshow"
+msgstr "Rekurzivna projekcija slik"
+
+#: id:13319
+msgid "Randomize"
+msgstr "Naključno"
+
+#: id:13320
+msgid "Stereo"
+msgstr "Stereo"
+
+#: id:13321
+msgid "Left only"
+msgstr "Samo levo"
+
+#: id:13322
+msgid "Right only"
+msgstr "Samo desno"
+
+#: id:13323
+msgid "Enable karaoke support"
+msgstr "Vključi podporo za karaoke"
+
+#: id:13324
+msgid "Background transparency"
+msgstr "Transparentno ozadje"
+
+#: id:13325
+msgid "Foreground transparency"
+msgstr "Transparentno ospredje"
+
+#: id:13326
+msgid "A/V delay"
+msgstr "A/V zamik"
+
+#: id:13327
+msgid "Karaoke"
+msgstr "Karaoke"
+
+#: id:13328
+msgid "%s not found"
+msgstr "%s ni najden"
+
+#: id:13329
+msgid "Error opening %s"
+msgstr "Napaka pri odpiranju %s"
+
+#: id:13330
+msgid "Unable to load %s"
+msgstr "Ne morem naložiti %s"
+
+#: id:13331
+msgid "Error: Out of memory"
+msgstr "Napaka: Ni dovolj spomina"
+
+#: id:13332
+msgid "Move up"
+msgstr "Premakni navzgor"
+
+#: id:13333
+msgid "Move down"
+msgstr "Premakni navzdol"
+
+#: id:13334
+msgid "Edit label"
+msgstr "Uredi oznako"
+
+#: id:13335
+msgid "Make default"
+msgstr "Napravi privzeto"
+
+#: id:13336
+msgid "Remove button"
+msgstr "Tipka odstrani"
+
+#: id:13340
+msgid "Leave as is"
+msgstr "Pusti kot je"
+
+#: id:13341
+msgid "Green"
+msgstr "Zelena"
+
+#: id:13342
+msgid "Orange"
+msgstr "Oranžna"
+
+#: id:13343
+msgid "Red"
+msgstr "Rdeča"
+
+#: id:13344
+msgid "Cycle"
+msgstr "Kroženje"
+
+#: id:13345
+msgid "Switch LED off on playback"
+msgstr "Ugasni LED med predvajanjem"
+
+#: id:13346
+msgctxt "Auto context with id 13346"
+msgid "Movie information"
+msgstr "Informacije o filmu"
+
+#: id:13347
+msgid "Queue item"
+msgstr "Postavi v vrsto"
+
+#: id:13348
+msgid "Search IMDb..."
+msgstr "Preišči IMDb..."
+
+#: id:13349
+msgid "Scan for new content"
+msgstr "Išči za nove vsebine"
+
+#: id:13350
+msgid "Now playing..."
+msgstr "Trenutno predvajam..."
+
+#: id:13351
+msgctxt "Auto context with id 13351"
+msgid "Album information"
+msgstr "Informacije o albumu"
+
+#: id:13352
+msgid "Scan item to library"
+msgstr "Dodaj predmet v bazo"
+
+#: id:13353
+msgid "Stop scanning"
+msgstr "Ustavi iskanje"
+
+#: id:13354
+msgctxt "Auto context with id 13354"
+msgid "Render method"
+msgstr "Metoda izrisa"
+
+#: id:13355
+msgid "Low quality pixel shader"
+msgstr "Nizkokvalitetno senčenje"
+
+#: id:13356
+msgid "Hardware overlays"
+msgstr "Strojno prekrivanje"
+
+#: id:13357
+msgid "High quality pixel shader"
+msgstr "Visokokvalitetno senčenje"
+
+#: id:13358
+msgid "Play item"
+msgstr "Predvajaj predmet"
+
+#: id:13359
+msgid "Set artist thumb"
+msgstr "Nastavi sličico izvajalca"
+
+#: id:13360
+msgid "Automatically generate thumbnails"
+msgstr "Generiraj sličice"
+
+#: id:13361
+msgid "Enable voice"
+msgstr "Uporabi govor"
+
+#: id:13375
+msgid "Enable device"
+msgstr "Vključi napravo"
+
+#: id:13376
+msgid "Volume"
+msgstr "Glasnost"
+
+#: id:13377
+msgid "Default view mode"
+msgstr "Privzet pogled"
+
+#: id:13378
+msgid "Default brightness"
+msgstr "Privzeta svetlost"
+
+#: id:13379
+msgid "Default contrast"
+msgstr "Privzet kontrast"
+
+#: id:13380
+msgid "Default gamma"
+msgstr "Privzeta gama"
+
+#: id:13381
+msgid "Resume video"
+msgstr "Nadaljuj video"
+
+#: id:13382
+msgid "Voice mask - Port 1"
+msgstr "Glasovna maska - Port 1"
+
+#: id:13383
+msgid "Voice mask - Port 2"
+msgstr "Glasovna maska - Port 2"
+
+#: id:13384
+msgid "Voice mask - Port 3"
+msgstr "Glasovna maska - Port 3"
+
+#: id:13385
+msgid "Voice mask - Port 4"
+msgstr "Glasovna maska - Port 4"
+
+#: id:13386
+msgid "Use time based seeking"
+msgstr "Uporabi iskanje po času"
+
+#: id:13387
+msgid "Track naming template - right"
+msgstr "Predloga za poimenovanje posnetkov - pravilno"
+
+#: id:13388
+msgid "Preset"
+msgstr "Prednastavitev"
+
+#: id:13389
+msgid "There are no presets available\nfor this visualization"
+msgstr "Ni prednastavitev za vizualizacijo"
+
+#: id:13390
+msgid "There are no settings available\nfor this visualization"
+msgstr "Ni nastavitev za vizualizacijo"
+
+#: id:13391
+msgid "Eject/Load"
+msgstr "Odpri/Zapri"
+
+#: id:13392
+msgid "Use visualization if playing audio"
+msgstr "Uporabi vizualizacijo pri predvajanju glasbe"
+
+#: id:13393
+msgid "Calculate size"
+msgstr "Preračunaj velikost"
+
+#: id:13394
+msgid "Calculating folder size"
+msgstr "Preračunavam velikost mape"
+
+#: id:13395
+msgid "Video settings"
+msgstr "Nastavitve slike"
+
+#: id:13396
+msgid "Audio and subtitle settings"
+msgstr "Nastavitve zvoka in podnapisov"
+
+#: id:13397
+msgid "Enable subtitles"
+msgstr "Vključi podnapise"
+
+#: id:13398
+msgctxt "Auto context with id 13398"
+msgid "Shortcuts"
+msgstr "Bližnjice"
+
+#: id:13399
+msgid "Ignore articles when sorting (e.g. \"the\")"
+msgstr "Pri razvrščanju izpusti člene (npr. \"the\")"
+
+#: id:13400
+msgid "Crossfade between songs on the same album"
+msgstr "Navzkrižni prehod posnetkov v istem albumu"
+
+#: id:13401
+msgid "Browse for %s"
+msgstr "Prebrskaj za %s"
+
+#: id:13402
+msgid "Show track position"
+msgstr "Prikaži pozicijo posnetka"
+
+#: id:13403
+msgid "Clear default"
+msgstr "Izbriši privzeto"
+
+#: id:13404
+msgid "Resume"
+msgstr "Nadaljuj"
+
+#: id:13405
+msgid "Get thumb"
+msgstr "Pridobi sličico"
+
+#: id:13406
+msgid "Picture information"
+msgstr "Informacije o sliki"
+
+#: id:13407
+msgid "%s presets"
+msgstr "%s prednastavitev"
+
+#: id:13408
+msgid "(IMDb user rating)"
+msgstr "(IMDb uporabniška ocena)"
+
+#: id:13409
+msgid "Top 250"
+msgstr "Top 250"
+
+#: id:13410
+msgid "Tune in on Last.fm"
+msgstr "Objavi na Last.fm"
+
+#: id:13411
+msgid "Minimum fan speed"
+msgstr "Najmanjša hitrost ventilatorja"
+
+#: id:13412
+msgid "Play from here"
+msgstr "Predvajaj od tukaj"
+
+#: id:13413
+msgid "Downloading"
+msgstr "Prenašam"
+
+#: id:13414
+msgid "Include artists who appear only on compilations"
+msgstr "Vključi izvajalce, ki se pojavljajo le na kompilacijah"
+
+#: id:13415
+msgctxt "Auto context with id 13415"
+msgid "Render method"
+msgstr "Metoda izrisa"
+
+#: id:13416
+msgid "Auto detect"
+msgstr "Samodejno zaznaj"
+
+#: id:13417
+msgid "Basic shaders (ARB)"
+msgstr "Osnovni senčilniki (ARB)"
+
+#: id:13418
+msgid "Advanced shaders (GLSL)"
+msgstr "Napredni senčilniki (GLSL)"
+
+#: id:13419
+msgid "Software"
+msgstr "Programska oprema"
+
+#: id:13420
+msgid "Remove safely"
+msgstr "Varno odstrani"
+
+#: id:13421
+msgctxt "Auto context with id 13421"
+msgid "VDPAU"
+msgstr "VDPAU"
+
+#: id:13422
+msgid "Start slideshow here"
+msgstr "Tukaj začni projekcijo slik"
+
+#: id:13423
+msgid "Remember for this path"
+msgstr "Zapomni si za to pot"
+
+#: id:13424
+msgid "Use pixel buffer objects"
+msgstr "Uporabi medpomnenje pikslov"
+
+#: id:13425
+msgid "Allow hardware acceleration (VDPAU)"
+msgstr "Dovoli strojno pospeševanje (VDPAU)"
+
+#: id:13426
+msgid "Allow hardware acceleration (VAAPI)"
+msgstr "Dovoli strojno pospeševanje (VAAPI)"
+
+#: id:13427
+msgid "Allow hardware acceleration (DXVA2)"
+msgstr "Dovoli strojno pospeševanje (DXVA2)"
+
+#: id:13428
+msgid "Allow hardware acceleration (CrystalHD)"
+msgstr "Dovoli strojno pospeševanje (CrystalHD)"
+
+#: id:13429
+msgid "Allow hardware acceleration (VDADecoder)"
+msgstr "Dovoli strojno pospeševanje (VDADecoder)"
+
+#: id:13430
+msgid "Allow hardware acceleration (OpenMax)"
+msgstr "Dovoli strojno pospeševanje (OpenMax)"
+
+#: id:13431
+msgid "Pixel Shaders"
+msgstr "Senčilniki pikslov"
+
+#: id:13432
+msgid "Allow hardware acceleration (VideoToolbox)"
+msgstr "Dovoli strojno pospeševanje (VideoToolbox)"
+
+#: id:13500
+msgid "A/V sync method"
+msgstr "A/V metoda sinhroniziranja"
+
+#: id:13501
+msgid "Audio clock"
+msgstr "Zvočna ura"
+
+#: id:13502
+msgid "Video clock (Drop/Dupe audio)"
+msgstr "Slikovna ura (Zavrži zvok)"
+
+#: id:13503
+msgid "Video clock (Resample audio)"
+msgstr "Slikovna ura (Pretvori zvok)"
+
+#: id:13504
+msgid "Maximum resample amount (%)"
+msgstr "Največja količina pretvorbe (%)"
+
+#: id:13505
+msgid "Resample quality"
+msgstr "Kvaliteta pretvorbe"
+
+#: id:13506
+msgid "Low(fast)"
+msgstr "Nizka(hitro)"
+
+#: id:13507
+msgctxt "Auto context with id 13507"
+msgid "Medium"
+msgstr "Srednja"
+
+#: id:13508
+msgctxt "Auto context with id 13508"
+msgid "High"
+msgstr "Visoka"
+
+#: id:13509
+msgid "Really high(slow!)"
+msgstr "Zelo visoka(počasno!)"
+
+#: id:13510
+msgid "Sync playback to display"
+msgstr "Sinhroniziraj predvajanje z zaslonom"
+
+#: id:13550
+msgid "Pause during refresh rate change"
+msgstr "Ustavi med spremembo osveževanja zaslona"
+
+#: id:13551
+msgctxt "Auto context with id 13551"
+msgid "Off"
+msgstr "Onemogočeno"
+
+#: id:13552
+msgid "%.1f Second"
+msgstr "%.1f sekunda"
+
+#: id:13553
+msgid "%.1f Seconds"
+msgstr "%.1f sekund"
+
+#: id:13600
+msgid "Apple remote"
+msgstr "Apple upravljalnik"
+
+#: id:13602
+msgid "Allow start of XBMC using the remote"
+msgstr "Dovoli zagon XBMC preko upravljalnika"
+
+#: id:13603
+msgid "Sequence delay time"
+msgstr "Zamik zaporedja"
+
+#: id:13610
+msgctxt "Auto context with id 13610"
+msgid "Disabled"
+msgstr "Onemogočeno"
+
+#: id:13611
+msgctxt "Auto context with id 13611"
+msgid "Standard"
+msgstr "Običajno"
+
+#: id:13612
+msgid "Universal Remote"
+msgstr "Univerzalni upravljalnik"
+
+#: id:13613
+msgid "Multi Remote (Harmony)"
+msgstr "Multi-upravljalnik (Harmony)"
+
+#: id:13620
+msgid "Apple Remote Error"
+msgstr "Apple Remote Napaka"
+
+#: id:13621
+msgid "Apple Remote support could be enabled."
+msgstr "Podpora za Apple Remote je lahko vključena."
+
+#: id:14000
+msgid "Stack"
+msgstr "Združi"
+
+#: id:14001
+msgid "Unstack"
+msgstr "Razdruži"
+
+#: id:14003
+msgid "Downloading playlist file..."
+msgstr "Prenašam predvajalni seznam..."
+
+#: id:14004
+msgid "Downloading streams list..."
+msgstr "Prenašam seznam pretokov..."
+
+#: id:14005
+msgid "Parsing streams list..."
+msgstr "Berem seznam pretokov..."
+
+#: id:14006
+msgid "Downloading streams list failed"
+msgstr "Prenos seznama pretokov ni uspel"
+
+#: id:14007
+msgid "Downloading playlist file failed"
+msgstr "Prenos predvajalnega seznama ni uspel"
+
+#: id:14009
+msgid "Games directory"
+msgstr "Mapa za igre"
+
+#: id:14010
+msgid "Auto switch to thumbs based on"
+msgstr "Samodejni prikaz sličic temeljujoč na"
+
+#: id:14011
+msgid "Enable auto switching to thumbs view"
+msgstr "Vključi samodejni preklop na slikovni pogled"
+
+#: id:14012
+msgid "- Use large icons"
+msgstr "- Uporabi velike ikone"
+
+#: id:14013
+msgid "- Switch based on"
+msgstr "- Preklop temeljujoč na"
+
+#: id:14014
+msgid "- Percentage"
+msgstr "- Odstotkih"
+
+#: id:14015
+msgid "No files and at least one thumb"
+msgstr "Ni datotek in vsaj ena sličica"
+
+#: id:14016
+msgid "At least one file and thumb"
+msgstr "Vsaj ena datoteka in ena sličica"
+
+#: id:14017
+msgid "Percentage of thumbs"
+msgstr "Odstotki sličic"
+
+#: id:14018
+msgid "View options"
+msgstr "Možnosti"
+
+#: id:14019
+msgid "Change area code 1"
+msgstr "Spremeni področno kodo 1"
+
+#: id:14020
+msgid "Change area code 2"
+msgstr "Spremeni področno kodo 2"
+
+#: id:14021
+msgid "Change area code 3"
+msgstr "Spremeni področno kodo 3"
+
+#: id:14022
+msgctxt "Auto context with id 14022"
+msgid "Library"
+msgstr "Knjižnica"
+
+#: id:14023
+msgid "No TV"
+msgstr "Brez TV"
+
+#: id:14024
+msgid "Enter the nearest large town"
+msgstr "Vnesi najbližje večje mesto"
+
+#: id:14025
+msgid "Video/Audio/DVD cache - Harddisk"
+msgstr "Video/Glasba/DVD začasni pomnilnik - Trdi disk"
+
+#: id:14026
+msgid "Video cache - DVD-ROM"
+msgstr "Video začasni pomnilnik - DVD-ROM"
+
+#: id:14027
+msgctxt "Auto context with id 14027"
+msgid "- Local Network"
+msgstr "- Krajevno omrežje"
+
+#: id:14028
+msgctxt "Auto context with id 14028"
+msgid "- Internet"
+msgstr "- Internet"
+
+#: id:14030
+msgid "Audio cache - DVD-ROM"
+msgstr "Glasbeni začasni pomnilnik - DVD-ROM"
+
+#: id:14031
+msgctxt "Auto context with id 14031"
+msgid "- Local Network"
+msgstr "- Krajevno omrežje"
+
+#: id:14032
+msgctxt "Auto context with id 14032"
+msgid "- Internet"
+msgstr "- Internet"
+
+#: id:14034
+msgid "DVD cache - DVD-ROM"
+msgstr "DVD začasni pomnilnik - DVD-ROM"
+
+#: id:14035
+msgctxt "Auto context with id 14035"
+msgid "- Local Network"
+msgstr "- Krajevno omrežje"
+
+#: id:14036
+msgctxt "Auto context with id 14036"
+msgid "Services"
+msgstr "Storitve"
+
+#: id:14038
+msgid "Network settings changed"
+msgstr "Omrežne nastavitve spremenjene"
+
+#: id:14039
+msgid "XBMC requires to restart to change your"
+msgstr "XBMC zahteva ponovni zagon, da spremeni vaše"
+
+#: id:14040
+msgid "network setup. Would you like to restart now?"
+msgstr "omrežne nastavitve. Ali želite ponovno zagnati program?"
+
+#: id:14041
+msgid "Internet connection bandwidth limitation"
+msgstr "Omejitev pasovne širine internetne povezave"
+
+#: id:14043
+msgid "- Shutdown while playing"
+msgstr "- Izklop med predvajanjem"
+
+#: id:14044
+msgid "%i min"
+msgstr "%i min"
+
+#: id:14045
+msgid "%i sec"
+msgstr "%i s"
+
+#: id:14046
+msgid "%i ms"
+msgstr "%i ms"
+
+#: id:14047
+msgid "%i %%"
+msgstr "%i %%"
+
+#: id:14048
+msgid "%i kbps"
+msgstr "%i kbps"
+
+#: id:14049
+msgid "%i kb"
+msgstr "%i kb"
+
+#: id:14050
+msgid "%i.0 dB"
+msgstr "%i.0 dB"
+
+#: id:14051
+msgid "Time format"
+msgstr "Časovni zapis"
+
+#: id:14052
+msgid "Date format"
+msgstr "Datumski zapis"
+
+#: id:14053
+msgid "GUI filters"
+msgstr "GUI filtri"
+
+#: id:14055
+msgid "Use background scanning"
+msgstr "Uporabi iskanje v ozadju"
+
+#: id:14056
+msgid "Stop scan"
+msgstr "Ustavi iskanje"
+
+#: id:14057
+msgid "Not possible while scanning for media info"
+msgstr "Ni mogoče med iskanjem medijskih info."
+
+#: id:14058
+msgid "Film grain effect"
+msgstr "Efekt zrnatosti filma"
+
+#: id:14059
+msgid "Search for thumbnails on remote shares"
+msgstr "Poizvedi za sličice na oddaljeni skupni rabi"
+
+#: id:14060
+msgid "Unknown type cache - Internet"
+msgstr "Nepoznan tip začasnega pomnilnika - Internet"
+
+#: id:14061
+msgctxt "Auto context with id 14061"
+msgid "Auto"
+msgstr "Samodejno"
+
+#: id:14062
+msgid "Enter username for"
+msgstr "Vnesi uporabniško ime za"
+
+#: id:14063
+msgid "Date & time"
+msgstr "Datum & čas"
+
+#: id:14064
+msgid "Set date"
+msgstr "Nastavi datum"
+
+#: id:14065
+msgid "Set time"
+msgstr "Nastavi čas"
+
+#: id:14066
+msgid "Enter the time in 24 hour HH:MM format"
+msgstr "Vnesi čas v 24 urnem HH:MM formatu"
+
+#: id:14067
+msgid "Enter the date in DD/MM/YYYY format"
+msgstr "Vnesi datum v DD/MM/YYYY formatu"
+
+#: id:14068
+msgid "Enter the IP address"
+msgstr "Vnesi IP naslov"
+
+#: id:14069
+msgid "Apply these settings now?"
+msgstr "Uporabim te nastavitve sedaj?"
+
+#: id:14070
+msgid "Apply changes now"
+msgstr "Uporabim spremembe sedaj?"
+
+#: id:14071
+msgid "Allow file renaming and deletion"
+msgstr "Dovoli preimenovanje datotek ter brisanje"
+
+#: id:14074
+msgid "Set timezone"
+msgstr "Nastavi časovni pas"
+
+#: id:14075
+msgid "Use daylight saving time"
+msgstr "Uporabi prestopni čas"
+
+#: id:14076
+msgid "Add to favourites"
+msgstr "Dodaj med priljubljene"
+
+#: id:14077
+msgid "Remove from favourites"
+msgstr "Odstrani iz priljubljenih"
+
+#: id:14078
+msgctxt "Auto context with id 14078"
+msgid "- Colours"
+msgstr "- Barve"
+
+#: id:14079
+msgid "Timezone country"
+msgstr "Država časovnega pasu"
+
+#: id:14080
+msgid "Timezone"
+msgstr "Časovni pas"
+
+#: id:14081
+msgid "File lists"
+msgstr "Seznam datotek"
+
+#: id:14082
+msgid "Show EXIF picture information"
+msgstr "Prikaži EXIF slikovne informacije"
+
+#: id:14083
+msgid "Use a fullscreen window rather than true fullscreen"
+msgstr "Uporabi celozaslonsko okno namesto pravega celozaslonskega načina"
+
+#: id:14084
+msgid "Queue songs on selection"
+msgstr "Pesmi postavi v vrsto ob izboru"
+
+#: id:14086
+msgid "Playback"
+msgstr "Predvajanje"
+
+#: id:14087
+msgid "DVDs"
+msgstr "DVD-ji"
+
+#: id:14088
+msgid "Play DVDs automatically"
+msgstr "Samodejno predvajaj DVD-je"
+
+#: id:14089
+msgid "Font to use for text subtitles"
+msgstr "Pisava podnapisov"
+
+#: id:14090
+msgid "International"
+msgstr "Jezik"
+
+#: id:14091
+msgid "Character set"
+msgstr "Nabor znakov"
+
+#: id:14092
+msgid "Debugging"
+msgstr "Razhroščevanje"
+
+#: id:14093
+msgid "Security"
+msgstr "Varnost"
+
+#: id:14094
+msgid "Input devices"
+msgstr "Naprave vnosa"
+
+#: id:14095
+msgid "Power saving"
+msgstr "Varčevanje energije"
+
+#: id:14096
+msgid "Rip"
+msgstr ""
+
+#: id:14097
+msgid "Audio CD Insert Action"
+msgstr ""
+
+#: id:14098
+msgctxt "Auto context with id 14098"
+msgid "Play"
+msgstr ""
+
+#: id:14099
+msgid "Eject disc when CD ripping is complete"
+msgstr ""
+
+#: id:15015
+msgctxt "Auto context with id 15015"
+msgid "Remove"
+msgstr "Odstrani"
+
+#: id:15016
+msgid "Games"
+msgstr "Igre"
+
+#: id:15019
+msgid "Add"
+msgstr "Dodaj"
+
+#: id:15052
+msgid "Password"
+msgstr "Geslo"
+
+#: id:15100
+msgctxt "Auto context with id 15100"
+msgid "Library"
+msgstr "Knjižnica"
+
+#: id:15101
+msgid "Database"
+msgstr "Podatkovna baza"
+
+#: id:15102
+msgid "* All albums"
+msgstr "* Vsi albumi"
+
+#: id:15103
+msgid "* All artists"
+msgstr "* Vsi izvajalci"
+
+#: id:15104
+msgid "* All songs"
+msgstr "* Vse pesmi"
+
+#: id:15105
+msgid "* All genres"
+msgstr "* Vsi žanri"
+
+#: id:15107
+msgid "Buffering..."
+msgstr "Medpomnenje..."
+
+#: id:15108
+msgid "Navigation sounds"
+msgstr "Navigacijski zvoki"
+
+#: id:15109
+msgid "Skin default"
+msgstr "Privzeto"
+
+#: id:15111
+msgid "- Theme"
+msgstr "- Tema"
+
+#: id:15112
+msgid "Default theme"
+msgstr "Privzeta tema"
+
+#: id:15200
+msgid "Last.fm"
+msgstr "Last.FM"
+
+#: id:15201
+msgid "Submit songs to Last.fm"
+msgstr "Objavi pesmi na Last.FM"
+
+#: id:15202
+msgid "Last.fm username"
+msgstr "Last.FM uporabniško ime"
+
+#: id:15203
+msgid "Last.fm password"
+msgstr "Last.FM geslo"
+
+#: id:15204
+msgid "Unable to handshake: sleeping..."
+msgstr "Povezava ni mogoča: Spim....."
+
+#: id:15205
+msgid "Please update XBMC"
+msgstr "Prosimo posodobite XBMC"
+
+#: id:15206
+msgid "Bad authorization: Check username and password"
+msgstr "Nepravilna avtorizacija: Preverite uporabniško ime in geslo"
+
+#: id:15207
+msgctxt "Auto context with id 15207"
+msgid "Connected"
+msgstr "Povezan"
+
+#: id:15208
+msgid "Not connected"
+msgstr "Brez povezave"
+
+#: id:15209
+msgid "Submit interval %i"
+msgstr "Interval objave %i"
+
+#: id:15210
+msgid "Cached %i songs"
+msgstr "V začasnem pomnilniku: %i pesmi"
+
+#: id:15211
+msgid "Submitting..."
+msgstr "Objavljam..."
+
+#: id:15212
+msgid "Submitting in %i secs"
+msgstr "Objavljam v %i s"
+
+#: id:15213
+msgid "Play using..."
+msgstr "Predvajaj z uporabo..."
+
+#: id:15214
+msgid "Use smoothed A/V synchronization"
+msgstr "Uporabi gladko A/V sinhronizacijo"
+
+#: id:15215
+msgid "Hide file names in thumbs view"
+msgstr "Skrij imena datotek v pogledu sličic"
+
+#: id:15216
+msgid "Play in party mode"
+msgstr "Predvajaj v zabavnem načinu"
+
+#: id:15217
+msgid "Submit songs to Libre.fm"
+msgstr "Objavi pesmi na Libre.fm"
+
+#: id:15218
+msgid "Libre.fm username"
+msgstr "Libre.fm uporabniško ime"
+
+#: id:15219
+msgid "Libre.fm password"
+msgstr "Libre.fm geslo"
+
+#: id:15220
+msgid "Libre.fm"
+msgstr "Libre.fm"
+
+#: id:15221
+msgid "Song submission"
+msgstr "Objava pesmi"
+
+#: id:15250
+msgid "Submit Last.fm radio to Last.fm"
+msgstr "Objavi Last.fm radio postajo na Last.FM"
+
+#: id:15251
+msgid "Connecting to Last.fm..."
+msgstr "Povezujem se na Last.fm..."
+
+#: id:15252
+msgid "Selecting station..."
+msgstr "Izberi postajo..."
+
+#: id:15253
+msgid "Search similar artists..."
+msgstr "Izberi podobnega izvajalca..."
+
+#: id:15254
+msgid "Search similar tags..."
+msgstr "Poišči podobne oznake..."
+
+#: id:15255
+msgid "Your profile (%name%)"
+msgstr "Tvoj profil (%name%)"
+
+#: id:15256
+msgid "Overall top tags"
+msgstr "Vse najbolše oznake"
+
+#: id:15257
+msgid "Top artists for tag %name%"
+msgstr "Najbolši izvajalci za oznako %name%"
+
+#: id:15258
+msgid "Top albums for tag %name%"
+msgstr "Najbolši albumi za oznako %name%"
+
+#: id:15259
+msgid "Top tracks for tag %name%"
+msgstr "Najboljše pesmi za oznako %name%"
+
+#: id:15260
+msgid "Listen to tag %name% Last.fm radio"
+msgstr "Poslušaj oznako %name% Last.fm radio"
+
+#: id:15261
+msgid "Similar artists as %name%"
+msgstr "Podobni izvajalci kot %name%"
+
+#: id:15262
+msgid "Top %name% albums"
+msgstr "Najbolši %name% albumi"
+
+#: id:15263
+msgid "Top %name% tracks"
+msgstr "Najbolše %name% pesmi"
+
+#: id:15264
+msgid "Top %name% tags"
+msgstr "Najbolše %name% oznake"
+
+#: id:15265
+msgid "Biggest fans of %name%"
+msgstr "Največji privrženci %name%"
+
+#: id:15266
+msgid "Listen to %name% fans Last.fm radio"
+msgstr "Poslušaj %name% privržencev Last.fm radio"
+
+#: id:15267
+msgid "Listen to %name% similar artists Last.fm radio"
+msgstr "Poslušaj %name% zadjnega podobnega izvajalca fm. radia"
+
+#: id:15268
+msgid "Top artists for user %name%"
+msgstr "Najbolši izvajalci za uporabnika %name%"
+
+#: id:15269
+msgid "Top albums for user %name%"
+msgstr "Najbolši albumi za uporabnika %name%"
+
+#: id:15270
+msgid "Top tracks for user %name%"
+msgstr "Najbolše pesmi za uporabnika %name%"
+
+#: id:15271
+msgid "Friends of user %name%"
+msgstr "Prijatelji uporabnika %name%"
+
+#: id:15272
+msgid "Neighbours of user %name%"
+msgstr "Sosedje uporabnika %name%"
+
+#: id:15273
+msgid "Weekly artist chart for %name%"
+msgstr "Tedenska lestvica izvajalcev za %name%"
+
+#: id:15274
+msgid "Weekly album chart for %name%"
+msgstr "Tedenska lestvica albumov za %name%"
+
+#: id:15275
+msgid "Weekly track chart for %name%"
+msgstr "Tedenska lestvica pesmi za %name%"
+
+#: id:15276
+msgid "Listen to %name%'s neighbours Last.fm radio"
+msgstr "Poslušaj %name% sosedski Last.fm radio"
+
+#: id:15277
+msgid "Listen to %name%'s personal Last.fm radio"
+msgstr "Poslušaj %name% osebni Last.fm radio"
+
+#: id:15278
+msgid "Listen to %name%'s mix Last.fm radio"
+msgstr "Poslušaj %name% miks Last.fm radio"
+
+#: id:15279
+msgid "Retrieving list from Last.fm..."
+msgstr "Prenašam seznam iz Last.fm"
+
+#: id:15280
+msgid "Can't retrieve list from Last.fm..."
+msgstr "Ne morem prenesti seznama iz Last.FM"
+
+#: id:15281
+msgid "Enter an artist name to find related ones"
+msgstr "Vnesi ime izvajalca za iskanje"
+
+#: id:15282
+msgid "Enter a tag name to find similar ones"
+msgstr "Vnesi oznako za iskanje podobnih"
+
+#: id:15283
+msgid "Tracks recently listened by %name%"
+msgstr "Zadnje poslušane skladbe %name%"
+
+#: id:15284
+msgid "Listen to %name%'s recommendations Last.fm radio"
+msgstr "Poslušaj priporočila %name% Last.FM radio"
+
+#: id:15285
+msgid "Top tags for user %name%"
+msgstr "Najbolj priljubljene oznake %name%"
+
+#: id:15287
+msgid "Do you want to add the current track to your loved tracks?"
+msgstr "Želite dodati trenutno skladbo med priljubljene?"
+
+#: id:15288
+msgid "Do you want to ban the current track?"
+msgstr "Želite prepovedati trenutno skladbo"
+
+#: id:15289
+msgid "Added to your loved tracks: '%s'."
+msgstr "Dodano med priljubljene: '%s'."
+
+#: id:15290
+msgid "Could not add '%s' to your loved tracks."
+msgstr "Ni bilo mogoče dodati '%s' med priljubljene."
+
+#: id:15291
+msgid "Banned: '%s'."
+msgstr "Prepovedano: '%s'."
+
+#: id:15292
+msgid "Could not ban '%s'."
+msgstr "Ni bilo mogoče prepovedati '%s'."
+
+#: id:15293
+msgid "Tracks recently loved by %name%"
+msgstr "Zadnje priljubljene pesmi %name%"
+
+#: id:15294
+msgid "Tracks recently banned by %name%"
+msgstr "Zadnje prepovedane pesmi %name%"
+
+#: id:15295
+msgid "Remove from loved tracks"
+msgstr "Odstrani iz priljubljenih"
+
+#: id:15296
+msgid "Un-ban"
+msgstr "Dovoli"
+
+#: id:15297
+msgid "Do you want to remove this track from your loved tracks?"
+msgstr "Želite odstraniti to skladbo iz priljubljenih?"
+
+#: id:15298
+msgid "Do you want to un-ban this track?"
+msgstr "Želite dovoliti to skladbo?"
+
+#: id:15300
+msgid "Path not found or invalid"
+msgstr "Povezava ni bila najdena oz. je neveljavna"
+
+#: id:15301
+msgid "Could not connect to network server"
+msgstr "Povezava z strežnikom ni mogoča"
+
+#: id:15302
+msgid "No servers found"
+msgstr "Ni strežnikov"
+
+#: id:15303
+msgid "Workgroup not found"
+msgstr "Delovne skupine ni mogoče najti"
+
+#: id:15310
+msgid "Opening multi-path source"
+msgstr "Odpiram vir z več potmi"
+
+#: id:15311
+msgid "Path:"
+msgstr "Pot:"
+
+#: id:16000
+msgctxt "Auto context with id 16000"
+msgid "General"
+msgstr "Splošno"
+
+#: id:16002
+msgid "Internet lookup"
+msgstr "Poizvedba na spletu"
+
+#: id:16003
+msgid "Player"
+msgstr "Predvajalnik"
+
+#: id:16004
+msgid "Play media from disc"
+msgstr "Predvajaj iz medija"
+
+#: id:16008
+msgid "Enter new title"
+msgstr "Vnesite nov naslov"
+
+#: id:16009
+msgid "Enter the movie name"
+msgstr "Vnesite ime filma"
+
+#: id:16010
+msgid "Enter the profile name"
+msgstr "Vnesite ime profila"
+
+#: id:16011
+msgid "Enter the album name"
+msgstr "Vnesite ime albuma"
+
+#: id:16012
+msgid "Enter the playlist name"
+msgstr "Vnesite ime predvajalnega seznama"
+
+#: id:16013
+msgid "Enter new filename"
+msgstr "Vnesite novo ime datoteke"
+
+#: id:16014
+msgid "Enter folder name"
+msgstr "Vnesite ime mape"
+
+#: id:16015
+msgid "Enter directory"
+msgstr "Vnesite direktorij"
+
+#: id:16016
+msgid "Available options: %A, %T, %N, %B, %D, %G, %Y, %F, %S"
+msgstr "Možnosti: %A, %T, %N, %B, %D, %G, %Y, %F, %S"
+
+#: id:16017
+msgid "Enter search string"
+msgstr "Vnesite iskalni niz"
+
+#: id:16018
+msgctxt "Auto context with id 16018"
+msgid "None"
+msgstr "Brez"
+
+#: id:16019
+msgid "Auto select"
+msgstr "Samodejna izbira"
+
+#: id:16020
+msgid "De-interlace"
+msgstr "Razpletanje"
+
+#: id:16021
+msgid "Bob"
+msgstr "Bob"
+
+#: id:16022
+msgid "Bob (inverted)"
+msgstr "Bob (obrnjeno)"
+
+#: id:16024
+msgid "Canceling..."
+msgstr "Preklic..."
+
+#: id:16025
+msgid "Enter the artist name"
+msgstr "Vnesite ime izvajalca"
+
+#: id:16026
+msgid "Playback failed"
+msgstr "Predvajanje ni uspelo"
+
+#: id:16027
+msgid "One or more items failed to play."
+msgstr "Ene ali več datotek ni mogoče predvajati."
+
+#: id:16028
+msgid "Enter value"
+msgstr "Vnesite vrednost"
+
+#: id:16029
+msgid "Check the log file for details."
+msgstr "Preberite več informacij v zapisniku."
+
+#: id:16030
+msgid "Party mode aborted."
+msgstr "Zabavni način preklican."
+
+#: id:16031
+msgid "No matching songs in the library."
+msgstr "Nobena pesem v bazi ne izpolnjuje pogojev."
+
+#: id:16032
+msgid "Could not initialize database."
+msgstr "Ne morem inicializirati podatkovne baze."
+
+#: id:16033
+msgid "Could not open database."
+msgstr "Ne morem odpreti podatkovne baze."
+
+#: id:16034
+msgid "Could not get songs from database."
+msgstr "Ne morem pridobiti pesmi iz baze"
+
+#: id:16035
+msgid "Party mode playlist"
+msgstr "Predvajalni seznam zabavnega načina"
+
+#: id:16036
+msgid "De-interlace (Half)"
+msgstr "Razpletanje (Polovično)"
+
+#: id:16037
+msgid "Deinterlace video"
+msgstr "Uporabi razpletanje videa"
+
+#: id:16038
+msgid "Deinterlace method"
+msgstr "Metoda razpletanja"
+
+#: id:16039
+msgctxt "Auto context with id 16039"
+msgid "Off"
+msgstr "Izključeno"
+
+#: id:16040
+msgctxt "Auto context with id 16040"
+msgid "Auto"
+msgstr "Avtomatsko"
+
+#: id:16041
+msgid "On"
+msgstr "Vključeno"
+
+#: id:16100
+msgid "All Videos"
+msgstr "Vsi posnetki"
+
+#: id:16101
+msgid "Unwatched"
+msgstr "Nepogledani"
+
+#: id:16102
+msgid "Watched"
+msgstr "Pogledani"
+
+#: id:16103
+msgid "Mark as watched"
+msgstr "Označi kot pogledan"
+
+#: id:16104
+msgid "Mark as unwatched"
+msgstr "Označi kot nepogledan"
+
+#: id:16105
+msgid "Edit title"
+msgstr "Uredi naslov"
+
+#: id:16200
+msgid "Operation was aborted"
+msgstr "Operacija je bila preklicana"
+
+#: id:16201
+msgid "Copy failed"
+msgstr "Kopiranje ni uspelo"
+
+#: id:16202
+msgid "Failed to copy at least one file"
+msgstr "Kopiranje najmanj ene datoteke ni uspelo"
+
+#: id:16203
+msgid "Move failed"
+msgstr "Premikanje ni uspelo"
+
+#: id:16204
+msgid "Failed to move at least one file"
+msgstr "Premikanje najmanj ene datoteke ni uspelo"
+
+#: id:16205
+msgid "Delete failed"
+msgstr "Izbris ni uspel"
+
+#: id:16206
+msgid "Failed to delete at least one file"
+msgstr "Izbris najmanj ene datoteke ni uspel"
+
+#: id:16300
+msgid "Video scaling method"
+msgstr "Način spreminjanja velikosti videa"
+
+#: id:16301
+msgid "Nearest neighbour"
+msgstr "Najbližji sosed"
+
+#: id:16302
+msgid "Bilinear"
+msgstr "Bilinear"
+
+#: id:16303
+msgctxt "Auto context with id 16303"
+msgid "Bicubic"
+msgstr "Bicubic"
+
+#: id:16304
+msgid "Lanczos2"
+msgstr "Lanczos2"
+
+#: id:16305
+msgid "Lanczos3"
+msgstr "Lanczos3"
+
+#: id:16306
+msgid "Sinc8"
+msgstr "Sinc8"
+
+#: id:16307
+msgid "Bicubic (software)"
+msgstr "Bicubic (programsko)"
+
+#: id:16308
+msgid "Lanczos (software)"
+msgstr "Lanczos (programsko)"
+
+#: id:16309
+msgid "Sinc (software)"
+msgstr "Sinc (programsko)"
+
+#: id:16310
+msgid "Temporal"
+msgstr "Temporal"
+
+#: id:16311
+msgid "Temporal/Spatial"
+msgstr "Temporal/Spatial"
+
+#: id:16312
+msgid "(VDPAU)Noise Reduction"
+msgstr "(VDPAU) Zmanjševanje šuma"
+
+#: id:16313
+msgid "(VDPAU)Sharpness"
+msgstr "(VDPAU) Ostrenje"
+
+#: id:16314
+msgid "Inverse Telecine"
+msgstr "Inverse Telecine"
+
+#: id:16315
+msgid "Lanczos3 optimized"
+msgstr "Lanczos3 optimalno"
+
+#: id:16316
+msgctxt "Auto context with id 16316"
+msgid "Auto"
+msgstr "Samodejno"
+
+#: id:16317
+msgid "Temporal (Half)"
+msgstr "Temporal (Polovično)"
+
+#: id:16318
+msgid "Temporal/Spatial (Half)"
+msgstr "Temporal/Spatial (Polovično)"
+
+#: id:16319
+msgid "DXVA"
+msgstr "DXVA"
+
+#: id:16320
+msgid "DXVA Bob"
+msgstr "DXVA Bob"
+
+#: id:16321
+msgid "DXVA Best"
+msgstr "DXVA Best"
+
+#: id:16322
+msgid "Spline36"
+msgstr "Spline36"
+
+#: id:16323
+msgid "Spline36 optimized"
+msgstr "Spline36 optimized"
+
+#: id:16324
+msgid "Software Blend"
+msgstr "Programski Blend"
+
+#: id:16400
+msgid "Post-processing"
+msgstr "Post-procesiranje"
+
+#: id:17500
+msgid "Display sleep timeout"
+msgstr "Prikaži čas to zamaknjenega izklopa"
+
+#: id:19000
+msgid "Switch to channel"
+msgstr "Preklopi na kanal"
+
+#: id:20000
+msgid "Saved music folder"
+msgstr "Mapa za shranjeno glasbo"
+
+#: id:20001
+msgid "Use external DVD player"
+msgstr "Uporabi zunanji DVD predvajalnik"
+
+#: id:20002
+msgid "External DVD player"
+msgstr "Zunanji DVD Predvajalnik"
+
+#: id:20003
+msgid "Trainers folder"
+msgstr "Trainer mapa"
+
+#: id:20004
+msgid "Screenshot folder"
+msgstr "Mapa za namizne posnetke"
+
+#: id:20006
+msgid "Playlists folder"
+msgstr "Mapa za predvajalne sezname"
+
+#: id:20007
+msgid "Recordings"
+msgstr "Posnetki"
+
+#: id:20008
+msgid "Screenshots"
+msgstr "Namizni posnetki"
+
+#: id:20009
+msgid "Use XBMC"
+msgstr "Uporabi XBMC"
+
+#: id:20011
+msgid "Music playlists"
+msgstr "Glasbeni predvajalni seznami"
+
+#: id:20012
+msgid "Video playlists"
+msgstr "Video predvajalni seznami"
+
+#: id:20013
+msgid "Do you wish to launch the game?"
+msgstr "Želite zagnati igro?"
+
+#: id:20014
+msgid "Sort by: Playlist"
+msgstr "Razporedi: Predvajalni seznam"
+
+#: id:20015
+msgid "Remote thumb"
+msgstr "Oddaljena sličica"
+
+#: id:20016
+msgid "Current thumb"
+msgstr "Trenutna sličica"
+
+#: id:20017
+msgid "Local thumb"
+msgstr "Krajevna sličica"
+
+#: id:20018
+msgid "No thumb"
+msgstr "Brez sličice"
+
+#: id:20019
+msgid "Choose thumbnail"
+msgstr "Izberi sličico"
+
+#: id:20023
+msgid "Conflict"
+msgstr "Konflikt"
+
+#: id:20024
+msgid "Scan new"
+msgstr "Novo iskanje"
+
+#: id:20025
+msgid "Scan all"
+msgstr "Preišči vse"
+
+#: id:20026
+msgid "Region"
+msgstr "Regija"
+
+#: id:20037
+msgid "Summary"
+msgstr "Kratek opis"
+
+#: id:20038
+msgid "Lock music window"
+msgstr "Zakleni glasbeni del"
+
+#: id:20039
+msgid "Lock videos window"
+msgstr "Zakleni video del"
+
+#: id:20040
+msgid "Lock pictures window"
+msgstr "Zakleni slikovni del"
+
+#: id:20041
+msgid "Lock programs & scripts windows"
+msgstr "Zakleni programski ter skriptni del"
+
+#: id:20042
+msgid "Lock file manager"
+msgstr "Zakleni brskalnik datotek"
+
+#: id:20043
+msgid "Lock settings"
+msgstr "Zakleni nastavitve"
+
+#: id:20044
+msgid "Start fresh"
+msgstr "Začni sveže"
+
+#: id:20045
+msgid "Enter master mode"
+msgstr "Vstopi v upravljalski način"
+
+#: id:20046
+msgid "Leave master mode"
+msgstr "Izstopi iz upravljalskega načina"
+
+#: id:20047
+msgid "Create profile '%s'?"
+msgstr "Ustvari profil '%s'?"
+
+#: id:20048
+msgid "Start with fresh settings"
+msgstr "Začni z svežimi nastavitvami"
+
+#: id:20049
+msgid "Best available"
+msgstr "Najboljša možna"
+
+#: id:20050
+msgid "Auto-switch between 16x9 and 4x3"
+msgstr "Samodejno preklopi med 16x9 in 4x3"
+
+#: id:20051
+msgid "Treat stacked files as single file"
+msgstr "Obravnavaj razdeljene datoteke kot eno datoteko"
+
+#: id:20052
+msgid "Caution"
+msgstr "Pozor"
+
+#: id:20053
+msgid "Left master mode"
+msgstr "Zapustili ste upravljalski način"
+
+#: id:20054
+msgid "Entered master mode"
+msgstr "Vstopili ste v upravljalski način"
+
+#: id:20055
+msgid "Allmusic.com thumb"
+msgstr "Allmusic.com sličica"
+
+#: id:20057
+msgid "Remove thumbnail"
+msgstr "Odstrani sličico"
+
+#: id:20058
+msgid "Add profile..."
+msgstr "Dodaj profil..."
+
+#: id:20059
+msgid "Query info for all albums"
+msgstr "Poizvedba informacij za vse albume"
+
+#: id:20060
+msgctxt "Auto context with id 20060"
+msgid "Media info"
+msgstr "Informacije o mediju"
+
+#: id:20061
+msgctxt "Auto context with id 20061"
+msgid "Separate"
+msgstr "Ločeno"
+
+#: id:20062
+msgid "Shares with default"
+msgstr "Privzeta skupna raba"
+
+#: id:20063
+msgid "Shares with default (read only)"
+msgstr "Privzeta skupna raba (samo za branje)"
+
+#: id:20064
+msgid "Copy default"
+msgstr "Privzeto kopiranje"
+
+#: id:20065
+msgid "Profile picture"
+msgstr "Slika profila"
+
+#: id:20066
+msgid "Lock preferences"
+msgstr "Nastavitve zaklepanja"
+
+#: id:20067
+msgid "Edit profile"
+msgstr "Uredi profil"
+
+#: id:20068
+msgid "Profile lock"
+msgstr "Zaklepanje profila"
+
+#: id:20069
+msgid "Could not create folder"
+msgstr "Ne morem ustvariti mape"
+
+#: id:20070
+msgid "Profile directory"
+msgstr "Direktorij z profili"
+
+#: id:20071
+msgid "Start with fresh media sources"
+msgstr "Začni z svežimi multimedijskimi viri"
+
+#: id:20072
+msgid "Make sure the selected folder is writable"
+msgstr "Prepričajte se, da je izbrana mapa zapisljiva"
+
+#: id:20073
+msgid "and that the new folder name is valid"
+msgstr "in da je ime nove mape pravilno"
+
+#: id:20074
+msgid "MPAA rating"
+msgstr "MPAA ocena"
+
+#: id:20075
+msgid "Enter master lock code"
+msgstr "Vnesi glavno geslo"
+
+#: id:20076
+msgid "Ask for master lock code on startup"
+msgstr "Vprašaj za glavno geslo pri zagonu"
+
+#: id:20077
+msgid "Skin settings"
+msgstr "Nastavitve preobleke"
+
+#: id:20078
+msgid "- no link set -"
+msgstr "- ni bližnjic -"
+
+#: id:20079
+msgid "Enable animations"
+msgstr "Vključi animacije"
+
+#: id:20080
+msgid "Disable RSS during music"
+msgstr "Izključi RSS med predvajanjem glasbe"
+
+#: id:20081
+msgid "Enable shortcut buttons"
+msgstr "Vključi gumbe bližnjic"
+
+#: id:20082
+msgid "Show programs in main menu"
+msgstr "Prikaži programe v glavnem menuju"
+
+#: id:20083
+msgid "Show music info"
+msgstr "Prikaži glasbene informacije"
+
+#: id:20084
+msgid "Show weather info"
+msgstr "Prikaži vremenske informacije"
+
+#: id:20085
+msgid "Show system info"
+msgstr "Prikaži sistemske informacije"
+
+#: id:20086
+msgid "Show available disc space C: E: F:"
+msgstr "Prikaži prosti del na trdem disku C: E: F:"
+
+#: id:20087
+msgid "Show available disc space E: F: G:"
+msgstr "Prikaži prosti del na trdem disku E: F: G:"
+
+#: id:20088
+msgid "Weather info"
+msgstr "Vremenske informacije"
+
+#: id:20089
+msgid "Drive space free"
+msgstr "Prostor na trdem disku"
+
+#: id:20090
+msgid "Enter the name of an existing share"
+msgstr "Vnesi naziv za obstoječo skupno rabo"
+
+#: id:20091
+msgid "Lock code"
+msgstr "Geslo za zaklepanje"
+
+#: id:20092
+msgid "Load profile"
+msgstr "Naloži profil"
+
+#: id:20093
+msgid "Profile name"
+msgstr "Ime profila"
+
+#: id:20094
+msgctxt "Auto context with id 20094"
+msgid "Media sources"
+msgstr "Multimedijski vir"
+
+#: id:20095
+msgid "Enter profile lock code"
+msgstr "Vnesi geslo za zaklepanje za profil"
+
+#: id:20096
+msgctxt "Auto context with id 20096"
+msgid "Login screen"
+msgstr "Prijavno okno"
+
+#: id:20097
+msgid "Fetching album info"
+msgstr "Prenašam informacije o albumu"
+
+#: id:20098
+msgid "Fetching info for album"
+msgstr "Prenašam informacije za album"
+
+#: id:20099
+msgid "Can't rip CD or track while playing from CD"
+msgstr "Ne morem shraniti CD-ja ali zapisa med predvajanjem"
+
+#: id:20100
+msgid "Master lock code and settings"
+msgstr "Glavno geslo in nastavitve"
+
+#: id:20101
+msgid "Entering master lock code always enables master mode"
+msgstr "Vnos glavnega gesla vedno vključi upravljalski način"
+
+#: id:20102
+msgid "or copy from default?"
+msgstr "ali kopiram iz privzete?"
+
+#: id:20103
+msgid "Save changes to profile?"
+msgstr "Shranim spremembe v profil?"
+
+#: id:20104
+msgid "Old settings found."
+msgstr "Najdene stare nastavitve"
+
+#: id:20105
+msgid "Do you want to use them?"
+msgstr "Jih želite uporabit?"
+
+#: id:20106
+msgid "Old media sources found."
+msgstr "Najdeni stari multimedijski viri"
+
+#: id:20107
+msgid "Separate (locked)"
+msgstr "Ločeno (zakljenjeno)"
+
+#: id:20108
+msgid "Root"
+msgstr "Root"
+
+#: id:20109
+msgid "- Zoom"
+msgstr "- Povečava"
+
+#: id:20110
+msgid "UPnP settings"
+msgstr "UPnP nastavitve"
+
+#: id:20111
+msgid "Autostart UPnP client"
+msgstr "Samodejni zagon odjemalca UPnP"
+
+#: id:20112
+msgid "Last login: %s"
+msgstr "Zadnja prijava: %s"
+
+#: id:20113
+msgid "Never logged on"
+msgstr "Nikoli prijavljen"
+
+#: id:20114
+msgid "Profile %i / %i"
+msgstr "Profil %i / %i"
+
+#: id:20115
+msgid "User login / Select a profile"
+msgstr "Uporabniška prijava / Izberi profil"
+
+#: id:20116
+msgid "Use lock on login screen"
+msgstr "Uporabi zaklepanje ob prijavi"
+
+#: id:20117
+msgid "Invalid lock code."
+msgstr "Napačna zaščitno geslo."
+
+#: id:20118
+msgid "This requires the master lock to be set."
+msgstr "Dejanje potrebuje nastavitev glavnega gesla."
+
+#: id:20119
+msgid "Would you like to set it now?"
+msgstr "Želite opraviti nastavitve sedaj?"
+
+#: id:20120
+msgid "Loading program information"
+msgstr "Nalagam programske info."
+
+#: id:20121
+msgid "Party on!"
+msgstr "Žuriraj!"
+
+#: id:20122
+msgid "True"
+msgstr "Drži"
+
+#: id:20123
+msgid "Mixing drinks"
+msgstr "Mešanje pijač"
+
+#: id:20124
+msgid "Filling glasses"
+msgstr "Polnjenje stekla"
+
+#: id:20125
+msgid "Logged on as"
+msgstr "Prijavljen kot"
+
+#: id:20126
+msgid "Log off"
+msgstr "Odjavi se"
+
+#: id:20128
+msgid "Go to root"
+msgstr "Pojdi na root"
+
+#: id:20129
+msgid "Weave"
+msgstr "Valovanje"
+
+#: id:20130
+msgid "Weave (inverted)"
+msgstr "Valovanje (invertirano)"
+
+#: id:20131
+msgid "Blend"
+msgstr "Zatemni"
+
+#: id:20132
+msgid "Restart video"
+msgstr "Ponovno zaženi video"
+
+#: id:20133
+msgid "Edit network location"
+msgstr "Uredi omrežno lokacijo"
+
+#: id:20134
+msgid "Remove network location"
+msgstr "Odstrani omrežno lokacijo"
+
+#: id:20135
+msgid "Do you want to scan the folder?"
+msgstr "Želite preiskati mapo?"
+
+#: id:20136
+msgid "Memory unit"
+msgstr "Spominska naprava"
+
+#: id:20137
+msgid "Memory unit mounted"
+msgstr "Spominska naprava priključiti"
+
+#: id:20138
+msgid "Unable to mount memory unit"
+msgstr "Spominske naprave ni mogoče priključiti"
+
+#: id:20139
+msgid "In port %i, slot %i"
+msgstr "Na portu %i, slot %i"
+
+#: id:20140
+msgid "Lock screensaver"
+msgstr "Zakleni ohranjevalnik"
+
+#: id:20141
+msgid "Set"
+msgstr "Nastavi"
+
+#: id:20142
+msgctxt "Auto context with id 20142"
+msgid "Username"
+msgstr "Uporabniško ime"
+
+#: id:20143
+msgid "Enter password for"
+msgstr "Vnesi geslo za"
+
+#: id:20144
+msgid "Shutdown timer"
+msgstr "Zakasnitev izklopa"
+
+#: id:20145
+msgid "Shutdown interval (in minutes)"
+msgstr "Interval zakasnitve izklopa (v minutah)"
+
+#: id:20146
+msgid "Started, shutdown in %im"
+msgstr "Vključen, izklop čez %im"
+
+#: id:20147
+msgid "Shutdown in 30 minutes"
+msgstr "Izključitev čez 30 minut"
+
+#: id:20148
+msgid "Shutdown in 60 minutes"
+msgstr "Izključitev čez 60 minut"
+
+#: id:20149
+msgid "Shutdown in 120 minutes"
+msgstr "Izključitev čez 120 minut"
+
+#: id:20150
+msgid "Custom shutdown timer"
+msgstr "Poljubna zakasnitev izklopa"
+
+#: id:20151
+msgid "Cancel shutdown timer"
+msgstr "Izključi zakasnitev izklopa"
+
+#: id:20152
+msgid "Lock preferences for %s"
+msgstr "Nastavitve zaklepa za %s"
+
+#: id:20153
+msgid "Browse..."
+msgstr "Prebrskaj..."
+
+#: id:20154
+msgid "Summary information"
+msgstr "Osnovne informacije"
+
+#: id:20155
+msgid "Storage information"
+msgstr "Informacije o shrambi"
+
+#: id:20156
+msgid "Hard disk information"
+msgstr "Informacije o trdem disku"
+
+#: id:20157
+msgid "DVD-ROM information"
+msgstr "DVD-ROM informacije"
+
+#: id:20158
+msgid "Network information"
+msgstr "Omrežne informacije"
+
+#: id:20159
+msgid "Video information"
+msgstr "Video informacije"
+
+#: id:20160
+msgid "Hardware information"
+msgstr "Informacije o strojni opremi"
+
+#: id:20161
+msgid "Total"
+msgstr "Skupaj"
+
+#: id:20162
+msgid "Used"
+msgstr "Uporabljeno"
+
+#: id:20163
+msgid "of"
+msgstr "od"
+
+#: id:20164
+msgid "Locking not supported"
+msgstr "Zaklepanje ni podprto"
+
+#: id:20165
+msgid "Not locked"
+msgstr "Ni zaklenjeno"
+
+#: id:20166
+msgid "Locked"
+msgstr "Zaklenjeno"
+
+#: id:20167
+msgid "Frozen"
+msgstr "Zamrznjeno"
+
+#: id:20168
+msgid "Requires reset"
+msgstr "Potreben je ponovni zagon"
+
+#: id:20169
+msgid "Week"
+msgstr "Teden"
+
+#: id:20170
+msgid "Line"
+msgstr "Linija"
+
+#: id:20171
+msgid "Windows network (SMB)"
+msgstr "Omrežje Windows (SMB)"
+
+#: id:20172
+msgid "XBMSP server"
+msgstr "XBMSP strežnik"
+
+#: id:20173
+msgctxt "Auto context with id 20173"
+msgid "FTP server"
+msgstr "FTP strežnik"
+
+#: id:20174
+msgid "iTunes music share (DAAP)"
+msgstr "Skupna raba iTunes glasbe (DAAP)"
+
+#: id:20175
+msgid "UPnP server"
+msgstr "UPnP strežnik"
+
+#: id:20176
+msgid "Show video info"
+msgstr "Prikaži video informacije"
+
+#: id:20177
+msgid "Done"
+msgstr "Uporabi"
+
+#: id:20178
+msgid "Shift"
+msgstr "Shift"
+
+#: id:20179
+msgid "Caps Lock"
+msgstr "Caps Lock"
+
+#: id:20180
+msgid "Symbols"
+msgstr "Simboli"
+
+#: id:20181
+msgid "Backspace"
+msgstr "Nazaj"
+
+#: id:20182
+msgid "Space"
+msgstr "Presledek"
+
+#: id:20183
+msgid "Reload skin"
+msgstr "Osveži preobleko"
+
+#: id:20184
+msgid "Rotate pictures using EXIF information"
+msgstr "Obrni z uporabo EXIF informacije"
+
+#: id:20185
+msgid "Use poster view styles for TV shows"
+msgstr "Uporabi plakate za TV serije"
+
+#: id:20186
+msgid "Please wait"
+msgstr "Prosim počakajte"
+
+#: id:20187
+msgid "UPnP"
+msgstr ""
+
+#: id:20189
+msgid "Enable auto scrolling for plot & review"
+msgstr "Vključi samodejno premikanje zgodbe & ocen"
+
+#: id:20190
+msgctxt "Auto context with id 20190"
+msgid "Custom"
+msgstr "Poljubno"
+
+#: id:20191
+msgid "Enable debug logging"
+msgstr "Vključi zapisovanje razhroščevanja"
+
+#: id:20192
+msgid "Download additional information during updates"
+msgstr "Prenesi dodatne informacije med posodabljanjem"
+
+#: id:20193
+msgid "Default service for album information"
+msgstr "Privzeta storitev za informacije o albumih"
+
+#: id:20194
+msgid "Default service for artist information"
+msgstr "Privzeta storitev za informacije o izvajalcih"
+
+#: id:20195
+msgid "Change scraper"
+msgstr "Spremeni ponudnika"
+
+#: id:20196
+msgid "Export music library"
+msgstr "Izvozi glasbeno knjižnico"
+
+#: id:20197
+msgid "Import music library"
+msgstr "Uvozi glasbeno knjižnico"
+
+#: id:20198
+msgid "No artist found!"
+msgstr "Ni najdenega izvajalca!"
+
+#: id:20199
+msgid "Downloading artist info failed"
+msgstr "Prenašanje informacij o izvajalcu ni uspelo"
+
+#: id:20250
+msgid "Party on! (videos)"
+msgstr "Žuriraj! (videi)"
+
+#: id:20251
+msgid "Mixing drinks (videos)"
+msgstr "Mešanje pijač (videi)"
+
+#: id:20252
+msgid "Filling glasses (videos)"
+msgstr "Polnenje kozarcev (videi)"
+
+#: id:20253
+msgid "WebDAV server (HTTP)"
+msgstr "WebDAV strežnik (HTTP)"
+
+#: id:20254
+msgid "WebDAV server (HTTPS)"
+msgstr "WebDAV strežnik (HTTPS)"
+
+#: id:20255
+msgid "First logon, edit your profile"
+msgstr "Uredi profil ob prvi prijavi"
+
+#: id:20256
+msgid "HTS Tvheadend client"
+msgstr "HTS Tvheadend odjemalec"
+
+#: id:20257
+msgid "VDR Streamdev client"
+msgstr "VDR Streamdev odjemalec"
+
+#: id:20258
+msgid "MythTV client"
+msgstr "MythTV odjemalec"
+
+#: id:20259
+msgid "Network Filesystem (NFS)"
+msgstr "Omrežni datotečni sistem (NFS)"
+
+#: id:20260
+msgid "Secure Shell (SSH/SFTP)"
+msgstr "Varna lupina (SSH/SFTP)"
+
+#: id:20261
+msgid "Apple Filing Protocol (AFP)"
+msgstr "Apple Filing protokol (AFP)"
+
+#: id:20300
+msgid "Web server directory (HTTP)"
+msgstr "Mapa spletnega strežnika (HTTP)"
+
+#: id:20301
+msgid "Web server directory (HTTPS)"
+msgstr "Mapa spletnega strežnika (HTTPS)"
+
+#: id:20302
+msgid "Unable to write to folder:"
+msgstr "Ni mogoče pisati v mapo:"
+
+#: id:20303
+msgid "Do you want to skip and proceed?"
+msgstr "Želite preskočiti in nadaljevati?"
+
+#: id:20304
+msgid "RSS Feed"
+msgstr "RSS"
+
+#: id:20307
+msgid "Secondary DNS"
+msgstr "Sekundarni DNS"
+
+#: id:20308
+msgid "DHCP server:"
+msgstr "DHCP strežnik:"
+
+#: id:20309
+msgid "Make new folder"
+msgstr "Ustvari novo mapo"
+
+#: id:20310
+msgid "Dim LCD on playback"
+msgstr "Zatemni LCD pri predvajanju"
+
+#: id:20311
+msgid "Unknown or onboard (protected)"
+msgstr "Neznano (zaščiteno)"
+
+#: id:20312
+msgid "Dim LCD on paused"
+msgstr "Zatemni LCD pri pavzi"
+
+#: id:20314
+msgid "Videos - Library"
+msgstr "Video - Knjižnica"
+
+#: id:20316
+msgid "Sort by: ID"
+msgstr "Razvrsti: ID"
+
+#: id:20324
+msgid "Play part..."
+msgstr "Igraj odlomek..."
+
+#: id:20325
+msgid "Calibration reset"
+msgstr "Ponastavitev prilagoditev"
+
+#: id:20326
+msgid "This will reset the calibration values for %s"
+msgstr "To bo ponastavilo vrednosti prilagoditev za %s"
+
+#: id:20327
+msgid "to it's default values."
+msgstr "na privzete vrednosti."
+
+#: id:20328
+msgid "Browse for destination"
+msgstr "Prebrskaj za ciljem"
+
+#: id:20329
+msgid "Movies are in separate folders that match the movie title"
+msgstr "Filmi so v ločenih mapah, ki se ujemajo z naslovom filma"
+
+#: id:20330
+msgid "Use folder names for lookups"
+msgstr "Uporabi imena map za poizvedbe"
+
+#: id:20331
+msgctxt "Auto context with id 20331"
+msgid "File"
+msgstr "Datoteka"
+
+#: id:20332
+msgid "Use file or folder names in lookups?"
+msgstr "Uporabi ime datoteke ali mape v poizvedbah?"
+
+#: id:20333
+msgid "Set content"
+msgstr "Nastavi vsebino"
+
+#: id:20334
+msgid "Folder"
+msgstr "Mapa"
+
+#: id:20335
+msgid "Look for content recursively?"
+msgstr "Brebrskaj za vsebine tudi v podmapah?"
+
+#: id:20336
+msgid "Unlock sources"
+msgstr "Odkleni izvore"
+
+#: id:20337
+msgid "Actor"
+msgstr "Igralec"
+
+#: id:20338
+msgid "Movie"
+msgstr "Film"
+
+#: id:20339
+msgid "Director"
+msgstr "Director"
+
+#: id:20340
+msgid "Do you want to remove all items within"
+msgstr "Želite odstraniti vse elemente"
+
+#: id:20341
+msgid "this path from the XBMC library?"
+msgstr "s to potjo iz knjižnice XBMC?"
+
+#: id:20342
+msgctxt "Auto context with id 20342"
+msgid "Movies"
+msgstr "Filmi"
+
+#: id:20343
+msgid "TV shows"
+msgstr "TV serije"
+
+#: id:20344
+msgid "This directory contains"
+msgstr "Ta mapa vsebuje"
+
+#: id:20345
+msgid "Run automated scan"
+msgstr "Zaženi samodejno iskanje"
+
+#: id:20346
+msgid "Scan recursively"
+msgstr "Preišči tudi podmape"
+
+#: id:20347
+msgid "as"
+msgstr "kot"
+
+#: id:20348
+msgid "Directors"
+msgstr "Režiserji"
+
+#: id:20349
+msgid "No video files found in this path!"
+msgstr "Na tej poti ni nobenih video datotek!"
+
+#: id:20350
+msgid "votes"
+msgstr "glasov"
+
+#: id:20351
+msgid "TV show information"
+msgstr "Informacija o TV seriji"
+
+#: id:20352
+msgid "Episode information"
+msgstr "Informacija o epizodi"
+
+#: id:20353
+msgid "Loading TV show details"
+msgstr "Dalagam podrobnosti o TV seriji"
+
+#: id:20354
+msgid "Fetching episode guide"
+msgstr "Prenašam opis epizod"
+
+#: id:20355
+msgid "Loading info for episodes in directory"
+msgstr "Iščem epizode v mapi"
+
+#: id:20356
+msgid "Select TV show:"
+msgstr "Izberi TV serijo:"
+
+#: id:20357
+msgid "Enter the TV show name"
+msgstr "Vnesi ime TV serije"
+
+#: id:20358
+msgid "Season %i"
+msgstr "Sezona %i"
+
+#: id:20359
+msgid "Episode"
+msgstr "Epizoda"
+
+#: id:20360
+msgid "Episodes"
+msgstr "Epizode"
+
+#: id:20361
+msgid "Loading episode details"
+msgstr "Nalagam podrobnosti o epizodi"
+
+#: id:20362
+msgid "Remove episode from library"
+msgstr "Odstrani epizode iz knjižnice"
+
+#: id:20363
+msgid "Remove TV show from library"
+msgstr "Odstrani TV serijo iz knjižnice"
+
+#: id:20364
+msgid "TV show"
+msgstr "TV serija"
+
+#: id:20365
+msgid "Episode plot"
+msgstr "Zgodba epizode"
+
+#: id:20366
+msgid "* All seasons"
+msgstr "* Vse sezone"
+
+#: id:20367
+msgid "Hide watched"
+msgstr "Skrij pogledane"
+
+#: id:20368
+msgid "Prod code"
+msgstr "Prod. št."
+
+#: id:20369
+msgid "Show plot for unwatched items"
+msgstr "Skrij zgodbo nepogledanih predmetov"
+
+#: id:20370
+msgid "* Hidden to prevent spoilers *"
+msgstr "* Skrito zaradi skrivanja zgodbe *"
+
+#: id:20371
+msgid "Set season thumb"
+msgstr "Nastavi sličico za sezono"
+
+#: id:20372
+msgid "Season image"
+msgstr "Slika sezone"
+
+#: id:20373
+msgid "Season"
+msgstr "Sezona"
+
+#: id:20374
+msgid "Downloading movie information"
+msgstr "Prenašam informacije o filmu"
+
+#: id:20375
+msgid "Unassign content"
+msgstr "Odstrani vsebino"
+
+#: id:20376
+msgid "Original title"
+msgstr "Prvotni naslov"
+
+#: id:20377
+msgid "Refresh TV show information"
+msgstr "Osveži informacije o TV seriji"
+
+#: id:20378
+msgid "Refresh info for all episodes?"
+msgstr "Osveži informacije za vse epizode?"
+
+#: id:20379
+msgid "Selected folder contains a single TV show"
+msgstr "Mapa vsebuje eno TV serijo"
+
+#: id:20380
+msgid "Exclude selected folder from scans"
+msgstr "Izključi mapo iz iskanja"
+
+#: id:20381
+msgid "Specials"
+msgstr "Posebne epizode"
+
+#: id:20382
+msgid "Automatically grab season thumbs"
+msgstr "Samodejno izberi sličico sezone"
+
+#: id:20383
+msgid "Selected folder contains a single video"
+msgstr "Mapa vsebuje samostojne videe"
+
+#: id:20384
+msgid "Link to TV show"
+msgstr "Povezava do TV serije"
+
+#: id:20385
+msgid "Remove link to TV show"
+msgstr "Odstrani povezavo do TV serije"
+
+#: id:20386
+msgid "Recently added movies"
+msgstr "Nazadnje dodani filmi"
+
+#: id:20387
+msgid "Recently added episodes"
+msgstr "Nazadnje dodane epizode"
+
+#: id:20388
+msgid "Studios"
+msgstr "Studiji"
+
+#: id:20389
+msgid "Music videos"
+msgstr "Videospoti"
+
+#: id:20390
+msgid "Recently added music videos"
+msgstr "Nazadnje dodani videospoti"
+
+#: id:20391
+msgid "Music video"
+msgstr "Videospot"
+
+#: id:20392
+msgid "Remove music video from library"
+msgstr "Odstrani videospot iz knjižnice"
+
+#: id:20393
+msgctxt "Auto context with id 20393"
+msgid "Music video information"
+msgstr "Informacije o videospotu"
+
+#: id:20394
+msgid "Loading music video information"
+msgstr "Nalagam informacije o videospotu"
+
+#: id:20395
+msgid "Mixed"
+msgstr "Mešano"
+
+#: id:20396
+msgid "Go to albums by artist"
+msgstr "Pojdi na albume po izvajalcu"
+
+#: id:20397
+msgid "Go to album"
+msgstr "Pojdi na album"
+
+#: id:20398
+msgid "Play song"
+msgstr "Predvajaj pesem"
+
+#: id:20399
+msgid "Go to music videos from album"
+msgstr "Pojdi na videospote iz albuma"
+
+#: id:20400
+msgid "Go to music videos by artist"
+msgstr "Pojdi na videospote po izvajalcu"
+
+#: id:20401
+msgid "Play music video"
+msgstr "Predvajaj videospot"
+
+#: id:20402
+msgid "Download actor thumbnails when adding to library"
+msgstr "Samodejno naloži sličico igralca ob dodajanju v knjižnico"
+
+#: id:20403
+msgid "Set actor thumb"
+msgstr "Nastavi sličico igralca"
+
+#: id:20405
+msgid "Remove episode bookmark"
+msgstr "Odstrani zaznamek epizode"
+
+#: id:20406
+msgid "Set episode bookmark"
+msgstr "Ustvari zaznamek epizode"
+
+#: id:20407
+msgid "Scraper settings"
+msgstr "Nastavitve ponudnika"
+
+#: id:20408
+msgid "Downloading music video information"
+msgstr "Prenašam informacije o videospotu"
+
+#: id:20409
+msgid "Downloading TV show information"
+msgstr "Prenašam informacije o TV seriji"
+
+#: id:20410
+msgid "Trailer"
+msgstr "Napovednik"
+
+#: id:20411
+msgid "Flatten"
+msgstr "Prikaži vse"
+
+#: id:20412
+msgid "Flatten TV shows"
+msgstr "Prikaži skupaj vse epizode TV serije"
+
+#: id:20413
+msgid "Get fanart"
+msgstr "Prenesi ozadje"
+
+#: id:20414
+msgid "Show Fanart in video and music libraries"
+msgstr "Prikaži ozadje v video in glasbenih knjižnicah"
+
+#: id:20415
+msgid "Scanning for new content"
+msgstr "Iščem nove vsebine"
+
+#: id:20416
+msgid "First aired"
+msgstr "Prvič na sporedu"
+
+#: id:20417
+msgid "Writer"
+msgstr "Scenarist"
+
+#: id:20419
+msgid "Replace file names with library titles"
+msgstr "Zamenjaj imena datotek z naslovi v knjižnici"
+
+#: id:20420
+msgctxt "Auto context with id 20420"
+msgid "Never"
+msgstr "Nikoli"
+
+#: id:20421
+msgid "If only one season"
+msgstr "Če vsebuje le eno sezono"
+
+#: id:20422
+msgid "Always"
+msgstr "Vedno"
+
+#: id:20423
+msgid "Has trailer"
+msgstr "Ima napovednik"
+
+#: id:20424
+msgid "False"
+msgstr "Nepravilno"
+
+#: id:20425
+msgid "Fanart slideshow"
+msgstr "Projekcija ozadij"
+
+#: id:20426
+msgid "Export to a single file or separate"
+msgstr "Izvozi v eno datoteko"
+
+#: id:20427
+msgid "files per entry?"
+msgstr "ali za vsak vnos ločeno?"
+
+#: id:20428
+msgid "Single file"
+msgstr "Ena datoteka"
+
+#: id:20429
+msgctxt "Auto context with id 20429"
+msgid "Separate"
+msgstr "Ločeno"
+
+#: id:20430
+msgid "Export thumbnails and fanart?"
+msgstr "Izvozi sličice in ozadja?"
+
+#: id:20431
+msgid "Overwrite old files?"
+msgstr "Prepiši stare datoteke?"
+
+#: id:20432
+msgid "Exclude path from library updates"
+msgstr "Izloči pot iz posodobitev knjižnice"
+
+#: id:20433
+msgid "Extract thumbnails and video information"
+msgstr "Izloči sličice in informacije o videu"
+
+#: id:20434
+msgid "Sets"
+msgstr "Zbirke"
+
+#: id:20435
+msgid "Set movieset thumb"
+msgstr "Nastavi sličico filmske zbirke"
+
+#: id:20436
+msgid "Export actor thumbs?"
+msgstr "Izvozi sličice izvajalcev?"
+
+#: id:20437
+msgid "Choose fanart"
+msgstr "Izberi ozadje"
+
+#: id:20438
+msgid "Local fanart"
+msgstr "Krajevno ozadje"
+
+#: id:20439
+msgid "No fanart"
+msgstr "Brez ozadja"
+
+#: id:20440
+msgid "Current fanart"
+msgstr "Trenutno ozadje"
+
+#: id:20441
+msgid "Remote fanart"
+msgstr "Oddaljeno ozadje"
+
+#: id:20442
+msgid "Change content"
+msgstr "Spremeni vsebino"
+
+#: id:20443
+msgid "Do you want to refresh info for all"
+msgstr "Želite osvežiti informacije"
+
+#: id:20444
+msgid "items within this path?"
+msgstr "vseh elementov s to potjo?"
+
+#: id:20445
+msgid "Fanart"
+msgstr "Ozadje"
+
+#: id:20446
+msgid "Locally stored information found."
+msgstr "Najdene krajevno shranjene informacije."
+
+#: id:20447
+msgid "Ignore and refresh from internet?"
+msgstr "Zanemari in prenesi z interneta?"
+
+#: id:20448
+msgid "Could not download information"
+msgstr "Ne morem prenesti informacij"
+
+#: id:20449
+msgid "Unable to connect to remote server"
+msgstr "Ne morem se povezati na oddaljeni strežnik"
+
+#: id:20450
+msgid "Would you like to continue scanning?"
+msgstr "Želite nadaljevati z iskanjem?"
+
+#: id:20451
+msgid "Countries"
+msgstr "Države"
+
+#: id:20452
+msgid "episode"
+msgstr "epizoda"
+
+#: id:20453
+msgid "episodes"
+msgstr "epizode"
+
+#: id:20454
+msgid "Listener"
+msgstr "Listener"
+
+#: id:20455
+msgid "Listeners"
+msgstr "Listeners"
+
+#: id:20456
+msgid "Set movieset fanart"
+msgstr "Nastavi ozadje filmske zbirke"
+
+#: id:20457
+msgid "Movie set"
+msgstr "Filmska zbirka"
+
+#: id:20458
+msgid "Group movies in sets"
+msgstr "Združi filme v zbirke"
+
+#: id:21330
+msgid "Show hidden files and directories"
+msgstr "Prikaži skrite datoteke in mape"
+
+#: id:21331
+msgid "TuxBox client"
+msgstr "TuxBox odjemalec"
+
+#: id:21332
+msgid "WARNING: Target TuxBox device is in recording-mode!"
+msgstr "OPOZORILO: Željena naprava TuxBox je v snemalnem načinu!"
+
+#: id:21333
+msgid "The stream will be stopped!"
+msgstr "Pretok bo ustavljen!"
+
+#: id:21334
+msgid "Zap to channel: %s failed!"
+msgstr "Povezava s kanalom: %s ni uspel!"
+
+#: id:21335
+msgid "Are you sure to start the stream?"
+msgstr "Ste prepričani, da želite začeti pretok?"
+
+#: id:21336
+msgid "Connecting to: %s"
+msgstr "Povezan z: %s"
+
+#: id:21337
+msgid "TuxBox device"
+msgstr "TuxBox naprava"
+
+#: id:21359
+msgid "Add media share..."
+msgstr "Dodaj multimedijsko skupno rabo..."
+
+#: id:21360
+msgid "Share video and music libraries through UPnP"
+msgstr "Deli video in glasbo preko UPnP"
+
+#: id:21364
+msgid "Edit media share"
+msgstr "Uredi multimedijsko skupno rabo"
+
+#: id:21365
+msgid "Remove media share"
+msgstr "Odstrani multimedijsko skupno rabo"
+
+#: id:21366
+msgid "Subtitle folder"
+msgstr "Mapa s podnapisi"
+
+#: id:21367
+msgid "Movie & alternate subtitle directory"
+msgstr "Film & dodatna mapa s podnapisi"
+
+#: id:21368
+msgid "Override ASS/SSA subtitles fonts"
+msgstr "Ponastavi pisave podnapisov ASS/SSA"
+
+#: id:21369
+msgid "Enable mouse and Touch Screen support"
+msgstr "Vključi miško in podporo za zaslone na dotik"
+
+#: id:21370
+msgid "Play navigation sounds during media playback"
+msgstr "Vključi navigacijske zvoke med predvajanjem vsebine"
+
+#: id:21371
+msgid "Thumbnail"
+msgstr "Sličica"
+
+#: id:21372
+msgid "Forced DVD player region"
+msgstr "Vsiljena DVD regija"
+
+#: id:21373
+msgid "Video output"
+msgstr "Izhod slike"
+
+#: id:21374
+msgid "Video aspect"
+msgstr "Razmerje slike"
+
+#: id:21375
+msgctxt "Auto context with id 21375"
+msgid "Normal"
+msgstr "Običajno"
+
+#: id:21376
+msgid "Letterbox"
+msgstr "Črni robovi"
+
+#: id:21377
+msgid "Widescreen"
+msgstr "Širokozaslonsko"
+
+#: id:21378
+msgid "Enable 480p"
+msgstr "Omogoči 480p"
+
+#: id:21379
+msgid "Enable 720p"
+msgstr "Omogoči 720p"
+
+#: id:21380
+msgid "Enable 1080i"
+msgstr "Omogoči 1080i"
+
+#: id:21381
+msgid "Enter name of new playlist"
+msgstr "Vnesi ime predvajalnega seznama"
+
+#: id:21382
+msgid "Show \"Add source\" buttons in file lists"
+msgstr "Prikaži gumb \"Dodaj izvor\" v seznamih datotek"
+
+#: id:21383
+msgid "Enable scrollbars"
+msgstr "Vključi drsnike"
+
+#: id:21384
+msgid "Make watched filtering a toggle in video library"
+msgstr "Omogoči preklop filtriranja pogledanih vsebin v video knjižnici"
+
+#: id:21385
+msgctxt "Auto context with id 21385"
+msgid "Open"
+msgstr "Odpri"
+
+#: id:21386
+msgid "Acoustic management level"
+msgstr "Upravljanje z akustičnimi nivoji"
+
+#: id:21387
+msgid "Fast"
+msgstr "Hitro"
+
+#: id:21388
+msgid "Quiet"
+msgstr "Tiho"
+
+#: id:21389
+msgid "Enable custom background"
+msgstr "Omogoči ozadja po meri"
+
+#: id:21390
+msgid "Power management level"
+msgstr "Upravljanje z nivoji varčevanja energije"
+
+#: id:21391
+msgid "High power"
+msgstr "Velika moč"
+
+#: id:21392
+msgid "Low power"
+msgstr "Nizka moč"
+
+#: id:21393
+msgid "High standby"
+msgstr "Dolga pripravljenost"
+
+#: id:21394
+msgid "Low standby"
+msgstr "Kratka pripravljenost"
+
+#: id:21395
+msgid "Unable to cache files bigger than 4GB"
+msgstr "Nemogoče začasno pomnenje datotek večjih od 4GB"
+
+#: id:21396
+msgid "Chapter"
+msgstr "Poglavje"
+
+#: id:21397
+msgid "High quality pixel shader v2"
+msgstr "Visoko kvalitetno senčenje v2"
+
+#: id:21398
+msgid "Enable playlist at startup"
+msgstr "Omogoči predvajalni seznam ob zagonu"
+
+#: id:21399
+msgid "Use tween animations"
+msgstr "Uporabi tween animacije"
+
+#: id:21400
+msgid "contains"
+msgstr "vsebuje"
+
+#: id:21401
+msgid "does not contain"
+msgstr "ne vsebuje"
+
+#: id:21402
+msgid "is"
+msgstr "je"
+
+#: id:21403
+msgid "is not"
+msgstr "ni"
+
+#: id:21404
+msgid "starts with"
+msgstr "prične z"
+
+#: id:21405
+msgid "ends with"
+msgstr "konča z"
+
+#: id:21406
+msgid "greater than"
+msgstr "večje kot"
+
+#: id:21407
+msgid "less than"
+msgstr "manj kot"
+
+#: id:21408
+msgid "after"
+msgstr "po"
+
+#: id:21409
+msgid "before"
+msgstr "pred"
+
+#: id:21410
+msgid "in the last"
+msgstr "v zadnjih"
+
+#: id:21411
+msgid "not in the last"
+msgstr "ne v zadnjih"
+
+#: id:21412
+msgid "Scrapers"
+msgstr "Ponudniki"
+
+#: id:21413
+msgid "Default movie scraper"
+msgstr "Privzet ponudnik filmov"
+
+#: id:21414
+msgid "Default tvshow scraper"
+msgstr "Privzet ponudnik TV serij"
+
+#: id:21415
+msgid "Default music video scraper"
+msgstr "Privzet ponudnik videospotov"
+
+#: id:21416
+msgid "Enable fallback based on scraper language"
+msgstr "Omogoči zasilno vračanje glede na jezik ponudnika"
+
+#: id:21417
+msgid "- Settings"
+msgstr "- Nastavitve"
+
+#: id:21418
+msgid "Multilingual"
+msgstr "Večjezikovno"
+
+#: id:21419
+msgid "No scrapers present"
+msgstr "Ni prisotnih ponudnikov"
+
+#: id:21420
+msgid "Value to match"
+msgstr "Vrednost ustrezanja"
+
+#: id:21421
+msgid "Smart playlist rule"
+msgstr "Pravilo pametnega predvajalnega seznama"
+
+#: id:21422
+msgid "Match items where"
+msgstr "Označi elemente kjer"
+
+#: id:21423
+msgid "New rule..."
+msgstr "Novo pravilo..."
+
+#: id:21424
+msgid "Items must match"
+msgstr "Elementi morajo ustrezati"
+
+#: id:21425
+msgid "all of the rules"
+msgstr "vsem pravilom"
+
+#: id:21426
+msgid "one or more of the rules"
+msgstr "enemu ali več pravilom"
+
+#: id:21427
+msgid "Limit to"
+msgstr "Omeji na"
+
+#: id:21428
+msgid "No limit"
+msgstr "Brez omejitve"
+
+#: id:21429
+msgid "Order by"
+msgstr "Razvrščeno po"
+
+#: id:21430
+msgid "ascending"
+msgstr "naraščajoče"
+
+#: id:21431
+msgid "descending"
+msgstr "padajoče"
+
+#: id:21432
+msgid "Edit smart playlist"
+msgstr "Uredi pameten predvajalni seznam"
+
+#: id:21433
+msgid "Name of the playlist"
+msgstr "Ime predvajalnega sezmama"
+
+#: id:21434
+msgid "Find items where"
+msgstr "Najdi pesmi kjer"
+
+#: id:21435
+msgid "Edit"
+msgstr "Uredi"
+
+#: id:21436
+msgid "%i items"
+msgstr "%i elementov"
+
+#: id:21437
+msgid "New smart playlist..."
+msgstr "Nov pameten predvajalni seznam..."
+
+#: id:21438
+msgid "%c Drive"
+msgstr "%c pogon"
+
+#: id:21439
+msgid "Edit party mode rules"
+msgstr "Uredi pravila zabavnega načina"
+
+#: id:21440
+msgid "Home folder"
+msgstr "Domača mapa"
+
+#: id:21441
+msgid "Watched count"
+msgstr "Število ogledov"
+
+#: id:21442
+msgid "Episode title"
+msgstr "Ime epizode"
+
+#: id:21443
+msgid "Video resolution"
+msgstr "Ločljivost slike"
+
+#: id:21444
+msgid "Audio channels"
+msgstr "Zvočni kanali"
+
+#: id:21445
+msgid "Video codec"
+msgstr "Slikovni kodek"
+
+#: id:21446
+msgid "Audio codec"
+msgstr "Zvočni kodek"
+
+#: id:21447
+msgid "Audio language"
+msgstr "Jezik zvoka"
+
+#: id:21448
+msgid "Subtitle language"
+msgstr "Jezik podnapisov"
+
+#: id:21449
+msgid "Remote control sends keyboard presses"
+msgstr "Oddaljeno upravljanje pošilja ukaze tipkovnice"
+
+#: id:21450
+msgid "- Edit"
+msgstr "- Uredi"
+
+#: id:21451
+msgid "Internet connection required."
+msgstr "Potrebna je internetna povezava."
+
+#: id:21452
+msgid "Get More..."
+msgstr "Prenesi več..."
+
+#: id:21453
+msgid "Root filesystem"
+msgstr "Korenski datotečni sistem"
+
+#: id:21454
+msgid "Cache full"
+msgstr "Začasni pomnilnik poln"
+
+#: id:21455
+msgid "Cache filled before reaching required amount for continous playback"
+msgstr "Začasni pomnilnik se je zapolnil, preden je bila dosežen nivo za tekoče predvajanje"
+
+#: id:21460
+msgid "Subtitle location"
+msgstr "Položaj podnapisov"
+
+#: id:21461
+msgid "Fixed"
+msgstr "Fiksno"
+
+#: id:21462
+msgid "Bottom of video"
+msgstr "Dno videa"
+
+#: id:21463
+msgid "Below video"
+msgstr "Pod videom"
+
+#: id:21464
+msgid "Top of video"
+msgstr "Vrh videa"
+
+#: id:21465
+msgid "Above video"
+msgstr "Nad videom"
+
+#: id:21800
+msgid "File name"
+msgstr "Ime datoteke"
+
+#: id:21801
+msgid "File path"
+msgstr "Pot datoteke"
+
+#: id:21802
+msgid "File size"
+msgstr "Velikost datoteke"
+
+#: id:21803
+msgid "File date/time"
+msgstr "Čas/datum datoteke"
+
+#: id:21804
+msgid "Slide index"
+msgstr "Številka diapozitiva"
+
+#: id:21805
+msgctxt "Auto context with id 21805"
+msgid "Resolution"
+msgstr "Ločljivost"
+
+#: id:21806
+msgctxt "Auto context with id 21806"
+msgid "Comment"
+msgstr "Komentar"
+
+#: id:21807
+msgid "Colour/B&W"
+msgstr "Barvno/ČB"
+
+#: id:21808
+msgid "JPEG process"
+msgstr "JPEG postopek"
+
+#: id:21820
+msgid "Date/Time"
+msgstr "Datum/Čas"
+
+#: id:21821
+msgid "Description"
+msgstr "Opis"
+
+#: id:21822
+msgid "Camera make"
+msgstr "Znamka fotoaparata"
+
+#: id:21823
+msgid "Camera model"
+msgstr "Model fotoaparata"
+
+#: id:21824
+msgid "EXIF comment"
+msgstr "EXIF komentar"
+
+#: id:21825
+msgid "Firmware"
+msgstr "Firmware"
+
+#: id:21826
+msgid "Aperture"
+msgstr "Zaslonka"
+
+#: id:21827
+msgid "Focal length"
+msgstr "Goriščna razdalja"
+
+#: id:21828
+msgid "Focus distance"
+msgstr "Oddaljenost ostrenja"
+
+#: id:21829
+msgid "Exposure"
+msgstr "Exposure"
+
+#: id:21830
+msgid "Exposure time"
+msgstr "Exposure Time"
+
+#: id:21831
+msgid "Exposure bias"
+msgstr "Exposure Bias"
+
+#: id:21832
+msgid "Exposure mode"
+msgstr "Exposure Mode"
+
+#: id:21833
+msgid "Flash used"
+msgstr "Uporaba bliskavice"
+
+#: id:21834
+msgid "White-balance"
+msgstr "Beline"
+
+#: id:21835
+msgid "Light source"
+msgstr "Vir svetlobe"
+
+#: id:21836
+msgid "Metering mode"
+msgstr "Metering Mode"
+
+#: id:21837
+msgid "ISO"
+msgstr "ISO"
+
+#: id:21838
+msgid "Digital zoom"
+msgstr "Digitalna povečava"
+
+#: id:21839
+msgid "CCD width"
+msgstr "Širina CCD"
+
+#: id:21840
+msgid "GPS latitude"
+msgstr "GPS Zemljepisna širina"
+
+#: id:21841
+msgid "GPS longitude"
+msgstr "GPS Zemljepisna dolžina"
+
+#: id:21842
+msgid "GPS altitude"
+msgstr "GPS Nadmorska višina"
+
+#: id:21843
+msgid "Orientation"
+msgstr "Orientacija"
+
+#: id:21860
+msgid "Supplemental categories"
+msgstr "Nadomestne kategorije"
+
+#: id:21861
+msgid "Keywords"
+msgstr "Ključne besede"
+
+#: id:21862
+msgid "Caption"
+msgstr "Zapis"
+
+#: id:21863
+msgid "Author"
+msgstr "Avtor"
+
+#: id:21864
+msgid "Headline"
+msgstr "Naslov"
+
+#: id:21865
+msgid "Special instructions"
+msgstr "Posebna navodila"
+
+#: id:21866
+msgid "Category"
+msgstr "Kategorija"
+
+#: id:21867
+msgid "Byline"
+msgstr "Byline"
+
+#: id:21868
+msgid "Byline title"
+msgstr "Byline Title"
+
+#: id:21869
+msgid "Credit"
+msgstr "Zasluge"
+
+#: id:21870
+msgid "Source"
+msgstr "Vir"
+
+#: id:21871
+msgid "Copyright notice"
+msgstr "Avtorske pravice"
+
+#: id:21872
+msgid "Object name"
+msgstr "Ime predmeta"
+
+#: id:21873
+msgid "City"
+msgstr "Mesto"
+
+#: id:21874
+msgid "State"
+msgstr "Zvezna država"
+
+#: id:21875
+msgctxt "Auto context with id 21875"
+msgid "Country"
+msgstr "Država"
+
+#: id:21876
+msgid "Original Tx Reference"
+msgstr "Izvorna Tx referenca"
+
+#: id:21877
+msgid "Date created"
+msgstr "Datum objave"
+
+#: id:21878
+msgid "Copyright flag"
+msgstr "Oznaka avtorskih pravic"
+
+#: id:21879
+msgid "Country code"
+msgstr "Koda države"
+
+#: id:21880
+msgid "Reference service"
+msgstr "Storitev referenc"
+
+#: id:21881
+msgid "Allow control of XBMC via UPnP"
+msgstr "Dovoli upravljanje z XBMC preko UPnP"
+
+#: id:21882
+msgid "Attempt to skip introduction before DVD menu"
+msgstr "Poskusi preskočiti uvod pred DVD menujem"
+
+#: id:21883
+msgid "Saved music"
+msgstr "Shranjena glasba"
+
+#: id:21884
+msgid "Query info for all artists"
+msgstr "Prenesi informacije vseh izvajalcev"
+
+#: id:21885
+msgid "Downloading album information"
+msgstr "Prenašam informacije o albumu"
+
+#: id:21886
+msgid "Downloading artist information"
+msgstr "Prenašam informacije o izvajalcu"
+
+#: id:21887
+msgid "Biography"
+msgstr "Življenjepis"
+
+#: id:21888
+msgid "Discography"
+msgstr "Diskografija"
+
+#: id:21889
+msgid "Searching artist"
+msgstr "Iščem izvajalca"
+
+#: id:21890
+msgid "Select artist"
+msgstr "Izberi izvajalca"
+
+#: id:21891
+msgctxt "Auto context with id 21891"
+msgid "Artist information"
+msgstr "Informacije o izvajalcu"
+
+#: id:21892
+msgid "Instruments"
+msgstr "Inštrumenti"
+
+#: id:21893
+msgid "Born"
+msgstr "Rojstvo"
+
+#: id:21894
+msgid "Formed"
+msgstr "Ustanovljena"
+
+#: id:21895
+msgid "Themes"
+msgstr "Teme"
+
+#: id:21896
+msgid "Disbanded"
+msgstr "Razidena"
+
+#: id:21897
+msgid "Died"
+msgstr "Smrt"
+
+#: id:21898
+msgid "Years active"
+msgstr "Leta aktivnosti"
+
+#: id:21899
+msgid "Label"
+msgstr "Založba"
+
+#: id:21900
+msgid "Born/Formed"
+msgstr "Rojstvo/Ustanovitev"
+
+#: id:22000
+msgid "Update library on startup"
+msgstr "Posodobi knjižnico ob zagonu"
+
+#: id:22001
+msgid "Hide progress of library updates"
+msgstr "Posodabljaj knjižnico v ozadju"
+
+#: id:22002
+msgid "- DNS suffix"
+msgstr "- DNS pripona"
+
+#: id:22003
+msgid "%2.3fs"
+msgstr "%2.3fs"
+
+#: id:22004
+msgid "Delayed by: %2.3fs"
+msgstr "Zaostanek za: %2.3fs"
+
+#: id:22005
+msgid "Ahead by: %2.3fs"
+msgstr "Prehitevanje za: %2.3fs"
+
+#: id:22006
+msgid "Subtitle offset"
+msgstr "Zamik podnapisov"
+
+#: id:22007
+msgid "OpenGL vendor:"
+msgstr "Gonilnik OpenGL:"
+
+#: id:22008
+msgid "OpenGL renderer:"
+msgstr "Izris OpenGL:"
+
+#: id:22009
+msgid "OpenGL version:"
+msgstr "Različica OpenGL:"
+
+#: id:22010
+msgid "GPU temperature:"
+msgstr "Temperatura GPU:"
+
+#: id:22011
+msgid "CPU temperature:"
+msgstr "Temperatura CPU:"
+
+#: id:22012
+msgid "Total memory"
+msgstr "Celoten pomnilnik"
+
+#: id:22013
+msgid "Profile data"
+msgstr "Podatki o profilu"
+
+#: id:22014
+msgid "Use dim if paused during video playback"
+msgstr "Zatemni med prekinitvijo predvajanja videa"
+
+#: id:22015
+msgid "All recordings"
+msgstr "Vsi posnetki"
+
+#: id:22016
+msgid "By title"
+msgstr "Po naslovu"
+
+#: id:22017
+msgid "By group"
+msgstr "Po skupini"
+
+#: id:22018
+msgid "Live channels"
+msgstr "Programi v živo"
+
+#: id:22019
+msgid "Recordings by title"
+msgstr "Posnetki po naslovu"
+
+#: id:22020
+msgid "Guide"
+msgstr "Vodič"
+
+#: id:22021
+msgid "Allowed error in aspect ratio to minimize black bars"
+msgstr "Popači razmerje slike, da se izognete črnim robovom"
+
+#: id:22022
+msgid "Show video files in listings"
+msgstr "V seznamih prikaži video datoteke"
+
+#: id:22023
+msgid "DirectX vendor:"
+msgstr "Gonilnik DirectX:"
+
+#: id:22024
+msgid "Direct3D version:"
+msgstr "Različica Direct3D:"
+
+#: id:22030
+msgctxt "Auto context with id 22030"
+msgid "Font"
+msgstr "Pisava"
+
+#: id:22031
+msgctxt "Auto context with id 22031"
+msgid "- Size"
+msgstr "- Velikost"
+
+#: id:22032
+msgctxt "Auto context with id 22032"
+msgid "- Colours"
+msgstr "- Barve"
+
+#: id:22033
+msgid "- Charset"
+msgstr "- Nabor znakov"
+
+#: id:22034
+msgid "Export karaoke titles as HTML"
+msgstr "Izvozi naslove karaok kot HTML"
+
+#: id:22035
+msgid "Export karaoke titles as CSV"
+msgstr "Izvozi naslove karaok kot CSV"
+
+#: id:22036
+msgid "Import karaoke titles..."
+msgstr "Uvozi naslove karaok..."
+
+#: id:22037
+msgid "Show song selector automatically"
+msgstr "Samodejno prikaži izbor pesmi"
+
+#: id:22038
+msgid "Export karaoke titles..."
+msgstr "Izvozi naslove karaok..."
+
+#: id:22039
+msgid "Enter song number"
+msgstr "Vnesi številko pesmi"
+
+#: id:22040
+msgid "white/green"
+msgstr "bela/zelena"
+
+#: id:22041
+msgid "white/red"
+msgstr "bela/rdeča"
+
+#: id:22042
+msgid "white/blue"
+msgstr "bela/modra"
+
+#: id:22043
+msgid "black/white"
+msgstr "črna/bela"
+
+#: id:22079
+msgid "Default select action"
+msgstr "Privzeta možnost izbire"
+
+#: id:22080
+msgid "Choose"
+msgstr "Izberi"
+
+#: id:22081
+msgid "Show Information"
+msgstr "Prikaži več informacij"
+
+#: id:22082
+msgid "More..."
+msgstr "Več..."
+
+#: id:22083
+msgid "Play all"
+msgstr "Predvajaj vse"
+
+#: id:23049
+msgid "Teletext not available"
+msgstr "Teletekst ni na voljo"
+
+#: id:23050
+msgid "Activate Teletext"
+msgstr "Vključi teletekst"
+
+#: id:23051
+msgid "Part %i"
+msgstr "Del %i"
+
+#: id:23052
+msgid "Buffering %i bytes"
+msgstr "Medpomnjenje %i bytov"
+
+#: id:23053
+msgid "Stopping"
+msgstr "Ustavlja"
+
+#: id:23054
+msgid "Running"
+msgstr "Teče"
+
+#: id:23100
+msgid "External Player Active"
+msgstr "Aktiven zunanji predvajalnik"
+
+#: id:23101
+msgid "Click OK to terminate the player"
+msgstr "Kliknite OK za prekinitev predvajalnika"
+
+#: id:23104
+msgid "Click OK when playback has ended"
+msgstr "Kliknite OK, ko se predvajanje konča"
+
+#: id:24000
+msgid "Add-on"
+msgstr "Dodatek"
+
+#: id:24001
+msgid "Add-ons"
+msgstr "Dodatki"
+
+#: id:24002
+msgid "Add-on options"
+msgstr "Možnosti dodatka"
+
+#: id:24003
+msgid "Add-on Information"
+msgstr "Informacije o dodatku"
+
+#: id:24005
+msgctxt "Auto context with id 24005"
+msgid "Media sources"
+msgstr "Multimedijski viri"
+
+#: id:24007
+msgctxt "Auto context with id 24007"
+msgid "Movie information"
+msgstr "Informacije o filmu"
+
+#: id:24008
+msgctxt "Auto context with id 24008"
+msgid "Screensaver"
+msgstr "Ohranjevalnik zaslona"
+
+#: id:24009
+msgid "Script"
+msgstr "Skripta"
+
+#: id:24010
+msgctxt "Auto context with id 24010"
+msgid "Visualization"
+msgstr "Vizualizacija"
+
+#: id:24011
+msgid "Add-on repository"
+msgstr "Skladišče dodatkov"
+
+#: id:24012
+msgctxt "Auto context with id 24012"
+msgid "Subtitles"
+msgstr "Podnapisi"
+
+#: id:24013
+msgid "Lyrics"
+msgstr "Besedilo pesmi"
+
+#: id:24014
+msgid "TV information"
+msgstr "Informacije o TV serijah"
+
+#: id:24015
+msgctxt "Auto context with id 24015"
+msgid "Music video information"
+msgstr "Informacije o videospotih"
+
+#: id:24016
+msgctxt "Auto context with id 24016"
+msgid "Album information"
+msgstr "Informacije o albumih"
+
+#: id:24017
+msgctxt "Auto context with id 24017"
+msgid "Artist information"
+msgstr "Informacije o izvajalcih"
+
+#: id:24018
+msgctxt "Auto context with id 24018"
+msgid "Services"
+msgstr "Storitve"
+
+#: id:24020
+msgid "Configure"
+msgstr "Prilagodi"
+
+#: id:24021
+msgctxt "Auto context with id 24021"
+msgid "Disable"
+msgstr "Onemogoči"
+
+#: id:24022
+msgid "Enable"
+msgstr "Omogoči"
+
+#: id:24023
+msgid "Add-on disabled"
+msgstr "Dodatek je onemogočen"
+
+#: id:24027
+msgctxt "Auto context with id 24027"
+msgid "Weather"
+msgstr "Vreme"
+
+#: id:24028
+msgid "Weather.com (standard)"
+msgstr "Weather.com (običajno)"
+
+#: id:24030
+msgid "This Add-on can not be configured"
+msgstr "Tega dodatka ni mogoče dodatno nastaviti"
+
+#: id:24031
+msgid "Error loading settings"
+msgstr "Napaka pri nalaganju nastavitev"
+
+#: id:24032
+msgid "All Add-ons"
+msgstr "Vsi dodatki"
+
+#: id:24033
+msgid "Get Add-ons"
+msgstr "Prenesi dodatke"
+
+#: id:24034
+msgid "Check for updates"
+msgstr "Preveri za posodobitve"
+
+#: id:24035
+msgid "Force refresh"
+msgstr "Vsili osvežitev"
+
+#: id:24036
+msgid "Change log"
+msgstr "Zgodovina sprememb"
+
+#: id:24037
+msgid "Uninstall"
+msgstr "Odstrani"
+
+#: id:24038
+msgid "Install"
+msgstr "Namesti"
+
+#: id:24039
+msgid "Disabled Add-ons"
+msgstr "Onemogočeni dodatki"
+
+#: id:24040
+msgid "(Clear the current setting)"
+msgstr "(Počisti trenutne nastavitve)"
+
+#: id:24041
+msgid "Install from zip file"
+msgstr "Namesti iz zip datoteke"
+
+#: id:24042
+msgid "Downloading %i%%"
+msgstr "Prenašam %i%%"
+
+#: id:24043
+msgid "Available Updates"
+msgstr "Na voljo so posodobitve"
+
+#: id:24044
+msgid "Dependencies not met"
+msgstr "Odvisnostim ni zadoščeno"
+
+#: id:24045
+msgid "Add-on does not have the correct structure"
+msgstr "Dodatek nima pravilne strukture"
+
+#: id:24046
+msgid "%s is used by the following installed add-on(s)"
+msgstr "%s je v uporabi s strani sledečih dodatkov"
+
+#: id:24047
+msgid "This add-on cannot be uninstalled"
+msgstr "Dodatka ni mogoče odstraniti"
+
+#: id:24048
+msgid "Rollback"
+msgstr "Razveljavi"
+
+#: id:24050
+msgid "Available Add-ons"
+msgstr "Dodatki na voljo"
+
+#: id:24051
+msgid "Version:"
+msgstr "Različica:"
+
+#: id:24052
+msgid "Disclaimer"
+msgstr "Opozorilo"
+
+#: id:24053
+msgid "License:"
+msgstr "Licenca:"
+
+#: id:24054
+msgid "Changelog"
+msgstr "Zgodovina sprememb"
+
+#: id:24059
+msgid "Would you like to enable this Add-on?"
+msgstr "Želite omogočiti ta dodatek?"
+
+#: id:24060
+msgid "Would you like to disable this Add-on?"
+msgstr "Želite onemogočiti ta dodatek?"
+
+#: id:24061
+msgid "Add-on update available!"
+msgstr "Na voljo je posodobitev dodatka!"
+
+#: id:24062
+msgid "Enabled Add-ons"
+msgstr "Omogočeni dodatki"
+
+#: id:24063
+msgid "Auto update"
+msgstr "Samodejna posodobitev"
+
+#: id:24064
+msgid "Add-on enabled"
+msgstr "Dodatek je omogočen"
+
+#: id:24065
+msgid "Add-on updated"
+msgstr "Dodatek je posodobljen"
+
+#: id:24066
+msgid "Cancel Add-on download?"
+msgstr "Prekličem prenos dodatka?"
+
+#: id:24067
+msgid "Currently downloading Add-ons"
+msgstr "Dodatki, ki se trenutno prenašajo"
+
+#: id:24068
+msgid "Update available"
+msgstr "Na voljo je posodobitev"
+
+#: id:24069
+msgid "Update"
+msgstr "Posodobitev"
+
+#: id:24070
+msgid "Add-on could not be loaded."
+msgstr "Dodatka ni mogoče zagnati."
+
+#: id:24071
+msgid "An unknown error has occurred."
+msgstr "Pojavila se je neznana napaka."
+
+#: id:24072
+msgid "Settings required"
+msgstr "Potrebne so dodatne nastavitve"
+
+#: id:24073
+msgid "Could not connect"
+msgstr "Ni se mogoče povezati"
+
+#: id:24074
+msgid "Needs to restart"
+msgstr "Potrebuje ponoven zagon"
+
+#: id:24075
+msgctxt "Auto context with id 24075"
+msgid "Disable"
+msgstr "Onemogoči"
+
+#: id:24076
+msgid "Add-on Required"
+msgstr "Zahtevan dodatek"
+
+#: id:24080
+msgid "Try to reconnect?"
+msgstr "Poskusim ponovno povezati?"
+
+#: id:24089
+msgid "Add-on restarts"
+msgstr "Ponovni zagoni dodatkov"
+
+#: id:24090
+msgid "Lock Add-on manager"
+msgstr "Zakleni upravljalnik z dodatki"
+
+#: id:24094
+msgid "(current)"
+msgstr "(trenuten)"
+
+#: id:24095
+msgid "(blacklisted)"
+msgstr "(nedelujoč)"
+
+#: id:24096
+msgid "Add-on has been marked as broken in repository."
+msgstr "Dodatek je bil v skladišču označen kot nedelujoč."
+
+#: id:24097
+msgid "Would you like to disable it on your system?"
+msgstr "Ga želite onemogočiti na vašem sistemu?"
+
+#: id:24098
+msgid "Broken"
+msgstr "Nedelujoč"
+
+#: id:24099
+msgid "Would you like to switch to this skin?"
+msgstr "Želite preklopiti na to preobleko?"
+
+#: id:24100
+msgid "To use this feature you must download an Add-on:"
+msgstr "Za uporabo te funkcije potrebujete dodatek:"
+
+#: id:24101
+msgid "Would you like to download this Add-on?"
+msgstr "Želite prenesti ta dodatek?"
+
+#: id:25000
+msgid "Notifications"
+msgstr "Obvestila"
+
+#: id:29800
+msgid "Library Mode"
+msgstr "Način knjižnice"
+
+#: id:29801
+msgid "QWERTY keyboard"
+msgstr "Tipkovnica QWERTY"
+
+#: id:29802
+msgid "Passthrough Audio in use"
+msgstr "Pretvori zvok v uporabi"
+
+#: id:33001
+msgid "Trailer quality"
+msgstr "Kvaliteta napovednika"
+
+#: id:33002
+msgid "Stream"
+msgstr "Pretok"
+
+#: id:33003
+msgid "Download"
+msgstr "Prenesi"
+
+#: id:33004
+msgid "Download & play"
+msgstr "Prenesi & predvajaj"
+
+#: id:33005
+msgid "Download & save"
+msgstr "Prenesi & shrani"
+
+#: id:33006
+msgid "Today"
+msgstr "Danes"
+
+#: id:33007
+msgid "Tomorrow"
+msgstr "Jutri"
+
+#: id:33008
+msgid "Saving"
+msgstr "Shranjujem"
+
+#: id:33009
+msgid "Copying"
+msgstr "Kopiram"
+
+#: id:33010
+msgid "Set download directory"
+msgstr "Nastavi mapo prenosov"
+
+#: id:33011
+msgid "Search duration"
+msgstr "Trajanje iskanja"
+
+#: id:33012
+msgid "Short"
+msgstr "Kratko"
+
+#: id:33013
+msgid "Long"
+msgstr "Dolgo"
+
+#: id:33014
+msgid "Use DVD player instead of regular player"
+msgstr "Uporabi DVD predvajalnik namesto običajnega"
+
+#: id:33015
+msgid "Ask for download before playing video"
+msgstr "Vprašaj za prenos pred predvajanjem"
+
+#: id:33016
+msgid "Clips"
+msgstr "Odlomki"
+
+#: id:33017
+msgid "Restart plugin to enable"
+msgstr "Ponovno zaženi vtičnik za vklop"
+
+#: id:33018
+msgid "Tonight"
+msgstr "Zvečer"
+
+#: id:33019
+msgid "Tomorrow Night"
+msgstr "Jutri zvečer"
+
+#: id:33020
+msgid "Condition"
+msgstr "Stanje"
+
+#: id:33021
+msgid "Precipitation"
+msgstr "Padavine"
+
+#: id:33022
+msgid "Precip"
+msgstr "Dež"
+
+#: id:33023
+msgid "Humid"
+msgstr "Vlažno"
+
+#: id:33024
+msgid "Feels"
+msgstr "Občuti se"
+
+#: id:33025
+msgid "Observed"
+msgstr "Opazovano"
+
+#: id:33026
+msgid "Departure from normal"
+msgstr "Odmik od običajnega"
+
+#: id:33027
+msgid "Sunrise"
+msgstr "Sončni vzhod"
+
+#: id:33028
+msgid "Sunset"
+msgstr "Sončni zahod"
+
+#: id:33029
+msgid "Details"
+msgstr "Podrobnosti"
+
+#: id:33030
+msgid "Outlook"
+msgstr "Izgled"
+
+#: id:33031
+msgid "Coverflow"
+msgstr "Coverflow"
+
+#: id:33032
+msgid "Translate text"
+msgstr "Prevedi besedilo"
+
+#: id:33033
+msgid "Map list %s category"
+msgstr "Zgradi seznam %s kategorije"
+
+#: id:33034
+msgid "36 Hour"
+msgstr "36 ur"
+
+#: id:33035
+msgid "Maps"
+msgstr "Zemljevidi"
+
+#: id:33036
+msgid "Hourly"
+msgstr "Vsako uro"
+
+#: id:33037
+msgid "Weekend"
+msgstr "Vikend"
+
+#: id:33038
+msgid "%s day"
+msgstr "%s dan"
+
+#: id:33049
+msgid "Alert"
+msgstr "Opozorilo"
+
+#: id:33050
+msgid "Alerts"
+msgstr "Opozorila"
+
+#: id:33051
+msgid "Choose Your"
+msgstr "Izberite vaš"
+
+#: id:33052
+msgid "Check"
+msgstr "Preveri"
+
+#: id:33053
+msgctxt "Auto context with id 33053"
+msgid "Configure the"
+msgstr "Nastavite"
+
+#: id:33054
+msgid "Seasons"
+msgstr "Letni časi"
+
+#: id:33055
+msgid "Use your"
+msgstr "Uporabite vaš"
+
+#: id:33056
+msgid "Watch your"
+msgstr "Glejte vaš"
+
+#: id:33057
+msgid "Listen to"
+msgstr "Poslušajte"
+
+#: id:33058
+msgid "View your"
+msgstr "Poglejte vaš"
+
+#: id:33059
+msgctxt "Auto context with id 33059"
+msgid "Configure the"
+msgstr "Nastavite"
+
+#: id:33060
+msgid "Power"
+msgstr "Zapusti"
+
+#: id:33061
+msgid "Menu"
+msgstr "Menu"
+
+#: id:33062
+msgid "Play the"
+msgstr "Predvajaj"
+
+#: id:33063
+msgid "Options"
+msgstr "Možnosti"
+
+#: id:33065
+msgid "Editor"
+msgstr "Urejevalnik"
+
+#: id:33066
+msgid "About your"
+msgstr "O vašem"
+
+#: id:33067
+msgid "Star rating"
+msgstr "Ocena"
+
+#: id:33068
+msgid "Background"
+msgstr "Ozadje"
+
+#: id:33069
+msgid "Backgrounds"
+msgstr "Ozadja"
+
+#: id:33070
+msgid "Custom background"
+msgstr "Poljubno ozadje"
+
+#: id:33071
+msgid "Custom backgrounds"
+msgstr "Poljubna ozadja"
+
+#: id:33072
+msgid "View Readme"
+msgstr "Preberite Berime"
+
+#: id:33073
+msgid "View Changelog"
+msgstr "Preberite Zgodovino sprememb"
+
+#: id:33074
+msgid "This version of %s requires an"
+msgstr "Ta različica %s za delovanje zahteva"
+
+#: id:33075
+msgid "XBMC revision of %s or greater to run."
+msgstr "XBMC revizije %s ali višje."
+
+#: id:33076
+msgid "Please update XBMC."
+msgstr "Posodobite XBMC."
+
+#: id:33077
+msgid "No data found!"
+msgstr "Ni najdenih nobenih podatkov!"
+
+#: id:33078
+msgid "Next page"
+msgstr "Naslednja stran"
+
+#: id:33079
+msgid "Love"
+msgstr "Ljubim"
+
+#: id:33080
+msgid "Hate"
+msgstr "Sovražim"
+
+#: id:33081
+msgid "This file is stacked, select the part you want to play from."
+msgstr "Ta datoteka je združena. Izberite del za predvajanje."
+
+#: id:33082
+msgid "Path to script"
+msgstr "Pot do skripte"
+
+#: id:33083
+msgid "Enable custom script button"
+msgstr "Vključi gumb poljubne skripte"
+
+#: id:33100
+msgid "Failed to start"
+msgstr "Ni mogoče zagnati"
+
+#: id:33101
+msgid "Webserver"
+msgstr "Spletni strežnik"
+
+#: id:33102
+msgid "Event Server"
+msgstr "Strežnik dogodkov"
+
+#: id:33103
+msgid "Remote communication server"
+msgstr "Strežnik oddaljene komunikacije"
+
+#: id:33200
+msgid "Detected New Connection"
+msgstr "Zaznana nova povezava"
+
+#: id:34000
+msgid "Lame"
+msgstr "Lame"
+
+#: id:34001
+msgid "Vorbis"
+msgstr "Vorbis"
+
+#: id:34002
+msgid "Wav"
+msgstr "Wav"
+
+#: id:34003
+msgid "DXVA2"
+msgstr "DXVA2"
+
+#: id:34004
+msgid "VAAPI"
+msgstr "VAAPI"
+
+#: id:34005
+msgid "Flac"
+msgstr "Flac"
+
+#: id:34100
+msgid "Speaker Configuration"
+msgstr "Sistem zvočnikov"
+
+#: id:34101
+msgid "2.0"
+msgstr "2.0"
+
+#: id:34102
+msgid "2.1"
+msgstr "2.1"
+
+#: id:34103
+msgid "3.0"
+msgstr "3.0"
+
+#: id:34104
+msgid "3.1"
+msgstr "3.1"
+
+#: id:34105
+msgid "4.0"
+msgstr "4.0"
+
+#: id:34106
+msgid "4.1"
+msgstr "4.1"
+
+#: id:34107
+msgid "5.0"
+msgstr "5.0"
+
+#: id:34108
+msgid "5.1"
+msgstr "5.1"
+
+#: id:34109
+msgid "7.0"
+msgstr "7.0"
+
+#: id:34110
+msgid "7.1"
+msgstr "7.1"
+
+#: id:34201
+msgid "Can't find a next item to play"
+msgstr "Ni mogoče najti naslednjega predmeta za predvajanje"
+
+#: id:34202
+msgid "Can't find a previous item to play"
+msgstr "Ni mogoče najti prejšnjega predmeta za predvajanje"
+
+#: id:34300
+msgid "Failed to start zeroconf"
+msgstr ""
+
+#: id:34301
+msgid "Is Apple's Bonjour Service installed? See log for more info."
+msgstr ""
+
+#: id:34400
+msgid "Video Rendering"
+msgstr ""
+
+#: id:34401
+msgid "Failed to init video filters/scalers, falling back to bilinear scaling"
+msgstr ""
+
+#: id:34402
+msgid "Failed to initialize audio device"
+msgstr ""
+
+#: id:34403
+msgid "Check your audiosettings"
+msgstr ""
+
+#: id:34404
+msgid "Use gestures for navigation:"
+msgstr ""
+
+#: id:34405
+msgid "1 finger swipe left,right,up,down for cursors"
+msgstr ""
+
+#: id:34406
+msgid "2 finger swipe left for backspace"
+msgstr ""
+
+#: id:34407
+msgid "1 finger single tap for enter"
+msgstr ""
+
+#: id:34408
+msgid "2 finger single tap for contextmenu"
+msgstr ""
+
+#: id:35000
+msgid "Peripherals"
+msgstr "Naprave"
+
+#: id:35001
+msgid "Generic HID device"
+msgstr "Generična naprava HID"
+
+#: id:35002
+msgid "Generic network adapter"
+msgstr "Generični omrežni vmesnik"
+
+#: id:35003
+msgid "Generic disk"
+msgstr "Generični disk"
+
+#: id:35004
+msgid "There are no settings available\nfor this peripheral."
+msgstr "Za to napravo ni na voljo nobenih dodatnih nastavitev."
+
+#: id:35005
+msgid "New device configured"
+msgstr "Dodana nova naprava"
+
+#: id:35006
+msgid "Device removed"
+msgstr "Odstranjena naprava"
+
+#: id:35007
+msgid "Keymap to use for this device"
+msgstr "Bližnjice za uporabo te naprave"
+
+#: id:35008
+msgid "Keymap enabled"
+msgstr "Vključene bližnjice"
+
+#: id:35009
+msgid "Do not use the custom keymap for this device"
+msgstr ""
+
+#: id:35500
+msgid "Location"
+msgstr "Lokacija"
+
+#: id:35501
+msgid "Class"
+msgstr "Razred"
+
+#: id:35502
+msgctxt "Auto context with id 35502"
+msgid "Name"
+msgstr "Ime"
+
+#: id:35503
+msgid "Vendor"
+msgstr "Proizvajalec"
+
+#: id:35504
+msgid "Product ID"
+msgstr "ID izdelka"
+
+#: id:36000
+msgid "Pulse-Eight CEC adapter"
+msgstr "Pulse-Eight CEC adapter"
+
+#: id:36001
+msgid "Pulse-Eight Nyxboard"
+msgstr "Pulse-Eight Nyxboard"
+
+#: id:36002
+msgid "Switch to keyboard side command"
+msgstr "Preklopi na upravljanje s stranjo tipkovnice"
+
+#: id:36003
+msgid "Switch to remote side command"
+msgstr "Preklopi na upravljanje s stranjo daljinskega upravljalnika"
+
+#: id:36004
+msgid "Press \"user\" button command"
+msgstr "Pritisni gumb \"uporabnik\""
+
+#: id:36005
+msgid "Enable switch side commands"
+msgstr "Vključi ukaz za menjavo strani"
+
+#: id:36006
+msgid "Could not open the adapter"
+msgstr "Ni mogoče odpreti adapterja"
+
+#: id:36007
+msgid "Devices to power on when starting XBMC"
+msgstr "Vključi TV ob zagonu XBMC"
+
+#: id:36008
+msgid "Devices to power off when stopping XBMC"
+msgstr "Izključi naprave ob izhodu iz XBMC"
+
+#: id:36009
+msgid "Put devices in standby mode when activating screensaver"
+msgstr "Postavi naprave v stanje pripravljenosti ob ohranjevalniku zaslona"
+
+#: id:36011
+msgid "Could not detect the CEC port. Set it up manually."
+msgstr "Ni mogoče zaznati vrat CEC. Nastavite jih ročno."
+
+#: id:36012
+msgid "Could not initialise the CEC adapter. Check your settings."
+msgstr "Ni mogoče zaznati adapterja CEC."
+
+#: id:36013
+msgid "Unsupported libCEC interface version. %d is greater than the version XBMC supports (%d)"
+msgstr "Nepodprta različica libcec. %d je višja, kot jo podpira XBMC (%d)"
+
+#: id:36014
+msgid "Put this PC in standby mode when the TV is switched off"
+msgstr "Postavi računalnik v stanje pripravljenosti, ko se ugasne TV"
+
+#: id:36015
+msgid "HDMI port number"
+msgstr "Št. vrat HDMI"
+
+#: id:36016
+msgctxt "Auto context with id 36016"
+msgid "Connected"
+msgstr "XBMC povezan"
+
+#: id:36017
+msgid "Adapter found, but libCEC is not available"
+msgstr "Vmesnik najden, toda libcec ni na voljo"
+
+#: id:36018
+msgid "Use the TV's language setting"
+msgstr "Uporabi jezikovne nastavitve TV"
+
+#: id:36019
+msgid "Connected to HDMI device"
+msgstr ""
+
+#: id:36020
+msgid "Make XBMC the active source when starting"
+msgstr ""
+
+#: id:36021
+msgid "Physical address (overrules HDMI port)"
+msgstr ""
+
+#: id:36022
+msgid "COM port (leave empty unless needed)"
+msgstr ""
+
+#: id:36023
+msgid "Configuration updated"
+msgstr ""
+
+#: id:36024
+msgid "Failed to set the new configuration. Please check your settings."
+msgstr ""
+
+#: id:36025
+msgid "Send 'inactive source' command when stopping XBMC"
+msgstr ""
+

--- a/language/Spanish (Mexico)/strings.po
+++ b/language/Spanish (Mexico)/strings.po
@@ -1,0 +1,9093 @@
+# Converted from xbmc strings.xml with xbmc-xml2po (by Team-XBMC)
+msgid ""
+msgstr ""
+"Project-Id-Version: xbmc.core-FRODO_GIT3ed1604ad7\n"
+"Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
+"POT-Creation-Date: 2012-04-09 18:00+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE\n"
+"Language: es_MX\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: id:0
+msgctxt "Auto context with id 0"
+msgid "Programs"
+msgstr "Programas"
+
+#: id:1
+msgctxt "Auto context with id 1"
+msgid "Pictures"
+msgstr "Imágenes"
+
+#: id:2
+msgctxt "Auto context with id 2"
+msgid "Music"
+msgstr "Música"
+
+#: id:3
+msgctxt "Auto context with id 3"
+msgid "Videos"
+msgstr "Vídeos"
+
+#: id:4
+msgid "TV-Guide"
+msgstr "Guía-TV"
+
+#: id:5
+msgctxt "Auto context with id 5"
+msgid "Settings"
+msgstr "Ajustes"
+
+#: id:6
+msgid "XBMC SVN"
+msgstr "XBMC SVN"
+
+#: id:7
+msgctxt "Auto context with id 7"
+msgid "File manager"
+msgstr "Administrador archivos"
+
+#: id:8
+msgctxt "Auto context with id 8"
+msgid "Weather"
+msgstr "Clima"
+
+#: id:9
+msgid "xbmc media center"
+msgstr "xbmc media center"
+
+#: id:11
+msgid "Monday"
+msgstr "Lunes"
+
+#: id:12
+msgid "Tuesday"
+msgstr "Martes"
+
+#: id:13
+msgid "Wednesday"
+msgstr "Miércoles"
+
+#: id:14
+msgid "Thursday"
+msgstr "Jueves"
+
+#: id:15
+msgid "Friday"
+msgstr "Viernes"
+
+#: id:16
+msgid "Saturday"
+msgstr "Sábado"
+
+#: id:17
+msgid "Sunday"
+msgstr "Domingo"
+
+#: id:21
+msgid "January"
+msgstr "Enero"
+
+#: id:22
+msgid "February"
+msgstr "Febrero"
+
+#: id:23
+msgid "March"
+msgstr "Marzo"
+
+#: id:24
+msgid "April"
+msgstr "Abril"
+
+#: id:25
+msgctxt "Auto context with id 25"
+msgid "May"
+msgstr "Mayo"
+
+#: id:26
+msgid "June"
+msgstr "Junio"
+
+#: id:27
+msgid "July"
+msgstr "Julio"
+
+#: id:28
+msgid "August"
+msgstr "Agosto"
+
+#: id:29
+msgid "September"
+msgstr "Septiembre"
+
+#: id:30
+msgid "October"
+msgstr "Octubre"
+
+#: id:31
+msgid "November"
+msgstr "Noviembre"
+
+#: id:32
+msgid "December"
+msgstr "Diciembre"
+
+#: id:41
+msgid "Mon"
+msgstr "Lun"
+
+#: id:42
+msgid "Tue"
+msgstr "Mar"
+
+#: id:43
+msgid "Wed"
+msgstr "Mié"
+
+#: id:44
+msgid "Thu"
+msgstr "Jue"
+
+#: id:45
+msgid "Fri"
+msgstr "Vie"
+
+#: id:46
+msgid "Sat"
+msgstr "Sab"
+
+#: id:47
+msgctxt "Auto context with id 47"
+msgid "Sun"
+msgstr "Dom"
+
+#: id:51
+msgid "Jan"
+msgstr "Ene"
+
+#: id:52
+msgid "Feb"
+msgstr "Feb"
+
+#: id:53
+msgid "Mar"
+msgstr "Mar"
+
+#: id:54
+msgid "Apr"
+msgstr "Abr"
+
+#: id:55
+msgctxt "Auto context with id 55"
+msgid "May"
+msgstr "May"
+
+#: id:56
+msgid "Jun"
+msgstr "Jun"
+
+#: id:57
+msgid "Jul"
+msgstr "Jul"
+
+#: id:58
+msgid "Aug"
+msgstr "Ago"
+
+#: id:59
+msgid "Sep"
+msgstr "Sep"
+
+#: id:60
+msgid "Oct"
+msgstr "Oct"
+
+#: id:61
+msgid "Nov"
+msgstr "Nov"
+
+#: id:62
+msgid "Dec"
+msgstr "Dic"
+
+#: id:71
+msgid "N"
+msgstr "N"
+
+#: id:72
+msgid "NNE"
+msgstr "NNE"
+
+#: id:73
+msgid "NE"
+msgstr "NE"
+
+#: id:74
+msgid "ENE"
+msgstr "ENE"
+
+#: id:75
+msgid "E"
+msgstr "E"
+
+#: id:76
+msgid "ESE"
+msgstr "ESE"
+
+#: id:77
+msgid "SE"
+msgstr "SE"
+
+#: id:78
+msgid "SSE"
+msgstr "SSE"
+
+#: id:79
+msgid "S"
+msgstr "S"
+
+#: id:80
+msgid "SSW"
+msgstr "SSO"
+
+#: id:81
+msgid "SW"
+msgstr "SO"
+
+#: id:82
+msgid "WSW"
+msgstr "OSO"
+
+#: id:83
+msgid "W"
+msgstr "O"
+
+#: id:84
+msgid "WNW"
+msgstr "ONO"
+
+#: id:85
+msgid "NW"
+msgstr "NO"
+
+#: id:86
+msgid "NNW"
+msgstr "NNO"
+
+#: id:87
+msgid "VAR"
+msgstr "VAR"
+
+#: id:98
+msgid "View: Auto"
+msgstr "Ver: Auto"
+
+#: id:99
+msgid "View: Auto big"
+msgstr "Ver: Auto Gr."
+
+#: id:100
+msgid "View: Icons"
+msgstr "Ver: Iconos"
+
+#: id:101
+msgid "View: List"
+msgstr "Ver: Lista"
+
+#: id:102
+msgctxt "Auto context with id 102"
+msgid "Scan"
+msgstr "Analizar"
+
+#: id:103
+msgctxt "Auto context with id 103"
+msgid "Sort by: Name"
+msgstr "Ord x Nombre"
+
+#: id:104
+msgid "Sort by: Date"
+msgstr "Ord x Fecha"
+
+#: id:105
+msgid "Sort by: Size"
+msgstr "Ord x Tamaño"
+
+#: id:106
+msgid "No"
+msgstr "No"
+
+#: id:107
+msgid "Yes"
+msgstr "Sí"
+
+#: id:108
+msgctxt "Auto context with id 108"
+msgid "Slideshow"
+msgstr "Presentación"
+
+#: id:109
+msgid "Create thumbs"
+msgstr "Crear miniat."
+
+#: id:110
+msgid "Create thumbnails"
+msgstr "Crear miniaturas"
+
+#: id:111
+msgctxt "Auto context with id 111"
+msgid "Shortcuts"
+msgstr "Accesos directos"
+
+#: id:112
+msgid "Paused"
+msgstr "Pausado"
+
+#: id:113
+msgid "Update failed"
+msgstr "Falló Actualiz."
+
+#: id:114
+msgid "Installation failed"
+msgstr "Falló Instalac."
+
+#: id:115
+msgid "Copy"
+msgstr "Copiar"
+
+#: id:116
+msgid "Move"
+msgstr "Mover"
+
+#: id:117
+msgid "Delete"
+msgstr "Eliminar"
+
+#: id:118
+msgid "Rename"
+msgstr "Renombrar"
+
+#: id:119
+msgid "New folder"
+msgstr "Nueva carpeta"
+
+#: id:120
+msgid "Confirm file copy"
+msgstr "Confirmar copiar"
+
+#: id:121
+msgid "Confirm file move"
+msgstr "Confirmar mover"
+
+#: id:122
+msgid "Confirm file delete?"
+msgstr "Confirmar eliminar"
+
+#: id:123
+msgid "Copy these files?"
+msgstr "¿Copiar estos archivos?"
+
+#: id:124
+msgid "Move these files?"
+msgstr "¿Mover estos archivos?"
+
+#: id:125
+msgid "Delete these files? - Deleting files cannot be undone!"
+msgstr "¿Eliminar estos archivos? - ¡No puede deshacerse!"
+
+#: id:126
+msgid "Status"
+msgstr "Estado"
+
+#: id:127
+msgid "Objects"
+msgstr "Objetos"
+
+#: id:128
+msgctxt "Auto context with id 128"
+msgid "General"
+msgstr "General"
+
+#: id:129
+msgctxt "Auto context with id 129"
+msgid "Slideshow"
+msgstr "Presentación"
+
+#: id:130
+msgctxt "Auto context with id 130"
+msgid "System info"
+msgstr "Info del sistema"
+
+#: id:131
+msgid "Display"
+msgstr "Pantalla"
+
+#: id:132
+msgid "Albums"
+msgstr "Álbumes"
+
+#: id:133
+msgid "Artists"
+msgstr "Intérpretes"
+
+#: id:134
+msgid "Songs"
+msgstr "Canciones"
+
+#: id:135
+msgid "Genres"
+msgstr "Géneros"
+
+#: id:136
+msgid "Playlists"
+msgstr "Listas de reproducción"
+
+#: id:137
+msgid "Search"
+msgstr "Buscar"
+
+#: id:138
+msgid "System Information"
+msgstr "Información del Sistema"
+
+#: id:139
+msgid "Temperatures:"
+msgstr "Temperaturas:"
+
+#: id:140
+msgid "CPU:"
+msgstr "CPU:"
+
+#: id:141
+msgid "GPU:"
+msgstr "GPU:"
+
+#: id:142
+msgid "Time:"
+msgstr "Hora:"
+
+#: id:143
+msgid "Current:"
+msgstr "Actual:"
+
+#: id:144
+msgid "Build:"
+msgstr "Compilación:"
+
+#: id:145
+msgid "Network:"
+msgstr "Red:"
+
+#: id:146
+msgid "Type:"
+msgstr "Tipo:"
+
+#: id:147
+msgid "Static"
+msgstr "IP Fija"
+
+#: id:148
+msgid "DHCP"
+msgstr "DHCP"
+
+#: id:149
+msgid "MAC address"
+msgstr "MAC"
+
+#: id:150
+msgctxt "Auto context with id 150"
+msgid "IP address"
+msgstr "IP"
+
+#: id:151
+msgid "Link:"
+msgstr "Conexión:"
+
+#: id:152
+msgid "Half duplex"
+msgstr "Half duplex"
+
+#: id:153
+msgid "Full duplex"
+msgstr "Full duplex"
+
+#: id:154
+msgctxt "Auto context with id 154"
+msgid "Storage"
+msgstr "Almacenamiento"
+
+#: id:155
+msgid "Drive"
+msgstr "Unidad"
+
+#: id:156
+msgctxt "Auto context with id 156"
+msgid "Free"
+msgstr "Libres"
+
+#: id:157
+msgctxt "Auto context with id 157"
+msgid "Video"
+msgstr "Vídeo"
+
+#: id:158
+msgid "Free memory"
+msgstr "Memoria libre"
+
+#: id:159
+msgid "No link"
+msgstr "Sin conexión"
+
+#: id:160
+msgctxt "Auto context with id 160"
+msgid "Free"
+msgstr "Libres"
+
+#: id:161
+msgid "Unavailable"
+msgstr "No disponible"
+
+#: id:162
+msgid "Tray open"
+msgstr "Bandeja abierta"
+
+#: id:163
+msgid "Reading"
+msgstr "Leyendo"
+
+#: id:164
+msgid "No disc"
+msgstr "Sin Disco"
+
+#: id:165
+msgid "Disc present"
+msgstr "Disco Presente"
+
+#: id:166
+msgid "Skin"
+msgstr "Skin"
+
+#: id:169
+msgctxt "Auto context with id 169"
+msgid "Resolution"
+msgstr "Resolución"
+
+#: id:170
+msgid "Adjust display refresh rate to match video"
+msgstr "Ajustar frecuencia de refresco de pantalla al video"
+
+#: id:172
+msgid "Release date"
+msgstr "Fecha de publicación"
+
+#: id:173
+msgid "Display 4:3 videos as"
+msgstr "Mostrar videos 4:3 como"
+
+#: id:175
+msgid "Moods"
+msgstr "Estados de ánimo"
+
+#: id:176
+msgid "Styles"
+msgstr "Estilos"
+
+#: id:179
+msgid "Song"
+msgstr "Canción"
+
+#: id:180
+msgid "Duration"
+msgstr "Duración"
+
+#: id:181
+msgid "Select album"
+msgstr "Seleccionar álbum"
+
+#: id:182
+msgid "Tracks"
+msgstr "Pistas"
+
+#: id:183
+msgid "Review"
+msgstr "Crítica"
+
+#: id:184
+msgid "Refresh"
+msgstr "Actualizar"
+
+#: id:185
+msgid "Searching album"
+msgstr "Buscando álbum"
+
+#: id:186
+msgid "OK"
+msgstr "OK"
+
+#: id:187
+msgid "No albums found!"
+msgstr "¡No se encontraron álbumes!"
+
+#: id:188
+msgid "Select all"
+msgstr "Seleccionar todo"
+
+#: id:189
+msgid "Scanning media info"
+msgstr "Obteniendo información de medios"
+
+#: id:190
+msgid "Save"
+msgstr "Guardar"
+
+#: id:191
+msgid "Shuffle"
+msgstr "Mezclar"
+
+#: id:192
+msgctxt "Auto context with id 192"
+msgid "Clear"
+msgstr "Limpiar"
+
+#: id:193
+msgctxt "Auto context with id 193"
+msgid "Scan"
+msgstr "Analizar"
+
+#: id:194
+msgid "Searching..."
+msgstr "Buscando..."
+
+#: id:195
+msgid "No info found!"
+msgstr "¡No se encontró información!"
+
+#: id:196
+msgid "Select movie:"
+msgstr "Seleccione película:"
+
+#: id:197
+msgid "Querying %s info"
+msgstr "Consultando %s"
+
+#: id:198
+msgid "Loading movie details"
+msgstr "Cargando detalles de la película"
+
+#: id:199
+msgid "Web interface"
+msgstr "Interfaz Web"
+
+#: id:202
+msgid "Tagline"
+msgstr "Eslogan"
+
+#: id:203
+msgid "Plot outline"
+msgstr "Resumen"
+
+#: id:205
+msgid "Votes"
+msgstr "Votos"
+
+#: id:206
+msgid "Cast"
+msgstr "Reparto"
+
+#: id:207
+msgid "Plot"
+msgstr "Argumento"
+
+#: id:208
+msgctxt "Auto context with id 208"
+msgid "Play"
+msgstr "Reproducir"
+
+#: id:209
+msgid "Next"
+msgstr "Siguiente"
+
+#: id:210
+msgid "Previous"
+msgstr "Anterior"
+
+#: id:213
+msgid "Calibrate user interface..."
+msgstr "Calibrar interfaz de usuario..."
+
+#: id:214
+msgid "Video calibration..."
+msgstr "Calibrar vídeo..."
+
+#: id:215
+msgid "Soften"
+msgstr "Suavizar"
+
+#: id:216
+msgid "Zoom amount"
+msgstr "Cantidad de zoom"
+
+#: id:217
+msgid "Pixel ratio"
+msgstr "Relación de aspecto"
+
+#: id:218
+msgid "DVD drive"
+msgstr "Unidad DVD"
+
+#: id:219
+msgid "Please insert disc"
+msgstr "Por favor, inserte disco"
+
+#: id:220
+msgid "Remote share"
+msgstr "Recurso compartido remoto"
+
+#: id:221
+msgid "Network is not connected"
+msgstr "La red no está conectada"
+
+#: id:222
+msgid "Cancel"
+msgstr "Cancelar"
+
+#: id:224
+msgid "Speed"
+msgstr "Velocidad"
+
+#: id:225
+msgid "Vertical Shift"
+msgstr "Desplazamiento vertical"
+
+#: id:226
+msgid "Test patterns..."
+msgstr "Patrones de prueba"
+
+#: id:227
+msgid "Lookup audio CD track names from freedb.org"
+msgstr "Consultar CDs de audio en freedb.org"
+
+#: id:228
+msgid "Shuffle playlist on load"
+msgstr "Mezclar lista de reproducción al cargar"
+
+#: id:229
+msgid "HDD spindown time"
+msgstr "Detener el disco duro tras"
+
+#: id:230
+msgid "Video filters"
+msgstr "Filtros de vídeo"
+
+#: id:231
+msgctxt "Auto context with id 231"
+msgid "None"
+msgstr "Ninguno"
+
+#: id:232
+msgid "Point"
+msgstr "Punto"
+
+#: id:233
+msgid "Linear"
+msgstr "Lineal"
+
+#: id:234
+msgid "Anisotropic"
+msgstr "Anisotrópico"
+
+#: id:235
+msgid "Quincunx"
+msgstr "Quincunx"
+
+#: id:236
+msgid "Gaussian cubic"
+msgstr "Cúbico gaussiano"
+
+#: id:237
+msgid "Minification"
+msgstr "Minimificación"
+
+#: id:238
+msgid "Magnification"
+msgstr "Magnificación"
+
+#: id:239
+msgid "Clear playlist on finish"
+msgstr "Borrar lista de reproducción al finalizar"
+
+#: id:240
+msgid "Display Mode"
+msgstr "Display Mode"
+
+#: id:241
+msgid "Full Screen #%d"
+msgstr "Pant. Completa #%d"
+
+#: id:242
+msgid "Windowed"
+msgstr "En ventana"
+
+#: id:243
+msgid "Refresh Rate"
+msgstr "Tasa de Refresco"
+
+#: id:244
+msgid "Full screen"
+msgstr "Pant. Completa"
+
+#: id:245
+msgid "Sizing: (%i,%i)->(%i,%i) (Zoom x%2.2f) AR:%2.2f:1 (Pixels: %2.2f:1) (VShift: %2.2f)"
+msgstr "Tamaño: (%i,%i)->(%i,%i) (Zoom x%2.2f) AR:%2.2f:1 (Pixeles: %2.2f:1) (VShift: %2.2f)"
+
+#: id:247
+msgctxt "Auto context with id 247"
+msgid "Scripts"
+msgstr "Scripts"
+
+#: id:248
+msgctxt "Auto context with id 248"
+msgid "Language"
+msgstr "Idioma"
+
+#: id:249
+msgctxt "Auto context with id 249"
+msgid "Music"
+msgstr "Música"
+
+#: id:250
+msgctxt "Auto context with id 250"
+msgid "Visualization"
+msgstr "Visualización"
+
+#: id:251
+msgid "Select destination directory"
+msgstr "Seleccione carpeta destino"
+
+#: id:252
+msgid "Output stereo to all speakers"
+msgstr "Salida estéreo a todos los altavoces"
+
+#: id:253
+msgid "Number of channels"
+msgstr "Número de canales"
+
+#: id:254
+msgid "- DTS capable receiver"
+msgstr "- Decodificador compatible DTS"
+
+#: id:255
+msgid "CDDB"
+msgstr "CDDB"
+
+#: id:256
+msgid "Fetching CD information"
+msgstr "Consultando información del CD"
+
+#: id:257
+msgid "Error"
+msgstr "Error"
+
+#: id:258
+msgid "Enable tag reading"
+msgstr "Habilitar lectura de etiquetas"
+
+#: id:259
+msgid "Opening"
+msgstr "Abriendo"
+
+#: id:260
+msgid "Shoutcast"
+msgstr "Shoutcast"
+
+#: id:261
+msgid "Waiting for start..."
+msgstr "Esperando para empezar...."
+
+#: id:262
+msgid "Scripts output"
+msgstr "Salida de secuencias de comandos"
+
+#: id:263
+msgid "Allow control of XBMC via HTTP"
+msgstr "Permitir controlar XBMC via HTTP"
+
+#: id:264
+msgid "Record"
+msgstr "Grabar"
+
+#: id:265
+msgid "Stop Rec."
+msgstr "Detener grabación"
+
+#: id:266
+msgid "Sort by: Track"
+msgstr "Por: Pista"
+
+#: id:267
+msgid "Sort by: Time"
+msgstr "Por: Duración"
+
+#: id:268
+msgid "Sort by: Title"
+msgstr "Por: Título"
+
+#: id:269
+msgid "Sort by: Artist"
+msgstr "Por: Intérprete"
+
+#: id:270
+msgid "Sort by: Album"
+msgstr "Por: Álbum"
+
+#: id:271
+msgid "Top 100"
+msgstr "Top 100"
+
+#: id:272
+msgid "Top-Left overscan compensation"
+msgstr "Compensación esquina superior izquierda"
+
+#: id:273
+msgid "Bottom-Right overscan compensation"
+msgstr "Compensación esquina inferior derecha"
+
+#: id:274
+msgid "Subtitle positioning"
+msgstr "Posición de los subtítulos"
+
+#: id:275
+msgid "Pixel ratio adjustment"
+msgstr "Ajuste de la relación de aspecto de pixel"
+
+#: id:276
+msgid "Adjust the arrow to change the amount of overscan"
+msgstr "Mueva la flecha para variar la cantidad de imagen perdida por los lados"
+
+#: id:277
+msgid "Adjust the bar to change the subtitles position"
+msgstr "Mueva la flecha para variar la posición de los subtítulos"
+
+#: id:278
+msgid "Adjust the rectangle so it is perfectly square"
+msgstr "Modifique el rectángulo hasta que sea un cuadrado perfecto"
+
+#: id:279
+msgid "Unable to load settings"
+msgstr "No se puede cargar la configuración"
+
+#: id:280
+msgid "Using default settings"
+msgstr "Usando valores por defecto"
+
+#: id:281
+msgid "Please check the XML files"
+msgstr "Por favor compruebe los archivos .xml"
+
+#: id:282
+msgid "Found %i items"
+msgstr "Encontrados %i elementos"
+
+#: id:283
+msgid "Search results"
+msgstr "Resultados de la búsqueda"
+
+#: id:284
+msgid "No results found"
+msgstr "No se encontraron resultados"
+
+#: id:287
+msgctxt "Auto context with id 287"
+msgid "Subtitles"
+msgstr "Subtítulos"
+
+#: id:288
+msgctxt "Auto context with id 288"
+msgid "Font"
+msgstr "Tipografía"
+
+#: id:289
+msgctxt "Auto context with id 289"
+msgid "- Size"
+msgstr "- Tamaño"
+
+#: id:290
+msgid "Dynamic range compression"
+msgstr "Compresión de Rango Dinámico"
+
+#: id:291
+msgctxt "Auto context with id 291"
+msgid "Video"
+msgstr "Vídeo"
+
+#: id:292
+msgctxt "Auto context with id 292"
+msgid "Audio"
+msgstr "Sonido"
+
+#: id:293
+msgid "Browse for subtitles"
+msgstr "Buscar subtítulos"
+
+#: id:294
+msgid "Create bookmark"
+msgstr "Crear marcador"
+
+#: id:296
+msgid "Clear bookmarks"
+msgstr "Borrar marcadores"
+
+#: id:297
+msgid "Audio offset"
+msgstr "Retardo de sonido"
+
+#: id:298
+msgid "Bookmarks"
+msgstr "Marcadores"
+
+#: id:299
+msgid "- AAC capable receiver"
+msgstr "- receptor con AAC"
+
+#: id:300
+msgid "- MP1 capable receiver"
+msgstr "- receptor con MP1"
+
+#: id:301
+msgid "- MP2 capable receiver"
+msgstr "- receptor con MP2"
+
+#: id:302
+msgid "- MP3 capable receiver"
+msgstr "- receptor con MP3"
+
+#: id:303
+msgid "Delay"
+msgstr "Retardo"
+
+#: id:304
+msgctxt "Auto context with id 304"
+msgid "Language"
+msgstr "Idioma"
+
+#: id:305
+msgctxt "Auto context with id 305"
+msgid "Enabled"
+msgstr "Activado"
+
+#: id:306
+msgid "Non-interleaved"
+msgstr "No-Interpolado"
+
+#: id:312
+msgid "(0=auto)"
+msgstr "(0=auto)"
+
+#: id:313
+msgid "Cleaning database"
+msgstr "Limpiando base de datos"
+
+#: id:314
+msgid "Preparing..."
+msgstr "Preparando..."
+
+#: id:315
+msgid "Database error"
+msgstr "Error en base de datos"
+
+#: id:316
+msgid "Searching songs..."
+msgstr "Buscando canciones..."
+
+#: id:317
+msgid "Cleaned database successfully"
+msgstr "Limpieza completada con éxito"
+
+#: id:318
+msgid "Cleaning songs..."
+msgstr "Limpiando canciones..."
+
+#: id:319
+msgid "Error cleaning songs"
+msgstr "Error limpiando canciones"
+
+#: id:320
+msgid "Cleaning artists..."
+msgstr "Limpiando intérpretes..."
+
+#: id:321
+msgid "Error cleaning artists"
+msgstr "Error limpiando intérpretes"
+
+#: id:322
+msgid "Cleaning genres..."
+msgstr "Limpiando géneros..."
+
+#: id:323
+msgid "Error cleaning genres"
+msgstr "Error limpiando géneros"
+
+#: id:324
+msgid "Cleaning paths..."
+msgstr "Limpiando rutas..."
+
+#: id:325
+msgid "Error cleaning paths"
+msgstr "Error limpiando rutas"
+
+#: id:326
+msgid "Cleaning albums..."
+msgstr "Limpiando álbumes..."
+
+#: id:327
+msgid "Error cleaning albums"
+msgstr "Error limpiando álbumes"
+
+#: id:328
+msgid "Writing changes..."
+msgstr "Escribiendo cambios..."
+
+#: id:329
+msgid "Error writing changes"
+msgstr "Error escribiendo cambios"
+
+#: id:330
+msgid "This may take some time..."
+msgstr "Esto puede llevar algún tiempo..."
+
+#: id:331
+msgid "Compressing database..."
+msgstr "Comprimiendo base de datos..."
+
+#: id:332
+msgid "Error compressing database"
+msgstr "Error comprimiendo base de datos"
+
+#: id:333
+msgid "Do you want to clean the library?"
+msgstr "¿Quiere limpiar la Bibloteca?"
+
+#: id:334
+msgid "Clean library..."
+msgstr "Limpiar biblioteca..."
+
+#: id:335
+msgid "Start"
+msgstr "Iniciar"
+
+#: id:336
+msgid "Framerate conversion"
+msgstr "Conversión de imágenes por segundo"
+
+#: id:337
+msgctxt "Auto context with id 337"
+msgid "Audio output"
+msgstr "Salida de sonido"
+
+#: id:338
+msgid "Analog"
+msgstr "Analógica"
+
+#: id:339
+msgid "Optical/Coax"
+msgstr "Optica/Coaxial"
+
+#: id:340
+msgid "Various artists"
+msgstr "Varios Intérpretes"
+
+#: id:341
+msgid "Play disc"
+msgstr "Reprod. disco"
+
+#: id:342
+msgctxt "Auto context with id 342"
+msgid "Movies"
+msgstr "Películas"
+
+#: id:343
+msgid "Adjust framerate"
+msgstr "Ajustar Imágenes/seg"
+
+#: id:344
+msgid "Actors"
+msgstr "Actores"
+
+#: id:345
+msgctxt "Auto context with id 345"
+msgid "Year"
+msgstr "Año"
+
+#: id:346
+msgid "Boost volume level on downmix"
+msgstr "Realzar volumen al hacer downmix"
+
+#: id:350
+msgctxt "Auto context with id 350"
+msgid "Programs"
+msgstr "Programas"
+
+#: id:351
+msgctxt "Auto context with id 351"
+msgid "Off"
+msgstr "Apagado"
+
+#: id:352
+msgid "Dim"
+msgstr "Atenuar"
+
+#: id:353
+msgid "Black"
+msgstr "Negro"
+
+#: id:354
+msgid "Matrix trails"
+msgstr "Tipo Matrix"
+
+#: id:355
+msgid "Screensaver time"
+msgstr "Activar salvapantallas tras"
+
+#: id:356
+msgid "Screensaver mode"
+msgstr "Modo del salvapantallas"
+
+#: id:357
+msgid "Shutdown function timer"
+msgstr "Apagar consola tras"
+
+#: id:358
+msgid "All albums"
+msgstr "Todos los álbumes"
+
+#: id:359
+msgid "Recently added albums"
+msgstr "Álbumes recientes"
+
+#: id:360
+msgctxt "Auto context with id 360"
+msgid "Screensaver"
+msgstr "Salvapantallas"
+
+#: id:361
+msgid "R. Slideshow"
+msgstr "Pres. Recurs."
+
+#: id:362
+msgid "Screensaver dim level"
+msgstr "Nivel de atenuación"
+
+#: id:363
+msgid "Sort by: File"
+msgstr "Por: Archivo"
+
+#: id:364
+msgid "- Dolby Digital (AC3) capable receiver"
+msgstr "- Decodificador compatible AC3"
+
+#: id:365
+msgctxt "Auto context with id 365"
+msgid "Sort by: Name"
+msgstr "Por: Nombre"
+
+#: id:366
+msgid "Sort by: Year"
+msgstr "Por: Año"
+
+#: id:367
+msgid "Sort by: Rating"
+msgstr "Por: Valoración"
+
+#: id:368
+msgid "IMDb"
+msgstr "IMDb"
+
+#: id:369
+msgctxt "Auto context with id 369"
+msgid "Title"
+msgstr "Título"
+
+#: id:370
+msgid "Thunderstorms"
+msgstr "Tormentas"
+
+#: id:371
+msgid "Partly"
+msgstr "Parcialmente"
+
+#: id:372
+msgid "Mostly"
+msgstr "Mayormente"
+
+#: id:373
+msgid "Sunny"
+msgstr "Soleado"
+
+#: id:374
+msgid "Cloudy"
+msgstr "Nublado"
+
+#: id:375
+msgid "Snow"
+msgstr "Nieve"
+
+#: id:376
+msgid "Rain"
+msgstr "Lluvia"
+
+#: id:377
+msgid "Light"
+msgstr "Débil"
+
+#: id:378
+msgid "AM"
+msgstr "AM"
+
+#: id:379
+msgid "PM"
+msgstr "PM"
+
+#: id:380
+msgid "Showers"
+msgstr "Chubascos"
+
+#: id:381
+msgid "Few"
+msgstr "Un poco"
+
+#: id:382
+msgid "Scattered"
+msgstr "Aislados"
+
+#: id:383
+msgctxt "Auto context with id 383"
+msgid "Wind"
+msgstr "Viento"
+
+#: id:384
+msgid "Strong"
+msgstr "Fuerte"
+
+#: id:385
+msgid "Fair"
+msgstr "Bueno"
+
+#: id:386
+msgctxt "Auto context with id 386"
+msgid "Clear"
+msgstr "Despejado"
+
+#: id:387
+msgid "Clouds"
+msgstr "Nublado"
+
+#: id:388
+msgid "Early"
+msgstr "Temprano"
+
+#: id:389
+msgid "Shower"
+msgstr "Chubascos"
+
+#: id:390
+msgid "Flurries"
+msgstr "Ráfagas de aire"
+
+#: id:391
+msgctxt "Auto context with id 391"
+msgid "Low"
+msgstr "Bajo"
+
+#: id:392
+msgctxt "Auto context with id 392"
+msgid "Medium"
+msgstr "Medio"
+
+#: id:393
+msgctxt "Auto context with id 393"
+msgid "High"
+msgstr "Alto"
+
+#: id:394
+msgid "Fog"
+msgstr "Niebla"
+
+#: id:395
+msgid "Haze"
+msgstr "Bruma"
+
+#: id:396
+msgid "Select location"
+msgstr "Seleccione Lugar"
+
+#: id:397
+msgid "Refresh time"
+msgstr "Actualizar cada"
+
+#: id:398
+msgid "Temperature units"
+msgstr "Temperatura en"
+
+#: id:399
+msgid "Speed units"
+msgstr "Velocidad en"
+
+#: id:400
+msgctxt "Auto context with id 400"
+msgid "Weather"
+msgstr "El Tiempo"
+
+#: id:401
+msgid "Temp"
+msgstr "Temperatura"
+
+#: id:402
+msgid "Feels like"
+msgstr "Sensación térmica"
+
+#: id:403
+msgid "UV index"
+msgstr "Índice UV"
+
+#: id:404
+msgctxt "Auto context with id 404"
+msgid "Wind"
+msgstr "Viento"
+
+#: id:405
+msgid "Dew point"
+msgstr "Punto Rocío"
+
+#: id:406
+msgid "Humidity"
+msgstr "Humedad"
+
+#: id:409
+msgid "Defaults"
+msgstr "Predef."
+
+#: id:410
+msgid "Accessing weather service"
+msgstr "Accediendo servicio de clima"
+
+#: id:411
+msgid "Getting weather for:"
+msgstr "Obteniendo clima para:"
+
+#: id:412
+msgid "Unable to get weather data"
+msgstr "No se pueden obtener datos de clima"
+
+#: id:413
+msgid "Manual"
+msgstr "Manual"
+
+#: id:414
+msgid "No review for this album"
+msgstr "No hay crítica para este álbum"
+
+#: id:415
+msgid "Downloading thumbnail..."
+msgstr "Descargando miniatura..."
+
+#: id:416
+msgid "Not available"
+msgstr "No disponible"
+
+#: id:417
+msgid "View: Big icons"
+msgstr "Ver: I. grandes"
+
+#: id:418
+msgctxt "Auto context with id 418"
+msgid "Low"
+msgstr "Min"
+
+#: id:419
+msgctxt "Auto context with id 419"
+msgid "High"
+msgstr "Max"
+
+#: id:420
+msgid "HDMI"
+msgstr "HDMI"
+
+#: id:422
+msgid "Delete album info"
+msgstr "Eliminar información del álbum"
+
+#: id:423
+msgid "Delete CD information"
+msgstr "Eliminar información CDDB"
+
+#: id:424
+msgid "Select"
+msgstr "Seleccionar"
+
+#: id:425
+msgid "No album information found"
+msgstr "No se encontró información del álbum."
+
+#: id:426
+msgid "No CD information found"
+msgstr "No se encontró información CDDB."
+
+#: id:427
+msgid "Disc"
+msgstr "Disco"
+
+#: id:428
+msgid "Insert correct CD/DVD"
+msgstr "Inserte el CD/DVD correcto"
+
+#: id:429
+msgid "Please insert the following disc:"
+msgstr "Por favor, inserte el siguiente CD/DVD"
+
+#: id:430
+msgid "Sort by: DVD#"
+msgstr "Por: DVD"
+
+#: id:431
+msgid "No cache"
+msgstr "Sin Caché"
+
+#: id:432
+msgid "Remove movie from library"
+msgstr "Eliminar película de la base de datos"
+
+#: id:433
+msgid "Really remove '%s'?"
+msgstr "¿Eliminar realmente '%s'?"
+
+#: id:434
+msgid "From %s at %i %s"
+msgstr "Del %s a %i %s"
+
+#: id:437
+msgid "Removable disk"
+msgstr "Disco Removible"
+
+#: id:438
+msgid "Opening file"
+msgstr "Abriendo fichero"
+
+#: id:439
+msgid "Cache"
+msgstr "Cache"
+
+#: id:440
+msgid "Harddisk"
+msgstr "Disco Duro"
+
+#: id:441
+msgid "UDF"
+msgstr "UDF"
+
+#: id:442
+msgid "Local network"
+msgstr "Red Local"
+
+#: id:443
+msgid "Internet"
+msgstr "Internet"
+
+#: id:444
+msgctxt "Auto context with id 444"
+msgid "Video"
+msgstr "Vídeo"
+
+#: id:445
+msgctxt "Auto context with id 445"
+msgid "Audio"
+msgstr "Sonido"
+
+#: id:446
+msgctxt "Auto context with id 446"
+msgid "DVD"
+msgstr "DVD"
+
+#: id:447
+msgid "Autorun media"
+msgstr "Reproducir automáticamente"
+
+#: id:448
+msgid "LCD"
+msgstr "LCD"
+
+#: id:449
+msgctxt "Auto context with id 449"
+msgid "Enabled"
+msgstr "Activado"
+
+#: id:450
+msgid "Columns"
+msgstr "Columnas"
+
+#: id:451
+msgid "Row 1 address"
+msgstr "Posición línea 1"
+
+#: id:452
+msgid "Row 2 address"
+msgstr "Posición línea 2"
+
+#: id:453
+msgid "Row 3 address"
+msgstr "Posición línea 3"
+
+#: id:454
+msgid "Row 4 address"
+msgstr "Posición línea 4"
+
+#: id:455
+msgid "Rows"
+msgstr "Líneas"
+
+#: id:456
+msgid "Mode"
+msgstr "Modo"
+
+#: id:457
+msgid "Switch view"
+msgstr "Cambiar vista"
+
+#: id:459
+msgid "Subs"
+msgstr "Subtítulos"
+
+#: id:460
+msgid "Audio stream"
+msgstr "Canal de sonido"
+
+#: id:461
+msgid "[active]"
+msgstr "[activo]"
+
+#: id:462
+msgid "Subtitle"
+msgstr "Subtítulos"
+
+#: id:463
+msgid "Backlight"
+msgstr "Retroiluminación"
+
+#: id:464
+msgid "Brightness"
+msgstr "Brillo"
+
+#: id:465
+msgid "Contrast"
+msgstr "Contraste"
+
+#: id:466
+msgid "Gamma"
+msgstr "Gamma"
+
+#: id:467
+msgctxt "Auto context with id 467"
+msgid "Type"
+msgstr "Tipo"
+
+#: id:468
+msgid "Move the bar to change the OSD position"
+msgstr "Mueva la barra para variar la posición del OSD"
+
+#: id:469
+msgid "OSD position"
+msgstr "Posición del OSD"
+
+#: id:470
+msgid "Credits"
+msgstr "Créditos"
+
+#: id:471
+msgid "Modchip"
+msgstr "Modchip"
+
+#: id:474
+msgctxt "Auto context with id 474"
+msgid "Off"
+msgstr "Apagado"
+
+#: id:475
+msgid "Music only"
+msgstr "Sólo Música"
+
+#: id:476
+msgctxt "Auto context with id 476"
+msgid "Music & video"
+msgstr "Música y Vídeo"
+
+#: id:477
+msgid "Unable to load playlist"
+msgstr "No se puede cargar la lista de reproducción"
+
+#: id:478
+msgid "OSD"
+msgstr "OSD"
+
+#: id:479
+msgid "Skin & language"
+msgstr "Skin e idioma"
+
+#: id:480
+msgid "Appearance"
+msgstr "Apariencia"
+
+#: id:481
+msgid "Audio options"
+msgstr "Opciones de Sonido"
+
+#: id:482
+msgid "About XBMC"
+msgstr "Acerca de XBMC"
+
+#: id:485
+msgid "Delete album"
+msgstr "Eliminar álbum"
+
+#: id:486
+msgid "Repeat"
+msgstr "Repetir"
+
+#: id:487
+msgid "Repeat one"
+msgstr "Repetir Uno"
+
+#: id:488
+msgid "Repeat folder"
+msgstr "Repetir carpetas"
+
+#: id:489
+msgid "Play the next song automatically"
+msgstr "Reproducir automáticamente la próxima canción"
+
+#: id:491
+msgid "- Use big icons"
+msgstr "- Usar iconos grandes"
+
+#: id:492
+msgid "Resize VobSubs"
+msgstr "Redimensionar subtítulos VOB"
+
+#: id:493
+msgid "Advanced options (Experts Only!)"
+msgstr "Opciones Avanzadas (¡Sólo expertos!)"
+
+#: id:494
+msgid "Overall audio headroom"
+msgstr "Margen total de sonido"
+
+#: id:495
+msgid "Upsample videos to GUI resolution"
+msgstr "Agrandar vídeos a resolución XBMC"
+
+#: id:496
+msgid "Calibration"
+msgstr "Calibración"
+
+#: id:497
+msgid "Show file extensions"
+msgstr "Mostrar extensiones"
+
+#: id:498
+msgid "Sort by: Type"
+msgstr "Por: Tipo"
+
+#: id:499
+msgid "Unable to connect to online lookup service"
+msgstr "No se puede conectar al servicio online"
+
+#: id:500
+msgid "Downloading album information failed"
+msgstr "Error al obtener información de album"
+
+#: id:501
+msgid "Looking for album names..."
+msgstr "Buscando nombres de los álbumes..."
+
+#: id:502
+msgctxt "Auto context with id 502"
+msgid "Open"
+msgstr "Abierto"
+
+#: id:503
+msgid "Busy"
+msgstr "Ocupado"
+
+#: id:504
+msgid "Empty"
+msgstr "Vacío"
+
+#: id:505
+msgid "Loading media info from files..."
+msgstr "Cargando informacion de archivos..."
+
+#: id:507
+msgid "Sort by: Usage"
+msgstr "Por: Uso"
+
+#: id:510
+msgid "Enable visualizations"
+msgstr "Habilitar Visualizaciones"
+
+#: id:511
+msgid "Enable video mode switching"
+msgstr "Habilitar cambio de modo de vídeo"
+
+#: id:512
+msgid "Startup window"
+msgstr "Pantalla de inicio"
+
+#: id:513
+msgid "Home window"
+msgstr "Pantalla principal"
+
+#: id:514
+msgid "Manual settings"
+msgstr "Ajustes manuales"
+
+#: id:515
+msgid "Genre"
+msgstr "Género"
+
+#: id:517
+msgid "Recently played albums"
+msgstr "Álbumes reproducidos recientemente"
+
+#: id:518
+msgid "Launch"
+msgstr "Lanzar"
+
+#: id:519
+msgid "Launch in..."
+msgstr "Lanzar en.."
+
+#: id:521
+msgid "Compilations"
+msgstr "Compilaciones"
+
+#: id:522
+msgid "Remove source"
+msgstr "Eliminar fuente"
+
+#: id:523
+msgid "Switch media"
+msgstr "Cambiar medio"
+
+#: id:524
+msgid "Select playlist"
+msgstr "Seleccione lista de reproducción"
+
+#: id:525
+msgid "New playlist..."
+msgstr "Nueva Lista de reproducción"
+
+#: id:526
+msgid "Add to playlist"
+msgstr "Añadir a Lista de reproducción"
+
+#: id:527
+msgid "Manually add to library"
+msgstr "Añadir manualmente a biblioteca"
+
+#: id:528
+msgid "Enter title"
+msgstr "Introduzca Título"
+
+#: id:529
+msgid "Error: Duplicate title"
+msgstr "Error: Título duplicado"
+
+#: id:530
+msgid "Select genre"
+msgstr "Seleccione Género"
+
+#: id:531
+msgid "New genre"
+msgstr "Nuevo género"
+
+#: id:532
+msgid "Manual addition"
+msgstr "Adición manual"
+
+#: id:533
+msgid "Enter genre"
+msgstr "Introduzca género"
+
+#: id:534
+msgid "View: %s"
+msgstr "Ver: %s"
+
+#: id:535
+msgid "List"
+msgstr "Lista"
+
+#: id:536
+msgid "Icons"
+msgstr "Iconos"
+
+#: id:537
+msgid "Big list"
+msgstr "Lista grande"
+
+#: id:538
+msgid "Big icons"
+msgstr "I. Grandes"
+
+#: id:539
+msgid "Wide"
+msgstr "Amplio"
+
+#: id:540
+msgid "Big wide"
+msgstr "Amplio Grande"
+
+#: id:541
+msgid "Album icons"
+msgstr "Iconos de Album"
+
+#: id:542
+msgid "DVD icons"
+msgstr "Iconos de DVD"
+
+#: id:543
+msgctxt "Auto context with id 543"
+msgid "DVD"
+msgstr "DVD"
+
+#: id:544
+msgctxt "Auto context with id 544"
+msgid "Media info"
+msgstr "Info de Medio"
+
+#: id:545
+msgid "Audio output device"
+msgstr "Dispositivo de salida de sonido"
+
+#: id:546
+msgid "Passthrough output device"
+msgstr "Dispositivo de salida passthrough"
+
+#: id:547
+msgid "No biography for this artist"
+msgstr "No hay biografía para este artista"
+
+#: id:548
+msgid "Downmix multichannel audio to stereo"
+msgstr "Convertir audio multicanal a stereo"
+
+#: id:550
+msgid "Sort by: %s"
+msgstr "Ordenar por: %s"
+
+#: id:551
+msgctxt "Auto context with id 551"
+msgid "Name"
+msgstr "Nombre"
+
+#: id:552
+msgid "Date"
+msgstr "Fecha"
+
+#: id:553
+msgid "Size"
+msgstr "Tamaño"
+
+#: id:554
+msgid "Track"
+msgstr "Pista"
+
+#: id:555
+msgid "Time"
+msgstr "Hora"
+
+#: id:556
+msgctxt "Auto context with id 556"
+msgid "Title"
+msgstr "Título"
+
+#: id:557
+msgid "Artist"
+msgstr "Artista"
+
+#: id:558
+msgid "Album"
+msgstr "Álbum"
+
+#: id:559
+msgid "Playlist"
+msgstr "Lista de reproducción"
+
+#: id:560
+msgid "ID"
+msgstr "ID"
+
+#: id:561
+msgctxt "Auto context with id 561"
+msgid "File"
+msgstr "Fichero"
+
+#: id:562
+msgctxt "Auto context with id 562"
+msgid "Year"
+msgstr "Año"
+
+#: id:563
+msgid "Rating"
+msgstr "Calificación"
+
+#: id:564
+msgctxt "Auto context with id 564"
+msgid "Type"
+msgstr "Tipo"
+
+#: id:565
+msgid "Usage"
+msgstr "Uso"
+
+#: id:566
+msgid "Album artist"
+msgstr "Artista álbum"
+
+#: id:567
+msgid "Play count"
+msgstr "Contador de reproducción"
+
+#: id:568
+msgid "Last played"
+msgstr "Reproducido por última vez"
+
+#: id:569
+msgctxt "Auto context with id 569"
+msgid "Comment"
+msgstr "Comentario"
+
+#: id:570
+msgid "Date added"
+msgstr "Fecha de inclusión"
+
+#: id:571
+msgctxt "Auto context with id 571"
+msgid "Default"
+msgstr "Por defecto"
+
+#: id:572
+msgid "Studio"
+msgstr "Estudio"
+
+#: id:573
+msgid "Path"
+msgstr "Ruta"
+
+#: id:574
+msgctxt "Auto context with id 574"
+msgid "Country"
+msgstr "País"
+
+#: id:575
+msgid "In progress"
+msgstr "En progreso"
+
+#: id:576
+msgid "Times played"
+msgstr "Veces reproducida"
+
+#: id:580
+msgid "Sort direction"
+msgstr "Dirección de ordenación"
+
+#: id:581
+msgid "Sort method"
+msgstr "Método de ordenación"
+
+#: id:582
+msgctxt "Auto context with id 582"
+msgid "View mode"
+msgstr "Modo de vista"
+
+#: id:583
+msgid "Remember views for different folders"
+msgstr "Recordar vistas para distintas carpetas"
+
+#: id:584
+msgid "Ascending"
+msgstr "Ascendente"
+
+#: id:585
+msgid "Descending"
+msgstr "Descendente"
+
+#: id:586
+msgid "Edit playlist"
+msgstr "Editar lista de reproducción"
+
+#: id:587
+msgid "Filter"
+msgstr "Filtro"
+
+#: id:588
+msgid "Cancel party mode"
+msgstr "Cancelar modo fiesta"
+
+#: id:589
+msgid "Party mode"
+msgstr "Modo fiesta"
+
+#: id:590
+msgid "Random"
+msgstr "Aleatorio"
+
+#: id:591
+msgctxt "Auto context with id 591"
+msgid "Off"
+msgstr "Off"
+
+#: id:592
+msgid "One"
+msgstr "Uno"
+
+#: id:593
+msgid "All"
+msgstr "Todos"
+
+#: id:594
+msgctxt "Auto context with id 594"
+msgid "Off"
+msgstr "Off"
+
+#: id:595
+msgid "Repeat: Off"
+msgstr "Repetir: Off"
+
+#: id:596
+msgid "Repeat: One"
+msgstr "Repetir: Uno"
+
+#: id:597
+msgid "Repeat: All"
+msgstr "Repetir: Todos"
+
+#: id:600
+msgid "Rip audio CD"
+msgstr "Ripear CD de Audio"
+
+#: id:601
+msgctxt "Auto context with id 601"
+msgid "Medium"
+msgstr "Media"
+
+#: id:602
+msgctxt "Auto context with id 602"
+msgid "Standard"
+msgstr "Estándar"
+
+#: id:603
+msgid "Extreme"
+msgstr "Extrema"
+
+#: id:604
+msgid "Constant bitrate"
+msgstr "Bitrate constante"
+
+#: id:605
+msgid "Ripping..."
+msgstr "Ripeando..."
+
+#: id:607
+msgid "To:"
+msgstr "A:"
+
+#: id:608
+msgid "Could not rip CD or track"
+msgstr "No se puede copiar CD o Pista"
+
+#: id:609
+msgid "CDDARipPath is not set."
+msgstr "CDDARipPath no está definido."
+
+#: id:610
+msgid "Rip audio track"
+msgstr "Copiar pista de audio"
+
+#: id:611
+msgid "Enter number"
+msgstr "Introducir número"
+
+#: id:612
+msgid "Bits/Sample"
+msgstr "Bits/Muestra"
+
+#: id:613
+msgid "Sample Frequency"
+msgstr "Frecuencia de muestreo"
+
+#: id:620
+msgid "Audio CDs"
+msgstr "CDs de audio"
+
+#: id:621
+msgid "Encoder"
+msgstr "Codificador"
+
+#: id:622
+msgid "Quality"
+msgstr "Calidad"
+
+#: id:623
+msgid "Bitrate"
+msgstr "Bitrate"
+
+#: id:624
+msgid "Include track number"
+msgstr "Incluir número de pista"
+
+#: id:625
+msgid "All songs of"
+msgstr "Todas las canciones de"
+
+#: id:629
+msgctxt "Auto context with id 629"
+msgid "View mode"
+msgstr "Modo de vista"
+
+#: id:630
+msgctxt "Auto context with id 630"
+msgid "Normal"
+msgstr "Normal"
+
+#: id:631
+msgid "Zoom"
+msgstr "Zoom"
+
+#: id:632
+msgid "Stretch 4:3"
+msgstr "Adaptar a 4:3"
+
+#: id:633
+msgid "Wide Zoom"
+msgstr "Zoom amplio"
+
+#: id:634
+msgid "Stretch 16:9"
+msgstr "Adaptar a 16:9"
+
+#: id:635
+msgid "Original Size"
+msgstr "Tamaño Original"
+
+#: id:636
+msgctxt "Auto context with id 636"
+msgid "Custom"
+msgstr "Personalizado"
+
+#: id:637
+msgid "Replay gain"
+msgstr "Replay gain"
+
+#: id:638
+msgid "Replaygain volume adjustments"
+msgstr "Ajuste de volumen Replay gain"
+
+#: id:639
+msgid "Use track levels"
+msgstr "Usar volumen de la pista"
+
+#: id:640
+msgid "Use album levels"
+msgstr "Usar volumen del álbum"
+
+#: id:641
+msgid "PreAmp Level - Replay gained files"
+msgstr "Nivel PreAmp - archivos con ReplayGain"
+
+#: id:642
+msgid "PreAmp Level - Non replay gained files"
+msgstr "Nivel PreAmp - archivos sin ReplayGain"
+
+#: id:643
+msgid "Avoid clipping on replay gained files"
+msgstr "Evitar distorsión digital en archivos con ReplayGain"
+
+#: id:644
+msgid "Crop black bars"
+msgstr "Eliminar bordes negros"
+
+#: id:645
+msgid "Need to unpack a big file. Continue?"
+msgstr "Es necesario descomprimir un fichero grande. ¿Continuar?"
+
+#: id:646
+msgid "Remove from library"
+msgstr "Eliminar de la base de datos"
+
+#: id:647
+msgid "Export video library"
+msgstr "Exportar biblioteca de vídeo"
+
+#: id:648
+msgid "Import video library"
+msgstr "Importar biblioteca de vídeo"
+
+#: id:649
+msgid "Importing"
+msgstr "Importando"
+
+#: id:650
+msgid "Exporting"
+msgstr "Exportando"
+
+#: id:651
+msgid "Browse for library"
+msgstr "Buscar biblioteca"
+
+#: id:652
+msgid "Years"
+msgstr "Años"
+
+#: id:653
+msgid "Update library"
+msgstr "Actualizar biblioteca"
+
+#: id:654
+msgid "Show debug info"
+msgstr "Ver Info Depuración"
+
+#: id:655
+msgid "Browse for executable"
+msgstr "Buscar Ejecutable"
+
+#: id:656
+msgid "Browse for playlist"
+msgstr "Buscar lista de reproducción"
+
+#: id:657
+msgid "Browse for folder"
+msgstr "Buscar carpeta"
+
+#: id:658
+msgid "Song information"
+msgstr "Info. de la Canción"
+
+#: id:659
+msgid "Non-linear stretch"
+msgstr "Estiramiento No-lineal"
+
+#: id:660
+msgid "Volume amplification"
+msgstr "Amplificación de Volumen"
+
+#: id:661
+msgid "Choose export folder"
+msgstr "Escoja la carpeta de exportación"
+
+#: id:662
+msgid "This file is no longer available."
+msgstr "Éste archivo ya no está disponible"
+
+#: id:663
+msgid "Would you like to remove it from the library?"
+msgstr "¿Le gustaría eliminarlo de la biblioteca?"
+
+#: id:664
+msgid "Browse for Script"
+msgstr "Buscar Script"
+
+#: id:665
+msgid "Compression level"
+msgstr "Nivel de compresión"
+
+#: id:700
+msgid "Cleaning up library"
+msgstr "Limpiando la biblioteca"
+
+#: id:701
+msgid "Removing old songs from the library"
+msgstr "Eliminando canciones antiguas de la biblioteca"
+
+#: id:702
+msgid "This path has been scanned before"
+msgstr "Esta ruta ya ha sido explorada anteriormente"
+
+#: id:705
+msgctxt "Auto context with id 705"
+msgid "Network"
+msgstr "Red"
+
+#: id:706
+msgid "- Server"
+msgstr "- Servidor"
+
+#: id:708
+msgid "Use an HTTP proxy server to access the internet"
+msgstr "Usar servidor proxy para acceder a internet"
+
+#: id:711
+msgid "Internet Protocol (IP)"
+msgstr "Protololo Internet (IP)"
+
+#: id:712
+msgid "Invalid port specified. Value must be between 1 and 65535."
+msgstr "Puerto especificado no válido. El valor debe estar entre 1 y 65535."
+
+#: id:713
+msgid "HTTP proxy"
+msgstr "Proxy HTTP"
+
+#: id:715
+msgid "- Assignment"
+msgstr "- Asignación"
+
+#: id:716
+msgid "Automatic (DHCP)"
+msgstr "Automática (DHCP)"
+
+#: id:717
+msgid "Manual (Static)"
+msgstr "Manual (Estática)"
+
+#: id:719
+msgid "- IP address"
+msgstr "- Dirección IP"
+
+#: id:720
+msgid "- Netmask"
+msgstr "- Máscara de Subred"
+
+#: id:721
+msgid "- Default gateway"
+msgstr "- Puerta de Enlace"
+
+#: id:722
+msgid "- DNS server"
+msgstr "- Servidor DNS"
+
+#: id:723
+msgid "Save & restart"
+msgstr "Guardar y Reiniciar"
+
+#: id:724
+msgid "Invalid address specified. Value must be AAA.BBB.CCC.DDD"
+msgstr "Dirección especificada no válida. El valor debe ser AAA.BBB.CCC.DDD"
+
+#: id:725
+msgid "with numbers between 0 and 255."
+msgstr "con números entre 0 y 255"
+
+#: id:726
+msgid "Changes not saved. Continue without saving?"
+msgstr "¿Continuar sin guardar los cambios?"
+
+#: id:727
+msgid "Web server"
+msgstr "Servidor Web"
+
+#: id:728
+msgctxt "Auto context with id 728"
+msgid "FTP server"
+msgstr "Servidor FTP"
+
+#: id:730
+msgid "- Port"
+msgstr "- Puerto"
+
+#: id:732
+msgid "Save & apply"
+msgstr "Guardar y Aplicar"
+
+#: id:733
+msgid "- Password"
+msgstr "- Contraseña"
+
+#: id:734
+msgid "No pass"
+msgstr "Sin contraseña"
+
+#: id:735
+msgid "- Character set"
+msgstr "- Juego de caracteres"
+
+#: id:736
+msgid "- Style"
+msgstr "- Estilo"
+
+#: id:737
+msgid "- Colour"
+msgstr "- Color"
+
+#: id:738
+msgctxt "Auto context with id 738"
+msgid "Normal"
+msgstr "Normal"
+
+#: id:739
+msgid "Bold"
+msgstr "Negrita"
+
+#: id:740
+msgid "Italics"
+msgstr "Cursiva"
+
+#: id:741
+msgid "Bold italics"
+msgstr "Negrita Cursiva"
+
+#: id:742
+msgctxt "Auto context with id 742"
+msgid "White"
+msgstr "Blanco"
+
+#: id:743
+msgctxt "Auto context with id 743"
+msgid "Yellow"
+msgstr "Amarillo"
+
+#: id:744
+msgctxt "Auto context with id 744"
+msgid "Files"
+msgstr "Archivos"
+
+#: id:745
+msgid "No scanned information for this view"
+msgstr "No se ha explorado información para esta vista"
+
+#: id:746
+msgid "Please turn off library mode"
+msgstr "Por favor apague el modo de biblioteca"
+
+#: id:747
+msgid "Error loading image"
+msgstr "Error cargando imagen"
+
+#: id:748
+msgid "Edit path"
+msgstr "Editar ruta"
+
+#: id:749
+msgid "Mirror image"
+msgstr "Añadir fuente"
+
+#: id:750
+msgid "Are you sure?"
+msgstr "¿Está seguro?"
+
+#: id:751
+msgid "Removing source"
+msgstr "Eliminando fuente"
+
+#: id:754
+msgid "Add program link"
+msgstr "Añadir Enlace a Programa"
+
+#: id:755
+msgid "Edit program path"
+msgstr "Editar Ruta Programa"
+
+#: id:756
+msgid "Edit program name"
+msgstr "Editar Nombre Programa"
+
+#: id:757
+msgid "Edit path depth"
+msgstr "Editar Profundidad Ruta"
+
+#: id:759
+msgid "View: Big list"
+msgstr "Ver: Lista Grande"
+
+#: id:760
+msgctxt "Auto context with id 760"
+msgid "Yellow"
+msgstr "Amarillo"
+
+#: id:761
+msgctxt "Auto context with id 761"
+msgid "White"
+msgstr "Blanco"
+
+#: id:762
+msgid "Blue"
+msgstr "Azul"
+
+#: id:763
+msgid "Bright green"
+msgstr "Verde Claro"
+
+#: id:764
+msgid "Yellow green"
+msgstr "Verde amarillento"
+
+#: id:765
+msgid "Cyan"
+msgstr "Verde azulado"
+
+#: id:766
+msgid "Light grey"
+msgstr "Gris claro"
+
+#: id:767
+msgid "Grey"
+msgstr "Gris"
+
+#: id:770
+msgid "Error %i: share not available"
+msgstr "Error %i: recurso no disponible"
+
+#: id:772
+msgctxt "Auto context with id 772"
+msgid "Audio output"
+msgstr "Hardware Sonido"
+
+#: id:773
+msgid "Seeking"
+msgstr "Buscando"
+
+#: id:774
+msgid "Slideshow folder"
+msgstr "Carpeta de diapositivas"
+
+#: id:775
+msgid "Network interface"
+msgstr "Interfaz de red"
+
+#: id:776
+msgid "- Wireless network name (ESSID)"
+msgstr "- Nombre de la red (ESSID)"
+
+#: id:777
+msgid "- Wireless password"
+msgstr "- Contraseña de red"
+
+#: id:778
+msgid "- Wireless security"
+msgstr "- Seguridad de red"
+
+#: id:779
+msgid "Save and apply network interface settings"
+msgstr "Guardar y aplicar la configuración del interfaz de red"
+
+#: id:780
+msgid "No encryption"
+msgstr "Sin cifrado"
+
+#: id:781
+msgid "WEP"
+msgstr "WEP"
+
+#: id:782
+msgid "WPA"
+msgstr "WPA"
+
+#: id:783
+msgid "WPA2"
+msgstr "WPA2"
+
+#: id:784
+msgid "Applying network interface settings. Please wait."
+msgstr "Aplicando la configuración del interfaz de red. Por favor, espere."
+
+#: id:785
+msgid "Network interface restarted successfully."
+msgstr "La interfaz de red se reinició con éxito."
+
+#: id:786
+msgid "Network interface did not start successfully."
+msgstr "La interfaz de red no se inició con éxito."
+
+#: id:787
+msgid "Interface disabled"
+msgstr "Interfaz deshabilitada"
+
+#: id:788
+msgid "Network interface disabled successfully."
+msgstr "La interfaz de red se deshabilitó con éxito."
+
+#: id:789
+msgid "Wireless network name (ESSID)"
+msgstr "Nombre de la red inalámbrica (ESSID)"
+
+#: id:790
+msgid "Remote control"
+msgstr ""
+
+#: id:791
+msgid "Allow programs on this system to control XBMC"
+msgstr "Permitir que programas en este equipo manejen a XBMC"
+
+#: id:792
+msgctxt "Auto context with id 792"
+msgid "Port"
+msgstr "Puerto"
+
+#: id:793
+msgid "Port range"
+msgstr "Rango de puertos de eventos remotos"
+
+#: id:794
+msgid "Allow programs on other systems to control XBMC"
+msgstr "Permitir que programas de otros equipos manejen a XBMC"
+
+#: id:795
+msgid "Initial repeat delay (ms)"
+msgstr "Retraso inicial de repetición (ms)"
+
+#: id:796
+msgid "Continuous repeat delay (ms)"
+msgstr "Retraso continuo de repetición (ms)"
+
+#: id:797
+msgid "Maximum number of clients"
+msgstr "Número máximo de clientes"
+
+#: id:798
+msgid "Internet access"
+msgstr "Accesso a Internet"
+
+#: id:850
+msgid "Invalid port number entered"
+msgstr "Se ingresó un número de puerto inválido"
+
+#: id:851
+msgid "Valid port range is 1-65535"
+msgstr "El rango válido de puerto es 1-65535"
+
+#: id:852
+msgid "Valid port range is 1024-65535"
+msgstr "El rango válido de puerto es 1024-65535"
+
+#: id:998
+msgid "Add Music..."
+msgstr "Agregar Música..."
+
+#: id:999
+msgid "Add Videos..."
+msgstr "Agregar Videos..."
+
+#: id:1000
+msgid "- Preview"
+msgstr "- Vista previa"
+
+#: id:1001
+msgid "Unable to connect"
+msgstr "Imposible conectar"
+
+#: id:1002
+msgid "XBMC was unable to connect to the network location."
+msgstr "XBMC ha sido incapaz de conectar a la dirección de red."
+
+#: id:1003
+msgid "This could be due to the network not being connected."
+msgstr "Podría ser debido a que la red no esté conectada."
+
+#: id:1004
+msgid "Would you like to add it anyway?"
+msgstr "¿Desea añadirla de todos modos?"
+
+#: id:1006
+msgctxt "Auto context with id 1006"
+msgid "IP address"
+msgstr "Dirección IP"
+
+#: id:1007
+msgid "Add network location"
+msgstr "Añadir Dirección de Red"
+
+#: id:1008
+msgid "Protocol"
+msgstr "Protocolo"
+
+#: id:1009
+msgid "Server address"
+msgstr "Dirección del Servidor"
+
+#: id:1010
+msgid "Server name"
+msgstr "Nombre del Servidor"
+
+#: id:1011
+msgid "Remote path"
+msgstr "Ruta Remota"
+
+#: id:1012
+msgid "Shared folder"
+msgstr "Carpeta compartida"
+
+#: id:1013
+msgctxt "Auto context with id 1013"
+msgid "Port"
+msgstr "Puerto"
+
+#: id:1014
+msgctxt "Auto context with id 1014"
+msgid "Username"
+msgstr "Usuario"
+
+#: id:1015
+msgid "Browse for network server"
+msgstr "servidor de red"
+
+#: id:1016
+msgid "Enter the network address of the server"
+msgstr "Introduzca la dirección de red del servidor"
+
+#: id:1017
+msgid "Enter the path on the server"
+msgstr "Introduzca la ruta en el servidor"
+
+#: id:1018
+msgid "Enter the port number"
+msgstr "Introduzca el número de puerto"
+
+#: id:1019
+msgid "Enter the username"
+msgstr "Introduzca el nombre de usuario"
+
+#: id:1020
+msgid "Add %s source"
+msgstr "Añadir fuente %s"
+
+#: id:1021
+msgid "Enter the paths or browse for the media locations."
+msgstr "Introduzca las rutas o busque la ubicación del medio."
+
+#: id:1022
+msgid "Enter a name for this media Source."
+msgstr "Introduzca un nombre para la Fuente."
+
+#: id:1023
+msgid "Browse for new share"
+msgstr "Buscar un nuevo recurso compartido"
+
+#: id:1024
+msgid "Browse"
+msgstr "Buscar"
+
+#: id:1025
+msgid "Could not retrieve directory information."
+msgstr "No se ha podido recuperar información de la carpeta."
+
+#: id:1026
+msgid "Add source"
+msgstr "Añadir fuente"
+
+#: id:1027
+msgid "Edit source"
+msgstr "Editar fuente"
+
+#: id:1028
+msgid "Edit %s source"
+msgstr "Editar fuente %s"
+
+#: id:1029
+msgid "Enter the new label"
+msgstr "Introduzca la nueva etiqueta"
+
+#: id:1030
+msgid "Browse for image"
+msgstr "Buscar imagen"
+
+#: id:1031
+msgid "Browse for image folder"
+msgstr "Buscar carpeta de imágenes"
+
+#: id:1032
+msgid "Add network location..."
+msgstr "Añadir sitio de red..."
+
+#: id:1033
+msgid "Browse for file"
+msgstr "Buscar fichero"
+
+#: id:1034
+msgid "Submenu"
+msgstr "Submenú"
+
+#: id:1035
+msgid "Enable submenu buttons"
+msgstr "Habilitar Botones de Submenú"
+
+#: id:1036
+msgid "Favourites"
+msgstr "Favoritos"
+
+#: id:1037
+msgid "Video Add-ons"
+msgstr "Addons de Vídeo"
+
+#: id:1038
+msgid "Music Add-ons"
+msgstr "Addons de Música"
+
+#: id:1039
+msgid "Picture Add-ons"
+msgstr "Addons de Imágenes"
+
+#: id:1040
+msgid "Loading directory"
+msgstr "Cargando carpeta"
+
+#: id:1041
+msgid "Retrieved %i items"
+msgstr "%i elementos obtenidos"
+
+#: id:1042
+msgid "Retrieved %i of %i items"
+msgstr "%i de %i elementos obtenidos"
+
+#: id:1043
+msgid "Program Add-ons"
+msgstr "Addons de Aplicaciones"
+
+#: id:1044
+msgid "Set plugin thumb"
+msgstr "Establecer miniatura de plugin"
+
+#: id:1045
+msgid "Add-on settings"
+msgstr "Configuración del Addon"
+
+#: id:1046
+msgid "Access points"
+msgstr "Puntos de acceso"
+
+#: id:1047
+msgid "Other..."
+msgstr "Otro..."
+
+#: id:1048
+msgid "- Username"
+msgstr "- Nombre de usuario"
+
+#: id:1049
+msgid "Script settings"
+msgstr "Configuración de Script"
+
+#: id:1050
+msgid "Singles"
+msgstr "Simples"
+
+#: id:1051
+msgid "Enter web address"
+msgstr "Ingrese dir. web"
+
+#: id:1200
+msgid "SMB client"
+msgstr "Cliente SMB"
+
+#: id:1202
+msgid "Workgroup"
+msgstr "Grupo de trabajo"
+
+#: id:1203
+msgid "Default username"
+msgstr "Usuario por defecto"
+
+#: id:1204
+msgid "Default password"
+msgstr "Contraseña por defecto"
+
+#: id:1207
+msgid "WINS server"
+msgstr "Servidor WINS"
+
+#: id:1208
+msgid "Mount SMB shares"
+msgstr "Montar recursos compartidos SMB"
+
+#: id:1210
+msgctxt "Auto context with id 1210"
+msgid "Remove"
+msgstr "Eliminar"
+
+#: id:1211
+msgctxt "Auto context with id 1211"
+msgid "Music"
+msgstr "Música"
+
+#: id:1212
+msgctxt "Auto context with id 1212"
+msgid "Video"
+msgstr "Vídeo"
+
+#: id:1213
+msgctxt "Auto context with id 1213"
+msgid "Pictures"
+msgstr "Imágenes"
+
+#: id:1214
+msgctxt "Auto context with id 1214"
+msgid "Files"
+msgstr "Archivos"
+
+#: id:1215
+msgctxt "Auto context with id 1215"
+msgid "Music & video"
+msgstr "Música y vídeo"
+
+#: id:1216
+msgid "Music & pictures"
+msgstr "Música e imágenes"
+
+#: id:1217
+msgid "Music & files"
+msgstr "Música y archivos"
+
+#: id:1218
+msgid "Video & pictures"
+msgstr "Vídeo e imágenes"
+
+#: id:1219
+msgid "Video & files"
+msgstr "Vídeo y archivos"
+
+#: id:1220
+msgid "Pictures & files"
+msgstr "Imágenes y archivos"
+
+#: id:1221
+msgid "Music & video & pictures"
+msgstr "Música, vídeo e imágenes"
+
+#: id:1222
+msgid "Music & video & pictures & files"
+msgstr "Música, vídeo, imágenes y archivos"
+
+#: id:1223
+msgctxt "Auto context with id 1223"
+msgid "Disabled"
+msgstr "Deshabilitado"
+
+#: id:1226
+msgid "Files & music & video"
+msgstr "Archivos, música y video"
+
+#: id:1227
+msgid "Files & pictures & music"
+msgstr "Archivos, imágenes y música"
+
+#: id:1228
+msgid "Files & pictures & video"
+msgstr "Archivos, imágenes y video"
+
+#: id:1229
+msgid "Music & programs"
+msgstr "Música y programas"
+
+#: id:1230
+msgid "Video & programs"
+msgstr "Vídeo y programas"
+
+#: id:1231
+msgid "Pictures & programs"
+msgstr "Imágenes y programas"
+
+#: id:1232
+msgid "Music & video & pictures & programs"
+msgstr "Música, video, imágenes y programas"
+
+#: id:1233
+msgid "Programs & video & music"
+msgstr "Programas, video y música"
+
+#: id:1234
+msgid "Programs & pictures & music"
+msgstr "Programas, imágenes y música"
+
+#: id:1235
+msgid "Programs & pictures & video"
+msgstr "Programas, imágenes y video"
+
+#: id:1250
+msgid "Auto-detection"
+msgstr "Autodetección"
+
+#: id:1251
+msgid "Auto-detect system"
+msgstr "Autodetectar sistema"
+
+#: id:1252
+msgid "Nickname"
+msgstr "Nickname"
+
+#: id:1254
+msgid "Ask to connect"
+msgstr "Preguntar antes de conectar"
+
+#: id:1255
+msgid "Send FTP user and password"
+msgstr "Enviar usuario y contraseña FTP"
+
+#: id:1256
+msgid "Ping interval"
+msgstr "Intervalo de Ping"
+
+#: id:1257
+msgid "Would you like to connect to the auto-detected system?"
+msgstr "¿Desea conectar al sistema autodetectado?"
+
+#: id:1259
+msgid "Zeroconf"
+msgstr ""
+
+#: id:1260
+msgid "Announce these services to other systems via Zeroconf"
+msgstr "Publicar servicios con Zeroconf"
+
+#: id:1270
+msgid "Allow XBMC to receive AirPlay content"
+msgstr "Permitir que XBMC reciba contenido AirPlay"
+
+#: id:1271
+msgid "Device name"
+msgstr "Nombre de dispositivo"
+
+#: id:1272
+msgid "- Use password protection"
+msgstr "- Usar contraseña"
+
+#: id:1273
+msgid "AirPlay"
+msgstr ""
+
+#: id:1300
+msgid "Custom audio device"
+msgstr "Dispositivo de audio especial"
+
+#: id:1301
+msgid "Custom passthrough device"
+msgstr "Dispositivo passthrough especial"
+
+#: id:1396
+msgid "Drifting"
+msgstr "A la deriva"
+
+#: id:1397
+msgid "and"
+msgstr "y"
+
+#: id:1398
+msgid "Freezing"
+msgstr "Helando"
+
+#: id:1399
+msgid "Late"
+msgstr "Tarde"
+
+#: id:1400
+msgid "Isolated"
+msgstr "Aisladas"
+
+#: id:1401
+msgid "Thundershowers"
+msgstr "Tormentas"
+
+#: id:1402
+msgid "Thunder"
+msgstr "Truenos"
+
+#: id:1403
+msgctxt "Auto context with id 1403"
+msgid "Sun"
+msgstr "Sol"
+
+#: id:1404
+msgid "Heavy"
+msgstr "Fuerte"
+
+#: id:1405
+msgid "in"
+msgstr "en"
+
+#: id:1406
+msgid "the"
+msgstr "la"
+
+#: id:1407
+msgid "Vicinity"
+msgstr "Vecindad"
+
+#: id:1408
+msgid "Ice"
+msgstr "Hielo"
+
+#: id:1409
+msgid "Crystals"
+msgstr "Granizo"
+
+#: id:1410
+msgid "Calm"
+msgstr "Calma"
+
+#: id:1411
+msgid "with"
+msgstr "con"
+
+#: id:1412
+msgid "windy"
+msgstr "ventoso"
+
+#: id:1413
+msgid "drizzle"
+msgstr "llovizna"
+
+#: id:1414
+msgid "Thunderstorm"
+msgstr "Tormenta Eléctrica"
+
+#: id:1415
+msgid "Drizzle"
+msgstr "Llovizna"
+
+#: id:1416
+msgid "Foggy"
+msgstr "Brumoso"
+
+#: id:1417
+msgid "Grains"
+msgstr "Granos"
+
+#: id:1418
+msgid "T-Storms"
+msgstr "T. Eléctricas"
+
+#: id:1419
+msgid "T-Showers"
+msgstr "Tormentas"
+
+#: id:1420
+msgid "Moderate"
+msgstr "Moderado"
+
+#: id:1421
+msgid "Very High"
+msgstr "Muy Alta"
+
+#: id:1422
+msgid "Windy"
+msgstr "Ventoso"
+
+#: id:1423
+msgid "Mist"
+msgstr "Niebla"
+
+#: id:1450
+msgid "Put display to sleep when idle"
+msgstr "Apagar pantalla cuando esté desocupado"
+
+#: id:2050
+msgid "Runtime"
+msgstr "Duración:"
+
+#: id:2100
+msgid "Script failed! : %s"
+msgstr "Falló script : %s"
+
+#: id:2101
+msgid "Newer version needed - See log"
+msgstr "Se necesita nueva versión - Vea log"
+
+#: id:4501
+msgid "Enable LCD/VFD"
+msgstr "Activar LCD/VFD"
+
+#: id:10000
+msgid "Home"
+msgstr "Inicio"
+
+#: id:10001
+msgctxt "Auto context with id 10001"
+msgid "Programs"
+msgstr "Programas"
+
+#: id:10002
+msgctxt "Auto context with id 10002"
+msgid "Pictures"
+msgstr "Imágenes"
+
+#: id:10003
+msgctxt "Auto context with id 10003"
+msgid "File manager"
+msgstr "Administrador de archivos"
+
+#: id:10004
+msgctxt "Auto context with id 10004"
+msgid "Settings"
+msgstr "Configuración"
+
+#: id:10005
+msgctxt "Auto context with id 10005"
+msgid "Music"
+msgstr "Música"
+
+#: id:10006
+msgctxt "Auto context with id 10006"
+msgid "Videos"
+msgstr "Vídeos"
+
+#: id:10007
+msgid "System information"
+msgstr "Información del Sistema"
+
+#: id:10008
+msgid "Settings - General"
+msgstr "Configuración - General"
+
+#: id:10009
+msgid "Settings - Screen"
+msgstr "Configuración - Pantalla"
+
+#: id:10010
+msgid "Settings - Appearance - GUI Calibration"
+msgstr "Configuración - Pantalla - Calibración GUI"
+
+#: id:10011
+msgid "Settings - Videos - Screen Calibration"
+msgstr "Configuración - Videos - Calibración Pantalla"
+
+#: id:10012
+msgid "Settings - Pictures"
+msgstr "Configuración - Imágenes"
+
+#: id:10013
+msgid "Settings - Programs"
+msgstr "Configuración - Programas"
+
+#: id:10014
+msgid "Settings - Weather"
+msgstr "Configuración - Clima"
+
+#: id:10015
+msgid "Settings - Music"
+msgstr "Configuración - Música"
+
+#: id:10016
+msgid "Settings - System"
+msgstr "Configuración - Sistema"
+
+#: id:10017
+msgid "Settings - Videos"
+msgstr "Configuración - Videos"
+
+#: id:10018
+msgid "Settings - Network"
+msgstr "Configuración - Red"
+
+#: id:10019
+msgid "Settings - Appearance"
+msgstr "Configuración - Apariencia"
+
+#: id:10020
+msgctxt "Auto context with id 10020"
+msgid "Scripts"
+msgstr "Scripts"
+
+#: id:10021
+msgid "Web Browser"
+msgstr "Navegador Web"
+
+#: id:10025
+msgctxt "Auto context with id 10025"
+msgid "Videos"
+msgstr ""
+
+#: id:10028
+msgid "Videos/Playlist"
+msgstr "Vídeos/Lista de reproducción"
+
+#: id:10029
+msgctxt "Auto context with id 10029"
+msgid "Login screen"
+msgstr ""
+
+#: id:10034
+msgid "Settings - Profiles"
+msgstr "Configuración - Perfiles"
+
+#: id:10040
+msgid "Addon browser"
+msgstr ""
+
+#: id:10100
+msgid "Yes/No dialog"
+msgstr "Cuadro de diálogo Sí/No"
+
+#: id:10101
+msgid "Progress dialog"
+msgstr "Diálogo de Progreso"
+
+#: id:10210
+msgid "Looking for subtitles..."
+msgstr "Buscando subtítulos..."
+
+#: id:10211
+msgid "Looking for or caching subtitles..."
+msgstr "Cacheando subtítulos..."
+
+#: id:10212
+msgid "terminating"
+msgstr "finalizando"
+
+#: id:10213
+msgid "buffering"
+msgstr "buffering"
+
+#: id:10214
+msgid "Opening stream"
+msgstr "Abriendo flujo"
+
+#: id:10500
+msgid "Music/Playlist"
+msgstr "Música/Lista de reproducción"
+
+#: id:10501
+msgid "Music/Files"
+msgstr "Música/Archivos"
+
+#: id:10502
+msgid "Music/Library"
+msgstr "Música/Biblioteca"
+
+#: id:10503
+msgid "Playlist editor"
+msgstr "Editor de listas de reproducción"
+
+#: id:10504
+msgid "Top 100 songs"
+msgstr "Top 100 Canciones"
+
+#: id:10505
+msgid "Top 100 albums"
+msgstr "Top 100 Albumes"
+
+#: id:10506
+msgctxt "Auto context with id 10506"
+msgid "Programs"
+msgstr "Programas"
+
+#: id:10507
+msgid "Configuration"
+msgstr "Configuración"
+
+#: id:10508
+msgid "Weather forecast"
+msgstr "Pronóstico del Tiempo"
+
+#: id:10509
+msgid "Network gaming"
+msgstr "Juego en Red"
+
+#: id:10510
+msgid "Extensions"
+msgstr "Extensiones"
+
+#: id:10511
+msgctxt "Auto context with id 10511"
+msgid "System info"
+msgstr "Info Sistema"
+
+#: id:10516
+msgid "Music - Library"
+msgstr "Música - Biblioteca"
+
+#: id:10517
+msgid "Now Playing - Music"
+msgstr "Música - Reproduciendo"
+
+#: id:10522
+msgid "Now Playing - Videos"
+msgstr "Vídeo - Reproduciendo"
+
+#: id:10523
+msgid "Album info"
+msgstr "Info de álbum"
+
+#: id:10524
+msgid "Movie info"
+msgstr "Infor de película"
+
+#: id:12000
+msgid "Select dialog"
+msgstr "Diálogo de Selección"
+
+#: id:12001
+msgid "Music/Info"
+msgstr "Música/info"
+
+#: id:12002
+msgid "Dialog OK"
+msgstr "Diálogo de OK"
+
+#: id:12003
+msgid "Videos/Info"
+msgstr "Vídeos/Info"
+
+#: id:12004
+msgid "Scripts/Info"
+msgstr "Secuencias de Comandos/Info"
+
+#: id:12005
+msgid "Fullscreen video"
+msgstr "Vídeo a pantalla completa"
+
+#: id:12006
+msgid "Audio visualization"
+msgstr "Visualización de sonido"
+
+#: id:12008
+msgid "File stacking dialog"
+msgstr "Diálogo de agrupar archivos"
+
+#: id:12009
+msgid "Rebuild index..."
+msgstr "Reconstruir índice..."
+
+#: id:12010
+msgid "Return to music window"
+msgstr "Volver a Ventana Música"
+
+#: id:12011
+msgid "Return to videos window"
+msgstr "Volver a Ventana Vídeos"
+
+#: id:12021
+msgid "Start from beginning"
+msgstr "Comenzar desde el principio"
+
+#: id:12022
+msgid "Resume from %s"
+msgstr "Continuar desde la posición %s"
+
+#: id:12310
+msgid "0"
+msgstr "0"
+
+#: id:12311
+msgid "1"
+msgstr "1"
+
+#: id:12312
+msgid "2"
+msgstr "2"
+
+#: id:12313
+msgid "3"
+msgstr "3"
+
+#: id:12314
+msgid "4"
+msgstr "4"
+
+#: id:12315
+msgid "5"
+msgstr "5"
+
+#: id:12316
+msgid "6"
+msgstr "6"
+
+#: id:12317
+msgid "7"
+msgstr "7"
+
+#: id:12318
+msgid "8"
+msgstr "8"
+
+#: id:12319
+msgid "9"
+msgstr "9"
+
+#: id:12320
+msgid "c"
+msgstr "c"
+
+#: id:12321
+msgid "Ok"
+msgstr "Ok"
+
+#: id:12322
+msgid "*"
+msgstr "*"
+
+#: id:12325
+msgid "Locked! Enter code..."
+msgstr "¡Bloqueado! Introduzca código..."
+
+#: id:12326
+msgid "Enter password"
+msgstr "Introduzca la contraseña"
+
+#: id:12327
+msgid "Enter master code"
+msgstr "Introduzca el código maestro"
+
+#: id:12328
+msgid "Enter unlock code"
+msgstr "Introduzca el código de desbloqueo"
+
+#: id:12329
+msgid "or press C to cancel"
+msgstr "o pulse C para cancelar"
+
+#: id:12330
+msgid "Enter gamepad button combo and"
+msgstr "Introduzca la combinación de botones en el gamepad y"
+
+#: id:12331
+msgid "press OK, or Back to cancel"
+msgstr "pulse Start, o Back para cancelar"
+
+#: id:12332
+msgid "Set lock"
+msgstr "Bloquear"
+
+#: id:12333
+msgid "Unlock"
+msgstr "Desbloquear"
+
+#: id:12334
+msgid "Reset lock"
+msgstr "Reiniciar bloqueo"
+
+#: id:12335
+msgid "Remove lock"
+msgstr "Quitar Bloqueo"
+
+#: id:12337
+msgid "Numeric password"
+msgstr "Contraseña numérica"
+
+#: id:12338
+msgid "Gamepad button combo"
+msgstr "Combinación de botones del mando de juego"
+
+#: id:12339
+msgid "Full-text password"
+msgstr "Contraseña alfanumérica"
+
+#: id:12340
+msgid "Enter new password"
+msgstr "Introduzca la nueva contraseña"
+
+#: id:12341
+msgid "Re-Enter new password"
+msgstr "Reintroduzca la nueva contraseña"
+
+#: id:12342
+msgid "Incorrect password,"
+msgstr "Contraseña incorrecta,"
+
+#: id:12343
+msgid "retries left"
+msgstr "intentos restantes"
+
+#: id:12344
+msgid "Passwords entered did not match."
+msgstr "Las contraseñas introducidas no coinciden."
+
+#: id:12345
+msgid "Access denied"
+msgstr "Acceso Denegado"
+
+#: id:12346
+msgid "Password retry limit exceeded."
+msgstr "Límite de intentos de contraseña excedidos."
+
+#: id:12347
+msgid "The system will now shut off."
+msgstr "El equipo se apagará ahora."
+
+#: id:12348
+msgid "Item locked"
+msgstr "Elemento Bloqueado"
+
+#: id:12353
+msgid "Reactivate lock"
+msgstr "Reactivar Bloqueo"
+
+#: id:12356
+msgid "Change lock"
+msgstr "Cambiar Bloqueo"
+
+#: id:12357
+msgid "Source lock"
+msgstr "Bloqueo de Recurso"
+
+#: id:12358
+msgid "Password entry was blank. Try again."
+msgstr "Contraseña introducida en blanco. Inténtelo de nuevo."
+
+#: id:12360
+msgid "Master lock"
+msgstr "Bloqueo Maestro"
+
+#: id:12362
+msgid "Shutdown system if Master Lock retries exceeded"
+msgstr "Apagar equipo si se excede el máximo de intentos"
+
+#: id:12367
+msgid "Master code is not valid"
+msgstr "¡Código Maestro no válido!"
+
+#: id:12368
+msgid "Please enter a valid master code"
+msgstr "¡Por favor, introduzca un Código Maestro Válido!"
+
+#: id:12373
+msgid "Settings & file manager"
+msgstr "Configuración y Archivos"
+
+#: id:12376
+msgid "Set as default for all movies"
+msgstr "Asignar por defecto para todas las Películas"
+
+#: id:12377
+msgid "This will reset any previously saved values"
+msgstr "Esto eliminará cualquier valor previamente salvado"
+
+#: id:12378
+msgid "Amount of time to display each image"
+msgstr "Mostrar cada imagen durante"
+
+#: id:12379
+msgid "Use pan and zoom effects"
+msgstr "Usar efectos de movimiento y ampliación"
+
+#: id:12383
+msgid "12 hour clock"
+msgstr "Reloj de 12 horas"
+
+#: id:12384
+msgid "24 hour clock"
+msgstr "Reloj de 24 horas"
+
+#: id:12385
+msgid "Day/Month"
+msgstr "Día/Mes"
+
+#: id:12386
+msgid "Month/Day"
+msgstr "Mes/Día"
+
+#: id:12390
+msgid "System uptime"
+msgstr "Encendido hace"
+
+#: id:12391
+msgid "Minutes"
+msgstr "Minutos"
+
+#: id:12392
+msgid "Hours"
+msgstr "Horas"
+
+#: id:12393
+msgid "Days"
+msgstr "Días"
+
+#: id:12394
+msgid "Total uptime"
+msgstr "Tiempo total encendido"
+
+#: id:12395
+msgid "Battery level"
+msgstr "Nivel de batería"
+
+#: id:12600
+msgctxt "Auto context with id 12600"
+msgid "Weather"
+msgstr "Clima"
+
+#: id:12900
+msgctxt "Auto context with id 12900"
+msgid "Screensaver"
+msgstr "Salvapantallas"
+
+#: id:12901
+msgid "Fullscreen OSD"
+msgstr "OSD a pantalla completa"
+
+#: id:13000
+msgid "System"
+msgstr "Sistema"
+
+#: id:13001
+msgid "Immediate HD spindown"
+msgstr "Parar el disco duro inmediatamente"
+
+#: id:13002
+msgid "Video only"
+msgstr "Sólo Vídeo"
+
+#: id:13003
+msgid "- Delay"
+msgstr "- Retardo"
+
+#: id:13004
+msgid "- Minimum file duration"
+msgstr "- Duración mínima del fichero"
+
+#: id:13005
+msgid "Shutdown"
+msgstr "Apagar"
+
+#: id:13008
+msgid "Shutdown function"
+msgstr "Acción de apagar"
+
+#: id:13009
+msgid "Quit"
+msgstr "Salir"
+
+#: id:13010
+msgid "Hibernate"
+msgstr "Hibernar"
+
+#: id:13011
+msgid "Suspend"
+msgstr "Suspender"
+
+#: id:13012
+msgid "Exit"
+msgstr "Salir"
+
+#: id:13013
+msgid "Reboot"
+msgstr "Reiniciar"
+
+#: id:13014
+msgid "Minimize"
+msgstr "Minimizar"
+
+#: id:13015
+msgid "Power button action"
+msgstr "Acción del boton de Encendido"
+
+#: id:13016
+msgid "Power off System"
+msgstr "Apagar sistema"
+
+#: id:13020
+msgid "Is another session active, perhaps over ssh?"
+msgstr "Existe otra sesión activa, ¿tal vez ssh?"
+
+#: id:13021
+msgid "Mounted removable harddrive"
+msgstr "Disco duro remoto montado"
+
+#: id:13022
+msgid "Unsafe device removal"
+msgstr "Expulsión de dispositivo no segura"
+
+#: id:13023
+msgid "Successfully removed device"
+msgstr "Dispositivo eliminado correctamente"
+
+#: id:13024
+msgid "Joystick plugged"
+msgstr "Joystick conectado"
+
+#: id:13025
+msgid "Joystick unplugged"
+msgstr "Joystick desconectado"
+
+#: id:13050
+msgid "Running low on battery"
+msgstr "Se está quedando sin batería"
+
+#: id:13100
+msgid "Flicker filter"
+msgstr "Filtro antivibración"
+
+#: id:13101
+msgid "Let driver choose (requires restart)"
+msgstr "Permitir que el controlador elija (requiere reinicio)"
+
+#: id:13105
+msgid "Vertical blank sync"
+msgstr "Sinc. de refresco vertical"
+
+#: id:13106
+msgctxt "Auto context with id 13106"
+msgid "Disabled"
+msgstr "Deshabilitado"
+
+#: id:13107
+msgid "Enabled during video playback"
+msgstr "Al reproducir vídeo"
+
+#: id:13108
+msgctxt "Auto context with id 13108"
+msgid "Always enabled"
+msgstr "Siempre habilitado"
+
+#: id:13109
+msgid "Test & apply resolution"
+msgstr "Probar resolución"
+
+#: id:13110
+msgid "Save resolution?"
+msgstr "¿Guardar resolución?"
+
+#: id:13111
+msgid "Would you like to keep this resolution?"
+msgstr "¿Desea mantener esta resolución?"
+
+#: id:13112
+msgid "High quality upscaling"
+msgstr "Reescalado de alta calidad"
+
+#: id:13113
+msgctxt "Auto context with id 13113"
+msgid "Disabled"
+msgstr "Deshabilitado"
+
+#: id:13114
+msgid "Enabled for SD content"
+msgstr "Habilitado para contenido en SD"
+
+#: id:13115
+msgctxt "Auto context with id 13115"
+msgid "Always enabled"
+msgstr "Siempre habilitado"
+
+#: id:13116
+msgid "Upscaling method"
+msgstr "Método de reescalado"
+
+#: id:13117
+msgctxt "Auto context with id 13117"
+msgid "Bicubic"
+msgstr "Bicúbico"
+
+#: id:13118
+msgid "Lanczos"
+msgstr "Lanczos"
+
+#: id:13119
+msgid "Sinc"
+msgstr "Sinc"
+
+#: id:13120
+msgctxt "Auto context with id 13120"
+msgid "VDPAU"
+msgstr "VDPAU"
+
+#: id:13121
+msgid "VDPAU HQ Upscaling level"
+msgstr "Nivel de reescalado HQ VDPAU"
+
+#: id:13122
+msgid "VDPAU Studio level color conversion"
+msgstr "Conversión de color VDPAU con calidad de estudio"
+
+#: id:13130
+msgid "Blank other displays"
+msgstr "Mostrar refresco"
+
+#: id:13131
+msgctxt "Auto context with id 13131"
+msgid "Disabled"
+msgstr "Deshabilitado"
+
+#: id:13132
+msgid "Blank displays"
+msgstr "Pantallas de refresco"
+
+#: id:13140
+msgid "Active connections detected!"
+msgstr "Conexiones activas detectadas!"
+
+#: id:13141
+msgid "If you proceed, you might not be able to control XBMC"
+msgstr "Si continúa, puede que pierda el control de XBMC"
+
+#: id:13142
+msgid "any longer. Are you sure you want to stop the Event server?"
+msgstr "¿Está seguro de que quiere parar el servidor de eventos??"
+
+#: id:13144
+msgid "Change Apple Remote mode?"
+msgstr "¿Cambiar modo Apple remoto"
+
+#: id:13145
+msgid "If you are currently using the Apple Remote to control"
+msgstr "Si está usando Apple Remote para controlar"
+
+#: id:13146
+msgid "XBMC, changing this setting might affect your ability"
+msgstr "XBMC, cambiar éste ajuste puede afectar su capacidad"
+
+#: id:13147
+msgid "to continue controlling it. Do you want to proceed?"
+msgstr "para continuar controlándolo.¿Desea continuar?"
+
+#: id:13159
+msgid "Subnet mask"
+msgstr "Máscara de red"
+
+#: id:13160
+msgid "Gateway"
+msgstr "Puerta de enlace"
+
+#: id:13161
+msgid "Primary DNS"
+msgstr "DNS Primario"
+
+#: id:13162
+msgid "Initialize failed"
+msgstr "Fallo en inicialización"
+
+#: id:13170
+msgctxt "Auto context with id 13170"
+msgid "Never"
+msgstr "Nunca"
+
+#: id:13171
+msgid "Immediately"
+msgstr "Inmediatamente"
+
+#: id:13172
+msgid "After %i secs"
+msgstr "Después de %i segs."
+
+#: id:13173
+msgid "HDD install date:"
+msgstr "Fecha de instalación del disco duro:"
+
+#: id:13174
+msgid "HDD power cycle count:"
+msgstr "Contador de encendidos del disco duro:"
+
+#: id:13200
+msgid "Profiles"
+msgstr "Perfiles"
+
+#: id:13201
+msgid "Delete profile '%s'?"
+msgstr "¿Eliminar el perfil '%s'?"
+
+#: id:13204
+msgid "Last loaded profile:"
+msgstr "Último perfil cargado:"
+
+#: id:13205
+msgid "Unknown"
+msgstr "Desconocido"
+
+#: id:13206
+msgid "Overwrite"
+msgstr "Sobreescribir"
+
+#: id:13208
+msgid "Alarm clock"
+msgstr "Alarma de Reloj"
+
+#: id:13209
+msgid "Alarm clock interval (in minutes)"
+msgstr "Intervalo de Alarma de Reloj (en minutos)"
+
+#: id:13210
+msgid "Started, alarm in %im"
+msgstr "Iniciada, alarma en %im"
+
+#: id:13211
+msgid "Alarm!"
+msgstr "¡Alarma!"
+
+#: id:13212
+msgid "Canceled with %im%is left"
+msgstr "Cancelada antes de %im%is"
+
+#: id:13213
+msgid "%2.0fm"
+msgstr "%2.0fm"
+
+#: id:13214
+msgid "%2.0fs"
+msgstr "%2.0fs"
+
+#: id:13249
+msgid "Search for subtitles in RARs"
+msgstr "Buscar subtítulos en RARs"
+
+#: id:13250
+msgid "Browse for subtitle..."
+msgstr "Buscar subtítulos..."
+
+#: id:13251
+msgid "Move item"
+msgstr "Mover Elemento"
+
+#: id:13252
+msgid "Move item here"
+msgstr "Mover Elemento Aquí"
+
+#: id:13253
+msgid "Cancel move"
+msgstr "Cancelar Movimiento"
+
+#: id:13270
+msgid "Hardware:"
+msgstr "Hardware:"
+
+#: id:13271
+msgid "CPU Usage:"
+msgstr "Uso de CPU:"
+
+#: id:13274
+msgid "Connected, but no DNS is available."
+msgstr "Conectado, pero no hay un DNS disponible."
+
+#: id:13275
+msgid "Hard Disk"
+msgstr "Disco duro"
+
+#: id:13276
+msgid "DVD-ROM"
+msgstr "DVD-ROM"
+
+#: id:13277
+msgctxt "Auto context with id 13277"
+msgid "Storage"
+msgstr "Almacenamiento"
+
+#: id:13278
+msgctxt "Auto context with id 13278"
+msgid "Default"
+msgstr "Por defecto"
+
+#: id:13279
+msgctxt "Auto context with id 13279"
+msgid "Network"
+msgstr "Red de trabajo"
+
+#: id:13280
+msgctxt "Auto context with id 13280"
+msgid "Video"
+msgstr "Vídeo"
+
+#: id:13281
+msgid "Hardware"
+msgstr "Hardware"
+
+#: id:13283
+msgid "Operating system:"
+msgstr "Sistema operativo:"
+
+#: id:13284
+msgid "CPU speed:"
+msgstr "Velocidad de CPU:"
+
+#: id:13286
+msgid "Video encoder:"
+msgstr "Codificador de Vídeo:"
+
+#: id:13287
+msgid "Screen resolution:"
+msgstr "Resolución de pantalla:"
+
+#: id:13292
+msgid "A/V cable:"
+msgstr "Cable A/V:"
+
+#: id:13294
+msgid "DVD region:"
+msgstr "Región de DVD:"
+
+#: id:13295
+msgid "Internet:"
+msgstr "Internet:"
+
+#: id:13296
+msgctxt "Auto context with id 13296"
+msgid "Connected"
+msgstr "Conectado"
+
+#: id:13297
+msgid "Not connected. Check network settings."
+msgstr "No conectado. Compruebe la configuración de red."
+
+#: id:13299
+msgid "Target temperature"
+msgstr "Temperatura deseada"
+
+#: id:13300
+msgid "Fan speed"
+msgstr "Velocidad del ventilador"
+
+#: id:13301
+msgid "Auto temperature control"
+msgstr "Control del ventilador por temperatura"
+
+#: id:13302
+msgid "Fan speed override"
+msgstr "Control manual del ventilador"
+
+#: id:13303
+msgid "- Fonts"
+msgstr "- Tipografías"
+
+#: id:13304
+msgid "Enable flipping bi-directional strings"
+msgstr "Invertir cadenas bidireccionales"
+
+#: id:13305
+msgid "Show RSS news feeds"
+msgstr "Activar noticias RSS"
+
+#: id:13306
+msgid "Show parent folder items"
+msgstr "Ocultar iconos de subir de carpeta"
+
+#: id:13307
+msgid "Track naming template"
+msgstr "Plantilla de nombrado de pistas"
+
+#: id:13308
+msgid "Do you wish to reboot your system"
+msgstr "¿Desea reiniciar su sistema?"
+
+#: id:13309
+msgid "instead of just XBMC?"
+msgstr "¿en lugar de sólo XBMC?"
+
+#: id:13310
+msgid "Zoom effect"
+msgstr "Efecto de Zoom"
+
+#: id:13311
+msgid "Float effect"
+msgstr "Efecto de flotar"
+
+#: id:13312
+msgid "Black bar reduction"
+msgstr "Reducción de las bandas negras"
+
+#: id:13313
+msgid "Restart"
+msgstr "Reiniciar"
+
+#: id:13314
+msgid "Crossfade between songs"
+msgstr "Mezclar pistas"
+
+#: id:13315
+msgid "Regenerate thumbnails"
+msgstr "Regenerar miniaturas"
+
+#: id:13316
+msgid "Recursive thumbnails"
+msgstr "Miniaturas recursivas"
+
+#: id:13317
+msgid "View slideshow"
+msgstr "Ver Presentación"
+
+#: id:13318
+msgid "Recursive slideshow"
+msgstr "Presentación recursiva"
+
+#: id:13319
+msgid "Randomize"
+msgstr "Reproducción aleatoria"
+
+#: id:13320
+msgid "Stereo"
+msgstr "Estéreo"
+
+#: id:13321
+msgid "Left only"
+msgstr "Sólo izquierdo"
+
+#: id:13322
+msgid "Right only"
+msgstr "Sólo derecho"
+
+#: id:13323
+msgid "Enable karaoke support"
+msgstr "Activar karaoke"
+
+#: id:13324
+msgid "Background transparency"
+msgstr "Transparencia del fondo"
+
+#: id:13325
+msgid "Foreground transparency"
+msgstr "Transparencia del primer plano"
+
+#: id:13326
+msgid "A/V delay"
+msgstr "Retardo A/V"
+
+#: id:13327
+msgid "Karaoke"
+msgstr "Karaoke"
+
+#: id:13328
+msgid "%s not found"
+msgstr "%s no encontrado"
+
+#: id:13329
+msgid "Error opening %s"
+msgstr "Error abriendo %s"
+
+#: id:13330
+msgid "Unable to load %s"
+msgstr "No se puede cargar %s"
+
+#: id:13331
+msgid "Error: Out of memory"
+msgstr "Error: memoria insuficiente"
+
+#: id:13332
+msgid "Move up"
+msgstr "Mover arriba"
+
+#: id:13333
+msgid "Move down"
+msgstr "Mover abajo"
+
+#: id:13334
+msgid "Edit label"
+msgstr "Editar etiqueta"
+
+#: id:13335
+msgid "Make default"
+msgstr "Crear por defecto"
+
+#: id:13336
+msgid "Remove button"
+msgstr "Quitar botón"
+
+#: id:13340
+msgid "Leave as is"
+msgstr "Dejarlo tal cual"
+
+#: id:13341
+msgid "Green"
+msgstr "Verde"
+
+#: id:13342
+msgid "Orange"
+msgstr "Naranja"
+
+#: id:13343
+msgid "Red"
+msgstr "Rojo"
+
+#: id:13344
+msgid "Cycle"
+msgstr "Cíclico"
+
+#: id:13345
+msgid "Switch LED off on playback"
+msgstr "Apagar el LED al reproducir"
+
+#: id:13346
+msgctxt "Auto context with id 13346"
+msgid "Movie information"
+msgstr "Información de la película"
+
+#: id:13347
+msgid "Queue item"
+msgstr "Añadir elemento a la cola"
+
+#: id:13348
+msgid "Search IMDb..."
+msgstr "Buscar en IMDb..."
+
+#: id:13349
+msgid "Scan for new content"
+msgstr "Explorar nuevo contenido"
+
+#: id:13350
+msgid "Now playing..."
+msgstr "Reproduciendo..."
+
+#: id:13351
+msgctxt "Auto context with id 13351"
+msgid "Album information"
+msgstr "Información del álbum"
+
+#: id:13352
+msgid "Scan item to library"
+msgstr "Explorar todo para la BD"
+
+#: id:13353
+msgid "Stop scanning"
+msgstr "Detener la exploración"
+
+#: id:13354
+msgctxt "Auto context with id 13354"
+msgid "Render method"
+msgstr "Método de renderizado"
+
+#: id:13355
+msgid "Low quality pixel shader"
+msgstr "Pixel Shader Baja Calidad"
+
+#: id:13356
+msgid "Hardware overlays"
+msgstr "Superposición por Hardware"
+
+#: id:13357
+msgid "High quality pixel shader"
+msgstr "Pixel Shader Alta Calidad"
+
+#: id:13358
+msgid "Play item"
+msgstr "Reproducir Elemento"
+
+#: id:13359
+msgid "Set artist thumb"
+msgstr "Establecer Imagen Artista"
+
+#: id:13360
+msgid "Automatically generate thumbnails"
+msgstr "Generar miniatura"
+
+#: id:13361
+msgid "Enable voice"
+msgstr "Habilitar voz"
+
+#: id:13375
+msgid "Enable device"
+msgstr "Habilitar dispositivo"
+
+#: id:13376
+msgid "Volume"
+msgstr "Volumen"
+
+#: id:13377
+msgid "Default view mode"
+msgstr "Modo de vista por defecto"
+
+#: id:13378
+msgid "Default brightness"
+msgstr "Brillo por defecto"
+
+#: id:13379
+msgid "Default contrast"
+msgstr "Contraste por defecto"
+
+#: id:13380
+msgid "Default gamma"
+msgstr "Gamma por defecto"
+
+#: id:13381
+msgid "Resume video"
+msgstr "Reanudar Vídeo"
+
+#: id:13382
+msgid "Voice mask - Port 1"
+msgstr "Máscara Voz - Puerto 1"
+
+#: id:13383
+msgid "Voice mask - Port 2"
+msgstr "Máscara Voz - Puerto 2"
+
+#: id:13384
+msgid "Voice mask - Port 3"
+msgstr "Máscara Voz - Puerto 3"
+
+#: id:13385
+msgid "Voice mask - Port 4"
+msgstr "Máscara Voz - Puerto 4"
+
+#: id:13386
+msgid "Use time based seeking"
+msgstr "Usar Búsqueda basada en tiempo"
+
+#: id:13387
+msgid "Track naming template - right"
+msgstr "Plantilla de nombres de pistas correcta"
+
+#: id:13388
+msgid "Preset"
+msgstr "Ajustes Predeterminados"
+
+#: id:13389
+msgid "There are no presets available\nfor this visualization"
+msgstr "No hay ajustes predet.\ndisponibles para esta visualización"
+
+#: id:13390
+msgid "There are no settings available\nfor this visualization"
+msgstr "No hay ajustes disponibles\npara esta visualización"
+
+#: id:13391
+msgid "Eject/Load"
+msgstr "Expulsar/Cargar"
+
+#: id:13392
+msgid "Use visualization if playing audio"
+msgstr "Usar visualización mientras se reproduce sonido"
+
+#: id:13393
+msgid "Calculate size"
+msgstr "Calcular Tamaño"
+
+#: id:13394
+msgid "Calculating folder size"
+msgstr "Calculando tamaño de carpeta"
+
+#: id:13395
+msgid "Video settings"
+msgstr "Ajustes de vídeo"
+
+#: id:13396
+msgid "Audio and subtitle settings"
+msgstr "Ajustes de sonido y subtítulos"
+
+#: id:13397
+msgid "Enable subtitles"
+msgstr "Habilitar subtítulos"
+
+#: id:13398
+msgctxt "Auto context with id 13398"
+msgid "Shortcuts"
+msgstr "Atajos"
+
+#: id:13399
+msgid "Ignore articles when sorting (e.g. \"the\")"
+msgstr "Ignorar tokens al ordenar"
+
+#: id:13400
+msgid "Crossfade between songs on the same album"
+msgstr "Enganchar pistas del mismo álbum"
+
+#: id:13401
+msgid "Browse for %s"
+msgstr "Buscar %s"
+
+#: id:13402
+msgid "Show track position"
+msgstr "Mostrar posición de la pista"
+
+#: id:13403
+msgid "Clear default"
+msgstr "Borrar por defecto"
+
+#: id:13404
+msgid "Resume"
+msgstr "Continuar"
+
+#: id:13405
+msgid "Get thumb"
+msgstr "Obtener Miniatura"
+
+#: id:13406
+msgid "Picture information"
+msgstr "Información de Imágen"
+
+#: id:13407
+msgid "%s presets"
+msgstr "%s ajustes"
+
+#: id:13408
+msgid "(IMDb user rating)"
+msgstr "(Calificación de usuarios de IMDb)"
+
+#: id:13409
+msgid "Top 250"
+msgstr "Top 250"
+
+#: id:13410
+msgid "Tune in on Last.fm"
+msgstr "Sintonizar en Last.FM"
+
+#: id:13411
+msgid "Minimum fan speed"
+msgstr "Velocidad mínima de ventilador"
+
+#: id:13412
+msgid "Play from here"
+msgstr "Continuar reproducción"
+
+#: id:13413
+msgid "Downloading"
+msgstr "Descargando"
+
+#: id:13414
+msgid "Include artists who appear only on compilations"
+msgstr "Ocultar artistas que sólo aparecen en compilaciones"
+
+#: id:13415
+msgctxt "Auto context with id 13415"
+msgid "Render method"
+msgstr "Método de renderizado"
+
+#: id:13416
+msgid "Auto detect"
+msgstr "Auto detectar"
+
+#: id:13417
+msgid "Basic shaders (ARB)"
+msgstr "Basic shaders (ARB)"
+
+#: id:13418
+msgid "Advanced shaders (GLSL)"
+msgstr "Advanced shaders (GLSL)"
+
+#: id:13419
+msgid "Software"
+msgstr "Software"
+
+#: id:13420
+msgid "Remove safely"
+msgstr "Expulsar"
+
+#: id:13421
+msgctxt "Auto context with id 13421"
+msgid "VDPAU"
+msgstr "VDPAU"
+
+#: id:13422
+msgid "Start slideshow here"
+msgstr "Comenzar presentación aquí"
+
+#: id:13423
+msgid "Remember for this path"
+msgstr "Recordar para esta carpeta"
+
+#: id:13424
+msgid "Use pixel buffer objects"
+msgstr "Usar objetos de buffer de pixel"
+
+#: id:13425
+msgid "Allow hardware acceleration (VDPAU)"
+msgstr "Permitir aceleración por HW (VDPAU)"
+
+#: id:13426
+msgid "Allow hardware acceleration (VAAPI)"
+msgstr "Permitir aceleración por HW (VAAPI)"
+
+#: id:13427
+msgid "Allow hardware acceleration (DXVA2)"
+msgstr "Permitir aceleración por HW (DXVA2)"
+
+#: id:13428
+msgid "Allow hardware acceleration (CrystalHD)"
+msgstr "Permitir aceleración por HW (CrystalHD)"
+
+#: id:13429
+msgid "Allow hardware acceleration (VDADecoder)"
+msgstr "Permitir aceleración por HW (VDADecoder)"
+
+#: id:13430
+msgid "Allow hardware acceleration (OpenMax)"
+msgstr "Permitir aceleración por HW (OpenMax)"
+
+#: id:13431
+msgid "Pixel Shaders"
+msgstr "Pixel Shaders"
+
+#: id:13432
+msgid "Allow hardware acceleration (VideoToolbox)"
+msgstr "Permitir aceleración por HW (VideoToolbox)"
+
+#: id:13500
+msgid "A/V sync method"
+msgstr "Método de sincron. de A/V"
+
+#: id:13501
+msgid "Audio clock"
+msgstr "Clock de audio"
+
+#: id:13502
+msgid "Video clock (Drop/Dupe audio)"
+msgstr "Clock de video(Drop/Dupe audio)"
+
+#: id:13503
+msgid "Video clock (Resample audio)"
+msgstr "Clock de video (Re-muestreo de audio)"
+
+#: id:13504
+msgid "Maximum resample amount (%)"
+msgstr "Re-muestreo máximo (%)"
+
+#: id:13505
+msgid "Resample quality"
+msgstr "Calidad de Re-muestreo"
+
+#: id:13506
+msgid "Low(fast)"
+msgstr "Baja(rápido)"
+
+#: id:13507
+msgctxt "Auto context with id 13507"
+msgid "Medium"
+msgstr "Media"
+
+#: id:13508
+msgctxt "Auto context with id 13508"
+msgid "High"
+msgstr "Alta"
+
+#: id:13509
+msgid "Really high(slow!)"
+msgstr "Realmente alta(lento!)"
+
+#: id:13510
+msgid "Sync playback to display"
+msgstr "Sincronizar reproducción con la pantalla"
+
+#: id:13550
+msgid "Pause during refresh rate change"
+msgstr "Pausar durante cambio de velocidad de refresco"
+
+#: id:13551
+msgctxt "Auto context with id 13551"
+msgid "Off"
+msgstr "Apagado"
+
+#: id:13552
+msgid "%.1f Second"
+msgstr "%.1f Segundo"
+
+#: id:13553
+msgid "%.1f Seconds"
+msgstr "%.1f Segundos"
+
+#: id:13600
+msgid "Apple remote"
+msgstr "Apple Remote"
+
+#: id:13602
+msgid "Allow start of XBMC using the remote"
+msgstr "Permitir arrancar XBMC desde remoto"
+
+#: id:13603
+msgid "Sequence delay time"
+msgstr "Retraso en tiempo de secuencia"
+
+#: id:13610
+msgctxt "Auto context with id 13610"
+msgid "Disabled"
+msgstr "Deshabilitado"
+
+#: id:13611
+msgctxt "Auto context with id 13611"
+msgid "Standard"
+msgstr "Estándar"
+
+#: id:13612
+msgid "Universal Remote"
+msgstr "Universal Remote"
+
+#: id:13613
+msgid "Multi Remote (Harmony)"
+msgstr "Multi Remote (Harmony)"
+
+#: id:13620
+msgid "Apple Remote Error"
+msgstr "Error de Apple Remote"
+
+#: id:13621
+msgid "Apple Remote support could be enabled."
+msgstr "No se puede activar el soporte para Apple Remote."
+
+#: id:14000
+msgid "Stack"
+msgstr "Agrupar"
+
+#: id:14001
+msgid "Unstack"
+msgstr "Desagrupar"
+
+#: id:14003
+msgid "Downloading playlist file..."
+msgstr "Descargando fichero de lista de reproducción..."
+
+#: id:14004
+msgid "Downloading streams list..."
+msgstr "Descargando lista de canales..."
+
+#: id:14005
+msgid "Parsing streams list..."
+msgstr "Procesando lista de canales..."
+
+#: id:14006
+msgid "Downloading streams list failed"
+msgstr "Descarga de lista de canales fallida"
+
+#: id:14007
+msgid "Downloading playlist file failed"
+msgstr "Descarga del fichero de lista de reproducción fallida"
+
+#: id:14009
+msgid "Games directory"
+msgstr "Carpeta de Juegos"
+
+#: id:14010
+msgid "Auto switch to thumbs based on"
+msgstr "Cambiar autom. a miniaturas según"
+
+#: id:14011
+msgid "Enable auto switching to thumbs view"
+msgstr "Activar cambio auto. a miniaturas"
+
+#: id:14012
+msgid "- Use large icons"
+msgstr "- Usar Iconos Grandes"
+
+#: id:14013
+msgid "- Switch based on"
+msgstr "- Cambio según"
+
+#: id:14014
+msgid "- Percentage"
+msgstr "- Porcentaje"
+
+#: id:14015
+msgid "No files and at least one thumb"
+msgstr "Sin archivos y al menos una miniat."
+
+#: id:14016
+msgid "At least one file and thumb"
+msgstr "Al menos un fichero y una miniat."
+
+#: id:14017
+msgid "Percentage of thumbs"
+msgstr "Porcentaje de miniaturas"
+
+#: id:14018
+msgid "View options"
+msgstr "Vista"
+
+#: id:14019
+msgid "Change area code 1"
+msgstr "Cambiar código de área 1"
+
+#: id:14020
+msgid "Change area code 2"
+msgstr "Cambiar código de área 2"
+
+#: id:14021
+msgid "Change area code 3"
+msgstr "Cambiar código de área 3"
+
+#: id:14022
+msgctxt "Auto context with id 14022"
+msgid "Library"
+msgstr "Biblioteca"
+
+#: id:14023
+msgid "No TV"
+msgstr "Sin TV"
+
+#: id:14024
+msgid "Enter the nearest large town"
+msgstr "Introduzca la ciudad grande más cercana"
+
+#: id:14025
+msgid "Video/Audio/DVD cache - Harddisk"
+msgstr "Caché de vídeo - Disco Duro"
+
+#: id:14026
+msgid "Video cache - DVD-ROM"
+msgstr "Caché de vídeo - DVD-ROM"
+
+#: id:14027
+msgctxt "Auto context with id 14027"
+msgid "- Local Network"
+msgstr "- Red Local"
+
+#: id:14028
+msgctxt "Auto context with id 14028"
+msgid "- Internet"
+msgstr "- Internet"
+
+#: id:14030
+msgid "Audio cache - DVD-ROM"
+msgstr "Caché de sonido - DVD-ROM"
+
+#: id:14031
+msgctxt "Auto context with id 14031"
+msgid "- Local Network"
+msgstr "- Red Local"
+
+#: id:14032
+msgctxt "Auto context with id 14032"
+msgid "- Internet"
+msgstr "- Internet"
+
+#: id:14034
+msgid "DVD cache - DVD-ROM"
+msgstr "Caché de DVD - DVD-ROM"
+
+#: id:14035
+msgctxt "Auto context with id 14035"
+msgid "- Local Network"
+msgstr "- Red Local"
+
+#: id:14036
+msgctxt "Auto context with id 14036"
+msgid "Services"
+msgstr "Servicios"
+
+#: id:14038
+msgid "Network settings changed"
+msgstr "Configuración de red cambiada"
+
+#: id:14039
+msgid "XBMC requires to restart to change your"
+msgstr "XBMC necesita reiniciar para poder cambiar su"
+
+#: id:14040
+msgid "network setup. Would you like to restart now?"
+msgstr "configuración de red. ¿Quiere reiniciar ahora?"
+
+#: id:14041
+msgid "Internet connection bandwidth limitation"
+msgstr "Limitar ancho de banda de la conexión de internet"
+
+#: id:14043
+msgid "- Shutdown while playing"
+msgstr "- Apagar mientras está reproduciendo"
+
+#: id:14044
+msgid "%i min"
+msgstr "%i min"
+
+#: id:14045
+msgid "%i sec"
+msgstr "%i seg"
+
+#: id:14046
+msgid "%i ms"
+msgstr "%i ms"
+
+#: id:14047
+msgid "%i %%"
+msgstr "%i %%"
+
+#: id:14048
+msgid "%i kbps"
+msgstr "%i kbps"
+
+#: id:14049
+msgid "%i kb"
+msgstr "%i kb"
+
+#: id:14050
+msgid "%i.0 dB"
+msgstr "%i.0 dB"
+
+#: id:14051
+msgid "Time format"
+msgstr "Formato de Hora"
+
+#: id:14052
+msgid "Date format"
+msgstr "Formato de Fecha"
+
+#: id:14053
+msgid "GUI filters"
+msgstr "Filtros GUI"
+
+#: id:14055
+msgid "Use background scanning"
+msgstr "Realizar la exploración en segundo plano"
+
+#: id:14056
+msgid "Stop scan"
+msgstr "Detener la exploración"
+
+#: id:14057
+msgid "Not possible while scanning for media info"
+msgstr "No es posible mientras se explora la información de medios"
+
+#: id:14058
+msgid "Film grain effect"
+msgstr "Efecto Pelicula con Textura Granulada"
+
+#: id:14059
+msgid "Search for thumbnails on remote shares"
+msgstr "Buscar miniaturas en recursos compartidos remotos"
+
+#: id:14060
+msgid "Unknown type cache - Internet"
+msgstr "Tipo de Caché Desconocido - Internet"
+
+#: id:14061
+msgctxt "Auto context with id 14061"
+msgid "Auto"
+msgstr "Auto"
+
+#: id:14062
+msgid "Enter username for"
+msgstr "Introduzca nombre de usuario para"
+
+#: id:14063
+msgid "Date & time"
+msgstr "Fecha y Hora"
+
+#: id:14064
+msgid "Set date"
+msgstr "Establecer Fecha"
+
+#: id:14065
+msgid "Set time"
+msgstr "Establecer Hora"
+
+#: id:14066
+msgid "Enter the time in 24 hour HH:MM format"
+msgstr "Introduzca la Hora en formato HH:MM 24 horas"
+
+#: id:14067
+msgid "Enter the date in DD/MM/YYYY format"
+msgstr "Introduzca la Hora en formato DD/MM/YYYY"
+
+#: id:14068
+msgid "Enter the IP address"
+msgstr "Introduzca la dirección IP"
+
+#: id:14069
+msgid "Apply these settings now?"
+msgstr "¿Quiere aplicar las opciones ahora?"
+
+#: id:14070
+msgid "Apply changes now"
+msgstr "Aplicar cambios ahora"
+
+#: id:14071
+msgid "Allow file renaming and deletion"
+msgstr "Permitir el renombrado y borrado de archivos"
+
+#: id:14074
+msgid "Set timezone"
+msgstr "Establecer Zona Horaria"
+
+#: id:14075
+msgid "Use daylight saving time"
+msgstr "Usar Horario de Verano"
+
+#: id:14076
+msgid "Add to favourites"
+msgstr "Añadir a favoritos"
+
+#: id:14077
+msgid "Remove from favourites"
+msgstr "Eliminar de favoritos"
+
+#: id:14078
+msgctxt "Auto context with id 14078"
+msgid "- Colours"
+msgstr "- Colores"
+
+#: id:14079
+msgid "Timezone country"
+msgstr "País del huso horario"
+
+#: id:14080
+msgid "Timezone"
+msgstr "Huso horario"
+
+#: id:14081
+msgid "File lists"
+msgstr "Listas de archivos"
+
+#: id:14082
+msgid "Show EXIF picture information"
+msgstr "Mostrar informacion EXIF de imágenes"
+
+#: id:14083
+msgid "Use a fullscreen window rather than true fullscreen"
+msgstr "Usar ventana de pantalla completa en vez de pantalla completa real"
+
+#: id:14084
+msgid "Queue songs on selection"
+msgstr "Encolar camciones al seleccionar"
+
+#: id:14086
+msgid "Playback"
+msgstr "Reproducir"
+
+#: id:14087
+msgid "DVDs"
+msgstr "DVDs"
+
+#: id:14088
+msgid "Play DVDs automatically"
+msgstr "Reproducir DVDs automaticamente"
+
+#: id:14089
+msgid "Font to use for text subtitles"
+msgstr "Tipografía de subtitulos"
+
+#: id:14090
+msgid "International"
+msgstr "Internacional"
+
+#: id:14091
+msgid "Character set"
+msgstr "Juego de carácteres"
+
+#: id:14092
+msgid "Debugging"
+msgstr "Debugging"
+
+#: id:14093
+msgid "Security"
+msgstr "Seguridad"
+
+#: id:14094
+msgid "Input devices"
+msgstr "Dispositivos de entrada"
+
+#: id:14095
+msgid "Power saving"
+msgstr "Ahorro de energía"
+
+#: id:14096
+msgid "Rip"
+msgstr ""
+
+#: id:14097
+msgid "Audio CD Insert Action"
+msgstr ""
+
+#: id:14098
+msgctxt "Auto context with id 14098"
+msgid "Play"
+msgstr ""
+
+#: id:14099
+msgid "Eject disc when CD ripping is complete"
+msgstr ""
+
+#: id:15015
+msgctxt "Auto context with id 15015"
+msgid "Remove"
+msgstr "Eliminar"
+
+#: id:15016
+msgid "Games"
+msgstr "Juegos"
+
+#: id:15019
+msgid "Add"
+msgstr "Añadir"
+
+#: id:15052
+msgid "Password"
+msgstr "Contraseña"
+
+#: id:15100
+msgctxt "Auto context with id 15100"
+msgid "Library"
+msgstr "Biblioteca"
+
+#: id:15101
+msgid "Database"
+msgstr "Base de datos"
+
+#: id:15102
+msgid "* All albums"
+msgstr "* Todos Albums"
+
+#: id:15103
+msgid "* All artists"
+msgstr "* Todos Artistas"
+
+#: id:15104
+msgid "* All songs"
+msgstr "* Todas Canciones"
+
+#: id:15105
+msgid "* All genres"
+msgstr "* Todos Géneros"
+
+#: id:15107
+msgid "Buffering..."
+msgstr "Almacenando..."
+
+#: id:15108
+msgid "Navigation sounds"
+msgstr "Sonidos de navegación"
+
+#: id:15109
+msgid "Skin default"
+msgstr "Según skin"
+
+#: id:15111
+msgid "- Theme"
+msgstr "- Tema del skin"
+
+#: id:15112
+msgid "Default theme"
+msgstr "Tema por defecto"
+
+#: id:15200
+msgid "Last.fm"
+msgstr "Last.FM"
+
+#: id:15201
+msgid "Submit songs to Last.fm"
+msgstr "Enviar canciones a Last.FM"
+
+#: id:15202
+msgid "Last.fm username"
+msgstr "Usuario Last.FM"
+
+#: id:15203
+msgid "Last.fm password"
+msgstr "Contraseña Last.FM"
+
+#: id:15204
+msgid "Unable to handshake: sleeping..."
+msgstr "Imposible conectar: durmiendo..."
+
+#: id:15205
+msgid "Please update XBMC"
+msgstr "Por favor, actualice XBMC"
+
+#: id:15206
+msgid "Bad authorization: Check username and password"
+msgstr "Autorización incorrecta: compruebe usuario y contraseña"
+
+#: id:15207
+msgctxt "Auto context with id 15207"
+msgid "Connected"
+msgstr "Conectado"
+
+#: id:15208
+msgid "Not connected"
+msgstr "No Conectado"
+
+#: id:15209
+msgid "Submit interval %i"
+msgstr "Intervalo de Envío %i"
+
+#: id:15210
+msgid "Cached %i songs"
+msgstr "Almacenadas %i Canciones"
+
+#: id:15211
+msgid "Submitting..."
+msgstr "Enviando..."
+
+#: id:15212
+msgid "Submitting in %i secs"
+msgstr "Enviando en %i segs"
+
+#: id:15213
+msgid "Play using..."
+msgstr "Reproducir Usando..."
+
+#: id:15214
+msgid "Use smoothed A/V synchronization"
+msgstr "Usar sincronización A/V suavizada"
+
+#: id:15215
+msgid "Hide file names in thumbs view"
+msgstr "Ocultar nombres de fichero en vista de miniaturas"
+
+#: id:15216
+msgid "Play in party mode"
+msgstr "Reproducir en modo fiesta"
+
+#: id:15217
+msgid "Submit songs to Libre.fm"
+msgstr "Enviar canciones a Libre.fm"
+
+#: id:15218
+msgid "Libre.fm username"
+msgstr "Nombre de usuario de Libre.fm"
+
+#: id:15219
+msgid "Libre.fm password"
+msgstr "Contraseña de Libre.fm"
+
+#: id:15220
+msgid "Libre.fm"
+msgstr "Libre.fm"
+
+#: id:15221
+msgid "Song submission"
+msgstr "Envío de canciones"
+
+#: id:15250
+msgid "Submit Last.fm radio to Last.fm"
+msgstr "Enviar datos de radio Last.FM a Last.FM"
+
+#: id:15251
+msgid "Connecting to Last.fm..."
+msgstr "Conectando a Last.FM..."
+
+#: id:15252
+msgid "Selecting station..."
+msgstr "Seleccionando emisora..."
+
+#: id:15253
+msgid "Search similar artists..."
+msgstr "Buscar intérpretes similares..."
+
+#: id:15254
+msgid "Search similar tags..."
+msgstr "Buscar géneros similares..."
+
+#: id:15255
+msgid "Your profile (%name%)"
+msgstr "Tu perfil (%name%)"
+
+#: id:15256
+msgid "Overall top tags"
+msgstr "Top global de géneros"
+
+#: id:15257
+msgid "Top artists for tag %name%"
+msgstr "Top intérpretes del género %name%"
+
+#: id:15258
+msgid "Top albums for tag %name%"
+msgstr "Top álbumes del género %name%"
+
+#: id:15259
+msgid "Top tracks for tag %name%"
+msgstr "Top canciones del género %name%"
+
+#: id:15260
+msgid "Listen to tag %name% Last.fm radio"
+msgstr "Oir el género %name% desde la radio last.fm"
+
+#: id:15261
+msgid "Similar artists as %name%"
+msgstr "Intérpretes similares a %name%"
+
+#: id:15262
+msgid "Top %name% albums"
+msgstr "Top álbumes de %name%"
+
+#: id:15263
+msgid "Top %name% tracks"
+msgstr "Top canciones de %name%"
+
+#: id:15264
+msgid "Top %name% tags"
+msgstr "Top géneros de %name%"
+
+#: id:15265
+msgid "Biggest fans of %name%"
+msgstr "Mayores fans de %name%"
+
+#: id:15266
+msgid "Listen to %name% fans Last.fm radio"
+msgstr "Oir a fans de %name% desde la radio last.fm"
+
+#: id:15267
+msgid "Listen to %name% similar artists Last.fm radio"
+msgstr "Oir artistas similares a %name% desde la radio last.fm"
+
+#: id:15268
+msgid "Top artists for user %name%"
+msgstr "Top intérpretes del usuario %name%"
+
+#: id:15269
+msgid "Top albums for user %name%"
+msgstr "Top álbumes del usuario %name%"
+
+#: id:15270
+msgid "Top tracks for user %name%"
+msgstr "Top canciones del usuario %name%"
+
+#: id:15271
+msgid "Friends of user %name%"
+msgstr "Amigos del usuario %name%"
+
+#: id:15272
+msgid "Neighbours of user %name%"
+msgstr "Vecinos del usuario %name%"
+
+#: id:15273
+msgid "Weekly artist chart for %name%"
+msgstr "Gráfica Semanal de intérprete para %name%"
+
+#: id:15274
+msgid "Weekly album chart for %name%"
+msgstr "Gráfica Semanal de album para %name%"
+
+#: id:15275
+msgid "Weekly track chart for %name%"
+msgstr "Gráfica Semanal de canciones para %name%"
+
+#: id:15276
+msgid "Listen to %name%'s neighbours Last.fm radio"
+msgstr "Oir a los vecinos de %name% desde la radio last.fm"
+
+#: id:15277
+msgid "Listen to %name%'s personal Last.fm radio"
+msgstr "Oir la radio last.fm personal de %name%"
+
+#: id:15278
+msgid "Listen to %name%'s mix Last.fm radio"
+msgstr "Oir canciones preferidas de %name% desde la radio last.fm"
+
+#: id:15279
+msgid "Retrieving list from Last.fm..."
+msgstr "Obteniendo la lista desde last.fm..."
+
+#: id:15280
+msgid "Can't retrieve list from Last.fm..."
+msgstr "No se puede obtener la lista desde last.fm..."
+
+#: id:15281
+msgid "Enter an artist name to find related ones"
+msgstr "Introduzca un nombre de intérprete para buscar relacionados"
+
+#: id:15282
+msgid "Enter a tag name to find similar ones"
+msgstr "Introduzca un género para encontrar similares"
+
+#: id:15283
+msgid "Tracks recently listened by %name%"
+msgstr "Canciones escuchadas recientemente por %name%"
+
+#: id:15284
+msgid "Listen to %name%'s recommendations Last.fm radio"
+msgstr "Escuche recomendaciones de %name% en la radio Last.FM"
+
+#: id:15285
+msgid "Top tags for user %name%"
+msgstr "Top de etiquetas para el usuario %name%"
+
+#: id:15287
+msgid "Do you want to add the current track to your loved tracks?"
+msgstr "¿Desea añadir la pista actual a su lista de canciones favoritas?"
+
+#: id:15288
+msgid "Do you want to ban the current track?"
+msgstr "¿Desea prohibir la reproducción de la pista actual?"
+
+#: id:15289
+msgid "Added to your loved tracks: '%s'."
+msgstr "Se ha añadido a sus canciones favoritas: '%s'."
+
+#: id:15290
+msgid "Could not add '%s' to your loved tracks."
+msgstr "No se pudo añadir '%s' a sus canciones favoritas."
+
+#: id:15291
+msgid "Banned: '%s'."
+msgstr "Prohibida: '%s'."
+
+#: id:15292
+msgid "Could not ban '%s'."
+msgstr "No se pudo prohibir '%s'."
+
+#: id:15293
+msgid "Tracks recently loved by %name%"
+msgstr "Canciones favoritas recientemente por %name%"
+
+#: id:15294
+msgid "Tracks recently banned by %name%"
+msgstr "Canciones prohibidas recientemente por %name%"
+
+#: id:15295
+msgid "Remove from loved tracks"
+msgstr "Quitar de las canciones favoritas"
+
+#: id:15296
+msgid "Un-ban"
+msgstr "Quitar prohibición"
+
+#: id:15297
+msgid "Do you want to remove this track from your loved tracks?"
+msgstr "¿Desea quitar esta pista de sus canciones favoritas?"
+
+#: id:15298
+msgid "Do you want to un-ban this track?"
+msgstr "¿Desea quitar la prohibición de esta pista?"
+
+#: id:15300
+msgid "Path not found or invalid"
+msgstr "Ruta no encontrada o inválida"
+
+#: id:15301
+msgid "Could not connect to network server"
+msgstr "Imposible conectar al servidor"
+
+#: id:15302
+msgid "No servers found"
+msgstr "No se encontraron servidores"
+
+#: id:15303
+msgid "Workgroup not found"
+msgstr "Grupo de trabajo no encontrado"
+
+#: id:15310
+msgid "Opening multi-path source"
+msgstr "Abriendo marcador multi-carpeta"
+
+#: id:15311
+msgid "Path:"
+msgstr "Ruta:"
+
+#: id:16000
+msgctxt "Auto context with id 16000"
+msgid "General"
+msgstr "General"
+
+#: id:16002
+msgid "Internet lookup"
+msgstr "Búsqueda en internet"
+
+#: id:16003
+msgid "Player"
+msgstr "Reproductor"
+
+#: id:16004
+msgid "Play media from disc"
+msgstr "Reproducir desde disco"
+
+#: id:16008
+msgid "Enter new title"
+msgstr "Introduzca nuevo título"
+
+#: id:16009
+msgid "Enter the movie name"
+msgstr "Introduzca el nombre de la Pelicula"
+
+#: id:16010
+msgid "Enter the profile name"
+msgstr "Introduzca el nombre del Perfil"
+
+#: id:16011
+msgid "Enter the album name"
+msgstr "Introduzca el nombre del Album"
+
+#: id:16012
+msgid "Enter the playlist name"
+msgstr "Introduzca el nombre de la Lista de Reproducción"
+
+#: id:16013
+msgid "Enter new filename"
+msgstr "Introduzca el nombre del Nuevo Fichero"
+
+#: id:16014
+msgid "Enter folder name"
+msgstr "Introduzca el nombre del carpeta"
+
+#: id:16015
+msgid "Enter directory"
+msgstr "Introduzca el carpeta"
+
+#: id:16016
+msgid "Available options: %A, %T, %N, %B, %D, %G, %Y, %F, %S"
+msgstr "Opciones disponibles: %A, %T, %N, %B, %D, %G, %Y, %F, %S"
+
+#: id:16017
+msgid "Enter search string"
+msgstr "Introduzca la cadena de búsqueda"
+
+#: id:16018
+msgctxt "Auto context with id 16018"
+msgid "None"
+msgstr "Ninguno"
+
+#: id:16019
+msgid "Auto select"
+msgstr "Seleccionar Auto."
+
+#: id:16020
+msgid "De-interlace"
+msgstr "Desentralazar"
+
+#: id:16021
+msgid "Bob"
+msgstr "Bob"
+
+#: id:16022
+msgid "Bob (inverted)"
+msgstr "Bob (Invertido)"
+
+#: id:16024
+msgid "Canceling..."
+msgstr "Cancelando..."
+
+#: id:16025
+msgid "Enter the artist name"
+msgstr "Introduzca el nombre del intérprete"
+
+#: id:16026
+msgid "Playback failed"
+msgstr "Falló reproducción"
+
+#: id:16027
+msgid "One or more items failed to play."
+msgstr "Falló la reproducción de uno o más items."
+
+#: id:16028
+msgid "Enter value"
+msgstr "Introducir valor"
+
+#: id:16029
+msgid "Check the log file for details."
+msgstr "Verifique los detalles en el archivo log."
+
+#: id:16030
+msgid "Party mode aborted."
+msgstr "Modo fiesta abortado."
+
+#: id:16031
+msgid "No matching songs in the library."
+msgstr "No hay canciones coincidentes en la base de datos."
+
+#: id:16032
+msgid "Could not initialize database."
+msgstr "No se pudo inicializar la base de datos."
+
+#: id:16033
+msgid "Could not open database."
+msgstr "No se pudo abrir la base de datos."
+
+#: id:16034
+msgid "Could not get songs from database."
+msgstr "No se pudo obtener canciones de la base de datos."
+
+#: id:16035
+msgid "Party mode playlist"
+msgstr "Lista de reproducción del modo fiesta"
+
+#: id:16036
+msgid "De-interlace (Half)"
+msgstr "Desentrelazar (Medio)"
+
+#: id:16037
+msgid "Deinterlace video"
+msgstr "Desentrelazar video"
+
+#: id:16038
+msgid "Deinterlace method"
+msgstr "Método de desetrelazado"
+
+#: id:16039
+msgctxt "Auto context with id 16039"
+msgid "Off"
+msgstr "apagado"
+
+#: id:16040
+msgctxt "Auto context with id 16040"
+msgid "Auto"
+msgstr "Auto"
+
+#: id:16041
+msgid "On"
+msgstr "activado"
+
+#: id:16100
+msgid "All Videos"
+msgstr "Todos los vídeos"
+
+#: id:16101
+msgid "Unwatched"
+msgstr "Los no vistos"
+
+#: id:16102
+msgid "Watched"
+msgstr "Los ya vistos"
+
+#: id:16103
+msgid "Mark as watched"
+msgstr "Marcar como vistos"
+
+#: id:16104
+msgid "Mark as unwatched"
+msgstr "Marcar como no vistos"
+
+#: id:16105
+msgid "Edit title"
+msgstr "Editar título"
+
+#: id:16200
+msgid "Operation was aborted"
+msgstr "Operación abortada"
+
+#: id:16201
+msgid "Copy failed"
+msgstr "Fallo al copiar"
+
+#: id:16202
+msgid "Failed to copy at least one file"
+msgstr "Fallo al copiar al menos un fichero"
+
+#: id:16203
+msgid "Move failed"
+msgstr "Fallo al mover"
+
+#: id:16204
+msgid "Failed to move at least one file"
+msgstr "Fallo al mover al menos un fichero"
+
+#: id:16205
+msgid "Delete failed"
+msgstr "Fallo al borrar"
+
+#: id:16206
+msgid "Failed to delete at least one file"
+msgstr "Fallo al borrar al menos un fichero"
+
+#: id:16300
+msgid "Video scaling method"
+msgstr "Método de escalado de vídeo"
+
+#: id:16301
+msgid "Nearest neighbour"
+msgstr "Vecino más cercano"
+
+#: id:16302
+msgid "Bilinear"
+msgstr "Bilinear"
+
+#: id:16303
+msgctxt "Auto context with id 16303"
+msgid "Bicubic"
+msgstr "Bicúbico"
+
+#: id:16304
+msgid "Lanczos2"
+msgstr "Lanczos2"
+
+#: id:16305
+msgid "Lanczos3"
+msgstr "Lanczos3"
+
+#: id:16306
+msgid "Sinc8"
+msgstr "Sinc8"
+
+#: id:16307
+msgid "Bicubic (software)"
+msgstr "Bicúbico (software)"
+
+#: id:16308
+msgid "Lanczos (software)"
+msgstr "Lanczos (software)"
+
+#: id:16309
+msgid "Sinc (software)"
+msgstr "Sinc (software)"
+
+#: id:16310
+msgid "Temporal"
+msgstr "Temporal"
+
+#: id:16311
+msgid "Temporal/Spatial"
+msgstr "Temporal/Espacial"
+
+#: id:16312
+msgid "(VDPAU)Noise Reduction"
+msgstr "(VDPAU)Reducción de Ruído"
+
+#: id:16313
+msgid "(VDPAU)Sharpness"
+msgstr "(VDPAU)Agudeza"
+
+#: id:16314
+msgid "Inverse Telecine"
+msgstr "Telecine inverso"
+
+#: id:16315
+msgid "Lanczos3 optimized"
+msgstr "Lanczos3 optimizado"
+
+#: id:16316
+msgctxt "Auto context with id 16316"
+msgid "Auto"
+msgstr "Auto"
+
+#: id:16317
+msgid "Temporal (Half)"
+msgstr "Temporal (medio)"
+
+#: id:16318
+msgid "Temporal/Spatial (Half)"
+msgstr "Temporal/Espacial (medio)"
+
+#: id:16319
+msgid "DXVA"
+msgstr "DXVA"
+
+#: id:16320
+msgid "DXVA Bob"
+msgstr "DXVA Bob"
+
+#: id:16321
+msgid "DXVA Best"
+msgstr "DXVA Best"
+
+#: id:16322
+msgid "Spline36"
+msgstr "Spline36"
+
+#: id:16323
+msgid "Spline36 optimized"
+msgstr "Spline36 optimized"
+
+#: id:16324
+msgid "Software Blend"
+msgstr "Software Blend"
+
+#: id:16400
+msgid "Post-processing"
+msgstr "Post-procesado"
+
+#: id:17500
+msgid "Display sleep timeout"
+msgstr "Mostrar cuenta atrás para el reposo"
+
+#: id:19000
+msgid "Switch to channel"
+msgstr "Cambiar a canal"
+
+#: id:20000
+msgid "Saved music folder"
+msgstr "Carpeta de grabación de CDs de audio"
+
+#: id:20001
+msgid "Use external DVD player"
+msgstr "Usar Reproductor DVD externo"
+
+#: id:20002
+msgid "External DVD player"
+msgstr "Reproductor DVD externo"
+
+#: id:20003
+msgid "Trainers folder"
+msgstr "Carpeta de trainers"
+
+#: id:20004
+msgid "Screenshot folder"
+msgstr "Carpeta de instantáneas"
+
+#: id:20006
+msgid "Playlists folder"
+msgstr "Carpeta de listas de reproducción"
+
+#: id:20007
+msgid "Recordings"
+msgstr "Grabaciones"
+
+#: id:20008
+msgid "Screenshots"
+msgstr "Instantáneas"
+
+#: id:20009
+msgid "Use XBMC"
+msgstr "Usar XBMC"
+
+#: id:20011
+msgid "Music playlists"
+msgstr "Listas Rep. Música"
+
+#: id:20012
+msgid "Video playlists"
+msgstr "Listas Rep. Vídeo"
+
+#: id:20013
+msgid "Do you wish to launch the game?"
+msgstr "¿Desea ejecutar el juego?"
+
+#: id:20014
+msgid "Sort by: Playlist"
+msgstr "Ver: Lista Rep."
+
+#: id:20015
+msgid "Remote thumb"
+msgstr "Miniatura remota"
+
+#: id:20016
+msgid "Current thumb"
+msgstr "Miniatura actual"
+
+#: id:20017
+msgid "Local thumb"
+msgstr "Miniatura local"
+
+#: id:20018
+msgid "No thumb"
+msgstr "Sin miniatura"
+
+#: id:20019
+msgid "Choose thumbnail"
+msgstr "Elija miniatura"
+
+#: id:20023
+msgid "Conflict"
+msgstr "Conflicto"
+
+#: id:20024
+msgid "Scan new"
+msgstr "Explorar nuevos"
+
+#: id:20025
+msgid "Scan all"
+msgstr "Explorar todo"
+
+#: id:20026
+msgid "Region"
+msgstr "Región"
+
+#: id:20037
+msgid "Summary"
+msgstr "Sumario"
+
+#: id:20038
+msgid "Lock music window"
+msgstr "Bloquear ventana música"
+
+#: id:20039
+msgid "Lock videos window"
+msgstr "Bloquear ventana vídeo"
+
+#: id:20040
+msgid "Lock pictures window"
+msgstr "Bloquear ventana imágenes"
+
+#: id:20041
+msgid "Lock programs & scripts windows"
+msgstr "Bloquear ventana programas y ventana scripts"
+
+#: id:20042
+msgid "Lock file manager"
+msgstr "Bloquear gestor de archivos"
+
+#: id:20043
+msgid "Lock settings"
+msgstr "Bloquear ajustes"
+
+#: id:20044
+msgid "Start fresh"
+msgstr "Inicio limpio"
+
+#: id:20045
+msgid "Enter master mode"
+msgstr "Entrar en modo maestro"
+
+#: id:20046
+msgid "Leave master mode"
+msgstr "Dejar modo maestro"
+
+#: id:20047
+msgid "Create profile '%s'?"
+msgstr "¿ Crear perfil '%s' ?"
+
+#: id:20048
+msgid "Start with fresh settings"
+msgstr "Iniciar con ajustes limpios"
+
+#: id:20049
+msgid "Best available"
+msgstr "La mejor disponible"
+
+#: id:20050
+msgid "Auto-switch between 16x9 and 4x3"
+msgstr "Cambio automático entre 16x9 y 4x3"
+
+#: id:20051
+msgid "Treat stacked files as single file"
+msgstr "Tratar archivos agrupados como un solo fichero"
+
+#: id:20052
+msgid "Caution"
+msgstr "Precaución"
+
+#: id:20053
+msgid "Left master mode"
+msgstr "Se abandonó el modo maestro"
+
+#: id:20054
+msgid "Entered master mode"
+msgstr "Se entró en modo maestro"
+
+#: id:20055
+msgid "Allmusic.com thumb"
+msgstr "Miniatura allmusic.com"
+
+#: id:20057
+msgid "Remove thumbnail"
+msgstr "Eliminar miniatura"
+
+#: id:20058
+msgid "Add profile..."
+msgstr "Añadir Perfil..."
+
+#: id:20059
+msgid "Query info for all albums"
+msgstr "Obtener información para todos los álbumes"
+
+#: id:20060
+msgctxt "Auto context with id 20060"
+msgid "Media info"
+msgstr "Info de Medio"
+
+#: id:20061
+msgctxt "Auto context with id 20061"
+msgid "Separate"
+msgstr "Separado"
+
+#: id:20062
+msgid "Shares with default"
+msgstr "Recursos con por defecto"
+
+#: id:20063
+msgid "Shares with default (read only)"
+msgstr "Recursos con por defecto (solo lectura)"
+
+#: id:20064
+msgid "Copy default"
+msgstr "Copiar por defecto"
+
+#: id:20065
+msgid "Profile picture"
+msgstr "Imagen de Perfil"
+
+#: id:20066
+msgid "Lock preferences"
+msgstr "Preferencias de Bloqueo"
+
+#: id:20067
+msgid "Edit profile"
+msgstr "Editar perfil"
+
+#: id:20068
+msgid "Profile lock"
+msgstr "Bloquear perfil"
+
+#: id:20069
+msgid "Could not create folder"
+msgstr "No se puede crear la carpeta"
+
+#: id:20070
+msgid "Profile directory"
+msgstr "Carpeta de Perfil"
+
+#: id:20071
+msgid "Start with fresh media sources"
+msgstr "Comenzar con fuentes de medios limpias"
+
+#: id:20072
+msgid "Make sure the selected folder is writable"
+msgstr "Asegúrese de que la carpeta seleccionable permite modificaciones"
+
+#: id:20073
+msgid "and that the new folder name is valid"
+msgstr "y que el nueva carpeta es válido"
+
+#: id:20074
+msgid "MPAA rating"
+msgstr "Calificación MPAA:"
+
+#: id:20075
+msgid "Enter master lock code"
+msgstr "Introduzca código de bloqueo maestro"
+
+#: id:20076
+msgid "Ask for master lock code on startup"
+msgstr "Preguntar código de bloqueo maestro al iniciar"
+
+#: id:20077
+msgid "Skin settings"
+msgstr "Ajustes de Interfaz"
+
+#: id:20078
+msgid "- no link set -"
+msgstr "- no hay enlace establecido -"
+
+#: id:20079
+msgid "Enable animations"
+msgstr "Habilitar Animaciones"
+
+#: id:20080
+msgid "Disable RSS during music"
+msgstr "Deshabilitar RSS con la Música"
+
+#: id:20081
+msgid "Enable shortcut buttons"
+msgstr "Habilitar Botones de Atajos"
+
+#: id:20082
+msgid "Show programs in main menu"
+msgstr "Mostrar programas en el menu principal"
+
+#: id:20083
+msgid "Show music info"
+msgstr "Mostrar Info Música"
+
+#: id:20084
+msgid "Show weather info"
+msgstr "Mostrar info de clima"
+
+#: id:20085
+msgid "Show system info"
+msgstr "Mostrar info de sistema"
+
+#: id:20086
+msgid "Show available disc space C: E: F:"
+msgstr "Mostrar espacio disponible en C: E: F:"
+
+#: id:20087
+msgid "Show available disc space E: F: G:"
+msgstr "Mostrar espacio disponible en E: F: G:"
+
+#: id:20088
+msgid "Weather info"
+msgstr "Información meteorológica"
+
+#: id:20089
+msgid "Drive space free"
+msgstr "Espacio libre en disco"
+
+#: id:20090
+msgid "Enter the name of an existing share"
+msgstr "Introduzca el nombre de un recurso existente"
+
+#: id:20091
+msgid "Lock code"
+msgstr "Código de bloqueo"
+
+#: id:20092
+msgid "Load profile"
+msgstr "Cargar perfil"
+
+#: id:20093
+msgid "Profile name"
+msgstr "Nombre de perfil"
+
+#: id:20094
+msgctxt "Auto context with id 20094"
+msgid "Media sources"
+msgstr "Fuentes de medios"
+
+#: id:20095
+msgid "Enter profile lock code"
+msgstr "Introduzca código de bloqueo de perfil"
+
+#: id:20096
+msgctxt "Auto context with id 20096"
+msgid "Login screen"
+msgstr "Inicio de sesión"
+
+#: id:20097
+msgid "Fetching album info"
+msgstr "Obteniendo info del álbum"
+
+#: id:20098
+msgid "Fetching info for album"
+msgstr "Obteniendo info para el álbum"
+
+#: id:20099
+msgid "Can't rip CD or track while playing from CD"
+msgstr "No se puede ripear CD o una pista mientras se reproduce el mismo"
+
+#: id:20100
+msgid "Master lock code and settings"
+msgstr "Código Maestro y Bloqueos"
+
+#: id:20101
+msgid "Entering master lock code always enables master mode"
+msgstr "Introducir el código maestro siempre habilita el modo maestro"
+
+#: id:20102
+msgid "or copy from default?"
+msgstr "o copiarlos de ajustes predefinidos?"
+
+#: id:20103
+msgid "Save changes to profile?"
+msgstr "¿Guardar cambios al perfil?"
+
+#: id:20104
+msgid "Old settings found."
+msgstr "Encontrados ajustes antiguos."
+
+#: id:20105
+msgid "Do you want to use them?"
+msgstr "¿Deseas usarlos?"
+
+#: id:20106
+msgid "Old media sources found."
+msgstr "Encontradas fuentes de medios antiguos."
+
+#: id:20107
+msgid "Separate (locked)"
+msgstr "Separado (bloqueado)"
+
+#: id:20108
+msgid "Root"
+msgstr "Raíz"
+
+#: id:20109
+msgid "- Zoom"
+msgstr "- Zoom"
+
+#: id:20110
+msgid "UPnP settings"
+msgstr "Ajustes UPnP"
+
+#: id:20111
+msgid "Autostart UPnP client"
+msgstr "Iniciar automáticamente el cliente UPnP"
+
+#: id:20112
+msgid "Last login: %s"
+msgstr "Último inicio de sesión: %s"
+
+#: id:20113
+msgid "Never logged on"
+msgstr "Nunca ha iniciado sesión"
+
+#: id:20114
+msgid "Profile %i / %i"
+msgstr "Perfil %i / %i"
+
+#: id:20115
+msgid "User login / Select a profile"
+msgstr "Inicio de Sesión de Usuario / Selecciona un Perfil"
+
+#: id:20116
+msgid "Use lock on login screen"
+msgstr "Usar bloqueo en pantalla de inicio de sesión"
+
+#: id:20117
+msgid "Invalid lock code."
+msgstr "Código de bloqueo no válido."
+
+#: id:20118
+msgid "This requires the master lock to be set."
+msgstr "Esto requiere asignar el bloqueo maestro."
+
+#: id:20119
+msgid "Would you like to set it now?"
+msgstr "Deseas hacerlo ahora?"
+
+#: id:20120
+msgid "Loading program information"
+msgstr "Cargando información de programa"
+
+#: id:20121
+msgid "Party on!"
+msgstr "¡Que empiece la fiesta!"
+
+#: id:20122
+msgid "True"
+msgstr "Sí"
+
+#: id:20123
+msgid "Mixing drinks"
+msgstr "Mezclando bebidas"
+
+#: id:20124
+msgid "Filling glasses"
+msgstr "Llenando vasos"
+
+#: id:20125
+msgid "Logged on as"
+msgstr "Iniciado como"
+
+#: id:20126
+msgid "Log off"
+msgstr "Cerrar sesión"
+
+#: id:20128
+msgid "Go to root"
+msgstr "Ir a la Raiz"
+
+#: id:20129
+msgid "Weave"
+msgstr "Entramado"
+
+#: id:20130
+msgid "Weave (inverted)"
+msgstr "Entramado (invertido)"
+
+#: id:20131
+msgid "Blend"
+msgstr "Mezclado"
+
+#: id:20132
+msgid "Restart video"
+msgstr "Reiniciar Vídeo"
+
+#: id:20133
+msgid "Edit network location"
+msgstr "Editar Dirección de Red"
+
+#: id:20134
+msgid "Remove network location"
+msgstr "Eliminar Dirección de Red"
+
+#: id:20135
+msgid "Do you want to scan the folder?"
+msgstr "¿Quieres realizar una exploración de la carpeta?"
+
+#: id:20136
+msgid "Memory unit"
+msgstr "Unidad de Memoria"
+
+#: id:20137
+msgid "Memory unit mounted"
+msgstr "Unidad de Memoria montada"
+
+#: id:20138
+msgid "Unable to mount memory unit"
+msgstr "Imposible montar Unidad de Memoria"
+
+#: id:20139
+msgid "In port %i, slot %i"
+msgstr "En puerto %i, bahía %i"
+
+#: id:20140
+msgid "Lock screensaver"
+msgstr "Bloquear salvapantallas"
+
+#: id:20141
+msgid "Set"
+msgstr "Configurar"
+
+#: id:20142
+msgctxt "Auto context with id 20142"
+msgid "Username"
+msgstr "Usuario"
+
+#: id:20143
+msgid "Enter password for"
+msgstr "Introduzca constraseña para"
+
+#: id:20144
+msgid "Shutdown timer"
+msgstr "Apagado Automático"
+
+#: id:20145
+msgid "Shutdown interval (in minutes)"
+msgstr "Intervalo de apagado (en minutos)"
+
+#: id:20146
+msgid "Started, shutdown in %im"
+msgstr "Iniciado, apagado en %im"
+
+#: id:20147
+msgid "Shutdown in 30 minutes"
+msgstr "Apagado en 30 minutos"
+
+#: id:20148
+msgid "Shutdown in 60 minutes"
+msgstr "Apagado en 60 minutos"
+
+#: id:20149
+msgid "Shutdown in 120 minutes"
+msgstr "Apagado en 120 minutos"
+
+#: id:20150
+msgid "Custom shutdown timer"
+msgstr "Apagado personalizado"
+
+#: id:20151
+msgid "Cancel shutdown timer"
+msgstr "Cancelar apagado automático"
+
+#: id:20152
+msgid "Lock preferences for %s"
+msgstr "Bloquear preferencias para %s"
+
+#: id:20153
+msgid "Browse..."
+msgstr "Explorar..."
+
+#: id:20154
+msgid "Summary information"
+msgstr "Información básica"
+
+#: id:20155
+msgid "Storage information"
+msgstr "Información de almacenamiento"
+
+#: id:20156
+msgid "Hard disk information"
+msgstr "Información de disco duro"
+
+#: id:20157
+msgid "DVD-ROM information"
+msgstr "Información de DVD-ROM"
+
+#: id:20158
+msgid "Network information"
+msgstr "Información de red"
+
+#: id:20159
+msgid "Video information"
+msgstr "Información de vídeo"
+
+#: id:20160
+msgid "Hardware information"
+msgstr "Información de hardware"
+
+#: id:20161
+msgid "Total"
+msgstr "Total"
+
+#: id:20162
+msgid "Used"
+msgstr "Usado"
+
+#: id:20163
+msgid "of"
+msgstr "de"
+
+#: id:20164
+msgid "Locking not supported"
+msgstr "Bloqueo no soportado"
+
+#: id:20165
+msgid "Not locked"
+msgstr "No bloqueado"
+
+#: id:20166
+msgid "Locked"
+msgstr "Bloqueado"
+
+#: id:20167
+msgid "Frozen"
+msgstr "Congelado"
+
+#: id:20168
+msgid "Requires reset"
+msgstr "Requiere reinicio"
+
+#: id:20169
+msgid "Week"
+msgstr "Semana"
+
+#: id:20170
+msgid "Line"
+msgstr "Línea"
+
+#: id:20171
+msgid "Windows network (SMB)"
+msgstr "Red Windows (SMB)"
+
+#: id:20172
+msgid "XBMSP server"
+msgstr "Servidor XBMSP"
+
+#: id:20173
+msgctxt "Auto context with id 20173"
+msgid "FTP server"
+msgstr "Servidor FTP"
+
+#: id:20174
+msgid "iTunes music share (DAAP)"
+msgstr "iTunes: música compartida (DAAP)"
+
+#: id:20175
+msgid "UPnP server"
+msgstr "Servidor UPnP"
+
+#: id:20176
+msgid "Show video info"
+msgstr "Ver Info de vídeo"
+
+#: id:20177
+msgid "Done"
+msgstr "Hecho"
+
+#: id:20178
+msgid "Shift"
+msgstr "Mays."
+
+#: id:20179
+msgid "Caps Lock"
+msgstr "Bloq. Mays."
+
+#: id:20180
+msgid "Symbols"
+msgstr "Símbolos"
+
+#: id:20181
+msgid "Backspace"
+msgstr "Retroceso"
+
+#: id:20182
+msgid "Space"
+msgstr "Espacio"
+
+#: id:20183
+msgid "Reload skin"
+msgstr "Recargar skin"
+
+#: id:20184
+msgid "Rotate pictures using EXIF information"
+msgstr "Rotar usando información EXIF"
+
+#: id:20185
+msgid "Use poster view styles for TV shows"
+msgstr "Usar vista de poster para programas de TV"
+
+#: id:20186
+msgid "Please wait"
+msgstr "Espere por favor"
+
+#: id:20187
+msgid "UPnP"
+msgstr ""
+
+#: id:20189
+msgid "Enable auto scrolling for plot & review"
+msgstr "Permitir desplazamiento automático para el argumento y la reseña"
+
+#: id:20190
+msgctxt "Auto context with id 20190"
+msgid "Custom"
+msgstr "Personalizado"
+
+#: id:20191
+msgid "Enable debug logging"
+msgstr "Habilitar trazas de depuración"
+
+#: id:20192
+msgid "Download additional information during updates"
+msgstr "Descargar información adicional durante la actualización"
+
+#: id:20193
+msgid "Default service for album information"
+msgstr "Servicio para informacion de album"
+
+#: id:20194
+msgid "Default service for artist information"
+msgstr "Servicio para informacion de artista"
+
+#: id:20195
+msgid "Change scraper"
+msgstr "Cambiar scraper"
+
+#: id:20196
+msgid "Export music library"
+msgstr "Exportar biblioteca de música"
+
+#: id:20197
+msgid "Import music library"
+msgstr "Importar biblioteca de música"
+
+#: id:20198
+msgid "No artist found!"
+msgstr "¡No se encontraron artistas!"
+
+#: id:20199
+msgid "Downloading artist info failed"
+msgstr "Falló la descarga de información de artista"
+
+#: id:20250
+msgid "Party on! (videos)"
+msgstr "¡Que empiece la fiesta! (vídeos)"
+
+#: id:20251
+msgid "Mixing drinks (videos)"
+msgstr "Mezclando bebidas (vídeos)"
+
+#: id:20252
+msgid "Filling glasses (videos)"
+msgstr "Llenando vasos (vídeos)"
+
+#: id:20253
+msgid "WebDAV server (HTTP)"
+msgstr "Servidor WebDAV (HTTP)"
+
+#: id:20254
+msgid "WebDAV server (HTTPS)"
+msgstr "Servidor WebDAV (HTTPS)"
+
+#: id:20255
+msgid "First logon, edit your profile"
+msgstr "Primer login, cargue su perfil"
+
+#: id:20256
+msgid "HTS Tvheadend client"
+msgstr "Cliente HTS Tvheadend"
+
+#: id:20257
+msgid "VDR Streamdev client"
+msgstr "Cliente VDR Streamdev"
+
+#: id:20258
+msgid "MythTV client"
+msgstr "Cliente MythTV"
+
+#: id:20259
+msgid "Network Filesystem (NFS)"
+msgstr "Network Filesystem (NFS)"
+
+#: id:20260
+msgid "Secure Shell (SSH/SFTP)"
+msgstr "Secure Shell (SSH/SFTP)"
+
+#: id:20261
+msgid "Apple Filing Protocol (AFP)"
+msgstr "Apple Filing Protocol (AFP)"
+
+#: id:20300
+msgid "Web server directory (HTTP)"
+msgstr "Carpeta Servidor Web (HTTP)"
+
+#: id:20301
+msgid "Web server directory (HTTPS)"
+msgstr "Carpeta Servidor Web (HTTPS)"
+
+#: id:20302
+msgid "Unable to write to folder:"
+msgstr "Imposible escribir en carpeta:"
+
+#: id:20303
+msgid "Do you want to skip and proceed?"
+msgstr "Desea saltear y continuar?"
+
+#: id:20304
+msgid "RSS Feed"
+msgstr "RSS Feed"
+
+#: id:20307
+msgid "Secondary DNS"
+msgstr "DNS Secundario"
+
+#: id:20308
+msgid "DHCP server:"
+msgstr "Servidor DHCP:"
+
+#: id:20309
+msgid "Make new folder"
+msgstr "Crear nueva carpeta"
+
+#: id:20310
+msgid "Dim LCD on playback"
+msgstr "Atenuar LCD al reproducir"
+
+#: id:20311
+msgid "Unknown or onboard (protected)"
+msgstr "Desconocido o en placa (protegido)"
+
+#: id:20312
+msgid "Dim LCD on paused"
+msgstr "Atenuar LCD al pausar"
+
+#: id:20314
+msgid "Videos - Library"
+msgstr "Vídeos - Biblioteca"
+
+#: id:20316
+msgid "Sort by: ID"
+msgstr "Por: ID"
+
+#: id:20324
+msgid "Play part..."
+msgstr "Reproducir fragmento..."
+
+#: id:20325
+msgid "Calibration reset"
+msgstr "Reiniciar Calibrado"
+
+#: id:20326
+msgid "This will reset the calibration values for %s"
+msgstr "Esto reiniciará los valores de calibración de %s"
+
+#: id:20327
+msgid "to it's default values."
+msgstr "a sus valores por defecto."
+
+#: id:20328
+msgid "Browse for destination"
+msgstr "Buscar destino"
+
+#: id:20329
+msgid "Movies are in separate folders that match the movie title"
+msgstr ""
+
+#: id:20330
+msgid "Use folder names for lookups"
+msgstr "Usar nombres de dir. en búsquedas"
+
+#: id:20331
+msgctxt "Auto context with id 20331"
+msgid "File"
+msgstr "Fichero"
+
+#: id:20332
+msgid "Use file or folder names in lookups?"
+msgstr "¿Usar nombres de archivo o carpeta en búsquedas?"
+
+#: id:20333
+msgid "Set content"
+msgstr "Contenido"
+
+#: id:20334
+msgid "Folder"
+msgstr "Carpeta"
+
+#: id:20335
+msgid "Look for content recursively?"
+msgstr "¿Buscar contenido recursivamente?"
+
+#: id:20336
+msgid "Unlock sources"
+msgstr "Desbloquear fuentes"
+
+#: id:20337
+msgid "Actor"
+msgstr "Intérprete"
+
+#: id:20338
+msgid "Movie"
+msgstr "Película"
+
+#: id:20339
+msgid "Director"
+msgstr "Director"
+
+#: id:20340
+msgid "Do you want to remove all items within"
+msgstr "¿Deseas eliminar todos los elementos de"
+
+#: id:20341
+msgid "this path from the XBMC library?"
+msgstr "esta ruta de la base de datos?"
+
+#: id:20342
+msgctxt "Auto context with id 20342"
+msgid "Movies"
+msgstr "Películas"
+
+#: id:20343
+msgid "TV shows"
+msgstr "Series de TV"
+
+#: id:20344
+msgid "This directory contains"
+msgstr "Esta carpeta contiene"
+
+#: id:20345
+msgid "Run automated scan"
+msgstr "Ejecutar exploración automatizada"
+
+#: id:20346
+msgid "Scan recursively"
+msgstr "Explorar recursivamente"
+
+#: id:20347
+msgid "as"
+msgstr "como"
+
+#: id:20348
+msgid "Directors"
+msgstr "Directores"
+
+#: id:20349
+msgid "No video files found in this path!"
+msgstr "¡No se han encontrado vídeos en esta ruta!"
+
+#: id:20350
+msgid "votes"
+msgstr "votos"
+
+#: id:20351
+msgid "TV show information"
+msgstr "Información de Programa de TV"
+
+#: id:20352
+msgid "Episode information"
+msgstr "Información de episodio"
+
+#: id:20353
+msgid "Loading TV show details"
+msgstr "Cargando detalles del Programa de TV"
+
+#: id:20354
+msgid "Fetching episode guide"
+msgstr "Obteniendo guía de episodios"
+
+#: id:20355
+msgid "Loading info for episodes in directory"
+msgstr "Cargando Info de Episodios en Carpeta"
+
+#: id:20356
+msgid "Select TV show:"
+msgstr "Seleccione Programa de TV:"
+
+#: id:20357
+msgid "Enter the TV show name"
+msgstr "Introduzca el Nombre de Programa de TV"
+
+#: id:20358
+msgid "Season %i"
+msgstr "Temporada %i"
+
+#: id:20359
+msgid "Episode"
+msgstr "Episodio"
+
+#: id:20360
+msgid "Episodes"
+msgstr "Episodios"
+
+#: id:20361
+msgid "Loading episode details"
+msgstr "Cargando detalles del Episodio"
+
+#: id:20362
+msgid "Remove episode from library"
+msgstr "Eliminar Episodio de biblioteca"
+
+#: id:20363
+msgid "Remove TV show from library"
+msgstr "Eliminar Programa de TV de la biblioteca"
+
+#: id:20364
+msgid "TV show"
+msgstr "Programa de TV"
+
+#: id:20365
+msgid "Episode plot"
+msgstr "Argumento del Episodio"
+
+#: id:20366
+msgid "* All seasons"
+msgstr "* Todas las temporadas"
+
+#: id:20367
+msgid "Hide watched"
+msgstr "Ocultar los vistos"
+
+#: id:20368
+msgid "Prod code"
+msgstr "Código de Prod."
+
+#: id:20369
+msgid "Show plot for unwatched items"
+msgstr "Ocultar el argumento de elementos no vistos"
+
+#: id:20370
+msgid "* Hidden to prevent spoilers *"
+msgstr "* Oculto para prevenir SPOILERS *"
+
+#: id:20371
+msgid "Set season thumb"
+msgstr "Establecer miniatura. de la temporada"
+
+#: id:20372
+msgid "Season image"
+msgstr "Imagen de la temporada"
+
+#: id:20373
+msgid "Season"
+msgstr "Temporada"
+
+#: id:20374
+msgid "Downloading movie information"
+msgstr "Descargando información de vídeo"
+
+#: id:20375
+msgid "Unassign content"
+msgstr "Desasignar contenido"
+
+#: id:20376
+msgid "Original title"
+msgstr "Título original"
+
+#: id:20377
+msgid "Refresh TV show information"
+msgstr "Actualizar información del programa de TV"
+
+#: id:20378
+msgid "Refresh info for all episodes?"
+msgstr "¿Actualizar información de todos los episodios?"
+
+#: id:20379
+msgid "Selected folder contains a single TV show"
+msgstr "El dir. contiene una única serie de TV"
+
+#: id:20380
+msgid "Exclude selected folder from scans"
+msgstr "Excluir carpeta de la exploración"
+
+#: id:20381
+msgid "Specials"
+msgstr "Especiales"
+
+#: id:20382
+msgid "Automatically grab season thumbs"
+msgstr "Obtener automáticamente las miniaturas de temporada"
+
+#: id:20383
+msgid "Selected folder contains a single video"
+msgstr "La carpeta contiene un solo Vídeo"
+
+#: id:20384
+msgid "Link to TV show"
+msgstr "Enlace a serie de TV"
+
+#: id:20385
+msgid "Remove link to TV show"
+msgstr "Eliminar enlace a serie de TV"
+
+#: id:20386
+msgid "Recently added movies"
+msgstr "Películas añadidas recientemente"
+
+#: id:20387
+msgid "Recently added episodes"
+msgstr "Episodios añadidos recientemente"
+
+#: id:20388
+msgid "Studios"
+msgstr "Estudios"
+
+#: id:20389
+msgid "Music videos"
+msgstr "Vídeoclips"
+
+#: id:20390
+msgid "Recently added music videos"
+msgstr "Vídeoclips añadidos recientemente"
+
+#: id:20391
+msgid "Music video"
+msgstr "Vídeoclip"
+
+#: id:20392
+msgid "Remove music video from library"
+msgstr "Eliminar videoclip de la biblioteca"
+
+#: id:20393
+msgctxt "Auto context with id 20393"
+msgid "Music video information"
+msgstr "Información de videoclip"
+
+#: id:20394
+msgid "Loading music video information"
+msgstr "Cargando información de videoclip"
+
+#: id:20395
+msgid "Mixed"
+msgstr "Mezclado"
+
+#: id:20396
+msgid "Go to albums by artist"
+msgstr "Ir a álbumes por artista"
+
+#: id:20397
+msgid "Go to album"
+msgstr "Ir al álbum"
+
+#: id:20398
+msgid "Play song"
+msgstr "Reproducir canción"
+
+#: id:20399
+msgid "Go to music videos from album"
+msgstr "Ir a videoclips desde el álbum"
+
+#: id:20400
+msgid "Go to music videos by artist"
+msgstr "Ir a videoclips por artista"
+
+#: id:20401
+msgid "Play music video"
+msgstr "Reproducir videoclip"
+
+#: id:20402
+msgid "Download actor thumbnails when adding to library"
+msgstr "Obtener automáticamente las miniaturas de actor"
+
+#: id:20403
+msgid "Set actor thumb"
+msgstr "Establecer Miniatura de Actor"
+
+#: id:20405
+msgid "Remove episode bookmark"
+msgstr "Eliminar marcador de episodio"
+
+#: id:20406
+msgid "Set episode bookmark"
+msgstr "Establecer marcador de episodio"
+
+#: id:20407
+msgid "Scraper settings"
+msgstr "Configuración del scraper"
+
+#: id:20408
+msgid "Downloading music video information"
+msgstr "Descargando información del videoclip"
+
+#: id:20409
+msgid "Downloading TV show information"
+msgstr "Descargando información de la serie de TV"
+
+#: id:20410
+msgid "Trailer"
+msgstr "Trailer"
+
+#: id:20411
+msgid "Flatten"
+msgstr "Aplanar"
+
+#: id:20412
+msgid "Flatten TV shows"
+msgstr "Aplanar series de TV"
+
+#: id:20413
+msgid "Get fanart"
+msgstr "Obtener fanart"
+
+#: id:20414
+msgid "Show Fanart in video and music libraries"
+msgstr "Mostrar fanart en la biblioteca de vídeo"
+
+#: id:20415
+msgid "Scanning for new content"
+msgstr "Buscando contenido nuevo"
+
+#: id:20416
+msgid "First aired"
+msgstr "Emitido el"
+
+#: id:20417
+msgid "Writer"
+msgstr "Escritor"
+
+#: id:20419
+msgid "Replace file names with library titles"
+msgstr "Mostrar Metainfo en lista de archivos"
+
+#: id:20420
+msgctxt "Auto context with id 20420"
+msgid "Never"
+msgstr "Nunca"
+
+#: id:20421
+msgid "If only one season"
+msgstr "Si hay sólo una temporada"
+
+#: id:20422
+msgid "Always"
+msgstr "Siempre"
+
+#: id:20423
+msgid "Has trailer"
+msgstr "Tiene trailer"
+
+#: id:20424
+msgid "False"
+msgstr "Falso"
+
+#: id:20425
+msgid "Fanart slideshow"
+msgstr "Presentación de fanart"
+
+#: id:20426
+msgid "Export to a single file or separate"
+msgstr "Exportar a un sólo archivo o separar"
+
+#: id:20427
+msgid "files per entry?"
+msgstr "¿Archivos por entrada?"
+
+#: id:20428
+msgid "Single file"
+msgstr "Un sólo archivo"
+
+#: id:20429
+msgctxt "Auto context with id 20429"
+msgid "Separate"
+msgstr "Separar"
+
+#: id:20430
+msgid "Export thumbnails and fanart?"
+msgstr "¿Exportar miniaturas y fanart?"
+
+#: id:20431
+msgid "Overwrite old files?"
+msgstr "¿Sobreescribir archivos antiguos?"
+
+#: id:20432
+msgid "Exclude path from library updates"
+msgstr "Excluir ruta de actualizaciones de biblioteca"
+
+#: id:20433
+msgid "Extract thumbnails and video information"
+msgstr "Extraer información de miniaturas y video"
+
+#: id:20434
+msgid "Sets"
+msgstr "Sets"
+
+#: id:20435
+msgid "Set movieset thumb"
+msgstr "Set movieset thumb"
+
+#: id:20436
+msgid "Export actor thumbs?"
+msgstr "Exportar miniaturas de actores?"
+
+#: id:20437
+msgid "Choose fanart"
+msgstr "Elegir fanart"
+
+#: id:20438
+msgid "Local fanart"
+msgstr "Fanart local"
+
+#: id:20439
+msgid "No fanart"
+msgstr "Sin fanart"
+
+#: id:20440
+msgid "Current fanart"
+msgstr "Fanart actual"
+
+#: id:20441
+msgid "Remote fanart"
+msgstr "Fanart remoto"
+
+#: id:20442
+msgid "Change content"
+msgstr "Cambiar contenido"
+
+#: id:20443
+msgid "Do you want to refresh info for all"
+msgstr "Desea actualizar la información de todos"
+
+#: id:20444
+msgid "items within this path?"
+msgstr "los items dentro desta carpeta?"
+
+#: id:20445
+msgid "Fanart"
+msgstr "Fanart"
+
+#: id:20446
+msgid "Locally stored information found."
+msgstr "Se encontró información almacenada localmente."
+
+#: id:20447
+msgid "Ignore and refresh from internet?"
+msgstr "Ignorar y actualizar desde intenet?"
+
+#: id:20448
+msgid "Could not download information"
+msgstr "No se pudo descargar información"
+
+#: id:20449
+msgid "Unable to connect to remote server"
+msgstr "No se pudo conectar al servidor remoto"
+
+#: id:20450
+msgid "Would you like to continue scanning?"
+msgstr "Desea continuar buscando?"
+
+#: id:20451
+msgid "Countries"
+msgstr "Paises"
+
+#: id:20452
+msgid "episode"
+msgstr "episodio"
+
+#: id:20453
+msgid "episodes"
+msgstr "episodios"
+
+#: id:20454
+msgid "Listener"
+msgstr "Listener"
+
+#: id:20455
+msgid "Listeners"
+msgstr "Listeners"
+
+#: id:20456
+msgid "Set movieset fanart"
+msgstr "Set movieset fanart"
+
+#: id:20457
+msgid "Movie set"
+msgstr "Movie set"
+
+#: id:20458
+msgid "Group movies in sets"
+msgstr ""
+
+#: id:21330
+msgid "Show hidden files and directories"
+msgstr "Mostrar archivos y carpetas ocultos"
+
+#: id:21331
+msgid "TuxBox client"
+msgstr "Cliente TuxBox"
+
+#: id:21332
+msgid "WARNING: Target TuxBox device is in recording-mode!"
+msgstr "¡AVISO: El dispositivo TuxBox está en Modo-Grabación!"
+
+#: id:21333
+msgid "The stream will be stopped!"
+msgstr "El medio se detendrá!"
+
+#: id:21334
+msgid "Zap to channel: %s failed!"
+msgstr "Cambio al Canal: %s fallido!"
+
+#: id:21335
+msgid "Are you sure to start the stream?"
+msgstr "¿Seguro que desea iniciar el medio?"
+
+#: id:21336
+msgid "Connecting to: %s"
+msgstr "Conectando a: %s"
+
+#: id:21337
+msgid "TuxBox device"
+msgstr "Dispositivo TuxBox"
+
+#: id:21359
+msgid "Add media share..."
+msgstr "Añadir Compartición"
+
+#: id:21360
+msgid "Share video and music libraries through UPnP"
+msgstr "Compartir librerias de video y música via UPnP"
+
+#: id:21364
+msgid "Edit media share"
+msgstr "Editar Compartición"
+
+#: id:21365
+msgid "Remove media share"
+msgstr "Eliminar Compartición"
+
+#: id:21366
+msgid "Subtitle folder"
+msgstr "Carpeta de subtítulos"
+
+#: id:21367
+msgid "Movie & alternate subtitle directory"
+msgstr "Carpeta de subtítulos de películas y otros"
+
+#: id:21368
+msgid "Override ASS/SSA subtitles fonts"
+msgstr "Ignorar fuente de subtitulos ASS/SSA"
+
+#: id:21369
+msgid "Enable mouse and Touch Screen support"
+msgstr "Habilitar ratón"
+
+#: id:21370
+msgid "Play navigation sounds during media playback"
+msgstr "Reproducir sonidos de navegación durante reproducción"
+
+#: id:21371
+msgid "Thumbnail"
+msgstr "Miniatura"
+
+#: id:21372
+msgid "Forced DVD player region"
+msgstr "Forzar región del reproductor DVD"
+
+#: id:21373
+msgid "Video output"
+msgstr "Hardware de vídeo"
+
+#: id:21374
+msgid "Video aspect"
+msgstr "Aspecto de vídeo"
+
+#: id:21375
+msgctxt "Auto context with id 21375"
+msgid "Normal"
+msgstr "Normal"
+
+#: id:21376
+msgid "Letterbox"
+msgstr "Panorámica en 4:3"
+
+#: id:21377
+msgid "Widescreen"
+msgstr "Panorámica"
+
+#: id:21378
+msgid "Enable 480p"
+msgstr "Habilitar 480p"
+
+#: id:21379
+msgid "Enable 720p"
+msgstr "Habilitar 720p"
+
+#: id:21380
+msgid "Enable 1080i"
+msgstr "Habilitar 1080i"
+
+#: id:21381
+msgid "Enter name of new playlist"
+msgstr "Introduzca Nombre de Nueva Lista Rep."
+
+#: id:21382
+msgid "Show \"Add source\" buttons in file lists"
+msgstr "Deshabilitar \"añadir fuente\" en listas de archivos"
+
+#: id:21383
+msgid "Enable scrollbars"
+msgstr "Habilitar barras de desplazamiento"
+
+#: id:21384
+msgid "Make watched filtering a toggle in video library"
+msgstr "Convertir el filtro mostrado en una opción de la biblioteca de vídeo"
+
+#: id:21385
+msgctxt "Auto context with id 21385"
+msgid "Open"
+msgstr "Abierto"
+
+#: id:21386
+msgid "Acoustic management level"
+msgstr "Nivel de Gestión Acústica"
+
+#: id:21387
+msgid "Fast"
+msgstr "Rápido"
+
+#: id:21388
+msgid "Quiet"
+msgstr "Silencioso"
+
+#: id:21389
+msgid "Enable custom background"
+msgstr "Habilitar Fondo Personalizado"
+
+#: id:21390
+msgid "Power management level"
+msgstr "Nivel de Gestión de Energía"
+
+#: id:21391
+msgid "High power"
+msgstr "High Power"
+
+#: id:21392
+msgid "Low power"
+msgstr "Low Power"
+
+#: id:21393
+msgid "High standby"
+msgstr "High Standby"
+
+#: id:21394
+msgid "Low standby"
+msgstr "Low Standby"
+
+#: id:21395
+msgid "Unable to cache files bigger than 4GB"
+msgstr "No se pueden hace cache de archivos mayores de 4 GB"
+
+#: id:21396
+msgid "Chapter"
+msgstr "Capítulo"
+
+#: id:21397
+msgid "High quality pixel shader v2"
+msgstr "Pixel Shader de alta calidad V2"
+
+#: id:21398
+msgid "Enable playlist at startup"
+msgstr "Habilitar lista de reproducción al inicio"
+
+#: id:21399
+msgid "Use tween animations"
+msgstr "Usar animaciones con interpolado"
+
+#: id:21400
+msgid "contains"
+msgstr "contiene"
+
+#: id:21401
+msgid "does not contain"
+msgstr "no contiene"
+
+#: id:21402
+msgid "is"
+msgstr "es"
+
+#: id:21403
+msgid "is not"
+msgstr "no es"
+
+#: id:21404
+msgid "starts with"
+msgstr "empieza por"
+
+#: id:21405
+msgid "ends with"
+msgstr "termina con"
+
+#: id:21406
+msgid "greater than"
+msgstr "mayor que"
+
+#: id:21407
+msgid "less than"
+msgstr "menor que"
+
+#: id:21408
+msgid "after"
+msgstr "después"
+
+#: id:21409
+msgid "before"
+msgstr "antes"
+
+#: id:21410
+msgid "in the last"
+msgstr "en los últimos"
+
+#: id:21411
+msgid "not in the last"
+msgstr "no en los últimos"
+
+#: id:21412
+msgid "Scrapers"
+msgstr "Scrapers"
+
+#: id:21413
+msgid "Default movie scraper"
+msgstr "Scraper de película por defecto"
+
+#: id:21414
+msgid "Default tvshow scraper"
+msgstr "Scraper de serie por defecto"
+
+#: id:21415
+msgid "Default music video scraper"
+msgstr "Scraper de vídeo musical por defecto"
+
+#: id:21416
+msgid "Enable fallback based on scraper language"
+msgstr "Habilitar vuelta atrás basada en lenguaje de Scraper"
+
+#: id:21417
+msgid "- Settings"
+msgstr "- Configuración"
+
+#: id:21418
+msgid "Multilingual"
+msgstr "Multilingüe"
+
+#: id:21419
+msgid "No scrapers present"
+msgstr "No hay scrapers presentes"
+
+#: id:21420
+msgid "Value to match"
+msgstr "Valor a encontrar"
+
+#: id:21421
+msgid "Smart playlist rule"
+msgstr "Regla de lista de reproducción inteligente"
+
+#: id:21422
+msgid "Match items where"
+msgstr "Encontrar canciones donde"
+
+#: id:21423
+msgid "New rule..."
+msgstr "Nueva regla..."
+
+#: id:21424
+msgid "Items must match"
+msgstr "Las canciones deben coincidir con"
+
+#: id:21425
+msgid "all of the rules"
+msgstr "todas las reglas"
+
+#: id:21426
+msgid "one or more of the rules"
+msgstr "una o más reglas"
+
+#: id:21427
+msgid "Limit to"
+msgstr "Limitar a"
+
+#: id:21428
+msgid "No limit"
+msgstr "Sin límite"
+
+#: id:21429
+msgid "Order by"
+msgstr "Ordenar por"
+
+#: id:21430
+msgid "ascending"
+msgstr "ascendente"
+
+#: id:21431
+msgid "descending"
+msgstr "descendente"
+
+#: id:21432
+msgid "Edit smart playlist"
+msgstr "Editar lista de reproducción inteligente"
+
+#: id:21433
+msgid "Name of the playlist"
+msgstr "Nombre de la lista de reproducción"
+
+#: id:21434
+msgid "Find items where"
+msgstr "Encontrar canciones coincidentes"
+
+#: id:21435
+msgid "Edit"
+msgstr "Editar"
+
+#: id:21436
+msgid "%i items"
+msgstr "%i canciones"
+
+#: id:21437
+msgid "New smart playlist..."
+msgstr "Nueva lista de reproducción inteligente..."
+
+#: id:21438
+msgid "%c Drive"
+msgstr "Unidad %c"
+
+#: id:21439
+msgid "Edit party mode rules"
+msgstr "Editar reglas del modo fiesta"
+
+#: id:21440
+msgid "Home folder"
+msgstr "Carpeta de inicio"
+
+#: id:21441
+msgid "Watched count"
+msgstr "Veces visto"
+
+#: id:21442
+msgid "Episode title"
+msgstr "Título del episodio"
+
+#: id:21443
+msgid "Video resolution"
+msgstr "Resolución de video"
+
+#: id:21444
+msgid "Audio channels"
+msgstr "Canales de audio"
+
+#: id:21445
+msgid "Video codec"
+msgstr "Códec de video"
+
+#: id:21446
+msgid "Audio codec"
+msgstr "Códec de audio"
+
+#: id:21447
+msgid "Audio language"
+msgstr "Lenguaje del audio"
+
+#: id:21448
+msgid "Subtitle language"
+msgstr "Lenguaje del subtítulo"
+
+#: id:21449
+msgid "Remote control sends keyboard presses"
+msgstr "El control remoto se comporta como un teclado"
+
+#: id:21450
+msgid "- Edit"
+msgstr "- Editar"
+
+#: id:21451
+msgid "Internet connection required."
+msgstr "Se requiere una conexión a internet."
+
+#: id:21452
+msgid "Get More..."
+msgstr "Obtener más..."
+
+#: id:21453
+msgid "Root filesystem"
+msgstr "Sistema de archivos Root"
+
+#: id:21454
+msgid "Cache full"
+msgstr "Cache lleno"
+
+#: id:21455
+msgid "Cache filled before reaching required amount for continous playback"
+msgstr "El cache se llenó antes de alcanzar la cantidad requerida para reproducción continua"
+
+#: id:21460
+msgid "Subtitle location"
+msgstr "Ubicación de subtitulos"
+
+#: id:21461
+msgid "Fixed"
+msgstr "Fijo"
+
+#: id:21462
+msgid "Bottom of video"
+msgstr "Sobre el final del video"
+
+#: id:21463
+msgid "Below video"
+msgstr "Debajo del video"
+
+#: id:21464
+msgid "Top of video"
+msgstr "Sobre el comienzo del video"
+
+#: id:21465
+msgid "Above video"
+msgstr "Arriba del video"
+
+#: id:21800
+msgid "File name"
+msgstr "Nombre de fichero"
+
+#: id:21801
+msgid "File path"
+msgstr "Ruta de fichero"
+
+#: id:21802
+msgid "File size"
+msgstr "Tamaño de fichero"
+
+#: id:21803
+msgid "File date/time"
+msgstr "Fecha/hora fichero"
+
+#: id:21804
+msgid "Slide index"
+msgstr "Índice de transparencia"
+
+#: id:21805
+msgctxt "Auto context with id 21805"
+msgid "Resolution"
+msgstr "Resolución"
+
+#: id:21806
+msgctxt "Auto context with id 21806"
+msgid "Comment"
+msgstr "Comentario"
+
+#: id:21807
+msgid "Colour/B&W"
+msgstr "Color/BN"
+
+#: id:21808
+msgid "JPEG process"
+msgstr "Procesado JPEG"
+
+#: id:21820
+msgid "Date/Time"
+msgstr "Fecha/Hora"
+
+#: id:21821
+msgid "Description"
+msgstr "Descripción"
+
+#: id:21822
+msgid "Camera make"
+msgstr "Fabricante de cámara"
+
+#: id:21823
+msgid "Camera model"
+msgstr "Modelo de cámara"
+
+#: id:21824
+msgid "EXIF comment"
+msgstr "Comentario EXIF"
+
+#: id:21825
+msgid "Firmware"
+msgstr "Firmware"
+
+#: id:21826
+msgid "Aperture"
+msgstr "Apertura"
+
+#: id:21827
+msgid "Focal length"
+msgstr "Longitud focal"
+
+#: id:21828
+msgid "Focus distance"
+msgstr "Distancia enfoque"
+
+#: id:21829
+msgid "Exposure"
+msgstr "Exposición"
+
+#: id:21830
+msgid "Exposure time"
+msgstr "Tiempo de exposición"
+
+#: id:21831
+msgid "Exposure bias"
+msgstr "Exposure Bias"
+
+#: id:21832
+msgid "Exposure mode"
+msgstr "Modo de Exposición"
+
+#: id:21833
+msgid "Flash used"
+msgstr "Flash Usado"
+
+#: id:21834
+msgid "White-balance"
+msgstr "Balance de blancos"
+
+#: id:21835
+msgid "Light source"
+msgstr "Fuente de luz"
+
+#: id:21836
+msgid "Metering mode"
+msgstr "Modo de medición"
+
+#: id:21837
+msgid "ISO"
+msgstr "ISO"
+
+#: id:21838
+msgid "Digital zoom"
+msgstr "Zoom digital"
+
+#: id:21839
+msgid "CCD width"
+msgstr "Ancho CCD"
+
+#: id:21840
+msgid "GPS latitude"
+msgstr "Latitud GPS"
+
+#: id:21841
+msgid "GPS longitude"
+msgstr "Longitud GPS"
+
+#: id:21842
+msgid "GPS altitude"
+msgstr "Altitud GPS"
+
+#: id:21843
+msgid "Orientation"
+msgstr "Orientación"
+
+#: id:21860
+msgid "Supplemental categories"
+msgstr "Categorías complementarias"
+
+#: id:21861
+msgid "Keywords"
+msgstr "Palabras clave"
+
+#: id:21862
+msgid "Caption"
+msgstr "Pie de foto"
+
+#: id:21863
+msgid "Author"
+msgstr "Autor"
+
+#: id:21864
+msgid "Headline"
+msgstr "Titular"
+
+#: id:21865
+msgid "Special instructions"
+msgstr "Instrucciones especiales"
+
+#: id:21866
+msgid "Category"
+msgstr "Categoría"
+
+#: id:21867
+msgid "Byline"
+msgstr "Byline"
+
+#: id:21868
+msgid "Byline title"
+msgstr "Byline Title"
+
+#: id:21869
+msgid "Credit"
+msgstr "Crédito"
+
+#: id:21870
+msgid "Source"
+msgstr "Fuente"
+
+#: id:21871
+msgid "Copyright notice"
+msgstr "Información de copyright"
+
+#: id:21872
+msgid "Object name"
+msgstr "Nombre de objeto"
+
+#: id:21873
+msgid "City"
+msgstr "Ciudad"
+
+#: id:21874
+msgid "State"
+msgstr "Estado"
+
+#: id:21875
+msgctxt "Auto context with id 21875"
+msgid "Country"
+msgstr "País"
+
+#: id:21876
+msgid "Original Tx Reference"
+msgstr "Referencia Tx Original"
+
+#: id:21877
+msgid "Date created"
+msgstr "Fecha de creación"
+
+#: id:21878
+msgid "Copyright flag"
+msgstr "Marca copyright"
+
+#: id:21879
+msgid "Country code"
+msgstr "Código de país"
+
+#: id:21880
+msgid "Reference service"
+msgstr "Servicio Referencia"
+
+#: id:21881
+msgid "Allow control of XBMC via UPnP"
+msgstr "Permitir control de XBMC via UPnP"
+
+#: id:21882
+msgid "Attempt to skip introduction before DVD menu"
+msgstr "Intentar saltar introducción previa al menú DVD"
+
+#: id:21883
+msgid "Saved music"
+msgstr "Música almacenada"
+
+#: id:21884
+msgid "Query info for all artists"
+msgstr "Solicitar información para todos los artistas"
+
+#: id:21885
+msgid "Downloading album information"
+msgstr "Descargando información de album"
+
+#: id:21886
+msgid "Downloading artist information"
+msgstr "Descargando información de artista"
+
+#: id:21887
+msgid "Biography"
+msgstr "Biografía"
+
+#: id:21888
+msgid "Discography"
+msgstr "Discografía"
+
+#: id:21889
+msgid "Searching artist"
+msgstr "Buscando artista"
+
+#: id:21890
+msgid "Select artist"
+msgstr "Seleccionar artista"
+
+#: id:21891
+msgctxt "Auto context with id 21891"
+msgid "Artist information"
+msgstr "Información de artista"
+
+#: id:21892
+msgid "Instruments"
+msgstr "Instrumentos"
+
+#: id:21893
+msgid "Born"
+msgstr "Nacido"
+
+#: id:21894
+msgid "Formed"
+msgstr "Formado"
+
+#: id:21895
+msgid "Themes"
+msgstr "Temas"
+
+#: id:21896
+msgid "Disbanded"
+msgstr "Separado"
+
+#: id:21897
+msgid "Died"
+msgstr "Muerto"
+
+#: id:21898
+msgid "Years active"
+msgstr "Años activo"
+
+#: id:21899
+msgid "Label"
+msgstr "Firma"
+
+#: id:21900
+msgid "Born/Formed"
+msgstr "Nacido/Formado"
+
+#: id:22000
+msgid "Update library on startup"
+msgstr "Actualizar biblioteca en el arranque"
+
+#: id:22001
+msgid "Hide progress of library updates"
+msgstr "Siempre actualizar la biblioteca en segundo plano"
+
+#: id:22002
+msgid "- DNS suffix"
+msgstr "- Sufijo DNS"
+
+#: id:22003
+msgid "%2.3fs"
+msgstr "%2.3fs"
+
+#: id:22004
+msgid "Delayed by: %2.3fs"
+msgstr "Retrasado en: %2.3fs"
+
+#: id:22005
+msgid "Ahead by: %2.3fs"
+msgstr "Adelantado en: %2.3fs"
+
+#: id:22006
+msgid "Subtitle offset"
+msgstr "Mover subtítulos"
+
+#: id:22007
+msgid "OpenGL vendor:"
+msgstr "Distribuidor OpenGL:"
+
+#: id:22008
+msgid "OpenGL renderer:"
+msgstr "Renderizador OpenGL:"
+
+#: id:22009
+msgid "OpenGL version:"
+msgstr "Versión OpenGL:"
+
+#: id:22010
+msgid "GPU temperature:"
+msgstr "Temperatura de GPU:"
+
+#: id:22011
+msgid "CPU temperature:"
+msgstr "Temperatura de CPU:"
+
+#: id:22012
+msgid "Total memory"
+msgstr "Memoria Total"
+
+#: id:22013
+msgid "Profile data"
+msgstr "Datos de perfil"
+
+#: id:22014
+msgid "Use dim if paused during video playback"
+msgstr "Atenuar si se pausa durante reproducción de video"
+
+#: id:22015
+msgid "All recordings"
+msgstr "Todas las grabaciones"
+
+#: id:22016
+msgid "By title"
+msgstr "Por título"
+
+#: id:22017
+msgid "By group"
+msgstr "Por grupo"
+
+#: id:22018
+msgid "Live channels"
+msgstr "Canales en vivo"
+
+#: id:22019
+msgid "Recordings by title"
+msgstr "Grabaciones por título"
+
+#: id:22020
+msgid "Guide"
+msgstr "Guía"
+
+#: id:22021
+msgid "Allowed error in aspect ratio to minimize black bars"
+msgstr "Error de aspecto permitido para minimizar bandas negras"
+
+#: id:22022
+msgid "Show video files in listings"
+msgstr "Mostrar archivos de video en listados"
+
+#: id:22023
+msgid "DirectX vendor:"
+msgstr "Distribuidor DirectX:"
+
+#: id:22024
+msgid "Direct3D version:"
+msgstr "Versión Direct3D:"
+
+#: id:22030
+msgctxt "Auto context with id 22030"
+msgid "Font"
+msgstr "Fuente"
+
+#: id:22031
+msgctxt "Auto context with id 22031"
+msgid "- Size"
+msgstr "- Tamaño"
+
+#: id:22032
+msgctxt "Auto context with id 22032"
+msgid "- Colours"
+msgstr "- Colores"
+
+#: id:22033
+msgid "- Charset"
+msgstr "- Juego de caracteres"
+
+#: id:22034
+msgid "Export karaoke titles as HTML"
+msgstr "Exportar títulos de karaoke como HTML"
+
+#: id:22035
+msgid "Export karaoke titles as CSV"
+msgstr "Exportar títulos de karaoke como CSV"
+
+#: id:22036
+msgid "Import karaoke titles..."
+msgstr "Importar títulos de karaoke..."
+
+#: id:22037
+msgid "Show song selector automatically"
+msgstr "Mostrar selector de canciones automáticamente"
+
+#: id:22038
+msgid "Export karaoke titles..."
+msgstr "Exportar títulos de karaoke..."
+
+#: id:22039
+msgid "Enter song number"
+msgstr "Introduzca nombre de canción"
+
+#: id:22040
+msgid "white/green"
+msgstr "Blanco/Verde"
+
+#: id:22041
+msgid "white/red"
+msgstr "Blanco/Rojo"
+
+#: id:22042
+msgid "white/blue"
+msgstr "Blanco/Azul"
+
+#: id:22043
+msgid "black/white"
+msgstr "Blanco/Negro"
+
+#: id:22079
+msgid "Default select action"
+msgstr "Acción del botón select"
+
+#: id:22080
+msgid "Choose"
+msgstr "Elegir"
+
+#: id:22081
+msgid "Show Information"
+msgstr "Mostrar información"
+
+#: id:22082
+msgid "More..."
+msgstr "Más..."
+
+#: id:22083
+msgid "Play all"
+msgstr "Reproducir todo"
+
+#: id:23049
+msgid "Teletext not available"
+msgstr "Teletext no disponible"
+
+#: id:23050
+msgid "Activate Teletext"
+msgstr "Activar Teletext"
+
+#: id:23051
+msgid "Part %i"
+msgstr "Parte %i"
+
+#: id:23052
+msgid "Buffering %i bytes"
+msgstr "Almacenando %i bytes"
+
+#: id:23053
+msgid "Stopping"
+msgstr "Deteniendo"
+
+#: id:23054
+msgid "Running"
+msgstr "Ejecutando"
+
+#: id:23100
+msgid "External Player Active"
+msgstr "Reproductor externo activo"
+
+#: id:23101
+msgid "Click OK to terminate the player"
+msgstr "Click en OK para terminar el reproductor"
+
+#: id:23104
+msgid "Click OK when playback has ended"
+msgstr "Click en OK cuando haya terminado la reproducción"
+
+#: id:24000
+msgid "Add-on"
+msgstr "Add-on"
+
+#: id:24001
+msgid "Add-ons"
+msgstr "Add-ons"
+
+#: id:24002
+msgid "Add-on options"
+msgstr "Opciones de Add-on"
+
+#: id:24003
+msgid "Add-on Information"
+msgstr "Información de Add-on"
+
+#: id:24005
+msgctxt "Auto context with id 24005"
+msgid "Media sources"
+msgstr "Fuente de contenidos"
+
+#: id:24007
+msgctxt "Auto context with id 24007"
+msgid "Movie information"
+msgstr "Info de Películas"
+
+#: id:24008
+msgctxt "Auto context with id 24008"
+msgid "Screensaver"
+msgstr "Refrescapantalla"
+
+#: id:24009
+msgid "Script"
+msgstr "Script"
+
+#: id:24010
+msgctxt "Auto context with id 24010"
+msgid "Visualization"
+msgstr "Visualización"
+
+#: id:24011
+msgid "Add-on repository"
+msgstr "Repositorio de Add-on"
+
+#: id:24012
+msgctxt "Auto context with id 24012"
+msgid "Subtitles"
+msgstr "Subtítulos"
+
+#: id:24013
+msgid "Lyrics"
+msgstr "Letras"
+
+#: id:24014
+msgid "TV information"
+msgstr "Info de TV"
+
+#: id:24015
+msgctxt "Auto context with id 24015"
+msgid "Music video information"
+msgstr "Info de videoclips"
+
+#: id:24016
+msgctxt "Auto context with id 24016"
+msgid "Album information"
+msgstr "Info de album musical"
+
+#: id:24017
+msgctxt "Auto context with id 24017"
+msgid "Artist information"
+msgstr "Info de artista"
+
+#: id:24018
+msgctxt "Auto context with id 24018"
+msgid "Services"
+msgstr "Servicios"
+
+#: id:24020
+msgid "Configure"
+msgstr "Configure"
+
+#: id:24021
+msgctxt "Auto context with id 24021"
+msgid "Disable"
+msgstr "Disable"
+
+#: id:24022
+msgid "Enable"
+msgstr "Enable"
+
+#: id:24023
+msgid "Add-on disabled"
+msgstr "Add-on disabled"
+
+#: id:24027
+msgctxt "Auto context with id 24027"
+msgid "Weather"
+msgstr "Weather"
+
+#: id:24028
+msgid "Weather.com (standard)"
+msgstr "Weather.com (standard)"
+
+#: id:24030
+msgid "This Add-on can not be configured"
+msgstr "This Add-on can not be configured"
+
+#: id:24031
+msgid "Error loading settings"
+msgstr "Error loading settings"
+
+#: id:24032
+msgid "All Add-ons"
+msgstr "All Add-ons"
+
+#: id:24033
+msgid "Get Add-ons"
+msgstr "Get Add-ons"
+
+#: id:24034
+msgid "Check for updates"
+msgstr "Check for updates"
+
+#: id:24035
+msgid "Force refresh"
+msgstr "Force refresh"
+
+#: id:24036
+msgid "Change log"
+msgstr "Change log"
+
+#: id:24037
+msgid "Uninstall"
+msgstr "Uninstall"
+
+#: id:24038
+msgid "Install"
+msgstr "Install"
+
+#: id:24039
+msgid "Disabled Add-ons"
+msgstr "Disabled Add-ons"
+
+#: id:24040
+msgid "(Clear the current setting)"
+msgstr "(Clear the current setting)"
+
+#: id:24041
+msgid "Install from zip file"
+msgstr "Install from zip file"
+
+#: id:24042
+msgid "Downloading %i%%"
+msgstr "Downloading %i%%"
+
+#: id:24043
+msgid "Available Updates"
+msgstr "Available Updates"
+
+#: id:24044
+msgid "Dependencies not met"
+msgstr "Dependencias no cumplidas"
+
+#: id:24045
+msgid "Add-on does not have the correct structure"
+msgstr "El Add-on no tiene la estructura correcta"
+
+#: id:24046
+msgid "%s is used by the following installed add-on(s)"
+msgstr "%s se usa por los siguientes addon(s) instalado(s)"
+
+#: id:24047
+msgid "This add-on cannot be uninstalled"
+msgstr "Este add-on no se puede desinstalar"
+
+#: id:24048
+msgid "Rollback"
+msgstr "Volver a versión anterior"
+
+#: id:24050
+msgid "Available Add-ons"
+msgstr "Available Add-ons"
+
+#: id:24051
+msgid "Version:"
+msgstr "Version:"
+
+#: id:24052
+msgid "Disclaimer"
+msgstr "Disclaimer"
+
+#: id:24053
+msgid "License:"
+msgstr "License:"
+
+#: id:24054
+msgid "Changelog"
+msgstr "Changelog"
+
+#: id:24059
+msgid "Would you like to enable this Add-on?"
+msgstr "Desea activar este Add-on?"
+
+#: id:24060
+msgid "Would you like to disable this Add-on?"
+msgstr "Desea desactivar este Add-on?"
+
+#: id:24061
+msgid "Add-on update available!"
+msgstr "Hay disponible una actualización del Add-on!"
+
+#: id:24062
+msgid "Enabled Add-ons"
+msgstr "Add-ons activados"
+
+#: id:24063
+msgid "Auto update"
+msgstr "Actualización automática"
+
+#: id:24064
+msgid "Add-on enabled"
+msgstr "Add-on activado"
+
+#: id:24065
+msgid "Add-on updated"
+msgstr "Add-on Actualizado"
+
+#: id:24066
+msgid "Cancel Add-on download?"
+msgstr "Cancelar descarga de Add-on?"
+
+#: id:24067
+msgid "Currently downloading Add-ons"
+msgstr "Add-ons siendo descargados"
+
+#: id:24068
+msgid "Update available"
+msgstr "Actualización disponible"
+
+#: id:24069
+msgid "Update"
+msgstr "Actualizar"
+
+#: id:24070
+msgid "Add-on could not be loaded."
+msgstr "No se pudo cargar el Add-on."
+
+#: id:24071
+msgid "An unknown error has occurred."
+msgstr "Ocurrió un error desconocido."
+
+#: id:24072
+msgid "Settings required"
+msgstr "Se requiere configuración"
+
+#: id:24073
+msgid "Could not connect"
+msgstr "No se pudo conectar"
+
+#: id:24074
+msgid "Needs to restart"
+msgstr "Es necesario reiniciar"
+
+#: id:24075
+msgctxt "Auto context with id 24075"
+msgid "Disable"
+msgstr "Desactivar"
+
+#: id:24076
+msgid "Add-on Required"
+msgstr "Add-on requerido"
+
+#: id:24080
+msgid "Try to reconnect?"
+msgstr "Intentar reconectar?"
+
+#: id:24089
+msgid "Add-on restarts"
+msgstr "Se reinicia Add-on"
+
+#: id:24090
+msgid "Lock Add-on manager"
+msgstr "Bloquear administrador de Add-on"
+
+#: id:24094
+msgid "(current)"
+msgstr "(actual)"
+
+#: id:24095
+msgid "(blacklisted)"
+msgstr "(blacklisted)"
+
+#: id:24096
+msgid "Add-on has been marked as broken in repository."
+msgstr "El Add-on ha sido marcado como ROTO en el repositorio."
+
+#: id:24097
+msgid "Would you like to disable it on your system?"
+msgstr "Desea desactivarlo en su sistema?"
+
+#: id:24098
+msgid "Broken"
+msgstr "ROTO"
+
+#: id:24099
+msgid "Would you like to switch to this skin?"
+msgstr "Desea cambiar a este skin?"
+
+#: id:24100
+msgid "To use this feature you must download an Add-on:"
+msgstr "Para usar esta opción necesita descargar un Add-on:"
+
+#: id:24101
+msgid "Would you like to download this Add-on?"
+msgstr "Quiere descargar este Add-on?"
+
+#: id:25000
+msgid "Notifications"
+msgstr "Notificaciones"
+
+#: id:29800
+msgid "Library Mode"
+msgstr "Modo biblioteca"
+
+#: id:29801
+msgid "QWERTY keyboard"
+msgstr "Teclado QWERTY"
+
+#: id:29802
+msgid "Passthrough Audio in use"
+msgstr "Audio Passthrough en uso"
+
+#: id:33001
+msgid "Trailer quality"
+msgstr "Calidad del Trailer"
+
+#: id:33002
+msgid "Stream"
+msgstr "Stream"
+
+#: id:33003
+msgid "Download"
+msgstr "Descargar"
+
+#: id:33004
+msgid "Download & play"
+msgstr "Descargar y reproducir"
+
+#: id:33005
+msgid "Download & save"
+msgstr "Descargar y guardar"
+
+#: id:33006
+msgid "Today"
+msgstr "Hoy"
+
+#: id:33007
+msgid "Tomorrow"
+msgstr "Mañana"
+
+#: id:33008
+msgid "Saving"
+msgstr "Guardando"
+
+#: id:33009
+msgid "Copying"
+msgstr "Copiando"
+
+#: id:33010
+msgid "Set download directory"
+msgstr "Establecer directorio de descargas"
+
+#: id:33011
+msgid "Search duration"
+msgstr "Duración de búsqueda"
+
+#: id:33012
+msgid "Short"
+msgstr "Corto"
+
+#: id:33013
+msgid "Long"
+msgstr "Largo"
+
+#: id:33014
+msgid "Use DVD player instead of regular player"
+msgstr "Usar reproductor de DVD en vez del reproductor regular"
+
+#: id:33015
+msgid "Ask for download before playing video"
+msgstr "Preguntar por descarga antes de reproducir video"
+
+#: id:33016
+msgid "Clips"
+msgstr "Clips"
+
+#: id:33017
+msgid "Restart plugin to enable"
+msgstr "Reiniciar plugin para activar"
+
+#: id:33018
+msgid "Tonight"
+msgstr "Esta noche"
+
+#: id:33019
+msgid "Tomorrow Night"
+msgstr "Mañana en la noche"
+
+#: id:33020
+msgid "Condition"
+msgstr "Condición"
+
+#: id:33021
+msgid "Precipitation"
+msgstr "Precipitación"
+
+#: id:33022
+msgid "Precip"
+msgstr "Precip"
+
+#: id:33023
+msgid "Humid"
+msgstr "Humedo"
+
+#: id:33024
+msgid "Feels"
+msgstr "Feels"
+
+#: id:33025
+msgid "Observed"
+msgstr "Observada"
+
+#: id:33026
+msgid "Departure from normal"
+msgstr "Alejamiento del promedio"
+
+#: id:33027
+msgid "Sunrise"
+msgstr "Amanece"
+
+#: id:33028
+msgid "Sunset"
+msgstr "Puesta"
+
+#: id:33029
+msgid "Details"
+msgstr "Detalles"
+
+#: id:33030
+msgid "Outlook"
+msgstr "Outlook"
+
+#: id:33031
+msgid "Coverflow"
+msgstr "Coverflow"
+
+#: id:33032
+msgid "Translate text"
+msgstr "Traducir texto"
+
+#: id:33033
+msgid "Map list %s category"
+msgstr "Map list %s category"
+
+#: id:33034
+msgid "36 Hour"
+msgstr "36 Horas"
+
+#: id:33035
+msgid "Maps"
+msgstr "Mapas"
+
+#: id:33036
+msgid "Hourly"
+msgstr "Hourly"
+
+#: id:33037
+msgid "Weekend"
+msgstr "Fin de semana"
+
+#: id:33038
+msgid "%s day"
+msgstr "%s días"
+
+#: id:33049
+msgid "Alert"
+msgstr "Alerta"
+
+#: id:33050
+msgid "Alerts"
+msgstr "Alertas"
+
+#: id:33051
+msgid "Choose Your"
+msgstr "Elija su"
+
+#: id:33052
+msgid "Check"
+msgstr "Check"
+
+#: id:33053
+msgctxt "Auto context with id 33053"
+msgid "Configure the"
+msgstr "Configure el"
+
+#: id:33054
+msgid "Seasons"
+msgstr "Temporadas"
+
+#: id:33055
+msgid "Use your"
+msgstr "Use su"
+
+#: id:33056
+msgid "Watch your"
+msgstr "Observe su"
+
+#: id:33057
+msgid "Listen to"
+msgstr "Escuche a"
+
+#: id:33058
+msgid "View your"
+msgstr "Mire su"
+
+#: id:33059
+msgctxt "Auto context with id 33059"
+msgid "Configure the"
+msgstr "Configure el"
+
+#: id:33060
+msgid "Power"
+msgstr "Power"
+
+#: id:33061
+msgid "Menu"
+msgstr "Menu"
+
+#: id:33062
+msgid "Play the"
+msgstr "Reproducir el"
+
+#: id:33063
+msgid "Options"
+msgstr "Opciones"
+
+#: id:33065
+msgid "Editor"
+msgstr "Editor"
+
+#: id:33066
+msgid "About your"
+msgstr "Acerca de su"
+
+#: id:33067
+msgid "Star rating"
+msgstr "Star rating"
+
+#: id:33068
+msgid "Background"
+msgstr "Background"
+
+#: id:33069
+msgid "Backgrounds"
+msgstr "Backgrounds"
+
+#: id:33070
+msgid "Custom background"
+msgstr "Custom background"
+
+#: id:33071
+msgid "Custom backgrounds"
+msgstr "Custom backgrounds"
+
+#: id:33072
+msgid "View Readme"
+msgstr "Ver Leáme"
+
+#: id:33073
+msgid "View Changelog"
+msgstr "Ver Changelog"
+
+#: id:33074
+msgid "This version of %s requires an"
+msgstr "Esta version de %s requiere"
+
+#: id:33075
+msgid "XBMC revision of %s or greater to run."
+msgstr "XBMC revision %s o superior para funcionar."
+
+#: id:33076
+msgid "Please update XBMC."
+msgstr "Por favor actualice XBMC."
+
+#: id:33077
+msgid "No data found!"
+msgstr "No se encontraron datos!"
+
+#: id:33078
+msgid "Next page"
+msgstr "Próx página"
+
+#: id:33079
+msgid "Love"
+msgstr "Amor"
+
+#: id:33080
+msgid "Hate"
+msgstr "Odio"
+
+#: id:33081
+msgid "This file is stacked, select the part you want to play from."
+msgstr "Este archivo esta apilado, seleccion la parte desde la que desea reproducir."
+
+#: id:33082
+msgid "Path to script"
+msgstr "Ruta al script"
+
+#: id:33083
+msgid "Enable custom script button"
+msgstr "Activar boton script personalizado"
+
+#: id:33100
+msgid "Failed to start"
+msgstr "Fallo al iniciar"
+
+#: id:33101
+msgid "Webserver"
+msgstr "Servidor Web"
+
+#: id:33102
+msgid "Event Server"
+msgstr "Servidor de eventos"
+
+#: id:33103
+msgid "Remote communication server"
+msgstr "Servidor de comunicacion remota"
+
+#: id:33200
+msgid "Detected New Connection"
+msgstr "Detectada nueva conexión"
+
+#: id:34000
+msgid "Lame"
+msgstr ""
+
+#: id:34001
+msgid "Vorbis"
+msgstr ""
+
+#: id:34002
+msgid "Wav"
+msgstr ""
+
+#: id:34003
+msgid "DXVA2"
+msgstr ""
+
+#: id:34004
+msgid "VAAPI"
+msgstr ""
+
+#: id:34005
+msgid "Flac"
+msgstr ""
+
+#: id:34100
+msgid "Speaker Configuration"
+msgstr "Configuración de parlantes"
+
+#: id:34101
+msgid "2.0"
+msgstr "2.0"
+
+#: id:34102
+msgid "2.1"
+msgstr "2.1"
+
+#: id:34103
+msgid "3.0"
+msgstr "3.0"
+
+#: id:34104
+msgid "3.1"
+msgstr "3.1"
+
+#: id:34105
+msgid "4.0"
+msgstr "4.0"
+
+#: id:34106
+msgid "4.1"
+msgstr "4.1"
+
+#: id:34107
+msgid "5.0"
+msgstr "5.0"
+
+#: id:34108
+msgid "5.1"
+msgstr "5.1"
+
+#: id:34109
+msgid "7.0"
+msgstr "7.0"
+
+#: id:34110
+msgid "7.1"
+msgstr "7.1"
+
+#: id:34201
+msgid "Can't find a next item to play"
+msgstr "No se encuentra el próximo item"
+
+#: id:34202
+msgid "Can't find a previous item to play"
+msgstr "No se encuentra el item anterior"
+
+#: id:34300
+msgid "Failed to start zeroconf"
+msgstr "Fallo al iniciar Zeroconf"
+
+#: id:34301
+msgid "Is Apple's Bonjour Service installed? See log for more info."
+msgstr "Está instalado el servicio Bonjour de Apple? vea log para mas info."
+
+#: id:34400
+msgid "Video Rendering"
+msgstr "Renderizado de video"
+
+#: id:34401
+msgid "Failed to init video filters/scalers, falling back to bilinear scaling"
+msgstr "Fallo al iniciar filtros/escaladores de video, utilizando escalado bilineal"
+
+#: id:34402
+msgid "Failed to initialize audio device"
+msgstr "Fallo al iniciar dispositivo de sonido"
+
+#: id:34403
+msgid "Check your audiosettings"
+msgstr "Verifique su configuracion de sonido"
+
+#: id:34404
+msgid "Use gestures for navigation:"
+msgstr ""
+
+#: id:34405
+msgid "1 finger swipe left,right,up,down for cursors"
+msgstr ""
+
+#: id:34406
+msgid "2 finger swipe left for backspace"
+msgstr ""
+
+#: id:34407
+msgid "1 finger single tap for enter"
+msgstr ""
+
+#: id:34408
+msgid "2 finger single tap for contextmenu"
+msgstr ""
+
+#: id:35000
+msgid "Peripherals"
+msgstr "Periféricos"
+
+#: id:35001
+msgid "Generic HID device"
+msgstr "Dispositivo HID genérico"
+
+#: id:35002
+msgid "Generic network adapter"
+msgstr "Adaptador de red genérico"
+
+#: id:35003
+msgid "Generic disk"
+msgstr "Disco genérico"
+
+#: id:35004
+msgid "There are no settings available\nfor this peripheral."
+msgstr "No hay configuración disponible\npara este periférico."
+
+#: id:35005
+msgid "New device configured"
+msgstr "Nuevo dispositivo configurado"
+
+#: id:35006
+msgid "Device removed"
+msgstr "Dispositivo removido"
+
+#: id:35007
+msgid "Keymap to use for this device"
+msgstr "Keymap para este dispositivo"
+
+#: id:35008
+msgid "Keymap enabled"
+msgstr "Keymap activado"
+
+#: id:35009
+msgid "Do not use the custom keymap for this device"
+msgstr ""
+
+#: id:35500
+msgid "Location"
+msgstr "Ubicación"
+
+#: id:35501
+msgid "Class"
+msgstr "Clase"
+
+#: id:35502
+msgctxt "Auto context with id 35502"
+msgid "Name"
+msgstr "Nombre"
+
+#: id:35503
+msgid "Vendor"
+msgstr "Fabricante"
+
+#: id:35504
+msgid "Product ID"
+msgstr "ID de producto"
+
+#: id:36000
+msgid "Pulse-Eight CEC adapter"
+msgstr "Adaptador Pulse-Eight CEC"
+
+#: id:36001
+msgid "Pulse-Eight Nyxboard"
+msgstr "Pulse-Eight Nyxboard"
+
+#: id:36002
+msgid "Switch to keyboard side command"
+msgstr "Switch to keyboard side command"
+
+#: id:36003
+msgid "Switch to remote side command"
+msgstr "Switch to remote side command"
+
+#: id:36004
+msgid "Press \"user\" button command"
+msgstr "Press \"user\" button command"
+
+#: id:36005
+msgid "Enable switch side commands"
+msgstr "Enable switch side commands"
+
+#: id:36006
+msgid "Could not open the adapter"
+msgstr "No se pudo acceder al adaptador"
+
+#: id:36007
+msgid "Devices to power on when starting XBMC"
+msgstr "Encender TV al iniciar XBMC"
+
+#: id:36008
+msgid "Devices to power off when stopping XBMC"
+msgstr "Apagar dispositivos al detener XBMC"
+
+#: id:36009
+msgid "Put devices in standby mode when activating screensaver"
+msgstr "Poner dispositivos en standby cuando se active el refrescapantallas"
+
+#: id:36011
+msgid "Could not detect the CEC port. Set it up manually."
+msgstr "No se pudo detectar puerto CEC. Configurelo manualmente."
+
+#: id:36012
+msgid "Could not initialise the CEC adapter. Check your settings."
+msgstr "No se pudo detectar adaptador CEC."
+
+#: id:36013
+msgid "Unsupported libCEC interface version. %d is greater than the version XBMC supports (%d)"
+msgstr "Versión de interface libcec no soportada. %d es mayor que la versión soportada por XBMC (%d)"
+
+#: id:36014
+msgid "Put this PC in standby mode when the TV is switched off"
+msgstr "Poner esta PC en standby cuando se apage la TV"
+
+#: id:36015
+msgid "HDMI port number"
+msgstr "puerto HDMI"
+
+#: id:36016
+msgctxt "Auto context with id 36016"
+msgid "Connected"
+msgstr "Connectado"
+
+#: id:36017
+msgid "Adapter found, but libCEC is not available"
+msgstr "Adaptador encontrado, pero libcec no está disponible"
+
+#: id:36018
+msgid "Use the TV's language setting"
+msgstr "Usar configuración de idioma de la TV"
+
+#: id:36019
+msgid "Connected to HDMI device"
+msgstr ""
+
+#: id:36020
+msgid "Make XBMC the active source when starting"
+msgstr ""
+
+#: id:36021
+msgid "Physical address (overrules HDMI port)"
+msgstr ""
+
+#: id:36022
+msgid "COM port (leave empty unless needed)"
+msgstr ""
+
+#: id:36023
+msgid "Configuration updated"
+msgstr ""
+
+#: id:36024
+msgid "Failed to set the new configuration. Please check your settings."
+msgstr ""
+
+#: id:36025
+msgid "Send 'inactive source' command when stopping XBMC"
+msgstr ""
+

--- a/language/Spanish/strings.po
+++ b/language/Spanish/strings.po
@@ -1,0 +1,9093 @@
+# Converted from xbmc strings.xml with xbmc-xml2po (by Team-XBMC)
+msgid ""
+msgstr ""
+"Project-Id-Version: xbmc.core-FRODO_GIT3ed1604ad7\n"
+"Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
+"POT-Creation-Date: 2012-04-09 18:00+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE\n"
+"Language: es\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: id:0
+msgctxt "Auto context with id 0"
+msgid "Programs"
+msgstr "Programas"
+
+#: id:1
+msgctxt "Auto context with id 1"
+msgid "Pictures"
+msgstr "Imágenes"
+
+#: id:2
+msgctxt "Auto context with id 2"
+msgid "Music"
+msgstr "Música"
+
+#: id:3
+msgctxt "Auto context with id 3"
+msgid "Videos"
+msgstr "Vídeos"
+
+#: id:4
+msgid "TV-Guide"
+msgstr "Guía de TV"
+
+#: id:5
+msgctxt "Auto context with id 5"
+msgid "Settings"
+msgstr "Ajustes"
+
+#: id:6
+msgid "XBMC SVN"
+msgstr "XBMC SVN"
+
+#: id:7
+msgctxt "Auto context with id 7"
+msgid "File manager"
+msgstr "Archivos"
+
+#: id:8
+msgctxt "Auto context with id 8"
+msgid "Weather"
+msgstr "El Tiempo"
+
+#: id:9
+msgid "xbmc media center"
+msgstr "xbmc media center"
+
+#: id:11
+msgid "Monday"
+msgstr "Lunes"
+
+#: id:12
+msgid "Tuesday"
+msgstr "Martes"
+
+#: id:13
+msgid "Wednesday"
+msgstr "Miércoles"
+
+#: id:14
+msgid "Thursday"
+msgstr "Jueves"
+
+#: id:15
+msgid "Friday"
+msgstr "Viernes"
+
+#: id:16
+msgid "Saturday"
+msgstr "Sábado"
+
+#: id:17
+msgid "Sunday"
+msgstr "Domingo"
+
+#: id:21
+msgid "January"
+msgstr "Enero"
+
+#: id:22
+msgid "February"
+msgstr "Febrero"
+
+#: id:23
+msgid "March"
+msgstr "Marzo"
+
+#: id:24
+msgid "April"
+msgstr "Abril"
+
+#: id:25
+msgctxt "Auto context with id 25"
+msgid "May"
+msgstr "Mayo"
+
+#: id:26
+msgid "June"
+msgstr "Junio"
+
+#: id:27
+msgid "July"
+msgstr "Julio"
+
+#: id:28
+msgid "August"
+msgstr "Agosto"
+
+#: id:29
+msgid "September"
+msgstr "Septiembre"
+
+#: id:30
+msgid "October"
+msgstr "Octubre"
+
+#: id:31
+msgid "November"
+msgstr "Noviembre"
+
+#: id:32
+msgid "December"
+msgstr "Diciembre"
+
+#: id:41
+msgid "Mon"
+msgstr "Lun"
+
+#: id:42
+msgid "Tue"
+msgstr "Mar"
+
+#: id:43
+msgid "Wed"
+msgstr "Mie"
+
+#: id:44
+msgid "Thu"
+msgstr "Jue"
+
+#: id:45
+msgid "Fri"
+msgstr "Vie"
+
+#: id:46
+msgid "Sat"
+msgstr "Sab"
+
+#: id:47
+msgctxt "Auto context with id 47"
+msgid "Sun"
+msgstr "Dom"
+
+#: id:51
+msgid "Jan"
+msgstr "Ene"
+
+#: id:52
+msgid "Feb"
+msgstr "Feb"
+
+#: id:53
+msgid "Mar"
+msgstr "Mar"
+
+#: id:54
+msgid "Apr"
+msgstr "Abr"
+
+#: id:55
+msgctxt "Auto context with id 55"
+msgid "May"
+msgstr "May"
+
+#: id:56
+msgid "Jun"
+msgstr "Jun"
+
+#: id:57
+msgid "Jul"
+msgstr "Jul"
+
+#: id:58
+msgid "Aug"
+msgstr "Ago"
+
+#: id:59
+msgid "Sep"
+msgstr "Sep"
+
+#: id:60
+msgid "Oct"
+msgstr "Oct"
+
+#: id:61
+msgid "Nov"
+msgstr "Nov"
+
+#: id:62
+msgid "Dec"
+msgstr "Dic"
+
+#: id:71
+msgid "N"
+msgstr "N"
+
+#: id:72
+msgid "NNE"
+msgstr "NNE"
+
+#: id:73
+msgid "NE"
+msgstr "NE"
+
+#: id:74
+msgid "ENE"
+msgstr "ENE"
+
+#: id:75
+msgid "E"
+msgstr "E"
+
+#: id:76
+msgid "ESE"
+msgstr "ESE"
+
+#: id:77
+msgid "SE"
+msgstr "SE"
+
+#: id:78
+msgid "SSE"
+msgstr "SSE"
+
+#: id:79
+msgid "S"
+msgstr "S"
+
+#: id:80
+msgid "SSW"
+msgstr "SSO"
+
+#: id:81
+msgid "SW"
+msgstr "SO"
+
+#: id:82
+msgid "WSW"
+msgstr "OSO"
+
+#: id:83
+msgid "W"
+msgstr "O"
+
+#: id:84
+msgid "WNW"
+msgstr "ONO"
+
+#: id:85
+msgid "NW"
+msgstr "NO"
+
+#: id:86
+msgid "NNW"
+msgstr "NNO"
+
+#: id:87
+msgid "VAR"
+msgstr "VAR"
+
+#: id:98
+msgid "View: Auto"
+msgstr "Ver: Auto"
+
+#: id:99
+msgid "View: Auto big"
+msgstr "Ver: Auto grande"
+
+#: id:100
+msgid "View: Icons"
+msgstr "Ver: Iconos"
+
+#: id:101
+msgid "View: List"
+msgstr "Ver: Lista"
+
+#: id:102
+msgctxt "Auto context with id 102"
+msgid "Scan"
+msgstr "Analizar"
+
+#: id:103
+msgctxt "Auto context with id 103"
+msgid "Sort by: Name"
+msgstr "Por: Nombre"
+
+#: id:104
+msgid "Sort by: Date"
+msgstr "Por: Fecha"
+
+#: id:105
+msgid "Sort by: Size"
+msgstr "Por: Tamaño"
+
+#: id:106
+msgid "No"
+msgstr "No"
+
+#: id:107
+msgid "Yes"
+msgstr "Sí"
+
+#: id:108
+msgctxt "Auto context with id 108"
+msgid "Slideshow"
+msgstr "Presentación"
+
+#: id:109
+msgid "Create thumbs"
+msgstr "Crear miniat."
+
+#: id:110
+msgid "Create thumbnails"
+msgstr "Crear miniaturas"
+
+#: id:111
+msgctxt "Auto context with id 111"
+msgid "Shortcuts"
+msgstr "Accesos directos"
+
+#: id:112
+msgid "Paused"
+msgstr "Pausado"
+
+#: id:113
+msgid "Update failed"
+msgstr "Ha fallado la actualización"
+
+#: id:114
+msgid "Installation failed"
+msgstr "Ha fallado la instalación"
+
+#: id:115
+msgid "Copy"
+msgstr "Copiar"
+
+#: id:116
+msgid "Move"
+msgstr "Mover"
+
+#: id:117
+msgid "Delete"
+msgstr "Eliminar"
+
+#: id:118
+msgid "Rename"
+msgstr "Renombrar"
+
+#: id:119
+msgid "New folder"
+msgstr "Nueva carpeta"
+
+#: id:120
+msgid "Confirm file copy"
+msgstr "Confirmar copiar"
+
+#: id:121
+msgid "Confirm file move"
+msgstr "Confirmar mover"
+
+#: id:122
+msgid "Confirm file delete?"
+msgstr "Confirmar eliminar"
+
+#: id:123
+msgid "Copy these files?"
+msgstr "¿Copiar estos archivos?"
+
+#: id:124
+msgid "Move these files?"
+msgstr "¿Mover estos archivos?"
+
+#: id:125
+msgid "Delete these files? - Deleting files cannot be undone!"
+msgstr "¿Eliminar estos archivos? ¡Ojo, no podrá deshacerse!"
+
+#: id:126
+msgid "Status"
+msgstr "Estado"
+
+#: id:127
+msgid "Objects"
+msgstr "Objetos"
+
+#: id:128
+msgctxt "Auto context with id 128"
+msgid "General"
+msgstr "General"
+
+#: id:129
+msgctxt "Auto context with id 129"
+msgid "Slideshow"
+msgstr "Presentación"
+
+#: id:130
+msgctxt "Auto context with id 130"
+msgid "System info"
+msgstr "Info del sistema"
+
+#: id:131
+msgid "Display"
+msgstr "Pantalla"
+
+#: id:132
+msgid "Albums"
+msgstr "Álbumes"
+
+#: id:133
+msgid "Artists"
+msgstr "Intérpretes"
+
+#: id:134
+msgid "Songs"
+msgstr "Canciones"
+
+#: id:135
+msgid "Genres"
+msgstr "Géneros"
+
+#: id:136
+msgid "Playlists"
+msgstr "Listas de reproducción"
+
+#: id:137
+msgid "Search"
+msgstr "Buscar"
+
+#: id:138
+msgid "System Information"
+msgstr "Información del sistema"
+
+#: id:139
+msgid "Temperatures:"
+msgstr "Temperaturas:"
+
+#: id:140
+msgid "CPU:"
+msgstr "CPU:"
+
+#: id:141
+msgid "GPU:"
+msgstr "GPU:"
+
+#: id:142
+msgid "Time:"
+msgstr "Hora:"
+
+#: id:143
+msgid "Current:"
+msgstr "Actual:"
+
+#: id:144
+msgid "Build:"
+msgstr "Compilación:"
+
+#: id:145
+msgid "Network:"
+msgstr "Red:"
+
+#: id:146
+msgid "Type:"
+msgstr "Tipo:"
+
+#: id:147
+msgid "Static"
+msgstr "IP estática"
+
+#: id:148
+msgid "DHCP"
+msgstr "DHCP"
+
+#: id:149
+msgid "MAC address"
+msgstr "MAC"
+
+#: id:150
+msgctxt "Auto context with id 150"
+msgid "IP address"
+msgstr "IP"
+
+#: id:151
+msgid "Link:"
+msgstr "Estado del enlace:"
+
+#: id:152
+msgid "Half duplex"
+msgstr "Half-duplex"
+
+#: id:153
+msgid "Full duplex"
+msgstr "Full-duplex"
+
+#: id:154
+msgctxt "Auto context with id 154"
+msgid "Storage"
+msgstr "Almacenamiento"
+
+#: id:155
+msgid "Drive"
+msgstr "Unidad"
+
+#: id:156
+msgctxt "Auto context with id 156"
+msgid "Free"
+msgstr "Libres"
+
+#: id:157
+msgctxt "Auto context with id 157"
+msgid "Video"
+msgstr "Vídeo"
+
+#: id:158
+msgid "Free memory"
+msgstr "Memoria libre"
+
+#: id:159
+msgid "No link"
+msgstr "Sin enlace"
+
+#: id:160
+msgctxt "Auto context with id 160"
+msgid "Free"
+msgstr "Libres"
+
+#: id:161
+msgid "Unavailable"
+msgstr "No disponible"
+
+#: id:162
+msgid "Tray open"
+msgstr "Bandeja abierta"
+
+#: id:163
+msgid "Reading"
+msgstr "Leyendo"
+
+#: id:164
+msgid "No disc"
+msgstr "Sin disco"
+
+#: id:165
+msgid "Disc present"
+msgstr "Disco presente"
+
+#: id:166
+msgid "Skin"
+msgstr "Skin"
+
+#: id:169
+msgctxt "Auto context with id 169"
+msgid "Resolution"
+msgstr "Resolución"
+
+#: id:170
+msgid "Adjust display refresh rate to match video"
+msgstr "Ajustar la frecuencia de refresco de la pantalla para ajustarse al vídeo"
+
+#: id:172
+msgid "Release date"
+msgstr "Fecha de publicación"
+
+#: id:173
+msgid "Display 4:3 videos as"
+msgstr "Mostrar vídeos 4:3 como"
+
+#: id:175
+msgid "Moods"
+msgstr "Estados de ánimo"
+
+#: id:176
+msgid "Styles"
+msgstr "Estilos"
+
+#: id:179
+msgid "Song"
+msgstr "Canción"
+
+#: id:180
+msgid "Duration"
+msgstr "Duración"
+
+#: id:181
+msgid "Select album"
+msgstr "Seleccionar álbum"
+
+#: id:182
+msgid "Tracks"
+msgstr "Pistas"
+
+#: id:183
+msgid "Review"
+msgstr "Crítica"
+
+#: id:184
+msgid "Refresh"
+msgstr "Actualizar"
+
+#: id:185
+msgid "Searching album"
+msgstr "Buscando álbum"
+
+#: id:186
+msgid "OK"
+msgstr "OK"
+
+#: id:187
+msgid "No albums found!"
+msgstr "¡No se encontraron álbumes!"
+
+#: id:188
+msgid "Select all"
+msgstr "Seleccionar todo"
+
+#: id:189
+msgid "Scanning media info"
+msgstr "Obteniendo información de medios"
+
+#: id:190
+msgid "Save"
+msgstr "Guardar"
+
+#: id:191
+msgid "Shuffle"
+msgstr "Aleatorio"
+
+#: id:192
+msgctxt "Auto context with id 192"
+msgid "Clear"
+msgstr "Limpiar"
+
+#: id:193
+msgctxt "Auto context with id 193"
+msgid "Scan"
+msgstr "Analizar"
+
+#: id:194
+msgid "Searching..."
+msgstr "Buscando..."
+
+#: id:195
+msgid "No info found!"
+msgstr "¡No se encontró información!"
+
+#: id:196
+msgid "Select movie:"
+msgstr "Seleccione película:"
+
+#: id:197
+msgid "Querying %s info"
+msgstr "Consultando %s"
+
+#: id:198
+msgid "Loading movie details"
+msgstr "Cargando detalles de la película"
+
+#: id:199
+msgid "Web interface"
+msgstr "Interfaz Web"
+
+#: id:202
+msgid "Tagline"
+msgstr "Eslogan"
+
+#: id:203
+msgid "Plot outline"
+msgstr "Resumen"
+
+#: id:205
+msgid "Votes"
+msgstr "Votos"
+
+#: id:206
+msgid "Cast"
+msgstr "Reparto"
+
+#: id:207
+msgid "Plot"
+msgstr "Argumento"
+
+#: id:208
+msgctxt "Auto context with id 208"
+msgid "Play"
+msgstr "Reproducir"
+
+#: id:209
+msgid "Next"
+msgstr "Siguiente"
+
+#: id:210
+msgid "Previous"
+msgstr "Anterior"
+
+#: id:213
+msgid "Calibrate user interface..."
+msgstr "Calibrar interfaz de usuario..."
+
+#: id:214
+msgid "Video calibration..."
+msgstr "Calibración de vídeo..."
+
+#: id:215
+msgid "Soften"
+msgstr "Suavizar"
+
+#: id:216
+msgid "Zoom amount"
+msgstr "Cantidad de zoom"
+
+#: id:217
+msgid "Pixel ratio"
+msgstr "Relación de aspecto"
+
+#: id:218
+msgid "DVD drive"
+msgstr "Unidad DVD"
+
+#: id:219
+msgid "Please insert disc"
+msgstr "Por favor, inserte un disco"
+
+#: id:220
+msgid "Remote share"
+msgstr "Recurso compartido remoto"
+
+#: id:221
+msgid "Network is not connected"
+msgstr "La red no está conectada"
+
+#: id:222
+msgid "Cancel"
+msgstr "Cancelar"
+
+#: id:224
+msgid "Speed"
+msgstr "Velocidad"
+
+#: id:225
+msgid "Vertical Shift"
+msgstr "Desplazamiento vertical"
+
+#: id:226
+msgid "Test patterns..."
+msgstr "Probar patrones..."
+
+#: id:227
+msgid "Lookup audio CD track names from freedb.org"
+msgstr "Consultar CDs de audio en Internet"
+
+#: id:228
+msgid "Shuffle playlist on load"
+msgstr "Lista de reproducción aleatoria al cargar"
+
+#: id:229
+msgid "HDD spindown time"
+msgstr "Parar el disco duro tras"
+
+#: id:230
+msgid "Video filters"
+msgstr "Filtros de vídeo"
+
+#: id:231
+msgctxt "Auto context with id 231"
+msgid "None"
+msgstr "Ninguno"
+
+#: id:232
+msgid "Point"
+msgstr "Punto"
+
+#: id:233
+msgid "Linear"
+msgstr "Lineal"
+
+#: id:234
+msgid "Anisotropic"
+msgstr "Anisotrópico"
+
+#: id:235
+msgid "Quincunx"
+msgstr "Quincunx"
+
+#: id:236
+msgid "Gaussian cubic"
+msgstr "Cúbico gaussiano"
+
+#: id:237
+msgid "Minification"
+msgstr "Minimificación"
+
+#: id:238
+msgid "Magnification"
+msgstr "Magnificación"
+
+#: id:239
+msgid "Clear playlist on finish"
+msgstr "Borrar lista de reproducción al finalizar"
+
+#: id:240
+msgid "Display Mode"
+msgstr "Modo de visualización"
+
+#: id:241
+msgid "Full Screen #%d"
+msgstr "Pantalla completa #%d"
+
+#: id:242
+msgid "Windowed"
+msgstr "Ventana"
+
+#: id:243
+msgid "Refresh Rate"
+msgstr "Frecuencia de actualización"
+
+#: id:244
+msgid "Full screen"
+msgstr "Pantalla completa"
+
+#: id:245
+msgid "Sizing: (%i,%i)->(%i,%i) (Zoom x%2.2f) AR:%2.2f:1 (Pixels: %2.2f:1) (VShift: %2.2f)"
+msgstr "Ajustando tamaño: (%i,%i)->(%i,%i) (Zoom x%2.2f) AR:%2.2f:1 (Píxeles: %2.2f:1) (VShift: %2.2f)"
+
+#: id:247
+msgctxt "Auto context with id 247"
+msgid "Scripts"
+msgstr "Scripts"
+
+#: id:248
+msgctxt "Auto context with id 248"
+msgid "Language"
+msgstr "Idioma"
+
+#: id:249
+msgctxt "Auto context with id 249"
+msgid "Music"
+msgstr "Música"
+
+#: id:250
+msgctxt "Auto context with id 250"
+msgid "Visualization"
+msgstr "Visualización"
+
+#: id:251
+msgid "Select destination directory"
+msgstr "Seleccione directorio de destino"
+
+#: id:252
+msgid "Output stereo to all speakers"
+msgstr "Salida estéreo a todos los altavoces"
+
+#: id:253
+msgid "Number of channels"
+msgstr "Número de canales"
+
+#: id:254
+msgid "- DTS capable receiver"
+msgstr "- Decodificador compatible DTS"
+
+#: id:255
+msgid "CDDB"
+msgstr "CDDB"
+
+#: id:256
+msgid "Fetching CD information"
+msgstr "Consultando información del CD"
+
+#: id:257
+msgid "Error"
+msgstr "Error"
+
+#: id:258
+msgid "Enable tag reading"
+msgstr "Habilitar lectura de etiquetas"
+
+#: id:259
+msgid "Opening"
+msgstr "Abriendo"
+
+#: id:260
+msgid "Shoutcast"
+msgstr "Shoutcast"
+
+#: id:261
+msgid "Waiting for start..."
+msgstr "Esperando para empezar..."
+
+#: id:262
+msgid "Scripts output"
+msgstr "Salida de Scripts"
+
+#: id:263
+msgid "Allow control of XBMC via HTTP"
+msgstr "Permitir el control de XBMC por HTTP"
+
+#: id:264
+msgid "Record"
+msgstr "Grabar"
+
+#: id:265
+msgid "Stop Rec."
+msgstr "Detener grabación"
+
+#: id:266
+msgid "Sort by: Track"
+msgstr "Ordenar por: Pista"
+
+#: id:267
+msgid "Sort by: Time"
+msgstr "Ordenar por: Duración"
+
+#: id:268
+msgid "Sort by: Title"
+msgstr "Ordenar por: Título"
+
+#: id:269
+msgid "Sort by: Artist"
+msgstr "Ordenar por: Intérprete"
+
+#: id:270
+msgid "Sort by: Album"
+msgstr "Ordenar por: Álbum"
+
+#: id:271
+msgid "Top 100"
+msgstr "Top 100"
+
+#: id:272
+msgid "Top-Left overscan compensation"
+msgstr "Compensación de overscan en esquina superior izquierda"
+
+#: id:273
+msgid "Bottom-Right overscan compensation"
+msgstr "Compensación de overscan en esquina inferior derecha"
+
+#: id:274
+msgid "Subtitle positioning"
+msgstr "Posición de los subtítulos"
+
+#: id:275
+msgid "Pixel ratio adjustment"
+msgstr "Ajuste de la proporción del pixel"
+
+#: id:276
+msgid "Adjust the arrow to change the amount of overscan"
+msgstr "Mueva la flecha para variar la cantidad de imagen perdida por los lados"
+
+#: id:277
+msgid "Adjust the bar to change the subtitles position"
+msgstr "Modifique la barra para variar la posición de los subtítulos"
+
+#: id:278
+msgid "Adjust the rectangle so it is perfectly square"
+msgstr "Modifique el rectángulo hasta que sea un cuadrado perfecto"
+
+#: id:279
+msgid "Unable to load settings"
+msgstr "No se puede cargar la configuración"
+
+#: id:280
+msgid "Using default settings"
+msgstr "Usando la configuración por defecto"
+
+#: id:281
+msgid "Please check the XML files"
+msgstr "Por favor, compruebe los archivos .xml"
+
+#: id:282
+msgid "Found %i items"
+msgstr "Encontrados %i elementos"
+
+#: id:283
+msgid "Search results"
+msgstr "Resultados de la búsqueda"
+
+#: id:284
+msgid "No results found"
+msgstr "No se encontraron resultados"
+
+#: id:287
+msgctxt "Auto context with id 287"
+msgid "Subtitles"
+msgstr "Subtítulos"
+
+#: id:288
+msgctxt "Auto context with id 288"
+msgid "Font"
+msgstr "Fuente"
+
+#: id:289
+msgctxt "Auto context with id 289"
+msgid "- Size"
+msgstr "- Tamaño"
+
+#: id:290
+msgid "Dynamic range compression"
+msgstr "Compresión de rango dinámico"
+
+#: id:291
+msgctxt "Auto context with id 291"
+msgid "Video"
+msgstr "Vídeo"
+
+#: id:292
+msgctxt "Auto context with id 292"
+msgid "Audio"
+msgstr "Sonido"
+
+#: id:293
+msgid "Browse for subtitles"
+msgstr "Buscar subtítulos"
+
+#: id:294
+msgid "Create bookmark"
+msgstr "Crear marcador"
+
+#: id:296
+msgid "Clear bookmarks"
+msgstr "Borrar marcadores"
+
+#: id:297
+msgid "Audio offset"
+msgstr "Retardo de sonido"
+
+#: id:298
+msgid "Bookmarks"
+msgstr "Marcadores"
+
+#: id:299
+msgid "- AAC capable receiver"
+msgstr "- Decodificador compatible AAC"
+
+#: id:300
+msgid "- MP1 capable receiver"
+msgstr "- Decodificador compatible MP1"
+
+#: id:301
+msgid "- MP2 capable receiver"
+msgstr "- Decodificador compatible MP2"
+
+#: id:302
+msgid "- MP3 capable receiver"
+msgstr "- Decodificador compatible MP3"
+
+#: id:303
+msgid "Delay"
+msgstr "Retardo"
+
+#: id:304
+msgctxt "Auto context with id 304"
+msgid "Language"
+msgstr "Idioma"
+
+#: id:305
+msgctxt "Auto context with id 305"
+msgid "Enabled"
+msgstr "Activado"
+
+#: id:306
+msgid "Non-interleaved"
+msgstr "No-Interpolado"
+
+#: id:312
+msgid "(0=auto)"
+msgstr "(0=auto)"
+
+#: id:313
+msgid "Cleaning database"
+msgstr "Limpieza de la base de datos"
+
+#: id:314
+msgid "Preparing..."
+msgstr "Preparando..."
+
+#: id:315
+msgid "Database error"
+msgstr "Error en la base de datos"
+
+#: id:316
+msgid "Searching songs..."
+msgstr "Buscando canciones..."
+
+#: id:317
+msgid "Cleaned database successfully"
+msgstr "Limpieza completada con éxito"
+
+#: id:318
+msgid "Cleaning songs..."
+msgstr "Limpiando canciones..."
+
+#: id:319
+msgid "Error cleaning songs"
+msgstr "Error limpiando canciones"
+
+#: id:320
+msgid "Cleaning artists..."
+msgstr "Limpiando intérpretes..."
+
+#: id:321
+msgid "Error cleaning artists"
+msgstr "Error limpiando intérpretes"
+
+#: id:322
+msgid "Cleaning genres..."
+msgstr "Limpiando géneros..."
+
+#: id:323
+msgid "Error cleaning genres"
+msgstr "Error limpiando géneros"
+
+#: id:324
+msgid "Cleaning paths..."
+msgstr "Limpiando rutas..."
+
+#: id:325
+msgid "Error cleaning paths"
+msgstr "Error limpiando rutas"
+
+#: id:326
+msgid "Cleaning albums..."
+msgstr "Limpiando álbumes..."
+
+#: id:327
+msgid "Error cleaning albums"
+msgstr "Error limpiando álbumes"
+
+#: id:328
+msgid "Writing changes..."
+msgstr "Escribiendo cambios..."
+
+#: id:329
+msgid "Error writing changes"
+msgstr "Error escribiendo cambios"
+
+#: id:330
+msgid "This may take some time..."
+msgstr "Esto puede llevar algún tiempo..."
+
+#: id:331
+msgid "Compressing database..."
+msgstr "Comprimiendo la base de datos..."
+
+#: id:332
+msgid "Error compressing database"
+msgstr "Error comprimiendo la base de datos"
+
+#: id:333
+msgid "Do you want to clean the library?"
+msgstr "¿Quieres limpiar la bibloteca?"
+
+#: id:334
+msgid "Clean library..."
+msgstr "Limpiar la biblioteca..."
+
+#: id:335
+msgid "Start"
+msgstr "Inicio"
+
+#: id:336
+msgid "Framerate conversion"
+msgstr "Conversión de imágenes por segundo"
+
+#: id:337
+msgctxt "Auto context with id 337"
+msgid "Audio output"
+msgstr "Salida de audio"
+
+#: id:338
+msgid "Analog"
+msgstr "Analógica"
+
+#: id:339
+msgid "Optical/Coax"
+msgstr "Óptica/Coaxial"
+
+#: id:340
+msgid "Various artists"
+msgstr "Varios intérpretes"
+
+#: id:341
+msgid "Play disc"
+msgstr "Reproducir disco"
+
+#: id:342
+msgctxt "Auto context with id 342"
+msgid "Movies"
+msgstr "Películas"
+
+#: id:343
+msgid "Adjust framerate"
+msgstr "Ajustar imágenes/seg"
+
+#: id:344
+msgid "Actors"
+msgstr "Actores"
+
+#: id:345
+msgctxt "Auto context with id 345"
+msgid "Year"
+msgstr "Año"
+
+#: id:346
+msgid "Boost volume level on downmix"
+msgstr "Aumentar el volumen al hacer un downmix"
+
+#: id:350
+msgctxt "Auto context with id 350"
+msgid "Programs"
+msgstr "Programas"
+
+#: id:351
+msgctxt "Auto context with id 351"
+msgid "Off"
+msgstr "Apagado"
+
+#: id:352
+msgid "Dim"
+msgstr "Atenuar"
+
+#: id:353
+msgid "Black"
+msgstr "Negro"
+
+#: id:354
+msgid "Matrix trails"
+msgstr "Tipo Matrix"
+
+#: id:355
+msgid "Screensaver time"
+msgstr "Activar salvapantallas tras"
+
+#: id:356
+msgid "Screensaver mode"
+msgstr "Modo del salvapantallas"
+
+#: id:357
+msgid "Shutdown function timer"
+msgstr "Apagar el equipo tras"
+
+#: id:358
+msgid "All albums"
+msgstr "Todos los álbumes"
+
+#: id:359
+msgid "Recently added albums"
+msgstr "Álbumes recientes"
+
+#: id:360
+msgctxt "Auto context with id 360"
+msgid "Screensaver"
+msgstr "Salvapantallas"
+
+#: id:361
+msgid "R. Slideshow"
+msgstr "Presentación R."
+
+#: id:362
+msgid "Screensaver dim level"
+msgstr "Nivel de atenuación"
+
+#: id:363
+msgid "Sort by: File"
+msgstr "Ordenar por: Archivo"
+
+#: id:364
+msgid "- Dolby Digital (AC3) capable receiver"
+msgstr "- Decodificador compatible AC3"
+
+#: id:365
+msgctxt "Auto context with id 365"
+msgid "Sort by: Name"
+msgstr "Ordenar por: Nombre"
+
+#: id:366
+msgid "Sort by: Year"
+msgstr "Ordenar por: Año"
+
+#: id:367
+msgid "Sort by: Rating"
+msgstr "Ordenar por: Calificación"
+
+#: id:368
+msgid "IMDb"
+msgstr "IMDb"
+
+#: id:369
+msgctxt "Auto context with id 369"
+msgid "Title"
+msgstr "Título"
+
+#: id:370
+msgid "Thunderstorms"
+msgstr "Tormenta"
+
+#: id:371
+msgid "Partly"
+msgstr "En parte"
+
+#: id:372
+msgid "Mostly"
+msgstr "Sobre todo"
+
+#: id:373
+msgid "Sunny"
+msgstr "Soleado"
+
+#: id:374
+msgid "Cloudy"
+msgstr "Nuboso"
+
+#: id:375
+msgid "Snow"
+msgstr "Nieve"
+
+#: id:376
+msgid "Rain"
+msgstr "Lluvia"
+
+#: id:377
+msgid "Light"
+msgstr "Débil"
+
+#: id:378
+msgid "AM"
+msgstr "AM"
+
+#: id:379
+msgid "PM"
+msgstr "PM"
+
+#: id:380
+msgid "Showers"
+msgstr "Chubascos"
+
+#: id:381
+msgid "Few"
+msgstr "Un poco"
+
+#: id:382
+msgid "Scattered"
+msgstr "Aislados"
+
+#: id:383
+msgctxt "Auto context with id 383"
+msgid "Wind"
+msgstr "Viento"
+
+#: id:384
+msgid "Strong"
+msgstr "Fuerte"
+
+#: id:385
+msgid "Fair"
+msgstr "Bueno"
+
+#: id:386
+msgctxt "Auto context with id 386"
+msgid "Clear"
+msgstr "Despejado"
+
+#: id:387
+msgid "Clouds"
+msgstr "Nuboso"
+
+#: id:388
+msgid "Early"
+msgstr "Temprano"
+
+#: id:389
+msgid "Shower"
+msgstr "Chubascos"
+
+#: id:390
+msgid "Flurries"
+msgstr "Ráfagas de aire"
+
+#: id:391
+msgctxt "Auto context with id 391"
+msgid "Low"
+msgstr "Bajo"
+
+#: id:392
+msgctxt "Auto context with id 392"
+msgid "Medium"
+msgstr "Medio"
+
+#: id:393
+msgctxt "Auto context with id 393"
+msgid "High"
+msgstr "Alto"
+
+#: id:394
+msgid "Fog"
+msgstr "Niebla"
+
+#: id:395
+msgid "Haze"
+msgstr "Bruma"
+
+#: id:396
+msgid "Select location"
+msgstr "Seleccione un lugar"
+
+#: id:397
+msgid "Refresh time"
+msgstr "Actualizar cada"
+
+#: id:398
+msgid "Temperature units"
+msgstr "Temperatura en"
+
+#: id:399
+msgid "Speed units"
+msgstr "Velocidad en"
+
+#: id:400
+msgctxt "Auto context with id 400"
+msgid "Weather"
+msgstr "El Tiempo"
+
+#: id:401
+msgid "Temp"
+msgstr "Temperatura"
+
+#: id:402
+msgid "Feels like"
+msgstr "Sen. térmica"
+
+#: id:403
+msgid "UV index"
+msgstr "Índice UV"
+
+#: id:404
+msgctxt "Auto context with id 404"
+msgid "Wind"
+msgstr "Viento"
+
+#: id:405
+msgid "Dew point"
+msgstr "Punto de rocío"
+
+#: id:406
+msgid "Humidity"
+msgstr "Humedad"
+
+#: id:409
+msgid "Defaults"
+msgstr "Por defecto"
+
+#: id:410
+msgid "Accessing weather service"
+msgstr "Accediendo a El Tiempo"
+
+#: id:411
+msgid "Getting weather for:"
+msgstr "Obteniendo el tiempo para:"
+
+#: id:412
+msgid "Unable to get weather data"
+msgstr "No se pueden obtener datos meteorológicos"
+
+#: id:413
+msgid "Manual"
+msgstr "Manual"
+
+#: id:414
+msgid "No review for this album"
+msgstr "No hay crítica para este álbum"
+
+#: id:415
+msgid "Downloading thumbnail..."
+msgstr "Descargando miniatura..."
+
+#: id:416
+msgid "Not available"
+msgstr "No disponible"
+
+#: id:417
+msgid "View: Big icons"
+msgstr "Ver: Iconos grandes"
+
+#: id:418
+msgctxt "Auto context with id 418"
+msgid "Low"
+msgstr "Bajo"
+
+#: id:419
+msgctxt "Auto context with id 419"
+msgid "High"
+msgstr "Alto"
+
+#: id:420
+msgid "HDMI"
+msgstr "HDMI"
+
+#: id:422
+msgid "Delete album info"
+msgstr "Eliminar información del álbum"
+
+#: id:423
+msgid "Delete CD information"
+msgstr "Eliminar información CDDB"
+
+#: id:424
+msgid "Select"
+msgstr "Seleccionar"
+
+#: id:425
+msgid "No album information found"
+msgstr "No se encontró información del álbum."
+
+#: id:426
+msgid "No CD information found"
+msgstr "No se encontró información CDDB."
+
+#: id:427
+msgid "Disc"
+msgstr "Disco"
+
+#: id:428
+msgid "Insert correct CD/DVD"
+msgstr "Inserte el CD/DVD correcto"
+
+#: id:429
+msgid "Please insert the following disc:"
+msgstr "Por favor, inserte el siguiente disco"
+
+#: id:430
+msgid "Sort by: DVD#"
+msgstr "Por: DVD#"
+
+#: id:431
+msgid "No cache"
+msgstr "Sin caché"
+
+#: id:432
+msgid "Remove movie from library"
+msgstr "Eliminar película de la base de datos"
+
+#: id:433
+msgid "Really remove '%s'?"
+msgstr "¿Eliminar realmente '%s'?"
+
+#: id:434
+msgid "From %s at %i %s"
+msgstr "De %s a %i %s"
+
+#: id:437
+msgid "Removable disk"
+msgstr "Disco extraíble"
+
+#: id:438
+msgid "Opening file"
+msgstr "Abriendo archivo"
+
+#: id:439
+msgid "Cache"
+msgstr "Caché"
+
+#: id:440
+msgid "Harddisk"
+msgstr "Disco duro"
+
+#: id:441
+msgid "UDF"
+msgstr "UDF"
+
+#: id:442
+msgid "Local network"
+msgstr "Red local"
+
+#: id:443
+msgid "Internet"
+msgstr "Internet"
+
+#: id:444
+msgctxt "Auto context with id 444"
+msgid "Video"
+msgstr "Vídeo"
+
+#: id:445
+msgctxt "Auto context with id 445"
+msgid "Audio"
+msgstr "Sonido"
+
+#: id:446
+msgctxt "Auto context with id 446"
+msgid "DVD"
+msgstr "DVD"
+
+#: id:447
+msgid "Autorun media"
+msgstr "Reproducción automática"
+
+#: id:448
+msgid "LCD"
+msgstr "LCD"
+
+#: id:449
+msgctxt "Auto context with id 449"
+msgid "Enabled"
+msgstr "Activado"
+
+#: id:450
+msgid "Columns"
+msgstr "Columnas"
+
+#: id:451
+msgid "Row 1 address"
+msgstr "Posición línea 1"
+
+#: id:452
+msgid "Row 2 address"
+msgstr "Posición línea 2"
+
+#: id:453
+msgid "Row 3 address"
+msgstr "Posición línea 3"
+
+#: id:454
+msgid "Row 4 address"
+msgstr "Posición línea 4"
+
+#: id:455
+msgid "Rows"
+msgstr "Líneas"
+
+#: id:456
+msgid "Mode"
+msgstr "Modo"
+
+#: id:457
+msgid "Switch view"
+msgstr "Cambiar vista"
+
+#: id:459
+msgid "Subs"
+msgstr "Subtítulos"
+
+#: id:460
+msgid "Audio stream"
+msgstr "Canal de sonido"
+
+#: id:461
+msgid "[active]"
+msgstr "[activo]"
+
+#: id:462
+msgid "Subtitle"
+msgstr "Subtítulos"
+
+#: id:463
+msgid "Backlight"
+msgstr "Retroiluminación"
+
+#: id:464
+msgid "Brightness"
+msgstr "Brillo"
+
+#: id:465
+msgid "Contrast"
+msgstr "Contraste"
+
+#: id:466
+msgid "Gamma"
+msgstr "Gamma"
+
+#: id:467
+msgctxt "Auto context with id 467"
+msgid "Type"
+msgstr "Tipo"
+
+#: id:468
+msgid "Move the bar to change the OSD position"
+msgstr "Mueva la barra para variar la posición del OSD"
+
+#: id:469
+msgid "OSD position"
+msgstr "Posición del OSD"
+
+#: id:470
+msgid "Credits"
+msgstr "Créditos"
+
+#: id:471
+msgid "Modchip"
+msgstr "Modchip"
+
+#: id:474
+msgctxt "Auto context with id 474"
+msgid "Off"
+msgstr "Apagado"
+
+#: id:475
+msgid "Music only"
+msgstr "Sólo música"
+
+#: id:476
+msgctxt "Auto context with id 476"
+msgid "Music & video"
+msgstr "Música y vídeo"
+
+#: id:477
+msgid "Unable to load playlist"
+msgstr "No se puede cargar la lista de reproducción"
+
+#: id:478
+msgid "OSD"
+msgstr "OSD"
+
+#: id:479
+msgid "Skin & language"
+msgstr "Skin e idioma"
+
+#: id:480
+msgid "Appearance"
+msgstr "Apariencia"
+
+#: id:481
+msgid "Audio options"
+msgstr "Opciones de sonido"
+
+#: id:482
+msgid "About XBMC"
+msgstr "Acerca de XBMC"
+
+#: id:485
+msgid "Delete album"
+msgstr "Eliminar álbum"
+
+#: id:486
+msgid "Repeat"
+msgstr "Repetir"
+
+#: id:487
+msgid "Repeat one"
+msgstr "Repetir uno"
+
+#: id:488
+msgid "Repeat folder"
+msgstr "Repetir directorio"
+
+#: id:489
+msgid "Play the next song automatically"
+msgstr "Reproducir automáticamente la siguiente canción"
+
+#: id:491
+msgid "- Use big icons"
+msgstr "- Usar iconos grandes"
+
+#: id:492
+msgid "Resize VobSubs"
+msgstr "Redimensionar subtítulos VOB"
+
+#: id:493
+msgid "Advanced options (Experts Only!)"
+msgstr "Opciones avanzadas (¡Sólo expertos!)"
+
+#: id:494
+msgid "Overall audio headroom"
+msgstr "Margen total de sonido (dB)"
+
+#: id:495
+msgid "Upsample videos to GUI resolution"
+msgstr "Sobremuestrear vídeos a resolución XBMC"
+
+#: id:496
+msgid "Calibration"
+msgstr "Calibración"
+
+#: id:497
+msgid "Show file extensions"
+msgstr "Mostrar las extensiones de archivo"
+
+#: id:498
+msgid "Sort by: Type"
+msgstr "Ordenar por: Tipo"
+
+#: id:499
+msgid "Unable to connect to online lookup service"
+msgstr "No se puede conectar al servicio de búsqueda online"
+
+#: id:500
+msgid "Downloading album information failed"
+msgstr "Error al obtener la información del álbum"
+
+#: id:501
+msgid "Looking for album names..."
+msgstr "Buscando nombres de los álbumes..."
+
+#: id:502
+msgctxt "Auto context with id 502"
+msgid "Open"
+msgstr "Abierto"
+
+#: id:503
+msgid "Busy"
+msgstr "Ocupado"
+
+#: id:504
+msgid "Empty"
+msgstr "Vacío"
+
+#: id:505
+msgid "Loading media info from files..."
+msgstr "Cargando información de archivos..."
+
+#: id:507
+msgid "Sort by: Usage"
+msgstr "Odenar por: Uso"
+
+#: id:510
+msgid "Enable visualizations"
+msgstr "Habilitar visualizaciones"
+
+#: id:511
+msgid "Enable video mode switching"
+msgstr "Habilitar cambio de modo de vídeo"
+
+#: id:512
+msgid "Startup window"
+msgstr "Pantalla de inicio"
+
+#: id:513
+msgid "Home window"
+msgstr "Pantalla principal"
+
+#: id:514
+msgid "Manual settings"
+msgstr "Ajustes manuales"
+
+#: id:515
+msgid "Genre"
+msgstr "Género"
+
+#: id:517
+msgid "Recently played albums"
+msgstr "Álbumes reproducidos recientemente"
+
+#: id:518
+msgid "Launch"
+msgstr "Lanzar"
+
+#: id:519
+msgid "Launch in..."
+msgstr "Lanzar en.."
+
+#: id:521
+msgid "Compilations"
+msgstr "Compilaciones"
+
+#: id:522
+msgid "Remove source"
+msgstr "Eliminar fuente"
+
+#: id:523
+msgid "Switch media"
+msgstr "Cambiar medio"
+
+#: id:524
+msgid "Select playlist"
+msgstr "Seleccione lista de reproducción"
+
+#: id:525
+msgid "New playlist..."
+msgstr "Nueva lista de reproducción"
+
+#: id:526
+msgid "Add to playlist"
+msgstr "Añadir a lista de reproducción"
+
+#: id:527
+msgid "Manually add to library"
+msgstr "Añadir manualmente a biblioteca"
+
+#: id:528
+msgid "Enter title"
+msgstr "Introduzca título"
+
+#: id:529
+msgid "Error: Duplicate title"
+msgstr "Error: Título duplicado"
+
+#: id:530
+msgid "Select genre"
+msgstr "Seleccione género"
+
+#: id:531
+msgid "New genre"
+msgstr "Nuevo género"
+
+#: id:532
+msgid "Manual addition"
+msgstr "Adición manual"
+
+#: id:533
+msgid "Enter genre"
+msgstr "Introduzca género"
+
+#: id:534
+msgid "View: %s"
+msgstr "Ver: %s"
+
+#: id:535
+msgid "List"
+msgstr "Lista"
+
+#: id:536
+msgid "Icons"
+msgstr "Iconos"
+
+#: id:537
+msgid "Big list"
+msgstr "Lista grande"
+
+#: id:538
+msgid "Big icons"
+msgstr "Iconos grandes"
+
+#: id:539
+msgid "Wide"
+msgstr "Ancho"
+
+#: id:540
+msgid "Big wide"
+msgstr "Ancho grande"
+
+#: id:541
+msgid "Album icons"
+msgstr "Iconos de álbum"
+
+#: id:542
+msgid "DVD icons"
+msgstr "Iconos de DVD"
+
+#: id:543
+msgctxt "Auto context with id 543"
+msgid "DVD"
+msgstr "DVD"
+
+#: id:544
+msgctxt "Auto context with id 544"
+msgid "Media info"
+msgstr "Info del medio"
+
+#: id:545
+msgid "Audio output device"
+msgstr "Dispositivo de salida de audio"
+
+#: id:546
+msgid "Passthrough output device"
+msgstr "Dispositivo de salida passthrough"
+
+#: id:547
+msgid "No biography for this artist"
+msgstr "No hay biografía para este artista"
+
+#: id:548
+msgid "Downmix multichannel audio to stereo"
+msgstr "Mezcla de audio multicanal a estéreo"
+
+#: id:550
+msgid "Sort by: %s"
+msgstr "Ordenar por: %s"
+
+#: id:551
+msgctxt "Auto context with id 551"
+msgid "Name"
+msgstr "Nombre"
+
+#: id:552
+msgid "Date"
+msgstr "Fecha"
+
+#: id:553
+msgid "Size"
+msgstr "Tamaño"
+
+#: id:554
+msgid "Track"
+msgstr "Pista"
+
+#: id:555
+msgid "Time"
+msgstr "Hora"
+
+#: id:556
+msgctxt "Auto context with id 556"
+msgid "Title"
+msgstr "Título"
+
+#: id:557
+msgid "Artist"
+msgstr "Artista"
+
+#: id:558
+msgid "Album"
+msgstr "Álbum"
+
+#: id:559
+msgid "Playlist"
+msgstr "Lista de reproducción"
+
+#: id:560
+msgid "ID"
+msgstr "ID"
+
+#: id:561
+msgctxt "Auto context with id 561"
+msgid "File"
+msgstr "Archivo"
+
+#: id:562
+msgctxt "Auto context with id 562"
+msgid "Year"
+msgstr "Año"
+
+#: id:563
+msgid "Rating"
+msgstr "Valoración"
+
+#: id:564
+msgctxt "Auto context with id 564"
+msgid "Type"
+msgstr "Tipo"
+
+#: id:565
+msgid "Usage"
+msgstr "Uso"
+
+#: id:566
+msgid "Album artist"
+msgstr "Álbum artista"
+
+#: id:567
+msgid "Play count"
+msgstr "Contador de reproducción"
+
+#: id:568
+msgid "Last played"
+msgstr "Reproducido por última vez"
+
+#: id:569
+msgctxt "Auto context with id 569"
+msgid "Comment"
+msgstr "Comentario"
+
+#: id:570
+msgid "Date added"
+msgstr "Fecha de inclusión"
+
+#: id:571
+msgctxt "Auto context with id 571"
+msgid "Default"
+msgstr "Por defecto"
+
+#: id:572
+msgid "Studio"
+msgstr "Estudio"
+
+#: id:573
+msgid "Path"
+msgstr "Ruta"
+
+#: id:574
+msgctxt "Auto context with id 574"
+msgid "Country"
+msgstr "País"
+
+#: id:575
+msgid "In progress"
+msgstr "En progreso"
+
+#: id:576
+msgid "Times played"
+msgstr ""
+
+#: id:580
+msgid "Sort direction"
+msgstr "Dirección de ordenación"
+
+#: id:581
+msgid "Sort method"
+msgstr "Método de ordenación"
+
+#: id:582
+msgctxt "Auto context with id 582"
+msgid "View mode"
+msgstr "Modo de vista"
+
+#: id:583
+msgid "Remember views for different folders"
+msgstr "Recordar vistas para distintos directorios"
+
+#: id:584
+msgid "Ascending"
+msgstr "Ascendente"
+
+#: id:585
+msgid "Descending"
+msgstr "Descendente"
+
+#: id:586
+msgid "Edit playlist"
+msgstr "Editar lista de reproducción"
+
+#: id:587
+msgid "Filter"
+msgstr "Filtro"
+
+#: id:588
+msgid "Cancel party mode"
+msgstr "Cancelar modo fiesta"
+
+#: id:589
+msgid "Party mode"
+msgstr "Modo fiesta"
+
+#: id:590
+msgid "Random"
+msgstr "Aleatorio"
+
+#: id:591
+msgctxt "Auto context with id 591"
+msgid "Off"
+msgstr "Off"
+
+#: id:592
+msgid "One"
+msgstr "Uno"
+
+#: id:593
+msgid "All"
+msgstr "Todos"
+
+#: id:594
+msgctxt "Auto context with id 594"
+msgid "Off"
+msgstr "Off"
+
+#: id:595
+msgid "Repeat: Off"
+msgstr "Repetir: Off"
+
+#: id:596
+msgid "Repeat: One"
+msgstr "Repetir: Uno"
+
+#: id:597
+msgid "Repeat: All"
+msgstr "Repetir: Todos"
+
+#: id:600
+msgid "Rip audio CD"
+msgstr "Ripear CD de audio"
+
+#: id:601
+msgctxt "Auto context with id 601"
+msgid "Medium"
+msgstr "Media"
+
+#: id:602
+msgctxt "Auto context with id 602"
+msgid "Standard"
+msgstr "Estándar"
+
+#: id:603
+msgid "Extreme"
+msgstr "Extrema"
+
+#: id:604
+msgid "Constant bitrate"
+msgstr "Bitrate constante (CBR)"
+
+#: id:605
+msgid "Ripping..."
+msgstr "Ripeando..."
+
+#: id:607
+msgid "To:"
+msgstr "A:"
+
+#: id:608
+msgid "Could not rip CD or track"
+msgstr "No se puede ripear CD o Pista"
+
+#: id:609
+msgid "CDDARipPath is not set."
+msgstr "CDDARipPath no está definido."
+
+#: id:610
+msgid "Rip audio track"
+msgstr "Ripear pista de audio"
+
+#: id:611
+msgid "Enter number"
+msgstr "Introducir número"
+
+#: id:612
+msgid "Bits/Sample"
+msgstr "Bits/Muestreo"
+
+#: id:613
+msgid "Sample Frequency"
+msgstr "Frecuencia de muestreo"
+
+#: id:620
+msgid "Audio CDs"
+msgstr "CDs de audio"
+
+#: id:621
+msgid "Encoder"
+msgstr "Codificador"
+
+#: id:622
+msgid "Quality"
+msgstr "Calidad"
+
+#: id:623
+msgid "Bitrate"
+msgstr "Bitrate"
+
+#: id:624
+msgid "Include track number"
+msgstr "Incluir número de pista"
+
+#: id:625
+msgid "All songs of"
+msgstr "Todas las canciones de"
+
+#: id:629
+msgctxt "Auto context with id 629"
+msgid "View mode"
+msgstr "Modo de vista"
+
+#: id:630
+msgctxt "Auto context with id 630"
+msgid "Normal"
+msgstr "Normal"
+
+#: id:631
+msgid "Zoom"
+msgstr "Zoom"
+
+#: id:632
+msgid "Stretch 4:3"
+msgstr "Adaptar a 4:3"
+
+#: id:633
+msgid "Wide Zoom"
+msgstr "Zoom amplio"
+
+#: id:634
+msgid "Stretch 16:9"
+msgstr "Adaptar a 16:9"
+
+#: id:635
+msgid "Original Size"
+msgstr "Tamaño original"
+
+#: id:636
+msgctxt "Auto context with id 636"
+msgid "Custom"
+msgstr "Personalizado"
+
+#: id:637
+msgid "Replay gain"
+msgstr "Replay Gain"
+
+#: id:638
+msgid "Replaygain volume adjustments"
+msgstr "Ajustes de volumen Replay Gain"
+
+#: id:639
+msgid "Use track levels"
+msgstr "Usar volumen de la pista"
+
+#: id:640
+msgid "Use album levels"
+msgstr "Usar volumen del álbum"
+
+#: id:641
+msgid "PreAmp Level - Replay gained files"
+msgstr "Nivel PreAmp - Archivos con Replay Gain"
+
+#: id:642
+msgid "PreAmp Level - Non replay gained files"
+msgstr "Nivel PreAmp - Archivos sin Replay Gain"
+
+#: id:643
+msgid "Avoid clipping on replay gained files"
+msgstr "Evitar distorsión digital en archivos con Replay Gain"
+
+#: id:644
+msgid "Crop black bars"
+msgstr "Eliminar bordes negros"
+
+#: id:645
+msgid "Need to unpack a big file. Continue?"
+msgstr "Es necesario descomprimir un archivos grande. ¿Continuar?"
+
+#: id:646
+msgid "Remove from library"
+msgstr "Eliminar de la base de datos"
+
+#: id:647
+msgid "Export video library"
+msgstr "Exportar la biblioteca de vídeo"
+
+#: id:648
+msgid "Import video library"
+msgstr "Importar la biblioteca de vídeo"
+
+#: id:649
+msgid "Importing"
+msgstr "Importando"
+
+#: id:650
+msgid "Exporting"
+msgstr "Exportando"
+
+#: id:651
+msgid "Browse for library"
+msgstr "Explorar la biblioteca"
+
+#: id:652
+msgid "Years"
+msgstr "Años"
+
+#: id:653
+msgid "Update library"
+msgstr "Actualizar la biblioteca"
+
+#: id:654
+msgid "Show debug info"
+msgstr "Ver información de depuración"
+
+#: id:655
+msgid "Browse for executable"
+msgstr "Buscar ejecutable"
+
+#: id:656
+msgid "Browse for playlist"
+msgstr "Buscar lista de reproducción"
+
+#: id:657
+msgid "Browse for folder"
+msgstr "Buscar directorio"
+
+#: id:658
+msgid "Song information"
+msgstr "Info de la canción"
+
+#: id:659
+msgid "Non-linear stretch"
+msgstr "Estirado no-lineal"
+
+#: id:660
+msgid "Volume amplification"
+msgstr "Amplificación de volumen"
+
+#: id:661
+msgid "Choose export folder"
+msgstr "Escoja el directorio de exportación"
+
+#: id:662
+msgid "This file is no longer available."
+msgstr "Éste archivo ya no está disponible"
+
+#: id:663
+msgid "Would you like to remove it from the library?"
+msgstr "¿Le gustaría eliminarlo de la biblioteca?"
+
+#: id:664
+msgid "Browse for Script"
+msgstr "Búsqueda de script"
+
+#: id:665
+msgid "Compression level"
+msgstr "Nivel de compresión"
+
+#: id:700
+msgid "Cleaning up library"
+msgstr "Limpiar la biblioteca"
+
+#: id:701
+msgid "Removing old songs from the library"
+msgstr "Eliminando canciones antiguas de la biblioteca"
+
+#: id:702
+msgid "This path has been scanned before"
+msgstr "Esta ruta ya ha sido explorada anteriormente"
+
+#: id:705
+msgctxt "Auto context with id 705"
+msgid "Network"
+msgstr "Red"
+
+#: id:706
+msgid "- Server"
+msgstr "- Servidor"
+
+#: id:708
+msgid "Use an HTTP proxy server to access the internet"
+msgstr "Usar un proxy HTTP para acceder a internet"
+
+#: id:711
+msgid "Internet Protocol (IP)"
+msgstr "Protocólo de Internet (IP)"
+
+#: id:712
+msgid "Invalid port specified. Value must be between 1 and 65535."
+msgstr "Puerto especificado no válido. El valor debe estar entre 1 y 65535."
+
+#: id:713
+msgid "HTTP proxy"
+msgstr "Proxy HTTP"
+
+#: id:715
+msgid "- Assignment"
+msgstr "- Asignación"
+
+#: id:716
+msgid "Automatic (DHCP)"
+msgstr "Automática (DHCP)"
+
+#: id:717
+msgid "Manual (Static)"
+msgstr "Manual (Estática)"
+
+#: id:719
+msgid "- IP address"
+msgstr "- Dirección IP"
+
+#: id:720
+msgid "- Netmask"
+msgstr "- Máscara de Subred"
+
+#: id:721
+msgid "- Default gateway"
+msgstr "- Puerta de Enlace"
+
+#: id:722
+msgid "- DNS server"
+msgstr "- Servidor DNS"
+
+#: id:723
+msgid "Save & restart"
+msgstr "Guardar y reiniciar"
+
+#: id:724
+msgid "Invalid address specified. Value must be AAA.BBB.CCC.DDD"
+msgstr "Dirección especificada no válida. El valor debe ser AAA.BBB.CCC.DDD"
+
+#: id:725
+msgid "with numbers between 0 and 255."
+msgstr "con números entre 0 y 255"
+
+#: id:726
+msgid "Changes not saved. Continue without saving?"
+msgstr "Cambios no guardados. ¿Seguir sin guardar?"
+
+#: id:727
+msgid "Web server"
+msgstr "Servidor Web"
+
+#: id:728
+msgctxt "Auto context with id 728"
+msgid "FTP server"
+msgstr "Servidor FTP"
+
+#: id:730
+msgid "- Port"
+msgstr "- Puerto"
+
+#: id:732
+msgid "Save & apply"
+msgstr "Guardar y aplicar"
+
+#: id:733
+msgid "- Password"
+msgstr "- Contraseña"
+
+#: id:734
+msgid "No pass"
+msgstr "Sin contraseña"
+
+#: id:735
+msgid "- Character set"
+msgstr "- Juego de caracteres"
+
+#: id:736
+msgid "- Style"
+msgstr "- Estilo"
+
+#: id:737
+msgid "- Colour"
+msgstr "- Color"
+
+#: id:738
+msgctxt "Auto context with id 738"
+msgid "Normal"
+msgstr "Normal"
+
+#: id:739
+msgid "Bold"
+msgstr "Negrita"
+
+#: id:740
+msgid "Italics"
+msgstr "Cursiva"
+
+#: id:741
+msgid "Bold italics"
+msgstr "Negrita cursiva"
+
+#: id:742
+msgctxt "Auto context with id 742"
+msgid "White"
+msgstr "Blanco"
+
+#: id:743
+msgctxt "Auto context with id 743"
+msgid "Yellow"
+msgstr "Amarillo"
+
+#: id:744
+msgctxt "Auto context with id 744"
+msgid "Files"
+msgstr "Archivos"
+
+#: id:745
+msgid "No scanned information for this view"
+msgstr "No se ha explorado información para esta vista"
+
+#: id:746
+msgid "Please turn off library mode"
+msgstr "Por favor desactive el modo bibloteca"
+
+#: id:747
+msgid "Error loading image"
+msgstr "Error cargando imagen"
+
+#: id:748
+msgid "Edit path"
+msgstr "Editar ruta"
+
+#: id:749
+msgid "Mirror image"
+msgstr "Añadir rec. compartido"
+
+#: id:750
+msgid "Are you sure?"
+msgstr "¿Está seguro?"
+
+#: id:751
+msgid "Removing source"
+msgstr "Eliminando rec. compartido"
+
+#: id:754
+msgid "Add program link"
+msgstr "Añadir enlace a programa"
+
+#: id:755
+msgid "Edit program path"
+msgstr "Editar ruta programa"
+
+#: id:756
+msgid "Edit program name"
+msgstr "Editar nombre programa"
+
+#: id:757
+msgid "Edit path depth"
+msgstr "Editar profundidad ruta"
+
+#: id:759
+msgid "View: Big list"
+msgstr "Ver: Lista grande"
+
+#: id:760
+msgctxt "Auto context with id 760"
+msgid "Yellow"
+msgstr "Amarillo"
+
+#: id:761
+msgctxt "Auto context with id 761"
+msgid "White"
+msgstr "Blanco"
+
+#: id:762
+msgid "Blue"
+msgstr "Azul"
+
+#: id:763
+msgid "Bright green"
+msgstr "Verde claro"
+
+#: id:764
+msgid "Yellow green"
+msgstr "Verde amarillento"
+
+#: id:765
+msgid "Cyan"
+msgstr "Verde azulado"
+
+#: id:766
+msgid "Light grey"
+msgstr "Gris Claro"
+
+#: id:767
+msgid "Grey"
+msgstr "Gris"
+
+#: id:770
+msgid "Error %i: share not available"
+msgstr "Error %i: recurso no disponible"
+
+#: id:772
+msgctxt "Auto context with id 772"
+msgid "Audio output"
+msgstr "Salida de audio"
+
+#: id:773
+msgid "Seeking"
+msgstr "Buscando"
+
+#: id:774
+msgid "Slideshow folder"
+msgstr "Directorio de diapositivas"
+
+#: id:775
+msgid "Network interface"
+msgstr "Interfaz de red"
+
+#: id:776
+msgid "- Wireless network name (ESSID)"
+msgstr "- Nombre de la red inalámbrica (ESSID)"
+
+#: id:777
+msgid "- Wireless password"
+msgstr "- Contraseña de la red inalámbrica"
+
+#: id:778
+msgid "- Wireless security"
+msgstr "- Seguridad de la red inalámbrica"
+
+#: id:779
+msgid "Save and apply network interface settings"
+msgstr "Guardar y aplicar la configuración de interfaz de red"
+
+#: id:780
+msgid "No encryption"
+msgstr "Sin cifrado"
+
+#: id:781
+msgid "WEP"
+msgstr "WEP"
+
+#: id:782
+msgid "WPA"
+msgstr "WPA"
+
+#: id:783
+msgid "WPA2"
+msgstr "WPA2"
+
+#: id:784
+msgid "Applying network interface settings. Please wait."
+msgstr "Aplicando la configuración de interfaz de red. Por favor, espere."
+
+#: id:785
+msgid "Network interface restarted successfully."
+msgstr "La interfaz de red se reinició con éxito."
+
+#: id:786
+msgid "Network interface did not start successfully."
+msgstr "La interfaz de red no se inició con éxito."
+
+#: id:787
+msgid "Interface disabled"
+msgstr "Interfaz deshabilitada"
+
+#: id:788
+msgid "Network interface disabled successfully."
+msgstr "La interfaz de red se deshabilitó con éxito."
+
+#: id:789
+msgid "Wireless network name (ESSID)"
+msgstr "Nombre de la red inalámbrica (ESSID)"
+
+#: id:790
+msgid "Remote control"
+msgstr ""
+
+#: id:791
+msgid "Allow programs on this system to control XBMC"
+msgstr "Permitir que los programas de este equipo controlen XBMC"
+
+#: id:792
+msgctxt "Auto context with id 792"
+msgid "Port"
+msgstr "Puerto"
+
+#: id:793
+msgid "Port range"
+msgstr "Rango de puertos"
+
+#: id:794
+msgid "Allow programs on other systems to control XBMC"
+msgstr "Permitir que los programas de otro equipo controlen XBMC"
+
+#: id:795
+msgid "Initial repeat delay (ms)"
+msgstr "Retraso inicial de repetición (ms)"
+
+#: id:796
+msgid "Continuous repeat delay (ms)"
+msgstr "Retraso continuo de repetición (ms)"
+
+#: id:797
+msgid "Maximum number of clients"
+msgstr "Número máximo de clientes"
+
+#: id:798
+msgid "Internet access"
+msgstr "Acceso a internet"
+
+#: id:850
+msgid "Invalid port number entered"
+msgstr "Numero de puerto introducido inválido"
+
+#: id:851
+msgid "Valid port range is 1-65535"
+msgstr "El rango válido de puertos es 1-65535"
+
+#: id:852
+msgid "Valid port range is 1024-65535"
+msgstr "El rango válido de puertos es 1024-65535"
+
+#: id:998
+msgid "Add Music..."
+msgstr ""
+
+#: id:999
+msgid "Add Videos..."
+msgstr ""
+
+#: id:1000
+msgid "- Preview"
+msgstr "- Vista previa"
+
+#: id:1001
+msgid "Unable to connect"
+msgstr "Imposible conectar"
+
+#: id:1002
+msgid "XBMC was unable to connect to the network location."
+msgstr "XBMC ha sido incapaz de conectar a la dirección de red."
+
+#: id:1003
+msgid "This could be due to the network not being connected."
+msgstr "Podría ser debido a que la red no esté conectada."
+
+#: id:1004
+msgid "Would you like to add it anyway?"
+msgstr "¿Desea añadirla de todos modos?"
+
+#: id:1006
+msgctxt "Auto context with id 1006"
+msgid "IP address"
+msgstr "Dirección IP"
+
+#: id:1007
+msgid "Add network location"
+msgstr "Añadir dirección de red"
+
+#: id:1008
+msgid "Protocol"
+msgstr "Protocolo"
+
+#: id:1009
+msgid "Server address"
+msgstr "Dirección del servidor"
+
+#: id:1010
+msgid "Server name"
+msgstr "Nombre del servidor"
+
+#: id:1011
+msgid "Remote path"
+msgstr "Ruta remota"
+
+#: id:1012
+msgid "Shared folder"
+msgstr "Directorio compartido"
+
+#: id:1013
+msgctxt "Auto context with id 1013"
+msgid "Port"
+msgstr "Puerto"
+
+#: id:1014
+msgctxt "Auto context with id 1014"
+msgid "Username"
+msgstr "Usuario"
+
+#: id:1015
+msgid "Browse for network server"
+msgstr "Buscar servidor de red"
+
+#: id:1016
+msgid "Enter the network address of the server"
+msgstr "Introduzca la dirección de red del servidor"
+
+#: id:1017
+msgid "Enter the path on the server"
+msgstr "Introduzca la ruta en el servidor"
+
+#: id:1018
+msgid "Enter the port number"
+msgstr "Introduzca el número de puerto"
+
+#: id:1019
+msgid "Enter the username"
+msgstr "Introduzca el nombre de usuario"
+
+#: id:1020
+msgid "Add %s source"
+msgstr "Añadir fuente %s"
+
+#: id:1021
+msgid "Enter the paths or browse for the media locations."
+msgstr "Introduzca las rutas o busque la ubicación del medio."
+
+#: id:1022
+msgid "Enter a name for this media Source."
+msgstr "Introduzca un nombre para la Fuente."
+
+#: id:1023
+msgid "Browse for new share"
+msgstr "Buscar un nuevo recurso compartido"
+
+#: id:1024
+msgid "Browse"
+msgstr "Buscar"
+
+#: id:1025
+msgid "Could not retrieve directory information."
+msgstr "No se ha podido recuperar información del directorio."
+
+#: id:1026
+msgid "Add source"
+msgstr "Añadir fuente"
+
+#: id:1027
+msgid "Edit source"
+msgstr "Editar fuente"
+
+#: id:1028
+msgid "Edit %s source"
+msgstr "Editar fuente %s"
+
+#: id:1029
+msgid "Enter the new label"
+msgstr "Introduzca la nueva etiqueta"
+
+#: id:1030
+msgid "Browse for image"
+msgstr "Buscar una imagen"
+
+#: id:1031
+msgid "Browse for image folder"
+msgstr "Buscar un directorio de imágenes"
+
+#: id:1032
+msgid "Add network location..."
+msgstr "Añadir sitio de red..."
+
+#: id:1033
+msgid "Browse for file"
+msgstr "Buscar un archivo"
+
+#: id:1034
+msgid "Submenu"
+msgstr "Submenú"
+
+#: id:1035
+msgid "Enable submenu buttons"
+msgstr "Habilitar botones de submenú"
+
+#: id:1036
+msgid "Favourites"
+msgstr "Favoritos"
+
+#: id:1037
+msgid "Video Add-ons"
+msgstr "Add-ons de vídeo"
+
+#: id:1038
+msgid "Music Add-ons"
+msgstr "Add-ons de música"
+
+#: id:1039
+msgid "Picture Add-ons"
+msgstr "Add-ons de imágenes"
+
+#: id:1040
+msgid "Loading directory"
+msgstr "Cargando directorio"
+
+#: id:1041
+msgid "Retrieved %i items"
+msgstr "%i elementos obtenidos"
+
+#: id:1042
+msgid "Retrieved %i of %i items"
+msgstr "%i de %i elementos obtenidos"
+
+#: id:1043
+msgid "Program Add-ons"
+msgstr "Add-ons de aplicaciones"
+
+#: id:1044
+msgid "Set plugin thumb"
+msgstr "Establecer miniatura de plugin"
+
+#: id:1045
+msgid "Add-on settings"
+msgstr "Configuración del Add-on"
+
+#: id:1046
+msgid "Access points"
+msgstr "Puntos de acceso"
+
+#: id:1047
+msgid "Other..."
+msgstr "Otro..."
+
+#: id:1048
+msgid "- Username"
+msgstr "- Nombre usuario"
+
+#: id:1049
+msgid "Script settings"
+msgstr "Configuración de script"
+
+#: id:1050
+msgid "Singles"
+msgstr "Individual"
+
+#: id:1051
+msgid "Enter web address"
+msgstr "Introduzca la dirección web"
+
+#: id:1200
+msgid "SMB client"
+msgstr "Cliente SMB"
+
+#: id:1202
+msgid "Workgroup"
+msgstr "Grupo de trabajo"
+
+#: id:1203
+msgid "Default username"
+msgstr "Usuario por defecto"
+
+#: id:1204
+msgid "Default password"
+msgstr "Contraseña por defecto"
+
+#: id:1207
+msgid "WINS server"
+msgstr "Servidor WINS"
+
+#: id:1208
+msgid "Mount SMB shares"
+msgstr "Montar recursos compartidos por SMB"
+
+#: id:1210
+msgctxt "Auto context with id 1210"
+msgid "Remove"
+msgstr "Eliminar"
+
+#: id:1211
+msgctxt "Auto context with id 1211"
+msgid "Music"
+msgstr "Música"
+
+#: id:1212
+msgctxt "Auto context with id 1212"
+msgid "Video"
+msgstr "Vídeo"
+
+#: id:1213
+msgctxt "Auto context with id 1213"
+msgid "Pictures"
+msgstr "Imágenes"
+
+#: id:1214
+msgctxt "Auto context with id 1214"
+msgid "Files"
+msgstr "Archivos"
+
+#: id:1215
+msgctxt "Auto context with id 1215"
+msgid "Music & video"
+msgstr "Música y vídeo"
+
+#: id:1216
+msgid "Music & pictures"
+msgstr "Música e imágenes"
+
+#: id:1217
+msgid "Music & files"
+msgstr "Música y archivos"
+
+#: id:1218
+msgid "Video & pictures"
+msgstr "Vídeo e imágenes"
+
+#: id:1219
+msgid "Video & files"
+msgstr "Vídeo y archivos"
+
+#: id:1220
+msgid "Pictures & files"
+msgstr "Imágenes y archivos"
+
+#: id:1221
+msgid "Music & video & pictures"
+msgstr "Música, vídeo e imágenes"
+
+#: id:1222
+msgid "Music & video & pictures & files"
+msgstr "Música, vídeo, imágenes y archivos"
+
+#: id:1223
+msgctxt "Auto context with id 1223"
+msgid "Disabled"
+msgstr "Deshabilitado"
+
+#: id:1226
+msgid "Files & music & video"
+msgstr "Archivos, música y vídeo"
+
+#: id:1227
+msgid "Files & pictures & music"
+msgstr "Archivos, imágenes y música"
+
+#: id:1228
+msgid "Files & pictures & video"
+msgstr "Archivos, imágenes y vídeo"
+
+#: id:1229
+msgid "Music & programs"
+msgstr "Música y programas"
+
+#: id:1230
+msgid "Video & programs"
+msgstr "Vídeo y programas"
+
+#: id:1231
+msgid "Pictures & programs"
+msgstr "Imágenes y programas"
+
+#: id:1232
+msgid "Music & video & pictures & programs"
+msgstr "Música, vídeo, imágenes y programas"
+
+#: id:1233
+msgid "Programs & video & music"
+msgstr "Programas, vídeo y música"
+
+#: id:1234
+msgid "Programs & pictures & music"
+msgstr "Programas, imágenes y música"
+
+#: id:1235
+msgid "Programs & pictures & video"
+msgstr "Programas, imágenes y vídeo"
+
+#: id:1250
+msgid "Auto-detection"
+msgstr "Autodetección"
+
+#: id:1251
+msgid "Auto-detect system"
+msgstr "Autodetectar sistema"
+
+#: id:1252
+msgid "Nickname"
+msgstr "Apodo"
+
+#: id:1254
+msgid "Ask to connect"
+msgstr "Preguntar antes de conectar"
+
+#: id:1255
+msgid "Send FTP user and password"
+msgstr "Enviar usuario y contraseña FTP"
+
+#: id:1256
+msgid "Ping interval"
+msgstr "Intervalo de ping"
+
+#: id:1257
+msgid "Would you like to connect to the auto-detected system?"
+msgstr "¿Desea conectar al sistema autodetectado?"
+
+#: id:1259
+msgid "Zeroconf"
+msgstr ""
+
+#: id:1260
+msgid "Announce these services to other systems via Zeroconf"
+msgstr "Anunciar estos servicios a otros sistemas a través de Zeroconf"
+
+#: id:1270
+msgid "Allow XBMC to receive AirPlay content"
+msgstr "Permitir a XBMC recibir contenido de AirPlay"
+
+#: id:1271
+msgid "Device name"
+msgstr "Nombre del Dispositivo"
+
+#: id:1272
+msgid "- Use password protection"
+msgstr ""
+
+#: id:1273
+msgid "AirPlay"
+msgstr ""
+
+#: id:1300
+msgid "Custom audio device"
+msgstr "Dispositivo de audio personalizado"
+
+#: id:1301
+msgid "Custom passthrough device"
+msgstr "Dispositivo passthrough personalizado"
+
+#: id:1396
+msgid "Drifting"
+msgstr "A la deriva"
+
+#: id:1397
+msgid "and"
+msgstr "y"
+
+#: id:1398
+msgid "Freezing"
+msgstr "Helando"
+
+#: id:1399
+msgid "Late"
+msgstr "Tarde"
+
+#: id:1400
+msgid "Isolated"
+msgstr "Aisladas"
+
+#: id:1401
+msgid "Thundershowers"
+msgstr "Tormentoso"
+
+#: id:1402
+msgid "Thunder"
+msgstr "Truenos"
+
+#: id:1403
+msgctxt "Auto context with id 1403"
+msgid "Sun"
+msgstr "Sol"
+
+#: id:1404
+msgid "Heavy"
+msgstr "Fuerte"
+
+#: id:1405
+msgid "in"
+msgstr "en"
+
+#: id:1406
+msgid "the"
+msgstr "los"
+
+#: id:1407
+msgid "Vicinity"
+msgstr "Alrededores"
+
+#: id:1408
+msgid "Ice"
+msgstr "Hielo"
+
+#: id:1409
+msgid "Crystals"
+msgstr "Granizo"
+
+#: id:1410
+msgid "Calm"
+msgstr "Calma"
+
+#: id:1411
+msgid "with"
+msgstr "con"
+
+#: id:1412
+msgid "windy"
+msgstr "viento"
+
+#: id:1413
+msgid "drizzle"
+msgstr "llovizna"
+
+#: id:1414
+msgid "Thunderstorm"
+msgstr "Tempestad"
+
+#: id:1415
+msgid "Drizzle"
+msgstr "Llovizna"
+
+#: id:1416
+msgid "Foggy"
+msgstr "Nublado"
+
+#: id:1417
+msgid "Grains"
+msgstr "Granos"
+
+#: id:1418
+msgid "T-Storms"
+msgstr "Tempestades"
+
+#: id:1419
+msgid "T-Showers"
+msgstr "Tormentas"
+
+#: id:1420
+msgid "Moderate"
+msgstr "Moderado"
+
+#: id:1421
+msgid "Very High"
+msgstr "Muy fuerte"
+
+#: id:1422
+msgid "Windy"
+msgstr "Viento"
+
+#: id:1423
+msgid "Mist"
+msgstr "Niebla"
+
+#: id:1450
+msgid "Put display to sleep when idle"
+msgstr "Apagar la pantalla cuando está inactivo"
+
+#: id:2050
+msgid "Runtime"
+msgstr "Duración"
+
+#: id:2100
+msgid "Script failed! : %s"
+msgstr "¡Fallo en el script! : %s"
+
+#: id:2101
+msgid "Newer version needed - See log"
+msgstr "Necesaria versión nueva. Consulta el log"
+
+#: id:4501
+msgid "Enable LCD/VFD"
+msgstr "Habilitar LCD/VFD"
+
+#: id:10000
+msgid "Home"
+msgstr "Inicio"
+
+#: id:10001
+msgctxt "Auto context with id 10001"
+msgid "Programs"
+msgstr "Programas"
+
+#: id:10002
+msgctxt "Auto context with id 10002"
+msgid "Pictures"
+msgstr "Imágenes"
+
+#: id:10003
+msgctxt "Auto context with id 10003"
+msgid "File manager"
+msgstr "Explorador de archivos"
+
+#: id:10004
+msgctxt "Auto context with id 10004"
+msgid "Settings"
+msgstr "Configuración"
+
+#: id:10005
+msgctxt "Auto context with id 10005"
+msgid "Music"
+msgstr "Música"
+
+#: id:10006
+msgctxt "Auto context with id 10006"
+msgid "Videos"
+msgstr "Vídeos"
+
+#: id:10007
+msgid "System information"
+msgstr "Información del sistema"
+
+#: id:10008
+msgid "Settings - General"
+msgstr "Configuración - General"
+
+#: id:10009
+msgid "Settings - Screen"
+msgstr "Configuración - Pantalla"
+
+#: id:10010
+msgid "Settings - Appearance - GUI Calibration"
+msgstr "Configuración - Pantalla - Posición del GUI"
+
+#: id:10011
+msgid "Settings - Videos - Screen Calibration"
+msgstr "Configuración - Pantalla - Calibración de pantalla"
+
+#: id:10012
+msgid "Settings - Pictures"
+msgstr "Configuración - Imágenes"
+
+#: id:10013
+msgid "Settings - Programs"
+msgstr "Configuración - Programas"
+
+#: id:10014
+msgid "Settings - Weather"
+msgstr "Configuración - El Tiempo"
+
+#: id:10015
+msgid "Settings - Music"
+msgstr "Configuración - Música"
+
+#: id:10016
+msgid "Settings - System"
+msgstr "Configuración - Sistema"
+
+#: id:10017
+msgid "Settings - Videos"
+msgstr "Configuración - Vídeos"
+
+#: id:10018
+msgid "Settings - Network"
+msgstr "Configuración - Red"
+
+#: id:10019
+msgid "Settings - Appearance"
+msgstr "Configuración - Apariencia"
+
+#: id:10020
+msgctxt "Auto context with id 10020"
+msgid "Scripts"
+msgstr "Scripts"
+
+#: id:10021
+msgid "Web Browser"
+msgstr "Navegador Web"
+
+#: id:10025
+msgctxt "Auto context with id 10025"
+msgid "Videos"
+msgstr ""
+
+#: id:10028
+msgid "Videos/Playlist"
+msgstr "Vídeos/Lista de reproducción"
+
+#: id:10029
+msgctxt "Auto context with id 10029"
+msgid "Login screen"
+msgstr ""
+
+#: id:10034
+msgid "Settings - Profiles"
+msgstr "Configuración - Perfiles"
+
+#: id:10040
+msgid "Addon browser"
+msgstr ""
+
+#: id:10100
+msgid "Yes/No dialog"
+msgstr "Cuadro de diálogo Sí/No"
+
+#: id:10101
+msgid "Progress dialog"
+msgstr "Diálogo de progreso"
+
+#: id:10210
+msgid "Looking for subtitles..."
+msgstr "Buscando subtítulos..."
+
+#: id:10211
+msgid "Looking for or caching subtitles..."
+msgstr "Cacheando subtítulos..."
+
+#: id:10212
+msgid "terminating"
+msgstr "finalizando"
+
+#: id:10213
+msgid "buffering"
+msgstr "buffering"
+
+#: id:10214
+msgid "Opening stream"
+msgstr "Abriendo flujo"
+
+#: id:10500
+msgid "Music/Playlist"
+msgstr "Música/Lista de reproducción"
+
+#: id:10501
+msgid "Music/Files"
+msgstr "Música/Archivos"
+
+#: id:10502
+msgid "Music/Library"
+msgstr "Música/Biblioteca"
+
+#: id:10503
+msgid "Playlist editor"
+msgstr "Editor de listas de reproducción"
+
+#: id:10504
+msgid "Top 100 songs"
+msgstr "Top 100 canciones"
+
+#: id:10505
+msgid "Top 100 albums"
+msgstr "Top 100 álbums"
+
+#: id:10506
+msgctxt "Auto context with id 10506"
+msgid "Programs"
+msgstr "Programas"
+
+#: id:10507
+msgid "Configuration"
+msgstr "Configuración"
+
+#: id:10508
+msgid "Weather forecast"
+msgstr "Pronóstico del Tiempo"
+
+#: id:10509
+msgid "Network gaming"
+msgstr "Juego en red"
+
+#: id:10510
+msgid "Extensions"
+msgstr "Extensiones"
+
+#: id:10511
+msgctxt "Auto context with id 10511"
+msgid "System info"
+msgstr "Info. sistema"
+
+#: id:10516
+msgid "Music - Library"
+msgstr "Música - Biblioteca"
+
+#: id:10517
+msgid "Now Playing - Music"
+msgstr "Reproduciendo - Música"
+
+#: id:10522
+msgid "Now Playing - Videos"
+msgstr "Reproduciendo - Vídeo"
+
+#: id:10523
+msgid "Album info"
+msgstr "Información de álbum"
+
+#: id:10524
+msgid "Movie info"
+msgstr "Información de película"
+
+#: id:12000
+msgid "Select dialog"
+msgstr "Diálogo de selección"
+
+#: id:12001
+msgid "Music/Info"
+msgstr "Música/info"
+
+#: id:12002
+msgid "Dialog OK"
+msgstr "Diálogo de OK"
+
+#: id:12003
+msgid "Videos/Info"
+msgstr "Vídeos/Info"
+
+#: id:12004
+msgid "Scripts/Info"
+msgstr "Scripts/Info"
+
+#: id:12005
+msgid "Fullscreen video"
+msgstr "Vídeo a pantalla completa"
+
+#: id:12006
+msgid "Audio visualization"
+msgstr "Visualización de sonido"
+
+#: id:12008
+msgid "File stacking dialog"
+msgstr "Diálogo de agrupar archivos"
+
+#: id:12009
+msgid "Rebuild index..."
+msgstr "Reconstruir índice..."
+
+#: id:12010
+msgid "Return to music window"
+msgstr "Volver a ventana Música"
+
+#: id:12011
+msgid "Return to videos window"
+msgstr "Volver a ventana Vídeos"
+
+#: id:12021
+msgid "Start from beginning"
+msgstr "Comenzar desde el principio"
+
+#: id:12022
+msgid "Resume from %s"
+msgstr "Reanudar desde %s"
+
+#: id:12310
+msgid "0"
+msgstr "0"
+
+#: id:12311
+msgid "1"
+msgstr "1"
+
+#: id:12312
+msgid "2"
+msgstr "2"
+
+#: id:12313
+msgid "3"
+msgstr "3"
+
+#: id:12314
+msgid "4"
+msgstr "4"
+
+#: id:12315
+msgid "5"
+msgstr "5"
+
+#: id:12316
+msgid "6"
+msgstr "6"
+
+#: id:12317
+msgid "7"
+msgstr "7"
+
+#: id:12318
+msgid "8"
+msgstr "8"
+
+#: id:12319
+msgid "9"
+msgstr "9"
+
+#: id:12320
+msgid "c"
+msgstr "c"
+
+#: id:12321
+msgid "Ok"
+msgstr "Ok"
+
+#: id:12322
+msgid "*"
+msgstr "*"
+
+#: id:12325
+msgid "Locked! Enter code..."
+msgstr "¡Bloqueado! Introduzca código..."
+
+#: id:12326
+msgid "Enter password"
+msgstr "Introduzca la contraseña"
+
+#: id:12327
+msgid "Enter master code"
+msgstr "Introduzca el código maestro"
+
+#: id:12328
+msgid "Enter unlock code"
+msgstr "Introduzca el código de desbloqueo"
+
+#: id:12329
+msgid "or press C to cancel"
+msgstr "o pulse C para cancelar"
+
+#: id:12330
+msgid "Enter gamepad button combo and"
+msgstr "Introduzca la combinación de botones en el gamepad y"
+
+#: id:12331
+msgid "press OK, or Back to cancel"
+msgstr "pulse Inicio, o Atrás para cancelar"
+
+#: id:12332
+msgid "Set lock"
+msgstr "Bloquear"
+
+#: id:12333
+msgid "Unlock"
+msgstr "Desbloquear"
+
+#: id:12334
+msgid "Reset lock"
+msgstr "Reiniciar bloqueo"
+
+#: id:12335
+msgid "Remove lock"
+msgstr "Quitar bloqueo"
+
+#: id:12337
+msgid "Numeric password"
+msgstr "Contraseña numérica"
+
+#: id:12338
+msgid "Gamepad button combo"
+msgstr "Combinación de botones del mando de juego"
+
+#: id:12339
+msgid "Full-text password"
+msgstr "Contraseña alfanumérica"
+
+#: id:12340
+msgid "Enter new password"
+msgstr "Introduzca la nueva contraseña"
+
+#: id:12341
+msgid "Re-Enter new password"
+msgstr "Reintroduzca la nueva contraseña"
+
+#: id:12342
+msgid "Incorrect password,"
+msgstr "Contraseña incorrecta,"
+
+#: id:12343
+msgid "retries left"
+msgstr "intentos restantes"
+
+#: id:12344
+msgid "Passwords entered did not match."
+msgstr "Las contraseñas introducidas no coinciden."
+
+#: id:12345
+msgid "Access denied"
+msgstr "Acceso denegado"
+
+#: id:12346
+msgid "Password retry limit exceeded."
+msgstr "Límite de intentos de contraseña excedidos."
+
+#: id:12347
+msgid "The system will now shut off."
+msgstr "El equipo se apagará ahora."
+
+#: id:12348
+msgid "Item locked"
+msgstr "Elemento bloqueado"
+
+#: id:12353
+msgid "Reactivate lock"
+msgstr "Reactivar bloqueo"
+
+#: id:12356
+msgid "Change lock"
+msgstr "Cambiar bloqueo"
+
+#: id:12357
+msgid "Source lock"
+msgstr "Bloqueo de recurso"
+
+#: id:12358
+msgid "Password entry was blank. Try again."
+msgstr "Contraseña introducida en blanco. Inténtelo de nuevo."
+
+#: id:12360
+msgid "Master lock"
+msgstr "Bloqueo maestro"
+
+#: id:12362
+msgid "Shutdown system if Master Lock retries exceeded"
+msgstr "Apagar equipo si se excede el máximo de intentos"
+
+#: id:12367
+msgid "Master code is not valid"
+msgstr "¡Código maestro no válido!"
+
+#: id:12368
+msgid "Please enter a valid master code"
+msgstr "¡Por favor, introduzca un código maestro válido!"
+
+#: id:12373
+msgid "Settings & file manager"
+msgstr "Configuración y explorador de archivos"
+
+#: id:12376
+msgid "Set as default for all movies"
+msgstr "Asignar por defecto para todas las películas"
+
+#: id:12377
+msgid "This will reset any previously saved values"
+msgstr "Esto eliminará cualquier valor previamente salvado"
+
+#: id:12378
+msgid "Amount of time to display each image"
+msgstr "Mostrar cada imagen durante"
+
+#: id:12379
+msgid "Use pan and zoom effects"
+msgstr "Usar efectos de movimiento y ampliación"
+
+#: id:12383
+msgid "12 hour clock"
+msgstr "Reloj de 12 horas"
+
+#: id:12384
+msgid "24 hour clock"
+msgstr "Reloj de 24 horas"
+
+#: id:12385
+msgid "Day/Month"
+msgstr "Día/Mes"
+
+#: id:12386
+msgid "Month/Day"
+msgstr "Mes/Día"
+
+#: id:12390
+msgid "System uptime"
+msgstr "Encendido hace"
+
+#: id:12391
+msgid "Minutes"
+msgstr "Minutos"
+
+#: id:12392
+msgid "Hours"
+msgstr "Horas"
+
+#: id:12393
+msgid "Days"
+msgstr "Días"
+
+#: id:12394
+msgid "Total uptime"
+msgstr "Tiempo total encendido"
+
+#: id:12395
+msgid "Battery level"
+msgstr "Nivel de batería"
+
+#: id:12600
+msgctxt "Auto context with id 12600"
+msgid "Weather"
+msgstr "El Tiempo"
+
+#: id:12900
+msgctxt "Auto context with id 12900"
+msgid "Screensaver"
+msgstr "Salvapantallas"
+
+#: id:12901
+msgid "Fullscreen OSD"
+msgstr "OSD a pantalla completa"
+
+#: id:13000
+msgid "System"
+msgstr "Sistema"
+
+#: id:13001
+msgid "Immediate HD spindown"
+msgstr "Parar el disco duro inmediatamente"
+
+#: id:13002
+msgid "Video only"
+msgstr "Sólo vídeo"
+
+#: id:13003
+msgid "- Delay"
+msgstr "- Retardo"
+
+#: id:13004
+msgid "- Minimum file duration"
+msgstr "- Duración mínima del archivo"
+
+#: id:13005
+msgid "Shutdown"
+msgstr "Apagar"
+
+#: id:13008
+msgid "Shutdown function"
+msgstr "Modo de apagado por defecto"
+
+#: id:13009
+msgid "Quit"
+msgstr "Salir"
+
+#: id:13010
+msgid "Hibernate"
+msgstr "Hibernar"
+
+#: id:13011
+msgid "Suspend"
+msgstr "Suspender"
+
+#: id:13012
+msgid "Exit"
+msgstr "Salir"
+
+#: id:13013
+msgid "Reboot"
+msgstr "Reiniciar"
+
+#: id:13014
+msgid "Minimize"
+msgstr "Minimizar"
+
+#: id:13015
+msgid "Power button action"
+msgstr "Acción del botón de apagado"
+
+#: id:13016
+msgid "Power off System"
+msgstr "Apagar el sistema"
+
+#: id:13020
+msgid "Is another session active, perhaps over ssh?"
+msgstr "Existe otra sesión activa, ¿tal vez sobre ssh?"
+
+#: id:13021
+msgid "Mounted removable harddrive"
+msgstr "Disco duro extraíble montado"
+
+#: id:13022
+msgid "Unsafe device removal"
+msgstr "Expulsión de dispositivo no segura"
+
+#: id:13023
+msgid "Successfully removed device"
+msgstr "Dispositivo expulsado correctamente"
+
+#: id:13024
+msgid "Joystick plugged"
+msgstr "Joystick conectado"
+
+#: id:13025
+msgid "Joystick unplugged"
+msgstr "Joystick desconectado"
+
+#: id:13050
+msgid "Running low on battery"
+msgstr "Batería baja"
+
+#: id:13100
+msgid "Flicker filter"
+msgstr "Filtro antivibración"
+
+#: id:13101
+msgid "Let driver choose (requires restart)"
+msgstr "Permitir al dispositivo elegir (requiere reinicio)"
+
+#: id:13105
+msgid "Vertical blank sync"
+msgstr "Sinc. de refresco vertical"
+
+#: id:13106
+msgctxt "Auto context with id 13106"
+msgid "Disabled"
+msgstr "Deshabilitado"
+
+#: id:13107
+msgid "Enabled during video playback"
+msgstr "Al reproducir vídeo"
+
+#: id:13108
+msgctxt "Auto context with id 13108"
+msgid "Always enabled"
+msgstr "Siempre habilitado"
+
+#: id:13109
+msgid "Test & apply resolution"
+msgstr "Probar y aplicar resolución"
+
+#: id:13110
+msgid "Save resolution?"
+msgstr "¿Guardar resolución?"
+
+#: id:13111
+msgid "Would you like to keep this resolution?"
+msgstr "¿Desea mantener esta resolución?"
+
+#: id:13112
+msgid "High quality upscaling"
+msgstr "Reescalado de alta calidad"
+
+#: id:13113
+msgctxt "Auto context with id 13113"
+msgid "Disabled"
+msgstr "Deshabilitado"
+
+#: id:13114
+msgid "Enabled for SD content"
+msgstr "Habilitado para contenido en baja definición"
+
+#: id:13115
+msgctxt "Auto context with id 13115"
+msgid "Always enabled"
+msgstr "Siempre habilitado"
+
+#: id:13116
+msgid "Upscaling method"
+msgstr "Método de reescalado"
+
+#: id:13117
+msgctxt "Auto context with id 13117"
+msgid "Bicubic"
+msgstr "Bicúbico"
+
+#: id:13118
+msgid "Lanczos"
+msgstr "Lanczos"
+
+#: id:13119
+msgid "Sinc"
+msgstr "Sinc"
+
+#: id:13120
+msgctxt "Auto context with id 13120"
+msgid "VDPAU"
+msgstr "VDPAU"
+
+#: id:13121
+msgid "VDPAU HQ Upscaling level"
+msgstr "Nivel de escalado de VDPAU HQ"
+
+#: id:13122
+msgid "VDPAU Studio level color conversion"
+msgstr "Conversión del nivel de color del estudio VDPAU"
+
+#: id:13130
+msgid "Blank other displays"
+msgstr "Refrescar otras pantallas"
+
+#: id:13131
+msgctxt "Auto context with id 13131"
+msgid "Disabled"
+msgstr "Deshabilitado"
+
+#: id:13132
+msgid "Blank displays"
+msgstr "Refresco de pantallas"
+
+#: id:13140
+msgid "Active connections detected!"
+msgstr "¡Conexiones activas detectadas!"
+
+#: id:13141
+msgid "If you proceed, you might not be able to control XBMC"
+msgstr "Si continúa, puede que pierda el control de XBMC"
+
+#: id:13142
+msgid "any longer. Are you sure you want to stop the Event server?"
+msgstr "¿Está seguro de que quiere parar el servidor de eventos?"
+
+#: id:13144
+msgid "Change Apple Remote mode?"
+msgstr "¿Cambiar modo del mando Apple?"
+
+#: id:13145
+msgid "If you are currently using the Apple Remote to control"
+msgstr "Si está usando el mando Apple para controlar"
+
+#: id:13146
+msgid "XBMC, changing this setting might affect your ability"
+msgstr "XBMC, cambiar éste ajuste puede afectar su capacidad"
+
+#: id:13147
+msgid "to continue controlling it. Do you want to proceed?"
+msgstr "para continuar controlándolo.¿Desea continuar?"
+
+#: id:13159
+msgid "Subnet mask"
+msgstr "Máscara de red"
+
+#: id:13160
+msgid "Gateway"
+msgstr "Puerta de enlace"
+
+#: id:13161
+msgid "Primary DNS"
+msgstr "DNS Primario"
+
+#: id:13162
+msgid "Initialize failed"
+msgstr "Fallo en inicialización"
+
+#: id:13170
+msgctxt "Auto context with id 13170"
+msgid "Never"
+msgstr "Nunca"
+
+#: id:13171
+msgid "Immediately"
+msgstr "Inmediatamente"
+
+#: id:13172
+msgid "After %i secs"
+msgstr "Después de %i segs."
+
+#: id:13173
+msgid "HDD install date:"
+msgstr "Fecha de instalación del disco duro:"
+
+#: id:13174
+msgid "HDD power cycle count:"
+msgstr "Contador de encendidos del disco duro:"
+
+#: id:13200
+msgid "Profiles"
+msgstr "Perfiles"
+
+#: id:13201
+msgid "Delete profile '%s'?"
+msgstr "¿Eliminar el perfil '%s'?"
+
+#: id:13204
+msgid "Last loaded profile:"
+msgstr "Último perfil cargado:"
+
+#: id:13205
+msgid "Unknown"
+msgstr "Desconocido"
+
+#: id:13206
+msgid "Overwrite"
+msgstr "Sobreescribir"
+
+#: id:13208
+msgid "Alarm clock"
+msgstr "Alarma del reloj"
+
+#: id:13209
+msgid "Alarm clock interval (in minutes)"
+msgstr "Intervalo de alarma del reloj (en minutos)"
+
+#: id:13210
+msgid "Started, alarm in %im"
+msgstr "Iniciada, alarma en %im"
+
+#: id:13211
+msgid "Alarm!"
+msgstr "¡Alarma!"
+
+#: id:13212
+msgid "Canceled with %im%is left"
+msgstr "Cancelada antes de %im%is"
+
+#: id:13213
+msgid "%2.0fm"
+msgstr "%2.0fm"
+
+#: id:13214
+msgid "%2.0fs"
+msgstr "%2.0fs"
+
+#: id:13249
+msgid "Search for subtitles in RARs"
+msgstr "Buscar subtítulos en RARs"
+
+#: id:13250
+msgid "Browse for subtitle..."
+msgstr "Buscar subtítulos..."
+
+#: id:13251
+msgid "Move item"
+msgstr "Mover elemento"
+
+#: id:13252
+msgid "Move item here"
+msgstr "Mover elemento aquí"
+
+#: id:13253
+msgid "Cancel move"
+msgstr "Cancelar mover"
+
+#: id:13270
+msgid "Hardware:"
+msgstr "Hardware:"
+
+#: id:13271
+msgid "CPU Usage:"
+msgstr "Uso de CPU:"
+
+#: id:13274
+msgid "Connected, but no DNS is available."
+msgstr "Conectado, pero no hay un DNS disponible."
+
+#: id:13275
+msgid "Hard Disk"
+msgstr "Disco duro"
+
+#: id:13276
+msgid "DVD-ROM"
+msgstr "DVD-ROM"
+
+#: id:13277
+msgctxt "Auto context with id 13277"
+msgid "Storage"
+msgstr "Almacenamiento"
+
+#: id:13278
+msgctxt "Auto context with id 13278"
+msgid "Default"
+msgstr "Por defecto"
+
+#: id:13279
+msgctxt "Auto context with id 13279"
+msgid "Network"
+msgstr "Red"
+
+#: id:13280
+msgctxt "Auto context with id 13280"
+msgid "Video"
+msgstr "Vídeo"
+
+#: id:13281
+msgid "Hardware"
+msgstr "Hardware"
+
+#: id:13283
+msgid "Operating system:"
+msgstr "Sistema operativo:"
+
+#: id:13284
+msgid "CPU speed:"
+msgstr "Velocidad de CPU:"
+
+#: id:13286
+msgid "Video encoder:"
+msgstr "Codificador de vídeo:"
+
+#: id:13287
+msgid "Screen resolution:"
+msgstr "Resolución de pantalla:"
+
+#: id:13292
+msgid "A/V cable:"
+msgstr "Cable A/V:"
+
+#: id:13294
+msgid "DVD region:"
+msgstr "Región de DVD:"
+
+#: id:13295
+msgid "Internet:"
+msgstr "Internet:"
+
+#: id:13296
+msgctxt "Auto context with id 13296"
+msgid "Connected"
+msgstr "Conectado"
+
+#: id:13297
+msgid "Not connected. Check network settings."
+msgstr "No conectado. Compruebe la configuración de red."
+
+#: id:13299
+msgid "Target temperature"
+msgstr "Temperatura deseada"
+
+#: id:13300
+msgid "Fan speed"
+msgstr "Velocidad del ventilador"
+
+#: id:13301
+msgid "Auto temperature control"
+msgstr "Control del ventilador por temperatura"
+
+#: id:13302
+msgid "Fan speed override"
+msgstr "Control manual del ventilador"
+
+#: id:13303
+msgid "- Fonts"
+msgstr "- Fuentes del skin"
+
+#: id:13304
+msgid "Enable flipping bi-directional strings"
+msgstr "Invertir cadenas bidireccionales"
+
+#: id:13305
+msgid "Show RSS news feeds"
+msgstr "Activar noticias RSS"
+
+#: id:13306
+msgid "Show parent folder items"
+msgstr "Mostrar el icono de subir directorio"
+
+#: id:13307
+msgid "Track naming template"
+msgstr "Plantilla de nombrado de pistas"
+
+#: id:13308
+msgid "Do you wish to reboot your system"
+msgstr "¿Desea reiniciar su equipo"
+
+#: id:13309
+msgid "instead of just XBMC?"
+msgstr "en lugar de sólo XBMC?"
+
+#: id:13310
+msgid "Zoom effect"
+msgstr "Efecto de zoom"
+
+#: id:13311
+msgid "Float effect"
+msgstr "Efecto de flotar"
+
+#: id:13312
+msgid "Black bar reduction"
+msgstr "Reducción de las bandas negras"
+
+#: id:13313
+msgid "Restart"
+msgstr "Reiniciar"
+
+#: id:13314
+msgid "Crossfade between songs"
+msgstr "Mezclar pistas"
+
+#: id:13315
+msgid "Regenerate thumbnails"
+msgstr "Regenerar miniaturas"
+
+#: id:13316
+msgid "Recursive thumbnails"
+msgstr "Miniaturas recursivas"
+
+#: id:13317
+msgid "View slideshow"
+msgstr "Ver presentación"
+
+#: id:13318
+msgid "Recursive slideshow"
+msgstr "Presentación recursiva"
+
+#: id:13319
+msgid "Randomize"
+msgstr "Reproducción aleatoria"
+
+#: id:13320
+msgid "Stereo"
+msgstr "Estéreo"
+
+#: id:13321
+msgid "Left only"
+msgstr "Sólo izquierdo"
+
+#: id:13322
+msgid "Right only"
+msgstr "Sólo derecho"
+
+#: id:13323
+msgid "Enable karaoke support"
+msgstr "Activar el soporte de karaoke"
+
+#: id:13324
+msgid "Background transparency"
+msgstr "Transparencia del fondo"
+
+#: id:13325
+msgid "Foreground transparency"
+msgstr "Transparencia del primer plano"
+
+#: id:13326
+msgid "A/V delay"
+msgstr "Retardo A/V"
+
+#: id:13327
+msgid "Karaoke"
+msgstr "Karaoke"
+
+#: id:13328
+msgid "%s not found"
+msgstr "%s no encontrado"
+
+#: id:13329
+msgid "Error opening %s"
+msgstr "Error abriendo %s"
+
+#: id:13330
+msgid "Unable to load %s"
+msgstr "No se puede cargar %s"
+
+#: id:13331
+msgid "Error: Out of memory"
+msgstr "Error: memoria insuficiente"
+
+#: id:13332
+msgid "Move up"
+msgstr "Mover arriba"
+
+#: id:13333
+msgid "Move down"
+msgstr "Mover abajo"
+
+#: id:13334
+msgid "Edit label"
+msgstr "Editar etiqueta"
+
+#: id:13335
+msgid "Make default"
+msgstr "Poner por defecto"
+
+#: id:13336
+msgid "Remove button"
+msgstr "Quitar botón"
+
+#: id:13340
+msgid "Leave as is"
+msgstr "Dejarlo tal cual"
+
+#: id:13341
+msgid "Green"
+msgstr "Verde"
+
+#: id:13342
+msgid "Orange"
+msgstr "Naranja"
+
+#: id:13343
+msgid "Red"
+msgstr "Rojo"
+
+#: id:13344
+msgid "Cycle"
+msgstr "Cíclico"
+
+#: id:13345
+msgid "Switch LED off on playback"
+msgstr "Apagar el LED al reproducir"
+
+#: id:13346
+msgctxt "Auto context with id 13346"
+msgid "Movie information"
+msgstr "Información de la película"
+
+#: id:13347
+msgid "Queue item"
+msgstr "Añadir elemento a la cola"
+
+#: id:13348
+msgid "Search IMDb..."
+msgstr "Buscar en IMDb..."
+
+#: id:13349
+msgid "Scan for new content"
+msgstr "Explorar nuevo contenido"
+
+#: id:13350
+msgid "Now playing..."
+msgstr "Reproduciendo..."
+
+#: id:13351
+msgctxt "Auto context with id 13351"
+msgid "Album information"
+msgstr "Información del álbum"
+
+#: id:13352
+msgid "Scan item to library"
+msgstr "Explorar todo para la BD"
+
+#: id:13353
+msgid "Stop scanning"
+msgstr "Detener la exploración"
+
+#: id:13354
+msgctxt "Auto context with id 13354"
+msgid "Render method"
+msgstr "Método de renderizado"
+
+#: id:13355
+msgid "Low quality pixel shader"
+msgstr "Sombreado de píxeles de baja calidad"
+
+#: id:13356
+msgid "Hardware overlays"
+msgstr "Superposición por hardware"
+
+#: id:13357
+msgid "High quality pixel shader"
+msgstr "Sombreado de píxeles de alta calidad"
+
+#: id:13358
+msgid "Play item"
+msgstr "Reproducir elemento"
+
+#: id:13359
+msgid "Set artist thumb"
+msgstr "Establecer miniatura de artista"
+
+#: id:13360
+msgid "Automatically generate thumbnails"
+msgstr "Generar miniaturas automáticamente"
+
+#: id:13361
+msgid "Enable voice"
+msgstr "Habilitar voz"
+
+#: id:13375
+msgid "Enable device"
+msgstr "Habilitar dispositivo"
+
+#: id:13376
+msgid "Volume"
+msgstr "Volumen"
+
+#: id:13377
+msgid "Default view mode"
+msgstr "Modo de vista por defecto"
+
+#: id:13378
+msgid "Default brightness"
+msgstr "Brillo por defecto"
+
+#: id:13379
+msgid "Default contrast"
+msgstr "Contraste por defecto"
+
+#: id:13380
+msgid "Default gamma"
+msgstr "Gamma por defecto"
+
+#: id:13381
+msgid "Resume video"
+msgstr "Reanudar vídeo"
+
+#: id:13382
+msgid "Voice mask - Port 1"
+msgstr "Máscara voz - Puerto 0"
+
+#: id:13383
+msgid "Voice mask - Port 2"
+msgstr "Máscara voz - Puerto 1"
+
+#: id:13384
+msgid "Voice mask - Port 3"
+msgstr "Máscara voz - Puerto 2"
+
+#: id:13385
+msgid "Voice mask - Port 4"
+msgstr "Máscara voz - Puerto 3"
+
+#: id:13386
+msgid "Use time based seeking"
+msgstr "Usar búsqueda basada en tiempo"
+
+#: id:13387
+msgid "Track naming template - right"
+msgstr "Plantilla de nombres de pistas correcta"
+
+#: id:13388
+msgid "Preset"
+msgstr "Ajustes predeterminados"
+
+#: id:13389
+msgid "There are no presets available\nfor this visualization"
+msgstr "No hay ajustes por defecto disponibles para esta visualización"
+
+#: id:13390
+msgid "There are no settings available\nfor this visualization"
+msgstr "No hay ajustes disponibles para esta visualización"
+
+#: id:13391
+msgid "Eject/Load"
+msgstr "Expulsar/Cargar"
+
+#: id:13392
+msgid "Use visualization if playing audio"
+msgstr "Usar visualización mientras se reproduce sonido"
+
+#: id:13393
+msgid "Calculate size"
+msgstr "Calcular tamaño"
+
+#: id:13394
+msgid "Calculating folder size"
+msgstr "Calculando tamaño de directorio"
+
+#: id:13395
+msgid "Video settings"
+msgstr "Ajustes de vídeo"
+
+#: id:13396
+msgid "Audio and subtitle settings"
+msgstr "Ajustes de sonido y subtítulos"
+
+#: id:13397
+msgid "Enable subtitles"
+msgstr "Habilitar subtítulos"
+
+#: id:13398
+msgctxt "Auto context with id 13398"
+msgid "Shortcuts"
+msgstr "Accesos directos"
+
+#: id:13399
+msgid "Ignore articles when sorting (e.g. \"the\")"
+msgstr "Ignorar los artículos al ordenar (p.e. \"el, los\")"
+
+#: id:13400
+msgid "Crossfade between songs on the same album"
+msgstr "Mezclar las canciones del mismo álbum"
+
+#: id:13401
+msgid "Browse for %s"
+msgstr "Buscar %s"
+
+#: id:13402
+msgid "Show track position"
+msgstr "Mostrar posición de la pista"
+
+#: id:13403
+msgid "Clear default"
+msgstr "Borrar por defecto"
+
+#: id:13404
+msgid "Resume"
+msgstr "Continuar"
+
+#: id:13405
+msgid "Get thumb"
+msgstr "Obtener miniatura"
+
+#: id:13406
+msgid "Picture information"
+msgstr "Información de imágen"
+
+#: id:13407
+msgid "%s presets"
+msgstr "%s ajustes por defecto"
+
+#: id:13408
+msgid "(IMDb user rating)"
+msgstr "(Valoración de usuarios de IMDb)"
+
+#: id:13409
+msgid "Top 250"
+msgstr "Top 250"
+
+#: id:13410
+msgid "Tune in on Last.fm"
+msgstr "Sintonizar en Last.fm"
+
+#: id:13411
+msgid "Minimum fan speed"
+msgstr "Velocidad mínima de ventilador"
+
+#: id:13412
+msgid "Play from here"
+msgstr "Reproducir desde aquí"
+
+#: id:13413
+msgid "Downloading"
+msgstr "Descargando"
+
+#: id:13414
+msgid "Include artists who appear only on compilations"
+msgstr "Incluir artistas que sólo aparecen en recopilaciones"
+
+#: id:13415
+msgctxt "Auto context with id 13415"
+msgid "Render method"
+msgstr "Método de renderizado"
+
+#: id:13416
+msgid "Auto detect"
+msgstr "Auto detectar"
+
+#: id:13417
+msgid "Basic shaders (ARB)"
+msgstr "Sombreado básico (ARB)"
+
+#: id:13418
+msgid "Advanced shaders (GLSL)"
+msgstr "Sombreado avanzado (GLSL)"
+
+#: id:13419
+msgid "Software"
+msgstr "Software"
+
+#: id:13420
+msgid "Remove safely"
+msgstr "Expulsar"
+
+#: id:13421
+msgctxt "Auto context with id 13421"
+msgid "VDPAU"
+msgstr "VDPAU"
+
+#: id:13422
+msgid "Start slideshow here"
+msgstr "Comenzar presentación aquí"
+
+#: id:13423
+msgid "Remember for this path"
+msgstr "Recordar esta ruta"
+
+#: id:13424
+msgid "Use pixel buffer objects"
+msgstr "Usar objetos de búfer de píxeles"
+
+#: id:13425
+msgid "Allow hardware acceleration (VDPAU)"
+msgstr "Permitir aceleración de hardware (VDPAU)"
+
+#: id:13426
+msgid "Allow hardware acceleration (VAAPI)"
+msgstr "Permitir aceleración de hardware (VAAPI)"
+
+#: id:13427
+msgid "Allow hardware acceleration (DXVA2)"
+msgstr "Permitir aceleración de hardware (DXVA2)"
+
+#: id:13428
+msgid "Allow hardware acceleration (CrystalHD)"
+msgstr "Permitir aceleración de hardware (CrystalHD)"
+
+#: id:13429
+msgid "Allow hardware acceleration (VDADecoder)"
+msgstr "Permitir aceleración de hardware (VDADecoder)"
+
+#: id:13430
+msgid "Allow hardware acceleration (OpenMax)"
+msgstr "Permitir aceleración de hardware (OpenMax)"
+
+#: id:13431
+msgid "Pixel Shaders"
+msgstr "Pixel Shaders"
+
+#: id:13432
+msgid "Allow hardware acceleration (VideoToolbox)"
+msgstr "Permitir aceleración de hardware (VideoToolbox)"
+
+#: id:13500
+msgid "A/V sync method"
+msgstr "Método sincronización de A/V"
+
+#: id:13501
+msgid "Audio clock"
+msgstr "Reloj de audio"
+
+#: id:13502
+msgid "Video clock (Drop/Dupe audio)"
+msgstr "Reloj de vídeo (Audio Drop/Dupe)"
+
+#: id:13503
+msgid "Video clock (Resample audio)"
+msgstr "Reloj de vídeo (remuestreo de audio)"
+
+#: id:13504
+msgid "Maximum resample amount (%)"
+msgstr "Cantidad máxima remuestreo (%)"
+
+#: id:13505
+msgid "Resample quality"
+msgstr "Calidad remuestreo"
+
+#: id:13506
+msgid "Low(fast)"
+msgstr "Bajo (rápido)"
+
+#: id:13507
+msgctxt "Auto context with id 13507"
+msgid "Medium"
+msgstr "Medio"
+
+#: id:13508
+msgctxt "Auto context with id 13508"
+msgid "High"
+msgstr "Alto"
+
+#: id:13509
+msgid "Really high(slow!)"
+msgstr "Muy alto (¡lento!)"
+
+#: id:13510
+msgid "Sync playback to display"
+msgstr "Sincronización de reproducción a mostrar"
+
+#: id:13550
+msgid "Pause during refresh rate change"
+msgstr "Pausar durante el cambio de frec. de actualización"
+
+#: id:13551
+msgctxt "Auto context with id 13551"
+msgid "Off"
+msgstr "Desactivado"
+
+#: id:13552
+msgid "%.1f Second"
+msgstr "%.1f Segundo"
+
+#: id:13553
+msgid "%.1f Seconds"
+msgstr "%.1f Segundos"
+
+#: id:13600
+msgid "Apple remote"
+msgstr "Mando Apple"
+
+#: id:13602
+msgid "Allow start of XBMC using the remote"
+msgstr "Permitir el inicio de XBMC usando el mando"
+
+#: id:13603
+msgid "Sequence delay time"
+msgstr "Retraso en tiempo de secuencia"
+
+#: id:13610
+msgctxt "Auto context with id 13610"
+msgid "Disabled"
+msgstr "Deshabilitado"
+
+#: id:13611
+msgctxt "Auto context with id 13611"
+msgid "Standard"
+msgstr "Estándar"
+
+#: id:13612
+msgid "Universal Remote"
+msgstr "Mando universal"
+
+#: id:13613
+msgid "Multi Remote (Harmony)"
+msgstr "Multi-mando (Harmony)"
+
+#: id:13620
+msgid "Apple Remote Error"
+msgstr "Error de mando Apple"
+
+#: id:13621
+msgid "Apple Remote support could be enabled."
+msgstr "No se puede activar el soporte para el mando Apple."
+
+#: id:14000
+msgid "Stack"
+msgstr "Agrupar"
+
+#: id:14001
+msgid "Unstack"
+msgstr "Desagrupar"
+
+#: id:14003
+msgid "Downloading playlist file..."
+msgstr "Descargando archivo de lista de reproducción..."
+
+#: id:14004
+msgid "Downloading streams list..."
+msgstr "Descargando lista de canales..."
+
+#: id:14005
+msgid "Parsing streams list..."
+msgstr "Procesando lista de canales..."
+
+#: id:14006
+msgid "Downloading streams list failed"
+msgstr "Descarga de lista de canales fallida"
+
+#: id:14007
+msgid "Downloading playlist file failed"
+msgstr "Descarga del archivo de lista de reproducción fallida"
+
+#: id:14009
+msgid "Games directory"
+msgstr "Directorio de juegos"
+
+#: id:14010
+msgid "Auto switch to thumbs based on"
+msgstr "Cambiar autom. a miniaturas según"
+
+#: id:14011
+msgid "Enable auto switching to thumbs view"
+msgstr "Activar cambio auto. a miniaturas"
+
+#: id:14012
+msgid "- Use large icons"
+msgstr "- Usar iconos grandes"
+
+#: id:14013
+msgid "- Switch based on"
+msgstr "- Cambio según:"
+
+#: id:14014
+msgid "- Percentage"
+msgstr "- Porcentaje"
+
+#: id:14015
+msgid "No files and at least one thumb"
+msgstr "Sin archivos y al menos una miniatura"
+
+#: id:14016
+msgid "At least one file and thumb"
+msgstr "Al menos un archivo y una miniatura"
+
+#: id:14017
+msgid "Percentage of thumbs"
+msgstr "Porcentaje de miniaturas"
+
+#: id:14018
+msgid "View options"
+msgstr "Vista"
+
+#: id:14019
+msgid "Change area code 1"
+msgstr "Cambiar el código del área 1"
+
+#: id:14020
+msgid "Change area code 2"
+msgstr "Cambiar el código del área 2"
+
+#: id:14021
+msgid "Change area code 3"
+msgstr "Cambiar el código del área 3"
+
+#: id:14022
+msgctxt "Auto context with id 14022"
+msgid "Library"
+msgstr "Biblioteca"
+
+#: id:14023
+msgid "No TV"
+msgstr "Sin TV"
+
+#: id:14024
+msgid "Enter the nearest large town"
+msgstr "Introduzca la ciudad grande más cercana"
+
+#: id:14025
+msgid "Video/Audio/DVD cache - Harddisk"
+msgstr "Caché de vídeo/sonido/DVD - Disco duro"
+
+#: id:14026
+msgid "Video cache - DVD-ROM"
+msgstr "Caché de vídeo - DVDRom"
+
+#: id:14027
+msgctxt "Auto context with id 14027"
+msgid "- Local Network"
+msgstr "- Red Local"
+
+#: id:14028
+msgctxt "Auto context with id 14028"
+msgid "- Internet"
+msgstr "- Internet"
+
+#: id:14030
+msgid "Audio cache - DVD-ROM"
+msgstr "Caché de sonido - DVD-ROM"
+
+#: id:14031
+msgctxt "Auto context with id 14031"
+msgid "- Local Network"
+msgstr "- Red Local"
+
+#: id:14032
+msgctxt "Auto context with id 14032"
+msgid "- Internet"
+msgstr "- Internet"
+
+#: id:14034
+msgid "DVD cache - DVD-ROM"
+msgstr "Caché de DVD - DVD-ROM"
+
+#: id:14035
+msgctxt "Auto context with id 14035"
+msgid "- Local Network"
+msgstr "- Red Local"
+
+#: id:14036
+msgctxt "Auto context with id 14036"
+msgid "Services"
+msgstr "Servicios"
+
+#: id:14038
+msgid "Network settings changed"
+msgstr "Configuración de red cambiada"
+
+#: id:14039
+msgid "XBMC requires to restart to change your"
+msgstr "XBMC necesita reiniciar para poder cambiar su"
+
+#: id:14040
+msgid "network setup. Would you like to restart now?"
+msgstr "configuración de red. ¿Quiere reiniciar ahora?"
+
+#: id:14041
+msgid "Internet connection bandwidth limitation"
+msgstr "Limitar el ancho de banda de conexión a Internet"
+
+#: id:14043
+msgid "- Shutdown while playing"
+msgstr "- Apagar mientras se está reproduciendo"
+
+#: id:14044
+msgid "%i min"
+msgstr "%i min"
+
+#: id:14045
+msgid "%i sec"
+msgstr "%i seg"
+
+#: id:14046
+msgid "%i ms"
+msgstr "%i ms"
+
+#: id:14047
+msgid "%i %%"
+msgstr "%i %%"
+
+#: id:14048
+msgid "%i kbps"
+msgstr "%i kbps"
+
+#: id:14049
+msgid "%i kb"
+msgstr "%i kb"
+
+#: id:14050
+msgid "%i.0 dB"
+msgstr "%i.0 dB"
+
+#: id:14051
+msgid "Time format"
+msgstr "Formato de hora"
+
+#: id:14052
+msgid "Date format"
+msgstr "Formato de fecha"
+
+#: id:14053
+msgid "GUI filters"
+msgstr "Filtros GUI"
+
+#: id:14055
+msgid "Use background scanning"
+msgstr "Realizar la exploración en segundo plano"
+
+#: id:14056
+msgid "Stop scan"
+msgstr "Detener la exploración"
+
+#: id:14057
+msgid "Not possible while scanning for media info"
+msgstr "No es posible mientras se explora la información de medios"
+
+#: id:14058
+msgid "Film grain effect"
+msgstr "Efecto de granulado"
+
+#: id:14059
+msgid "Search for thumbnails on remote shares"
+msgstr "Buscar miniaturas en recursos compartidos remotos"
+
+#: id:14060
+msgid "Unknown type cache - Internet"
+msgstr "Tipo de caché desconocido - Internet"
+
+#: id:14061
+msgctxt "Auto context with id 14061"
+msgid "Auto"
+msgstr "Auto"
+
+#: id:14062
+msgid "Enter username for"
+msgstr "Introduzca nombre de usuario para"
+
+#: id:14063
+msgid "Date & time"
+msgstr "Fecha y hora"
+
+#: id:14064
+msgid "Set date"
+msgstr "Establecer la fecha"
+
+#: id:14065
+msgid "Set time"
+msgstr "Establecer la hora"
+
+#: id:14066
+msgid "Enter the time in 24 hour HH:MM format"
+msgstr "Introduzca la hora en formato 24 horas HH:MM"
+
+#: id:14067
+msgid "Enter the date in DD/MM/YYYY format"
+msgstr "Introduzca la fecha en formato DD/MM/YYYY"
+
+#: id:14068
+msgid "Enter the IP address"
+msgstr "Introduzca la dirección IP"
+
+#: id:14069
+msgid "Apply these settings now?"
+msgstr "¿Quiere aplicar las opciones ahora?"
+
+#: id:14070
+msgid "Apply changes now"
+msgstr "Aplicar cambios ahora"
+
+#: id:14071
+msgid "Allow file renaming and deletion"
+msgstr "Permitir el renombrado y borrado de archivos"
+
+#: id:14074
+msgid "Set timezone"
+msgstr "Establecer zona horaria"
+
+#: id:14075
+msgid "Use daylight saving time"
+msgstr "Usar horario de verano"
+
+#: id:14076
+msgid "Add to favourites"
+msgstr "Añadir a favoritos"
+
+#: id:14077
+msgid "Remove from favourites"
+msgstr "Eliminar de favoritos"
+
+#: id:14078
+msgctxt "Auto context with id 14078"
+msgid "- Colours"
+msgstr "- Colores"
+
+#: id:14079
+msgid "Timezone country"
+msgstr "País del huso horario"
+
+#: id:14080
+msgid "Timezone"
+msgstr "Huso horario"
+
+#: id:14081
+msgid "File lists"
+msgstr "Listas de archivos"
+
+#: id:14082
+msgid "Show EXIF picture information"
+msgstr "Mostrar la información EXIF de las imágenes"
+
+#: id:14083
+msgid "Use a fullscreen window rather than true fullscreen"
+msgstr "Usar una ventana maximizada en lugar de pantalla completa"
+
+#: id:14084
+msgid "Queue songs on selection"
+msgstr "Poner en la cola las canciones al seleccionarlas"
+
+#: id:14086
+msgid "Playback"
+msgstr "Reproducción"
+
+#: id:14087
+msgid "DVDs"
+msgstr "DVDs"
+
+#: id:14088
+msgid "Play DVDs automatically"
+msgstr "Reproducir DVDs de forma automática"
+
+#: id:14089
+msgid "Font to use for text subtitles"
+msgstr "Fuente para subtítulos"
+
+#: id:14090
+msgid "International"
+msgstr "Internacional"
+
+#: id:14091
+msgid "Character set"
+msgstr "Conjunto de caracteres"
+
+#: id:14092
+msgid "Debugging"
+msgstr "Depuración"
+
+#: id:14093
+msgid "Security"
+msgstr "Seguridad"
+
+#: id:14094
+msgid "Input devices"
+msgstr "Dispositivos de entrada"
+
+#: id:14095
+msgid "Power saving"
+msgstr "Ahorro de energía"
+
+#: id:14096
+msgid "Rip"
+msgstr ""
+
+#: id:14097
+msgid "Audio CD Insert Action"
+msgstr ""
+
+#: id:14098
+msgctxt "Auto context with id 14098"
+msgid "Play"
+msgstr ""
+
+#: id:14099
+msgid "Eject disc when CD ripping is complete"
+msgstr ""
+
+#: id:15015
+msgctxt "Auto context with id 15015"
+msgid "Remove"
+msgstr "Eliminar"
+
+#: id:15016
+msgid "Games"
+msgstr "Juegos"
+
+#: id:15019
+msgid "Add"
+msgstr "Añadir"
+
+#: id:15052
+msgid "Password"
+msgstr "Contraseña"
+
+#: id:15100
+msgctxt "Auto context with id 15100"
+msgid "Library"
+msgstr "Biblioteca"
+
+#: id:15101
+msgid "Database"
+msgstr "Base de Datos"
+
+#: id:15102
+msgid "* All albums"
+msgstr "* Todos los álbumes"
+
+#: id:15103
+msgid "* All artists"
+msgstr "* Todos los interpretes"
+
+#: id:15104
+msgid "* All songs"
+msgstr "* Todas las canciones"
+
+#: id:15105
+msgid "* All genres"
+msgstr "* Todos los géneros"
+
+#: id:15107
+msgid "Buffering..."
+msgstr "Cargando..."
+
+#: id:15108
+msgid "Navigation sounds"
+msgstr "Sonidos de Navegación"
+
+#: id:15109
+msgid "Skin default"
+msgstr "Por defecto"
+
+#: id:15111
+msgid "- Theme"
+msgstr "- Tema"
+
+#: id:15112
+msgid "Default theme"
+msgstr "Tema predeterminado"
+
+#: id:15200
+msgid "Last.fm"
+msgstr "Last.fm"
+
+#: id:15201
+msgid "Submit songs to Last.fm"
+msgstr "Enviar canciones a Last.fm"
+
+#: id:15202
+msgid "Last.fm username"
+msgstr "Usuario de Last.fm"
+
+#: id:15203
+msgid "Last.fm password"
+msgstr "Contraseña de Last.fm"
+
+#: id:15204
+msgid "Unable to handshake: sleeping..."
+msgstr "Imposible conectar: durmiendo..."
+
+#: id:15205
+msgid "Please update XBMC"
+msgstr "Por favor, actualice XBMC"
+
+#: id:15206
+msgid "Bad authorization: Check username and password"
+msgstr "Autorización incorrecta: compruebe usuario y contraseña"
+
+#: id:15207
+msgctxt "Auto context with id 15207"
+msgid "Connected"
+msgstr "Conectado"
+
+#: id:15208
+msgid "Not connected"
+msgstr "No conectado"
+
+#: id:15209
+msgid "Submit interval %i"
+msgstr "Intervalo de envío %i"
+
+#: id:15210
+msgid "Cached %i songs"
+msgstr "Almacenadas %i canciones"
+
+#: id:15211
+msgid "Submitting..."
+msgstr "Enviando..."
+
+#: id:15212
+msgid "Submitting in %i secs"
+msgstr "Enviando en %i segs"
+
+#: id:15213
+msgid "Play using..."
+msgstr "Reproducir usando..."
+
+#: id:15214
+msgid "Use smoothed A/V synchronization"
+msgstr "Usar sincronización A/V suavizada"
+
+#: id:15215
+msgid "Hide file names in thumbs view"
+msgstr "Ocultar nombres de archivo en vista de miniaturas"
+
+#: id:15216
+msgid "Play in party mode"
+msgstr "Reproducir en modo fiesta"
+
+#: id:15217
+msgid "Submit songs to Libre.fm"
+msgstr "Enviar canciones a Libre.fm"
+
+#: id:15218
+msgid "Libre.fm username"
+msgstr "Usuario de Libre.fm"
+
+#: id:15219
+msgid "Libre.fm password"
+msgstr "Contraseña de Libre.fm"
+
+#: id:15220
+msgid "Libre.fm"
+msgstr "Libre.fm"
+
+#: id:15221
+msgid "Song submission"
+msgstr "Envío de canción"
+
+#: id:15250
+msgid "Submit Last.fm radio to Last.fm"
+msgstr "Enviar datos de radio Last.fm a Last.fm"
+
+#: id:15251
+msgid "Connecting to Last.fm..."
+msgstr "Conectando a Last.fm..."
+
+#: id:15252
+msgid "Selecting station..."
+msgstr "Seleccionando emisora..."
+
+#: id:15253
+msgid "Search similar artists..."
+msgstr "Buscar intérpretes similares..."
+
+#: id:15254
+msgid "Search similar tags..."
+msgstr "Buscar géneros similares..."
+
+#: id:15255
+msgid "Your profile (%name%)"
+msgstr "Tu perfil (%name%)"
+
+#: id:15256
+msgid "Overall top tags"
+msgstr "Top global de géneros"
+
+#: id:15257
+msgid "Top artists for tag %name%"
+msgstr "Top intérpretes del género %name%"
+
+#: id:15258
+msgid "Top albums for tag %name%"
+msgstr "Top álbumes del género %name%"
+
+#: id:15259
+msgid "Top tracks for tag %name%"
+msgstr "Top canciones del género %name%"
+
+#: id:15260
+msgid "Listen to tag %name% Last.fm radio"
+msgstr "Oir el género %name% desde la radio Last.fm"
+
+#: id:15261
+msgid "Similar artists as %name%"
+msgstr "Intérpretes similares a %name%"
+
+#: id:15262
+msgid "Top %name% albums"
+msgstr "Top álbumes de %name%"
+
+#: id:15263
+msgid "Top %name% tracks"
+msgstr "Top canciones de %name%"
+
+#: id:15264
+msgid "Top %name% tags"
+msgstr "Top géneros de %name%"
+
+#: id:15265
+msgid "Biggest fans of %name%"
+msgstr "Mayores fans de %name%"
+
+#: id:15266
+msgid "Listen to %name% fans Last.fm radio"
+msgstr "Oir a fans de %name% desde la radio Last.fm"
+
+#: id:15267
+msgid "Listen to %name% similar artists Last.fm radio"
+msgstr "Oir artistas similares a %name% desde la radio Last.fm"
+
+#: id:15268
+msgid "Top artists for user %name%"
+msgstr "Top intérpretes del usuario %name%"
+
+#: id:15269
+msgid "Top albums for user %name%"
+msgstr "Top álbumes del usuario %name%"
+
+#: id:15270
+msgid "Top tracks for user %name%"
+msgstr "Top canciones del usuario %name%"
+
+#: id:15271
+msgid "Friends of user %name%"
+msgstr "Amigos del usuario %name%"
+
+#: id:15272
+msgid "Neighbours of user %name%"
+msgstr "Vecinos del usuario %name%"
+
+#: id:15273
+msgid "Weekly artist chart for %name%"
+msgstr "Gráfica semanal de intérprete para %name%"
+
+#: id:15274
+msgid "Weekly album chart for %name%"
+msgstr "Gráfica semanal de álbum para %name%"
+
+#: id:15275
+msgid "Weekly track chart for %name%"
+msgstr "Gráfica semanal de canciones para %name%"
+
+#: id:15276
+msgid "Listen to %name%'s neighbours Last.fm radio"
+msgstr "Oir a los vecinos de %name% desde la radio Last.fm"
+
+#: id:15277
+msgid "Listen to %name%'s personal Last.fm radio"
+msgstr "Oir la radio Last.fm personal de %name%"
+
+#: id:15278
+msgid "Listen to %name%'s mix Last.fm radio"
+msgstr "Oir el mix de %name% desde la radio Last.fm"
+
+#: id:15279
+msgid "Retrieving list from Last.fm..."
+msgstr "Obteniendo la lista desde Last.fm..."
+
+#: id:15280
+msgid "Can't retrieve list from Last.fm..."
+msgstr "No se puede obtener la lista desde Last.fm..."
+
+#: id:15281
+msgid "Enter an artist name to find related ones"
+msgstr "Introduzca un nombre de intérprete para buscar relacionados"
+
+#: id:15282
+msgid "Enter a tag name to find similar ones"
+msgstr "Introduzca un género para encontrar similares"
+
+#: id:15283
+msgid "Tracks recently listened by %name%"
+msgstr "Canciones escuchadas recientemente por %name%"
+
+#: id:15284
+msgid "Listen to %name%'s recommendations Last.fm radio"
+msgstr "Escuche recomendaciones de %name% en la radio Last.fm"
+
+#: id:15285
+msgid "Top tags for user %name%"
+msgstr "Top de etiquetas para el usuario %name%"
+
+#: id:15287
+msgid "Do you want to add the current track to your loved tracks?"
+msgstr "¿Desea añadir la pista actual a su lista de canciones favoritas?"
+
+#: id:15288
+msgid "Do you want to ban the current track?"
+msgstr "¿Desea prohibir la reproducción de la pista actual?"
+
+#: id:15289
+msgid "Added to your loved tracks: '%s'."
+msgstr "Se ha añadido a sus canciones favoritas: '%s'."
+
+#: id:15290
+msgid "Could not add '%s' to your loved tracks."
+msgstr "No se pudo añadir '%s' a sus canciones favoritas."
+
+#: id:15291
+msgid "Banned: '%s'."
+msgstr "Prohibida: '%s'."
+
+#: id:15292
+msgid "Could not ban '%s'."
+msgstr "No se pudo prohibir '%s'."
+
+#: id:15293
+msgid "Tracks recently loved by %name%"
+msgstr "Canciones favoritas recientemente por %name%"
+
+#: id:15294
+msgid "Tracks recently banned by %name%"
+msgstr "Canciones prohibidas recientemente por %name%"
+
+#: id:15295
+msgid "Remove from loved tracks"
+msgstr "Quitar de las canciones favoritas"
+
+#: id:15296
+msgid "Un-ban"
+msgstr "Quitar prohibición"
+
+#: id:15297
+msgid "Do you want to remove this track from your loved tracks?"
+msgstr "¿Desea quitar esta pista de sus canciones favoritas?"
+
+#: id:15298
+msgid "Do you want to un-ban this track?"
+msgstr "¿Desea quitar la prohibición de esta pista?"
+
+#: id:15300
+msgid "Path not found or invalid"
+msgstr "Ruta no encontrada o inválida"
+
+#: id:15301
+msgid "Could not connect to network server"
+msgstr "Imposible conectar al servidor"
+
+#: id:15302
+msgid "No servers found"
+msgstr "No se encontraron servidores"
+
+#: id:15303
+msgid "Workgroup not found"
+msgstr "Grupo de trabajo no encontrado"
+
+#: id:15310
+msgid "Opening multi-path source"
+msgstr "Abriendo marcador multi-directorio"
+
+#: id:15311
+msgid "Path:"
+msgstr "Ruta:"
+
+#: id:16000
+msgctxt "Auto context with id 16000"
+msgid "General"
+msgstr "General"
+
+#: id:16002
+msgid "Internet lookup"
+msgstr "Consulta en internet"
+
+#: id:16003
+msgid "Player"
+msgstr "Reproductor"
+
+#: id:16004
+msgid "Play media from disc"
+msgstr "Reproducir desde disco"
+
+#: id:16008
+msgid "Enter new title"
+msgstr "Introduzca nuevo título"
+
+#: id:16009
+msgid "Enter the movie name"
+msgstr "Introduzca el nombre de la película"
+
+#: id:16010
+msgid "Enter the profile name"
+msgstr "Introduzca el nombre del perfil"
+
+#: id:16011
+msgid "Enter the album name"
+msgstr "Introduzca el nombre del álbum"
+
+#: id:16012
+msgid "Enter the playlist name"
+msgstr "Introduzca el nombre de la lista de reproducción"
+
+#: id:16013
+msgid "Enter new filename"
+msgstr "Introduzca el nombre del nuevo archivo"
+
+#: id:16014
+msgid "Enter folder name"
+msgstr "Introduzca el nombre del directorio"
+
+#: id:16015
+msgid "Enter directory"
+msgstr "Introduzca el directorio"
+
+#: id:16016
+msgid "Available options: %A, %T, %N, %B, %D, %G, %Y, %F, %S"
+msgstr "Opciones disponibles: %A, %T, %N, %B, %D, %G, %Y, %F, %S"
+
+#: id:16017
+msgid "Enter search string"
+msgstr "Introduzca la cadena de búsqueda"
+
+#: id:16018
+msgctxt "Auto context with id 16018"
+msgid "None"
+msgstr "Ninguno"
+
+#: id:16019
+msgid "Auto select"
+msgstr "Selección autom."
+
+#: id:16020
+msgid "De-interlace"
+msgstr "Desentralazar"
+
+#: id:16021
+msgid "Bob"
+msgstr "Bob"
+
+#: id:16022
+msgid "Bob (inverted)"
+msgstr "Bob (Invertido)"
+
+#: id:16024
+msgid "Canceling..."
+msgstr "Cancelando..."
+
+#: id:16025
+msgid "Enter the artist name"
+msgstr "Introduzca el nombre del intérprete"
+
+#: id:16026
+msgid "Playback failed"
+msgstr "Reproducción de lista abortada"
+
+#: id:16027
+msgid "One or more items failed to play."
+msgstr "Uno o más elementos fallaron al reproducirlos."
+
+#: id:16028
+msgid "Enter value"
+msgstr "Introducir valor"
+
+#: id:16029
+msgid "Check the log file for details."
+msgstr "Compruebe el archivo de registro para detalles."
+
+#: id:16030
+msgid "Party mode aborted."
+msgstr "Modo fiesta abortado."
+
+#: id:16031
+msgid "No matching songs in the library."
+msgstr "No hay canciones coincidentes en la base de datos."
+
+#: id:16032
+msgid "Could not initialize database."
+msgstr "No se pudo inicializar la base de datos."
+
+#: id:16033
+msgid "Could not open database."
+msgstr "No se pudo abrir la base de datos."
+
+#: id:16034
+msgid "Could not get songs from database."
+msgstr "No se pudieron obtener canciones de la base de datos."
+
+#: id:16035
+msgid "Party mode playlist"
+msgstr "Lista de reproducción del modo fiesta"
+
+#: id:16036
+msgid "De-interlace (Half)"
+msgstr "Desentrelazar (Half)"
+
+#: id:16037
+msgid "Deinterlace video"
+msgstr ""
+
+#: id:16038
+msgid "Deinterlace method"
+msgstr ""
+
+#: id:16039
+msgctxt "Auto context with id 16039"
+msgid "Off"
+msgstr ""
+
+#: id:16040
+msgctxt "Auto context with id 16040"
+msgid "Auto"
+msgstr ""
+
+#: id:16041
+msgid "On"
+msgstr ""
+
+#: id:16100
+msgid "All Videos"
+msgstr "Todos los vídeos"
+
+#: id:16101
+msgid "Unwatched"
+msgstr "No vistos"
+
+#: id:16102
+msgid "Watched"
+msgstr "Vistos"
+
+#: id:16103
+msgid "Mark as watched"
+msgstr "Marcar como visto"
+
+#: id:16104
+msgid "Mark as unwatched"
+msgstr "Marcar como no visto"
+
+#: id:16105
+msgid "Edit title"
+msgstr "Editar título"
+
+#: id:16200
+msgid "Operation was aborted"
+msgstr "Operación abortada"
+
+#: id:16201
+msgid "Copy failed"
+msgstr "Fallo al copiar"
+
+#: id:16202
+msgid "Failed to copy at least one file"
+msgstr "Fallo al copiar al menos un archivo"
+
+#: id:16203
+msgid "Move failed"
+msgstr "Fallo al mover"
+
+#: id:16204
+msgid "Failed to move at least one file"
+msgstr "Fallo al mover al menos un archivo"
+
+#: id:16205
+msgid "Delete failed"
+msgstr "Fallo al borrar"
+
+#: id:16206
+msgid "Failed to delete at least one file"
+msgstr "Fallo al borrar al menos un archivo"
+
+#: id:16300
+msgid "Video scaling method"
+msgstr "Método de escalado de vídeo"
+
+#: id:16301
+msgid "Nearest neighbour"
+msgstr "Vecino más cercano"
+
+#: id:16302
+msgid "Bilinear"
+msgstr "Bilinear"
+
+#: id:16303
+msgctxt "Auto context with id 16303"
+msgid "Bicubic"
+msgstr "Bicúbico"
+
+#: id:16304
+msgid "Lanczos2"
+msgstr "Lanczos2"
+
+#: id:16305
+msgid "Lanczos3"
+msgstr "Lanczos3"
+
+#: id:16306
+msgid "Sinc8"
+msgstr "Sinc8"
+
+#: id:16307
+msgid "Bicubic (software)"
+msgstr "Bicúbico (software)"
+
+#: id:16308
+msgid "Lanczos (software)"
+msgstr "Lanczos (software)"
+
+#: id:16309
+msgid "Sinc (software)"
+msgstr "Sinc (software)"
+
+#: id:16310
+msgid "Temporal"
+msgstr "Temporal"
+
+#: id:16311
+msgid "Temporal/Spatial"
+msgstr "Temporal/Espacial"
+
+#: id:16312
+msgid "(VDPAU)Noise Reduction"
+msgstr "(VDPAU)Reducción de Ruído"
+
+#: id:16313
+msgid "(VDPAU)Sharpness"
+msgstr "(VDPAU)Agudeza"
+
+#: id:16314
+msgid "Inverse Telecine"
+msgstr "Telecine inverso"
+
+#: id:16315
+msgid "Lanczos3 optimized"
+msgstr "Lanczos3 optimizado"
+
+#: id:16316
+msgctxt "Auto context with id 16316"
+msgid "Auto"
+msgstr "Auto"
+
+#: id:16317
+msgid "Temporal (Half)"
+msgstr "Temporal (Medio)"
+
+#: id:16318
+msgid "Temporal/Spatial (Half)"
+msgstr "Temporal/Espacial (Medio)"
+
+#: id:16319
+msgid "DXVA"
+msgstr "DXVA"
+
+#: id:16320
+msgid "DXVA Bob"
+msgstr "DXVA Bob"
+
+#: id:16321
+msgid "DXVA Best"
+msgstr "DXVA Best"
+
+#: id:16322
+msgid "Spline36"
+msgstr "Spline36"
+
+#: id:16323
+msgid "Spline36 optimized"
+msgstr "Spline36 optimizado"
+
+#: id:16324
+msgid "Software Blend"
+msgstr ""
+
+#: id:16400
+msgid "Post-processing"
+msgstr "Post-procesamiento de vídeo"
+
+#: id:17500
+msgid "Display sleep timeout"
+msgstr "Mostrar la cuenta atrás para el reposo"
+
+#: id:19000
+msgid "Switch to channel"
+msgstr "Cambiar al canal"
+
+#: id:20000
+msgid "Saved music folder"
+msgstr "Directorio de grabación de CDs de audio"
+
+#: id:20001
+msgid "Use external DVD player"
+msgstr "Usar reproductor DVD externo"
+
+#: id:20002
+msgid "External DVD player"
+msgstr "Reproductor DVD externo"
+
+#: id:20003
+msgid "Trainers folder"
+msgstr "Directorio de trainers"
+
+#: id:20004
+msgid "Screenshot folder"
+msgstr "Directorio de instantáneas"
+
+#: id:20006
+msgid "Playlists folder"
+msgstr "Directorio de listas de reproducción"
+
+#: id:20007
+msgid "Recordings"
+msgstr "Grabaciones"
+
+#: id:20008
+msgid "Screenshots"
+msgstr "Instantáneas"
+
+#: id:20009
+msgid "Use XBMC"
+msgstr "Usar XBMC"
+
+#: id:20011
+msgid "Music playlists"
+msgstr "Listas rep. música"
+
+#: id:20012
+msgid "Video playlists"
+msgstr "Listas rep. vídeo"
+
+#: id:20013
+msgid "Do you wish to launch the game?"
+msgstr "¿Desea ejecutar el juego?"
+
+#: id:20014
+msgid "Sort by: Playlist"
+msgstr "Ordenar por: Lista repr."
+
+#: id:20015
+msgid "Remote thumb"
+msgstr "Miniatura IMDb"
+
+#: id:20016
+msgid "Current thumb"
+msgstr "Miniatura actual"
+
+#: id:20017
+msgid "Local thumb"
+msgstr "Miniatura local"
+
+#: id:20018
+msgid "No thumb"
+msgstr "Sin miniatura"
+
+#: id:20019
+msgid "Choose thumbnail"
+msgstr "Elija miniatura"
+
+#: id:20023
+msgid "Conflict"
+msgstr "Conflicto"
+
+#: id:20024
+msgid "Scan new"
+msgstr "Explorar nuevos"
+
+#: id:20025
+msgid "Scan all"
+msgstr "Explorar todo"
+
+#: id:20026
+msgid "Region"
+msgstr "Región"
+
+#: id:20037
+msgid "Summary"
+msgstr "Resumen"
+
+#: id:20038
+msgid "Lock music window"
+msgstr "Bloquear la ventana de música"
+
+#: id:20039
+msgid "Lock videos window"
+msgstr "Bloquear la ventana de vídeo"
+
+#: id:20040
+msgid "Lock pictures window"
+msgstr "Bloquear la ventana de imágenes"
+
+#: id:20041
+msgid "Lock programs & scripts windows"
+msgstr "Bloquear la ventana de programas y scripts"
+
+#: id:20042
+msgid "Lock file manager"
+msgstr "Bloquear el explorador de archivos"
+
+#: id:20043
+msgid "Lock settings"
+msgstr "Bloquear ajustes"
+
+#: id:20044
+msgid "Start fresh"
+msgstr "Inicio limpio"
+
+#: id:20045
+msgid "Enter master mode"
+msgstr "Entrar en modo maestro"
+
+#: id:20046
+msgid "Leave master mode"
+msgstr "Dejar modo maestro"
+
+#: id:20047
+msgid "Create profile '%s'?"
+msgstr "¿Crear perfil '%s'?"
+
+#: id:20048
+msgid "Start with fresh settings"
+msgstr "Iniciar con ajustes limpios"
+
+#: id:20049
+msgid "Best available"
+msgstr "La mejor disponible"
+
+#: id:20050
+msgid "Auto-switch between 16x9 and 4x3"
+msgstr "Cambio automático entre 16:9 y 4:3"
+
+#: id:20051
+msgid "Treat stacked files as single file"
+msgstr "Tratar archivos agrupados como un solo archivo"
+
+#: id:20052
+msgid "Caution"
+msgstr "Precaución"
+
+#: id:20053
+msgid "Left master mode"
+msgstr "Falta modo maestro"
+
+#: id:20054
+msgid "Entered master mode"
+msgstr "Se entró en modo maestro"
+
+#: id:20055
+msgid "Allmusic.com thumb"
+msgstr "Miniatura allmusic.com"
+
+#: id:20057
+msgid "Remove thumbnail"
+msgstr "Eliminar miniatura"
+
+#: id:20058
+msgid "Add profile..."
+msgstr "Añadir perfil..."
+
+#: id:20059
+msgid "Query info for all albums"
+msgstr "Obtener la información para todos los álbumes"
+
+#: id:20060
+msgctxt "Auto context with id 20060"
+msgid "Media info"
+msgstr "Info de medio"
+
+#: id:20061
+msgctxt "Auto context with id 20061"
+msgid "Separate"
+msgstr "Separado"
+
+#: id:20062
+msgid "Shares with default"
+msgstr "Recursos comp. por defecto"
+
+#: id:20063
+msgid "Shares with default (read only)"
+msgstr "Recursos comp. por defecto (sólo lectura)"
+
+#: id:20064
+msgid "Copy default"
+msgstr "Copiar por defecto"
+
+#: id:20065
+msgid "Profile picture"
+msgstr "Imagen de perfil"
+
+#: id:20066
+msgid "Lock preferences"
+msgstr "Preferencias de bloqueo"
+
+#: id:20067
+msgid "Edit profile"
+msgstr "Editar perfil"
+
+#: id:20068
+msgid "Profile lock"
+msgstr "Bloquear perfil"
+
+#: id:20069
+msgid "Could not create folder"
+msgstr "No se puede crear el directorio"
+
+#: id:20070
+msgid "Profile directory"
+msgstr "Directorio del perfil"
+
+#: id:20071
+msgid "Start with fresh media sources"
+msgstr "Comenzar con fuentes de medios limpias"
+
+#: id:20072
+msgid "Make sure the selected folder is writable"
+msgstr "Asegúrese de que el directorio seleccionable permite modificaciones"
+
+#: id:20073
+msgid "and that the new folder name is valid"
+msgstr "y que el nuevo directorio es válido"
+
+#: id:20074
+msgid "MPAA rating"
+msgstr "Calificación MPAA:"
+
+#: id:20075
+msgid "Enter master lock code"
+msgstr "Introduzca código de bloqueo maestro"
+
+#: id:20076
+msgid "Ask for master lock code on startup"
+msgstr "Preguntar el código de bloqueo maestro al iniciar"
+
+#: id:20077
+msgid "Skin settings"
+msgstr "Ajustes de skin"
+
+#: id:20078
+msgid "- no link set -"
+msgstr "- no hay enlace establecido -"
+
+#: id:20079
+msgid "Enable animations"
+msgstr "Habilitar animaciones"
+
+#: id:20080
+msgid "Disable RSS during music"
+msgstr "Deshabilitar RSS con la música"
+
+#: id:20081
+msgid "Enable shortcut buttons"
+msgstr "Habilitar accesos directos"
+
+#: id:20082
+msgid "Show programs in main menu"
+msgstr "Mostrar programas en menú principal"
+
+#: id:20083
+msgid "Show music info"
+msgstr "Mostrar información de música"
+
+#: id:20084
+msgid "Show weather info"
+msgstr "Mostrar información meteorológica"
+
+#: id:20085
+msgid "Show system info"
+msgstr "Mostrar información de sistema"
+
+#: id:20086
+msgid "Show available disc space C: E: F:"
+msgstr "Mostrar espacio disponible en C: E: F:"
+
+#: id:20087
+msgid "Show available disc space E: F: G:"
+msgstr "Mostrar espacio disponible en E: F: G:"
+
+#: id:20088
+msgid "Weather info"
+msgstr "Información meteorológica"
+
+#: id:20089
+msgid "Drive space free"
+msgstr "Espacio libre en disco"
+
+#: id:20090
+msgid "Enter the name of an existing share"
+msgstr "Introduzca el nombre de un recurso existente"
+
+#: id:20091
+msgid "Lock code"
+msgstr "Código de bloqueo"
+
+#: id:20092
+msgid "Load profile"
+msgstr "Cargar perfil"
+
+#: id:20093
+msgid "Profile name"
+msgstr "Nombre de perfil"
+
+#: id:20094
+msgctxt "Auto context with id 20094"
+msgid "Media sources"
+msgstr "Fuentes de medios"
+
+#: id:20095
+msgid "Enter profile lock code"
+msgstr "Introduzca código de bloqueo de perfil"
+
+#: id:20096
+msgctxt "Auto context with id 20096"
+msgid "Login screen"
+msgstr "Inicio de sesión"
+
+#: id:20097
+msgid "Fetching album info"
+msgstr "Obteniendo info del álbum"
+
+#: id:20098
+msgid "Fetching info for album"
+msgstr "Obteniendo info para el álbum"
+
+#: id:20099
+msgid "Can't rip CD or track while playing from CD"
+msgstr "No se puede copiar CD o pista mientras se reproduce el CD"
+
+#: id:20100
+msgid "Master lock code and settings"
+msgstr "Código y configuración del bloqueo maestro"
+
+#: id:20101
+msgid "Entering master lock code always enables master mode"
+msgstr "Introducir el código maestro siempre habilita el modo maestro"
+
+#: id:20102
+msgid "or copy from default?"
+msgstr "o copiarlos de ajustes predefinidos?"
+
+#: id:20103
+msgid "Save changes to profile?"
+msgstr "¿Guardar cambios al perfil?"
+
+#: id:20104
+msgid "Old settings found."
+msgstr "Encontrados ajustes antiguos."
+
+#: id:20105
+msgid "Do you want to use them?"
+msgstr "¿Deseas usarlos?"
+
+#: id:20106
+msgid "Old media sources found."
+msgstr "Encontradas fuentes de medios antiguos."
+
+#: id:20107
+msgid "Separate (locked)"
+msgstr "Separado (bloqueado)"
+
+#: id:20108
+msgid "Root"
+msgstr "Raíz"
+
+#: id:20109
+msgid "- Zoom"
+msgstr "- Zoom"
+
+#: id:20110
+msgid "UPnP settings"
+msgstr "Ajustes UPnP"
+
+#: id:20111
+msgid "Autostart UPnP client"
+msgstr "Inicio automático de cliente UPnP"
+
+#: id:20112
+msgid "Last login: %s"
+msgstr "Último inicio de sesión: %s"
+
+#: id:20113
+msgid "Never logged on"
+msgstr "Nunca ha iniciado sesión"
+
+#: id:20114
+msgid "Profile %i / %i"
+msgstr "Perfil %i / %i"
+
+#: id:20115
+msgid "User login / Select a profile"
+msgstr "Inicio de sesión de usuario / Selecciona un perfil"
+
+#: id:20116
+msgid "Use lock on login screen"
+msgstr "Usar bloqueo en pantalla de inicio de sesión"
+
+#: id:20117
+msgid "Invalid lock code."
+msgstr "Código de bloqueo no válido."
+
+#: id:20118
+msgid "This requires the master lock to be set."
+msgstr "Esto requiere asignar el bloqueo maestro."
+
+#: id:20119
+msgid "Would you like to set it now?"
+msgstr "Deseas hacerlo ahora?"
+
+#: id:20120
+msgid "Loading program information"
+msgstr "Cargando información de programa"
+
+#: id:20121
+msgid "Party on!"
+msgstr "¡Que empiece la fiesta!"
+
+#: id:20122
+msgid "True"
+msgstr "Sí"
+
+#: id:20123
+msgid "Mixing drinks"
+msgstr "Mezclando bebidas"
+
+#: id:20124
+msgid "Filling glasses"
+msgstr "Llenando vasos"
+
+#: id:20125
+msgid "Logged on as"
+msgstr "Iniciado como"
+
+#: id:20126
+msgid "Log off"
+msgstr "Cerrar sesión"
+
+#: id:20128
+msgid "Go to root"
+msgstr "Ir a la raíz"
+
+#: id:20129
+msgid "Weave"
+msgstr "Entramado"
+
+#: id:20130
+msgid "Weave (inverted)"
+msgstr "Entramado (invertido)"
+
+#: id:20131
+msgid "Blend"
+msgstr "Mezclado"
+
+#: id:20132
+msgid "Restart video"
+msgstr "Reiniciar vídeo"
+
+#: id:20133
+msgid "Edit network location"
+msgstr "Editar dirección de red"
+
+#: id:20134
+msgid "Remove network location"
+msgstr "Eliminar dirección de red"
+
+#: id:20135
+msgid "Do you want to scan the folder?"
+msgstr "¿Quieres realizar una exploración del directorio?"
+
+#: id:20136
+msgid "Memory unit"
+msgstr "Unidad de memoria"
+
+#: id:20137
+msgid "Memory unit mounted"
+msgstr "Unidad de memoria montada"
+
+#: id:20138
+msgid "Unable to mount memory unit"
+msgstr "Imposible montar unidad de memoria"
+
+#: id:20139
+msgid "In port %i, slot %i"
+msgstr "En puerto %i, bahía %i"
+
+#: id:20140
+msgid "Lock screensaver"
+msgstr "Bloquear salvapantallas"
+
+#: id:20141
+msgid "Set"
+msgstr "Configurar"
+
+#: id:20142
+msgctxt "Auto context with id 20142"
+msgid "Username"
+msgstr "Usuario"
+
+#: id:20143
+msgid "Enter password for"
+msgstr "Introduzca constraseña para"
+
+#: id:20144
+msgid "Shutdown timer"
+msgstr "Temporizador de apagado"
+
+#: id:20145
+msgid "Shutdown interval (in minutes)"
+msgstr "Intervalo de apagado (en minutos)"
+
+#: id:20146
+msgid "Started, shutdown in %im"
+msgstr "Iniciado, apagado en %im"
+
+#: id:20147
+msgid "Shutdown in 30 minutes"
+msgstr "Apagado en 30 minutos"
+
+#: id:20148
+msgid "Shutdown in 60 minutes"
+msgstr "Apagado en 60 minutos"
+
+#: id:20149
+msgid "Shutdown in 120 minutes"
+msgstr "Apagado en 120 minutos"
+
+#: id:20150
+msgid "Custom shutdown timer"
+msgstr "Apagado personalizado"
+
+#: id:20151
+msgid "Cancel shutdown timer"
+msgstr "Cancelar apagado automático"
+
+#: id:20152
+msgid "Lock preferences for %s"
+msgstr "Bloquear preferencias para %s"
+
+#: id:20153
+msgid "Browse..."
+msgstr "Explorar..."
+
+#: id:20154
+msgid "Summary information"
+msgstr "Información básica"
+
+#: id:20155
+msgid "Storage information"
+msgstr "Información de almacenamiento"
+
+#: id:20156
+msgid "Hard disk information"
+msgstr "Información de disco duro"
+
+#: id:20157
+msgid "DVD-ROM information"
+msgstr "Información de DVD-ROM"
+
+#: id:20158
+msgid "Network information"
+msgstr "Información de red"
+
+#: id:20159
+msgid "Video information"
+msgstr "Información de vídeo"
+
+#: id:20160
+msgid "Hardware information"
+msgstr "Información de hardware"
+
+#: id:20161
+msgid "Total"
+msgstr "Total"
+
+#: id:20162
+msgid "Used"
+msgstr "Usado"
+
+#: id:20163
+msgid "of"
+msgstr "de"
+
+#: id:20164
+msgid "Locking not supported"
+msgstr "Bloqueo no soportado"
+
+#: id:20165
+msgid "Not locked"
+msgstr "No bloqueado"
+
+#: id:20166
+msgid "Locked"
+msgstr "Bloqueado"
+
+#: id:20167
+msgid "Frozen"
+msgstr "Colgado"
+
+#: id:20168
+msgid "Requires reset"
+msgstr "Requiere reinicio"
+
+#: id:20169
+msgid "Week"
+msgstr "Semana"
+
+#: id:20170
+msgid "Line"
+msgstr "Línea"
+
+#: id:20171
+msgid "Windows network (SMB)"
+msgstr "Red Windows (SMB)"
+
+#: id:20172
+msgid "XBMSP server"
+msgstr "Servidor XBMSP"
+
+#: id:20173
+msgctxt "Auto context with id 20173"
+msgid "FTP server"
+msgstr "Servidor FTP"
+
+#: id:20174
+msgid "iTunes music share (DAAP)"
+msgstr "iTunes: música compartida (DAAP)"
+
+#: id:20175
+msgid "UPnP server"
+msgstr "Servidor UPnP"
+
+#: id:20176
+msgid "Show video info"
+msgstr "Mostrar información de vídeo"
+
+#: id:20177
+msgid "Done"
+msgstr "Hecho"
+
+#: id:20178
+msgid "Shift"
+msgstr "Mays."
+
+#: id:20179
+msgid "Caps Lock"
+msgstr "Bloq. Mays."
+
+#: id:20180
+msgid "Symbols"
+msgstr "Símbolos"
+
+#: id:20181
+msgid "Backspace"
+msgstr "Borrado"
+
+#: id:20182
+msgid "Space"
+msgstr "Espacio"
+
+#: id:20183
+msgid "Reload skin"
+msgstr "Recargar skin"
+
+#: id:20184
+msgid "Rotate pictures using EXIF information"
+msgstr "Rotar usando la información EXIF"
+
+#: id:20185
+msgid "Use poster view styles for TV shows"
+msgstr "Usar vistas de posters para series de TV"
+
+#: id:20186
+msgid "Please wait"
+msgstr "¡Espere"
+
+#: id:20187
+msgid "UPnP"
+msgstr ""
+
+#: id:20189
+msgid "Enable auto scrolling for plot & review"
+msgstr "Permitir desplazamiento automático para el argumento y la reseña"
+
+#: id:20190
+msgctxt "Auto context with id 20190"
+msgid "Custom"
+msgstr "Personalizado"
+
+#: id:20191
+msgid "Enable debug logging"
+msgstr "Habilitar trazas de depuración"
+
+#: id:20192
+msgid "Download additional information during updates"
+msgstr "Obtener la información del álbum cuando sea añadido"
+
+#: id:20193
+msgid "Default service for album information"
+msgstr "Servicio por defecto para la información de album"
+
+#: id:20194
+msgid "Default service for artist information"
+msgstr "Servicio por defecto para la información de música"
+
+#: id:20195
+msgid "Change scraper"
+msgstr "Cambiar scraper"
+
+#: id:20196
+msgid "Export music library"
+msgstr "Exportar la biblioteca de música"
+
+#: id:20197
+msgid "Import music library"
+msgstr "Importar la biblioteca de música"
+
+#: id:20198
+msgid "No artist found!"
+msgstr "¡No se encontraron artistas!"
+
+#: id:20199
+msgid "Downloading artist info failed"
+msgstr "Falló la descarga de información de artista"
+
+#: id:20250
+msgid "Party on! (videos)"
+msgstr "¡Que empiece la fiesta! (vídeos)"
+
+#: id:20251
+msgid "Mixing drinks (videos)"
+msgstr "Mezclando bebidas (vídeos)"
+
+#: id:20252
+msgid "Filling glasses (videos)"
+msgstr "Llenando vasos (vídeos)"
+
+#: id:20253
+msgid "WebDAV server (HTTP)"
+msgstr "Servidor WebDAV (HTTP)"
+
+#: id:20254
+msgid "WebDAV server (HTTPS)"
+msgstr "Servidor WebDAV (HTTPS)"
+
+#: id:20255
+msgid "First logon, edit your profile"
+msgstr "Inicia sesión y edita tu perfil"
+
+#: id:20256
+msgid "HTS Tvheadend client"
+msgstr "Cliente HTS Tvheadend"
+
+#: id:20257
+msgid "VDR Streamdev client"
+msgstr "Cliente VDR Streamdev"
+
+#: id:20258
+msgid "MythTV client"
+msgstr "Cliente MythTV"
+
+#: id:20259
+msgid "Network Filesystem (NFS)"
+msgstr "Network Filesystem (NFS)"
+
+#: id:20260
+msgid "Secure Shell (SSH/SFTP)"
+msgstr "Secure Shell (SSH/SFTP)"
+
+#: id:20261
+msgid "Apple Filing Protocol (AFP)"
+msgstr "Apple File Protocol (AFP)"
+
+#: id:20300
+msgid "Web server directory (HTTP)"
+msgstr "Directorio servidor web (HTTP)"
+
+#: id:20301
+msgid "Web server directory (HTTPS)"
+msgstr "Directorio servidor web (HTTPS)"
+
+#: id:20302
+msgid "Unable to write to folder:"
+msgstr "No se puede escribir en la carpeta:"
+
+#: id:20303
+msgid "Do you want to skip and proceed?"
+msgstr "¿Desea omitir y continuar?"
+
+#: id:20304
+msgid "RSS Feed"
+msgstr "Canal RSS"
+
+#: id:20307
+msgid "Secondary DNS"
+msgstr "DNS Secundario"
+
+#: id:20308
+msgid "DHCP server:"
+msgstr "Servidor DHCP:"
+
+#: id:20309
+msgid "Make new folder"
+msgstr "Crear nuevo directorio"
+
+#: id:20310
+msgid "Dim LCD on playback"
+msgstr "Atenuar LCD al reproducir"
+
+#: id:20311
+msgid "Unknown or onboard (protected)"
+msgstr "Desconocido o en placa (protegido)"
+
+#: id:20312
+msgid "Dim LCD on paused"
+msgstr "Atenuar LCD al pausar"
+
+#: id:20314
+msgid "Videos - Library"
+msgstr "Vídeos - Biblioteca"
+
+#: id:20316
+msgid "Sort by: ID"
+msgstr "Ordenar por: ID"
+
+#: id:20324
+msgid "Play part..."
+msgstr "Reproducir fragmento..."
+
+#: id:20325
+msgid "Calibration reset"
+msgstr "Reiniciar calibrado"
+
+#: id:20326
+msgid "This will reset the calibration values for %s"
+msgstr "Esto reiniciará los valores de calibración de %s"
+
+#: id:20327
+msgid "to it's default values."
+msgstr "a sus valores por defecto."
+
+#: id:20328
+msgid "Browse for destination"
+msgstr "Buscar destino"
+
+#: id:20329
+msgid "Movies are in separate folders that match the movie title"
+msgstr ""
+
+#: id:20330
+msgid "Use folder names for lookups"
+msgstr "Usar nombres de carpetas en búsquedas"
+
+#: id:20331
+msgctxt "Auto context with id 20331"
+msgid "File"
+msgstr "Archivo"
+
+#: id:20332
+msgid "Use file or folder names in lookups?"
+msgstr "¿Usar nombres de archivos o carpetas en búsquedas?"
+
+#: id:20333
+msgid "Set content"
+msgstr "Establecer el contenido"
+
+#: id:20334
+msgid "Folder"
+msgstr "Carpeta"
+
+#: id:20335
+msgid "Look for content recursively?"
+msgstr "¿Buscar contenido recursivamente?"
+
+#: id:20336
+msgid "Unlock sources"
+msgstr "Desbloquear fuentes"
+
+#: id:20337
+msgid "Actor"
+msgstr "Intérprete"
+
+#: id:20338
+msgid "Movie"
+msgstr "Película"
+
+#: id:20339
+msgid "Director"
+msgstr "Director"
+
+#: id:20340
+msgid "Do you want to remove all items within"
+msgstr "¿Deseas eliminar todos los elementos de"
+
+#: id:20341
+msgid "this path from the XBMC library?"
+msgstr "esta ruta de la base de datos?"
+
+#: id:20342
+msgctxt "Auto context with id 20342"
+msgid "Movies"
+msgstr "Películas"
+
+#: id:20343
+msgid "TV shows"
+msgstr "Series de TV"
+
+#: id:20344
+msgid "This directory contains"
+msgstr "Este directorio contiene"
+
+#: id:20345
+msgid "Run automated scan"
+msgstr "Ejecutar exploración automatizada"
+
+#: id:20346
+msgid "Scan recursively"
+msgstr "Explorar recursivamente"
+
+#: id:20347
+msgid "as"
+msgstr "como"
+
+#: id:20348
+msgid "Directors"
+msgstr "Directores"
+
+#: id:20349
+msgid "No video files found in this path!"
+msgstr "¡No se han encontrado vídeos en esta ruta!"
+
+#: id:20350
+msgid "votes"
+msgstr "votos"
+
+#: id:20351
+msgid "TV show information"
+msgstr "Información de serie de TV"
+
+#: id:20352
+msgid "Episode information"
+msgstr "Información de episodio"
+
+#: id:20353
+msgid "Loading TV show details"
+msgstr "Cargando detalles de serie de TV"
+
+#: id:20354
+msgid "Fetching episode guide"
+msgstr "Obteniendo guía de episodios"
+
+#: id:20355
+msgid "Loading info for episodes in directory"
+msgstr "Cargando info de episodios en directorio"
+
+#: id:20356
+msgid "Select TV show:"
+msgstr "Seleccione serie de TV:"
+
+#: id:20357
+msgid "Enter the TV show name"
+msgstr "Introduzca el nombre de serie de TV"
+
+#: id:20358
+msgid "Season %i"
+msgstr "Temporada %i"
+
+#: id:20359
+msgid "Episode"
+msgstr "Episodio"
+
+#: id:20360
+msgid "Episodes"
+msgstr "Episodios"
+
+#: id:20361
+msgid "Loading episode details"
+msgstr "Cargando detalles del episodio"
+
+#: id:20362
+msgid "Remove episode from library"
+msgstr "Eliminar episodio de biblioteca"
+
+#: id:20363
+msgid "Remove TV show from library"
+msgstr "Eliminar serie de TV de la biblioteca"
+
+#: id:20364
+msgid "TV show"
+msgstr "Serie de TV"
+
+#: id:20365
+msgid "Episode plot"
+msgstr "Argumento del episodio"
+
+#: id:20366
+msgid "* All seasons"
+msgstr "* Todas las temporadas"
+
+#: id:20367
+msgid "Hide watched"
+msgstr "Ocultar los vistos"
+
+#: id:20368
+msgid "Prod code"
+msgstr "Código de Prod."
+
+#: id:20369
+msgid "Show plot for unwatched items"
+msgstr "Mostrar el argumento de los elementos no vistos"
+
+#: id:20370
+msgid "* Hidden to prevent spoilers *"
+msgstr "* Oculto para prevenir desenlaces *"
+
+#: id:20371
+msgid "Set season thumb"
+msgstr "Establecer miniatura de la temporada"
+
+#: id:20372
+msgid "Season image"
+msgstr "Imagen de la temporada"
+
+#: id:20373
+msgid "Season"
+msgstr "Temporada"
+
+#: id:20374
+msgid "Downloading movie information"
+msgstr "Descargando información de vídeo"
+
+#: id:20375
+msgid "Unassign content"
+msgstr "Desasignar contenido"
+
+#: id:20376
+msgid "Original title"
+msgstr "Título original"
+
+#: id:20377
+msgid "Refresh TV show information"
+msgstr "Actualizar información de serie de TV"
+
+#: id:20378
+msgid "Refresh info for all episodes?"
+msgstr "¿Actualizar información de todos los episodios?"
+
+#: id:20379
+msgid "Selected folder contains a single TV show"
+msgstr "La carpeta seleccionada contiene una única serie de TV"
+
+#: id:20380
+msgid "Exclude selected folder from scans"
+msgstr "Excluir directorio de la exploración"
+
+#: id:20381
+msgid "Specials"
+msgstr "Especiales"
+
+#: id:20382
+msgid "Automatically grab season thumbs"
+msgstr "Obtener automáticamente las miniaturas de temporada"
+
+#: id:20383
+msgid "Selected folder contains a single video"
+msgstr "El directorio contiene un solo vídeo"
+
+#: id:20384
+msgid "Link to TV show"
+msgstr "Enlace a serie de TV"
+
+#: id:20385
+msgid "Remove link to TV show"
+msgstr "Eliminar enlace a serie de TV"
+
+#: id:20386
+msgid "Recently added movies"
+msgstr "Películas añadidas recientemente"
+
+#: id:20387
+msgid "Recently added episodes"
+msgstr "Episodios añadidos recientemente"
+
+#: id:20388
+msgid "Studios"
+msgstr "Estudios"
+
+#: id:20389
+msgid "Music videos"
+msgstr "Vídeoclips"
+
+#: id:20390
+msgid "Recently added music videos"
+msgstr "Vídeoclips añadidos recientemente"
+
+#: id:20391
+msgid "Music video"
+msgstr "Vídeoclip"
+
+#: id:20392
+msgid "Remove music video from library"
+msgstr "Eliminar videoclip de la biblioteca"
+
+#: id:20393
+msgctxt "Auto context with id 20393"
+msgid "Music video information"
+msgstr "Información de videoclip"
+
+#: id:20394
+msgid "Loading music video information"
+msgstr "Cargando información de videoclip"
+
+#: id:20395
+msgid "Mixed"
+msgstr "Mezclado"
+
+#: id:20396
+msgid "Go to albums by artist"
+msgstr "Ir a álbumes por artista"
+
+#: id:20397
+msgid "Go to album"
+msgstr "Ir al álbum"
+
+#: id:20398
+msgid "Play song"
+msgstr "Reproducir canción"
+
+#: id:20399
+msgid "Go to music videos from album"
+msgstr "Ir a videoclips desde el álbum"
+
+#: id:20400
+msgid "Go to music videos by artist"
+msgstr "Ir a videoclips por artista"
+
+#: id:20401
+msgid "Play music video"
+msgstr "Reproducir videoclip"
+
+#: id:20402
+msgid "Download actor thumbnails when adding to library"
+msgstr "Obtener automáticamente las miniaturas de actor"
+
+#: id:20403
+msgid "Set actor thumb"
+msgstr "Establecer miniatura de actor"
+
+#: id:20405
+msgid "Remove episode bookmark"
+msgstr "Eliminar marcador de episodio"
+
+#: id:20406
+msgid "Set episode bookmark"
+msgstr "Establecer marcador de episodio"
+
+#: id:20407
+msgid "Scraper settings"
+msgstr "Configuración del scraper"
+
+#: id:20408
+msgid "Downloading music video information"
+msgstr "Descargando información del videoclip"
+
+#: id:20409
+msgid "Downloading TV show information"
+msgstr "Descargando información de serie de TV"
+
+#: id:20410
+msgid "Trailer"
+msgstr "Trailer"
+
+#: id:20411
+msgid "Flatten"
+msgstr "Acoplar"
+
+#: id:20412
+msgid "Flatten TV shows"
+msgstr "Acoplar series de TV"
+
+#: id:20413
+msgid "Get fanart"
+msgstr "Descargar fanart"
+
+#: id:20414
+msgid "Show Fanart in video and music libraries"
+msgstr "Mostrar fanarts en biblioteca de música y vídeo"
+
+#: id:20415
+msgid "Scanning for new content"
+msgstr "Buscando contenido nuevo"
+
+#: id:20416
+msgid "First aired"
+msgstr "Emisión"
+
+#: id:20417
+msgid "Writer"
+msgstr "Escritor"
+
+#: id:20419
+msgid "Replace file names with library titles"
+msgstr "Mostrar datos de media en el modo de Archivos"
+
+#: id:20420
+msgctxt "Auto context with id 20420"
+msgid "Never"
+msgstr "Nunca"
+
+#: id:20421
+msgid "If only one season"
+msgstr "Si hay sólo una temporada"
+
+#: id:20422
+msgid "Always"
+msgstr "Siempre"
+
+#: id:20423
+msgid "Has trailer"
+msgstr "Tiene trailer"
+
+#: id:20424
+msgid "False"
+msgstr "Falso"
+
+#: id:20425
+msgid "Fanart slideshow"
+msgstr "Presentación de fanart"
+
+#: id:20426
+msgid "Export to a single file or separate"
+msgstr "¿Exportar a un sólo archivo o separar"
+
+#: id:20427
+msgid "files per entry?"
+msgstr "archivos por entrada?"
+
+#: id:20428
+msgid "Single file"
+msgstr "Un sólo archivo"
+
+#: id:20429
+msgctxt "Auto context with id 20429"
+msgid "Separate"
+msgstr "Separar"
+
+#: id:20430
+msgid "Export thumbnails and fanart?"
+msgstr "¿Exportar miniaturas y fanart?"
+
+#: id:20431
+msgid "Overwrite old files?"
+msgstr "¿Sobreescribir archivos antiguos?"
+
+#: id:20432
+msgid "Exclude path from library updates"
+msgstr "Excluir ruta de actualizaciones de biblioteca"
+
+#: id:20433
+msgid "Extract thumbnails and video information"
+msgstr "Extraer los metadatos de información del medio"
+
+#: id:20434
+msgid "Sets"
+msgstr "Colecciones"
+
+#: id:20435
+msgid "Set movieset thumb"
+msgstr "Fijar miniaturas de películas"
+
+#: id:20436
+msgid "Export actor thumbs?"
+msgstr "Exportar miniaturas de actor"
+
+#: id:20437
+msgid "Choose fanart"
+msgstr "Elegir fanart"
+
+#: id:20438
+msgid "Local fanart"
+msgstr "Fanart local"
+
+#: id:20439
+msgid "No fanart"
+msgstr "Sin fanart"
+
+#: id:20440
+msgid "Current fanart"
+msgstr "Fanart actual"
+
+#: id:20441
+msgid "Remote fanart"
+msgstr "Fanart remoto"
+
+#: id:20442
+msgid "Change content"
+msgstr "Cambiar el contenido"
+
+#: id:20443
+msgid "Do you want to refresh info for all"
+msgstr "¿Desea actualizar la información para todos"
+
+#: id:20444
+msgid "items within this path?"
+msgstr "los elementos dentro de esta ruta?"
+
+#: id:20445
+msgid "Fanart"
+msgstr "Fanart"
+
+#: id:20446
+msgid "Locally stored information found."
+msgstr "Se ha encontrado información ya guardada."
+
+#: id:20447
+msgid "Ignore and refresh from internet?"
+msgstr "¿Desea ignorarla y actualizarla de Internet?"
+
+#: id:20448
+msgid "Could not download information"
+msgstr "No se ha podido descargar la información."
+
+#: id:20449
+msgid "Unable to connect to remote server"
+msgstr "No se puede conectar al servidor remoto"
+
+#: id:20450
+msgid "Would you like to continue scanning?"
+msgstr "¿Desea continuar escaneando?"
+
+#: id:20451
+msgid "Countries"
+msgstr "Países"
+
+#: id:20452
+msgid "episode"
+msgstr "episodio"
+
+#: id:20453
+msgid "episodes"
+msgstr "episodios"
+
+#: id:20454
+msgid "Listener"
+msgstr "Oyente"
+
+#: id:20455
+msgid "Listeners"
+msgstr "Oyentes"
+
+#: id:20456
+msgid "Set movieset fanart"
+msgstr "Fijar fanart de Colección"
+
+#: id:20457
+msgid "Movie set"
+msgstr "Colección de Películas"
+
+#: id:20458
+msgid "Group movies in sets"
+msgstr ""
+
+#: id:21330
+msgid "Show hidden files and directories"
+msgstr "Mostrar archivos y directorios ocultos"
+
+#: id:21331
+msgid "TuxBox client"
+msgstr "Cliente TuxBox"
+
+#: id:21332
+msgid "WARNING: Target TuxBox device is in recording-mode!"
+msgstr "¡AVISO: El dispositivo TuxBox está en Modo-Grabación!"
+
+#: id:21333
+msgid "The stream will be stopped!"
+msgstr "¡El medio se detendrá!"
+
+#: id:21334
+msgid "Zap to channel: %s failed!"
+msgstr "Cambio al canal: %s fallido!"
+
+#: id:21335
+msgid "Are you sure to start the stream?"
+msgstr "¿Seguro que desea iniciar el medio?"
+
+#: id:21336
+msgid "Connecting to: %s"
+msgstr "Conectando a: %s"
+
+#: id:21337
+msgid "TuxBox device"
+msgstr "Dispositivo TuxBox"
+
+#: id:21359
+msgid "Add media share..."
+msgstr "Añadir recurso compartido..."
+
+#: id:21360
+msgid "Share video and music libraries through UPnP"
+msgstr "Compartir las bibliotecas de vídeo y música a través de UPnP"
+
+#: id:21364
+msgid "Edit media share"
+msgstr "Editar recurso compartido"
+
+#: id:21365
+msgid "Remove media share"
+msgstr "Eliminar recurso compartido"
+
+#: id:21366
+msgid "Subtitle folder"
+msgstr "Directorio de los subtítulos"
+
+#: id:21367
+msgid "Movie & alternate subtitle directory"
+msgstr "Directorio de los subtítulos de películas y otros"
+
+#: id:21368
+msgid "Override ASS/SSA subtitles fonts"
+msgstr ""
+
+#: id:21369
+msgid "Enable mouse and Touch Screen support"
+msgstr "Habilitar el ratón"
+
+#: id:21370
+msgid "Play navigation sounds during media playback"
+msgstr "Reproducir sonidos de navegación durante reproducción"
+
+#: id:21371
+msgid "Thumbnail"
+msgstr "Miniatura"
+
+#: id:21372
+msgid "Forced DVD player region"
+msgstr "Forzar región del reproductor DVD"
+
+#: id:21373
+msgid "Video output"
+msgstr "Hardware de vídeo"
+
+#: id:21374
+msgid "Video aspect"
+msgstr "Aspecto de vídeo"
+
+#: id:21375
+msgctxt "Auto context with id 21375"
+msgid "Normal"
+msgstr "Normal"
+
+#: id:21376
+msgid "Letterbox"
+msgstr "Panorámica en 4:3 (Letterbox)"
+
+#: id:21377
+msgid "Widescreen"
+msgstr "Panorámica"
+
+#: id:21378
+msgid "Enable 480p"
+msgstr "Habilitar 480p"
+
+#: id:21379
+msgid "Enable 720p"
+msgstr "Habilitar 720p"
+
+#: id:21380
+msgid "Enable 1080i"
+msgstr "Habilitar 1080i"
+
+#: id:21381
+msgid "Enter name of new playlist"
+msgstr "Introduzca nombre de nueva lista de rep."
+
+#: id:21382
+msgid "Show \"Add source\" buttons in file lists"
+msgstr "Mostrar \"Añadir fuente\" en las listas de archivos"
+
+#: id:21383
+msgid "Enable scrollbars"
+msgstr "Habilitar barras de desplazamiento"
+
+#: id:21384
+msgid "Make watched filtering a toggle in video library"
+msgstr "Convertir el filtro mostrado en una opción de la biblioteca de vídeo"
+
+#: id:21385
+msgctxt "Auto context with id 21385"
+msgid "Open"
+msgstr "Abierto"
+
+#: id:21386
+msgid "Acoustic management level"
+msgstr "Nivel de gestión acústica"
+
+#: id:21387
+msgid "Fast"
+msgstr "Rápido"
+
+#: id:21388
+msgid "Quiet"
+msgstr "Silencioso"
+
+#: id:21389
+msgid "Enable custom background"
+msgstr "Habilitar fondo personalizado"
+
+#: id:21390
+msgid "Power management level"
+msgstr "Nivel de gestión de energía"
+
+#: id:21391
+msgid "High power"
+msgstr "Energía alta"
+
+#: id:21392
+msgid "Low power"
+msgstr "Energía baja"
+
+#: id:21393
+msgid "High standby"
+msgstr "Standby alto"
+
+#: id:21394
+msgid "Low standby"
+msgstr "Standby bajo"
+
+#: id:21395
+msgid "Unable to cache files bigger than 4GB"
+msgstr "No se pueden almacenar archivos mayores de 4 GB"
+
+#: id:21396
+msgid "Chapter"
+msgstr "Capítulo"
+
+#: id:21397
+msgid "High quality pixel shader v2"
+msgstr "Sombreado de píxeles de alta calidad v2"
+
+#: id:21398
+msgid "Enable playlist at startup"
+msgstr "Habilitar la lista de reproducción al inicio"
+
+#: id:21399
+msgid "Use tween animations"
+msgstr "Usar animaciones con interpolado"
+
+#: id:21400
+msgid "contains"
+msgstr "contiene"
+
+#: id:21401
+msgid "does not contain"
+msgstr "no contiene"
+
+#: id:21402
+msgid "is"
+msgstr "es"
+
+#: id:21403
+msgid "is not"
+msgstr "no es"
+
+#: id:21404
+msgid "starts with"
+msgstr "empieza por"
+
+#: id:21405
+msgid "ends with"
+msgstr "termina con"
+
+#: id:21406
+msgid "greater than"
+msgstr "mayor que"
+
+#: id:21407
+msgid "less than"
+msgstr "menor que"
+
+#: id:21408
+msgid "after"
+msgstr "después"
+
+#: id:21409
+msgid "before"
+msgstr "antes"
+
+#: id:21410
+msgid "in the last"
+msgstr "en los últimos"
+
+#: id:21411
+msgid "not in the last"
+msgstr "no en los últimos"
+
+#: id:21412
+msgid "Scrapers"
+msgstr "Scrapers"
+
+#: id:21413
+msgid "Default movie scraper"
+msgstr "Scraper por defecto para películas"
+
+#: id:21414
+msgid "Default tvshow scraper"
+msgstr "Scraper por defecto para series"
+
+#: id:21415
+msgid "Default music video scraper"
+msgstr "Scraper por defecto para vídeos musicales"
+
+#: id:21416
+msgid "Enable fallback based on scraper language"
+msgstr "Habilitar contenido basado en el idioma del scraper"
+
+#: id:21417
+msgid "- Settings"
+msgstr "- Configuración"
+
+#: id:21418
+msgid "Multilingual"
+msgstr "Multi-idioma"
+
+#: id:21419
+msgid "No scrapers present"
+msgstr "No hay scrapers"
+
+#: id:21420
+msgid "Value to match"
+msgstr "Valor a encontrar"
+
+#: id:21421
+msgid "Smart playlist rule"
+msgstr "Regla de lista de reproducción inteligente"
+
+#: id:21422
+msgid "Match items where"
+msgstr "Encontrar elementos donde"
+
+#: id:21423
+msgid "New rule..."
+msgstr "Nueva regla..."
+
+#: id:21424
+msgid "Items must match"
+msgstr "Los elementos deben coincidir con"
+
+#: id:21425
+msgid "all of the rules"
+msgstr "todas las reglas"
+
+#: id:21426
+msgid "one or more of the rules"
+msgstr "una o más reglas"
+
+#: id:21427
+msgid "Limit to"
+msgstr "Limitar a"
+
+#: id:21428
+msgid "No limit"
+msgstr "Sin límite"
+
+#: id:21429
+msgid "Order by"
+msgstr "Ordenar por"
+
+#: id:21430
+msgid "ascending"
+msgstr "ascendente"
+
+#: id:21431
+msgid "descending"
+msgstr "descendente"
+
+#: id:21432
+msgid "Edit smart playlist"
+msgstr "Editar lista de reproducción inteligente"
+
+#: id:21433
+msgid "Name of the playlist"
+msgstr "Nombre de la lista de reproducción"
+
+#: id:21434
+msgid "Find items where"
+msgstr "Encontrar elementos que coincidan"
+
+#: id:21435
+msgid "Edit"
+msgstr "- Editar"
+
+#: id:21436
+msgid "%i items"
+msgstr "%i elementos"
+
+#: id:21437
+msgid "New smart playlist..."
+msgstr "Nueva lista de reproducción inteligente..."
+
+#: id:21438
+msgid "%c Drive"
+msgstr "Unidad %c"
+
+#: id:21439
+msgid "Edit party mode rules"
+msgstr "Editar reglas del modo fiesta"
+
+#: id:21440
+msgid "Home folder"
+msgstr "Directorio de inicio"
+
+#: id:21441
+msgid "Watched count"
+msgstr "Veces visto"
+
+#: id:21442
+msgid "Episode title"
+msgstr "Título del episodio"
+
+#: id:21443
+msgid "Video resolution"
+msgstr "Resolución de vídeo"
+
+#: id:21444
+msgid "Audio channels"
+msgstr "Canales de audio"
+
+#: id:21445
+msgid "Video codec"
+msgstr "Códec de vídeo"
+
+#: id:21446
+msgid "Audio codec"
+msgstr "Códec de audio"
+
+#: id:21447
+msgid "Audio language"
+msgstr "Idioma de audio"
+
+#: id:21448
+msgid "Subtitle language"
+msgstr "Idioma de subtítulos"
+
+#: id:21449
+msgid "Remote control sends keyboard presses"
+msgstr "El mando a distancia envía pulsaciones de teclado"
+
+#: id:21450
+msgid "- Edit"
+msgstr "- Editar"
+
+#: id:21451
+msgid "Internet connection required."
+msgstr "Se necesita conexión a Internet."
+
+#: id:21452
+msgid "Get More..."
+msgstr "Conseguir más..."
+
+#: id:21453
+msgid "Root filesystem"
+msgstr "Raíz del sistema de archivos"
+
+#: id:21454
+msgid "Cache full"
+msgstr ""
+
+#: id:21455
+msgid "Cache filled before reaching required amount for continous playback"
+msgstr ""
+
+#: id:21460
+msgid "Subtitle location"
+msgstr "Subtitle location"
+
+#: id:21461
+msgid "Fixed"
+msgstr "Fijo"
+
+#: id:21462
+msgid "Bottom of video"
+msgstr "Pie de vídeo"
+
+#: id:21463
+msgid "Below video"
+msgstr "Debajo del vídeo"
+
+#: id:21464
+msgid "Top of video"
+msgstr "Arriba del vídeo"
+
+#: id:21465
+msgid "Above video"
+msgstr "Encima del vídeo"
+
+#: id:21800
+msgid "File name"
+msgstr "Nombre de archivo"
+
+#: id:21801
+msgid "File path"
+msgstr "Ruta de archivo"
+
+#: id:21802
+msgid "File size"
+msgstr "Tamaño de archivo"
+
+#: id:21803
+msgid "File date/time"
+msgstr "Fecha/hora de archivo"
+
+#: id:21804
+msgid "Slide index"
+msgstr "Índice de diapositivas"
+
+#: id:21805
+msgctxt "Auto context with id 21805"
+msgid "Resolution"
+msgstr "Resolución"
+
+#: id:21806
+msgctxt "Auto context with id 21806"
+msgid "Comment"
+msgstr "Comentario"
+
+#: id:21807
+msgid "Colour/B&W"
+msgstr "Color/BN"
+
+#: id:21808
+msgid "JPEG process"
+msgstr "Procesado JPEG"
+
+#: id:21820
+msgid "Date/Time"
+msgstr "Fecha/Hora"
+
+#: id:21821
+msgid "Description"
+msgstr "Descripción"
+
+#: id:21822
+msgid "Camera make"
+msgstr "Fabricante de cámara"
+
+#: id:21823
+msgid "Camera model"
+msgstr "Modelo de cámara"
+
+#: id:21824
+msgid "EXIF comment"
+msgstr "Comentario EXIF"
+
+#: id:21825
+msgid "Firmware"
+msgstr "Firmware"
+
+#: id:21826
+msgid "Aperture"
+msgstr "Apertura"
+
+#: id:21827
+msgid "Focal length"
+msgstr "Longitud focal"
+
+#: id:21828
+msgid "Focus distance"
+msgstr "Distancia enfoque"
+
+#: id:21829
+msgid "Exposure"
+msgstr "Exposición"
+
+#: id:21830
+msgid "Exposure time"
+msgstr "Tiempo de exposición"
+
+#: id:21831
+msgid "Exposure bias"
+msgstr "Polarización de exposición"
+
+#: id:21832
+msgid "Exposure mode"
+msgstr "Modo de exposición"
+
+#: id:21833
+msgid "Flash used"
+msgstr "Flash usado"
+
+#: id:21834
+msgid "White-balance"
+msgstr "Balance de blancos"
+
+#: id:21835
+msgid "Light source"
+msgstr "Fuente de luz"
+
+#: id:21836
+msgid "Metering mode"
+msgstr "Modo de medición"
+
+#: id:21837
+msgid "ISO"
+msgstr "ISO"
+
+#: id:21838
+msgid "Digital zoom"
+msgstr "Zoom digital"
+
+#: id:21839
+msgid "CCD width"
+msgstr "Ancho CCD"
+
+#: id:21840
+msgid "GPS latitude"
+msgstr "Latitud GPS"
+
+#: id:21841
+msgid "GPS longitude"
+msgstr "Longitud GPS"
+
+#: id:21842
+msgid "GPS altitude"
+msgstr "Altitud GPS"
+
+#: id:21843
+msgid "Orientation"
+msgstr "Orientación"
+
+#: id:21860
+msgid "Supplemental categories"
+msgstr "Categorías complementarias"
+
+#: id:21861
+msgid "Keywords"
+msgstr "Palabras clave"
+
+#: id:21862
+msgid "Caption"
+msgstr "Leyenda"
+
+#: id:21863
+msgid "Author"
+msgstr "Autor"
+
+#: id:21864
+msgid "Headline"
+msgstr "Titular"
+
+#: id:21865
+msgid "Special instructions"
+msgstr "Instrucciones especiales"
+
+#: id:21866
+msgid "Category"
+msgstr "Categoría"
+
+#: id:21867
+msgid "Byline"
+msgstr "Línea de autor"
+
+#: id:21868
+msgid "Byline title"
+msgstr "Título línea de autor"
+
+#: id:21869
+msgid "Credit"
+msgstr "Crédito"
+
+#: id:21870
+msgid "Source"
+msgstr "Fuente"
+
+#: id:21871
+msgid "Copyright notice"
+msgstr "Información de copyright"
+
+#: id:21872
+msgid "Object name"
+msgstr "Nombre de objeto"
+
+#: id:21873
+msgid "City"
+msgstr "Ciudad"
+
+#: id:21874
+msgid "State"
+msgstr "Estado"
+
+#: id:21875
+msgctxt "Auto context with id 21875"
+msgid "Country"
+msgstr "País"
+
+#: id:21876
+msgid "Original Tx Reference"
+msgstr "Referencia Tx Original"
+
+#: id:21877
+msgid "Date created"
+msgstr "Fecha de creación"
+
+#: id:21878
+msgid "Copyright flag"
+msgstr "Marca copyright"
+
+#: id:21879
+msgid "Country code"
+msgstr "Código de país"
+
+#: id:21880
+msgid "Reference service"
+msgstr "Servicio referencia"
+
+#: id:21881
+msgid "Allow control of XBMC via UPnP"
+msgstr "Permitir el control de XBMC vía UPnP"
+
+#: id:21882
+msgid "Attempt to skip introduction before DVD menu"
+msgstr "Intentar saltar la introducción previa al menú DVD"
+
+#: id:21883
+msgid "Saved music"
+msgstr "Música guardada"
+
+#: id:21884
+msgid "Query info for all artists"
+msgstr "Solicitar información para todos los artistas"
+
+#: id:21885
+msgid "Downloading album information"
+msgstr "Descargando información de álbum"
+
+#: id:21886
+msgid "Downloading artist information"
+msgstr "Descargando información de artista"
+
+#: id:21887
+msgid "Biography"
+msgstr "Biografía"
+
+#: id:21888
+msgid "Discography"
+msgstr "Discografía"
+
+#: id:21889
+msgid "Searching artist"
+msgstr "Buscando artista"
+
+#: id:21890
+msgid "Select artist"
+msgstr "Seleccionar artista"
+
+#: id:21891
+msgctxt "Auto context with id 21891"
+msgid "Artist information"
+msgstr "Información de artista"
+
+#: id:21892
+msgid "Instruments"
+msgstr "Instrumentos"
+
+#: id:21893
+msgid "Born"
+msgstr "Nacido"
+
+#: id:21894
+msgid "Formed"
+msgstr "Formado"
+
+#: id:21895
+msgid "Themes"
+msgstr "Temas"
+
+#: id:21896
+msgid "Disbanded"
+msgstr "Separado"
+
+#: id:21897
+msgid "Died"
+msgstr "Muerto"
+
+#: id:21898
+msgid "Years active"
+msgstr "Años activo"
+
+#: id:21899
+msgid "Label"
+msgstr "Firma"
+
+#: id:21900
+msgid "Born/Formed"
+msgstr "Nacido/Formado"
+
+#: id:22000
+msgid "Update library on startup"
+msgstr "Actualizar la biblioteca en el arranque"
+
+#: id:22001
+msgid "Hide progress of library updates"
+msgstr "Ocultar el progreso de actualización de la biblioteca"
+
+#: id:22002
+msgid "- DNS suffix"
+msgstr "- Sufijo DNS"
+
+#: id:22003
+msgid "%2.3fs"
+msgstr "%2.3fs"
+
+#: id:22004
+msgid "Delayed by: %2.3fs"
+msgstr "Retrasado en: %2.3fs"
+
+#: id:22005
+msgid "Ahead by: %2.3fs"
+msgstr "Adelantado en: %2.3fs"
+
+#: id:22006
+msgid "Subtitle offset"
+msgstr "Retraso de subtitulos"
+
+#: id:22007
+msgid "OpenGL vendor:"
+msgstr "Distribuidor OpenGL:"
+
+#: id:22008
+msgid "OpenGL renderer:"
+msgstr "Renderizador OpenGL:"
+
+#: id:22009
+msgid "OpenGL version:"
+msgstr "Versión OpenGL:"
+
+#: id:22010
+msgid "GPU temperature:"
+msgstr "Temperatura de GPU:"
+
+#: id:22011
+msgid "CPU temperature:"
+msgstr "Temperatura de CPU:"
+
+#: id:22012
+msgid "Total memory"
+msgstr "Memoria total"
+
+#: id:22013
+msgid "Profile data"
+msgstr "Datos de perfil"
+
+#: id:22014
+msgid "Use dim if paused during video playback"
+msgstr "Atenuado si se pausa durante la reproducción de video"
+
+#: id:22015
+msgid "All recordings"
+msgstr "Todas las grabaciones"
+
+#: id:22016
+msgid "By title"
+msgstr "Por título"
+
+#: id:22017
+msgid "By group"
+msgstr "Por grupo"
+
+#: id:22018
+msgid "Live channels"
+msgstr "Canales en vivo"
+
+#: id:22019
+msgid "Recordings by title"
+msgstr "Grabaciones por título"
+
+#: id:22020
+msgid "Guide"
+msgstr "Guía"
+
+#: id:22021
+msgid "Allowed error in aspect ratio to minimize black bars"
+msgstr "Error permitido para minmizar las barras negras en R/A"
+
+#: id:22022
+msgid "Show video files in listings"
+msgstr "Mostrar los archivos de vídeo en las listas"
+
+#: id:22023
+msgid "DirectX vendor:"
+msgstr "Distribuidor de DirectX:"
+
+#: id:22024
+msgid "Direct3D version:"
+msgstr "Versión de Direct3D:"
+
+#: id:22030
+msgctxt "Auto context with id 22030"
+msgid "Font"
+msgstr "Fuente"
+
+#: id:22031
+msgctxt "Auto context with id 22031"
+msgid "- Size"
+msgstr "- Tamaño"
+
+#: id:22032
+msgctxt "Auto context with id 22032"
+msgid "- Colours"
+msgstr "- Colores"
+
+#: id:22033
+msgid "- Charset"
+msgstr "- Juego de caracteres"
+
+#: id:22034
+msgid "Export karaoke titles as HTML"
+msgstr "Como HTML"
+
+#: id:22035
+msgid "Export karaoke titles as CSV"
+msgstr "Como CSV"
+
+#: id:22036
+msgid "Import karaoke titles..."
+msgstr "Importar los títulos de karaoke..."
+
+#: id:22037
+msgid "Show song selector automatically"
+msgstr "Mostrar el selector de canciones automáticamente"
+
+#: id:22038
+msgid "Export karaoke titles..."
+msgstr "Exportar los títulos de karaoke..."
+
+#: id:22039
+msgid "Enter song number"
+msgstr "Introduzca número de canción"
+
+#: id:22040
+msgid "white/green"
+msgstr "Blanco/Verde"
+
+#: id:22041
+msgid "white/red"
+msgstr "Blanco/Rojo"
+
+#: id:22042
+msgid "white/blue"
+msgstr "Blanco/Azul"
+
+#: id:22043
+msgid "black/white"
+msgstr "Blanco/Negro"
+
+#: id:22079
+msgid "Default select action"
+msgstr "Seleccionar la acción por defecto"
+
+#: id:22080
+msgid "Choose"
+msgstr "Elegir"
+
+#: id:22081
+msgid "Show Information"
+msgstr "Mostrar información"
+
+#: id:22082
+msgid "More..."
+msgstr "Más..."
+
+#: id:22083
+msgid "Play all"
+msgstr "Reproducir todo"
+
+#: id:23049
+msgid "Teletext not available"
+msgstr "Teletexto no disponible"
+
+#: id:23050
+msgid "Activate Teletext"
+msgstr "Activar el teletexto"
+
+#: id:23051
+msgid "Part %i"
+msgstr "Parte %i"
+
+#: id:23052
+msgid "Buffering %i bytes"
+msgstr "Almacenando %i bytes"
+
+#: id:23053
+msgid "Stopping"
+msgstr "Parando"
+
+#: id:23054
+msgid "Running"
+msgstr "Ejecutando"
+
+#: id:23100
+msgid "External Player Active"
+msgstr "Reproductor externo activo"
+
+#: id:23101
+msgid "Click OK to terminate the player"
+msgstr "Haga clic en Aceptar para cerrar el reproductor"
+
+#: id:23104
+msgid "Click OK when playback has ended"
+msgstr "Haga clic en Aceptar cuando haya terminado la reproducción"
+
+#: id:24000
+msgid "Add-on"
+msgstr "Add-on"
+
+#: id:24001
+msgid "Add-ons"
+msgstr "Add-ons"
+
+#: id:24002
+msgid "Add-on options"
+msgstr "Opciones de Add-ons"
+
+#: id:24003
+msgid "Add-on Information"
+msgstr "Información del Add-on"
+
+#: id:24005
+msgctxt "Auto context with id 24005"
+msgid "Media sources"
+msgstr "Fuentes de medios"
+
+#: id:24007
+msgctxt "Auto context with id 24007"
+msgid "Movie information"
+msgstr "Información de películas"
+
+#: id:24008
+msgctxt "Auto context with id 24008"
+msgid "Screensaver"
+msgstr "Salvapantallas"
+
+#: id:24009
+msgid "Script"
+msgstr "Script"
+
+#: id:24010
+msgctxt "Auto context with id 24010"
+msgid "Visualization"
+msgstr "Visualización"
+
+#: id:24011
+msgid "Add-on repository"
+msgstr "Repositorio de Add-ons"
+
+#: id:24012
+msgctxt "Auto context with id 24012"
+msgid "Subtitles"
+msgstr "Subtítulos"
+
+#: id:24013
+msgid "Lyrics"
+msgstr "Letras"
+
+#: id:24014
+msgid "TV information"
+msgstr "Información de TV"
+
+#: id:24015
+msgctxt "Auto context with id 24015"
+msgid "Music video information"
+msgstr "Información de vídeos musicales"
+
+#: id:24016
+msgctxt "Auto context with id 24016"
+msgid "Album information"
+msgstr "Información de álbum"
+
+#: id:24017
+msgctxt "Auto context with id 24017"
+msgid "Artist information"
+msgstr "Información del artista"
+
+#: id:24018
+msgctxt "Auto context with id 24018"
+msgid "Services"
+msgstr "Servicios"
+
+#: id:24020
+msgid "Configure"
+msgstr "Configurar"
+
+#: id:24021
+msgctxt "Auto context with id 24021"
+msgid "Disable"
+msgstr "Desactivar"
+
+#: id:24022
+msgid "Enable"
+msgstr "Activar"
+
+#: id:24023
+msgid "Add-on disabled"
+msgstr "El add-on está desactivado"
+
+#: id:24027
+msgctxt "Auto context with id 24027"
+msgid "Weather"
+msgstr "El Tiempo"
+
+#: id:24028
+msgid "Weather.com (standard)"
+msgstr "Weather.com (estandar)"
+
+#: id:24030
+msgid "This Add-on can not be configured"
+msgstr "Este add-on no se puede configurar"
+
+#: id:24031
+msgid "Error loading settings"
+msgstr "Error cargando las opciones"
+
+#: id:24032
+msgid "All Add-ons"
+msgstr "Todos los Add-ons"
+
+#: id:24033
+msgid "Get Add-ons"
+msgstr "Conseguir Add-ons"
+
+#: id:24034
+msgid "Check for updates"
+msgstr "Comprobar actualizaciones"
+
+#: id:24035
+msgid "Force refresh"
+msgstr "Forzar refresco"
+
+#: id:24036
+msgid "Change log"
+msgstr "Log de cambios"
+
+#: id:24037
+msgid "Uninstall"
+msgstr "Desinstalar"
+
+#: id:24038
+msgid "Install"
+msgstr "Instalar"
+
+#: id:24039
+msgid "Disabled Add-ons"
+msgstr "Add-ons desactivados"
+
+#: id:24040
+msgid "(Clear the current setting)"
+msgstr "(Limpia los ajustes actuales)"
+
+#: id:24041
+msgid "Install from zip file"
+msgstr "Instalar desde un archivo .zip"
+
+#: id:24042
+msgid "Downloading %i%%"
+msgstr "Descargando %i%%"
+
+#: id:24043
+msgid "Available Updates"
+msgstr "Actualizaciones disponibles"
+
+#: id:24044
+msgid "Dependencies not met"
+msgstr "Dependencias incumplidas"
+
+#: id:24045
+msgid "Add-on does not have the correct structure"
+msgstr "El Add-on no tiene la estructura correcta"
+
+#: id:24046
+msgid "%s is used by the following installed add-on(s)"
+msgstr "%s es usado por los siguintes add-ons instalados"
+
+#: id:24047
+msgid "This add-on cannot be uninstalled"
+msgstr "Este add-on no se puede desinstalar"
+
+#: id:24048
+msgid "Rollback"
+msgstr "Volver una versión atrás"
+
+#: id:24050
+msgid "Available Add-ons"
+msgstr "Add-ons disponibles"
+
+#: id:24051
+msgid "Version:"
+msgstr "Versión:"
+
+#: id:24052
+msgid "Disclaimer"
+msgstr "Leeme"
+
+#: id:24053
+msgid "License:"
+msgstr "Licencia:"
+
+#: id:24054
+msgid "Changelog"
+msgstr "Cambios"
+
+#: id:24059
+msgid "Would you like to enable this Add-on?"
+msgstr "¿Deseas activar este Add-on?"
+
+#: id:24060
+msgid "Would you like to disable this Add-on?"
+msgstr "¿Deseas desactivar este Add-on?"
+
+#: id:24061
+msgid "Add-on update available!"
+msgstr "¡Hay una actualización de Add-on!"
+
+#: id:24062
+msgid "Enabled Add-ons"
+msgstr "Add-ons activados"
+
+#: id:24063
+msgid "Auto update"
+msgstr "Auto actualizar"
+
+#: id:24064
+msgid "Add-on enabled"
+msgstr "Add-on activado"
+
+#: id:24065
+msgid "Add-on updated"
+msgstr "Add-on actualizado"
+
+#: id:24066
+msgid "Cancel Add-on download?"
+msgstr "¿Cancelar descarga de Add-on?"
+
+#: id:24067
+msgid "Currently downloading Add-ons"
+msgstr "Add-ons descargando ahora"
+
+#: id:24068
+msgid "Update available"
+msgstr "Actualización disponible"
+
+#: id:24069
+msgid "Update"
+msgstr "Actualizar"
+
+#: id:24070
+msgid "Add-on could not be loaded."
+msgstr "El add-on no se pudo cargar."
+
+#: id:24071
+msgid "An unknown error has occurred."
+msgstr "Ha ocurrido un error desconocido."
+
+#: id:24072
+msgid "Settings required"
+msgstr "Configuración necesaria"
+
+#: id:24073
+msgid "Could not connect"
+msgstr "No se puede conectar"
+
+#: id:24074
+msgid "Needs to restart"
+msgstr "Necesita reinicio"
+
+#: id:24075
+msgctxt "Auto context with id 24075"
+msgid "Disable"
+msgstr "Desactivar"
+
+#: id:24076
+msgid "Add-on Required"
+msgstr ""
+
+#: id:24080
+msgid "Try to reconnect?"
+msgstr "¿Reintentar conexión?"
+
+#: id:24089
+msgid "Add-on restarts"
+msgstr "El Add-on se reinicia"
+
+#: id:24090
+msgid "Lock Add-on manager"
+msgstr "Bloquear el gestor de Add-ons"
+
+#: id:24094
+msgid "(current)"
+msgstr "(actual)"
+
+#: id:24095
+msgid "(blacklisted)"
+msgstr "(en la lista negra)"
+
+#: id:24096
+msgid "Add-on has been marked as broken in repository."
+msgstr "Add-on marcado como roto en el repositorio"
+
+#: id:24097
+msgid "Would you like to disable it on your system?"
+msgstr "¿Desea deshabilitarlo en el sistema?"
+
+#: id:24098
+msgid "Broken"
+msgstr "Roto"
+
+#: id:24099
+msgid "Would you like to switch to this skin?"
+msgstr "¿Deséa cambiar a esta skin?"
+
+#: id:24100
+msgid "To use this feature you must download an Add-on:"
+msgstr ""
+
+#: id:24101
+msgid "Would you like to download this Add-on?"
+msgstr ""
+
+#: id:25000
+msgid "Notifications"
+msgstr "Notificaciones"
+
+#: id:29800
+msgid "Library Mode"
+msgstr "Modo Biblioteca"
+
+#: id:29801
+msgid "QWERTY keyboard"
+msgstr "Teclado QWERTY"
+
+#: id:29802
+msgid "Passthrough Audio in use"
+msgstr "Pasarela de audio en uso"
+
+#: id:33001
+msgid "Trailer quality"
+msgstr "Calidad el Trailer"
+
+#: id:33002
+msgid "Stream"
+msgstr "Flujo"
+
+#: id:33003
+msgid "Download"
+msgstr "Descargar"
+
+#: id:33004
+msgid "Download & play"
+msgstr "Descargar y reproducir"
+
+#: id:33005
+msgid "Download & save"
+msgstr "Descargar y guardar"
+
+#: id:33006
+msgid "Today"
+msgstr "Hoy"
+
+#: id:33007
+msgid "Tomorrow"
+msgstr "Mañana"
+
+#: id:33008
+msgid "Saving"
+msgstr "Guardando"
+
+#: id:33009
+msgid "Copying"
+msgstr "Copiando"
+
+#: id:33010
+msgid "Set download directory"
+msgstr "Establecer el directorio de descarga"
+
+#: id:33011
+msgid "Search duration"
+msgstr "Buscar por duración"
+
+#: id:33012
+msgid "Short"
+msgstr "Corto"
+
+#: id:33013
+msgid "Long"
+msgstr "Largo"
+
+#: id:33014
+msgid "Use DVD player instead of regular player"
+msgstr "Forzar uso del DVD Player"
+
+#: id:33015
+msgid "Ask for download before playing video"
+msgstr "Preguntar si deseamos descargar vídeo antes de reproducirlo"
+
+#: id:33016
+msgid "Clips"
+msgstr "Clips"
+
+#: id:33017
+msgid "Restart plugin to enable"
+msgstr "Es necesario reiniciar el plugin"
+
+#: id:33018
+msgid "Tonight"
+msgstr "Esta noche"
+
+#: id:33019
+msgid "Tomorrow Night"
+msgstr "Mañana por la noche"
+
+#: id:33020
+msgid "Condition"
+msgstr "Condición"
+
+#: id:33021
+msgid "Precipitation"
+msgstr "Precipitación"
+
+#: id:33022
+msgid "Precip"
+msgstr "Lluvia"
+
+#: id:33023
+msgid "Humid"
+msgstr "Húmedad"
+
+#: id:33024
+msgid "Feels"
+msgstr "Sensaciones"
+
+#: id:33025
+msgid "Observed"
+msgstr "Observado"
+
+#: id:33026
+msgid "Departure from normal"
+msgstr "Salida de lo normal"
+
+#: id:33027
+msgid "Sunrise"
+msgstr "Amanecer"
+
+#: id:33028
+msgid "Sunset"
+msgstr "Anochecer"
+
+#: id:33029
+msgid "Details"
+msgstr "Detalles"
+
+#: id:33030
+msgid "Outlook"
+msgstr "Pronóstico"
+
+#: id:33031
+msgid "Coverflow"
+msgstr "Flujo de portadas"
+
+#: id:33032
+msgid "Translate text"
+msgstr "Traducir texto"
+
+#: id:33033
+msgid "Map list %s category"
+msgstr "Categoría %s de lista de mapas"
+
+#: id:33034
+msgid "36 Hour"
+msgstr "36 horas"
+
+#: id:33035
+msgid "Maps"
+msgstr "Mapas"
+
+#: id:33036
+msgid "Hourly"
+msgstr "Por hora"
+
+#: id:33037
+msgid "Weekend"
+msgstr "Fin de semana"
+
+#: id:33038
+msgid "%s day"
+msgstr "%s día"
+
+#: id:33049
+msgid "Alert"
+msgstr "Alerta"
+
+#: id:33050
+msgid "Alerts"
+msgstr "Alertas"
+
+#: id:33051
+msgid "Choose Your"
+msgstr "Elegir tus"
+
+#: id:33052
+msgid "Check"
+msgstr "Comprobar"
+
+#: id:33053
+msgctxt "Auto context with id 33053"
+msgid "Configure the"
+msgstr "Configurar el"
+
+#: id:33054
+msgid "Seasons"
+msgstr "Temporadas"
+
+#: id:33055
+msgid "Use your"
+msgstr "Usar tus"
+
+#: id:33056
+msgid "Watch your"
+msgstr "Mirar tus"
+
+#: id:33057
+msgid "Listen to"
+msgstr "Escuchar"
+
+#: id:33058
+msgid "View your"
+msgstr "Ver tus"
+
+#: id:33059
+msgctxt "Auto context with id 33059"
+msgid "Configure the"
+msgstr "Configurar el"
+
+#: id:33060
+msgid "Power"
+msgstr "Power"
+
+#: id:33061
+msgid "Menu"
+msgstr "Menú"
+
+#: id:33062
+msgid "Play the"
+msgstr "Reproducir"
+
+#: id:33063
+msgid "Options"
+msgstr "Opciones"
+
+#: id:33065
+msgid "Editor"
+msgstr "Editor"
+
+#: id:33066
+msgid "About your"
+msgstr "Acerca de"
+
+#: id:33067
+msgid "Star rating"
+msgstr "Puntuación"
+
+#: id:33068
+msgid "Background"
+msgstr "Fondo"
+
+#: id:33069
+msgid "Backgrounds"
+msgstr "Fondos"
+
+#: id:33070
+msgid "Custom background"
+msgstr "Fondo personalizado"
+
+#: id:33071
+msgid "Custom backgrounds"
+msgstr "Fondos personalizados"
+
+#: id:33072
+msgid "View Readme"
+msgstr "Ver Léeme"
+
+#: id:33073
+msgid "View Changelog"
+msgstr "Ver Cambios"
+
+#: id:33074
+msgid "This version of %s requires an"
+msgstr "Esta versión %s necesita una"
+
+#: id:33075
+msgid "XBMC revision of %s or greater to run."
+msgstr "revisión XBMC %s o mayor para funcionar."
+
+#: id:33076
+msgid "Please update XBMC."
+msgstr "Por favor, actualice su XBMC."
+
+#: id:33077
+msgid "No data found!"
+msgstr "¡No se han encontrado datos!"
+
+#: id:33078
+msgid "Next page"
+msgstr "Página siguiente"
+
+#: id:33079
+msgid "Love"
+msgstr "Me gusta"
+
+#: id:33080
+msgid "Hate"
+msgstr "No me gusta"
+
+#: id:33081
+msgid "This file is stacked, select the part you want to play from."
+msgstr "Este archivo está partido. Seleccione la parte que desea reproducir."
+
+#: id:33082
+msgid "Path to script"
+msgstr "Ruta al script"
+
+#: id:33083
+msgid "Enable custom script button"
+msgstr "Habilitar el botón de scripts personalizado"
+
+#: id:33100
+msgid "Failed to start"
+msgstr "Error al iniciar"
+
+#: id:33101
+msgid "Webserver"
+msgstr "Servidor Web"
+
+#: id:33102
+msgid "Event Server"
+msgstr "Servidor de Eventos"
+
+#: id:33103
+msgid "Remote communication server"
+msgstr "Servidor de comunicación remoto"
+
+#: id:33200
+msgid "Detected New Connection"
+msgstr ""
+
+#: id:34000
+msgid "Lame"
+msgstr ""
+
+#: id:34001
+msgid "Vorbis"
+msgstr ""
+
+#: id:34002
+msgid "Wav"
+msgstr ""
+
+#: id:34003
+msgid "DXVA2"
+msgstr ""
+
+#: id:34004
+msgid "VAAPI"
+msgstr ""
+
+#: id:34005
+msgid "Flac"
+msgstr ""
+
+#: id:34100
+msgid "Speaker Configuration"
+msgstr "Configuración de altavoces"
+
+#: id:34101
+msgid "2.0"
+msgstr ""
+
+#: id:34102
+msgid "2.1"
+msgstr ""
+
+#: id:34103
+msgid "3.0"
+msgstr ""
+
+#: id:34104
+msgid "3.1"
+msgstr ""
+
+#: id:34105
+msgid "4.0"
+msgstr ""
+
+#: id:34106
+msgid "4.1"
+msgstr ""
+
+#: id:34107
+msgid "5.0"
+msgstr ""
+
+#: id:34108
+msgid "5.1"
+msgstr ""
+
+#: id:34109
+msgid "7.0"
+msgstr ""
+
+#: id:34110
+msgid "7.1"
+msgstr ""
+
+#: id:34201
+msgid "Can't find a next item to play"
+msgstr "No se ha podido encontrar el siguiente elemento a reproducir"
+
+#: id:34202
+msgid "Can't find a previous item to play"
+msgstr "No se ha podido encontrar el elemento anterior a reproducir"
+
+#: id:34300
+msgid "Failed to start zeroconf"
+msgstr ""
+
+#: id:34301
+msgid "Is Apple's Bonjour Service installed? See log for more info."
+msgstr ""
+
+#: id:34400
+msgid "Video Rendering"
+msgstr ""
+
+#: id:34401
+msgid "Failed to init video filters/scalers, falling back to bilinear scaling"
+msgstr ""
+
+#: id:34402
+msgid "Failed to initialize audio device"
+msgstr ""
+
+#: id:34403
+msgid "Check your audiosettings"
+msgstr ""
+
+#: id:34404
+msgid "Use gestures for navigation:"
+msgstr ""
+
+#: id:34405
+msgid "1 finger swipe left,right,up,down for cursors"
+msgstr ""
+
+#: id:34406
+msgid "2 finger swipe left for backspace"
+msgstr ""
+
+#: id:34407
+msgid "1 finger single tap for enter"
+msgstr ""
+
+#: id:34408
+msgid "2 finger single tap for contextmenu"
+msgstr ""
+
+#: id:35000
+msgid "Peripherals"
+msgstr ""
+
+#: id:35001
+msgid "Generic HID device"
+msgstr ""
+
+#: id:35002
+msgid "Generic network adapter"
+msgstr ""
+
+#: id:35003
+msgid "Generic disk"
+msgstr ""
+
+#: id:35004
+msgid "There are no settings available\nfor this peripheral."
+msgstr ""
+
+#: id:35005
+msgid "New device configured"
+msgstr ""
+
+#: id:35006
+msgid "Device removed"
+msgstr ""
+
+#: id:35007
+msgid "Keymap to use for this device"
+msgstr ""
+
+#: id:35008
+msgid "Keymap enabled"
+msgstr ""
+
+#: id:35009
+msgid "Do not use the custom keymap for this device"
+msgstr ""
+
+#: id:35500
+msgid "Location"
+msgstr ""
+
+#: id:35501
+msgid "Class"
+msgstr ""
+
+#: id:35502
+msgctxt "Auto context with id 35502"
+msgid "Name"
+msgstr ""
+
+#: id:35503
+msgid "Vendor"
+msgstr ""
+
+#: id:35504
+msgid "Product ID"
+msgstr ""
+
+#: id:36000
+msgid "Pulse-Eight CEC adapter"
+msgstr ""
+
+#: id:36001
+msgid "Pulse-Eight Nyxboard"
+msgstr ""
+
+#: id:36002
+msgid "Switch to keyboard side command"
+msgstr ""
+
+#: id:36003
+msgid "Switch to remote side command"
+msgstr ""
+
+#: id:36004
+msgid "Press \"user\" button command"
+msgstr ""
+
+#: id:36005
+msgid "Enable switch side commands"
+msgstr ""
+
+#: id:36006
+msgid "Could not open the adapter"
+msgstr ""
+
+#: id:36007
+msgid "Devices to power on when starting XBMC"
+msgstr ""
+
+#: id:36008
+msgid "Devices to power off when stopping XBMC"
+msgstr ""
+
+#: id:36009
+msgid "Put devices in standby mode when activating screensaver"
+msgstr ""
+
+#: id:36011
+msgid "Could not detect the CEC port. Set it up manually."
+msgstr ""
+
+#: id:36012
+msgid "Could not initialise the CEC adapter. Check your settings."
+msgstr ""
+
+#: id:36013
+msgid "Unsupported libCEC interface version. %d is greater than the version XBMC supports (%d)"
+msgstr ""
+
+#: id:36014
+msgid "Put this PC in standby mode when the TV is switched off"
+msgstr ""
+
+#: id:36015
+msgid "HDMI port number"
+msgstr ""
+
+#: id:36016
+msgctxt "Auto context with id 36016"
+msgid "Connected"
+msgstr ""
+
+#: id:36017
+msgid "Adapter found, but libCEC is not available"
+msgstr ""
+
+#: id:36018
+msgid "Use the TV's language setting"
+msgstr ""
+
+#: id:36019
+msgid "Connected to HDMI device"
+msgstr ""
+
+#: id:36020
+msgid "Make XBMC the active source when starting"
+msgstr ""
+
+#: id:36021
+msgid "Physical address (overrules HDMI port)"
+msgstr ""
+
+#: id:36022
+msgid "COM port (leave empty unless needed)"
+msgstr ""
+
+#: id:36023
+msgid "Configuration updated"
+msgstr ""
+
+#: id:36024
+msgid "Failed to set the new configuration. Please check your settings."
+msgstr ""
+
+#: id:36025
+msgid "Send 'inactive source' command when stopping XBMC"
+msgstr ""
+

--- a/language/Swedish/strings.po
+++ b/language/Swedish/strings.po
@@ -1,0 +1,9093 @@
+# Converted from xbmc strings.xml with xbmc-xml2po (by Team-XBMC)
+msgid ""
+msgstr ""
+"Project-Id-Version: xbmc.core-FRODO_GIT3ed1604ad7\n"
+"Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
+"POT-Creation-Date: 2012-04-09 18:00+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE\n"
+"Language: sv\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: id:0
+msgctxt "Auto context with id 0"
+msgid "Programs"
+msgstr "Program"
+
+#: id:1
+msgctxt "Auto context with id 1"
+msgid "Pictures"
+msgstr "Bilder"
+
+#: id:2
+msgctxt "Auto context with id 2"
+msgid "Music"
+msgstr "Musik"
+
+#: id:3
+msgctxt "Auto context with id 3"
+msgid "Videos"
+msgstr "Videor"
+
+#: id:4
+msgid "TV-Guide"
+msgstr "TV-guide"
+
+#: id:5
+msgctxt "Auto context with id 5"
+msgid "Settings"
+msgstr "Inställningar"
+
+#: id:6
+msgid "XBMC SVN"
+msgstr ""
+
+#: id:7
+msgctxt "Auto context with id 7"
+msgid "File manager"
+msgstr "Filhanterare"
+
+#: id:8
+msgctxt "Auto context with id 8"
+msgid "Weather"
+msgstr "Väder"
+
+#: id:9
+msgid "xbmc media center"
+msgstr ""
+
+#: id:11
+msgid "Monday"
+msgstr "Måndag"
+
+#: id:12
+msgid "Tuesday"
+msgstr "Tisdag"
+
+#: id:13
+msgid "Wednesday"
+msgstr "Onsdag"
+
+#: id:14
+msgid "Thursday"
+msgstr "Torsdag"
+
+#: id:15
+msgid "Friday"
+msgstr "Fredag"
+
+#: id:16
+msgid "Saturday"
+msgstr "Lördag"
+
+#: id:17
+msgid "Sunday"
+msgstr "Söndag"
+
+#: id:21
+msgid "January"
+msgstr "Januari"
+
+#: id:22
+msgid "February"
+msgstr "Februari"
+
+#: id:23
+msgid "March"
+msgstr "Mars"
+
+#: id:24
+msgid "April"
+msgstr "April"
+
+#: id:25
+msgctxt "Auto context with id 25"
+msgid "May"
+msgstr "Maj"
+
+#: id:26
+msgid "June"
+msgstr "Juni"
+
+#: id:27
+msgid "July"
+msgstr "Juli"
+
+#: id:28
+msgid "August"
+msgstr "Augusti"
+
+#: id:29
+msgid "September"
+msgstr "September"
+
+#: id:30
+msgid "October"
+msgstr "Oktober"
+
+#: id:31
+msgid "November"
+msgstr "November"
+
+#: id:32
+msgid "December"
+msgstr "December"
+
+#: id:41
+msgid "Mon"
+msgstr "Mån"
+
+#: id:42
+msgid "Tue"
+msgstr "Tis"
+
+#: id:43
+msgid "Wed"
+msgstr "Ons"
+
+#: id:44
+msgid "Thu"
+msgstr "Tors"
+
+#: id:45
+msgid "Fri"
+msgstr "Fre"
+
+#: id:46
+msgid "Sat"
+msgstr "Lör"
+
+#: id:47
+msgctxt "Auto context with id 47"
+msgid "Sun"
+msgstr "Sön"
+
+#: id:51
+msgid "Jan"
+msgstr "Jan"
+
+#: id:52
+msgid "Feb"
+msgstr "Feb"
+
+#: id:53
+msgid "Mar"
+msgstr "Mar"
+
+#: id:54
+msgid "Apr"
+msgstr "Apr"
+
+#: id:55
+msgctxt "Auto context with id 55"
+msgid "May"
+msgstr "Maj"
+
+#: id:56
+msgid "Jun"
+msgstr "Jun"
+
+#: id:57
+msgid "Jul"
+msgstr "Jul"
+
+#: id:58
+msgid "Aug"
+msgstr "Aug"
+
+#: id:59
+msgid "Sep"
+msgstr "Sep"
+
+#: id:60
+msgid "Oct"
+msgstr "Okt"
+
+#: id:61
+msgid "Nov"
+msgstr "Nov"
+
+#: id:62
+msgid "Dec"
+msgstr "Dec"
+
+#: id:71
+msgid "N"
+msgstr "N"
+
+#: id:72
+msgid "NNE"
+msgstr "NNÖ"
+
+#: id:73
+msgid "NE"
+msgstr "NÖ"
+
+#: id:74
+msgid "ENE"
+msgstr "ÖNÖ"
+
+#: id:75
+msgid "E"
+msgstr "Ö"
+
+#: id:76
+msgid "ESE"
+msgstr "ÖSÖ"
+
+#: id:77
+msgid "SE"
+msgstr "SÖ"
+
+#: id:78
+msgid "SSE"
+msgstr "SSÖ"
+
+#: id:79
+msgid "S"
+msgstr "S"
+
+#: id:80
+msgid "SSW"
+msgstr "SSV"
+
+#: id:81
+msgid "SW"
+msgstr "SV"
+
+#: id:82
+msgid "WSW"
+msgstr "VSV"
+
+#: id:83
+msgid "W"
+msgstr "V"
+
+#: id:84
+msgid "WNW"
+msgstr "VNV"
+
+#: id:85
+msgid "NW"
+msgstr "NV"
+
+#: id:86
+msgid "NNW"
+msgstr "NNV"
+
+#: id:87
+msgid "VAR"
+msgstr "VAR"
+
+#: id:98
+msgid "View: Auto"
+msgstr "Vy: Auto"
+
+#: id:99
+msgid "View: Auto big"
+msgstr "Vy: Auto stor"
+
+#: id:100
+msgid "View: Icons"
+msgstr "Vy: Ikoner"
+
+#: id:101
+msgid "View: List"
+msgstr "Vy: Lista"
+
+#: id:102
+msgctxt "Auto context with id 102"
+msgid "Scan"
+msgstr "Skanna"
+
+#: id:103
+msgctxt "Auto context with id 103"
+msgid "Sort by: Name"
+msgstr "Sort: Namn"
+
+#: id:104
+msgid "Sort by: Date"
+msgstr "Sort: Datum"
+
+#: id:105
+msgid "Sort by: Size"
+msgstr "Sort: Storlek"
+
+#: id:106
+msgid "No"
+msgstr "Nej"
+
+#: id:107
+msgid "Yes"
+msgstr "Ja"
+
+#: id:108
+msgctxt "Auto context with id 108"
+msgid "Slideshow"
+msgstr "Bildspel"
+
+#: id:109
+msgid "Create thumbs"
+msgstr "Skapa minibilder"
+
+#: id:110
+msgid "Create thumbnails"
+msgstr "Skapa miniatyrbilder"
+
+#: id:111
+msgctxt "Auto context with id 111"
+msgid "Shortcuts"
+msgstr "Genvägar"
+
+#: id:112
+msgid "Paused"
+msgstr "Pausad"
+
+#: id:113
+msgid "Update failed"
+msgstr "Uppdatering misslyckades"
+
+#: id:114
+msgid "Installation failed"
+msgstr "Installation misslyckades"
+
+#: id:115
+msgid "Copy"
+msgstr "Kopiera"
+
+#: id:116
+msgid "Move"
+msgstr "Flytta"
+
+#: id:117
+msgid "Delete"
+msgstr "Radera"
+
+#: id:118
+msgid "Rename"
+msgstr "Byt namn"
+
+#: id:119
+msgid "New folder"
+msgstr "Ny mapp"
+
+#: id:120
+msgid "Confirm file copy"
+msgstr "Bekräfta kopiering"
+
+#: id:121
+msgid "Confirm file move"
+msgstr "Bekräfta flyttning"
+
+#: id:122
+msgid "Confirm file delete?"
+msgstr "Bekräfta radering?"
+
+#: id:123
+msgid "Copy these files?"
+msgstr "Kopiera filerna?"
+
+#: id:124
+msgid "Move these files?"
+msgstr "Flytta filerna?"
+
+#: id:125
+msgid "Delete these files? - Deleting files cannot be undone!"
+msgstr "Radera filerna? - Radering av filer kan inte ångras!"
+
+#: id:126
+msgid "Status"
+msgstr "Status"
+
+#: id:127
+msgid "Objects"
+msgstr "Objekt"
+
+#: id:128
+msgctxt "Auto context with id 128"
+msgid "General"
+msgstr "Allmänt"
+
+#: id:129
+msgctxt "Auto context with id 129"
+msgid "Slideshow"
+msgstr "Bildspel"
+
+#: id:130
+msgctxt "Auto context with id 130"
+msgid "System info"
+msgstr "Systeminfo"
+
+#: id:131
+msgid "Display"
+msgstr "Bildskärm"
+
+#: id:132
+msgid "Albums"
+msgstr "Album"
+
+#: id:133
+msgid "Artists"
+msgstr "Artister"
+
+#: id:134
+msgid "Songs"
+msgstr "Låtar"
+
+#: id:135
+msgid "Genres"
+msgstr "Genre"
+
+#: id:136
+msgid "Playlists"
+msgstr "Spellistor"
+
+#: id:137
+msgid "Search"
+msgstr "Sök"
+
+#: id:138
+msgid "System Information"
+msgstr "Systeminformation"
+
+#: id:139
+msgid "Temperatures:"
+msgstr "Temperaturer:"
+
+#: id:140
+msgid "CPU:"
+msgstr "CPU:"
+
+#: id:141
+msgid "GPU:"
+msgstr "GPU:"
+
+#: id:142
+msgid "Time:"
+msgstr "Tid:"
+
+#: id:143
+msgid "Current:"
+msgstr "Aktuell:"
+
+#: id:144
+msgid "Build:"
+msgstr "Version:"
+
+#: id:145
+msgid "Network:"
+msgstr "Nätverk:"
+
+#: id:146
+msgid "Type:"
+msgstr "Typ:"
+
+#: id:147
+msgid "Static"
+msgstr "Statiskt"
+
+#: id:148
+msgid "DHCP"
+msgstr "DHCP"
+
+#: id:149
+msgid "MAC address"
+msgstr "MAC-adress"
+
+#: id:150
+msgctxt "Auto context with id 150"
+msgid "IP address"
+msgstr "IP-adress"
+
+#: id:151
+msgid "Link:"
+msgstr "Länk:"
+
+#: id:152
+msgid "Half duplex"
+msgstr "Halv duplex"
+
+#: id:153
+msgid "Full duplex"
+msgstr "Full duplex"
+
+#: id:154
+msgctxt "Auto context with id 154"
+msgid "Storage"
+msgstr "Lagring"
+
+#: id:155
+msgid "Drive"
+msgstr "Enhet"
+
+#: id:156
+msgctxt "Auto context with id 156"
+msgid "Free"
+msgstr "Ledigt"
+
+#: id:157
+msgctxt "Auto context with id 157"
+msgid "Video"
+msgstr "Video"
+
+#: id:158
+msgid "Free memory"
+msgstr "Ledigt minne"
+
+#: id:159
+msgid "No link"
+msgstr "Inget nätverk"
+
+#: id:160
+msgctxt "Auto context with id 160"
+msgid "Free"
+msgstr "Ledigt"
+
+#: id:161
+msgid "Unavailable"
+msgstr "Otillgänglig"
+
+#: id:162
+msgid "Tray open"
+msgstr "Släde öppen"
+
+#: id:163
+msgid "Reading"
+msgstr "Läser"
+
+#: id:164
+msgid "No disc"
+msgstr "Ingen skiva"
+
+#: id:165
+msgid "Disc present"
+msgstr "Skiva laddad"
+
+#: id:166
+msgid "Skin"
+msgstr "Skal"
+
+#: id:169
+msgctxt "Auto context with id 169"
+msgid "Resolution"
+msgstr "Upplösning"
+
+#: id:170
+msgid "Adjust display refresh rate to match video"
+msgstr "Justera uppdateringsfrekvens till att matcha video"
+
+#: id:172
+msgid "Release date"
+msgstr "Utgivningsdatum"
+
+#: id:173
+msgid "Display 4:3 videos as"
+msgstr "Visa 4:3 filmer som"
+
+#: id:175
+msgid "Moods"
+msgstr "Sinnesstämning"
+
+#: id:176
+msgid "Styles"
+msgstr "Stilar"
+
+#: id:179
+msgid "Song"
+msgstr "Låt"
+
+#: id:180
+msgid "Duration"
+msgstr "Varaktighet"
+
+#: id:181
+msgid "Select album"
+msgstr "Välj album"
+
+#: id:182
+msgid "Tracks"
+msgstr "Spår"
+
+#: id:183
+msgid "Review"
+msgstr "Recension"
+
+#: id:184
+msgid "Refresh"
+msgstr "Uppdatera"
+
+#: id:185
+msgid "Searching album"
+msgstr "Söker album"
+
+#: id:186
+msgid "OK"
+msgstr "OK"
+
+#: id:187
+msgid "No albums found!"
+msgstr "Inga album hittades!"
+
+#: id:188
+msgid "Select all"
+msgstr "Välj alla"
+
+#: id:189
+msgid "Scanning media info"
+msgstr "Skannar mediainformation"
+
+#: id:190
+msgid "Save"
+msgstr "Spara"
+
+#: id:191
+msgid "Shuffle"
+msgstr "Blanda"
+
+#: id:192
+msgctxt "Auto context with id 192"
+msgid "Clear"
+msgstr "Rensa"
+
+#: id:193
+msgctxt "Auto context with id 193"
+msgid "Scan"
+msgstr "Skanna"
+
+#: id:194
+msgid "Searching..."
+msgstr "Söker..."
+
+#: id:195
+msgid "No info found!"
+msgstr "Ingen info hittades!"
+
+#: id:196
+msgid "Select movie:"
+msgstr "Välj film:"
+
+#: id:197
+msgid "Querying %s info"
+msgstr "Hämtar info för %s"
+
+#: id:198
+msgid "Loading movie details"
+msgstr "Laddar filmdetaljer"
+
+#: id:199
+msgid "Web interface"
+msgstr "Webbgränssnitt"
+
+#: id:202
+msgid "Tagline"
+msgstr "Slogan"
+
+#: id:203
+msgid "Plot outline"
+msgstr "Handling"
+
+#: id:205
+msgid "Votes"
+msgstr "Röster"
+
+#: id:206
+msgid "Cast"
+msgstr "Rollsättning"
+
+#: id:207
+msgid "Plot"
+msgstr "Handling"
+
+#: id:208
+msgctxt "Auto context with id 208"
+msgid "Play"
+msgstr "Spela upp"
+
+#: id:209
+msgid "Next"
+msgstr "Nästa"
+
+#: id:210
+msgid "Previous"
+msgstr "Föregående"
+
+#: id:213
+msgid "Calibrate user interface..."
+msgstr "Kalibrera gränssnitt..."
+
+#: id:214
+msgid "Video calibration..."
+msgstr "Kalibrera bildskärm..."
+
+#: id:215
+msgid "Soften"
+msgstr "Mjuka upp"
+
+#: id:216
+msgid "Zoom amount"
+msgstr "Förstoring"
+
+#: id:217
+msgid "Pixel ratio"
+msgstr "Pixelförhållande"
+
+#: id:218
+msgid "DVD drive"
+msgstr "DVD-enhet"
+
+#: id:219
+msgid "Please insert disc"
+msgstr "Var god sätt i skiva"
+
+#: id:220
+msgid "Remote share"
+msgstr "Fjärrdisk"
+
+#: id:221
+msgid "Network is not connected"
+msgstr "Det finns inget nätverk"
+
+#: id:222
+msgid "Cancel"
+msgstr "Avbryt"
+
+#: id:224
+msgid "Speed"
+msgstr "Hastighet"
+
+#: id:225
+msgid "Vertical Shift"
+msgstr "Vertikal skiftning"
+
+#: id:226
+msgid "Test patterns..."
+msgstr "Testmönster..."
+
+#: id:227
+msgid "Lookup audio CD track names from freedb.org"
+msgstr "Slå upp låtnamn till musikskivor på freedb.org"
+
+#: id:228
+msgid "Shuffle playlist on load"
+msgstr "Blanda spellistor när de laddas"
+
+#: id:229
+msgid "HDD spindown time"
+msgstr "Tid innan hårddisken går till energiläge"
+
+#: id:230
+msgid "Video filters"
+msgstr "Videofilter"
+
+#: id:231
+msgctxt "Auto context with id 231"
+msgid "None"
+msgstr "Inget"
+
+#: id:232
+msgid "Point"
+msgstr "Punkt"
+
+#: id:233
+msgid "Linear"
+msgstr "Linjär"
+
+#: id:234
+msgid "Anisotropic"
+msgstr "Anisotropisk"
+
+#: id:235
+msgid "Quincunx"
+msgstr "Quincunx"
+
+#: id:236
+msgid "Gaussian cubic"
+msgstr "Gaussisk-kubiskt"
+
+#: id:237
+msgid "Minification"
+msgstr "Förminskning"
+
+#: id:238
+msgid "Magnification"
+msgstr "Förstoring"
+
+#: id:239
+msgid "Clear playlist on finish"
+msgstr "Rensa efter spellistans slut"
+
+#: id:240
+msgid "Display Mode"
+msgstr "Displayläge"
+
+#: id:241
+msgid "Full Screen #%d"
+msgstr "Fullskärm #%d"
+
+#: id:242
+msgid "Windowed"
+msgstr "Fönster"
+
+#: id:243
+msgid "Refresh Rate"
+msgstr "Uppdateringsfrekvens"
+
+#: id:244
+msgid "Full screen"
+msgstr "Fullskärm"
+
+#: id:245
+msgid "Sizing: (%i,%i)->(%i,%i) (Zoom x%2.2f) AR:%2.2f:1 (Pixels: %2.2f:1) (VShift: %2.2f)"
+msgstr "Storlek: (%i,%i)->(%i,%i) (Zoom x%2.2f) AR:%2.2f:1 (Pixlar: %2.2f:1)"
+
+#: id:247
+msgctxt "Auto context with id 247"
+msgid "Scripts"
+msgstr "Skript"
+
+#: id:248
+msgctxt "Auto context with id 248"
+msgid "Language"
+msgstr "Språk"
+
+#: id:249
+msgctxt "Auto context with id 249"
+msgid "Music"
+msgstr "Musik"
+
+#: id:250
+msgctxt "Auto context with id 250"
+msgid "Visualization"
+msgstr "Visualisering"
+
+#: id:251
+msgid "Select destination directory"
+msgstr "Välj destinationsmapp"
+
+#: id:252
+msgid "Output stereo to all speakers"
+msgstr "Stereo till alla högtalare"
+
+#: id:253
+msgid "Number of channels"
+msgstr "Antal kanaler"
+
+#: id:254
+msgid "- DTS capable receiver"
+msgstr "- DTS-kapabel förstärkare"
+
+#: id:255
+msgid "CDDB"
+msgstr "CDDB"
+
+#: id:256
+msgid "Fetching CD information"
+msgstr "Hämtar CD-information"
+
+#: id:257
+msgid "Error"
+msgstr "Fel"
+
+#: id:258
+msgid "Enable tag reading"
+msgstr "Aktivera taggläsning"
+
+#: id:259
+msgid "Opening"
+msgstr "Öppnar"
+
+#: id:260
+msgid "Shoutcast"
+msgstr "Shoutcast"
+
+#: id:261
+msgid "Waiting for start..."
+msgstr "Väntar på start..."
+
+#: id:262
+msgid "Scripts output"
+msgstr "Skript utdata"
+
+#: id:263
+msgid "Allow control of XBMC via HTTP"
+msgstr "Tillåt kontroll av XBMC via HTTP"
+
+#: id:264
+msgid "Record"
+msgstr "Spela in"
+
+#: id:265
+msgid "Stop Rec."
+msgstr "Stoppa insp."
+
+#: id:266
+msgid "Sort by: Track"
+msgstr "Sort: Låtar"
+
+#: id:267
+msgid "Sort by: Time"
+msgstr "Sort: Speltid"
+
+#: id:268
+msgid "Sort by: Title"
+msgstr "Sort: Titel"
+
+#: id:269
+msgid "Sort by: Artist"
+msgstr "Sort: Artist"
+
+#: id:270
+msgid "Sort by: Album"
+msgstr "Sort: Album"
+
+#: id:271
+msgid "Top 100"
+msgstr "Topp 100"
+
+#: id:272
+msgid "Top-Left overscan compensation"
+msgstr "Övre vänster översvepskompensation"
+
+#: id:273
+msgid "Bottom-Right overscan compensation"
+msgstr "Nedre höger översvepskompensation"
+
+#: id:274
+msgid "Subtitle positioning"
+msgstr "Undertextsposition"
+
+#: id:275
+msgid "Pixel ratio adjustment"
+msgstr "Justering av pixelförhållande"
+
+#: id:276
+msgid "Adjust the arrow to change the amount of overscan"
+msgstr "Flytta pilen för att ändra översvepsmängd"
+
+#: id:277
+msgid "Adjust the bar to change the subtitles position"
+msgstr "Flytta pilen för att flytta undertextsposition"
+
+#: id:278
+msgid "Adjust the rectangle so it is perfectly square"
+msgstr "Ändra rektangeln till en perfekt fyrkant"
+
+#: id:279
+msgid "Unable to load settings"
+msgstr "Kunde inte ladda inställningar"
+
+#: id:280
+msgid "Using default settings"
+msgstr "Använder standardinställningar"
+
+#: id:281
+msgid "Please check the XML files"
+msgstr "Var god kontrollera XML-filerna"
+
+#: id:282
+msgid "Found %i items"
+msgstr "Hittade %i objekt"
+
+#: id:283
+msgid "Search results"
+msgstr "Sökresultat"
+
+#: id:284
+msgid "No results found"
+msgstr "Inga resultat hittades"
+
+#: id:287
+msgctxt "Auto context with id 287"
+msgid "Subtitles"
+msgstr "Undertexter"
+
+#: id:288
+msgctxt "Auto context with id 288"
+msgid "Font"
+msgstr "Typsnitt"
+
+#: id:289
+msgctxt "Auto context with id 289"
+msgid "- Size"
+msgstr "- Storlek"
+
+#: id:290
+msgid "Dynamic range compression"
+msgstr "Dynamisk registerkompression"
+
+#: id:291
+msgctxt "Auto context with id 291"
+msgid "Video"
+msgstr "Video"
+
+#: id:292
+msgctxt "Auto context with id 292"
+msgid "Audio"
+msgstr "Ljud"
+
+#: id:293
+msgid "Browse for subtitles"
+msgstr "Bläddra efter undertexter"
+
+#: id:294
+msgid "Create bookmark"
+msgstr "Skapa bokmärke"
+
+#: id:296
+msgid "Clear bookmarks"
+msgstr "Ta bort bokmärken"
+
+#: id:297
+msgid "Audio offset"
+msgstr "Ljudkompensering"
+
+#: id:298
+msgid "Bookmarks"
+msgstr "Bokmärken"
+
+#: id:299
+msgid "- AAC capable receiver"
+msgstr "- AAC-kapabel förstärkare"
+
+#: id:300
+msgid "- MP1 capable receiver"
+msgstr "- MP1-kapabel förstärkare"
+
+#: id:301
+msgid "- MP2 capable receiver"
+msgstr "- MP2-kapabel förstärkare"
+
+#: id:302
+msgid "- MP3 capable receiver"
+msgstr "- MP3-kapabel förstärkare"
+
+#: id:303
+msgid "Delay"
+msgstr "Fördröjning"
+
+#: id:304
+msgctxt "Auto context with id 304"
+msgid "Language"
+msgstr "Språk"
+
+#: id:305
+msgctxt "Auto context with id 305"
+msgid "Enabled"
+msgstr "Aktiverad"
+
+#: id:306
+msgid "Non-interleaved"
+msgstr "Icke-interfolierad"
+
+#: id:312
+msgid "(0=auto)"
+msgstr "(0 = auto)"
+
+#: id:313
+msgid "Cleaning database"
+msgstr "Rensar databas"
+
+#: id:314
+msgid "Preparing..."
+msgstr "Förbereder..."
+
+#: id:315
+msgid "Database error"
+msgstr "Databasfel"
+
+#: id:316
+msgid "Searching songs..."
+msgstr "Söker låtar..."
+
+#: id:317
+msgid "Cleaned database successfully"
+msgstr "Rensning av databasen lyckades"
+
+#: id:318
+msgid "Cleaning songs..."
+msgstr "Rensar låtar..."
+
+#: id:319
+msgid "Error cleaning songs"
+msgstr "Fel vid rensning av låtar"
+
+#: id:320
+msgid "Cleaning artists..."
+msgstr "Rensar artister..."
+
+#: id:321
+msgid "Error cleaning artists"
+msgstr "Fel vid rensning av artister"
+
+#: id:322
+msgid "Cleaning genres..."
+msgstr "Rensar genre..."
+
+#: id:323
+msgid "Error cleaning genres"
+msgstr "Fel vid rensning av genre"
+
+#: id:324
+msgid "Cleaning paths..."
+msgstr "Rensar sökvägar..."
+
+#: id:325
+msgid "Error cleaning paths"
+msgstr "Fel vid rensning av sökvägar"
+
+#: id:326
+msgid "Cleaning albums..."
+msgstr "Rensar album..."
+
+#: id:327
+msgid "Error cleaning albums"
+msgstr "Fel vid rensning av album"
+
+#: id:328
+msgid "Writing changes..."
+msgstr "Sparar ändringar..."
+
+#: id:329
+msgid "Error writing changes"
+msgstr "Fel vid sparande av ändringar"
+
+#: id:330
+msgid "This may take some time..."
+msgstr "Detta kan ta ett tag..."
+
+#: id:331
+msgid "Compressing database..."
+msgstr "Komprimerar databas..."
+
+#: id:332
+msgid "Error compressing database"
+msgstr "Fel vid komprimering av databas"
+
+#: id:333
+msgid "Do you want to clean the library?"
+msgstr "Vill du rensa biblioteket?"
+
+#: id:334
+msgid "Clean library..."
+msgstr "Rensa biblioteket..."
+
+#: id:335
+msgid "Start"
+msgstr "Starta"
+
+#: id:336
+msgid "Framerate conversion"
+msgstr "Justera bildfrekvens"
+
+#: id:337
+msgctxt "Auto context with id 337"
+msgid "Audio output"
+msgstr "Ljudutgång"
+
+#: id:338
+msgid "Analog"
+msgstr "Analog"
+
+#: id:339
+msgid "Optical/Coax"
+msgstr "Optisk/Koaxial"
+
+#: id:340
+msgid "Various artists"
+msgstr "Blandade artister"
+
+#: id:341
+msgid "Play disc"
+msgstr "Spela skiva"
+
+#: id:342
+msgctxt "Auto context with id 342"
+msgid "Movies"
+msgstr "Filmer"
+
+#: id:343
+msgid "Adjust framerate"
+msgstr "Justera bildfrekvens"
+
+#: id:344
+msgid "Actors"
+msgstr "Skådespelare"
+
+#: id:345
+msgctxt "Auto context with id 345"
+msgid "Year"
+msgstr "År"
+
+#: id:346
+msgid "Boost volume level on downmix"
+msgstr "Öka volymen vid nedmixning"
+
+#: id:350
+msgctxt "Auto context with id 350"
+msgid "Programs"
+msgstr "Program"
+
+#: id:351
+msgctxt "Auto context with id 351"
+msgid "Off"
+msgstr "Av"
+
+#: id:352
+msgid "Dim"
+msgstr "Tona ned"
+
+#: id:353
+msgid "Black"
+msgstr "Svart"
+
+#: id:354
+msgid "Matrix trails"
+msgstr "Matrix-spår"
+
+#: id:355
+msgid "Screensaver time"
+msgstr "Tid innan skärmsläckare startar"
+
+#: id:356
+msgid "Screensaver mode"
+msgstr "Skärmsläckarläge"
+
+#: id:357
+msgid "Shutdown function timer"
+msgstr "Avstängningsfunktionstimer"
+
+#: id:358
+msgid "All albums"
+msgstr "Alla album"
+
+#: id:359
+msgid "Recently added albums"
+msgstr "Senast tillagda album"
+
+#: id:360
+msgctxt "Auto context with id 360"
+msgid "Screensaver"
+msgstr "Skärmsläckare"
+
+#: id:361
+msgid "R. Slideshow"
+msgstr "Starta bildspel"
+
+#: id:362
+msgid "Screensaver dim level"
+msgstr "Skärmsläckarnivå"
+
+#: id:363
+msgid "Sort by: File"
+msgstr "Sort: Filer"
+
+#: id:364
+msgid "- Dolby Digital (AC3) capable receiver"
+msgstr "- Dolby Digital (AC3)-kapabel förstärkare"
+
+#: id:365
+msgctxt "Auto context with id 365"
+msgid "Sort by: Name"
+msgstr "Sort: Namn"
+
+#: id:366
+msgid "Sort by: Year"
+msgstr "Sort: År"
+
+#: id:367
+msgid "Sort by: Rating"
+msgstr "Sort: Betyg"
+
+#: id:368
+msgid "IMDb"
+msgstr "IMDb"
+
+#: id:369
+msgctxt "Auto context with id 369"
+msgid "Title"
+msgstr "Titel"
+
+#: id:370
+msgid "Thunderstorms"
+msgstr "Åskstormar"
+
+#: id:371
+msgid "Partly"
+msgstr "Delvis"
+
+#: id:372
+msgid "Mostly"
+msgstr "Mest"
+
+#: id:373
+msgid "Sunny"
+msgstr "Soligt"
+
+#: id:374
+msgid "Cloudy"
+msgstr "Molnigt"
+
+#: id:375
+msgid "Snow"
+msgstr "Snö"
+
+#: id:376
+msgid "Rain"
+msgstr "Regn"
+
+#: id:377
+msgid "Light"
+msgstr "Lätt"
+
+#: id:378
+msgid "AM"
+msgstr "Förmiddag"
+
+#: id:379
+msgid "PM"
+msgstr "Eftermiddag"
+
+#: id:380
+msgid "Showers"
+msgstr "Skurar"
+
+#: id:381
+msgid "Few"
+msgstr "Få"
+
+#: id:382
+msgid "Scattered"
+msgstr "Spridda"
+
+#: id:383
+msgctxt "Auto context with id 383"
+msgid "Wind"
+msgstr "Vind"
+
+#: id:384
+msgid "Strong"
+msgstr "Starka"
+
+#: id:385
+msgid "Fair"
+msgstr "Medel"
+
+#: id:386
+msgctxt "Auto context with id 386"
+msgid "Clear"
+msgstr "Klart"
+
+#: id:387
+msgid "Clouds"
+msgstr "Moln"
+
+#: id:388
+msgid "Early"
+msgstr "Tidiga"
+
+#: id:389
+msgid "Shower"
+msgstr "Skurar"
+
+#: id:390
+msgid "Flurries"
+msgstr "Lätt snöfall"
+
+#: id:391
+msgctxt "Auto context with id 391"
+msgid "Low"
+msgstr "Låg"
+
+#: id:392
+msgctxt "Auto context with id 392"
+msgid "Medium"
+msgstr "Medel"
+
+#: id:393
+msgctxt "Auto context with id 393"
+msgid "High"
+msgstr "Hög"
+
+#: id:394
+msgid "Fog"
+msgstr "Dimma"
+
+#: id:395
+msgid "Haze"
+msgstr "Dis"
+
+#: id:396
+msgid "Select location"
+msgstr "Välj plats"
+
+#: id:397
+msgid "Refresh time"
+msgstr "Uppdateringstid"
+
+#: id:398
+msgid "Temperature units"
+msgstr "Temperaturenhet"
+
+#: id:399
+msgid "Speed units"
+msgstr "Hastighetsenhet"
+
+#: id:400
+msgctxt "Auto context with id 400"
+msgid "Weather"
+msgstr "Väder"
+
+#: id:401
+msgid "Temp"
+msgstr "Temp"
+
+#: id:402
+msgid "Feels like"
+msgstr "Känns som"
+
+#: id:403
+msgid "UV index"
+msgstr "UV-index"
+
+#: id:404
+msgctxt "Auto context with id 404"
+msgid "Wind"
+msgstr "Vind"
+
+#: id:405
+msgid "Dew point"
+msgstr "Daggpunkt"
+
+#: id:406
+msgid "Humidity"
+msgstr "Fuktighet"
+
+#: id:409
+msgid "Defaults"
+msgstr "Standard"
+
+#: id:410
+msgid "Accessing weather service"
+msgstr "Kontaktar väderservice"
+
+#: id:411
+msgid "Getting weather for:"
+msgstr "Hämtar väder för:"
+
+#: id:412
+msgid "Unable to get weather data"
+msgstr "Kunde inte hämta väderdata"
+
+#: id:413
+msgid "Manual"
+msgstr "Manuell"
+
+#: id:414
+msgid "No review for this album"
+msgstr "Ingen recension för detta album"
+
+#: id:415
+msgid "Downloading thumbnail..."
+msgstr "Laddar ned miniatyrbild..."
+
+#: id:416
+msgid "Not available"
+msgstr "Inte tillgänglig"
+
+#: id:417
+msgid "View: Big icons"
+msgstr "Vy: Stora ikoner"
+
+#: id:418
+msgctxt "Auto context with id 418"
+msgid "Low"
+msgstr "Låg"
+
+#: id:419
+msgctxt "Auto context with id 419"
+msgid "High"
+msgstr "Hög"
+
+#: id:420
+msgid "HDMI"
+msgstr "HDMI"
+
+#: id:422
+msgid "Delete album info"
+msgstr "Radera albuminfo"
+
+#: id:423
+msgid "Delete CD information"
+msgstr "Radera CD-information"
+
+#: id:424
+msgid "Select"
+msgstr "Välj"
+
+#: id:425
+msgid "No album information found"
+msgstr "Ingen albuminfo hittad"
+
+#: id:426
+msgid "No CD information found"
+msgstr "Ingen CD-information hittad"
+
+#: id:427
+msgid "Disc"
+msgstr "Skiva"
+
+#: id:428
+msgid "Insert correct CD/DVD"
+msgstr "Sätt i korrekt CD/DVD"
+
+#: id:429
+msgid "Please insert the following disc:"
+msgstr "Var god sätt i följande CD/DVD"
+
+#: id:430
+msgid "Sort by: DVD#"
+msgstr "Sort: DVD#"
+
+#: id:431
+msgid "No cache"
+msgstr "Ingen buffert"
+
+#: id:432
+msgid "Remove movie from library"
+msgstr "Radera filmen från biblioteket"
+
+#: id:433
+msgid "Really remove '%s'?"
+msgstr "Är du säker på att ta bort '%s'?"
+
+#: id:434
+msgid "From %s at %i %s"
+msgstr "Från %s vidd %i %s"
+
+#: id:437
+msgid "Removable disk"
+msgstr "Löstagbar disk"
+
+#: id:438
+msgid "Opening file"
+msgstr "Öppnar fil"
+
+#: id:439
+msgid "Cache"
+msgstr "Buffert"
+
+#: id:440
+msgid "Harddisk"
+msgstr "Hårddisk"
+
+#: id:441
+msgid "UDF"
+msgstr "UDF"
+
+#: id:442
+msgid "Local network"
+msgstr "Lokalt nätverk"
+
+#: id:443
+msgid "Internet"
+msgstr "Internet"
+
+#: id:444
+msgctxt "Auto context with id 444"
+msgid "Video"
+msgstr "Video"
+
+#: id:445
+msgctxt "Auto context with id 445"
+msgid "Audio"
+msgstr "Ljud"
+
+#: id:446
+msgctxt "Auto context with id 446"
+msgid "DVD"
+msgstr "DVD"
+
+#: id:447
+msgid "Autorun media"
+msgstr "Autostarta media"
+
+#: id:448
+msgid "LCD"
+msgstr "LCD"
+
+#: id:449
+msgctxt "Auto context with id 449"
+msgid "Enabled"
+msgstr "På"
+
+#: id:450
+msgid "Columns"
+msgstr "Kolumner"
+
+#: id:451
+msgid "Row 1 address"
+msgstr "Rad 1 adress"
+
+#: id:452
+msgid "Row 2 address"
+msgstr "Rad 2 adress"
+
+#: id:453
+msgid "Row 3 address"
+msgstr "Rad 3 adress"
+
+#: id:454
+msgid "Row 4 address"
+msgstr "Rad 4 adress"
+
+#: id:455
+msgid "Rows"
+msgstr "Rader"
+
+#: id:456
+msgid "Mode"
+msgstr "Läge"
+
+#: id:457
+msgid "Switch view"
+msgstr "Växla vy"
+
+#: id:459
+msgid "Subs"
+msgstr "Undertexter"
+
+#: id:460
+msgid "Audio stream"
+msgstr "Ljudström"
+
+#: id:461
+msgid "[active]"
+msgstr "[aktiv]"
+
+#: id:462
+msgid "Subtitle"
+msgstr "Undertext"
+
+#: id:463
+msgid "Backlight"
+msgstr "Bakgrundsljus"
+
+#: id:464
+msgid "Brightness"
+msgstr "Ljusstyrka"
+
+#: id:465
+msgid "Contrast"
+msgstr "Kontrast"
+
+#: id:466
+msgid "Gamma"
+msgstr "Gamma"
+
+#: id:467
+msgctxt "Auto context with id 467"
+msgid "Type"
+msgstr "Typ"
+
+#: id:468
+msgid "Move the bar to change the OSD position"
+msgstr "Flytta stapeln för att ändra OSD-position"
+
+#: id:469
+msgid "OSD position"
+msgstr "OSD-position"
+
+#: id:470
+msgid "Credits"
+msgstr "Credits"
+
+#: id:471
+msgid "Modchip"
+msgstr "Modchipp"
+
+#: id:474
+msgctxt "Auto context with id 474"
+msgid "Off"
+msgstr "Av"
+
+#: id:475
+msgid "Music only"
+msgstr "Bara Musik"
+
+#: id:476
+msgctxt "Auto context with id 476"
+msgid "Music & video"
+msgstr "Musik & Video"
+
+#: id:477
+msgid "Unable to load playlist"
+msgstr "Kunde inte ladda spellista"
+
+#: id:478
+msgid "OSD"
+msgstr "OSD"
+
+#: id:479
+msgid "Skin & language"
+msgstr "Skal och språk"
+
+#: id:480
+msgid "Appearance"
+msgstr "Utseende"
+
+#: id:481
+msgid "Audio options"
+msgstr "Ljudalternativ"
+
+#: id:482
+msgid "About XBMC"
+msgstr "Om XBMC"
+
+#: id:485
+msgid "Delete album"
+msgstr "Radera album"
+
+#: id:486
+msgid "Repeat"
+msgstr "Repetera"
+
+#: id:487
+msgid "Repeat one"
+msgstr "Repetera en"
+
+#: id:488
+msgid "Repeat folder"
+msgstr "Repetera mappar"
+
+#: id:489
+msgid "Play the next song automatically"
+msgstr "Spela kommande låt automatiskt"
+
+#: id:491
+msgid "- Use big icons"
+msgstr "- Använd stora ikoner"
+
+#: id:492
+msgid "Resize VobSubs"
+msgstr "Förstora VOB-undertexter"
+
+#: id:493
+msgid "Advanced options (Experts Only!)"
+msgstr "Avancerade alternativ (bara för experter!)"
+
+#: id:494
+msgid "Overall audio headroom"
+msgstr "Totalt ljudutrymme (dB)"
+
+#: id:495
+msgid "Upsample videos to GUI resolution"
+msgstr "Sampla upp video till GUI-upplösning"
+
+#: id:496
+msgid "Calibration"
+msgstr "Kalibrering"
+
+#: id:497
+msgid "Show file extensions"
+msgstr "Visa filändelser"
+
+#: id:498
+msgid "Sort by: Type"
+msgstr "Sort: Typ"
+
+#: id:499
+msgid "Unable to connect to online lookup service"
+msgstr "Kunde inte kontakta informationsserver"
+
+#: id:500
+msgid "Downloading album information failed"
+msgstr "Nedladdning av albuminfo misslyckades"
+
+#: id:501
+msgid "Looking for album names..."
+msgstr "Letar efter albumnamn..."
+
+#: id:502
+msgctxt "Auto context with id 502"
+msgid "Open"
+msgstr "Öppen"
+
+#: id:503
+msgid "Busy"
+msgstr "Upptagen"
+
+#: id:504
+msgid "Empty"
+msgstr "Tom"
+
+#: id:505
+msgid "Loading media info from files..."
+msgstr "Laddar mediainfo från filer..."
+
+#: id:507
+msgid "Sort by: Usage"
+msgstr "Sort: Använd."
+
+#: id:510
+msgid "Enable visualizations"
+msgstr "Aktivera visualiseringar"
+
+#: id:511
+msgid "Enable video mode switching"
+msgstr "Aktivera videolägesväxling"
+
+#: id:512
+msgid "Startup window"
+msgstr "Startfönster"
+
+#: id:513
+msgid "Home window"
+msgstr "Hemfönster"
+
+#: id:514
+msgid "Manual settings"
+msgstr "Manuella inställningar"
+
+#: id:515
+msgid "Genre"
+msgstr "Genre"
+
+#: id:517
+msgid "Recently played albums"
+msgstr "Senast spelade album"
+
+#: id:518
+msgid "Launch"
+msgstr "Starta"
+
+#: id:519
+msgid "Launch in..."
+msgstr "Starta i..."
+
+#: id:521
+msgid "Compilations"
+msgstr "Kompileringar"
+
+#: id:522
+msgid "Remove source"
+msgstr "Ta bort källa"
+
+#: id:523
+msgid "Switch media"
+msgstr "Byt media"
+
+#: id:524
+msgid "Select playlist"
+msgstr "Välj spellista"
+
+#: id:525
+msgid "New playlist..."
+msgstr "Ny spellista..."
+
+#: id:526
+msgid "Add to playlist"
+msgstr "Lägg till i spellista"
+
+#: id:527
+msgid "Manually add to library"
+msgstr "Lägg till i databas"
+
+#: id:528
+msgid "Enter title"
+msgstr "Ange titel"
+
+#: id:529
+msgid "Error: Duplicate title"
+msgstr "Fel: Dublett-titel"
+
+#: id:530
+msgid "Select genre"
+msgstr "Välj genre"
+
+#: id:531
+msgid "New genre"
+msgstr "Ny genre"
+
+#: id:532
+msgid "Manual addition"
+msgstr "Manuellt tillägg"
+
+#: id:533
+msgid "Enter genre"
+msgstr "Lägg in genre"
+
+#: id:534
+msgid "View: %s"
+msgstr "Vy: %s"
+
+#: id:535
+msgid "List"
+msgstr "Lista"
+
+#: id:536
+msgid "Icons"
+msgstr "Ikoner"
+
+#: id:537
+msgid "Big list"
+msgstr "Stor lista"
+
+#: id:538
+msgid "Big icons"
+msgstr "Stora ikoner"
+
+#: id:539
+msgid "Wide"
+msgstr "Bred"
+
+#: id:540
+msgid "Big wide"
+msgstr "Stor bred"
+
+#: id:541
+msgid "Album icons"
+msgstr "Albumikoner"
+
+#: id:542
+msgid "DVD icons"
+msgstr "DVD-ikoner"
+
+#: id:543
+msgctxt "Auto context with id 543"
+msgid "DVD"
+msgstr "DVD"
+
+#: id:544
+msgctxt "Auto context with id 544"
+msgid "Media info"
+msgstr "Mediainfo"
+
+#: id:545
+msgid "Audio output device"
+msgstr "Ljudutgångsenhet"
+
+#: id:546
+msgid "Passthrough output device"
+msgstr "Ljudutgångsenhet för genomströmning"
+
+#: id:547
+msgid "No biography for this artist"
+msgstr "Ingen biografi för denna artist"
+
+#: id:548
+msgid "Downmix multichannel audio to stereo"
+msgstr "Mixa ned flerkanalsljud till stereo"
+
+#: id:550
+msgid "Sort by: %s"
+msgstr "Sort: %s"
+
+#: id:551
+msgctxt "Auto context with id 551"
+msgid "Name"
+msgstr "Namn"
+
+#: id:552
+msgid "Date"
+msgstr "Datum"
+
+#: id:553
+msgid "Size"
+msgstr "Storlek"
+
+#: id:554
+msgid "Track"
+msgstr "Spår"
+
+#: id:555
+msgid "Time"
+msgstr "Tid"
+
+#: id:556
+msgctxt "Auto context with id 556"
+msgid "Title"
+msgstr "Titel"
+
+#: id:557
+msgid "Artist"
+msgstr "Artist"
+
+#: id:558
+msgid "Album"
+msgstr "Album"
+
+#: id:559
+msgid "Playlist"
+msgstr "Spellista"
+
+#: id:560
+msgid "ID"
+msgstr "ID"
+
+#: id:561
+msgctxt "Auto context with id 561"
+msgid "File"
+msgstr "Fil"
+
+#: id:562
+msgctxt "Auto context with id 562"
+msgid "Year"
+msgstr "Årtal"
+
+#: id:563
+msgid "Rating"
+msgstr "Betyg"
+
+#: id:564
+msgctxt "Auto context with id 564"
+msgid "Type"
+msgstr "Typ"
+
+#: id:565
+msgid "Usage"
+msgstr "Användning"
+
+#: id:566
+msgid "Album artist"
+msgstr "Albumartist"
+
+#: id:567
+msgid "Play count"
+msgstr "Spelad räknare"
+
+#: id:568
+msgid "Last played"
+msgstr "Senast spelad"
+
+#: id:569
+msgctxt "Auto context with id 569"
+msgid "Comment"
+msgstr "Kommentar"
+
+#: id:570
+msgid "Date added"
+msgstr "Datum tillagt"
+
+#: id:571
+msgctxt "Auto context with id 571"
+msgid "Default"
+msgstr "Standard"
+
+#: id:572
+msgid "Studio"
+msgstr "Studio"
+
+#: id:573
+msgid "Path"
+msgstr "Sökväg"
+
+#: id:574
+msgctxt "Auto context with id 574"
+msgid "Country"
+msgstr "Land"
+
+#: id:575
+msgid "In progress"
+msgstr "Pågår"
+
+#: id:576
+msgid "Times played"
+msgstr "Gånger spelad"
+
+#: id:580
+msgid "Sort direction"
+msgstr "Sorteringsriktning"
+
+#: id:581
+msgid "Sort method"
+msgstr "Sorteringsmetod"
+
+#: id:582
+msgctxt "Auto context with id 582"
+msgid "View mode"
+msgstr "Visningsläge"
+
+#: id:583
+msgid "Remember views for different folders"
+msgstr "Kom ihåg visningslägen för olika mappar"
+
+#: id:584
+msgid "Ascending"
+msgstr "Stigande"
+
+#: id:585
+msgid "Descending"
+msgstr "Fallande"
+
+#: id:586
+msgid "Edit playlist"
+msgstr "Redigera spellista"
+
+#: id:587
+msgid "Filter"
+msgstr "Filter"
+
+#: id:588
+msgid "Cancel party mode"
+msgstr "Avbryt partyläge"
+
+#: id:589
+msgid "Party mode"
+msgstr "Partyläge"
+
+#: id:590
+msgid "Random"
+msgstr "Slumpmässig"
+
+#: id:591
+msgctxt "Auto context with id 591"
+msgid "Off"
+msgstr "Av"
+
+#: id:592
+msgid "One"
+msgstr "En"
+
+#: id:593
+msgid "All"
+msgstr "Alla"
+
+#: id:594
+msgctxt "Auto context with id 594"
+msgid "Off"
+msgstr "Av"
+
+#: id:595
+msgid "Repeat: Off"
+msgstr "Repetera: Av"
+
+#: id:596
+msgid "Repeat: One"
+msgstr "Repetera: En"
+
+#: id:597
+msgid "Repeat: All"
+msgstr "Repetera: Alla"
+
+#: id:600
+msgid "Rip audio CD"
+msgstr "Rippa ljud-CD"
+
+#: id:601
+msgctxt "Auto context with id 601"
+msgid "Medium"
+msgstr "Medel"
+
+#: id:602
+msgctxt "Auto context with id 602"
+msgid "Standard"
+msgstr "Standard"
+
+#: id:603
+msgid "Extreme"
+msgstr "Extrem"
+
+#: id:604
+msgid "Constant bitrate"
+msgstr "Konstant bitrate"
+
+#: id:605
+msgid "Ripping..."
+msgstr "Rippar..."
+
+#: id:607
+msgid "To:"
+msgstr "Till:"
+
+#: id:608
+msgid "Could not rip CD or track"
+msgstr "Kunde inte rippa CD eller spår"
+
+#: id:609
+msgid "CDDARipPath is not set."
+msgstr "CDDA-sökväg inte angiven."
+
+#: id:610
+msgid "Rip audio track"
+msgstr "Rippa ljudspår"
+
+#: id:611
+msgid "Enter number"
+msgstr "Ange nummer"
+
+#: id:612
+msgid "Bits/Sample"
+msgstr "Bitar/Sampling"
+
+#: id:613
+msgid "Sample Frequency"
+msgstr "Samplingsfrekvens"
+
+#: id:620
+msgid "Audio CDs"
+msgstr "Ljud-CD"
+
+#: id:621
+msgid "Encoder"
+msgstr "Omkodare"
+
+#: id:622
+msgid "Quality"
+msgstr "Kvalitet"
+
+#: id:623
+msgid "Bitrate"
+msgstr "Bitrate"
+
+#: id:624
+msgid "Include track number"
+msgstr "Inkludera spårnummer"
+
+#: id:625
+msgid "All songs of"
+msgstr "Alla låtar av"
+
+#: id:629
+msgctxt "Auto context with id 629"
+msgid "View mode"
+msgstr "Visningsläge"
+
+#: id:630
+msgctxt "Auto context with id 630"
+msgid "Normal"
+msgstr "Normal"
+
+#: id:631
+msgid "Zoom"
+msgstr "Zoom"
+
+#: id:632
+msgid "Stretch 4:3"
+msgstr "Sträck 4:3"
+
+#: id:633
+msgid "Wide Zoom"
+msgstr "Bred zoom"
+
+#: id:634
+msgid "Stretch 16:9"
+msgstr "Sträck 16:9"
+
+#: id:635
+msgid "Original Size"
+msgstr "Originalstorlek"
+
+#: id:636
+msgctxt "Auto context with id 636"
+msgid "Custom"
+msgstr "Anpassad storlek"
+
+#: id:637
+msgid "Replay gain"
+msgstr "Replay Gain"
+
+#: id:638
+msgid "Replaygain volume adjustments"
+msgstr "Replay Gain-volymjusteringar"
+
+#: id:639
+msgid "Use track levels"
+msgstr "Använd låtnivåer"
+
+#: id:640
+msgid "Use album levels"
+msgstr "Använd albumnivåer"
+
+#: id:641
+msgid "PreAmp Level - Replay gained files"
+msgstr "Förstärkarnivå - Replay Gain-filer"
+
+#: id:642
+msgid "PreAmp Level - Non replay gained files"
+msgstr "Förstärkarnivå - Icke Replay Gain-filer"
+
+#: id:643
+msgid "Avoid clipping on replay gained files"
+msgstr "Undvik klippning på Replay Gain filer"
+
+#: id:644
+msgid "Crop black bars"
+msgstr "Klipp bort svarta ramar"
+
+#: id:645
+msgid "Need to unpack a big file. Continue?"
+msgstr "Måste packa upp en stor fil. Fortsätta?"
+
+#: id:646
+msgid "Remove from library"
+msgstr "Ta bort från bibliotek"
+
+#: id:647
+msgid "Export video library"
+msgstr "Exportera filmbibliotek"
+
+#: id:648
+msgid "Import video library"
+msgstr "Importera filmbibliotek"
+
+#: id:649
+msgid "Importing"
+msgstr "Importerar"
+
+#: id:650
+msgid "Exporting"
+msgstr "Exporterar"
+
+#: id:651
+msgid "Browse for library"
+msgstr "Bläddra efter bibliotek"
+
+#: id:652
+msgid "Years"
+msgstr "År"
+
+#: id:653
+msgid "Update library"
+msgstr "Uppdatera bibliotek"
+
+#: id:654
+msgid "Show debug info"
+msgstr "Visa debuginfo"
+
+#: id:655
+msgid "Browse for executable"
+msgstr "Bläddra efter körbar fil"
+
+#: id:656
+msgid "Browse for playlist"
+msgstr "Bläddra efter spellista"
+
+#: id:657
+msgid "Browse for folder"
+msgstr "Bläddra efter mapp"
+
+#: id:658
+msgid "Song information"
+msgstr "Låtinformation"
+
+#: id:659
+msgid "Non-linear stretch"
+msgstr "Icke-linjär sträckning"
+
+#: id:660
+msgid "Volume amplification"
+msgstr "Volymförstärkning"
+
+#: id:661
+msgid "Choose export folder"
+msgstr "Välj exporteringsmapp"
+
+#: id:662
+msgid "This file is no longer available."
+msgstr "Denna fil är inte tillgänglig längre."
+
+#: id:663
+msgid "Would you like to remove it from the library?"
+msgstr "Vill du ta bort den från biblioteket?"
+
+#: id:664
+msgid "Browse for Script"
+msgstr "Bläddra efter skript"
+
+#: id:665
+msgid "Compression level"
+msgstr "Kompressionsnivå"
+
+#: id:700
+msgid "Cleaning up library"
+msgstr "Rensar bibliotek"
+
+#: id:701
+msgid "Removing old songs from the library"
+msgstr "Raderar gamla låtar från databasen"
+
+#: id:702
+msgid "This path has been scanned before"
+msgstr "Denna sökväg har skannats tidigare"
+
+#: id:705
+msgctxt "Auto context with id 705"
+msgid "Network"
+msgstr "Nätverk"
+
+#: id:706
+msgid "- Server"
+msgstr "- Server"
+
+#: id:708
+msgid "Use an HTTP proxy server to access the internet"
+msgstr "Använd en HTTP-proxyserver för att ansluta till internet"
+
+#: id:711
+msgid "Internet Protocol (IP)"
+msgstr "Internetprotokoll (IP)"
+
+#: id:712
+msgid "Invalid port specified. Value must be between 1 and 65535."
+msgstr "Felaktig port angiven. Värde måste vara mellan 1 och 65535."
+
+#: id:713
+msgid "HTTP proxy"
+msgstr "HTTP-proxy"
+
+#: id:715
+msgid "- Assignment"
+msgstr "- Tilldelning"
+
+#: id:716
+msgid "Automatic (DHCP)"
+msgstr "Automatisk (DHCP)"
+
+#: id:717
+msgid "Manual (Static)"
+msgstr "Manuell (Statisk)"
+
+#: id:719
+msgid "- IP address"
+msgstr "- IP-adress"
+
+#: id:720
+msgid "- Netmask"
+msgstr "- Nätmask"
+
+#: id:721
+msgid "- Default gateway"
+msgstr "- Standardgateway"
+
+#: id:722
+msgid "- DNS server"
+msgstr "- DNS-server"
+
+#: id:723
+msgid "Save & restart"
+msgstr "Spara & starta om"
+
+#: id:724
+msgid "Invalid address specified. Value must be AAA.BBB.CCC.DDD"
+msgstr "Felaktig adress angiven. Formatet skall vara"
+
+#: id:725
+msgid "with numbers between 0 and 255."
+msgstr "AAA.BBB.CCC.DDD med siffror mellan 0 och 255."
+
+#: id:726
+msgid "Changes not saved. Continue without saving?"
+msgstr "Inställningar sparades inte. Fortsätt utan att spara?"
+
+#: id:727
+msgid "Web server"
+msgstr "Webbserver"
+
+#: id:728
+msgctxt "Auto context with id 728"
+msgid "FTP server"
+msgstr "FTP-server"
+
+#: id:730
+msgid "- Port"
+msgstr "- Port"
+
+#: id:732
+msgid "Save & apply"
+msgstr "Spara & ange"
+
+#: id:733
+msgid "- Password"
+msgstr "- Lösenord"
+
+#: id:734
+msgid "No pass"
+msgstr "Inget lösenord"
+
+#: id:735
+msgid "- Character set"
+msgstr "- Teckenuppsättning"
+
+#: id:736
+msgid "- Style"
+msgstr "- Stil"
+
+#: id:737
+msgid "- Colour"
+msgstr "- Färg"
+
+#: id:738
+msgctxt "Auto context with id 738"
+msgid "Normal"
+msgstr "Normal"
+
+#: id:739
+msgid "Bold"
+msgstr "Fet"
+
+#: id:740
+msgid "Italics"
+msgstr "Kursiv"
+
+#: id:741
+msgid "Bold italics"
+msgstr "Fet kursiv"
+
+#: id:742
+msgctxt "Auto context with id 742"
+msgid "White"
+msgstr "Vit"
+
+#: id:743
+msgctxt "Auto context with id 743"
+msgid "Yellow"
+msgstr "Gul"
+
+#: id:744
+msgctxt "Auto context with id 744"
+msgid "Files"
+msgstr "Filer"
+
+#: id:745
+msgid "No scanned information for this view"
+msgstr "Ingen skannad information för denna vy"
+
+#: id:746
+msgid "Please turn off library mode"
+msgstr "Byt tillbaka till fil-vyn"
+
+#: id:747
+msgid "Error loading image"
+msgstr "Fel vid laddning av bilden"
+
+#: id:748
+msgid "Edit path"
+msgstr "Ändra sökväg"
+
+#: id:749
+msgid "Mirror image"
+msgstr "Spegelvänd bild"
+
+#: id:750
+msgid "Are you sure?"
+msgstr "Är du säker?"
+
+#: id:751
+msgid "Removing source"
+msgstr "Tar bort källa"
+
+#: id:754
+msgid "Add program link"
+msgstr "Lägg till programlänk"
+
+#: id:755
+msgid "Edit program path"
+msgstr "Ändra programsökväg"
+
+#: id:756
+msgid "Edit program name"
+msgstr "Ändra programnamn"
+
+#: id:757
+msgid "Edit path depth"
+msgstr "Ändra sökvägsdjup"
+
+#: id:759
+msgid "View: Big list"
+msgstr "Vy: Stor lista"
+
+#: id:760
+msgctxt "Auto context with id 760"
+msgid "Yellow"
+msgstr "Gul"
+
+#: id:761
+msgctxt "Auto context with id 761"
+msgid "White"
+msgstr "Vit"
+
+#: id:762
+msgid "Blue"
+msgstr "Blå"
+
+#: id:763
+msgid "Bright green"
+msgstr "Ljusgrön"
+
+#: id:764
+msgid "Yellow green"
+msgstr "Gulgrön"
+
+#: id:765
+msgid "Cyan"
+msgstr "Cyan"
+
+#: id:766
+msgid "Light grey"
+msgstr "Ljusgrå"
+
+#: id:767
+msgid "Grey"
+msgstr "Grå"
+
+#: id:770
+msgid "Error %i: share not available"
+msgstr "Fel %i: utdelningen inte tillgänglig"
+
+#: id:772
+msgctxt "Auto context with id 772"
+msgid "Audio output"
+msgstr "Ljudutgång"
+
+#: id:773
+msgid "Seeking"
+msgstr "Söker"
+
+#: id:774
+msgid "Slideshow folder"
+msgstr "Mapp för bildspelsskärmsläckare"
+
+#: id:775
+msgid "Network interface"
+msgstr "Nätverksgränssnitt"
+
+#: id:776
+msgid "- Wireless network name (ESSID)"
+msgstr "- Trådlöst nätverksnamn (ESSID)"
+
+#: id:777
+msgid "- Wireless password"
+msgstr "- Trådlöst lösenord"
+
+#: id:778
+msgid "- Wireless security"
+msgstr "- Trådlös säkerhet"
+
+#: id:779
+msgid "Save and apply network interface settings"
+msgstr "Spara och applicera inställningar för nätversgränssnittet"
+
+#: id:780
+msgid "No encryption"
+msgstr "Ingen kryptering"
+
+#: id:781
+msgid "WEP"
+msgstr "WEP"
+
+#: id:782
+msgid "WPA"
+msgstr "WPA"
+
+#: id:783
+msgid "WPA2"
+msgstr "WPA2"
+
+#: id:784
+msgid "Applying network interface settings. Please wait."
+msgstr "Applicerar inställningar för nätverksgränssnitt. Var god vänta."
+
+#: id:785
+msgid "Network interface restarted successfully."
+msgstr "Lyckad omstart av nätversgränssnittet."
+
+#: id:786
+msgid "Network interface did not start successfully."
+msgstr "Nätverkgränssnittet lyckades inte starta."
+
+#: id:787
+msgid "Interface disabled"
+msgstr "Gränssnitt inaktiverat"
+
+#: id:788
+msgid "Network interface disabled successfully."
+msgstr "Inaktivering av nätverkgränssnittet lyckades."
+
+#: id:789
+msgid "Wireless network name (ESSID)"
+msgstr "Trådlöst nätverksnamn (ESSID)"
+
+#: id:790
+msgid "Remote control"
+msgstr ""
+
+#: id:791
+msgid "Allow programs on this system to control XBMC"
+msgstr "Tillåt program på detta system att kontrollera XBMC"
+
+#: id:792
+msgctxt "Auto context with id 792"
+msgid "Port"
+msgstr "Port"
+
+#: id:793
+msgid "Port range"
+msgstr "Portintervall"
+
+#: id:794
+msgid "Allow programs on other systems to control XBMC"
+msgstr "Tillåt program på andra system att kontrollera XBMC"
+
+#: id:795
+msgid "Initial repeat delay (ms)"
+msgstr "Begynnande repetitionsfördröjning (ms)"
+
+#: id:796
+msgid "Continuous repeat delay (ms)"
+msgstr "Kontinuerligt repititionsfördröjning (ms)"
+
+#: id:797
+msgid "Maximum number of clients"
+msgstr "Maximalt antal klienter"
+
+#: id:798
+msgid "Internet access"
+msgstr "Internetåtkomst"
+
+#: id:850
+msgid "Invalid port number entered"
+msgstr "Ogiltigt portnummer angivet"
+
+#: id:851
+msgid "Valid port range is 1-65535"
+msgstr "Giltigt portintervall är 1-65535"
+
+#: id:852
+msgid "Valid port range is 1024-65535"
+msgstr "Giltigt portintervall är 1024-65535"
+
+#: id:998
+msgid "Add Music..."
+msgstr "Lägg till musik..."
+
+#: id:999
+msgid "Add Videos..."
+msgstr "Lägg till video..."
+
+#: id:1000
+msgid "- Preview"
+msgstr "- Förhandsgranska"
+
+#: id:1001
+msgid "Unable to connect"
+msgstr "Kunde inte ansluta"
+
+#: id:1002
+msgid "XBMC was unable to connect to the network location."
+msgstr "XBMC kunde inte ansluta till nätverksplatsen."
+
+#: id:1003
+msgid "This could be due to the network not being connected."
+msgstr "Detta kan bero på att nätverket inte är anslutet."
+
+#: id:1004
+msgid "Would you like to add it anyway?"
+msgstr "Vill du lägga till detta i alla fall?"
+
+#: id:1006
+msgctxt "Auto context with id 1006"
+msgid "IP address"
+msgstr "IP-adress"
+
+#: id:1007
+msgid "Add network location"
+msgstr "Lägg till nätverksplats"
+
+#: id:1008
+msgid "Protocol"
+msgstr "Protokoll"
+
+#: id:1009
+msgid "Server address"
+msgstr "Serveradress"
+
+#: id:1010
+msgid "Server name"
+msgstr "Servernamn"
+
+#: id:1011
+msgid "Remote path"
+msgstr "Fjärrsökväg"
+
+#: id:1012
+msgid "Shared folder"
+msgstr "Delad mapp"
+
+#: id:1013
+msgctxt "Auto context with id 1013"
+msgid "Port"
+msgstr "Port"
+
+#: id:1014
+msgctxt "Auto context with id 1014"
+msgid "Username"
+msgstr "Användarnamn"
+
+#: id:1015
+msgid "Browse for network server"
+msgstr "Bläddra efter nätverksserver"
+
+#: id:1016
+msgid "Enter the network address of the server"
+msgstr "Ange nätverksadress för denna server"
+
+#: id:1017
+msgid "Enter the path on the server"
+msgstr "Ange sökvägen på servern"
+
+#: id:1018
+msgid "Enter the port number"
+msgstr "Ange portnumret"
+
+#: id:1019
+msgid "Enter the username"
+msgstr "Ange användarnamn"
+
+#: id:1020
+msgid "Add %s source"
+msgstr "Lägg till %s-källa"
+
+#: id:1021
+msgid "Enter the paths or browse for the media locations."
+msgstr "Skriv in sökväg eller bläddra efter mediaplatser."
+
+#: id:1022
+msgid "Enter a name for this media Source."
+msgstr "Skriv in namn för denna mediakälla."
+
+#: id:1023
+msgid "Browse for new share"
+msgstr "Bläddra efter ny utdelning"
+
+#: id:1024
+msgid "Browse"
+msgstr "Bläddra"
+
+#: id:1025
+msgid "Could not retrieve directory information."
+msgstr "Kunde inte hämta mappinformation."
+
+#: id:1026
+msgid "Add source"
+msgstr "Lägg till källa"
+
+#: id:1027
+msgid "Edit source"
+msgstr "Redigera källa"
+
+#: id:1028
+msgid "Edit %s source"
+msgstr "Redigera %s-källa"
+
+#: id:1029
+msgid "Enter the new label"
+msgstr "Skriv in den nya beskrivningen"
+
+#: id:1030
+msgid "Browse for image"
+msgstr "Bläddra efter bild"
+
+#: id:1031
+msgid "Browse for image folder"
+msgstr "Bläddra efter bildmapp"
+
+#: id:1032
+msgid "Add network location..."
+msgstr "Lägg till nätverksplats..."
+
+#: id:1033
+msgid "Browse for file"
+msgstr "Bläddra efter fil"
+
+#: id:1034
+msgid "Submenu"
+msgstr "Undermeny"
+
+#: id:1035
+msgid "Enable submenu buttons"
+msgstr "Aktivera undermenyknappar"
+
+#: id:1036
+msgid "Favourites"
+msgstr "Favoriter"
+
+#: id:1037
+msgid "Video Add-ons"
+msgstr "Filmtillägg"
+
+#: id:1038
+msgid "Music Add-ons"
+msgstr "Musiktillägg"
+
+#: id:1039
+msgid "Picture Add-ons"
+msgstr "Bildtillägg"
+
+#: id:1040
+msgid "Loading directory"
+msgstr "Laddar mapp"
+
+#: id:1041
+msgid "Retrieved %i items"
+msgstr "Hämtade %i objekt"
+
+#: id:1042
+msgid "Retrieved %i of %i items"
+msgstr "Hämtade %i av %i objekt"
+
+#: id:1043
+msgid "Program Add-ons"
+msgstr "Programtillägg"
+
+#: id:1044
+msgid "Set plugin thumb"
+msgstr "Ange tilläggsminiatyr"
+
+#: id:1045
+msgid "Add-on settings"
+msgstr "Tilläggsinställningar"
+
+#: id:1046
+msgid "Access points"
+msgstr "Accesspunkter"
+
+#: id:1047
+msgid "Other..."
+msgstr "Annan..."
+
+#: id:1048
+msgid "- Username"
+msgstr "- Användarnamn"
+
+#: id:1049
+msgid "Script settings"
+msgstr "Skriptinställningar"
+
+#: id:1050
+msgid "Singles"
+msgstr "Singlar"
+
+#: id:1051
+msgid "Enter web address"
+msgstr "Skriv in webbadress"
+
+#: id:1200
+msgid "SMB client"
+msgstr "SMB-klient"
+
+#: id:1202
+msgid "Workgroup"
+msgstr "Arbetsgrupp"
+
+#: id:1203
+msgid "Default username"
+msgstr "Standardanvändarnamn"
+
+#: id:1204
+msgid "Default password"
+msgstr "Standardlösenord"
+
+#: id:1207
+msgid "WINS server"
+msgstr "WINS-server"
+
+#: id:1208
+msgid "Mount SMB shares"
+msgstr "Montera SMB-utdelningar"
+
+#: id:1210
+msgctxt "Auto context with id 1210"
+msgid "Remove"
+msgstr "Ta bort"
+
+#: id:1211
+msgctxt "Auto context with id 1211"
+msgid "Music"
+msgstr "Musik"
+
+#: id:1212
+msgctxt "Auto context with id 1212"
+msgid "Video"
+msgstr "Video"
+
+#: id:1213
+msgctxt "Auto context with id 1213"
+msgid "Pictures"
+msgstr "Bilder"
+
+#: id:1214
+msgctxt "Auto context with id 1214"
+msgid "Files"
+msgstr "Filer"
+
+#: id:1215
+msgctxt "Auto context with id 1215"
+msgid "Music & video"
+msgstr "Musik & Video"
+
+#: id:1216
+msgid "Music & pictures"
+msgstr "Musik & Bilder"
+
+#: id:1217
+msgid "Music & files"
+msgstr "Musik & Filer"
+
+#: id:1218
+msgid "Video & pictures"
+msgstr "Video & Bilder"
+
+#: id:1219
+msgid "Video & files"
+msgstr "Video & Filer"
+
+#: id:1220
+msgid "Pictures & files"
+msgstr "Bilder & Filer"
+
+#: id:1221
+msgid "Music & video & pictures"
+msgstr "Musik & Video & Bilder"
+
+#: id:1222
+msgid "Music & video & pictures & files"
+msgstr "Musik & Video & Bilder & Filer"
+
+#: id:1223
+msgctxt "Auto context with id 1223"
+msgid "Disabled"
+msgstr "Inaktiverad"
+
+#: id:1226
+msgid "Files & music & video"
+msgstr "Filer & Musik & Video"
+
+#: id:1227
+msgid "Files & pictures & music"
+msgstr "Filer & Bilder & Musik"
+
+#: id:1228
+msgid "Files & pictures & video"
+msgstr "Filer & Bilder & Video"
+
+#: id:1229
+msgid "Music & programs"
+msgstr "Musik & Program"
+
+#: id:1230
+msgid "Video & programs"
+msgstr "Video & Program"
+
+#: id:1231
+msgid "Pictures & programs"
+msgstr "Bilder & Program"
+
+#: id:1232
+msgid "Music & video & pictures & programs"
+msgstr "Musik & Video & Bilder & Program"
+
+#: id:1233
+msgid "Programs & video & music"
+msgstr "Program & Video & Musik"
+
+#: id:1234
+msgid "Programs & pictures & music"
+msgstr "Program & Bilder & Musik"
+
+#: id:1235
+msgid "Programs & pictures & video"
+msgstr "Program & Bilder & Video"
+
+#: id:1250
+msgid "Auto-detection"
+msgstr "Autodetektering"
+
+#: id:1251
+msgid "Auto-detect system"
+msgstr "Autodetektera system"
+
+#: id:1252
+msgid "Nickname"
+msgstr "Smeknamn"
+
+#: id:1254
+msgid "Ask to connect"
+msgstr "Fråga om att ansluta"
+
+#: id:1255
+msgid "Send FTP user and password"
+msgstr "Skicka FTP-användare och lösenord"
+
+#: id:1256
+msgid "Ping interval"
+msgstr "Pingintervall (sek)"
+
+#: id:1257
+msgid "Would you like to connect to the auto-detected system?"
+msgstr "Vill du ansluta till det autodetekterade systemet?"
+
+#: id:1259
+msgid "Zeroconf"
+msgstr ""
+
+#: id:1260
+msgid "Announce these services to other systems via Zeroconf"
+msgstr "Publicera dessa tjänster till andra system via Zeroconf"
+
+#: id:1270
+msgid "Allow XBMC to receive AirPlay content"
+msgstr "Tillåt XBMC att ta emot AirPlay-innehåll"
+
+#: id:1271
+msgid "Device name"
+msgstr "Enhetsnamn"
+
+#: id:1272
+msgid "- Use password protection"
+msgstr "- Använd lösenordsskydd"
+
+#: id:1273
+msgid "AirPlay"
+msgstr ""
+
+#: id:1300
+msgid "Custom audio device"
+msgstr "Anpassad ljudenhet"
+
+#: id:1301
+msgid "Custom passthrough device"
+msgstr "Anpassad ljudutgångsenhet för genomströmning"
+
+#: id:1396
+msgid "Drifting"
+msgstr "Blåsigt"
+
+#: id:1397
+msgid "and"
+msgstr "och"
+
+#: id:1398
+msgid "Freezing"
+msgstr "Nollgradigt"
+
+#: id:1399
+msgid "Late"
+msgstr "Sent"
+
+#: id:1400
+msgid "Isolated"
+msgstr "Isolerade"
+
+#: id:1401
+msgid "Thundershowers"
+msgstr "Åskskurar"
+
+#: id:1402
+msgid "Thunder"
+msgstr "Åska"
+
+#: id:1403
+msgctxt "Auto context with id 1403"
+msgid "Sun"
+msgstr "Sol"
+
+#: id:1404
+msgid "Heavy"
+msgstr "Tunga"
+
+#: id:1405
+msgid "in"
+msgstr "i"
+
+#: id:1406
+msgid "the"
+msgstr ""
+
+#: id:1407
+msgid "Vicinity"
+msgstr "närområdet"
+
+#: id:1408
+msgid "Ice"
+msgstr "Is"
+
+#: id:1409
+msgid "Crystals"
+msgstr "Flingor"
+
+#: id:1410
+msgid "Calm"
+msgstr "Lugnt"
+
+#: id:1411
+msgid "with"
+msgstr "med"
+
+#: id:1412
+msgid "windy"
+msgstr "blåsigt"
+
+#: id:1413
+msgid "drizzle"
+msgstr "duggregn"
+
+#: id:1414
+msgid "Thunderstorm"
+msgstr "Åskstorm"
+
+#: id:1415
+msgid "Drizzle"
+msgstr "Duggar"
+
+#: id:1416
+msgid "Foggy"
+msgstr "Disigt"
+
+#: id:1417
+msgid "Grains"
+msgstr "Grynigt"
+
+#: id:1418
+msgid "T-Storms"
+msgstr "Åskstorm"
+
+#: id:1419
+msgid "T-Showers"
+msgstr "Åskskurar"
+
+#: id:1420
+msgid "Moderate"
+msgstr "Moderat"
+
+#: id:1421
+msgid "Very High"
+msgstr "Väldigt hög"
+
+#: id:1422
+msgid "Windy"
+msgstr "Blåsigt"
+
+#: id:1423
+msgid "Mist"
+msgstr "Dimma"
+
+#: id:1450
+msgid "Put display to sleep when idle"
+msgstr "Slå av bildskärm vid inaktivitet"
+
+#: id:2050
+msgid "Runtime"
+msgstr "Speltid"
+
+#: id:2100
+msgid "Script failed! : %s"
+msgstr "Skript misslyckades! : %s"
+
+#: id:2101
+msgid "Newer version needed - See log"
+msgstr "Nyare version behövs - Se loggen"
+
+#: id:4501
+msgid "Enable LCD/VFD"
+msgstr "Aktivera LCD/VFD"
+
+#: id:10000
+msgid "Home"
+msgstr "Hem"
+
+#: id:10001
+msgctxt "Auto context with id 10001"
+msgid "Programs"
+msgstr "Program"
+
+#: id:10002
+msgctxt "Auto context with id 10002"
+msgid "Pictures"
+msgstr "Bilder"
+
+#: id:10003
+msgctxt "Auto context with id 10003"
+msgid "File manager"
+msgstr "Filhanterare"
+
+#: id:10004
+msgctxt "Auto context with id 10004"
+msgid "Settings"
+msgstr "Inställningar"
+
+#: id:10005
+msgctxt "Auto context with id 10005"
+msgid "Music"
+msgstr "Musik"
+
+#: id:10006
+msgctxt "Auto context with id 10006"
+msgid "Videos"
+msgstr "Filmer"
+
+#: id:10007
+msgid "System information"
+msgstr "Systeminformation"
+
+#: id:10008
+msgid "Settings - General"
+msgstr "Inställningar - Allmänna"
+
+#: id:10009
+msgid "Settings - Screen"
+msgstr "Inställningar - Bildskärm"
+
+#: id:10010
+msgid "Settings - Appearance - GUI Calibration"
+msgstr "Inställningar - Utseende - GUI-kalibrering"
+
+#: id:10011
+msgid "Settings - Videos - Screen Calibration"
+msgstr "Inställningar - Filmer - Skärmkalibrering"
+
+#: id:10012
+msgid "Settings - Pictures"
+msgstr "Inställningar - Bilder"
+
+#: id:10013
+msgid "Settings - Programs"
+msgstr "Inställningar - Program"
+
+#: id:10014
+msgid "Settings - Weather"
+msgstr "Inställningar - Väder"
+
+#: id:10015
+msgid "Settings - Music"
+msgstr "Inställningar - Musik"
+
+#: id:10016
+msgid "Settings - System"
+msgstr "Inställningar - System"
+
+#: id:10017
+msgid "Settings - Videos"
+msgstr "Inställningar - Filmer"
+
+#: id:10018
+msgid "Settings - Network"
+msgstr "Inställningar - Nätverk"
+
+#: id:10019
+msgid "Settings - Appearance"
+msgstr "Inställningar - Utseende"
+
+#: id:10020
+msgctxt "Auto context with id 10020"
+msgid "Scripts"
+msgstr "Skript"
+
+#: id:10021
+msgid "Web Browser"
+msgstr "Webbläsare"
+
+#: id:10025
+msgctxt "Auto context with id 10025"
+msgid "Videos"
+msgstr ""
+
+#: id:10028
+msgid "Videos/Playlist"
+msgstr "Filmer/Spellista"
+
+#: id:10029
+msgctxt "Auto context with id 10029"
+msgid "Login screen"
+msgstr ""
+
+#: id:10034
+msgid "Settings - Profiles"
+msgstr "Inställningar - Profiler"
+
+#: id:10040
+msgid "Addon browser"
+msgstr ""
+
+#: id:10100
+msgid "Yes/No dialog"
+msgstr "Ja/Nej-dialog"
+
+#: id:10101
+msgid "Progress dialog"
+msgstr "Förloppsdialog"
+
+#: id:10210
+msgid "Looking for subtitles..."
+msgstr "Letar efter undertexter..."
+
+#: id:10211
+msgid "Looking for or caching subtitles..."
+msgstr "Letar efter eller buffrar undertexter..."
+
+#: id:10212
+msgid "terminating"
+msgstr "avbryter"
+
+#: id:10213
+msgid "buffering"
+msgstr "buffrar"
+
+#: id:10214
+msgid "Opening stream"
+msgstr "Öppnar ström"
+
+#: id:10500
+msgid "Music/Playlist"
+msgstr "Musik/Spellista"
+
+#: id:10501
+msgid "Music/Files"
+msgstr "Musik/Filer"
+
+#: id:10502
+msgid "Music/Library"
+msgstr "Musik/Bibliotek"
+
+#: id:10503
+msgid "Playlist editor"
+msgstr "Spellistsredigerare"
+
+#: id:10504
+msgid "Top 100 songs"
+msgstr "Topp 100 låtar"
+
+#: id:10505
+msgid "Top 100 albums"
+msgstr "Topp 100 album"
+
+#: id:10506
+msgctxt "Auto context with id 10506"
+msgid "Programs"
+msgstr "Program"
+
+#: id:10507
+msgid "Configuration"
+msgstr "Konfiguration"
+
+#: id:10508
+msgid "Weather forecast"
+msgstr "Väderprognos"
+
+#: id:10509
+msgid "Network gaming"
+msgstr "Nätverksspel"
+
+#: id:10510
+msgid "Extensions"
+msgstr "Tillägg"
+
+#: id:10511
+msgctxt "Auto context with id 10511"
+msgid "System info"
+msgstr "Systeminfo"
+
+#: id:10516
+msgid "Music - Library"
+msgstr "Musik - Bibliotek"
+
+#: id:10517
+msgid "Now Playing - Music"
+msgstr "Nu spelas - Musik"
+
+#: id:10522
+msgid "Now Playing - Videos"
+msgstr "Nu spelas - Filmer"
+
+#: id:10523
+msgid "Album info"
+msgstr "Albuminfo"
+
+#: id:10524
+msgid "Movie info"
+msgstr "Filminfo"
+
+#: id:12000
+msgid "Select dialog"
+msgstr "Valdialog"
+
+#: id:12001
+msgid "Music/Info"
+msgstr "Musik/Info"
+
+#: id:12002
+msgid "Dialog OK"
+msgstr "Dialog OK"
+
+#: id:12003
+msgid "Videos/Info"
+msgstr "Filmer/Info"
+
+#: id:12004
+msgid "Scripts/Info"
+msgstr "Skript/Info"
+
+#: id:12005
+msgid "Fullscreen video"
+msgstr "Fullskärmsvideo"
+
+#: id:12006
+msgid "Audio visualization"
+msgstr "Ljudvisualisering"
+
+#: id:12008
+msgid "File stacking dialog"
+msgstr "Filsammanslagningsdialog"
+
+#: id:12009
+msgid "Rebuild index..."
+msgstr "Återuppbygg index..."
+
+#: id:12010
+msgid "Return to music window"
+msgstr "Återgå till Musik"
+
+#: id:12011
+msgid "Return to videos window"
+msgstr "Återgå till Filmer"
+
+#: id:12021
+msgid "Start from beginning"
+msgstr "Starta från början"
+
+#: id:12022
+msgid "Resume from %s"
+msgstr "Återuppta från %s"
+
+#: id:12310
+msgid "0"
+msgstr "0"
+
+#: id:12311
+msgid "1"
+msgstr "1"
+
+#: id:12312
+msgid "2"
+msgstr "2"
+
+#: id:12313
+msgid "3"
+msgstr "3"
+
+#: id:12314
+msgid "4"
+msgstr "4"
+
+#: id:12315
+msgid "5"
+msgstr "5"
+
+#: id:12316
+msgid "6"
+msgstr "6"
+
+#: id:12317
+msgid "7"
+msgstr "7"
+
+#: id:12318
+msgid "8"
+msgstr "8"
+
+#: id:12319
+msgid "9"
+msgstr "9"
+
+#: id:12320
+msgid "c"
+msgstr "c"
+
+#: id:12321
+msgid "Ok"
+msgstr "Ok"
+
+#: id:12322
+msgid "*"
+msgstr "*"
+
+#: id:12325
+msgid "Locked! Enter code..."
+msgstr "Låst! Ange kod..."
+
+#: id:12326
+msgid "Enter password"
+msgstr "Ange lösenord"
+
+#: id:12327
+msgid "Enter master code"
+msgstr "Ange huvudkod"
+
+#: id:12328
+msgid "Enter unlock code"
+msgstr "Ange låskod"
+
+#: id:12329
+msgid "or press C to cancel"
+msgstr "eller tryck C för att avbryta"
+
+#: id:12330
+msgid "Enter gamepad button combo and"
+msgstr "Ange knappkombination på spelkontrollen och"
+
+#: id:12331
+msgid "press OK, or Back to cancel"
+msgstr "tryck Start eller Back för att avbryta"
+
+#: id:12332
+msgid "Set lock"
+msgstr "Ange lås"
+
+#: id:12333
+msgid "Unlock"
+msgstr "Lås upp"
+
+#: id:12334
+msgid "Reset lock"
+msgstr "Återställ lås"
+
+#: id:12335
+msgid "Remove lock"
+msgstr "Ta bort låset"
+
+#: id:12337
+msgid "Numeric password"
+msgstr "Sifferlösen"
+
+#: id:12338
+msgid "Gamepad button combo"
+msgstr "Knappar på spelkontroll"
+
+#: id:12339
+msgid "Full-text password"
+msgstr "Textlösen"
+
+#: id:12340
+msgid "Enter new password"
+msgstr "Ange nytt lösenord"
+
+#: id:12341
+msgid "Re-Enter new password"
+msgstr "Ange nytt lösenord igen"
+
+#: id:12342
+msgid "Incorrect password,"
+msgstr "Felaktigt lösenord,"
+
+#: id:12343
+msgid "retries left"
+msgstr "försök kvar"
+
+#: id:12344
+msgid "Passwords entered did not match."
+msgstr "Lösenordet som angavs matchade inte."
+
+#: id:12345
+msgid "Access denied"
+msgstr "Åtkomst nekad"
+
+#: id:12346
+msgid "Password retry limit exceeded."
+msgstr "Antal lösenordsförsök har överstigits."
+
+#: id:12347
+msgid "The system will now shut off."
+msgstr "Systemet kommer nu stängas av."
+
+#: id:12348
+msgid "Item locked"
+msgstr "Objekt låst"
+
+#: id:12353
+msgid "Reactivate lock"
+msgstr "Återaktivera lås"
+
+#: id:12356
+msgid "Change lock"
+msgstr "Byt lås"
+
+#: id:12357
+msgid "Source lock"
+msgstr "Käll-lås"
+
+#: id:12358
+msgid "Password entry was blank. Try again."
+msgstr "Lösenordet var tomt. Försök igen."
+
+#: id:12360
+msgid "Master lock"
+msgstr "Huvudlås"
+
+#: id:12362
+msgid "Shutdown system if Master Lock retries exceeded"
+msgstr "Stäng av systemet om låsförsök överskrids"
+
+#: id:12367
+msgid "Master code is not valid"
+msgstr "Huvudkoden är ogiltig"
+
+#: id:12368
+msgid "Please enter a valid master code"
+msgstr "Var god ange korrekt huvudkod"
+
+#: id:12373
+msgid "Settings & file manager"
+msgstr "Inställningar & Filhanterare"
+
+#: id:12376
+msgid "Set as default for all movies"
+msgstr "Använd som standard för alla filmer"
+
+#: id:12377
+msgid "This will reset any previously saved values"
+msgstr "Detta tar bort alla tidigare sparade värden"
+
+#: id:12378
+msgid "Amount of time to display each image"
+msgstr "Tid att visa varje bild"
+
+#: id:12379
+msgid "Use pan and zoom effects"
+msgstr "Använd pan- och zoomeffekter"
+
+#: id:12383
+msgid "12 hour clock"
+msgstr "12-timmarsklocka"
+
+#: id:12384
+msgid "24 hour clock"
+msgstr "24-timmarsklocka"
+
+#: id:12385
+msgid "Day/Month"
+msgstr "Dag/Månad"
+
+#: id:12386
+msgid "Month/Day"
+msgstr "Månad/Dag"
+
+#: id:12390
+msgid "System uptime"
+msgstr "Driftstid"
+
+#: id:12391
+msgid "Minutes"
+msgstr "minuter"
+
+#: id:12392
+msgid "Hours"
+msgstr "timmar"
+
+#: id:12393
+msgid "Days"
+msgstr "dagar"
+
+#: id:12394
+msgid "Total uptime"
+msgstr "Total driftstid"
+
+#: id:12395
+msgid "Battery level"
+msgstr "Batterinivå"
+
+#: id:12600
+msgctxt "Auto context with id 12600"
+msgid "Weather"
+msgstr "Väder"
+
+#: id:12900
+msgctxt "Auto context with id 12900"
+msgid "Screensaver"
+msgstr "Skärmsläckare"
+
+#: id:12901
+msgid "Fullscreen OSD"
+msgstr "Fullskärms-OSD"
+
+#: id:13000
+msgid "System"
+msgstr "System"
+
+#: id:13001
+msgid "Immediate HD spindown"
+msgstr "Omedelbar HD-nedvarvning"
+
+#: id:13002
+msgid "Video only"
+msgstr "Bara Video"
+
+#: id:13003
+msgid "- Delay"
+msgstr "- Fördröjning"
+
+#: id:13004
+msgid "- Minimum file duration"
+msgstr "- Minimal speltid"
+
+#: id:13005
+msgid "Shutdown"
+msgstr "Stäng av"
+
+#: id:13008
+msgid "Shutdown function"
+msgstr "Avstängningsfunktion"
+
+#: id:13009
+msgid "Quit"
+msgstr "Avsluta"
+
+#: id:13010
+msgid "Hibernate"
+msgstr "Viloläge"
+
+#: id:13011
+msgid "Suspend"
+msgstr "Vänteläge"
+
+#: id:13012
+msgid "Exit"
+msgstr "Avsluta"
+
+#: id:13013
+msgid "Reboot"
+msgstr "Starta om"
+
+#: id:13014
+msgid "Minimize"
+msgstr "Minimera"
+
+#: id:13015
+msgid "Power button action"
+msgstr "Funktion för avstängningsknapp"
+
+#: id:13016
+msgid "Power off System"
+msgstr "Stäng av systemet"
+
+#: id:13020
+msgid "Is another session active, perhaps over ssh?"
+msgstr "Är en annan session aktiv, kanske över ssh?"
+
+#: id:13021
+msgid "Mounted removable harddrive"
+msgstr "Monterade flyttbar hårddisk"
+
+#: id:13022
+msgid "Unsafe device removal"
+msgstr "Osäker borttagning av enhet"
+
+#: id:13023
+msgid "Successfully removed device"
+msgstr "Borttagning av enhet lyckades"
+
+#: id:13024
+msgid "Joystick plugged"
+msgstr "Joystick ansluten"
+
+#: id:13025
+msgid "Joystick unplugged"
+msgstr "Joystick borttagen"
+
+#: id:13050
+msgid "Running low on battery"
+msgstr "Batteriet börjar ta slut"
+
+#: id:13100
+msgid "Flicker filter"
+msgstr "Flimmerfilter"
+
+#: id:13101
+msgid "Let driver choose (requires restart)"
+msgstr "Låt drivrutinen välja (kräver omstart)"
+
+#: id:13105
+msgid "Vertical blank sync"
+msgstr "Vertikal blankningssynk"
+
+#: id:13106
+msgctxt "Auto context with id 13106"
+msgid "Disabled"
+msgstr "Inaktiverad"
+
+#: id:13107
+msgid "Enabled during video playback"
+msgstr "Aktiverad under videouppspelning"
+
+#: id:13108
+msgctxt "Auto context with id 13108"
+msgid "Always enabled"
+msgstr "Alltid aktiverad"
+
+#: id:13109
+msgid "Test & apply resolution"
+msgstr "Prova och ange upplösning"
+
+#: id:13110
+msgid "Save resolution?"
+msgstr "Spara upplösning?"
+
+#: id:13111
+msgid "Would you like to keep this resolution?"
+msgstr "Vill du behålla denna upplösning?"
+
+#: id:13112
+msgid "High quality upscaling"
+msgstr "Högkvalitetsuppskalning"
+
+#: id:13113
+msgctxt "Auto context with id 13113"
+msgid "Disabled"
+msgstr "Inaktiverad"
+
+#: id:13114
+msgid "Enabled for SD content"
+msgstr "Aktiverad för SD-innehåll"
+
+#: id:13115
+msgctxt "Auto context with id 13115"
+msgid "Always enabled"
+msgstr "Alltid aktiverad"
+
+#: id:13116
+msgid "Upscaling method"
+msgstr "Uppskalningsmetod"
+
+#: id:13117
+msgctxt "Auto context with id 13117"
+msgid "Bicubic"
+msgstr "Bicubic"
+
+#: id:13118
+msgid "Lanczos"
+msgstr "Lanczos"
+
+#: id:13119
+msgid "Sinc"
+msgstr "Sinc"
+
+#: id:13120
+msgctxt "Auto context with id 13120"
+msgid "VDPAU"
+msgstr "VDPAU"
+
+#: id:13121
+msgid "VDPAU HQ Upscaling level"
+msgstr "HQ-uppskalningsnivå (VDPAU)"
+
+#: id:13122
+msgid "VDPAU Studio level color conversion"
+msgstr "Studionivåfärgkonvertering (VDPAU)"
+
+#: id:13130
+msgid "Blank other displays"
+msgstr "Mörka övriga skärmar"
+
+#: id:13131
+msgctxt "Auto context with id 13131"
+msgid "Disabled"
+msgstr "Inaktivera"
+
+#: id:13132
+msgid "Blank displays"
+msgstr "Rensa skärmar"
+
+#: id:13140
+msgid "Active connections detected!"
+msgstr "Aktiva anslutningar detekterade!"
+
+#: id:13141
+msgid "If you proceed, you might not be able to control XBMC"
+msgstr "Om du fortsätter kommer du kanske inte att kunna kontrollera"
+
+#: id:13142
+msgid "any longer. Are you sure you want to stop the Event server?"
+msgstr "XBMC längre. Är du säker att du vill stoppa händelseservern?"
+
+#: id:13144
+msgid "Change Apple Remote mode?"
+msgstr "Ändra Apple-fjärrläge?"
+
+#: id:13145
+msgid "If you are currently using the Apple Remote to control"
+msgstr "Om du för närvarande använder Apple-fjärr för att kontrollera"
+
+#: id:13146
+msgid "XBMC, changing this setting might affect your ability"
+msgstr "XBMC, ändra denna inställning kan påverka din möjlighet"
+
+#: id:13147
+msgid "to continue controlling it. Do you want to proceed?"
+msgstr "för fortsatt kontroll av XBMC. Vill du fortsätta?"
+
+#: id:13159
+msgid "Subnet mask"
+msgstr "Nätmask"
+
+#: id:13160
+msgid "Gateway"
+msgstr "Gateway"
+
+#: id:13161
+msgid "Primary DNS"
+msgstr "Primär DNS"
+
+#: id:13162
+msgid "Initialize failed"
+msgstr "Initialisering misslyckades"
+
+#: id:13170
+msgctxt "Auto context with id 13170"
+msgid "Never"
+msgstr "Aldrig"
+
+#: id:13171
+msgid "Immediately"
+msgstr "Omedelbart"
+
+#: id:13172
+msgid "After %i secs"
+msgstr "Efter %i sek"
+
+#: id:13173
+msgid "HDD install date:"
+msgstr "HDD-installationsdatum:"
+
+#: id:13174
+msgid "HDD power cycle count:"
+msgstr "HDD-strömcykelräkning:"
+
+#: id:13200
+msgid "Profiles"
+msgstr "Profiler"
+
+#: id:13201
+msgid "Delete profile '%s'?"
+msgstr "Radera profil '%s'?"
+
+#: id:13204
+msgid "Last loaded profile:"
+msgstr "Senast laddade profil:"
+
+#: id:13205
+msgid "Unknown"
+msgstr "Okänd"
+
+#: id:13206
+msgid "Overwrite"
+msgstr "Skriva över"
+
+#: id:13208
+msgid "Alarm clock"
+msgstr "Alarmklocka"
+
+#: id:13209
+msgid "Alarm clock interval (in minutes)"
+msgstr "Alarmklocksintervall (i minuter)"
+
+#: id:13210
+msgid "Started, alarm in %im"
+msgstr "Startad, alarm om %im"
+
+#: id:13211
+msgid "Alarm!"
+msgstr "Alarm!"
+
+#: id:13212
+msgid "Canceled with %im%is left"
+msgstr "Avbruten med %im%is kvar"
+
+#: id:13213
+msgid "%2.0fm"
+msgstr "%2.0fm"
+
+#: id:13214
+msgid "%2.0fs"
+msgstr "%2.0fs"
+
+#: id:13249
+msgid "Search for subtitles in RARs"
+msgstr "Sök efter undertexter i rar-filer"
+
+#: id:13250
+msgid "Browse for subtitle..."
+msgstr "Bläddra efter undertext..."
+
+#: id:13251
+msgid "Move item"
+msgstr "Flytta objekt"
+
+#: id:13252
+msgid "Move item here"
+msgstr "Flytta objekt hit"
+
+#: id:13253
+msgid "Cancel move"
+msgstr "Avbryt flyttning"
+
+#: id:13270
+msgid "Hardware:"
+msgstr "Hårdvara:"
+
+#: id:13271
+msgid "CPU Usage:"
+msgstr "CPU-användning:"
+
+#: id:13274
+msgid "Connected, but no DNS is available."
+msgstr "Ansluten, men ingen DNS är tillgänglig."
+
+#: id:13275
+msgid "Hard Disk"
+msgstr "Hårddisk"
+
+#: id:13276
+msgid "DVD-ROM"
+msgstr "DVD-Rom"
+
+#: id:13277
+msgctxt "Auto context with id 13277"
+msgid "Storage"
+msgstr "Lagring"
+
+#: id:13278
+msgctxt "Auto context with id 13278"
+msgid "Default"
+msgstr "Standard"
+
+#: id:13279
+msgctxt "Auto context with id 13279"
+msgid "Network"
+msgstr "Nätverk"
+
+#: id:13280
+msgctxt "Auto context with id 13280"
+msgid "Video"
+msgstr "Video"
+
+#: id:13281
+msgid "Hardware"
+msgstr "Hårdvara"
+
+#: id:13283
+msgid "Operating system:"
+msgstr "Operativsystem:"
+
+#: id:13284
+msgid "CPU speed:"
+msgstr "CPU-hastighet:"
+
+#: id:13286
+msgid "Video encoder:"
+msgstr "Video-kodare:"
+
+#: id:13287
+msgid "Screen resolution:"
+msgstr "Skärmupplösning:"
+
+#: id:13292
+msgid "A/V cable:"
+msgstr "A/V-kabel:"
+
+#: id:13294
+msgid "DVD region:"
+msgstr "DVD-region:"
+
+#: id:13295
+msgid "Internet:"
+msgstr "Internet:"
+
+#: id:13296
+msgctxt "Auto context with id 13296"
+msgid "Connected"
+msgstr "Ansluten"
+
+#: id:13297
+msgid "Not connected. Check network settings."
+msgstr "Inte uppkopplad. Kontrollera nätverksinställningar."
+
+#: id:13299
+msgid "Target temperature"
+msgstr "Måltemperatur"
+
+#: id:13300
+msgid "Fan speed"
+msgstr "Fläktfart"
+
+#: id:13301
+msgid "Auto temperature control"
+msgstr "Automatisk tempkontroll"
+
+#: id:13302
+msgid "Fan speed override"
+msgstr "Styr fläkthastighet"
+
+#: id:13303
+msgid "- Fonts"
+msgstr "- Typsnitt"
+
+#: id:13304
+msgid "Enable flipping bi-directional strings"
+msgstr "Vänd textriktning"
+
+#: id:13305
+msgid "Show RSS news feeds"
+msgstr "Visa RSS-nyheter"
+
+#: id:13306
+msgid "Show parent folder items"
+msgstr "Visa föremål i överordnad mapp"
+
+#: id:13307
+msgid "Track naming template"
+msgstr "Låtnamn enligt"
+
+#: id:13308
+msgid "Do you wish to reboot your system"
+msgstr "Vill du starta om systemet"
+
+#: id:13309
+msgid "instead of just XBMC?"
+msgstr "istället för endast XBMC?"
+
+#: id:13310
+msgid "Zoom effect"
+msgstr "Zoomeffekt"
+
+#: id:13311
+msgid "Float effect"
+msgstr "Flyteffekt"
+
+#: id:13312
+msgid "Black bar reduction"
+msgstr "Reducera svart ram"
+
+#: id:13313
+msgid "Restart"
+msgstr "Starta om"
+
+#: id:13314
+msgid "Crossfade between songs"
+msgstr "Övertoning mellan låtar"
+
+#: id:13315
+msgid "Regenerate thumbnails"
+msgstr "Återskapa miniatyrer"
+
+#: id:13316
+msgid "Recursive thumbnails"
+msgstr "Rekursiva miniatyrer"
+
+#: id:13317
+msgid "View slideshow"
+msgstr "Visa bildspel"
+
+#: id:13318
+msgid "Recursive slideshow"
+msgstr "Rekursivt bildspel"
+
+#: id:13319
+msgid "Randomize"
+msgstr "Slumpa"
+
+#: id:13320
+msgid "Stereo"
+msgstr "Stereo"
+
+#: id:13321
+msgid "Left only"
+msgstr "Endast vänster"
+
+#: id:13322
+msgid "Right only"
+msgstr "Endast höger"
+
+#: id:13323
+msgid "Enable karaoke support"
+msgstr "Aktivera karaoke"
+
+#: id:13324
+msgid "Background transparency"
+msgstr "Bakgrundstransparens"
+
+#: id:13325
+msgid "Foreground transparency"
+msgstr "Förgrundstransparens"
+
+#: id:13326
+msgid "A/V delay"
+msgstr "A/V-förskjutning"
+
+#: id:13327
+msgid "Karaoke"
+msgstr "Karaoke"
+
+#: id:13328
+msgid "%s not found"
+msgstr "%s hittades inte"
+
+#: id:13329
+msgid "Error opening %s"
+msgstr "Fel vid öppnande av %s"
+
+#: id:13330
+msgid "Unable to load %s"
+msgstr "Gick inte ladda %s"
+
+#: id:13331
+msgid "Error: Out of memory"
+msgstr "Fel: För lite ledigt minne"
+
+#: id:13332
+msgid "Move up"
+msgstr "Flytta upp"
+
+#: id:13333
+msgid "Move down"
+msgstr "Flytta ned"
+
+#: id:13334
+msgid "Edit label"
+msgstr "Ändra namn"
+
+#: id:13335
+msgid "Make default"
+msgstr "Ange som standard"
+
+#: id:13336
+msgid "Remove button"
+msgstr "Ta bort knapp"
+
+#: id:13340
+msgid "Leave as is"
+msgstr "Låt vara"
+
+#: id:13341
+msgid "Green"
+msgstr "Grön"
+
+#: id:13342
+msgid "Orange"
+msgstr "Orange"
+
+#: id:13343
+msgid "Red"
+msgstr "Röd"
+
+#: id:13344
+msgid "Cycle"
+msgstr "Cykla"
+
+#: id:13345
+msgid "Switch LED off on playback"
+msgstr "Stäng av LED under uppspelning"
+
+#: id:13346
+msgctxt "Auto context with id 13346"
+msgid "Movie information"
+msgstr "Filminformation"
+
+#: id:13347
+msgid "Queue item"
+msgstr "Lägg till i spellistan"
+
+#: id:13348
+msgid "Search IMDb..."
+msgstr "Sök på IMDb..."
+
+#: id:13349
+msgid "Scan for new content"
+msgstr "Skanna efter nytt innehåll"
+
+#: id:13350
+msgid "Now playing..."
+msgstr "Nu spelas..."
+
+#: id:13351
+msgctxt "Auto context with id 13351"
+msgid "Album information"
+msgstr "Albuminformation"
+
+#: id:13352
+msgid "Scan item to library"
+msgstr "Skanna objekt > databas"
+
+#: id:13353
+msgid "Stop scanning"
+msgstr "Stoppa skanning"
+
+#: id:13354
+msgctxt "Auto context with id 13354"
+msgid "Render method"
+msgstr "Renderingsmetod"
+
+#: id:13355
+msgid "Low quality pixel shader"
+msgstr "Lågkvalitets-pixelshader"
+
+#: id:13356
+msgid "Hardware overlays"
+msgstr "Hårdvaruöverlägg"
+
+#: id:13357
+msgid "High quality pixel shader"
+msgstr "Högkvalitets-pixelshader"
+
+#: id:13358
+msgid "Play item"
+msgstr "Spela objekt"
+
+#: id:13359
+msgid "Set artist thumb"
+msgstr "Ange artistminiatyr"
+
+#: id:13360
+msgid "Automatically generate thumbnails"
+msgstr "Skapa miniatyrer automatiskt"
+
+#: id:13361
+msgid "Enable voice"
+msgstr "Aktivera röst"
+
+#: id:13375
+msgid "Enable device"
+msgstr "Aktivera enhet"
+
+#: id:13376
+msgid "Volume"
+msgstr "Volym"
+
+#: id:13377
+msgid "Default view mode"
+msgstr "Förvalt vyläge"
+
+#: id:13378
+msgid "Default brightness"
+msgstr "Förvald ljusstyrka"
+
+#: id:13379
+msgid "Default contrast"
+msgstr "Förvald kontrast"
+
+#: id:13380
+msgid "Default gamma"
+msgstr "Förvald gamma"
+
+#: id:13381
+msgid "Resume video"
+msgstr "Återuppta film"
+
+#: id:13382
+msgid "Voice mask - Port 1"
+msgstr "Röst förvr. - Port 0"
+
+#: id:13383
+msgid "Voice mask - Port 2"
+msgstr "Röst förvr. - Port 1"
+
+#: id:13384
+msgid "Voice mask - Port 3"
+msgstr "Röst förvr. - Port 2"
+
+#: id:13385
+msgid "Voice mask - Port 4"
+msgstr "Röst förvr. - Port 3"
+
+#: id:13386
+msgid "Use time based seeking"
+msgstr "Använd tidsbaserad sökning"
+
+#: id:13387
+msgid "Track naming template - right"
+msgstr "Mall för spårnamn - höger sida"
+
+#: id:13388
+msgid "Preset"
+msgstr "Förinställning"
+
+#: id:13389
+msgid "There are no presets available\nfor this visualization"
+msgstr "Det finns inga förinställningar för den här visualiseringen"
+
+#: id:13390
+msgid "There are no settings available\nfor this visualization"
+msgstr "Det finns inga inställningar för den här visualiseringen"
+
+#: id:13391
+msgid "Eject/Load"
+msgstr "Mata ut/Mata in"
+
+#: id:13392
+msgid "Use visualization if playing audio"
+msgstr "Använd visualisering under musikuppspelning"
+
+#: id:13393
+msgid "Calculate size"
+msgstr "Beräkna storlek"
+
+#: id:13394
+msgid "Calculating folder size"
+msgstr "Beräknar mappstorlek"
+
+#: id:13395
+msgid "Video settings"
+msgstr "Grafikinställningar"
+
+#: id:13396
+msgid "Audio and subtitle settings"
+msgstr "Ljud- och textinställningar"
+
+#: id:13397
+msgid "Enable subtitles"
+msgstr "Aktivera undertexter"
+
+#: id:13398
+msgctxt "Auto context with id 13398"
+msgid "Shortcuts"
+msgstr "Genvägar"
+
+#: id:13399
+msgid "Ignore articles when sorting (e.g. \"the\")"
+msgstr "Ignorera \"tokens\" i sortering (ex: \"the\")"
+
+#: id:13400
+msgid "Crossfade between songs on the same album"
+msgstr "Använd övertoning på låtar från samma album"
+
+#: id:13401
+msgid "Browse for %s"
+msgstr "Bläddra efter %s"
+
+#: id:13402
+msgid "Show track position"
+msgstr "Visa spårposition"
+
+#: id:13403
+msgid "Clear default"
+msgstr "Rensa standard"
+
+#: id:13404
+msgid "Resume"
+msgstr "Återuppta"
+
+#: id:13405
+msgid "Get thumb"
+msgstr "Hämta miniatyr"
+
+#: id:13406
+msgid "Picture information"
+msgstr "Bildinformation"
+
+#: id:13407
+msgid "%s presets"
+msgstr "%s förinställningar"
+
+#: id:13408
+msgid "(IMDb user rating)"
+msgstr "(IMDb-användarbetyg)"
+
+#: id:13409
+msgid "Top 250"
+msgstr "Topp 250"
+
+#: id:13410
+msgid "Tune in on Last.fm"
+msgstr "Ställ in på Last.fm"
+
+#: id:13411
+msgid "Minimum fan speed"
+msgstr "Minsta fläkthastighet"
+
+#: id:13412
+msgid "Play from here"
+msgstr "Spela från här"
+
+#: id:13413
+msgid "Downloading"
+msgstr "Laddar ned"
+
+#: id:13414
+msgid "Include artists who appear only on compilations"
+msgstr "Inkludera artister som endast är med på samlingsalbum"
+
+#: id:13415
+msgctxt "Auto context with id 13415"
+msgid "Render method"
+msgstr "Renderingsmetod"
+
+#: id:13416
+msgid "Auto detect"
+msgstr "Autodetektera"
+
+#: id:13417
+msgid "Basic shaders (ARB)"
+msgstr "Grundläggande shaders (ARB)"
+
+#: id:13418
+msgid "Advanced shaders (GLSL)"
+msgstr "Avancerade shaders (GLSL)"
+
+#: id:13419
+msgid "Software"
+msgstr "Mjukvara"
+
+#: id:13420
+msgid "Remove safely"
+msgstr "Säker borttagning"
+
+#: id:13421
+msgctxt "Auto context with id 13421"
+msgid "VDPAU"
+msgstr "VDPAU"
+
+#: id:13422
+msgid "Start slideshow here"
+msgstr "Starta bildspel här"
+
+#: id:13423
+msgid "Remember for this path"
+msgstr "Kom ihåg för denna sökväg"
+
+#: id:13424
+msgid "Use pixel buffer objects"
+msgstr "Använd pixelbufferobjekt"
+
+#: id:13425
+msgid "Allow hardware acceleration (VDPAU)"
+msgstr "Tillåt hårdvaruacceleration (VDPAU)"
+
+#: id:13426
+msgid "Allow hardware acceleration (VAAPI)"
+msgstr "Tillåt hårdvaruacceleration (VAAPI)"
+
+#: id:13427
+msgid "Allow hardware acceleration (DXVA2)"
+msgstr "Tillåt hårdvaruacceleration (DXVA2)"
+
+#: id:13428
+msgid "Allow hardware acceleration (CrystalHD)"
+msgstr "Tillåt hårdvaruacceleration (CrystalHD)"
+
+#: id:13429
+msgid "Allow hardware acceleration (VDADecoder)"
+msgstr "Tillåt hårdvaruacceleration (VDADecoder)"
+
+#: id:13430
+msgid "Allow hardware acceleration (OpenMax)"
+msgstr "Tillåt hårdvaruacceleration (OpenMax)"
+
+#: id:13431
+msgid "Pixel Shaders"
+msgstr "Pixelskuggning"
+
+#: id:13432
+msgid "Allow hardware acceleration (VideoToolbox)"
+msgstr "Tillåt hårdvaruacceleration (Videoverktyg)"
+
+#: id:13500
+msgid "A/V sync method"
+msgstr "A/V-synkmetod"
+
+#: id:13501
+msgid "Audio clock"
+msgstr "Ljudklocka"
+
+#: id:13502
+msgid "Video clock (Drop/Dupe audio)"
+msgstr "Videoklocka (tappat/dubblerat ljud)"
+
+#: id:13503
+msgid "Video clock (Resample audio)"
+msgstr "Videoklocka (omsamplat ljud)"
+
+#: id:13504
+msgid "Maximum resample amount (%)"
+msgstr "Maximal omsampling (%)"
+
+#: id:13505
+msgid "Resample quality"
+msgstr "Omsamplingskvalitet"
+
+#: id:13506
+msgid "Low(fast)"
+msgstr "Låg (snabb)"
+
+#: id:13507
+msgctxt "Auto context with id 13507"
+msgid "Medium"
+msgstr "Medium"
+
+#: id:13508
+msgctxt "Auto context with id 13508"
+msgid "High"
+msgstr "Hög"
+
+#: id:13509
+msgid "Really high(slow!)"
+msgstr "Riktigt hög (långsam!)"
+
+#: id:13510
+msgid "Sync playback to display"
+msgstr "Synkronisera uppspelning till display"
+
+#: id:13550
+msgid "Pause during refresh rate change"
+msgstr "Pausa under uppdateringsfrekvensändring"
+
+#: id:13551
+msgctxt "Auto context with id 13551"
+msgid "Off"
+msgstr "Av"
+
+#: id:13552
+msgid "%.1f Second"
+msgstr "%.1f sekund"
+
+#: id:13553
+msgid "%.1f Seconds"
+msgstr "%.1f sekunder"
+
+#: id:13600
+msgid "Apple remote"
+msgstr "Apple-fjärrkontroll"
+
+#: id:13602
+msgid "Allow start of XBMC using the remote"
+msgstr "Tillåt start av XBMC med fjärrkontroll"
+
+#: id:13603
+msgid "Sequence delay time"
+msgstr "Sekvensfördröjningstid"
+
+#: id:13610
+msgctxt "Auto context with id 13610"
+msgid "Disabled"
+msgstr "Inaktiverad"
+
+#: id:13611
+msgctxt "Auto context with id 13611"
+msgid "Standard"
+msgstr "Standard"
+
+#: id:13612
+msgid "Universal Remote"
+msgstr "Universiell fjärrkontroll"
+
+#: id:13613
+msgid "Multi Remote (Harmony)"
+msgstr "Multifjärr (Harmony)"
+
+#: id:13620
+msgid "Apple Remote Error"
+msgstr "Apple-fjärrkontrollsfel"
+
+#: id:13621
+msgid "Apple Remote support could be enabled."
+msgstr "Apple-fjärrkontroll kunde inte aktiveras."
+
+#: id:14000
+msgid "Stack"
+msgstr "Slå samman"
+
+#: id:14001
+msgid "Unstack"
+msgstr "Slå samman: Av"
+
+#: id:14003
+msgid "Downloading playlist file..."
+msgstr "Laddar ned spellista..."
+
+#: id:14004
+msgid "Downloading streams list..."
+msgstr "Laddar ned strömlista..."
+
+#: id:14005
+msgid "Parsing streams list..."
+msgstr "Bearbetar strömlista..."
+
+#: id:14006
+msgid "Downloading streams list failed"
+msgstr "Nedladdning av strömlista misslyckades"
+
+#: id:14007
+msgid "Downloading playlist file failed"
+msgstr "Nedladdning av spellista misslyckades"
+
+#: id:14009
+msgid "Games directory"
+msgstr "Spelmapp"
+
+#: id:14010
+msgid "Auto switch to thumbs based on"
+msgstr "Autoväxla till miniatyrer baserat på"
+
+#: id:14011
+msgid "Enable auto switching to thumbs view"
+msgstr "Aktivera autoväxling till miniatyrer"
+
+#: id:14012
+msgid "- Use large icons"
+msgstr "- Använd stora ikoner"
+
+#: id:14013
+msgid "- Switch based on"
+msgstr "- Växla baserat på"
+
+#: id:14014
+msgid "- Percentage"
+msgstr "- Procent"
+
+#: id:14015
+msgid "No files and at least one thumb"
+msgstr "Inga filer men minst en miniatyr"
+
+#: id:14016
+msgid "At least one file and thumb"
+msgstr "Minst en fil och en miniatyr"
+
+#: id:14017
+msgid "Percentage of thumbs"
+msgstr "Procent av miniatyrer"
+
+#: id:14018
+msgid "View options"
+msgstr "Vyalternativ"
+
+#: id:14019
+msgid "Change area code 1"
+msgstr "Områdeskod 1"
+
+#: id:14020
+msgid "Change area code 2"
+msgstr "Områdeskod 2"
+
+#: id:14021
+msgid "Change area code 3"
+msgstr "Områdeskod 3"
+
+#: id:14022
+msgctxt "Auto context with id 14022"
+msgid "Library"
+msgstr "Bibliotek"
+
+#: id:14023
+msgid "No TV"
+msgstr "Ingen TV"
+
+#: id:14024
+msgid "Enter the nearest large town"
+msgstr "Skriv in din närmsta storstad"
+
+#: id:14025
+msgid "Video/Audio/DVD cache - Harddisk"
+msgstr "Video/Ljud/DVDbuffert - Hårddisk"
+
+#: id:14026
+msgid "Video cache - DVD-ROM"
+msgstr "Videobuffert - DVDRom"
+
+#: id:14027
+msgctxt "Auto context with id 14027"
+msgid "- Local Network"
+msgstr "- Lokalt Nätverk"
+
+#: id:14028
+msgctxt "Auto context with id 14028"
+msgid "- Internet"
+msgstr "- Internet"
+
+#: id:14030
+msgid "Audio cache - DVD-ROM"
+msgstr "Ljudbuffert - DVDRom"
+
+#: id:14031
+msgctxt "Auto context with id 14031"
+msgid "- Local Network"
+msgstr "- Lokalt Nätverk"
+
+#: id:14032
+msgctxt "Auto context with id 14032"
+msgid "- Internet"
+msgstr "- Internet"
+
+#: id:14034
+msgid "DVD cache - DVD-ROM"
+msgstr "DVDbuffert - DVDRom"
+
+#: id:14035
+msgctxt "Auto context with id 14035"
+msgid "- Local Network"
+msgstr "- Lokalt Nätverk"
+
+#: id:14036
+msgctxt "Auto context with id 14036"
+msgid "Services"
+msgstr "Tjänster"
+
+#: id:14038
+msgid "Network settings changed"
+msgstr "Nätverksinställningar ändrade"
+
+#: id:14039
+msgid "XBMC requires to restart to change your"
+msgstr "XBMC måste startas om för att slutföra din"
+
+#: id:14040
+msgid "network setup. Would you like to restart now?"
+msgstr "nätverksinställning. Vill du starta om nu?"
+
+#: id:14041
+msgid "Internet connection bandwidth limitation"
+msgstr "Bandbreddsbegränsning för internetanslutning"
+
+#: id:14043
+msgid "- Shutdown while playing"
+msgstr "- Stäng av under uppspelning"
+
+#: id:14044
+msgid "%i min"
+msgstr "%i min"
+
+#: id:14045
+msgid "%i sec"
+msgstr "%i sek"
+
+#: id:14046
+msgid "%i ms"
+msgstr "%i ms"
+
+#: id:14047
+msgid "%i %%"
+msgstr "%i %%"
+
+#: id:14048
+msgid "%i kbps"
+msgstr "%i kbps"
+
+#: id:14049
+msgid "%i kb"
+msgstr "%i kb"
+
+#: id:14050
+msgid "%i.0 dB"
+msgstr "%i.0 dB"
+
+#: id:14051
+msgid "Time format"
+msgstr "Tidsformat"
+
+#: id:14052
+msgid "Date format"
+msgstr "Datumformat"
+
+#: id:14053
+msgid "GUI filters"
+msgstr "GUI-filter"
+
+#: id:14055
+msgid "Use background scanning"
+msgstr "Använd bakgrundskanning"
+
+#: id:14056
+msgid "Stop scan"
+msgstr "Avsluta skanning"
+
+#: id:14057
+msgid "Not possible while scanning for media info"
+msgstr "Inte möjligt medan du skannar efter mediainfo"
+
+#: id:14058
+msgid "Film grain effect"
+msgstr "Filmbruseffekt"
+
+#: id:14059
+msgid "Search for thumbnails on remote shares"
+msgstr "Leta miniatyrer på utdelningar"
+
+#: id:14060
+msgid "Unknown type cache - Internet"
+msgstr "Okänd buffert - Internet"
+
+#: id:14061
+msgctxt "Auto context with id 14061"
+msgid "Auto"
+msgstr "Auto"
+
+#: id:14062
+msgid "Enter username for"
+msgstr "Ange användarnamn för"
+
+#: id:14063
+msgid "Date & time"
+msgstr "Datum & tid"
+
+#: id:14064
+msgid "Set date"
+msgstr "Ange datum"
+
+#: id:14065
+msgid "Set time"
+msgstr "Ange klockslag"
+
+#: id:14066
+msgid "Enter the time in 24 hour HH:MM format"
+msgstr "Ange tiden i formatet TT:MM"
+
+#: id:14067
+msgid "Enter the date in DD/MM/YYYY format"
+msgstr "Ange datumet i formatet DD/MM/ÅÅÅÅ"
+
+#: id:14068
+msgid "Enter the IP address"
+msgstr "Ange IP-adress"
+
+#: id:14069
+msgid "Apply these settings now?"
+msgstr "Vill du spara inställningarna nu?"
+
+#: id:14070
+msgid "Apply changes now"
+msgstr "Spara inställningar"
+
+#: id:14071
+msgid "Allow file renaming and deletion"
+msgstr "Tillåt omdöpning och radering av filer"
+
+#: id:14074
+msgid "Set timezone"
+msgstr "Ange tidszon"
+
+#: id:14075
+msgid "Use daylight saving time"
+msgstr "Använd sommartid"
+
+#: id:14076
+msgid "Add to favourites"
+msgstr "Lägg till i favoriter"
+
+#: id:14077
+msgid "Remove from favourites"
+msgstr "Ta bort från favoriter"
+
+#: id:14078
+msgctxt "Auto context with id 14078"
+msgid "- Colours"
+msgstr "- Färger"
+
+#: id:14079
+msgid "Timezone country"
+msgstr "Tidszonsland"
+
+#: id:14080
+msgid "Timezone"
+msgstr "Tidszon"
+
+#: id:14081
+msgid "File lists"
+msgstr "Fillistor"
+
+#: id:14082
+msgid "Show EXIF picture information"
+msgstr "Visa EXIF-information"
+
+#: id:14083
+msgid "Use a fullscreen window rather than true fullscreen"
+msgstr "Använd helskärmsfönster istället för äkta helskärm"
+
+#: id:14084
+msgid "Queue songs on selection"
+msgstr "Köa låtar vid markering"
+
+#: id:14086
+msgid "Playback"
+msgstr "Uppspelning"
+
+#: id:14087
+msgid "DVDs"
+msgstr "DVDer"
+
+#: id:14088
+msgid "Play DVDs automatically"
+msgstr "Spela DVDer automatiskt"
+
+#: id:14089
+msgid "Font to use for text subtitles"
+msgstr "Typsnitt att använda för undertexter"
+
+#: id:14090
+msgid "International"
+msgstr "Internationellt"
+
+#: id:14091
+msgid "Character set"
+msgstr "Teckenuppsättning"
+
+#: id:14092
+msgid "Debugging"
+msgstr "Debuggning"
+
+#: id:14093
+msgid "Security"
+msgstr "Säkerhet"
+
+#: id:14094
+msgid "Input devices"
+msgstr "Inmatningsenheter"
+
+#: id:14095
+msgid "Power saving"
+msgstr "Strömbesparing"
+
+#: id:14096
+msgid "Rip"
+msgstr ""
+
+#: id:14097
+msgid "Audio CD Insert Action"
+msgstr ""
+
+#: id:14098
+msgctxt "Auto context with id 14098"
+msgid "Play"
+msgstr ""
+
+#: id:14099
+msgid "Eject disc when CD ripping is complete"
+msgstr ""
+
+#: id:15015
+msgctxt "Auto context with id 15015"
+msgid "Remove"
+msgstr "Ta bort"
+
+#: id:15016
+msgid "Games"
+msgstr "Spel"
+
+#: id:15019
+msgid "Add"
+msgstr "Lägg till"
+
+#: id:15052
+msgid "Password"
+msgstr "Lösenord"
+
+#: id:15100
+msgctxt "Auto context with id 15100"
+msgid "Library"
+msgstr "Bibliotek"
+
+#: id:15101
+msgid "Database"
+msgstr "Databas"
+
+#: id:15102
+msgid "* All albums"
+msgstr "* Alla album"
+
+#: id:15103
+msgid "* All artists"
+msgstr "* Alla artister"
+
+#: id:15104
+msgid "* All songs"
+msgstr "* Alla låtar"
+
+#: id:15105
+msgid "* All genres"
+msgstr "* Alla genrer"
+
+#: id:15107
+msgid "Buffering..."
+msgstr "Buffrar..."
+
+#: id:15108
+msgid "Navigation sounds"
+msgstr "Navigeringsljud"
+
+#: id:15109
+msgid "Skin default"
+msgstr "Skalets egna"
+
+#: id:15111
+msgid "- Theme"
+msgstr "- Tema"
+
+#: id:15112
+msgid "Default theme"
+msgstr "Standardtema"
+
+#: id:15200
+msgid "Last.fm"
+msgstr "Last.fm"
+
+#: id:15201
+msgid "Submit songs to Last.fm"
+msgstr "Skicka låtinfo till Last.fm"
+
+#: id:15202
+msgid "Last.fm username"
+msgstr "Last.fm-användarnamn"
+
+#: id:15203
+msgid "Last.fm password"
+msgstr "Last.fm-lösenord"
+
+#: id:15204
+msgid "Unable to handshake: sleeping..."
+msgstr "Inget svar: avvaktar..."
+
+#: id:15205
+msgid "Please update XBMC"
+msgstr "Var vänlig uppdatera XBMC"
+
+#: id:15206
+msgid "Bad authorization: Check username and password"
+msgstr "Felaktig autentisering: Kontrollera användarnamn och lösenord"
+
+#: id:15207
+msgctxt "Auto context with id 15207"
+msgid "Connected"
+msgstr "Uppkopplad"
+
+#: id:15208
+msgid "Not connected"
+msgstr "Inte uppkopplad"
+
+#: id:15209
+msgid "Submit interval %i"
+msgstr "Leveransintervall %i"
+
+#: id:15210
+msgid "Cached %i songs"
+msgstr "Buffrade %i låtar"
+
+#: id:15211
+msgid "Submitting..."
+msgstr "Skickar..."
+
+#: id:15212
+msgid "Submitting in %i secs"
+msgstr "Skickar om %i sek"
+
+#: id:15213
+msgid "Play using..."
+msgstr "Spela upp med..."
+
+#: id:15214
+msgid "Use smoothed A/V synchronization"
+msgstr "Använd utjämnad A/V-synkronisering"
+
+#: id:15215
+msgid "Hide file names in thumbs view"
+msgstr "Göm filnamn i miniatyrläget"
+
+#: id:15216
+msgid "Play in party mode"
+msgstr "Spela i partyläge"
+
+#: id:15217
+msgid "Submit songs to Libre.fm"
+msgstr "Skicka låtar till Libre.fm"
+
+#: id:15218
+msgid "Libre.fm username"
+msgstr "Libre.fm användarnamn"
+
+#: id:15219
+msgid "Libre.fm password"
+msgstr "Libre.fm lösenord"
+
+#: id:15220
+msgid "Libre.fm"
+msgstr "Libre.fm"
+
+#: id:15221
+msgid "Song submission"
+msgstr "Låtinlämning"
+
+#: id:15250
+msgid "Submit Last.fm radio to Last.fm"
+msgstr "Skicka Last.fm radio till Last.fm"
+
+#: id:15251
+msgid "Connecting to Last.fm..."
+msgstr "Ansluter till Last.fm..."
+
+#: id:15252
+msgid "Selecting station..."
+msgstr "Väljer station..."
+
+#: id:15253
+msgid "Search similar artists..."
+msgstr "Sök liknande artister..."
+
+#: id:15254
+msgid "Search similar tags..."
+msgstr "Sök liknande taggar..."
+
+#: id:15255
+msgid "Your profile (%name%)"
+msgstr "Din profil (%name%)"
+
+#: id:15256
+msgid "Overall top tags"
+msgstr "Överlag topp-taggar"
+
+#: id:15257
+msgid "Top artists for tag %name%"
+msgstr "Toppartister för tagg %name%"
+
+#: id:15258
+msgid "Top albums for tag %name%"
+msgstr "Toppalbum för tagg %name%"
+
+#: id:15259
+msgid "Top tracks for tag %name%"
+msgstr "Topplåtar för tagg %name%"
+
+#: id:15260
+msgid "Listen to tag %name% Last.fm radio"
+msgstr "Lyssna till tagg %name% Last.fm radio"
+
+#: id:15261
+msgid "Similar artists as %name%"
+msgstr "Liknande artister som %name%"
+
+#: id:15262
+msgid "Top %name% albums"
+msgstr "Topp %name%-album"
+
+#: id:15263
+msgid "Top %name% tracks"
+msgstr "Topp %name%-spår"
+
+#: id:15264
+msgid "Top %name% tags"
+msgstr "Topp %name%-taggar"
+
+#: id:15265
+msgid "Biggest fans of %name%"
+msgstr "Största fansen av %name%"
+
+#: id:15266
+msgid "Listen to %name% fans Last.fm radio"
+msgstr "Lyssna på %name%-fans Last.fm radio"
+
+#: id:15267
+msgid "Listen to %name% similar artists Last.fm radio"
+msgstr "Lyssna på %name%-liknande artister Last.fm radio"
+
+#: id:15268
+msgid "Top artists for user %name%"
+msgstr "Toppartister för användare %name%"
+
+#: id:15269
+msgid "Top albums for user %name%"
+msgstr "Toppalbum för användare %name%"
+
+#: id:15270
+msgid "Top tracks for user %name%"
+msgstr "Topplåtar för användare %name%"
+
+#: id:15271
+msgid "Friends of user %name%"
+msgstr "Vänner till användare %name%"
+
+#: id:15272
+msgid "Neighbours of user %name%"
+msgstr "Grannar till användare %name%"
+
+#: id:15273
+msgid "Weekly artist chart for %name%"
+msgstr "Vecko-artistlista för %name%"
+
+#: id:15274
+msgid "Weekly album chart for %name%"
+msgstr "Vecko-albumlista för %name%"
+
+#: id:15275
+msgid "Weekly track chart for %name%"
+msgstr "Vecko-låtlista för %name%"
+
+#: id:15276
+msgid "Listen to %name%'s neighbours Last.fm radio"
+msgstr "Lyssna på %name%'s grannes Last.fm radio"
+
+#: id:15277
+msgid "Listen to %name%'s personal Last.fm radio"
+msgstr "Lyssna på %name%'s personliga Last.fm radio"
+
+#: id:15278
+msgid "Listen to %name%'s mix Last.fm radio"
+msgstr "Lyssna på %name%'s älsklingsspår Last.fm radio"
+
+#: id:15279
+msgid "Retrieving list from Last.fm..."
+msgstr "Hämtar lista från Last.fm..."
+
+#: id:15280
+msgid "Can't retrieve list from Last.fm..."
+msgstr "Kan inte hämta lista från Last.fm..."
+
+#: id:15281
+msgid "Enter an artist name to find related ones"
+msgstr "Ange ett artistnamn för att hitta liknande"
+
+#: id:15282
+msgid "Enter a tag name to find similar ones"
+msgstr "Ange ett taggnamn för att hitta liknande"
+
+#: id:15283
+msgid "Tracks recently listened by %name%"
+msgstr "Nyligen spelade låtar av %name%"
+
+#: id:15284
+msgid "Listen to %name%'s recommendations Last.fm radio"
+msgstr "Lyssna till %name%'s rekommenderade Last.fm radio"
+
+#: id:15285
+msgid "Top tags for user %name%"
+msgstr "Topp taggar för användare %name%"
+
+#: id:15287
+msgid "Do you want to add the current track to your loved tracks?"
+msgstr "Vill du lägga till detta spår i dina älsklingsspår?"
+
+#: id:15288
+msgid "Do you want to ban the current track?"
+msgstr "Vill du bannlysa detta spår?"
+
+#: id:15289
+msgid "Added to your loved tracks: '%s'."
+msgstr "Tillagt i dina älsklingsspår: '%s'."
+
+#: id:15290
+msgid "Could not add '%s' to your loved tracks."
+msgstr "Kunde inte lägga till '%s' till dina älsklingsspår."
+
+#: id:15291
+msgid "Banned: '%s'."
+msgstr "Bannlyste: '%s'."
+
+#: id:15292
+msgid "Could not ban '%s'."
+msgstr "Kunde inte bannlysa '%s'."
+
+#: id:15293
+msgid "Tracks recently loved by %name%"
+msgstr "Nyligen tillagda spår i %name% älsklingsspår"
+
+#: id:15294
+msgid "Tracks recently banned by %name%"
+msgstr "Nyligen tillagda spår i %name% bannlista"
+
+#: id:15295
+msgid "Remove from loved tracks"
+msgstr "Ta bort från älsklingsspår"
+
+#: id:15296
+msgid "Un-ban"
+msgstr "Ta bort bannlysning"
+
+#: id:15297
+msgid "Do you want to remove this track from your loved tracks?"
+msgstr "Vill du ta bort detta spår från dina älsklingsspår?"
+
+#: id:15298
+msgid "Do you want to un-ban this track?"
+msgstr "Vill du ta bort bannlysningen på detta spår?"
+
+#: id:15300
+msgid "Path not found or invalid"
+msgstr "Sökväg hittades inte eller är ogiltig"
+
+#: id:15301
+msgid "Could not connect to network server"
+msgstr "Kunde inte ansluta till nätverksserver"
+
+#: id:15302
+msgid "No servers found"
+msgstr "Inga servrar hittade"
+
+#: id:15303
+msgid "Workgroup not found"
+msgstr "Arbetsgrupp hittades inte"
+
+#: id:15310
+msgid "Opening multi-path source"
+msgstr "Öppnar multi-sökvägskälla"
+
+#: id:15311
+msgid "Path:"
+msgstr "Sökväg:"
+
+#: id:16000
+msgctxt "Auto context with id 16000"
+msgid "General"
+msgstr "Allmänt"
+
+#: id:16002
+msgid "Internet lookup"
+msgstr "Internetsökning"
+
+#: id:16003
+msgid "Player"
+msgstr "Spelare"
+
+#: id:16004
+msgid "Play media from disc"
+msgstr "Spela media från skiva"
+
+#: id:16008
+msgid "Enter new title"
+msgstr "Lägg till ny titel"
+
+#: id:16009
+msgid "Enter the movie name"
+msgstr "Ange filmtitel"
+
+#: id:16010
+msgid "Enter the profile name"
+msgstr "Ange profilnamn"
+
+#: id:16011
+msgid "Enter the album name"
+msgstr "Ange albumtitel"
+
+#: id:16012
+msgid "Enter the playlist name"
+msgstr "Ange namn för spellistan"
+
+#: id:16013
+msgid "Enter new filename"
+msgstr "Ange nytt filnamn"
+
+#: id:16014
+msgid "Enter folder name"
+msgstr "Ange mappnamn"
+
+#: id:16015
+msgid "Enter directory"
+msgstr "Ange mapp"
+
+#: id:16016
+msgid "Available options: %A, %T, %N, %B, %D, %G, %Y, %F, %S"
+msgstr "Alternativ: %A, %T, %N, %B, %D, %G, %Y, %F, %S"
+
+#: id:16017
+msgid "Enter search string"
+msgstr "Ange söksträng"
+
+#: id:16018
+msgctxt "Auto context with id 16018"
+msgid "None"
+msgstr "Ingen"
+
+#: id:16019
+msgid "Auto select"
+msgstr "Autoval"
+
+#: id:16020
+msgid "De-interlace"
+msgstr "Avfläta"
+
+#: id:16021
+msgid "Bob"
+msgstr "Bob"
+
+#: id:16022
+msgid "Bob (inverted)"
+msgstr "Bob (Inverted)"
+
+#: id:16024
+msgid "Canceling..."
+msgstr "Avbryter..."
+
+#: id:16025
+msgid "Enter the artist name"
+msgstr "Ange artistnamnet"
+
+#: id:16026
+msgid "Playback failed"
+msgstr "Uppspelning misslyckades"
+
+#: id:16027
+msgid "One or more items failed to play."
+msgstr "En eller flera objekt spelades inte."
+
+#: id:16028
+msgid "Enter value"
+msgstr "Ange värde"
+
+#: id:16029
+msgid "Check the log file for details."
+msgstr "Kontrollera loggfilen för detaljer."
+
+#: id:16030
+msgid "Party mode aborted."
+msgstr "Festläge avbrutet."
+
+#: id:16031
+msgid "No matching songs in the library."
+msgstr "Inga matchande låtar i biblioteket."
+
+#: id:16032
+msgid "Could not initialize database."
+msgstr "Kunde inte initiera databasen."
+
+#: id:16033
+msgid "Could not open database."
+msgstr "Kunde inte öppna databasen."
+
+#: id:16034
+msgid "Could not get songs from database."
+msgstr "Kunde inte hämta låtar från databasen."
+
+#: id:16035
+msgid "Party mode playlist"
+msgstr "Partylägespellista"
+
+#: id:16036
+msgid "De-interlace (Half)"
+msgstr "Avflätning (halv)"
+
+#: id:16037
+msgid "Deinterlace video"
+msgstr "Avfläta video"
+
+#: id:16038
+msgid "Deinterlace method"
+msgstr "Avflätningsmetod"
+
+#: id:16039
+msgctxt "Auto context with id 16039"
+msgid "Off"
+msgstr "Av"
+
+#: id:16040
+msgctxt "Auto context with id 16040"
+msgid "Auto"
+msgstr "Auto"
+
+#: id:16041
+msgid "On"
+msgstr "På"
+
+#: id:16100
+msgid "All Videos"
+msgstr "Alla filmer"
+
+#: id:16101
+msgid "Unwatched"
+msgstr "Inte visad"
+
+#: id:16102
+msgid "Watched"
+msgstr "Visad"
+
+#: id:16103
+msgid "Mark as watched"
+msgstr "Markera som visad"
+
+#: id:16104
+msgid "Mark as unwatched"
+msgstr "Markera som inte visad"
+
+#: id:16105
+msgid "Edit title"
+msgstr "Ändra titel"
+
+#: id:16200
+msgid "Operation was aborted"
+msgstr "Operationen blev avbruten"
+
+#: id:16201
+msgid "Copy failed"
+msgstr "Kopieringen misslyckades"
+
+#: id:16202
+msgid "Failed to copy at least one file"
+msgstr "Misslyckades kopiera minst en fil"
+
+#: id:16203
+msgid "Move failed"
+msgstr "Flyttning misslyckades"
+
+#: id:16204
+msgid "Failed to move at least one file"
+msgstr "Misslyckades flytta minst en fil"
+
+#: id:16205
+msgid "Delete failed"
+msgstr "Radering misslyckades"
+
+#: id:16206
+msgid "Failed to delete at least one file"
+msgstr "Misslyckades radera minst en fil"
+
+#: id:16300
+msgid "Video scaling method"
+msgstr "Videoskalningsmetod"
+
+#: id:16301
+msgid "Nearest neighbour"
+msgstr "Närmsta granne"
+
+#: id:16302
+msgid "Bilinear"
+msgstr "Bilinear"
+
+#: id:16303
+msgctxt "Auto context with id 16303"
+msgid "Bicubic"
+msgstr "Bicubic"
+
+#: id:16304
+msgid "Lanczos2"
+msgstr "Lanczos2"
+
+#: id:16305
+msgid "Lanczos3"
+msgstr "Lanczos3"
+
+#: id:16306
+msgid "Sinc8"
+msgstr "Sinc8"
+
+#: id:16307
+msgid "Bicubic (software)"
+msgstr "Bicubic (mjukvara)"
+
+#: id:16308
+msgid "Lanczos (software)"
+msgstr "Lanczos (mjukvara)"
+
+#: id:16309
+msgid "Sinc (software)"
+msgstr "Sinc (mjukvara)"
+
+#: id:16310
+msgid "Temporal"
+msgstr "Temporal"
+
+#: id:16311
+msgid "Temporal/Spatial"
+msgstr "Temporal/Spatial"
+
+#: id:16312
+msgid "(VDPAU)Noise Reduction"
+msgstr "(VDPAU)Noise Reduction"
+
+#: id:16313
+msgid "(VDPAU)Sharpness"
+msgstr "(VDPAU)Sharpness"
+
+#: id:16314
+msgid "Inverse Telecine"
+msgstr "Inverse Telecine"
+
+#: id:16315
+msgid "Lanczos3 optimized"
+msgstr "Lanczos3 optimerad"
+
+#: id:16316
+msgctxt "Auto context with id 16316"
+msgid "Auto"
+msgstr "Auto"
+
+#: id:16317
+msgid "Temporal (Half)"
+msgstr "Temporal (Halv)"
+
+#: id:16318
+msgid "Temporal/Spatial (Half)"
+msgstr "Temporal/Spatial (Halv)"
+
+#: id:16319
+msgid "DXVA"
+msgstr "DXVA"
+
+#: id:16320
+msgid "DXVA Bob"
+msgstr "DXVA Bob"
+
+#: id:16321
+msgid "DXVA Best"
+msgstr "DXVA Best"
+
+#: id:16322
+msgid "Spline36"
+msgstr "Spline36"
+
+#: id:16323
+msgid "Spline36 optimized"
+msgstr "Spline36-optimerad"
+
+#: id:16324
+msgid "Software Blend"
+msgstr "Mjukvarublandning"
+
+#: id:16400
+msgid "Post-processing"
+msgstr "Efterbearbetning"
+
+#: id:17500
+msgid "Display sleep timeout"
+msgstr "Visa insommningstimeout"
+
+#: id:19000
+msgid "Switch to channel"
+msgstr "Byt till kanal"
+
+#: id:20000
+msgid "Saved music folder"
+msgstr "Mapp för sparad musik"
+
+#: id:20001
+msgid "Use external DVD player"
+msgstr "Använd extern DVD-spelare"
+
+#: id:20002
+msgid "External DVD player"
+msgstr "Extern DVD-spelare"
+
+#: id:20003
+msgid "Trainers folder"
+msgstr "Mapp för hjälpprogram"
+
+#: id:20004
+msgid "Screenshot folder"
+msgstr "Skärmdumpsmapp"
+
+#: id:20006
+msgid "Playlists folder"
+msgstr "Spellistsmapp"
+
+#: id:20007
+msgid "Recordings"
+msgstr "Inspelningar"
+
+#: id:20008
+msgid "Screenshots"
+msgstr "Skärmdumpar"
+
+#: id:20009
+msgid "Use XBMC"
+msgstr "Använd XBMC"
+
+#: id:20011
+msgid "Music playlists"
+msgstr "Musikspellistor"
+
+#: id:20012
+msgid "Video playlists"
+msgstr "Filmspellistor"
+
+#: id:20013
+msgid "Do you wish to launch the game?"
+msgstr "Vill du starta spelet?"
+
+#: id:20014
+msgid "Sort by: Playlist"
+msgstr "Sort: Spellista"
+
+#: id:20015
+msgid "Remote thumb"
+msgstr "Fjärrminiatyr"
+
+#: id:20016
+msgid "Current thumb"
+msgstr "Nuvarande miniatyr"
+
+#: id:20017
+msgid "Local thumb"
+msgstr "Lokal miniatyr"
+
+#: id:20018
+msgid "No thumb"
+msgstr "Ingen miniatyr"
+
+#: id:20019
+msgid "Choose thumbnail"
+msgstr "Välj miniatyrbild"
+
+#: id:20023
+msgid "Conflict"
+msgstr "Konflikt"
+
+#: id:20024
+msgid "Scan new"
+msgstr "Skanna nya"
+
+#: id:20025
+msgid "Scan all"
+msgstr "Skanna alla"
+
+#: id:20026
+msgid "Region"
+msgstr "Region"
+
+#: id:20037
+msgid "Summary"
+msgstr "Översikt"
+
+#: id:20038
+msgid "Lock music window"
+msgstr "Lås musikfönster"
+
+#: id:20039
+msgid "Lock videos window"
+msgstr "Lås filmfönster"
+
+#: id:20040
+msgid "Lock pictures window"
+msgstr "Lås bildfönster"
+
+#: id:20041
+msgid "Lock programs & scripts windows"
+msgstr "Lås program & skriptfönster"
+
+#: id:20042
+msgid "Lock file manager"
+msgstr "Lås filhanteraren"
+
+#: id:20043
+msgid "Lock settings"
+msgstr "Lås inställningar"
+
+#: id:20044
+msgid "Start fresh"
+msgstr "Starta på nytt"
+
+#: id:20045
+msgid "Enter master mode"
+msgstr "Gå in i huvudläge"
+
+#: id:20046
+msgid "Leave master mode"
+msgstr "Lämna huvudläge"
+
+#: id:20047
+msgid "Create profile '%s'?"
+msgstr "Skapa profil '%s'?"
+
+#: id:20048
+msgid "Start with fresh settings"
+msgstr "Starta med nya inställningar"
+
+#: id:20049
+msgid "Best available"
+msgstr "Bästa möjliga"
+
+#: id:20050
+msgid "Auto-switch between 16x9 and 4x3"
+msgstr "Autoväxling mellan 16x9 och 4x3"
+
+#: id:20051
+msgid "Treat stacked files as single file"
+msgstr "Behandla sammmanslagna filer som en enda"
+
+#: id:20052
+msgid "Caution"
+msgstr "Varning"
+
+#: id:20053
+msgid "Left master mode"
+msgstr "Lämnade huvudläge"
+
+#: id:20054
+msgid "Entered master mode"
+msgstr "Gick in i huvudläge"
+
+#: id:20055
+msgid "Allmusic.com thumb"
+msgstr "Allmusic.com-miniatyr"
+
+#: id:20057
+msgid "Remove thumbnail"
+msgstr "Ta bort miniatyrbild"
+
+#: id:20058
+msgid "Add profile..."
+msgstr "Lägg till profil..."
+
+#: id:20059
+msgid "Query info for all albums"
+msgstr "Hämta info för alla album"
+
+#: id:20060
+msgctxt "Auto context with id 20060"
+msgid "Media info"
+msgstr "Mediainfo"
+
+#: id:20061
+msgctxt "Auto context with id 20061"
+msgid "Separate"
+msgstr "Separata"
+
+#: id:20062
+msgid "Shares with default"
+msgstr "Källor med standard"
+
+#: id:20063
+msgid "Shares with default (read only)"
+msgstr "Källor med standard (endast läsning)"
+
+#: id:20064
+msgid "Copy default"
+msgstr "Kopiera standard"
+
+#: id:20065
+msgid "Profile picture"
+msgstr "Profilbild"
+
+#: id:20066
+msgid "Lock preferences"
+msgstr "Låsinställningar"
+
+#: id:20067
+msgid "Edit profile"
+msgstr "Redigera profil"
+
+#: id:20068
+msgid "Profile lock"
+msgstr "Profillås"
+
+#: id:20069
+msgid "Could not create folder"
+msgstr "Kunde inte skapa mapp"
+
+#: id:20070
+msgid "Profile directory"
+msgstr "Profilmapp"
+
+#: id:20071
+msgid "Start with fresh media sources"
+msgstr "Starta med nya mediakällor"
+
+#: id:20072
+msgid "Make sure the selected folder is writable"
+msgstr "Säkerställ att mappen är skrivbar"
+
+#: id:20073
+msgid "and that the new folder name is valid"
+msgstr "och att mappnamnet är giltigt"
+
+#: id:20074
+msgid "MPAA rating"
+msgstr "MPAA-klassificiering"
+
+#: id:20075
+msgid "Enter master lock code"
+msgstr "Mata in huvudkod"
+
+#: id:20076
+msgid "Ask for master lock code on startup"
+msgstr "Fråga efter huvudkod vid uppstart"
+
+#: id:20077
+msgid "Skin settings"
+msgstr "Skalinställningar"
+
+#: id:20078
+msgid "- no link set -"
+msgstr "- ingen länk -"
+
+#: id:20079
+msgid "Enable animations"
+msgstr "Aktivera animationer"
+
+#: id:20080
+msgid "Disable RSS during music"
+msgstr "Inaktivera RSS under musik"
+
+#: id:20081
+msgid "Enable shortcut buttons"
+msgstr "Aktivera genvägsknappar"
+
+#: id:20082
+msgid "Show programs in main menu"
+msgstr "Visa program i huvudmenyn"
+
+#: id:20083
+msgid "Show music info"
+msgstr "Visa musikinformation"
+
+#: id:20084
+msgid "Show weather info"
+msgstr "Visa väderinformation"
+
+#: id:20085
+msgid "Show system info"
+msgstr "Visa systeminformation"
+
+#: id:20086
+msgid "Show available disc space C: E: F:"
+msgstr "Visa ledigt diskutrymme (C: E: F:)"
+
+#: id:20087
+msgid "Show available disc space E: F: G:"
+msgstr "Visa ledigt diskutrymme (E: F: G:)"
+
+#: id:20088
+msgid "Weather info"
+msgstr "Väderinfo"
+
+#: id:20089
+msgid "Drive space free"
+msgstr "Ledigt diskutrymme"
+
+#: id:20090
+msgid "Enter the name of an existing share"
+msgstr "Ange namnet på en befintlig delning"
+
+#: id:20091
+msgid "Lock code"
+msgstr "Låskod"
+
+#: id:20092
+msgid "Load profile"
+msgstr "Ladda profil"
+
+#: id:20093
+msgid "Profile name"
+msgstr "Profilnamn"
+
+#: id:20094
+msgctxt "Auto context with id 20094"
+msgid "Media sources"
+msgstr "Mediakällor"
+
+#: id:20095
+msgid "Enter profile lock code"
+msgstr "Mata in profilens låskod"
+
+#: id:20096
+msgctxt "Auto context with id 20096"
+msgid "Login screen"
+msgstr "Inlogg. skärm"
+
+#: id:20097
+msgid "Fetching album info"
+msgstr "Hämtar albuminfo"
+
+#: id:20098
+msgid "Fetching info for album"
+msgstr "Hämtar info för album"
+
+#: id:20099
+msgid "Can't rip CD or track while playing from CD"
+msgstr "Kan inte rippa CD eller spår medan CDn spelar"
+
+#: id:20100
+msgid "Master lock code and settings"
+msgstr "Huvudkod och lås"
+
+#: id:20101
+msgid "Entering master lock code always enables master mode"
+msgstr "Logga in som huvudanv. aktiverar huvudläge"
+
+#: id:20102
+msgid "or copy from default?"
+msgstr "eller kopiera från standard?"
+
+#: id:20103
+msgid "Save changes to profile?"
+msgstr "Spara ändringar till profil?"
+
+#: id:20104
+msgid "Old settings found."
+msgstr "Gamla inställningar hittade."
+
+#: id:20105
+msgid "Do you want to use them?"
+msgstr "Vill du använda dom?"
+
+#: id:20106
+msgid "Old media sources found."
+msgstr "Gamla mediakällor hittade."
+
+#: id:20107
+msgid "Separate (locked)"
+msgstr "Separata (låsta)"
+
+#: id:20108
+msgid "Root"
+msgstr "Huvudmapp"
+
+#: id:20109
+msgid "- Zoom"
+msgstr "- Zoom"
+
+#: id:20110
+msgid "UPnP settings"
+msgstr "UPnP-inställningar"
+
+#: id:20111
+msgid "Autostart UPnP client"
+msgstr "Autostarta UPnP-klient"
+
+#: id:20112
+msgid "Last login: %s"
+msgstr "Sist inloggad: %s"
+
+#: id:20113
+msgid "Never logged on"
+msgstr "Aldrig inloggad"
+
+#: id:20114
+msgid "Profile %i / %i"
+msgstr "Profil %i / %i"
+
+#: id:20115
+msgid "User login / Select a profile"
+msgstr "Användarinloggning / Välj en profil"
+
+#: id:20116
+msgid "Use lock on login screen"
+msgstr "Använd lås på inloggningsskärmen"
+
+#: id:20117
+msgid "Invalid lock code."
+msgstr "Ogiltig låskod."
+
+#: id:20118
+msgid "This requires the master lock to be set."
+msgstr "Detta kräver att huvudkoden är satt."
+
+#: id:20119
+msgid "Would you like to set it now?"
+msgstr "Vill du sätta den nu?"
+
+#: id:20120
+msgid "Loading program information"
+msgstr "Laddar programinformation"
+
+#: id:20121
+msgid "Party on!"
+msgstr "Festa på!"
+
+#: id:20122
+msgid "True"
+msgstr "Sant"
+
+#: id:20123
+msgid "Mixing drinks"
+msgstr "Blandar drinkar"
+
+#: id:20124
+msgid "Filling glasses"
+msgstr "Fyller glasen"
+
+#: id:20125
+msgid "Logged on as"
+msgstr "Inloggad som"
+
+#: id:20126
+msgid "Log off"
+msgstr "Logga ut"
+
+#: id:20128
+msgid "Go to root"
+msgstr "Gå till huvudmapp"
+
+#: id:20129
+msgid "Weave"
+msgstr "Weave"
+
+#: id:20130
+msgid "Weave (inverted)"
+msgstr "Weave (inverterad)"
+
+#: id:20131
+msgid "Blend"
+msgstr "Blend"
+
+#: id:20132
+msgid "Restart video"
+msgstr "Starta om film"
+
+#: id:20133
+msgid "Edit network location"
+msgstr "Redigera nätverksplats"
+
+#: id:20134
+msgid "Remove network location"
+msgstr "Ta bort nätverksplats"
+
+#: id:20135
+msgid "Do you want to scan the folder?"
+msgstr "Vill du skanna mappen?"
+
+#: id:20136
+msgid "Memory unit"
+msgstr "Minnesenhet"
+
+#: id:20137
+msgid "Memory unit mounted"
+msgstr "Minnesenhet monterad"
+
+#: id:20138
+msgid "Unable to mount memory unit"
+msgstr "Kunde inte montera minnesenhet"
+
+#: id:20139
+msgid "In port %i, slot %i"
+msgstr "I port %i, plats %i"
+
+#: id:20140
+msgid "Lock screensaver"
+msgstr "Lås skärmsläckare"
+
+#: id:20141
+msgid "Set"
+msgstr "Satt"
+
+#: id:20142
+msgctxt "Auto context with id 20142"
+msgid "Username"
+msgstr "Användarnamn"
+
+#: id:20143
+msgid "Enter password for"
+msgstr "Ange lösenord för"
+
+#: id:20144
+msgid "Shutdown timer"
+msgstr "Avstängningstimer"
+
+#: id:20145
+msgid "Shutdown interval (in minutes)"
+msgstr "Avstängningsintervall (i minuter)"
+
+#: id:20146
+msgid "Started, shutdown in %im"
+msgstr "Startad, avstängning om %im"
+
+#: id:20147
+msgid "Shutdown in 30 minutes"
+msgstr "Stäng av om 30 minuter"
+
+#: id:20148
+msgid "Shutdown in 60 minutes"
+msgstr "Stäng av om 60 minuter"
+
+#: id:20149
+msgid "Shutdown in 120 minutes"
+msgstr "Stäng av om 120 minuter"
+
+#: id:20150
+msgid "Custom shutdown timer"
+msgstr "Ange avstängningstimer"
+
+#: id:20151
+msgid "Cancel shutdown timer"
+msgstr "Avbryt avstängningstimer"
+
+#: id:20152
+msgid "Lock preferences for %s"
+msgstr "Låsinställningar för %s"
+
+#: id:20153
+msgid "Browse..."
+msgstr "Bläddra..."
+
+#: id:20154
+msgid "Summary information"
+msgstr "Sammanfattad information"
+
+#: id:20155
+msgid "Storage information"
+msgstr "Lagringsinformation"
+
+#: id:20156
+msgid "Hard disk information"
+msgstr "Hårddiskinformation"
+
+#: id:20157
+msgid "DVD-ROM information"
+msgstr "DVD-Rom-information"
+
+#: id:20158
+msgid "Network information"
+msgstr "Nätverksinformation"
+
+#: id:20159
+msgid "Video information"
+msgstr "Grafikinformation"
+
+#: id:20160
+msgid "Hardware information"
+msgstr "Hårdvaruinformation"
+
+#: id:20161
+msgid "Total"
+msgstr "Totalt"
+
+#: id:20162
+msgid "Used"
+msgstr "använt"
+
+#: id:20163
+msgid "of"
+msgstr "av"
+
+#: id:20164
+msgid "Locking not supported"
+msgstr "Låsning stöds inte"
+
+#: id:20165
+msgid "Not locked"
+msgstr "Inte låst"
+
+#: id:20166
+msgid "Locked"
+msgstr "Låst"
+
+#: id:20167
+msgid "Frozen"
+msgstr "Fryst"
+
+#: id:20168
+msgid "Requires reset"
+msgstr "Kräver omstart"
+
+#: id:20169
+msgid "Week"
+msgstr "Vecka"
+
+#: id:20170
+msgid "Line"
+msgstr "Linje"
+
+#: id:20171
+msgid "Windows network (SMB)"
+msgstr "Windowsnätverk (SMB)"
+
+#: id:20172
+msgid "XBMSP server"
+msgstr "XBMSP-server"
+
+#: id:20173
+msgctxt "Auto context with id 20173"
+msgid "FTP server"
+msgstr "FTP-server"
+
+#: id:20174
+msgid "iTunes music share (DAAP)"
+msgstr "iTunes-musikdelning (DAAP)"
+
+#: id:20175
+msgid "UPnP server"
+msgstr "UPnP-server"
+
+#: id:20176
+msgid "Show video info"
+msgstr "Visa grafikinformation"
+
+#: id:20177
+msgid "Done"
+msgstr "Färdig"
+
+#: id:20178
+msgid "Shift"
+msgstr "Shift"
+
+#: id:20179
+msgid "Caps Lock"
+msgstr "Capslock"
+
+#: id:20180
+msgid "Symbols"
+msgstr "Symboler"
+
+#: id:20181
+msgid "Backspace"
+msgstr "Backsteg"
+
+#: id:20182
+msgid "Space"
+msgstr "Mellanslag"
+
+#: id:20183
+msgid "Reload skin"
+msgstr "Ladda om skal"
+
+#: id:20184
+msgid "Rotate pictures using EXIF information"
+msgstr "Vrid som angivet i EXIF-information"
+
+#: id:20185
+msgid "Use poster view styles for TV shows"
+msgstr "Använd postervisning för TV-serier"
+
+#: id:20186
+msgid "Please wait"
+msgstr "Var god vänta"
+
+#: id:20187
+msgid "UPnP"
+msgstr ""
+
+#: id:20189
+msgid "Enable auto scrolling for plot & review"
+msgstr "Aktivera automatisk rullning för handling & recension"
+
+#: id:20190
+msgctxt "Auto context with id 20190"
+msgid "Custom"
+msgstr "Anpassad"
+
+#: id:20191
+msgid "Enable debug logging"
+msgstr "Aktivera debugloggning"
+
+#: id:20192
+msgid "Download additional information during updates"
+msgstr "Hämta tilläggsinformation under uppdateringar"
+
+#: id:20193
+msgid "Default service for album information"
+msgstr "Standardservice för albuminformation"
+
+#: id:20194
+msgid "Default service for artist information"
+msgstr "Standardservice för artistinformation"
+
+#: id:20195
+msgid "Change scraper"
+msgstr "Byt skrapa"
+
+#: id:20196
+msgid "Export music library"
+msgstr "Exportera musikbibliotek"
+
+#: id:20197
+msgid "Import music library"
+msgstr "Importera musikbibliotek"
+
+#: id:20198
+msgid "No artist found!"
+msgstr "Ingen artist hittad!"
+
+#: id:20199
+msgid "Downloading artist info failed"
+msgstr "Nedladdning av artistinfo misslyckades"
+
+#: id:20250
+msgid "Party on! (videos)"
+msgstr "Festa på! (filmer)"
+
+#: id:20251
+msgid "Mixing drinks (videos)"
+msgstr "Blandar drinkar (filmer)"
+
+#: id:20252
+msgid "Filling glasses (videos)"
+msgstr "Fyller glasen (filmer)"
+
+#: id:20253
+msgid "WebDAV server (HTTP)"
+msgstr "WebDAV-server (HTTP)"
+
+#: id:20254
+msgid "WebDAV server (HTTPS)"
+msgstr "WebDAV-server (HTTPS)"
+
+#: id:20255
+msgid "First logon, edit your profile"
+msgstr "Första inloggningen, ändra din profil"
+
+#: id:20256
+msgid "HTS Tvheadend client"
+msgstr "HTS Tvheadend-klient"
+
+#: id:20257
+msgid "VDR Streamdev client"
+msgstr "VDR Streamdev-klient"
+
+#: id:20258
+msgid "MythTV client"
+msgstr "MythTV-klient"
+
+#: id:20259
+msgid "Network Filesystem (NFS)"
+msgstr "Network Filesystem (NFS)"
+
+#: id:20260
+msgid "Secure Shell (SSH/SFTP)"
+msgstr "Secure Shell (SSH/SFTP)"
+
+#: id:20261
+msgid "Apple Filing Protocol (AFP)"
+msgstr "Apple Flin Protocol (AFP)"
+
+#: id:20300
+msgid "Web server directory (HTTP)"
+msgstr "Webbserver katalog (HTTP)"
+
+#: id:20301
+msgid "Web server directory (HTTPS)"
+msgstr "Webbserver katalog (HTTPS)"
+
+#: id:20302
+msgid "Unable to write to folder:"
+msgstr "Kunde inte skriva till mapp:"
+
+#: id:20303
+msgid "Do you want to skip and proceed?"
+msgstr "Vill du hoppa över och fortsätta?"
+
+#: id:20304
+msgid "RSS Feed"
+msgstr "RSS-flöde"
+
+#: id:20307
+msgid "Secondary DNS"
+msgstr "Sekundär DNS"
+
+#: id:20308
+msgid "DHCP server:"
+msgstr "DHCP-server:"
+
+#: id:20309
+msgid "Make new folder"
+msgstr "Skapa ny mapp"
+
+#: id:20310
+msgid "Dim LCD on playback"
+msgstr "Tona ned LCD under uppspelning"
+
+#: id:20311
+msgid "Unknown or onboard (protected)"
+msgstr "Okänd eller inbyggd (skyddad)"
+
+#: id:20312
+msgid "Dim LCD on paused"
+msgstr "Tona ned LCD under paus"
+
+#: id:20314
+msgid "Videos - Library"
+msgstr "Filmer - Bibliotek"
+
+#: id:20316
+msgid "Sort by: ID"
+msgstr "Sort: ID"
+
+#: id:20324
+msgid "Play part..."
+msgstr "Spela del..."
+
+#: id:20325
+msgid "Calibration reset"
+msgstr "Kalibreringsåterställning"
+
+#: id:20326
+msgid "This will reset the calibration values for %s"
+msgstr "Detta kommer att återställa kalibreringsvärden för %s"
+
+#: id:20327
+msgid "to it's default values."
+msgstr "till dess usprungliga värden."
+
+#: id:20328
+msgid "Browse for destination"
+msgstr "Bläddra efter destination"
+
+#: id:20329
+msgid "Movies are in separate folders that match the movie title"
+msgstr ""
+
+#: id:20330
+msgid "Use folder names for lookups"
+msgstr "Använd mappnamn för sökningar"
+
+#: id:20331
+msgctxt "Auto context with id 20331"
+msgid "File"
+msgstr "Fil"
+
+#: id:20332
+msgid "Use file or folder names in lookups?"
+msgstr "Använd fil- eller mappnamn i förfrågningar?"
+
+#: id:20333
+msgid "Set content"
+msgstr "Sätt innehåll"
+
+#: id:20334
+msgid "Folder"
+msgstr "Mapp"
+
+#: id:20335
+msgid "Look for content recursively?"
+msgstr "Leta rekursivt efter innehåll?"
+
+#: id:20336
+msgid "Unlock sources"
+msgstr "Lås upp källor"
+
+#: id:20337
+msgid "Actor"
+msgstr "Skådespelare"
+
+#: id:20338
+msgid "Movie"
+msgstr "Film"
+
+#: id:20339
+msgid "Director"
+msgstr "Regissör"
+
+#: id:20340
+msgid "Do you want to remove all items within"
+msgstr "Vill du ta bort alla objekt för"
+
+#: id:20341
+msgid "this path from the XBMC library?"
+msgstr "XBMC-biblioteket i denna sökväg?"
+
+#: id:20342
+msgctxt "Auto context with id 20342"
+msgid "Movies"
+msgstr "Filmer"
+
+#: id:20343
+msgid "TV shows"
+msgstr "TV-serier"
+
+#: id:20344
+msgid "This directory contains"
+msgstr "Denna mapp innehåller"
+
+#: id:20345
+msgid "Run automated scan"
+msgstr "Kör automatisk skanning"
+
+#: id:20346
+msgid "Scan recursively"
+msgstr "Skanna rekursivt"
+
+#: id:20347
+msgid "as"
+msgstr "som"
+
+#: id:20348
+msgid "Directors"
+msgstr "Regissörer"
+
+#: id:20349
+msgid "No video files found in this path!"
+msgstr "Inga filmfiler hittades i denna sökväg!"
+
+#: id:20350
+msgid "votes"
+msgstr "röster"
+
+#: id:20351
+msgid "TV show information"
+msgstr "TV-serieinformation"
+
+#: id:20352
+msgid "Episode information"
+msgstr "Avsnittsinformation"
+
+#: id:20353
+msgid "Loading TV show details"
+msgstr "Laddar TV-seriedetaljer"
+
+#: id:20354
+msgid "Fetching episode guide"
+msgstr "Hämtar avsnittsguide"
+
+#: id:20355
+msgid "Loading info for episodes in directory"
+msgstr "Laddar info för avsnitt i mappen"
+
+#: id:20356
+msgid "Select TV show:"
+msgstr "Välj TV-serie:"
+
+#: id:20357
+msgid "Enter the TV show name"
+msgstr "Ange TV-seriens namn"
+
+#: id:20358
+msgid "Season %i"
+msgstr "Säsong %i"
+
+#: id:20359
+msgid "Episode"
+msgstr "Avsnitt"
+
+#: id:20360
+msgid "Episodes"
+msgstr "Avsnitt"
+
+#: id:20361
+msgid "Loading episode details"
+msgstr "Laddar avsnittsdetaljer"
+
+#: id:20362
+msgid "Remove episode from library"
+msgstr "Ta bort avsnitt från bibliotek"
+
+#: id:20363
+msgid "Remove TV show from library"
+msgstr "Ta bort TV-serie från bibliotek"
+
+#: id:20364
+msgid "TV show"
+msgstr "TV-serie"
+
+#: id:20365
+msgid "Episode plot"
+msgstr "Handling i avsnitt"
+
+#: id:20366
+msgid "* All seasons"
+msgstr "* Alla säsonger"
+
+#: id:20367
+msgid "Hide watched"
+msgstr "Dölj sedda"
+
+#: id:20368
+msgid "Prod code"
+msgstr "Prod. kod"
+
+#: id:20369
+msgid "Show plot for unwatched items"
+msgstr "Visa handling för osedda objekt"
+
+#: id:20370
+msgid "* Hidden to prevent spoilers *"
+msgstr "* Dold för att inte förstöra handlingen *"
+
+#: id:20371
+msgid "Set season thumb"
+msgstr "Sätt säsongsminiatyr"
+
+#: id:20372
+msgid "Season image"
+msgstr "Säsongsbild"
+
+#: id:20373
+msgid "Season"
+msgstr "Säsong"
+
+#: id:20374
+msgid "Downloading movie information"
+msgstr "Hämtar filminformation"
+
+#: id:20375
+msgid "Unassign content"
+msgstr "Oassocierat innehåll"
+
+#: id:20376
+msgid "Original title"
+msgstr "Originaltitel"
+
+#: id:20377
+msgid "Refresh TV show information"
+msgstr "Uppdatera TV-serieinformation"
+
+#: id:20378
+msgid "Refresh info for all episodes?"
+msgstr "Uppdatera alla avsnitt?"
+
+#: id:20379
+msgid "Selected folder contains a single TV show"
+msgstr "Mappen innehåller en enda TV-serie"
+
+#: id:20380
+msgid "Exclude selected folder from scans"
+msgstr "Ignorera mapp vid skanning"
+
+#: id:20381
+msgid "Specials"
+msgstr "Specialer"
+
+#: id:20382
+msgid "Automatically grab season thumbs"
+msgstr "Hämta säsongsminiatyrer automatiskt"
+
+#: id:20383
+msgid "Selected folder contains a single video"
+msgstr "Mappen innehåller en enstaka film"
+
+#: id:20384
+msgid "Link to TV show"
+msgstr "Länk till TV-serie"
+
+#: id:20385
+msgid "Remove link to TV show"
+msgstr "Ta bort länk till TV-serie"
+
+#: id:20386
+msgid "Recently added movies"
+msgstr "Nyligen tillagda filmer"
+
+#: id:20387
+msgid "Recently added episodes"
+msgstr "Nyligen tillagda avsnitt"
+
+#: id:20388
+msgid "Studios"
+msgstr "Studior"
+
+#: id:20389
+msgid "Music videos"
+msgstr "Musikvideor"
+
+#: id:20390
+msgid "Recently added music videos"
+msgstr "Nyligen tillagda musikvideor"
+
+#: id:20391
+msgid "Music video"
+msgstr "Musikvideo"
+
+#: id:20392
+msgid "Remove music video from library"
+msgstr "Ta bort musikvideo från biblioteket"
+
+#: id:20393
+msgctxt "Auto context with id 20393"
+msgid "Music video information"
+msgstr "Musikvideoinformation"
+
+#: id:20394
+msgid "Loading music video information"
+msgstr "Laddar musikvideoinformation"
+
+#: id:20395
+msgid "Mixed"
+msgstr "Blandad"
+
+#: id:20396
+msgid "Go to albums by artist"
+msgstr "Gå till album av artist"
+
+#: id:20397
+msgid "Go to album"
+msgstr "Gå till album"
+
+#: id:20398
+msgid "Play song"
+msgstr "Spela låt"
+
+#: id:20399
+msgid "Go to music videos from album"
+msgstr "Gå till musikvideor från album"
+
+#: id:20400
+msgid "Go to music videos by artist"
+msgstr "Gå till musikvideor av artist"
+
+#: id:20401
+msgid "Play music video"
+msgstr "Spela musikvideo"
+
+#: id:20402
+msgid "Download actor thumbnails when adding to library"
+msgstr "Hämta skådespelarminiatyrer vid tilläggning till biblioteket"
+
+#: id:20403
+msgid "Set actor thumb"
+msgstr "Ange skådespelarminiatyr"
+
+#: id:20405
+msgid "Remove episode bookmark"
+msgstr "Ta bort avsnittsbokmärke"
+
+#: id:20406
+msgid "Set episode bookmark"
+msgstr "Lägg till avsnittsbokmärke"
+
+#: id:20407
+msgid "Scraper settings"
+msgstr "Skrap-inställningar"
+
+#: id:20408
+msgid "Downloading music video information"
+msgstr "Hämtar musikvideoinformation"
+
+#: id:20409
+msgid "Downloading TV show information"
+msgstr "Hämtar TV-serieinformation"
+
+#: id:20410
+msgid "Trailer"
+msgstr "Trailer"
+
+#: id:20411
+msgid "Flatten"
+msgstr "Lägg ihop"
+
+#: id:20412
+msgid "Flatten TV shows"
+msgstr "Lägg ihop TV-serie"
+
+#: id:20413
+msgid "Get fanart"
+msgstr "Hämta fanart"
+
+#: id:20414
+msgid "Show Fanart in video and music libraries"
+msgstr "Visa fanart i video och musikbibliotek"
+
+#: id:20415
+msgid "Scanning for new content"
+msgstr "Skannar efter nytt innehåll"
+
+#: id:20416
+msgid "First aired"
+msgstr "Först sänt"
+
+#: id:20417
+msgid "Writer"
+msgstr "Författare"
+
+#: id:20419
+msgid "Replace file names with library titles"
+msgstr "Visa metadata i filläge"
+
+#: id:20420
+msgctxt "Auto context with id 20420"
+msgid "Never"
+msgstr "Aldrig"
+
+#: id:20421
+msgid "If only one season"
+msgstr "Om endast en säsong"
+
+#: id:20422
+msgid "Always"
+msgstr "Alltid"
+
+#: id:20423
+msgid "Has trailer"
+msgstr "Har trailer"
+
+#: id:20424
+msgid "False"
+msgstr "Falskt"
+
+#: id:20425
+msgid "Fanart slideshow"
+msgstr "Fanart-bildspel"
+
+#: id:20426
+msgid "Export to a single file or separate"
+msgstr "Exportera till en ensam fil eller"
+
+#: id:20427
+msgid "files per entry?"
+msgstr "separata filer per post?"
+
+#: id:20428
+msgid "Single file"
+msgstr "Ensam fil"
+
+#: id:20429
+msgctxt "Auto context with id 20429"
+msgid "Separate"
+msgstr "Separata"
+
+#: id:20430
+msgid "Export thumbnails and fanart?"
+msgstr "Exportera miniatyrer och fanart?"
+
+#: id:20431
+msgid "Overwrite old files?"
+msgstr "Skriva över äldre filer?"
+
+#: id:20432
+msgid "Exclude path from library updates"
+msgstr "Uteslut sökväg från biblioteksuppdateringar"
+
+#: id:20433
+msgid "Extract thumbnails and video information"
+msgstr "Hämta miniatyrer och filminformation"
+
+#: id:20434
+msgid "Sets"
+msgstr "Uppsättningar"
+
+#: id:20435
+msgid "Set movieset thumb"
+msgstr "Ange filmuppsättningsminiatyr"
+
+#: id:20436
+msgid "Export actor thumbs?"
+msgstr "Exportera skådespelarminiatyrer?"
+
+#: id:20437
+msgid "Choose fanart"
+msgstr "Välj fanart"
+
+#: id:20438
+msgid "Local fanart"
+msgstr "Lokal fanart"
+
+#: id:20439
+msgid "No fanart"
+msgstr "Ingen fanart"
+
+#: id:20440
+msgid "Current fanart"
+msgstr "Nuvarande fanart"
+
+#: id:20441
+msgid "Remote fanart"
+msgstr "Fjärr-fanart"
+
+#: id:20442
+msgid "Change content"
+msgstr "Ändra innehåll"
+
+#: id:20443
+msgid "Do you want to refresh info for all"
+msgstr "Vill du uppdatera info för alla"
+
+#: id:20444
+msgid "items within this path?"
+msgstr "objekt i denna sökväg?"
+
+#: id:20445
+msgid "Fanart"
+msgstr "Fanart"
+
+#: id:20446
+msgid "Locally stored information found."
+msgstr "Lokalt lagrad information hittad."
+
+#: id:20447
+msgid "Ignore and refresh from internet?"
+msgstr "Ignorera och uppdatera från Internet?"
+
+#: id:20448
+msgid "Could not download information"
+msgstr "Kunde inte ladda ner information"
+
+#: id:20449
+msgid "Unable to connect to remote server"
+msgstr "Kunde inte ansluta till fjärrserver"
+
+#: id:20450
+msgid "Would you like to continue scanning?"
+msgstr "Vill du fortsätta skanna?"
+
+#: id:20451
+msgid "Countries"
+msgstr "Länder"
+
+#: id:20452
+msgid "episode"
+msgstr "avsnitt"
+
+#: id:20453
+msgid "episodes"
+msgstr "avsnitt"
+
+#: id:20454
+msgid "Listener"
+msgstr "Lyssnare"
+
+#: id:20455
+msgid "Listeners"
+msgstr "Lyssnare"
+
+#: id:20456
+msgid "Set movieset fanart"
+msgstr "Ange filmsetsfanart"
+
+#: id:20457
+msgid "Movie set"
+msgstr "Filmset"
+
+#: id:20458
+msgid "Group movies in sets"
+msgstr ""
+
+#: id:21330
+msgid "Show hidden files and directories"
+msgstr "Visa dolda filer och mappar"
+
+#: id:21331
+msgid "TuxBox client"
+msgstr "TuxBox-klient"
+
+#: id:21332
+msgid "WARNING: Target TuxBox device is in recording-mode!"
+msgstr "VARNING: Vald TuxBox-enhet är i inspelningsläge!"
+
+#: id:21333
+msgid "The stream will be stopped!"
+msgstr "Strömmen kommer att stoppas!"
+
+#: id:21334
+msgid "Zap to channel: %s failed!"
+msgstr "Byte till kanal: %s misslyckades!"
+
+#: id:21335
+msgid "Are you sure to start the stream?"
+msgstr "Är du säker att du vill starta strömmen?"
+
+#: id:21336
+msgid "Connecting to: %s"
+msgstr "Ansluter till: %s"
+
+#: id:21337
+msgid "TuxBox device"
+msgstr "TuxBox-enhet"
+
+#: id:21359
+msgid "Add media share..."
+msgstr "Lägg till mediautdelning..."
+
+#: id:21360
+msgid "Share video and music libraries through UPnP"
+msgstr "Dela film- och musikbibliotek via UPnP"
+
+#: id:21364
+msgid "Edit media share"
+msgstr "Redigera mediautdelning"
+
+#: id:21365
+msgid "Remove media share"
+msgstr "Ta bort mediautdelning"
+
+#: id:21366
+msgid "Subtitle folder"
+msgstr "Undertextsmapp"
+
+#: id:21367
+msgid "Movie & alternate subtitle directory"
+msgstr "Film & alternativ undertextmapp"
+
+#: id:21368
+msgid "Override ASS/SSA subtitles fonts"
+msgstr "Åsidosätt ASS/SSA undertextstypsnitt"
+
+#: id:21369
+msgid "Enable mouse and Touch Screen support"
+msgstr "Aktivera mus"
+
+#: id:21370
+msgid "Play navigation sounds during media playback"
+msgstr "Spela navigationsljud under mediauppspelning"
+
+#: id:21371
+msgid "Thumbnail"
+msgstr "Miniatyrbild"
+
+#: id:21372
+msgid "Forced DVD player region"
+msgstr "Tvingad DVD-region"
+
+#: id:21373
+msgid "Video output"
+msgstr "Grafikutgång"
+
+#: id:21374
+msgid "Video aspect"
+msgstr "Bildläge"
+
+#: id:21375
+msgctxt "Auto context with id 21375"
+msgid "Normal"
+msgstr "Normal"
+
+#: id:21376
+msgid "Letterbox"
+msgstr "Letterbox"
+
+#: id:21377
+msgid "Widescreen"
+msgstr "Bredbild"
+
+#: id:21378
+msgid "Enable 480p"
+msgstr "Aktivera 480p"
+
+#: id:21379
+msgid "Enable 720p"
+msgstr "Aktivera 720p"
+
+#: id:21380
+msgid "Enable 1080i"
+msgstr "Aktivera 1080i"
+
+#: id:21381
+msgid "Enter name of new playlist"
+msgstr "Ange namn på den nya spellistan"
+
+#: id:21382
+msgid "Show \"Add source\" buttons in file lists"
+msgstr "Visa knapp för \"Lägg till källa\" i fillistan"
+
+#: id:21383
+msgid "Enable scrollbars"
+msgstr "Aktivera rullningslister"
+
+#: id:21384
+msgid "Make watched filtering a toggle in video library"
+msgstr "Gör visad-filter ett val i filmbibliotek"
+
+#: id:21385
+msgctxt "Auto context with id 21385"
+msgid "Open"
+msgstr "Öppna"
+
+#: id:21386
+msgid "Acoustic management level"
+msgstr "Ljudnivåhantering"
+
+#: id:21387
+msgid "Fast"
+msgstr "Snabb"
+
+#: id:21388
+msgid "Quiet"
+msgstr "Tyst"
+
+#: id:21389
+msgid "Enable custom background"
+msgstr "Aktivera annpassad bakgrund"
+
+#: id:21390
+msgid "Power management level"
+msgstr "Energibesparingshantering"
+
+#: id:21391
+msgid "High power"
+msgstr "Hög strömförbrukning"
+
+#: id:21392
+msgid "Low power"
+msgstr "Låg strömförbrukning"
+
+#: id:21393
+msgid "High standby"
+msgstr "Hög standby"
+
+#: id:21394
+msgid "Low standby"
+msgstr "Låg standby"
+
+#: id:21395
+msgid "Unable to cache files bigger than 4GB"
+msgstr "Kan inte buffra filer större än 4GB"
+
+#: id:21396
+msgid "Chapter"
+msgstr "Kapitel"
+
+#: id:21397
+msgid "High quality pixel shader v2"
+msgstr "Högkvalitets pixelshader v2"
+
+#: id:21398
+msgid "Enable playlist at startup"
+msgstr "Aktivera spellista vid start"
+
+#: id:21399
+msgid "Use tween animations"
+msgstr "Använd elastiska animeringar"
+
+#: id:21400
+msgid "contains"
+msgstr "innehåller"
+
+#: id:21401
+msgid "does not contain"
+msgstr "innehåller inte"
+
+#: id:21402
+msgid "is"
+msgstr "är"
+
+#: id:21403
+msgid "is not"
+msgstr "är inte"
+
+#: id:21404
+msgid "starts with"
+msgstr "börjar med"
+
+#: id:21405
+msgid "ends with"
+msgstr "slutar med"
+
+#: id:21406
+msgid "greater than"
+msgstr "större än"
+
+#: id:21407
+msgid "less than"
+msgstr "mindre än"
+
+#: id:21408
+msgid "after"
+msgstr "efter"
+
+#: id:21409
+msgid "before"
+msgstr "före"
+
+#: id:21410
+msgid "in the last"
+msgstr "i det senaste"
+
+#: id:21411
+msgid "not in the last"
+msgstr "inte i det senaste"
+
+#: id:21412
+msgid "Scrapers"
+msgstr "Skrapor"
+
+#: id:21413
+msgid "Default movie scraper"
+msgstr "Standard-filmskrapa"
+
+#: id:21414
+msgid "Default tvshow scraper"
+msgstr "Standard-TV-serieskrapa"
+
+#: id:21415
+msgid "Default music video scraper"
+msgstr "Standard-musikvideoskrapa"
+
+#: id:21416
+msgid "Enable fallback based on scraper language"
+msgstr "Aktivera återfall baserat på skrapspråk"
+
+#: id:21417
+msgid "- Settings"
+msgstr "- Inställningar"
+
+#: id:21418
+msgid "Multilingual"
+msgstr "Flerspråkig"
+
+#: id:21419
+msgid "No scrapers present"
+msgstr "Inga skrapor tillgängliga"
+
+#: id:21420
+msgid "Value to match"
+msgstr "Värde att matcha"
+
+#: id:21421
+msgid "Smart playlist rule"
+msgstr "Smart spellistregel"
+
+#: id:21422
+msgid "Match items where"
+msgstr "Matcha objekt som"
+
+#: id:21423
+msgid "New rule..."
+msgstr "Ny regel..."
+
+#: id:21424
+msgid "Items must match"
+msgstr "Objekt måste matcha"
+
+#: id:21425
+msgid "all of the rules"
+msgstr "alla regler"
+
+#: id:21426
+msgid "one or more of the rules"
+msgstr "en eller flera regler"
+
+#: id:21427
+msgid "Limit to"
+msgstr "Begränsa till"
+
+#: id:21428
+msgid "No limit"
+msgstr "Ingen begränsning"
+
+#: id:21429
+msgid "Order by"
+msgstr "Sortera efter"
+
+#: id:21430
+msgid "ascending"
+msgstr "stigande"
+
+#: id:21431
+msgid "descending"
+msgstr "fallande"
+
+#: id:21432
+msgid "Edit smart playlist"
+msgstr "Redigera smart spellista"
+
+#: id:21433
+msgid "Name of the playlist"
+msgstr "Namn på spellista"
+
+#: id:21434
+msgid "Find items where"
+msgstr "Hitta objekt som matchar"
+
+#: id:21435
+msgid "Edit"
+msgstr "Redigera"
+
+#: id:21436
+msgid "%i items"
+msgstr "%i låtar"
+
+#: id:21437
+msgid "New smart playlist..."
+msgstr "Ny smart spellista..."
+
+#: id:21438
+msgid "%c Drive"
+msgstr "%c disk"
+
+#: id:21439
+msgid "Edit party mode rules"
+msgstr "Redigera partylägesregler"
+
+#: id:21440
+msgid "Home folder"
+msgstr "Hemmapp"
+
+#: id:21441
+msgid "Watched count"
+msgstr "Visad-räkning"
+
+#: id:21442
+msgid "Episode title"
+msgstr "Avsnittstitel"
+
+#: id:21443
+msgid "Video resolution"
+msgstr "Videoupplösning"
+
+#: id:21444
+msgid "Audio channels"
+msgstr "Ljudkanaler"
+
+#: id:21445
+msgid "Video codec"
+msgstr "Videocodec"
+
+#: id:21446
+msgid "Audio codec"
+msgstr "Ljudcodec"
+
+#: id:21447
+msgid "Audio language"
+msgstr "Ljudspråk"
+
+#: id:21448
+msgid "Subtitle language"
+msgstr "Undertextsspråk"
+
+#: id:21449
+msgid "Remote control sends keyboard presses"
+msgstr "Fjärrkontroll sänder tangentbordstryckningar"
+
+#: id:21450
+msgid "- Edit"
+msgstr "- Redigera"
+
+#: id:21451
+msgid "Internet connection required."
+msgstr "Internetuppkoppling krävs."
+
+#: id:21452
+msgid "Get More..."
+msgstr "Hämta fler..."
+
+#: id:21453
+msgid "Root filesystem"
+msgstr "Rotfilsystem"
+
+#: id:21454
+msgid "Cache full"
+msgstr ""
+
+#: id:21455
+msgid "Cache filled before reaching required amount for continous playback"
+msgstr ""
+
+#: id:21460
+msgid "Subtitle location"
+msgstr "Undertextsplacering"
+
+#: id:21461
+msgid "Fixed"
+msgstr "Fast"
+
+#: id:21462
+msgid "Bottom of video"
+msgstr "Botten av videon"
+
+#: id:21463
+msgid "Below video"
+msgstr "Under videon"
+
+#: id:21464
+msgid "Top of video"
+msgstr "Toppen av videon"
+
+#: id:21465
+msgid "Above video"
+msgstr "Över videon"
+
+#: id:21800
+msgid "File name"
+msgstr "Filnamn"
+
+#: id:21801
+msgid "File path"
+msgstr "Filsökväg"
+
+#: id:21802
+msgid "File size"
+msgstr "Filstorlek"
+
+#: id:21803
+msgid "File date/time"
+msgstr "Fildatum/tid"
+
+#: id:21804
+msgid "Slide index"
+msgstr "Bildspelsindex"
+
+#: id:21805
+msgctxt "Auto context with id 21805"
+msgid "Resolution"
+msgstr "Upplösning"
+
+#: id:21806
+msgctxt "Auto context with id 21806"
+msgid "Comment"
+msgstr "Kommentar"
+
+#: id:21807
+msgid "Colour/B&W"
+msgstr "Färg/SV"
+
+#: id:21808
+msgid "JPEG process"
+msgstr "JPEG-behandling"
+
+#: id:21820
+msgid "Date/Time"
+msgstr "Datum/tid"
+
+#: id:21821
+msgid "Description"
+msgstr "Beskrivning"
+
+#: id:21822
+msgid "Camera make"
+msgstr "Kameramärke"
+
+#: id:21823
+msgid "Camera model"
+msgstr "Kameramodell"
+
+#: id:21824
+msgid "EXIF comment"
+msgstr "Exif-kommentar"
+
+#: id:21825
+msgid "Firmware"
+msgstr "Hårdvaruprogram"
+
+#: id:21826
+msgid "Aperture"
+msgstr "Bländare"
+
+#: id:21827
+msgid "Focal length"
+msgstr "Brännvidd"
+
+#: id:21828
+msgid "Focus distance"
+msgstr "Fokuseringsavstånd"
+
+#: id:21829
+msgid "Exposure"
+msgstr "Exponering"
+
+#: id:21830
+msgid "Exposure time"
+msgstr "Exponeringstid"
+
+#: id:21831
+msgid "Exposure bias"
+msgstr "Exponeringsbias"
+
+#: id:21832
+msgid "Exposure mode"
+msgstr "Exponeringsläge"
+
+#: id:21833
+msgid "Flash used"
+msgstr "Blixt använd"
+
+#: id:21834
+msgid "White-balance"
+msgstr "Vitbalans"
+
+#: id:21835
+msgid "Light source"
+msgstr "Ljuskälla"
+
+#: id:21836
+msgid "Metering mode"
+msgstr "Mätningsläge"
+
+#: id:21837
+msgid "ISO"
+msgstr "ISO"
+
+#: id:21838
+msgid "Digital zoom"
+msgstr "Digital zoom"
+
+#: id:21839
+msgid "CCD width"
+msgstr "CCD-bredd"
+
+#: id:21840
+msgid "GPS latitude"
+msgstr "GPS-latitud"
+
+#: id:21841
+msgid "GPS longitude"
+msgstr "GPS-longitud"
+
+#: id:21842
+msgid "GPS altitude"
+msgstr "GPS-höjd"
+
+#: id:21843
+msgid "Orientation"
+msgstr "Riktning"
+
+#: id:21860
+msgid "Supplemental categories"
+msgstr "Tilläggskategorier"
+
+#: id:21861
+msgid "Keywords"
+msgstr "Nyckelord"
+
+#: id:21862
+msgid "Caption"
+msgstr "Överskrift"
+
+#: id:21863
+msgid "Author"
+msgstr "Skapare"
+
+#: id:21864
+msgid "Headline"
+msgstr "Rubrik"
+
+#: id:21865
+msgid "Special instructions"
+msgstr "Speciella instruktioner"
+
+#: id:21866
+msgid "Category"
+msgstr "Kategori"
+
+#: id:21867
+msgid "Byline"
+msgstr "Upphovsman"
+
+#: id:21868
+msgid "Byline title"
+msgstr "Titel på upphovman"
+
+#: id:21869
+msgid "Credit"
+msgstr "Förtjänst"
+
+#: id:21870
+msgid "Source"
+msgstr "Källa"
+
+#: id:21871
+msgid "Copyright notice"
+msgstr "Upphovsrättsnotering"
+
+#: id:21872
+msgid "Object name"
+msgstr "Objektsnamn"
+
+#: id:21873
+msgid "City"
+msgstr "Stad"
+
+#: id:21874
+msgid "State"
+msgstr "Delstat"
+
+#: id:21875
+msgctxt "Auto context with id 21875"
+msgid "Country"
+msgstr "Land"
+
+#: id:21876
+msgid "Original Tx Reference"
+msgstr "Originalreferens till TX"
+
+#: id:21877
+msgid "Date created"
+msgstr "Skapad datum"
+
+#: id:21878
+msgid "Copyright flag"
+msgstr "Upphovsrättsflagga"
+
+#: id:21879
+msgid "Country code"
+msgstr "Landskod"
+
+#: id:21880
+msgid "Reference service"
+msgstr "Referenstjänst"
+
+#: id:21881
+msgid "Allow control of XBMC via UPnP"
+msgstr "Tillåt kontroll av XBMC via UPnP"
+
+#: id:21882
+msgid "Attempt to skip introduction before DVD menu"
+msgstr "Försök hoppa över introduktion före DVD-menyn"
+
+#: id:21883
+msgid "Saved music"
+msgstr "Sparad musik"
+
+#: id:21884
+msgid "Query info for all artists"
+msgstr "Hämta info för alla artister"
+
+#: id:21885
+msgid "Downloading album information"
+msgstr "Hämtar albuminformation"
+
+#: id:21886
+msgid "Downloading artist information"
+msgstr "Hämtar artistinformation"
+
+#: id:21887
+msgid "Biography"
+msgstr "Biografi"
+
+#: id:21888
+msgid "Discography"
+msgstr "Diskografi"
+
+#: id:21889
+msgid "Searching artist"
+msgstr "Söker artist"
+
+#: id:21890
+msgid "Select artist"
+msgstr "Välj artist"
+
+#: id:21891
+msgctxt "Auto context with id 21891"
+msgid "Artist information"
+msgstr "Artistinformation"
+
+#: id:21892
+msgid "Instruments"
+msgstr "Instrument"
+
+#: id:21893
+msgid "Born"
+msgstr "Född"
+
+#: id:21894
+msgid "Formed"
+msgstr "Bildat"
+
+#: id:21895
+msgid "Themes"
+msgstr "Teman"
+
+#: id:21896
+msgid "Disbanded"
+msgstr "Upplöst"
+
+#: id:21897
+msgid "Died"
+msgstr "Död"
+
+#: id:21898
+msgid "Years active"
+msgstr "Aktiva år"
+
+#: id:21899
+msgid "Label"
+msgstr "Etikett"
+
+#: id:21900
+msgid "Born/Formed"
+msgstr "Född/bildat"
+
+#: id:22000
+msgid "Update library on startup"
+msgstr "Uppdatera biblioteket vid uppstart"
+
+#: id:22001
+msgid "Hide progress of library updates"
+msgstr "Dölj framsteg för biblioteksuppdateringar"
+
+#: id:22002
+msgid "- DNS suffix"
+msgstr "- DNS-suffix"
+
+#: id:22003
+msgid "%2.3fs"
+msgstr "%2.3fs"
+
+#: id:22004
+msgid "Delayed by: %2.3fs"
+msgstr "Fördröjd med: %2.3fs"
+
+#: id:22005
+msgid "Ahead by: %2.3fs"
+msgstr "Förväg med: %2.3fs"
+
+#: id:22006
+msgid "Subtitle offset"
+msgstr "Undertextkompensering"
+
+#: id:22007
+msgid "OpenGL vendor:"
+msgstr "OpenGL-tillverkare:"
+
+#: id:22008
+msgid "OpenGL renderer:"
+msgstr "OpenGL-renderare:"
+
+#: id:22009
+msgid "OpenGL version:"
+msgstr "OpenGL-version:"
+
+#: id:22010
+msgid "GPU temperature:"
+msgstr "GPU-temperatur:"
+
+#: id:22011
+msgid "CPU temperature:"
+msgstr "CPU-temperatur:"
+
+#: id:22012
+msgid "Total memory"
+msgstr "Totalt minne"
+
+#: id:22013
+msgid "Profile data"
+msgstr "Profildata"
+
+#: id:22014
+msgid "Use dim if paused during video playback"
+msgstr "Använd nedtoning om videouppspelningen är pausad"
+
+#: id:22015
+msgid "All recordings"
+msgstr "Alla inspelningar"
+
+#: id:22016
+msgid "By title"
+msgstr "Efter titel"
+
+#: id:22017
+msgid "By group"
+msgstr "Efter grupp"
+
+#: id:22018
+msgid "Live channels"
+msgstr "Aktuella kanaler"
+
+#: id:22019
+msgid "Recordings by title"
+msgstr "Inspelningar efter titel"
+
+#: id:22020
+msgid "Guide"
+msgstr "Guide"
+
+#: id:22021
+msgid "Allowed error in aspect ratio to minimize black bars"
+msgstr "Felmarginal i bildförhållande för att minska svarta ränder"
+
+#: id:22022
+msgid "Show video files in listings"
+msgstr "Visa videofiler i listningar"
+
+#: id:22023
+msgid "DirectX vendor:"
+msgstr "DirectX-tillverkare:"
+
+#: id:22024
+msgid "Direct3D version:"
+msgstr "Direct3D-version:"
+
+#: id:22030
+msgctxt "Auto context with id 22030"
+msgid "Font"
+msgstr "Typsnitt"
+
+#: id:22031
+msgctxt "Auto context with id 22031"
+msgid "- Size"
+msgstr "- Storlek"
+
+#: id:22032
+msgctxt "Auto context with id 22032"
+msgid "- Colours"
+msgstr "- Färger"
+
+#: id:22033
+msgid "- Charset"
+msgstr "- Teckenuppsättning"
+
+#: id:22034
+msgid "Export karaoke titles as HTML"
+msgstr "Exportera karaoketitlar som HTML"
+
+#: id:22035
+msgid "Export karaoke titles as CSV"
+msgstr "Exportera karaoketitlar som CSV"
+
+#: id:22036
+msgid "Import karaoke titles..."
+msgstr "Importera karaoketitlar..."
+
+#: id:22037
+msgid "Show song selector automatically"
+msgstr "Visa låtväljare automatiskt"
+
+#: id:22038
+msgid "Export karaoke titles..."
+msgstr "Exportera karaoketitlar..."
+
+#: id:22039
+msgid "Enter song number"
+msgstr "Ange låtnummer"
+
+#: id:22040
+msgid "white/green"
+msgstr "vit/grön"
+
+#: id:22041
+msgid "white/red"
+msgstr "vit/röd"
+
+#: id:22042
+msgid "white/blue"
+msgstr "vit/blå"
+
+#: id:22043
+msgid "black/white"
+msgstr "svart/vit"
+
+#: id:22079
+msgid "Default select action"
+msgstr "Standardaktion för val"
+
+#: id:22080
+msgid "Choose"
+msgstr "Välj"
+
+#: id:22081
+msgid "Show Information"
+msgstr "Visa information"
+
+#: id:22082
+msgid "More..."
+msgstr "Mer..."
+
+#: id:22083
+msgid "Play all"
+msgstr "Spela alla"
+
+#: id:23049
+msgid "Teletext not available"
+msgstr "Teletext inte tillgänglig"
+
+#: id:23050
+msgid "Activate Teletext"
+msgstr "Aktivera teletext"
+
+#: id:23051
+msgid "Part %i"
+msgstr "Del %i"
+
+#: id:23052
+msgid "Buffering %i bytes"
+msgstr "Buffrar %i bytes"
+
+#: id:23053
+msgid "Stopping"
+msgstr "Stoppar"
+
+#: id:23054
+msgid "Running"
+msgstr "Igång"
+
+#: id:23100
+msgid "External Player Active"
+msgstr "Extern spelare är aktiv"
+
+#: id:23101
+msgid "Click OK to terminate the player"
+msgstr "Klicka OK för att avsluta spelaren"
+
+#: id:23104
+msgid "Click OK when playback has ended"
+msgstr "Klicka OK när uppspelningen har slutat"
+
+#: id:24000
+msgid "Add-on"
+msgstr "Tillägg"
+
+#: id:24001
+msgid "Add-ons"
+msgstr "Tillägg"
+
+#: id:24002
+msgid "Add-on options"
+msgstr "Tilläggsval"
+
+#: id:24003
+msgid "Add-on Information"
+msgstr "Tilläggsinformation"
+
+#: id:24005
+msgctxt "Auto context with id 24005"
+msgid "Media sources"
+msgstr "Mediakällor"
+
+#: id:24007
+msgctxt "Auto context with id 24007"
+msgid "Movie information"
+msgstr "Filminformation"
+
+#: id:24008
+msgctxt "Auto context with id 24008"
+msgid "Screensaver"
+msgstr "Skärmsläckare"
+
+#: id:24009
+msgid "Script"
+msgstr "Skript"
+
+#: id:24010
+msgctxt "Auto context with id 24010"
+msgid "Visualization"
+msgstr "Visualisering"
+
+#: id:24011
+msgid "Add-on repository"
+msgstr "Tilläggsförråd"
+
+#: id:24012
+msgctxt "Auto context with id 24012"
+msgid "Subtitles"
+msgstr "Undertexter"
+
+#: id:24013
+msgid "Lyrics"
+msgstr "Sångtexter"
+
+#: id:24014
+msgid "TV information"
+msgstr "TV-information"
+
+#: id:24015
+msgctxt "Auto context with id 24015"
+msgid "Music video information"
+msgstr "Musikvideoinformation"
+
+#: id:24016
+msgctxt "Auto context with id 24016"
+msgid "Album information"
+msgstr "Albuminformation"
+
+#: id:24017
+msgctxt "Auto context with id 24017"
+msgid "Artist information"
+msgstr "Artistinformation"
+
+#: id:24018
+msgctxt "Auto context with id 24018"
+msgid "Services"
+msgstr "Tjänster"
+
+#: id:24020
+msgid "Configure"
+msgstr "Konfigurera"
+
+#: id:24021
+msgctxt "Auto context with id 24021"
+msgid "Disable"
+msgstr "Inaktivera"
+
+#: id:24022
+msgid "Enable"
+msgstr "Aktivera"
+
+#: id:24023
+msgid "Add-on disabled"
+msgstr "Tillägg inaktiverat"
+
+#: id:24027
+msgctxt "Auto context with id 24027"
+msgid "Weather"
+msgstr "Väder"
+
+#: id:24028
+msgid "Weather.com (standard)"
+msgstr "Weather.com (standard)"
+
+#: id:24030
+msgid "This Add-on can not be configured"
+msgstr "Detta tillägg kan ej konfigureras"
+
+#: id:24031
+msgid "Error loading settings"
+msgstr "Laddning av inställningar misslyckades"
+
+#: id:24032
+msgid "All Add-ons"
+msgstr "Alla tillägg"
+
+#: id:24033
+msgid "Get Add-ons"
+msgstr "Hämta tillägg"
+
+#: id:24034
+msgid "Check for updates"
+msgstr "Kontrollera uppdateringar"
+
+#: id:24035
+msgid "Force refresh"
+msgstr "Tvinga uppdatering"
+
+#: id:24036
+msgid "Change log"
+msgstr "Ändringslogg"
+
+#: id:24037
+msgid "Uninstall"
+msgstr "Avinstallera"
+
+#: id:24038
+msgid "Install"
+msgstr "Installera"
+
+#: id:24039
+msgid "Disabled Add-ons"
+msgstr "Inaktiverat tillägg"
+
+#: id:24040
+msgid "(Clear the current setting)"
+msgstr "(Rensa nuvarande inställning)"
+
+#: id:24041
+msgid "Install from zip file"
+msgstr "Installera från zipfil"
+
+#: id:24042
+msgid "Downloading %i%%"
+msgstr "Laddar ner %i%%"
+
+#: id:24043
+msgid "Available Updates"
+msgstr "Tillgängliga uppdateringar"
+
+#: id:24044
+msgid "Dependencies not met"
+msgstr "Beronden möts inte"
+
+#: id:24045
+msgid "Add-on does not have the correct structure"
+msgstr "Tillägget har inte korrekt stuktur"
+
+#: id:24046
+msgid "%s is used by the following installed add-on(s)"
+msgstr "%s används av följande installerade tillägg"
+
+#: id:24047
+msgid "This add-on cannot be uninstalled"
+msgstr "Detta tillägg kan inte avinstalleras"
+
+#: id:24048
+msgid "Rollback"
+msgstr "Återladdning"
+
+#: id:24050
+msgid "Available Add-ons"
+msgstr "Tillgängliga Ttillägg"
+
+#: id:24051
+msgid "Version:"
+msgstr "Version:"
+
+#: id:24052
+msgid "Disclaimer"
+msgstr "Ansvarsfriskrivning"
+
+#: id:24053
+msgid "License:"
+msgstr "Licens:"
+
+#: id:24054
+msgid "Changelog"
+msgstr "Ändringslogg"
+
+#: id:24059
+msgid "Would you like to enable this Add-on?"
+msgstr "Vill du aktivera detta tillägg?"
+
+#: id:24060
+msgid "Would you like to disable this Add-on?"
+msgstr "Vill du inaktivera detta tillägg?"
+
+#: id:24061
+msgid "Add-on update available!"
+msgstr "Tilläggsuppdatering tillgänglig!"
+
+#: id:24062
+msgid "Enabled Add-ons"
+msgstr "Aktivera tillägg"
+
+#: id:24063
+msgid "Auto update"
+msgstr "Autouppdatering"
+
+#: id:24064
+msgid "Add-on enabled"
+msgstr "Tillägg aktiverat"
+
+#: id:24065
+msgid "Add-on updated"
+msgstr "Tillägg uppdaterat"
+
+#: id:24066
+msgid "Cancel Add-on download?"
+msgstr "Avbryt tilläggsnedladdning?"
+
+#: id:24067
+msgid "Currently downloading Add-ons"
+msgstr "Laddar ner tillägg nu"
+
+#: id:24068
+msgid "Update available"
+msgstr "Uppdatering tillgänglig"
+
+#: id:24069
+msgid "Update"
+msgstr "Uppdatera"
+
+#: id:24070
+msgid "Add-on could not be loaded."
+msgstr "Tillägget kunde inte laddas."
+
+#: id:24071
+msgid "An unknown error has occurred."
+msgstr "Ett okänt fel har uppstått"
+
+#: id:24072
+msgid "Settings required"
+msgstr "Krav på inställningar"
+
+#: id:24073
+msgid "Could not connect"
+msgstr "Kan ej ansluta"
+
+#: id:24074
+msgid "Needs to restart"
+msgstr "Kräver omstart"
+
+#: id:24075
+msgctxt "Auto context with id 24075"
+msgid "Disable"
+msgstr "Inaktivera"
+
+#: id:24076
+msgid "Add-on Required"
+msgstr "Tillägg krävs"
+
+#: id:24080
+msgid "Try to reconnect?"
+msgstr "Prova återanslut?"
+
+#: id:24089
+msgid "Add-on restarts"
+msgstr "Tillägget startar om"
+
+#: id:24090
+msgid "Lock Add-on manager"
+msgstr "Lås tilläggshanteraren"
+
+#: id:24094
+msgid "(current)"
+msgstr "(nuvarande)"
+
+#: id:24095
+msgid "(blacklisted)"
+msgstr "(svartlistad)"
+
+#: id:24096
+msgid "Add-on has been marked as broken in repository."
+msgstr "Tillägget har markerats som trasigt i förrådet."
+
+#: id:24097
+msgid "Would you like to disable it on your system?"
+msgstr "Vill du inaktivera det på ditt system?"
+
+#: id:24098
+msgid "Broken"
+msgstr "Trasigt"
+
+#: id:24099
+msgid "Would you like to switch to this skin?"
+msgstr "Vill du byta till detta skal?"
+
+#: id:24100
+msgid "To use this feature you must download an Add-on:"
+msgstr "För att använda denna funktion måste du ladda ner ett tillägg:"
+
+#: id:24101
+msgid "Would you like to download this Add-on?"
+msgstr "Vill du ladda ner detta tillägg?"
+
+#: id:25000
+msgid "Notifications"
+msgstr "Notifieringar"
+
+#: id:29800
+msgid "Library Mode"
+msgstr "Biblioteksläge"
+
+#: id:29801
+msgid "QWERTY keyboard"
+msgstr "QWERTY-tangentbord"
+
+#: id:29802
+msgid "Passthrough Audio in use"
+msgstr "Ljudgenomströmning används"
+
+#: id:33001
+msgid "Trailer quality"
+msgstr "Trailerkvalitet"
+
+#: id:33002
+msgid "Stream"
+msgstr "Strömma"
+
+#: id:33003
+msgid "Download"
+msgstr "Ladda ned"
+
+#: id:33004
+msgid "Download & play"
+msgstr "ladda ned & spela"
+
+#: id:33005
+msgid "Download & save"
+msgstr "Ladda ned & spara"
+
+#: id:33006
+msgid "Today"
+msgstr "Idag"
+
+#: id:33007
+msgid "Tomorrow"
+msgstr "Imorgon"
+
+#: id:33008
+msgid "Saving"
+msgstr "Sparar"
+
+#: id:33009
+msgid "Copying"
+msgstr "Kopierar"
+
+#: id:33010
+msgid "Set download directory"
+msgstr "Ange nedladdningsmapp"
+
+#: id:33011
+msgid "Search duration"
+msgstr "Söklängd"
+
+#: id:33012
+msgid "Short"
+msgstr "Kort"
+
+#: id:33013
+msgid "Long"
+msgstr "Lång"
+
+#: id:33014
+msgid "Use DVD player instead of regular player"
+msgstr "Använd DVD-spelare istället för den vanliga spelaren"
+
+#: id:33015
+msgid "Ask for download before playing video"
+msgstr "Fråga om nedladdning innan uppspelning"
+
+#: id:33016
+msgid "Clips"
+msgstr "Klipp"
+
+#: id:33017
+msgid "Restart plugin to enable"
+msgstr "Starta om tillägg för att aktivera"
+
+#: id:33018
+msgid "Tonight"
+msgstr "I natt"
+
+#: id:33019
+msgid "Tomorrow Night"
+msgstr "Imorgon natt"
+
+#: id:33020
+msgid "Condition"
+msgstr "Förhållande"
+
+#: id:33021
+msgid "Precipitation"
+msgstr "Nederbörd"
+
+#: id:33022
+msgid "Precip"
+msgstr "Nederbörd"
+
+#: id:33023
+msgid "Humid"
+msgstr "Fuktig"
+
+#: id:33024
+msgid "Feels"
+msgstr "Känns"
+
+#: id:33025
+msgid "Observed"
+msgstr "Observerad"
+
+#: id:33026
+msgid "Departure from normal"
+msgstr "Avvikelse från normal"
+
+#: id:33027
+msgid "Sunrise"
+msgstr "Soluppgång"
+
+#: id:33028
+msgid "Sunset"
+msgstr "Solnedgång"
+
+#: id:33029
+msgid "Details"
+msgstr "Detaljer"
+
+#: id:33030
+msgid "Outlook"
+msgstr "Utsikt"
+
+#: id:33031
+msgid "Coverflow"
+msgstr "Omslagsflöde"
+
+#: id:33032
+msgid "Translate text"
+msgstr "Översätt text"
+
+#: id:33033
+msgid "Map list %s category"
+msgstr "Kartlista %s-kategori"
+
+#: id:33034
+msgid "36 Hour"
+msgstr "36 timmar"
+
+#: id:33035
+msgid "Maps"
+msgstr "Kartor"
+
+#: id:33036
+msgid "Hourly"
+msgstr "Per timme"
+
+#: id:33037
+msgid "Weekend"
+msgstr "Helg"
+
+#: id:33038
+msgid "%s day"
+msgstr "%s dag"
+
+#: id:33049
+msgid "Alert"
+msgstr "Varning"
+
+#: id:33050
+msgid "Alerts"
+msgstr "Varningar"
+
+#: id:33051
+msgid "Choose Your"
+msgstr "Välj dina"
+
+#: id:33052
+msgid "Check"
+msgstr "Kontrollera"
+
+#: id:33053
+msgctxt "Auto context with id 33053"
+msgid "Configure the"
+msgstr "Konfigurera"
+
+#: id:33054
+msgid "Seasons"
+msgstr "Säsonger"
+
+#: id:33055
+msgid "Use your"
+msgstr "Använd din"
+
+#: id:33056
+msgid "Watch your"
+msgstr "Se dina"
+
+#: id:33057
+msgid "Listen to"
+msgstr "Lyssna på"
+
+#: id:33058
+msgid "View your"
+msgstr "Visa dina"
+
+#: id:33059
+msgctxt "Auto context with id 33059"
+msgid "Configure the"
+msgstr "Konfigurera"
+
+#: id:33060
+msgid "Power"
+msgstr "Ström"
+
+#: id:33061
+msgid "Menu"
+msgstr "Meny"
+
+#: id:33062
+msgid "Play the"
+msgstr "Spela"
+
+#: id:33063
+msgid "Options"
+msgstr "Alternativ"
+
+#: id:33065
+msgid "Editor"
+msgstr "Redigerare"
+
+#: id:33066
+msgid "About your"
+msgstr "Om ditt"
+
+#: id:33067
+msgid "Star rating"
+msgstr "Stjärnbetyg"
+
+#: id:33068
+msgid "Background"
+msgstr "Bakgrund"
+
+#: id:33069
+msgid "Backgrounds"
+msgstr "Bakgrunder"
+
+#: id:33070
+msgid "Custom background"
+msgstr "Anpassad bakgrund"
+
+#: id:33071
+msgid "Custom backgrounds"
+msgstr "Anpassade bakgrunder"
+
+#: id:33072
+msgid "View Readme"
+msgstr "Visa Readme"
+
+#: id:33073
+msgid "View Changelog"
+msgstr "Visa ändringslogg"
+
+#: id:33074
+msgid "This version of %s requires an"
+msgstr "Denna version av %s kräver en"
+
+#: id:33075
+msgid "XBMC revision of %s or greater to run."
+msgstr "XBMC-version större än %s för att köras."
+
+#: id:33076
+msgid "Please update XBMC."
+msgstr "Var god uppdatera XBMC."
+
+#: id:33077
+msgid "No data found!"
+msgstr "Ingen data hittades!"
+
+#: id:33078
+msgid "Next page"
+msgstr "Nästa sida"
+
+#: id:33079
+msgid "Love"
+msgstr "Älska"
+
+#: id:33080
+msgid "Hate"
+msgstr "Hata"
+
+#: id:33081
+msgid "This file is stacked, select the part you want to play from."
+msgstr "Denna fil är sammanslagen, välj den del du vill spela."
+
+#: id:33082
+msgid "Path to script"
+msgstr "Sökväg till skript"
+
+#: id:33083
+msgid "Enable custom script button"
+msgstr "Aktivera egen skriptknapp"
+
+#: id:33100
+msgid "Failed to start"
+msgstr "Misslyckades att starta"
+
+#: id:33101
+msgid "Webserver"
+msgstr "Webbserver"
+
+#: id:33102
+msgid "Event Server"
+msgstr "Händelseserver"
+
+#: id:33103
+msgid "Remote communication server"
+msgstr "Fjärrkommunikationsserver"
+
+#: id:33200
+msgid "Detected New Connection"
+msgstr ""
+
+#: id:34000
+msgid "Lame"
+msgstr "Lame"
+
+#: id:34001
+msgid "Vorbis"
+msgstr "Vorbis"
+
+#: id:34002
+msgid "Wav"
+msgstr "Wav"
+
+#: id:34003
+msgid "DXVA2"
+msgstr "DXVA2"
+
+#: id:34004
+msgid "VAAPI"
+msgstr "VAAPI"
+
+#: id:34005
+msgid "Flac"
+msgstr "Flac"
+
+#: id:34100
+msgid "Speaker Configuration"
+msgstr "Högtalarkonfiguration"
+
+#: id:34101
+msgid "2.0"
+msgstr "2.0"
+
+#: id:34102
+msgid "2.1"
+msgstr "2.1"
+
+#: id:34103
+msgid "3.0"
+msgstr "3.0"
+
+#: id:34104
+msgid "3.1"
+msgstr "3.1"
+
+#: id:34105
+msgid "4.0"
+msgstr "4.0"
+
+#: id:34106
+msgid "4.1"
+msgstr "4.1"
+
+#: id:34107
+msgid "5.0"
+msgstr "5.0"
+
+#: id:34108
+msgid "5.1"
+msgstr "5.1"
+
+#: id:34109
+msgid "7.0"
+msgstr "7.0"
+
+#: id:34110
+msgid "7.1"
+msgstr "7.1"
+
+#: id:34201
+msgid "Can't find a next item to play"
+msgstr "Kan inte hitta nästa objekt att spela"
+
+#: id:34202
+msgid "Can't find a previous item to play"
+msgstr "Kan inte hitta föregående objekt att spela"
+
+#: id:34300
+msgid "Failed to start zeroconf"
+msgstr ""
+
+#: id:34301
+msgid "Is Apple's Bonjour Service installed? See log for more info."
+msgstr ""
+
+#: id:34400
+msgid "Video Rendering"
+msgstr ""
+
+#: id:34401
+msgid "Failed to init video filters/scalers, falling back to bilinear scaling"
+msgstr ""
+
+#: id:34402
+msgid "Failed to initialize audio device"
+msgstr ""
+
+#: id:34403
+msgid "Check your audiosettings"
+msgstr ""
+
+#: id:34404
+msgid "Use gestures for navigation:"
+msgstr ""
+
+#: id:34405
+msgid "1 finger swipe left,right,up,down for cursors"
+msgstr ""
+
+#: id:34406
+msgid "2 finger swipe left for backspace"
+msgstr ""
+
+#: id:34407
+msgid "1 finger single tap for enter"
+msgstr ""
+
+#: id:34408
+msgid "2 finger single tap for contextmenu"
+msgstr ""
+
+#: id:35000
+msgid "Peripherals"
+msgstr "Kringutrustning"
+
+#: id:35001
+msgid "Generic HID device"
+msgstr "Allmän HID-enhet"
+
+#: id:35002
+msgid "Generic network adapter"
+msgstr "Allmän nätverksadapter"
+
+#: id:35003
+msgid "Generic disk"
+msgstr "Allmän disk"
+
+#: id:35004
+msgid "There are no settings available\nfor this peripheral."
+msgstr "Det finns inga tillgängliga\ninställningar för denna kringutrustning"
+
+#: id:35005
+msgid "New device configured"
+msgstr "Ny enhet konfigurerad"
+
+#: id:35006
+msgid "Device removed"
+msgstr "Enhet borttagen"
+
+#: id:35007
+msgid "Keymap to use for this device"
+msgstr "Tangentmappning att använda för denna enhet"
+
+#: id:35008
+msgid "Keymap enabled"
+msgstr "Tangentmappning aktiverad"
+
+#: id:35009
+msgid "Do not use the custom keymap for this device"
+msgstr ""
+
+#: id:35500
+msgid "Location"
+msgstr "Plats"
+
+#: id:35501
+msgid "Class"
+msgstr "Klass"
+
+#: id:35502
+msgctxt "Auto context with id 35502"
+msgid "Name"
+msgstr "Namn"
+
+#: id:35503
+msgid "Vendor"
+msgstr "Tillverkare"
+
+#: id:35504
+msgid "Product ID"
+msgstr "Produktid"
+
+#: id:36000
+msgid "Pulse-Eight CEC adapter"
+msgstr "Pulse-Eight CEC-adapter"
+
+#: id:36001
+msgid "Pulse-Eight Nyxboard"
+msgstr "Pulse-Eight Nyxboard"
+
+#: id:36002
+msgid "Switch to keyboard side command"
+msgstr "Byt till tangentbordskommando"
+
+#: id:36003
+msgid "Switch to remote side command"
+msgstr "Byt till fjärrkontrollskomando"
+
+#: id:36004
+msgid "Press \"user\" button command"
+msgstr "Tryck \"user\"-knappskommando"
+
+#: id:36005
+msgid "Enable switch side commands"
+msgstr "Aktivera sidbytskommando"
+
+#: id:36006
+msgid "Could not open the adapter"
+msgstr "Kunde inte öppna adaptern"
+
+#: id:36007
+msgid "Devices to power on when starting XBMC"
+msgstr "Slå på TVn när XBMC startas"
+
+#: id:36008
+msgid "Devices to power off when stopping XBMC"
+msgstr "Slå av enheter när XBMC stängs av"
+
+#: id:36009
+msgid "Put devices in standby mode when activating screensaver"
+msgstr "Ställ enheter i standbyläge när skärmsläckaren aktiveras"
+
+#: id:36011
+msgid "Could not detect the CEC port. Set it up manually."
+msgstr "Kunde inte hitta CEC-porten. Ställ in den manuellt"
+
+#: id:36012
+msgid "Could not initialise the CEC adapter. Check your settings."
+msgstr "Kunde inte hitta CEC-adaptern"
+
+#: id:36013
+msgid "Unsupported libCEC interface version. %d is greater than the version XBMC supports (%d)"
+msgstr "Ostödd libcec-gränssnittsversion. %d är nyare än versionen XBMC stödjer (%d)"
+
+#: id:36014
+msgid "Put this PC in standby mode when the TV is switched off"
+msgstr "Ställ denna PC i standbyläge när TVn stängs av"
+
+#: id:36015
+msgid "HDMI port number"
+msgstr "HDMI-portnummer"
+
+#: id:36016
+msgctxt "Auto context with id 36016"
+msgid "Connected"
+msgstr "Ansluten"
+
+#: id:36017
+msgid "Adapter found, but libCEC is not available"
+msgstr "Adapter hittat, men libcec är inte tillgänglig"
+
+#: id:36018
+msgid "Use the TV's language setting"
+msgstr "Använd TV'ns språkinställning"
+
+#: id:36019
+msgid "Connected to HDMI device"
+msgstr ""
+
+#: id:36020
+msgid "Make XBMC the active source when starting"
+msgstr ""
+
+#: id:36021
+msgid "Physical address (overrules HDMI port)"
+msgstr ""
+
+#: id:36022
+msgid "COM port (leave empty unless needed)"
+msgstr ""
+
+#: id:36023
+msgid "Configuration updated"
+msgstr ""
+
+#: id:36024
+msgid "Failed to set the new configuration. Please check your settings."
+msgstr ""
+
+#: id:36025
+msgid "Send 'inactive source' command when stopping XBMC"
+msgstr ""
+

--- a/language/Thai/strings.po
+++ b/language/Thai/strings.po
@@ -1,0 +1,9093 @@
+# Converted from xbmc strings.xml with xbmc-xml2po (by Team-XBMC)
+msgid ""
+msgstr ""
+"Project-Id-Version: xbmc.core-FRODO_GIT3ed1604ad7\n"
+"Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
+"POT-Creation-Date: 2012-04-09 18:00+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE\n"
+"Language: th\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: id:0
+msgctxt "Auto context with id 0"
+msgid "Programs"
+msgstr "โปรแกรม"
+
+#: id:1
+msgctxt "Auto context with id 1"
+msgid "Pictures"
+msgstr "รูปภาพ"
+
+#: id:2
+msgctxt "Auto context with id 2"
+msgid "Music"
+msgstr "เพลง"
+
+#: id:3
+msgctxt "Auto context with id 3"
+msgid "Videos"
+msgstr "วิดีโอ"
+
+#: id:4
+msgid "TV-Guide"
+msgstr "TV-Guide"
+
+#: id:5
+msgctxt "Auto context with id 5"
+msgid "Settings"
+msgstr "ตั้งค่า"
+
+#: id:6
+msgid "XBMC SVN"
+msgstr "XBMC SVN"
+
+#: id:7
+msgctxt "Auto context with id 7"
+msgid "File manager"
+msgstr "จัดการแฟ้ม"
+
+#: id:8
+msgctxt "Auto context with id 8"
+msgid "Weather"
+msgstr "สภาพอากาศ"
+
+#: id:9
+msgid "xbmc media center"
+msgstr "xbmc media center"
+
+#: id:11
+msgid "Monday"
+msgstr "จันทร์"
+
+#: id:12
+msgid "Tuesday"
+msgstr "อังคาร"
+
+#: id:13
+msgid "Wednesday"
+msgstr "พุธ"
+
+#: id:14
+msgid "Thursday"
+msgstr "พฤหัสบดี"
+
+#: id:15
+msgid "Friday"
+msgstr "ศกร์"
+
+#: id:16
+msgid "Saturday"
+msgstr "เสาร์"
+
+#: id:17
+msgid "Sunday"
+msgstr "อาทิตย์"
+
+#: id:21
+msgid "January"
+msgstr "มกราคม"
+
+#: id:22
+msgid "February"
+msgstr "กุมภาพันธ์"
+
+#: id:23
+msgid "March"
+msgstr "มีนาคม"
+
+#: id:24
+msgid "April"
+msgstr "เมษายน"
+
+#: id:25
+msgctxt "Auto context with id 25"
+msgid "May"
+msgstr "พฤษภาคม"
+
+#: id:26
+msgid "June"
+msgstr "มิถุนายน"
+
+#: id:27
+msgid "July"
+msgstr "กรกฎาคม"
+
+#: id:28
+msgid "August"
+msgstr "สิงหาคม"
+
+#: id:29
+msgid "September"
+msgstr "กันยายน"
+
+#: id:30
+msgid "October"
+msgstr "ตุลาคม"
+
+#: id:31
+msgid "November"
+msgstr "พฤศจิกายน"
+
+#: id:32
+msgid "December"
+msgstr "ธันวาคม"
+
+#: id:41
+msgid "Mon"
+msgstr "จ"
+
+#: id:42
+msgid "Tue"
+msgstr "อ"
+
+#: id:43
+msgid "Wed"
+msgstr "พ"
+
+#: id:44
+msgid "Thu"
+msgstr "พฤ"
+
+#: id:45
+msgid "Fri"
+msgstr "ศ"
+
+#: id:46
+msgid "Sat"
+msgstr "ส"
+
+#: id:47
+msgctxt "Auto context with id 47"
+msgid "Sun"
+msgstr "อ"
+
+#: id:51
+msgid "Jan"
+msgstr ""
+
+#: id:52
+msgid "Feb"
+msgstr ""
+
+#: id:53
+msgid "Mar"
+msgstr ""
+
+#: id:54
+msgid "Apr"
+msgstr ""
+
+#: id:55
+msgctxt "Auto context with id 55"
+msgid "May"
+msgstr ""
+
+#: id:56
+msgid "Jun"
+msgstr ""
+
+#: id:57
+msgid "Jul"
+msgstr ""
+
+#: id:58
+msgid "Aug"
+msgstr ""
+
+#: id:59
+msgid "Sep"
+msgstr ""
+
+#: id:60
+msgid "Oct"
+msgstr ""
+
+#: id:61
+msgid "Nov"
+msgstr ""
+
+#: id:62
+msgid "Dec"
+msgstr ""
+
+#: id:71
+msgid "N"
+msgstr ""
+
+#: id:72
+msgid "NNE"
+msgstr ""
+
+#: id:73
+msgid "NE"
+msgstr ""
+
+#: id:74
+msgid "ENE"
+msgstr ""
+
+#: id:75
+msgid "E"
+msgstr ""
+
+#: id:76
+msgid "ESE"
+msgstr ""
+
+#: id:77
+msgid "SE"
+msgstr ""
+
+#: id:78
+msgid "SSE"
+msgstr ""
+
+#: id:79
+msgid "S"
+msgstr ""
+
+#: id:80
+msgid "SSW"
+msgstr ""
+
+#: id:81
+msgid "SW"
+msgstr ""
+
+#: id:82
+msgid "WSW"
+msgstr ""
+
+#: id:83
+msgid "W"
+msgstr ""
+
+#: id:84
+msgid "WNW"
+msgstr ""
+
+#: id:85
+msgid "NW"
+msgstr ""
+
+#: id:86
+msgid "NNW"
+msgstr ""
+
+#: id:87
+msgid "VAR"
+msgstr ""
+
+#: id:98
+msgid "View: Auto"
+msgstr "มุมมอง: อัตโนมัติ"
+
+#: id:99
+msgid "View: Auto big"
+msgstr "มุมมอง: อัตโนมัติ ขนาดใหญ่"
+
+#: id:100
+msgid "View: Icons"
+msgstr "มุมมอง: ไอคอน"
+
+#: id:101
+msgid "View: List"
+msgstr "มุมมอง: รายการ"
+
+#: id:102
+msgctxt "Auto context with id 102"
+msgid "Scan"
+msgstr "สำรวจข้อมูล"
+
+#: id:103
+msgctxt "Auto context with id 103"
+msgid "Sort by: Name"
+msgstr "เรียงลำดับ: ชื่อ"
+
+#: id:104
+msgid "Sort by: Date"
+msgstr "เรียงลำดับ: วันที่"
+
+#: id:105
+msgid "Sort by: Size"
+msgstr "เรียงลำดับ: ขนาด"
+
+#: id:106
+msgid "No"
+msgstr "ไม่"
+
+#: id:107
+msgid "Yes"
+msgstr "ใช่"
+
+#: id:108
+msgctxt "Auto context with id 108"
+msgid "Slideshow"
+msgstr "สไลด์โชว์"
+
+#: id:109
+msgid "Create thumbs"
+msgstr "สร้างรูปย่อ"
+
+#: id:110
+msgid "Create thumbnails"
+msgstr "สร้างรูปย่อ"
+
+#: id:111
+msgctxt "Auto context with id 111"
+msgid "Shortcuts"
+msgstr "ทางลัด"
+
+#: id:112
+msgid "Paused"
+msgstr "หยุดชั่วขณะ"
+
+#: id:113
+msgid "Update failed"
+msgstr ""
+
+#: id:114
+msgid "Installation failed"
+msgstr ""
+
+#: id:115
+msgid "Copy"
+msgstr "คัดลอก"
+
+#: id:116
+msgid "Move"
+msgstr "ย้าย"
+
+#: id:117
+msgid "Delete"
+msgstr "ลบ"
+
+#: id:118
+msgid "Rename"
+msgstr "เปลี่ยนชื่อ"
+
+#: id:119
+msgid "New folder"
+msgstr "สร้างโฟลเดอร์ใหม่"
+
+#: id:120
+msgid "Confirm file copy"
+msgstr "ยืนยันการคัดลอกแฟ้ม"
+
+#: id:121
+msgid "Confirm file move"
+msgstr "ยืนยันการย้ายแฟ้ม"
+
+#: id:122
+msgid "Confirm file delete?"
+msgstr "ต้องการลบแฟ้มหรือไม่?"
+
+#: id:123
+msgid "Copy these files?"
+msgstr "ต้องการคัดลอกแฟ้มหรือไม่?"
+
+#: id:124
+msgid "Move these files?"
+msgstr "ต้องการย้ายแฟ้มหรือไม่?"
+
+#: id:125
+msgid "Delete these files? - Deleting files cannot be undone!"
+msgstr "ลบแฟ้มหรือไม่? การลบแฟ้มไม่สามารถกู้คืนได้!"
+
+#: id:126
+msgid "Status"
+msgstr "สถานะ"
+
+#: id:127
+msgid "Objects"
+msgstr "วัตถุ"
+
+#: id:128
+msgctxt "Auto context with id 128"
+msgid "General"
+msgstr "ทั่วไป"
+
+#: id:129
+msgctxt "Auto context with id 129"
+msgid "Slideshow"
+msgstr "สไลด์โชว์"
+
+#: id:130
+msgctxt "Auto context with id 130"
+msgid "System info"
+msgstr "ข้อมูลระบบ"
+
+#: id:131
+msgid "Display"
+msgstr "การแสดงผล"
+
+#: id:132
+msgid "Albums"
+msgstr "อัลบั้ม"
+
+#: id:133
+msgid "Artists"
+msgstr "ศิลปิน"
+
+#: id:134
+msgid "Songs"
+msgstr "เพลง"
+
+#: id:135
+msgid "Genres"
+msgstr "ประเภท"
+
+#: id:136
+msgid "Playlists"
+msgstr "รายการเพลง"
+
+#: id:137
+msgid "Search"
+msgstr "ค้นหา"
+
+#: id:138
+msgid "System Information"
+msgstr "ข้อมูลระบบ"
+
+#: id:139
+msgid "Temperatures:"
+msgstr "อุณหภูมิ:"
+
+#: id:140
+msgid "CPU:"
+msgstr "ซีพียู:"
+
+#: id:141
+msgid "GPU:"
+msgstr "จีพียู:"
+
+#: id:142
+msgid "Time:"
+msgstr "เวลา:"
+
+#: id:143
+msgid "Current:"
+msgstr "ปัจจุบัน:"
+
+#: id:144
+msgid "Build:"
+msgstr "รุ่น"
+
+#: id:145
+msgid "Network:"
+msgstr "เครือข่าย:"
+
+#: id:146
+msgid "Type:"
+msgstr "ชนิด:"
+
+#: id:147
+msgid "Static"
+msgstr "ค่าคงที่"
+
+#: id:148
+msgid "DHCP"
+msgstr "DHCP"
+
+#: id:149
+msgid "MAC address"
+msgstr "หมายเลขฮาร์ดแวร์"
+
+#: id:150
+msgctxt "Auto context with id 150"
+msgid "IP address"
+msgstr "ที่อยู่ไอพี"
+
+#: id:151
+msgid "Link:"
+msgstr "การเชื่อมต่อ:"
+
+#: id:152
+msgid "Half duplex"
+msgstr "Half duplex"
+
+#: id:153
+msgid "Full duplex"
+msgstr "Full duplex"
+
+#: id:154
+msgctxt "Auto context with id 154"
+msgid "Storage"
+msgstr "หน่วยจัดเก็บข้อมูล"
+
+#: id:155
+msgid "Drive"
+msgstr "ไดร์ฟ"
+
+#: id:156
+msgctxt "Auto context with id 156"
+msgid "Free"
+msgstr "ว่าง"
+
+#: id:157
+msgctxt "Auto context with id 157"
+msgid "Video"
+msgstr "วิดีโอ"
+
+#: id:158
+msgid "Free memory"
+msgstr "หน่วยความจำที่ว่าง"
+
+#: id:159
+msgid "No link"
+msgstr "ไม่มีการเชื่อมต่อ"
+
+#: id:160
+msgctxt "Auto context with id 160"
+msgid "Free"
+msgstr "ว่าง"
+
+#: id:161
+msgid "Unavailable"
+msgstr "ไม่สามารถใช้ได้"
+
+#: id:162
+msgid "Tray open"
+msgstr "ถาดเปิดอยู่"
+
+#: id:163
+msgid "Reading"
+msgstr "กำลังอ่าน"
+
+#: id:164
+msgid "No disc"
+msgstr "ไม่มีแผ่น"
+
+#: id:165
+msgid "Disc present"
+msgstr "แผ่นปัจจุบัน"
+
+#: id:166
+msgid "Skin"
+msgstr "หน้าตา"
+
+#: id:169
+msgctxt "Auto context with id 169"
+msgid "Resolution"
+msgstr "ความละเอียดจอ"
+
+#: id:170
+msgid "Adjust display refresh rate to match video"
+msgstr "ทำให้ refresh rate ตรงกับวิดีโอ"
+
+#: id:172
+msgid "Release date"
+msgstr "วันที่ออก"
+
+#: id:173
+msgid "Display 4:3 videos as"
+msgstr ""
+
+#: id:175
+msgid "Moods"
+msgstr "Moods"
+
+#: id:176
+msgid "Styles"
+msgstr "รูปแบบ"
+
+#: id:179
+msgid "Song"
+msgstr "เพลง"
+
+#: id:180
+msgid "Duration"
+msgstr "ระยะเวลา"
+
+#: id:181
+msgid "Select album"
+msgstr "เลือกอัลบั้ม"
+
+#: id:182
+msgid "Tracks"
+msgstr "ลำดับ"
+
+#: id:183
+msgid "Review"
+msgstr "Review"
+
+#: id:184
+msgid "Refresh"
+msgstr "เรียกใหม่"
+
+#: id:185
+msgid "Searching album"
+msgstr "ค้นหาอัลบั้ม"
+
+#: id:186
+msgid "OK"
+msgstr "ตกลง"
+
+#: id:187
+msgid "No albums found!"
+msgstr "ไม่พบอัลบั้มที่ค้นหา!"
+
+#: id:188
+msgid "Select all"
+msgstr "เลือกทั้งหมด"
+
+#: id:189
+msgid "Scanning media info"
+msgstr "ค้นหารายละเอียด"
+
+#: id:190
+msgid "Save"
+msgstr "บันทึก"
+
+#: id:191
+msgid "Shuffle"
+msgstr "สุ่มลำดับ"
+
+#: id:192
+msgctxt "Auto context with id 192"
+msgid "Clear"
+msgstr "ล้าง"
+
+#: id:193
+msgctxt "Auto context with id 193"
+msgid "Scan"
+msgstr "สำรวจข้อมูล"
+
+#: id:194
+msgid "Searching..."
+msgstr "ค้นหา..."
+
+#: id:195
+msgid "No info found!"
+msgstr "ไม่พบรายละเอียด!"
+
+#: id:196
+msgid "Select movie:"
+msgstr "เลือกภาพยนต์:"
+
+#: id:197
+msgid "Querying %s info"
+msgstr "Querying %s info"
+
+#: id:198
+msgid "Loading movie details"
+msgstr "กำลังโหลดรายละเอียดภาพยนต์"
+
+#: id:199
+msgid "Web interface"
+msgstr ""
+
+#: id:202
+msgid "Tagline"
+msgstr "Tagline"
+
+#: id:203
+msgid "Plot outline"
+msgstr "Plot outline"
+
+#: id:205
+msgid "Votes"
+msgstr "โหวต"
+
+#: id:206
+msgid "Cast"
+msgstr "Cast"
+
+#: id:207
+msgid "Plot"
+msgstr "Plot"
+
+#: id:208
+msgctxt "Auto context with id 208"
+msgid "Play"
+msgstr "เล่น"
+
+#: id:209
+msgid "Next"
+msgstr "ต่อไป"
+
+#: id:210
+msgid "Previous"
+msgstr "ก่อนหน้า"
+
+#: id:213
+msgid "Calibrate user interface..."
+msgstr "Calibrate user interface..."
+
+#: id:214
+msgid "Video calibration..."
+msgstr "วิดีโอ calibration..."
+
+#: id:215
+msgid "Soften"
+msgstr "Soften"
+
+#: id:216
+msgid "Zoom amount"
+msgstr "ซูมจำนวน"
+
+#: id:217
+msgid "Pixel ratio"
+msgstr "อัตราส่วนพิกเซล"
+
+#: id:218
+msgid "DVD drive"
+msgstr "ดีวีดีไดร์ฟ"
+
+#: id:219
+msgid "Please insert disc"
+msgstr "กรุณาใส่แผ่น"
+
+#: id:220
+msgid "Remote share"
+msgstr "Remote share"
+
+#: id:221
+msgid "Network is not connected"
+msgstr "ยังไม่ได้เชื่อมต่อเครือข่าย"
+
+#: id:222
+msgid "Cancel"
+msgstr "ยกเลิก"
+
+#: id:224
+msgid "Speed"
+msgstr "ความเร็ว"
+
+#: id:225
+msgid "Vertical Shift"
+msgstr ""
+
+#: id:226
+msgid "Test patterns..."
+msgstr "ทดสอบ patterns..."
+
+#: id:227
+msgid "Lookup audio CD track names from freedb.org"
+msgstr "ค้นหาชื่อเพลงของแผ่นเสียงจากfreedb.org"
+
+#: id:228
+msgid "Shuffle playlist on load"
+msgstr "สุ่มลำดับในรายการที่จะเล่นเมื่อเริ่มต้น"
+
+#: id:229
+msgid "HDD spindown time"
+msgstr "เวลาลดการทำงานของฮาร์ตดิสก์"
+
+#: id:230
+msgid "Video filters"
+msgstr "ตัวกรองวิดีโอ"
+
+#: id:231
+msgctxt "Auto context with id 231"
+msgid "None"
+msgstr "ไม่มี"
+
+#: id:232
+msgid "Point"
+msgstr "จุด"
+
+#: id:233
+msgid "Linear"
+msgstr "ลายเส้น"
+
+#: id:234
+msgid "Anisotropic"
+msgstr "Anisotropic"
+
+#: id:235
+msgid "Quincunx"
+msgstr "Quincunx"
+
+#: id:236
+msgid "Gaussian cubic"
+msgstr "Gaussian cubic"
+
+#: id:237
+msgid "Minification"
+msgstr "Minification"
+
+#: id:238
+msgid "Magnification"
+msgstr "Magnification"
+
+#: id:239
+msgid "Clear playlist on finish"
+msgstr "ล้างรายการที่จะเล่นเมื่อเสร็จ"
+
+#: id:240
+msgid "Display Mode"
+msgstr ""
+
+#: id:241
+msgid "Full Screen #%d"
+msgstr ""
+
+#: id:242
+msgid "Windowed"
+msgstr ""
+
+#: id:243
+msgid "Refresh Rate"
+msgstr ""
+
+#: id:244
+msgid "Full screen"
+msgstr ""
+
+#: id:245
+msgid "Sizing: (%i,%i)->(%i,%i) (Zoom x%2.2f) AR:%2.2f:1 (Pixels: %2.2f:1) (VShift: %2.2f)"
+msgstr ""
+
+#: id:247
+msgctxt "Auto context with id 247"
+msgid "Scripts"
+msgstr "สคริปต์"
+
+#: id:248
+msgctxt "Auto context with id 248"
+msgid "Language"
+msgstr "ภาษา"
+
+#: id:249
+msgctxt "Auto context with id 249"
+msgid "Music"
+msgstr "เพลง"
+
+#: id:250
+msgctxt "Auto context with id 250"
+msgid "Visualization"
+msgstr "Visualization"
+
+#: id:251
+msgid "Select destination directory"
+msgstr "เลือกเป้าหมาย"
+
+#: id:252
+msgid "Output stereo to all speakers"
+msgstr "ส่งออกไปยังลำโพงทั้งหมด"
+
+#: id:253
+msgid "Number of channels"
+msgstr "จำนวนของช่อง"
+
+#: id:254
+msgid "- DTS capable receiver"
+msgstr "- DTS Capable Receiver"
+
+#: id:255
+msgid "CDDB"
+msgstr "CDDB"
+
+#: id:256
+msgid "Fetching CD information"
+msgstr "Fetching CD information"
+
+#: id:257
+msgid "Error"
+msgstr "ผิดพลาด"
+
+#: id:258
+msgid "Enable tag reading"
+msgstr "เปิดใช้งานการอ่านแท็ก"
+
+#: id:259
+msgid "Opening"
+msgstr "กำลังเปิด"
+
+#: id:260
+msgid "Shoutcast"
+msgstr "Shoutcast"
+
+#: id:261
+msgid "Waiting for start..."
+msgstr "กำลังรอเปิด..."
+
+#: id:262
+msgid "Scripts output"
+msgstr "ผลลัพธ์ของสคริปต์"
+
+#: id:263
+msgid "Allow control of XBMC via HTTP"
+msgstr "อนุญาตให้ควบคุม XBMC ผ่าน HTTP"
+
+#: id:264
+msgid "Record"
+msgstr "บันทึก"
+
+#: id:265
+msgid "Stop Rec."
+msgstr "หยุดบันทึก."
+
+#: id:266
+msgid "Sort by: Track"
+msgstr "เรียงลำดับ: ลำดับเพลง"
+
+#: id:267
+msgid "Sort by: Time"
+msgstr "เรียงลำดับ: เวลา"
+
+#: id:268
+msgid "Sort by: Title"
+msgstr "เรียงลำดับ: ชื่อ"
+
+#: id:269
+msgid "Sort by: Artist"
+msgstr "เรียงลำดับ: ศิลปิน"
+
+#: id:270
+msgid "Sort by: Album"
+msgstr "เรียงลำดับ: อัลบั้ม"
+
+#: id:271
+msgid "Top 100"
+msgstr "Top 100"
+
+#: id:272
+msgid "Top-Left overscan compensation"
+msgstr "Top-Left overscan compensation"
+
+#: id:273
+msgid "Bottom-Right overscan compensation"
+msgstr "Bottom-Right overscan compensation"
+
+#: id:274
+msgid "Subtitle positioning"
+msgstr "ตำแหน่งของ ซับไตเติ้ล"
+
+#: id:275
+msgid "Pixel ratio adjustment"
+msgstr "ปรับอัตราส่วนพิกเซล"
+
+#: id:276
+msgid "Adjust the arrow to change the amount of overscan"
+msgstr "Adjust the arrow to change the amount of overscan"
+
+#: id:277
+msgid "Adjust the bar to change the subtitles position"
+msgstr "Adjust the bar to change the ซับไตเติ้ล position"
+
+#: id:278
+msgid "Adjust the rectangle so it is perfectly square"
+msgstr "Adjust the rectangle so it is perfectly square"
+
+#: id:279
+msgid "Unable to load settings"
+msgstr "ไม่สามารถโหลดการตั้งค่าได้"
+
+#: id:280
+msgid "Using default settings"
+msgstr "ใช้การตั้งค่ามาตรฐาน"
+
+#: id:281
+msgid "Please check the XML files"
+msgstr "กรุณาตรวจสอบแฟ้ม XML"
+
+#: id:282
+msgid "Found %i items"
+msgstr "ตรวจพบ %i"
+
+#: id:283
+msgid "Search results"
+msgstr "ผลการค้นหา"
+
+#: id:284
+msgid "No results found"
+msgstr "ไม่พบผลลัพธ์"
+
+#: id:287
+msgctxt "Auto context with id 287"
+msgid "Subtitles"
+msgstr "ซับไตเติ้ล"
+
+#: id:288
+msgctxt "Auto context with id 288"
+msgid "Font"
+msgstr "ตัวอักษร"
+
+#: id:289
+msgctxt "Auto context with id 289"
+msgid "- Size"
+msgstr "- ขนาด"
+
+#: id:290
+msgid "Dynamic range compression"
+msgstr "Dynamic range compression"
+
+#: id:291
+msgctxt "Auto context with id 291"
+msgid "Video"
+msgstr "วิดีโอ"
+
+#: id:292
+msgctxt "Auto context with id 292"
+msgid "Audio"
+msgstr "เพลง"
+
+#: id:293
+msgid "Browse for subtitles"
+msgstr "ค้นหาซับไตเติ้ล"
+
+#: id:294
+msgid "Create bookmark"
+msgstr "สร้างบุ๊คมาร์ค"
+
+#: id:296
+msgid "Clear bookmarks"
+msgstr "ล้างบุคมาร์ค"
+
+#: id:297
+msgid "Audio offset"
+msgstr "เสียง offset"
+
+#: id:298
+msgid "Bookmarks"
+msgstr "บุ๊คมาร์ค"
+
+#: id:299
+msgid "- AAC capable receiver"
+msgstr ""
+
+#: id:300
+msgid "- MP1 capable receiver"
+msgstr ""
+
+#: id:301
+msgid "- MP2 capable receiver"
+msgstr ""
+
+#: id:302
+msgid "- MP3 capable receiver"
+msgstr ""
+
+#: id:303
+msgid "Delay"
+msgstr "ดีเลย์"
+
+#: id:304
+msgctxt "Auto context with id 304"
+msgid "Language"
+msgstr "ภาษา"
+
+#: id:305
+msgctxt "Auto context with id 305"
+msgid "Enabled"
+msgstr "เปิดใช้แล้ว"
+
+#: id:306
+msgid "Non-interleaved"
+msgstr "Non-interleaved"
+
+#: id:312
+msgid "(0=auto)"
+msgstr "(0=อัตโนมัติ)"
+
+#: id:313
+msgid "Cleaning database"
+msgstr "ล้างฐานข้อมูล"
+
+#: id:314
+msgid "Preparing..."
+msgstr "กำลังจัดเตรียม..."
+
+#: id:315
+msgid "Database error"
+msgstr "ฐานข้อมูลผิดพลาด"
+
+#: id:316
+msgid "Searching songs..."
+msgstr "กำลังค้นหาเพลง..."
+
+#: id:317
+msgid "Cleaned database successfully"
+msgstr "ล้างฐานข้อมูลเรียบร้อยแล้ว"
+
+#: id:318
+msgid "Cleaning songs..."
+msgstr "กำลังล้างข้อมูลเพลง..."
+
+#: id:319
+msgid "Error cleaning songs"
+msgstr "ล้างข้อมูลเพลงผิดพลาด"
+
+#: id:320
+msgid "Cleaning artists..."
+msgstr "ล้างข้อมูลศิลปิน..."
+
+#: id:321
+msgid "Error cleaning artists"
+msgstr "ล้างข้อมูลศิลปินผิดพลาด"
+
+#: id:322
+msgid "Cleaning genres..."
+msgstr "ล้างข้อมูลประเภท"
+
+#: id:323
+msgid "Error cleaning genres"
+msgstr "ล้างข้อมูลประเภทผิดพลาด"
+
+#: id:324
+msgid "Cleaning paths..."
+msgstr "ล้างข้อมูลที่อยู่แฟ้ม"
+
+#: id:325
+msgid "Error cleaning paths"
+msgstr "ล้างข้อมูลที่อยู่แฟ้มผิดพลาด"
+
+#: id:326
+msgid "Cleaning albums..."
+msgstr "ล้างข้อมูลอัลบั้ม"
+
+#: id:327
+msgid "Error cleaning albums"
+msgstr "ล้างข้อมูลอัลบั้มผิดพลาด"
+
+#: id:328
+msgid "Writing changes..."
+msgstr "กำลังเขียนข้อมูลการเปลี่ยนแปลง..."
+
+#: id:329
+msgid "Error writing changes"
+msgstr "การเขียนข้อมูลผิดพลาด"
+
+#: id:330
+msgid "This may take some time..."
+msgstr "การกระทำนี้จะใช้เวลาซักครู่..."
+
+#: id:331
+msgid "Compressing database..."
+msgstr "กำลังบีบอัดฐานข้อมูล..."
+
+#: id:332
+msgid "Error compressing database"
+msgstr "บีบอัดฐานข้อมูลผิดพลาด"
+
+#: id:333
+msgid "Do you want to clean the library?"
+msgstr "ต้องการจะล้างคลังข้อมูลหรือไม่?"
+
+#: id:334
+msgid "Clean library..."
+msgstr "ล้างคลังข้อมูล..."
+
+#: id:335
+msgid "Start"
+msgstr "เริ่ม"
+
+#: id:336
+msgid "Framerate conversion"
+msgstr "แปลง Framerate"
+
+#: id:337
+msgctxt "Auto context with id 337"
+msgid "Audio output"
+msgstr "ส่งออกเสียง"
+
+#: id:338
+msgid "Analog"
+msgstr "อนาล๊อก"
+
+#: id:339
+msgid "Optical/Coax"
+msgstr "ดิจิทัล"
+
+#: id:340
+msgid "Various artists"
+msgstr "ศิลปิน"
+
+#: id:341
+msgid "Play disc"
+msgstr "เล่นแผ่น"
+
+#: id:342
+msgctxt "Auto context with id 342"
+msgid "Movies"
+msgstr "ภาพยนต์"
+
+#: id:343
+msgid "Adjust framerate"
+msgstr "ปรับค่า framerate"
+
+#: id:344
+msgid "Actors"
+msgstr "นักแสดง"
+
+#: id:345
+msgctxt "Auto context with id 345"
+msgid "Year"
+msgstr "ปี"
+
+#: id:346
+msgid "Boost volume level on downmix"
+msgstr ""
+
+#: id:350
+msgctxt "Auto context with id 350"
+msgid "Programs"
+msgstr "โปรแกรม"
+
+#: id:351
+msgctxt "Auto context with id 351"
+msgid "Off"
+msgstr "ปิด"
+
+#: id:352
+msgid "Dim"
+msgstr "Dim"
+
+#: id:353
+msgid "Black"
+msgstr "ดำ"
+
+#: id:354
+msgid "Matrix trails"
+msgstr "Matrix trails"
+
+#: id:355
+msgid "Screensaver time"
+msgstr "เวลาพักหน้าจอ"
+
+#: id:356
+msgid "Screensaver mode"
+msgstr "โหมดการพักหน้าจอ"
+
+#: id:357
+msgid "Shutdown function timer"
+msgstr "เวลาปิดเครื่องอัตโนมัติ"
+
+#: id:358
+msgid "All albums"
+msgstr "ทุกอัลบั้ม"
+
+#: id:359
+msgid "Recently added albums"
+msgstr "อัลบั้มที่เพิ่งเพิ่ม"
+
+#: id:360
+msgctxt "Auto context with id 360"
+msgid "Screensaver"
+msgstr "พักหน้าจอ"
+
+#: id:361
+msgid "R. Slideshow"
+msgstr "R. Slideshow"
+
+#: id:362
+msgid "Screensaver dim level"
+msgstr "Screensaver dim level"
+
+#: id:363
+msgid "Sort by: File"
+msgstr "เรียงลำดับ: แฟ้ม"
+
+#: id:364
+msgid "- Dolby Digital (AC3) capable receiver"
+msgstr "- Dolby Digital (AC3) capable receiver"
+
+#: id:365
+msgctxt "Auto context with id 365"
+msgid "Sort by: Name"
+msgstr "เรียงลำดับ: ชื่อ"
+
+#: id:366
+msgid "Sort by: Year"
+msgstr "เรียงลำดับ: ปี"
+
+#: id:367
+msgid "Sort by: Rating"
+msgstr "เรียงลำดับ: เรตติ้ง"
+
+#: id:368
+msgid "IMDb"
+msgstr "IMDb"
+
+#: id:369
+msgctxt "Auto context with id 369"
+msgid "Title"
+msgstr "ชื่อเรื่อง"
+
+#: id:370
+msgid "Thunderstorms"
+msgstr "พายุฝนฟ้าคะนอง"
+
+#: id:371
+msgid "Partly"
+msgstr "บางส่วน"
+
+#: id:372
+msgid "Mostly"
+msgstr "ทั่วไป"
+
+#: id:373
+msgid "Sunny"
+msgstr "แดด"
+
+#: id:374
+msgid "Cloudy"
+msgstr "เมฆมาก"
+
+#: id:375
+msgid "Snow"
+msgstr "หิมะตก"
+
+#: id:376
+msgid "Rain"
+msgstr "ฝน"
+
+#: id:377
+msgid "Light"
+msgstr "สว่าง"
+
+#: id:378
+msgid "AM"
+msgstr "AM"
+
+#: id:379
+msgid "PM"
+msgstr "PM"
+
+#: id:380
+msgid "Showers"
+msgstr "ฝน"
+
+#: id:381
+msgid "Few"
+msgstr "เล็กน้อย"
+
+#: id:382
+msgid "Scattered"
+msgstr "Scattered"
+
+#: id:383
+msgctxt "Auto context with id 383"
+msgid "Wind"
+msgstr "ลม"
+
+#: id:384
+msgid "Strong"
+msgstr "แรง"
+
+#: id:385
+msgid "Fair"
+msgstr "ปกติ"
+
+#: id:386
+msgctxt "Auto context with id 386"
+msgid "Clear"
+msgstr "ไม่มี"
+
+#: id:387
+msgid "Clouds"
+msgstr "หนาว"
+
+#: id:388
+msgid "Early"
+msgstr "เช้า"
+
+#: id:389
+msgid "Shower"
+msgstr "ฝน"
+
+#: id:390
+msgid "Flurries"
+msgstr "Flurries"
+
+#: id:391
+msgctxt "Auto context with id 391"
+msgid "Low"
+msgstr "ต่ำ"
+
+#: id:392
+msgctxt "Auto context with id 392"
+msgid "Medium"
+msgstr "ปานกลาง"
+
+#: id:393
+msgctxt "Auto context with id 393"
+msgid "High"
+msgstr "สูง"
+
+#: id:394
+msgid "Fog"
+msgstr "หมอก"
+
+#: id:395
+msgid "Haze"
+msgstr "Haze"
+
+#: id:396
+msgid "Select location"
+msgstr "เลือกสถานที่"
+
+#: id:397
+msgid "Refresh time"
+msgstr "เวลาเรียกใหม่"
+
+#: id:398
+msgid "Temperature units"
+msgstr "หน่วยอุณหภูมิ"
+
+#: id:399
+msgid "Speed units"
+msgstr "หน่วยความเร็ว"
+
+#: id:400
+msgctxt "Auto context with id 400"
+msgid "Weather"
+msgstr "สภาพอากาศ"
+
+#: id:401
+msgid "Temp"
+msgstr "อุณหภูมิ"
+
+#: id:402
+msgid "Feels like"
+msgstr "รู้สึกคล้าย"
+
+#: id:403
+msgid "UV index"
+msgstr "ดัชนี UV"
+
+#: id:404
+msgctxt "Auto context with id 404"
+msgid "Wind"
+msgstr "ลม"
+
+#: id:405
+msgid "Dew point"
+msgstr "Dew point"
+
+#: id:406
+msgid "Humidity"
+msgstr "Humidity"
+
+#: id:409
+msgid "Defaults"
+msgstr "ค่าเดิม"
+
+#: id:410
+msgid "Accessing weather service"
+msgstr "เข้าถึงบริการสภาพอากาศ"
+
+#: id:411
+msgid "Getting weather for:"
+msgstr "เรียกดูสภาพอากาศ :"
+
+#: id:412
+msgid "Unable to get weather data"
+msgstr "ไม่สามารถดึงข้อมูลสภาพอากาศ"
+
+#: id:413
+msgid "Manual"
+msgstr "ด้วยตนเอง"
+
+#: id:414
+msgid "No review for this album"
+msgstr "ไม่มีข้อคิดเห็นสำหรับอัลบั้มนี้"
+
+#: id:415
+msgid "Downloading thumbnail..."
+msgstr "กำลังโหลดรูปย่อ..."
+
+#: id:416
+msgid "Not available"
+msgstr "ไม่สามารถใช้ได้"
+
+#: id:417
+msgid "View: Big icons"
+msgstr "มุมมอง : ไอคอนขนาดใหญ่"
+
+#: id:418
+msgctxt "Auto context with id 418"
+msgid "Low"
+msgstr ""
+
+#: id:419
+msgctxt "Auto context with id 419"
+msgid "High"
+msgstr ""
+
+#: id:420
+msgid "HDMI"
+msgstr ""
+
+#: id:422
+msgid "Delete album info"
+msgstr "ลบข้อมูลอัลบั้ม"
+
+#: id:423
+msgid "Delete CD information"
+msgstr "ลบข้อมูลซีดี"
+
+#: id:424
+msgid "Select"
+msgstr "เลือก"
+
+#: id:425
+msgid "No album information found"
+msgstr "ไม่พบข้อมูลอัลบั้ม"
+
+#: id:426
+msgid "No CD information found"
+msgstr "ไม่พบข้อมูลซีดี"
+
+#: id:427
+msgid "Disc"
+msgstr "แผ่น"
+
+#: id:428
+msgid "Insert correct CD/DVD"
+msgstr "ใส่ซีดี / ดีวีดี"
+
+#: id:429
+msgid "Please insert the following disc:"
+msgstr "ใส่ซีดี/ดีวีดีต่อไปนี้"
+
+#: id:430
+msgid "Sort by: DVD#"
+msgstr "เรียงลำดับ: ดีวีดี#"
+
+#: id:431
+msgid "No cache"
+msgstr "ไม่มีแคช"
+
+#: id:432
+msgid "Remove movie from library"
+msgstr "ลบภาพยนต์ จาก คลังข้อมูล"
+
+#: id:433
+msgid "Really remove '%s'?"
+msgstr "ต้องการลบ '%s' จริงหรือ?"
+
+#: id:434
+msgid "From %s at %i %s"
+msgstr ""
+
+#: id:437
+msgid "Removable disk"
+msgstr "สื่อภายนอก"
+
+#: id:438
+msgid "Opening file"
+msgstr "กำลังเปิดแฟ้ม"
+
+#: id:439
+msgid "Cache"
+msgstr "แคช"
+
+#: id:440
+msgid "Harddisk"
+msgstr "ฮาร์ดดิสก์"
+
+#: id:441
+msgid "UDF"
+msgstr "UDF"
+
+#: id:442
+msgid "Local network"
+msgstr "เครือข่ายท้องถิ่น"
+
+#: id:443
+msgid "Internet"
+msgstr "อินเตอร์เน็ต"
+
+#: id:444
+msgctxt "Auto context with id 444"
+msgid "Video"
+msgstr "วิดีโอ"
+
+#: id:445
+msgctxt "Auto context with id 445"
+msgid "Audio"
+msgstr "เสียง"
+
+#: id:446
+msgctxt "Auto context with id 446"
+msgid "DVD"
+msgstr "ดีวีดี"
+
+#: id:447
+msgid "Autorun media"
+msgstr "สื่อที่ทำงานอัตโนมัติ"
+
+#: id:448
+msgid "LCD"
+msgstr "LCD"
+
+#: id:449
+msgctxt "Auto context with id 449"
+msgid "Enabled"
+msgstr "ใช้งาน"
+
+#: id:450
+msgid "Columns"
+msgstr "สดมภ์"
+
+#: id:451
+msgid "Row 1 address"
+msgstr "ที่อยู่แถวหนึ่ง"
+
+#: id:452
+msgid "Row 2 address"
+msgstr "ที่อยู่แถวสอง"
+
+#: id:453
+msgid "Row 3 address"
+msgstr "ที่อยู่แถวสาม"
+
+#: id:454
+msgid "Row 4 address"
+msgstr "ที่อยู่แถวสี่"
+
+#: id:455
+msgid "Rows"
+msgstr "แถว"
+
+#: id:456
+msgid "Mode"
+msgstr "โหมด"
+
+#: id:457
+msgid "Switch view"
+msgstr "เปลี่ยนมุมมอง"
+
+#: id:459
+msgid "Subs"
+msgstr "ย่อย"
+
+#: id:460
+msgid "Audio stream"
+msgstr "เสียง stream"
+
+#: id:461
+msgid "[active]"
+msgstr "[ทำงาน]"
+
+#: id:462
+msgid "Subtitle"
+msgstr "ซับไตเติ้ล"
+
+#: id:463
+msgid "Backlight"
+msgstr "Backlight"
+
+#: id:464
+msgid "Brightness"
+msgstr "Brightness"
+
+#: id:465
+msgid "Contrast"
+msgstr "Contrast"
+
+#: id:466
+msgid "Gamma"
+msgstr "Gamma"
+
+#: id:467
+msgctxt "Auto context with id 467"
+msgid "Type"
+msgstr "ชนิด"
+
+#: id:468
+msgid "Move the bar to change the OSD position"
+msgstr "ย้ายบาร์เพื่อเปลี่ยนตำแหน่งของ OSD"
+
+#: id:469
+msgid "OSD position"
+msgstr "ตำแหน่งของ OSD"
+
+#: id:470
+msgid "Credits"
+msgstr "เครดิต"
+
+#: id:471
+msgid "Modchip"
+msgstr "Modchip"
+
+#: id:474
+msgctxt "Auto context with id 474"
+msgid "Off"
+msgstr "ปิด"
+
+#: id:475
+msgid "Music only"
+msgstr "เพลงเท่านั้น"
+
+#: id:476
+msgctxt "Auto context with id 476"
+msgid "Music & video"
+msgstr "เพลง & วิดีโอ"
+
+#: id:477
+msgid "Unable to load playlist"
+msgstr "ไม่สามารถโหลดรายการเพลงที่จะเล่น"
+
+#: id:478
+msgid "OSD"
+msgstr "OSD"
+
+#: id:479
+msgid "Skin & language"
+msgstr "หน้าตา & ภาษา"
+
+#: id:480
+msgid "Appearance"
+msgstr "การแสดงผล"
+
+#: id:481
+msgid "Audio options"
+msgstr "ตัวเลือกเสียง"
+
+#: id:482
+msgid "About XBMC"
+msgstr "เกี่ยวกับโปรแกรม"
+
+#: id:485
+msgid "Delete album"
+msgstr "ลบอัลบั้ม"
+
+#: id:486
+msgid "Repeat"
+msgstr "เล่นซ้ำ"
+
+#: id:487
+msgid "Repeat one"
+msgstr "เล่นซ้ำหนึ่งครั้ง"
+
+#: id:488
+msgid "Repeat folder"
+msgstr "เล่นซ้ำทั้งโฟลเดอร์"
+
+#: id:489
+msgid "Play the next song automatically"
+msgstr "เล่นเพลงต่อไปอัตโนมัติ"
+
+#: id:491
+msgid "- Use big icons"
+msgstr "- ใช้ไอคอนขนาดใหญ่"
+
+#: id:492
+msgid "Resize VobSubs"
+msgstr "ลดขนาด VobSubs"
+
+#: id:493
+msgid "Advanced options (Experts Only!)"
+msgstr "ตัวเลือกขั้นสูง"
+
+#: id:494
+msgid "Overall audio headroom"
+msgstr "Overall เสียง headroom"
+
+#: id:495
+msgid "Upsample videos to GUI resolution"
+msgstr "Upsample วิดีโอ to GUI resolution"
+
+#: id:496
+msgid "Calibration"
+msgstr "Calibration"
+
+#: id:497
+msgid "Show file extensions"
+msgstr "แสดงนามสกุลแฟ้ม"
+
+#: id:498
+msgid "Sort by: Type"
+msgstr "เรียงลำดับ: ชนิด"
+
+#: id:499
+msgid "Unable to connect to online lookup service"
+msgstr "ไม่สามารถเชื่อมต่อการค้นหาออนไลน์ได้"
+
+#: id:500
+msgid "Downloading album information failed"
+msgstr "ไม่สามารถโหลดข้อมูลอัลบั้ม"
+
+#: id:501
+msgid "Looking for album names..."
+msgstr "ค้นหาชื่ออัลบั้ม..."
+
+#: id:502
+msgctxt "Auto context with id 502"
+msgid "Open"
+msgstr "เปิด"
+
+#: id:503
+msgid "Busy"
+msgstr "กำลังประมวลผล"
+
+#: id:504
+msgid "Empty"
+msgstr "ว่างเปล่า"
+
+#: id:505
+msgid "Loading media info from files..."
+msgstr "กำลังโหลดข้อมูลจากแฟ้ม..."
+
+#: id:507
+msgid "Sort by: Usage"
+msgstr "เรียงลำดับ: การใช้"
+
+#: id:510
+msgid "Enable visualizations"
+msgstr "เปิดใช้งาน visualizations"
+
+#: id:511
+msgid "Enable video mode switching"
+msgstr "ใช้งานการเปลี่ยนโหมดวิดีโอ"
+
+#: id:512
+msgid "Startup window"
+msgstr "หน้าต่างเริ่มต้น"
+
+#: id:513
+msgid "Home window"
+msgstr "หน้าต่างหลัก"
+
+#: id:514
+msgid "Manual settings"
+msgstr "ตั้งค่าด้วยตนเอง"
+
+#: id:515
+msgid "Genre"
+msgstr "ชนิด"
+
+#: id:517
+msgid "Recently played albums"
+msgstr "อัลบั้มที่เล่นแล้ว"
+
+#: id:518
+msgid "Launch"
+msgstr "ทำงาน"
+
+#: id:519
+msgid "Launch in..."
+msgstr "ทำงานใน..."
+
+#: id:521
+msgid "Compilations"
+msgstr "Compilations"
+
+#: id:522
+msgid "Remove source"
+msgstr "ลบแหล่งข้อมูล"
+
+#: id:523
+msgid "Switch media"
+msgstr "เปลี่ยนสื่อ"
+
+#: id:524
+msgid "Select playlist"
+msgstr "เลือกรายการที่จะเล่น"
+
+#: id:525
+msgid "New playlist..."
+msgstr "สร้างรายการที่จะเล่น..."
+
+#: id:526
+msgid "Add to playlist"
+msgstr "เพิ่มไปยังรายการที่จะเล่น"
+
+#: id:527
+msgid "Manually add to library"
+msgstr "เพิ่มไปยังคลังข้อมูลด้วยตนเอง"
+
+#: id:528
+msgid "Enter title"
+msgstr "ใส่ชื่อเรื่อง"
+
+#: id:529
+msgid "Error: Duplicate title"
+msgstr "ผิดพลาด: ชื่อเรื่องซ้ำ"
+
+#: id:530
+msgid "Select genre"
+msgstr "เลือกชนิด"
+
+#: id:531
+msgid "New genre"
+msgstr "สร้างชนิดใหม่"
+
+#: id:532
+msgid "Manual addition"
+msgstr "Manual addition"
+
+#: id:533
+msgid "Enter genre"
+msgstr "กรอกชนิด"
+
+#: id:534
+msgid "View: %s"
+msgstr "มุมมอง: %s"
+
+#: id:535
+msgid "List"
+msgstr "รายการ"
+
+#: id:536
+msgid "Icons"
+msgstr "ไอคอน"
+
+#: id:537
+msgid "Big list"
+msgstr "รายการขนาดใหญ่"
+
+#: id:538
+msgid "Big icons"
+msgstr "ไอคอนขนาดใหญ่"
+
+#: id:539
+msgid "Wide"
+msgstr "กว้าง"
+
+#: id:540
+msgid "Big wide"
+msgstr "กว้างใหญ่"
+
+#: id:541
+msgid "Album icons"
+msgstr "อัลบั้มไอคอน"
+
+#: id:542
+msgid "DVD icons"
+msgstr "ดีวีดีไอคอน"
+
+#: id:543
+msgctxt "Auto context with id 543"
+msgid "DVD"
+msgstr "ดีวีดี"
+
+#: id:544
+msgctxt "Auto context with id 544"
+msgid "Media info"
+msgstr "ข้อมูลสื่อ"
+
+#: id:545
+msgid "Audio output device"
+msgstr "อุปกรณ์ส่งออกเสียง"
+
+#: id:546
+msgid "Passthrough output device"
+msgstr "อุปกรณืที่ใช้ส่งออก"
+
+#: id:547
+msgid "No biography for this artist"
+msgstr "ไม่พบประวัตินักร้องคนนี้"
+
+#: id:548
+msgid "Downmix multichannel audio to stereo"
+msgstr "Downmix multichannel เสียง to stereo"
+
+#: id:550
+msgid "Sort by: %s"
+msgstr "เรียงลำดับ: %s"
+
+#: id:551
+msgctxt "Auto context with id 551"
+msgid "Name"
+msgstr "ชื่อ"
+
+#: id:552
+msgid "Date"
+msgstr "วันที่"
+
+#: id:553
+msgid "Size"
+msgstr "ขนาด"
+
+#: id:554
+msgid "Track"
+msgstr "เพลงที่"
+
+#: id:555
+msgid "Time"
+msgstr "เวลา"
+
+#: id:556
+msgctxt "Auto context with id 556"
+msgid "Title"
+msgstr "ชื่อเรื่อง"
+
+#: id:557
+msgid "Artist"
+msgstr "ศิลปิน"
+
+#: id:558
+msgid "Album"
+msgstr "อัลบั้ม"
+
+#: id:559
+msgid "Playlist"
+msgstr "รายการเพลง"
+
+#: id:560
+msgid "ID"
+msgstr "ไอดี"
+
+#: id:561
+msgctxt "Auto context with id 561"
+msgid "File"
+msgstr "แฟ้ม"
+
+#: id:562
+msgctxt "Auto context with id 562"
+msgid "Year"
+msgstr "ปี"
+
+#: id:563
+msgid "Rating"
+msgstr "เรตติ้ง"
+
+#: id:564
+msgctxt "Auto context with id 564"
+msgid "Type"
+msgstr "ชนิด"
+
+#: id:565
+msgid "Usage"
+msgstr "การเล่นเพลง"
+
+#: id:566
+msgid "Album artist"
+msgstr "ศิลปิน"
+
+#: id:567
+msgid "Play count"
+msgstr "จำนวนการเล่น"
+
+#: id:568
+msgid "Last played"
+msgstr "เล่นครั้งสุดท้าย"
+
+#: id:569
+msgctxt "Auto context with id 569"
+msgid "Comment"
+msgstr "ข้อคิดเห็น"
+
+#: id:570
+msgid "Date added"
+msgstr "วันที่เพิ่ม"
+
+#: id:571
+msgctxt "Auto context with id 571"
+msgid "Default"
+msgstr "ค่าปริยาย"
+
+#: id:572
+msgid "Studio"
+msgstr "Studio"
+
+#: id:573
+msgid "Path"
+msgstr "พาธ"
+
+#: id:574
+msgctxt "Auto context with id 574"
+msgid "Country"
+msgstr ""
+
+#: id:575
+msgid "In progress"
+msgstr ""
+
+#: id:576
+msgid "Times played"
+msgstr ""
+
+#: id:580
+msgid "Sort direction"
+msgstr "ทิศทางการเรียงลำดับ"
+
+#: id:581
+msgid "Sort method"
+msgstr "วิธีการเรียงลำดับ"
+
+#: id:582
+msgctxt "Auto context with id 582"
+msgid "View mode"
+msgstr "มุมมองการดู"
+
+#: id:583
+msgid "Remember views for different folders"
+msgstr "จำค่ามุมมองสำหรับทุกโฟลเดอร์"
+
+#: id:584
+msgid "Ascending"
+msgstr "น้อยไปมาก"
+
+#: id:585
+msgid "Descending"
+msgstr "มากไปน้อย"
+
+#: id:586
+msgid "Edit playlist"
+msgstr "แก้ไขรายการเพลงที่จะเล่น"
+
+#: id:587
+msgid "Filter"
+msgstr "ตัวกรอง"
+
+#: id:588
+msgid "Cancel party mode"
+msgstr "ยกเลิกโหมดปาตี้"
+
+#: id:589
+msgid "Party mode"
+msgstr "ปาตี้โหมด"
+
+#: id:590
+msgid "Random"
+msgstr "สุ่ม"
+
+#: id:591
+msgctxt "Auto context with id 591"
+msgid "Off"
+msgstr "ปิด"
+
+#: id:592
+msgid "One"
+msgstr "ครั้งเดียว"
+
+#: id:593
+msgid "All"
+msgstr "ทั้งหมด"
+
+#: id:594
+msgctxt "Auto context with id 594"
+msgid "Off"
+msgstr "ปิด"
+
+#: id:595
+msgid "Repeat: Off"
+msgstr "เล่นซ้ำ: ปิด"
+
+#: id:596
+msgid "Repeat: One"
+msgstr "เล่นซ้ำ: ครั้งเดียว"
+
+#: id:597
+msgid "Repeat: All"
+msgstr "เล่นซ้ำ: ทั้งหมด"
+
+#: id:600
+msgid "Rip audio CD"
+msgstr "Rip เสียง CD"
+
+#: id:601
+msgctxt "Auto context with id 601"
+msgid "Medium"
+msgstr "ตัวกลาง"
+
+#: id:602
+msgctxt "Auto context with id 602"
+msgid "Standard"
+msgstr "มาตรฐาน"
+
+#: id:603
+msgid "Extreme"
+msgstr "Extreme"
+
+#: id:604
+msgid "Constant bitrate"
+msgstr "ค่าบิตเรตคงที่"
+
+#: id:605
+msgid "Ripping..."
+msgstr "Ripping..."
+
+#: id:607
+msgid "To:"
+msgstr "ถึง:"
+
+#: id:608
+msgid "Could not rip CD or track"
+msgstr "Could not rip CD or track"
+
+#: id:609
+msgid "CDDARipPath is not set."
+msgstr "CDDARipPath is not set."
+
+#: id:610
+msgid "Rip audio track"
+msgstr "Rip เสียง track"
+
+#: id:611
+msgid "Enter number"
+msgstr "ป้อนหมายเลข"
+
+#: id:612
+msgid "Bits/Sample"
+msgstr ""
+
+#: id:613
+msgid "Sample Frequency"
+msgstr ""
+
+#: id:620
+msgid "Audio CDs"
+msgstr "ซีดีเพลง"
+
+#: id:621
+msgid "Encoder"
+msgstr "การแปลงเสียง"
+
+#: id:622
+msgid "Quality"
+msgstr "คุณภาพ"
+
+#: id:623
+msgid "Bitrate"
+msgstr "บิทเรต"
+
+#: id:624
+msgid "Include track number"
+msgstr "รวมหมายเลขเพลง"
+
+#: id:625
+msgid "All songs of"
+msgstr "เพลงทั้งหมดจาก"
+
+#: id:629
+msgctxt "Auto context with id 629"
+msgid "View mode"
+msgstr "มุมมอง"
+
+#: id:630
+msgctxt "Auto context with id 630"
+msgid "Normal"
+msgstr "ปกติ"
+
+#: id:631
+msgid "Zoom"
+msgstr "ซูม"
+
+#: id:632
+msgid "Stretch 4:3"
+msgstr "ปรับเป็น 4:3"
+
+#: id:633
+msgid "Wide Zoom"
+msgstr "ปรับเป็น 14:9"
+
+#: id:634
+msgid "Stretch 16:9"
+msgstr "ปรับเป็น 16:9"
+
+#: id:635
+msgid "Original Size"
+msgstr "ขนาดเริ่มต้น"
+
+#: id:636
+msgctxt "Auto context with id 636"
+msgid "Custom"
+msgstr "กำหนดเอง"
+
+#: id:637
+msgid "Replay gain"
+msgstr "ได้รับการเล่นอีกครั้ง"
+
+#: id:638
+msgid "Replaygain volume adjustments"
+msgstr "การปรับระดับเสียง (เฉพาะเพลง)"
+
+#: id:639
+msgid "Use track levels"
+msgstr "Use track levels"
+
+#: id:640
+msgid "Use album levels"
+msgstr "Use album levels"
+
+#: id:641
+msgid "PreAmp Level - Replay gained files"
+msgstr "PreAmp Level - Reเล่น gained แฟ้ม"
+
+#: id:642
+msgid "PreAmp Level - Non replay gained files"
+msgstr "PreAmp Level - Non reเล่น gained แฟ้ม"
+
+#: id:643
+msgid "Avoid clipping on replay gained files"
+msgstr "Avoid clipping on reเล่น gained แฟ้ม"
+
+#: id:644
+msgid "Crop black bars"
+msgstr "ตัดแถบดำ"
+
+#: id:645
+msgid "Need to unpack a big file. Continue?"
+msgstr "ต้องการขยายแฟ้มขนาดใหญ่ ทำต่อหรือไม่?"
+
+#: id:646
+msgid "Remove from library"
+msgstr "ลบจากคลังข้อมูล"
+
+#: id:647
+msgid "Export video library"
+msgstr "ส่งออกคลังวิดีโอ"
+
+#: id:648
+msgid "Import video library"
+msgstr "นำเข้าคลังวิดีโอ"
+
+#: id:649
+msgid "Importing"
+msgstr "กำลังนำเข้า"
+
+#: id:650
+msgid "Exporting"
+msgstr "กำลังส่งออก"
+
+#: id:651
+msgid "Browse for library"
+msgstr "เรียกดูคลังข้อมูล"
+
+#: id:652
+msgid "Years"
+msgstr "ปี"
+
+#: id:653
+msgid "Update library"
+msgstr "อัพเดทคลังข้อมูล"
+
+#: id:654
+msgid "Show debug info"
+msgstr "แสดงข้อมูล debug"
+
+#: id:655
+msgid "Browse for executable"
+msgstr "เรียกดูแฟ้มที่สามารถทำงานได้"
+
+#: id:656
+msgid "Browse for playlist"
+msgstr "เรียกดูรายการเพลงที่จะเล่น"
+
+#: id:657
+msgid "Browse for folder"
+msgstr "เรียกดูโฟล์เดอร์"
+
+#: id:658
+msgid "Song information"
+msgstr "ข้อมูลเพลง"
+
+#: id:659
+msgid "Non-linear stretch"
+msgstr ""
+
+#: id:660
+msgid "Volume amplification"
+msgstr "ส่วนขยายเสียง"
+
+#: id:661
+msgid "Choose export folder"
+msgstr "เลือกโฟลเดอร์ส่งออก"
+
+#: id:662
+msgid "This file is no longer available."
+msgstr "แฟ้มนี้ไม่สามารถใช้ได้"
+
+#: id:663
+msgid "Would you like to remove it from the library?"
+msgstr "คุณต้องการมราจะลบจากคลังข้อมูล?"
+
+#: id:664
+msgid "Browse for Script"
+msgstr "เรียกดูสคริปต์"
+
+#: id:665
+msgid "Compression level"
+msgstr ""
+
+#: id:700
+msgid "Cleaning up library"
+msgstr "ทำความสะอาดคลังข้อมูล"
+
+#: id:701
+msgid "Removing old songs from the library"
+msgstr "ลบเพลงเก่าจากคลังข้อมูล"
+
+#: id:702
+msgid "This path has been scanned before"
+msgstr "พาธนี้ได้รับการสแกนแล้ว"
+
+#: id:705
+msgctxt "Auto context with id 705"
+msgid "Network"
+msgstr "เครือข่าย"
+
+#: id:706
+msgid "- Server"
+msgstr "- เซิฟเวอร์"
+
+#: id:708
+msgid "Use an HTTP proxy server to access the internet"
+msgstr "ใช้ HTTP proxy server ในการเข้าถึงอินเตอร์เน็ต"
+
+#: id:711
+msgid "Internet Protocol (IP)"
+msgstr "อินเตอร์เน็ตโพรโทคอล (IP)"
+
+#: id:712
+msgid "Invalid port specified. Value must be between 1 and 65535."
+msgstr "หมายเลขพอร์ตผิดพลาด. ตัวเลขต้องอยู่ระหว่าง 1 ถึง 65535."
+
+#: id:713
+msgid "HTTP proxy"
+msgstr "HTTP proxy"
+
+#: id:715
+msgid "- Assignment"
+msgstr "- การกำหนดค่า"
+
+#: id:716
+msgid "Automatic (DHCP)"
+msgstr "Automatic (DHCP)"
+
+#: id:717
+msgid "Manual (Static)"
+msgstr "Manual (Static)"
+
+#: id:719
+msgid "- IP address"
+msgstr "- ที่อยู่ไอพี"
+
+#: id:720
+msgid "- Netmask"
+msgstr "- Netmask"
+
+#: id:721
+msgid "- Default gateway"
+msgstr "- Default gateway"
+
+#: id:722
+msgid "- DNS server"
+msgstr "- DNS server"
+
+#: id:723
+msgid "Save & restart"
+msgstr "บันทึก & ทำงานใหม่"
+
+#: id:724
+msgid "Invalid address specified. Value must be AAA.BBB.CCC.DDD"
+msgstr "ที่อยู่ผิดพลาด. ค่าต้องอยู่ในรูปแบบ AAA.BBB.CCC.DDD"
+
+#: id:725
+msgid "with numbers between 0 and 255."
+msgstr "ด้วยตัวเลขระหว่าง 0 ถึง 255."
+
+#: id:726
+msgid "Changes not saved. Continue without saving?"
+msgstr "การเปลี่ยนแปลงไม่บันทึก ต้องการทำต่อโดยไม่บันทึกหรือไม่?"
+
+#: id:727
+msgid "Web server"
+msgstr "Web server"
+
+#: id:728
+msgctxt "Auto context with id 728"
+msgid "FTP server"
+msgstr "FTP server"
+
+#: id:730
+msgid "- Port"
+msgstr "- พอร์ต"
+
+#: id:732
+msgid "Save & apply"
+msgstr "จัดเก็บ & นำไปใช้"
+
+#: id:733
+msgid "- Password"
+msgstr "- รหัสผ่าน"
+
+#: id:734
+msgid "No pass"
+msgstr "ไม่มีรหัส"
+
+#: id:735
+msgid "- Character set"
+msgstr "- ชุดอักขระ"
+
+#: id:736
+msgid "- Style"
+msgstr "- รูปแบบ"
+
+#: id:737
+msgid "- Colour"
+msgstr "- สี"
+
+#: id:738
+msgctxt "Auto context with id 738"
+msgid "Normal"
+msgstr "ปกติ"
+
+#: id:739
+msgid "Bold"
+msgstr "หนา"
+
+#: id:740
+msgid "Italics"
+msgstr "เอียง"
+
+#: id:741
+msgid "Bold italics"
+msgstr "หนา เอียง"
+
+#: id:742
+msgctxt "Auto context with id 742"
+msgid "White"
+msgstr "ขาว"
+
+#: id:743
+msgctxt "Auto context with id 743"
+msgid "Yellow"
+msgstr "เหลือง"
+
+#: id:744
+msgctxt "Auto context with id 744"
+msgid "Files"
+msgstr "แฟ้ม"
+
+#: id:745
+msgid "No scanned information for this view"
+msgstr "มุมมองนี้ไม่มีข้อมูลที่ทำการสำรวจ"
+
+#: id:746
+msgid "Please turn off library mode"
+msgstr "กรุณาปิดโหมดคลังข้อมูล"
+
+#: id:747
+msgid "Error loading image"
+msgstr "ผิดพลาด! กำลังโหลดรูปภาพ"
+
+#: id:748
+msgid "Edit path"
+msgstr "แก้ไขพาธ"
+
+#: id:749
+msgid "Mirror image"
+msgstr "สำเนาภาพ"
+
+#: id:750
+msgid "Are you sure?"
+msgstr "คุณแน่ใจหรือไม่?"
+
+#: id:751
+msgid "Removing source"
+msgstr "กำลังลบแหล่งข้อมูล"
+
+#: id:754
+msgid "Add program link"
+msgstr "เพิ่มลิงค์โปรแกรม"
+
+#: id:755
+msgid "Edit program path"
+msgstr "แก้ไขโปรแกรมพาธ"
+
+#: id:756
+msgid "Edit program name"
+msgstr "แก้ไขชื่อโปรแกรม"
+
+#: id:757
+msgid "Edit path depth"
+msgstr "Edit path depth"
+
+#: id:759
+msgid "View: Big list"
+msgstr "มุมมอง: รายการขนาดใหญ่"
+
+#: id:760
+msgctxt "Auto context with id 760"
+msgid "Yellow"
+msgstr "เหลือง"
+
+#: id:761
+msgctxt "Auto context with id 761"
+msgid "White"
+msgstr "ขาว"
+
+#: id:762
+msgid "Blue"
+msgstr "น้ำเงิน"
+
+#: id:763
+msgid "Bright green"
+msgstr "เขียวอ่อน"
+
+#: id:764
+msgid "Yellow green"
+msgstr "เขียวเหลือง"
+
+#: id:765
+msgid "Cyan"
+msgstr "คราม"
+
+#: id:766
+msgid "Light grey"
+msgstr "Reserved"
+
+#: id:767
+msgid "Grey"
+msgstr "Reserved"
+
+#: id:770
+msgid "Error %i: share not available"
+msgstr "ผิดพลาด %i: ไม่ได้ทำการแบ่งปัน"
+
+#: id:772
+msgctxt "Auto context with id 772"
+msgid "Audio output"
+msgstr "การส่งออกเสียง"
+
+#: id:773
+msgid "Seeking"
+msgstr "ค้นหา"
+
+#: id:774
+msgid "Slideshow folder"
+msgstr "สไลด์โชว์โฟลเดอร์"
+
+#: id:775
+msgid "Network interface"
+msgstr "อุปกรณ์เครือข่าย"
+
+#: id:776
+msgid "- Wireless network name (ESSID)"
+msgstr "- ชื่อเครือข่ายไร้สาย(ESSID)"
+
+#: id:777
+msgid "- Wireless password"
+msgstr "- รหัสผ่าน"
+
+#: id:778
+msgid "- Wireless security"
+msgstr "- ความปลอดภัย"
+
+#: id:779
+msgid "Save and apply network interface settings"
+msgstr "บันทึกและนำากรตั้งค่าเครือข่ายไปใช้"
+
+#: id:780
+msgid "No encryption"
+msgstr "ไม่มีการเข้ารหัส"
+
+#: id:781
+msgid "WEP"
+msgstr "WEP"
+
+#: id:782
+msgid "WPA"
+msgstr "WPA"
+
+#: id:783
+msgid "WPA2"
+msgstr "WPA2"
+
+#: id:784
+msgid "Applying network interface settings. Please wait."
+msgstr "กำลังบันทึกการตั้งค่า กรุณารอซักครู่."
+
+#: id:785
+msgid "Network interface restarted successfully."
+msgstr "อินเตอร์เฟซเริ่มทำงานใหม่เสร็จสมบูรณ์."
+
+#: id:786
+msgid "Network interface did not start successfully."
+msgstr "อินเตอร์เฟซเริ่มทำงานใหม่ผิดพลาด."
+
+#: id:787
+msgid "Interface disabled"
+msgstr "ปิดการใช้งานอินเตอร์เฟซ"
+
+#: id:788
+msgid "Network interface disabled successfully."
+msgstr "ปิดการใช้งานอินเตอร์เฟซเสร็จสมบูรณ์."
+
+#: id:789
+msgid "Wireless network name (ESSID)"
+msgstr "ชื่อเครือข่ายไร้สาย(ESSID)"
+
+#: id:790
+msgid "Remote control"
+msgstr ""
+
+#: id:791
+msgid "Allow programs on this system to control XBMC"
+msgstr "อนุญาตให้โปรแกรมในระบบสามารถควบคุม XBMC"
+
+#: id:792
+msgctxt "Auto context with id 792"
+msgid "Port"
+msgstr "พอร์ต"
+
+#: id:793
+msgid "Port range"
+msgstr "ความกว้างของพอร์ต"
+
+#: id:794
+msgid "Allow programs on other systems to control XBMC"
+msgstr "อนุญาตให้โปรแกรมบนระบบอื่นควบคุม XBMC"
+
+#: id:795
+msgid "Initial repeat delay (ms)"
+msgstr "Initial repeat delay (ms)"
+
+#: id:796
+msgid "Continuous repeat delay (ms)"
+msgstr "Continuous repeat delay (ms)"
+
+#: id:797
+msgid "Maximum number of clients"
+msgstr "จำนวนลูกข่ายสูงสุด"
+
+#: id:798
+msgid "Internet access"
+msgstr "การเข้าถึงอินเตอร์เน็ต"
+
+#: id:850
+msgid "Invalid port number entered"
+msgstr ""
+
+#: id:851
+msgid "Valid port range is 1-65535"
+msgstr ""
+
+#: id:852
+msgid "Valid port range is 1024-65535"
+msgstr ""
+
+#: id:998
+msgid "Add Music..."
+msgstr ""
+
+#: id:999
+msgid "Add Videos..."
+msgstr ""
+
+#: id:1000
+msgid "- Preview"
+msgstr "แสดงตัวอย่าง"
+
+#: id:1001
+msgid "Unable to connect"
+msgstr "ไม่สามารถเชื่อต่อได้"
+
+#: id:1002
+msgid "XBMC was unable to connect to the network location."
+msgstr "XBMC ไม่สามารถเชื่อมต่อไปยังเครือข่ายดังกล่าวได้."
+
+#: id:1003
+msgid "This could be due to the network not being connected."
+msgstr "ไม่สามารถทำงานได้เนื่องจากยังไม่ได้เชื่อมต่อเครือข่าย."
+
+#: id:1004
+msgid "Would you like to add it anyway?"
+msgstr "คุณต้องการเพิ่มจริงหรือไม่?"
+
+#: id:1006
+msgctxt "Auto context with id 1006"
+msgid "IP address"
+msgstr "ไอพี"
+
+#: id:1007
+msgid "Add network location"
+msgstr "เพิ่มเครือข่าย"
+
+#: id:1008
+msgid "Protocol"
+msgstr "โปรโตคอล"
+
+#: id:1009
+msgid "Server address"
+msgstr "ที่อยู่เซิฟเวอร์"
+
+#: id:1010
+msgid "Server name"
+msgstr "ชื่อเซิฟเวอร์"
+
+#: id:1011
+msgid "Remote path"
+msgstr "รีโมทพาธ"
+
+#: id:1012
+msgid "Shared folder"
+msgstr "โฟลเดอร์ที่แบ่งปัน"
+
+#: id:1013
+msgctxt "Auto context with id 1013"
+msgid "Port"
+msgstr "พอร์ต"
+
+#: id:1014
+msgctxt "Auto context with id 1014"
+msgid "Username"
+msgstr "ชื่อผู้ใช้"
+
+#: id:1015
+msgid "Browse for network server"
+msgstr "เรียกดูเซิฟเวอร์เครือข่าย"
+
+#: id:1016
+msgid "Enter the network address of the server"
+msgstr "ป้อนที่อยู่เครือข่าย"
+
+#: id:1017
+msgid "Enter the path on the server"
+msgstr "ป้อนพาธของเซิฟเวอร์"
+
+#: id:1018
+msgid "Enter the port number"
+msgstr "ป้อนหมายเลขพอร์ต"
+
+#: id:1019
+msgid "Enter the username"
+msgstr "ป้อนชื่อผู้ใช้"
+
+#: id:1020
+msgid "Add %s source"
+msgstr "เพิ่มแหล่งข้อมูล %s"
+
+#: id:1021
+msgid "Enter the paths or browse for the media locations."
+msgstr "ป้อนพาธหรือเรียกดูสื่อ."
+
+#: id:1022
+msgid "Enter a name for this media Source."
+msgstr "ป้อนชื่อสำหรับแหล่งข้อมูล."
+
+#: id:1023
+msgid "Browse for new share"
+msgstr "เรียกดูการแบ่งปัน"
+
+#: id:1024
+msgid "Browse"
+msgstr "เรียกดู"
+
+#: id:1025
+msgid "Could not retrieve directory information."
+msgstr "ไม่สามารถรับข้อมูลได้."
+
+#: id:1026
+msgid "Add source"
+msgstr "เพิ่มแหล่งข้อมูล"
+
+#: id:1027
+msgid "Edit source"
+msgstr "แก้ไขแหล่งข้อมูล"
+
+#: id:1028
+msgid "Edit %s source"
+msgstr "แก้ไขแหล่งข้อมูล %s"
+
+#: id:1029
+msgid "Enter the new label"
+msgstr "ป้อนป้ายชื่อใหม่"
+
+#: id:1030
+msgid "Browse for image"
+msgstr "เรียกดูรูปภาพ"
+
+#: id:1031
+msgid "Browse for image folder"
+msgstr "เรียกดูรูปภาพโฟลเดอร์"
+
+#: id:1032
+msgid "Add network location..."
+msgstr "เพื่มที่อยู่เครือข่าย..."
+
+#: id:1033
+msgid "Browse for file"
+msgstr "เรียกดูแฟ้ม"
+
+#: id:1034
+msgid "Submenu"
+msgstr "เมนูย่อย"
+
+#: id:1035
+msgid "Enable submenu buttons"
+msgstr "เปิดใช้ปุ่มเมนูย่อย"
+
+#: id:1036
+msgid "Favourites"
+msgstr "ที่ชื่นชอบ"
+
+#: id:1037
+msgid "Video Add-ons"
+msgstr "ส่วนเสริมวิดีโอ"
+
+#: id:1038
+msgid "Music Add-ons"
+msgstr "ส่วนเสริมเสียง"
+
+#: id:1039
+msgid "Picture Add-ons"
+msgstr "ส่วนเสริมรูปภาพ"
+
+#: id:1040
+msgid "Loading directory"
+msgstr "กำลังโหลดไดรเร็กทอรี่"
+
+#: id:1041
+msgid "Retrieved %i items"
+msgstr "นำกลับแล้ว %i รายการ"
+
+#: id:1042
+msgid "Retrieved %i of %i items"
+msgstr "นำกลับแล้ว %i จาก %i รายการ"
+
+#: id:1043
+msgid "Program Add-ons"
+msgstr "ส่วนเสริมโปรแกรม"
+
+#: id:1044
+msgid "Set plugin thumb"
+msgstr "Set plugin thumb"
+
+#: id:1045
+msgid "Add-on settings"
+msgstr "การตั้งค่าส่วนเสริม"
+
+#: id:1046
+msgid "Access points"
+msgstr "Access points"
+
+#: id:1047
+msgid "Other..."
+msgstr "อื่นๆ"
+
+#: id:1048
+msgid "- Username"
+msgstr "- ชื่อผู้ใช้"
+
+#: id:1049
+msgid "Script settings"
+msgstr "การตั้งค่าสคริปต์"
+
+#: id:1050
+msgid "Singles"
+msgstr "Singles"
+
+#: id:1051
+msgid "Enter web address"
+msgstr ""
+
+#: id:1200
+msgid "SMB client"
+msgstr "SMB client"
+
+#: id:1202
+msgid "Workgroup"
+msgstr "Workgroup"
+
+#: id:1203
+msgid "Default username"
+msgstr "ชื่อผู้ใช้เริ่มต้น"
+
+#: id:1204
+msgid "Default password"
+msgstr "รหัสผ่านเริ่มต้น"
+
+#: id:1207
+msgid "WINS server"
+msgstr "WINS server"
+
+#: id:1208
+msgid "Mount SMB shares"
+msgstr "Mount SMB shares"
+
+#: id:1210
+msgctxt "Auto context with id 1210"
+msgid "Remove"
+msgstr "ลบ"
+
+#: id:1211
+msgctxt "Auto context with id 1211"
+msgid "Music"
+msgstr "เพลง"
+
+#: id:1212
+msgctxt "Auto context with id 1212"
+msgid "Video"
+msgstr "วิดีโอ"
+
+#: id:1213
+msgctxt "Auto context with id 1213"
+msgid "Pictures"
+msgstr "รูปภาพ"
+
+#: id:1214
+msgctxt "Auto context with id 1214"
+msgid "Files"
+msgstr "แฟ้ม"
+
+#: id:1215
+msgctxt "Auto context with id 1215"
+msgid "Music & video"
+msgstr "เพลง & วิดีโอ"
+
+#: id:1216
+msgid "Music & pictures"
+msgstr "เพลง & รูปภาพ"
+
+#: id:1217
+msgid "Music & files"
+msgstr "เพลง & แฟ้ม"
+
+#: id:1218
+msgid "Video & pictures"
+msgstr "วิดีโอ & รูปภาพ"
+
+#: id:1219
+msgid "Video & files"
+msgstr "วิดีโอ & แฟ้ม"
+
+#: id:1220
+msgid "Pictures & files"
+msgstr "รูปภาพ & แฟ้ม"
+
+#: id:1221
+msgid "Music & video & pictures"
+msgstr "เพลง & วิดีโอ & รูปภาพ"
+
+#: id:1222
+msgid "Music & video & pictures & files"
+msgstr "เพลง & วิดีโอ & รูปภาพ & แฟ้ม"
+
+#: id:1223
+msgctxt "Auto context with id 1223"
+msgid "Disabled"
+msgstr "ปิดใช้งาน"
+
+#: id:1226
+msgid "Files & music & video"
+msgstr "แฟ้ม & เพลง & วิดีโอ"
+
+#: id:1227
+msgid "Files & pictures & music"
+msgstr "แฟ้ม & รูปภาพ & เพลง"
+
+#: id:1228
+msgid "Files & pictures & video"
+msgstr "แฟ้ม & รูปภาพ & วิดีโอ"
+
+#: id:1229
+msgid "Music & programs"
+msgstr "เพลง & โปรแกรม"
+
+#: id:1230
+msgid "Video & programs"
+msgstr "วิดีโอ & โปรแกรม"
+
+#: id:1231
+msgid "Pictures & programs"
+msgstr "รูปภาพ & โปรแกรม"
+
+#: id:1232
+msgid "Music & video & pictures & programs"
+msgstr "เพลง & วิดีโอ & รูปภาพ & โปรแกรม"
+
+#: id:1233
+msgid "Programs & video & music"
+msgstr "โปรแกรม & วิดีโอ & เพลง"
+
+#: id:1234
+msgid "Programs & pictures & music"
+msgstr "โปรแกรม & รูปภาพ & เพลง"
+
+#: id:1235
+msgid "Programs & pictures & video"
+msgstr "โปรแกรม & รูปภาพ & วิดีโอ"
+
+#: id:1250
+msgid "Auto-detection"
+msgstr "ค้นหาอัตโนมัติ"
+
+#: id:1251
+msgid "Auto-detect system"
+msgstr "ระบบค้นหาอัตโนมัติ"
+
+#: id:1252
+msgid "Nickname"
+msgstr "ชื่อเล่น"
+
+#: id:1254
+msgid "Ask to connect"
+msgstr "ถามเมื่อเชื่อมต่อ"
+
+#: id:1255
+msgid "Send FTP user and password"
+msgstr "ส่งชื่อผู้ใช้และรหัสผ่าน"
+
+#: id:1256
+msgid "Ping interval"
+msgstr "รอบการ Ping"
+
+#: id:1257
+msgid "Would you like to connect to the auto-detected system?"
+msgstr "คุณต้องการที่จะเชื่อมต่อระบบค้นหาอัตโนมัติหรือไม่?"
+
+#: id:1259
+msgid "Zeroconf"
+msgstr ""
+
+#: id:1260
+msgid "Announce these services to other systems via Zeroconf"
+msgstr "ประกาศการให้บริการผ่านทาง Zeroconf"
+
+#: id:1270
+msgid "Allow XBMC to receive AirPlay content"
+msgstr ""
+
+#: id:1271
+msgid "Device name"
+msgstr ""
+
+#: id:1272
+msgid "- Use password protection"
+msgstr ""
+
+#: id:1273
+msgid "AirPlay"
+msgstr ""
+
+#: id:1300
+msgid "Custom audio device"
+msgstr "ปรับแต่งอุปการณ์เสียง"
+
+#: id:1301
+msgid "Custom passthrough device"
+msgstr "ปรับแต่งอุปกรณ์ส่งผ่านเสียง"
+
+#: id:1396
+msgid "Drifting"
+msgstr "ลอย"
+
+#: id:1397
+msgid "and"
+msgstr "และ"
+
+#: id:1398
+msgid "Freezing"
+msgstr "แช่แข็ง"
+
+#: id:1399
+msgid "Late"
+msgstr "ช้า"
+
+#: id:1400
+msgid "Isolated"
+msgstr "แยกตัว"
+
+#: id:1401
+msgid "Thundershowers"
+msgstr "ฝนฟ้าคะนอง"
+
+#: id:1402
+msgid "Thunder"
+msgstr "ฟ้าร้อง"
+
+#: id:1403
+msgctxt "Auto context with id 1403"
+msgid "Sun"
+msgstr "แดดจัด"
+
+#: id:1404
+msgid "Heavy"
+msgstr "หนักมาก"
+
+#: id:1405
+msgid "in"
+msgstr "ใน"
+
+#: id:1406
+msgid "the"
+msgstr ""
+
+#: id:1407
+msgid "Vicinity"
+msgstr "บริเวณใกล้เคียง"
+
+#: id:1408
+msgid "Ice"
+msgstr "น้ำแข็ง"
+
+#: id:1409
+msgid "Crystals"
+msgstr "ผลึก"
+
+#: id:1410
+msgid "Calm"
+msgstr "ไม่มีลม"
+
+#: id:1411
+msgid "with"
+msgstr "โดย"
+
+#: id:1412
+msgid "windy"
+msgstr "ลมแรง"
+
+#: id:1413
+msgid "drizzle"
+msgstr "ฝนโปรยปราย"
+
+#: id:1414
+msgid "Thunderstorm"
+msgstr "ฝนฟ้าคะนอง"
+
+#: id:1415
+msgid "Drizzle"
+msgstr "ฝนตกปรอยๆ"
+
+#: id:1416
+msgid "Foggy"
+msgstr "หมอก"
+
+#: id:1417
+msgid "Grains"
+msgstr "Grains"
+
+#: id:1418
+msgid "T-Storms"
+msgstr "พายุฝนฟ้าคะนอง"
+
+#: id:1419
+msgid "T-Showers"
+msgstr "ฝนฟ้าคะนอง"
+
+#: id:1420
+msgid "Moderate"
+msgstr ""
+
+#: id:1421
+msgid "Very High"
+msgstr ""
+
+#: id:1422
+msgid "Windy"
+msgstr ""
+
+#: id:1423
+msgid "Mist"
+msgstr ""
+
+#: id:1450
+msgid "Put display to sleep when idle"
+msgstr "พักหน้าจอเมื่อไม่ทำงาน"
+
+#: id:2050
+msgid "Runtime"
+msgstr "Runtime"
+
+#: id:2100
+msgid "Script failed! : %s"
+msgstr "Script failed! : %s"
+
+#: id:2101
+msgid "Newer version needed - See log"
+msgstr ""
+
+#: id:4501
+msgid "Enable LCD/VFD"
+msgstr "เปิดใช้งาน LCD/VFD"
+
+#: id:10000
+msgid "Home"
+msgstr "หน้าหลัก"
+
+#: id:10001
+msgctxt "Auto context with id 10001"
+msgid "Programs"
+msgstr "โปรแกรม"
+
+#: id:10002
+msgctxt "Auto context with id 10002"
+msgid "Pictures"
+msgstr "รูปภาพ"
+
+#: id:10003
+msgctxt "Auto context with id 10003"
+msgid "File manager"
+msgstr "จัดการแฟ้ม"
+
+#: id:10004
+msgctxt "Auto context with id 10004"
+msgid "Settings"
+msgstr "การตั้งค่า"
+
+#: id:10005
+msgctxt "Auto context with id 10005"
+msgid "Music"
+msgstr "เพลง"
+
+#: id:10006
+msgctxt "Auto context with id 10006"
+msgid "Videos"
+msgstr "วิดีโอ"
+
+#: id:10007
+msgid "System information"
+msgstr "ข้อมูลระบบ"
+
+#: id:10008
+msgid "Settings - General"
+msgstr "การตั้งค่า - ทั่วไป"
+
+#: id:10009
+msgid "Settings - Screen"
+msgstr "การตั้งค่า - หน้าจอ"
+
+#: id:10010
+msgid "Settings - Appearance - GUI Calibration"
+msgstr "การตั้งค่า - การแสดงผล - GUI Calibration"
+
+#: id:10011
+msgid "Settings - Videos - Screen Calibration"
+msgstr "การตั้งค่า - วิดีโอ - Screen Calibration"
+
+#: id:10012
+msgid "Settings - Pictures"
+msgstr "การตั้งค่า - รูปภาพ"
+
+#: id:10013
+msgid "Settings - Programs"
+msgstr "การตั้งค่า - โปรแกรม"
+
+#: id:10014
+msgid "Settings - Weather"
+msgstr "การตั้งค่า - สภาพอากาศ"
+
+#: id:10015
+msgid "Settings - Music"
+msgstr "การตั้งค่า - เพลง"
+
+#: id:10016
+msgid "Settings - System"
+msgstr "การตั้งค่า - ระบบ"
+
+#: id:10017
+msgid "Settings - Videos"
+msgstr "การตั้งค่า - วิดีโอ"
+
+#: id:10018
+msgid "Settings - Network"
+msgstr "การตั้งค่า - เครือข่าย"
+
+#: id:10019
+msgid "Settings - Appearance"
+msgstr "การตั้งค่า - การแสดงผล"
+
+#: id:10020
+msgctxt "Auto context with id 10020"
+msgid "Scripts"
+msgstr "สคริปต์"
+
+#: id:10021
+msgid "Web Browser"
+msgstr ""
+
+#: id:10025
+msgctxt "Auto context with id 10025"
+msgid "Videos"
+msgstr ""
+
+#: id:10028
+msgid "Videos/Playlist"
+msgstr "วิดีโอ/รายการที่จะเล่น"
+
+#: id:10029
+msgctxt "Auto context with id 10029"
+msgid "Login screen"
+msgstr ""
+
+#: id:10034
+msgid "Settings - Profiles"
+msgstr "การตั้งค่า - แฟ้มประวัติ"
+
+#: id:10040
+msgid "Addon browser"
+msgstr ""
+
+#: id:10100
+msgid "Yes/No dialog"
+msgstr "กล่องโต้ตอบ ใช่หรือไม่"
+
+#: id:10101
+msgid "Progress dialog"
+msgstr "กล่องโต้ตอบ กระบวนการ"
+
+#: id:10210
+msgid "Looking for subtitles..."
+msgstr "มองหาซับไตเติ้ล..."
+
+#: id:10211
+msgid "Looking for or caching subtitles..."
+msgstr "ค้นหาซับไตเติ้ล..."
+
+#: id:10212
+msgid "terminating"
+msgstr "จบการทำงาน"
+
+#: id:10213
+msgid "buffering"
+msgstr "บัฟเฟอร์"
+
+#: id:10214
+msgid "Opening stream"
+msgstr "Opening stream"
+
+#: id:10500
+msgid "Music/Playlist"
+msgstr "เพลง/เพลงที่จะเล่น"
+
+#: id:10501
+msgid "Music/Files"
+msgstr "เพลง/แฟ้ม"
+
+#: id:10502
+msgid "Music/Library"
+msgstr "เพลง/คลังข้อมูล"
+
+#: id:10503
+msgid "Playlist editor"
+msgstr "แก้ไขเพลงที่จะเล่น"
+
+#: id:10504
+msgid "Top 100 songs"
+msgstr "Top 100 เพลง"
+
+#: id:10505
+msgid "Top 100 albums"
+msgstr "Top 100 อัลบั้ม"
+
+#: id:10506
+msgctxt "Auto context with id 10506"
+msgid "Programs"
+msgstr "โปรแกรม"
+
+#: id:10507
+msgid "Configuration"
+msgstr "ปรับตั้งค่า"
+
+#: id:10508
+msgid "Weather forecast"
+msgstr "การพยากรณ์อากาศ"
+
+#: id:10509
+msgid "Network gaming"
+msgstr "เกมบนเครือข่าย"
+
+#: id:10510
+msgid "Extensions"
+msgstr "ส่วนเสริม"
+
+#: id:10511
+msgctxt "Auto context with id 10511"
+msgid "System info"
+msgstr "ข้อมูลระบบ"
+
+#: id:10516
+msgid "Music - Library"
+msgstr "เพลง - คลังข้อมูล"
+
+#: id:10517
+msgid "Now Playing - Music"
+msgstr "กำลังโหลด - เพลง"
+
+#: id:10522
+msgid "Now Playing - Videos"
+msgstr "กำลังโหลด - วิดีโอ"
+
+#: id:10523
+msgid "Album info"
+msgstr "ข้อมูลอัลบั้ม"
+
+#: id:10524
+msgid "Movie info"
+msgstr "ข้อมูลภาพยนต์"
+
+#: id:12000
+msgid "Select dialog"
+msgstr "เลือกกล่องโต้ตอบ"
+
+#: id:12001
+msgid "Music/Info"
+msgstr "เพลง/ข้อมูล"
+
+#: id:12002
+msgid "Dialog OK"
+msgstr "กล่องโต้ตอบ ตกลง"
+
+#: id:12003
+msgid "Videos/Info"
+msgstr "วิดีโอ/ข้อมูล"
+
+#: id:12004
+msgid "Scripts/Info"
+msgstr "สคริปต์/ข้อมูล"
+
+#: id:12005
+msgid "Fullscreen video"
+msgstr "วิดีโอเต็มจอ"
+
+#: id:12006
+msgid "Audio visualization"
+msgstr "เสียง visualization"
+
+#: id:12008
+msgid "File stacking dialog"
+msgstr "แฟ้ม stacking dialog"
+
+#: id:12009
+msgid "Rebuild index..."
+msgstr "กำลังสร้างดัชนีใหม่..."
+
+#: id:12010
+msgid "Return to music window"
+msgstr "กลับไปยังหน้าต่างเพลง"
+
+#: id:12011
+msgid "Return to videos window"
+msgstr "กลับไปยังหน้าต่างวิดีโอ"
+
+#: id:12021
+msgid "Start from beginning"
+msgstr "เริ่มจากจุดเริ่มต้น"
+
+#: id:12022
+msgid "Resume from %s"
+msgstr "เล่นต่อจาก %s"
+
+#: id:12310
+msgid "0"
+msgstr "0"
+
+#: id:12311
+msgid "1"
+msgstr "1"
+
+#: id:12312
+msgid "2"
+msgstr "2"
+
+#: id:12313
+msgid "3"
+msgstr "3"
+
+#: id:12314
+msgid "4"
+msgstr "4"
+
+#: id:12315
+msgid "5"
+msgstr "5"
+
+#: id:12316
+msgid "6"
+msgstr "6"
+
+#: id:12317
+msgid "7"
+msgstr "7"
+
+#: id:12318
+msgid "8"
+msgstr "8"
+
+#: id:12319
+msgid "9"
+msgstr "9"
+
+#: id:12320
+msgid "c"
+msgstr "c"
+
+#: id:12321
+msgid "Ok"
+msgstr "Ok"
+
+#: id:12322
+msgid "*"
+msgstr "*"
+
+#: id:12325
+msgid "Locked! Enter code..."
+msgstr "ล๊อค! ป้อนรหัส..."
+
+#: id:12326
+msgid "Enter password"
+msgstr "ป้อนรหัสผ่าน"
+
+#: id:12327
+msgid "Enter master code"
+msgstr "ป้อนรหัสหลัก"
+
+#: id:12328
+msgid "Enter unlock code"
+msgstr "ป้อนรหัสเพื่อปลดล๊อค"
+
+#: id:12329
+msgid "or press C to cancel"
+msgstr "หรือกด C เพื่อยกเลิก"
+
+#: id:12330
+msgid "Enter gamepad button combo and"
+msgstr "กดปุ่มคำสั่งผสม(Combo)บนจอยสติ๊กและ"
+
+#: id:12331
+msgid "press OK, or Back to cancel"
+msgstr "กด Start, หรือ Back เพื่อยกเลิก"
+
+#: id:12332
+msgid "Set lock"
+msgstr "ตั้งค่าล๊อค"
+
+#: id:12333
+msgid "Unlock"
+msgstr "ปลดล๊อค"
+
+#: id:12334
+msgid "Reset lock"
+msgstr "ตั้งต่าล๊อคใหม่"
+
+#: id:12335
+msgid "Remove lock"
+msgstr "ลบการล๊อค"
+
+#: id:12337
+msgid "Numeric password"
+msgstr "รหัสผ่านแบบตัวเลข"
+
+#: id:12338
+msgid "Gamepad button combo"
+msgstr "ปุ่มคำสั่งผสม(Combo)บนจอยสติ๊ก"
+
+#: id:12339
+msgid "Full-text password"
+msgstr "รหัสผ่านตัวแบบอักษรล้วน"
+
+#: id:12340
+msgid "Enter new password"
+msgstr "ป้อนรหัสใหม่"
+
+#: id:12341
+msgid "Re-Enter new password"
+msgstr "ป้อนรหัสใหม่อีกครั้ง"
+
+#: id:12342
+msgid "Incorrect password,"
+msgstr "รหัสผานผิด,"
+
+#: id:12343
+msgid "retries left"
+msgstr "ครั้งที่สามารถลองใหม่"
+
+#: id:12344
+msgid "Passwords entered did not match."
+msgstr "รหัสผ่านที่ป้อนไม่ตรง."
+
+#: id:12345
+msgid "Access denied"
+msgstr "ไม่สามารถเข้าถึงได้"
+
+#: id:12346
+msgid "Password retry limit exceeded."
+msgstr "ป้อนรหัสผ่านผิดเกินจำนวนที่จำกัด."
+
+#: id:12347
+msgid "The system will now shut off."
+msgstr "ระบบกำลังจะผิด."
+
+#: id:12348
+msgid "Item locked"
+msgstr "ล๊อครายการ"
+
+#: id:12353
+msgid "Reactivate lock"
+msgstr "ล๊อคอีกครั้ง"
+
+#: id:12356
+msgid "Change lock"
+msgstr "เปลี่ยนล๊อค"
+
+#: id:12357
+msgid "Source lock"
+msgstr "ล๊อคแหล่งข้อมูล"
+
+#: id:12358
+msgid "Password entry was blank. Try again."
+msgstr "รหัสผ่านที่ป้อนว่าง กรุณาป้อนใหม่อีกครั้ง."
+
+#: id:12360
+msgid "Master lock"
+msgstr "ผู้ดูแล"
+
+#: id:12362
+msgid "Shutdown system if Master Lock retries exceeded"
+msgstr "ปิดระบบถ้าป้อนรหัสผิดเกินกำหนด"
+
+#: id:12367
+msgid "Master code is not valid"
+msgstr "โค้ดหลักไม่ถูกต้อง"
+
+#: id:12368
+msgid "Please enter a valid master code"
+msgstr "กรุณาป้อนโค้ดที่ถูกต้อง"
+
+#: id:12373
+msgid "Settings & file manager"
+msgstr "การตั้งค่า & จัดการแฟ้ม"
+
+#: id:12376
+msgid "Set as default for all movies"
+msgstr "ตั้งค่าพื้นฐานสำหรับภาพยนต์ทั้งหมด"
+
+#: id:12377
+msgid "This will reset any previously saved values"
+msgstr "การกระทำนี้จะแก้ไขค่าทั้งหมดก่อนหน้านี้"
+
+#: id:12378
+msgid "Amount of time to display each image"
+msgstr "เวลาที่ใช้ในการแสดงต่อภาพ"
+
+#: id:12379
+msgid "Use pan and zoom effects"
+msgstr "Use pan and zoom effects"
+
+#: id:12383
+msgid "12 hour clock"
+msgstr "12 ชั่วโมง"
+
+#: id:12384
+msgid "24 hour clock"
+msgstr "24 ชั่วโมง"
+
+#: id:12385
+msgid "Day/Month"
+msgstr "วัน/เดือน"
+
+#: id:12386
+msgid "Month/Day"
+msgstr "เดือน/วัน"
+
+#: id:12390
+msgid "System uptime"
+msgstr "เวลาที่ระบบทำงาน"
+
+#: id:12391
+msgid "Minutes"
+msgstr "นาที"
+
+#: id:12392
+msgid "Hours"
+msgstr "ชั่วโมง"
+
+#: id:12393
+msgid "Days"
+msgstr "วัน"
+
+#: id:12394
+msgid "Total uptime"
+msgstr "เวลาทำงานทั้งหมด"
+
+#: id:12395
+msgid "Battery level"
+msgstr ""
+
+#: id:12600
+msgctxt "Auto context with id 12600"
+msgid "Weather"
+msgstr "อากาศ"
+
+#: id:12900
+msgctxt "Auto context with id 12900"
+msgid "Screensaver"
+msgstr "พักหน้าจอ"
+
+#: id:12901
+msgid "Fullscreen OSD"
+msgstr "OSD เต็มจอ"
+
+#: id:13000
+msgid "System"
+msgstr "ระบบ"
+
+#: id:13001
+msgid "Immediate HD spindown"
+msgstr "ลดรอบการหมุนฮาร์ดดิสก์ทันที"
+
+#: id:13002
+msgid "Video only"
+msgstr "วิดีโอเท่านั้น"
+
+#: id:13003
+msgid "- Delay"
+msgstr "- หน่วงเวลา"
+
+#: id:13004
+msgid "- Minimum file duration"
+msgstr "- เวลาน้อยสุดของแฟ้ม"
+
+#: id:13005
+msgid "Shutdown"
+msgstr "ปิดระบบ"
+
+#: id:13008
+msgid "Shutdown function"
+msgstr "การกระทำเมื่อปิด"
+
+#: id:13009
+msgid "Quit"
+msgstr "ออก"
+
+#: id:13010
+msgid "Hibernate"
+msgstr "จำศีล"
+
+#: id:13011
+msgid "Suspend"
+msgstr "หยุดทำงานชั่วคราว"
+
+#: id:13012
+msgid "Exit"
+msgstr "ออก"
+
+#: id:13013
+msgid "Reboot"
+msgstr "เริ่มระบบใหม่"
+
+#: id:13014
+msgid "Minimize"
+msgstr "ย่อเก็บ"
+
+#: id:13015
+msgid "Power button action"
+msgstr "การกระทำของปุ่มปิด"
+
+#: id:13016
+msgid "Power off System"
+msgstr ""
+
+#: id:13020
+msgid "Is another session active, perhaps over ssh?"
+msgstr "เซสชั่นอื่นทำงานอยู่หรือไม่, หรืออาจจะเป็น ssh?"
+
+#: id:13021
+msgid "Mounted removable harddrive"
+msgstr "เมานท์ฮาร์ดดิสก์ภายนอก"
+
+#: id:13022
+msgid "Unsafe device removal"
+msgstr "การเอาอุปกรณ์ออกอย่างไม่ปลอดภัย"
+
+#: id:13023
+msgid "Successfully removed device"
+msgstr "เอาอุปกร์ออกเรียบร้อยแล้ว"
+
+#: id:13024
+msgid "Joystick plugged"
+msgstr "เชื่อมต่อจอยสติ๊ก"
+
+#: id:13025
+msgid "Joystick unplugged"
+msgstr "ถอดจอยสติ๊ก"
+
+#: id:13050
+msgid "Running low on battery"
+msgstr ""
+
+#: id:13100
+msgid "Flicker filter"
+msgstr "ตัวกรอง Flicker"
+
+#: id:13101
+msgid "Let driver choose (requires restart)"
+msgstr "ให้ไดร์ฟเวอร์เลือก(ต้องการเริ่มการทำงานใหม่)"
+
+#: id:13105
+msgid "Vertical blank sync"
+msgstr "Vertical blank sync"
+
+#: id:13106
+msgctxt "Auto context with id 13106"
+msgid "Disabled"
+msgstr "ปิดใช้งาน"
+
+#: id:13107
+msgid "Enabled during video playback"
+msgstr "เปิดใช้งานระหว่างการเล่นวิดีโอ"
+
+#: id:13108
+msgctxt "Auto context with id 13108"
+msgid "Always enabled"
+msgstr "เปิดใช้งานเสมอ"
+
+#: id:13109
+msgid "Test & apply resolution"
+msgstr "ทดสอบ & นำความละเอียดหน้าจอไปใช้"
+
+#: id:13110
+msgid "Save resolution?"
+msgstr "จัดเก็บความละเอียดหน้าจอ?"
+
+#: id:13111
+msgid "Would you like to keep this resolution?"
+msgstr "คุณต้องการที่จะจัดเก็บความละเอียดนี้ใช่หรือไม่?"
+
+#: id:13112
+msgid "High quality upscaling"
+msgstr "คุณภาพสูง upscaling"
+
+#: id:13113
+msgctxt "Auto context with id 13113"
+msgid "Disabled"
+msgstr "ปิดใช้งาน"
+
+#: id:13114
+msgid "Enabled for SD content"
+msgstr "เปิดใช้งานข้อมูล SD"
+
+#: id:13115
+msgctxt "Auto context with id 13115"
+msgid "Always enabled"
+msgstr "เปิดใช้งานเสมอ"
+
+#: id:13116
+msgid "Upscaling method"
+msgstr "Upscaling method"
+
+#: id:13117
+msgctxt "Auto context with id 13117"
+msgid "Bicubic"
+msgstr "Bicubic"
+
+#: id:13118
+msgid "Lanczos"
+msgstr "Lanczos"
+
+#: id:13119
+msgid "Sinc"
+msgstr "Sinc"
+
+#: id:13120
+msgctxt "Auto context with id 13120"
+msgid "VDPAU"
+msgstr "VDPAU"
+
+#: id:13121
+msgid "VDPAU HQ Upscaling level"
+msgstr "VDPAU HQ Upscaling level"
+
+#: id:13122
+msgid "VDPAU Studio level color conversion"
+msgstr "VDPAU Studio level color conversion"
+
+#: id:13130
+msgid "Blank other displays"
+msgstr "ยกเลิกการแสดงผลที่จออื่น"
+
+#: id:13131
+msgctxt "Auto context with id 13131"
+msgid "Disabled"
+msgstr "ปิดการใช้งาน"
+
+#: id:13132
+msgid "Blank displays"
+msgstr "ปิดากรแสดงผล"
+
+#: id:13140
+msgid "Active connections detected!"
+msgstr "ทำงานการเชื่อมต่อที่ตรวจพบ!"
+
+#: id:13141
+msgid "If you proceed, you might not be able to control XBMC"
+msgstr "ถ้าคุณดำเนินการแล้ว, คุณอาจไม่สามารถควบคุม XBMC ได้"
+
+#: id:13142
+msgid "any longer. Are you sure you want to stop the Event server?"
+msgstr "อย่างไรก้อตาม คุณต้องการที่จะหยุดการดำเนินการหรือไม่?"
+
+#: id:13144
+msgid "Change Apple Remote mode?"
+msgstr "เปลี่ยนโหมดแอปเปิ้ลรีโมท?"
+
+#: id:13145
+msgid "If you are currently using the Apple Remote to control"
+msgstr "ถ้าคุณกำลังใช้ Apple Remote ควบคุม"
+
+#: id:13146
+msgid "XBMC, changing this setting might affect your ability"
+msgstr "XBMC, การเปลี่ยนการตั้งค่าจะมีผลต่อความสามารถ"
+
+#: id:13147
+msgid "to continue controlling it. Do you want to proceed?"
+msgstr "ในการควบคุมต่อไป. คุณต้องการดำเนินการหรือไม่?"
+
+#: id:13159
+msgid "Subnet mask"
+msgstr "Subnet mask"
+
+#: id:13160
+msgid "Gateway"
+msgstr "Gateway"
+
+#: id:13161
+msgid "Primary DNS"
+msgstr "Primary DNS"
+
+#: id:13162
+msgid "Initialize failed"
+msgstr "การเตรียมการล้มเหลว"
+
+#: id:13170
+msgctxt "Auto context with id 13170"
+msgid "Never"
+msgstr "ไม่เคย"
+
+#: id:13171
+msgid "Immediately"
+msgstr "ทันที"
+
+#: id:13172
+msgid "After %i secs"
+msgstr "หลังจาก %i วินาที"
+
+#: id:13173
+msgid "HDD install date:"
+msgstr "วันที่ติดตั้งฮาร์ดดิสก์:"
+
+#: id:13174
+msgid "HDD power cycle count:"
+msgstr "ฮาร์ดดิสก์ power cycle count:"
+
+#: id:13200
+msgid "Profiles"
+msgstr "ข้อมูลส่วนตัว"
+
+#: id:13201
+msgid "Delete profile '%s'?"
+msgstr "ลบข้อมูลส่วนตัว '%s'?"
+
+#: id:13204
+msgid "Last loaded profile:"
+msgstr "ครั้งสุดท้ายที่เรียกใช้ข้อมูลส่วนตัว:"
+
+#: id:13205
+msgid "Unknown"
+msgstr "ไม่รู้จัก"
+
+#: id:13206
+msgid "Overwrite"
+msgstr "เขียนทับ"
+
+#: id:13208
+msgid "Alarm clock"
+msgstr "นาฬิกาปลุก"
+
+#: id:13209
+msgid "Alarm clock interval (in minutes)"
+msgstr "ระยะห่างในากรปลุก(นาที)"
+
+#: id:13210
+msgid "Started, alarm in %im"
+msgstr "เริ่มต้น, ปลุกใน %im"
+
+#: id:13211
+msgid "Alarm!"
+msgstr "ปลุก!"
+
+#: id:13212
+msgid "Canceled with %im%is left"
+msgstr "ยกเลิกเวลาที่เหลือ %im%is"
+
+#: id:13213
+msgid "%2.0fm"
+msgstr ""
+
+#: id:13214
+msgid "%2.0fs"
+msgstr ""
+
+#: id:13249
+msgid "Search for subtitles in RARs"
+msgstr "ค้นหาซับไตเติ้ลในแฟ้ม RARs"
+
+#: id:13250
+msgid "Browse for subtitle..."
+msgstr "เรียกดูซับไตเติ้ล..."
+
+#: id:13251
+msgid "Move item"
+msgstr "ย้ายรายการ"
+
+#: id:13252
+msgid "Move item here"
+msgstr "ย้ายมาที่นี่"
+
+#: id:13253
+msgid "Cancel move"
+msgstr "ยกเลิกการย้าย"
+
+#: id:13270
+msgid "Hardware:"
+msgstr "ฮาร์ดแวร์:"
+
+#: id:13271
+msgid "CPU Usage:"
+msgstr "ซีพียูที่ใช้:"
+
+#: id:13274
+msgid "Connected, but no DNS is available."
+msgstr "เชื่อมต่อแล้ว แต่ไม่มี DNS."
+
+#: id:13275
+msgid "Hard Disk"
+msgstr "ฮาร์ดดิสก์"
+
+#: id:13276
+msgid "DVD-ROM"
+msgstr "ดีวีดีรอม"
+
+#: id:13277
+msgctxt "Auto context with id 13277"
+msgid "Storage"
+msgstr "หน่วยเก็บข้อมูล"
+
+#: id:13278
+msgctxt "Auto context with id 13278"
+msgid "Default"
+msgstr "ค่าพื้นฐาน"
+
+#: id:13279
+msgctxt "Auto context with id 13279"
+msgid "Network"
+msgstr "เครือข่าย"
+
+#: id:13280
+msgctxt "Auto context with id 13280"
+msgid "Video"
+msgstr "วิดีโอ"
+
+#: id:13281
+msgid "Hardware"
+msgstr "ฮาร์ดแวร์"
+
+#: id:13283
+msgid "Operating system:"
+msgstr "ระบบปฏิบัติการ:"
+
+#: id:13284
+msgid "CPU speed:"
+msgstr "ความเร็วซีพียู:"
+
+#: id:13286
+msgid "Video encoder:"
+msgstr "ตัวถอดรหัสวิดีโอ:"
+
+#: id:13287
+msgid "Screen resolution:"
+msgstr "ความละเอียดหน้าจอ:"
+
+#: id:13292
+msgid "A/V cable:"
+msgstr "A/V cable:"
+
+#: id:13294
+msgid "DVD region:"
+msgstr "DVD region:"
+
+#: id:13295
+msgid "Internet:"
+msgstr "อินเตอร์เน็ต:"
+
+#: id:13296
+msgctxt "Auto context with id 13296"
+msgid "Connected"
+msgstr "เชื่อมต่อแล้ว"
+
+#: id:13297
+msgid "Not connected. Check network settings."
+msgstr "ยังไม่เชื่อมต่อ ตรวจสอบการตั้งค่าเครือข่าย."
+
+#: id:13299
+msgid "Target temperature"
+msgstr "อุณหภูมิเป้าหมาย"
+
+#: id:13300
+msgid "Fan speed"
+msgstr "ความเร็วพัดลม"
+
+#: id:13301
+msgid "Auto temperature control"
+msgstr "ควบคุมอุณภูมิอัตโนมัติ"
+
+#: id:13302
+msgid "Fan speed override"
+msgstr "แทนที่ความเร็วพัดลม"
+
+#: id:13303
+msgid "- Fonts"
+msgstr "- ตัวอักษร"
+
+#: id:13304
+msgid "Enable flipping bi-directional strings"
+msgstr "Enable flipping bi-directional strings"
+
+#: id:13305
+msgid "Show RSS news feeds"
+msgstr "แสดงข่าว RSS"
+
+#: id:13306
+msgid "Show parent folder items"
+msgstr "แสดงโฟลเดอร์หลัก"
+
+#: id:13307
+msgid "Track naming template"
+msgstr "แม่แบบชื่อเพลง"
+
+#: id:13308
+msgid "Do you wish to reboot your system"
+msgstr "คุณต้องการจะเริ่มระบบใหม่หรือไม่"
+
+#: id:13309
+msgid "instead of just XBMC?"
+msgstr "แทนที่เฉพาะ XBMC?"
+
+#: id:13310
+msgid "Zoom effect"
+msgstr "ซูม"
+
+#: id:13311
+msgid "Float effect"
+msgstr "ลอย"
+
+#: id:13312
+msgid "Black bar reduction"
+msgstr "การลดแถบสีดำ"
+
+#: id:13313
+msgid "Restart"
+msgstr "เริ่มระบบใหม่"
+
+#: id:13314
+msgid "Crossfade between songs"
+msgstr "ครอสเฟดระหว่างเพลง"
+
+#: id:13315
+msgid "Regenerate thumbnails"
+msgstr "สร้างรูปย่ออีกครั้ง"
+
+#: id:13316
+msgid "Recursive thumbnails"
+msgstr "Recursive thumbnails"
+
+#: id:13317
+msgid "View slideshow"
+msgstr "ดูไสลด์โชว์"
+
+#: id:13318
+msgid "Recursive slideshow"
+msgstr "การเรียกสไลด์โชว์ซ้ำ"
+
+#: id:13319
+msgid "Randomize"
+msgstr "สุ่มลำกับ"
+
+#: id:13320
+msgid "Stereo"
+msgstr "สเตอริโอ"
+
+#: id:13321
+msgid "Left only"
+msgstr "ซ้านเท่านั้น"
+
+#: id:13322
+msgid "Right only"
+msgstr "ขวาเท่านั้น"
+
+#: id:13323
+msgid "Enable karaoke support"
+msgstr "เปิดใช้งานสนับสนุนคาราโอเกะ"
+
+#: id:13324
+msgid "Background transparency"
+msgstr "พื้นหลังโปร่งใส"
+
+#: id:13325
+msgid "Foreground transparency"
+msgstr "พื้นหน้าโปร่งแสง"
+
+#: id:13326
+msgid "A/V delay"
+msgstr "หน่วงเวลา A/V"
+
+#: id:13327
+msgid "Karaoke"
+msgstr "คาราโอเกะ"
+
+#: id:13328
+msgid "%s not found"
+msgstr "%s ไม่พบ"
+
+#: id:13329
+msgid "Error opening %s"
+msgstr "เปิด %s ผิดพลาด"
+
+#: id:13330
+msgid "Unable to load %s"
+msgstr "ไม่สามารถโหลด %s"
+
+#: id:13331
+msgid "Error: Out of memory"
+msgstr "ผิดพลาด: หน่วยความจำไม่พอ"
+
+#: id:13332
+msgid "Move up"
+msgstr "ย้ายขึ้น"
+
+#: id:13333
+msgid "Move down"
+msgstr "ย้ายลง"
+
+#: id:13334
+msgid "Edit label"
+msgstr "แก้ป้ายชื่อ"
+
+#: id:13335
+msgid "Make default"
+msgstr "คืนค่าเดิม"
+
+#: id:13336
+msgid "Remove button"
+msgstr "ลบปุ่ม"
+
+#: id:13340
+msgid "Leave as is"
+msgstr "คงค่าเดิม"
+
+#: id:13341
+msgid "Green"
+msgstr "เขียว"
+
+#: id:13342
+msgid "Orange"
+msgstr "ส้ม"
+
+#: id:13343
+msgid "Red"
+msgstr "แดง"
+
+#: id:13344
+msgid "Cycle"
+msgstr "วงกลม"
+
+#: id:13345
+msgid "Switch LED off on playback"
+msgstr "ปิด LED ขณะเล่น"
+
+#: id:13346
+msgctxt "Auto context with id 13346"
+msgid "Movie information"
+msgstr "ข้อมูลภาพยนต์"
+
+#: id:13347
+msgid "Queue item"
+msgstr "เพิ่มลงรายการที่จะเล่น"
+
+#: id:13348
+msgid "Search IMDb..."
+msgstr "ค้นหา IMDb..."
+
+#: id:13349
+msgid "Scan for new content"
+msgstr "สำรวจหาข้อมูลใหม่"
+
+#: id:13350
+msgid "Now playing..."
+msgstr "กำลังเล่น..."
+
+#: id:13351
+msgctxt "Auto context with id 13351"
+msgid "Album information"
+msgstr "ข้อมูลอัลบั้ม"
+
+#: id:13352
+msgid "Scan item to library"
+msgstr "สำรวจรายการไปยังคลังข้อมูล"
+
+#: id:13353
+msgid "Stop scanning"
+msgstr "หยุดสำรวจ"
+
+#: id:13354
+msgctxt "Auto context with id 13354"
+msgid "Render method"
+msgstr "วิธีการเรนเดอร์"
+
+#: id:13355
+msgid "Low quality pixel shader"
+msgstr "แรเงาพิกเซลคุณภาพต่ำ"
+
+#: id:13356
+msgid "Hardware overlays"
+msgstr "Hardware overlays"
+
+#: id:13357
+msgid "High quality pixel shader"
+msgstr "แรเงาพิกเซลคุณภาพสูง"
+
+#: id:13358
+msgid "Play item"
+msgstr "เล่นรายการ"
+
+#: id:13359
+msgid "Set artist thumb"
+msgstr "ตั้งรูปย่อ"
+
+#: id:13360
+msgid "Automatically generate thumbnails"
+msgstr "สร้างรูปย่ออัตโนมัติ"
+
+#: id:13361
+msgid "Enable voice"
+msgstr "เปิดใช้เสียง"
+
+#: id:13375
+msgid "Enable device"
+msgstr "เปิดใช้อุปกรณ์"
+
+#: id:13376
+msgid "Volume"
+msgstr "เสียง"
+
+#: id:13377
+msgid "Default view mode"
+msgstr "มุมมองมาตรฐาน"
+
+#: id:13378
+msgid "Default brightness"
+msgstr "ความสว่างมาตรฐาน"
+
+#: id:13379
+msgid "Default contrast"
+msgstr "ความต่างระดับสีมาตรฐาน"
+
+#: id:13380
+msgid "Default gamma"
+msgstr "แกมม่ามาตรฐาน"
+
+#: id:13381
+msgid "Resume video"
+msgstr "เล่นวิดีโอต่อ"
+
+#: id:13382
+msgid "Voice mask - Port 1"
+msgstr "Voice mask - พอร์ต 1"
+
+#: id:13383
+msgid "Voice mask - Port 2"
+msgstr "Voice mask - พอร์ต 2"
+
+#: id:13384
+msgid "Voice mask - Port 3"
+msgstr "Voice mask - พอร์ต 3"
+
+#: id:13385
+msgid "Voice mask - Port 4"
+msgstr "Voice mask - พอร์ต 4"
+
+#: id:13386
+msgid "Use time based seeking"
+msgstr "ใช่เวลาค้นหา"
+
+#: id:13387
+msgid "Track naming template - right"
+msgstr "แม่แบบการตั้งชื่อ - ขวา"
+
+#: id:13388
+msgid "Preset"
+msgstr "ค่าที่กำหนดไว้"
+
+#: id:13389
+msgid "There are no presets available\nfor this visualization"
+msgstr "ไม่มีค่าที่กำหนดไว้ สำหรับ visualization นี้"
+
+#: id:13390
+msgid "There are no settings available\nfor this visualization"
+msgstr "ไม่มีการตั้งค่า สำหรับ visualization นี้"
+
+#: id:13391
+msgid "Eject/Load"
+msgstr "เปิด/ปิด"
+
+#: id:13392
+msgid "Use visualization if playing audio"
+msgstr "ใช้ visualization ถ้ากำลังเล่นเสียง"
+
+#: id:13393
+msgid "Calculate size"
+msgstr "คำนวณขนาด"
+
+#: id:13394
+msgid "Calculating folder size"
+msgstr "คำนวณขนาดโฟลเดอร์"
+
+#: id:13395
+msgid "Video settings"
+msgstr "วิดีโอ การตั้งค่า"
+
+#: id:13396
+msgid "Audio and subtitle settings"
+msgstr "การตั้งค่าเสียงและซับไตเติ้ล"
+
+#: id:13397
+msgid "Enable subtitles"
+msgstr "ใช้งานซับไตเติ้ล"
+
+#: id:13398
+msgctxt "Auto context with id 13398"
+msgid "Shortcuts"
+msgstr "ปุ่มลัด"
+
+#: id:13399
+msgid "Ignore articles when sorting (e.g. \"the\")"
+msgstr "ยกเว้นคำนำหน้าเมื่อเรียงลำดับ(เช่น \"the\")"
+
+#: id:13400
+msgid "Crossfade between songs on the same album"
+msgstr "ครอสเฟดเพลงในอัลบั้มเดียวกัน"
+
+#: id:13401
+msgid "Browse for %s"
+msgstr "เรียกดู %s"
+
+#: id:13402
+msgid "Show track position"
+msgstr "แสดงตำแหน่งเพลง"
+
+#: id:13403
+msgid "Clear default"
+msgstr "เคลียร์ค่ามาตรฐาน"
+
+#: id:13404
+msgid "Resume"
+msgstr "เล่นต่อ"
+
+#: id:13405
+msgid "Get thumb"
+msgstr "รับรูปย่อ"
+
+#: id:13406
+msgid "Picture information"
+msgstr "ข้อมูลรูปภาพ"
+
+#: id:13407
+msgid "%s presets"
+msgstr "%s แม่แบบ"
+
+#: id:13408
+msgid "(IMDb user rating)"
+msgstr "(IMDb user ratting)"
+
+#: id:13409
+msgid "Top 250"
+msgstr "Top 250"
+
+#: id:13410
+msgid "Tune in on Last.fm"
+msgstr "Tune in on Last.fm"
+
+#: id:13411
+msgid "Minimum fan speed"
+msgstr "ความเร็วพัดลมต่ำสุด"
+
+#: id:13412
+msgid "Play from here"
+msgstr ""
+
+#: id:13413
+msgid "Downloading"
+msgstr "กำลังดาวน์โหลด"
+
+#: id:13414
+msgid "Include artists who appear only on compilations"
+msgstr ""
+
+#: id:13415
+msgctxt "Auto context with id 13415"
+msgid "Render method"
+msgstr "วิธีการเรนเดอร์"
+
+#: id:13416
+msgid "Auto detect"
+msgstr "ค้นหาอัตโนมัติ"
+
+#: id:13417
+msgid "Basic shaders (ARB)"
+msgstr "shaders พื้นฐาน(ARB)"
+
+#: id:13418
+msgid "Advanced shaders (GLSL)"
+msgstr "shaders ขั้นสูง(GLSL)"
+
+#: id:13419
+msgid "Software"
+msgstr "ซอฟแวร์"
+
+#: id:13420
+msgid "Remove safely"
+msgstr "ถอดแบบปลอดภัย"
+
+#: id:13421
+msgctxt "Auto context with id 13421"
+msgid "VDPAU"
+msgstr "VDPAU"
+
+#: id:13422
+msgid "Start slideshow here"
+msgstr "เริ่มแสดงสไลด์ที่นี่"
+
+#: id:13423
+msgid "Remember for this path"
+msgstr "จดจำเส้นทางนี้"
+
+#: id:13424
+msgid "Use pixel buffer objects"
+msgstr ""
+
+#: id:13425
+msgid "Allow hardware acceleration (VDPAU)"
+msgstr ""
+
+#: id:13426
+msgid "Allow hardware acceleration (VAAPI)"
+msgstr ""
+
+#: id:13427
+msgid "Allow hardware acceleration (DXVA2)"
+msgstr ""
+
+#: id:13428
+msgid "Allow hardware acceleration (CrystalHD)"
+msgstr ""
+
+#: id:13429
+msgid "Allow hardware acceleration (VDADecoder)"
+msgstr ""
+
+#: id:13430
+msgid "Allow hardware acceleration (OpenMax)"
+msgstr ""
+
+#: id:13431
+msgid "Pixel Shaders"
+msgstr ""
+
+#: id:13432
+msgid "Allow hardware acceleration (VideoToolbox)"
+msgstr ""
+
+#: id:13500
+msgid "A/V sync method"
+msgstr "A/V sync method"
+
+#: id:13501
+msgid "Audio clock"
+msgstr "ความถี่เสียง"
+
+#: id:13502
+msgid "Video clock (Drop/Dupe audio)"
+msgstr "ความถี่วิดีโอ (Drop/Dupe audio)"
+
+#: id:13503
+msgid "Video clock (Resample audio)"
+msgstr "ความถี่วิดีโอ (Resample audio)"
+
+#: id:13504
+msgid "Maximum resample amount (%)"
+msgstr "Maximum resample amount (%)"
+
+#: id:13505
+msgid "Resample quality"
+msgstr "คุณภาพ Resample"
+
+#: id:13506
+msgid "Low(fast)"
+msgstr "ต่ำ(เร็ว)"
+
+#: id:13507
+msgctxt "Auto context with id 13507"
+msgid "Medium"
+msgstr "ปานกลาง"
+
+#: id:13508
+msgctxt "Auto context with id 13508"
+msgid "High"
+msgstr "สูง"
+
+#: id:13509
+msgid "Really high(slow!)"
+msgstr "สูงมาก(ช้า!)"
+
+#: id:13510
+msgid "Sync playback to display"
+msgstr "การเล่นเพลงพร้อมกับการแสดงผล"
+
+#: id:13550
+msgid "Pause during refresh rate change"
+msgstr ""
+
+#: id:13551
+msgctxt "Auto context with id 13551"
+msgid "Off"
+msgstr ""
+
+#: id:13552
+msgid "%.1f Second"
+msgstr ""
+
+#: id:13553
+msgid "%.1f Seconds"
+msgstr ""
+
+#: id:13600
+msgid "Apple remote"
+msgstr "Apple รีโมท"
+
+#: id:13602
+msgid "Allow start of XBMC using the remote"
+msgstr "อนุญาตเริ่มการใช้งานด้วยรีโมท"
+
+#: id:13603
+msgid "Sequence delay time"
+msgstr "รอบการหน่วงเวลา"
+
+#: id:13610
+msgctxt "Auto context with id 13610"
+msgid "Disabled"
+msgstr "ปิดการใช้งาน"
+
+#: id:13611
+msgctxt "Auto context with id 13611"
+msgid "Standard"
+msgstr "มาตรฐาน"
+
+#: id:13612
+msgid "Universal Remote"
+msgstr "รีโมทสากล"
+
+#: id:13613
+msgid "Multi Remote (Harmony)"
+msgstr "Multi Remote (Harmony)"
+
+#: id:13620
+msgid "Apple Remote Error"
+msgstr "Apple รีโมทผิดพลาด"
+
+#: id:13621
+msgid "Apple Remote support could be enabled."
+msgstr "Apple รีโมทเปิดการสนับสนุนผิดพลาด."
+
+#: id:14000
+msgid "Stack"
+msgstr "ซ้อน"
+
+#: id:14001
+msgid "Unstack"
+msgstr "ยกเลิกการซ้อน"
+
+#: id:14003
+msgid "Downloading playlist file..."
+msgstr "กำลังโหลดแฟ้มรายการเพลง..."
+
+#: id:14004
+msgid "Downloading streams list..."
+msgstr "กำลังโหลด streams list..."
+
+#: id:14005
+msgid "Parsing streams list..."
+msgstr "Parsing streams list..."
+
+#: id:14006
+msgid "Downloading streams list failed"
+msgstr "ไม่สามารถโหลด streams list"
+
+#: id:14007
+msgid "Downloading playlist file failed"
+msgstr "ไม่สามารถโหลดแฟ้มรายการเพลง"
+
+#: id:14009
+msgid "Games directory"
+msgstr "เกมส์ไดเรกทอรี"
+
+#: id:14010
+msgid "Auto switch to thumbs based on"
+msgstr "สลับใช้รูปย่ออัตโนมัติ"
+
+#: id:14011
+msgid "Enable auto switching to thumbs view"
+msgstr "ใช้งานสลับไปใช้รูปย่ออัตโนมัติ"
+
+#: id:14012
+msgid "- Use large icons"
+msgstr "- ใช้ไอคอนขนาดใหญ่"
+
+#: id:14013
+msgid "- Switch based on"
+msgstr "- ขึ้นกับการสลับ"
+
+#: id:14014
+msgid "- Percentage"
+msgstr "- เปอร์เซนต์"
+
+#: id:14015
+msgid "No files and at least one thumb"
+msgstr "ไม่มีรูปย่ออัตโนมัติ"
+
+#: id:14016
+msgid "At least one file and thumb"
+msgstr "อย่างน้อยหนึ่งแฟ้มและรูปย่อ"
+
+#: id:14017
+msgid "Percentage of thumbs"
+msgstr "เปอร์เซ็นต์ของรูปย่อ"
+
+#: id:14018
+msgid "View options"
+msgstr "ตัวเลือกการดู"
+
+#: id:14019
+msgid "Change area code 1"
+msgstr "เปลี่ยนรหัสพื้นที่ 1"
+
+#: id:14020
+msgid "Change area code 2"
+msgstr "เปลี่ยนรหัสพื้นที่ 2"
+
+#: id:14021
+msgid "Change area code 3"
+msgstr "เปลี่ยนรหัสพื้นที่ 3"
+
+#: id:14022
+msgctxt "Auto context with id 14022"
+msgid "Library"
+msgstr "คลังข้อมูล"
+
+#: id:14023
+msgid "No TV"
+msgstr "ไม่มี TV"
+
+#: id:14024
+msgid "Enter the nearest large town"
+msgstr "ป้อนเมืองขนาดใหญ่ที่อยู่ใกล้ที่สุด"
+
+#: id:14025
+msgid "Video/Audio/DVD cache - Harddisk"
+msgstr "วิดีโอ/เสียง/ดีวีดี แคช - ฮาร์ดดิสก์"
+
+#: id:14026
+msgid "Video cache - DVD-ROM"
+msgstr "วิดีโอ แคช - ดีวีดี รอม"
+
+#: id:14027
+msgctxt "Auto context with id 14027"
+msgid "- Local Network"
+msgstr "- เครือข่ายท้องถิ่น"
+
+#: id:14028
+msgctxt "Auto context with id 14028"
+msgid "- Internet"
+msgstr "- อินเตอร์เน็ต"
+
+#: id:14030
+msgid "Audio cache - DVD-ROM"
+msgstr "แคชเสียง - ดีวีดี รอม"
+
+#: id:14031
+msgctxt "Auto context with id 14031"
+msgid "- Local Network"
+msgstr "- เครือข่ายท้องถิ่น"
+
+#: id:14032
+msgctxt "Auto context with id 14032"
+msgid "- Internet"
+msgstr "- อินเตอร์เน็ต"
+
+#: id:14034
+msgid "DVD cache - DVD-ROM"
+msgstr "ดีวีดี แคช - ดีวีดี รอม"
+
+#: id:14035
+msgctxt "Auto context with id 14035"
+msgid "- Local Network"
+msgstr "- เครือข่ายท้องถิ่น"
+
+#: id:14036
+msgctxt "Auto context with id 14036"
+msgid "Services"
+msgstr "บริการ"
+
+#: id:14038
+msgid "Network settings changed"
+msgstr "กาารตั้งค่าเครือข่ายเปลี่ยนแปลง"
+
+#: id:14039
+msgid "XBMC requires to restart to change your"
+msgstr "XBMC ต้องการเริ่มต้นการทำงานใหม่เพื่อเปลี่ยนการตั้งค่า"
+
+#: id:14040
+msgid "network setup. Would you like to restart now?"
+msgstr "เครือข่ายคุณต้องการเริ่มต้องการทำงานใหม่อีกครั้ง?"
+
+#: id:14041
+msgid "Internet connection bandwidth limitation"
+msgstr "การประมวลผลหลัง"
+
+#: id:14043
+msgid "- Shutdown while playing"
+msgstr "- ปิดเครื่องระหว่างเล่นเพลง"
+
+#: id:14044
+msgid "%i min"
+msgstr "%i นาที"
+
+#: id:14045
+msgid "%i sec"
+msgstr "%i วินาที"
+
+#: id:14046
+msgid "%i ms"
+msgstr "%i มิลลิวินาที"
+
+#: id:14047
+msgid "%i %%"
+msgstr "%i %%"
+
+#: id:14048
+msgid "%i kbps"
+msgstr "%i kbps"
+
+#: id:14049
+msgid "%i kb"
+msgstr "%i kb"
+
+#: id:14050
+msgid "%i.0 dB"
+msgstr "%i.0 dB"
+
+#: id:14051
+msgid "Time format"
+msgstr "รูปแบบเวลา"
+
+#: id:14052
+msgid "Date format"
+msgstr "รูปแบบวันที่"
+
+#: id:14053
+msgid "GUI filters"
+msgstr "GUI filters"
+
+#: id:14055
+msgid "Use background scanning"
+msgstr "ใช้การสำรวจแบบเบื้องหลัง"
+
+#: id:14056
+msgid "Stop scan"
+msgstr "หยุดการสำรวจ"
+
+#: id:14057
+msgid "Not possible while scanning for media info"
+msgstr "เป็นไปไม่ได้ระหว่างสำรวจข้อมูลสื่อ"
+
+#: id:14058
+msgid "Film grain effect"
+msgstr "Film grain effect"
+
+#: id:14059
+msgid "Search for thumbnails on remote shares"
+msgstr "ค้นหารูปย่อบนเครือข่าย"
+
+#: id:14060
+msgid "Unknown type cache - Internet"
+msgstr "ไม่ทราบชนิดแคช - อินเตอร์เน็ต"
+
+#: id:14061
+msgctxt "Auto context with id 14061"
+msgid "Auto"
+msgstr "อัตโนมัติ"
+
+#: id:14062
+msgid "Enter username for"
+msgstr "ป้อนรหัสผ่านสำหรับ"
+
+#: id:14063
+msgid "Date & time"
+msgstr "วันที่ & เวลา"
+
+#: id:14064
+msgid "Set date"
+msgstr "ตั้งวันที่"
+
+#: id:14065
+msgid "Set time"
+msgstr "ตั้งเวลา"
+
+#: id:14066
+msgid "Enter the time in 24 hour HH:MM format"
+msgstr "ป้อนเวลาในรูปแบบ 24 ชั่วโมง(HH:MM)"
+
+#: id:14067
+msgid "Enter the date in DD/MM/YYYY format"
+msgstr "ป้อนวันที่ในรูปแบบ DD/MM/YYYY"
+
+#: id:14068
+msgid "Enter the IP address"
+msgstr "ป้อนที่อยู่อินเตอร์เน็ต"
+
+#: id:14069
+msgid "Apply these settings now?"
+msgstr "จัดเก็บการตั้งค่าปัจจุบัน?"
+
+#: id:14070
+msgid "Apply changes now"
+msgstr "ใช้การตั้งค่าปัจจุบัน"
+
+#: id:14071
+msgid "Allow file renaming and deletion"
+msgstr "อนุญาตเปลี่ยนชื่อและลบ"
+
+#: id:14074
+msgid "Set timezone"
+msgstr "ตั้งโซนเวลา"
+
+#: id:14075
+msgid "Use daylight saving time"
+msgstr "Use daylight saving time"
+
+#: id:14076
+msgid "Add to favourites"
+msgstr "เพิ่มที่ชื่นชอบ"
+
+#: id:14077
+msgid "Remove from favourites"
+msgstr "ลบที่ชื่นชอบ"
+
+#: id:14078
+msgctxt "Auto context with id 14078"
+msgid "- Colours"
+msgstr "- สี"
+
+#: id:14079
+msgid "Timezone country"
+msgstr "โซนเวลาประเทศ"
+
+#: id:14080
+msgid "Timezone"
+msgstr "โซนเวลา"
+
+#: id:14081
+msgid "File lists"
+msgstr "รายการแฟ้ม"
+
+#: id:14082
+msgid "Show EXIF picture information"
+msgstr "แสดงข้อมูลภาพ EXIF"
+
+#: id:14083
+msgid "Use a fullscreen window rather than true fullscreen"
+msgstr "ใช้หน้าต่างเต็มจอมากกว่าการแสเงผลเต็มจอจริง"
+
+#: id:14084
+msgid "Queue songs on selection"
+msgstr "จัดลำดับเพลงเมื่อเลือก"
+
+#: id:14086
+msgid "Playback"
+msgstr "เล่นเพลง"
+
+#: id:14087
+msgid "DVDs"
+msgstr "ดีวีดี"
+
+#: id:14088
+msgid "Play DVDs automatically"
+msgstr "เล่นดีวีดีอัตโนมัติ"
+
+#: id:14089
+msgid "Font to use for text subtitles"
+msgstr "ตัวอักษรใช้สำหรับซับไตเติ้ล"
+
+#: id:14090
+msgid "International"
+msgstr "International"
+
+#: id:14091
+msgid "Character set"
+msgstr "ชุดอักขระ"
+
+#: id:14092
+msgid "Debugging"
+msgstr "แก้จุดบกพร่อง"
+
+#: id:14093
+msgid "Security"
+msgstr "ความปลอดภัย"
+
+#: id:14094
+msgid "Input devices"
+msgstr "อุปกรณ์นำเข้า"
+
+#: id:14095
+msgid "Power saving"
+msgstr "ประหยัดพลังงาน"
+
+#: id:14096
+msgid "Rip"
+msgstr ""
+
+#: id:14097
+msgid "Audio CD Insert Action"
+msgstr ""
+
+#: id:14098
+msgctxt "Auto context with id 14098"
+msgid "Play"
+msgstr ""
+
+#: id:14099
+msgid "Eject disc when CD ripping is complete"
+msgstr ""
+
+#: id:15015
+msgctxt "Auto context with id 15015"
+msgid "Remove"
+msgstr "ลบ"
+
+#: id:15016
+msgid "Games"
+msgstr "เกม"
+
+#: id:15019
+msgid "Add"
+msgstr "เพิ่ม"
+
+#: id:15052
+msgid "Password"
+msgstr "รหัสผ่าน"
+
+#: id:15100
+msgctxt "Auto context with id 15100"
+msgid "Library"
+msgstr "คลังข้อมูล"
+
+#: id:15101
+msgid "Database"
+msgstr "ฐานข้อมูล"
+
+#: id:15102
+msgid "* All albums"
+msgstr "* อัลบั้มทั้งหมด"
+
+#: id:15103
+msgid "* All artists"
+msgstr "* นักร้องทั้งหมด"
+
+#: id:15104
+msgid "* All songs"
+msgstr "* เพลงทั้งหมด"
+
+#: id:15105
+msgid "* All genres"
+msgstr "* ประเภททั้งหมด"
+
+#: id:15107
+msgid "Buffering..."
+msgstr "กำลังบัฟเฟอร์"
+
+#: id:15108
+msgid "Navigation sounds"
+msgstr "เสียงนำทาง"
+
+#: id:15109
+msgid "Skin default"
+msgstr "หน้าตาพื้นฐาน"
+
+#: id:15111
+msgid "- Theme"
+msgstr "- รูปแบบ"
+
+#: id:15112
+msgid "Default theme"
+msgstr "รูปแบบพื้นฐาน"
+
+#: id:15200
+msgid "Last.fm"
+msgstr "Last.fm"
+
+#: id:15201
+msgid "Submit songs to Last.fm"
+msgstr "ส่งเพลงไปยัง Last.fm"
+
+#: id:15202
+msgid "Last.fm username"
+msgstr "ชื่อผู้ใช้ Last.fm"
+
+#: id:15203
+msgid "Last.fm password"
+msgstr "รหัสผ่าน Last.fm"
+
+#: id:15204
+msgid "Unable to handshake: sleeping..."
+msgstr "ไม่สามารถเชื่อมต่อ: พักการเชื่อมต่อ..."
+
+#: id:15205
+msgid "Please update XBMC"
+msgstr "กรุณาปรับปรุงรุ่น XBMC"
+
+#: id:15206
+msgid "Bad authorization: Check username and password"
+msgstr "การยืนยันตัวตนผิดพลาด: ตรวจสอบชื่อผู้ใช้และรหัสผ่าน"
+
+#: id:15207
+msgctxt "Auto context with id 15207"
+msgid "Connected"
+msgstr "เชื่อมต่อแล้ว"
+
+#: id:15208
+msgid "Not connected"
+msgstr "ไม่สามารถเชื่อมต่อ"
+
+#: id:15209
+msgid "Submit interval %i"
+msgstr "รอบการส่ง %i"
+
+#: id:15210
+msgid "Cached %i songs"
+msgstr "แคชแล้ว %i เพลง"
+
+#: id:15211
+msgid "Submitting..."
+msgstr "กำลังส่ง..."
+
+#: id:15212
+msgid "Submitting in %i secs"
+msgstr "กำลังส่งใน %i วินาที"
+
+#: id:15213
+msgid "Play using..."
+msgstr "เล่นโดยใช้..."
+
+#: id:15214
+msgid "Use smoothed A/V synchronization"
+msgstr "Use smoothed A/V synchronization"
+
+#: id:15215
+msgid "Hide file names in thumbs view"
+msgstr "ซ่อนชื่อแฟ้มในมุมมองรูปย่อ"
+
+#: id:15216
+msgid "Play in party mode"
+msgstr "เล่นโหมดร่วมกัน"
+
+#: id:15217
+msgid "Submit songs to Libre.fm"
+msgstr "ส่งเพลงไปยัง Libre.fm"
+
+#: id:15218
+msgid "Libre.fm username"
+msgstr "ชื่อผู้ใช้ Libre.fm"
+
+#: id:15219
+msgid "Libre.fm password"
+msgstr "รหัสผ่าน Libre.fm"
+
+#: id:15220
+msgid "Libre.fm"
+msgstr "Libre.fm"
+
+#: id:15221
+msgid "Song submission"
+msgstr "การส่งเพลง"
+
+#: id:15250
+msgid "Submit Last.fm radio to Last.fm"
+msgstr "ส่งวิทยุของ Last.fm ไปยัง Last.fm"
+
+#: id:15251
+msgid "Connecting to Last.fm..."
+msgstr "เชื่อมต่อไปยัง Last.fm..."
+
+#: id:15252
+msgid "Selecting station..."
+msgstr "กำลังเลือกสถานี..."
+
+#: id:15253
+msgid "Search similar artists..."
+msgstr "ค้นหาศิลปินที่คล้ายกัน..."
+
+#: id:15254
+msgid "Search similar tags..."
+msgstr "ค้นหาแท็กที่คล้ายกัน..."
+
+#: id:15255
+msgid "Your profile (%name%)"
+msgstr "ข้อมูลส่วนตัวของคุณ (%name%)"
+
+#: id:15256
+msgid "Overall top tags"
+msgstr "Overall top tags"
+
+#: id:15257
+msgid "Top artists for tag %name%"
+msgstr "Top artists for tag %name%"
+
+#: id:15258
+msgid "Top albums for tag %name%"
+msgstr "Top albums for tag %name%"
+
+#: id:15259
+msgid "Top tracks for tag %name%"
+msgstr "Top tracks for tag %name%"
+
+#: id:15260
+msgid "Listen to tag %name% Last.fm radio"
+msgstr "Listen to tag %name% Last.fm radio"
+
+#: id:15261
+msgid "Similar artists as %name%"
+msgstr "Similar artists as %name%"
+
+#: id:15262
+msgid "Top %name% albums"
+msgstr "Top %name% albums"
+
+#: id:15263
+msgid "Top %name% tracks"
+msgstr "Top %name% tracks"
+
+#: id:15264
+msgid "Top %name% tags"
+msgstr "Top %name% tags"
+
+#: id:15265
+msgid "Biggest fans of %name%"
+msgstr "Biggest fans of %name%"
+
+#: id:15266
+msgid "Listen to %name% fans Last.fm radio"
+msgstr "Listen to %name% fans Last.fm radio"
+
+#: id:15267
+msgid "Listen to %name% similar artists Last.fm radio"
+msgstr "Listen to %name% similar artists Last.fm radio"
+
+#: id:15268
+msgid "Top artists for user %name%"
+msgstr "Top artists for user %name%"
+
+#: id:15269
+msgid "Top albums for user %name%"
+msgstr "Top albums for user %name%"
+
+#: id:15270
+msgid "Top tracks for user %name%"
+msgstr "Top tracks for user %name%"
+
+#: id:15271
+msgid "Friends of user %name%"
+msgstr "Friends of user %name%"
+
+#: id:15272
+msgid "Neighbours of user %name%"
+msgstr "Neighbours of user %name%"
+
+#: id:15273
+msgid "Weekly artist chart for %name%"
+msgstr "Weekly artist chart for %name%"
+
+#: id:15274
+msgid "Weekly album chart for %name%"
+msgstr "Weekly album chart for %name%"
+
+#: id:15275
+msgid "Weekly track chart for %name%"
+msgstr "Weekly track chart for %name%"
+
+#: id:15276
+msgid "Listen to %name%'s neighbours Last.fm radio"
+msgstr "Listen to %name%'s neighbours Last.fm radio"
+
+#: id:15277
+msgid "Listen to %name%'s personal Last.fm radio"
+msgstr "Listen to %name%'s personal Last.fm radio"
+
+#: id:15278
+msgid "Listen to %name%'s mix Last.fm radio"
+msgstr "Listen to %name%'s loved tracks Last.fm radio"
+
+#: id:15279
+msgid "Retrieving list from Last.fm..."
+msgstr "Retrieving list from Last.fm..."
+
+#: id:15280
+msgid "Can't retrieve list from Last.fm..."
+msgstr "Can't retrieve list from Last.fm..."
+
+#: id:15281
+msgid "Enter an artist name to find related ones"
+msgstr "Enter an artist name to find related ones"
+
+#: id:15282
+msgid "Enter a tag name to find similar ones"
+msgstr "Enter a tag name to find similar ones"
+
+#: id:15283
+msgid "Tracks recently listened by %name%"
+msgstr "Tracks recently listened by %name%"
+
+#: id:15284
+msgid "Listen to %name%'s recommendations Last.fm radio"
+msgstr "Listen to %name%'s recommendations Last.fm radio"
+
+#: id:15285
+msgid "Top tags for user %name%"
+msgstr "Top tags for user %name%"
+
+#: id:15287
+msgid "Do you want to add the current track to your loved tracks?"
+msgstr "Do you want to add the current track to your loved tracks?"
+
+#: id:15288
+msgid "Do you want to ban the current track?"
+msgstr "Do you want to ban the current track?"
+
+#: id:15289
+msgid "Added to your loved tracks: '%s'."
+msgstr "Added to your loved tracks: '%s'."
+
+#: id:15290
+msgid "Could not add '%s' to your loved tracks."
+msgstr "Could not add '%s' to your loved tracks."
+
+#: id:15291
+msgid "Banned: '%s'."
+msgstr "แบน: '%s'."
+
+#: id:15292
+msgid "Could not ban '%s'."
+msgstr "ไม่สามารถแบน '%s'."
+
+#: id:15293
+msgid "Tracks recently loved by %name%"
+msgstr "Tracks recently loved by %name%"
+
+#: id:15294
+msgid "Tracks recently banned by %name%"
+msgstr "Tracks recently banned by %name%"
+
+#: id:15295
+msgid "Remove from loved tracks"
+msgstr "Remove from loved tracks"
+
+#: id:15296
+msgid "Un-ban"
+msgstr "ยกเลิกการแบน"
+
+#: id:15297
+msgid "Do you want to remove this track from your loved tracks?"
+msgstr "Do you want to remove this track from your loved tracks?"
+
+#: id:15298
+msgid "Do you want to un-ban this track?"
+msgstr "Do you want to un-ban this track?"
+
+#: id:15300
+msgid "Path not found or invalid"
+msgstr "Path not found or invalid"
+
+#: id:15301
+msgid "Could not connect to network server"
+msgstr "Could not connect to network server"
+
+#: id:15302
+msgid "No servers found"
+msgstr "No servers found"
+
+#: id:15303
+msgid "Workgroup not found"
+msgstr "Workgroup not found"
+
+#: id:15310
+msgid "Opening multi-path source"
+msgstr "Opening multi-path source"
+
+#: id:15311
+msgid "Path:"
+msgstr "พาธ:"
+
+#: id:16000
+msgctxt "Auto context with id 16000"
+msgid "General"
+msgstr "ทั่วไป"
+
+#: id:16002
+msgid "Internet lookup"
+msgstr "ค้นหาจากอินเตอร์เน็ต"
+
+#: id:16003
+msgid "Player"
+msgstr "ตัวเล่น"
+
+#: id:16004
+msgid "Play media from disc"
+msgstr "เล่นสื่อจากแผ่น"
+
+#: id:16008
+msgid "Enter new title"
+msgstr "ป้อนชื่อเรื่องใหม่"
+
+#: id:16009
+msgid "Enter the movie name"
+msgstr "ป้อนชื่อภาพยนต์"
+
+#: id:16010
+msgid "Enter the profile name"
+msgstr "ป้อนชื่อข้อมูลผู้ใช้"
+
+#: id:16011
+msgid "Enter the album name"
+msgstr "ป้อนชื่ออัลบั้ม"
+
+#: id:16012
+msgid "Enter the playlist name"
+msgstr "ป้อนชื่อรายการเพลง"
+
+#: id:16013
+msgid "Enter new filename"
+msgstr "ป้อนชื่อแฟ้ม"
+
+#: id:16014
+msgid "Enter folder name"
+msgstr "ป้อนชื่อโฟลเดอร์"
+
+#: id:16015
+msgid "Enter directory"
+msgstr "แก้ไขไดเรกทอรี"
+
+#: id:16016
+msgid "Available options: %A, %T, %N, %B, %D, %G, %Y, %F, %S"
+msgstr "ตัวเลือกที่ใช้ได้: %A, %T, %N, %B, %D, %G, %Y, %F, %S"
+
+#: id:16017
+msgid "Enter search string"
+msgstr "ป้อนคำค้น"
+
+#: id:16018
+msgctxt "Auto context with id 16018"
+msgid "None"
+msgstr "ไม่มี"
+
+#: id:16019
+msgid "Auto select"
+msgstr "เลือกอัตโนมัติ"
+
+#: id:16020
+msgid "De-interlace"
+msgstr "De-interlace"
+
+#: id:16021
+msgid "Bob"
+msgstr "Bob"
+
+#: id:16022
+msgid "Bob (inverted)"
+msgstr "Bob (inverted)"
+
+#: id:16024
+msgid "Canceling..."
+msgstr "กำลังยกเลิก"
+
+#: id:16025
+msgid "Enter the artist name"
+msgstr "ป้อนชื่อศิลปิน"
+
+#: id:16026
+msgid "Playback failed"
+msgstr "เล่นเพลงผิดพลาด"
+
+#: id:16027
+msgid "One or more items failed to play."
+msgstr "หนึ่งหรือมากกว่ารายการเล่นไม่ได้"
+
+#: id:16028
+msgid "Enter value"
+msgstr "ป้อนค่า"
+
+#: id:16029
+msgid "Check the log file for details."
+msgstr "ตรวจสอบแฟ้ม log สำหรับรายละเอียด"
+
+#: id:16030
+msgid "Party mode aborted."
+msgstr "นกเลิกโหมดเล่นเพลงร่วมกัน"
+
+#: id:16031
+msgid "No matching songs in the library."
+msgstr "ไม่พบเพลงที่ตรงกันในคลังข้อมูล"
+
+#: id:16032
+msgid "Could not initialize database."
+msgstr "ไม่สามารถเริ่มต้นฐานข้อมูล"
+
+#: id:16033
+msgid "Could not open database."
+msgstr "ไม่สามารถเปิดฐานข้อมูล"
+
+#: id:16034
+msgid "Could not get songs from database."
+msgstr "ไม่สามารถดึงเพลงจากฐานข้อมมูล"
+
+#: id:16035
+msgid "Party mode playlist"
+msgstr "รายการเพลงโหมดร่วมกัน"
+
+#: id:16036
+msgid "De-interlace (Half)"
+msgstr ""
+
+#: id:16037
+msgid "Deinterlace video"
+msgstr ""
+
+#: id:16038
+msgid "Deinterlace method"
+msgstr ""
+
+#: id:16039
+msgctxt "Auto context with id 16039"
+msgid "Off"
+msgstr ""
+
+#: id:16040
+msgctxt "Auto context with id 16040"
+msgid "Auto"
+msgstr ""
+
+#: id:16041
+msgid "On"
+msgstr ""
+
+#: id:16100
+msgid "All Videos"
+msgstr "วิดีโอทั้งหมด"
+
+#: id:16101
+msgid "Unwatched"
+msgstr "ยังไม่ดู"
+
+#: id:16102
+msgid "Watched"
+msgstr "ดูแล้ว"
+
+#: id:16103
+msgid "Mark as watched"
+msgstr "ดูแล้ว"
+
+#: id:16104
+msgid "Mark as unwatched"
+msgstr "ทำยังไม่ได้ดู"
+
+#: id:16105
+msgid "Edit title"
+msgstr "แก้ไขชื่อเรื่อง"
+
+#: id:16200
+msgid "Operation was aborted"
+msgstr "การทำงานถูกยกเลิก"
+
+#: id:16201
+msgid "Copy failed"
+msgstr "คัดลอกผิดพลาด"
+
+#: id:16202
+msgid "Failed to copy at least one file"
+msgstr "คัดลอกผิดพลาดอย่างน้อยหนึ่งแฟ้ม"
+
+#: id:16203
+msgid "Move failed"
+msgstr "ย้ายผิดพลาด"
+
+#: id:16204
+msgid "Failed to move at least one file"
+msgstr "ไม่สามารถย้ายแฟ้มอย่างน้อยหนึ่งแฟ้ม"
+
+#: id:16205
+msgid "Delete failed"
+msgstr "ลบผิดพลาด"
+
+#: id:16206
+msgid "Failed to delete at least one file"
+msgstr "ไม่สามารถลบแฟ้มอย่างน้อยหนึ่งแฟ้ม"
+
+#: id:16300
+msgid "Video scaling method"
+msgstr "วิธีการปรับขนาดวิดีโอ"
+
+#: id:16301
+msgid "Nearest neighbour"
+msgstr "เพื่อนบ้านใกล้สุด"
+
+#: id:16302
+msgid "Bilinear"
+msgstr "Bilinear"
+
+#: id:16303
+msgctxt "Auto context with id 16303"
+msgid "Bicubic"
+msgstr "Bicubic"
+
+#: id:16304
+msgid "Lanczos2"
+msgstr "Lanczos2"
+
+#: id:16305
+msgid "Lanczos3"
+msgstr "Lanczos3"
+
+#: id:16306
+msgid "Sinc8"
+msgstr "Sinc8"
+
+#: id:16307
+msgid "Bicubic (software)"
+msgstr "Bicubic (software)"
+
+#: id:16308
+msgid "Lanczos (software)"
+msgstr "Lanczos (software)"
+
+#: id:16309
+msgid "Sinc (software)"
+msgstr "Sinc (software)"
+
+#: id:16310
+msgid "Temporal"
+msgstr "(VDPAU)Temporal"
+
+#: id:16311
+msgid "Temporal/Spatial"
+msgstr "(VDPAU)Temporal/Spatial"
+
+#: id:16312
+msgid "(VDPAU)Noise Reduction"
+msgstr "(VDPAU)Noise Reduction"
+
+#: id:16313
+msgid "(VDPAU)Sharpness"
+msgstr "(VDPAU)Sharpness"
+
+#: id:16314
+msgid "Inverse Telecine"
+msgstr "Inverse Telecine"
+
+#: id:16315
+msgid "Lanczos3 optimized"
+msgstr ""
+
+#: id:16316
+msgctxt "Auto context with id 16316"
+msgid "Auto"
+msgstr ""
+
+#: id:16317
+msgid "Temporal (Half)"
+msgstr ""
+
+#: id:16318
+msgid "Temporal/Spatial (Half)"
+msgstr ""
+
+#: id:16319
+msgid "DXVA"
+msgstr ""
+
+#: id:16320
+msgid "DXVA Bob"
+msgstr ""
+
+#: id:16321
+msgid "DXVA Best"
+msgstr ""
+
+#: id:16322
+msgid "Spline36"
+msgstr ""
+
+#: id:16323
+msgid "Spline36 optimized"
+msgstr ""
+
+#: id:16324
+msgid "Software Blend"
+msgstr ""
+
+#: id:16400
+msgid "Post-processing"
+msgstr ""
+
+#: id:17500
+msgid "Display sleep timeout"
+msgstr "เวลาพักหน้าจอ"
+
+#: id:19000
+msgid "Switch to channel"
+msgstr "เปลี่ยนช่อง"
+
+#: id:20000
+msgid "Saved music folder"
+msgstr "โฟลเดอร์บันทึกเพลง"
+
+#: id:20001
+msgid "Use external DVD player"
+msgstr "ใช้ตัวเล่นดีวีดีภายนอก"
+
+#: id:20002
+msgid "External DVD player"
+msgstr "ตัวเล่นดีวีดีภายนอก"
+
+#: id:20003
+msgid "Trainers folder"
+msgstr "Trainers folder"
+
+#: id:20004
+msgid "Screenshot folder"
+msgstr "โฟลเดอร์ Screenshot"
+
+#: id:20006
+msgid "Playlists folder"
+msgstr "โฟลเดอร์รายการเพลง"
+
+#: id:20007
+msgid "Recordings"
+msgstr "กำลังบันทึก"
+
+#: id:20008
+msgid "Screenshots"
+msgstr "Screenshots"
+
+#: id:20009
+msgid "Use XBMC"
+msgstr "ใช้ XBMC"
+
+#: id:20011
+msgid "Music playlists"
+msgstr "รายการเพลง"
+
+#: id:20012
+msgid "Video playlists"
+msgstr "รายการวิดีโอ"
+
+#: id:20013
+msgid "Do you wish to launch the game?"
+msgstr "คุณต้องการเริ่มต้นเกม?"
+
+#: id:20014
+msgid "Sort by: Playlist"
+msgstr "เรียงลำดับ: รายการที่จะเล่น"
+
+#: id:20015
+msgid "Remote thumb"
+msgstr "รูปย่อรีโมท"
+
+#: id:20016
+msgid "Current thumb"
+msgstr "รูปย่อปัจจุบัน"
+
+#: id:20017
+msgid "Local thumb"
+msgstr "รูปย่อในเครื่อง"
+
+#: id:20018
+msgid "No thumb"
+msgstr "ไม่มีรูปย่อ"
+
+#: id:20019
+msgid "Choose thumbnail"
+msgstr "เลือกรูปย่อ"
+
+#: id:20023
+msgid "Conflict"
+msgstr "ขัดแย้ง"
+
+#: id:20024
+msgid "Scan new"
+msgstr "สำรวจใหม่"
+
+#: id:20025
+msgid "Scan all"
+msgstr "สำรวจทั้งหมด"
+
+#: id:20026
+msgid "Region"
+msgstr "ภูมิภาค"
+
+#: id:20037
+msgid "Summary"
+msgstr "สรุป"
+
+#: id:20038
+msgid "Lock music window"
+msgstr "ล๊อคหน้าต่างเพลง"
+
+#: id:20039
+msgid "Lock videos window"
+msgstr "ล๊อคหน้าต่างวิดีโอ"
+
+#: id:20040
+msgid "Lock pictures window"
+msgstr "ล๊อคหน้าต่างรูปภาพ"
+
+#: id:20041
+msgid "Lock programs & scripts windows"
+msgstr "ล๊อคหน้าต่างโปรแกรมมสคริปต์"
+
+#: id:20042
+msgid "Lock file manager"
+msgstr "ล๊อคหน้าต่างจัดการแฟ้ม"
+
+#: id:20043
+msgid "Lock settings"
+msgstr "ล๊อคการตั้งค่า"
+
+#: id:20044
+msgid "Start fresh"
+msgstr "เริ่มต้นใหม่"
+
+#: id:20045
+msgid "Enter master mode"
+msgstr "เข้าสู่โหมดผู้ดูแล"
+
+#: id:20046
+msgid "Leave master mode"
+msgstr "ออกโหมดผู้ดูแล"
+
+#: id:20047
+msgid "Create profile '%s'?"
+msgstr "สร้างข้อมูลส่วนตัว '%s'?"
+
+#: id:20048
+msgid "Start with fresh settings"
+msgstr "เริ่มด้วยการตั้งค่าใหม่"
+
+#: id:20049
+msgid "Best available"
+msgstr "ดีที่สุด"
+
+#: id:20050
+msgid "Auto-switch between 16x9 and 4x3"
+msgstr "สลับอัตโนมัติระหว่าง 16x9 และ4x3"
+
+#: id:20051
+msgid "Treat stacked files as single file"
+msgstr "Treat stacked files as single file"
+
+#: id:20052
+msgid "Caution"
+msgstr "คำเตือน"
+
+#: id:20053
+msgid "Left master mode"
+msgstr "ออกโหมดผู้ดูแล"
+
+#: id:20054
+msgid "Entered master mode"
+msgstr "เข้าสู่โหมดผู้ดูแลแล้ว"
+
+#: id:20055
+msgid "Allmusic.com thumb"
+msgstr "รูปย่อจาก Allmusic.com"
+
+#: id:20057
+msgid "Remove thumbnail"
+msgstr "ลบรูปบ่อ"
+
+#: id:20058
+msgid "Add profile..."
+msgstr "เพิ่มข้อมูลส่วนตัว"
+
+#: id:20059
+msgid "Query info for all albums"
+msgstr "สอบถามข้อมูลอัลบั้มทั้งหมด"
+
+#: id:20060
+msgctxt "Auto context with id 20060"
+msgid "Media info"
+msgstr "ข้อมูลสื่อ"
+
+#: id:20061
+msgctxt "Auto context with id 20061"
+msgid "Separate"
+msgstr "แยก"
+
+#: id:20062
+msgid "Shares with default"
+msgstr "แยกโดยปริยาย"
+
+#: id:20063
+msgid "Shares with default (read only)"
+msgstr "แบ่งปันตามค่าเดิม (อ่านอย่างเดียว)"
+
+#: id:20064
+msgid "Copy default"
+msgstr "คัดลอกปริยาย"
+
+#: id:20065
+msgid "Profile picture"
+msgstr "ข้อมูลส่วนตัวรูปภาพ"
+
+#: id:20066
+msgid "Lock preferences"
+msgstr "ล๊อคการแสดงผล"
+
+#: id:20067
+msgid "Edit profile"
+msgstr "แก้ไขข้อมูลส่วนตัว"
+
+#: id:20068
+msgid "Profile lock"
+msgstr "ข้อมูลส่วนตัวล๊อค"
+
+#: id:20069
+msgid "Could not create folder"
+msgstr "ไม่สามารถสร้างโฟลเดอร์"
+
+#: id:20070
+msgid "Profile directory"
+msgstr "ไดเรกทอรีข้อมูลส่วนตัว"
+
+#: id:20071
+msgid "Start with fresh media sources"
+msgstr "เริ่มต้นด้วยแหล่งสื่อใหม่"
+
+#: id:20072
+msgid "Make sure the selected folder is writable"
+msgstr "ตรวจสอบว่าโฟลเดอร์สามารถเขียนได้"
+
+#: id:20073
+msgid "and that the new folder name is valid"
+msgstr "และชื่อโฟลเดอร์ถูกต้อง"
+
+#: id:20074
+msgid "MPAA rating"
+msgstr "MPAA rating"
+
+#: id:20075
+msgid "Enter master lock code"
+msgstr "ป้อนรหัสผู้ดูแล"
+
+#: id:20076
+msgid "Ask for master lock code on startup"
+msgstr "ถามรหัสผู้ดูแลเมื่อเริ่มการทำงาน"
+
+#: id:20077
+msgid "Skin settings"
+msgstr "การตั้งค่าหน้าตา"
+
+#: id:20078
+msgid "- no link set -"
+msgstr "- no link set -"
+
+#: id:20079
+msgid "Enable animations"
+msgstr "ใช้งานภาพเคลื่อนไหว"
+
+#: id:20080
+msgid "Disable RSS during music"
+msgstr "ปิดใช้งาน RSS ระหว่างเล่นเพลง"
+
+#: id:20081
+msgid "Enable shortcut buttons"
+msgstr "ใช้งานปุ่มทางลัด"
+
+#: id:20082
+msgid "Show programs in main menu"
+msgstr "แสดงโปรแกรมในเมนูหลัก"
+
+#: id:20083
+msgid "Show music info"
+msgstr "แสดงข้อมูลเพลง"
+
+#: id:20084
+msgid "Show weather info"
+msgstr "แสดงข้อมูลสภาพอากาศ"
+
+#: id:20085
+msgid "Show system info"
+msgstr "แสดงข้อมูลระบบ"
+
+#: id:20086
+msgid "Show available disc space C: E: F:"
+msgstr "แสดงพื้นที่ว่าง C: E: F:"
+
+#: id:20087
+msgid "Show available disc space E: F: G:"
+msgstr "แสดงพื้นที่ว่าง E: F: G:"
+
+#: id:20088
+msgid "Weather info"
+msgstr "ข้อมูลสภาพอากาศ"
+
+#: id:20089
+msgid "Drive space free"
+msgstr "พื้นที่ว่างในไดร์ฟ"
+
+#: id:20090
+msgid "Enter the name of an existing share"
+msgstr "ป้อนชื่อการแบ่งปันปัจจุบัน"
+
+#: id:20091
+msgid "Lock code"
+msgstr "รหัสล๊อค"
+
+#: id:20092
+msgid "Load profile"
+msgstr "โหลดข้อมูลส่วนตัว"
+
+#: id:20093
+msgid "Profile name"
+msgstr "ชื่อข้อมูลส่วนตัว"
+
+#: id:20094
+msgctxt "Auto context with id 20094"
+msgid "Media sources"
+msgstr "แหล่งข้อมูลสื่อ"
+
+#: id:20095
+msgid "Enter profile lock code"
+msgstr "ป้อนรหัสล๊อคข้อมูลส่วนตัว"
+
+#: id:20096
+msgctxt "Auto context with id 20096"
+msgid "Login screen"
+msgstr "หน้าจอเข้าระบบ"
+
+#: id:20097
+msgid "Fetching album info"
+msgstr "ดึงข้อมูลอัลบั้ม"
+
+#: id:20098
+msgid "Fetching info for album"
+msgstr "ดึงข้อมูลสำหรับอัลบั้ม"
+
+#: id:20099
+msgid "Can't rip CD or track while playing from CD"
+msgstr "ไม่สามารถ rip ระหว่างเล่นจากสื่อ"
+
+#: id:20100
+msgid "Master lock code and settings"
+msgstr "รหัสผู้ดูแลและการตั้งค่า"
+
+#: id:20101
+msgid "Entering master lock code always enables master mode"
+msgstr "การป้อนรหัสผู้ดูแลจะเป็นการเปิดโหมดผู้ดูแลเสมอ"
+
+#: id:20102
+msgid "or copy from default?"
+msgstr "หรือคัดลอกจากค่าปริยาย?"
+
+#: id:20103
+msgid "Save changes to profile?"
+msgstr "จัดเก็บการตั้งค่าลงข้อมูลส่วนตัว?"
+
+#: id:20104
+msgid "Old settings found."
+msgstr "ไม่พบการตั้งค่าเดิม"
+
+#: id:20105
+msgid "Do you want to use them?"
+msgstr "คุณต้องการที่จะใช้หรือไม่?"
+
+#: id:20106
+msgid "Old media sources found."
+msgstr "พบแหล่งข้อมูลสื่อเดิม"
+
+#: id:20107
+msgid "Separate (locked)"
+msgstr "แยก (ล๊อค)"
+
+#: id:20108
+msgid "Root"
+msgstr "Root"
+
+#: id:20109
+msgid "- Zoom"
+msgstr "- ซูม"
+
+#: id:20110
+msgid "UPnP settings"
+msgstr "การตั้งค่า UPnP"
+
+#: id:20111
+msgid "Autostart UPnP client"
+msgstr "เริ่มต้นลูกข่าย UPnP อัตโนมัมติ"
+
+#: id:20112
+msgid "Last login: %s"
+msgstr "เข้าระบบครั้งสุดท้าย: %s"
+
+#: id:20113
+msgid "Never logged on"
+msgstr "ไม่เคยเข้าสู่ระบบ"
+
+#: id:20114
+msgid "Profile %i / %i"
+msgstr "ข้อมูลส่วนตัว %i / %i"
+
+#: id:20115
+msgid "User login / Select a profile"
+msgstr "ผู้ใช้เข้าระบบ / เลือกข้อมูลส่วนตัว"
+
+#: id:20116
+msgid "Use lock on login screen"
+msgstr "ใช้ล๊อคในหน้าต่างเข้าระบบ"
+
+#: id:20117
+msgid "Invalid lock code."
+msgstr "รหัสล๊อคผิดพลาด"
+
+#: id:20118
+msgid "This requires the master lock to be set."
+msgstr "ต้องเปิดโหมดผู้ดูแลก่อน"
+
+#: id:20119
+msgid "Would you like to set it now?"
+msgstr "คุณต้องการตั้งค่าปัจจุบันหรือไม่?"
+
+#: id:20120
+msgid "Loading program information"
+msgstr "โหลดข้อมูลโปรแกรม"
+
+#: id:20121
+msgid "Party on!"
+msgstr "เปิดใช้งานร่วมกัน!"
+
+#: id:20122
+msgid "True"
+msgstr "จริง"
+
+#: id:20123
+msgid "Mixing drinks"
+msgstr "Mixing drinks"
+
+#: id:20124
+msgid "Filling glasses"
+msgstr "Filling glasses"
+
+#: id:20125
+msgid "Logged on as"
+msgstr "เข้าระบบเป็น"
+
+#: id:20126
+msgid "Log off"
+msgstr "ออกจากระบบ"
+
+#: id:20128
+msgid "Go to root"
+msgstr "ไปที่รูท"
+
+#: id:20129
+msgid "Weave"
+msgstr "Weave"
+
+#: id:20130
+msgid "Weave (inverted)"
+msgstr "Weave (inverted)"
+
+#: id:20131
+msgid "Blend"
+msgstr "Blend"
+
+#: id:20132
+msgid "Restart video"
+msgstr "Restart video"
+
+#: id:20133
+msgid "Edit network location"
+msgstr "Edit network location"
+
+#: id:20134
+msgid "Remove network location"
+msgstr "ลบสถานที่เครือชข่าย"
+
+#: id:20135
+msgid "Do you want to scan the folder?"
+msgstr "คุรณต้องการสำรวจโฟลเดอร์"
+
+#: id:20136
+msgid "Memory unit"
+msgstr "หน่วยความจำ"
+
+#: id:20137
+msgid "Memory unit mounted"
+msgstr "หน่วยความจำที่เมานท์"
+
+#: id:20138
+msgid "Unable to mount memory unit"
+msgstr "ไม่สามารถเมานท์หน่วยความจำ"
+
+#: id:20139
+msgid "In port %i, slot %i"
+msgstr "ในพอร์ต %i, สลอต %i"
+
+#: id:20140
+msgid "Lock screensaver"
+msgstr "ล๊อคการพักหน้าจอ"
+
+#: id:20141
+msgid "Set"
+msgstr "ตั้งค่า"
+
+#: id:20142
+msgctxt "Auto context with id 20142"
+msgid "Username"
+msgstr "ชื่อผู้ใช้"
+
+#: id:20143
+msgid "Enter password for"
+msgstr "ป้อนรัหสผ่านสำหรับ"
+
+#: id:20144
+msgid "Shutdown timer"
+msgstr "เวลาปิดเครื่อง"
+
+#: id:20145
+msgid "Shutdown interval (in minutes)"
+msgstr "รอบการปิดเครื่อง (นาที)"
+
+#: id:20146
+msgid "Started, shutdown in %im"
+msgstr "เริ่ม,จะปิดเครื่องใน %im"
+
+#: id:20147
+msgid "Shutdown in 30 minutes"
+msgstr "ปิดเครื่องใน 30 นาที"
+
+#: id:20148
+msgid "Shutdown in 60 minutes"
+msgstr "ปิดเครื่องใน 60 นาที"
+
+#: id:20149
+msgid "Shutdown in 120 minutes"
+msgstr "ปิดเครื่องใน 120 นาที"
+
+#: id:20150
+msgid "Custom shutdown timer"
+msgstr "กำหนดเวลาปิดเครื่อง"
+
+#: id:20151
+msgid "Cancel shutdown timer"
+msgstr "ยกเลิกการตั้งเวลาปิดเครื่อง"
+
+#: id:20152
+msgid "Lock preferences for %s"
+msgstr "ล๊อคการแสดงผลสำหรับ %s"
+
+#: id:20153
+msgid "Browse..."
+msgstr "เรียกดู"
+
+#: id:20154
+msgid "Summary information"
+msgstr "สรุปผลข้อมูล"
+
+#: id:20155
+msgid "Storage information"
+msgstr "ข้อมูลหน่วยจัดเก็บข้อมูล"
+
+#: id:20156
+msgid "Hard disk information"
+msgstr "ข้อมูลฮาร์ดดิสก์"
+
+#: id:20157
+msgid "DVD-ROM information"
+msgstr "ข้อมูลดีวีดีรอม"
+
+#: id:20158
+msgid "Network information"
+msgstr "ข้อมูลเครือข่าย"
+
+#: id:20159
+msgid "Video information"
+msgstr "ข้อมูลวิดีโอ"
+
+#: id:20160
+msgid "Hardware information"
+msgstr "ข้อมูลฮาร์ดแวร์"
+
+#: id:20161
+msgid "Total"
+msgstr "ทั้งหมด"
+
+#: id:20162
+msgid "Used"
+msgstr "ใช้"
+
+#: id:20163
+msgid "of"
+msgstr "จาก"
+
+#: id:20164
+msgid "Locking not supported"
+msgstr "การล๊อคไม่สนับสนุน"
+
+#: id:20165
+msgid "Not locked"
+msgstr "ไม่ล๊อค"
+
+#: id:20166
+msgid "Locked"
+msgstr "ล๊อคแล้ว"
+
+#: id:20167
+msgid "Frozen"
+msgstr "แช่แข็ง"
+
+#: id:20168
+msgid "Requires reset"
+msgstr "ต้องการทำงานใหม่"
+
+#: id:20169
+msgid "Week"
+msgstr "สัปดาห์"
+
+#: id:20170
+msgid "Line"
+msgstr "บรรทัด"
+
+#: id:20171
+msgid "Windows network (SMB)"
+msgstr "เครือข่ายวินโดว์ (SMB)"
+
+#: id:20172
+msgid "XBMSP server"
+msgstr "เซิฟเวอร์ XBMSP"
+
+#: id:20173
+msgctxt "Auto context with id 20173"
+msgid "FTP server"
+msgstr "เซิฟเวอร์ FTP"
+
+#: id:20174
+msgid "iTunes music share (DAAP)"
+msgstr "iTunes music share (DAAP)"
+
+#: id:20175
+msgid "UPnP server"
+msgstr "UPnP server"
+
+#: id:20176
+msgid "Show video info"
+msgstr "แสดงข้อมูลวิดีโอ"
+
+#: id:20177
+msgid "Done"
+msgstr "สำเร็จ"
+
+#: id:20178
+msgid "Shift"
+msgstr "Shift"
+
+#: id:20179
+msgid "Caps Lock"
+msgstr "Caps Lock"
+
+#: id:20180
+msgid "Symbols"
+msgstr "สัญลักษณ์"
+
+#: id:20181
+msgid "Backspace"
+msgstr "Backspace"
+
+#: id:20182
+msgid "Space"
+msgstr "Space"
+
+#: id:20183
+msgid "Reload skin"
+msgstr "โหลดหน้าตาอีกครั้ง"
+
+#: id:20184
+msgid "Rotate pictures using EXIF information"
+msgstr "หมุนรูปภาพโดยใช้ข้อมูล EXIF"
+
+#: id:20185
+msgid "Use poster view styles for TV shows"
+msgstr "ใช้มุมมองรูปแบบโปสเตอร์สำหรับรายการทีวี"
+
+#: id:20186
+msgid "Please wait"
+msgstr "กรุณารอสักครู่"
+
+#: id:20187
+msgid "UPnP"
+msgstr "สำรอง EEPROM"
+
+#: id:20189
+msgid "Enable auto scrolling for plot & review"
+msgstr "ใช้งานแถบเลื่อนอัตโนมัติสำหรับ plot & review"
+
+#: id:20190
+msgctxt "Auto context with id 20190"
+msgid "Custom"
+msgstr "กำหนดเอง"
+
+#: id:20191
+msgid "Enable debug logging"
+msgstr "Enable debug logging"
+
+#: id:20192
+msgid "Download additional information during updates"
+msgstr "ดาวน์โหลดข้อมูลเพิ่มเติมระหว่างปรับปรุงรุ่น"
+
+#: id:20193
+msgid "Default service for album information"
+msgstr ""
+
+#: id:20194
+msgid "Default service for artist information"
+msgstr "บริการพื้นฐานสำหรับข้อมูลเพลง"
+
+#: id:20195
+msgid "Change scraper"
+msgstr "Change scraper"
+
+#: id:20196
+msgid "Export music library"
+msgstr "ส่งออกคลังเสียง"
+
+#: id:20197
+msgid "Import music library"
+msgstr "นำเข้าคลังเสียง"
+
+#: id:20198
+msgid "No artist found!"
+msgstr "ไม่พบศิลปิน"
+
+#: id:20199
+msgid "Downloading artist info failed"
+msgstr "ดาวน์โหลดข้อมูลศิลปินผิดพลาด"
+
+#: id:20250
+msgid "Party on! (videos)"
+msgstr "Party on! (videos)"
+
+#: id:20251
+msgid "Mixing drinks (videos)"
+msgstr "Mixing drinks (videos)"
+
+#: id:20252
+msgid "Filling glasses (videos)"
+msgstr "Filling glasses (videos)"
+
+#: id:20253
+msgid "WebDAV server (HTTP)"
+msgstr ""
+
+#: id:20254
+msgid "WebDAV server (HTTPS)"
+msgstr ""
+
+#: id:20255
+msgid "First logon, edit your profile"
+msgstr ""
+
+#: id:20256
+msgid "HTS Tvheadend client"
+msgstr ""
+
+#: id:20257
+msgid "VDR Streamdev client"
+msgstr ""
+
+#: id:20258
+msgid "MythTV client"
+msgstr ""
+
+#: id:20259
+msgid "Network Filesystem (NFS)"
+msgstr ""
+
+#: id:20260
+msgid "Secure Shell (SSH/SFTP)"
+msgstr ""
+
+#: id:20261
+msgid "Apple Filing Protocol (AFP)"
+msgstr ""
+
+#: id:20300
+msgid "Web server directory (HTTP)"
+msgstr "Web server directory (HTTP)"
+
+#: id:20301
+msgid "Web server directory (HTTPS)"
+msgstr "Web server directory (HTTPS)"
+
+#: id:20302
+msgid "Unable to write to folder:"
+msgstr "ไม่สามารถเขียนไปยังโฟลเดอร์"
+
+#: id:20303
+msgid "Do you want to skip and proceed?"
+msgstr "คุณต้องการข้ามและทำต่อหรือไม่?"
+
+#: id:20304
+msgid "RSS Feed"
+msgstr "RSS Feed"
+
+#: id:20307
+msgid "Secondary DNS"
+msgstr "DNS สำรอง"
+
+#: id:20308
+msgid "DHCP server:"
+msgstr "DHCP server:"
+
+#: id:20309
+msgid "Make new folder"
+msgstr "สร้างโฟลเดอ ร์ใหม่"
+
+#: id:20310
+msgid "Dim LCD on playback"
+msgstr "Dim LCD on playback"
+
+#: id:20311
+msgid "Unknown or onboard (protected)"
+msgstr "Unknown or onboard (protected)"
+
+#: id:20312
+msgid "Dim LCD on paused"
+msgstr "Dim LCD on paused"
+
+#: id:20314
+msgid "Videos - Library"
+msgstr "วิดีโอ - คลังข้อมูล"
+
+#: id:20316
+msgid "Sort by: ID"
+msgstr "เรียงลำดับ: ไอดี"
+
+#: id:20324
+msgid "Play part..."
+msgstr "ส่วนที่เล่น"
+
+#: id:20325
+msgid "Calibration reset"
+msgstr "Calibration reset"
+
+#: id:20326
+msgid "This will reset the calibration values for %s"
+msgstr "This will reset the calibration values for %s"
+
+#: id:20327
+msgid "to it's default values."
+msgstr "to it's default values."
+
+#: id:20328
+msgid "Browse for destination"
+msgstr "เรียกดูเป้าหมาย"
+
+#: id:20329
+msgid "Movies are in separate folders that match the movie title"
+msgstr ""
+
+#: id:20330
+msgid "Use folder names for lookups"
+msgstr "ใช้ชื่อโฟลเดอร์ในการค้นหา"
+
+#: id:20331
+msgctxt "Auto context with id 20331"
+msgid "File"
+msgstr "แฟ้ม"
+
+#: id:20332
+msgid "Use file or folder names in lookups?"
+msgstr "ใช้ชื่อแฟ้มหรือโฟลเดอร์ในการค้นหา?"
+
+#: id:20333
+msgid "Set content"
+msgstr "ตั้งค่าเนื้อหา"
+
+#: id:20334
+msgid "Folder"
+msgstr "โฟลเดอร์"
+
+#: id:20335
+msgid "Look for content recursively?"
+msgstr "มองหาเนื้อหาที่เกี่ยวข้อง?"
+
+#: id:20336
+msgid "Unlock sources"
+msgstr "ปลดล๊อคแหล่งข้อมูล"
+
+#: id:20337
+msgid "Actor"
+msgstr "นักแสดง"
+
+#: id:20338
+msgid "Movie"
+msgstr "ภาพยนต์"
+
+#: id:20339
+msgid "Director"
+msgstr "ผู้กำกับ"
+
+#: id:20340
+msgid "Do you want to remove all items within"
+msgstr "คุณต้องการลบทุกรายการภายใน"
+
+#: id:20341
+msgid "this path from the XBMC library?"
+msgstr "พาธนี้ออกจากคลังข้อมูลหรือไม่?"
+
+#: id:20342
+msgctxt "Auto context with id 20342"
+msgid "Movies"
+msgstr "ภาพยนต์"
+
+#: id:20343
+msgid "TV shows"
+msgstr "รายการทีวี"
+
+#: id:20344
+msgid "This directory contains"
+msgstr "ไดเรกทอรีนี้มี"
+
+#: id:20345
+msgid "Run automated scan"
+msgstr "ทำงานสืบค้นอัตโนมัติ"
+
+#: id:20346
+msgid "Scan recursively"
+msgstr "สืบค้นข้อมูลเกี่ยวข้อง"
+
+#: id:20347
+msgid "as"
+msgstr "เป็น"
+
+#: id:20348
+msgid "Directors"
+msgstr "ผู้กำกับ"
+
+#: id:20349
+msgid "No video files found in this path!"
+msgstr "ไม่พบวิดีโอในพาธนี้!"
+
+#: id:20350
+msgid "votes"
+msgstr "โหวต"
+
+#: id:20351
+msgid "TV show information"
+msgstr "ข้อมูลรายการทีวี"
+
+#: id:20352
+msgid "Episode information"
+msgstr "ข้อมูลตอน"
+
+#: id:20353
+msgid "Loading TV show details"
+msgstr "โหลดข้อมูลรายการทีวี"
+
+#: id:20354
+msgid "Fetching episode guide"
+msgstr "ดึงข้อมูลนำทาง episode"
+
+#: id:20355
+msgid "Loading info for episodes in directory"
+msgstr "โหลดขอ้มูล episode ในไดเรกทอรี"
+
+#: id:20356
+msgid "Select TV show:"
+msgstr "เลือกรายการทีวี:"
+
+#: id:20357
+msgid "Enter the TV show name"
+msgstr "ป้อนชื่อรายการทีวี"
+
+#: id:20358
+msgid "Season %i"
+msgstr "ฤดู %i"
+
+#: id:20359
+msgid "Episode"
+msgstr "ตอน"
+
+#: id:20360
+msgid "Episodes"
+msgstr "ตอน"
+
+#: id:20361
+msgid "Loading episode details"
+msgstr "โหลดรายละเอียดตอน"
+
+#: id:20362
+msgid "Remove episode from library"
+msgstr "ลบตอนออกจากคลัง"
+
+#: id:20363
+msgid "Remove TV show from library"
+msgstr "ลบรายากรทีวีออกจากคลัง"
+
+#: id:20364
+msgid "TV show"
+msgstr "รายการทีวี"
+
+#: id:20365
+msgid "Episode plot"
+msgstr "Episode plot"
+
+#: id:20366
+msgid "* All seasons"
+msgstr "* All seasons"
+
+#: id:20367
+msgid "Hide watched"
+msgstr "Hide watched"
+
+#: id:20368
+msgid "Prod code"
+msgstr "Prod code"
+
+#: id:20369
+msgid "Show plot for unwatched items"
+msgstr "Show plot for unwatched items"
+
+#: id:20370
+msgid "* Hidden to prevent spoilers *"
+msgstr "* Hidden to prevent spoilers *"
+
+#: id:20371
+msgid "Set season thumb"
+msgstr "ตั้งภาพย่อฤดู"
+
+#: id:20372
+msgid "Season image"
+msgstr "รูปภาพฤดู"
+
+#: id:20373
+msgid "Season"
+msgstr "ฤดู"
+
+#: id:20374
+msgid "Downloading movie information"
+msgstr "กำลังดาวน์โหลดข้อมูลภาพยนต์"
+
+#: id:20375
+msgid "Unassign content"
+msgstr "ยกเลิกกำหนดเนื้อหา"
+
+#: id:20376
+msgid "Original title"
+msgstr ""
+
+#: id:20377
+msgid "Refresh TV show information"
+msgstr "เรียกข้อมูลรายการทีวีใหม่"
+
+#: id:20378
+msgid "Refresh info for all episodes?"
+msgstr "เรียกข้อมูลใหม่สำหรับทุกตอน?"
+
+#: id:20379
+msgid "Selected folder contains a single TV show"
+msgstr "โฟลเดอร์ที่เลือกประกอบด้วยรายการทีวี"
+
+#: id:20380
+msgid "Exclude selected folder from scans"
+msgstr "แยกโฟลเดอร์ที่เลือกระหว่างสำรวจ"
+
+#: id:20381
+msgid "Specials"
+msgstr "พิเศษ"
+
+#: id:20382
+msgid "Automatically grab season thumbs"
+msgstr "Automatically grab season thumbs"
+
+#: id:20383
+msgid "Selected folder contains a single video"
+msgstr "โฟลเดอร์ที่เลือกมีวิดีโอเดียว"
+
+#: id:20384
+msgid "Link to TV show"
+msgstr "ลิ้งค์รายการทีวี"
+
+#: id:20385
+msgid "Remove link to TV show"
+msgstr "ลบลิงค์รายการทีวี"
+
+#: id:20386
+msgid "Recently added movies"
+msgstr "ภาพยนต์ที่เพิ่งเพิ่ม"
+
+#: id:20387
+msgid "Recently added episodes"
+msgstr "ตอนที่เพิ่งเพิ่ม"
+
+#: id:20388
+msgid "Studios"
+msgstr "สตูดิโอ"
+
+#: id:20389
+msgid "Music videos"
+msgstr "วิดีโอเพลง"
+
+#: id:20390
+msgid "Recently added music videos"
+msgstr "วิดีโอเพลงที่เพิ่งเพิ่ม"
+
+#: id:20391
+msgid "Music video"
+msgstr "วิดีโอเพลง"
+
+#: id:20392
+msgid "Remove music video from library"
+msgstr "ลบวิดีโอเพลงจากคลังข้อมูล"
+
+#: id:20393
+msgctxt "Auto context with id 20393"
+msgid "Music video information"
+msgstr "ข้อมูลวิดีโอเพลง"
+
+#: id:20394
+msgid "Loading music video information"
+msgstr "กำลังโหลดข้อมูลวิดีโอเพลง"
+
+#: id:20395
+msgid "Mixed"
+msgstr "ผสม"
+
+#: id:20396
+msgid "Go to albums by artist"
+msgstr "ไปยังอัลบั้มตามศิลปิน"
+
+#: id:20397
+msgid "Go to album"
+msgstr "ไปยังอัลบั้ม"
+
+#: id:20398
+msgid "Play song"
+msgstr "เล่นเพลง"
+
+#: id:20399
+msgid "Go to music videos from album"
+msgstr "ไปยังวิดีโอเพลงจากอัลบั้ม"
+
+#: id:20400
+msgid "Go to music videos by artist"
+msgstr "ไปยังวิดีโอเพลงตามชื่อศิลปิน"
+
+#: id:20401
+msgid "Play music video"
+msgstr "เล่นวิดีอเพลง"
+
+#: id:20402
+msgid "Download actor thumbnails when adding to library"
+msgstr "ดาวน์โหลดรูปย่อนักแสดงเมื่อเพิ่มเข้าคลังข้อมูล"
+
+#: id:20403
+msgid "Set actor thumb"
+msgstr "ตั้งค่ารูปย่อนักแสดง"
+
+#: id:20405
+msgid "Remove episode bookmark"
+msgstr "ลบบุ๊คมาร์คตอน"
+
+#: id:20406
+msgid "Set episode bookmark"
+msgstr "ตั้งค่าบุ๊คมาร์คสำหรับตอน"
+
+#: id:20407
+msgid "Scraper settings"
+msgstr "Scraper settings"
+
+#: id:20408
+msgid "Downloading music video information"
+msgstr "ดาวน์โหลดข้อมูลวิดีโอเพลง"
+
+#: id:20409
+msgid "Downloading TV show information"
+msgstr "ดาวน์โหลดข้อมูลรายการทีวี"
+
+#: id:20410
+msgid "Trailer"
+msgstr "ตัวอย่างภาพยนต์"
+
+#: id:20411
+msgid "Flatten"
+msgstr "Flatten"
+
+#: id:20412
+msgid "Flatten TV shows"
+msgstr "Flatten TV shows"
+
+#: id:20413
+msgid "Get fanart"
+msgstr "รับ Fanart"
+
+#: id:20414
+msgid "Show Fanart in video and music libraries"
+msgstr "แสดง Fanart ในคลังวิดีโอและเพลง"
+
+#: id:20415
+msgid "Scanning for new content"
+msgstr "สำรวจเนื้อหาใหม่"
+
+#: id:20416
+msgid "First aired"
+msgstr "ออกอากาศครั้งแรก"
+
+#: id:20417
+msgid "Writer"
+msgstr "เขียน"
+
+#: id:20419
+msgid "Replace file names with library titles"
+msgstr ""
+
+#: id:20420
+msgctxt "Auto context with id 20420"
+msgid "Never"
+msgstr "ไม่เคย"
+
+#: id:20421
+msgid "If only one season"
+msgstr "ถ้ามีเพียงหนึ่งฤดู"
+
+#: id:20422
+msgid "Always"
+msgstr "เสมอ"
+
+#: id:20423
+msgid "Has trailer"
+msgstr "มีตัวอย่าง"
+
+#: id:20424
+msgid "False"
+msgstr "ไม่จริง"
+
+#: id:20425
+msgid "Fanart slideshow"
+msgstr "Fanart สไลด์โชว์"
+
+#: id:20426
+msgid "Export to a single file or separate"
+msgstr "ส่งออกในแฟ้มเดียวหรือ"
+
+#: id:20427
+msgid "files per entry?"
+msgstr "แยกแฟ้ม?"
+
+#: id:20428
+msgid "Single file"
+msgstr "แฟ้มเดียว"
+
+#: id:20429
+msgctxt "Auto context with id 20429"
+msgid "Separate"
+msgstr "แยก"
+
+#: id:20430
+msgid "Export thumbnails and fanart?"
+msgstr "ส่งออกรูปย่อและ fanart?"
+
+#: id:20431
+msgid "Overwrite old files?"
+msgstr "เขียนทับแฟ้มเดิมหรือไม่?"
+
+#: id:20432
+msgid "Exclude path from library updates"
+msgstr "แยกพาธจากการอัพเดทคลังข้อมูล"
+
+#: id:20433
+msgid "Extract thumbnails and video information"
+msgstr "แยกรูปย่อและข้อมูลวิดีโอ"
+
+#: id:20434
+msgid "Sets"
+msgstr "ตั้งค่า"
+
+#: id:20435
+msgid "Set movieset thumb"
+msgstr "ตั้งค่ารูปย่อภาพยนต์"
+
+#: id:20436
+msgid "Export actor thumbs?"
+msgstr "ส่งออกรูปย่อนักแสดง"
+
+#: id:20437
+msgid "Choose fanart"
+msgstr "เลือก fanart"
+
+#: id:20438
+msgid "Local fanart"
+msgstr "fanart ท้องถิ่น"
+
+#: id:20439
+msgid "No fanart"
+msgstr "ไม่มี fanart"
+
+#: id:20440
+msgid "Current fanart"
+msgstr "fanart ปัจจุบัน"
+
+#: id:20441
+msgid "Remote fanart"
+msgstr "รีโมท fanart"
+
+#: id:20442
+msgid "Change content"
+msgstr "เปลี่ยนเนื้อหา"
+
+#: id:20443
+msgid "Do you want to refresh info for all"
+msgstr "คุณต้องการที่จะเรียกใหม่ทั้งหมด"
+
+#: id:20444
+msgid "items within this path?"
+msgstr "สำหรับรายการที่อยู่ในพาธ?"
+
+#: id:20445
+msgid "Fanart"
+msgstr "Fanart"
+
+#: id:20446
+msgid "Locally stored information found."
+msgstr ""
+
+#: id:20447
+msgid "Ignore and refresh from internet?"
+msgstr ""
+
+#: id:20448
+msgid "Could not download information"
+msgstr ""
+
+#: id:20449
+msgid "Unable to connect to remote server"
+msgstr ""
+
+#: id:20450
+msgid "Would you like to continue scanning?"
+msgstr ""
+
+#: id:20451
+msgid "Countries"
+msgstr ""
+
+#: id:20452
+msgid "episode"
+msgstr ""
+
+#: id:20453
+msgid "episodes"
+msgstr ""
+
+#: id:20454
+msgid "Listener"
+msgstr ""
+
+#: id:20455
+msgid "Listeners"
+msgstr ""
+
+#: id:20456
+msgid "Set movieset fanart"
+msgstr ""
+
+#: id:20457
+msgid "Movie set"
+msgstr ""
+
+#: id:20458
+msgid "Group movies in sets"
+msgstr ""
+
+#: id:21330
+msgid "Show hidden files and directories"
+msgstr "แสดงแฟ้มและโฟลเดอร์ที่ซ่อน"
+
+#: id:21331
+msgid "TuxBox client"
+msgstr "ลูกข่าย TuxBox"
+
+#: id:21332
+msgid "WARNING: Target TuxBox device is in recording-mode!"
+msgstr "ระวัง: อุปกรณ์ TuxBox เป้าหมายกำลังบันทึก!"
+
+#: id:21333
+msgid "The stream will be stopped!"
+msgstr "การเชื่อต่อจะหยุด!"
+
+#: id:21334
+msgid "Zap to channel: %s failed!"
+msgstr "Zap ช่อง: %s ผิดพลาด!"
+
+#: id:21335
+msgid "Are you sure to start the stream?"
+msgstr "คุณต้องการที่จะเริ่มต้นหรือไม่?"
+
+#: id:21336
+msgid "Connecting to: %s"
+msgstr "กำลังเชื่อต่อ : %s"
+
+#: id:21337
+msgid "TuxBox device"
+msgstr "อุปกรณ์ TuxBox"
+
+#: id:21359
+msgid "Add media share..."
+msgstr "เพิ่มสื่อที่แบ่งปัน..."
+
+#: id:21360
+msgid "Share video and music libraries through UPnP"
+msgstr "แบ่งปันวิดีโอและเพลงผ่าน UPnP"
+
+#: id:21364
+msgid "Edit media share"
+msgstr "แก้ไขสื่อที่แบ่งปัน"
+
+#: id:21365
+msgid "Remove media share"
+msgstr "สื่อที่แบ่งปัน"
+
+#: id:21366
+msgid "Subtitle folder"
+msgstr "โฟลเดอร์ซับไตเติ้ล"
+
+#: id:21367
+msgid "Movie & alternate subtitle directory"
+msgstr "ไดเร็กทอรี่ภาพยนต์ & ซับไตเติ้ลสำรอง"
+
+#: id:21368
+msgid "Override ASS/SSA subtitles fonts"
+msgstr ""
+
+#: id:21369
+msgid "Enable mouse and Touch Screen support"
+msgstr "เปิดใช้งานเมาส์"
+
+#: id:21370
+msgid "Play navigation sounds during media playback"
+msgstr "เล่นเสียงนำทางระหว่างการเล่นสื่อ"
+
+#: id:21371
+msgid "Thumbnail"
+msgstr "รูปย่อ"
+
+#: id:21372
+msgid "Forced DVD player region"
+msgstr "บังคับตัวเล่นดีวีดีตามภูมิภาค"
+
+#: id:21373
+msgid "Video output"
+msgstr "การแสดงออกวิดีโอ"
+
+#: id:21374
+msgid "Video aspect"
+msgstr "ลักษณะวิดีโอ"
+
+#: id:21375
+msgctxt "Auto context with id 21375"
+msgid "Normal"
+msgstr "ปกติ"
+
+#: id:21376
+msgid "Letterbox"
+msgstr "กล่องจดหมาย"
+
+#: id:21377
+msgid "Widescreen"
+msgstr "จอกว้าง"
+
+#: id:21378
+msgid "Enable 480p"
+msgstr "เปิดใช้งาน 480p"
+
+#: id:21379
+msgid "Enable 720p"
+msgstr "เปิดใช้งาน 720p"
+
+#: id:21380
+msgid "Enable 1080i"
+msgstr "เปิดใช้งาน 1080i"
+
+#: id:21381
+msgid "Enter name of new playlist"
+msgstr "ป้อนชื่อรายการเพลงใหม่"
+
+#: id:21382
+msgid "Show \"Add source\" buttons in file lists"
+msgstr "แสดง \"เพิ่มแหล่งข้อมูล\" ในรายการแฟ้ม"
+
+#: id:21383
+msgid "Enable scrollbars"
+msgstr "เปิดใช้แถบเลื่อน"
+
+#: id:21384
+msgid "Make watched filtering a toggle in video library"
+msgstr "Make watched filtering a toggle in วิดีโอ คลังข้อมูล"
+
+#: id:21385
+msgctxt "Auto context with id 21385"
+msgid "Open"
+msgstr "เปิด"
+
+#: id:21386
+msgid "Acoustic management level"
+msgstr "ระดับการจัดการเสียง"
+
+#: id:21387
+msgid "Fast"
+msgstr "เร็ว"
+
+#: id:21388
+msgid "Quiet"
+msgstr "เงียบ"
+
+#: id:21389
+msgid "Enable custom background"
+msgstr "เปิดใช้งานปรับแต่งพื้นหลัง"
+
+#: id:21390
+msgid "Power management level"
+msgstr "ระดับการจัดการพลังงาน"
+
+#: id:21391
+msgid "High power"
+msgstr "High power"
+
+#: id:21392
+msgid "Low power"
+msgstr "Low power"
+
+#: id:21393
+msgid "High standby"
+msgstr "High standby"
+
+#: id:21394
+msgid "Low standby"
+msgstr "Low standby"
+
+#: id:21395
+msgid "Unable to cache files bigger than 4GB"
+msgstr "ไม่สามารถแคชแฟ้มใหญ่กว่า 4GB"
+
+#: id:21396
+msgid "Chapter"
+msgstr "บท"
+
+#: id:21397
+msgid "High quality pixel shader v2"
+msgstr "การไล่สีพิกเซลคุณภาพสูง v2"
+
+#: id:21398
+msgid "Enable playlist at startup"
+msgstr "เปิดใช้งานรายการเพลงเมื่อเริ่มต้น"
+
+#: id:21399
+msgid "Use tween animations"
+msgstr "ใช้ภาพเคลื่อนไหว"
+
+#: id:21400
+msgid "contains"
+msgstr "ประกอบด้วย"
+
+#: id:21401
+msgid "does not contain"
+msgstr "ไม่ประกอบด้วย"
+
+#: id:21402
+msgid "is"
+msgstr "เป็น"
+
+#: id:21403
+msgid "is not"
+msgstr "ไม่ใช่"
+
+#: id:21404
+msgid "starts with"
+msgstr "เริ่มต้นด้วย"
+
+#: id:21405
+msgid "ends with"
+msgstr "จบด้วย"
+
+#: id:21406
+msgid "greater than"
+msgstr "มากกว่า"
+
+#: id:21407
+msgid "less than"
+msgstr "น้อยกว่า"
+
+#: id:21408
+msgid "after"
+msgstr "หลัง"
+
+#: id:21409
+msgid "before"
+msgstr "ก่อน"
+
+#: id:21410
+msgid "in the last"
+msgstr "เป็นตัวสุดท้าย"
+
+#: id:21411
+msgid "not in the last"
+msgstr "ไม่เป็นตัวสุดท้าย"
+
+#: id:21412
+msgid "Scrapers"
+msgstr "Scrapers"
+
+#: id:21413
+msgid "Default movie scraper"
+msgstr "Default ภาพยนต์ scraper"
+
+#: id:21414
+msgid "Default tvshow scraper"
+msgstr "Default tvshow scraper"
+
+#: id:21415
+msgid "Default music video scraper"
+msgstr "Default เพลงวิดีโอ scraper"
+
+#: id:21416
+msgid "Enable fallback based on scraper language"
+msgstr "เปิดใช้งานตามภาษาเครื่อง"
+
+#: id:21417
+msgid "- Settings"
+msgstr "- การตั้งค่า"
+
+#: id:21418
+msgid "Multilingual"
+msgstr "หลายภาษา"
+
+#: id:21419
+msgid "No scrapers present"
+msgstr ""
+
+#: id:21420
+msgid "Value to match"
+msgstr "ค่าที่ตรงกัน"
+
+#: id:21421
+msgid "Smart playlist rule"
+msgstr "ตัวกรองรายการเพลง"
+
+#: id:21422
+msgid "Match items where"
+msgstr "รายการตรงตาม"
+
+#: id:21423
+msgid "New rule..."
+msgstr "สร้างรูปแบบการแสดงผล"
+
+#: id:21424
+msgid "Items must match"
+msgstr "รายการต้องตรงตาม"
+
+#: id:21425
+msgid "all of the rules"
+msgstr "รูปแบบการแสดงผลทั้งหมด"
+
+#: id:21426
+msgid "one or more of the rules"
+msgstr "หนึ่งหรือมากกกว่า"
+
+#: id:21427
+msgid "Limit to"
+msgstr "จำกัด"
+
+#: id:21428
+msgid "No limit"
+msgstr "ไม่จำกัด"
+
+#: id:21429
+msgid "Order by"
+msgstr "เรียงลำดับตาม"
+
+#: id:21430
+msgid "ascending"
+msgstr "น้อยไปมาก"
+
+#: id:21431
+msgid "descending"
+msgstr "มากไปน้อย"
+
+#: id:21432
+msgid "Edit smart playlist"
+msgstr "แก้ไขรายการเพลง"
+
+#: id:21433
+msgid "Name of the playlist"
+msgstr "ชื่อรายการเพลง"
+
+#: id:21434
+msgid "Find items where"
+msgstr "ค้นหารายการ"
+
+#: id:21435
+msgid "Edit"
+msgstr "- แก้ไข"
+
+#: id:21436
+msgid "%i items"
+msgstr "%i รายการ"
+
+#: id:21437
+msgid "New smart playlist..."
+msgstr "สร้างรายการเพลงที่จะเเล่น..."
+
+#: id:21438
+msgid "%c Drive"
+msgstr "%c ไดร์ฟ"
+
+#: id:21439
+msgid "Edit party mode rules"
+msgstr "แก้ไขปาตี้โหมด"
+
+#: id:21440
+msgid "Home folder"
+msgstr "โฟลเดอร์หลัก"
+
+#: id:21441
+msgid "Watched count"
+msgstr "จำนวนคนดู"
+
+#: id:21442
+msgid "Episode title"
+msgstr "ชื่อตอน"
+
+#: id:21443
+msgid "Video resolution"
+msgstr "ความละเอียดภาพยนต์"
+
+#: id:21444
+msgid "Audio channels"
+msgstr "ช่องเสียง"
+
+#: id:21445
+msgid "Video codec"
+msgstr "ตัวแปลงสัญญาณวิดีโอ"
+
+#: id:21446
+msgid "Audio codec"
+msgstr "ตัวแปลงสัญญาณเสียง"
+
+#: id:21447
+msgid "Audio language"
+msgstr "ภาษาเสียง"
+
+#: id:21448
+msgid "Subtitle language"
+msgstr "ภาษาซับไตเติ้ล"
+
+#: id:21449
+msgid "Remote control sends keyboard presses"
+msgstr "รีโมทส่งคำสั่งคีย์บอร์ด"
+
+#: id:21450
+msgid "- Edit"
+msgstr ""
+
+#: id:21451
+msgid "Internet connection required."
+msgstr ""
+
+#: id:21452
+msgid "Get More..."
+msgstr ""
+
+#: id:21453
+msgid "Root filesystem"
+msgstr ""
+
+#: id:21454
+msgid "Cache full"
+msgstr ""
+
+#: id:21455
+msgid "Cache filled before reaching required amount for continous playback"
+msgstr ""
+
+#: id:21460
+msgid "Subtitle location"
+msgstr ""
+
+#: id:21461
+msgid "Fixed"
+msgstr ""
+
+#: id:21462
+msgid "Bottom of video"
+msgstr ""
+
+#: id:21463
+msgid "Below video"
+msgstr ""
+
+#: id:21464
+msgid "Top of video"
+msgstr ""
+
+#: id:21465
+msgid "Above video"
+msgstr ""
+
+#: id:21800
+msgid "File name"
+msgstr "ชื่อแฟ้ม"
+
+#: id:21801
+msgid "File path"
+msgstr "พาธแฟ้ม"
+
+#: id:21802
+msgid "File size"
+msgstr "ขนาดแฟ้ม"
+
+#: id:21803
+msgid "File date/time"
+msgstr "วันที่/เวลาแฟ้ม"
+
+#: id:21804
+msgid "Slide index"
+msgstr "ดัชนี"
+
+#: id:21805
+msgctxt "Auto context with id 21805"
+msgid "Resolution"
+msgstr "ความละเอียด"
+
+#: id:21806
+msgctxt "Auto context with id 21806"
+msgid "Comment"
+msgstr "ข้อคิดเห็น"
+
+#: id:21807
+msgid "Colour/B&W"
+msgstr "สี /สมดุลแสงขาว"
+
+#: id:21808
+msgid "JPEG process"
+msgstr "JPEG process"
+
+#: id:21820
+msgid "Date/Time"
+msgstr "วันที่/เวลา"
+
+#: id:21821
+msgid "Description"
+msgstr "คำอธิบาย"
+
+#: id:21822
+msgid "Camera make"
+msgstr "Camera make"
+
+#: id:21823
+msgid "Camera model"
+msgstr "รุ่นกล้อง"
+
+#: id:21824
+msgid "EXIF comment"
+msgstr "ข้อคิดเห็นข้อมูลภาพ"
+
+#: id:21825
+msgid "Firmware"
+msgstr "เฟิร์มแวร์"
+
+#: id:21826
+msgid "Aperture"
+msgstr "ช่อง"
+
+#: id:21827
+msgid "Focal length"
+msgstr "ความยาวโฟกัส"
+
+#: id:21828
+msgid "Focus distance"
+msgstr "ระยะโฟกัส"
+
+#: id:21829
+msgid "Exposure"
+msgstr "ความเร็วชัตเตอร์"
+
+#: id:21830
+msgid "Exposure time"
+msgstr "ความเร็วชัตเตอร์"
+
+#: id:21831
+msgid "Exposure bias"
+msgstr "การชดเชยแสง"
+
+#: id:21832
+msgid "Exposure mode"
+msgstr "โหมดความเร็วชัตเตอร์"
+
+#: id:21833
+msgid "Flash used"
+msgstr "ใช้แฟรช"
+
+#: id:21834
+msgid "White-balance"
+msgstr "แสงสมดุล"
+
+#: id:21835
+msgid "Light source"
+msgstr "แหล่งของแสง"
+
+#: id:21836
+msgid "Metering mode"
+msgstr "โหมด Metering"
+
+#: id:21837
+msgid "ISO"
+msgstr "ISO"
+
+#: id:21838
+msgid "Digital zoom"
+msgstr "ดิจิทัลซูม"
+
+#: id:21839
+msgid "CCD width"
+msgstr "CCD กว้าง"
+
+#: id:21840
+msgid "GPS latitude"
+msgstr "GPS ละติจูด"
+
+#: id:21841
+msgid "GPS longitude"
+msgstr "GPS ลองติจูด"
+
+#: id:21842
+msgid "GPS altitude"
+msgstr "GPS ระดับความสูล"
+
+#: id:21843
+msgid "Orientation"
+msgstr "ปฐมนิเทศ"
+
+#: id:21860
+msgid "Supplemental categories"
+msgstr "ประเภทเพิ่มเติม"
+
+#: id:21861
+msgid "Keywords"
+msgstr "คำสำคัญ"
+
+#: id:21862
+msgid "Caption"
+msgstr "คำบรรยาย"
+
+#: id:21863
+msgid "Author"
+msgstr "ผู้แต่ง"
+
+#: id:21864
+msgid "Headline"
+msgstr "หัวเรื่อง"
+
+#: id:21865
+msgid "Special instructions"
+msgstr "คำแนะนำพิเศษ"
+
+#: id:21866
+msgid "Category"
+msgstr "หมวด"
+
+#: id:21867
+msgid "Byline"
+msgstr "เรื่องย่อย"
+
+#: id:21868
+msgid "Byline title"
+msgstr "ชื่อเรื่องย่อย"
+
+#: id:21869
+msgid "Credit"
+msgstr "เครดิต"
+
+#: id:21870
+msgid "Source"
+msgstr "แหล่งข้อมูล"
+
+#: id:21871
+msgid "Copyright notice"
+msgstr "แจ้งให้ทราบเกี่ยวกับลิขสิทธิ์"
+
+#: id:21872
+msgid "Object name"
+msgstr "ชื่อวัตถุ"
+
+#: id:21873
+msgid "City"
+msgstr "เมือง"
+
+#: id:21874
+msgid "State"
+msgstr "ถนน"
+
+#: id:21875
+msgctxt "Auto context with id 21875"
+msgid "Country"
+msgstr "ประเทศ"
+
+#: id:21876
+msgid "Original Tx Reference"
+msgstr "อ้างอิง Tx ต้นฉบับ"
+
+#: id:21877
+msgid "Date created"
+msgstr "สร้างข้อมูลแล้ว"
+
+#: id:21878
+msgid "Copyright flag"
+msgstr "สถานะลิขสิทธิ์"
+
+#: id:21879
+msgid "Country code"
+msgstr "รหัสประเทศ"
+
+#: id:21880
+msgid "Reference service"
+msgstr "บริการอ้งอิง"
+
+#: id:21881
+msgid "Allow control of XBMC via UPnP"
+msgstr "อนุญาตควบคุม XBMC ผ่าน UPnP"
+
+#: id:21882
+msgid "Attempt to skip introduction before DVD menu"
+msgstr "ข้ามการแนะนำก่อนเมนู"
+
+#: id:21883
+msgid "Saved music"
+msgstr "เพลงที่เก็บไว้"
+
+#: id:21884
+msgid "Query info for all artists"
+msgstr "สอบถามข้อมูสำหรับศิลปินทั้งหมด"
+
+#: id:21885
+msgid "Downloading album information"
+msgstr "กำลังโหลดข้อมูลอัลบั้ม"
+
+#: id:21886
+msgid "Downloading artist information"
+msgstr "กำลังโหลดข้อมูลศิลปิน"
+
+#: id:21887
+msgid "Biography"
+msgstr "ประวัติ"
+
+#: id:21888
+msgid "Discography"
+msgstr "ของสะสม"
+
+#: id:21889
+msgid "Searching artist"
+msgstr "ค้นหาศิลปิน"
+
+#: id:21890
+msgid "Select artist"
+msgstr "ศิลปินที่เลือก"
+
+#: id:21891
+msgctxt "Auto context with id 21891"
+msgid "Artist information"
+msgstr "ข้อมูลศิลปิน"
+
+#: id:21892
+msgid "Instruments"
+msgstr "เครื่องเสียง"
+
+#: id:21893
+msgid "Born"
+msgstr "เกิด"
+
+#: id:21894
+msgid "Formed"
+msgstr "รูปแบบ"
+
+#: id:21895
+msgid "Themes"
+msgstr "ชุดตกแต่ง"
+
+#: id:21896
+msgid "Disbanded"
+msgstr "แยกย้าย"
+
+#: id:21897
+msgid "Died"
+msgstr "สิ้นอายุ"
+
+#: id:21898
+msgid "Years active"
+msgstr "ปี"
+
+#: id:21899
+msgid "Label"
+msgstr "ป้ายชื่อ"
+
+#: id:21900
+msgid "Born/Formed"
+msgstr "เกิด/ก่อตั้ง"
+
+#: id:22000
+msgid "Update library on startup"
+msgstr "ปรับปรุงคลังข้อมูลเมื่อเริ่มต้นการทำงาน"
+
+#: id:22001
+msgid "Hide progress of library updates"
+msgstr "ปรังปรุงคลังแบบพื้นหลังเสมอ"
+
+#: id:22002
+msgid "- DNS suffix"
+msgstr "- DNS ต่อท้าย"
+
+#: id:22003
+msgid "%2.3fs"
+msgstr ""
+
+#: id:22004
+msgid "Delayed by: %2.3fs"
+msgstr "หน่วงเวลา: %2.3fs"
+
+#: id:22005
+msgid "Ahead by: %2.3fs"
+msgstr "ไปข้างหน้า: %2.3fs"
+
+#: id:22006
+msgid "Subtitle offset"
+msgstr "ซับไตไติ้ลออฟเซ็ต"
+
+#: id:22007
+msgid "OpenGL vendor:"
+msgstr "ผู้ผลิด OpenGL:"
+
+#: id:22008
+msgid "OpenGL renderer:"
+msgstr "OpenGL renderer:"
+
+#: id:22009
+msgid "OpenGL version:"
+msgstr "รุ่น OpenGL:"
+
+#: id:22010
+msgid "GPU temperature:"
+msgstr "GPU อุณหภูมิ:"
+
+#: id:22011
+msgid "CPU temperature:"
+msgstr "CPU อุณหภูมิ:"
+
+#: id:22012
+msgid "Total memory"
+msgstr "หน่วยความจำทั้งหมด"
+
+#: id:22013
+msgid "Profile data"
+msgstr "ข้อมูลส่วนตัว"
+
+#: id:22014
+msgid "Use dim if paused during video playback"
+msgstr "Use dim if paused during video playback"
+
+#: id:22015
+msgid "All recordings"
+msgstr "ที่จดจำทั้งหมด"
+
+#: id:22016
+msgid "By title"
+msgstr "ชื่อเรื่อง"
+
+#: id:22017
+msgid "By group"
+msgstr "กลุ่ม"
+
+#: id:22018
+msgid "Live channels"
+msgstr "ช่องสด"
+
+#: id:22019
+msgid "Recordings by title"
+msgstr "บันทึกตามชื่อเรื่อง"
+
+#: id:22020
+msgid "Guide"
+msgstr "ตัวนำทาง"
+
+#: id:22021
+msgid "Allowed error in aspect ratio to minimize black bars"
+msgstr "Allowed error in aspect ratio to minimize black bars"
+
+#: id:22022
+msgid "Show video files in listings"
+msgstr "แสดงแฟ้มวิดีโอระหว่างฟังเพลง"
+
+#: id:22023
+msgid "DirectX vendor:"
+msgstr "ผู้ผลิด DirectX:"
+
+#: id:22024
+msgid "Direct3D version:"
+msgstr "Direct3Dเวอร์ชัน:"
+
+#: id:22030
+msgctxt "Auto context with id 22030"
+msgid "Font"
+msgstr "ตัวอักษร"
+
+#: id:22031
+msgctxt "Auto context with id 22031"
+msgid "- Size"
+msgstr "- ขนาด"
+
+#: id:22032
+msgctxt "Auto context with id 22032"
+msgid "- Colours"
+msgstr "- สี"
+
+#: id:22033
+msgid "- Charset"
+msgstr "- ชุดอักขระ"
+
+#: id:22034
+msgid "Export karaoke titles as HTML"
+msgstr "ส่งออกชื่อเพลงคาราโอเกะเป็น HTML"
+
+#: id:22035
+msgid "Export karaoke titles as CSV"
+msgstr "ส่งออกชื่อเพลงคาราโอเกะเป็น CSV"
+
+#: id:22036
+msgid "Import karaoke titles..."
+msgstr "นำเข้าชื่อเพลงคาราโอเกะ..."
+
+#: id:22037
+msgid "Show song selector automatically"
+msgstr "แสดงการเลือกเพลงอัตโนมัติ"
+
+#: id:22038
+msgid "Export karaoke titles..."
+msgstr "ส่งออกชื่อเพลงคาราโอเกะ..."
+
+#: id:22039
+msgid "Enter song number"
+msgstr "ป้อนหมายเลขเพลง"
+
+#: id:22040
+msgid "white/green"
+msgstr "ขาว/เขียว"
+
+#: id:22041
+msgid "white/red"
+msgstr "ขาว/แดง"
+
+#: id:22042
+msgid "white/blue"
+msgstr "ขาว/ฟ้า"
+
+#: id:22043
+msgid "black/white"
+msgstr "ดำ/ขาว"
+
+#: id:22079
+msgid "Default select action"
+msgstr ""
+
+#: id:22080
+msgid "Choose"
+msgstr ""
+
+#: id:22081
+msgid "Show Information"
+msgstr ""
+
+#: id:22082
+msgid "More..."
+msgstr ""
+
+#: id:22083
+msgid "Play all"
+msgstr ""
+
+#: id:23049
+msgid "Teletext not available"
+msgstr ""
+
+#: id:23050
+msgid "Activate Teletext"
+msgstr "ทำงาน Teletext"
+
+#: id:23051
+msgid "Part %i"
+msgstr "ส่วนที่ %i"
+
+#: id:23052
+msgid "Buffering %i bytes"
+msgstr "บัฟเฟอร์ %i bytes"
+
+#: id:23053
+msgid "Stopping"
+msgstr ""
+
+#: id:23054
+msgid "Running"
+msgstr ""
+
+#: id:23100
+msgid "External Player Active"
+msgstr "ตัวเล่นภายนอกทำงาน"
+
+#: id:23101
+msgid "Click OK to terminate the player"
+msgstr "กด OK เพื่อปิดตัวเล่นเพลง"
+
+#: id:23104
+msgid "Click OK when playback has ended"
+msgstr "กด OK เมื่อเล่นเพลงจบ"
+
+#: id:24000
+msgid "Add-on"
+msgstr ""
+
+#: id:24001
+msgid "Add-ons"
+msgstr ""
+
+#: id:24002
+msgid "Add-on options"
+msgstr ""
+
+#: id:24003
+msgid "Add-on Information"
+msgstr ""
+
+#: id:24005
+msgctxt "Auto context with id 24005"
+msgid "Media sources"
+msgstr ""
+
+#: id:24007
+msgctxt "Auto context with id 24007"
+msgid "Movie information"
+msgstr ""
+
+#: id:24008
+msgctxt "Auto context with id 24008"
+msgid "Screensaver"
+msgstr ""
+
+#: id:24009
+msgid "Script"
+msgstr ""
+
+#: id:24010
+msgctxt "Auto context with id 24010"
+msgid "Visualization"
+msgstr ""
+
+#: id:24011
+msgid "Add-on repository"
+msgstr ""
+
+#: id:24012
+msgctxt "Auto context with id 24012"
+msgid "Subtitles"
+msgstr ""
+
+#: id:24013
+msgid "Lyrics"
+msgstr ""
+
+#: id:24014
+msgid "TV information"
+msgstr ""
+
+#: id:24015
+msgctxt "Auto context with id 24015"
+msgid "Music video information"
+msgstr ""
+
+#: id:24016
+msgctxt "Auto context with id 24016"
+msgid "Album information"
+msgstr ""
+
+#: id:24017
+msgctxt "Auto context with id 24017"
+msgid "Artist information"
+msgstr ""
+
+#: id:24018
+msgctxt "Auto context with id 24018"
+msgid "Services"
+msgstr ""
+
+#: id:24020
+msgid "Configure"
+msgstr ""
+
+#: id:24021
+msgctxt "Auto context with id 24021"
+msgid "Disable"
+msgstr ""
+
+#: id:24022
+msgid "Enable"
+msgstr ""
+
+#: id:24023
+msgid "Add-on disabled"
+msgstr ""
+
+#: id:24027
+msgctxt "Auto context with id 24027"
+msgid "Weather"
+msgstr ""
+
+#: id:24028
+msgid "Weather.com (standard)"
+msgstr ""
+
+#: id:24030
+msgid "This Add-on can not be configured"
+msgstr ""
+
+#: id:24031
+msgid "Error loading settings"
+msgstr ""
+
+#: id:24032
+msgid "All Add-ons"
+msgstr ""
+
+#: id:24033
+msgid "Get Add-ons"
+msgstr ""
+
+#: id:24034
+msgid "Check for updates"
+msgstr ""
+
+#: id:24035
+msgid "Force refresh"
+msgstr ""
+
+#: id:24036
+msgid "Change log"
+msgstr ""
+
+#: id:24037
+msgid "Uninstall"
+msgstr ""
+
+#: id:24038
+msgid "Install"
+msgstr ""
+
+#: id:24039
+msgid "Disabled Add-ons"
+msgstr ""
+
+#: id:24040
+msgid "(Clear the current setting)"
+msgstr ""
+
+#: id:24041
+msgid "Install from zip file"
+msgstr ""
+
+#: id:24042
+msgid "Downloading %i%%"
+msgstr ""
+
+#: id:24043
+msgid "Available Updates"
+msgstr ""
+
+#: id:24044
+msgid "Dependencies not met"
+msgstr ""
+
+#: id:24045
+msgid "Add-on does not have the correct structure"
+msgstr ""
+
+#: id:24046
+msgid "%s is used by the following installed add-on(s)"
+msgstr ""
+
+#: id:24047
+msgid "This add-on cannot be uninstalled"
+msgstr ""
+
+#: id:24048
+msgid "Rollback"
+msgstr ""
+
+#: id:24050
+msgid "Available Add-ons"
+msgstr ""
+
+#: id:24051
+msgid "Version:"
+msgstr ""
+
+#: id:24052
+msgid "Disclaimer"
+msgstr ""
+
+#: id:24053
+msgid "License:"
+msgstr ""
+
+#: id:24054
+msgid "Changelog"
+msgstr ""
+
+#: id:24059
+msgid "Would you like to enable this Add-on?"
+msgstr ""
+
+#: id:24060
+msgid "Would you like to disable this Add-on?"
+msgstr ""
+
+#: id:24061
+msgid "Add-on update available!"
+msgstr ""
+
+#: id:24062
+msgid "Enabled Add-ons"
+msgstr ""
+
+#: id:24063
+msgid "Auto update"
+msgstr ""
+
+#: id:24064
+msgid "Add-on enabled"
+msgstr ""
+
+#: id:24065
+msgid "Add-on updated"
+msgstr ""
+
+#: id:24066
+msgid "Cancel Add-on download?"
+msgstr ""
+
+#: id:24067
+msgid "Currently downloading Add-ons"
+msgstr ""
+
+#: id:24068
+msgid "Update available"
+msgstr ""
+
+#: id:24069
+msgid "Update"
+msgstr ""
+
+#: id:24070
+msgid "Add-on could not be loaded."
+msgstr ""
+
+#: id:24071
+msgid "An unknown error has occurred."
+msgstr ""
+
+#: id:24072
+msgid "Settings required"
+msgstr ""
+
+#: id:24073
+msgid "Could not connect"
+msgstr ""
+
+#: id:24074
+msgid "Needs to restart"
+msgstr ""
+
+#: id:24075
+msgctxt "Auto context with id 24075"
+msgid "Disable"
+msgstr ""
+
+#: id:24076
+msgid "Add-on Required"
+msgstr ""
+
+#: id:24080
+msgid "Try to reconnect?"
+msgstr ""
+
+#: id:24089
+msgid "Add-on restarts"
+msgstr ""
+
+#: id:24090
+msgid "Lock Add-on manager"
+msgstr ""
+
+#: id:24094
+msgid "(current)"
+msgstr ""
+
+#: id:24095
+msgid "(blacklisted)"
+msgstr ""
+
+#: id:24096
+msgid "Add-on has been marked as broken in repository."
+msgstr ""
+
+#: id:24097
+msgid "Would you like to disable it on your system?"
+msgstr ""
+
+#: id:24098
+msgid "Broken"
+msgstr ""
+
+#: id:24099
+msgid "Would you like to switch to this skin?"
+msgstr ""
+
+#: id:24100
+msgid "To use this feature you must download an Add-on:"
+msgstr ""
+
+#: id:24101
+msgid "Would you like to download this Add-on?"
+msgstr ""
+
+#: id:25000
+msgid "Notifications"
+msgstr ""
+
+#: id:29800
+msgid "Library Mode"
+msgstr "โหมดคลังข้อมูล"
+
+#: id:29801
+msgid "QWERTY keyboard"
+msgstr "QWERTY keyboard"
+
+#: id:29802
+msgid "Passthrough Audio in use"
+msgstr "Passthrough Audio in use"
+
+#: id:33001
+msgid "Trailer quality"
+msgstr "คุณภาพตัวอย่าง"
+
+#: id:33002
+msgid "Stream"
+msgstr "Stream"
+
+#: id:33003
+msgid "Download"
+msgstr "ดาวน์โหลด"
+
+#: id:33004
+msgid "Download & play"
+msgstr "ดาวน์โหลด & เล่น"
+
+#: id:33005
+msgid "Download & save"
+msgstr "ดาวน์โหลด & บันทึก"
+
+#: id:33006
+msgid "Today"
+msgstr "วันนี้"
+
+#: id:33007
+msgid "Tomorrow"
+msgstr "พรุ่งนี้"
+
+#: id:33008
+msgid "Saving"
+msgstr "บันทึก"
+
+#: id:33009
+msgid "Copying"
+msgstr "คัดลอก"
+
+#: id:33010
+msgid "Set download directory"
+msgstr "จัดโฟล์เดอร์เก็บไฟล์ดาวน์โหลด"
+
+#: id:33011
+msgid "Search duration"
+msgstr ""
+
+#: id:33012
+msgid "Short"
+msgstr "สั้น"
+
+#: id:33013
+msgid "Long"
+msgstr "นาน"
+
+#: id:33014
+msgid "Use DVD player instead of regular player"
+msgstr "ใช้ตัวเล่นดีวีดีแทนตัวเล่นปกติ"
+
+#: id:33015
+msgid "Ask for download before playing video"
+msgstr "ถมการดาวน์โหลดก่อนเริ่มเล่น"
+
+#: id:33016
+msgid "Clips"
+msgstr "คลิป"
+
+#: id:33017
+msgid "Restart plugin to enable"
+msgstr "เริ่มการทำงานใหม่เพื่อใช้งาน"
+
+#: id:33018
+msgid "Tonight"
+msgstr "คืนนี้"
+
+#: id:33019
+msgid "Tomorrow Night"
+msgstr "คืนพรุ่งนี้"
+
+#: id:33020
+msgid "Condition"
+msgstr "เงื่อนไข"
+
+#: id:33021
+msgid "Precipitation"
+msgstr "Precipitation"
+
+#: id:33022
+msgid "Precip"
+msgstr "Precip"
+
+#: id:33023
+msgid "Humid"
+msgstr "Humid"
+
+#: id:33024
+msgid "Feels"
+msgstr "รู้สึก"
+
+#: id:33025
+msgid "Observed"
+msgstr "สังเกต"
+
+#: id:33026
+msgid "Departure from normal"
+msgstr "Departure from normal"
+
+#: id:33027
+msgid "Sunrise"
+msgstr "พระอาทิตย์ขั้น"
+
+#: id:33028
+msgid "Sunset"
+msgstr "พระอาทิตย์ตก"
+
+#: id:33029
+msgid "Details"
+msgstr "รายละเอียด"
+
+#: id:33030
+msgid "Outlook"
+msgstr "Outlook"
+
+#: id:33031
+msgid "Coverflow"
+msgstr "Coverflow"
+
+#: id:33032
+msgid "Translate text"
+msgstr "แปลตัวอักษร"
+
+#: id:33033
+msgid "Map list %s category"
+msgstr "รายการแผนที่ %s"
+
+#: id:33034
+msgid "36 Hour"
+msgstr "36 ชั่วโมง"
+
+#: id:33035
+msgid "Maps"
+msgstr "อผนที่"
+
+#: id:33036
+msgid "Hourly"
+msgstr "ทุกชั่วโมง"
+
+#: id:33037
+msgid "Weekend"
+msgstr "สุดสัปดาห์"
+
+#: id:33038
+msgid "%s day"
+msgstr "%s วัน"
+
+#: id:33049
+msgid "Alert"
+msgstr "เตือน"
+
+#: id:33050
+msgid "Alerts"
+msgstr "เตือน"
+
+#: id:33051
+msgid "Choose Your"
+msgstr "เลือก"
+
+#: id:33052
+msgid "Check"
+msgstr "ตรวจสอบ"
+
+#: id:33053
+msgctxt "Auto context with id 33053"
+msgid "Configure the"
+msgstr "ปรับแต่ง"
+
+#: id:33054
+msgid "Seasons"
+msgstr "ฤดู"
+
+#: id:33055
+msgid "Use your"
+msgstr "ใช้"
+
+#: id:33056
+msgid "Watch your"
+msgstr "ดู"
+
+#: id:33057
+msgid "Listen to"
+msgstr "ฟัง"
+
+#: id:33058
+msgid "View your"
+msgstr "ดู"
+
+#: id:33059
+msgctxt "Auto context with id 33059"
+msgid "Configure the"
+msgstr "ปรับตั้งค่า"
+
+#: id:33060
+msgid "Power"
+msgstr "ปิดเครื่อง"
+
+#: id:33061
+msgid "Menu"
+msgstr "เมนู"
+
+#: id:33062
+msgid "Play the"
+msgstr "เล่น"
+
+#: id:33063
+msgid "Options"
+msgstr "ตัวเลือก"
+
+#: id:33065
+msgid "Editor"
+msgstr "ตัวแก้ไข"
+
+#: id:33066
+msgid "About your"
+msgstr "เกี่ยวกับคุณ"
+
+#: id:33067
+msgid "Star rating"
+msgstr "Star rating"
+
+#: id:33068
+msgid "Background"
+msgstr "พื้นหลัง"
+
+#: id:33069
+msgid "Backgrounds"
+msgstr "พื้นหลัง"
+
+#: id:33070
+msgid "Custom background"
+msgstr "ปรับแต่งพื้นหลัง"
+
+#: id:33071
+msgid "Custom backgrounds"
+msgstr "ปรับแต่งพื้นหลัง"
+
+#: id:33072
+msgid "View Readme"
+msgstr "อ่านรายละเอียดโปรแรกม"
+
+#: id:33073
+msgid "View Changelog"
+msgstr "ดูข้อมูลการปรับปรุงรุ่น"
+
+#: id:33074
+msgid "This version of %s requires an"
+msgstr "เวอร์ชั่น %s ต้องการ"
+
+#: id:33075
+msgid "XBMC revision of %s or greater to run."
+msgstr "XBMC รุ่นปรับปรุง %s หรือใหม่กว่าในการทำงาน."
+
+#: id:33076
+msgid "Please update XBMC."
+msgstr "กรุณาปรับปรุงรุ่น XBMC."
+
+#: id:33077
+msgid "No data found!"
+msgstr "ไม่พบข้อมูล!"
+
+#: id:33078
+msgid "Next page"
+msgstr "หน้าต่อไป"
+
+#: id:33079
+msgid "Love"
+msgstr "รัก"
+
+#: id:33080
+msgid "Hate"
+msgstr "เกลียด"
+
+#: id:33081
+msgid "This file is stacked, select the part you want to play from."
+msgstr "This แฟ้ม is stacked, select the part you want to play from."
+
+#: id:33082
+msgid "Path to script"
+msgstr "พาธสคริปต์"
+
+#: id:33083
+msgid "Enable custom script button"
+msgstr "เปิดใช้ปุ่มสริปต์กำหนดเอง"
+
+#: id:33100
+msgid "Failed to start"
+msgstr ""
+
+#: id:33101
+msgid "Webserver"
+msgstr ""
+
+#: id:33102
+msgid "Event Server"
+msgstr ""
+
+#: id:33103
+msgid "Remote communication server"
+msgstr ""
+
+#: id:33200
+msgid "Detected New Connection"
+msgstr ""
+
+#: id:34000
+msgid "Lame"
+msgstr ""
+
+#: id:34001
+msgid "Vorbis"
+msgstr ""
+
+#: id:34002
+msgid "Wav"
+msgstr ""
+
+#: id:34003
+msgid "DXVA2"
+msgstr ""
+
+#: id:34004
+msgid "VAAPI"
+msgstr ""
+
+#: id:34005
+msgid "Flac"
+msgstr ""
+
+#: id:34100
+msgid "Speaker Configuration"
+msgstr ""
+
+#: id:34101
+msgid "2.0"
+msgstr ""
+
+#: id:34102
+msgid "2.1"
+msgstr ""
+
+#: id:34103
+msgid "3.0"
+msgstr ""
+
+#: id:34104
+msgid "3.1"
+msgstr ""
+
+#: id:34105
+msgid "4.0"
+msgstr ""
+
+#: id:34106
+msgid "4.1"
+msgstr ""
+
+#: id:34107
+msgid "5.0"
+msgstr ""
+
+#: id:34108
+msgid "5.1"
+msgstr ""
+
+#: id:34109
+msgid "7.0"
+msgstr ""
+
+#: id:34110
+msgid "7.1"
+msgstr ""
+
+#: id:34201
+msgid "Can't find a next item to play"
+msgstr ""
+
+#: id:34202
+msgid "Can't find a previous item to play"
+msgstr ""
+
+#: id:34300
+msgid "Failed to start zeroconf"
+msgstr ""
+
+#: id:34301
+msgid "Is Apple's Bonjour Service installed? See log for more info."
+msgstr ""
+
+#: id:34400
+msgid "Video Rendering"
+msgstr ""
+
+#: id:34401
+msgid "Failed to init video filters/scalers, falling back to bilinear scaling"
+msgstr ""
+
+#: id:34402
+msgid "Failed to initialize audio device"
+msgstr ""
+
+#: id:34403
+msgid "Check your audiosettings"
+msgstr ""
+
+#: id:34404
+msgid "Use gestures for navigation:"
+msgstr ""
+
+#: id:34405
+msgid "1 finger swipe left,right,up,down for cursors"
+msgstr ""
+
+#: id:34406
+msgid "2 finger swipe left for backspace"
+msgstr ""
+
+#: id:34407
+msgid "1 finger single tap for enter"
+msgstr ""
+
+#: id:34408
+msgid "2 finger single tap for contextmenu"
+msgstr ""
+
+#: id:35000
+msgid "Peripherals"
+msgstr ""
+
+#: id:35001
+msgid "Generic HID device"
+msgstr ""
+
+#: id:35002
+msgid "Generic network adapter"
+msgstr ""
+
+#: id:35003
+msgid "Generic disk"
+msgstr ""
+
+#: id:35004
+msgid "There are no settings available\nfor this peripheral."
+msgstr ""
+
+#: id:35005
+msgid "New device configured"
+msgstr ""
+
+#: id:35006
+msgid "Device removed"
+msgstr ""
+
+#: id:35007
+msgid "Keymap to use for this device"
+msgstr ""
+
+#: id:35008
+msgid "Keymap enabled"
+msgstr ""
+
+#: id:35009
+msgid "Do not use the custom keymap for this device"
+msgstr ""
+
+#: id:35500
+msgid "Location"
+msgstr ""
+
+#: id:35501
+msgid "Class"
+msgstr ""
+
+#: id:35502
+msgctxt "Auto context with id 35502"
+msgid "Name"
+msgstr ""
+
+#: id:35503
+msgid "Vendor"
+msgstr ""
+
+#: id:35504
+msgid "Product ID"
+msgstr ""
+
+#: id:36000
+msgid "Pulse-Eight CEC adapter"
+msgstr ""
+
+#: id:36001
+msgid "Pulse-Eight Nyxboard"
+msgstr ""
+
+#: id:36002
+msgid "Switch to keyboard side command"
+msgstr ""
+
+#: id:36003
+msgid "Switch to remote side command"
+msgstr ""
+
+#: id:36004
+msgid "Press \"user\" button command"
+msgstr ""
+
+#: id:36005
+msgid "Enable switch side commands"
+msgstr ""
+
+#: id:36006
+msgid "Could not open the adapter"
+msgstr ""
+
+#: id:36007
+msgid "Devices to power on when starting XBMC"
+msgstr ""
+
+#: id:36008
+msgid "Devices to power off when stopping XBMC"
+msgstr ""
+
+#: id:36009
+msgid "Put devices in standby mode when activating screensaver"
+msgstr ""
+
+#: id:36011
+msgid "Could not detect the CEC port. Set it up manually."
+msgstr ""
+
+#: id:36012
+msgid "Could not initialise the CEC adapter. Check your settings."
+msgstr ""
+
+#: id:36013
+msgid "Unsupported libCEC interface version. %d is greater than the version XBMC supports (%d)"
+msgstr ""
+
+#: id:36014
+msgid "Put this PC in standby mode when the TV is switched off"
+msgstr ""
+
+#: id:36015
+msgid "HDMI port number"
+msgstr ""
+
+#: id:36016
+msgctxt "Auto context with id 36016"
+msgid "Connected"
+msgstr ""
+
+#: id:36017
+msgid "Adapter found, but libCEC is not available"
+msgstr ""
+
+#: id:36018
+msgid "Use the TV's language setting"
+msgstr ""
+
+#: id:36019
+msgid "Connected to HDMI device"
+msgstr ""
+
+#: id:36020
+msgid "Make XBMC the active source when starting"
+msgstr ""
+
+#: id:36021
+msgid "Physical address (overrules HDMI port)"
+msgstr ""
+
+#: id:36022
+msgid "COM port (leave empty unless needed)"
+msgstr ""
+
+#: id:36023
+msgid "Configuration updated"
+msgstr ""
+
+#: id:36024
+msgid "Failed to set the new configuration. Please check your settings."
+msgstr ""
+
+#: id:36025
+msgid "Send 'inactive source' command when stopping XBMC"
+msgstr ""
+

--- a/language/Turkish/strings.po
+++ b/language/Turkish/strings.po
@@ -1,0 +1,9093 @@
+# Converted from xbmc strings.xml with xbmc-xml2po (by Team-XBMC)
+msgid ""
+msgstr ""
+"Project-Id-Version: xbmc.core-FRODO_GIT3ed1604ad7\n"
+"Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
+"POT-Creation-Date: 2012-04-09 18:00+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE\n"
+"Language: tr\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: id:0
+msgctxt "Auto context with id 0"
+msgid "Programs"
+msgstr "Programlar"
+
+#: id:1
+msgctxt "Auto context with id 1"
+msgid "Pictures"
+msgstr "Resimler"
+
+#: id:2
+msgctxt "Auto context with id 2"
+msgid "Music"
+msgstr "Müzik"
+
+#: id:3
+msgctxt "Auto context with id 3"
+msgid "Videos"
+msgstr "Videolar"
+
+#: id:4
+msgid "TV-Guide"
+msgstr "TV-Rehberi"
+
+#: id:5
+msgctxt "Auto context with id 5"
+msgid "Settings"
+msgstr "Ayarlar"
+
+#: id:6
+msgid "XBMC SVN"
+msgstr "XBMC SVN"
+
+#: id:7
+msgctxt "Auto context with id 7"
+msgid "File manager"
+msgstr "Dosya yöneticisi"
+
+#: id:8
+msgctxt "Auto context with id 8"
+msgid "Weather"
+msgstr "Hava Durumu"
+
+#: id:9
+msgid "xbmc media center"
+msgstr "xbmc medya merkezi"
+
+#: id:11
+msgid "Monday"
+msgstr "Pazartesi"
+
+#: id:12
+msgid "Tuesday"
+msgstr "Salı"
+
+#: id:13
+msgid "Wednesday"
+msgstr "Çarşamba"
+
+#: id:14
+msgid "Thursday"
+msgstr "Perşembe"
+
+#: id:15
+msgid "Friday"
+msgstr "Cuma"
+
+#: id:16
+msgid "Saturday"
+msgstr "Cumartesi"
+
+#: id:17
+msgid "Sunday"
+msgstr "Pazar"
+
+#: id:21
+msgid "January"
+msgstr "Ocak"
+
+#: id:22
+msgid "February"
+msgstr "Şubat"
+
+#: id:23
+msgid "March"
+msgstr "Mart"
+
+#: id:24
+msgid "April"
+msgstr "Nisan"
+
+#: id:25
+msgctxt "Auto context with id 25"
+msgid "May"
+msgstr "Mayıs"
+
+#: id:26
+msgid "June"
+msgstr "Haziran"
+
+#: id:27
+msgid "July"
+msgstr "Temmuz"
+
+#: id:28
+msgid "August"
+msgstr "Ağustos"
+
+#: id:29
+msgid "September"
+msgstr "Eylül"
+
+#: id:30
+msgid "October"
+msgstr "Ekim"
+
+#: id:31
+msgid "November"
+msgstr "Kasım"
+
+#: id:32
+msgid "December"
+msgstr "Aralık"
+
+#: id:41
+msgid "Mon"
+msgstr "Pzt"
+
+#: id:42
+msgid "Tue"
+msgstr "Sal"
+
+#: id:43
+msgid "Wed"
+msgstr "Çar"
+
+#: id:44
+msgid "Thu"
+msgstr "Per"
+
+#: id:45
+msgid "Fri"
+msgstr "Cum"
+
+#: id:46
+msgid "Sat"
+msgstr "Cmt"
+
+#: id:47
+msgctxt "Auto context with id 47"
+msgid "Sun"
+msgstr "Paz"
+
+#: id:51
+msgid "Jan"
+msgstr "Oca"
+
+#: id:52
+msgid "Feb"
+msgstr "Şub"
+
+#: id:53
+msgid "Mar"
+msgstr "Mar"
+
+#: id:54
+msgid "Apr"
+msgstr "Nis"
+
+#: id:55
+msgctxt "Auto context with id 55"
+msgid "May"
+msgstr "May"
+
+#: id:56
+msgid "Jun"
+msgstr "Haz"
+
+#: id:57
+msgid "Jul"
+msgstr "Tem"
+
+#: id:58
+msgid "Aug"
+msgstr "Ağu"
+
+#: id:59
+msgid "Sep"
+msgstr "Eyl"
+
+#: id:60
+msgid "Oct"
+msgstr "Eki"
+
+#: id:61
+msgid "Nov"
+msgstr "Kas"
+
+#: id:62
+msgid "Dec"
+msgstr "Ara"
+
+#: id:71
+msgid "N"
+msgstr "K"
+
+#: id:72
+msgid "NNE"
+msgstr "KKD"
+
+#: id:73
+msgid "NE"
+msgstr "KD"
+
+#: id:74
+msgid "ENE"
+msgstr "DKD"
+
+#: id:75
+msgid "E"
+msgstr "D"
+
+#: id:76
+msgid "ESE"
+msgstr "DGD"
+
+#: id:77
+msgid "SE"
+msgstr "GD"
+
+#: id:78
+msgid "SSE"
+msgstr "GGD"
+
+#: id:79
+msgid "S"
+msgstr "G"
+
+#: id:80
+msgid "SSW"
+msgstr "GGB"
+
+#: id:81
+msgid "SW"
+msgstr "GB"
+
+#: id:82
+msgid "WSW"
+msgstr "BGB"
+
+#: id:83
+msgid "W"
+msgstr "B"
+
+#: id:84
+msgid "WNW"
+msgstr "BKB"
+
+#: id:85
+msgid "NW"
+msgstr "KB"
+
+#: id:86
+msgid "NNW"
+msgstr "KKB"
+
+#: id:87
+msgid "VAR"
+msgstr "VAR"
+
+#: id:98
+msgid "View: Auto"
+msgstr "Görünüm: Otomatik"
+
+#: id:99
+msgid "View: Auto big"
+msgstr "Görünüm: Otomatik büyük"
+
+#: id:100
+msgid "View: Icons"
+msgstr "Görünüm: Simge"
+
+#: id:101
+msgid "View: List"
+msgstr "Görünüm: Liste"
+
+#: id:102
+msgctxt "Auto context with id 102"
+msgid "Scan"
+msgstr "Tara"
+
+#: id:103
+msgctxt "Auto context with id 103"
+msgid "Sort by: Name"
+msgstr "Sırala: İsim"
+
+#: id:104
+msgid "Sort by: Date"
+msgstr "Sırala: Tarih"
+
+#: id:105
+msgid "Sort by: Size"
+msgstr "Sırala: Boyut"
+
+#: id:106
+msgid "No"
+msgstr "Hayır"
+
+#: id:107
+msgid "Yes"
+msgstr "Evet"
+
+#: id:108
+msgctxt "Auto context with id 108"
+msgid "Slideshow"
+msgstr "Slayt Gösterisi"
+
+#: id:109
+msgid "Create thumbs"
+msgstr "Küçük resim oluştur"
+
+#: id:110
+msgid "Create thumbnails"
+msgstr "Küçük resim oluştur"
+
+#: id:111
+msgctxt "Auto context with id 111"
+msgid "Shortcuts"
+msgstr "Kısayollar"
+
+#: id:112
+msgid "Paused"
+msgstr "Duraklatıldı"
+
+#: id:113
+msgid "Update failed"
+msgstr "Güncelleme başarısız"
+
+#: id:114
+msgid "Installation failed"
+msgstr "Yükleme başarısız"
+
+#: id:115
+msgid "Copy"
+msgstr "Kopyala"
+
+#: id:116
+msgid "Move"
+msgstr "Taşı"
+
+#: id:117
+msgid "Delete"
+msgstr "Sil"
+
+#: id:118
+msgid "Rename"
+msgstr "Yeniden adlandır"
+
+#: id:119
+msgid "New folder"
+msgstr "Yeni klasör"
+
+#: id:120
+msgid "Confirm file copy"
+msgstr "Kopyalamayı onayla"
+
+#: id:121
+msgid "Confirm file move"
+msgstr "Taşımayı onayla"
+
+#: id:122
+msgid "Confirm file delete?"
+msgstr "Silmeyi onaylıyor musunuz?"
+
+#: id:123
+msgid "Copy these files?"
+msgstr "Dosyalar kopyalansın mı?"
+
+#: id:124
+msgid "Move these files?"
+msgstr "Dosyalar taşınsın mı?"
+
+#: id:125
+msgid "Delete these files? - Deleting files cannot be undone!"
+msgstr "Dosyalar silinsin mi? - Silinen dosyalar geri alınamaz!"
+
+#: id:126
+msgid "Status"
+msgstr "Durum"
+
+#: id:127
+msgid "Objects"
+msgstr "Nesneler"
+
+#: id:128
+msgctxt "Auto context with id 128"
+msgid "General"
+msgstr "Genel"
+
+#: id:129
+msgctxt "Auto context with id 129"
+msgid "Slideshow"
+msgstr "Slayt Gösterisi"
+
+#: id:130
+msgctxt "Auto context with id 130"
+msgid "System info"
+msgstr "Sistem bilgisi"
+
+#: id:131
+msgid "Display"
+msgstr "Görüntü"
+
+#: id:132
+msgid "Albums"
+msgstr "Albümler"
+
+#: id:133
+msgid "Artists"
+msgstr "Sanatçılar"
+
+#: id:134
+msgid "Songs"
+msgstr "Parçalar"
+
+#: id:135
+msgid "Genres"
+msgstr "Tarzlar"
+
+#: id:136
+msgid "Playlists"
+msgstr "Çalma listeleri"
+
+#: id:137
+msgid "Search"
+msgstr "Ara"
+
+#: id:138
+msgid "System Information"
+msgstr "Sistem Bilgisi"
+
+#: id:139
+msgid "Temperatures:"
+msgstr "Isı:"
+
+#: id:140
+msgid "CPU:"
+msgstr "CPU:"
+
+#: id:141
+msgid "GPU:"
+msgstr "GPU:"
+
+#: id:142
+msgid "Time:"
+msgstr "Zaman:"
+
+#: id:143
+msgid "Current:"
+msgstr "Geçerli:"
+
+#: id:144
+msgid "Build:"
+msgstr "Versiyon:"
+
+#: id:145
+msgid "Network:"
+msgstr "Ağ:"
+
+#: id:146
+msgid "Type:"
+msgstr "Tür:"
+
+#: id:147
+msgid "Static"
+msgstr "Statik"
+
+#: id:148
+msgid "DHCP"
+msgstr "DHCP"
+
+#: id:149
+msgid "MAC address"
+msgstr "MAC adresi"
+
+#: id:150
+msgctxt "Auto context with id 150"
+msgid "IP address"
+msgstr "IP adresi"
+
+#: id:151
+msgid "Link:"
+msgstr "Bağlantı:"
+
+#: id:152
+msgid "Half duplex"
+msgstr "Half duplex"
+
+#: id:153
+msgid "Full duplex"
+msgstr "Full duplex"
+
+#: id:154
+msgctxt "Auto context with id 154"
+msgid "Storage"
+msgstr "Depolama"
+
+#: id:155
+msgid "Drive"
+msgstr "Sürücü"
+
+#: id:156
+msgctxt "Auto context with id 156"
+msgid "Free"
+msgstr "Boş"
+
+#: id:157
+msgctxt "Auto context with id 157"
+msgid "Video"
+msgstr "Video"
+
+#: id:158
+msgid "Free memory"
+msgstr "Boş bellek"
+
+#: id:159
+msgid "No link"
+msgstr "Bağlantı yok"
+
+#: id:160
+msgctxt "Auto context with id 160"
+msgid "Free"
+msgstr "Boş"
+
+#: id:161
+msgid "Unavailable"
+msgstr "Kullanılamıyor"
+
+#: id:162
+msgid "Tray open"
+msgstr "Tepsi açık"
+
+#: id:163
+msgid "Reading"
+msgstr "Okunuyor"
+
+#: id:164
+msgid "No disc"
+msgstr "Disk yok"
+
+#: id:165
+msgid "Disc present"
+msgstr "Disk var"
+
+#: id:166
+msgid "Skin"
+msgstr "Dış Görünüm"
+
+#: id:169
+msgctxt "Auto context with id 169"
+msgid "Resolution"
+msgstr "Çözünürlük"
+
+#: id:170
+msgid "Adjust display refresh rate to match video"
+msgstr "Görüntü yenileme hızını videoyla eşleşecek şekilde ayarla"
+
+#: id:172
+msgid "Release date"
+msgstr "Çıkış tarihi"
+
+#: id:173
+msgid "Display 4:3 videos as"
+msgstr "4:3 videoları görüntüleme biçimi"
+
+#: id:175
+msgid "Moods"
+msgstr "Nitelik"
+
+#: id:176
+msgid "Styles"
+msgstr "Stiller"
+
+#: id:179
+msgid "Song"
+msgstr "Şarkı"
+
+#: id:180
+msgid "Duration"
+msgstr "Süre"
+
+#: id:181
+msgid "Select album"
+msgstr "Albüm seç"
+
+#: id:182
+msgid "Tracks"
+msgstr "Parçalar"
+
+#: id:183
+msgid "Review"
+msgstr "Yorum"
+
+#: id:184
+msgid "Refresh"
+msgstr "Yenile"
+
+#: id:185
+msgid "Searching album"
+msgstr "Albüm aranıyor"
+
+#: id:186
+msgid "OK"
+msgstr "Tamam"
+
+#: id:187
+msgid "No albums found!"
+msgstr "Hiç albüm bulunamadı!"
+
+#: id:188
+msgid "Select all"
+msgstr "Tümünü seç"
+
+#: id:189
+msgid "Scanning media info"
+msgstr "Ortam bilgisi taranıyor"
+
+#: id:190
+msgid "Save"
+msgstr "Kaydet"
+
+#: id:191
+msgid "Shuffle"
+msgstr "Karışık"
+
+#: id:192
+msgctxt "Auto context with id 192"
+msgid "Clear"
+msgstr "Temizle"
+
+#: id:193
+msgctxt "Auto context with id 193"
+msgid "Scan"
+msgstr "Tara"
+
+#: id:194
+msgid "Searching..."
+msgstr "Aranıyor..."
+
+#: id:195
+msgid "No info found!"
+msgstr "Bilgi bulunamadı!"
+
+#: id:196
+msgid "Select movie:"
+msgstr "Film seç:"
+
+#: id:197
+msgid "Querying %s info"
+msgstr "%s bilgisi sorgulanıyor"
+
+#: id:198
+msgid "Loading movie details"
+msgstr "Film ayrıntıları yükleniyor"
+
+#: id:199
+msgid "Web interface"
+msgstr "Web arabirimi"
+
+#: id:202
+msgid "Tagline"
+msgstr "Hakkında"
+
+#: id:203
+msgid "Plot outline"
+msgstr "İçerik"
+
+#: id:205
+msgid "Votes"
+msgstr "Toplam Oy"
+
+#: id:206
+msgid "Cast"
+msgstr "Oyuncular"
+
+#: id:207
+msgid "Plot"
+msgstr "İçerik"
+
+#: id:208
+msgctxt "Auto context with id 208"
+msgid "Play"
+msgstr "Oynat"
+
+#: id:209
+msgid "Next"
+msgstr "Sonraki"
+
+#: id:210
+msgid "Previous"
+msgstr "Önceki"
+
+#: id:213
+msgid "Calibrate user interface..."
+msgstr "Kullanıcı arabirimini ayarla..."
+
+#: id:214
+msgid "Video calibration..."
+msgstr "Video ayarı..."
+
+#: id:215
+msgid "Soften"
+msgstr "Yumuşat"
+
+#: id:216
+msgid "Zoom amount"
+msgstr "Yakınlaştırma miktarı"
+
+#: id:217
+msgid "Pixel ratio"
+msgstr "Piksel oranı"
+
+#: id:218
+msgid "DVD drive"
+msgstr "DVD sürücü"
+
+#: id:219
+msgid "Please insert disc"
+msgstr "Lütfen bir disk yerleştirin"
+
+#: id:220
+msgid "Remote share"
+msgstr "Uzak paylaşım"
+
+#: id:221
+msgid "Network is not connected"
+msgstr "Ağ bağlantısı yok"
+
+#: id:222
+msgid "Cancel"
+msgstr "İptal"
+
+#: id:224
+msgid "Speed"
+msgstr "Hız"
+
+#: id:225
+msgid "Vertical Shift"
+msgstr "Dikey Kaydırma"
+
+#: id:226
+msgid "Test patterns..."
+msgstr "Desenleri test et..."
+
+#: id:227
+msgid "Lookup audio CD track names from freedb.org"
+msgstr "Ses CD'lerinin parça isimlerini freedb.org'da ara"
+
+#: id:228
+msgid "Shuffle playlist on load"
+msgstr "Çalma listesini karıştır"
+
+#: id:229
+msgid "HDD spindown time"
+msgstr "Sabit disk yavaşlatma zamanı"
+
+#: id:230
+msgid "Video filters"
+msgstr "Video filtreleri"
+
+#: id:231
+msgctxt "Auto context with id 231"
+msgid "None"
+msgstr "Hiçbiri"
+
+#: id:232
+msgid "Point"
+msgstr "Nokta"
+
+#: id:233
+msgid "Linear"
+msgstr "Çizgisel"
+
+#: id:234
+msgid "Anisotropic"
+msgstr "Anisotropic"
+
+#: id:235
+msgid "Quincunx"
+msgstr "Quincunx"
+
+#: id:236
+msgid "Gaussian cubic"
+msgstr "Gaussian cubic"
+
+#: id:237
+msgid "Minification"
+msgstr "Küçültmek"
+
+#: id:238
+msgid "Magnification"
+msgstr "Büyültmek"
+
+#: id:239
+msgid "Clear playlist on finish"
+msgstr "Oynatma bittiğinde çalma listesini temizle"
+
+#: id:240
+msgid "Display Mode"
+msgstr "Görüntü Modu"
+
+#: id:241
+msgid "Full Screen #%d"
+msgstr "Tam Ekran #%d"
+
+#: id:242
+msgid "Windowed"
+msgstr "Pencere"
+
+#: id:243
+msgid "Refresh Rate"
+msgstr "Yenileme Hızı"
+
+#: id:244
+msgid "Full screen"
+msgstr "Tam ekran"
+
+#: id:245
+msgid "Sizing: (%i,%i)->(%i,%i) (Zoom x%2.2f) AR:%2.2f:1 (Pixels: %2.2f:1) (VShift: %2.2f)"
+msgstr "Boyutlandırma: (%i,%i)->(%i,%i) (Yakınlaştırma x%2.2f) AR:%2.2f:1 (Pikseller: %2.2f:1) (DKaydırma: %2.2f)"
+
+#: id:247
+msgctxt "Auto context with id 247"
+msgid "Scripts"
+msgstr "Betikler"
+
+#: id:248
+msgctxt "Auto context with id 248"
+msgid "Language"
+msgstr "Dil"
+
+#: id:249
+msgctxt "Auto context with id 249"
+msgid "Music"
+msgstr "Müzik"
+
+#: id:250
+msgctxt "Auto context with id 250"
+msgid "Visualization"
+msgstr "Görsel öğe"
+
+#: id:251
+msgid "Select destination directory"
+msgstr "Hedef klasörü seç"
+
+#: id:252
+msgid "Output stereo to all speakers"
+msgstr "Bütün kolonlara stereo ses ver"
+
+#: id:253
+msgid "Number of channels"
+msgstr "Kanal sayısı"
+
+#: id:254
+msgid "- DTS capable receiver"
+msgstr "- DTS destekli alıcı"
+
+#: id:255
+msgid "CDDB"
+msgstr "CDDB"
+
+#: id:256
+msgid "Fetching CD information"
+msgstr "CD bilgileri getiriliyor"
+
+#: id:257
+msgid "Error"
+msgstr "Hata"
+
+#: id:258
+msgid "Enable tag reading"
+msgstr "Etiket okumasını etkinleştir"
+
+#: id:259
+msgid "Opening"
+msgstr "Açılıyor"
+
+#: id:260
+msgid "Shoutcast"
+msgstr "Shoutcast"
+
+#: id:261
+msgid "Waiting for start..."
+msgstr "Başlaması bekleniyor..."
+
+#: id:262
+msgid "Scripts output"
+msgstr "Betik çıktısı"
+
+#: id:263
+msgid "Allow control of XBMC via HTTP"
+msgstr "HTTP üzerinden XBMC kontrolüne izin ver"
+
+#: id:264
+msgid "Record"
+msgstr "Kayıt"
+
+#: id:265
+msgid "Stop Rec."
+msgstr "Kaydı Durdur"
+
+#: id:266
+msgid "Sort by: Track"
+msgstr "Sırala: Parça"
+
+#: id:267
+msgid "Sort by: Time"
+msgstr "Sırala: Süre"
+
+#: id:268
+msgid "Sort by: Title"
+msgstr "Sırala: Başlık"
+
+#: id:269
+msgid "Sort by: Artist"
+msgstr "Sırala: Sanatçı"
+
+#: id:270
+msgid "Sort by: Album"
+msgstr "Sırala: Albüm"
+
+#: id:271
+msgid "Top 100"
+msgstr "En İyi 100"
+
+#: id:272
+msgid "Top-Left overscan compensation"
+msgstr "Sol Üst Köşe Resim Ayarı"
+
+#: id:273
+msgid "Bottom-Right overscan compensation"
+msgstr "Sağ Alt Köşe Resim Ayarı"
+
+#: id:274
+msgid "Subtitle positioning"
+msgstr "Altyazı konumlandırması"
+
+#: id:275
+msgid "Pixel ratio adjustment"
+msgstr "Piksel oranı ayarı"
+
+#: id:276
+msgid "Adjust the arrow to change the amount of overscan"
+msgstr "Ok işaretini resmi ayarlamak için kaydır"
+
+#: id:277
+msgid "Adjust the bar to change the subtitles position"
+msgstr "Sütunu altyazı pozisyonunu ayarlamak için kaydır"
+
+#: id:278
+msgid "Adjust the rectangle so it is perfectly square"
+msgstr "Dörtgeni tam olarak kare olacak şekilde ayarla"
+
+#: id:279
+msgid "Unable to load settings"
+msgstr "Ayarlar yüklenemiyor"
+
+#: id:280
+msgid "Using default settings"
+msgstr "Varsayılan ayarlar kullanılıyor"
+
+#: id:281
+msgid "Please check the XML files"
+msgstr "Lütfen XML dosyalarını kontrol edin"
+
+#: id:282
+msgid "Found %i items"
+msgstr "%i öge bulundu"
+
+#: id:283
+msgid "Search results"
+msgstr "Arama sonuçları"
+
+#: id:284
+msgid "No results found"
+msgstr "Hiçbir sonuç bulunamadı"
+
+#: id:287
+msgctxt "Auto context with id 287"
+msgid "Subtitles"
+msgstr "Altyazılar"
+
+#: id:288
+msgctxt "Auto context with id 288"
+msgid "Font"
+msgstr "Yazı tipi"
+
+#: id:289
+msgctxt "Auto context with id 289"
+msgid "- Size"
+msgstr "- Boyut"
+
+#: id:290
+msgid "Dynamic range compression"
+msgstr "Dinamik aralık sıkıştırma"
+
+#: id:291
+msgctxt "Auto context with id 291"
+msgid "Video"
+msgstr "Video"
+
+#: id:292
+msgctxt "Auto context with id 292"
+msgid "Audio"
+msgstr "Ses"
+
+#: id:293
+msgid "Browse for subtitles"
+msgstr "Altyazılara gözat"
+
+#: id:294
+msgid "Create bookmark"
+msgstr "Yer işareti oluştur"
+
+#: id:296
+msgid "Clear bookmarks"
+msgstr "Yer işaretlerini temizle"
+
+#: id:297
+msgid "Audio offset"
+msgstr "Ses gecikmesi"
+
+#: id:298
+msgid "Bookmarks"
+msgstr "Yer İşaretleri"
+
+#: id:299
+msgid "- AAC capable receiver"
+msgstr "- AAC destekli alıcı"
+
+#: id:300
+msgid "- MP1 capable receiver"
+msgstr "- MP1 destekli alıcı"
+
+#: id:301
+msgid "- MP2 capable receiver"
+msgstr "- MP2 destekli alıcı"
+
+#: id:302
+msgid "- MP3 capable receiver"
+msgstr "- MP3 destekli alıcı"
+
+#: id:303
+msgid "Delay"
+msgstr "Geciktirme"
+
+#: id:304
+msgctxt "Auto context with id 304"
+msgid "Language"
+msgstr "Dil"
+
+#: id:305
+msgctxt "Auto context with id 305"
+msgid "Enabled"
+msgstr "Aktif"
+
+#: id:306
+msgid "Non-interleaved"
+msgstr "Non-interleaved"
+
+#: id:312
+msgid "(0=auto)"
+msgstr "(0=otomatik)"
+
+#: id:313
+msgid "Cleaning database"
+msgstr "Veritabanı temizleniyor"
+
+#: id:314
+msgid "Preparing..."
+msgstr "Hazırlanıyor..."
+
+#: id:315
+msgid "Database error"
+msgstr "Veritabanı hatası"
+
+#: id:316
+msgid "Searching songs..."
+msgstr "Şarkılar aranıyor..."
+
+#: id:317
+msgid "Cleaned database successfully"
+msgstr "Veritabanı başarıyla temizlendi"
+
+#: id:318
+msgid "Cleaning songs..."
+msgstr "Şarkılar temizleniyor..."
+
+#: id:319
+msgid "Error cleaning songs"
+msgstr "Şarkılar temizlenirken hata oluştu"
+
+#: id:320
+msgid "Cleaning artists..."
+msgstr "Sanatçılar temizleniyor..."
+
+#: id:321
+msgid "Error cleaning artists"
+msgstr "Sanatçılar temizlenirken hata oluştu"
+
+#: id:322
+msgid "Cleaning genres..."
+msgstr "Tarzlar temizleniyor..."
+
+#: id:323
+msgid "Error cleaning genres"
+msgstr "Tarzlar temizlenirken hata oluştu"
+
+#: id:324
+msgid "Cleaning paths..."
+msgstr "Yollar siliniyor..."
+
+#: id:325
+msgid "Error cleaning paths"
+msgstr "Yollar silinirken hata oluştu"
+
+#: id:326
+msgid "Cleaning albums..."
+msgstr "Albümler siliniyor..."
+
+#: id:327
+msgid "Error cleaning albums"
+msgstr "Albümler silinirken hata oluştu"
+
+#: id:328
+msgid "Writing changes..."
+msgstr "Değişiklikler yazılıyor..."
+
+#: id:329
+msgid "Error writing changes"
+msgstr "Değişiklikler yazılırken hata oluştu"
+
+#: id:330
+msgid "This may take some time..."
+msgstr "Bu biraz zaman alabilir..."
+
+#: id:331
+msgid "Compressing database..."
+msgstr "Veritabanı sıkıştırılıyor..."
+
+#: id:332
+msgid "Error compressing database"
+msgstr "Veritabanı sıkıştırılırken hata oluştu"
+
+#: id:333
+msgid "Do you want to clean the library?"
+msgstr "Kitaplığı temizlemek istiyor musunuz?"
+
+#: id:334
+msgid "Clean library..."
+msgstr "Kitaplığı temizle..."
+
+#: id:335
+msgid "Start"
+msgstr "Başlat"
+
+#: id:336
+msgid "Framerate conversion"
+msgstr "Çerçeve hızı çeviricisi"
+
+#: id:337
+msgctxt "Auto context with id 337"
+msgid "Audio output"
+msgstr "Ses çıkışı"
+
+#: id:338
+msgid "Analog"
+msgstr "Analog"
+
+#: id:339
+msgid "Optical/Coax"
+msgstr "Optik/Koaksiyel"
+
+#: id:340
+msgid "Various artists"
+msgstr "Çeşitli sanatçılar"
+
+#: id:341
+msgid "Play disc"
+msgstr "Diski oynat"
+
+#: id:342
+msgctxt "Auto context with id 342"
+msgid "Movies"
+msgstr "Filmler"
+
+#: id:343
+msgid "Adjust framerate"
+msgstr "Kare hızını ayarla"
+
+#: id:344
+msgid "Actors"
+msgstr "Aktörler"
+
+#: id:345
+msgctxt "Auto context with id 345"
+msgid "Year"
+msgstr "Yıl"
+
+#: id:346
+msgid "Boost volume level on downmix"
+msgstr "Downmix yaparken ses seviyesini yükselt"
+
+#: id:350
+msgctxt "Auto context with id 350"
+msgid "Programs"
+msgstr "Programlar"
+
+#: id:351
+msgctxt "Auto context with id 351"
+msgid "Off"
+msgstr "Kapalı"
+
+#: id:352
+msgid "Dim"
+msgstr "Karart"
+
+#: id:353
+msgid "Black"
+msgstr "Siyah"
+
+#: id:354
+msgid "Matrix trails"
+msgstr "Matrix trails"
+
+#: id:355
+msgid "Screensaver time"
+msgstr "Ekran koruyucu süresi"
+
+#: id:356
+msgid "Screensaver mode"
+msgstr "Ekran koruyucu modu"
+
+#: id:357
+msgid "Shutdown function timer"
+msgstr "Kapatma fonksiyonu zamanlayıcısı"
+
+#: id:358
+msgid "All albums"
+msgstr "Bütün albümler"
+
+#: id:359
+msgid "Recently added albums"
+msgstr "Yeni eklenen albümler"
+
+#: id:360
+msgctxt "Auto context with id 360"
+msgid "Screensaver"
+msgstr "Ekran Koruyucu"
+
+#: id:361
+msgid "R. Slideshow"
+msgstr "Yinelemeli Slayt Gösterisi"
+
+#: id:362
+msgid "Screensaver dim level"
+msgstr "Ekran koruyucu karartma seviyesi"
+
+#: id:363
+msgid "Sort by: File"
+msgstr "Sırala: Dosya"
+
+#: id:364
+msgid "- Dolby Digital (AC3) capable receiver"
+msgstr "- Dolby Digital (AC3) destekli alıcı"
+
+#: id:365
+msgctxt "Auto context with id 365"
+msgid "Sort by: Name"
+msgstr "Sırala: İsim"
+
+#: id:366
+msgid "Sort by: Year"
+msgstr "Sırala: Yıl"
+
+#: id:367
+msgid "Sort by: Rating"
+msgstr "Sırala: Beğeni"
+
+#: id:368
+msgid "IMDb"
+msgstr "IMDb"
+
+#: id:369
+msgctxt "Auto context with id 369"
+msgid "Title"
+msgstr "Başlık"
+
+#: id:370
+msgid "Thunderstorms"
+msgstr "Gök gürültülü"
+
+#: id:371
+msgid "Partly"
+msgstr "Parçalı"
+
+#: id:372
+msgid "Mostly"
+msgstr "Genelde"
+
+#: id:373
+msgid "Sunny"
+msgstr "Güneşli"
+
+#: id:374
+msgid "Cloudy"
+msgstr "Bulutlu"
+
+#: id:375
+msgid "Snow"
+msgstr "Karlı"
+
+#: id:376
+msgid "Rain"
+msgstr "Yağmurlu"
+
+#: id:377
+msgid "Light"
+msgstr "Hafif"
+
+#: id:378
+msgid "AM"
+msgstr "Sabah"
+
+#: id:379
+msgid "PM"
+msgstr "Akşam"
+
+#: id:380
+msgid "Showers"
+msgstr "Yağışlı"
+
+#: id:381
+msgid "Few"
+msgstr "Daha az"
+
+#: id:382
+msgid "Scattered"
+msgstr "Bazen"
+
+#: id:383
+msgctxt "Auto context with id 383"
+msgid "Wind"
+msgstr "Rüzgarlı"
+
+#: id:384
+msgid "Strong"
+msgstr "Kuvvetli"
+
+#: id:385
+msgid "Fair"
+msgstr "Güzel"
+
+#: id:386
+msgctxt "Auto context with id 386"
+msgid "Clear"
+msgstr "Açık"
+
+#: id:387
+msgid "Clouds"
+msgstr "Bulutlu"
+
+#: id:388
+msgid "Early"
+msgstr "Erken"
+
+#: id:389
+msgid "Shower"
+msgstr "Yağmurlu"
+
+#: id:390
+msgid "Flurries"
+msgstr "Kar yağışlı"
+
+#: id:391
+msgctxt "Auto context with id 391"
+msgid "Low"
+msgstr "Düşük"
+
+#: id:392
+msgctxt "Auto context with id 392"
+msgid "Medium"
+msgstr "Orta"
+
+#: id:393
+msgctxt "Auto context with id 393"
+msgid "High"
+msgstr "Yüksek"
+
+#: id:394
+msgid "Fog"
+msgstr "Sisli"
+
+#: id:395
+msgid "Haze"
+msgstr "Puslu"
+
+#: id:396
+msgid "Select location"
+msgstr "Yer seçimi"
+
+#: id:397
+msgid "Refresh time"
+msgstr "Yenileme zamanı"
+
+#: id:398
+msgid "Temperature units"
+msgstr "Sıcaklık birimi"
+
+#: id:399
+msgid "Speed units"
+msgstr "Hız birimi"
+
+#: id:400
+msgctxt "Auto context with id 400"
+msgid "Weather"
+msgstr "Hava"
+
+#: id:401
+msgid "Temp"
+msgstr "Hava sıcaklığı"
+
+#: id:402
+msgid "Feels like"
+msgstr "Hissedilen sıcaklık"
+
+#: id:403
+msgid "UV index"
+msgstr "UV değeri"
+
+#: id:404
+msgctxt "Auto context with id 404"
+msgid "Wind"
+msgstr "Rüzgar"
+
+#: id:405
+msgid "Dew point"
+msgstr "Donma noktası"
+
+#: id:406
+msgid "Humidity"
+msgstr "Nem oranı"
+
+#: id:409
+msgid "Defaults"
+msgstr "Varsayılanlar"
+
+#: id:410
+msgid "Accessing weather service"
+msgstr "Hava Durumu hizmetine erişiliyor"
+
+#: id:411
+msgid "Getting weather for:"
+msgstr "Hava Durumu bilgileri alınıyor:"
+
+#: id:412
+msgid "Unable to get weather data"
+msgstr "Hava Durumu bilgileri alınamıyor"
+
+#: id:413
+msgid "Manual"
+msgstr "El ile"
+
+#: id:414
+msgid "No review for this album"
+msgstr "Bu albüm için yorum mevcut değil"
+
+#: id:415
+msgid "Downloading thumbnail..."
+msgstr "Küçük resim karşıdan yükleniyor..."
+
+#: id:416
+msgid "Not available"
+msgstr "Kullanılamaz"
+
+#: id:417
+msgid "View: Big icons"
+msgstr "Görünüm: Büyük simgeler"
+
+#: id:418
+msgctxt "Auto context with id 418"
+msgid "Low"
+msgstr "Düşük"
+
+#: id:419
+msgctxt "Auto context with id 419"
+msgid "High"
+msgstr "Yüksek"
+
+#: id:420
+msgid "HDMI"
+msgstr "HDMI"
+
+#: id:422
+msgid "Delete album info"
+msgstr "Albüm bilgisini sil"
+
+#: id:423
+msgid "Delete CD information"
+msgstr "CD bilgisini sil"
+
+#: id:424
+msgid "Select"
+msgstr "Seç"
+
+#: id:425
+msgid "No album information found"
+msgstr "Albüm bilgisi bulunamadı"
+
+#: id:426
+msgid "No CD information found"
+msgstr "CD bilgisi bulunamadı"
+
+#: id:427
+msgid "Disc"
+msgstr "Disk"
+
+#: id:428
+msgid "Insert correct CD/DVD"
+msgstr "Doğru CD/DVD'yi koyunuz"
+
+#: id:429
+msgid "Please insert the following disc:"
+msgstr "Lütfen sıradaki diski yerleştirin:"
+
+#: id:430
+msgid "Sort by: DVD#"
+msgstr "Sırala: DVD#"
+
+#: id:431
+msgid "No cache"
+msgstr "Önbellek yok"
+
+#: id:432
+msgid "Remove movie from library"
+msgstr "Filmi kitaplıktan kaldır"
+
+#: id:433
+msgid "Really remove '%s'?"
+msgstr "'%s' gerçekten kaldırılsın mı?"
+
+#: id:434
+msgid "From %s at %i %s"
+msgstr "%s yönünden %i %s"
+
+#: id:437
+msgid "Removable disk"
+msgstr "Çıkartılabilir disk"
+
+#: id:438
+msgid "Opening file"
+msgstr "Dosya açılıyor"
+
+#: id:439
+msgid "Cache"
+msgstr "Önbellek"
+
+#: id:440
+msgid "Harddisk"
+msgstr "Sabit disk"
+
+#: id:441
+msgid "UDF"
+msgstr "UDF"
+
+#: id:442
+msgid "Local network"
+msgstr "Yerel ağ"
+
+#: id:443
+msgid "Internet"
+msgstr "İnternet"
+
+#: id:444
+msgctxt "Auto context with id 444"
+msgid "Video"
+msgstr "Video"
+
+#: id:445
+msgctxt "Auto context with id 445"
+msgid "Audio"
+msgstr "Ses"
+
+#: id:446
+msgctxt "Auto context with id 446"
+msgid "DVD"
+msgstr "DVD"
+
+#: id:447
+msgid "Autorun media"
+msgstr "Ortamları otomatik başlat"
+
+#: id:448
+msgid "LCD"
+msgstr "LCD"
+
+#: id:449
+msgctxt "Auto context with id 449"
+msgid "Enabled"
+msgstr "Etkin"
+
+#: id:450
+msgid "Columns"
+msgstr "Sütunlar"
+
+#: id:451
+msgid "Row 1 address"
+msgstr "1. Sıra adresi"
+
+#: id:452
+msgid "Row 2 address"
+msgstr "2. Sıra adresi"
+
+#: id:453
+msgid "Row 3 address"
+msgstr "3. Sıra adresi"
+
+#: id:454
+msgid "Row 4 address"
+msgstr "4. Sıra adresi"
+
+#: id:455
+msgid "Rows"
+msgstr "Sıralar"
+
+#: id:456
+msgid "Mode"
+msgstr "Mod"
+
+#: id:457
+msgid "Switch view"
+msgstr "Görünümü değiştir"
+
+#: id:459
+msgid "Subs"
+msgstr "Altyazılar"
+
+#: id:460
+msgid "Audio stream"
+msgstr "Ses akışı"
+
+#: id:461
+msgid "[active]"
+msgstr "[aktif]"
+
+#: id:462
+msgid "Subtitle"
+msgstr "Altyazı"
+
+#: id:463
+msgid "Backlight"
+msgstr "Arka Işık"
+
+#: id:464
+msgid "Brightness"
+msgstr "Parlaklık"
+
+#: id:465
+msgid "Contrast"
+msgstr "Kontrast"
+
+#: id:466
+msgid "Gamma"
+msgstr "Gamma"
+
+#: id:467
+msgctxt "Auto context with id 467"
+msgid "Type"
+msgstr "Tür"
+
+#: id:468
+msgid "Move the bar to change the OSD position"
+msgstr "OSD pozisyonunu değiştirmek için çubuğu kaydırın"
+
+#: id:469
+msgid "OSD position"
+msgstr "OSD pozisyonu"
+
+#: id:470
+msgid "Credits"
+msgstr "Jenerik"
+
+#: id:471
+msgid "Modchip"
+msgstr "Modchip"
+
+#: id:474
+msgctxt "Auto context with id 474"
+msgid "Off"
+msgstr "Kapalı"
+
+#: id:475
+msgid "Music only"
+msgstr "Sadece müzik"
+
+#: id:476
+msgctxt "Auto context with id 476"
+msgid "Music & video"
+msgstr "Müzik ve video"
+
+#: id:477
+msgid "Unable to load playlist"
+msgstr "Çalma listesi yüklenemedi"
+
+#: id:478
+msgid "OSD"
+msgstr "OSD"
+
+#: id:479
+msgid "Skin & language"
+msgstr "Dış görünüm ve dil"
+
+#: id:480
+msgid "Appearance"
+msgstr "Görünüm"
+
+#: id:481
+msgid "Audio options"
+msgstr "Ses seçenekleri"
+
+#: id:482
+msgid "About XBMC"
+msgstr "XBMC Hakkında"
+
+#: id:485
+msgid "Delete album"
+msgstr "Albümü sil"
+
+#: id:486
+msgid "Repeat"
+msgstr "Tekrarla"
+
+#: id:487
+msgid "Repeat one"
+msgstr "Tekrarla: Birini"
+
+#: id:488
+msgid "Repeat folder"
+msgstr "Tekrarla: Klasörü"
+
+#: id:489
+msgid "Play the next song automatically"
+msgstr "Sonraki şarkıyı otomatik olarak çal"
+
+#: id:491
+msgid "- Use big icons"
+msgstr "- Büyük simge kullan"
+
+#: id:492
+msgid "Resize VobSubs"
+msgstr "Altyazı Büyüklüğünü Ayarla"
+
+#: id:493
+msgid "Advanced options (Experts Only!)"
+msgstr "Gelişmiş seçenekler (Uzmanlar İçin!)"
+
+#: id:494
+msgid "Overall audio headroom"
+msgstr "Genel ses boşluk payı"
+
+#: id:495
+msgid "Upsample videos to GUI resolution"
+msgstr "Videoları arayüz çözünülürlüğüne yükselt"
+
+#: id:496
+msgid "Calibration"
+msgstr "Ayarlama"
+
+#: id:497
+msgid "Show file extensions"
+msgstr "Dosya uzantılarını göster"
+
+#: id:498
+msgid "Sort by: Type"
+msgstr "Sırala: Tür"
+
+#: id:499
+msgid "Unable to connect to online lookup service"
+msgstr "Çevrimiçi arama hizmetine bağlanılamıyor"
+
+#: id:500
+msgid "Downloading album information failed"
+msgstr "Albüm bilgileri indirilemedi"
+
+#: id:501
+msgid "Looking for album names..."
+msgstr "Albüm adları aranıyor..."
+
+#: id:502
+msgctxt "Auto context with id 502"
+msgid "Open"
+msgstr "Açık"
+
+#: id:503
+msgid "Busy"
+msgstr "Meşgul"
+
+#: id:504
+msgid "Empty"
+msgstr "Boş"
+
+#: id:505
+msgid "Loading media info from files..."
+msgstr "Dosyalardan ortam bilgileri yükleniyor..."
+
+#: id:507
+msgid "Sort by: Usage"
+msgstr "Sırala: Kullanım"
+
+#: id:510
+msgid "Enable visualizations"
+msgstr "Görsel öğeleri etkinleştir"
+
+#: id:511
+msgid "Enable video mode switching"
+msgstr "Video modu geçişini etkinleştir"
+
+#: id:512
+msgid "Startup window"
+msgstr "Başlangıç penceresi"
+
+#: id:513
+msgid "Home window"
+msgstr "Giriş penceresi"
+
+#: id:514
+msgid "Manual settings"
+msgstr "Kişisel ayarlar"
+
+#: id:515
+msgid "Genre"
+msgstr "Tarz"
+
+#: id:517
+msgid "Recently played albums"
+msgstr "Yeni çalınan albümler"
+
+#: id:518
+msgid "Launch"
+msgstr "Başlat"
+
+#: id:519
+msgid "Launch in..."
+msgstr "...Modunda Başlat"
+
+#: id:521
+msgid "Compilations"
+msgstr "Derlemeler"
+
+#: id:522
+msgid "Remove source"
+msgstr "Kaynağı kaldır"
+
+#: id:523
+msgid "Switch media"
+msgstr "Ortamı değiştir"
+
+#: id:524
+msgid "Select playlist"
+msgstr "Çalma listesini seç"
+
+#: id:525
+msgid "New playlist..."
+msgstr "Yeni çalma listesi..."
+
+#: id:526
+msgid "Add to playlist"
+msgstr "Çalma listesine ekle"
+
+#: id:527
+msgid "Manually add to library"
+msgstr "Kitaplığa el ile ekle"
+
+#: id:528
+msgid "Enter title"
+msgstr "Başlığı gir"
+
+#: id:529
+msgid "Error: Duplicate title"
+msgstr "Hata: Başlık daha önce kullanıldı"
+
+#: id:530
+msgid "Select genre"
+msgstr "Tarz seçin"
+
+#: id:531
+msgid "New genre"
+msgstr "Yeni tarz"
+
+#: id:532
+msgid "Manual addition"
+msgstr "El ile ekle"
+
+#: id:533
+msgid "Enter genre"
+msgstr "Tarz girin"
+
+#: id:534
+msgid "View: %s"
+msgstr "Görünüm: %s"
+
+#: id:535
+msgid "List"
+msgstr "Liste"
+
+#: id:536
+msgid "Icons"
+msgstr "Simgeler"
+
+#: id:537
+msgid "Big list"
+msgstr "Büyük liste"
+
+#: id:538
+msgid "Big icons"
+msgstr "Büyük simge"
+
+#: id:539
+msgid "Wide"
+msgstr "Geniş"
+
+#: id:540
+msgid "Big wide"
+msgstr "Büyük geniş"
+
+#: id:541
+msgid "Album icons"
+msgstr "Albüm simgeleri"
+
+#: id:542
+msgid "DVD icons"
+msgstr "DVD simgeleri"
+
+#: id:543
+msgctxt "Auto context with id 543"
+msgid "DVD"
+msgstr "DVD"
+
+#: id:544
+msgctxt "Auto context with id 544"
+msgid "Media info"
+msgstr "Ortam bilgisi"
+
+#: id:545
+msgid "Audio output device"
+msgstr "Ses çıkış aygıtı"
+
+#: id:546
+msgid "Passthrough output device"
+msgstr "Passthrough çıkış aygıtı"
+
+#: id:547
+msgid "No biography for this artist"
+msgstr "Bu sanatçı için biyografi yok"
+
+#: id:548
+msgid "Downmix multichannel audio to stereo"
+msgstr "Çoklu ses kanallarını stereo'ya indirge"
+
+#: id:550
+msgid "Sort by: %s"
+msgstr "Sırala: %s"
+
+#: id:551
+msgctxt "Auto context with id 551"
+msgid "Name"
+msgstr "İsim"
+
+#: id:552
+msgid "Date"
+msgstr "Tarih"
+
+#: id:553
+msgid "Size"
+msgstr "Boyut"
+
+#: id:554
+msgid "Track"
+msgstr "Parça"
+
+#: id:555
+msgid "Time"
+msgstr "Zaman"
+
+#: id:556
+msgctxt "Auto context with id 556"
+msgid "Title"
+msgstr "Başlık"
+
+#: id:557
+msgid "Artist"
+msgstr "Sanatçı"
+
+#: id:558
+msgid "Album"
+msgstr "Albüm"
+
+#: id:559
+msgid "Playlist"
+msgstr "Çalma listesi"
+
+#: id:560
+msgid "ID"
+msgstr "ID"
+
+#: id:561
+msgctxt "Auto context with id 561"
+msgid "File"
+msgstr "Dosya"
+
+#: id:562
+msgctxt "Auto context with id 562"
+msgid "Year"
+msgstr "Yıl"
+
+#: id:563
+msgid "Rating"
+msgstr "Derecelendirme"
+
+#: id:564
+msgctxt "Auto context with id 564"
+msgid "Type"
+msgstr "Tür"
+
+#: id:565
+msgid "Usage"
+msgstr "Kullanım"
+
+#: id:566
+msgid "Album artist"
+msgstr "Albüm sanatçısı"
+
+#: id:567
+msgid "Play count"
+msgstr "Çalma sayısı"
+
+#: id:568
+msgid "Last played"
+msgstr "Son çalınan"
+
+#: id:569
+msgctxt "Auto context with id 569"
+msgid "Comment"
+msgstr "Açıklama"
+
+#: id:570
+msgid "Date added"
+msgstr "Eklenme tarihi"
+
+#: id:571
+msgctxt "Auto context with id 571"
+msgid "Default"
+msgstr "Varsayılan"
+
+#: id:572
+msgid "Studio"
+msgstr "Stüdyo"
+
+#: id:573
+msgid "Path"
+msgstr "Yol"
+
+#: id:574
+msgctxt "Auto context with id 574"
+msgid "Country"
+msgstr "Ülke"
+
+#: id:575
+msgid "In progress"
+msgstr "İşlem sürüyor"
+
+#: id:576
+msgid "Times played"
+msgstr "Yürütme sayısı"
+
+#: id:580
+msgid "Sort direction"
+msgstr "Sıralama yönü"
+
+#: id:581
+msgid "Sort method"
+msgstr "Sıralama yöntemi"
+
+#: id:582
+msgctxt "Auto context with id 582"
+msgid "View mode"
+msgstr "Görünüm modu"
+
+#: id:583
+msgid "Remember views for different folders"
+msgstr "Farklı klasörlerin görünümlerini hatırla"
+
+#: id:584
+msgid "Ascending"
+msgstr "Artan"
+
+#: id:585
+msgid "Descending"
+msgstr "Azalan"
+
+#: id:586
+msgid "Edit playlist"
+msgstr "Çalma listesini düzenle"
+
+#: id:587
+msgid "Filter"
+msgstr "Filtre"
+
+#: id:588
+msgid "Cancel party mode"
+msgstr "Parti modundan çık"
+
+#: id:589
+msgid "Party mode"
+msgstr "Parti modu"
+
+#: id:590
+msgid "Random"
+msgstr "Rastgele"
+
+#: id:591
+msgctxt "Auto context with id 591"
+msgid "Off"
+msgstr "Kapalı"
+
+#: id:592
+msgid "One"
+msgstr "Biri"
+
+#: id:593
+msgid "All"
+msgstr "Hepsi"
+
+#: id:594
+msgctxt "Auto context with id 594"
+msgid "Off"
+msgstr "Kapalı"
+
+#: id:595
+msgid "Repeat: Off"
+msgstr "Tekrar: Kapalı"
+
+#: id:596
+msgid "Repeat: One"
+msgstr "Tekrar: Birini"
+
+#: id:597
+msgid "Repeat: All"
+msgstr "Tekrar: Hepsini"
+
+#: id:600
+msgid "Rip audio CD"
+msgstr "Ses CD'sinden kopyala"
+
+#: id:601
+msgctxt "Auto context with id 601"
+msgid "Medium"
+msgstr "Orta"
+
+#: id:602
+msgctxt "Auto context with id 602"
+msgid "Standard"
+msgstr "Standart"
+
+#: id:603
+msgid "Extreme"
+msgstr "Extreme"
+
+#: id:604
+msgid "Constant bitrate"
+msgstr "Değişken bit oranı"
+
+#: id:605
+msgid "Ripping..."
+msgstr "Kopyalanıyor..."
+
+#: id:607
+msgid "To:"
+msgstr "Nereye:"
+
+#: id:608
+msgid "Could not rip CD or track"
+msgstr "CD veya parça kopyalanamıyor"
+
+#: id:609
+msgid "CDDARipPath is not set."
+msgstr "CDDA kopyalama yolu ayarlanmamış"
+
+#: id:610
+msgid "Rip audio track"
+msgstr "Parçayı kopyala"
+
+#: id:611
+msgid "Enter number"
+msgstr "Numara gir"
+
+#: id:612
+msgid "Bits/Sample"
+msgstr "Bits/Sample"
+
+#: id:613
+msgid "Sample Frequency"
+msgstr "Sample Frequency"
+
+#: id:620
+msgid "Audio CDs"
+msgstr "Ses CD'leri"
+
+#: id:621
+msgid "Encoder"
+msgstr "Kodlayıcı"
+
+#: id:622
+msgid "Quality"
+msgstr "Kalite"
+
+#: id:623
+msgid "Bitrate"
+msgstr "Bit oranı"
+
+#: id:624
+msgid "Include track number"
+msgstr "Parça numarasını dahil et"
+
+#: id:625
+msgid "All songs of"
+msgstr "Bütün şarkılar buraya"
+
+#: id:629
+msgctxt "Auto context with id 629"
+msgid "View mode"
+msgstr "Görünüm modu"
+
+#: id:630
+msgctxt "Auto context with id 630"
+msgid "Normal"
+msgstr "Normal"
+
+#: id:631
+msgid "Zoom"
+msgstr "Yakınlaştır"
+
+#: id:632
+msgid "Stretch 4:3"
+msgstr "4:3'e genişlet"
+
+#: id:633
+msgid "Wide Zoom"
+msgstr "Geniş yakınlaştırma"
+
+#: id:634
+msgid "Stretch 16:9"
+msgstr "16:9'a genişlet"
+
+#: id:635
+msgid "Original Size"
+msgstr "Orijinal Boyut"
+
+#: id:636
+msgctxt "Auto context with id 636"
+msgid "Custom"
+msgstr "Özel"
+
+#: id:637
+msgid "Replay gain"
+msgstr "Replay gain"
+
+#: id:638
+msgid "Replaygain volume adjustments"
+msgstr "Replaygain ses ayarlamaları"
+
+#: id:639
+msgid "Use track levels"
+msgstr "Parça seviyesini kullan"
+
+#: id:640
+msgid "Use album levels"
+msgstr "Albüm seviyesini kullan"
+
+#: id:641
+msgid "PreAmp Level - Replay gained files"
+msgstr "PreAmp Level - Replay gained files"
+
+#: id:642
+msgid "PreAmp Level - Non replay gained files"
+msgstr "PreAmp Level - Non replay gained files"
+
+#: id:643
+msgid "Avoid clipping on replay gained files"
+msgstr "Avoid clipping on replay gained files"
+
+#: id:644
+msgid "Crop black bars"
+msgstr "Siyah yerleri kırp"
+
+#: id:645
+msgid "Need to unpack a big file. Continue?"
+msgstr "Büyük bir dosyayı açmak gerekiyor. Devam edilsin mi?"
+
+#: id:646
+msgid "Remove from library"
+msgstr "Kitaplıktan kaldır"
+
+#: id:647
+msgid "Export video library"
+msgstr "Video kitaplığını dışa aktar"
+
+#: id:648
+msgid "Import video library"
+msgstr "Video kitaplığını içe aktar"
+
+#: id:649
+msgid "Importing"
+msgstr "İçe aktar"
+
+#: id:650
+msgid "Exporting"
+msgstr "Dışa aktar"
+
+#: id:651
+msgid "Browse for library"
+msgstr "Kitaplığa gözat"
+
+#: id:652
+msgid "Years"
+msgstr "Yıllar"
+
+#: id:653
+msgid "Update library"
+msgstr "Kitaplığı güncelle"
+
+#: id:654
+msgid "Show debug info"
+msgstr "Hata ayıklama bilgisini göster"
+
+#: id:655
+msgid "Browse for executable"
+msgstr "Çalıştırılabilirlere gözat"
+
+#: id:656
+msgid "Browse for playlist"
+msgstr "Çalma listesine gözat"
+
+#: id:657
+msgid "Browse for folder"
+msgstr "Klasöre gözat"
+
+#: id:658
+msgid "Song information"
+msgstr "Şarkı bilgisi"
+
+#: id:659
+msgid "Non-linear stretch"
+msgstr "Doğrusal olmayan genişletme"
+
+#: id:660
+msgid "Volume amplification"
+msgstr "Ses yükseltici"
+
+#: id:661
+msgid "Choose export folder"
+msgstr "Dışa aktarma dizinini seç"
+
+#: id:662
+msgid "This file is no longer available."
+msgstr "Bu dosya artık mevcut değil."
+
+#: id:663
+msgid "Would you like to remove it from the library?"
+msgstr "Kitaplıktan kaldırmak ister misiniz?"
+
+#: id:664
+msgid "Browse for Script"
+msgstr "Betiklere gözat"
+
+#: id:665
+msgid "Compression level"
+msgstr "Sıkıştırma düzeyi"
+
+#: id:700
+msgid "Cleaning up library"
+msgstr "Kitaplık temizleniyor"
+
+#: id:701
+msgid "Removing old songs from the library"
+msgstr "Eski şarkılar kitaplıktan kaldırılıyor"
+
+#: id:702
+msgid "This path has been scanned before"
+msgstr "Bu yol daha önceden taranmıştı"
+
+#: id:705
+msgctxt "Auto context with id 705"
+msgid "Network"
+msgstr "Ağ Bağlantıları"
+
+#: id:706
+msgid "- Server"
+msgstr "- Sunucu"
+
+#: id:708
+msgid "Use an HTTP proxy server to access the internet"
+msgstr "İnternet erişimi için HTTP vekil sunucusu kullan"
+
+#: id:711
+msgid "Internet Protocol (IP)"
+msgstr "İnternet Protokolü (IP)"
+
+#: id:712
+msgid "Invalid port specified. Value must be between 1 and 65535."
+msgstr "Geçersiz port numarası girildi. Değerler 1 ile 65535 arası olmalı."
+
+#: id:713
+msgid "HTTP proxy"
+msgstr "HTTP vekil sunucu"
+
+#: id:715
+msgid "- Assignment"
+msgstr "- Atama"
+
+#: id:716
+msgid "Automatic (DHCP)"
+msgstr "Otomatik (DHCP)"
+
+#: id:717
+msgid "Manual (Static)"
+msgstr "Kişisel (Statik)"
+
+#: id:719
+msgid "- IP address"
+msgstr "- IP adresi"
+
+#: id:720
+msgid "- Netmask"
+msgstr "- Ağ maskesi"
+
+#: id:721
+msgid "- Default gateway"
+msgstr "- Varsayılan ağ geçidi"
+
+#: id:722
+msgid "- DNS server"
+msgstr "- DNS sunucusu"
+
+#: id:723
+msgid "Save & restart"
+msgstr "Kaydet ve yeniden başlat"
+
+#: id:724
+msgid "Invalid address specified. Value must be AAA.BBB.CCC.DDD"
+msgstr "Geçersiz adres girildi. Veriler AAA.BBB.CCC.DDD şeklinde olmalı"
+
+#: id:725
+msgid "with numbers between 0 and 255."
+msgstr "0 ile 255 arası bir rakam seçiniz."
+
+#: id:726
+msgid "Changes not saved. Continue without saving?"
+msgstr "Değişiklikler kaydedilmedi. Kaydetmeden çıkmak istiyor musunuz?"
+
+#: id:727
+msgid "Web server"
+msgstr "Web sunucusu"
+
+#: id:728
+msgctxt "Auto context with id 728"
+msgid "FTP server"
+msgstr "FTP sunucusu"
+
+#: id:730
+msgid "- Port"
+msgstr "- Port"
+
+#: id:732
+msgid "Save & apply"
+msgstr "Kaydet ve uygula"
+
+#: id:733
+msgid "- Password"
+msgstr "- Parola"
+
+#: id:734
+msgid "No pass"
+msgstr "Parola yok"
+
+#: id:735
+msgid "- Character set"
+msgstr "- Karakter kodlaması"
+
+#: id:736
+msgid "- Style"
+msgstr "- Stil"
+
+#: id:737
+msgid "- Colour"
+msgstr "- Renk"
+
+#: id:738
+msgctxt "Auto context with id 738"
+msgid "Normal"
+msgstr "Normal"
+
+#: id:739
+msgid "Bold"
+msgstr "Kalın"
+
+#: id:740
+msgid "Italics"
+msgstr "İtalik"
+
+#: id:741
+msgid "Bold italics"
+msgstr "Kalın italik"
+
+#: id:742
+msgctxt "Auto context with id 742"
+msgid "White"
+msgstr "Beyaz"
+
+#: id:743
+msgctxt "Auto context with id 743"
+msgid "Yellow"
+msgstr "Sarı"
+
+#: id:744
+msgctxt "Auto context with id 744"
+msgid "Files"
+msgstr "Dosyalar"
+
+#: id:745
+msgid "No scanned information for this view"
+msgstr "Bu görünüm için taranmış bilgi yok"
+
+#: id:746
+msgid "Please turn off library mode"
+msgstr "Lütfen kitaplık modunu kapatın"
+
+#: id:747
+msgid "Error loading image"
+msgstr "Resim yüklenirken hata oluştu"
+
+#: id:748
+msgid "Edit path"
+msgstr "Yolu düzenle"
+
+#: id:749
+msgid "Mirror image"
+msgstr "Resmi aynala"
+
+#: id:750
+msgid "Are you sure?"
+msgstr "Emin misiniz?"
+
+#: id:751
+msgid "Removing source"
+msgstr "Kaynak kaldırılıyor"
+
+#: id:754
+msgid "Add program link"
+msgstr "Program bağlantısı ekle"
+
+#: id:755
+msgid "Edit program path"
+msgstr "Program yolunu düzenle"
+
+#: id:756
+msgid "Edit program name"
+msgstr "Program adını düzenle"
+
+#: id:757
+msgid "Edit path depth"
+msgstr "Yolun derinliğini düzenle"
+
+#: id:759
+msgid "View: Big list"
+msgstr "Görünüm: Büyük liste"
+
+#: id:760
+msgctxt "Auto context with id 760"
+msgid "Yellow"
+msgstr "Sarı"
+
+#: id:761
+msgctxt "Auto context with id 761"
+msgid "White"
+msgstr "Beyaz"
+
+#: id:762
+msgid "Blue"
+msgstr "Mavi"
+
+#: id:763
+msgid "Bright green"
+msgstr "Açık yeşil"
+
+#: id:764
+msgid "Yellow green"
+msgstr "Turkuaz"
+
+#: id:765
+msgid "Cyan"
+msgstr "Çiyan"
+
+#: id:766
+msgid "Light grey"
+msgstr "Açık gri"
+
+#: id:767
+msgid "Grey"
+msgstr "Gri"
+
+#: id:770
+msgid "Error %i: share not available"
+msgstr "Hata %i: paylaşım bulunamıyor"
+
+#: id:772
+msgctxt "Auto context with id 772"
+msgid "Audio output"
+msgstr "Ses çıkışı"
+
+#: id:773
+msgid "Seeking"
+msgstr "Atla"
+
+#: id:774
+msgid "Slideshow folder"
+msgstr "Slayt Gösterisi klasörü"
+
+#: id:775
+msgid "Network interface"
+msgstr "Ağ arabirimi"
+
+#: id:776
+msgid "- Wireless network name (ESSID)"
+msgstr "- Kablosuz ağın adı (ESSID)"
+
+#: id:777
+msgid "- Wireless password"
+msgstr "- Kablosuz ağın parolası"
+
+#: id:778
+msgid "- Wireless security"
+msgstr "- Kablosuz ağın güvenliği"
+
+#: id:779
+msgid "Save and apply network interface settings"
+msgstr "Ağ arabirimi ayarlarını kaydet ve uygula"
+
+#: id:780
+msgid "No encryption"
+msgstr "Şifreleme yok"
+
+#: id:781
+msgid "WEP"
+msgstr "WEP"
+
+#: id:782
+msgid "WPA"
+msgstr "WPA"
+
+#: id:783
+msgid "WPA2"
+msgstr "WPA2"
+
+#: id:784
+msgid "Applying network interface settings. Please wait."
+msgstr "Ağ arabirim ayarları uygulanıyor. Lütfen bekleyin."
+
+#: id:785
+msgid "Network interface restarted successfully."
+msgstr "Ağ arabirimi yeniden başlatıldı."
+
+#: id:786
+msgid "Network interface did not start successfully."
+msgstr "Ağ arabirimi başlatılamadı."
+
+#: id:787
+msgid "Interface disabled"
+msgstr "Arabirim devre dışı"
+
+#: id:788
+msgid "Network interface disabled successfully."
+msgstr "Ağ arabirimi başarıyla devre dışı bırakıldı."
+
+#: id:789
+msgid "Wireless network name (ESSID)"
+msgstr "Kablosuz ağın adı (ESSID)"
+
+#: id:790
+msgid "Remote control"
+msgstr "Uzaktan kontrol"
+
+#: id:791
+msgid "Allow programs on this system to control XBMC"
+msgstr "Bu sistemdeki programların XBMC'yi kontrol etmesine izin ver"
+
+#: id:792
+msgctxt "Auto context with id 792"
+msgid "Port"
+msgstr "Port"
+
+#: id:793
+msgid "Port range"
+msgstr "Port aralığı"
+
+#: id:794
+msgid "Allow programs on other systems to control XBMC"
+msgstr "Diğer sistemlerdeki programların XBMC'yi kontrol etmesine izin ver"
+
+#: id:795
+msgid "Initial repeat delay (ms)"
+msgstr "Başlangıçtaki tekrar gecikmesi (ms)"
+
+#: id:796
+msgid "Continuous repeat delay (ms)"
+msgstr "Kesintisiz tekrar gecikmesi (ms)"
+
+#: id:797
+msgid "Maximum number of clients"
+msgstr "Azami istemci sayısı"
+
+#: id:798
+msgid "Internet access"
+msgstr "İnternet erişimi"
+
+#: id:850
+msgid "Invalid port number entered"
+msgstr "Geçersiz port numarası girildi"
+
+#: id:851
+msgid "Valid port range is 1-65535"
+msgstr "Geçerli port aralığı 1-65535"
+
+#: id:852
+msgid "Valid port range is 1024-65535"
+msgstr "Geçerli port aralığı 1024-65535"
+
+#: id:998
+msgid "Add Music..."
+msgstr "Müzik Ekle..."
+
+#: id:999
+msgid "Add Videos..."
+msgstr "Video Ekle..."
+
+#: id:1000
+msgid "- Preview"
+msgstr "- Önizleme"
+
+#: id:1001
+msgid "Unable to connect"
+msgstr "Bağlanamıyor"
+
+#: id:1002
+msgid "XBMC was unable to connect to the network location."
+msgstr "XBMC ağda belirtilen klasöre bağlanamıyor."
+
+#: id:1003
+msgid "This could be due to the network not being connected."
+msgstr "Bu olay ağın bağlı olmamasından kaynaklanabilir."
+
+#: id:1004
+msgid "Would you like to add it anyway?"
+msgstr "Yine de eklemek istiyor musunuz?"
+
+#: id:1006
+msgctxt "Auto context with id 1006"
+msgid "IP address"
+msgstr "IP adresi"
+
+#: id:1007
+msgid "Add network location"
+msgstr "Ağ konumu ekle"
+
+#: id:1008
+msgid "Protocol"
+msgstr "Protokol"
+
+#: id:1009
+msgid "Server address"
+msgstr "Sunucu adresi"
+
+#: id:1010
+msgid "Server name"
+msgstr "Sunucu adı"
+
+#: id:1011
+msgid "Remote path"
+msgstr "Uzak yol"
+
+#: id:1012
+msgid "Shared folder"
+msgstr "Paylaştırılmış klasör"
+
+#: id:1013
+msgctxt "Auto context with id 1013"
+msgid "Port"
+msgstr "Port"
+
+#: id:1014
+msgctxt "Auto context with id 1014"
+msgid "Username"
+msgstr "Kullanıcı adı"
+
+#: id:1015
+msgid "Browse for network server"
+msgstr "Ağ sunucusuna gözat"
+
+#: id:1016
+msgid "Enter the network address of the server"
+msgstr "Sunucunun ağ adresini girin"
+
+#: id:1017
+msgid "Enter the path on the server"
+msgstr "Sunucu üstündeki yolu girin"
+
+#: id:1018
+msgid "Enter the port number"
+msgstr "Port numarasını girin"
+
+#: id:1019
+msgid "Enter the username"
+msgstr "Kullanıcı adını girin"
+
+#: id:1020
+msgid "Add %s source"
+msgstr "%s kaynağını ekle"
+
+#: id:1021
+msgid "Enter the paths or browse for the media locations."
+msgstr "Yolları girin veya ortam konumlarına gözatın."
+
+#: id:1022
+msgid "Enter a name for this media Source."
+msgstr "Bu ortam kaynağı için bir isim girin."
+
+#: id:1023
+msgid "Browse for new share"
+msgstr "Yeni paylaşımlara gözat"
+
+#: id:1024
+msgid "Browse"
+msgstr "Gözat"
+
+#: id:1025
+msgid "Could not retrieve directory information."
+msgstr "Dizin bilgileri alınamıyor."
+
+#: id:1026
+msgid "Add source"
+msgstr "Kaynak ekle"
+
+#: id:1027
+msgid "Edit source"
+msgstr "Kaynağı düzenle"
+
+#: id:1028
+msgid "Edit %s source"
+msgstr "%s kaynağını düzenle"
+
+#: id:1029
+msgid "Enter the new label"
+msgstr "Yeni etiket girin"
+
+#: id:1030
+msgid "Browse for image"
+msgstr "Resme gözat"
+
+#: id:1031
+msgid "Browse for image folder"
+msgstr "Resim klasörüne gözat"
+
+#: id:1032
+msgid "Add network location..."
+msgstr "Ağ adresi ekle..."
+
+#: id:1033
+msgid "Browse for file"
+msgstr "Dosyaya gözat"
+
+#: id:1034
+msgid "Submenu"
+msgstr "Altmenü"
+
+#: id:1035
+msgid "Enable submenu buttons"
+msgstr "Altmenü tuşlarını etkinleştir"
+
+#: id:1036
+msgid "Favourites"
+msgstr "Sık Kullanılanlar"
+
+#: id:1037
+msgid "Video Add-ons"
+msgstr "Video Eklentileri"
+
+#: id:1038
+msgid "Music Add-ons"
+msgstr "Müzik Eklentileri"
+
+#: id:1039
+msgid "Picture Add-ons"
+msgstr "Resim Eklentileri"
+
+#: id:1040
+msgid "Loading directory"
+msgstr "Klasör yükleniyor"
+
+#: id:1041
+msgid "Retrieved %i items"
+msgstr "%i öge alındı"
+
+#: id:1042
+msgid "Retrieved %i of %i items"
+msgstr "%i ögeden %i tanesi alındı"
+
+#: id:1043
+msgid "Program Add-ons"
+msgstr "Program Eklentileri"
+
+#: id:1044
+msgid "Set plugin thumb"
+msgstr "Eklenti küçük resmini ayarla"
+
+#: id:1045
+msgid "Add-on settings"
+msgstr "Eklenti ayarları"
+
+#: id:1046
+msgid "Access points"
+msgstr "Giriş noktaları"
+
+#: id:1047
+msgid "Other..."
+msgstr "Diğer..."
+
+#: id:1048
+msgid "- Username"
+msgstr "- Kullanıcı adı"
+
+#: id:1049
+msgid "Script settings"
+msgstr "Betik ayarları"
+
+#: id:1050
+msgid "Singles"
+msgstr "Tek Parçalık Albümler"
+
+#: id:1051
+msgid "Enter web address"
+msgstr "İnternet adresini girin"
+
+#: id:1200
+msgid "SMB client"
+msgstr "SMB istemcisi"
+
+#: id:1202
+msgid "Workgroup"
+msgstr "Çalışma grubu"
+
+#: id:1203
+msgid "Default username"
+msgstr "Varsayılan kullanıcı adı"
+
+#: id:1204
+msgid "Default password"
+msgstr "Varsayılan parola"
+
+#: id:1207
+msgid "WINS server"
+msgstr "WINS sunucusu"
+
+#: id:1208
+msgid "Mount SMB shares"
+msgstr "SMB paylaşımlarını bağla"
+
+#: id:1210
+msgctxt "Auto context with id 1210"
+msgid "Remove"
+msgstr "Kaldır"
+
+#: id:1211
+msgctxt "Auto context with id 1211"
+msgid "Music"
+msgstr "Müzik"
+
+#: id:1212
+msgctxt "Auto context with id 1212"
+msgid "Video"
+msgstr "Video"
+
+#: id:1213
+msgctxt "Auto context with id 1213"
+msgid "Pictures"
+msgstr "Resimler"
+
+#: id:1214
+msgctxt "Auto context with id 1214"
+msgid "Files"
+msgstr "Dosyalar"
+
+#: id:1215
+msgctxt "Auto context with id 1215"
+msgid "Music & video"
+msgstr "Müzik & video"
+
+#: id:1216
+msgid "Music & pictures"
+msgstr "Müzik & resimler"
+
+#: id:1217
+msgid "Music & files"
+msgstr "Müzik & dosyalar"
+
+#: id:1218
+msgid "Video & pictures"
+msgstr "Video & resimler"
+
+#: id:1219
+msgid "Video & files"
+msgstr "Video & dosyalar"
+
+#: id:1220
+msgid "Pictures & files"
+msgstr "Resimler & dosyalar"
+
+#: id:1221
+msgid "Music & video & pictures"
+msgstr "Müzik & video & resimler"
+
+#: id:1222
+msgid "Music & video & pictures & files"
+msgstr "Müzik & video & resimler & dosyalar"
+
+#: id:1223
+msgctxt "Auto context with id 1223"
+msgid "Disabled"
+msgstr "Devre dışı"
+
+#: id:1226
+msgid "Files & music & video"
+msgstr "Dosyalar & müzik & video"
+
+#: id:1227
+msgid "Files & pictures & music"
+msgstr "Dosyalar & resimler & müzik"
+
+#: id:1228
+msgid "Files & pictures & video"
+msgstr "Dosyalar & resimler & video"
+
+#: id:1229
+msgid "Music & programs"
+msgstr "Müzik & programlar"
+
+#: id:1230
+msgid "Video & programs"
+msgstr "Video & programlar"
+
+#: id:1231
+msgid "Pictures & programs"
+msgstr "Resimler & programlar"
+
+#: id:1232
+msgid "Music & video & pictures & programs"
+msgstr "Müzik & video & resimler & programlar"
+
+#: id:1233
+msgid "Programs & video & music"
+msgstr "Programlar & video & müzik"
+
+#: id:1234
+msgid "Programs & pictures & music"
+msgstr "Programlar & resimler & müzik"
+
+#: id:1235
+msgid "Programs & pictures & video"
+msgstr "Programlar & resimler & video"
+
+#: id:1250
+msgid "Auto-detection"
+msgstr "Otomatik algılama"
+
+#: id:1251
+msgid "Auto-detect system"
+msgstr "Otomatik sistem algılama"
+
+#: id:1252
+msgid "Nickname"
+msgstr "Takma isim"
+
+#: id:1254
+msgid "Ask to connect"
+msgstr "Bağlanmak için sor"
+
+#: id:1255
+msgid "Send FTP user and password"
+msgstr "FTP kullanıcı adını ve parolasını gönder"
+
+#: id:1256
+msgid "Ping interval"
+msgstr "Ping süresi"
+
+#: id:1257
+msgid "Would you like to connect to the auto-detected system?"
+msgstr "Otomatik olarak tanımlanan sisteme bağlanmak ister misiniz?"
+
+#: id:1259
+msgid "Zeroconf"
+msgstr "Zeroconf"
+
+#: id:1260
+msgid "Announce these services to other systems via Zeroconf"
+msgstr "Bu hizmetleri Zeroconf üzerinden diğer sistemlere bildir"
+
+#: id:1270
+msgid "Allow XBMC to receive AirPlay content"
+msgstr "XBMC'nin AirPlay içeriğini almasına izin ver"
+
+#: id:1271
+msgid "Device name"
+msgstr "Aygıt adı"
+
+#: id:1272
+msgid "- Use password protection"
+msgstr "- Parola koruması kullan"
+
+#: id:1273
+msgid "AirPlay"
+msgstr "AirPlay"
+
+#: id:1300
+msgid "Custom audio device"
+msgstr "Özel ses aygıtı"
+
+#: id:1301
+msgid "Custom passthrough device"
+msgstr "Özel passthrough aygıtı"
+
+#: id:1396
+msgid "Drifting"
+msgstr "Akıntılı"
+
+#: id:1397
+msgid "and"
+msgstr "ve"
+
+#: id:1398
+msgid "Freezing"
+msgstr "Donma noktası"
+
+#: id:1399
+msgid "Late"
+msgstr "Gecikmiş"
+
+#: id:1400
+msgid "Isolated"
+msgstr "Tecrit edilmiş"
+
+#: id:1401
+msgid "Thundershowers"
+msgstr "Sağanak yağışlı"
+
+#: id:1402
+msgid "Thunder"
+msgstr "Gök gürültülü"
+
+#: id:1403
+msgctxt "Auto context with id 1403"
+msgid "Sun"
+msgstr "Güneşli"
+
+#: id:1404
+msgid "Heavy"
+msgstr "Sağanak"
+
+#: id:1405
+msgid "in"
+msgstr "içinde"
+
+#: id:1406
+msgid "the"
+msgstr "-"
+
+#: id:1407
+msgid "Vicinity"
+msgstr "Görüş mesafesi"
+
+#: id:1408
+msgid "Ice"
+msgstr "Buz"
+
+#: id:1409
+msgid "Crystals"
+msgstr "Kristal"
+
+#: id:1410
+msgid "Calm"
+msgstr "Ilık"
+
+#: id:1411
+msgid "with"
+msgstr "ile"
+
+#: id:1412
+msgid "windy"
+msgstr "rüzgarlı"
+
+#: id:1413
+msgid "drizzle"
+msgstr "çiseleyen"
+
+#: id:1414
+msgid "Thunderstorm"
+msgstr "Gök gürültülü sağanak"
+
+#: id:1415
+msgid "Drizzle"
+msgstr "Çiseleyen"
+
+#: id:1416
+msgid "Foggy"
+msgstr "Sisli"
+
+#: id:1417
+msgid "Grains"
+msgstr "Grains"
+
+#: id:1418
+msgid "T-Storms"
+msgstr "T-Storms"
+
+#: id:1419
+msgid "T-Showers"
+msgstr "T-Showers"
+
+#: id:1420
+msgid "Moderate"
+msgstr "Hafif"
+
+#: id:1421
+msgid "Very High"
+msgstr "Çok Yüksek"
+
+#: id:1422
+msgid "Windy"
+msgstr "Rüzgarlı"
+
+#: id:1423
+msgid "Mist"
+msgstr "Sisli"
+
+#: id:1450
+msgid "Put display to sleep when idle"
+msgstr "Boştayken uyku moduna geç"
+
+#: id:2050
+msgid "Runtime"
+msgstr "Süre"
+
+#: id:2100
+msgid "Script failed! : %s"
+msgstr "Betik başarısız! : %s"
+
+#: id:2101
+msgid "Newer version needed - See log"
+msgstr "Yeni bir sürümü gerekli - Günlüğe bakın"
+
+#: id:4501
+msgid "Enable LCD/VFD"
+msgstr "LCD/VFD'yi etkinleştir"
+
+#: id:10000
+msgid "Home"
+msgstr "Giriş"
+
+#: id:10001
+msgctxt "Auto context with id 10001"
+msgid "Programs"
+msgstr "Programlar"
+
+#: id:10002
+msgctxt "Auto context with id 10002"
+msgid "Pictures"
+msgstr "Resimler"
+
+#: id:10003
+msgctxt "Auto context with id 10003"
+msgid "File manager"
+msgstr "Dosya yöneticisi"
+
+#: id:10004
+msgctxt "Auto context with id 10004"
+msgid "Settings"
+msgstr "Ayarlar"
+
+#: id:10005
+msgctxt "Auto context with id 10005"
+msgid "Music"
+msgstr "Müzik"
+
+#: id:10006
+msgctxt "Auto context with id 10006"
+msgid "Videos"
+msgstr "Videolar"
+
+#: id:10007
+msgid "System information"
+msgstr "Sistem bilgisi"
+
+#: id:10008
+msgid "Settings - General"
+msgstr "Ayarlar - Genel"
+
+#: id:10009
+msgid "Settings - Screen"
+msgstr "Ayarlar - Ekran"
+
+#: id:10010
+msgid "Settings - Appearance - GUI Calibration"
+msgstr "Ayarlar - Görünüm - Arayüz Ayarları"
+
+#: id:10011
+msgid "Settings - Videos - Screen Calibration"
+msgstr "Ayarlar - Videolar - Ekran Ayarları"
+
+#: id:10012
+msgid "Settings - Pictures"
+msgstr "Ayarlar - Resimler"
+
+#: id:10013
+msgid "Settings - Programs"
+msgstr "Ayarlar - Programlar"
+
+#: id:10014
+msgid "Settings - Weather"
+msgstr "Ayarlar - Hava Durumu"
+
+#: id:10015
+msgid "Settings - Music"
+msgstr "Ayarlar - Müzik"
+
+#: id:10016
+msgid "Settings - System"
+msgstr "Ayarlar - Sistem"
+
+#: id:10017
+msgid "Settings - Videos"
+msgstr "Ayarlar - Videolar"
+
+#: id:10018
+msgid "Settings - Network"
+msgstr "Ayarlar - Ağ Bağlantısı"
+
+#: id:10019
+msgid "Settings - Appearance"
+msgstr "Ayarlar - Görünüm"
+
+#: id:10020
+msgctxt "Auto context with id 10020"
+msgid "Scripts"
+msgstr "Betikler"
+
+#: id:10021
+msgid "Web Browser"
+msgstr "Web Tarayıcısı"
+
+#: id:10025
+msgctxt "Auto context with id 10025"
+msgid "Videos"
+msgstr "Videolar"
+
+#: id:10028
+msgid "Videos/Playlist"
+msgstr "Videolar/Çalma Listesi"
+
+#: id:10029
+msgctxt "Auto context with id 10029"
+msgid "Login screen"
+msgstr "Giriş ekranı"
+
+#: id:10034
+msgid "Settings - Profiles"
+msgstr "Ayarlar - Profiller"
+
+#: id:10040
+msgid "Addon browser"
+msgstr "Eklenti tarayıcısı"
+
+#: id:10100
+msgid "Yes/No dialog"
+msgstr "Evet/Hayır iletişim kutusu"
+
+#: id:10101
+msgid "Progress dialog"
+msgstr "İlerleme iletişim kutusu"
+
+#: id:10210
+msgid "Looking for subtitles..."
+msgstr "Altyazılara bakılıyor..."
+
+#: id:10211
+msgid "Looking for or caching subtitles..."
+msgstr "Altyazılara bakılıyor veya önbellekleniyor..."
+
+#: id:10212
+msgid "terminating"
+msgstr "sonlandırılıyor"
+
+#: id:10213
+msgid "buffering"
+msgstr "arabelleğe alınıyor"
+
+#: id:10214
+msgid "Opening stream"
+msgstr "Akış açılıyor"
+
+#: id:10500
+msgid "Music/Playlist"
+msgstr "Müzik/Çalma Listesi"
+
+#: id:10501
+msgid "Music/Files"
+msgstr "Müzik/Dosyalar"
+
+#: id:10502
+msgid "Music/Library"
+msgstr "Müzik/Kitaplık"
+
+#: id:10503
+msgid "Playlist editor"
+msgstr "Çalma listesi düzenleyicisi"
+
+#: id:10504
+msgid "Top 100 songs"
+msgstr "En iyi 100 şarkı"
+
+#: id:10505
+msgid "Top 100 albums"
+msgstr "En iyi 100 albüm"
+
+#: id:10506
+msgctxt "Auto context with id 10506"
+msgid "Programs"
+msgstr "Programlar"
+
+#: id:10507
+msgid "Configuration"
+msgstr "Yapılandırma"
+
+#: id:10508
+msgid "Weather forecast"
+msgstr "Hava Tahmini"
+
+#: id:10509
+msgid "Network gaming"
+msgstr "Ağ üzerinden oyun"
+
+#: id:10510
+msgid "Extensions"
+msgstr "Eklentiler"
+
+#: id:10511
+msgctxt "Auto context with id 10511"
+msgid "System info"
+msgstr "Sistem bilgisi"
+
+#: id:10516
+msgid "Music - Library"
+msgstr "Müzik - Kitaplık"
+
+#: id:10517
+msgid "Now Playing - Music"
+msgstr "Şimdi Çalınıyor - Müzik"
+
+#: id:10522
+msgid "Now Playing - Videos"
+msgstr "Şimdi Oynatılıyor - Videolar"
+
+#: id:10523
+msgid "Album info"
+msgstr "Albüm bilgisi"
+
+#: id:10524
+msgid "Movie info"
+msgstr "Film bilgisi"
+
+#: id:12000
+msgid "Select dialog"
+msgstr "Seçim iletişim kutusu"
+
+#: id:12001
+msgid "Music/Info"
+msgstr "Müzik/Bilgi"
+
+#: id:12002
+msgid "Dialog OK"
+msgstr "Tamam iletişim kutusu"
+
+#: id:12003
+msgid "Videos/Info"
+msgstr "Videolar/Bilgi"
+
+#: id:12004
+msgid "Scripts/Info"
+msgstr "Betikler/Bilgi"
+
+#: id:12005
+msgid "Fullscreen video"
+msgstr "Tam Ekran Video"
+
+#: id:12006
+msgid "Audio visualization"
+msgstr "Müzik görsel öğesi"
+
+#: id:12008
+msgid "File stacking dialog"
+msgstr "Dosya yığınlama iletişim kutusu"
+
+#: id:12009
+msgid "Rebuild index..."
+msgstr "İçeriği yenile..."
+
+#: id:12010
+msgid "Return to music window"
+msgstr "Müzik penceresine dön"
+
+#: id:12011
+msgid "Return to videos window"
+msgstr "Videolar penceresine dön"
+
+#: id:12021
+msgid "Start from beginning"
+msgstr "Baştan başla"
+
+#: id:12022
+msgid "Resume from %s"
+msgstr "%s pozisyonundan devam et"
+
+#: id:12310
+msgid "0"
+msgstr "0"
+
+#: id:12311
+msgid "1"
+msgstr "1"
+
+#: id:12312
+msgid "2"
+msgstr "2"
+
+#: id:12313
+msgid "3"
+msgstr "3"
+
+#: id:12314
+msgid "4"
+msgstr "4"
+
+#: id:12315
+msgid "5"
+msgstr "5"
+
+#: id:12316
+msgid "6"
+msgstr "6"
+
+#: id:12317
+msgid "7"
+msgstr "7"
+
+#: id:12318
+msgid "8"
+msgstr "8"
+
+#: id:12319
+msgid "9"
+msgstr "9"
+
+#: id:12320
+msgid "c"
+msgstr "c"
+
+#: id:12321
+msgid "Ok"
+msgstr "Tamam"
+
+#: id:12322
+msgid "*"
+msgstr "*"
+
+#: id:12325
+msgid "Locked! Enter code..."
+msgstr "Kilitli! Şifreyi girin..."
+
+#: id:12326
+msgid "Enter password"
+msgstr "Parola girin"
+
+#: id:12327
+msgid "Enter master code"
+msgstr "Yönetici şifresini girin"
+
+#: id:12328
+msgid "Enter unlock code"
+msgstr "Açma şifresini girin"
+
+#: id:12329
+msgid "or press C to cancel"
+msgstr "veya çıkmak için C'ye basın"
+
+#: id:12330
+msgid "Enter gamepad button combo and"
+msgstr "Joystick tuş kombinasyonunun girin ve Start'a basın"
+
+#: id:12331
+msgid "press OK, or Back to cancel"
+msgstr "Start'a basın veya çıkmak için Back'e basın"
+
+#: id:12332
+msgid "Set lock"
+msgstr "Kilidi ayarla"
+
+#: id:12333
+msgid "Unlock"
+msgstr "Kilidi aç"
+
+#: id:12334
+msgid "Reset lock"
+msgstr "Kilidi sıfırla"
+
+#: id:12335
+msgid "Remove lock"
+msgstr "Kilidi kaldır"
+
+#: id:12337
+msgid "Numeric password"
+msgstr "Sayısal parola"
+
+#: id:12338
+msgid "Gamepad button combo"
+msgstr "Joystick tuş kombinasyonu"
+
+#: id:12339
+msgid "Full-text password"
+msgstr "Tam metin parola"
+
+#: id:12340
+msgid "Enter new password"
+msgstr "Yeni parolayı girin"
+
+#: id:12341
+msgid "Re-Enter new password"
+msgstr "Yeni parolayı tekrar girin"
+
+#: id:12342
+msgid "Incorrect password,"
+msgstr "Yanlış parola,"
+
+#: id:12343
+msgid "retries left"
+msgstr "deneme hakkı kaldı"
+
+#: id:12344
+msgid "Passwords entered did not match."
+msgstr "Girilen parola aynı değil."
+
+#: id:12345
+msgid "Access denied"
+msgstr "Giriş reddedildi"
+
+#: id:12346
+msgid "Password retry limit exceeded."
+msgstr "Parola deneme hakkı tükendi."
+
+#: id:12347
+msgid "The system will now shut off."
+msgstr "Sistem şimdi kapatılacak."
+
+#: id:12348
+msgid "Item locked"
+msgstr "Kilitli"
+
+#: id:12353
+msgid "Reactivate lock"
+msgstr "Kilidi yeniden etkinleştir"
+
+#: id:12356
+msgid "Change lock"
+msgstr "Kilidi değiştir"
+
+#: id:12357
+msgid "Source lock"
+msgstr "Kaynak kilidi"
+
+#: id:12358
+msgid "Password entry was blank. Try again."
+msgstr "Boş parola girildi. Yeniden deneyin."
+
+#: id:12360
+msgid "Master lock"
+msgstr "Yönetici kilidi"
+
+#: id:12362
+msgid "Shutdown system if Master Lock retries exceeded"
+msgstr "Eğer Yönetici Kilidi denemesi aşılırsa sistemi kapat"
+
+#: id:12367
+msgid "Master code is not valid"
+msgstr "Geçersiz yönetici şifresi"
+
+#: id:12368
+msgid "Please enter a valid master code"
+msgstr "Lütfen doğru yönetici şifresini girin"
+
+#: id:12373
+msgid "Settings & file manager"
+msgstr "Ayarlar ve dosya yöneticisi"
+
+#: id:12376
+msgid "Set as default for all movies"
+msgstr "Tüm videolar için varsayılan olarak ayarla"
+
+#: id:12377
+msgid "This will reset any previously saved values"
+msgstr "Bu işlem önceki kayıtları silecek"
+
+#: id:12378
+msgid "Amount of time to display each image"
+msgstr "Her resim için görüntüleme zamanı miktarı"
+
+#: id:12379
+msgid "Use pan and zoom effects"
+msgstr "Kaydırma ve yakınlaştırma efekti kullan"
+
+#: id:12383
+msgid "12 hour clock"
+msgstr "12'li saat sistemi"
+
+#: id:12384
+msgid "24 hour clock"
+msgstr "24'lü saat sistemi"
+
+#: id:12385
+msgid "Day/Month"
+msgstr "Gün/Ay"
+
+#: id:12386
+msgid "Month/Day"
+msgstr "Ay/Gün"
+
+#: id:12390
+msgid "System uptime"
+msgstr "Sistemin çalışma süresi"
+
+#: id:12391
+msgid "Minutes"
+msgstr "Dakika"
+
+#: id:12392
+msgid "Hours"
+msgstr "Saat"
+
+#: id:12393
+msgid "Days"
+msgstr "Gün"
+
+#: id:12394
+msgid "Total uptime"
+msgstr "Toplam çalışma süresi"
+
+#: id:12395
+msgid "Battery level"
+msgstr "Pil düzeyi"
+
+#: id:12600
+msgctxt "Auto context with id 12600"
+msgid "Weather"
+msgstr "Hava Durumu"
+
+#: id:12900
+msgctxt "Auto context with id 12900"
+msgid "Screensaver"
+msgstr "Ekran Koruyucu"
+
+#: id:12901
+msgid "Fullscreen OSD"
+msgstr "Tam Ekran OSD"
+
+#: id:13000
+msgid "System"
+msgstr "Sistem"
+
+#: id:13001
+msgid "Immediate HD spindown"
+msgstr "Sabit diski yavaşlat"
+
+#: id:13002
+msgid "Video only"
+msgstr "Sadece Video"
+
+#: id:13003
+msgid "- Delay"
+msgstr "- Gecikme"
+
+#: id:13004
+msgid "- Minimum file duration"
+msgstr "- Minimum dosya süresi"
+
+#: id:13005
+msgid "Shutdown"
+msgstr "Kapat"
+
+#: id:13008
+msgid "Shutdown function"
+msgstr "Kapatma fonksiyonu"
+
+#: id:13009
+msgid "Quit"
+msgstr "Çık"
+
+#: id:13010
+msgid "Hibernate"
+msgstr "Hazırda Beklet"
+
+#: id:13011
+msgid "Suspend"
+msgstr "Askıya Al"
+
+#: id:13012
+msgid "Exit"
+msgstr "Çıkış"
+
+#: id:13013
+msgid "Reboot"
+msgstr "Yeniden Başlat"
+
+#: id:13014
+msgid "Minimize"
+msgstr "Simge Durumuna"
+
+#: id:13015
+msgid "Power button action"
+msgstr "Güç düğmesi eylemi"
+
+#: id:13016
+msgid "Power off System"
+msgstr "Sistemi Kapat"
+
+#: id:13020
+msgid "Is another session active, perhaps over ssh?"
+msgstr "Başka bir oturum mu etkin, ssh üzerinden olabilir mi?"
+
+#: id:13021
+msgid "Mounted removable harddrive"
+msgstr "Çıkarılabilir sabit disk bağlandı"
+
+#: id:13022
+msgid "Unsafe device removal"
+msgstr "Aygıt güvensiz bir şekilde kaldırıldı"
+
+#: id:13023
+msgid "Successfully removed device"
+msgstr "Aygıt başarıyla kaldırıldı"
+
+#: id:13024
+msgid "Joystick plugged"
+msgstr "Joystick takılı"
+
+#: id:13025
+msgid "Joystick unplugged"
+msgstr "Joystick takılı değil"
+
+#: id:13050
+msgid "Running low on battery"
+msgstr "Düşük pil ile çalışıyor"
+
+#: id:13100
+msgid "Flicker filter"
+msgstr "Titreme filtresi"
+
+#: id:13101
+msgid "Let driver choose (requires restart)"
+msgstr "Sürücü seçsin (yeniden başlatmak gerekir)"
+
+#: id:13105
+msgid "Vertical blank sync"
+msgstr "Dikey boşluk senkronizasyonu"
+
+#: id:13106
+msgctxt "Auto context with id 13106"
+msgid "Disabled"
+msgstr "Devre dışı"
+
+#: id:13107
+msgid "Enabled during video playback"
+msgstr "Video oynatılırken etkinleştir"
+
+#: id:13108
+msgctxt "Auto context with id 13108"
+msgid "Always enabled"
+msgstr "Her zaman etkin"
+
+#: id:13109
+msgid "Test & apply resolution"
+msgstr "Çözünürlüğü test et ve uygula"
+
+#: id:13110
+msgid "Save resolution?"
+msgstr "Çözünürlük kaydedilsin mi?"
+
+#: id:13111
+msgid "Would you like to keep this resolution?"
+msgstr "Bu çözünürlük ayarlarını saklamak ister misiniz?"
+
+#: id:13112
+msgid "High quality upscaling"
+msgstr "Yüksek kalite yazılım upscaling"
+
+#: id:13113
+msgctxt "Auto context with id 13113"
+msgid "Disabled"
+msgstr "Devre dışı"
+
+#: id:13114
+msgid "Enabled for SD content"
+msgstr "SD içeriği için etkinleştir"
+
+#: id:13115
+msgctxt "Auto context with id 13115"
+msgid "Always enabled"
+msgstr "Her zaman etkin"
+
+#: id:13116
+msgid "Upscaling method"
+msgstr "Upscaling yöntemi"
+
+#: id:13117
+msgctxt "Auto context with id 13117"
+msgid "Bicubic"
+msgstr "Bicubic"
+
+#: id:13118
+msgid "Lanczos"
+msgstr "Lanczos"
+
+#: id:13119
+msgid "Sinc"
+msgstr "Sinc"
+
+#: id:13120
+msgctxt "Auto context with id 13120"
+msgid "VDPAU"
+msgstr "VDPAU"
+
+#: id:13121
+msgid "VDPAU HQ Upscaling level"
+msgstr "VDPAU HQ Upscaling level"
+
+#: id:13122
+msgid "VDPAU Studio level color conversion"
+msgstr "VDPAU Studio level color conversion"
+
+#: id:13130
+msgid "Blank other displays"
+msgstr "Diğer görüntüleri temizle"
+
+#: id:13131
+msgctxt "Auto context with id 13131"
+msgid "Disabled"
+msgstr "Devre dışı"
+
+#: id:13132
+msgid "Blank displays"
+msgstr "Görüntüleri temizle"
+
+#: id:13140
+msgid "Active connections detected!"
+msgstr "Aktif bağlantılar saptandı!"
+
+#: id:13141
+msgid "If you proceed, you might not be able to control XBMC"
+msgstr "Devam ederseniz, XBMC'yi kontrol etmek mümkün olmayabilir."
+
+#: id:13142
+msgid "any longer. Are you sure you want to stop the Event server?"
+msgstr "Olay sunucusunu durdurmak istediğinize emin misiniz?"
+
+#: id:13144
+msgid "Change Apple Remote mode?"
+msgstr "Apple Kumanda modu değiştirilsin mi?"
+
+#: id:13145
+msgid "If you are currently using the Apple Remote to control"
+msgstr "XBMC'yi kontrol etmek için Apple Kumandayı kullanıyorsanız,"
+
+#: id:13146
+msgid "XBMC, changing this setting might affect your ability"
+msgstr "bu ayarı değiştirmek kontrol yeteneğini etkileyebilir."
+
+#: id:13147
+msgid "to continue controlling it. Do you want to proceed?"
+msgstr "Devam etmek istiyor musunuz?"
+
+#: id:13159
+msgid "Subnet mask"
+msgstr "Alt ağ maskesi"
+
+#: id:13160
+msgid "Gateway"
+msgstr "Ağ geçidi"
+
+#: id:13161
+msgid "Primary DNS"
+msgstr "Birincil DNS"
+
+#: id:13162
+msgid "Initialize failed"
+msgstr "Bilgi mevcut değil"
+
+#: id:13170
+msgctxt "Auto context with id 13170"
+msgid "Never"
+msgstr "Hiçbir zaman"
+
+#: id:13171
+msgid "Immediately"
+msgstr "Hemen"
+
+#: id:13172
+msgid "After %i secs"
+msgstr "%i saniye sonra"
+
+#: id:13173
+msgid "HDD install date:"
+msgstr "HDD yükleme tarihi:"
+
+#: id:13174
+msgid "HDD power cycle count:"
+msgstr "HDD güç döngüsü sayısı:"
+
+#: id:13200
+msgid "Profiles"
+msgstr "Profiller"
+
+#: id:13201
+msgid "Delete profile '%s'?"
+msgstr "'%s' profili silinsin mi?"
+
+#: id:13204
+msgid "Last loaded profile:"
+msgstr "En son yüklenen profil:"
+
+#: id:13205
+msgid "Unknown"
+msgstr "Bilinmiyor"
+
+#: id:13206
+msgid "Overwrite"
+msgstr "Üzerine yaz"
+
+#: id:13208
+msgid "Alarm clock"
+msgstr "Çalar saat"
+
+#: id:13209
+msgid "Alarm clock interval (in minutes)"
+msgstr "Çalar saat aralığı (dakika şeklinde)"
+
+#: id:13210
+msgid "Started, alarm in %im"
+msgstr "Alarm Aktif: %idk"
+
+#: id:13211
+msgid "Alarm!"
+msgstr "Alarm!"
+
+#: id:13212
+msgid "Canceled with %im%is left"
+msgstr "%idk:%isn kala iptal edildi"
+
+#: id:13213
+msgid "%2.0fm"
+msgstr "%2.0fm"
+
+#: id:13214
+msgid "%2.0fs"
+msgstr "%2.0fs"
+
+#: id:13249
+msgid "Search for subtitles in RARs"
+msgstr "Altyazıları sıkıştırılmış klasörlerde ara"
+
+#: id:13250
+msgid "Browse for subtitle..."
+msgstr "Altyazıya gözat..."
+
+#: id:13251
+msgid "Move item"
+msgstr "Taşı"
+
+#: id:13252
+msgid "Move item here"
+msgstr "Buraya taşı"
+
+#: id:13253
+msgid "Cancel move"
+msgstr "Taşımayı iptal et"
+
+#: id:13270
+msgid "Hardware:"
+msgstr "Donanım:"
+
+#: id:13271
+msgid "CPU Usage:"
+msgstr "CPU Kullanımı:"
+
+#: id:13274
+msgid "Connected, but no DNS is available."
+msgstr "Bağlı, fakat DNS yok."
+
+#: id:13275
+msgid "Hard Disk"
+msgstr "Sabit Disk"
+
+#: id:13276
+msgid "DVD-ROM"
+msgstr "DVD-ROM"
+
+#: id:13277
+msgctxt "Auto context with id 13277"
+msgid "Storage"
+msgstr "Kapasite"
+
+#: id:13278
+msgctxt "Auto context with id 13278"
+msgid "Default"
+msgstr "Varsayılan"
+
+#: id:13279
+msgctxt "Auto context with id 13279"
+msgid "Network"
+msgstr "Ağ Bağlantıları"
+
+#: id:13280
+msgctxt "Auto context with id 13280"
+msgid "Video"
+msgstr "Video"
+
+#: id:13281
+msgid "Hardware"
+msgstr "Donanım"
+
+#: id:13283
+msgid "Operating system:"
+msgstr "İşletim sistemi:"
+
+#: id:13284
+msgid "CPU speed:"
+msgstr "CPU hızı:"
+
+#: id:13286
+msgid "Video encoder:"
+msgstr "Video kodlayıcı:"
+
+#: id:13287
+msgid "Screen resolution:"
+msgstr "Ekran çözünülürlüğü:"
+
+#: id:13292
+msgid "A/V cable:"
+msgstr "Görüntü/Ses kablosu:"
+
+#: id:13294
+msgid "DVD region:"
+msgstr "DVD bölgesi:"
+
+#: id:13295
+msgid "Internet:"
+msgstr "İnternet:"
+
+#: id:13296
+msgctxt "Auto context with id 13296"
+msgid "Connected"
+msgstr "Bağlı"
+
+#: id:13297
+msgid "Not connected. Check network settings."
+msgstr "Bağlı değil. Ağ ayarlarınızı kontrol edin."
+
+#: id:13299
+msgid "Target temperature"
+msgstr "Hedef sıcaklık"
+
+#: id:13300
+msgid "Fan speed"
+msgstr "Fan hızı"
+
+#: id:13301
+msgid "Auto temperature control"
+msgstr "Otomatik ısı kontrolü"
+
+#: id:13302
+msgid "Fan speed override"
+msgstr "Fan hızı ayarı"
+
+#: id:13303
+msgid "- Fonts"
+msgstr "- Yazı tipleri"
+
+#: id:13304
+msgid "Enable flipping bi-directional strings"
+msgstr "Enable flipping bi-directional strings"
+
+#: id:13305
+msgid "Show RSS news feeds"
+msgstr "RSS haber akışlarını göster"
+
+#: id:13306
+msgid "Show parent folder items"
+msgstr "Geri gitme simgesini göster"
+
+#: id:13307
+msgid "Track naming template"
+msgstr "Parça isim kalıbı"
+
+#: id:13308
+msgid "Do you wish to reboot your system"
+msgstr "XBMC'yi yeniden başlatmak yerine sistemi"
+
+#: id:13309
+msgid "instead of just XBMC?"
+msgstr "yeniden başlatmak ister misiniz?"
+
+#: id:13310
+msgid "Zoom effect"
+msgstr "Yakınlaştırma efekti"
+
+#: id:13311
+msgid "Float effect"
+msgstr "Kaydırma efekti"
+
+#: id:13312
+msgid "Black bar reduction"
+msgstr "Siyah yerleri daralt"
+
+#: id:13313
+msgid "Restart"
+msgstr "Yeniden Başlat"
+
+#: id:13314
+msgid "Crossfade between songs"
+msgstr "Şarkılar arasında sesi azaltarak geçiş yap"
+
+#: id:13315
+msgid "Regenerate thumbnails"
+msgstr "Küçük resimleri yeniden oluştur"
+
+#: id:13316
+msgid "Recursive thumbnails"
+msgstr "Yinelemeli küçük resimler"
+
+#: id:13317
+msgid "View slideshow"
+msgstr "Slayt Gösterisi"
+
+#: id:13318
+msgid "Recursive slideshow"
+msgstr "Yinelemeli slayt gösterisi"
+
+#: id:13319
+msgid "Randomize"
+msgstr "Rastgele"
+
+#: id:13320
+msgid "Stereo"
+msgstr "Stereo"
+
+#: id:13321
+msgid "Left only"
+msgstr "Sadece sol"
+
+#: id:13322
+msgid "Right only"
+msgstr "Sadece sağ"
+
+#: id:13323
+msgid "Enable karaoke support"
+msgstr "Karaoke desteğini etkinleştir"
+
+#: id:13324
+msgid "Background transparency"
+msgstr "Arka plan şeffaflığı"
+
+#: id:13325
+msgid "Foreground transparency"
+msgstr "Ön plan şeffaflığı"
+
+#: id:13326
+msgid "A/V delay"
+msgstr "Ses/Video gecikmesi"
+
+#: id:13327
+msgid "Karaoke"
+msgstr "Karaoke"
+
+#: id:13328
+msgid "%s not found"
+msgstr "%s bulunamadı"
+
+#: id:13329
+msgid "Error opening %s"
+msgstr "%s açılamıyor"
+
+#: id:13330
+msgid "Unable to load %s"
+msgstr "%s yüklenemiyor"
+
+#: id:13331
+msgid "Error: Out of memory"
+msgstr "Hata: Bellek yetersiz"
+
+#: id:13332
+msgid "Move up"
+msgstr "Yukarı taşı"
+
+#: id:13333
+msgid "Move down"
+msgstr "Aşağı taşı"
+
+#: id:13334
+msgid "Edit label"
+msgstr "Etiketi düzenle"
+
+#: id:13335
+msgid "Make default"
+msgstr "Varsayılan yap"
+
+#: id:13336
+msgid "Remove button"
+msgstr "Tuşu kaldır"
+
+#: id:13340
+msgid "Leave as is"
+msgstr "Serbest bırak"
+
+#: id:13341
+msgid "Green"
+msgstr "Yeşil"
+
+#: id:13342
+msgid "Orange"
+msgstr "Turuncu"
+
+#: id:13343
+msgid "Red"
+msgstr "Kırmızı"
+
+#: id:13344
+msgid "Cycle"
+msgstr "Karışık"
+
+#: id:13345
+msgid "Switch LED off on playback"
+msgstr "Ortam oynatırken LED' i kapat"
+
+#: id:13346
+msgctxt "Auto context with id 13346"
+msgid "Movie information"
+msgstr "Film bilgisi"
+
+#: id:13347
+msgid "Queue item"
+msgstr "Kuyruğa ekle"
+
+#: id:13348
+msgid "Search IMDb..."
+msgstr "IMDb'de ara..."
+
+#: id:13349
+msgid "Scan for new content"
+msgstr "Yeni içerik için tara"
+
+#: id:13350
+msgid "Now playing..."
+msgstr "Şimdi çalıyor..."
+
+#: id:13351
+msgctxt "Auto context with id 13351"
+msgid "Album information"
+msgstr "Albüm bilgisi"
+
+#: id:13352
+msgid "Scan item to library"
+msgstr "Ögeleri kitaplık için tara"
+
+#: id:13353
+msgid "Stop scanning"
+msgstr "Taramayı durdur"
+
+#: id:13354
+msgctxt "Auto context with id 13354"
+msgid "Render method"
+msgstr "İşleyici yöntemi"
+
+#: id:13355
+msgid "Low quality pixel shader"
+msgstr "Düşük kalite piksel gölgeleme"
+
+#: id:13356
+msgid "Hardware overlays"
+msgstr "Donanımsal olarak"
+
+#: id:13357
+msgid "High quality pixel shader"
+msgstr "Yüksek kalite piksel gölgeleme"
+
+#: id:13358
+msgid "Play item"
+msgstr "Oynat"
+
+#: id:13359
+msgid "Set artist thumb"
+msgstr "Sanatçı küçük resmini ayarla"
+
+#: id:13360
+msgid "Automatically generate thumbnails"
+msgstr "Küçük resimleri otomatik olarak oluştur"
+
+#: id:13361
+msgid "Enable voice"
+msgstr "Sesi etkinleştir"
+
+#: id:13375
+msgid "Enable device"
+msgstr "Donanımı etkinleştir"
+
+#: id:13376
+msgid "Volume"
+msgstr "Ses Şiddeti"
+
+#: id:13377
+msgid "Default view mode"
+msgstr "Varsayılan görünüm modu"
+
+#: id:13378
+msgid "Default brightness"
+msgstr "Varsayılan parlaklık"
+
+#: id:13379
+msgid "Default contrast"
+msgstr "Varsayılan kontrast"
+
+#: id:13380
+msgid "Default gamma"
+msgstr "Varsayılan gamma"
+
+#: id:13381
+msgid "Resume video"
+msgstr "Videoyu devam ettir"
+
+#: id:13382
+msgid "Voice mask - Port 1"
+msgstr "Ses maskesi - Port 1"
+
+#: id:13383
+msgid "Voice mask - Port 2"
+msgstr "Ses maskesi - Port 2"
+
+#: id:13384
+msgid "Voice mask - Port 3"
+msgstr "Ses maskesi - Port 3"
+
+#: id:13385
+msgid "Voice mask - Port 4"
+msgstr "Ses maskesi - Port 4"
+
+#: id:13386
+msgid "Use time based seeking"
+msgstr "Zamana göre ara"
+
+#: id:13387
+msgid "Track naming template - right"
+msgstr "Parça isim kalıbı - sağ"
+
+#: id:13388
+msgid "Preset"
+msgstr "Önayar"
+
+#: id:13389
+msgid "There are no presets available\nfor this visualization"
+msgstr "Bu görsel öğenin kullanılabilir önayarları yok"
+
+#: id:13390
+msgid "There are no settings available\nfor this visualization"
+msgstr "Bu görsel öğenin kullanılabilir ayarları yok"
+
+#: id:13391
+msgid "Eject/Load"
+msgstr "Çıkart/Tak"
+
+#: id:13392
+msgid "Use visualization if playing audio"
+msgstr "Eğer müzik çalıyorsa görsel öğe kullan"
+
+#: id:13393
+msgid "Calculate size"
+msgstr "Boyutu hesapla"
+
+#: id:13394
+msgid "Calculating folder size"
+msgstr "Dosya boyutu hesaplanıyor"
+
+#: id:13395
+msgid "Video settings"
+msgstr "Video ayarları"
+
+#: id:13396
+msgid "Audio and subtitle settings"
+msgstr "Ses ve altyazı ayarları"
+
+#: id:13397
+msgid "Enable subtitles"
+msgstr "Altyazıları etkinleştir"
+
+#: id:13398
+msgctxt "Auto context with id 13398"
+msgid "Shortcuts"
+msgstr "Kısayollar"
+
+#: id:13399
+msgid "Ignore articles when sorting (e.g. \"the\")"
+msgstr "Sıralarken tanımlık ekleri yoksay (\"the\" vb.)"
+
+#: id:13400
+msgid "Crossfade between songs on the same album"
+msgstr "Aynı albümdeki parçalar arasında sesi azaltarak geçiş yap"
+
+#: id:13401
+msgid "Browse for %s"
+msgstr "%s gözat"
+
+#: id:13402
+msgid "Show track position"
+msgstr "Şarkı pozisyonunu göster"
+
+#: id:13403
+msgid "Clear default"
+msgstr "Varsayılanı temizle"
+
+#: id:13404
+msgid "Resume"
+msgstr "Devam Et"
+
+#: id:13405
+msgid "Get thumb"
+msgstr "Küçük resim al"
+
+#: id:13406
+msgid "Picture information"
+msgstr "Resim bilgisi"
+
+#: id:13407
+msgid "%s presets"
+msgstr "%s önayarları"
+
+#: id:13408
+msgid "(IMDb user rating)"
+msgstr "(IMDb kullanıcı derecelendirmesi)"
+
+#: id:13409
+msgid "Top 250"
+msgstr "En İyi 250"
+
+#: id:13410
+msgid "Tune in on Last.fm"
+msgstr "Last.fm'de bul"
+
+#: id:13411
+msgid "Minimum fan speed"
+msgstr "Asgari fan hızı"
+
+#: id:13412
+msgid "Play from here"
+msgstr "Buradan oynat"
+
+#: id:13413
+msgid "Downloading"
+msgstr "Karşıdan yükleniyor"
+
+#: id:13414
+msgid "Include artists who appear only on compilations"
+msgstr "Sadece derlemelerde görünen sanatçıları dahil et"
+
+#: id:13415
+msgctxt "Auto context with id 13415"
+msgid "Render method"
+msgstr "İzleyici yöntemi"
+
+#: id:13416
+msgid "Auto detect"
+msgstr "Otomatik algıla"
+
+#: id:13417
+msgid "Basic shaders (ARB)"
+msgstr "Basit gölgeleme (ARB)"
+
+#: id:13418
+msgid "Advanced shaders (GLSL)"
+msgstr "Gelişmiş gölgeleme (GLSL)"
+
+#: id:13419
+msgid "Software"
+msgstr "Yazılım"
+
+#: id:13420
+msgid "Remove safely"
+msgstr "Güvenli kaldır"
+
+#: id:13421
+msgctxt "Auto context with id 13421"
+msgid "VDPAU"
+msgstr "VDPAU"
+
+#: id:13422
+msgid "Start slideshow here"
+msgstr "Slayt gösterisine buradan başla"
+
+#: id:13423
+msgid "Remember for this path"
+msgstr "Bu yolu hatırla"
+
+#: id:13424
+msgid "Use pixel buffer objects"
+msgstr "Piksel tampon nesnelerini kullan"
+
+#: id:13425
+msgid "Allow hardware acceleration (VDPAU)"
+msgstr "Donanım hızlandırmasına izin ver (VDPAU)"
+
+#: id:13426
+msgid "Allow hardware acceleration (VAAPI)"
+msgstr "Donanım hızlandırmasına izin ver (VAAPI)"
+
+#: id:13427
+msgid "Allow hardware acceleration (DXVA2)"
+msgstr "Donanım hızlandırmasına izin ver (DXVA2)"
+
+#: id:13428
+msgid "Allow hardware acceleration (CrystalHD)"
+msgstr "Donanım hızlandırmasına izin ver (CrystalHD)"
+
+#: id:13429
+msgid "Allow hardware acceleration (VDADecoder)"
+msgstr "Donanım hızlandırmasına izin ver (VDADecoder)"
+
+#: id:13430
+msgid "Allow hardware acceleration (OpenMax)"
+msgstr "Donanım hızlandırmasına izin ver (OpenMax)"
+
+#: id:13431
+msgid "Pixel Shaders"
+msgstr "Piksel Gölgelendiriciler"
+
+#: id:13432
+msgid "Allow hardware acceleration (VideoToolbox)"
+msgstr "Donanım hızlandırmasına izin ver (VideoToolbox)"
+
+#: id:13500
+msgid "A/V sync method"
+msgstr "Ses/Video senkron biçimi"
+
+#: id:13501
+msgid "Audio clock"
+msgstr "Ses saati"
+
+#: id:13502
+msgid "Video clock (Drop/Dupe audio)"
+msgstr "Video saati (Drop/Dupe audio)"
+
+#: id:13503
+msgid "Video clock (Resample audio)"
+msgstr "Video saati (yeniden ses örnekleme)"
+
+#: id:13504
+msgid "Maximum resample amount (%)"
+msgstr "Azami yeniden örnekleme miktarı (%)"
+
+#: id:13505
+msgid "Resample quality"
+msgstr "Yeniden örnekleme kalitesi"
+
+#: id:13506
+msgid "Low(fast)"
+msgstr "Düşük(hızlı)"
+
+#: id:13507
+msgctxt "Auto context with id 13507"
+msgid "Medium"
+msgstr "Orta"
+
+#: id:13508
+msgctxt "Auto context with id 13508"
+msgid "High"
+msgstr "Yüksek"
+
+#: id:13509
+msgid "Really high(slow!)"
+msgstr "Gerçekten yüksek(yavaş!)"
+
+#: id:13510
+msgid "Sync playback to display"
+msgstr "Oynatımı görüntüye senkronla"
+
+#: id:13550
+msgid "Pause during refresh rate change"
+msgstr "Yenileme hızını değiştirirken duraklat"
+
+#: id:13551
+msgctxt "Auto context with id 13551"
+msgid "Off"
+msgstr "Kapalı"
+
+#: id:13552
+msgid "%.1f Second"
+msgstr "%.1f Saniye"
+
+#: id:13553
+msgid "%.1f Seconds"
+msgstr "%.1f Saniye"
+
+#: id:13600
+msgid "Apple remote"
+msgstr "Apple kumanda"
+
+#: id:13602
+msgid "Allow start of XBMC using the remote"
+msgstr "XBMC'nin kumandayı kullanarak başlamasına izin ver"
+
+#: id:13603
+msgid "Sequence delay time"
+msgstr "Sekans gecikme süresi"
+
+#: id:13610
+msgctxt "Auto context with id 13610"
+msgid "Disabled"
+msgstr "Devre dışı"
+
+#: id:13611
+msgctxt "Auto context with id 13611"
+msgid "Standard"
+msgstr "Standart"
+
+#: id:13612
+msgid "Universal Remote"
+msgstr "Evrensel Kumanda"
+
+#: id:13613
+msgid "Multi Remote (Harmony)"
+msgstr "Çoklu Kumanda (Harmony)"
+
+#: id:13620
+msgid "Apple Remote Error"
+msgstr "Apple Kumanda Hatası"
+
+#: id:13621
+msgid "Apple Remote support could be enabled."
+msgstr "Apple Kumanda desteği etkinleştirilebilir."
+
+#: id:14000
+msgid "Stack"
+msgstr "Yığın"
+
+#: id:14001
+msgid "Unstack"
+msgstr "Yığını kaldır"
+
+#: id:14003
+msgid "Downloading playlist file..."
+msgstr "Çalma listesi karşıdan yükleniyor..."
+
+#: id:14004
+msgid "Downloading streams list..."
+msgstr "Akış listeleri karşıdan yükleniyor..."
+
+#: id:14005
+msgid "Parsing streams list..."
+msgstr "Akış listeleri alınıyor..."
+
+#: id:14006
+msgid "Downloading streams list failed"
+msgstr "Akış listesi karşıdan yüklenirken hata oluştu"
+
+#: id:14007
+msgid "Downloading playlist file failed"
+msgstr "Çalma listesi karşıdan yüklenirken hata oluştu"
+
+#: id:14009
+msgid "Games directory"
+msgstr "Oyun dizini"
+
+#: id:14010
+msgid "Auto switch to thumbs based on"
+msgstr "Orijinal küçük resimleri göster"
+
+#: id:14011
+msgid "Enable auto switching to thumbs view"
+msgstr "Küçük resim görünümüne otomatik değiştirmeyi etkinleştir"
+
+#: id:14012
+msgid "- Use large icons"
+msgstr "- Büyük simgeler"
+
+#: id:14013
+msgid "- Switch based on"
+msgstr "- Orijinal boyut"
+
+#: id:14014
+msgid "- Percentage"
+msgstr "- Oran"
+
+#: id:14015
+msgid "No files and at least one thumb"
+msgstr "Dosya yok ve en az bir Küçük resim"
+
+#: id:14016
+msgid "At least one file and thumb"
+msgstr "En az bir dosya ve küçük resim"
+
+#: id:14017
+msgid "Percentage of thumbs"
+msgstr "Küçük resimlerin boyutu"
+
+#: id:14018
+msgid "View options"
+msgstr "Görünüm seçenekleri"
+
+#: id:14019
+msgid "Change area code 1"
+msgstr "1. bölge kodunu değiştir"
+
+#: id:14020
+msgid "Change area code 2"
+msgstr "2. bölge kodunu değiştir"
+
+#: id:14021
+msgid "Change area code 3"
+msgstr "3. bölge kodunu değiştir"
+
+#: id:14022
+msgctxt "Auto context with id 14022"
+msgid "Library"
+msgstr "Kitaplık"
+
+#: id:14023
+msgid "No TV"
+msgstr "TV Yok"
+
+#: id:14024
+msgid "Enter the nearest large town"
+msgstr "En yakındaki büyük şehrin ismini veya bölge kodunu girin"
+
+#: id:14025
+msgid "Video/Audio/DVD cache - Harddisk"
+msgstr "Video/Ses/DVD önbelleği - Sabit disk"
+
+#: id:14026
+msgid "Video cache - DVD-ROM"
+msgstr "Video önbelleği - DVD-ROM"
+
+#: id:14027
+msgctxt "Auto context with id 14027"
+msgid "- Local Network"
+msgstr "- Yerel Ağ"
+
+#: id:14028
+msgctxt "Auto context with id 14028"
+msgid "- Internet"
+msgstr "- İnternet"
+
+#: id:14030
+msgid "Audio cache - DVD-ROM"
+msgstr "Ses önbelleği - DVD-ROM"
+
+#: id:14031
+msgctxt "Auto context with id 14031"
+msgid "- Local Network"
+msgstr "- Yerel Ağ"
+
+#: id:14032
+msgctxt "Auto context with id 14032"
+msgid "- Internet"
+msgstr "- İnternet"
+
+#: id:14034
+msgid "DVD cache - DVD-ROM"
+msgstr "DVD önbelleği - DVD-ROM"
+
+#: id:14035
+msgctxt "Auto context with id 14035"
+msgid "- Local Network"
+msgstr "- Yerel Ağ"
+
+#: id:14036
+msgctxt "Auto context with id 14036"
+msgid "Services"
+msgstr "Hizmetler"
+
+#: id:14038
+msgid "Network settings changed"
+msgstr "Ağ ayarları değişti"
+
+#: id:14039
+msgid "XBMC requires to restart to change your"
+msgstr "Ayarların etkili olabilmesi için yeniden başlatmak gerekli."
+
+#: id:14040
+msgid "network setup. Would you like to restart now?"
+msgstr "XBMC'yi yeniden başlatmak istiyor musunuz?"
+
+#: id:14041
+msgid "Internet connection bandwidth limitation"
+msgstr "İnternet bağlantısı bant genişliği sınırlaması"
+
+#: id:14043
+msgid "- Shutdown while playing"
+msgstr "- Ortam oynatılıyor olsa bile kapat"
+
+#: id:14044
+msgid "%i min"
+msgstr "%i dk"
+
+#: id:14045
+msgid "%i sec"
+msgstr "%i sn"
+
+#: id:14046
+msgid "%i ms"
+msgstr "%i ms"
+
+#: id:14047
+msgid "%i %%"
+msgstr "%i %%"
+
+#: id:14048
+msgid "%i kbps"
+msgstr "%i kbps"
+
+#: id:14049
+msgid "%i kb"
+msgstr "%i kb"
+
+#: id:14050
+msgid "%i.0 dB"
+msgstr "%i.0 dB"
+
+#: id:14051
+msgid "Time format"
+msgstr "Saat biçimi"
+
+#: id:14052
+msgid "Date format"
+msgstr "Tarih biçimi"
+
+#: id:14053
+msgid "GUI filters"
+msgstr "Arayüz filtreleri"
+
+#: id:14055
+msgid "Use background scanning"
+msgstr "Arka plan taramasını kullan"
+
+#: id:14056
+msgid "Stop scan"
+msgstr "Taramayı durdur"
+
+#: id:14057
+msgid "Not possible while scanning for media info"
+msgstr "Tarama yaparken ortam bilgisine ulaşılamaz"
+
+#: id:14058
+msgid "Film grain effect"
+msgstr "Film toz efekti"
+
+#: id:14059
+msgid "Search for thumbnails on remote shares"
+msgstr "Küçük resimleri uzak bağlantılarda ara"
+
+#: id:14060
+msgid "Unknown type cache - Internet"
+msgstr "Bilinmeyen dosya türü önbelleği - İnternet"
+
+#: id:14061
+msgctxt "Auto context with id 14061"
+msgid "Auto"
+msgstr "Otomatik"
+
+#: id:14062
+msgid "Enter username for"
+msgstr "Kullanıcı adı girin"
+
+#: id:14063
+msgid "Date & time"
+msgstr "Tarih ve saat"
+
+#: id:14064
+msgid "Set date"
+msgstr "Tarihi ayarla"
+
+#: id:14065
+msgid "Set time"
+msgstr "Saati ayarla"
+
+#: id:14066
+msgid "Enter the time in 24 hour HH:MM format"
+msgstr "Saati 24'lük formatta SS:DD olarak girin"
+
+#: id:14067
+msgid "Enter the date in DD/MM/YYYY format"
+msgstr "Tarihi GG/AA/YYYY olarak girin"
+
+#: id:14068
+msgid "Enter the IP address"
+msgstr "IP adresini girin"
+
+#: id:14069
+msgid "Apply these settings now?"
+msgstr "Bu ayarlar şimdi uygulansın mı?"
+
+#: id:14070
+msgid "Apply changes now"
+msgstr "Değişiklikleri şimdi uygula"
+
+#: id:14071
+msgid "Allow file renaming and deletion"
+msgstr "Dosyaları silmeye ve yeniden adlandırmaya izin ver"
+
+#: id:14074
+msgid "Set timezone"
+msgstr "Saat dilimini ayarla"
+
+#: id:14075
+msgid "Use daylight saving time"
+msgstr "Yaz saati uygulamasını kullan"
+
+#: id:14076
+msgid "Add to favourites"
+msgstr "Sık kullanılanlara ekle"
+
+#: id:14077
+msgid "Remove from favourites"
+msgstr "Sık kullanılanlardan kaldır"
+
+#: id:14078
+msgctxt "Auto context with id 14078"
+msgid "- Colours"
+msgstr "- Renkler"
+
+#: id:14079
+msgid "Timezone country"
+msgstr "Ülke zaman dilimi"
+
+#: id:14080
+msgid "Timezone"
+msgstr "Zaman dilimi"
+
+#: id:14081
+msgid "File lists"
+msgstr "Dosya listesi"
+
+#: id:14082
+msgid "Show EXIF picture information"
+msgstr "EXIF resim bilgilerini göster"
+
+#: id:14083
+msgid "Use a fullscreen window rather than true fullscreen"
+msgstr "Gerçek tam ekran yerine tam ekran penceresini kullan"
+
+#: id:14084
+msgid "Queue songs on selection"
+msgstr "Seçilen şarkıları kuyruğa ekle"
+
+#: id:14086
+msgid "Playback"
+msgstr "Oynatım"
+
+#: id:14087
+msgid "DVDs"
+msgstr "DVD'ler"
+
+#: id:14088
+msgid "Play DVDs automatically"
+msgstr "DVD'leri otomatik olarak oynat"
+
+#: id:14089
+msgid "Font to use for text subtitles"
+msgstr "Altyazı metni için kullanılacak yazı tipi"
+
+#: id:14090
+msgid "International"
+msgstr "Uluslararası"
+
+#: id:14091
+msgid "Character set"
+msgstr "Karakter kodlaması"
+
+#: id:14092
+msgid "Debugging"
+msgstr "Hata ayıklama"
+
+#: id:14093
+msgid "Security"
+msgstr "Güvenlik"
+
+#: id:14094
+msgid "Input devices"
+msgstr "Giriş aygıtları"
+
+#: id:14095
+msgid "Power saving"
+msgstr "Güç tasarrufu"
+
+#: id:14096
+msgid "Rip"
+msgstr "Kopyala"
+
+#: id:14097
+msgid "Audio CD Insert Action"
+msgstr "Ses CD'si Takılınca Yapılacak Eylem"
+
+#: id:14098
+msgctxt "Auto context with id 14098"
+msgid "Play"
+msgstr "Çal"
+
+#: id:14099
+msgid "Eject disc when CD ripping is complete"
+msgstr "CD kopyalama işlemi bitince diski çıkar"
+
+#: id:15015
+msgctxt "Auto context with id 15015"
+msgid "Remove"
+msgstr "Kaldır"
+
+#: id:15016
+msgid "Games"
+msgstr "Oyunlar"
+
+#: id:15019
+msgid "Add"
+msgstr "Ekle"
+
+#: id:15052
+msgid "Password"
+msgstr "Parola"
+
+#: id:15100
+msgctxt "Auto context with id 15100"
+msgid "Library"
+msgstr "Kitaplık"
+
+#: id:15101
+msgid "Database"
+msgstr "Veritabanı"
+
+#: id:15102
+msgid "* All albums"
+msgstr "* Bütün albümler"
+
+#: id:15103
+msgid "* All artists"
+msgstr "* Bütün sanatçılar"
+
+#: id:15104
+msgid "* All songs"
+msgstr "* Bütün şarkılar"
+
+#: id:15105
+msgid "* All genres"
+msgstr "* Bütün tarzlar"
+
+#: id:15107
+msgid "Buffering..."
+msgstr "Arabelleğe alınıyor..."
+
+#: id:15108
+msgid "Navigation sounds"
+msgstr "Menü sesleri"
+
+#: id:15109
+msgid "Skin default"
+msgstr "Dış görünüm varsayılanı"
+
+#: id:15111
+msgid "- Theme"
+msgstr "- Tema"
+
+#: id:15112
+msgid "Default theme"
+msgstr "Varsayılan tema"
+
+#: id:15200
+msgid "Last.fm"
+msgstr "Last.fm"
+
+#: id:15201
+msgid "Submit songs to Last.fm"
+msgstr "Şarkıları Last.fm'e gönder"
+
+#: id:15202
+msgid "Last.fm username"
+msgstr "Last.fm kullanıcı adı"
+
+#: id:15203
+msgid "Last.fm password"
+msgstr "Last.fm parolası"
+
+#: id:15204
+msgid "Unable to handshake: sleeping..."
+msgstr "Bağlanamıyor: uyku moduna alınıyor..."
+
+#: id:15205
+msgid "Please update XBMC"
+msgstr "Lütfen XBMC'yi güncelleyin"
+
+#: id:15206
+msgid "Bad authorization: Check username and password"
+msgstr "Yetkiniz yok: Kullanıcı adını ve parolayı kontrol ediniz"
+
+#: id:15207
+msgctxt "Auto context with id 15207"
+msgid "Connected"
+msgstr "Bağlandı"
+
+#: id:15208
+msgid "Not connected"
+msgstr "Bağlanamadı"
+
+#: id:15209
+msgid "Submit interval %i"
+msgstr "Gönderme zamanı %i"
+
+#: id:15210
+msgid "Cached %i songs"
+msgstr "%i şarkı önbellekte"
+
+#: id:15211
+msgid "Submitting..."
+msgstr "Gönderiyor..."
+
+#: id:15212
+msgid "Submitting in %i secs"
+msgstr "%i sn. dir gönderiyor"
+
+#: id:15213
+msgid "Play using..."
+msgstr "...Kullanarak oynat"
+
+#: id:15214
+msgid "Use smoothed A/V synchronization"
+msgstr "Düzgün Ses/Video senkronizasyonunu kullan"
+
+#: id:15215
+msgid "Hide file names in thumbs view"
+msgstr "Küçük resim görünümünde dosya isimlerini sakla"
+
+#: id:15216
+msgid "Play in party mode"
+msgstr "Parti modunda çal"
+
+#: id:15217
+msgid "Submit songs to Libre.fm"
+msgstr "Şarkıları Libre.fm'e gönder"
+
+#: id:15218
+msgid "Libre.fm username"
+msgstr "Libre.fm kullanıcı adı"
+
+#: id:15219
+msgid "Libre.fm password"
+msgstr "Libre.fm parolası"
+
+#: id:15220
+msgid "Libre.fm"
+msgstr "Libre.fm"
+
+#: id:15221
+msgid "Song submission"
+msgstr "Şarkı sunumu"
+
+#: id:15250
+msgid "Submit Last.fm radio to Last.fm"
+msgstr "Last.fm radyoyu Last.fm'e gönder"
+
+#: id:15251
+msgid "Connecting to Last.fm..."
+msgstr "Last.fm'e bağlanılıyor..."
+
+#: id:15252
+msgid "Selecting station..."
+msgstr "İstasyon seçiliyor..."
+
+#: id:15253
+msgid "Search similar artists..."
+msgstr "Benzer sanatçıları ara..."
+
+#: id:15254
+msgid "Search similar tags..."
+msgstr "Benzer etiketleri ara..."
+
+#: id:15255
+msgid "Your profile (%name%)"
+msgstr "Profiliniz (%name%)"
+
+#: id:15256
+msgid "Overall top tags"
+msgstr "En popüler etiketler"
+
+#: id:15257
+msgid "Top artists for tag %name%"
+msgstr "%name% adlı kullanıcı için en iyi sanatçı"
+
+#: id:15258
+msgid "Top albums for tag %name%"
+msgstr "%name% adlı kullanıcı için en iyi albüm"
+
+#: id:15259
+msgid "Top tracks for tag %name%"
+msgstr "%name% adlı kullanıcı için en iyi parça"
+
+#: id:15260
+msgid "Listen to tag %name% Last.fm radio"
+msgstr "%name% etiketini Last.fm radyosunda dinle"
+
+#: id:15261
+msgid "Similar artists as %name%"
+msgstr "%name% adındaki benzer sanatçılar"
+
+#: id:15262
+msgid "Top %name% albums"
+msgstr "En İyi %name% albümleri"
+
+#: id:15263
+msgid "Top %name% tracks"
+msgstr "En İyi %name% parçaları"
+
+#: id:15264
+msgid "Top %name% tags"
+msgstr "En İyi %name% başlıkları"
+
+#: id:15265
+msgid "Biggest fans of %name%"
+msgstr "%name% sevenler"
+
+#: id:15266
+msgid "Listen to %name% fans Last.fm radio"
+msgstr "%name% sevenleri Last.fm radyo ile dinle"
+
+#: id:15267
+msgid "Listen to %name% similar artists Last.fm radio"
+msgstr "%name% ve benzer sanatçıları Last.fm radyo ile dinle"
+
+#: id:15268
+msgid "Top artists for user %name%"
+msgstr "%name% için en iyi sanatçılar"
+
+#: id:15269
+msgid "Top albums for user %name%"
+msgstr "%name% için en iyi albümler"
+
+#: id:15270
+msgid "Top tracks for user %name%"
+msgstr "%name% için en iyi parçalar"
+
+#: id:15271
+msgid "Friends of user %name%"
+msgstr "%name% adlı kullanıcının arkadaşları"
+
+#: id:15272
+msgid "Neighbours of user %name%"
+msgstr "%name% adlı kullanıcının komşuları"
+
+#: id:15273
+msgid "Weekly artist chart for %name%"
+msgstr "%name% için haftalık sanatçı çizelgesi"
+
+#: id:15274
+msgid "Weekly album chart for %name%"
+msgstr "%name% için hartalık albüm çizelgesi"
+
+#: id:15275
+msgid "Weekly track chart for %name%"
+msgstr "%name% için haftalık parça çizelgesi"
+
+#: id:15276
+msgid "Listen to %name%'s neighbours Last.fm radio"
+msgstr "%name% adlı kullanıcının komşularını Last.fm radyosunda dinle"
+
+#: id:15277
+msgid "Listen to %name%'s personal Last.fm radio"
+msgstr "%name% adlı kullanıcının kişisel Last.fm radyosunu dinle"
+
+#: id:15278
+msgid "Listen to %name%'s mix Last.fm radio"
+msgstr "%name% adlı kullanıcının mix Last.fm radyosunu dinle"
+
+#: id:15279
+msgid "Retrieving list from Last.fm..."
+msgstr "Last.fm' den liste alınıyor..."
+
+#: id:15280
+msgid "Can't retrieve list from Last.fm..."
+msgstr "Last.fm' den alınamıyor..."
+
+#: id:15281
+msgid "Enter an artist name to find related ones"
+msgstr "Çıkmış albümlerimi bulmak için bir sanatçı adı girin"
+
+#: id:15282
+msgid "Enter a tag name to find similar ones"
+msgstr "Benzerlerini bulmak için bir isim girin"
+
+#: id:15283
+msgid "Tracks recently listened by %name%"
+msgstr "%name% tarafından dinlenen parçalar"
+
+#: id:15284
+msgid "Listen to %name%'s recommendations Last.fm radio"
+msgstr "%name% adlı kullanıcının önerdiklerini Last.fm radyosunda dinle"
+
+#: id:15285
+msgid "Top tags for user %name%"
+msgstr "%name% için en iyi etiketler"
+
+#: id:15287
+msgid "Do you want to add the current track to your loved tracks?"
+msgstr "Geçerli parçayı sevilen parçalara eklemek ister misiniz?"
+
+#: id:15288
+msgid "Do you want to ban the current track?"
+msgstr "Geçerli parçayı engellemek ister misiniz?"
+
+#: id:15289
+msgid "Added to your loved tracks: '%s'."
+msgstr "Sevilen parçalara eklendi: '%s'."
+
+#: id:15290
+msgid "Could not add '%s' to your loved tracks."
+msgstr "'%s' sevilen parçalara eklenemedi."
+
+#: id:15291
+msgid "Banned: '%s'."
+msgstr "Yasaklı: '%s'."
+
+#: id:15292
+msgid "Could not ban '%s'."
+msgstr "'%s' yasaklanamaz."
+
+#: id:15293
+msgid "Tracks recently loved by %name%"
+msgstr "%name% adlı kullanıcının sevdiği parçalar"
+
+#: id:15294
+msgid "Tracks recently banned by %name%"
+msgstr "%name% adlı kullanıcının engellediği parçalar"
+
+#: id:15295
+msgid "Remove from loved tracks"
+msgstr "Sevilen parçalardan kaldır"
+
+#: id:15296
+msgid "Un-ban"
+msgstr "Yasaksız"
+
+#: id:15297
+msgid "Do you want to remove this track from your loved tracks?"
+msgstr "Bu parçayı sevilen parçalardan kaldırmak istiyor musunuz?"
+
+#: id:15298
+msgid "Do you want to un-ban this track?"
+msgstr "Bu parçanın yasağını kaldırmak istiyor musunuz?"
+
+#: id:15300
+msgid "Path not found or invalid"
+msgstr "Yol bulunamadı veya geçersiz"
+
+#: id:15301
+msgid "Could not connect to network server"
+msgstr "Ağ sunucusuna bağlanamıyor"
+
+#: id:15302
+msgid "No servers found"
+msgstr "Sunucu bulunamadı"
+
+#: id:15303
+msgid "Workgroup not found"
+msgstr "Çalışma grubu bulunamadı"
+
+#: id:15310
+msgid "Opening multi-path source"
+msgstr "Çok yollu kaynak açılıyor"
+
+#: id:15311
+msgid "Path:"
+msgstr "Yol:"
+
+#: id:16000
+msgctxt "Auto context with id 16000"
+msgid "General"
+msgstr "Genel"
+
+#: id:16002
+msgid "Internet lookup"
+msgstr "İnternet'te ara"
+
+#: id:16003
+msgid "Player"
+msgstr "Ortam Oynatıcısı"
+
+#: id:16004
+msgid "Play media from disc"
+msgstr "Ortamları CD/DVD'den oynat"
+
+#: id:16008
+msgid "Enter new title"
+msgstr "Yeni başlık giriniz"
+
+#: id:16009
+msgid "Enter the movie name"
+msgstr "Film adını girin"
+
+#: id:16010
+msgid "Enter the profile name"
+msgstr "Profil adını girin"
+
+#: id:16011
+msgid "Enter the album name"
+msgstr "Albüm adını girin"
+
+#: id:16012
+msgid "Enter the playlist name"
+msgstr "Çalma listesi adını girin"
+
+#: id:16013
+msgid "Enter new filename"
+msgstr "Yeni dosya adını girin"
+
+#: id:16014
+msgid "Enter folder name"
+msgstr "Klasör adını girin"
+
+#: id:16015
+msgid "Enter directory"
+msgstr "Dizin girin"
+
+#: id:16016
+msgid "Available options: %A, %T, %N, %B, %D, %G, %Y, %F, %S"
+msgstr "Kullanılabilir seçenekler: %A, %T, %N, %B, %D, %G, %Y, %F, %S"
+
+#: id:16017
+msgid "Enter search string"
+msgstr "Aranacak terimleri girin"
+
+#: id:16018
+msgctxt "Auto context with id 16018"
+msgid "None"
+msgstr "Hayır"
+
+#: id:16019
+msgid "Auto select"
+msgstr "Otomatik seç"
+
+#: id:16020
+msgid "De-interlace"
+msgstr "De-interlace"
+
+#: id:16021
+msgid "Bob"
+msgstr "Bob"
+
+#: id:16022
+msgid "Bob (inverted)"
+msgstr "Bob (inverted)"
+
+#: id:16024
+msgid "Canceling..."
+msgstr "İptal ediliyor..."
+
+#: id:16025
+msgid "Enter the artist name"
+msgstr "Sanatçı adını girin"
+
+#: id:16026
+msgid "Playback failed"
+msgstr "Çalma başarısız"
+
+#: id:16027
+msgid "One or more items failed to play."
+msgstr "Bir veya daha fazla öğe çalınamadı"
+
+#: id:16028
+msgid "Enter value"
+msgstr "Değeri girin"
+
+#: id:16029
+msgid "Check the log file for details."
+msgstr "Detaylar için günlük dosyasına bakınız."
+
+#: id:16030
+msgid "Party mode aborted."
+msgstr "Parti modu durduruldu."
+
+#: id:16031
+msgid "No matching songs in the library."
+msgstr "Veritabanına uyan sonuç bulunamadı."
+
+#: id:16032
+msgid "Could not initialize database."
+msgstr "Veritabanı bilgisine ulaşılamıyor."
+
+#: id:16033
+msgid "Could not open database."
+msgstr "Veritabanı açılamıyor."
+
+#: id:16034
+msgid "Could not get songs from database."
+msgstr "Veritabanından şarkılar alınamıyor."
+
+#: id:16035
+msgid "Party mode playlist"
+msgstr "Parti modu çalma listesi"
+
+#: id:16036
+msgid "De-interlace (Half)"
+msgstr "De-interlace (Yarım)"
+
+#: id:16037
+msgid "Deinterlace video"
+msgstr "Deinterlace video"
+
+#: id:16038
+msgid "Deinterlace method"
+msgstr "Deinterlace metodu"
+
+#: id:16039
+msgctxt "Auto context with id 16039"
+msgid "Off"
+msgstr "Kapalı"
+
+#: id:16040
+msgctxt "Auto context with id 16040"
+msgid "Auto"
+msgstr "Otomatik"
+
+#: id:16041
+msgid "On"
+msgstr "Açık"
+
+#: id:16100
+msgid "All Videos"
+msgstr "Bütün Videolar"
+
+#: id:16101
+msgid "Unwatched"
+msgstr "Seyredilmeyen"
+
+#: id:16102
+msgid "Watched"
+msgstr "Seyredilen"
+
+#: id:16103
+msgid "Mark as watched"
+msgstr "Seyredilmiş olarak işaretle"
+
+#: id:16104
+msgid "Mark as unwatched"
+msgstr "Seyredilmemiş olarak işaretle"
+
+#: id:16105
+msgid "Edit title"
+msgstr "Başlığı düzenle"
+
+#: id:16200
+msgid "Operation was aborted"
+msgstr "İşlem durduruldu"
+
+#: id:16201
+msgid "Copy failed"
+msgstr "Kopyalanamadı"
+
+#: id:16202
+msgid "Failed to copy at least one file"
+msgstr "En az bir dosya kopyalanamadı"
+
+#: id:16203
+msgid "Move failed"
+msgstr "Taşınamadı"
+
+#: id:16204
+msgid "Failed to move at least one file"
+msgstr "En az bir dosya taşınamadı"
+
+#: id:16205
+msgid "Delete failed"
+msgstr "Silinemedi"
+
+#: id:16206
+msgid "Failed to delete at least one file"
+msgstr "En az bir dosya silinemedi"
+
+#: id:16300
+msgid "Video scaling method"
+msgstr "Video ölçekleme yöntemi"
+
+#: id:16301
+msgid "Nearest neighbour"
+msgstr "En yakın komşu"
+
+#: id:16302
+msgid "Bilinear"
+msgstr "Bilinear"
+
+#: id:16303
+msgctxt "Auto context with id 16303"
+msgid "Bicubic"
+msgstr "Bicubic"
+
+#: id:16304
+msgid "Lanczos2"
+msgstr "Lanczos2"
+
+#: id:16305
+msgid "Lanczos3"
+msgstr "Lanczos3"
+
+#: id:16306
+msgid "Sinc8"
+msgstr "Sinc8"
+
+#: id:16307
+msgid "Bicubic (software)"
+msgstr "Bicubic (yazılım)"
+
+#: id:16308
+msgid "Lanczos (software)"
+msgstr "Lanczos (yazılım)"
+
+#: id:16309
+msgid "Sinc (software)"
+msgstr "Sinc (yazılım)"
+
+#: id:16310
+msgid "Temporal"
+msgstr "Temporal"
+
+#: id:16311
+msgid "Temporal/Spatial"
+msgstr "Temporal/Spatial"
+
+#: id:16312
+msgid "(VDPAU)Noise Reduction"
+msgstr "(VDPAU)Noise Reduction"
+
+#: id:16313
+msgid "(VDPAU)Sharpness"
+msgstr "(VDPAU)Sharpness"
+
+#: id:16314
+msgid "Inverse Telecine"
+msgstr "Inverse Telecine"
+
+#: id:16315
+msgid "Lanczos3 optimized"
+msgstr "Lanczos3 iyileştirilmiş"
+
+#: id:16316
+msgctxt "Auto context with id 16316"
+msgid "Auto"
+msgstr "Otomatik"
+
+#: id:16317
+msgid "Temporal (Half)"
+msgstr "Temporal (Yarım)"
+
+#: id:16318
+msgid "Temporal/Spatial (Half)"
+msgstr "Temporal/Spatial (Yarım)"
+
+#: id:16319
+msgid "DXVA"
+msgstr "DXVA"
+
+#: id:16320
+msgid "DXVA Bob"
+msgstr "DXVA Bob"
+
+#: id:16321
+msgid "DXVA Best"
+msgstr "DXVA Best"
+
+#: id:16322
+msgid "Spline36"
+msgstr "Spline36"
+
+#: id:16323
+msgid "Spline36 optimized"
+msgstr "Spline36 optimized"
+
+#: id:16324
+msgid "Software Blend"
+msgstr "Software Blend"
+
+#: id:16400
+msgid "Post-processing"
+msgstr "Post-processing"
+
+#: id:17500
+msgid "Display sleep timeout"
+msgstr "Görüntü uyku zaman aşımı"
+
+#: id:19000
+msgid "Switch to channel"
+msgstr "Kanal değiştir"
+
+#: id:20000
+msgid "Saved music folder"
+msgstr "Kaydedilen müzik klasörü"
+
+#: id:20001
+msgid "Use external DVD player"
+msgstr "Harici DVD oynatıcıyı kullan"
+
+#: id:20002
+msgid "External DVD player"
+msgstr "Harici DVD oynatıcı"
+
+#: id:20003
+msgid "Trainers folder"
+msgstr "Hile klasörü"
+
+#: id:20004
+msgid "Screenshot folder"
+msgstr "Ekran görüntüsü klasörü"
+
+#: id:20006
+msgid "Playlists folder"
+msgstr "Çalma listesi klasörü"
+
+#: id:20007
+msgid "Recordings"
+msgstr "Kayıtlar"
+
+#: id:20008
+msgid "Screenshots"
+msgstr "Ekran görüntüsü"
+
+#: id:20009
+msgid "Use XBMC"
+msgstr "XBMC Kullanımı"
+
+#: id:20011
+msgid "Music playlists"
+msgstr "Müzik çalma listeleri"
+
+#: id:20012
+msgid "Video playlists"
+msgstr "Video oynatma listeleri"
+
+#: id:20013
+msgid "Do you wish to launch the game?"
+msgstr "Oyunu başlatmak istiyor musunuz?"
+
+#: id:20014
+msgid "Sort by: Playlist"
+msgstr "Sırala: Çalma listesi"
+
+#: id:20015
+msgid "Remote thumb"
+msgstr "Uzak küçük resim"
+
+#: id:20016
+msgid "Current thumb"
+msgstr "Geçerli küçük resim"
+
+#: id:20017
+msgid "Local thumb"
+msgstr "Yerel küçük resim"
+
+#: id:20018
+msgid "No thumb"
+msgstr "Küçük resim yok"
+
+#: id:20019
+msgid "Choose thumbnail"
+msgstr "Küçük resim seç"
+
+#: id:20023
+msgid "Conflict"
+msgstr "Çakışma"
+
+#: id:20024
+msgid "Scan new"
+msgstr "Yenileri tara"
+
+#: id:20025
+msgid "Scan all"
+msgstr "Hepsini tara"
+
+#: id:20026
+msgid "Region"
+msgstr "Ülke"
+
+#: id:20037
+msgid "Summary"
+msgstr "Özet"
+
+#: id:20038
+msgid "Lock music window"
+msgstr "Müzik penceresini kilitle"
+
+#: id:20039
+msgid "Lock videos window"
+msgstr "Video penceresini kilitle"
+
+#: id:20040
+msgid "Lock pictures window"
+msgstr "Resim penceresini kilitle"
+
+#: id:20041
+msgid "Lock programs & scripts windows"
+msgstr "Programlar ve betikler penceresini kilitle"
+
+#: id:20042
+msgid "Lock file manager"
+msgstr "Dosya yöneticisini kilitle"
+
+#: id:20043
+msgid "Lock settings"
+msgstr "Ayarları kilitle"
+
+#: id:20044
+msgid "Start fresh"
+msgstr "Yeniden başlat"
+
+#: id:20045
+msgid "Enter master mode"
+msgstr "Yönetici moduna gir"
+
+#: id:20046
+msgid "Leave master mode"
+msgstr "Yönetici modunu terk et"
+
+#: id:20047
+msgid "Create profile '%s'?"
+msgstr "'%s' profili oluşturulsun mu?"
+
+#: id:20048
+msgid "Start with fresh settings"
+msgstr "Taze ayarlarla başla"
+
+#: id:20049
+msgid "Best available"
+msgstr "En avantajlı"
+
+#: id:20050
+msgid "Auto-switch between 16x9 and 4x3"
+msgstr "16x9 ve 4x3 arasında otomatik geçiş yap"
+
+#: id:20051
+msgid "Treat stacked files as single file"
+msgstr "Yığınlanmış dosyalara tek dosya gibi davran"
+
+#: id:20052
+msgid "Caution"
+msgstr "Dikkat"
+
+#: id:20053
+msgid "Left master mode"
+msgstr "Yönetici modundan ayrıl"
+
+#: id:20054
+msgid "Entered master mode"
+msgstr "Yönetici moduna giriliyor"
+
+#: id:20055
+msgid "Allmusic.com thumb"
+msgstr "Allmusic.com küçük resimleri"
+
+#: id:20057
+msgid "Remove thumbnail"
+msgstr "Küçük resimleri kaldır"
+
+#: id:20058
+msgid "Add profile..."
+msgstr "Profil ekle..."
+
+#: id:20059
+msgid "Query info for all albums"
+msgstr "Bütün albümler için bilgileri sorgula"
+
+#: id:20060
+msgctxt "Auto context with id 20060"
+msgid "Media info"
+msgstr "Ortam bilgisi"
+
+#: id:20061
+msgctxt "Auto context with id 20061"
+msgid "Separate"
+msgstr "Ayrı"
+
+#: id:20062
+msgid "Shares with default"
+msgstr "Varsayılan paylaşımlar"
+
+#: id:20063
+msgid "Shares with default (read only)"
+msgstr "Varsayılan paylaşımlar (salt okunur)"
+
+#: id:20064
+msgid "Copy default"
+msgstr "Varsayılanı kopyala"
+
+#: id:20065
+msgid "Profile picture"
+msgstr "Profil resmi"
+
+#: id:20066
+msgid "Lock preferences"
+msgstr "Tercihleri kilitle"
+
+#: id:20067
+msgid "Edit profile"
+msgstr "Profili düzenle"
+
+#: id:20068
+msgid "Profile lock"
+msgstr "Profil kilidi"
+
+#: id:20069
+msgid "Could not create folder"
+msgstr "Klasör oluşturulamadı"
+
+#: id:20070
+msgid "Profile directory"
+msgstr "Profil dizini"
+
+#: id:20071
+msgid "Start with fresh media sources"
+msgstr "Taze ortam kaynaklarıyla başla"
+
+#: id:20072
+msgid "Make sure the selected folder is writable"
+msgstr "Seçili klasörün yazılabilir ve klasör adının"
+
+#: id:20073
+msgid "and that the new folder name is valid"
+msgstr "geçerli olduğundan emin olun"
+
+#: id:20074
+msgid "MPAA rating"
+msgstr "MPAA derecelendirmesi"
+
+#: id:20075
+msgid "Enter master lock code"
+msgstr "Yönetici kilit kodunu gir"
+
+#: id:20076
+msgid "Ask for master lock code on startup"
+msgstr "Başlangıçta yönetici kilit kodunu sor"
+
+#: id:20077
+msgid "Skin settings"
+msgstr "Dış görünüm ayarları"
+
+#: id:20078
+msgid "- no link set -"
+msgstr "- bağlantı ayarı yok -"
+
+#: id:20079
+msgid "Enable animations"
+msgstr "Animasyonları etkinleştir"
+
+#: id:20080
+msgid "Disable RSS during music"
+msgstr "Müzik çalarken RSS beslemelerini devre dışı bırak"
+
+#: id:20081
+msgid "Enable shortcut buttons"
+msgstr "Kısayol tuşlarını etkinleştir"
+
+#: id:20082
+msgid "Show programs in main menu"
+msgstr "Programları ana menüde göster"
+
+#: id:20083
+msgid "Show music info"
+msgstr "Müzik bilgilerini göster"
+
+#: id:20084
+msgid "Show weather info"
+msgstr "Hava Durumu'nu göster"
+
+#: id:20085
+msgid "Show system info"
+msgstr "Sistem bilgisini göster"
+
+#: id:20086
+msgid "Show available disc space C: E: F:"
+msgstr "Kullanılabilir disk alanını göster C: E: F:"
+
+#: id:20087
+msgid "Show available disc space E: F: G:"
+msgstr "Kullanılabilir disk alanını göster E: F: G:"
+
+#: id:20088
+msgid "Weather info"
+msgstr "Hava Durumu bilgisi"
+
+#: id:20089
+msgid "Drive space free"
+msgstr "Boş disk alanı"
+
+#: id:20090
+msgid "Enter the name of an existing share"
+msgstr "Mevcut bir paylaşım adı girin"
+
+#: id:20091
+msgid "Lock code"
+msgstr "Kilit kodu"
+
+#: id:20092
+msgid "Load profile"
+msgstr "Profili yükle"
+
+#: id:20093
+msgid "Profile name"
+msgstr "Profil adı"
+
+#: id:20094
+msgctxt "Auto context with id 20094"
+msgid "Media sources"
+msgstr "Ortam kaynakları"
+
+#: id:20095
+msgid "Enter profile lock code"
+msgstr "Profil kilit kodunu girin"
+
+#: id:20096
+msgctxt "Auto context with id 20096"
+msgid "Login screen"
+msgstr "Giriş ekranı"
+
+#: id:20097
+msgid "Fetching album info"
+msgstr "Albüm bilgileri getiriliyor"
+
+#: id:20098
+msgid "Fetching info for album"
+msgstr "Albüm için bilgiler getiriliyor"
+
+#: id:20099
+msgid "Can't rip CD or track while playing from CD"
+msgstr "CD'den çalınırken CD veya parça aktarılamaz"
+
+#: id:20100
+msgid "Master lock code and settings"
+msgstr "Yönetici kilit kodu ve ayarları"
+
+#: id:20101
+msgid "Entering master lock code always enables master mode"
+msgstr "Yönetici kilit kodunu girmek her zaman yönetici modu etkinleştirir"
+
+#: id:20102
+msgid "or copy from default?"
+msgstr "veya varsayılanı kopyala?"
+
+#: id:20103
+msgid "Save changes to profile?"
+msgstr "Değişiklikler profile kaydedilsin mi?"
+
+#: id:20104
+msgid "Old settings found."
+msgstr "Eski ayarlar bulundu."
+
+#: id:20105
+msgid "Do you want to use them?"
+msgstr "Onları kullanmak istiyor musunuz?"
+
+#: id:20106
+msgid "Old media sources found."
+msgstr "Eski ortam kaynakları bulundu."
+
+#: id:20107
+msgid "Separate (locked)"
+msgstr "Ayrı (kilitli)"
+
+#: id:20108
+msgid "Root"
+msgstr "Kök"
+
+#: id:20109
+msgid "- Zoom"
+msgstr "- Yakınlaştır"
+
+#: id:20110
+msgid "UPnP settings"
+msgstr "UPnP ayarları"
+
+#: id:20111
+msgid "Autostart UPnP client"
+msgstr "UPnP istemcisini otomatik başlat"
+
+#: id:20112
+msgid "Last login: %s"
+msgstr "Son giriş: %s"
+
+#: id:20113
+msgid "Never logged on"
+msgstr "Hiç giriş yapılmamış"
+
+#: id:20114
+msgid "Profile %i / %i"
+msgstr "Profil %i / %i"
+
+#: id:20115
+msgid "User login / Select a profile"
+msgstr "Kullanıcı girişi / Profil seçin"
+
+#: id:20116
+msgid "Use lock on login screen"
+msgstr "Giriş ekranında kilit kullan"
+
+#: id:20117
+msgid "Invalid lock code."
+msgstr "Geçersiz kilit kodu."
+
+#: id:20118
+msgid "This requires the master lock to be set."
+msgstr "Bunun için yönetici kilit kodunun ayarlanması gerekli"
+
+#: id:20119
+msgid "Would you like to set it now?"
+msgstr "Şimdi ayarlamak ister misiniz?"
+
+#: id:20120
+msgid "Loading program information"
+msgstr "Program bilgisi yükleniyor"
+
+#: id:20121
+msgid "Party on!"
+msgstr "Partiye devam!"
+
+#: id:20122
+msgid "True"
+msgstr "Doğru"
+
+#: id:20123
+msgid "Mixing drinks"
+msgstr "İçecekler karıştırılıyor"
+
+#: id:20124
+msgid "Filling glasses"
+msgstr "Bardaklar dolduruluyor"
+
+#: id:20125
+msgid "Logged on as"
+msgstr "Giriş yapıldı"
+
+#: id:20126
+msgid "Log off"
+msgstr "Oturumu kapat"
+
+#: id:20128
+msgid "Go to root"
+msgstr "Kök dizine git"
+
+#: id:20129
+msgid "Weave"
+msgstr "Weave"
+
+#: id:20130
+msgid "Weave (inverted)"
+msgstr "Weave (ters)"
+
+#: id:20131
+msgid "Blend"
+msgstr "Karıştır"
+
+#: id:20132
+msgid "Restart video"
+msgstr "Video'yu yeniden başlat"
+
+#: id:20133
+msgid "Edit network location"
+msgstr "Ağ konumunu düzenle"
+
+#: id:20134
+msgid "Remove network location"
+msgstr "Ağ konumunu kaldır"
+
+#: id:20135
+msgid "Do you want to scan the folder?"
+msgstr "Klasörü taramak istiyor musunuz?"
+
+#: id:20136
+msgid "Memory unit"
+msgstr "Bellek ünitesi"
+
+#: id:20137
+msgid "Memory unit mounted"
+msgstr "Bellek ünitesi bağlandı"
+
+#: id:20138
+msgid "Unable to mount memory unit"
+msgstr "Bellek ünitesi bağlanamıyor"
+
+#: id:20139
+msgid "In port %i, slot %i"
+msgstr "Bağlantı noktası %i, yuvası %i"
+
+#: id:20140
+msgid "Lock screensaver"
+msgstr "Ekran koruyucuyu kilitle"
+
+#: id:20141
+msgid "Set"
+msgstr "Ayarla"
+
+#: id:20142
+msgctxt "Auto context with id 20142"
+msgid "Username"
+msgstr "Kullanıcı Adı"
+
+#: id:20143
+msgid "Enter password for"
+msgstr "Parolayı gir"
+
+#: id:20144
+msgid "Shutdown timer"
+msgstr "Kapatma zamanlayıcısı"
+
+#: id:20145
+msgid "Shutdown interval (in minutes)"
+msgstr "Kapatma aralığı (dakika olarak)"
+
+#: id:20146
+msgid "Started, shutdown in %im"
+msgstr "%im içinde kapatılacak"
+
+#: id:20147
+msgid "Shutdown in 30 minutes"
+msgstr "30 dakika içinde kapat"
+
+#: id:20148
+msgid "Shutdown in 60 minutes"
+msgstr "60 dakika içinde kapat"
+
+#: id:20149
+msgid "Shutdown in 120 minutes"
+msgstr "120 dakika içinde kapat"
+
+#: id:20150
+msgid "Custom shutdown timer"
+msgstr "Özel kapatma zamanlayıcısı"
+
+#: id:20151
+msgid "Cancel shutdown timer"
+msgstr "Kapatma zamanlayıcısını iptal et"
+
+#: id:20152
+msgid "Lock preferences for %s"
+msgstr "%s için tercihleri kilitle"
+
+#: id:20153
+msgid "Browse..."
+msgstr "Gözat..."
+
+#: id:20154
+msgid "Summary information"
+msgstr "Özetlenmiş bilgiler"
+
+#: id:20155
+msgid "Storage information"
+msgstr "Depolama bilgisi"
+
+#: id:20156
+msgid "Hard disk information"
+msgstr "Sabit sürücü bilgisi"
+
+#: id:20157
+msgid "DVD-ROM information"
+msgstr "DVD-ROM bilgisi"
+
+#: id:20158
+msgid "Network information"
+msgstr "Ağ bilgisi"
+
+#: id:20159
+msgid "Video information"
+msgstr "Video bilgisi"
+
+#: id:20160
+msgid "Hardware information"
+msgstr "Donanım bilgisi"
+
+#: id:20161
+msgid "Total"
+msgstr "Toplam"
+
+#: id:20162
+msgid "Used"
+msgstr "Kullanılan"
+
+#: id:20163
+msgid "of"
+msgstr "onun"
+
+#: id:20164
+msgid "Locking not supported"
+msgstr "Kilitleme desteklenmiyor"
+
+#: id:20165
+msgid "Not locked"
+msgstr "Kilitli değil"
+
+#: id:20166
+msgid "Locked"
+msgstr "Kilitli"
+
+#: id:20167
+msgid "Frozen"
+msgstr "Donmuş"
+
+#: id:20168
+msgid "Requires reset"
+msgstr "Yeniden başlatmak gerekli"
+
+#: id:20169
+msgid "Week"
+msgstr "Hafta"
+
+#: id:20170
+msgid "Line"
+msgstr "Satır"
+
+#: id:20171
+msgid "Windows network (SMB)"
+msgstr "Windows ağı (SMB)"
+
+#: id:20172
+msgid "XBMSP server"
+msgstr "XBMSP sunucusu"
+
+#: id:20173
+msgctxt "Auto context with id 20173"
+msgid "FTP server"
+msgstr "FTP sunucusu"
+
+#: id:20174
+msgid "iTunes music share (DAAP)"
+msgstr "iTunes müzik paylaşımı (DAAP)"
+
+#: id:20175
+msgid "UPnP server"
+msgstr "UPnP sunucusu"
+
+#: id:20176
+msgid "Show video info"
+msgstr "Video bilgilerini göster"
+
+#: id:20177
+msgid "Done"
+msgstr "Tamam"
+
+#: id:20178
+msgid "Shift"
+msgstr "Üst Karakter"
+
+#: id:20179
+msgid "Caps Lock"
+msgstr "Büyük Harf Kilidi"
+
+#: id:20180
+msgid "Symbols"
+msgstr "Semboller"
+
+#: id:20181
+msgid "Backspace"
+msgstr "Sil"
+
+#: id:20182
+msgid "Space"
+msgstr "Boşluk"
+
+#: id:20183
+msgid "Reload skin"
+msgstr "Dış görünümü yeniden yükle"
+
+#: id:20184
+msgid "Rotate pictures using EXIF information"
+msgstr "EXIF bilgilerini kullanarak resmi çevir"
+
+#: id:20185
+msgid "Use poster view styles for TV shows"
+msgstr "TV programları için poster görünümünü kullan"
+
+#: id:20186
+msgid "Please wait"
+msgstr "Lütfen bekleyin"
+
+#: id:20187
+msgid "UPnP"
+msgstr "UPnP"
+
+#: id:20189
+msgid "Enable auto scrolling for plot & review"
+msgstr "İçerik ve yorum için otomatik kaydırmayı etkinleştir"
+
+#: id:20190
+msgctxt "Auto context with id 20190"
+msgid "Custom"
+msgstr "Özel"
+
+#: id:20191
+msgid "Enable debug logging"
+msgstr "Hata ayıklama günlüğünü etkinleştir"
+
+#: id:20192
+msgid "Download additional information during updates"
+msgstr "Güncellemeler sırasında ek bilgileri karşıdan yükle"
+
+#: id:20193
+msgid "Default service for album information"
+msgstr "Albüm bilgileri için varsayılan hizmet"
+
+#: id:20194
+msgid "Default service for artist information"
+msgstr "Sanatçı bilgileri için varsayılan hizmet"
+
+#: id:20195
+msgid "Change scraper"
+msgstr "Scraper'ı değiştir"
+
+#: id:20196
+msgid "Export music library"
+msgstr "Müzik kitaplığını dışa aktar"
+
+#: id:20197
+msgid "Import music library"
+msgstr "Müzik kitaplığını içe aktar"
+
+#: id:20198
+msgid "No artist found!"
+msgstr "Sanatçı bulunamadı!"
+
+#: id:20199
+msgid "Downloading artist info failed"
+msgstr "Sanatçı bilgisi indirilemedi"
+
+#: id:20250
+msgid "Party on! (videos)"
+msgstr "Partiye devam! (videolar)"
+
+#: id:20251
+msgid "Mixing drinks (videos)"
+msgstr "İçecekler karıştırılıyor (videolar)"
+
+#: id:20252
+msgid "Filling glasses (videos)"
+msgstr "Bardaklar dolduruluyor (videolar)"
+
+#: id:20253
+msgid "WebDAV server (HTTP)"
+msgstr "WebDAV sunucu (HTTP)"
+
+#: id:20254
+msgid "WebDAV server (HTTPS)"
+msgstr "WebDAV sunucu (HTTPS)"
+
+#: id:20255
+msgid "First logon, edit your profile"
+msgstr "İlk oturum açılışı, profilinizi düzenleyin"
+
+#: id:20256
+msgid "HTS Tvheadend client"
+msgstr "HTS Tvheadend istemcisi"
+
+#: id:20257
+msgid "VDR Streamdev client"
+msgstr "VDR Streamdev istemcisi"
+
+#: id:20258
+msgid "MythTV client"
+msgstr "MythTV istemcisi"
+
+#: id:20259
+msgid "Network Filesystem (NFS)"
+msgstr "Ağ Dosya Sistemi (NFS)"
+
+#: id:20260
+msgid "Secure Shell (SSH/SFTP)"
+msgstr "Güvenli Kabuk (SSH/SFTP)"
+
+#: id:20261
+msgid "Apple Filing Protocol (AFP)"
+msgstr "Apple Filing Protocol (AFP)"
+
+#: id:20300
+msgid "Web server directory (HTTP)"
+msgstr "Web sunucu dizini (HTTP)"
+
+#: id:20301
+msgid "Web server directory (HTTPS)"
+msgstr "Web sunucu dizini (HTTPS)"
+
+#: id:20302
+msgid "Unable to write to folder:"
+msgstr "Klasöre yazılamıyor:"
+
+#: id:20303
+msgid "Do you want to skip and proceed?"
+msgstr "Bu adımı atlayıp devam etme istiyor musunuz?"
+
+#: id:20304
+msgid "RSS Feed"
+msgstr "RSS Akışı"
+
+#: id:20307
+msgid "Secondary DNS"
+msgstr "İkincil DNS"
+
+#: id:20308
+msgid "DHCP server:"
+msgstr "DHCP sunucusu:"
+
+#: id:20309
+msgid "Make new folder"
+msgstr "Yeni klasör yarat"
+
+#: id:20310
+msgid "Dim LCD on playback"
+msgstr "Oynatırken LCD'yi karart"
+
+#: id:20311
+msgid "Unknown or onboard (protected)"
+msgstr "Yerleşik veya bilinmiyor (korumalı)"
+
+#: id:20312
+msgid "Dim LCD on paused"
+msgstr "Duraklatılınca LCD'yi karart"
+
+#: id:20314
+msgid "Videos - Library"
+msgstr "Videolar - Kitaplık"
+
+#: id:20316
+msgid "Sort by: ID"
+msgstr "Sırala: ID"
+
+#: id:20324
+msgid "Play part..."
+msgstr "...Bölümü oynat"
+
+#: id:20325
+msgid "Calibration reset"
+msgstr "Ayarları sıfırla"
+
+#: id:20326
+msgid "This will reset the calibration values for %s"
+msgstr "Bu %s için olan ayarlama değerlerini"
+
+#: id:20327
+msgid "to it's default values."
+msgstr "varsayılana sıfırlayacak."
+
+#: id:20328
+msgid "Browse for destination"
+msgstr "Hedefe gözat"
+
+#: id:20329
+msgid "Movies are in separate folders that match the movie title"
+msgstr "Filmler ayrı klasörlerde film başlığı ile eşleşecek şekilde bulunuyor"
+
+#: id:20330
+msgid "Use folder names for lookups"
+msgstr "Arama için klasör adlarını kullan"
+
+#: id:20331
+msgctxt "Auto context with id 20331"
+msgid "File"
+msgstr "Dosya"
+
+#: id:20332
+msgid "Use file or folder names in lookups?"
+msgstr "Aramalarda dosya veya klasör adları kullanılsın mı?"
+
+#: id:20333
+msgid "Set content"
+msgstr "İçeriği ayarla"
+
+#: id:20334
+msgid "Folder"
+msgstr "Dizin"
+
+#: id:20335
+msgid "Look for content recursively?"
+msgstr "İçeriğe özyinelemeli olarak bakılsın mı?"
+
+#: id:20336
+msgid "Unlock sources"
+msgstr "Kaynakların kilidini kaldır"
+
+#: id:20337
+msgid "Actor"
+msgstr "Aktör"
+
+#: id:20338
+msgid "Movie"
+msgstr "Film"
+
+#: id:20339
+msgid "Director"
+msgstr "Yönetmen"
+
+#: id:20340
+msgid "Do you want to remove all items within"
+msgstr "Bu yol içindeki tüm ögeleri"
+
+#: id:20341
+msgid "this path from the XBMC library?"
+msgstr "XBMC kitaplığından kaldırmak istiyor musunuz?"
+
+#: id:20342
+msgctxt "Auto context with id 20342"
+msgid "Movies"
+msgstr "Filmler"
+
+#: id:20343
+msgid "TV shows"
+msgstr "TV programları"
+
+#: id:20344
+msgid "This directory contains"
+msgstr "Bu dizinin içeriği"
+
+#: id:20345
+msgid "Run automated scan"
+msgstr "Otomatik taramayı çalıştır"
+
+#: id:20346
+msgid "Scan recursively"
+msgstr "Alt dizinleride tara"
+
+#: id:20347
+msgid "as"
+msgstr "-"
+
+#: id:20348
+msgid "Directors"
+msgstr "Yönetmenler"
+
+#: id:20349
+msgid "No video files found in this path!"
+msgstr "Bu yolda video dosyası bulunamadı!"
+
+#: id:20350
+msgid "votes"
+msgstr "oylar"
+
+#: id:20351
+msgid "TV show information"
+msgstr "TV programı bilgisi"
+
+#: id:20352
+msgid "Episode information"
+msgstr "Bölüm bilgisi"
+
+#: id:20353
+msgid "Loading TV show details"
+msgstr "TV programının ayrıntıları yükleniyor"
+
+#: id:20354
+msgid "Fetching episode guide"
+msgstr "Bölüm rehberi getiriliyor"
+
+#: id:20355
+msgid "Loading info for episodes in directory"
+msgstr "Klasördeki bölümlerin bilgileri yükleniyor"
+
+#: id:20356
+msgid "Select TV show:"
+msgstr "TV programı seçin:"
+
+#: id:20357
+msgid "Enter the TV show name"
+msgstr "TV programının adını girin"
+
+#: id:20358
+msgid "Season %i"
+msgstr "Sezon %i"
+
+#: id:20359
+msgid "Episode"
+msgstr "Bölüm"
+
+#: id:20360
+msgid "Episodes"
+msgstr "Bölüm"
+
+#: id:20361
+msgid "Loading episode details"
+msgstr "Bölüm ayrıntıları yükleniyor"
+
+#: id:20362
+msgid "Remove episode from library"
+msgstr "Bölümü kitaplıktan kaldır"
+
+#: id:20363
+msgid "Remove TV show from library"
+msgstr "TV programını kitaplıktan kaldır"
+
+#: id:20364
+msgid "TV show"
+msgstr "TV programı"
+
+#: id:20365
+msgid "Episode plot"
+msgstr "Bölüm içeriği"
+
+#: id:20366
+msgid "* All seasons"
+msgstr "* Bütün sezonlar"
+
+#: id:20367
+msgid "Hide watched"
+msgstr "İzlenenleri gizle"
+
+#: id:20368
+msgid "Prod code"
+msgstr "Üretim kodu"
+
+#: id:20369
+msgid "Show plot for unwatched items"
+msgstr "Seyredilmeyen ögelerin içeriğini göster"
+
+#: id:20370
+msgid "* Hidden to prevent spoilers *"
+msgstr "* Gizli spoilerleri önlemek için *"
+
+#: id:20371
+msgid "Set season thumb"
+msgstr "Sezon küçük resmini ayarla"
+
+#: id:20372
+msgid "Season image"
+msgstr "Sezon resmi"
+
+#: id:20373
+msgid "Season"
+msgstr "Sezon"
+
+#: id:20374
+msgid "Downloading movie information"
+msgstr "Film bilgileri karşıdan yükleniyor"
+
+#: id:20375
+msgid "Unassign content"
+msgstr "Atanmamış içerik"
+
+#: id:20376
+msgid "Original title"
+msgstr "Orijinal başlık"
+
+#: id:20377
+msgid "Refresh TV show information"
+msgstr "TV programının bilgilerini yenile"
+
+#: id:20378
+msgid "Refresh info for all episodes?"
+msgstr "Tüm bölümlerin bilgileri yenilensin mi?"
+
+#: id:20379
+msgid "Selected folder contains a single TV show"
+msgstr "Seçilen klasör tek bir TV programı içerir"
+
+#: id:20380
+msgid "Exclude selected folder from scans"
+msgstr "Seçilen klasörü taramalara dahil etme"
+
+#: id:20381
+msgid "Specials"
+msgstr "Specials"
+
+#: id:20382
+msgid "Automatically grab season thumbs"
+msgstr "Sezon küçük resimlerini otomatik olarak al"
+
+#: id:20383
+msgid "Selected folder contains a single video"
+msgstr "Seçilen klasör tek bir video içeriyor"
+
+#: id:20384
+msgid "Link to TV show"
+msgstr "TV programına bağlantı"
+
+#: id:20385
+msgid "Remove link to TV show"
+msgstr "TV program bağlantısını kaldır"
+
+#: id:20386
+msgid "Recently added movies"
+msgstr "Son eklenen filmler"
+
+#: id:20387
+msgid "Recently added episodes"
+msgstr "Son eklenen bölümler"
+
+#: id:20388
+msgid "Studios"
+msgstr "Stüdyolar"
+
+#: id:20389
+msgid "Music videos"
+msgstr "Müzik videoları"
+
+#: id:20390
+msgid "Recently added music videos"
+msgstr "Son eklenen müzik videoları"
+
+#: id:20391
+msgid "Music video"
+msgstr "Müzik videosu"
+
+#: id:20392
+msgid "Remove music video from library"
+msgstr "Müzik videosunu kitaplıktan kaldır"
+
+#: id:20393
+msgctxt "Auto context with id 20393"
+msgid "Music video information"
+msgstr "Müzik video bilgisi"
+
+#: id:20394
+msgid "Loading music video information"
+msgstr "Müzik videosu bilgisi yükleniyor"
+
+#: id:20395
+msgid "Mixed"
+msgstr "Karışık"
+
+#: id:20396
+msgid "Go to albums by artist"
+msgstr "Sanatçıya göre albüme git"
+
+#: id:20397
+msgid "Go to album"
+msgstr "Albüme git"
+
+#: id:20398
+msgid "Play song"
+msgstr "Şarkıyı çal"
+
+#: id:20399
+msgid "Go to music videos from album"
+msgstr "Albümden müzik videosuna git"
+
+#: id:20400
+msgid "Go to music videos by artist"
+msgstr "Sanatçıya göre müzik videosuna git"
+
+#: id:20401
+msgid "Play music video"
+msgstr "Müzik videosunu oynat"
+
+#: id:20402
+msgid "Download actor thumbnails when adding to library"
+msgstr "Kitaplığa eklendiğinde aktör küçük resimlerini karşıdan yükle"
+
+#: id:20403
+msgid "Set actor thumb"
+msgstr "Aktör küçük resmini ayarla"
+
+#: id:20405
+msgid "Remove episode bookmark"
+msgstr "Bölüm yer işaretini kaldır"
+
+#: id:20406
+msgid "Set episode bookmark"
+msgstr "Bölüm yer işaretini ayarla"
+
+#: id:20407
+msgid "Scraper settings"
+msgstr "Scraper ayarları"
+
+#: id:20408
+msgid "Downloading music video information"
+msgstr "Müzik videosunun bilgisi karşıdan yükleniyor"
+
+#: id:20409
+msgid "Downloading TV show information"
+msgstr "TV programının bilgisi karşıdan yükleniyor"
+
+#: id:20410
+msgid "Trailer"
+msgstr "Fragman"
+
+#: id:20411
+msgid "Flatten"
+msgstr "Birleştir"
+
+#: id:20412
+msgid "Flatten TV shows"
+msgstr "TV programlarını birleştir"
+
+#: id:20413
+msgid "Get fanart"
+msgstr "Fanart al"
+
+#: id:20414
+msgid "Show Fanart in video and music libraries"
+msgstr "Video ve Müzik kitaplıklarında Fanart'ı göster"
+
+#: id:20415
+msgid "Scanning for new content"
+msgstr "Yeni içerik için taranıyor"
+
+#: id:20416
+msgid "First aired"
+msgstr "İlk gösterim"
+
+#: id:20417
+msgid "Writer"
+msgstr "Yazar"
+
+#: id:20419
+msgid "Replace file names with library titles"
+msgstr "Dosya görünümünde meta verileri gösterilsin mi?"
+
+#: id:20420
+msgctxt "Auto context with id 20420"
+msgid "Never"
+msgstr "Asla"
+
+#: id:20421
+msgid "If only one season"
+msgstr "Yalnızca bir sezon ise"
+
+#: id:20422
+msgid "Always"
+msgstr "Her zaman"
+
+#: id:20423
+msgid "Has trailer"
+msgstr "Fragmanı var"
+
+#: id:20424
+msgid "False"
+msgstr "Yanlış"
+
+#: id:20425
+msgid "Fanart slideshow"
+msgstr "Fanart slayt gösterisi"
+
+#: id:20426
+msgid "Export to a single file or separate"
+msgstr "Dışarı aktarma işlemi tek bir dosya mı,"
+
+#: id:20427
+msgid "files per entry?"
+msgstr "ayrı dosyalar halinde mi olsun?"
+
+#: id:20428
+msgid "Single file"
+msgstr "Tek dosya"
+
+#: id:20429
+msgctxt "Auto context with id 20429"
+msgid "Separate"
+msgstr "Ayrı"
+
+#: id:20430
+msgid "Export thumbnails and fanart?"
+msgstr "Küçük resimler ve fanart dışarı aktarılsın mı?"
+
+#: id:20431
+msgid "Overwrite old files?"
+msgstr "Eski dosyaların üzerine yazılsın mı?"
+
+#: id:20432
+msgid "Exclude path from library updates"
+msgstr "Bu yolu kitaplık güncellemelerine dahil etme"
+
+#: id:20433
+msgid "Extract thumbnails and video information"
+msgstr "Küçük resimleri ve video bilgilerini çıkart"
+
+#: id:20434
+msgid "Sets"
+msgstr "Setler"
+
+#: id:20435
+msgid "Set movieset thumb"
+msgstr "Film kümesi küçük resmini ayarla"
+
+#: id:20436
+msgid "Export actor thumbs?"
+msgstr "Aktör küçük resimlerini çıkart"
+
+#: id:20437
+msgid "Choose fanart"
+msgstr "Fanart seç"
+
+#: id:20438
+msgid "Local fanart"
+msgstr "Yerel fanart"
+
+#: id:20439
+msgid "No fanart"
+msgstr "Fanart yok"
+
+#: id:20440
+msgid "Current fanart"
+msgstr "Geçerli fanart"
+
+#: id:20441
+msgid "Remote fanart"
+msgstr "Uzak fanart"
+
+#: id:20442
+msgid "Change content"
+msgstr "İçeriği değiştir"
+
+#: id:20443
+msgid "Do you want to refresh info for all"
+msgstr "Bu yolun içindeki tüm öğelerin bilgilerini"
+
+#: id:20444
+msgid "items within this path?"
+msgstr "yenilemek istiyor musunuz?"
+
+#: id:20445
+msgid "Fanart"
+msgstr "Fanart"
+
+#: id:20446
+msgid "Locally stored information found."
+msgstr "Yerel olarak depolanan bilgi bulundu."
+
+#: id:20447
+msgid "Ignore and refresh from internet?"
+msgstr "Yoksayıp internetten yenilensin mi?"
+
+#: id:20448
+msgid "Could not download information"
+msgstr "Bilgi indirilemiyor"
+
+#: id:20449
+msgid "Unable to connect to remote server"
+msgstr "Uzak sunucuya bağlanılamıyor."
+
+#: id:20450
+msgid "Would you like to continue scanning?"
+msgstr "Taramaya devam etmek istiyor musunuz?"
+
+#: id:20451
+msgid "Countries"
+msgstr "Ülkeler"
+
+#: id:20452
+msgid "episode"
+msgstr "bölüm"
+
+#: id:20453
+msgid "episodes"
+msgstr "bölüm"
+
+#: id:20454
+msgid "Listener"
+msgstr "Dinleyici"
+
+#: id:20455
+msgid "Listeners"
+msgstr "Dinleyiciler"
+
+#: id:20456
+msgid "Set movieset fanart"
+msgstr "Set movieset fanart"
+
+#: id:20457
+msgid "Movie set"
+msgstr "Movie set"
+
+#: id:20458
+msgid "Group movies in sets"
+msgstr "Group movies in sets"
+
+#: id:21330
+msgid "Show hidden files and directories"
+msgstr "Gizli dosya ve dizinleri göster"
+
+#: id:21331
+msgid "TuxBox client"
+msgstr "TuxBox istemcisi"
+
+#: id:21332
+msgid "WARNING: Target TuxBox device is in recording-mode!"
+msgstr "UYARI: Hedef TuxBox aygıtı kayıt modunda!"
+
+#: id:21333
+msgid "The stream will be stopped!"
+msgstr "Akış durdurulacak!"
+
+#: id:21334
+msgid "Zap to channel: %s failed!"
+msgstr "Kanalı zapla: %s zaplanamadı!"
+
+#: id:21335
+msgid "Are you sure to start the stream?"
+msgstr "Akışı başlatmak istediğinize emin misiniz?"
+
+#: id:21336
+msgid "Connecting to: %s"
+msgstr "Bağlanıyor: %s"
+
+#: id:21337
+msgid "TuxBox device"
+msgstr "TuxBox aygıtı"
+
+#: id:21359
+msgid "Add media share..."
+msgstr "Ortam paylaşımı ekle..."
+
+#: id:21360
+msgid "Share video and music libraries through UPnP"
+msgstr "Video ve müzik kitaplıklarını UPnP üzerinden paylaş"
+
+#: id:21364
+msgid "Edit media share"
+msgstr "Ortam paylaşımını düzenle"
+
+#: id:21365
+msgid "Remove media share"
+msgstr "Ortam paylaşımını kaldır"
+
+#: id:21366
+msgid "Subtitle folder"
+msgstr "Altyazı klasörü"
+
+#: id:21367
+msgid "Movie & alternate subtitle directory"
+msgstr "Film ve alternatif altyazı klasörü"
+
+#: id:21368
+msgid "Override ASS/SSA subtitles fonts"
+msgstr "ASS/SSA altyazı yazı tiplerini geçersiz kıl"
+
+#: id:21369
+msgid "Enable mouse and Touch Screen support"
+msgstr "Fareyi ve Dokunmatik Ekran desteğini etkinleştir"
+
+#: id:21370
+msgid "Play navigation sounds during media playback"
+msgstr "Ortam oynatılırken kılavuz seslerini çal"
+
+#: id:21371
+msgid "Thumbnail"
+msgstr "Küçük resimler"
+
+#: id:21372
+msgid "Forced DVD player region"
+msgstr "DVD bölge kodunu zorla"
+
+#: id:21373
+msgid "Video output"
+msgstr "Video çıkışı"
+
+#: id:21374
+msgid "Video aspect"
+msgstr "Video görüntü oranı"
+
+#: id:21375
+msgctxt "Auto context with id 21375"
+msgid "Normal"
+msgstr "Normal"
+
+#: id:21376
+msgid "Letterbox"
+msgstr "Sinemaskop"
+
+#: id:21377
+msgid "Widescreen"
+msgstr "Geniş ekran"
+
+#: id:21378
+msgid "Enable 480p"
+msgstr "480p'yi etkinleştir"
+
+#: id:21379
+msgid "Enable 720p"
+msgstr "720p'ti etkinleştir"
+
+#: id:21380
+msgid "Enable 1080i"
+msgstr "1080i'yi etkinleştir"
+
+#: id:21381
+msgid "Enter name of new playlist"
+msgstr "Yeni çalma listesinin adını girin"
+
+#: id:21382
+msgid "Show \"Add source\" buttons in file lists"
+msgstr "Dosya listesindeki \"Kaynak ekle\" tuşunu göster"
+
+#: id:21383
+msgid "Enable scrollbars"
+msgstr "Kaydırma çubuklarını etkinleştir"
+
+#: id:21384
+msgid "Make watched filtering a toggle in video library"
+msgstr "Video kitaplığında seyredilmiş filtresini aç/kapat"
+
+#: id:21385
+msgctxt "Auto context with id 21385"
+msgid "Open"
+msgstr "Aç"
+
+#: id:21386
+msgid "Acoustic management level"
+msgstr "Akustik yönetim düzeyi"
+
+#: id:21387
+msgid "Fast"
+msgstr "Hızlı"
+
+#: id:21388
+msgid "Quiet"
+msgstr "Sessiz"
+
+#: id:21389
+msgid "Enable custom background"
+msgstr "Özel akra planları etkinleştir"
+
+#: id:21390
+msgid "Power management level"
+msgstr "Güç yönetimi düzeyi"
+
+#: id:21391
+msgid "High power"
+msgstr "Yüksek güç"
+
+#: id:21392
+msgid "Low power"
+msgstr "Düşük güç"
+
+#: id:21393
+msgid "High standby"
+msgstr "Yüksek bekleme"
+
+#: id:21394
+msgid "Low standby"
+msgstr "Düşük bekleme"
+
+#: id:21395
+msgid "Unable to cache files bigger than 4GB"
+msgstr "4GB'den büyük dosyalar önbelleğe alınamıyor"
+
+#: id:21396
+msgid "Chapter"
+msgstr "Bölüm"
+
+#: id:21397
+msgid "High quality pixel shader v2"
+msgstr "Yüksek kalite piksel gölgeleme v2"
+
+#: id:21398
+msgid "Enable playlist at startup"
+msgstr "Çalma listesini başlangıçta etkinleştir"
+
+#: id:21399
+msgid "Use tween animations"
+msgstr "Ara animasyonları kullan"
+
+#: id:21400
+msgid "contains"
+msgstr "içeriyor"
+
+#: id:21401
+msgid "does not contain"
+msgstr "içermiyor"
+
+#: id:21402
+msgid "is"
+msgstr "-"
+
+#: id:21403
+msgid "is not"
+msgstr "-"
+
+#: id:21404
+msgid "starts with"
+msgstr "başlangıçta"
+
+#: id:21405
+msgid "ends with"
+msgstr "bitişte"
+
+#: id:21406
+msgid "greater than"
+msgstr "daha fazla"
+
+#: id:21407
+msgid "less than"
+msgstr "daha az"
+
+#: id:21408
+msgid "after"
+msgstr "sonra"
+
+#: id:21409
+msgid "before"
+msgstr "önce"
+
+#: id:21410
+msgid "in the last"
+msgstr "sonuncu"
+
+#: id:21411
+msgid "not in the last"
+msgstr "en sonuncu değil"
+
+#: id:21412
+msgid "Scrapers"
+msgstr "Scrapers"
+
+#: id:21413
+msgid "Default movie scraper"
+msgstr "Varsayılan film scraper"
+
+#: id:21414
+msgid "Default tvshow scraper"
+msgstr "Varsayılan tv programı scraper"
+
+#: id:21415
+msgid "Default music video scraper"
+msgstr "Varsayılan müzik video scraper"
+
+#: id:21416
+msgid "Enable fallback based on scraper language"
+msgstr "Scraper diline dayalı başvurmayı etkinleştir"
+
+#: id:21417
+msgid "- Settings"
+msgstr "- Ayarlar"
+
+#: id:21418
+msgid "Multilingual"
+msgstr "Çok dilli"
+
+#: id:21419
+msgid "No scrapers present"
+msgstr "Scraper mevcut değil"
+
+#: id:21420
+msgid "Value to match"
+msgstr "Değer eşleşmelidir"
+
+#: id:21421
+msgid "Smart playlist rule"
+msgstr "Akıllı çalma listesi talimatı"
+
+#: id:21422
+msgid "Match items where"
+msgstr "Eşleşen ögeler nerede"
+
+#: id:21423
+msgid "New rule..."
+msgstr "Yeni kural..."
+
+#: id:21424
+msgid "Items must match"
+msgstr "Ögeler eşleşmelidir"
+
+#: id:21425
+msgid "all of the rules"
+msgstr "tüm kurallar"
+
+#: id:21426
+msgid "one or more of the rules"
+msgstr "bir veya daha fazla kural"
+
+#: id:21427
+msgid "Limit to"
+msgstr "Sınırla"
+
+#: id:21428
+msgid "No limit"
+msgstr "Sınırsız"
+
+#: id:21429
+msgid "Order by"
+msgstr "Sırala"
+
+#: id:21430
+msgid "ascending"
+msgstr "artan"
+
+#: id:21431
+msgid "descending"
+msgstr "azalan"
+
+#: id:21432
+msgid "Edit smart playlist"
+msgstr "Akıllı çalma listesini düzenle"
+
+#: id:21433
+msgid "Name of the playlist"
+msgstr "Çalma listesinin adı"
+
+#: id:21434
+msgid "Find items where"
+msgstr "Ögeleri bulun"
+
+#: id:21435
+msgid "Edit"
+msgstr "Düzenle"
+
+#: id:21436
+msgid "%i items"
+msgstr "%i ögeleri"
+
+#: id:21437
+msgid "New smart playlist..."
+msgstr "Yeni akıllı çalma listesi..."
+
+#: id:21438
+msgid "%c Drive"
+msgstr "%c Sürücüsü"
+
+#: id:21439
+msgid "Edit party mode rules"
+msgstr "Parti modu kurallarını düzenle"
+
+#: id:21440
+msgid "Home folder"
+msgstr "Ana klasör"
+
+#: id:21441
+msgid "Watched count"
+msgstr "İzlenme sayısı"
+
+#: id:21442
+msgid "Episode title"
+msgstr "Bölüm başlığı"
+
+#: id:21443
+msgid "Video resolution"
+msgstr "Video çözünürlüğü"
+
+#: id:21444
+msgid "Audio channels"
+msgstr "Ses kanalları"
+
+#: id:21445
+msgid "Video codec"
+msgstr "Video codec"
+
+#: id:21446
+msgid "Audio codec"
+msgstr "Ses codec"
+
+#: id:21447
+msgid "Audio language"
+msgstr "Ses dili"
+
+#: id:21448
+msgid "Subtitle language"
+msgstr "Altyazı dili"
+
+#: id:21449
+msgid "Remote control sends keyboard presses"
+msgstr "Remote control sends keyboard presses"
+
+#: id:21450
+msgid "- Edit"
+msgstr "- Düzenle"
+
+#: id:21451
+msgid "Internet connection required."
+msgstr "İnternet bağlantısı gereklidir."
+
+#: id:21452
+msgid "Get More..."
+msgstr "Daha Fazla..."
+
+#: id:21453
+msgid "Root filesystem"
+msgstr "Kök dosya sistemi"
+
+#: id:21454
+msgid "Cache full"
+msgstr "Önbellek dolu"
+
+#: id:21455
+msgid "Cache filled before reaching required amount for continous playback"
+msgstr "Önbellek sürekli oynatma için gerekli miktara ulaşamadan doldu"
+
+#: id:21460
+msgid "Subtitle location"
+msgstr "Altyazı konumu"
+
+#: id:21461
+msgid "Fixed"
+msgstr "Sabit"
+
+#: id:21462
+msgid "Bottom of video"
+msgstr "Videonun en altında"
+
+#: id:21463
+msgid "Below video"
+msgstr "Videonun altında"
+
+#: id:21464
+msgid "Top of video"
+msgstr "Videonun en üstünde"
+
+#: id:21465
+msgid "Above video"
+msgstr "Videonun üstünde"
+
+#: id:21800
+msgid "File name"
+msgstr "Dosya adı"
+
+#: id:21801
+msgid "File path"
+msgstr "Dosya yolu"
+
+#: id:21802
+msgid "File size"
+msgstr "Dosya boyutu"
+
+#: id:21803
+msgid "File date/time"
+msgstr "Dosya tarih/zaman"
+
+#: id:21804
+msgid "Slide index"
+msgstr "Slayt içeriği"
+
+#: id:21805
+msgctxt "Auto context with id 21805"
+msgid "Resolution"
+msgstr "Çözünürlük"
+
+#: id:21806
+msgctxt "Auto context with id 21806"
+msgid "Comment"
+msgstr "Açıklama"
+
+#: id:21807
+msgid "Colour/B&W"
+msgstr "Renkli/B&W"
+
+#: id:21808
+msgid "JPEG process"
+msgstr "JPEG yöntemi"
+
+#: id:21820
+msgid "Date/Time"
+msgstr "Tarih/Saat"
+
+#: id:21821
+msgid "Description"
+msgstr "Açıklama"
+
+#: id:21822
+msgid "Camera make"
+msgstr "Kamera"
+
+#: id:21823
+msgid "Camera model"
+msgstr "Kamera modeli"
+
+#: id:21824
+msgid "EXIF comment"
+msgstr "EXIF açıklaması"
+
+#: id:21825
+msgid "Firmware"
+msgstr "Firmware"
+
+#: id:21826
+msgid "Aperture"
+msgstr "Diyafram"
+
+#: id:21827
+msgid "Focal length"
+msgstr "Odak uzaklığı"
+
+#: id:21828
+msgid "Focus distance"
+msgstr "Odak mesafesi"
+
+#: id:21829
+msgid "Exposure"
+msgstr "Pozlama"
+
+#: id:21830
+msgid "Exposure time"
+msgstr "Pozlama süresi"
+
+#: id:21831
+msgid "Exposure bias"
+msgstr "Pozlama sapması"
+
+#: id:21832
+msgid "Exposure mode"
+msgstr "Pozlama modu"
+
+#: id:21833
+msgid "Flash used"
+msgstr "Flaş kullanımı"
+
+#: id:21834
+msgid "White-balance"
+msgstr "Beyaz oranı"
+
+#: id:21835
+msgid "Light source"
+msgstr "Işık kaynağı"
+
+#: id:21836
+msgid "Metering mode"
+msgstr "Ölçüm modu"
+
+#: id:21837
+msgid "ISO"
+msgstr "ISO"
+
+#: id:21838
+msgid "Digital zoom"
+msgstr "Dijital yakınlaştırma"
+
+#: id:21839
+msgid "CCD width"
+msgstr "CCD genişliği"
+
+#: id:21840
+msgid "GPS latitude"
+msgstr "GPS enlem"
+
+#: id:21841
+msgid "GPS longitude"
+msgstr "GPS boylam"
+
+#: id:21842
+msgid "GPS altitude"
+msgstr "GPS rakım"
+
+#: id:21843
+msgid "Orientation"
+msgstr "Oryantasyon"
+
+#: id:21860
+msgid "Supplemental categories"
+msgstr "Ek sınıflandırmalar"
+
+#: id:21861
+msgid "Keywords"
+msgstr "Anahtar sözcük"
+
+#: id:21862
+msgid "Caption"
+msgstr "Başlık"
+
+#: id:21863
+msgid "Author"
+msgstr "Yazar"
+
+#: id:21864
+msgid "Headline"
+msgstr "Manşet"
+
+#: id:21865
+msgid "Special instructions"
+msgstr "Özel talimatlar"
+
+#: id:21866
+msgid "Category"
+msgstr "Kategori"
+
+#: id:21867
+msgid "Byline"
+msgstr "Byline"
+
+#: id:21868
+msgid "Byline title"
+msgstr "Byline title"
+
+#: id:21869
+msgid "Credit"
+msgstr "Jenerik"
+
+#: id:21870
+msgid "Source"
+msgstr "Kaynak"
+
+#: id:21871
+msgid "Copyright notice"
+msgstr "Telif Hakkı Uyarısı"
+
+#: id:21872
+msgid "Object name"
+msgstr "Nesne adı"
+
+#: id:21873
+msgid "City"
+msgstr "Şehir"
+
+#: id:21874
+msgid "State"
+msgstr "Eyalet"
+
+#: id:21875
+msgctxt "Auto context with id 21875"
+msgid "Country"
+msgstr "Ülke"
+
+#: id:21876
+msgid "Original Tx Reference"
+msgstr "Orijinal Tx Referansı"
+
+#: id:21877
+msgid "Date created"
+msgstr "Oluşturma tarihi"
+
+#: id:21878
+msgid "Copyright flag"
+msgstr "Telif hakkı"
+
+#: id:21879
+msgid "Country code"
+msgstr "Ülke kodu"
+
+#: id:21880
+msgid "Reference service"
+msgstr "Başvuru hizmeti"
+
+#: id:21881
+msgid "Allow control of XBMC via UPnP"
+msgstr "UPnP üzerinden XBMC kontrolüne izin ver"
+
+#: id:21882
+msgid "Attempt to skip introduction before DVD menu"
+msgstr "DVD menüsünden önceki tanıtımı geçmeyi dene"
+
+#: id:21883
+msgid "Saved music"
+msgstr "Kaydedilen müzik"
+
+#: id:21884
+msgid "Query info for all artists"
+msgstr "Bütün sanatçılar için bilgileri sorgula"
+
+#: id:21885
+msgid "Downloading album information"
+msgstr "Albüm bilgisi karşıdan yükleniyor"
+
+#: id:21886
+msgid "Downloading artist information"
+msgstr "Sanatçı bilgisi karşıdan yükleniyor"
+
+#: id:21887
+msgid "Biography"
+msgstr "Biyografi"
+
+#: id:21888
+msgid "Discography"
+msgstr "Diskografi"
+
+#: id:21889
+msgid "Searching artist"
+msgstr "Sanatçı aranıyor"
+
+#: id:21890
+msgid "Select artist"
+msgstr "Sanatçı seç"
+
+#: id:21891
+msgctxt "Auto context with id 21891"
+msgid "Artist information"
+msgstr "Sanatçı bilgisi"
+
+#: id:21892
+msgid "Instruments"
+msgstr "Enstrümanlar"
+
+#: id:21893
+msgid "Born"
+msgstr "Doğum"
+
+#: id:21894
+msgid "Formed"
+msgstr "Biçimlendirilmiş"
+
+#: id:21895
+msgid "Themes"
+msgstr "Temalar"
+
+#: id:21896
+msgid "Disbanded"
+msgstr "Dağılmış"
+
+#: id:21897
+msgid "Died"
+msgstr "Ölüm"
+
+#: id:21898
+msgid "Years active"
+msgstr "Etkin yıllar"
+
+#: id:21899
+msgid "Label"
+msgstr "Etiket"
+
+#: id:21900
+msgid "Born/Formed"
+msgstr "Doğum"
+
+#: id:22000
+msgid "Update library on startup"
+msgstr "Kitaplığı başlangıçta güncelle"
+
+#: id:22001
+msgid "Hide progress of library updates"
+msgstr "Kitaplık güncellemelerinin ilerleme durumunu gizle"
+
+#: id:22002
+msgid "- DNS suffix"
+msgstr "- DNS soneki"
+
+#: id:22003
+msgid "%2.3fs"
+msgstr "%2.3fs"
+
+#: id:22004
+msgid "Delayed by: %2.3fs"
+msgstr "Geriye :% 2.3fs"
+
+#: id:22005
+msgid "Ahead by: %2.3fs"
+msgstr "İleriye: %2.3fs"
+
+#: id:22006
+msgid "Subtitle offset"
+msgstr "Altyazı gecikmesi"
+
+#: id:22007
+msgid "OpenGL vendor:"
+msgstr "OpenGL üreticisi:"
+
+#: id:22008
+msgid "OpenGL renderer:"
+msgstr "OpenGL işleyicisi:"
+
+#: id:22009
+msgid "OpenGL version:"
+msgstr "OpenGL sürümü:"
+
+#: id:22010
+msgid "GPU temperature:"
+msgstr "GPU sıcaklığı:"
+
+#: id:22011
+msgid "CPU temperature:"
+msgstr "CPU sıcaklığı:"
+
+#: id:22012
+msgid "Total memory"
+msgstr "Toplam bellek"
+
+#: id:22013
+msgid "Profile data"
+msgstr "Profil verisi"
+
+#: id:22014
+msgid "Use dim if paused during video playback"
+msgstr "Video duraklatılırsa karartma efekti kullan"
+
+#: id:22015
+msgid "All recordings"
+msgstr "Bütün kayıtlar"
+
+#: id:22016
+msgid "By title"
+msgstr "Başlığa göre"
+
+#: id:22017
+msgid "By group"
+msgstr "Gruba göre"
+
+#: id:22018
+msgid "Live channels"
+msgstr "Canlı kanallar"
+
+#: id:22019
+msgid "Recordings by title"
+msgstr "Başlığa göre kayıtlar"
+
+#: id:22020
+msgid "Guide"
+msgstr "Rehber"
+
+#: id:22021
+msgid "Allowed error in aspect ratio to minimize black bars"
+msgstr "Siyah şeritleri azaltmak için izin verilen görüntü oranı hatası"
+
+#: id:22022
+msgid "Show video files in listings"
+msgstr "Listelerde video dosyalarını göster"
+
+#: id:22023
+msgid "DirectX vendor:"
+msgstr "DirectX üreticisi:"
+
+#: id:22024
+msgid "Direct3D version:"
+msgstr "Direct3D sürümü:"
+
+#: id:22030
+msgctxt "Auto context with id 22030"
+msgid "Font"
+msgstr "Yazı tipi"
+
+#: id:22031
+msgctxt "Auto context with id 22031"
+msgid "- Size"
+msgstr "- Boyut"
+
+#: id:22032
+msgctxt "Auto context with id 22032"
+msgid "- Colours"
+msgstr "- Renkler"
+
+#: id:22033
+msgid "- Charset"
+msgstr "- Karakter Tablosu"
+
+#: id:22034
+msgid "Export karaoke titles as HTML"
+msgstr "Karaoke başlıklarını HTML olarak dışa aktar"
+
+#: id:22035
+msgid "Export karaoke titles as CSV"
+msgstr "Karaoke başlıklarını CVS olarak dışa aktar"
+
+#: id:22036
+msgid "Import karaoke titles..."
+msgstr "Karaoke başlıklarını içe aktar..."
+
+#: id:22037
+msgid "Show song selector automatically"
+msgstr "Şarkı seçiciyi otomatik olarak göster"
+
+#: id:22038
+msgid "Export karaoke titles..."
+msgstr "Karaoke başlıklarını dışa aktar..."
+
+#: id:22039
+msgid "Enter song number"
+msgstr "Şarkı numarasını girin"
+
+#: id:22040
+msgid "white/green"
+msgstr "beyaz/yeşil"
+
+#: id:22041
+msgid "white/red"
+msgstr "beyaz/kırmızı"
+
+#: id:22042
+msgid "white/blue"
+msgstr "beyaz/mavi"
+
+#: id:22043
+msgid "black/white"
+msgstr "siyah/beyaz"
+
+#: id:22079
+msgid "Default select action"
+msgstr "Varsayılan seçme eylemi"
+
+#: id:22080
+msgid "Choose"
+msgstr "Seç"
+
+#: id:22081
+msgid "Show Information"
+msgstr "Bilgileri görüntüle"
+
+#: id:22082
+msgid "More..."
+msgstr "Daha fazla..."
+
+#: id:22083
+msgid "Play all"
+msgstr "Tümünü yürüt"
+
+#: id:23049
+msgid "Teletext not available"
+msgstr "Teletext mevcut değil"
+
+#: id:23050
+msgid "Activate Teletext"
+msgstr "Teletext'i Etkinleştir"
+
+#: id:23051
+msgid "Part %i"
+msgstr "Bölüm %i"
+
+#: id:23052
+msgid "Buffering %i bytes"
+msgstr "%i bayt arabelleğe alındı"
+
+#: id:23053
+msgid "Stopping"
+msgstr "Durduruluyor"
+
+#: id:23054
+msgid "Running"
+msgstr "Çalışıyor"
+
+#: id:23100
+msgid "External Player Active"
+msgstr "Harici Oynatıcı Etkin"
+
+#: id:23101
+msgid "Click OK to terminate the player"
+msgstr "Oynatıcıyı sonlandırmak için Tamam'a basın"
+
+#: id:23104
+msgid "Click OK when playback has ended"
+msgstr "Oynatma bitince Tamam'a basın"
+
+#: id:24000
+msgid "Add-on"
+msgstr "Eklenti"
+
+#: id:24001
+msgid "Add-ons"
+msgstr "Eklentiler"
+
+#: id:24002
+msgid "Add-on options"
+msgstr "Eklenti seçenekleri"
+
+#: id:24003
+msgid "Add-on Information"
+msgstr "Eklenti Bilgisi"
+
+#: id:24005
+msgctxt "Auto context with id 24005"
+msgid "Media sources"
+msgstr "Ortam kaynakları"
+
+#: id:24007
+msgctxt "Auto context with id 24007"
+msgid "Movie information"
+msgstr "Film bilgisi"
+
+#: id:24008
+msgctxt "Auto context with id 24008"
+msgid "Screensaver"
+msgstr "Ekran koruyucu"
+
+#: id:24009
+msgid "Script"
+msgstr "Betik"
+
+#: id:24010
+msgctxt "Auto context with id 24010"
+msgid "Visualization"
+msgstr "Görsel öğe"
+
+#: id:24011
+msgid "Add-on repository"
+msgstr "Eklenti deposu"
+
+#: id:24012
+msgctxt "Auto context with id 24012"
+msgid "Subtitles"
+msgstr "Altyazılar"
+
+#: id:24013
+msgid "Lyrics"
+msgstr "Şakı Sözleri"
+
+#: id:24014
+msgid "TV information"
+msgstr "TV bilgisi"
+
+#: id:24015
+msgctxt "Auto context with id 24015"
+msgid "Music video information"
+msgstr "Müzik videosu bilgisi"
+
+#: id:24016
+msgctxt "Auto context with id 24016"
+msgid "Album information"
+msgstr "Albüm bilgisi"
+
+#: id:24017
+msgctxt "Auto context with id 24017"
+msgid "Artist information"
+msgstr "Sanatçı bilgisi"
+
+#: id:24018
+msgctxt "Auto context with id 24018"
+msgid "Services"
+msgstr "Hizmetler"
+
+#: id:24020
+msgid "Configure"
+msgstr "Yapılandır"
+
+#: id:24021
+msgctxt "Auto context with id 24021"
+msgid "Disable"
+msgstr "Devre dışı bırak"
+
+#: id:24022
+msgid "Enable"
+msgstr "Etkinleştir"
+
+#: id:24023
+msgid "Add-on disabled"
+msgstr "Eklenti devre dışı"
+
+#: id:24027
+msgctxt "Auto context with id 24027"
+msgid "Weather"
+msgstr "Hava Durumu"
+
+#: id:24028
+msgid "Weather.com (standard)"
+msgstr "Weather.com (standart)"
+
+#: id:24030
+msgid "This Add-on can not be configured"
+msgstr "Bu eklenti yapılandırılamaz"
+
+#: id:24031
+msgid "Error loading settings"
+msgstr "Ayarlar yüklenirken hata oluştu"
+
+#: id:24032
+msgid "All Add-ons"
+msgstr "Tüm Eklentiler"
+
+#: id:24033
+msgid "Get Add-ons"
+msgstr "Eklentileri Al"
+
+#: id:24034
+msgid "Check for updates"
+msgstr "Güncelleştirmeleri denetle"
+
+#: id:24035
+msgid "Force refresh"
+msgstr "Yenileme işlemini zorla"
+
+#: id:24036
+msgid "Change log"
+msgstr "Değişim günlüğü"
+
+#: id:24037
+msgid "Uninstall"
+msgstr "Kaldır"
+
+#: id:24038
+msgid "Install"
+msgstr "Yükle"
+
+#: id:24039
+msgid "Disabled Add-ons"
+msgstr "Devre Dışı Bırakılan Eklentiler"
+
+#: id:24040
+msgid "(Clear the current setting)"
+msgstr "(Geçerli ayarı temizle)"
+
+#: id:24041
+msgid "Install from zip file"
+msgstr "Zip dosyasından yükle"
+
+#: id:24042
+msgid "Downloading %i%%"
+msgstr "Karşıdan yükleniyor %i%%"
+
+#: id:24043
+msgid "Available Updates"
+msgstr "Kullanılabilir Güncelleştirmeler"
+
+#: id:24044
+msgid "Dependencies not met"
+msgstr "Bağımlılıklar karşılanmadı"
+
+#: id:24045
+msgid "Add-on does not have the correct structure"
+msgstr "Eklenti doğru bir yapıya sahip değil"
+
+#: id:24046
+msgid "%s is used by the following installed add-on(s)"
+msgstr "%s yüklü eklenti(ler) tarafından kullanılıyor"
+
+#: id:24047
+msgid "This add-on cannot be uninstalled"
+msgstr "Bu eklenti kaldırılamaz"
+
+#: id:24048
+msgid "Rollback"
+msgstr "Geri alma"
+
+#: id:24050
+msgid "Available Add-ons"
+msgstr "Kullanılabilir Eklentiler"
+
+#: id:24051
+msgid "Version:"
+msgstr "Sürüm:"
+
+#: id:24052
+msgid "Disclaimer"
+msgstr "Yasal Uyarı"
+
+#: id:24053
+msgid "License:"
+msgstr "Lisans:"
+
+#: id:24054
+msgid "Changelog"
+msgstr "Değişim günlüğü"
+
+#: id:24059
+msgid "Would you like to enable this Add-on?"
+msgstr "Bu eklentiyi etkinleştirmek ister misiniz?"
+
+#: id:24060
+msgid "Would you like to disable this Add-on?"
+msgstr "Bu eklentiyi devre dışı bırakmak ister misiniz?"
+
+#: id:24061
+msgid "Add-on update available!"
+msgstr "Kullanılabilir eklenti güncelleştirmesi!"
+
+#: id:24062
+msgid "Enabled Add-ons"
+msgstr "Etkin Eklentiler"
+
+#: id:24063
+msgid "Auto update"
+msgstr "Otomatik güncelleştir"
+
+#: id:24064
+msgid "Add-on enabled"
+msgstr "Eklenti etkin"
+
+#: id:24065
+msgid "Add-on updated"
+msgstr "Eklenti güncelleştirildi"
+
+#: id:24066
+msgid "Cancel Add-on download?"
+msgstr "Karşıdan yüklenen eklenti iptal edilsin mi?"
+
+#: id:24067
+msgid "Currently downloading Add-ons"
+msgstr "Şu anda karşıdan yüklenen eklentiler"
+
+#: id:24068
+msgid "Update available"
+msgstr "Güncelleştirme var"
+
+#: id:24069
+msgid "Update"
+msgstr "Güncelleştir"
+
+#: id:24070
+msgid "Add-on could not be loaded."
+msgstr "Eklenti yüklenemedi."
+
+#: id:24071
+msgid "An unknown error has occurred."
+msgstr "Bilinmeyen bir hata oluştu."
+
+#: id:24072
+msgid "Settings required"
+msgstr "Ayarlar gerekli"
+
+#: id:24073
+msgid "Could not connect"
+msgstr "Bağlanılamadı"
+
+#: id:24074
+msgid "Needs to restart"
+msgstr "Yeniden başlatmak gerekiyor"
+
+#: id:24075
+msgctxt "Auto context with id 24075"
+msgid "Disable"
+msgstr "Devre dışı bırak"
+
+#: id:24076
+msgid "Add-on Required"
+msgstr "Eklenti Gerekli"
+
+#: id:24080
+msgid "Try to reconnect?"
+msgstr "Yeniden bağlanılsın mı?"
+
+#: id:24089
+msgid "Add-on restarts"
+msgstr "Eklenti yeniden başlatmaları"
+
+#: id:24090
+msgid "Lock Add-on manager"
+msgstr "Eklenti yöneticisini kilitle"
+
+#: id:24094
+msgid "(current)"
+msgstr "(geçerli)"
+
+#: id:24095
+msgid "(blacklisted)"
+msgstr "(kara listede)"
+
+#: id:24096
+msgid "Add-on has been marked as broken in repository."
+msgstr "Depodaki eklenti bozuk olarak işaretlenmiş."
+
+#: id:24097
+msgid "Would you like to disable it on your system?"
+msgstr "Sisteminizde devre dışı bırakmak ister misiniz?"
+
+#: id:24098
+msgid "Broken"
+msgstr "Bozuk"
+
+#: id:24099
+msgid "Would you like to switch to this skin?"
+msgstr "Bu dış görünüme geçmek ister misiniz?"
+
+#: id:24100
+msgid "To use this feature you must download an Add-on:"
+msgstr "Bu özelliği kullanabilmek için indirmeniz gereken eklenti:"
+
+#: id:24101
+msgid "Would you like to download this Add-on?"
+msgstr "Bu eklentiyi indirmek istiyor musunuz?"
+
+#: id:25000
+msgid "Notifications"
+msgstr "Bildirimler"
+
+#: id:29800
+msgid "Library Mode"
+msgstr "Kitaplık Modu"
+
+#: id:29801
+msgid "QWERTY keyboard"
+msgstr "QWERTY klavye"
+
+#: id:29802
+msgid "Passthrough Audio in use"
+msgstr "Passthrough Ses kullanımda"
+
+#: id:33001
+msgid "Trailer quality"
+msgstr "Fragman kalitesi"
+
+#: id:33002
+msgid "Stream"
+msgstr "Akış"
+
+#: id:33003
+msgid "Download"
+msgstr "İndir"
+
+#: id:33004
+msgid "Download & play"
+msgstr "İndir ve oynat"
+
+#: id:33005
+msgid "Download & save"
+msgstr "İndir ve kaydet"
+
+#: id:33006
+msgid "Today"
+msgstr "Bugün"
+
+#: id:33007
+msgid "Tomorrow"
+msgstr "Yarın"
+
+#: id:33008
+msgid "Saving"
+msgstr "Kaydediliyor"
+
+#: id:33009
+msgid "Copying"
+msgstr "Kopyalanıyor"
+
+#: id:33010
+msgid "Set download directory"
+msgstr "İndirme klasörünü ayarla"
+
+#: id:33011
+msgid "Search duration"
+msgstr "Arama süresi"
+
+#: id:33012
+msgid "Short"
+msgstr "Kısa"
+
+#: id:33013
+msgid "Long"
+msgstr "Uzun"
+
+#: id:33014
+msgid "Use DVD player instead of regular player"
+msgstr "Herzamanki oynatıcı yerine DVD oynatıcıyı kullan"
+
+#: id:33015
+msgid "Ask for download before playing video"
+msgstr "Videoyu oynatmadan önce indirmek için sor"
+
+#: id:33016
+msgid "Clips"
+msgstr "Klipler"
+
+#: id:33017
+msgid "Restart plugin to enable"
+msgstr "Etkinleştirmek için eklentiyi yeniden başlat"
+
+#: id:33018
+msgid "Tonight"
+msgstr "Bu Gece"
+
+#: id:33019
+msgid "Tomorrow Night"
+msgstr "Yarın Gece"
+
+#: id:33020
+msgid "Condition"
+msgstr "Durum"
+
+#: id:33021
+msgid "Precipitation"
+msgstr "Düşen Yağış"
+
+#: id:33022
+msgid "Precip"
+msgstr "Yağış"
+
+#: id:33023
+msgid "Humid"
+msgstr "Nemli"
+
+#: id:33024
+msgid "Feels"
+msgstr "Hissedilen"
+
+#: id:33025
+msgid "Observed"
+msgstr "Görünen"
+
+#: id:33026
+msgid "Departure from normal"
+msgstr "Departure from normal"
+
+#: id:33027
+msgid "Sunrise"
+msgstr "Gündoğumu"
+
+#: id:33028
+msgid "Sunset"
+msgstr "Günbatımı"
+
+#: id:33029
+msgid "Details"
+msgstr "Ayrıntılar"
+
+#: id:33030
+msgid "Outlook"
+msgstr "Outlook"
+
+#: id:33031
+msgid "Coverflow"
+msgstr "Coverflow"
+
+#: id:33032
+msgid "Translate text"
+msgstr "Metni tercüme et"
+
+#: id:33033
+msgid "Map list %s category"
+msgstr "%s kategorisinin harita listesi"
+
+#: id:33034
+msgid "36 Hour"
+msgstr "36 Saatlik"
+
+#: id:33035
+msgid "Maps"
+msgstr "Haritalar"
+
+#: id:33036
+msgid "Hourly"
+msgstr "Saatlik"
+
+#: id:33037
+msgid "Weekend"
+msgstr "Haftalık"
+
+#: id:33038
+msgid "%s day"
+msgstr "%s günlük"
+
+#: id:33049
+msgid "Alert"
+msgstr "Uyarı"
+
+#: id:33050
+msgid "Alerts"
+msgstr "Uyarılar"
+
+#: id:33051
+msgid "Choose Your"
+msgstr "Choose Your"
+
+#: id:33052
+msgid "Check"
+msgstr "Check"
+
+#: id:33053
+msgctxt "Auto context with id 33053"
+msgid "Configure the"
+msgstr "Configure the"
+
+#: id:33054
+msgid "Seasons"
+msgstr "Seasons"
+
+#: id:33055
+msgid "Use your"
+msgstr "Use your"
+
+#: id:33056
+msgid "Watch your"
+msgstr "Watch your"
+
+#: id:33057
+msgid "Listen to"
+msgstr "Listen to"
+
+#: id:33058
+msgid "View your"
+msgstr "View your"
+
+#: id:33059
+msgctxt "Auto context with id 33059"
+msgid "Configure the"
+msgstr "Configure the"
+
+#: id:33060
+msgid "Power"
+msgstr "Güç"
+
+#: id:33061
+msgid "Menu"
+msgstr "Menü"
+
+#: id:33062
+msgid "Play the"
+msgstr "Play the"
+
+#: id:33063
+msgid "Options"
+msgstr "Seçenekler"
+
+#: id:33065
+msgid "Editor"
+msgstr "Düzenleyici"
+
+#: id:33066
+msgid "About your"
+msgstr "About your"
+
+#: id:33067
+msgid "Star rating"
+msgstr "Yıldız derecelendirmesi"
+
+#: id:33068
+msgid "Background"
+msgstr "Arka Plan"
+
+#: id:33069
+msgid "Backgrounds"
+msgstr "Arka Planlar"
+
+#: id:33070
+msgid "Custom background"
+msgstr "Özel arka plan"
+
+#: id:33071
+msgid "Custom backgrounds"
+msgstr "Özel arka planlar"
+
+#: id:33072
+msgid "View Readme"
+msgstr "Benioku'yu görüntüle"
+
+#: id:33073
+msgid "View Changelog"
+msgstr "Değişiklikleri görüntüle"
+
+#: id:33074
+msgid "This version of %s requires an"
+msgstr "%s sürümünün çalışması için"
+
+#: id:33075
+msgid "XBMC revision of %s or greater to run."
+msgstr "%s veya daha büyük bir XBMC sürümü gerekli."
+
+#: id:33076
+msgid "Please update XBMC."
+msgstr "Lütfen XBMC'yi güncelleyin."
+
+#: id:33077
+msgid "No data found!"
+msgstr "Hiç veri bulunamadı!"
+
+#: id:33078
+msgid "Next page"
+msgstr "Sonraki sayfa"
+
+#: id:33079
+msgid "Love"
+msgstr "Aşk"
+
+#: id:33080
+msgid "Hate"
+msgstr "Nefret"
+
+#: id:33081
+msgid "This file is stacked, select the part you want to play from."
+msgstr "Bu dosya yığınlandı, oynatmak istediğiniz bölümü seçin."
+
+#: id:33082
+msgid "Path to script"
+msgstr "Betik yolu"
+
+#: id:33083
+msgid "Enable custom script button"
+msgstr "Özel betik tuşunu etkinleştir"
+
+#: id:33100
+msgid "Failed to start"
+msgstr "Başlatılamadı"
+
+#: id:33101
+msgid "Webserver"
+msgstr "Web Sunucusu"
+
+#: id:33102
+msgid "Event Server"
+msgstr "Olay Sunucusu"
+
+#: id:33103
+msgid "Remote communication server"
+msgstr "Uzak iletişim sunucusu"
+
+#: id:33200
+msgid "Detected New Connection"
+msgstr "Yeni Bağlantı Algılandı"
+
+#: id:34000
+msgid "Lame"
+msgstr "Lame"
+
+#: id:34001
+msgid "Vorbis"
+msgstr "Vorbis"
+
+#: id:34002
+msgid "Wav"
+msgstr "Wav"
+
+#: id:34003
+msgid "DXVA2"
+msgstr "DXVA2"
+
+#: id:34004
+msgid "VAAPI"
+msgstr "VAAPI"
+
+#: id:34005
+msgid "Flac"
+msgstr "Flac"
+
+#: id:34100
+msgid "Speaker Configuration"
+msgstr "Hoparlör Yapılandırma"
+
+#: id:34101
+msgid "2.0"
+msgstr "2.0"
+
+#: id:34102
+msgid "2.1"
+msgstr "2.1"
+
+#: id:34103
+msgid "3.0"
+msgstr "3.0"
+
+#: id:34104
+msgid "3.1"
+msgstr "3.1"
+
+#: id:34105
+msgid "4.0"
+msgstr "4.0"
+
+#: id:34106
+msgid "4.1"
+msgstr "4.1"
+
+#: id:34107
+msgid "5.0"
+msgstr "5.0"
+
+#: id:34108
+msgid "5.1"
+msgstr "5.1"
+
+#: id:34109
+msgid "7.0"
+msgstr "7.0"
+
+#: id:34110
+msgid "7.1"
+msgstr "7.1"
+
+#: id:34201
+msgid "Can't find a next item to play"
+msgstr "Çalınacak sonraki öğeyi bulamıyor"
+
+#: id:34202
+msgid "Can't find a previous item to play"
+msgstr "Çalınacak önceki öğeyi bulamıyor"
+
+#: id:34300
+msgid "Failed to start zeroconf"
+msgstr "Zeroconf başlatılamadı"
+
+#: id:34301
+msgid "Is Apple's Bonjour Service installed? See log for more info."
+msgstr "Apple'ın Bonjour Hizmeti yüklü mü? Daha fazla bilgi için hata ayıklama çıktısına bakın."
+
+#: id:34400
+msgid "Video Rendering"
+msgstr "Video İşleme"
+
+#: id:34401
+msgid "Failed to init video filters/scalers, falling back to bilinear scaling"
+msgstr "Video filtreleri/ölçekleyiciler başlatılamadı, bilinear ölçeklendirmeye dönülüyor"
+
+#: id:34402
+msgid "Failed to initialize audio device"
+msgstr "Ses aygıtı başlatılamadı"
+
+#: id:34403
+msgid "Check your audiosettings"
+msgstr "Ses ayarlarınızı denetleyin"
+
+#: id:34404
+msgid "Use gestures for navigation:"
+msgstr ""
+
+#: id:34405
+msgid "1 finger swipe left,right,up,down for cursors"
+msgstr ""
+
+#: id:34406
+msgid "2 finger swipe left for backspace"
+msgstr ""
+
+#: id:34407
+msgid "1 finger single tap for enter"
+msgstr ""
+
+#: id:34408
+msgid "2 finger single tap for contextmenu"
+msgstr ""
+
+#: id:35000
+msgid "Peripherals"
+msgstr "Çevre birimleri"
+
+#: id:35001
+msgid "Generic HID device"
+msgstr "Genel HID aygıtı"
+
+#: id:35002
+msgid "Generic network adapter"
+msgstr "Genel ağ bağdaştırıcısı"
+
+#: id:35003
+msgid "Generic disk"
+msgstr "Genel disk"
+
+#: id:35004
+msgid "There are no settings available\nfor this peripheral."
+msgstr "Bu çevre birimi için ayar mevcut değil."
+
+#: id:35005
+msgid "New device configured"
+msgstr "Yani aygıt yapılandırıldı"
+
+#: id:35006
+msgid "Device removed"
+msgstr "Aygıt kaldırıldı"
+
+#: id:35007
+msgid "Keymap to use for this device"
+msgstr "Bu aygıt için kullanılacak keymap"
+
+#: id:35008
+msgid "Keymap enabled"
+msgstr "Keymap etkin"
+
+#: id:35009
+msgid "Do not use the custom keymap for this device"
+msgstr "Bu aygıt için özel keymap kullanma"
+
+#: id:35500
+msgid "Location"
+msgstr "Konum"
+
+#: id:35501
+msgid "Class"
+msgstr "Sınıf"
+
+#: id:35502
+msgctxt "Auto context with id 35502"
+msgid "Name"
+msgstr "Adı"
+
+#: id:35503
+msgid "Vendor"
+msgstr "Satıcı"
+
+#: id:35504
+msgid "Product ID"
+msgstr "Ürün Kimliği"
+
+#: id:36000
+msgid "Pulse-Eight CEC adapter"
+msgstr "Pulse-Eight CEC bağdaştırıcısı"
+
+#: id:36001
+msgid "Pulse-Eight Nyxboard"
+msgstr "Pulse-Eight Nyxboard"
+
+#: id:36002
+msgid "Switch to keyboard side command"
+msgstr "Switch to keyboard side command"
+
+#: id:36003
+msgid "Switch to remote side command"
+msgstr "Switch to remote side command"
+
+#: id:36004
+msgid "Press \"user\" button command"
+msgstr "Press \"user\" button command"
+
+#: id:36005
+msgid "Enable switch side commands"
+msgstr "Enable switch side commands"
+
+#: id:36006
+msgid "Could not open the adapter"
+msgstr "Bağdaştırıcı açılamıyor"
+
+#: id:36007
+msgid "Devices to power on when starting XBMC"
+msgstr "XBMC başlatılınca aygıtları aç"
+
+#: id:36008
+msgid "Devices to power off when stopping XBMC"
+msgstr "XBMC durdurulunca aygıtları kapat"
+
+#: id:36009
+msgid "Put devices in standby mode when activating screensaver"
+msgstr "Ekran koruyucu devreye girince aygıtı bekleme moduna geçir"
+
+#: id:36011
+msgid "Could not detect the CEC port. Set it up manually."
+msgstr "CEC portu algılanamadı. El ile ayarla."
+
+#: id:36012
+msgid "Could not initialise the CEC adapter. Check your settings."
+msgstr "CEC bağdaştırıcısı algılanamadı."
+
+#: id:36013
+msgid "Unsupported libCEC interface version. %d is greater than the version XBMC supports (%d)"
+msgstr "Desteklenmeyen libcec arabirim sürümü. %d is greater than the version XBMC supports (%d)"
+
+#: id:36014
+msgid "Put this PC in standby mode when the TV is switched off"
+msgstr "Televizyon kapatılınca bilgisayarı bekleme moduna geçir"
+
+#: id:36015
+msgid "HDMI port number"
+msgstr "HDMI port numarası"
+
+#: id:36016
+msgctxt "Auto context with id 36016"
+msgid "Connected"
+msgstr "Bağlandı"
+
+#: id:36017
+msgid "Adapter found, but libCEC is not available"
+msgstr "Bağdaştırıcı bulundu, fakat libcec kullanılamıyor"
+
+#: id:36018
+msgid "Use the TV's language setting"
+msgstr "Televizyonun dil ayarlarını kullan"
+
+#: id:36019
+msgid "Connected to HDMI device"
+msgstr "HDMI aygıtına bağlandı"
+
+#: id:36020
+msgid "Make XBMC the active source when starting"
+msgstr "Başlatırken XBMC aktif kaynak olsun"
+
+#: id:36021
+msgid "Physical address (overrules HDMI port)"
+msgstr "Fiziksel adres (overrules HDMI port)"
+
+#: id:36022
+msgid "COM port (leave empty unless needed)"
+msgstr "COM port (gerekmedikçe boş bırakın)"
+
+#: id:36023
+msgid "Configuration updated"
+msgstr "Yapılandırma güncellendi"
+
+#: id:36024
+msgid "Failed to set the new configuration. Please check your settings."
+msgstr "Yeni yapılandırma değeri ayarlanamadı. Lütfen ayarlarınızı kontrol edin."
+
+#: id:36025
+msgid "Send 'inactive source' command when stopping XBMC"
+msgstr "XBMC durdurulunca 'etkin olmayan kaynak' komutu yolla"
+

--- a/language/Ukrainian/strings.po
+++ b/language/Ukrainian/strings.po
@@ -1,0 +1,9093 @@
+# Converted from xbmc strings.xml with xbmc-xml2po (by Team-XBMC)
+msgid ""
+msgstr ""
+"Project-Id-Version: xbmc.core-FRODO_GIT3ed1604ad7\n"
+"Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
+"POT-Creation-Date: 2012-04-09 18:00+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE\n"
+"Language: uk\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: id:0
+msgctxt "Auto context with id 0"
+msgid "Programs"
+msgstr "Програми"
+
+#: id:1
+msgctxt "Auto context with id 1"
+msgid "Pictures"
+msgstr "Фотографії"
+
+#: id:2
+msgctxt "Auto context with id 2"
+msgid "Music"
+msgstr "Музика"
+
+#: id:3
+msgctxt "Auto context with id 3"
+msgid "Videos"
+msgstr "Відео"
+
+#: id:4
+msgid "TV-Guide"
+msgstr "Гід ТБ"
+
+#: id:5
+msgctxt "Auto context with id 5"
+msgid "Settings"
+msgstr "Налаштування"
+
+#: id:6
+msgid "XBMC SVN"
+msgstr ""
+
+#: id:7
+msgctxt "Auto context with id 7"
+msgid "File manager"
+msgstr "Менеджер файлів"
+
+#: id:8
+msgctxt "Auto context with id 8"
+msgid "Weather"
+msgstr "Погода"
+
+#: id:9
+msgid "xbmc media center"
+msgstr "XBMC медіа центр"
+
+#: id:11
+msgid "Monday"
+msgstr "Понеділок"
+
+#: id:12
+msgid "Tuesday"
+msgstr "Вівторок"
+
+#: id:13
+msgid "Wednesday"
+msgstr "Середа"
+
+#: id:14
+msgid "Thursday"
+msgstr "Четвер"
+
+#: id:15
+msgid "Friday"
+msgstr "П'ятниця"
+
+#: id:16
+msgid "Saturday"
+msgstr "Субота"
+
+#: id:17
+msgid "Sunday"
+msgstr "Неділя"
+
+#: id:21
+msgid "January"
+msgstr "січня"
+
+#: id:22
+msgid "February"
+msgstr "лютого"
+
+#: id:23
+msgid "March"
+msgstr "березня"
+
+#: id:24
+msgid "April"
+msgstr "квітня"
+
+#: id:25
+msgctxt "Auto context with id 25"
+msgid "May"
+msgstr "травня"
+
+#: id:26
+msgid "June"
+msgstr "червня"
+
+#: id:27
+msgid "July"
+msgstr "липня"
+
+#: id:28
+msgid "August"
+msgstr "серпня"
+
+#: id:29
+msgid "September"
+msgstr "вересня"
+
+#: id:30
+msgid "October"
+msgstr "жовтня"
+
+#: id:31
+msgid "November"
+msgstr "листопада"
+
+#: id:32
+msgid "December"
+msgstr "грудня"
+
+#: id:41
+msgid "Mon"
+msgstr "Пн"
+
+#: id:42
+msgid "Tue"
+msgstr "Вт"
+
+#: id:43
+msgid "Wed"
+msgstr "Ср"
+
+#: id:44
+msgid "Thu"
+msgstr "Чт"
+
+#: id:45
+msgid "Fri"
+msgstr "Пт"
+
+#: id:46
+msgid "Sat"
+msgstr "Сб"
+
+#: id:47
+msgctxt "Auto context with id 47"
+msgid "Sun"
+msgstr "Нд"
+
+#: id:51
+msgid "Jan"
+msgstr "Січ"
+
+#: id:52
+msgid "Feb"
+msgstr "Лют"
+
+#: id:53
+msgid "Mar"
+msgstr "Бер"
+
+#: id:54
+msgid "Apr"
+msgstr "Квт"
+
+#: id:55
+msgctxt "Auto context with id 55"
+msgid "May"
+msgstr "Тра"
+
+#: id:56
+msgid "Jun"
+msgstr "Чер"
+
+#: id:57
+msgid "Jul"
+msgstr "Лип"
+
+#: id:58
+msgid "Aug"
+msgstr "Срп"
+
+#: id:59
+msgid "Sep"
+msgstr "Вер"
+
+#: id:60
+msgid "Oct"
+msgstr "Жов"
+
+#: id:61
+msgid "Nov"
+msgstr "Лст"
+
+#: id:62
+msgid "Dec"
+msgstr "Гру"
+
+#: id:71
+msgid "N"
+msgstr "Пн"
+
+#: id:72
+msgid "NNE"
+msgstr "ПнПнСх"
+
+#: id:73
+msgid "NE"
+msgstr "ПнСх"
+
+#: id:74
+msgid "ENE"
+msgstr "СхПнСх"
+
+#: id:75
+msgid "E"
+msgstr "Сх"
+
+#: id:76
+msgid "ESE"
+msgstr "СхПдСх"
+
+#: id:77
+msgid "SE"
+msgstr "ПдСх"
+
+#: id:78
+msgid "SSE"
+msgstr "ПдПдСх"
+
+#: id:79
+msgid "S"
+msgstr "Пд"
+
+#: id:80
+msgid "SSW"
+msgstr "ПдПдЗах"
+
+#: id:81
+msgid "SW"
+msgstr "ПдЗах"
+
+#: id:82
+msgid "WSW"
+msgstr "ЗахПдЗах"
+
+#: id:83
+msgid "W"
+msgstr "Зах"
+
+#: id:84
+msgid "WNW"
+msgstr "ЗахПнЗах"
+
+#: id:85
+msgid "NW"
+msgstr "ПнЗах"
+
+#: id:86
+msgid "NNW"
+msgstr "ПнПнЗах"
+
+#: id:87
+msgid "VAR"
+msgstr ""
+
+#: id:98
+msgid "View: Auto"
+msgstr "Вигляд: Авто."
+
+#: id:99
+msgid "View: Auto big"
+msgstr "Вигляд: Авто. Велик"
+
+#: id:100
+msgid "View: Icons"
+msgstr "Вигляд: Значки"
+
+#: id:101
+msgid "View: List"
+msgstr "Вигляд: Список"
+
+#: id:102
+msgctxt "Auto context with id 102"
+msgid "Scan"
+msgstr "Сканувати"
+
+#: id:103
+msgctxt "Auto context with id 103"
+msgid "Sort by: Name"
+msgstr "Сорт.по: Назві"
+
+#: id:104
+msgid "Sort by: Date"
+msgstr "Сорт.по: Даті"
+
+#: id:105
+msgid "Sort by: Size"
+msgstr "Сорт.по: Розміру"
+
+#: id:106
+msgid "No"
+msgstr "Ні"
+
+#: id:107
+msgid "Yes"
+msgstr "Так"
+
+#: id:108
+msgctxt "Auto context with id 108"
+msgid "Slideshow"
+msgstr "Слайдшоу"
+
+#: id:109
+msgid "Create thumbs"
+msgstr "Створити ескізи"
+
+#: id:110
+msgid "Create thumbnails"
+msgstr "Створити ескізи"
+
+#: id:111
+msgctxt "Auto context with id 111"
+msgid "Shortcuts"
+msgstr "Ярлики"
+
+#: id:112
+msgid "Paused"
+msgstr "ПАУЗА"
+
+#: id:113
+msgid "Update failed"
+msgstr "Помилка поновлення"
+
+#: id:114
+msgid "Installation failed"
+msgstr "Помилка встановлення"
+
+#: id:115
+msgid "Copy"
+msgstr "Копіювати"
+
+#: id:116
+msgid "Move"
+msgstr "Перемістити"
+
+#: id:117
+msgid "Delete"
+msgstr "Видалити"
+
+#: id:118
+msgid "Rename"
+msgstr "Змінити назву"
+
+#: id:119
+msgid "New folder"
+msgstr "Нова папка"
+
+#: id:120
+msgid "Confirm file copy"
+msgstr "Підтвердження копіювання"
+
+#: id:121
+msgid "Confirm file move"
+msgstr "Підтвердження переміщення"
+
+#: id:122
+msgid "Confirm file delete?"
+msgstr "Підтверджуєте видалення?"
+
+#: id:123
+msgid "Copy these files?"
+msgstr "Копіювати файли?"
+
+#: id:124
+msgid "Move these files?"
+msgstr "Перемістити файли?"
+
+#: id:125
+msgid "Delete these files? - Deleting files cannot be undone!"
+msgstr "Видалити ці файли? Повернути їх буде неможливо."
+
+#: id:126
+msgid "Status"
+msgstr "Статус"
+
+#: id:127
+msgid "Objects"
+msgstr "Об'єкт(ів)"
+
+#: id:128
+msgctxt "Auto context with id 128"
+msgid "General"
+msgstr "Головні"
+
+#: id:129
+msgctxt "Auto context with id 129"
+msgid "Slideshow"
+msgstr "Слайдшоу"
+
+#: id:130
+msgctxt "Auto context with id 130"
+msgid "System info"
+msgstr "Інформація про систему"
+
+#: id:131
+msgid "Display"
+msgstr "Екран"
+
+#: id:132
+msgid "Albums"
+msgstr "Альбоми"
+
+#: id:133
+msgid "Artists"
+msgstr "Виконавці"
+
+#: id:134
+msgid "Songs"
+msgstr "Пісні"
+
+#: id:135
+msgid "Genres"
+msgstr "Жанри"
+
+#: id:136
+msgid "Playlists"
+msgstr "Плейлисти"
+
+#: id:137
+msgid "Search"
+msgstr "Пошук"
+
+#: id:138
+msgid "System Information"
+msgstr "Інформація про систему"
+
+#: id:139
+msgid "Temperatures:"
+msgstr "Температура:"
+
+#: id:140
+msgid "CPU:"
+msgstr "CPU:"
+
+#: id:141
+msgid "GPU:"
+msgstr "GPU:"
+
+#: id:142
+msgid "Time:"
+msgstr "Час:"
+
+#: id:143
+msgid "Current:"
+msgstr "Зараз:"
+
+#: id:144
+msgid "Build:"
+msgstr "Версія:"
+
+#: id:145
+msgid "Network:"
+msgstr "Мережа:"
+
+#: id:146
+msgid "Type:"
+msgstr "Тип:"
+
+#: id:147
+msgid "Static"
+msgstr "Статичний"
+
+#: id:148
+msgid "DHCP"
+msgstr "DHCP"
+
+#: id:149
+msgid "MAC address"
+msgstr "MAC-адреса"
+
+#: id:150
+msgctxt "Auto context with id 150"
+msgid "IP address"
+msgstr "IP-адреса"
+
+#: id:151
+msgid "Link:"
+msgstr "З'єднання:"
+
+#: id:152
+msgid "Half duplex"
+msgstr "Напівдуплекс"
+
+#: id:153
+msgid "Full duplex"
+msgstr "Повний дуплекс"
+
+#: id:154
+msgctxt "Auto context with id 154"
+msgid "Storage"
+msgstr "Диски"
+
+#: id:155
+msgid "Drive"
+msgstr "лоток DVD приводу"
+
+#: id:156
+msgctxt "Auto context with id 156"
+msgid "Free"
+msgstr "Вільно"
+
+#: id:157
+msgctxt "Auto context with id 157"
+msgid "Video"
+msgstr "Відео"
+
+#: id:158
+msgid "Free memory"
+msgstr "Вільно пам'яті"
+
+#: id:159
+msgid "No link"
+msgstr "Немає з'еднання"
+
+#: id:160
+msgctxt "Auto context with id 160"
+msgid "Free"
+msgstr "вільно"
+
+#: id:161
+msgid "Unavailable"
+msgstr "Недоступно"
+
+#: id:162
+msgid "Tray open"
+msgstr "Лоток відкритий"
+
+#: id:163
+msgid "Reading"
+msgstr "Зчитування"
+
+#: id:164
+msgid "No disc"
+msgstr "Диск відсутній"
+
+#: id:165
+msgid "Disc present"
+msgstr "Диск присутній"
+
+#: id:166
+msgid "Skin"
+msgstr "Оформлення"
+
+#: id:169
+msgctxt "Auto context with id 169"
+msgid "Resolution"
+msgstr "Роздільна здатність екрану"
+
+#: id:170
+msgid "Adjust display refresh rate to match video"
+msgstr "Налаштувати частоту екрану"
+
+#: id:172
+msgid "Release date"
+msgstr "Дата випуску"
+
+#: id:173
+msgid "Display 4:3 videos as"
+msgstr "Показувати 4:3 відео як"
+
+#: id:175
+msgid "Moods"
+msgstr "Настрій"
+
+#: id:176
+msgid "Styles"
+msgstr "Стилі"
+
+#: id:179
+msgid "Song"
+msgstr "Пісня"
+
+#: id:180
+msgid "Duration"
+msgstr "Тривалість"
+
+#: id:181
+msgid "Select album"
+msgstr "Виберіть альбом"
+
+#: id:182
+msgid "Tracks"
+msgstr "Треки"
+
+#: id:183
+msgid "Review"
+msgstr "Огляд"
+
+#: id:184
+msgid "Refresh"
+msgstr "Оновити"
+
+#: id:185
+msgid "Searching album"
+msgstr "Пошук альбому"
+
+#: id:186
+msgid "OK"
+msgstr "Так"
+
+#: id:187
+msgid "No albums found!"
+msgstr "Альбомів не знайдено!"
+
+#: id:188
+msgid "Select all"
+msgstr "Вибрати все"
+
+#: id:189
+msgid "Scanning media info"
+msgstr "Сканування інформації"
+
+#: id:190
+msgid "Save"
+msgstr "Зберегти"
+
+#: id:191
+msgid "Shuffle"
+msgstr "Перемішати"
+
+#: id:192
+msgctxt "Auto context with id 192"
+msgid "Clear"
+msgstr "Очистити"
+
+#: id:193
+msgctxt "Auto context with id 193"
+msgid "Scan"
+msgstr "Сканувати"
+
+#: id:194
+msgid "Searching..."
+msgstr "Пошук..."
+
+#: id:195
+msgid "No info found!"
+msgstr "Інформації не знайдено!"
+
+#: id:196
+msgid "Select movie:"
+msgstr "Виберіть фільм:"
+
+#: id:197
+msgid "Querying %s info"
+msgstr "Запит інформації з %s"
+
+#: id:198
+msgid "Loading movie details"
+msgstr "Завантаження інформації про фільм"
+
+#: id:199
+msgid "Web interface"
+msgstr "Web інтерфейс"
+
+#: id:202
+msgid "Tagline"
+msgstr "Девіз"
+
+#: id:203
+msgid "Plot outline"
+msgstr "Сюжет"
+
+#: id:205
+msgid "Votes"
+msgstr "Голосів"
+
+#: id:206
+msgid "Cast"
+msgstr "Актори"
+
+#: id:207
+msgid "Plot"
+msgstr "Сюжет"
+
+#: id:208
+msgctxt "Auto context with id 208"
+msgid "Play"
+msgstr "Програти"
+
+#: id:209
+msgid "Next"
+msgstr "Наступний"
+
+#: id:210
+msgid "Previous"
+msgstr "Попередній"
+
+#: id:213
+msgid "Calibrate user interface..."
+msgstr "Калібрування інтерфейсу..."
+
+#: id:214
+msgid "Video calibration..."
+msgstr "Калібрування екрану..."
+
+#: id:215
+msgid "Soften"
+msgstr "Згладжування"
+
+#: id:216
+msgid "Zoom amount"
+msgstr "Ступінь збільшення"
+
+#: id:217
+msgid "Pixel ratio"
+msgstr "Співвідношення сторін"
+
+#: id:218
+msgid "DVD drive"
+msgstr "DVD-привід"
+
+#: id:219
+msgid "Please insert disc"
+msgstr "Вставте диск, будь ласка"
+
+#: id:220
+msgid "Remote share"
+msgstr "Зовнішній ресурс"
+
+#: id:221
+msgid "Network is not connected"
+msgstr "Немає підключення до мережі"
+
+#: id:222
+msgid "Cancel"
+msgstr "Відмінити"
+
+#: id:224
+msgid "Speed"
+msgstr "Тривалість показу слайда"
+
+#: id:225
+msgid "Vertical Shift"
+msgstr ""
+
+#: id:226
+msgid "Test patterns..."
+msgstr "Тестові шаблони..."
+
+#: id:227
+msgid "Lookup audio CD track names from freedb.org"
+msgstr "Шукати інформацію про аудіо CD в Internet"
+
+#: id:228
+msgid "Shuffle playlist on load"
+msgstr "Перемішати плейлист при завантаженні"
+
+#: id:229
+msgid "HDD spindown time"
+msgstr "Зупиняти HDD через (хв)"
+
+#: id:230
+msgid "Video filters"
+msgstr "Відео-фільтри"
+
+#: id:231
+msgctxt "Auto context with id 231"
+msgid "None"
+msgstr "Пусто"
+
+#: id:232
+msgid "Point"
+msgstr "Крапка"
+
+#: id:233
+msgid "Linear"
+msgstr "Лінійний"
+
+#: id:234
+msgid "Anisotropic"
+msgstr "Анізотропний"
+
+#: id:235
+msgid "Quincunx"
+msgstr "Шаховий"
+
+#: id:236
+msgid "Gaussian cubic"
+msgstr "Кубічний по Гауссу"
+
+#: id:237
+msgid "Minification"
+msgstr "Зменшення"
+
+#: id:238
+msgid "Magnification"
+msgstr "Збільшення"
+
+#: id:239
+msgid "Clear playlist on finish"
+msgstr "Очистити плейлист після програвання"
+
+#: id:240
+msgid "Display Mode"
+msgstr "Автопрогравання DVD-Video диска"
+
+#: id:241
+msgid "Full Screen #%d"
+msgstr "На весь екран #%d"
+
+#: id:242
+msgid "Windowed"
+msgstr "У вікні"
+
+#: id:243
+msgid "Refresh Rate"
+msgstr "Частота поновлення екрану"
+
+#: id:244
+msgid "Full screen"
+msgstr "На весь екран"
+
+#: id:245
+msgid "Sizing: (%i,%i)->(%i,%i) (Zoom x%2.2f) AR:%2.2f:1 (Pixels: %2.2f:1) (VShift: %2.2f)"
+msgstr "Масштабування: (%i,%i)->(%i,%i) (Збільш. x%2.2f) Співвідн.:%2.2f:1 (Пікс.: %2.2f:1)"
+
+#: id:247
+msgctxt "Auto context with id 247"
+msgid "Scripts"
+msgstr "Скрипти"
+
+#: id:248
+msgctxt "Auto context with id 248"
+msgid "Language"
+msgstr "Мова"
+
+#: id:249
+msgctxt "Auto context with id 249"
+msgid "Music"
+msgstr "Музика"
+
+#: id:250
+msgctxt "Auto context with id 250"
+msgid "Visualization"
+msgstr "Відео-ефекти"
+
+#: id:251
+msgid "Select destination directory"
+msgstr "Виберіть папку призначення"
+
+#: id:252
+msgid "Output stereo to all speakers"
+msgstr "Виводити стерео на всі динаміки"
+
+#: id:253
+msgid "Number of channels"
+msgstr "Кількість каналів"
+
+#: id:254
+msgid "- DTS capable receiver"
+msgstr "- виводити звук в форматі DTS®"
+
+#: id:255
+msgid "CDDB"
+msgstr ""
+
+#: id:256
+msgid "Fetching CD information"
+msgstr "Запит інформації про CD"
+
+#: id:257
+msgid "Error"
+msgstr "Помилка"
+
+#: id:258
+msgid "Enable tag reading"
+msgstr "Читати інформацію з тегів"
+
+#: id:259
+msgid "Opening"
+msgstr "Відкриття"
+
+#: id:260
+msgid "Shoutcast"
+msgstr ""
+
+#: id:261
+msgid "Waiting for start..."
+msgstr "Очікування старту..."
+
+#: id:262
+msgid "Scripts output"
+msgstr "Лог роботи скриптів"
+
+#: id:263
+msgid "Allow control of XBMC via HTTP"
+msgstr "Дозволити керування XBMC через HTTP"
+
+#: id:264
+msgid "Record"
+msgstr "Запис"
+
+#: id:265
+msgid "Stop Rec."
+msgstr "Зупинити запис"
+
+#: id:266
+msgid "Sort by: Track"
+msgstr "Сорт.по: Треку"
+
+#: id:267
+msgid "Sort by: Time"
+msgstr "Сорт.по: Часу"
+
+#: id:268
+msgid "Sort by: Title"
+msgstr "Сорт.по: Назві"
+
+#: id:269
+msgid "Sort by: Artist"
+msgstr "Сорт.по: Виконавцю"
+
+#: id:270
+msgid "Sort by: Album"
+msgstr "Сорт.по: Альбму"
+
+#: id:271
+msgid "Top 100"
+msgstr "Топ 100"
+
+#: id:272
+msgid "Top-Left overscan compensation"
+msgstr "Налаштування розмірів екрана (лівий верхній кут)"
+
+#: id:273
+msgid "Bottom-Right overscan compensation"
+msgstr "Налаштування розмірів екрана (правий нижній кут)"
+
+#: id:274
+msgid "Subtitle positioning"
+msgstr "Позиція субтитрів"
+
+#: id:275
+msgid "Pixel ratio adjustment"
+msgstr "Регулювання співвідношення висоти і ширини"
+
+#: id:276
+msgid "Adjust the arrow to change the amount of overscan"
+msgstr "Рухайте стрілки для регулювання розмірів екрана"
+
+#: id:277
+msgid "Adjust the bar to change the subtitles position"
+msgstr "Рухайте смужку щоб змінити позицію субтитрів"
+
+#: id:278
+msgid "Adjust the rectangle so it is perfectly square"
+msgstr "Змінюйте прямокутник так, щоб він став ідеальним квадратом"
+
+#: id:279
+msgid "Unable to load settings"
+msgstr "Неможливо завантажити налаштування"
+
+#: id:280
+msgid "Using default settings"
+msgstr "Використання стандартних налаштувань"
+
+#: id:281
+msgid "Please check the XML files"
+msgstr "Будь ласка, перевірте XML файли"
+
+#: id:282
+msgid "Found %i items"
+msgstr "знайдено %і об'ект(ів)"
+
+#: id:283
+msgid "Search results"
+msgstr "Результати пошуку"
+
+#: id:284
+msgid "No results found"
+msgstr "Нічого не знайдено"
+
+#: id:287
+msgctxt "Auto context with id 287"
+msgid "Subtitles"
+msgstr "Субтитри"
+
+#: id:288
+msgctxt "Auto context with id 288"
+msgid "Font"
+msgstr "Шрифт"
+
+#: id:289
+msgctxt "Auto context with id 289"
+msgid "- Size"
+msgstr "- розмір"
+
+#: id:290
+msgid "Dynamic range compression"
+msgstr "Стиснення динамічного діапазону"
+
+#: id:291
+msgctxt "Auto context with id 291"
+msgid "Video"
+msgstr "Відео"
+
+#: id:292
+msgctxt "Auto context with id 292"
+msgid "Audio"
+msgstr "Звук"
+
+#: id:293
+msgid "Browse for subtitles"
+msgstr "Вкажіть субтитри"
+
+#: id:294
+msgid "Create bookmark"
+msgstr "Поставити закладку"
+
+#: id:296
+msgid "Clear bookmarks"
+msgstr "Очистити закладки"
+
+#: id:297
+msgid "Audio offset"
+msgstr "Затримка звуку"
+
+#: id:298
+msgid "Bookmarks"
+msgstr "Закладки"
+
+#: id:299
+msgid "- AAC capable receiver"
+msgstr "- виводити звук в форматі AAC"
+
+#: id:300
+msgid "- MP1 capable receiver"
+msgstr "- виводити звук в форматі MP1"
+
+#: id:301
+msgid "- MP2 capable receiver"
+msgstr "- виводити звук в форматі MP2"
+
+#: id:302
+msgid "- MP3 capable receiver"
+msgstr "- виводити звук в форматі MP3"
+
+#: id:303
+msgid "Delay"
+msgstr "Затримка субтитрів"
+
+#: id:304
+msgctxt "Auto context with id 304"
+msgid "Language"
+msgstr "Мова"
+
+#: id:305
+msgctxt "Auto context with id 305"
+msgid "Enabled"
+msgstr "Включено"
+
+#: id:306
+msgid "Non-interleaved"
+msgstr ""
+
+#: id:312
+msgid "(0=auto)"
+msgstr "(0=авто)"
+
+#: id:313
+msgid "Cleaning database"
+msgstr "Очищення бази даних"
+
+#: id:314
+msgid "Preparing..."
+msgstr "Підготовка..."
+
+#: id:315
+msgid "Database error"
+msgstr "Помилка бази даних"
+
+#: id:316
+msgid "Searching songs..."
+msgstr "Пошук пісень..."
+
+#: id:317
+msgid "Cleaned database successfully"
+msgstr "Очищення бази даних виконано"
+
+#: id:318
+msgid "Cleaning songs..."
+msgstr "Очищення пісень..."
+
+#: id:319
+msgid "Error cleaning songs"
+msgstr "Помилка очищення пісень"
+
+#: id:320
+msgid "Cleaning artists..."
+msgstr "Очищення виконавців..."
+
+#: id:321
+msgid "Error cleaning artists"
+msgstr "Помилка очищення виконавців"
+
+#: id:322
+msgid "Cleaning genres..."
+msgstr "Очищення жанрів..."
+
+#: id:323
+msgid "Error cleaning genres"
+msgstr "Помилка очищення жанрів"
+
+#: id:324
+msgid "Cleaning paths..."
+msgstr "Очищення шляхів..."
+
+#: id:325
+msgid "Error cleaning paths"
+msgstr "Помилка очищення шляхів"
+
+#: id:326
+msgid "Cleaning albums..."
+msgstr "Очищення альбомів..."
+
+#: id:327
+msgid "Error cleaning albums"
+msgstr "Помилка очищення альбомів"
+
+#: id:328
+msgid "Writing changes..."
+msgstr "Запис змін..."
+
+#: id:329
+msgid "Error writing changes"
+msgstr "Помилка запису змін"
+
+#: id:330
+msgid "This may take some time..."
+msgstr "Це займе деякий час..."
+
+#: id:331
+msgid "Compressing database..."
+msgstr "Стиснення бази даних..."
+
+#: id:332
+msgid "Error compressing database"
+msgstr "Помилка стискування бази даних"
+
+#: id:333
+msgid "Do you want to clean the library?"
+msgstr "Ви хочете очистити Бібліотеку?"
+
+#: id:334
+msgid "Clean library..."
+msgstr "Очистити Бібліотеку..."
+
+#: id:335
+msgid "Start"
+msgstr "Старт"
+
+#: id:336
+msgid "Framerate conversion"
+msgstr "Перетворення частоти кадрів"
+
+#: id:337
+msgctxt "Auto context with id 337"
+msgid "Audio output"
+msgstr "Аудіо вихід"
+
+#: id:338
+msgid "Analog"
+msgstr "Аналоговий"
+
+#: id:339
+msgid "Optical/Coax"
+msgstr "Цифровий"
+
+#: id:340
+msgid "Various artists"
+msgstr "Різні виконавці"
+
+#: id:341
+msgid "Play disc"
+msgstr "Програти диск"
+
+#: id:342
+msgctxt "Auto context with id 342"
+msgid "Movies"
+msgstr "Фільми"
+
+#: id:343
+msgid "Adjust framerate"
+msgstr "Налаштувати частоту кадрів"
+
+#: id:344
+msgid "Actors"
+msgstr "Актори"
+
+#: id:345
+msgctxt "Auto context with id 345"
+msgid "Year"
+msgstr "Рік"
+
+#: id:346
+msgid "Boost volume level on downmix"
+msgstr ""
+
+#: id:350
+msgctxt "Auto context with id 350"
+msgid "Programs"
+msgstr "Програми"
+
+#: id:351
+msgctxt "Auto context with id 351"
+msgid "Off"
+msgstr "Вимкнено"
+
+#: id:352
+msgid "Dim"
+msgstr "Затемнення"
+
+#: id:353
+msgid "Black"
+msgstr "Чорний екран"
+
+#: id:354
+msgid "Matrix trails"
+msgstr "Сліди \"Матриці\""
+
+#: id:355
+msgid "Screensaver time"
+msgstr "Вмикати заставку через"
+
+#: id:356
+msgid "Screensaver mode"
+msgstr "Режим заставки"
+
+#: id:357
+msgid "Shutdown function timer"
+msgstr "Завершити роботу через"
+
+#: id:358
+msgid "All albums"
+msgstr "Усі альбоми"
+
+#: id:359
+msgid "Recently added albums"
+msgstr "Свіжі альбоми"
+
+#: id:360
+msgctxt "Auto context with id 360"
+msgid "Screensaver"
+msgstr "Заставка"
+
+#: id:361
+msgid "R. Slideshow"
+msgstr "Рекурсивне слайдшоу"
+
+#: id:362
+msgid "Screensaver dim level"
+msgstr "Рівень затемнення екрану"
+
+#: id:363
+msgid "Sort by: File"
+msgstr "Сорт.по: Файлу"
+
+#: id:364
+msgid "- Dolby Digital (AC3) capable receiver"
+msgstr "- виводити звук в форматі AC3 (Dolby Digital®)"
+
+#: id:365
+msgctxt "Auto context with id 365"
+msgid "Sort by: Name"
+msgstr "Сорт.по: Назві"
+
+#: id:366
+msgid "Sort by: Year"
+msgstr "Сорт.по: Року"
+
+#: id:367
+msgid "Sort by: Rating"
+msgstr "Сорт.по: Рейтингу"
+
+#: id:368
+msgid "IMDb"
+msgstr ""
+
+#: id:369
+msgctxt "Auto context with id 369"
+msgid "Title"
+msgstr "Назва"
+
+#: id:370
+msgid "Thunderstorms"
+msgstr "грози"
+
+#: id:371
+msgid "Partly"
+msgstr "Місцями"
+
+#: id:372
+msgid "Mostly"
+msgstr "Переважно"
+
+#: id:373
+msgid "Sunny"
+msgstr "сонячно"
+
+#: id:374
+msgid "Cloudy"
+msgstr "хмарно"
+
+#: id:375
+msgid "Snow"
+msgstr "сніг"
+
+#: id:376
+msgid "Rain"
+msgstr "дощ"
+
+#: id:377
+msgid "Light"
+msgstr "невеликий"
+
+#: id:378
+msgid "AM"
+msgstr "вранці"
+
+#: id:379
+msgid "PM"
+msgstr "вдень"
+
+#: id:380
+msgid "Showers"
+msgstr "злива"
+
+#: id:381
+msgid "Few"
+msgstr "трохи"
+
+#: id:382
+msgid "Scattered"
+msgstr "місцями"
+
+#: id:383
+msgctxt "Auto context with id 383"
+msgid "Wind"
+msgstr "вітер"
+
+#: id:384
+msgid "Strong"
+msgstr "сильний"
+
+#: id:385
+msgid "Fair"
+msgstr "ясно"
+
+#: id:386
+msgctxt "Auto context with id 386"
+msgid "Clear"
+msgstr "безхмарно"
+
+#: id:387
+msgid "Clouds"
+msgstr "хмарно"
+
+#: id:388
+msgid "Early"
+msgstr "рано"
+
+#: id:389
+msgid "Shower"
+msgstr "рясний"
+
+#: id:390
+msgid "Flurries"
+msgstr "шквали"
+
+#: id:391
+msgctxt "Auto context with id 391"
+msgid "Low"
+msgstr "низький"
+
+#: id:392
+msgctxt "Auto context with id 392"
+msgid "Medium"
+msgstr "помірний"
+
+#: id:393
+msgctxt "Auto context with id 393"
+msgid "High"
+msgstr "всиокий"
+
+#: id:394
+msgid "Fog"
+msgstr "туман"
+
+#: id:395
+msgid "Haze"
+msgstr "серпанок"
+
+#: id:396
+msgid "Select location"
+msgstr "Місцевість"
+
+#: id:397
+msgid "Refresh time"
+msgstr "Час оновлення"
+
+#: id:398
+msgid "Temperature units"
+msgstr "Одиниця виміру температури"
+
+#: id:399
+msgid "Speed units"
+msgstr "Одиниця виміру швидкості вітру"
+
+#: id:400
+msgctxt "Auto context with id 400"
+msgid "Weather"
+msgstr "Погода"
+
+#: id:401
+msgid "Temp"
+msgstr "Температура"
+
+#: id:402
+msgid "Feels like"
+msgstr "За відчуттям"
+
+#: id:403
+msgid "UV index"
+msgstr "Рівень УФ"
+
+#: id:404
+msgctxt "Auto context with id 404"
+msgid "Wind"
+msgstr "Вітер"
+
+#: id:405
+msgid "Dew point"
+msgstr "Крапка роси"
+
+#: id:406
+msgid "Humidity"
+msgstr "Вологість"
+
+#: id:409
+msgid "Defaults"
+msgstr "За змовчуванням"
+
+#: id:410
+msgid "Accessing weather service"
+msgstr "Підключення до Гідрометеоцентру"
+
+#: id:411
+msgid "Getting weather for:"
+msgstr "Одержання прогнозу для:"
+
+#: id:412
+msgid "Unable to get weather data"
+msgstr "Неможливо отримати прогноз"
+
+#: id:413
+msgid "Manual"
+msgstr "Вписати вручну"
+
+#: id:414
+msgid "No review for this album"
+msgstr "Немає опису для цого альбома"
+
+#: id:415
+msgid "Downloading thumbnail..."
+msgstr "Завантаження ескізів..."
+
+#: id:416
+msgid "Not available"
+msgstr "Не доступно"
+
+#: id:417
+msgid "View: Big icons"
+msgstr "Вигляд: Великі значки"
+
+#: id:418
+msgctxt "Auto context with id 418"
+msgid "Low"
+msgstr "Мін."
+
+#: id:419
+msgctxt "Auto context with id 419"
+msgid "High"
+msgstr "Макс."
+
+#: id:420
+msgid "HDMI"
+msgstr "Порт HDMI"
+
+#: id:422
+msgid "Delete album info"
+msgstr "Видалити дані про альбом"
+
+#: id:423
+msgid "Delete CD information"
+msgstr "Видалити дані про CD"
+
+#: id:424
+msgid "Select"
+msgstr "Вибір"
+
+#: id:425
+msgid "No album information found"
+msgstr "Даних про альбом не знайдено"
+
+#: id:426
+msgid "No CD information found"
+msgstr "Даних про CD не знайдено"
+
+#: id:427
+msgid "Disc"
+msgstr "Диск"
+
+#: id:428
+msgid "Insert correct CD/DVD"
+msgstr "Вставте правильний CD/DVD диск"
+
+#: id:429
+msgid "Please insert the following disc:"
+msgstr "Вставте наступний CD/DVD диск"
+
+#: id:430
+msgid "Sort by: DVD#"
+msgstr "Сорт.по: №DVD"
+
+#: id:431
+msgid "No cache"
+msgstr "Не кешувати"
+
+#: id:432
+msgid "Remove movie from library"
+msgstr "Видалити фільм із Бібліотеки"
+
+#: id:433
+msgid "Really remove '%s'?"
+msgstr "Дійсно видалити '%s'?"
+
+#: id:434
+msgid "From %s at %i %s"
+msgstr "%s Швидк. %i %s"
+
+#: id:437
+msgid "Removable disk"
+msgstr "З'ємний диск"
+
+#: id:438
+msgid "Opening file"
+msgstr "Відкриття файла"
+
+#: id:439
+msgid "Cache"
+msgstr "Кеш"
+
+#: id:440
+msgid "Harddisk"
+msgstr "Жорсткий диск"
+
+#: id:441
+msgid "UDF"
+msgstr ""
+
+#: id:442
+msgid "Local network"
+msgstr "Локальна мережа"
+
+#: id:443
+msgid "Internet"
+msgstr "Інтернет"
+
+#: id:444
+msgctxt "Auto context with id 444"
+msgid "Video"
+msgstr "Відео"
+
+#: id:445
+msgctxt "Auto context with id 445"
+msgid "Audio"
+msgstr "Аудіо"
+
+#: id:446
+msgctxt "Auto context with id 446"
+msgid "DVD"
+msgstr ""
+
+#: id:447
+msgid "Autorun media"
+msgstr "Автопрогравання"
+
+#: id:448
+msgid "LCD"
+msgstr "РК екран (LCD)"
+
+#: id:449
+msgctxt "Auto context with id 449"
+msgid "Enabled"
+msgstr "Включено"
+
+#: id:450
+msgid "Columns"
+msgstr "Кількість знаків у рядку"
+
+#: id:451
+msgid "Row 1 address"
+msgstr "Адреса 1-го рядка"
+
+#: id:452
+msgid "Row 2 address"
+msgstr "Адреса 2-го рядка"
+
+#: id:453
+msgid "Row 3 address"
+msgstr "Адреса 3-го рядка"
+
+#: id:454
+msgid "Row 4 address"
+msgstr "Адреса 4-го рядка"
+
+#: id:455
+msgid "Rows"
+msgstr "Кількість рядків"
+
+#: id:456
+msgid "Mode"
+msgstr "Режим"
+
+#: id:457
+msgid "Switch view"
+msgstr "Замінити вигляд"
+
+#: id:459
+msgid "Subs"
+msgstr "Субтитри"
+
+#: id:460
+msgid "Audio stream"
+msgstr "Аудіо потік"
+
+#: id:461
+msgid "[active]"
+msgstr "[працює]"
+
+#: id:462
+msgid "Subtitle"
+msgstr "Субтитри"
+
+#: id:463
+msgid "Backlight"
+msgstr "Підсвічування"
+
+#: id:464
+msgid "Brightness"
+msgstr "Яскравість"
+
+#: id:465
+msgid "Contrast"
+msgstr "Контрастність"
+
+#: id:466
+msgid "Gamma"
+msgstr "Гама"
+
+#: id:467
+msgctxt "Auto context with id 467"
+msgid "Type"
+msgstr "Тип"
+
+#: id:468
+msgid "Move the bar to change the OSD position"
+msgstr "Рухайте смужку щоб змінити позицію OSD"
+
+#: id:469
+msgid "OSD position"
+msgstr "Позиція екранного меню (OSD)"
+
+#: id:470
+msgid "Credits"
+msgstr "Творці"
+
+#: id:471
+msgid "Modchip"
+msgstr "МOD-чіп"
+
+#: id:474
+msgctxt "Auto context with id 474"
+msgid "Off"
+msgstr "Вимкнено"
+
+#: id:475
+msgid "Music only"
+msgstr "Тільки музика"
+
+#: id:476
+msgctxt "Auto context with id 476"
+msgid "Music & video"
+msgstr "Музика та Відео"
+
+#: id:477
+msgid "Unable to load playlist"
+msgstr "Неможливо завантажити плейлист"
+
+#: id:478
+msgid "OSD"
+msgstr "Екранне меню (OSD)"
+
+#: id:479
+msgid "Skin & language"
+msgstr "Оформлення і мова"
+
+#: id:480
+msgid "Appearance"
+msgstr "Вигляд"
+
+#: id:481
+msgid "Audio options"
+msgstr "Налаштування аудіо"
+
+#: id:482
+msgid "About XBMC"
+msgstr "Про XBMC"
+
+#: id:485
+msgid "Delete album"
+msgstr "Видалити альбом"
+
+#: id:486
+msgid "Repeat"
+msgstr "Повторювати"
+
+#: id:487
+msgid "Repeat one"
+msgstr "Повторювати 1 трек"
+
+#: id:488
+msgid "Repeat folder"
+msgstr "Повторювати папку"
+
+#: id:489
+msgid "Play the next song automatically"
+msgstr "Програвати наступний файл автоматично"
+
+#: id:491
+msgid "- Use big icons"
+msgstr "- використовувати великі значки"
+
+#: id:492
+msgid "Resize VobSubs"
+msgstr "Масштабувати субтитри"
+
+#: id:493
+msgid "Advanced options (Experts Only!)"
+msgstr "Розширені опції (Тільки для експертів!)"
+
+#: id:494
+msgid "Overall audio headroom"
+msgstr "Загальний рівень шуму в кімнаті (dB)"
+
+#: id:495
+msgid "Upsample videos to GUI resolution"
+msgstr "Перераховувати відео до розд. зд. GUI"
+
+#: id:496
+msgid "Calibration"
+msgstr "Калібрування"
+
+#: id:497
+msgid "Show file extensions"
+msgstr "Показати розширення файлів"
+
+#: id:498
+msgid "Sort by: Type"
+msgstr "Сорт.по: Типу"
+
+#: id:499
+msgid "Unable to connect to online lookup service"
+msgstr "Неможливо з'єднатися з пошуковим сервісом"
+
+#: id:500
+msgid "Downloading album information failed"
+msgstr "Невдалося завантажити дані про альбом"
+
+#: id:501
+msgid "Looking for album names..."
+msgstr "Перевірка назв альбомів..."
+
+#: id:502
+msgctxt "Auto context with id 502"
+msgid "Open"
+msgstr "Відкритий"
+
+#: id:503
+msgid "Busy"
+msgstr "Обробка..."
+
+#: id:504
+msgid "Empty"
+msgstr "порожній"
+
+#: id:505
+msgid "Loading media info from files..."
+msgstr "Завантаження інформації з файлів..."
+
+#: id:507
+msgid "Sort by: Usage"
+msgstr "Сорт.по: Використ."
+
+#: id:510
+msgid "Enable visualizations"
+msgstr "Задіяти відео-ефекти"
+
+#: id:511
+msgid "Enable video mode switching"
+msgstr "Автоматичне переключення PAL/NTSC"
+
+#: id:512
+msgid "Startup window"
+msgstr "Після старту переходити в меню:"
+
+#: id:513
+msgid "Home window"
+msgstr "Головне меню"
+
+#: id:514
+msgid "Manual settings"
+msgstr "Налаштування"
+
+#: id:515
+msgid "Genre"
+msgstr "Жанр"
+
+#: id:517
+msgid "Recently played albums"
+msgstr "Недавно прослухані альбоми"
+
+#: id:518
+msgid "Launch"
+msgstr "Запустити"
+
+#: id:519
+msgid "Launch in..."
+msgstr "Запустити в режимі…"
+
+#: id:521
+msgid "Compilations"
+msgstr "Збірки"
+
+#: id:522
+msgid "Remove source"
+msgstr "Видалити джерело"
+
+#: id:523
+msgid "Switch media"
+msgstr "Перейти до розділу..."
+
+#: id:524
+msgid "Select playlist"
+msgstr "Вибрати плейлист"
+
+#: id:525
+msgid "New playlist..."
+msgstr "Створити новий плейлист..."
+
+#: id:526
+msgid "Add to playlist"
+msgstr "Додати до плейлиста"
+
+#: id:527
+msgid "Manually add to library"
+msgstr "Додати до Бібліотеки"
+
+#: id:528
+msgid "Enter title"
+msgstr "Впишіть назву"
+
+#: id:529
+msgid "Error: Duplicate title"
+msgstr "Помилка: Однакові назви"
+
+#: id:530
+msgid "Select genre"
+msgstr "Виберіть жанр"
+
+#: id:531
+msgid "New genre"
+msgstr "Новий жанр"
+
+#: id:532
+msgid "Manual addition"
+msgstr "Додавання вручну"
+
+#: id:533
+msgid "Enter genre"
+msgstr "Впишіть жанр"
+
+#: id:534
+msgid "View: %s"
+msgstr "Вигляд: %s"
+
+#: id:535
+msgid "List"
+msgstr "Список"
+
+#: id:536
+msgid "Icons"
+msgstr "Значки"
+
+#: id:537
+msgid "Big list"
+msgstr "Повний список"
+
+#: id:538
+msgid "Big icons"
+msgstr "Великі значки"
+
+#: id:539
+msgid "Wide"
+msgstr "Широкий"
+
+#: id:540
+msgid "Big wide"
+msgstr "Повний широкий"
+
+#: id:541
+msgid "Album icons"
+msgstr "Значки альбомів"
+
+#: id:542
+msgid "DVD icons"
+msgstr "Значки DVD"
+
+#: id:543
+msgctxt "Auto context with id 543"
+msgid "DVD"
+msgstr ""
+
+#: id:544
+msgctxt "Auto context with id 544"
+msgid "Media info"
+msgstr "Інфо"
+
+#: id:545
+msgid "Audio output device"
+msgstr "Пристрій виводу звуку"
+
+#: id:546
+msgid "Passthrough output device"
+msgstr "Пристрій передачі звуку"
+
+#: id:547
+msgid "No biography for this artist"
+msgstr "Для цього виконавця немає біографії"
+
+#: id:548
+msgid "Downmix multichannel audio to stereo"
+msgstr "Змішати багатоканальний звук до стерео"
+
+#: id:550
+msgid "Sort by: %s"
+msgstr "Сорт. по: %s"
+
+#: id:551
+msgctxt "Auto context with id 551"
+msgid "Name"
+msgstr "Назві"
+
+#: id:552
+msgid "Date"
+msgstr "Даті"
+
+#: id:553
+msgid "Size"
+msgstr "Розміру"
+
+#: id:554
+msgid "Track"
+msgstr "№ трека"
+
+#: id:555
+msgid "Time"
+msgstr "Час"
+
+#: id:556
+msgctxt "Auto context with id 556"
+msgid "Title"
+msgstr "Назва пісні"
+
+#: id:557
+msgid "Artist"
+msgstr "Виконавець"
+
+#: id:558
+msgid "Album"
+msgstr "Альбом"
+
+#: id:559
+msgid "Playlist"
+msgstr "Плейлист"
+
+#: id:560
+msgid "ID"
+msgstr ""
+
+#: id:561
+msgctxt "Auto context with id 561"
+msgid "File"
+msgstr "Імені файлу"
+
+#: id:562
+msgctxt "Auto context with id 562"
+msgid "Year"
+msgstr "Рік"
+
+#: id:563
+msgid "Rating"
+msgstr "Рейтинг"
+
+#: id:564
+msgctxt "Auto context with id 564"
+msgid "Type"
+msgstr "Тип"
+
+#: id:565
+msgid "Usage"
+msgstr "Використання"
+
+#: id:566
+msgid "Album artist"
+msgstr "Виконавець альбому"
+
+#: id:567
+msgid "Play count"
+msgstr "Кількість програвань"
+
+#: id:568
+msgid "Last played"
+msgstr "Останній програний"
+
+#: id:569
+msgctxt "Auto context with id 569"
+msgid "Comment"
+msgstr "Нотатки"
+
+#: id:570
+msgid "Date added"
+msgstr "Дата додавання"
+
+#: id:571
+msgctxt "Auto context with id 571"
+msgid "Default"
+msgstr "За змовчуванням"
+
+#: id:572
+msgid "Studio"
+msgstr "Кіностудія"
+
+#: id:573
+msgid "Path"
+msgstr "Шлях"
+
+#: id:574
+msgctxt "Auto context with id 574"
+msgid "Country"
+msgstr "Країна"
+
+#: id:575
+msgid "In progress"
+msgstr "В процесі"
+
+#: id:576
+msgid "Times played"
+msgstr ""
+
+#: id:580
+msgid "Sort direction"
+msgstr "Напрямок сортування"
+
+#: id:581
+msgid "Sort method"
+msgstr "Метод сортування"
+
+#: id:582
+msgctxt "Auto context with id 582"
+msgid "View mode"
+msgstr "Режим перегляду"
+
+#: id:583
+msgid "Remember views for different folders"
+msgstr "Пам'ятати параметри відображення кожної папки"
+
+#: id:584
+msgid "Ascending"
+msgstr "За зростанням"
+
+#: id:585
+msgid "Descending"
+msgstr "За убуванням"
+
+#: id:586
+msgid "Edit playlist"
+msgstr "Редагувати плейлист"
+
+#: id:587
+msgid "Filter"
+msgstr "Фільтр"
+
+#: id:588
+msgid "Cancel party mode"
+msgstr "Відключити режим 'Вечірка'"
+
+#: id:589
+msgid "Party mode"
+msgstr "Режим 'Вечірка'"
+
+#: id:590
+msgid "Random"
+msgstr "Випадково"
+
+#: id:591
+msgctxt "Auto context with id 591"
+msgid "Off"
+msgstr "Виключене"
+
+#: id:592
+msgid "One"
+msgstr "Один"
+
+#: id:593
+msgid "All"
+msgstr "Усі"
+
+#: id:594
+msgctxt "Auto context with id 594"
+msgid "Off"
+msgstr "Вимкнено"
+
+#: id:595
+msgid "Repeat: Off"
+msgstr "Повтор: Вимкнено"
+
+#: id:596
+msgid "Repeat: One"
+msgstr "Повтор: Один трек"
+
+#: id:597
+msgid "Repeat: All"
+msgstr "Повтор: Усі треки"
+
+#: id:600
+msgid "Rip audio CD"
+msgstr "Зберегти з Audio CD"
+
+#: id:601
+msgctxt "Auto context with id 601"
+msgid "Medium"
+msgstr "Середня"
+
+#: id:602
+msgctxt "Auto context with id 602"
+msgid "Standard"
+msgstr "Стандартна"
+
+#: id:603
+msgid "Extreme"
+msgstr "Екстремальна"
+
+#: id:604
+msgid "Constant bitrate"
+msgstr "Постійний бітрейт"
+
+#: id:605
+msgid "Ripping..."
+msgstr "Збереження..."
+
+#: id:607
+msgid "To:"
+msgstr "У:"
+
+#: id:608
+msgid "Could not rip CD or track"
+msgstr "Збереження CD чи треку неможлива"
+
+#: id:609
+msgid "CDDARipPath is not set."
+msgstr "Не зазначено значення CDDARipPath"
+
+#: id:610
+msgid "Rip audio track"
+msgstr "Зберегти аудіо трек"
+
+#: id:611
+msgid "Enter number"
+msgstr "Впишіть номер"
+
+#: id:612
+msgid "Bits/Sample"
+msgstr "Біт/відлік"
+
+#: id:613
+msgid "Sample Frequency"
+msgstr "Частота відліків"
+
+#: id:620
+msgid "Audio CDs"
+msgstr "Аудіо CD"
+
+#: id:621
+msgid "Encoder"
+msgstr "Кодувальник"
+
+#: id:622
+msgid "Quality"
+msgstr "Якість"
+
+#: id:623
+msgid "Bitrate"
+msgstr "Бітрейт"
+
+#: id:624
+msgid "Include track number"
+msgstr "Додати номер треку"
+
+#: id:625
+msgid "All songs of"
+msgstr "Усі пісні"
+
+#: id:629
+msgctxt "Auto context with id 629"
+msgid "View mode"
+msgstr "Режим перегляду"
+
+#: id:630
+msgctxt "Auto context with id 630"
+msgid "Normal"
+msgstr "Нормальний"
+
+#: id:631
+msgid "Zoom"
+msgstr "Збільшений"
+
+#: id:632
+msgid "Stretch 4:3"
+msgstr "Розтягнутий 4:3"
+
+#: id:633
+msgid "Wide Zoom"
+msgstr "Розтягнутий 14:9"
+
+#: id:634
+msgid "Stretch 16:9"
+msgstr "Розтягнутий 16:9"
+
+#: id:635
+msgid "Original Size"
+msgstr "Оригінальний розмір"
+
+#: id:636
+msgctxt "Auto context with id 636"
+msgid "Custom"
+msgstr "Особливий"
+
+#: id:637
+msgid "Replay gain"
+msgstr "Replay Gain"
+
+#: id:638
+msgid "Replaygain volume adjustments"
+msgstr "Режим Replay Gain"
+
+#: id:639
+msgid "Use track levels"
+msgstr "по рівням треку"
+
+#: id:640
+msgid "Use album levels"
+msgstr "по рівням альбому"
+
+#: id:641
+msgid "PreAmp Level - Replay gained files"
+msgstr "Рівень для файлів з Replay Gain"
+
+#: id:642
+msgid "PreAmp Level - Non replay gained files"
+msgstr "Рівень для файлів без Replay Gain"
+
+#: id:643
+msgid "Avoid clipping on replay gained files"
+msgstr "Уникати втрати якості на файлах з Reply Gain"
+
+#: id:644
+msgid "Crop black bars"
+msgstr "Видаляти чорні смуги"
+
+#: id:645
+msgid "Need to unpack a big file. Continue?"
+msgstr "Необхідно розпакувати великий файл. Продовжити?"
+
+#: id:646
+msgid "Remove from library"
+msgstr "Видалити з Бібліотеки"
+
+#: id:647
+msgid "Export video library"
+msgstr "Експортувати відео Бібліотеку"
+
+#: id:648
+msgid "Import video library"
+msgstr "Імпортувати відео Бібліотеку"
+
+#: id:649
+msgid "Importing"
+msgstr "Імпортування"
+
+#: id:650
+msgid "Exporting"
+msgstr "Експортування"
+
+#: id:651
+msgid "Browse for library"
+msgstr "Вкажіть Бібліотеку"
+
+#: id:652
+msgid "Years"
+msgstr "Роки"
+
+#: id:653
+msgid "Update library"
+msgstr "Оновити Бібліотеку"
+
+#: id:654
+msgid "Show debug info"
+msgstr "Показувати інформацію для відладки"
+
+#: id:655
+msgid "Browse for executable"
+msgstr "Вкажіть програму"
+
+#: id:656
+msgid "Browse for playlist"
+msgstr "Вкажіть плейлист"
+
+#: id:657
+msgid "Browse for folder"
+msgstr "Вкажіть папку"
+
+#: id:658
+msgid "Song information"
+msgstr "Інформація про пісню"
+
+#: id:659
+msgid "Non-linear stretch"
+msgstr "Нелінійний розтяг"
+
+#: id:660
+msgid "Volume amplification"
+msgstr "Підсилення звуку"
+
+#: id:661
+msgid "Choose export folder"
+msgstr "Виберіть папку для експорту"
+
+#: id:662
+msgid "This file is no longer available."
+msgstr "Цей файл більше недоступний."
+
+#: id:663
+msgid "Would you like to remove it from the library?"
+msgstr "Хочете видалити його з Бібліотеки?"
+
+#: id:664
+msgid "Browse for Script"
+msgstr "Вказати скрипт"
+
+#: id:665
+msgid "Compression level"
+msgstr "Рівень стиску"
+
+#: id:700
+msgid "Cleaning up library"
+msgstr "Очищення Бібліотеки"
+
+#: id:701
+msgid "Removing old songs from the library"
+msgstr "Видалення старих пісень з Бібліотеки"
+
+#: id:702
+msgid "This path has been scanned before"
+msgstr "Ця папка вже була просканована раніше"
+
+#: id:705
+msgctxt "Auto context with id 705"
+msgid "Network"
+msgstr "Мережа"
+
+#: id:706
+msgid "- Server"
+msgstr "Адреса HTTP проксі сервера"
+
+#: id:708
+msgid "Use an HTTP proxy server to access the internet"
+msgstr "Використовувати HTTP proxy сервер"
+
+#: id:711
+msgid "Internet Protocol (IP)"
+msgstr "Інтернет протокол (IP)"
+
+#: id:712
+msgid "Invalid port specified. Value must be between 1 and 65535."
+msgstr "Неправильний порт. Повинно бути від 1 до 65535."
+
+#: id:713
+msgid "HTTP proxy"
+msgstr "HTTP проксі"
+
+#: id:715
+msgid "- Assignment"
+msgstr "- Призначення"
+
+#: id:716
+msgid "Automatic (DHCP)"
+msgstr "автоматично (DHCP)"
+
+#: id:717
+msgid "Manual (Static)"
+msgstr "вручну (Static)"
+
+#: id:719
+msgid "- IP address"
+msgstr "- IP-адреса"
+
+#: id:720
+msgid "- Netmask"
+msgstr "- Маска мережі"
+
+#: id:721
+msgid "- Default gateway"
+msgstr "- Адреса шлюзу"
+
+#: id:722
+msgid "- DNS server"
+msgstr "- Адреса DNS сервера"
+
+#: id:723
+msgid "Save & restart"
+msgstr "Записати і перезапустити"
+
+#: id:724
+msgid "Invalid address specified. Value must be AAA.BBB.CCC.DDD"
+msgstr "Неправильна адреса. Повинно бути як AAA.BBB.CCC.DDD"
+
+#: id:725
+msgid "with numbers between 0 and 255."
+msgstr "з числами від 0 до 255."
+
+#: id:726
+msgid "Changes not saved. Continue without saving?"
+msgstr "Зміни не збережені. Продовжити без збереження?"
+
+#: id:727
+msgid "Web server"
+msgstr "Web сервер"
+
+#: id:728
+msgctxt "Auto context with id 728"
+msgid "FTP server"
+msgstr "FTP сервер"
+
+#: id:730
+msgid "- Port"
+msgstr "- Порт"
+
+#: id:732
+msgid "Save & apply"
+msgstr "Зберегти і застосувати"
+
+#: id:733
+msgid "- Password"
+msgstr "- Пароль"
+
+#: id:734
+msgid "No pass"
+msgstr "без пароля"
+
+#: id:735
+msgid "- Character set"
+msgstr "- набір символів"
+
+#: id:736
+msgid "- Style"
+msgstr "- стиль"
+
+#: id:737
+msgid "- Colour"
+msgstr "- колір"
+
+#: id:738
+msgctxt "Auto context with id 738"
+msgid "Normal"
+msgstr "нормальний"
+
+#: id:739
+msgid "Bold"
+msgstr "жирний"
+
+#: id:740
+msgid "Italics"
+msgstr "похилий"
+
+#: id:741
+msgid "Bold italics"
+msgstr "жирний похилий"
+
+#: id:742
+msgctxt "Auto context with id 742"
+msgid "White"
+msgstr "білий"
+
+#: id:743
+msgctxt "Auto context with id 743"
+msgid "Yellow"
+msgstr "жовтий"
+
+#: id:744
+msgctxt "Auto context with id 744"
+msgid "Files"
+msgstr "Файли"
+
+#: id:745
+msgid "No scanned information for this view"
+msgstr "Немає сканірованої інформації для цього вигляду"
+
+#: id:746
+msgid "Please turn off library mode"
+msgstr "Відключіть режим Бібліотеки"
+
+#: id:747
+msgid "Error loading image"
+msgstr "Помилка завантаження картинки"
+
+#: id:748
+msgid "Edit path"
+msgstr "Змінити шлях"
+
+#: id:749
+msgid "Mirror image"
+msgstr "Дзеркально"
+
+#: id:750
+msgid "Are you sure?"
+msgstr "Ви впевнені?"
+
+#: id:751
+msgid "Removing source"
+msgstr "Видалення джерела"
+
+#: id:754
+msgid "Add program link"
+msgstr "Додати посилання на програму"
+
+#: id:755
+msgid "Edit program path"
+msgstr "Змінити шлях до програми"
+
+#: id:756
+msgid "Edit program name"
+msgstr "Змінити назву програми"
+
+#: id:757
+msgid "Edit path depth"
+msgstr "Змінити глибину шляху"
+
+#: id:759
+msgid "View: Big list"
+msgstr "Вигляд: Великий список"
+
+#: id:760
+msgctxt "Auto context with id 760"
+msgid "Yellow"
+msgstr "жовтий"
+
+#: id:761
+msgctxt "Auto context with id 761"
+msgid "White"
+msgstr "білий"
+
+#: id:762
+msgid "Blue"
+msgstr "синій"
+
+#: id:763
+msgid "Bright green"
+msgstr "світло-зелений"
+
+#: id:764
+msgid "Yellow green"
+msgstr "жовто-зелений"
+
+#: id:765
+msgid "Cyan"
+msgstr "блакитний"
+
+#: id:766
+msgid "Light grey"
+msgstr "Світло-сірий"
+
+#: id:767
+msgid "Grey"
+msgstr "Сірий"
+
+#: id:770
+msgid "Error %i: share not available"
+msgstr "Помилка %і: ресурс не доступний"
+
+#: id:772
+msgctxt "Auto context with id 772"
+msgid "Audio output"
+msgstr "Аудіо обладнання"
+
+#: id:773
+msgid "Seeking"
+msgstr "Пошук"
+
+#: id:774
+msgid "Slideshow folder"
+msgstr "Папка для слайдшоу"
+
+#: id:775
+msgid "Network interface"
+msgstr "Мережевий інтерфейс"
+
+#: id:776
+msgid "- Wireless network name (ESSID)"
+msgstr "- Ім'я бездротової мережі (ESSID)"
+
+#: id:777
+msgid "- Wireless password"
+msgstr "- Пароль для бездротової мережі"
+
+#: id:778
+msgid "- Wireless security"
+msgstr "- Безпека бездротової мережі"
+
+#: id:779
+msgid "Save and apply network interface settings"
+msgstr "Зберегти і застосувати налаштування мережевого інтерфейсу"
+
+#: id:780
+msgid "No encryption"
+msgstr "Без шифрування"
+
+#: id:781
+msgid "WEP"
+msgstr ""
+
+#: id:782
+msgid "WPA"
+msgstr ""
+
+#: id:783
+msgid "WPA2"
+msgstr ""
+
+#: id:784
+msgid "Applying network interface settings. Please wait."
+msgstr "Застосування налаштувань мережевого інтерфейсу. Зачекайте."
+
+#: id:785
+msgid "Network interface restarted successfully."
+msgstr "Мережевий інтерфейс перезапущено"
+
+#: id:786
+msgid "Network interface did not start successfully."
+msgstr "Мережевий інтерфейс не запустився"
+
+#: id:787
+msgid "Interface disabled"
+msgstr "Інтерфейс вимкнено"
+
+#: id:788
+msgid "Network interface disabled successfully."
+msgstr "Мережевий інтерфейс відключено"
+
+#: id:789
+msgid "Wireless network name (ESSID)"
+msgstr "Ім'я бездротової мережі (ESSID)"
+
+#: id:790
+msgid "Remote control"
+msgstr ""
+
+#: id:791
+msgid "Allow programs on this system to control XBMC"
+msgstr "Дозволити програмам на цьому комп’ютері керувати XBMC"
+
+#: id:792
+msgctxt "Auto context with id 792"
+msgid "Port"
+msgstr "Порт"
+
+#: id:793
+msgid "Port range"
+msgstr "Діапазон портів"
+
+#: id:794
+msgid "Allow programs on other systems to control XBMC"
+msgstr "Дозволити програмам на інших комп'ютерах керувати XBMC"
+
+#: id:795
+msgid "Initial repeat delay (ms)"
+msgstr "Затримка начального повтору (мс)"
+
+#: id:796
+msgid "Continuous repeat delay (ms)"
+msgstr "Затримка послідуючих повторів (мс)"
+
+#: id:797
+msgid "Maximum number of clients"
+msgstr "Максимальна кількість клієнтів"
+
+#: id:798
+msgid "Internet access"
+msgstr "Доступ в інтернет"
+
+#: id:850
+msgid "Invalid port number entered"
+msgstr "Введено неправильний номер проту"
+
+#: id:851
+msgid "Valid port range is 1-65535"
+msgstr "Номер порту має бути в діапазоні 1-65535"
+
+#: id:852
+msgid "Valid port range is 1024-65535"
+msgstr "Номер порту має бути в діапазоні 1024-65536"
+
+#: id:998
+msgid "Add Music..."
+msgstr ""
+
+#: id:999
+msgid "Add Videos..."
+msgstr ""
+
+#: id:1000
+msgid "- Preview"
+msgstr "Подивитися заставку"
+
+#: id:1001
+msgid "Unable to connect"
+msgstr "Неможливо підключитися"
+
+#: id:1002
+msgid "XBMC was unable to connect to the network location."
+msgstr "XBMC неспроможний підключитися до мережі."
+
+#: id:1003
+msgid "This could be due to the network not being connected."
+msgstr "Можливо, мережа не під'єднана."
+
+#: id:1004
+msgid "Would you like to add it anyway?"
+msgstr "Додати у будь-якому разі?"
+
+#: id:1006
+msgctxt "Auto context with id 1006"
+msgid "IP address"
+msgstr "IP-адреса"
+
+#: id:1007
+msgid "Add network location"
+msgstr "Додати мережеве розташування"
+
+#: id:1008
+msgid "Protocol"
+msgstr "Протокол"
+
+#: id:1009
+msgid "Server address"
+msgstr "Адреса сервера"
+
+#: id:1010
+msgid "Server name"
+msgstr "Ім'я серверу"
+
+#: id:1011
+msgid "Remote path"
+msgstr "Зовнішній шлях"
+
+#: id:1012
+msgid "Shared folder"
+msgstr "Доступна папка"
+
+#: id:1013
+msgctxt "Auto context with id 1013"
+msgid "Port"
+msgstr "Порт"
+
+#: id:1014
+msgctxt "Auto context with id 1014"
+msgid "Username"
+msgstr "Ім'я користувача"
+
+#: id:1015
+msgid "Browse for network server"
+msgstr "Вкажіть мережевий сервер"
+
+#: id:1016
+msgid "Enter the network address of the server"
+msgstr "Впишіть мережеву адресу сервера"
+
+#: id:1017
+msgid "Enter the path on the server"
+msgstr "Впишіть шлях на сервері"
+
+#: id:1018
+msgid "Enter the port number"
+msgstr "Впишіть номер порту"
+
+#: id:1019
+msgid "Enter the username"
+msgstr "Впишіть ім'я користувача"
+
+#: id:1020
+msgid "Add %s source"
+msgstr "Додати джерело %s"
+
+#: id:1021
+msgid "Enter the paths or browse for the media locations."
+msgstr "Впишіть шляхи чи вкажіть розташування медіа-файлів."
+
+#: id:1022
+msgid "Enter a name for this media Source."
+msgstr "Впишіть ім'я для цього медіа-джерела."
+
+#: id:1023
+msgid "Browse for new share"
+msgstr "Вкажіть новий ресурс"
+
+#: id:1024
+msgid "Browse"
+msgstr "Перегляд"
+
+#: id:1025
+msgid "Could not retrieve directory information."
+msgstr "Не можу одержати інформацію про папку."
+
+#: id:1026
+msgid "Add source"
+msgstr "Додати джерело"
+
+#: id:1027
+msgid "Edit source"
+msgstr "Змінити джерело"
+
+#: id:1028
+msgid "Edit %s source"
+msgstr "Змінити джерело %s"
+
+#: id:1029
+msgid "Enter the new label"
+msgstr "Впишіть нову позначку"
+
+#: id:1030
+msgid "Browse for image"
+msgstr "Вкажіть малюнок"
+
+#: id:1031
+msgid "Browse for image folder"
+msgstr "Вкажіть папку з малюнками"
+
+#: id:1032
+msgid "Add network location..."
+msgstr "Додати мережеве розташування…"
+
+#: id:1033
+msgid "Browse for file"
+msgstr "Вкажіть файл"
+
+#: id:1034
+msgid "Submenu"
+msgstr "Підменю"
+
+#: id:1035
+msgid "Enable submenu buttons"
+msgstr "Дозволити пункти в підменю"
+
+#: id:1036
+msgid "Favourites"
+msgstr "Вибране"
+
+#: id:1037
+msgid "Video Add-ons"
+msgstr "Відео додатки"
+
+#: id:1038
+msgid "Music Add-ons"
+msgstr "Музичні додатки"
+
+#: id:1039
+msgid "Picture Add-ons"
+msgstr "Фото додатки"
+
+#: id:1040
+msgid "Loading directory"
+msgstr "Завантаження папки"
+
+#: id:1041
+msgid "Retrieved %i items"
+msgstr "Отримано %i об'ект(ів)"
+
+#: id:1042
+msgid "Retrieved %i of %i items"
+msgstr "Отримано %i з %i об'ект(ів)"
+
+#: id:1043
+msgid "Program Add-ons"
+msgstr "Програмні додатки"
+
+#: id:1044
+msgid "Set plugin thumb"
+msgstr "Встановити ескіз для додатка"
+
+#: id:1045
+msgid "Add-on settings"
+msgstr "Налаштування додатка"
+
+#: id:1046
+msgid "Access points"
+msgstr "Крапки доступу"
+
+#: id:1047
+msgid "Other..."
+msgstr "Різне..."
+
+#: id:1048
+msgid "- Username"
+msgstr "- Ім'я користувача"
+
+#: id:1049
+msgid "Script settings"
+msgstr "Налаштування скриптів"
+
+#: id:1050
+msgid "Singles"
+msgstr ""
+
+#: id:1051
+msgid "Enter web address"
+msgstr "Введіть web адресу"
+
+#: id:1200
+msgid "SMB client"
+msgstr "SMB клієнт"
+
+#: id:1202
+msgid "Workgroup"
+msgstr "Робоча група"
+
+#: id:1203
+msgid "Default username"
+msgstr "Ім'я користувача за змовчуванням"
+
+#: id:1204
+msgid "Default password"
+msgstr "Пароль користувача за змовчуванням"
+
+#: id:1207
+msgid "WINS server"
+msgstr "WINS сервер"
+
+#: id:1208
+msgid "Mount SMB shares"
+msgstr "Монтувати SMB ресурси"
+
+#: id:1210
+msgctxt "Auto context with id 1210"
+msgid "Remove"
+msgstr "Видалити"
+
+#: id:1211
+msgctxt "Auto context with id 1211"
+msgid "Music"
+msgstr "Музика"
+
+#: id:1212
+msgctxt "Auto context with id 1212"
+msgid "Video"
+msgstr "Відео"
+
+#: id:1213
+msgctxt "Auto context with id 1213"
+msgid "Pictures"
+msgstr "Фотографії"
+
+#: id:1214
+msgctxt "Auto context with id 1214"
+msgid "Files"
+msgstr "Файли"
+
+#: id:1215
+msgctxt "Auto context with id 1215"
+msgid "Music & video"
+msgstr "Музика і Відео"
+
+#: id:1216
+msgid "Music & pictures"
+msgstr "Музика і Фото"
+
+#: id:1217
+msgid "Music & files"
+msgstr "Музика і Файли"
+
+#: id:1218
+msgid "Video & pictures"
+msgstr "Відео і Фото"
+
+#: id:1219
+msgid "Video & files"
+msgstr "Відео і Файли"
+
+#: id:1220
+msgid "Pictures & files"
+msgstr "Фото і Файли"
+
+#: id:1221
+msgid "Music & video & pictures"
+msgstr "Музика, Відео і Фото"
+
+#: id:1222
+msgid "Music & video & pictures & files"
+msgstr "Музика, Відео, Фото і Файли"
+
+#: id:1223
+msgctxt "Auto context with id 1223"
+msgid "Disabled"
+msgstr "Відключено"
+
+#: id:1226
+msgid "Files & music & video"
+msgstr "Файли, Музика і Відео"
+
+#: id:1227
+msgid "Files & pictures & music"
+msgstr "Файли, Фото і Музика"
+
+#: id:1228
+msgid "Files & pictures & video"
+msgstr "Файли, Фото і Відео"
+
+#: id:1229
+msgid "Music & programs"
+msgstr "Музика і Програми"
+
+#: id:1230
+msgid "Video & programs"
+msgstr "Відео і Програми"
+
+#: id:1231
+msgid "Pictures & programs"
+msgstr "Фото і Програми"
+
+#: id:1232
+msgid "Music & video & pictures & programs"
+msgstr "Музика, Відео, Фото і Програми"
+
+#: id:1233
+msgid "Programs & video & music"
+msgstr "Програми, Відео і Музика"
+
+#: id:1234
+msgid "Programs & pictures & music"
+msgstr "Програми, Фото і Музика"
+
+#: id:1235
+msgid "Programs & pictures & video"
+msgstr "Програми, Фото і Відео"
+
+#: id:1250
+msgid "Auto-detection"
+msgstr "Авто-визначення"
+
+#: id:1251
+msgid "Auto-detect system"
+msgstr "Автоматично визначати систему"
+
+#: id:1252
+msgid "Nickname"
+msgstr "Нік"
+
+#: id:1254
+msgid "Ask to connect"
+msgstr "Спитати дозвіл на підключення"
+
+#: id:1255
+msgid "Send FTP user and password"
+msgstr "Відправляти логін і пароль для FTP"
+
+#: id:1256
+msgid "Ping interval"
+msgstr "Інтервал для команди 'ping'"
+
+#: id:1257
+msgid "Would you like to connect to the auto-detected system?"
+msgstr "Ви хочете під'єднатися до знайденої системи?"
+
+#: id:1259
+msgid "Zeroconf"
+msgstr ""
+
+#: id:1260
+msgid "Announce these services to other systems via Zeroconf"
+msgstr "Повідомляти іншим комп’ютерам про ці сервіси через Zeroconf"
+
+#: id:1270
+msgid "Allow XBMC to receive AirPlay content"
+msgstr ""
+
+#: id:1271
+msgid "Device name"
+msgstr ""
+
+#: id:1272
+msgid "- Use password protection"
+msgstr ""
+
+#: id:1273
+msgid "AirPlay"
+msgstr ""
+
+#: id:1300
+msgid "Custom audio device"
+msgstr ""
+
+#: id:1301
+msgid "Custom passthrough device"
+msgstr ""
+
+#: id:1396
+msgid "Drifting"
+msgstr "ожеледь"
+
+#: id:1397
+msgid "and"
+msgstr "і"
+
+#: id:1398
+msgid "Freezing"
+msgstr "замерзання"
+
+#: id:1399
+msgid "Late"
+msgstr "пізніше"
+
+#: id:1400
+msgid "Isolated"
+msgstr "місцями"
+
+#: id:1401
+msgid "Thundershowers"
+msgstr "грозова злива"
+
+#: id:1402
+msgid "Thunder"
+msgstr "грім"
+
+#: id:1403
+msgctxt "Auto context with id 1403"
+msgid "Sun"
+msgstr "сонце"
+
+#: id:1404
+msgid "Heavy"
+msgstr "сильний"
+
+#: id:1405
+msgid "in"
+msgstr "в"
+
+#: id:1406
+msgid "the"
+msgstr ".."
+
+#: id:1407
+msgid "Vicinity"
+msgstr "околицях"
+
+#: id:1408
+msgid "Ice"
+msgstr "лід"
+
+#: id:1409
+msgid "Crystals"
+msgstr "кристали"
+
+#: id:1410
+msgid "Calm"
+msgstr "штиль"
+
+#: id:1411
+msgid "with"
+msgstr "з"
+
+#: id:1412
+msgid "windy"
+msgstr "вітряно"
+
+#: id:1413
+msgid "drizzle"
+msgstr "дощ"
+
+#: id:1414
+msgid "Thunderstorm"
+msgstr "гроза"
+
+#: id:1415
+msgid "Drizzle"
+msgstr "Дощ"
+
+#: id:1416
+msgid "Foggy"
+msgstr "Туманно"
+
+#: id:1417
+msgid "Grains"
+msgstr "Зерна"
+
+#: id:1418
+msgid "T-Storms"
+msgstr "Грози"
+
+#: id:1419
+msgid "T-Showers"
+msgstr "Грозові зливи"
+
+#: id:1420
+msgid "Moderate"
+msgstr ""
+
+#: id:1421
+msgid "Very High"
+msgstr ""
+
+#: id:1422
+msgid "Windy"
+msgstr ""
+
+#: id:1423
+msgid "Mist"
+msgstr ""
+
+#: id:1450
+msgid "Put display to sleep when idle"
+msgstr "Дозволити енергозбереження під час бездії"
+
+#: id:2050
+msgid "Runtime"
+msgstr "Тривалість"
+
+#: id:2100
+msgid "Script failed! : %s"
+msgstr "Помилка скрипта! : %s"
+
+#: id:2101
+msgid "Newer version needed - See log"
+msgstr "Потрібна новіша версія- Див log"
+
+#: id:4501
+msgid "Enable LCD/VFD"
+msgstr "Задіяти LCD/VFD"
+
+#: id:10000
+msgid "Home"
+msgstr "Основний"
+
+#: id:10001
+msgctxt "Auto context with id 10001"
+msgid "Programs"
+msgstr "Програми"
+
+#: id:10002
+msgctxt "Auto context with id 10002"
+msgid "Pictures"
+msgstr "Фотографії"
+
+#: id:10003
+msgctxt "Auto context with id 10003"
+msgid "File manager"
+msgstr "Файли"
+
+#: id:10004
+msgctxt "Auto context with id 10004"
+msgid "Settings"
+msgstr "Налаштування"
+
+#: id:10005
+msgctxt "Auto context with id 10005"
+msgid "Music"
+msgstr "Музика"
+
+#: id:10006
+msgctxt "Auto context with id 10006"
+msgid "Videos"
+msgstr "Відео"
+
+#: id:10007
+msgid "System information"
+msgstr "Інформація про систему"
+
+#: id:10008
+msgid "Settings - General"
+msgstr "Налаштування -> Головні"
+
+#: id:10009
+msgid "Settings - Screen"
+msgstr "Налаштування -> Екран"
+
+#: id:10010
+msgid "Settings - Appearance - GUI Calibration"
+msgstr "Налаштування -> Зовнішній вигляд -> Калібровка GUI"
+
+#: id:10011
+msgid "Settings - Videos - Screen Calibration"
+msgstr "Налаштування -> Відео -> Калібровка екрана"
+
+#: id:10012
+msgid "Settings - Pictures"
+msgstr "Налаштування -> Фотографії"
+
+#: id:10013
+msgid "Settings - Programs"
+msgstr "Налаштування -> Програми"
+
+#: id:10014
+msgid "Settings - Weather"
+msgstr "Налаштування -> Погода"
+
+#: id:10015
+msgid "Settings - Music"
+msgstr "Налаштування -> Музика"
+
+#: id:10016
+msgid "Settings - System"
+msgstr "Налаштування -> Система"
+
+#: id:10017
+msgid "Settings - Videos"
+msgstr "Налаштування -> Відео"
+
+#: id:10018
+msgid "Settings - Network"
+msgstr "Налаштування -> Мережа"
+
+#: id:10019
+msgid "Settings - Appearance"
+msgstr "Налаштування -> Зовнішній вигляд"
+
+#: id:10020
+msgctxt "Auto context with id 10020"
+msgid "Scripts"
+msgstr "Скрипти"
+
+#: id:10021
+msgid "Web Browser"
+msgstr ""
+
+#: id:10025
+msgctxt "Auto context with id 10025"
+msgid "Videos"
+msgstr ""
+
+#: id:10028
+msgid "Videos/Playlist"
+msgstr "Відео/Плейлист"
+
+#: id:10029
+msgctxt "Auto context with id 10029"
+msgid "Login screen"
+msgstr ""
+
+#: id:10034
+msgid "Settings - Profiles"
+msgstr "Налаштування -> Користувачі"
+
+#: id:10040
+msgid "Addon browser"
+msgstr ""
+
+#: id:10100
+msgid "Yes/No dialog"
+msgstr "Діалог \"Так/Ні\""
+
+#: id:10101
+msgid "Progress dialog"
+msgstr "Діалог прогресу"
+
+#: id:10210
+msgid "Looking for subtitles..."
+msgstr "Пошук субтитрів..."
+
+#: id:10211
+msgid "Looking for or caching subtitles..."
+msgstr "Пошук або буферизація субтитрів..."
+
+#: id:10212
+msgid "terminating"
+msgstr "припинення"
+
+#: id:10213
+msgid "buffering"
+msgstr "Буферизація"
+
+#: id:10214
+msgid "Opening stream"
+msgstr "Відкриття потоку"
+
+#: id:10500
+msgid "Music/Playlist"
+msgstr "Музика/Плейлист"
+
+#: id:10501
+msgid "Music/Files"
+msgstr "Музика/Файли"
+
+#: id:10502
+msgid "Music/Library"
+msgstr "Музика/Бібліотека"
+
+#: id:10503
+msgid "Playlist editor"
+msgstr "Редактор плейлисту"
+
+#: id:10504
+msgid "Top 100 songs"
+msgstr "Top 100 - Пісні"
+
+#: id:10505
+msgid "Top 100 albums"
+msgstr "Top 100 - Альбоми"
+
+#: id:10506
+msgctxt "Auto context with id 10506"
+msgid "Programs"
+msgstr "Програми"
+
+#: id:10507
+msgid "Configuration"
+msgstr "Налаштування профілю"
+
+#: id:10508
+msgid "Weather forecast"
+msgstr "Прогноз погоди"
+
+#: id:10509
+msgid "Network gaming"
+msgstr "Мережеві Ігри"
+
+#: id:10510
+msgid "Extensions"
+msgstr "Доповнення"
+
+#: id:10511
+msgctxt "Auto context with id 10511"
+msgid "System info"
+msgstr "Інформація про систему"
+
+#: id:10516
+msgid "Music - Library"
+msgstr "Музика - Бібліотека"
+
+#: id:10517
+msgid "Now Playing - Music"
+msgstr "Музика - Поточний плейлист"
+
+#: id:10522
+msgid "Now Playing - Videos"
+msgstr "Відео - Поточний плейлист"
+
+#: id:10523
+msgid "Album info"
+msgstr "Інформація про альбом"
+
+#: id:10524
+msgid "Movie info"
+msgstr "Інформація про фільм"
+
+#: id:12000
+msgid "Select dialog"
+msgstr "Діалогу вибору"
+
+#: id:12001
+msgid "Music/Info"
+msgstr "Музика/Дані"
+
+#: id:12002
+msgid "Dialog OK"
+msgstr "Діалог \"OK\""
+
+#: id:12003
+msgid "Videos/Info"
+msgstr "Відео/Дані"
+
+#: id:12004
+msgid "Scripts/Info"
+msgstr "Скрипти/Дані"
+
+#: id:12005
+msgid "Fullscreen video"
+msgstr "Повноекранне відео"
+
+#: id:12006
+msgid "Audio visualization"
+msgstr "Відео-ефекти для аудіо"
+
+#: id:12008
+msgid "File stacking dialog"
+msgstr "Діалог послідовності файлів"
+
+#: id:12009
+msgid "Rebuild index..."
+msgstr "Переіндексація…"
+
+#: id:12010
+msgid "Return to music window"
+msgstr "Назад в розділ \"Музика\""
+
+#: id:12011
+msgid "Return to videos window"
+msgstr "Назад в розділ \"Відео\""
+
+#: id:12021
+msgid "Start from beginning"
+msgstr "Починати з початку"
+
+#: id:12022
+msgid "Resume from %s"
+msgstr "Продовжувати з %s"
+
+#: id:12310
+msgid "0"
+msgstr ""
+
+#: id:12311
+msgid "1"
+msgstr ""
+
+#: id:12312
+msgid "2"
+msgstr ""
+
+#: id:12313
+msgid "3"
+msgstr ""
+
+#: id:12314
+msgid "4"
+msgstr ""
+
+#: id:12315
+msgid "5"
+msgstr ""
+
+#: id:12316
+msgid "6"
+msgstr ""
+
+#: id:12317
+msgid "7"
+msgstr ""
+
+#: id:12318
+msgid "8"
+msgstr ""
+
+#: id:12319
+msgid "9"
+msgstr ""
+
+#: id:12320
+msgid "c"
+msgstr ""
+
+#: id:12321
+msgid "Ok"
+msgstr ""
+
+#: id:12322
+msgid "*"
+msgstr ""
+
+#: id:12325
+msgid "Locked! Enter code..."
+msgstr "Заблоковано! Впишіть код..."
+
+#: id:12326
+msgid "Enter password"
+msgstr "Впишіть пароль"
+
+#: id:12327
+msgid "Enter master code"
+msgstr "Введіть код захисту"
+
+#: id:12328
+msgid "Enter unlock code"
+msgstr "Введіть код розблокування"
+
+#: id:12329
+msgid "or press C to cancel"
+msgstr "або нажміть 'С' для відміни"
+
+#: id:12330
+msgid "Enter gamepad button combo and"
+msgstr "Натисніть потрібні кнопки на джойстику і"
+
+#: id:12331
+msgid "press OK, or Back to cancel"
+msgstr "потім 'Start', або 'Back' для відміни"
+
+#: id:12332
+msgid "Set lock"
+msgstr "Встановити захист"
+
+#: id:12333
+msgid "Unlock"
+msgstr "Розблокувати"
+
+#: id:12334
+msgid "Reset lock"
+msgstr "Скинути захист"
+
+#: id:12335
+msgid "Remove lock"
+msgstr "Видалити захист"
+
+#: id:12337
+msgid "Numeric password"
+msgstr "цифровий пароль"
+
+#: id:12338
+msgid "Gamepad button combo"
+msgstr "комбінація кнопок джойстика"
+
+#: id:12339
+msgid "Full-text password"
+msgstr "текстовий пароль"
+
+#: id:12340
+msgid "Enter new password"
+msgstr "Впишіть новий пароль"
+
+#: id:12341
+msgid "Re-Enter new password"
+msgstr "Повторіть новий пароль"
+
+#: id:12342
+msgid "Incorrect password,"
+msgstr "Неправильний пароль,"
+
+#: id:12343
+msgid "retries left"
+msgstr "спроб(и) залишилось"
+
+#: id:12344
+msgid "Passwords entered did not match."
+msgstr "Введені паролі не збігаються."
+
+#: id:12345
+msgid "Access denied"
+msgstr "Доступ заборонено"
+
+#: id:12346
+msgid "Password retry limit exceeded."
+msgstr "Кількість спроб вводу пароля вичерпано."
+
+#: id:12347
+msgid "The system will now shut off."
+msgstr "Зараз систему буде вимкнено."
+
+#: id:12348
+msgid "Item locked"
+msgstr "Заблоковано"
+
+#: id:12353
+msgid "Reactivate lock"
+msgstr "Перевстановити захист"
+
+#: id:12356
+msgid "Change lock"
+msgstr "Змінити захист"
+
+#: id:12357
+msgid "Source lock"
+msgstr "Захист джерела"
+
+#: id:12358
+msgid "Password entry was blank. Try again."
+msgstr "Поле вводу пароля порожнє. Спробуйте ще раз."
+
+#: id:12360
+msgid "Master lock"
+msgstr "Головний захист"
+
+#: id:12362
+msgid "Shutdown system if Master Lock retries exceeded"
+msgstr "Вимкнути систему якщо кількість спроб вичерпано"
+
+#: id:12367
+msgid "Master code is not valid"
+msgstr "Код захисту не правильний!"
+
+#: id:12368
+msgid "Please enter a valid master code"
+msgstr "Введіть правильний код захисту!"
+
+#: id:12373
+msgid "Settings & file manager"
+msgstr "Настройки і Файли"
+
+#: id:12376
+msgid "Set as default for all movies"
+msgstr "Встановити для всіх фільмів"
+
+#: id:12377
+msgid "This will reset any previously saved values"
+msgstr "Збережені раніше значення буде скинуто."
+
+#: id:12378
+msgid "Amount of time to display each image"
+msgstr "Час показу кожного слайду"
+
+#: id:12379
+msgid "Use pan and zoom effects"
+msgstr "Ефекти панорами та збільшення"
+
+#: id:12383
+msgid "12 hour clock"
+msgstr "12-ти годинний"
+
+#: id:12384
+msgid "24 hour clock"
+msgstr "24-х годинний"
+
+#: id:12385
+msgid "Day/Month"
+msgstr "День/Місяць"
+
+#: id:12386
+msgid "Month/Day"
+msgstr "Місяць/День"
+
+#: id:12390
+msgid "System uptime"
+msgstr "Час роботи системи"
+
+#: id:12391
+msgid "Minutes"
+msgstr "хвилин"
+
+#: id:12392
+msgid "Hours"
+msgstr "годин"
+
+#: id:12393
+msgid "Days"
+msgstr "днів"
+
+#: id:12394
+msgid "Total uptime"
+msgstr "Загальний час роботи"
+
+#: id:12395
+msgid "Battery level"
+msgstr ""
+
+#: id:12600
+msgctxt "Auto context with id 12600"
+msgid "Weather"
+msgstr "Погода"
+
+#: id:12900
+msgctxt "Auto context with id 12900"
+msgid "Screensaver"
+msgstr "Заставка"
+
+#: id:12901
+msgid "Fullscreen OSD"
+msgstr "Повноекранне OSD"
+
+#: id:13000
+msgid "System"
+msgstr "Система"
+
+#: id:13001
+msgid "Immediate HD spindown"
+msgstr "Термінова зупинка HDD"
+
+#: id:13002
+msgid "Video only"
+msgstr "Тільки відео"
+
+#: id:13003
+msgid "- Delay"
+msgstr "- затримка"
+
+#: id:13004
+msgid "- Minimum file duration"
+msgstr "- мінімальна тривалість файла"
+
+#: id:13005
+msgid "Shutdown"
+msgstr "Вимикання"
+
+#: id:13008
+msgid "Shutdown function"
+msgstr "Завершити роботу і вимкнути"
+
+#: id:13009
+msgid "Quit"
+msgstr "Вихід"
+
+#: id:13010
+msgid "Hibernate"
+msgstr "Зберегти сеанс на диск і вимкнути"
+
+#: id:13011
+msgid "Suspend"
+msgstr "Призупинити"
+
+#: id:13012
+msgid "Exit"
+msgstr "Вихід із"
+
+#: id:13013
+msgid "Reboot"
+msgstr "Перезавантаження"
+
+#: id:13014
+msgid "Minimize"
+msgstr "Згорнути"
+
+#: id:13015
+msgid "Power button action"
+msgstr "Дія кнопки живлення"
+
+#: id:13016
+msgid "Power off System"
+msgstr "Вимкнути комп’ютер"
+
+#: id:13020
+msgid "Is another session active, perhaps over ssh?"
+msgstr "Активна інша сессія, можливо через SSH?"
+
+#: id:13021
+msgid "Mounted removable harddrive"
+msgstr "Під'єднано переносний жорсткий диск"
+
+#: id:13022
+msgid "Unsafe device removal"
+msgstr "Небезпечне видалення пристрою"
+
+#: id:13023
+msgid "Successfully removed device"
+msgstr "Пристрій від'єднано успішно"
+
+#: id:13024
+msgid "Joystick plugged"
+msgstr "Джойстик підключено"
+
+#: id:13025
+msgid "Joystick unplugged"
+msgstr "Джойстик відключено"
+
+#: id:13050
+msgid "Running low on battery"
+msgstr "Низький заряд батареї"
+
+#: id:13100
+msgid "Flicker filter"
+msgstr "Рівень зменшення мерехтіння"
+
+#: id:13101
+msgid "Let driver choose (requires restart)"
+msgstr "За виб. драйверу (перезав.)"
+
+#: id:13105
+msgid "Vertical blank sync"
+msgstr "Вертик. синхронізація"
+
+#: id:13106
+msgctxt "Auto context with id 13106"
+msgid "Disabled"
+msgstr "Вимкнено"
+
+#: id:13107
+msgid "Enabled during video playback"
+msgstr "Тільки при програванні відео"
+
+#: id:13108
+msgctxt "Auto context with id 13108"
+msgid "Always enabled"
+msgstr "Включено завжди"
+
+#: id:13109
+msgid "Test & apply resolution"
+msgstr "Перевірка відеорежиму"
+
+#: id:13110
+msgid "Save resolution?"
+msgstr "Зберегти відеорежим?"
+
+#: id:13111
+msgid "Would you like to keep this resolution?"
+msgstr "Ви хочете залишити цей відеорежим?"
+
+#: id:13112
+msgid "High quality upscaling"
+msgstr "Високоякісне масштабування"
+
+#: id:13113
+msgctxt "Auto context with id 13113"
+msgid "Disabled"
+msgstr "Відключено"
+
+#: id:13114
+msgid "Enabled for SD content"
+msgstr "Тільки для SD вмісту"
+
+#: id:13115
+msgctxt "Auto context with id 13115"
+msgid "Always enabled"
+msgstr "Включено завжди"
+
+#: id:13116
+msgid "Upscaling method"
+msgstr "Метод масштабування"
+
+#: id:13117
+msgctxt "Auto context with id 13117"
+msgid "Bicubic"
+msgstr ""
+
+#: id:13118
+msgid "Lanczos"
+msgstr ""
+
+#: id:13119
+msgid "Sinc"
+msgstr ""
+
+#: id:13120
+msgctxt "Auto context with id 13120"
+msgid "VDPAU"
+msgstr "Strict Pixmap-Texture Binding (перезавантажити)"
+
+#: id:13121
+msgid "VDPAU HQ Upscaling level"
+msgstr ""
+
+#: id:13122
+msgid "VDPAU Studio level color conversion"
+msgstr "Перетворення кольорів VDPAU Studio"
+
+#: id:13130
+msgid "Blank other displays"
+msgstr "Погасити інші екрани"
+
+#: id:13131
+msgctxt "Auto context with id 13131"
+msgid "Disabled"
+msgstr "Відключено"
+
+#: id:13132
+msgid "Blank displays"
+msgstr "Погасити екрани"
+
+#: id:13140
+msgid "Active connections detected!"
+msgstr "Знайдено активне з'єднання!"
+
+#: id:13141
+msgid "If you proceed, you might not be able to control XBMC"
+msgstr "Якщо ви продовжите, то можете втратити можливість"
+
+#: id:13142
+msgid "any longer. Are you sure you want to stop the Event server?"
+msgstr "керувати XBMC. Ви впевнені що хочете зупинити сервер подій?"
+
+#: id:13144
+msgid "Change Apple Remote mode?"
+msgstr "Змінити режим пульта Apple?"
+
+#: id:13145
+msgid "If you are currently using the Apple Remote to control"
+msgstr "Якщо ви зараз використовуєте пульт Apple щоб керувать"
+
+#: id:13146
+msgid "XBMC, changing this setting might affect your ability"
+msgstr "XBMC, то зміна цих налаштувань може перешкодити"
+
+#: id:13147
+msgid "to continue controlling it. Do you want to proceed?"
+msgstr "можливості керування ним. Хочете продовжити?"
+
+#: id:13159
+msgid "Subnet mask"
+msgstr "Маска мережі"
+
+#: id:13160
+msgid "Gateway"
+msgstr "Шлюз"
+
+#: id:13161
+msgid "Primary DNS"
+msgstr "Основний DNS"
+
+#: id:13162
+msgid "Initialize failed"
+msgstr "Ініціалізація не вдалася"
+
+#: id:13170
+msgctxt "Auto context with id 13170"
+msgid "Never"
+msgstr "ніколи"
+
+#: id:13171
+msgid "Immediately"
+msgstr "відразу"
+
+#: id:13172
+msgid "After %i secs"
+msgstr "через %і сек"
+
+#: id:13173
+msgid "HDD install date:"
+msgstr "Дата встановлення HDD:"
+
+#: id:13174
+msgid "HDD power cycle count:"
+msgstr "Кількість циклів ввімкнення/вимкнення HDD:"
+
+#: id:13200
+msgid "Profiles"
+msgstr "Профілі"
+
+#: id:13201
+msgid "Delete profile '%s'?"
+msgstr "Видалити профіль '%s'?"
+
+#: id:13204
+msgid "Last loaded profile:"
+msgstr "Останній завантажений профіль:"
+
+#: id:13205
+msgid "Unknown"
+msgstr "Невідомо"
+
+#: id:13206
+msgid "Overwrite"
+msgstr "Перезаписати"
+
+#: id:13208
+msgid "Alarm clock"
+msgstr "Таймер нагадувань"
+
+#: id:13209
+msgid "Alarm clock interval (in minutes)"
+msgstr "Період таймера нагадувань (в хвилинах)"
+
+#: id:13210
+msgid "Started, alarm in %im"
+msgstr "Запущено, спрацює в %im"
+
+#: id:13211
+msgid "Alarm!"
+msgstr "НАГАДУВАННЯ!"
+
+#: id:13212
+msgid "Canceled with %im%is left"
+msgstr "Скасовано за %im%is до спрацювання"
+
+#: id:13213
+msgid "%2.0fm"
+msgstr ""
+
+#: id:13214
+msgid "%2.0fs"
+msgstr ""
+
+#: id:13249
+msgid "Search for subtitles in RARs"
+msgstr "Шукати субтитри в RAR-архівах"
+
+#: id:13250
+msgid "Browse for subtitle..."
+msgstr "Вкажіть субтитри..."
+
+#: id:13251
+msgid "Move item"
+msgstr "Перемістити об'єкт"
+
+#: id:13252
+msgid "Move item here"
+msgstr "Перемістити об'єкт сюди"
+
+#: id:13253
+msgid "Cancel move"
+msgstr "Відмінити переміщення"
+
+#: id:13270
+msgid "Hardware:"
+msgstr "Обладнання:"
+
+#: id:13271
+msgid "CPU Usage:"
+msgstr "Завантаженість CPU:"
+
+#: id:13274
+msgid "Connected, but no DNS is available."
+msgstr "Підключено, але DNS сервер недоступний."
+
+#: id:13275
+msgid "Hard Disk"
+msgstr "Жорсткий диск"
+
+#: id:13276
+msgid "DVD-ROM"
+msgstr "Привід DVD"
+
+#: id:13277
+msgctxt "Auto context with id 13277"
+msgid "Storage"
+msgstr "Накопичувачі"
+
+#: id:13278
+msgctxt "Auto context with id 13278"
+msgid "Default"
+msgstr "Стандартне"
+
+#: id:13279
+msgctxt "Auto context with id 13279"
+msgid "Network"
+msgstr "Мережа"
+
+#: id:13280
+msgctxt "Auto context with id 13280"
+msgid "Video"
+msgstr "Відео"
+
+#: id:13281
+msgid "Hardware"
+msgstr "Обладнання"
+
+#: id:13283
+msgid "Operating system:"
+msgstr "Операційна система:"
+
+#: id:13284
+msgid "CPU speed:"
+msgstr "Частота CPU:"
+
+#: id:13286
+msgid "Video encoder:"
+msgstr "Чіп відеокодувальника:"
+
+#: id:13287
+msgid "Screen resolution:"
+msgstr "Відеорежим:"
+
+#: id:13292
+msgid "A/V cable:"
+msgstr "Кабель A/V:"
+
+#: id:13294
+msgid "DVD region:"
+msgstr "Регіон DVD:"
+
+#: id:13295
+msgid "Internet:"
+msgstr "Інтернет:"
+
+#: id:13296
+msgctxt "Auto context with id 13296"
+msgid "Connected"
+msgstr "Підключено"
+
+#: id:13297
+msgid "Not connected. Check network settings."
+msgstr "Не підключено. Перевірте параметри мережі."
+
+#: id:13299
+msgid "Target temperature"
+msgstr "Підтримувати температуру"
+
+#: id:13300
+msgid "Fan speed"
+msgstr "Швидкість вентилятора"
+
+#: id:13301
+msgid "Auto temperature control"
+msgstr "Автоматичний контроль температури"
+
+#: id:13302
+msgid "Fan speed override"
+msgstr "Управління швидкістю вентилятора"
+
+#: id:13303
+msgid "- Fonts"
+msgstr "- Шрифти"
+
+#: id:13304
+msgid "Enable flipping bi-directional strings"
+msgstr "Дозволити зворотній напрямок рядків"
+
+#: id:13305
+msgid "Show RSS news feeds"
+msgstr "Задіяти RSS-новини"
+
+#: id:13306
+msgid "Show parent folder items"
+msgstr "Сховати значок переходу на верхній рівень"
+
+#: id:13307
+msgid "Track naming template"
+msgstr "Шаблон для імені треку"
+
+#: id:13308
+msgid "Do you wish to reboot your system"
+msgstr "Хочете перезавантажити систему"
+
+#: id:13309
+msgid "instead of just XBMC?"
+msgstr "замість перезапуску XBMC?"
+
+#: id:13310
+msgid "Zoom effect"
+msgstr "Ефект збільшення"
+
+#: id:13311
+msgid "Float effect"
+msgstr "Ефект ковзання"
+
+#: id:13312
+msgid "Black bar reduction"
+msgstr "Зменшення чорних смуг"
+
+#: id:13313
+msgid "Restart"
+msgstr "Перезапуск"
+
+#: id:13314
+msgid "Crossfade between songs"
+msgstr "Тривалість накладання треків"
+
+#: id:13315
+msgid "Regenerate thumbnails"
+msgstr "Оновити ескізи"
+
+#: id:13316
+msgid "Recursive thumbnails"
+msgstr "Рекурсивні ескізи"
+
+#: id:13317
+msgid "View slideshow"
+msgstr "Перегляд слайдшоу"
+
+#: id:13318
+msgid "Recursive slideshow"
+msgstr "Рекурсивне слайдшоу"
+
+#: id:13319
+msgid "Randomize"
+msgstr "Випадково"
+
+#: id:13320
+msgid "Stereo"
+msgstr "Стерео"
+
+#: id:13321
+msgid "Left only"
+msgstr "лише Лівий"
+
+#: id:13322
+msgid "Right only"
+msgstr "лише Правий"
+
+#: id:13323
+msgid "Enable karaoke support"
+msgstr "Задіяти підтримку караоке (CD+G)"
+
+#: id:13324
+msgid "Background transparency"
+msgstr "Рівень прозорості фону"
+
+#: id:13325
+msgid "Foreground transparency"
+msgstr "Рівень прозорості тексту"
+
+#: id:13326
+msgid "A/V delay"
+msgstr "Затримка звуку щодо зображення"
+
+#: id:13327
+msgid "Karaoke"
+msgstr "Караоке"
+
+#: id:13328
+msgid "%s not found"
+msgstr "%s не знайдено"
+
+#: id:13329
+msgid "Error opening %s"
+msgstr "Помилка відкриття %s"
+
+#: id:13330
+msgid "Unable to load %s"
+msgstr "Неможливо завантажити %s"
+
+#: id:13331
+msgid "Error: Out of memory"
+msgstr "Помилка: Недостатньо пам'яті"
+
+#: id:13332
+msgid "Move up"
+msgstr "Перемістити вище"
+
+#: id:13333
+msgid "Move down"
+msgstr "Перемістити нижче"
+
+#: id:13334
+msgid "Edit label"
+msgstr "Змінити позначку"
+
+#: id:13335
+msgid "Make default"
+msgstr "Зробити за замовчуванням"
+
+#: id:13336
+msgid "Remove button"
+msgstr "Прибрати кнопку"
+
+#: id:13340
+msgid "Leave as is"
+msgstr "Залишити як є"
+
+#: id:13341
+msgid "Green"
+msgstr "зелений"
+
+#: id:13342
+msgid "Orange"
+msgstr "помаранчевий"
+
+#: id:13343
+msgid "Red"
+msgstr "червоний"
+
+#: id:13344
+msgid "Cycle"
+msgstr "усі кольори по черзі"
+
+#: id:13345
+msgid "Switch LED off on playback"
+msgstr "Вимикати LED при програванні"
+
+#: id:13346
+msgctxt "Auto context with id 13346"
+msgid "Movie information"
+msgstr "Інформація про фільм"
+
+#: id:13347
+msgid "Queue item"
+msgstr "Додати в плейлист"
+
+#: id:13348
+msgid "Search IMDb..."
+msgstr "Знайти в IMDb..."
+
+#: id:13349
+msgid "Scan for new content"
+msgstr "Сканувати новий вміст"
+
+#: id:13350
+msgid "Now playing..."
+msgstr "Поточний плейлист..."
+
+#: id:13351
+msgctxt "Auto context with id 13351"
+msgid "Album information"
+msgstr "Дані про альбом"
+
+#: id:13352
+msgid "Scan item to library"
+msgstr "Сканувати в Бібліотеку"
+
+#: id:13353
+msgid "Stop scanning"
+msgstr "Зупинити сканування"
+
+#: id:13354
+msgctxt "Auto context with id 13354"
+msgid "Render method"
+msgstr "Метод обробки"
+
+#: id:13355
+msgid "Low quality pixel shader"
+msgstr "Пікс.шейдер низ.якості"
+
+#: id:13356
+msgid "Hardware overlays"
+msgstr "Апаратне накладення"
+
+#: id:13357
+msgid "High quality pixel shader"
+msgstr "Пікс.шейдер вис.якості"
+
+#: id:13358
+msgid "Play item"
+msgstr "Програти об'єкт"
+
+#: id:13359
+msgid "Set artist thumb"
+msgstr "Встановити ескіз виконавця"
+
+#: id:13360
+msgid "Automatically generate thumbnails"
+msgstr "Створювати ескізи"
+
+#: id:13361
+msgid "Enable voice"
+msgstr "Задіяти мікрофон"
+
+#: id:13375
+msgid "Enable device"
+msgstr "Задіяти пристрій"
+
+#: id:13376
+msgid "Volume"
+msgstr "Гучність"
+
+#: id:13377
+msgid "Default view mode"
+msgstr "Основний режим перегляду"
+
+#: id:13378
+msgid "Default brightness"
+msgstr "Стандартна яскравість"
+
+#: id:13379
+msgid "Default contrast"
+msgstr "Стандартна контрасність"
+
+#: id:13380
+msgid "Default gamma"
+msgstr "Стандартна гама"
+
+#: id:13381
+msgid "Resume video"
+msgstr "Продовжити відео"
+
+#: id:13382
+msgid "Voice mask - Port 1"
+msgstr "Маска для голосу 1"
+
+#: id:13383
+msgid "Voice mask - Port 2"
+msgstr "Маска для голосу 2"
+
+#: id:13384
+msgid "Voice mask - Port 3"
+msgstr "Маска для голосу 3"
+
+#: id:13385
+msgid "Voice mask - Port 4"
+msgstr "Маска для голосу 4"
+
+#: id:13386
+msgid "Use time based seeking"
+msgstr "Позиціонувати за часом"
+
+#: id:13387
+msgid "Track naming template - right"
+msgstr "Права колонка у списку"
+
+#: id:13388
+msgid "Preset"
+msgstr "Перед-налаштування"
+
+#: id:13389
+msgid "There are no presets available\nfor this visualization"
+msgstr "Для цього відео-ефекту немає перед-налаштувань"
+
+#: id:13390
+msgid "There are no settings available\nfor this visualization"
+msgstr "Для цього відео-ефекту немає налаштувань"
+
+#: id:13391
+msgid "Eject/Load"
+msgstr "Відкрити / Закрити"
+
+#: id:13392
+msgid "Use visualization if playing audio"
+msgstr "Вмикати відео-ефекти при програванні музики"
+
+#: id:13393
+msgid "Calculate size"
+msgstr "Вичислити розмір"
+
+#: id:13394
+msgid "Calculating folder size"
+msgstr "Обчислюється розмір папки"
+
+#: id:13395
+msgid "Video settings"
+msgstr "Налаштування Відео"
+
+#: id:13396
+msgid "Audio and subtitle settings"
+msgstr "Налаштування субтитрів і звуку"
+
+#: id:13397
+msgid "Enable subtitles"
+msgstr "Використовувати субтитри"
+
+#: id:13398
+msgctxt "Auto context with id 13398"
+msgid "Shortcuts"
+msgstr "Ярлики"
+
+#: id:13399
+msgid "Ignore articles when sorting (e.g. \"the\")"
+msgstr "Не враховувати артиклі при сортуванні"
+
+#: id:13400
+msgid "Crossfade between songs on the same album"
+msgstr "М'який перехід до наступного треку"
+
+#: id:13401
+msgid "Browse for %s"
+msgstr "Пошук %s"
+
+#: id:13402
+msgid "Show track position"
+msgstr "Показати позицію треку"
+
+#: id:13403
+msgid "Clear default"
+msgstr "Очистити за замовчуванням"
+
+#: id:13404
+msgid "Resume"
+msgstr "Продовжити"
+
+#: id:13405
+msgid "Get thumb"
+msgstr "Одержати ескіз"
+
+#: id:13406
+msgid "Picture information"
+msgstr "Дані про фотографію"
+
+#: id:13407
+msgid "%s presets"
+msgstr "%s перед-налаштування"
+
+#: id:13408
+msgid "(IMDb user rating)"
+msgstr "(Рейтинг користувачів IMDb)"
+
+#: id:13409
+msgid "Top 250"
+msgstr "Топ 250"
+
+#: id:13410
+msgid "Tune in on Last.fm"
+msgstr "Налаштуватися на Last.fm"
+
+#: id:13411
+msgid "Minimum fan speed"
+msgstr "Мінімальна швидкість вентиляторів"
+
+#: id:13412
+msgid "Play from here"
+msgstr ""
+
+#: id:13413
+msgid "Downloading"
+msgstr "Завантаження"
+
+#: id:13414
+msgid "Include artists who appear only on compilations"
+msgstr "Ховати виконавців, які з'являються лише у збірках"
+
+#: id:13415
+msgctxt "Auto context with id 13415"
+msgid "Render method"
+msgstr "Метод обробки"
+
+#: id:13416
+msgid "Auto detect"
+msgstr "Авто-визначення"
+
+#: id:13417
+msgid "Basic shaders (ARB)"
+msgstr "Основні шейдери (ARB)"
+
+#: id:13418
+msgid "Advanced shaders (GLSL)"
+msgstr "Розширені шейдери (GLSL)"
+
+#: id:13419
+msgid "Software"
+msgstr "Програмний"
+
+#: id:13420
+msgid "Remove safely"
+msgstr "Видалити безпечно"
+
+#: id:13421
+msgctxt "Auto context with id 13421"
+msgid "VDPAU"
+msgstr ""
+
+#: id:13422
+msgid "Start slideshow here"
+msgstr "Почати показ слайдів звідси"
+
+#: id:13423
+msgid "Remember for this path"
+msgstr "Запам’ятати для цього шляху"
+
+#: id:13424
+msgid "Use pixel buffer objects"
+msgstr "Використовувати об’єкти піксельних буферів"
+
+#: id:13425
+msgid "Allow hardware acceleration (VDPAU)"
+msgstr "Дозволити апаратне прискорення (VDPAU)"
+
+#: id:13426
+msgid "Allow hardware acceleration (VAAPI)"
+msgstr "Дозволити апаратне прискорення (VAAPI)"
+
+#: id:13427
+msgid "Allow hardware acceleration (DXVA2)"
+msgstr "Дозволити апаратне прискорення (DXVA2)"
+
+#: id:13428
+msgid "Allow hardware acceleration (CrystalHD)"
+msgstr "Дозволити апаратне прискорення (CrystalHD)"
+
+#: id:13429
+msgid "Allow hardware acceleration (VDADecoder)"
+msgstr "Дозволити апаратне прискорення (VDADecoder)"
+
+#: id:13430
+msgid "Allow hardware acceleration (OpenMax)"
+msgstr "Дозволити апаратне прискорення (OpenMax)"
+
+#: id:13431
+msgid "Pixel Shaders"
+msgstr "Піксельні шейдери"
+
+#: id:13432
+msgid "Allow hardware acceleration (VideoToolbox)"
+msgstr ""
+
+#: id:13500
+msgid "A/V sync method"
+msgstr "Метод синхронізації A/V"
+
+#: id:13501
+msgid "Audio clock"
+msgstr "по частоті звуку"
+
+#: id:13502
+msgid "Video clock (Drop/Dupe audio)"
+msgstr "по частоті відео (пропускати / дублювати звук)"
+
+#: id:13503
+msgid "Video clock (Resample audio)"
+msgstr "по частоті відео (перетв. звук)"
+
+#: id:13504
+msgid "Maximum resample amount (%)"
+msgstr "Максимальна величина перетворення (%)"
+
+#: id:13505
+msgid "Resample quality"
+msgstr "Якість перетворення"
+
+#: id:13506
+msgid "Low(fast)"
+msgstr "Низька (швидко)"
+
+#: id:13507
+msgctxt "Auto context with id 13507"
+msgid "Medium"
+msgstr "Середня"
+
+#: id:13508
+msgctxt "Auto context with id 13508"
+msgid "High"
+msgstr "Висока"
+
+#: id:13509
+msgid "Really high(slow!)"
+msgstr "Дійсно висока (повільно!)"
+
+#: id:13510
+msgid "Sync playback to display"
+msgstr "Синхронізувати з частотою екрану"
+
+#: id:13550
+msgid "Pause during refresh rate change"
+msgstr "Призупиняти при зміні частоти оновлення"
+
+#: id:13551
+msgctxt "Auto context with id 13551"
+msgid "Off"
+msgstr "Вимкн."
+
+#: id:13552
+msgid "%.1f Second"
+msgstr ""
+
+#: id:13553
+msgid "%.1f Seconds"
+msgstr ""
+
+#: id:13600
+msgid "Apple remote"
+msgstr "Пульт Apple"
+
+#: id:13602
+msgid "Allow start of XBMC using the remote"
+msgstr "Працює завжди"
+
+#: id:13603
+msgid "Sequence delay time"
+msgstr "Час затримки послідовності"
+
+#: id:13610
+msgctxt "Auto context with id 13610"
+msgid "Disabled"
+msgstr "Вимкнено"
+
+#: id:13611
+msgctxt "Auto context with id 13611"
+msgid "Standard"
+msgstr "Стандартний"
+
+#: id:13612
+msgid "Universal Remote"
+msgstr "Універсальний пульт"
+
+#: id:13613
+msgid "Multi Remote (Harmony)"
+msgstr "Мульти-пульт (Harmony)"
+
+#: id:13620
+msgid "Apple Remote Error"
+msgstr "Помилка пульта Apple"
+
+#: id:13621
+msgid "Apple Remote support could be enabled."
+msgstr "Підтримка пультів Apple повинна бути включена"
+
+#: id:14000
+msgid "Stack"
+msgstr "Об'єднати"
+
+#: id:14001
+msgid "Unstack"
+msgstr "Роз'єднати"
+
+#: id:14003
+msgid "Downloading playlist file..."
+msgstr "Завантажується файл плейлиста..."
+
+#: id:14004
+msgid "Downloading streams list..."
+msgstr "Завантажується список потоків..."
+
+#: id:14005
+msgid "Parsing streams list..."
+msgstr "Аналіз списку потоків..."
+
+#: id:14006
+msgid "Downloading streams list failed"
+msgstr "Помилка завантаження списку потоків"
+
+#: id:14007
+msgid "Downloading playlist file failed"
+msgstr "Помилка завантаження файла плейлиста"
+
+#: id:14009
+msgid "Games directory"
+msgstr "Папка з іграми"
+
+#: id:14010
+msgid "Auto switch to thumbs based on"
+msgstr "Авто-переключення вигляду на ескізи по"
+
+#: id:14011
+msgid "Enable auto switching to thumbs view"
+msgstr "Автоматично переключати вигляд на ескізи"
+
+#: id:14012
+msgid "- Use large icons"
+msgstr "- використовувати великі значки"
+
+#: id:14013
+msgid "- Switch based on"
+msgstr "- переключати по"
+
+#: id:14014
+msgid "- Percentage"
+msgstr "- відсотків"
+
+#: id:14015
+msgid "No files and at least one thumb"
+msgstr "Немає файлів, але є хоча б один ескіз"
+
+#: id:14016
+msgid "At least one file and thumb"
+msgstr "Хоча б один файл і ескіз"
+
+#: id:14017
+msgid "Percentage of thumbs"
+msgstr "Відсотків ескізів"
+
+#: id:14018
+msgid "View options"
+msgstr "Налаштування перегляду"
+
+#: id:14019
+msgid "Change area code 1"
+msgstr "Місцевість 1"
+
+#: id:14020
+msgid "Change area code 2"
+msgstr "Місцевість 2"
+
+#: id:14021
+msgid "Change area code 3"
+msgstr "Місцевість 3"
+
+#: id:14022
+msgctxt "Auto context with id 14022"
+msgid "Library"
+msgstr "Бібліотека"
+
+#: id:14023
+msgid "No TV"
+msgstr "Без ТБ"
+
+#: id:14024
+msgid "Enter the nearest large town"
+msgstr "Впишіть найближче велике місто"
+
+#: id:14025
+msgid "Video/Audio/DVD cache - Harddisk"
+msgstr "Кеш для Аудіо, Відео та DVD-файлів: - з HDD"
+
+#: id:14026
+msgid "Video cache - DVD-ROM"
+msgstr "Кеш для Відеофайлів: - з DVD диска"
+
+#: id:14027
+msgctxt "Auto context with id 14027"
+msgid "- Local Network"
+msgstr "- з локальної мережі"
+
+#: id:14028
+msgctxt "Auto context with id 14028"
+msgid "- Internet"
+msgstr "- з Інтернету"
+
+#: id:14030
+msgid "Audio cache - DVD-ROM"
+msgstr "Кеш для Аудіофайлів: - з DVD диска"
+
+#: id:14031
+msgctxt "Auto context with id 14031"
+msgid "- Local Network"
+msgstr "- з локальної мережі"
+
+#: id:14032
+msgctxt "Auto context with id 14032"
+msgid "- Internet"
+msgstr "- з Інтернету"
+
+#: id:14034
+msgid "DVD cache - DVD-ROM"
+msgstr "Кеш для файлів DVD-Video: - з DVD диска"
+
+#: id:14035
+msgctxt "Auto context with id 14035"
+msgid "- Local Network"
+msgstr "- з локальної мережі"
+
+#: id:14036
+msgctxt "Auto context with id 14036"
+msgid "Services"
+msgstr "Сервери"
+
+#: id:14038
+msgid "Network settings changed"
+msgstr "Налаштування локальної мережі змінені"
+
+#: id:14039
+msgid "XBMC requires to restart to change your"
+msgstr "Для застосування змін мережевих параметрів, потрібне"
+
+#: id:14040
+msgid "network setup. Would you like to restart now?"
+msgstr "перезавантаження XBMC. Перезавантажити зараз?"
+
+#: id:14041
+msgid "Internet connection bandwidth limitation"
+msgstr "Пост-процессінг"
+
+#: id:14043
+msgid "- Shutdown while playing"
+msgstr "- Вимикати під час програвання"
+
+#: id:14044
+msgid "%i min"
+msgstr "%i хв."
+
+#: id:14045
+msgid "%i sec"
+msgstr "%i сек."
+
+#: id:14046
+msgid "%i ms"
+msgstr "%i мсек."
+
+#: id:14047
+msgid "%i %%"
+msgstr "%i %%"
+
+#: id:14048
+msgid "%i kbps"
+msgstr "%i кб/сек"
+
+#: id:14049
+msgid "%i kb"
+msgstr "%i кб"
+
+#: id:14050
+msgid "%i.0 dB"
+msgstr "%i.0 dB"
+
+#: id:14051
+msgid "Time format"
+msgstr "Формат часу"
+
+#: id:14052
+msgid "Date format"
+msgstr "Формат дати"
+
+#: id:14053
+msgid "GUI filters"
+msgstr "Фільтри інтерфейсу"
+
+#: id:14055
+msgid "Use background scanning"
+msgstr "Сканувати у фоновому режимі"
+
+#: id:14056
+msgid "Stop scan"
+msgstr "Зупинити сканування"
+
+#: id:14057
+msgid "Not possible while scanning for media info"
+msgstr "Неможливо, поки скануються файли"
+
+#: id:14058
+msgid "Film grain effect"
+msgstr "Ефект кіноплівки"
+
+#: id:14059
+msgid "Search for thumbnails on remote shares"
+msgstr "Шукати ескізи на зовнішніх ресурсах"
+
+#: id:14060
+msgid "Unknown type cache - Internet"
+msgstr "Кеш невизначених файлів: - з Інтернету"
+
+#: id:14061
+msgctxt "Auto context with id 14061"
+msgid "Auto"
+msgstr "Автоматично"
+
+#: id:14062
+msgid "Enter username for"
+msgstr "Впишіть ім'я користувача для"
+
+#: id:14063
+msgid "Date & time"
+msgstr "Дата і Час"
+
+#: id:14064
+msgid "Set date"
+msgstr "Встановити дату"
+
+#: id:14065
+msgid "Set time"
+msgstr "Встановити час"
+
+#: id:14066
+msgid "Enter the time in 24 hour HH:MM format"
+msgstr "Впишіть час у 24-х годинному форматі ГГ:ХХ"
+
+#: id:14067
+msgid "Enter the date in DD/MM/YYYY format"
+msgstr "Впишіть дату в форматі ДД/ММ/РРРР"
+
+#: id:14068
+msgid "Enter the IP address"
+msgstr "Впишіть IP-адресу"
+
+#: id:14069
+msgid "Apply these settings now?"
+msgstr "Застосувати ці зміни зараз?"
+
+#: id:14070
+msgid "Apply changes now"
+msgstr "Застосувати зміни зараз"
+
+#: id:14071
+msgid "Allow file renaming and deletion"
+msgstr "Дозволити перейменування і видалення файлів"
+
+#: id:14074
+msgid "Set timezone"
+msgstr "Встановити часовий пояс"
+
+#: id:14075
+msgid "Use daylight saving time"
+msgstr "Враховувати літній/зимовий час"
+
+#: id:14076
+msgid "Add to favourites"
+msgstr "Додати до Вибраного"
+
+#: id:14077
+msgid "Remove from favourites"
+msgstr "Видалити з Вибраного"
+
+#: id:14078
+msgctxt "Auto context with id 14078"
+msgid "- Colours"
+msgstr "- Колір"
+
+#: id:14079
+msgid "Timezone country"
+msgstr "Країна"
+
+#: id:14080
+msgid "Timezone"
+msgstr "Часовий пояс"
+
+#: id:14081
+msgid "File lists"
+msgstr "Списки файлів"
+
+#: id:14082
+msgid "Show EXIF picture information"
+msgstr "Показати EXIF інформацію зображення"
+
+#: id:14083
+msgid "Use a fullscreen window rather than true fullscreen"
+msgstr "Використовувати повноекранне вікно замість справжнього повноекранного режиму"
+
+#: id:14084
+msgid "Queue songs on selection"
+msgstr "Додавати треки у чергу при виборі"
+
+#: id:14086
+msgid "Playback"
+msgstr "Програвання"
+
+#: id:14087
+msgid "DVDs"
+msgstr ""
+
+#: id:14088
+msgid "Play DVDs automatically"
+msgstr "Автоматично програвати DVD диски"
+
+#: id:14089
+msgid "Font to use for text subtitles"
+msgstr "Шрифт для текстових субтитрів"
+
+#: id:14090
+msgid "International"
+msgstr "Мова та регіон"
+
+#: id:14091
+msgid "Character set"
+msgstr "Кодування символів"
+
+#: id:14092
+msgid "Debugging"
+msgstr "Відлагодження"
+
+#: id:14093
+msgid "Security"
+msgstr "Безпека"
+
+#: id:14094
+msgid "Input devices"
+msgstr "Пристрої вводу"
+
+#: id:14095
+msgid "Power saving"
+msgstr "Енергозбереження"
+
+#: id:14096
+msgid "Rip"
+msgstr ""
+
+#: id:14097
+msgid "Audio CD Insert Action"
+msgstr ""
+
+#: id:14098
+msgctxt "Auto context with id 14098"
+msgid "Play"
+msgstr ""
+
+#: id:14099
+msgid "Eject disc when CD ripping is complete"
+msgstr ""
+
+#: id:15015
+msgctxt "Auto context with id 15015"
+msgid "Remove"
+msgstr "Прибрати"
+
+#: id:15016
+msgid "Games"
+msgstr "Ігри"
+
+#: id:15019
+msgid "Add"
+msgstr "Додати"
+
+#: id:15052
+msgid "Password"
+msgstr "Пароль"
+
+#: id:15100
+msgctxt "Auto context with id 15100"
+msgid "Library"
+msgstr "Бібліотека"
+
+#: id:15101
+msgid "Database"
+msgstr "База Даних"
+
+#: id:15102
+msgid "* All albums"
+msgstr "* Усі альбоми"
+
+#: id:15103
+msgid "* All artists"
+msgstr "* Усі артисти"
+
+#: id:15104
+msgid "* All songs"
+msgstr "* Усі пісні"
+
+#: id:15105
+msgid "* All genres"
+msgstr "* Усі жанри"
+
+#: id:15107
+msgid "Buffering..."
+msgstr "Буфериуеться..."
+
+#: id:15108
+msgid "Navigation sounds"
+msgstr "Звуки інтерфейсу"
+
+#: id:15109
+msgid "Skin default"
+msgstr "Стандартне оформлення"
+
+#: id:15111
+msgid "- Theme"
+msgstr "- Тема оформлення"
+
+#: id:15112
+msgid "Default theme"
+msgstr "Стандартна тема"
+
+#: id:15200
+msgid "Last.fm"
+msgstr ""
+
+#: id:15201
+msgid "Submit songs to Last.fm"
+msgstr "Відправляти статистику на Last.fm"
+
+#: id:15202
+msgid "Last.fm username"
+msgstr "Ім'я користувача для Last.fm"
+
+#: id:15203
+msgid "Last.fm password"
+msgstr "Пароль для Last.fm"
+
+#: id:15204
+msgid "Unable to handshake: sleeping..."
+msgstr "Неможливо з'єднатися: засинаю..."
+
+#: id:15205
+msgid "Please update XBMC"
+msgstr "Будь ласка, обновіть XBMC"
+
+#: id:15206
+msgid "Bad authorization: Check username and password"
+msgstr "Невірна авторизація: Перевірте ім'я і пароль"
+
+#: id:15207
+msgctxt "Auto context with id 15207"
+msgid "Connected"
+msgstr "Підключений"
+
+#: id:15208
+msgid "Not connected"
+msgstr "Не підключений"
+
+#: id:15209
+msgid "Submit interval %i"
+msgstr "Інтервал підключень %і"
+
+#: id:15210
+msgid "Cached %i songs"
+msgstr "В буфері %і пісень"
+
+#: id:15211
+msgid "Submitting..."
+msgstr "Підключення..."
+
+#: id:15212
+msgid "Submitting in %i secs"
+msgstr "Підключення через %і сек."
+
+#: id:15213
+msgid "Play using..."
+msgstr "Використовувати програвач..."
+
+#: id:15214
+msgid "Use smoothed A/V synchronization"
+msgstr "М'яка синхронізація звуку і відео"
+
+#: id:15215
+msgid "Hide file names in thumbs view"
+msgstr "Ховати імена файлів в режимі ескізів"
+
+#: id:15216
+msgid "Play in party mode"
+msgstr "Програвати в режимі 'Вечірки'"
+
+#: id:15217
+msgid "Submit songs to Libre.fm"
+msgstr "Відправляти статистику на Libre.fm"
+
+#: id:15218
+msgid "Libre.fm username"
+msgstr "Ім'я користувача для Libre.fm"
+
+#: id:15219
+msgid "Libre.fm password"
+msgstr "Пароль для Libre.fm"
+
+#: id:15220
+msgid "Libre.fm"
+msgstr ""
+
+#: id:15221
+msgid "Song submission"
+msgstr "Скробблер"
+
+#: id:15250
+msgid "Submit Last.fm radio to Last.fm"
+msgstr "Облік в статистиці пісень з Last.fm"
+
+#: id:15251
+msgid "Connecting to Last.fm..."
+msgstr "Підключення до Last.fm..."
+
+#: id:15252
+msgid "Selecting station..."
+msgstr "Вибір станції..."
+
+#: id:15253
+msgid "Search similar artists..."
+msgstr "Пошук схожих виконавців..."
+
+#: id:15254
+msgid "Search similar tags..."
+msgstr "Пошук схожих тегів..."
+
+#: id:15255
+msgid "Your profile (%name%)"
+msgstr "Ваш профіль (%name%)"
+
+#: id:15256
+msgid "Overall top tags"
+msgstr "Загальний топ тегів"
+
+#: id:15257
+msgid "Top artists for tag %name%"
+msgstr "Топ виконавців по тегу %name%"
+
+#: id:15258
+msgid "Top albums for tag %name%"
+msgstr "Топ альбомів по тегу %name%"
+
+#: id:15259
+msgid "Top tracks for tag %name%"
+msgstr "Топ треків по тегу %name%"
+
+#: id:15260
+msgid "Listen to tag %name% Last.fm radio"
+msgstr "Слухати треки по тегу %name% на Last.fm"
+
+#: id:15261
+msgid "Similar artists as %name%"
+msgstr "Виконавці, схожі на %name%"
+
+#: id:15262
+msgid "Top %name% albums"
+msgstr "Топ альбомів %name%"
+
+#: id:15263
+msgid "Top %name% tracks"
+msgstr "Топ треків %name%"
+
+#: id:15264
+msgid "Top %name% tags"
+msgstr "Топ тегів %name%"
+
+#: id:15265
+msgid "Biggest fans of %name%"
+msgstr "Найбільші фани %name%"
+
+#: id:15266
+msgid "Listen to %name% fans Last.fm radio"
+msgstr "Слухати вибір фанів %name% на Last.fm"
+
+#: id:15267
+msgid "Listen to %name% similar artists Last.fm radio"
+msgstr "Слухати виконавців, схожих на %name% на Last.fm"
+
+#: id:15268
+msgid "Top artists for user %name%"
+msgstr "Топ виконавців від %name%"
+
+#: id:15269
+msgid "Top albums for user %name%"
+msgstr "Топ альбомів від %name%"
+
+#: id:15270
+msgid "Top tracks for user %name%"
+msgstr "Топ треків від %name%"
+
+#: id:15271
+msgid "Friends of user %name%"
+msgstr "Друзі %name%"
+
+#: id:15272
+msgid "Neighbours of user %name%"
+msgstr "Співтовариства %name%"
+
+#: id:15273
+msgid "Weekly artist chart for %name%"
+msgstr "Тижневий чарт виконавців %name%"
+
+#: id:15274
+msgid "Weekly album chart for %name%"
+msgstr "Тижневий чарт альбомів %name%"
+
+#: id:15275
+msgid "Weekly track chart for %name%"
+msgstr "Тижневий чарт треків %name%"
+
+#: id:15276
+msgid "Listen to %name%'s neighbours Last.fm radio"
+msgstr "Слухати вибір співтовариств %name% на Last.fm"
+
+#: id:15277
+msgid "Listen to %name%'s personal Last.fm radio"
+msgstr "Слухати особистий вибір %name%'а на Last.fm"
+
+#: id:15278
+msgid "Listen to %name%'s mix Last.fm radio"
+msgstr "Слухати улюблені треки %name% на Last.fm"
+
+#: id:15279
+msgid "Retrieving list from Last.fm..."
+msgstr "Одержання списку від Last.fm..."
+
+#: id:15280
+msgid "Can't retrieve list from Last.fm..."
+msgstr "Не можу одержати список від Last.fm..."
+
+#: id:15281
+msgid "Enter an artist name to find related ones"
+msgstr "Впишіть ім'я виконавця щоб знайти схожих"
+
+#: id:15282
+msgid "Enter a tag name to find similar ones"
+msgstr "Впишіть назву тегу щоб знайти схожі"
+
+#: id:15283
+msgid "Tracks recently listened by %name%"
+msgstr "Треки, які недавно слухав(ла) %name%"
+
+#: id:15284
+msgid "Listen to %name%'s recommendations Last.fm radio"
+msgstr "Слухати треки, які рекомендує %name% на Last.fm"
+
+#: id:15285
+msgid "Top tags for user %name%"
+msgstr "Топ тегів для %name%"
+
+#: id:15287
+msgid "Do you want to add the current track to your loved tracks?"
+msgstr "Ви хочете додати цей трек до ваших улюблених треків?"
+
+#: id:15288
+msgid "Do you want to ban the current track?"
+msgstr "Ви хочете заблокувати цей трек?"
+
+#: id:15289
+msgid "Added to your loved tracks: '%s'."
+msgstr "Додано до ваших улюблених треків: '%s'."
+
+#: id:15290
+msgid "Could not add '%s' to your loved tracks."
+msgstr "Не можу додати '%s' до ваших улюблених треків."
+
+#: id:15291
+msgid "Banned: '%s'."
+msgstr "Заблоковано: '%s'."
+
+#: id:15292
+msgid "Could not ban '%s'."
+msgstr "Не можу заблокувати: '%s'."
+
+#: id:15293
+msgid "Tracks recently loved by %name%"
+msgstr "Треки, які недавно полюбив(ла) %name%"
+
+#: id:15294
+msgid "Tracks recently banned by %name%"
+msgstr "Треки, які недавно заблокував(ла) %name%"
+
+#: id:15295
+msgid "Remove from loved tracks"
+msgstr "Видалити з улюблених треків"
+
+#: id:15296
+msgid "Un-ban"
+msgstr "Розблокувати"
+
+#: id:15297
+msgid "Do you want to remove this track from your loved tracks?"
+msgstr "Ви хочете видалити цей трек з ваших улюблених треків?"
+
+#: id:15298
+msgid "Do you want to un-ban this track?"
+msgstr "Ви хочете розблокувати цей трек?"
+
+#: id:15300
+msgid "Path not found or invalid"
+msgstr "Шлях не знайдено або він не правильний"
+
+#: id:15301
+msgid "Could not connect to network server"
+msgstr "Не можу з'єднатися з сервером"
+
+#: id:15302
+msgid "No servers found"
+msgstr "Сервери не знайдені"
+
+#: id:15303
+msgid "Workgroup not found"
+msgstr "Робоча група не знайдена"
+
+#: id:15310
+msgid "Opening multi-path source"
+msgstr "Відкриття кілька-шляхового джерела"
+
+#: id:15311
+msgid "Path:"
+msgstr "Шлях:"
+
+#: id:16000
+msgctxt "Auto context with id 16000"
+msgid "General"
+msgstr "Основний"
+
+#: id:16002
+msgid "Internet lookup"
+msgstr "Пошук в Інтернеті"
+
+#: id:16003
+msgid "Player"
+msgstr "Програвач"
+
+#: id:16004
+msgid "Play media from disc"
+msgstr "Програти файл з диска"
+
+#: id:16008
+msgid "Enter new title"
+msgstr "Впишіть нову назву"
+
+#: id:16009
+msgid "Enter the movie name"
+msgstr "Впишіть назву фільму"
+
+#: id:16010
+msgid "Enter the profile name"
+msgstr "Впишіть назву профілю"
+
+#: id:16011
+msgid "Enter the album name"
+msgstr "Впишіть назву альбому"
+
+#: id:16012
+msgid "Enter the playlist name"
+msgstr "Впишіть назву плейлиста"
+
+#: id:16013
+msgid "Enter new filename"
+msgstr "Впишіть нове ім'я файла"
+
+#: id:16014
+msgid "Enter folder name"
+msgstr "Впишіть назву папки"
+
+#: id:16015
+msgid "Enter directory"
+msgstr "Впишіть назву директорії"
+
+#: id:16016
+msgid "Available options: %A, %T, %N, %B, %D, %G, %Y, %F, %S"
+msgstr "Доступні опції: %A, %T, %N, %B, %D, %G, %Y, %F, %S"
+
+#: id:16017
+msgid "Enter search string"
+msgstr "Напишіть, що ви хочете знайти"
+
+#: id:16018
+msgctxt "Auto context with id 16018"
+msgid "None"
+msgstr "Нічого"
+
+#: id:16019
+msgid "Auto select"
+msgstr "Автовибір"
+
+#: id:16020
+msgid "De-interlace"
+msgstr ""
+
+#: id:16021
+msgid "Bob"
+msgstr ""
+
+#: id:16022
+msgid "Bob (inverted)"
+msgstr ""
+
+#: id:16024
+msgid "Canceling..."
+msgstr "Скасування..."
+
+#: id:16025
+msgid "Enter the artist name"
+msgstr "Впишіть назву виконавця"
+
+#: id:16026
+msgid "Playback failed"
+msgstr "Програвання плейлиста перервано"
+
+#: id:16027
+msgid "One or more items failed to play."
+msgstr "Занадто багато послідовних помилок"
+
+#: id:16028
+msgid "Enter value"
+msgstr "Впишіть значення"
+
+#: id:16029
+msgid "Check the log file for details."
+msgstr "Деталі можна продовитися у файлі журналу"
+
+#: id:16030
+msgid "Party mode aborted."
+msgstr "Режим 'Вечірки' перервано."
+
+#: id:16031
+msgid "No matching songs in the library."
+msgstr "Немає відповідних пісень в Бібліотеці."
+
+#: id:16032
+msgid "Could not initialize database."
+msgstr "Не можу ініцюювати Базу Даних."
+
+#: id:16033
+msgid "Could not open database."
+msgstr "Не можу відкрити Базу Даних."
+
+#: id:16034
+msgid "Could not get songs from database."
+msgstr "Не можу отримати пісні з Бази Даних."
+
+#: id:16035
+msgid "Party mode playlist"
+msgstr "Плейлист режиму 'Вечірки'"
+
+#: id:16036
+msgid "De-interlace (Half)"
+msgstr ""
+
+#: id:16037
+msgid "Deinterlace video"
+msgstr ""
+
+#: id:16038
+msgid "Deinterlace method"
+msgstr ""
+
+#: id:16039
+msgctxt "Auto context with id 16039"
+msgid "Off"
+msgstr ""
+
+#: id:16040
+msgctxt "Auto context with id 16040"
+msgid "Auto"
+msgstr ""
+
+#: id:16041
+msgid "On"
+msgstr ""
+
+#: id:16100
+msgid "All Videos"
+msgstr "Усі Відео"
+
+#: id:16101
+msgid "Unwatched"
+msgstr "Непереглянуті"
+
+#: id:16102
+msgid "Watched"
+msgstr "Переглянуті"
+
+#: id:16103
+msgid "Mark as watched"
+msgstr "Відмітити як переглянуте"
+
+#: id:16104
+msgid "Mark as unwatched"
+msgstr "Відмітити як непереглянуте"
+
+#: id:16105
+msgid "Edit title"
+msgstr "Змінити назву"
+
+#: id:16200
+msgid "Operation was aborted"
+msgstr "Операцію перервано"
+
+#: id:16201
+msgid "Copy failed"
+msgstr "Не вдалося скопіювати"
+
+#: id:16202
+msgid "Failed to copy at least one file"
+msgstr "Не вдалося скопіювати жоден файл"
+
+#: id:16203
+msgid "Move failed"
+msgstr "Не вдалося перемістити"
+
+#: id:16204
+msgid "Failed to move at least one file"
+msgstr "Не вдалося перемістити жоден файл"
+
+#: id:16205
+msgid "Delete failed"
+msgstr "Не вдалося видалити"
+
+#: id:16206
+msgid "Failed to delete at least one file"
+msgstr "Не вдалося видалити жоден файл"
+
+#: id:16300
+msgid "Video scaling method"
+msgstr "Метод масштабування відео"
+
+#: id:16301
+msgid "Nearest neighbour"
+msgstr "Найближчий сусідній"
+
+#: id:16302
+msgid "Bilinear"
+msgstr "Білінійний"
+
+#: id:16303
+msgctxt "Auto context with id 16303"
+msgid "Bicubic"
+msgstr "Бікубічний"
+
+#: id:16304
+msgid "Lanczos2"
+msgstr ""
+
+#: id:16305
+msgid "Lanczos3"
+msgstr ""
+
+#: id:16306
+msgid "Sinc8"
+msgstr ""
+
+#: id:16307
+msgid "Bicubic (software)"
+msgstr "Бікубічний (програмний)"
+
+#: id:16308
+msgid "Lanczos (software)"
+msgstr "Lanczos (програмний)"
+
+#: id:16309
+msgid "Sinc (software)"
+msgstr "Sinc (програмний)"
+
+#: id:16310
+msgid "Temporal"
+msgstr "(VDPAU) Тимчасовий"
+
+#: id:16311
+msgid "Temporal/Spatial"
+msgstr "(VDPAU) Тимчасовий / Просторовий"
+
+#: id:16312
+msgid "(VDPAU)Noise Reduction"
+msgstr "(VDPAU) Зменшення шумів"
+
+#: id:16313
+msgid "(VDPAU)Sharpness"
+msgstr "(VDPAU) Чіткість"
+
+#: id:16314
+msgid "Inverse Telecine"
+msgstr "Зворотній Telecine"
+
+#: id:16315
+msgid "Lanczos3 optimized"
+msgstr ""
+
+#: id:16316
+msgctxt "Auto context with id 16316"
+msgid "Auto"
+msgstr "Авто"
+
+#: id:16317
+msgid "Temporal (Half)"
+msgstr ""
+
+#: id:16318
+msgid "Temporal/Spatial (Half)"
+msgstr ""
+
+#: id:16319
+msgid "DXVA"
+msgstr ""
+
+#: id:16320
+msgid "DXVA Bob"
+msgstr ""
+
+#: id:16321
+msgid "DXVA Best"
+msgstr ""
+
+#: id:16322
+msgid "Spline36"
+msgstr ""
+
+#: id:16323
+msgid "Spline36 optimized"
+msgstr ""
+
+#: id:16324
+msgid "Software Blend"
+msgstr ""
+
+#: id:16400
+msgid "Post-processing"
+msgstr "Післяобробка"
+
+#: id:17500
+msgid "Display sleep timeout"
+msgstr "Переключення екрану в сплячий режим через"
+
+#: id:19000
+msgid "Switch to channel"
+msgstr "Перемикнути на канал"
+
+#: id:20000
+msgid "Saved music folder"
+msgstr "Папка для збереження з аудіо CD"
+
+#: id:20001
+msgid "Use external DVD player"
+msgstr "Використовувати зовнішній DVD-програвач"
+
+#: id:20002
+msgid "External DVD player"
+msgstr "Зовнішній DVD-програвач"
+
+#: id:20003
+msgid "Trainers folder"
+msgstr "Папка для трейнерів"
+
+#: id:20004
+msgid "Screenshot folder"
+msgstr "Папка для скріншотів"
+
+#: id:20006
+msgid "Playlists folder"
+msgstr "Папка для плейлистів"
+
+#: id:20007
+msgid "Recordings"
+msgstr "Записи"
+
+#: id:20008
+msgid "Screenshots"
+msgstr "Скріншоти"
+
+#: id:20009
+msgid "Use XBMC"
+msgstr "Використовувати XBMC"
+
+#: id:20011
+msgid "Music playlists"
+msgstr "Музичний плейлист"
+
+#: id:20012
+msgid "Video playlists"
+msgstr "Відео плейлист"
+
+#: id:20013
+msgid "Do you wish to launch the game?"
+msgstr "Ви хочете запустити гру?"
+
+#: id:20014
+msgid "Sort by: Playlist"
+msgstr "Сорт.по: Плейлисту"
+
+#: id:20015
+msgid "Remote thumb"
+msgstr "Зовнішній ескіз"
+
+#: id:20016
+msgid "Current thumb"
+msgstr "Поточний ескіз"
+
+#: id:20017
+msgid "Local thumb"
+msgstr "Локальний ескіз"
+
+#: id:20018
+msgid "No thumb"
+msgstr "Без ескізу"
+
+#: id:20019
+msgid "Choose thumbnail"
+msgstr "Виберіть ескіз"
+
+#: id:20023
+msgid "Conflict"
+msgstr "Конфлікт"
+
+#: id:20024
+msgid "Scan new"
+msgstr "Сканувати нове"
+
+#: id:20025
+msgid "Scan all"
+msgstr "Сканувати все"
+
+#: id:20026
+msgid "Region"
+msgstr "Регіон"
+
+#: id:20037
+msgid "Summary"
+msgstr "Підсумок"
+
+#: id:20038
+msgid "Lock music window"
+msgstr "Заблокувати розділ Музика"
+
+#: id:20039
+msgid "Lock videos window"
+msgstr "Заблокувати розділ Відео"
+
+#: id:20040
+msgid "Lock pictures window"
+msgstr "Заблокувати розділ Фотографії"
+
+#: id:20041
+msgid "Lock programs & scripts windows"
+msgstr "Заблокувати розділ Програми і Скрипти"
+
+#: id:20042
+msgid "Lock file manager"
+msgstr "Заблокувати Менеджер файлів"
+
+#: id:20043
+msgid "Lock settings"
+msgstr "Заблокувати Налаштування"
+
+#: id:20044
+msgid "Start fresh"
+msgstr "Чистий старт"
+
+#: id:20045
+msgid "Enter master mode"
+msgstr "Перейти у режим Повного доступу"
+
+#: id:20046
+msgid "Leave master mode"
+msgstr "Вийти з режиму Повного доступу"
+
+#: id:20047
+msgid "Create profile '%s'?"
+msgstr "Створити профіль '%s' ?"
+
+#: id:20048
+msgid "Start with fresh settings"
+msgstr "Старт з чистими параметрами"
+
+#: id:20049
+msgid "Best available"
+msgstr "Найкраще з доступних"
+
+#: id:20050
+msgid "Auto-switch between 16x9 and 4x3"
+msgstr "Автовибір 16:9 чи 4:3"
+
+#: id:20051
+msgid "Treat stacked files as single file"
+msgstr "Представляти послідовні файли як один файл"
+
+#: id:20052
+msgid "Caution"
+msgstr "Застереження"
+
+#: id:20053
+msgid "Left master mode"
+msgstr "Залишити режим Повного доступу"
+
+#: id:20054
+msgid "Entered master mode"
+msgstr "Включений режим Повного доступу"
+
+#: id:20055
+msgid "Allmusic.com thumb"
+msgstr "Ескіз з Allmusic.com"
+
+#: id:20057
+msgid "Remove thumbnail"
+msgstr "Прибрати ескіз"
+
+#: id:20058
+msgid "Add profile..."
+msgstr "Додати профіль..."
+
+#: id:20059
+msgid "Query info for all albums"
+msgstr "Запит даних про всі альбоми"
+
+#: id:20060
+msgctxt "Auto context with id 20060"
+msgid "Media info"
+msgstr "Дані про медіафайл"
+
+#: id:20061
+msgctxt "Auto context with id 20061"
+msgid "Separate"
+msgstr "Роздільно"
+
+#: id:20062
+msgid "Shares with default"
+msgstr "Стандартні ресурси"
+
+#: id:20063
+msgid "Shares with default (read only)"
+msgstr "Стандартні ресурси (зчитування)"
+
+#: id:20064
+msgid "Copy default"
+msgstr "Скопіювати стандартний"
+
+#: id:20065
+msgid "Profile picture"
+msgstr "Картинка профілю"
+
+#: id:20066
+msgid "Lock preferences"
+msgstr "Заблокувати переваги"
+
+#: id:20067
+msgid "Edit profile"
+msgstr "Змінити профіль"
+
+#: id:20068
+msgid "Profile lock"
+msgstr "Захист профіля"
+
+#: id:20069
+msgid "Could not create folder"
+msgstr "Не можу створити папку"
+
+#: id:20070
+msgid "Profile directory"
+msgstr "Папка профілю"
+
+#: id:20071
+msgid "Start with fresh media sources"
+msgstr "Старт із свіжими джерелами"
+
+#: id:20072
+msgid "Make sure the selected folder is writable"
+msgstr "Переконайтеся, що в обрану папку дозволено"
+
+#: id:20073
+msgid "and that the new folder name is valid"
+msgstr "запис і її назва правильна"
+
+#: id:20074
+msgid "MPAA rating"
+msgstr "Рейтинг MPAA"
+
+#: id:20075
+msgid "Enter master lock code"
+msgstr "Введіть код захисту"
+
+#: id:20076
+msgid "Ask for master lock code on startup"
+msgstr "Запитувати код захисту при старті"
+
+#: id:20077
+msgid "Skin settings"
+msgstr "Параметри вигляду"
+
+#: id:20078
+msgid "- no link set -"
+msgstr "- немає зв'язку -"
+
+#: id:20079
+msgid "Enable animations"
+msgstr "Використовувати анімацію"
+
+#: id:20080
+msgid "Disable RSS during music"
+msgstr "Відключити RSS під час музики"
+
+#: id:20081
+msgid "Enable shortcut buttons"
+msgstr "Задіяти кнопки посилань"
+
+#: id:20082
+msgid "Show programs in main menu"
+msgstr "Показувати розділ \"Програми\" у головному меню"
+
+#: id:20083
+msgid "Show music info"
+msgstr "Показувати інформацію про музику"
+
+#: id:20084
+msgid "Show weather info"
+msgstr "Показувати інформацію про погоду"
+
+#: id:20085
+msgid "Show system info"
+msgstr "Показувати інформацію про систему"
+
+#: id:20086
+msgid "Show available disc space C: E: F:"
+msgstr "Показувати вільне місце на C: E: F:"
+
+#: id:20087
+msgid "Show available disc space E: F: G:"
+msgstr "Показувати вільне місце на E: F: G:"
+
+#: id:20088
+msgid "Weather info"
+msgstr "Погода"
+
+#: id:20089
+msgid "Drive space free"
+msgstr "Вільне місце на диску"
+
+#: id:20090
+msgid "Enter the name of an existing share"
+msgstr "Впишіть назву існуючого ресурсу"
+
+#: id:20091
+msgid "Lock code"
+msgstr "Код захисту"
+
+#: id:20092
+msgid "Load profile"
+msgstr "Завантажити профіль"
+
+#: id:20093
+msgid "Profile name"
+msgstr "Назва профілю"
+
+#: id:20094
+msgctxt "Auto context with id 20094"
+msgid "Media sources"
+msgstr "Джерела медіафайлів"
+
+#: id:20095
+msgid "Enter profile lock code"
+msgstr "Введіть код захисту профілю"
+
+#: id:20096
+msgctxt "Auto context with id 20096"
+msgid "Login screen"
+msgstr "Екран входу"
+
+#: id:20097
+msgid "Fetching album info"
+msgstr "Запит інформації про альбом"
+
+#: id:20098
+msgid "Fetching info for album"
+msgstr "Запит інформації для альбому"
+
+#: id:20099
+msgid "Can't rip CD or track while playing from CD"
+msgstr "Не можна оцифровувать під час програвання"
+
+#: id:20100
+msgid "Master lock code and settings"
+msgstr "Код захисту та його налаштування"
+
+#: id:20101
+msgid "Entering master lock code always enables master mode"
+msgstr "Введення коду захисту завжди переключає до режиму Повного доступу"
+
+#: id:20102
+msgid "or copy from default?"
+msgstr "чи копіювати із стандартного?"
+
+#: id:20103
+msgid "Save changes to profile?"
+msgstr "Зберегти зміни в профілі?"
+
+#: id:20104
+msgid "Old settings found."
+msgstr "Знайдено старі налаштування"
+
+#: id:20105
+msgid "Do you want to use them?"
+msgstr "Ви хочете використовувати їх?"
+
+#: id:20106
+msgid "Old media sources found."
+msgstr "Знайдено старі джерела"
+
+#: id:20107
+msgid "Separate (locked)"
+msgstr "Роздільно (заблоковано)"
+
+#: id:20108
+msgid "Root"
+msgstr "Корінь"
+
+#: id:20109
+msgid "- Zoom"
+msgstr "- Збільшення"
+
+#: id:20110
+msgid "UPnP settings"
+msgstr "UPnP налаштування"
+
+#: id:20111
+msgid "Autostart UPnP client"
+msgstr "Автозапуск UPnP-клієнта"
+
+#: id:20112
+msgid "Last login: %s"
+msgstr "Останній вхід: %s"
+
+#: id:20113
+msgid "Never logged on"
+msgstr "Ніколи не входив"
+
+#: id:20114
+msgid "Profile %i / %i"
+msgstr "Профіль %і / %і"
+
+#: id:20115
+msgid "User login / Select a profile"
+msgstr "Вхід користувача / Вибір профілю"
+
+#: id:20116
+msgid "Use lock on login screen"
+msgstr "Використовувати захист на екрані входу"
+
+#: id:20117
+msgid "Invalid lock code."
+msgstr "Не правильний код захисту."
+
+#: id:20118
+msgid "This requires the master lock to be set."
+msgstr "Для цього код захисту має бути встановлений."
+
+#: id:20119
+msgid "Would you like to set it now?"
+msgstr "Встановити його зараз?"
+
+#: id:20120
+msgid "Loading program information"
+msgstr "Завантаження даних про програму"
+
+#: id:20121
+msgid "Party on!"
+msgstr "Вечірка почалася!"
+
+#: id:20122
+msgid "True"
+msgstr "Істина"
+
+#: id:20123
+msgid "Mixing drinks"
+msgstr "Змішування напоїв"
+
+#: id:20124
+msgid "Filling glasses"
+msgstr "Наповнювання келихів"
+
+#: id:20125
+msgid "Logged on as"
+msgstr "Увійшов як"
+
+#: id:20126
+msgid "Log off"
+msgstr "Вихід"
+
+#: id:20128
+msgid "Go to root"
+msgstr "Перейти до кореню"
+
+#: id:20129
+msgid "Weave"
+msgstr ""
+
+#: id:20130
+msgid "Weave (inverted)"
+msgstr ""
+
+#: id:20131
+msgid "Blend"
+msgstr ""
+
+#: id:20132
+msgid "Restart video"
+msgstr "Перезапустити відео"
+
+#: id:20133
+msgid "Edit network location"
+msgstr "Змінити мережеве розташування"
+
+#: id:20134
+msgid "Remove network location"
+msgstr "Видалити мережеве розташування"
+
+#: id:20135
+msgid "Do you want to scan the folder?"
+msgstr "Хочете просканувати папку?"
+
+#: id:20136
+msgid "Memory unit"
+msgstr "Карта пам'яті"
+
+#: id:20137
+msgid "Memory unit mounted"
+msgstr "Карта пам'яті підключена"
+
+#: id:20138
+msgid "Unable to mount memory unit"
+msgstr "Неможливо підключити Карту пам'яті"
+
+#: id:20139
+msgid "In port %i, slot %i"
+msgstr "У порт %і, слот %і"
+
+#: id:20140
+msgid "Lock screensaver"
+msgstr "Заблокувати заставку"
+
+#: id:20141
+msgid "Set"
+msgstr "Встановити"
+
+#: id:20142
+msgctxt "Auto context with id 20142"
+msgid "Username"
+msgstr "Ім'я користувача"
+
+#: id:20143
+msgid "Enter password for"
+msgstr "Впишіть пароль для"
+
+#: id:20144
+msgid "Shutdown timer"
+msgstr "Таймер вимикання"
+
+#: id:20145
+msgid "Shutdown interval (in minutes)"
+msgstr "Інтервал вимикання (хвилини)"
+
+#: id:20146
+msgid "Started, shutdown in %im"
+msgstr "Запущено, вимикання через %im"
+
+#: id:20147
+msgid "Shutdown in 30 minutes"
+msgstr "Вимикання через 30 хв."
+
+#: id:20148
+msgid "Shutdown in 60 minutes"
+msgstr "Вимикання через 1 годину"
+
+#: id:20149
+msgid "Shutdown in 120 minutes"
+msgstr "Вимикання через 2 години"
+
+#: id:20150
+msgid "Custom shutdown timer"
+msgstr "Особливий таймер вимикання"
+
+#: id:20151
+msgid "Cancel shutdown timer"
+msgstr "Відключити таймер вимикання"
+
+#: id:20152
+msgid "Lock preferences for %s"
+msgstr "Заблокувати переваги для %s"
+
+#: id:20153
+msgid "Browse..."
+msgstr "Перегляд..."
+
+#: id:20154
+msgid "Summary information"
+msgstr "Загальна інформація"
+
+#: id:20155
+msgid "Storage information"
+msgstr "Інформація про накопичувачі"
+
+#: id:20156
+msgid "Hard disk information"
+msgstr "Інформація про HDD"
+
+#: id:20157
+msgid "DVD-ROM information"
+msgstr "Інформація про DVD-ROM"
+
+#: id:20158
+msgid "Network information"
+msgstr "Інформація про мережу"
+
+#: id:20159
+msgid "Video information"
+msgstr "Інформація про відео"
+
+#: id:20160
+msgid "Hardware information"
+msgstr "Інформація про обладнання"
+
+#: id:20161
+msgid "Total"
+msgstr "Усього"
+
+#: id:20162
+msgid "Used"
+msgstr "Використано"
+
+#: id:20163
+msgid "of"
+msgstr "з"
+
+#: id:20164
+msgid "Locking not supported"
+msgstr "Захист не підтримується"
+
+#: id:20165
+msgid "Not locked"
+msgstr "Не заблоковано"
+
+#: id:20166
+msgid "Locked"
+msgstr "Заблоковано"
+
+#: id:20167
+msgid "Frozen"
+msgstr "Заморожений"
+
+#: id:20168
+msgid "Requires reset"
+msgstr "Необхідне скидання"
+
+#: id:20169
+msgid "Week"
+msgstr "Тиждень"
+
+#: id:20170
+msgid "Line"
+msgstr "Лінія"
+
+#: id:20171
+msgid "Windows network (SMB)"
+msgstr "Мережа Windows (SMB)"
+
+#: id:20172
+msgid "XBMSP server"
+msgstr "Сервер XBMSP"
+
+#: id:20173
+msgctxt "Auto context with id 20173"
+msgid "FTP server"
+msgstr "Сервер FTP"
+
+#: id:20174
+msgid "iTunes music share (DAAP)"
+msgstr "Ресурс iTunes (DAAP)"
+
+#: id:20175
+msgid "UPnP server"
+msgstr "Сервер UPnP"
+
+#: id:20176
+msgid "Show video info"
+msgstr "Показувати інформацію про відео"
+
+#: id:20177
+msgid "Done"
+msgstr "Готово"
+
+#: id:20178
+msgid "Shift"
+msgstr ""
+
+#: id:20179
+msgid "Caps Lock"
+msgstr ""
+
+#: id:20180
+msgid "Symbols"
+msgstr "Символи"
+
+#: id:20181
+msgid "Backspace"
+msgstr "<-----"
+
+#: id:20182
+msgid "Space"
+msgstr "Пробіл"
+
+#: id:20183
+msgid "Reload skin"
+msgstr "Оновити вигляд"
+
+#: id:20184
+msgid "Rotate pictures using EXIF information"
+msgstr "Повертати за інформацією зі EXIF"
+
+#: id:20185
+msgid "Use poster view styles for TV shows"
+msgstr "Використовувати вигляд постерів для серіалів"
+
+#: id:20186
+msgid "Please wait"
+msgstr "Зачекайте, будь ласка"
+
+#: id:20187
+msgid "UPnP"
+msgstr "Резервування EEPROM"
+
+#: id:20189
+msgid "Enable auto scrolling for plot & review"
+msgstr "Задіяти автоматичну прокрутку для сюжетів та оглядів"
+
+#: id:20190
+msgctxt "Auto context with id 20190"
+msgid "Custom"
+msgstr "Додаткові"
+
+#: id:20191
+msgid "Enable debug logging"
+msgstr "Задіяти протоколювання (для відладки)"
+
+#: id:20192
+msgid "Download additional information during updates"
+msgstr "Шукати дані про альбом при додаванні до Бібліотеки"
+
+#: id:20193
+msgid "Default service for album information"
+msgstr "Шукати дані про виконавця при додаванні до Бібліотеки"
+
+#: id:20194
+msgid "Default service for artist information"
+msgstr "Стандартний інфо-ресурс"
+
+#: id:20195
+msgid "Change scraper"
+msgstr "Змінити інфо-ресурс"
+
+#: id:20196
+msgid "Export music library"
+msgstr "Експортувати музичну Бібліотеку"
+
+#: id:20197
+msgid "Import music library"
+msgstr "Імпортувати музичну Бібліотеку"
+
+#: id:20198
+msgid "No artist found!"
+msgstr "Виконавців не знайдено!"
+
+#: id:20199
+msgid "Downloading artist info failed"
+msgstr "Невдалося завантажити дані про виконавця"
+
+#: id:20250
+msgid "Party on! (videos)"
+msgstr "Вечірка почалася! (Відео)"
+
+#: id:20251
+msgid "Mixing drinks (videos)"
+msgstr "Змішування напоїв (Відео)"
+
+#: id:20252
+msgid "Filling glasses (videos)"
+msgstr "Наповнювання келихів (Відео)"
+
+#: id:20253
+msgid "WebDAV server (HTTP)"
+msgstr "WebDAV сервер (HTTP)"
+
+#: id:20254
+msgid "WebDAV server (HTTPS)"
+msgstr "WebDAV сервер (HTTPS)"
+
+#: id:20255
+msgid "First logon, edit your profile"
+msgstr "Це перший вхід, відредагуйте свій профіль"
+
+#: id:20256
+msgid "HTS Tvheadend client"
+msgstr "HTS Tvheadend клієнт"
+
+#: id:20257
+msgid "VDR Streamdev client"
+msgstr "VDR Streamdev клієнт"
+
+#: id:20258
+msgid "MythTV client"
+msgstr "MythTV клієнт"
+
+#: id:20259
+msgid "Network Filesystem (NFS)"
+msgstr ""
+
+#: id:20260
+msgid "Secure Shell (SSH/SFTP)"
+msgstr ""
+
+#: id:20261
+msgid "Apple Filing Protocol (AFP)"
+msgstr ""
+
+#: id:20300
+msgid "Web server directory (HTTP)"
+msgstr "Папка Web сервера (HTTP)"
+
+#: id:20301
+msgid "Web server directory (HTTPS)"
+msgstr "Папка Web-сервера (HTTPS)"
+
+#: id:20302
+msgid "Unable to write to folder:"
+msgstr "Неможливо записати у папку:"
+
+#: id:20303
+msgid "Do you want to skip and proceed?"
+msgstr "Хочете пропустити і продовжити далі?"
+
+#: id:20304
+msgid "RSS Feed"
+msgstr "RSS канал"
+
+#: id:20307
+msgid "Secondary DNS"
+msgstr "Вторинний DNS"
+
+#: id:20308
+msgid "DHCP server:"
+msgstr "Сервер DHCP:"
+
+#: id:20309
+msgid "Make new folder"
+msgstr "Створити нову папку"
+
+#: id:20310
+msgid "Dim LCD on playback"
+msgstr "Пригасити LCD при програванні"
+
+#: id:20311
+msgid "Unknown or onboard (protected)"
+msgstr "Невідомий, чи вмонтований (захищений)"
+
+#: id:20312
+msgid "Dim LCD on paused"
+msgstr "Пригасити LCD в паузі"
+
+#: id:20314
+msgid "Videos - Library"
+msgstr "Відео - Бібліотека"
+
+#: id:20316
+msgid "Sort by: ID"
+msgstr "Сорт.по: ID"
+
+#: id:20324
+msgid "Play part..."
+msgstr "Грати частину..."
+
+#: id:20325
+msgid "Calibration reset"
+msgstr "Скидання калібровки"
+
+#: id:20326
+msgid "This will reset the calibration values for %s"
+msgstr "Це скине значення калібровки для %s"
+
+#: id:20327
+msgid "to it's default values."
+msgstr "до їх стандартних значень."
+
+#: id:20328
+msgid "Browse for destination"
+msgstr "Вкажіть ціль"
+
+#: id:20329
+msgid "Movies are in separate folders that match the movie title"
+msgstr ""
+
+#: id:20330
+msgid "Use folder names for lookups"
+msgstr "Використовувати назви папок для пошуку"
+
+#: id:20331
+msgctxt "Auto context with id 20331"
+msgid "File"
+msgstr "Файл"
+
+#: id:20332
+msgid "Use file or folder names in lookups?"
+msgstr "Використовувати назви файлів або папок для пошуку?"
+
+#: id:20333
+msgid "Set content"
+msgstr "Зазначити вміст"
+
+#: id:20334
+msgid "Folder"
+msgstr "Папка"
+
+#: id:20335
+msgid "Look for content recursively?"
+msgstr "Передивлятися також вміст підпапок?"
+
+#: id:20336
+msgid "Unlock sources"
+msgstr "Розблокувати джерела"
+
+#: id:20337
+msgid "Actor"
+msgstr "Актор"
+
+#: id:20338
+msgid "Movie"
+msgstr "Фільм"
+
+#: id:20339
+msgid "Director"
+msgstr "Режисер"
+
+#: id:20340
+msgid "Do you want to remove all items within"
+msgstr "Ви хочете видалити всі об'єкти за"
+
+#: id:20341
+msgid "this path from the XBMC library?"
+msgstr "цим шляхом з Бібліотеки?"
+
+#: id:20342
+msgctxt "Auto context with id 20342"
+msgid "Movies"
+msgstr "Фільми"
+
+#: id:20343
+msgid "TV shows"
+msgstr "Серіали"
+
+#: id:20344
+msgid "This directory contains"
+msgstr "Ця папка містить"
+
+#: id:20345
+msgid "Run automated scan"
+msgstr "Запустити автоматичне сканування"
+
+#: id:20346
+msgid "Scan recursively"
+msgstr "Сканувати з підпапками"
+
+#: id:20347
+msgid "as"
+msgstr "у ролі"
+
+#: id:20348
+msgid "Directors"
+msgstr "Режисери"
+
+#: id:20349
+msgid "No video files found in this path!"
+msgstr "За цим шляхом відеофайлів не знайдено!"
+
+#: id:20350
+msgid "votes"
+msgstr "проголосували"
+
+#: id:20351
+msgid "TV show information"
+msgstr "Інформація про серіал"
+
+#: id:20352
+msgid "Episode information"
+msgstr "Інформація про епізод"
+
+#: id:20353
+msgid "Loading TV show details"
+msgstr "Завантаження подробиць про серіал"
+
+#: id:20354
+msgid "Fetching episode guide"
+msgstr "Керівництво з вибору епізоду"
+
+#: id:20355
+msgid "Loading info for episodes in directory"
+msgstr "Завантаження даних про епізоди в папці"
+
+#: id:20356
+msgid "Select TV show:"
+msgstr "Виберіть серіал:"
+
+#: id:20357
+msgid "Enter the TV show name"
+msgstr "Впишіть назву серіалу"
+
+#: id:20358
+msgid "Season %i"
+msgstr "Сезон %i"
+
+#: id:20359
+msgid "Episode"
+msgstr "Епізод"
+
+#: id:20360
+msgid "Episodes"
+msgstr "Епізоди"
+
+#: id:20361
+msgid "Loading episode details"
+msgstr "Завантаження подробиць про епізод"
+
+#: id:20362
+msgid "Remove episode from library"
+msgstr "Видалити епізод з Бібліотеки"
+
+#: id:20363
+msgid "Remove TV show from library"
+msgstr "Видалити серіал з Бібліотеки"
+
+#: id:20364
+msgid "TV show"
+msgstr "Серіал"
+
+#: id:20365
+msgid "Episode plot"
+msgstr "Сюжет епізоду"
+
+#: id:20366
+msgid "* All seasons"
+msgstr "* Всі сезони"
+
+#: id:20367
+msgid "Hide watched"
+msgstr "Сховати переглянуті"
+
+#: id:20368
+msgid "Prod code"
+msgstr "Код продукту"
+
+#: id:20369
+msgid "Show plot for unwatched items"
+msgstr "Сховати сюжет для непереглянутих"
+
+#: id:20370
+msgid "* Hidden to prevent spoilers *"
+msgstr "* Приховано, щоб запобігти перешкод *"
+
+#: id:20371
+msgid "Set season thumb"
+msgstr "Встановити ескіз сезону"
+
+#: id:20372
+msgid "Season image"
+msgstr "Картинка сезону"
+
+#: id:20373
+msgid "Season"
+msgstr "Сезон"
+
+#: id:20374
+msgid "Downloading movie information"
+msgstr "Завантаження інформації про фільм"
+
+#: id:20375
+msgid "Unassign content"
+msgstr "Не зазначати вміст"
+
+#: id:20376
+msgid "Original title"
+msgstr ""
+
+#: id:20377
+msgid "Refresh TV show information"
+msgstr "Оновити інформацію про серіал"
+
+#: id:20378
+msgid "Refresh info for all episodes?"
+msgstr "Оновити інформацію про всі епізоди"
+
+#: id:20379
+msgid "Selected folder contains a single TV show"
+msgstr "Вказана папка містить окремій серіал"
+
+#: id:20380
+msgid "Exclude selected folder from scans"
+msgstr "Не сканувати вибрану папку"
+
+#: id:20381
+msgid "Specials"
+msgstr "Спеціальне"
+
+#: id:20382
+msgid "Automatically grab season thumbs"
+msgstr "Автоматично створювати ескізи для сезонів"
+
+#: id:20383
+msgid "Selected folder contains a single video"
+msgstr "Вказана папка містить окреме відео"
+
+#: id:20384
+msgid "Link to TV show"
+msgstr "Зв'язати з серіалом"
+
+#: id:20385
+msgid "Remove link to TV show"
+msgstr "Видалити зв'язок з серіалом"
+
+#: id:20386
+msgid "Recently added movies"
+msgstr "Свіжі фільми"
+
+#: id:20387
+msgid "Recently added episodes"
+msgstr "Свіжі епізоди"
+
+#: id:20388
+msgid "Studios"
+msgstr "Кіностудії"
+
+#: id:20389
+msgid "Music videos"
+msgstr "Музичні відео"
+
+#: id:20390
+msgid "Recently added music videos"
+msgstr "Свіжі музичні відео"
+
+#: id:20391
+msgid "Music video"
+msgstr "Музичне відео"
+
+#: id:20392
+msgid "Remove music video from library"
+msgstr "Видалити музичне відео з Бібліотеки"
+
+#: id:20393
+msgctxt "Auto context with id 20393"
+msgid "Music video information"
+msgstr "Інформація про музичне відео"
+
+#: id:20394
+msgid "Loading music video information"
+msgstr "Завантаження інформації про музичне відео"
+
+#: id:20395
+msgid "Mixed"
+msgstr "Змішане"
+
+#: id:20396
+msgid "Go to albums by artist"
+msgstr "Перейти до альбому за виконавцем"
+
+#: id:20397
+msgid "Go to album"
+msgstr "Перейти до альбому"
+
+#: id:20398
+msgid "Play song"
+msgstr "Грати пісню"
+
+#: id:20399
+msgid "Go to music videos from album"
+msgstr "Перейти до музичних відео з альбому"
+
+#: id:20400
+msgid "Go to music videos by artist"
+msgstr "Перейти до музичних відео за виконавцем"
+
+#: id:20401
+msgid "Play music video"
+msgstr "Грати музичне відео"
+
+#: id:20402
+msgid "Download actor thumbnails when adding to library"
+msgstr "Автоматично створювати ескізи для акторів"
+
+#: id:20403
+msgid "Set actor thumb"
+msgstr "Встановити ескіз для актора"
+
+#: id:20405
+msgid "Remove episode bookmark"
+msgstr "Видалити закладку епізоду"
+
+#: id:20406
+msgid "Set episode bookmark"
+msgstr "Встановити закладку епізоду"
+
+#: id:20407
+msgid "Scraper settings"
+msgstr "Налаштування інфо-ресурсу"
+
+#: id:20408
+msgid "Downloading music video information"
+msgstr "Завантаження інформації про музичне відео"
+
+#: id:20409
+msgid "Downloading TV show information"
+msgstr "Завантаження інформації про серіал"
+
+#: id:20410
+msgid "Trailer"
+msgstr "Трейлер"
+
+#: id:20411
+msgid "Flatten"
+msgstr "Об'єднати"
+
+#: id:20412
+msgid "Flatten TV shows"
+msgstr "Об'єднати серіали"
+
+#: id:20413
+msgid "Get fanart"
+msgstr "Одержати Fanart"
+
+#: id:20414
+msgid "Show Fanart in video and music libraries"
+msgstr "Показувати Fanart в відео та музичній Бібліотеці"
+
+#: id:20415
+msgid "Scanning for new content"
+msgstr "Сканування нового вмісту"
+
+#: id:20416
+msgid "First aired"
+msgstr "Перший переданий"
+
+#: id:20417
+msgid "Writer"
+msgstr "Автор сценарію"
+
+#: id:20419
+msgid "Replace file names with library titles"
+msgstr ""
+
+#: id:20420
+msgctxt "Auto context with id 20420"
+msgid "Never"
+msgstr "Ніколи"
+
+#: id:20421
+msgid "If only one season"
+msgstr "Лише якщо один сезон"
+
+#: id:20422
+msgid "Always"
+msgstr "Завжди"
+
+#: id:20423
+msgid "Has trailer"
+msgstr "Є трейлер"
+
+#: id:20424
+msgid "False"
+msgstr "Брехня"
+
+#: id:20425
+msgid "Fanart slideshow"
+msgstr "Слайдшоу Fanart'ов"
+
+#: id:20426
+msgid "Export to a single file or separate"
+msgstr "Виводити одним файлом чи розділяти"
+
+#: id:20427
+msgid "files per entry?"
+msgstr "на окремі файли по записам?"
+
+#: id:20428
+msgid "Single file"
+msgstr "Одним файлом"
+
+#: id:20429
+msgctxt "Auto context with id 20429"
+msgid "Separate"
+msgstr "Розділяти"
+
+#: id:20430
+msgid "Export thumbnails and fanart?"
+msgstr "Виводити ескізи и fanart?"
+
+#: id:20431
+msgid "Overwrite old files?"
+msgstr "Перезаписати старі файли?"
+
+#: id:20432
+msgid "Exclude path from library updates"
+msgstr "Виключити шлях з оновлень Бібліотеки"
+
+#: id:20433
+msgid "Extract thumbnails and video information"
+msgstr "Видобути мета-данні з медіафайлу"
+
+#: id:20434
+msgid "Sets"
+msgstr ""
+
+#: id:20435
+msgid "Set movieset thumb"
+msgstr ""
+
+#: id:20436
+msgid "Export actor thumbs?"
+msgstr ""
+
+#: id:20437
+msgid "Choose fanart"
+msgstr ""
+
+#: id:20438
+msgid "Local fanart"
+msgstr ""
+
+#: id:20439
+msgid "No fanart"
+msgstr ""
+
+#: id:20440
+msgid "Current fanart"
+msgstr ""
+
+#: id:20441
+msgid "Remote fanart"
+msgstr ""
+
+#: id:20442
+msgid "Change content"
+msgstr ""
+
+#: id:20443
+msgid "Do you want to refresh info for all"
+msgstr "Ви хочете оновити інформацію для всіх"
+
+#: id:20444
+msgid "items within this path?"
+msgstr "об’єктів у цьому шляху?"
+
+#: id:20445
+msgid "Fanart"
+msgstr ""
+
+#: id:20446
+msgid "Locally stored information found."
+msgstr "Знайдено локально збережену інформацію."
+
+#: id:20447
+msgid "Ignore and refresh from internet?"
+msgstr "Ігнорувати і оновити з інтернету?"
+
+#: id:20448
+msgid "Could not download information"
+msgstr "Не вдалося завантажити інформацію"
+
+#: id:20449
+msgid "Unable to connect to remote server"
+msgstr "Не можливо приєднатися до віддаленого серверу"
+
+#: id:20450
+msgid "Would you like to continue scanning?"
+msgstr "Ви бажаєте продовжити сканування?"
+
+#: id:20451
+msgid "Countries"
+msgstr "Країни"
+
+#: id:20452
+msgid "episode"
+msgstr "епізод"
+
+#: id:20453
+msgid "episodes"
+msgstr "епізоди"
+
+#: id:20454
+msgid "Listener"
+msgstr ""
+
+#: id:20455
+msgid "Listeners"
+msgstr ""
+
+#: id:20456
+msgid "Set movieset fanart"
+msgstr ""
+
+#: id:20457
+msgid "Movie set"
+msgstr ""
+
+#: id:20458
+msgid "Group movies in sets"
+msgstr ""
+
+#: id:21330
+msgid "Show hidden files and directories"
+msgstr "Показувати приховані файли і папки"
+
+#: id:21331
+msgid "TuxBox client"
+msgstr "Кліент TuXbox"
+
+#: id:21332
+msgid "WARNING: Target TuxBox device is in recording-mode!"
+msgstr "УВАГА: Цільовий пристрій TuXbox знаходиться в режимі запису!"
+
+#: id:21333
+msgid "The stream will be stopped!"
+msgstr "Потік буде зупинено!"
+
+#: id:21334
+msgid "Zap to channel: %s failed!"
+msgstr "Не вдалося переключитися на канал: %s!"
+
+#: id:21335
+msgid "Are you sure to start the stream?"
+msgstr "Ви впевнені що хочете включити потік?"
+
+#: id:21336
+msgid "Connecting to: %s"
+msgstr "Підключення до: %s"
+
+#: id:21337
+msgid "TuxBox device"
+msgstr "Пристрій TuXbox"
+
+#: id:21359
+msgid "Add media share..."
+msgstr "Додати медіа ресурс..."
+
+#: id:21360
+msgid "Share video and music libraries through UPnP"
+msgstr "Поширювати бібліотеки музики і фільмів через UPnP"
+
+#: id:21364
+msgid "Edit media share"
+msgstr "Змінити медіа ресурс"
+
+#: id:21365
+msgid "Remove media share"
+msgstr "Видалити медіа ресурс"
+
+#: id:21366
+msgid "Subtitle folder"
+msgstr "Особлива папка для субтитрів"
+
+#: id:21367
+msgid "Movie & alternate subtitle directory"
+msgstr "Папка для фільмів та альтернативних субтитрів"
+
+#: id:21368
+msgid "Override ASS/SSA subtitles fonts"
+msgstr ""
+
+#: id:21369
+msgid "Enable mouse and Touch Screen support"
+msgstr "Задіяти мишу"
+
+#: id:21370
+msgid "Play navigation sounds during media playback"
+msgstr "Звуки інтерфейсу під час програвання"
+
+#: id:21371
+msgid "Thumbnail"
+msgstr "Ескізи"
+
+#: id:21372
+msgid "Forced DVD player region"
+msgstr "Регіон для DVD-програвача"
+
+#: id:21373
+msgid "Video output"
+msgstr "Відео обладнання"
+
+#: id:21374
+msgid "Video aspect"
+msgstr "Співвідношення сторін відео"
+
+#: id:21375
+msgctxt "Auto context with id 21375"
+msgid "Normal"
+msgstr "Normal (4:3)"
+
+#: id:21376
+msgid "Letterbox"
+msgstr "Letterbox (5:4)"
+
+#: id:21377
+msgid "Widescreen"
+msgstr "Widescreen (16:9)"
+
+#: id:21378
+msgid "Enable 480p"
+msgstr "Задіяти 480p"
+
+#: id:21379
+msgid "Enable 720p"
+msgstr "Задіяти 720p"
+
+#: id:21380
+msgid "Enable 1080i"
+msgstr "Задіяти 1080p"
+
+#: id:21381
+msgid "Enter name of new playlist"
+msgstr "Впишіть назву нового плейлиста"
+
+#: id:21382
+msgid "Show \"Add source\" buttons in file lists"
+msgstr "Сховати кнопку \"Додати джерело\" в списку файлів"
+
+#: id:21383
+msgid "Enable scrollbars"
+msgstr "Задіяти смуги прокрутки"
+
+#: id:21384
+msgid "Make watched filtering a toggle in video library"
+msgstr "Відмічати переглянуте відео в Бібліотеці галочкою"
+
+#: id:21385
+msgctxt "Auto context with id 21385"
+msgid "Open"
+msgstr "Відкрити"
+
+#: id:21386
+msgid "Acoustic management level"
+msgstr "Управлінння акустичними шумами"
+
+#: id:21387
+msgid "Fast"
+msgstr "Швидкість"
+
+#: id:21388
+msgid "Quiet"
+msgstr "Тиша"
+
+#: id:21389
+msgid "Enable custom background"
+msgstr "Дозволити свій фон"
+
+#: id:21390
+msgid "Power management level"
+msgstr "Управління живленням"
+
+#: id:21391
+msgid "High power"
+msgstr "Повна потужність"
+
+#: id:21392
+msgid "Low power"
+msgstr "Часткова потужність"
+
+#: id:21393
+msgid "High standby"
+msgstr "Повне очікування"
+
+#: id:21394
+msgid "Low standby"
+msgstr "Часткове очікування"
+
+#: id:21395
+msgid "Unable to cache files bigger than 4GB"
+msgstr "Неможливо кешувати файли більші ніж 4 Гігабайти"
+
+#: id:21396
+msgid "Chapter"
+msgstr "Розділ"
+
+#: id:21397
+msgid "High quality pixel shader v2"
+msgstr "Пікс.шейдер вис.якості v2"
+
+#: id:21398
+msgid "Enable playlist at startup"
+msgstr "Програвати плейлист при старті"
+
+#: id:21399
+msgid "Use tween animations"
+msgstr "Анімація відскакування панелей"
+
+#: id:21400
+msgid "contains"
+msgstr "містить"
+
+#: id:21401
+msgid "does not contain"
+msgstr "не містить"
+
+#: id:21402
+msgid "is"
+msgstr "дорівнює"
+
+#: id:21403
+msgid "is not"
+msgstr "не"
+
+#: id:21404
+msgid "starts with"
+msgstr "починається з"
+
+#: id:21405
+msgid "ends with"
+msgstr "закінчується на"
+
+#: id:21406
+msgid "greater than"
+msgstr "більші ніж"
+
+#: id:21407
+msgid "less than"
+msgstr "менші ніж"
+
+#: id:21408
+msgid "after"
+msgstr "після"
+
+#: id:21409
+msgid "before"
+msgstr "перед"
+
+#: id:21410
+msgid "in the last"
+msgstr "на кінці"
+
+#: id:21411
+msgid "not in the last"
+msgstr "не на кінці"
+
+#: id:21412
+msgid "Scrapers"
+msgstr "Інфо-ресурси"
+
+#: id:21413
+msgid "Default movie scraper"
+msgstr "Стандартний інфо-ресурс для фільмів"
+
+#: id:21414
+msgid "Default tvshow scraper"
+msgstr "Стандартний інфо-ресурс для серіалів"
+
+#: id:21415
+msgid "Default music video scraper"
+msgstr "Стандартний інфо-ресурс для музичного відео"
+
+#: id:21416
+msgid "Enable fallback based on scraper language"
+msgstr "Дозволити виправлення, залежно від мови інфо-ресурсу"
+
+#: id:21417
+msgid "- Settings"
+msgstr "- Налаштування"
+
+#: id:21418
+msgid "Multilingual"
+msgstr "Багатомовний"
+
+#: id:21419
+msgid "No scrapers present"
+msgstr ""
+
+#: id:21420
+msgid "Value to match"
+msgstr "Значення занадто велике"
+
+#: id:21421
+msgid "Smart playlist rule"
+msgstr "Правило \"розумного\" плейлиста"
+
+#: id:21422
+msgid "Match items where"
+msgstr "Вибрати об'єкти, в яких"
+
+#: id:21423
+msgid "New rule..."
+msgstr "Нове правило..."
+
+#: id:21424
+msgid "Items must match"
+msgstr "Об'єкти повинні задовольняти"
+
+#: id:21425
+msgid "all of the rules"
+msgstr "всім правилам"
+
+#: id:21426
+msgid "one or more of the rules"
+msgstr "одному або більше павилам"
+
+#: id:21427
+msgid "Limit to"
+msgstr "Обмежити до"
+
+#: id:21428
+msgid "No limit"
+msgstr "Без обмежень"
+
+#: id:21429
+msgid "Order by"
+msgstr "Упорядкувати за"
+
+#: id:21430
+msgid "ascending"
+msgstr "збільшенням"
+
+#: id:21431
+msgid "descending"
+msgstr "зменшенням"
+
+#: id:21432
+msgid "Edit smart playlist"
+msgstr "Виправити \"розумний\" плейлист"
+
+#: id:21433
+msgid "Name of the playlist"
+msgstr "Назва плейлиста"
+
+#: id:21434
+msgid "Find items where"
+msgstr "Знайти об'єкти, в яких"
+
+#: id:21435
+msgid "Edit"
+msgstr "Виправити"
+
+#: id:21436
+msgid "%i items"
+msgstr "%i об'єктів"
+
+#: id:21437
+msgid "New smart playlist..."
+msgstr "Створити новий \"розумний\" плейлист..."
+
+#: id:21438
+msgid "%c Drive"
+msgstr "Диск %c"
+
+#: id:21439
+msgid "Edit party mode rules"
+msgstr "Змінити правила режиму 'вечірка'"
+
+#: id:21440
+msgid "Home folder"
+msgstr "Домашня папка"
+
+#: id:21441
+msgid "Watched count"
+msgstr "Кількість переглядів"
+
+#: id:21442
+msgid "Episode title"
+msgstr "Назва епізоду"
+
+#: id:21443
+msgid "Video resolution"
+msgstr "Роздільна здатність відео"
+
+#: id:21444
+msgid "Audio channels"
+msgstr "Аудіо канали"
+
+#: id:21445
+msgid "Video codec"
+msgstr "Відео кодек"
+
+#: id:21446
+msgid "Audio codec"
+msgstr "Аудіо кодек"
+
+#: id:21447
+msgid "Audio language"
+msgstr "Мова звукової доріжки"
+
+#: id:21448
+msgid "Subtitle language"
+msgstr "Мова субтитрів"
+
+#: id:21449
+msgid "Remote control sends keyboard presses"
+msgstr "Пульт дист. керування симулює натискання клавіш клавіатури"
+
+#: id:21450
+msgid "- Edit"
+msgstr "- редагувати"
+
+#: id:21451
+msgid "Internet connection required."
+msgstr "Необхідне підключення до інтернету"
+
+#: id:21452
+msgid "Get More..."
+msgstr "Отримати більше..."
+
+#: id:21453
+msgid "Root filesystem"
+msgstr "Коренева файлова система"
+
+#: id:21454
+msgid "Cache full"
+msgstr ""
+
+#: id:21455
+msgid "Cache filled before reaching required amount for continous playback"
+msgstr ""
+
+#: id:21460
+msgid "Subtitle location"
+msgstr ""
+
+#: id:21461
+msgid "Fixed"
+msgstr ""
+
+#: id:21462
+msgid "Bottom of video"
+msgstr ""
+
+#: id:21463
+msgid "Below video"
+msgstr ""
+
+#: id:21464
+msgid "Top of video"
+msgstr ""
+
+#: id:21465
+msgid "Above video"
+msgstr ""
+
+#: id:21800
+msgid "File name"
+msgstr "Назва файлу"
+
+#: id:21801
+msgid "File path"
+msgstr "Шлях до файлу"
+
+#: id:21802
+msgid "File size"
+msgstr "Розмір файлу"
+
+#: id:21803
+msgid "File date/time"
+msgstr "Дата і час файлу"
+
+#: id:21804
+msgid "Slide index"
+msgstr "№ у слайдшоу"
+
+#: id:21805
+msgctxt "Auto context with id 21805"
+msgid "Resolution"
+msgstr "Розміри"
+
+#: id:21806
+msgctxt "Auto context with id 21806"
+msgid "Comment"
+msgstr "Нотатка"
+
+#: id:21807
+msgid "Colour/B&W"
+msgstr "Кольорова / Ч-Б"
+
+#: id:21808
+msgid "JPEG process"
+msgstr "Алгоритм JPEG"
+
+#: id:21820
+msgid "Date/Time"
+msgstr "Дата і час зйомки"
+
+#: id:21821
+msgid "Description"
+msgstr "Опис"
+
+#: id:21822
+msgid "Camera make"
+msgstr "Виробник фотоап-ту"
+
+#: id:21823
+msgid "Camera model"
+msgstr "Модель фотоапарату"
+
+#: id:21824
+msgid "EXIF comment"
+msgstr "EXIF нотатка"
+
+#: id:21825
+msgid "Firmware"
+msgstr "Прошивка"
+
+#: id:21826
+msgid "Aperture"
+msgstr "Діафрагма"
+
+#: id:21827
+msgid "Focal length"
+msgstr "Фокальна довжина"
+
+#: id:21828
+msgid "Focus distance"
+msgstr "Фокусна відстань"
+
+#: id:21829
+msgid "Exposure"
+msgstr "Експозиція"
+
+#: id:21830
+msgid "Exposure time"
+msgstr "Час експозиції"
+
+#: id:21831
+msgid "Exposure bias"
+msgstr "Підсилен. експозиції"
+
+#: id:21832
+msgid "Exposure mode"
+msgstr "Режим експозиції"
+
+#: id:21833
+msgid "Flash used"
+msgstr "Із спалахом"
+
+#: id:21834
+msgid "White-balance"
+msgstr "Баланс білого"
+
+#: id:21835
+msgid "Light source"
+msgstr "Джерело світла"
+
+#: id:21836
+msgid "Metering mode"
+msgstr "Режим виміру"
+
+#: id:21837
+msgid "ISO"
+msgstr ""
+
+#: id:21838
+msgid "Digital zoom"
+msgstr "Цифрове збільшення"
+
+#: id:21839
+msgid "CCD width"
+msgstr "Ширина CCD"
+
+#: id:21840
+msgid "GPS latitude"
+msgstr "GPS широта"
+
+#: id:21841
+msgid "GPS longitude"
+msgstr "GPS довгота"
+
+#: id:21842
+msgid "GPS altitude"
+msgstr "GPS висота"
+
+#: id:21843
+msgid "Orientation"
+msgstr "Орієнтація"
+
+#: id:21860
+msgid "Supplemental categories"
+msgstr "Додаткові категорії"
+
+#: id:21861
+msgid "Keywords"
+msgstr "Ключові слова"
+
+#: id:21862
+msgid "Caption"
+msgstr "Заголовок"
+
+#: id:21863
+msgid "Author"
+msgstr "Автор"
+
+#: id:21864
+msgid "Headline"
+msgstr "Рубрика"
+
+#: id:21865
+msgid "Special instructions"
+msgstr "Спеціальні інструкції"
+
+#: id:21866
+msgid "Category"
+msgstr "Категорія"
+
+#: id:21867
+msgid "Byline"
+msgstr "Підпис"
+
+#: id:21868
+msgid "Byline title"
+msgstr "Назва підпису"
+
+#: id:21869
+msgid "Credit"
+msgstr "Творець"
+
+#: id:21870
+msgid "Source"
+msgstr "Джерело"
+
+#: id:21871
+msgid "Copyright notice"
+msgstr "Авторське право"
+
+#: id:21872
+msgid "Object name"
+msgstr "Назва об'єкту"
+
+#: id:21873
+msgid "City"
+msgstr "Місто"
+
+#: id:21874
+msgid "State"
+msgstr "Штат"
+
+#: id:21875
+msgctxt "Auto context with id 21875"
+msgid "Country"
+msgstr "Країна"
+
+#: id:21876
+msgid "Original Tx Reference"
+msgstr ""
+
+#: id:21877
+msgid "Date created"
+msgstr "Дата створення"
+
+#: id:21878
+msgid "Copyright flag"
+msgstr "Признак авторського права"
+
+#: id:21879
+msgid "Country code"
+msgstr "Код країни"
+
+#: id:21880
+msgid "Reference service"
+msgstr "Довідковий сервіс"
+
+#: id:21881
+msgid "Allow control of XBMC via UPnP"
+msgstr "Дозволити керування XBMC через UPnP"
+
+#: id:21882
+msgid "Attempt to skip introduction before DVD menu"
+msgstr "Намагатися пропускати вступ перед меню DVD диска"
+
+#: id:21883
+msgid "Saved music"
+msgstr "Зкопійовані аудіо CD диски"
+
+#: id:21884
+msgid "Query info for all artists"
+msgstr "Дані про всіх виконавців"
+
+#: id:21885
+msgid "Downloading album information"
+msgstr "Загрузка інформації про альбом"
+
+#: id:21886
+msgid "Downloading artist information"
+msgstr "Загрузка інформації про виконавця"
+
+#: id:21887
+msgid "Biography"
+msgstr "Біографія"
+
+#: id:21888
+msgid "Discography"
+msgstr "Дискографія"
+
+#: id:21889
+msgid "Searching artist"
+msgstr "Пошук виконавця"
+
+#: id:21890
+msgid "Select artist"
+msgstr "Виберіть виконавця"
+
+#: id:21891
+msgctxt "Auto context with id 21891"
+msgid "Artist information"
+msgstr "Інформація про виконавця"
+
+#: id:21892
+msgid "Instruments"
+msgstr "Інструменти"
+
+#: id:21893
+msgid "Born"
+msgstr "Родився"
+
+#: id:21894
+msgid "Formed"
+msgstr "Створено"
+
+#: id:21895
+msgid "Themes"
+msgstr "Теми"
+
+#: id:21896
+msgid "Disbanded"
+msgstr "Розпалися"
+
+#: id:21897
+msgid "Died"
+msgstr "Помер"
+
+#: id:21898
+msgid "Years active"
+msgstr "Роки творч-ті"
+
+#: id:21899
+msgid "Label"
+msgstr "Позначка"
+
+#: id:21900
+msgid "Born/Formed"
+msgstr "Родився/Створено"
+
+#: id:22000
+msgid "Update library on startup"
+msgstr "Оновляти Бібліотеку при старті"
+
+#: id:22001
+msgid "Hide progress of library updates"
+msgstr "Завжди оновлювати Бібліотеку у фоновому режимі"
+
+#: id:22002
+msgid "- DNS suffix"
+msgstr "- DNS суфікс"
+
+#: id:22003
+msgid "%2.3fs"
+msgstr "Задіяти списки виправлень та рішень"
+
+#: id:22004
+msgid "Delayed by: %2.3fs"
+msgstr "Затримано на: %2.3fs"
+
+#: id:22005
+msgid "Ahead by: %2.3fs"
+msgstr "Випереджає на: %2.3fs"
+
+#: id:22006
+msgid "Subtitle offset"
+msgstr "Зміщення субтитрів"
+
+#: id:22007
+msgid "OpenGL vendor:"
+msgstr "Виробник OpenGL:"
+
+#: id:22008
+msgid "OpenGL renderer:"
+msgstr "Обробник OpenGL:"
+
+#: id:22009
+msgid "OpenGL version:"
+msgstr "Версія OpenGL:"
+
+#: id:22010
+msgid "GPU temperature:"
+msgstr "Температура GPU:"
+
+#: id:22011
+msgid "CPU temperature:"
+msgstr "Температура CPU:"
+
+#: id:22012
+msgid "Total memory"
+msgstr "Усього пам'яті"
+
+#: id:22013
+msgid "Profile data"
+msgstr "Дані профіля"
+
+#: id:22014
+msgid "Use dim if paused during video playback"
+msgstr "Затемнювати в паузі при програванні відео"
+
+#: id:22015
+msgid "All recordings"
+msgstr "Всі записи"
+
+#: id:22016
+msgid "By title"
+msgstr "За назвою"
+
+#: id:22017
+msgid "By group"
+msgstr "За групою"
+
+#: id:22018
+msgid "Live channels"
+msgstr "Канали прямої трансляції"
+
+#: id:22019
+msgid "Recordings by title"
+msgstr "Записи по назві"
+
+#: id:22020
+msgid "Guide"
+msgstr "Керівництво"
+
+#: id:22021
+msgid "Allowed error in aspect ratio to minimize black bars"
+msgstr "Дозволена похибка у співвідношенні сторін для зменшення чорних смуг"
+
+#: id:22022
+msgid "Show video files in listings"
+msgstr "Показувати відеофайли у списках"
+
+#: id:22023
+msgid "DirectX vendor:"
+msgstr "Постачальник DirectX:"
+
+#: id:22024
+msgid "Direct3D version:"
+msgstr "Версія Direct3D:"
+
+#: id:22030
+msgctxt "Auto context with id 22030"
+msgid "Font"
+msgstr "Шрифт"
+
+#: id:22031
+msgctxt "Auto context with id 22031"
+msgid "- Size"
+msgstr "- Розмір"
+
+#: id:22032
+msgctxt "Auto context with id 22032"
+msgid "- Colours"
+msgstr "- Кольори"
+
+#: id:22033
+msgid "- Charset"
+msgstr "- Набір символів"
+
+#: id:22034
+msgid "Export karaoke titles as HTML"
+msgstr "Експортувати список караоке в форматі HTML"
+
+#: id:22035
+msgid "Export karaoke titles as CSV"
+msgstr "Експортувати список караоке в форматі CSV"
+
+#: id:22036
+msgid "Import karaoke titles..."
+msgstr "Імпортувати список караоке..."
+
+#: id:22037
+msgid "Show song selector automatically"
+msgstr "Автоматично спливаючий вибір пісень"
+
+#: id:22038
+msgid "Export karaoke titles..."
+msgstr "Експортувати список караоке..."
+
+#: id:22039
+msgid "Enter song number"
+msgstr "Введіть номер пісні"
+
+#: id:22040
+msgid "white/green"
+msgstr "білий/зелений"
+
+#: id:22041
+msgid "white/red"
+msgstr "білий/червоний"
+
+#: id:22042
+msgid "white/blue"
+msgstr "білий/синій"
+
+#: id:22043
+msgid "black/white"
+msgstr "чорний/білий"
+
+#: id:22079
+msgid "Default select action"
+msgstr "Дія за замовчуванням при виборі"
+
+#: id:22080
+msgid "Choose"
+msgstr "Вибрати"
+
+#: id:22081
+msgid "Show Information"
+msgstr "Показати інформацію"
+
+#: id:22082
+msgid "More..."
+msgstr "Більше..."
+
+#: id:22083
+msgid "Play all"
+msgstr "Програти все"
+
+#: id:23049
+msgid "Teletext not available"
+msgstr "Телетекст недоступний"
+
+#: id:23050
+msgid "Activate Teletext"
+msgstr "Ввімкнути телетекст"
+
+#: id:23051
+msgid "Part %i"
+msgstr "Частина %i"
+
+#: id:23052
+msgid "Buffering %i bytes"
+msgstr "Буферизація... %i байт"
+
+#: id:23053
+msgid "Stopping"
+msgstr "Припинення..."
+
+#: id:23054
+msgid "Running"
+msgstr "Виконання..."
+
+#: id:23100
+msgid "External Player Active"
+msgstr "Зовнішній програвач активний"
+
+#: id:23101
+msgid "Click OK to terminate the player"
+msgstr "Натисніть OK для закриття програвача"
+
+#: id:23104
+msgid "Click OK when playback has ended"
+msgstr "Натисніть ОК коли програвання завершиться"
+
+#: id:24000
+msgid "Add-on"
+msgstr "Додаток"
+
+#: id:24001
+msgid "Add-ons"
+msgstr "Додатки"
+
+#: id:24002
+msgid "Add-on options"
+msgstr "Параметри додатків"
+
+#: id:24003
+msgid "Add-on Information"
+msgstr "Інформація про додаток"
+
+#: id:24005
+msgctxt "Auto context with id 24005"
+msgid "Media sources"
+msgstr "Джерела медіа"
+
+#: id:24007
+msgctxt "Auto context with id 24007"
+msgid "Movie information"
+msgstr "Інформація про фільм"
+
+#: id:24008
+msgctxt "Auto context with id 24008"
+msgid "Screensaver"
+msgstr "Зберігач екрану"
+
+#: id:24009
+msgid "Script"
+msgstr "Скрипт"
+
+#: id:24010
+msgctxt "Auto context with id 24010"
+msgid "Visualization"
+msgstr ""
+
+#: id:24011
+msgid "Add-on repository"
+msgstr "Репозиторій додатків"
+
+#: id:24012
+msgctxt "Auto context with id 24012"
+msgid "Subtitles"
+msgstr "Субтитри"
+
+#: id:24013
+msgid "Lyrics"
+msgstr "Тексти пісень"
+
+#: id:24014
+msgid "TV information"
+msgstr ""
+
+#: id:24015
+msgctxt "Auto context with id 24015"
+msgid "Music video information"
+msgstr ""
+
+#: id:24016
+msgctxt "Auto context with id 24016"
+msgid "Album information"
+msgstr "Інформація про альбом"
+
+#: id:24017
+msgctxt "Auto context with id 24017"
+msgid "Artist information"
+msgstr "Інформація про виконавця"
+
+#: id:24018
+msgctxt "Auto context with id 24018"
+msgid "Services"
+msgstr ""
+
+#: id:24020
+msgid "Configure"
+msgstr "Налаштувати"
+
+#: id:24021
+msgctxt "Auto context with id 24021"
+msgid "Disable"
+msgstr "Вимкнути"
+
+#: id:24022
+msgid "Enable"
+msgstr "Увімкнути"
+
+#: id:24023
+msgid "Add-on disabled"
+msgstr "Додаток вимкнений"
+
+#: id:24027
+msgctxt "Auto context with id 24027"
+msgid "Weather"
+msgstr "Погода"
+
+#: id:24028
+msgid "Weather.com (standard)"
+msgstr "Weather.com (за замовчуванням)"
+
+#: id:24030
+msgid "This Add-on can not be configured"
+msgstr "Цей додаток не можна налаштувати"
+
+#: id:24031
+msgid "Error loading settings"
+msgstr "Помилка завантаження налаштувань"
+
+#: id:24032
+msgid "All Add-ons"
+msgstr "Всі додатки"
+
+#: id:24033
+msgid "Get Add-ons"
+msgstr "Отримати додатки"
+
+#: id:24034
+msgid "Check for updates"
+msgstr "Перевірити наявність оновлень"
+
+#: id:24035
+msgid "Force refresh"
+msgstr "Примусове оновлення"
+
+#: id:24036
+msgid "Change log"
+msgstr "Журнал змін"
+
+#: id:24037
+msgid "Uninstall"
+msgstr "Видалити"
+
+#: id:24038
+msgid "Install"
+msgstr "Встановити"
+
+#: id:24039
+msgid "Disabled Add-ons"
+msgstr "Вимкнені додатки"
+
+#: id:24040
+msgid "(Clear the current setting)"
+msgstr "(Очистити поточні налаштування)"
+
+#: id:24041
+msgid "Install from zip file"
+msgstr "Встановити із zip файлу"
+
+#: id:24042
+msgid "Downloading %i%%"
+msgstr "Завантаження.... %i%%"
+
+#: id:24043
+msgid "Available Updates"
+msgstr "Доступні оновлення"
+
+#: id:24044
+msgid "Dependencies not met"
+msgstr ""
+
+#: id:24045
+msgid "Add-on does not have the correct structure"
+msgstr ""
+
+#: id:24046
+msgid "%s is used by the following installed add-on(s)"
+msgstr ""
+
+#: id:24047
+msgid "This add-on cannot be uninstalled"
+msgstr ""
+
+#: id:24048
+msgid "Rollback"
+msgstr ""
+
+#: id:24050
+msgid "Available Add-ons"
+msgstr "Доступні додатки"
+
+#: id:24051
+msgid "Version:"
+msgstr "Версія:"
+
+#: id:24052
+msgid "Disclaimer"
+msgstr ""
+
+#: id:24053
+msgid "License:"
+msgstr "Ліцензія:"
+
+#: id:24054
+msgid "Changelog"
+msgstr "Журнал змін"
+
+#: id:24059
+msgid "Would you like to enable this Add-on?"
+msgstr "Увімкнути цей додаток?"
+
+#: id:24060
+msgid "Would you like to disable this Add-on?"
+msgstr "Вимкнути цей додаток?"
+
+#: id:24061
+msgid "Add-on update available!"
+msgstr "Доступне оновлення додатку!"
+
+#: id:24062
+msgid "Enabled Add-ons"
+msgstr "Ввімкнені додатки"
+
+#: id:24063
+msgid "Auto update"
+msgstr "Автооновлення"
+
+#: id:24064
+msgid "Add-on enabled"
+msgstr "Додаток активований"
+
+#: id:24065
+msgid "Add-on updated"
+msgstr "Додаток оновлений"
+
+#: id:24066
+msgid "Cancel Add-on download?"
+msgstr "Відмінити завантаження додатку?"
+
+#: id:24067
+msgid "Currently downloading Add-ons"
+msgstr "Додатки які зараз завантажуються"
+
+#: id:24068
+msgid "Update available"
+msgstr "Доступне оновлення"
+
+#: id:24069
+msgid "Update"
+msgstr "Оновлення"
+
+#: id:24070
+msgid "Add-on could not be loaded."
+msgstr "Неможливо завантажити додаток"
+
+#: id:24071
+msgid "An unknown error has occurred."
+msgstr "Виникла невідома помилка"
+
+#: id:24072
+msgid "Settings required"
+msgstr "Потрібно налаштувати"
+
+#: id:24073
+msgid "Could not connect"
+msgstr "Неможливо під’єднатися"
+
+#: id:24074
+msgid "Needs to restart"
+msgstr "Потрбно перезавантажити"
+
+#: id:24075
+msgctxt "Auto context with id 24075"
+msgid "Disable"
+msgstr "Вимкнути"
+
+#: id:24076
+msgid "Add-on Required"
+msgstr ""
+
+#: id:24080
+msgid "Try to reconnect?"
+msgstr "Спробувати під’єднатися знову?"
+
+#: id:24089
+msgid "Add-on restarts"
+msgstr ""
+
+#: id:24090
+msgid "Lock Add-on manager"
+msgstr "Заблокувати менеджер додатків"
+
+#: id:24094
+msgid "(current)"
+msgstr ""
+
+#: id:24095
+msgid "(blacklisted)"
+msgstr ""
+
+#: id:24096
+msgid "Add-on has been marked as broken in repository."
+msgstr "Додаток був позначений у репозиторії як зламаний."
+
+#: id:24097
+msgid "Would you like to disable it on your system?"
+msgstr "Вимкнути його у вашій системі?"
+
+#: id:24098
+msgid "Broken"
+msgstr "Зламаний"
+
+#: id:24099
+msgid "Would you like to switch to this skin?"
+msgstr ""
+
+#: id:24100
+msgid "To use this feature you must download an Add-on:"
+msgstr ""
+
+#: id:24101
+msgid "Would you like to download this Add-on?"
+msgstr ""
+
+#: id:25000
+msgid "Notifications"
+msgstr ""
+
+#: id:29800
+msgid "Library Mode"
+msgstr "Режим Бібліотеки"
+
+#: id:29801
+msgid "QWERTY keyboard"
+msgstr "Клавіатура QWERTY"
+
+#: id:29802
+msgid "Passthrough Audio in use"
+msgstr ""
+
+#: id:33001
+msgid "Trailer quality"
+msgstr "Якість трейлеру"
+
+#: id:33002
+msgid "Stream"
+msgstr "Потік"
+
+#: id:33003
+msgid "Download"
+msgstr "Завантаження"
+
+#: id:33004
+msgid "Download & play"
+msgstr "Завантажити і програти"
+
+#: id:33005
+msgid "Download & save"
+msgstr "Завантажити і зберегти"
+
+#: id:33006
+msgid "Today"
+msgstr "Сьогодні"
+
+#: id:33007
+msgid "Tomorrow"
+msgstr "Завтра"
+
+#: id:33008
+msgid "Saving"
+msgstr "Збереження"
+
+#: id:33009
+msgid "Copying"
+msgstr "Копіювання"
+
+#: id:33010
+msgid "Set download directory"
+msgstr "Вкажіть папку завантаження"
+
+#: id:33011
+msgid "Search duration"
+msgstr "Період пошуку"
+
+#: id:33012
+msgid "Short"
+msgstr "Короткий"
+
+#: id:33013
+msgid "Long"
+msgstr "Довгий"
+
+#: id:33014
+msgid "Use DVD player instead of regular player"
+msgstr ""
+
+#: id:33015
+msgid "Ask for download before playing video"
+msgstr "Запитати про завантаження перед програванням відео"
+
+#: id:33016
+msgid "Clips"
+msgstr "Кліпи"
+
+#: id:33017
+msgid "Restart plugin to enable"
+msgstr "Перезавантажити додаток для активації"
+
+#: id:33018
+msgid "Tonight"
+msgstr "Вночі"
+
+#: id:33019
+msgid "Tomorrow Night"
+msgstr "Сьогодні вночі"
+
+#: id:33020
+msgid "Condition"
+msgstr "Умови"
+
+#: id:33021
+msgid "Precipitation"
+msgstr ""
+
+#: id:33022
+msgid "Precip"
+msgstr ""
+
+#: id:33023
+msgid "Humid"
+msgstr ""
+
+#: id:33024
+msgid "Feels"
+msgstr ""
+
+#: id:33025
+msgid "Observed"
+msgstr ""
+
+#: id:33026
+msgid "Departure from normal"
+msgstr ""
+
+#: id:33027
+msgid "Sunrise"
+msgstr "Схід сонця"
+
+#: id:33028
+msgid "Sunset"
+msgstr "Захід сонця"
+
+#: id:33029
+msgid "Details"
+msgstr "Подробиці"
+
+#: id:33030
+msgid "Outlook"
+msgstr ""
+
+#: id:33031
+msgid "Coverflow"
+msgstr ""
+
+#: id:33032
+msgid "Translate text"
+msgstr "Перекласти текст"
+
+#: id:33033
+msgid "Map list %s category"
+msgstr ""
+
+#: id:33034
+msgid "36 Hour"
+msgstr ""
+
+#: id:33035
+msgid "Maps"
+msgstr "Мапи"
+
+#: id:33036
+msgid "Hourly"
+msgstr "Щогодини"
+
+#: id:33037
+msgid "Weekend"
+msgstr "Щотижня"
+
+#: id:33038
+msgid "%s day"
+msgstr "%s днів"
+
+#: id:33049
+msgid "Alert"
+msgstr "Сигнал"
+
+#: id:33050
+msgid "Alerts"
+msgstr "Сигнали"
+
+#: id:33051
+msgid "Choose Your"
+msgstr ""
+
+#: id:33052
+msgid "Check"
+msgstr ""
+
+#: id:33053
+msgctxt "Auto context with id 33053"
+msgid "Configure the"
+msgstr "Налаштувати"
+
+#: id:33054
+msgid "Seasons"
+msgstr "Сезони"
+
+#: id:33055
+msgid "Use your"
+msgstr ""
+
+#: id:33056
+msgid "Watch your"
+msgstr ""
+
+#: id:33057
+msgid "Listen to"
+msgstr ""
+
+#: id:33058
+msgid "View your"
+msgstr ""
+
+#: id:33059
+msgctxt "Auto context with id 33059"
+msgid "Configure the"
+msgstr "Налаштувати"
+
+#: id:33060
+msgid "Power"
+msgstr ""
+
+#: id:33061
+msgid "Menu"
+msgstr "Меню"
+
+#: id:33062
+msgid "Play the"
+msgstr "Програти"
+
+#: id:33063
+msgid "Options"
+msgstr "Параметри"
+
+#: id:33065
+msgid "Editor"
+msgstr "Редактор"
+
+#: id:33066
+msgid "About your"
+msgstr ""
+
+#: id:33067
+msgid "Star rating"
+msgstr ""
+
+#: id:33068
+msgid "Background"
+msgstr "Фон"
+
+#: id:33069
+msgid "Backgrounds"
+msgstr "Фони"
+
+#: id:33070
+msgid "Custom background"
+msgstr "Власний фон"
+
+#: id:33071
+msgid "Custom backgrounds"
+msgstr "Власні фони"
+
+#: id:33072
+msgid "View Readme"
+msgstr "Переглянути Readme"
+
+#: id:33073
+msgid "View Changelog"
+msgstr "Переглянути журнал змін"
+
+#: id:33074
+msgid "This version of %s requires an"
+msgstr "Для запуску ця версія %s вимагає"
+
+#: id:33075
+msgid "XBMC revision of %s or greater to run."
+msgstr "XBMC випуску %s або новіший."
+
+#: id:33076
+msgid "Please update XBMC."
+msgstr "Будь-ласка, оновіть XBMC."
+
+#: id:33077
+msgid "No data found!"
+msgstr "Інформацію не знайдено!"
+
+#: id:33078
+msgid "Next page"
+msgstr "Наступна сторінка"
+
+#: id:33079
+msgid "Love"
+msgstr "Подобається"
+
+#: id:33080
+msgid "Hate"
+msgstr "Неподобається"
+
+#: id:33081
+msgid "This file is stacked, select the part you want to play from."
+msgstr ""
+
+#: id:33082
+msgid "Path to script"
+msgstr "Шлях до скрипту"
+
+#: id:33083
+msgid "Enable custom script button"
+msgstr "Ввімкнути кнопку власного скрипта"
+
+#: id:33100
+msgid "Failed to start"
+msgstr ""
+
+#: id:33101
+msgid "Webserver"
+msgstr ""
+
+#: id:33102
+msgid "Event Server"
+msgstr ""
+
+#: id:33103
+msgid "Remote communication server"
+msgstr ""
+
+#: id:33200
+msgid "Detected New Connection"
+msgstr ""
+
+#: id:34000
+msgid "Lame"
+msgstr ""
+
+#: id:34001
+msgid "Vorbis"
+msgstr ""
+
+#: id:34002
+msgid "Wav"
+msgstr ""
+
+#: id:34003
+msgid "DXVA2"
+msgstr ""
+
+#: id:34004
+msgid "VAAPI"
+msgstr ""
+
+#: id:34005
+msgid "Flac"
+msgstr ""
+
+#: id:34100
+msgid "Speaker Configuration"
+msgstr "Конфігурація гучномовців"
+
+#: id:34101
+msgid "2.0"
+msgstr ""
+
+#: id:34102
+msgid "2.1"
+msgstr ""
+
+#: id:34103
+msgid "3.0"
+msgstr ""
+
+#: id:34104
+msgid "3.1"
+msgstr ""
+
+#: id:34105
+msgid "4.0"
+msgstr ""
+
+#: id:34106
+msgid "4.1"
+msgstr ""
+
+#: id:34107
+msgid "5.0"
+msgstr ""
+
+#: id:34108
+msgid "5.1"
+msgstr ""
+
+#: id:34109
+msgid "7.0"
+msgstr ""
+
+#: id:34110
+msgid "7.1"
+msgstr ""
+
+#: id:34201
+msgid "Can't find a next item to play"
+msgstr ""
+
+#: id:34202
+msgid "Can't find a previous item to play"
+msgstr ""
+
+#: id:34300
+msgid "Failed to start zeroconf"
+msgstr ""
+
+#: id:34301
+msgid "Is Apple's Bonjour Service installed? See log for more info."
+msgstr ""
+
+#: id:34400
+msgid "Video Rendering"
+msgstr ""
+
+#: id:34401
+msgid "Failed to init video filters/scalers, falling back to bilinear scaling"
+msgstr ""
+
+#: id:34402
+msgid "Failed to initialize audio device"
+msgstr ""
+
+#: id:34403
+msgid "Check your audiosettings"
+msgstr ""
+
+#: id:34404
+msgid "Use gestures for navigation:"
+msgstr ""
+
+#: id:34405
+msgid "1 finger swipe left,right,up,down for cursors"
+msgstr ""
+
+#: id:34406
+msgid "2 finger swipe left for backspace"
+msgstr ""
+
+#: id:34407
+msgid "1 finger single tap for enter"
+msgstr ""
+
+#: id:34408
+msgid "2 finger single tap for contextmenu"
+msgstr ""
+
+#: id:35000
+msgid "Peripherals"
+msgstr ""
+
+#: id:35001
+msgid "Generic HID device"
+msgstr ""
+
+#: id:35002
+msgid "Generic network adapter"
+msgstr ""
+
+#: id:35003
+msgid "Generic disk"
+msgstr ""
+
+#: id:35004
+msgid "There are no settings available\nfor this peripheral."
+msgstr ""
+
+#: id:35005
+msgid "New device configured"
+msgstr ""
+
+#: id:35006
+msgid "Device removed"
+msgstr ""
+
+#: id:35007
+msgid "Keymap to use for this device"
+msgstr ""
+
+#: id:35008
+msgid "Keymap enabled"
+msgstr ""
+
+#: id:35009
+msgid "Do not use the custom keymap for this device"
+msgstr ""
+
+#: id:35500
+msgid "Location"
+msgstr ""
+
+#: id:35501
+msgid "Class"
+msgstr ""
+
+#: id:35502
+msgctxt "Auto context with id 35502"
+msgid "Name"
+msgstr ""
+
+#: id:35503
+msgid "Vendor"
+msgstr ""
+
+#: id:35504
+msgid "Product ID"
+msgstr ""
+
+#: id:36000
+msgid "Pulse-Eight CEC adapter"
+msgstr ""
+
+#: id:36001
+msgid "Pulse-Eight Nyxboard"
+msgstr ""
+
+#: id:36002
+msgid "Switch to keyboard side command"
+msgstr ""
+
+#: id:36003
+msgid "Switch to remote side command"
+msgstr ""
+
+#: id:36004
+msgid "Press \"user\" button command"
+msgstr ""
+
+#: id:36005
+msgid "Enable switch side commands"
+msgstr ""
+
+#: id:36006
+msgid "Could not open the adapter"
+msgstr ""
+
+#: id:36007
+msgid "Devices to power on when starting XBMC"
+msgstr ""
+
+#: id:36008
+msgid "Devices to power off when stopping XBMC"
+msgstr ""
+
+#: id:36009
+msgid "Put devices in standby mode when activating screensaver"
+msgstr ""
+
+#: id:36011
+msgid "Could not detect the CEC port. Set it up manually."
+msgstr ""
+
+#: id:36012
+msgid "Could not initialise the CEC adapter. Check your settings."
+msgstr ""
+
+#: id:36013
+msgid "Unsupported libCEC interface version. %d is greater than the version XBMC supports (%d)"
+msgstr ""
+
+#: id:36014
+msgid "Put this PC in standby mode when the TV is switched off"
+msgstr ""
+
+#: id:36015
+msgid "HDMI port number"
+msgstr ""
+
+#: id:36016
+msgctxt "Auto context with id 36016"
+msgid "Connected"
+msgstr ""
+
+#: id:36017
+msgid "Adapter found, but libCEC is not available"
+msgstr ""
+
+#: id:36018
+msgid "Use the TV's language setting"
+msgstr ""
+
+#: id:36019
+msgid "Connected to HDMI device"
+msgstr ""
+
+#: id:36020
+msgid "Make XBMC the active source when starting"
+msgstr ""
+
+#: id:36021
+msgid "Physical address (overrules HDMI port)"
+msgstr ""
+
+#: id:36022
+msgid "COM port (leave empty unless needed)"
+msgstr ""
+
+#: id:36023
+msgid "Configuration updated"
+msgstr ""
+
+#: id:36024
+msgid "Failed to set the new configuration. Please check your settings."
+msgstr ""
+
+#: id:36025
+msgid "Send 'inactive source' command when stopping XBMC"
+msgstr ""
+

--- a/project/VS2010Express/XBMC.vcxproj
+++ b/project/VS2010Express/XBMC.vcxproj
@@ -1051,6 +1051,7 @@
     <ClCompile Include="..\..\xbmc\utils\PCMAmplifier.cpp" />
     <ClCompile Include="..\..\xbmc\utils\PerformanceSample.cpp" />
     <ClCompile Include="..\..\xbmc\utils\PerformanceStats.cpp" />
+    <ClCompile Include="..\..\xbmc\utils\POUtils.cpp" />
     <ClCompile Include="..\..\xbmc\utils\RecentlyAddedJob.cpp" />
     <ClCompile Include="..\..\xbmc\utils\RegExp.cpp" />
     <ClCompile Include="..\..\xbmc\utils\RingBuffer.cpp" />
@@ -1865,6 +1866,7 @@
     <ClInclude Include="..\..\xbmc\utils\PCMAmplifier.h" />
     <ClInclude Include="..\..\xbmc\utils\PerformanceSample.h" />
     <ClInclude Include="..\..\xbmc\utils\PerformanceStats.h" />
+    <ClInclude Include="..\..\xbmc\utils\POUtils.h" />
     <ClInclude Include="..\..\xbmc\utils\RecentlyAddedJob.h" />
     <ClInclude Include="..\..\xbmc\utils\RegExp.h" />
     <ClInclude Include="..\..\xbmc\utils\RingBuffer.h" />

--- a/project/VS2010Express/XBMC.vcxproj.filters
+++ b/project/VS2010Express/XBMC.vcxproj.filters
@@ -2640,6 +2640,9 @@
     <ClCompile Include="..\..\xbmc\filesystem\MemBufferCache.cpp">
       <Filter>filesystem</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\xbmc\utils\POUtils.cpp">
+      <Filter>utils</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\xbmc\win32\pch.h">
@@ -5318,6 +5321,9 @@
     </ClInclude>
     <ClInclude Include="..\..\xbmc\network\httprequesthandler\HTTPJsonRpcHandler.h">
       <Filter>network\httprequesthandler</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\xbmc\utils\POUtils.h">
+      <Filter>utils</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -731,9 +731,9 @@ bool CApplication::Create()
   g_langInfo.Load(strLangInfoPath);
 
   CStdString strLanguagePath;
-  strLanguagePath.Format("special://xbmc/language/%s/strings.xml", strLanguage.c_str());
+  strLanguagePath.Format("special://xbmc/language/%s", strLanguage.c_str());
 
-  CLog::Log(LOGINFO, "load language file: %s", strLanguagePath.c_str());
+  CLog::Log(LOGINFO, "load language file from path: %s", strLanguagePath.c_str());
   if (!g_localizeStrings.Load(strLanguagePath))
     FatalErrorHandler(false, false, true);
 
@@ -1749,11 +1749,9 @@ void CApplication::LoadSkin(const SkinPtr& skin)
   CStdString langPath, skinEnglishPath;
   URIUtils::AddFileToFolder(skin->Path(), "language", langPath);
   URIUtils::AddFileToFolder(langPath, g_guiSettings.GetString("locale.language"), langPath);
-  URIUtils::AddFileToFolder(langPath, "strings.xml", langPath);
 
   URIUtils::AddFileToFolder(skin->Path(), "language", skinEnglishPath);
   URIUtils::AddFileToFolder(skinEnglishPath, "English", skinEnglishPath);
-  URIUtils::AddFileToFolder(skinEnglishPath, "strings.xml", skinEnglishPath);
 
   g_localizeStrings.LoadSkinStrings(langPath, skinEnglishPath);
 

--- a/xbmc/addons/Addon.cpp
+++ b/xbmc/addons/Addon.cpp
@@ -338,9 +338,9 @@ bool CAddon::LoadStrings()
 {
   // Path where the language strings reside
   CStdString chosenPath;
-  chosenPath.Format("resources/language/%s/strings.xml", g_guiSettings.GetString("locale.language").c_str());
+  chosenPath.Format("resources/language/%s", g_guiSettings.GetString("locale.language").c_str());
   CStdString chosen = URIUtils::AddFileToFolder(m_props.path, chosenPath);
-  CStdString fallback = URIUtils::AddFileToFolder(m_props.path, "resources/language/English/strings.xml");
+  CStdString fallback = URIUtils::AddFileToFolder(m_props.path, "resources/language/English");
 
   m_hasStrings = m_strings.Load(chosen, fallback);
   return m_checkedStrings = true;

--- a/xbmc/guilib/LocalizeStrings.cpp
+++ b/xbmc/guilib/LocalizeStrings.cpp
@@ -25,6 +25,9 @@
 #include "utils/log.h"
 #include "filesystem/SpecialProtocol.h"
 #include "utils/XMLUtils.h"
+#include "utils/URIUtils.h"
+#include "utils/POUtils.h"
+#include "filesystem/Directory.h"
 
 CLocalizeStrings::CLocalizeStrings(void)
 {
@@ -57,7 +60,7 @@ bool CLocalizeStrings::LoadSkinStrings(const CStdString& path, const CStdString&
   ClearSkinStrings();
   // load the skin strings in.
   CStdString encoding;
-  if (!LoadXML(path, encoding))
+  if (!LoadStr2Mem(path, encoding))
   {
     if (path == fallbackPath) // no fallback, nothing to do
       return false;
@@ -65,15 +68,58 @@ bool CLocalizeStrings::LoadSkinStrings(const CStdString& path, const CStdString&
 
   // load the fallback
   if (path != fallbackPath)
-    LoadXML(fallbackPath, encoding);
+    LoadStr2Mem(fallbackPath, encoding);
 
+  return true;
+}
+
+bool CLocalizeStrings::LoadStr2Mem(const CStdString &pathname_in, CStdString &encoding, uint32_t offset /* = 0 */)
+{
+  CStdString pathname = CSpecialProtocol::TranslatePathConvertCase(pathname_in);
+  if (!XFILE::CDirectory::Exists(pathname))
+  {
+    CLog::Log(LOGDEBUG, "LocalizeStrings: no translation available in currently set gui language, at path %s", pathname.c_str());
+    return false;
+  };
+
+  bool bIsSourceLanguage = CStdString((pathname.substr(pathname.size()-7,7))).ToLower() == "english";
+
+  if (LoadPO(URIUtils::AddFileToFolder(pathname, "strings.po"), encoding, offset, bIsSourceLanguage))
+    return true;
+
+  CLog::Log(LOGDEBUG, "LocalizeStrings: no strings.po file exist at %s, fallback to strings.xml", pathname.c_str());
+  return LoadXML(URIUtils::AddFileToFolder(pathname, "strings.xml"), encoding, offset);
+}
+
+bool CLocalizeStrings::LoadPO(const CStdString &filename, CStdString &encoding, uint32_t offset /* = 0 */, bool bSourceLanguage)
+{
+  CPODocument PODoc;
+  if (!PODoc.LoadFile(filename)) return false;
+  int counter = 0;
+  int id;
+  while ((PODoc.GetNextEntry()))
+  {
+    if (PODoc.GetEntryType() == ID_FOUND && m_strings.find((id = PODoc.GetEntryID()) + offset) == m_strings.end())
+    {
+      PODoc.ParseEntry();
+      if (bSourceLanguage)
+      {
+        if (PODoc.GetMsgid(0) != "") {m_strings[id + offset] = PODoc.GetMsgid(0).c_str(); counter++;}
+      }
+      else
+      {
+        if (PODoc.GetMsgstr(0) != "") {m_strings[id + offset] = PODoc.GetMsgstr(0).c_str(); counter++;}
+      }
+    }
+  }
+  CLog::Log(LOGDEBUG, "POParser: loaded %i strings from file %s", counter, filename.c_str());
   return true;
 }
 
 bool CLocalizeStrings::LoadXML(const CStdString &filename, CStdString &encoding, uint32_t offset /* = 0 */)
 {
   TiXmlDocument xmlDoc;
-  if (!xmlDoc.LoadFile(CSpecialProtocol::TranslatePathConvertCase(filename)))
+  if (!xmlDoc.LoadFile(filename))
   {
     CLog::Log(LOGDEBUG, "unable to load %s: %s at line %d", filename.c_str(), xmlDoc.ErrorDesc(), xmlDoc.ErrorRow());
     return false;
@@ -112,17 +158,17 @@ bool CLocalizeStrings::Load(const CStdString& strFileName, const CStdString& str
   CStdString encoding;
   Clear();
 
-  if (!LoadXML(strFileName, encoding))
+  if (!LoadStr2Mem(strFileName, encoding))
   {
     // try loading the fallback
-    if (!bLoadFallback || !LoadXML(strFallbackFileName, encoding))
+    if (!bLoadFallback || !LoadStr2Mem(strFallbackFileName, encoding))
       return false;
 
     bLoadFallback = false;
   }
 
   if (bLoadFallback)
-    LoadXML(strFallbackFileName, encoding);
+    LoadStr2Mem(strFallbackFileName, encoding);
 
   // fill in the constant strings
   m_strings[20022] = "";
@@ -192,7 +238,7 @@ uint32_t CLocalizeStrings::LoadBlock(const CStdString &id, const CStdString &pat
 
   // load the strings
   CStdString encoding;
-  bool success = LoadXML(path, encoding, offset);
+  bool success = LoadStr2Mem(path, encoding, offset);
   if (!success)
   {
     if (path == fallbackPath) // no fallback, nothing to do
@@ -201,7 +247,7 @@ uint32_t CLocalizeStrings::LoadBlock(const CStdString &id, const CStdString &pat
 
   // load the fallback
   if (path != fallbackPath)
-    success |= LoadXML(fallbackPath, encoding, offset);
+    success |= LoadStr2Mem(fallbackPath, encoding, offset);
 
   return success ? offset : 0;
 }

--- a/xbmc/guilib/LocalizeStrings.cpp
+++ b/xbmc/guilib/LocalizeStrings.cpp
@@ -80,7 +80,7 @@ bool CLocalizeStrings::LoadStr2Mem(const CStdString &pathname_in, CStdString &en
   {
     CLog::Log(LOGDEBUG, "LocalizeStrings: no translation available in currently set gui language, at path %s", pathname.c_str());
     return false;
-  };
+  }
 
   bool bIsSourceLanguage = CStdString((pathname.substr(pathname.size()-7,7))).ToLower() == "english";
 
@@ -94,7 +94,8 @@ bool CLocalizeStrings::LoadStr2Mem(const CStdString &pathname_in, CStdString &en
 bool CLocalizeStrings::LoadPO(const CStdString &filename, CStdString &encoding, uint32_t offset /* = 0 */, bool bSourceLanguage)
 {
   CPODocument PODoc;
-  if (!PODoc.LoadFile(filename)) return false;
+  if (!PODoc.LoadFile(filename))
+    return false;
   int counter = 0;
   int id;
   while ((PODoc.GetNextEntry()))
@@ -104,11 +105,19 @@ bool CLocalizeStrings::LoadPO(const CStdString &filename, CStdString &encoding, 
       PODoc.ParseEntry();
       if (bSourceLanguage)
       {
-        if (PODoc.GetMsgid(0) != "") {m_strings[id + offset] = PODoc.GetMsgid(0).c_str(); counter++;}
+        if (!PODoc.GetMsgid(0).empty())
+        {
+          m_strings[id + offset] = PODoc.GetMsgid(0);
+          counter++;
+        }
       }
       else
       {
-        if (PODoc.GetMsgstr(0) != "") {m_strings[id + offset] = PODoc.GetMsgstr(0).c_str(); counter++;}
+        if (!PODoc.GetMsgstr(0).empty())
+        {
+          m_strings[id + offset] = PODoc.GetMsgstr(0);
+          counter++;
+        }
       }
     }
   }

--- a/xbmc/guilib/LocalizeStrings.h
+++ b/xbmc/guilib/LocalizeStrings.h
@@ -42,7 +42,7 @@ class CLocalizeStrings
 public:
   CLocalizeStrings(void);
   virtual ~CLocalizeStrings(void);
-  bool Load(const CStdString& strFileName, const CStdString& strFallbackFileName="special://xbmc/language/english/strings.xml");
+  bool Load(const CStdString& strFileName, const CStdString& strFallbackFileName="special://xbmc/language/english");
   bool LoadSkinStrings(const CStdString& path, const CStdString& fallbackPath);
   void ClearSkinStrings();
   const CStdString& Get(uint32_t code) const;
@@ -51,6 +51,8 @@ public:
   void ClearBlock(const CStdString &id);
 protected:
   void Clear(uint32_t start, uint32_t end);
+  bool LoadStr2Mem(const CStdString &pathname, CStdString &encoding, uint32_t offset = 0);
+  bool LoadPO(const CStdString &filename, CStdString &encoding, uint32_t offset = 0, bool bSourceLanguage = false);
   bool LoadXML(const CStdString &filename, CStdString &encoding, uint32_t offset = 0);
   CStdString ToUTF8(const CStdString &encoding, const CStdString &str);
   std::map<uint32_t, CStdString> m_strings;

--- a/xbmc/guilib/LocalizeStrings.h
+++ b/xbmc/guilib/LocalizeStrings.h
@@ -51,9 +51,35 @@ public:
   void ClearBlock(const CStdString &id);
 protected:
   void Clear(uint32_t start, uint32_t end);
+
+  /*! \brief Loads language ids and strings to memory map m_strings.
+   * It tries to load a string.po file first. If doesn't exist, it loads a strings.xml file instead.
+   \param pathname The directory name, where we look for the strings file.
+   \param encoding Encoding of the strings. For PO files we only use utf-8.
+   \param offset An offset value to place strings from the id value.
+   \return false if no strings.po or strings.xml file was loaded.
+   */
   bool LoadStr2Mem(const CStdString &pathname, CStdString &encoding, uint32_t offset = 0);
+
+  /*! \brief Tries to load ids and strings from astrings.po file to m_strings map.
+   * It should only be called from the LoadStr2Mem function to have a fallback.
+   *   \param pathname The directory name, where we look for the strings file.
+   *   \param encoding Encoding of the strings. For PO files we only use utf-8.
+   *   \param offset An offset value to place strings from the id value.
+   *   \param bSourceLanguage If we are loading the source English strings.po.
+   *   \return false if no strings.po file was loaded.
+   */
   bool LoadPO(const CStdString &filename, CStdString &encoding, uint32_t offset = 0, bool bSourceLanguage = false);
+
+  /*! \brief Tries to load ids and strings from astrings.xml file to m_strings map.
+   * It should only be called from the LoadStr2Mem function to try a PO file first.
+   *   \param pathname The directory name, where we look for the strings file.
+   *   \param encoding Encoding of the strings.
+   *   \param offset An offset value to place strings from the id value.
+   *   \return false if no strings.xml file was loaded.
+   */
   bool LoadXML(const CStdString &filename, CStdString &encoding, uint32_t offset = 0);
+
   CStdString ToUTF8(const CStdString &encoding, const CStdString &str);
   std::map<uint32_t, CStdString> m_strings;
   typedef std::map<uint32_t, CStdString>::const_iterator ciStrings;

--- a/xbmc/interfaces/python/xbmcmodule/GUIPythonWindowXML.cpp
+++ b/xbmc/interfaces/python/xbmcmodule/GUIPythonWindowXML.cpp
@@ -447,8 +447,6 @@ unsigned int CGUIPythonWindowXML::LoadScriptStrings()
   URIUtils::AddFileToFolder(pathToFallbackLanguageFile, "language", pathToFallbackLanguageFile);
   URIUtils::AddFileToFolder(pathToLanguageFile, g_guiSettings.GetString("locale.language"), pathToLanguageFile);
   URIUtils::AddFileToFolder(pathToFallbackLanguageFile, "english", pathToFallbackLanguageFile);
-  URIUtils::AddFileToFolder(pathToLanguageFile, "strings.xml", pathToLanguageFile);
-  URIUtils::AddFileToFolder(pathToFallbackLanguageFile, "strings.xml", pathToFallbackLanguageFile);
 
   // allocate a bunch of strings
   return g_localizeStrings.LoadBlock(m_scriptPath, pathToLanguageFile, pathToFallbackLanguageFile);

--- a/xbmc/settings/GUISettings.cpp
+++ b/xbmc/settings/GUISettings.cpp
@@ -1422,7 +1422,7 @@ bool CGUISettings::SetLanguage(const CStdString &strLanguage)
     g_charsetConverter.reset();
 
     CStdString strLanguagePath;
-    strLanguagePath.Format("special://xbmc/language/%s/strings.xml", strNewLanguage.c_str());
+    strLanguagePath.Format("special://xbmc/language/%s", strNewLanguage.c_str());
     if (!g_localizeStrings.Load(strLanguagePath))
       return false;
 

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -947,7 +947,7 @@ bool CSettings::LoadProfile(unsigned int index)
     g_langInfo.Load(strLangInfoPath);
 
     CStdString strLanguagePath;
-    strLanguagePath.Format("special://xbmc/language/%s/strings.xml", strLanguage.c_str());
+    strLanguagePath.Format("special://xbmc/language/%s", strLanguage.c_str());
 
     CButtonTranslator::GetInstance().Load(true);
     g_localizeStrings.Load(strLanguagePath);

--- a/xbmc/utils/Makefile
+++ b/xbmc/utils/Makefile
@@ -60,6 +60,7 @@ SRCS=AlarmClock.cpp \
      Weather.cpp \
      Win32Exception.cpp \
      XMLUtils.cpp \
+     POUtils.cpp \
 
 LIB=utils.a
 

--- a/xbmc/utils/Makefile
+++ b/xbmc/utils/Makefile
@@ -39,6 +39,7 @@ SRCS=AlarmClock.cpp \
      PCMRemap.cpp \
      PerformanceSample.cpp \
      PerformanceStats.cpp \
+     POUtils.cpp \
      RecentlyAddedJob.cpp \
      RegExp.cpp \
      RingBuffer.cpp \
@@ -60,7 +61,6 @@ SRCS=AlarmClock.cpp \
      Weather.cpp \
      Win32Exception.cpp \
      XMLUtils.cpp \
-     POUtils.cpp \
 
 LIB=utils.a
 

--- a/xbmc/utils/POUtils.cpp
+++ b/xbmc/utils/POUtils.cpp
@@ -1,0 +1,286 @@
+/*
+ *      Copyright (C) 2005-2008 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
+
+#include "utils/POUtils.h"
+#include "filesystem/File.h"
+#include "utils/log.h"
+
+CPODocument::CPODocument()
+{
+  m_id = 0;
+  m_pBuffer = NULL;
+  m_pCursor = NULL;
+  m_POfilelength = 0;
+  m_currentline = "";
+  m_pLastCursor = NULL;
+}
+
+CPODocument::~CPODocument()
+{
+  if (m_pBuffer)
+  {
+    delete [] m_pBuffer;
+    m_pBuffer = NULL;
+  }
+  m_pCursor = NULL;
+  m_pLastCursor = NULL;
+}
+
+bool CPODocument::LoadFile(const CStdString &pofilename)
+{
+  XFILE::CFile file;
+  if (!file.Open(pofilename)) return false;
+  m_POfilelength = file.GetLength();
+  if (m_POfilelength < 1)
+  {
+    file.Close();
+    CLog::Log(LOGERROR, "POParser: wrong filesize read from file: %s", pofilename.c_str());
+    return false;
+  }
+  m_pBuffer = new char[static_cast<size_t>(m_POfilelength+1)];
+  m_pCursor = m_pBuffer;
+  file.Read(m_pBuffer, m_POfilelength);
+  file.Close();
+  if (ParseHeader()) return true;
+  CLog::Log(LOGERROR, "POParser: unable to read PO file header from file: %s", pofilename.c_str());
+  return false;
+}
+
+bool CPODocument::GetNextEntry()
+{
+  if (m_pCursor == m_pLastCursor) m_pCursor++; // if nothing was parsed from last call
+  while ((m_pCursor - m_pBuffer + 8) < m_POfilelength)
+  {
+    if (*(m_pCursor-1) == '\n')
+    {
+      if (m_pCursor[0] == '#' && m_pCursor[1] == ':' && m_pCursor[2] == ' '
+        && m_pCursor[3] == 'i' && m_pCursor[4] == 'd' && m_pCursor[5] == ':')
+      {
+        m_entrytype = ID_FOUND;
+        m_pLastCursor = m_pCursor;
+        return true;
+      }
+      if (m_pCursor[0] == 'm' && m_pCursor[1] == 's' && m_pCursor[2] == 'g')
+      {
+        if (m_pCursor[3] == 'i' && m_pCursor[4] == 'd')
+        {
+          m_entrytype = MSGID_FOUND;
+          m_pLastCursor = m_pCursor;
+          return true;
+        }
+        if (m_pCursor[3] == 'c' && m_pCursor[4] == 't' && m_pCursor[5] == 'x' && m_pCursor[6] == 't')
+        {
+          m_entrytype = MSGCTXT_FOUND;
+          m_pLastCursor = m_pCursor;
+          return true;
+        }
+      }
+    }
+    m_pCursor++;
+  }
+  return false; // if we have the end of buffer
+}
+
+int CPODocument::GetEntryID()
+{
+  CStdString strID;
+  strID.append( &m_pCursor[6], NextNonDigit( &m_pCursor[6], 11));
+  m_id = atoi (strID.c_str());
+  return m_id;
+}
+
+void CPODocument::ParseEntry()
+{
+  CStdString* pStr = NULL;
+  m_msgctx = "";
+  for (int i=0; i < 10; i++) m_msgid[i] = m_msgstr[i] = "";
+  while (ReadLine())
+  {
+    if (IsEmptyLine()) return; // an empty line closes the the reading of the entry
+
+    if (pStr && ReadStringLine(pStr,0)) continue; // we are reading a continous multilne string
+    else pStr = NULL; // end of reading the multiline string
+
+    if (HasPrefix(m_currentline, "msgctxt") && m_currentline.size() > 9)
+    {
+      pStr = &m_msgctx;
+      if (!ReadStringLine(pStr,8))
+      {
+        CLog::Log(LOGERROR, "POParser: wrong msgctxt format for id: %i", m_id);
+        pStr = NULL;
+      }
+    }
+    else if (HasPrefix(m_currentline, "msgid") && m_currentline.size() > 7)
+    {
+      pStr = &m_msgid[0];
+      if (!ReadStringLine(pStr,6))
+      {
+        CLog::Log(LOGERROR, "POParser: wrong msgid format for id: %i", m_id);
+        pStr = NULL;
+      }
+    }
+    else if (HasPrefix(m_currentline, "msgstr") && m_currentline.size() > 8)
+    {
+      pStr = &m_msgstr[0];
+      if (!ReadStringLine(pStr,7))
+      {
+        CLog::Log(LOGERROR, "POParser: wrong msgstr format for id: %i", m_id);
+        pStr = NULL;
+      }
+    }
+    else pStr=NULL; // any non recognized line breaks the reading of a multiline string
+  }
+  return; // we have the end of buffer
+}
+
+bool CPODocument::ParseHeader()
+{
+  do
+  {
+    if (!ReadLine()) return false;
+  }
+  while (!HasPrefix(m_currentline, "msgid"));
+
+  do
+  {
+    if (IsEmptyLine()) return true; // an empty line closes the reading of the header
+  }
+  while (ReadLine());
+  return false; // not found the end of the header until reaching EOF
+}
+
+CStdString CPODocument::UnescapeString(CStdString &strInput)
+{
+  char oescchar;
+  CStdString strOutput = "";
+  for (CStdString::iterator it = strInput.begin(); it < strInput.end(); it++)
+  {
+    if (*it != '\\') strOutput += *it;
+    else
+    {
+      if (it+1 == strInput.end())
+      {
+        CLog::Log(LOGERROR, "POParser: warning, unhandled escape character at line-end in entry id: %i", m_id);
+        continue;
+      }
+      it++;
+      switch (*it)
+      {
+        case 'a':  oescchar = '\a'; break;
+        case 'b':  oescchar = '\b'; break;
+        case 'v':  oescchar = '\v'; break;
+        case 'n':  oescchar = '\n'; break;
+        case 't':  oescchar = '\t'; break;
+        case 'r':  oescchar = '\r'; break;
+        case '"':  oescchar = '"' ; break;
+        case '\\': oescchar = '\\'; break;
+        default: 
+        {
+          CLog::Log(LOGERROR, "POParser: warning, unhandled escape character in entry id: %i", m_id);
+          continue;
+        }
+      }
+      strOutput += oescchar;
+    }
+  }
+  return strOutput;
+}
+
+bool CPODocument::ReadStringLine(CStdString* pStrToAppend, int skip)
+{
+  int linesize = m_currentline.size(); 
+  if (m_currentline[linesize-1] != '\"' || m_currentline[skip] != '\"') return false;
+  pStrToAppend->append(m_currentline, skip + 1, linesize - skip - 2);
+  return true;
+}
+
+bool CPODocument::HasPrefix(const CStdString &strLine, const CStdString &strPrefix)
+{
+  if (strLine.length() < strPrefix.length())
+    return false;
+  else
+    return strLine.compare(0, strPrefix.length(), strPrefix) == 0;
+}
+
+bool CPODocument::ReadLine()
+{
+  long nbuff, offset;
+  m_currentline = "";
+  nbuff = m_pBuffer + m_POfilelength - m_pCursor;
+  if (nbuff < 1) return false; // if we are at the end of buffer
+
+  offset =  NextChar(m_pCursor, '\n', nbuff);
+  long offset_end = offset;
+  long offset_start = 0;
+
+  while (IsWhitespace(m_pCursor[offset_start])) offset_start++; // check first non-whitespace char
+  while (IsWhitespace(m_pCursor[offset_end])) offset_end--; // check last non whitespace char
+  m_currentline.append(m_pCursor+offset_start, offset_end - offset_start);
+  m_pCursor += offset +1;
+  return true;
+}
+
+long CPODocument::NextChar(char* pString, char char2find, long n)
+{
+  int i=0;
+  while (pString[i] != char2find && i < n) i++;
+  return i;
+}
+
+long CPODocument::NextNonDigit(char* pString, long n)
+{
+  int i=0;
+  while (CharIsDigit(pString[i]) && (i < n)) i++;
+  return i;
+}
+
+bool CPODocument::CharIsDigit(char char2check)
+{
+  return (char2check >= '0' && char2check <= '9');
+}
+
+bool CPODocument::IsWhitespace(char char2check)
+{
+  return (char2check == ' ' || char2check == '\t'
+    || char2check == '\v' || char2check == '\f');
+}
+
+bool CPODocument::IsEmptyLine()
+{
+  if (m_currentline.empty()) return true;
+  else if (m_currentline == "\n") return true;
+  else if (m_currentline[0] == '#')
+  { // handle "# comment" style comments as empty lines
+    if (m_currentline.size() == 1 || (m_currentline.size() >= 2 && isspace(m_currentline[1])))
+      return true;
+    else
+      return false;
+  }
+  else
+  { // if the line only contains whitespaces
+    for(CStdString::iterator i = m_currentline.begin(); i != m_currentline.end(); ++i)
+    {
+      if (!IsWhitespace(*i))
+        return false;
+    }
+  }
+  return true;
+}

--- a/xbmc/utils/POUtils.h
+++ b/xbmc/utils/POUtils.h
@@ -1,0 +1,179 @@
+/*
+ *      Copyright (C) 2005-2008 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
+
+#include "utils/StdString.h"
+
+enum
+{
+  ID_FOUND,
+  MSGID_FOUND,
+  MSGCTXT_FOUND
+};
+
+class CPODocument
+{
+  public:
+    CPODocument();
+    ~CPODocument();
+
+    /*! \brief Tries to load a PO file into a temporary buffer.
+     * It also tries to parse the header of the PO file.
+     \param pofilename filename of the PO file to load.
+     \return true if the load was successful, unless return false
+     */
+    bool LoadFile(const CStdString &pofilename);
+
+    /*! \brief Fast jumps to the next entry in PO buffer.
+     * Finds next entry started with "#: id:" or msgctx or msgid.
+     * to be as fast as possible this does not even get the id number
+     * just the type of the entry found. GetEntryID() has to be called
+     * for getting the id. After that ParseEntry() needs a call for
+     * actually getting the msgstr strings. The reason for this is to
+     * have calls and checks as fast as possible generally and specially
+     * for parsing weather tokens.
+     \return true if there was an entry found, false if reached the end of buffer
+     */
+    bool GetNextEntry();
+
+    /*! \brief Gets the type of entry found with GetNextEntry.
+     \return the type of entry: ID_FOUND || MSGID_FOUND || MSGCTXT_FOUND
+     */
+    int GetEntryType() {return m_entrytype;}
+
+    /*! \brief Parses the numeric ID from the buffer at cursor position.
+     * This function can only be called right after GetNextEntry()
+     * to make sure that m_pCursor stands right at the beginning of and ID entry
+     \return parsed ID number
+     */
+    int GetEntryID();
+
+    /*! \brief Parses next entry.
+     * Reads msgid, msgstr, msgctxt strings.
+     * Note that this function does not yet back-convert escaped characters.
+     * The conversion is done with the GetMsgid, GetMsgstr, GetMsgctxt functions.
+     */
+    void ParseEntry();
+
+    /*! \brief Gets the msgctxt string previously parsed by ParseEntry().
+     * This function also converts c++ style character escapes back to chars.
+     \return string containing the msgctxt string, unescaped and linked together.
+     */
+    CStdString GetMsgctxt() {return UnescapeString(m_msgctx);}
+
+    /*! \brief Gets the msgid string previously parsed by ParseEntry().
+     * This function also converts c++ style character escapes back to chars.
+     \param plural the number of plural-form expected to get (0-9).
+     \return string containing the msgid string, unescaped and linked together.
+     */
+    CStdString GetMsgid(const int plural) {return UnescapeString(m_msgid[plural]);}
+
+    /*! \brief Gets the msgstr string previously parsed by ParseEntry().
+     * This function also converts c++ style character escapes back to chars.
+     \param plural the number of plural-form expected to get (0-9).
+     \return string containing the msgstr string, unescaped and linked together.
+     */
+    CStdString GetMsgstr(const int plural) {return UnescapeString(m_msgstr[plural]);}
+
+  protected:
+
+    /*! \brief Parses the header and sets the cursor to the end of the header.
+     * It does not actually get any useful information at the moment,
+     * since we don't need them in xbmc. Just sets cursor at right position.
+     \return true if we found the header, false when no header was found.
+     */
+    bool ParseHeader();
+
+    /*! \brief Converts c++ style char escapes back to char.
+     \param strInput string contains the string to be unescaped.
+     \return unescaped string.
+     */
+    CStdString UnescapeString(CStdString &strInput);
+
+    /*! \brief Reads msg strings from current line, from position "skip".
+     * Note that the msg strings should always start and end with apostrophe.
+     * This appends the read string to an existing one, pointed by a pointer.
+     \param skip The position we should start reading the string.
+     \param pStrToAppend Pointer to a string where we should add the read string.
+     \return false if the string is not surrounded by apostrophe chars.
+     */
+    bool ReadStringLine(CStdString * pStrToAppend, int skip);
+
+    /*! \brief Checks if strLine starts with strPrefix.
+     \param strLine The string to check.
+     \param strPrefix The string containing the prefix to look for.
+     \return true if the string starts with the prefix.
+     */
+    bool HasPrefix(const CStdString &strLine, const CStdString &strPrefix);
+
+    /*! \brief Reads the next line from the buffer.
+     * It also removes trailing and leading whitespace from the read line.
+     * The successfully read line gets stored in m_currentline.
+     \return false if we try to read data over the end of the buffer.
+     */
+    bool ReadLine();
+
+    /*! \brief Look for a given character in string pointed by pString.
+     \param char2find The character we are looking for.
+     \param pString Pointer to the string where we look for the char.
+     \param n Number of characters we go before stop searching.
+     \return position of the found character.
+     */
+    long NextChar(char* pString, char char2find, long n);
+
+    /*! \brief Look for the first non-number character from pString.
+     \param pString Pointer to the string where we look for nondigit.
+     \param n Number of characters we go before stop searching.
+     \return position of the found character.
+     */
+    long NextNonDigit(char* pString, long n);
+
+    /*! \brief Check if character is a number.
+     \param char2check The input char to evaluate.
+     \return true if char was a number.
+     */
+    bool CharIsDigit(char char2check);
+
+    /*! \brief Check if character is whitespace.
+     * We actually look for: ' ', '\t', '\v", '\f' NOT '\n'
+     \param char2check The input char to evaluate.
+     \return true if char was whitespace.
+     */
+    bool IsWhitespace(char char2check);
+
+    /*! \brief Checks if the string in m_currentline is an empty line or a comment.
+     * For this function to work, we need ReadLine() to fill in m_currentline.
+     * The function considers comments in "# Comment" style as an empty lines.
+     * Also if the line only contains whitespace, it is handled as an empty line.
+     \return true, if m_currentline contained an empty line or a comment.
+     */
+    bool IsEmptyLine();
+
+    char* m_pBuffer;
+    char* m_pCursor;
+    char* m_pLastCursor;
+    int m_id;
+    int m_entrytype;
+    CStdString m_msgid[10];
+    CStdString m_msgstr[10];
+    CStdString m_msgctx;
+    int64_t m_POfilelength;
+    CStdString m_currentline;
+};

--- a/xbmc/utils/POUtils.h
+++ b/xbmc/utils/POUtils.h
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2005-2008 Team XBMC
+ *      Copyright (C) 2012 Team XBMC
  *      http://www.xbmc.org
  *
  *  This Program is free software; you can redistribute it and/or modify
@@ -19,7 +19,7 @@
  *
  */
 
-#include "utils/StdString.h"
+#include <string>
 
 enum
 {
@@ -39,7 +39,7 @@ class CPODocument
      \param pofilename filename of the PO file to load.
      \return true if the load was successful, unless return false
      */
-    bool LoadFile(const CStdString &pofilename);
+    bool LoadFile(const std::string &pofilename);
 
     /*! \brief Fast jumps to the next entry in PO buffer.
      * Finds next entry started with "#: id:" or msgctx or msgid.
@@ -76,21 +76,21 @@ class CPODocument
      * This function also converts c++ style character escapes back to chars.
      \return string containing the msgctxt string, unescaped and linked together.
      */
-    CStdString GetMsgctxt() {return UnescapeString(m_msgctx);}
+    std::string GetMsgctxt() {return UnescapeString(m_msgctx);}
 
     /*! \brief Gets the msgid string previously parsed by ParseEntry().
      * This function also converts c++ style character escapes back to chars.
      \param plural the number of plural-form expected to get (0-9).
      \return string containing the msgid string, unescaped and linked together.
      */
-    CStdString GetMsgid(const int plural) {return UnescapeString(m_msgid[plural]);}
+    std::string GetMsgid(const unsigned plural) {return UnescapeString(m_msgid[plural]);}
 
     /*! \brief Gets the msgstr string previously parsed by ParseEntry().
      * This function also converts c++ style character escapes back to chars.
      \param plural the number of plural-form expected to get (0-9).
      \return string containing the msgstr string, unescaped and linked together.
      */
-    CStdString GetMsgstr(const int plural) {return UnescapeString(m_msgstr[plural]);}
+    std::string GetMsgstr(const unsigned plural) {return UnescapeString(m_msgstr[plural]);}
 
   protected:
 
@@ -105,7 +105,7 @@ class CPODocument
      \param strInput string contains the string to be unescaped.
      \return unescaped string.
      */
-    CStdString UnescapeString(CStdString &strInput);
+    std::string UnescapeString(std::string &strInput);
 
     /*! \brief Reads msg strings from current line, from position "skip".
      * Note that the msg strings should always start and end with apostrophe.
@@ -114,14 +114,14 @@ class CPODocument
      \param pStrToAppend Pointer to a string where we should add the read string.
      \return false if the string is not surrounded by apostrophe chars.
      */
-    bool ReadStringLine(CStdString * pStrToAppend, int skip);
+    bool ReadStringLine(std::string * pStrToAppend, int skip);
 
     /*! \brief Checks if strLine starts with strPrefix.
      \param strLine The string to check.
      \param strPrefix The string containing the prefix to look for.
      \return true if the string starts with the prefix.
      */
-    bool HasPrefix(const CStdString &strLine, const CStdString &strPrefix);
+    bool HasPrefix(const std::string &strLine, const std::string &strPrefix);
 
     /*! \brief Reads the next line from the buffer.
      * It also removes trailing and leading whitespace from the read line.
@@ -145,12 +145,6 @@ class CPODocument
      */
     long NextNonDigit(char* pString, long n);
 
-    /*! \brief Check if character is a number.
-     \param char2check The input char to evaluate.
-     \return true if char was a number.
-     */
-    bool CharIsDigit(char char2check);
-
     /*! \brief Check if character is whitespace.
      * We actually look for: ' ', '\t', '\v", '\f' NOT '\n'
      \param char2check The input char to evaluate.
@@ -171,9 +165,9 @@ class CPODocument
     char* m_pLastCursor;
     int m_id;
     int m_entrytype;
-    CStdString m_msgid[10];
-    CStdString m_msgstr[10];
-    CStdString m_msgctx;
-    int64_t m_POfilelength;
-    CStdString m_currentline;
+    std::string m_msgid[10];
+    std::string m_msgstr[10];
+    std::string m_msgctx;
+    size_t m_POfilelength;
+    std::string m_currentline;
 };

--- a/xbmc/utils/Weather.cpp
+++ b/xbmc/utils/Weather.cpp
@@ -25,6 +25,7 @@
 #include "Weather.h"
 #include "filesystem/ZipManager.h"
 #include "XMLUtils.h"
+#include "utils/POUtils.h"
 #include "Temperature.h"
 #include "network/Network.h"
 #include "Application.h"
@@ -229,6 +230,39 @@ void CWeatherJob::FormatTemperature(CStdString &text, int temp)
 void CWeatherJob::LoadLocalizedToken()
 {
   // We load the english strings in to get our tokens
+
+  // Try the strings PO file first
+  CPODocument PODoc;
+  if (PODoc.LoadFile("special://xbmc/language/English/strings.po"))
+  {
+    int counter = 0;
+    while (PODoc.GetNextEntry())
+    {
+      if (PODoc.GetEntryType() != ID_FOUND) continue;
+      int id = PODoc.GetEntryID();
+      PODoc.ParseEntry();
+
+      if (id > LOCALIZED_TOKEN_LASTID2) break;
+      if ((LOCALIZED_TOKEN_FIRSTID <= id && id <= LOCALIZED_TOKEN_LASTID) ||
+        (LOCALIZED_TOKEN_FIRSTID2 <= id && id <= LOCALIZED_TOKEN_LASTID2) ||
+        (LOCALIZED_TOKEN_FIRSTID3 <= id && id <= LOCALIZED_TOKEN_LASTID3) ||
+        (LOCALIZED_TOKEN_FIRSTID4 <= id && id <= LOCALIZED_TOKEN_LASTID4))
+      {
+        CStdString Label = PODoc.GetMsgid(0);
+        if (!Label.IsEmpty())
+        {
+          m_localizedTokens.insert(make_pair(Label, id));
+          counter++;
+        }
+      }
+    }
+  CLog::Log(LOGDEBUG, "POParser: loaded %i weather tokens", counter);
+  return;
+  }
+
+  CLog::Log(LOGDEBUG, "Weather: no PO string file available, to load English tokens, fallback to strings.xml file");
+
+  // We load the tokens from the strings.xml file
   CStdString strLanguagePath = "special://xbmc/language/English/strings.xml";
 
   TiXmlDocument xmlDoc;


### PR DESCRIPTION
These commits add support for using Gettext format strings.po files as primary language files.
Of course there is a strings.xml fallback in case no strings.po file exists in the language directory.

Also I kept the strings.xml files for even where the converted srtings.po files already exist.
The purpose for this is to handle pre written PR-s. I will manually add the new strings coming to the strings.xml files to the new strings.po files.

The strings.po files were generated with the tool I've written:
https://github.com/alanwww1/xbmc-xml2po 
(windows binary is available to download, on Linux it is just a simple compile)

These new files are directly suitable for use with web based translation tools eg. Transifex.net, what I will intend to use for all translations.
