### PR TITLE
extend xbmc.Monitor with onAbortRequested()

### DIFF
--- a/xbmc/interfaces/python/XBPyThread.cpp
+++ b/xbmc/interfaces/python/XBPyThread.cpp
@@ -344,6 +344,9 @@ void XBPyThread::Process()
     Py_XDECREF(pystring);
   }
 
+  //tell xbmc.Monitor to call onAbortRequested()    
+  g_pythonParser.OnAbortRequested();
+
   PyObject *m = PyImport_AddModule((char*)"xbmc");
   if(!m || PyObject_SetAttrString(m, (char*)"abortRequested", PyBool_FromLong(1)))
     CLog::Log(LOGERROR, "Scriptresult: failed to set abortRequested");
@@ -429,6 +432,9 @@ void XBPyThread::stop()
   {
     PyEval_AcquireLock();
     PyThreadState* old = PyThreadState_Swap((PyThreadState*)m_threadState);
+
+    //tell xbmc.Monitor to call onAbortRequested()
+    g_pythonParser.OnAbortRequested();
 
     PyObject *m;
     m = PyImport_AddModule((char*)"xbmc");

--- a/xbmc/interfaces/python/XBPython.cpp
+++ b/xbmc/interfaces/python/XBPython.cpp
@@ -336,6 +336,20 @@ void XBPython::OnDatabaseUpdated(const std::string &database)
  }  
 } 
 
+void XBPython::OnAbortRequested()
+{
+  CSingleLock lock(m_critSection);
+  if (m_bInitialized)
+  {
+    MonitorCallbackList::iterator it = m_vecMonitorCallbackList.begin();
+    while (it != m_vecMonitorCallbackList.end())
+    {
+      ((CPythonMonitor*)(*it))->OnAbortRequested();
+      it++;
+    }
+  }  
+} 
+
 /**
 * Check for file and print an error if needed
 */

--- a/xbmc/interfaces/python/XBPython.cpp
+++ b/xbmc/interfaces/python/XBPython.cpp
@@ -336,7 +336,7 @@ void XBPython::OnDatabaseUpdated(const std::string &database)
  }  
 } 
 
-void XBPython::OnAbortRequested()
+void XBPython::OnAbortRequested(const CStdString &ID)
 {
   CSingleLock lock(m_critSection);
   if (m_bInitialized)
@@ -344,7 +344,15 @@ void XBPython::OnAbortRequested()
     MonitorCallbackList::iterator it = m_vecMonitorCallbackList.begin();
     while (it != m_vecMonitorCallbackList.end())
     {
-      ((CPythonMonitor*)(*it))->OnAbortRequested();
+      if (ID.IsEmpty())
+      {    
+        ((CPythonMonitor*)(*it))->OnAbortRequested();
+      }
+      else
+      {
+        if (((CPythonMonitor*)(*it))->Id == ID)
+          ((CPythonMonitor*)(*it))->OnAbortRequested();
+      }
       it++;
     }
   }  

--- a/xbmc/interfaces/python/XBPython.h
+++ b/xbmc/interfaces/python/XBPython.h
@@ -70,7 +70,7 @@ public:
   void OnScreensaverActivated();
   void OnScreensaverDeactivated();
   void OnDatabaseUpdated(const std::string &database);
-  void OnAbortRequested();
+  void OnAbortRequested(const CStdString &ID="");
   void Initialize();
   void Finalize();
   void FinalizeScript();

--- a/xbmc/interfaces/python/XBPython.h
+++ b/xbmc/interfaces/python/XBPython.h
@@ -70,6 +70,7 @@ public:
   void OnScreensaverActivated();
   void OnScreensaverDeactivated();
   void OnDatabaseUpdated(const std::string &database);
+  void OnAbortRequested();
   void Initialize();
   void Finalize();
   void FinalizeScript();

--- a/xbmc/interfaces/python/xbmcmodule/PythonMonitor.cpp
+++ b/xbmc/interfaces/python/xbmcmodule/PythonMonitor.cpp
@@ -123,6 +123,12 @@ void CPythonMonitor::OnDatabaseUpdated(const std::string &database)
  g_pythonParser.PulseGlobalEvent();
 }
 
+void CPythonMonitor::OnAbortRequested()
+{
+  PyXBMC_AddPendingCall(m_state, SPyMonitor_Function, new SPyMonitor(this, "onAbortRequested"));
+  g_pythonParser.PulseGlobalEvent();
+}
+
 void CPythonMonitor::SetCallback(PyThreadState *state, PyObject *object)
 {
   /* python lock should be held */

--- a/xbmc/interfaces/python/xbmcmodule/PythonMonitor.h
+++ b/xbmc/interfaces/python/xbmcmodule/PythonMonitor.h
@@ -38,6 +38,7 @@ public:
   void    OnScreensaverActivated();
   void    OnScreensaverDeactivated();
   void    OnDatabaseUpdated(const std::string &database);
+  void    OnAbortRequested();
   
   void    Acquire();
   void    Release();

--- a/xbmc/interfaces/python/xbmcmodule/monitor.cpp
+++ b/xbmc/interfaces/python/xbmcmodule/monitor.cpp
@@ -114,11 +114,24 @@ namespace PYXBMC
    return Py_None;
   }  
  
+  // Monitor_onAbortRequested
+  PyDoc_STRVAR(onAbortRequested__doc__,
+               "onAbortRequested() -- onAbortRequested method.\n"
+               "\n"
+               "Will be called when XBMC requests Abort");
+
+  PyObject* Monitor_OnAbortRequested(PyObject *self, PyObject *args)
+  {
+    Py_INCREF(Py_None);
+    return Py_None;
+  }     
+    
   PyMethodDef Monitor_methods[] = {
     {(char*)"onSettingsChanged", (PyCFunction)Monitor_OnSettingsChanged, METH_VARARGS, onSettingsChanged__doc__},
     {(char*)"onScreensaverActivated", (PyCFunction)Monitor_OnScreensaverActivated, METH_VARARGS, onScreensaverActivated__doc__},
     {(char*)"onScreensaverDeactivated", (PyCFunction)Monitor_OnScreensaverDeactivated, METH_VARARGS, onScreensaverDeactivated__doc__},
     {(char*)"onDatabaseUpdated", (PyCFunction)Monitor_OnDatabaseUpdated, METH_VARARGS  , onDatabaseUpdated__doc__},
+    {(char*)"onAbortRequested", (PyCFunction)Monitor_OnAbortRequested, METH_VARARGS  , onAbortRequested__doc__},
     {NULL, NULL, 0, NULL}
   };
 


### PR DESCRIPTION
it will be called by XBMC before shutting down.

aim is to replace xbmc.abortRequested  and have xbmc.Monitor notify the script once XBMC wants us to shutdown instead of checking for xbmc.abortRequested in a while loop.

xbmc.abortRequested is still in but if we are doing API bump and are braking addons in future, it might be a good idea to remove it.

Cheers,
amet
