### PR TITLE
fix direct playback of playable plugin favorites which have slash at end

### DIFF
--- a/xbmc/interfaces/Builtins.cpp
+++ b/xbmc/interfaces/Builtins.cpp
@@ -487,7 +487,7 @@ int CBuiltins::Execute(const CStdString& execString)
     }
 
     CFileItem item(params[0], false);
-    if (URIUtils::HasSlashAtEnd(params[0]))
+    if (!item.IsPlugin() && URIUtils::HasSlashAtEnd(params[0]))
       item.m_bIsFolder = true;
 
     // restore to previous window if needed


### PR DESCRIPTION
addresses my trac ticket http://trac.xbmc.org/ticket/13074

PlayMedia was assuming that every vfs-path with a slash at the end is a folder - which isn't correct. I fixed this with the additional condition that the item need to be a non-plugin item. But still wondering if this switch is ever needed because folder-favorites (even plugin folders) are using ActivateWindow(vfs) and not PlayMedia(vfs).
