### PR TITLE
don't map 'end' key to Shutdown()

### DIFF
--- a/system/keymaps/keyboard.xml
+++ b/system/keymaps/keyboard.xml
@@ -145,13 +145,13 @@
   </global>
   <LoginScreen>
     <keyboard>
-      <end>XBMC.ShutDown()</end>
+      <end mod="ctrl">XBMC.ShutDown()</end>
     </keyboard>
   </LoginScreen>
   <Home>
     <keyboard>
       <i>info</i>
-      <end>XBMC.ShutDown()</end>
+      <end mod="ctrl">XBMC.ShutDown()</end>
     </keyboard>
   </Home>
   <VirtualKeyboard>


### PR DESCRIPTION
we use the 'end' key to jump to the end of a list.
i would expect it to do the same on the homescreen (home menu / submenu / recently added list)

so please don't shut down my system when i press 'end' on home.

this PR maps Shutdown() to 'end mod="ctrl"' instead.
