### PR TITLE
[LINUX] Enable separate 32/64-bit libraries for linux addons

### DIFF
--- a/xbmc/addons/AddonDll.h
+++ b/xbmc/addons/AddonDll.h
@@ -91,7 +91,15 @@ CAddonDll<TheDll, TheStruct, TheProps>::CAddonDll(const cp_extension_t *ext)
 #if defined(TARGET_ANDROID)
   m_strLibName = CAddonMgr::Get().GetExtValue(ext->configuration, "@library_android");
 #elif defined(_LINUX) && !defined(TARGET_DARWIN)
-    m_strLibName = CAddonMgr::Get().GetExtValue(ext->configuration, "@library_linux");
+#if defined(__amd64__)
+    m_strLibName = CAddonMgr::Get().GetExtValue(ext->configuration, "@library_linux64");
+    if (m_strLibName.empty())
+      m_strLibName = CAddonMgr::Get().GetExtValue(ext->configuration, "@library_linux");
+#else
+    m_strLibName = CAddonMgr::Get().GetExtValue(ext->configuration, "@library_linux32");
+    if (m_strLibName.empty())
+      m_strLibName = CAddonMgr::Get().GetExtValue(ext->configuration, "@library_linux");
+#endif
 #elif defined(_WIN32) && defined(HAS_SDL_OPENGL)
     m_strLibName = CAddonMgr::Get().GetExtValue(ext->configuration, "@library_wingl");
 #elif defined(_WIN32) && defined(HAS_DX)
@@ -529,4 +537,3 @@ void CAddonDll<TheDll, TheStruct, TheProps>::HandleException(std::exception &e, 
 }
 
 }; /* namespace ADDON */
-

--- a/xbmc/addons/AddonManager.cpp
+++ b/xbmc/addons/AddonManager.cpp
@@ -123,6 +123,7 @@ AddonPtr CAddonMgr::Factory(const cp_extension_t *props)
         { // built in screensaver
           return AddonPtr(new CAddon(props));
         }
+<<<<<<< HEAD
         if (type == ADDON_SCREENSAVER)
         { // Python screensaver
           CStdString library = CAddonMgr::Get().GetExtValue(props->configuration, "@library");
@@ -132,9 +133,16 @@ AddonPtr CAddonMgr::Factory(const cp_extension_t *props)
 #if defined(TARGET_ANDROID)                                                                                                                                                      
           if ((value = GetExtValue(props->plugin->extensions->configuration, "@library_android")) && value.empty())                                                                
             break;                                                                                                                                                                 
- #elif defined(_LINUX) && !defined(TARGET_DARWIN)
-        if ((value = GetExtValue(props->plugin->extensions->configuration, "@library_linux")) && value.empty())
-          break;
+#elif defined(_LINUX) && !defined(TARGET_DARWIN)
+#if defined(__amd64__)
+        if ((value = GetExtValue(props->plugin->extensions->configuration, "@library_linux64")) && value.empty())
+          if ((value = GetExtValue(props->plugin->extensions->configuration, "@library_linux")) && value.empty())
+            break;
+#else
+        if ((value = GetExtValue(props->plugin->extensions->configuration, "@library_linux32")) && value.empty())
+          if ((value = GetExtValue(props->plugin->extensions->configuration, "@library_linux")) && value.empty())
+            break;
+#endif
 #elif defined(_WIN32) && defined(HAS_SDL_OPENGL)
         if ((value = GetExtValue(props->plugin->extensions->configuration, "@library_wingl")) && value.empty())
           break;
@@ -330,22 +338,22 @@ void CAddonMgr::RemoveFromUpdateableAddons(AddonPtr &pAddon)
 {
   CSingleLock lock(m_critSection);
   VECADDONS::iterator it = std::find(m_updateableAddons.begin(), m_updateableAddons.end(), pAddon);
-  
+
   if(it != m_updateableAddons.end())
   {
     m_updateableAddons.erase(it);
   }
 }
 
-struct AddonIdFinder 
-{ 
+struct AddonIdFinder
+{
     AddonIdFinder(const CStdString& id)
       : m_id(id)
     {}
-    
-    bool operator()(const AddonPtr& addon) 
-    { 
-      return m_id.Equals(addon->ID()); 
+
+    bool operator()(const AddonPtr& addon)
+    {
+      return m_id.Equals(addon->ID());
     }
     private:
     CStdString m_id;
@@ -355,7 +363,7 @@ bool CAddonMgr::ReloadSettings(const CStdString &id)
 {
   CSingleLock lock(m_critSection);
   VECADDONS::iterator it = std::find_if(m_updateableAddons.begin(), m_updateableAddons.end(), AddonIdFinder(id));
-  
+
   if( it != m_updateableAddons.end())
   {
     return (*it)->ReloadSettings();
@@ -887,4 +895,3 @@ void cp_logger(cp_log_severity_t level, const char *msg, const char *apid, void 
 }
 
 } /* namespace ADDON */
-

--- a/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
+++ b/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
@@ -169,7 +169,7 @@ void CPeripheralCecAdapter::Announce(AnnouncementFlag flag, const char *sender, 
   else if (flag == GUI && !strcmp(sender, "xbmc") && !strcmp(message, "OnScreensaverActivated") && m_bIsReady)
   {
     // Don't put devices to standby if application is currently playing
-    if ((!g_application.IsPlaying() || g_application.IsPaused()) && m_configuration.bPowerOffScreensaver == 1)
+    if ((!g_application.IsPlaying() && !g_application.IsPaused()) && m_configuration.bPowerOffScreensaver == 1)
     {
       m_screensaverLastActivated = CDateTime::GetCurrentDateTime();
       // only power off when we're the active source

--- a/xbmc/pvr/channels/PVRChannelGroup.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroup.cpp
@@ -962,7 +962,12 @@ void CPVRChannelGroup::ResetChannelNumbers(void)
 
 void CPVRChannelGroup::Notify(const Observable &obs, const ObservableMessage msg)
 {
-  if (msg == ObservableMessageGuiSettings)
+  /* TODO: while pvr manager is starting up do accept setting changes. */
+  if(!g_PVRManager.IsStarted())
+  {
+    CLog::Log(LOGWARNING, "CPVRChannelGroup setting change ignored while PVRManager is starting\n");
+  }
+  else if (msg == ObservableMessageGuiSettings)
   {
     CSingleLock lock(m_critSection);
     bool bUsingBackendChannelOrder   = g_guiSettings.GetBool("pvrmanager.backendchannelorder");
@@ -972,6 +977,7 @@ void CPVRChannelGroup::Notify(const Observable &obs, const ObservableMessage msg
 
     m_bUsingBackendChannelOrder   = bUsingBackendChannelOrder;
     m_bUsingBackendChannelNumbers = bUsingBackendChannelNumbers;
+    lock.Leave();
 
     /* check whether this channel group has to be renumbered */
     if (bChannelOrderChanged || bChannelNumbersChanged)


### PR DESCRIPTION
 (library_linux32 or library_linux64 are tried first, library_linux is fallback)
This enables addon authors to distribute one ZIP package including both 32- and 64-bit binaries
