### PR TITLE
Add-on info window on info-action and via context-menu on add-ons

### DIFF
--- a/xbmc/music/windows/GUIWindowMusicBase.cpp
+++ b/xbmc/music/windows/GUIWindowMusicBase.cpp
@@ -44,6 +44,7 @@
 #include "GUIInfoManager.h"
 #include "filesystem/MusicDatabaseDirectory.h"
 #include "music/dialogs/GUIDialogSongInfo.h"
+#include "addons/GUIDialogAddonInfo.h"
 #include "dialogs/GUIDialogSmartPlaylistEditor.h"
 #include "music/LastFmManager.h"
 #include "music/tags/MusicInfoTag.h"
@@ -264,6 +265,12 @@ void CGUIWindowMusicBase::OnInfo(int iItem, bool bShowInfo)
   if (item->IsVideoDb())
   { // music video
     OnContextButton(iItem, CONTEXT_BUTTON_INFO);
+    return;
+  }
+
+  if (!m_vecItems->IsPlugin() && (item->IsPlugin() || item->IsScript()))
+  {
+    CGUIDialogAddonInfo::ShowForItem(item);
     return;
   }
 
@@ -870,6 +877,8 @@ void CGUIWindowMusicBase::GetContextButtons(int itemNumber, CContextButtons &but
   {
     if (item && !item->IsParentFolder())
     {
+      if (!m_vecItems->IsPlugin() && (item->IsPlugin() || item->IsScript()))
+        buttons.Add(CONTEXT_BUTTON_INFO,24003); // Add-on info
       if (item->GetExtraInfo().Equals("lastfmloved"))
       {
         buttons.Add(CONTEXT_BUTTON_LASTFM_UNLOVE_ITEM, 15295); //unlove

--- a/xbmc/pictures/GUIWindowPictures.cpp
+++ b/xbmc/pictures/GUIWindowPictures.cpp
@@ -29,6 +29,7 @@
 #include "GUIPassword.h"
 #include "dialogs/GUIDialogMediaSource.h"
 #include "GUIDialogPictureInfo.h"
+#include "addons/GUIDialogAddonInfo.h"
 #include "dialogs/GUIDialogProgress.h"
 #include "playlists/PlayListFactory.h"
 #include "PictureInfoLoader.h"
@@ -458,7 +459,9 @@ void CGUIWindowPictures::GetContextButtons(int itemNumber, CContextButtons &butt
     {
       if (item)
       {
-        if (!(item->m_bIsFolder || item->IsZIP() || item->IsRAR() || item->IsCBZ() || item->IsCBR()))
+        if (!m_vecItems->IsPlugin() && (item->IsPlugin() || item->IsScript()))
+          buttons.Add(CONTEXT_BUTTON_INFO, 24003); // Add-on info
+        if (!(item->m_bIsFolder || item->IsZIP() || item->IsRAR() || item->IsCBZ() || item->IsCBR() || item->IsScript()))
           buttons.Add(CONTEXT_BUTTON_INFO, 13406); // picture info
         buttons.Add(CONTEXT_BUTTON_VIEW_SLIDESHOW, item->m_bIsFolder ? 13317 : 13422);      // View Slideshow
         if (item->m_bIsFolder)
@@ -583,7 +586,14 @@ void CGUIWindowPictures::LoadPlayList(const CStdString& strPlayList)
 void CGUIWindowPictures::OnInfo(int itemNumber)
 {
   CFileItemPtr item = (itemNumber >= 0 && itemNumber < m_vecItems->Size()) ? m_vecItems->Get(itemNumber) : CFileItemPtr();
-  if (!item || item->m_bIsFolder || item->IsZIP() || item->IsRAR() || item->IsCBZ() || item->IsCBR() || !item->IsPicture())
+  if (!item)
+    return;
+  if (!m_vecItems->IsPlugin() && (item->IsPlugin() || item->IsScript()))
+  {
+    CGUIDialogAddonInfo::ShowForItem(item);
+    return;
+  }
+  if (item->m_bIsFolder || item->IsZIP() || item->IsRAR() || item->IsCBZ() || item->IsCBR() || !item->IsPicture())
     return;
   CGUIDialogPictureInfo *pictureInfo = (CGUIDialogPictureInfo *)g_windowManager.GetWindow(WINDOW_DIALOG_PICTURE_INFO);
   if (pictureInfo)

--- a/xbmc/programs/GUIWindowPrograms.cpp
+++ b/xbmc/programs/GUIWindowPrograms.cpp
@@ -26,6 +26,7 @@
 #include "filesystem/HDDirectory.h"
 #include "GUIPassword.h"
 #include "dialogs/GUIDialogMediaSource.h"
+#include "addons/GUIDialogAddonInfo.h"
 #include "Autorun.h"
 #include "utils/LabelFormatter.h"
 #include "Autorun.h"
@@ -109,9 +110,16 @@ bool CGUIWindowPrograms::OnMessage(CGUIMessage& message)
       }
       if (m_viewControl.HasControl(message.GetSenderId()))  // list/thumb control
       {
-        if (message.GetParam1() == ACTION_PLAYER_PLAY)
+        int iAction = message.GetParam1();
+        int iItem = m_viewControl.GetSelectedItem();
+        if (iAction == ACTION_PLAYER_PLAY)
         {
-          OnPlayMedia(m_viewControl.GetSelectedItem());
+          OnPlayMedia(iItem);
+          return true;
+        }
+        else if (iAction == ACTION_SHOW_INFO)
+        {
+          OnInfo(iItem);
           return true;
         }
       }
@@ -149,6 +157,8 @@ void CGUIWindowPrograms::GetContextButtons(int itemNumber, CContextButtons &butt
         }
       }
 
+      if (!m_vecItems->IsPlugin() && (item->IsPlugin() || item->IsScript()))
+        buttons.Add(CONTEXT_BUTTON_INFO, 24003); // Add-on info
       if (item->IsPlugin() || item->IsScript() || m_vecItems->IsPlugin())
         buttons.Add(CONTEXT_BUTTON_PLUGIN_SETTINGS, 1045);
 
@@ -208,6 +218,10 @@ bool CGUIWindowPrograms::OnContextButton(int itemNumber, CONTEXT_BUTTON button)
 
   case CONTEXT_BUTTON_LAUNCH:
     OnClick(itemNumber);
+    return true;
+
+  case CONTEXT_BUTTON_INFO:
+    OnInfo(itemNumber);
     return true;
 
   default:
@@ -290,4 +304,16 @@ CStdString CGUIWindowPrograms::GetStartFolder(const CStdString &dir)
     return dir;
   }
   return CGUIMediaWindow::GetStartFolder(dir);
+}
+
+void CGUIWindowPrograms::OnInfo(int iItem)
+{
+  if (iItem < 0 || iItem >= m_vecItems->Size())
+    return;
+
+  CFileItemPtr item = m_vecItems->Get(iItem);
+  if (!m_vecItems->IsPlugin() && (item->IsPlugin() || item->IsScript()))
+  {
+    CGUIDialogAddonInfo::ShowForItem(item);
+  }
 }

--- a/xbmc/programs/GUIWindowPrograms.h
+++ b/xbmc/programs/GUIWindowPrograms.h
@@ -33,6 +33,7 @@ public:
   CGUIWindowPrograms(void);
   virtual ~CGUIWindowPrograms(void);
   virtual bool OnMessage(CGUIMessage& message);
+  virtual void OnInfo(int iItem);
 protected:
   virtual void OnItemLoaded(CFileItem* pItem) {};
   virtual bool Update(const CStdString& strDirectory);

--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -26,6 +26,7 @@
 #include "utils/RegExp.h"
 #include "utils/Variant.h"
 #include "addons/AddonManager.h"
+#include "addons/GUIDialogAddonInfo.h"
 #include "addons/IAddon.h"
 #include "video/dialogs/GUIDialogVideoInfo.h"
 #include "GUIWindowVideoNav.h"
@@ -958,6 +959,9 @@ bool CGUIWindowVideoBase::OnInfo(int iItem)
      (item->IsPlayList() && !URIUtils::GetExtension(item->GetPath()).Equals(".strm")))
     return false;
 
+  if (!m_vecItems->IsPlugin() && (item->IsPlugin() || item->IsScript()))
+    return CGUIDialogAddonInfo::ShowForItem(item);
+
   ADDON::ScraperPtr scraper;
   if (!m_vecItems->IsPlugin() && !m_vecItems->IsRSS() && !m_vecItems->IsLiveTV())
   {
@@ -1127,6 +1131,10 @@ void CGUIWindowVideoBase::GetContextButtons(int itemNumber, CContextButtons &but
           buttons.Add(CONTEXT_BUTTON_PLAY_ITEM, 208);
         }
       }
+
+      if (!m_vecItems->IsPlugin() && (item->IsPlugin() || item->IsScript()))
+        buttons.Add(CONTEXT_BUTTON_INFO,24003); // Add-on info
+
       if (!item->m_bIsFolder && !(item->IsPlayList() && !g_advancedSettings.m_playlistAsFolders))
       { // get players
         VECPLAYERCORES vecCores;


### PR DESCRIPTION
This is a pull request for my self wanted features/improvements on add-on info-window call possibility's.

These changes resulting in:
- adding "Add-On Informations" to the context-menu of add-ons in their media windows (video, music, pictures and programs)
- opening the add-on window on the info-action

I opened a forum thread (http://forum.xbmc.org/showthread.php?tid=128475) and spiff told me the relevant files so that I can change myself.

On video, music and picture add-ons the changes are minimal but to get this working on program add-ons I had to add a little more lines.
I also fixed a small inequality in the context-menu between picture scripts and plugins (there was already an entry "Picture Information" on scripts but not an plugins which is now removed) by adding "Add-on Information" to both.

This is my first code pull request to xbmc and to be honest, I'm better on Python than on C++ ;)
I only tested this on windows but I guess it doesn't makes a difference on other OS's.

If you want me to change or squash something, just tell me.

regards,
sphere
