### PR TITLE
cec - libCEC 1.7 and firmware v2 support (for wake over CEC)

### DIFF
--- a/addons/skin.confluence/720p/DialogPeripheralManager.xml
+++ b/addons/skin.confluence/720p/DialogPeripheralManager.xml
@@ -117,7 +117,7 @@
 						<posy>50</posy>
 						<width>520</width>
 						<height>20</height>
-						<label>$LOCALIZE[35501]:  [COLOR=grey2]$INFO[ListItem.Property(Class)][/COLOR]</label>
+						<label>$LOCALIZE[35501]:  [COLOR=grey2]$INFO[ListItem.Property(Class)][/COLOR]     $LOCALIZE[19114]:  [COLOR=grey2]$INFO[ListItem.Property(Version)][/COLOR]</label>
 						<align>left</align>
 						<aligny>center</aligny>
 						<font>font12</font>
@@ -173,7 +173,7 @@
 						<posy>50</posy>
 						<width>520</width>
 						<height>20</height>
-						<label>$LOCALIZE[35501]:  [COLOR=grey2]$INFO[ListItem.Property(Class)][/COLOR]</label>
+						<label>$LOCALIZE[35501]:  [COLOR=grey2]$INFO[ListItem.Property(Class)][/COLOR]     $LOCALIZE[19114]:  [COLOR=grey2]$INFO[ListItem.Property(Version)][/COLOR]</label>
 						<align>left</align>
 						<aligny>center</aligny>
 						<font>font12</font>

--- a/configure.in
+++ b/configure.in
@@ -1258,7 +1258,7 @@ if test "x$use_libcec" != "xno"; then
 
   # libcec is dyloaded, so we need to check for its headers and link any depends.
   if test "x$use_libcec" != "xno"; then
-    PKG_CHECK_MODULES([CEC],[libcec >= 1.5.0],,[use_libcec="no";AC_MSG_RESULT($libcec_disabled)])
+    PKG_CHECK_MODULES([CEC],[libcec >= 1.7.0],,[use_libcec="no";AC_MSG_RESULT($libcec_disabled)])
 
     if test "x$use_libcec" != "xno"; then
       INCLUDES="$INCLUDES $CEC_CFLAGS"

--- a/language/Afrikaans/strings.po
+++ b/language/Afrikaans/strings.po
@@ -8862,19 +8862,15 @@ msgid "Put devices in standby mode when activating screensaver"
 msgstr ""
 
 msgctxt "#36011"
-msgid "Could not detect the CEC port. Set it up manually."
+msgid "Could not detect the CEC com port. Set it up manually."
 msgstr ""
 
 msgctxt "#36012"
-msgid "Could not initialise the CEC adapter. Check your settings."
+msgid "Could not initialise the CEC adapter. Please check your settings."
 msgstr ""
 
 msgctxt "#36013"
 msgid "Unsupported libCEC interface version. %d is greater than the version XBMC supports (%d)"
-msgstr ""
-
-msgctxt "#36014"
-msgid "Put this PC in standby mode when the TV is switched off"
 msgstr ""
 
 msgctxt "#36015"
@@ -8886,7 +8882,7 @@ msgid "Connected"
 msgstr ""
 
 msgctxt "#36017"
-msgid "Adapter found, but libCEC is not available"
+msgid "Could not initialise the CEC adapter: libCEC was not found on your system."
 msgstr ""
 
 msgctxt "#36018"
@@ -8919,5 +8915,33 @@ msgstr ""
 
 msgctxt "#36025"
 msgid "Send 'inactive source' command when stopping XBMC"
+msgstr ""
+
+msgctxt "#36026"
+msgid "Put devices in standby mode when putting the PC in standby"
+msgstr ""
+
+msgctxt "#36027"
+msgid "This device needs servicing"
+msgstr ""
+
+msgctxt "#36028"
+msgid "Ignore"
+msgstr ""
+
+msgctxt "#36029"
+msgid "When the TV is switched off"
+msgstr ""
+
+msgctxt "#36030"
+msgid "Connection lost"
+msgstr ""
+
+msgctxt "#36031"
+msgid "This user does not have permissions to open the CEC adapter"
+msgstr ""
+
+msgctxt "#36032"
+msgid "The port is busy. Only one program can access the CEC adapter"
 msgstr ""
 

--- a/language/Arabic/strings.po
+++ b/language/Arabic/strings.po
@@ -8862,19 +8862,15 @@ msgid "Put devices in standby mode when activating screensaver"
 msgstr "وضع الأجهزة في وضع الاستعداد عند تنشيط شاشة التوقف"
 
 msgctxt "#36011"
-msgid "Could not detect the CEC port. Set it up manually."
+msgid "Could not detect the CEC com port. Set it up manually."
 msgstr ""
 
 msgctxt "#36012"
-msgid "Could not initialise the CEC adapter. Check your settings."
+msgid "Could not initialise the CEC adapter. Please check your settings."
 msgstr ""
 
 msgctxt "#36013"
 msgid "Unsupported libCEC interface version. %d is greater than the version XBMC supports (%d)"
-msgstr ""
-
-msgctxt "#36014"
-msgid "Put this PC in standby mode when the TV is switched off"
 msgstr ""
 
 msgctxt "#36015"
@@ -8886,7 +8882,7 @@ msgid "Connected"
 msgstr "متصل"
 
 msgctxt "#36017"
-msgid "Adapter found, but libCEC is not available"
+msgid "Could not initialise the CEC adapter: libCEC was not found on your system."
 msgstr "غير متوفر libcec تم العثور على الارتباط, ولكن"
 
 msgctxt "#36018"
@@ -8919,5 +8915,33 @@ msgstr ""
 
 msgctxt "#36025"
 msgid "Send 'inactive source' command when stopping XBMC"
+msgstr ""
+
+msgctxt "#36026"
+msgid "Put devices in standby mode when putting the PC in standby"
+msgstr ""
+
+msgctxt "#36027"
+msgid "This device needs servicing"
+msgstr ""
+
+msgctxt "#36028"
+msgid "Ignore"
+msgstr ""
+
+msgctxt "#36029"
+msgid "When the TV is switched off"
+msgstr ""
+
+msgctxt "#36030"
+msgid "Connection lost"
+msgstr ""
+
+msgctxt "#36031"
+msgid "This user does not have permissions to open the CEC adapter"
+msgstr ""
+
+msgctxt "#36032"
+msgid "The port is busy. Only one program can access the CEC adapter"
 msgstr ""
 

--- a/language/Basque/strings.po
+++ b/language/Basque/strings.po
@@ -8862,19 +8862,15 @@ msgid "Put devices in standby mode when activating screensaver"
 msgstr ""
 
 msgctxt "#36011"
-msgid "Could not detect the CEC port. Set it up manually."
+msgid "Could not detect the CEC com port. Set it up manually."
 msgstr ""
 
 msgctxt "#36012"
-msgid "Could not initialise the CEC adapter. Check your settings."
+msgid "Could not initialise the CEC adapter. Please check your settings."
 msgstr ""
 
 msgctxt "#36013"
 msgid "Unsupported libCEC interface version. %d is greater than the version XBMC supports (%d)"
-msgstr ""
-
-msgctxt "#36014"
-msgid "Put this PC in standby mode when the TV is switched off"
 msgstr ""
 
 msgctxt "#36015"
@@ -8886,7 +8882,7 @@ msgid "Connected"
 msgstr ""
 
 msgctxt "#36017"
-msgid "Adapter found, but libCEC is not available"
+msgid "Could not initialise the CEC adapter: libCEC was not found on your system."
 msgstr ""
 
 msgctxt "#36018"
@@ -8919,5 +8915,33 @@ msgstr ""
 
 msgctxt "#36025"
 msgid "Send 'inactive source' command when stopping XBMC"
+msgstr ""
+
+msgctxt "#36026"
+msgid "Put devices in standby mode when putting the PC in standby"
+msgstr ""
+
+msgctxt "#36027"
+msgid "This device needs servicing"
+msgstr ""
+
+msgctxt "#36028"
+msgid "Ignore"
+msgstr ""
+
+msgctxt "#36029"
+msgid "When the TV is switched off"
+msgstr ""
+
+msgctxt "#36030"
+msgid "Connection lost"
+msgstr ""
+
+msgctxt "#36031"
+msgid "This user does not have permissions to open the CEC adapter"
+msgstr ""
+
+msgctxt "#36032"
+msgid "The port is busy. Only one program can access the CEC adapter"
 msgstr ""
 

--- a/language/Bosnian/strings.po
+++ b/language/Bosnian/strings.po
@@ -8862,19 +8862,15 @@ msgid "Put devices in standby mode when activating screensaver"
 msgstr ""
 
 msgctxt "#36011"
-msgid "Could not detect the CEC port. Set it up manually."
+msgid "Could not detect the CEC com port. Set it up manually."
 msgstr ""
 
 msgctxt "#36012"
-msgid "Could not initialise the CEC adapter. Check your settings."
+msgid "Could not initialise the CEC adapter. Please check your settings."
 msgstr ""
 
 msgctxt "#36013"
 msgid "Unsupported libCEC interface version. %d is greater than the version XBMC supports (%d)"
-msgstr ""
-
-msgctxt "#36014"
-msgid "Put this PC in standby mode when the TV is switched off"
 msgstr ""
 
 msgctxt "#36015"
@@ -8886,7 +8882,7 @@ msgid "Connected"
 msgstr ""
 
 msgctxt "#36017"
-msgid "Adapter found, but libCEC is not available"
+msgid "Could not initialise the CEC adapter: libCEC was not found on your system."
 msgstr ""
 
 msgctxt "#36018"
@@ -8919,5 +8915,33 @@ msgstr ""
 
 msgctxt "#36025"
 msgid "Send 'inactive source' command when stopping XBMC"
+msgstr ""
+
+msgctxt "#36026"
+msgid "Put devices in standby mode when putting the PC in standby"
+msgstr ""
+
+msgctxt "#36027"
+msgid "This device needs servicing"
+msgstr ""
+
+msgctxt "#36028"
+msgid "Ignore"
+msgstr ""
+
+msgctxt "#36029"
+msgid "When the TV is switched off"
+msgstr ""
+
+msgctxt "#36030"
+msgid "Connection lost"
+msgstr ""
+
+msgctxt "#36031"
+msgid "This user does not have permissions to open the CEC adapter"
+msgstr ""
+
+msgctxt "#36032"
+msgid "The port is busy. Only one program can access the CEC adapter"
 msgstr ""
 

--- a/language/Bulgarian/strings.po
+++ b/language/Bulgarian/strings.po
@@ -8862,20 +8862,16 @@ msgid "Put devices in standby mode when activating screensaver"
 msgstr "Сложи устройствата на стендбай, когато се активира скрийнсейвър"
 
 msgctxt "#36011"
-msgid "Could not detect the CEC port. Set it up manually."
+msgid "Could not detect the CEC com port. Set it up manually."
 msgstr "Не мога да открия  порт CEC. Настройте ръчно."
 
 msgctxt "#36012"
-msgid "Could not initialise the CEC adapter. Check your settings."
+msgid "Could not initialise the CEC adapter. Please check your settings."
 msgstr "Не мога да открия  адаптер CEC."
 
 msgctxt "#36013"
 msgid "Unsupported libCEC interface version. %d is greater than the version XBMC supports (%d)"
 msgstr "Неподдържана libcec интерфейс версия. %d е по-голяма от поддържаната от XBMC (%d)"
-
-msgctxt "#36014"
-msgid "Put this PC in standby mode when the TV is switched off"
-msgstr "Компютъра на стендбай, когато телевизора е изключен"
 
 msgctxt "#36015"
 msgid "HDMI port number"
@@ -8886,7 +8882,7 @@ msgid "Connected"
 msgstr "Свързан"
 
 msgctxt "#36017"
-msgid "Adapter found, but libCEC is not available"
+msgid "Could not initialise the CEC adapter: libCEC was not found on your system."
 msgstr "Адаптера е намерен, но libcec не е достъпен"
 
 msgctxt "#36018"
@@ -8919,5 +8915,33 @@ msgstr ""
 
 msgctxt "#36025"
 msgid "Send 'inactive source' command when stopping XBMC"
+msgstr ""
+
+msgctxt "#36026"
+msgid "Put devices in standby mode when putting the PC in standby"
+msgstr ""
+
+msgctxt "#36027"
+msgid "This device needs servicing"
+msgstr ""
+
+msgctxt "#36028"
+msgid "Ignore"
+msgstr ""
+
+msgctxt "#36029"
+msgid "When the TV is switched off"
+msgstr ""
+
+msgctxt "#36030"
+msgid "Connection lost"
+msgstr ""
+
+msgctxt "#36031"
+msgid "This user does not have permissions to open the CEC adapter"
+msgstr ""
+
+msgctxt "#36032"
+msgid "The port is busy. Only one program can access the CEC adapter"
 msgstr ""
 

--- a/language/Catalan/strings.po
+++ b/language/Catalan/strings.po
@@ -8823,59 +8823,55 @@ msgstr "Product ID"
 
 msgctxt "#36000"
 msgid "Pulse-Eight CEC adapter"
-msgstr "Pulse-Eight CEC adapter"
+msgstr ""
 
 msgctxt "#36001"
 msgid "Pulse-Eight Nyxboard"
-msgstr "Pulse-Eight Nyxboard"
+msgstr ""
 
 msgctxt "#36002"
 msgid "Switch to keyboard side command"
-msgstr "Switch to keyboard side command"
+msgstr ""
 
 msgctxt "#36003"
 msgid "Switch to remote side command"
-msgstr "Switch to remote side command"
+msgstr ""
 
 msgctxt "#36004"
 msgid "Press \"user\" button command"
-msgstr "Press \"user\" button command"
+msgstr ""
 
 msgctxt "#36005"
 msgid "Enable switch side commands"
-msgstr "Enable switch side commands"
+msgstr ""
 
 msgctxt "#36006"
 msgid "Could not open the adapter"
-msgstr "Could not open the adapter"
+msgstr ""
 
 msgctxt "#36007"
 msgid "Devices to power on when starting XBMC"
-msgstr "Power on the TV when starting XBMC"
+msgstr ""
 
 msgctxt "#36008"
 msgid "Devices to power off when stopping XBMC"
-msgstr "Power off devices when stopping XBMC"
+msgstr ""
 
 msgctxt "#36009"
 msgid "Put devices in standby mode when activating screensaver"
-msgstr "Put devices in standby mode when activating screensaver"
+msgstr ""
 
 msgctxt "#36011"
-msgid "Could not detect the CEC port. Set it up manually."
-msgstr "Could not detect the CEC port. Set it up manually."
+msgid "Could not detect the CEC com port. Set it up manually."
+msgstr ""
 
 msgctxt "#36012"
-msgid "Could not initialise the CEC adapter. Check your settings."
-msgstr "Could not detect the CEC adapter."
+msgid "Could not initialise the CEC adapter. Please check your settings."
+msgstr ""
 
 msgctxt "#36013"
 msgid "Unsupported libCEC interface version. %d is greater than the version XBMC supports (%d)"
-msgstr "Unsupported libcec interface version. %d is greater than the version XBMC supports (%d)"
-
-msgctxt "#36014"
-msgid "Put this PC in standby mode when the TV is switched off"
-msgstr "Put this PC in standby mode when the TV is switched off"
+msgstr ""
 
 msgctxt "#36015"
 msgid "HDMI port number"
@@ -8886,12 +8882,12 @@ msgid "Connected"
 msgstr "Connectat"
 
 msgctxt "#36017"
-msgid "Adapter found, but libCEC is not available"
+msgid "Could not initialise the CEC adapter: libCEC was not found on your system."
 msgstr "S'ha trobat un adaptador, però la libcec no està disponible"
 
 msgctxt "#36018"
 msgid "Use the TV's language setting"
-msgstr "Use the TV's language setting"
+msgstr ""
 
 msgctxt "#36019"
 msgid "Connected to HDMI device"
@@ -8919,5 +8915,33 @@ msgstr ""
 
 msgctxt "#36025"
 msgid "Send 'inactive source' command when stopping XBMC"
+msgstr ""
+
+msgctxt "#36026"
+msgid "Put devices in standby mode when putting the PC in standby"
+msgstr ""
+
+msgctxt "#36027"
+msgid "This device needs servicing"
+msgstr ""
+
+msgctxt "#36028"
+msgid "Ignore"
+msgstr ""
+
+msgctxt "#36029"
+msgid "When the TV is switched off"
+msgstr ""
+
+msgctxt "#36030"
+msgid "Connection lost"
+msgstr ""
+
+msgctxt "#36031"
+msgid "This user does not have permissions to open the CEC adapter"
+msgstr ""
+
+msgctxt "#36032"
+msgid "The port is busy. Only one program can access the CEC adapter"
 msgstr ""
 

--- a/language/Chinese (Simple)/strings.po
+++ b/language/Chinese (Simple)/strings.po
@@ -8862,20 +8862,16 @@ msgid "Put devices in standby mode when activating screensaver"
 msgstr "激活屏幕保护程序时设备进入待机状态"
 
 msgctxt "#36011"
-msgid "Could not detect the CEC port. Set it up manually."
+msgid "Could not detect the CEC com port. Set it up manually."
 msgstr "未检测到 CEC 端口。需人工设置。"
 
 msgctxt "#36012"
-msgid "Could not initialise the CEC adapter. Check your settings."
+msgid "Could not initialise the CEC adapter. Please check your settings."
 msgstr "无法初始化 CEC 适配器。请检查设置"
 
 msgctxt "#36013"
 msgid "Unsupported libCEC interface version. %d is greater than the version XBMC supports (%d)"
 msgstr "不支持的 libcec 界面版本。%d 高于 XBMC 支持的版本（%d）"
-
-msgctxt "#36014"
-msgid "Put this PC in standby mode when the TV is switched off"
-msgstr "电视关闭时本计算机进入待机状态"
 
 msgctxt "#36015"
 msgid "HDMI port number"
@@ -8886,7 +8882,7 @@ msgid "Connected"
 msgstr "XBMC 已连接"
 
 msgctxt "#36017"
-msgid "Adapter found, but libCEC is not available"
+msgid "Could not initialise the CEC adapter: libCEC was not found on your system."
 msgstr "发现适配器，但 libCEC 不可用"
 
 msgctxt "#36018"
@@ -8920,4 +8916,32 @@ msgstr "新配置设定失败，请检查设置。"
 msgctxt "#36025"
 msgid "Send 'inactive source' command when stopping XBMC"
 msgstr "停止 XBMC 时发送“非活动源”命令"
+
+msgctxt "#36026"
+msgid "Put devices in standby mode when putting the PC in standby"
+msgstr ""
+
+msgctxt "#36027"
+msgid "This device needs servicing"
+msgstr ""
+
+msgctxt "#36028"
+msgid "Ignore"
+msgstr ""
+
+msgctxt "#36029"
+msgid "When the TV is switched off"
+msgstr ""
+
+msgctxt "#36030"
+msgid "Connection lost"
+msgstr ""
+
+msgctxt "#36031"
+msgid "This user does not have permissions to open the CEC adapter"
+msgstr ""
+
+msgctxt "#36032"
+msgid "The port is busy. Only one program can access the CEC adapter"
+msgstr ""
 

--- a/language/Chinese (Traditional)/strings.po
+++ b/language/Chinese (Traditional)/strings.po
@@ -8862,20 +8862,16 @@ msgid "Put devices in standby mode when activating screensaver"
 msgstr "螢幕保護啟動時讓裝置進入待機模式"
 
 msgctxt "#36011"
-msgid "Could not detect the CEC port. Set it up manually."
+msgid "Could not detect the CEC com port. Set it up manually."
 msgstr "無法偵測CEC連接埠。請手動設定。"
 
 msgctxt "#36012"
-msgid "Could not initialise the CEC adapter. Check your settings."
+msgid "Could not initialise the CEC adapter. Please check your settings."
 msgstr "無法偵測CEC配接器"
 
 msgctxt "#36013"
 msgid "Unsupported libCEC interface version. %d is greater than the version XBMC supports (%d)"
 msgstr "不支援的 libcec 介面版本。 %d 大於XBMC支援的版本 (%d)"
-
-msgctxt "#36014"
-msgid "Put this PC in standby mode when the TV is switched off"
-msgstr "如果關掉這台電視，讓這台電腦進入待機模式"
 
 msgctxt "#36015"
 msgid "HDMI port number"
@@ -8886,7 +8882,7 @@ msgid "Connected"
 msgstr "已連接"
 
 msgctxt "#36017"
-msgid "Adapter found, but libCEC is not available"
+msgid "Could not initialise the CEC adapter: libCEC was not found on your system."
 msgstr "找到配接器，但無法取得 libcec"
 
 msgctxt "#36018"
@@ -8919,5 +8915,33 @@ msgstr ""
 
 msgctxt "#36025"
 msgid "Send 'inactive source' command when stopping XBMC"
+msgstr ""
+
+msgctxt "#36026"
+msgid "Put devices in standby mode when putting the PC in standby"
+msgstr ""
+
+msgctxt "#36027"
+msgid "This device needs servicing"
+msgstr ""
+
+msgctxt "#36028"
+msgid "Ignore"
+msgstr ""
+
+msgctxt "#36029"
+msgid "When the TV is switched off"
+msgstr ""
+
+msgctxt "#36030"
+msgid "Connection lost"
+msgstr ""
+
+msgctxt "#36031"
+msgid "This user does not have permissions to open the CEC adapter"
+msgstr ""
+
+msgctxt "#36032"
+msgid "The port is busy. Only one program can access the CEC adapter"
 msgstr ""
 

--- a/language/Croatian/strings.po
+++ b/language/Croatian/strings.po
@@ -8862,19 +8862,15 @@ msgid "Put devices in standby mode when activating screensaver"
 msgstr ""
 
 msgctxt "#36011"
-msgid "Could not detect the CEC port. Set it up manually."
+msgid "Could not detect the CEC com port. Set it up manually."
 msgstr ""
 
 msgctxt "#36012"
-msgid "Could not initialise the CEC adapter. Check your settings."
+msgid "Could not initialise the CEC adapter. Please check your settings."
 msgstr ""
 
 msgctxt "#36013"
 msgid "Unsupported libCEC interface version. %d is greater than the version XBMC supports (%d)"
-msgstr ""
-
-msgctxt "#36014"
-msgid "Put this PC in standby mode when the TV is switched off"
 msgstr ""
 
 msgctxt "#36015"
@@ -8886,7 +8882,7 @@ msgid "Connected"
 msgstr ""
 
 msgctxt "#36017"
-msgid "Adapter found, but libCEC is not available"
+msgid "Could not initialise the CEC adapter: libCEC was not found on your system."
 msgstr ""
 
 msgctxt "#36018"
@@ -8919,5 +8915,33 @@ msgstr ""
 
 msgctxt "#36025"
 msgid "Send 'inactive source' command when stopping XBMC"
+msgstr ""
+
+msgctxt "#36026"
+msgid "Put devices in standby mode when putting the PC in standby"
+msgstr ""
+
+msgctxt "#36027"
+msgid "This device needs servicing"
+msgstr ""
+
+msgctxt "#36028"
+msgid "Ignore"
+msgstr ""
+
+msgctxt "#36029"
+msgid "When the TV is switched off"
+msgstr ""
+
+msgctxt "#36030"
+msgid "Connection lost"
+msgstr ""
+
+msgctxt "#36031"
+msgid "This user does not have permissions to open the CEC adapter"
+msgstr ""
+
+msgctxt "#36032"
+msgid "The port is busy. Only one program can access the CEC adapter"
 msgstr ""
 

--- a/language/Czech/strings.po
+++ b/language/Czech/strings.po
@@ -8862,20 +8862,16 @@ msgid "Put devices in standby mode when activating screensaver"
 msgstr "Uvést zařízení do pohotovostního režimu při aktivování spořiče obrazovky"
 
 msgctxt "#36011"
-msgid "Could not detect the CEC port. Set it up manually."
+msgid "Could not detect the CEC com port. Set it up manually."
 msgstr "Nepodařilo se najít CEC port. Nastavte jej ručně."
 
 msgctxt "#36012"
-msgid "Could not initialise the CEC adapter. Check your settings."
+msgid "Could not initialise the CEC adapter. Please check your settings."
 msgstr "Nepodařilo se najít CEC adaptér."
 
 msgctxt "#36013"
 msgid "Unsupported libCEC interface version. %d is greater than the version XBMC supports (%d)"
 msgstr "Nepodporovaná verze libcec rozhraní. %d je vyšší než verze podporovaná XBMC (%d)"
-
-msgctxt "#36014"
-msgid "Put this PC in standby mode when the TV is switched off"
-msgstr "Při vypnutí TV uspat tento počítač"
 
 msgctxt "#36015"
 msgid "HDMI port number"
@@ -8886,7 +8882,7 @@ msgid "Connected"
 msgstr "Připojeno"
 
 msgctxt "#36017"
-msgid "Adapter found, but libCEC is not available"
+msgid "Could not initialise the CEC adapter: libCEC was not found on your system."
 msgstr "Adaptér byl nalezen, ale libcec není k dispozici"
 
 msgctxt "#36018"
@@ -8920,4 +8916,32 @@ msgstr "Načtení nového nastavení selhalo. Prosím zkontrolujte Vaše nastave
 msgctxt "#36025"
 msgid "Send 'inactive source' command when stopping XBMC"
 msgstr "Poslat příkaz 'neaktivní zdroj' při vypnutí XMBC"
+
+msgctxt "#36026"
+msgid "Put devices in standby mode when putting the PC in standby"
+msgstr ""
+
+msgctxt "#36027"
+msgid "This device needs servicing"
+msgstr ""
+
+msgctxt "#36028"
+msgid "Ignore"
+msgstr ""
+
+msgctxt "#36029"
+msgid "When the TV is switched off"
+msgstr ""
+
+msgctxt "#36030"
+msgid "Connection lost"
+msgstr ""
+
+msgctxt "#36031"
+msgid "This user does not have permissions to open the CEC adapter"
+msgstr ""
+
+msgctxt "#36032"
+msgid "The port is busy. Only one program can access the CEC adapter"
+msgstr ""
 

--- a/language/Danish/strings.po
+++ b/language/Danish/strings.po
@@ -8862,19 +8862,15 @@ msgid "Put devices in standby mode when activating screensaver"
 msgstr ""
 
 msgctxt "#36011"
-msgid "Could not detect the CEC port. Set it up manually."
+msgid "Could not detect the CEC com port. Set it up manually."
 msgstr ""
 
 msgctxt "#36012"
-msgid "Could not initialise the CEC adapter. Check your settings."
+msgid "Could not initialise the CEC adapter. Please check your settings."
 msgstr ""
 
 msgctxt "#36013"
 msgid "Unsupported libCEC interface version. %d is greater than the version XBMC supports (%d)"
-msgstr ""
-
-msgctxt "#36014"
-msgid "Put this PC in standby mode when the TV is switched off"
 msgstr ""
 
 msgctxt "#36015"
@@ -8886,7 +8882,7 @@ msgid "Connected"
 msgstr ""
 
 msgctxt "#36017"
-msgid "Adapter found, but libCEC is not available"
+msgid "Could not initialise the CEC adapter: libCEC was not found on your system."
 msgstr ""
 
 msgctxt "#36018"
@@ -8919,5 +8915,33 @@ msgstr ""
 
 msgctxt "#36025"
 msgid "Send 'inactive source' command when stopping XBMC"
+msgstr ""
+
+msgctxt "#36026"
+msgid "Put devices in standby mode when putting the PC in standby"
+msgstr ""
+
+msgctxt "#36027"
+msgid "This device needs servicing"
+msgstr ""
+
+msgctxt "#36028"
+msgid "Ignore"
+msgstr ""
+
+msgctxt "#36029"
+msgid "When the TV is switched off"
+msgstr ""
+
+msgctxt "#36030"
+msgid "Connection lost"
+msgstr ""
+
+msgctxt "#36031"
+msgid "This user does not have permissions to open the CEC adapter"
+msgstr ""
+
+msgctxt "#36032"
+msgid "The port is busy. Only one program can access the CEC adapter"
 msgstr ""
 

--- a/language/Dutch/strings.po
+++ b/language/Dutch/strings.po
@@ -8845,7 +8845,7 @@ msgstr "Keymap ingeschakeld"
 
 msgctxt "#35009"
 msgid "Do not use the custom keymap for this device"
-msgstr ""
+msgstr "Gebruik geen aangepaste keymap voor dit apparaat"
 
 msgctxt "#35500"
 msgid "Location"
@@ -8908,20 +8908,16 @@ msgid "Put devices in standby mode when activating screensaver"
 msgstr "Schakel app. uit zolang de schermbeveiliging actief is"
 
 msgctxt "#36011"
-msgid "Could not detect the CEC port. Set it up manually."
+msgid "Could not detect the CEC com port. Set it up manually."
 msgstr "Kon de COM poort niet detecteren. Stel het manueel in."
 
 msgctxt "#36012"
-msgid "Could not initialise the CEC adapter. Check your settings."
-msgstr "Kon de CEC adapter niet initialiseren."
+msgid "Could not initialise the CEC adapter. Please check your settings."
+msgstr "Kon de CEC adapter niet initialiseren. Controleer de instellingen."
 
 msgctxt "#36013"
 msgid "Unsupported libCEC interface version. %d is greater than the version XBMC supports (%d)"
 msgstr "Versie %d van de libCEC interface version wordt niet ondersteund door XBMC (> %d)"
-
-msgctxt "#36014"
-msgid "Put this PC in standby mode when the TV is switched off"
-msgstr "Zet XBMC in standby wanneer de TV uitgeschakeld wordt"
 
 msgctxt "#36015"
 msgid "HDMI port number"
@@ -8932,8 +8928,8 @@ msgid "Connected"
 msgstr "Verbonden"
 
 msgctxt "#36017"
-msgid "Adapter found, but libCEC is not available"
-msgstr "Adapter gevonden, maar libCEC is niet beschikbaar"
+msgid "Could not initialise the CEC adapter: libCEC was not found on your system."
+msgstr "Kon de CEC adapter niet initialiseren: libCEC is niet gevonden op dit systeem."
 
 msgctxt "#36018"
 msgid "Use the TV's language setting"
@@ -8966,4 +8962,32 @@ msgstr "Kon de nieuwe configuratie niet instellen. Controleer de instellingen."
 msgctxt "#36025"
 msgid "Send 'inactive source' command when stopping XBMC"
 msgstr "Verstuur 'inactieve bron' commando bij het stoppen"
+
+msgctxt "#36026"
+msgid "Put devices in standby mode when putting the PC in standby"
+msgstr "Schakel apparatuur uit wanneer de PC in slaapstand gaat"
+
+msgctxt "#36027"
+msgid "This device needs servicing"
+msgstr "Dit apparaat heeft onderhoud nodig"
+
+msgctxt "#36028"
+msgid "Ignore"
+msgstr "Negeer"
+
+msgctxt "#36029"
+msgid "When the TV is switched off"
+msgstr "Wanneer de TV uitgeschakeld wordt"
+
+msgctxt "#36030"
+msgid "Connection lost"
+msgstr "Verbinding verbroken"
+
+msgctxt "#36031"
+msgid "This user does not have permissions to open the CEC adapter"
+msgstr ""
+
+msgctxt "#36032"
+msgid "The port is busy. Only one program can access the CEC adapter"
+msgstr ""
 

--- a/language/English (US)/strings.po
+++ b/language/English (US)/strings.po
@@ -8862,19 +8862,15 @@ msgid "Put devices in standby mode when activating screensaver"
 msgstr ""
 
 msgctxt "#36011"
-msgid "Could not detect the CEC port. Set it up manually."
+msgid "Could not detect the CEC com port. Set it up manually."
 msgstr ""
 
 msgctxt "#36012"
-msgid "Could not initialise the CEC adapter. Check your settings."
+msgid "Could not initialise the CEC adapter. Please check your settings."
 msgstr ""
 
 msgctxt "#36013"
 msgid "Unsupported libCEC interface version. %d is greater than the version XBMC supports (%d)"
-msgstr ""
-
-msgctxt "#36014"
-msgid "Put this PC in standby mode when the TV is switched off"
 msgstr ""
 
 msgctxt "#36015"
@@ -8886,7 +8882,7 @@ msgid "Connected"
 msgstr ""
 
 msgctxt "#36017"
-msgid "Adapter found, but libCEC is not available"
+msgid "Could not initialise the CEC adapter: libCEC was not found on your system."
 msgstr ""
 
 msgctxt "#36018"
@@ -8919,5 +8915,33 @@ msgstr ""
 
 msgctxt "#36025"
 msgid "Send 'inactive source' command when stopping XBMC"
+msgstr ""
+
+msgctxt "#36026"
+msgid "Put devices in standby mode when putting the PC in standby"
+msgstr ""
+
+msgctxt "#36027"
+msgid "This device needs servicing"
+msgstr ""
+
+msgctxt "#36028"
+msgid "Ignore"
+msgstr ""
+
+msgctxt "#36029"
+msgid "When the TV is switched off"
+msgstr ""
+
+msgctxt "#36030"
+msgid "Connection lost"
+msgstr ""
+
+msgctxt "#36031"
+msgid "This user does not have permissions to open the CEC adapter"
+msgstr ""
+
+msgctxt "#36032"
+msgid "The port is busy. Only one program can access the CEC adapter"
 msgstr ""
 

--- a/language/English/strings.po
+++ b/language/English/strings.po
@@ -9361,20 +9361,18 @@ msgstr ""
 #empty string with id 36010
 
 msgctxt "#36011"
-msgid "Could not detect the CEC port. Set it up manually."
+msgid "Could not detect the CEC com port. Set it up manually."
 msgstr ""
 
 msgctxt "#36012"
-msgid "Could not initialise the CEC adapter. Check your settings."
+msgid "Could not initialise the CEC adapter. Please check your settings."
 msgstr ""
 
 msgctxt "#36013"
 msgid "Unsupported libCEC interface version. %d is greater than the version XBMC supports (%d)"
 msgstr ""
 
-msgctxt "#36014"
-msgid "Put this PC in standby mode when the TV is switched off"
-msgstr ""
+#empty string with id 36014
 
 msgctxt "#36015"
 msgid "HDMI port number"
@@ -9386,7 +9384,7 @@ msgid "Connected"
 msgstr ""
 
 msgctxt "#36017"
-msgid "Adapter found, but libCEC is not available"
+msgid "Could not initialise the CEC adapter: libCEC was not found on your system."
 msgstr ""
 
 msgctxt "#36018"
@@ -9419,5 +9417,33 @@ msgstr ""
 
 msgctxt "#36025"
 msgid "Send 'inactive source' command when stopping XBMC"
+msgstr ""
+
+msgctxt "#36026"
+msgid "Put devices in standby mode when putting the PC in standby"
+msgstr ""
+
+msgctxt "#36027"
+msgid "This device needs servicing"
+msgstr ""
+
+msgctxt "#36028"
+msgid "Ignore"
+msgstr ""
+
+msgctxt "#36029"
+msgid "When the TV is switched off"
+msgstr ""
+
+msgctxt "#36030"
+msgid "Connection lost"
+msgstr ""
+
+msgctxt "#36031"
+msgid "This user does not have permissions to open the CEC adapter"
+msgstr ""
+
+msgctxt "#36032"
+msgid "The port is busy. Only one program can access the CEC adapter"
 msgstr ""
 

--- a/language/Esperanto/strings.po
+++ b/language/Esperanto/strings.po
@@ -8862,19 +8862,15 @@ msgid "Put devices in standby mode when activating screensaver"
 msgstr ""
 
 msgctxt "#36011"
-msgid "Could not detect the CEC port. Set it up manually."
+msgid "Could not detect the CEC com port. Set it up manually."
 msgstr ""
 
 msgctxt "#36012"
-msgid "Could not initialise the CEC adapter. Check your settings."
+msgid "Could not initialise the CEC adapter. Please check your settings."
 msgstr ""
 
 msgctxt "#36013"
 msgid "Unsupported libCEC interface version. %d is greater than the version XBMC supports (%d)"
-msgstr ""
-
-msgctxt "#36014"
-msgid "Put this PC in standby mode when the TV is switched off"
 msgstr ""
 
 msgctxt "#36015"
@@ -8886,7 +8882,7 @@ msgid "Connected"
 msgstr ""
 
 msgctxt "#36017"
-msgid "Adapter found, but libCEC is not available"
+msgid "Could not initialise the CEC adapter: libCEC was not found on your system."
 msgstr ""
 
 msgctxt "#36018"
@@ -8919,5 +8915,33 @@ msgstr ""
 
 msgctxt "#36025"
 msgid "Send 'inactive source' command when stopping XBMC"
+msgstr ""
+
+msgctxt "#36026"
+msgid "Put devices in standby mode when putting the PC in standby"
+msgstr ""
+
+msgctxt "#36027"
+msgid "This device needs servicing"
+msgstr ""
+
+msgctxt "#36028"
+msgid "Ignore"
+msgstr ""
+
+msgctxt "#36029"
+msgid "When the TV is switched off"
+msgstr ""
+
+msgctxt "#36030"
+msgid "Connection lost"
+msgstr ""
+
+msgctxt "#36031"
+msgid "This user does not have permissions to open the CEC adapter"
+msgstr ""
+
+msgctxt "#36032"
+msgid "The port is busy. Only one program can access the CEC adapter"
 msgstr ""
 

--- a/language/Finnish/strings.po
+++ b/language/Finnish/strings.po
@@ -8862,20 +8862,16 @@ msgid "Put devices in standby mode when activating screensaver"
 msgstr "Aseta laitteet valmiustilaan näytönsäästäjän aktivoituessa"
 
 msgctxt "#36011"
-msgid "Could not detect the CEC port. Set it up manually."
+msgid "Could not detect the CEC com port. Set it up manually."
 msgstr "CEC-porttia ei havaittu. Määritä se käsin."
 
 msgctxt "#36012"
-msgid "Could not initialise the CEC adapter. Check your settings."
+msgid "Could not initialise the CEC adapter. Please check your settings."
 msgstr "CEC-sovitinta ei havaittu."
 
 msgctxt "#36013"
 msgid "Unsupported libCEC interface version. %d is greater than the version XBMC supports (%d)"
 msgstr "Ei tuettu libcec-rajapinnan versio. %d on suurempi kuin versio, jota XBMC tukee (%d)"
-
-msgctxt "#36014"
-msgid "Put this PC in standby mode when the TV is switched off"
-msgstr "Aseta tämä tietokone valmiustilaan kun TV sammutetaan"
 
 msgctxt "#36015"
 msgid "HDMI port number"
@@ -8886,7 +8882,7 @@ msgid "Connected"
 msgstr "Yhdistetty"
 
 msgctxt "#36017"
-msgid "Adapter found, but libCEC is not available"
+msgid "Could not initialise the CEC adapter: libCEC was not found on your system."
 msgstr "Sovitin löytyi, mutta libcec ei ole saatavilla"
 
 msgctxt "#36018"
@@ -8919,5 +8915,33 @@ msgstr ""
 
 msgctxt "#36025"
 msgid "Send 'inactive source' command when stopping XBMC"
+msgstr ""
+
+msgctxt "#36026"
+msgid "Put devices in standby mode when putting the PC in standby"
+msgstr ""
+
+msgctxt "#36027"
+msgid "This device needs servicing"
+msgstr ""
+
+msgctxt "#36028"
+msgid "Ignore"
+msgstr ""
+
+msgctxt "#36029"
+msgid "When the TV is switched off"
+msgstr ""
+
+msgctxt "#36030"
+msgid "Connection lost"
+msgstr ""
+
+msgctxt "#36031"
+msgid "This user does not have permissions to open the CEC adapter"
+msgstr ""
+
+msgctxt "#36032"
+msgid "The port is busy. Only one program can access the CEC adapter"
 msgstr ""
 

--- a/language/French/strings.po
+++ b/language/French/strings.po
@@ -8862,11 +8862,11 @@ msgid "Put devices in standby mode when activating screensaver"
 msgstr "Placer les dispositifs en veille si l'écran de veille est activé"
 
 msgctxt "#36011"
-msgid "Could not detect the CEC port. Set it up manually."
+msgid "Could not detect the CEC com port. Set it up manually."
 msgstr "Impossible de détecter le port CEC. Le paramétrer manuellement."
 
 msgctxt "#36012"
-msgid "Could not initialise the CEC adapter. Check your settings."
+msgid "Could not initialise the CEC adapter. Please check your settings."
 msgstr "Impossible de détecter l'adaptateur CEC."
 
 msgctxt "#36013"
@@ -8886,7 +8886,7 @@ msgid "Connected"
 msgstr "Connecté"
 
 msgctxt "#36017"
-msgid "Adapter found, but libCEC is not available"
+msgid "Could not initialise the CEC adapter: libCEC was not found on your system."
 msgstr "Adaptateur trouvé, mais libcec indisponible"
 
 msgctxt "#36018"
@@ -8919,5 +8919,33 @@ msgstr ""
 
 msgctxt "#36025"
 msgid "Send 'inactive source' command when stopping XBMC"
+msgstr ""
+
+msgctxt "#36026"
+msgid "Put devices in standby mode when putting the PC in standby"
+msgstr ""
+
+msgctxt "#36027"
+msgid "This device needs servicing"
+msgstr ""
+
+msgctxt "#36028"
+msgid "Ignore"
+msgstr ""
+
+msgctxt "#36029"
+msgid "When the TV is switched off"
+msgstr ""
+
+msgctxt "#36030"
+msgid "Connection lost"
+msgstr ""
+
+msgctxt "#36031"
+msgid "This user does not have permissions to open the CEC adapter"
+msgstr ""
+
+msgctxt "#36032"
+msgid "The port is busy. Only one program can access the CEC adapter"
 msgstr ""
 

--- a/language/German/strings.po
+++ b/language/German/strings.po
@@ -8908,20 +8908,16 @@ msgid "Put devices in standby mode when activating screensaver"
 msgstr "Geräte in den Standby versetzen wenn der Bilschirmschoner aktiviert wird"
 
 msgctxt "#36011"
-msgid "Could not detect the CEC port. Set it up manually."
+msgid "Could not detect the CEC com port. Set it up manually."
 msgstr "Der CEC Port konnte nicht gefunden werden. Manuell einstellen."
 
 msgctxt "#36012"
-msgid "Could not initialise the CEC adapter. Check your settings."
+msgid "Could not initialise the CEC adapter. Please check your settings."
 msgstr "Der CEC Adapter konnte nicht initialisiert werden. Bitte Einstellungen prüfen!"
 
 msgctxt "#36013"
 msgid "Unsupported libCEC interface version. %d is greater than the version XBMC supports (%d)"
 msgstr "Nicht unterstützte libCEC Version. %d ist größer als die von XBMC unterstützte Version (%d)"
-
-msgctxt "#36014"
-msgid "Put this PC in standby mode when the TV is switched off"
-msgstr "PC in den Standby versetzen wenn der Fernseher ausgeschaltet wird"
 
 msgctxt "#36015"
 msgid "HDMI port number"
@@ -8932,7 +8928,7 @@ msgid "Connected"
 msgstr "Verbunden"
 
 msgctxt "#36017"
-msgid "Adapter found, but libCEC is not available"
+msgid "Could not initialise the CEC adapter: libCEC was not found on your system."
 msgstr "CEC Adapter gefunden, aber libCEC ist nicht verfügbar"
 
 msgctxt "#36018"
@@ -8966,4 +8962,32 @@ msgstr "Konfiguration konnte nicht aktualisiert werden. Bitte Einstellungen prü
 msgctxt "#36025"
 msgid "Send 'inactive source' command when stopping XBMC"
 msgstr "Sende 'inaktive Quelle' wenn XBMC beendet wird"
+
+msgctxt "#36026"
+msgid "Put devices in standby mode when putting the PC in standby"
+msgstr ""
+
+msgctxt "#36027"
+msgid "This device needs servicing"
+msgstr ""
+
+msgctxt "#36028"
+msgid "Ignore"
+msgstr ""
+
+msgctxt "#36029"
+msgid "When the TV is switched off"
+msgstr ""
+
+msgctxt "#36030"
+msgid "Connection lost"
+msgstr ""
+
+msgctxt "#36031"
+msgid "This user does not have permissions to open the CEC adapter"
+msgstr ""
+
+msgctxt "#36032"
+msgid "The port is busy. Only one program can access the CEC adapter"
+msgstr ""
 

--- a/language/Greek/strings.po
+++ b/language/Greek/strings.po
@@ -8908,20 +8908,16 @@ msgid "Put devices in standby mode when activating screensaver"
 msgstr "Συσκευές σε κατάσταση αναμονής κατά την προφύλαξη οθόνης"
 
 msgctxt "#36011"
-msgid "Could not detect the CEC port. Set it up manually."
+msgid "Could not detect the CEC com port. Set it up manually."
 msgstr "Δεν εντοπίστηκε η θύρα CEC. Ρυθμίστε την χειροκίνητα."
 
 msgctxt "#36012"
-msgid "Could not initialise the CEC adapter. Check your settings."
+msgid "Could not initialise the CEC adapter. Please check your settings."
 msgstr "Ο προσαρμογέας CEC δεν εκκίνησε. Ελέγξτε τις ρυθμίσεις σας."
 
 msgctxt "#36013"
 msgid "Unsupported libCEC interface version. %d is greater than the version XBMC supports (%d)"
 msgstr "Μη υποστηριζόμενη έκδοση libCEC. Η %d είναι μεγαλύτερη από την έκδοση που το XBMC υποστηρίζει (%d)"
-
-msgctxt "#36014"
-msgid "Put this PC in standby mode when the TV is switched off"
-msgstr "Ο υπολογιστής σε κατάσταση αναμονής όταν κλείσει η τηλεόραση"
 
 msgctxt "#36015"
 msgid "HDMI port number"
@@ -8932,7 +8928,7 @@ msgid "Connected"
 msgstr "Συνδεδεμένη"
 
 msgctxt "#36017"
-msgid "Adapter found, but libCEC is not available"
+msgid "Could not initialise the CEC adapter: libCEC was not found on your system."
 msgstr "O προσαρμογέας εντοπίσθηκε, αλλά η libCEC δεν είναι διαθέσιμη"
 
 msgctxt "#36018"
@@ -8966,4 +8962,32 @@ msgstr "Οι νέες ρυθμίσεις δεν ορίστηκαν. Επανελ
 msgctxt "#36025"
 msgid "Send 'inactive source' command when stopping XBMC"
 msgstr "Αποστολή εντολής 'ανενεργή πηγή' κατά τον τερματισμό του XBMC"
+
+msgctxt "#36026"
+msgid "Put devices in standby mode when putting the PC in standby"
+msgstr ""
+
+msgctxt "#36027"
+msgid "This device needs servicing"
+msgstr ""
+
+msgctxt "#36028"
+msgid "Ignore"
+msgstr ""
+
+msgctxt "#36029"
+msgid "When the TV is switched off"
+msgstr ""
+
+msgctxt "#36030"
+msgid "Connection lost"
+msgstr ""
+
+msgctxt "#36031"
+msgid "This user does not have permissions to open the CEC adapter"
+msgstr ""
+
+msgctxt "#36032"
+msgid "The port is busy. Only one program can access the CEC adapter"
+msgstr ""
 

--- a/language/Hebrew/strings.po
+++ b/language/Hebrew/strings.po
@@ -8862,20 +8862,16 @@ msgid "Put devices in standby mode when activating screensaver"
 msgstr "הכנס את ההתקנים למצב שינה כאשר מפעילים שומר מסך"
 
 msgctxt "#36011"
-msgid "Could not detect the CEC port. Set it up manually."
+msgid "Could not detect the CEC com port. Set it up manually."
 msgstr "אין אפשרות לזהות פורט CEC. הגדר זאת ידנית."
 
 msgctxt "#36012"
-msgid "Could not initialise the CEC adapter. Check your settings."
+msgid "Could not initialise the CEC adapter. Please check your settings."
 msgstr "אין אפשרות לאתחל מתאם CEC. בדוק את ההגדרות שלך"
 
 msgctxt "#36013"
 msgid "Unsupported libCEC interface version. %d is greater than the version XBMC supports (%d)"
 msgstr "ממשק libCEC  לא נתמך. %d גדול יותר מאשר הגרסא ש- XBMC תומך (%d)"
-
-msgctxt "#36014"
-msgid "Put this PC in standby mode when the TV is switched off"
-msgstr "הכנס את המחשב למצב המתנה כאשר הטלוויזיה נכבית"
 
 msgctxt "#36015"
 msgid "HDMI port number"
@@ -8886,7 +8882,7 @@ msgid "Connected"
 msgstr "מחובר"
 
 msgctxt "#36017"
-msgid "Adapter found, but libCEC is not available"
+msgid "Could not initialise the CEC adapter: libCEC was not found on your system."
 msgstr "מתאם נמצא. אבל libCEC לא זמין"
 
 msgctxt "#36018"
@@ -8920,4 +8916,32 @@ msgstr "נכשל בהגדרת תצורה חדשה. אנא בדוק את ההגד
 msgctxt "#36025"
 msgid "Send 'inactive source' command when stopping XBMC"
 msgstr "שלח פקודת 'מקור לא פעיל' כאשר עוצרים את XBMC"
+
+msgctxt "#36026"
+msgid "Put devices in standby mode when putting the PC in standby"
+msgstr ""
+
+msgctxt "#36027"
+msgid "This device needs servicing"
+msgstr ""
+
+msgctxt "#36028"
+msgid "Ignore"
+msgstr ""
+
+msgctxt "#36029"
+msgid "When the TV is switched off"
+msgstr ""
+
+msgctxt "#36030"
+msgid "Connection lost"
+msgstr ""
+
+msgctxt "#36031"
+msgid "This user does not have permissions to open the CEC adapter"
+msgstr ""
+
+msgctxt "#36032"
+msgid "The port is busy. Only one program can access the CEC adapter"
+msgstr ""
 

--- a/language/Hindi (Devanagiri)/strings.po
+++ b/language/Hindi (Devanagiri)/strings.po
@@ -8862,19 +8862,15 @@ msgid "Put devices in standby mode when activating screensaver"
 msgstr ""
 
 msgctxt "#36011"
-msgid "Could not detect the CEC port. Set it up manually."
+msgid "Could not detect the CEC com port. Set it up manually."
 msgstr ""
 
 msgctxt "#36012"
-msgid "Could not initialise the CEC adapter. Check your settings."
+msgid "Could not initialise the CEC adapter. Please check your settings."
 msgstr ""
 
 msgctxt "#36013"
 msgid "Unsupported libCEC interface version. %d is greater than the version XBMC supports (%d)"
-msgstr ""
-
-msgctxt "#36014"
-msgid "Put this PC in standby mode when the TV is switched off"
 msgstr ""
 
 msgctxt "#36015"
@@ -8886,7 +8882,7 @@ msgid "Connected"
 msgstr ""
 
 msgctxt "#36017"
-msgid "Adapter found, but libCEC is not available"
+msgid "Could not initialise the CEC adapter: libCEC was not found on your system."
 msgstr ""
 
 msgctxt "#36018"
@@ -8919,5 +8915,33 @@ msgstr ""
 
 msgctxt "#36025"
 msgid "Send 'inactive source' command when stopping XBMC"
+msgstr ""
+
+msgctxt "#36026"
+msgid "Put devices in standby mode when putting the PC in standby"
+msgstr ""
+
+msgctxt "#36027"
+msgid "This device needs servicing"
+msgstr ""
+
+msgctxt "#36028"
+msgid "Ignore"
+msgstr ""
+
+msgctxt "#36029"
+msgid "When the TV is switched off"
+msgstr ""
+
+msgctxt "#36030"
+msgid "Connection lost"
+msgstr ""
+
+msgctxt "#36031"
+msgid "This user does not have permissions to open the CEC adapter"
+msgstr ""
+
+msgctxt "#36032"
+msgid "The port is busy. Only one program can access the CEC adapter"
 msgstr ""
 

--- a/language/Hungarian/strings.po
+++ b/language/Hungarian/strings.po
@@ -8862,20 +8862,16 @@ msgid "Put devices in standby mode when activating screensaver"
 msgstr "Képernyővédő bekapcsolásával az eszközöket készenléti módba helyezni"
 
 msgctxt "#36011"
-msgid "Could not detect the CEC port. Set it up manually."
+msgid "Could not detect the CEC com port. Set it up manually."
 msgstr "A CEC csatlakozó nem található. Állítsd be manuálisan."
 
 msgctxt "#36012"
-msgid "Could not initialise the CEC adapter. Check your settings."
+msgid "Could not initialise the CEC adapter. Please check your settings."
 msgstr "A CEC adapter nem található."
 
 msgctxt "#36013"
 msgid "Unsupported libCEC interface version. %d is greater than the version XBMC supports (%d)"
 msgstr "Nem támogatott libcec csatoló verzió. %d nagyobb mint amit az XBMC támogat (%d)"
-
-msgctxt "#36014"
-msgid "Put this PC in standby mode when the TV is switched off"
-msgstr "A Média Center készenléti módba helyezése, a TV kikapcsolásával"
 
 msgctxt "#36015"
 msgid "HDMI port number"
@@ -8886,7 +8882,7 @@ msgid "Connected"
 msgstr "Csatlakozva"
 
 msgctxt "#36017"
-msgid "Adapter found, but libCEC is not available"
+msgid "Could not initialise the CEC adapter: libCEC was not found on your system."
 msgstr "Az adaptert megtaláltam, de a libcec nem elérhető"
 
 msgctxt "#36018"
@@ -8919,5 +8915,33 @@ msgstr ""
 
 msgctxt "#36025"
 msgid "Send 'inactive source' command when stopping XBMC"
+msgstr ""
+
+msgctxt "#36026"
+msgid "Put devices in standby mode when putting the PC in standby"
+msgstr ""
+
+msgctxt "#36027"
+msgid "This device needs servicing"
+msgstr ""
+
+msgctxt "#36028"
+msgid "Ignore"
+msgstr ""
+
+msgctxt "#36029"
+msgid "When the TV is switched off"
+msgstr ""
+
+msgctxt "#36030"
+msgid "Connection lost"
+msgstr ""
+
+msgctxt "#36031"
+msgid "This user does not have permissions to open the CEC adapter"
+msgstr ""
+
+msgctxt "#36032"
+msgid "The port is busy. Only one program can access the CEC adapter"
 msgstr ""
 

--- a/language/Icelandic/strings.po
+++ b/language/Icelandic/strings.po
@@ -8862,20 +8862,16 @@ msgid "Put devices in standby mode when activating screensaver"
 msgstr "Setja tæki í biðstöðu þegar skjávari er virkur"
 
 msgctxt "#36011"
-msgid "Could not detect the CEC port. Set it up manually."
+msgid "Could not detect the CEC com port. Set it up manually."
 msgstr "Fann ekki CEC gátt. Settu það upp handvirkt."
 
 msgctxt "#36012"
-msgid "Could not initialise the CEC adapter. Check your settings."
+msgid "Could not initialise the CEC adapter. Please check your settings."
 msgstr "Fann ekki CEC tengispjald."
 
 msgctxt "#36013"
 msgid "Unsupported libCEC interface version. %d is greater than the version XBMC supports (%d)"
 msgstr "Þessi útgáfa af libcec er ekki studd. %d er hærri en útgáfan sem XBMC styður (%d)"
-
-msgctxt "#36014"
-msgid "Put this PC in standby mode when the TV is switched off"
-msgstr "Setja tölvuna í biðstöðu þegar slökkt er á sjónvarpinu"
 
 msgctxt "#36015"
 msgid "HDMI port number"
@@ -8886,7 +8882,7 @@ msgid "Connected"
 msgstr "Tengdur"
 
 msgctxt "#36017"
-msgid "Adapter found, but libCEC is not available"
+msgid "Could not initialise the CEC adapter: libCEC was not found on your system."
 msgstr "Fann tengispjald, en libcec er ekki tiltækt"
 
 msgctxt "#36018"
@@ -8919,5 +8915,33 @@ msgstr ""
 
 msgctxt "#36025"
 msgid "Send 'inactive source' command when stopping XBMC"
+msgstr ""
+
+msgctxt "#36026"
+msgid "Put devices in standby mode when putting the PC in standby"
+msgstr ""
+
+msgctxt "#36027"
+msgid "This device needs servicing"
+msgstr ""
+
+msgctxt "#36028"
+msgid "Ignore"
+msgstr ""
+
+msgctxt "#36029"
+msgid "When the TV is switched off"
+msgstr ""
+
+msgctxt "#36030"
+msgid "Connection lost"
+msgstr ""
+
+msgctxt "#36031"
+msgid "This user does not have permissions to open the CEC adapter"
+msgstr ""
+
+msgctxt "#36032"
+msgid "The port is busy. Only one program can access the CEC adapter"
 msgstr ""
 

--- a/language/Indonesian/strings.po
+++ b/language/Indonesian/strings.po
@@ -8862,19 +8862,15 @@ msgid "Put devices in standby mode when activating screensaver"
 msgstr ""
 
 msgctxt "#36011"
-msgid "Could not detect the CEC port. Set it up manually."
+msgid "Could not detect the CEC com port. Set it up manually."
 msgstr ""
 
 msgctxt "#36012"
-msgid "Could not initialise the CEC adapter. Check your settings."
+msgid "Could not initialise the CEC adapter. Please check your settings."
 msgstr ""
 
 msgctxt "#36013"
 msgid "Unsupported libCEC interface version. %d is greater than the version XBMC supports (%d)"
-msgstr ""
-
-msgctxt "#36014"
-msgid "Put this PC in standby mode when the TV is switched off"
 msgstr ""
 
 msgctxt "#36015"
@@ -8886,7 +8882,7 @@ msgid "Connected"
 msgstr ""
 
 msgctxt "#36017"
-msgid "Adapter found, but libCEC is not available"
+msgid "Could not initialise the CEC adapter: libCEC was not found on your system."
 msgstr ""
 
 msgctxt "#36018"
@@ -8919,5 +8915,33 @@ msgstr ""
 
 msgctxt "#36025"
 msgid "Send 'inactive source' command when stopping XBMC"
+msgstr ""
+
+msgctxt "#36026"
+msgid "Put devices in standby mode when putting the PC in standby"
+msgstr ""
+
+msgctxt "#36027"
+msgid "This device needs servicing"
+msgstr ""
+
+msgctxt "#36028"
+msgid "Ignore"
+msgstr ""
+
+msgctxt "#36029"
+msgid "When the TV is switched off"
+msgstr ""
+
+msgctxt "#36030"
+msgid "Connection lost"
+msgstr ""
+
+msgctxt "#36031"
+msgid "This user does not have permissions to open the CEC adapter"
+msgstr ""
+
+msgctxt "#36032"
+msgid "The port is busy. Only one program can access the CEC adapter"
 msgstr ""
 

--- a/language/Italian/strings.po
+++ b/language/Italian/strings.po
@@ -8862,20 +8862,16 @@ msgid "Put devices in standby mode when activating screensaver"
 msgstr "Imposta il dispositivo in stanby all'attivazione dello screensaver"
 
 msgctxt "#36011"
-msgid "Could not detect the CEC port. Set it up manually."
+msgid "Could not detect the CEC com port. Set it up manually."
 msgstr "Impossibile trovare la porta CEC. Impostala manualmente."
 
 msgctxt "#36012"
-msgid "Could not initialise the CEC adapter. Check your settings."
+msgid "Could not initialise the CEC adapter. Please check your settings."
 msgstr "Impossibile connettersi all'adattatore CEC."
 
 msgctxt "#36013"
 msgid "Unsupported libCEC interface version. %d is greater than the version XBMC supports (%d)"
 msgstr "Versione interfaccia libcec non supportata. %d è maggiore della versione supportata da XBMC (%d)"
-
-msgctxt "#36014"
-msgid "Put this PC in standby mode when the TV is switched off"
-msgstr "Metti il pc in standby quando la TV viene spenta"
 
 msgctxt "#36015"
 msgid "HDMI port number"
@@ -8886,7 +8882,7 @@ msgid "Connected"
 msgstr "Connesso"
 
 msgctxt "#36017"
-msgid "Adapter found, but libCEC is not available"
+msgid "Could not initialise the CEC adapter: libCEC was not found on your system."
 msgstr "Adattatore trovato, ma libcec non è disponibile"
 
 msgctxt "#36018"
@@ -8919,5 +8915,33 @@ msgstr ""
 
 msgctxt "#36025"
 msgid "Send 'inactive source' command when stopping XBMC"
+msgstr ""
+
+msgctxt "#36026"
+msgid "Put devices in standby mode when putting the PC in standby"
+msgstr ""
+
+msgctxt "#36027"
+msgid "This device needs servicing"
+msgstr ""
+
+msgctxt "#36028"
+msgid "Ignore"
+msgstr ""
+
+msgctxt "#36029"
+msgid "When the TV is switched off"
+msgstr ""
+
+msgctxt "#36030"
+msgid "Connection lost"
+msgstr ""
+
+msgctxt "#36031"
+msgid "This user does not have permissions to open the CEC adapter"
+msgstr ""
+
+msgctxt "#36032"
+msgid "The port is busy. Only one program can access the CEC adapter"
 msgstr ""
 

--- a/language/Japanese/strings.po
+++ b/language/Japanese/strings.po
@@ -8862,20 +8862,16 @@ msgid "Put devices in standby mode when activating screensaver"
 msgstr "スクリーンセーバー動作中にデバイスをスタンバイモードにする"
 
 msgctxt "#36011"
-msgid "Could not detect the CEC port. Set it up manually."
+msgid "Could not detect the CEC com port. Set it up manually."
 msgstr "CEC ポートが検出できませんでした。手動で設定してください。"
 
 msgctxt "#36012"
-msgid "Could not initialise the CEC adapter. Check your settings."
+msgid "Could not initialise the CEC adapter. Please check your settings."
 msgstr "CEC アダプタの初期化に失敗しました。設定を見直してください。"
 
 msgctxt "#36013"
 msgid "Unsupported libCEC interface version. %d is greater than the version XBMC supports (%d)"
 msgstr "この libCEC インターフェースバージョンは未サポートです。%d は、XBMC がサポートするバージョン %d より大きいバージョン番号です。"
-
-msgctxt "#36014"
-msgid "Put this PC in standby mode when the TV is switched off"
-msgstr "TV の電源が落とされたら PC をスタンバイモードにする"
 
 msgctxt "#36015"
 msgid "HDMI port number"
@@ -8886,7 +8882,7 @@ msgid "Connected"
 msgstr "接続完了"
 
 msgctxt "#36017"
-msgid "Adapter found, but libCEC is not available"
+msgid "Could not initialise the CEC adapter: libCEC was not found on your system."
 msgstr "アダプタはありますが libCEC がありません"
 
 msgctxt "#36018"
@@ -8920,4 +8916,32 @@ msgstr "設定変更に失敗しました。設定内容を確認してくださ
 msgctxt "#36025"
 msgid "Send 'inactive source' command when stopping XBMC"
 msgstr "XBMC 終了時に'非アクティブソース'コマンドを送信"
+
+msgctxt "#36026"
+msgid "Put devices in standby mode when putting the PC in standby"
+msgstr ""
+
+msgctxt "#36027"
+msgid "This device needs servicing"
+msgstr ""
+
+msgctxt "#36028"
+msgid "Ignore"
+msgstr ""
+
+msgctxt "#36029"
+msgid "When the TV is switched off"
+msgstr ""
+
+msgctxt "#36030"
+msgid "Connection lost"
+msgstr ""
+
+msgctxt "#36031"
+msgid "This user does not have permissions to open the CEC adapter"
+msgstr ""
+
+msgctxt "#36032"
+msgid "The port is busy. Only one program can access the CEC adapter"
+msgstr ""
 

--- a/language/Korean/strings.po
+++ b/language/Korean/strings.po
@@ -8862,20 +8862,16 @@ msgid "Put devices in standby mode when activating screensaver"
 msgstr "화면보호기 작동시 장치를 대기모드로 설정"
 
 msgctxt "#36011"
-msgid "Could not detect the CEC port. Set it up manually."
+msgid "Could not detect the CEC com port. Set it up manually."
 msgstr "CEC 포트를 찾을 수 없습니다. 수동으로 설정하세요."
 
 msgctxt "#36012"
-msgid "Could not initialise the CEC adapter. Check your settings."
+msgid "Could not initialise the CEC adapter. Please check your settings."
 msgstr "CEC 어댑터를 찾을 수 없음."
 
 msgctxt "#36013"
 msgid "Unsupported libCEC interface version. %d is greater than the version XBMC supports (%d)"
 msgstr "지원하지 않는 libcec 인터페이스 버전입니다. %d 가 XBMC가 지원하는 버전보다 높습니다 (%d)"
-
-msgctxt "#36014"
-msgid "Put this PC in standby mode when the TV is switched off"
-msgstr "TV가 꺼지면 PC를 대기모드로 전환"
 
 msgctxt "#36015"
 msgid "HDMI port number"
@@ -8886,7 +8882,7 @@ msgid "Connected"
 msgstr "연결됨"
 
 msgctxt "#36017"
-msgid "Adapter found, but libCEC is not available"
+msgid "Could not initialise the CEC adapter: libCEC was not found on your system."
 msgstr "어댑터가 확인되었으나 libcec를 사용할 수 없습니다"
 
 msgctxt "#36018"
@@ -8919,5 +8915,33 @@ msgstr ""
 
 msgctxt "#36025"
 msgid "Send 'inactive source' command when stopping XBMC"
+msgstr ""
+
+msgctxt "#36026"
+msgid "Put devices in standby mode when putting the PC in standby"
+msgstr ""
+
+msgctxt "#36027"
+msgid "This device needs servicing"
+msgstr ""
+
+msgctxt "#36028"
+msgid "Ignore"
+msgstr ""
+
+msgctxt "#36029"
+msgid "When the TV is switched off"
+msgstr ""
+
+msgctxt "#36030"
+msgid "Connection lost"
+msgstr ""
+
+msgctxt "#36031"
+msgid "This user does not have permissions to open the CEC adapter"
+msgstr ""
+
+msgctxt "#36032"
+msgid "The port is busy. Only one program can access the CEC adapter"
 msgstr ""
 

--- a/language/Lithuanian/strings.po
+++ b/language/Lithuanian/strings.po
@@ -8862,20 +8862,16 @@ msgid "Put devices in standby mode when activating screensaver"
 msgstr "Patalpinkite prietaisus laukimo režime, kai aktyvi ekrano užsklanda"
 
 msgctxt "#36011"
-msgid "Could not detect the CEC port. Set it up manually."
+msgid "Could not detect the CEC com port. Set it up manually."
 msgstr "Nepavyko aptikti CEC prievado. Nustatyti jį rankiniu būdu."
 
 msgctxt "#36012"
-msgid "Could not initialise the CEC adapter. Check your settings."
+msgid "Could not initialise the CEC adapter. Please check your settings."
 msgstr "Nepavyko aptikti CEC adapterio."
 
 msgctxt "#36013"
 msgid "Unsupported libCEC interface version. %d is greater than the version XBMC supports (%d)"
 msgstr "Nepalaikomas 'libec' sąsajos versija.%d atsisiuskite naujesnę  XBMC versiją (%d)"
-
-msgctxt "#36014"
-msgid "Put this PC in standby mode when the TV is switched off"
-msgstr "Kompiuterį budėjimo režimu, kai televizorius yra išjungtas"
 
 msgctxt "#36015"
 msgid "HDMI port number"
@@ -8886,7 +8882,7 @@ msgid "Connected"
 msgstr "Sujungtas"
 
 msgctxt "#36017"
-msgid "Adapter found, but libCEC is not available"
+msgid "Could not initialise the CEC adapter: libCEC was not found on your system."
 msgstr "Adapteris rastas, bet Libcec nėra"
 
 msgctxt "#36018"
@@ -8919,5 +8915,33 @@ msgstr ""
 
 msgctxt "#36025"
 msgid "Send 'inactive source' command when stopping XBMC"
+msgstr ""
+
+msgctxt "#36026"
+msgid "Put devices in standby mode when putting the PC in standby"
+msgstr ""
+
+msgctxt "#36027"
+msgid "This device needs servicing"
+msgstr ""
+
+msgctxt "#36028"
+msgid "Ignore"
+msgstr ""
+
+msgctxt "#36029"
+msgid "When the TV is switched off"
+msgstr ""
+
+msgctxt "#36030"
+msgid "Connection lost"
+msgstr ""
+
+msgctxt "#36031"
+msgid "This user does not have permissions to open the CEC adapter"
+msgstr ""
+
+msgctxt "#36032"
+msgid "The port is busy. Only one program can access the CEC adapter"
 msgstr ""
 

--- a/language/Maltese/strings.po
+++ b/language/Maltese/strings.po
@@ -8862,19 +8862,15 @@ msgid "Put devices in standby mode when activating screensaver"
 msgstr ""
 
 msgctxt "#36011"
-msgid "Could not detect the CEC port. Set it up manually."
+msgid "Could not detect the CEC com port. Set it up manually."
 msgstr ""
 
 msgctxt "#36012"
-msgid "Could not initialise the CEC adapter. Check your settings."
+msgid "Could not initialise the CEC adapter. Please check your settings."
 msgstr ""
 
 msgctxt "#36013"
 msgid "Unsupported libCEC interface version. %d is greater than the version XBMC supports (%d)"
-msgstr ""
-
-msgctxt "#36014"
-msgid "Put this PC in standby mode when the TV is switched off"
 msgstr ""
 
 msgctxt "#36015"
@@ -8886,7 +8882,7 @@ msgid "Connected"
 msgstr ""
 
 msgctxt "#36017"
-msgid "Adapter found, but libCEC is not available"
+msgid "Could not initialise the CEC adapter: libCEC was not found on your system."
 msgstr ""
 
 msgctxt "#36018"
@@ -8919,5 +8915,33 @@ msgstr ""
 
 msgctxt "#36025"
 msgid "Send 'inactive source' command when stopping XBMC"
+msgstr ""
+
+msgctxt "#36026"
+msgid "Put devices in standby mode when putting the PC in standby"
+msgstr ""
+
+msgctxt "#36027"
+msgid "This device needs servicing"
+msgstr ""
+
+msgctxt "#36028"
+msgid "Ignore"
+msgstr ""
+
+msgctxt "#36029"
+msgid "When the TV is switched off"
+msgstr ""
+
+msgctxt "#36030"
+msgid "Connection lost"
+msgstr ""
+
+msgctxt "#36031"
+msgid "This user does not have permissions to open the CEC adapter"
+msgstr ""
+
+msgctxt "#36032"
+msgid "The port is busy. Only one program can access the CEC adapter"
 msgstr ""
 

--- a/language/Norwegian/strings.po
+++ b/language/Norwegian/strings.po
@@ -8908,19 +8908,15 @@ msgid "Put devices in standby mode when activating screensaver"
 msgstr ""
 
 msgctxt "#36011"
-msgid "Could not detect the CEC port. Set it up manually."
+msgid "Could not detect the CEC com port. Set it up manually."
 msgstr ""
 
 msgctxt "#36012"
-msgid "Could not initialise the CEC adapter. Check your settings."
+msgid "Could not initialise the CEC adapter. Please check your settings."
 msgstr ""
 
 msgctxt "#36013"
 msgid "Unsupported libCEC interface version. %d is greater than the version XBMC supports (%d)"
-msgstr ""
-
-msgctxt "#36014"
-msgid "Put this PC in standby mode when the TV is switched off"
 msgstr ""
 
 msgctxt "#36015"
@@ -8932,7 +8928,7 @@ msgid "Connected"
 msgstr ""
 
 msgctxt "#36017"
-msgid "Adapter found, but libCEC is not available"
+msgid "Could not initialise the CEC adapter: libCEC was not found on your system."
 msgstr ""
 
 msgctxt "#36018"
@@ -8965,5 +8961,33 @@ msgstr ""
 
 msgctxt "#36025"
 msgid "Send 'inactive source' command when stopping XBMC"
+msgstr ""
+
+msgctxt "#36026"
+msgid "Put devices in standby mode when putting the PC in standby"
+msgstr ""
+
+msgctxt "#36027"
+msgid "This device needs servicing"
+msgstr ""
+
+msgctxt "#36028"
+msgid "Ignore"
+msgstr ""
+
+msgctxt "#36029"
+msgid "When the TV is switched off"
+msgstr ""
+
+msgctxt "#36030"
+msgid "Connection lost"
+msgstr ""
+
+msgctxt "#36031"
+msgid "This user does not have permissions to open the CEC adapter"
+msgstr ""
+
+msgctxt "#36032"
+msgid "The port is busy. Only one program can access the CEC adapter"
 msgstr ""
 

--- a/language/Polish/strings.po
+++ b/language/Polish/strings.po
@@ -8862,20 +8862,16 @@ msgid "Put devices in standby mode when activating screensaver"
 msgstr "Włącz tryb czuwania w urządzeniach, kiedy aktywny jest wygaszacz ekranu"
 
 msgctxt "#36011"
-msgid "Could not detect the CEC port. Set it up manually."
+msgid "Could not detect the CEC com port. Set it up manually."
 msgstr "Nie mogę wykryć portu CEC. Ustaw go ręcznie."
 
 msgctxt "#36012"
-msgid "Could not initialise the CEC adapter. Check your settings."
+msgid "Could not initialise the CEC adapter. Please check your settings."
 msgstr "Nie mogę wykryć adaptera CEC."
 
 msgctxt "#36013"
 msgid "Unsupported libCEC interface version. %d is greater than the version XBMC supports (%d)"
 msgstr "Nieaktualna wersja interfejsu libcec. %d jest wyższy niż wersja wspierana przez XBMC (%d)"
-
-msgctxt "#36014"
-msgid "Put this PC in standby mode when the TV is switched off"
-msgstr "Włącz tryb czuwania tego PC, kiedy TV jest wyłączony"
 
 msgctxt "#36015"
 msgid "HDMI port number"
@@ -8886,7 +8882,7 @@ msgid "Connected"
 msgstr "Połączono"
 
 msgctxt "#36017"
-msgid "Adapter found, but libCEC is not available"
+msgid "Could not initialise the CEC adapter: libCEC was not found on your system."
 msgstr "Znaleziono adapter, ale brak biblioteki libcec"
 
 msgctxt "#36018"
@@ -8919,5 +8915,33 @@ msgstr ""
 
 msgctxt "#36025"
 msgid "Send 'inactive source' command when stopping XBMC"
+msgstr ""
+
+msgctxt "#36026"
+msgid "Put devices in standby mode when putting the PC in standby"
+msgstr ""
+
+msgctxt "#36027"
+msgid "This device needs servicing"
+msgstr ""
+
+msgctxt "#36028"
+msgid "Ignore"
+msgstr ""
+
+msgctxt "#36029"
+msgid "When the TV is switched off"
+msgstr ""
+
+msgctxt "#36030"
+msgid "Connection lost"
+msgstr ""
+
+msgctxt "#36031"
+msgid "This user does not have permissions to open the CEC adapter"
+msgstr ""
+
+msgctxt "#36032"
+msgid "The port is busy. Only one program can access the CEC adapter"
 msgstr ""
 

--- a/language/Portuguese (Brazil)/strings.po
+++ b/language/Portuguese (Brazil)/strings.po
@@ -8910,20 +8910,16 @@ msgid "Put devices in standby mode when activating screensaver"
 msgstr "Colocar os equipamentos em modo de espera quando ativando proteção de tela"
 
 msgctxt "#36011"
-msgid "Could not detect the CEC port. Set it up manually."
+msgid "Could not detect the CEC com port. Set it up manually."
 msgstr "Não pude detectar a porta CEC. Seta manualmente."
 
 msgctxt "#36012"
-msgid "Could not initialise the CEC adapter. Check your settings."
+msgid "Could not initialise the CEC adapter. Please check your settings."
 msgstr "Não pude detectar o adaptador CEC."
 
 msgctxt "#36013"
 msgid "Unsupported libCEC interface version. %d is greater than the version XBMC supports (%d)"
 msgstr "Versãod libcec da interface não suportada. %d é superior a versão que o XBMC suporta (%d)"
-
-msgctxt "#36014"
-msgid "Put this PC in standby mode when the TV is switched off"
-msgstr "Passar este PC para modo standby, quando a TV for desligada"
 
 msgctxt "#36015"
 msgid "HDMI port number"
@@ -8934,7 +8930,7 @@ msgid "Connected"
 msgstr "Conectado"
 
 msgctxt "#36017"
-msgid "Adapter found, but libCEC is not available"
+msgid "Could not initialise the CEC adapter: libCEC was not found on your system."
 msgstr "Adaptador encontrado, mas libcec não esta disponível"
 
 msgctxt "#36018"
@@ -8968,4 +8964,32 @@ msgstr "Falha para setar a nova configuração. Por favor verifique seus ajustes
 msgctxt "#36025"
 msgid "Send 'inactive source' command when stopping XBMC"
 msgstr "Envie comando 'fonte inativa' quando parando XBMC"
+
+msgctxt "#36026"
+msgid "Put devices in standby mode when putting the PC in standby"
+msgstr ""
+
+msgctxt "#36027"
+msgid "This device needs servicing"
+msgstr ""
+
+msgctxt "#36028"
+msgid "Ignore"
+msgstr ""
+
+msgctxt "#36029"
+msgid "When the TV is switched off"
+msgstr ""
+
+msgctxt "#36030"
+msgid "Connection lost"
+msgstr ""
+
+msgctxt "#36031"
+msgid "This user does not have permissions to open the CEC adapter"
+msgstr ""
+
+msgctxt "#36032"
+msgid "The port is busy. Only one program can access the CEC adapter"
+msgstr ""
 

--- a/language/Portuguese/strings.po
+++ b/language/Portuguese/strings.po
@@ -8862,19 +8862,15 @@ msgid "Put devices in standby mode when activating screensaver"
 msgstr ""
 
 msgctxt "#36011"
-msgid "Could not detect the CEC port. Set it up manually."
+msgid "Could not detect the CEC com port. Set it up manually."
 msgstr ""
 
 msgctxt "#36012"
-msgid "Could not initialise the CEC adapter. Check your settings."
+msgid "Could not initialise the CEC adapter. Please check your settings."
 msgstr ""
 
 msgctxt "#36013"
 msgid "Unsupported libCEC interface version. %d is greater than the version XBMC supports (%d)"
-msgstr ""
-
-msgctxt "#36014"
-msgid "Put this PC in standby mode when the TV is switched off"
 msgstr ""
 
 msgctxt "#36015"
@@ -8886,7 +8882,7 @@ msgid "Connected"
 msgstr ""
 
 msgctxt "#36017"
-msgid "Adapter found, but libCEC is not available"
+msgid "Could not initialise the CEC adapter: libCEC was not found on your system."
 msgstr ""
 
 msgctxt "#36018"
@@ -8919,5 +8915,33 @@ msgstr ""
 
 msgctxt "#36025"
 msgid "Send 'inactive source' command when stopping XBMC"
+msgstr ""
+
+msgctxt "#36026"
+msgid "Put devices in standby mode when putting the PC in standby"
+msgstr ""
+
+msgctxt "#36027"
+msgid "This device needs servicing"
+msgstr ""
+
+msgctxt "#36028"
+msgid "Ignore"
+msgstr ""
+
+msgctxt "#36029"
+msgid "When the TV is switched off"
+msgstr ""
+
+msgctxt "#36030"
+msgid "Connection lost"
+msgstr ""
+
+msgctxt "#36031"
+msgid "This user does not have permissions to open the CEC adapter"
+msgstr ""
+
+msgctxt "#36032"
+msgid "The port is busy. Only one program can access the CEC adapter"
 msgstr ""
 

--- a/language/Romanian/strings.po
+++ b/language/Romanian/strings.po
@@ -8862,20 +8862,16 @@ msgid "Put devices in standby mode when activating screensaver"
 msgstr "Pune dispozitivele în modul repaus când protector ecran este activat"
 
 msgctxt "#36011"
-msgid "Could not detect the CEC port. Set it up manually."
+msgid "Could not detect the CEC com port. Set it up manually."
 msgstr "Portul CEC nu poate fi detectat. Setați-l manual."
 
 msgctxt "#36012"
-msgid "Could not initialise the CEC adapter. Check your settings."
+msgid "Could not initialise the CEC adapter. Please check your settings."
 msgstr "Adaptorul CEC nu poate fi detectat."
 
 msgctxt "#36013"
 msgid "Unsupported libCEC interface version. %d is greater than the version XBMC supports (%d)"
 msgstr "Versiune interfață libcec nesuportată. %d este mai mare decât versiunea pe care XBMC o suportă (%d)"
-
-msgctxt "#36014"
-msgid "Put this PC in standby mode when the TV is switched off"
-msgstr "Pune acest calculator în repaus când televizorul este oprit"
 
 msgctxt "#36015"
 msgid "HDMI port number"
@@ -8886,7 +8882,7 @@ msgid "Connected"
 msgstr "Conectat"
 
 msgctxt "#36017"
-msgid "Adapter found, but libCEC is not available"
+msgid "Could not initialise the CEC adapter: libCEC was not found on your system."
 msgstr "Adaptor găsit, dar librăria libcec nu este disponibilă"
 
 msgctxt "#36018"
@@ -8919,5 +8915,33 @@ msgstr ""
 
 msgctxt "#36025"
 msgid "Send 'inactive source' command when stopping XBMC"
+msgstr ""
+
+msgctxt "#36026"
+msgid "Put devices in standby mode when putting the PC in standby"
+msgstr ""
+
+msgctxt "#36027"
+msgid "This device needs servicing"
+msgstr ""
+
+msgctxt "#36028"
+msgid "Ignore"
+msgstr ""
+
+msgctxt "#36029"
+msgid "When the TV is switched off"
+msgstr ""
+
+msgctxt "#36030"
+msgid "Connection lost"
+msgstr ""
+
+msgctxt "#36031"
+msgid "This user does not have permissions to open the CEC adapter"
+msgstr ""
+
+msgctxt "#36032"
+msgid "The port is busy. Only one program can access the CEC adapter"
 msgstr ""
 

--- a/language/Russian/strings.po
+++ b/language/Russian/strings.po
@@ -8908,20 +8908,16 @@ msgid "Put devices in standby mode when activating screensaver"
 msgstr "Переводить устройства в спящий режим при активной заставке"
 
 msgctxt "#36011"
-msgid "Could not detect the CEC port. Set it up manually."
+msgid "Could not detect the CEC com port. Set it up manually."
 msgstr "Не удалось обнаружить порт CEC. Настройте его вручную."
 
 msgctxt "#36012"
-msgid "Could not initialise the CEC adapter. Check your settings."
+msgid "Could not initialise the CEC adapter. Please check your settings."
 msgstr "Не удалось инициализировать адаптер CEC. Проверьте настройки."
 
 msgctxt "#36013"
 msgid "Unsupported libCEC interface version. %d is greater than the version XBMC supports (%d)"
 msgstr "Неподдерживаемая версия интерфейса libCEC. %d выше, чем версия, поддерживаемая XBMC (%d)"
-
-msgctxt "#36014"
-msgid "Put this PC in standby mode when the TV is switched off"
-msgstr "Переводить этот ПК в режим ожидания при выключении ТВ"
 
 msgctxt "#36015"
 msgid "HDMI port number"
@@ -8932,7 +8928,7 @@ msgid "Connected"
 msgstr "Подключено"
 
 msgctxt "#36017"
-msgid "Adapter found, but libCEC is not available"
+msgid "Could not initialise the CEC adapter: libCEC was not found on your system."
 msgstr "Адаптер найден, но libCEC недоступен"
 
 msgctxt "#36018"
@@ -8966,4 +8962,32 @@ msgstr "Не удалось задать новую конфигурацию. П
 msgctxt "#36025"
 msgid "Send 'inactive source' command when stopping XBMC"
 msgstr "Посылать команду \"источник неактивен\" при выходе из XBMC"
+
+msgctxt "#36026"
+msgid "Put devices in standby mode when putting the PC in standby"
+msgstr ""
+
+msgctxt "#36027"
+msgid "This device needs servicing"
+msgstr ""
+
+msgctxt "#36028"
+msgid "Ignore"
+msgstr ""
+
+msgctxt "#36029"
+msgid "When the TV is switched off"
+msgstr ""
+
+msgctxt "#36030"
+msgid "Connection lost"
+msgstr ""
+
+msgctxt "#36031"
+msgid "This user does not have permissions to open the CEC adapter"
+msgstr ""
+
+msgctxt "#36032"
+msgid "The port is busy. Only one program can access the CEC adapter"
+msgstr ""
 

--- a/language/Serbian (Cyrillic)/strings.po
+++ b/language/Serbian (Cyrillic)/strings.po
@@ -8862,19 +8862,15 @@ msgid "Put devices in standby mode when activating screensaver"
 msgstr ""
 
 msgctxt "#36011"
-msgid "Could not detect the CEC port. Set it up manually."
+msgid "Could not detect the CEC com port. Set it up manually."
 msgstr ""
 
 msgctxt "#36012"
-msgid "Could not initialise the CEC adapter. Check your settings."
+msgid "Could not initialise the CEC adapter. Please check your settings."
 msgstr ""
 
 msgctxt "#36013"
 msgid "Unsupported libCEC interface version. %d is greater than the version XBMC supports (%d)"
-msgstr ""
-
-msgctxt "#36014"
-msgid "Put this PC in standby mode when the TV is switched off"
 msgstr ""
 
 msgctxt "#36015"
@@ -8886,7 +8882,7 @@ msgid "Connected"
 msgstr ""
 
 msgctxt "#36017"
-msgid "Adapter found, but libCEC is not available"
+msgid "Could not initialise the CEC adapter: libCEC was not found on your system."
 msgstr ""
 
 msgctxt "#36018"
@@ -8919,5 +8915,33 @@ msgstr ""
 
 msgctxt "#36025"
 msgid "Send 'inactive source' command when stopping XBMC"
+msgstr ""
+
+msgctxt "#36026"
+msgid "Put devices in standby mode when putting the PC in standby"
+msgstr ""
+
+msgctxt "#36027"
+msgid "This device needs servicing"
+msgstr ""
+
+msgctxt "#36028"
+msgid "Ignore"
+msgstr ""
+
+msgctxt "#36029"
+msgid "When the TV is switched off"
+msgstr ""
+
+msgctxt "#36030"
+msgid "Connection lost"
+msgstr ""
+
+msgctxt "#36031"
+msgid "This user does not have permissions to open the CEC adapter"
+msgstr ""
+
+msgctxt "#36032"
+msgid "The port is busy. Only one program can access the CEC adapter"
 msgstr ""
 

--- a/language/Serbian/strings.po
+++ b/language/Serbian/strings.po
@@ -8862,19 +8862,15 @@ msgid "Put devices in standby mode when activating screensaver"
 msgstr ""
 
 msgctxt "#36011"
-msgid "Could not detect the CEC port. Set it up manually."
+msgid "Could not detect the CEC com port. Set it up manually."
 msgstr ""
 
 msgctxt "#36012"
-msgid "Could not initialise the CEC adapter. Check your settings."
+msgid "Could not initialise the CEC adapter. Please check your settings."
 msgstr ""
 
 msgctxt "#36013"
 msgid "Unsupported libCEC interface version. %d is greater than the version XBMC supports (%d)"
-msgstr ""
-
-msgctxt "#36014"
-msgid "Put this PC in standby mode when the TV is switched off"
 msgstr ""
 
 msgctxt "#36015"
@@ -8886,7 +8882,7 @@ msgid "Connected"
 msgstr ""
 
 msgctxt "#36017"
-msgid "Adapter found, but libCEC is not available"
+msgid "Could not initialise the CEC adapter: libCEC was not found on your system."
 msgstr ""
 
 msgctxt "#36018"
@@ -8919,5 +8915,33 @@ msgstr ""
 
 msgctxt "#36025"
 msgid "Send 'inactive source' command when stopping XBMC"
+msgstr ""
+
+msgctxt "#36026"
+msgid "Put devices in standby mode when putting the PC in standby"
+msgstr ""
+
+msgctxt "#36027"
+msgid "This device needs servicing"
+msgstr ""
+
+msgctxt "#36028"
+msgid "Ignore"
+msgstr ""
+
+msgctxt "#36029"
+msgid "When the TV is switched off"
+msgstr ""
+
+msgctxt "#36030"
+msgid "Connection lost"
+msgstr ""
+
+msgctxt "#36031"
+msgid "This user does not have permissions to open the CEC adapter"
+msgstr ""
+
+msgctxt "#36032"
+msgid "The port is busy. Only one program can access the CEC adapter"
 msgstr ""
 

--- a/language/Slovak/strings.po
+++ b/language/Slovak/strings.po
@@ -8862,20 +8862,16 @@ msgid "Put devices in standby mode when activating screensaver"
 msgstr "Aktivovať pohotovostný režim zariadení pri spustení šetriča obrazovky"
 
 msgctxt "#36011"
-msgid "Could not detect the CEC port. Set it up manually."
+msgid "Could not detect the CEC com port. Set it up manually."
 msgstr "Nepodarilo sa zistiť CEC port. Nastavte ho manuálne."
 
 msgctxt "#36012"
-msgid "Could not initialise the CEC adapter. Check your settings."
+msgid "Could not initialise the CEC adapter. Please check your settings."
 msgstr "Nepodarilo sa zistiť CEC adaptér."
 
 msgctxt "#36013"
 msgid "Unsupported libCEC interface version. %d is greater than the version XBMC supports (%d)"
 msgstr "Nepodporovaná verzia libcec rozhrania. %d je vyššia ako XBMC podporuje (%d)"
-
-msgctxt "#36014"
-msgid "Put this PC in standby mode when the TV is switched off"
-msgstr "Aktivovať pohotovstný režim PC pri vypnutí TV"
 
 msgctxt "#36015"
 msgid "HDMI port number"
@@ -8886,7 +8882,7 @@ msgid "Connected"
 msgstr "Pripojené"
 
 msgctxt "#36017"
-msgid "Adapter found, but libCEC is not available"
+msgid "Could not initialise the CEC adapter: libCEC was not found on your system."
 msgstr "Adaptér nájdený, libcec nie je dostupný"
 
 msgctxt "#36018"
@@ -8919,5 +8915,33 @@ msgstr ""
 
 msgctxt "#36025"
 msgid "Send 'inactive source' command when stopping XBMC"
+msgstr ""
+
+msgctxt "#36026"
+msgid "Put devices in standby mode when putting the PC in standby"
+msgstr ""
+
+msgctxt "#36027"
+msgid "This device needs servicing"
+msgstr ""
+
+msgctxt "#36028"
+msgid "Ignore"
+msgstr ""
+
+msgctxt "#36029"
+msgid "When the TV is switched off"
+msgstr ""
+
+msgctxt "#36030"
+msgid "Connection lost"
+msgstr ""
+
+msgctxt "#36031"
+msgid "This user does not have permissions to open the CEC adapter"
+msgstr ""
+
+msgctxt "#36032"
+msgid "The port is busy. Only one program can access the CEC adapter"
 msgstr ""
 

--- a/language/Slovenian/strings.po
+++ b/language/Slovenian/strings.po
@@ -8908,20 +8908,16 @@ msgid "Put devices in standby mode when activating screensaver"
 msgstr "Postavi naprave v stanje pripravljenosti ob ohranjevalniku zaslona"
 
 msgctxt "#36011"
-msgid "Could not detect the CEC port. Set it up manually."
+msgid "Could not detect the CEC com port. Set it up manually."
 msgstr "Ni mogoče zaznati vrat CEC. Nastavite jih ročno."
 
 msgctxt "#36012"
-msgid "Could not initialise the CEC adapter. Check your settings."
+msgid "Could not initialise the CEC adapter. Please check your settings."
 msgstr "Ni mogoče zaznati adapterja CEC."
 
 msgctxt "#36013"
 msgid "Unsupported libCEC interface version. %d is greater than the version XBMC supports (%d)"
 msgstr "Nepodprta različica libcec. %d je višja, kot jo podpira XBMC (%d)"
-
-msgctxt "#36014"
-msgid "Put this PC in standby mode when the TV is switched off"
-msgstr "Postavi računalnik v stanje pripravljenosti, ko se ugasne TV"
 
 msgctxt "#36015"
 msgid "HDMI port number"
@@ -8932,7 +8928,7 @@ msgid "Connected"
 msgstr "XBMC povezan"
 
 msgctxt "#36017"
-msgid "Adapter found, but libCEC is not available"
+msgid "Could not initialise the CEC adapter: libCEC was not found on your system."
 msgstr "Vmesnik najden, toda libcec ni na voljo"
 
 msgctxt "#36018"
@@ -8966,4 +8962,32 @@ msgstr "Ni mogoče uveljaviti novih nastavitev. Preverite svoje možnosti."
 msgctxt "#36025"
 msgid "Send 'inactive source' command when stopping XBMC"
 msgstr "Pošlji ukaz 'neaktiven vir' ob izhodu iz XBMC"
+
+msgctxt "#36026"
+msgid "Put devices in standby mode when putting the PC in standby"
+msgstr ""
+
+msgctxt "#36027"
+msgid "This device needs servicing"
+msgstr ""
+
+msgctxt "#36028"
+msgid "Ignore"
+msgstr ""
+
+msgctxt "#36029"
+msgid "When the TV is switched off"
+msgstr ""
+
+msgctxt "#36030"
+msgid "Connection lost"
+msgstr ""
+
+msgctxt "#36031"
+msgid "This user does not have permissions to open the CEC adapter"
+msgstr ""
+
+msgctxt "#36032"
+msgid "The port is busy. Only one program can access the CEC adapter"
+msgstr ""
 

--- a/language/Spanish (Mexico)/strings.po
+++ b/language/Spanish (Mexico)/strings.po
@@ -8862,20 +8862,16 @@ msgid "Put devices in standby mode when activating screensaver"
 msgstr "Poner dispositivos en standby cuando se active el refrescapantallas"
 
 msgctxt "#36011"
-msgid "Could not detect the CEC port. Set it up manually."
+msgid "Could not detect the CEC com port. Set it up manually."
 msgstr "No se pudo detectar puerto CEC. Configurelo manualmente."
 
 msgctxt "#36012"
-msgid "Could not initialise the CEC adapter. Check your settings."
+msgid "Could not initialise the CEC adapter. Please check your settings."
 msgstr "No se pudo detectar adaptador CEC."
 
 msgctxt "#36013"
 msgid "Unsupported libCEC interface version. %d is greater than the version XBMC supports (%d)"
 msgstr "Versión de interface libcec no soportada. %d es mayor que la versión soportada por XBMC (%d)"
-
-msgctxt "#36014"
-msgid "Put this PC in standby mode when the TV is switched off"
-msgstr "Poner esta PC en standby cuando se apage la TV"
 
 msgctxt "#36015"
 msgid "HDMI port number"
@@ -8886,7 +8882,7 @@ msgid "Connected"
 msgstr "Connectado"
 
 msgctxt "#36017"
-msgid "Adapter found, but libCEC is not available"
+msgid "Could not initialise the CEC adapter: libCEC was not found on your system."
 msgstr "Adaptador encontrado, pero libcec no está disponible"
 
 msgctxt "#36018"
@@ -8919,5 +8915,33 @@ msgstr ""
 
 msgctxt "#36025"
 msgid "Send 'inactive source' command when stopping XBMC"
+msgstr ""
+
+msgctxt "#36026"
+msgid "Put devices in standby mode when putting the PC in standby"
+msgstr ""
+
+msgctxt "#36027"
+msgid "This device needs servicing"
+msgstr ""
+
+msgctxt "#36028"
+msgid "Ignore"
+msgstr ""
+
+msgctxt "#36029"
+msgid "When the TV is switched off"
+msgstr ""
+
+msgctxt "#36030"
+msgid "Connection lost"
+msgstr ""
+
+msgctxt "#36031"
+msgid "This user does not have permissions to open the CEC adapter"
+msgstr ""
+
+msgctxt "#36032"
+msgid "The port is busy. Only one program can access the CEC adapter"
 msgstr ""
 

--- a/language/Spanish/strings.po
+++ b/language/Spanish/strings.po
@@ -8862,20 +8862,16 @@ msgid "Put devices in standby mode when activating screensaver"
 msgstr "Poner dispositivos en standby cuando se active el salvapantallas"
 
 msgctxt "#36011"
-msgid "Could not detect the CEC port. Set it up manually."
+msgid "Could not detect the CEC com port. Set it up manually."
 msgstr "No se pudo detectar puerto CEC. Configúrelo manualmente."
 
 msgctxt "#36012"
-msgid "Could not initialise the CEC adapter. Check your settings."
+msgid "Could not initialise the CEC adapter. Please check your settings."
 msgstr "No se pudo iniciar el adaptador CEC. Revise la configuración."
 
 msgctxt "#36013"
 msgid "Unsupported libCEC interface version. %d is greater than the version XBMC supports (%d)"
 msgstr "Versión de interfaz libCEC no soportada. %d es mayor que la versión soportada por XBMC (%d)"
-
-msgctxt "#36014"
-msgid "Put this PC in standby mode when the TV is switched off"
-msgstr "Poner este PC en standby cuando se apaga la TV"
 
 msgctxt "#36015"
 msgid "HDMI port number"
@@ -8886,7 +8882,7 @@ msgid "Connected"
 msgstr "Conectado"
 
 msgctxt "#36017"
-msgid "Adapter found, but libCEC is not available"
+msgid "Could not initialise the CEC adapter: libCEC was not found on your system."
 msgstr "Adaptador encontrado, pero libCEC no está disponible"
 
 msgctxt "#36018"
@@ -8920,4 +8916,32 @@ msgstr "Fallo al establecer la nueva configuración. Por favor, revise su config
 msgctxt "#36025"
 msgid "Send 'inactive source' command when stopping XBMC"
 msgstr "Enviar comando 'fuente inactiva' al detener XBMC"
+
+msgctxt "#36026"
+msgid "Put devices in standby mode when putting the PC in standby"
+msgstr ""
+
+msgctxt "#36027"
+msgid "This device needs servicing"
+msgstr ""
+
+msgctxt "#36028"
+msgid "Ignore"
+msgstr ""
+
+msgctxt "#36029"
+msgid "When the TV is switched off"
+msgstr ""
+
+msgctxt "#36030"
+msgid "Connection lost"
+msgstr ""
+
+msgctxt "#36031"
+msgid "This user does not have permissions to open the CEC adapter"
+msgstr ""
+
+msgctxt "#36032"
+msgid "The port is busy. Only one program can access the CEC adapter"
+msgstr ""
 

--- a/language/Swedish/strings.po
+++ b/language/Swedish/strings.po
@@ -8908,20 +8908,16 @@ msgid "Put devices in standby mode when activating screensaver"
 msgstr "Ställ enheter i standbyläge när skärmsläckaren aktiveras"
 
 msgctxt "#36011"
-msgid "Could not detect the CEC port. Set it up manually."
+msgid "Could not detect the CEC com port. Set it up manually."
 msgstr "Kunde inte hitta CEC-porten. Ställ in den manuellt"
 
 msgctxt "#36012"
-msgid "Could not initialise the CEC adapter. Check your settings."
+msgid "Could not initialise the CEC adapter. Please check your settings."
 msgstr "Kunde inte hitta CEC-adaptern"
 
 msgctxt "#36013"
 msgid "Unsupported libCEC interface version. %d is greater than the version XBMC supports (%d)"
 msgstr "Ostödd libcec-gränssnittsversion. %d är nyare än versionen XBMC stödjer (%d)"
-
-msgctxt "#36014"
-msgid "Put this PC in standby mode when the TV is switched off"
-msgstr "Ställ denna PC i standbyläge när TVn stängs av"
 
 msgctxt "#36015"
 msgid "HDMI port number"
@@ -8932,7 +8928,7 @@ msgid "Connected"
 msgstr "Ansluten"
 
 msgctxt "#36017"
-msgid "Adapter found, but libCEC is not available"
+msgid "Could not initialise the CEC adapter: libCEC was not found on your system."
 msgstr "Adapter hittat, men libcec är inte tillgänglig"
 
 msgctxt "#36018"
@@ -8966,4 +8962,32 @@ msgstr "Misslyckads att ange den nya konfigurationen. Var god kontrollera dina i
 msgctxt "#36025"
 msgid "Send 'inactive source' command when stopping XBMC"
 msgstr "Skicka 'inaktiv källa' kommandot när XBMC stoppas"
+
+msgctxt "#36026"
+msgid "Put devices in standby mode when putting the PC in standby"
+msgstr ""
+
+msgctxt "#36027"
+msgid "This device needs servicing"
+msgstr ""
+
+msgctxt "#36028"
+msgid "Ignore"
+msgstr ""
+
+msgctxt "#36029"
+msgid "When the TV is switched off"
+msgstr ""
+
+msgctxt "#36030"
+msgid "Connection lost"
+msgstr ""
+
+msgctxt "#36031"
+msgid "This user does not have permissions to open the CEC adapter"
+msgstr ""
+
+msgctxt "#36032"
+msgid "The port is busy. Only one program can access the CEC adapter"
+msgstr ""
 

--- a/language/Thai/strings.po
+++ b/language/Thai/strings.po
@@ -8862,19 +8862,15 @@ msgid "Put devices in standby mode when activating screensaver"
 msgstr ""
 
 msgctxt "#36011"
-msgid "Could not detect the CEC port. Set it up manually."
+msgid "Could not detect the CEC com port. Set it up manually."
 msgstr ""
 
 msgctxt "#36012"
-msgid "Could not initialise the CEC adapter. Check your settings."
+msgid "Could not initialise the CEC adapter. Please check your settings."
 msgstr ""
 
 msgctxt "#36013"
 msgid "Unsupported libCEC interface version. %d is greater than the version XBMC supports (%d)"
-msgstr ""
-
-msgctxt "#36014"
-msgid "Put this PC in standby mode when the TV is switched off"
 msgstr ""
 
 msgctxt "#36015"
@@ -8886,7 +8882,7 @@ msgid "Connected"
 msgstr ""
 
 msgctxt "#36017"
-msgid "Adapter found, but libCEC is not available"
+msgid "Could not initialise the CEC adapter: libCEC was not found on your system."
 msgstr ""
 
 msgctxt "#36018"
@@ -8919,5 +8915,33 @@ msgstr ""
 
 msgctxt "#36025"
 msgid "Send 'inactive source' command when stopping XBMC"
+msgstr ""
+
+msgctxt "#36026"
+msgid "Put devices in standby mode when putting the PC in standby"
+msgstr ""
+
+msgctxt "#36027"
+msgid "This device needs servicing"
+msgstr ""
+
+msgctxt "#36028"
+msgid "Ignore"
+msgstr ""
+
+msgctxt "#36029"
+msgid "When the TV is switched off"
+msgstr ""
+
+msgctxt "#36030"
+msgid "Connection lost"
+msgstr ""
+
+msgctxt "#36031"
+msgid "This user does not have permissions to open the CEC adapter"
+msgstr ""
+
+msgctxt "#36032"
+msgid "The port is busy. Only one program can access the CEC adapter"
 msgstr ""
 

--- a/language/Turkish/strings.po
+++ b/language/Turkish/strings.po
@@ -8862,20 +8862,16 @@ msgid "Put devices in standby mode when activating screensaver"
 msgstr "Ekran koruyucu devreye girince aygıtı bekleme moduna geçir"
 
 msgctxt "#36011"
-msgid "Could not detect the CEC port. Set it up manually."
+msgid "Could not detect the CEC com port. Set it up manually."
 msgstr "CEC portu algılanamadı. El ile ayarla."
 
 msgctxt "#36012"
-msgid "Could not initialise the CEC adapter. Check your settings."
+msgid "Could not initialise the CEC adapter. Please check your settings."
 msgstr "CEC bağdaştırıcısı algılanamadı."
 
 msgctxt "#36013"
 msgid "Unsupported libCEC interface version. %d is greater than the version XBMC supports (%d)"
 msgstr "Desteklenmeyen libcec arabirim sürümü. %d is greater than the version XBMC supports (%d)"
-
-msgctxt "#36014"
-msgid "Put this PC in standby mode when the TV is switched off"
-msgstr "Televizyon kapatılınca bilgisayarı bekleme moduna geçir"
 
 msgctxt "#36015"
 msgid "HDMI port number"
@@ -8886,7 +8882,7 @@ msgid "Connected"
 msgstr "Bağlandı"
 
 msgctxt "#36017"
-msgid "Adapter found, but libCEC is not available"
+msgid "Could not initialise the CEC adapter: libCEC was not found on your system."
 msgstr "Bağdaştırıcı bulundu, fakat libcec kullanılamıyor"
 
 msgctxt "#36018"
@@ -8920,4 +8916,32 @@ msgstr "Yeni yapılandırma değeri ayarlanamadı. Lütfen ayarlarınızı kontr
 msgctxt "#36025"
 msgid "Send 'inactive source' command when stopping XBMC"
 msgstr "XBMC durdurulunca 'etkin olmayan kaynak' komutu yolla"
+
+msgctxt "#36026"
+msgid "Put devices in standby mode when putting the PC in standby"
+msgstr ""
+
+msgctxt "#36027"
+msgid "This device needs servicing"
+msgstr ""
+
+msgctxt "#36028"
+msgid "Ignore"
+msgstr ""
+
+msgctxt "#36029"
+msgid "When the TV is switched off"
+msgstr ""
+
+msgctxt "#36030"
+msgid "Connection lost"
+msgstr ""
+
+msgctxt "#36031"
+msgid "This user does not have permissions to open the CEC adapter"
+msgstr ""
+
+msgctxt "#36032"
+msgid "The port is busy. Only one program can access the CEC adapter"
+msgstr ""
 

--- a/language/Ukrainian/strings.po
+++ b/language/Ukrainian/strings.po
@@ -8862,20 +8862,16 @@ msgid "Put devices in standby mode when activating screensaver"
 msgstr "Переводити аудіопристрої в режим сну при активній заставці"
 
 msgctxt "#36011"
-msgid "Could not detect the CEC port. Set it up manually."
+msgid "Could not detect the CEC com port. Set it up manually."
 msgstr "Не вдалося виявити порт CEC. Налаштуйте його вручну."
 
 msgctxt "#36012"
-msgid "Could not initialise the CEC adapter. Check your settings."
+msgid "Could not initialise the CEC adapter. Please check your settings."
 msgstr "Не вдалося ініціалізувати адаптер CEC. Перевірте налаштування."
 
 msgctxt "#36013"
 msgid "Unsupported libCEC interface version. %d is greater than the version XBMC supports (%d)"
 msgstr "Непідтримувана версія інтерфейсу libCEC. %d вище, ніж версія, підтримувана XBMC (%d)"
-
-msgctxt "#36014"
-msgid "Put this PC in standby mode when the TV is switched off"
-msgstr "Переводити цей ПК у режим очікування при вимкненні ТБ"
 
 msgctxt "#36015"
 msgid "HDMI port number"
@@ -8886,7 +8882,7 @@ msgid "Connected"
 msgstr "Підключено"
 
 msgctxt "#36017"
-msgid "Adapter found, but libCEC is not available"
+msgid "Could not initialise the CEC adapter: libCEC was not found on your system."
 msgstr "Адаптер знайдено, але libCEC недоступний"
 
 msgctxt "#36018"
@@ -8920,4 +8916,32 @@ msgstr "Не вдалося задати нову конфігурацію. Пе
 msgctxt "#36025"
 msgid "Send 'inactive source' command when stopping XBMC"
 msgstr "Посилати команду \"джерело неактивне\" при виході з XBMC"
+
+msgctxt "#36026"
+msgid "Put devices in standby mode when putting the PC in standby"
+msgstr ""
+
+msgctxt "#36027"
+msgid "This device needs servicing"
+msgstr ""
+
+msgctxt "#36028"
+msgid "Ignore"
+msgstr ""
+
+msgctxt "#36029"
+msgid "When the TV is switched off"
+msgstr ""
+
+msgctxt "#36030"
+msgid "Connection lost"
+msgstr ""
+
+msgctxt "#36031"
+msgid "This user does not have permissions to open the CEC adapter"
+msgstr ""
+
+msgctxt "#36032"
+msgid "The port is busy. Only one program can access the CEC adapter"
+msgstr ""
 

--- a/project/BuildDependencies/scripts/libcec_d.bat
+++ b/project/BuildDependencies/scripts/libcec_d.bat
@@ -11,6 +11,5 @@ mkdir "%CUR_PATH%\include\libcec"
 xcopy libcec\include\* "%CUR_PATH%\include\libcec\." /E /Q /I /Y
 
 copy libcec\libcec.dll "%XBMC_PATH%\system\."
-copy libcec\pthreadVC2.dll "%XBMC_PATH%\system\."
 
 cd %LOC_PATH%

--- a/project/BuildDependencies/scripts/libcec_d.txt
+++ b/project/BuildDependencies/scripts/libcec_d.txt
@@ -1,3 +1,3 @@
 ; filename                        source of the file
 
-libcec-1.5.2.zip                  http://mirrors.xbmc.org/build-deps/win32/
+libcec-1.7.1.zip                  http://mirrors.xbmc.org/build-deps/win32/

--- a/system/peripherals.xml
+++ b/system/peripherals.xml
@@ -6,6 +6,7 @@
     <setting key="flip_keyboard" value="XBMC.VideoLibrary.Search" label="36002" order="3" />
     <setting key="flip_remote" value="Dialog.Close(virtualkeyboard)" label="36003" order="4" />
     <setting key="key_user" value="" label="36004" order="5" />
+    <setting key="key_power" value="XBMC.ShutDown()" label="13015" order="6" />
   </peripheral>
 
   <peripheral vendor_product="2548:1001" bus="usb" name="Pulse-Eight CEC Adapter" mapTo="cec">

--- a/system/peripherals.xml
+++ b/system/peripherals.xml
@@ -14,13 +14,14 @@
     <setting key="wake_devices" type="string" value="0" label="36007" order="3" />
     <setting key="standby_devices" type="string" value="0" label="36008" order="4" />
     <setting key="cec_standby_screensaver" type="bool" value="1" label="36009" order="5" />
-    <setting key="standby_pc_on_tv_standby" type="bool" value="1" label="36014" order="6" />
-    <setting key="send_inactive_source" type="bool" value="1" label="36025" order="7" />
-    <setting key="use_tv_menu_language" type="bool" value="1" label="36018" order="8" />
-    <setting key="physical_address" type="string" label="36021" value="0" order="9" />
-    <setting key="cec_hdmi_port" type="int" value="1" min="1" max="16" label="36015" order="10" />
-    <setting key="connected_device" type="int" label="36019" value="0" min="0" max="15" step="1" order="11" />
-    <setting key="port" type="string" value="" label="36022" order="12" />
+    <setting key="standby_pc_on_tv_standby" type="enum" value="13011" label="36029" order="6" lvalues="36028|13005|13011" />
+    <setting key="standby_tv_on_pc_standby" type="bool" value="1" label="36026" order="7" />
+    <setting key="send_inactive_source" type="bool" value="1" label="36025" order="8" />
+    <setting key="use_tv_menu_language" type="bool" value="1" label="36018" order="9" />
+    <setting key="physical_address" type="string" label="36021" value="0" order="10" />
+    <setting key="cec_hdmi_port" type="int" value="1" min="1" max="15" label="36015" order="11" />
+    <setting key="connected_device" type="int" label="36019" value="0" min="0" max="15" step="1" order="12" />
+    <setting key="port" type="string" value="" label="36022" order="13" />
 
     <setting key="tv_vendor" type="int" value="0" configurable="0" />
     <setting key="device_name" type="string" value="XBMC" configurable="0" />

--- a/tools/darwin/depends/libcec/Makefile
+++ b/tools/darwin/depends/libcec/Makefile
@@ -3,7 +3,7 @@ include ../config.site.mk
 
 # lib name, version
 LIBNAME=libcec
-VERSION=1.5.2
+VERSION=1.7.1
 SOURCE=$(LIBNAME)-$(VERSION)
 ARCHIVE=$(SOURCE).tar.gz
 

--- a/xbmc/Application.h
+++ b/xbmc/Application.h
@@ -204,8 +204,8 @@ public:
   void ResetScreenSaverTimer();
   void StopScreenSaverTimer();
   // Wakes up from the screensaver and / or DPMS. Returns true if woken up.
-  bool WakeUpScreenSaverAndDPMS();
-  bool WakeUpScreenSaver();
+  bool WakeUpScreenSaverAndDPMS(bool bPowerOffKeyPressed = false);
+  bool WakeUpScreenSaver(bool bPowerOffKeyPressed = false);
   double GetTotalTime() const;
   double GetTime() const;
   float GetPercentage() const;

--- a/xbmc/peripherals/Peripherals.h
+++ b/xbmc/peripherals/Peripherals.h
@@ -20,6 +20,7 @@
  *
  */
 
+#include "system.h"
 #include "bus/PeripheralBus.h"
 #include "devices/Peripheral.h"
 #include "threads/CriticalSection.h"

--- a/xbmc/peripherals/bus/PeripheralBus.cpp
+++ b/xbmc/peripherals/bus/PeripheralBus.cpp
@@ -323,6 +323,7 @@ void CPeripheralBus::GetDirectory(const CStdString &strPath, CFileItemList &item
     peripheralFile->SetProperty("bus", PeripheralTypeTranslator::BusTypeToString(peripheral->GetBusType()));
     peripheralFile->SetProperty("location", peripheral->Location());
     peripheralFile->SetProperty("class", PeripheralTypeTranslator::TypeToString(peripheral->Type()));
+    peripheralFile->SetProperty("version", peripheral->GetVersionInfo());
     items.Add(peripheralFile);
   }
 }

--- a/xbmc/peripherals/bus/PeripheralBus.cpp
+++ b/xbmc/peripherals/bus/PeripheralBus.cpp
@@ -143,7 +143,10 @@ void CPeripheralBus::UnregisterRemovedDevices(const PeripheralScanResults &resul
     {
       /* device removed */
       if (peripheral->Type() != PERIPHERAL_UNKNOWN)
+      {
         CLog::Log(LOGNOTICE, "%s - device removed from %s/%s: %s (%s:%s)", __FUNCTION__, PeripheralTypeTranslator::TypeToString(peripheral->Type()), peripheral->Location().c_str(), peripheral->DeviceName().c_str(), peripheral->VendorIdAsString(), peripheral->ProductIdAsString());
+        peripheral->OnDeviceRemoved();
+      }
       m_peripherals.erase(m_peripherals.begin() + iDevicePtr);
       lock.Leave();
 

--- a/xbmc/peripherals/devices/Peripheral.cpp
+++ b/xbmc/peripherals/devices/Peripheral.cpp
@@ -211,7 +211,15 @@ void CPeripheral::AddSetting(const CStdString &strKey, const CSetting *setting)
     case SETTINGS_TYPE_INT:
       {
         const CSettingInt *mappedSetting = (const CSettingInt *) setting;
-        CSettingInt *intSetting = new CSettingInt(mappedSetting->GetOrder(), strKey.c_str(), mappedSetting->GetLabel(), mappedSetting->GetData(), mappedSetting->m_iMin, mappedSetting->m_iStep, mappedSetting->m_iMax, mappedSetting->GetControlType(), mappedSetting->m_strFormat);
+        CSettingInt *intSetting(NULL);
+        if (mappedSetting->GetControlType() == SPIN_CONTROL_INT)
+        {
+          intSetting = new CSettingInt(mappedSetting->GetOrder(), strKey.c_str(), mappedSetting->GetLabel(), mappedSetting->GetData(), mappedSetting->m_iMin, mappedSetting->m_iStep, mappedSetting->m_iMax, mappedSetting->GetControlType(), mappedSetting->m_strFormat);
+        }
+        else if (mappedSetting->GetControlType() == SPIN_CONTROL_TEXT)
+        {
+          intSetting = new CSettingInt(mappedSetting->GetOrder(), strKey.c_str(), mappedSetting->GetLabel(), mappedSetting->GetData(), mappedSetting->m_entries, mappedSetting->GetControlType());
+        }
         if (intSetting)
         {
           intSetting->SetVisible(mappedSetting->IsVisible());

--- a/xbmc/peripherals/devices/Peripheral.cpp
+++ b/xbmc/peripherals/devices/Peripheral.cpp
@@ -26,6 +26,7 @@
 #include "settings/GUISettings.h"
 #include "utils/XBMCTinyXML.h"
 #include "utils/URIUtils.h"
+#include "guilib/LocalizeStrings.h"
 
 using namespace PERIPHERALS;
 using namespace std;
@@ -46,6 +47,7 @@ CPeripheral::CPeripheral(const PeripheralType type, const PeripheralBusType busT
   m_strFileLocation(StringUtils::EmptyString),
   m_iVendorId(iVendorId),
   m_iProductId(iProductId),
+  m_strVersionInfo(g_localizeStrings.Get(13205)), // "unknown"
   m_bInitialised(false),
   m_bHidden(false),
   m_bError(false)
@@ -65,8 +67,10 @@ CPeripheral::CPeripheral(void) :
   m_strVendorId("0000"),
   m_iProductId(0),
   m_strProductId("0000"),
+  m_strVersionInfo(g_localizeStrings.Get(13205)), // "unknown"
   m_bInitialised(false),
-  m_bHidden(false)
+  m_bHidden(false),
+  m_bError(false)
 {
 }
 
@@ -337,52 +341,58 @@ const CStdString CPeripheral::GetSettingString(const CStdString &strKey) const
   return StringUtils::EmptyString;
 }
 
-void CPeripheral::SetSetting(const CStdString &strKey, bool bValue)
+bool CPeripheral::SetSetting(const CStdString &strKey, bool bValue)
 {
+  bool bChanged(false);
   map<CStdString, CSetting *>::iterator it = m_settings.find(strKey);
   if (it != m_settings.end() && (*it).second->GetType() == SETTINGS_TYPE_BOOL)
   {
     CSettingBool *boolSetting = (CSettingBool *) (*it).second;
     if (boolSetting)
     {
-      bool bChanged(boolSetting->GetData() != bValue);
+      bChanged = boolSetting->GetData() != bValue;
       boolSetting->SetData(bValue);
       if (bChanged && m_bInitialised)
         m_changedSettings.insert(strKey);
     }
   }
+  return bChanged;
 }
 
-void CPeripheral::SetSetting(const CStdString &strKey, int iValue)
+bool CPeripheral::SetSetting(const CStdString &strKey, int iValue)
 {
+  bool bChanged(false);
   map<CStdString, CSetting *>::iterator it = m_settings.find(strKey);
   if (it != m_settings.end() && (*it).second->GetType() == SETTINGS_TYPE_INT)
   {
     CSettingInt *intSetting = (CSettingInt *) (*it).second;
     if (intSetting)
     {
-      bool bChanged(intSetting->GetData() != iValue);
+      bChanged = intSetting->GetData() != iValue;
       intSetting->SetData(iValue);
       if (bChanged && m_bInitialised)
         m_changedSettings.insert(strKey);
     }
   }
+  return bChanged;
 }
 
-void CPeripheral::SetSetting(const CStdString &strKey, float fValue)
+bool CPeripheral::SetSetting(const CStdString &strKey, float fValue)
 {
+  bool bChanged(false);
   map<CStdString, CSetting *>::iterator it = m_settings.find(strKey);
   if (it != m_settings.end() && (*it).second->GetType() == SETTINGS_TYPE_FLOAT)
   {
     CSettingFloat *floatSetting = (CSettingFloat *) (*it).second;
     if (floatSetting)
     {
-      bool bChanged(floatSetting->GetData() != fValue);
+      bChanged = floatSetting->GetData() != fValue;
       floatSetting->SetData(fValue);
       if (bChanged && m_bInitialised)
         m_changedSettings.insert(strKey);
     }
   }
+  return bChanged;
 }
 
 void CPeripheral::SetSettingVisible(const CStdString &strKey, bool bSetTo)
@@ -400,8 +410,9 @@ bool CPeripheral::IsSettingVisible(const CStdString &strKey) const
   return false;
 }
 
-void CPeripheral::SetSetting(const CStdString &strKey, const CStdString &strValue)
+bool CPeripheral::SetSetting(const CStdString &strKey, const CStdString &strValue)
 {
+  bool bChanged(false);
   map<CStdString, CSetting *>::iterator it = m_settings.find(strKey);
   if (it != m_settings.end())
   {
@@ -410,19 +421,20 @@ void CPeripheral::SetSetting(const CStdString &strKey, const CStdString &strValu
       CSettingString *stringSetting = (CSettingString *) (*it).second;
       if (stringSetting)
       {
-        bool bChanged(!stringSetting->GetData().Equals(strValue));
+        bChanged = !stringSetting->GetData().Equals(strValue);
         stringSetting->SetData(strValue);
         if (bChanged && m_bInitialised)
           m_changedSettings.insert(strKey);
       }
     }
     else if ((*it).second->GetType() == SETTINGS_TYPE_INT)
-      SetSetting(strKey, (int) (strValue.IsEmpty() ? 0 : atoi(strValue.c_str())));
+      bChanged = SetSetting(strKey, (int) (strValue.IsEmpty() ? 0 : atoi(strValue.c_str())));
     else if ((*it).second->GetType() == SETTINGS_TYPE_FLOAT)
-      SetSetting(strKey, (float) (strValue.IsEmpty() ? 0 : atof(strValue.c_str())));
+      bChanged = SetSetting(strKey, (float) (strValue.IsEmpty() ? 0 : atof(strValue.c_str())));
     else if ((*it).second->GetType() == SETTINGS_TYPE_BOOL)
-      SetSetting(strKey, strValue.Equals("1"));
+      bChanged = SetSetting(strKey, strValue.Equals("1"));
   }
+  return bChanged;
 }
 
 void CPeripheral::PersistSettings(bool bExiting /* = false */)

--- a/xbmc/peripherals/devices/Peripheral.h
+++ b/xbmc/peripherals/devices/Peripheral.h
@@ -53,6 +53,7 @@ namespace PERIPHERALS
     const CStdString &DeviceName(void) const       { return m_strDeviceName; }
     bool IsHidden(void) const                      { return m_bHidden; }
     void SetHidden(bool bSetTo = true)             { m_bHidden = bSetTo; }
+    const CStdString &GetVersionInfo(void) const   { return m_strVersionInfo; }
 
     /*!
      * @brief Check whether this device has the given feature.
@@ -127,18 +128,18 @@ namespace PERIPHERALS
      * @return The value or an empty string if it wasn't found.
      */
     virtual const CStdString GetSettingString(const CStdString &strKey) const;
-    virtual void SetSetting(const CStdString &strKey, const CStdString &strValue);
+    virtual bool SetSetting(const CStdString &strKey, const CStdString &strValue);
     virtual void SetSettingVisible(const CStdString &strKey, bool bSetTo);
     virtual bool IsSettingVisible(const CStdString &strKey) const;
 
     virtual int GetSettingInt(const CStdString &strKey) const;
-    virtual void SetSetting(const CStdString &strKey, int iValue);
+    virtual bool SetSetting(const CStdString &strKey, int iValue);
 
     virtual bool GetSettingBool(const CStdString &strKey) const;
-    virtual void SetSetting(const CStdString &strKey, bool bValue);
+    virtual bool SetSetting(const CStdString &strKey, bool bValue);
 
     virtual float GetSettingFloat(const CStdString &strKey) const;
-    virtual void SetSetting(const CStdString &strKey, float fValue);
+    virtual bool SetSetting(const CStdString &strKey, float fValue);
 
     virtual void PersistSettings(bool bExiting = false);
     virtual void LoadPersistedSettings(void);
@@ -161,6 +162,7 @@ namespace PERIPHERALS
     CStdString                       m_strVendorId;
     int                              m_iProductId;
     CStdString                       m_strProductId;
+    CStdString                       m_strVersionInfo;
     bool                             m_bInitialised;
     bool                             m_bHidden;
     bool                             m_bError;

--- a/xbmc/peripherals/devices/Peripheral.h
+++ b/xbmc/peripherals/devices/Peripheral.h
@@ -88,6 +88,11 @@ namespace PERIPHERALS
     virtual void OnSettingChanged(const CStdString &strChangedSetting) {};
 
     /*!
+     * @brief Called when this device is removed, before calling the destructor.
+     */
+    virtual void OnDeviceRemoved(void) {}
+
+    /*!
      * @brief Get all subdevices if this device is multifunctional.
      * @param subDevices The subdevices.
      */

--- a/xbmc/peripherals/devices/PeripheralCecAdapter.h
+++ b/xbmc/peripherals/devices/PeripheralCecAdapter.h
@@ -90,40 +90,47 @@ namespace PERIPHERALS
     CPeripheralCecAdapter(const PeripheralType type, const PeripheralBusType busType, const CStdString &strLocation, const CStdString &strDeviceName, int iVendorId, int iProductId);
     virtual ~CPeripheralCecAdapter(void);
 
-    virtual void Announce(ANNOUNCEMENT::AnnouncementFlag flag, const char *sender, const char *message, const CVariant &data);
-    virtual bool HasConnectedAudioSystem(void);
-    virtual void SetAudioSystemConnected(bool bSetTo);
-    virtual void ScheduleVolumeUp(void);
-    virtual void VolumeUp(void);
-    virtual void ScheduleVolumeDown(void);
-    virtual void VolumeDown(void);
-    virtual void ScheduleMute(void);
-    virtual void Mute(void);
-    virtual bool IsMuted(void);
+    void Announce(ANNOUNCEMENT::AnnouncementFlag flag, const char *sender, const char *message, const CVariant &data);
+    bool HasConnectedAudioSystem(void);
+    void SetAudioSystemConnected(bool bSetTo);
+    void ScheduleVolumeUp(void);
+    void VolumeUp(void);
+    void ScheduleVolumeDown(void);
+    void VolumeDown(void);
+    void ScheduleMute(void);
+    void Mute(void);
+    bool IsMuted(void);
 
-    virtual void OnSettingChanged(const CStdString &strChangedSetting);
+    void OnSettingChanged(const CStdString &strChangedSetting);
+    void OnDeviceRemoved(void);
 
-    virtual int GetButton(void);
-    virtual unsigned int GetHoldTime(void);
-    virtual void ResetButton(void);
-    virtual CStdString GetComPort(void);
+    int GetButton(void);
+    unsigned int GetHoldTime(void);
+    void ResetButton(void);
+    CStdString GetComPort(void);
+
+    void PushCecKeypress(const CEC::cec_keypress &key);
 
   protected:
-    virtual bool OpenConnection(void);
-    virtual void SetConfigurationFromSettings(void);
-    virtual void SetConfigurationFromLibCEC(const CEC::libcec_configuration &config);
+    bool OpenConnection(void);
+    void SetConfigurationFromSettings(void);
+    void SetConfigurationFromLibCEC(const CEC::libcec_configuration &config);
+    void SetVersionInfo(const CEC::libcec_configuration &configuration);
     static void ReadLogicalAddresses(const CStdString &strString, CEC::cec_logical_addresses &addresses);
     static int CecKeyPress(void *cbParam, const CEC::cec_keypress &key);
+    void PushCecKeypress(const CecButtonPress &key);
     static int CecLogMessage(void *cbParam, const CEC::cec_log_message &message);
     static int CecCommand(void *cbParam, const CEC::cec_command &command);
     static int CecConfiguration(void *cbParam, const CEC::libcec_configuration &config);
+    static int CecAlert(void *cbParam, const CEC::libcec_alert alert, const CEC::libcec_parameter &data);
+    bool IsRunning(void) const;
+    void ReopenConnection(void);
 
-    virtual bool GetNextKey(void);
-    virtual bool GetNextCecKey(CEC::cec_keypress &key);
-    virtual bool InitialiseFeature(const PeripheralFeature feature);
-    virtual void Process(void);
-    virtual void ProcessVolumeChange(void);
-    virtual void SetMenuLanguage(const char *strLanguage);
+    void GetNextKey(void);
+    bool InitialiseFeature(const PeripheralFeature feature);
+    void Process(void);
+    void ProcessVolumeChange(void);
+    void SetMenuLanguage(const char *strLanguage);
     static bool FindConfigLocation(CStdString &strString);
     static bool TranslateComPort(CStdString &strPort);
 
@@ -135,13 +142,16 @@ namespace PERIPHERALS
     bool                              m_bHasConnectedAudioSystem;
     CStdString                        m_strMenuLanguage;
     CDateTime                         m_screensaverLastActivated;
-    CecButtonPress                    m_button;
-    std::queue<CEC::cec_keypress>     m_buttonQueue;
+    std::vector<CecButtonPress>       m_buttonQueue;
+    CecButtonPress                    m_currentButton;
     std::queue<CecVolumeChange>       m_volumeChangeQueue;
     unsigned int                      m_lastKeypress;
     CecVolumeChange                   m_lastChange;
     int                               m_iExitCode;
     bool                              m_bIsMuted;
+    bool                              m_bGoingToStandby;
+    bool                              m_bIsRunning;
+    bool                              m_bDeviceRemoved;
     CPeripheralCecAdapterUpdateThread*m_queryThread;
     CEC::ICECCallbacks                m_callbacks;
     CCriticalSection                  m_critSection;
@@ -154,13 +164,15 @@ namespace PERIPHERALS
     CPeripheralCecAdapterUpdateThread(CPeripheralCecAdapter *adapter, CEC::libcec_configuration *configuration);
     virtual ~CPeripheralCecAdapterUpdateThread(void);
 
-    virtual void Signal(void);
-    virtual bool UpdateConfiguration(CEC::libcec_configuration *configuration);
+    void Signal(void);
+    bool UpdateConfiguration(CEC::libcec_configuration *configuration);
 
   protected:
-    virtual bool WaitReady(void);
-    virtual bool SetInitialConfiguration(void);
-    virtual void Process(void);
+    void UpdateMenuLanguage(void);
+    CStdString UpdateAudioSystemStatus(void);
+    bool WaitReady(void);
+    bool SetInitialConfiguration(void);
+    void Process(void);
 
     CPeripheralCecAdapter *    m_adapter;
     CEvent                     m_event;

--- a/xbmc/peripherals/devices/PeripheralNyxboard.cpp
+++ b/xbmc/peripherals/devices/PeripheralNyxboard.cpp
@@ -28,6 +28,8 @@
 using namespace PERIPHERALS;
 using namespace std;
 
+#define NYBOARD_POWER_BUTTON_KEYSYM 0x9f
+
 CPeripheralNyxboard::CPeripheralNyxboard(const PeripheralType type, const PeripheralBusType busType, const CStdString &strLocation, const CStdString &strDeviceName, int iVendorId, int iProductId) :
   CPeripheralHID(type, busType, strLocation, strDeviceName, iVendorId, iProductId)
 {
@@ -54,6 +56,12 @@ bool CPeripheralNyxboard::LookupSymAndUnicode(XBMC_keysym &keysym, uint8_t *key,
     /* 'user' key pressed */
     CLog::Log(LOGDEBUG, "%s - 'user' key pressed", __FUNCTION__);
     strCommand = GetSettingString("key_user");
+  }
+  else if (keysym.sym == NYBOARD_POWER_BUTTON_KEYSYM && keysym.mod == XBMCKMOD_NONE)
+  {
+    /* 'power' key pressed */
+    CLog::Log(LOGDEBUG, "%s - 'power' key pressed", __FUNCTION__);
+    strCommand = GetSettingString("key_power");
   }
 
   if (!strCommand.IsEmpty())

--- a/xbmc/peripherals/dialogs/GUIDialogPeripheralSettings.cpp
+++ b/xbmc/peripherals/dialogs/GUIDialogPeripheralSettings.cpp
@@ -51,6 +51,7 @@ void CGUIDialogPeripheralSettings::SetFileItem(CFileItemPtr item)
     delete m_item;
     m_boolSettings.clear();
     m_intSettings.clear();
+    m_intTextSettings.clear();
     m_floatSettings.clear();
     m_stringSettings.clear();
     m_settings.clear();
@@ -96,8 +97,23 @@ void CGUIDialogPeripheralSettings::CreateSettings()
             CSettingInt *intSetting = (CSettingInt *) setting;
             if (intSetting)
             {
-              m_intSettings.insert(make_pair(CStdString(intSetting->GetSetting()), (float) intSetting->GetData()));
-              AddSlider(intSetting->GetOrder(), intSetting->GetLabel(), &m_intSettings[intSetting->GetSetting()], (float)intSetting->m_iMin, (float)intSetting->m_iStep, (float)intSetting->m_iMax, CGUIDialogVideoSettings::FormatInteger, false);
+              if (intSetting->GetControlType() == SPIN_CONTROL_INT)
+              {
+                m_intSettings.insert(make_pair(CStdString(intSetting->GetSetting()), (float) intSetting->GetData()));
+                AddSlider(intSetting->GetOrder(), intSetting->GetLabel(), &m_intSettings[intSetting->GetSetting()], (float)intSetting->m_iMin, (float)intSetting->m_iStep, (float)intSetting->m_iMax, CGUIDialogVideoSettings::FormatInteger, false);
+              }
+              else if (intSetting->GetControlType() == SPIN_CONTROL_TEXT)
+              {
+                m_intTextSettings.insert(make_pair(CStdString(intSetting->GetSetting()), intSetting->GetData()));
+                vector<pair<int, int> > entries;
+                map<int, int>::iterator entriesItr = intSetting->m_entries.begin();
+                while (entriesItr != intSetting->m_entries.end())
+                {
+                  entries.push_back(make_pair(entriesItr->first, entriesItr->second));
+                  ++entriesItr;
+                }
+                AddSpin(intSetting->GetOrder(), intSetting->GetLabel(), &m_intTextSettings[intSetting->GetSetting()], entries);
+              }
             }
           }
           break;
@@ -160,6 +176,13 @@ void CGUIDialogPeripheralSettings::UpdatePeripheralSettings(void)
     ++intItr;
   }
 
+  map<CStdString, int>::iterator intTextItr = m_intTextSettings.begin();
+  while (intTextItr != m_intTextSettings.end())
+  {
+    peripheral->SetSetting((*intTextItr).first, (*intTextItr).second);
+    ++intTextItr;
+  }
+
   map<CStdString, float>::iterator floatItr = m_floatSettings.begin();
   while (floatItr != m_floatSettings.end())
   {
@@ -210,6 +233,7 @@ void CGUIDialogPeripheralSettings::ResetDefaultSettings(void)
     /* clear the settings */
     m_boolSettings.clear();
     m_intSettings.clear();
+    m_intTextSettings.clear();
     m_floatSettings.clear();
     m_stringSettings.clear();
     m_settings.clear();

--- a/xbmc/peripherals/dialogs/GUIDialogPeripheralSettings.h
+++ b/xbmc/peripherals/dialogs/GUIDialogPeripheralSettings.h
@@ -44,6 +44,7 @@ namespace PERIPHERALS
     bool                             m_bIsInitialising;
     std::map<CStdString, bool>       m_boolSettings;
     std::map<CStdString, float>      m_intSettings;
+    std::map<CStdString, int>        m_intTextSettings;
     std::map<CStdString, float>      m_floatSettings;
     std::map<CStdString, CStdString> m_stringSettings;
   };


### PR DESCRIPTION
this PR adds the following:

libCEC 1.7 support and fixes. libCEC 1.6+ is needed when using firmware v2 on the CEC adapter, which adds wake over CEC
      \* added a new setting to control whether to put the TV in standby when the player is put in standby.
      \* added some button mappings: all menu related buttons -> menu, previous channel -> teletext, added support for the channels list on samsung, mapped next fav -> menu (when available)
      \* display the firmware version in the peripheral manager (if available)
      \* handle the new CEC alert callback (libCEC 1.6+)
      \* replaced 'Put this PC in standby mode when the TV is switched off' with an enum that allows the user to chose between 'Ignore', 'Suspend' and 'Shutdown'
      \* fixed - crash when changing settings without libCEC started.
      \* fixed - range of wake and power-off devices
      \* fixed - update the correct standby device setting ('standby_devices' not 'wake_devices')
      \* fixed - don't get the settings from the eeprom, but always use the settings provided in xbmc
      \* peripherals: added support for enum settings
      \* physical address autodetection for AMD

win32 and darwin deps will need to be pushed to the mirrors before merging this.
