### PR TITLE
fire OnUpdate events when the thumb or fanart is updated in the video info

### DIFF
--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -636,7 +636,7 @@ public:
     }
   }
 
-  void SetArtForItem(int mediaId, const std::string &mediaType, const std::string &artType, const std::string &url);
+  void SetArtForItem(int mediaId, const std::string &mediaType, const std::string &artType, const std::string &url, bool announce = false);
   void SetArtForItem(int mediaId, const std::string &mediaType, const std::map<std::string, std::string> &art);
   bool GetArtForItem(int mediaId, const std::string &mediaType, std::map<std::string, std::string> &art);
   std::string GetArtForItem(int mediaId, const std::string &mediaType, const std::string &artType);

--- a/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
@@ -658,7 +658,7 @@ void CGUIDialogVideoInfo::OnGetThumb()
   CVideoDatabase db;
   if (db.Open())
   {
-    db.SetArtForItem(m_movieItem->GetVideoInfoTag()->m_iDbId, m_movieItem->GetVideoInfoTag()->m_type, "thumb", newThumb);
+    db.SetArtForItem(m_movieItem->GetVideoInfoTag()->m_iDbId, m_movieItem->GetVideoInfoTag()->m_type, "thumb", newThumb, true);
     db.Close();
   }
 
@@ -758,7 +758,7 @@ void CGUIDialogVideoInfo::OnGetFanart()
   CVideoDatabase db;
   if (db.Open())
   {
-    db.SetArtForItem(m_movieItem->GetVideoInfoTag()->m_iDbId, m_movieItem->GetVideoInfoTag()->m_type, "fanart", result);
+    db.SetArtForItem(m_movieItem->GetVideoInfoTag()->m_iDbId, m_movieItem->GetVideoInfoTag()->m_type, "fanart", result, true);
     db.Close();
   }
 

--- a/xbmc/video/windows/GUIWindowVideoNav.cpp
+++ b/xbmc/video/windows/GUIWindowVideoNav.cpp
@@ -1215,7 +1215,7 @@ bool CGUIWindowVideoNav::OnContextButton(int itemNumber, CONTEXT_BUTTON button)
       if (button == CONTEXT_BUTTON_SET_MOVIESET_THUMB ||
           button == CONTEXT_BUTTON_SET_ACTOR_THUMB ||
           button == CONTEXT_BUTTON_SET_SEASON_THUMB)
-        m_database.SetArtForItem(m_vecItems->Get(itemNumber)->GetVideoInfoTag()->m_iDbId, m_vecItems->Get(itemNumber)->GetVideoInfoTag()->m_type, "thumb", result);
+        m_database.SetArtForItem(m_vecItems->Get(itemNumber)->GetVideoInfoTag()->m_iDbId, m_vecItems->Get(itemNumber)->GetVideoInfoTag()->m_type, "thumb", result, true);
       else
       {
         CTextureCache::Get().ClearCachedImage(cachedThumb, true);

--- a/xbmc/windows/GUIWindowHome.cpp
+++ b/xbmc/windows/GUIWindowHome.cpp
@@ -69,6 +69,8 @@ void CGUIWindowHome::Announce(AnnouncementFlag flag, const char *sender, const c
     {
       if (data.isMember("playcount"))
         ra_flag |= Totals;
+      if (data.isMember("thumb") || data.isMember("fanart"))
+        ra_flag |= Video;
     }
     else if (strcmp(message, "OnScanFinished") == 0)
     {


### PR DESCRIPTION
This fixes #13005.  Done as a PR, as I think it would be useful to work out exactly when we're going to fire these events and what they should contain.

ATM I'm doing it somewhat similar to the playcount one, just specifying that "art" has changed (and specified whether it was thumb or fanart).  The same thing will also be required I suspect in the "Set Thumb" in context menu.

@Montellese Any comments?
