### PR TITLE
libavcodec/libavutil: Switch from private avcodec_guess_channel_layout (in libavcodec) to, equivalent but public, av_get_default_channel in libavutil.

### DIFF
--- a/lib/DllAvCodec.h
+++ b/lib/DllAvCodec.h
@@ -60,7 +60,6 @@ extern "C" {
   #endif
 
   /* From non-public audioconvert.h */
-  int64_t avcodec_guess_channel_layout(int nb_channels, enum CodecID codec_id, const char *fmt_name);
   struct AVAudioConvert;
   typedef struct AVAudioConvert AVAudioConvert;
   AVAudioConvert *av_audio_convert_alloc(enum AVSampleFormat out_fmt, int out_channels,
@@ -125,7 +124,6 @@ public:
                                const void * const  in[6], const int  in_stride[6], int len)=0;
   virtual int av_dup_packet(AVPacket *pkt)=0;
   virtual void av_init_packet(AVPacket *pkt)=0;
-  virtual int64_t avcodec_guess_channel_layout(int nb_channels, enum CodecID codec_id, const char *fmt_name)=0;
 };
 
 #if (defined USE_EXTERNAL_FFMPEG) || (defined TARGET_DARWIN)
@@ -205,7 +203,6 @@ public:
 
   virtual int av_dup_packet(AVPacket *pkt) { return ::av_dup_packet(pkt); }
   virtual void av_init_packet(AVPacket *pkt) { return ::av_init_packet(pkt); }
-  virtual int64_t avcodec_guess_channel_layout(int nb_channels, enum CodecID codec_id, const char *fmt_name) { return ::avcodec_guess_channel_layout(nb_channels, codec_id, fmt_name); }
 
   // DLL faking.
   virtual bool ResolveExports() { return true; }
@@ -230,7 +227,6 @@ class DllAvCodec : public DllDynamic, DllAvCodecInterface
   DEFINE_FUNC_ALIGNED9(int, __cdecl, av_parser_parse2, AVCodecParserContext*,AVCodecContext*, uint8_t**, int*, const uint8_t*, int, int64_t, int64_t, int64_t)
   DEFINE_METHOD1(int, av_dup_packet, (AVPacket *p1))
   DEFINE_METHOD1(void, av_init_packet, (AVPacket *p1))
-  DEFINE_METHOD3(int64_t, avcodec_guess_channel_layout, (int p1, enum CodecID p2, const char *p3))
 
   LOAD_SYMBOLS();
 
@@ -297,7 +293,6 @@ class DllAvCodec : public DllDynamic, DllAvCodecInterface
     RESOLVE_METHOD(av_audio_convert)
     RESOLVE_METHOD(av_dup_packet)
     RESOLVE_METHOD(av_init_packet)
-    RESOLVE_METHOD(avcodec_guess_channel_layout)
   END_METHOD_RESOLVE()
 
   /* dependencies of libavcodec */

--- a/lib/DllAvUtil.h
+++ b/lib/DllAvUtil.h
@@ -102,6 +102,7 @@ public:
   virtual AVDictionaryEntry *av_dict_get(AVDictionary *m, const char *key, const AVDictionaryEntry *prev, int flags) = 0;
   virtual int av_dict_set(AVDictionary **pm, const char *key, const char *value, int flags)=0;
   virtual int av_samples_get_buffer_size (int *linesize, int nb_channels, int nb_samples, enum AVSampleFormat sample_fmt, int align) = 0;
+  virtual int64_t av_get_default_channel_layout(int nb_channels)=0;
 };
 
 #if defined (USE_EXTERNAL_FFMPEG) || (defined TARGET_DARWIN)
@@ -137,6 +138,7 @@ public:
   virtual int av_dict_set(AVDictionary **pm, const char *key, const char *value, int flags) { return ::av_dict_set(pm, key, value, flags); }
   virtual int av_samples_get_buffer_size (int *linesize, int nb_channels, int nb_samples, enum AVSampleFormat sample_fmt, int align)
     { return ::av_samples_get_buffer_size(linesize, nb_channels, nb_samples, sample_fmt, align); }
+  virtual int64_t av_get_default_channel_layout(int nb_channels) { return ::av_get_default_channel_layout(nb_channels); }
 
    // DLL faking.
    virtual bool ResolveExports() { return true; }
@@ -177,6 +179,7 @@ class DllAvUtilBase : public DllDynamic, DllAvUtilInterface
   DEFINE_METHOD4(AVDictionaryEntry *, av_dict_get, (AVDictionary *p1, const char *p2, const AVDictionaryEntry *p3, int p4))
   DEFINE_METHOD4(int, av_dict_set, (AVDictionary **p1, const char *p2, const char *p3, int p4));
   DEFINE_METHOD5(int, av_samples_get_buffer_size, (int *p1, int p2, int p3, enum AVSampleFormat p4, int p5))
+  DEFINE_METHOD1(int64_t, av_get_default_channel_layout, (int p1))
 
   public:
   BEGIN_METHOD_RESOLVE()
@@ -202,6 +205,7 @@ class DllAvUtilBase : public DllDynamic, DllAvUtilInterface
     RESOLVE_METHOD(av_dict_get)
     RESOLVE_METHOD(av_dict_set)
     RESOLVE_METHOD(av_samples_get_buffer_size)
+    RESOLVE_METHOD(av_get_default_channel_layout)
   END_METHOD_RESOLVE()
 };
 

--- a/xbmc/cdrip/EncoderFFmpeg.cpp
+++ b/xbmc/cdrip/EncoderFFmpeg.cpp
@@ -106,7 +106,7 @@ bool CEncoderFFmpeg::Init(const char* strFile, int iInChannels, int iInRate, int
   m_CodecCtx->bit_rate       = m_Format->bit_rate;
   m_CodecCtx->sample_rate    = iInRate;
   m_CodecCtx->channels       = iInChannels;
-  m_CodecCtx->channel_layout = m_dllAvCodec.avcodec_guess_channel_layout(iInChannels, codec->id, NULL);
+  m_CodecCtx->channel_layout = m_dllAvUtil.av_get_default_channel_layout(iInChannels);
   m_CodecCtx->time_base      = (AVRational){1, iInRate};
 
   if(fmt->flags & AVFMT_GLOBALHEADER)

--- a/xbmc/cores/dvdplayer/DVDCodecs/Audio/DVDAudioCodecFFmpeg.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Audio/DVDAudioCodecFFmpeg.cpp
@@ -279,7 +279,7 @@ void CDVDAudioCodecFFmpeg::BuildChannelMap()
   else
   {
     CLog::Log(LOGINFO, "CDVDAudioCodecFFmpeg::GetChannelMap - FFmpeg reported %d channels, but the layout contains %d ignoring", m_pCodecContext->channels, bits);
-    layout = m_dllAvCodec.avcodec_guess_channel_layout(m_pCodecContext->channels, m_pCodecContext->codec_id, NULL);
+    layout = m_dllAvUtil.av_get_default_channel_layout(m_pCodecContext->channels);
   }
 
   int index = 0;


### PR DESCRIPTION
This fixes the build with ffmpeg git and remove usage of one internal symbol in ffmpeg.
