### PR TITLE
Fixed album artist scanning when using Vorbis comments

### DIFF
--- a/xbmc/music/tags/MusicInfoTag.cpp
+++ b/xbmc/music/tags/MusicInfoTag.cpp
@@ -546,7 +546,7 @@ void CMusicInfoTag::AppendAlbumArtist(const CStdString &albumArtist)
       return;
   }
 
-  m_artist.push_back(albumArtist);
+  m_albumArtist.push_back(albumArtist);
 }
 
 void CMusicInfoTag::AppendGenre(const CStdString &genre)


### PR DESCRIPTION
This PR fixes the album artists in CMusicInfoTag::AppendAlbumArtist (atm only used by flacs/oggs with Vorbis comments).

Currently when adding such files to the db (with ALBUMARTIST or ALBUM ARTIST set), the file's album artist will be added as additional artist. The GUI shows this as ARTIST / ARTIST - TITLE and the album will appear under 'Various Artists'.

The fix is rather small, it looks like a typo in the code.
