### PR TITLE
Polish time format

### DIFF
--- a/language/Polish/langinfo.xml
+++ b/language/Polish/langinfo.xml
@@ -13,7 +13,7 @@
     <region name="Polska" locale="PL">
       <dateshort>DD.MM.YYYY</dateshort>
       <datelong>DDDD, D MMMM YYYY</datelong>
-      <time symbolAM="" symbolPM="">HH:mm:ss</time>
+      <time symbolAM="" symbolPM="">H:mm:ss</time>
       <tempunit>C</tempunit>
       <speedunit>kmh</speedunit>
       <timezone>CEST</timezone>


### PR DESCRIPTION
Time format in Polish language contain wrong format causing displaying hours twice, eg. 7 PM will be 1919:00:00 instead just 19:00:00.
Translation need some work but according to forum minor translation changes should not be done before next release which will contain new language model.
