### PR TITLE
Build Shared Lib

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -183,13 +183,20 @@ CXXFLAGS=@CXXFLAGS@
 LDFLAGS=@LDFLAGS@
 INCLUDES=$(sort @INCLUDES@)
 
-CLEAN_FILES=xbmc.bin xbmc-xrandr
+CLEAN_FILES=xbmc.bin xbmc-xrandr libxbmc.so
 
 DISTCLEAN_FILES=config.h config.log config.status tools/Linux/xbmc.sh \
         tools/Linux/xbmc-standalone.sh autom4te.cache config.h.in~ \
         system/libcpluff-@ARCH@.so
 
-all : Makefile externals xbmc.bin xbmc-xrandr skins
+ifeq (@USE_LIBXBMC@,1)
+FINAL_TARGETS+=libxbmc.so
+else
+FINAL_TARGETS=xbmc.bin skins xbmc-xrandr
+endif
+FINAL_TARGETS+=Makefile externals
+
+all : $(FINAL_TARGETS)
 	@echo '-----------------------'
 	@echo 'XBMC built successfully'
 	@echo '-----------------------'
@@ -335,7 +342,14 @@ OBJSXBMC:=$(filter-out $(DYNOBJSXBMC), $(OBJSXBMC))
 
 LIBS += @PYTHON_LDFLAGS@
 
-xbmc.bin: $(OBJSXBMC) $(DYNOBJSXBMC) $(NWAOBJSXBMC)
+libxbmc.so: $(OBJSXBMC) $(DYNOBJSXBMC)
+ifeq ($(findstring osx,@ARCH@), osx)
+	$(SILENT_LD) $(CXX) $(LDFLAGS) -bundle -o $@ -Wl,-all_load,-ObjC $(DYNOBJSXBMC) $(OBJSXBMC) $(LIBS)
+else
+	$(SILENT_LD) $(CXX) $(CXXFLAGS) $(LDFLAGS) -shared -o $@ -Wl,--whole-archive $(DYNOBJSXBMC) $(OBJSXBMC) -Wl,--no-whole-archive $(LIBS)
+endif
+
+xbmc.bin: $(OBJSXBMC) $(DYNOBJSXBMC)
 
 ifeq ($(findstring osx,@ARCH@), osx)
 	$(SILENT_LD) $(CXX) $(LDFLAGS) -o xbmc.bin -Wl,-all_load,-ObjC $(DYNOBJSXBMC) $(OBJSXBMC) $(LIBS) -rdynamic
@@ -379,7 +393,11 @@ install-binaries: install-scripts
 ifeq (1,@USE_XRANDR@)
 	@install xbmc-xrandr $(DESTDIR)$(libdir)/xbmc/xbmc-xrandr
 endif
+ifeq (@USE_LIBXBMC@,1)
+	@install libxbmc.so $(DESTDIR)$(libdir)/xbmc/libxbmc.so
+else
 	@echo "You can run XBMC with the command 'xbmc'"
+endif
 endif
 
 install-arch:

--- a/XBMC.xcodeproj/project.pbxproj
+++ b/XBMC.xcodeproj/project.pbxproj
@@ -949,6 +949,7 @@
 		F5D8D732102BB3B1004A11AB /* OverlayRendererGL.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5D8D72F102BB3B1004A11AB /* OverlayRendererGL.cpp */; };
 		F5D8D733102BB3B1004A11AB /* OverlayRenderer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5D8D731102BB3B1004A11AB /* OverlayRenderer.cpp */; };
 		F5D8EF5B103912A4004A11AB /* DVDSubtitleParserVplayer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5D8EF59103912A4004A11AB /* DVDSubtitleParserVplayer.cpp */; };
+		F5DA82D915803129003EE43C /* main.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5DA82D815803129003EE43C /* main.cpp */; };
 		F5DC87E2110A287400EE1B15 /* RingBuffer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5DC87E1110A287400EE1B15 /* RingBuffer.cpp */; };
 		F5DC8801110A46C700EE1B15 /* ModplugCodec.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5DC8800110A46C700EE1B15 /* ModplugCodec.cpp */; };
 		F5DC888B110A654000EE1B15 /* libapetag.a in Frameworks */ = {isa = PBXBuildFile; fileRef = F5DC888A110A654000EE1B15 /* libapetag.a */; };
@@ -3011,6 +3012,7 @@
 		F5D8D731102BB3B1004A11AB /* OverlayRenderer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = OverlayRenderer.cpp; sourceTree = "<group>"; };
 		F5D8EF59103912A4004A11AB /* DVDSubtitleParserVplayer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = DVDSubtitleParserVplayer.cpp; sourceTree = "<group>"; };
 		F5D8EF5A103912A4004A11AB /* DVDSubtitleParserVplayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DVDSubtitleParserVplayer.h; sourceTree = "<group>"; };
+		F5DA82D815803129003EE43C /* main.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = main.cpp; sourceTree = "<group>"; };
 		F5DC87E0110A287400EE1B15 /* RingBuffer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RingBuffer.h; sourceTree = "<group>"; };
 		F5DC87E1110A287400EE1B15 /* RingBuffer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = RingBuffer.cpp; sourceTree = "<group>"; };
 		F5DC87FF110A46C700EE1B15 /* ModplugCodec.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ModplugCodec.h; sourceTree = "<group>"; };
@@ -4345,6 +4347,7 @@
 				E38E184F0D25F9FA00618676 /* IProgressCallback.h */,
 				E38E18580D25F9FA00618676 /* LangInfo.cpp */,
 				E38E18590D25F9FA00618676 /* LangInfo.h */,
+				F5DA82D815803129003EE43C /* main.cpp */,
 				880DBE4B0DC223FF00E26B71 /* MediaSource.cpp */,
 				880DBE4C0DC223FF00E26B71 /* MediaSource.h */,
 				E38E1DC10D25F9FD00618676 /* NfoFile.cpp */,
@@ -7297,6 +7300,7 @@
 				7C6EB330155BD1D40080368A /* ImageFile.cpp in Sources */,
 				7C6EB6FA155F32C30080368A /* HTTPImageHandler.cpp in Sources */,
 				18E7CACB1578C26D001D4554 /* CDDARipJob.cpp in Sources */,
+				F5DA82D915803129003EE43C /* main.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/configure.in
+++ b/configure.in
@@ -147,6 +147,11 @@ dashes="------------------------"
 final_message="\n  XBMC Configuration:"
 final_message="\n$dashes$final_message\n$dashes"
 
+AC_ARG_ENABLE([shared-lib],
+  [AS_HELP_STRING([--enable-shared-lib],
+  [build libxbmc. helpful for tests (default is no)])],
+  [build_shared_lib=$enableval],
+  [build_shared_lib=no])
 
 AC_ARG_ENABLE([debug],
   [AS_HELP_STRING([--enable-debug],
@@ -560,6 +565,11 @@ case $host in
      AC_MSG_ERROR(unsupported host ($host))
 esac
 AC_SUBST([ARCH])
+
+if test "$build_shared_lib" = "yes"; then
+  final_message="$final_message\n Shared lib\tYes"
+  AC_SUBST(USE_LIBXBMC,1)
+fi
 
 # platform debug flags
 if test "$use_debug" = "yes"; then

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -552,6 +552,7 @@ void CApplication::Preflight()
 
 bool CApplication::Create()
 {
+  Preflight();
   g_settings.Initialize(); //Initialize default AdvancedSettings
 
 #ifdef _LINUX

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -743,6 +743,11 @@ bool CApplication::Create()
 
   m_lastFrameTime = XbmcThreads::SystemClockMillis();
   m_lastRenderTime = m_lastFrameTime;
+  return true;
+}
+
+bool CApplication::CreateGUI()
+{
 #ifdef HAS_SDL
   CLog::Log(LOGNOTICE, "Setup SDL");
 
@@ -774,7 +779,6 @@ bool CApplication::Create()
   setenv("__GL_SYNC_TO_VBLANK", "1", 0);
   setenv("__GL_YIELD", "USLEEP", 0);
 #endif
-
 
   m_bSystemScreenSaverEnable = g_Windowing.IsSystemScreenSaverEnabled();
   g_Windowing.EnableSystemScreenSaver(false);
@@ -868,7 +872,7 @@ bool CApplication::Create()
             g_settings.m_ResInfo[iResolution].strMode.c_str());
   g_windowManager.Initialize();
 
-  return Initialize();
+  return true;
 }
 
 bool CApplication::InitDirectoriesLinux()

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -2746,18 +2746,18 @@ void CApplication::FrameMove(bool processEvents, bool processGUI)
 
     if (processGUI)
     {
-    g_graphicsContext.Lock();
-    // check if there are notifications to display
-    CGUIDialogKaiToast *toast = (CGUIDialogKaiToast *)g_windowManager.GetWindow(WINDOW_DIALOG_KAI_TOAST);
-    if (toast && toast->DoWork())
-    {
-      if (!toast->IsDialogRunning())
+      g_graphicsContext.Lock();
+      // check if there are notifications to display
+      CGUIDialogKaiToast *toast = (CGUIDialogKaiToast *)g_windowManager.GetWindow(WINDOW_DIALOG_KAI_TOAST);
+      if (toast && toast->DoWork())
       {
-        toast->Show();
+        if (!toast->IsDialogRunning())
+        {
+          toast->Show();
+        }
       }
-    }
-    g_graphicsContext.Unlock();
-    CWinEvents::MessagePump();
+      g_graphicsContext.Unlock();
+      CWinEvents::MessagePump();
     }
 
     UpdateLCD();
@@ -2779,9 +2779,9 @@ void CApplication::FrameMove(bool processEvents, bool processGUI)
   }
   if (processGUI)
   {
-  if (!m_bStop)
-    g_windowManager.Process(CTimeUtils::GetFrameTime());
-  g_windowManager.FrameMove();
+    if (!m_bStop)
+      g_windowManager.Process(CTimeUtils::GetFrameTime());
+    g_windowManager.FrameMove();
   }
 }
 

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -1155,136 +1155,136 @@ bool CApplication::Initialize()
   m_dpms = new DPMSSupport();
   if (g_windowManager.Initialized())
   {
-  g_guiSettings.GetSetting("powermanagement.displaysoff")->SetVisible(m_dpms->IsSupported());
+    g_guiSettings.GetSetting("powermanagement.displaysoff")->SetVisible(m_dpms->IsSupported());
 
-  g_windowManager.Add(new CGUIWindowHome);                     // window id = 0
-  g_windowManager.Add(new CGUIWindowPrograms);                 // window id = 1
-  g_windowManager.Add(new CGUIWindowPictures);                 // window id = 2
-  g_windowManager.Add(new CGUIWindowFileManager);      // window id = 3
-  g_windowManager.Add(new CGUIWindowSettings);                 // window id = 4
-  g_windowManager.Add(new CGUIWindowSystemInfo);               // window id = 7
+    g_windowManager.Add(new CGUIWindowHome);                     // window id = 0
+    g_windowManager.Add(new CGUIWindowPrograms);                 // window id = 1
+    g_windowManager.Add(new CGUIWindowPictures);                 // window id = 2
+    g_windowManager.Add(new CGUIWindowFileManager);      // window id = 3
+    g_windowManager.Add(new CGUIWindowSettings);                 // window id = 4
+    g_windowManager.Add(new CGUIWindowSystemInfo);               // window id = 7
 #ifdef HAS_GL
-  g_windowManager.Add(new CGUIWindowTestPatternGL);      // window id = 8
+    g_windowManager.Add(new CGUIWindowTestPatternGL);      // window id = 8
 #endif
 #ifdef HAS_DX
-  g_windowManager.Add(new CGUIWindowTestPatternDX);      // window id = 8
+    g_windowManager.Add(new CGUIWindowTestPatternDX);      // window id = 8
 #endif
-  g_windowManager.Add(new CGUIDialogTeletext);               // window id =
-  g_windowManager.Add(new CGUIWindowSettingsScreenCalibration); // window id = 11
-  g_windowManager.Add(new CGUIWindowSettingsCategory);         // window id = 12 slideshow:window id 2007
-  g_windowManager.Add(new CGUIWindowVideoNav);                 // window id = 36
-  g_windowManager.Add(new CGUIWindowVideoPlaylist);            // window id = 28
-  g_windowManager.Add(new CGUIWindowLoginScreen);            // window id = 29
-  g_windowManager.Add(new CGUIWindowSettingsProfile);          // window id = 34
-  g_windowManager.Add(new CGUIWindowAddonBrowser);          // window id = 40
-  g_windowManager.Add(new CGUIWindowScreensaverDim);            // window id = 97  
-  g_windowManager.Add(new CGUIWindowDebugInfo);            // window id = 98
-  g_windowManager.Add(new CGUIWindowPointer);            // window id = 99
-  g_windowManager.Add(new CGUIDialogYesNo);              // window id = 100
-  g_windowManager.Add(new CGUIDialogProgress);           // window id = 101
-  g_windowManager.Add(new CGUIDialogKeyboard);           // window id = 103
-  g_windowManager.Add(new CGUIDialogVolumeBar);          // window id = 104
-  g_windowManager.Add(new CGUIDialogSeekBar);            // window id = 115
-  g_windowManager.Add(new CGUIDialogSubMenu);            // window id = 105
-  g_windowManager.Add(new CGUIDialogContextMenu);        // window id = 106
-  g_windowManager.Add(new CGUIDialogKaiToast);           // window id = 107
-  g_windowManager.Add(new CGUIDialogNumeric);            // window id = 109
-  g_windowManager.Add(new CGUIDialogGamepad);            // window id = 110
-  g_windowManager.Add(new CGUIDialogButtonMenu);         // window id = 111
-  g_windowManager.Add(new CGUIDialogMusicScan);          // window id = 112
-  g_windowManager.Add(new CGUIDialogMuteBug);            // window id = 113
-  g_windowManager.Add(new CGUIDialogPlayerControls);     // window id = 114
+    g_windowManager.Add(new CGUIDialogTeletext);               // window id =
+    g_windowManager.Add(new CGUIWindowSettingsScreenCalibration); // window id = 11
+    g_windowManager.Add(new CGUIWindowSettingsCategory);         // window id = 12 slideshow:window id 2007
+    g_windowManager.Add(new CGUIWindowVideoNav);                 // window id = 36
+    g_windowManager.Add(new CGUIWindowVideoPlaylist);            // window id = 28
+    g_windowManager.Add(new CGUIWindowLoginScreen);            // window id = 29
+    g_windowManager.Add(new CGUIWindowSettingsProfile);          // window id = 34
+    g_windowManager.Add(new CGUIWindowAddonBrowser);          // window id = 40
+    g_windowManager.Add(new CGUIWindowScreensaverDim);            // window id = 97  
+    g_windowManager.Add(new CGUIWindowDebugInfo);            // window id = 98
+    g_windowManager.Add(new CGUIWindowPointer);            // window id = 99
+    g_windowManager.Add(new CGUIDialogYesNo);              // window id = 100
+    g_windowManager.Add(new CGUIDialogProgress);           // window id = 101
+    g_windowManager.Add(new CGUIDialogKeyboard);           // window id = 103
+    g_windowManager.Add(new CGUIDialogVolumeBar);          // window id = 104
+    g_windowManager.Add(new CGUIDialogSeekBar);            // window id = 115
+    g_windowManager.Add(new CGUIDialogSubMenu);            // window id = 105
+    g_windowManager.Add(new CGUIDialogContextMenu);        // window id = 106
+    g_windowManager.Add(new CGUIDialogKaiToast);           // window id = 107
+    g_windowManager.Add(new CGUIDialogNumeric);            // window id = 109
+    g_windowManager.Add(new CGUIDialogGamepad);            // window id = 110
+    g_windowManager.Add(new CGUIDialogButtonMenu);         // window id = 111
+    g_windowManager.Add(new CGUIDialogMusicScan);          // window id = 112
+    g_windowManager.Add(new CGUIDialogMuteBug);            // window id = 113
+    g_windowManager.Add(new CGUIDialogPlayerControls);     // window id = 114
 #ifdef HAS_KARAOKE
-  g_windowManager.Add(new CGUIDialogKaraokeSongSelectorSmall); // window id 143
-  g_windowManager.Add(new CGUIDialogKaraokeSongSelectorLarge); // window id 144
+    g_windowManager.Add(new CGUIDialogKaraokeSongSelectorSmall); // window id 143
+    g_windowManager.Add(new CGUIDialogKaraokeSongSelectorLarge); // window id 144
 #endif
-  g_windowManager.Add(new CGUIDialogSlider);             // window id = 145
-  g_windowManager.Add(new CGUIDialogMusicOSD);           // window id = 120
-  g_windowManager.Add(new CGUIDialogVisualisationPresetList);   // window id = 122
-  g_windowManager.Add(new CGUIDialogVideoSettings);             // window id = 123
-  g_windowManager.Add(new CGUIDialogAudioSubtitleSettings);     // window id = 124
-  g_windowManager.Add(new CGUIDialogVideoBookmarks);      // window id = 125
-  // Don't add the filebrowser dialog - it's created and added when it's needed
-  g_windowManager.Add(new CGUIDialogNetworkSetup);  // window id = 128
-  g_windowManager.Add(new CGUIDialogMediaSource);   // window id = 129
-  g_windowManager.Add(new CGUIDialogProfileSettings); // window id = 130
-  g_windowManager.Add(new CGUIDialogVideoScan);      // window id = 133
-  g_windowManager.Add(new CGUIDialogFavourites);     // window id = 134
-  g_windowManager.Add(new CGUIDialogSongInfo);       // window id = 135
-  g_windowManager.Add(new CGUIDialogSmartPlaylistEditor);       // window id = 136
-  g_windowManager.Add(new CGUIDialogSmartPlaylistRule);       // window id = 137
-  g_windowManager.Add(new CGUIDialogBusy);      // window id = 138
-  g_windowManager.Add(new CGUIDialogPictureInfo);      // window id = 139
-  g_windowManager.Add(new CGUIDialogAddonInfo);
-  g_windowManager.Add(new CGUIDialogAddonSettings);      // window id = 140
+    g_windowManager.Add(new CGUIDialogSlider);             // window id = 145
+    g_windowManager.Add(new CGUIDialogMusicOSD);           // window id = 120
+    g_windowManager.Add(new CGUIDialogVisualisationPresetList);   // window id = 122
+    g_windowManager.Add(new CGUIDialogVideoSettings);             // window id = 123
+    g_windowManager.Add(new CGUIDialogAudioSubtitleSettings);     // window id = 124
+    g_windowManager.Add(new CGUIDialogVideoBookmarks);      // window id = 125
+    // Don't add the filebrowser dialog - it's created and added when it's needed
+    g_windowManager.Add(new CGUIDialogNetworkSetup);  // window id = 128
+    g_windowManager.Add(new CGUIDialogMediaSource);   // window id = 129
+    g_windowManager.Add(new CGUIDialogProfileSettings); // window id = 130
+    g_windowManager.Add(new CGUIDialogVideoScan);      // window id = 133
+    g_windowManager.Add(new CGUIDialogFavourites);     // window id = 134
+    g_windowManager.Add(new CGUIDialogSongInfo);       // window id = 135
+    g_windowManager.Add(new CGUIDialogSmartPlaylistEditor);       // window id = 136
+    g_windowManager.Add(new CGUIDialogSmartPlaylistRule);       // window id = 137
+    g_windowManager.Add(new CGUIDialogBusy);      // window id = 138
+    g_windowManager.Add(new CGUIDialogPictureInfo);      // window id = 139
+    g_windowManager.Add(new CGUIDialogAddonInfo);
+    g_windowManager.Add(new CGUIDialogAddonSettings);      // window id = 140
 #ifdef HAS_LINUX_NETWORK
-  g_windowManager.Add(new CGUIDialogAccessPoints);      // window id = 141
+    g_windowManager.Add(new CGUIDialogAccessPoints);      // window id = 141
 #endif
 
-  g_windowManager.Add(new CGUIDialogLockSettings); // window id = 131
+    g_windowManager.Add(new CGUIDialogLockSettings); // window id = 131
 
-  g_windowManager.Add(new CGUIDialogContentSettings);        // window id = 132
+    g_windowManager.Add(new CGUIDialogContentSettings);        // window id = 132
 
-  g_windowManager.Add(new CGUIDialogPlayEject);
+    g_windowManager.Add(new CGUIDialogPlayEject);
 
-  g_windowManager.Add(new CGUIDialogPeripheralManager);
-  g_windowManager.Add(new CGUIDialogPeripheralSettings);
+    g_windowManager.Add(new CGUIDialogPeripheralManager);
+    g_windowManager.Add(new CGUIDialogPeripheralSettings);
 
-  g_windowManager.Add(new CGUIWindowMusicPlayList);          // window id = 500
-  g_windowManager.Add(new CGUIWindowMusicSongs);             // window id = 501
-  g_windowManager.Add(new CGUIWindowMusicNav);               // window id = 502
-  g_windowManager.Add(new CGUIWindowMusicPlaylistEditor);    // window id = 503
+    g_windowManager.Add(new CGUIWindowMusicPlayList);          // window id = 500
+    g_windowManager.Add(new CGUIWindowMusicSongs);             // window id = 501
+    g_windowManager.Add(new CGUIWindowMusicNav);               // window id = 502
+    g_windowManager.Add(new CGUIWindowMusicPlaylistEditor);    // window id = 503
 
-  g_windowManager.Add(new CGUIDialogSelect);             // window id = 2000
-  g_windowManager.Add(new CGUIDialogMusicInfo);          // window id = 2001
-  g_windowManager.Add(new CGUIDialogOK);                 // window id = 2002
-  g_windowManager.Add(new CGUIDialogVideoInfo);          // window id = 2003
-  g_windowManager.Add(new CGUIDialogTextViewer);
-  g_windowManager.Add(new CGUIWindowFullScreen);         // window id = 2005
-  g_windowManager.Add(new CGUIWindowVisualisation);      // window id = 2006
-  g_windowManager.Add(new CGUIWindowSlideShow);          // window id = 2007
-  g_windowManager.Add(new CGUIDialogFileStacking);       // window id = 2008
+    g_windowManager.Add(new CGUIDialogSelect);             // window id = 2000
+    g_windowManager.Add(new CGUIDialogMusicInfo);          // window id = 2001
+    g_windowManager.Add(new CGUIDialogOK);                 // window id = 2002
+    g_windowManager.Add(new CGUIDialogVideoInfo);          // window id = 2003
+    g_windowManager.Add(new CGUIDialogTextViewer);
+    g_windowManager.Add(new CGUIWindowFullScreen);         // window id = 2005
+    g_windowManager.Add(new CGUIWindowVisualisation);      // window id = 2006
+    g_windowManager.Add(new CGUIWindowSlideShow);          // window id = 2007
+    g_windowManager.Add(new CGUIDialogFileStacking);       // window id = 2008
 #ifdef HAS_KARAOKE
-  g_windowManager.Add(new CGUIWindowKaraokeLyrics);      // window id = 2009
+    g_windowManager.Add(new CGUIWindowKaraokeLyrics);      // window id = 2009
 #endif
 
-  g_windowManager.Add(new CGUIDialogVideoOSD);           // window id = 2901
-  g_windowManager.Add(new CGUIDialogMusicOverlay);       // window id = 2903
-  g_windowManager.Add(new CGUIDialogVideoOverlay);       // window id = 2904
-  g_windowManager.Add(new CGUIWindowScreensaver);        // window id = 2900 Screensaver
-  g_windowManager.Add(new CGUIWindowWeather);            // window id = 2600 WEATHER
-  g_windowManager.Add(new CGUIWindowStartup);            // startup window (id 2999)
+    g_windowManager.Add(new CGUIDialogVideoOSD);           // window id = 2901
+    g_windowManager.Add(new CGUIDialogMusicOverlay);       // window id = 2903
+    g_windowManager.Add(new CGUIDialogVideoOverlay);       // window id = 2904
+    g_windowManager.Add(new CGUIWindowScreensaver);        // window id = 2900 Screensaver
+    g_windowManager.Add(new CGUIWindowWeather);            // window id = 2600 WEATHER
+    g_windowManager.Add(new CGUIWindowStartup);            // startup window (id 2999)
 
-  /* window id's 3000 - 3100 are reserved for python */
+    /* window id's 3000 - 3100 are reserved for python */
 
-  // Make sure we have at least the default skin
-  if (!LoadSkin(g_guiSettings.GetString("lookandfeel.skin")) && !LoadSkin(DEFAULT_SKIN))
-  {
-      CLog::Log(LOGERROR, "Default skin '%s' not found! Terminating..", DEFAULT_SKIN);
-      FatalErrorHandler(true, true, true);
-  }
+    // Make sure we have at least the default skin
+    if (!LoadSkin(g_guiSettings.GetString("lookandfeel.skin")) && !LoadSkin(DEFAULT_SKIN))
+    {
+        CLog::Log(LOGERROR, "Default skin '%s' not found! Terminating..", DEFAULT_SKIN);
+        FatalErrorHandler(true, true, true);
+    }
 
-  if (g_advancedSettings.m_splashImage)
-    SAFE_DELETE(m_splash);
+    if (g_advancedSettings.m_splashImage)
+      SAFE_DELETE(m_splash);
 
-  if (g_guiSettings.GetBool("masterlock.startuplock") &&
-      g_settings.GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE &&
-     !g_settings.GetMasterProfile().getLockCode().IsEmpty())
-  {
-     g_passwordManager.CheckStartUpLock();
-  }
+    if (g_guiSettings.GetBool("masterlock.startuplock") &&
+        g_settings.GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE &&
+       !g_settings.GetMasterProfile().getLockCode().IsEmpty())
+    {
+       g_passwordManager.CheckStartUpLock();
+    }
 
-  // check if we should use the login screen
-  if (g_settings.UsingLoginScreen())
-    g_windowManager.ActivateWindow(WINDOW_LOGIN_SCREEN);
-  else
-  {
+    // check if we should use the login screen
+    if (g_settings.UsingLoginScreen())
+      g_windowManager.ActivateWindow(WINDOW_LOGIN_SCREEN);
+    else
+    {
 #ifdef HAS_JSONRPC
-    CJSONRPC::Initialize();
+      CJSONRPC::Initialize();
 #endif
-    ADDON::CAddonMgr::Get().StartServices(false);
-    g_windowManager.ActivateWindow(g_SkinInfo->GetFirstWindow());
-  }
+      ADDON::CAddonMgr::Get().StartServices(false);
+      g_windowManager.ActivateWindow(g_SkinInfo->GetFirstWindow());
+    }
 
   }
   else //No GUI Created

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -817,33 +817,10 @@ bool CApplication::CreateGUI()
     CLog::Log(LOGERROR, "The screen resolution requested is not valid, resetting to a valid mode");
     g_guiSettings.m_LookAndFeelResolution = RES_DESKTOP;
   }
-
-#ifdef TARGET_DARWIN_OSX
-  // force initial window creation to be windowed, if fullscreen, it will switch to it below
-  // fixes the white screen of death if starting fullscreen and switching to windowed.
-  bool bFullScreen = false;
-  if (!g_Windowing.CreateNewWindow("XBMC", bFullScreen, g_settings.m_ResInfo[RES_WINDOW], OnEvent))
+  if (!InitWindow())
   {
-    CLog::Log(LOGFATAL, "CApplication::Create: Unable to create window");
     return false;
   }
-#else
-  bool bFullScreen = g_guiSettings.m_LookAndFeelResolution != RES_WINDOW;
-  if (!g_Windowing.CreateNewWindow("XBMC", bFullScreen, g_settings.m_ResInfo[g_guiSettings.m_LookAndFeelResolution], OnEvent))
-  {
-    CLog::Log(LOGFATAL, "CApplication::Create: Unable to create window");
-    return false;
-  }
-#endif
-
-  if (!g_Windowing.InitRenderSystem())
-  {
-    CLog::Log(LOGFATAL, "CApplication::Create: Unable to init rendering system");
-    return false;
-  }
-
-  // set GUI res and force the clear of the screen
-  g_graphicsContext.SetVideoResolution(g_guiSettings.m_LookAndFeelResolution);
 
   if (g_advancedSettings.m_splashImage)
   {
@@ -874,6 +851,42 @@ bool CApplication::CreateGUI()
   g_windowManager.Initialize();
 
   return true;
+}
+
+bool CApplication::InitWindow()
+{
+#ifdef TARGET_DARWIN_OSX
+  // force initial window creation to be windowed, if fullscreen, it will switch to it below
+  // fixes the white screen of death if starting fullscreen and switching to windowed.
+  bool bFullScreen = false;
+  if (!g_Windowing.CreateNewWindow("XBMC", bFullScreen, g_settings.m_ResInfo[RES_WINDOW], OnEvent))
+  {
+    CLog::Log(LOGFATAL, "CApplication::Create: Unable to create window");
+    return false;
+  }
+#else
+  bool bFullScreen = g_guiSettings.m_LookAndFeelResolution != RES_WINDOW;
+  if (!g_Windowing.CreateNewWindow("XBMC", bFullScreen, g_settings.m_ResInfo[g_guiSettings.m_LookAndFeelResolution], OnEvent))
+  {
+    CLog::Log(LOGFATAL, "CApplication::Create: Unable to create window");
+    return false;
+  }
+#endif
+
+  if (!g_Windowing.InitRenderSystem())
+  {
+    CLog::Log(LOGFATAL, "CApplication::Create: Unable to init rendering system");
+    return false;
+  }
+  // set GUI res and force the clear of the screen
+  g_graphicsContext.SetVideoResolution(g_guiSettings.m_LookAndFeelResolution);
+  return true;
+}
+
+bool CApplication::DestroyWindow()
+{
+  g_Windowing.DestroyRenderSystem();
+  return g_Windowing.DestroyWindow();
 }
 
 bool CApplication::InitDirectoriesLinux()

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -1153,6 +1153,8 @@ bool CApplication::Initialize()
 
   // Init DPMS, before creating the corresponding setting control.
   m_dpms = new DPMSSupport();
+  if (g_windowManager.Initialized())
+  {
   g_guiSettings.GetSetting("powermanagement.displaysoff")->SetVisible(m_dpms->IsSupported());
 
   g_windowManager.Add(new CGUIWindowHome);                     // window id = 0
@@ -1282,6 +1284,15 @@ bool CApplication::Initialize()
 #endif
     ADDON::CAddonMgr::Get().StartServices(false);
     g_windowManager.ActivateWindow(g_SkinInfo->GetFirstWindow());
+  }
+
+  }
+  else //No GUI Created
+  {
+#ifdef HAS_JSONRPC
+    CJSONRPC::Initialize();
+#endif
+    ADDON::CAddonMgr::Get().StartServices(false);
   }
 
   g_sysinfo.Refresh();

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -2732,7 +2732,7 @@ void CApplication::UpdateLCD()
 #endif
 }
 
-void CApplication::FrameMove(bool processEvents)
+void CApplication::FrameMove(bool processEvents, bool processGUI)
 {
   MEASURE_FUNCTION;
 
@@ -2744,6 +2744,8 @@ void CApplication::FrameMove(bool processEvents)
     // never set a frametime less than 2 fps to avoid problems when debuggin and on breaks
     if( frameTime > 0.5 ) frameTime = 0.5;
 
+    if (processGUI)
+    {
     g_graphicsContext.Lock();
     // check if there are notifications to display
     CGUIDialogKaiToast *toast = (CGUIDialogKaiToast *)g_windowManager.GetWindow(WINDOW_DIALOG_KAI_TOAST);
@@ -2755,6 +2757,8 @@ void CApplication::FrameMove(bool processEvents)
       }
     }
     g_graphicsContext.Unlock();
+    CWinEvents::MessagePump();
+    }
 
     UpdateLCD();
 
@@ -2764,18 +2768,21 @@ void CApplication::FrameMove(bool processEvents)
 #endif
 
     // process input actions
-    CWinEvents::MessagePump();
     ProcessHTTPApiButtons();
     ProcessJsonRpcButtons();
     ProcessRemote(frameTime);
     ProcessGamepad(frameTime);
     ProcessEventServer(frameTime);
     ProcessPeripherals(frameTime);
-    m_pInertialScrollingHandler->ProcessInertialScroll(frameTime);
+    if (processGUI)
+      m_pInertialScrollingHandler->ProcessInertialScroll(frameTime);
   }
+  if (processGUI)
+  {
   if (!m_bStop)
     g_windowManager.Process(CTimeUtils::GetFrameTime());
   g_windowManager.FrameMove();
+  }
 }
 
 bool CApplication::ProcessGamepad(float frameTime)

--- a/xbmc/Application.h
+++ b/xbmc/Application.h
@@ -118,6 +118,7 @@ public:
   virtual bool Create();
   virtual bool Cleanup();
 
+  bool CreateGUI();
   void StartServices();
   void StopServices();
   bool StartWebServer();

--- a/xbmc/Application.h
+++ b/xbmc/Application.h
@@ -119,6 +119,8 @@ public:
   virtual bool Cleanup();
 
   bool CreateGUI();
+  bool InitWindow();
+  bool DestroyWindow();
   void StartServices();
   void StopServices();
   bool StartWebServer();

--- a/xbmc/Application.h
+++ b/xbmc/Application.h
@@ -111,7 +111,7 @@ public:
   CApplication(void);
   virtual ~CApplication(void);
   virtual bool Initialize();
-  virtual void FrameMove(bool processEvents);
+  virtual void FrameMove(bool processEvents, bool processGUI = true);
   virtual void Render();
   virtual bool RenderNoPresent();
   virtual void Preflight();

--- a/xbmc/Makefile.in
+++ b/xbmc/Makefile.in
@@ -37,6 +37,10 @@ SRCS=Application.cpp \
 
 LIB=xbmc.a
 
+ifneq (@USE_LIBXBMC@,1)
+SRCS += main.cpp
+endif
+
 DISTCLEAN_FILES=DllPaths_generated.h
 
 include @abs_top_srcdir@/Makefile.include

--- a/xbmc/XBApplicationEx.cpp
+++ b/xbmc/XBApplicationEx.cpp
@@ -68,7 +68,7 @@ VOID CXBApplicationEx::Destroy()
 }
 
 /* Function that runs the application */
-INT CXBApplicationEx::Run()
+INT CXBApplicationEx::Run(bool renderGUI)
 {
   CLog::Log(LOGNOTICE, "Running the application..." );
 
@@ -117,7 +117,7 @@ INT CXBApplicationEx::Run()
     try
     {
 #endif
-      if (!m_bStop) FrameMove(true);
+      if (!m_bStop) FrameMove(true, renderGUI);
       //reset exception count
       frameMoveExceptionCount = 0;
 
@@ -142,7 +142,7 @@ INT CXBApplicationEx::Run()
     try
     {
 #endif
-      if (!m_bStop) Render();
+      if (renderGUI && !m_bStop) Render();
       //reset exception count
       renderExceptionCount = 0;
 

--- a/xbmc/XBApplicationEx.cpp
+++ b/xbmc/XBApplicationEx.cpp
@@ -21,6 +21,7 @@
 #include "system.h"
 #include "XBApplicationEx.h"
 #include "utils/log.h"
+#include "threads/SystemClock.h"
 #ifdef HAS_PERFORMANCE_SAMPLE
 #include "utils/PerformanceSample.h"
 #else
@@ -75,6 +76,9 @@ INT CXBApplicationEx::Run(bool renderGUI)
   BYTE processExceptionCount = 0;
   BYTE frameMoveExceptionCount = 0;
   BYTE renderExceptionCount = 0;
+  unsigned int lastFrameTime = 0;
+  unsigned int frameTime = 0;
+  const unsigned int noRenderFrameTime = 15;  // Simulates ~66fps
 
 #ifndef _DEBUG
   const BYTE MAX_EXCEPTION_COUNT = 10;
@@ -93,6 +97,7 @@ INT CXBApplicationEx::Run(bool renderGUI)
     try
     {
 #endif
+      lastFrameTime = XbmcThreads::SystemClockMillis();
       Process();
       //reset exception count
       processExceptionCount = 0;
@@ -143,6 +148,13 @@ INT CXBApplicationEx::Run(bool renderGUI)
     {
 #endif
       if (renderGUI && !m_bStop) Render();
+      else if (!renderGUI)
+      {
+        frameTime = XbmcThreads::SystemClockMillis() - lastFrameTime;
+        if(frameTime < noRenderFrameTime)
+          Sleep(noRenderFrameTime - frameTime);
+      }
+
       //reset exception count
       renderExceptionCount = 0;
 

--- a/xbmc/XBApplicationEx.h
+++ b/xbmc/XBApplicationEx.h
@@ -50,7 +50,7 @@ public:
 public:
   // Functions to create, run, and clean up the application
   virtual bool Create();
-  INT Run();
+  INT Run(bool renderGUI = true);
   VOID Destroy();
 
 private:

--- a/xbmc/guilib/IWindowManagerCallback.h
+++ b/xbmc/guilib/IWindowManagerCallback.h
@@ -36,7 +36,7 @@ public:
   IWindowManagerCallback(void);
   virtual ~IWindowManagerCallback(void);
 
-  virtual void FrameMove(bool processEvents) = 0;
+  virtual void FrameMove(bool processEvents, bool processGUI = true) = 0;
   virtual void Render() = 0;
   virtual void Process() = 0;
 };

--- a/xbmc/main.cpp
+++ b/xbmc/main.cpp
@@ -1,0 +1,86 @@
+/*
+ *      Copyright (C) 2005-2008 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
+
+#include "system.h"
+#include "settings/AppParamParser.h"
+#include "settings/AdvancedSettings.h"
+#include "FileItem.h"
+#include "Application.h"
+#include "PlayListPlayer.h"
+#include "utils/log.h"
+#include "xbmc.h"
+#ifdef _LINUX
+#include <sys/resource.h>
+#include <signal.h>
+#endif
+#if defined(TARGET_DARWIN_OSX)
+  #include "Util.h"
+  // SDL redefines main as SDL_main 
+  #ifdef HAS_SDL
+    #include <SDL/SDL.h>
+  #endif
+#endif
+#ifdef HAS_LIRC
+#include "input/linux/LIRC.h"
+#endif
+#include "XbmcContext.h"
+
+int main(int argc, char* argv[])
+{
+  // set up some xbmc specific relationships
+  XBMC::Context context;
+
+  bool renderGUI = true;
+  //this can't be set from CAdvancedSettings::Initialize() because it will overwrite
+  //the loglevel set with the --debug flag
+#ifdef _DEBUG
+  g_advancedSettings.m_logLevel     = LOG_LEVEL_DEBUG;
+  g_advancedSettings.m_logLevelHint = LOG_LEVEL_DEBUG;
+#else
+  g_advancedSettings.m_logLevel     = LOG_LEVEL_NORMAL;
+  g_advancedSettings.m_logLevelHint = LOG_LEVEL_NORMAL;
+#endif
+  CLog::SetLogLevel(g_advancedSettings.m_logLevel);
+
+#ifdef _LINUX
+#if defined(DEBUG)
+  struct rlimit rlim;
+  rlim.rlim_cur = rlim.rlim_max = RLIM_INFINITY;
+  if (setrlimit(RLIMIT_CORE, &rlim) == -1)
+    CLog::Log(LOGDEBUG, "Failed to set core size limit (%s)", strerror(errno));
+#endif
+  // Prevent child processes from becoming zombies on exit if not waited upon. See also Util::Command
+  struct sigaction sa;
+  memset(&sa, 0, sizeof(sa));
+
+  sa.sa_flags = SA_NOCLDWAIT;
+  sa.sa_handler = SIG_IGN;
+  sigaction(SIGCHLD, &sa, NULL);
+#endif
+  setlocale(LC_NUMERIC, "C");
+  g_advancedSettings.Initialize();
+
+#ifndef _WIN32
+  CAppParamParser appParamParser;
+  appParamParser.Parse((const char **)argv, argc);
+#endif
+  return XBMC_Run(renderGUI);
+}

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -41,6 +41,7 @@ using namespace XFILE;
 
 CAdvancedSettings::CAdvancedSettings()
 {
+  m_initialized = false;
 }
 
 void CAdvancedSettings::Initialize()
@@ -296,6 +297,7 @@ void CAdvancedSettings::Initialize()
   m_logEnableAirtunes = false;
   m_airTunesPort = 36666;
   m_airPlayPort = 36667;
+  m_initialized = true;
 }
 
 bool CAdvancedSettings::Load()

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -80,6 +80,7 @@ class CAdvancedSettings
     static CAdvancedSettings* getInstance();
 
     void Initialize();
+    bool Initialized() { return m_initialized; };
     void AddSettingsFile(const CStdString &filename);
     bool Load();
     void Clear();
@@ -326,6 +327,7 @@ class CAdvancedSettings
     void ParseSettingsFile(const CStdString &file);
 
     float GetDisplayLatency(float refreshrate);
+    bool m_initialized;
 };
 
 XBMC_GLOBAL(CAdvancedSettings,g_advancedSettings);

--- a/xbmc/win32/XBMC_PC.cpp
+++ b/xbmc/win32/XBMC_PC.cpp
@@ -199,7 +199,23 @@ INT WINAPI WinMain( HINSTANCE hInst, HINSTANCE, LPSTR commandLine, INT )
   SetErrorMode(SEM_FAILCRITICALERRORS|SEM_NOOPENFILEERRORBOX);
 #endif
 
-  g_application.Run();
+  if (!g_application.CreateGUI())
+  {
+    CStdString errorMsg;
+    errorMsg.Format("CApplication::CreateGUI() failed - Check log file for display errors");
+    MessageBox(NULL, errorMsg.c_str(), "XBMC: Error", MB_OK|MB_ICONERROR);
+    return 0;
+  }
+
+  if (!g_application.Initialize())
+  {
+    CStdString errorMsg;
+    errorMsg.Format("CApplication::Initialize() failed - Check log file and that it is writable");
+    MessageBox(NULL, errorMsg.c_str(), "XBMC: Error", MB_OK|MB_ICONERROR);
+    return 0;
+  }
+
+  g_application.Run(true);
   
   // put everything in CApplication::Cleanup() since this point is never reached
 

--- a/xbmc/xbmc.cpp
+++ b/xbmc/xbmc.cpp
@@ -95,6 +95,16 @@ int main(int argc, char* argv[])
     fprintf(stderr, "ERROR: Unable to create application. Exiting\n");
     return status;
   }
+  if (!g_application.CreateGUI())
+  {
+    fprintf(stderr, "ERROR: Unable to create GUI. Exiting\n");
+    return status;
+  }
+  if (!g_application.Initialize())
+  {
+    fprintf(stderr, "ERROR: Unable to Initialize. Exiting\n");
+    return status;
+  }
 
   try
   {

--- a/xbmc/xbmc.cpp
+++ b/xbmc/xbmc.cpp
@@ -90,7 +90,6 @@ int main(int argc, char* argv[])
   CAppParamParser appParamParser;
   appParamParser.Parse((const char **)argv, argc);
 #endif
-  g_application.Preflight();
   if (!g_application.Create())
   {
     fprintf(stderr, "ERROR: Unable to create application. Exiting\n");

--- a/xbmc/xbmc.cpp
+++ b/xbmc/xbmc.cpp
@@ -19,77 +19,15 @@
  *
  */
 
-
-// XBMC
-//
-// libraries:
-//   - CDRipX   : doesnt support section loading yet
-//   - xbfilezilla : doesnt support section loading yet
-//
-
-#include "system.h"
-#include "settings/AppParamParser.h"
-#include "settings/AdvancedSettings.h"
-#include "FileItem.h"
 #include "Application.h"
-#include "PlayListPlayer.h"
-#include "utils/log.h"
-#ifdef _LINUX
-#include <sys/resource.h>
-#include <signal.h>
-#endif
-#if defined(TARGET_DARWIN_OSX)
-  #include "Util.h"
-  // SDL redefines main as SDL_main 
-  #ifdef HAS_SDL
-    #include <SDL/SDL.h>
-  #endif
-#endif
-#ifdef HAS_LIRC
-#include "input/linux/LIRC.h"
-#endif
-#include "XbmcContext.h"
-
-int main(int argc, char* argv[])
+#include "settings/AdvancedSettings.h"
+extern "C" int XBMC_Run(bool renderGUI)
 {
-  // set up some xbmc specific relationships
-  XBMC::Context context;
-
   int status = -1;
-  bool renderGUI = true;
-  //this can't be set from CAdvancedSettings::Initialize() because it will overwrite
-  //the loglevel set with the --debug flag
-#ifdef _DEBUG
-  g_advancedSettings.m_logLevel     = LOG_LEVEL_DEBUG;
-  g_advancedSettings.m_logLevelHint = LOG_LEVEL_DEBUG;
-#else
-  g_advancedSettings.m_logLevel     = LOG_LEVEL_NORMAL;
-  g_advancedSettings.m_logLevelHint = LOG_LEVEL_NORMAL;
-#endif
-  CLog::SetLogLevel(g_advancedSettings.m_logLevel);
 
-#ifdef _LINUX
-#if defined(DEBUG)
-  struct rlimit rlim;
-  rlim.rlim_cur = rlim.rlim_max = RLIM_INFINITY;
-  if (setrlimit(RLIMIT_CORE, &rlim) == -1)
-    CLog::Log(LOGDEBUG, "Failed to set core size limit (%s)", strerror(errno));
-#endif
-  // Prevent child processes from becoming zombies on exit if not waited upon. See also Util::Command
-  struct sigaction sa;
-  memset(&sa, 0, sizeof(sa));
+  if (!g_advancedSettings.Initialized())
+    g_advancedSettings.Initialize();
 
-  sa.sa_flags = SA_NOCLDWAIT;
-  sa.sa_handler = SIG_IGN;
-  sigaction(SIGCHLD, &sa, NULL);
-#endif
-  setlocale(LC_NUMERIC, "C");
-  g_advancedSettings.Initialize();
-  
-#ifndef _WIN32
-  CAppParamParser appParamParser;
-  appParamParser.Parse((const char **)argv, argc);
-#endif
   if (!g_application.Create())
   {
     fprintf(stderr, "ERROR: Unable to create application. Exiting\n");

--- a/xbmc/xbmc.cpp
+++ b/xbmc/xbmc.cpp
@@ -56,6 +56,7 @@ int main(int argc, char* argv[])
   XBMC::Context context;
 
   int status = -1;
+  bool renderGUI = true;
   //this can't be set from CAdvancedSettings::Initialize() because it will overwrite
   //the loglevel set with the --debug flag
 #ifdef _DEBUG
@@ -95,7 +96,7 @@ int main(int argc, char* argv[])
     fprintf(stderr, "ERROR: Unable to create application. Exiting\n");
     return status;
   }
-  if (!g_application.CreateGUI())
+  if (renderGUI && !g_application.CreateGUI())
   {
     fprintf(stderr, "ERROR: Unable to create GUI. Exiting\n");
     return status;
@@ -108,7 +109,7 @@ int main(int argc, char* argv[])
 
   try
   {
-    status = g_application.Run();
+    status = g_application.Run(renderGUI);
   }
   catch(...)
   {

--- a/xbmc/xbmc.h
+++ b/xbmc/xbmc.h
@@ -1,0 +1,23 @@
+/*
+ *      Copyright (C) 2005-2012 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
+
+#pragma once
+extern "C" int XBMC_Run(bool renderGUI);
+


### PR DESCRIPTION
This is a continuation of https://github.com/xbmc/xbmc/pull/890

This PR is purely foundational. No new behavior is introduced here, except for the ability to build a libxbmc.so in linux/osx, but the lib isn't good for much in its current form.

I'm submitting this now because I have several things up that depend on it. Because it's a nightmare to rebase, it would be a big help to get this part in, and continue contributing to it after that.

There are 2 primary things going on here:
1. Building as a shared lib. Gives us the ability to do unit testing with all of xbmc's features at our disposal. Also allows for stand-alone programs to use our functionality, eg. scrapers. Eventually we may want to come up with an API that allows for individual services to be started up.
2. Refactor startup to allow us to run without a window. When combined with #1, this could lead to headless, lightweight xbmc instances. There is still lots of work that remains here. Many functions still rely on a window to exist, so it's quite crash-heavy. As a result, I didn't hook up any way to run this way.

@davilla This likely needs some osx love. For OSX I made an attempt at the link-line, but I'm unfamiliar with the syntax there.

@wiso For win32 I didn't attempt any of the shared lib stuff, only fixed up the startup sequence to match current behavior. I have no way to test, but I think it should be ok.
