### PR TITLE
[osx/ios] refactor depends build and switchover to using 10.6sdk for osx

### DIFF
--- a/XBMC-ATV2.xcodeproj/project.pbxproj
+++ b/XBMC-ATV2.xcodeproj/project.pbxproj
@@ -3100,10 +3100,10 @@
 			children = (
 				DFC539391526659D00D5FD5C /* AppIcon.png */,
 				8316267513B670D7004AED87 /* Documentation */,
-				F589AE6D12890B6700D8079E /* Internal Libs */,
-				19C28FB6FE9D52B211CA2CBB /* Products */,
 				F56C704E131EC150000AD0F6 /* Source */,
+				F589AE6D12890B6700D8079E /* Internal Libs */,
 				F5899DC91287212700D8079E /* System Libs and Frameworks */,
+				19C28FB6FE9D52B211CA2CBB /* Products */,
 			);
 			name = "XBMC-frapp";
 			sourceTree = "<group>";
@@ -6239,7 +6239,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/bash;
-			shellScript = "#set -x\n\nfunction check_dyloaded_depends\n{\n  b=$(find \"$EXTERNAL_LIBS\" -name $1 -print)\n  if [ -f \"$b\" ]; then\n    #echo \"Processing $b\"\n    if [ ! -f  \"$TARGET_FRAMEWORKS/$(basename $b)\" ]; then\n      echo \"    Packaging $b\"\n      cp -f \"$b\" \"$TARGET_FRAMEWORKS/\"\n      chmod u+w \"$TARGET_FRAMEWORKS/$(basename $b)\"\n    fi\n    for a in $(otool -L \"$b\"  | grep \"$EXTERNAL_LIBS\" | awk ' { print $1 } ') ; do\n      if [ -f \"$a\" ]; then\n        if [ ! -f  \"$TARGET_FRAMEWORKS/$(basename $a)\" ]; then\n          echo \"    Packaging $a\"\n          cp -f \"$a\" \"$TARGET_FRAMEWORKS/\"\n          chmod u+w \"$TARGET_FRAMEWORKS/$(basename $a)\"\n          install_name_tool -change \"$a\" \"$DYLIB_NAMEPATH/$(basename $a)\" \"$TARGET_FRAMEWORKS/$(basename $b)\"\n        fi\n      fi\n    done \n  fi\n}\n\nfunction check_xbmc_dylib_depends\n{\n  REWIND=\"1\"\n  while [ $REWIND = \"1\" ]\n  do\n    let REWIND=\"0\"\n    for b in $(find \"$1\" -name \"$2\" -print) ; do\n      #echo \"Processing $b\"\n      for a in $(otool -L \"$b\"  | grep \"$EXTERNAL_LIBS\" | awk ' { print $1 } ') ; do\n        #echo \"    Packaging $a\"\n        if [ ! -f  \"$TARGET_FRAMEWORKS/$(basename $a)\" ]; then\n          echo \"    Packaging $a\"\n          cp -f \"$a\" \"$TARGET_FRAMEWORKS/\"\n          chmod u+w \"$TARGET_FRAMEWORKS/$(basename $a)\"\n          let REWIND=\"1\"\n        fi\n        install_name_tool -change \"$a\" \"$DYLIB_NAMEPATH/$(basename $a)\" \"$b\"\n      done\n    done\n  done\n}\n\nEXTERNAL_LIBS=/Users/Shared/xbmc-depends/ios-4.2_armv7\n\nTARGET_NAME=$PRODUCT_NAME.$WRAPPER_EXTENSION\nTARGET_CONTENTS=$TARGET_BUILD_DIR/$TARGET_NAME\n\nTARGET_BINARY=$TARGET_CONTENTS/XBMC\nTARGET_FRAMEWORKS=$TARGET_CONTENTS/Frameworks\nDYLIB_NAMEPATH=@executable_path/Appliances/XBMC.frappliance/Frameworks\nXBMC_HOME=$TARGET_CONTENTS/XBMCData/XBMCHome\n\nmkdir -p \"$TARGET_CONTENTS\"\nmkdir -p \"$TARGET_CONTENTS/XBMCData/XBMCHome\"\n# start clean so we don't keep old dylibs\nrm -rf \"$TARGET_CONTENTS/Frameworks\"\nmkdir -p \"$TARGET_CONTENTS/Frameworks\"\n\necho \"Package $TARGET_BUILD_DIR/XBMC\"\n\n# Copy all of XBMC's dylib dependencies and rename their locations to inside the Framework\necho \"Checking $TARGET_BINARY dylib dependencies\"\nfor a in $(otool -L \"$TARGET_BINARY\"  | grep \"$EXTERNAL_LIBS\" | awk ' { print $1 } ') ; do \n\techo \"    Packaging $a\"\n\tcp -f \"$a\" \"$TARGET_FRAMEWORKS/\"\n\tchmod u+w \"$TARGET_FRAMEWORKS/$(basename $a)\"\n\tinstall_name_tool -change \"$a\" \"$DYLIB_NAMEPATH/$(basename $a)\" \"$TARGET_BINARY\"\ndone\n\necho \"Package $EXTERNAL_LIBS/lib/python2.6\"\nmkdir -p \"$TARGET_CONTENTS/Frameworks/lib\"\nPYTHONSYNC=\"rsync -aq --exclude .DS_Store --exclude *.a --exclude *.exe --exclude test --exclude tests\"\n${PYTHONSYNC} \"$EXTERNAL_LIBS/lib/python2.6\" \"$TARGET_FRAMEWORKS/lib/\"\nrm -rf \"$TARGET_FRAMEWORKS/lib/python2.6/config\"\n\necho \"Checking $TARGET_FRAMEWORKS/lib/python2.6 *.so for dylib dependencies\"\ncheck_xbmc_dylib_depends \"$TARGET_FRAMEWORKS\"/lib/python2.6 \"*.so\"\n\necho \"Checking $XBMC_HOME/system *.so for dylib dependencies\"\ncheck_xbmc_dylib_depends \"$XBMC_HOME\"/system \"*.so\"\n\necho \"Checking $XBMC_HOME/addons *.so for dylib dependencies\"\ncheck_xbmc_dylib_depends \"$XBMC_HOME\"/addons \"*.so\"\n\necho \"Checking $XBMC_HOME/addons *.xbs for dylib dependencies\"\ncheck_xbmc_dylib_depends \"$XBMC_HOME\"/addons \"*.xbs\"\n\necho \"Checking xbmc/DllPaths_generated.h for dylib dependencies\"\nfor a in $(grep .dylib \"$SRCROOT\"/xbmc/DllPaths_generated.h | awk '{print $3}' | sed s/\\\"//g) ; do\n  check_dyloaded_depends $a\ndone\n\necho \"Checking $TARGET_FRAMEWORKS for missing dylib dependencies\"\nREWIND=\"1\"\nwhile [ $REWIND = \"1\" ]\ndo\n\tlet REWIND=\"0\"\n\tfor b in \"$TARGET_FRAMEWORKS/\"*dylib* ; do\n\t\t#echo \"  Processing $b\"\n\t\tfor a in $(otool -L \"$b\"  | grep \"$EXTERNAL_LIBS\" | awk ' { print $1 } ') ; do\n\t\t\t#echo \"Processing $a\"\n\t\t\tif [ ! -f  \"$TARGET_FRAMEWORKS/$(basename $a)\" ]; then\n\t\t\t\techo \"    Packaging $a\"\n\t\t\t\tcp -f \"$a\" \"$TARGET_FRAMEWORKS/\"\n\t\t\t\tchmod u+w \"$TARGET_FRAMEWORKS/$(basename $a)\"\n\t\t\t\tlet REWIND=\"1\"\n\t\t\tfi\n\t\t\tinstall_name_tool -change \"$a\" \"$DYLIB_NAMEPATH/$(basename $a)\" \"$TARGET_FRAMEWORKS/$(basename $b)\"\n\t\tdone \n\tdone\ndone\n";
+			shellScript = "#set -x\n\nfunction check_dyloaded_depends\n{\n  b=$(find \"$EXTERNAL_LIBS\" -name $1 -print)\n  if [ -f \"$b\" ]; then\n    #echo \"Processing $b\"\n    if [ ! -f  \"$TARGET_FRAMEWORKS/$(basename $b)\" ]; then\n      echo \"    Packaging $b\"\n      cp -f \"$b\" \"$TARGET_FRAMEWORKS/\"\n      chmod u+w \"$TARGET_FRAMEWORKS/$(basename $b)\"\n    fi\n    for a in $(otool -L \"$b\"  | grep \"$EXTERNAL_LIBS\" | awk ' { print $1 } ') ; do\n      if [ -f \"$a\" ]; then\n        if [ ! -f  \"$TARGET_FRAMEWORKS/$(basename $a)\" ]; then\n          echo \"    Packaging $a\"\n          cp -f \"$a\" \"$TARGET_FRAMEWORKS/\"\n          chmod u+w \"$TARGET_FRAMEWORKS/$(basename $a)\"\n          install_name_tool -change \"$a\" \"$DYLIB_NAMEPATH/$(basename $a)\" \"$TARGET_FRAMEWORKS/$(basename $b)\"\n        fi\n      fi\n    done \n  fi\n}\n\nfunction check_xbmc_dylib_depends\n{\n  REWIND=\"1\"\n  while [ $REWIND = \"1\" ]\n  do\n    let REWIND=\"0\"\n    for b in $(find \"$1\" -name \"$2\" -print) ; do\n      #echo \"Processing $b\"\n      for a in $(otool -L \"$b\"  | grep \"$EXTERNAL_LIBS\" | awk ' { print $1 } ') ; do\n        #echo \"    Packaging $a\"\n        if [ ! -f  \"$TARGET_FRAMEWORKS/$(basename $a)\" ]; then\n          echo \"    Packaging $a\"\n          cp -f \"$a\" \"$TARGET_FRAMEWORKS/\"\n          chmod u+w \"$TARGET_FRAMEWORKS/$(basename $a)\"\n          let REWIND=\"1\"\n        fi\n        install_name_tool -change \"$a\" \"$DYLIB_NAMEPATH/$(basename $a)\" \"$b\"\n      done\n    done\n  done\n}\n\nEXTERNAL_LIBS=/Users/Shared/xbmc-depends/\"$SDK_NAME\"_\"$ARCHS\"\n\nTARGET_NAME=$PRODUCT_NAME.$WRAPPER_EXTENSION\nTARGET_CONTENTS=$TARGET_BUILD_DIR/$TARGET_NAME\n\nTARGET_BINARY=$TARGET_CONTENTS/XBMC\nTARGET_FRAMEWORKS=$TARGET_CONTENTS/Frameworks\nDYLIB_NAMEPATH=@executable_path/Appliances/XBMC.frappliance/Frameworks\nXBMC_HOME=$TARGET_CONTENTS/XBMCData/XBMCHome\n\nmkdir -p \"$TARGET_CONTENTS\"\nmkdir -p \"$TARGET_CONTENTS/XBMCData/XBMCHome\"\n# start clean so we don't keep old dylibs\nrm -rf \"$TARGET_CONTENTS/Frameworks\"\nmkdir -p \"$TARGET_CONTENTS/Frameworks\"\n\necho \"Package $TARGET_BUILD_DIR/XBMC\"\n\n# Copy all of XBMC's dylib dependencies and rename their locations to inside the Framework\necho \"Checking $TARGET_BINARY dylib dependencies\"\nfor a in $(otool -L \"$TARGET_BINARY\"  | grep \"$EXTERNAL_LIBS\" | awk ' { print $1 } ') ; do \n\techo \"    Packaging $a\"\n\tcp -f \"$a\" \"$TARGET_FRAMEWORKS/\"\n\tchmod u+w \"$TARGET_FRAMEWORKS/$(basename $a)\"\n\tinstall_name_tool -change \"$a\" \"$DYLIB_NAMEPATH/$(basename $a)\" \"$TARGET_BINARY\"\ndone\n\necho \"Package $EXTERNAL_LIBS/lib/python2.6\"\nmkdir -p \"$TARGET_CONTENTS/Frameworks/lib\"\nPYTHONSYNC=\"rsync -aq --exclude .DS_Store --exclude *.a --exclude *.exe --exclude test --exclude tests\"\n${PYTHONSYNC} \"$EXTERNAL_LIBS/lib/python2.6\" \"$TARGET_FRAMEWORKS/lib/\"\nrm -rf \"$TARGET_FRAMEWORKS/lib/python2.6/config\"\n\necho \"Checking $TARGET_FRAMEWORKS/lib/python2.6 *.so for dylib dependencies\"\ncheck_xbmc_dylib_depends \"$TARGET_FRAMEWORKS\"/lib/python2.6 \"*.so\"\n\necho \"Checking $XBMC_HOME/system *.so for dylib dependencies\"\ncheck_xbmc_dylib_depends \"$XBMC_HOME\"/system \"*.so\"\n\necho \"Checking $XBMC_HOME/addons *.so for dylib dependencies\"\ncheck_xbmc_dylib_depends \"$XBMC_HOME\"/addons \"*.so\"\n\necho \"Checking $XBMC_HOME/addons *.xbs for dylib dependencies\"\ncheck_xbmc_dylib_depends \"$XBMC_HOME\"/addons \"*.xbs\"\n\necho \"Checking xbmc/DllPaths_generated.h for dylib dependencies\"\nfor a in $(grep .dylib \"$SRCROOT\"/xbmc/DllPaths_generated.h | awk '{print $3}' | sed s/\\\"//g) ; do\n  check_dyloaded_depends $a\ndone\n\necho \"Checking $TARGET_FRAMEWORKS for missing dylib dependencies\"\nREWIND=\"1\"\nwhile [ $REWIND = \"1\" ]\ndo\n\tlet REWIND=\"0\"\n\tfor b in \"$TARGET_FRAMEWORKS/\"*dylib* ; do\n\t\t#echo \"  Processing $b\"\n\t\tfor a in $(otool -L \"$b\"  | grep \"$EXTERNAL_LIBS\" | awk ' { print $1 } ') ; do\n\t\t\t#echo \"Processing $a\"\n\t\t\tif [ ! -f  \"$TARGET_FRAMEWORKS/$(basename $a)\" ]; then\n\t\t\t\techo \"    Packaging $a\"\n\t\t\t\tcp -f \"$a\" \"$TARGET_FRAMEWORKS/\"\n\t\t\t\tchmod u+w \"$TARGET_FRAMEWORKS/$(basename $a)\"\n\t\t\t\tlet REWIND=\"1\"\n\t\t\tfi\n\t\t\tinstall_name_tool -change \"$a\" \"$DYLIB_NAMEPATH/$(basename $a)\" \"$TARGET_FRAMEWORKS/$(basename $b)\"\n\t\tdone \n\tdone\ndone\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -7321,7 +7321,7 @@
 				TARGETED_DEVICE_FAMILY = "2,3";
 				USER_HEADER_SEARCH_PATHS = "$XBMC_DEPENDS/include $XBMC_DEPENDS/include/mysql $XBMC_DEPENDS/include/freetype2 $XBMC_DEPENDS/include/python2.6";
 				WRAPPER_EXTENSION = frappliance;
-				XBMC_DEPENDS = "/Users/Shared/xbmc-depends/ios-4.2_armv7";
+				XBMC_DEPENDS = "/Users/Shared/xbmc-depends/$(SDK_NAME)_$(ARCHS)";
 			};
 			name = Debug;
 		};
@@ -7437,7 +7437,7 @@
 				TARGETED_DEVICE_FAMILY = "2,3";
 				USER_HEADER_SEARCH_PATHS = "$XBMC_DEPENDS/include $XBMC_DEPENDS/include/mysql $XBMC_DEPENDS/include/freetype2 $XBMC_DEPENDS/include/python2.6";
 				WRAPPER_EXTENSION = frappliance;
-				XBMC_DEPENDS = "/Users/Shared/xbmc-depends/ios-4.2_armv7";
+				XBMC_DEPENDS = "/Users/Shared/xbmc-depends/$(SDK_NAME)_$(ARCHS)";
 			};
 			name = Release;
 		};
@@ -7449,7 +7449,7 @@
 				GCC_OPTIMIZATION_LEVEL = 0;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 4.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 4.2;
 				ONLY_ACTIVE_ARCH = NO;
 				PREBINDING = NO;
 				SDKROOT = iphoneos;
@@ -7468,7 +7468,7 @@
 				GCC_OPTIMIZATION_LEVEL = s;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 4.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 4.2;
 				ONLY_ACTIVE_ARCH = NO;
 				PREBINDING = NO;
 				SDKROOT = iphoneos;

--- a/XBMC-IOS.xcodeproj/project.pbxproj
+++ b/XBMC-IOS.xcodeproj/project.pbxproj
@@ -1623,7 +1623,6 @@
 		F56C81F2131F42E6000AD0F6 /* EncoderVorbis.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EncoderVorbis.h; sourceTree = "<group>"; };
 		F56C81F3131F42E6000AD0F6 /* EncoderWav.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = EncoderWav.cpp; sourceTree = "<group>"; };
 		F56C81F4131F42E6000AD0F6 /* EncoderWav.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EncoderWav.h; sourceTree = "<group>"; };
-		F56C81F6131F42E6000AD0F6 /* lame.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = lame.h; sourceTree = "<group>"; };
 		F56C8207131F42E6000AD0F6 /* coff.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = coff.cpp; sourceTree = "<group>"; };
 		F56C8208131F42E6000AD0F6 /* coff.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = coff.h; sourceTree = "<group>"; };
 		F56C8209131F42E6000AD0F6 /* coffldr.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = coffldr.h; sourceTree = "<group>"; };
@@ -3098,10 +3097,10 @@
 			isa = PBXGroup;
 			children = (
 				83D619BA13C0D23400418A0F /* Documentation */,
-				F589AE6D12890B6700D8079E /* Internal Libs */,
-				19C28FB6FE9D52B211CA2CBB /* Products */,
 				F56C8034131F42E5000AD0F6 /* Source */,
+				F589AE6D12890B6700D8079E /* Internal Libs */,
 				F5899DC91287212700D8079E /* System Libs and Frameworks */,
+				19C28FB6FE9D52B211CA2CBB /* Products */,
 			);
 			name = "XBMC-frapp";
 			sourceTree = "<group>";
@@ -5996,9 +5995,9 @@
 				F56B14A412CAF523009B4C96 /* AudioToolbox.framework */,
 				4D5D2E1D1301758F006ABC13 /* CFNetwork.framework */,
 				3255316512B2D02400837CD2 /* CoreAudio.framework */,
-				F56B15D412CD67A9009B4C96 /* CoreGraphics.framework */,
-				F5A29EC212A7221B003A610C /* CoreMedia.framework */,
 				F56B143312CAF279009B4C96 /* CoreVideo.framework */,
+				F5A29EC212A7221B003A610C /* CoreMedia.framework */,
+				F56B15D412CD67A9009B4C96 /* CoreGraphics.framework */,
 				F5899DCD1287212700D8079E /* Foundation.framework */,
 				F56B160712CD6999009B4C96 /* ImageIO.framework */,
 				F5899DCB1287212700D8079E /* OpenGLES.framework */,
@@ -6251,7 +6250,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/bash;
-			shellScript = "#set -x\n\nfunction check_dyloaded_depends\n{\n  b=$(find \"$EXTERNAL_LIBS\" -name $1 -print)\n  if [ -f \"$b\" ]; then\n    #echo \"Processing $b\"\n    if [ ! -f  \"$TARGET_FRAMEWORKS/$(basename $b)\" ]; then\n      echo \"    Packaging $b\"\n      cp -f \"$b\" \"$TARGET_FRAMEWORKS/\"\n      chmod u+w \"$TARGET_FRAMEWORKS/$(basename $b)\"\n    fi\n    for a in $(otool -L \"$b\"  | grep \"$EXTERNAL_LIBS\" | awk ' { print $1 } ') ; do\n      if [ -f \"$a\" ]; then\n        if [ ! -f  \"$TARGET_FRAMEWORKS/$(basename $a)\" ]; then\n          echo \"    Packaging $a\"\n          cp -f \"$a\" \"$TARGET_FRAMEWORKS/\"\n          chmod u+w \"$TARGET_FRAMEWORKS/$(basename $a)\"\n          install_name_tool -change \"$a\" \"$DYLIB_NAMEPATH/$(basename $a)\" \"$TARGET_FRAMEWORKS/$(basename $b)\"\n        fi\n      fi\n    done \n  fi\n}\n\nfunction check_xbmc_dylib_depends\n{\n  REWIND=\"1\"\n  while [ $REWIND = \"1\" ]\n  do\n    let REWIND=\"0\"\n    for b in $(find \"$1\" -name \"$2\" -print) ; do\n      #echo \"Processing $b\"\n      for a in $(otool -L \"$b\"  | grep \"$EXTERNAL_LIBS\" | awk ' { print $1 } ') ; do\n        #echo \"    Packaging $a\"\n        if [ ! -f  \"$TARGET_FRAMEWORKS/$(basename $a)\" ]; then\n          echo \"    Packaging $a\"\n          cp -f \"$a\" \"$TARGET_FRAMEWORKS/\"\n          chmod u+w \"$TARGET_FRAMEWORKS/$(basename $a)\"\n          let REWIND=\"1\"\n        fi\n        install_name_tool -change \"$a\" \"$DYLIB_NAMEPATH/$(basename $a)\" \"$b\"\n      done\n    done\n  done\n}\n\nEXTERNAL_LIBS=/Users/Shared/xbmc-depends/ios-4.2_armv7\n\nTARGET_NAME=$PRODUCT_NAME.$WRAPPER_EXTENSION\nTARGET_CONTENTS=$TARGET_BUILD_DIR/$TARGET_NAME\n\nTARGET_BINARY=$TARGET_CONTENTS/XBMC\nTARGET_FRAMEWORKS=$TARGET_CONTENTS/Frameworks\nDYLIB_NAMEPATH=@executable_path/Frameworks\nXBMC_HOME=$TARGET_CONTENTS/XBMCData/XBMCHome\n\nmkdir -p \"$TARGET_CONTENTS\"\nmkdir -p \"$TARGET_CONTENTS/XBMCData/XBMCHome\"\n# start clean so we don't keep old dylibs\nrm -rf \"$TARGET_CONTENTS/Frameworks\"\nmkdir -p \"$TARGET_CONTENTS/Frameworks\"\n\necho \"Package $TARGET_BUILD_DIR/XBMC\"\n\n# Copy all of XBMC's dylib dependencies and rename their locations to inside the Framework\necho \"Checking $TARGET_BINARY dylib dependencies\"\nfor a in $(otool -L \"$TARGET_BINARY\"  | grep \"$EXTERNAL_LIBS\" | awk ' { print $1 } ') ; do \n\techo \"    Packaging $a\"\n\tcp -f \"$a\" \"$TARGET_FRAMEWORKS/\"\n\tchmod u+w \"$TARGET_FRAMEWORKS/$(basename $a)\"\n\tinstall_name_tool -change \"$a\" \"$DYLIB_NAMEPATH/$(basename $a)\" \"$TARGET_BINARY\"\ndone\n\necho \"Package $EXTERNAL_LIBS/lib/python2.6\"\nmkdir -p \"$TARGET_CONTENTS/Frameworks/lib\"\nPYTHONSYNC=\"rsync -aq --exclude .DS_Store --exclude *.a --exclude *.exe --exclude test --exclude tests\"\n${PYTHONSYNC} \"$EXTERNAL_LIBS/lib/python2.6\" \"$TARGET_FRAMEWORKS/lib/\"\nrm -rf \"$TARGET_FRAMEWORKS/lib/python2.6/config\"\n\necho \"Checking $TARGET_FRAMEWORKS/lib/python2.6 *.so for dylib dependencies\"\ncheck_xbmc_dylib_depends \"$TARGET_FRAMEWORKS\"/lib/python2.6 \"*.so\"\n\necho \"Checking $XBMC_HOME/system *.so for dylib dependencies\"\ncheck_xbmc_dylib_depends \"$XBMC_HOME\"/system \"*.so\"\n\necho \"Checking $XBMC_HOME/addons *.so for dylib dependencies\"\ncheck_xbmc_dylib_depends \"$XBMC_HOME\"/addons \"*.so\"\n\necho \"Checking $XBMC_HOME/addons *.xbs for dylib dependencies\"\ncheck_xbmc_dylib_depends \"$XBMC_HOME\"/addons \"*.xbs\"\n\necho \"Checking xbmc/DllPaths_generated.h for dylib dependencies\"\nfor a in $(grep .dylib \"$SRCROOT\"/xbmc/DllPaths_generated.h | awk '{print $3}' | sed s/\\\"//g) ; do\n  check_dyloaded_depends $a\ndone\n\necho \"Checking $TARGET_FRAMEWORKS for missing dylib dependencies\"\nREWIND=\"1\"\nwhile [ $REWIND = \"1\" ]\ndo\n\tlet REWIND=\"0\"\n\tfor b in \"$TARGET_FRAMEWORKS/\"*dylib* ; do\n\t\t#echo \"  Processing $b\"\n\t\tfor a in $(otool -L \"$b\"  | grep \"$EXTERNAL_LIBS\" | awk ' { print $1 } ') ; do\n\t\t\t#echo \"Processing $a\"\n\t\t\tif [ ! -f  \"$TARGET_FRAMEWORKS/$(basename $a)\" ]; then\n\t\t\t\techo \"    Packaging $a\"\n\t\t\t\tcp -f \"$a\" \"$TARGET_FRAMEWORKS/\"\n\t\t\t\tchmod u+w \"$TARGET_FRAMEWORKS/$(basename $a)\"\n\t\t\t\tlet REWIND=\"1\"\n\t\t\tfi\n\t\t\tinstall_name_tool -change \"$a\" \"$DYLIB_NAMEPATH/$(basename $a)\" \"$TARGET_FRAMEWORKS/$(basename $b)\"\n\t\tdone \n\tdone\ndone\n";
+			shellScript = "#set -x\n\nfunction check_dyloaded_depends\n{\n  b=$(find \"$EXTERNAL_LIBS\" -name $1 -print)\n  if [ -f \"$b\" ]; then\n    #echo \"Processing $b\"\n    if [ ! -f  \"$TARGET_FRAMEWORKS/$(basename $b)\" ]; then\n      echo \"    Packaging $b\"\n      cp -f \"$b\" \"$TARGET_FRAMEWORKS/\"\n      chmod u+w \"$TARGET_FRAMEWORKS/$(basename $b)\"\n    fi\n    for a in $(otool -L \"$b\"  | grep \"$EXTERNAL_LIBS\" | awk ' { print $1 } ') ; do\n      if [ -f \"$a\" ]; then\n        if [ ! -f  \"$TARGET_FRAMEWORKS/$(basename $a)\" ]; then\n          echo \"    Packaging $a\"\n          cp -f \"$a\" \"$TARGET_FRAMEWORKS/\"\n          chmod u+w \"$TARGET_FRAMEWORKS/$(basename $a)\"\n          install_name_tool -change \"$a\" \"$DYLIB_NAMEPATH/$(basename $a)\" \"$TARGET_FRAMEWORKS/$(basename $b)\"\n        fi\n      fi\n    done \n  fi\n}\n\nfunction check_xbmc_dylib_depends\n{\n  REWIND=\"1\"\n  while [ $REWIND = \"1\" ]\n  do\n    let REWIND=\"0\"\n    for b in $(find \"$1\" -name \"$2\" -print) ; do\n      #echo \"Processing $b\"\n      for a in $(otool -L \"$b\"  | grep \"$EXTERNAL_LIBS\" | awk ' { print $1 } ') ; do\n        #echo \"    Packaging $a\"\n        if [ ! -f  \"$TARGET_FRAMEWORKS/$(basename $a)\" ]; then\n          echo \"    Packaging $a\"\n          cp -f \"$a\" \"$TARGET_FRAMEWORKS/\"\n          chmod u+w \"$TARGET_FRAMEWORKS/$(basename $a)\"\n          let REWIND=\"1\"\n        fi\n        install_name_tool -change \"$a\" \"$DYLIB_NAMEPATH/$(basename $a)\" \"$b\"\n      done\n    done\n  done\n}\n\nEXTERNAL_LIBS=/Users/Shared/xbmc-depends/\"$SDK_NAME\"_\"$ARCHS\"\n\nTARGET_NAME=$PRODUCT_NAME.$WRAPPER_EXTENSION\nTARGET_CONTENTS=$TARGET_BUILD_DIR/$TARGET_NAME\n\nTARGET_BINARY=$TARGET_CONTENTS/XBMC\nTARGET_FRAMEWORKS=$TARGET_CONTENTS/Frameworks\nDYLIB_NAMEPATH=@executable_path/Frameworks\nXBMC_HOME=$TARGET_CONTENTS/XBMCData/XBMCHome\n\nmkdir -p \"$TARGET_CONTENTS\"\nmkdir -p \"$TARGET_CONTENTS/XBMCData/XBMCHome\"\n# start clean so we don't keep old dylibs\nrm -rf \"$TARGET_CONTENTS/Frameworks\"\nmkdir -p \"$TARGET_CONTENTS/Frameworks\"\n\necho \"Package $TARGET_BUILD_DIR/XBMC\"\n\n# Copy all of XBMC's dylib dependencies and rename their locations to inside the Framework\necho \"Checking $TARGET_BINARY dylib dependencies\"\nfor a in $(otool -L \"$TARGET_BINARY\"  | grep \"$EXTERNAL_LIBS\" | awk ' { print $1 } ') ; do \n\techo \"    Packaging $a\"\n\tcp -f \"$a\" \"$TARGET_FRAMEWORKS/\"\n\tchmod u+w \"$TARGET_FRAMEWORKS/$(basename $a)\"\n\tinstall_name_tool -change \"$a\" \"$DYLIB_NAMEPATH/$(basename $a)\" \"$TARGET_BINARY\"\ndone\n\necho \"Package $EXTERNAL_LIBS/lib/python2.6\"\nmkdir -p \"$TARGET_CONTENTS/Frameworks/lib\"\nPYTHONSYNC=\"rsync -aq --exclude .DS_Store --exclude *.a --exclude *.exe --exclude test --exclude tests\"\n${PYTHONSYNC} \"$EXTERNAL_LIBS/lib/python2.6\" \"$TARGET_FRAMEWORKS/lib/\"\nrm -rf \"$TARGET_FRAMEWORKS/lib/python2.6/config\"\n\necho \"Checking $TARGET_FRAMEWORKS/lib/python2.6 *.so for dylib dependencies\"\ncheck_xbmc_dylib_depends \"$TARGET_FRAMEWORKS\"/lib/python2.6 \"*.so\"\n\necho \"Checking $XBMC_HOME/system *.so for dylib dependencies\"\ncheck_xbmc_dylib_depends \"$XBMC_HOME\"/system \"*.so\"\n\necho \"Checking $XBMC_HOME/addons *.so for dylib dependencies\"\ncheck_xbmc_dylib_depends \"$XBMC_HOME\"/addons \"*.so\"\n\necho \"Checking $XBMC_HOME/addons *.xbs for dylib dependencies\"\ncheck_xbmc_dylib_depends \"$XBMC_HOME\"/addons \"*.xbs\"\n\necho \"Checking xbmc/DllPaths_generated.h for dylib dependencies\"\nfor a in $(grep .dylib \"$SRCROOT\"/xbmc/DllPaths_generated.h | awk '{print $3}' | sed s/\\\"//g) ; do\n  check_dyloaded_depends $a\ndone\n\necho \"Checking $TARGET_FRAMEWORKS for missing dylib dependencies\"\nREWIND=\"1\"\nwhile [ $REWIND = \"1\" ]\ndo\n\tlet REWIND=\"0\"\n\tfor b in \"$TARGET_FRAMEWORKS/\"*dylib* ; do\n\t\t#echo \"  Processing $b\"\n\t\tfor a in $(otool -L \"$b\"  | grep \"$EXTERNAL_LIBS\" | awk ' { print $1 } ') ; do\n\t\t\t#echo \"Processing $a\"\n\t\t\tif [ ! -f  \"$TARGET_FRAMEWORKS/$(basename $a)\" ]; then\n\t\t\t\techo \"    Packaging $a\"\n\t\t\t\tcp -f \"$a\" \"$TARGET_FRAMEWORKS/\"\n\t\t\t\tchmod u+w \"$TARGET_FRAMEWORKS/$(basename $a)\"\n\t\t\t\tlet REWIND=\"1\"\n\t\t\tfi\n\t\t\tinstall_name_tool -change \"$a\" \"$DYLIB_NAMEPATH/$(basename $a)\" \"$TARGET_FRAMEWORKS/$(basename $b)\"\n\t\tdone \n\tdone\ndone\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -7330,7 +7329,7 @@
 				USER_HEADER_SEARCH_PATHS = "$XBMC_DEPENDS/include $XBMC_DEPENDS/include/mysql $XBMC_DEPENDS/include/freetype2 $XBMC_DEPENDS/include/python2.6";
 				VALIDATE_PRODUCT = NO;
 				WRAPPER_EXTENSION = app;
-				XBMC_DEPENDS = "/Users/Shared/xbmc-depends/ios-4.2_armv7";
+				XBMC_DEPENDS = "/Users/Shared/xbmc-depends/$(SDK_NAME)_$(ARCHS)";
 			};
 			name = Debug;
 		};
@@ -7445,7 +7444,7 @@
 				USER_HEADER_SEARCH_PATHS = "$XBMC_DEPENDS/include $XBMC_DEPENDS/include/mysql $XBMC_DEPENDS/include/freetype2 $XBMC_DEPENDS/include/python2.6";
 				VALIDATE_PRODUCT = NO;
 				WRAPPER_EXTENSION = app;
-				XBMC_DEPENDS = "/Users/Shared/xbmc-depends/ios-4.2_armv7";
+				XBMC_DEPENDS = "/Users/Shared/xbmc-depends/$(SDK_NAME)_$(ARCHS)";
 			};
 			name = Release;
 		};
@@ -7461,7 +7460,7 @@
 				GCC_THUMB_SUPPORT = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 4.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 4.2;
 				ONLY_ACTIVE_ARCH = NO;
 				OTHER_CFLAGS = "";
 				OTHER_LDFLAGS = "";
@@ -7485,7 +7484,7 @@
 				GCC_THUMB_SUPPORT = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 4.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 4.2;
 				ONLY_ACTIVE_ARCH = NO;
 				OTHER_CFLAGS = "";
 				OTHER_LDFLAGS = "";

--- a/XBMC.xcodeproj/project.pbxproj
+++ b/XBMC.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 45;
+	objectVersion = 46;
 	objects = {
 
 /* Begin PBXAggregateTarget section */
@@ -21,76 +21,36 @@
 			name = XBMC.app;
 			productName = XBMC.app;
 		};
-		F5A1CBDB0F6B0B4700A96ABD /* XBMC_ppc.app */ = {
-			isa = PBXAggregateTarget;
-			buildConfigurationList = F5A1CBE10F6B0B4700A96ABD /* Build configuration list for PBXAggregateTarget "XBMC_ppc.app" */;
-			buildPhases = (
-				F5A1CBDE0F6B0B4700A96ABD /* copy root files */,
-				F5A1CBDF0F6B0B4700A96ABD /* copy frameworks */,
-				F5A1CBE00F6B0B4700A96ABD /* update version info */,
-			);
-			dependencies = (
-				F5A1CBE60F6B0BFB00A96ABD /* PBXTargetDependency */,
-			);
-			name = XBMC_ppc.app;
-			productName = XBMC.app;
-		};
 /* End PBXAggregateTarget section */
 
 /* Begin PBXBuildFile section */
 		1830212813B8E2DC00770920 /* controledit.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1830212713B8E2DC00770920 /* controledit.cpp */; };
-		1830212913B8E2DC00770920 /* controledit.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1830212713B8E2DC00770920 /* controledit.cpp */; };
 		183C454D130C4D55006AA317 /* xbmcvfsmodule.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 189047D11301DEAB00C11012 /* xbmcvfsmodule.cpp */; settings = {COMPILER_FLAGS = "-I$XBMC_DEPENDS/include/python2.6"; }; };
 		183FDF8A11AF0B0500B81E9C /* PluginSource.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 183FDF8811AF0B0500B81E9C /* PluginSource.cpp */; };
-		183FDF8B11AF0B0500B81E9C /* PluginSource.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 183FDF8811AF0B0500B81E9C /* PluginSource.cpp */; };
 		18404DA61396C31B00863BBA /* SlingboxLib.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 18404DA51396C31B00863BBA /* SlingboxLib.a */; };
-		18404E711396E06C00863BBA /* SlingboxLib.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 18404DA51396C31B00863BBA /* SlingboxLib.a */; };
 		1840B74D13993D8A007C848B /* JSONVariantParser.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1840B74B13993D8A007C848B /* JSONVariantParser.cpp */; };
-		1840B74E13993D8A007C848B /* JSONVariantParser.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1840B74B13993D8A007C848B /* JSONVariantParser.cpp */; };
 		1840B75313993DA0007C848B /* JSONVariantWriter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1840B75113993DA0007C848B /* JSONVariantWriter.cpp */; };
-		1840B75413993DA0007C848B /* JSONVariantWriter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1840B75113993DA0007C848B /* JSONVariantWriter.cpp */; };
 		184C472F1296BC6E0006DB3E /* Service.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 184C472D1296BC6E0006DB3E /* Service.cpp */; };
-		184C47301296BC6E0006DB3E /* Service.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 184C472D1296BC6E0006DB3E /* Service.cpp */; };
 		188F75FE152217BC009870CE /* Mime.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 188F75FC152217BC009870CE /* Mime.cpp */; };
-		188F75FF152217BC009870CE /* Mime.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 188F75FC152217BC009870CE /* Mime.cpp */; };
 		188F7602152217DF009870CE /* GUIOperations.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 188F7600152217DF009870CE /* GUIOperations.cpp */; };
-		188F7603152217DF009870CE /* GUIOperations.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 188F7600152217DF009870CE /* GUIOperations.cpp */; };
 		18968DC814155D7C005BA742 /* ApplicationOperations.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18968DC614155D7C005BA742 /* ApplicationOperations.cpp */; };
-		18968DC914155D7C005BA742 /* ApplicationOperations.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18968DC614155D7C005BA742 /* ApplicationOperations.cpp */; };
 		18ACF84313596C9B00B67371 /* RecentlyAddedJob.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18ACF84113596C9B00B67371 /* RecentlyAddedJob.cpp */; };
 		18B4A0021152BFA5001AF8A6 /* Addon.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B49FF11152BFA5001AF8A6 /* Addon.cpp */; };
 		18B4A0041152BFA5001AF8A6 /* fft.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B49FF91152BFA5001AF8A6 /* fft.cpp */; };
 		18B4A0051152BFA5001AF8A6 /* Scraper.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B49FFC1152BFA5001AF8A6 /* Scraper.cpp */; };
 		18B4A0061152BFA5001AF8A6 /* ScreenSaver.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B49FFE1152BFA5001AF8A6 /* ScreenSaver.cpp */; };
 		18B4A0071152BFA5001AF8A6 /* Visualisation.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B4A0001152BFA5001AF8A6 /* Visualisation.cpp */; };
-		18B4A0081152BFA5001AF8A6 /* Addon.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B49FF11152BFA5001AF8A6 /* Addon.cpp */; };
-		18B4A0091152BFA5001AF8A6 /* AddonManager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B49FF41152BFA5001AF8A6 /* AddonManager.cpp */; };
-		18B4A00A1152BFA5001AF8A6 /* fft.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B49FF91152BFA5001AF8A6 /* fft.cpp */; };
-		18B4A00B1152BFA5001AF8A6 /* Scraper.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B49FFC1152BFA5001AF8A6 /* Scraper.cpp */; };
-		18B4A00C1152BFA5001AF8A6 /* ScreenSaver.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B49FFE1152BFA5001AF8A6 /* ScreenSaver.cpp */; };
-		18B4A00D1152BFA5001AF8A6 /* Visualisation.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B4A0001152BFA5001AF8A6 /* Visualisation.cpp */; };
 		18B700E113A6A5750009C1AF /* AddonVersion.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B700DF13A6A5750009C1AF /* AddonVersion.cpp */; };
-		18B700E213A6A5750009C1AF /* AddonVersion.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B700DF13A6A5750009C1AF /* AddonVersion.cpp */; };
 		18B7C3841294203F009E7A26 /* AddonDatabase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C3821294203F009E7A26 /* AddonDatabase.cpp */; };
-		18B7C3851294203F009E7A26 /* AddonDatabase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C3821294203F009E7A26 /* AddonDatabase.cpp */; };
 		18B7C38A12942090009E7A26 /* GUIDialogAddonInfo.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C38612942090009E7A26 /* GUIDialogAddonInfo.cpp */; };
 		18B7C38B12942090009E7A26 /* GUIViewStateAddonBrowser.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C38812942090009E7A26 /* GUIViewStateAddonBrowser.cpp */; };
-		18B7C38C12942090009E7A26 /* GUIDialogAddonInfo.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C38612942090009E7A26 /* GUIDialogAddonInfo.cpp */; };
-		18B7C38D12942090009E7A26 /* GUIViewStateAddonBrowser.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C38812942090009E7A26 /* GUIViewStateAddonBrowser.cpp */; };
 		18B7C392129420E5009E7A26 /* Settings.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C38E129420E5009E7A26 /* Settings.cpp */; };
 		18B7C393129420E5009E7A26 /* SettingsControls.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C390129420E5009E7A26 /* SettingsControls.cpp */; };
-		18B7C394129420E5009E7A26 /* Settings.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C38E129420E5009E7A26 /* Settings.cpp */; };
-		18B7C395129420E5009E7A26 /* SettingsControls.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C390129420E5009E7A26 /* SettingsControls.cpp */; };
 		18B7C39E12942114009E7A26 /* GUIWindowSettings.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C39612942114009E7A26 /* GUIWindowSettings.cpp */; };
 		18B7C39F12942114009E7A26 /* GUIWindowSettingsCategory.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C39812942114009E7A26 /* GUIWindowSettingsCategory.cpp */; };
 		18B7C3A012942114009E7A26 /* GUIWindowSettingsProfile.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C39A12942114009E7A26 /* GUIWindowSettingsProfile.cpp */; };
 		18B7C3A112942114009E7A26 /* GUIWindowSettingsScreenCalibration.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C39C12942114009E7A26 /* GUIWindowSettingsScreenCalibration.cpp */; };
-		18B7C3A212942114009E7A26 /* GUIWindowSettings.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C39612942114009E7A26 /* GUIWindowSettings.cpp */; };
-		18B7C3A312942114009E7A26 /* GUIWindowSettingsCategory.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C39812942114009E7A26 /* GUIWindowSettingsCategory.cpp */; };
-		18B7C3A412942114009E7A26 /* GUIWindowSettingsProfile.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C39A12942114009E7A26 /* GUIWindowSettingsProfile.cpp */; };
-		18B7C3A512942114009E7A26 /* GUIWindowSettingsScreenCalibration.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C39C12942114009E7A26 /* GUIWindowSettingsScreenCalibration.cpp */; };
 		18B7C3A812942132009E7A26 /* AdvancedSettings.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C3A612942132009E7A26 /* AdvancedSettings.cpp */; };
-		18B7C3A912942132009E7A26 /* AdvancedSettings.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C3A612942132009E7A26 /* AdvancedSettings.cpp */; };
 		18B7C7A91294222E009E7A26 /* AnimatedGif.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C7541294222E009E7A26 /* AnimatedGif.cpp */; };
 		18B7C7AB1294222E009E7A26 /* D3DResource.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C7561294222E009E7A26 /* D3DResource.cpp */; };
 		18B7C7AC1294222E009E7A26 /* DDSImage.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C7571294222E009E7A26 /* DDSImage.cpp */; };
@@ -173,88 +133,6 @@
 		18B7C7FB1294222E009E7A26 /* VisibleEffect.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C7A61294222E009E7A26 /* VisibleEffect.cpp */; };
 		18B7C7FC1294222E009E7A26 /* XBTF.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C7A71294222E009E7A26 /* XBTF.cpp */; };
 		18B7C7FD1294222E009E7A26 /* XBTFReader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C7A81294222E009E7A26 /* XBTFReader.cpp */; };
-		18B7C7FE1294222E009E7A26 /* AnimatedGif.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C7541294222E009E7A26 /* AnimatedGif.cpp */; };
-		18B7C8001294222E009E7A26 /* D3DResource.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C7561294222E009E7A26 /* D3DResource.cpp */; };
-		18B7C8011294222E009E7A26 /* DDSImage.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C7571294222E009E7A26 /* DDSImage.cpp */; };
-		18B7C8021294222E009E7A26 /* DirectXGraphics.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C7581294222E009E7A26 /* DirectXGraphics.cpp */; };
-		18B7C8031294222E009E7A26 /* FrameBufferObject.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C7591294222E009E7A26 /* FrameBufferObject.cpp */; };
-		18B7C8041294222E009E7A26 /* GraphicContext.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C75A1294222E009E7A26 /* GraphicContext.cpp */; };
-		18B7C8051294222E009E7A26 /* GUIAudioManager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C75B1294222E009E7A26 /* GUIAudioManager.cpp */; };
-		18B7C8061294222E009E7A26 /* GUIBaseContainer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C75C1294222E009E7A26 /* GUIBaseContainer.cpp */; };
-		18B7C8071294222E009E7A26 /* GUIBorderedImage.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C75D1294222E009E7A26 /* GUIBorderedImage.cpp */; };
-		18B7C8081294222E009E7A26 /* GUIButtonControl.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C75E1294222E009E7A26 /* GUIButtonControl.cpp */; };
-		18B7C80A1294222E009E7A26 /* GUICheckMarkControl.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C7601294222E009E7A26 /* GUICheckMarkControl.cpp */; };
-		18B7C80B1294222E009E7A26 /* GUIColorManager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C7611294222E009E7A26 /* GUIColorManager.cpp */; };
-		18B7C80C1294222E009E7A26 /* GUIControl.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C7621294222E009E7A26 /* GUIControl.cpp */; };
-		18B7C80D1294222E009E7A26 /* GUIControlFactory.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C7631294222E009E7A26 /* GUIControlFactory.cpp */; };
-		18B7C80E1294222E009E7A26 /* GUIControlGroup.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C7641294222E009E7A26 /* GUIControlGroup.cpp */; };
-		18B7C80F1294222E009E7A26 /* GUIControlGroupList.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C7651294222E009E7A26 /* GUIControlGroupList.cpp */; };
-		18B7C8101294222E009E7A26 /* GUIControlProfiler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C7661294222E009E7A26 /* GUIControlProfiler.cpp */; };
-		18B7C8111294222E009E7A26 /* GUIDialog.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C7671294222E009E7A26 /* GUIDialog.cpp */; };
-		18B7C8121294222E009E7A26 /* GUIEditControl.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C7681294222E009E7A26 /* GUIEditControl.cpp */; };
-		18B7C8131294222E009E7A26 /* GUIFadeLabelControl.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C7691294222E009E7A26 /* GUIFadeLabelControl.cpp */; };
-		18B7C8141294222E009E7A26 /* GUIFixedListContainer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C76A1294222E009E7A26 /* GUIFixedListContainer.cpp */; };
-		18B7C8151294222E009E7A26 /* GUIFont.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C76B1294222E009E7A26 /* GUIFont.cpp */; };
-		18B7C8161294222E009E7A26 /* GUIFontManager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C76C1294222E009E7A26 /* GUIFontManager.cpp */; };
-		18B7C8171294222E009E7A26 /* GUIFontTTF.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C76D1294222E009E7A26 /* GUIFontTTF.cpp */; };
-		18B7C8181294222E009E7A26 /* GUIFontTTFDX.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C76E1294222E009E7A26 /* GUIFontTTFDX.cpp */; };
-		18B7C8191294222E009E7A26 /* GUIFontTTFGL.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C76F1294222E009E7A26 /* GUIFontTTFGL.cpp */; };
-		18B7C81A1294222E009E7A26 /* GUIImage.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C7701294222E009E7A26 /* GUIImage.cpp */; };
-		18B7C81B1294222E009E7A26 /* GUIIncludes.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C7711294222E009E7A26 /* GUIIncludes.cpp */; };
-		18B7C81C1294222E009E7A26 /* GUIInfoTypes.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C7721294222E009E7A26 /* GUIInfoTypes.cpp */; };
-		18B7C81D1294222E009E7A26 /* GUILabel.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C7731294222E009E7A26 /* GUILabel.cpp */; };
-		18B7C81E1294222E009E7A26 /* GUILabelControl.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C7741294222E009E7A26 /* GUILabelControl.cpp */; };
-		18B7C81F1294222E009E7A26 /* GUIListContainer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C7751294222E009E7A26 /* GUIListContainer.cpp */; };
-		18B7C8201294222E009E7A26 /* GUIListGroup.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C7761294222E009E7A26 /* GUIListGroup.cpp */; };
-		18B7C8211294222E009E7A26 /* GUIListItem.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C7771294222E009E7A26 /* GUIListItem.cpp */; };
-		18B7C8221294222E009E7A26 /* GUIListItemLayout.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C7781294222E009E7A26 /* GUIListItemLayout.cpp */; };
-		18B7C8231294222E009E7A26 /* GUIListLabel.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C7791294222E009E7A26 /* GUIListLabel.cpp */; };
-		18B7C8241294222E009E7A26 /* GUIMessage.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C77A1294222E009E7A26 /* GUIMessage.cpp */; };
-		18B7C8251294222E009E7A26 /* GUIMoverControl.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C77B1294222E009E7A26 /* GUIMoverControl.cpp */; };
-		18B7C8261294222E009E7A26 /* GUIMultiImage.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C77C1294222E009E7A26 /* GUIMultiImage.cpp */; };
-		18B7C8271294222E009E7A26 /* GUIMultiSelectText.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C77D1294222E009E7A26 /* GUIMultiSelectText.cpp */; };
-		18B7C8281294222E009E7A26 /* GUIPanelContainer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C77E1294222E009E7A26 /* GUIPanelContainer.cpp */; };
-		18B7C8291294222E009E7A26 /* GUIProgressControl.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C77F1294222E009E7A26 /* GUIProgressControl.cpp */; };
-		18B7C82A1294222E009E7A26 /* GUIRadioButtonControl.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C7801294222E009E7A26 /* GUIRadioButtonControl.cpp */; };
-		18B7C82B1294222E009E7A26 /* GUIRenderingControl.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C7811294222E009E7A26 /* GUIRenderingControl.cpp */; };
-		18B7C82C1294222E009E7A26 /* GUIResizeControl.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C7821294222E009E7A26 /* GUIResizeControl.cpp */; };
-		18B7C82D1294222E009E7A26 /* GUIRSSControl.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C7831294222E009E7A26 /* GUIRSSControl.cpp */; };
-		18B7C82E1294222E009E7A26 /* GUIScrollBarControl.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C7841294222E009E7A26 /* GUIScrollBarControl.cpp */; };
-		18B7C82F1294222E009E7A26 /* GUISelectButtonControl.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C7851294222E009E7A26 /* GUISelectButtonControl.cpp */; };
-		18B7C8301294222E009E7A26 /* GUISettingsSliderControl.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C7861294222E009E7A26 /* GUISettingsSliderControl.cpp */; };
-		18B7C8311294222E009E7A26 /* GUIShader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C7871294222E009E7A26 /* GUIShader.cpp */; };
-		18B7C8321294222E009E7A26 /* GUISliderControl.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C7881294222E009E7A26 /* GUISliderControl.cpp */; };
-		18B7C8341294222E009E7A26 /* GUISpinControl.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C78A1294222E009E7A26 /* GUISpinControl.cpp */; };
-		18B7C8351294222E009E7A26 /* GUISpinControlEx.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C78B1294222E009E7A26 /* GUISpinControlEx.cpp */; };
-		18B7C8361294222E009E7A26 /* GUIStandardWindow.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C78C1294222E009E7A26 /* GUIStandardWindow.cpp */; };
-		18B7C8371294222E009E7A26 /* GUIStaticItem.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C78D1294222E009E7A26 /* GUIStaticItem.cpp */; };
-		18B7C8381294222E009E7A26 /* GUITextBox.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C78E1294222E009E7A26 /* GUITextBox.cpp */; };
-		18B7C8391294222E009E7A26 /* GUITextLayout.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C78F1294222E009E7A26 /* GUITextLayout.cpp */; };
-		18B7C83A1294222E009E7A26 /* GUITexture.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C7901294222E009E7A26 /* GUITexture.cpp */; };
-		18B7C83B1294222E009E7A26 /* GUITextureD3D.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C7911294222E009E7A26 /* GUITextureD3D.cpp */; };
-		18B7C83C1294222E009E7A26 /* GUITextureGL.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C7921294222E009E7A26 /* GUITextureGL.cpp */; };
-		18B7C83D1294222E009E7A26 /* GUITextureGLES.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C7931294222E009E7A26 /* GUITextureGLES.cpp */; };
-		18B7C83E1294222E009E7A26 /* GUIToggleButtonControl.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C7941294222E009E7A26 /* GUIToggleButtonControl.cpp */; };
-		18B7C83F1294222E009E7A26 /* GUIVideoControl.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C7951294222E009E7A26 /* GUIVideoControl.cpp */; };
-		18B7C8401294222E009E7A26 /* GUIVisualisationControl.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C7961294222E009E7A26 /* GUIVisualisationControl.cpp */; };
-		18B7C8411294222E009E7A26 /* GUIWindow.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C7971294222E009E7A26 /* GUIWindow.cpp */; };
-		18B7C8421294222E009E7A26 /* GUIWindowManager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C7981294222E009E7A26 /* GUIWindowManager.cpp */; };
-		18B7C8431294222E009E7A26 /* GUIWrappingListContainer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C7991294222E009E7A26 /* GUIWrappingListContainer.cpp */; };
-		18B7C8441294222E009E7A26 /* IWindowManagerCallback.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C79A1294222E009E7A26 /* IWindowManagerCallback.cpp */; };
-		18B7C8451294222E009E7A26 /* Key.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C79B1294222E009E7A26 /* Key.cpp */; };
-		18B7C8461294222E009E7A26 /* LocalizeStrings.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C79C1294222E009E7A26 /* LocalizeStrings.cpp */; };
-		18B7C8471294222E009E7A26 /* MatrixGLES.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C79D1294222E009E7A26 /* MatrixGLES.cpp */; };
-		18B7C8481294222E009E7A26 /* Shader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C79E1294222E009E7A26 /* Shader.cpp */; };
-		18B7C8491294222E009E7A26 /* Texture.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C79F1294222E009E7A26 /* Texture.cpp */; };
-		18B7C84A1294222E009E7A26 /* TextureBundle.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C7A01294222E009E7A26 /* TextureBundle.cpp */; };
-		18B7C84B1294222E009E7A26 /* TextureBundleXBT.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C7A11294222E009E7A26 /* TextureBundleXBT.cpp */; };
-		18B7C84C1294222E009E7A26 /* TextureBundleXPR.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C7A21294222E009E7A26 /* TextureBundleXPR.cpp */; };
-		18B7C84D1294222E009E7A26 /* TextureDX.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C7A31294222E009E7A26 /* TextureDX.cpp */; };
-		18B7C84E1294222E009E7A26 /* TextureGL.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C7A41294222E009E7A26 /* TextureGL.cpp */; };
-		18B7C84F1294222E009E7A26 /* TextureManager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C7A51294222E009E7A26 /* TextureManager.cpp */; };
-		18B7C8501294222E009E7A26 /* VisibleEffect.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C7A61294222E009E7A26 /* VisibleEffect.cpp */; };
-		18B7C8511294222E009E7A26 /* XBTF.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C7A71294222E009E7A26 /* XBTF.cpp */; };
-		18B7C8521294222E009E7A26 /* XBTFReader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C7A81294222E009E7A26 /* XBTFReader.cpp */; };
 		18B7C88C129423A7009E7A26 /* APEv2Tag.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C855129423A7009E7A26 /* APEv2Tag.cpp */; };
 		18B7C88D129423A7009E7A26 /* FlacTag.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C857129423A7009E7A26 /* FlacTag.cpp */; };
 		18B7C88E129423A7009E7A26 /* Id3Tag.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C859129423A7009E7A26 /* Id3Tag.cpp */; };
@@ -281,64 +159,22 @@
 		18B7C8A4129423A7009E7A26 /* MusicInfoTagLoaderYM.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C886129423A7009E7A26 /* MusicInfoTagLoaderYM.cpp */; };
 		18B7C8A5129423A7009E7A26 /* OggTag.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C888129423A7009E7A26 /* OggTag.cpp */; };
 		18B7C8A6129423A7009E7A26 /* VorbisTag.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C88A129423A7009E7A26 /* VorbisTag.cpp */; };
-		18B7C8A7129423A7009E7A26 /* APEv2Tag.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C855129423A7009E7A26 /* APEv2Tag.cpp */; };
-		18B7C8A8129423A7009E7A26 /* FlacTag.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C857129423A7009E7A26 /* FlacTag.cpp */; };
-		18B7C8A9129423A7009E7A26 /* Id3Tag.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C859129423A7009E7A26 /* Id3Tag.cpp */; };
-		18B7C8AB129423A7009E7A26 /* MusicInfoTag.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C85E129423A7009E7A26 /* MusicInfoTag.cpp */; };
-		18B7C8AC129423A7009E7A26 /* MusicInfoTagLoaderAAC.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C860129423A7009E7A26 /* MusicInfoTagLoaderAAC.cpp */; };
-		18B7C8AD129423A7009E7A26 /* MusicInfoTagLoaderApe.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C862129423A7009E7A26 /* MusicInfoTagLoaderApe.cpp */; };
-		18B7C8AE129423A7009E7A26 /* MusicInfoTagLoaderASAP.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C864129423A7009E7A26 /* MusicInfoTagLoaderASAP.cpp */; };
-		18B7C8AF129423A7009E7A26 /* MusicInfoTagLoaderCDDA.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C866129423A7009E7A26 /* MusicInfoTagLoaderCDDA.cpp */; };
-		18B7C8B0129423A7009E7A26 /* MusicInfoTagLoaderDatabase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C868129423A7009E7A26 /* MusicInfoTagLoaderDatabase.cpp */; };
-		18B7C8B1129423A7009E7A26 /* MusicInfoTagLoaderFactory.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C86A129423A7009E7A26 /* MusicInfoTagLoaderFactory.cpp */; };
-		18B7C8B2129423A7009E7A26 /* MusicInfoTagLoaderFlac.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C86C129423A7009E7A26 /* MusicInfoTagLoaderFlac.cpp */; };
-		18B7C8B3129423A7009E7A26 /* MusicInfoTagLoaderMidi.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C86E129423A7009E7A26 /* MusicInfoTagLoaderMidi.cpp */; };
-		18B7C8B4129423A7009E7A26 /* MusicInfoTagLoaderMod.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C870129423A7009E7A26 /* MusicInfoTagLoaderMod.cpp */; };
-		18B7C8B5129423A7009E7A26 /* MusicInfoTagLoaderMP3.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C872129423A7009E7A26 /* MusicInfoTagLoaderMP3.cpp */; };
-		18B7C8B6129423A7009E7A26 /* MusicInfoTagLoaderMP4.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C874129423A7009E7A26 /* MusicInfoTagLoaderMP4.cpp */; };
-		18B7C8B7129423A7009E7A26 /* MusicInfoTagLoaderMPC.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C876129423A7009E7A26 /* MusicInfoTagLoaderMPC.cpp */; };
-		18B7C8B8129423A7009E7A26 /* MusicInfoTagLoaderNSF.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C878129423A7009E7A26 /* MusicInfoTagLoaderNSF.cpp */; };
-		18B7C8B9129423A7009E7A26 /* MusicInfoTagLoaderOgg.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C87A129423A7009E7A26 /* MusicInfoTagLoaderOgg.cpp */; };
-		18B7C8BA129423A7009E7A26 /* MusicInfoTagLoaderShn.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C87C129423A7009E7A26 /* MusicInfoTagLoaderShn.cpp */; };
-		18B7C8BB129423A7009E7A26 /* MusicInfoTagLoaderSPC.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C87E129423A7009E7A26 /* MusicInfoTagLoaderSPC.cpp */; };
-		18B7C8BC129423A7009E7A26 /* MusicInfoTagLoaderWav.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C880129423A7009E7A26 /* MusicInfoTagLoaderWav.cpp */; };
-		18B7C8BD129423A7009E7A26 /* MusicInfoTagLoaderWavPack.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C882129423A7009E7A26 /* MusicInfoTagLoaderWavPack.cpp */; };
-		18B7C8BE129423A7009E7A26 /* MusicInfoTagLoaderWMA.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C884129423A7009E7A26 /* MusicInfoTagLoaderWMA.cpp */; };
-		18B7C8BF129423A7009E7A26 /* MusicInfoTagLoaderYM.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C886129423A7009E7A26 /* MusicInfoTagLoaderYM.cpp */; };
-		18B7C8C0129423A7009E7A26 /* OggTag.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C888129423A7009E7A26 /* OggTag.cpp */; };
-		18B7C8C1129423A7009E7A26 /* VorbisTag.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C88A129423A7009E7A26 /* VorbisTag.cpp */; };
 		18B7C8C412942451009E7A26 /* GUISettings.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C8C212942451009E7A26 /* GUISettings.cpp */; };
-		18B7C8C512942451009E7A26 /* GUISettings.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C8C212942451009E7A26 /* GUISettings.cpp */; };
 		18B7C8D712942546009E7A26 /* ButtonTranslator.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C8CB12942546009E7A26 /* ButtonTranslator.cpp */; };
 		18B7C8D812942546009E7A26 /* KeyboardLayoutConfiguration.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C8CD12942546009E7A26 /* KeyboardLayoutConfiguration.cpp */; };
 		18B7C8D912942546009E7A26 /* KeyboardStat.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C8CF12942546009E7A26 /* KeyboardStat.cpp */; };
 		18B7C8DA12942546009E7A26 /* MouseStat.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C8D112942546009E7A26 /* MouseStat.cpp */; };
 		18B7C8DB12942546009E7A26 /* SDLJoystick.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C8D312942546009E7A26 /* SDLJoystick.cpp */; };
-		18B7C8DC12942546009E7A26 /* ButtonTranslator.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C8CB12942546009E7A26 /* ButtonTranslator.cpp */; };
-		18B7C8DD12942546009E7A26 /* KeyboardLayoutConfiguration.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C8CD12942546009E7A26 /* KeyboardLayoutConfiguration.cpp */; };
-		18B7C8DE12942546009E7A26 /* KeyboardStat.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C8CF12942546009E7A26 /* KeyboardStat.cpp */; };
-		18B7C8DF12942546009E7A26 /* MouseStat.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C8D112942546009E7A26 /* MouseStat.cpp */; };
-		18B7C8E012942546009E7A26 /* SDLJoystick.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C8D312942546009E7A26 /* SDLJoystick.cpp */; };
 		18B7C8E912942603009E7A26 /* Crc32.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C8E712942603009E7A26 /* Crc32.cpp */; };
-		18B7C8EA12942603009E7A26 /* Crc32.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C8E712942603009E7A26 /* Crc32.cpp */; };
 		18B7C8EE12942613009E7A26 /* URIUtils.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C8EC12942613009E7A26 /* URIUtils.cpp */; };
-		18B7C8EF12942613009E7A26 /* URIUtils.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C8EC12942613009E7A26 /* URIUtils.cpp */; };
 		18B7C8F31294261F009E7A26 /* StringUtils.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C8F11294261F009E7A26 /* StringUtils.cpp */; };
-		18B7C8F41294261F009E7A26 /* StringUtils.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C8F11294261F009E7A26 /* StringUtils.cpp */; };
 		18B7C8FB12942718009E7A26 /* GUIDialogAddonSettings.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C8F912942718009E7A26 /* GUIDialogAddonSettings.cpp */; };
-		18B7C8FC12942718009E7A26 /* GUIDialogAddonSettings.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C8F912942718009E7A26 /* GUIDialogAddonSettings.cpp */; };
 		18B7C90012942761009E7A26 /* GUIDialogAudioSubtitleSettings.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C8FE12942761009E7A26 /* GUIDialogAudioSubtitleSettings.cpp */; };
-		18B7C90112942761009E7A26 /* GUIDialogAudioSubtitleSettings.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C8FE12942761009E7A26 /* GUIDialogAudioSubtitleSettings.cpp */; };
 		18B7C90D129427A6009E7A26 /* GUIDialogContentSettings.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C903129427A6009E7A26 /* GUIDialogContentSettings.cpp */; };
 		18B7C90E129427A6009E7A26 /* GUIDialogLockSettings.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C905129427A6009E7A26 /* GUIDialogLockSettings.cpp */; };
 		18B7C90F129427A6009E7A26 /* GUIDialogProfileSettings.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C907129427A6009E7A26 /* GUIDialogProfileSettings.cpp */; };
 		18B7C910129427A6009E7A26 /* GUIDialogSettings.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C909129427A6009E7A26 /* GUIDialogSettings.cpp */; };
 		18B7C911129427A6009E7A26 /* GUIDialogVideoSettings.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C90B129427A6009E7A26 /* GUIDialogVideoSettings.cpp */; };
-		18B7C912129427A6009E7A26 /* GUIDialogContentSettings.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C903129427A6009E7A26 /* GUIDialogContentSettings.cpp */; };
-		18B7C913129427A6009E7A26 /* GUIDialogLockSettings.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C905129427A6009E7A26 /* GUIDialogLockSettings.cpp */; };
-		18B7C914129427A6009E7A26 /* GUIDialogProfileSettings.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C907129427A6009E7A26 /* GUIDialogProfileSettings.cpp */; };
-		18B7C915129427A6009E7A26 /* GUIDialogSettings.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C909129427A6009E7A26 /* GUIDialogSettings.cpp */; };
-		18B7C916129427A6009E7A26 /* GUIDialogVideoSettings.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C90B129427A6009E7A26 /* GUIDialogVideoSettings.cpp */; };
 		18B7C930129428CA009E7A26 /* PlayList.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C91D129428CA009E7A26 /* PlayList.cpp */; };
 		18B7C931129428CA009E7A26 /* PlayListB4S.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C91F129428CA009E7A26 /* PlayListB4S.cpp */; };
 		18B7C932129428CA009E7A26 /* PlayListFactory.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C921129428CA009E7A26 /* PlayListFactory.cpp */; };
@@ -348,77 +184,23 @@
 		18B7C936129428CA009E7A26 /* PlayListWPL.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C929129428CA009E7A26 /* PlayListWPL.cpp */; };
 		18B7C937129428CA009E7A26 /* PlayListXML.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C92B129428CA009E7A26 /* PlayListXML.cpp */; };
 		18B7C938129428CA009E7A26 /* SmartPlayList.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C92D129428CA009E7A26 /* SmartPlayList.cpp */; };
-		18B7C93A129428CA009E7A26 /* PlayList.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C91D129428CA009E7A26 /* PlayList.cpp */; };
-		18B7C93B129428CA009E7A26 /* PlayListB4S.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C91F129428CA009E7A26 /* PlayListB4S.cpp */; };
-		18B7C93C129428CA009E7A26 /* PlayListFactory.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C921129428CA009E7A26 /* PlayListFactory.cpp */; };
-		18B7C93D129428CA009E7A26 /* PlayListM3U.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C923129428CA009E7A26 /* PlayListM3U.cpp */; };
-		18B7C93E129428CA009E7A26 /* PlayListPLS.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C925129428CA009E7A26 /* PlayListPLS.cpp */; };
-		18B7C93F129428CA009E7A26 /* PlayListURL.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C927129428CA009E7A26 /* PlayListURL.cpp */; };
-		18B7C940129428CA009E7A26 /* PlayListWPL.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C929129428CA009E7A26 /* PlayListWPL.cpp */; };
-		18B7C941129428CA009E7A26 /* PlayListXML.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C92B129428CA009E7A26 /* PlayListXML.cpp */; };
-		18B7C942129428CA009E7A26 /* SmartPlayList.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C92D129428CA009E7A26 /* SmartPlayList.cpp */; };
 		18B7C97C1294380A009E7A26 /* GUIWindowAddonBrowser.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C97A12943809009E7A26 /* GUIWindowAddonBrowser.cpp */; };
-		18B7C97D1294380A009E7A26 /* GUIWindowAddonBrowser.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C97A12943809009E7A26 /* GUIWindowAddonBrowser.cpp */; };
 		18B7C9831294385F009E7A26 /* XMLUtils.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C9811294385F009E7A26 /* XMLUtils.cpp */; };
-		18B7C9841294385F009E7A26 /* XMLUtils.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B7C9811294385F009E7A26 /* XMLUtils.cpp */; };
 		18C1D22D13033F6A00CFFE59 /* GLUtils.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18C1D22B13033F6A00CFFE59 /* GLUtils.cpp */; };
-		18C1D22E13033F6A00CFFE59 /* GLUtils.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18C1D22B13033F6A00CFFE59 /* GLUtils.cpp */; };
 		18ECC96213CF178D00A9ED6C /* StreamUtils.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18ECC96013CF178D00A9ED6C /* StreamUtils.cpp */; };
 		32C631281423A90F00F18420 /* JpegIO.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 32C631261423A90F00F18420 /* JpegIO.cpp */; };
 		3802709A13D5A653009493DD /* SystemClock.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3802709813D5A653009493DD /* SystemClock.cpp */; };
 		384718D81325BA04000486D6 /* XBDateTime.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 384718D61325BA04000486D6 /* XBDateTime.cpp */; };
 		38F4E57013CCCB3B00664821 /* Implementation.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 38F4E56C13CCCB3B00664821 /* Implementation.cpp */; };
-		4308680413E3F64100698436 /* StreamUtils.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18ECC96013CF178D00A9ED6C /* StreamUtils.cpp */; };
-		4308680913E3F64C00698436 /* SystemClock.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3802709813D5A653009493DD /* SystemClock.cpp */; };
-		4308680D13E3F65700698436 /* Implementation.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 38F4E56C13CCCB3B00664821 /* Implementation.cpp */; };
-		4308681213E3F66600698436 /* DVDOverlayCodecTX3G.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5CEE60713D3C89700225F72 /* DVDOverlayCodecTX3G.cpp */; };
-		431AE5D9109C1A63007428C3 /* OverlayRendererUtil.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 431AE5D7109C1A63007428C3 /* OverlayRendererUtil.cpp */; };
 		431AE5DA109C1A63007428C3 /* OverlayRendererUtil.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 431AE5D7109C1A63007428C3 /* OverlayRendererUtil.cpp */; };
-		43248C4E0FBE224000B88866 /* LockFree.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 83A72B950FBC8E3B00171871 /* LockFree.cpp */; };
 		432D7CE412D86DA500CE4C49 /* NetworkLinux.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 432D7CE312D86DA500CE4C49 /* NetworkLinux.cpp */; };
-		432D7CE512D86DA500CE4C49 /* NetworkLinux.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 432D7CE312D86DA500CE4C49 /* NetworkLinux.cpp */; };
 		432D7CF712D870E800CE4C49 /* TCPServer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 432D7CF612D870E800CE4C49 /* TCPServer.cpp */; };
-		432D7CF812D870E800CE4C49 /* TCPServer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 432D7CF612D870E800CE4C49 /* TCPServer.cpp */; };
 		433219D812E4C6A500CD7486 /* udf25.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 433219D312E4C6A500CD7486 /* udf25.cpp */; };
 		433219D912E4C6A500CD7486 /* UDFDirectory.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 433219D512E4C6A500CD7486 /* UDFDirectory.cpp */; };
-		433219DB12E4C6A500CD7486 /* udf25.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 433219D312E4C6A500CD7486 /* udf25.cpp */; };
-		433219DC12E4C6A500CD7486 /* UDFDirectory.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 433219D512E4C6A500CD7486 /* UDFDirectory.cpp */; };
-		43348AA3107747CD00F859CF /* Edl.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 43348AA1107747CD00F859CF /* Edl.cpp */; };
 		43348AA4107747CD00F859CF /* Edl.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 43348AA1107747CD00F859CF /* Edl.cpp */; };
-		43348AAC1077486D00F859CF /* PlayerCoreFactory.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 43348AA81077486D00F859CF /* PlayerCoreFactory.cpp */; };
-		43348AAD1077486D00F859CF /* PlayerSelectionRule.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 43348AAA1077486D00F859CF /* PlayerSelectionRule.cpp */; };
 		43348AAE1077486D00F859CF /* PlayerCoreFactory.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 43348AA81077486D00F859CF /* PlayerCoreFactory.cpp */; };
 		43348AAF1077486D00F859CF /* PlayerSelectionRule.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 43348AAA1077486D00F859CF /* PlayerSelectionRule.cpp */; };
 		43352CEE1071634600706B8A /* libsquish.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 43352CED1071634600706B8A /* libsquish.a */; };
-		43BF08EB1080C6BA00E25290 /* Neptune.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 43BF08A41080C6B900E25290 /* Neptune.cpp */; };
-		43BF08EC1080C6BA00E25290 /* NptBase64.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 43BF08A71080C6B900E25290 /* NptBase64.cpp */; };
-		43BF08ED1080C6BA00E25290 /* NptBufferedStreams.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 43BF08A91080C6B900E25290 /* NptBufferedStreams.cpp */; };
-		43BF08EE1080C6BA00E25290 /* NptCommon.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 43BF08AB1080C6B900E25290 /* NptCommon.cpp */; };
-		43BF08EF1080C6BA00E25290 /* NptConsole.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 43BF08AE1080C6B900E25290 /* NptConsole.cpp */; };
-		43BF08F01080C6BA00E25290 /* NptDataBuffer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 43BF08B11080C6B900E25290 /* NptDataBuffer.cpp */; };
-		43BF08F11080C6BA00E25290 /* NptDebug.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 43BF08B31080C6B900E25290 /* NptDebug.cpp */; };
-		43BF08F21080C6BA00E25290 /* NptDynamicLibraries.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 43BF08B71080C6B900E25290 /* NptDynamicLibraries.cpp */; };
-		43BF08F31080C6BA00E25290 /* NptFile.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 43BF08B91080C6B900E25290 /* NptFile.cpp */; };
-		43BF08F41080C6BA00E25290 /* NptHttp.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 43BF08BB1080C6B900E25290 /* NptHttp.cpp */; };
-		43BF08F51080C6BA00E25290 /* NptList.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 43BF08BE1080C6B900E25290 /* NptList.cpp */; };
-		43BF08F61080C6BA00E25290 /* NptLogging.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 43BF08C01080C6B900E25290 /* NptLogging.cpp */; };
-		43BF08F71080C6BA00E25290 /* NptMessaging.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 43BF08C31080C6B900E25290 /* NptMessaging.cpp */; };
-		43BF08F81080C6BA00E25290 /* NptNetwork.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 43BF08C51080C6B900E25290 /* NptNetwork.cpp */; };
-		43BF08F91080C6BA00E25290 /* NptQueue.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 43BF08C71080C6B900E25290 /* NptQueue.cpp */; };
-		43BF08FA1080C6BA00E25290 /* NptResults.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 43BF08CA1080C6B900E25290 /* NptResults.cpp */; };
-		43BF08FB1080C6BA00E25290 /* NptRingBuffer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 43BF08CC1080C6B900E25290 /* NptRingBuffer.cpp */; };
-		43BF08FC1080C6BA00E25290 /* NptSimpleMessageQueue.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 43BF08D01080C6BA00E25290 /* NptSimpleMessageQueue.cpp */; };
-		43BF08FD1080C6BA00E25290 /* NptSockets.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 43BF08D21080C6BA00E25290 /* NptSockets.cpp */; };
-		43BF08FE1080C6BA00E25290 /* NptStreams.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 43BF08D51080C6BA00E25290 /* NptStreams.cpp */; };
-		43BF08FF1080C6BA00E25290 /* NptStrings.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 43BF08D71080C6BA00E25290 /* NptStrings.cpp */; };
-		43BF09001080C6BA00E25290 /* NptSystem.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 43BF08D91080C6BA00E25290 /* NptSystem.cpp */; };
-		43BF09011080C6BA00E25290 /* NptThreads.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 43BF08DB1080C6BA00E25290 /* NptThreads.cpp */; };
-		43BF09021080C6BA00E25290 /* NptTime.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 43BF08DD1080C6BA00E25290 /* NptTime.cpp */; };
-		43BF09031080C6BA00E25290 /* NptTls.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 43BF08DF1080C6BA00E25290 /* NptTls.cpp */; };
-		43BF09041080C6BA00E25290 /* NptUri.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 43BF08E21080C6BA00E25290 /* NptUri.cpp */; };
-		43BF09051080C6BA00E25290 /* NptUtils.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 43BF08E41080C6BA00E25290 /* NptUtils.cpp */; };
-		43BF09061080C6BA00E25290 /* NptXml.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 43BF08E71080C6BA00E25290 /* NptXml.cpp */; };
-		43BF09071080C6BA00E25290 /* NptZip.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 43BF08E91080C6BA00E25290 /* NptZip.cpp */; };
 		43BF09081080C6BA00E25290 /* Neptune.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 43BF08A41080C6B900E25290 /* Neptune.cpp */; };
 		43BF09091080C6BA00E25290 /* NptBase64.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 43BF08A71080C6B900E25290 /* NptBase64.cpp */; };
 		43BF090A1080C6BA00E25290 /* NptBufferedStreams.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 43BF08A91080C6B900E25290 /* NptBufferedStreams.cpp */; };
@@ -448,133 +230,67 @@
 		43BF09221080C6BA00E25290 /* NptUtils.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 43BF08E41080C6BA00E25290 /* NptUtils.cpp */; };
 		43BF09231080C6BA00E25290 /* NptXml.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 43BF08E71080C6BA00E25290 /* NptXml.cpp */; };
 		43BF09241080C6BA00E25290 /* NptZip.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 43BF08E91080C6BA00E25290 /* NptZip.cpp */; };
-		43BF09311080C71700E25290 /* NptBsdNetwork.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 43BF092F1080C71700E25290 /* NptBsdNetwork.cpp */; };
-		43BF09321080C71700E25290 /* NptBsdSockets.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 43BF09301080C71700E25290 /* NptBsdSockets.cpp */; };
 		43BF09331080C71700E25290 /* NptBsdNetwork.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 43BF092F1080C71700E25290 /* NptBsdNetwork.cpp */; };
 		43BF09341080C71700E25290 /* NptBsdSockets.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 43BF09301080C71700E25290 /* NptBsdSockets.cpp */; };
-		43BF09431080C76E00E25290 /* NptPosixFile.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 43BF093D1080C76E00E25290 /* NptPosixFile.cpp */; };
-		43BF09441080C76E00E25290 /* NptPosixNetwork.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 43BF093E1080C76E00E25290 /* NptPosixNetwork.cpp */; };
-		43BF09451080C76E00E25290 /* NptPosixQueue.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 43BF093F1080C76E00E25290 /* NptPosixQueue.cpp */; };
-		43BF09461080C76E00E25290 /* NptPosixSystem.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 43BF09401080C76E00E25290 /* NptPosixSystem.cpp */; };
-		43BF09471080C76E00E25290 /* NptPosixThreads.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 43BF09411080C76E00E25290 /* NptPosixThreads.cpp */; };
-		43BF09481080C76E00E25290 /* NptSelectableMessageQueue.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 43BF09421080C76E00E25290 /* NptSelectableMessageQueue.cpp */; };
 		43BF09491080C76E00E25290 /* NptPosixFile.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 43BF093D1080C76E00E25290 /* NptPosixFile.cpp */; };
 		43BF094A1080C76E00E25290 /* NptPosixNetwork.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 43BF093E1080C76E00E25290 /* NptPosixNetwork.cpp */; };
 		43BF094B1080C76E00E25290 /* NptPosixQueue.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 43BF093F1080C76E00E25290 /* NptPosixQueue.cpp */; };
 		43BF094C1080C76E00E25290 /* NptPosixSystem.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 43BF09401080C76E00E25290 /* NptPosixSystem.cpp */; };
 		43BF094D1080C76E00E25290 /* NptPosixThreads.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 43BF09411080C76E00E25290 /* NptPosixThreads.cpp */; };
 		43BF094E1080C76E00E25290 /* NptSelectableMessageQueue.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 43BF09421080C76E00E25290 /* NptSelectableMessageQueue.cpp */; };
-		43BF09501080C79900E25290 /* NptPosixDynamicLibraries.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 43BF094F1080C79900E25290 /* NptPosixDynamicLibraries.cpp */; };
 		43BF09511080C79900E25290 /* NptPosixDynamicLibraries.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 43BF094F1080C79900E25290 /* NptPosixDynamicLibraries.cpp */; };
-		43BF095C1080C82D00E25290 /* NptStdcDebug.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 43BF09571080C82D00E25290 /* NptStdcDebug.cpp */; };
-		43BF095D1080C82D00E25290 /* NptStdcEnvironment.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 43BF09581080C82D00E25290 /* NptStdcEnvironment.cpp */; };
-		43BF095F1080C82D00E25290 /* NptStdCTime.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 43BF095A1080C82D00E25290 /* NptStdCTime.cpp */; };
 		43BF09611080C82D00E25290 /* NptStdcDebug.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 43BF09571080C82D00E25290 /* NptStdcDebug.cpp */; };
 		43BF09621080C82D00E25290 /* NptStdcEnvironment.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 43BF09581080C82D00E25290 /* NptStdcEnvironment.cpp */; };
 		43BF09641080C82D00E25290 /* NptStdCTime.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 43BF095A1080C82D00E25290 /* NptStdCTime.cpp */; };
-		43BF09741080CCB700E25290 /* PltTime.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 43BF09721080CCB700E25290 /* PltTime.cpp */; };
 		43BF09751080CCB700E25290 /* PltTime.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 43BF09721080CCB700E25290 /* PltTime.cpp */; };
-		43BF09951080D13F00E25290 /* ConnectionManagerSCPD.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 43BF09921080D13F00E25290 /* ConnectionManagerSCPD.cpp */; };
-		43BF09961080D13F00E25290 /* ContentDirectorySCPD.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 43BF09931080D13F00E25290 /* ContentDirectorySCPD.cpp */; };
-		43BF09971080D13F00E25290 /* ContentDirectorywSearchSCPD.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 43BF09941080D13F00E25290 /* ContentDirectorywSearchSCPD.cpp */; };
 		43BF09981080D13F00E25290 /* ConnectionManagerSCPD.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 43BF09921080D13F00E25290 /* ConnectionManagerSCPD.cpp */; };
 		43BF09991080D13F00E25290 /* ContentDirectorySCPD.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 43BF09931080D13F00E25290 /* ContentDirectorySCPD.cpp */; };
 		43BF099A1080D13F00E25290 /* ContentDirectorywSearchSCPD.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 43BF09941080D13F00E25290 /* ContentDirectorywSearchSCPD.cpp */; };
-		43BF099C1080D17600E25290 /* X_MS_MediaReceiverRegistrarSCPD.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 43BF099B1080D17600E25290 /* X_MS_MediaReceiverRegistrarSCPD.cpp */; };
 		43BF099D1080D17600E25290 /* X_MS_MediaReceiverRegistrarSCPD.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 43BF099B1080D17600E25290 /* X_MS_MediaReceiverRegistrarSCPD.cpp */; };
-		43BF09A01080D1E900E25290 /* AVTransportSCPD.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 43BF099E1080D1E900E25290 /* AVTransportSCPD.cpp */; };
-		43BF09A11080D1E900E25290 /* RenderingControlSCPD.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 43BF099F1080D1E900E25290 /* RenderingControlSCPD.cpp */; };
 		43BF09A21080D1E900E25290 /* AVTransportSCPD.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 43BF099E1080D1E900E25290 /* AVTransportSCPD.cpp */; };
 		43BF09A31080D1E900E25290 /* RenderingControlSCPD.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 43BF099F1080D1E900E25290 /* RenderingControlSCPD.cpp */; };
-		43BF09AA1080D2ED00E25290 /* RdrConnectionManagerSCPD.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 43BF09A81080D2ED00E25290 /* RdrConnectionManagerSCPD.cpp */; };
 		43BF09AB1080D2ED00E25290 /* RdrConnectionManagerSCPD.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 43BF09A81080D2ED00E25290 /* RdrConnectionManagerSCPD.cpp */; };
-		43EA4276136C04D9002C82A5 /* XBDateTime.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 384718D61325BA04000486D6 /* XBDateTime.cpp */; };
-		43EA4279136C079A002C82A5 /* JSONServiceDescription.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C84BF7321349BB74006D6FC9 /* JSONServiceDescription.cpp */; };
-		43EA427E136C07BF002C82A5 /* XBMC_keytable.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C8EC5D0C1369519D00CCC10D /* XBMC_keytable.cpp */; };
-		43EA4282136C0806002C82A5 /* RecentlyAddedJob.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18ACF84113596C9B00B67371 /* RecentlyAddedJob.cpp */; };
-		43EA4297136C1D9E002C82A5 /* RenderCapture.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F56579AD13060D1E0085ED7F /* RenderCapture.cpp */; };
-		43EA429B136C1E2F002C82A5 /* xbmcvfsmodule.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 189047D11301DEAB00C11012 /* xbmcvfsmodule.cpp */; };
-		43EA42B0136C2274002C82A5 /* InputOperations.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C807114B135DB5CC002F601B /* InputOperations.cpp */; };
 		7C0A7EC013A5DBCE00AFC2BD /* AppParamParser.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C0A7EBE13A5DBCE00AFC2BD /* AppParamParser.cpp */; };
-		7C0A7EC113A5DBCE00AFC2BD /* AppParamParser.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C0A7EBE13A5DBCE00AFC2BD /* AppParamParser.cpp */; };
-		7C0B98A3154B79C30065A238 /* AEDeviceInfo.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C0B98A1154B79C30065A238 /* AEDeviceInfo.cpp */; };
 		7C0B98A4154B79C30065A238 /* AEDeviceInfo.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C0B98A1154B79C30065A238 /* AEDeviceInfo.cpp */; };
-		7C1A85651520522500C63311 /* TextureCacheJob.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C1A85631520522500C63311 /* TextureCacheJob.cpp */; };
 		7C1A85661520522500C63311 /* TextureCacheJob.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C1A85631520522500C63311 /* TextureCacheJob.cpp */; };
 		7C1F6EBB13ECCFA7001726AB /* LibraryDirectory.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C1F6EB913ECCFA7001726AB /* LibraryDirectory.cpp */; };
-		7C1F6EBC13ECCFA7001726AB /* LibraryDirectory.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C1F6EB913ECCFA7001726AB /* LibraryDirectory.cpp */; };
 		7C2D6AE40F35453E00DD2E85 /* SpecialProtocol.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C2D6AE20F35453E00DD2E85 /* SpecialProtocol.cpp */; };
 		7C45DBE910F325C400D4BBF3 /* DAVDirectory.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C45DBE710F325C400D4BBF3 /* DAVDirectory.cpp */; };
-		7C45DBEA10F325C400D4BBF3 /* DAVDirectory.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C45DBE710F325C400D4BBF3 /* DAVDirectory.cpp */; };
 		7C4705AE12EF584C00369E51 /* AddonInstaller.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C4705AC12EF584C00369E51 /* AddonInstaller.cpp */; };
-		7C4705AF12EF584C00369E51 /* AddonInstaller.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C4705AC12EF584C00369E51 /* AddonInstaller.cpp */; };
 		7C5608C70F1754930056433A /* ExternalPlayer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C5608C40F1754930056433A /* ExternalPlayer.cpp */; };
 		7C62F24210505BC7002AD2C1 /* Bookmark.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C62F24010505BC7002AD2C1 /* Bookmark.cpp */; };
-		7C62F24310505BC7002AD2C1 /* Bookmark.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C62F24010505BC7002AD2C1 /* Bookmark.cpp */; };
 		7C62F45E1057A62D002AD2C1 /* DirectoryNodeSingles.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C62F45C1057A62D002AD2C1 /* DirectoryNodeSingles.cpp */; };
-		7C62F45F1057A62D002AD2C1 /* DirectoryNodeSingles.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C62F45C1057A62D002AD2C1 /* DirectoryNodeSingles.cpp */; };
 		7C779E3A104A57E500F444C4 /* RenderSystem.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C779E1F104A57E500F444C4 /* RenderSystem.cpp */; };
 		7C779E3B104A57E500F444C4 /* RenderSystemGL.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C779E21104A57E500F444C4 /* RenderSystemGL.cpp */; };
 		7C779E3C104A57E500F444C4 /* WinEventsSDL.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C779E27104A57E500F444C4 /* WinEventsSDL.cpp */; };
 		7C779E3D104A57E500F444C4 /* WinSystem.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C779E29104A57E500F444C4 /* WinSystem.cpp */; };
 		7C779E3E104A57E500F444C4 /* WinSystemOSX.mm in Sources */ = {isa = PBXBuildFile; fileRef = 7C779E2B104A57E500F444C4 /* WinSystemOSX.mm */; };
 		7C779E3F104A57E500F444C4 /* WinSystemOSXGL.mm in Sources */ = {isa = PBXBuildFile; fileRef = 7C779E2D104A57E500F444C4 /* WinSystemOSXGL.mm */; };
-		7C779E45104A57E500F444C4 /* RenderSystem.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C779E1F104A57E500F444C4 /* RenderSystem.cpp */; };
-		7C779E46104A57E500F444C4 /* RenderSystemGL.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C779E21104A57E500F444C4 /* RenderSystemGL.cpp */; };
-		7C779E47104A57E500F444C4 /* WinEventsSDL.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C779E27104A57E500F444C4 /* WinEventsSDL.cpp */; };
-		7C779E48104A57E500F444C4 /* WinSystem.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C779E29104A57E500F444C4 /* WinSystem.cpp */; };
-		7C779E49104A57E500F444C4 /* WinSystemOSX.mm in Sources */ = {isa = PBXBuildFile; fileRef = 7C779E2B104A57E500F444C4 /* WinSystemOSX.mm */; };
-		7C779E4A104A57E500F444C4 /* WinSystemOSXGL.mm in Sources */ = {isa = PBXBuildFile; fileRef = 7C779E2D104A57E500F444C4 /* WinSystemOSXGL.mm */; };
 		7C779E54104A58F900F444C4 /* GUIWindowTestPatternGL.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C779E50104A58F900F444C4 /* GUIWindowTestPatternGL.cpp */; };
-		7C779E56104A58F900F444C4 /* GUIWindowTestPatternGL.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C779E50104A58F900F444C4 /* GUIWindowTestPatternGL.cpp */; };
 		7C7B2B301134F36400713D6D /* mysqldataset.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C7B2B2E1134F36400713D6D /* mysqldataset.cpp */; };
-		7C7B2B311134F36400713D6D /* mysqldataset.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C7B2B2E1134F36400713D6D /* mysqldataset.cpp */; };
 		7C84A59E12FA3C1600CD1714 /* SourcesDirectory.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C84A59C12FA3C1600CD1714 /* SourcesDirectory.cpp */; };
-		7C84A59F12FA3C1600CD1714 /* SourcesDirectory.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C84A59C12FA3C1600CD1714 /* SourcesDirectory.cpp */; };
 		7C89619213B6A16F003631FE /* GUIWindowScreensaverDim.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C89619013B6A16F003631FE /* GUIWindowScreensaverDim.cpp */; };
-		7C89619313B6A16F003631FE /* GUIWindowScreensaverDim.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C89619013B6A16F003631FE /* GUIWindowScreensaverDim.cpp */; };
 		7C89674613C03B22003631FE /* InfoBool.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C89674313C03B22003631FE /* InfoBool.cpp */; };
-		7C89674813C03B22003631FE /* InfoBool.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C89674313C03B22003631FE /* InfoBool.cpp */; };
-		7C8A14561154CB2600E5FCFA /* TextureCache.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C8A14541154CB2600E5FCFA /* TextureCache.cpp */; };
 		7C8A14571154CB2600E5FCFA /* TextureCache.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C8A14541154CB2600E5FCFA /* TextureCache.cpp */; };
-		7C8A187C115B2A8200E5FCFA /* TextureDatabase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C8A187A115B2A8200E5FCFA /* TextureDatabase.cpp */; };
 		7C8A187D115B2A8200E5FCFA /* TextureDatabase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C8A187A115B2A8200E5FCFA /* TextureDatabase.cpp */; };
 		7C99B6A4133D342100FC2B16 /* CircularCache.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C99B6A2133D342100FC2B16 /* CircularCache.cpp */; };
-		7C99B6A5133D342100FC2B16 /* CircularCache.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C99B6A2133D342100FC2B16 /* CircularCache.cpp */; };
 		7C99B7951340723F00FC2B16 /* GUIDialogPlayEject.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C99B7931340723F00FC2B16 /* GUIDialogPlayEject.cpp */; };
-		7C99B7961340723F00FC2B16 /* GUIDialogPlayEject.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C99B7931340723F00FC2B16 /* GUIDialogPlayEject.cpp */; };
 		7CAA20511079C8160096DE39 /* BaseRenderer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7CAA204F1079C8160096DE39 /* BaseRenderer.cpp */; };
-		7CAA20521079C8160096DE39 /* BaseRenderer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7CAA204F1079C8160096DE39 /* BaseRenderer.cpp */; };
 		7CAA25351085963B0096DE39 /* PasswordManager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7CAA25331085963B0096DE39 /* PasswordManager.cpp */; };
-		7CAA25361085963B0096DE39 /* PasswordManager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7CAA25331085963B0096DE39 /* PasswordManager.cpp */; };
-		7CBEBB8312912BA300431822 /* fstrcmp.c in Sources */ = {isa = PBXBuildFile; fileRef = 7CBEBB8212912BA300431822 /* fstrcmp.c */; };
 		7CBEBB8412912BA400431822 /* fstrcmp.c in Sources */ = {isa = PBXBuildFile; fileRef = 7CBEBB8212912BA300431822 /* fstrcmp.c */; };
 		7CCF7E721067643800992676 /* DirectoryNodeSets.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7CCF7E701067643800992676 /* DirectoryNodeSets.cpp */; };
-		7CCF7E731067643800992676 /* DirectoryNodeSets.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7CCF7E701067643800992676 /* DirectoryNodeSets.cpp */; };
 		7CCF7F1D1069F3AE00992676 /* Builtins.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7CCF7F1B1069F3AE00992676 /* Builtins.cpp */; };
-		7CCF7F1E1069F3AE00992676 /* Builtins.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7CCF7F1B1069F3AE00992676 /* Builtins.cpp */; };
 		7CCF7FC9106A0DF500992676 /* TimeUtils.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7CCF7FC7106A0DF500992676 /* TimeUtils.cpp */; };
-		7CCF7FCA106A0DF500992676 /* TimeUtils.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7CCF7FC7106A0DF500992676 /* TimeUtils.cpp */; };
-		7CCFD98C151494E100211D82 /* PCMCodec.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7CCFD98A151494E100211D82 /* PCMCodec.cpp */; };
 		7CCFD98D151494E100211D82 /* PCMCodec.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7CCFD98A151494E100211D82 /* PCMCodec.cpp */; };
-		7CD2C3AA11940B270009EFC1 /* DirectoryNodeCountry.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7CD2C3A811940B270009EFC1 /* DirectoryNodeCountry.cpp */; };
 		7CD2C3AB11940B270009EFC1 /* DirectoryNodeCountry.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7CD2C3A811940B270009EFC1 /* DirectoryNodeCountry.cpp */; };
-		7CD2CD0111B38B000009EFC1 /* PythonAddon.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7CD2CCFE11B38B000009EFC1 /* PythonAddon.cpp */; };
-		7CD2CD0211B38B000009EFC1 /* xbmcaddonmodule.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7CD2CD0011B38B000009EFC1 /* xbmcaddonmodule.cpp */; };
 		7CD2CD0311B38B000009EFC1 /* PythonAddon.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7CD2CCFE11B38B000009EFC1 /* PythonAddon.cpp */; settings = {COMPILER_FLAGS = "-I$XBMC_DEPENDS/include/python2.6"; }; };
 		7CD2CD0411B38B000009EFC1 /* xbmcaddonmodule.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7CD2CD0011B38B000009EFC1 /* xbmcaddonmodule.cpp */; settings = {COMPILER_FLAGS = "-I$XBMC_DEPENDS/include/python2.6"; }; };
 		7CDAE9050FFCA3520040B25F /* DVDTSCorrection.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7CDAE9030FFCA3520040B25F /* DVDTSCorrection.cpp */; };
-		7CDAE9060FFCA3520040B25F /* DVDTSCorrection.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7CDAE9030FFCA3520040B25F /* DVDTSCorrection.cpp */; };
 		7CDAEA7D1001CD6E0040B25F /* karaokelyricstextustar.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7CDAEA7B1001CD6E0040B25F /* karaokelyricstextustar.cpp */; };
-		7CDAEA7E1001CD6E0040B25F /* karaokelyricstextustar.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7CDAEA7B1001CD6E0040B25F /* karaokelyricstextustar.cpp */; };
 		7CDAEA8C1001EBA70040B25F /* PltConstants.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7CDAEA891001EBA70040B25F /* PltConstants.cpp */; };
 		7CDAEA8D1001EBA70040B25F /* PltIconsData.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7CDAEA8B1001EBA70040B25F /* PltIconsData.cpp */; };
-		7CDAEA8E1001EBA70040B25F /* PltConstants.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7CDAEA891001EBA70040B25F /* PltConstants.cpp */; };
-		7CDAEA8F1001EBA70040B25F /* PltIconsData.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7CDAEA8B1001EBA70040B25F /* PltIconsData.cpp */; };
 		7CEBD8A80F33A0D800CAF6AD /* SpecialProtocolDirectory.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7CEBD8A60F33A0D800CAF6AD /* SpecialProtocolDirectory.cpp */; };
 		7CEE2E5B13D6B71E000ABF2A /* TimeSmoother.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7CEE2E5913D6B71E000ABF2A /* TimeSmoother.cpp */; };
-		7CEE2E5C13D6B71E000ABF2A /* TimeSmoother.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7CEE2E5913D6B71E000ABF2A /* TimeSmoother.cpp */; };
-		7CF1FB0B123B1AF000B2CBCB /* Variant.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7CF1FB09123B1AF000B2CBCB /* Variant.cpp */; };
 		7CF1FB0C123B1AF000B2CBCB /* Variant.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7CF1FB09123B1AF000B2CBCB /* Variant.cpp */; };
 		810C9F630D67BD2F0095F5DD /* PltMediaConnect.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 810C9F600D67BD2F0095F5DD /* PltMediaConnect.cpp */; };
 		810C9FA90D67D1FB0095F5DD /* MythDirectory.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 810C9FA50D67D1FB0095F5DD /* MythDirectory.cpp */; };
@@ -582,7 +298,6 @@
 		815EE6350E17F1DC009FBE3C /* DVDInputStreamRTMP.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 815EE6330E17F1DC009FBE3C /* DVDInputStreamRTMP.cpp */; };
 		83A72B970FBC8E3B00171871 /* LockFree.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 83A72B950FBC8E3B00171871 /* LockFree.cpp */; settings = {COMPILER_FLAGS = "-O0"; }; };
 		83E0B2490F7C95FF0091643F /* Atomics.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 83E0B2480F7C95FF0091643F /* Atomics.cpp */; };
-		83E0B24A0F7C95FF0091643F /* Atomics.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 83E0B2480F7C95FF0091643F /* Atomics.cpp */; };
 		880DBE4E0DC223FF00E26B71 /* MediaSource.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 880DBE4B0DC223FF00E26B71 /* MediaSource.cpp */; };
 		880DBE550DC224A100E26B71 /* MusicFileDirectory.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 880DBE530DC224A100E26B71 /* MusicFileDirectory.cpp */; };
 		8863281D0E07B37200BB3DAB /* GUIDialogFullScreenInfo.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 886328150E07B37200BB3DAB /* GUIDialogFullScreenInfo.cpp */; };
@@ -597,48 +312,29 @@
 		88ECB6590DE013C4003396A7 /* DiskArbitration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 88ECB6580DE013C4003396A7 /* DiskArbitration.framework */; };
 		8DD76F790486A8DE00D96B5E /* CoreFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 09AB6884FE841BABC02AAC07 /* CoreFoundation.framework */; };
 		C80425711158A0DE00D158A6 /* controlslider.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C80425701158A0DE00D158A6 /* controlslider.cpp */; settings = {COMPILER_FLAGS = "-I$XBMC_DEPENDS/include/python2.6"; }; };
-		C80425721158A0DE00D158A6 /* controlslider.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C80425701158A0DE00D158A6 /* controlslider.cpp */; };
 		C807114D135DB5CC002F601B /* InputOperations.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C807114B135DB5CC002F601B /* InputOperations.cpp */; };
 		C84BF7341349BB74006D6FC9 /* JSONServiceDescription.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C84BF7321349BB74006D6FC9 /* JSONServiceDescription.cpp */; };
 		C85EB75C1174614E0008E5A5 /* Repository.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C85EB75A1174614E0008E5A5 /* Repository.cpp */; };
-		C85EB75D1174614E0008E5A5 /* Repository.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C85EB75A1174614E0008E5A5 /* Repository.cpp */; };
 		C8936052152C86CF00812418 /* monitor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C8936050152C86CF00812418 /* monitor.cpp */; };
-		C8936053152C86CF00812418 /* monitor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C8936050152C86CF00812418 /* monitor.cpp */; };
 		C8936056152C86D800812418 /* PythonMonitor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C8936054152C86D800812418 /* PythonMonitor.cpp */; };
-		C8936057152C86D800812418 /* PythonMonitor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C8936054152C86D800812418 /* PythonMonitor.cpp */; };
 		C8D0B2AF1265A9A800F0C0AC /* SystemGlobals.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C8D0B2AE1265A9A800F0C0AC /* SystemGlobals.cpp */; };
-		C8D0B2B01265A9A800F0C0AC /* SystemGlobals.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C8D0B2AE1265A9A800F0C0AC /* SystemGlobals.cpp */; };
 		C8EC5D0E1369519D00CCC10D /* XBMC_keytable.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C8EC5D0C1369519D00CCC10D /* XBMC_keytable.cpp */; };
 		DF0DF15C13A3ADA7008ED511 /* NFSDirectory.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF0DF15913A3ADA7008ED511 /* NFSDirectory.cpp */; };
 		DF24A6B41406C7C500C7721E /* AFPDirectory.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF24A6B01406C7C500C7721E /* AFPDirectory.cpp */; };
-		DF24A6B61406C7C500C7721E /* AFPDirectory.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF24A6B01406C7C500C7721E /* AFPDirectory.cpp */; };
 		DF3488E713FD958F0026A711 /* GUIAction.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF3488E513FD958F0026A711 /* GUIAction.cpp */; };
-		DF3488E813FD958F0026A711 /* GUIAction.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF3488E513FD958F0026A711 /* GUIAction.cpp */; };
 		DF34892A13FD9C780026A711 /* AirPlayServer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF34892813FD9C780026A711 /* AirPlayServer.cpp */; };
-		DF34892B13FD9C780026A711 /* AirPlayServer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF34892813FD9C780026A711 /* AirPlayServer.cpp */; };
 		DF34898213FDAAF60026A711 /* HttpParser.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF34898113FDAAF60026A711 /* HttpParser.cpp */; };
-		DF34898313FDAAF60026A711 /* HttpParser.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF34898113FDAAF60026A711 /* HttpParser.cpp */; };
 		DF448457140048A60069344B /* AirTunesServer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF448455140048A60069344B /* AirTunesServer.cpp */; };
-		DF448458140048A60069344B /* AirTunesServer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF448455140048A60069344B /* AirTunesServer.cpp */; };
 		DF44845E140048C80069344B /* PipesManager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF44845B140048C80069344B /* PipesManager.cpp */; };
-		DF448460140048C80069344B /* PipesManager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF44845B140048C80069344B /* PipesManager.cpp */; };
 		DF4484EE140054530069344B /* BXAcodec.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF4484EC140054530069344B /* BXAcodec.cpp */; };
-		DF4484EF140054530069344B /* BXAcodec.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF4484EC140054530069344B /* BXAcodec.cpp */; };
 		DF5276E1151BAEDA00B5B63B /* Base64.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF52769A151BAEDA00B5B63B /* Base64.cpp */; };
 		DF5276E2151BAEDA00B5B63B /* HttpResponse.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF52769C151BAEDA00B5B63B /* HttpResponse.cpp */; };
-		DF527726151BAEDA00B5B63B /* Base64.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF52769A151BAEDA00B5B63B /* Base64.cpp */; };
-		DF527727151BAEDA00B5B63B /* HttpResponse.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF52769C151BAEDA00B5B63B /* HttpResponse.cpp */; };
 		DF527734151BAF4C00B5B63B /* WebSocket.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF52772B151BAF4C00B5B63B /* WebSocket.cpp */; };
 		DF527735151BAF4C00B5B63B /* WebSocketManager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF52772D151BAF4C00B5B63B /* WebSocketManager.cpp */; };
 		DF527736151BAF4C00B5B63B /* WebSocketV13.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF52772F151BAF4C00B5B63B /* WebSocketV13.cpp */; };
 		DF527737151BAF4C00B5B63B /* WebSocketV8.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF527731151BAF4C00B5B63B /* WebSocketV8.cpp */; };
-		DF527739151BAF4C00B5B63B /* WebSocket.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF52772B151BAF4C00B5B63B /* WebSocket.cpp */; };
-		DF52773A151BAF4C00B5B63B /* WebSocketManager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF52772D151BAF4C00B5B63B /* WebSocketManager.cpp */; };
-		DF52773B151BAF4C00B5B63B /* WebSocketV13.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF52772F151BAF4C00B5B63B /* WebSocketV13.cpp */; };
-		DF52773C151BAF4C00B5B63B /* WebSocketV8.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF527731151BAF4C00B5B63B /* WebSocketV8.cpp */; };
 		DF673AA51443819600A5A509 /* AddonManager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B49FF41152BFA5001AF8A6 /* AddonManager.cpp */; };
 		DF93D65D1444A7A3007C6459 /* SlingboxDirectory.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF93D65C1444A7A3007C6459 /* SlingboxDirectory.cpp */; };
-		DF93D65E1444A7A3007C6459 /* SlingboxDirectory.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF93D65C1444A7A3007C6459 /* SlingboxDirectory.cpp */; };
 		DF93D6991444A8B1007C6459 /* AFPFile.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF93D6631444A8B0007C6459 /* AFPFile.cpp */; };
 		DF93D69A1444A8B1007C6459 /* DirectoryCache.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF93D6651444A8B0007C6459 /* DirectoryCache.cpp */; };
 		DF93D69B1444A8B1007C6459 /* FileCache.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF93D6671444A8B0007C6459 /* FileCache.cpp */; };
@@ -666,41 +362,10 @@
 		DF93D6B11444A8B1007C6459 /* UDFFile.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF93D6931444A8B0007C6459 /* UDFFile.cpp */; };
 		DF93D6B21444A8B1007C6459 /* UPnPFile.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF93D6951444A8B0007C6459 /* UPnPFile.cpp */; };
 		DF93D6B31444A8B1007C6459 /* ZipFile.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF93D6971444A8B0007C6459 /* ZipFile.cpp */; };
-		DF93D6B41444A8B1007C6459 /* AFPFile.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF93D6631444A8B0007C6459 /* AFPFile.cpp */; };
-		DF93D6B51444A8B1007C6459 /* DirectoryCache.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF93D6651444A8B0007C6459 /* DirectoryCache.cpp */; };
-		DF93D6B61444A8B1007C6459 /* FileCache.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF93D6671444A8B0007C6459 /* FileCache.cpp */; };
-		DF93D6B71444A8B1007C6459 /* CDDAFile.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF93D6691444A8B0007C6459 /* CDDAFile.cpp */; };
-		DF93D6B81444A8B1007C6459 /* CurlFile.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF93D66B1444A8B0007C6459 /* CurlFile.cpp */; };
-		DF93D6B91444A8B1007C6459 /* DAAPFile.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF93D66D1444A8B0007C6459 /* DAAPFile.cpp */; };
-		DF93D6BA1444A8B1007C6459 /* DirectoryFactory.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF93D66F1444A8B0007C6459 /* DirectoryFactory.cpp */; };
-		DF93D6BB1444A8B1007C6459 /* FileDirectoryFactory.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF93D6711444A8B0007C6459 /* FileDirectoryFactory.cpp */; };
-		DF93D6BC1444A8B1007C6459 /* FileReaderFile.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF93D6731444A8B0007C6459 /* FileReaderFile.cpp */; };
-		DF93D6BD1444A8B1007C6459 /* HDFile.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF93D6751444A8B0007C6459 /* HDFile.cpp */; };
-		DF93D6BE1444A8B1007C6459 /* ISOFile.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF93D6771444A8B0007C6459 /* ISOFile.cpp */; };
-		DF93D6BF1444A8B1007C6459 /* LastFMFile.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF93D6791444A8B0007C6459 /* LastFMFile.cpp */; };
-		DF93D6C01444A8B1007C6459 /* MusicDatabaseFile.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF93D67B1444A8B0007C6459 /* MusicDatabaseFile.cpp */; };
-		DF93D6C11444A8B1007C6459 /* NFSFile.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF93D67D1444A8B0007C6459 /* NFSFile.cpp */; };
-		DF93D6C21444A8B1007C6459 /* PipeFile.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF93D67F1444A8B0007C6459 /* PipeFile.cpp */; };
-		DF93D6C31444A8B1007C6459 /* RarFile.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF93D6811444A8B0007C6459 /* RarFile.cpp */; };
-		DF93D6C41444A8B1007C6459 /* RTVFile.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF93D6831444A8B0007C6459 /* RTVFile.cpp */; };
-		DF93D6C51444A8B1007C6459 /* SFTPFile.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF93D6851444A8B0007C6459 /* SFTPFile.cpp */; };
-		DF93D6C61444A8B1007C6459 /* ShoutcastFile.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF93D6871444A8B0007C6459 /* ShoutcastFile.cpp */; };
-		DF93D6C71444A8B1007C6459 /* SlingboxFile.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF93D6891444A8B0007C6459 /* SlingboxFile.cpp */; };
-		DF93D6C81444A8B1007C6459 /* SmbFile.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF93D68B1444A8B0007C6459 /* SmbFile.cpp */; };
-		DF93D6C91444A8B1007C6459 /* SpecialProtocolFile.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF93D68D1444A8B0007C6459 /* SpecialProtocolFile.cpp */; };
-		DF93D6CA1444A8B1007C6459 /* TuxBoxDirectory.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF93D68F1444A8B0007C6459 /* TuxBoxDirectory.cpp */; };
-		DF93D6CB1444A8B1007C6459 /* TuxBoxFile.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF93D6911444A8B0007C6459 /* TuxBoxFile.cpp */; };
-		DF93D6CC1444A8B1007C6459 /* UDFFile.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF93D6931444A8B0007C6459 /* UDFFile.cpp */; };
-		DF93D6CD1444A8B1007C6459 /* UPnPFile.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF93D6951444A8B0007C6459 /* UPnPFile.cpp */; };
-		DF93D6CE1444A8B1007C6459 /* ZipFile.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF93D6971444A8B0007C6459 /* ZipFile.cpp */; };
 		DF93D7F21444B54A007C6459 /* HDHomeRunFile.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF93D7F01444B54A007C6459 /* HDHomeRunFile.cpp */; };
-		DF93D7F31444B54A007C6459 /* HDHomeRunFile.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF93D7F01444B54A007C6459 /* HDHomeRunFile.cpp */; };
 		DF93D7F61444B568007C6459 /* HDHomeRunDirectory.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF93D7F51444B568007C6459 /* HDHomeRunDirectory.cpp */; };
-		DF93D7F71444B568007C6459 /* HDHomeRunDirectory.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF93D7F51444B568007C6459 /* HDHomeRunDirectory.cpp */; };
 		DF98D98C1434F47D00A6EBE1 /* SkinVariable.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF98D98A1434F47D00A6EBE1 /* SkinVariable.cpp */; };
-		DF98D98D1434F47D00A6EBE1 /* SkinVariable.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF98D98A1434F47D00A6EBE1 /* SkinVariable.cpp */; };
 		DFAB049813F8376700B70BFB /* InertialScrollingHandler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DFAB049613F8376700B70BFB /* InertialScrollingHandler.cpp */; };
-		DFAB049913F8376700B70BFB /* InertialScrollingHandler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DFAB049613F8376700B70BFB /* InertialScrollingHandler.cpp */; };
 		DFB65FB515373AE7006B8FF1 /* AEFactory.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DFB65F6515373AE7006B8FF1 /* AEFactory.cpp */; };
 		DFB65FB715373AE7006B8FF1 /* AEEncoderFFmpeg.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DFB65F6A15373AE7006B8FF1 /* AEEncoderFFmpeg.cpp */; };
 		DFB65FB815373AE7006B8FF1 /* CoreAudioAE.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DFB65F6D15373AE7006B8FF1 /* CoreAudioAE.cpp */; };
@@ -719,40 +384,14 @@
 		DFB65FD215373AE7006B8FF1 /* AEStreamInfo.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DFB65FAF15373AE7006B8FF1 /* AEStreamInfo.cpp */; };
 		DFB65FD315373AE7006B8FF1 /* AEUtil.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DFB65FB115373AE7006B8FF1 /* AEUtil.cpp */; };
 		DFB65FD415373AE7006B8FF1 /* AEWAVLoader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DFB65FB315373AE7006B8FF1 /* AEWAVLoader.cpp */; };
-		DFB65FD515373AE7006B8FF1 /* AEFactory.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DFB65F6515373AE7006B8FF1 /* AEFactory.cpp */; };
-		DFB65FD715373AE7006B8FF1 /* AEEncoderFFmpeg.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DFB65F6A15373AE7006B8FF1 /* AEEncoderFFmpeg.cpp */; };
-		DFB65FD815373AE7006B8FF1 /* CoreAudioAE.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DFB65F6D15373AE7006B8FF1 /* CoreAudioAE.cpp */; };
-		DFB65FD915373AE7006B8FF1 /* CoreAudioAEHAL.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DFB65F6F15373AE7006B8FF1 /* CoreAudioAEHAL.cpp */; };
-		DFB65FDA15373AE7006B8FF1 /* CoreAudioAEHALIOS.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DFB65F7115373AE7006B8FF1 /* CoreAudioAEHALIOS.cpp */; };
-		DFB65FDB15373AE7006B8FF1 /* CoreAudioAEHALOSX.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DFB65F7315373AE7006B8FF1 /* CoreAudioAEHALOSX.cpp */; };
-		DFB65FDC15373AE7006B8FF1 /* CoreAudioAESound.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DFB65F7515373AE7006B8FF1 /* CoreAudioAESound.cpp */; };
-		DFB65FDD15373AE7006B8FF1 /* CoreAudioAEStream.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DFB65F7715373AE7006B8FF1 /* CoreAudioAEStream.cpp */; };
-		DFB65FE515373AE7006B8FF1 /* AEPPAnimationFade.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DFB65F9315373AE7006B8FF1 /* AEPPAnimationFade.cpp */; };
-		DFB65FEC15373AE7006B8FF1 /* AEBitstreamPacker.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DFB65FA315373AE7006B8FF1 /* AEBitstreamPacker.cpp */; };
-		DFB65FED15373AE7006B8FF1 /* AEBuffer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DFB65FA515373AE7006B8FF1 /* AEBuffer.cpp */; };
-		DFB65FEE15373AE7006B8FF1 /* AEChannelInfo.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DFB65FA715373AE7006B8FF1 /* AEChannelInfo.cpp */; };
-		DFB65FEF15373AE7006B8FF1 /* AEConvert.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DFB65FA915373AE7006B8FF1 /* AEConvert.cpp */; };
-		DFB65FF015373AE7006B8FF1 /* AEPackIEC61937.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DFB65FAB15373AE7006B8FF1 /* AEPackIEC61937.cpp */; };
-		DFB65FF115373AE7006B8FF1 /* AERemap.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DFB65FAD15373AE7006B8FF1 /* AERemap.cpp */; };
-		DFB65FF215373AE7006B8FF1 /* AEStreamInfo.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DFB65FAF15373AE7006B8FF1 /* AEStreamInfo.cpp */; };
-		DFB65FF315373AE7006B8FF1 /* AEUtil.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DFB65FB115373AE7006B8FF1 /* AEUtil.cpp */; };
-		DFB65FF415373AE7006B8FF1 /* AEWAVLoader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DFB65FB315373AE7006B8FF1 /* AEWAVLoader.cpp */; };
 		DFB6610915374E80006B8FF1 /* DVDAudioCodecPassthrough.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DFB6610615374E80006B8FF1 /* DVDAudioCodecPassthrough.cpp */; };
-		DFB6610B15374E80006B8FF1 /* DVDAudioCodecPassthrough.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DFB6610615374E80006B8FF1 /* DVDAudioCodecPassthrough.cpp */; };
 		DFC1B8F01464840E00B1BE79 /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DFC1B8EF1464840E00B1BE79 /* SystemConfiguration.framework */; };
-		DFC1BA3414648D6500B1BE79 /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DFC1B8EF1464840E00B1BE79 /* SystemConfiguration.framework */; };
 		DFCA6AC6152245CD000BFAAE /* HTTPApiHandler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DFCA6AB9152245CD000BFAAE /* HTTPApiHandler.cpp */; };
 		DFCA6AC7152245CD000BFAAE /* HTTPJsonRpcHandler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DFCA6ABB152245CD000BFAAE /* HTTPJsonRpcHandler.cpp */; };
 		DFCA6AC8152245CD000BFAAE /* HTTPVfsHandler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DFCA6ABD152245CD000BFAAE /* HTTPVfsHandler.cpp */; };
 		DFCA6AC9152245CD000BFAAE /* HTTPWebinterfaceAddonsHandler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DFCA6ABF152245CD000BFAAE /* HTTPWebinterfaceAddonsHandler.cpp */; };
 		DFCA6ACA152245CD000BFAAE /* HTTPWebinterfaceHandler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DFCA6AC1152245CD000BFAAE /* HTTPWebinterfaceHandler.cpp */; };
 		DFCA6ACB152245CD000BFAAE /* IHTTPRequestHandler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DFCA6AC3152245CD000BFAAE /* IHTTPRequestHandler.cpp */; };
-		DFCA6ACD152245CD000BFAAE /* HTTPApiHandler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DFCA6AB9152245CD000BFAAE /* HTTPApiHandler.cpp */; };
-		DFCA6ACE152245CD000BFAAE /* HTTPJsonRpcHandler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DFCA6ABB152245CD000BFAAE /* HTTPJsonRpcHandler.cpp */; };
-		DFCA6ACF152245CD000BFAAE /* HTTPVfsHandler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DFCA6ABD152245CD000BFAAE /* HTTPVfsHandler.cpp */; };
-		DFCA6AD0152245CD000BFAAE /* HTTPWebinterfaceAddonsHandler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DFCA6ABF152245CD000BFAAE /* HTTPWebinterfaceAddonsHandler.cpp */; };
-		DFCA6AD1152245CD000BFAAE /* HTTPWebinterfaceHandler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DFCA6AC1152245CD000BFAAE /* HTTPWebinterfaceHandler.cpp */; };
-		DFCA6AD2152245CD000BFAAE /* IHTTPRequestHandler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DFCA6AC3152245CD000BFAAE /* IHTTPRequestHandler.cpp */; };
 		E306D12E0DDF7B590052C2AD /* XBMCHelper.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E306D12C0DDF7B590052C2AD /* XBMCHelper.cpp */; };
 		E33206380D5070AA00435CE3 /* DVDDemuxVobsub.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E33206370D5070AA00435CE3 /* DVDDemuxVobsub.cpp */; };
 		E33466A60D2E5103005A65EC /* IOKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E33466A50D2E5103005A65EC /* IOKit.framework */; };
@@ -1219,52 +858,35 @@
 		E3E920020D8C622A002BF43D /* EventClient.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E3E920010D8C622A002BF43D /* EventClient.cpp */; };
 		E43196170FB2382E0030E150 /* HTSPDirectory.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E43196140FB2382E0030E150 /* HTSPDirectory.cpp */; };
 		E43196180FB2382E0030E150 /* HTSPSession.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E43196160FB2382E0030E150 /* HTSPSession.cpp */; };
-		E43196190FB2382E0030E150 /* HTSPDirectory.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E43196140FB2382E0030E150 /* HTSPDirectory.cpp */; };
-		E431961A0FB2382E0030E150 /* HTSPSession.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E43196160FB2382E0030E150 /* HTSPSession.cpp */; };
-		E435380311076A2900792AB8 /* eprintf.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5ACB5370FC3DF3D00AAA056 /* eprintf.cpp */; };
 		E435380411076A2900792AB8 /* eprintf.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5ACB5370FC3DF3D00AAA056 /* eprintf.cpp */; };
 		E46F7C2A0F77217400C25D29 /* Zeroconf.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E46F7C280F77217400C25D29 /* Zeroconf.cpp */; };
 		E46F7C2D0F77219700C25D29 /* ZeroconfOSX.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E46F7C2C0F77219700C25D29 /* ZeroconfOSX.cpp */; };
 		E49ACD8C100745C400A86ECD /* ZeroconfDirectory.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E49ACD8B100745C400A86ECD /* ZeroconfDirectory.cpp */; };
-		E49ACD8D100745C400A86ECD /* ZeroconfDirectory.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E49ACD8B100745C400A86ECD /* ZeroconfDirectory.cpp */; };
 		E49ACD9F10074A4000A86ECD /* ZeroconfBrowserOSX.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E49ACD9D10074A4000A86ECD /* ZeroconfBrowserOSX.cpp */; };
-		E49ACDA010074A4000A86ECD /* ZeroconfBrowserOSX.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E49ACD9D10074A4000A86ECD /* ZeroconfBrowserOSX.cpp */; };
 		E49ACDD510074F9200A86ECD /* ZeroconfBrowser.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E49ACDD410074F9200A86ECD /* ZeroconfBrowser.cpp */; };
-		E49ACDD610074F9200A86ECD /* ZeroconfBrowser.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E49ACDD410074F9200A86ECD /* ZeroconfBrowser.cpp */; };
 		E4A249F71095C880003D74C6 /* AutorunMediaJob.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E4A249F51095C880003D74C6 /* AutorunMediaJob.cpp */; };
-		E4A249F81095C880003D74C6 /* AutorunMediaJob.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E4A249F51095C880003D74C6 /* AutorunMediaJob.cpp */; };
 		E4DC97540FFE5BA8008E0C07 /* SAPDirectory.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E4DC97500FFE5BA8008E0C07 /* SAPDirectory.cpp */; };
 		E4DC97550FFE5BA8008E0C07 /* SAPFile.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E4DC97520FFE5BA8008E0C07 /* SAPFile.cpp */; };
-		E4DC97560FFE5BA8008E0C07 /* SAPDirectory.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E4DC97500FFE5BA8008E0C07 /* SAPDirectory.cpp */; };
-		E4DC97570FFE5BA8008E0C07 /* SAPFile.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E4DC97520FFE5BA8008E0C07 /* SAPFile.cpp */; };
 		E4E91BB80E7F7338001F0546 /* NptXbmcFile.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E4E91BB70E7F7338001F0546 /* NptXbmcFile.cpp */; };
 		EC720A8F155091BB00FFD782 /* ilog.cpp in Sources */ = {isa = PBXBuildFile; fileRef = EC720A8D155091BB00FFD782 /* ilog.cpp */; };
-		EC720A90155091BB00FFD782 /* ilog.cpp in Sources */ = {isa = PBXBuildFile; fileRef = EC720A8D155091BB00FFD782 /* ilog.cpp */; };
 		EC720A9D1550927000FFD782 /* XbmcContext.cpp in Sources */ = {isa = PBXBuildFile; fileRef = EC720A9B1550927000FFD782 /* XbmcContext.cpp */; };
-		EC720A9E1550927000FFD782 /* XbmcContext.cpp in Sources */ = {isa = PBXBuildFile; fileRef = EC720A9B1550927000FFD782 /* XbmcContext.cpp */; };
 		F506297A0E57B9680066625A /* MultiPathFile.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F50629780E57B9680066625A /* MultiPathFile.cpp */; };
 		F50FDC5A119B4B2C00C8B8CD /* GUIDialogTextViewer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F50FDC59119B4B2C00C8B8CD /* GUIDialogTextViewer.cpp */; };
-		F50FDC5B119B4B2C00C8B8CD /* GUIDialogTextViewer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F50FDC59119B4B2C00C8B8CD /* GUIDialogTextViewer.cpp */; };
 		F50FE04A11A3410300C8B8CD /* EncoderFlac.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F50FE04811A3410300C8B8CD /* EncoderFlac.cpp */; };
-		F50FE04B11A3410300C8B8CD /* EncoderFlac.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F50FE04811A3410300C8B8CD /* EncoderFlac.cpp */; };
 		F50FE04E11A3411A00C8B8CD /* EncoderFFmpeg.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F50FE04D11A3411A00C8B8CD /* EncoderFFmpeg.cpp */; };
-		F50FE04F11A3411B00C8B8CD /* EncoderFFmpeg.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F50FE04D11A3411A00C8B8CD /* EncoderFFmpeg.cpp */; };
 		F51CEEEF0F5C5D20004F4602 /* OSXGNUReplacements.c in Sources */ = {isa = PBXBuildFile; fileRef = F51CEEEE0F5C5D20004F4602 /* OSXGNUReplacements.c */; };
 		F51CEF880F5C64A5004F4602 /* DVDInputStreamHTSP.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F51CEF860F5C64A5004F4602 /* DVDInputStreamHTSP.cpp */; };
 		F51CF2D00F6055A4004F4602 /* sha1.c in Sources */ = {isa = PBXBuildFile; fileRef = F51CF2CE0F6055A4004F4602 /* sha1.c */; };
 		F52910140EE1D5F0001167F0 /* DirectoryNodeMusicVideoAlbum.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F52910130EE1D5F0001167F0 /* DirectoryNodeMusicVideoAlbum.cpp */; };
 		F52B063B11869862004B1D66 /* Skin.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F52B063A11869862004B1D66 /* Skin.cpp */; };
-		F52B063C11869862004B1D66 /* Skin.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F52B063A11869862004B1D66 /* Skin.cpp */; };
 		F52B06BA1187CE18004B1D66 /* DVDVideoCodecVDA.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F52B06B81187CE18004B1D66 /* DVDVideoCodecVDA.cpp */; };
-		F52B06BB1187CE18004B1D66 /* DVDVideoCodecVDA.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F52B06B81187CE18004B1D66 /* DVDVideoCodecVDA.cpp */; };
 		F52BFFDB115D5574004B1D66 /* AddonStatusHandler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F52BFFDA115D5574004B1D66 /* AddonStatusHandler.cpp */; };
-		F52BFFDC115D5574004B1D66 /* AddonStatusHandler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F52BFFDA115D5574004B1D66 /* AddonStatusHandler.cpp */; };
+		F5364D34155B3B270016D00B /* CoreVideo.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F5364D33155B3B270016D00B /* CoreVideo.framework */; };
+		F5364D55155B3C7B0016D00B /* libm.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = F5364D54155B3C7B0016D00B /* libm.dylib */; };
+		F5364E05155B3CAF0016D00B /* IOSurface.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F5364E04155B3CAF0016D00B /* IOSurface.framework */; };
 		F548786D0FE060FF00E506FD /* DVDSubtitleParserMPL2.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F548786C0FE060FF00E506FD /* DVDSubtitleParserMPL2.cpp */; };
-		F548786E0FE060FF00E506FD /* DVDSubtitleParserMPL2.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F548786C0FE060FF00E506FD /* DVDSubtitleParserMPL2.cpp */; };
 		F5487B4C0FE6F02700E506FD /* StreamDetails.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5487B4B0FE6F02700E506FD /* StreamDetails.cpp */; };
-		F5487B4D0FE6F02700E506FD /* StreamDetails.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5487B4B0FE6F02700E506FD /* StreamDetails.cpp */; };
 		F54BCC5F1439345300F86B0F /* HotKeyController.m in Sources */ = {isa = PBXBuildFile; fileRef = F54BCC5E1439345300F86B0F /* HotKeyController.m */; };
-		F54BCC601439345300F86B0F /* HotKeyController.m in Sources */ = {isa = PBXBuildFile; fileRef = F54BCC5E1439345300F86B0F /* HotKeyController.m */; };
 		F54C51D20F1E783200D46E3C /* GUIDialogKaraokeSongSelector.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F54C51D00F1E783200D46E3C /* GUIDialogKaraokeSongSelector.cpp */; };
 		F54C51D50F1E784800D46E3C /* karaokelyricscdg.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F54C51D40F1E784800D46E3C /* karaokelyricscdg.cpp */; };
 		F54C51D80F1E785700D46E3C /* karaokelyrics.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F54C51D60F1E785700D46E3C /* karaokelyrics.cpp */; };
@@ -1281,591 +903,41 @@
 		F55110800F5C424700955236 /* htsstr.c in Sources */ = {isa = PBXBuildFile; fileRef = F55110760F5C424700955236 /* htsstr.c */; };
 		F55110820F5C424700955236 /* net_posix.c in Sources */ = {isa = PBXBuildFile; fileRef = F551107B0F5C424700955236 /* net_posix.c */; };
 		F558F25613ABCF7800631E12 /* WinEventsOSX.mm in Sources */ = {isa = PBXBuildFile; fileRef = F558F25513ABCF7800631E12 /* WinEventsOSX.mm */; };
-		F558F25713ABCF7800631E12 /* WinEventsOSX.mm in Sources */ = {isa = PBXBuildFile; fileRef = F558F25513ABCF7800631E12 /* WinEventsOSX.mm */; };
 		F558F27B13ABD56600631E12 /* DirtyRegionSolvers.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F558F27913ABD56600631E12 /* DirtyRegionSolvers.cpp */; };
-		F558F27C13ABD56600631E12 /* DirtyRegionSolvers.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F558F27913ABD56600631E12 /* DirtyRegionSolvers.cpp */; };
 		F558F27F13ABD57400631E12 /* DirtyRegionTracker.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F558F27D13ABD57400631E12 /* DirtyRegionTracker.cpp */; };
-		F558F28013ABD57400631E12 /* DirtyRegionTracker.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F558F27D13ABD57400631E12 /* DirtyRegionTracker.cpp */; };
 		F558F29613ABD7DF00631E12 /* GUIWindowDebugInfo.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F558F29413ABD7DF00631E12 /* GUIWindowDebugInfo.cpp */; };
-		F558F29713ABD7DF00631E12 /* GUIWindowDebugInfo.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F558F29413ABD7DF00631E12 /* GUIWindowDebugInfo.cpp */; };
-		F558F3D113AE663A00631E12 /* NFSDirectory.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF0DF15913A3ADA7008ED511 /* NFSDirectory.cpp */; };
 		F56579AF13060D1E0085ED7F /* RenderCapture.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F56579AD13060D1E0085ED7F /* RenderCapture.cpp */; };
 		F56A084B0F4A18FB003F9F87 /* karaokewindowbackground.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F56A084A0F4A18FB003F9F87 /* karaokewindowbackground.cpp */; };
 		F56C8CE7131F5DC6000AD0F6 /* libz.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = F56C8CE6131F5DC6000AD0F6 /* libz.dylib */; };
-		F56C8CE8131F5DC6000AD0F6 /* libz.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = F56C8CE6131F5DC6000AD0F6 /* libz.dylib */; };
-		F56C8CEA131F5DCC000AD0F6 /* libm.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = F56C8CE9131F5DCC000AD0F6 /* libm.dylib */; };
-		F56C8CEB131F5DCC000AD0F6 /* libm.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = F56C8CE9131F5DCC000AD0F6 /* libm.dylib */; };
 		F56C8CED131F5DE7000AD0F6 /* libbz2.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = F56C8CEC131F5DE7000AD0F6 /* libbz2.dylib */; };
-		F56C8CEE131F5DE7000AD0F6 /* libbz2.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = F56C8CEC131F5DE7000AD0F6 /* libbz2.dylib */; };
 		F56C8CF0131F5DED000AD0F6 /* libxml2.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = F56C8CEF131F5DED000AD0F6 /* libxml2.dylib */; };
-		F56C8CF1131F5DED000AD0F6 /* libxml2.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = F56C8CEF131F5DED000AD0F6 /* libxml2.dylib */; };
 		F56C8CF3131F5DFD000AD0F6 /* libiconv.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = F56C8CF2131F5DFD000AD0F6 /* libiconv.dylib */; };
-		F56C8CF4131F5DFD000AD0F6 /* libiconv.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = F56C8CF2131F5DFD000AD0F6 /* libiconv.dylib */; };
 		F56C8CF6131F5E0B000AD0F6 /* libncurses.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = F56C8CF5131F5E0B000AD0F6 /* libncurses.dylib */; };
-		F56C8CF7131F5E0B000AD0F6 /* libncurses.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = F56C8CF5131F5E0B000AD0F6 /* libncurses.dylib */; };
 		F57A1D1E1329B15300498CC7 /* AutoPool.mm in Sources */ = {isa = PBXBuildFile; fileRef = F57A1D1D1329B15300498CC7 /* AutoPool.mm */; };
-		F57A1D1F1329B15300498CC7 /* AutoPool.mm in Sources */ = {isa = PBXBuildFile; fileRef = F57A1D1D1329B15300498CC7 /* AutoPool.mm */; };
 		F57B6F801071B8B500079ACB /* JobManager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F57B6F7E1071B8B500079ACB /* JobManager.cpp */; };
-		F57B6F811071B8B500079ACB /* JobManager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F57B6F7E1071B8B500079ACB /* JobManager.cpp */; };
 		F584E12E0F257C5100DB26A5 /* HTTPDirectory.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F584E12D0F257C5100DB26A5 /* HTTPDirectory.cpp */; };
 		F58E293911FFC103006F4D46 /* DVDInputStreamBluray.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F58E293711FFC103006F4D46 /* DVDInputStreamBluray.cpp */; };
-		F58E293A11FFC103006F4D46 /* DVDInputStreamBluray.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F58E293711FFC103006F4D46 /* DVDInputStreamBluray.cpp */; };
 		F592568810FBF2E100D2C91D /* ConvolutionKernels.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F592568710FBF2E100D2C91D /* ConvolutionKernels.cpp */; };
-		F592568910FBF2E100D2C91D /* ConvolutionKernels.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F592568710FBF2E100D2C91D /* ConvolutionKernels.cpp */; };
 		F595994510E9F322004B58B3 /* DVDVideoCodecCrystalHD.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F595994410E9F322004B58B3 /* DVDVideoCodecCrystalHD.cpp */; };
 		F59876BC0FBA34C0008EF4FB /* DVDPlayerAudioResampler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F59876BA0FBA34C0008EF4FB /* DVDPlayerAudioResampler.cpp */; };
-		F59876BD0FBA34C0008EF4FB /* DVDPlayerAudioResampler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F59876BA0FBA34C0008EF4FB /* DVDPlayerAudioResampler.cpp */; };
 		F59876C00FBA351D008EF4FB /* VideoReferenceClock.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F59876BF0FBA351D008EF4FB /* VideoReferenceClock.cpp */; };
-		F59876C10FBA351D008EF4FB /* VideoReferenceClock.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F59876BF0FBA351D008EF4FB /* VideoReferenceClock.cpp */; };
 		F59879080FBAA0C3008EF4FB /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F59879070FBAA0C3008EF4FB /* QuartzCore.framework */; };
-		F59879090FBAA0C3008EF4FB /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F59879070FBAA0C3008EF4FB /* QuartzCore.framework */; };
 		F5987B250FBB9682008EF4FB /* librefmscrobbler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5987B220FBB9682008EF4FB /* librefmscrobbler.cpp */; };
 		F5987B260FBB9682008EF4FB /* lastfmscrobbler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5987B230FBB9682008EF4FB /* lastfmscrobbler.cpp */; };
-		F5987B270FBB9682008EF4FB /* librefmscrobbler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5987B220FBB9682008EF4FB /* librefmscrobbler.cpp */; };
-		F5987B280FBB9682008EF4FB /* lastfmscrobbler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5987B230FBB9682008EF4FB /* lastfmscrobbler.cpp */; };
 		F5987F050FBDF274008EF4FB /* DPMSSupport.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5987F040FBDF274008EF4FB /* DPMSSupport.cpp */; };
-		F5987F060FBDF274008EF4FB /* DPMSSupport.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5987F040FBDF274008EF4FB /* DPMSSupport.cpp */; };
 		F5987FDB0FBE2DFD008EF4FB /* PAPlayer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5987FDA0FBE2DFD008EF4FB /* PAPlayer.cpp */; };
-		F5987FDC0FBE2DFD008EF4FB /* PAPlayer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5987FDA0FBE2DFD008EF4FB /* PAPlayer.cpp */; };
 		F599CD2B108E65370010EC2A /* IoSupport.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F599CD29108E65370010EC2A /* IoSupport.cpp */; };
-		F599CD2C108E65370010EC2A /* IoSupport.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F599CD29108E65370010EC2A /* IoSupport.cpp */; };
 		F599CD74108E6A7A0010EC2A /* DarwinStorageProvider.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F599CD73108E6A7A0010EC2A /* DarwinStorageProvider.cpp */; };
-		F599CD75108E6A7A0010EC2A /* DarwinStorageProvider.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F599CD73108E6A7A0010EC2A /* DarwinStorageProvider.cpp */; };
-		F5A1C8C00F6B06CF00A96ABD /* Application.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E14640D25F9F900618676 /* Application.cpp */; };
-		F5A1C8C10F6B06CF00A96ABD /* ApplicationMessenger.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E14660D25F9F900618676 /* ApplicationMessenger.cpp */; };
-		F5A1C8C40F6B06CF00A96ABD /* Autorun.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E146E0D25F9F900618676 /* Autorun.cpp */; };
-		F5A1C8C50F6B06CF00A96ABD /* AutoSwitch.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E14700D25F9F900618676 /* AutoSwitch.cpp */; };
-		F5A1C8C60F6B06CF00A96ABD /* BackgroundInfoLoader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E14720D25F9F900618676 /* BackgroundInfoLoader.cpp */; };
-		F5A1C8C80F6B06CF00A96ABD /* CDDAReader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E14800D25F9F900618676 /* CDDAReader.cpp */; };
-		F5A1C8C90F6B06CF00A96ABD /* CDDARipper.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E14820D25F9F900618676 /* CDDARipper.cpp */; };
-		F5A1C8CA0F6B06CF00A96ABD /* Encoder.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E14880D25F9F900618676 /* Encoder.cpp */; };
-		F5A1C8CB0F6B06CF00A96ABD /* EncoderLame.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E148A0D25F9F900618676 /* EncoderLame.cpp */; };
-		F5A1C8CC0F6B06CF00A96ABD /* EncoderVorbis.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E148C0D25F9F900618676 /* EncoderVorbis.cpp */; };
-		F5A1C8CD0F6B06CF00A96ABD /* EncoderWav.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E148E0D25F9F900618676 /* EncoderWav.cpp */; };
-		F5A1C8CE0F6B06CF00A96ABD /* coff.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E149E0D25F9F900618676 /* coff.cpp */; };
-		F5A1C8CF0F6B06CF00A96ABD /* dll.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E14A30D25F9F900618676 /* dll.cpp */; };
-		F5A1C8D00F6B06CF00A96ABD /* dll_tracker.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E14A50D25F9F900618676 /* dll_tracker.cpp */; };
-		F5A1C8D20F6B06CF00A96ABD /* dll_tracker_file.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E14A90D25F9F900618676 /* dll_tracker_file.cpp */; };
-		F5A1C8D30F6B06CF00A96ABD /* dll_tracker_library.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E14AB0D25F9F900618676 /* dll_tracker_library.cpp */; };
-		F5A1C8D50F6B06CF00A96ABD /* dll_util.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E14B10D25F9F900618676 /* dll_util.cpp */; };
-		F5A1C8D60F6B06CF00A96ABD /* DllLoader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E14B40D25F9F900618676 /* DllLoader.cpp */; };
-		F5A1C8D70F6B06CF00A96ABD /* DllLoaderContainer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E14B60D25F9F900618676 /* DllLoaderContainer.cpp */; };
-		F5A1C8D80F6B06CF00A96ABD /* emu_dummy.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E14B90D25F9F900618676 /* emu_dummy.cpp */; };
-		F5A1C8DA0F6B06CF00A96ABD /* emu_kernel32.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E14BD0D25F9F900618676 /* emu_kernel32.cpp */; };
-		F5A1C8DB0F6B06CF00A96ABD /* emu_msvcrt.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E14C10D25F9F900618676 /* emu_msvcrt.cpp */; };
-		F5A1C8DF0F6B06CF00A96ABD /* EmuFileWrapper.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E14E30D25F9F900618676 /* EmuFileWrapper.cpp */; };
-		F5A1C8E00F6B06CF00A96ABD /* wrapper.c in Sources */ = {isa = PBXBuildFile; fileRef = E38E14E80D25F9F900618676 /* wrapper.c */; };
-		F5A1C8E10F6B06CF00A96ABD /* ldt_keeper.c in Sources */ = {isa = PBXBuildFile; fileRef = E38E14EB0D25F9F900618676 /* ldt_keeper.c */; };
-		F5A1C8E20F6B06CF00A96ABD /* LibraryLoader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E14ED0D25F9F900618676 /* LibraryLoader.cpp */; };
-		F5A1C8E30F6B06CF00A96ABD /* mmap_anon.c in Sources */ = {isa = PBXBuildFile; fileRef = E38E14F10D25F9F900618676 /* mmap_anon.c */; };
-		F5A1C8E40F6B06CF00A96ABD /* SoLoader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E14F40D25F9F900618676 /* SoLoader.cpp */; };
-		F5A1C8E50F6B06CF00A96ABD /* DummyVideoPlayer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E14F60D25F9F900618676 /* DummyVideoPlayer.cpp */; };
-		F5A1C8E70F6B06CF00A96ABD /* DVDAudio.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E14FC0D25F9F900618676 /* DVDAudio.cpp */; };
-		F5A1C8E80F6B06CF00A96ABD /* DVDClock.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E14FE0D25F9F900618676 /* DVDClock.cpp */; };
-		F5A1C8E90F6B06CF00A96ABD /* DVDAudioCodecFFmpeg.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E15070D25F9F900618676 /* DVDAudioCodecFFmpeg.cpp */; };
-		F5A1C8ED0F6B06CF00A96ABD /* DVDAudioCodecLibMad.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E150F0D25F9F900618676 /* DVDAudioCodecLibMad.cpp */; };
-		F5A1C8EE0F6B06CF00A96ABD /* DVDAudioCodecLPcm.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E15110D25F9F900618676 /* DVDAudioCodecLPcm.cpp */; };
-		F5A1C8F00F6B06CF00A96ABD /* DVDAudioCodecPcm.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E15150D25F9F900618676 /* DVDAudioCodecPcm.cpp */; };
-		F5A1C8F10F6B06CF00A96ABD /* DVDCodecUtils.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E15220D25F9F900618676 /* DVDCodecUtils.cpp */; };
-		F5A1C8F20F6B06CF00A96ABD /* DVDFactoryCodec.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E15240D25F9F900618676 /* DVDFactoryCodec.cpp */; };
-		F5A1C8F30F6B06CF00A96ABD /* DVDOverlayCodecCC.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E152B0D25F9F900618676 /* DVDOverlayCodecCC.cpp */; };
-		F5A1C8F40F6B06CF00A96ABD /* DVDOverlayCodecFFmpeg.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E152D0D25F9F900618676 /* DVDOverlayCodecFFmpeg.cpp */; };
-		F5A1C8F50F6B06CF00A96ABD /* DVDOverlayCodecText.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E152F0D25F9F900618676 /* DVDOverlayCodecText.cpp */; };
-		F5A1C8F60F6B06CF00A96ABD /* cc_decoder.c in Sources */ = {isa = PBXBuildFile; fileRef = E38E15350D25F9F900618676 /* cc_decoder.c */; };
-		F5A1C8F70F6B06CF00A96ABD /* DVDVideoCodecFFmpeg.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E153D0D25F9F900618676 /* DVDVideoCodecFFmpeg.cpp */; };
-		F5A1C8F80F6B06CF00A96ABD /* DVDVideoCodecLibMpeg2.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E153F0D25F9F900618676 /* DVDVideoCodecLibMpeg2.cpp */; };
-		F5A1C8F90F6B06CF00A96ABD /* DVDVideoPPFFmpeg.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E15410D25F9F900618676 /* DVDVideoPPFFmpeg.cpp */; };
-		F5A1C8FA0F6B06CF00A96ABD /* DVDDemux.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E15490D25F9F900618676 /* DVDDemux.cpp */; };
-		F5A1C8FB0F6B06CF00A96ABD /* DVDDemuxShoutcast.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E154D0D25F9F900618676 /* DVDDemuxShoutcast.cpp */; };
-		F5A1C8FC0F6B06CF00A96ABD /* DVDDemuxUtils.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E154F0D25F9F900618676 /* DVDDemuxUtils.cpp */; };
-		F5A1C8FD0F6B06CF00A96ABD /* DVDDemuxSPU.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E15550D25F9FA00618676 /* DVDDemuxSPU.cpp */; };
-		F5A1C8FE0F6B06CF00A96ABD /* DVDFactoryInputStream.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E15590D25F9FA00618676 /* DVDFactoryInputStream.cpp */; };
-		F5A1C8FF0F6B06CF00A96ABD /* DVDInputStream.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E155B0D25F9FA00618676 /* DVDInputStream.cpp */; };
-		F5A1C9000F6B06CF00A96ABD /* DVDInputStreamFFmpeg.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E155D0D25F9FA00618676 /* DVDInputStreamFFmpeg.cpp */; };
-		F5A1C9010F6B06CF00A96ABD /* DVDInputStreamFile.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E155F0D25F9FA00618676 /* DVDInputStreamFile.cpp */; };
-		F5A1C9020F6B06CF00A96ABD /* DVDInputStreamHttp.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E15610D25F9FA00618676 /* DVDInputStreamHttp.cpp */; };
-		F5A1C9030F6B06CF00A96ABD /* DVDInputStreamMemory.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E15630D25F9FA00618676 /* DVDInputStreamMemory.cpp */; };
-		F5A1C9040F6B06CF00A96ABD /* DVDInputStreamNavigator.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E15650D25F9FA00618676 /* DVDInputStreamNavigator.cpp */; };
-		F5A1C9050F6B06CF00A96ABD /* DVDStateSerializer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E15740D25F9FA00618676 /* DVDStateSerializer.cpp */; };
-		F5A1C9060F6B06CF00A96ABD /* DVDMessage.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E15780D25F9FA00618676 /* DVDMessage.cpp */; };
-		F5A1C9070F6B06CF00A96ABD /* DVDMessageQueue.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E157A0D25F9FA00618676 /* DVDMessageQueue.cpp */; };
-		F5A1C9080F6B06CF00A96ABD /* DVDMessageTracker.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E157C0D25F9FA00618676 /* DVDMessageTracker.cpp */; };
-		F5A1C9090F6B06CF00A96ABD /* DVDOverlayContainer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E157E0D25F9FA00618676 /* DVDOverlayContainer.cpp */; };
-		F5A1C90A0F6B06CF00A96ABD /* DVDOverlayRenderer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E15800D25F9FA00618676 /* DVDOverlayRenderer.cpp */; };
-		F5A1C90B0F6B06CF00A96ABD /* DVDPerformanceCounter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E15820D25F9FA00618676 /* DVDPerformanceCounter.cpp */; };
-		F5A1C90C0F6B06CF00A96ABD /* DVDPlayer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E15840D25F9FA00618676 /* DVDPlayer.cpp */; };
-		F5A1C90D0F6B06CF00A96ABD /* DVDPlayerAudio.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E15860D25F9FA00618676 /* DVDPlayerAudio.cpp */; };
-		F5A1C90E0F6B06CF00A96ABD /* DVDPlayerSubtitle.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E15880D25F9FA00618676 /* DVDPlayerSubtitle.cpp */; };
-		F5A1C90F0F6B06CF00A96ABD /* DVDPlayerVideo.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E158A0D25F9FA00618676 /* DVDPlayerVideo.cpp */; };
-		F5A1C9100F6B06CF00A96ABD /* DVDStreamInfo.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E158C0D25F9FA00618676 /* DVDStreamInfo.cpp */; };
-		F5A1C9110F6B06CF00A96ABD /* DVDFactorySubtitle.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E158F0D25F9FA00618676 /* DVDFactorySubtitle.cpp */; };
-		F5A1C9120F6B06CF00A96ABD /* DVDSubtitleLineCollection.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E15910D25F9FA00618676 /* DVDSubtitleLineCollection.cpp */; };
-		F5A1C9130F6B06CF00A96ABD /* DVDSubtitleParserSubrip.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E15940D25F9FA00618676 /* DVDSubtitleParserSubrip.cpp */; };
-		F5A1C9140F6B06CF00A96ABD /* DVDSubtitleStream.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E15960D25F9FA00618676 /* DVDSubtitleStream.cpp */; };
-		F5A1C9190F6B06CF00A96ABD /* ADPCMCodec.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E15DB0D25F9FA00618676 /* ADPCMCodec.cpp */; };
-		F5A1C91D0F6B06CF00A96ABD /* AudioDecoder.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E15E30D25F9FA00618676 /* AudioDecoder.cpp */; };
-		F5A1C91E0F6B06CF00A96ABD /* CDDAcodec.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E15E60D25F9FA00618676 /* CDDAcodec.cpp */; };
-		F5A1C91F0F6B06CF00A96ABD /* CodecFactory.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E15E80D25F9FA00618676 /* CodecFactory.cpp */; };
-		F5A1C9200F6B06CF00A96ABD /* FLACcodec.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E160A0D25F9FA00618676 /* FLACcodec.cpp */; };
-		F5A1C9230F6B06CF00A96ABD /* MP3codec.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E16130D25F9FA00618676 /* MP3codec.cpp */; };
-		F5A1C9250F6B06CF00A96ABD /* NSFCodec.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E161B0D25F9FA00618676 /* NSFCodec.cpp */; };
-		F5A1C9260F6B06CF00A96ABD /* OGGcodec.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E16230D25F9FA00618676 /* OGGcodec.cpp */; };
-		F5A1C9270F6B06CF00A96ABD /* ReplayGain.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E162A0D25F9FA00618676 /* ReplayGain.cpp */; };
-		F5A1C9290F6B06CF00A96ABD /* SIDCodec.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E16310D25F9FA00618676 /* SIDCodec.cpp */; };
-		F5A1C92A0F6B06CF00A96ABD /* SPCCodec.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E16350D25F9FA00618676 /* SPCCodec.cpp */; };
-		F5A1C92B0F6B06CF00A96ABD /* TimidityCodec.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E16370D25F9FA00618676 /* TimidityCodec.cpp */; };
-		F5A1C92C0F6B06CF00A96ABD /* WAVcodec.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E16390D25F9FA00618676 /* WAVcodec.cpp */; };
-		F5A1C92F0F6B06CF00A96ABD /* YMCodec.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E16410D25F9FA00618676 /* YMCodec.cpp */; };
-		F5A1C9310F6B06CF00A96ABD /* ssrc.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E16560D25F9FA00618676 /* ssrc.cpp */; };
-		F5A1C9340F6B06CF00A96ABD /* LinuxRendererGL.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E165F0D25F9FA00618676 /* LinuxRendererGL.cpp */; };
-		F5A1C9350F6B06CF00A96ABD /* RenderManager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E16650D25F9FA00618676 /* RenderManager.cpp */; };
-		F5A1C9360F6B06CF00A96ABD /* VideoFilterShader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E166F0D25F9FA00618676 /* VideoFilterShader.cpp */; };
-		F5A1C9370F6B06CF00A96ABD /* YUV2RGBShader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E16710D25F9FA00618676 /* YUV2RGBShader.cpp */; };
-		F5A1C9390F6B06CF00A96ABD /* CueDocument.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E167E0D25F9FA00618676 /* CueDocument.cpp */; };
-		F5A1C93A0F6B06CF00A96ABD /* Database.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E16800D25F9FA00618676 /* Database.cpp */; };
-		F5A1C93C0F6B06CF00A96ABD /* DetectDVDType.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E16840D25F9FA00618676 /* DetectDVDType.cpp */; };
-		F5A1C93D0F6B06CF00A96ABD /* DNSNameCache.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E16890D25F9FA00618676 /* DNSNameCache.cpp */; };
-		F5A1C93E0F6B06CF00A96ABD /* DynamicDll.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E168C0D25F9FA00618676 /* DynamicDll.cpp */; };
-		F5A1C9400F6B06CF00A96ABD /* Favourites.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E16900D25F9FA00618676 /* Favourites.cpp */; };
-		F5A1C9410F6B06CF00A96ABD /* FileItem.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E16920D25F9FA00618676 /* FileItem.cpp */; };
-		F5A1C9420F6B06CF00A96ABD /* MemBufferCache.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E16970D25F9FA00618676 /* MemBufferCache.cpp */; };
-		F5A1C9430F6B06CF00A96ABD /* CacheStrategy.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E16990D25F9FA00618676 /* CacheStrategy.cpp */; };
-		F5A1C9440F6B06CF00A96ABD /* CDDADirectory.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E169B0D25F9FA00618676 /* CDDADirectory.cpp */; };
-		F5A1C9450F6B06CF00A96ABD /* cddb.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E169D0D25F9FA00618676 /* cddb.cpp */; };
-		F5A1C9460F6B06CF00A96ABD /* cdioSupport.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E169F0D25F9FA00618676 /* cdioSupport.cpp */; };
-		F5A1C9470F6B06CF00A96ABD /* DAAPDirectory.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E16AA0D25F9FA00618676 /* DAAPDirectory.cpp */; };
-		F5A1C9480F6B06CF00A96ABD /* Directory.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E16AC0D25F9FA00618676 /* Directory.cpp */; };
-		F5A1C94A0F6B06CF00A96ABD /* DirectoryHistory.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E16B00D25F9FA00618676 /* DirectoryHistory.cpp */; };
-		F5A1C94C0F6B06CF00A96ABD /* DllLibCurl.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E16B40D25F9FA00618676 /* DllLibCurl.cpp */; };
-		F5A1C94F0F6B06CF00A96ABD /* File.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E16BA0D25F9FA00618676 /* File.cpp */; };
-		F5A1C9540F6B06CF00A96ABD /* FileFactory.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E16C40D25F9FA00618676 /* FileFactory.cpp */; };
-		F5A1C95E0F6B06CF00A96ABD /* FTPDirectory.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E16E40D25F9FA00618676 /* FTPDirectory.cpp */; };
-		F5A1C95F0F6B06CF00A96ABD /* FTPParse.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E16E60D25F9FA00618676 /* FTPParse.cpp */; };
-		F5A1C9600F6B06CF00A96ABD /* HDDirectory.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E16E80D25F9FA00618676 /* HDDirectory.cpp */; };
-		F5A1C9620F6B06CF00A96ABD /* IDirectory.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E16EC0D25F9FA00618676 /* IDirectory.cpp */; };
-		F5A1C9630F6B06CF00A96ABD /* IFile.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E16EE0D25F9FA00618676 /* IFile.cpp */; };
-		F5A1C9640F6B06CF00A96ABD /* iso9660.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E16F10D25F9FA00618676 /* iso9660.cpp */; };
-		F5A1C9650F6B06CF00A96ABD /* ISO9660Directory.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E16F30D25F9FA00618676 /* ISO9660Directory.cpp */; };
-		F5A1C9660F6B06CF00A96ABD /* LastFMDirectory.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E16F50D25F9FA00618676 /* LastFMDirectory.cpp */; };
-		F5A1C9670F6B06CF00A96ABD /* MultiPathDirectory.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E17080D25F9FA00618676 /* MultiPathDirectory.cpp */; };
-		F5A1C9680F6B06CF00A96ABD /* DirectoryNode.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E170B0D25F9FA00618676 /* DirectoryNode.cpp */; };
-		F5A1C9690F6B06CF00A96ABD /* DirectoryNodeAlbum.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E170D0D25F9FA00618676 /* DirectoryNodeAlbum.cpp */; };
-		F5A1C96A0F6B06CF00A96ABD /* DirectoryNodeAlbumCompilations.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E170F0D25F9FA00618676 /* DirectoryNodeAlbumCompilations.cpp */; };
-		F5A1C96B0F6B06CF00A96ABD /* DirectoryNodeAlbumCompilationsSongs.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E17110D25F9FA00618676 /* DirectoryNodeAlbumCompilationsSongs.cpp */; };
-		F5A1C96C0F6B06CF00A96ABD /* DirectoryNodeAlbumRecentlyAdded.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E17130D25F9FA00618676 /* DirectoryNodeAlbumRecentlyAdded.cpp */; };
-		F5A1C96D0F6B06CF00A96ABD /* DirectoryNodeAlbumRecentlyAddedSong.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E17150D25F9FA00618676 /* DirectoryNodeAlbumRecentlyAddedSong.cpp */; };
-		F5A1C96E0F6B06CF00A96ABD /* DirectoryNodeAlbumRecentlyPlayed.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E17170D25F9FA00618676 /* DirectoryNodeAlbumRecentlyPlayed.cpp */; };
-		F5A1C96F0F6B06CF00A96ABD /* DirectoryNodeAlbumRecentlyPlayedSong.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E17190D25F9FA00618676 /* DirectoryNodeAlbumRecentlyPlayedSong.cpp */; };
-		F5A1C9700F6B06CF00A96ABD /* DirectoryNodeAlbumTop100.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E171B0D25F9FA00618676 /* DirectoryNodeAlbumTop100.cpp */; };
-		F5A1C9710F6B06CF00A96ABD /* DirectoryNodeAlbumTop100Song.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E171D0D25F9FA00618676 /* DirectoryNodeAlbumTop100Song.cpp */; };
-		F5A1C9720F6B06CF00A96ABD /* DirectoryNodeArtist.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E171F0D25F9FA00618676 /* DirectoryNodeArtist.cpp */; };
-		F5A1C9730F6B06CF00A96ABD /* DirectoryNodeGenre.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E17210D25F9FA00618676 /* DirectoryNodeGenre.cpp */; };
-		F5A1C9740F6B06CF00A96ABD /* DirectoryNodeOverview.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E17230D25F9FA00618676 /* DirectoryNodeOverview.cpp */; };
-		F5A1C9750F6B06CF00A96ABD /* DirectoryNodeRoot.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E17250D25F9FA00618676 /* DirectoryNodeRoot.cpp */; };
-		F5A1C9760F6B06CF00A96ABD /* DirectoryNodeSong.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E17270D25F9FA00618676 /* DirectoryNodeSong.cpp */; };
-		F5A1C9770F6B06CF00A96ABD /* DirectoryNodeSongTop100.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E17290D25F9FA00618676 /* DirectoryNodeSongTop100.cpp */; };
-		F5A1C9780F6B06CF00A96ABD /* DirectoryNodeTop100.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E172B0D25F9FA00618676 /* DirectoryNodeTop100.cpp */; };
-		F5A1C9790F6B06CF00A96ABD /* DirectoryNodeYear.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E172D0D25F9FA00618676 /* DirectoryNodeYear.cpp */; };
-		F5A1C97A0F6B06CF00A96ABD /* DirectoryNodeYearAlbum.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E172F0D25F9FA00618676 /* DirectoryNodeYearAlbum.cpp */; };
-		F5A1C97B0F6B06CF00A96ABD /* DirectoryNodeYearSong.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E17310D25F9FA00618676 /* DirectoryNodeYearSong.cpp */; };
-		F5A1C97C0F6B06CF00A96ABD /* QueryParams.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E17350D25F9FA00618676 /* QueryParams.cpp */; };
-		F5A1C97D0F6B06CF00A96ABD /* MusicDatabaseDirectory.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E17370D25F9FA00618676 /* MusicDatabaseDirectory.cpp */; };
-		F5A1C97E0F6B06CF00A96ABD /* MusicSearchDirectory.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E17390D25F9FA00618676 /* MusicSearchDirectory.cpp */; };
-		F5A1C97F0F6B06CF00A96ABD /* NSFFileDirectory.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E173C0D25F9FA00618676 /* NSFFileDirectory.cpp */; };
-		F5A1C9800F6B06CF00A96ABD /* OGGFileDirectory.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E173E0D25F9FA00618676 /* OGGFileDirectory.cpp */; };
-		F5A1C9810F6B06CF00A96ABD /* PlaylistDirectory.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E17400D25F9FA00618676 /* PlaylistDirectory.cpp */; };
-		F5A1C9820F6B06CF00A96ABD /* PlaylistFileDirectory.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E17420D25F9FA00618676 /* PlaylistFileDirectory.cpp */; };
-		F5A1C9830F6B06CF00A96ABD /* PluginDirectory.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E17440D25F9FA00618676 /* PluginDirectory.cpp */; };
-		F5A1C9840F6B06CF00A96ABD /* RarDirectory.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E17460D25F9FA00618676 /* RarDirectory.cpp */; };
-		F5A1C9850F6B06CF00A96ABD /* RarManager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E17480D25F9FA00618676 /* RarManager.cpp */; };
-		F5A1C9860F6B06CF00A96ABD /* RTVDirectory.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E174B0D25F9FA00618676 /* RTVDirectory.cpp */; };
-		F5A1C9890F6B06CF00A96ABD /* SIDFileDirectory.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E17510D25F9FA00618676 /* SIDFileDirectory.cpp */; };
-		F5A1C98A0F6B06CF00A96ABD /* SmartPlaylistDirectory.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E17530D25F9FA00618676 /* SmartPlaylistDirectory.cpp */; };
-		F5A1C98B0F6B06CF00A96ABD /* StackDirectory.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E17590D25F9FA00618676 /* StackDirectory.cpp */; };
-		F5A1C98C0F6B06CF00A96ABD /* UPnPDirectory.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E175B0D25F9FA00618676 /* UPnPDirectory.cpp */; };
-		F5A1C98E0F6B06CF00A96ABD /* DirectoryNode.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E17600D25F9FA00618676 /* DirectoryNode.cpp */; };
-		F5A1C98F0F6B06CF00A96ABD /* DirectoryNodeActor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E17620D25F9FA00618676 /* DirectoryNodeActor.cpp */; };
-		F5A1C9900F6B06CF00A96ABD /* DirectoryNodeDirector.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E17640D25F9FA00618676 /* DirectoryNodeDirector.cpp */; };
-		F5A1C9910F6B06CF00A96ABD /* DirectoryNodeEpisodes.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E17660D25F9FA00618676 /* DirectoryNodeEpisodes.cpp */; };
-		F5A1C9920F6B06CF00A96ABD /* DirectoryNodeGenre.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E17680D25F9FA00618676 /* DirectoryNodeGenre.cpp */; };
-		F5A1C9930F6B06CF00A96ABD /* DirectoryNodeMoviesOverview.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E176A0D25F9FA00618676 /* DirectoryNodeMoviesOverview.cpp */; };
-		F5A1C9940F6B06CF00A96ABD /* DirectoryNodeMusicVideosOverview.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E176C0D25F9FA00618676 /* DirectoryNodeMusicVideosOverview.cpp */; };
-		F5A1C9950F6B06CF00A96ABD /* DirectoryNodeOverview.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E176E0D25F9FA00618676 /* DirectoryNodeOverview.cpp */; };
-		F5A1C9960F6B06CF00A96ABD /* DirectoryNodeRecentlyAddedEpisodes.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E17700D25F9FA00618676 /* DirectoryNodeRecentlyAddedEpisodes.cpp */; };
-		F5A1C9970F6B06CF00A96ABD /* DirectoryNodeRecentlyAddedMovies.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E17720D25F9FA00618676 /* DirectoryNodeRecentlyAddedMovies.cpp */; };
-		F5A1C9980F6B06CF00A96ABD /* DirectoryNodeRecentlyAddedMusicVideos.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E17740D25F9FA00618676 /* DirectoryNodeRecentlyAddedMusicVideos.cpp */; };
-		F5A1C9990F6B06CF00A96ABD /* DirectoryNodeRoot.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E17760D25F9FA00618676 /* DirectoryNodeRoot.cpp */; };
-		F5A1C99A0F6B06CF00A96ABD /* DirectoryNodeSeasons.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E17780D25F9FA00618676 /* DirectoryNodeSeasons.cpp */; };
-		F5A1C99B0F6B06CF00A96ABD /* DirectoryNodeStudio.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E177A0D25F9FA00618676 /* DirectoryNodeStudio.cpp */; };
-		F5A1C99C0F6B06CF00A96ABD /* DirectoryNodeTitleMovies.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E177C0D25F9FA00618676 /* DirectoryNodeTitleMovies.cpp */; };
-		F5A1C99D0F6B06CF00A96ABD /* DirectoryNodeTitleMusicVideos.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E177E0D25F9FA00618676 /* DirectoryNodeTitleMusicVideos.cpp */; };
-		F5A1C99E0F6B06CF00A96ABD /* DirectoryNodeTitleTvShows.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E17800D25F9FA00618676 /* DirectoryNodeTitleTvShows.cpp */; };
-		F5A1C99F0F6B06CF00A96ABD /* DirectoryNodeTvShowsOverview.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E17820D25F9FA00618676 /* DirectoryNodeTvShowsOverview.cpp */; };
-		F5A1C9A00F6B06CF00A96ABD /* DirectoryNodeYear.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E17840D25F9FA00618676 /* DirectoryNodeYear.cpp */; };
-		F5A1C9A10F6B06CF00A96ABD /* QueryParams.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E17880D25F9FA00618676 /* QueryParams.cpp */; };
-		F5A1C9A20F6B06CF00A96ABD /* VideoDatabaseDirectory.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E178A0D25F9FA00618676 /* VideoDatabaseDirectory.cpp */; };
-		F5A1C9A30F6B06CF00A96ABD /* VirtualDirectory.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E178C0D25F9FA00618676 /* VirtualDirectory.cpp */; };
-		F5A1C9A50F6B06CF00A96ABD /* ZipDirectory.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E17930D25F9FA00618676 /* ZipDirectory.cpp */; };
-		F5A1C9A60F6B06CF00A96ABD /* ZipManager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E17950D25F9FA00618676 /* ZipManager.cpp */; };
-		F5A1C9A90F6B06CF00A96ABD /* GUIDialogBoxBase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E179C0D25F9FA00618676 /* GUIDialogBoxBase.cpp */; };
-		F5A1C9AA0F6B06CF00A96ABD /* GUIDialogBusy.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E179E0D25F9FA00618676 /* GUIDialogBusy.cpp */; };
-		F5A1C9AB0F6B06CF00A96ABD /* GUIDialogButtonMenu.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E17A00D25F9FA00618676 /* GUIDialogButtonMenu.cpp */; };
-		F5A1C9AD0F6B06CF00A96ABD /* GUIDialogContextMenu.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E17A40D25F9FA00618676 /* GUIDialogContextMenu.cpp */; };
-		F5A1C9AE0F6B06CF00A96ABD /* GUIDialogFavourites.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E17A60D25F9FA00618676 /* GUIDialogFavourites.cpp */; };
-		F5A1C9AF0F6B06CF00A96ABD /* GUIDialogFileBrowser.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E17A80D25F9FA00618676 /* GUIDialogFileBrowser.cpp */; };
-		F5A1C9B00F6B06CF00A96ABD /* GUIDialogFileStacking.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E17AA0D25F9FA00618676 /* GUIDialogFileStacking.cpp */; };
-		F5A1C9B10F6B06CF00A96ABD /* GUIDialogGamepad.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E17AC0D25F9FA00618676 /* GUIDialogGamepad.cpp */; };
-		F5A1C9B20F6B06CF00A96ABD /* GUIDialogKeyboard.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E17B40D25F9FA00618676 /* GUIDialogKeyboard.cpp */; };
-		F5A1C9B40F6B06CF00A96ABD /* GUIDialogMediaSource.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E17B80D25F9FA00618676 /* GUIDialogMediaSource.cpp */; };
-		F5A1C9B50F6B06CF00A96ABD /* GUIDialogMusicOSD.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E17BA0D25F9FA00618676 /* GUIDialogMusicOSD.cpp */; };
-		F5A1C9B60F6B06CF00A96ABD /* GUIDialogMusicScan.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E17BC0D25F9FA00618676 /* GUIDialogMusicScan.cpp */; };
-		F5A1C9B70F6B06CF00A96ABD /* GUIDialogMuteBug.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E17BE0D25F9FA00618676 /* GUIDialogMuteBug.cpp */; };
-		F5A1C9B80F6B06CF00A96ABD /* GUIDialogNetworkSetup.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E17C00D25F9FA00618676 /* GUIDialogNetworkSetup.cpp */; };
-		F5A1C9B90F6B06CF00A96ABD /* GUIDialogNumeric.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E17C20D25F9FA00618676 /* GUIDialogNumeric.cpp */; };
-		F5A1C9BA0F6B06CF00A96ABD /* GUIDialogOK.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E17C40D25F9FA00618676 /* GUIDialogOK.cpp */; };
-		F5A1C9BB0F6B06CF00A96ABD /* GUIDialogPictureInfo.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E17C60D25F9FA00618676 /* GUIDialogPictureInfo.cpp */; };
-		F5A1C9BC0F6B06CF00A96ABD /* GUIDialogPlayerControls.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E17C80D25F9FA00618676 /* GUIDialogPlayerControls.cpp */; };
-		F5A1C9BF0F6B06CF00A96ABD /* GUIDialogProgress.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E17CE0D25F9FA00618676 /* GUIDialogProgress.cpp */; };
-		F5A1C9C00F6B06CF00A96ABD /* GUIDialogSeekBar.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E17D00D25F9FA00618676 /* GUIDialogSeekBar.cpp */; };
-		F5A1C9C30F6B06CF00A96ABD /* GUIDialogSmartPlaylistEditor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E17D60D25F9FA00618676 /* GUIDialogSmartPlaylistEditor.cpp */; };
-		F5A1C9C40F6B06CF00A96ABD /* GUIDialogSmartPlaylistRule.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E17D80D25F9FA00618676 /* GUIDialogSmartPlaylistRule.cpp */; };
-		F5A1C9C50F6B06CF00A96ABD /* GUIDialogSongInfo.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E17DA0D25F9FA00618676 /* GUIDialogSongInfo.cpp */; };
-		F5A1C9C60F6B06CF00A96ABD /* GUIDialogSubMenu.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E17DC0D25F9FA00618676 /* GUIDialogSubMenu.cpp */; };
-		F5A1C9C70F6B06CF00A96ABD /* GUIDialogVideoBookmarks.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E17E00D25F9FA00618676 /* GUIDialogVideoBookmarks.cpp */; };
-		F5A1C9C80F6B06CF00A96ABD /* GUIDialogVideoScan.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E17E20D25F9FA00618676 /* GUIDialogVideoScan.cpp */; };
-		F5A1C9CA0F6B06CF00A96ABD /* GUIDialogVisualisationPresetList.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E17E60D25F9FA00618676 /* GUIDialogVisualisationPresetList.cpp */; };
-		F5A1C9CC0F6B06CF00A96ABD /* GUIDialogVolumeBar.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E17EA0D25F9FA00618676 /* GUIDialogVolumeBar.cpp */; };
-		F5A1C9CD0F6B06CF00A96ABD /* GUIDialogYesNo.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E17EC0D25F9FA00618676 /* GUIDialogYesNo.cpp */; };
-		F5A1C9CE0F6B06CF00A96ABD /* GUILargeTextureManager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E17EE0D25F9FA00618676 /* GUILargeTextureManager.cpp */; };
-		F5A1C9CF0F6B06CF00A96ABD /* GUIMediaWindow.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E17F00D25F9FA00618676 /* GUIMediaWindow.cpp */; };
-		F5A1C9D00F6B06CF00A96ABD /* GUIPassword.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E17F20D25F9FA00618676 /* GUIPassword.cpp */; };
-		F5A1C9D20F6B06CF00A96ABD /* GUIViewControl.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E17F70D25F9FA00618676 /* GUIViewControl.cpp */; };
-		F5A1C9D30F6B06CF00A96ABD /* GUIViewState.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E17F90D25F9FA00618676 /* GUIViewState.cpp */; };
-		F5A1C9D40F6B06CF00A96ABD /* GUIViewStateMusic.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E17FB0D25F9FA00618676 /* GUIViewStateMusic.cpp */; };
-		F5A1C9D50F6B06CF00A96ABD /* GUIViewStateVideo.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E17FF0D25F9FA00618676 /* GUIViewStateVideo.cpp */; };
-		F5A1C9D60F6B06CF00A96ABD /* GUIWindowFileManager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E18030D25F9FA00618676 /* GUIWindowFileManager.cpp */; };
-		F5A1C9D70F6B06CF00A96ABD /* GUIWindowFullScreen.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E18050D25F9FA00618676 /* GUIWindowFullScreen.cpp */; };
-		F5A1C9D80F6B06CF00A96ABD /* GUIWindowHome.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E18090D25F9FA00618676 /* GUIWindowHome.cpp */; };
-		F5A1C9D90F6B06CF00A96ABD /* GUIWindowLoginScreen.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E180B0D25F9FA00618676 /* GUIWindowLoginScreen.cpp */; };
-		F5A1C9DA0F6B06CF00A96ABD /* GUIWindowMusicBase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E180D0D25F9FA00618676 /* GUIWindowMusicBase.cpp */; };
-		F5A1C9DB0F6B06CF00A96ABD /* GUIDialogMusicInfo.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E180F0D25F9FA00618676 /* GUIDialogMusicInfo.cpp */; };
-		F5A1C9DC0F6B06CF00A96ABD /* GUIWindowMusicNav.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E18110D25F9FA00618676 /* GUIWindowMusicNav.cpp */; };
-		F5A1C9DD0F6B06CF00A96ABD /* GUIDialogMusicOverlay.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E18130D25F9FA00618676 /* GUIDialogMusicOverlay.cpp */; };
-		F5A1C9DE0F6B06CF00A96ABD /* GUIWindowMusicPlaylist.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E18150D25F9FA00618676 /* GUIWindowMusicPlaylist.cpp */; };
-		F5A1C9DF0F6B06CF00A96ABD /* GUIWindowMusicPlaylistEditor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E18170D25F9FA00618676 /* GUIWindowMusicPlaylistEditor.cpp */; };
-		F5A1C9E00F6B06CF00A96ABD /* GUIWindowMusicSongs.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E18190D25F9FA00618676 /* GUIWindowMusicSongs.cpp */; };
-		F5A1C9E10F6B06CF00A96ABD /* GUIDialogVideoOSD.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E181D0D25F9FA00618676 /* GUIDialogVideoOSD.cpp */; };
-		F5A1C9E20F6B06CF00A96ABD /* GUIWindowPictures.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E181F0D25F9FA00618676 /* GUIWindowPictures.cpp */; };
-		F5A1C9E30F6B06CF00A96ABD /* GUIWindowPointer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E18210D25F9FA00618676 /* GUIWindowPointer.cpp */; };
-		F5A1C9E40F6B06CF00A96ABD /* GUIWindowPrograms.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E18230D25F9FA00618676 /* GUIWindowPrograms.cpp */; };
-		F5A1C9E50F6B06CF00A96ABD /* GUIWindowScreensaver.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E18250D25F9FA00618676 /* GUIWindowScreensaver.cpp */; };
-		F5A1C9EC0F6B06CF00A96ABD /* GUIWindowSlideShow.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E18350D25F9FA00618676 /* GUIWindowSlideShow.cpp */; };
-		F5A1C9ED0F6B06CF00A96ABD /* GUIWindowStartup.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E18370D25F9FA00618676 /* GUIWindowStartup.cpp */; };
-		F5A1C9EE0F6B06CF00A96ABD /* GUIWindowSystemInfo.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E18390D25F9FA00618676 /* GUIWindowSystemInfo.cpp */; };
-		F5A1C9EF0F6B06CF00A96ABD /* GUIWindowVideoBase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E183B0D25F9FA00618676 /* GUIWindowVideoBase.cpp */; };
-		F5A1C9F10F6B06CF00A96ABD /* GUIDialogVideoInfo.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E183F0D25F9FA00618676 /* GUIDialogVideoInfo.cpp */; };
-		F5A1C9F20F6B06CF00A96ABD /* GUIWindowVideoNav.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E18410D25F9FA00618676 /* GUIWindowVideoNav.cpp */; };
-		F5A1C9F30F6B06CF00A96ABD /* GUIDialogVideoOverlay.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E18430D25F9FA00618676 /* GUIDialogVideoOverlay.cpp */; };
-		F5A1C9F40F6B06CF00A96ABD /* GUIWindowVideoPlaylist.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E18450D25F9FA00618676 /* GUIWindowVideoPlaylist.cpp */; };
-		F5A1C9F50F6B06CF00A96ABD /* GUIWindowVisualisation.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E18470D25F9FA00618676 /* GUIWindowVisualisation.cpp */; };
-		F5A1C9F60F6B06CF00A96ABD /* GUIWindowWeather.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E18490D25F9FA00618676 /* GUIWindowWeather.cpp */; };
-		F5A1C9F90F6B06CF00A96ABD /* LangCodeExpander.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E18560D25F9FA00618676 /* LangCodeExpander.cpp */; };
-		F5A1C9FA0F6B06CF00A96ABD /* LangInfo.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E18580D25F9FA00618676 /* LangInfo.cpp */; };
-		F5A1C9FB0F6B06CF00A96ABD /* LastFmManager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E185A0D25F9FA00618676 /* LastFmManager.cpp */; };
-		F5A1CA010F6B06CF00A96ABD /* XBPython.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E1A0D0D25F9FB00618676 /* XBPython.cpp */; };
-		F5A1CA030F6B06CF00A96ABD /* XBPyThread.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E1A110D25F9FB00618676 /* XBPyThread.cpp */; };
-		F5A1CA040F6B06CF00A96ABD /* scrobbler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E1A250D25F9FB00618676 /* scrobbler.cpp */; };
-		F5A1CA050F6B06CF00A96ABD /* MediaCrawler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E1ABD0D25F9FB00618676 /* MediaCrawler.cpp */; };
-		F5A1CA060F6B06CF00A96ABD /* PltMicroMediaController.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E1AC20D25F9FB00618676 /* PltMicroMediaController.cpp */; };
-		F5A1CA080F6B06CF00A96ABD /* PltAction.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E1AC70D25F9FB00618676 /* PltAction.cpp */; };
-		F5A1CA090F6B06CF00A96ABD /* PltArgument.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E1AC90D25F9FB00618676 /* PltArgument.cpp */; };
-		F5A1CA0A0F6B06CF00A96ABD /* PltCtrlPoint.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E1ACB0D25F9FB00618676 /* PltCtrlPoint.cpp */; };
-		F5A1CA0B0F6B06CF00A96ABD /* PltCtrlPointTask.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E1ACD0D25F9FB00618676 /* PltCtrlPointTask.cpp */; };
-		F5A1CA0C0F6B06CF00A96ABD /* PltDatagramStream.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E1ACF0D25F9FB00618676 /* PltDatagramStream.cpp */; };
-		F5A1CA0D0F6B06CF00A96ABD /* PltDeviceData.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E1AD10D25F9FB00618676 /* PltDeviceData.cpp */; };
-		F5A1CA0E0F6B06CF00A96ABD /* PltDeviceHost.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E1AD30D25F9FB00618676 /* PltDeviceHost.cpp */; };
-		F5A1CA0F0F6B06CF00A96ABD /* PltDownloader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E1AD50D25F9FB00618676 /* PltDownloader.cpp */; };
-		F5A1CA100F6B06CF00A96ABD /* PltEvent.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E1AD70D25F9FB00618676 /* PltEvent.cpp */; };
-		F5A1CA110F6B06CF00A96ABD /* PltHttp.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E1AD90D25F9FB00618676 /* PltHttp.cpp */; };
-		F5A1CA120F6B06CF00A96ABD /* PltHttpClientTask.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E1ADB0D25F9FB00618676 /* PltHttpClientTask.cpp */; };
-		F5A1CA130F6B06CF00A96ABD /* PltHttpServer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E1ADD0D25F9FB00618676 /* PltHttpServer.cpp */; };
-		F5A1CA140F6B06CF00A96ABD /* PltHttpServerTask.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E1AE00D25F9FB00618676 /* PltHttpServerTask.cpp */; };
-		F5A1CA150F6B06CF00A96ABD /* PltLeaks.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E1AE20D25F9FB00618676 /* PltLeaks.cpp */; };
-		F5A1CA160F6B06CF00A96ABD /* PltMetadataHandler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E1AE60D25F9FB00618676 /* PltMetadataHandler.cpp */; };
-		F5A1CA170F6B06CF00A96ABD /* PltRingBufferStream.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E1AE80D25F9FB00618676 /* PltRingBufferStream.cpp */; };
-		F5A1CA180F6B06CF00A96ABD /* PltService.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E1AEA0D25F9FB00618676 /* PltService.cpp */; };
-		F5A1CA190F6B06CF00A96ABD /* PltSsdp.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E1AEC0D25F9FB00618676 /* PltSsdp.cpp */; };
-		F5A1CA1A0F6B06CF00A96ABD /* PltStateVariable.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E1AEF0D25F9FB00618676 /* PltStateVariable.cpp */; };
-		F5A1CA1B0F6B06CF00A96ABD /* PltStreamPump.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E1AF10D25F9FB00618676 /* PltStreamPump.cpp */; };
-		F5A1CA1C0F6B06CF00A96ABD /* PltTaskManager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E1AF30D25F9FB00618676 /* PltTaskManager.cpp */; };
-		F5A1CA1D0F6B06CF00A96ABD /* PltThreadTask.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E1AF50D25F9FB00618676 /* PltThreadTask.cpp */; };
-		F5A1CA1E0F6B06CF00A96ABD /* PltUPnP.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E1AF70D25F9FB00618676 /* PltUPnP.cpp */; };
-		F5A1CA1F0F6B06CF00A96ABD /* PltMediaController.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E1B000D25F9FB00618676 /* PltMediaController.cpp */; };
-		F5A1CA200F6B06CF00A96ABD /* PltMediaRenderer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E1B030D25F9FB00618676 /* PltMediaRenderer.cpp */; };
-		F5A1CA220F6B06CF00A96ABD /* PltDidl.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E1B0B0D25F9FB00618676 /* PltDidl.cpp */; };
-		F5A1CA230F6B06CF00A96ABD /* PltFileMediaServer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E1B0D0D25F9FB00618676 /* PltFileMediaServer.cpp */; };
-		F5A1CA240F6B06CF00A96ABD /* PltMediaBrowser.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E1B0F0D25F9FB00618676 /* PltMediaBrowser.cpp */; };
-		F5A1CA250F6B06CF00A96ABD /* PltMediaCache.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E1B120D25F9FB00618676 /* PltMediaCache.cpp */; };
-		F5A1CA260F6B06CF00A96ABD /* PltMediaItem.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E1B140D25F9FB00618676 /* PltMediaItem.cpp */; };
-		F5A1CA270F6B06CF00A96ABD /* PltMediaPlaylist.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E1B160D25F9FB00618676 /* PltMediaPlaylist.cpp */; };
-		F5A1CA280F6B06CF00A96ABD /* PltMediaServer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E1B180D25F9FB00618676 /* PltMediaServer.cpp */; };
-		F5A1CA2A0F6B06CF00A96ABD /* PltSyncMediaBrowser.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E1B1B0D25F9FB00618676 /* PltSyncMediaBrowser.cpp */; };
-		F5A1CA2B0F6B06CF00A96ABD /* PltLightSample.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E1B250D25F9FB00618676 /* PltLightSample.cpp */; };
-		F5A1CA4B0F6B06CF00A96ABD /* dataset.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E1CD70D25F9FC00618676 /* dataset.cpp */; };
-		F5A1CA4C0F6B06CF00A96ABD /* qry_dat.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E1CDF0D25F9FC00618676 /* qry_dat.cpp */; };
-		F5A1CA4D0F6B06CF00A96ABD /* sqlitedataset.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E1CE20D25F9FC00618676 /* sqlitedataset.cpp */; };
-		F5A1CA4E0F6B06CF00A96ABD /* archive.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E1CE60D25F9FC00618676 /* archive.cpp */; settings = {COMPILER_FLAGS = "-DSILENT"; }; };
-		F5A1CA4F0F6B06CF00A96ABD /* arcread.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E1CE80D25F9FC00618676 /* arcread.cpp */; settings = {COMPILER_FLAGS = "-DSILENT"; }; };
-		F5A1CA500F6B06CF00A96ABD /* cmddata.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E1CEA0D25F9FC00618676 /* cmddata.cpp */; settings = {COMPILER_FLAGS = "-DSILENT"; }; };
-		F5A1CA510F6B06CF00A96ABD /* consio.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E1CEF0D25F9FC00618676 /* consio.cpp */; settings = {COMPILER_FLAGS = "-DSILENT"; }; };
-		F5A1CA520F6B06CF00A96ABD /* crc.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E1CF10D25F9FC00618676 /* crc.cpp */; settings = {COMPILER_FLAGS = "-DSILENT"; }; };
-		F5A1CA530F6B06CF00A96ABD /* crypt.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E1CF40D25F9FC00618676 /* crypt.cpp */; settings = {COMPILER_FLAGS = "-DSILENT"; }; };
-		F5A1CA540F6B06CF00A96ABD /* encname.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E1CF80D25F9FC00618676 /* encname.cpp */; settings = {COMPILER_FLAGS = "-DSILENT"; }; };
-		F5A1CA550F6B06CF00A96ABD /* errhnd.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E1CFA0D25F9FC00618676 /* errhnd.cpp */; settings = {COMPILER_FLAGS = "-DSILENT"; }; };
-		F5A1CA560F6B06CF00A96ABD /* extinfo.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E1CFC0D25F9FC00618676 /* extinfo.cpp */; settings = {COMPILER_FLAGS = "-DSILENT"; }; };
-		F5A1CA570F6B06CF00A96ABD /* extract.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E1CFE0D25F9FC00618676 /* extract.cpp */; settings = {COMPILER_FLAGS = "-DSILENT"; }; };
-		F5A1CA580F6B06CF00A96ABD /* filcreat.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E1D000D25F9FC00618676 /* filcreat.cpp */; settings = {COMPILER_FLAGS = "-DSILENT"; }; };
-		F5A1CA590F6B06CF00A96ABD /* file.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E1D020D25F9FC00618676 /* file.cpp */; settings = {COMPILER_FLAGS = "-DSILENT"; }; };
-		F5A1CA5A0F6B06CF00A96ABD /* filefn.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E1D040D25F9FC00618676 /* filefn.cpp */; settings = {COMPILER_FLAGS = "-DSILENT"; }; };
-		F5A1CA5B0F6B06CF00A96ABD /* filestr.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E1D060D25F9FC00618676 /* filestr.cpp */; settings = {COMPILER_FLAGS = "-DSILENT"; }; };
-		F5A1CA5C0F6B06CF00A96ABD /* find.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E1D080D25F9FC00618676 /* find.cpp */; settings = {COMPILER_FLAGS = "-DSILENT"; }; };
-		F5A1CA5D0F6B06CF00A96ABD /* getbits.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E1D0A0D25F9FC00618676 /* getbits.cpp */; settings = {COMPILER_FLAGS = "-DSILENT"; }; };
-		F5A1CA5E0F6B06CF00A96ABD /* global.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E1D0C0D25F9FC00618676 /* global.cpp */; settings = {COMPILER_FLAGS = "-DSILENT"; }; };
-		F5A1CA5F0F6B06CF00A96ABD /* int64.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E1D0F0D25F9FC00618676 /* int64.cpp */; settings = {COMPILER_FLAGS = "-DSILENT"; }; };
-		F5A1CA600F6B06CF00A96ABD /* isnt.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E1D110D25F9FC00618676 /* isnt.cpp */; settings = {COMPILER_FLAGS = "-DSILENT"; }; };
-		F5A1CA610F6B06CF00A96ABD /* log.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E1D160D25F9FC00618676 /* log.cpp */; settings = {COMPILER_FLAGS = "-DSILENT"; }; };
-		F5A1CA620F6B06CF00A96ABD /* match.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E1D1A0D25F9FC00618676 /* match.cpp */; settings = {COMPILER_FLAGS = "-DSILENT"; }; };
-		F5A1CA630F6B06CF00A96ABD /* options.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E1D1E0D25F9FC00618676 /* options.cpp */; settings = {COMPILER_FLAGS = "-DSILENT"; }; };
-		F5A1CA640F6B06CF00A96ABD /* pathfn.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E1D210D25F9FC00618676 /* pathfn.cpp */; settings = {COMPILER_FLAGS = "-DSILENT"; }; };
-		F5A1CA650F6B06CF00A96ABD /* rarvm.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E1D2A0D25F9FC00618676 /* rarvm.cpp */; settings = {COMPILER_FLAGS = "-DSILENT"; }; };
-		F5A1CA660F6B06CF00A96ABD /* rawread.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E1D2D0D25F9FC00618676 /* rawread.cpp */; settings = {COMPILER_FLAGS = "-DSILENT"; }; };
-		F5A1CA670F6B06CF00A96ABD /* rdwrfn.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E1D2F0D25F9FC00618676 /* rdwrfn.cpp */; settings = {COMPILER_FLAGS = "-DSILENT"; }; };
-		F5A1CA680F6B06CF00A96ABD /* recvol.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E1D330D25F9FC00618676 /* recvol.cpp */; settings = {COMPILER_FLAGS = "-DSILENT"; }; };
-		F5A1CA690F6B06CF00A96ABD /* resource.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E1D350D25F9FC00618676 /* resource.cpp */; settings = {COMPILER_FLAGS = "-DSILENT"; }; };
-		F5A1CA6A0F6B06CF00A96ABD /* rijndael.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E1D370D25F9FC00618676 /* rijndael.cpp */; settings = {COMPILER_FLAGS = "-DSILENT"; }; };
-		F5A1CA6B0F6B06CF00A96ABD /* rs.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E1D390D25F9FC00618676 /* rs.cpp */; settings = {COMPILER_FLAGS = "-DSILENT"; }; };
-		F5A1CA6C0F6B06CF00A96ABD /* savepos.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E1D3B0D25F9FC00618676 /* savepos.cpp */; settings = {COMPILER_FLAGS = "-DSILENT"; }; };
-		F5A1CA6D0F6B06CF00A96ABD /* scantree.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E1D3D0D25F9FC00618676 /* scantree.cpp */; settings = {COMPILER_FLAGS = "-DSILENT"; }; };
-		F5A1CA6E0F6B06CF00A96ABD /* sha1.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E1D3F0D25F9FC00618676 /* sha1.cpp */; settings = {COMPILER_FLAGS = "-DSILENT"; }; };
-		F5A1CA6F0F6B06CF00A96ABD /* strfn.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E1D460D25F9FC00618676 /* strfn.cpp */; settings = {COMPILER_FLAGS = "-DSILENT"; }; };
-		F5A1CA700F6B06CF00A96ABD /* strlist.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E1D480D25F9FC00618676 /* strlist.cpp */; settings = {COMPILER_FLAGS = "-DSILENT"; }; };
-		F5A1CA710F6B06CF00A96ABD /* system.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E1D4C0D25F9FC00618676 /* system.cpp */; settings = {COMPILER_FLAGS = "-DSILENT"; }; };
-		F5A1CA720F6B06CF00A96ABD /* timefn.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E1D4E0D25F9FC00618676 /* timefn.cpp */; settings = {COMPILER_FLAGS = "-DSILENT"; }; };
-		F5A1CA730F6B06CF00A96ABD /* ulinks.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E1D500D25F9FC00618676 /* ulinks.cpp */; settings = {COMPILER_FLAGS = "-DSILENT"; }; };
-		F5A1CA740F6B06CF00A96ABD /* unicode.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E1D520D25F9FC00618676 /* unicode.cpp */; settings = {COMPILER_FLAGS = "-DSILENT"; }; };
-		F5A1CA750F6B06CF00A96ABD /* volume.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E1D5E0D25F9FC00618676 /* volume.cpp */; settings = {COMPILER_FLAGS = "-DSILENT"; }; };
-		F5A1CA760F6B06CF00A96ABD /* ConvUtils.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E1D6A0D25F9FD00618676 /* ConvUtils.cpp */; };
-		F5A1CA790F6B06CF00A96ABD /* LinuxResourceCounter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E1D700D25F9FD00618676 /* LinuxResourceCounter.cpp */; };
-		F5A1CA7A0F6B06CF00A96ABD /* LinuxTimezone.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E1D720D25F9FD00618676 /* LinuxTimezone.cpp */; };
-		F5A1CA7D0F6B06CF00A96ABD /* XFileUtils.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E1D7D0D25F9FD00618676 /* XFileUtils.cpp */; };
-		F5A1CA7E0F6B06CF00A96ABD /* XHandle.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E1D7F0D25F9FD00618676 /* XHandle.cpp */; };
-		F5A1CA7F0F6B06CF00A96ABD /* XMemUtils.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E1D810D25F9FD00618676 /* XMemUtils.cpp */; };
-		F5A1CA820F6B06CF00A96ABD /* XTimeUtils.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E1D870D25F9FD00618676 /* XTimeUtils.cpp */; };
-		F5A1CA830F6B06CF00A96ABD /* MediaManager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E1D8B0D25F9FD00618676 /* MediaManager.cpp */; };
-		F5A1CA840F6B06CF00A96ABD /* MusicDatabase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E1D8F0D25F9FD00618676 /* MusicDatabase.cpp */; };
-		F5A1CA850F6B06CF00A96ABD /* MusicInfoLoader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E1D910D25F9FD00618676 /* MusicInfoLoader.cpp */; };
-		F5A1CA860F6B06CF00A96ABD /* MusicInfoScanner.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E1D930D25F9FD00618676 /* MusicInfoScanner.cpp */; };
-		F5A1CA9D0F6B06CF00A96ABD /* NfoFile.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E1DC10D25F9FD00618676 /* NfoFile.cpp */; };
-		F5A1CA9F0F6B06CF00A96ABD /* PartyModeManager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E1DD50D25F9FD00618676 /* PartyModeManager.cpp */; };
-		F5A1CAA00F6B06CF00A96ABD /* Picture.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E1DD70D25F9FD00618676 /* Picture.cpp */; };
-		F5A1CAA10F6B06CF00A96ABD /* PictureInfoLoader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E1DD90D25F9FD00618676 /* PictureInfoLoader.cpp */; };
-		F5A1CAA20F6B06CF00A96ABD /* PictureInfoTag.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E1DDB0D25F9FD00618676 /* PictureInfoTag.cpp */; };
-		F5A1CAA30F6B06CF00A96ABD /* PictureThumbLoader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E1DDD0D25F9FD00618676 /* PictureThumbLoader.cpp */; };
-		F5A1CAA80F6B06CF00A96ABD /* PlayListPlayer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E1DE90D25F9FD00618676 /* PlayListPlayer.cpp */; };
-		F5A1CAAC0F6B06CF00A96ABD /* Profile.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E1DF10D25F9FD00618676 /* Profile.cpp */; };
-		F5A1CAAD0F6B06CF00A96ABD /* ProgramDatabase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E1DF30D25F9FD00618676 /* ProgramDatabase.cpp */; };
-		F5A1CAB00F6B06CF00A96ABD /* SectionLoader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E1DFE0D25F9FD00618676 /* SectionLoader.cpp */; };
-		F5A1CAB10F6B06CF00A96ABD /* VideoSettings.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E1E010D25F9FD00618676 /* VideoSettings.cpp */; };
-		F5A1CAB40F6B06CF00A96ABD /* Shortcut.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E1E070D25F9FD00618676 /* Shortcut.cpp */; };
-		F5A1CAB50F6B06CF00A96ABD /* SlideShowPicture.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E1E090D25F9FD00618676 /* SlideShowPicture.cpp */; };
-		F5A1CAB70F6B06CF00A96ABD /* Song.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E1E0D0D25F9FD00618676 /* Song.cpp */; };
-		F5A1CAB80F6B06CF00A96ABD /* SortFileItem.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E1E0F0D25F9FD00618676 /* SortFileItem.cpp */; };
-		F5A1CABB0F6B06CF00A96ABD /* Temperature.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E1E160D25F9FD00618676 /* Temperature.cpp */; };
-		F5A1CABC0F6B06CF00A96ABD /* ThumbLoader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E1E180D25F9FD00618676 /* ThumbLoader.cpp */; };
-		F5A1CABD0F6B06CF00A96ABD /* ThumbnailCache.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E1E1A0D25F9FD00618676 /* ThumbnailCache.cpp */; };
-		F5A1CABE0F6B06CF00A96ABD /* UPnP.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E1E1C0D25F9FD00618676 /* UPnP.cpp */; settings = {COMPILER_FLAGS = "-Ixbmc/lib/libUPnP/Platinum/ThirdParty/Neptune/Source/Core -Ixbmc/lib/libUPnP/Platinum/Source/Core -Ixbmc/lib/libUPnP/Platinum/Source/Devices/MediaServer -Ixbmc/lib/libUPnP/Platinum/ThirdParty/Neptune/Source/System/Posix -Ixbmc/lib/libUPnP/Platinum/Source/Devices/MediaConnect -Ixbmc/lib/libUPnP/Platinum/Source/Devices/MediaRenderer"; }; };
-		F5A1CABF0F6B06CF00A96ABD /* URL.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E1E1E0D25F9FD00618676 /* URL.cpp */; };
-		F5A1CAC00F6B06CF00A96ABD /* Util.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E1E200D25F9FD00618676 /* Util.cpp */; };
-		F5A1CAC10F6B06CF00A96ABD /* AlarmClock.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E1E230D25F9FD00618676 /* AlarmClock.cpp */; };
-		F5A1CAC20F6B06CF00A96ABD /* Archive.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E1E250D25F9FD00618676 /* Archive.cpp */; };
-		F5A1CAC30F6B06CF00A96ABD /* BitstreamStats.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E1E270D25F9FD00618676 /* BitstreamStats.cpp */; };
-		F5A1CAC40F6B06CF00A96ABD /* CharsetConverter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E1E290D25F9FD00618676 /* CharsetConverter.cpp */; };
-		F5A1CAC50F6B06CF00A96ABD /* CPUInfo.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E1E2B0D25F9FD00618676 /* CPUInfo.cpp */; };
-		F5A1CAC80F6B06CF00A96ABD /* DownloadQueue.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E1E310D25F9FD00618676 /* DownloadQueue.cpp */; };
-		F5A1CAC90F6B06CF00A96ABD /* DownloadQueueManager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E1E330D25F9FD00618676 /* DownloadQueueManager.cpp */; };
-		F5A1CACA0F6B06CF00A96ABD /* Event.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E1E350D25F9FD00618676 /* Event.cpp */; };
-		F5A1CACC0F6B06CF00A96ABD /* GUIInfoManager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E1E3E0D25F9FD00618676 /* GUIInfoManager.cpp */; };
-		F5A1CACD0F6B06CF00A96ABD /* HTMLTable.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E1E400D25F9FD00618676 /* HTMLTable.cpp */; };
-		F5A1CACE0F6B06CF00A96ABD /* HTMLUtil.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E1E420D25F9FD00618676 /* HTMLUtil.cpp */; };
-		F5A1CAD00F6B06CF00A96ABD /* HttpHeader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E1E460D25F9FD00618676 /* HttpHeader.cpp */; };
-		F5A1CAD10F6B06CF00A96ABD /* VideoInfoDownloader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E1E4A0D25F9FD00618676 /* VideoInfoDownloader.cpp */; };
-		F5A1CAD20F6B06CF00A96ABD /* InfoLoader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E1E4C0D25F9FD00618676 /* InfoLoader.cpp */; };
-		F5A1CAD30F6B06CF00A96ABD /* LabelFormatter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E1E530D25F9FD00618676 /* LabelFormatter.cpp */; };
-		F5A1CAD40F6B06CF00A96ABD /* LCD.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E1E550D25F9FD00618676 /* LCD.cpp */; };
-		F5A1CAD50F6B06CF00A96ABD /* log.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E1E5B0D25F9FD00618676 /* log.cpp */; };
-		F5A1CAD60F6B06CF00A96ABD /* MusicAlbumInfo.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E1E650D25F9FD00618676 /* MusicAlbumInfo.cpp */; };
-		F5A1CAD70F6B06CF00A96ABD /* MusicInfoScraper.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E1E670D25F9FD00618676 /* MusicInfoScraper.cpp */; };
-		F5A1CAD90F6B06CF00A96ABD /* Network.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E1E6B0D25F9FD00618676 /* Network.cpp */; };
-		F5A1CADB0F6B06CF00A96ABD /* PerformanceSample.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E1E6F0D25F9FD00618676 /* PerformanceSample.cpp */; };
-		F5A1CADC0F6B06CF00A96ABD /* PerformanceStats.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E1E710D25F9FD00618676 /* PerformanceStats.cpp */; };
-		F5A1CADD0F6B06CF00A96ABD /* RegExp.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E1E730D25F9FD00618676 /* RegExp.cpp */; };
-		F5A1CADE0F6B06CF00A96ABD /* RssReader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E1E750D25F9FD00618676 /* RssReader.cpp */; };
-		F5A1CADF0F6B06CF00A96ABD /* ScraperParser.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E1E770D25F9FD00618676 /* ScraperParser.cpp */; };
-		F5A1CAE20F6B06CF00A96ABD /* Splash.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E1E7F0D25F9FD00618676 /* Splash.cpp */; };
-		F5A1CAE30F6B06CF00A96ABD /* Stopwatch.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E1E810D25F9FD00618676 /* Stopwatch.cpp */; };
-		F5A1CAE40F6B06CF00A96ABD /* SystemInfo.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E1E830D25F9FD00618676 /* SystemInfo.cpp */; };
-		F5A1CAE50F6B06CF00A96ABD /* Thread.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E1E850D25F9FD00618676 /* Thread.cpp */; };
-		F5A1CAE60F6B06CF00A96ABD /* TuxBoxUtil.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E1E890D25F9FD00618676 /* TuxBoxUtil.cpp */; };
-		F5A1CAE70F6B06CF00A96ABD /* UdpClient.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E1E8B0D25F9FD00618676 /* UdpClient.cpp */; };
-		F5A1CAE80F6B06CF00A96ABD /* Weather.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E1E8D0D25F9FD00618676 /* Weather.cpp */; };
-		F5A1CAE90F6B06CF00A96ABD /* Win32Exception.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E1E8F0D25F9FD00618676 /* Win32Exception.cpp */; };
-		F5A1CAEA0F6B06CF00A96ABD /* VideoDatabase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E1E930D25F9FD00618676 /* VideoDatabase.cpp */; };
-		F5A1CAEB0F6B06CF00A96ABD /* VideoInfoScanner.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E1E950D25F9FD00618676 /* VideoInfoScanner.cpp */; };
-		F5A1CAEC0F6B06CF00A96ABD /* VideoInfoTag.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E1E970D25F9FD00618676 /* VideoInfoTag.cpp */; };
-		F5A1CAED0F6B06CF00A96ABD /* ViewDatabase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E1E990D25F9FD00618676 /* ViewDatabase.cpp */; };
-		F5A1CAF20F6B06CF00A96ABD /* XBApplicationEx.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E1EA70D25F9FD00618676 /* XBApplicationEx.cpp */; };
-		F5A1CAF60F6B06CF00A96ABD /* xbmc.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E1ED10D25F9FD00618676 /* xbmc.cpp */; };
-		F5A1CAF80F6B06CF00A96ABD /* unpack.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E25770D263BF600618676 /* unpack.cpp */; };
-		F5A1CAF90F6B06CF00A96ABD /* rar.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E257B0D263C4400618676 /* rar.cpp */; };
-		F5A1CAFA0F6B06CF00A96ABD /* action.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E257E0D263CE000618676 /* action.cpp */; };
-		F5A1CAFB0F6B06CF00A96ABD /* control.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E257F0D263CE000618676 /* control.cpp */; };
-		F5A1CAFC0F6B06CF00A96ABD /* controlbutton.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E25800D263CE000618676 /* controlbutton.cpp */; };
-		F5A1CAFD0F6B06CF00A96ABD /* controlcheckmark.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E25810D263CE000618676 /* controlcheckmark.cpp */; };
-		F5A1CAFE0F6B06CF00A96ABD /* controlfadelabel.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E25820D263CE000618676 /* controlfadelabel.cpp */; };
-		F5A1CAFF0F6B06CF00A96ABD /* controlgroup.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E25830D263CE000618676 /* controlgroup.cpp */; };
-		F5A1CB000F6B06CF00A96ABD /* controlimage.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E25840D263CE000618676 /* controlimage.cpp */; };
-		F5A1CB010F6B06CF00A96ABD /* controllabel.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E25850D263CE000618676 /* controllabel.cpp */; };
-		F5A1CB020F6B06CF00A96ABD /* controllist.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E25860D263CE000618676 /* controllist.cpp */; };
-		F5A1CB030F6B06CF00A96ABD /* controlprogress.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E25870D263CE000618676 /* controlprogress.cpp */; };
-		F5A1CB040F6B06CF00A96ABD /* controlspin.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E25880D263CE000618676 /* controlspin.cpp */; };
-		F5A1CB050F6B06CF00A96ABD /* controltextbox.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E25890D263CE000618676 /* controltextbox.cpp */; };
-		F5A1CB060F6B06CF00A96ABD /* dialog.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E258A0D263CE000618676 /* dialog.cpp */; };
-		F5A1CB070F6B06CF00A96ABD /* GUIPythonWindow.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E258B0D263CE000618676 /* GUIPythonWindow.cpp */; };
-		F5A1CB080F6B06CF00A96ABD /* GUIPythonWindowDialog.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E258C0D263CE000618676 /* GUIPythonWindowDialog.cpp */; };
-		F5A1CB090F6B06CF00A96ABD /* GUIPythonWindowXML.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E258D0D263CE000618676 /* GUIPythonWindowXML.cpp */; };
-		F5A1CB0A0F6B06CF00A96ABD /* GUIPythonWindowXMLDialog.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E258E0D263CE000618676 /* GUIPythonWindowXMLDialog.cpp */; };
-		F5A1CB0B0F6B06CF00A96ABD /* infotagmusic.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E258F0D263CE000618676 /* infotagmusic.cpp */; };
-		F5A1CB0C0F6B06CF00A96ABD /* infotagvideo.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E25900D263CE000618676 /* infotagvideo.cpp */; };
-		F5A1CB0D0F6B06CF00A96ABD /* keyboard.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E25910D263CE000618676 /* keyboard.cpp */; };
-		F5A1CB0E0F6B06CF00A96ABD /* listitem.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E25920D263CE000618676 /* listitem.cpp */; };
-		F5A1CB0F0F6B06CF00A96ABD /* player.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E25930D263CE000618676 /* player.cpp */; };
-		F5A1CB100F6B06CF00A96ABD /* pyplaylist.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E25940D263CE000618676 /* pyplaylist.cpp */; };
-		F5A1CB110F6B06CF00A96ABD /* PythonPlayer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E25950D263CE000618676 /* PythonPlayer.cpp */; };
-		F5A1CB120F6B06CF00A96ABD /* pyutil.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E25960D263CE000618676 /* pyutil.cpp */; };
-		F5A1CB130F6B06CF00A96ABD /* window.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E25970D263CE000618676 /* window.cpp */; };
-		F5A1CB140F6B06CF00A96ABD /* winxml.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E25980D263CE000618676 /* winxml.cpp */; };
-		F5A1CB150F6B06CF00A96ABD /* winxmldialog.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E25990D263CE000618676 /* winxmldialog.cpp */; };
-		F5A1CB160F6B06CF00A96ABD /* xbmcguimodule.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E259A0D263CE000618676 /* xbmcguimodule.cpp */; };
-		F5A1CB170F6B06CF00A96ABD /* xbmcmodule.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E259B0D263CE000618676 /* xbmcmodule.cpp */; };
-		F5A1CB180F6B06CF00A96ABD /* xbmcplugin.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E259C0D263CE000618676 /* xbmcplugin.cpp */; };
-		F5A1CB190F6B06CF00A96ABD /* DVDFactoryDemuxer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E25BF0D263DC100618676 /* DVDFactoryDemuxer.cpp */; };
-		F5A1CB1A0F6B06CF00A96ABD /* DVDDemuxFFmpeg.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38E25C20D263DE200618676 /* DVDDemuxFFmpeg.cpp */; };
-		F5A1CB1B0F6B06CF00A96ABD /* GUIDialogCache.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E3A478090D29029A00F3C3A6 /* GUIDialogCache.cpp */; };
-		F5A1CB1D0F6B06CF00A96ABD /* GUIDialogAccessPoints.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E3A478190D29032C00F3C3A6 /* GUIDialogAccessPoints.cpp */; };
-		F5A1CB220F6B06CF00A96ABD /* DVDPlayerCodec.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E36578860D3AA7B40033CC1C /* DVDPlayerCodec.cpp */; };
-		F5A1CB230F6B06CF00A96ABD /* DVDDemuxVobsub.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E33206370D5070AA00435CE3 /* DVDDemuxVobsub.cpp */; };
-		F5A1CB240F6B06CF00A96ABD /* DVDInputStreamTV.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E33979940D62FD47004ECDDA /* DVDInputStreamTV.cpp */; };
-		F5A1CB250F6B06CF00A96ABD /* PltMediaConnect.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 810C9F600D67BD2F0095F5DD /* PltMediaConnect.cpp */; };
-		F5A1CB3C0F6B06CF00A96ABD /* MythDirectory.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 810C9FA50D67D1FB0095F5DD /* MythDirectory.cpp */; };
-		F5A1CB3D0F6B06CF00A96ABD /* MythFile.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 810C9FA70D67D1FB0095F5DD /* MythFile.cpp */; };
-		F5A1CB3F0F6B06CF00A96ABD /* SMBDirectory.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E3DAAF8B0D6E1B0500F17647 /* SMBDirectory.cpp */; };
-		F5A1CB410F6B06CF00A96ABD /* MythSession.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E3BBB7980D7EA78A00CAAFD3 /* MythSession.cpp */; };
-		F5A1CB420F6B06CF00A96ABD /* EventPacket.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E3E91FFA0D8C61DF002BF43D /* EventPacket.cpp */; };
-		F5A1CB430F6B06CF00A96ABD /* EventServer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E3E91FFB0D8C61DF002BF43D /* EventServer.cpp */; };
-		F5A1CB440F6B06CF00A96ABD /* Socket.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E3E91FFC0D8C61DF002BF43D /* Socket.cpp */; };
-		F5A1CB450F6B06CF00A96ABD /* EventClient.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E3E920010D8C622A002BF43D /* EventClient.cpp */; };
-		F5A1CB470F6B06CF00A96ABD /* GUIDialogKaiToast.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38A06CC0D95AA5500FF8227 /* GUIDialogKaiToast.cpp */; };
-		F5A1CB480F6B06CF00A96ABD /* DVDSubtitleParserMicroDVD.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E3B53E7A0D97B08100021A96 /* DVDSubtitleParserMicroDVD.cpp */; };
-		F5A1CB490F6B06CF00A96ABD /* controlradiobutton.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E354EF030D99EDC900B55311 /* controlradiobutton.cpp */; };
-		F5A1CB4A0F6B06CF00A96ABD /* Artist.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E36C29DB0DA72429001F0C9D /* Artist.cpp */; };
-		F5A1CB4B0F6B06CF00A96ABD /* Album.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E36C29DC0DA72429001F0C9D /* Album.cpp */; };
-		F5A1CB4C0F6B06CF00A96ABD /* DVDSubtitleParserSami.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E36C29E50DA72442001F0C9D /* DVDSubtitleParserSami.cpp */; };
-		F5A1CB4D0F6B06CF00A96ABD /* ScraperUrl.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E36C29E70DA72486001F0C9D /* ScraperUrl.cpp */; };
-		F5A1CB4E0F6B06CF00A96ABD /* MusicArtistInfo.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E36C29E80DA72486001F0C9D /* MusicArtistInfo.cpp */; };
-		F5A1CB4F0F6B06CF00A96ABD /* Fanart.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E36C29E90DA72486001F0C9D /* Fanart.cpp */; };
-		F5A1CB510F6B06CF00A96ABD /* MediaSource.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 880DBE4B0DC223FF00E26B71 /* MediaSource.cpp */; };
-		F5A1CB520F6B06CF00A96ABD /* MusicFileDirectory.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 880DBE530DC224A100E26B71 /* MusicFileDirectory.cpp */; };
-		F5A1CB530F6B06CF00A96ABD /* ASAPFileDirectory.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 88ACB0190DCF40800083CFDF /* ASAPFileDirectory.cpp */; };
-		F5A1CB540F6B06CF00A96ABD /* ASAPCodec.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 88ACB01C0DCF409E0083CFDF /* ASAPCodec.cpp */; };
-		F5A1CB570F6B06CF00A96ABD /* DVDOverlayCodecSSA.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 8883CE9E0DD817D1004E8B72 /* DVDOverlayCodecSSA.cpp */; };
-		F5A1CB580F6B06CF00A96ABD /* DVDSubtitleParserSSA.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 8883CEA30DD81807004E8B72 /* DVDSubtitleParserSSA.cpp */; };
-		F5A1CB590F6B06CF00A96ABD /* DVDSubtitlesLibass.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 8883CEA50DD81807004E8B72 /* DVDSubtitlesLibass.cpp */; };
-		F5A1CB5A0F6B06CF00A96ABD /* XBMCHelper.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E306D12C0DDF7B590052C2AD /* XBMCHelper.cpp */; };
-		F5A1CB5B0F6B06CF00A96ABD /* GUIDialogFullScreenInfo.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 886328150E07B37200BB3DAB /* GUIDialogFullScreenInfo.cpp */; };
-		F5A1CB5C0F6B06CF00A96ABD /* GUIViewStatePictures.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 886328170E07B37200BB3DAB /* GUIViewStatePictures.cpp */; };
-		F5A1CB5D0F6B06CF00A96ABD /* GUIViewStatePrograms.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 886328190E07B37200BB3DAB /* GUIViewStatePrograms.cpp */; };
-		F5A1CB600F6B06CF00A96ABD /* RSSDirectory.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 889B4D8C0E0EF86C00FAD25E /* RSSDirectory.cpp */; };
-		F5A1CB640F6B06CF00A96ABD /* DVDInputStreamRTMP.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 815EE6330E17F1DC009FBE3C /* DVDInputStreamRTMP.cpp */; };
-		F5A1CB670F6B06CF00A96ABD /* VGMCodec.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5F8E1D90E427E8000A8E96F /* VGMCodec.cpp */; };
-		F5A1CB680F6B06CF00A96ABD /* md5.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5F8E1E60E427F6700A8E96F /* md5.cpp */; };
-		F5A1CB6A0F6B06CF00A96ABD /* GUIWindowTestPattern.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5F95D9F0E4E203700C3FA5C /* GUIWindowTestPattern.cpp */; };
-		F5A1CB6C0F6B06CF00A96ABD /* MultiPathFile.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F50629780E57B9680066625A /* MultiPathFile.cpp */; };
-		F5A1CB6D0F6B06CF00A96ABD /* DVDFileInfo.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5F2EF4A0E593E0D0092C37F /* DVDFileInfo.cpp */; };
-		F5A1CB6E0F6B06CF00A96ABD /* AsyncFileCopy.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5FDF51C0E7218950005B0A6 /* AsyncFileCopy.cpp */; };
-		F5A1CB740F6B06CF00A96ABD /* NptXbmcFile.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E4E91BB70E7F7338001F0546 /* NptXbmcFile.cpp */; };
-		F5A1CB7A0F6B06CF00A96ABD /* DirectoryNodeMusicVideoAlbum.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F52910130EE1D5F0001167F0 /* DirectoryNodeMusicVideoAlbum.cpp */; };
-		F5A1CB7C0F6B06CF00A96ABD /* VTPFile.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5FAB0700EFABAC800BAD4AE /* VTPFile.cpp */; };
-		F5A1CB7D0F6B06CF00A96ABD /* VTPDirectory.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5FAB0750EFABE2C00BAD4AE /* VTPDirectory.cpp */; };
-		F5A1CB7E0F6B06CF00A96ABD /* VTPSession.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5FAB0790EFABE4A00BAD4AE /* VTPSession.cpp */; };
-		F5A1CB810F6B06CF00A96ABD /* ExternalPlayer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C5608C40F1754930056433A /* ExternalPlayer.cpp */; };
-		F5A1CB830F6B06CF00A96ABD /* HTTPDirectory.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F584E12D0F257C5100DB26A5 /* HTTPDirectory.cpp */; };
-		F5A1CB840F6B06CF00A96ABD /* GUIDialogKaraokeSongSelector.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F54C51D00F1E783200D46E3C /* GUIDialogKaraokeSongSelector.cpp */; };
-		F5A1CB850F6B06CF00A96ABD /* karaokelyricscdg.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F54C51D40F1E784800D46E3C /* karaokelyricscdg.cpp */; };
-		F5A1CB860F6B06CF00A96ABD /* karaokelyrics.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F54C51D60F1E785700D46E3C /* karaokelyrics.cpp */; };
-		F5A1CB870F6B06CF00A96ABD /* karaokelyricstextkar.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F54C51DE0F1E787700D46E3C /* karaokelyricstextkar.cpp */; };
-		F5A1CB880F6B06CF00A96ABD /* karaokelyricsmanager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F54C51E10F1E787700D46E3C /* karaokelyricsmanager.cpp */; };
-		F5A1CB890F6B06CF00A96ABD /* karaokelyricsfactory.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F54C51E20F1E787700D46E3C /* karaokelyricsfactory.cpp */; };
-		F5A1CB8A0F6B06CF00A96ABD /* karaokelyricstextlrc.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F54C51E30F1E787700D46E3C /* karaokelyricstextlrc.cpp */; };
-		F5A1CB8B0F6B06CF00A96ABD /* karaokelyricstext.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F54C51E40F1E787700D46E3C /* karaokelyricstext.cpp */; };
-		F5A1CB8E0F6B06CF00A96ABD /* SpecialProtocolDirectory.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7CEBD8A60F33A0D800CAF6AD /* SpecialProtocolDirectory.cpp */; };
-		F5A1CB8F0F6B06CF00A96ABD /* SpecialProtocol.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C2D6AE20F35453E00DD2E85 /* SpecialProtocol.cpp */; };
-		F5A1CB900F6B06CF00A96ABD /* GUIWindowKaraokeLyrics.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5AD1EA70F488A1A0065EB5D /* GUIWindowKaraokeLyrics.cpp */; };
-		F5A1CB910F6B06CF00A96ABD /* karaokewindowbackground.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F56A084A0F4A18FB003F9F87 /* karaokewindowbackground.cpp */; };
-		F5A1CB970F6B06CF00A96ABD /* DVDDemuxHTSP.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F55110440F5C3C0000955236 /* DVDDemuxHTSP.cpp */; };
-		F5A1CB980F6B06CF00A96ABD /* htsatomic.c in Sources */ = {isa = PBXBuildFile; fileRef = F551106D0F5C424700955236 /* htsatomic.c */; };
-		F5A1CB990F6B06CF00A96ABD /* htsbuf.c in Sources */ = {isa = PBXBuildFile; fileRef = F551106F0F5C424700955236 /* htsbuf.c */; };
-		F5A1CB9A0F6B06CF00A96ABD /* htsmsg.c in Sources */ = {isa = PBXBuildFile; fileRef = F55110710F5C424700955236 /* htsmsg.c */; };
-		F5A1CB9B0F6B06CF00A96ABD /* htsmsg_binary.c in Sources */ = {isa = PBXBuildFile; fileRef = F55110730F5C424700955236 /* htsmsg_binary.c */; };
-		F5A1CB9C0F6B06CF00A96ABD /* htsstr.c in Sources */ = {isa = PBXBuildFile; fileRef = F55110760F5C424700955236 /* htsstr.c */; };
-		F5A1CB9D0F6B06CF00A96ABD /* net_posix.c in Sources */ = {isa = PBXBuildFile; fileRef = F551107B0F5C424700955236 /* net_posix.c */; };
-		F5A1CB9E0F6B06CF00A96ABD /* OSXGNUReplacements.c in Sources */ = {isa = PBXBuildFile; fileRef = F51CEEEE0F5C5D20004F4602 /* OSXGNUReplacements.c */; };
-		F5A1CB9F0F6B06CF00A96ABD /* DVDInputStreamHTSP.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F51CEF860F5C64A5004F4602 /* DVDInputStreamHTSP.cpp */; };
-		F5A1CBA00F6B06CF00A96ABD /* sha1.c in Sources */ = {isa = PBXBuildFile; fileRef = F51CF2CE0F6055A4004F4602 /* sha1.c */; };
-		F5A1CBA20F6B06CF00A96ABD /* CoreFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 09AB6884FE841BABC02AAC07 /* CoreFoundation.framework */; };
-		F5A1CBA30F6B06CF00A96ABD /* AudioToolbox.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E38E238B0D2626E600618676 /* AudioToolbox.framework */; };
-		F5A1CBA40F6B06CF00A96ABD /* AudioUnit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E38E238C0D2626E600618676 /* AudioUnit.framework */; };
-		F5A1CBA50F6B06CF00A96ABD /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E38E238D0D2626E600618676 /* Cocoa.framework */; };
-		F5A1CBA60F6B06CF00A96ABD /* CoreAudio.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E38E238E0D2626E600618676 /* CoreAudio.framework */; };
-		F5A1CBA70F6B06CF00A96ABD /* CoreServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E38E238F0D2626E600618676 /* CoreServices.framework */; };
-		F5A1CBA80F6B06CF00A96ABD /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E38E23900D2626E600618676 /* Foundation.framework */; };
-		F5A1CBA90F6B06CF00A96ABD /* OpenGL.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E38E23910D2626E600618676 /* OpenGL.framework */; };
-		F5A1CBAE0F6B06CF00A96ABD /* AppKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E38E25330D26365C00618676 /* AppKit.framework */; };
-		F5A1CBAF0F6B06CF00A96ABD /* ApplicationServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E38E25340D26365C00618676 /* ApplicationServices.framework */; };
-		F5A1CBB30F6B06CF00A96ABD /* IOKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E33466A50D2E5103005A65EC /* IOKit.framework */; };
-		F5A1CBB40F6B06CF00A96ABD /* QuickTime.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E35EF2540D380C3D00DB5CD5 /* QuickTime.framework */; };
-		F5A1CBB50F6B06CF00A96ABD /* Carbon.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E35EF3230D380E1E00DB5CD5 /* Carbon.framework */; };
-		F5A1CBBB0F6B06CF00A96ABD /* DiskArbitration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 88ECB6580DE013C4003396A7 /* DiskArbitration.framework */; };
-		F5A2BD0E0F7AD9140006ABA0 /* ZeroconfOSX.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E46F7C2C0F77219700C25D29 /* ZeroconfOSX.cpp */; };
-		F5A2BD0F0F7AD92C0006ABA0 /* Zeroconf.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E46F7C280F77217400C25D29 /* Zeroconf.cpp */; };
 		F5A7A702112893E50059D6AA /* AnnouncementManager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5A7A700112893E50059D6AA /* AnnouncementManager.cpp */; };
-		F5A7A703112893E50059D6AA /* AnnouncementManager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5A7A700112893E50059D6AA /* AnnouncementManager.cpp */; };
 		F5A7A85B112908F00059D6AA /* WebServer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5A7A859112908F00059D6AA /* WebServer.cpp */; };
-		F5A7A85C112908F00059D6AA /* WebServer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5A7A859112908F00059D6AA /* WebServer.cpp */; };
 		F5A7B37E113AFB900059D6AA /* SFTPDirectory.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5A7B37C113AFB900059D6AA /* SFTPDirectory.cpp */; };
-		F5A7B37F113AFB900059D6AA /* SFTPDirectory.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5A7B37C113AFB900059D6AA /* SFTPDirectory.cpp */; };
 		F5A7B42C113CBB950059D6AA /* AddonsDirectory.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5A7B42B113CBB950059D6AA /* AddonsDirectory.cpp */; };
-		F5A7B42D113CBB950059D6AA /* AddonsDirectory.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5A7B42B113CBB950059D6AA /* AddonsDirectory.cpp */; };
 		F5A9D3091097C9370050490F /* AliasShortcutUtils.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5A9D3081097C9370050490F /* AliasShortcutUtils.cpp */; };
-		F5A9D30A1097C9370050490F /* AliasShortcutUtils.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5A9D3081097C9370050490F /* AliasShortcutUtils.cpp */; };
 		F5AACA680FB3DE2D00DBB77C /* GUIDialogSelect.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5AACA670FB3DE2D00DBB77C /* GUIDialogSelect.cpp */; };
-		F5AACA690FB3DE2D00DBB77C /* GUIDialogSelect.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5AACA670FB3DE2D00DBB77C /* GUIDialogSelect.cpp */; };
 		F5AACA970FB3E2B800DBB77C /* GUIDialogSlider.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5AACA950FB3E2B800DBB77C /* GUIDialogSlider.cpp */; };
-		F5AACA980FB3E2B800DBB77C /* GUIDialogSlider.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5AACA950FB3E2B800DBB77C /* GUIDialogSlider.cpp */; };
 		F5AD1EA80F488A1A0065EB5D /* GUIWindowKaraokeLyrics.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5AD1EA70F488A1A0065EB5D /* GUIWindowKaraokeLyrics.cpp */; };
 		F5AE407613415D8D0004BD79 /* HttpApi.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5AE406F13415D8C0004BD79 /* HttpApi.cpp */; };
 		F5AE407913415D8D0004BD79 /* XBMChttp.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5AE407413415D8C0004BD79 /* XBMChttp.cpp */; };
-		F5AE407A13415D8D0004BD79 /* HttpApi.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5AE406F13415D8C0004BD79 /* HttpApi.cpp */; };
-		F5AE407D13415D8D0004BD79 /* XBMChttp.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5AE407413415D8C0004BD79 /* XBMChttp.cpp */; };
 		F5AE409C13415D9E0004BD79 /* AudioLibrary.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5AE408013415D9E0004BD79 /* AudioLibrary.cpp */; };
 		F5AE409F13415D9E0004BD79 /* FileItemHandler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5AE408613415D9E0004BD79 /* FileItemHandler.cpp */; };
 		F5AE40A013415D9E0004BD79 /* FileOperations.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5AE408813415D9E0004BD79 /* FileOperations.cpp */; };
@@ -1875,41 +947,18 @@
 		F5AE40A613415D9E0004BD79 /* SystemOperations.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5AE409613415D9E0004BD79 /* SystemOperations.cpp */; };
 		F5AE40A713415D9E0004BD79 /* VideoLibrary.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5AE409813415D9E0004BD79 /* VideoLibrary.cpp */; };
 		F5AE40A813415D9E0004BD79 /* XBMCOperations.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5AE409A13415D9E0004BD79 /* XBMCOperations.cpp */; };
-		F5AE40A913415D9E0004BD79 /* AudioLibrary.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5AE408013415D9E0004BD79 /* AudioLibrary.cpp */; };
-		F5AE40AC13415D9E0004BD79 /* FileItemHandler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5AE408613415D9E0004BD79 /* FileItemHandler.cpp */; };
-		F5AE40AD13415D9E0004BD79 /* FileOperations.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5AE408813415D9E0004BD79 /* FileOperations.cpp */; };
-		F5AE40AE13415D9E0004BD79 /* JSONRPC.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5AE408C13415D9E0004BD79 /* JSONRPC.cpp */; };
-		F5AE40B113415D9E0004BD79 /* PlayerOperations.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5AE409213415D9E0004BD79 /* PlayerOperations.cpp */; };
-		F5AE40B213415D9E0004BD79 /* PlaylistOperations.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5AE409413415D9E0004BD79 /* PlaylistOperations.cpp */; };
-		F5AE40B313415D9E0004BD79 /* SystemOperations.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5AE409613415D9E0004BD79 /* SystemOperations.cpp */; };
-		F5AE40B413415D9E0004BD79 /* VideoLibrary.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5AE409813415D9E0004BD79 /* VideoLibrary.cpp */; };
-		F5AE40B513415D9E0004BD79 /* XBMCOperations.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5AE409A13415D9E0004BD79 /* XBMCOperations.cpp */; };
 		F5B13C8D1334056B0045076D /* DarwinUtils.mm in Sources */ = {isa = PBXBuildFile; fileRef = F5B13C8C1334056B0045076D /* DarwinUtils.mm */; };
-		F5B13C8E1334056B0045076D /* DarwinUtils.mm in Sources */ = {isa = PBXBuildFile; fileRef = F5B13C8C1334056B0045076D /* DarwinUtils.mm */; };
-		F5B5D64D133FC2C1007A4B4C /* libsquish.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 43352CED1071634600706B8A /* libsquish.a */; };
-		F5B5D64E133FC2E7007A4B4C /* librtv.a in Frameworks */ = {isa = PBXBuildFile; fileRef = E38E256C0D263A1C00618676 /* librtv.a */; };
-		F5B5D650133FC312007A4B4C /* libxdaap.a in Frameworks */ = {isa = PBXBuildFile; fileRef = E38E25680D2639F100618676 /* libxdaap.a */; };
 		F5BD02F6148D3A7E001B5583 /* CryptThreading.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5BD02F4148D3A7E001B5583 /* CryptThreading.cpp */; };
-		F5BD02F7148D3A7E001B5583 /* CryptThreading.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5BD02F4148D3A7E001B5583 /* CryptThreading.cpp */; };
 		F5BDB80C120202F400F0B710 /* DVDSubtitleTagSami.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5BDB80B120202F400F0B710 /* DVDSubtitleTagSami.cpp */; };
-		F5BDB80D120202F400F0B710 /* DVDSubtitleTagSami.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5BDB80B120202F400F0B710 /* DVDSubtitleTagSami.cpp */; };
 		F5BDB81A1202032400F0B710 /* DVDSubtitleTagMicroDVD.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5BDB8191202032400F0B710 /* DVDSubtitleTagMicroDVD.cpp */; };
-		F5BDB81B1202032400F0B710 /* DVDSubtitleTagMicroDVD.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5BDB8191202032400F0B710 /* DVDSubtitleTagMicroDVD.cpp */; };
 		F5BDB820120203C200F0B710 /* AutoPtrHandle.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5BDB81F120203C200F0B710 /* AutoPtrHandle.cpp */; };
-		F5BDB821120203C200F0B710 /* AutoPtrHandle.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5BDB81F120203C200F0B710 /* AutoPtrHandle.cpp */; };
 		F5CEE60913D3C89700225F72 /* DVDOverlayCodecTX3G.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5CEE60713D3C89700225F72 /* DVDOverlayCodecTX3G.cpp */; };
 		F5D8D732102BB3B1004A11AB /* OverlayRendererGL.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5D8D72F102BB3B1004A11AB /* OverlayRendererGL.cpp */; };
 		F5D8D733102BB3B1004A11AB /* OverlayRenderer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5D8D731102BB3B1004A11AB /* OverlayRenderer.cpp */; };
-		F5D8D734102BB3B1004A11AB /* OverlayRendererGL.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5D8D72F102BB3B1004A11AB /* OverlayRendererGL.cpp */; };
-		F5D8D735102BB3B1004A11AB /* OverlayRenderer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5D8D731102BB3B1004A11AB /* OverlayRenderer.cpp */; };
 		F5D8EF5B103912A4004A11AB /* DVDSubtitleParserVplayer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5D8EF59103912A4004A11AB /* DVDSubtitleParserVplayer.cpp */; };
-		F5D8EF5C103912A4004A11AB /* DVDSubtitleParserVplayer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5D8EF59103912A4004A11AB /* DVDSubtitleParserVplayer.cpp */; };
 		F5DC87E2110A287400EE1B15 /* RingBuffer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5DC87E1110A287400EE1B15 /* RingBuffer.cpp */; };
-		F5DC87E3110A287400EE1B15 /* RingBuffer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5DC87E1110A287400EE1B15 /* RingBuffer.cpp */; };
 		F5DC8801110A46C700EE1B15 /* ModplugCodec.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5DC8800110A46C700EE1B15 /* ModplugCodec.cpp */; };
-		F5DC8802110A46C700EE1B15 /* ModplugCodec.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5DC8800110A46C700EE1B15 /* ModplugCodec.cpp */; };
 		F5DC888B110A654000EE1B15 /* libapetag.a in Frameworks */ = {isa = PBXBuildFile; fileRef = F5DC888A110A654000EE1B15 /* libapetag.a */; };
-		F5DC888C110A654000EE1B15 /* libapetag.a in Frameworks */ = {isa = PBXBuildFile; fileRef = F5DC888A110A654000EE1B15 /* libapetag.a */; };
 		F5E10537140AA38100175026 /* PeripheralBusUSB.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5E10513140AA38000175026 /* PeripheralBusUSB.cpp */; };
 		F5E10538140AA38100175026 /* PeripheralBus.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5E10515140AA38000175026 /* PeripheralBus.cpp */; };
 		F5E1053B140AA38100175026 /* Peripheral.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5E1051C140AA38000175026 /* Peripheral.cpp */; };
@@ -1922,56 +971,25 @@
 		F5E10543140AA38100175026 /* GUIDialogPeripheralManager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5E1052D140AA38000175026 /* GUIDialogPeripheralManager.cpp */; };
 		F5E10544140AA38100175026 /* GUIDialogPeripheralSettings.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5E1052F140AA38000175026 /* GUIDialogPeripheralSettings.cpp */; };
 		F5E10547140AA38100175026 /* Peripherals.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5E10533140AA38000175026 /* Peripherals.cpp */; };
-		F5E10549140AA38100175026 /* PeripheralBusUSB.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5E10513140AA38000175026 /* PeripheralBusUSB.cpp */; };
-		F5E1054A140AA38100175026 /* PeripheralBus.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5E10515140AA38000175026 /* PeripheralBus.cpp */; };
-		F5E1054D140AA38100175026 /* Peripheral.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5E1051C140AA38000175026 /* Peripheral.cpp */; };
-		F5E1054E140AA38100175026 /* PeripheralBluetooth.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5E1051E140AA38000175026 /* PeripheralBluetooth.cpp */; };
-		F5E10550140AA38100175026 /* PeripheralDisk.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5E10522140AA38000175026 /* PeripheralDisk.cpp */; };
-		F5E10551140AA38100175026 /* PeripheralHID.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5E10524140AA38000175026 /* PeripheralHID.cpp */; };
-		F5E10552140AA38100175026 /* PeripheralNIC.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5E10526140AA38000175026 /* PeripheralNIC.cpp */; };
-		F5E10553140AA38100175026 /* PeripheralNyxboard.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5E10528140AA38000175026 /* PeripheralNyxboard.cpp */; };
-		F5E10554140AA38100175026 /* PeripheralTuner.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5E1052A140AA38000175026 /* PeripheralTuner.cpp */; };
-		F5E10555140AA38100175026 /* GUIDialogPeripheralManager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5E1052D140AA38000175026 /* GUIDialogPeripheralManager.cpp */; };
-		F5E10556140AA38100175026 /* GUIDialogPeripheralSettings.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5E1052F140AA38000175026 /* GUIDialogPeripheralSettings.cpp */; };
-		F5E10559140AA38100175026 /* Peripherals.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5E10533140AA38000175026 /* Peripherals.cpp */; };
-		F5E10D381428426B00175026 /* JpegIO.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 32C631261423A90F00F18420 /* JpegIO.cpp */; };
 		F5E1125E14356B2400175026 /* pyrendercapture.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5E1125C14356B2400175026 /* pyrendercapture.cpp */; };
-		F5E1125F14356B2400175026 /* pyrendercapture.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5E1125C14356B2400175026 /* pyrendercapture.cpp */; };
 		F5E1138014357F3800175026 /* PeripheralCecAdapter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5E10520140AA38000175026 /* PeripheralCecAdapter.cpp */; };
-		F5E1138114357F3900175026 /* PeripheralCecAdapter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5E10520140AA38000175026 /* PeripheralCecAdapter.cpp */; };
 		F5E55B5D10741272006E788A /* DVDPlayerTeletext.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5E55B5B10741272006E788A /* DVDPlayerTeletext.cpp */; };
-		F5E55B5E10741272006E788A /* DVDPlayerTeletext.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5E55B5B10741272006E788A /* DVDPlayerTeletext.cpp */; };
 		F5E55B66107412DE006E788A /* GUIDialogTeletext.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5E55B65107412DE006E788A /* GUIDialogTeletext.cpp */; };
-		F5E55B67107412DE006E788A /* GUIDialogTeletext.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5E55B65107412DE006E788A /* GUIDialogTeletext.cpp */; };
 		F5E55B7010741340006E788A /* Teletext.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5E55B6E10741340006E788A /* Teletext.cpp */; };
-		F5E55B7110741340006E788A /* Teletext.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5E55B6E10741340006E788A /* Teletext.cpp */; };
 		F5E560BC10770F9F006E788A /* OggCallback.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5E560BB10770F9F006E788A /* OggCallback.cpp */; };
-		F5E560BD10770F9F006E788A /* OggCallback.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5E560BB10770F9F006E788A /* OggCallback.cpp */; };
 		F5E5697310803FC3006E788A /* fastmemcpy.c in Sources */ = {isa = PBXBuildFile; fileRef = F5E5697210803FC3006E788A /* fastmemcpy.c */; };
-		F5E5697410803FC3006E788A /* fastmemcpy.c in Sources */ = {isa = PBXBuildFile; fileRef = F5E5697210803FC3006E788A /* fastmemcpy.c */; };
 		F5E56BA61082A675006E788A /* PosixMountProvider.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5E56BA51082A675006E788A /* PosixMountProvider.cpp */; };
-		F5E56BA71082A675006E788A /* PosixMountProvider.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5E56BA51082A675006E788A /* PosixMountProvider.cpp */; };
-		F5EA021C0F6DA7E8005C2EC5 /* PowerManager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5EA021A0F6DA7E8005C2EC5 /* PowerManager.cpp */; };
-		F5EA02220F6DA85C005C2EC5 /* CocoaPowerSyscall.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5EA02200F6DA85C005C2EC5 /* CocoaPowerSyscall.cpp */; };
 		F5EA02260F6DA990005C2EC5 /* CocoaPowerSyscall.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5EA02200F6DA85C005C2EC5 /* CocoaPowerSyscall.cpp */; };
 		F5EA02270F6DA9A5005C2EC5 /* PowerManager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5EA021A0F6DA7E8005C2EC5 /* PowerManager.cpp */; };
-		F5EA04290F72EB88005C2EC5 /* SDLMain.mm in Sources */ = {isa = PBXBuildFile; fileRef = F5EA04280F72EB88005C2EC5 /* SDLMain.mm */; };
 		F5EA04800F72F188005C2EC5 /* SDLMain.mm in Sources */ = {isa = PBXBuildFile; fileRef = F5EA04280F72EB88005C2EC5 /* SDLMain.mm */; };
-		F5EA05C10F733812005C2EC5 /* CocoaInterface.mm in Sources */ = {isa = PBXBuildFile; fileRef = F5EA05C00F733812005C2EC5 /* CocoaInterface.mm */; };
 		F5EA05C20F733812005C2EC5 /* CocoaInterface.mm in Sources */ = {isa = PBXBuildFile; fileRef = F5EA05C00F733812005C2EC5 /* CocoaInterface.mm */; };
 		F5ED8D6C1551F91400842059 /* BlurayDirectory.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5ED8D6A1551F91400842059 /* BlurayDirectory.cpp */; };
-		F5ED8D6D1551F91400842059 /* BlurayDirectory.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5ED8D6A1551F91400842059 /* BlurayDirectory.cpp */; };
 		F5ED908815538DCE00842059 /* XBMCTinyXML.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5ED908615538DCE00842059 /* XBMCTinyXML.cpp */; };
-		F5ED908915538DCE00842059 /* XBMCTinyXML.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5ED908615538DCE00842059 /* XBMCTinyXML.cpp */; };
 		F5ED908E15538E2300842059 /* POUtils.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5ED908C15538E2300842059 /* POUtils.cpp */; };
-		F5ED908F15538E2300842059 /* POUtils.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5ED908C15538E2300842059 /* POUtils.cpp */; };
 		F5F240EF110A4F76009126C6 /* CrystalHD.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5F240EB110A4F76009126C6 /* CrystalHD.cpp */; };
 		F5F244651110DC6B009126C6 /* FileOperationJob.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5F244641110DC6B009126C6 /* FileOperationJob.cpp */; };
-		F5F244661110DC6B009126C6 /* FileOperationJob.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5F244641110DC6B009126C6 /* FileOperationJob.cpp */; };
 		F5F245DA1112C6AC009126C6 /* DVDAudioCodecPassthroughFFmpeg.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5F245D81112C6AC009126C6 /* DVDAudioCodecPassthroughFFmpeg.cpp */; };
-		F5F245DB1112C6AC009126C6 /* DVDAudioCodecPassthroughFFmpeg.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5F245D81112C6AC009126C6 /* DVDAudioCodecPassthroughFFmpeg.cpp */; };
 		F5F245EE1112C9AB009126C6 /* FileUtils.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5F245EC1112C9AB009126C6 /* FileUtils.cpp */; };
-		F5F245EF1112C9AB009126C6 /* FileUtils.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5F245EC1112C9AB009126C6 /* FileUtils.cpp */; };
 		F5F2EF4B0E593E0D0092C37F /* DVDFileInfo.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5F2EF4A0E593E0D0092C37F /* DVDFileInfo.cpp */; };
 		F5F8E1DA0E427E8000A8E96F /* VGMCodec.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5F8E1D90E427E8000A8E96F /* VGMCodec.cpp */; };
 		F5F8E1E80E427F6700A8E96F /* md5.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5F8E1E60E427F6700A8E96F /* md5.cpp */; };
@@ -1989,13 +1007,6 @@
 			proxyType = 1;
 			remoteGlobalIDString = 8DD76F740486A8DE00D96B5E;
 			remoteInfo = XBMC;
-		};
-		F5A1CBE50F6B0BFB00A96ABD /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 08FB7793FE84155DC02AAC07 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = F5A1C8710F6B06CF00A96ABD;
-			remoteInfo = XBMC_ppc;
 		};
 /* End PBXContainerItemProxy section */
 
@@ -3850,6 +2861,9 @@
 		F52B06B91187CE18004B1D66 /* DVDVideoCodecVDA.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = DVDVideoCodecVDA.h; path = xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecVDA.h; sourceTree = SOURCE_ROOT; };
 		F52BFFD9115D5574004B1D66 /* AddonStatusHandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AddonStatusHandler.h; sourceTree = "<group>"; };
 		F52BFFDA115D5574004B1D66 /* AddonStatusHandler.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = AddonStatusHandler.cpp; sourceTree = "<group>"; };
+		F5364D33155B3B270016D00B /* CoreVideo.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreVideo.framework; path = /System/Library/Frameworks/CoreVideo.framework; sourceTree = "<absolute>"; };
+		F5364D54155B3C7B0016D00B /* libm.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libm.dylib; path = /usr/lib/libm.dylib; sourceTree = "<absolute>"; };
+		F5364E04155B3CAF0016D00B /* IOSurface.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = IOSurface.framework; path = /System/Library/Frameworks/IOSurface.framework; sourceTree = "<absolute>"; };
 		F548786B0FE060FF00E506FD /* DVDSubtitleParserMPL2.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DVDSubtitleParserMPL2.h; sourceTree = "<group>"; };
 		F548786C0FE060FF00E506FD /* DVDSubtitleParserMPL2.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; path = DVDSubtitleParserMPL2.cpp; sourceTree = "<group>"; };
 		F5487B4A0FE6F02700E506FD /* StreamDetails.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = StreamDetails.h; sourceTree = "<group>"; };
@@ -3904,7 +2918,6 @@
 		F56A08490F4A18FB003F9F87 /* karaokewindowbackground.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = karaokewindowbackground.h; sourceTree = "<group>"; };
 		F56A084A0F4A18FB003F9F87 /* karaokewindowbackground.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = karaokewindowbackground.cpp; sourceTree = "<group>"; };
 		F56C8CE6131F5DC6000AD0F6 /* libz.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libz.dylib; path = usr/lib/libz.dylib; sourceTree = SDKROOT; };
-		F56C8CE9131F5DCC000AD0F6 /* libm.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libm.dylib; path = usr/lib/libm.dylib; sourceTree = SDKROOT; };
 		F56C8CEC131F5DE7000AD0F6 /* libbz2.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libbz2.dylib; path = usr/lib/libbz2.dylib; sourceTree = SDKROOT; };
 		F56C8CEF131F5DED000AD0F6 /* libxml2.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libxml2.dylib; path = usr/lib/libxml2.dylib; sourceTree = SDKROOT; };
 		F56C8CF2131F5DFD000AD0F6 /* libiconv.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libiconv.dylib; path = usr/lib/libiconv.dylib; sourceTree = SDKROOT; };
@@ -3938,7 +2951,6 @@
 		F599CD2A108E65370010EC2A /* IoSupport.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = IoSupport.h; sourceTree = "<group>"; };
 		F599CD72108E6A7A0010EC2A /* DarwinStorageProvider.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DarwinStorageProvider.h; sourceTree = "<group>"; };
 		F599CD73108E6A7A0010EC2A /* DarwinStorageProvider.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = DarwinStorageProvider.cpp; sourceTree = "<group>"; };
-		F5A1CBD20F6B06CF00A96ABD /* XBMC */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = XBMC; sourceTree = BUILT_PRODUCTS_DIR; };
 		F5A7A700112893E50059D6AA /* AnnouncementManager.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = AnnouncementManager.cpp; sourceTree = "<group>"; };
 		F5A7A701112893E50059D6AA /* AnnouncementManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AnnouncementManager.h; sourceTree = "<group>"; };
 		F5A7A859112908F00059D6AA /* WebServer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WebServer.cpp; sourceTree = "<group>"; };
@@ -4111,47 +3123,15 @@
 				43352CEE1071634600706B8A /* libsquish.a in Frameworks */,
 				F5DC888B110A654000EE1B15 /* libapetag.a in Frameworks */,
 				F56C8CE7131F5DC6000AD0F6 /* libz.dylib in Frameworks */,
-				F56C8CEA131F5DCC000AD0F6 /* libm.dylib in Frameworks */,
 				F56C8CED131F5DE7000AD0F6 /* libbz2.dylib in Frameworks */,
 				F56C8CF0131F5DED000AD0F6 /* libxml2.dylib in Frameworks */,
 				F56C8CF3131F5DFD000AD0F6 /* libiconv.dylib in Frameworks */,
 				F56C8CF6131F5E0B000AD0F6 /* libncurses.dylib in Frameworks */,
 				18404DA61396C31B00863BBA /* SlingboxLib.a in Frameworks */,
 				DFC1B8F01464840E00B1BE79 /* SystemConfiguration.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		F5A1CBA10F6B06CF00A96ABD /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				F5A1CBA20F6B06CF00A96ABD /* CoreFoundation.framework in Frameworks */,
-				F5A1CBA30F6B06CF00A96ABD /* AudioToolbox.framework in Frameworks */,
-				F5A1CBA40F6B06CF00A96ABD /* AudioUnit.framework in Frameworks */,
-				F5A1CBA50F6B06CF00A96ABD /* Cocoa.framework in Frameworks */,
-				F5A1CBA60F6B06CF00A96ABD /* CoreAudio.framework in Frameworks */,
-				F5A1CBA70F6B06CF00A96ABD /* CoreServices.framework in Frameworks */,
-				F5A1CBA80F6B06CF00A96ABD /* Foundation.framework in Frameworks */,
-				F5A1CBA90F6B06CF00A96ABD /* OpenGL.framework in Frameworks */,
-				F5A1CBAE0F6B06CF00A96ABD /* AppKit.framework in Frameworks */,
-				F5A1CBAF0F6B06CF00A96ABD /* ApplicationServices.framework in Frameworks */,
-				F5A1CBB30F6B06CF00A96ABD /* IOKit.framework in Frameworks */,
-				F5A1CBB40F6B06CF00A96ABD /* QuickTime.framework in Frameworks */,
-				F5A1CBB50F6B06CF00A96ABD /* Carbon.framework in Frameworks */,
-				F5A1CBBB0F6B06CF00A96ABD /* DiskArbitration.framework in Frameworks */,
-				F59879090FBAA0C3008EF4FB /* QuartzCore.framework in Frameworks */,
-				F5DC888C110A654000EE1B15 /* libapetag.a in Frameworks */,
-				F56C8CE8131F5DC6000AD0F6 /* libz.dylib in Frameworks */,
-				F56C8CEB131F5DCC000AD0F6 /* libm.dylib in Frameworks */,
-				F56C8CEE131F5DE7000AD0F6 /* libbz2.dylib in Frameworks */,
-				F56C8CF1131F5DED000AD0F6 /* libxml2.dylib in Frameworks */,
-				F56C8CF4131F5DFD000AD0F6 /* libiconv.dylib in Frameworks */,
-				F56C8CF7131F5E0B000AD0F6 /* libncurses.dylib in Frameworks */,
-				F5B5D64D133FC2C1007A4B4C /* libsquish.a in Frameworks */,
-				F5B5D64E133FC2E7007A4B4C /* librtv.a in Frameworks */,
-				F5B5D650133FC312007A4B4C /* libxdaap.a in Frameworks */,
-				18404E711396E06C00863BBA /* SlingboxLib.a in Frameworks */,
-				DFC1BA3414648D6500B1BE79 /* SystemConfiguration.framework in Frameworks */,
+				F5364D34155B3B270016D00B /* CoreVideo.framework in Frameworks */,
+				F5364D55155B3C7B0016D00B /* libm.dylib in Frameworks */,
+				F5364E05155B3CAF0016D00B /* IOSurface.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -4162,10 +3142,10 @@
 			isa = PBXGroup;
 			children = (
 				C6859E96029091FE04C91782 /* Documentation */,
-				F57E1ED20E36E8FD00700C9D /* internal libs */,
-				19C28FBDFE9D53C911CA2CBB /* Products */,
 				08FB7795FE84155DC02AAC07 /* Source */,
+				F57E1ED20E36E8FD00700C9D /* internal libs */,
 				08FB779DFE84155DC02AAC07 /* System Libs and Frameworks */,
+				19C28FBDFE9D53C911CA2CBB /* Products */,
 			);
 			name = XBMC;
 			sourceTree = "<group>";
@@ -4182,6 +3162,12 @@
 		08FB779DFE84155DC02AAC07 /* System Libs and Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				F56C8CE6131F5DC6000AD0F6 /* libz.dylib */,
+				F5364D54155B3C7B0016D00B /* libm.dylib */,
+				F56C8CEC131F5DE7000AD0F6 /* libbz2.dylib */,
+				F56C8CEF131F5DED000AD0F6 /* libxml2.dylib */,
+				F56C8CF2131F5DFD000AD0F6 /* libiconv.dylib */,
+				F56C8CF5131F5E0B000AD0F6 /* libncurses.dylib */,
 				E38E25330D26365C00618676 /* AppKit.framework */,
 				E38E25340D26365C00618676 /* ApplicationServices.framework */,
 				E38E238B0D2626E600618676 /* AudioToolbox.framework */,
@@ -4189,22 +3175,17 @@
 				E35EF3230D380E1E00DB5CD5 /* Carbon.framework */,
 				E38E238D0D2626E600618676 /* Cocoa.framework */,
 				E38E238E0D2626E600618676 /* CoreAudio.framework */,
+				F5364D33155B3B270016D00B /* CoreVideo.framework */,
 				09AB6884FE841BABC02AAC07 /* CoreFoundation.framework */,
 				E38E238F0D2626E600618676 /* CoreServices.framework */,
 				88ECB6580DE013C4003396A7 /* DiskArbitration.framework */,
 				E38E23900D2626E600618676 /* Foundation.framework */,
 				E33466A50D2E5103005A65EC /* IOKit.framework */,
-				F56C8CEC131F5DE7000AD0F6 /* libbz2.dylib */,
-				F56C8CF2131F5DFD000AD0F6 /* libiconv.dylib */,
-				F56C8CE9131F5DCC000AD0F6 /* libm.dylib */,
-				F56C8CF5131F5E0B000AD0F6 /* libncurses.dylib */,
-				F56C8CEF131F5DED000AD0F6 /* libxml2.dylib */,
-				F56C8CE6131F5DC6000AD0F6 /* libz.dylib */,
+				F5364E04155B3CAF0016D00B /* IOSurface.framework */,
 				DFC1B8EF1464840E00B1BE79 /* SystemConfiguration.framework */,
 				E38E23910D2626E600618676 /* OpenGL.framework */,
 				F59879070FBAA0C3008EF4FB /* QuartzCore.framework */,
 				E35EF2540D380C3D00DB5CD5 /* QuickTime.framework */,
-				F56C8CE9131F5DCC000AD0F6 /* libm.dylib */,
 			);
 			name = "System Libs and Frameworks";
 			sourceTree = "<group>";
@@ -4585,7 +3566,6 @@
 			isa = PBXGroup;
 			children = (
 				8DD76F7E0486A8DE00D96B5E /* XBMC */,
-				F5A1CBD20F6B06CF00A96ABD /* XBMC */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -7238,30 +6218,13 @@
 			productReference = 8DD76F7E0486A8DE00D96B5E /* XBMC */;
 			productType = "com.apple.product-type.tool";
 		};
-		F5A1C8710F6B06CF00A96ABD /* XBMC_ppc */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = F5A1CBCF0F6B06CF00A96ABD /* Build configuration list for PBXNativeTarget "XBMC_ppc" */;
-			buildPhases = (
-				F5A1C8730F6B06CF00A96ABD /* Sources */,
-				F5A1CBA10F6B06CF00A96ABD /* Frameworks */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = XBMC_ppc;
-			productInstallPath = "$(HOME)/bin";
-			productName = XBMC;
-			productReference = F5A1CBD20F6B06CF00A96ABD /* XBMC */;
-			productType = "com.apple.product-type.tool";
-		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
 		08FB7793FE84155DC02AAC07 /* Project object */ = {
 			isa = PBXProject;
 			buildConfigurationList = 1DEB924B08733DCA0010E9CD /* Build configuration list for PBXProject "XBMC" */;
-			compatibilityVersion = "Xcode 3.1";
+			compatibilityVersion = "Xcode 3.2";
 			developmentRegion = English;
 			hasScannedForEncodings = 1;
 			knownRegions = (
@@ -7276,8 +6239,6 @@
 			targets = (
 				8DD76F740486A8DE00D96B5E /* XBMC */,
 				6E2FACBA0E26DF7A00DF79EA /* XBMC.app */,
-				F5A1C8710F6B06CF00A96ABD /* XBMC_ppc */,
-				F5A1CBDB0F6B0B4700A96ABD /* XBMC_ppc.app */,
 			);
 		};
 /* End PBXProject section */
@@ -7296,52 +6257,9 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "#set -x\n\nfunction check_dyloaded_depends\n{\n  b=$(find \"$EXTERNAL_LIBS\" -name $1 -print)\n  if [ -f \"$b\" ]; then\n    #echo \"Processing $b\"\n    if [ ! -f  \"$TARGET_FRAMEWORKS/$(basename $b)\" ]; then\n      echo \"    Packaging $b\"\n      cp -f \"$b\" \"$TARGET_FRAMEWORKS/\"\n      chmod u+w \"$TARGET_FRAMEWORKS/$(basename $b)\"\n    fi\n    for a in $(otool -L \"$b\"  | grep \"$EXTERNAL_LIBS\" | awk ' { print $1 } ') ; do\n      if [ -f \"$a\" ]; then\n        if [ ! -f  \"$TARGET_FRAMEWORKS/$(basename $a)\" ]; then\n          echo \"    Packaging $a\"\n          cp -f \"$a\" \"$TARGET_FRAMEWORKS/\"\n          chmod u+w \"$TARGET_FRAMEWORKS/$(basename $a)\"\n          install_name_tool -change \"$a\" \"$DYLIB_NAMEPATH/$(basename $a)\" \"$TARGET_FRAMEWORKS/$(basename $b)\"\n        fi\n      fi\n    done \n  fi\n}\n\nfunction check_xbmc_dylib_depends\n{\n  REWIND=\"1\"\n  while [ $REWIND = \"1\" ]\n  do\n    let REWIND=\"0\"\n    for b in $(find \"$1\" -name \"$2\" -print) ; do\n      #echo \"Processing $b\"\n      for a in $(otool -L \"$b\"  | grep \"$EXTERNAL_LIBS\" | awk ' { print $1 } ') ; do\n        #echo \"    Packaging $a\"\n        if [ ! -f  \"$TARGET_FRAMEWORKS/$(basename $a)\" ]; then\n          echo \"    Packaging $a\"\n          cp -f \"$a\" \"$TARGET_FRAMEWORKS/\"\n          chmod u+w \"$TARGET_FRAMEWORKS/$(basename $a)\"\n          let REWIND=\"1\"\n        fi\n        install_name_tool -change \"$a\" \"$DYLIB_NAMEPATH/$(basename $a)\" \"$b\"\n      done\n    done\n  done\n}\n\nEXTERNAL_LIBS=/Users/Shared/xbmc-depends/osx-10.4_i386\n\nTARGET_NAME=$PRODUCT_NAME\nTARGET_CONTENTS=$TARGET_BUILD_DIR/$TARGET_NAME/Contents\n\nTARGET_BINARY=$TARGET_CONTENTS/MacOS/XBMC\nTARGET_FRAMEWORKS=$TARGET_CONTENTS/Frameworks\nDYLIB_NAMEPATH=@executable_path/../Frameworks\nXBMC_HOME=$TARGET_CONTENTS/Resources/XBMC\n\nmkdir -p \"$TARGET_CONTENTS/MacOS\"\nmkdir -p \"$TARGET_CONTENTS/Resources\"\n# start clean so we don't keep old dylibs\nrm -rf \"$TARGET_CONTENTS/Frameworks\"\nmkdir -p \"$TARGET_CONTENTS/Frameworks\"\n\necho \"Package $TARGET_BUILD_DIR/XBMC\"\ncp -f \"$TARGET_BUILD_DIR/XBMC\" \"$TARGET_BINARY\"\ncp -f \"$SRCROOT/media/xbmc.icns\" \"$TARGET_CONTENTS/Resources/\"\ncp -f \"$SRCROOT/xbmc/osx/Info.plist\" \"$TARGET_CONTENTS/\"\n\n# Copy all of XBMC's dylib dependencies and rename their locations to inside the Framework\necho \"Checking $TARGET_BINARY dylib dependencies\"\nfor a in $(otool -L \"$TARGET_BINARY\"  | grep \"$EXTERNAL_LIBS\" | awk ' { print $1 } ') ; do \n\techo \"    Packaging $a\"\n\tcp -f \"$a\" \"$TARGET_FRAMEWORKS/\"\n\tchmod u+w \"$TARGET_FRAMEWORKS/$(basename $a)\"\n\tinstall_name_tool -change \"$a\" \"$DYLIB_NAMEPATH/$(basename $a)\" \"$TARGET_BINARY\"\ndone\n\necho \"Package $EXTERNAL_LIBS/lib/python2.6\"\nmkdir -p \"$TARGET_CONTENTS/Frameworks/lib\"\nPYTHONSYNC=\"rsync -aq --exclude .DS_Store --exclude *.a --exclude *.exe --exclude test --exclude tests\"\n${PYTHONSYNC} \"$EXTERNAL_LIBS/lib/python2.6\" \"$TARGET_FRAMEWORKS/lib/\"\nrm -rf \"$TARGET_FRAMEWORKS/lib/python2.6/config\"\n\necho \"Checking $TARGET_FRAMEWORKS/lib/python2.6 *.so for dylib dependencies\"\ncheck_xbmc_dylib_depends \"$TARGET_FRAMEWORKS\"/lib/python2.6 \"*.so\"\n\necho \"Checking $XBMC_HOME/system *.so for dylib dependencies\"\ncheck_xbmc_dylib_depends \"$XBMC_HOME\"/system \"*.so\"\n\necho \"Checking $XBMC_HOME/addons *.so for dylib dependencies\"\ncheck_xbmc_dylib_depends \"$XBMC_HOME\"/addons \"*.so\"\n\necho \"Checking $XBMC_HOME/addons *.xbs for dylib dependencies\"\ncheck_xbmc_dylib_depends \"$XBMC_HOME\"/addons \"*.xbs\"\n\necho \"Checking xbmc/DllPaths_generated.h for dylib dependencies\"\nfor a in $(grep .dylib \"$SRCROOT\"/xbmc/DllPaths_generated.h | awk '{print $3}' | sed s/\\\"//g) ; do\n  check_dyloaded_depends $a\ndone\n\necho \"Checking $TARGET_FRAMEWORKS for missing dylib dependencies\"\nREWIND=\"1\"\nwhile [ $REWIND = \"1\" ]\ndo\n\tlet REWIND=\"0\"\n\tfor b in \"$TARGET_FRAMEWORKS/\"*dylib* ; do\n\t\t#echo \"  Processing $b\"\n\t\tfor a in $(otool -L \"$b\"  | grep \"$EXTERNAL_LIBS\" | awk ' { print $1 } ') ; do\n\t\t\t#echo \"Processing $a\"\n\t\t\tif [ ! -f  \"$TARGET_FRAMEWORKS/$(basename $a)\" ]; then\n\t\t\t\techo \"    Packaging $a\"\n\t\t\t\tcp -f \"$a\" \"$TARGET_FRAMEWORKS/\"\n\t\t\t\tchmod u+w \"$TARGET_FRAMEWORKS/$(basename $a)\"\n\t\t\t\tlet REWIND=\"1\"\n\t\t\tfi\n\t\t\tinstall_name_tool -change \"$a\" \"$DYLIB_NAMEPATH/$(basename $a)\" \"$TARGET_FRAMEWORKS/$(basename $b)\"\n\t\tdone \n\tdone\ndone\n";
+			shellScript = "#set -x\n\nfunction check_dyloaded_depends\n{\n  b=$(find \"$EXTERNAL_LIBS\" -name $1 -print)\n  if [ -f \"$b\" ]; then\n    #echo \"Processing $b\"\n    if [ ! -f  \"$TARGET_FRAMEWORKS/$(basename $b)\" ]; then\n      echo \"    Packaging $b\"\n      cp -f \"$b\" \"$TARGET_FRAMEWORKS/\"\n      chmod u+w \"$TARGET_FRAMEWORKS/$(basename $b)\"\n    fi\n    for a in $(otool -L \"$b\"  | grep \"$EXTERNAL_LIBS\" | awk ' { print $1 } ') ; do\n      if [ -f \"$a\" ]; then\n        if [ ! -f  \"$TARGET_FRAMEWORKS/$(basename $a)\" ]; then\n          echo \"    Packaging $a\"\n          cp -f \"$a\" \"$TARGET_FRAMEWORKS/\"\n          chmod u+w \"$TARGET_FRAMEWORKS/$(basename $a)\"\n          install_name_tool -change \"$a\" \"$DYLIB_NAMEPATH/$(basename $a)\" \"$TARGET_FRAMEWORKS/$(basename $b)\"\n        fi\n      fi\n    done \n  fi\n}\n\nfunction check_xbmc_dylib_depends\n{\n  REWIND=\"1\"\n  while [ $REWIND = \"1\" ]\n  do\n    let REWIND=\"0\"\n    for b in $(find \"$1\" -name \"$2\" -print) ; do\n      #echo \"Processing $b\"\n      for a in $(otool -L \"$b\"  | grep \"$EXTERNAL_LIBS\" | awk ' { print $1 } ') ; do\n        #echo \"    Packaging $a\"\n        if [ ! -f  \"$TARGET_FRAMEWORKS/$(basename $a)\" ]; then\n          echo \"    Packaging $a\"\n          cp -f \"$a\" \"$TARGET_FRAMEWORKS/\"\n          chmod u+w \"$TARGET_FRAMEWORKS/$(basename $a)\"\n          let REWIND=\"1\"\n        fi\n        install_name_tool -change \"$a\" \"$DYLIB_NAMEPATH/$(basename $a)\" \"$b\"\n      done\n    done\n  done\n}\n\nEXTERNAL_LIBS=/Users/Shared/xbmc-depends/\"$SDK_NAME\"_\"$ARCHS\"\n\nTARGET_NAME=$PRODUCT_NAME\nTARGET_CONTENTS=$TARGET_BUILD_DIR/$TARGET_NAME/Contents\n\nTARGET_BINARY=$TARGET_CONTENTS/MacOS/XBMC\nTARGET_FRAMEWORKS=$TARGET_CONTENTS/Frameworks\nDYLIB_NAMEPATH=@executable_path/../Frameworks\nXBMC_HOME=$TARGET_CONTENTS/Resources/XBMC\n\nmkdir -p \"$TARGET_CONTENTS/MacOS\"\nmkdir -p \"$TARGET_CONTENTS/Resources\"\n# start clean so we don't keep old dylibs\nrm -rf \"$TARGET_CONTENTS/Frameworks\"\nmkdir -p \"$TARGET_CONTENTS/Frameworks\"\n\necho \"Package $TARGET_BUILD_DIR/XBMC\"\ncp -f \"$TARGET_BUILD_DIR/XBMC\" \"$TARGET_BINARY\"\ncp -f \"$SRCROOT/media/xbmc.icns\" \"$TARGET_CONTENTS/Resources/\"\ncp -f \"$SRCROOT/xbmc/osx/Info.plist\" \"$TARGET_CONTENTS/\"\n\n# Copy all of XBMC's dylib dependencies and rename their locations to inside the Framework\necho \"Checking $TARGET_BINARY dylib dependencies\"\nfor a in $(otool -L \"$TARGET_BINARY\"  | grep \"$EXTERNAL_LIBS\" | awk ' { print $1 } ') ; do \n\techo \"    Packaging $a\"\n\tcp -f \"$a\" \"$TARGET_FRAMEWORKS/\"\n\tchmod u+w \"$TARGET_FRAMEWORKS/$(basename $a)\"\n\tinstall_name_tool -change \"$a\" \"$DYLIB_NAMEPATH/$(basename $a)\" \"$TARGET_BINARY\"\ndone\n\necho \"Package $EXTERNAL_LIBS/lib/python2.6\"\nmkdir -p \"$TARGET_CONTENTS/Frameworks/lib\"\nPYTHONSYNC=\"rsync -aq --exclude .DS_Store --exclude *.a --exclude *.exe --exclude test --exclude tests\"\n${PYTHONSYNC} \"$EXTERNAL_LIBS/lib/python2.6\" \"$TARGET_FRAMEWORKS/lib/\"\nrm -rf \"$TARGET_FRAMEWORKS/lib/python2.6/config\"\n\necho \"Checking $TARGET_FRAMEWORKS/lib/python2.6 *.so for dylib dependencies\"\ncheck_xbmc_dylib_depends \"$TARGET_FRAMEWORKS\"/lib/python2.6 \"*.so\"\n\necho \"Checking $XBMC_HOME/system *.so for dylib dependencies\"\ncheck_xbmc_dylib_depends \"$XBMC_HOME\"/system \"*.so\"\n\necho \"Checking $XBMC_HOME/addons *.so for dylib dependencies\"\ncheck_xbmc_dylib_depends \"$XBMC_HOME\"/addons \"*.so\"\n\necho \"Checking $XBMC_HOME/addons *.xbs for dylib dependencies\"\ncheck_xbmc_dylib_depends \"$XBMC_HOME\"/addons \"*.xbs\"\n\necho \"Checking xbmc/DllPaths_generated.h for dylib dependencies\"\nfor a in $(grep .dylib \"$SRCROOT\"/xbmc/DllPaths_generated.h | awk '{print $3}' | sed s/\\\"//g) ; do\n  check_dyloaded_depends $a\ndone\n\necho \"Checking $TARGET_FRAMEWORKS for missing dylib dependencies\"\nREWIND=\"1\"\nwhile [ $REWIND = \"1\" ]\ndo\n\tlet REWIND=\"0\"\n\tfor b in \"$TARGET_FRAMEWORKS/\"*dylib* ; do\n\t\t#echo \"  Processing $b\"\n\t\tfor a in $(otool -L \"$b\"  | grep \"$EXTERNAL_LIBS\" | awk ' { print $1 } ') ; do\n\t\t\t#echo \"Processing $a\"\n\t\t\tif [ ! -f  \"$TARGET_FRAMEWORKS/$(basename $a)\" ]; then\n\t\t\t\techo \"    Packaging $a\"\n\t\t\t\tcp -f \"$a\" \"$TARGET_FRAMEWORKS/\"\n\t\t\t\tchmod u+w \"$TARGET_FRAMEWORKS/$(basename $a)\"\n\t\t\t\tlet REWIND=\"1\"\n\t\t\tfi\n\t\t\tinstall_name_tool -change \"$a\" \"$DYLIB_NAMEPATH/$(basename $a)\" \"$TARGET_FRAMEWORKS/$(basename $b)\"\n\t\tdone \n\tdone\ndone\n";
 		};
 		81B8FC150E7D927A00354E2E /* update version info */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "update version info";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "# Update version in Info.plist with Git revision\nGIT_REVISION=\"Unknown\"\nBUNDLE_NAME=\"XBMC\"\n\nGIT_REVISION=\"Git-\"$(cat git_revision.h | sed -n 's/\\(.*\\)\\\"\\(.*\\)\\\"\\(.*\\)/\\2/p')\nperl -p -i -e \"s/r####/$GIT_REVISION/\" \"$TARGET_BUILD_DIR/$BUNDLE_NAME.app/Contents/Info.plist\"\n";
-		};
-		F5A1CBDE0F6B0B4700A96ABD /* copy root files */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "copy root files";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/bash;
-			shellScript = "#!/bin/bash\n\necho \"copy root files\"\n\nif [ \"$ACTION\" = build ] ; then\n\n# for external testing\n#TARGET_NAME=XBMC.app\n#SRCROOT=/Users/Shared/xbmc_svn/XBMC\n#TARGET_BUILD_DIR=/Users/Shared/xbmc_svn/XBMC/build/Debug\n# force TARGET_NAME on ppc\nTARGET_NAME=$PRODUCT_NAME\n\n# rsync command with exclusions for items we don't want in the app package\nSYNC=\"rsync -aq --exclude .DS_Store* --exclude *.dll --exclude *.DLL --exclude *linux.* --exclude *arm-osx.* --exclude *.zlib --exclude *.a\"\n\n# rsync command for excluding pngs and jpgs as well. Note that if the skin itself is not compiled\n# using XBMCTex then excluding the pngs and jpgs will most likely make the skin unusable \nSYNCSKIN=\"rsync -aq --exclude CVS* --exclude .svn* --exclude .cvsignore* --exclude .cvspass* --exclude .DS_Store* --exclude *.dll  --exclude *.DLL --exclude *linux.* --exclude *.png --exclude *.jpg --exclude *.bat\"\n\n# rsync command for including everything but the skins\nADDONSYNC=\"rsync -aq --exclude .DS_Store* --exclude skin.confluence --exclude skin.touched\"\n\nmkdir -p \"$TARGET_BUILD_DIR/$TARGET_NAME/Contents/Resources/XBMC\"\nmkdir -p \"$TARGET_BUILD_DIR/$TARGET_NAME/Contents/Resources/XBMC/addons\"\nmkdir -p \"$TARGET_BUILD_DIR/$TARGET_NAME/Contents/Resources/XBMC/language\"\nmkdir -p \"$TARGET_BUILD_DIR/$TARGET_NAME/Contents/Resources/XBMC/media\"\nmkdir -p \"$TARGET_BUILD_DIR/$TARGET_NAME/Contents/Resources/XBMC/sounds\"\nmkdir -p \"$TARGET_BUILD_DIR/$TARGET_NAME/Contents/Resources/XBMC/system\"\nmkdir -p \"$TARGET_BUILD_DIR/$TARGET_NAME/Contents/Resources/XBMC/userdata\"\nmkdir -p \"$TARGET_BUILD_DIR/$TARGET_NAME/Contents/Resources/XBMC/media\"\nmkdir -p \"$TARGET_BUILD_DIR/$TARGET_NAME/Contents/Resources/XBMC/tools/darwin/runtime\"\nmkdir -p \"$TARGET_BUILD_DIR/$TARGET_NAME/Contents/Resources/XBMC/extras/user\"\n\n${SYNC} \"$SRCROOT/LICENSE.GPL\" \t\"$TARGET_BUILD_DIR/$TARGET_NAME/Contents/Resources/\"\n${SYNC} \"$SRCROOT/xbmc/osx/Credits.html\" \t\"$TARGET_BUILD_DIR/$TARGET_NAME/Contents/Resources/\"\n${SYNC} \"$SRCROOT/tools/darwin/runtime\"\t\"$TARGET_BUILD_DIR/$TARGET_NAME/Contents/Resources/XBMC/tools/darwin\"\n${ADDONSYNC} \"$SRCROOT/addons\"\t\t\"$TARGET_BUILD_DIR/$TARGET_NAME/Contents/Resources/XBMC\"\n${SYNC} \"$SRCROOT/language\"\t\t\"$TARGET_BUILD_DIR/$TARGET_NAME/Contents/Resources/XBMC\"\n${SYNC} \"$SRCROOT/media\" \t\t\"$TARGET_BUILD_DIR/$TARGET_NAME/Contents/Resources/XBMC\"\n${SYNCSKIN} \"$SRCROOT/addons/skin.confluence\" \t\"$TARGET_BUILD_DIR/$TARGET_NAME/Contents/Resources/XBMC/addons\"\n${SYNC} \"$SRCROOT/addons/skin.confluence/backgrounds\" \t\"$TARGET_BUILD_DIR/$TARGET_NAME/Contents/Resources/XBMC/addons/skin.confluence\"\n${SYNC} \"$SRCROOT/addons/skin.confluence/icon.png\" \t\"$TARGET_BUILD_DIR/$TARGET_NAME/Contents/Resources/XBMC/addons/skin.confluence\"\n${SYNC} \"$SRCROOT/sounds\" \t\t\"$TARGET_BUILD_DIR/$TARGET_NAME/Contents/Resources/XBMC\"\n${SYNC} \"$SRCROOT/system\" \t\t\"$TARGET_BUILD_DIR/$TARGET_NAME/Contents/Resources/XBMC\"\n${SYNC} \"$SRCROOT/userdata\" \t\"$TARGET_BUILD_DIR/$TARGET_NAME/Contents/Resources/XBMC\"\n\n# copy extra packages if applicable\nif [ -d \"$SRCROOT/extras/system\" ]; then\n\t${SYNC} \"$SRCROOT/extras/system/\" \"$TARGET_BUILD_DIR/$TARGET_NAME/Contents/Resources/XBMC\"\nfi\n\n# copy extra user packages if applicable\nif [ -d \"$SRCROOT/extras/user\" ]; then\n\t${SYNC} \"$SRCROOT/extras/user/\" \"$TARGET_BUILD_DIR/$TARGET_NAME/Contents/Resources/XBMC/extras/user\"\nfi\n\n\n\n# magic that gets the icon to update\ntouch \"$TARGET_BUILD_DIR/$TARGET_NAME\"\n\n# not sure we want to do this with out major testing, many scripts cannot handle the spaces in the app name\n#mv \"$TARGET_BUILD_DIR/$TARGET_NAME\" \"$TARGET_BUILD_DIR/XBMC Media Center.app\"\n\nfi";
-		};
-		F5A1CBDF0F6B0B4700A96ABD /* copy frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 12;
-			files = (
-			);
-			inputPaths = (
-				"$(SRCROOT)/build/Release/$PRODUCT_NAME",
-			);
-			name = "copy frameworks";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "#set -x\n\nfunction check_dyloaded_depends\n{\n  b=$(find \"$EXTERNAL_LIBS\" -name $1 -print)\n  if [ -f \"$b\" ]; then\n    #echo \"Processing $b\"\n    if [ ! -f  \"$TARGET_FRAMEWORKS/$(basename $b)\" ]; then\n      echo \"    Packaging $b\"\n      cp -f \"$b\" \"$TARGET_FRAMEWORKS/\"\n      chmod u+w \"$TARGET_FRAMEWORKS/$(basename $b)\"\n    fi\n    for a in $(otool -L \"$b\"  | grep \"$EXTERNAL_LIBS\" | awk ' { print $1 } ') ; do\n      if [ -f \"$a\" ]; then\n        if [ ! -f  \"$TARGET_FRAMEWORKS/$(basename $a)\" ]; then\n          echo \"    Packaging $a\"\n          cp -f \"$a\" \"$TARGET_FRAMEWORKS/\"\n          chmod u+w \"$TARGET_FRAMEWORKS/$(basename $a)\"\n          install_name_tool -change \"$a\" \"$DYLIB_NAMEPATH/$(basename $a)\" \"$TARGET_FRAMEWORKS/$(basename $b)\"\n        fi\n      fi\n    done \n  fi\n}\n\nfunction check_xbmc_dylib_depends\n{\n  REWIND=\"1\"\n  while [ $REWIND = \"1\" ]\n  do\n    let REWIND=\"0\"\n    for b in $(find \"$1\" -name \"$2\" -print) ; do\n      #echo \"Processing $b\"\n      for a in $(otool -L \"$b\"  | grep \"$EXTERNAL_LIBS\" | awk ' { print $1 } ') ; do\n        #echo \"    Packaging $a\"\n        if [ ! -f  \"$TARGET_FRAMEWORKS/$(basename $a)\" ]; then\n          echo \"    Packaging $a\"\n          cp -f \"$a\" \"$TARGET_FRAMEWORKS/\"\n          chmod u+w \"$TARGET_FRAMEWORKS/$(basename $a)\"\n          let REWIND=\"1\"\n        fi\n        install_name_tool -change \"$a\" \"$DYLIB_NAMEPATH/$(basename $a)\" \"$b\"\n      done\n    done\n  done\n}\n\nEXTERNAL_LIBS=/Users/Shared/xbmc-depends/osx-10.4_ppc\n\nTARGET_NAME=$PRODUCT_NAME\nTARGET_CONTENTS=$TARGET_BUILD_DIR/$TARGET_NAME/Contents\n\nTARGET_BINARY=$TARGET_CONTENTS/MacOS/XBMC\nTARGET_FRAMEWORKS=$TARGET_CONTENTS/Frameworks\nDYLIB_NAMEPATH=@executable_path/../Frameworks\nXBMC_HOME=$TARGET_CONTENTS/Resources/XBMC\n\nmkdir -p \"$TARGET_CONTENTS/MacOS\"\nmkdir -p \"$TARGET_CONTENTS/Resources\"\n# start clean so we don't keep old dylibs\nrm -rf \"$TARGET_CONTENTS/Frameworks\"\nmkdir -p \"$TARGET_CONTENTS/Frameworks\"\n\necho \"Package $TARGET_BUILD_DIR/XBMC\"\ncp -f \"$TARGET_BUILD_DIR/XBMC\" \"$TARGET_BINARY\"\ncp -f \"$SRCROOT/media/xbmc.icns\" \"$TARGET_CONTENTS/Resources/\"\ncp -f \"$SRCROOT/xbmc/osx/Info.plist\" \"$TARGET_CONTENTS/\"\n\n# Copy all of XBMC's dylib dependencies and rename their locations to inside the Framework\necho \"Checking $TARGET_BINARY dylib dependencies\"\nfor a in $(otool -L \"$TARGET_BINARY\"  | grep \"$EXTERNAL_LIBS\" | awk ' { print $1 } ') ; do \n\techo \"    Packaging $a\"\n\tcp -f \"$a\" \"$TARGET_FRAMEWORKS/\"\n\tchmod u+w \"$TARGET_FRAMEWORKS/$(basename $a)\"\n\tinstall_name_tool -change \"$a\" \"$DYLIB_NAMEPATH/$(basename $a)\" \"$TARGET_BINARY\"\ndone\n\necho \"Package $EXTERNAL_LIBS/lib/python2.6\"\nmkdir -p \"$TARGET_CONTENTS/Frameworks/lib\"\nPYTHONSYNC=\"rsync -aq --exclude .DS_Store --exclude *.a --exclude *.exe --exclude test --exclude tests\"\n${PYTHONSYNC} \"$EXTERNAL_LIBS/lib/python2.6\" \"$TARGET_FRAMEWORKS/lib/\"\nrm -rf \"$TARGET_FRAMEWORKS/lib/python2.6/config\"\n\necho \"Checking $TARGET_FRAMEWORKS/lib/python2.6 *.so for dylib dependencies\"\ncheck_xbmc_dylib_depends \"$TARGET_FRAMEWORKS\"/lib/python2.6 \"*.so\"\n\necho \"Checking $XBMC_HOME/system *.so for dylib dependencies\"\ncheck_xbmc_dylib_depends \"$XBMC_HOME\"/system \"*.so\"\n\necho \"Checking $XBMC_HOME/addons *.so for dylib dependencies\"\ncheck_xbmc_dylib_depends \"$XBMC_HOME\"/addons \"*.so\"\n\necho \"Checking $XBMC_HOME/addons *.xbs for dylib dependencies\"\ncheck_xbmc_dylib_depends \"$XBMC_HOME\"/addons \"*.xbs\"\n\necho \"Checking xbmc/DllPaths_generated.h for dylib dependencies\"\nfor a in $(grep .dylib \"$SRCROOT\"/xbmc/DllPaths_generated.h | awk '{print $3}' | sed s/\\\"//g) ; do\n  check_dyloaded_depends $a\ndone\n\necho \"Checking $TARGET_FRAMEWORKS for missing dylib dependencies\"\nREWIND=\"1\"\nwhile [ $REWIND = \"1\" ]\ndo\n\tlet REWIND=\"0\"\n\tfor b in \"$TARGET_FRAMEWORKS/\"*dylib* ; do\n\t\t#echo \"  Processing $b\"\n\t\tfor a in $(otool -L \"$b\"  | grep \"$EXTERNAL_LIBS\" | awk ' { print $1 } ') ; do\n\t\t\t#echo \"Processing $a\"\n\t\t\tif [ ! -f  \"$TARGET_FRAMEWORKS/$(basename $a)\" ]; then\n\t\t\t\techo \"    Packaging $a\"\n\t\t\t\tcp -f \"$a\" \"$TARGET_FRAMEWORKS/\"\n\t\t\t\tchmod u+w \"$TARGET_FRAMEWORKS/$(basename $a)\"\n\t\t\t\tlet REWIND=\"1\"\n\t\t\tfi\n\t\t\tinstall_name_tool -change \"$a\" \"$DYLIB_NAMEPATH/$(basename $a)\" \"$TARGET_FRAMEWORKS/$(basename $b)\"\n\t\tdone \n\tdone\ndone\n";
-		};
-		F5A1CBE00F6B0B4700A96ABD /* update version info */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -8325,956 +7243,6 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		F5A1C8730F6B06CF00A96ABD /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				F5A1C8C00F6B06CF00A96ABD /* Application.cpp in Sources */,
-				F5A1C8C10F6B06CF00A96ABD /* ApplicationMessenger.cpp in Sources */,
-				F5A1C8C40F6B06CF00A96ABD /* Autorun.cpp in Sources */,
-				F5A1C8C50F6B06CF00A96ABD /* AutoSwitch.cpp in Sources */,
-				F5A1C8C60F6B06CF00A96ABD /* BackgroundInfoLoader.cpp in Sources */,
-				F5A1C8C80F6B06CF00A96ABD /* CDDAReader.cpp in Sources */,
-				F5A1C8C90F6B06CF00A96ABD /* CDDARipper.cpp in Sources */,
-				F5A1C8CA0F6B06CF00A96ABD /* Encoder.cpp in Sources */,
-				F5A1C8CB0F6B06CF00A96ABD /* EncoderLame.cpp in Sources */,
-				F5A1C8CC0F6B06CF00A96ABD /* EncoderVorbis.cpp in Sources */,
-				F5A1C8CD0F6B06CF00A96ABD /* EncoderWav.cpp in Sources */,
-				F5A1C8CE0F6B06CF00A96ABD /* coff.cpp in Sources */,
-				F5A1C8CF0F6B06CF00A96ABD /* dll.cpp in Sources */,
-				F5A1C8D00F6B06CF00A96ABD /* dll_tracker.cpp in Sources */,
-				F5A1C8D20F6B06CF00A96ABD /* dll_tracker_file.cpp in Sources */,
-				F5A1C8D30F6B06CF00A96ABD /* dll_tracker_library.cpp in Sources */,
-				F5A1C8D50F6B06CF00A96ABD /* dll_util.cpp in Sources */,
-				F5A1C8D60F6B06CF00A96ABD /* DllLoader.cpp in Sources */,
-				F5A1C8D70F6B06CF00A96ABD /* DllLoaderContainer.cpp in Sources */,
-				F5A1C8D80F6B06CF00A96ABD /* emu_dummy.cpp in Sources */,
-				F5A1C8DA0F6B06CF00A96ABD /* emu_kernel32.cpp in Sources */,
-				F5A1C8DB0F6B06CF00A96ABD /* emu_msvcrt.cpp in Sources */,
-				F5A1C8DF0F6B06CF00A96ABD /* EmuFileWrapper.cpp in Sources */,
-				F5A1C8E00F6B06CF00A96ABD /* wrapper.c in Sources */,
-				F5A1C8E10F6B06CF00A96ABD /* ldt_keeper.c in Sources */,
-				F5A1C8E20F6B06CF00A96ABD /* LibraryLoader.cpp in Sources */,
-				F5A1C8E30F6B06CF00A96ABD /* mmap_anon.c in Sources */,
-				F5A1C8E40F6B06CF00A96ABD /* SoLoader.cpp in Sources */,
-				F5A1C8E50F6B06CF00A96ABD /* DummyVideoPlayer.cpp in Sources */,
-				F5A1C8E70F6B06CF00A96ABD /* DVDAudio.cpp in Sources */,
-				F5A1C8E80F6B06CF00A96ABD /* DVDClock.cpp in Sources */,
-				F5A1C8E90F6B06CF00A96ABD /* DVDAudioCodecFFmpeg.cpp in Sources */,
-				F5A1C8ED0F6B06CF00A96ABD /* DVDAudioCodecLibMad.cpp in Sources */,
-				F5A1C8EE0F6B06CF00A96ABD /* DVDAudioCodecLPcm.cpp in Sources */,
-				F5A1C8F00F6B06CF00A96ABD /* DVDAudioCodecPcm.cpp in Sources */,
-				F5A1C8F10F6B06CF00A96ABD /* DVDCodecUtils.cpp in Sources */,
-				F5A1C8F20F6B06CF00A96ABD /* DVDFactoryCodec.cpp in Sources */,
-				F5A1C8F30F6B06CF00A96ABD /* DVDOverlayCodecCC.cpp in Sources */,
-				F5A1C8F40F6B06CF00A96ABD /* DVDOverlayCodecFFmpeg.cpp in Sources */,
-				F5A1C8F50F6B06CF00A96ABD /* DVDOverlayCodecText.cpp in Sources */,
-				F5A1C8F60F6B06CF00A96ABD /* cc_decoder.c in Sources */,
-				F5A1C8F70F6B06CF00A96ABD /* DVDVideoCodecFFmpeg.cpp in Sources */,
-				F5A1C8F80F6B06CF00A96ABD /* DVDVideoCodecLibMpeg2.cpp in Sources */,
-				F5A1C8F90F6B06CF00A96ABD /* DVDVideoPPFFmpeg.cpp in Sources */,
-				F5A1C8FA0F6B06CF00A96ABD /* DVDDemux.cpp in Sources */,
-				F5A1C8FB0F6B06CF00A96ABD /* DVDDemuxShoutcast.cpp in Sources */,
-				F5A1C8FC0F6B06CF00A96ABD /* DVDDemuxUtils.cpp in Sources */,
-				F5A1C8FD0F6B06CF00A96ABD /* DVDDemuxSPU.cpp in Sources */,
-				F5A1C8FE0F6B06CF00A96ABD /* DVDFactoryInputStream.cpp in Sources */,
-				F5A1C8FF0F6B06CF00A96ABD /* DVDInputStream.cpp in Sources */,
-				F5A1C9000F6B06CF00A96ABD /* DVDInputStreamFFmpeg.cpp in Sources */,
-				F5A1C9010F6B06CF00A96ABD /* DVDInputStreamFile.cpp in Sources */,
-				F5A1C9020F6B06CF00A96ABD /* DVDInputStreamHttp.cpp in Sources */,
-				F5A1C9030F6B06CF00A96ABD /* DVDInputStreamMemory.cpp in Sources */,
-				F5A1C9040F6B06CF00A96ABD /* DVDInputStreamNavigator.cpp in Sources */,
-				F5A1C9050F6B06CF00A96ABD /* DVDStateSerializer.cpp in Sources */,
-				F5A1C9060F6B06CF00A96ABD /* DVDMessage.cpp in Sources */,
-				F5A1C9070F6B06CF00A96ABD /* DVDMessageQueue.cpp in Sources */,
-				F5A1C9080F6B06CF00A96ABD /* DVDMessageTracker.cpp in Sources */,
-				F5A1C9090F6B06CF00A96ABD /* DVDOverlayContainer.cpp in Sources */,
-				F5A1C90A0F6B06CF00A96ABD /* DVDOverlayRenderer.cpp in Sources */,
-				F5A1C90B0F6B06CF00A96ABD /* DVDPerformanceCounter.cpp in Sources */,
-				F5A1C90C0F6B06CF00A96ABD /* DVDPlayer.cpp in Sources */,
-				F5A1C90D0F6B06CF00A96ABD /* DVDPlayerAudio.cpp in Sources */,
-				F5A1C90E0F6B06CF00A96ABD /* DVDPlayerSubtitle.cpp in Sources */,
-				F5A1C90F0F6B06CF00A96ABD /* DVDPlayerVideo.cpp in Sources */,
-				F5A1C9100F6B06CF00A96ABD /* DVDStreamInfo.cpp in Sources */,
-				F5A1C9110F6B06CF00A96ABD /* DVDFactorySubtitle.cpp in Sources */,
-				F5A1C9120F6B06CF00A96ABD /* DVDSubtitleLineCollection.cpp in Sources */,
-				F5A1C9130F6B06CF00A96ABD /* DVDSubtitleParserSubrip.cpp in Sources */,
-				F5A1C9140F6B06CF00A96ABD /* DVDSubtitleStream.cpp in Sources */,
-				F5A1C9190F6B06CF00A96ABD /* ADPCMCodec.cpp in Sources */,
-				F5A1C91D0F6B06CF00A96ABD /* AudioDecoder.cpp in Sources */,
-				F5A1C91E0F6B06CF00A96ABD /* CDDAcodec.cpp in Sources */,
-				F5A1C91F0F6B06CF00A96ABD /* CodecFactory.cpp in Sources */,
-				F5A1C9200F6B06CF00A96ABD /* FLACcodec.cpp in Sources */,
-				F5A1C9230F6B06CF00A96ABD /* MP3codec.cpp in Sources */,
-				F5A1C9250F6B06CF00A96ABD /* NSFCodec.cpp in Sources */,
-				F5A1C9260F6B06CF00A96ABD /* OGGcodec.cpp in Sources */,
-				F5A1C9270F6B06CF00A96ABD /* ReplayGain.cpp in Sources */,
-				F5A1C9290F6B06CF00A96ABD /* SIDCodec.cpp in Sources */,
-				F5A1C92A0F6B06CF00A96ABD /* SPCCodec.cpp in Sources */,
-				F5A1C92B0F6B06CF00A96ABD /* TimidityCodec.cpp in Sources */,
-				F5A1C92C0F6B06CF00A96ABD /* WAVcodec.cpp in Sources */,
-				F5A1C92F0F6B06CF00A96ABD /* YMCodec.cpp in Sources */,
-				F5A1C9310F6B06CF00A96ABD /* ssrc.cpp in Sources */,
-				F5A1C9340F6B06CF00A96ABD /* LinuxRendererGL.cpp in Sources */,
-				F5A1C9350F6B06CF00A96ABD /* RenderManager.cpp in Sources */,
-				F5A1C9360F6B06CF00A96ABD /* VideoFilterShader.cpp in Sources */,
-				F5A1C9370F6B06CF00A96ABD /* YUV2RGBShader.cpp in Sources */,
-				F5A1C9390F6B06CF00A96ABD /* CueDocument.cpp in Sources */,
-				F5A1C93A0F6B06CF00A96ABD /* Database.cpp in Sources */,
-				F5A1C93C0F6B06CF00A96ABD /* DetectDVDType.cpp in Sources */,
-				F5A1C93D0F6B06CF00A96ABD /* DNSNameCache.cpp in Sources */,
-				F5A1C93E0F6B06CF00A96ABD /* DynamicDll.cpp in Sources */,
-				F5A1C9400F6B06CF00A96ABD /* Favourites.cpp in Sources */,
-				F5A1C9410F6B06CF00A96ABD /* FileItem.cpp in Sources */,
-				F5A1C9420F6B06CF00A96ABD /* MemBufferCache.cpp in Sources */,
-				F5A1C9430F6B06CF00A96ABD /* CacheStrategy.cpp in Sources */,
-				F5A1C9440F6B06CF00A96ABD /* CDDADirectory.cpp in Sources */,
-				F5A1C9450F6B06CF00A96ABD /* cddb.cpp in Sources */,
-				F5A1C9460F6B06CF00A96ABD /* cdioSupport.cpp in Sources */,
-				F5A1C9470F6B06CF00A96ABD /* DAAPDirectory.cpp in Sources */,
-				F5A1C9480F6B06CF00A96ABD /* Directory.cpp in Sources */,
-				F5A1C94A0F6B06CF00A96ABD /* DirectoryHistory.cpp in Sources */,
-				F5A1C94C0F6B06CF00A96ABD /* DllLibCurl.cpp in Sources */,
-				F5A1C94F0F6B06CF00A96ABD /* File.cpp in Sources */,
-				F5A1C9540F6B06CF00A96ABD /* FileFactory.cpp in Sources */,
-				F5A1C95E0F6B06CF00A96ABD /* FTPDirectory.cpp in Sources */,
-				F5A1C95F0F6B06CF00A96ABD /* FTPParse.cpp in Sources */,
-				F5A1C9600F6B06CF00A96ABD /* HDDirectory.cpp in Sources */,
-				F5A1C9620F6B06CF00A96ABD /* IDirectory.cpp in Sources */,
-				F5A1C9630F6B06CF00A96ABD /* IFile.cpp in Sources */,
-				F5A1C9640F6B06CF00A96ABD /* iso9660.cpp in Sources */,
-				F5A1C9650F6B06CF00A96ABD /* ISO9660Directory.cpp in Sources */,
-				F5A1C9660F6B06CF00A96ABD /* LastFMDirectory.cpp in Sources */,
-				F5A1C9670F6B06CF00A96ABD /* MultiPathDirectory.cpp in Sources */,
-				F5A1C9680F6B06CF00A96ABD /* DirectoryNode.cpp in Sources */,
-				F5A1C9690F6B06CF00A96ABD /* DirectoryNodeAlbum.cpp in Sources */,
-				F5A1C96A0F6B06CF00A96ABD /* DirectoryNodeAlbumCompilations.cpp in Sources */,
-				F5A1C96B0F6B06CF00A96ABD /* DirectoryNodeAlbumCompilationsSongs.cpp in Sources */,
-				F5A1C96C0F6B06CF00A96ABD /* DirectoryNodeAlbumRecentlyAdded.cpp in Sources */,
-				F5A1C96D0F6B06CF00A96ABD /* DirectoryNodeAlbumRecentlyAddedSong.cpp in Sources */,
-				F5A1C96E0F6B06CF00A96ABD /* DirectoryNodeAlbumRecentlyPlayed.cpp in Sources */,
-				F5A1C96F0F6B06CF00A96ABD /* DirectoryNodeAlbumRecentlyPlayedSong.cpp in Sources */,
-				F5A1C9700F6B06CF00A96ABD /* DirectoryNodeAlbumTop100.cpp in Sources */,
-				F5A1C9710F6B06CF00A96ABD /* DirectoryNodeAlbumTop100Song.cpp in Sources */,
-				F5A1C9720F6B06CF00A96ABD /* DirectoryNodeArtist.cpp in Sources */,
-				F5A1C9730F6B06CF00A96ABD /* DirectoryNodeGenre.cpp in Sources */,
-				F5A1C9740F6B06CF00A96ABD /* DirectoryNodeOverview.cpp in Sources */,
-				F5A1C9750F6B06CF00A96ABD /* DirectoryNodeRoot.cpp in Sources */,
-				F5A1C9760F6B06CF00A96ABD /* DirectoryNodeSong.cpp in Sources */,
-				F5A1C9770F6B06CF00A96ABD /* DirectoryNodeSongTop100.cpp in Sources */,
-				F5A1C9780F6B06CF00A96ABD /* DirectoryNodeTop100.cpp in Sources */,
-				F5A1C9790F6B06CF00A96ABD /* DirectoryNodeYear.cpp in Sources */,
-				F5A1C97A0F6B06CF00A96ABD /* DirectoryNodeYearAlbum.cpp in Sources */,
-				F5A1C97B0F6B06CF00A96ABD /* DirectoryNodeYearSong.cpp in Sources */,
-				F5A1C97C0F6B06CF00A96ABD /* QueryParams.cpp in Sources */,
-				F5A1C97D0F6B06CF00A96ABD /* MusicDatabaseDirectory.cpp in Sources */,
-				F5A1C97E0F6B06CF00A96ABD /* MusicSearchDirectory.cpp in Sources */,
-				F5A1C97F0F6B06CF00A96ABD /* NSFFileDirectory.cpp in Sources */,
-				F5A1C9800F6B06CF00A96ABD /* OGGFileDirectory.cpp in Sources */,
-				F5A1C9810F6B06CF00A96ABD /* PlaylistDirectory.cpp in Sources */,
-				F5A1C9820F6B06CF00A96ABD /* PlaylistFileDirectory.cpp in Sources */,
-				F5A1C9830F6B06CF00A96ABD /* PluginDirectory.cpp in Sources */,
-				F5A1C9840F6B06CF00A96ABD /* RarDirectory.cpp in Sources */,
-				F5A1C9850F6B06CF00A96ABD /* RarManager.cpp in Sources */,
-				F5A1C9860F6B06CF00A96ABD /* RTVDirectory.cpp in Sources */,
-				F5A1C9890F6B06CF00A96ABD /* SIDFileDirectory.cpp in Sources */,
-				F5A1C98A0F6B06CF00A96ABD /* SmartPlaylistDirectory.cpp in Sources */,
-				F5A1C98B0F6B06CF00A96ABD /* StackDirectory.cpp in Sources */,
-				F5A1C98C0F6B06CF00A96ABD /* UPnPDirectory.cpp in Sources */,
-				F5A1C98E0F6B06CF00A96ABD /* DirectoryNode.cpp in Sources */,
-				F5A1C98F0F6B06CF00A96ABD /* DirectoryNodeActor.cpp in Sources */,
-				F5A1C9900F6B06CF00A96ABD /* DirectoryNodeDirector.cpp in Sources */,
-				F5A1C9910F6B06CF00A96ABD /* DirectoryNodeEpisodes.cpp in Sources */,
-				F5A1C9920F6B06CF00A96ABD /* DirectoryNodeGenre.cpp in Sources */,
-				F5A1C9930F6B06CF00A96ABD /* DirectoryNodeMoviesOverview.cpp in Sources */,
-				F5A1C9940F6B06CF00A96ABD /* DirectoryNodeMusicVideosOverview.cpp in Sources */,
-				F5A1C9950F6B06CF00A96ABD /* DirectoryNodeOverview.cpp in Sources */,
-				F5A1C9960F6B06CF00A96ABD /* DirectoryNodeRecentlyAddedEpisodes.cpp in Sources */,
-				F5A1C9970F6B06CF00A96ABD /* DirectoryNodeRecentlyAddedMovies.cpp in Sources */,
-				F5A1C9980F6B06CF00A96ABD /* DirectoryNodeRecentlyAddedMusicVideos.cpp in Sources */,
-				F5A1C9990F6B06CF00A96ABD /* DirectoryNodeRoot.cpp in Sources */,
-				F5A1C99A0F6B06CF00A96ABD /* DirectoryNodeSeasons.cpp in Sources */,
-				F5A1C99B0F6B06CF00A96ABD /* DirectoryNodeStudio.cpp in Sources */,
-				F5A1C99C0F6B06CF00A96ABD /* DirectoryNodeTitleMovies.cpp in Sources */,
-				F5A1C99D0F6B06CF00A96ABD /* DirectoryNodeTitleMusicVideos.cpp in Sources */,
-				F5A1C99E0F6B06CF00A96ABD /* DirectoryNodeTitleTvShows.cpp in Sources */,
-				F5A1C99F0F6B06CF00A96ABD /* DirectoryNodeTvShowsOverview.cpp in Sources */,
-				F5A1C9A00F6B06CF00A96ABD /* DirectoryNodeYear.cpp in Sources */,
-				F5A1C9A10F6B06CF00A96ABD /* QueryParams.cpp in Sources */,
-				F5A1C9A20F6B06CF00A96ABD /* VideoDatabaseDirectory.cpp in Sources */,
-				F5A1C9A30F6B06CF00A96ABD /* VirtualDirectory.cpp in Sources */,
-				F5A1C9A50F6B06CF00A96ABD /* ZipDirectory.cpp in Sources */,
-				F5A1C9A60F6B06CF00A96ABD /* ZipManager.cpp in Sources */,
-				F5A1C9A90F6B06CF00A96ABD /* GUIDialogBoxBase.cpp in Sources */,
-				F5A1C9AA0F6B06CF00A96ABD /* GUIDialogBusy.cpp in Sources */,
-				F5A1C9AB0F6B06CF00A96ABD /* GUIDialogButtonMenu.cpp in Sources */,
-				F5A1C9AD0F6B06CF00A96ABD /* GUIDialogContextMenu.cpp in Sources */,
-				F5A1C9AE0F6B06CF00A96ABD /* GUIDialogFavourites.cpp in Sources */,
-				F5A1C9AF0F6B06CF00A96ABD /* GUIDialogFileBrowser.cpp in Sources */,
-				F5A1C9B00F6B06CF00A96ABD /* GUIDialogFileStacking.cpp in Sources */,
-				F5A1C9B10F6B06CF00A96ABD /* GUIDialogGamepad.cpp in Sources */,
-				F5A1C9B20F6B06CF00A96ABD /* GUIDialogKeyboard.cpp in Sources */,
-				F5A1C9B40F6B06CF00A96ABD /* GUIDialogMediaSource.cpp in Sources */,
-				F5A1C9B50F6B06CF00A96ABD /* GUIDialogMusicOSD.cpp in Sources */,
-				F5A1C9B60F6B06CF00A96ABD /* GUIDialogMusicScan.cpp in Sources */,
-				F5A1C9B70F6B06CF00A96ABD /* GUIDialogMuteBug.cpp in Sources */,
-				F5A1C9B80F6B06CF00A96ABD /* GUIDialogNetworkSetup.cpp in Sources */,
-				F5A1C9B90F6B06CF00A96ABD /* GUIDialogNumeric.cpp in Sources */,
-				F5A1C9BA0F6B06CF00A96ABD /* GUIDialogOK.cpp in Sources */,
-				F5A1C9BB0F6B06CF00A96ABD /* GUIDialogPictureInfo.cpp in Sources */,
-				F5A1C9BC0F6B06CF00A96ABD /* GUIDialogPlayerControls.cpp in Sources */,
-				F5A1C9BF0F6B06CF00A96ABD /* GUIDialogProgress.cpp in Sources */,
-				F5A1C9C00F6B06CF00A96ABD /* GUIDialogSeekBar.cpp in Sources */,
-				F5A1C9C30F6B06CF00A96ABD /* GUIDialogSmartPlaylistEditor.cpp in Sources */,
-				F5A1C9C40F6B06CF00A96ABD /* GUIDialogSmartPlaylistRule.cpp in Sources */,
-				F5A1C9C50F6B06CF00A96ABD /* GUIDialogSongInfo.cpp in Sources */,
-				F5A1C9C60F6B06CF00A96ABD /* GUIDialogSubMenu.cpp in Sources */,
-				F5A1C9C70F6B06CF00A96ABD /* GUIDialogVideoBookmarks.cpp in Sources */,
-				F5A1C9C80F6B06CF00A96ABD /* GUIDialogVideoScan.cpp in Sources */,
-				F5A1C9CA0F6B06CF00A96ABD /* GUIDialogVisualisationPresetList.cpp in Sources */,
-				F5A1C9CC0F6B06CF00A96ABD /* GUIDialogVolumeBar.cpp in Sources */,
-				F5A1C9CD0F6B06CF00A96ABD /* GUIDialogYesNo.cpp in Sources */,
-				F5A1C9CE0F6B06CF00A96ABD /* GUILargeTextureManager.cpp in Sources */,
-				F5A1C9CF0F6B06CF00A96ABD /* GUIMediaWindow.cpp in Sources */,
-				F5A1C9D00F6B06CF00A96ABD /* GUIPassword.cpp in Sources */,
-				F5A1C9D20F6B06CF00A96ABD /* GUIViewControl.cpp in Sources */,
-				F5A1C9D30F6B06CF00A96ABD /* GUIViewState.cpp in Sources */,
-				F5A1C9D40F6B06CF00A96ABD /* GUIViewStateMusic.cpp in Sources */,
-				F5A1C9D50F6B06CF00A96ABD /* GUIViewStateVideo.cpp in Sources */,
-				F5A1C9D60F6B06CF00A96ABD /* GUIWindowFileManager.cpp in Sources */,
-				F5A1C9D70F6B06CF00A96ABD /* GUIWindowFullScreen.cpp in Sources */,
-				F5A1C9D80F6B06CF00A96ABD /* GUIWindowHome.cpp in Sources */,
-				F5A1C9D90F6B06CF00A96ABD /* GUIWindowLoginScreen.cpp in Sources */,
-				F5A1C9DA0F6B06CF00A96ABD /* GUIWindowMusicBase.cpp in Sources */,
-				F5A1C9DB0F6B06CF00A96ABD /* GUIDialogMusicInfo.cpp in Sources */,
-				F5A1C9DC0F6B06CF00A96ABD /* GUIWindowMusicNav.cpp in Sources */,
-				F5A1C9DD0F6B06CF00A96ABD /* GUIDialogMusicOverlay.cpp in Sources */,
-				F5A1C9DE0F6B06CF00A96ABD /* GUIWindowMusicPlaylist.cpp in Sources */,
-				F5A1C9DF0F6B06CF00A96ABD /* GUIWindowMusicPlaylistEditor.cpp in Sources */,
-				F5A1C9E00F6B06CF00A96ABD /* GUIWindowMusicSongs.cpp in Sources */,
-				F5A1C9E10F6B06CF00A96ABD /* GUIDialogVideoOSD.cpp in Sources */,
-				F5A1C9E20F6B06CF00A96ABD /* GUIWindowPictures.cpp in Sources */,
-				F5A1C9E30F6B06CF00A96ABD /* GUIWindowPointer.cpp in Sources */,
-				F5A1C9E40F6B06CF00A96ABD /* GUIWindowPrograms.cpp in Sources */,
-				F5A1C9E50F6B06CF00A96ABD /* GUIWindowScreensaver.cpp in Sources */,
-				F5A1C9EC0F6B06CF00A96ABD /* GUIWindowSlideShow.cpp in Sources */,
-				F5A1C9ED0F6B06CF00A96ABD /* GUIWindowStartup.cpp in Sources */,
-				F5A1C9EE0F6B06CF00A96ABD /* GUIWindowSystemInfo.cpp in Sources */,
-				F5A1C9EF0F6B06CF00A96ABD /* GUIWindowVideoBase.cpp in Sources */,
-				F5A1C9F10F6B06CF00A96ABD /* GUIDialogVideoInfo.cpp in Sources */,
-				F5A1C9F20F6B06CF00A96ABD /* GUIWindowVideoNav.cpp in Sources */,
-				F5A1C9F30F6B06CF00A96ABD /* GUIDialogVideoOverlay.cpp in Sources */,
-				F5A1C9F40F6B06CF00A96ABD /* GUIWindowVideoPlaylist.cpp in Sources */,
-				F5A1C9F50F6B06CF00A96ABD /* GUIWindowVisualisation.cpp in Sources */,
-				F5A1C9F60F6B06CF00A96ABD /* GUIWindowWeather.cpp in Sources */,
-				F5A1C9F90F6B06CF00A96ABD /* LangCodeExpander.cpp in Sources */,
-				F5A1C9FA0F6B06CF00A96ABD /* LangInfo.cpp in Sources */,
-				F5A1C9FB0F6B06CF00A96ABD /* LastFmManager.cpp in Sources */,
-				F5A1CA010F6B06CF00A96ABD /* XBPython.cpp in Sources */,
-				F5A1CA030F6B06CF00A96ABD /* XBPyThread.cpp in Sources */,
-				F5A1CA040F6B06CF00A96ABD /* scrobbler.cpp in Sources */,
-				F5A1CA050F6B06CF00A96ABD /* MediaCrawler.cpp in Sources */,
-				F5A1CA060F6B06CF00A96ABD /* PltMicroMediaController.cpp in Sources */,
-				F5A1CA080F6B06CF00A96ABD /* PltAction.cpp in Sources */,
-				F5A1CA090F6B06CF00A96ABD /* PltArgument.cpp in Sources */,
-				F5A1CA0A0F6B06CF00A96ABD /* PltCtrlPoint.cpp in Sources */,
-				F5A1CA0B0F6B06CF00A96ABD /* PltCtrlPointTask.cpp in Sources */,
-				F5A1CA0C0F6B06CF00A96ABD /* PltDatagramStream.cpp in Sources */,
-				F5A1CA0D0F6B06CF00A96ABD /* PltDeviceData.cpp in Sources */,
-				F5A1CA0E0F6B06CF00A96ABD /* PltDeviceHost.cpp in Sources */,
-				F5A1CA0F0F6B06CF00A96ABD /* PltDownloader.cpp in Sources */,
-				F5A1CA100F6B06CF00A96ABD /* PltEvent.cpp in Sources */,
-				F5A1CA110F6B06CF00A96ABD /* PltHttp.cpp in Sources */,
-				F5A1CA120F6B06CF00A96ABD /* PltHttpClientTask.cpp in Sources */,
-				F5A1CA130F6B06CF00A96ABD /* PltHttpServer.cpp in Sources */,
-				F5A1CA140F6B06CF00A96ABD /* PltHttpServerTask.cpp in Sources */,
-				F5A1CA150F6B06CF00A96ABD /* PltLeaks.cpp in Sources */,
-				F5A1CA160F6B06CF00A96ABD /* PltMetadataHandler.cpp in Sources */,
-				F5A1CA170F6B06CF00A96ABD /* PltRingBufferStream.cpp in Sources */,
-				F5A1CA180F6B06CF00A96ABD /* PltService.cpp in Sources */,
-				F5A1CA190F6B06CF00A96ABD /* PltSsdp.cpp in Sources */,
-				F5A1CA1A0F6B06CF00A96ABD /* PltStateVariable.cpp in Sources */,
-				F5A1CA1B0F6B06CF00A96ABD /* PltStreamPump.cpp in Sources */,
-				F5A1CA1C0F6B06CF00A96ABD /* PltTaskManager.cpp in Sources */,
-				F5A1CA1D0F6B06CF00A96ABD /* PltThreadTask.cpp in Sources */,
-				F5A1CA1E0F6B06CF00A96ABD /* PltUPnP.cpp in Sources */,
-				F5A1CA1F0F6B06CF00A96ABD /* PltMediaController.cpp in Sources */,
-				F5A1CA200F6B06CF00A96ABD /* PltMediaRenderer.cpp in Sources */,
-				F5A1CA220F6B06CF00A96ABD /* PltDidl.cpp in Sources */,
-				F5A1CA230F6B06CF00A96ABD /* PltFileMediaServer.cpp in Sources */,
-				F5A1CA240F6B06CF00A96ABD /* PltMediaBrowser.cpp in Sources */,
-				F5A1CA250F6B06CF00A96ABD /* PltMediaCache.cpp in Sources */,
-				F5A1CA260F6B06CF00A96ABD /* PltMediaItem.cpp in Sources */,
-				F5A1CA270F6B06CF00A96ABD /* PltMediaPlaylist.cpp in Sources */,
-				F5A1CA280F6B06CF00A96ABD /* PltMediaServer.cpp in Sources */,
-				F5A1CA2A0F6B06CF00A96ABD /* PltSyncMediaBrowser.cpp in Sources */,
-				F5A1CA2B0F6B06CF00A96ABD /* PltLightSample.cpp in Sources */,
-				F5A1CA4B0F6B06CF00A96ABD /* dataset.cpp in Sources */,
-				F5A1CA4C0F6B06CF00A96ABD /* qry_dat.cpp in Sources */,
-				F5A1CA4D0F6B06CF00A96ABD /* sqlitedataset.cpp in Sources */,
-				F5A1CA4E0F6B06CF00A96ABD /* archive.cpp in Sources */,
-				F5A1CA4F0F6B06CF00A96ABD /* arcread.cpp in Sources */,
-				F5A1CA500F6B06CF00A96ABD /* cmddata.cpp in Sources */,
-				F5A1CA510F6B06CF00A96ABD /* consio.cpp in Sources */,
-				F5A1CA520F6B06CF00A96ABD /* crc.cpp in Sources */,
-				F5A1CA530F6B06CF00A96ABD /* crypt.cpp in Sources */,
-				F5A1CA540F6B06CF00A96ABD /* encname.cpp in Sources */,
-				F5A1CA550F6B06CF00A96ABD /* errhnd.cpp in Sources */,
-				F5A1CA560F6B06CF00A96ABD /* extinfo.cpp in Sources */,
-				F5A1CA570F6B06CF00A96ABD /* extract.cpp in Sources */,
-				F5A1CA580F6B06CF00A96ABD /* filcreat.cpp in Sources */,
-				F5A1CA590F6B06CF00A96ABD /* file.cpp in Sources */,
-				F5A1CA5A0F6B06CF00A96ABD /* filefn.cpp in Sources */,
-				F5A1CA5B0F6B06CF00A96ABD /* filestr.cpp in Sources */,
-				F5A1CA5C0F6B06CF00A96ABD /* find.cpp in Sources */,
-				F5A1CA5D0F6B06CF00A96ABD /* getbits.cpp in Sources */,
-				F5A1CA5E0F6B06CF00A96ABD /* global.cpp in Sources */,
-				F5A1CA5F0F6B06CF00A96ABD /* int64.cpp in Sources */,
-				F5A1CA600F6B06CF00A96ABD /* isnt.cpp in Sources */,
-				F5A1CA610F6B06CF00A96ABD /* log.cpp in Sources */,
-				F5A1CA620F6B06CF00A96ABD /* match.cpp in Sources */,
-				F5A1CA630F6B06CF00A96ABD /* options.cpp in Sources */,
-				F5A1CA640F6B06CF00A96ABD /* pathfn.cpp in Sources */,
-				F5A1CA650F6B06CF00A96ABD /* rarvm.cpp in Sources */,
-				F5A1CA660F6B06CF00A96ABD /* rawread.cpp in Sources */,
-				F5A1CA670F6B06CF00A96ABD /* rdwrfn.cpp in Sources */,
-				F5A1CA680F6B06CF00A96ABD /* recvol.cpp in Sources */,
-				F5A1CA690F6B06CF00A96ABD /* resource.cpp in Sources */,
-				F5A1CA6A0F6B06CF00A96ABD /* rijndael.cpp in Sources */,
-				F5A1CA6B0F6B06CF00A96ABD /* rs.cpp in Sources */,
-				F5A1CA6C0F6B06CF00A96ABD /* savepos.cpp in Sources */,
-				F5A1CA6D0F6B06CF00A96ABD /* scantree.cpp in Sources */,
-				F5A1CA6E0F6B06CF00A96ABD /* sha1.cpp in Sources */,
-				F5A1CA6F0F6B06CF00A96ABD /* strfn.cpp in Sources */,
-				F5A1CA700F6B06CF00A96ABD /* strlist.cpp in Sources */,
-				F5A1CA710F6B06CF00A96ABD /* system.cpp in Sources */,
-				F5A1CA720F6B06CF00A96ABD /* timefn.cpp in Sources */,
-				F5A1CA730F6B06CF00A96ABD /* ulinks.cpp in Sources */,
-				F5A1CA740F6B06CF00A96ABD /* unicode.cpp in Sources */,
-				F5A1CA750F6B06CF00A96ABD /* volume.cpp in Sources */,
-				F5A1CA760F6B06CF00A96ABD /* ConvUtils.cpp in Sources */,
-				F5A1CA790F6B06CF00A96ABD /* LinuxResourceCounter.cpp in Sources */,
-				F5A1CA7A0F6B06CF00A96ABD /* LinuxTimezone.cpp in Sources */,
-				F5A1CA7D0F6B06CF00A96ABD /* XFileUtils.cpp in Sources */,
-				F5A1CA7E0F6B06CF00A96ABD /* XHandle.cpp in Sources */,
-				F5A1CA7F0F6B06CF00A96ABD /* XMemUtils.cpp in Sources */,
-				F5A1CA820F6B06CF00A96ABD /* XTimeUtils.cpp in Sources */,
-				F5A1CA830F6B06CF00A96ABD /* MediaManager.cpp in Sources */,
-				F5A1CA840F6B06CF00A96ABD /* MusicDatabase.cpp in Sources */,
-				F5A1CA850F6B06CF00A96ABD /* MusicInfoLoader.cpp in Sources */,
-				F5A1CA860F6B06CF00A96ABD /* MusicInfoScanner.cpp in Sources */,
-				F5A1CA9D0F6B06CF00A96ABD /* NfoFile.cpp in Sources */,
-				F5A1CA9F0F6B06CF00A96ABD /* PartyModeManager.cpp in Sources */,
-				F5A1CAA00F6B06CF00A96ABD /* Picture.cpp in Sources */,
-				F5A1CAA10F6B06CF00A96ABD /* PictureInfoLoader.cpp in Sources */,
-				F5A1CAA20F6B06CF00A96ABD /* PictureInfoTag.cpp in Sources */,
-				F5A1CAA30F6B06CF00A96ABD /* PictureThumbLoader.cpp in Sources */,
-				F5A1CAA80F6B06CF00A96ABD /* PlayListPlayer.cpp in Sources */,
-				F5A1CAAC0F6B06CF00A96ABD /* Profile.cpp in Sources */,
-				F5A1CAAD0F6B06CF00A96ABD /* ProgramDatabase.cpp in Sources */,
-				F5A1CAB00F6B06CF00A96ABD /* SectionLoader.cpp in Sources */,
-				F5A1CAB10F6B06CF00A96ABD /* VideoSettings.cpp in Sources */,
-				F5A1CAB40F6B06CF00A96ABD /* Shortcut.cpp in Sources */,
-				F5A1CAB50F6B06CF00A96ABD /* SlideShowPicture.cpp in Sources */,
-				F5A1CAB70F6B06CF00A96ABD /* Song.cpp in Sources */,
-				F5A1CAB80F6B06CF00A96ABD /* SortFileItem.cpp in Sources */,
-				F5A1CABB0F6B06CF00A96ABD /* Temperature.cpp in Sources */,
-				F5A1CABC0F6B06CF00A96ABD /* ThumbLoader.cpp in Sources */,
-				F5A1CABD0F6B06CF00A96ABD /* ThumbnailCache.cpp in Sources */,
-				F5A1CABE0F6B06CF00A96ABD /* UPnP.cpp in Sources */,
-				F5A1CABF0F6B06CF00A96ABD /* URL.cpp in Sources */,
-				F5A1CAC00F6B06CF00A96ABD /* Util.cpp in Sources */,
-				F5A1CAC10F6B06CF00A96ABD /* AlarmClock.cpp in Sources */,
-				F5A1CAC20F6B06CF00A96ABD /* Archive.cpp in Sources */,
-				F5A1CAC30F6B06CF00A96ABD /* BitstreamStats.cpp in Sources */,
-				F5A1CAC40F6B06CF00A96ABD /* CharsetConverter.cpp in Sources */,
-				F5A1CAC50F6B06CF00A96ABD /* CPUInfo.cpp in Sources */,
-				F5A1CAC80F6B06CF00A96ABD /* DownloadQueue.cpp in Sources */,
-				F5A1CAC90F6B06CF00A96ABD /* DownloadQueueManager.cpp in Sources */,
-				F5A1CACA0F6B06CF00A96ABD /* Event.cpp in Sources */,
-				F5A1CACC0F6B06CF00A96ABD /* GUIInfoManager.cpp in Sources */,
-				F5A1CACD0F6B06CF00A96ABD /* HTMLTable.cpp in Sources */,
-				F5A1CACE0F6B06CF00A96ABD /* HTMLUtil.cpp in Sources */,
-				F5A1CAD00F6B06CF00A96ABD /* HttpHeader.cpp in Sources */,
-				F5A1CAD10F6B06CF00A96ABD /* VideoInfoDownloader.cpp in Sources */,
-				F5A1CAD20F6B06CF00A96ABD /* InfoLoader.cpp in Sources */,
-				F5A1CAD30F6B06CF00A96ABD /* LabelFormatter.cpp in Sources */,
-				F5A1CAD40F6B06CF00A96ABD /* LCD.cpp in Sources */,
-				F5A1CAD50F6B06CF00A96ABD /* log.cpp in Sources */,
-				F5A1CAD60F6B06CF00A96ABD /* MusicAlbumInfo.cpp in Sources */,
-				F5A1CAD70F6B06CF00A96ABD /* MusicInfoScraper.cpp in Sources */,
-				F5A1CAD90F6B06CF00A96ABD /* Network.cpp in Sources */,
-				F5A1CADB0F6B06CF00A96ABD /* PerformanceSample.cpp in Sources */,
-				F5A1CADC0F6B06CF00A96ABD /* PerformanceStats.cpp in Sources */,
-				F5A1CADD0F6B06CF00A96ABD /* RegExp.cpp in Sources */,
-				F5A1CADE0F6B06CF00A96ABD /* RssReader.cpp in Sources */,
-				F5A1CADF0F6B06CF00A96ABD /* ScraperParser.cpp in Sources */,
-				F5A1CAE20F6B06CF00A96ABD /* Splash.cpp in Sources */,
-				F5A1CAE30F6B06CF00A96ABD /* Stopwatch.cpp in Sources */,
-				F5A1CAE40F6B06CF00A96ABD /* SystemInfo.cpp in Sources */,
-				F5A1CAE50F6B06CF00A96ABD /* Thread.cpp in Sources */,
-				F5A1CAE60F6B06CF00A96ABD /* TuxBoxUtil.cpp in Sources */,
-				F5A1CAE70F6B06CF00A96ABD /* UdpClient.cpp in Sources */,
-				F5A1CAE80F6B06CF00A96ABD /* Weather.cpp in Sources */,
-				F5A1CAE90F6B06CF00A96ABD /* Win32Exception.cpp in Sources */,
-				F5A1CAEA0F6B06CF00A96ABD /* VideoDatabase.cpp in Sources */,
-				F5A1CAEB0F6B06CF00A96ABD /* VideoInfoScanner.cpp in Sources */,
-				F5A1CAEC0F6B06CF00A96ABD /* VideoInfoTag.cpp in Sources */,
-				F5A1CAED0F6B06CF00A96ABD /* ViewDatabase.cpp in Sources */,
-				F5A1CAF20F6B06CF00A96ABD /* XBApplicationEx.cpp in Sources */,
-				F5A1CAF60F6B06CF00A96ABD /* xbmc.cpp in Sources */,
-				F5A1CAF80F6B06CF00A96ABD /* unpack.cpp in Sources */,
-				F5A1CAF90F6B06CF00A96ABD /* rar.cpp in Sources */,
-				F5A1CAFA0F6B06CF00A96ABD /* action.cpp in Sources */,
-				F5A1CAFB0F6B06CF00A96ABD /* control.cpp in Sources */,
-				F5A1CAFC0F6B06CF00A96ABD /* controlbutton.cpp in Sources */,
-				F5A1CAFD0F6B06CF00A96ABD /* controlcheckmark.cpp in Sources */,
-				F5A1CAFE0F6B06CF00A96ABD /* controlfadelabel.cpp in Sources */,
-				F5A1CAFF0F6B06CF00A96ABD /* controlgroup.cpp in Sources */,
-				F5A1CB000F6B06CF00A96ABD /* controlimage.cpp in Sources */,
-				F5A1CB010F6B06CF00A96ABD /* controllabel.cpp in Sources */,
-				F5A1CB020F6B06CF00A96ABD /* controllist.cpp in Sources */,
-				F5A1CB030F6B06CF00A96ABD /* controlprogress.cpp in Sources */,
-				F5A1CB040F6B06CF00A96ABD /* controlspin.cpp in Sources */,
-				F5A1CB050F6B06CF00A96ABD /* controltextbox.cpp in Sources */,
-				F5A1CB060F6B06CF00A96ABD /* dialog.cpp in Sources */,
-				F5A1CB070F6B06CF00A96ABD /* GUIPythonWindow.cpp in Sources */,
-				F5A1CB080F6B06CF00A96ABD /* GUIPythonWindowDialog.cpp in Sources */,
-				F5A1CB090F6B06CF00A96ABD /* GUIPythonWindowXML.cpp in Sources */,
-				F5A1CB0A0F6B06CF00A96ABD /* GUIPythonWindowXMLDialog.cpp in Sources */,
-				F5A1CB0B0F6B06CF00A96ABD /* infotagmusic.cpp in Sources */,
-				F5A1CB0C0F6B06CF00A96ABD /* infotagvideo.cpp in Sources */,
-				F5A1CB0D0F6B06CF00A96ABD /* keyboard.cpp in Sources */,
-				F5A1CB0E0F6B06CF00A96ABD /* listitem.cpp in Sources */,
-				F5A1CB0F0F6B06CF00A96ABD /* player.cpp in Sources */,
-				F5A1CB100F6B06CF00A96ABD /* pyplaylist.cpp in Sources */,
-				F5A1CB110F6B06CF00A96ABD /* PythonPlayer.cpp in Sources */,
-				F5A1CB120F6B06CF00A96ABD /* pyutil.cpp in Sources */,
-				F5A1CB130F6B06CF00A96ABD /* window.cpp in Sources */,
-				F5A1CB140F6B06CF00A96ABD /* winxml.cpp in Sources */,
-				F5A1CB150F6B06CF00A96ABD /* winxmldialog.cpp in Sources */,
-				F5A1CB160F6B06CF00A96ABD /* xbmcguimodule.cpp in Sources */,
-				F5A1CB170F6B06CF00A96ABD /* xbmcmodule.cpp in Sources */,
-				F5A1CB180F6B06CF00A96ABD /* xbmcplugin.cpp in Sources */,
-				F5A1CB190F6B06CF00A96ABD /* DVDFactoryDemuxer.cpp in Sources */,
-				F5A1CB1A0F6B06CF00A96ABD /* DVDDemuxFFmpeg.cpp in Sources */,
-				F5A1CB1B0F6B06CF00A96ABD /* GUIDialogCache.cpp in Sources */,
-				F5A1CB1D0F6B06CF00A96ABD /* GUIDialogAccessPoints.cpp in Sources */,
-				F5A1CB220F6B06CF00A96ABD /* DVDPlayerCodec.cpp in Sources */,
-				F5A1CB230F6B06CF00A96ABD /* DVDDemuxVobsub.cpp in Sources */,
-				F5A1CB240F6B06CF00A96ABD /* DVDInputStreamTV.cpp in Sources */,
-				F5A1CB250F6B06CF00A96ABD /* PltMediaConnect.cpp in Sources */,
-				F5A1CB3C0F6B06CF00A96ABD /* MythDirectory.cpp in Sources */,
-				F5A1CB3D0F6B06CF00A96ABD /* MythFile.cpp in Sources */,
-				F5A1CB3F0F6B06CF00A96ABD /* SMBDirectory.cpp in Sources */,
-				F5A1CB410F6B06CF00A96ABD /* MythSession.cpp in Sources */,
-				F5A1CB420F6B06CF00A96ABD /* EventPacket.cpp in Sources */,
-				F5A1CB430F6B06CF00A96ABD /* EventServer.cpp in Sources */,
-				F5A1CB440F6B06CF00A96ABD /* Socket.cpp in Sources */,
-				F5A1CB450F6B06CF00A96ABD /* EventClient.cpp in Sources */,
-				F5A1CB470F6B06CF00A96ABD /* GUIDialogKaiToast.cpp in Sources */,
-				F5A1CB480F6B06CF00A96ABD /* DVDSubtitleParserMicroDVD.cpp in Sources */,
-				F5A1CB490F6B06CF00A96ABD /* controlradiobutton.cpp in Sources */,
-				F5A1CB4A0F6B06CF00A96ABD /* Artist.cpp in Sources */,
-				F5A1CB4B0F6B06CF00A96ABD /* Album.cpp in Sources */,
-				F5A1CB4C0F6B06CF00A96ABD /* DVDSubtitleParserSami.cpp in Sources */,
-				F5A1CB4D0F6B06CF00A96ABD /* ScraperUrl.cpp in Sources */,
-				F5A1CB4E0F6B06CF00A96ABD /* MusicArtistInfo.cpp in Sources */,
-				F5A1CB4F0F6B06CF00A96ABD /* Fanart.cpp in Sources */,
-				F5A1CB510F6B06CF00A96ABD /* MediaSource.cpp in Sources */,
-				F5A1CB520F6B06CF00A96ABD /* MusicFileDirectory.cpp in Sources */,
-				F5A1CB530F6B06CF00A96ABD /* ASAPFileDirectory.cpp in Sources */,
-				F5A1CB540F6B06CF00A96ABD /* ASAPCodec.cpp in Sources */,
-				F5A1CB570F6B06CF00A96ABD /* DVDOverlayCodecSSA.cpp in Sources */,
-				F5A1CB580F6B06CF00A96ABD /* DVDSubtitleParserSSA.cpp in Sources */,
-				F5A1CB590F6B06CF00A96ABD /* DVDSubtitlesLibass.cpp in Sources */,
-				F5A1CB5A0F6B06CF00A96ABD /* XBMCHelper.cpp in Sources */,
-				F5A1CB5B0F6B06CF00A96ABD /* GUIDialogFullScreenInfo.cpp in Sources */,
-				F5A1CB5C0F6B06CF00A96ABD /* GUIViewStatePictures.cpp in Sources */,
-				F5A1CB5D0F6B06CF00A96ABD /* GUIViewStatePrograms.cpp in Sources */,
-				F5A1CB600F6B06CF00A96ABD /* RSSDirectory.cpp in Sources */,
-				F5A1CB640F6B06CF00A96ABD /* DVDInputStreamRTMP.cpp in Sources */,
-				F5A1CB670F6B06CF00A96ABD /* VGMCodec.cpp in Sources */,
-				F5A1CB680F6B06CF00A96ABD /* md5.cpp in Sources */,
-				F5A1CB6A0F6B06CF00A96ABD /* GUIWindowTestPattern.cpp in Sources */,
-				F5A1CB6C0F6B06CF00A96ABD /* MultiPathFile.cpp in Sources */,
-				F5A1CB6D0F6B06CF00A96ABD /* DVDFileInfo.cpp in Sources */,
-				F5A1CB6E0F6B06CF00A96ABD /* AsyncFileCopy.cpp in Sources */,
-				F5A1CB740F6B06CF00A96ABD /* NptXbmcFile.cpp in Sources */,
-				F5A1CB7A0F6B06CF00A96ABD /* DirectoryNodeMusicVideoAlbum.cpp in Sources */,
-				F5A1CB7C0F6B06CF00A96ABD /* VTPFile.cpp in Sources */,
-				F5A1CB7D0F6B06CF00A96ABD /* VTPDirectory.cpp in Sources */,
-				F5A1CB7E0F6B06CF00A96ABD /* VTPSession.cpp in Sources */,
-				F5A1CB810F6B06CF00A96ABD /* ExternalPlayer.cpp in Sources */,
-				F5A1CB830F6B06CF00A96ABD /* HTTPDirectory.cpp in Sources */,
-				F5A1CB840F6B06CF00A96ABD /* GUIDialogKaraokeSongSelector.cpp in Sources */,
-				F5A1CB850F6B06CF00A96ABD /* karaokelyricscdg.cpp in Sources */,
-				F5A1CB860F6B06CF00A96ABD /* karaokelyrics.cpp in Sources */,
-				F5A1CB870F6B06CF00A96ABD /* karaokelyricstextkar.cpp in Sources */,
-				F5A1CB880F6B06CF00A96ABD /* karaokelyricsmanager.cpp in Sources */,
-				F5A1CB890F6B06CF00A96ABD /* karaokelyricsfactory.cpp in Sources */,
-				F5A1CB8A0F6B06CF00A96ABD /* karaokelyricstextlrc.cpp in Sources */,
-				F5A1CB8B0F6B06CF00A96ABD /* karaokelyricstext.cpp in Sources */,
-				F5A1CB8E0F6B06CF00A96ABD /* SpecialProtocolDirectory.cpp in Sources */,
-				F5A1CB8F0F6B06CF00A96ABD /* SpecialProtocol.cpp in Sources */,
-				F5A1CB900F6B06CF00A96ABD /* GUIWindowKaraokeLyrics.cpp in Sources */,
-				F5A1CB910F6B06CF00A96ABD /* karaokewindowbackground.cpp in Sources */,
-				F5A1CB970F6B06CF00A96ABD /* DVDDemuxHTSP.cpp in Sources */,
-				F5A1CB980F6B06CF00A96ABD /* htsatomic.c in Sources */,
-				F5A1CB990F6B06CF00A96ABD /* htsbuf.c in Sources */,
-				F5A1CB9A0F6B06CF00A96ABD /* htsmsg.c in Sources */,
-				F5A1CB9B0F6B06CF00A96ABD /* htsmsg_binary.c in Sources */,
-				F5A1CB9C0F6B06CF00A96ABD /* htsstr.c in Sources */,
-				F5A1CB9D0F6B06CF00A96ABD /* net_posix.c in Sources */,
-				F5A1CB9E0F6B06CF00A96ABD /* OSXGNUReplacements.c in Sources */,
-				F5A1CB9F0F6B06CF00A96ABD /* DVDInputStreamHTSP.cpp in Sources */,
-				F5A1CBA00F6B06CF00A96ABD /* sha1.c in Sources */,
-				F5EA021C0F6DA7E8005C2EC5 /* PowerManager.cpp in Sources */,
-				F5EA02220F6DA85C005C2EC5 /* CocoaPowerSyscall.cpp in Sources */,
-				F5EA04290F72EB88005C2EC5 /* SDLMain.mm in Sources */,
-				F5EA05C10F733812005C2EC5 /* CocoaInterface.mm in Sources */,
-				F5A2BD0E0F7AD9140006ABA0 /* ZeroconfOSX.cpp in Sources */,
-				F5A2BD0F0F7AD92C0006ABA0 /* Zeroconf.cpp in Sources */,
-				83E0B24A0F7C95FF0091643F /* Atomics.cpp in Sources */,
-				E43196190FB2382E0030E150 /* HTSPDirectory.cpp in Sources */,
-				E431961A0FB2382E0030E150 /* HTSPSession.cpp in Sources */,
-				F5AACA690FB3DE2D00DBB77C /* GUIDialogSelect.cpp in Sources */,
-				F5AACA980FB3E2B800DBB77C /* GUIDialogSlider.cpp in Sources */,
-				F59876BD0FBA34C0008EF4FB /* DVDPlayerAudioResampler.cpp in Sources */,
-				F59876C10FBA351D008EF4FB /* VideoReferenceClock.cpp in Sources */,
-				F5987B270FBB9682008EF4FB /* librefmscrobbler.cpp in Sources */,
-				F5987B280FBB9682008EF4FB /* lastfmscrobbler.cpp in Sources */,
-				F5987F060FBDF274008EF4FB /* DPMSSupport.cpp in Sources */,
-				43248C4E0FBE224000B88866 /* LockFree.cpp in Sources */,
-				F5987FDC0FBE2DFD008EF4FB /* PAPlayer.cpp in Sources */,
-				F548786E0FE060FF00E506FD /* DVDSubtitleParserMPL2.cpp in Sources */,
-				F5487B4D0FE6F02700E506FD /* StreamDetails.cpp in Sources */,
-				7CDAE9060FFCA3520040B25F /* DVDTSCorrection.cpp in Sources */,
-				E4DC97560FFE5BA8008E0C07 /* SAPDirectory.cpp in Sources */,
-				E4DC97570FFE5BA8008E0C07 /* SAPFile.cpp in Sources */,
-				7CDAEA7E1001CD6E0040B25F /* karaokelyricstextustar.cpp in Sources */,
-				7CDAEA8E1001EBA70040B25F /* PltConstants.cpp in Sources */,
-				7CDAEA8F1001EBA70040B25F /* PltIconsData.cpp in Sources */,
-				F5D8D734102BB3B1004A11AB /* OverlayRendererGL.cpp in Sources */,
-				F5D8D735102BB3B1004A11AB /* OverlayRenderer.cpp in Sources */,
-				E49ACD8D100745C400A86ECD /* ZeroconfDirectory.cpp in Sources */,
-				E49ACDA010074A4000A86ECD /* ZeroconfBrowserOSX.cpp in Sources */,
-				E49ACDD610074F9200A86ECD /* ZeroconfBrowser.cpp in Sources */,
-				F5D8EF5C103912A4004A11AB /* DVDSubtitleParserVplayer.cpp in Sources */,
-				7C779E45104A57E500F444C4 /* RenderSystem.cpp in Sources */,
-				7C779E46104A57E500F444C4 /* RenderSystemGL.cpp in Sources */,
-				7C779E47104A57E500F444C4 /* WinEventsSDL.cpp in Sources */,
-				7C779E48104A57E500F444C4 /* WinSystem.cpp in Sources */,
-				7C779E49104A57E500F444C4 /* WinSystemOSX.mm in Sources */,
-				7C779E4A104A57E500F444C4 /* WinSystemOSXGL.mm in Sources */,
-				7C779E56104A58F900F444C4 /* GUIWindowTestPatternGL.cpp in Sources */,
-				7C62F24310505BC7002AD2C1 /* Bookmark.cpp in Sources */,
-				7C62F45F1057A62D002AD2C1 /* DirectoryNodeSingles.cpp in Sources */,
-				7CCF7E731067643800992676 /* DirectoryNodeSets.cpp in Sources */,
-				7CCF7F1E1069F3AE00992676 /* Builtins.cpp in Sources */,
-				7CCF7FCA106A0DF500992676 /* TimeUtils.cpp in Sources */,
-				F57B6F811071B8B500079ACB /* JobManager.cpp in Sources */,
-				F5E55B5E10741272006E788A /* DVDPlayerTeletext.cpp in Sources */,
-				F5E55B67107412DE006E788A /* GUIDialogTeletext.cpp in Sources */,
-				F5E55B7110741340006E788A /* Teletext.cpp in Sources */,
-				F5E560BD10770F9F006E788A /* OggCallback.cpp in Sources */,
-				43348AA3107747CD00F859CF /* Edl.cpp in Sources */,
-				43348AAC1077486D00F859CF /* PlayerCoreFactory.cpp in Sources */,
-				43348AAD1077486D00F859CF /* PlayerSelectionRule.cpp in Sources */,
-				7CAA20521079C8160096DE39 /* BaseRenderer.cpp in Sources */,
-				F5E5697410803FC3006E788A /* fastmemcpy.c in Sources */,
-				43BF08EB1080C6BA00E25290 /* Neptune.cpp in Sources */,
-				43BF08EC1080C6BA00E25290 /* NptBase64.cpp in Sources */,
-				43BF08ED1080C6BA00E25290 /* NptBufferedStreams.cpp in Sources */,
-				43BF08EE1080C6BA00E25290 /* NptCommon.cpp in Sources */,
-				43BF08EF1080C6BA00E25290 /* NptConsole.cpp in Sources */,
-				43BF08F01080C6BA00E25290 /* NptDataBuffer.cpp in Sources */,
-				43BF08F11080C6BA00E25290 /* NptDebug.cpp in Sources */,
-				43BF08F21080C6BA00E25290 /* NptDynamicLibraries.cpp in Sources */,
-				43BF08F31080C6BA00E25290 /* NptFile.cpp in Sources */,
-				43BF08F41080C6BA00E25290 /* NptHttp.cpp in Sources */,
-				43BF08F51080C6BA00E25290 /* NptList.cpp in Sources */,
-				43BF08F61080C6BA00E25290 /* NptLogging.cpp in Sources */,
-				43BF08F71080C6BA00E25290 /* NptMessaging.cpp in Sources */,
-				43BF08F81080C6BA00E25290 /* NptNetwork.cpp in Sources */,
-				43BF08F91080C6BA00E25290 /* NptQueue.cpp in Sources */,
-				43BF08FA1080C6BA00E25290 /* NptResults.cpp in Sources */,
-				43BF08FB1080C6BA00E25290 /* NptRingBuffer.cpp in Sources */,
-				43BF08FC1080C6BA00E25290 /* NptSimpleMessageQueue.cpp in Sources */,
-				43BF08FD1080C6BA00E25290 /* NptSockets.cpp in Sources */,
-				43BF08FE1080C6BA00E25290 /* NptStreams.cpp in Sources */,
-				43BF08FF1080C6BA00E25290 /* NptStrings.cpp in Sources */,
-				43BF09001080C6BA00E25290 /* NptSystem.cpp in Sources */,
-				43BF09011080C6BA00E25290 /* NptThreads.cpp in Sources */,
-				43BF09021080C6BA00E25290 /* NptTime.cpp in Sources */,
-				43BF09031080C6BA00E25290 /* NptTls.cpp in Sources */,
-				43BF09041080C6BA00E25290 /* NptUri.cpp in Sources */,
-				43BF09051080C6BA00E25290 /* NptUtils.cpp in Sources */,
-				43BF09061080C6BA00E25290 /* NptXml.cpp in Sources */,
-				43BF09071080C6BA00E25290 /* NptZip.cpp in Sources */,
-				43BF09311080C71700E25290 /* NptBsdNetwork.cpp in Sources */,
-				43BF09321080C71700E25290 /* NptBsdSockets.cpp in Sources */,
-				43BF09431080C76E00E25290 /* NptPosixFile.cpp in Sources */,
-				43BF09441080C76E00E25290 /* NptPosixNetwork.cpp in Sources */,
-				43BF09451080C76E00E25290 /* NptPosixQueue.cpp in Sources */,
-				43BF09461080C76E00E25290 /* NptPosixSystem.cpp in Sources */,
-				43BF09471080C76E00E25290 /* NptPosixThreads.cpp in Sources */,
-				43BF09481080C76E00E25290 /* NptSelectableMessageQueue.cpp in Sources */,
-				43BF09501080C79900E25290 /* NptPosixDynamicLibraries.cpp in Sources */,
-				43BF095C1080C82D00E25290 /* NptStdcDebug.cpp in Sources */,
-				43BF095D1080C82D00E25290 /* NptStdcEnvironment.cpp in Sources */,
-				43BF095F1080C82D00E25290 /* NptStdCTime.cpp in Sources */,
-				43BF09741080CCB700E25290 /* PltTime.cpp in Sources */,
-				43BF09951080D13F00E25290 /* ConnectionManagerSCPD.cpp in Sources */,
-				43BF09961080D13F00E25290 /* ContentDirectorySCPD.cpp in Sources */,
-				43BF09971080D13F00E25290 /* ContentDirectorywSearchSCPD.cpp in Sources */,
-				43BF099C1080D17600E25290 /* X_MS_MediaReceiverRegistrarSCPD.cpp in Sources */,
-				43BF09A01080D1E900E25290 /* AVTransportSCPD.cpp in Sources */,
-				43BF09A11080D1E900E25290 /* RenderingControlSCPD.cpp in Sources */,
-				43BF09AA1080D2ED00E25290 /* RdrConnectionManagerSCPD.cpp in Sources */,
-				F5E56BA71082A675006E788A /* PosixMountProvider.cpp in Sources */,
-				7CAA25361085963B0096DE39 /* PasswordManager.cpp in Sources */,
-				F599CD2C108E65370010EC2A /* IoSupport.cpp in Sources */,
-				F599CD75108E6A7A0010EC2A /* DarwinStorageProvider.cpp in Sources */,
-				E4A249F81095C880003D74C6 /* AutorunMediaJob.cpp in Sources */,
-				F5A9D30A1097C9370050490F /* AliasShortcutUtils.cpp in Sources */,
-				431AE5D9109C1A63007428C3 /* OverlayRendererUtil.cpp in Sources */,
-				7C45DBEA10F325C400D4BBF3 /* DAVDirectory.cpp in Sources */,
-				F592568910FBF2E100D2C91D /* ConvolutionKernels.cpp in Sources */,
-				E435380311076A2900792AB8 /* eprintf.cpp in Sources */,
-				F5DC87E3110A287400EE1B15 /* RingBuffer.cpp in Sources */,
-				F5DC8802110A46C700EE1B15 /* ModplugCodec.cpp in Sources */,
-				F5F244661110DC6B009126C6 /* FileOperationJob.cpp in Sources */,
-				F5F245DB1112C6AC009126C6 /* DVDAudioCodecPassthroughFFmpeg.cpp in Sources */,
-				F5F245EF1112C9AB009126C6 /* FileUtils.cpp in Sources */,
-				F5A7A703112893E50059D6AA /* AnnouncementManager.cpp in Sources */,
-				F5A7A85C112908F00059D6AA /* WebServer.cpp in Sources */,
-				7C7B2B311134F36400713D6D /* mysqldataset.cpp in Sources */,
-				F5A7B37F113AFB900059D6AA /* SFTPDirectory.cpp in Sources */,
-				F5A7B42D113CBB950059D6AA /* AddonsDirectory.cpp in Sources */,
-				18B4A0081152BFA5001AF8A6 /* Addon.cpp in Sources */,
-				18B4A0091152BFA5001AF8A6 /* AddonManager.cpp in Sources */,
-				18B4A00A1152BFA5001AF8A6 /* fft.cpp in Sources */,
-				18B4A00B1152BFA5001AF8A6 /* Scraper.cpp in Sources */,
-				18B4A00C1152BFA5001AF8A6 /* ScreenSaver.cpp in Sources */,
-				18B4A00D1152BFA5001AF8A6 /* Visualisation.cpp in Sources */,
-				7C8A14561154CB2600E5FCFA /* TextureCache.cpp in Sources */,
-				C80425721158A0DE00D158A6 /* controlslider.cpp in Sources */,
-				7C8A187C115B2A8200E5FCFA /* TextureDatabase.cpp in Sources */,
-				F52BFFDC115D5574004B1D66 /* AddonStatusHandler.cpp in Sources */,
-				C85EB75D1174614E0008E5A5 /* Repository.cpp in Sources */,
-				F52B063C11869862004B1D66 /* Skin.cpp in Sources */,
-				F52B06BB1187CE18004B1D66 /* DVDVideoCodecVDA.cpp in Sources */,
-				7CD2C3AA11940B270009EFC1 /* DirectoryNodeCountry.cpp in Sources */,
-				F50FDC5B119B4B2C00C8B8CD /* GUIDialogTextViewer.cpp in Sources */,
-				F50FE04B11A3410300C8B8CD /* EncoderFlac.cpp in Sources */,
-				F50FE04F11A3411B00C8B8CD /* EncoderFFmpeg.cpp in Sources */,
-				183FDF8B11AF0B0500B81E9C /* PluginSource.cpp in Sources */,
-				7CD2CD0111B38B000009EFC1 /* PythonAddon.cpp in Sources */,
-				7CD2CD0211B38B000009EFC1 /* xbmcaddonmodule.cpp in Sources */,
-				F58E293A11FFC103006F4D46 /* DVDInputStreamBluray.cpp in Sources */,
-				F5BDB80D120202F400F0B710 /* DVDSubtitleTagSami.cpp in Sources */,
-				F5BDB81B1202032400F0B710 /* DVDSubtitleTagMicroDVD.cpp in Sources */,
-				F5BDB821120203C200F0B710 /* AutoPtrHandle.cpp in Sources */,
-				7CF1FB0B123B1AF000B2CBCB /* Variant.cpp in Sources */,
-				C8D0B2B01265A9A800F0C0AC /* SystemGlobals.cpp in Sources */,
-				7CBEBB8312912BA300431822 /* fstrcmp.c in Sources */,
-				184C47301296BC6E0006DB3E /* Service.cpp in Sources */,
-				18B7C3851294203F009E7A26 /* AddonDatabase.cpp in Sources */,
-				18B7C38C12942090009E7A26 /* GUIDialogAddonInfo.cpp in Sources */,
-				18B7C38D12942090009E7A26 /* GUIViewStateAddonBrowser.cpp in Sources */,
-				18B7C394129420E5009E7A26 /* Settings.cpp in Sources */,
-				18B7C395129420E5009E7A26 /* SettingsControls.cpp in Sources */,
-				18B7C3A212942114009E7A26 /* GUIWindowSettings.cpp in Sources */,
-				18B7C3A312942114009E7A26 /* GUIWindowSettingsCategory.cpp in Sources */,
-				18B7C3A412942114009E7A26 /* GUIWindowSettingsProfile.cpp in Sources */,
-				18B7C3A512942114009E7A26 /* GUIWindowSettingsScreenCalibration.cpp in Sources */,
-				18B7C3A912942132009E7A26 /* AdvancedSettings.cpp in Sources */,
-				18B7C7FE1294222E009E7A26 /* AnimatedGif.cpp in Sources */,
-				18B7C8001294222E009E7A26 /* D3DResource.cpp in Sources */,
-				18B7C8011294222E009E7A26 /* DDSImage.cpp in Sources */,
-				18B7C8021294222E009E7A26 /* DirectXGraphics.cpp in Sources */,
-				18B7C8031294222E009E7A26 /* FrameBufferObject.cpp in Sources */,
-				18B7C8041294222E009E7A26 /* GraphicContext.cpp in Sources */,
-				18B7C8051294222E009E7A26 /* GUIAudioManager.cpp in Sources */,
-				18B7C8061294222E009E7A26 /* GUIBaseContainer.cpp in Sources */,
-				18B7C8071294222E009E7A26 /* GUIBorderedImage.cpp in Sources */,
-				18B7C8081294222E009E7A26 /* GUIButtonControl.cpp in Sources */,
-				18B7C80A1294222E009E7A26 /* GUICheckMarkControl.cpp in Sources */,
-				18B7C80B1294222E009E7A26 /* GUIColorManager.cpp in Sources */,
-				18B7C80C1294222E009E7A26 /* GUIControl.cpp in Sources */,
-				18B7C80D1294222E009E7A26 /* GUIControlFactory.cpp in Sources */,
-				18B7C80E1294222E009E7A26 /* GUIControlGroup.cpp in Sources */,
-				18B7C80F1294222E009E7A26 /* GUIControlGroupList.cpp in Sources */,
-				18B7C8101294222E009E7A26 /* GUIControlProfiler.cpp in Sources */,
-				18B7C8111294222E009E7A26 /* GUIDialog.cpp in Sources */,
-				18B7C8121294222E009E7A26 /* GUIEditControl.cpp in Sources */,
-				18B7C8131294222E009E7A26 /* GUIFadeLabelControl.cpp in Sources */,
-				18B7C8141294222E009E7A26 /* GUIFixedListContainer.cpp in Sources */,
-				18B7C8151294222E009E7A26 /* GUIFont.cpp in Sources */,
-				18B7C8161294222E009E7A26 /* GUIFontManager.cpp in Sources */,
-				18B7C8171294222E009E7A26 /* GUIFontTTF.cpp in Sources */,
-				18B7C8181294222E009E7A26 /* GUIFontTTFDX.cpp in Sources */,
-				18B7C8191294222E009E7A26 /* GUIFontTTFGL.cpp in Sources */,
-				18B7C81A1294222E009E7A26 /* GUIImage.cpp in Sources */,
-				18B7C81B1294222E009E7A26 /* GUIIncludes.cpp in Sources */,
-				18B7C81C1294222E009E7A26 /* GUIInfoTypes.cpp in Sources */,
-				18B7C81D1294222E009E7A26 /* GUILabel.cpp in Sources */,
-				18B7C81E1294222E009E7A26 /* GUILabelControl.cpp in Sources */,
-				18B7C81F1294222E009E7A26 /* GUIListContainer.cpp in Sources */,
-				18B7C8201294222E009E7A26 /* GUIListGroup.cpp in Sources */,
-				18B7C8211294222E009E7A26 /* GUIListItem.cpp in Sources */,
-				18B7C8221294222E009E7A26 /* GUIListItemLayout.cpp in Sources */,
-				18B7C8231294222E009E7A26 /* GUIListLabel.cpp in Sources */,
-				18B7C8241294222E009E7A26 /* GUIMessage.cpp in Sources */,
-				18B7C8251294222E009E7A26 /* GUIMoverControl.cpp in Sources */,
-				18B7C8261294222E009E7A26 /* GUIMultiImage.cpp in Sources */,
-				18B7C8271294222E009E7A26 /* GUIMultiSelectText.cpp in Sources */,
-				18B7C8281294222E009E7A26 /* GUIPanelContainer.cpp in Sources */,
-				18B7C8291294222E009E7A26 /* GUIProgressControl.cpp in Sources */,
-				18B7C82A1294222E009E7A26 /* GUIRadioButtonControl.cpp in Sources */,
-				18B7C82B1294222E009E7A26 /* GUIRenderingControl.cpp in Sources */,
-				18B7C82C1294222E009E7A26 /* GUIResizeControl.cpp in Sources */,
-				18B7C82D1294222E009E7A26 /* GUIRSSControl.cpp in Sources */,
-				18B7C82E1294222E009E7A26 /* GUIScrollBarControl.cpp in Sources */,
-				18B7C82F1294222E009E7A26 /* GUISelectButtonControl.cpp in Sources */,
-				18B7C8301294222E009E7A26 /* GUISettingsSliderControl.cpp in Sources */,
-				18B7C8311294222E009E7A26 /* GUIShader.cpp in Sources */,
-				18B7C8321294222E009E7A26 /* GUISliderControl.cpp in Sources */,
-				18B7C8341294222E009E7A26 /* GUISpinControl.cpp in Sources */,
-				18B7C8351294222E009E7A26 /* GUISpinControlEx.cpp in Sources */,
-				18B7C8361294222E009E7A26 /* GUIStandardWindow.cpp in Sources */,
-				18B7C8371294222E009E7A26 /* GUIStaticItem.cpp in Sources */,
-				18B7C8381294222E009E7A26 /* GUITextBox.cpp in Sources */,
-				18B7C8391294222E009E7A26 /* GUITextLayout.cpp in Sources */,
-				18B7C83A1294222E009E7A26 /* GUITexture.cpp in Sources */,
-				18B7C83B1294222E009E7A26 /* GUITextureD3D.cpp in Sources */,
-				18B7C83C1294222E009E7A26 /* GUITextureGL.cpp in Sources */,
-				18B7C83D1294222E009E7A26 /* GUITextureGLES.cpp in Sources */,
-				18B7C83E1294222E009E7A26 /* GUIToggleButtonControl.cpp in Sources */,
-				18B7C83F1294222E009E7A26 /* GUIVideoControl.cpp in Sources */,
-				18B7C8401294222E009E7A26 /* GUIVisualisationControl.cpp in Sources */,
-				18B7C8411294222E009E7A26 /* GUIWindow.cpp in Sources */,
-				18B7C8421294222E009E7A26 /* GUIWindowManager.cpp in Sources */,
-				18B7C8431294222E009E7A26 /* GUIWrappingListContainer.cpp in Sources */,
-				18B7C8441294222E009E7A26 /* IWindowManagerCallback.cpp in Sources */,
-				18B7C8451294222E009E7A26 /* Key.cpp in Sources */,
-				18B7C8461294222E009E7A26 /* LocalizeStrings.cpp in Sources */,
-				18B7C8471294222E009E7A26 /* MatrixGLES.cpp in Sources */,
-				18B7C8481294222E009E7A26 /* Shader.cpp in Sources */,
-				18B7C8491294222E009E7A26 /* Texture.cpp in Sources */,
-				18B7C84A1294222E009E7A26 /* TextureBundle.cpp in Sources */,
-				18B7C84B1294222E009E7A26 /* TextureBundleXBT.cpp in Sources */,
-				18B7C84C1294222E009E7A26 /* TextureBundleXPR.cpp in Sources */,
-				18B7C84D1294222E009E7A26 /* TextureDX.cpp in Sources */,
-				18B7C84E1294222E009E7A26 /* TextureGL.cpp in Sources */,
-				18B7C84F1294222E009E7A26 /* TextureManager.cpp in Sources */,
-				18B7C8501294222E009E7A26 /* VisibleEffect.cpp in Sources */,
-				18B7C8511294222E009E7A26 /* XBTF.cpp in Sources */,
-				18B7C8521294222E009E7A26 /* XBTFReader.cpp in Sources */,
-				18B7C8A7129423A7009E7A26 /* APEv2Tag.cpp in Sources */,
-				18B7C8A8129423A7009E7A26 /* FlacTag.cpp in Sources */,
-				18B7C8A9129423A7009E7A26 /* Id3Tag.cpp in Sources */,
-				18B7C8AB129423A7009E7A26 /* MusicInfoTag.cpp in Sources */,
-				18B7C8AC129423A7009E7A26 /* MusicInfoTagLoaderAAC.cpp in Sources */,
-				18B7C8AD129423A7009E7A26 /* MusicInfoTagLoaderApe.cpp in Sources */,
-				18B7C8AE129423A7009E7A26 /* MusicInfoTagLoaderASAP.cpp in Sources */,
-				18B7C8AF129423A7009E7A26 /* MusicInfoTagLoaderCDDA.cpp in Sources */,
-				18B7C8B0129423A7009E7A26 /* MusicInfoTagLoaderDatabase.cpp in Sources */,
-				18B7C8B1129423A7009E7A26 /* MusicInfoTagLoaderFactory.cpp in Sources */,
-				18B7C8B2129423A7009E7A26 /* MusicInfoTagLoaderFlac.cpp in Sources */,
-				18B7C8B3129423A7009E7A26 /* MusicInfoTagLoaderMidi.cpp in Sources */,
-				18B7C8B4129423A7009E7A26 /* MusicInfoTagLoaderMod.cpp in Sources */,
-				18B7C8B5129423A7009E7A26 /* MusicInfoTagLoaderMP3.cpp in Sources */,
-				18B7C8B6129423A7009E7A26 /* MusicInfoTagLoaderMP4.cpp in Sources */,
-				18B7C8B7129423A7009E7A26 /* MusicInfoTagLoaderMPC.cpp in Sources */,
-				18B7C8B8129423A7009E7A26 /* MusicInfoTagLoaderNSF.cpp in Sources */,
-				18B7C8B9129423A7009E7A26 /* MusicInfoTagLoaderOgg.cpp in Sources */,
-				18B7C8BA129423A7009E7A26 /* MusicInfoTagLoaderShn.cpp in Sources */,
-				18B7C8BB129423A7009E7A26 /* MusicInfoTagLoaderSPC.cpp in Sources */,
-				18B7C8BC129423A7009E7A26 /* MusicInfoTagLoaderWav.cpp in Sources */,
-				18B7C8BD129423A7009E7A26 /* MusicInfoTagLoaderWavPack.cpp in Sources */,
-				18B7C8BE129423A7009E7A26 /* MusicInfoTagLoaderWMA.cpp in Sources */,
-				18B7C8BF129423A7009E7A26 /* MusicInfoTagLoaderYM.cpp in Sources */,
-				18B7C8C0129423A7009E7A26 /* OggTag.cpp in Sources */,
-				18B7C8C1129423A7009E7A26 /* VorbisTag.cpp in Sources */,
-				18B7C8C512942451009E7A26 /* GUISettings.cpp in Sources */,
-				18B7C8DC12942546009E7A26 /* ButtonTranslator.cpp in Sources */,
-				18B7C8DD12942546009E7A26 /* KeyboardLayoutConfiguration.cpp in Sources */,
-				18B7C8DE12942546009E7A26 /* KeyboardStat.cpp in Sources */,
-				18B7C8DF12942546009E7A26 /* MouseStat.cpp in Sources */,
-				18B7C8E012942546009E7A26 /* SDLJoystick.cpp in Sources */,
-				18B7C8EA12942603009E7A26 /* Crc32.cpp in Sources */,
-				18B7C8EF12942613009E7A26 /* URIUtils.cpp in Sources */,
-				18B7C8F41294261F009E7A26 /* StringUtils.cpp in Sources */,
-				18B7C8FC12942718009E7A26 /* GUIDialogAddonSettings.cpp in Sources */,
-				18B7C90112942761009E7A26 /* GUIDialogAudioSubtitleSettings.cpp in Sources */,
-				18B7C912129427A6009E7A26 /* GUIDialogContentSettings.cpp in Sources */,
-				18B7C913129427A6009E7A26 /* GUIDialogLockSettings.cpp in Sources */,
-				18B7C914129427A6009E7A26 /* GUIDialogProfileSettings.cpp in Sources */,
-				18B7C915129427A6009E7A26 /* GUIDialogSettings.cpp in Sources */,
-				18B7C916129427A6009E7A26 /* GUIDialogVideoSettings.cpp in Sources */,
-				18B7C93A129428CA009E7A26 /* PlayList.cpp in Sources */,
-				18B7C93B129428CA009E7A26 /* PlayListB4S.cpp in Sources */,
-				18B7C93C129428CA009E7A26 /* PlayListFactory.cpp in Sources */,
-				18B7C93D129428CA009E7A26 /* PlayListM3U.cpp in Sources */,
-				18B7C93E129428CA009E7A26 /* PlayListPLS.cpp in Sources */,
-				18B7C93F129428CA009E7A26 /* PlayListURL.cpp in Sources */,
-				18B7C940129428CA009E7A26 /* PlayListWPL.cpp in Sources */,
-				18B7C941129428CA009E7A26 /* PlayListXML.cpp in Sources */,
-				18B7C942129428CA009E7A26 /* SmartPlayList.cpp in Sources */,
-				18B7C97D1294380A009E7A26 /* GUIWindowAddonBrowser.cpp in Sources */,
-				18B7C9841294385F009E7A26 /* XMLUtils.cpp in Sources */,
-				432D7CE512D86DA500CE4C49 /* NetworkLinux.cpp in Sources */,
-				432D7CF812D870E800CE4C49 /* TCPServer.cpp in Sources */,
-				433219DB12E4C6A500CD7486 /* udf25.cpp in Sources */,
-				433219DC12E4C6A500CD7486 /* UDFDirectory.cpp in Sources */,
-				7C4705AF12EF584C00369E51 /* AddonInstaller.cpp in Sources */,
-				18C1D22E13033F6A00CFFE59 /* GLUtils.cpp in Sources */,
-				7C84A59F12FA3C1600CD1714 /* SourcesDirectory.cpp in Sources */,
-				F57A1D1F1329B15300498CC7 /* AutoPool.mm in Sources */,
-				F5B13C8E1334056B0045076D /* DarwinUtils.mm in Sources */,
-				7C99B6A5133D342100FC2B16 /* CircularCache.cpp in Sources */,
-				7C99B7961340723F00FC2B16 /* GUIDialogPlayEject.cpp in Sources */,
-				F5AE407A13415D8D0004BD79 /* HttpApi.cpp in Sources */,
-				F5AE407D13415D8D0004BD79 /* XBMChttp.cpp in Sources */,
-				F5AE40A913415D9E0004BD79 /* AudioLibrary.cpp in Sources */,
-				F5AE40AC13415D9E0004BD79 /* FileItemHandler.cpp in Sources */,
-				F5AE40AD13415D9E0004BD79 /* FileOperations.cpp in Sources */,
-				F5AE40AE13415D9E0004BD79 /* JSONRPC.cpp in Sources */,
-				F5AE40B113415D9E0004BD79 /* PlayerOperations.cpp in Sources */,
-				F5AE40B213415D9E0004BD79 /* PlaylistOperations.cpp in Sources */,
-				F5AE40B313415D9E0004BD79 /* SystemOperations.cpp in Sources */,
-				F5AE40B413415D9E0004BD79 /* VideoLibrary.cpp in Sources */,
-				F5AE40B513415D9E0004BD79 /* XBMCOperations.cpp in Sources */,
-				43EA4276136C04D9002C82A5 /* XBDateTime.cpp in Sources */,
-				43EA4279136C079A002C82A5 /* JSONServiceDescription.cpp in Sources */,
-				43EA427E136C07BF002C82A5 /* XBMC_keytable.cpp in Sources */,
-				43EA4282136C0806002C82A5 /* RecentlyAddedJob.cpp in Sources */,
-				43EA4297136C1D9E002C82A5 /* RenderCapture.cpp in Sources */,
-				43EA429B136C1E2F002C82A5 /* xbmcvfsmodule.cpp in Sources */,
-				43EA42B0136C2274002C82A5 /* InputOperations.cpp in Sources */,
-				1840B74E13993D8A007C848B /* JSONVariantParser.cpp in Sources */,
-				1840B75413993DA0007C848B /* JSONVariantWriter.cpp in Sources */,
-				7C0A7EC113A5DBCE00AFC2BD /* AppParamParser.cpp in Sources */,
-				18B700E213A6A5750009C1AF /* AddonVersion.cpp in Sources */,
-				F558F25713ABCF7800631E12 /* WinEventsOSX.mm in Sources */,
-				F558F27C13ABD56600631E12 /* DirtyRegionSolvers.cpp in Sources */,
-				F558F28013ABD57400631E12 /* DirtyRegionTracker.cpp in Sources */,
-				F558F29713ABD7DF00631E12 /* GUIWindowDebugInfo.cpp in Sources */,
-				F558F3D113AE663A00631E12 /* NFSDirectory.cpp in Sources */,
-				7C89619313B6A16F003631FE /* GUIWindowScreensaverDim.cpp in Sources */,
-				1830212913B8E2DC00770920 /* controledit.cpp in Sources */,
-				7CEE2E5C13D6B71E000ABF2A /* TimeSmoother.cpp in Sources */,
-				4308680413E3F64100698436 /* StreamUtils.cpp in Sources */,
-				4308680913E3F64C00698436 /* SystemClock.cpp in Sources */,
-				4308680D13E3F65700698436 /* Implementation.cpp in Sources */,
-				4308681213E3F66600698436 /* DVDOverlayCodecTX3G.cpp in Sources */,
-				7C89674813C03B22003631FE /* InfoBool.cpp in Sources */,
-				DFAB049913F8376700B70BFB /* InertialScrollingHandler.cpp in Sources */,
-				DF3488E813FD958F0026A711 /* GUIAction.cpp in Sources */,
-				DF34892B13FD9C780026A711 /* AirPlayServer.cpp in Sources */,
-				DF34898313FDAAF60026A711 /* HttpParser.cpp in Sources */,
-				18968DC914155D7C005BA742 /* ApplicationOperations.cpp in Sources */,
-				DF24A6B61406C7C500C7721E /* AFPDirectory.cpp in Sources */,
-				F5E10D381428426B00175026 /* JpegIO.cpp in Sources */,
-				DF448458140048A60069344B /* AirTunesServer.cpp in Sources */,
-				DF448460140048C80069344B /* PipesManager.cpp in Sources */,
-				DF4484EF140054530069344B /* BXAcodec.cpp in Sources */,
-				DF98D98D1434F47D00A6EBE1 /* SkinVariable.cpp in Sources */,
-				F5E10549140AA38100175026 /* PeripheralBusUSB.cpp in Sources */,
-				F5E1054A140AA38100175026 /* PeripheralBus.cpp in Sources */,
-				F5E1054D140AA38100175026 /* Peripheral.cpp in Sources */,
-				F5E1054E140AA38100175026 /* PeripheralBluetooth.cpp in Sources */,
-				F5E10550140AA38100175026 /* PeripheralDisk.cpp in Sources */,
-				F5E10551140AA38100175026 /* PeripheralHID.cpp in Sources */,
-				F5E10552140AA38100175026 /* PeripheralNIC.cpp in Sources */,
-				F5E10553140AA38100175026 /* PeripheralNyxboard.cpp in Sources */,
-				F5E10554140AA38100175026 /* PeripheralTuner.cpp in Sources */,
-				F5E10555140AA38100175026 /* GUIDialogPeripheralManager.cpp in Sources */,
-				F5E10556140AA38100175026 /* GUIDialogPeripheralSettings.cpp in Sources */,
-				F5E10559140AA38100175026 /* Peripherals.cpp in Sources */,
-				F5E1125F14356B2400175026 /* pyrendercapture.cpp in Sources */,
-				F5E1138114357F3900175026 /* PeripheralCecAdapter.cpp in Sources */,
-				F54BCC601439345300F86B0F /* HotKeyController.m in Sources */,
-				F5BD02F7148D3A7E001B5583 /* CryptThreading.cpp in Sources */,
-				7CCFD98C151494E100211D82 /* PCMCodec.cpp in Sources */,
-				DF527726151BAEDA00B5B63B /* Base64.cpp in Sources */,
-				DF527727151BAEDA00B5B63B /* HttpResponse.cpp in Sources */,
-				DF527739151BAF4C00B5B63B /* WebSocket.cpp in Sources */,
-				DF52773A151BAF4C00B5B63B /* WebSocketManager.cpp in Sources */,
-				DF52773B151BAF4C00B5B63B /* WebSocketV13.cpp in Sources */,
-				DF52773C151BAF4C00B5B63B /* WebSocketV8.cpp in Sources */,
-				188F75FF152217BC009870CE /* Mime.cpp in Sources */,
-				188F7603152217DF009870CE /* GUIOperations.cpp in Sources */,
-				DFCA6ACD152245CD000BFAAE /* HTTPApiHandler.cpp in Sources */,
-				DFCA6ACE152245CD000BFAAE /* HTTPJsonRpcHandler.cpp in Sources */,
-				DFCA6ACF152245CD000BFAAE /* HTTPVfsHandler.cpp in Sources */,
-				DFCA6AD0152245CD000BFAAE /* HTTPWebinterfaceAddonsHandler.cpp in Sources */,
-				DFCA6AD1152245CD000BFAAE /* HTTPWebinterfaceHandler.cpp in Sources */,
-				DFCA6AD2152245CD000BFAAE /* IHTTPRequestHandler.cpp in Sources */,
-				DF93D65E1444A7A3007C6459 /* SlingboxDirectory.cpp in Sources */,
-				DF93D6B41444A8B1007C6459 /* AFPFile.cpp in Sources */,
-				DF93D6B51444A8B1007C6459 /* DirectoryCache.cpp in Sources */,
-				DF93D6B61444A8B1007C6459 /* FileCache.cpp in Sources */,
-				DF93D6B71444A8B1007C6459 /* CDDAFile.cpp in Sources */,
-				DF93D6B81444A8B1007C6459 /* CurlFile.cpp in Sources */,
-				DF93D6B91444A8B1007C6459 /* DAAPFile.cpp in Sources */,
-				DF93D6BA1444A8B1007C6459 /* DirectoryFactory.cpp in Sources */,
-				DF93D6BB1444A8B1007C6459 /* FileDirectoryFactory.cpp in Sources */,
-				DF93D6BC1444A8B1007C6459 /* FileReaderFile.cpp in Sources */,
-				DF93D6BD1444A8B1007C6459 /* HDFile.cpp in Sources */,
-				DF93D6BE1444A8B1007C6459 /* ISOFile.cpp in Sources */,
-				DF93D6BF1444A8B1007C6459 /* LastFMFile.cpp in Sources */,
-				DF93D6C01444A8B1007C6459 /* MusicDatabaseFile.cpp in Sources */,
-				DF93D6C11444A8B1007C6459 /* NFSFile.cpp in Sources */,
-				DF93D6C21444A8B1007C6459 /* PipeFile.cpp in Sources */,
-				DF93D6C31444A8B1007C6459 /* RarFile.cpp in Sources */,
-				DF93D6C41444A8B1007C6459 /* RTVFile.cpp in Sources */,
-				DF93D6C51444A8B1007C6459 /* SFTPFile.cpp in Sources */,
-				DF93D6C61444A8B1007C6459 /* ShoutcastFile.cpp in Sources */,
-				DF93D6C71444A8B1007C6459 /* SlingboxFile.cpp in Sources */,
-				DF93D6C81444A8B1007C6459 /* SmbFile.cpp in Sources */,
-				DF93D6C91444A8B1007C6459 /* SpecialProtocolFile.cpp in Sources */,
-				DF93D6CA1444A8B1007C6459 /* TuxBoxDirectory.cpp in Sources */,
-				DF93D6CB1444A8B1007C6459 /* TuxBoxFile.cpp in Sources */,
-				DF93D6CC1444A8B1007C6459 /* UDFFile.cpp in Sources */,
-				DF93D6CD1444A8B1007C6459 /* UPnPFile.cpp in Sources */,
-				DF93D6CE1444A8B1007C6459 /* ZipFile.cpp in Sources */,
-				DF93D7F31444B54A007C6459 /* HDHomeRunFile.cpp in Sources */,
-				DF93D7F71444B568007C6459 /* HDHomeRunDirectory.cpp in Sources */,
-				7C1A85651520522500C63311 /* TextureCacheJob.cpp in Sources */,
-				C8936053152C86CF00812418 /* monitor.cpp in Sources */,
-				C8936057152C86D800812418 /* PythonMonitor.cpp in Sources */,
-				7C1F6EBC13ECCFA7001726AB /* LibraryDirectory.cpp in Sources */,
-				EC720A90155091BB00FFD782 /* ilog.cpp in Sources */,
-				EC720A9E1550927000FFD782 /* XbmcContext.cpp in Sources */,
-				F5ED8D6D1551F91400842059 /* BlurayDirectory.cpp in Sources */,
-				F5ED908915538DCE00842059 /* XBMCTinyXML.cpp in Sources */,
-				F5ED908F15538E2300842059 /* POUtils.cpp in Sources */,
-				DFB65FD515373AE7006B8FF1 /* AEFactory.cpp in Sources */,
-				DFB65FD715373AE7006B8FF1 /* AEEncoderFFmpeg.cpp in Sources */,
-				DFB65FD815373AE7006B8FF1 /* CoreAudioAE.cpp in Sources */,
-				DFB65FD915373AE7006B8FF1 /* CoreAudioAEHAL.cpp in Sources */,
-				DFB65FDA15373AE7006B8FF1 /* CoreAudioAEHALIOS.cpp in Sources */,
-				DFB65FDB15373AE7006B8FF1 /* CoreAudioAEHALOSX.cpp in Sources */,
-				DFB65FDC15373AE7006B8FF1 /* CoreAudioAESound.cpp in Sources */,
-				DFB65FDD15373AE7006B8FF1 /* CoreAudioAEStream.cpp in Sources */,
-				DFB65FE515373AE7006B8FF1 /* AEPPAnimationFade.cpp in Sources */,
-				DFB65FEC15373AE7006B8FF1 /* AEBitstreamPacker.cpp in Sources */,
-				DFB65FED15373AE7006B8FF1 /* AEBuffer.cpp in Sources */,
-				DFB65FEE15373AE7006B8FF1 /* AEChannelInfo.cpp in Sources */,
-				DFB65FEF15373AE7006B8FF1 /* AEConvert.cpp in Sources */,
-				DFB65FF015373AE7006B8FF1 /* AEPackIEC61937.cpp in Sources */,
-				DFB65FF115373AE7006B8FF1 /* AERemap.cpp in Sources */,
-				DFB65FF215373AE7006B8FF1 /* AEStreamInfo.cpp in Sources */,
-				DFB65FF315373AE7006B8FF1 /* AEUtil.cpp in Sources */,
-				DFB65FF415373AE7006B8FF1 /* AEWAVLoader.cpp in Sources */,
-				DFB6610B15374E80006B8FF1 /* DVDAudioCodecPassthrough.cpp in Sources */,
-				7C0B98A3154B79C30065A238 /* AEDeviceInfo.cpp in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
@@ -9282,11 +7250,6 @@
 			isa = PBXTargetDependency;
 			target = 8DD76F740486A8DE00D96B5E /* XBMC */;
 			targetProxy = 6E2FACC30E26E08100DF79EA /* PBXContainerItemProxy */;
-		};
-		F5A1CBE60F6B0BFB00A96ABD /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = F5A1C8710F6B06CF00A96ABD /* XBMC_ppc */;
-			targetProxy = F5A1CBE50F6B0BFB00A96ABD /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -9321,6 +7284,7 @@
 					HAS_SPC_CODEC,
 				);
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_VERSION = "";
 				GENERATE_PROFILING_CODE = NO;
 				HEADER_SEARCH_PATHS = (
 					$SRCROOT,
@@ -9399,7 +7363,7 @@
 				);
 				PRODUCT_NAME = XBMC;
 				USER_HEADER_SEARCH_PATHS = "$XBMC_DEPENDS/include $XBMC_DEPENDS/include/libcec $XBMC_DEPENDS/include/mysql $XBMC_DEPENDS/include/freetype2 $XBMC_DEPENDS/include/python2.6";
-				XBMC_DEPENDS = "/Users/Shared/xbmc-depends/osx-10.4_i386";
+				XBMC_DEPENDS = "/Users/Shared/xbmc-depends/$(SDK_NAME)_$(ARCHS)";
 				ZERO_LINK = NO;
 			};
 			name = Debug;
@@ -9438,7 +7402,7 @@
 				);
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
 				GCC_UNROLL_LOOPS = YES;
-				GCC_VERSION = 4.0;
+				GCC_VERSION = "";
 				HEADER_SEARCH_PATHS = (
 					$SRCROOT,
 					xbmc,
@@ -9516,7 +7480,7 @@
 				);
 				PRODUCT_NAME = XBMC;
 				USER_HEADER_SEARCH_PATHS = "$XBMC_DEPENDS/include $XBMC_DEPENDS/include/libcec $XBMC_DEPENDS/include/mysql $XBMC_DEPENDS/include/freetype2 $XBMC_DEPENDS/include/python2.6";
-				XBMC_DEPENDS = "/Users/Shared/xbmc-depends/osx-10.4_i386";
+				XBMC_DEPENDS = "/Users/Shared/xbmc-depends/$(SDK_NAME)_$(ARCHS)";
 				ZERO_LINK = NO;
 			};
 			name = Release;
@@ -9533,11 +7497,11 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				HEADER_SEARCH_PATHS = "";
 				LIBRARY_SEARCH_PATHS = "";
-				MACOSX_DEPLOYMENT_TARGET = 10.4;
+				MACOSX_DEPLOYMENT_TARGET = 10.6;
 				PREBINDING = NO;
-				SDKROOT = macosx10.4;
+				SDKROOT = macosx;
 				USER_HEADER_SEARCH_PATHS = .;
-				VALID_ARCHS = "ppc i386";
+				VALID_ARCHS = "i386 x86_64";
 			};
 			name = Debug;
 		};
@@ -9552,11 +7516,11 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				HEADER_SEARCH_PATHS = "";
 				LIBRARY_SEARCH_PATHS = "";
-				MACOSX_DEPLOYMENT_TARGET = 10.4;
+				MACOSX_DEPLOYMENT_TARGET = 10.6;
 				PREBINDING = NO;
-				SDKROOT = macosx10.4;
+				SDKROOT = macosx;
 				USER_HEADER_SEARCH_PATHS = .;
-				VALID_ARCHS = "ppc i386";
+				VALID_ARCHS = "i386 x86_64";
 			};
 			name = Release;
 		};
@@ -9577,265 +7541,6 @@
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				GCC_ENABLE_FIX_AND_CONTINUE = NO;
 				PRODUCT_NAME = XBMC.app;
-				ZERO_LINK = NO;
-			};
-			name = Release;
-		};
-		F5A1CBD00F6B06CF00A96ABD /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ARCHS = ppc;
-				COPY_PHASE_STRIP = NO;
-				DEAD_CODE_STRIPPING = NO;
-				DEBUG_INFORMATION_FORMAT = dwarf;
-				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
-				GCC_AUTO_VECTORIZATION = YES;
-				GCC_DYNAMIC_NO_PIC = NO;
-				GCC_ENABLE_FIX_AND_CONTINUE = NO;
-				GCC_ENABLE_OBJC_EXCEPTIONS = YES;
-				GCC_ENABLE_SSE3_EXTENSIONS = NO;
-				GCC_ENABLE_SUPPLEMENTAL_SSE3_INSTRUCTIONS = NO;
-				GCC_INLINES_ARE_PRIVATE_EXTERN = NO;
-				GCC_MODEL_TUNING = "";
-				GCC_OPTIMIZATION_LEVEL = 0;
-				GCC_PREPROCESSOR_DEFINITIONS = (
-					_DEBUG,
-					TARGET_POSIX,
-					TARGET_DARWIN,
-					TARGET_DARWIN_OSX,
-					_LINUX,
-					_REENTRANT,
-					_FILE_DEFINED,
-					"_FILE_OFFSET_BITS=64",
-					_LARGEFILE64_SOURCE,
-					__STDC_CONSTANT_MACROS,
-					HAS_SDL_JOYSTICK,
-					HAVE_CONFIG_H,
-					HAS_SPC_CODEC,
-				);
-				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
-				GCC_VERSION = 4.0;
-				GENERATE_PROFILING_CODE = NO;
-				HEADER_SEARCH_PATHS = (
-					$SRCROOT,
-					xbmc,
-					xbmc/osx,
-					xbmc/linux,
-					xbmc/cores/dvdplayer,
-					lib,
-					lib/ffmpeg,
-					$XBMC_DEPENDS/include,
-					$XBMC_DEPENDS/include/libcec,
-					$XBMC_DEPENDS/include/mysql,
-					$XBMC_DEPENDS/include/freetype2,
-					$XBMC_DEPENDS/include/python2.6,
-				);
-				INFOPLIST_FILE = $SRCROOT/xbmc/osx/Info.plist;
-				INSTALL_PATH = /usr/local/bin;
-				LIBRARY_SEARCH_PATHS = (
-					"$(SRCROOT)",
-					"$(SRCROOT)/lib/libRTV",
-					"$(SRCROOT)/lib/libXDAAP",
-					"$(SRCROOT)/lib/cmyth/libcmyth",
-					"$(SRCROOT)/lib/cmyth/librefmem",
-					"$(SRCROOT)/lib/libapetag/.libs",
-					"$(SRCROOT)/lib/libsquish",
-					"$(SRCROOT)/lib/jsoncpp/src/lib_json",
-					"$(SRCROOT)/xbmc/interfaces/http-api",
-					"$(SRCROOT)/xbmc/interfaces/json-rpc",
-					"$(SRCROOT)/lib/SlingboxLib",
-					"\"$(SRCROOT)/lib/shairport\"",
-					"\"$(SRCROOT)/lib/ffmpeg/libavcodec\"",
-					"\"$(SRCROOT)/lib/ffmpeg/libavutil\"",
-					"\"$(SRCROOT)/lib/ffmpeg/libavformat\"",
-					"\"$(SRCROOT)/lib/ffmpeg/libavfilter\"",
-					"\"$(SRCROOT)/lib/ffmpeg/libavdevice\"",
-					"\"$(SRCROOT)/lib/ffmpeg/libswresample\"",
-					"\"$(SRCROOT)/lib/ffmpeg/libpostproc\"",
-					"\"$(SRCROOT)/lib/ffmpeg/libswscale\"",
-				);
-				LINK_WITH_STANDARD_LIBRARIES = YES;
-				OTHER_LDFLAGS = (
-					"-headerpad_max_install_names",
-					"-all_load",
-					"-L$XBMC_DEPENDS/lib",
-					"-lssh",
-					"-llzo2",
-					"-lpcre",
-					"-lpcrecpp",
-					"-lfribidi",
-					"-lcdio",
-					"-lfreetype",
-					"-lfontconfig",
-					"-lsqlite3",
-					"-lsamplerate",
-					"-lmicrohttpd",
-					"-lyajl",
-					"-ljpeg",
-					"-lcrypto",
-					"-lgcrypt",
-					"-lavdevice",
-					"-lavfilter",
-					"-lavcodec",
-					"-lavformat",
-					"-lpostproc",
-					"-lavutil",
-					"-lswresample",
-					"-lswscale",
-					"-lGLEW",
-					"-lSDL",
-					"-lSDL_mixer",
-					"-lsmbclient",
-					"-lpython2.6",
-					"-L$XBMC_DEPENDS/lib/mysql",
-					"-lmysqlclient",
-				);
-				PRODUCT_NAME = XBMC;
-				USER_HEADER_SEARCH_PATHS = "$XBMC_DEPENDS/include $XBMC_DEPENDS/include/libcec $XBMC_DEPENDS/include/mysql $XBMC_DEPENDS/include/freetype2 $XBMC_DEPENDS/include/python2.6";
-				VALID_ARCHS = ppc;
-				XBMC_DEPENDS = "/Users/Shared/xbmc-depends/osx-10.4_ppc";
-				ZERO_LINK = NO;
-			};
-			name = Debug;
-		};
-		F5A1CBD10F6B06CF00A96ABD /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ARCHS = ppc;
-				COPY_PHASE_STRIP = NO;
-				DEAD_CODE_STRIPPING = NO;
-				DEBUG_INFORMATION_FORMAT = dwarf;
-				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
-				GCC_AUTO_VECTORIZATION = YES;
-				GCC_DYNAMIC_NO_PIC = NO;
-				GCC_ENABLE_FIX_AND_CONTINUE = NO;
-				GCC_ENABLE_OBJC_EXCEPTIONS = YES;
-				GCC_ENABLE_SSE3_EXTENSIONS = NO;
-				GCC_ENABLE_SUPPLEMENTAL_SSE3_INSTRUCTIONS = NO;
-				GCC_FAST_OBJC_DISPATCH = YES;
-				GCC_MODEL_PPC64 = NO;
-				GCC_MODEL_TUNING = "";
-				GCC_OPTIMIZATION_LEVEL = 2;
-				GCC_PREPROCESSOR_DEFINITIONS = (
-					TARGET_POSIX,
-					TARGET_DARWIN,
-					TARGET_DARWIN_OSX,
-					_LINUX,
-					_REENTRANT,
-					_FILE_DEFINED,
-					"_FILE_OFFSET_BITS=64",
-					_LARGEFILE64_SOURCE,
-					__STDC_CONSTANT_MACROS,
-					HAS_SDL_JOYSTICK,
-					HAVE_CONFIG_H,
-					HAS_SPC_CODEC,
-				);
-				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
-				GCC_UNROLL_LOOPS = YES;
-				GCC_VERSION = 4.0;
-				HEADER_SEARCH_PATHS = (
-					$SRCROOT,
-					xbmc,
-					xbmc/osx,
-					xbmc/linux,
-					xbmc/cores/dvdplayer,
-					lib,
-					lib/ffmpeg,
-					$XBMC_DEPENDS/include,
-					$XBMC_DEPENDS/include/libcec,
-					$XBMC_DEPENDS/include/mysql,
-					$XBMC_DEPENDS/include/freetype2,
-					$XBMC_DEPENDS/include/python2.6,
-				);
-				INFOPLIST_FILE = $SRCROOT/xbmc/osx/Info.plist;
-				INSTALL_PATH = /usr/local/bin;
-				LIBRARY_SEARCH_PATHS = (
-					"$(SRCROOT)",
-					"$(SRCROOT)/lib/libRTV",
-					"$(SRCROOT)/lib/libXDAAP",
-					"$(SRCROOT)/lib/cmyth/libcmyth",
-					"$(SRCROOT)/lib/cmyth/librefmem",
-					"$(SRCROOT)/lib/libapetag/.libs",
-					"$(SRCROOT)/lib/libsquish",
-					"$(SRCROOT)/lib/jsoncpp/src/lib_json",
-					"$(SRCROOT)/xbmc/interfaces/http-api",
-					"$(SRCROOT)/xbmc/interfaces/json-rpc",
-					"$(SRCROOT)/lib/SlingboxLib",
-					"\"$(SRCROOT)/lib/shairport\"",
-					"\"$(SRCROOT)/lib/ffmpeg/libavcodec\"",
-					"\"$(SRCROOT)/lib/ffmpeg/libavutil\"",
-					"\"$(SRCROOT)/lib/ffmpeg/libavformat\"",
-					"\"$(SRCROOT)/lib/ffmpeg/libavfilter\"",
-					"\"$(SRCROOT)/lib/ffmpeg/libavdevice\"",
-					"\"$(SRCROOT)/lib/ffmpeg/libswresample\"",
-					"\"$(SRCROOT)/lib/ffmpeg/libpostproc\"",
-					"\"$(SRCROOT)/lib/ffmpeg/libswscale\"",
-				);
-				LINK_WITH_STANDARD_LIBRARIES = YES;
-				OTHER_LDFLAGS = (
-					"-headerpad_max_install_names",
-					"-all_load",
-					"-L$XBMC_DEPENDS/lib",
-					"-lssh",
-					"-llzo2",
-					"-lpcre",
-					"-lpcrecpp",
-					"-lfribidi",
-					"-lcdio",
-					"-lfreetype",
-					"-lfontconfig",
-					"-lsqlite3",
-					"-lsamplerate",
-					"-lmicrohttpd",
-					"-lyajl",
-					"-ljpeg",
-					"-lcrypto",
-					"-lgcrypt",
-					"-lavdevice",
-					"-lavfilter",
-					"-lavcodec",
-					"-lavformat",
-					"-lpostproc",
-					"-lavutil",
-					"-lswresample",
-					"-lswscale",
-					"-lGLEW",
-					"-lSDL",
-					"-lSDL_mixer",
-					"-lsmbclient",
-					"-lpython2.6",
-					"-L$XBMC_DEPENDS/lib/mysql",
-					"-lmysqlclient",
-				);
-				PRODUCT_NAME = XBMC;
-				USER_HEADER_SEARCH_PATHS = "$XBMC_DEPENDS/include $XBMC_DEPENDS/include/libcec $XBMC_DEPENDS/include/mysql $XBMC_DEPENDS/include/freetype2 $XBMC_DEPENDS/include/python2.6";
-				VALID_ARCHS = ppc;
-				XBMC_DEPENDS = "/Users/Shared/xbmc-depends/osx-10.4_ppc";
-				ZERO_LINK = NO;
-			};
-			name = Release;
-		};
-		F5A1CBE20F6B0B4700A96ABD /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ARCHS = ppc;
-				COPY_PHASE_STRIP = NO;
-				GCC_DYNAMIC_NO_PIC = NO;
-				GCC_OPTIMIZATION_LEVEL = 0;
-				PRODUCT_NAME = XBMC.app;
-				VALID_ARCHS = ppc;
-			};
-			name = Debug;
-		};
-		F5A1CBE30F6B0B4700A96ABD /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ARCHS = ppc;
-				COPY_PHASE_STRIP = YES;
-				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				GCC_ENABLE_FIX_AND_CONTINUE = NO;
-				PRODUCT_NAME = XBMC.app;
-				VALID_ARCHS = ppc;
 				ZERO_LINK = NO;
 			};
 			name = Release;
@@ -9866,24 +7571,6 @@
 			buildConfigurations = (
 				6E2FACBB0E26DF7A00DF79EA /* Debug */,
 				6E2FACBD0E26DF7A00DF79EA /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		F5A1CBCF0F6B06CF00A96ABD /* Build configuration list for PBXNativeTarget "XBMC_ppc" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				F5A1CBD00F6B06CF00A96ABD /* Debug */,
-				F5A1CBD10F6B06CF00A96ABD /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		F5A1CBE10F6B0B4700A96ABD /* Build configuration list for PBXAggregateTarget "XBMC_ppc.app" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				F5A1CBE20F6B0B4700A96ABD /* Debug */,
-				F5A1CBE30F6B0B4700A96ABD /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/tools/darwin/depends/Makefile.buildtools
+++ b/tools/darwin/depends/Makefile.buildtools
@@ -1,0 +1,11 @@
+TOOLCHAIN=/Users/Shared/xbmc-depends/toolchain
+export PATH:=$(TOOLCHAIN)/bin:${PATH}
+
+TARBALLS_LOCATION=/Users/Shared/xbmc-depends/tarballs
+BASE_URL=http://mirrors.xbmc.org/build-deps/darwin-libs
+MAKE_JOBS=$(shell sysctl hw.ncpu | awk '{print $$2}')
+
+RETRIEVE_TOOL=/usr/bin/curl
+RETRIEVE_TOOL_FLAGS=-Ls --create-dirs --output $(TARBALLS_LOCATION)/$(ARCHIVE)
+ARCHIVE_TOOL=tar
+ARCHIVE_TOOL_FLAGS=xf

--- a/tools/darwin/depends/Makefile.include.in
+++ b/tools/darwin/depends/Makefile.include.in
@@ -3,12 +3,8 @@ ARCH=@use_arch@
 DARWIN=@use_darwin@
 PREFIX=@use_prefix@
 STAGING=@use_staging@
-TOOLCHAIN=@use_toolchain@
-TARBALLS_LOCATION=@use_staging@/tarballs
-BASE_URL=http://mirrors.xbmc.org/build-deps/darwin-libs
-MAKE_JOBS=$(shell sysctl hw.ncpu | awk '{print $$2}')
 
-RETRIEVE_TOOL=/usr/bin/curl
-RETRIEVE_TOOL_FLAGS=-Ls --create-dirs --output $(TARBALLS_LOCATION)/$(ARCHIVE)
-ARCHIVE_TOOL=tar
-ARCHIVE_TOOL_FLAGS=xf
+# hack, include both possible paths which
+# depends on where we do the make.
+-include Makefile.buildtools
+-include ../Makefile.buildtools

--- a/tools/darwin/depends/autoconf/Makefile
+++ b/tools/darwin/depends/autoconf/Makefile
@@ -1,4 +1,4 @@
-include ../Makefile.include
+include ../Makefile.buildtools
 
 # lib name, version
 APPNAME=autoconf

--- a/tools/darwin/depends/automake/Makefile
+++ b/tools/darwin/depends/automake/Makefile
@@ -1,4 +1,4 @@
-include ../Makefile.include
+include ../Makefile.buildtools
 
 # lib name, version
 APPNAME=automake

--- a/tools/darwin/depends/boost/Makefile
+++ b/tools/darwin/depends/boost/Makefile
@@ -7,6 +7,23 @@ LIBVERSION=1.44.0
 SOURCE=$(LIBNAME)_$(VERSION)
 ARCHIVE=$(SOURCE).tar.bz2
 
+bjam_args = toolset=darwin-$(platform_gcc_version)
+boost_flags = $(platform_sdk_path) -arch $(ARCH)
+ifeq ("$(DARWIN)", "ios")
+  bjam_args += --architecture=arm target-os=iphone macosx-version=iphone-$(platform_sdk_version) define=_LITTLE_ENDIAN
+  # arm uses non-thread-safe compare-and-swap instruction so use posix thread primitives
+  boost_flags += -DBOOST_AC_USE_PTHREADS -DBOOST_SP_USE_PTHREADS
+else
+  ifeq ("$(ARCH)", "ppc")
+    bjam_args +=  --architecture=$(boost_architecture)=power address-model=32
+  else ifeq ("$(ARCH)", "i386")
+    bjam_args +=  --architecture=$(boost_architecture)=x86 address-model=32
+  else
+    bjam_args +=  --architecture=$(boost_architecture)=x86 address-model=64
+  endif
+  bjam_args += target-os=darwin --link=static
+endif
+
 all: .installed
 
 $(TARBALLS_LOCATION)/$(ARCHIVE):
@@ -16,9 +33,11 @@ $(TARBALLS_LOCATION)/$(ARCHIVE):
 	rm -rf $(SOURCE)
 	$(ARCHIVE_TOOL) $(ARCHIVE_TOOL_FLAGS) $(TARBALLS_LOCATION)/$(ARCHIVE)
 	echo $(SOURCE) > .gitignore
-	sed -e "s?@boost_flags@?$(boost_flags)?g" \
-            -e "s?@platform_gcc_version@?$(platform_gcc_version)?g" \
-            user-config.jam.in >> $(SOURCE)/tools/build/v2/user-config.jam
+	echo 'using darwin : $(platform_gcc_version) : $(platform_cxx) :' >> $(SOURCE)/tools/build/v2/user-config.jam
+	echo '  <cflags>"-isysroot $(boost_flags) -fvisibility=default -fvisibility-inlines-hidden"' >> $(SOURCE)/tools/build/v2/user-config.jam
+	echo '  <cxxflags>"-isysroot $(boost_flags) -fvisibility=default -fvisibility-inlines-hidden"' >> $(SOURCE)/tools/build/v2/user-config.jam
+	echo '  <linkflags>"-Wl,-syslibroot,$(boost_flags)"' >> $(SOURCE)/tools/build/v2/user-config.jam
+	echo ';' >> $(SOURCE)/tools/build/v2/user-config.jam
 	cd $(SOURCE); patch -p1 < ../add-arm-mem-barrier.patch
 	cd $(SOURCE); patch -p1 < ../fix-deprecated-swp.patch
 	cd $(SOURCE); ./bootstrap.sh --prefix=$(PREFIX) --with-libraries=thread,date_time

--- a/tools/darwin/depends/boost/user-config.jam.in
+++ b/tools/darwin/depends/boost/user-config.jam.in
@@ -1,5 +1,0 @@
-using darwin : @platform_gcc_version@ : g++-@platform_gcc_version@ :
-  <cflags>"-isysroot @boost_flags@ -fvisibility=default -fvisibility-inlines-hidden"
-  <cxxflags>"-isysroot @boost_flags@ -fvisibility=default -fvisibility-inlines-hidden"
-  <linkflags>"-Wl,-syslibroot,@boost_flags@"
-;

--- a/tools/darwin/depends/bootstrap
+++ b/tools/darwin/depends/bootstrap
@@ -1,1 +1,17 @@
+#!/bin/sh
+
+mkdir -p /Users/Shared/xbmc-depends/toolchain
+mkdir -p /Users/Shared/xbmc-depends/tarballs
+export PATH="/Users/Shared/xbmc-depends/toolchain/bin:${PATH}"
+
+# check if we can autoconf
+type -P autoconf &>/dev/null && has_autoconf=yes || has_autoconf=no
+
+if test "$has_autoconf" = "no"; then
+  # if not then prebuild our autoconf.
+  echo "autoconf not found, pre-building autoconf"
+  make -C m4
+  make -C autoconf
+fi
+
 autoconf

--- a/tools/darwin/depends/cmake/Makefile
+++ b/tools/darwin/depends/cmake/Makefile
@@ -5,6 +5,7 @@ APPNAME=cmake
 VERSION=2.8.8
 SOURCE=$(APPNAME)-$(VERSION)
 ARCHIVE=$(SOURCE).tar.gz
+BASE_URL=http://www.cmake.org/files/v2.8
 
 # configuration settings
 export PATH:=$(TOOLCHAIN)/bin:$(PATH)

--- a/tools/darwin/depends/config.site_ios.in
+++ b/tools/darwin/depends/config.site_ios.in
@@ -1,23 +1,38 @@
-host_alias=arm-apple-darwin10
+case @use_xcode@ in
+  3.*.*)
+    platform_cc=gcc-4.2
+    platform_cpp=cpp-4.2
+    platform_cxx=g++-4.2
+    ;;
+  *)
+    platform_cc=llvm-gcc-4.2
+    platform_cpp="llvm-gcc-4.2 -E"
+    platform_cxx=llvm-g++-4.2
+    ;;
+esac
+platform_gnu=gnu99
 platform_gcc_version=4.2
 platform_sdk_version=@use_sdk@
+platform_min_version="iphoneos-version-min=4.2"
+
+host_alias=arm-apple-darwin10
+
 cross_compiling=yes
 
-platform_min_version="iphoneos-version-min=4.1"
-platform_path="/Developer/Platforms/iPhoneOS.platform/Developer"
+platform_path="@use_xcodepath@/Platforms/iPhoneOS.platform/Developer"
 platform_os_cflags="-arch @use_arch@ -mcpu=cortex-a8 -mfpu=neon -ftree-vectorize -mfloat-abi=softfp -pipe -Wno-trigraphs -fpascal-strings -O3 -Wreturn-type -Wunused-variable -fmessage-length=0 -gdwarf-2"
 platform_os_ldflags="-arch @use_arch@ -mcpu=cortex-a8"
-platform_sdk_path="${platform_path}/SDKs/iPhoneOS${platform_sdk_version}.sdk"
+platform_sdk_path=@use_sdk_path@
 
 export NM=${platform_path}/usr/bin/nm
-export CPP=${platform_path}/usr/bin/cpp-${platform_gcc_version}
+export CPP=${platform_path}/usr/bin/${platform_cpp}
 export CXXCPP=${CPP}
 export CPPFLAGS="${CPPFLAGS} -no-cpp-precomp -I${prefix}/include -m${platform_min_version} -isysroot ${platform_sdk_path} ${platform_os_cflags}"
-export CC=${platform_path}/usr/bin/gcc-${platform_gcc_version}
+export CC=${platform_path}/usr/bin/${platform_cc}
 export CFLAGS="${CFLAGS} -std=gnu99 -no-cpp-precomp -m${platform_min_version} -isysroot ${platform_sdk_path} ${platform_os_cflags} -I${platform_sdk_path}/usr/include"
 export LD=${platform_path}/usr/bin/ld
 export LDFLAGS="${LDFLAGS} -m${platform_min_version} -isysroot ${platform_sdk_path} -L${platform_sdk_path}/usr/lib -L${platform_sdk_path}/usr/lib/system ${platform_os_ldflags} -L${prefix}/lib"
-export CXX=${platform_path}/usr/bin/g++-${platform_gcc_version}
+export CXX=${platform_path}/usr/bin/${platform_cxx}
 export CXXFLAGS="${CXXFLAGS} -m${platform_min_version} -isysroot ${platform_sdk_path} ${platform_os_cflags}"
 export AR=${platform_path}/usr/bin/ar
 export AS="@use_toolchain@/bin/gas-preprocessor.pl ${CC}"
@@ -25,7 +40,7 @@ export M4=@use_toolchain@/bin/m4
 export CCAS="--tag CC @use_toolchain@/bin/gas-preprocessor.pl ${CC}"
 export STRIP=${platform_path}/usr/bin/strip
 export RANLIB=${platform_path}/usr/bin/ranlib
-export ACLOCAL="@use_toolchain@/bin/aclocal -I ${prefix}/share/aclocal -I @use_toolchain@/share/aclocal -I /Developer/usr/share/aclocal"
+export ACLOCAL="@use_toolchain@/bin/aclocal -I ${prefix}/share/aclocal -I @use_toolchain@/share/aclocal"
 export LIBTOOL=@use_toolchain@/bin/glibtool
 export LIBTOOLIZE=@use_toolchain@/bin/glibtoolize
 export PKG_CONFIG_PATH=${prefix}/lib/pkgconfig:${platform_sdk_path}/usr/lib/pkgconfig

--- a/tools/darwin/depends/config.site_ios.mk.in
+++ b/tools/darwin/depends/config.site_ios.mk.in
@@ -1,23 +1,36 @@
-host_alias=arm-apple-darwin10
+xcode3_chk=case @use_xcode@ in 3.*.*) echo 1 ;; *) echo 0 ;; esac
+ifeq ($(shell $(xcode3_chk)) , 1)
+  platform_cc=gcc-4.2
+  platform_cpp=cpp-4.2
+  platform_cxx=g++-4.2
+else
+  platform_cc=llvm-gcc-4.2
+  platform_cpp=llvm-gcc-4.2 -E
+  platform_cxx=llvm-g++-4.2
+endif
+platform_gnu=gnu99
 platform_gcc_version=4.2
 platform_sdk_version=@use_sdk@
+platform_min_version=iphoneos-version-min=4.2
+
+host_alias=arm-apple-darwin10
+
 cross_compiling=yes
 
-platform_min_version=iphoneos-version-min=4.1
-platform_path=/Developer/Platforms/iPhoneOS.platform/Developer
+platform_path=@use_xcodepath@/Platforms/iPhoneOS.platform/Developer
 platform_os_cflags=-arch @use_arch@ -mcpu=cortex-a8 -mfpu=neon -ftree-vectorize -mfloat-abi=softfp -pipe -Wno-trigraphs -fpascal-strings -O3 -Wreturn-type -Wunused-variable -fmessage-length=0 -gdwarf-2
 platform_os_ldflags=-arch @use_arch@ -mcpu=cortex-a8
-platform_sdk_path=${platform_path}/SDKs/iPhoneOS${platform_sdk_version}.sdk
+platform_sdk_path=@use_sdk_path@
 
 export NM=${platform_path}/usr/bin/nm
-export CPP=${platform_path}/usr/bin/cpp-${platform_gcc_version}
+export CPP=${platform_path}/usr/bin/${platform_cpp}
 export CXXCPP=${CPP}
 export CPPFLAGS+=-no-cpp-precomp -I${PREFIX}/include -m${platform_min_version} -isysroot ${platform_sdk_path} ${platform_os_cflags}
-export CC=${platform_path}/usr/bin/gcc-${platform_gcc_version}
+export CC=${platform_path}/usr/bin/${platform_cc}
 export CFLAGS+=-std=gnu99 -no-cpp-precomp -m${platform_min_version} -isysroot ${platform_sdk_path} ${platform_os_cflags} -I${platform_sdk_path}/usr/include
 export LD=${platform_path}/usr/bin/ld
 export LDFLAGS+=-m${platform_min_version} -isysroot ${platform_sdk_path} -L${platform_sdk_path}/usr/lib -L${platform_sdk_path}/usr/lib/system ${platform_os_ldflags} -L${PREFIX}/lib
-export CXX=${platform_path}/usr/bin/g++-${platform_gcc_version}
+export CXX=${platform_path}/usr/bin/${platform_cxx}
 export CXXFLAGS+=-m${platform_min_version} -isysroot ${platform_sdk_path} ${platform_os_cflags}
 export AR=${platform_path}/usr/bin/ar
 export AS=@use_toolchain@/bin/gas-preprocessor.pl ${CC}
@@ -25,13 +38,8 @@ export M4=@use_toolchain@/bin/m4
 export CCAS=--tag CC @use_toolchain@/bin/gas-preprocessor.pl ${CC}
 export STRIP=${platform_path}/usr/bin/strip
 export RANLIB=${platform_path}/usr/bin/ranlib
-export ACLOCAL=@use_toolchain@/bin/aclocal -I ${PREFIX}/share/aclocal -I @use_toolchain@/share/aclocal -I /Developer/usr/share/aclocal
+export ACLOCAL=@use_toolchain@/bin/aclocal -I ${PREFIX}/share/aclocal -I @use_toolchain@/share/aclocal
 export LIBTOOL=@use_toolchain@/bin/glibtool
 export LIBTOOLIZE=@use_toolchain@/bin/glibtoolize
 export PKG_CONFIG_PATH=${PREFIX}/lib/pkgconfig:${platform_sdk_path}/usr/lib/pkgconfig
 export PATH:=@use_toolchain@/bin:${PREFIX}/bin:${platform_path}/usr/bin:/Developer/usr/bin:${PATH}
-
-# tweaks for boost
-bjam_args=toolset=darwin-${platform_gcc_version} --architecture=arm target-os=iphone macosx-version=iphone-${platform_sdk_version} define=_LITTLE_ENDIAN
-# arm uses non-thread-safe compare-and-swap instruction so use posix thread primitives
-boost_flags=${platform_sdk_path} -arch @use_arch@ -DBOOST_AC_USE_PTHREADS -DBOOST_SP_USE_PTHREADS

--- a/tools/darwin/depends/config.site_osx.in
+++ b/tools/darwin/depends/config.site_osx.in
@@ -5,41 +5,60 @@ if test "@use_sdk@" = "10.4" ; then
   else
     host_alias=i386-apple-darwin8
   fi
+  platform_gnu=gnu89
+  platform_cc=gcc-4.0
+  platform_cpp=cpp-4.0
+  platform_cxx=g++-4.0
   platform_gcc_version=4.0
   platform_sdk_version=@use_sdk@u
+  export MACOSX_DEPLOYMENT_TARGET=10.4
+  platform_min_version=macosx-version-min=10.4
 else
-  host_alias=i686-apple-darwin
+  case @use_xcode@ in
+    3.*.*)
+      platform_cc=gcc-4.2
+      platform_cpp=cpp-4.2
+      platform_cxx=g++-4.2
+      ;;
+    *)
+      platform_cc=llvm-gcc-4.2
+      platform_cpp="llvm-gcc-4.2 -E"
+      platform_cxx=llvm-g++-4.2
+      ;;
+  esac
+  platform_gnu=gnu99
   platform_gcc_version=4.2
   platform_sdk_version=@use_sdk@
+  host_alias=@use_arch@-apple-darwin
+  export MACOSX_DEPLOYMENT_TARGET=10.6
+  platform_min_version=macosx-version-min=10.6
 fi
 
-platform_min_version=macosx-version-min=10.4
-platform_path="/Developer"
+platform_path=@use_xcodepath@
 platform_os_cflags="-arch @use_arch@ -no_compact_linkedit"
 platform_os_ldflags="-arch @use_arch@ -Wl,-arch,@use_arch@ -no_compact_linkedit"
-platform_sdk_path="${platform_path}/SDKs/MacOSX${platform_sdk_version}.sdk"
+platform_sdk_path=@use_sdk_path@
 
 export NM=${platform_path}/usr/bin/nm
-export CPP=${platform_path}/usr/bin/cpp-${platform_gcc_version}
+export CPP=${platform_path}/usr/bin/${platform_cpp}
 export CXXCPP=${CPP}
 export CPPFLAGS="${CPPFLAGS} -no-cpp-precomp -I${prefix}/include -m${platform_min_version} -isysroot ${platform_sdk_path} ${platform_os_cflags}"
-export CC=/usr/bin/gcc-${platform_gcc_version}
-export CFLAGS="${CFLAGS} -std=gnu89 -no-cpp-precomp -m${platform_min_version} -isysroot ${platform_sdk_path} ${platform_os_cflags}"
+export CC=/usr/bin/${platform_cc}
+export CFLAGS="${CFLAGS} -std=${platform_gnu} -no-cpp-precomp -m${platform_min_version} -isysroot ${platform_sdk_path} ${platform_os_cflags}"
 export LD=${platform_path}/usr/bin/ld
 export LDFLAGS="${LDFLAGS} -m${platform_min_version} -isysroot ${platform_sdk_path} ${platform_os_ldflags} -L${prefix}/lib"
-export CXX=/usr/bin/g++-${platform_gcc_version}
+export CXX=/usr/bin/${platform_cxx}
 export CXXFLAGS="${CXXFLAGS} -m${platform_min_version} -isysroot ${platform_sdk_path} ${platform_os_cflags}"
 export AR=${platform_path}/usr/bin/ar
 export AS=${platform_path}/usr/bin/as
 export M4=@use_toolchain@/bin/m4
 export STRIP=${platform_path}/usr/bin/strip
 export RANLIB=${platform_path}/usr/bin/ranlib
-export ACLOCAL="@use_toolchain@/bin/aclocal -I ${prefix}/share/aclocal -I @use_toolchain@/share/aclocal -I /Developer/usr/share/aclocal"
+export ACLOCAL="@use_toolchain@/bin/aclocal -I ${prefix}/share/aclocal -I @use_toolchain@/share/aclocal"
 export LIBTOOL=@use_toolchain@/bin/glibtool
 export LIBTOOLIZE=@use_toolchain@/bin/glibtoolize
 export PKG_CONFIG_PATH=${prefix}/lib/pkgconfig:${platform_sdk_path}/usr/lib/pkgconfig
 export PATH="@use_toolchain@/bin:${prefix}/bin:${platform_path}/usr/bin:/Developer/usr/bin:${PATH}"
-export MACOSX_DEPLOYMENT_TARGET=10.4
 
 # tweaks for samba
 if test "${PACKAGE_NAME}" = "Samba" ; then
@@ -58,6 +77,11 @@ fi
 # tweaks for python
 if test "${PACKAGE_NAME}" = "python" ; then
   export OPT="${CFLAGS}"
+fi
+
+# tweaks for libogg / libvorbis
+if test "${PACKAGE_NAME}" = "libogg" || test "${PACKAGE_NAME}" = "libvorbis" ; then
+  export CFLAGS="${CFLAGS} -O"
 fi
 
 # tweaks for libjpeg-turbo

--- a/tools/darwin/depends/config.site_osx.mk.in
+++ b/tools/darwin/depends/config.site_osx.mk.in
@@ -4,47 +4,55 @@ ifeq ("@use_sdk@", "10.4")
   else
     host_alias=i386-apple-darwin8
   endif
+  platform_gnu=gnu89
+  platform_cc=gcc-4.0
+  platform_cpp=cpp-4.0
+  platform_cxx=g++-4.0
   platform_gcc_version=4.0
   platform_sdk_version=@use_sdk@u
-else
-  host_alias=i686-apple-darwin
+  export MACOSX_DEPLOYMENT_TARGET=10.4
+  platform_min_version=macosx-version-min=10.4
+else 
+  xcode3_chk=case @use_xcode@ in 3.*.*) echo 1 ;; *) echo 0 ;; esac
+  ifeq ($(shell $(xcode3_chk)) , 1)
+    platform_cc=gcc-4.2
+    platform_cpp=cpp-4.2
+    platform_cxx=g++-4.2
+  else
+    platform_cc=llvm-gcc-4.2
+    platform_cpp=llvm-gcc-4.2 -E
+    platform_cxx=llvm-g++-4.2
+  endif
+  platform_gnu=gnu99
   platform_gcc_version=4.2
   platform_sdk_version=@use_sdk@
+  host_alias=@use_arch@-apple-darwin
+  export MACOSX_DEPLOYMENT_TARGET=10.6
+  platform_min_version=macosx-version-min=10.6
 endif
 
-platform_min_version=macosx-version-min=10.4
-platform_path=/Developer
+platform_path=@use_xcodepath@
 platform_os_cflags=-arch @use_arch@ -no_compact_linkedit
 platform_os_ldflags=-arch @use_arch@ -no_compact_linkedit
-platform_sdk_path=${platform_path}/SDKs/MacOSX${platform_sdk_version}.sdk
+platform_sdk_path=@use_sdk_path@
 
 export NM=${platform_path}/usr/bin/nm
-export CPP=${platform_path}/usr/bin/cpp-${platform_gcc_version}
+export CPP=${platform_path}/usr/bin/${platform_cpp}
 export CXXCPP=${CPP}
 export CPPFLAGS+=-no-cpp-precomp -I${PREFIX}/include -m${platform_min_version} -isysroot ${platform_sdk_path} ${platform_os_cflags}
-export CC=/usr/bin/gcc-${platform_gcc_version}
-export CFLAGS+=-std=gnu89 -no-cpp-precomp -m${platform_min_version} -isysroot ${platform_sdk_path} ${platform_os_cflags}
+export CC=/usr/bin/${platform_cc}
+export CFLAGS+=-std=${platform_gnu} -no-cpp-precomp -m${platform_min_version} -isysroot ${platform_sdk_path} ${platform_os_cflags}
 export LD=${platform_path}/usr/bin/ld
 export LDFLAGS+=-m${platform_min_version} -isysroot ${platform_sdk_path} ${platform_os_ldflags} -L${PREFIX}/lib
-export CXX=/usr/bin/g++-${platform_gcc_version}
+export CXX=/usr/bin/${platform_cxx}
 export CXXFLAGS+=-m${platform_min_version} -isysroot ${platform_sdk_path} ${platform_os_cflags}
 export AR=${platform_path}/usr/bin/ar
 export AS=${platform_path}/usr/bin/as
 export M4=@use_toolchain@/bin/m4
 export STRIP=${platform_path}/usr/bin/strip
 export RANLIB=${platform_path}/usr/bin/ranlib
-export ACLOCAL=@use_toolchain@/bin/aclocal -I ${PREFIX}/share/aclocal -I @use_toolchain@/share/aclocal -I /Developer/usr/share/aclocal
+export ACLOCAL=@use_toolchain@/bin/aclocal -I ${PREFIX}/share/aclocal -I @use_toolchain@/share/aclocal
 export LIBTOOL=@use_toolchain@/bin/glibtool
 export LIBTOOLIZE=@use_toolchain@/bin/glibtoolize
 export PKG_CONFIG_PATH=${PREFIX}/lib/pkgconfig:${platform_sdk_path}/usr/lib/pkgconfig
 export PATH:=@use_toolchain@/bin:${PREFIX}/bin:${platform_path}/usr/bin:/Developer/usr/bin:${PATH}
-export MACOSX_DEPLOYMENT_TARGET=10.4
-
-# tweaks for boost
-ifeq ("@use_arch@", "ppc")
-  boost_architecture=power
-else
-  boost_architecture=x86
-endif
-bjam_args=toolset=darwin-${platform_gcc_version} --architecture=${boost_architecture} address-model=32 target-os=darwin --link=static
-boost_flags=${platform_sdk_path} -arch @use_arch@

--- a/tools/darwin/depends/configure.in
+++ b/tools/darwin/depends/configure.in
@@ -1,11 +1,5 @@
 AC_PREREQ(2.59)
-AC_INIT([darwin-depends], [1.00], [http://trac.xbmc.org])
-
-AC_ARG_WITH([staging],
-  [AS_HELP_STRING([--with-staging],
-  [depends build location (/Users/Shared/xbmc-depends).])],
-  [use_staging=$withval],
-  [use_staging="/Users/Shared/xbmc-depends"])
+AC_INIT([darwin-depends], [2.00], [http://trac.xbmc.org])
 
 AC_ARG_WITH([darwin],
   [AS_HELP_STRING([--with-darwin],
@@ -20,43 +14,55 @@ AC_ARG_WITH([arch],
 
 AC_ARG_WITH([sdk],
   [AS_HELP_STRING([--with-sdk],
-  [build depend libs using sdk 10.4 (default osx) or 4.2 (default ios).])],
+  [build depend libs using sdk 10.6 (default osx) or 4.2 (default ios).])],
   [use_sdk=$withval],)
+
+use_staging="/Users/Shared/xbmc-depends"
+
+# find xcodebuild, test in Xcode.app, if not there, fall back to normal location
+use_xcodepath="/Applications/Xcode.app/Contents/Developer"
+use_xcodebuild="/Applications/Xcode.app/Contents/Developer/usr/bin/xcodebuild"
+if [[ ! -f "$use_xcodebuild" ]]; then
+  use_xcodepath="/Developer"
+  use_xcodebuild="/usr/bin/xcodebuild"  
+fi
+AC_MSG_RESULT(found xcodebuild at $use_xcodebuild)
+use_xcode=[`$use_xcodebuild -version | grep Xcode | awk '{ print $2}'`]
 
 OUTPUT_FILES="Makefile Makefile.include"
 case $use_darwin in
   osx)
      use_arch="${use_arch:-i386}"
-     use_sdk="${use_sdk:-10.4}"
-     use_prefix=${use_staging}/${use_darwin}-${use_sdk}_${use_arch}
      if test "$use_arch" = "armv7"; then
        AC_MSG_ERROR(error in configure of --with-arch=$use_arch)
      fi
+     found_sdk_version=[`$use_xcodebuild -showsdks | grep macosx | sort | tail -n 1 | awk '{ print $4}'`]
+     use_sdk="${use_sdk:-$found_sdk_version}"
      case $use_sdk in
      10.*);;
      *)
        AC_MSG_ERROR(error in configure of --with-sdk=$use_sdk)
      esac
+     sdk_name=macosx$use_sdk
+     use_prefix=${use_staging}/${sdk_name}_${use_arch}
      CONFIG_SITE=" [config.site:config.site_osx.in]"
      MK_CONFIG_SITE=" [config.site.mk:config.site_osx.mk.in]"
      ;;
   ios)
-     found_sdk=`xcodebuild -showsdks | grep iphoneos | sort | tail -n 1 | awk '{ print $2}'`
      use_arch="${use_arch:-armv7}"
-     use_sdk="${use_sdk:-$found_sdk}"
-     # this is an issue. if we set prefix according to ${use_sdk}_${use_arch}, 
-     # then XBMC_DEPENDS prefix location in xcode must match but xcode uses its
-     # own defines for build. So just hardcode to 4.2_${use_arch} for now until we
-     # can figure out a better way.
-     use_prefix=${use_staging}/${use_darwin}-4.2_${use_arch}
      if test "$use_arch" != "armv7"; then
        AC_MSG_ERROR(error in configure of --with-arch=$use_arch)
      fi
+     found_sdk_version=[`$use_xcodebuild -showsdks | grep iphoneos | sort | tail -n 1 | awk '{ print $2}'`]
+     use_sdk="${use_sdk:-$found_sdk_version}"
      case $use_sdk in
      4.*);;
+     5.*);;
      *)
        AC_MSG_ERROR(error in configure of --with-sdk=$use_sdk)
      esac
+     sdk_name=iphoneos$use_sdk
+     use_prefix=${use_staging}/${sdk_name}_${use_arch}
      CONFIG_SITE=" [config.site:config.site_ios.in]"
      MK_CONFIG_SITE=" [config.site.mk:config.site_ios.mk.in]"
      ;;
@@ -65,7 +71,10 @@ case $use_darwin in
      ;;
 esac
 
-AC_MSG_RESULT(configuring for darwin $use_darwin-$use_sdk-$use_arch)
+use_sdk_path=[`$use_xcodebuild -version -sdk $sdk_name | grep ^Path | awk '{ print $2}'`]
+
+AC_MSG_RESULT(configuring for darwin $sdk_name)
+AC_MSG_RESULT(using the sdk path of $use_sdk_path)
 AC_MSG_RESULT(creating hostroot at $use_staging)
 
 OUTPUT_FILES+=${CONFIG_SITE}
@@ -87,12 +96,16 @@ mkdir -p ${use_prefix}/share/aclocal
 mkdir -p ${use_prefix}/include
 
 
-AC_SUBST(use_toolchain)
-AC_SUBST(use_staging)
-AC_SUBST(use_prefix)
-AC_SUBST(use_darwin)
-AC_SUBST(use_arch)
+AC_SUBST(use_xcode)
+AC_SUBST(use_xcodepath)
+
 AC_SUBST(use_sdk)
+AC_SUBST(use_arch)
+AC_SUBST(use_darwin)
+AC_SUBST(use_prefix)
+AC_SUBST(use_staging)
+AC_SUBST(use_sdk_path)
+AC_SUBST(use_toolchain)
 
 AC_CONFIG_FILES([${OUTPUT_FILES}])
 

--- a/tools/darwin/depends/libflac/Makefile
+++ b/tools/darwin/depends/libflac/Makefile
@@ -25,7 +25,7 @@ $(SOURCE): $(TARBALLS_LOCATION)/$(ARCHIVE)
 	echo $(SOURCE) > .gitignore
 	cd $(SOURCE); $(CONFIGURE)
 	if test "$(DARWIN)" = "ios"; then \
-		sed -i "" -e "s|CC -dynamiclib|CC -arch armv7 -dynamiclib|" "$(SOURCE)/libtool"; \
+		sed -ie "s|CC -dynamiclib|CC -arch armv7 -dynamiclib|" "$(SOURCE)/libtool"; \
 	fi
 
 $(LIBDYLIB): $(SOURCE)

--- a/tools/darwin/depends/libtool/Makefile
+++ b/tools/darwin/depends/libtool/Makefile
@@ -1,4 +1,4 @@
-include ../Makefile.include
+include ../Makefile.buildtools
 
 # lib name, version
 APPNAME=libtool

--- a/tools/darwin/depends/m4/Makefile
+++ b/tools/darwin/depends/m4/Makefile
@@ -1,4 +1,4 @@
-include ../Makefile.include
+include ../Makefile.buildtools
 
 # lib name, version
 APPNAME=m4

--- a/tools/darwin/depends/sqlite3/Makefile
+++ b/tools/darwin/depends/sqlite3/Makefile
@@ -2,9 +2,10 @@ include ../Makefile.include
 
 # lib name, version
 LIBNAME=sqlite
-VERSION=3.6.11
-SOURCE=$(LIBNAME)-$(VERSION)
-ARCHIVE=$(SOURCE).tar.gz
+VERSION=3.7.7.1
+SOURCE=sqlite-autoconf-3070701
+ARCHIVE=sqlite-autoconf-3070701.tar.gz
+BASE_URL=http://www.sqlite.org
 
 # configuration settings
 export CXXFLAGS+=-DSQLITE_ENABLE_COLUMN_METADATA=1

--- a/tools/darwin/depends/xbmc/Makefile
+++ b/tools/darwin/depends/xbmc/Makefile
@@ -5,6 +5,7 @@ SOURCE=../../../../
 # configuration settings
 export PATH:=$(TOOLCHAIN)/bin:$(PREFIX)/bin:$(PATH)
 CONFIGURE=./configure --prefix=$(PREFIX) \
+  --disable-rsxs \
   PKG_CONFIG_PATH=$(PREFIX)/lib/pkgconfig \
   PYTHON=$(PREFIX)/bin/python
 

--- a/xbmc/cores/AudioEngine/Engines/CoreAudioAEHALOSX.cpp
+++ b/xbmc/cores/AudioEngine/Engines/CoreAudioAEHALOSX.cpp
@@ -35,6 +35,8 @@
 #include "settings/Settings.h"
 #include "settings/AdvancedSettings.h"
 
+#include <CoreServices/CoreServices.h>
+
 const char* g_ChannelLabels[] =
 {
   "Unused", // kAudioChannelLabel_Unused

--- a/xbmc/cores/AudioEngine/Engines/CoreAudioAEHALOSX.h
+++ b/xbmc/cores/AudioEngine/Engines/CoreAudioAEHALOSX.h
@@ -25,6 +25,7 @@
 #include "ICoreAudioAEHAL.h"
 #include "ICoreAudioSource.h"
 
+#include <CoreAudio/CoreAudio.h>
 #include <AudioUnit/AudioUnit.h>
 #include <AudioToolbox/AudioToolbox.h>
 #include <AudioToolbox/AUGraph.h>
@@ -73,7 +74,7 @@ class CCoreAudioHardware
 public:
   static bool GetAutoHogMode();
   static void SetAutoHogMode(bool enable);
-  static AudioStreamBasicDescription *CCoreAudioHardware::FormatsList(AudioStreamID stream);
+  static AudioStreamBasicDescription *FormatsList(AudioStreamID stream);
   static AudioStreamID *StreamsList(AudioDeviceID device);
   static void ResetAudioDevices();
   static void ResetStream(AudioStreamID stream);

--- a/xbmc/utils/MathUtils.h
+++ b/xbmc/utils/MathUtils.h
@@ -70,7 +70,7 @@ namespace MathUtils
       sar i, 1
     }
 #else
-#if defined(__powerpc__) || defined(__ppc__) || defined(__ARM_PCS_VFP)
+#if defined(__powerpc__) || defined(__ppc__) || defined(__ARM_PCS_VFP) || defined(TARGET_DARWIN_OSX)
     i = floor(x + round_to_nearest);
 #elif defined(__arm__)
     // From 'ARM®v7-M Architecture Reference Manual' page A7-569:
@@ -135,7 +135,7 @@ namespace MathUtils
     assert(x > static_cast<double>(INT_MIN / 2) - 1.0);
     assert(x < static_cast <double>(INT_MAX / 2) + 1.0);
 
-#if !defined(__powerpc__) && !defined(__ppc__) && !defined(__arm__)
+#if !defined(__powerpc__) && !defined(__ppc__) && !defined(__arm__) && !defined(TARGET_DARWIN_OSX)
     const float round_towards_m_i = -0.5f;
 #endif
     int i;
@@ -151,7 +151,7 @@ namespace MathUtils
       sar i, 1
     }
 #else
-#if defined(__powerpc__) || defined(__ppc__)
+#if defined(__powerpc__) || defined(__ppc__) || defined(TARGET_DARWIN_OSX)
     return (int)x;
 #elif defined(__arm__)
     __asm__ __volatile__ (


### PR DESCRIPTION
With a fond farewell, we say goodbye to atv1(osx) and ppc with a switchover to targeting 10.6 sdk as our new min os verison for OSX. Also iOS min gets bumped to 4.2 from 4.1.

This change will also allow us to move forward to running the build under Xcode4 and 10.7.

Note a big warning, depends will need to be completely rebuilt as are are paths changes involved, rebuild and do not try to rename the dirs :)
