### PR TITLE
[AE][GUI] Add Audio category to System Information GUI window and popula...

### DIFF
--- a/addons/skin.confluence/720p/SettingsSystemInfo.xml
+++ b/addons/skin.confluence/720p/SettingsSystemInfo.xml
@@ -132,6 +132,21 @@
 					<label>13280</label>
 				</control>
 				<control type="button" id="98">
+					<description>Button Audio</description>
+					<height>60</height>
+					<width>241</width>
+					<textoffsetx>0</textoffsetx>
+					<align>right</align>
+					<aligny>center</aligny>
+					<font>font13_title</font>
+					<textcolor>grey2</textcolor>
+					<focusedcolor>white</focusedcolor>
+					<texturefocus border="5">MenuItemFO.png</texturefocus>
+					<texturenofocus border="5">MenuItemNF.png</texturenofocus>
+					<pulseonselect>false</pulseonselect>
+					<label>292</label>
+				</control>
+				<control type="button" id="99">
 					<description>Button Hardware</description>
 					<height>60</height>
 					<width>241</width>

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -76,6 +76,7 @@
 #include "interfaces/info/InfoBool.h"
 #include "TextureCache.h"
 #include "cores/AudioEngine/Utils/AEUtil.h"
+#include "cores/AudioEngine/AEFactory.h"
 
 #define SYSHEATUPDATEINTERVAL 60000
 
@@ -1679,6 +1680,11 @@ CStdString CGUIInfoManager::GetLabel(int info, int contextWindow, CStdString *fa
   }
 
   return strLabel;
+}
+
+AEDeviceReport* CGUIInfoManager::GetAudioDeviceReport()
+{
+  return CAEFactory::AE->GetDeviceReport();
 }
 
 // tries to get a integer value for use in progressbars/sliders and such

--- a/xbmc/GUIInfoManager.h
+++ b/xbmc/GUIInfoManager.h
@@ -656,6 +656,9 @@ public:
   CStdString GetVersion();
   CStdString GetBuild();
 
+  /* Retrieve AudioEngine current audio device report */
+  AEDeviceReport* GetAudioDeviceReport();
+
   bool GetDisplayAfterSeek();
   void SetDisplayAfterSeek(unsigned int timeOut = 2500, int seekOffset = 0);
   void SetSeeking(bool seeking) { m_playerSeeking = seeking; };

--- a/xbmc/cores/AudioEngine/AEFactory.h
+++ b/xbmc/cores/AudioEngine/AEFactory.h
@@ -22,6 +22,7 @@
 
 #include "Interfaces/AE.h"
 #include "threads/Thread.h"
+#include <string.h>
 
 enum AEEngine
 {
@@ -38,6 +39,9 @@ public:
   static IAE *AE;
   static bool LoadEngine();
   static bool StartEngine();
+
+  virtual std::string DeviceReport() {return this->DeviceReport();};
+
 private:
   static bool LoadEngine(enum AEEngine engine);
 };

--- a/xbmc/cores/AudioEngine/Engines/SoftAE/SoftAE.h
+++ b/xbmc/cores/AudioEngine/Engines/SoftAE/SoftAE.h
@@ -110,6 +110,11 @@ public:
   void PauseStream (CSoftAEStream *stream);
   void ResumeStream(CSoftAEStream *stream);
 
+  AEDeviceReport  m_DeviceReport;
+
+  /* provide device report for SystemInfo */
+  AEDeviceReport* GetDeviceReport();
+
 private:
   CThread *m_thread;
 
@@ -123,6 +128,8 @@ private:
   void ResetEncoder();
   bool SetupEncoder(AEAudioFormat &format);
   void Deinitialize();
+
+  void GenerateDeviceReport();
 
   IAESink *GetSink(AEAudioFormat &desiredFormat, bool passthrough, std::string &device);
   void StopAllSounds();

--- a/xbmc/cores/AudioEngine/Interfaces/AE.h
+++ b/xbmc/cores/AudioEngine/Interfaces/AE.h
@@ -33,6 +33,20 @@
 typedef std::pair<std::string, std::string> AEDevice;
 typedef std::vector<AEDevice> AEDeviceList;
 
+typedef struct
+{
+  std::string      m_drDevice;
+  std::string      m_drDevType;
+  std::string      m_drChannels;
+  std::string      m_drSampleRates;
+  std::string      m_drAC3ok;
+  std::string      m_drDTSok;
+  std::string      m_drAACok;
+  std::string      m_drLPCMok;
+  std::string      m_drTRUEHDok;
+  std::string      m_drDTSHDok;
+} AEDeviceReport;
+
 /* forward declarations */
 class IAEStream;
 class IAESound;
@@ -158,5 +172,7 @@ public:
    * @returns true if the AudioEngine is capable of RAW output
    */
   virtual bool SupportsRaw() { return false; }
+
+  virtual AEDeviceReport* GetDeviceReport() { return NULL; }
 };
 

--- a/xbmc/windows/GUIWindowSystemInfo.cpp
+++ b/xbmc/windows/GUIWindowSystemInfo.cpp
@@ -34,7 +34,8 @@
 #define CONTROL_BT_DEFAULT  95
 #define CONTROL_BT_NETWORK  96
 #define CONTROL_BT_VIDEO    97
-#define CONTROL_BT_HARDWARE 98
+#define CONTROL_BT_AUDIO    98
+#define CONTROL_BT_HARDWARE 99
 
 #define CONTROL_START       CONTROL_BT_STORAGE
 #define CONTROL_END         CONTROL_BT_HARDWARE
@@ -137,6 +138,26 @@ void CGUIWindowSystemInfo::FrameMove()
     SetControlLabel(i++, "%s %s", 22024, SYSTEM_RENDER_VERSION);
 #endif
     SetControlLabel(i++, "%s %s", 22010, SYSTEM_GPU_TEMPERATURE);
+  }
+  else if (m_section == CONTROL_BT_AUDIO)
+  {
+    AEDeviceReport* pDeviceReport = g_infoManager.GetAudioDeviceReport();
+    SET_CONTROL_LABEL(i++, (CStdString)pDeviceReport->m_drDevice);
+    SET_CONTROL_LABEL(i++, (CStdString)pDeviceReport->m_drDevType);
+    SET_CONTROL_LABEL(i++, (CStdString)pDeviceReport->m_drChannels);
+    SET_CONTROL_LABEL(i++, (CStdString)pDeviceReport->m_drSampleRates);
+    if ((CStdString)pDeviceReport->m_drAC3ok != "")
+      SET_CONTROL_LABEL(i++, (CStdString)pDeviceReport->m_drAC3ok);
+    if ((CStdString)pDeviceReport->m_drDTSok != "")
+      SET_CONTROL_LABEL(i++, (CStdString)pDeviceReport->m_drDTSok);
+    if ((CStdString)pDeviceReport->m_drAACok != "")
+      SET_CONTROL_LABEL(i++, (CStdString)pDeviceReport->m_drAACok);
+    if ((CStdString)pDeviceReport->m_drTRUEHDok != "")
+      SET_CONTROL_LABEL(i++, (CStdString)pDeviceReport->m_drTRUEHDok);
+    if ((CStdString)pDeviceReport->m_drDTSHDok != "")
+      SET_CONTROL_LABEL(i++, (CStdString)pDeviceReport->m_drDTSHDok);
+    if ((CStdString)pDeviceReport->m_drLPCMok != "")
+      SET_CONTROL_LABEL(i++, (CStdString)pDeviceReport->m_drLPCMok);
   }
   else if (m_section == CONTROL_BT_HARDWARE)
   {


### PR DESCRIPTION
...te with current AudioEngine audio device capabilities enumeration results.

This PR aims to present the capabilites of the currently selected audio device in the System Information GUI window as we currently do with other hardware info.

This is the result of the code on my machine with an HDMI device selected: http://i45.tinypic.com/2n8wgnq.jpg

The data is derived from the sinks EnumerateDevicesEx() method.

As written, it calls the loaded engine and thus requires similar methods to be added for CA. It would be great if Gimli, Davilla or Memphiz could comment on whether useful information can also be returned from CA. If not we can make it specific to SoftAE/Linux/Windows.

There is limited space available in the window - as shown and written there is just enough room to describe the current passthrough device. If the window were scrollable we could add the current PCM/analog device info a well. Perhaps Jezz_X can comment on that possibility.

The goal is to provide the user with enough user-friendly info on their device(s) capabilities.
