### PR TITLE
No GUI dependency for library scans

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -5477,6 +5477,28 @@ void CApplication::UpdateLibraries()
   }
 }
 
+bool CApplication::IsVideoScanning() const
+{
+  return m_videoInfoScanner->IsScanning();
+}
+
+bool CApplication::IsMusicScanning() const
+{
+  return m_musicInfoScanner->IsScanning();
+}
+
+void CApplication::StopVideoScan()
+{
+  if (m_videoInfoScanner->IsScanning())
+    m_videoInfoScanner->Stop();
+}
+
+void CApplication::StopMusicScan()
+{
+  if (m_musicInfoScanner->IsScanning())
+    m_musicInfoScanner->Stop();
+}
+
 void CApplication::StartVideoScan(const CStdString &strDirectory, bool scanAll)
 {
   if (m_videoInfoScanner->IsScanning())

--- a/xbmc/Application.h
+++ b/xbmc/Application.h
@@ -83,6 +83,15 @@ class CHTTPWebinterfaceHandler;
 class CHTTPWebinterfaceAddonsHandler;
 #endif
 #endif
+namespace VIDEO
+{
+  class CVideoInfoScanner;
+}
+
+namespace MUSIC_INFO
+{
+  class CMusicInfoScanner;
+}
 
 class CBackgroundPlayer : public CThread
 {
@@ -208,6 +217,12 @@ public:
 
   void SaveMusicScanSettings();
   void RestoreMusicScanSettings();
+
+  void StartVideoScan(const CStdString &path, bool scanAll = false);
+  void StartMusicScan(const CStdString &path);
+  void StartMusicAlbumScan(const CStdString& strDirectory);
+  void StartMusicArtistScan(const CStdString& strDirectory);
+
   void UpdateLibraries();
   void CheckMusicPlaylist();
 
@@ -372,6 +387,9 @@ protected:
   int        m_frameCount;
   CCriticalSection m_frameMutex;
   XbmcThreads::ConditionVariable  m_frameCond;
+
+  VIDEO::CVideoInfoScanner *m_videoInfoScanner;
+  MUSIC_INFO::CMusicInfoScanner *m_musicInfoScanner;
 
   void Mute();
   void UnMute();

--- a/xbmc/Application.h
+++ b/xbmc/Application.h
@@ -218,6 +218,11 @@ public:
   void SaveMusicScanSettings();
   void RestoreMusicScanSettings();
 
+  void StopVideoScan();
+  void StopMusicScan();
+  bool IsMusicScanning() const;
+  bool IsVideoScanning() const;
+
   void StartVideoScan(const CStdString &path, bool scanAll = false);
   void StartMusicScan(const CStdString &path);
   void StartMusicAlbumScan(const CStdString& strDirectory);

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -46,8 +46,6 @@
 #include "music/LastFmManager.h"
 #include "pictures/PictureInfoTag.h"
 #include "music/tags/MusicInfoTag.h"
-#include "music/dialogs/GUIDialogMusicScan.h"
-#include "video/dialogs/GUIDialogVideoScan.h"
 #include "guilib/GUIWindowManager.h"
 #include "filesystem/File.h"
 #include "playlists/PlayList.h"

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -1866,22 +1866,18 @@ bool CGUIInfoManager::GetBool(int condition1, int contextWindow, const CGUIListI
     bReturn = GetLibraryBool(condition);
   else if (condition == LIBRARY_IS_SCANNING)
   {
-    CGUIDialogMusicScan *musicScanner = (CGUIDialogMusicScan *)g_windowManager.GetWindow(WINDOW_DIALOG_MUSIC_SCAN);
-    CGUIDialogVideoScan *videoScanner = (CGUIDialogVideoScan *)g_windowManager.GetWindow(WINDOW_DIALOG_VIDEO_SCAN);
-    if (musicScanner->IsScanning() || videoScanner->IsScanning())
+    if (g_application.IsMusicScanning() || g_application.IsVideoScanning())
       bReturn = true;
     else
       bReturn = false;
   }
   else if (condition == LIBRARY_IS_SCANNING_VIDEO)
   {
-    CGUIDialogVideoScan *videoScanner = (CGUIDialogVideoScan *)g_windowManager.GetWindow(WINDOW_DIALOG_VIDEO_SCAN);
-    bReturn = (videoScanner && videoScanner->IsScanning());
+    bReturn = g_application.IsVideoScanning();
   }
   else if (condition == LIBRARY_IS_SCANNING_MUSIC)
   {
-    CGUIDialogMusicScan *musicScanner = (CGUIDialogMusicScan *)g_windowManager.GetWindow(WINDOW_DIALOG_MUSIC_SCAN);
-    bReturn = (musicScanner && musicScanner->IsScanning());
+    bReturn = g_application.IsMusicScanning();
   }
   else if (condition == SYSTEM_PLATFORM_LINUX)
 #if defined(_LINUX) && !defined(__APPLE__)

--- a/xbmc/interfaces/Builtins.cpp
+++ b/xbmc/interfaces/Builtins.cpp
@@ -1172,18 +1172,22 @@ int CBuiltins::Execute(const CStdString& execString)
       return -1;
 
     g_application.StopPlaying();
-    CGUIDialogMusicScan *musicScan = (CGUIDialogMusicScan *)g_windowManager.GetWindow(WINDOW_DIALOG_MUSIC_SCAN);
-    if (musicScan && musicScan->IsScanning())
+    if (g_application.IsMusicScanning())
     {
-      musicScan->StopScanning();
-      musicScan->Close(true);
+      g_application.StopMusicScan();
+      CGUIDialogMusicScan *musicScan = (CGUIDialogMusicScan *)g_windowManager.GetWindow(WINDOW_DIALOG_MUSIC_SCAN);
+      if (musicScan)
+        musicScan->Close(true);
     }
 
-    CGUIDialogVideoScan *videoScan = (CGUIDialogVideoScan *)g_windowManager.GetWindow(WINDOW_DIALOG_VIDEO_SCAN);
-    if (videoScan && videoScan->IsScanning())
+    if (g_application.IsVideoScanning())
     {
-      videoScan->StopScanning();
-      videoScan->Close(true);
+      g_application.StopVideoScan();
+      CGUIDialogVideoScan *videoScan = (CGUIDialogVideoScan *)g_windowManager.GetWindow(WINDOW_DIALOG_VIDEO_SCAN);
+      if (videoScan)
+      {
+        videoScan->Close(true);
+      }
     }
 
     ADDON::CAddonMgr::Get().StopServices(true);
@@ -1211,35 +1215,24 @@ int CBuiltins::Execute(const CStdString& execString)
   {
     if (params[0].Equals("music"))
     {
-      CGUIDialogMusicScan *scanner = (CGUIDialogMusicScan *)g_windowManager.GetWindow(WINDOW_DIALOG_MUSIC_SCAN);
-      if (scanner)
-      {
-        if (scanner->IsScanning())
-          scanner->StopScanning();
-        else
-          scanner->StartScanning(params.size() > 1 ? params[1] : "");
-      }
+      if (g_application.IsMusicScanning())
+        g_application.StopMusicScan();
+      else
+        g_application.StartMusicScan(params.size() > 1 ? params[1] : "");
     }
     if (params[0].Equals("video"))
     {
-      CGUIDialogVideoScan *scanner = (CGUIDialogVideoScan *)g_windowManager.GetWindow(WINDOW_DIALOG_VIDEO_SCAN);
-      if (scanner)
-      {
-        if (scanner->IsScanning())
-          scanner->StopScanning();
-        else
-          scanner->StartScanning(params.size() > 1 ? params[1] : "");
-      }
+      if (g_application.IsVideoScanning())
+        g_application.StopVideoScan();
+      else
+        g_application.StartVideoScan(params.size() > 1 ? params[1] : "");
     }
   }
   else if (execute.Equals("cleanlibrary"))
   {
     if (!params.size() || params[0].Equals("video"))
     {
-      CGUIDialogVideoScan *scanner = (CGUIDialogVideoScan *)g_windowManager.GetWindow(WINDOW_DIALOG_VIDEO_SCAN);
-      if (scanner)
-      {
-        if (!scanner->IsScanning())
+        if (!g_application.IsVideoScanning())
         {
            CVideoDatabase videodatabase;
            videodatabase.Open();
@@ -1248,14 +1241,10 @@ int CBuiltins::Execute(const CStdString& execString)
         }
         else
           CLog::Log(LOGERROR, "XBMC.CleanLibrary is not possible while scanning for media info");
-      }
     }
     else if (params[0].Equals("music"))
     {
-      CGUIDialogMusicScan *scanner = (CGUIDialogMusicScan *)g_windowManager.GetWindow(WINDOW_DIALOG_MUSIC_SCAN);
-      if (scanner)
-      {
-        if (!scanner->IsScanning())
+        if (!g_application.IsMusicScanning())
         {
           CMusicDatabase musicdatabase;
 
@@ -1265,7 +1254,6 @@ int CBuiltins::Execute(const CStdString& execString)
         }
         else
           CLog::Log(LOGERROR, "XBMC.CleanLibrary is not possible while scanning for media info");
-      }
     }
   }
   else if (execute.Equals("exportlibrary"))

--- a/xbmc/interfaces/Builtins.cpp
+++ b/xbmc/interfaces/Builtins.cpp
@@ -1232,28 +1232,28 @@ int CBuiltins::Execute(const CStdString& execString)
   {
     if (!params.size() || params[0].Equals("video"))
     {
-        if (!g_application.IsVideoScanning())
-        {
-           CVideoDatabase videodatabase;
-           videodatabase.Open();
-           videodatabase.CleanDatabase();
-           videodatabase.Close();
-        }
-        else
-          CLog::Log(LOGERROR, "XBMC.CleanLibrary is not possible while scanning for media info");
+      if (!g_application.IsVideoScanning())
+      {
+         CVideoDatabase videodatabase;
+         videodatabase.Open();
+         videodatabase.CleanDatabase();
+         videodatabase.Close();
+      }
+      else
+        CLog::Log(LOGERROR, "XBMC.CleanLibrary is not possible while scanning for media info");
     }
     else if (params[0].Equals("music"))
     {
-        if (!g_application.IsMusicScanning())
-        {
-          CMusicDatabase musicdatabase;
+      if (!g_application.IsMusicScanning())
+      {
+        CMusicDatabase musicdatabase;
 
-          musicdatabase.Open();
-          musicdatabase.Cleanup();
-          musicdatabase.Close();
-        }
-        else
-          CLog::Log(LOGERROR, "XBMC.CleanLibrary is not possible while scanning for media info");
+        musicdatabase.Open();
+        musicdatabase.Cleanup();
+        musicdatabase.Close();
+      }
+      else
+        CLog::Log(LOGERROR, "XBMC.CleanLibrary is not possible while scanning for media info");
     }
   }
   else if (execute.Equals("exportlibrary"))

--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -28,7 +28,6 @@
 #include "filesystem/MusicDatabaseDirectory/QueryParams.h"
 #include "filesystem/MusicDatabaseDirectory.h"
 #include "filesystem/SpecialProtocol.h"
-#include "music/dialogs/GUIDialogMusicScan.h"
 #include "GUIInfoManager.h"
 #include "music/tags/MusicInfoTag.h"
 #include "addons/AddonManager.h"

--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -2326,8 +2326,7 @@ void CMusicDatabase::DeleteAlbumInfo()
 
   // If we are scanning for music info in the background,
   // other writing access to the database is prohibited.
-  CGUIDialogMusicScan* dlgMusicScan = (CGUIDialogMusicScan*)g_windowManager.GetWindow(WINDOW_DIALOG_MUSIC_SCAN);
-  if (dlgMusicScan->IsDialogRunning())
+  if (g_application.IsMusicScanning())
   {
     CGUIDialogOK::ShowAndGetInput(189, 14057, 0, 0);
     return;
@@ -2577,8 +2576,7 @@ void CMusicDatabase::Clean()
 {
   // If we are scanning for music info in the background,
   // other writing access to the database is prohibited.
-  CGUIDialogMusicScan* dlgMusicScan = (CGUIDialogMusicScan*)g_windowManager.GetWindow(WINDOW_DIALOG_MUSIC_SCAN);
-  if (dlgMusicScan->IsDialogRunning())
+  if (g_application.IsMusicScanning())
   {
     CGUIDialogOK::ShowAndGetInput(189, 14057, 0, 0);
     return;

--- a/xbmc/music/dialogs/GUIDialogMusicScan.cpp
+++ b/xbmc/music/dialogs/GUIDialogMusicScan.cpp
@@ -39,7 +39,6 @@ using namespace MUSIC_INFO;
 CGUIDialogMusicScan::CGUIDialogMusicScan(void)
 : CGUIDialog(WINDOW_DIALOG_MUSIC_SCAN, "DialogMusicScan.xml")
 {
-  m_musicInfoScanner.SetObserver(this);
 }
 
 CGUIDialogMusicScan::~CGUIDialogMusicScan(void)
@@ -110,6 +109,12 @@ void CGUIDialogMusicScan::StartScanning(const CStdString& strDirectory)
   g_application.SaveMusicScanSettings();
 
   m_musicInfoScanner.Start(strDirectory);
+}
+
+void CGUIDialogMusicScan::ShowScan()
+{
+  m_ScanState = PREPARING;
+  Show();
 }
 
 void CGUIDialogMusicScan::StartAlbumScan(const CStdString& strDirectory)

--- a/xbmc/music/dialogs/GUIDialogMusicScan.cpp
+++ b/xbmc/music/dialogs/GUIDialogMusicScan.cpp
@@ -96,66 +96,10 @@ void CGUIDialogMusicScan::OnSetProgress(int currentItem, int itemCount)
   if (m_fPercentDone>100.0F) m_fPercentDone=100.0F;
 }
 
-void CGUIDialogMusicScan::StartScanning(const CStdString& strDirectory)
-{
-  m_ScanState = PREPARING;
-
-  if (!g_guiSettings.GetBool("musiclibrary.backgroundupdate"))
-  {
-    Show();
-  }
-
-  // save settings
-  g_application.SaveMusicScanSettings();
-
-  m_musicInfoScanner.Start(strDirectory);
-}
-
 void CGUIDialogMusicScan::ShowScan()
 {
   m_ScanState = PREPARING;
   Show();
-}
-
-void CGUIDialogMusicScan::StartAlbumScan(const CStdString& strDirectory)
-{
-  m_ScanState = PREPARING;
-
-  if (!g_guiSettings.GetBool("musiclibrary.backgroundupdate"))
-  {
-    Show();
-  }
-
-  // save settings
-  g_application.SaveMusicScanSettings();
-
-  m_musicInfoScanner.FetchAlbumInfo(strDirectory);
-}
-
-void CGUIDialogMusicScan::StartArtistScan(const CStdString& strDirectory)
-{
-  m_ScanState = PREPARING;
-
-  if (!g_guiSettings.GetBool("musiclibrary.backgroundupdate"))
-  {
-    Show();
-  }
-
-  // save settings
-  g_application.SaveMusicScanSettings();
-
-  m_musicInfoScanner.FetchArtistInfo(strDirectory);
-}
-
-void CGUIDialogMusicScan::StopScanning()
-{
-  if (m_musicInfoScanner.IsScanning())
-    m_musicInfoScanner.Stop();
-}
-
-bool CGUIDialogMusicScan::IsScanning()
-{
-  return m_musicInfoScanner.IsScanning();
 }
 
 void CGUIDialogMusicScan::OnDirectoryScanned(const CStdString& strDirectory)

--- a/xbmc/music/dialogs/GUIDialogMusicScan.h
+++ b/xbmc/music/dialogs/GUIDialogMusicScan.h
@@ -36,6 +36,7 @@ public:
   void StartScanning(const CStdString& strDirectory);
   void StartAlbumScan(const CStdString& strDirectory);
   void StartArtistScan(const CStdString& strDirectory);
+  void ShowScan();
   bool IsScanning();
   void StopScanning();
 

--- a/xbmc/music/dialogs/GUIDialogMusicScan.h
+++ b/xbmc/music/dialogs/GUIDialogMusicScan.h
@@ -33,12 +33,7 @@ public:
   virtual bool OnMessage(CGUIMessage& message);
   virtual void FrameMove();
 
-  void StartScanning(const CStdString& strDirectory);
-  void StartAlbumScan(const CStdString& strDirectory);
-  void StartArtistScan(const CStdString& strDirectory);
   void ShowScan();
-  bool IsScanning();
-  void StopScanning();
 
   void UpdateState();
 protected:
@@ -49,7 +44,6 @@ protected:
   virtual void OnStateChanged(MUSIC_INFO::SCAN_STATE state);
   virtual void OnSetProgress(int currentItem, int itemCount);
 
-  MUSIC_INFO::CMusicInfoScanner m_musicInfoScanner;
   MUSIC_INFO::SCAN_STATE m_ScanState;
   CStdString m_strCurrentDir;
 

--- a/xbmc/music/windows/GUIWindowMusicBase.cpp
+++ b/xbmc/music/windows/GUIWindowMusicBase.cpp
@@ -89,8 +89,7 @@ CGUIWindowMusicBase::~CGUIWindowMusicBase ()
 
 bool CGUIWindowMusicBase::OnBack(int actionID)
 {
-  CGUIDialogMusicScan *musicScan = (CGUIDialogMusicScan *)g_windowManager.GetWindow(WINDOW_DIALOG_MUSIC_SCAN);
-  if (musicScan && !musicScan->IsDialogRunning())
+  if (!g_application.IsMusicScanning())
   {
     CUtil::ThumbCacheClear();
     CUtil::RemoveTempFiles();
@@ -240,16 +239,15 @@ bool CGUIWindowMusicBase::OnMessage(CGUIMessage& message)
 
 void CGUIWindowMusicBase::OnInfoAll(int iItem, bool bCurrent)
 {
-  CGUIDialogMusicScan* musicScan = (CGUIDialogMusicScan *)g_windowManager.GetWindow(WINDOW_DIALOG_MUSIC_SCAN);
   CMusicDatabaseDirectory dir;
   CStdString strPath = m_vecItems->GetPath();
   if (bCurrent)
     strPath = m_vecItems->Get(iItem)->GetPath();
 
   if (dir.HasAlbumInfo(m_vecItems->Get(iItem)->GetPath()))
-    musicScan->StartAlbumScan(strPath);
+    g_application.StartMusicAlbumScan(strPath);
   else
-    musicScan->StartArtistScan(strPath);
+    g_application.StartMusicArtistScan(strPath);
 }
 
 /// \brief Retrieves music info for albums from allmusic.com and displays them in CGUIDialogMusicInfo
@@ -419,8 +417,7 @@ void CGUIWindowMusicBase::ShowArtistInfo(const CArtist& artist, const CStdString
 
   // If we are scanning for music info in the background,
   // other writing access to the database is prohibited.
-  CGUIDialogMusicScan* dlgMusicScan = (CGUIDialogMusicScan*)g_windowManager.GetWindow(WINDOW_DIALOG_MUSIC_SCAN);
-  if (dlgMusicScan->IsDialogRunning())
+  if (g_application.IsMusicScanning())
   {
     CGUIDialogOK::ShowAndGetInput(189, 14057, 0, 0);
     return;
@@ -512,8 +509,7 @@ void CGUIWindowMusicBase::ShowAlbumInfo(const CAlbum& album, const CStdString& p
 
   // If we are scanning for music info in the background,
   // other writing access to the database is prohibited.
-  CGUIDialogMusicScan* dlgMusicScan = (CGUIDialogMusicScan*)g_windowManager.GetWindow(WINDOW_DIALOG_MUSIC_SCAN);
-  if (dlgMusicScan->IsDialogRunning())
+  if (g_application.IsMusicScanning())
   {
     CGUIDialogOK::ShowAndGetInput(189, 14057, 0, 0);
     return;
@@ -981,9 +977,7 @@ bool CGUIWindowMusicBase::OnContextButton(int itemNumber, CONTEXT_BUTTON button)
 
   case CONTEXT_BUTTON_STOP_SCANNING:
     {
-      CGUIDialogMusicScan *scanner = (CGUIDialogMusicScan *)g_windowManager.GetWindow(WINDOW_DIALOG_MUSIC_SCAN);
-      if (scanner)
-        scanner->StopScanning();
+      g_application.StopMusicScan();
       return true;
     }
 

--- a/xbmc/music/windows/GUIWindowMusicNav.cpp
+++ b/xbmc/music/windows/GUIWindowMusicNav.cpp
@@ -408,7 +408,6 @@ void CGUIWindowMusicNav::GetContextButtons(int itemNumber, CContextButtons &butt
 {
   CGUIWindowMusicBase::GetContextButtons(itemNumber, buttons);
 
-  CGUIDialogMusicScan *musicScan = (CGUIDialogMusicScan *)g_windowManager.GetWindow(WINDOW_DIALOG_MUSIC_SCAN);
   CFileItemPtr item;
   if (itemNumber >= 0 && itemNumber < m_vecItems->Size())
     item = m_vecItems->Get(itemNumber);
@@ -532,9 +531,9 @@ void CGUIWindowMusicNav::GetContextButtons(int itemNumber, CContextButtons &butt
   }
   // noncontextual buttons
 
-  if (musicScan && musicScan->IsScanning())
+  if (g_application.IsMusicScanning())
     buttons.Add(CONTEXT_BUTTON_STOP_SCANNING, 13353);     // Stop Scanning
-  else if (musicScan)
+  else
     buttons.Add(CONTEXT_BUTTON_UPDATE_LIBRARY, 653);
 
   CGUIWindowMusicBase::GetNonContextButtons(buttons);
@@ -606,9 +605,7 @@ bool CGUIWindowMusicNav::OnContextButton(int itemNumber, CONTEXT_BUTTON button)
 
   case CONTEXT_BUTTON_UPDATE_LIBRARY:
     {
-      CGUIDialogMusicScan *scanner = (CGUIDialogMusicScan *)g_windowManager.GetWindow(WINDOW_DIALOG_MUSIC_SCAN);
-      if (scanner)
-        scanner->StartScanning("");
+      g_application.StartMusicScan("");
       return true;
     }
 

--- a/xbmc/music/windows/GUIWindowMusicNav.cpp
+++ b/xbmc/music/windows/GUIWindowMusicNav.cpp
@@ -31,7 +31,6 @@
 #include "PartyModeManager.h"
 #include "playlists/PlayList.h"
 #include "playlists/PlayListFactory.h"
-#include "music/dialogs/GUIDialogMusicScan.h"
 #include "video/VideoDatabase.h"
 #include "video/windows/GUIWindowVideoNav.h"
 #include "music/tags/MusicInfoTag.h"

--- a/xbmc/music/windows/GUIWindowMusicSongs.cpp
+++ b/xbmc/music/windows/GUIWindowMusicSongs.cpp
@@ -177,16 +177,15 @@ void CGUIWindowMusicSongs::OnScan(int iItem)
 
 void CGUIWindowMusicSongs::DoScan(const CStdString &strPath)
 {
-  CGUIDialogMusicScan *musicScan = (CGUIDialogMusicScan *)g_windowManager.GetWindow(WINDOW_DIALOG_MUSIC_SCAN);
-  if (musicScan && musicScan->IsScanning())
+  if (g_application.IsMusicScanning())
   {
-    musicScan->StopScanning();
+    g_application.StopMusicScan();
     return;
   }
 
   // Start background loader
   int iControl=GetFocusedControlID();
-  if (musicScan) musicScan->StartScanning(strPath);
+  g_application.StartMusicScan(strPath);
   SET_CONTROL_FOCUS(iControl, 0);
   UpdateButtons();
 
@@ -269,8 +268,7 @@ void CGUIWindowMusicSongs::UpdateButtons()
     CONTROL_ENABLE(CONTROL_BTNSCAN);
   }
 
-  CGUIDialogMusicScan *musicScan = (CGUIDialogMusicScan *)g_windowManager.GetWindow(WINDOW_DIALOG_MUSIC_SCAN);
-  if (musicScan && musicScan->IsScanning())
+  if (g_application.IsMusicScanning())
   {
     SET_CONTROL_LABEL(CONTROL_BTNSCAN, 14056); // Stop Scan
   }
@@ -362,10 +360,7 @@ void CGUIWindowMusicSongs::GetContextButtons(int itemNumber, CContextButtons &bu
     }
 
     // Add the scan button(s)
-    CGUIDialogMusicScan *pScanDlg = (CGUIDialogMusicScan *)g_windowManager.GetWindow(WINDOW_DIALOG_MUSIC_SCAN);
-    if (pScanDlg)
-    {
-      if (pScanDlg->IsScanning())
+      if (g_application.IsMusicScanning())
         buttons.Add(CONTEXT_BUTTON_STOP_SCANNING, 13353); // Stop Scanning
       else if (!inPlaylists && !m_vecItems->IsInternetStream()           &&
                !item->IsLastFM()                                         &&
@@ -375,7 +370,6 @@ void CGUIWindowMusicSongs::GetContextButtons(int itemNumber, CContextButtons &bu
       {
         buttons.Add(CONTEXT_BUTTON_SCAN, 13352);
       }
-    }
     if (item->IsPlugin() || item->IsScript() || m_vecItems->IsPlugin())
       buttons.Add(CONTEXT_BUTTON_PLUGIN_SETTINGS, 1045);
   }

--- a/xbmc/music/windows/GUIWindowMusicSongs.cpp
+++ b/xbmc/music/windows/GUIWindowMusicSongs.cpp
@@ -360,16 +360,16 @@ void CGUIWindowMusicSongs::GetContextButtons(int itemNumber, CContextButtons &bu
     }
 
     // Add the scan button(s)
-      if (g_application.IsMusicScanning())
-        buttons.Add(CONTEXT_BUTTON_STOP_SCANNING, 13353); // Stop Scanning
-      else if (!inPlaylists && !m_vecItems->IsInternetStream()           &&
-               !item->IsLastFM()                                         &&
-               !item->GetPath().Equals("add") && !item->IsParentFolder() &&
-               !item->IsPlugin()                                         &&
-              (g_settings.GetCurrentProfile().canWriteDatabases() || g_passwordManager.bMasterUser))
-      {
-        buttons.Add(CONTEXT_BUTTON_SCAN, 13352);
-      }
+    if (g_application.IsMusicScanning())
+      buttons.Add(CONTEXT_BUTTON_STOP_SCANNING, 13353); // Stop Scanning
+    else if (!inPlaylists && !m_vecItems->IsInternetStream()           &&
+             !item->IsLastFM()                                         &&
+             !item->GetPath().Equals("add") && !item->IsParentFolder() &&
+             !item->IsPlugin()                                         &&
+            (g_settings.GetCurrentProfile().canWriteDatabases() || g_passwordManager.bMasterUser))
+    {
+      buttons.Add(CONTEXT_BUTTON_SCAN, 13352);
+    }
     if (item->IsPlugin() || item->IsScript() || m_vecItems->IsPlugin())
       buttons.Add(CONTEXT_BUTTON_PLUGIN_SETTINGS, 1045);
   }

--- a/xbmc/music/windows/GUIWindowMusicSongs.cpp
+++ b/xbmc/music/windows/GUIWindowMusicSongs.cpp
@@ -26,7 +26,6 @@
 #include "Application.h"
 #include "CueDocument.h"
 #include "GUIPassword.h"
-#include "music/dialogs/GUIDialogMusicScan.h"
 #include "dialogs/GUIDialogYesNo.h"
 #include "GUIUserMessages.h"
 #include "guilib/GUIWindowManager.h"

--- a/xbmc/video/dialogs/GUIDialogVideoScan.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoScan.cpp
@@ -114,33 +114,10 @@ void CGUIDialogVideoScan::OnSetTitle(const CStdString& strTitle)
   m_strTitle = strTitle;
 }
 
-void CGUIDialogVideoScan::StartScanning(const CStdString& strDirectory, bool scanAll)
-{
-  m_ScanState = PREPARING;
-
-  if (!g_guiSettings.GetBool("videolibrary.backgroundupdate"))
-  {
-    Show();
-  }
-
-  m_videoInfoScanner.Start(strDirectory,scanAll);
-}
-
 void CGUIDialogVideoScan::ShowScan()
 {
   m_ScanState = PREPARING;
   Show();
-}
-
-void CGUIDialogVideoScan::StopScanning()
-{
-  if (m_videoInfoScanner.IsScanning())
-    m_videoInfoScanner.Stop();
-}
-
-bool CGUIDialogVideoScan::IsScanning()
-{
-  return m_videoInfoScanner.IsScanning();
 }
 
 void CGUIDialogVideoScan::OnDirectoryScanned(const CStdString& strDirectory)

--- a/xbmc/video/dialogs/GUIDialogVideoScan.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoScan.cpp
@@ -40,7 +40,6 @@ using namespace VIDEO;
 CGUIDialogVideoScan::CGUIDialogVideoScan(void)
 : CGUIDialog(WINDOW_DIALOG_VIDEO_SCAN, "DialogVideoScan.xml")
 {
-  m_videoInfoScanner.SetObserver(this);
 }
 
 CGUIDialogVideoScan::~CGUIDialogVideoScan(void)
@@ -125,6 +124,12 @@ void CGUIDialogVideoScan::StartScanning(const CStdString& strDirectory, bool sca
   }
 
   m_videoInfoScanner.Start(strDirectory,scanAll);
+}
+
+void CGUIDialogVideoScan::ShowScan()
+{
+  m_ScanState = PREPARING;
+  Show();
 }
 
 void CGUIDialogVideoScan::StopScanning()

--- a/xbmc/video/dialogs/GUIDialogVideoScan.h
+++ b/xbmc/video/dialogs/GUIDialogVideoScan.h
@@ -34,9 +34,6 @@ public:
   virtual void FrameMove();
 
   void ShowScan();
-  void StartScanning(const CStdString& strDirectory, bool scanAll = false);
-  bool IsScanning();
-  void StopScanning();
 
   void UpdateState();
 protected:
@@ -49,7 +46,6 @@ protected:
   virtual void OnSetCurrentProgress(int currentItem, int itemCount);
   virtual void OnSetTitle(const CStdString& strTitle);
 
-  VIDEO::CVideoInfoScanner m_videoInfoScanner;
   VIDEO::SCAN_STATE m_ScanState;
   CStdString m_strCurrentDir;
   CStdString m_strTitle;

--- a/xbmc/video/dialogs/GUIDialogVideoScan.h
+++ b/xbmc/video/dialogs/GUIDialogVideoScan.h
@@ -33,6 +33,7 @@ public:
   virtual bool OnMessage(CGUIMessage& message);
   virtual void FrameMove();
 
+  void ShowScan();
   void StartScanning(const CStdString& strDirectory, bool scanAll = false);
   bool IsScanning();
   void StopScanning();

--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -444,8 +444,7 @@ bool CGUIWindowVideoBase::ShowIMDB(CFileItem *item, const ScraperPtr &info2)
   if(!info)
     return false;
 
-  CGUIDialogVideoScan* pDialog = (CGUIDialogVideoScan*)g_windowManager.GetWindow(WINDOW_DIALOG_VIDEO_SCAN);
-  if (pDialog && pDialog->IsScanning())
+  if (g_application.IsVideoScanning())
   {
     CGUIDialogOK::ShowAndGetInput(13346,14057,-1,-1);
     return false;
@@ -1296,9 +1295,7 @@ bool CGUIWindowVideoBase::OnContextButton(int itemNumber, CONTEXT_BUTTON button)
 
   case CONTEXT_BUTTON_STOP_SCANNING:
     {
-      CGUIDialogVideoScan *pScanDlg = (CGUIDialogVideoScan *)g_windowManager.GetWindow(WINDOW_DIALOG_VIDEO_SCAN);
-      if (pScanDlg && pScanDlg->IsScanning())
-        pScanDlg->StopScanning();
+      g_application.StopVideoScan();
       return true;
     }
   case CONTEXT_BUTTON_SCAN:
@@ -1468,8 +1465,7 @@ void CGUIWindowVideoBase::MarkWatched(const CFileItemPtr &item, bool bMark)
   if (!g_settings.GetCurrentProfile().canWriteDatabases())
     return;
   // dont allow update while scanning
-  CGUIDialogVideoScan* pDialogScan = (CGUIDialogVideoScan*)g_windowManager.GetWindow(WINDOW_DIALOG_VIDEO_SCAN);
-  if (pDialogScan && pDialogScan->IsScanning())
+  if (g_application.IsVideoScanning())
   {
     CGUIDialogOK::ShowAndGetInput(257, 0, 14057, 0);
     return;
@@ -1516,8 +1512,7 @@ void CGUIWindowVideoBase::MarkWatched(const CFileItemPtr &item, bool bMark)
 void CGUIWindowVideoBase::UpdateVideoTitle(const CFileItem* pItem)
 {
   // dont allow update while scanning
-  CGUIDialogVideoScan* pDialogScan = (CGUIDialogVideoScan*)g_windowManager.GetWindow(WINDOW_DIALOG_VIDEO_SCAN);
-  if (pDialogScan && pDialogScan->IsScanning())
+  if (g_application.IsVideoScanning())
   {
     CGUIDialogOK::ShowAndGetInput(257, 0, 14057, 0);
     return;
@@ -1909,9 +1904,7 @@ int CGUIWindowVideoBase::GetScraperForItem(CFileItem *item, ADDON::ScraperPtr &i
 
 void CGUIWindowVideoBase::OnScan(const CStdString& strPath, bool scanAll)
 {
-  CGUIDialogVideoScan* pDialog = (CGUIDialogVideoScan*)g_windowManager.GetWindow(WINDOW_DIALOG_VIDEO_SCAN);
-  if (pDialog)
-    pDialog->StartScanning(strPath, scanAll);
+    g_application.StartVideoScan(strPath, scanAll);
 }
 
 CStdString CGUIWindowVideoBase::GetStartFolder(const CStdString &dir)
@@ -1991,8 +1984,6 @@ void CGUIWindowVideoBase::OnAssignContent(const CStdString &path)
 
   if (bScan)
   {
-    CGUIDialogVideoScan* pDialog = (CGUIDialogVideoScan*)g_windowManager.GetWindow(WINDOW_DIALOG_VIDEO_SCAN);
-    if (pDialog)
-      pDialog->StartScanning(path, true);
+    g_application.StartVideoScan(path, true);
   }
 }

--- a/xbmc/video/windows/GUIWindowVideoNav.cpp
+++ b/xbmc/video/windows/GUIWindowVideoNav.cpp
@@ -747,8 +747,7 @@ bool CGUIWindowVideoNav::DeleteItem(CFileItem* pItem, bool bUnavailable /* = fal
     iType = VIDEODB_CONTENT_MUSICVIDEOS;
 
   // dont allow update while scanning
-  CGUIDialogVideoScan* pDialogScan = (CGUIDialogVideoScan*)g_windowManager.GetWindow(WINDOW_DIALOG_VIDEO_SCAN);
-  if (pDialogScan && pDialogScan->IsScanning())
+  if (g_application.IsVideoScanning())
   {
     CGUIDialogOK::ShowAndGetInput(257, 0, 14057, 0);
     return false;
@@ -887,8 +886,7 @@ void CGUIWindowVideoNav::GetContextButtons(int itemNumber, CContextButtons &butt
 
   if (!item)
   {
-    CGUIDialogVideoScan *pScanDlg = (CGUIDialogVideoScan *)g_windowManager.GetWindow(WINDOW_DIALOG_VIDEO_SCAN);
-    if (pScanDlg && pScanDlg->IsScanning())
+    if (g_application.IsVideoScanning())
       buttons.Add(CONTEXT_BUTTON_STOP_SCANNING, 13353);
     else
       buttons.Add(CONTEXT_BUTTON_UPDATE_LIBRARY, 653);
@@ -898,8 +896,7 @@ void CGUIWindowVideoNav::GetContextButtons(int itemNumber, CContextButtons &butt
     // get the usual shares
     CGUIDialogContextMenu::GetContextButtons("video", item, buttons);
     // add scan button somewhere here
-    CGUIDialogVideoScan *pScanDlg = (CGUIDialogVideoScan *)g_windowManager.GetWindow(WINDOW_DIALOG_VIDEO_SCAN);
-    if (pScanDlg && pScanDlg->IsScanning())
+    if (g_application.IsVideoScanning())
       buttons.Add(CONTEXT_BUTTON_STOP_SCANNING, 13353);  // Stop Scanning
     if (!item->IsDVD() && item->GetPath() != "add" && !item->IsParentFolder() &&
         (g_settings.GetCurrentProfile().canWriteDatabases() || g_passwordManager.bMasterUser))
@@ -908,7 +905,7 @@ void CGUIWindowVideoNav::GetContextButtons(int itemNumber, CContextButtons &butt
       database.Open();
       ADDON::ScraperPtr info = database.GetScraperForPath(item->GetPath());
 
-      if (!pScanDlg || (pScanDlg && !pScanDlg->IsScanning()))
+      if (!g_application.IsVideoScanning())
       {
         if (!item->IsLiveTV() && !item->IsPlugin() && !item->IsAddonsPath())
         {
@@ -919,7 +916,7 @@ void CGUIWindowVideoNav::GetContextButtons(int itemNumber, CContextButtons &butt
         }
       }
 
-      if (info && (!pScanDlg || (pScanDlg && !pScanDlg->IsScanning())))
+      if (info && !g_application.IsVideoScanning())
         buttons.Add(CONTEXT_BUTTON_SCAN, 13349);
     }
   }
@@ -974,8 +971,7 @@ void CGUIWindowVideoNav::GetContextButtons(int itemNumber, CContextButtons &butt
       {
         if (node == NODE_TYPE_TITLE_TVSHOWS)
         {
-          CGUIDialogVideoScan *pScanDlg = (CGUIDialogVideoScan *)g_windowManager.GetWindow(WINDOW_DIALOG_VIDEO_SCAN);
-          if (pScanDlg && pScanDlg->IsScanning())
+          if (g_application.IsVideoScanning())
             buttons.Add(CONTEXT_BUTTON_STOP_SCANNING, 13353);
           else
             buttons.Add(CONTEXT_BUTTON_UPDATE_TVSHOW, 13349);
@@ -1044,8 +1040,7 @@ void CGUIWindowVideoNav::GetContextButtons(int itemNumber, CContextButtons &butt
         }
 
         // this should ideally be non-contextual (though we need some context for non-tv show node I guess)
-        CGUIDialogVideoScan *pScanDlg = (CGUIDialogVideoScan *)g_windowManager.GetWindow(WINDOW_DIALOG_VIDEO_SCAN);
-        if (pScanDlg && pScanDlg->IsScanning())
+        if (g_application.IsVideoScanning())
         {
           if (node != NODE_TYPE_TITLE_TVSHOWS)
             buttons.Add(CONTEXT_BUTTON_STOP_SCANNING, 13353);
@@ -1067,13 +1062,12 @@ void CGUIWindowVideoNav::GetContextButtons(int itemNumber, CContextButtons &butt
         // add "Set/Change content" to folders
         if (item->m_bIsFolder && !item->IsPlayList() && !item->IsSmartPlayList() && !item->IsLiveTV() && !item->IsPlugin() && !item->IsAddonsPath())
         {
-          CGUIDialogVideoScan *pScanDlg = (CGUIDialogVideoScan *)g_windowManager.GetWindow(WINDOW_DIALOG_VIDEO_SCAN);
-          if (!pScanDlg || (pScanDlg && !pScanDlg->IsScanning()))
+          if (!g_application.IsVideoScanning())
           {
             if (info && info->Content() != CONTENT_NONE)
             {
               buttons.Add(CONTEXT_BUTTON_SET_CONTENT, 20442);
-              if (info && (!pScanDlg || (pScanDlg && !pScanDlg->IsScanning())))
+              if (info && g_application.IsVideoScanning())
                 buttons.Add(CONTEXT_BUTTON_SCAN, 13349);
             }
             else


### PR DESCRIPTION
In working on a headless libxbmc, we've hit a few snags in places where the gui is used needlessly. In this case, music/video scanning required use of dialogs in order to function. This series removes that dependency.
