### PR TITLE
[python] added missing onPlayback* events to python

### DIFF
--- a/xbmc/interfaces/python/XBPython.cpp
+++ b/xbmc/interfaces/python/XBPython.cpp
@@ -181,6 +181,66 @@ void XBPython::OnPlayBackStopped()
   }
 }
 
+// message all registered callbacks that playback speed changed (FF/RW)
+void XBPython::OnPlayBackSpeedChanged(int iSpeed)
+{
+  CSingleLock lock(m_critSection);
+  if (m_bInitialized)
+  {
+    PlayerCallbackList::iterator it = m_vecPlayerCallbackList.begin();
+    while (it != m_vecPlayerCallbackList.end())
+    {
+      ((IPlayerCallback*)(*it))->OnPlayBackSpeedChanged(iSpeed);
+      it++;
+    }
+  }
+}
+
+// message all registered callbacks that player is seeking
+void XBPython::OnPlayBackSeek(int iTime, int seekOffset)
+{
+  CSingleLock lock(m_critSection);
+  if (m_bInitialized)
+  {
+    PlayerCallbackList::iterator it = m_vecPlayerCallbackList.begin();
+    while (it != m_vecPlayerCallbackList.end())
+    {
+      ((IPlayerCallback*)(*it))->OnPlayBackSeek(iTime, seekOffset);
+      it++;
+    }
+  }
+}
+
+// message all registered callbacks that player chapter seeked
+void XBPython::OnPlayBackSeekChapter(int iChapter)
+{
+  CSingleLock lock(m_critSection);
+  if (m_bInitialized)
+  {
+    PlayerCallbackList::iterator it = m_vecPlayerCallbackList.begin();
+    while (it != m_vecPlayerCallbackList.end())
+    {
+      ((IPlayerCallback*)(*it))->OnPlayBackSeekChapter(iChapter);
+      it++;
+    }
+  }
+}
+
+// message all registered callbacks that next item has been queued
+void XBPython::OnQueueNextItem()
+{
+  CSingleLock lock(m_critSection);
+  if (m_bInitialized)
+  {
+    PlayerCallbackList::iterator it = m_vecPlayerCallbackList.begin();
+    while (it != m_vecPlayerCallbackList.end())
+    {
+      ((IPlayerCallback*)(*it))->OnQueueNextItem();
+      it++;
+    }
+  }
+}
+
 void XBPython::RegisterPythonPlayerCallBack(IPlayerCallback* pCallback)
 {
   CSingleLock lock(m_critSection);

--- a/xbmc/interfaces/python/XBPython.h
+++ b/xbmc/interfaces/python/XBPython.h
@@ -56,7 +56,11 @@ public:
   virtual void OnPlayBackPaused();
   virtual void OnPlayBackResumed();
   virtual void OnPlayBackStopped();
-  virtual void OnQueueNextItem() {};
+  virtual void OnPlayBackSpeedChanged(int iSpeed);
+  virtual void OnPlayBackSeek(int iTime, int seekOffset);
+  virtual void OnPlayBackSeekChapter(int iChapter);
+  virtual void OnQueueNextItem();
+
   virtual void Announce(ANNOUNCEMENT::AnnouncementFlag flag, const char *sender, const char *message, const CVariant &data);
   void RegisterPythonPlayerCallBack(IPlayerCallback* pCallback);
   void UnregisterPythonPlayerCallBack(IPlayerCallback* pCallback);

--- a/xbmc/interfaces/python/xbmcmodule/PythonPlayer.cpp
+++ b/xbmc/interfaces/python/xbmcmodule/PythonPlayer.cpp
@@ -29,12 +29,12 @@ using namespace PYXBMC;
 
 struct SPyEvent
 {
-  SPyEvent(CPythonPlayer* player
-         , const char*    function)
+  SPyEvent(CPythonPlayer *player, const char *function, const std::vector<int> &params=std::vector<int>())
   {
     m_player   = player;
     m_player->Acquire();
     m_function = function;
+    m_params = params;
   }
 
   ~SPyEvent()
@@ -44,6 +44,7 @@ struct SPyEvent
 
   const char*    m_function;
   CPythonPlayer* m_player;
+  std::vector<int> m_params;
 };
 
 /*
@@ -55,7 +56,14 @@ static int SPyEvent_Function(void* e)
   PyObject* ret    = NULL;
 
   if(object->m_player->m_callback)
-    ret = PyObject_CallMethod(object->m_player->m_callback, (char*)object->m_function, NULL);
+   {
+    if (object->m_params.size() == 2)
+      ret = PyObject_CallMethod(object->m_player->m_callback, (char*)object->m_function, "ii", object->m_params[0], object->m_params[1]);
+    else if (object->m_params.size() == 1)
+      ret = PyObject_CallMethod(object->m_player->m_callback, (char*)object->m_function, "i", object->m_params[0]);
+    else
+      ret = PyObject_CallMethod(object->m_player->m_callback, (char*)object->m_function, NULL);
+   }
 
   if(ret)
   {

--- a/xbmc/interfaces/python/xbmcmodule/PythonPlayer.cpp
+++ b/xbmc/interfaces/python/xbmcmodule/PythonPlayer.cpp
@@ -130,6 +130,37 @@ void CPythonPlayer::OnPlayBackResumed()
   g_pythonParser.PulseGlobalEvent();
 }
 
+void CPythonPlayer::OnPlayBackSpeedChanged(int iSpeed)
+{
+  std::vector<int> params;
+  params.push_back(iSpeed);
+  PyXBMC_AddPendingCall(m_state, SPyEvent_Function, new SPyEvent(this, "onPlayBackSpeedChanged", params));
+  g_pythonParser.PulseGlobalEvent();
+}
+
+void CPythonPlayer::OnPlayBackSeek(int iTime, int seekOffset)
+{
+  std::vector<int> params;
+  params.push_back(iTime);
+  params.push_back(seekOffset);
+  PyXBMC_AddPendingCall(m_state, SPyEvent_Function, new SPyEvent(this, "onPlayBackSeek", params));
+  g_pythonParser.PulseGlobalEvent();
+}
+
+void CPythonPlayer::OnPlayBackSeekChapter(int iChapter)
+{
+  std::vector<int> params;
+  params.push_back(iChapter);
+  PyXBMC_AddPendingCall(m_state, SPyEvent_Function, new SPyEvent(this, "onPlayBackSeekChapter", params));
+  g_pythonParser.PulseGlobalEvent();
+}
+
+void CPythonPlayer::OnQueueNextItem()
+{
+  PyXBMC_AddPendingCall(m_state, SPyEvent_Function, new SPyEvent(this, "onQueueNextItem"));
+  g_pythonParser.PulseGlobalEvent();
+}
+
 void CPythonPlayer::SetCallback(PyThreadState *state, PyObject *object)
 {
   /* python lock should be held */

--- a/xbmc/interfaces/python/xbmcmodule/PythonPlayer.h
+++ b/xbmc/interfaces/python/xbmcmodule/PythonPlayer.h
@@ -30,6 +30,10 @@ int Py_XBMC_Event_OnPlayBackEnded(void* arg);
 int Py_XBMC_Event_OnPlayBackStopped(void* arg);
 int Py_XBMC_Event_OnPlayBackPaused(void* arg);
 int Py_XBMC_Event_OnPlayBackResumed(void* arg);
+int Py_XBMC_Event_OnPlayBackSpeedChanged(int iSpeed);
+int Py_XBMC_Event_OnPlayBackSeek(int iTime, int seekOffset);
+int Py_XBMC_Event_OnPlayBackSeekChapter(int iChapter);
+int Py_XBMC_Event_OnQueueNextItem(void* arg);
 
 class CPythonPlayer : public IPlayerCallback
 {
@@ -41,7 +45,10 @@ public:
   void    OnPlayBackPaused();
   void    OnPlayBackResumed();
   void    OnPlayBackStopped();
-  void    OnQueueNextItem() {}; // unimplemented
+  void    OnPlayBackSpeedChanged(int iSpeed);
+  void    OnPlayBackSeek(int iTime, int seekOffset);
+  void    OnPlayBackSeekChapter(int iChapter);
+  void    OnQueueNextItem();
 
   void    Acquire();
   void    Release();

--- a/xbmc/interfaces/python/xbmcmodule/player.cpp
+++ b/xbmc/interfaces/python/xbmcmodule/player.cpp
@@ -326,6 +326,63 @@ namespace PYXBMC
     return Py_None;
   }
 
+  // Player_OnPlayBackSpeedChanged(speed)
+  PyDoc_STRVAR(onPlayBackSpeedChanged__doc__,
+    "onPlayBackSpeedChanged(speed) -- onPlayBackSpeedChanged method.\n"
+    "\n"
+    "speed          : integer - current speed of player.\n"
+    "\n"
+    "*Note, negative speed means player is rewinding, 1 is normal playback speed.\n"
+    "\n"
+    "Will be called when players speed changes. (eg. user FF/RW)");
+
+  PyObject* Player_OnPlayBackSpeedChanged(PyObject *self, PyObject *args)
+  {
+    Py_INCREF(Py_None);
+    return Py_None;
+  }
+
+  // Player_OnPlayBackSeek(time, seekOffset)
+  PyDoc_STRVAR(onPlayBackSeek__doc__,
+    "onPlayBackSeek(time, seekOffset) -- onPlayBackSeek method.\n"
+    "\n"
+    "time           : integer - time to seek to.\n"
+    "seekOffset     : integer - ?.\n"
+    "\n"
+    "Will be called when user seeks to a time");
+
+  PyObject* Player_OnPlayBackSeek(PyObject *self, PyObject *args)
+  {
+    Py_INCREF(Py_None);
+    return Py_None;
+  }
+
+  // Player_OnPlayBackSeekChapter(chapter)
+  PyDoc_STRVAR(onPlayBackSeekChapter__doc__,
+    "onPlayBackSeekChapter(chapter) -- onPlayBackSeekChapter method.\n"
+    "\n"
+    "chapter        : integer - chapter to seek to.\n"
+    "\n"
+    "Will be called when user performs a chapter seek");
+
+  PyObject* Player_OnPlayBackSeekChapter(PyObject *self, PyObject *args)
+  {
+    Py_INCREF(Py_None);
+    return Py_None;
+  }
+
+  // Player_OnQueueNextItem()
+  PyDoc_STRVAR(onQueueNextItem__doc__,
+    "onQueueNextItem() -- onQueueNextItem method.\n"
+    "\n"
+    "Will be called when player requests next item");
+
+  PyObject* Player_OnQueueNextItem(PyObject *self, PyObject *args)
+  {
+    Py_INCREF(Py_None);
+    return Py_None;
+  }
+
   // Player_IsPlaying
   PyDoc_STRVAR(isPlaying__doc__,
     "isPlaying() -- returns True is xbmc is playing a file.");
@@ -698,6 +755,10 @@ namespace PYXBMC
     {(char*)"onPlayBackStopped", (PyCFunction)Player_OnPlayBackStopped, METH_VARARGS, onPlayBackStopped__doc__},
     {(char*)"onPlayBackPaused", (PyCFunction)Player_OnPlayBackPaused, METH_VARARGS, onPlayBackPaused__doc__},
     {(char*)"onPlayBackResumed", (PyCFunction)Player_OnPlayBackResumed, METH_VARARGS, onPlayBackResumed__doc__},
+    {(char*)"onPlayBackSpeedChanged", (PyCFunction)Player_OnPlayBackSpeedChanged, METH_VARARGS, onPlayBackSpeedChanged__doc__},
+    {(char*)"onPlayBackSeek", (PyCFunction)Player_OnPlayBackSeek, METH_VARARGS, onPlayBackSeek__doc__},
+    {(char*)"onPlayBackSeekChapter", (PyCFunction)Player_OnPlayBackSeekChapter, METH_VARARGS, onPlayBackSeekChapter__doc__},
+    {(char*)"onQueueNextItem", (PyCFunction)Player_OnQueueNextItem, METH_VARARGS, onQueueNextItem__doc__},
     {(char*)"isPlaying", (PyCFunction)Player_IsPlaying, METH_VARARGS, isPlaying__doc__},
     {(char*)"isPlayingAudio", (PyCFunction)Player_IsPlayingAudio, METH_VARARGS, isPlayingAudio__doc__},
     {(char*)"isPlayingVideo", (PyCFunction)Player_IsPlayingVideo, METH_VARARGS, isPlayingVideo__doc__},


### PR DESCRIPTION
[python] added support for params in SPyEvent(_Function)

is push one to add the missing onPlayback\* events to python. replaces #994.

thanks @jmarshallnz, but i think it was hopeless to correct my other branch.
