### PR TITLE
fix: strlen not a member of std error

### DIFF
--- a/xbmc/interfaces/python/xbmcmodule/xbmcvfsmodule.cpp
+++ b/xbmc/interfaces/python/xbmcmodule/xbmcvfsmodule.cpp
@@ -20,6 +20,7 @@
  */
 
 #include <Python.h>
+#include <cstring>
 
 
 #include "filesystem/Directory.h"


### PR DESCRIPTION
This fixes the error in xbmc/interfaces/python/xbmcmodule/xbmcvfsmodule.cpp:458 when it is compile in Linux
