### PR TITLE
[arm] enable pause/unpause of thumbjobs when playback starts/stops/ends.

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -3979,6 +3979,9 @@ void CApplication::OnPlayBackEnded()
   if(m_bPlaybackStarting)
     return;
 
+  if (CJobManager::GetInstance().IsPaused(kJobTypeMediaFlags))
+    CJobManager::GetInstance().UnPause(kJobTypeMediaFlags);
+
   // informs python script currently running playback has ended
   // (does nothing if python is not loaded)
 #ifdef HAS_PYTHON
@@ -4007,6 +4010,9 @@ void CApplication::OnPlayBackStarted()
 {
   if(m_bPlaybackStarting)
     return;
+
+  if (!CJobManager::GetInstance().IsPaused(kJobTypeMediaFlags))
+    CJobManager::GetInstance().Pause(kJobTypeMediaFlags);
 
 #ifdef HAS_PYTHON
   // informs python script currently running playback has started
@@ -4052,6 +4058,9 @@ void CApplication::OnPlayBackStopped()
 {
   if(m_bPlaybackStarting)
     return;
+
+  if (CJobManager::GetInstance().IsPaused(kJobTypeMediaFlags))
+    CJobManager::GetInstance().UnPause(kJobTypeMediaFlags);
 
   // informs python script currently running playback has ended
   // (does nothing if python is not loaded)

--- a/xbmc/ThumbLoader.h
+++ b/xbmc/ThumbLoader.h
@@ -25,6 +25,8 @@
 #include "utils/JobManager.h"
 #include "FileItem.h"
 
+#define kJobTypeMediaFlags "mediaflags"
+
 class CStreamDetails;
 class IStreamDetailsObserver;
 class CVideoDatabase;
@@ -50,7 +52,7 @@ public:
 
   virtual const char* GetType() const
   {
-    return "mediaflags";
+    return kJobTypeMediaFlags;
   }
 
   virtual bool operator==(const CJob* job) const;


### PR DESCRIPTION
lets try this again. jm was right (as usual) so diddling in thumbloader was removed.

we check before pause/unpause because pausing is stackable.

need spiff's sign off if the ifdefs are to be removed.
