### PR TITLE
fixed volume, use consistant units and do not create strange non-linear audio scaling

### DIFF
--- a/xbmc/Application.h
+++ b/xbmc/Application.h
@@ -191,8 +191,8 @@ public:
   virtual void Process();
   void ProcessSlow();
   void ResetScreenSaver();
-  int GetVolume() const;
-  void SetVolume(float iValue, bool isPercentage = true);
+  float GetLinearVolume() const;
+  void SetLinearVolume(float volume);
   bool IsMuted() const;
   void ToggleMute(void);
   void ShowVolumeBar(const CAction *action = NULL);
@@ -406,7 +406,6 @@ protected:
   void Mute();
   void UnMute();
 
-  void SetHardwareVolume(float hardwareVolume);
   void UpdateLCD();
   void FatalErrorHandler(bool WindowSystemInitialized, bool MapDrives, bool InitNetwork);
 

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -1149,7 +1149,7 @@ CStdString CGUIInfoManager::GetLabel(int info, int contextWindow, CStdString *fa
     strLabel.Format("%02.2f", m_fps);
     break;
   case PLAYER_VOLUME:
-    strLabel.Format("%2.1f dB", CAEUtil::PercentToGain(g_settings.m_fVolumeLevel));
+    strLabel.Format("%2.1f dB", CAEUtil::LinearToDecibel(g_application.GetLinearVolume()));
     break;
   case PLAYER_SUBTITLE_DELAY:
     strLabel.Format("%2.3f s", g_settings.m_currentVideoSettings.m_SubtitleDelay);
@@ -1694,7 +1694,7 @@ bool CGUIInfoManager::GetInt(int &value, int info, int contextWindow, const CGUI
   switch( info )
   {
     case PLAYER_VOLUME:
-      value = g_application.GetVolume();
+      value = (int)(g_application.GetLinearVolume() * 100.0 + 0.5);
       return true;
     case PLAYER_SUBTITLE_DELAY:
       value = g_application.GetSubtitleDelay();

--- a/xbmc/cores/AudioEngine/Utils/AEUtil.h
+++ b/xbmc/cores/AudioEngine/Utils/AEUtil.h
@@ -53,28 +53,30 @@ public:
   static const unsigned int      DataFormatToBits  (const enum AEDataFormat dataFormat);
   static const char*             DataFormatToStr   (const enum AEDataFormat dataFormat);
 
-  /*! \brief convert a volume percentage (as a proportion) to a dB gain
-   We assume a dB range of 60dB, i.e. assume that 0% volume corresponds
-   to a reduction of 60dB.
-   \param value the volume from 0..1
-   \return the corresponding gain in dB from -60dB .. 0dB.
-   \sa GainToScale
+  /*! \brief convert a linear factor to a dB gain for audio manipulation
+   Inverts linear = pow(10.0f, dB/20)
+   \param linear factor from 0..1
+   \return the gain in dB from -60dB .. 0dB.
+   \sa DecibelToLinear
    */
-  static inline const float PercentToGain(const float value)
+  static inline const float LinearToDecibel(const float linear)
   {
-    static const float db_range = 60.0f;
-    return (value - 1)*db_range;
+    // clamp to -60dB
+    if (linear < 0.001f) 
+      return -60.0f;
+    else
+      return 20.0f * log10(linear);
   }
 
-  /*! \brief convert a dB gain to a scale factor for audio manipulation
-   Inverts gain = 20 log_10(scale)
+  /*! \brief convert a dB gain to a linear factor for audio manipulation
+   Inverts gain = 20 log_10(linear)
    \param dB the gain in decibels.
-   \return the scale factor (equivalent to a voltage multiplier).
-   \sa PercentToGain
+   \return the linear factor (equivalent to a voltage multiplier).
+   \sa LinearToDecibel
    */
-  static inline const float GainToScale(const float dB)
+  static inline const float DecibelToLinear(const float dB)
   {
-    return pow(10.0f, dB/20);
+    return pow(10.0f, dB/20.0f);
   }
 
   #ifdef __SSE__

--- a/xbmc/interfaces/Builtins.cpp
+++ b/xbmc/interfaces/Builtins.cpp
@@ -825,10 +825,10 @@ int CBuiltins::Execute(const CStdString& execString)
   }
   else if (execute.Equals("setvolume"))
   {
-    int oldVolume = g_application.GetVolume();
+    int oldVolume = (int)(g_application.GetLinearVolume() * 100.0 + 0.5);
     int volume = atoi(parameter.c_str());
 
-    g_application.SetVolume((float)volume);
+    g_application.SetLinearVolume((float)volume/100.0);
     if(oldVolume != volume)
     {
       if(params.size() > 1 && params[1].Equals("showVolumeBar"))    

--- a/xbmc/interfaces/http-api/XBMChttp.cpp
+++ b/xbmc/interfaces/http-api/XBMChttp.cpp
@@ -1598,7 +1598,7 @@ int CXbmcHttp::xbmcSetVolume(int numParas, CStdString paras[])
   else
   {
     int iPercent = atoi(paras[0].c_str());
-    g_application.SetVolume((float)iPercent, true);
+    g_application.SetLinearVolume((float)iPercent/100.0);
     return SetResponse(openTag+"OK");
   }
 }
@@ -1606,7 +1606,7 @@ int CXbmcHttp::xbmcSetVolume(int numParas, CStdString paras[])
 int CXbmcHttp::xbmcGetVolume()
 {
   CStdString tmp;
-  tmp.Format("%i",g_application.GetVolume());
+  tmp.Format("%i", (int)(g_application.GetLinearVolume() * 100.0 + 0.5));
   return SetResponse(openTag + tmp);
 }
 
@@ -2613,7 +2613,7 @@ int CXbmcHttp::xbmcSTSetting(int numParas, CStdString paras[])
       else if (paras[i]=="httpapibroadcastlevel")
         tmp.Format("%i",g_settings.m_HttpApiBroadcastLevel);
       else if (paras[i]=="volumelevel")
-        tmp.Format("%i",g_application.GetVolume());
+        tmp.Format("%i",(int)(g_application.GetLinearVolume() * 100.0 + 0.5));
       else if (paras[i]=="systemtimetotalup")
         tmp.Format("%i",g_settings.m_iSystemTimeTotalUp);
       else if (paras[i]=="mute")

--- a/xbmc/interfaces/json-rpc/ApplicationOperations.cpp
+++ b/xbmc/interfaces/json-rpc/ApplicationOperations.cpp
@@ -55,10 +55,10 @@ JSONRPC_STATUS CApplicationOperations::SetVolume(const CStdString &method, ITran
   bool up = false;
   if (parameterObject["volume"].isInteger())
   {
-    int oldVolume = g_application.GetVolume();
+    int oldVolume = (int)(g_application.GetLinearVolume() * 100.0 + 0.5);
     int volume = (int)parameterObject["volume"].asInteger();
   
-    g_application.SetVolume((float)volume, true);
+    g_application.SetLinearVolume((float)volume/100.0);
 
     up = oldVolume < volume;
   }
@@ -110,7 +110,7 @@ JSONRPC_STATUS CApplicationOperations::Quit(const CStdString &method, ITransport
 JSONRPC_STATUS CApplicationOperations::GetPropertyValue(const CStdString &property, CVariant &result)
 {
   if (property.Equals("volume"))
-    result = g_application.GetVolume();
+    result = (int)(g_application.GetLinearVolume() * 100.0 + 0.5);
   else if (property.Equals("muted"))
     result = g_application.IsMuted();
   else if (property.Equals("name"))

--- a/xbmc/network/AirPlayServer.cpp
+++ b/xbmc/network/AirPlayServer.cpp
@@ -698,11 +698,11 @@ int CAirPlayServer::CTCPClient::ProcessRequest( CStdString& responseHeader,
       }
       else if (volume >= 0 && volume <= 1)
       {
-        int oldVolume = g_application.GetVolume();
+        int oldVolume = (int)(g_application.GetLinearVolume() * 100.0 + 0.5);
         volume *= 100;
         if(oldVolume != (int)volume)
         {
-          g_application.SetVolume(volume);          
+          g_application.SetLinearVolume(volume/100.0);          
           g_application.getApplicationMessenger().ShowVolumeBar(oldVolume < volume);
         }
       }

--- a/xbmc/network/UPnP.cpp
+++ b/xbmc/network/UPnP.cpp
@@ -59,6 +59,7 @@
 #include "utils/md5.h"
 #include "guilib/Key.h"
 #include "ThumbLoader.h"
+#include "cores/AudioEngine/Utils/AEUtil.h"
 
 using namespace std;
 using namespace MUSIC_INFO;
@@ -1675,12 +1676,12 @@ CUPnPRenderer::UpdateState()
     } else {
         rct->SetStateVariable("Mute", "0");
     }
-    volume = g_application.GetVolume();
+    volume = (int)(g_application.GetLinearVolume() * 100.0 + 0.5);
 
     buffer.Format("%d", volume);
     rct->SetStateVariable("Volume", buffer.c_str());
 
-    buffer.Format("%d", 256 * (volume * 60 - 60) / 100);
+    buffer.Format("%d", (int)CAEUtil::LinearToDecibel(g_application.GetLinearVolume()));
     rct->SetStateVariable("VolumeDb", buffer.c_str());
 
     if (g_application.IsPlaying() || g_application.IsPaused()) {
@@ -1990,7 +1991,8 @@ CUPnPRenderer::OnSetVolume(PLT_ActionReference& action)
 {
     NPT_String volume;
     NPT_CHECK_SEVERE(action->GetArgumentValue("DesiredVolume", volume));
-    g_application.SetVolume((float)strtod((const char*)volume, NULL));
+    float volume_percent = (float)strtod((const char*)volume, NULL);
+    g_application.SetLinearVolume(volume_percent/100.0);
     return NPT_SUCCESS;
 }
 

--- a/xbmc/video/dialogs/GUIDialogAudioSubtitleSettings.cpp
+++ b/xbmc/video/dialogs/GUIDialogAudioSubtitleSettings.cpp
@@ -76,8 +76,8 @@ void CGUIDialogAudioSubtitleSettings::CreateSettings()
   // clear out any old settings
   m_settings.clear();
   // create our settings
-  m_volume = g_settings.m_fVolumeLevel;
-  AddSlider(AUDIO_SETTINGS_VOLUME, 13376, &m_volume, VOLUME_MINIMUM, VOLUME_MAXIMUM / 100.0f, VOLUME_MAXIMUM, PercentAsDecibel, false);
+  m_volume_percent = g_settings.m_fVolumeLevel * 100;
+  AddSlider(AUDIO_SETTINGS_VOLUME, 13376, &m_volume_percent, VOLUME_MINIMUM, VOLUME_MAXIMUM * 100, VOLUME_MAXIMUM * 100, PercentAsDecibel, false);
   AddSlider(AUDIO_SETTINGS_VOLUME_AMPLIFICATION, 660, &g_settings.m_currentVideoSettings.m_VolumeAmplification, VOLUME_DRC_MINIMUM * 0.01f, (VOLUME_DRC_MAXIMUM - VOLUME_DRC_MINIMUM) / 6000.0f, VOLUME_DRC_MAXIMUM * 0.01f, FormatDecibel, false);
   if (g_application.m_pPlayer && g_application.m_pPlayer->IsPassthrough())
   {
@@ -215,8 +215,8 @@ void CGUIDialogAudioSubtitleSettings::OnSettingChanged(SettingInfo &setting)
   // check and update anything that needs it
   if (setting.id == AUDIO_SETTINGS_VOLUME)
   {
-    g_settings.m_fVolumeLevel = m_volume;
-    g_application.SetVolume(m_volume, false);//false - value is not in percent
+    g_settings.m_fVolumeLevel = m_volume_percent / 100.0;
+    g_application.SetLinearVolume(g_settings.m_fVolumeLevel);
   }
   else if (setting.id == AUDIO_SETTINGS_VOLUME_AMPLIFICATION)
   {
@@ -353,7 +353,7 @@ void CGUIDialogAudioSubtitleSettings::OnSettingChanged(SettingInfo &setting)
 
 void CGUIDialogAudioSubtitleSettings::FrameMove()
 {
-  m_volume = g_settings.m_fVolumeLevel;
+  m_volume_percent = g_settings.m_fVolumeLevel * 100;
   UpdateSetting(AUDIO_SETTINGS_VOLUME);
   if (g_application.m_pPlayer)
   {
@@ -368,7 +368,7 @@ void CGUIDialogAudioSubtitleSettings::FrameMove()
 CStdString CGUIDialogAudioSubtitleSettings::PercentAsDecibel(float value, float interval)
 {
   CStdString text;
-  text.Format("%2.1f dB", CAEUtil::PercentToGain(value));
+  text.Format("%2.1f dB", CAEUtil::LinearToDecibel(value/100.0));
   return text;
 }
 

--- a/xbmc/video/dialogs/GUIDialogAudioSubtitleSettings.h
+++ b/xbmc/video/dialogs/GUIDialogAudioSubtitleSettings.h
@@ -42,7 +42,7 @@ protected:
   void AddAudioStreams(unsigned int id);
   void AddSubtitleStreams(unsigned int id);
 
-  float m_volume;
+  float m_volume_percent;
   int m_audioStream;
   int m_subtitleStream;
   int m_outputmode;


### PR DESCRIPTION
This restore pre-AE behavior. volume is displayed in dB, we use a linear scaling inside xbmc.

Tested on osx and linux (alsa) to give 1/2 the apparent loudness at 1/2 the scale.
