### PR TITLE
Re-enable manually add to library

### DIFF
--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -1827,6 +1827,13 @@ void CGUIWindowVideoBase::AddToDatabase(int iItem)
   m_database.Open();
   int idMovie = m_database.AddMovie(pItem->GetPath());
   movie.m_strIMDBNumber.Format("xx%08i", idMovie);
+
+  if (movie.m_basePath.IsEmpty())
+    movie.m_basePath = pItem->GetBaseMoviePath(false);
+  movie.m_parentPathID = m_database.AddPath(URIUtils::GetParentPath(movie.m_basePath));
+
+  movie.m_strFileNameAndPath = pItem->GetPath();
+
   m_database.SetDetailsForMovie(pItem->GetPath(), movie, pItem->GetArt());
   m_database.Close();
 

--- a/xbmc/video/windows/GUIWindowVideoNav.cpp
+++ b/xbmc/video/windows/GUIWindowVideoNav.cpp
@@ -1030,6 +1030,13 @@ void CGUIWindowVideoNav::GetContextButtons(int itemNumber, CContextButtons &butt
           buttons.Add(CONTEXT_BUTTON_DELETE, 117);
           buttons.Add(CONTEXT_BUTTON_RENAME, 118);
         }
+
+        if (!item->IsLiveTV()) 
+        { 
+          if (!m_database.HasMovieInfo(item->GetPath()) &&  !m_database.HasEpisodeInfo(item->GetPath())) 
+             buttons.Add(CONTEXT_BUTTON_ADD_TO_LIBRARY, 527); // Add to Database 
+        } 
+
         // add "Set/Change content" to folders
         if (item->m_bIsFolder && !item->IsPlayList() && !item->IsSmartPlayList() && !item->IsLiveTV() && !item->IsPlugin() && !item->IsAddonsPath())
         {
@@ -1328,6 +1335,12 @@ bool CGUIWindowVideoNav::OnContextButton(int itemNumber, CONTEXT_BUTTON button)
       CUtil::DeleteVideoDatabaseDirectoryCache();
       Update(m_vecItems->GetPath());
       return true;
+    }
+
+  case CONTEXT_BUTTON_ADD_TO_LIBRARY: 
+    {
+      AddToDatabase(itemNumber); 
+      return true; 
     }
 
   default:


### PR DESCRIPTION
this functionality used to be available in earlier versions (Dharma?) of xbmc but was removed as part of the context menu clean up. Unfortunately no suitable replacement has come up (like a scraper addon that would allow manual addition to library).

How to use: navigate in file view to the item not in the library, select context menu "Manually Add to Library". Done. 
