### PR TITLE
fixed tinyxml detection

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -718,6 +718,7 @@ AC_CHECK_LIB([mysqlclient], [main],, AC_MSG_ERROR($missing_library))
 AC_CHECK_LIB([ssh],         [sftp_tell64],, AC_MSG_RESULT([Could not find suitable version of libssh]))
 AC_CHECK_LIB([bluetooth],   [hci_devid],, AC_MSG_RESULT([Could not find suitable version of libbluetooth]))
 AC_CHECK_LIB([yajl],        [main],, AC_MSG_ERROR($missing_library))
+AC_CHECK_LIB([tinyxml],     [main],, AC_MSG_ERROR($missing_library))
 
 PKG_CHECK_MODULES([FONTCONFIG], [fontconfig],
   [INCLUDES="$INCLUDES $FONTCONFIG_CFLAGS"; LIBS="$LIBS $FONTCONFIG_LIBS"],
@@ -747,9 +748,6 @@ PKG_CHECK_MODULES([SAMPLERATE], [samplerate],
   AC_MSG_ERROR($missing_library))
 PKG_CHECK_MODULES([FREETYPE2],  [freetype2],
   [INCLUDES="$INCLUDES $FREETYPE2_CFLAGS"; LIBS="$LIBS $FREETYPE2_LIBS"],
-  AC_MSG_ERROR($missing_library))
-PKG_CHECK_MODULES([TINYXML],   [tinyxml],
-  [INCLUDES="$INCLUDES $TINYXML_CFLAGS"; LIBS="$LIBS $TINYXML_LIBS"],
   AC_MSG_ERROR($missing_library))
 
 # check for libbluray


### PR DESCRIPTION
Tinyxml by default is not shiped with a pkg-config file. Debian added one, archlinux for example not.
