### PR TITLE
[WIN32] fixed: receive response from the bonjour daemon if one is available 

### DIFF
--- a/xbmc/network/Zeroconf.h
+++ b/xbmc/network/Zeroconf.h
@@ -77,6 +77,8 @@ public:
   static void   ReleaseInstance();
   // returns false if ReleaseInstance() was called befores
   static bool   IsInstantiated() { return  smp_instance != 0; }
+  // win32: process results from the bonjour daemon
+  virtual void  ProcessResults() {}
 
 protected:
   //methods to implement for concrete implementations

--- a/xbmc/network/windows/ZeroconfWIN.h
+++ b/xbmc/network/windows/ZeroconfWIN.h
@@ -45,13 +45,22 @@ protected:
 
   bool IsZCdaemonRunning();
 
+  void ProcessResults();
+
 private:
 
-  static void DNSSD_API registerCallback(DNSServiceRef sdref, const DNSServiceFlags flags, DNSServiceErrorType errorCode, const char *name, const char *regtype, const char *domain, void *context);
+  static void DNSSD_API registerCallback(DNSServiceRef sdref,
+                                         const DNSServiceFlags flags,
+                                         DNSServiceErrorType errorCode,
+                                         const char *name,
+                                         const char *regtype,
+                                         const char *domain,
+                                         void *context);
 
 
   //lock + data (accessed from runloop(main thread) + the rest)
   CCriticalSection m_data_guard;
   typedef std::map<std::string, DNSServiceRef> tServiceMap;
   tServiceMap m_services;
+  DNSServiceRef m_service;
 };

--- a/xbmc/win32/WIN32Util.h
+++ b/xbmc/win32/WIN32Util.h
@@ -38,6 +38,7 @@ enum Drive_Types
   DVD_DRIVES
 };
 
+#define BONJOUR_EVENT		( WM_USER + 0x100 )	// Message sent to the Window when a Bonjour event occurs.
 
 class CWIN32Util
 {

--- a/xbmc/windowing/windows/WinEventsWin32.cpp
+++ b/xbmc/windowing/windows/WinEventsWin32.cpp
@@ -43,6 +43,7 @@
 #include "settings/AdvancedSettings.h"
 #include "peripherals/Peripherals.h"
 #include "utils/JobManager.h"
+#include "network/Zeroconf.h"
 
 #ifdef _WIN32
 
@@ -703,6 +704,9 @@ LRESULT CALLBACK CWinEventsWin32::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, L
     case WM_PAINT:
       //some other app has painted over our window, mark everything as dirty
       g_windowManager.MarkDirty();
+      break;
+    case BONJOUR_EVENT:
+      CZeroconf::GetInstance()->ProcessResults();
       break;
   }
   return(DefWindowProc(hWnd, uMsg, wParam, lParam));


### PR DESCRIPTION
for easier maintenance we only talk via one connection to the daemon now.
Need a sign off from osx or linux dev if the additional method for zeroconf won't harm.
