### PR TITLE
dateadded: add < dateadded > to < videolibrary > in as.xml

### DIFF
--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -218,6 +218,7 @@ void CAdvancedSettings::Initialize()
   m_bVideoLibraryImportWatchedState = false;
   m_bVideoLibraryImportResumePoint = false;
   m_bVideoScannerIgnoreErrors = false;
+  m_iVideoLibraryDateAdded = 1; // prefer mtime over ctime and current time
 
   m_iTuxBoxStreamtsPort = 31339;
   m_bTuxBoxAudioChannelSelection = false;
@@ -622,6 +623,7 @@ void CAdvancedSettings::ParseSettingsFile(const CStdString &file)
     XMLUtils::GetBoolean(pElement, "exportautothumbs", m_bVideoLibraryExportAutoThumbs);
     XMLUtils::GetBoolean(pElement, "importwatchedstate", m_bVideoLibraryImportWatchedState);
     XMLUtils::GetBoolean(pElement, "importresumepoint", m_bVideoLibraryImportResumePoint);
+    XMLUtils::GetInt(pElement, "dateadded", m_iVideoLibraryDateAdded);
   }
 
   pElement = pRootElement->FirstChildElement("videoscanner");

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -242,6 +242,7 @@ class CAdvancedSettings
     bool m_bVideoLibraryImportResumePoint;
 
     bool m_bVideoScannerIgnoreErrors;
+    int m_iVideoLibraryDateAdded;
 
     std::vector<CStdString> m_vecTokens; // cleaning strings tied to language
     //TuxBox


### PR DESCRIPTION
There have been some (persistent) requests to get the old behaviour of "Sort by Date Added" back so I added a < dateadded > tag to < videolibrary > in advancedsettings.xml which can take the following values:

0 results in using the current datetime when adding a video. This is equivalent to the behaviour before introducing the dateadded feature.
1 (default) results in prefering to use the files mtime (if it's valid) and only using the file's ctime if the mtime isn't valid.
2 results in using the newer datetime of the file's mtime and ctime.
