### PR TITLE
Several fixes concerning URL handling

### DIFF
--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -2223,6 +2223,9 @@ void CFileItemList::StackFiles()
     VECCREGEXP::iterator  expr        = stackRegExps.begin();
 
     URIUtils::Split(item1->GetPath(), filePath, file1);
+    if (URIUtils::ProtocolHasEncodedFilename(CURL(filePath).GetProtocol() ) )
+      CURL::Decode(file1);
+
     int j;
     while (expr != stackRegExps.end())
     {
@@ -2253,6 +2256,8 @@ void CFileItemList::StackFiles()
 
           CStdString file2, filePath2;
           URIUtils::Split(item2->GetPath(), filePath2, file2);
+          if (URIUtils::ProtocolHasEncodedFilename(CURL(filePath2).GetProtocol() ) )
+            CURL::Decode(file2);
 
           if (expr->RegFind(file2, offset) != -1)
           {
@@ -2340,7 +2345,7 @@ void CFileItemList::StackFiles()
         // the label is converted from utf8, but the filename is not)
         if (!g_guiSettings.GetBool("filelists.showextensions"))
           URIUtils::RemoveExtension(stackName);
-        CURL::Decode(stackName);
+
         item1->SetLabel(stackName);
         item1->m_dwSize = size;
         break;

--- a/xbmc/URL.cpp
+++ b/xbmc/URL.cpp
@@ -714,7 +714,6 @@ CStdString CURL::TranslateProtocol(const CStdString& prot)
    || prot == "dav"
    || prot == "tuxbox"
    || prot == "lastfm"
-   || prot == "mms"
    || prot == "rss")
    return "http";
 

--- a/xbmc/URL.cpp
+++ b/xbmc/URL.cpp
@@ -692,8 +692,11 @@ void CURL::Encode(CStdString& strURLData)
   for (int i = 0; i < (int)strURLData.size(); ++i)
   {
     int kar = (unsigned char)strURLData[i];
-    //if (kar == ' ') strResult += '+';
-    if (isalnum(kar)) strResult += kar;
+    //if (kar == ' ') strResult += '+'; // obsolete
+    if (isalnum(kar) || strchr("-_.!()" , kar) ) // Don't URL encode these according to RFC1738s
+    {
+      strResult += kar;
+    }
     else
     {
       CStdString strTmp;

--- a/xbmc/URL.cpp
+++ b/xbmc/URL.cpp
@@ -433,19 +433,7 @@ const CStdString& CURL::GetProtocol() const
 
 const CStdString CURL::GetTranslatedProtocol() const
 {
-  if (m_strProtocol == "shout"
-   || m_strProtocol == "daap"
-   || m_strProtocol == "dav"
-   || m_strProtocol == "tuxbox"
-   || m_strProtocol == "lastfm"
-   || m_strProtocol == "mms"
-   || m_strProtocol == "rss")
-   return "http";
-  
-  if (m_strProtocol == "davs")
-    return "https";
-  
-  return m_strProtocol;
+  return TranslateProtocol(m_strProtocol);
 }
 
 const CStdString& CURL::GetFileType() const
@@ -715,3 +703,21 @@ void CURL::Encode(CStdString& strURLData)
   }
   strURLData = strResult;
 }
+
+CStdString CURL::TranslateProtocol(const CStdString& prot)
+{
+  if (prot == "shout"
+   || prot == "daap"
+   || prot == "dav"
+   || prot == "tuxbox"
+   || prot == "lastfm"
+   || prot == "mms"
+   || prot == "rss")
+   return "http";
+
+  if (prot == "davs")
+    return "https";
+
+  return prot;
+}
+

--- a/xbmc/URL.h
+++ b/xbmc/URL.h
@@ -71,6 +71,8 @@ public:
   static bool IsFullPath(const CStdString &url); ///< return true if the url includes the full path
   static void Decode(CStdString& strURLData);
   static void Encode(CStdString& strURLData);
+  static CStdString TranslateProtocol(const CStdString& prot);
+
 protected:
   int m_iPort;
   CStdString m_strHostName;

--- a/xbmc/filesystem/StackDirectory.cpp
+++ b/xbmc/filesystem/StackDirectory.cpp
@@ -25,6 +25,7 @@
 #include "FileItem.h"
 #include "utils/StringUtils.h"
 #include "settings/AdvancedSettings.h"
+#include "URL.h"
 
 using namespace std;
 namespace XFILE
@@ -102,6 +103,12 @@ namespace XFILE
 
       CStdString File1 = URIUtils::GetFileName(files[0]->GetPath());
       CStdString File2 = URIUtils::GetFileName(files[1]->GetPath());
+      // Check if source path uses URL encoding
+      if (URIUtils::ProtocolHasEncodedFilename(CURL(strCommonDir).GetProtocol()))
+      {
+        CURL::Decode(File1);
+        CURL::Decode(File2);
+      }
 
       std::vector<CRegExp>::iterator itRegExp = RegExps.begin();
       int offset = 0;
@@ -131,7 +138,13 @@ namespace XFILE
                 if (Ignore1.Equals(Ignore2) && Extension1.Equals(Extension2))
                 {
                   // got it
-                  strStackTitle = Title1 + Ignore1 + Extension1;
+                  strStackTitle = Title1 + Ignore1;
+                  // Check if source path uses URL encoding
+                  if (URIUtils::ProtocolHasEncodedFilename(CURL(strCommonDir).GetProtocol()))
+                    CURL::Encode(strStackTitle);
+
+                  strStackTitle += Extension1;
+
                   itRegExp = RegExps.end();
                   break;
                 }

--- a/xbmc/utils/FileOperationJob.cpp
+++ b/xbmc/utils/FileOperationJob.cpp
@@ -134,6 +134,11 @@ bool CFileOperationJob::DoProcess(FileAction action, CFileItemList & items, cons
       URIUtils::RemoveSlashAtEnd(strNoSlash);
       CStdString strFileName = URIUtils::GetFileName(strNoSlash);
 
+      // URL Decode for cases where source uses URL encoding and target does not 
+      if ( URIUtils::ProtocolHasEncodedFilename(CURL(pItem->GetPath()).GetProtocol() )
+       && !URIUtils::ProtocolHasEncodedFilename(CURL(strDestFile).GetProtocol() ) )
+        CURL::Decode(strFileName);
+
       // special case for upnp
       if (URIUtils::IsUPnP(items.GetPath()) || URIUtils::IsUPnP(pItem->GetPath()))
       {

--- a/xbmc/utils/URIUtils.cpp
+++ b/xbmc/utils/URIUtils.cpp
@@ -682,13 +682,18 @@ bool URIUtils::IsInternetStream(const CURL& url, bool bStrictCheck /* = false */
   CStdString strProtocol2 = url.GetTranslatedProtocol();
 
   // Special case these
-  if (strProtocol2 == "ftp" || strProtocol2 == "ftps" ||
-      strProtocol  == "dav" || strProtocol  == "davs")
+  if (strProtocol2 == "ftp"   || strProtocol2 == "ftps"   ||
+      strProtocol  == "dav"   || strProtocol  == "davs")
     return bStrictCheck;
 
-  if (strProtocol2 == "http" || strProtocol2 == "https" ||
-      strProtocol  == "rtp"  || strProtocol  == "udp"   ||
-      strProtocol  == "rtmp" || strProtocol  == "rtsp")
+  if (strProtocol2 == "http"  || strProtocol2 == "https"  ||
+      strProtocol2 == "tcp"   || strProtocol2 == "udp"    ||
+      strProtocol2 == "rtp"   || strProtocol2 == "sdp"    ||
+      strProtocol2 == "mms"   || strProtocol2 == "mmst"   ||
+      strProtocol2 == "mmsh"  || strProtocol2 == "rtsp"   ||
+      strProtocol2 == "rtmp"  || strProtocol2 == "rtmpt"  ||
+      strProtocol2 == "rtmpe" || strProtocol2 == "rtmpte" ||
+      strProtocol2 == "rtmps")
     return true;
 
   return false;

--- a/xbmc/utils/URIUtils.cpp
+++ b/xbmc/utils/URIUtils.cpp
@@ -241,6 +241,15 @@ bool URIUtils::ProtocolHasEncodedHostname(const CStdString& prot)
       || prot.Equals("musicsearch");
 }
 
+bool URIUtils::ProtocolHasEncodedFilename(const CStdString& prot)
+{
+  CStdString prot2 = CURL::TranslateProtocol(prot);
+
+  // For now assume only (quasi) http internet streams use URL encoding
+  return prot2 == "http"  ||
+         prot2 == "https";
+}
+
 CStdString URIUtils::GetParentPath(const CStdString& strPath)
 {
   CStdString strReturn;
@@ -661,7 +670,6 @@ bool URIUtils::IsFTP(const CStdString& strFile)
 
 bool URIUtils::IsInternetStream(const CURL& url, bool bStrictCheck /* = false */)
 {
-  
   CStdString strProtocol = url.GetProtocol();
   
   if (strProtocol.IsEmpty())

--- a/xbmc/utils/URIUtils.cpp
+++ b/xbmc/utils/URIUtils.cpp
@@ -662,10 +662,8 @@ bool URIUtils::IsFTP(const CStdString& strFile)
   if (IsStack(strFile))
     strFile2 = CStackDirectory::GetFirstStackedFile(strFile);
 
-  CURL url(strFile2);
-
-  return url.GetTranslatedProtocol() == "ftp"  ||
-         url.GetTranslatedProtocol() == "ftps";
+  return strFile2.Left(4).Equals("ftp:")  ||
+         strFile2.Left(5).Equals("ftps:");
 }
 
 bool URIUtils::IsInternetStream(const CURL& url, bool bStrictCheck /* = false */)
@@ -682,7 +680,7 @@ bool URIUtils::IsInternetStream(const CURL& url, bool bStrictCheck /* = false */
   CStdString strProtocol2 = url.GetTranslatedProtocol();
 
   // Special case these
-  if (strProtocol2 == "ftp"   || strProtocol2 == "ftps"   ||
+  if (strProtocol  == "ftp"   || strProtocol  == "ftps"   ||
       strProtocol  == "dav"   || strProtocol  == "davs")
     return bStrictCheck;
 

--- a/xbmc/utils/URIUtils.h
+++ b/xbmc/utils/URIUtils.h
@@ -112,5 +112,6 @@ public:
 
   static bool ProtocolHasParentInHostname(const CStdString& prot);
   static bool ProtocolHasEncodedHostname(const CStdString& prot);
+  static bool ProtocolHasEncodedFilename(const CStdString& prot);
 };
 


### PR DESCRIPTION
This commit fixes the way we handle URL encoded paths in various locations. Eg. the Webdav filesystem didn't work properly for finding local thumbs and fanart for stacks. Ideally we should still switch to using URLs for the Fileitem's path in CFileItem but since that's a major change, these fixes should remedy most of the issues in the mean time. Any feedback is welcome (it's not that unlikely that I missed stuff) + I like a signoff by a senior.
