### PR TITLE
Bug when cleaning the database from rar files

### DIFF
--- a/xbmc/filesystem/RarFile.cpp
+++ b/xbmc/filesystem/RarFile.cpp
@@ -226,6 +226,14 @@ bool CRarFile::Open(const CURL& url)
 bool CRarFile::Exists(const CURL& url)
 {
   InitFromUrl(url);
+  
+  // First step:
+  // Make sure that the archive exists in the filesystem.
+  if (!CFile::Exists(m_strRarPath, false)) 
+    return false;
+
+  // Second step:
+  // Make sure that the requested file exists in the archive.
   bool bResult;
 
   if (!g_RarManager.IsFileInRar(bResult, m_strRarPath, m_strPathInRar))


### PR DESCRIPTION
Since the CRarFile::Exist method looks for files in the rar cache, it might return false positives when a file exists in the cache but not in the filesystem.

This small fix solves that problem by adding a check to the RarFile::Exists method, checking for the file in the filesystem using the CFile::Exists-method. If so; it continues by looking for the file in the archive, else it returns false.
