### PR TITLE
CURL::IsFullPath() should return true for UNC paths, which seem to work

### DIFF
--- a/xbmc/URL.cpp
+++ b/xbmc/URL.cpp
@@ -656,6 +656,7 @@ bool CURL::IsFullPath(const CStdString &url)
   if (url.size() && url[0] == '/') return true;     //   /foo/bar.ext
   if (url.Find("://") >= 0) return true;                 //   foo://bar.ext
   if (url.size() > 1 && url[1] == ':') return true; //   c:\\foo\\bar\\bar.ext
+  if (url.compare(0,2,"\\\\") == 0) return true;    //   \\UNC\path\to\file
   return false;
 }
 


### PR DESCRIPTION
Pretty straightforward.  UNC paths can be added to XBMC as sources, and seem to work OK, possibly by coincidence (they drop through to SetFileName() on the complete path in Parse()).

However, IsFullPath() returns false on them currently, which is clearly wrong, breaking things like thumbs which use the IsFullPath() check to see whether it should append the folder/file onto the cached path etc.

@elupus mind having a quick look?
