### PR TITLE
Fix bt keyboard input for apple tv 2 (ios) to support unicode input

### DIFF
--- a/xbmc/osx/atv2/XBMCController.mm
+++ b/xbmc/osx/atv2/XBMCController.mm
@@ -598,7 +598,7 @@ int           m_systemsleepTimeout;
             else
             {
               newEvent.key.keysym.sym = (XBMCKey)wstr[0];
-              newEvent.key.keysym.unicode = wstr[0];
+              newEvent.key.keysym.unicode = wstr[0] | (wstr[1] << 8);
             }
             newEvent.type = XBMC_KEYDOWN;
             CWinEventsIOS::MessagePush(&newEvent);


### PR DESCRIPTION
This fixes a but when keyboard input was treated as single byte. I'm making a fix for bt keyboard support as well to enable input using non-English keyboard layouts.
