### PR TITLE
[Confluence] added volume control via slider

### DIFF
--- a/addons/skin.confluence/720p/MusicOSD.xml
+++ b/addons/skin.confluence/720p/MusicOSD.xml
@@ -228,6 +228,86 @@
 				<ondown>1000</ondown>
 			</control>
 		</control>
+			<control type="group">
+					<animation effect="slide" start="0,-40" end="0,0" time="100" condition="Control.HasFocus(608)">Conditional</animation>
+					<animation effect="slide" start="0,0" end="0,-40" delay="400" time="100" condition="!Control.HasFocus(608)">Conditional</animation>
+				<posx>0</posx>
+				<posy>0</posy>
+				<visible allowhiddenfocus="true">Control.HasFocus(608)</visible>
+				<control type="button" id="608">
+					<posx>820</posx>
+					<posy>0</posy>
+					<width>300</width>
+					<height>100</height>
+					<texturefocus>-</texturefocus>
+				</control>
+				<control type="image">
+					<posx>820</posx>
+					<posy>-10</posy>
+					<width>300</width>
+					<height>50</height>
+					<texture flipy="true" border="20,20,20,2">InfoMessagePanel.png</texture>
+				</control>
+				<control type="group">
+						<posx>20</posx>
+						<posy>14</posy>
+					<control type="image">
+						<description>Lite Volume Logo</description>
+						<visible>!player.passthrough</visible>
+						<posx>810</posx>
+						<posy>-14</posy>
+						<width>40</width>
+						<height>35</height>
+						<aspectratio>keep</aspectratio>
+						<texture>VolumeIcon.png</texture>
+					</control>
+					<control type="image">
+						<description>Lite Volume Logo</description>
+						<visible>player.passthrough</visible>
+						<posx>810</posx>
+						<posy>-14</posy>
+						<width>40</width>
+						<height>35</height>
+						<aspectratio>keep</aspectratio>
+						<colordiffuse>CCFF0000</colordiffuse>						
+						<texture>VolumeIcon.png</texture>
+					</control>					
+					<control type="progress" id="1">
+						<description>Progressbar</description>
+						<visible>!player.passthrough</visible>
+						<posx>850</posx>
+						<posy>-6</posy>
+						<width>230</width>
+						<height>18</height>
+						<info>Player.Volume</info>
+						<overlaytexture>-</overlaytexture>
+						<visible>true</visible>
+					</control>
+					<control type="slider">
+						<description>Seek Slider</description>
+						<visible>system.getbool(input.enablemouse)</visible>
+						<posx>850</posx>
+						<posy>-6</posy>
+						<width>230</width>
+						<height>18</height>
+						<action>volume</action>
+					</control>
+					<control type="label">
+						<description>Passthrough Label</description>
+						<visible>player.passthrough</visible>
+						<posx>850</posx>
+						<posy>-8</posy>
+						<width>230</width>
+						<height>20</height>
+						<label>$LOCALIZE[29802]</label>
+						<font>font10_title</font>
+						<textcolor>white</textcolor>
+						<shadowcolor>black</shadowcolor>
+						<align>left</align>
+						<aligny>center</aligny>
+					</control>					
+				</control>
+			</control>		
 		<control type="group">
 			<posx>250r</posx>
 			<posy>50r</posy>

--- a/addons/skin.confluence/720p/VideoOSD.xml
+++ b/addons/skin.confluence/720p/VideoOSD.xml
@@ -141,6 +141,86 @@
 				<onclick>PlayerControl(Next)</onclick>
 			</control>
 		</control>
+			<control type="group">
+					<animation effect="slide" start="0,-40" end="0,0" time="100" condition="Control.HasFocus(608)">Conditional</animation>
+					<animation effect="slide" start="0,0" end="0,-40" delay="400" time="100" condition="!Control.HasFocus(608)">Conditional</animation>
+				<posx>0</posx>
+				<posy>0</posy>
+				<visible allowhiddenfocus="true">Control.HasFocus(608)</visible>
+				<control type="button" id="608">
+					<posx>820</posx>
+					<posy>0</posy>
+					<width>300</width>
+					<height>100</height>
+					<texturefocus>-</texturefocus>
+				</control>
+				<control type="image">
+					<posx>820</posx>
+					<posy>-10</posy>
+					<width>300</width>
+					<height>50</height>
+					<texture flipy="true" border="20,20,20,2">InfoMessagePanel.png</texture>
+				</control>
+				<control type="group">
+						<posx>20</posx>
+						<posy>14</posy>
+					<control type="image">
+						<description>Lite Volume Logo</description>
+						<visible>!player.passthrough</visible>
+						<posx>810</posx>
+						<posy>-14</posy>
+						<width>40</width>
+						<height>35</height>
+						<aspectratio>keep</aspectratio>
+						<texture>VolumeIcon.png</texture>
+					</control>
+					<control type="image">
+						<description>Lite Volume Logo</description>
+						<visible>player.passthrough</visible>
+						<posx>810</posx>
+						<posy>-14</posy>
+						<width>40</width>
+						<height>35</height>
+						<aspectratio>keep</aspectratio>
+						<colordiffuse>CCFF0000</colordiffuse>						
+						<texture>VolumeIcon.png</texture>
+					</control>					
+					<control type="progress" id="1">
+						<description>Progressbar</description>
+						<visible>!player.passthrough</visible>
+						<posx>850</posx>
+						<posy>-6</posy>
+						<width>230</width>
+						<height>18</height>
+						<info>Player.Volume</info>
+						<overlaytexture>-</overlaytexture>
+						<visible>true</visible>
+					</control>
+					<control type="slider">
+						<description>Seek Slider</description>
+						<visible>system.getbool(input.enablemouse)</visible>
+						<posx>850</posx>
+						<posy>-6</posy>
+						<width>230</width>
+						<height>18</height>
+						<action>volume</action>
+					</control>
+					<control type="label">
+						<description>Passthrough Label</description>
+						<visible>player.passthrough</visible>
+						<posx>850</posx>
+						<posy>-8</posy>
+						<width>230</width>
+						<height>20</height>
+						<label>$LOCALIZE[29802]</label>
+						<font>font10_title</font>
+						<textcolor>white</textcolor>
+						<shadowcolor>black</shadowcolor>
+						<align>left</align>
+						<aligny>center</aligny>
+					</control>					
+				</control>
+			</control>		
 		<control type="group">
 			<posx>250r</posx>
 			<posy>50r</posy>


### PR DESCRIPTION
Hey guys,

based on https://github.com/xbmc/xbmc/pull/764, I reworked the volume control to have a slider.
Basically this adds a new group to VideoOSD and MusicOSD that has the same look and feel like
"DialogVolumeBar" but can control the volume.

Unfortunately I do not have a touch device, so I'm not sure if this is suitable for it due to the hidden button.
So maybe someone with a touch device can test and or tell me if it is working.

Or maybe there can be a <visible>!System.Platform.IOS </visible> to avoid confusion there.

Any opinion on this?
Any things that need to be changed?

cheers,
mad-max
