### PR TITLE
Provide skins access to the Library ID of a video file.

### DIFF
--- a/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
@@ -231,6 +231,7 @@ void CGUIDialogVideoInfo::SetMovie(const CFileItem *item)
   // content type to determine visibility, so we'll set the wrong label)
   ClearCastList();
   VIDEODB_CONTENT_TYPE type = (VIDEODB_CONTENT_TYPE)m_movieItem->GetVideoContentType();
+  m_movieItem->SetProperty("videodbid", m_movieItem->GetVideoInfoTag()->m_iDbId);
   if (type == VIDEODB_CONTENT_MUSICVIDEOS)
   { // music video
     const std::vector<std::string> &artists = m_movieItem->GetVideoInfoTag()->m_artist;


### PR DESCRIPTION
This is much like the PR for the music section.  This will allow skins to pass a Database ID to an addon, allowing the addon a direct and accurate for retrieving Video Info(ie Title, path)  Would be useful for the Artwork Downloader addon.

This provides 'ListItem.Property("VideoDbId')' which will contain the Database ID.  It will work with Movies, MusicVideos, TV Shows, TV Episodes.  
