### PR TITLE
smartplaylist: use sorttitle in ORDER BY clause to sort movies by title

### DIFF
--- a/xbmc/playlists/SmartPlayList.cpp
+++ b/xbmc/playlists/SmartPlayList.cpp
@@ -600,7 +600,7 @@ CStdString CSmartPlaylistRule::GetWhereClause(CDatabase &db, const CStdString& s
   return query;
 }
 
-CStdString CSmartPlaylistRule::GetDatabaseField(DATABASE_FIELD field, const CStdString& type)
+CStdString CSmartPlaylistRule::GetDatabaseField(DATABASE_FIELD field, const CStdString& type, bool whereClause /* = true */)
 {
   if (type == "songs")
   {
@@ -640,7 +640,7 @@ CStdString CSmartPlaylistRule::GetDatabaseField(DATABASE_FIELD field, const CStd
   else if (type == "movies")
   {
     CStdString result;
-    if (field == FIELD_TITLE) result.Format("c%02d", VIDEODB_ID_TITLE);
+    if (field == FIELD_TITLE) result.Format("c%02d", whereClause ? VIDEODB_ID_TITLE : VIDEODB_ID_SORTTITLE);
     else if (field == FIELD_PLOT) result.Format("c%02d", VIDEODB_ID_PLOT);
     else if (field == FIELD_PLOTOUTLINE) result.Format("c%02d", VIDEODB_ID_PLOTOUTLINE);
     else if (field == FIELD_TAGLINE) result.Format("c%02d", VIDEODB_ID_TAGLINE);
@@ -965,9 +965,9 @@ CStdString CSmartPlaylist::GetOrderClause(CDatabase &db)
   if (m_orderField != CSmartPlaylistRule::FIELD_NONE)
   {
     if (CSmartPlaylistRule::GetFieldType(m_orderField) == CSmartPlaylistRule::NUMERIC_FIELD)
-      order.Format("ORDER BY 1*%s", CSmartPlaylistRule::GetDatabaseField(m_orderField,GetType()));
+      order.Format("ORDER BY 1*%s", CSmartPlaylistRule::GetDatabaseField(m_orderField, GetType(), false));
     else
-      order = db.PrepareSQL("ORDER BY %s", CSmartPlaylistRule::GetDatabaseField(m_orderField,GetType()).c_str());
+      order = db.PrepareSQL("ORDER BY %s", CSmartPlaylistRule::GetDatabaseField(m_orderField, GetType(), false).c_str());
     if (!m_orderAscending)
       order += " DESC";
   }

--- a/xbmc/playlists/SmartPlayList.cpp
+++ b/xbmc/playlists/SmartPlayList.cpp
@@ -640,7 +640,14 @@ CStdString CSmartPlaylistRule::GetDatabaseField(DATABASE_FIELD field, const CStd
   else if (type == "movies")
   {
     CStdString result;
-    if (field == FIELD_TITLE) result.Format("c%02d", whereClause ? VIDEODB_ID_TITLE : VIDEODB_ID_SORTTITLE);
+    if (field == FIELD_TITLE)
+    {
+      if (whereClause)
+        result.Format("c%02d", VIDEODB_ID_TITLE);
+      else
+        // We need some extra logic to get the title value if sorttitle isn't set
+        result.Format("CASE WHEN length(c%02d) > 0 THEN c%02d ELSE c%02d END", VIDEODB_ID_SORTTITLE, VIDEODB_ID_SORTTITLE, VIDEODB_ID_TITLE);
+    }
     else if (field == FIELD_PLOT) result.Format("c%02d", VIDEODB_ID_PLOT);
     else if (field == FIELD_PLOTOUTLINE) result.Format("c%02d", VIDEODB_ID_PLOTOUTLINE);
     else if (field == FIELD_TAGLINE) result.Format("c%02d", VIDEODB_ID_TAGLINE);

--- a/xbmc/playlists/SmartPlayList.h
+++ b/xbmc/playlists/SmartPlayList.h
@@ -119,7 +119,7 @@ public:
   void TranslateStrings(const char *field, const char *oper, const char *parameter);
   static DATABASE_FIELD TranslateField(const char *field);
   static CStdString     TranslateField(DATABASE_FIELD field);
-  static CStdString     GetDatabaseField(DATABASE_FIELD field, const CStdString& strType);
+  static CStdString     GetDatabaseField(DATABASE_FIELD field, const CStdString& strType, bool whereClause = true);
   static CStdString     TranslateOperator(SEARCH_OPERATOR oper);
 
   static CStdString     GetLocalizedField(DATABASE_FIELD field);


### PR DESCRIPTION
The title says it all. This adjusts the sorting behaviour for movie-based smartplaylists to behave the same way sorting movies by title works in the library views. Instead of using the "title" property (c00) it uses the "sorttitle" property (c10). This has been requested here http://forum.xbmc.org/showthread.php?tid=127793 and IMO makes sense as SmartPlaylists should give (almost) the same experience as browsing the standard libraries.
