### PR TITLE
added: AEStreamFactory wrapper for checking MakeStream parameters

### DIFF
--- a/xbmc/cores/AudioEngine/AEStreamFactory.cpp
+++ b/xbmc/cores/AudioEngine/AEStreamFactory.cpp
@@ -1,0 +1,51 @@
+/*
+ *      Copyright (C) 2012 Team XBMC
+ *      http://xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING. If not, write to the Free
+ *  Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ *  Boston, MA  02110-1301, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ */
+
+#include "AEStreamFactory.h"
+#include "AEFactory.h"
+#include "utils/log.h"
+
+IAEStream *CAEStreamFactory::MakeStream(enum AEDataFormat dataFormat, unsigned int sampleRate, unsigned int encodedSampleRate, CAEChannelInfo channelLayout, unsigned int options)
+{
+  if (sampleRate == 0)
+  {
+    CLog::Log(LOGERROR, "MakeStream: Cannot create an audio stream with zero sample rate");
+    return NULL;
+  }
+
+  if (channelLayout.Count() == 0)
+  {
+    CLog::Log(LOGERROR, "MakeStream: Cannot create an audio stream with no channels");
+    return NULL;
+  }
+  
+  if (AE_IS_RAW(dataFormat) && encodedSampleRate == 0)
+  {
+    CLog::Log(LOGERROR, "MakeStream: Cannot create a passthrough audio stream without encoded sample rate");
+  }
+  
+  return CAEFactory::AE->MakeStream(dataFormat, sampleRate, encodedSampleRate, channelLayout, options);
+}
+
+void CAEStreamFactory::FreeStream(IAEStream *stream)
+{
+  CAEFactory::AE->FreeStream(stream);
+}

--- a/xbmc/cores/AudioEngine/AEStreamFactory.h
+++ b/xbmc/cores/AudioEngine/AEStreamFactory.h
@@ -1,0 +1,43 @@
+#pragma once
+/*
+ *      Copyright (C) 2012 Team XBMC
+ *      http://xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING. If not, write to the Free
+ *  Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ *  Boston, MA  02110-1301, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ */
+
+#include "AEAudioFormat.h"
+
+class IAEStream;
+
+class CAEStreamFactory
+{
+public:
+  /**
+   * Creates and returns a new IAEStream for the currently active engine.
+   * 
+   * @returns A valid stream or NULL if the supplied parameters were invalid
+   * 
+   * @see IAE::MakeStream for parameter documentation
+   */
+  static IAEStream *MakeStream(enum AEDataFormat dataFormat, unsigned int sampleRate, unsigned int encodedSampleRate, CAEChannelInfo channelLayout, unsigned int options = 0);
+  
+  /**
+   * Remove the specified stream from the engine and free it.
+   */
+  static void FreeStream(IAEStream *stream);
+};

--- a/xbmc/cores/AudioEngine/Engines/CoreAudio/CoreAudioAE.h
+++ b/xbmc/cores/AudioEngine/Engines/CoreAudio/CoreAudioAE.h
@@ -93,7 +93,8 @@ public:
   virtual bool      SupportsRaw();
   
   CCoreAudioAEHAL*  GetHAL();
-  
+
+private:
   // returns a new stream for data in the specified format
   virtual IAEStream* MakeStream(enum AEDataFormat dataFormat, 
     unsigned int sampleRate,unsigned int encodedSamplerate,
@@ -101,6 +102,7 @@ public:
   
   virtual IAEStream* FreeStream(IAEStream *stream);
     
+public:
   // returns a new sound object
   virtual IAESound* MakeSound(const std::string& file);
   void              StopAllSounds();

--- a/xbmc/cores/AudioEngine/Engines/PulseAE/PulseAE.h
+++ b/xbmc/cores/AudioEngine/Engines/PulseAE/PulseAE.h
@@ -49,11 +49,13 @@ public:
   virtual float GetVolume();
   virtual void  SetVolume(float volume);
 
+private:
   /* returns a new stream for data in the specified format */
   virtual IAEStream *MakeStream(enum AEDataFormat dataFormat, unsigned int sampleRate, unsigned int encodedSampleRate, CAEChannelInfo channelLayout, unsigned int options = 0);
   virtual IAEStream *FreeStream(IAEStream *stream);
   void RemoveStream(IAEStream *stream);
 
+public:
   /* returns a new sound object */
   virtual IAESound *MakeSound(const std::string& file);
   virtual void      FreeSound(IAESound *sound);

--- a/xbmc/cores/AudioEngine/Engines/SoftAE/SoftAE.h
+++ b/xbmc/cores/AudioEngine/Engines/SoftAE/SoftAE.h
@@ -71,10 +71,12 @@ public:
   virtual bool  IsMuted() { return m_muted; }
   virtual void  SetSoundMode(const int mode);
 
+private:
   /* returns a new stream for data in the specified format */
   virtual IAEStream *MakeStream(enum AEDataFormat dataFormat, unsigned int sampleRate, unsigned int encodedSampleRate, CAEChannelInfo channelLayout, unsigned int options = 0);
   virtual IAEStream *FreeStream(IAEStream *stream);
 
+public:
   /* returns a new sound object */
   virtual IAESound *MakeSound(const std::string& file);
   virtual void      FreeSound(IAESound *sound);

--- a/xbmc/cores/AudioEngine/Interfaces/AE.h
+++ b/xbmc/cores/AudioEngine/Interfaces/AE.h
@@ -50,6 +50,7 @@ class IAE
 {
 protected:
   friend class CAEFactory;
+  friend class CAEStreamFactory;
 
   IAE() {}
   virtual ~IAE() {}
@@ -101,6 +102,7 @@ public:
    */
   virtual void SetSoundMode(const int mode) = 0;
 
+private:
   /**
    * Creates and returns a new IAEStream in the format specified, this function should never fail
    * @param dataFormat The data format the incoming audio will be in (eg, AE_FMT_S16LE)
@@ -120,6 +122,7 @@ public:
    */
   virtual IAEStream *FreeStream(IAEStream *stream) = 0;
 
+public:
   /**
    * Creates a new IAESound that is ready to play the specified file
    * @param file The WAV file to load, this supports XBMC's VFS

--- a/xbmc/cores/AudioEngine/Makefile.in
+++ b/xbmc/cores/AudioEngine/Makefile.in
@@ -20,6 +20,7 @@ CXXFLAGS += -D__STDC_LIMIT_MACROS
 
 SRCS  = AEFactory.cpp
 SRCS += AESinkFactory.cpp
+SRCS += AEStreamFactory.cpp
 SRCS += Sinks/AESinkALSA.cpp
 SRCS += Sinks/AESinkOSS.cpp
 SRCS += Sinks/AESinkProfiler.cpp

--- a/xbmc/cores/dvdplayer/DVDAudio.cpp
+++ b/xbmc/cores/dvdplayer/DVDAudio.cpp
@@ -27,6 +27,7 @@
 #include "DVDCodecs/DVDCodecs.h"
 #include "DVDPlayerAudio.h"
 #include "cores/AudioEngine/AEFactory.h"
+#include "cores/AudioEngine/AEStreamFactory.h"
 #include "settings/Settings.h"
 
 using namespace std;
@@ -49,7 +50,7 @@ CDVDAudio::~CDVDAudio()
 {
   CSingleLock lock (m_critSection);
   if (m_pAudioStream)
-    CAEFactory::AE->FreeStream(m_pAudioStream);
+    CAEStreamFactory::FreeStream(m_pAudioStream);
 
   free(m_pBuffer);
 }
@@ -69,7 +70,7 @@ bool CDVDAudio::Create(const DVDAudioFrame &audioframe, CodecID codec, bool need
   unsigned int options = needresampler && !audioframe.passthrough ? AESTREAM_FORCE_RESAMPLE : 0;
   options |= AESTREAM_AUTOSTART;
 
-  m_pAudioStream = CAEFactory::AE->MakeStream(
+  m_pAudioStream = CAEStreamFactory::MakeStream(
     audioframe.data_format,
     audioframe.sample_rate,
     audioframe.encoded_sample_rate,
@@ -100,7 +101,7 @@ void CDVDAudio::Destroy()
   CSingleLock lock (m_critSection);
 
   if (m_pAudioStream)
-    CAEFactory::AE->FreeStream(m_pAudioStream);
+    CAEStreamFactory::FreeStream(m_pAudioStream);
 
   free(m_pBuffer);
   m_pBuffer = NULL;

--- a/xbmc/cores/paplayer/PAPlayer.cpp
+++ b/xbmc/cores/paplayer/PAPlayer.cpp
@@ -34,6 +34,7 @@
 
 #include "threads/SingleLock.h"
 #include "cores/AudioEngine/Utils/AEUtil.h"
+#include "cores/AudioEngine/AEStreamFactory.h"
 
 #define TIME_TO_CACHE_NEXT_FILE 5000 /* 5 seconds before end of song, start caching the next song */
 #define FAST_XFADE_TIME           80 /* 80 milliseconds */
@@ -187,7 +188,7 @@ void PAPlayer::CloseAllStreams(bool fade/* = true */)
       
       if (si->m_stream)
       {
-        CAEFactory::AE->FreeStream(si->m_stream);
+        CAEStreamFactory::FreeStream(si->m_stream);
         si->m_stream = NULL;
       }
 
@@ -202,7 +203,7 @@ void PAPlayer::CloseAllStreams(bool fade/* = true */)
 
       if (si->m_stream)
       {
-        CAEFactory::AE->FreeStream(si->m_stream);
+        CAEStreamFactory::FreeStream(si->m_stream);
         si->m_stream = NULL;
       }
 
@@ -346,7 +347,7 @@ inline bool PAPlayer::PrepareStream(StreamInfo *si)
     return true;
 
   /* get a paused stream */
-  si->m_stream = CAEFactory::AE->MakeStream(
+  si->m_stream = CAEStreamFactory::MakeStream(
     si->m_dataFormat,
     si->m_sampleRate,
     si->m_encodedSampleRate,
@@ -446,7 +447,7 @@ inline void PAPlayer::ProcessStreams(double &delay, double &buffer)
     if (si->m_stream->IsDrained())
     {      
       itt = m_finishing.erase(itt);
-      CAEFactory::AE->FreeStream(si->m_stream);
+      CAEStreamFactory::FreeStream(si->m_stream);
       delete si;
       CLog::Log(LOGDEBUG, "PAPlayer::ProcessStreams - Stream Freed");
     }


### PR DESCRIPTION
Currently the audio engines do not validate (except by asserts) the
MakeStream() parameters. Add a wrapper function in a new AEStreamFactory
class for MakeStream() (and FreeStream(), for consistency) which checks
that the sample rate and channel map are not invalid and that encoded
sample rate is provided when needed.

The MakeStream() and FreeStream() methods of the AE interface are made
private so that they can only be called through AEStreamFactory.

A new file is added, win/osx will need an update.
