### PR TITLE
Return appropriate type from Addon.getSetting()

### DIFF
--- a/xbmc/addons/Addon.cpp
+++ b/xbmc/addons/Addon.cpp
@@ -463,6 +463,53 @@ CStdString CAddon::GetSetting(const CStdString& key)
   return "";
 }
 
+SETTINGS_TYPE TypeFromSetting(const char *type)
+{
+  if (!type)
+    return SETTINGS_UNKNOWN;
+  if (strcmpi(type, "text") == 0 || strcmpi(type, "ipaddress") == 0 ||
+      strcmpi(type, "video") == 0 || strcmpi(type, "audio") == 0 ||
+      strcmpi(type, "image") == 0 || strcmpi(type, "folder") == 0 ||
+      strcmpi(type, "executable") == 0 || strcmpi(type, "file") == 0 ||
+      strcmpi(type, "date") == 0 || strcmpi(type, "time") == 0 ||
+      strcmpi(type, "action") == 0 || strcmpi(type, "addon") == 0 ||
+      strcmpi(type, "select") == 0) // select ??
+  { // normally in a button control
+    return SETTINGS_STRING;
+  }
+  else if (strcmpi(type, "number") == 0 || strcmpi(type, "enum") == 0 || strcmpi(type, "rangeofnum") == 0)
+    return SETTINGS_INT;
+  else if (strcmpi(type, "slider") == 0) // This could potentially hold an integer (or percent) depending on option type
+    return SETTINGS_FLOAT;
+  else if (strcmpi(type, "bool") == 0)
+    return SETTINGS_BOOL;
+  return SETTINGS_UNKNOWN;
+}
+
+SETTINGS_TYPE CAddon::GetSettingType(const CStdString& key)
+{
+  if (!LoadSettings() || !m_addonXmlDoc.RootElement())
+    return SETTINGS_UNKNOWN; // no settings available
+
+  // run through the XML and get the setting type
+  const TiXmlElement* category = m_addonXmlDoc.RootElement()->FirstChildElement("category");
+  if (!category)
+    category = m_addonXmlDoc.RootElement();
+  while (category)
+  {
+    const TiXmlElement *setting = category->FirstChildElement("setting");
+    while (setting)
+    {
+      const char *id = setting->Attribute("id");
+      if (key == id)
+        return TypeFromSetting(setting->Attribute("type"));
+      setting = setting->NextSiblingElement("setting");
+    }
+    category = category->NextSiblingElement("category");
+  }
+  return SETTINGS_UNKNOWN;
+}
+
 void CAddon::UpdateSetting(const CStdString& key, const CStdString& value)
 {
   LoadSettings();

--- a/xbmc/addons/Addon.h
+++ b/xbmc/addons/Addon.h
@@ -132,6 +132,14 @@ public:
    */
   virtual CStdString GetSetting(const CStdString& key);
 
+  /*! \brief Retrieve a particular settings type
+   If a previously configured user setting is available, we return it's type, else we return TYPE_UNKNOWN
+   \param key the id of the setting to retrieve
+   \return the current value of the setting, or the default if the setting has yet to be configured.
+   \sa LoadSettings, LoadUserSettings, SaveSettings, HasSettings, HasUserSettings, UpdateSetting
+   */
+  virtual SETTINGS_TYPE GetSettingType(const CStdString &key);
+
   TiXmlElement* GetSettingsXML();
   virtual CStdString GetString(uint32_t id);
 

--- a/xbmc/addons/AddonDll.h
+++ b/xbmc/addons/AddonDll.h
@@ -46,7 +46,6 @@ namespace ADDON
 
     // addon settings
     virtual void SaveSettings();
-    virtual CStdString GetSetting(const CStdString& key);
 
     bool Create();
     virtual void Stop();
@@ -386,12 +385,6 @@ void CAddonDll<TheDll, TheStruct, TheProps>::SaveSettings()
   CAddon::SaveSettings();
   if (m_initialized)
     TransferSettings();
-}
-
-template<class TheDll, typename TheStruct, typename TheProps>
-CStdString CAddonDll<TheDll, TheStruct, TheProps>::GetSetting(const CStdString& key)
-{
-  return CAddon::GetSetting(key);
 }
 
 template<class TheDll, typename TheStruct, typename TheProps>

--- a/xbmc/addons/IAddon.h
+++ b/xbmc/addons/IAddon.h
@@ -76,6 +76,12 @@ namespace ADDON
   typedef std::map<CStdString, CStdString> InfoMap;
   class AddonProps;
 
+  enum SETTINGS_TYPE { SETTINGS_UNKNOWN = 0,
+                       SETTINGS_STRING,
+                       SETTINGS_INT,
+                       SETTINGS_FLOAT,
+                       SETTINGS_BOOL };
+
   class IAddon : public boost::enable_shared_from_this<IAddon>
   {
   public:
@@ -107,6 +113,7 @@ namespace ADDON
     virtual void SaveSettings() =0;
     virtual void UpdateSetting(const CStdString& key, const CStdString& value) =0;
     virtual CStdString GetSetting(const CStdString& key) =0;
+    virtual SETTINGS_TYPE GetSettingType(const CStdString &key) =0;
     virtual TiXmlElement* GetSettingsXML() =0;
     virtual CStdString GetString(uint32_t id) =0;
     virtual const ADDONDEPS &GetDeps() const =0;

--- a/xbmc/interfaces/python/xbmcmodule/PythonAddon.cpp
+++ b/xbmc/interfaces/python/xbmcmodule/PythonAddon.cpp
@@ -184,7 +184,7 @@ namespace PYXBMC
   }
 
     PyDoc_STRVAR(getSetting__doc__,
-    "getSetting(id) -- Returns the value of a setting as a unicode string.\n"
+    "getSetting(id) -- Returns the value of a setting as a boolean, integer, float or string.\n"
     "\n"
     "id        : string - id of the setting that the module needs to access.\n"
     "\n"
@@ -208,7 +208,20 @@ namespace PYXBMC
       return NULL;
     };
 
-    return Py_BuildValue((char*)"s", self->pAddon->GetSetting(id).c_str());
+    std::string value = self->pAddon->GetSetting(id);
+    ADDON::SETTINGS_TYPE type = self->pAddon->GetSettingType(id);
+    switch (type)
+    {
+    case ADDON::SETTINGS_BOOL:
+      return Py_BuildValue((char*)"b", value == "true");
+    case ADDON::SETTINGS_INT:
+      return Py_BuildValue((char*)"i", strtol(value.c_str(), NULL, 10));
+    case ADDON::SETTINGS_FLOAT:
+      return Py_BuildValue((char*)"f", strtod(value.c_str(), NULL));
+    case ADDON::SETTINGS_STRING:
+    default:
+      return Py_BuildValue((char*)"s", value.c_str());
+    }
   }
 
   PyDoc_STRVAR(setSetting__doc__,

--- a/xbmc/interfaces/python/xbmcmodule/PythonAddon.cpp
+++ b/xbmc/interfaces/python/xbmcmodule/PythonAddon.cpp
@@ -184,7 +184,7 @@ namespace PYXBMC
   }
 
     PyDoc_STRVAR(getSetting__doc__,
-    "getSetting(id) -- Returns the value of a setting as a boolean, integer, float or string.\n"
+    "getSetting(id) -- Returns the value of a setting as a boolean, integer, float or unicode string.\n"
     "\n"
     "id        : string - id of the setting that the module needs to access.\n"
     "\n"
@@ -220,7 +220,7 @@ namespace PYXBMC
       return Py_BuildValue((char*)"f", strtod(value.c_str(), NULL));
     case ADDON::SETTINGS_STRING:
     default:
-      return Py_BuildValue((char*)"s", value.c_str());
+      return PyUnicode_DecodeUTF8(value.c_str(), value.size(), "replace");
     }
   }
 
@@ -308,7 +308,7 @@ namespace PYXBMC
   }
 
   PyDoc_STRVAR(getAddonInfo__doc__,
-    "getAddonInfo(id) -- Returns the value of an addon property as a string.\n"
+    "getAddonInfo(id) -- Returns the value of an addon property as a unicode string.\n"
     "\n"
     "id        : string - id of the property that the module needs to access.\n"
     "\n"
@@ -336,34 +336,35 @@ namespace PYXBMC
       return NULL;
     };
 
+    CStdString value;
     if (strcmpi(id, "author") == 0)
-      return Py_BuildValue((char*)"s", self->pAddon->Author().c_str());
+      value = self->pAddon->Author();
     else if (strcmpi(id, "changelog") == 0)
-      return Py_BuildValue((char*)"s", self->pAddon->ChangeLog().c_str());
+      value = self->pAddon->ChangeLog();
     else if (strcmpi(id, "description") == 0)
-      return Py_BuildValue((char*)"s", self->pAddon->Description().c_str());
+      value = self->pAddon->Description();
     else if (strcmpi(id, "disclaimer") == 0)
-      return Py_BuildValue((char*)"s", self->pAddon->Disclaimer().c_str());
+      value = self->pAddon->Disclaimer();
     else if (strcmpi(id, "fanart") == 0)
-      return Py_BuildValue((char*)"s", self->pAddon->FanArt().c_str());
+      value = self->pAddon->FanArt();
     else if (strcmpi(id, "icon") == 0)
-      return Py_BuildValue((char*)"s", self->pAddon->Icon().c_str());
+      value = self->pAddon->Icon();
     else if (strcmpi(id, "id") == 0)
-      return Py_BuildValue((char*)"s", self->pAddon->ID().c_str());
+      value = self->pAddon->ID();
     else if (strcmpi(id, "name") == 0)
-      return Py_BuildValue((char*)"s", self->pAddon->Name().c_str());
+      value = self->pAddon->Name();
     else if (strcmpi(id, "path") == 0)
-      return Py_BuildValue((char*)"s", self->pAddon->Path().c_str());
+      value = self->pAddon->Path();
     else if (strcmpi(id, "profile") == 0)
-      return Py_BuildValue((char*)"s", self->pAddon->Profile().c_str());
+      value = self->pAddon->Profile();
     else if (strcmpi(id, "stars") == 0)
-      return Py_BuildValue((char*)"i", self->pAddon->Stars());
+      value = self->pAddon->Stars();
     else if (strcmpi(id, "summary") == 0)
-      return Py_BuildValue((char*)"s", self->pAddon->Summary().c_str());
+      value = self->pAddon->Summary();
     else if (strcmpi(id, "type") == 0)
-      return Py_BuildValue((char*)"s", ADDON::TranslateType(self->pAddon->Type()).c_str());
+      value = ADDON::TranslateType(self->pAddon->Type());
     else if (strcmpi(id, "version") == 0)
-      return Py_BuildValue((char*)"s", self->pAddon->Version().c_str());
+      value = self->pAddon->Version().c_str();
     else
     {
       CStdString error;
@@ -371,6 +372,7 @@ namespace PYXBMC
       PyErr_SetString(PyExc_ValueError, error.c_str());
       return NULL;
     }
+    return PyUnicode_DecodeUTF8(value.c_str(), value.size(), "replace");
   }
 
   PyMethodDef Addon_methods[] = {

--- a/xbmc/interfaces/python/xbmcmodule/controledit.cpp
+++ b/xbmc/interfaces/python/xbmcmodule/controledit.cpp
@@ -173,7 +173,7 @@ namespace PYXBMC
 
   // getLabel() Method
   PyDoc_STRVAR(getLabel__doc__,
-    "getLabel() -- Returns the text heading for this edit control.\n"
+    "getLabel() -- Returns the unicode text heading for this edit control.\n"
     "\n"
     "example:\n"
     "  - label = self.edit.getLabel()\n");
@@ -181,7 +181,7 @@ namespace PYXBMC
   PyObject* ControlEdit_GetLabel(ControlLabel *self, PyObject *args)
   {
     if (!self->pGUIControl) return NULL;
-    return Py_BuildValue((char*)"s", self->strText.c_str());
+    return PyUnicode_DecodeUTF8(self->strText.c_str(), self->strText.size(), "replace");
   }
 
   // setLabel() Method
@@ -211,7 +211,7 @@ namespace PYXBMC
 
     // getText() Method
   PyDoc_STRVAR(getText__doc__,
-    "getText() -- Returns the text value for this edit control.\n"
+    "getText() -- Returns the unicode text value for this edit control.\n"
     "\n"
     "example:\n"
     "  - value = self.edit.getText()\n");
@@ -224,7 +224,7 @@ namespace PYXBMC
     CGUIMessage msg(GUI_MSG_ITEM_SELECTED, pControl->iParentId, pControl->iControlId);
     g_windowManager.SendMessage(msg, pControl->iParentId);
 
-    return Py_BuildValue((char*)"s", msg.GetLabel().c_str());
+    return PyUnicode_DecodeUTF8(msg.GetLabel().c_str(), msg.GetLabel().size(), "replace");
   }
 
   PyMethodDef ControlEdit_methods[] = {

--- a/xbmc/interfaces/python/xbmcmodule/controllabel.cpp
+++ b/xbmc/interfaces/python/xbmcmodule/controllabel.cpp
@@ -154,7 +154,7 @@ namespace PYXBMC
 
   // getLabel() Method
   PyDoc_STRVAR(getLabel__doc__,
-    "getLabel() -- Returns the text value for this label.\n"
+    "getLabel() -- Returns the unicode text value for this label.\n"
     "\n"
     "example:\n"
     "  - label = self.label.getLabel()\n");
@@ -162,7 +162,7 @@ namespace PYXBMC
   PyObject* ControlLabel_GetLabel(ControlLabel *self, PyObject *args)
   {
     if (!self->pGUIControl) return NULL;
-    return Py_BuildValue((char*)"s", self->strText.c_str());
+    return PyUnicode_DecodeUTF8(self->strText.c_str(), self->strText.size(), "replace");
   }
 
   PyMethodDef ControlLabel_methods[] = {

--- a/xbmc/interfaces/python/xbmcmodule/dialog.cpp
+++ b/xbmc/interfaces/python/xbmcmodule/dialog.cpp
@@ -140,10 +140,10 @@ namespace PYXBMC
     "  2 : ShowAndGetImage\n"
     "  3 : ShowAndGetWriteableDirectory\n"
     "\n"
-    "*Note, If enableMultiple is False (default): returns filename and/or path as a string\n"
+    "*Note, If enableMultiple is False (default): returns filename and/or path as a unicode string\n"
     "       to the location of the highlighted item, if user pressed 'Ok' or a masked item\n"
     "       was selected. Returns the default value if dialog was canceled.\n"
-    "       If enableMultiple is True: returns tuple of marked filenames as a string,"
+    "       If enableMultiple is True: returns tuple of marked filenames as unicode strings,"
     "       if user pressed 'Ok' or a masked item was selected. Returns empty tuple if dialog was canceled.\n"
     "\n"
     "       If type is 0 or 3 the enableMultiple parameter is ignored."
@@ -216,12 +216,12 @@ namespace PYXBMC
         return NULL;
 
       for (unsigned int i = 0; i < valuelist.size(); i++)
-        PyTuple_SetItem(result, i, PyString_FromString(valuelist.at(i).c_str()));
+        PyTuple_SetItem(result, i, PyUnicode_DecodeUTF8(valuelist.at(i).c_str(), valuelist.at(i).size(), "replace"));
 
       return result;
     }
     else
-      return Py_BuildValue((char*)"s", value.c_str());
+      return PyUnicode_DecodeUTF8(value.c_str(), value.size(), "replace");
   }
 
   PyDoc_STRVAR(numeric__doc__,
@@ -237,7 +237,7 @@ namespace PYXBMC
     "  2 : ShowAndGetTime      (default format: HH:MM)\n"
     "  3 : ShowAndGetIPAddress (default format: #.#.#.#)\n"
     "\n"
-    "*Note, Returns the entered data as a string.\n"
+    "*Note, Returns the entered data as a unicode string.\n"
     "       Returns the default value if dialog was canceled.\n"
     "\n"
     "example:\n"
@@ -325,7 +325,7 @@ namespace PYXBMC
         }
       }
     }
-    return Py_BuildValue((char*)"s", value.c_str());
+    return PyUnicode_DecodeUTF8(value.c_str(), value.size(), "replace");
   }
 
   PyDoc_STRVAR(yesno__doc__,

--- a/xbmc/interfaces/python/xbmcmodule/infotagmusic.cpp
+++ b/xbmc/interfaces/python/xbmcmodule/infotagmusic.cpp
@@ -55,56 +55,62 @@ namespace PYXBMC
 
   // InfoTagMusic_GetURL
   PyDoc_STRVAR(getURL__doc__,
-    "getURL() -- returns a string.\n");
+    "getURL() -- returns a unicode string.\n");
 
   PyObject* InfoTagMusic_GetURL(InfoTagMusic *self, PyObject *args)
   {
-    return Py_BuildValue((char*)"s", self->infoTag.GetURL().c_str());
+    std::string value = self->infoTag.GetURL();
+    return PyUnicode_DecodeUTF8(value.c_str(), value.size(), "replace");
   }
 
   // InfoTagMusic_GetTitle
   PyDoc_STRVAR(getTitle__doc__,
-    "getTitle() -- returns a string.\n");
+    "getTitle() -- returns a unicode string.\n");
 
   PyObject* InfoTagMusic_GetTitle(InfoTagMusic *self, PyObject *args)
   {
-    return Py_BuildValue((char*)"s", self->infoTag.GetTitle().c_str());
+    std::string value = self->infoTag.GetTitle();
+    return PyUnicode_DecodeUTF8(value.c_str(), value.size(), "replace");
   }
 
   // InfoTagMusic_GetArtist
   PyDoc_STRVAR(getArtist__doc__,
-    "getArtist() -- returns a string.\n");
+    "getArtist() -- returns a unicode string.\n");
 
   PyObject* InfoTagMusic_GetArtist(InfoTagMusic *self, PyObject *args)
   {
-    return Py_BuildValue((char*)"s", StringUtils::Join(self->infoTag.GetArtist(), g_advancedSettings.m_musicItemSeparator).c_str());
+    std::string value = StringUtils::Join(self->infoTag.GetArtist(), g_advancedSettings.m_musicItemSeparator);
+    return PyUnicode_DecodeUTF8(value.c_str(), value.size(), "replace");
   }
 
   // InfoTagMusic_GetAlbumArtist
   PyDoc_STRVAR(getAlbumArtist__doc__,
-    "getAlbumArtist() -- returns a string.\n");
+    "getAlbumArtist() -- returns a unicode string.\n");
 
   PyObject* InfoTagMusic_GetAlbumArtist(InfoTagMusic *self, PyObject *args)
   {
-    return Py_BuildValue((char*)"s", StringUtils::Join(self->infoTag.GetAlbumArtist(), g_advancedSettings.m_musicItemSeparator).c_str());
+    std::string value = StringUtils::Join(self->infoTag.GetAlbumArtist(), g_advancedSettings.m_musicItemSeparator);
+    return PyUnicode_DecodeUTF8(value.c_str(), value.size(), "replace");
   }
 
   // InfoTagMusic_GetAlbum
   PyDoc_STRVAR(getAlbum__doc__,
-    "getAlbum() -- returns a string.\n");
+    "getAlbum() -- returns a unicode string.\n");
 
   PyObject* InfoTagMusic_GetAlbum(InfoTagMusic *self, PyObject *args)
   {
-    return Py_BuildValue((char*)"s", self->infoTag.GetAlbum().c_str());
+    std::string value = self->infoTag.GetAlbum();
+    return PyUnicode_DecodeUTF8(value.c_str(), value.size(), "replace");
   }
 
   // InfoTagMusic_GetGenre
   PyDoc_STRVAR(getGenre__doc__,
-    "getAlbum() -- returns a string.\n");
+    "getAlbum() -- returns a unicode string.\n");
 
   PyObject* InfoTagMusic_GetGenre(InfoTagMusic *self, PyObject *args)
   {
-    return Py_BuildValue((char*)"s", StringUtils::Join(self->infoTag.GetGenre(), g_advancedSettings.m_musicItemSeparator).c_str());
+    std::string value = StringUtils::Join(self->infoTag.GetGenre(), g_advancedSettings.m_musicItemSeparator);
+    return PyUnicode_DecodeUTF8(value.c_str(), value.size(), "replace");
   }
 
   // InfoTagMusic_GetDuration
@@ -145,11 +151,12 @@ namespace PYXBMC
 
   // InfoTagMusic_ReleaseDate
   PyDoc_STRVAR(getReleaseDate__doc__,
-    "getReleaseDate() -- returns a string.\n");
+    "getReleaseDate() -- returns a unicode string.\n");
 
   PyObject* InfoTagMusic_GetReleaseDate(InfoTagMusic *self, PyObject *args)
   {
-    return Py_BuildValue((char*)"s", self->infoTag.GetYearString().c_str());
+    std::string value = self->infoTag.GetYearString();
+    return PyUnicode_DecodeUTF8(value.c_str(), value.size(), "replace");
   }
 
   // InfoTagMusic_GetListeners
@@ -172,29 +179,32 @@ namespace PYXBMC
 
   // InfoTagMusic_GetLastPlayed
   PyDoc_STRVAR(getLastPlayed__doc__,
-    "getLastPlayed() -- returns a string.\n");
+    "getLastPlayed() -- returns a unicode string.\n");
 
   PyObject* InfoTagMusic_GetLastPlayed(InfoTagMusic *self, PyObject *args)
   {
-    return Py_BuildValue((char*)"s", self->infoTag.GetLastPlayed().GetAsLocalizedDate().c_str());
+    std::string value = self->infoTag.GetLastPlayed().GetAsLocalizedDate();
+    return PyUnicode_DecodeUTF8(value.c_str(), value.size(), "replace");
   }
 
   // InfoTagMusic_GetComment
   PyDoc_STRVAR(getComment__doc__,
-    "getComment() -- returns a string.\n");
+    "getComment() -- returns a unicode string.\n");
 
   PyObject* InfoTagMusic_GetComment(InfoTagMusic *self, PyObject *args)
   {
-    return Py_BuildValue((char*)"s", self->infoTag.GetComment().c_str());
+    std::string value = self->infoTag.GetComment();
+    return PyUnicode_DecodeUTF8(value.c_str(), value.size(), "replace");
   }
 
   // InfoTagMusic_GetLyrics
   PyDoc_STRVAR(getLyrics__doc__,
-    "getLyrics() -- returns a string.\n");
+    "getLyrics() -- returns a unicode string.\n");
 
   PyObject* InfoTagMusic_GetLyrics(InfoTagMusic *self, PyObject *args)
   {
-    return Py_BuildValue((char*)"s", self->infoTag.GetLyrics().c_str());
+    std::string value = self->infoTag.GetLyrics();
+    return PyUnicode_DecodeUTF8(value.c_str(), value.size(), "replace");
   }
 
   PyMethodDef InfoTagMusic_methods[] = {

--- a/xbmc/interfaces/python/xbmcmodule/infotagvideo.cpp
+++ b/xbmc/interfaces/python/xbmcmodule/infotagvideo.cpp
@@ -53,128 +53,142 @@ namespace PYXBMC
 
   // InfoTagVideo_GetDirector
   PyDoc_STRVAR(getDirector__doc__,
-    "getDirector() -- returns a string.\n");
+    "getDirector() -- returns a unicode string.\n");
 
   PyObject* InfoTagVideo_GetDirector(InfoTagVideo *self, PyObject *args)
   {
-    return Py_BuildValue((char*)"s",  StringUtils::Join(self->infoTag.m_director, g_advancedSettings.m_videoItemSeparator).c_str());
+    std::string value = StringUtils::Join(self->infoTag.m_director, g_advancedSettings.m_videoItemSeparator);
+    return PyUnicode_DecodeUTF8(value.c_str(), value.size(), "replace");
   }
 
   // InfoTagVideo_GetWritingCredits
   PyDoc_STRVAR(getWritingCredits__doc__,
-    "getWritingCredits() -- returns a string.\n");
+    "getWritingCredits() -- returns a unicode string.\n");
 
   PyObject* InfoTagVideo_GetWritingCredits(InfoTagVideo *self, PyObject *args)
   {
-    return Py_BuildValue((char*)"s", StringUtils::Join(self->infoTag.m_writingCredits, g_advancedSettings.m_videoItemSeparator).c_str());
+    std::string value = StringUtils::Join(self->infoTag.m_writingCredits, g_advancedSettings.m_videoItemSeparator);
+    return PyUnicode_DecodeUTF8(value.c_str(), value.size(), "replace");
   }
 
   // InfoTagVideo_GetGenre
   PyDoc_STRVAR(getGenre__doc__,
-    "getGenre() -- returns a string.\n");
+    "getGenre() -- returns a unicode string.\n");
 
   PyObject* InfoTagVideo_GetGenre(InfoTagVideo *self, PyObject *args)
   {
-    return Py_BuildValue((char*)"s", StringUtils::Join(self->infoTag.m_genre, g_advancedSettings.m_videoItemSeparator).c_str());
+    std::string value = StringUtils::Join(self->infoTag.m_genre, g_advancedSettings.m_videoItemSeparator);
+    return PyUnicode_DecodeUTF8(value.c_str(), value.size(), "replace");
   }
 
   // InfoTagVideo_GetTagLine
   PyDoc_STRVAR(getTagLine__doc__,
-    "getTagLine() -- returns a string.\n");
+    "getTagLine() -- returns a unicode string.\n");
 
   PyObject* InfoTagVideo_GetTagLine(InfoTagVideo *self, PyObject *args)
   {
-    return Py_BuildValue((char*)"s", self->infoTag.m_strTagLine.c_str());
+    std::string value = self->infoTag.m_strTagLine;
+    return PyUnicode_DecodeUTF8(value.c_str(), value.size(), "replace");
   }
 
   // InfoTagVideo_GetPlotOutline
   PyDoc_STRVAR(getPlotOutline__doc__,
-    "getPlotOutline() -- returns a string.\n");
+    "getPlotOutline() -- returns a unicode string.\n");
 
   PyObject* InfoTagVideo_GetPlotOutline(InfoTagVideo *self, PyObject *args)
   {
-    return Py_BuildValue((char*)"s", self->infoTag.m_strPlotOutline.c_str());
+    std::string value = self->infoTag.m_strPlotOutline;
+    return PyUnicode_DecodeUTF8(value.c_str(), value.size(), "replace");
   }
 
   // InfoTagVideo_GetPlot
   PyDoc_STRVAR(getPlot__doc__,
-    "getPlot() -- returns a string.\n");
+    "getPlot() -- returns a unicode string.\n");
 
   PyObject* InfoTagVideo_GetPlot(InfoTagVideo *self, PyObject *args)
   {
-    return Py_BuildValue((char*)"s", self->infoTag.m_strPlot.c_str());
+    std::string value = self->infoTag.m_strPlot;
+    return PyUnicode_DecodeUTF8(value.c_str(), value.size(), "replace");
   }
 
   // InfoTagVideo_GetPictureURL
   PyDoc_STRVAR(getPictureURL__doc__,
-    "getPictureURL() -- returns a string.\n");
+    "getPictureURL() -- returns a unicode string.\n");
 
   PyObject* InfoTagVideo_GetPictureURL(InfoTagVideo *self, PyObject *args)
   {
-    return Py_BuildValue((char*)"s", self->infoTag.m_strPictureURL.GetFirstThumb().m_url.c_str());
+    std::string value = self->infoTag.m_strPictureURL.GetFirstThumb().m_url;
+    return PyUnicode_DecodeUTF8(value.c_str(), value.size(), "replace");
   }
 
   // InfoTagVideo_GetTitle
   PyDoc_STRVAR(getTitle__doc__,
-    "getTitle() -- returns a string.\n");
+    "getTitle() -- returns a unicode string.\n");
 
   PyObject* InfoTagVideo_GetTitle(InfoTagVideo *self, PyObject *args)
   {
-    return Py_BuildValue((char*)"s", self->infoTag.m_strTitle.c_str());
+    std::string value = self->infoTag.m_strTitle;
+    return PyUnicode_DecodeUTF8(value.c_str(), value.size(), "replace");
   }
 
   // InfoTagVideo_GetOriginalTitle
   PyDoc_STRVAR(getOriginalTitle__doc__,
-    "getOriginalTitle() -- returns a string.\n");
+    "getOriginalTitle() -- returns a unicode string.\n");
 
   PyObject* InfoTagVideo_GetOriginalTitle(InfoTagVideo *self, PyObject *args)
   {
-    return Py_BuildValue((char*)"s", self->infoTag.m_strOriginalTitle.c_str());
+    std::string value = self->infoTag.m_strOriginalTitle;
+    return PyUnicode_DecodeUTF8(value.c_str(), value.size(), "replace");
   }
 
   // InfoTagVideo_GetVotes
   PyDoc_STRVAR(getVotes__doc__,
-    "getVotes() -- returns a string.\n");
+    "getVotes() -- returns a unicode string.\n");
 
   PyObject* InfoTagVideo_GetVotes(InfoTagVideo *self, PyObject *args)
   {
-    return Py_BuildValue((char*)"s", self->infoTag.m_strVotes.c_str());
+    std::string value = self->infoTag.m_strVotes;
+    return PyUnicode_DecodeUTF8(value.c_str(), value.size(), "replace");
   }
 
   // InfoTagVideo_GetCast
   PyDoc_STRVAR(getCast__doc__,
-    "getCast() -- returns a string.\n");
+    "getCast() -- returns a unicode string.\n");
 
   PyObject* InfoTagVideo_GetCast(InfoTagVideo *self, PyObject *args)
   {
-    return Py_BuildValue((char*)"s", self->infoTag.GetCast(true).c_str());
+    std::string value = self->infoTag.GetCast(true);
+    return PyUnicode_DecodeUTF8(value.c_str(), value.size(), "replace");
   }
 
   // InfoTagVideo_GetFile
   PyDoc_STRVAR(getFile__doc__,
-    "getFile() -- returns a string.\n");
+    "getFile() -- returns a unicode string.\n");
 
   PyObject* InfoTagVideo_GetFile(InfoTagVideo *self, PyObject *args)
   {
-    return Py_BuildValue((char*)"s", self->infoTag.m_strFile.c_str());
+    std::string value = self->infoTag.m_strFile;
+    return PyUnicode_DecodeUTF8(value.c_str(), value.size(), "replace");
   }
 
   // InfoTagVideo_GetPath
   PyDoc_STRVAR(getPath__doc__,
-    "getPath() -- returns a string.\n");
+    "getPath() -- returns a unicode string.\n");
 
   PyObject* InfoTagVideo_GetPath(InfoTagVideo *self, PyObject *args)
   {
-    return Py_BuildValue((char*)"s", self->infoTag.m_strPath.c_str());
+    std::string value = self->infoTag.m_strPath;
+    return PyUnicode_DecodeUTF8(value.c_str(), value.size(), "replace");
   }
 
   // InfoTagVideo_GetIMDBNumber
   PyDoc_STRVAR(getIMDBNumber__doc__,
-    "getIMDBNumber() -- returns a string.\n");
+    "getIMDBNumber() -- returns a unicode string.\n");
 
   PyObject* InfoTagVideo_GetIMDBNumber(InfoTagVideo *self, PyObject *args)
   {
-    return Py_BuildValue((char*)"s", self->infoTag.m_strIMDBNumber.c_str());
+    std::string value = self->infoTag.m_strIMDBNumber;
+    return PyUnicode_DecodeUTF8(value.c_str(), value.size(), "replace");
   }
 
   // InfoTagVideo_GetYear
@@ -188,20 +202,22 @@ namespace PYXBMC
 
   // InfoTagVideo_GetPremiered
   PyDoc_STRVAR(getPremiered__doc__,
-    "getPremiered() -- returns a string.\n");
+    "getPremiered() -- returns a unicode string.\n");
 
   PyObject* InfoTagVideo_GetPremiered(InfoTagVideo *self, PyObject *args)
   {
-    return Py_BuildValue((char*)"s", self->infoTag.m_premiered.GetAsLocalizedDate().c_str());
+    std::string value = self->infoTag.m_premiered.GetAsLocalizedDate();
+    return PyUnicode_DecodeUTF8(value.c_str(), value.size(), "replace");
   }
 
   // InfoTagVideo_GetFirstAired
   PyDoc_STRVAR(getFirstAired__doc__,
-    "getFirstAired() -- returns a string.\n");
+    "getFirstAired() -- returns a unicode string.\n");
 
   PyObject* InfoTagVideo_GetFirstAired(InfoTagVideo *self, PyObject *args)
   {
-    return Py_BuildValue((char*)"s", self->infoTag.m_firstAired.GetAsLocalizedDate().c_str());
+    std::string value = self->infoTag.m_firstAired.GetAsLocalizedDate();
+    return PyUnicode_DecodeUTF8(value.c_str(), value.size(), "replace");
   }
 
   // InfoTagVideo_GetRating
@@ -224,11 +240,12 @@ namespace PYXBMC
 
   // InfoTagVideo_GetLastPlayed
   PyDoc_STRVAR(getLastPlayed__doc__,
-    "getLastPlayed() -- returns a string.\n");
+    "getLastPlayed() -- returns a unicode string.\n");
 
   PyObject* InfoTagVideo_GetLastPlayed(InfoTagVideo *self, PyObject *args)
   {
-    return Py_BuildValue((char*)"s", self->infoTag.m_lastPlayed.GetAsLocalizedDateTime().c_str());
+    std::string value = self->infoTag.m_lastPlayed.GetAsLocalizedDateTime();
+    return PyUnicode_DecodeUTF8(value.c_str(), value.size(), "replace");
   }
 
   PyMethodDef InfoTagVideo_methods[] = {

--- a/xbmc/interfaces/python/xbmcmodule/keyboard.cpp
+++ b/xbmc/interfaces/python/xbmcmodule/keyboard.cpp
@@ -207,7 +207,7 @@ namespace PYXBMC
 
   // getText() Method
   PyDoc_STRVAR(getText__doc__,
-    "getText() -- Returns the user input as a string.\n"
+    "getText() -- Returns the user input as a unicode string.\n"
     "\n"
     "*Note, This will always return the text entry even if you cancel the keyboard.\n"
     "       Use the isConfirmed() method to check if user cancelled the keyboard.\n"
@@ -227,7 +227,7 @@ namespace PYXBMC
     PyXBMCGUILock();
     CStdString result = pKeyboard->GetText();
     PyXBMCGUIUnlock();
-    return Py_BuildValue((char*)"s", result.c_str());
+    return PyUnicode_DecodeUTF8(result.c_str(), result.size(), "replace");
   }
 
   // isConfirmed() Method

--- a/xbmc/interfaces/python/xbmcmodule/listitem.cpp
+++ b/xbmc/interfaces/python/xbmcmodule/listitem.cpp
@@ -131,7 +131,7 @@ namespace PYXBMC
   }
 
   PyDoc_STRVAR(getLabel__doc__,
-    "getLabel() -- Returns the listitem label.\n"
+    "getLabel() -- Returns the listitem label as a unicode string.\n"
     "\n"
     "example:\n"
     "  - label = self.list.getSelectedItem().getLabel()\n");
@@ -141,14 +141,14 @@ namespace PYXBMC
     if (!self->item) return NULL;
 
     PyXBMCGUILock();
-    const char *cLabel = self->item->GetLabel().c_str();
+    std::string value = self->item->GetLabel();
     PyXBMCGUIUnlock();
 
-    return Py_BuildValue((char*)"s", cLabel);
+    return PyUnicode_DecodeUTF8(value.c_str(), value.size(), "replace");
   }
 
   PyDoc_STRVAR(getLabel2__doc__,
-    "getLabel2() -- Returns the listitem's second label.\n"
+    "getLabel2() -- Returns the listitem's second label as a unicode string.\n"
     "\n"
     "example:\n"
     "  - label2 = self.list.getSelectedItem().getLabel2()\n");
@@ -158,10 +158,10 @@ namespace PYXBMC
     if (!self->item) return NULL;
 
     PyXBMCGUILock();
-    const char *cLabel = self->item->GetLabel2().c_str();
+    std::string value = self->item->GetLabel2();
     PyXBMCGUIUnlock();
 
-    return Py_BuildValue((char*)"s", cLabel);
+    return PyUnicode_DecodeUTF8(value.c_str(), value.size(), "replace");
   }
 
   PyDoc_STRVAR(setLabel__doc__,
@@ -821,7 +821,7 @@ namespace PYXBMC
   }
 
   PyDoc_STRVAR(getProperty__doc__,
-    "getProperty(key) -- Returns a listitem property as a string, similar to an infolabel.\n"
+    "getProperty(key) -- Returns a listitem property as a unicode string, similar to an infolabel.\n"
     "\n"
     "key            : string - property name.\n"
     "\n"
@@ -866,7 +866,7 @@ namespace PYXBMC
       value = self->item->GetProperty(lowerKey.ToLower()).asString();
     PyXBMCGUIUnlock();
 
-    return Py_BuildValue((char*)"s", value.c_str());
+    return PyUnicode_DecodeUTF8(value.c_str(), value.size(), "replace");
   }
 
   // addContextMenuItems() method

--- a/xbmc/interfaces/python/xbmcmodule/listitem.cpp
+++ b/xbmc/interfaces/python/xbmcmodule/listitem.cpp
@@ -852,21 +852,20 @@ namespace PYXBMC
 
     PyXBMCGUILock();
     CStdString lowerKey = key;
-    CStdString value;
+    CVariant value;
     if (lowerKey.CompareNoCase("startoffset") == 0)
     { // special case for start offset - don't actually store in a property,
       // we store it in item.m_lStartOffset instead
-      value.Format("%f", self->item->m_lStartOffset / 75.0);
+      value = self->item->m_lStartOffset / 75.0;
     }
     else if (lowerKey.CompareNoCase("totaltime") == 0)
-      value.Format("%f", self->item->GetVideoInfoTag()->m_resumePoint.totalTimeInSeconds);
+      value = self->item->GetVideoInfoTag()->m_resumePoint.totalTimeInSeconds;
     else if (lowerKey.CompareNoCase("resumetime") == 0)
-      value.Format("%f", self->item->GetVideoInfoTag()->m_resumePoint.timeInSeconds);
+      value = self->item->GetVideoInfoTag()->m_resumePoint.timeInSeconds;
     else
-      value = self->item->GetProperty(lowerKey.ToLower()).asString();
+      value = self->item->GetProperty(lowerKey.ToLower());
     PyXBMCGUIUnlock();
-
-    return PyUnicode_DecodeUTF8(value.c_str(), value.size(), "replace");
+    return PyVariantToObject(value);
   }
 
   // addContextMenuItems() method

--- a/xbmc/interfaces/python/xbmcmodule/player.cpp
+++ b/xbmc/interfaces/python/xbmcmodule/player.cpp
@@ -413,7 +413,7 @@ namespace PYXBMC
 
   // Player_GetPlayingFile
   PyDoc_STRVAR(getPlayingFile__doc__,
-    "getPlayingFile() -- returns the current playing file as a string.\n"
+    "getPlayingFile() -- returns the current playing file as a unicode string.\n"
     "\n"
     "Throws: Exception, if player is not playing a file.\n"
     "");
@@ -425,7 +425,7 @@ namespace PYXBMC
       PyErr_SetString(PyExc_Exception, "XBMC is not playing any file");
       return NULL;
     }
-    return Py_BuildValue((char*)"s", g_application.CurrentFile().c_str());
+    return PyUnicode_DecodeUTF8(g_application.CurrentFile().c_str(), g_application.CurrentFile().size(), "replace");
   }
 
   // Player_GetVideoInfoTag
@@ -576,7 +576,7 @@ namespace PYXBMC
 
   // Player_GetSubtitles
   PyDoc_STRVAR(getSubtitles__doc__,
-    "getSubtitles() -- get subtitle stream name\n");
+    "getSubtitles() -- get subtitle stream name as a unicode string\n");
 
   PyObject* Player_GetSubtitles(PyObject *self)
   {
@@ -588,7 +588,7 @@ namespace PYXBMC
 
       if (strName == "Unknown(Invalid)")
         strName = "";
-      return Py_BuildValue((char*)"s", strName.c_str());
+      return PyUnicode_DecodeUTF8(strName.c_str(), strName.size(), "replace");
     }
 
     Py_INCREF(Py_None);

--- a/xbmc/interfaces/python/xbmcmodule/pyplaylist.cpp
+++ b/xbmc/interfaces/python/xbmcmodule/pyplaylist.cpp
@@ -62,11 +62,11 @@ namespace PYXBMC
   }
 
   PyDoc_STRVAR(getDescription__doc__,
-    "getdescription() -- Returns the description of this PlayListItem.\n");
+    "getdescription() -- Returns the description of this PlayListItem as a unicode string.\n");
 
   PyObject* PlayListItem_GetDescription(PlayListItem *self, PyObject *key)
   {
-    return Py_BuildValue((char*)"s", self->item->GetLabel().c_str());
+    return PyUnicode_DecodeUTF8(self->item->GetLabel().c_str(), self->item->GetLabel().size(), "replace");
   }
 
   PyDoc_STRVAR(getDuration__doc__,
@@ -78,17 +78,17 @@ namespace PYXBMC
       return Py_BuildValue((char*)"l", self->item->GetMusicInfoTag()->GetDuration());
 
     if (self->item->HasVideoInfoTag())
-      return Py_BuildValue((char*)"s", self->item->GetVideoInfoTag()->m_strRuntime.c_str());
+      return PyUnicode_DecodeUTF8(self->item->GetVideoInfoTag()->m_strRuntime.c_str(), self->item->GetVideoInfoTag()->m_strRuntime.size(), "replace");
 
     return Py_BuildValue((char*)"l", 0);
   }
 
   PyDoc_STRVAR(getFilename__doc__,
-    "getfilename() -- Returns the filename of this PlayListItem.\n");
+    "getfilename() -- Returns the filename of this PlayListItem as a unicode string.\n");
 
   PyObject* PlayListItem_GetFileName(PlayListItem *self, PyObject *key)
   {
-    return Py_BuildValue((char*)"s", self->item->GetPath().c_str());
+    return PyUnicode_DecodeUTF8(self->item->GetPath().c_str(), self->item->GetPath().size(), "replace");
   }
 
 /* PlayList Fucntions */

--- a/xbmc/interfaces/python/xbmcmodule/pyutil.cpp
+++ b/xbmc/interfaces/python/xbmcmodule/pyutil.cpp
@@ -27,6 +27,7 @@
 #include "utils/log.h"
 #include "utils/XBMCTinyXML.h"
 #include "utils/CharsetConverter.h"
+#include "utils/Variant.h"
 #include "threads/CriticalSection.h"
 #include "threads/SingleLock.h"
 #include "ApplicationMessenger.h"
@@ -159,6 +160,26 @@ namespace PYXBMC
     
     addonId = PyString_AsString(pyid);
     return true;
+  }
+  
+  PyObject *PyVariantToObject(const CVariant &value)
+  {
+    switch (value.type())
+    {
+      case CVariant::VariantTypeBoolean:
+        return Py_BuildValue((char*)"b", value.asBoolean());
+      case CVariant::VariantTypeInteger:
+      case CVariant::VariantTypeUnsignedInteger:
+        return Py_BuildValue((char*)"i", value.asInteger());
+      case CVariant::VariantTypeDouble:
+        return Py_BuildValue((char*)"f", value.asDouble());
+      case CVariant::VariantTypeString:
+      default:
+      {
+        std::string svalue = value.asString();
+        return PyUnicode_DecodeUTF8(svalue.c_str(), svalue.size(), "replace");
+      }
+    }
   }
 }
 

--- a/xbmc/interfaces/python/xbmcmodule/pyutil.h
+++ b/xbmc/interfaces/python/xbmcmodule/pyutil.h
@@ -32,6 +32,8 @@ extern "C" {
 #define PY_XBMC_CREDITS   "Team XBMC"
 #define PY_XBMC_PLATFORM  "ALL"
 
+class CVariant;
+
 namespace PYXBMC
 {
   int   PyXBMCGetUnicodeString(std::string& buf, PyObject* pObject, int pos = -1);
@@ -44,6 +46,10 @@ namespace PYXBMC
   void  PyXBMCWaitForThreadMessage(int message, int param1, int param2);
  
   bool  PyXBMCGetAddonId(std::string &addonId);
+
+  /*! \brief convert CVariant into a python object
+   */
+  PyObject *PyVariantToObject(const CVariant &value);
 }
 
 // Python doesn't play nice with PyXBMC_AddPendingCall

--- a/xbmc/interfaces/python/xbmcmodule/window.cpp
+++ b/xbmc/interfaces/python/xbmcmodule/window.cpp
@@ -1038,7 +1038,7 @@ namespace PYXBMC
   }
 
   PyDoc_STRVAR(getProperty__doc__,
-    "getProperty(key) -- Returns a window property as a string, similar to an infolabel.\n"
+    "getProperty(key) -- Returns a window property as a unicode string, similar to an infolabel.\n"
     "\n"
     "key            : string - property name.\n"
     "\n"
@@ -1069,7 +1069,7 @@ namespace PYXBMC
     CStdString lowerKey = key;
     string value = self->pWindow->GetProperty(lowerKey.ToLower()).asString();
 
-    return Py_BuildValue((char*)"s", value.c_str());
+    return PyUnicode_DecodeUTF8(value.c_str(), value.size(), "replace");
   }
 
   PyDoc_STRVAR(clearProperty__doc__,

--- a/xbmc/interfaces/python/xbmcmodule/window.cpp
+++ b/xbmc/interfaces/python/xbmcmodule/window.cpp
@@ -1067,9 +1067,7 @@ namespace PYXBMC
 
     GilSafeSingleLock lock(g_graphicsContext);
     CStdString lowerKey = key;
-    string value = self->pWindow->GetProperty(lowerKey.ToLower()).asString();
-
-    return PyUnicode_DecodeUTF8(value.c_str(), value.size(), "replace");
+    return PyVariantToObject(self->pWindow->GetProperty(lowerKey.ToLower()));
   }
 
   PyDoc_STRVAR(clearProperty__doc__,

--- a/xbmc/interfaces/python/xbmcmodule/xbmcmodule.cpp
+++ b/xbmc/interfaces/python/xbmcmodule/xbmcmodule.cpp
@@ -107,22 +107,26 @@ namespace PYXBMC
       "level",
       NULL};
 
-    char *s_line = NULL;
+    PyObject *s_line = NULL;
     int iLevel = LOGNOTICE;
     if (!PyArg_ParseTupleAndKeywords(
       args,
       kwds,
-      (char*)"s|i",
+      (char*)"O|i",
       (char**)keywords,
       &s_line,
       &iLevel))
     {
       return NULL;
     }
+    CStdString uText;
+    if (!PyXBMCGetUnicodeString(uText, s_line, 1))
+      return NULL;
+
     // check for a valid loglevel
     if (iLevel < LOGDEBUG || iLevel > LOGNONE)
       iLevel = LOGNOTICE;
-    CLog::Log(iLevel, "%s", s_line);
+    CLog::Log(iLevel, "%s", uText.c_str());
 
     Py_INCREF(Py_None);
     return Py_None;

--- a/xbmc/interfaces/python/xbmcmodule/xbmcmodule.cpp
+++ b/xbmc/interfaces/python/xbmcmodule/xbmcmodule.cpp
@@ -368,7 +368,7 @@ namespace PYXBMC
 
   // getSkinDir() method
   PyDoc_STRVAR(getSkinDir__doc__,
-    "getSkinDir() -- Returns the active skin directory as a string.\n"
+    "getSkinDir() -- Returns the active skin directory as a unicode string.\n"
     "\n"
     "*Note, This is not the full path like 'special://home/addons/MediaCenter', but only 'MediaCenter'.\n"
     "\n"
@@ -377,37 +377,39 @@ namespace PYXBMC
 
   PyObject* XBMC_GetSkinDir(PyObject *self, PyObject *args)
   {
-    return PyString_FromString(g_guiSettings.GetString("lookandfeel.skin"));
+    CStdString value = g_guiSettings.GetString("lookandfeel.skin");
+    return PyUnicode_DecodeUTF8(value.c_str(), value.size(), "replace");
   }
 
   // getLanguage() method
   PyDoc_STRVAR(getLanguage__doc__,
-    "getLanguage() -- Returns the active language as a string.\n"
+    "getLanguage() -- Returns the active language as a unicode string.\n"
     "\n"
     "example:\n"
     "  - language = xbmc.getLanguage()\n");
 
   PyObject* XBMC_GetLanguage(PyObject *self, PyObject *args)
   {
-    return PyString_FromString(g_guiSettings.GetString("locale.language"));
+    CStdString value = g_guiSettings.GetString("locale.language");
+    return PyUnicode_DecodeUTF8(value.c_str(), value.size(), "replace");
   }
 
   // getIPAddress() method
   PyDoc_STRVAR(getIPAddress__doc__,
-    "getIPAddress() -- Returns the current ip address as a string.\n"
+    "getIPAddress() -- Returns the current ip address as a unicode string.\n"
     "\n"
     "example:\n"
     "  - ip = xbmc.getIPAddress()\n");
 
   PyObject* XBMC_GetIPAddress(PyObject *self, PyObject *args)
   {
-    char cTitleIP[32];
-    sprintf(cTitleIP, "127.0.0.1");
     CNetworkInterface* iface = g_application.getNetwork().GetFirstConnectedInterface();
     if (iface)
-      return PyString_FromString(iface->GetCurrentIPAddress().c_str());
-
-    return PyString_FromString(cTitleIP);
+    {
+      CStdString value = iface->GetCurrentIPAddress();
+      return PyUnicode_DecodeUTF8(value.c_str(), value.size(), "replace");
+    }
+    return PyUnicode_DecodeUTF8("127.0.0.1", 9, "replace");
   }
 
   // getDVDState() method
@@ -478,7 +480,7 @@ namespace PYXBMC
 
   // getInfolabel() method
   PyDoc_STRVAR(getInfoLabel__doc__,
-    "getInfoLabel(infotag) -- Returns an InfoLabel as a string.\n"
+    "getInfoLabel(infotag) -- Returns an InfoLabel as a unicode string.\n"
     "\n"
     "infotag        : string - infoTag for value you want returned.\n"
     "                 Also multiple InfoLabels are possible e.x.:\n"
@@ -512,13 +514,13 @@ namespace PYXBMC
         cret = g_infoManager.GetLabel(ret);
       }
     }
-    return Py_BuildValue((char*)"s", cret.c_str());
+    return PyUnicode_DecodeUTF8(cret.c_str(), cret.size(), "replace");
   }
 
   // getInfoImage() method
   PyDoc_STRVAR(getInfoImage__doc__,
     "getInfoImage(infotag) -- Returns a filename including path to the InfoImage's\n"
-    "                         thumbnail as a string.\n"
+    "                         thumbnail as a unicode string.\n"
     "\n"
     "infotag        : string - infotag for value you want returned.\n"
     "\n"
@@ -541,7 +543,7 @@ namespace PYXBMC
       cret = g_infoManager.GetImage(ret, WINDOW_INVALID);
     }
 
-    return Py_BuildValue((char*)"s", cret.c_str());
+    return PyUnicode_DecodeUTF8(cret.c_str(), cret.size(), "replace");
   }
 
   // playSFX() method
@@ -663,7 +665,7 @@ namespace PYXBMC
 
   // makeLegalFilename function
   PyDoc_STRVAR(makeLegalFilename__doc__,
-    "makeLegalFilename(filename[, fatX]) -- Returns a legal filename or path as a string.\n"
+    "makeLegalFilename(filename[, fatX]) -- Returns a legal filename or path as a unicode string.\n"
     "\n"
     "filename       : string or unicode - filename/path to make legal\n"
     "fatX           : [opt] bool - True=Xbox file system(Default)\n"
@@ -700,12 +702,12 @@ namespace PYXBMC
 
     CStdString strFilename;
     strFilename = CUtil::MakeLegalPath(strText);
-    return Py_BuildValue((char*)"s", strFilename.c_str());
+    return PyUnicode_DecodeUTF8(strFilename.c_str(), strFilename.size(), "replace");
   }
 
   // translatePath function
   PyDoc_STRVAR(translatePath__doc__,
-    "translatePath(path) -- Returns the translated path.\n"
+    "translatePath(path) -- Returns the translated path as a unicode string.\n"
     "\n"
     "path           : string or unicode - Path to format\n"
     "\n"
@@ -727,12 +729,12 @@ namespace PYXBMC
     CStdString strPath;
     strPath = CSpecialProtocol::TranslatePath(strText);
 
-    return Py_BuildValue((char*)"s", strPath.c_str());
+    return PyUnicode_DecodeUTF8(strPath.c_str(), strPath.size(), "replace");
   }
 
   // getcleanmovietitle function
   PyDoc_STRVAR(getCleanMovieTitle__doc__,
-    "getCleanMovieTitle(path[, usefoldername]) -- Returns a clean movie title and year string if available.\n"
+    "getCleanMovieTitle(path[, usefoldername]) -- Returns a clean movie title and year unicode string if available.\n"
     "\n"
     "path           : string or unicode - String to clean\n"
     "bool           : [opt] bool - use folder names (defaults to false)\n"
@@ -767,12 +769,13 @@ namespace PYXBMC
     CStdString strTitle, strTitleAndYear, strYear;
     CUtil::CleanString(strName, strTitle, strTitleAndYear, strYear, bUseFolderName);
 
-    return Py_BuildValue((char*)"s,s", strTitle.c_str(), strYear.c_str());
+    return Py_BuildValue((char*)"O,O", PyUnicode_DecodeUTF8(strTitle.c_str(), strTitle.size(), "replace"),
+                                       PyUnicode_DecodeUTF8(strYear.c_str(), strYear.size(), "replace"));
   }
 
   // validatePath function
   PyDoc_STRVAR(validatePath__doc__,
-    "validatePath(path) -- Returns the validated path.\n"
+    "validatePath(path) -- Returns the validated path as a unicode string.\n"
     "\n"
     "path           : string or unicode - Path to format\n"
     "\n"
@@ -790,12 +793,13 @@ namespace PYXBMC
     CStdString strText;
     if (!PyXBMCGetUnicodeString(strText, pObjectText, 1)) return NULL;
 
-    return Py_BuildValue((char*)"s", CUtil::ValidatePath(strText, true).c_str());
+    CStdString validated = CUtil::ValidatePath(strText, true);
+    return PyUnicode_DecodeUTF8(validated.c_str(), validated.size(), "replace");
   }
 
   // getRegion function
   PyDoc_STRVAR(getRegion__doc__,
-    "getRegion(id) -- Returns your regions setting as a string for the specified id.\n"
+    "getRegion(id) -- Returns your regions setting as a unicode string for the specified id.\n"
     "\n"
     "id             : string - id of setting to return\n"
     "\n"
@@ -855,12 +859,12 @@ namespace PYXBMC
     else if (strcmpi(id, "meridiem") == 0)
       result.Format("%s/%s", g_langInfo.GetMeridiemSymbol(CLangInfo::MERIDIEM_SYMBOL_AM), g_langInfo.GetMeridiemSymbol(CLangInfo::MERIDIEM_SYMBOL_PM));
 
-    return Py_BuildValue((char*)"s", result.c_str());
+    return PyUnicode_DecodeUTF8(result.c_str(), result.size(), "replace");
   }
 
   // getSupportedMedia function
   PyDoc_STRVAR(getSupportedMedia__doc__,
-    "getSupportedMedia(media) -- Returns the supported file types for the specific media as a string.\n"
+    "getSupportedMedia(media) -- Returns the supported file types for the specific media as a unicode string.\n"
     "\n"
     "media          : string - media type\n"
     "\n"
@@ -902,7 +906,7 @@ namespace PYXBMC
       return NULL;
     }
 
-    return Py_BuildValue((char*)"s", result.c_str());
+    return PyUnicode_DecodeUTF8(result.c_str(), result.size(), "replace");
   }
 
   // skinHasImage function

--- a/xbmc/interfaces/python/xbmcmodule/xbmcmodule.cpp
+++ b/xbmc/interfaces/python/xbmcmodule/xbmcmodule.cpp
@@ -30,10 +30,6 @@
 #endif
 #include "infotagvideo.h"
 #include "infotagmusic.h"
-#ifdef HAS_HTTPAPI
-#include "interfaces/http-api/XBMChttp.h"
-#include "interfaces/http-api/HttpApi.h"
-#endif
 #include "pyjsonrpc.h"
 #include "GUIInfoManager.h"
 #include "guilib/GUIWindowManager.h"
@@ -222,59 +218,6 @@ namespace PYXBMC
     Py_INCREF(Py_None);
     return Py_None;
   }
-
-#ifdef HAS_HTTPAPI
-  // executehttpapi() method
-  PyDoc_STRVAR(executeHttpApi__doc__,
-    "executehttpapi(httpcommand) -- Execute an HTTP API command.\n"
-    "\n"
-    "httpcommand    : string - http command to execute.\n"
-    "\n"
-    "List of commands - http://wiki.xbmc.org/?title=WebServerHTTP-API#The_Commands \n"
-    "\n"
-    "example:\n"
-    "  - response = xbmc.executehttpapi('TakeScreenShot(special://temp/test.jpg,0,false,200,-1,90)')\n");
-
-  PyObject* XBMC_ExecuteHttpApi(PyObject *self, PyObject *args)
-  {
-    char *cLine = NULL;
-    if (!PyArg_ParseTuple(args, (char*)"s", &cLine)) return NULL;
-
-    CPyThreadState pyLock;
-
-    if (!m_pXbmcHttp)
-      m_pXbmcHttp = new CXbmcHttp();
-    CStdString method = cLine;
-
-    int open, close;
-    CStdString parameter="", cmd=cLine, execute;
-    open = cmd.Find("(");
-    if (open>0)
-    {
-      close=cmd.length();
-      while (close>open && cmd.Mid(close,1)!=")")
-        close--;
-      if (close>open)
-      {
-        parameter = cmd.Mid(open + 1, close - open - 1);
-        parameter.Replace(",",";");
-        execute = cmd.Left(open);
-      }
-      else //open bracket but no close
-      {
-        pyLock.Restore();
-        return PyString_FromString("");
-      }
-    }
-    else //no parameters
-      execute = cmd;
-
-    CURL::Decode(parameter);
-
-    pyLock.Restore();
-    return PyString_FromString(CHttpApi::MethodCall(execute, parameter).c_str());
-  }
-#endif
 
 #ifdef HAS_JSONRPC
   // executeJSONRPC() method
@@ -979,10 +922,6 @@ namespace PYXBMC
     {(char*)"getDVDState", (PyCFunction)XBMC_GetDVDState, METH_VARARGS, getDVDState__doc__},
     {(char*)"getFreeMem", (PyCFunction)XBMC_GetFreeMem, METH_VARARGS, getFreeMem__doc__},
     //{(char*)"getCpuTemp", (PyCFunction)XBMC_GetCpuTemp, METH_VARARGS, getCpuTemp__doc__},
-
-#ifdef HAS_HTTPAPI
-    {(char*)"executehttpapi", (PyCFunction)XBMC_ExecuteHttpApi, METH_VARARGS, executeHttpApi__doc__},
-#endif
 #ifdef HAS_JSONRPC
     {(char*)"executeJSONRPC", (PyCFunction)XBMC_ExecuteJSONRPC, METH_VARARGS, executeJSONRPC__doc__},
 #endif

--- a/xbmc/interfaces/python/xbmcmodule/xbmcmodule.cpp
+++ b/xbmc/interfaces/python/xbmcmodule/xbmcmodule.cpp
@@ -542,30 +542,6 @@ namespace PYXBMC
     return Py_BuildValue((char*)"i", g_application.GlobalIdleTime());
   }
 
-  // getCacheThumbName function
-  PyDoc_STRVAR(getCacheThumbName__doc__,
-    "getCacheThumbName(path) -- Returns a thumb cache filename.\n"
-    "\n"
-    "path           : string or unicode - path to file\n"
-    "\n"
-    "example:\n"
-    "  - thumb = xbmc.getCacheThumbName('f:\\\\videos\\\\movie.avi')\n");
-
-  PyObject* XBMC_GetCacheThumbName(PyObject *self, PyObject *args)
-  {
-    PyObject *pObjectText;
-    if (!PyArg_ParseTuple(args, (char*)"O", &pObjectText)) return NULL;
-
-    string strText;
-    if (!PyXBMCGetUnicodeString(strText, pObjectText, 1)) return NULL;
-
-    Crc32 crc;
-    CStdString strPath;
-    crc.ComputeFromLowerCase(strText);
-    strPath.Format("%08x.tbn", (unsigned __int32)crc);
-    return Py_BuildValue((char*)"s", strPath.c_str());
-  }
-
   // makeLegalFilename function
   PyDoc_STRVAR(makeLegalFilename__doc__,
     "makeLegalFilename(filename[, fatX]) -- Returns a legal filename or path as a unicode string.\n"
@@ -920,8 +896,6 @@ namespace PYXBMC
 
     {(char*)"playSFX", (PyCFunction)XBMC_PlaySFX, METH_VARARGS, playSFX__doc__},
     {(char*)"enableNavSounds", (PyCFunction)XBMC_EnableNavSounds, METH_VARARGS, enableNavSounds__doc__},
-
-    {(char*)"getCacheThumbName", (PyCFunction)XBMC_GetCacheThumbName, METH_VARARGS, getCacheThumbName__doc__},
 
     {(char*)"makeLegalFilename", (PyCFunction)XBMC_MakeLegalFilename, METH_VARARGS|METH_KEYWORDS, makeLegalFilename__doc__},
     {(char*)"translatePath", (PyCFunction)XBMC_TranslatePath, METH_VARARGS, translatePath__doc__},

--- a/xbmc/interfaces/python/xbmcmodule/xbmcmodule.cpp
+++ b/xbmc/interfaces/python/xbmcmodule/xbmcmodule.cpp
@@ -277,7 +277,7 @@ namespace PYXBMC
 #endif
 
 #ifdef HAS_JSONRPC
-  // executehttpapi() method
+  // executeJSONRPC() method
   PyDoc_STRVAR(executeJSONRPC__doc__,
     "executeJSONRPC(jsonrpccommand) -- Execute an JSONRPC command.\n"
     "\n"
@@ -448,39 +448,6 @@ namespace PYXBMC
     GlobalMemoryStatusEx(&stat);
     return PyInt_FromLong( (long)(stat.ullAvailPhys  / ( 1024 * 1024 )) );
   }
-
-  // getCpuTemp() method
-  // ## Doesn't work right, use getInfoLabel('System.CPUTemperature') instead.
-  /*PyDoc_STRVAR(getCpuTemp__doc__,
-    "getCpuTemp() -- Returns the current cpu temperature as an integer.\n"
-    "\n"
-    "example:\n"
-    "  - cputemp = xbmc.getCpuTemp()\n");
-
-  PyObject* XBMC_GetCpuTemp(PyObject *self, PyObject *args)
-  {
-    unsigned short cputemp;
-    unsigned short cpudec;
-
-    _outp(0xc004, (0x4c<<1)|0x01);
-    _outp(0xc008, 0x01);
-    _outpw(0xc000, _inpw(0xc000));
-    _outp(0xc002, (0) ? 0x0b : 0x0a);
-    while ((_inp(0xc000) & 8));
-    cputemp = _inpw(0xc006);
-
-    _outp(0xc004, (0x4c<<1)|0x01);
-    _outp(0xc008, 0x10);
-    _outpw(0xc000, _inpw(0xc000));
-    _outp(0xc002, (0) ? 0x0b : 0x0a);
-    while ((_inp(0xc000) & 8));
-    cpudec = _inpw(0xc006);
-
-    if (cpudec<10) cpudec = cpudec * 100;
-    if (cpudec<100) cpudec = cpudec *10;
-
-    return PyInt_FromLong((long)(cputemp + cpudec / 1000.0f));
-  }*/
 
   // getInfolabel() method
   PyDoc_STRVAR(getInfoLabel__doc__,

--- a/xbmc/interfaces/python/xbmcmodule/xbmcmodule.cpp
+++ b/xbmc/interfaces/python/xbmcmodule/xbmcmodule.cpp
@@ -128,17 +128,6 @@ namespace PYXBMC
     return Py_None;
   }
 
-  // output() method
-  PyDoc_STRVAR(output__doc__,
-    "'xbmc.output()' is depreciated and will be removed in future releases,\n"
-    "please use 'xbmc.log()' instead");
-
-  PyObject* XBMC_Output(PyObject *self, PyObject *args, PyObject *kwds)
-  {
-    CLog::Log(LOGWARNING,"'xbmc.output()' is depreciated and will be removed in future releases, please use 'xbmc.log()' instead");
-    return XBMC_Log(self, args, kwds);
-  }
-
   // shutdown() method
   PyDoc_STRVAR(shutdown__doc__,
     "shutdown() -- Shutdown the system.\n"
@@ -906,7 +895,6 @@ namespace PYXBMC
 
   // define c functions to be used in python here
   PyMethodDef xbmcMethods[] = {
-    {(char*)"output", (PyCFunction)XBMC_Output, METH_VARARGS|METH_KEYWORDS, output__doc__},
     {(char*)"log", (PyCFunction)XBMC_Log, METH_VARARGS|METH_KEYWORDS, log__doc__},
     {(char*)"executescript", (PyCFunction)XBMC_ExecuteScript, METH_VARARGS, executeScript__doc__},
     {(char*)"executebuiltin", (PyCFunction)XBMC_ExecuteBuiltIn, METH_VARARGS, executeBuiltIn__doc__},

--- a/xbmc/interfaces/python/xbmcmodule/xbmcplugin.cpp
+++ b/xbmc/interfaces/python/xbmcmodule/xbmcplugin.cpp
@@ -299,7 +299,7 @@ namespace PYXBMC
   }
 
   PyDoc_STRVAR(getSetting__doc__,
-    "getSetting(handle, id) -- Returns the value of a setting as a string.\n"
+    "getSetting(handle, id) -- Returns the value of a setting as a unicode string.\n"
     "\n"
     "handle    : integer - handle the plugin was started with.\n"
     "id        : string - id of the setting that the module needs to access.\n"
@@ -326,7 +326,8 @@ namespace PYXBMC
       return NULL;
     };
 
-    return Py_BuildValue((char*)"s", XFILE::CPluginDirectory::GetSetting(handle, id).c_str());
+    CStdString value = XFILE::CPluginDirectory::GetSetting(handle, id);
+    return PyUnicode_DecodeUTF8(value.c_str(), value.size(), "replace");
   }
 
   PyDoc_STRVAR(setSetting__doc__,


### PR DESCRIPTION
This is nowhere near acceptable (essentially hides the ickyness in CAddon), but just wanted to get it out there given there's talk of non-backward compatible changes to the python API.  To do it properly we need to decide on how we wish to store settings within CAddon - keeping XML doesn't seem to be appropriate - not sure whether we want something similar to GUISettings (i.e. base settings class with derived classes for different settings types) or not.  Comments welcome.

What currently isn't handled is verification of the values set by python (eg they could set "bob" as the value of a bool setting if they wanted to).  It might pay, for example, to allow setSetting() to take different types (bool, int, float, string).

@jimfcarroll: this may well have implications for your stuff.
