### PR TITLE
[linux] fixed compile error. malloc/free is defined in stdlib.h

### DIFF
--- a/xbmc/linux/PlatformDefs.h
+++ b/xbmc/linux/PlatformDefs.h
@@ -48,6 +48,7 @@
 #endif
 #include <sys/time.h>
 #include <time.h>
+#include <stdlib.h>
 #endif
 
 // do not move this, it will break osx build bad"


### PR DESCRIPTION
In file included from OverlayRenderer.cpp:26:0:
/opt/xbmc-bcm/xbmc-rbp/xbmc/cores/dvdplayer/DVDCodecs/Overlay/DVDOverlayImage.h: In copy constructor 'CDVDOverlayImage::CDVDOverlayImage(const CDVDOverlayImage&)':
/opt/xbmc-bcm/xbmc-rbp/xbmc/cores/dvdplayer/DVDCodecs/Overlay/DVDOverlayImage.h:47:54: error: 'malloc' was not declared in this scope
/opt/xbmc-bcm/xbmc-rbp/xbmc/cores/dvdplayer/DVDCodecs/Overlay/DVDOverlayImage.h: In destructor 'virtual CDVDOverlayImage::~CDVDOverlayImage()':
/opt/xbmc-bcm/xbmc-rbp/xbmc/cores/dvdplayer/DVDCodecs/Overlay/DVDOverlayImage.h:66:23: error: 'free' was not declared in this scope
/opt/xbmc-bcm/xbmc-rbp/xbmc/cores/dvdplayer/DVDCodecs/Overlay/DVDOverlayImage.h:67:29: error: 'free' was not declared in this scope
In file included from OverlayRendererUtil.cpp:23:0:
OverlayRendererUtil.h: In destructor 'OVERLAY::SQuads::~SQuads()':
OverlayRendererUtil.h:48:16: error: 'free' was not declared in this scope
In file included from OverlayRendererUtil.cpp:24:0:
/opt/xbmc-bcm/xbmc-rbp/xbmc/cores/dvdplayer/DVDCodecs/Overlay/DVDOverlayImage.h: In copy constructor 'CDVDOverlayImage::CDVDOverlayImage(const CDVDOverlayImage&)':
/opt/xbmc-bcm/xbmc-rbp/xbmc/cores/dvdplayer/DVDCodecs/Overlay/DVDOverlayImage.h:47:54: error: 'malloc' was not declared in this scope
/opt/xbmc-bcm/xbmc-rbp/xbmc/cores/dvdplayer/DVDCodecs/Overlay/DVDOverlayImage.h: In destructor 'virtual CDVDOverlayImage::~CDVDOverlayImage()':
/opt/xbmc-bcm/xbmc-rbp/xbmc/cores/dvdplayer/DVDCodecs/Overlay/DVDOverlayImage.h:66:23: error: 'free' was not declared in this scope
/opt/xbmc-bcm/xbmc-rbp/xbmc/cores/dvdplayer/DVDCodecs/Overlay/DVDOverlayImage.h:67:29: error: 'free' was not declared in this scope
/opt/xbmc-bcm/xbmc-rbp/xbmc/utils/CharsetConverter.h: At global scope:
/opt/xbmc-bcm/xbmc-rbp/xbmc/utils/CharsetConverter.h:84:1: warning: 'g_charsetConverter' defined but not used [-Wunused-variable]
