### PR TITLE
Reconnect to MySql DB also on CR_SERVER_LOST error.

### DIFF
--- a/xbmc/dbwrappers/mysqldataset.cpp
+++ b/xbmc/dbwrappers/mysqldataset.cpp
@@ -293,7 +293,7 @@ int MysqlDatabase::query_with_reconnect(const char* query) {
 
   // try to reconnect if server is gone
   while ( ((result = mysql_real_query(conn, query, strlen(query))) != MYSQL_OK) &&
-          ((result = mysql_errno(conn)) == CR_SERVER_GONE_ERROR) && 
+          ((result = mysql_errno(conn)) == CR_SERVER_GONE_ERROR || result == CR_SERVER_LOST) &&
           (attempts-- > 0) )
   {
     CLog::Log(LOGINFO,"MYSQL server has gone. Will try %d more attempt(s) to reconnect.", attempts);


### PR DESCRIPTION
This patch makes xbmc reconnect on CR_SERVER_LOST and CR_SERVER_GONE_ERROR.
It seems that when resuming from standby, sometimes you get an CR_SERVER_LOST instead of CR_SERVER_GONE_ERROR.
Might be depending on the mysql version (with 5.5.19 it's quite reproducable).
