### PR TITLE
Index out of bound in panel container

### DIFF
--- a/xbmc/guilib/GUIPanelContainer.cpp
+++ b/xbmc/guilib/GUIPanelContainer.cpp
@@ -352,7 +352,7 @@ bool CGUIPanelContainer::MoveLeft(bool wrapAround)
   { // wrap around
     SetCursor(GetCursor() + m_itemsPerRow - 1);
     if (GetOffset() * m_itemsPerRow + GetCursor() >= (int)m_items.size())
-      SetCursor((int)m_items.size() - GetOffset() * m_itemsPerRow);
+      SetCursor((int)m_items.size() - GetOffset() * m_itemsPerRow - 1);
   }
   else
     return false;


### PR DESCRIPTION
If wrapAround is active in Panel Container and the focus  is on the first item of the last row,
pressing left should go to the last item in row and the correct index is one less than items count.
