### PR TITLE
changed, always show video->files so we do not have to add a video source to see usb drives

### DIFF
--- a/xbmc/filesystem/SourcesDirectory.cpp
+++ b/xbmc/filesystem/SourcesDirectory.cpp
@@ -53,7 +53,7 @@ bool CSourcesDirectory::GetDirectory(const CStdString& strPath, CFileItemList &i
     sources = *sourcesFromType;
   g_mediaManager.GetRemovableDrives(sources);
 
-  if (sources.empty())
+  if (!sourcesFromType)
     return false;
 
   return GetDirectory(sources, items);

--- a/xbmc/video/GUIViewStateVideo.cpp
+++ b/xbmc/video/GUIViewStateVideo.cpp
@@ -423,16 +423,6 @@ VECSOURCES& CGUIViewStateWindowVideoNav::GetSources()
     m_sources.push_back(share);
   }
 
-  if (g_settings.GetSourcesFromType("video")->empty())
-  { // no sources - add the "Add Source" item
-    CMediaSource share;
-    share.strName=g_localizeStrings.Get(999); // "Add Videos"
-    share.strPath = "sources://add/";
-    share.m_strThumbnailImage = CUtil::GetDefaultFolderThumb("DefaultAddSource.png");
-    share.m_iDriveType = CMediaSource::SOURCE_TYPE_LOCAL;
-    m_sources.push_back(share);
-  }
-  else
   {
     { // Files share
       CMediaSource share;


### PR DESCRIPTION
Currently we do not show video->files until a video source is added. This can cause newbee user confusion when they insert a usb drive with videos and the drive does not show up anywhere despite a toast announce of said drive being added. Then we confuse them further by moving video->add videos to inside video->files when a video source is added.

This change always shows video->files and 'add videos...' is always inside video->files so we present a consistent user interface and solves the 'wtf is my usb drive of videos' issues for new users of xbmc.
