### PR TITLE
Bluray directory support

### DIFF
--- a/language/English/strings.xml
+++ b/language/English/strings.xml
@@ -2253,6 +2253,11 @@
   <string id="24101">Would you like to download this Add-on?</string>
   <string id="25000">Notifications</string>
   <string id="25001">Hide foreign</string>
+  <string id="25002">Select from all titles ...</string>
+  <string id="25003">Show bluray menus</string>
+  <string id="25004">Play main title: %d</string>
+  <string id="25005">Title: %d</string>
+  <string id="25006">Select playback item</string>
 
   <!-- strings 29800 thru 29998 reserved strings used only in the default Project Mayhem III skin and not c++ code -->
   <string id="29800">Library Mode</string>

--- a/project/VS2010Express/XBMC.vcxproj
+++ b/project/VS2010Express/XBMC.vcxproj
@@ -346,6 +346,7 @@
     <ClCompile Include="..\..\xbmc\filesystem\AFPDirectory.cpp" />
     <ClCompile Include="..\..\xbmc\filesystem\AFPFile.cpp" />
     <ClCompile Include="..\..\xbmc\filesystem\ASAPFileDirectory.cpp" />
+    <ClCompile Include="..\..\xbmc\filesystem\BlurayDirectory.cpp" />
     <ClCompile Include="..\..\xbmc\filesystem\CacheStrategy.cpp" />
     <ClCompile Include="..\..\xbmc\filesystem\CDDADirectory.cpp" />
     <ClCompile Include="..\..\xbmc\filesystem\CDDAFile.cpp" />
@@ -907,6 +908,7 @@
     <ClInclude Include="..\..\xbmc\filesystem\AFPDirectory.h" />
     <ClInclude Include="..\..\xbmc\filesystem\AFPFile.h" />
     <ClInclude Include="..\..\xbmc\filesystem\ASAPFileDirectory.h" />
+    <ClInclude Include="..\..\xbmc\filesystem\BlurayDirectory.h" />
     <ClInclude Include="..\..\xbmc\filesystem\CacheStrategy.h" />
     <ClInclude Include="..\..\xbmc\filesystem\CDDADirectory.h" />
     <ClInclude Include="..\..\xbmc\filesystem\CDDAFile.h" />

--- a/project/VS2010Express/XBMC.vcxproj.filters
+++ b/project/VS2010Express/XBMC.vcxproj.filters
@@ -2345,6 +2345,9 @@
     <ClCompile Include="..\..\xbmc\filesystem\ASAPFileDirectory.cpp">
       <Filter>filesystem</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\xbmc\filesystem\BlurayDirectory.cpp">
+      <Filter>filesystem</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\xbmc\filesystem\CacheStrategy.cpp">
       <Filter>filesystem</Filter>
     </ClCompile>
@@ -5204,6 +5207,9 @@
       <Filter>filesystem</Filter>
     </ClInclude>
     <ClInclude Include="..\..\xbmc\filesystem\FileCache.h">
+      <Filter>filesystem</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\xbmc\filesystem\BlurayDirectory.h">
       <Filter>filesystem</Filter>
     </ClInclude>
     <ClInclude Include="..\..\xbmc\utils\Base64.h">

--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -2859,6 +2859,7 @@ CStdString CFileItem::GetLocalFanart() const
   // no local fanart available for these
   if (IsInternetStream()
    || URIUtils::IsUPnP(strFile)
+   || URIUtils::IsBluray(strFile)
    || IsLiveTV()
    || IsPlugin()
    || IsAddonsPath()
@@ -3119,6 +3120,7 @@ CStdString CFileItem::FindTrailer() const
   // no local trailer available for these
   if (IsInternetStream()
    || URIUtils::IsUPnP(strFile)
+   || URIUtils::IsBluray(strFile)
    || IsLiveTV()
    || IsPlugin()
    || IsDVD())

--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -1258,6 +1258,7 @@ CStdString CUtil::ValidatePath(const CStdString &path, bool bFixDoubleSlashes /*
       path.Left(4).Equals("zip:") ||
       path.Left(4).Equals("rar:") ||
       path.Left(6).Equals("stack:") ||
+      path.Left(7).Equals("bluray:") ||
       path.Left(10).Equals("multipath:") ))
     return result;
 

--- a/xbmc/cores/dvdplayer/DVDInputStreams/DVDFactoryInputStream.cpp
+++ b/xbmc/cores/dvdplayer/DVDInputStreams/DVDFactoryInputStream.cpp
@@ -53,7 +53,7 @@ CDVDInputStream* CDVDFactoryInputStream::CreateInputStream(IDVDPlayer* pPlayer, 
     return (new CDVDInputStreamNavigator(pPlayer));
   }
 #ifdef HAVE_LIBBLURAY
-  else if (item.IsType(".bdmv") || item.IsType(".mpls") || content == "bluray/iso")
+  else if (item.IsType(".bdmv") || item.IsType(".mpls") || content == "bluray/iso" || file.substr(0, 7) == "bluray:")
     return new CDVDInputStreamBluray(pPlayer);
 #endif
   else if(file.substr(0, 6) == "rtp://"

--- a/xbmc/filesystem/BlurayDirectory.cpp
+++ b/xbmc/filesystem/BlurayDirectory.cpp
@@ -26,6 +26,7 @@
 #include "DllLibbluray.h"
 #include "FileItem.h"
 #include "video/VideoInfoTag.h"
+#include "guilib/LocalizeStrings.h"
 
 namespace XFILE
 {
@@ -64,7 +65,7 @@ CFileItemPtr CBlurayDirectory::GetTitle(const BLURAY_TITLE_INFO* title, const CS
   item->SetPath(path.Get());
   item->GetVideoInfoTag()->m_strRuntime.Format("%d",title->duration / 90000);
   item->GetVideoInfoTag()->m_iTrack = title->playlist;
-  buf.Format("%s %d", label.c_str(), title->playlist);
+  buf.Format(label.c_str(), title->playlist);
   item->m_strTitle = buf;
   item->SetLabel(buf);
   item->m_dwSize = 0;
@@ -107,7 +108,7 @@ void CBlurayDirectory::GetTitles(bool main, CFileItemList &items)
   {
     if((*it)->duration < duration)
       continue;
-    items.Add(GetTitle(*it, main ? "Main Title" : "Title"));
+    items.Add(GetTitle(*it, main ? g_localizeStrings.Get(25004) /* Main Title */ : g_localizeStrings.Get(25005) /* Title */));
   }
 
 
@@ -126,7 +127,7 @@ void CBlurayDirectory::GetRoot(CFileItemList &items)
     item.reset(new CFileItem());
     item->SetPath(path.Get());
     item->m_bIsFolder = true;
-    item->SetLabel("All Titles");
+    item->SetLabel(g_localizeStrings.Get(25002) /* All titles */);
     item->SetIconImage("DefaultVideoPlaylists.png");
     items.Add(item);
 
@@ -134,7 +135,7 @@ void CBlurayDirectory::GetRoot(CFileItemList &items)
     item.reset(new CFileItem());
     item->SetPath(path.Get());
     item->m_bIsFolder = false;
-    item->SetLabel("Menus");
+    item->SetLabel(g_localizeStrings.Get(25003) /* Menus */);
     item->SetIconImage("DefaultProgram.png");
     items.Add(item);
 }

--- a/xbmc/filesystem/BlurayDirectory.cpp
+++ b/xbmc/filesystem/BlurayDirectory.cpp
@@ -1,0 +1,184 @@
+/*
+ *      Copyright (C) 2005-2008 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
+
+#include "BlurayDirectory.h"
+#include "utils/log.h"
+#include "utils/URIUtils.h"
+#include "URL.h"
+#include "DllLibbluray.h"
+#include "FileItem.h"
+#include "video/VideoInfoTag.h"
+
+namespace XFILE
+{
+
+#define MAIN_TITLE_LENGTH_PERCENT 70 /** Minumum length of main titles, based on longest title */
+
+CBlurayDirectory::CBlurayDirectory()
+  : m_dll(NULL)
+  , m_bd(NULL)
+{
+}
+
+CBlurayDirectory::~CBlurayDirectory()
+{
+  Dispose();
+}
+
+void CBlurayDirectory::Dispose()
+{
+  if(m_bd)
+  {
+    m_dll->bd_close(m_bd);
+    m_bd = NULL;
+  }
+  delete m_dll;
+  m_dll = NULL;
+}
+
+CFileItemPtr CBlurayDirectory::GetTitle(const BLURAY_TITLE_INFO* title, const CStdString& label)
+{
+  CStdString buf;
+  CFileItemPtr item(new CFileItem("", false));
+  CURL path(m_url);
+  buf.Format("BDMV/PLAYLIST/%05d.mpls", title->playlist);
+  path.SetFileName(buf);
+  item->SetPath(path.Get());
+  item->GetVideoInfoTag()->m_strRuntime.Format("%d",title->duration / 90000);
+  item->GetVideoInfoTag()->m_iTrack = title->playlist;
+  buf.Format("%s %d", label.c_str(), title->playlist);
+  item->m_strTitle = buf;
+  item->SetLabel(buf);
+  item->m_dwSize = 0;
+  item->SetIconImage("DefaultVideo.png");
+  for(unsigned int i = 0; i < title->clip_count; ++i)
+    item->m_dwSize += title->clips[i].pkt_count * 192;
+
+  return item;
+}
+
+void CBlurayDirectory::GetTitles(bool main, CFileItemList &items)
+{
+  unsigned titles = m_dll->bd_get_titles(m_bd, TITLES_RELEVANT, 0);
+  CStdString buf;
+
+  std::vector<BLURAY_TITLE_INFO*> buffer;
+
+  uint64_t duration = 0;
+
+  for(unsigned i=0; i < titles; i++)
+  {
+    BLURAY_TITLE_INFO *t = m_dll->bd_get_title_info(m_bd, i, 0);
+    if(!t)
+    {
+      CLog::Log(LOGDEBUG, "CBlurayDirectory - unable to get title %d", i);
+      continue;
+    }
+    if(t->duration > duration)
+      duration = t->duration;
+
+    buffer.push_back(t);
+  }
+
+  if(main)
+    duration = duration * MAIN_TITLE_LENGTH_PERCENT / 100;
+  else
+    duration = 0;
+
+  for(std::vector<BLURAY_TITLE_INFO*>::iterator it = buffer.begin(); it != buffer.end(); ++it)
+  {
+    if((*it)->duration < duration)
+      continue;
+    items.Add(GetTitle(*it, main ? "Main Title" : "Title"));
+  }
+
+
+  for(std::vector<BLURAY_TITLE_INFO*>::iterator it = buffer.begin(); it != buffer.end(); ++it)
+    m_dll->bd_free_title_info(*it);
+}
+
+void CBlurayDirectory::GetRoot(CFileItemList &items)
+{
+    GetTitles(true, items);
+
+    CURL path(m_url);
+    CFileItemPtr item;
+
+    path.SetFileName(URIUtils::AddFileToFolder(m_url.GetFileName(), "titles"));
+    item.reset(new CFileItem());
+    item->SetPath(path.Get());
+    item->m_bIsFolder = true;
+    item->SetLabel("All Titles");
+    item->SetIconImage("DefaultVideoPlaylists.png");
+    items.Add(item);
+
+    path.SetFileName("BDMV/MovieObject.bdmv");
+    item.reset(new CFileItem());
+    item->SetPath(path.Get());
+    item->m_bIsFolder = false;
+    item->SetLabel("Menus");
+    item->SetIconImage("DefaultProgram.png");
+    items.Add(item);
+}
+
+bool CBlurayDirectory::GetDirectory(const CStdString& path, CFileItemList &items)
+{
+  Dispose();
+  m_url.Parse(path);
+  CStdString root = m_url.GetHostName();
+  CStdString file = m_url.GetFileName();
+  URIUtils::RemoveSlashAtEnd(file);
+
+  m_dll = new DllLibbluray();
+  if (!m_dll->Load())
+  {
+    CLog::Log(LOGERROR, "CBlurayDirectory::GetDirectory - failed to load dll");
+    return false;
+  }
+
+  m_dll->bd_register_dir(DllLibbluray::dir_open);
+  m_dll->bd_register_file(DllLibbluray::file_open);
+  m_dll->bd_set_debug_handler(DllLibbluray::bluray_logger);
+  m_dll->bd_set_debug_mask(DBG_CRIT | DBG_BLURAY | DBG_NAV);
+
+  m_bd = m_dll->bd_open(root.c_str(), NULL);
+
+  if(!m_bd)
+  {
+    CLog::Log(LOGERROR, "CBlurayDirectory::GetDirectory - failed to open %s", root.c_str());
+    return false;
+  }
+
+  if(file == "")
+    GetRoot(items);
+  else if(file == "titles")
+    GetTitles(false, items);
+  else
+    return false;
+
+  items.AddSortMethod(SORT_METHOD_TRACKNUM , 554, LABEL_MASKS("%L", "%D", "%L", ""));    // FileName, Duration | Foldername, empty
+  items.AddSortMethod(SORT_METHOD_SIZE     , 553, LABEL_MASKS("%L", "%I", "%L", "%I"));  // FileName, Size | Foldername, Size
+
+  return true;
+}
+
+
+} /* namespace XFILE */

--- a/xbmc/filesystem/BlurayDirectory.h
+++ b/xbmc/filesystem/BlurayDirectory.h
@@ -1,0 +1,53 @@
+#pragma once
+
+/*
+ *      Copyright (C) 2005-2008 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
+
+#include "Directory.h"
+#include "FileItem.h"
+#include "URL.h"
+
+class  DllLibbluray;
+typedef struct bluray BLURAY;
+typedef struct bd_title_info BLURAY_TITLE_INFO;
+
+namespace XFILE
+{
+
+class CBlurayDirectory: public XFILE::IDirectory
+{
+public:
+  CBlurayDirectory();
+  virtual ~CBlurayDirectory();
+  virtual bool GetDirectory(const CStdString& path, CFileItemList &items);
+
+private:
+
+  void         Dispose();
+  void         GetRoot  (CFileItemList &items);
+  void         GetTitles(bool main, CFileItemList &items);
+  CFileItemPtr GetTitle(const BLURAY_TITLE_INFO* title, const CStdString& label);
+  CURL          m_url;
+  DllLibbluray* m_dll;
+  BLURAY*       m_bd;
+};
+
+}

--- a/xbmc/filesystem/DirectoryFactory.cpp
+++ b/xbmc/filesystem/DirectoryFactory.cpp
@@ -100,6 +100,9 @@
 #ifdef HAS_FILESYSTEM_AFP
 #include "AFPDirectory.h"
 #endif
+#ifdef HAVE_LIBBLURAY
+#include "BlurayDirectory.h"
+#endif
 
 using namespace XFILE;
 
@@ -197,6 +200,9 @@ IDirectory* CDirectoryFactory::Create(const CStdString& strPath)
 #endif
 #ifdef HAS_FILESYSTEM_AFP
       if (strProtocol == "afp") return new CAFPDirectory();
+#endif
+#ifdef HAVE_LIBBLURAY
+      if (strProtocol == "bluray") return new CBlurayDirectory();
 #endif
   }
 

--- a/xbmc/filesystem/Makefile.in
+++ b/xbmc/filesystem/Makefile.in
@@ -112,6 +112,10 @@ SRCS+=AFPFile.cpp
 SRCS+=AFPDirectory.cpp
 endif
 
+ifeq (@HAVE_LIBBLURAY@,1)
+SRCS+=BlurayDirectory.cpp
+endif
+
 INCLUDES+=-I@abs_top_srcdir@/lib/libUPnP/Platinum/Source/Core \
           -I@abs_top_srcdir@/lib/libUPnP/Platinum/Source/Platinum \
           -I@abs_top_srcdir@/lib/libUPnP/Platinum/Source/Devices/MediaServer \

--- a/xbmc/utils/URIUtils.cpp
+++ b/xbmc/utils/URIUtils.cpp
@@ -231,7 +231,8 @@ void URIUtils::GetCommonPath(CStdString& strParent, const CStdString& strPath)
 bool URIUtils::ProtocolHasParentInHostname(const CStdString& prot)
 {
   return prot.Equals("zip")
-      || prot.Equals("rar");
+      || prot.Equals("rar")
+      || prot.Equals("bluray");
 }
 
 bool URIUtils::ProtocolHasEncodedHostname(const CStdString& prot)
@@ -775,6 +776,11 @@ bool URIUtils::IsVideoDb(const CStdString& strFile)
 bool URIUtils::IsLastFM(const CStdString& strFile)
 {
   return strFile.Left(7).Equals("lastfm:");
+}
+
+bool URIUtils::IsBluray(const CStdString& strFile)
+{
+  return strFile.Left(7).Equals("bluray:");
 }
 
 bool URIUtils::IsDOSPath(const CStdString &path)

--- a/xbmc/utils/URIUtils.h
+++ b/xbmc/utils/URIUtils.h
@@ -88,6 +88,7 @@ public:
   static bool IsVideoDb(const CStdString& strFile);
   static bool IsVTP(const CStdString& strFile);
   static bool IsZIP(const CStdString& strFile);
+  static bool IsBluray(const CStdString& strFile);
 
   static void AddSlashAtEnd(CStdString& strFolder);
   static bool HasSlashAtEnd(const CStdString& strFile);

--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -1048,6 +1048,77 @@ bool CGUIWindowVideoBase::ShowResumeMenu(CFileItem &item)
   return true;
 }
 
+bool CGUIWindowVideoBase::ShowPlaySelection(CFileItemPtr& item)
+{
+  /* if asked to resume somewhere, we should not show anything */
+  if (item->m_lStartOffset)
+    return true;
+
+  if (item->IsBDFile())
+  {
+    CStdString root = URIUtils::GetParentPath(item->GetPath());
+    URIUtils::RemoveSlashAtEnd(root);
+    if(URIUtils::GetFileName(root) == "BDMV")
+    {
+      CURL url("bluray://");
+      url.SetHostName(URIUtils::GetParentPath(root));
+      return ShowPlaySelection(item, url.Get());
+    }
+  }
+
+  return true;
+}
+
+bool CGUIWindowVideoBase::ShowPlaySelection(CFileItemPtr& item, const CStdString& directory)
+{
+
+  CFileItemList items;
+
+  if (!XFILE::CDirectory::GetDirectory(directory, items, XFILE::CDirectory::CHints(), true))
+  {
+    CLog::Log(LOGERROR, "CGUIWindowVideoBase::ShowPlaySelection - Failed to get play directory for %s", directory.c_str());
+    return true;
+  }
+
+  if (items.Size() == 0)
+  {
+    CLog::Log(LOGERROR, "CGUIWindowVideoBase::ShowPlaySelection - Failed to get any items %s", directory.c_str());
+    return true;
+  }
+
+  CGUIDialogSelect* dialog = (CGUIDialogSelect*)g_windowManager.GetWindow(WINDOW_DIALOG_SELECT);
+  while(true)
+  {
+    dialog->Reset();
+    dialog->SetHeading("Select playback item");
+    dialog->SetItems(&items);
+    dialog->SetUseDetails(true);
+    dialog->DoModal();
+
+    CFileItemPtr item_new = dialog->GetSelectedItem();
+    if(!item_new || dialog->GetSelectedLabel() < 0)
+    {
+      CLog::Log(LOGDEBUG, "CGUIWindowVideoBase::ShowPlaySelection - User aborted %s", directory.c_str());
+      break;
+    }
+
+    if(item_new->m_bIsFolder == false)
+    {
+      item = item_new;
+      return true;
+    }
+
+    items.Clear();
+    if(!XFILE::CDirectory::GetDirectory(item_new->GetPath(), items, XFILE::CDirectory::CHints(), true) || items.Size() == 0)
+    {
+      CLog::Log(LOGERROR, "CGUIWindowVideoBase::ShowPlaySelection - Failed to get any items %s", item_new->GetPath().c_str());
+      break;
+    }
+  }
+
+  return false;
+}
+
 bool CGUIWindowVideoBase::OnResumeItem(int iItem)
 {
   if (iItem < 0 || iItem >= m_vecItems->Size()) return true;
@@ -1417,6 +1488,9 @@ bool CGUIWindowVideoBase::OnPlayAndQueueMedia(const CFileItemPtr &item)
 void CGUIWindowVideoBase::PlayMovie(const CFileItem *item)
 {
   CFileItemPtr movieItem(new CFileItem(*item));
+
+  if(!ShowPlaySelection(movieItem))
+    return;
 
   g_playlistPlayer.Reset();
   g_playlistPlayer.SetCurrentPlaylist(PLAYLIST_VIDEO);

--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -1090,7 +1090,7 @@ bool CGUIWindowVideoBase::ShowPlaySelection(CFileItemPtr& item, const CStdString
   while(true)
   {
     dialog->Reset();
-    dialog->SetHeading("Select playback item");
+    dialog->SetHeading(25006 /* Select playback item */);
     dialog->SetItems(&items);
     dialog->SetUseDetails(true);
     dialog->DoModal();

--- a/xbmc/video/windows/GUIWindowVideoBase.h
+++ b/xbmc/video/windows/GUIWindowVideoBase.h
@@ -43,6 +43,11 @@ public:
   static void MarkWatched(const CFileItemPtr &pItem, bool bMark);
   static void UpdateVideoTitle(const CFileItem* pItem);
 
+  /*! \brief Show dialog allowing selection of wanted playback item */
+  static bool ShowPlaySelection(CFileItemPtr& item);
+  static bool ShowPlaySelection(CFileItemPtr& item, const CStdString& directory);
+
+
   /*! \brief Show the resume menu for this item (if it has a resume bookmark)
    If a resume bookmark is found, we set the item's m_lStartOffset to STARTOFFSET_RESUME
    \param item item to check for a resume bookmark


### PR DESCRIPTION
This adds a bluray virtual directory to more easily navigate a bluray file with it's title tracks and playlists.

Something similar aught to be done for dvd's too. This gives a directory structure like:

/titles/Title 1 [duration]
/titles/Title 2 [duration]
/titles/Title 3 [duration]
/Menus
/Title 5 [duration] ///< this is the longest duration title

It also contains a commit which during scanning avoids all title's apart from the longest titles in the root (can be multiple, set to larger than 2/3 of the longest title).
