### PR TITLE
refactor gl/gles includes out of system.h

### DIFF
--- a/xbmc/cores/VideoRenderers/BaseRenderer.h
+++ b/xbmc/cores/VideoRenderers/BaseRenderer.h
@@ -42,6 +42,13 @@ typedef struct YV12Image
   unsigned bpp; /* bytes per pixel */
 } YV12Image;
 
+enum EFIELDSYNC
+{
+  FS_NONE,
+  FS_TOP,
+  FS_BOT
+};
+
 enum ERENDERFEATURE
 {
   RENDERFEATURE_GAMMA,

--- a/xbmc/cores/VideoRenderers/LinuxRendererGL.cpp
+++ b/xbmc/cores/VideoRenderers/LinuxRendererGL.cpp
@@ -27,6 +27,7 @@
 
 #ifdef HAS_GL
 #include <locale.h>
+
 #include "LinuxRendererGL.h"
 #include "Application.h"
 #include "settings/Settings.h"

--- a/xbmc/cores/VideoRenderers/LinuxRendererGL.h
+++ b/xbmc/cores/VideoRenderers/LinuxRendererGL.h
@@ -22,7 +22,10 @@
  *
  */
 
+#include "system.h"
+
 #ifdef HAS_GL
+#include "system_gl.h"
 
 #include "guilib/FrameBufferObject.h"
 #include "guilib/Shader.h"
@@ -64,13 +67,6 @@ struct DRAWRECT
   float top;
   float right;
   float bottom;
-};
-
-enum EFIELDSYNC
-{
-  FS_NONE,
-  FS_TOP,
-  FS_BOT
 };
 
 struct YUVRANGE

--- a/xbmc/cores/VideoRenderers/LinuxRendererGLES.h
+++ b/xbmc/cores/VideoRenderers/LinuxRendererGLES.h
@@ -24,6 +24,8 @@
 
 #if HAS_GLES == 2
 
+#include "system_gl.h"
+
 #include "xbmc/guilib/FrameBufferObject.h"
 #include "xbmc/guilib/Shader.h"
 #include "settings/VideoSettings.h"
@@ -61,13 +63,6 @@ struct DRAWRECT
   float top;
   float right;
   float bottom;
-};
-
-enum EFIELDSYNC
-{
-  FS_NONE,
-  FS_TOP,
-  FS_BOT
 };
 
 struct YUVRANGE

--- a/xbmc/cores/VideoRenderers/OverlayRendererGL.cpp
+++ b/xbmc/cores/VideoRenderers/OverlayRendererGL.cpp
@@ -25,10 +25,10 @@
 #include "OverlayRendererUtil.h"
 #include "OverlayRendererGL.h"
 #ifdef HAS_GL
-#include "LinuxRendererGL.h"
+  #include "LinuxRendererGL.h"
 #elif HAS_GLES == 2
-#include "LinuxRendererGLES.h"
-#include "guilib/MatrixGLES.h"
+  #include "LinuxRendererGLES.h"
+  #include "guilib/MatrixGLES.h"
 #endif
 #include "RenderManager.h"
 #include "cores/dvdplayer/DVDCodecs/Overlay/DVDOverlayImage.h"

--- a/xbmc/cores/VideoRenderers/OverlayRendererGL.h
+++ b/xbmc/cores/VideoRenderers/OverlayRendererGL.h
@@ -22,11 +22,8 @@
  */
 
 #pragma once
+#include "system_gl.h"
 #include "OverlayRenderer.h"
-
-#ifdef HAS_GL
-#include <GL/glew.h>
-#endif
 
 class CDVDOverlay;
 class CDVDOverlayImage;

--- a/xbmc/cores/VideoRenderers/RenderCapture.h
+++ b/xbmc/cores/VideoRenderers/RenderCapture.h
@@ -174,6 +174,7 @@ class CRenderCaptureBase
 };
 
 #if defined(HAS_GL) || defined(HAS_GLES)
+#include "system_gl.h"
 
 class CRenderCaptureGL : public CRenderCaptureBase
 {

--- a/xbmc/cores/VideoRenderers/VideoShaders/VideoFilterShader.cpp
+++ b/xbmc/cores/VideoRenderers/VideoShaders/VideoFilterShader.cpp
@@ -19,18 +19,15 @@
 */
 
 #include "system.h"
+
+#if defined(HAS_GL) || HAS_GLES == 2
+#include <string>
+#include <math.h>
+
 #include "VideoFilterShader.h"
 #include "utils/log.h"
 #include "utils/GLUtils.h"
 #include "ConvolutionKernels.h"
-
-#include <string>
-#include <math.h>
-
-#if defined(HAS_GL) || HAS_GLES == 2
-
-using namespace Shaders;
-using namespace std;
 
 #if defined(HAS_GL)
   #define USE1DTEXTURE
@@ -38,6 +35,9 @@ using namespace std;
 #else
   #define TEXTARGET GL_TEXTURE_2D
 #endif
+
+using namespace Shaders;
+using namespace std;
 
 //////////////////////////////////////////////////////////////////////
 // BaseVideoFilterShader - base class for video filter shaders

--- a/xbmc/cores/VideoRenderers/VideoShaders/VideoFilterShader.h
+++ b/xbmc/cores/VideoRenderers/VideoShaders/VideoFilterShader.h
@@ -22,12 +22,14 @@
  *
  */
 
+#include "system.h"
+
 #if defined(HAS_GL) || HAS_GLES == 2
+#include "system_gl.h"
+
 
 #include "guilib/Shader.h"
-#include "../../../settings/VideoSettings.h"
-
-using namespace Shaders;
+#include "settings/VideoSettings.h"
 
 namespace Shaders {
 

--- a/xbmc/cores/VideoRenderers/WinRenderer.h
+++ b/xbmc/cores/VideoRenderers/WinRenderer.h
@@ -71,14 +71,6 @@ struct DRAWRECT
   float bottom;
 };
 
-enum EFIELDSYNC
-{
-  FS_NONE,
-  FS_TOP,
-  FS_BOT,
-};
-
-
 struct YUVRANGE
 {
   int y_min, y_max;

--- a/xbmc/cores/dvdplayer/DVDPlayerVideo.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayerVideo.cpp
@@ -20,6 +20,7 @@
  */
 
 #include "system.h"
+#include "cores/VideoRenderers/RenderFlags.h"
 #include "windowing/WindowingFactory.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/GUISettings.h"

--- a/xbmc/guilib/FrameBufferObject.cpp
+++ b/xbmc/guilib/FrameBufferObject.cpp
@@ -22,19 +22,21 @@
 #include "system.h"
 
 #if defined(HAS_GL) || HAS_GLES == 2
+#include "FrameBufferObject.h"
 #include "settings/Settings.h"
 #include "windowing/WindowingFactory.h"
-#include "FrameBufferObject.h"
-#include "utils/log.h"
 #include "utils/GLUtils.h"
+#include "utils/log.h"
 
 #if HAS_GLES == 2
 // For OpenGL ES2.0, FBO are not extensions but part of the API.
-#define glGenFramebuffersEXT		glGenFramebuffers
-#define glDeleteFramebuffersEXT		glDeleteFramebuffers
+#define GL_FRAMEBUFFER_EXT GL_FRAMEBUFFER
+#define glBindFramebufferEXT glBindFramebuffer
+#define glGenFramebuffersEXT glGenFramebuffers
+#define glDeleteFramebuffersEXT glDeleteFramebuffers
 #define glFramebufferTexture2DEXT	glFramebufferTexture2D
 #define glCheckFramebufferStatusEXT	glCheckFramebufferStatus
-#define GL_COLOR_ATTACHMENT0_EXT	GL_COLOR_ATTACHMENT0
+#define GL_COLOR_ATTACHMENT0_EXT GL_COLOR_ATTACHMENT0
 #define GL_FRAMEBUFFER_COMPLETE_EXT	GL_FRAMEBUFFER_COMPLETE
 #endif
 
@@ -140,6 +142,24 @@ bool CFrameBufferObject::BindToTexture(GLenum target, GLuint texid)
   }
   m_bound = true;
   return true;
+}
+
+// Begin rendering to FBO
+bool CFrameBufferObject::BeginRender()
+{
+  if (IsValid() && IsBound())
+  {
+    glBindFramebufferEXT(GL_FRAMEBUFFER_EXT, m_fbo);
+    return true;
+  }
+  return false;
+}
+
+// Finish rendering to FBO
+void CFrameBufferObject::EndRender()
+{
+  if (IsValid())
+    glBindFramebufferEXT(GL_FRAMEBUFFER_EXT, 0);
 }
 
 #endif

--- a/xbmc/guilib/FrameBufferObject.h
+++ b/xbmc/guilib/FrameBufferObject.h
@@ -25,6 +25,7 @@
 #include "system.h" // for HAS_GL
 
 #if defined(HAS_GL) || HAS_GLES == 2
+#include "system_gl.h"
 
 //
 // CFrameBufferObject
@@ -44,12 +45,6 @@
 //     bind and use texture anywhere
 //     glBindTexture(GL_TEXTURE_2D, fbo->Texture());
 //
-
-#if HAS_GLES == 2
-// For OpenGL ES2.0, FBO are not extensions but part of the API.
-#define glBindFramebufferEXT  glBindFramebuffer
-#define GL_FRAMEBUFFER_EXT    GL_FRAMEBUFFER
-#endif
 
 class CFrameBufferObject
 {
@@ -80,28 +75,15 @@ public:
 
   // Create a new texture and bind to it
   bool CreateAndBindToTexture(GLenum target, int width, int height, GLenum format,
-                              GLenum filter=GL_LINEAR, GLenum clamp=GL_CLAMP_TO_EDGE);
+                              GLenum filter=GL_LINEAR, GLenum clampmode=GL_CLAMP_TO_EDGE);
 
   // Return the internally created texture ID
   GLuint Texture() { return m_texid; }
 
   // Begin rendering to FBO
-  bool BeginRender()
-  {
-    if (IsValid() && IsBound())
-    {
-      glBindFramebufferEXT(GL_FRAMEBUFFER_EXT, m_fbo);
-      return true;
-    }
-    return false;
-  }
-
+  bool BeginRender();
   // Finish rendering to FBO
-  void EndRender()
-  {
-    if (IsValid())
-      glBindFramebufferEXT(GL_FRAMEBUFFER_EXT, 0);
-  }
+  void EndRender();
 
 private:
   GLuint m_fbo;

--- a/xbmc/guilib/GUITextureGL.h
+++ b/xbmc/guilib/GUITextureGL.h
@@ -31,6 +31,8 @@
 
 #include "GUITexture.h"
 
+#include "system_gl.h"
+
 class CGUITextureGL : public CGUITextureBase
 {
 public:

--- a/xbmc/guilib/Shader.cpp
+++ b/xbmc/guilib/Shader.cpp
@@ -22,11 +22,16 @@
 #include "system.h"
 
 #if defined(HAS_GL) || HAS_GLES == 2
+
+#include "Shader.h"
 #include "settings/Settings.h"
 #include "filesystem/File.h"
-#include "Shader.h"
 #include "utils/log.h"
 #include "utils/GLUtils.h"
+
+#ifdef HAS_GLES
+#define GLchar char
+#endif
 
 #define LOG_SIZE 1024
 

--- a/xbmc/guilib/Shader.h
+++ b/xbmc/guilib/Shader.h
@@ -28,6 +28,7 @@
 #include <string>
 
 #if defined(HAS_GL) || defined(HAS_GLES)
+#include "system_gl.h"
 
 namespace Shaders {
 

--- a/xbmc/guilib/Texture.h
+++ b/xbmc/guilib/Texture.h
@@ -26,6 +26,10 @@
 
 #ifndef GUILIB_TEXTURE_H
 #define GUILIB_TEXTURE_H
+#include "system.h"
+#if defined(HAS_GL) || HAS_GLES == 2
+#include "system_gl.h"
+#endif
 
 #include "gui3d.h"
 #include "utils/StdString.h"
@@ -69,14 +73,18 @@ public:
   virtual void DestroyTextureObject() = 0;
   virtual void LoadToGPU() = 0;
 
-  XBMC::TexturePtr GetTextureObject() const
-  {
 #ifdef HAS_DX
+  LPDIRECT3DTEXTURE9 GetTextureObject() const
+  {
     return m_texture.Get();
-#else
-    return m_texture;
-#endif
   }
+#else
+  GLuint GetTextureObject() const
+  {
+    return m_texture;
+  }
+#endif
+
   unsigned char* GetPixels() const { return m_pixels; }
   unsigned int GetPitch() const { return GetPitch(m_textureWidth); }
   unsigned int GetRows() const { return GetRows(m_textureHeight); }
@@ -107,7 +115,7 @@ protected:
 #ifdef HAS_DX
   CD3DTexture m_texture;
 #else
-  XBMC::TexturePtr m_texture;
+  GLuint m_texture;
 #endif
   unsigned char* m_pixels;
   bool m_loadedToGPU;

--- a/xbmc/guilib/gui3d.h
+++ b/xbmc/guilib/gui3d.h
@@ -66,40 +66,4 @@ struct D3DPalette
 
 typedef D3DPalette* LPDIRECT3DPALETTE8;
 
-#if defined(HAS_GL) || defined(HAS_GLES)
-
-namespace XBMC
-{
-  typedef void*  DevicePtr;
-  typedef GLuint SurfacePtr;
-  typedef GLuint TexturePtr;
-  typedef void* PalettePtr; // elis change it
-  typedef GLint PixelFormat; // elis change it
-}
-
-#if defined(_LINUX) && !defined(GL_GLEXT_PROTOTYPES)
-#define GL_GLEXT_PROTOTYPES
-#endif
-
-#endif // HAS_GL
-
-#ifdef HAS_DX
-
-namespace XBMC
-{
-  typedef LPDIRECT3DDEVICE9  DevicePtr;
-  typedef LPDIRECT3DTEXTURE9 TexturePtr;
-  typedef LPDIRECT3DSURFACE9 SurfacePtr;
-  typedef LPDIRECT3DPALETTE8 PalettePtr;
-};
-
-#define DELETE_TEXTURE(texture) texture->Release()
-
-#endif // HAS_DX
-
-#ifdef HAS_GLES
-
-#define GLchar char
-
-#endif
 #endif // GUILIB_GUI3D_H

--- a/xbmc/music/karaoke/karaokelyricscdg.cpp
+++ b/xbmc/music/karaoke/karaokelyricscdg.cpp
@@ -19,9 +19,9 @@
  *
  */
 
+#include "system.h"
 #include "filesystem/File.h"
 #include "settings/Settings.h"
-#include "system.h"
 #include "guilib/Texture.h"
 #include "guilib/GUITexture.h"
 #include "settings/AdvancedSettings.h"

--- a/xbmc/rendering/gl/GUIWindowTestPatternGL.cpp
+++ b/xbmc/rendering/gl/GUIWindowTestPatternGL.cpp
@@ -22,9 +22,10 @@
  */
 
 #include "system.h"
-#include "GUIWindowTestPatternGL.h"
 
 #ifdef HAS_GL
+#include "system_gl.h"
+#include "GUIWindowTestPatternGL.h"
 
 CGUIWindowTestPatternGL::CGUIWindowTestPatternGL(void) : CGUIWindowTestPattern()
 {

--- a/xbmc/rendering/gl/RenderSystemGL.cpp
+++ b/xbmc/rendering/gl/RenderSystemGL.cpp
@@ -19,10 +19,12 @@
 *
 */
 
-#include "RenderSystemGL.h"
+
+#include "system.h"
 
 #ifdef HAS_GL
 
+#include "RenderSystemGL.h"
 #include "guilib/GraphicContext.h"
 #include "settings/AdvancedSettings.h"
 #include "utils/log.h"

--- a/xbmc/rendering/gl/RenderSystemGL.h
+++ b/xbmc/rendering/gl/RenderSystemGL.h
@@ -25,6 +25,7 @@
 #pragma once
 
 #include "system.h"
+#include "system_gl.h"
 #include "rendering/RenderSystem.h"
 
 class CRenderSystemGL : public CRenderSystemBase
@@ -86,11 +87,9 @@ protected:
   int        m_glslMajor;
   int        m_glslMinor;
   
-#ifdef HAS_GL
   GLdouble   m_view[16];
   GLdouble   m_projection[16];
   GLint      m_viewPort[4];
-#endif
 };
 
 #endif // RENDER_SYSTEM_H

--- a/xbmc/rendering/gles/RenderSystemGLES.h
+++ b/xbmc/rendering/gles/RenderSystemGLES.h
@@ -24,6 +24,8 @@
 
 #pragma once
 
+#include "system.h"
+#include "system_gl.h"
 #include "rendering/RenderSystem.h"
 #include "xbmc/guilib/GUIShader.h"
 

--- a/xbmc/system.h
+++ b/xbmc/system.h
@@ -238,32 +238,6 @@
 #define HAS_GLES 1
 #endif
 
-
-#ifdef HAS_GL
-#if defined(TARGET_WINDOWS)
-#include "GL/glew.h"
-#include <GL/gl.h>
-#include <GL/glu.h>
-//#include <GL/wglext.h>
-#elif defined(TARGET_DARWIN)
-#include <GL/glew.h>
-#include <OpenGL/gl.h>
-#elif defined(TARGET_LINUX)
-#include <GL/glew.h>
-#include <GL/gl.h>
-#endif
-#endif
-
-#if HAS_GLES == 2
-  #if defined(TARGET_DARWIN)
-    #include <OpenGLES/ES2/gl.h>
-    #include <OpenGLES/ES2/glext.h>
-  #else
-    #include <GLES2/gl2.h>
-    #include <GLES2/gl2ext.h>
-  #endif
-#endif
-
 #ifdef HAS_DVD_DRIVE
 #define HAS_CDDA_RIPPER
 #endif

--- a/xbmc/system_gl.h
+++ b/xbmc/system_gl.h
@@ -1,15 +1,7 @@
-/*!
-\file GUITextureGLES.h
-\brief
-*/
-
-#ifndef GUILIB_GUITEXTUREGLES_H
-#define GUILIB_GUITEXTUREGLES_H
--
 #pragma once
 
 /*
- *      Copyright (C) 2005-2008 Team XBMC
+ *      Copyright (C) 2005-2012 Team XBMC
  *      http://www.xbmc.org
  *
  *  This Program is free software; you can redistribute it and/or modify
@@ -29,24 +21,32 @@
  *
  */
 
-#include "GUITexture.h"
+#include "system.h"
 
-#include "system_gl.h"
-
-class CGUITextureGLES : public CGUITextureBase
-{
-public:
-  CGUITextureGLES(float posX, float posY, float width, float height, const CTextureInfo& texture);
-  static void DrawQuad(const CRect &coords, color_t color, CBaseTexture *texture = NULL, const CRect *texCoords = NULL);
-protected:
-  void Begin(color_t color);
-  void Draw(float *x, float *y, float *z, const CRect &texture, const CRect &diffuse, int orientation);
-  void End();
-
-  GLubyte m_col [4][4];
-  GLfloat m_vert[4][3];
-  GLfloat m_tex0[4][2];
-  GLfloat m_tex1[4][2];
-};
-
+#ifdef HAS_GL
+  // always define GL_GLEXT_PROTOTYPES before include gl headers
+  #if !defined(GL_GLEXT_PROTOTYPES)
+    #define GL_GLEXT_PROTOTYPES
+  #endif
+  #if defined(TARGET_WINDOWS)
+    #include <GL/glew.h>
+    #include <GL/gl.h>
+    #include <GL/glu.h>
+  #elif defined(TARGET_LINUX)
+    #include <GL/glew.h>
+    #include <GL/gl.h>
+    #include <GL/glext.h>
+  #elif defined(TARGET_DARWIN)
+    #include <GL/glew.h>
+    #include <OpenGL/gl.h>
+    #include <OpenGL/glext.h>
+  #endif
+#elif HAS_GLES == 2
+  #if defined(TARGET_DARWIN)
+    #include <OpenGLES/ES2/gl.h>
+    #include <OpenGLES/ES2/glext.h>
+  #else
+    #include <GLES2/gl2.h>
+    #include <GLES2/gl2ext.h>
+  #endif
 #endif

--- a/xbmc/utils/GLUtils.cpp
+++ b/xbmc/utils/GLUtils.cpp
@@ -19,8 +19,10 @@
  *
  */
 
-#include "log.h"
 #include "system.h"
+
+#include "GLUtils.h"
+#include "log.h"
 #include "settings/AdvancedSettings.h"
 #include "windowing/WindowingFactory.h"
 

--- a/xbmc/utils/GLUtils.h
+++ b/xbmc/utils/GLUtils.h
@@ -32,6 +32,9 @@
 // if not it's just an empty inline stub, and thus won't affect performance
 // and will be optimized out.
 
+#include "system.h"
+#include "system_gl.h"
+
 void _VerifyGLState(const char* szfile, const char* szfunction, int lineno);
 #if defined(GL_DEBUGGING) && (defined(HAS_GL) || defined(HAS_GLES))
 #define VerifyGLState() _VerifyGLState(__FILE__, __FUNCTION__, __LINE__)

--- a/xbmc/video/VideoReferenceClock.h
+++ b/xbmc/video/VideoReferenceClock.h
@@ -27,6 +27,7 @@
 //TODO: get rid of #ifdef hell, abstract implementations in separate classes
 
 #if defined(HAS_GLX) && defined(HAS_XRANDR)
+  #include "system_gl.h"
   #include <X11/X.h>
   #include <X11/Xlib.h>
   #include <GL/glx.h>

--- a/xbmc/windowing/X11/WinSystemX11.h
+++ b/xbmc/windowing/X11/WinSystemX11.h
@@ -23,9 +23,12 @@
  *  http://www.gnu.org/copyleft/gpl.html
  *
  */
+
+#include "system_gl.h"
+#include <GL/glx.h>
+
 #include "windowing/WinSystem.h"
 #include "utils/Stopwatch.h"
-#include <GL/glx.h>
 #include "threads/CriticalSection.h"
 
 class IDispResource;


### PR DESCRIPTION
This fixes spewing gl/gles includes all over the build and handles pesky glew.h which will bitch like a sailor if it ever follow any other gl include.
