### PR TITLE
[gles] - query the max texture size from GLES instead of assuming 2048 (...

### DIFF
--- a/xbmc/rendering/gles/RenderSystemGLES.cpp
+++ b/xbmc/rendering/gles/RenderSystemGLES.cpp
@@ -59,13 +59,17 @@ CRenderSystemGLES::~CRenderSystemGLES()
 
 bool CRenderSystemGLES::InitRenderSystem()
 {
+  GLint maxTextureSize;
+
+  glGetIntegerv(GL_MAX_TEXTURE_SIZE, &maxTextureSize);
+
+  m_maxTextureSize = maxTextureSize;
   m_bVSync = false;
   m_iVSyncMode = 0;
   m_iSwapStamp = 0;
   m_iSwapTime = 0;
   m_iSwapRate = 0;
   m_bVsyncInit = false;
-  m_maxTextureSize = 2048;
   m_renderCaps = 0;
   // Get the GLES version number
   m_RenderVersionMajor = 0;


### PR DESCRIPTION
...new ipad has 4096 for example).

Any doubts that this will run on other gles platforms? Want to have a sign-off by the GLES gurus please.
