### PR TITLE
[AE] changed wrapp AE calls into the factory

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -706,8 +706,8 @@ bool CApplication::Create()
 
   // restore AE's previous volume state
   SetHardwareVolume(g_settings.m_fVolumeLevel);
-  CAEFactory::AE->SetMute     (g_settings.m_bMute);
-  CAEFactory::AE->SetSoundMode(g_guiSettings.GetInt("audiooutput.guisoundmode"));
+  CAEFactory::SetMute     (g_settings.m_bMute);
+  CAEFactory::SetSoundMode(g_guiSettings.GetInt("audiooutput.guisoundmode"));
 
   // start-up Addons Framework
   // currently bails out if either cpluff Dll is unavailable or system dir can not be scanned
@@ -3496,7 +3496,7 @@ void CApplication::Stop(int exitCode)
     g_Windowing.DestroyWindowSystem();
 
     // shutdown the AudioEngine
-    CAEFactory::AE->Shutdown();
+    CAEFactory::Shutdown();
 
     CLog::Log(LOGNOTICE, "stopped");
   }
@@ -5066,7 +5066,7 @@ void CApplication::ProcessSlow()
   if (!IsPlayingVideo())
     CAddonInstaller::Get().UpdateRepos();
 
-  CAEFactory::AE->GarbageCollect();
+  CAEFactory::GarbageCollect();
 }
 
 // Global Idle Time in Seconds
@@ -5168,7 +5168,7 @@ bool CApplication::IsMuted() const
 {
   if (g_peripherals.IsMuted())
     return true;
-  return CAEFactory::AE->IsMuted();
+  return CAEFactory::IsMuted();
 }
 
 void CApplication::ToggleMute(void)
@@ -5184,7 +5184,7 @@ void CApplication::Mute()
   if (g_peripherals.Mute())
     return;
 
-  CAEFactory::AE->SetMute(true);
+  CAEFactory::SetMute(true);
   g_settings.m_bMute = true;
 }
 
@@ -5193,7 +5193,7 @@ void CApplication::UnMute()
   if (g_peripherals.UnMute())
     return;
 
-  CAEFactory::AE->SetMute(false);
+  CAEFactory::SetMute(false);
   g_settings.m_bMute = false;
 }
 
@@ -5226,7 +5226,7 @@ void CApplication::SetHardwareVolume(float hardwareVolume)
   if (value >= 0.99f)
     value = 1.0f;
 
-  CAEFactory::AE->SetVolume(value);
+  CAEFactory::SetVolume(value);
 }
 
 int CApplication::GetVolume() const

--- a/xbmc/cores/AudioEngine/AEFactory.cpp
+++ b/xbmc/cores/AudioEngine/AEFactory.cpp
@@ -36,6 +36,11 @@ IAE* CAEFactory::AE = NULL;
 static float  g_fVolume = 1.0f;
 static bool   g_bMute = false;
 
+IAE *CAEFactory::GetEngine()
+{
+  return AE;
+}
+
 bool CAEFactory::LoadEngine()
 {
   bool loaded = false;

--- a/xbmc/cores/AudioEngine/AEFactory.cpp
+++ b/xbmc/cores/AudioEngine/AEFactory.cpp
@@ -33,6 +33,8 @@
 #endif
 
 IAE* CAEFactory::AE = NULL;
+static float  g_fVolume = 1.0f;
+static bool   g_bMute = false;
 
 bool CAEFactory::LoadEngine()
 {
@@ -96,8 +98,22 @@ bool CAEFactory::LoadEngine(enum AEEngine engine)
   return AE != NULL;
 }
 
+void CAEFactory::UnLoadEngine()
+{
+  if(AE)
+  {
+    AE->Shutdown();
+    delete AE;
+    AE = NULL;
+  }
+}
+
 bool CAEFactory::StartEngine()
 {
+#if defined(TARGET_RASPBERRY_PI)
+  return true;
+#endif
+
   if (!AE)
     return false;
 
@@ -107,4 +123,114 @@ bool CAEFactory::StartEngine()
   delete AE;
   AE = NULL;
   return false;
+}
+
+/* engine wrapping */
+IAESound *CAEFactory::MakeSound(const std::string &file)
+{
+  if(AE)
+    return AE->MakeSound(file);
+  
+  return NULL;
+}
+
+void CAEFactory::FreeSound(IAESound *sound)
+{
+  if(AE)
+    AE->FreeSound(sound);
+}
+
+void CAEFactory::SetSoundMode(const int mode)
+{
+  if(AE)
+    AE->SetSoundMode(mode);
+}
+
+void CAEFactory::OnSettingsChange(std::string setting)
+{
+  if(AE)
+    AE->OnSettingsChange(setting);
+}
+
+void CAEFactory::EnumerateOutputDevices(AEDeviceList &devices, bool passthrough)
+{
+  if(AE)
+    AE->EnumerateOutputDevices(devices, passthrough);
+}
+
+std::string CAEFactory::GetDefaultDevice(bool passthrough)
+{
+  if(AE)
+    return AE->GetDefaultDevice(passthrough);
+
+  return "default";
+}
+
+bool CAEFactory::SupportsRaw()
+{
+  if(AE)
+    return AE->SupportsRaw();
+
+  return false;
+}
+
+void CAEFactory::SetMute(const bool enabled)
+{
+  if(AE)
+    AE->SetMute(enabled);
+
+  g_bMute = enabled;
+}
+
+bool CAEFactory::IsMuted()
+{
+  if(AE)
+    return AE->IsMuted();
+
+  return g_bMute || (g_fVolume == 0.0f);
+}
+
+float CAEFactory::GetVolume()
+{
+  if(AE)
+    return AE->GetVolume();
+
+  return g_fVolume;
+}
+
+void CAEFactory::SetVolume(const float volume)
+{
+  if(AE)
+    AE->SetVolume(volume);
+  else
+    g_fVolume = volume;
+}
+
+void CAEFactory::Shutdown()
+{
+  if(AE)
+    AE->Shutdown();
+}
+
+IAEStream *CAEFactory::MakeStream(enum AEDataFormat dataFormat, unsigned int sampleRate, 
+  unsigned int encodedSampleRate, CAEChannelInfo channelLayout, unsigned int options)
+{
+  if(AE)
+    return AE->MakeStream(dataFormat, sampleRate, encodedSampleRate, channelLayout, options);
+
+  return NULL;
+}
+
+IAEStream *CAEFactory::FreeStream(IAEStream *stream)
+{
+  if(AE)
+    return AE->FreeStream(stream);
+
+  return NULL;
+}
+
+void CAEFactory::GarbageCollect()
+{
+  if(AE)
+    AE->GarbageCollect();
 }

--- a/xbmc/cores/AudioEngine/AEFactory.h
+++ b/xbmc/cores/AudioEngine/AEFactory.h
@@ -37,7 +37,25 @@ class CAEFactory
 public:
   static IAE *AE;
   static bool LoadEngine();
+  static void UnLoadEngine();
   static bool StartEngine();
+  /* wrapp engine interface */
+  static IAESound *MakeSound(const std::string &file);
+  static void FreeSound(IAESound *sound);
+  static void SetSoundMode(const int mode);
+  static void OnSettingsChange(std::string setting);
+  static void EnumerateOutputDevices(AEDeviceList &devices, bool passthrough);
+  static std::string GetDefaultDevice(bool passthrough);
+  static bool SupportsRaw();
+  static void SetMute(const bool enabled);
+  static bool IsMuted();
+  static float GetVolume();
+  static void SetVolume(const float volume);
+  static void Shutdown();
+  static IAEStream *MakeStream(enum AEDataFormat dataFormat, unsigned int sampleRate, 
+    unsigned int encodedSampleRate, CAEChannelInfo channelLayout, unsigned int options = 0);
+  static IAEStream *FreeStream(IAEStream *stream);
+  static void GarbageCollect();
 private:
   static bool LoadEngine(enum AEEngine engine);
 };

--- a/xbmc/cores/AudioEngine/AEFactory.h
+++ b/xbmc/cores/AudioEngine/AEFactory.h
@@ -36,6 +36,7 @@ class CAEFactory
 {
 public:
   static IAE *AE;
+  static IAE *GetEngine();
   static bool LoadEngine();
   static void UnLoadEngine();
   static bool StartEngine();

--- a/xbmc/cores/AudioEngine/Engines/CoreAudio/CoreAudioAESound.cpp
+++ b/xbmc/cores/AudioEngine/Engines/CoreAudio/CoreAudioAESound.cpp
@@ -35,7 +35,7 @@
 #include "utils/EndianSwap.h"
 
 /* typecast AE to CCoreAudioAE */
-#define AE (*(CCoreAudioAE*)CAEFactory::AE)
+#define AE (*(CCoreAudioAE*)CAEFactory::GetEngine())
 
 CCoreAudioAESound::CCoreAudioAESound(const std::string &filename) :
   IAESound         (filename),

--- a/xbmc/cores/AudioEngine/Engines/CoreAudio/CoreAudioAEStream.cpp
+++ b/xbmc/cores/AudioEngine/Engines/CoreAudio/CoreAudioAEStream.cpp
@@ -36,7 +36,7 @@
 #include "MathUtils.h"
 
 // typecast AE to CCoreAudioAE
-#define AE (*(CCoreAudioAE*)CAEFactory::AE)
+#define AE (*(CCoreAudioAE*)CAEFactory::GetEngine())
 
 void CheckOutputBufferSize(void **buffer, int *oldSize, int newSize)
 {

--- a/xbmc/cores/AudioEngine/Engines/PulseAE/PulseAESound.cpp
+++ b/xbmc/cores/AudioEngine/Engines/PulseAE/PulseAESound.cpp
@@ -79,7 +79,7 @@ bool CPulseAESound::Initialize()
       return false;
   }
 
-  m_maxVolume     = CAEFactory::AE->GetVolume();
+  m_maxVolume     = CAEFactory::GetEngine()->GetVolume();
   m_volume        = 1.0f;
   pa_volume_t paVolume = pa_sw_volume_from_linear((double)(m_volume * m_maxVolume));
   pa_cvolume_set(&m_chVolume, m_sampleSpec.channels, paVolume);

--- a/xbmc/cores/AudioEngine/Engines/PulseAE/PulseAEStream.cpp
+++ b/xbmc/cores/AudioEngine/Engines/PulseAE/PulseAEStream.cpp
@@ -137,7 +137,7 @@ CPulseAEStream::CPulseAEStream(pa_context *context, pa_threaded_mainloop *mainLo
       default: break;
     }
 
-  m_MaxVolume     = CAEFactory::AE->GetVolume();
+  m_MaxVolume     = CAEFactory::GetEngine()->GetVolume();
   m_Volume        = 1.0f;
   pa_volume_t paVolume = pa_sw_volume_from_linear((double)(m_Volume * m_MaxVolume));
   pa_cvolume_set(&m_ChVolume, m_SampleSpec.channels, paVolume);

--- a/xbmc/cores/AudioEngine/Engines/SoftAE/SoftAESound.cpp
+++ b/xbmc/cores/AudioEngine/Engines/SoftAE/SoftAESound.cpp
@@ -36,7 +36,7 @@
 #include "SoftAESound.h"
 
 /* typecast AE to CSoftAE */
-#define AE (*((CSoftAE*)CAEFactory::AE))
+#define AE (*((CSoftAE*)CAEFactory::GetEngine()))
 
 typedef struct
 {

--- a/xbmc/cores/AudioEngine/Engines/SoftAE/SoftAEStream.cpp
+++ b/xbmc/cores/AudioEngine/Engines/SoftAE/SoftAEStream.cpp
@@ -31,7 +31,7 @@
 #include "SoftAEStream.h"
 
 /* typecast AE to CSoftAE */
-#define AE (*((CSoftAE*)CAEFactory::AE))
+#define AE (*((CSoftAE*)CAEFactory::GetEngine()))
 
 using namespace std;
 

--- a/xbmc/cores/dvdplayer/DVDAudio.cpp
+++ b/xbmc/cores/dvdplayer/DVDAudio.cpp
@@ -49,7 +49,7 @@ CDVDAudio::~CDVDAudio()
 {
   CSingleLock lock (m_critSection);
   if (m_pAudioStream)
-    CAEFactory::AE->FreeStream(m_pAudioStream);
+    CAEFactory::FreeStream(m_pAudioStream);
 
   free(m_pBuffer);
 }
@@ -69,7 +69,7 @@ bool CDVDAudio::Create(const DVDAudioFrame &audioframe, CodecID codec, bool need
   unsigned int options = needresampler && !audioframe.passthrough ? AESTREAM_FORCE_RESAMPLE : 0;
   options |= AESTREAM_AUTOSTART;
 
-  m_pAudioStream = CAEFactory::AE->MakeStream(
+  m_pAudioStream = CAEFactory::MakeStream(
     audioframe.data_format,
     audioframe.sample_rate,
     audioframe.encoded_sample_rate,
@@ -100,7 +100,7 @@ void CDVDAudio::Destroy()
   CSingleLock lock (m_critSection);
 
   if (m_pAudioStream)
-    CAEFactory::AE->FreeStream(m_pAudioStream);
+    CAEFactory::FreeStream(m_pAudioStream);
 
   free(m_pBuffer);
   m_pBuffer = NULL;

--- a/xbmc/cores/dvdplayer/DVDCodecs/Audio/DVDAudioCodecPassthrough.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Audio/DVDAudioCodecPassthrough.cpp
@@ -42,7 +42,7 @@ CDVDAudioCodecPassthrough::~CDVDAudioCodecPassthrough(void)
 bool CDVDAudioCodecPassthrough::Open(CDVDStreamInfo &hints, CDVDCodecOptions &options)
 {
   /* dont open if AE doesnt support RAW */
-  if (!CAEFactory::AE->SupportsRaw())
+  if (!CAEFactory::SupportsRaw())
     return false;
 
   bool bSupportsAC3Out    = false;

--- a/xbmc/cores/paplayer/PAPlayer.cpp
+++ b/xbmc/cores/paplayer/PAPlayer.cpp
@@ -187,7 +187,7 @@ void PAPlayer::CloseAllStreams(bool fade/* = true */)
       
       if (si->m_stream)
       {
-        CAEFactory::AE->FreeStream(si->m_stream);
+        CAEFactory::FreeStream(si->m_stream);
         si->m_stream = NULL;
       }
 
@@ -202,7 +202,7 @@ void PAPlayer::CloseAllStreams(bool fade/* = true */)
 
       if (si->m_stream)
       {
-        CAEFactory::AE->FreeStream(si->m_stream);
+        CAEFactory::FreeStream(si->m_stream);
         si->m_stream = NULL;
       }
 
@@ -347,7 +347,7 @@ inline bool PAPlayer::PrepareStream(StreamInfo *si)
     return true;
 
   /* get a paused stream */
-  si->m_stream = CAEFactory::AE->MakeStream(
+  si->m_stream = CAEFactory::MakeStream(
     si->m_dataFormat,
     si->m_sampleRate,
     si->m_encodedSampleRate,
@@ -447,7 +447,7 @@ inline void PAPlayer::ProcessStreams(double &delay, double &buffer)
     if (si->m_stream->IsDrained())
     {      
       itt = m_finishing.erase(itt);
-      CAEFactory::AE->FreeStream(si->m_stream);
+      CAEFactory::FreeStream(si->m_stream);
       delete si;
       CLog::Log(LOGDEBUG, "PAPlayer::ProcessStreams - Stream Freed");
     }

--- a/xbmc/guilib/GUIAudioManager.cpp
+++ b/xbmc/guilib/GUIAudioManager.cpp
@@ -298,7 +298,7 @@ IAESound* CGUIAudioManager::LoadSound(const CStdString &filename)
     return it->second.sound;
   }
 
-  IAESound *sound = CAEFactory::AE->MakeSound(filename);
+  IAESound *sound = CAEFactory::MakeSound(filename);
   if (!sound)
     return NULL;
 
@@ -316,7 +316,7 @@ void CGUIAudioManager::FreeSound(IAESound *sound)
   for(soundCache::iterator it = m_soundCache.begin(); it != m_soundCache.end(); ++it) {
     if (it->second.sound == sound) {
       if (--it->second.usage == 0) {     
-        CAEFactory::AE->FreeSound(sound);
+        CAEFactory::FreeSound(sound);
         m_soundCache.erase(it);
       }
       return;

--- a/xbmc/settings/GUISettings.cpp
+++ b/xbmc/settings/GUISettings.cpp
@@ -486,8 +486,8 @@ void CGUISettings::Initialize()
   AddString(NULL, "audiooutput.passthroughdevice", 546, defaultDeviceName.c_str(), SPIN_CONTROL_TEXT);
 #else
   AddSeparator(ao, "audiooutput.sep1");
-  AddString   (ao, "audiooutput.audiodevice"      , 545, CStdString(CAEFactory::AE->GetDefaultDevice(false)), SPIN_CONTROL_TEXT);
-  AddString   (ao, "audiooutput.passthroughdevice", 546, CStdString(CAEFactory::AE->GetDefaultDevice(true )), SPIN_CONTROL_TEXT);
+  AddString   (ao, "audiooutput.audiodevice"      , 545, CStdString(CAEFactory::GetDefaultDevice(false)), SPIN_CONTROL_TEXT);
+  AddString   (ao, "audiooutput.passthroughdevice", 546, CStdString(CAEFactory::GetDefaultDevice(true )), SPIN_CONTROL_TEXT);
   AddSeparator(ao, "audiooutput.sep2");
 #endif
 

--- a/xbmc/settings/GUIWindowSettingsCategory.cpp
+++ b/xbmc/settings/GUIWindowSettingsCategory.cpp
@@ -721,7 +721,7 @@ void CGUIWindowSettingsCategory::UpdateSettings()
     }
     else if (strSetting.Equals("audiooutput.guisoundmode"))
     {
-      CAEFactory::AE->SetSoundMode(g_guiSettings.GetInt("audiooutput.guisoundmode"));
+      CAEFactory::SetSoundMode(g_guiSettings.GetInt("audiooutput.guisoundmode"));
     }
     else if (strSetting.Equals("musicplayer.crossfade"))
     {
@@ -1852,7 +1852,7 @@ void CGUIWindowSettingsCategory::OnSettingChanged(CBaseSettingControl *pSettingC
     }
 #endif
     
-    CAEFactory::AE->OnSettingsChange(strSetting);
+    CAEFactory::OnSettingsChange(strSetting);
   }
 
   UpdateSettings();
@@ -2704,7 +2704,7 @@ void CGUIWindowSettingsCategory::FillInAudioDevices(CSetting* pSetting, bool Pas
 
   int selectedValue = -1;
   AEDeviceList sinkList;
-  CAEFactory::AE->EnumerateOutputDevices(sinkList, Passthrough);
+  CAEFactory::EnumerateOutputDevices(sinkList, Passthrough);
 #if !defined(TARGET_DARWIN)
   if (sinkList.size()==0)
   {


### PR DESCRIPTION
Wrap AE calls through AEFactory. There are two advantages :

1.) It is simple to skip AE initialization for platforms where we do not use AE without touching xbmc core code.
2.) Closing/opening of AE at runtime should be possible. External players seem to need that.

This PR is for sure not thought to the end and should be a discussion base.
