### PR TITLE
jsonrpc: add "lastplayed" property for songs (closes #12943)

### DIFF
--- a/xbmc/interfaces/json-rpc/ServiceDescription.h
+++ b/xbmc/interfaces/json-rpc/ServiceDescription.h
@@ -346,7 +346,7 @@ namespace JSONRPC
                   "\"lyrics\", \"musicbrainztrackid\", \"musicbrainzartistid\","
                   "\"musicbrainzalbumid\", \"musicbrainzalbumartistid\","
                   "\"playcount\", \"fanart\", \"thumbnail\", \"file\", \"artistid\","
-                  "\"albumid\" ]"
+                  "\"albumid\", \"lastplayed\" ]"
       "}"
     "}",
     "\"Audio.Details.Base\": {"
@@ -411,7 +411,8 @@ namespace JSONRPC
         "\"musicbrainztrackid\": { \"type\": \"string\" },"
         "\"musicbrainzartistid\": { \"type\": \"string\" },"
         "\"artistid\": { \"$ref\": \"Library.Id\" },"
-        "\"albumid\": { \"$ref\": \"Library.Id\" }"
+        "\"albumid\": { \"$ref\": \"Library.Id\" },"
+        "\"lastplayed\": { \"type\": \"string\" }"
       "}"
     "}",
     "\"Video.Fields.Movie\": {"

--- a/xbmc/interfaces/json-rpc/types.json
+++ b/xbmc/interfaces/json-rpc/types.json
@@ -318,7 +318,7 @@
                 "lyrics", "musicbrainztrackid", "musicbrainzartistid",
                 "musicbrainzalbumid", "musicbrainzalbumartistid",
                 "playcount", "fanart", "thumbnail", "file", "artistid",
-                "albumid" ]
+                "albumid", "lastplayed" ]
     }
   },
   "Audio.Details.Base": {
@@ -383,7 +383,8 @@
       "musicbrainztrackid": { "type": "string" },
       "musicbrainzartistid": { "type": "string" },
       "artistid": { "$ref": "Library.Id" },
-      "albumid": { "$ref": "Library.Id" }
+      "albumid": { "$ref": "Library.Id" },
+      "lastplayed": { "type": "string" }
     }
   },
   "Video.Fields.Movie": {

--- a/xbmc/music/Song.cpp
+++ b/xbmc/music/Song.cpp
@@ -81,6 +81,7 @@ void CSong::Serialize(CVariant& value)
   value["comment"] = strComment;
   value["rating"] = rating;
   value["timesplayed"] = iTimesPlayed;
+  value["lastplayed"] = lastPlayed.IsValid() ? lastPlayed.GetAsDBDateTime() : "";
   value["karaokenumber"] = (int64_t) iKaraokeNumber;
   value["artistid"] = iArtistId;
   value["albumid"] = iAlbumId;

--- a/xbmc/music/tags/MusicInfoTag.cpp
+++ b/xbmc/music/tags/MusicInfoTag.cpp
@@ -444,6 +444,7 @@ void CMusicInfoTag::Serialize(CVariant& value)
   value["comment"] = m_strComment;
   value["rating"] = m_rating;
   value["playcount"] = m_iTimesPlayed;
+  value["lastplayed"] = m_lastPlayed.IsValid() ? m_lastPlayed.GetAsDBDateTime() : StringUtils::EmptyString;
   value["lyrics"] = m_strLyrics;
   value["artistid"] = m_iArtistId;
   value["albumid"] = m_iAlbumId;


### PR DESCRIPTION
This is a no-brainer but as everything that's not a fix has to go through a PR, here it is. This closes ticket http://trac.xbmc.org/ticket/12943 from ronie. I wondered myself why this wasn't exposed before because it is for videos.
