### PR TITLE
Give skins access to idAlbum and idArtist from database

### DIFF
--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -4900,6 +4900,7 @@ void CMusicDatabase::SetPropertiesFromArtist(CFileItem& item, const CArtist& art
   item.SetProperty("artist_disbanded", artist.strDisbanded);
   item.SetProperty("artist_yearsactive", StringUtils::Join(artist.yearsActive, g_advancedSettings.m_musicItemSeparator));
   item.SetProperty("artist_yearsactive_array", artist.yearsActive);
+  item.SetProperty("artist_id", (int)artist.idArtist);
 }
 
 void CMusicDatabase::SetPropertiesFromAlbum(CFileItem& item, const CAlbum& album)
@@ -4918,6 +4919,7 @@ void CMusicDatabase::SetPropertiesFromAlbum(CFileItem& item, const CAlbum& album
   item.SetProperty("album_genre", StringUtils::Join(album.genre, g_advancedSettings.m_musicItemSeparator));
   item.SetProperty("album_genre_array", album.genre);
   item.SetProperty("album_title", album.strAlbum);
+  item.SetProperty("album_id", (int)album.idAlbum);
   if (album.iRating > 0)
     item.SetProperty("album_rating", album.iRating);
 }


### PR DESCRIPTION
This PR give skins two new ListItem.Property options, ListItem.Property(Artist_Id) and ListItem.Property(Album_Id).   Though skins have no real use of the database IDs but addons do.  This permits the skin to send the database ID to an addon permitting very acurate database access, since addons only should access the database through JSON-RPC and JSON-RPC uses IDs to access the database.(AudioLibrary.GetAlbumDetails for example)  
