### PR TITLE
Video thumbs to texture cache

### DIFF
--- a/xbmc/ApplicationMessenger.cpp
+++ b/xbmc/ApplicationMessenger.cpp
@@ -830,7 +830,7 @@ void CApplicationMessenger::MediaPlay(string filename)
   if (item.IsAudio())
     item.SetMusicThumb();
   else
-    item.SetThumbnailImage(CVideoThumbLoader::GetLocalThumb(item));
+    CVideoThumbLoader::FillThumb(item);
   item.FillInDefaultIcon();
 
   MediaPlay(item);

--- a/xbmc/ApplicationMessenger.cpp
+++ b/xbmc/ApplicationMessenger.cpp
@@ -69,6 +69,7 @@
 
 #include "utils/JobManager.h"
 #include "storage/DetectDVDType.h"
+#include "ThumbLoader.h"
 
 using namespace std;
 
@@ -829,7 +830,7 @@ void CApplicationMessenger::MediaPlay(string filename)
   if (item.IsAudio())
     item.SetMusicThumb();
   else
-    item.SetVideoThumb();
+    item.SetThumbnailImage(CVideoThumbLoader::GetLocalThumb(item));
   item.FillInDefaultIcon();
 
   MediaPlay(item);

--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -988,16 +988,6 @@ CStdString CFileItem::GetCachedArtistThumb() const
   return CThumbnailCache::GetArtistThumb(*this);
 }
 
-CStdString CFileItem::GetCachedSeasonThumb() const
-{
-  return CThumbnailCache::GetSeasonThumb(*this);
-}
-
-CStdString CFileItem::GetCachedActorThumb() const
-{
-  return CThumbnailCache::GetActorThumb(*this);
-}
-
 void CFileItem::SetCachedArtistThumb()
 {
   CStdString thumb(GetCachedArtistThumb());
@@ -1016,16 +1006,6 @@ void CFileItem::SetMusicThumb(bool alwaysCheckRemote /* = true */)
   SetCachedMusicThumb();
   if (!HasThumbnail())
     SetUserMusicThumb(alwaysCheckRemote);
-}
-
-void CFileItem::SetCachedSeasonThumb()
-{
-  CStdString thumb(GetCachedSeasonThumb());
-  if (CFile::Exists(thumb))
-  {
-    // found it, we are finished.
-    SetThumbnailImage(thumb);
-  }
 }
 
 void CFileItem::RemoveExtension()
@@ -2396,17 +2376,6 @@ bool CFileItemList::AlwaysCache() const
   return false;
 }
 
-void CFileItemList::SetCachedVideoThumbs()
-{
-  CSingleLock lock(m_lock);
-  // TODO: Investigate caching time to see if it speeds things up
-  for (unsigned int i = 0; i < m_items.size(); ++i)
-  {
-    CFileItemPtr pItem = m_items[i];
-    pItem->SetCachedVideoThumb();
-  }
-}
-
 void CFileItemList::SetCachedMusicThumbs()
 {
   CSingleLock lock(m_lock);
@@ -2546,31 +2515,6 @@ void CFileItem::SetUserMusicThumb(bool alwaysCheckRemote /* = false */)
   }
 
   SetCachedMusicThumb();
-}
-
-CStdString CFileItem::GetCachedVideoThumb() const
-{
-  return CThumbnailCache::GetVideoThumb(*this);
-}
-
-CStdString CFileItem::GetCachedEpisodeThumb() const
-{
-  return CThumbnailCache::GetEpisodeThumb(*this);
-}
-
-void CFileItem::SetCachedVideoThumb()
-{
-  if (IsParentFolder()) return;
-  if (HasThumbnail()) return;
-  CStdString cachedThumb(GetCachedVideoThumb());
-  if (HasVideoInfoTag() && !m_bIsFolder  &&
-      GetVideoInfoTag()->m_iEpisode > -1 &&
-      CFile::Exists(GetCachedEpisodeThumb()))
-  {
-    SetThumbnailImage(GetCachedEpisodeThumb());
-  }
-  else if (CFile::Exists(cachedThumb))
-    SetThumbnailImage(cachedThumb);
 }
 
 // Gets the .tbn filename from a file or folder name.
@@ -2785,29 +2729,6 @@ bool CFileItem::testGetBaseMoviePath()
   return true;
 }
 #endif
-
-void CFileItem::SetVideoThumb()
-{
-  if (HasThumbnail()) return;
-  SetCachedVideoThumb();
-  if (!HasThumbnail())
-    SetUserVideoThumb();
-}
-
-void CFileItem::SetUserVideoThumb()
-{
-  if (m_bIsShareOrDrive) return;
-  if (IsParentFolder()) return;
-
-  // caches as the local thumb
-  CStdString thumb(GetUserVideoThumb());
-  if (!thumb.IsEmpty())
-  {
-    CStdString cachedThumb(GetCachedVideoThumb());
-    CPicture::CreateThumbnail(thumb, cachedThumb);
-  }
-  SetCachedVideoThumb();
-}
 
 bool CFileItem::CacheLocalFanart() const
 {

--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -132,7 +132,6 @@ CFileItem::CFileItem(const CVideoInfoTag& movie)
   *GetVideoInfoTag() = movie;
   if (movie.m_iSeason == 0) SetProperty("isspecial", "true");
   FillInDefaultIcon();
-  SetCachedVideoThumb();
 }
 
 CFileItem::CFileItem(const CArtist& artist)

--- a/xbmc/FileItem.h
+++ b/xbmc/FileItem.h
@@ -199,11 +199,7 @@ public:
   CPictureInfoTag* GetPictureInfoTag();
 
   // Gets the cached thumb filename (no existence checks)
-  CStdString GetCachedVideoThumb() const;
-  CStdString GetCachedEpisodeThumb() const;
   CStdString GetCachedArtistThumb() const;
-  CStdString GetCachedSeasonThumb() const;
-  CStdString GetCachedActorThumb() const;
   /*!
    \brief Get the cached fanart path for this item if it exists
    \return path to the cached fanart for this item, or empty if none exists
@@ -212,8 +208,6 @@ public:
   CStdString GetCachedFanart() const;
   static CStdString GetCachedThumb(const CStdString &path, const CStdString& strPath2, bool split=false);
 
-  // Sets the video thumb (cached first, else caches user thumb)
-  void SetVideoThumb();
   /*!
    \brief Cache a copy of the local fanart for this item if we don't already have an image cached
    \return true if we already have cached fanart or if the caching was successful, false if no image is cached.
@@ -228,10 +222,8 @@ public:
   CStdString GetLocalFanart() const;
 
   // Sets the cached thumb for the item if it exists
-  void SetCachedVideoThumb();
   void SetCachedArtistThumb();
   void SetCachedMusicThumb();
-  void SetCachedSeasonThumb();
 
   // Gets the .tbn file associated with this item
   CStdString GetTBNFile() const;
@@ -258,7 +250,6 @@ public:
   CStdString GetUserMusicThumb(bool alwaysCheckRemote = false) const;
 
   // Caches the user thumb and assigns it to the item
-  void SetUserVideoThumb();
   void SetUserMusicThumb(bool alwaysCheckRemote = false);
 
   /*! \brief Get the path where we expect local metadata to reside.
@@ -471,7 +462,6 @@ public:
   void RemoveDiscCache(int windowID = 0) const;
   bool AlwaysCache() const;
 
-  void SetCachedVideoThumbs();
   void SetCachedMusicThumbs();
 
   void Swap(unsigned int item1, unsigned int item2);

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -3579,12 +3579,16 @@ void CGUIInfoManager::SetCurrentMovie(CFileItem &item)
   }
 
   // Find a thumb for this file.
-  item.SetVideoThumb();
   if (!item.HasThumbnail())
   {
-    CStdString thumbURL = CVideoThumbLoader::GetEmbeddedThumbURL(item);
-    if (!CTextureCache::Get().GetCachedImage(thumbURL).IsEmpty())
-      item.SetThumbnailImage(thumbURL);
+    CStdString thumb = CVideoThumbLoader::GetLocalThumb(item);
+    if (thumb.IsEmpty())
+    {
+      CStdString thumb = CVideoThumbLoader::GetEmbeddedThumbURL(item);
+      if (CTextureCache::Get().GetCachedImage(thumb).IsEmpty())
+        thumb.clear();
+    }
+    item.SetThumbnailImage(thumb);
   }
 
   // find a thumb for this stream
@@ -3602,9 +3606,9 @@ void CGUIInfoManager::SetCurrentMovie(CFileItem &item)
     {
       CLog::Log(LOGDEBUG,"Streaming media detected... using %s to find a thumb", g_application.m_strPlayListFile.c_str());
       CFileItem thumbItem(g_application.m_strPlayListFile,false);
-      thumbItem.SetVideoThumb();
-      if (thumbItem.HasThumbnail())
-        item.SetThumbnailImage(thumbItem.GetThumbnailImage());
+      CStdString thumb = CVideoThumbLoader::GetLocalThumb(thumbItem);
+      if (!thumb.IsEmpty())
+        item.SetThumbnailImage(thumb);
     }
   }
 

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -3581,14 +3581,12 @@ void CGUIInfoManager::SetCurrentMovie(CFileItem &item)
   // Find a thumb for this file.
   if (!item.HasThumbnail())
   {
-    CStdString thumb = CVideoThumbLoader::GetLocalThumb(item);
-    if (thumb.IsEmpty())
+    if (!CVideoThumbLoader::FillThumb(item))
     {
       CStdString thumb = CVideoThumbLoader::GetEmbeddedThumbURL(item);
-      if (CTextureCache::Get().GetCachedImage(thumb).IsEmpty())
-        thumb.clear();
+      if (!CTextureCache::Get().GetCachedImage(thumb).IsEmpty())
+        item.SetThumbnailImage(thumb);
     }
-    item.SetThumbnailImage(thumb);
   }
 
   // find a thumb for this stream
@@ -3606,9 +3604,8 @@ void CGUIInfoManager::SetCurrentMovie(CFileItem &item)
     {
       CLog::Log(LOGDEBUG,"Streaming media detected... using %s to find a thumb", g_application.m_strPlayListFile.c_str());
       CFileItem thumbItem(g_application.m_strPlayListFile,false);
-      CStdString thumb = CVideoThumbLoader::GetLocalThumb(thumbItem);
-      if (!thumb.IsEmpty())
-        item.SetThumbnailImage(thumb);
+      if (CVideoThumbLoader::FillThumb(thumbItem))
+        item.SetThumbnailImage(thumbItem.GetThumbnailImage());
     }
   }
 

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -74,6 +74,7 @@
 
 #include "addons/AddonManager.h"
 #include "interfaces/info/InfoBool.h"
+#include "TextureCache.h"
 
 #define SYSHEATUPDATEINTERVAL 60000
 
@@ -3581,13 +3582,9 @@ void CGUIInfoManager::SetCurrentMovie(CFileItem &item)
   item.SetVideoThumb();
   if (!item.HasThumbnail())
   {
-    CStdString strPath, strFileName;
-    URIUtils::Split(item.GetCachedVideoThumb(), strPath, strFileName);
-
-    // create unique thumb for auto generated thumbs
-    CStdString cachedThumb = strPath + "auto-" + strFileName;
-    if (CFile::Exists(cachedThumb))
-      item.SetThumbnailImage(cachedThumb);
+    CStdString thumbURL = CVideoThumbLoader::GetEmbeddedThumbURL(item);
+    if (!CTextureCache::Get().GetCachedImage(thumbURL).IsEmpty())
+      item.SetThumbnailImage(thumbURL);
   }
 
   // find a thumb for this stream

--- a/xbmc/TextureCache.cpp
+++ b/xbmc/TextureCache.cpp
@@ -98,18 +98,22 @@ CStdString CTextureCache::GetCachedImage(const CStdString &url, CStdString &cach
   return "";
 }
 
-CStdString CTextureCache::GetWrappedImageURL(const CStdString &image, const CStdString &type)
+CStdString CTextureCache::GetWrappedImageURL(const CStdString &image, const CStdString &type, const CStdString &options)
 {
-  CStdString url(image);
-  CURL::Encode(url);
-  return "image://" + type + "@" + url;
+  CStdString encoded(image);
+  CURL::Encode(encoded);
+  CStdString url = "image://";
+  if (!type.IsEmpty())
+    url += type + "@";
+  url += encoded;
+  if (!options.IsEmpty())
+    url += "/transform?" + options;
+  return url;
 }
 
 CStdString CTextureCache::GetWrappedThumbURL(const CStdString &image)
 {
-  CStdString url(image);
-  CURL::Encode(url);
-  return "image://" + url + "/transform?size=thumb";
+  return GetWrappedImageURL(image, "", "size=thumb");
 }
 
 CStdString CTextureCache::CheckCachedImage(const CStdString &url, bool returnDDS, bool &needsRecaching)

--- a/xbmc/TextureCache.h
+++ b/xbmc/TextureCache.h
@@ -140,10 +140,11 @@ public:
 
   /*! \brief retrieve a wrapped URL for a image file
    \param image name of the file
-   \param type type of file containing the image (picture, video, music)
+   \param type signifies a special type of image (eg embedded video thumb, picture folder thumb)
+   \param options which options we need (eg size=thumb)
    \return full wrapped URL of the image file
    */
-  static CStdString GetWrappedImageURL(const CStdString &image, const CStdString &type);
+  static CStdString GetWrappedImageURL(const CStdString &image, const CStdString &type, const CStdString &options = "");
   static CStdString GetWrappedThumbURL(const CStdString &image);
 
   /*! \brief get a unique image path to associate with the given URL, useful for caching images

--- a/xbmc/ThumbLoader.cpp
+++ b/xbmc/ThumbLoader.cpp
@@ -30,7 +30,6 @@
 #include "settings/GUISettings.h"
 #include "GUIUserMessages.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/TextureManager.h"
 #include "TextureCache.h"
 #include "utils/log.h"
 #include "programs/Shortcut.h"
@@ -48,26 +47,6 @@ CThumbLoader::CThumbLoader(int nThreads) :
 
 CThumbLoader::~CThumbLoader()
 {
-}
-
-bool CThumbLoader::LoadRemoteThumb(CFileItem *pItem)
-{
-  // look for remote thumbs
-  CStdString thumb(pItem->GetThumbnailImage());
-  if (!g_TextureManager.CanLoad(thumb))
-  {
-    CStdString cachedThumb(pItem->GetCachedVideoThumb());
-    if (CFile::Exists(cachedThumb))
-      pItem->SetThumbnailImage(cachedThumb);
-    else
-    {
-      if (CPicture::CreateThumbnail(thumb, cachedThumb))
-        pItem->SetThumbnailImage(cachedThumb);
-      else
-        pItem->SetThumbnailImage("");
-    }
-  }
-  return pItem->HasThumbnail();
 }
 
 CStdString CThumbLoader::GetCachedImage(const CFileItem &item, const CStdString &type)
@@ -412,8 +391,6 @@ bool CMusicThumbLoader::LoadItem(CFileItem* pItem)
   if (pItem->m_bIsShareOrDrive) return true;
   if (!pItem->HasThumbnail())
     pItem->SetUserMusicThumb();
-  else
-    LoadRemoteThumb(pItem);
   return true;
 }
 

--- a/xbmc/ThumbLoader.h
+++ b/xbmc/ThumbLoader.h
@@ -92,6 +92,12 @@ public:
   virtual bool LoadItem(CFileItem* pItem);
   void SetStreamDetailsObserver(IStreamDetailsObserver *pObs) { m_pStreamDetailsObs = pObs; }
 
+  /*! \brief Get a local thumb for a video item
+   \param item a video CFileItem.
+   \return the URL for the local thumb
+   */
+  static CStdString GetLocalThumb(const CFileItem &item);
+
   /*! \brief helper function to retrieve a thumb URL for embedded video thumbs
    \param item a video CFileItem.
    \return a URL for the embedded thumb.

--- a/xbmc/ThumbLoader.h
+++ b/xbmc/ThumbLoader.h
@@ -67,8 +67,6 @@ public:
   CThumbLoader(int nThreads=-1);
   virtual ~CThumbLoader();
 
-  bool LoadRemoteThumb(CFileItem *pItem);
-
   /*! \brief Checks whether the given item has an image listed in the texture database
    \param item CFileItem to check
    \param type the type of image to retrieve

--- a/xbmc/ThumbLoader.h
+++ b/xbmc/ThumbLoader.h
@@ -92,6 +92,12 @@ public:
   virtual bool LoadItem(CFileItem* pItem);
   void SetStreamDetailsObserver(IStreamDetailsObserver *pObs) { m_pStreamDetailsObs = pObs; }
 
+  /*! \brief helper function to retrieve a thumb URL for embedded video thumbs
+   \param item a video CFileItem.
+   \return a URL for the embedded thumb.
+   */
+  static CStdString GetEmbeddedThumbURL(const CFileItem &item);
+
   /*!
    \brief Callback from CThumbExtractor on completion of a generated image
 

--- a/xbmc/ThumbLoader.h
+++ b/xbmc/ThumbLoader.h
@@ -90,11 +90,13 @@ public:
   virtual bool LoadItem(CFileItem* pItem);
   void SetStreamDetailsObserver(IStreamDetailsObserver *pObs) { m_pStreamDetailsObs = pObs; }
 
-  /*! \brief Get a local thumb for a video item
-   \param item a video CFileItem.
-   \return the URL for the local thumb
+  /*! \brief Fill the thumb of a video item
+   First uses a cached thumb from a previous run, then checks for a local thumb
+   and caches it for the next run
+   \param item the CFileItem object to fill
+   \return true if we fill the thumb, false otherwise
    */
-  static CStdString GetLocalThumb(const CFileItem &item);
+  static bool FillThumb(CFileItem &item);
 
   /*! \brief helper function to retrieve a thumb URL for embedded video thumbs
    \param item a video CFileItem.

--- a/xbmc/ThumbnailCache.cpp
+++ b/xbmc/ThumbnailCache.cpp
@@ -154,60 +154,6 @@ CStdString CThumbnailCache::GetArtistThumb(const CStdString &label)
   return GetThumb("artist" + label, g_settings.GetMusicArtistThumbFolder());
 }
 
-CStdString CThumbnailCache::GetActorThumb(const CFileItem &item)
-{
-  return GetActorThumb(item.GetLabel());
-}
-
-CStdString CThumbnailCache::GetActorThumb(const CStdString &label)
-{
-  return GetThumb("actor" + label, g_settings.GetVideoThumbFolder(), true);
-}
-
-CStdString CThumbnailCache::GetSeasonThumb(const CFileItem &item)
-{
-  return GetSeasonThumb(item.GetLabel(), item.GetVideoInfoTag());
-}
-
-CStdString CThumbnailCache::GetSeasonThumb(const CStdString &label, const CVideoInfoTag *videoInfo /* = NULL */)
-{
-  CStdString seasonPath;
-  if (videoInfo)
-    seasonPath = videoInfo->m_strPath;
-
-  return GetThumb("season" + seasonPath + label, g_settings.GetVideoThumbFolder(), true);
-}
-
-CStdString CThumbnailCache::GetEpisodeThumb(const CFileItem &item)
-{
-  if (!item.HasVideoInfoTag())
-    return CStdString();
-
-  return GetEpisodeThumb(item.GetVideoInfoTag());
-}
-
-CStdString CThumbnailCache::GetEpisodeThumb(const CVideoInfoTag* videoInfo)
-{
-  // get the locally cached thumb
-  CStdString strCRC;
-  strCRC.Format("%sepisode%i", videoInfo->m_strFileNameAndPath.c_str(), videoInfo->m_iEpisode);
-  return GetThumb(strCRC, g_settings.GetVideoThumbFolder(), true);
-}
-
-CStdString CThumbnailCache::GetVideoThumb(const CFileItem &item)
-{
-  if (item.IsStack())
-    return GetThumb(CStackDirectory::GetFirstStackedFile(item.GetPath()), g_settings.GetVideoThumbFolder(), true);
-  else if (item.IsVideoDb() && item.HasVideoInfoTag())
-  {
-    if (item.m_bIsFolder && !item.GetVideoInfoTag()->m_strPath.IsEmpty())
-      return GetThumb(item.GetVideoInfoTag()->m_strPath, g_settings.GetVideoThumbFolder(), true);
-    else if (!item.GetVideoInfoTag()->m_strFileNameAndPath.IsEmpty())
-      return GetThumb(item.GetVideoInfoTag()->m_strFileNameAndPath, g_settings.GetVideoThumbFolder(), true);
-  }
-  return GetThumb(item.GetPath(), g_settings.GetVideoThumbFolder(), true);
-}
-
 CStdString CThumbnailCache::GetFanart(const CFileItem &item)
 {
   // get the locally cached thumb

--- a/xbmc/ThumbnailCache.h
+++ b/xbmc/ThumbnailCache.h
@@ -55,13 +55,6 @@ public:
   static CStdString GetArtistThumb(const CArtist &artist);
   static CStdString GetArtistThumb(const CFileItem &item);
   static CStdString GetArtistThumb(const CStdString &label);
-  static CStdString GetActorThumb(const CFileItem &item);
-  static CStdString GetActorThumb(const CStdString &label);
-  static CStdString GetSeasonThumb(const CFileItem &item);
-  static CStdString GetSeasonThumb(const CStdString &label, const CVideoInfoTag *videoInfo = NULL);
-  static CStdString GetEpisodeThumb(const CFileItem &item);
-  static CStdString GetEpisodeThumb(const CVideoInfoTag *videoInfo);
-  static CStdString GetVideoThumb(const CFileItem &item);
   static CStdString GetFanart(const CFileItem &item);
   static CStdString GetThumb(const CStdString &path, const CStdString &path2, bool split = false);
 protected:

--- a/xbmc/cores/dvdplayer/DVDFileInfo.cpp
+++ b/xbmc/cores/dvdplayer/DVDFileInfo.cpp
@@ -49,6 +49,7 @@
 #include "DllAvCodec.h"
 #include "DllSwScale.h"
 #include "filesystem/File.h"
+#include "TextureCache.h"
 
 
 bool CDVDFileInfo::GetFileDuration(const CStdString &path, int& duration)
@@ -74,7 +75,7 @@ bool CDVDFileInfo::GetFileDuration(const CStdString &path, int& duration)
     return false;
 }
 
-bool CDVDFileInfo::ExtractThumb(const CStdString &strPath, const CStdString &strTarget, CStreamDetails *pStreamDetails)
+bool CDVDFileInfo::ExtractThumb(const CStdString &strPath, CTextureDetails &details, CStreamDetails *pStreamDetails)
 {
   unsigned int nTime = XbmcThreads::SystemClockMillis();
   CDVDInputStream *pInputStream = CDVDFactoryInputStream::CreateInputStream(NULL, strPath, "");
@@ -225,7 +226,9 @@ bool CDVDFileInfo::ExtractThumb(const CStdString &strPath, const CStdString &str
               dllSwScale.sws_scale(context, src, srcStride, 0, picture.iHeight, dst, dstStride);
               dllSwScale.sws_freeContext(context);
 
-              CPicture::CacheTexture(pOutBuf, nWidth, nHeight, nWidth * 4, 0, nWidth, nHeight, strTarget);
+              details.width = nWidth;
+              details.height = nHeight;
+              CPicture::CacheTexture(pOutBuf, nWidth, nHeight, nWidth * 4, 0, nWidth, nHeight, CTextureCache::GetCachedPath(details.file));
               bOk = true;
             }
 
@@ -250,7 +253,7 @@ bool CDVDFileInfo::ExtractThumb(const CStdString &strPath, const CStdString &str
   if(!bOk)
   {
     XFILE::CFile file;
-    if(file.OpenForWrite(strTarget))
+    if(file.OpenForWrite(CTextureCache::GetCachedPath(details.file)))
       file.Close();
   }
 

--- a/xbmc/cores/dvdplayer/DVDFileInfo.h
+++ b/xbmc/cores/dvdplayer/DVDFileInfo.h
@@ -26,12 +26,13 @@ class CFileItem;
 class CDVDDemux;
 class CStreamDetails;
 class CDVDInputStream;
+class CTextureDetails;
 
 class CDVDFileInfo
 {
 public:
-  // Extract a thumbnail immage from the media at strPath an image file in strTarget, optionally populating a streamdetails class with the data
-  static bool ExtractThumb(const CStdString &strPath, const CStdString &strTarget, CStreamDetails *pStreamDetails);
+  // Extract a thumbnail immage from the media at strPath, optionally populating a streamdetails class with the data
+  static bool ExtractThumb(const CStdString &strPath, CTextureDetails &details, CStreamDetails *pStreamDetails);
 
   // Probe the files streams and store the info in the VideoInfoTag
   static bool GetFileStreamDetails(CFileItem *pItem);

--- a/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamHTSP.cpp
+++ b/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamHTSP.cpp
@@ -247,7 +247,6 @@ bool CDVDInputStreamHTSP::UpdateItem(CFileItem& item)
   CFileItem current(item);
   CHTSPSession::ParseItem(channel, m_tag, m_event, item);
   item.SetThumbnailImage(channel.icon);
-  item.SetCachedVideoThumb();
   return current.GetPath()  != item.GetPath()
       || current.m_strTitle != item.m_strTitle;
 }

--- a/xbmc/dialogs/GUIDialogContextMenu.cpp
+++ b/xbmc/dialogs/GUIDialogContextMenu.cpp
@@ -552,9 +552,7 @@ bool CGUIDialogContextMenu::OnContextButton(const CStdString &type, const CFileI
           URIUtils::RemoveSlashAtEnd(cachedThumb);
           cachedThumb = CThumbnailCache::GetMusicThumb(cachedThumb);
         }
-        else if (type == "video")
-          cachedThumb = item->GetCachedVideoThumb();
-        else  // assume "programs"
+        else  // programs, video, pictures
         { // store the thumb for this share
           CTextureDatabase db;
           if (db.Open())

--- a/xbmc/filesystem/HTSPSession.cpp
+++ b/xbmc/filesystem/HTSPSession.cpp
@@ -645,7 +645,6 @@ bool CHTSPSession::ParseItem(const SChannel& channel, int tagid, const SEvent& e
   item.m_strTitle = tag->m_strTitle;
   item.SetThumbnailImage(channel.icon);
   item.SetMimeType("video/X-htsp");
-  item.SetCachedVideoThumb();
   return true;
 }
 

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNode.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNode.cpp
@@ -51,6 +51,7 @@
 #include "utils/StringUtils.h"
 #include "guilib/LocalizeStrings.h"
 #include "utils/Variant.h"
+#include "video/VideoDatabase.h"
 
 using namespace std;
 using namespace XFILE::VIDEODATABASEDIRECTORY;
@@ -320,6 +321,12 @@ void CDirectoryNode::AddQueuingFolder(CFileItemList& items) const
         pItem->GetVideoInfoTag()->m_strTitle = strLabel;
         pItem->GetVideoInfoTag()->m_iEpisode = watched + unwatched;
         pItem->GetVideoInfoTag()->m_playCount = (unwatched == 0) ? 1 : 0;
+        CVideoDatabase db;
+        if (db.Open())
+        {
+          pItem->GetVideoInfoTag()->m_iDbId = db.GetSeasonId(pItem->GetVideoInfoTag()->m_iIdShow, -1);
+          db.Close();
+        }
         if (XFILE::CFile::Exists(pItem->GetCachedSeasonThumb()))
           pItem->SetThumbnailImage(pItem->GetCachedSeasonThumb());
       }

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNode.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNode.cpp
@@ -327,8 +327,7 @@ void CDirectoryNode::AddQueuingFolder(CFileItemList& items) const
           pItem->GetVideoInfoTag()->m_iDbId = db.GetSeasonId(pItem->GetVideoInfoTag()->m_iIdShow, -1);
           db.Close();
         }
-        if (XFILE::CFile::Exists(pItem->GetCachedSeasonThumb()))
-          pItem->SetThumbnailImage(pItem->GetCachedSeasonThumb());
+        pItem->GetVideoInfoTag()->m_type = "season";
       }
       break;
     default:

--- a/xbmc/guilib/GUIListItem.cpp
+++ b/xbmc/guilib/GUIListItem.cpp
@@ -25,6 +25,8 @@
 #include "utils/CharsetConverter.h"
 #include "utils/Variant.h"
 
+using namespace std;
+
 CGUIListItem::CGUIListItem(const CGUIListItem& item)
 {
   m_layout = NULL;
@@ -163,6 +165,25 @@ CStdString CGUIListItem::GetOverlayImage() const
   default:
     return "";
   }
+}
+
+map<string, string> CGUIListItem::GetArt() const
+{
+  map<string, string> art;
+  if (HasThumbnail())
+    art.insert(make_pair("thumb", GetThumbnailImage()));
+  if (HasProperty("fanart_image"))
+    art.insert(make_pair("fanart", GetProperty("fanart_image").asString()));
+  return art;
+}
+
+void CGUIListItem::SetArt(const map<string, string> &art)
+{
+  map<string, string>::const_iterator i = art.find("thumb");
+  if (i != art.end())
+    SetThumbnailImage(i->second);
+  if ((i = art.find("fanart")) != art.end())
+    SetProperty("fanart_image", i->second);
 }
 
 void CGUIListItem::Select(bool bOnOff)

--- a/xbmc/guilib/GUIListItem.h
+++ b/xbmc/guilib/GUIListItem.h
@@ -79,6 +79,20 @@ public:
   void SetOverlayImage(GUIIconOverlay icon, bool bOnOff=false);
   CStdString GetOverlayImage() const;
 
+  /*! \brief set artwork for an item
+   Sets thumb and fanart image
+   \param map a type:url map for artwork
+   \sa GetArt
+   */
+  void SetArt(const std::map<std::string, std::string> &art);
+
+  /*! \brief get artwork for an item
+   Retrieves artwork in a type:url map
+   \return a type:url map for artwork
+   \sa SetArt
+   */
+  std::map<std::string, std::string> GetArt() const;
+
   void SetSortLabel(const CStdString &label);
   const CStdStringW &GetSortLabel() const;
 

--- a/xbmc/interfaces/http-api/XBMChttp.cpp
+++ b/xbmc/interfaces/http-api/XBMChttp.cpp
@@ -1256,11 +1256,10 @@ int CXbmcHttp::xbmcGetMovieDetails(int numParas, CStdString paras[])
           cast += character;
         }*/
         output += closeTag+openTag+"Cast:" + cast;
-        thumb = CVideoThumbLoader::GetLocalThumb(*item);
-        if (thumb.IsEmpty())
+        if (!CVideoThumbLoader::FillThumb(*item))
           thumb = "[None]";
         else
-          thumb = CTextureCache::Get().CheckAndCacheImage(thumb);
+          thumb = CTextureCache::Get().CheckAndCacheImage(item->GetThumbnailImage());
         output += closeTag+openTag+"Thumb:" + thumb;
         m_database.Close();
         delete item;

--- a/xbmc/interfaces/http-api/XBMChttp.cpp
+++ b/xbmc/interfaces/http-api/XBMChttp.cpp
@@ -52,6 +52,7 @@
 #include "utils/log.h"
 #include "TextureCache.h"
 #include "ThumbnailCache.h"
+#include "ThumbLoader.h"
 
 #ifdef _WIN32
 extern "C" FILE *fopen_utf8(const char *_Filename, const char *_Mode);
@@ -1255,11 +1256,11 @@ int CXbmcHttp::xbmcGetMovieDetails(int numParas, CStdString paras[])
           cast += character;
         }*/
         output += closeTag+openTag+"Cast:" + cast;
-        item->SetVideoThumb();
-        if (!item->HasThumbnail())
+        thumb = CVideoThumbLoader::GetLocalThumb(*item);
+        if (thumb.IsEmpty())
           thumb = "[None]";
         else
-          thumb = item->GetCachedVideoThumb();
+          thumb = CTextureCache::Get().CheckAndCacheImage(thumb);
         output += closeTag+openTag+"Thumb:" + thumb;
         m_database.Close();
         delete item;

--- a/xbmc/interfaces/json-rpc/FileItemHandler.cpp
+++ b/xbmc/interfaces/json-rpc/FileItemHandler.cpp
@@ -93,7 +93,7 @@ void CFileItemHandler::FillDetails(ISerializable* info, CFileItemPtr item, const
       {
         CStdString fanart;
         if (item->HasProperty("fanart_image"))
-          fanart = item->GetProperty("fanart_image").asString();
+          fanart = CTextureCache::Get().CheckAndCacheImage(item->GetProperty("fanart_image").asString());
         if (fanart.empty())
           fanart = item->GetCachedFanart();
         if (!fanart.empty())

--- a/xbmc/interfaces/json-rpc/FileItemHandler.cpp
+++ b/xbmc/interfaces/json-rpc/FileItemHandler.cpp
@@ -35,6 +35,7 @@
 #include "filesystem/Directory.h"
 #include "filesystem/File.h"
 #include "TextureCache.h"
+#include "ThumbLoader.h"
 
 using namespace MUSIC_INFO;
 using namespace JSONRPC;
@@ -231,12 +232,11 @@ void CFileItemHandler::HandleFileItem(const char *ID, bool allowFile, const char
       if (item->HasThumbnail())
         object["thumbnail"] = CTextureCache::Get().CheckAndCacheImage(item->GetThumbnailImage());
       else if (item->HasVideoInfoTag())
-      {
-        CStdString strPath, strFileName;
-        URIUtils::Split(item->GetCachedVideoThumb(), strPath, strFileName);
-        CStdString cachedThumb = strPath + "auto-" + strFileName;
-
-        if (CFile::Exists(cachedThumb))
+      { // TODO: Should the JSON-API return actual image URLs, virtual thumb URLs, or local URLs to the cached image?
+        //       ATM we return the latter
+        CStdString thumbURL = CVideoThumbLoader::GetEmbeddedThumbURL(*item);
+        CStdString cachedThumb = CTextureCache::Get().GetCachedImage(thumbURL);
+        if (!cachedThumb.IsEmpty())
           object["thumbnail"] = cachedThumb;
       }
       else if (item->HasPictureInfoTag())

--- a/xbmc/interfaces/json-rpc/VideoLibrary.cpp
+++ b/xbmc/interfaces/json-rpc/VideoLibrary.cpp
@@ -401,12 +401,15 @@ JSONRPC_STATUS CVideoLibrary::SetTVShowDetails(const CStdString &method, ITransp
   std::map<std::string, std::string> artwork;
   videodatabase.GetArtForItem(infos.m_iDbId, infos.m_type, artwork);
 
+  std::map<int, std::string> seasonArt;
+  videodatabase.GetTvShowSeasonArt(infos.m_iDbId, seasonArt);
+
   int playcount = infos.m_playCount;
   CDateTime lastPlayed = infos.m_lastPlayed;
 
   UpdateVideoTag(parameterObject, infos);
 
-  if (videodatabase.SetDetailsForTvShow(infos.m_strFileNameAndPath, infos, artwork, id) > 0)
+  if (videodatabase.SetDetailsForTvShow(infos.m_strFileNameAndPath, infos, artwork, seasonArt, id) > 0)
   {
     if (playcount != infos.m_playCount || lastPlayed != infos.m_lastPlayed)
       videodatabase.SetPlayCount(CFileItem(infos), infos.m_playCount, infos.m_lastPlayed);

--- a/xbmc/interfaces/json-rpc/VideoLibrary.cpp
+++ b/xbmc/interfaces/json-rpc/VideoLibrary.cpp
@@ -364,12 +364,15 @@ JSONRPC_STATUS CVideoLibrary::SetMovieDetails(const CStdString &method, ITranspo
     return InvalidParams;
   }
 
+  std::map<std::string, std::string> artwork;
+  videodatabase.GetArtForItem(infos.m_iDbId, infos.m_type, artwork);
+
   int playcount = infos.m_playCount;
   CDateTime lastPlayed = infos.m_lastPlayed;
 
   UpdateVideoTag(parameterObject, infos);
 
-  if (videodatabase.SetDetailsForMovie(infos.m_strFileNameAndPath, infos, id) > 0)
+  if (videodatabase.SetDetailsForMovie(infos.m_strFileNameAndPath, infos, artwork, id) > 0)
   {
     if (playcount != infos.m_playCount || lastPlayed != infos.m_lastPlayed)
       videodatabase.SetPlayCount(CFileItem(infos), infos.m_playCount, infos.m_lastPlayed);
@@ -395,12 +398,15 @@ JSONRPC_STATUS CVideoLibrary::SetTVShowDetails(const CStdString &method, ITransp
     return InvalidParams;
   }
 
+  std::map<std::string, std::string> artwork;
+  videodatabase.GetArtForItem(infos.m_iDbId, infos.m_type, artwork);
+
   int playcount = infos.m_playCount;
   CDateTime lastPlayed = infos.m_lastPlayed;
 
   UpdateVideoTag(parameterObject, infos);
 
-  if (videodatabase.SetDetailsForTvShow(infos.m_strFileNameAndPath, infos, id) > 0)
+  if (videodatabase.SetDetailsForTvShow(infos.m_strFileNameAndPath, infos, artwork, id) > 0)
   {
     if (playcount != infos.m_playCount || lastPlayed != infos.m_lastPlayed)
       videodatabase.SetPlayCount(CFileItem(infos), infos.m_playCount, infos.m_lastPlayed);
@@ -433,12 +439,15 @@ JSONRPC_STATUS CVideoLibrary::SetEpisodeDetails(const CStdString &method, ITrans
     return InvalidParams;
   }
 
+  std::map<std::string, std::string> artwork;
+  videodatabase.GetArtForItem(infos.m_iDbId, infos.m_type, artwork);
+
   int playcount = infos.m_playCount;
   CDateTime lastPlayed = infos.m_lastPlayed;
 
   UpdateVideoTag(parameterObject, infos);
 
-  if (videodatabase.SetDetailsForEpisode(infos.m_strFileNameAndPath, infos, tvshowid, id) > 0)
+  if (videodatabase.SetDetailsForEpisode(infos.m_strFileNameAndPath, infos, artwork, tvshowid, id) > 0)
   {
     if (playcount != infos.m_playCount || lastPlayed != infos.m_lastPlayed)
       videodatabase.SetPlayCount(CFileItem(infos), infos.m_playCount, infos.m_lastPlayed);
@@ -464,12 +473,15 @@ JSONRPC_STATUS CVideoLibrary::SetMusicVideoDetails(const CStdString &method, ITr
     return InvalidParams;
   }
 
+  std::map<std::string, std::string> artwork;
+  videodatabase.GetArtForItem(infos.m_iDbId, infos.m_type, artwork);
+
   int playcount = infos.m_playCount;
   CDateTime lastPlayed = infos.m_lastPlayed;
 
   UpdateVideoTag(parameterObject, infos);
 
-  if (videodatabase.SetDetailsForMusicVideo(infos.m_strFileNameAndPath, infos, id) > 0)
+  if (videodatabase.SetDetailsForMusicVideo(infos.m_strFileNameAndPath, infos, artwork, id) > 0)
   {
     if (playcount != infos.m_playCount || lastPlayed != infos.m_lastPlayed)
       videodatabase.SetPlayCount(CFileItem(infos), infos.m_playCount, infos.m_lastPlayed);

--- a/xbmc/network/UPnP.cpp
+++ b/xbmc/network/UPnP.cpp
@@ -58,6 +58,7 @@
 #include "utils/TimeUtils.h"
 #include "utils/md5.h"
 #include "guilib/Key.h"
+#include "ThumbLoader.h"
 
 using namespace std;
 using namespace MUSIC_INFO;
@@ -926,7 +927,7 @@ CUPnPServer::Build(CFileItemPtr                  item,
                 }
 
                 if (!item->HasThumbnail() )
-                    item->SetCachedVideoThumb();
+                    item->SetThumbnailImage(CThumbLoader::GetCachedImage(*item, "thumb"));
             }
         }
 

--- a/xbmc/pictures/PictureThumbLoader.cpp
+++ b/xbmc/pictures/PictureThumbLoader.cpp
@@ -68,8 +68,7 @@ bool CPictureThumbLoader::LoadItem(CFileItem* pItem)
   }
   else if (pItem->IsVideo() && !pItem->IsZIP() && !pItem->IsRAR() && !pItem->IsCBZ() && !pItem->IsCBR() && !pItem->IsPlayList())
   { // video
-    CStdString thumb = CVideoThumbLoader::GetLocalThumb(*pItem);
-    if (thumb.IsEmpty())
+    if (!CVideoThumbLoader::FillThumb(*pItem))
     {
       CStdString thumbURL = CVideoThumbLoader::GetEmbeddedThumbURL(*pItem);
       CStdString cachedThumb = CTextureCache::Get().GetCachedImage(thumbURL);

--- a/xbmc/pictures/PictureThumbLoader.cpp
+++ b/xbmc/pictures/PictureThumbLoader.cpp
@@ -68,8 +68,8 @@ bool CPictureThumbLoader::LoadItem(CFileItem* pItem)
   }
   else if (pItem->IsVideo() && !pItem->IsZIP() && !pItem->IsRAR() && !pItem->IsCBZ() && !pItem->IsCBR() && !pItem->IsPlayList())
   { // video
-    thumb = pItem->GetCachedVideoThumb();
-    if (!CFile::Exists(thumb))
+    CStdString thumb = CVideoThumbLoader::GetLocalThumb(*pItem);
+    if (thumb.IsEmpty())
     {
       CStdString thumbURL = CVideoThumbLoader::GetEmbeddedThumbURL(*pItem);
       CStdString cachedThumb = CTextureCache::Get().GetCachedImage(thumbURL);

--- a/xbmc/pictures/PictureThumbLoader.cpp
+++ b/xbmc/pictures/PictureThumbLoader.cpp
@@ -234,6 +234,8 @@ void CPictureThumbLoader::ProcessFoldersAndArchives(CFileItem *pItem)
         {
           CTextureDetails details;
           details.file = relativeCacheFile;
+          details.width = g_advancedSettings.m_thumbSize;
+          details.height = g_advancedSettings.m_thumbSize;
           CTextureCache::Get().AddCachedTexture(thumb, details);
           db.SetTextureForPath(pItem->GetPath(), "thumb", thumb);
           pItem->SetThumbnailImage(CTextureCache::GetCachedPath(relativeCacheFile));

--- a/xbmc/pictures/PictureThumbLoader.cpp
+++ b/xbmc/pictures/PictureThumbLoader.cpp
@@ -71,23 +71,16 @@ bool CPictureThumbLoader::LoadItem(CFileItem* pItem)
     thumb = pItem->GetCachedVideoThumb();
     if (!CFile::Exists(thumb))
     {
-      CStdString strPath, strFileName;
-      URIUtils::Split(thumb, strPath, strFileName);
-
-      CStdString autoThumb = strPath + "auto-" + strFileName;
-
-      // this is abit of a hack to avoid loading zero sized images
-      // which we know will fail. They will just display empty image
-      // we should really have some way for the texture loader to
-      // do fallbacks to default images for a failed image instead
-      if (CFile::Exists(autoThumb))
+      CStdString thumbURL = CVideoThumbLoader::GetEmbeddedThumbURL(*pItem);
+      CStdString cachedThumb = CTextureCache::Get().GetCachedImage(thumbURL);
+      if (!cachedThumb.IsEmpty())
       {
-        thumb = autoThumb;
+        thumb = thumbURL;
       }
       else if (g_guiSettings.GetBool("myvideos.extractthumb") && g_guiSettings.GetBool("myvideos.extractflags"))
       {
         CFileItem item(*pItem);
-        CThumbExtractor* extract = new CThumbExtractor(item, pItem->GetPath(), true, autoThumb);
+        CThumbExtractor* extract = new CThumbExtractor(item, pItem->GetPath(), true, thumbURL);
         AddJob(extract);
         thumb.clear();
       }

--- a/xbmc/utils/RecentlyAddedJob.cpp
+++ b/xbmc/utils/RecentlyAddedJob.cpp
@@ -78,7 +78,7 @@ bool CRecentlyAddedJob::UpdateVideo()
         m_thumbLoader.LoadItem(item.get());
 
       home->SetProperty("LatestMovie." + value + ".Thumb"       , item->GetThumbnailImage());
-      home->SetProperty("LatestMovie." + value + ".Fanart"      , item->GetCachedFanart());
+      home->SetProperty("LatestMovie." + value + ".Fanart"      , item->GetProperty("fanart_image"));
     }
   } 
   for (; i < NUM_ITEMS; ++i)
@@ -114,14 +114,6 @@ bool CRecentlyAddedJob::UpdateVideo()
       value.Format("%i", i + 1);
       strRating.Format("%.1f", item->GetVideoInfoTag()->m_fRating);
 
-      if (EpisodeSeason == 0)
-        strSeason = g_localizeStrings.Get(20381);
-      else
-        strSeason.Format(g_localizeStrings.Get(20358), EpisodeSeason);
-
-      CFileItem season(strSeason);
-      season.GetVideoInfoTag()->m_strPath = item->GetVideoInfoTag()->m_strShowPath;
-
       CFileItem show(item->GetVideoInfoTag()->m_strShowPath, true);
 
       home->SetProperty("LatestEpisode." + value + ".ShowTitle"     , item->GetVideoInfoTag()->m_strShowTitle);
@@ -136,10 +128,14 @@ bool CRecentlyAddedJob::UpdateVideo()
       if (!item->HasThumbnail())
         m_thumbLoader.LoadItem(item.get());
 
+      int seasonID = videodatabase.GetSeasonId(item->GetVideoInfoTag()->m_iIdShow, EpisodeSeason);
+      std::string seasonThumb = videodatabase.GetArtForItem(seasonID, "season", "thumb");
+      std::string showThumb = videodatabase.GetArtForItem(item->GetVideoInfoTag()->m_iIdShow, "tvshow", "thumb");
+
       home->SetProperty("LatestEpisode." + value + ".Thumb"         , item->GetThumbnailImage());
-      home->SetProperty("LatestEpisode." + value + ".ShowThumb"     , show.GetCachedVideoThumb());
-      home->SetProperty("LatestEpisode." + value + ".SeasonThumb"   , season.GetCachedSeasonThumb());
-      home->SetProperty("LatestEpisode." + value + ".Fanart"        , item->GetCachedFanart());
+      home->SetProperty("LatestEpisode." + value + ".ShowThumb"     , showThumb);
+      home->SetProperty("LatestEpisode." + value + ".SeasonThumb"   , seasonThumb);
+      home->SetProperty("LatestEpisode." + value + ".Fanart"        , item->GetProperty("fanart_image"));
     }
   } 
   for (; i < NUM_ITEMS; ++i)
@@ -182,7 +178,7 @@ bool CRecentlyAddedJob::UpdateVideo()
         m_thumbLoader.LoadItem(item.get());
 
       home->SetProperty("LatestMusicVideo." + value + ".Thumb"       , item->GetThumbnailImage());
-      home->SetProperty("LatestMusicVideo." + value + ".Fanart"      , item->GetCachedFanart());
+      home->SetProperty("LatestMusicVideo." + value + ".Fanart"      , item->GetProperty("fanart_image"));
     }
   }
   for (; i < NUM_ITEMS; ++i)

--- a/xbmc/utils/ScraperUrl.cpp
+++ b/xbmc/utils/ScraperUrl.cpp
@@ -175,6 +175,15 @@ const CScraperUrl::SUrlEntry CScraperUrl::GetSeasonThumb(int season) const
   return result;
 }
 
+void CScraperUrl::GetSeasonThumbs(map<int, string> &thumbs) const
+{
+  for (vector<SUrlEntry>::const_iterator iter=m_url.begin();iter != m_url.end();++iter)
+  {
+    if (iter->m_type == URL_TYPE_SEASON && thumbs.find(iter->m_season) == thumbs.end())
+      thumbs.insert(make_pair(iter->m_season, GetThumbURL(*iter)));
+  }
+}
+
 bool CScraperUrl::Get(const SUrlEntry& scrURL, std::string& strHTML, XFILE::CCurlFile& http, const CStdString& cacheContext)
 {
   CURL url(scrURL.m_url);

--- a/xbmc/utils/ScraperUrl.h
+++ b/xbmc/utils/ScraperUrl.h
@@ -23,6 +23,7 @@
  */
 
 #include <vector>
+#include <map>
 #include "StdString.h"
 
 class TiXmlElement;
@@ -60,6 +61,7 @@ public:
 
   const SUrlEntry GetFirstThumb() const;
   const SUrlEntry GetSeasonThumb(int) const;
+  void GetSeasonThumbs(std::map<int, std::string> &thumbs) const;
 
   /*! \brief fetch the full URL (including referrer) of a thumb
    \param URL entry to use to create the full URL

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -1888,7 +1888,7 @@ int CVideoDatabase::SetDetailsForMovie(const CStdString& strFilenameAndPath, con
   return -1;
 }
 
-int CVideoDatabase::SetDetailsForTvShow(const CStdString& strPath, const CVideoInfoTag& details, const map<string, string> &artwork, int idTvShow /*= -1 */)
+int CVideoDatabase::SetDetailsForTvShow(const CStdString& strPath, const CVideoInfoTag& details, const map<string, string> &artwork, const map<int, string> &seasonArt, int idTvShow /*= -1 */)
 {
   try
   {
@@ -1942,6 +1942,12 @@ int CVideoDatabase::SetDetailsForTvShow(const CStdString& strPath, const CVideoI
     AddSeason(idTvShow, -1);
 
     SetArtForItem(idTvShow, "tvshow", artwork);
+    for (map<int, string>::const_iterator i = seasonArt.begin(); i != seasonArt.end(); ++i)
+    {
+      int idSeason = AddSeason(idTvShow, i->first);
+      if (idSeason > -1)
+        SetArtForItem(idSeason, "season", "thumb", i->second);
+    }
 
     // and insert the new row
     CStdString sql = "update tvshow set " + GetValueString(details, VIDEODB_ID_TV_MIN, VIDEODB_ID_TV_MAX, DbTvShowOffsets);
@@ -4908,7 +4914,6 @@ bool CVideoDatabase::GetSeasonsNav(const CStdString& strBaseDir, CFileItemList& 
         pItem->SetProperty("unwatchedepisodes", it->second.numEpisodes - it->second.numWatched);
         if (iSeason == 0) pItem->SetProperty("isspecial", true);
         pItem->GetVideoInfoTag()->m_playCount = (it->second.numEpisodes == it->second.numWatched) ? 1 : 0;
-        pItem->SetCachedSeasonThumb();
         pItem->SetOverlayImage(CGUIListItem::ICON_OVERLAY_UNWATCHED, (pItem->GetVideoInfoTag()->m_playCount > 0) && (pItem->GetVideoInfoTag()->m_iEpisode > 0));
         items.Add(pItem);
       }
@@ -4947,7 +4952,6 @@ bool CVideoDatabase::GetSeasonsNav(const CStdString& strBaseDir, CFileItemList& 
         pItem->SetProperty("unwatchedepisodes", totalEpisodes - watchedEpisodes);
         if (iSeason == 0) pItem->SetProperty("isspecial", true);
         pItem->GetVideoInfoTag()->m_playCount = (totalEpisodes == watchedEpisodes) ? 1 : 0;
-        pItem->SetCachedSeasonThumb();
         pItem->SetOverlayImage(CGUIListItem::ICON_OVERLAY_UNWATCHED, (pItem->GetVideoInfoTag()->m_playCount > 0) && (pItem->GetVideoInfoTag()->m_iEpisode > 0));
         items.Add(pItem);
         m_pDS->next();

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -3329,6 +3329,35 @@ string CVideoDatabase::GetArtForItem(int mediaId, const string &mediaType, const
   return GetSingleValue("art", "url", PrepareSQL("media_id=%i AND media_type='%s' AND type='%s'", mediaId, mediaType.c_str(), artType.c_str()));
 }
 
+bool CVideoDatabase::GetTvShowSeasonArt(int showId, map<int, string> &seasonArt)
+{
+  try
+  {
+    if (NULL == m_pDB.get()) return false;
+    if (NULL == m_pDS2.get()) return false; // using dataset 2 as we're likely called in loops on dataset 1
+
+    // get all seasons for this show
+    CStdString sql = PrepareSQL("select idSeason,season from seasons where idShow=%i", showId);
+    m_pDS2->query(sql.c_str());
+
+    vector< pair<int, int> > seasons;
+    while (!m_pDS2->eof())
+    {
+      seasons.push_back(make_pair(m_pDS2->fv(0).get_asInt(), m_pDS2->fv(1).get_asInt()));
+      m_pDS2->next();
+    }
+    m_pDS2->close();
+
+    for (vector< pair<int,int> >::const_iterator i = seasons.begin(); i != seasons.end(); ++i)
+      seasonArt.insert(make_pair(i->second,GetArtForItem(i->first, "season", "thumb")));
+  }
+  catch (...)
+  {
+    CLog::Log(LOGERROR, "%s(%d) failed", __FUNCTION__, showId);
+  }
+  return false;
+}
+
 /// \brief GetStackTimes() obtains any saved video times for the stacked file
 /// \retval Returns true if the stack times exist, false otherwise.
 bool CVideoDatabase::GetStackTimes(const CStdString &filePath, vector<int> &times)

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -4287,33 +4287,6 @@ bool CVideoDatabase::GetSetsNav(const CStdString& strBaseDir, CFileItemList& ite
           pItem->SetOverlayImage(CGUIListItem::ICON_OVERLAY_UNWATCHED, pItem->GetVideoInfoTag()->m_playCount > 0);
           pItem->GetVideoInfoTag()->m_strTitle = pItem->GetLabel();
         }
-        bool thumb=false,fanart=false;
-        if (CFile::Exists(pItem->GetCachedVideoThumb()))
-        {
-          pItem->SetThumbnailImage(pItem->GetCachedVideoThumb());
-          thumb = true;
-        }
-        if (CFile::Exists(pItem->GetCachedFanart()))
-        {
-          pItem->SetProperty("fanart_image",pItem->GetCachedFanart());
-          fanart = true;
-        }
-        if (!thumb || !fanart) // use the first item's thumb
-        {
-          CStdString strSQL = PrepareSQL("select strPath, strFileName from movieview join setlinkmovie on setlinkmovie.idMovie=movieview.idMovie where setlinkmovie.idSet=%u", m_pDS->fv("sets.idSet").get_asInt());
-          m_pDS2->query(strSQL.c_str());
-          if (!m_pDS2->eof())
-          {
-            CStdString path;
-            ConstructPath(path,m_pDS2->fv(0).get_asString(),m_pDS2->fv(1).get_asString());
-            CFileItem item(path,false);
-            if (!thumb && CFile::Exists(item.GetCachedVideoThumb()))
-              pItem->SetThumbnailImage(item.GetCachedVideoThumb());
-            if (!fanart && CFile::Exists(item.GetCachedFanart()))
-              pItem->SetProperty("fanart_image",item.GetCachedFanart());
-            m_pDS2->close();
-          }
-        }
         items.Add(pItem);
         m_pDS->next();
       }
@@ -4456,11 +4429,7 @@ bool CVideoDatabase::GetActorsNav(const CStdString& strBaseDir, CFileItemList& i
         pItem->SetIconImage("DefaultArtist.png");
       }
       else
-      {
-        if (CFile::Exists(pItem->GetCachedActorThumb()))
-          pItem->SetThumbnailImage(pItem->GetCachedActorThumb());
         pItem->SetIconImage("DefaultActor.png");
-      }
     }
     return true;
   }

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -1802,7 +1802,7 @@ CStdString CVideoDatabase::GetValueString(const CVideoInfoTag &details, int min,
 }
 
 //********************************************************************************************************************************
-int CVideoDatabase::SetDetailsForMovie(const CStdString& strFilenameAndPath, const CVideoInfoTag& details, int idMovie /* = -1 */)
+int CVideoDatabase::SetDetailsForMovie(const CStdString& strFilenameAndPath, const CVideoInfoTag& details, const map<string, string> &artwork, int idMovie /* = -1 */)
 {
   try
   {
@@ -1854,7 +1854,14 @@ int CVideoDatabase::SetDetailsForMovie(const CStdString& strFilenameAndPath, con
 
     // add sets...
     for (unsigned int i = 0; i < details.m_set.size(); i++)
-      AddSetToMovie(idMovie, AddSet(details.m_set[i]));
+    {
+      int idSet = AddSet(details.m_set[i]);
+      // add art if not available
+      map<string, string> setArt;
+      if (!GetArtForItem(idSet, "set", setArt))
+        SetArtForItem(idSet, "set", artwork);
+      AddSetToMovie(idMovie, idSet);
+    }
 
     // add countries...
     for (unsigned int i = 0; i < details.m_country.size(); i++)
@@ -1862,6 +1869,8 @@ int CVideoDatabase::SetDetailsForMovie(const CStdString& strFilenameAndPath, con
 
     if (details.HasStreamDetails())
       SetStreamDetailsForFileId(details.m_streamDetails, GetFileId(strFilenameAndPath));
+
+    SetArtForItem(idMovie, "movie", artwork);
 
     // update our movie table (we know it was added already above)
     // and insert the new row
@@ -1879,7 +1888,7 @@ int CVideoDatabase::SetDetailsForMovie(const CStdString& strFilenameAndPath, con
   return -1;
 }
 
-int CVideoDatabase::SetDetailsForTvShow(const CStdString& strPath, const CVideoInfoTag& details, int idTvShow /*= -1 */)
+int CVideoDatabase::SetDetailsForTvShow(const CStdString& strPath, const CVideoInfoTag& details, const map<string, string> &artwork, int idTvShow /*= -1 */)
 {
   try
   {
@@ -1932,6 +1941,8 @@ int CVideoDatabase::SetDetailsForTvShow(const CStdString& strPath, const CVideoI
     // add "all seasons" - the rest are added in SetDetailsForEpisode
     AddSeason(idTvShow, -1);
 
+    SetArtForItem(idTvShow, "tvshow", artwork);
+
     // and insert the new row
     CStdString sql = "update tvshow set " + GetValueString(details, VIDEODB_ID_TV_MIN, VIDEODB_ID_TV_MAX, DbTvShowOffsets);
     sql += PrepareSQL("where idShow=%i", idTvShow);
@@ -1949,7 +1960,7 @@ int CVideoDatabase::SetDetailsForTvShow(const CStdString& strPath, const CVideoI
   return -1;
 }
 
-int CVideoDatabase::SetDetailsForEpisode(const CStdString& strFilenameAndPath, const CVideoInfoTag& details, int idShow, int idEpisode)
+int CVideoDatabase::SetDetailsForEpisode(const CStdString& strFilenameAndPath, const CVideoInfoTag& details, const map<string, string> &artwork, int idShow, int idEpisode)
 {
   try
   {
@@ -2005,6 +2016,8 @@ int CVideoDatabase::SetDetailsForEpisode(const CStdString& strFilenameAndPath, c
     // ensure we have this season already added
     AddSeason(idShow, details.m_iSeason);
 
+    SetArtForItem(idEpisode, "episode", artwork);
+
     // and insert the new row
     CStdString sql = "update episode set " + GetValueString(details, VIDEODB_ID_EPISODE_MIN, VIDEODB_ID_EPISODE_MAX, DbEpisodeOffsets);
     sql += PrepareSQL("where idEpisode=%i", idEpisode);
@@ -2040,7 +2053,7 @@ int CVideoDatabase::AddSeason(int showID, int season)
   return seasonId;
 }
 
-int CVideoDatabase::SetDetailsForMusicVideo(const CStdString& strFilenameAndPath, const CVideoInfoTag& details, int idMVideo /* = -1 */)
+int CVideoDatabase::SetDetailsForMusicVideo(const CStdString& strFilenameAndPath, const CVideoInfoTag& details, const map<string, string> &artwork, int idMVideo /* = -1 */)
 {
   try
   {
@@ -2099,6 +2112,8 @@ int CVideoDatabase::SetDetailsForMusicVideo(const CStdString& strFilenameAndPath
 
     if (details.HasStreamDetails())
       SetStreamDetailsForFileId(details.m_streamDetails, GetFileId(strFilenameAndPath));
+
+    SetArtForItem(idMVideo, "musicvideo", artwork);
 
     // update our movie table (we know it was added already above)
     // and insert the new row

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -314,6 +314,17 @@ bool CVideoDatabase::CreateTables()
     m_pDS->exec("CREATE TABLE seasons ( idSeason integer primary key, idShow integer, season integer)");
     m_pDS->exec("CREATE INDEX ix_seasons ON season (idShow, season)");
 
+    CLog::Log(LOGINFO, "create art table and triggers");
+    m_pDS->exec("CREATE TABLE art(art_id INTEGER PRIMARY KEY, media_id INTEGER, media_type TEXT, type TEXT, url TEXT)");
+    m_pDS->exec("CREATE INDEX ix_art ON art(media_id, media_type, type)");
+    m_pDS->exec("CREATE TRIGGER delete_movie AFTER DELETE ON movie FOR EACH ROW BEGIN DELETE FROM art WHERE media_id=old.idMovie AND media_type='movie'; END");
+    m_pDS->exec("CREATE TRIGGER delete_tvshow AFTER DELETE ON tvshow FOR EACH ROW BEGIN DELETE FROM art WHERE media_id=old.idShow AND media_type='tvshow'; END");
+    m_pDS->exec("CREATE TRIGGER delete_musicvideo AFTER DELETE ON musicvideo FOR EACH ROW BEGIN DELETE FROM art WHERE media_id=old.idMVideo AND media_type='musicvideo'; END");
+    m_pDS->exec("CREATE TRIGGER delete_episode AFTER DELETE ON episode FOR EACH ROW BEGIN DELETE FROM art WHERE media_id=old.idEpisode AND media_type='episode'; END");
+    m_pDS->exec("CREATE TRIGGER delete_season AFTER DELETE ON seasons FOR EACH ROW BEGIN DELETE FROM art WHERE media_id=old.idSeason AND media_type='season'; END");
+    m_pDS->exec("CREATE TRIGGER delete_set AFTER DELETE ON sets FOR EACH ROW BEGIN DELETE FROM art WHERE media_id=old.idSet AND media_type='set'; END");
+    m_pDS->exec("CREATE TRIGGER delete_person AFTER DELETE ON actors FOR EACH ROW BEGIN DELETE FROM art WHERE media_id=old.idActor AND media_type IN ('actor','artist','writer','director'); END");
+
     // we create views last to ensure all indexes are rolled in
     CreateViews();
   }
@@ -3641,6 +3652,18 @@ bool CVideoDatabase::UpdateOldVersion(int iVersion)
         m_pDS2->exec(sql.c_str());
         m_pDS->next();
       }
+    }
+    if (iVersion < 63)
+    { // add art table
+      m_pDS->exec("CREATE TABLE art(art_id INTEGER PRIMARY KEY, media_id INTEGER, media_type TEXT, type TEXT, url TEXT)");
+      m_pDS->exec("CREATE INDEX ix_art ON art(media_id, media_type, type)");
+      m_pDS->exec("CREATE TRIGGER delete_movie AFTER DELETE ON movie FOR EACH ROW BEGIN DELETE FROM art WHERE media_id=old.idMovie AND media_type='movie'; END");
+      m_pDS->exec("CREATE TRIGGER delete_tvshow AFTER DELETE ON tvshow FOR EACH ROW BEGIN DELETE FROM art WHERE media_id=old.idShow AND media_type='tvshow'; END");
+      m_pDS->exec("CREATE TRIGGER delete_musicvideo AFTER DELETE ON musicvideo FOR EACH ROW BEGIN DELETE FROM art WHERE media_id=old.idMVideo AND media_type='musicvideo'; END");
+      m_pDS->exec("CREATE TRIGGER delete_episode AFTER DELETE ON episode FOR EACH ROW BEGIN DELETE FROM art WHERE media_id=old.idEpisode AND media_type='episode'; END");
+      m_pDS->exec("CREATE TRIGGER delete_season AFTER DELETE ON seasons FOR EACH ROW BEGIN DELETE FROM art WHERE media_id=old.idSeason AND media_type='season'; END");
+      m_pDS->exec("CREATE TRIGGER delete_set AFTER DELETE ON sets FOR EACH ROW BEGIN DELETE FROM art WHERE media_id=old.idSet AND media_type='set'; END");
+      m_pDS->exec("CREATE TRIGGER delete_person AFTER DELETE ON actors FOR EACH ROW BEGIN DELETE FROM art WHERE media_id=old.idActor AND media_type IN ('actor','artist','writer','director'); END");
     }
     // always recreate the view after any table change
     CreateViews();

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -2930,6 +2930,7 @@ CVideoInfoTag CVideoDatabase::GetDetailsForMovie(auto_ptr<Dataset> &pDS, bool ne
   GetDetailsFromDB(pDS, VIDEODB_ID_MIN, VIDEODB_ID_MAX, DbMovieOffsets, details);
 
   details.m_iDbId = idMovie;
+  details.m_type = "movie";
   GetCommonDetails(pDS, details);
   movieTime += XbmcThreads::SystemClockMillis() - time; time = XbmcThreads::SystemClockMillis();
 
@@ -2980,6 +2981,7 @@ CVideoInfoTag CVideoDatabase::GetDetailsForTvShow(auto_ptr<Dataset> &pDS, bool n
 
   GetDetailsFromDB(pDS, VIDEODB_ID_TV_MIN, VIDEODB_ID_TV_MAX, DbTvShowOffsets, details, 1);
   details.m_iDbId = idTvShow;
+  details.m_type = "tvshow";
   details.m_strPath = pDS->fv(VIDEODB_DETAILS_TVSHOW_PATH).get_asString();
   details.m_dateAdded.SetFromDBDateTime(pDS->fv(VIDEODB_DETAILS_TVSHOW_DATEADDED).get_asString());
   details.m_iEpisode = m_pDS->fv(VIDEODB_DETAILS_TVSHOW_NUM_EPISODES).get_asInt();
@@ -3009,6 +3011,7 @@ CVideoInfoTag CVideoDatabase::GetDetailsForEpisode(auto_ptr<Dataset> &pDS, bool 
 
   GetDetailsFromDB(pDS, VIDEODB_ID_EPISODE_MIN, VIDEODB_ID_EPISODE_MAX, DbEpisodeOffsets, details);
   details.m_iDbId = idEpisode;
+  details.m_type = "episode";
   GetCommonDetails(pDS, details);
   movieTime += XbmcThreads::SystemClockMillis() - time; time = XbmcThreads::SystemClockMillis();
 
@@ -3048,6 +3051,7 @@ CVideoInfoTag CVideoDatabase::GetDetailsForMusicVideo(auto_ptr<Dataset> &pDS)
 
   GetDetailsFromDB(pDS, VIDEODB_ID_MUSICVIDEO_MIN, VIDEODB_ID_MUSICVIDEO_MAX, DbMusicVideoOffsets, details);
   details.m_iDbId = idMovie;
+  details.m_type = "musicvideo";
   GetCommonDetails(pDS, details);
   movieTime += XbmcThreads::SystemClockMillis() - time; time = XbmcThreads::SystemClockMillis();
 
@@ -4058,6 +4062,7 @@ bool CVideoDatabase::GetNavCommon(const CStdString& strBaseDir, CFileItemList& i
       {
         CFileItemPtr pItem(new CFileItem(m_pDS->fv(1).get_asString()));
         pItem->GetVideoInfoTag()->m_iDbId = m_pDS->fv(0).get_asInt();
+        pItem->GetVideoInfoTag()->m_type = "set";
         CStdString strDir;
         strDir.Format("%ld/", m_pDS->fv(0).get_asInt());
         pItem->SetPath(strBaseDir + strDir);
@@ -4142,6 +4147,7 @@ bool CVideoDatabase::GetSetsNav(const CStdString& strBaseDir, CFileItemList& ite
       {
         CFileItemPtr pItem(new CFileItem(it->second.name));
         pItem->GetVideoInfoTag()->m_iDbId = it->first;
+        pItem->GetVideoInfoTag()->m_type = "set";
         CStdString strDir;
         strDir.Format("%ld/", it->first);
         pItem->SetPath(strBaseDir + strDir);
@@ -4452,6 +4458,8 @@ bool CVideoDatabase::GetPeopleNav(const CStdString& strBaseDir, CFileItemList& i
         pItem->m_bIsFolder=true;
         pItem->GetVideoInfoTag()->m_playCount = it->second.playcount;
         pItem->GetVideoInfoTag()->m_strPictureURL.ParseString(it->second.thumb);
+        pItem->GetVideoInfoTag()->m_iDbId = it->first;
+        pItem->GetVideoInfoTag()->m_type = type;
         items.Add(pItem);
       }
     }
@@ -4467,6 +4475,8 @@ bool CVideoDatabase::GetPeopleNav(const CStdString& strBaseDir, CFileItemList& i
           pItem->SetPath(strBaseDir + strDir);
           pItem->m_bIsFolder=true;
           pItem->GetVideoInfoTag()->m_strPictureURL.ParseString(m_pDS->fv(2).get_asString());
+          pItem->GetVideoInfoTag()->m_iDbId = m_pDS->fv(0).get_asInt();
+          pItem->GetVideoInfoTag()->m_type = type;
           if (idContent != VIDEODB_CONTENT_TVSHOWS)
           {
             // fv(4) is the number of videos watched, fv(3) is the total number.  We set the playcount
@@ -4784,6 +4794,7 @@ bool CVideoDatabase::GetSeasonsNav(const CStdString& strBaseDir, CFileItemList& 
         pItem->GetVideoInfoTag()->m_strTitle = strLabel;
         pItem->GetVideoInfoTag()->m_iSeason = iSeason;
         pItem->GetVideoInfoTag()->m_iDbId = it->second.id;
+        pItem->GetVideoInfoTag()->m_type = "season";
         pItem->GetVideoInfoTag()->m_strPath = it->second.path;
         pItem->GetVideoInfoTag()->m_genre = it->second.genre;
         pItem->GetVideoInfoTag()->m_studio = StringUtils::Split(showStudio, g_advancedSettings.m_videoItemSeparator);
@@ -4820,6 +4831,7 @@ bool CVideoDatabase::GetSeasonsNav(const CStdString& strBaseDir, CFileItemList& 
         pItem->GetVideoInfoTag()->m_strTitle = strLabel;
         pItem->GetVideoInfoTag()->m_iSeason = iSeason;
         pItem->GetVideoInfoTag()->m_iDbId = m_pDS->fv(6).get_asInt();
+        pItem->GetVideoInfoTag()->m_type = "season";
         pItem->GetVideoInfoTag()->m_strPath = m_pDS->fv(1).get_asString();
         pItem->GetVideoInfoTag()->m_genre = StringUtils::Split(m_pDS->fv(3).get_asString(), g_advancedSettings.m_videoItemSeparator);
         pItem->GetVideoInfoTag()->m_studio = StringUtils::Split(showStudio, g_advancedSettings.m_videoItemSeparator);

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -7617,12 +7617,11 @@ CStdString CVideoDatabase::GetCachedThumb(const CFileItem& item) const
     cachedThumb = item.GetCachedEpisodeThumb();
   if (!CFile::Exists(cachedThumb) && g_advancedSettings.m_bVideoLibraryExportAutoThumbs)
   {
-    CStdString strPath, strFileName;
-    URIUtils::Split(cachedThumb, strPath, strFileName);
-    cachedThumb = strPath + "auto-" + strFileName;
+    CStdString thumbURL = CVideoThumbLoader::GetEmbeddedThumbURL(item);
+    cachedThumb = CTextureCache::Get().GetCachedImage(thumbURL);
   }
 
-  if (CFile::Exists(cachedThumb))
+  if (!cachedThumb.IsEmpty() && CFile::Exists(cachedThumb))
     return cachedThumb;
   else
     return "";

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -1512,7 +1512,7 @@ bool CVideoDatabase::HasMusicVideoInfo(const CStdString& strFilenameAndPath)
   return false;
 }
 
-void CVideoDatabase::DeleteDetailsForTvShow(const CStdString& strPath, bool bKeepThumb /* = false */, int idTvShow /* = -1 */)
+void CVideoDatabase::DeleteDetailsForTvShow(const CStdString& strPath, int idTvShow /* = -1 */)
 {
   try
   {
@@ -1524,17 +1524,6 @@ void CVideoDatabase::DeleteDetailsForTvShow(const CStdString& strPath, bool bKee
       idTvShow = GetTvShowId(strPath);
       if (idTvShow < 0)
         return;
-    }
-
-    if (!bKeepThumb)
-    {
-      CFileItemList items;
-      CStdString strPath2;
-      strPath2.Format("videodb://2/2/%i/", idTvShow);
-      GetSeasonsNav(strPath2, items, -1, -1, -1, -1, idTvShow);
-      for (int i = 0; i < items.Size(); ++i)
-        CTextureCache::Get().ClearCachedImage(items[i]->GetCachedSeasonThumb(), true);
-      DeleteThumbForItem(strPath, true);
     }
 
     CStdString strSQL;
@@ -1812,7 +1801,7 @@ int CVideoDatabase::SetDetailsForMovie(const CStdString& strFilenameAndPath, con
       idMovie = GetMovieId(strFilenameAndPath);
 
     if (idMovie > -1)
-      DeleteMovie(strFilenameAndPath, true, true, idMovie); // true to keep the table entry and the thumb
+      DeleteMovie(strFilenameAndPath, true, idMovie); // true to keep the table entry
     else
     {
       // only add a new movie if we don't already have a valid idMovie
@@ -1904,7 +1893,7 @@ int CVideoDatabase::SetDetailsForTvShow(const CStdString& strPath, const CVideoI
       idTvShow = GetTvShowId(strPath);
 
     if (idTvShow > -1)
-      DeleteDetailsForTvShow(strPath, true, idTvShow);
+      DeleteDetailsForTvShow(strPath, idTvShow);
     else
     {
       idTvShow = AddTvShow(strPath);
@@ -1975,7 +1964,7 @@ int CVideoDatabase::SetDetailsForEpisode(const CStdString& strFilenameAndPath, c
       idEpisode = GetEpisodeId(strFilenameAndPath);
 
     if (idEpisode > 0)
-      DeleteEpisode(strFilenameAndPath, idEpisode, true, true); // true to keep the table entry and the thumb
+      DeleteEpisode(strFilenameAndPath, idEpisode, true); // true to keep the table entry
     else
     {
       // only add a new episode if we don't already have a valid idEpisode
@@ -2069,7 +2058,7 @@ int CVideoDatabase::SetDetailsForMusicVideo(const CStdString& strFilenameAndPath
       idMVideo = GetMusicVideoId(strFilenameAndPath);
 
     if (idMVideo > -1)
-      DeleteMusicVideo(strFilenameAndPath, true, true, idMVideo); // Keep id and thumb
+      DeleteMusicVideo(strFilenameAndPath, true, idMVideo); // Keep id
     else
     {
       // only add a new musicvideo if we don't already have a valid idMVideo
@@ -2499,7 +2488,7 @@ void CVideoDatabase::DeleteBookMarkForEpisode(const CVideoInfoTag& tag)
 }
 
 //********************************************************************************************************************************
-void CVideoDatabase::DeleteMovie(int idMovie, bool bKeepId /* = false */, bool bKeepThumb /* = false */)
+void CVideoDatabase::DeleteMovie(int idMovie, bool bKeepId /* = false */)
 {
   if (idMovie < 0)
     return;
@@ -2507,10 +2496,10 @@ void CVideoDatabase::DeleteMovie(int idMovie, bool bKeepId /* = false */, bool b
   CStdString path;
   GetFilePathById(idMovie, path, VIDEODB_CONTENT_MOVIES);
   if (!path.empty())
-    DeleteMovie(path, bKeepId, bKeepThumb, idMovie);
+    DeleteMovie(path, bKeepId, idMovie);
 }
 
-void CVideoDatabase::DeleteMovie(const CStdString& strFilenameAndPath, bool bKeepId /* = false */, bool bKeepThumb /* = false */, int idMovie /* = -1 */)
+void CVideoDatabase::DeleteMovie(const CStdString& strFilenameAndPath, bool bKeepId /* = false */, int idMovie /* = -1 */)
 {
   try
   {
@@ -2544,9 +2533,6 @@ void CVideoDatabase::DeleteMovie(const CStdString& strFilenameAndPath, bool bKee
     strSQL=PrepareSQL("delete from countrylinkmovie where idMovie=%i", idMovie);
     m_pDS->exec(strSQL.c_str());
 
-    if (!bKeepThumb)
-      DeleteThumbForItem(strFilenameAndPath,false);
-
     DeleteStreamDetails(GetFileId(strFilenameAndPath));
 
     // keep the movie table entry, linking to tv shows, and bookmarks
@@ -2577,7 +2563,7 @@ void CVideoDatabase::DeleteMovie(const CStdString& strFilenameAndPath, bool bKee
   }
 }
 
-void CVideoDatabase::DeleteTvShow(int idTvShow, bool bKeepId /* = false */, bool bKeepThumb /* = false */)
+void CVideoDatabase::DeleteTvShow(int idTvShow, bool bKeepId /* = false */)
 {
   if (idTvShow < 0)
     return;
@@ -2585,10 +2571,10 @@ void CVideoDatabase::DeleteTvShow(int idTvShow, bool bKeepId /* = false */, bool
   CStdString path;
   GetFilePathById(idTvShow, path, VIDEODB_CONTENT_TVSHOWS);
   if (!path.empty())
-    DeleteTvShow(path, bKeepId, bKeepThumb, idTvShow);
+    DeleteTvShow(path, bKeepId, idTvShow);
 }
 
-void CVideoDatabase::DeleteTvShow(const CStdString& strPath, bool bKeepId /* = false */, bool bKeepThumb /* = false */, int idTvShow /* = -1 */)
+void CVideoDatabase::DeleteTvShow(const CStdString& strPath, bool bKeepId /* = false */, int idTvShow /* = -1 */)
 {
   try
   {
@@ -2615,7 +2601,7 @@ void CVideoDatabase::DeleteTvShow(const CStdString& strPath, bool bKeepId /* = f
       m_pDS2->next();
     }
 
-    DeleteDetailsForTvShow(strPath, bKeepThumb, idTvShow);
+    DeleteDetailsForTvShow(strPath, idTvShow);
 
     strSQL=PrepareSQL("delete from seasons where idShow=%i", idTvShow);
     m_pDS->exec(strSQL.c_str());
@@ -2646,7 +2632,7 @@ void CVideoDatabase::DeleteTvShow(const CStdString& strPath, bool bKeepId /* = f
   }
 }
 
-void CVideoDatabase::DeleteEpisode(int idEpisode, bool bKeepId /* = false */, bool bKeepThumb /* = false */)
+void CVideoDatabase::DeleteEpisode(int idEpisode, bool bKeepId /* = false */)
 {
   if (idEpisode < 0)
     return;
@@ -2654,10 +2640,10 @@ void CVideoDatabase::DeleteEpisode(int idEpisode, bool bKeepId /* = false */, bo
   CStdString path;
   GetFilePathById(idEpisode, path, VIDEODB_CONTENT_EPISODES);
   if (!path.empty())
-    DeleteEpisode(path, idEpisode, bKeepId, bKeepThumb);
+    DeleteEpisode(path, idEpisode, bKeepId);
 }
 
-void CVideoDatabase::DeleteEpisode(const CStdString& strFilenameAndPath, int idEpisode /* = -1 */, bool bKeepId /* = false */, bool bKeepThumb /* = false */)
+void CVideoDatabase::DeleteEpisode(const CStdString& strFilenameAndPath, int idEpisode /* = -1 */, bool bKeepId /* = false */)
 {
   try
   {
@@ -2681,9 +2667,6 @@ void CVideoDatabase::DeleteEpisode(const CStdString& strFilenameAndPath, int idE
 
     strSQL=PrepareSQL("delete from writerlinkepisode where idEpisode=%i", idEpisode);
     m_pDS->exec(strSQL.c_str());
-
-    if (!bKeepThumb)
-      DeleteThumbForItem(strFilenameAndPath, false, idEpisode);
 
     DeleteStreamDetails(GetFileId(strFilenameAndPath));
 
@@ -2709,7 +2692,7 @@ void CVideoDatabase::DeleteEpisode(const CStdString& strFilenameAndPath, int idE
   }
 }
 
-void CVideoDatabase::DeleteMusicVideo(int idMusicVideo, bool bKeepId /* = false */, bool bKeepThumb /* = false */)
+void CVideoDatabase::DeleteMusicVideo(int idMusicVideo, bool bKeepId /* = false */)
 {
   if (idMusicVideo < 0)
     return;
@@ -2717,10 +2700,10 @@ void CVideoDatabase::DeleteMusicVideo(int idMusicVideo, bool bKeepId /* = false 
   CStdString path;
   GetFilePathById(idMusicVideo, path, VIDEODB_CONTENT_MUSICVIDEOS);
   if (!path.empty())
-    DeleteMusicVideo(path, bKeepId, bKeepThumb, idMusicVideo);
+    DeleteMusicVideo(path, bKeepId, idMusicVideo);
 }
 
-void CVideoDatabase::DeleteMusicVideo(const CStdString& strFilenameAndPath, bool bKeepId /* = false */, bool bKeepThumb /* = false */, int idMVideo /* = -1 */)
+void CVideoDatabase::DeleteMusicVideo(const CStdString& strFilenameAndPath, bool bKeepId /* = false */, int idMVideo /* = -1 */)
 {
   try
   {
@@ -2747,9 +2730,6 @@ void CVideoDatabase::DeleteMusicVideo(const CStdString& strFilenameAndPath, bool
 
     strSQL=PrepareSQL("delete from studiolinkmusicvideo where idMVideo=%i", idMVideo);
     m_pDS->exec(strSQL.c_str());
-
-    if (!bKeepThumb)
-      DeleteThumbForItem(strFilenameAndPath,false);
 
     DeleteStreamDetails(GetFileId(strFilenameAndPath));
 
@@ -8032,29 +8012,6 @@ bool CVideoDatabase::CommitTransaction()
     return true;
   }
   return false;
-}
-
-void CVideoDatabase::DeleteThumbForItem(const CStdString& strPath, bool bFolder, int idEpisode)
-{
-  CFileItem item(strPath,bFolder);
-  if (idEpisode > 0)
-  {
-    item.SetPath(item.GetVideoInfoTag()->m_strFileNameAndPath);
-    if (CFile::Exists(item.GetCachedEpisodeThumb()))
-      CTextureCache::Get().ClearCachedImage(item.GetCachedEpisodeThumb(), true);
-    else
-      CTextureCache::Get().ClearCachedImage(item.GetCachedVideoThumb(), true);
-  }
-  else
-  {
-    CTextureCache::Get().ClearCachedImage(item.GetCachedVideoThumb(), true);
-    CTextureCache::Get().ClearCachedImage(item.GetCachedFanart(), true);
-  }
-
-  // tell our GUI to completely reload all controls (as some of them
-  // are likely to have had this image in use so will need refreshing)
-  CGUIMessage msg(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_REFRESH_THUMBS);
-  g_windowManager.SendThreadMessage(msg);
 }
 
 void CVideoDatabase::SetDetail(const CStdString& strDetail, int id, int field,

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -4692,6 +4692,7 @@ bool CVideoDatabase::GetSeasonsNav(const CStdString& strBaseDir, CFileItemList& 
                                    "       tvshow.c%02d,"
                                    "       tvshow.c%02d,"
                                    "       tvshow.c%02d,"
+                                   "       seasons.idSeason,"
                                    "       count(1),"
                                    "       count(files.playCount) "
                                    "FROM episode"
@@ -4699,8 +4700,10 @@ bool CVideoDatabase::GetSeasonsNav(const CStdString& strBaseDir, CFileItemList& 
                                    "   tvshowlinkepisode.idEpisode=episode.idEpisode"
                                    " JOIN tvshow ON"
                                    "   tvshow.idShow=tvshowlinkepisode.idShow"
+                                   " JOIN seasons ON"
+                                   "   (seasons.idShow=tvshow.idShow AND seasons.season=episode.c%02d)"
                                    " JOIN files ON"
-                                   "   files.idFile=episode.idFile ", VIDEODB_ID_EPISODE_SEASON, VIDEODB_ID_TV_TITLE, VIDEODB_ID_TV_GENRE, VIDEODB_ID_TV_STUDIOS, VIDEODB_ID_TV_MPAA);
+                                   "   files.idFile=episode.idFile ", VIDEODB_ID_EPISODE_SEASON, VIDEODB_ID_TV_TITLE, VIDEODB_ID_TV_GENRE, VIDEODB_ID_TV_STUDIOS, VIDEODB_ID_TV_MPAA, VIDEODB_ID_EPISODE_SEASON);
     CStdString joins = PrepareSQL("  JOIN tvshowlinkpath ON"
                                   "    tvshowlinkpath.idShow = tvshow.idShow"
                                   "  JOIN path ON"
@@ -4756,8 +4759,9 @@ bool CVideoDatabase::GetSeasonsNav(const CStdString& strBaseDir, CFileItemList& 
           CSeason season;
           season.path = m_pDS->fv(1).get_asString();
           season.genre = StringUtils::Split(m_pDS->fv(3).get_asString(), g_advancedSettings.m_videoItemSeparator);
-          season.numEpisodes = m_pDS->fv(6).get_asInt();
-          season.numWatched = m_pDS->fv(7).get_asInt();
+          season.id = m_pDS->fv(6).get_asInt();
+          season.numEpisodes = m_pDS->fv(7).get_asInt();
+          season.numWatched = m_pDS->fv(8).get_asInt();
           mapSeasons.insert(make_pair(iSeason, season));
         }
         m_pDS->next();
@@ -4779,7 +4783,7 @@ bool CVideoDatabase::GetSeasonsNav(const CStdString& strBaseDir, CFileItemList& 
         pItem->m_bIsFolder=true;
         pItem->GetVideoInfoTag()->m_strTitle = strLabel;
         pItem->GetVideoInfoTag()->m_iSeason = iSeason;
-        pItem->GetVideoInfoTag()->m_iDbId = idShow;
+        pItem->GetVideoInfoTag()->m_iDbId = it->second.id;
         pItem->GetVideoInfoTag()->m_strPath = it->second.path;
         pItem->GetVideoInfoTag()->m_genre = it->second.genre;
         pItem->GetVideoInfoTag()->m_studio = StringUtils::Split(showStudio, g_advancedSettings.m_videoItemSeparator);
@@ -4815,15 +4819,15 @@ bool CVideoDatabase::GetSeasonsNav(const CStdString& strBaseDir, CFileItemList& 
         pItem->m_bIsFolder=true;
         pItem->GetVideoInfoTag()->m_strTitle = strLabel;
         pItem->GetVideoInfoTag()->m_iSeason = iSeason;
-        pItem->GetVideoInfoTag()->m_iDbId = idShow;
+        pItem->GetVideoInfoTag()->m_iDbId = m_pDS->fv(6).get_asInt();
         pItem->GetVideoInfoTag()->m_strPath = m_pDS->fv(1).get_asString();
         pItem->GetVideoInfoTag()->m_genre = StringUtils::Split(m_pDS->fv(3).get_asString(), g_advancedSettings.m_videoItemSeparator);
         pItem->GetVideoInfoTag()->m_studio = StringUtils::Split(showStudio, g_advancedSettings.m_videoItemSeparator);
         pItem->GetVideoInfoTag()->m_strMPAARating = showMPAARating;
         pItem->GetVideoInfoTag()->m_iIdShow = idShow;
         pItem->GetVideoInfoTag()->m_strShowTitle = showTitle;
-        int totalEpisodes = m_pDS->fv(6).get_asInt();
-        int watchedEpisodes = m_pDS->fv(7).get_asInt();
+        int totalEpisodes = m_pDS->fv(7).get_asInt();
+        int watchedEpisodes = m_pDS->fv(8).get_asInt();
         pItem->GetVideoInfoTag()->m_iEpisode = totalEpisodes;
         pItem->SetProperty("totalepisodes", totalEpisodes);
         pItem->SetProperty("numepisodes", totalEpisodes); // will be changed later to reflect watchmode setting

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -406,10 +406,10 @@ public:
 
   void GetEpisodesByFile(const CStdString& strFilenameAndPath, std::vector<CVideoInfoTag>& episodes);
 
-  int SetDetailsForMovie(const CStdString& strFilenameAndPath, const CVideoInfoTag& details, int idMovie = -1);
-  int SetDetailsForTvShow(const CStdString& strPath, const CVideoInfoTag& details, int idTvShow = -1);
-  int SetDetailsForEpisode(const CStdString& strFilenameAndPath, const CVideoInfoTag& details, int idShow, int idEpisode=-1);
-  int SetDetailsForMusicVideo(const CStdString& strFilenameAndPath, const CVideoInfoTag& details, int idMVideo = -1);
+  int SetDetailsForMovie(const CStdString& strFilenameAndPath, const CVideoInfoTag& details, const std::map<std::string, std::string> &artwork, int idMovie = -1);
+  int SetDetailsForTvShow(const CStdString& strPath, const CVideoInfoTag& details, const std::map<std::string, std::string> &artwork, int idTvShow = -1);
+  int SetDetailsForEpisode(const CStdString& strFilenameAndPath, const CVideoInfoTag& details, const std::map<std::string, std::string> &artwork, int idShow, int idEpisode=-1);
+  int SetDetailsForMusicVideo(const CStdString& strFilenameAndPath, const CVideoInfoTag& details, const std::map<std::string, std::string> &artwork, int idMVideo = -1);
   void SetStreamDetailsForFile(const CStreamDetails& details, const CStdString &strFileNameAndPath);
   void SetStreamDetailsForFileId(const CStreamDetails& details, int idFile);
   void SetDetail(const CStdString& strDetail, int id, int field, VIDEODB_CONTENT_TYPE type);

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -750,7 +750,7 @@ private:
    */
   bool LookupByFolders(const CStdString &path, bool shows = false);
 
-  virtual int GetMinVersion() const { return 62; };
+  virtual int GetMinVersion() const { return 63; };
   virtual int GetExportVersion() const { return 1; };
   const char *GetBaseDBName() const { return "MyVideos"; };
 

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -407,7 +407,7 @@ public:
   void GetEpisodesByFile(const CStdString& strFilenameAndPath, std::vector<CVideoInfoTag>& episodes);
 
   int SetDetailsForMovie(const CStdString& strFilenameAndPath, const CVideoInfoTag& details, const std::map<std::string, std::string> &artwork, int idMovie = -1);
-  int SetDetailsForTvShow(const CStdString& strPath, const CVideoInfoTag& details, const std::map<std::string, std::string> &artwork, int idTvShow = -1);
+  int SetDetailsForTvShow(const CStdString& strPath, const CVideoInfoTag& details, const std::map<std::string, std::string> &artwork, const std::map<int, std::string> &seasonArt, int idTvShow = -1);
   int SetDetailsForEpisode(const CStdString& strFilenameAndPath, const CVideoInfoTag& details, const std::map<std::string, std::string> &artwork, int idShow, int idEpisode=-1);
   int SetDetailsForMusicVideo(const CStdString& strFilenameAndPath, const CVideoInfoTag& details, const std::map<std::string, std::string> &artwork, int idMVideo = -1);
   void SetStreamDetailsForFile(const CStreamDetails& details, const CStdString &strFileNameAndPath);

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -401,6 +401,7 @@ public:
   int GetPathId(const CStdString& strPath);
   int GetTvShowId(const CStdString& strPath);
   int GetEpisodeId(const CStdString& strFilenameAndPath, int idEpisode=-1, int idSeason=-1); // idEpisode, idSeason are used for multipart episodes as hints
+  int GetSeasonId(int idShow, int season);
 
   void GetEpisodesByFile(const CStdString& strFilenameAndPath, std::vector<CVideoInfoTag>& episodes);
 
@@ -660,6 +661,7 @@ protected:
 
   int AddTvShow(const CStdString& strPath);
   int AddMusicVideo(const CStdString& strFilenameAndPath);
+  int AddSeason(int showID, int season);
 
   // link functions - these two do all the work
   void AddLinkToActor(const char *table, int actorID, const char *secondField, int secondID, const CStdString &role, int order);
@@ -747,7 +749,7 @@ private:
    */
   bool LookupByFolders(const CStdString &path, bool shows = false);
 
-  virtual int GetMinVersion() const { return 61; };
+  virtual int GetMinVersion() const { return 62; };
   virtual int GetExportVersion() const { return 1; };
   const char *GetBaseDBName() const { return "MyVideos"; };
 

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -414,15 +414,15 @@ public:
   void SetStreamDetailsForFileId(const CStreamDetails& details, int idFile);
   void SetDetail(const CStdString& strDetail, int id, int field, VIDEODB_CONTENT_TYPE type);
 
-  void DeleteMovie(int idMovie, bool bKeepId = false, bool bKeepThumb = false);
-  void DeleteMovie(const CStdString& strFilenameAndPath, bool bKeepId = false, bool bKeepThumb = false, int idMovie = -1);
-  void DeleteTvShow(int idTvShow, bool bKeepId = false, bool bKeepThumb = false);
-  void DeleteTvShow(const CStdString& strPath, bool bKeepId = false, bool bKeepThumb = false, int idTvShow = -1);
-  void DeleteEpisode(int idEpisode, bool bKeepId = false, bool bKeepThumb = false);
-  void DeleteEpisode(const CStdString& strFilenameAndPath, int idEpisode = -1, bool bKeepId = false, bool bKeepThumb = false);
-  void DeleteMusicVideo(int idMusicVideo, bool bKeepId = false, bool bKeepThumb = false);
-  void DeleteMusicVideo(const CStdString& strFilenameAndPath, bool bKeepId = false, bool bKeepThumb = false, int idMVideo = -1);
-  void DeleteDetailsForTvShow(const CStdString& strPath, bool bKeepThumb = false, int idTvShow = -1);
+  void DeleteMovie(int idMovie, bool bKeepId = false);
+  void DeleteMovie(const CStdString& strFilenameAndPath, bool bKeepId = false, int idMovie = -1);
+  void DeleteTvShow(int idTvShow, bool bKeepId = false);
+  void DeleteTvShow(const CStdString& strPath, bool bKeepId = false, int idTvShow = -1);
+  void DeleteEpisode(int idEpisode, bool bKeepId = false);
+  void DeleteEpisode(const CStdString& strFilenameAndPath, int idEpisode = -1, bool bKeepId = false);
+  void DeleteMusicVideo(int idMusicVideo, bool bKeepId = false);
+  void DeleteMusicVideo(const CStdString& strFilenameAndPath, bool bKeepId = false, int idMVideo = -1);
+  void DeleteDetailsForTvShow(const CStdString& strPath, int idTvShow = -1);
   void RemoveContentForPath(const CStdString& strPath,CGUIDialogProgress *progress = NULL);
   void UpdateFanart(const CFileItem &item, VIDEODB_CONTENT_TYPE type);
   void DeleteSet(int idSet);
@@ -763,7 +763,6 @@ private:
   void ConstructPath(CStdString& strDest, const CStdString& strPath, const CStdString& strFileName);
   void SplitPath(const CStdString& strFileNameAndPath, CStdString& strPath, CStdString& strFileName);
   void InvalidatePathHash(const CStdString& strPath);
-  void DeleteThumbForItem(const CStdString& strPath, bool bFolder, int idEpisode = -1);
 
   bool GetStackedTvShowList(int idShow, CStdString& strIn);
   void Stack(CFileItemList& items, VIDEODB_CONTENT_TYPE type, bool maintainSortOrder = false);

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -318,6 +318,7 @@ public:
     std::vector<std::string> genre;
     int numEpisodes;
     int numWatched;
+    int id;
   };
 
   class CSetInfo

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -636,6 +636,11 @@ public:
     }
   }
 
+  void SetArtForItem(int mediaId, const std::string &mediaType, const std::string &artType, const std::string &url);
+  void SetArtForItem(int mediaId, const std::string &mediaType, const std::map<std::string, std::string> &art);
+  bool GetArtForItem(int mediaId, const std::string &mediaType, std::map<std::string, std::string> &art);
+  std::string GetArtForItem(int mediaId, const std::string &mediaType, const std::string &artType);
+
 protected:
   int GetMovieId(const CStdString& strFilenameAndPath);
   int GetMusicVideoId(const CStdString& strFilenameAndPath);

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -640,6 +640,7 @@ public:
   void SetArtForItem(int mediaId, const std::string &mediaType, const std::map<std::string, std::string> &art);
   bool GetArtForItem(int mediaId, const std::string &mediaType, std::map<std::string, std::string> &art);
   std::string GetArtForItem(int mediaId, const std::string &mediaType, const std::string &artType);
+  bool GetTvShowSeasonArt(int mediaId, std::map<int, std::string> &seasonArt);
 
 protected:
   int GetMovieId(const CStdString& strFilenameAndPath);

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -661,7 +661,7 @@ protected:
 
   int AddToTable(const CStdString& table, const CStdString& firstField, const CStdString& secondField, const CStdString& value);
   int AddGenre(const CStdString& strGenre1);
-  int AddActor(const CStdString& strActor, const CStdString& strThumb);
+  int AddActor(const CStdString& strActor, const CStdString& thumbURL, const CStdString &thumb = "");
   int AddCountry(const CStdString& strCountry);
   int AddSet(const CStdString& strSet);
   int AddStudio(const CStdString& strStudio1);

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -602,7 +602,7 @@ public:
   void ExportActorThumbs(const CStdString &path, const CVideoInfoTag& tag, bool singleFiles, bool overwrite=false);
   void ImportFromXML(const CStdString &path);
   void DumpToDummyFiles(const CStdString &path);
-  CStdString GetCachedThumb(const CFileItem& item) const;
+  bool ImportArtFromXML(const TiXmlNode *node, std::map<std::string, std::string> &artwork);
 
   // smart playlists and main retrieval work in these functions
   bool GetMoviesByWhere(const CStdString& strBaseDir, const CStdString &where, const CStdString &order, CFileItemList& items, bool fetchSets = false);

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -1665,23 +1665,22 @@ namespace VIDEO
     m_database.Close();
   }
 
-  void CVideoInfoScanner::FetchActorThumbs(const vector<SActorInfo>& actors, const CStdString& strPath)
+  void CVideoInfoScanner::FetchActorThumbs(vector<SActorInfo>& actors, const CStdString& strPath)
   {
-    for (unsigned int i=0;i<actors.size();++i)
+    for (vector<SActorInfo>::iterator i = actors.begin(); i != actors.end(); ++i)
     {
-      CFileItem item;
-      item.SetLabel(actors[i].strName);
-      CStdString strThumb = item.GetCachedActorThumb();
-      if (!CFile::Exists(strThumb))
+      if (i->thumb.IsEmpty())
       {
-        CStdString thumbFile = actors[i].strName;
+        CStdString thumbFile = i->strName;
         thumbFile.Replace(" ","_");
         thumbFile += ".tbn";
         CStdString strLocal = URIUtils::AddFileToFolder(URIUtils::AddFileToFolder(strPath, ".actors"), thumbFile);
         if (CFile::Exists(strLocal))
-          CPicture::CreateThumbnail(strLocal, strThumb);
-        else if (!actors[i].thumbUrl.GetFirstThumb().m_url.IsEmpty())
-          DownloadImage(CScraperUrl::GetThumbURL(actors[i].thumbUrl.GetFirstThumb()), strThumb);
+          i->thumb = strLocal;
+        else if (!i->thumbUrl.GetFirstThumb().m_url.IsEmpty())
+          i->thumb = CScraperUrl::GetThumbURL(i->thumbUrl.GetFirstThumb());
+        if (!i->thumb.IsEmpty())
+          CTextureCache::Get().BackgroundCacheImage(strLocal);
       }
     }
   }

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -1046,7 +1046,7 @@ namespace VIDEO
       if (!strTrailer.IsEmpty())
         movieDetails.m_strTrailer = strTrailer;
 
-      lResult = m_database.SetDetailsForMovie(pItem->GetPath(), movieDetails);
+      lResult = m_database.SetDetailsForMovie(pItem->GetPath(), movieDetails, pItem->GetArt());
       movieDetails.m_iDbId = lResult;
 
       // setup links to shows if the linked shows are in the db
@@ -1064,7 +1064,7 @@ namespace VIDEO
     {
       if (pItem->m_bIsFolder)
       {
-        lResult = m_database.SetDetailsForTvShow(pItem->GetPath(), movieDetails);
+        lResult = m_database.SetDetailsForTvShow(pItem->GetPath(), movieDetails, pItem->GetArt());
         movieDetails.m_iDbId = lResult;
       }
       else
@@ -1072,7 +1072,7 @@ namespace VIDEO
         // we add episode then set details, as otherwise set details will delete the
         // episode then add, which breaks multi-episode files.
         int idEpisode = m_database.AddEpisode(idShow, pItem->GetPath());
-        lResult = m_database.SetDetailsForEpisode(pItem->GetPath(), movieDetails, idShow, idEpisode);
+        lResult = m_database.SetDetailsForEpisode(pItem->GetPath(), movieDetails, pItem->GetArt(), idShow, idEpisode);
         movieDetails.m_iDbId = lResult;
         if (movieDetails.m_fEpBookmark > 0)
         {
@@ -1087,7 +1087,7 @@ namespace VIDEO
     }
     else if (content == CONTENT_MUSICVIDEOS)
     {
-      lResult = m_database.SetDetailsForMusicVideo(pItem->GetPath(), movieDetails);
+      lResult = m_database.SetDetailsForMusicVideo(pItem->GetPath(), movieDetails, pItem->GetArt());
       movieDetails.m_iDbId = lResult;
     }
 

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -46,6 +46,7 @@
 #include "utils/log.h"
 #include "utils/URIUtils.h"
 #include "utils/Variant.h"
+#include "ThumbLoader.h"
 
 using namespace std;
 using namespace XFILE;
@@ -1516,11 +1517,10 @@ namespace VIDEO
   void CVideoInfoScanner::ApplyThumbToFolder(const CStdString &folder, const CStdString &imdbThumb)
   {
     // copy icon to folder also;
-    if (CFile::Exists(imdbThumb))
+    if (!imdbThumb.IsEmpty())
     {
       CFileItem folderItem(folder, true);
-      CStdString strThumb(folderItem.GetCachedVideoThumb());
-      CFile::Cache(imdbThumb.c_str(), strThumb.c_str(), NULL, NULL);
+      CThumbLoader::SetCachedImage(folderItem, "thumb", imdbThumb);
     }
   }
 

--- a/xbmc/video/VideoInfoScanner.h
+++ b/xbmc/video/VideoInfoScanner.h
@@ -195,7 +195,13 @@ namespace VIDEO
      */
     bool GetAirDateFromRegExp(CRegExp &reg, SEpisode &episodeInfo);
 
-    void FetchActorThumbs(const std::vector<SActorInfo>& actors, const CStdString& strPath);
+    /*! \brief Fetch thumbs for actors
+     Updates each actor with their thumb (local or online)
+     \param actors - vector of SActorInfo
+     \param strPath - path on filesystem to look for local thumbs
+     */
+    void FetchActorThumbs(std::vector<SActorInfo>& actors, const CStdString& strPath);
+
     static int GetPathHash(const CFileItemList &items, CStdString &hash);
 
     /*! \brief Retrieve a "fast" hash of the given directory (if available)

--- a/xbmc/video/VideoInfoScanner.h
+++ b/xbmc/video/VideoInfoScanner.h
@@ -135,6 +135,14 @@ namespace VIDEO
      */
     void GetArtwork(CFileItem *pItem, const CONTENT_TYPE &content, bool bApplyToDir=false, bool useLocal=true);
 
+    /*! \brief Get season thumbs for a tvshow.
+     All seasons (regardless of whether the user has episodes) are added to the art map.
+     \param show     tvshow info tag
+     \param art      artwork map to which season thumbs are added.
+     \param useLocal whether to use local thumbs, defaults to true
+     */
+    static void GetSeasonThumbs(const CVideoInfoTag &show, std::map<int, std::string> &art, bool useLocal = true);
+
   protected:
     virtual void Process();
     bool DoScan(const CStdString& strDirectory);

--- a/xbmc/video/VideoInfoScanner.h
+++ b/xbmc/video/VideoInfoScanner.h
@@ -126,6 +126,15 @@ namespace VIDEO
      \param overwrite whether to overwrite currently cached thumbs.  Defaults to false.
      */
     void FetchSeasonThumbs(int idTvShow, const CStdString &folderToCheck = "", bool download = true, bool overwrite = false);
+
+    /*! \brief Retrieve any artwork associated with an item
+     \param pItem item to find artwork for.
+     \param content content type of the item.
+     \param bApplyToDir whether we should apply any thumbs to a folder.  Defaults to false.
+     \param useLocal whether we should use local thumbs. Defaults to true.
+     */
+    void GetArtwork(CFileItem *pItem, const CONTENT_TYPE &content, bool bApplyToDir=false, bool useLocal=true);
+
   protected:
     virtual void Process();
     bool DoScan(const CStdString& strDirectory);
@@ -162,14 +171,6 @@ namespace VIDEO
      \return true if information is found, false if an error occurred, the lookup was cancelled, or no information was found.
      */
     bool GetDetails(CFileItem *pItem, CScraperUrl &url, const ADDON::ScraperPtr &scraper, CNfoFile *nfoFile=NULL, CGUIDialogProgress* pDialog=NULL);
-
-    /*! \brief Retrieve any artwork associated with an item
-     \param pItem item to find artwork for.
-     \param content content type of the item.
-     \param bApplyToDir whether we should apply any thumbs to a folder.  Defaults to false.
-     \param useLocal whether we should use local thumbs. Defaults to true.
-     */
-    void GetArtwork(CFileItem *pItem, const CONTENT_TYPE &content, bool bApplyToDir=false, bool useLocal=true);
 
     /*! \brief Extract episode and season numbers from a processed regexp
      \param reg Regular expression object with at least 2 matches

--- a/xbmc/video/VideoInfoScanner.h
+++ b/xbmc/video/VideoInfoScanner.h
@@ -95,10 +95,11 @@ namespace VIDEO
      \param pItem item to add to the database.
      \param content content type of the item.
      \param videoFolder whether the video is represented by a folder (single movie per folder). Defaults to false.
+     \param useLocal whether to use local information for artwork etc.
      \param idShow database id of the tvshow if we're adding an episode.  Defaults to -1.
      \return database id of the added item, or -1 on failure.
      */
-    long AddVideo(CFileItem *pItem, const CONTENT_TYPE &content, bool videoFolder = false, int idShow = -1);
+    long AddVideo(CFileItem *pItem, const CONTENT_TYPE &content, bool videoFolder = false, bool useLocal = true, int idShow = -1);
 
     /*! \brief Retrieve information for a list of items and add them to the database.
      \param items list of items to retrieve info for.
@@ -163,13 +164,12 @@ namespace VIDEO
     bool GetDetails(CFileItem *pItem, CScraperUrl &url, const ADDON::ScraperPtr &scraper, CNfoFile *nfoFile=NULL, CGUIDialogProgress* pDialog=NULL);
 
     /*! \brief Retrieve any artwork associated with an item
-     \param pItem item to add to the database.
+     \param pItem item to find artwork for.
      \param content content type of the item.
      \param bApplyToDir whether we should apply any thumbs to a folder.  Defaults to false.
      \param useLocal whether we should use local thumbs. Defaults to true.
-     \param pDialog progress dialog to update during processing. Defaults to NULL.
      */
-    void GetArtwork(CFileItem *pItem, const CONTENT_TYPE &content, bool bApplyToDir=false, bool useLocal=true, CGUIDialogProgress* pDialog = NULL);
+    void GetArtwork(CFileItem *pItem, const CONTENT_TYPE &content, bool bApplyToDir=false, bool useLocal=true);
 
     /*! \brief Extract episode and season numbers from a processed regexp
      \param reg Regular expression object with at least 2 matches

--- a/xbmc/video/VideoInfoScanner.h
+++ b/xbmc/video/VideoInfoScanner.h
@@ -117,16 +117,6 @@ namespace VIDEO
     static bool DownloadFailed(CGUIDialogProgress* pDlgProgress);
     CNfoFile::NFOResult CheckForNFOFile(CFileItem* pItem, bool bGrabAny, ADDON::ScraperPtr& scraper, CScraperUrl& scrUrl);
 
-    /*! \brief Fetch thumbs for seasons for a given show
-     Fetches and caches local season thumbs of the form season##.tbn and season-all.tbn for the current show,
-     and downloads online thumbs if they don't exist.
-     \param idTvShow database id of the tvshow.
-     \param folderToCheck folder to check for local thumbs, if other than the show folder.  Defaults to empty.
-     \param download whether we should download thumbs that don't exist.  Defaults to true.
-     \param overwrite whether to overwrite currently cached thumbs.  Defaults to false.
-     */
-    void FetchSeasonThumbs(int idTvShow, const CStdString &folderToCheck = "", bool download = true, bool overwrite = false);
-
     /*! \brief Retrieve any artwork associated with an item
      \param pItem item to find artwork for.
      \param content content type of the item.

--- a/xbmc/video/VideoInfoTag.cpp
+++ b/xbmc/video/VideoInfoTag.cpp
@@ -91,6 +91,7 @@ void CVideoInfoTag::Reset()
   m_iIdShow = -1;
   m_strShowPath.clear();
   m_dateAdded.Reset();
+  m_type.clear();
 }
 
 bool CVideoInfoTag::Save(TiXmlNode *node, const CStdString &tag, bool savePathInfo)
@@ -323,6 +324,7 @@ void CVideoInfoTag::Archive(CArchive& ar)
     ar << m_iIdShow;
     ar << m_strShowPath;
     ar << m_dateAdded.GetAsDBDateTime();
+    ar << m_type;
   }
   else
   {
@@ -399,6 +401,7 @@ void CVideoInfoTag::Archive(CArchive& ar)
     CStdString dateAdded;
     ar >> dateAdded;
     m_dateAdded.SetFromDBDateTime(dateAdded);
+    ar >> m_type;
   }
 }
 
@@ -468,6 +471,7 @@ void CVideoInfoTag::Serialize(CVariant& value)
   value["tvshowid"] = m_iIdShow;
   value["tvshowpath"] = m_strShowPath;
   value["dateadded"] = m_dateAdded.IsValid() ? m_dateAdded.GetAsDBDateTime() : StringUtils::EmptyString;
+  value["type"] = m_type;
 }
 
 const CStdString CVideoInfoTag::GetCast(bool bIncludeRole /*= false*/) const

--- a/xbmc/video/VideoInfoTag.cpp
+++ b/xbmc/video/VideoInfoTag.cpp
@@ -284,6 +284,7 @@ void CVideoInfoTag::Archive(CArchive& ar)
     {
       ar << m_cast[i].strName;
       ar << m_cast[i].strRole;
+      ar << m_cast[i].thumb;
       ar << m_cast[i].thumbUrl.m_xml;
     }
 
@@ -355,6 +356,7 @@ void CVideoInfoTag::Archive(CArchive& ar)
       SActorInfo info;
       ar >> info.strName;
       ar >> info.strRole;
+      ar >> info.thumb;
       CStdString strXml;
       ar >> strXml;
       info.thumbUrl.ParseString(strXml);

--- a/xbmc/video/VideoInfoTag.cpp
+++ b/xbmc/video/VideoInfoTag.cpp
@@ -28,7 +28,6 @@
 #include "utils/StringUtils.h"
 #include "utils/Variant.h"
 #include "utils/CharsetConverter.h"
-#include "ThumbnailCache.h"
 #include "filesystem/File.h"
 
 #include <sstream>
@@ -432,9 +431,8 @@ void CVideoInfoTag::Serialize(CVariant& value)
     CVariant actor;
     actor["name"] = m_cast[i].strName;
     actor["role"] = m_cast[i].strRole;
-    CStdString thumb = CThumbnailCache::GetActorThumb(m_cast[i].strName);
-    if (XFILE::CFile::Exists(thumb))
-      actor["thumbnail"] = thumb;
+    if (!m_cast[i].thumb.IsEmpty())
+      actor["thumbnail"] = m_cast[i].thumb;
     value["cast"].push_back(actor);
   }
   value["set"] = m_set;

--- a/xbmc/video/VideoInfoTag.cpp
+++ b/xbmc/video/VideoInfoTag.cpp
@@ -94,7 +94,7 @@ void CVideoInfoTag::Reset()
   m_type.clear();
 }
 
-bool CVideoInfoTag::Save(TiXmlNode *node, const CStdString &tag, bool savePathInfo)
+bool CVideoInfoTag::Save(TiXmlNode *node, const CStdString &tag, bool savePathInfo, const TiXmlElement *additionalNode)
 {
   if (!node) return false;
 
@@ -243,6 +243,9 @@ bool CVideoInfoTag::Save(TiXmlNode *node, const CStdString &tag, bool savePathIn
   movie->InsertEndChild(resume);
 
   XMLUtils::SetString(movie, "dateadded", m_dateAdded.GetAsDBDateTime());
+
+  if (additionalNode)
+    movie->InsertEndChild(*additionalNode);
 
   return true;
 }

--- a/xbmc/video/VideoInfoTag.cpp
+++ b/xbmc/video/VideoInfoTag.cpp
@@ -28,6 +28,7 @@
 #include "utils/StringUtils.h"
 #include "utils/Variant.h"
 #include "utils/CharsetConverter.h"
+#include "TextureCache.h"
 #include "filesystem/File.h"
 
 #include <sstream>
@@ -431,8 +432,8 @@ void CVideoInfoTag::Serialize(CVariant& value)
     CVariant actor;
     actor["name"] = m_cast[i].strName;
     actor["role"] = m_cast[i].strRole;
-    if (!m_cast[i].thumb.IsEmpty())
-      actor["thumbnail"] = m_cast[i].thumb;
+    if (!m_cast[i].thumb.IsEmpty()) // TODO: json-rpc should use real URLs just like everywhere else
+      actor["thumbnail"] = CTextureCache::Get().CheckAndCacheImage(m_cast[i].thumb);
     value["cast"].push_back(actor);
   }
   value["set"] = m_set;

--- a/xbmc/video/VideoInfoTag.h
+++ b/xbmc/video/VideoInfoTag.h
@@ -38,6 +38,7 @@ struct SActorInfo
   CStdString strName;
   CStdString strRole;
   CScraperUrl thumbUrl;
+  CStdString thumb;
 };
 
 class CVideoInfoTag : public IArchivable, public ISerializable

--- a/xbmc/video/VideoInfoTag.h
+++ b/xbmc/video/VideoInfoTag.h
@@ -61,7 +61,7 @@ public:
    \sa ParseNative
    */
   bool Load(const TiXmlElement *element, bool append = false, bool prioritise = false);
-  bool Save(TiXmlNode *node, const CStdString &tag, bool savePathInfo = true);
+  bool Save(TiXmlNode *node, const CStdString &tag, bool savePathInfo = true, const TiXmlElement *additionalNode = NULL);
   virtual void Archive(CArchive& ar);
   virtual void Serialize(CVariant& value);
   const CStdString GetCast(bool bIncludeRole = false) const;

--- a/xbmc/video/VideoInfoTag.h
+++ b/xbmc/video/VideoInfoTag.h
@@ -130,6 +130,7 @@ public:
   CStreamDetails m_streamDetails;
   CBookmark m_resumePoint;
   CDateTime m_dateAdded;
+  CStdString m_type;
 
 private:
   /* \brief Parse our native XML format for video info.

--- a/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
@@ -281,20 +281,19 @@ void CGUIDialogVideoInfo::SetMovie(const CFileItem *item)
       if(m_movieItem->GetVideoInfoTag()->m_iYear == 0 && m_movieItem->m_dateTime.IsValid())
         m_movieItem->GetVideoInfoTag()->m_iYear = m_movieItem->m_dateTime.GetYear();
       // retrieve the season thumb.
-      // NOTE: This is overly complicated. Perhaps we should cache season thumbs by showtitle and season number,
-      //       rather than bothering with show path and the localized strings involved?
+      // TODO: should we use the thumbloader for this?
       if (m_movieItem->GetVideoInfoTag()->m_iSeason > -1)
       {
-        CStdString label;
-        if (m_movieItem->GetVideoInfoTag()->m_iSeason == 0)
-          label = g_localizeStrings.Get(20381);
-        else
-          label.Format(g_localizeStrings.Get(20358), m_movieItem->GetVideoInfoTag()->m_iSeason);
-        CFileItem season(label);
-        season.m_bIsFolder = true;
-        season.GetVideoInfoTag()->m_strPath = item->GetVideoInfoTag()->m_strShowPath;
-        if (CFile::Exists(season.GetCachedSeasonThumb()))
-          m_movieItem->SetProperty("seasonthumb", season.GetCachedSeasonThumb());
+        CVideoDatabase db;
+        if (db.Open())
+        {
+          int seasonID = db.GetSeasonId(m_movieItem->GetVideoInfoTag()->m_iIdShow,
+                                        m_movieItem->GetVideoInfoTag()->m_iSeason);
+          string thumb = db.GetArtForItem(seasonID, "season", "thumb");
+          if (!thumb.empty())
+            m_movieItem->SetProperty("seasonthumb", thumb);
+          db.Close();
+        }
       }
     }
     else if (type == VIDEODB_CONTENT_MOVIES)

--- a/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
@@ -254,7 +254,17 @@ void CGUIDialogVideoInfo::SetMovie(const CFileItem *item)
       else
         character.Format("%s %s %s", it->strName.c_str(), g_localizeStrings.Get(20347).c_str(), it->strRole.c_str());
       CFileItemPtr item(new CFileItem(it->strName));
-      item->SetThumbnailImage(it->thumb);
+      if (!it->thumb.IsEmpty())
+        item->SetThumbnailImage(it->thumb);
+      else
+      { // backward compatibility
+        CStdString thumb = CScraperUrl::GetThumbURL(it->thumbUrl.GetFirstThumb());
+        if (!thumb.IsEmpty())
+        {
+          item->SetThumbnailImage(thumb);
+          CTextureCache::Get().BackgroundCacheImage(thumb);
+        }
+      }
       item->SetIconImage("DefaultActor.png");
       item->SetLabel(character);
       m_castList->Add(item);

--- a/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
@@ -260,12 +260,6 @@ void CGUIDialogVideoInfo::SetMovie(const CFileItem *item)
       item->SetLabel(character);
       m_castList->Add(item);
     }
-    // set fanart property for tvshows and movies
-    if (type == VIDEODB_CONTENT_TVSHOWS || type == VIDEODB_CONTENT_MOVIES)
-    {
-      if (m_movieItem->CacheLocalFanart())
-        m_movieItem->SetProperty("fanart_image",m_movieItem->GetCachedFanart());
-    }
     // determine type:
     if (type == VIDEODB_CONTENT_TVSHOWS)
     {
@@ -287,8 +281,6 @@ void CGUIDialogVideoInfo::SetMovie(const CFileItem *item)
       m_movieItem->m_dateTime = m_movieItem->GetVideoInfoTag()->m_firstAired;
       if(m_movieItem->GetVideoInfoTag()->m_iYear == 0 && m_movieItem->m_dateTime.IsValid())
         m_movieItem->GetVideoInfoTag()->m_iYear = m_movieItem->m_dateTime.GetYear();
-      if (CFile::Exists(m_movieItem->GetCachedEpisodeThumb()))
-        m_movieItem->SetThumbnailImage(m_movieItem->GetCachedEpisodeThumb());
       // retrieve the season thumb.
       // NOTE: This is overly complicated. Perhaps we should cache season thumbs by showtitle and season number,
       //       rather than bothering with show path and the localized strings involved?

--- a/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
@@ -254,8 +254,7 @@ void CGUIDialogVideoInfo::SetMovie(const CFileItem *item)
       else
         character.Format("%s %s %s", it->strName.c_str(), g_localizeStrings.Get(20347).c_str(), it->strRole.c_str());
       CFileItemPtr item(new CFileItem(it->strName));
-      if (CFile::Exists(item->GetCachedActorThumb()))
-        item->SetThumbnailImage(item->GetCachedActorThumb());
+      item->SetThumbnailImage(it->thumb);
       item->SetIconImage("DefaultActor.png");
       item->SetLabel(character);
       m_castList->Add(item);

--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -1821,7 +1821,7 @@ void CGUIWindowVideoBase::AddToDatabase(int iItem)
   m_database.Open();
   int idMovie = m_database.AddMovie(pItem->GetPath());
   movie.m_strIMDBNumber.Format("xx%08i", idMovie);
-  m_database.SetDetailsForMovie(pItem->GetPath(), movie);
+  m_database.SetDetailsForMovie(pItem->GetPath(), movie, pItem->GetArt());
   m_database.Close();
 
   // done...

--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -1763,22 +1763,6 @@ bool CGUIWindowVideoBase::StackingAvailable(const CFileItemList &items) const
 
 void CGUIWindowVideoBase::OnPrepareFileItems(CFileItemList &items)
 {
-  if (!items.GetPath().Equals("plugin://video/"))
-    items.SetCachedVideoThumbs();
-
-  if (items.GetContent() != "episodes")
-  { // we don't set cached fanart for episodes, as this requires a db fetch per episode
-    for (int i = 0; i < items.Size(); ++i)
-    {
-      CFileItemPtr item = items[i];
-      if (!item->HasProperty("fanart_image"))
-      {
-        CStdString art = item->GetCachedFanart();
-        if (CFile::Exists(art))
-          item->SetProperty("fanart_image", art);
-      }
-    }
-  }
 }
 
 void CGUIWindowVideoBase::AddToDatabase(int iItem)

--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -621,6 +621,9 @@ bool CGUIWindowVideoBase::ShowIMDB(CFileItem *item, const ScraperPtr &info2)
       pDlgProgress->Progress();
       if (bHasInfo)
       {
+        // clear artwork
+        item->SetThumbnailImage("");
+        item->ClearProperty("fanart_image");
         if (info->Content() == CONTENT_MOVIES)
           m_database.DeleteMovie(item->GetPath());
         if (info->Content() == CONTENT_TVSHOWS && !item->m_bIsFolder)

--- a/xbmc/video/windows/GUIWindowVideoNav.cpp
+++ b/xbmc/video/windows/GUIWindowVideoNav.cpp
@@ -1142,7 +1142,7 @@ bool CGUIWindowVideoNav::OnContextButton(int itemNumber, CONTEXT_BUTTON button)
       {
         CVideoInfoTag tag;
         if (button == CONTEXT_BUTTON_SET_SEASON_THUMB)
-          m_database.GetTvShowInfo("",tag,m_vecItems->Get(itemNumber)->GetVideoInfoTag()->m_iDbId);
+          m_database.GetTvShowInfo("",tag,m_vecItems->Get(itemNumber)->GetVideoInfoTag()->m_iIdShow);
         else
           tag = *m_vecItems->Get(itemNumber)->GetVideoInfoTag();
         if (button == CONTEXT_BUTTON_SET_SEASON_THUMB)

--- a/xbmc/video/windows/GUIWindowVideoNav.cpp
+++ b/xbmc/video/windows/GUIWindowVideoNav.cpp
@@ -1124,14 +1124,14 @@ bool CGUIWindowVideoNav::OnContextButton(int itemNumber, CONTEXT_BUTTON button)
       CFileUtils::DeleteItem(cacheItem,true);
       XFILE::CDirectory::Create(strPath);
       CFileItemPtr noneitem(new CFileItem("thumb://None", false));
-      CStdString cachedThumb = m_vecItems->Get(itemNumber)->GetCachedSeasonThumb();
-      if (button == CONTEXT_BUTTON_SET_ACTOR_THUMB)
-        cachedThumb = m_vecItems->Get(itemNumber)->GetCachedActorThumb();
-      if (button == CONTEXT_BUTTON_SET_ARTIST_THUMB)
+      CStdString cachedThumb;
+      if (button == CONTEXT_BUTTON_SET_SEASON_THUMB)
+        cachedThumb = m_vecItems->Get(itemNumber)->GetCachedSeasonThumb();
+      else if (button == CONTEXT_BUTTON_SET_ARTIST_THUMB)
         cachedThumb = m_vecItems->Get(itemNumber)->GetCachedArtistThumb();
-      if (button == CONTEXT_BUTTON_SET_MOVIESET_THUMB)
+      else
         cachedThumb = m_database.GetArtForItem(m_vecItems->Get(itemNumber)->GetVideoInfoTag()->m_iDbId, m_vecItems->Get(itemNumber)->GetVideoInfoTag()->m_type, "thumb");
-      if (CFile::Exists(cachedThumb))
+      if (!cachedThumb.IsEmpty() && CFile::Exists(cachedThumb))
       {
         CFileItemPtr item(new CFileItem("thumb://Current", false));
         item->SetThumbnailImage(cachedThumb);
@@ -1246,7 +1246,8 @@ bool CGUIWindowVideoNav::OnContextButton(int itemNumber, CONTEXT_BUTTON button)
       }
       else if (result == "thumb://None")
         result.clear();
-      if (button == CONTEXT_BUTTON_SET_MOVIESET_THUMB)
+      if (button == CONTEXT_BUTTON_SET_MOVIESET_THUMB ||
+          button == CONTEXT_BUTTON_SET_ACTOR_THUMB)
         m_database.SetArtForItem(m_vecItems->Get(itemNumber)->GetVideoInfoTag()->m_iDbId, m_vecItems->Get(itemNumber)->GetVideoInfoTag()->m_type, "thumb", result);
       else
       {

--- a/xbmc/video/windows/GUIWindowVideoNav.cpp
+++ b/xbmc/video/windows/GUIWindowVideoNav.cpp
@@ -322,50 +322,18 @@ bool CGUIWindowVideoNav::GetDirectory(const CStdString &strDirectory, CFileItemL
         // save the show description (showplot)
         items.SetProperty("showplot", details.m_strPlot);
 
-        // set the season thumb
-        CStdString strLabel;
-        if (params.GetSeason() == 0)
-          strLabel = g_localizeStrings.Get(20381);
-        else
-          strLabel.Format(g_localizeStrings.Get(20358), params.GetSeason());
-
-        CFileItem item(strLabel);
-        item.SetPath(URIUtils::GetParentPath(items.GetPath()));
-        item.m_bIsFolder = true;
-        item.SetCachedSeasonThumb();
-        if (item.HasThumbnail())
-          items.SetProperty("seasonthumb",item.GetThumbnailImage());
-
         // the container folder thumb is the parent (i.e. season or show)
         if (node == NODE_TYPE_EPISODES || node == NODE_TYPE_RECENTLY_ADDED_EPISODES)
         {
           items.SetContent("episodes");
           // grab the season thumb as the folder thumb
-          CStdString strLabel;
-          CStdString strPath;
-          if (params.GetSeason() <= -1 && items.Size() > 0)
+          int seasonID = m_database.GetSeasonId(details.m_iDbId, params.GetSeason());
+          string seasonThumb = m_database.GetArtForItem(seasonID, "season", "thumb");
+          if (!seasonThumb.empty())
           {
-            CQueryParams params2;
-            dir.GetQueryParams(items[0]->GetPath(),params2);
-            strLabel.Format(g_localizeStrings.Get(20358), params2.GetSeason());
-            strPath = URIUtils::GetParentPath(items.GetPath());
+            items.SetProperty("seasonthumb",seasonThumb);
+            items.SetThumbnailImage(seasonThumb);
           }
-          else
-          {
-            if (params.GetSeason() == 0)
-              strLabel = g_localizeStrings.Get(20381);
-            else
-              strLabel.Format(g_localizeStrings.Get(20358), params.GetSeason());
-            strPath = items.GetPath();
-          }
-
-          CFileItem item(strPath, true);
-          item.SetLabel(strLabel);
-          item.GetVideoInfoTag()->m_strPath = showItem.GetPath();
-          item.SetCachedSeasonThumb();
-
-          items.SetThumbnailImage(item.GetThumbnailImage());
-          items.SetProperty("seasonthumb",item.GetThumbnailImage());
         }
         else
         {
@@ -1125,9 +1093,7 @@ bool CGUIWindowVideoNav::OnContextButton(int itemNumber, CONTEXT_BUTTON button)
       XFILE::CDirectory::Create(strPath);
       CFileItemPtr noneitem(new CFileItem("thumb://None", false));
       CStdString cachedThumb;
-      if (button == CONTEXT_BUTTON_SET_SEASON_THUMB)
-        cachedThumb = m_vecItems->Get(itemNumber)->GetCachedSeasonThumb();
-      else if (button == CONTEXT_BUTTON_SET_ARTIST_THUMB)
+      if (button == CONTEXT_BUTTON_SET_ARTIST_THUMB)
         cachedThumb = m_vecItems->Get(itemNumber)->GetCachedArtistThumb();
       else
         cachedThumb = m_database.GetArtForItem(m_vecItems->Get(itemNumber)->GetVideoInfoTag()->m_iDbId, m_vecItems->Get(itemNumber)->GetVideoInfoTag()->m_type, "thumb");
@@ -1247,7 +1213,8 @@ bool CGUIWindowVideoNav::OnContextButton(int itemNumber, CONTEXT_BUTTON button)
       else if (result == "thumb://None")
         result.clear();
       if (button == CONTEXT_BUTTON_SET_MOVIESET_THUMB ||
-          button == CONTEXT_BUTTON_SET_ACTOR_THUMB)
+          button == CONTEXT_BUTTON_SET_ACTOR_THUMB ||
+          button == CONTEXT_BUTTON_SET_SEASON_THUMB)
         m_database.SetArtForItem(m_vecItems->Get(itemNumber)->GetVideoInfoTag()->m_iDbId, m_vecItems->Get(itemNumber)->GetVideoInfoTag()->m_type, "thumb", result);
       else
       {

--- a/xbmc/video/windows/GUIWindowVideoNav.cpp
+++ b/xbmc/video/windows/GUIWindowVideoNav.cpp
@@ -304,16 +304,20 @@ bool CGUIWindowVideoNav::GetDirectory(const CStdString &strDirectory, CFileItemL
         // grab the show thumb
         CVideoInfoTag details;
         m_database.GetTvShowInfo("", details, params.GetTvShowId());
+        map<string, string> art;
+        if (m_database.GetArtForItem(details.m_iDbId, details.m_type, art))
+        {
+          if (art.find("thumb") != art.end())
+            items.SetProperty("tvshowthumb", art["thumb"]);
+          if (art.find("fanart") != art.end())
+            items.SetProperty("fanart_image", art["fanart"]);
+        }
         CFileItem showItem(details.m_strShowPath, true);
-        if (showItem.GetCachedVideoThumb())
-          items.SetProperty("tvshowthumb", showItem.GetCachedVideoThumb());
 
         // Grab fanart data
         items.SetProperty("fanart_color1", details.m_fanart.GetColor(0));
         items.SetProperty("fanart_color2", details.m_fanart.GetColor(1));
         items.SetProperty("fanart_color3", details.m_fanart.GetColor(2));
-        if (showItem.CacheLocalFanart())
-          items.SetProperty("fanart_image", showItem.GetCachedFanart());
 
         // save the show description (showplot)
         items.SetProperty("showplot", details.m_strPlot);
@@ -1126,7 +1130,7 @@ bool CGUIWindowVideoNav::OnContextButton(int itemNumber, CONTEXT_BUTTON button)
       if (button == CONTEXT_BUTTON_SET_ARTIST_THUMB)
         cachedThumb = m_vecItems->Get(itemNumber)->GetCachedArtistThumb();
       if (button == CONTEXT_BUTTON_SET_MOVIESET_THUMB)
-        cachedThumb = m_vecItems->Get(itemNumber)->GetCachedVideoThumb();
+        cachedThumb = m_database.GetArtForItem(m_vecItems->Get(itemNumber)->GetVideoInfoTag()->m_iDbId, m_vecItems->Get(itemNumber)->GetVideoInfoTag()->m_type, "thumb");
       if (CFile::Exists(cachedThumb))
       {
         CFileItemPtr item(new CFileItem("thumb://Current", false));
@@ -1235,16 +1239,21 @@ bool CGUIWindowVideoNav::OnContextButton(int itemNumber, CONTEXT_BUTTON button)
 
       // delete the thumbnail if that's what the user wants, else overwrite with the
       // new thumbnail
-      CTextureCache::Get().ClearCachedImage(cachedThumb, true);
       if (result.Left(14) == "thumb://Remote")
       {
         int number = atoi(result.Mid(14));
-        CFile::Cache(thumbs[number], cachedThumb);
+        result = thumbs[number];
       }
-      if (result == "thumb://None")
-        CTextureCache::Get().ClearCachedImage(cachedThumb, true);
+      else if (result == "thumb://None")
+        result.clear();
+      if (button == CONTEXT_BUTTON_SET_MOVIESET_THUMB)
+        m_database.SetArtForItem(m_vecItems->Get(itemNumber)->GetVideoInfoTag()->m_iDbId, m_vecItems->Get(itemNumber)->GetVideoInfoTag()->m_type, "thumb", result);
       else
-        CFile::Cache(result,cachedThumb);
+      {
+        CTextureCache::Get().ClearCachedImage(cachedThumb, true);
+        if (!result.IsEmpty())
+          CFile::Cache(result,cachedThumb);
+      }
 
       CUtil::DeleteVideoDatabaseDirectoryCache();
       CGUIMessage msg(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_REFRESH_THUMBS);
@@ -1256,26 +1265,19 @@ bool CGUIWindowVideoNav::OnContextButton(int itemNumber, CONTEXT_BUTTON button)
   case CONTEXT_BUTTON_SET_MOVIESET_FANART:
     {
       CFileItemList items;
-      CStdString cachedFanart(item->GetCachedFanart());
 
-      if (CFile::Exists(cachedFanart))
+      CVideoThumbLoader loader;
+      loader.LoadItem(item.get());
+
+      if (item->HasProperty("fanart_image"))
       {
         CFileItemPtr itemCurrent(new CFileItem("fanart://Current",false));
-        itemCurrent->SetThumbnailImage(cachedFanart);
+        itemCurrent->SetThumbnailImage(item->GetProperty("fanart_image").asString());
         itemCurrent->SetLabel(g_localizeStrings.Get(20440));
         items.Add(itemCurrent);
       }
 
-      CStdString localFanart(item->GetLocalFanart());
-      if (!localFanart.IsEmpty())
-      {
-        CFileItemPtr itemLocal(new CFileItem("fanart://Local",false));
-        itemLocal->SetThumbnailImage(localFanart);
-        itemLocal->SetLabel(g_localizeStrings.Get(20438));
-        CTextureCache::Get().ClearCachedImage(localFanart);
-        items.Add(itemLocal);
-      }
-      else
+      // add the none option
       {
         CFileItemPtr itemNone(new CFileItem("fanart://None", false));
         itemNone->SetIconImage("DefaultVideo.png");
@@ -1290,26 +1292,16 @@ bool CGUIWindowVideoNav::OnContextButton(int itemNumber, CONTEXT_BUTTON button)
       if (!CGUIDialogFileBrowser::ShowAndGetImage(items, sources, g_localizeStrings.Get(20437), result, &flip, 20445) || result.Equals("fanart://Current"))
         return false;
 
-      CTextureCache::Get().ClearCachedImage(cachedFanart, true);
+      if (result.Equals("fanart://None") || !CFile::Exists(result))
+          result.clear();
+      if (!result.IsEmpty() && flip)
+        result = CTextureCache::GetWrappedImageURL(result, "", "flipped");
 
-      if (result.Equals("fanart://Local"))
-        result = localFanart;
-
-      if (CFile::Exists(result))
-      {
-        if (flip)
-          CPicture::ConvertFile(result, cachedFanart,0,1920,-1,100,true);
-        else
-          CPicture::CacheFanart(result, cachedFanart);
-      }
+      // update the db
+      m_database.SetArtForItem(item->GetVideoInfoTag()->m_iDbId, item->GetVideoInfoTag()->m_type, "fanart", result);
 
       // clear view cache and reload images
       CUtil::DeleteVideoDatabaseDirectoryCache();
-
-      if (CFile::Exists(cachedFanart))
-        item->SetProperty("fanart_image", cachedFanart);
-      else
-        item->ClearProperty("fanart_image");
 
       Update(m_vecItems->GetPath());
       return true;


### PR DESCRIPTION
This moves video art to the texture cache.

We store all video art in the video library (for items in the library) in the new art table.

There's backward compat in the thumbloader to find the image.  Obviously we may get this wrong in the case where the user has changed the thumb or fanart to something other than the local image or the first scraped image, but that's what this is here to solve :)

It'd be useful to get #918 in first I think.

@Montellese: the last commit uses cached paths for JSON-RPC, as I believe this is required for back-compat.  Hopefully we can redo to something like image:// URLs later on so we don't need the texture cache hits (which are on-thread).
