### PR TITLE
[dvdplayer] Fix synchronize timeout with non-flushed seeking.

### DIFF
--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -3040,10 +3040,16 @@ void CDVDPlayer::FlushBuffers(bool queued, double pts, bool accurate)
   {
     m_dvdPlayerAudio.SendMessage(new CDVDMsg(CDVDMsg::GENERAL_RESET));
     m_dvdPlayerVideo.SendMessage(new CDVDMsg(CDVDMsg::GENERAL_RESET));
+    // TODO: Why the VIDEO_NO_SKIP message?
     m_dvdPlayerVideo.SendMessage(new CDVDMsg(CDVDMsg::VIDEO_NOSKIP));
     m_dvdPlayerSubtitle.SendMessage(new CDVDMsg(CDVDMsg::GENERAL_RESET));
     m_dvdPlayerTeletext.SendMessage(new CDVDMsg(CDVDMsg::GENERAL_RESET));
-    SynchronizePlayers(SYNCSOURCE_ALL);
+
+    CDVDMsgGeneralSynchronize* msg = new CDVDMsgGeneralSynchronize(100, SYNCSOURCE_ALL);
+    m_dvdPlayerAudio.SendMessage(msg->Acquire(), 1);
+    m_dvdPlayerVideo.SendMessage(msg->Acquire(), 1);
+    msg->Wait(&m_bStop, 0);
+    msg->Release();
   }
   else
   {


### PR DESCRIPTION
Non-flushed seeking (like used for automatic EDL and commercial break skipping) no longer uses the internal SynchronizePlayers function, which times out waiting for sync in favour of a typical GeneralSynchronize message to both the video and audio players.

@elupus, I've looked at the SynchronizePlayers function for a while now and I can't figure out how it's supposed to work. The only other place SynchronizePlayers is used is when an audio stream is opened and there is already a video stream opened. I'm not even sure if the method would ever work prior to the timeout being triggered.

I've tested the changes with short and long commercial breaks and EDL cuts and this change makes all of those test cases work smoothly again. Looking for a review to see if this is the best way to resolve the problem. Non-flushed seeking is only used by the automatic EDL and CommBreak seeks based on the references I found in dvdplayer.
