### PR TITLE
use filtering for handling watched mode (view watched / unwatched / all)...

### DIFF
--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -1717,7 +1717,7 @@ bool CGUIWindowVideoBase::Update(const CStdString &strDirectory)
   if (!CGUIMediaWindow::Update(strDirectory))
     return false;
 
-  m_thumbLoader.Load(*m_vecItems);
+  m_thumbLoader.Load(*m_unfilteredItems);
 
   return true;
 }

--- a/xbmc/video/windows/GUIWindowVideoNav.h
+++ b/xbmc/video/windows/GUIWindowVideoNav.h
@@ -37,6 +37,7 @@ public:
   virtual bool OnMessage(CGUIMessage& message);
 
   virtual void OnPrepareFileItems(CFileItemList &items);
+
   virtual void OnInfo(CFileItem* pItem, ADDON::ScraperPtr &info);
   static bool CanDelete(const CStdString& strPath);
   static bool DeleteItem(CFileItem* pItem, bool bUnavailable=false);
@@ -47,6 +48,9 @@ protected:
    \param items the items to load information for.
    */
   void LoadVideoInfo(CFileItemList &items);
+
+  void ApplyWatchedFilter(CFileItemList &items);
+  virtual bool GetFilteredItems(const CStdString &filter, CFileItemList &items);
 
   virtual void OnItemLoaded(CFileItem* pItem) {};
   void OnLinkMovieToTvShow(int itemnumber, bool bRemove);

--- a/xbmc/windows/GUIMediaWindow.h
+++ b/xbmc/windows/GUIMediaWindow.h
@@ -86,7 +86,7 @@ protected:
    \param items CFileItemList to filter
    \sa OnFilterItems
    */
-  void GetFilteredItems(const CStdString &filter, CFileItemList &items);
+  virtual bool GetFilteredItems(const CStdString &filter, CFileItemList &items);
 
   // check for a disc or connection
   virtual bool HaveDiscOrConnection(const CStdString& strPath, int iDriveType);


### PR DESCRIPTION
... instead of removing items from main list.

Currently show/hide of watched items in the GUI actually removes watched items prior to sorting/filtering. This causes issues with Directory caching - which can be resolved by clearing the cache when you need to. A smarter way to resolve this is to hide watched items as part of the filtering mechanism. 

A nice bonus is that you can now first set a filter, then apply the watched mode, whereas previously this didn't work.
