### PR TITLE
[windows] [libass] add harfbuzz support for Arabic shaping

### DIFF
--- a/lib/ffmpeg/libavcodec/avcodec.h
+++ b/lib/ffmpeg/libavcodec/avcodec.h
@@ -435,6 +435,7 @@ enum CodecID {
     CODEC_ID_BINTEXT    = MKBETAG('B','T','X','T'),
     CODEC_ID_XBIN       = MKBETAG('X','B','I','N'),
     CODEC_ID_IDF        = MKBETAG( 0 ,'I','D','F'),
+    CODEC_ID_OTF        = MKBETAG( 0 ,'O','T','F'),
 
     CODEC_ID_PROBE = 0x19000, ///< codec_id is not known (like CODEC_ID_NONE) but lavf should attempt to identify it
 

--- a/lib/ffmpeg/libavformat/matroska.c
+++ b/lib/ffmpeg/libavformat/matroska.c
@@ -90,6 +90,7 @@ const CodecMime ff_mkv_mime_tags[] = {
     {"image/tiff"                 , CODEC_ID_TIFF},
     {"application/x-truetype-font", CODEC_ID_TTF},
     {"application/x-font"         , CODEC_ID_TTF},
+    {"application/vnd.ms-opentype", CODEC_ID_OTF},
 
     {""                           , CODEC_ID_NONE}
 };

--- a/lib/ffmpeg/patches/0028-added-support-for-OTF-fonts.patch
+++ b/lib/ffmpeg/patches/0028-added-support-for-OTF-fonts.patch
@@ -1,0 +1,56 @@
+From 864acb01cc73762918794ddecf0fc2f7b6cf8529 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?S=C3=A9bastien=20Brochet?= <blinkseb@xbmc.org>
+Date: Sun, 15 Apr 2012 22:43:46 +0200
+Subject: [PATCH 1/3] added: support for OTF fonts
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+
+Signed-off-by: Sébastien Brochet <blinkseb@xbmc.org>
+---
+ lib/ffmpeg/libavcodec/avcodec.h                     |    1 +
+ lib/ffmpeg/libavformat/matroska.c                   |    1 +
+ xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxFFmpeg.cpp |    2 +-
+ 3 files changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/lib/ffmpeg/libavcodec/avcodec.h b/lib/ffmpeg/libavcodec/avcodec.h
+index 0b756d0..6996c92 100644
+--- a/lib/ffmpeg/libavcodec/avcodec.h
++++ b/lib/ffmpeg/libavcodec/avcodec.h
+@@ -435,6 +435,7 @@ enum CodecID {
+     CODEC_ID_BINTEXT    = MKBETAG('B','T','X','T'),
+     CODEC_ID_XBIN       = MKBETAG('X','B','I','N'),
+     CODEC_ID_IDF        = MKBETAG( 0 ,'I','D','F'),
++    CODEC_ID_OTF        = MKBETAG( 0 ,'O','T','F'),
+ 
+     CODEC_ID_PROBE = 0x19000, ///< codec_id is not known (like CODEC_ID_NONE) but lavf should attempt to identify it
+ 
+diff --git a/lib/ffmpeg/libavformat/matroska.c b/lib/ffmpeg/libavformat/matroska.c
+index 52481d7..2f5b617 100644
+--- a/lib/ffmpeg/libavformat/matroska.c
++++ b/lib/ffmpeg/libavformat/matroska.c
+@@ -90,6 +90,7 @@ const CodecMime ff_mkv_mime_tags[] = {
+     {"image/tiff"                 , CODEC_ID_TIFF},
+     {"application/x-truetype-font", CODEC_ID_TTF},
+     {"application/x-font"         , CODEC_ID_TTF},
++    {"application/vnd.ms-opentype", CODEC_ID_OTF},
+ 
+     {""                           , CODEC_ID_NONE}
+ };
+diff --git a/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxFFmpeg.cpp b/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+index 17cbd48..4524141 100644
+--- a/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
++++ b/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+@@ -1062,7 +1062,7 @@ void CDVDDemuxFFmpeg::AddStream(int iId)
+       }
+     case AVMEDIA_TYPE_ATTACHMENT:
+       { //mkv attachments. Only bothering with fonts for now.
+-        if(pStream->codec->codec_id == CODEC_ID_TTF)
++        if(pStream->codec->codec_id == CODEC_ID_TTF || pStream->codec->codec_id == CODEC_ID_OTF)
+         {
+           std::string fileName = "special://temp/fonts/";
+           XFILE::CDirectory::Create(fileName);
+-- 
+1.7.10.msysgit.1
+

--- a/lib/libass/libass/ass_shaper.c
+++ b/lib/libass/libass/ass_shaper.c
@@ -349,9 +349,11 @@ static hb_font_t *get_hb_font(ASS_Shaper *shaper, GlyphInfo *info)
 {
     ASS_Font *font = info->font;
     hb_font_t **hb_fonts;
+    struct ass_shaper_metrics_data *metrics;
+    hb_font_funcs_t *funcs;
 
     if (!font->shaper_priv)
-        font->shaper_priv = calloc(sizeof(ASS_ShaperFontData), 1);
+        font->shaper_priv = (ASS_ShaperFontData *) calloc(sizeof(ASS_ShaperFontData), 1);
 
 
     hb_fonts = font->shaper_priv->fonts;
@@ -360,14 +362,13 @@ static hb_font_t *get_hb_font(ASS_Shaper *shaper, GlyphInfo *info)
             hb_ft_font_create(font->faces[info->face_index], NULL);
 
         // set up cached metrics access
-        font->shaper_priv->metrics_data[info->face_index] =
+        font->shaper_priv->metrics_data[info->face_index] = (struct ass_shaper_metrics_data *)
             calloc(sizeof(struct ass_shaper_metrics_data), 1);
-        struct ass_shaper_metrics_data *metrics =
-            font->shaper_priv->metrics_data[info->face_index];
+        metrics = font->shaper_priv->metrics_data[info->face_index];
         metrics->metrics_cache = shaper->metrics_cache;
         metrics->vertical = info->font->desc.vertical;
 
-        hb_font_funcs_t *funcs = hb_font_funcs_create();
+        funcs = hb_font_funcs_create();
         font->shaper_priv->font_funcs[info->face_index] = funcs;
         hb_font_funcs_set_glyph_func(funcs, get_glyph,
                 metrics, NULL);
@@ -395,8 +396,7 @@ static hb_font_t *get_hb_font(ASS_Shaper *shaper, GlyphInfo *info)
     update_hb_size(hb_fonts[info->face_index], font->faces[info->face_index]);
 
     // update hash key for cached metrics
-    struct ass_shaper_metrics_data *metrics =
-        font->shaper_priv->metrics_data[info->face_index];
+    metrics = font->shaper_priv->metrics_data[info->face_index];
     metrics->hash_key.font = info->font;
     metrics->hash_key.face_index = info->face_index;
     metrics->hash_key.size = info->font_size;

--- a/lib/libass/libass/ass_utils.h
+++ b/lib/libass/libass/ass_utils.h
@@ -34,6 +34,12 @@
 
 #ifdef _WIN32
 #include "config.h"
+// This is needed in debug build. Without those defines, those 3 symbols are taken from msvcr100.dll, and free() from msvcr100d.dll
+// This cause a heap corruption each time a strdup is freed
+// See http://www.altdevblogaday.com/2011/08/02/a-journey-into-linker-hell-and-a-mistake/
+#define strdup _strdup
+#define stricmp _stricmp
+#define strnicmp _strnicmp
 #endif
 
 #define MSGL_FATAL 0

--- a/lib/libass/xbmc/libass_win32/libass_win32_vs2010.vcxproj
+++ b/lib/libass/xbmc/libass_win32/libass_win32_vs2010.vcxproj
@@ -56,7 +56,7 @@
     <ClCompile>
       <Optimization>Disabled</Optimization>
       <AdditionalIncludeDirectories>.\;..\..\..\enca\lib;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_USRDLL;LIBASS_WIN32_EXPORTS;_CRT_SECURE_NO_WARNINGS;_CRT_NONSTDC_NO_DEPRECATE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_USRDLL;LIBASS_WIN32_EXPORTS;CONFIG_HARFBUZZ;_CRT_SECURE_NO_WARNINGS;_CRT_NONSTDC_NO_DEPRECATE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MinimalRebuild>true</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
@@ -69,7 +69,7 @@
       <EnableEnhancedInstructionSet>StreamingSIMDExtensions</EnableEnhancedInstructionSet>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>fontconfig.lib;zlib.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>fontconfig.lib;zlib.lib;harfbuzz.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>$(OutDir)$(TargetName)$(TargetExt)</OutputFile>
       <IgnoreSpecificDefaultLibraries>libcmt;libcmtd;%(IgnoreSpecificDefaultLibraries)</IgnoreSpecificDefaultLibraries>
       <GenerateDebugInformation>true</GenerateDebugInformation>
@@ -95,7 +95,7 @@
     <ClCompile>
       <Optimization>Full</Optimization>
       <AdditionalIncludeDirectories>.\;..\..\..\enca\lib;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;_USRDLL;LIBASS_WIN32_EXPORTS;_CRT_SECURE_NO_WARNINGS;_CRT_NONSTDC_NO_DEPRECATE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;_USRDLL;LIBASS_WIN32_EXPORTS;CONFIG_HARFBUZZ;_CRT_SECURE_NO_WARNINGS;_CRT_NONSTDC_NO_DEPRECATE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <PrecompiledHeader>
       </PrecompiledHeader>
@@ -106,7 +106,7 @@
       <EnableEnhancedInstructionSet>StreamingSIMDExtensions</EnableEnhancedInstructionSet>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>fontconfig.lib;zlib.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>fontconfig.lib;zlib.lib;harfbuzz.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>$(OutDir)$(TargetName)$(TargetExt)</OutputFile>
       <IgnoreSpecificDefaultLibraries>libcmt;libcmtd;%(IgnoreSpecificDefaultLibraries)</IgnoreSpecificDefaultLibraries>
       <GenerateDebugInformation>true</GenerateDebugInformation>

--- a/project/BuildDependencies/scripts/harfbuzz_d.bat
+++ b/project/BuildDependencies/scripts/harfbuzz_d.bat
@@ -1,0 +1,13 @@
+@ECHO ON
+
+SET LOC_PATH=%CD%
+SET FILES=%LOC_PATH%\harfbuzz_d.txt
+
+CALL dlextract.bat harfbuzz %FILES%
+
+cd %TMP_PATH%
+
+xcopy harfbuzz-0.7.0\include\* "%CUR_PATH%\include\" /E /Q /I /Y
+copy  harfbuzz-0.7.0\lib\harfbuzz.lib "%CUR_PATH%\lib\" /Y
+
+cd %LOC_PATH%

--- a/project/BuildDependencies/scripts/harfbuzz_d.txt
+++ b/project/BuildDependencies/scripts/harfbuzz_d.txt
@@ -1,0 +1,2 @@
+; filename                   mirror of the file
+harfbuzz-0.7.0.7z    http://mirrors.xbmc.org/build-deps/win32/

--- a/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -1060,7 +1060,7 @@ void CDVDDemuxFFmpeg::AddStream(int iId)
       }
     case AVMEDIA_TYPE_ATTACHMENT:
       { //mkv attachments. Only bothering with fonts for now.
-        if(pStream->codec->codec_id == CODEC_ID_TTF)
+        if(pStream->codec->codec_id == CODEC_ID_TTF || pStream->codec->codec_id == CODEC_ID_OTF)
         {
           std::string fileName = "special://temp/fonts/";
           XFILE::CDirectory::Create(fileName);


### PR DESCRIPTION
This PR adds support for harfbuff in our libass. Harfbuff brings proper support for Arabic shaping in ass subtitles.

The first commit is not mandatory, but it seems like most Arabic mkv embed an OTF font instead of TTF.

Only for Windows.
