### PR TITLE
Disc stubs: Display information that a optical disc drive is needed if a disc stub is selected on a system without any optical disc drive

### DIFF
--- a/language/English/strings.po
+++ b/language/English/strings.po
@@ -1585,7 +1585,13 @@ msgctxt "#434"
 msgid "From %s at %i %s"
 msgstr ""
 
-#empty strings from id 435 to 436
+msgctxt "#435"
+msgid "No optical disc drive detected"
+msgstr ""
+
+msgctxt "#436"
+msgid "You need an optical disc drive to play this video"
+msgstr ""
 
 msgctxt "#437"
 msgid "Removable disk"

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -3899,13 +3899,17 @@ bool CApplication::PlayFile(const CFileItem& item, bool bRestart)
 
   if (item.IsDiscStub())
   {
-#ifdef HAS_DVD_DRIVE
-    // Display the Play Eject dialog
-    if (CGUIDialogPlayEject::ShowAndGetInput(item))
-      // PlayDiscAskResume takes path to disc. No parameter means default DVD drive.
-      // Can't do better as CGUIDialogPlayEject calls CMediaManager::IsDiscInDrive, which assumes default DVD drive anyway
-      return MEDIA_DETECT::CAutorun::PlayDiscAskResume();
-#endif
+    // Display the Play Eject dialog if there is any optical disc drive
+    if (g_mediaManager.HasOpticalDrive())
+    {
+      if (CGUIDialogPlayEject::ShowAndGetInput(item))
+        // PlayDiscAskResume takes path to disc. No parameter means default DVD drive.
+        // Can't do better as CGUIDialogPlayEject calls CMediaManager::IsDiscInDrive, which assumes default DVD drive anyway
+        return MEDIA_DETECT::CAutorun::PlayDiscAskResume();
+    }
+    else
+      CGUIDialogOK::ShowAndGetInput(435, NULL, 436, NULL);
+
     return true;
   }
 

--- a/xbmc/storage/MediaManager.cpp
+++ b/xbmc/storage/MediaManager.cpp
@@ -368,6 +368,15 @@ bool CMediaManager::IsAudio(const CStdString& devicePath)
   return false;
 }
 
+bool CMediaManager::HasOpticalDrive()
+{
+#ifdef HAS_DVD_DRIVE
+  if (!strFirstAvailDrive.IsEmpty())
+    return true;
+#endif
+  return false;
+}
+
 DWORD CMediaManager::GetDriveStatus(const CStdString& devicePath)
 {
 #ifdef HAS_DVD_DRIVE

--- a/xbmc/storage/MediaManager.h
+++ b/xbmc/storage/MediaManager.h
@@ -65,6 +65,7 @@ public:
   void RemoveAutoSource(const CMediaSource &share);
   bool IsDiscInDrive(const CStdString& devicePath="");
   bool IsAudio(const CStdString& devicePath="");
+  bool HasOpticalDrive();
   CStdString TranslateDevicePath(const CStdString& devicePath, bool bReturnAsDevice=false);
   DWORD GetDriveStatus(const CStdString& devicePath="");
 #ifdef HAS_DVD_DRIVE


### PR DESCRIPTION
Sorry, I accidentally closed the old PR.

As in ticket [#12875](http://trac.xbmc.org/ticket/12875) reported it just happens nothing if a disc stub is selected on a system without any optical discdrive. Imho there should be an information that a optical disc drive is needed to play the video.
