### PR TITLE
added <disabledColorDiffuse> so textures can be faded when not enabled

### DIFF
--- a/xbmc/guilib/GUIButtonControl.cpp
+++ b/xbmc/guilib/GUIButtonControl.cpp
@@ -239,10 +239,11 @@ void CGUIButtonControl::SetAlpha(unsigned char alpha)
 
 bool CGUIButtonControl::UpdateColors()
 {
+  CGUIInfoColor color = m_enabled ? m_enabledDiffuseColor : m_disabledDiffuseColor;
   bool changed = CGUIControl::UpdateColors();
   changed |= m_label.UpdateColors();
-  changed |= m_imgFocus.SetDiffuseColor(m_diffuseColor);
-  changed |= m_imgNoFocus.SetDiffuseColor(m_diffuseColor);
+  changed |= m_imgFocus.SetDiffuseColor(color);
+  changed |= m_imgNoFocus.SetDiffuseColor(color);
 
   return changed;
 }

--- a/xbmc/guilib/GUICheckMarkControl.cpp
+++ b/xbmc/guilib/GUICheckMarkControl.cpp
@@ -197,10 +197,11 @@ void CGUICheckMarkControl::PythonSetDisabledColor(color_t disabledColor)
 
 bool CGUICheckMarkControl::UpdateColors()
 {
+  CGUIInfoColor color = m_enabled ? m_enabledDiffuseColor : m_disabledDiffuseColor;
   bool changed = CGUIControl::UpdateColors();
   changed |= m_label.UpdateColors();
-  changed |= m_imgCheckMark.SetDiffuseColor(m_diffuseColor);
-  changed |= m_imgCheckMarkNoFocus.SetDiffuseColor(m_diffuseColor);
+  changed |= m_imgCheckMark.SetDiffuseColor(color);
+  changed |= m_imgCheckMarkNoFocus.SetDiffuseColor(color);
 
   return changed;
 }

--- a/xbmc/guilib/GUIControl.cpp
+++ b/xbmc/guilib/GUIControl.cpp
@@ -44,6 +44,8 @@ CGUIControl::CGUIControl()
   m_enableCondition = 0;
   m_enabled = true;
   m_diffuseColor = 0xffffffff;
+  m_enabledDiffuseColor = 0xffffffff;
+  m_disabledDiffuseColor = 0x60ffffff;
   m_posX = 0;
   m_posY = 0;
   m_width = 0;
@@ -71,6 +73,8 @@ CGUIControl::CGUIControl(int parentID, int controlID, float posX, float posY, fl
   m_visible = VISIBLE;
   m_visibleFromSkinCondition = true;
   m_diffuseColor = 0xffffffff;
+  m_enabledDiffuseColor = 0xffffffff;
+  m_disabledDiffuseColor = 0x60ffffff;
   m_forceHidden = false;
   m_visibleCondition = 0;
   m_enableCondition = 0;
@@ -419,6 +423,16 @@ bool CGUIControl::SetColorDiffuse(const CGUIInfoColor &color)
   bool changed = m_diffuseColor != color;
   m_diffuseColor = color;
   return changed;
+}
+
+void CGUIControl::SetEnabledColorDiffuse(const CGUIInfoColor &color)
+{
+  m_enabledDiffuseColor = color;
+}
+
+void CGUIControl::SetDisabledColorDiffuse(const CGUIInfoColor &color)
+{
+  m_disabledDiffuseColor = color;
 }
 
 float CGUIControl::GetXPosition() const

--- a/xbmc/guilib/GUIControl.h
+++ b/xbmc/guilib/GUIControl.h
@@ -161,6 +161,8 @@ public:
   virtual void SetHitRect(const CRect &rect);
   virtual void SetCamera(const CPoint &camera);
   bool SetColorDiffuse(const CGUIInfoColor &color);
+  void SetEnabledColorDiffuse(const CGUIInfoColor &color);
+  void SetDisabledColorDiffuse(const CGUIInfoColor &color);
   CPoint GetRenderPosition() const;
   virtual float GetXPosition() const;
   virtual float GetYPosition() const;
@@ -322,6 +324,8 @@ protected:
   float m_width;
   CRect m_hitRect;
   CGUIInfoColor m_diffuseColor;
+  CGUIInfoColor m_enabledDiffuseColor;
+  CGUIInfoColor m_disabledDiffuseColor;
   int m_controlID;
   int m_parentID;
   bool m_bHasFocus;

--- a/xbmc/guilib/GUIControlFactory.cpp
+++ b/xbmc/guilib/GUIControlFactory.cpp
@@ -580,6 +580,7 @@ CGUIControl* CGUIControlFactory::Create(int parentID, const CRect &rect, TiXmlEl
 
   int pageControl = 0;
   CGUIInfoColor colorDiffuse(0xFFFFFFFF);
+  CGUIInfoColor disabledColorDiffuse(0x60FFFFFF);
   int defaultControl = 0;
   bool  defaultAlways = false;
   CStdString strTmp;
@@ -738,6 +739,7 @@ CGUIControl* CGUIControlFactory::Create(int parentID, const CRect &rect, TiXmlEl
   XMLUtils::GetInt(pControlNode, "pagecontrol", pageControl);
 
   GetInfoColor(pControlNode, "colordiffuse", colorDiffuse, parentID);
+  GetInfoColor(pControlNode, "disabledcolordiffuse", disabledColorDiffuse, parentID);
 
   GetConditionalVisibility(pControlNode, visibleCondition, allowHiddenFocus);
   XMLUtils::GetString(pControlNode, "enable", enableCondition);
@@ -1318,7 +1320,10 @@ CGUIControl* CGUIControlFactory::Create(int parentID, const CRect &rect, TiXmlEl
     control->SetVisibleCondition(visibleCondition, allowHiddenFocus);
     control->SetEnableCondition(enableCondition);
     control->SetAnimations(animations);
-    control->SetColorDiffuse(colorDiffuse);
+    CGUIInfoColor color = control->IsDisabled() ? disabledColorDiffuse : colorDiffuse;
+    control->SetColorDiffuse(color);
+    control->SetEnabledColorDiffuse(colorDiffuse);
+    control->SetDisabledColorDiffuse(disabledColorDiffuse);
     control->SetNavigationActions(upActions, downActions, leftActions, rightActions, backActions);
     control->SetPulseOnSelect(bPulse);
     if (hasCamera)

--- a/xbmc/guilib/GUIMoverControl.cpp
+++ b/xbmc/guilib/GUIMoverControl.cpp
@@ -252,9 +252,10 @@ bool CGUIMoverControl::SetAlpha(unsigned char alpha)
 
 bool CGUIMoverControl::UpdateColors()
 {
+  CGUIInfoColor color = m_enabled ? m_enabledDiffuseColor : m_disabledDiffuseColor;
   bool changed = CGUIControl::UpdateColors();
-  changed |= m_imgFocus.SetDiffuseColor(m_diffuseColor);
-  changed |= m_imgNoFocus.SetDiffuseColor(m_diffuseColor);
+  changed |= m_imgFocus.SetDiffuseColor(color);
+  changed |= m_imgNoFocus.SetDiffuseColor(color);
 
   return changed;
 }

--- a/xbmc/guilib/GUIProgressControl.cpp
+++ b/xbmc/guilib/GUIProgressControl.cpp
@@ -189,12 +189,13 @@ void CGUIProgressControl::SetInfo(int iInfo)
 
 bool CGUIProgressControl::UpdateColors()
 {
+  CGUIInfoColor color = m_enabled ? m_enabledDiffuseColor : m_disabledDiffuseColor;
   bool changed = CGUIControl::UpdateColors();
-  changed |= m_guiBackground.SetDiffuseColor(m_diffuseColor);
-  changed |= m_guiRight.SetDiffuseColor(m_diffuseColor);
-  changed |= m_guiLeft.SetDiffuseColor(m_diffuseColor);
-  changed |= m_guiMid.SetDiffuseColor(m_diffuseColor);
-  changed |= m_guiOverlay.SetDiffuseColor(m_diffuseColor);
+  changed |= m_guiBackground.SetDiffuseColor(color);
+  changed |= m_guiRight.SetDiffuseColor(color);
+  changed |= m_guiLeft.SetDiffuseColor(color);
+  changed |= m_guiMid.SetDiffuseColor(color);
+  changed |= m_guiOverlay.SetDiffuseColor(color);
 
   return changed;
 }

--- a/xbmc/guilib/GUIRadioButtonControl.cpp
+++ b/xbmc/guilib/GUIRadioButtonControl.cpp
@@ -168,9 +168,10 @@ CStdString CGUIRadioButtonControl::GetDescription() const
 
 bool CGUIRadioButtonControl::UpdateColors()
 {
+  CGUIInfoColor color = m_enabled ? m_enabledDiffuseColor : m_disabledDiffuseColor;
   bool changed = CGUIButtonControl::UpdateColors();
-  changed |= m_imgRadioOn.SetDiffuseColor(m_diffuseColor);
-  changed |= m_imgRadioOff.SetDiffuseColor(m_diffuseColor);
+  changed |= m_imgRadioOn.SetDiffuseColor(color);
+  changed |= m_imgRadioOff.SetDiffuseColor(color);
 
   return changed;
 }

--- a/xbmc/guilib/GUIResizeControl.cpp
+++ b/xbmc/guilib/GUIResizeControl.cpp
@@ -231,9 +231,10 @@ bool CGUIResizeControl::SetAlpha(unsigned char alpha)
 
 bool CGUIResizeControl::UpdateColors()
 {
+  CGUIInfoColor color = m_enabled ? m_enabledDiffuseColor : m_disabledDiffuseColor;
   bool changed = CGUIControl::UpdateColors();
-  changed |= m_imgFocus.SetDiffuseColor(m_diffuseColor);
-  changed |= m_imgNoFocus.SetDiffuseColor(m_diffuseColor);
+  changed |= m_imgFocus.SetDiffuseColor(color);
+  changed |= m_imgNoFocus.SetDiffuseColor(color);
 
   return changed;
 }

--- a/xbmc/guilib/GUIScrollBarControl.cpp
+++ b/xbmc/guilib/GUIScrollBarControl.cpp
@@ -369,12 +369,13 @@ CStdString CGUIScrollBar::GetDescription() const
 
 bool CGUIScrollBar::UpdateColors()
 {
+  CGUIInfoColor color = m_enabled ? m_enabledDiffuseColor : m_disabledDiffuseColor;
   bool changed = CGUIControl::UpdateColors();
-  changed |= m_guiBackground.SetDiffuseColor(m_diffuseColor);
-  changed |= m_guiBarNoFocus.SetDiffuseColor(m_diffuseColor);
-  changed |= m_guiBarFocus.SetDiffuseColor(m_diffuseColor);
-  changed |= m_guiNibNoFocus.SetDiffuseColor(m_diffuseColor);
-  changed |= m_guiNibFocus.SetDiffuseColor(m_diffuseColor);
+  changed |= m_guiBackground.SetDiffuseColor(color);
+  changed |= m_guiBarNoFocus.SetDiffuseColor(color);
+  changed |= m_guiBarFocus.SetDiffuseColor(color);
+  changed |= m_guiNibNoFocus.SetDiffuseColor(color);
+  changed |= m_guiNibFocus.SetDiffuseColor(color);
 
   return changed;
 }

--- a/xbmc/guilib/GUISelectButtonControl.cpp
+++ b/xbmc/guilib/GUISelectButtonControl.cpp
@@ -436,12 +436,13 @@ void CGUISelectButtonControl::SetPosition(float posX, float posY)
 
 bool CGUISelectButtonControl::UpdateColors()
 {
+  CGUIInfoColor color = m_enabled ? m_enabledDiffuseColor : m_disabledDiffuseColor;
   bool changed = CGUIButtonControl::UpdateColors();
-  changed |= m_imgLeft.SetDiffuseColor(m_diffuseColor);
-  changed |= m_imgLeftFocus.SetDiffuseColor(m_diffuseColor);
-  changed |= m_imgRight.SetDiffuseColor(m_diffuseColor);
-  changed |= m_imgRightFocus.SetDiffuseColor(m_diffuseColor);
-  changed |= m_imgBackground.SetDiffuseColor(m_diffuseColor);
+  changed |= m_imgLeft.SetDiffuseColor(color);
+  changed |= m_imgLeftFocus.SetDiffuseColor(color);
+  changed |= m_imgRight.SetDiffuseColor(color);
+  changed |= m_imgRightFocus.SetDiffuseColor(color);
+  changed |= m_imgBackground.SetDiffuseColor(color);
 
   return changed;
 }

--- a/xbmc/guilib/GUISliderControl.cpp
+++ b/xbmc/guilib/GUISliderControl.cpp
@@ -422,10 +422,11 @@ CStdString CGUISliderControl::GetDescription() const
 
 bool CGUISliderControl::UpdateColors()
 {
+  CGUIInfoColor color = m_enabled ? m_enabledDiffuseColor : m_disabledDiffuseColor;
   bool changed = CGUIControl::UpdateColors();
-  changed |= m_guiBackground.SetDiffuseColor(m_diffuseColor);
-  changed |= m_guiMid.SetDiffuseColor(m_diffuseColor);
-  changed |= m_guiMidFocus.SetDiffuseColor(m_diffuseColor);
+  changed |= m_guiBackground.SetDiffuseColor(color);
+  changed |= m_guiMid.SetDiffuseColor(color);
+  changed |= m_guiMidFocus.SetDiffuseColor(color);
 
   return changed;
 }

--- a/xbmc/guilib/GUISpinControl.cpp
+++ b/xbmc/guilib/GUISpinControl.cpp
@@ -942,12 +942,13 @@ void CGUISpinControl::ChangePage(int amount)
 
 bool CGUISpinControl::UpdateColors()
 {
+  CGUIInfoColor color = m_enabled ? m_enabledDiffuseColor : m_disabledDiffuseColor;
   bool changed = CGUIControl::UpdateColors();
   changed |= m_label.UpdateColors();
-  changed |= m_imgspinDownFocus.SetDiffuseColor(m_diffuseColor);
-  changed |= m_imgspinDown.SetDiffuseColor(m_diffuseColor);
-  changed |= m_imgspinUp.SetDiffuseColor(m_diffuseColor);
-  changed |= m_imgspinUpFocus.SetDiffuseColor(m_diffuseColor);
+  changed |= m_imgspinDownFocus.SetDiffuseColor(color);
+  changed |= m_imgspinDown.SetDiffuseColor(color);
+  changed |= m_imgspinUp.SetDiffuseColor(color);
+  changed |= m_imgspinUpFocus.SetDiffuseColor(color);
 
   return changed;
 }

--- a/xbmc/guilib/GUISpinControlEx.cpp
+++ b/xbmc/guilib/GUISpinControlEx.cpp
@@ -104,8 +104,9 @@ void CGUISpinControlEx::SetHeight(float height)
 
 bool CGUISpinControlEx::UpdateColors()
 {
+  CGUIInfoColor color = m_enabled ? m_diffuseColor : m_disabledDiffuseColor;
   bool changed = CGUISpinControl::UpdateColors();
-  changed |= m_buttonControl.SetColorDiffuse(m_diffuseColor);
+  changed |= m_buttonControl.SetColorDiffuse(color);
   changed |= m_buttonControl.UpdateColors();
 
   return changed;

--- a/xbmc/guilib/GUIToggleButtonControl.cpp
+++ b/xbmc/guilib/GUIToggleButtonControl.cpp
@@ -130,8 +130,9 @@ void CGUIToggleButtonControl::SetHeight(float height)
 
 bool CGUIToggleButtonControl::UpdateColors()
 {
+  CGUIInfoColor color = m_enabled ? m_enabledDiffuseColor : m_disabledDiffuseColor;
   bool changed = CGUIButtonControl::UpdateColors();
-  changed |= m_selectButton.SetColorDiffuse(m_diffuseColor);
+  changed |= m_selectButton.SetColorDiffuse(color);
   changed |= m_selectButton.UpdateColors();
 
   return changed;


### PR DESCRIPTION
i know this won't get much love, but i'll put it out there. :)

it allows a more visible indication if a control is disabled. especially useful in settings where skinners can not control looks with <animation> tags.
