### PR TITLE
smartplaylist: make Year rules browsable

### DIFF
--- a/xbmc/dialogs/GUIDialogSmartPlaylistRule.cpp
+++ b/xbmc/dialogs/GUIDialogSmartPlaylistRule.cpp
@@ -154,6 +154,18 @@ void CGUIDialogSmartPlaylistRule::OnBrowse()
     videodatabase.GetActorsNav("",items,type);
     iLabel = 20337;
   }
+  else if (m_rule.m_field == FieldYear)
+  {
+    if (m_type.Equals("songs") || m_type.Equals("mixed") || m_type.Equals("albums"))
+      database.GetYearsNav("", items);
+    if (!m_type.Equals("songs") && !m_type.Equals("albums"))
+    {
+      CFileItemList items2;
+      videodatabase.GetYearsNav("", items2, type);
+      items.Append(items2);
+    }
+    iLabel = 562;
+  }
   else if (m_rule.m_field == FieldDirector)
   {
     videodatabase.GetDirectorsNav("",items,type);

--- a/xbmc/playlists/SmartPlayList.cpp
+++ b/xbmc/playlists/SmartPlayList.cpp
@@ -62,7 +62,7 @@ static const translateField fields[] = {
   { "label",             FieldMusicLabel,              SortByNone,                     CSmartPlaylistRule::TEXT_FIELD,       21899 },
   { "title",             FieldTitle,                   SortByTitle,                    CSmartPlaylistRule::TEXT_FIELD,       556 },
   { "sorttitle",         FieldSortTitle,               SortBySortTitle,                CSmartPlaylistRule::TEXT_FIELD,       556 },
-  { "year",              FieldYear,                    SortByYear,                     CSmartPlaylistRule::NUMERIC_FIELD,    562 },
+  { "year",              FieldYear,                    SortByYear,                     CSmartPlaylistRule::BROWSEABLE_FIELD, 562 },
   { "time",              FieldTime,                    SortByTime,                     CSmartPlaylistRule::SECONDS_FIELD,    180 },
   { "playcount",         FieldPlaycount,               SortByPlaycount,                CSmartPlaylistRule::NUMERIC_FIELD,    567 },
   { "lastplayed",        FieldLastPlayed,              SortByLastPlayed,               CSmartPlaylistRule::DATE_FIELD,       568 },


### PR DESCRIPTION
This makes the Year rule in the smartplaylist editor browsable (similar to Actors, Director, Genre etc). IMO this makes sense considering that we also have a browsable Year node in the video/music library.
