### PR TITLE
Texture cache changes to prepare for various new features

### DIFF
--- a/xbmc/GUILargeTextureManager.cpp
+++ b/xbmc/GUILargeTextureManager.cpp
@@ -67,7 +67,7 @@ bool CImageLoader::DoWork()
     m_texture = CTextureCacheJob::LoadImage(image, width, height, flipped);
 
     if (m_texture)
-      CTextureCache::Get().BackgroundCacheTexture(texturePath, m_texture, width, height);
+      CTextureCache::Get().BackgroundCacheTexture(texturePath, m_texture);
   }
   else
   {

--- a/xbmc/GUILargeTextureManager.cpp
+++ b/xbmc/GUILargeTextureManager.cpp
@@ -57,19 +57,11 @@ bool CImageLoader::DoWork()
   if (loadPath.IsEmpty())
   {
     // not in our texture cache, so try and load directly and then cache the result
-    bool flipped;
-    unsigned int width, height;
-    CStdString image = CTextureCacheJob::DecodeImageURL(texturePath, width, height, flipped);
-
-    if (image.IsEmpty())
-      return false; // nothing to load
-
-    m_texture = CTextureCacheJob::LoadImage(image, width, height, flipped);
-
+    loadPath = CTextureCache::Get().CacheTexture(texturePath, &m_texture);
     if (m_texture)
-      CTextureCache::Get().BackgroundCacheTexture(texturePath, m_texture);
+      return true; // we're done
   }
-  else
+  if (!loadPath.IsEmpty())
   {
     // direct route - load the image
     m_texture = new CTexture();

--- a/xbmc/GUILargeTextureManager.cpp
+++ b/xbmc/GUILargeTextureManager.cpp
@@ -166,7 +166,6 @@ void CGUILargeTextureManager::CleanupUnusedImages(bool immediately)
 // else, add to the queue list if appropriate.
 bool CGUILargeTextureManager::GetImage(const CStdString &path, CTextureArray &texture, bool firstRequest)
 {
-  // note: max size to load images: 2048x1024? (8MB)
   CSingleLock lock(m_listSection);
   for (listIterator it = m_allocated.begin(); it != m_allocated.end(); ++it)
   {

--- a/xbmc/GUILargeTextureManager.cpp
+++ b/xbmc/GUILargeTextureManager.cpp
@@ -198,6 +198,12 @@ void CGUILargeTextureManager::ReleaseImage(const CStdString &path, bool immediat
       return;
     }
   }
+  assert(false);
+}
+
+void CGUILargeTextureManager::ReleaseQueuedImage(const CStdString &path)
+{
+  CSingleLock lock(m_listSection);
   for (queueIterator it = m_queued.begin(); it != m_queued.end(); ++it)
   {
     unsigned int id = it->first;

--- a/xbmc/GUILargeTextureManager.h
+++ b/xbmc/GUILargeTextureManager.h
@@ -93,13 +93,14 @@ public:
 
    When textures are finished with, this function should be called.  This decrements the texture's
    reference count, and schedules it to be unloaded once the reference count reaches zero.  If the
-   texture is still queued for loading, or is in the process of loading, the image load is cancelled.
+   texture is still queued for loading, or is in the process of loading, use ReleaseQueuedImage instead
 
    \param path path of the image to release.
    \param immediately if set true the image is immediately unloaded once its reference count reaches zero
                       rather than being unloaded after a delay.
    */
   void ReleaseImage(const CStdString &path, bool immediately = false);
+  void ReleaseQueuedImage(const CStdString &path);
 
   /*!
    \brief Cleanup images that are no longer in use.

--- a/xbmc/TextureCache.cpp
+++ b/xbmc/TextureCache.cpp
@@ -151,9 +151,9 @@ void CTextureCache::BackgroundCacheImage(const CStdString &url)
   AddJob(new CTextureCacheJob(url, cacheHash));
 }
 
-void CTextureCache::BackgroundCacheTexture(const CStdString &url, const CBaseTexture *texture, unsigned int max_width, unsigned int max_height)
+void CTextureCache::BackgroundCacheTexture(const CStdString &url, const CBaseTexture *texture)
 {
-  AddJob(new CTextureCacheJob(url, texture, max_width, max_height));
+  AddJob(new CTextureCacheJob(url, texture));
 }
 
 CStdString CTextureCache::CacheImageFile(const CStdString &url)

--- a/xbmc/TextureCache.cpp
+++ b/xbmc/TextureCache.cpp
@@ -91,7 +91,10 @@ CStdString CTextureCache::GetCachedImage(const CStdString &url, CStdString &cach
   // lookup the item in the database
   CTextureDetails details;
   if (GetCachedTexture(url, details))
+  {
+    IncrementUseCount(details);
     return GetCachedPath(details.file);
+  }
   return "";
 }
 
@@ -233,6 +236,12 @@ bool CTextureCache::AddCachedTexture(const CStdString &url, const CTextureDetail
 {
   CSingleLock lock(m_databaseSection);
   return m_database.AddCachedTexture(url, details);
+}
+
+bool CTextureCache::IncrementUseCount(const CTextureDetails &details)
+{
+  CSingleLock lock(m_databaseSection);
+  return m_database.IncrementUseCount(details);
 }
 
 bool CTextureCache::ClearCachedTexture(const CStdString &url, CStdString &cachedURL)

--- a/xbmc/TextureCache.cpp
+++ b/xbmc/TextureCache.cpp
@@ -162,7 +162,7 @@ CStdString CTextureCache::CacheImageFile(const CStdString &url)
   CTextureCacheJob job(url, "");
   if (job.DoWork() && !job.m_hash.IsEmpty())
   {
-    AddCachedTexture(url, job.m_cacheFile, job.m_hash);
+    AddCachedTexture(url, job.m_cacheFile, job.m_hash, job.m_updateable);
     if (g_advancedSettings.m_useDDSFanart && !job.m_cacheFile.IsEmpty())
       AddJob(new CTextureDDSJob(GetCachedPath(job.m_cacheFile)));
     return GetCachedPath(job.m_cacheFile);
@@ -229,10 +229,10 @@ bool CTextureCache::GetCachedTexture(const CStdString &url, CStdString &cachedUR
   return m_database.GetCachedTexture(url, cachedURL, cachedHash);
 }
 
-bool CTextureCache::AddCachedTexture(const CStdString &url, const CStdString &cachedURL, const CStdString &hash)
+bool CTextureCache::AddCachedTexture(const CStdString &url, const CStdString &cachedURL, const CStdString &hash, bool updateable)
 {
   CSingleLock lock(m_databaseSection);
-  return m_database.AddCachedTexture(url, cachedURL, hash);
+  return m_database.AddCachedTexture(url, cachedURL, hash, updateable);
 }
 
 bool CTextureCache::ClearCachedTexture(const CStdString &url, CStdString &cachedURL)
@@ -262,7 +262,7 @@ void CTextureCache::OnJobComplete(unsigned int jobID, bool success, CJob *job)
   if (strcmp(job->GetType(), "cacheimage") == 0 && success)
   {
     CTextureCacheJob *cacheJob = (CTextureCacheJob *)job;
-    AddCachedTexture(cacheJob->m_url, cacheJob->m_cacheFile, cacheJob->m_hash);
+    AddCachedTexture(cacheJob->m_url, cacheJob->m_cacheFile, cacheJob->m_hash, cacheJob->m_updateable);
     // TODO: call back to the UI indicating that it can update it's image...
     if (g_advancedSettings.m_useDDSFanart && !cacheJob->m_cacheFile.IsEmpty())
       AddJob(new CTextureDDSJob(GetCachedPath(cacheJob->m_cacheFile)));

--- a/xbmc/TextureCache.h
+++ b/xbmc/TextureCache.h
@@ -192,6 +192,13 @@ private:
    */
   bool ClearCachedTexture(const CStdString &url, CStdString &cacheFile);
 
+  /*! \brief Increment the use count of a texture in the database
+   Thread-safe wrapper of CTextureDatabase::IncrementUseCount
+   \param details the texture to increment the use count
+   \return true on success, false otherwise
+   */
+  bool IncrementUseCount(const CTextureDetails &details);
+
   virtual void OnJobComplete(unsigned int jobID, bool success, CJob *job);
 
   CCriticalSection m_databaseSection;

--- a/xbmc/TextureCache.h
+++ b/xbmc/TextureCache.h
@@ -144,12 +144,10 @@ public:
   /*! \brief Add this image to the database
    Thread-safe wrapper of CTextureDatabase::AddCachedTexture
    \param image url of the original image
-   \param cacheFile url of the cached image
-   \param hash hash of the original image
-   \param updateable whether this image is updateable
+   \param details the texture details to add
    \return true if we successfully added to the database, false otherwise.
    */
-  bool AddCachedTexture(const CStdString &image, const CStdString &cacheFile, const CStdString &hash, bool updateable = false);
+  bool AddCachedTexture(const CStdString &image, const CTextureDetails &details);
 
   /*! \brief Export a (possibly) cached image to a file
    \param image url of the original image
@@ -181,11 +179,10 @@ private:
   /*! \brief Get an image from the database
    Thread-safe wrapper of CTextureDatabase::GetCachedTexture
    \param image url of the original image
-   \param cacheFile [out] url of the cached original (if available)
-   \param cacheHash [out] the hash of the cached image if it requires recaching, empty otherwise.
+   \param details [out] texture details from the database (if available)
    \return true if we have a cached version of this image, false otherwise.
    */
-  bool GetCachedTexture(const CStdString &url, CStdString &cacheFile, CStdString &cacheHash);
+  bool GetCachedTexture(const CStdString &url, CTextureDetails &details);
 
   /*! \brief Clear an image from the database
    Thread-safe wrapper of CTextureDatabase::ClearCachedTexture

--- a/xbmc/TextureCache.h
+++ b/xbmc/TextureCache.h
@@ -96,7 +96,7 @@ public:
 
    \param image url of the image to cache
    \return cached url of this image
-   \sa CCacheJob::CacheImage
+   \sa CTextureCacheJob::DoWork
    */  
   CStdString CacheImageFile(const CStdString &url);
 

--- a/xbmc/TextureCache.h
+++ b/xbmc/TextureCache.h
@@ -21,6 +21,7 @@
 
 #pragma once
 
+#include <set>
 #include "utils/StdString.h"
 #include "utils/JobManager.h"
 #include "TextureDatabase.h"
@@ -208,8 +209,11 @@ private:
   bool SetCachedTextureValid(const CStdString &url, bool updateable);
 
   virtual void OnJobComplete(unsigned int jobID, bool success, CJob *job);
+  virtual void OnJobProgress(unsigned int jobID, unsigned int progress, unsigned int total, const CJob *job);
 
   CCriticalSection m_databaseSection;
   CTextureDatabase m_database;
+  std::set<CStdString> m_processing; ///< currently processing list to avoid 2 jobs being processed at once
+  CCriticalSection     m_processingSection;
 };
 

--- a/xbmc/TextureCache.h
+++ b/xbmc/TextureCache.h
@@ -199,6 +199,14 @@ private:
    */
   bool IncrementUseCount(const CTextureDetails &details);
 
+  /*! \brief Set a previously cached texture as valid in the database
+   Thread-safe wrapper of CTextureDatabase::SetCachedTextureValid
+   \param image url of the original image
+   \param updateable whether this image should be checked for updates
+   \return true if successful, false otherwise.
+   */
+  bool SetCachedTextureValid(const CStdString &url, bool updateable);
+
   virtual void OnJobComplete(unsigned int jobID, bool success, CJob *job);
 
   CCriticalSection m_databaseSection;

--- a/xbmc/TextureCache.h
+++ b/xbmc/TextureCache.h
@@ -25,6 +25,7 @@
 #include "utils/StdString.h"
 #include "utils/JobManager.h"
 #include "TextureDatabase.h"
+#include "threads/Event.h"
 
 class CBaseTexture;
 
@@ -89,7 +90,17 @@ public:
    \sa CheckAndCacheImage
    */
   void BackgroundCacheImage(const CStdString &image);
-  void BackgroundCacheTexture(const CStdString &image, const CBaseTexture *texture);
+
+  /*! \brief Cache an image to image cache, optionally return the texture
+
+   Caches the given image, returning the texture if the caller wants it.
+
+   \param image url of the image to cache
+   \param texture [out] the loaded image
+   \return cached url of this image
+   \sa CTextureCacheJob::CacheTexture
+   */
+  CStdString CacheTexture(const CStdString &url, CBaseTexture **texture = NULL);
 
   /*! \brief Take image URL and add it to image cache
 
@@ -215,5 +226,6 @@ private:
   CTextureDatabase m_database;
   std::set<CStdString> m_processing; ///< currently processing list to avoid 2 jobs being processed at once
   CCriticalSection     m_processingSection;
+  CEvent               m_completeEvent; ///< Set whenever a job has finished
 };
 

--- a/xbmc/TextureCache.h
+++ b/xbmc/TextureCache.h
@@ -88,7 +88,7 @@ public:
    \sa CheckAndCacheImage
    */
   void BackgroundCacheImage(const CStdString &image);
-  void BackgroundCacheTexture(const CStdString &image, const CBaseTexture *texture, unsigned int max_width, unsigned int max_height);
+  void BackgroundCacheTexture(const CStdString &image, const CBaseTexture *texture);
 
   /*! \brief Take image URL and add it to image cache
 

--- a/xbmc/TextureCache.h
+++ b/xbmc/TextureCache.h
@@ -146,9 +146,10 @@ public:
    \param image url of the original image
    \param cacheFile url of the cached image
    \param hash hash of the original image
+   \param updateable whether this image is updateable
    \return true if we successfully added to the database, false otherwise.
    */
-  bool AddCachedTexture(const CStdString &image, const CStdString &cacheFile, const CStdString &hash);
+  bool AddCachedTexture(const CStdString &image, const CStdString &cacheFile, const CStdString &hash, bool updateable = false);
 
   /*! \brief Export a (possibly) cached image to a file
    \param image url of the original image

--- a/xbmc/TextureCacheJob.cpp
+++ b/xbmc/TextureCacheJob.cpp
@@ -63,6 +63,11 @@ bool CTextureCacheJob::DoWork()
   if (ShouldCancel(1, 0)) // HACK: second check is because we cancel the job in the first callback, but we don't detect it
     return false;         //       until the second
 
+  // check whether we need cache the job anyway
+  bool needsRecaching = false;
+  CStdString path(CTextureCache::Get().CheckCachedImage(m_url, false, needsRecaching));
+  if (!path.IsEmpty() && !needsRecaching)
+    return false;
   return CacheTexture();
 }
 

--- a/xbmc/TextureCacheJob.cpp
+++ b/xbmc/TextureCacheJob.cpp
@@ -100,7 +100,12 @@ bool CTextureCacheJob::DoWork()
       CLog::Log(LOGDEBUG, "%s image '%s' fullsize with orientation %d as '%s'", m_oldHash.IsEmpty() ? "Caching" : "Recaching", image.c_str(),
                 m_texture->GetOrientation(), m_details.file.c_str());
 
-    return CPicture::CacheTexture(m_texture, width, height, CTextureCache::GetCachedPath(m_details.file));
+    if (CPicture::CacheTexture(m_texture, width, height, CTextureCache::GetCachedPath(m_details.file)))
+    {
+      m_details.width = width;
+      m_details.height = height;
+      return true;
+    }
   }
   return false;
 }

--- a/xbmc/TextureCacheJob.cpp
+++ b/xbmc/TextureCacheJob.cpp
@@ -39,22 +39,10 @@ CTextureCacheJob::CTextureCacheJob(const CStdString &url, const CStdString &oldH
   m_url = url;
   m_oldHash = oldHash;
   m_cachePath = CTextureCache::GetCacheFile(m_url);
-  m_texture = NULL;
-}
-
-CTextureCacheJob::CTextureCacheJob(const CStdString &url, const CBaseTexture *texture)
-{
-  m_url = url;
-  if (texture)
-    m_texture = new CTexture(*(CTexture *)texture);
-  else
-    m_texture = NULL;
-  m_cachePath = CTextureCache::GetCacheFile(m_url);
 }
 
 CTextureCacheJob::~CTextureCacheJob()
 {
-  delete m_texture;
 }
 
 bool CTextureCacheJob::operator==(const CJob* job) const
@@ -75,7 +63,7 @@ bool CTextureCacheJob::DoWork()
   if (ShouldCancel(1, 0)) // HACK: second check is because we cancel the job in the first callback, but we don't detect it
     return false;         //       until the second
 
-  return CacheTexture(&m_texture);
+  return CacheTexture();
 }
 
 bool CTextureCacheJob::CacheTexture(CBaseTexture **out_texture)
@@ -94,9 +82,7 @@ bool CTextureCacheJob::CacheTexture(CBaseTexture **out_texture)
   else if (m_details.hash == m_oldHash)
     return true;
 
-  CBaseTexture *texture = (old_texture && *old_texture) ? *old_texture : NULL;
-  if (!texture)
-    texture = LoadImage(image, width, height, flipped);
+  CBaseTexture *texture = LoadImage(image, width, height, flipped);
   if (texture)
   {
     if (texture->HasAlpha())

--- a/xbmc/TextureCacheJob.cpp
+++ b/xbmc/TextureCacheJob.cpp
@@ -41,6 +41,7 @@ CTextureCacheJob::CTextureCacheJob(const CStdString &url, const CStdString &oldH
   m_cachePath = CTextureCache::GetCacheFile(m_url);
   m_texture = NULL;
   m_maxWidth = m_maxHeight = 0;
+  m_updateable = false;
 }
 
 CTextureCacheJob::CTextureCacheJob(const CStdString &url, const CBaseTexture *texture, unsigned int max_width, unsigned int max_height)
@@ -53,6 +54,7 @@ CTextureCacheJob::CTextureCacheJob(const CStdString &url, const CBaseTexture *te
   m_maxWidth = max_width;
   m_maxHeight = max_height;
   m_cachePath = CTextureCache::GetCacheFile(m_url);
+  m_updateable = false;
 }
 
 CTextureCacheJob::~CTextureCacheJob()
@@ -77,6 +79,8 @@ bool CTextureCacheJob::DoWork()
   bool flipped;
   unsigned int width, height;
   CStdString image = DecodeImageURL(m_url, width, height, flipped);
+
+  m_updateable = UpdateableURL(image);
 
   // generate the hash
   m_hash = GetImageHash(image);
@@ -177,6 +181,15 @@ CBaseTexture *CTextureCacheJob::LoadImage(const CStdString &image, unsigned int 
     texture->SetOrientation(texture->GetOrientation() ^ 1);
 
   return texture;
+}
+
+bool CTextureCacheJob::UpdateableURL(const CStdString &url) const
+{
+  // we don't constantly check online images
+  if (url.compare(0, 7, "http://") == 0 ||
+      url.compare(0, 8, "https://") == 0)
+    return false;
+  return true;
 }
 
 CStdString CTextureCacheJob::GetImageHash(const CStdString &url)

--- a/xbmc/TextureCacheJob.cpp
+++ b/xbmc/TextureCacheJob.cpp
@@ -40,19 +40,16 @@ CTextureCacheJob::CTextureCacheJob(const CStdString &url, const CStdString &oldH
   m_oldHash = oldHash;
   m_cachePath = CTextureCache::GetCacheFile(m_url);
   m_texture = NULL;
-  m_maxWidth = m_maxHeight = 0;
   m_updateable = false;
 }
 
-CTextureCacheJob::CTextureCacheJob(const CStdString &url, const CBaseTexture *texture, unsigned int max_width, unsigned int max_height)
+CTextureCacheJob::CTextureCacheJob(const CStdString &url, const CBaseTexture *texture)
 {
   m_url = url;
   if (texture)
     m_texture = new CTexture(*(CTexture *)texture);
   else
     m_texture = NULL;
-  m_maxWidth = max_width;
-  m_maxHeight = max_height;
   m_cachePath = CTextureCache::GetCacheFile(m_url);
   m_updateable = false;
 }

--- a/xbmc/TextureCacheJob.cpp
+++ b/xbmc/TextureCacheJob.cpp
@@ -40,7 +40,6 @@ CTextureCacheJob::CTextureCacheJob(const CStdString &url, const CStdString &oldH
   m_oldHash = oldHash;
   m_cachePath = CTextureCache::GetCacheFile(m_url);
   m_texture = NULL;
-  m_updateable = false;
 }
 
 CTextureCacheJob::CTextureCacheJob(const CStdString &url, const CBaseTexture *texture)
@@ -51,7 +50,6 @@ CTextureCacheJob::CTextureCacheJob(const CStdString &url, const CBaseTexture *te
   else
     m_texture = NULL;
   m_cachePath = CTextureCache::GetCacheFile(m_url);
-  m_updateable = false;
 }
 
 CTextureCacheJob::~CTextureCacheJob()
@@ -77,13 +75,13 @@ bool CTextureCacheJob::DoWork()
   unsigned int width, height;
   CStdString image = DecodeImageURL(m_url, width, height, flipped);
 
-  m_updateable = UpdateableURL(image);
+  m_details.updateable = UpdateableURL(image);
 
   // generate the hash
-  m_hash = GetImageHash(image);
-  if (m_hash.IsEmpty())
+  m_details.hash = GetImageHash(image);
+  if (m_details.hash.empty())
     return false;
-  else if (m_hash == m_oldHash)
+  else if (m_details.hash == m_oldHash)
     return true;
 
   if (!m_texture)
@@ -91,18 +89,18 @@ bool CTextureCacheJob::DoWork()
   if (m_texture)
   {
     if (m_texture->HasAlpha())
-      m_cacheFile = m_cachePath + ".png";
+      m_details.file = m_cachePath + ".png";
     else
-      m_cacheFile = m_cachePath + ".jpg";
+      m_details.file = m_cachePath + ".jpg";
 
     if (width > 0 && height > 0)
       CLog::Log(LOGDEBUG, "%s image '%s' at %dx%d with orientation %d as '%s'", m_oldHash.IsEmpty() ? "Caching" : "Recaching", image.c_str(),
-                width, height, m_texture->GetOrientation(), m_cacheFile.c_str());
+                width, height, m_texture->GetOrientation(), m_details.file.c_str());
     else
       CLog::Log(LOGDEBUG, "%s image '%s' fullsize with orientation %d as '%s'", m_oldHash.IsEmpty() ? "Caching" : "Recaching", image.c_str(),
-                m_texture->GetOrientation(), m_cacheFile.c_str());
+                m_texture->GetOrientation(), m_details.file.c_str());
 
-    return CPicture::CacheTexture(m_texture, width, height, CTextureCache::GetCachedPath(m_cacheFile));
+    return CPicture::CacheTexture(m_texture, width, height, CTextureCache::GetCachedPath(m_details.file));
   }
   return false;
 }

--- a/xbmc/TextureCacheJob.cpp
+++ b/xbmc/TextureCacheJob.cpp
@@ -70,6 +70,11 @@ bool CTextureCacheJob::operator==(const CJob* job) const
 
 bool CTextureCacheJob::DoWork()
 {
+  if (ShouldCancel(0, 0))
+    return false;
+  if (ShouldCancel(1, 0)) // HACK: second check is because we cancel the job in the first callback, but we don't detect it
+    return false;         //       until the second
+
   // unwrap the URL as required
   bool flipped;
   unsigned int width, height;

--- a/xbmc/TextureCacheJob.h
+++ b/xbmc/TextureCacheJob.h
@@ -69,6 +69,7 @@ public:
   CStdString m_cacheFile;
   CStdString m_hash;
   CStdString m_oldHash;
+  bool       m_updateable;
 private:
   /*! \brief retrieve a hash for the given image
    Combines the size, ctime and mtime of the image file into a "unique" hash
@@ -76,6 +77,15 @@ private:
    \return a hash string for this image
    */
   static CStdString GetImageHash(const CStdString &url);
+
+  /*! \brief Check whether a given URL represents an image that can be updated
+   We currently don't check http:// and https:// URLs for updates, under the assumption that
+   a image URL is much more likely to be static and the actual image at the URL is unlikely
+   to change, so no point checking all the time.
+   \param url the url to check
+   \return true if the image given by the URL should be checked for updates, false otehrwise
+   */
+  bool UpdateableURL(const CStdString &url) const;
 
   unsigned int  m_maxWidth;
   unsigned int  m_maxHeight;

--- a/xbmc/TextureCacheJob.h
+++ b/xbmc/TextureCacheJob.h
@@ -36,7 +36,7 @@ class CTextureCacheJob : public CJob
 {
 public:
   CTextureCacheJob(const CStdString &url, const CStdString &oldHash);
-  CTextureCacheJob(const CStdString &url, const CBaseTexture *texture, unsigned int max_width, unsigned int max_height);
+  CTextureCacheJob(const CStdString &url, const CBaseTexture *texture);
   virtual ~CTextureCacheJob();
 
   virtual const char* GetType() const { return "cacheimage"; };
@@ -87,8 +87,6 @@ private:
    */
   bool UpdateableURL(const CStdString &url) const;
 
-  unsigned int  m_maxWidth;
-  unsigned int  m_maxHeight;
   CBaseTexture *m_texture;
   CStdString    m_cachePath;
 };

--- a/xbmc/TextureCacheJob.h
+++ b/xbmc/TextureCacheJob.h
@@ -56,13 +56,20 @@ public:
 class CTextureCacheJob : public CJob
 {
 public:
-  CTextureCacheJob(const CStdString &url, const CStdString &oldHash);
+  CTextureCacheJob(const CStdString &url, const CStdString &oldHash = "");
   CTextureCacheJob(const CStdString &url, const CBaseTexture *texture);
   virtual ~CTextureCacheJob();
 
   virtual const char* GetType() const { return "cacheimage"; };
   virtual bool operator==(const CJob *job) const;
   virtual bool DoWork();
+
+  /*! \brief retrieve a hash for the given image
+   Combines the size, ctime and mtime of the image file into a "unique" hash
+   \param url location of the image
+   \return a hash string for this image
+   */
+  bool CacheTexture(CBaseTexture **texture = NULL);
 
   /*! \brief Decode an image URL to the underlying image, width, height and orientation
    \param url wrapped URL of the image

--- a/xbmc/TextureCacheJob.h
+++ b/xbmc/TextureCacheJob.h
@@ -28,6 +28,24 @@ class CBaseTexture;
 
 /*!
  \ingroup textures
+ \brief Simple class for passing texture detail around
+ */
+class CTextureDetails
+{
+public:
+  CTextureDetails()
+  {
+    id = -1;
+    updateable = false;
+  };
+  int          id;
+  std::string  file;
+  std::string  hash;
+  bool         updateable;
+};
+
+/*!
+ \ingroup textures
  \brief Job class for caching textures
  
  Handles loading and caching of textures.
@@ -66,10 +84,8 @@ public:
   static CBaseTexture *LoadImage(const CStdString &image, unsigned int width, unsigned int height, bool flipped);
 
   CStdString m_url;
-  CStdString m_cacheFile;
-  CStdString m_hash;
   CStdString m_oldHash;
-  bool       m_updateable;
+  CTextureDetails m_details;
 private:
   /*! \brief retrieve a hash for the given image
    Combines the size, ctime and mtime of the image file into a "unique" hash

--- a/xbmc/TextureCacheJob.h
+++ b/xbmc/TextureCacheJob.h
@@ -57,7 +57,6 @@ class CTextureCacheJob : public CJob
 {
 public:
   CTextureCacheJob(const CStdString &url, const CStdString &oldHash = "");
-  CTextureCacheJob(const CStdString &url, const CBaseTexture *texture);
   virtual ~CTextureCacheJob();
 
   virtual const char* GetType() const { return "cacheimage"; };
@@ -70,6 +69,26 @@ public:
    \return a hash string for this image
    */
   bool CacheTexture(CBaseTexture **texture = NULL);
+
+  CStdString m_url;
+  CStdString m_oldHash;
+  CTextureDetails m_details;
+private:
+  /*! \brief retrieve a hash for the given image
+   Combines the size, ctime and mtime of the image file into a "unique" hash
+   \param url location of the image
+   \return a hash string for this image
+   */
+  static CStdString GetImageHash(const CStdString &url);
+
+  /*! \brief Check whether a given URL represents an image that can be updated
+   We currently don't check http:// and https:// URLs for updates, under the assumption that
+   a image URL is much more likely to be static and the actual image at the URL is unlikely
+   to change, so no point checking all the time.
+   \param url the url to check
+   \return true if the image given by the URL should be checked for updates, false otehrwise
+   */
+  bool UpdateableURL(const CStdString &url) const;
 
   /*! \brief Decode an image URL to the underlying image, width, height and orientation
    \param url wrapped URL of the image
@@ -93,27 +112,6 @@ public:
    */
   static CBaseTexture *LoadImage(const CStdString &image, unsigned int width, unsigned int height, bool flipped);
 
-  CStdString m_url;
-  CStdString m_oldHash;
-  CTextureDetails m_details;
-private:
-  /*! \brief retrieve a hash for the given image
-   Combines the size, ctime and mtime of the image file into a "unique" hash
-   \param url location of the image
-   \return a hash string for this image
-   */
-  static CStdString GetImageHash(const CStdString &url);
-
-  /*! \brief Check whether a given URL represents an image that can be updated
-   We currently don't check http:// and https:// URLs for updates, under the assumption that
-   a image URL is much more likely to be static and the actual image at the URL is unlikely
-   to change, so no point checking all the time.
-   \param url the url to check
-   \return true if the image given by the URL should be checked for updates, false otehrwise
-   */
-  bool UpdateableURL(const CStdString &url) const;
-
-  CBaseTexture *m_texture;
   CStdString    m_cachePath;
 };
 

--- a/xbmc/TextureCacheJob.h
+++ b/xbmc/TextureCacheJob.h
@@ -36,11 +36,14 @@ public:
   CTextureDetails()
   {
     id = -1;
+    width = height = 0;
     updateable = false;
   };
   int          id;
   std::string  file;
   std::string  hash;
+  unsigned int width;
+  unsigned int height;
   bool         updateable;
 };
 

--- a/xbmc/TextureDatabase.cpp
+++ b/xbmc/TextureDatabase.cpp
@@ -149,7 +149,7 @@ bool CTextureDatabase::GetCachedTexture(const CStdString &url, CStdString &cache
       cacheFile = m_pDS->fv(1).get_asString();
       CDateTime lastCheck;
       lastCheck.SetFromDBDateTime(m_pDS->fv(2).get_asString());
-      if (!lastCheck.IsValid() || lastCheck + CDateTimeSpan(1,0,0,0) < CDateTime::GetCurrentDateTime())
+      if (lastCheck.IsValid() && lastCheck + CDateTimeSpan(1,0,0,0) < CDateTime::GetCurrentDateTime())
         imageHash = m_pDS->fv(3).get_asString();
       m_pDS->close();
       // update the use count
@@ -166,7 +166,7 @@ bool CTextureDatabase::GetCachedTexture(const CStdString &url, CStdString &cache
   return false;
 }
 
-bool CTextureDatabase::AddCachedTexture(const CStdString &url, const CStdString &cacheFile, const CStdString &imageHash)
+bool CTextureDatabase::AddCachedTexture(const CStdString &url, const CStdString &cacheFile, const CStdString &imageHash, bool updateable)
 {
   try
   {
@@ -174,7 +174,7 @@ bool CTextureDatabase::AddCachedTexture(const CStdString &url, const CStdString 
     if (NULL == m_pDS.get()) return false;
 
     CStdString cacheURL(cacheFile);
-    CStdString date = CDateTime::GetCurrentDateTime().GetAsDBDateTime();
+    CStdString date = updateable ? CDateTime::GetCurrentDateTime().GetAsDBDateTime() : "";
 
     CStdString sql = PrepareSQL("select id,cachedurl from texture where url='%s'", url.c_str());
     m_pDS->query(sql.c_str());

--- a/xbmc/TextureDatabase.cpp
+++ b/xbmc/TextureDatabase.cpp
@@ -233,6 +233,13 @@ bool CTextureDatabase::ClearCachedTexture(const CStdString &url, CStdString &cac
   return false;
 }
 
+bool CTextureDatabase::InvalidateCachedTexture(const CStdString &url)
+{
+  CStdString date = (CDateTime::GetCurrentDateTime() - CDateTimeSpan(2, 0, 0, 0)).GetAsDBDateTime();
+  CStdString sql = PrepareSQL("UPDATE texture SET lasthashcheck='%s' WHERE url='%s'", date.c_str(), url.c_str());
+  return ExecuteQuery(sql);
+}
+
 CStdString CTextureDatabase::GetTextureForPath(const CStdString &url, const CStdString &type)
 {
   try

--- a/xbmc/TextureDatabase.cpp
+++ b/xbmc/TextureDatabase.cpp
@@ -133,6 +133,12 @@ bool CTextureDatabase::UpdateOldVersion(int version)
   return true;
 }
 
+bool CTextureDatabase::IncrementUseCount(const CTextureDetails &details)
+{
+  CStdString sql = PrepareSQL("update texture set usecount=usecount+1, lastusetime=CURRENT_TIMESTAMP where id=%u", details.id);
+  return ExecuteQuery(sql);
+}
+
 bool CTextureDatabase::GetCachedTexture(const CStdString &url, CTextureDetails &details)
 {
   try
@@ -152,9 +158,6 @@ bool CTextureDatabase::GetCachedTexture(const CStdString &url, CTextureDetails &
       if (lastCheck.IsValid() && lastCheck + CDateTimeSpan(1,0,0,0) < CDateTime::GetCurrentDateTime())
         details.hash = m_pDS->fv(3).get_asString();
       m_pDS->close();
-      // update the use count
-      sql = PrepareSQL("update texture set usecount=usecount+1, lastusetime=CURRENT_TIMESTAMP where id=%u", details.id);
-      m_pDS->exec(sql.c_str());
       return true;
     }
     m_pDS->close();

--- a/xbmc/TextureDatabase.h
+++ b/xbmc/TextureDatabase.h
@@ -82,6 +82,6 @@ protected:
 
   virtual bool CreateTables();
   virtual bool UpdateOldVersion(int version);
-  virtual int GetMinVersion() const { return 11; };
+  virtual int GetMinVersion() const { return 12; };
   const char *GetBaseDBName() const { return "Textures"; };
 };

--- a/xbmc/TextureDatabase.h
+++ b/xbmc/TextureDatabase.h
@@ -34,6 +34,13 @@ public:
   bool AddCachedTexture(const CStdString &originalURL, const CStdString &cachedFile, const CStdString &imageHash = "");
   bool ClearCachedTexture(const CStdString &originalURL, CStdString &cacheFile);
 
+  /*! \brief Invalidate a previously cached texture
+   Invalidates the texture hash, and sets the texture update time to the current time so that
+   next texture load it will be re-cached.
+   \param url texture path
+   */
+  bool InvalidateCachedTexture(const CStdString &originalURL);
+
   /*! \brief Get a texture associated with the given path
    Used for retrieval of previously discovered images to save
    stat() on the filesystem all the time

--- a/xbmc/TextureDatabase.h
+++ b/xbmc/TextureDatabase.h
@@ -34,6 +34,7 @@ public:
   bool GetCachedTexture(const CStdString &originalURL, CTextureDetails &details);
   bool AddCachedTexture(const CStdString &originalURL, const CTextureDetails &details);
   bool ClearCachedTexture(const CStdString &originalURL, CStdString &cacheFile);
+  bool IncrementUseCount(const CTextureDetails &details);
 
   /*! \brief Invalidate a previously cached texture
    Invalidates the texture hash, and sets the texture update time to the current time so that

--- a/xbmc/TextureDatabase.h
+++ b/xbmc/TextureDatabase.h
@@ -22,6 +22,7 @@
 #pragma once
 
 #include "dbwrappers/Database.h"
+#include "TextureCacheJob.h"
 
 class CTextureDatabase : public CDatabase
 {
@@ -30,8 +31,8 @@ public:
   virtual ~CTextureDatabase();
   virtual bool Open();
 
-  bool GetCachedTexture(const CStdString &originalURL, CStdString &cacheFile, CStdString &imageHash);
-  bool AddCachedTexture(const CStdString &originalURL, const CStdString &cachedFile, const CStdString &imageHash = "", bool updateable = true);
+  bool GetCachedTexture(const CStdString &originalURL, CTextureDetails &details);
+  bool AddCachedTexture(const CStdString &originalURL, const CTextureDetails &details);
   bool ClearCachedTexture(const CStdString &originalURL, CStdString &cacheFile);
 
   /*! \brief Invalidate a previously cached texture

--- a/xbmc/TextureDatabase.h
+++ b/xbmc/TextureDatabase.h
@@ -33,6 +33,7 @@ public:
 
   bool GetCachedTexture(const CStdString &originalURL, CTextureDetails &details);
   bool AddCachedTexture(const CStdString &originalURL, const CTextureDetails &details);
+  bool SetCachedTextureValid(const CStdString &originalURL, bool updateable);
   bool ClearCachedTexture(const CStdString &originalURL, CStdString &cacheFile);
   bool IncrementUseCount(const CTextureDetails &details);
 

--- a/xbmc/TextureDatabase.h
+++ b/xbmc/TextureDatabase.h
@@ -31,7 +31,7 @@ public:
   virtual bool Open();
 
   bool GetCachedTexture(const CStdString &originalURL, CStdString &cacheFile, CStdString &imageHash);
-  bool AddCachedTexture(const CStdString &originalURL, const CStdString &cachedFile, const CStdString &imageHash = "");
+  bool AddCachedTexture(const CStdString &originalURL, const CStdString &cachedFile, const CStdString &imageHash = "", bool updateable = true);
   bool ClearCachedTexture(const CStdString &originalURL, CStdString &cacheFile);
 
   /*! \brief Invalidate a previously cached texture

--- a/xbmc/ThumbLoader.cpp
+++ b/xbmc/ThumbLoader.cpp
@@ -307,17 +307,19 @@ bool CProgramThumbLoader::LoadItem(CFileItem *pItem)
 bool CProgramThumbLoader::FillThumb(CFileItem &item)
 {
   // no need to do anything if we already have a thumb set
-  if (item.HasThumbnail())
-    return true;
+  CStdString thumb = item.GetThumbnailImage();
 
-  // see whether we have a cached image for this item
-  CStdString thumb = GetCachedImage(item, "thumb");
   if (thumb.IsEmpty())
-  {
-    thumb = GetLocalThumb(item);
-    if (!thumb.IsEmpty())
-      SetCachedImage(item, "thumb", thumb);
+  { // see whether we have a cached image for this item
+    thumb = GetCachedImage(item, "thumb");
+    if (thumb.IsEmpty())
+    {
+      thumb = GetLocalThumb(item);
+      if (!thumb.IsEmpty())
+        SetCachedImage(item, "thumb", thumb);
+    }
   }
+
   if (!thumb.IsEmpty())
   {
     CTextureCache::Get().BackgroundCacheImage(thumb);

--- a/xbmc/addons/GUIWindowAddonBrowser.h
+++ b/xbmc/addons/GUIWindowAddonBrowser.h
@@ -23,7 +23,7 @@
 
 #include "addons/Addon.h"
 #include "windows/GUIMediaWindow.h"
-#include "pictures/PictureThumbLoader.h"
+#include "ThumbLoader.h"
 
 class CFileItem;
 class CFileItemList;
@@ -67,6 +67,6 @@ protected:
   virtual bool Update(const CStdString &strDirectory);
   virtual CStdString GetStartFolder(const CStdString &dir);
 private:
-  CPictureThumbLoader m_thumbLoader;
+  CProgramThumbLoader m_thumbLoader;
 };
 

--- a/xbmc/addons/Repository.cpp
+++ b/xbmc/addons/Repository.cpp
@@ -31,6 +31,7 @@
 #include "utils/URIUtils.h"
 #include "dialogs/GUIDialogYesNo.h"
 #include "dialogs/GUIDialogKaiToast.h"
+#include "TextureDatabase.h"
 
 using namespace XFILE;
 using namespace ADDON;
@@ -193,6 +194,9 @@ bool CRepositoryUpdateJob::DoWork()
   // check for updates
   CAddonDatabase database;
   database.Open();
+  
+  CTextureDatabase textureDB;
+  textureDB.Open();
   for (unsigned int i=0;i<addons.size();++i)
   {
     // manager told us to feck off
@@ -200,6 +204,12 @@ bool CRepositoryUpdateJob::DoWork()
       break;
     if (!CAddonInstaller::Get().CheckDependencies(addons[i]))
       addons[i]->Props().broken = g_localizeStrings.Get(24044);
+
+    // invalidate the art associated with this item
+    if (!addons[i]->Props().fanart.empty())
+      textureDB.InvalidateCachedTexture(addons[i]->Props().fanart);
+    if (!addons[i]->Props().icon.empty())
+      textureDB.InvalidateCachedTexture(addons[i]->Props().icon);
 
     AddonPtr addon;
     CAddonMgr::Get().GetAddon(addons[i]->ID(),addon);

--- a/xbmc/cores/dvdplayer/DVDFileInfo.cpp
+++ b/xbmc/cores/dvdplayer/DVDFileInfo.cpp
@@ -203,11 +203,11 @@ bool CDVDFileInfo::ExtractThumb(const CStdString &strPath, const CStdString &str
         if (iDecoderState & VC_PICTURE && !(picture.iFlags & DVP_FLAG_DROPPED))
         {
           {
-            int nWidth = g_advancedSettings.m_thumbSize;
+            unsigned int nWidth = g_advancedSettings.m_thumbSize;
             double aspect = (double)picture.iDisplayWidth / (double)picture.iDisplayHeight;
             if(hint.forced_aspect && hint.aspect != 0)
               aspect = hint.aspect;
-            int nHeight = (int)((double)g_advancedSettings.m_thumbSize / aspect);
+            unsigned int nHeight = (unsigned int)((double)g_advancedSettings.m_thumbSize / aspect);
 
             DllSwScale dllSwScale;
             dllSwScale.Load();
@@ -225,7 +225,7 @@ bool CDVDFileInfo::ExtractThumb(const CStdString &strPath, const CStdString &str
               dllSwScale.sws_scale(context, src, srcStride, 0, picture.iHeight, dst, dstStride);
               dllSwScale.sws_freeContext(context);
 
-              CPicture::CacheTexture(pOutBuf, nWidth, nHeight, nWidth * 4, 0, 0, 0, strTarget);
+              CPicture::CacheTexture(pOutBuf, nWidth, nHeight, nWidth * 4, 0, nWidth, nHeight, strTarget);
               bOk = true;
             }
 

--- a/xbmc/cores/dvdplayer/DVDFileInfo.cpp
+++ b/xbmc/cores/dvdplayer/DVDFileInfo.cpp
@@ -225,7 +225,7 @@ bool CDVDFileInfo::ExtractThumb(const CStdString &strPath, const CStdString &str
               dllSwScale.sws_scale(context, src, srcStride, 0, picture.iHeight, dst, dstStride);
               dllSwScale.sws_freeContext(context);
 
-              CPicture::CreateThumbnailFromSurface(pOutBuf, nWidth, nHeight, nWidth * 4, strTarget);
+              CPicture::CacheTexture(pOutBuf, nWidth, nHeight, nWidth * 4, 0, 0, 0, strTarget);
               bOk = true;
             }
 

--- a/xbmc/guilib/GUITexture.cpp
+++ b/xbmc/guilib/GUITexture.cpp
@@ -130,7 +130,7 @@ bool CGUITextureBase::AllocateOnDemand()
 {
   if (m_visible)
   { // visible, so make sure we're allocated
-    if (!IsAllocated() || (m_isAllocated == LARGE && !m_texture.size()))
+    if (!IsAllocated() || (m_isAllocated == IN_PROGRESS))
       return AllocResources();
   }
   else
@@ -315,11 +315,12 @@ bool CGUITextureBase::AllocResources()
       CTextureArray texture;
       if (g_largeTextureManager.GetImage(m_info.filename, texture, !IsAllocated()))
       {
-        m_isAllocated = LARGE;
+        m_isAllocated = IN_PROGRESS;
 
         if (!texture.size()) // not ready as yet
           return false;
 
+        m_isAllocated = LARGE;
         m_texture = texture;
         changed = true;
       }
@@ -455,7 +456,9 @@ bool CGUITextureBase::CalculateSize()
 
 void CGUITextureBase::FreeResources(bool immediately /* = false */)
 {
-  if (m_isAllocated == LARGE || m_isAllocated == LARGE_FAILED)
+  if (m_isAllocated == IN_PROGRESS)
+    g_largeTextureManager.ReleaseQueuedImage(m_info.filename);
+  else if (m_isAllocated == LARGE || m_isAllocated == LARGE_FAILED)
     g_largeTextureManager.ReleaseImage(m_info.filename, immediately || (m_isAllocated == LARGE_FAILED));
   else if (m_isAllocated == NORMAL && m_texture.size())
     g_TextureManager.ReleaseTexture(m_info.filename);

--- a/xbmc/guilib/GUITexture.h
+++ b/xbmc/guilib/GUITexture.h
@@ -161,7 +161,7 @@ protected:
   CPoint m_diffuseOffset;                 // offset into the diffuse frame (it's not always the origin)
 
   bool m_allocateDynamically;
-  enum ALLOCATE_TYPE { NO = 0, NORMAL, LARGE, NORMAL_FAILED, LARGE_FAILED };
+  enum ALLOCATE_TYPE { NO = 0, NORMAL, IN_PROGRESS, LARGE, NORMAL_FAILED, LARGE_FAILED };
   ALLOCATE_TYPE m_isAllocated;
 
   CTextureInfo m_info;

--- a/xbmc/pictures/Picture.cpp
+++ b/xbmc/pictures/Picture.cpp
@@ -168,27 +168,33 @@ bool CThumbnailWriter::DoWork()
 
 bool CPicture::CacheTexture(CBaseTexture *texture, uint32_t max_width, uint32_t max_height, const std::string &dest)
 {
+  return CacheTexture(texture->GetPixels(), texture->GetWidth(), texture->GetHeight(), texture->GetPitch(),
+                      texture->GetOrientation(), max_width, max_height, dest);
+}
+
+bool CPicture::CacheTexture(uint8_t *pixels, uint32_t width, uint32_t height, uint32_t pitch, int orientation, uint32_t max_width, uint32_t max_height, const std::string &dest)
+{
   // if no max width or height is specified, don't resize
   if (max_width == 0)
-    max_width = texture->GetWidth();
+    max_width = width;
   if (max_height == 0)
-    max_height = texture->GetHeight();
+    max_height = height;
 
-  if (texture->GetWidth() > max_width || texture->GetHeight() > max_height || texture->GetOrientation())
+  if (width > max_width || height > max_height || orientation)
   {
     bool success = false;
 
-    unsigned int dest_width = std::min(texture->GetWidth(), max_width);
-    unsigned int dest_height = std::min(texture->GetHeight(), max_height);
+    unsigned int dest_width = std::min(width, max_width);
+    unsigned int dest_height = std::min(height, max_height);
     // create a buffer large enough for the resulting image
-    GetScale(texture->GetWidth(), texture->GetHeight(), dest_width, dest_height);
+    GetScale(width, height, dest_width, dest_height);
     uint32_t *buffer = new uint32_t[dest_width * dest_height];
     if (buffer)
     {
-      if (ScaleImage(texture->GetPixels(), texture->GetWidth(), texture->GetHeight(), texture->GetPitch(),
+      if (ScaleImage(pixels, width, height, pitch,
                      (uint8_t *)buffer, dest_width, dest_height, dest_width * 4))
       {
-        if (!texture->GetOrientation() || OrientateImage(buffer, dest_width, dest_height, texture->GetOrientation()))
+        if (!orientation || OrientateImage(buffer, dest_width, dest_height, orientation))
         {
           success = CreateThumbnailFromSurface((unsigned char*)buffer, dest_width, dest_height, dest_width * 4, dest);
         }
@@ -199,7 +205,7 @@ bool CPicture::CacheTexture(CBaseTexture *texture, uint32_t max_width, uint32_t 
   }
   else
   { // no orientation needed
-    return CreateThumbnailFromSurface(texture->GetPixels(), texture->GetWidth(), texture->GetHeight(), texture->GetPitch(), dest);
+    return CreateThumbnailFromSurface(pixels, width, height, pitch, dest);
   }
   return false;
 }

--- a/xbmc/pictures/Picture.cpp
+++ b/xbmc/pictures/Picture.cpp
@@ -166,26 +166,26 @@ bool CThumbnailWriter::DoWork()
   return success;
 }
 
-bool CPicture::CacheTexture(CBaseTexture *texture, uint32_t max_width, uint32_t max_height, const std::string &dest)
+bool CPicture::CacheTexture(CBaseTexture *texture, uint32_t &dest_width, uint32_t &dest_height, const std::string &dest)
 {
   return CacheTexture(texture->GetPixels(), texture->GetWidth(), texture->GetHeight(), texture->GetPitch(),
-                      texture->GetOrientation(), max_width, max_height, dest);
+                      texture->GetOrientation(), dest_width, dest_height, dest);
 }
 
-bool CPicture::CacheTexture(uint8_t *pixels, uint32_t width, uint32_t height, uint32_t pitch, int orientation, uint32_t max_width, uint32_t max_height, const std::string &dest)
+bool CPicture::CacheTexture(uint8_t *pixels, uint32_t width, uint32_t height, uint32_t pitch, int orientation, uint32_t &dest_width, uint32_t &dest_height, const std::string &dest)
 {
   // if no max width or height is specified, don't resize
-  if (max_width == 0)
-    max_width = width;
-  if (max_height == 0)
-    max_height = height;
+  if (dest_width == 0)
+    dest_width = width;
+  if (dest_height == 0)
+    dest_height = height;
 
-  if (width > max_width || height > max_height || orientation)
+  if (width > dest_width || height > dest_height || orientation)
   {
     bool success = false;
 
-    unsigned int dest_width = std::min(width, max_width);
-    unsigned int dest_height = std::min(height, max_height);
+    dest_width = std::min(width, dest_width);
+    dest_height = std::min(height, dest_height);
     // create a buffer large enough for the resulting image
     GetScale(width, height, dest_width, dest_height);
     uint32_t *buffer = new uint32_t[dest_width * dest_height];
@@ -205,6 +205,8 @@ bool CPicture::CacheTexture(uint8_t *pixels, uint32_t width, uint32_t height, ui
   }
   else
   { // no orientation needed
+    dest_width = width;
+    dest_height = height;
     return CreateThumbnailFromSurface(pixels, width, height, pitch, dest);
   }
   return false;

--- a/xbmc/pictures/Picture.h
+++ b/xbmc/pictures/Picture.h
@@ -50,6 +50,7 @@ public:
    \return true if successful, false otherwise
    */
   static bool CacheTexture(CBaseTexture *texture, uint32_t max_width, uint32_t max_height, const std::string &dest);
+  static bool CacheTexture(uint8_t *pixels, uint32_t width, uint32_t height, uint32_t pitch, int orientation, uint32_t max_width, uint32_t max_height, const std::string &dest);
 
 private:
   static bool CacheImage(const CStdString& sourceUrl, const CStdString& destFile, int width, int height);

--- a/xbmc/pictures/Picture.h
+++ b/xbmc/pictures/Picture.h
@@ -44,13 +44,13 @@ public:
 
   /*! \brief Cache a texture, resizing, rotating and flipping as needed, and saving as a JPG or PNG
    \param texture a pointer to a CBaseTexture
-   \param max_width maximum width in pixels of cached version
-   \param max_height maximum height in pixels of cached version
+   \param dest_width [in/out] maximum width in pixels of cached version - replaced with actual cached width
+   \param dest_height [in/out] maximum height in pixels of cached version - replaced with actual cached height
    \param dest the output cache file
    \return true if successful, false otherwise
    */
-  static bool CacheTexture(CBaseTexture *texture, uint32_t max_width, uint32_t max_height, const std::string &dest);
-  static bool CacheTexture(uint8_t *pixels, uint32_t width, uint32_t height, uint32_t pitch, int orientation, uint32_t max_width, uint32_t max_height, const std::string &dest);
+  static bool CacheTexture(CBaseTexture *texture, uint32_t &dest_width, uint32_t &dest_height, const std::string &dest);
+  static bool CacheTexture(uint8_t *pixels, uint32_t width, uint32_t height, uint32_t pitch, int orientation, uint32_t &dest_width, uint32_t &dest_height, const std::string &dest);
 
 private:
   static bool CacheImage(const CStdString& sourceUrl, const CStdString& destFile, int width, int height);

--- a/xbmc/pictures/PictureThumbLoader.cpp
+++ b/xbmc/pictures/PictureThumbLoader.cpp
@@ -32,6 +32,7 @@
 #include "settings/GUISettings.h"
 #include "utils/URIUtils.h"
 #include "settings/Settings.h"
+#include "settings/AdvancedSettings.h"
 
 using namespace XFILE;
 using namespace std;
@@ -231,7 +232,9 @@ void CPictureThumbLoader::ProcessFoldersAndArchives(CFileItem *pItem)
         CStdString relativeCacheFile = CTextureCache::GetCacheFile(thumb) + ".png";
         if (CPicture::CreateTiledThumb(files, CTextureCache::GetCachedPath(relativeCacheFile)))
         {
-          CTextureCache::Get().AddCachedTexture(thumb, relativeCacheFile, "");
+          CTextureDetails details;
+          details.file = relativeCacheFile;
+          CTextureCache::Get().AddCachedTexture(thumb, details);
           db.SetTextureForPath(pItem->GetPath(), "thumb", thumb);
           pItem->SetThumbnailImage(CTextureCache::GetCachedPath(relativeCacheFile));
         }

--- a/xbmc/utils/Job.h
+++ b/xbmc/utils/Job.h
@@ -66,7 +66,7 @@ public:
    \param jobID the unique id of the job (as retrieved from CJobManager::AddJob)
    \param progress the current progress of the job, out of total.
    \param total the total amount of work to be processed.
-   \param job the job that has been processed.  The job will be destroyed after this function returns
+   \param job the job that has been processed.
    \sa CJobManager and CJob
    */
   virtual void OnJobProgress(unsigned int jobID, unsigned int progress, unsigned int total, const CJob *job) {};

--- a/xbmc/utils/JobManager.cpp
+++ b/xbmc/utils/JobManager.cpp
@@ -102,6 +102,24 @@ void CJobQueue::OnJobComplete(unsigned int jobID, bool success, CJob *job)
   QueueNextJob();
 }
 
+void CJobQueue::CancelJob(const CJob *job)
+{
+  CSingleLock lock(m_section);
+  Processing::iterator i = find(m_processing.begin(), m_processing.end(), job);
+  if (i != m_processing.end())
+  {
+    i->CancelJob();
+    m_processing.erase(i);
+    return;
+  }
+  Queue::iterator j = find(m_jobQueue.begin(), m_jobQueue.end(), job);
+  if (j != m_jobQueue.end())
+  {
+    j->FreeJob();
+    m_jobQueue.erase(j);
+  }
+}
+
 void CJobQueue::AddJob(CJob *job)
 {
   CSingleLock lock(m_section);

--- a/xbmc/utils/JobManager.h
+++ b/xbmc/utils/JobManager.h
@@ -104,6 +104,16 @@ public:
   void AddJob(CJob *job);
 
   /*!
+   \brief Cancel a job in the queue
+   Cancels a job in the queue. Any job currently being processed may complete after this
+   call has completed, but OnJobComplete will not be performed. If the job is only queued
+   then it will be removed from the queue and deleted.
+   \param job a pointer to the job to cancel. The job should be subclassed from CJob.
+   \sa CJob
+   */
+  void CancelJob(const CJob *job);
+
+  /*!
    \brief Cancel all jobs in the queue
    Removes all jobs from the queue. Any job currently being processed may complete after this
    call has completed, but OnJobComplete will not be performed.


### PR DESCRIPTION
This basically is work to better cache images at load time and also prepare for the texture cache holding more than one size of the same image.

Also contains fixes for attempts at caching the same image in 2 different threads (results in corrupt jpg) and fixes for addon thumbs.

In addition, http:// art is considered stable (i.e. non-changing) which is most likely the case anyway, so this should reduce load on thetvdb/themoviedb, whose URLs are stable.  There's a routine in place to invalidate this (thus forcing a check, not necessarily a re-cache if nothing has changed) which the addon repos use.

Would like this one in before the video_thumbs_to_cache (PR on the way) as it is hopefully the last time that the texturedb will need dropping.
