### PR TITLE
Advancedsettings.xml for dateAdded

### DIFF
--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -217,6 +217,7 @@ void CAdvancedSettings::Initialize()
   m_bVideoLibraryExportAutoThumbs = false;
   m_bVideoLibraryImportWatchedState = false;
   m_bVideoLibraryImportResumePoint = false;
+  m_bVideoLibraryDateAdded = false;
   m_bVideoScannerIgnoreErrors = false;
 
   m_iTuxBoxStreamtsPort = 31339;
@@ -622,6 +623,7 @@ void CAdvancedSettings::ParseSettingsFile(const CStdString &file)
     XMLUtils::GetBoolean(pElement, "exportautothumbs", m_bVideoLibraryExportAutoThumbs);
     XMLUtils::GetBoolean(pElement, "importwatchedstate", m_bVideoLibraryImportWatchedState);
     XMLUtils::GetBoolean(pElement, "importresumepoint", m_bVideoLibraryImportResumePoint);
+    XMLUtils::GetBoolean(pElement, "dateadded", m_bVideoLibraryDateAdded);
   }
 
   pElement = pRootElement->FirstChildElement("videoscanner");

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -240,6 +240,7 @@ class CAdvancedSettings
     bool m_bVideoLibraryExportAutoThumbs;
     bool m_bVideoLibraryImportWatchedState;
     bool m_bVideoLibraryImportResumePoint;
+    bool m_bVideoLibraryDateAdded;
 
     bool m_bVideoScannerIgnoreErrors;
 

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -697,26 +697,29 @@ void CVideoDatabase::UpdateFileDateAdded(int idFile, const CStdString& strFileNa
       file = CStackDirectory::GetFirstStackedFile(strFileNameAndPath);
 
     CDateTime dateAdded;
-    // Let's try to get the modification datetime
-    struct __stat64 buffer;
-    if (CFile::Stat(file, &buffer) == 0)
-    {
-      time_t now = time(NULL);
-      time_t addedTime = max((time_t)buffer.st_ctime, (time_t)buffer.st_mtime);
-      // if the newer of the two dates is in the future, we try it with the older one
-      if (addedTime > now)
-        addedTime = min((time_t)buffer.st_ctime, (time_t)buffer.st_mtime);
 
-      // make sure the datetime does is not in the future
-      if (addedTime <= now)
+    if (!g_advancedSettings.m_bVideoLibraryDateAdded)
+  	{
+      // Let's try to get the modification datetime
+      struct __stat64 buffer;
+      if (CFile::Stat(file, &buffer) == 0)
       {
-        struct tm *time = localtime(&addedTime);
-        if (time)
-          dateAdded = *time;
-      }
-    }
+        time_t now = time(NULL);
+        time_t addedTime = max((time_t)buffer.st_ctime, (time_t)buffer.st_mtime);
+        // if the newer of the two dates is in the future, we try it with the older one
+        if (addedTime > now)
+          addedTime = min((time_t)buffer.st_ctime, (time_t)buffer.st_mtime);
 
-    if (!dateAdded.IsValid())
+        // make sure the datetime does is not in the future
+        if (addedTime <= now)
+        {
+          struct tm *time = localtime(&addedTime);
+          if (time)
+            dateAdded = *time;
+        }
+      }
+	}
+	  else
       dateAdded = CDateTime::GetCurrentDateTime();
 
     strSQL = PrepareSQL("update files set dateAdded='%s' where idFile=%d", dateAdded.GetAsDBDateTime().c_str(), idFile);
@@ -1103,22 +1106,25 @@ int CVideoDatabase::AddTvShow(const CStdString& strPath)
     m_pDS->exec(strSQL.c_str());
     int idTvShow = (int)m_pDS->lastinsertid();
 
-    // Get the creation datetime of the tvshow directory
     CDateTime dateAdded;
-    struct __stat64 buffer;
-    if (XFILE::CFile::Stat(strPath, &buffer) == 0)
-    {
-      time_t now = time(NULL);
-      // Make sure we have a valid date (i.e. not in the future)
-      if ((time_t)buffer.st_ctime <= now)
-      {
-        struct tm *time = localtime((const time_t*)&buffer.st_ctime);
-        if (time)
-          dateAdded = *time;
-      }
-    }
 
-    if (!dateAdded.IsValid())
+    if (!g_advancedSettings.m_bVideoLibraryDateAdded)
+  	{
+	  // Get the creation datetime of the tvshow directory
+      struct __stat64 buffer;
+      if (XFILE::CFile::Stat(strPath, &buffer) == 0)
+      {
+        time_t now = time(NULL);
+        // Make sure we have a valid date (i.e. not in the future)
+        if ((time_t)buffer.st_ctime <= now)
+        {
+          struct tm *time = localtime((const time_t*)&buffer.st_ctime);
+          if (time)
+            dateAdded = *time;
+        }
+      }
+	  }
+  	else
       dateAdded = CDateTime::GetCurrentDateTime();
 
     int idPath = AddPath(strPath, dateAdded.GetAsDBDateTime());


### PR DESCRIPTION
I added a flag called 'dateadded' which is checked when a Video or TV Show is added to the database. If set to true in the advancedsettings.xml file, XBMC will use the current date/time when inserting to the database for 'dateAdded'. If set to false (default), XBMC will attempt to use the modified date of the file. If it cannot use the modified date then the current date/time is used.
