### PR TITLE
[AE] Fix issues related to endianness in passthrough

### DIFF
--- a/xbmc/cores/AudioEngine/Engines/CoreAudio/CoreAudioAEHAL.cpp
+++ b/xbmc/cores/AudioEngine/Engines/CoreAudio/CoreAudioAEHAL.cpp
@@ -90,7 +90,9 @@ const char* StreamDescriptionToString(AudioStreamBasicDescription desc, std::str
     case kAudioFormat60958AC3:
       sstr  << "["
             << fourCC
-            << "] AC-3/DTS for S/PDIF ("
+            << "] AC-3/DTS for S/PDIF "
+            << ((desc.mFormatFlags & kAudioFormatFlagIsBigEndian) ? "BE" : "LE")
+            << " ("
             << (UInt32)desc.mSampleRate
             << "Hz)";
       str = sstr.str();

--- a/xbmc/cores/AudioEngine/Engines/SoftAE/SoftAE.h
+++ b/xbmc/cores/AudioEngine/Engines/SoftAE/SoftAE.h
@@ -192,6 +192,8 @@ private:
   uint8_t        *m_converted;
   size_t          m_convertedSize;
 
+  void         AllocateConvIfNeeded(size_t convertedSize);
+
   /* thread run stages */
   void         MixSounds        (float *buffer, unsigned int samples);
   void         FinalizeSamples  (float *buffer, unsigned int samples);

--- a/xbmc/cores/AudioEngine/Sinks/AESinkALSA.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkALSA.cpp
@@ -193,13 +193,15 @@ bool CAESinkALSA::IsCompatible(const AEAudioFormat format, const std::string dev
 snd_pcm_format_t CAESinkALSA::AEFormatToALSAFormat(const enum AEDataFormat format)
 {
   if (AE_IS_RAW(format))
-    return SND_PCM_FORMAT_S16_LE;
+    return SND_PCM_FORMAT_S16;
 
   switch (format)
   {
     case AE_FMT_S8    : return SND_PCM_FORMAT_S8;
     case AE_FMT_U8    : return SND_PCM_FORMAT_U8;
     case AE_FMT_S16NE : return SND_PCM_FORMAT_S16;
+    case AE_FMT_S16LE : return SND_PCM_FORMAT_S16_LE;
+    case AE_FMT_S16BE : return SND_PCM_FORMAT_S16_BE;
     case AE_FMT_S24NE4: return SND_PCM_FORMAT_S24;
 #ifdef __BIG_ENDIAN__
     case AE_FMT_S24NE3: return SND_PCM_FORMAT_S24_3BE;
@@ -258,6 +260,10 @@ bool CAESinkALSA::InitializeHW(AEAudioFormat &format)
     {
       if (AE_IS_RAW(i) || i == AE_FMT_MAX)
         continue;
+
+      if (m_passthrough && i != AE_FMT_S16BE && i != AE_FMT_S16LE)
+	continue;
+
       fmt = AEFormatToALSAFormat(i);
 
       if (fmt == SND_PCM_FORMAT_UNKNOWN || snd_pcm_hw_params_set_format(m_pcm, hw_params, fmt) < 0)

--- a/xbmc/cores/AudioEngine/Utils/AEBitstreamPacker.cpp
+++ b/xbmc/cores/AudioEngine/Utils/AEBitstreamPacker.cpp
@@ -20,6 +20,7 @@
  */
 
 #include "AEBitstreamPacker.h"
+#include "AEPackIEC61937.h"
 #include <stdint.h>
 #include <stddef.h>
 #include <string.h>
@@ -54,6 +55,18 @@ void CAEBitstreamPacker::Pack(CAEStreamInfo &info, uint8_t* data, int size)
 
     case CAEStreamInfo::STREAM_TYPE_DTSHD:
       PackDTSHD (info, data, size);
+      break;
+
+    case CAEStreamInfo::STREAM_TYPE_DTS_512:
+      m_dataSize = CAEPackIEC61937::PackDTS_512(data, size, m_packedBuffer, info.IsLittleEndian());
+      break;
+
+    case CAEStreamInfo::STREAM_TYPE_DTS_1024:
+      m_dataSize = CAEPackIEC61937::PackDTS_1024(data, size, m_packedBuffer, info.IsLittleEndian());
+      break;
+
+    case CAEStreamInfo::STREAM_TYPE_DTS_2048:
+      m_dataSize = CAEPackIEC61937::PackDTS_2048(data, size, m_packedBuffer, info.IsLittleEndian());
       break;
 
     default:

--- a/xbmc/cores/AudioEngine/Utils/AEConvert.h
+++ b/xbmc/cores/AudioEngine/Utils/AEConvert.h
@@ -23,8 +23,6 @@
 #include <stdint.h>
 #include "../AEAudioFormat.h"
 
-/* note: always converts to machine byte endian */
-
 class CAEConvert{
 private:
   static unsigned int U8_Float    (uint8_t *data, const unsigned int samples, float   *dest);

--- a/xbmc/cores/AudioEngine/Utils/AEPackIEC61937.h
+++ b/xbmc/cores/AudioEngine/Utils/AEPackIEC61937.h
@@ -52,12 +52,16 @@ public:
 
   static int PackAC3     (uint8_t *data, unsigned int size, uint8_t *dest);
   static int PackEAC3    (uint8_t *data, unsigned int size, uint8_t *dest);
-  static int PackDTS_512 (uint8_t *data, unsigned int size, uint8_t *dest);
-  static int PackDTS_1024(uint8_t *data, unsigned int size, uint8_t *dest);
-  static int PackDTS_2048(uint8_t *data, unsigned int size, uint8_t *dest);
+  static int PackDTS_512 (uint8_t *data, unsigned int size, uint8_t *dest, bool littleEndian);
+  static int PackDTS_1024(uint8_t *data, unsigned int size, uint8_t *dest, bool littleEndian);
+  static int PackDTS_2048(uint8_t *data, unsigned int size, uint8_t *dest, bool littleEndian);
   static int PackTrueHD  (uint8_t *data, unsigned int size, uint8_t *dest);
   static int PackDTSHD   (uint8_t *data, unsigned int size, uint8_t *dest, unsigned int period);
 private:
+
+  static int PackDTS(uint8_t *data, unsigned int size, uint8_t *dest, bool littleEndian,
+                     unsigned int frameSize, uint16_t type);
+
   enum IEC61937DataType
   {
     IEC61937_TYPE_NULL   = 0x00,

--- a/xbmc/cores/AudioEngine/Utils/AEStreamInfo.cpp
+++ b/xbmc/cores/AudioEngine/Utils/AEStreamInfo.cpp
@@ -504,9 +504,9 @@ unsigned int CAEStreamInfo::SyncDTS(uint8_t *data, unsigned int size)
     DataType dataType;
     switch (dtsBlocks << 5)
     {
-      case 512 : dataType = STREAM_TYPE_DTS_512 ; m_packFunc = &CAEPackIEC61937::PackDTS_512 ; break;
-      case 1024: dataType = STREAM_TYPE_DTS_1024; m_packFunc = &CAEPackIEC61937::PackDTS_1024; break;
-      case 2048: dataType = STREAM_TYPE_DTS_2048; m_packFunc = &CAEPackIEC61937::PackDTS_2048; break;
+      case 512 : dataType = STREAM_TYPE_DTS_512 ; break;
+      case 1024: dataType = STREAM_TYPE_DTS_1024; break;
+      case 2048: dataType = STREAM_TYPE_DTS_2048; break;
       default:
         invalid = true;
         break;

--- a/xbmc/cores/AudioEngine/Utils/AEUtil.cpp
+++ b/xbmc/cores/AudioEngine/Utils/AEUtil.cpp
@@ -455,3 +455,20 @@ void CAEUtil::FloatRand4(const float min, const float max, float result[4], __m1
     result[3] = ((float)(m_seed = (214013 * m_seed + 2531011)) * factor) - delta;
   #endif
 }
+
+bool CAEUtil::S16NeedsByteSwap(AEDataFormat in, AEDataFormat out)
+{
+  const AEDataFormat nativeFormat =
+#ifdef WORDS_BIGENDIAN
+    AE_FMT_S16BE;
+#else
+    AE_FMT_S16LE;
+#endif
+
+  if (in == AE_FMT_S16NE || AE_IS_RAW(in))
+    in = nativeFormat;
+  if (out == AE_FMT_S16NE || AE_IS_RAW(out))
+    out = nativeFormat;
+
+  return in != out;
+}

--- a/xbmc/cores/AudioEngine/Utils/AEUtil.h
+++ b/xbmc/cores/AudioEngine/Utils/AEUtil.h
@@ -74,4 +74,6 @@ public:
   */
   static float FloatRand1(const float min, const float max);
   static void  FloatRand4(const float min, const float max, float result[4], __m128 *sseresult = NULL);
+
+  static bool S16NeedsByteSwap(AEDataFormat in, AEDataFormat out);
 };

--- a/xbmc/utils/EndianSwap.cpp
+++ b/xbmc/utils/EndianSwap.cpp
@@ -1,0 +1,42 @@
+/*
+ *      Copyright (C) 2012 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ */
+
+#include "EndianSwap.h"
+
+/* based on libavformat/spdif.c */
+void Endian_Swap16_buf(uint16_t *dst, uint16_t *src, int w)
+{
+  int i;
+
+  for (i = 0; i + 8 <= w; i += 8) {
+    dst[i + 0] = Endian_Swap16(src[i + 0]);
+    dst[i + 1] = Endian_Swap16(src[i + 1]);
+    dst[i + 2] = Endian_Swap16(src[i + 2]);
+    dst[i + 3] = Endian_Swap16(src[i + 3]);
+    dst[i + 4] = Endian_Swap16(src[i + 4]);
+    dst[i + 5] = Endian_Swap16(src[i + 5]);
+    dst[i + 6] = Endian_Swap16(src[i + 6]);
+    dst[i + 7] = Endian_Swap16(src[i + 7]);
+  }
+
+  for (; i < w; i++)
+    dst[i + 0] = Endian_Swap16(src[i + 0]);
+}
+

--- a/xbmc/utils/EndianSwap.h
+++ b/xbmc/utils/EndianSwap.h
@@ -19,7 +19,7 @@
  *
  */
 
- /* Functions taken from SDL (SDL_endian.h) */
+ /* Endian_SwapXX functions taken from SDL (SDL_endian.h) */
 
 #ifndef __ENDIAN_SWAP_H__
 #define __ENDIAN_SWAP_H__
@@ -82,6 +82,8 @@ static __inline__ uint64_t Endian_Swap64(uint64_t x) {
         return(x);
 
 }
+
+void Endian_Swap16_buf(uint16_t *dst, uint16_t *src, int w);
 
 #ifndef WORDS_BIGENDIAN
 #define Endian_SwapLE16(X) (X)

--- a/xbmc/utils/Makefile
+++ b/xbmc/utils/Makefile
@@ -11,6 +11,7 @@ SRCS=AlarmClock.cpp \
      CryptThreading.cpp \
      DownloadQueue.cpp \
      DownloadQueueManager.cpp \
+     EndianSwap.cpp \
      Fanart.cpp \
      fastmemcpy.c \
      fastmemcpy-arm.S \


### PR DESCRIPTION
Currently the code assumes that the sink takes S16_NE when performing passthrough. However, this may not be the case, and especially on big-endian systems the sink may want S16_LE instead (if the audio hardware / API takes that instead of S16_BE).

Byteswapping is currently performed by AEPackIEC61937 on little-endian systems to get the IEC 61937 data from the standard format to S16_LE byteswapped format. This is done because S16_LE audio hardware will byteswap the data (as IEC958 is big-endian) and it will return to the original raw format.

Optimally, when outputting to a S16_BE device, no byteswap should be performed, and when outputting to a S16_LE device, one byteswap should be performed. The best place to do that is the packetizer, because it knows what part of the stream is zero padding (and there can be lots of padding) which doesn't need to be byteswapped.

Unfortunately, our packetizer doesn't know what the endianness of the output sink is (as packetization happens in the player already). Therefore this patchset adds additional byteswap at engine/sink level, which will be triggered when output device has a non-system endianness.

This patchset only makes the byteswap happen when using the ALSA sink, however, previously I've seen also big-endian osx-ppc systems needing S16_LE passthrough with CoreAudio. That platform is no longer supported, though. and the CoreAudio code has changed a bit (due to AE switch), so I'm not sure if we need to do something to allow proper (non-"DD-Wav") passthrough using kAudioFormat60958AC3 on big-endian CoreAudio systems - I guess it doesn't matter since we don't have such systems. The IOS code seems to not use kAudioFormat60958AC3 at all.

Also fixed are some DTS passthrough issues (passthrough of LE DTS, pre-padded DTS, and crash on invalid DTS), see the commit log for more info about that. (similar crash issues due to improper validation seem to exist for other passthrough formats as well, will look at those later)

This PR adds a new file (xbmc/utils/EndianSwap.cpp), so win32/osx buildsystem will need an update.

I'm not 100% sure if I've done all the stuff the way the AE people want it, so please do give suggestions if you have those.
