### PR TITLE
System libav-0.8 for Eden

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -1248,7 +1248,11 @@ if test "$use_external_ffmpeg" = "yes"; then
   AC_DEFINE([USE_EXTERNAL_FFMPEG], [1], [Whether to use external FFmpeg libraries.])
 
   # Disable vdpau support if external libavcodec doesn't have it
-  AC_CHECK_LIB([avcodec], [ff_vdpau_vc1_decode_picture],,
+  AC_RUN_IFELSE(
+    AC_LANG_PROGRAM([[#include <libavcodec/avcodec.h>]],
+      [[avcodec_register_all();
+        AVCodec *codec = avcodec_find_decoder_by_name("vc1_vdpau");
+        return (codec) ? 0 : 1;]]),,
     [if test "x$use_vdpau" = "xyes"; then
       AC_MSG_ERROR($ffmpeg_vdpau_not_supported)
     else
@@ -1256,6 +1260,23 @@ if test "$use_external_ffmpeg" = "yes"; then
       AC_MSG_RESULT($ffmpeg_vdpau_not_supported)
     fi])
 
+  # Other headers to include if available.
+  AC_CHECK_HEADERS([libavutil/mathematics.h],,)
+
+  # Check if <libavfilter/vsrc_buffer.h> exists and defines old
+  # av_vsrc_buffer_add_frame() from SoC. This avoids multiple declarations of
+  # av_vsrc_buffer_add_frame().
+  AC_COMPILE_IFELSE(
+    AC_LANG_SOURCE([[
+      #include <libavfilter/vsrc_buffer.h>
+      void foo(void)
+      {
+        AVRational a;
+        av_vsrc_buffer_add_frame(NULL, NULL, 0, a);
+      }
+      ]]), AC_DEFINE([USE_OLD_AV_VSRC_BUFFER_ADD_FRAME],
+        [1], [Check if SoC av_vsrc_buffer_add_frame() is defined in libavfilter/vsrc_buffer.h.]),)
+  
   # Check for 'PIX_FMT_VDPAU_MPEG4' from libavutil
   if test "x$use_vdpau" != "xno"; then
     AC_LANG_PUSH([C++])

--- a/lib/DllAvFilter.h
+++ b/lib/DllAvFilter.h
@@ -47,17 +47,21 @@ extern "C" {
     #include <ffmpeg/avfiltergraph.h>
   #endif
   /* for av_vsrc_buffer_add_frame */
-  #if LIBAVFILTER_VERSION_INT >= AV_VERSION_INT(2,8,0)
-    #include <libavfilter/avcodec.h>
-  #elif LIBAVFILTER_VERSION_INT >= AV_VERSION_INT(2,7,0)
-    int av_vsrc_buffer_add_frame(AVFilterContext *buffer_filter,
-                                 AVFrame *frame);
-  #elif LIBAVCODEC_VERSION_INT >= AV_VERSION_INT(53,3,0)
-    int av_vsrc_buffer_add_frame(AVFilterContext *buffer_filter,
-                                 AVFrame *frame, int64_t pts);
+  #if (defined USE_OLD_AV_VSRC_BUFFER_ADD_FRAME)
+    #include <libavfilter/vsrc_buffer.h>
   #else
-    int av_vsrc_buffer_add_frame(AVFilterContext *buffer_filter,
-          AVFrame *frame, int64_t pts, AVRational pixel_aspect);
+    #if LIBAVFILTER_VERSION_INT >= AV_VERSION_INT(2,8,0)
+      #include <libavfilter/avcodec.h>
+    #elif LIBAVFILTER_VERSION_INT >= AV_VERSION_INT(2,7,0)
+      int av_vsrc_buffer_add_frame(AVFilterContext *buffer_filter,
+                                   AVFrame *frame);
+    #elif LIBAVCODEC_VERSION_INT >= AV_VERSION_INT(53,3,0)
+      int av_vsrc_buffer_add_frame(AVFilterContext *buffer_filter,
+                                   AVFrame *frame, int64_t pts);
+    #else
+      int av_vsrc_buffer_add_frame(AVFilterContext *buffer_filter,
+            AVFrame *frame, int64_t pts, AVRational pixel_aspect);
+    #endif
   #endif
 #else
   #include "libavfilter/avfiltergraph.h"
@@ -82,6 +86,9 @@ public:
   virtual int avfilter_graph_config(AVFilterGraph *graphctx, void *log_ctx)=0;
   virtual int avfilter_poll_frame(AVFilterLink *link)=0;
   virtual int avfilter_request_frame(AVFilterLink *link)=0;
+#if (defined USE_OLD_AV_VSRC_BUFFER_ADD_FRAME)
+  virtual int av_vsrc_buffer_add_frame(AVFilterContext *buffer_filter, AVFrame *frame, int64_t pts, AVRational pixel_aspect)=0;
+#else
 #if LIBAVFILTER_VERSION_INT >= AV_VERSION_INT(2,13,0)
   virtual int av_vsrc_buffer_add_frame(AVFilterContext *buffer_filter, AVFrame *frame, int flags)=0;
 #elif LIBAVFILTER_VERSION_INT >= AV_VERSION_INT(2,7,0)
@@ -90,6 +97,7 @@ public:
   virtual int av_vsrc_buffer_add_frame(AVFilterContext *buffer_filter, AVFrame *frame, int64_t pts)=0;
 #else
   virtual int av_vsrc_buffer_add_frame(AVFilterContext *buffer_filter, AVFrame *frame, int64_t pts, AVRational pixel_aspect)=0;
+#endif
 #endif
   virtual AVFilterBufferRef *avfilter_get_video_buffer(AVFilterLink *link, int perms, int w, int h)=0;
   virtual void avfilter_unref_buffer(AVFilterBufferRef *ref)=0;
@@ -171,6 +179,9 @@ public:
   }
   virtual int avfilter_poll_frame(AVFilterLink *link) { return ::avfilter_poll_frame(link); }
   virtual int avfilter_request_frame(AVFilterLink *link) { return ::avfilter_request_frame(link); }
+#if (defined USE_OLD_AV_VSRC_BUFFER_ADD_FRAME)
+  virtual int av_vsrc_buffer_add_frame(AVFilterContext *buffer_filter, AVFrame *frame, int64_t pts, AVRational pixel_aspect) { return ::av_vsrc_buffer_add_frame(buffer_filter, frame, pts, pixel_aspect); }
+#else
 #if LIBAVFILTER_VERSION_INT >= AV_VERSION_INT(2,13,0)
   virtual int av_vsrc_buffer_add_frame(AVFilterContext *buffer_filter, AVFrame *frame, int flags) { return ::av_vsrc_buffer_add_frame(buffer_filter, frame, flags); }
 #elif LIBAVFILTER_VERSION_INT >= AV_VERSION_INT(2,7,0)
@@ -179,6 +190,7 @@ public:
   virtual int av_vsrc_buffer_add_frame(AVFilterContext *buffer_filter, AVFrame *frame, int64_t pts) { return ::av_vsrc_buffer_add_frame(buffer_filter, frame, pts); }
 #else
   virtual int av_vsrc_buffer_add_frame(AVFilterContext *buffer_filter, AVFrame *frame, int64_t pts, AVRational pixel_aspect) { return ::av_vsrc_buffer_add_frame(buffer_filter, frame, pts, pixel_aspect); }
+#endif
 #endif
   virtual AVFilterBufferRef *avfilter_get_video_buffer(AVFilterLink *link, int perms, int w, int h) { return ::avfilter_get_video_buffer(link, perms, w, h); }
   virtual void avfilter_unref_buffer(AVFilterBufferRef *ref) { ::avfilter_unref_buffer(ref); }

--- a/lib/DllAvUtil.h
+++ b/lib/DllAvUtil.h
@@ -59,6 +59,10 @@ extern "C" {
   #else
     #include <ffmpeg/mem.h>
   #endif
+  /* For AVRounding */
+  #if (defined HAVE_LIBAVUTIL_MATHEMATICS_H)
+    #include <libavutil/mathematics.h>
+  #endif
 #else
   #include "libavutil/avutil.h"
   #include "libavutil/crc.h"

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
@@ -813,6 +813,9 @@ int CDVDVideoCodecFFmpeg::FilterProcess(AVFrame* frame)
 
   if (frame)
   {
+#if (defined USE_OLD_AV_VSRC_BUFFER_ADD_FRAME)
+    result = m_dllAvFilter.av_vsrc_buffer_add_frame(m_pFilterIn, frame, frame->pts, m_pCodecContext->sample_aspect_ratio);
+#else
 #if LIBAVFILTER_VERSION_INT >= AV_VERSION_INT(2,13,0)
     result = m_dllAvFilter.av_vsrc_buffer_add_frame(m_pFilterIn, frame, 0);
 #elif LIBAVFILTER_VERSION_INT >= AV_VERSION_INT(2,7,0)
@@ -821,6 +824,7 @@ int CDVDVideoCodecFFmpeg::FilterProcess(AVFrame* frame)
     result = m_dllAvFilter.av_vsrc_buffer_add_frame(m_pFilterIn, frame, frame->pts);
 #else
     result = m_dllAvFilter.av_vsrc_buffer_add_frame(m_pFilterIn, frame, frame->pts, m_pCodecContext->sample_aspect_ratio);
+#endif
 #endif
 
     if (result < 0)


### PR DESCRIPTION
This enables support for building/running XBMC Eden with libav, tested primarily with libav-0.8. This is direct for the Eden branch. The master branch will need different modifications.
