### PR TITLE
revert parts of 43699ed7 and fix scanning of excluded folders (fixes #12955)

### DIFF
--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -213,7 +213,7 @@ namespace VIDEO
     if (CUtil::ExcludeFileOrFolder(strDirectory, regexps))
       return true;
 
-    bool ignoreFolder = m_scanAll && settings.noupdate;
+    bool ignoreFolder = !m_scanAll && settings.noupdate;
     if (content == CONTENT_NONE || ignoreFolder)
       return true;
 

--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -1322,7 +1322,7 @@ bool CGUIWindowVideoBase::OnContextButton(int itemNumber, CONTEXT_BUTTON button)
       if (item->m_bIsFolder)
       {
         m_database.SetPathHash(strPath,""); // to force scan
-        OnScan(strPath);
+        OnScan(strPath, true);
       }
       else
         OnInfo(item.get(),info);

--- a/xbmc/video/windows/GUIWindowVideoNav.cpp
+++ b/xbmc/video/windows/GUIWindowVideoNav.cpp
@@ -1321,7 +1321,7 @@ bool CGUIWindowVideoNav::OnContextButton(int itemNumber, CONTEXT_BUTTON button)
     }
   case CONTEXT_BUTTON_UPDATE_LIBRARY:
     {
-      OnScan("",true);
+      OnScan("");
       return true;
     }
   case CONTEXT_BUTTON_UNLINK_MOVIE:


### PR DESCRIPTION
This commit reverts parts of 43699ed7 from @cptspiff which changed the meaning of the scanAll parameter of CVideoInfoScanner::Start() to "only scan non-excluded folders" but didn't adjust the parameter's name or its default value accordingly. Furthermore it didn't adjust the other calls to CVideoInfoScanner::Start (in CApplication in case "update library on startup" is enabled and in JSON-RPC) which lead to those calls ignoring the "exclude folder from scan" setting during those scans. To keep the change minimal I kept the name and the default value of the scanAll parameter and therefore had to revert the logic change in CVideoInfoScanner::DoScan() and adjust the calls to CVideoInfoScanner::Start() (and it's wrappers) accordingly.

This should fix http://trac.xbmc.org/ticket/12955
