### PR TITLE
fix for error: 'usleep' was not declared

### DIFF
--- a/xbmc/threads/platform/pthreads/ThreadImpl.h
+++ b/xbmc/threads/platform/pthreads/ThreadImpl.h
@@ -22,6 +22,7 @@
 #pragma once
 
 #include <pthread.h>
+#include <unistd.h>
 
 struct threadOpaque
 {


### PR DESCRIPTION
usleep requires unistd.h header or I get this error ThreadImpl.h:38:75: error: 'usleep' was not declared in this scope.
 At least this is happening on my Slackware Linux.
