### PR TITLE
Musicvideo artist in setinfo

### DIFF
--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -3186,7 +3186,7 @@ int CFileItem::GetVideoContentType() const
     type = VIDEODB_CONTENT_TVSHOWS;
   if (HasVideoInfoTag() && GetVideoInfoTag()->m_iSeason > -1 && !m_bIsFolder) // episode
     type = VIDEODB_CONTENT_EPISODES;
-  if (HasVideoInfoTag() && !GetVideoInfoTag()->m_strArtist.IsEmpty())
+  if (HasVideoInfoTag() && !GetVideoInfoTag()->m_artist.empty())
     type = VIDEODB_CONTENT_MUSICVIDEOS;
   return type;
 }

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -2557,7 +2557,7 @@ bool CGUIInfoManager::GetMultiInfoBool(const GUIInfo &info, int contextWindow, c
             strContent = "files";
           if (m_currentFile->HasVideoInfoTag() && m_currentFile->GetVideoInfoTag()->m_iSeason > -1) // episode
             strContent = "episodes";
-          if (m_currentFile->HasVideoInfoTag() && !m_currentFile->GetVideoInfoTag()->m_strArtist.IsEmpty())
+          if (m_currentFile->HasVideoInfoTag() && !m_currentFile->GetVideoInfoTag()->m_artist.empty())
             strContent = "musicvideos";
           if (m_currentFile->HasVideoInfoTag() && m_currentFile->GetVideoInfoTag()->m_strStatus == "livetv")
             strContent = "livetv";
@@ -3437,7 +3437,7 @@ CStdString CGUIInfoManager::GetVideoLabel(int item)
     case VIDEOPLAYER_CAST_AND_ROLE:
       return m_currentFile->GetVideoInfoTag()->GetCast(true);
     case VIDEOPLAYER_ARTIST:
-      return m_currentFile->GetVideoInfoTag()->m_strArtist;
+      return StringUtils::Join(m_currentFile->GetVideoInfoTag()->m_artist, g_advancedSettings.m_videoItemSeparator);
     case VIDEOPLAYER_ALBUM:
       return m_currentFile->GetVideoInfoTag()->m_strAlbum;
     case VIDEOPLAYER_WRITER:
@@ -3908,7 +3908,7 @@ CStdString CGUIInfoManager::GetItemLabel(const CFileItem *item, int info, CStdSt
     }
   case LISTITEM_ARTIST:
     if (item->HasVideoInfoTag())
-      return item->GetVideoInfoTag()->m_strArtist;
+      return StringUtils::Join(item->GetVideoInfoTag()->m_artist, g_advancedSettings.m_videoItemSeparator);
     if (item->HasMusicInfoTag())
       return StringUtils::Join(item->GetMusicInfoTag()->GetArtist(), g_advancedSettings.m_musicItemSeparator);
     break;

--- a/xbmc/SortFileItem.cpp
+++ b/xbmc/SortFileItem.cpp
@@ -223,7 +223,7 @@ void SSortFileItem::BySongAlbum(CFileItemPtr &item)
   if (item->HasMusicInfoTag())
     artist = StringUtils::Join(item->GetMusicInfoTag()->GetArtist(), g_advancedSettings.m_musicItemSeparator);
   else if (item->HasVideoInfoTag())
-    artist = item->GetVideoInfoTag()->m_strArtist;
+    artist = StringUtils::Join(item->GetVideoInfoTag()->m_artist, g_advancedSettings.m_videoItemSeparator);
   label += " " + artist;
 
   if (item->HasMusicInfoTag())
@@ -246,7 +246,7 @@ void SSortFileItem::BySongAlbumNoThe(CFileItemPtr &item)
   if (item->HasMusicInfoTag())
     artist = StringUtils::Join(item->GetMusicInfoTag()->GetArtist(), g_advancedSettings.m_musicItemSeparator);
   else if (item->HasVideoInfoTag())
-    artist = item->GetVideoInfoTag()->m_strArtist;
+    artist = StringUtils::Join(item->GetVideoInfoTag()->m_artist, g_advancedSettings.m_videoItemSeparator);
   label += " " + RemoveArticles(artist);
 
   if (item->HasMusicInfoTag())
@@ -263,7 +263,7 @@ void SSortFileItem::BySongArtist(CFileItemPtr &item)
   if (item->HasMusicInfoTag())
     label = StringUtils::Join(item->GetMusicInfoTag()->GetArtist(), g_advancedSettings.m_musicItemSeparator);
   else if (item->HasVideoInfoTag())
-    label = item->GetVideoInfoTag()->m_strArtist;
+    label = StringUtils::Join(item->GetVideoInfoTag()->m_artist, g_advancedSettings.m_videoItemSeparator);
 
   if (g_advancedSettings.m_bMusicLibraryAlbumsSortByArtistThenYear)
   {
@@ -296,7 +296,7 @@ void SSortFileItem::BySongArtistNoThe(CFileItemPtr &item)
   if (item->HasMusicInfoTag())
     label = StringUtils::Join(item->GetMusicInfoTag()->GetArtist(), g_advancedSettings.m_musicItemSeparator);
   else if (item->HasVideoInfoTag())
-    label = item->GetVideoInfoTag()->m_strArtist;
+    label = StringUtils::Join(item->GetVideoInfoTag()->m_artist, g_advancedSettings.m_videoItemSeparator);
   label = RemoveArticles(label);
 
   if (g_advancedSettings.m_bMusicLibraryAlbumsSortByArtistThenYear)

--- a/xbmc/ThumbnailCache.cpp
+++ b/xbmc/ThumbnailCache.cpp
@@ -215,8 +215,8 @@ CStdString CThumbnailCache::GetFanart(const CFileItem &item)
   {
     if (!item.HasVideoInfoTag())
       return "";
-    if (!item.GetVideoInfoTag()->m_strArtist.IsEmpty())
-      return GetThumb(item.GetVideoInfoTag()->m_strArtist,g_settings.GetMusicFanartFolder());
+    if (!item.GetVideoInfoTag()->m_artist.empty())
+      return GetThumb(StringUtils::Join(item.GetVideoInfoTag()->m_artist, g_advancedSettings.m_videoItemSeparator),g_settings.GetMusicFanartFolder());
     if (!item.m_bIsFolder && !item.GetVideoInfoTag()->m_strShowTitle.IsEmpty())
     {
       CStdString showPath;

--- a/xbmc/interfaces/AnnouncementManager.cpp
+++ b/xbmc/interfaces/AnnouncementManager.cpp
@@ -24,6 +24,7 @@
 #include <stdio.h>
 #include "utils/log.h"
 #include "utils/Variant.h"
+#include "utils/StringUtils.h"
 #include "FileItem.h"
 #include "music/tags/MusicInfoTag.h"
 #include "music/MusicDatabase.h"
@@ -139,8 +140,8 @@ void CAnnouncementManager::Announce(AnnouncementFlag flag, const char *sender, c
       case VIDEODB_CONTENT_MUSICVIDEOS:
         if (!item->GetVideoInfoTag()->m_strAlbum.empty())
           object["album"] = item->GetVideoInfoTag()->m_strAlbum;
-        if (!item->GetVideoInfoTag()->m_strArtist.empty())
-          object["artist"] = item->GetVideoInfoTag()->m_strArtist;
+        if (!item->GetVideoInfoTag()->m_artist.empty())
+          object["artist"] = StringUtils::Join(item->GetVideoInfoTag()->m_artist, " / ");
         break;
       }
     }

--- a/xbmc/interfaces/python/xbmcmodule/listitem.cpp
+++ b/xbmc/interfaces/python/xbmcmodule/listitem.cpp
@@ -363,6 +363,7 @@ namespace PYXBMC
     "    credits       : string (Andy Kaufman) - writing credits\n"
     "    lastplayed    : string (%Y-%m-%d %h:%m:%s = 2009-04-05 23:16:04)\n"
     "    album         : string (The Joshua Tree)\n"
+    "    artist        : list (['U2'])\n"
     "    votes         : string (12345 votes)\n"
     "    trailer       : string (/home/user/trailer.avi)\n"
     "\n"
@@ -470,6 +471,19 @@ namespace PYXBMC
             if (pRole != NULL)
               PyXBMCGetUnicodeString(info.strRole, pRole, 1);
             self->item->GetVideoInfoTag()->m_cast.push_back(info);
+          }
+        }
+        else if (strcmpi(PyString_AsString(key), "artist") == 0)
+        {
+          if (!PyObject_TypeCheck(value, &PyList_Type)) continue;
+          self->item->GetVideoInfoTag()->m_artist.clear();
+          for (int i = 0; i < PyList_Size(value); i++)
+          {
+            PyObject *pActor = PyList_GetItem(value, i);
+            if (pActor == NULL) continue;
+            CStdString actor;
+            if (!PyXBMCGetUnicodeString(actor, pActor, 1)) continue;
+            self->item->GetVideoInfoTag()->m_artist.push_back(actor);
           }
         }
         else

--- a/xbmc/music/tags/MusicInfoTag.cpp
+++ b/xbmc/music/tags/MusicInfoTag.cpp
@@ -428,10 +428,10 @@ void CMusicInfoTag::Serialize(CVariant& value)
      JSON-RPC v4 can be broken */
   value["url"] = m_strURL;
   value["title"] = m_strTitle;
-  value["artist"] = StringUtils::Join(m_artist, g_advancedSettings.m_musicItemSeparator);
+  value["artist"] = StringUtils::Join(m_artist, " / ");
   value["album"] = m_strAlbum;
-  value["albumartist"] = StringUtils::Join(m_albumArtist, g_advancedSettings.m_musicItemSeparator);
-  value["genre"] = StringUtils::Join(m_genre, g_advancedSettings.m_musicItemSeparator);
+  value["albumartist"] = StringUtils::Join(m_albumArtist, " / ");
+  value["genre"] = StringUtils::Join(m_genre, " / ");
   value["duration"] = m_iDuration;
   value["track"] = m_iTrack;
   value["loaded"] = m_bLoaded;

--- a/xbmc/music/windows/GUIWindowMusicBase.cpp
+++ b/xbmc/music/windows/GUIWindowMusicBase.cpp
@@ -1367,7 +1367,7 @@ void CGUIWindowMusicBase::SetupFanart(CFileItemList& items)
     if (item->HasMusicInfoTag())
       strArtist = StringUtils::Join(item->GetMusicInfoTag()->GetArtist(), g_advancedSettings.m_musicItemSeparator);
     if (item->HasVideoInfoTag())
-      strArtist = item->GetVideoInfoTag()->m_strArtist;
+      strArtist = StringUtils::Join(item->GetVideoInfoTag()->m_artist, g_advancedSettings.m_videoItemSeparator);
     if (strArtist.IsEmpty())
       continue;
     map<CStdString, CStdString>::iterator artist = artists.find(strArtist);

--- a/xbmc/network/UPnP.cpp
+++ b/xbmc/network/UPnP.cpp
@@ -504,9 +504,9 @@ CUPnPServer::PopulateObjectFromTag(CVideoInfoTag&         tag,
       *file_path = tag.m_strFileNameAndPath;
 
     if (tag.m_iDbId != -1 ) {
-        if (!tag.m_strArtist.IsEmpty()) {
+        if (!tag.m_artist.empty()) {
           object.m_ObjectClass.type = "object.item.videoItem.musicVideoClip";
-          object.m_Creator = tag.m_strArtist;
+          object.m_Creator = StringUtils::Join(tag.m_artist, g_advancedSettings.m_videoItemSeparator);
           object.m_Title = tag.m_strTitle;
           object.m_ReferenceID = NPT_String::Format("videodb://3/2/%i", tag.m_iDbId);
         } else if (!tag.m_strShowTitle.IsEmpty()) {
@@ -730,7 +730,7 @@ CUPnPServer::BuildObject(const CFileItem&              item,
                   break;
                 case VIDEODATABASEDIRECTORY::NODE_TYPE_ACTOR:
                   container->m_ObjectClass.type += ".person.videoArtist";
-                  container->m_Creator = tag.m_strArtist;
+                  container->m_Creator = StringUtils::Join(tag.m_artist, g_advancedSettings.m_videoItemSeparator);
                   container->m_Title   = tag.m_strTitle;
                   break;
                 case VIDEODATABASEDIRECTORY::NODE_TYPE_TITLE_TVSHOWS:

--- a/xbmc/utils/LabelFormatter.cpp
+++ b/xbmc/utils/LabelFormatter.cpp
@@ -165,8 +165,8 @@ CStdString CLabelFormatter::GetMaskContent(const CMaskString &mask, const CFileI
   case 'A':
     if (music && music->GetArtist().size())
       value = StringUtils::Join(music->GetArtist(), g_advancedSettings.m_musicItemSeparator);
-    if (movie && movie->m_strArtist.size())
-      value = movie->m_strArtist;
+    if (movie && movie->m_artist.size())
+      value = StringUtils::Join(movie->m_artist, g_advancedSettings.m_videoItemSeparator);
     break;
   case 'T':
     if (music && music->GetTitle().size())

--- a/xbmc/utils/RecentlyAddedJob.cpp
+++ b/xbmc/utils/RecentlyAddedJob.cpp
@@ -176,7 +176,7 @@ bool CRecentlyAddedJob::UpdateVideo()
       home->SetProperty("LatestMusicVideo." + value + ".Plot"        , item->GetVideoInfoTag()->m_strPlot);
       home->SetProperty("LatestMusicVideo." + value + ".RunningTime" , item->GetVideoInfoTag()->m_strRuntime);
       home->SetProperty("LatestMusicVideo." + value + ".Path"        , item->GetVideoInfoTag()->m_strFileNameAndPath);
-      home->SetProperty("LatestMusicVideo." + value + ".Artist"      , item->GetVideoInfoTag()->m_strArtist);
+      home->SetProperty("LatestMusicVideo." + value + ".Artist"      , StringUtils::Join(item->GetVideoInfoTag()->m_artist, g_advancedSettings.m_videoItemSeparator));
 
       if (!item->HasThumbnail())
         m_thumbLoader.LoadItem(item.get());

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -1597,7 +1597,7 @@ void CVideoDatabase::GetMusicVideosByArtist(const CStdString& strArtist, CFileIt
     {
       CVideoInfoTag tag = GetDetailsForMusicVideo(m_pDS);
       CFileItemPtr pItem(new CFileItem(tag));
-      pItem->SetLabel(tag.m_strArtist);
+      pItem->SetLabel(StringUtils::Join(tag.m_artist, g_advancedSettings.m_videoItemSeparator));
       items.Add(pItem);
       m_pDS->next();
     }
@@ -1999,13 +1999,11 @@ int CVideoDatabase::SetDetailsForMusicVideo(const CStdString& strFilenameAndPath
     AddGenreAndDirectorsAndStudios(details,vecDirectors,vecGenres,vecStudios);
 
     // add artists...
-    if (!details.m_strArtist.IsEmpty())
+    if (!details.m_artist.empty())
     {
-      CStdStringArray vecArtists;
-      StringUtils::SplitString(details.m_strArtist, g_advancedSettings.m_videoItemSeparator, vecArtists);
-      for (unsigned int i = 0; i < vecArtists.size(); i++)
+      for (unsigned int i = 0; i < details.m_artist.size(); i++)
       {
-        CStdString artist = vecArtists[i];
+        CStdString artist = details.m_artist[i];
         artist.Trim();
         int idArtist = AddActor(artist,"");
         AddArtistToMusicVideo(idMVideo, idArtist);
@@ -4162,7 +4160,7 @@ bool CVideoDatabase::GetMusicVideoAlbumsNav(const CStdString& strBaseDir, CFileI
           pItem->SetLabelPreformated(true);
           if (!items.Contains(pItem->GetPath()))
           {
-            pItem->GetVideoInfoTag()->m_strArtist = it->second.second;
+            pItem->GetVideoInfoTag()->m_artist.push_back(it->second.second);
             CStdString strThumb = CThumbnailCache::GetAlbumThumb(*pItem);
             if (CFile::Exists(strThumb))
               pItem->SetThumbnailImage(strThumb);
@@ -4185,7 +4183,7 @@ bool CVideoDatabase::GetMusicVideoAlbumsNav(const CStdString& strBaseDir, CFileI
           pItem->SetLabelPreformated(true);
           if (!items.Contains(pItem->GetPath()))
           {
-            pItem->GetVideoInfoTag()->m_strArtist = m_pDS->fv(2).get_asString();
+            pItem->GetVideoInfoTag()->m_artist.push_back(m_pDS->fv(2).get_asString());
             CStdString strThumb = CThumbnailCache::GetAlbumThumb(pItem->GetLabel(), m_pDS->fv(2).get_asString());
             if (CFile::Exists(strThumb))
               pItem->SetThumbnailImage(strThumb);
@@ -4357,7 +4355,7 @@ bool CVideoDatabase::GetPeopleNav(const CStdString& strBaseDir, CFileItemList& i
             pItem->GetVideoInfoTag()->m_playCount = (m_pDS->fv(4).get_asInt() == m_pDS->fv(3).get_asInt()) ? 1 : 0;
           }
           if (idContent == VIDEODB_CONTENT_MUSICVIDEOS)
-            pItem->GetVideoInfoTag()->m_strArtist = pItem->GetLabel();
+            pItem->GetVideoInfoTag()->m_artist.push_back(pItem->GetLabel());
           items.Add(pItem);
           m_pDS->next();
         }
@@ -7137,7 +7135,7 @@ void CVideoDatabase::ExportToXML(const CStdString &path, bool singleFiles /* = f
       CFileItem saveItem(item);
       if (!singleFiles)
       {
-        CStdString strFileName(movie.m_strArtist + "." + movie.m_strTitle);
+        CStdString strFileName(StringUtils::Join(movie.m_artist, g_advancedSettings.m_videoItemSeparator) + "." + movie.m_strTitle);
         if (movie.m_iYear > 0)
           strFileName.AppendFormat("_%i", movie.m_iYear);
         saveItem = CFileItem(GetSafeFile(musicvideosDir, strFileName) + ".avi", false);
@@ -7626,7 +7624,7 @@ void CVideoDatabase::ImportFromXML(const CStdString &path)
         bool useFolders = info.m_basePath.IsEmpty() ? LookupByFolders(item.GetPath()) : false;
         scanner.AddVideo(&item, CONTENT_MUSICVIDEOS, useFolders);
         SetPlayCount(item, info.m_playCount, info.m_lastPlayed);
-        CStdString strFileName(info.m_strArtist + "." + info.m_strTitle);
+        CStdString strFileName(StringUtils::Join(info.m_artist, g_advancedSettings.m_videoItemSeparator) + "." + info.m_strTitle);
         if (iVersion >= 1 && info.m_iYear > 0)
           strFileName.AppendFormat("_%i", info.m_iYear);
         CStdString file(GetSafeFile(musicvideosDir, strFileName));

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -289,7 +289,7 @@ const struct SDbTableOffsets DbMusicVideoOffsets[] =
   { VIDEODB_TYPE_INT, my_offsetof(CVideoInfoTag,m_iYear) },
   { VIDEODB_TYPE_STRING, my_offsetof(CVideoInfoTag,m_strPlot) },
   { VIDEODB_TYPE_STRING, my_offsetof(CVideoInfoTag,m_strAlbum) },
-  { VIDEODB_TYPE_STRING, my_offsetof(CVideoInfoTag,m_strArtist) },
+  { VIDEODB_TYPE_STRINGARRAY, my_offsetof(CVideoInfoTag,m_artist) },
   { VIDEODB_TYPE_STRINGARRAY, my_offsetof(CVideoInfoTag,m_genre) },
   { VIDEODB_TYPE_INT, my_offsetof(CVideoInfoTag,m_iTrack) },
   { VIDEODB_TYPE_STRING, my_offsetof(CVideoInfoTag,m_basePath) },

--- a/xbmc/video/VideoInfoTag.cpp
+++ b/xbmc/video/VideoInfoTag.cpp
@@ -64,7 +64,7 @@ void CVideoInfoTag::Reset()
   m_firstAired.Reset();
   m_studio.clear();
   m_strAlbum.clear();
-  m_strArtist.clear();
+  m_artist.clear();
   m_strTrailer.clear();
   m_iTop250 = 0;
   m_iYear = 0;
@@ -233,8 +233,7 @@ bool CVideoInfoTag::Save(TiXmlNode *node, const CStdString &tag, bool savePathIn
     TiXmlText th(it->thumbUrl.GetFirstThumb().m_url);
     thumbNode->InsertEndChild(th);
   }
-  XMLUtils::SetAdditiveString(movie, "artist",
-                         g_advancedSettings.m_videoItemSeparator, m_strArtist);
+  XMLUtils::SetStringArray(movie, "artist", m_artist);
   XMLUtils::SetStringArray(movie, "showlink", m_showLink);
  
   TiXmlElement resume("resume");
@@ -300,7 +299,7 @@ void CVideoInfoTag::Archive(CArchive& ar)
     ar << m_firstAired;
     ar << m_strShowTitle;
     ar << m_strAlbum;
-    ar << m_strArtist;
+    ar << m_artist;
     ar << m_playCount;
     ar << m_lastPlayed;
     ar << m_iTop250;
@@ -373,7 +372,7 @@ void CVideoInfoTag::Archive(CArchive& ar)
     ar >> m_firstAired;
     ar >> m_strShowTitle;
     ar >> m_strAlbum;
-    ar >> m_strArtist;
+    ar >> m_artist;
     ar >> m_playCount;
     ar >> m_lastPlayed;
     ar >> m_iTop250;
@@ -449,7 +448,7 @@ void CVideoInfoTag::Serialize(CVariant& value)
   value["firstaired"] = m_firstAired.IsValid() ? m_firstAired.GetAsDBDate() : StringUtils::EmptyString;
   value["showtitle"] = m_strShowTitle;
   value["album"] = m_strAlbum;
-  value["artist"] = m_strArtist;
+  value["artist"] = StringUtils::Join(m_artist, " / ");
   value["playcount"] = m_playCount;
   value["lastplayed"] = m_lastPlayed.IsValid() ? m_lastPlayed.GetAsDBDateTime() : StringUtils::EmptyString;
   value["top250"] = m_iTop250;
@@ -598,7 +597,7 @@ void CVideoInfoTag::ParseNative(const TiXmlElement* movie, bool prioritise)
   // artists
   node = movie->FirstChildElement("artist");
   if (node && node->FirstChild() && prioritise)
-    m_strArtist.clear();
+    m_artist.clear();
   while (node)
   {
     const TiXmlNode* pNode = node->FirstChild("name");
@@ -610,10 +609,10 @@ void CVideoInfoTag::ParseNative(const TiXmlElement* movie, bool prioritise)
     if (pValue)
     {
       const char* clear=node->Attribute("clear");
-      if (m_strArtist.IsEmpty() || (clear && stricmp(clear,"true")==0))
-        m_strArtist = pValue;
-      else
-        m_strArtist += g_advancedSettings.m_videoItemSeparator + pValue;
+      if (clear && stricmp(clear,"true")==0)
+        m_artist.clear();
+      vector<string> artists = StringUtils::Split(pValue, g_advancedSettings.m_videoItemSeparator);
+      m_artist.insert(m_artist.end(), artists.begin(), artists.end());
     }
     node = node->NextSiblingElement("artist");
   }

--- a/xbmc/video/VideoInfoTag.cpp
+++ b/xbmc/video/VideoInfoTag.cpp
@@ -408,16 +408,16 @@ void CVideoInfoTag::Serialize(CVariant& value)
   /* TODO:
      All the StringUtils::Join() calls can be removed once backwards-compatibility to
      JSON-RPC v4 can be broken */
-  value["director"] = StringUtils::Join(m_director, g_advancedSettings.m_videoItemSeparator);
-  value["writer"] = StringUtils::Join(m_writingCredits, g_advancedSettings.m_videoItemSeparator);
-  value["genre"] = StringUtils::Join(m_genre, g_advancedSettings.m_videoItemSeparator);
-  value["country"] = StringUtils::Join(m_country, g_advancedSettings.m_videoItemSeparator);
+  value["director"] = StringUtils::Join(m_director, " / ");
+  value["writer"] = StringUtils::Join(m_writingCredits, " / ");
+  value["genre"] = StringUtils::Join(m_genre, " / ");
+  value["country"] = StringUtils::Join(m_country, " / ");
   value["tagline"] = m_strTagLine;
   value["plotoutline"] = m_strPlotOutline;
   value["plot"] = m_strPlot;
   value["title"] = m_strTitle;
   value["votes"] = m_strVotes;
-  value["studio"] = StringUtils::Join(m_studio, g_advancedSettings.m_videoItemSeparator);
+  value["studio"] = StringUtils::Join(m_studio, " / ");
   value["trailer"] = m_strTrailer;
   value["cast"] = CVariant(CVariant::VariantTypeArray);
   for (unsigned int i = 0; i < m_cast.size(); ++i)
@@ -460,7 +460,7 @@ void CVideoInfoTag::Serialize(CVariant& value)
   value["dbid"] = m_iDbId;
   value["fileid"] = m_iFileId;
   value["track"] = m_iTrack;
-  value["showlink"] = StringUtils::Join(m_showLink, g_advancedSettings.m_videoItemSeparator);
+  value["showlink"] = StringUtils::Join(m_showLink, " / ");
   m_streamDetails.Serialize(value["streamdetails"]);
   CVariant resume = CVariant(CVariant::VariantTypeObject);
   resume["position"] = (float)m_resumePoint.timeInSeconds;

--- a/xbmc/video/VideoInfoTag.h
+++ b/xbmc/video/VideoInfoTag.h
@@ -89,7 +89,7 @@ public:
   CStdString m_strTitle;
   CStdString m_strSortTitle;
   CStdString m_strVotes;
-  CStdString m_strArtist;
+  std::vector<std::string> m_artist;
   std::vector< SActorInfo > m_cast;
   typedef std::vector< SActorInfo >::const_iterator iCast;
   std::vector<std::string> m_set;

--- a/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
@@ -233,9 +233,8 @@ void CGUIDialogVideoInfo::SetMovie(const CFileItem *item)
   VIDEODB_CONTENT_TYPE type = (VIDEODB_CONTENT_TYPE)m_movieItem->GetVideoContentType();
   if (type == VIDEODB_CONTENT_MUSICVIDEOS)
   { // music video
-    CStdStringArray artists;
-    StringUtils::SplitString(m_movieItem->GetVideoInfoTag()->m_strArtist, g_advancedSettings.m_videoItemSeparator, artists);
-    for (std::vector<CStdString>::const_iterator it = artists.begin(); it != artists.end(); ++it)
+    const std::vector<std::string> &artists = m_movieItem->GetVideoInfoTag()->m_artist;
+    for (std::vector<std::string>::const_iterator it = artists.begin(); it != artists.end(); ++it)
     {
       CFileItemPtr item(new CFileItem(*it));
       if (CFile::Exists(item->GetCachedArtistThumb()))
@@ -354,7 +353,7 @@ void CGUIDialogVideoInfo::Update()
   {
     if (m_bViewReview)
     {
-      if (!m_movieItem->GetVideoInfoTag()->m_strArtist.IsEmpty())
+      if (!m_movieItem->GetVideoInfoTag()->m_artist.empty())
       {
         SET_CONTROL_LABEL(CONTROL_BTN_TRACKS, 133);
       }
@@ -540,7 +539,7 @@ void CGUIDialogVideoInfo::DoSearch(CStdString& strSearch, CFileItemList& items)
   db.GetMusicVideosByArtist(strSearch, movies);
   for (int i = 0; i < movies.Size(); ++i)
   {
-    CStdString label = movies[i]->GetVideoInfoTag()->m_strArtist + " - " + movies[i]->GetVideoInfoTag()->m_strTitle;
+    CStdString label = StringUtils::Join(movies[i]->GetVideoInfoTag()->m_artist, g_advancedSettings.m_videoItemSeparator) + " - " + movies[i]->GetVideoInfoTag()->m_strTitle;
     if (movies[i]->GetVideoInfoTag()->m_iYear > 0)
       label.AppendFormat(" (%i)", movies[i]->GetVideoInfoTag()->m_iYear);
     movies[i]->SetLabel(label);

--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -1539,7 +1539,7 @@ void CGUIWindowVideoBase::UpdateVideoTitle(const CFileItem* pItem)
   }
   if (pItem->HasVideoInfoTag() && pItem->GetVideoInfoTag()->m_iSeason > -1 && !pItem->m_bIsFolder)
     iType = VIDEODB_CONTENT_EPISODES;
-  if (pItem->HasVideoInfoTag() && !pItem->GetVideoInfoTag()->m_strArtist.IsEmpty())
+  if (pItem->HasVideoInfoTag() && !pItem->GetVideoInfoTag()->m_artist.empty())
     iType = VIDEODB_CONTENT_MUSICVIDEOS;
   if (params.GetSetId() != -1 && params.GetMovieId() == -1)
     iType = VIDEODB_CONTENT_MOVIE_SETS;

--- a/xbmc/video/windows/GUIWindowVideoNav.cpp
+++ b/xbmc/video/windows/GUIWindowVideoNav.cpp
@@ -49,6 +49,7 @@
 #include "storage/MediaManager.h"
 #include "utils/log.h"
 #include "utils/URIUtils.h"
+#include "utils/StringUtils.h"
 #include "pictures/Picture.h"
 #include "TextureCache.h"
 
@@ -743,7 +744,7 @@ bool CGUIWindowVideoNav::DeleteItem(CFileItem* pItem, bool bUnavailable /* = fal
     iType = VIDEODB_CONTENT_TVSHOWS;
   if (pItem->HasVideoInfoTag() && pItem->GetVideoInfoTag()->m_iSeason > -1 && !pItem->m_bIsFolder)
     iType = VIDEODB_CONTENT_EPISODES;
-  if (pItem->HasVideoInfoTag() && !pItem->GetVideoInfoTag()->m_strArtist.IsEmpty())
+  if (pItem->HasVideoInfoTag() && !pItem->GetVideoInfoTag()->m_artist.empty())
     iType = VIDEODB_CONTENT_MUSICVIDEOS;
 
   // dont allow update while scanning
@@ -929,11 +930,11 @@ void CGUIWindowVideoNav::GetContextButtons(int itemNumber, CContextButtons &butt
     bool inPlaylists = m_vecItems->GetPath().Equals(CUtil::VideoPlaylistsLocation()) ||
                        m_vecItems->GetPath().Equals("special://videoplaylists/");
 
-    if (item->HasVideoInfoTag() && !item->GetVideoInfoTag()->m_strArtist.IsEmpty())
+    if (item->HasVideoInfoTag() && !item->GetVideoInfoTag()->m_artist.empty())
     {
       CMusicDatabase database;
       database.Open();
-      if (database.GetArtistByName(item->GetVideoInfoTag()->m_strArtist) > -1)
+      if (database.GetArtistByName(StringUtils::Join(item->GetVideoInfoTag()->m_artist, g_advancedSettings.m_videoItemSeparator)) > -1)
         buttons.Add(CONTEXT_BUTTON_GO_TO_ARTIST, 20396);
     }
     if (item->HasVideoInfoTag() && item->GetVideoInfoTag()->m_strAlbum.size() > 0)
@@ -944,12 +945,12 @@ void CGUIWindowVideoNav::GetContextButtons(int itemNumber, CContextButtons &butt
         buttons.Add(CONTEXT_BUTTON_GO_TO_ALBUM, 20397);
     }
     if (item->HasVideoInfoTag() && item->GetVideoInfoTag()->m_strAlbum.size() > 0 &&
-        item->GetVideoInfoTag()->m_strArtist.size() > 0                           &&
+        item->GetVideoInfoTag()->m_artist.size() > 0                              &&
         item->GetVideoInfoTag()->m_strTitle.size() > 0)
     {
       CMusicDatabase database;
       database.Open();
-      if (database.GetSongByArtistAndAlbumAndTitle(item->GetVideoInfoTag()->m_strArtist,
+      if (database.GetSongByArtistAndAlbumAndTitle(StringUtils::Join(item->GetVideoInfoTag()->m_artist, g_advancedSettings.m_videoItemSeparator),
                                                    item->GetVideoInfoTag()->m_strAlbum,
                                                    item->GetVideoInfoTag()->m_strTitle) > -1)
       {
@@ -1004,7 +1005,7 @@ void CGUIWindowVideoNav::GetContextButtons(int itemNumber, CContextButtons &butt
         }
         if (m_database.HasContent(VIDEODB_CONTENT_TVSHOWS) && item->HasVideoInfoTag() &&
            !item->m_bIsFolder && item->GetVideoInfoTag()->m_iEpisode == -1 &&
-            item->GetVideoInfoTag()->m_strArtist.IsEmpty() && item->GetVideoInfoTag()->m_iDbId >= 0) // movie entry
+            item->GetVideoInfoTag()->m_artist.empty() && item->GetVideoInfoTag()->m_iDbId >= 0) // movie entry
         {
           if (m_database.IsLinkedToTvshow(item->GetVideoInfoTag()->m_iDbId))
             buttons.Add(CONTEXT_BUTTON_UNLINK_MOVIE,20385);
@@ -1340,7 +1341,7 @@ bool CGUIWindowVideoNav::OnContextButton(int itemNumber, CONTEXT_BUTTON button)
       CStdString strPath;
       CMusicDatabase database;
       database.Open();
-      strPath.Format("musicdb://2/%ld/",database.GetArtistByName(m_vecItems->Get(itemNumber)->GetVideoInfoTag()->m_strArtist));
+      strPath.Format("musicdb://2/%ld/",database.GetArtistByName(StringUtils::Join(m_vecItems->Get(itemNumber)->GetVideoInfoTag()->m_artist, g_advancedSettings.m_videoItemSeparator)));
       g_windowManager.ActivateWindow(WINDOW_MUSIC_NAV,strPath);
       return true;
     }
@@ -1358,7 +1359,7 @@ bool CGUIWindowVideoNav::OnContextButton(int itemNumber, CONTEXT_BUTTON button)
       CMusicDatabase database;
       database.Open();
       CSong song;
-      if (database.GetSongById(database.GetSongByArtistAndAlbumAndTitle(m_vecItems->Get(itemNumber)->GetVideoInfoTag()->m_strArtist,m_vecItems->Get(itemNumber)->GetVideoInfoTag()->m_strAlbum,
+      if (database.GetSongById(database.GetSongByArtistAndAlbumAndTitle(StringUtils::Join(m_vecItems->Get(itemNumber)->GetVideoInfoTag()->m_artist, g_advancedSettings.m_videoItemSeparator),m_vecItems->Get(itemNumber)->GetVideoInfoTag()->m_strAlbum,
                                                                         m_vecItems->Get(itemNumber)->GetVideoInfoTag()->m_strTitle),
                                                                         song))
       {


### PR DESCRIPTION
Two changes here:
1. CVideoInfoTag::m_strArtist to use a vector (this one was missed in #394).
2. Support a list for artist for musicvideos in setInfo (previously not available at all).

@Montellese: I didn't like adding those headers to the AnnounceManager.  Your thoughts on allowing the array there instead?
