### PR TITLE
Add graceful checks to avoid hitting several AE asserts

### DIFF
--- a/xbmc/cores/AudioEngine/Interfaces/AE.h
+++ b/xbmc/cores/AudioEngine/Interfaces/AE.h
@@ -103,6 +103,10 @@ public:
 
   /**
    * Creates and returns a new IAEStream in the format specified, this function should never fail
+   *
+   * It is the caller's responsibility to check that the channelLayout is valid,
+   * it will not be validated (calling with empty layout can cause a crash).
+   *
    * @param dataFormat The data format the incoming audio will be in (eg, AE_FMT_S16LE)
    * @param sampleRate The sample rate of the audio data (eg, 48000)
    * @prarm encodedSampleRate The sample rate of the encoded audio data if AE_IS_RAW(dataFormat)

--- a/xbmc/cores/AudioEngine/Interfaces/AE.h
+++ b/xbmc/cores/AudioEngine/Interfaces/AE.h
@@ -106,6 +106,7 @@ public:
    *
    * It is the caller's responsibility to check that the channelLayout is valid,
    * it will not be validated (calling with empty layout can cause a crash).
+   * encodedSampleRate has to be set for raw formats. It will not be validated.
    *
    * @param dataFormat The data format the incoming audio will be in (eg, AE_FMT_S16LE)
    * @param sampleRate The sample rate of the audio data (eg, 48000)

--- a/xbmc/cores/dvdplayer/DVDAudio.cpp
+++ b/xbmc/cores/dvdplayer/DVDAudio.cpp
@@ -64,6 +64,20 @@ bool CDVDAudio::Create(const DVDAudioFrame &audioframe, CodecID codec, bool need
     audioframe.passthrough ? "pass-through" : "no pass-through"
   );
 
+  if ((int)audioframe.channel_layout.Count() != audioframe.channel_count)
+  {
+    CLog::Log(LOGERROR,
+      "Not creating an audio stream with incorrect channel layout (layout has %d channels, stream has %d channels)",
+      audioframe.channel_layout.Count(), audioframe.channel_count);
+    return false;
+  }
+
+  if (audioframe.channel_count == 0)
+  {
+    CLog::Log(LOGERROR, "Not creating an empty audio stream");
+    return false;
+  }
+
   // if passthrough isset do something else
   CSingleLock lock(m_critSection);
   unsigned int options = needresampler && !audioframe.passthrough ? AESTREAM_FORCE_RESAMPLE : 0;

--- a/xbmc/cores/dvdplayer/DVDAudio.cpp
+++ b/xbmc/cores/dvdplayer/DVDAudio.cpp
@@ -78,6 +78,12 @@ bool CDVDAudio::Create(const DVDAudioFrame &audioframe, CodecID codec, bool need
     return false;
   }
 
+  if (audioframe.passthrough && !audioframe.encoded_sample_rate)
+  {
+    CLog::Log(LOGERROR, "Not creating a passthrough audio stream without known encoded sample rate");
+    return false;
+  }
+
   // if passthrough isset do something else
   CSingleLock lock(m_critSection);
   unsigned int options = needresampler && !audioframe.passthrough ? AESTREAM_FORCE_RESAMPLE : 0;

--- a/xbmc/cores/paplayer/PAPlayer.cpp
+++ b/xbmc/cores/paplayer/PAPlayer.cpp
@@ -316,6 +316,12 @@ inline bool PAPlayer::PrepareStream(StreamInfo *si)
   if (si->m_stream)
     return true;
 
+  if (si->m_channelInfo.Count() == 0)
+  {
+    CLog::Log(LOGERROR, "PAPlayer::PrepareStream - Not creating an empty audio stream");
+    return false;
+  }
+
   /* get a paused stream */
   si->m_stream = CAEFactory::AE->MakeStream(
     si->m_dataFormat,


### PR DESCRIPTION
CSoftAE will assert when trying to create a stream with an empty layout or with raw stream type but without specified encoded sample rate, but these cases weren't actually checked anywhere.

These commits fix those issues by adding checks in dvdplayer and paplayer for those cases, and by adding notes in AE documentation that these need to be checked by the caller.

Note: I would've preferred that MakeStream() would check these things itself and bail out gracefully, but @DDDamian insisted that it isn't its responsibility. Do you agree with him?
If not, I will redo the patchset with my preferred solution of checking these in AE MakeStream() instead.
