### PR TITLE
jobmanager: add functions to pause job creation

### DIFF
--- a/xbmc/utils/JobManager.h
+++ b/xbmc/utils/JobManager.h
@@ -215,6 +215,39 @@ public:
    */
   void CancelJobs();
 
+  /*!
+   \brief Suspends queueing of the specified type until unpaused
+   Useful to (for ex) stop queuing thumb jobs during video playback. Only affects PRIORITY_LOW or lower.
+   Does not affect currently processing jobs, use IsProcessing to see if any need to be waited on
+   Types accumulate, so more than one can be set at a time.
+   Refcounted, so UnPause() must be called once for each Pause().
+   \param pausedType only jobs of this type will be affected
+   \sa UnPause(), IsPaused(), IsProcessing()
+   */
+  void Pause(const std::string &pausedType);
+
+  /*!
+   \brief Resumes queueing of the specified type
+   \param pausedType only jobs of this type will be affected
+   \sa Pause(), IsPaused(), IsProcessing()
+   */
+  void UnPause(const std::string &pausedType);
+
+  /*!
+   \brief Checks if jobs of specified type are paused.
+   \param pausedType only jobs of this type will be affected
+   \sa Pause(), UnPause(), IsProcessing()
+   */
+  bool IsPaused(const std::string &pausedType);
+
+  /*!
+   \brief Checks to see if any jobs of a specific type are currently processing.
+   \param pausedType Job type to search for
+   \return Number of matching jobs
+   \sa Pause(), UnPause(), IsPaused()
+   */
+  int IsProcessing(const std::string &pausedType);
+
 protected:
   friend class CJobWorker;
   friend class CJob;
@@ -275,4 +308,5 @@ private:
   CCriticalSection m_section;
   CEvent           m_jobEvent;
   bool             m_running;
+  std::vector<std::string>  m_pausedTypes;
 };


### PR DESCRIPTION
useful for delaying all new job creation until later. As an example, we may
want to disable thumbnailing during video playback if the player can't decode 2 streams at once.

Not currently hooked up to anything.

This is not particularly pretty, but it does work as advertised.

@jmarshallnz + @cptspiff: @davilla is dying to know who won the bet.
