### PR TITLE
[osx] fixed: incorrect mFormatFlags set for S16LE

### DIFF
--- a/xbmc/cores/AudioEngine/Engines/CoreAudio/CoreAudioAEHALIOS.cpp
+++ b/xbmc/cores/AudioEngine/Engines/CoreAudio/CoreAudioAEHALIOS.cpp
@@ -311,7 +311,6 @@ void CCoreAudioUnit::GetFormatDesc(AEAudioFormat format,
       streamDesc->mFormatFlags |= kAudioFormatFlagIsSignedInteger;
       break;
     case AE_FMT_S16LE:
-      streamDesc->mFormatFlags |= kAudioFormatFlagsNativeEndian;
       streamDesc->mFormatFlags |= kAudioFormatFlagIsSignedInteger;
       break;
     case AE_FMT_S16BE:

--- a/xbmc/cores/AudioEngine/Engines/CoreAudio/CoreAudioUnit.cpp
+++ b/xbmc/cores/AudioEngine/Engines/CoreAudio/CoreAudioUnit.cpp
@@ -314,7 +314,6 @@ void CCoreAudioUnit::GetFormatDesc(AEAudioFormat format,
       streamDesc->mFormatFlags |= kAudioFormatFlagIsSignedInteger;
       break;
     case AE_FMT_S16LE:
-      streamDesc->mFormatFlags |= kAudioFormatFlagsNativeEndian;
       streamDesc->mFormatFlags |= kAudioFormatFlagIsSignedInteger;
       break;
     case AE_FMT_S16BE:


### PR DESCRIPTION
CCoreAudioUnit::GetFormatDesc() currently sets
kAudioFormatFlagsNativeEndian for AE_FMT_S16LE.

However, S16LE is always little-endian, not native-endian, so that flag
shouldn't be set.

This incorrect value presumably didn't cause widespread issues because
on little-endian systems S16LE is also native-endian, so the code did
nothing (as kAudioFormatFlagsNativeEndian is zero), and on big-endian
systems we normally output S16BE instead of S16LE, so the codepath was
not hit.

Note that I haven't tested this, just noticed the bug when looking at the code.
So please check everything still works before pulling :)
