### PR TITLE
[WIN32] replace SDL Joystick by DirectInput

### DIFF
--- a/project/VS2010Express/XBMC.vcxproj
+++ b/project/VS2010Express/XBMC.vcxproj
@@ -573,9 +573,9 @@
     <ClCompile Include="..\..\xbmc\input\KeyboardLayoutConfiguration.cpp" />
     <ClCompile Include="..\..\xbmc\input\KeyboardStat.cpp" />
     <ClCompile Include="..\..\xbmc\input\MouseStat.cpp" />
-    <ClCompile Include="..\..\xbmc\input\SDLJoystick.cpp" />
     <ClCompile Include="..\..\xbmc\input\windows\IRServerSuite.cpp" />
     <ClCompile Include="..\..\xbmc\input\windows\IrssMessage.cpp" />
+    <ClCompile Include="..\..\xbmc\input\windows\WINJoystick.cpp" />
     <ClCompile Include="..\..\xbmc\input\XBMC_keytable.cpp" />
     <ClCompile Include="..\..\xbmc\interfaces\AnnouncementManager.cpp" />
     <ClCompile Include="..\..\xbmc\interfaces\Builtins.cpp" />
@@ -929,6 +929,7 @@
     <ClInclude Include="..\..\xbmc\filesystem\ImageFile.h" />
     <ClInclude Include="..\..\xbmc\filesystem\windows\WINFileSMB.h" />
     <ClInclude Include="..\..\xbmc\filesystem\windows\WINSMBDirectory.h" />
+    <ClInclude Include="..\..\xbmc\input\windows\WINJoystick.h" />
     <ClInclude Include="..\..\xbmc\interfaces\python\xbmcmodule\pythreadstate.h" />
     <ClInclude Include="..\..\xbmc\network\httprequesthandler\HTTPImageHandler.h" />
     <ClInclude Include="..\..\xbmc\network\AirTunesServer.h" />
@@ -1615,7 +1616,6 @@
     <ClInclude Include="..\..\xbmc\input\KeyboardLayoutConfiguration.h" />
     <ClInclude Include="..\..\xbmc\input\KeyboardStat.h" />
     <ClInclude Include="..\..\xbmc\input\MouseStat.h" />
-    <ClInclude Include="..\..\xbmc\input\SDLJoystick.h" />
     <ClInclude Include="..\..\xbmc\input\windows\IRServerSuite.h" />
     <ClInclude Include="..\..\xbmc\input\windows\IrssMessage.h" />
     <ClInclude Include="..\..\xbmc\input\XBIRRemote.h" />

--- a/project/VS2010Express/XBMC.vcxproj.filters
+++ b/project/VS2010Express/XBMC.vcxproj.filters
@@ -1171,9 +1171,6 @@
     <ClCompile Include="..\..\xbmc\input\MouseStat.cpp">
       <Filter>input</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\xbmc\input\SDLJoystick.cpp">
-      <Filter>input</Filter>
-    </ClCompile>
     <ClCompile Include="..\..\xbmc\input\windows\IRServerSuite.cpp">
       <Filter>input\windows</Filter>
     </ClCompile>
@@ -2578,6 +2575,9 @@
     <ClCompile Include="..\..\xbmc\utils\RecentlyAddedJob.cpp">
       <Filter>utils</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\xbmc\input\windows\WINJoystick.cpp">
+      <Filter>input\windows</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\xbmc\filesystem\ImageFile.cpp">
       <Filter>filesystem</Filter>
     </ClCompile>
@@ -3696,9 +3696,6 @@
       <Filter>input</Filter>
     </ClInclude>
     <ClInclude Include="..\..\xbmc\input\MouseStat.h">
-      <Filter>input</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\xbmc\input\SDLJoystick.h">
       <Filter>input</Filter>
     </ClInclude>
     <ClInclude Include="..\..\xbmc\input\XBIRRemote.h">
@@ -5201,6 +5198,9 @@
     <ClInclude Include="..\..\xbmc\BackgroundInfoLoader.h" />
     <ClInclude Include="..\..\xbmc\utils\RecentlyAddedJob.h">
       <Filter>utils</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\xbmc\input\windows\WINJoystick.h">
+      <Filter>input\windows</Filter>
     </ClInclude>
     <ClInclude Include="..\..\xbmc\filesystem\ImageFile.h">
       <Filter>filesystem</Filter>

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -319,6 +319,12 @@
   #include "input/windows/IRServerSuite.h"
 #endif
 
+#if defined(TARGET_WINDOWS)
+#include "input/windows/WINJoystick.h"
+#elif defined(HAS_SDL_JOYSTICK) || defined(HAS_EVENT_SERVER)
+#include "input/SDLJoystick.h"
+#endif
+
 using namespace std;
 using namespace ADDON;
 using namespace XFILE;

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -652,7 +652,7 @@ bool CApplication::Create()
   sdlFlags |= SDL_INIT_VIDEO;
 #endif
 
-#ifdef HAS_SDL_JOYSTICK
+#if defined(HAS_SDL_JOYSTICK) && !defined(TARGET_WINDOWS)
   sdlFlags |= SDL_INIT_JOYSTICK;
 #endif
 
@@ -778,9 +778,6 @@ bool CApplication::Create()
 #if defined(HAS_LIRC) || defined(HAS_IRSERVERSUITE)
   g_RemoteControl.Initialize();
 #endif
-#ifdef HAS_SDL_JOYSTICK
-  g_Joystick.Initialize();
-#endif
 
 #if defined(__APPLE__) && !defined(__arm__)
   // Configure and possible manually start the helper.
@@ -856,6 +853,10 @@ bool CApplication::Create()
   g_windowManager.Initialize();
 
   CUtil::InitRandomSeed();
+
+#ifdef HAS_SDL_JOYSTICK
+  g_Joystick.Initialize();
+#endif
 
   g_mediaManager.Initialize();
 

--- a/xbmc/input/ButtonTranslator.cpp
+++ b/xbmc/input/ButtonTranslator.cpp
@@ -35,6 +35,12 @@
 #include "utils/XBMCTinyXML.h"
 #include "XBIRRemote.h"
 
+#if defined(TARGET_WINDOWS)
+#include "input/windows/WINJoystick.h"
+#elif defined(HAS_SDL_JOYSTICK) || defined(HAS_EVENT_SERVER)
+#include "SDLJoystick.h"
+#endif
+
 using namespace std;
 using namespace XFILE;
 

--- a/xbmc/input/ButtonTranslator.h
+++ b/xbmc/input/ButtonTranslator.h
@@ -31,12 +31,6 @@
 #include "network/EventClient.h"
 #endif
 
-#if defined(TARGET_WINDOWS)
-#include "input/windows/WINJoystick.h"
-#elif defined(HAS_SDL_JOYSTICK) || defined(HAS_EVENT_SERVER)
-#include "SDLJoystick.h"
-#endif
-
 class CKey;
 class CAction;
 class TiXmlNode;

--- a/xbmc/input/ButtonTranslator.h
+++ b/xbmc/input/ButtonTranslator.h
@@ -31,7 +31,9 @@
 #include "network/EventClient.h"
 #endif
 
-#if defined(HAS_SDL_JOYSTICK) || defined(HAS_EVENT_SERVER)
+#if defined(TARGET_WINDOWS)
+#include "input/windows/WINJoystick.h"
+#elif defined(HAS_SDL_JOYSTICK) || defined(HAS_EVENT_SERVER)
 #include "SDLJoystick.h"
 #endif
 

--- a/xbmc/input/windows/WINJoystick.cpp
+++ b/xbmc/input/windows/WINJoystick.cpp
@@ -1,0 +1,477 @@
+/*
+*      Copyright (C) 2012 Team XBMC
+*      http://www.xbmc.org
+*
+*  This Program is free software; you can redistribute it and/or modify
+*  it under the terms of the GNU General Public License as published by
+*  the Free Software Foundation; either version 2, or (at your option)
+*  any later version.
+*
+*  This Program is distributed in the hope that it will be useful,
+*  but WITHOUT ANY WARRANTY; without even the implied warranty of
+*  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+*  GNU General Public License for more details.
+*
+*  You should have received a copy of the GNU General Public License
+*  along with XBMC; see the file COPYING.  If not, write to
+*  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+*  http://www.gnu.org/copyleft/gpl.html
+*
+*/
+
+#include "WINJoystick.h"
+#include "input/ButtonTranslator.h"
+#include "settings/AdvancedSettings.h"
+#include "utils/log.h"
+
+#include <math.h>
+
+#include <dinput.h>
+#include <dinputd.h>
+
+using namespace std;
+
+CJoystick g_Joystick; // global
+
+extern HWND g_hWnd;
+
+#define MAX_AXISAMOUNT  32768
+#define AXIS_MIN       -32768  /* minimum value for axis coordinate */
+#define AXIS_MAX        32767  /* maximum value for axis coordinate */
+
+#if !defined(HAS_SDL)
+#define SDL_HAT_CENTERED    0x00
+#define SDL_HAT_UP          0x01
+#define SDL_HAT_RIGHT       0x02
+#define SDL_HAT_DOWN        0x04
+#define SDL_HAT_LEFT        0x08
+#define SDL_HAT_RIGHTUP     (SDL_HAT_RIGHT|SDL_HAT_UP)
+#define SDL_HAT_RIGHTDOWN   (SDL_HAT_RIGHT|SDL_HAT_DOWN)
+#define SDL_HAT_LEFTUP      (SDL_HAT_LEFT|SDL_HAT_UP)
+#define SDL_HAT_LEFTDOWN    (SDL_HAT_LEFT|SDL_HAT_DOWN)
+#endif
+
+CJoystick::CJoystick()
+{
+  Reset();
+  m_NumAxes = 0;
+  m_AxisId = 0;
+  m_JoyId = 0;
+  m_ButtonId = 0;
+  m_HatId = 0;
+  m_HatState = SDL_HAT_CENTERED;
+  m_ActiveFlags = JACTIVE_NONE;
+  for (int i = 0 ; i<MAX_AXES ; i++)
+    m_Amount[i] = 0;
+  SetDeadzone(0);
+
+  m_pDI = NULL;
+  m_lastPressTicks = 0;
+  m_lastTicks = 0;
+}
+
+CJoystick::~CJoystick()
+{
+  ReleaseJoysticks();
+}
+
+void CJoystick::ReleaseJoysticks()
+{
+  // Unacquire the device one last time just in case
+  // the app tried to exit while the device is still acquired.
+  for(std::vector<LPDIRECTINPUTDEVICE8>::iterator it = m_pJoysticks.begin(); it != m_pJoysticks.end(); ++it)
+  {
+    if( (*it) )
+      (*it)->Unacquire();
+    SAFE_RELEASE( (*it) );
+  }
+  m_pJoysticks.clear();
+  m_JoystickNames.clear();
+  m_devCaps.clear();
+  // Release any DirectInput objects.
+  SAFE_RELEASE( m_pDI );
+}
+
+BOOL CALLBACK CJoystick::EnumJoysticksCallback( const DIDEVICEINSTANCE* pdidInstance, VOID* pContext )
+{
+  HRESULT hr;
+  CJoystick* p_this = (CJoystick*) pContext;
+  LPDIRECTINPUTDEVICE8    pJoystick = NULL;
+
+  // Obtain an interface to the enumerated joystick.
+  hr = p_this->m_pDI->CreateDevice( pdidInstance->guidInstance, &pJoystick, NULL );
+  if( SUCCEEDED( hr ) )
+  {
+    // Set the data format to "simple joystick" - a predefined data format
+    //
+    // A data format specifies which controls on a device we are interested in,
+    // and how they should be reported. This tells DInput that we will be
+    // passing a DIJOYSTATE2 structure to IDirectInputDevice::GetDeviceState().
+    if( SUCCEEDED( hr = pJoystick->SetDataFormat( &c_dfDIJoystick2 ) ) )
+    {
+      // Set the cooperative level to let DInput know how this device should
+      // interact with the system and with other DInput applications.
+      if( SUCCEEDED( hr = pJoystick->SetCooperativeLevel( g_hWnd, DISCL_EXCLUSIVE | DISCL_FOREGROUND ) ) )
+      {
+        DIDEVCAPS diDevCaps;
+        diDevCaps.dwSize = sizeof(DIDEVCAPS);
+        if (SUCCEEDED(hr = pJoystick->GetCapabilities(&diDevCaps)))
+        {
+          CLog::Log(LOGNOTICE, __FUNCTION__" : Enabled Joystick: %s", pdidInstance->tszProductName);
+          CLog::Log(LOGNOTICE, __FUNCTION__" : Total Axis: %d Total Hats: %d Total Buttons: %d", diDevCaps.dwAxes, diDevCaps.dwPOVs, diDevCaps.dwButtons);
+          p_this->m_pJoysticks.push_back(pJoystick);
+          p_this->m_JoystickNames.push_back(pdidInstance->tszProductName);
+          p_this->m_devCaps.push_back(diDevCaps);
+        }
+        else
+          CLog::Log(LOGDEBUG, __FUNCTION__" : Failed to GetCapabilities for: %s", pdidInstance->tszProductName);
+      }
+      else
+        CLog::Log(LOGDEBUG, __FUNCTION__" : Failed to SetCooperativeLevel on: %s", pdidInstance->tszProductName);
+
+    }
+    else
+      CLog::Log(LOGDEBUG, __FUNCTION__" : Failed to SetDataFormat on: %s", pdidInstance->tszProductName);
+  }
+  else
+    CLog::Log(LOGDEBUG, __FUNCTION__" : Failed to CreateDevice: %s", pdidInstance->tszProductName);
+
+  return DIENUM_CONTINUE;
+}
+
+//-----------------------------------------------------------------------------
+// Name: EnumObjectsCallback()
+// Desc: Callback function for enumerating objects (axes, buttons, POVs) on a
+//       joystick. This function enables user interface elements for objects
+//       that are found to exist, and scales axes min/max values.
+//-----------------------------------------------------------------------------
+BOOL CALLBACK CJoystick::EnumObjectsCallback( const DIDEVICEOBJECTINSTANCE* pdidoi, VOID* pContext )
+{
+
+  LPDIRECTINPUTDEVICE8 pJoy = (LPDIRECTINPUTDEVICE8) pContext;
+
+  // For axes that are returned, set the DIPROP_RANGE property for the
+  // enumerated axis in order to scale min/max values.
+  if( pdidoi->dwType & DIDFT_AXIS )
+  {
+      DIPROPRANGE diprg;
+      diprg.diph.dwSize = sizeof( DIPROPRANGE );
+      diprg.diph.dwHeaderSize = sizeof( DIPROPHEADER );
+      diprg.diph.dwHow = DIPH_BYID;
+      diprg.diph.dwObj = pdidoi->dwType; // Specify the enumerated axis
+      diprg.lMin = AXIS_MIN;
+      diprg.lMax = AXIS_MAX;
+
+      // Set the range for the axis
+      if( FAILED( pJoy->SetProperty( DIPROP_RANGE, &diprg.diph ) ) )
+        return DIENUM_STOP;
+  }
+
+  return DIENUM_CONTINUE;
+}
+
+void CJoystick::Initialize()
+{
+  HRESULT hr;
+
+  // clear old joystick names
+  ReleaseJoysticks();
+
+  if( FAILED( hr = DirectInput8Create( GetModuleHandle( NULL ), DIRECTINPUT_VERSION, IID_IDirectInput8, ( VOID** )&m_pDI, NULL ) ) )
+  {
+    CLog::Log(LOGDEBUG, __FUNCTION__" : Failed to create DirectInput");
+    return;
+  }
+
+  if( FAILED( hr = m_pDI->EnumDevices( DI8DEVCLASS_GAMECTRL, EnumJoysticksCallback, this, DIEDFL_ATTACHEDONLY ) ) )
+    return;
+
+  if(m_pJoysticks.size() == 0)
+  {
+    CLog::Log(LOGDEBUG, __FUNCTION__" : No Joystick found");
+    return;
+  }
+
+  for(std::vector<LPDIRECTINPUTDEVICE8>::iterator it = m_pJoysticks.begin(); it != m_pJoysticks.end(); ++it)
+  {
+    LPDIRECTINPUTDEVICE8 pJoy = (*it);
+    // Enumerate the joystick objects. The callback function enabled user
+    // interface elements for objects that are found, and sets the min/max
+    // values property for discovered axes.
+    if( FAILED( hr = pJoy->EnumObjects( EnumObjectsCallback, pJoy, DIDFT_ALL ) ) )
+      CLog::Log(LOGDEBUG, __FUNCTION__" : Failed to enumerate objects");
+  }
+
+  m_JoyId = -1;
+
+  // Set deadzone range
+  SetDeadzone(g_advancedSettings.m_controllerDeadzone);
+}
+
+void CJoystick::Reset(bool axis)
+{
+  if (axis)
+  {
+    SetAxisActive(false);
+    for (int i = 0 ; i<MAX_AXES ; i++)
+    {
+      ResetAxis(i);
+    }
+  }
+}
+
+void CJoystick::Update()
+{
+  int buttonId    = -1;
+  int axisId      = -1;
+  int hatId       = -1;
+  int numhat      = -1;
+  int numj        = m_pJoysticks.size();
+  if (numj <= 0)
+    return;
+
+  // go through all joysticks
+  for (int j = 0; j<numj; j++)
+  {
+    LPDIRECTINPUTDEVICE8 pjoy = m_pJoysticks[j];
+    HRESULT hr;
+    DIJOYSTATE2 js;           // DInput joystick state
+
+    m_NumAxes = (m_devCaps[j].dwAxes > MAX_AXES) ? MAX_AXES : m_devCaps[j].dwAxes;
+    numhat    = (m_devCaps[j].dwPOVs > 4) ? 4 : m_devCaps[j].dwPOVs;
+
+    hr = pjoy->Poll();
+    if( FAILED( hr ) )
+    {
+      int i=0;
+      // DInput is telling us that the input stream has been
+      // interrupted. We aren't tracking any state between polls, so
+      // we don't have any special reset that needs to be done. We
+      // just re-acquire and try again.
+      hr = pjoy->Acquire();
+      while( (hr == DIERR_INPUTLOST) && (i++ < 10)  )
+          hr = pjoy->Acquire();
+
+      // hr may be DIERR_OTHERAPPHASPRIO or other errors.  This
+      // may occur when the app is minimized or in the process of
+      // switching, so just try again later
+      return;
+    }
+
+    // Get the input's device state
+    if( FAILED( hr = pjoy->GetDeviceState( sizeof( DIJOYSTATE2 ), &js ) ) )
+      return; // The device should have been acquired during the Poll()
+
+    // get button states first, they take priority over axis
+    for( int b = 0; b < 128; b++ )
+    {
+      if( js.rgbButtons[b] & 0x80 )
+      {
+        m_JoyId = j;
+        buttonId = b+1;
+        j = numj-1;
+        break;
+      }
+    }
+
+    // get only first hat position
+    for (int h = 0; h < numhat; h++)
+    {
+      if((LOWORD(js.rgdwPOV[h]) == 0xFFFF) != true)
+      {
+        m_JoyId = j;
+        hatId = h + 1;
+        j = numj-1;
+        if ( (js.rgdwPOV[0] > JOY_POVLEFT) || (js.rgdwPOV[0] < JOY_POVRIGHT) )
+          m_HatState |= SDL_HAT_UP;
+
+        if ( (js.rgdwPOV[0] > JOY_POVFORWARD) && (js.rgdwPOV[0] < JOY_POVBACKWARD) )
+          m_HatState |= SDL_HAT_RIGHT;
+
+        if ( (js.rgdwPOV[0] > JOY_POVRIGHT) && (js.rgdwPOV[0] < JOY_POVLEFT) )
+          m_HatState |= SDL_HAT_DOWN;
+
+        if ( js.rgdwPOV[0] > JOY_POVBACKWARD )
+          m_HatState |= SDL_HAT_LEFT;
+      }
+    }
+
+    // get axis states
+    m_Amount[0] = js.lX;
+    m_Amount[1] = js.lY;
+    m_Amount[2] = js.lZ;
+    m_Amount[3] = js.lRx;
+    m_Amount[4] = js.lRy;
+    m_Amount[5] = js.lRz;
+
+    m_AxisId = GetAxisWithMaxAmount();
+    if (m_AxisId)
+    {
+      m_JoyId = j;
+      j = numj-1;
+      break;
+    }
+  }
+
+  if(hatId==-1)
+  {
+    if(m_HatId!=0)
+      CLog::Log(LOGDEBUG, "Joystick %d hat %d Centered", m_JoyId, abs(hatId));
+    m_pressTicksHat = 0;
+    SetHatActive(false);
+    m_HatId = 0;
+  }
+  else
+  {
+    if(hatId!=m_HatId)
+    {
+      CLog::Log(LOGDEBUG, "Joystick %d hat %u Down", m_JoyId, hatId);
+      m_HatId = hatId;
+      m_pressTicksHat = XbmcThreads::SystemClockMillis();
+    }
+    SetHatActive();
+  }
+
+  if (buttonId==-1)
+  {
+    if (m_ButtonId!=0)
+    {
+      CLog::Log(LOGDEBUG, "Joystick %d button %d Up", m_JoyId, m_ButtonId);
+    }
+    m_pressTicksButton = 0;
+    SetButtonActive(false);
+    m_ButtonId = 0;
+  }
+  else
+  {
+    if (buttonId!=m_ButtonId)
+    {
+      CLog::Log(LOGDEBUG, "Joystick %d button %d Down", m_JoyId, buttonId);
+      m_ButtonId = buttonId;
+      m_pressTicksButton = XbmcThreads::SystemClockMillis();
+    }
+    SetButtonActive();
+  }
+
+}
+
+bool CJoystick::GetHat(int &id, int &position,bool consider_repeat)
+{
+  if (!IsHatActive())
+    return false;
+  position = m_HatState;
+  id = m_HatId;
+  if (!consider_repeat)
+    return true;
+
+  uint32_t nowTicks = 0;
+
+  if ((m_HatId>=0) && m_pressTicksHat)
+  {
+    // return the id if it's the first press
+    if (m_lastPressTicks!=m_pressTicksHat)
+    {
+      m_lastPressTicks = m_pressTicksHat;
+      return true;
+    }
+    nowTicks = XbmcThreads::SystemClockMillis();
+    if ((nowTicks-m_pressTicksHat)<500) // 500ms delay before we repeat
+      return false;
+    if ((nowTicks-m_lastTicks)<100) // 100ms delay before successive repeats
+      return false;
+
+    m_lastTicks = nowTicks;
+  }
+
+  return true;
+}
+
+bool CJoystick::GetButton(int &id, bool consider_repeat)
+{
+  if (!IsButtonActive())
+    return false;
+  if (!consider_repeat)
+  {
+    id = m_ButtonId;
+    return true;
+  }
+
+  uint32_t nowTicks = 0;
+
+  if ((m_ButtonId>=0) && m_pressTicksButton)
+  {
+    // return the id if it's the first press
+    if (m_lastPressTicks!=m_pressTicksButton)
+    {
+      m_lastPressTicks = m_pressTicksButton;
+      id = m_ButtonId;
+      return true;
+    }
+    nowTicks = XbmcThreads::SystemClockMillis();
+    if ((nowTicks-m_pressTicksButton)<500) // 500ms delay before we repeat
+    {
+      return false;
+    }
+    if ((nowTicks-m_lastTicks)<100) // 100ms delay before successive repeats
+    {
+      return false;
+    }
+    m_lastTicks = nowTicks;
+  }
+  id = m_ButtonId;
+  return true;
+}
+
+int CJoystick::GetAxisWithMaxAmount()
+{
+  int maxAmount = 0;
+  int axis = 0;
+  int tempf;
+  for (int i = 1 ; i<=m_NumAxes ; i++)
+  {
+    tempf = abs(m_Amount[i]);
+    if (tempf>m_DeadzoneRange && tempf>maxAmount)
+    {
+      maxAmount = tempf;
+      axis = i;
+    }
+  }
+  SetAxisActive(0 != maxAmount);
+  return axis;
+}
+
+float CJoystick::GetAmount(int axis)
+{
+  if (m_Amount[axis] > m_DeadzoneRange)
+    return (float)(m_Amount[axis]-m_DeadzoneRange)/(float)(MAX_AXISAMOUNT-m_DeadzoneRange);
+  if (m_Amount[axis] < -m_DeadzoneRange)
+    return (float)(m_Amount[axis]+m_DeadzoneRange)/(float)(MAX_AXISAMOUNT-m_DeadzoneRange);
+  return 0;
+}
+
+float CJoystick::SetDeadzone(float val)
+{
+  if (val<0) val=0;
+  if (val>1) val=1;
+  m_DeadzoneRange = (int)(val*MAX_AXISAMOUNT);
+  return val;
+}
+
+bool CJoystick::Reinitialize()
+{
+  Initialize();
+  return true;
+}
+
+void CJoystick::Acquire()
+{
+  if(!m_pJoysticks.empty())
+  {
+    CLog::Log(LOGDEBUG, __FUNCTION__": Focus back, acquire Joysticks");
+    for(std::vector<LPDIRECTINPUTDEVICE8>::iterator it = m_pJoysticks.begin(); it != m_pJoysticks.end(); ++it)
+    {
+      if( (*it) )
+        (*it)->Acquire();
+    }
+  }
+}

--- a/xbmc/input/windows/WINJoystick.h
+++ b/xbmc/input/windows/WINJoystick.h
@@ -1,0 +1,92 @@
+#pragma once
+/*
+*      Copyright (C) 2012 Team XBMC
+*      http://www.xbmc.org
+*
+*  This Program is free software; you can redistribute it and/or modify
+*  it under the terms of the GNU General Public License as published by
+*  the Free Software Foundation; either version 2, or (at your option)
+*  any later version.
+*
+*  This Program is distributed in the hope that it will be useful,
+*  but WITHOUT ANY WARRANTY; without even the implied warranty of
+*  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+*  GNU General Public License for more details.
+*
+*  You should have received a copy of the GNU General Public License
+*  along with XBMC; see the file COPYING.  If not, write to
+*  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+*  http://www.gnu.org/copyleft/gpl.html
+*
+*/
+
+#include <vector>
+#include <string>
+
+#define JACTIVE_BUTTON 0x00000001
+#define JACTIVE_AXIS   0x00000002
+#define JACTIVE_HAT    0x00000004
+#define JACTIVE_NONE   0x00000000
+#define JACTIVE_HAT_UP    0x01
+#define JACTIVE_HAT_RIGHT 0x02
+#define JACTIVE_HAT_DOWN  0x04
+#define JACTIVE_HAT_LEFT  0x08
+
+#define MAX_AXES 6
+
+// Class to manage all connected joysticks
+
+class CJoystick
+{
+public:
+  CJoystick();
+  ~CJoystick();
+
+  void Initialize();
+  void Reset(bool axis=false);
+  void ResetAxis(int axisId) { m_Amount[axisId] = 0; }
+  void Update();
+  bool GetButton (int& id, bool consider_repeat=true);
+  bool GetAxis (int &id) { if (!IsAxisActive()) return false; id=m_AxisId; return true; }
+  bool GetHat (int &id, int &position, bool consider_repeat=true);
+  std::string GetJoystick() { return (m_JoyId>-1)?m_JoystickNames[m_JoyId]:""; }
+  int GetAxisWithMaxAmount();
+  float GetAmount(int axis);
+  float GetAmount() { return GetAmount(m_AxisId); }
+  float SetDeadzone(float val);
+  bool Reinitialize();
+  void Acquire();
+
+private:
+  void SetAxisActive(bool active=true) { m_ActiveFlags = active?(m_ActiveFlags|JACTIVE_AXIS):(m_ActiveFlags&(~JACTIVE_AXIS)); }
+  void SetButtonActive(bool active=true) { m_ActiveFlags = active?(m_ActiveFlags|JACTIVE_BUTTON):(m_ActiveFlags&(~JACTIVE_BUTTON)); }
+  void SetHatActive(bool active=true) { m_ActiveFlags = active?(m_ActiveFlags|JACTIVE_HAT):(m_ActiveFlags&(~JACTIVE_HAT)); }
+  bool IsButtonActive() { return (m_ActiveFlags & JACTIVE_BUTTON) == JACTIVE_BUTTON; }
+  bool IsAxisActive() { return (m_ActiveFlags & JACTIVE_AXIS) == JACTIVE_AXIS; }
+  bool IsHatActive() { return (m_ActiveFlags & JACTIVE_HAT) == JACTIVE_HAT; }
+
+  void ReleaseJoysticks();
+  static BOOL CALLBACK EnumJoysticksCallback( const DIDEVICEINSTANCE* pdidInstance, VOID* pContext );
+  static BOOL CALLBACK EnumObjectsCallback( const DIDEVICEOBJECTINSTANCE* pdidoi, VOID* pContext );
+
+  int m_Amount[MAX_AXES];
+  int m_AxisId;
+  int m_ButtonId;
+  uint8_t m_HatState;
+  int m_HatId;
+  int m_JoyId;
+  int m_NumAxes;
+  int m_DeadzoneRange;
+  uint32_t m_pressTicksButton;
+  uint32_t m_pressTicksHat;
+  uint8_t m_ActiveFlags;
+  uint32_t m_lastPressTicks;
+  uint32_t m_lastTicks;
+
+  LPDIRECTINPUT8  m_pDI;
+  std::vector<LPDIRECTINPUTDEVICE8> m_pJoysticks;
+  std::vector<std::string> m_JoystickNames;
+  std::vector<DIDEVCAPS> m_devCaps;
+};
+
+extern CJoystick g_Joystick;

--- a/xbmc/windowing/windows/WinEventsWin32.cpp
+++ b/xbmc/windowing/windows/WinEventsWin32.cpp
@@ -27,9 +27,7 @@
 #include "Application.h"
 #include "input/XBMC_vkeys.h"
 #include "input/MouseStat.h"
-#if defined(HAS_SDL_JOYSTICK)
-#include "input/SDLJoystick.h"
-#endif
+#include "input/windows/WINJoystick.h"
 #include "storage/MediaManager.h"
 #include "windowing/WindowingFactory.h"
 #include <dbt.h>
@@ -404,6 +402,9 @@ LRESULT CALLBACK CWinEventsWin32::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, L
       break;
     case WM_ACTIVATE:
       {
+        if( WA_INACTIVE != wParam )
+          g_Joystick.Acquire();
+
         bool active = g_application.m_AppActive;
         if (HIWORD(wParam))
         {
@@ -695,9 +696,7 @@ LRESULT CALLBACK CWinEventsWin32::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, L
             if (((_DEV_BROADCAST_HEADER*) lParam)->dbcd_devicetype == DBT_DEVTYP_DEVICEINTERFACE)
             {
               g_peripherals.TriggerDeviceScan(PERIPHERAL_BUS_USB);
-#if defined(HAS_SDL_JOYSTICK)
               g_Joystick.Reinitialize();
-#endif
             }
         }
         break;


### PR DESCRIPTION
There're three reasons why this was done:
1) the old and deprecated joystick interface used in SDL seems to have problems with newer joysticks like the x360. Also a native implementation with the old interface showed a lot of crashes.
2) a further step to get rid of SDL
3) see 2)

I dunno what to do with HAS_SDL_JOYSTICK. It also guards generic joystick code which I'll need with directinput as well. Currently I just left it in and only ifdef'ed the SDL_Joystick init out.

I also had to place the g_Joystick.Initialize() after the window creation as I need the window handle in order to set the cooperative level. Please review if this could cause problems somehow.
