### PR TITLE
Just a simple build fix as discussed with Spiff on IRC yesterday.

### DIFF
--- a/xbmc/visualizations/Goom/Main.cpp
+++ b/xbmc/visualizations/Goom/Main.cpp
@@ -27,9 +27,11 @@ Goom Visualization Interface for XBMC
 
 */
 
+#define __STDC_LIMIT_MACROS
 
 #include "../../addons/include/xbmc_vis_dll.h"
 #include <stdio.h>
+#include <stdint.h>
 #include <string.h>
 #include <string>
 extern "C" {


### PR DESCRIPTION
At least on my system this would cause build errors with
--enable-goom

A similar fix exists already in OpenGLSpectrum.

I used the [AE] naming as it's a fix for a problem introduced in an AE commit.
