### PR TITLE
Add keymap support for the power button

### DIFF
--- a/xbmc/input/XBMC_keytable.cpp
+++ b/xbmc/input/XBMC_keytable.cpp
@@ -222,6 +222,7 @@ static const XBMCKEYTABLE XBMCKeyTable[] =
 , { XBMCK_PAUSE,                  0,    0, XBMCVK_PAUSE,         "pause" }
 , { XBMCK_SCROLLOCK,              0,    0, XBMCVK_SCROLLLOCK,    "scrolllock" }
 , { XBMCK_PRINT,                  0,    0, XBMCVK_PRINTSCREEN,   "printscreen" }
+, { XBMCK_POWER,                  0,    0, XBMCVK_POWER,         "power" }
 };
 
 static int XBMCKeyTableSize = sizeof(XBMCKeyTable)/sizeof(XBMCKEYTABLE);

--- a/xbmc/input/XBMC_vkeys.h
+++ b/xbmc/input/XBMC_vkeys.h
@@ -204,6 +204,7 @@ typedef enum {
   XBMCVK_PRINTSCREEN    = 0xDB,
   XBMCVK_SCROLLLOCK     = 0xDC,
   XBMCVK_PAUSE          = 0XDD,
+  XBMCVK_POWER          = 0XDE,
 
   XBMCVK_LAST           = 0xFF
 } XBMCVKey;

--- a/xbmc/windowing/WinEventsSDL.cpp
+++ b/xbmc/windowing/WinEventsSDL.cpp
@@ -62,6 +62,7 @@ static uint16_t SymMappingsEvdev[][2] =
 { { 121, XBMCK_VOLUME_MUTE }         // Volume mute
 , { 122, XBMCK_VOLUME_DOWN }         // Volume down
 , { 123, XBMCK_VOLUME_UP }           // Volume up
+, { 124, XBMCK_POWER }               // Power button on PC case
 , { 127, XBMCK_SPACE }               // Pause
 , { 135, XBMCK_MENU }                // Right click
 , { 136, XBMCK_MEDIA_STOP }          // Stop


### PR DESCRIPTION
In Ubuntu pressing the power button generates a keypress with scan code 0x7C and the rest of the keysum empty. This commit allows the power button press to be mapped to an action using "<power>".

Related to http://trac.xbmc.org/ticket/10004
