### PR TITLE
jsonrpc: add "thumbnail" and "fanart" to VideoLibrary.SetFooDetails

### DIFF
--- a/xbmc/interfaces/json-rpc/ServiceDescription.h
+++ b/xbmc/interfaces/json-rpc/ServiceDescription.h
@@ -2072,7 +2072,9 @@ namespace JSONRPC
         "{ \"name\": \"top250\", \"$ref\": \"Optional.Integer\" },"
         "{ \"name\": \"sorttitle\", \"$ref\": \"Optional.String\" },"
         "{ \"name\": \"set\", \"type\": [ \"null\", { \"$ref\": \"Array.String\", \"required\": true } ], \"default\": null },"
-        "{ \"name\": \"showlink\", \"type\": [ \"null\", { \"$ref\": \"Array.String\", \"required\": true } ], \"default\": null }"
+        "{ \"name\": \"showlink\", \"type\": [ \"null\", { \"$ref\": \"Array.String\", \"required\": true } ], \"default\": null },"
+        "{ \"name\": \"thumbnail\", \"$ref\": \"Optional.String\" },"
+        "{ \"name\": \"fanart\", \"$ref\": \"Optional.String\" }"
       "],"
       "\"returns\": \"string\""
     "}",
@@ -2097,7 +2099,9 @@ namespace JSONRPC
         "{ \"name\": \"lastplayed\", \"$ref\": \"Optional.String\" },"
         "{ \"name\": \"originaltitle\", \"$ref\": \"Optional.String\" },"
         "{ \"name\": \"sorttitle\", \"$ref\": \"Optional.String\" },"
-        "{ \"name\": \"episodeguide\", \"$ref\": \"Optional.String\" }"
+        "{ \"name\": \"episodeguide\", \"$ref\": \"Optional.String\" },"
+        "{ \"name\": \"thumbnail\", \"$ref\": \"Optional.String\" },"
+        "{ \"name\": \"fanart\", \"$ref\": \"Optional.String\" }"
       "],"
       "\"returns\": \"string\""
     "}",
@@ -2121,7 +2125,9 @@ namespace JSONRPC
         "{ \"name\": \"productioncode\", \"$ref\": \"Optional.String\" },"
         "{ \"name\": \"season\", \"$ref\": \"Optional.Integer\" },"
         "{ \"name\": \"episode\", \"$ref\": \"Optional.Integer\" },"
-        "{ \"name\": \"originaltitle\", \"$ref\": \"Optional.String\" }"
+        "{ \"name\": \"originaltitle\", \"$ref\": \"Optional.String\" },"
+        "{ \"name\": \"thumbnail\", \"$ref\": \"Optional.String\" },"
+        "{ \"name\": \"fanart\", \"$ref\": \"Optional.String\" }"
       "],"
       "\"returns\": \"string\""
     "}",
@@ -2143,7 +2149,9 @@ namespace JSONRPC
         "{ \"name\": \"artist\", \"type\": [ \"null\", { \"$ref\": \"Array.String\", \"required\": true } ] },"
         "{ \"name\": \"genre\", \"type\": [ \"null\", { \"$ref\": \"Array.String\", \"required\": true } ], \"default\": null },"
         "{ \"name\": \"track\", \"$ref\": \"Optional.Integer\" },"
-        "{ \"name\": \"lastplayed\", \"$ref\": \"Optional.String\" }"
+        "{ \"name\": \"lastplayed\", \"$ref\": \"Optional.String\" },"
+        "{ \"name\": \"thumbnail\", \"$ref\": \"Optional.String\" },"
+        "{ \"name\": \"fanart\", \"$ref\": \"Optional.String\" }"
       "],"
       "\"returns\": \"string\""
     "}",

--- a/xbmc/interfaces/json-rpc/VideoLibrary.cpp
+++ b/xbmc/interfaces/json-rpc/VideoLibrary.cpp
@@ -370,7 +370,7 @@ JSONRPC_STATUS CVideoLibrary::SetMovieDetails(const CStdString &method, ITranspo
   int playcount = infos.m_playCount;
   CDateTime lastPlayed = infos.m_lastPlayed;
 
-  UpdateVideoTag(parameterObject, infos);
+  UpdateVideoTag(parameterObject, infos, artwork);
 
   if (videodatabase.SetDetailsForMovie(infos.m_strFileNameAndPath, infos, artwork, id) > 0)
   {
@@ -407,7 +407,7 @@ JSONRPC_STATUS CVideoLibrary::SetTVShowDetails(const CStdString &method, ITransp
   int playcount = infos.m_playCount;
   CDateTime lastPlayed = infos.m_lastPlayed;
 
-  UpdateVideoTag(parameterObject, infos);
+  UpdateVideoTag(parameterObject, infos, artwork);
 
   if (videodatabase.SetDetailsForTvShow(infos.m_strFileNameAndPath, infos, artwork, seasonArt, id) > 0)
   {
@@ -448,7 +448,7 @@ JSONRPC_STATUS CVideoLibrary::SetEpisodeDetails(const CStdString &method, ITrans
   int playcount = infos.m_playCount;
   CDateTime lastPlayed = infos.m_lastPlayed;
 
-  UpdateVideoTag(parameterObject, infos);
+  UpdateVideoTag(parameterObject, infos, artwork);
 
   if (videodatabase.SetDetailsForEpisode(infos.m_strFileNameAndPath, infos, artwork, tvshowid, id) > 0)
   {
@@ -482,7 +482,7 @@ JSONRPC_STATUS CVideoLibrary::SetMusicVideoDetails(const CStdString &method, ITr
   int playcount = infos.m_playCount;
   CDateTime lastPlayed = infos.m_lastPlayed;
 
-  UpdateVideoTag(parameterObject, infos);
+  UpdateVideoTag(parameterObject, infos, artwork);
 
   if (videodatabase.SetDetailsForMusicVideo(infos.m_strFileNameAndPath, infos, artwork, id) > 0)
   {
@@ -708,7 +708,7 @@ JSONRPC_STATUS CVideoLibrary::RemoveVideo(const CVariant &parameterObject)
   return ACK;
 }
 
-void CVideoLibrary::UpdateVideoTag(const CVariant &parameterObject, CVideoInfoTag& details)
+void CVideoLibrary::UpdateVideoTag(const CVariant &parameterObject, CVideoInfoTag& details, std::map<std::string, std::string> &artwork)
 {
   if (ParameterNotNull(parameterObject, "title"))
     details.m_strTitle = parameterObject["title"].asString();
@@ -774,4 +774,8 @@ void CVideoLibrary::UpdateVideoTag(const CVariant &parameterObject, CVideoInfoTa
     CopyStringArray(parameterObject["set"], details.m_set);
   if (ParameterNotNull(parameterObject, "showlink"))
     CopyStringArray(parameterObject["showlink"], details.m_showLink);
+  if (ParameterNotNull(parameterObject, "thumbnail"))
+    artwork["thumb"] = parameterObject["thumbnail"].asString();
+  if (ParameterNotNull(parameterObject, "fanart"))
+    artwork["fanart"] = parameterObject["fanart"].asString();
 }

--- a/xbmc/interfaces/json-rpc/VideoLibrary.h
+++ b/xbmc/interfaces/json-rpc/VideoLibrary.h
@@ -73,6 +73,6 @@ namespace JSONRPC
     static JSONRPC_STATUS GetAdditionalEpisodeDetails(const CVariant &parameterObject, CFileItemList &items, CVariant &result, CVideoDatabase &videodatabase);
     static JSONRPC_STATUS GetAdditionalMusicVideoDetails(const CVariant &parameterObject, CFileItemList &items, CVariant &result, CVideoDatabase &videodatabase);
     static JSONRPC_STATUS RemoveVideo(const CVariant &parameterObject);
-    static void UpdateVideoTag(const CVariant &parameterObject, CVideoInfoTag& details);
+    static void UpdateVideoTag(const CVariant &parameterObject, CVideoInfoTag& details, std::map<std::string, std::string> &artwork);
   };
 }

--- a/xbmc/interfaces/json-rpc/methods.json
+++ b/xbmc/interfaces/json-rpc/methods.json
@@ -1210,7 +1210,9 @@
       { "name": "top250", "$ref": "Optional.Integer" },
       { "name": "sorttitle", "$ref": "Optional.String" },
       { "name": "set", "type": [ "null", { "$ref": "Array.String", "required": true } ], "default": null },
-      { "name": "showlink", "type": [ "null", { "$ref": "Array.String", "required": true } ], "default": null }
+      { "name": "showlink", "type": [ "null", { "$ref": "Array.String", "required": true } ], "default": null },
+      { "name": "thumbnail", "$ref": "Optional.String" },
+      { "name": "fanart", "$ref": "Optional.String" }
     ],
     "returns": "string"
   },
@@ -1235,7 +1237,9 @@
       { "name": "lastplayed", "$ref": "Optional.String" },
       { "name": "originaltitle", "$ref": "Optional.String" },
       { "name": "sorttitle", "$ref": "Optional.String" },
-      { "name": "episodeguide", "$ref": "Optional.String" }
+      { "name": "episodeguide", "$ref": "Optional.String" },
+      { "name": "thumbnail", "$ref": "Optional.String" },
+      { "name": "fanart", "$ref": "Optional.String" }
     ],
     "returns": "string"
   },
@@ -1259,7 +1263,9 @@
       { "name": "productioncode", "$ref": "Optional.String" },
       { "name": "season", "$ref": "Optional.Integer" },
       { "name": "episode", "$ref": "Optional.Integer" },
-      { "name": "originaltitle", "$ref": "Optional.String" }
+      { "name": "originaltitle", "$ref": "Optional.String" },
+      { "name": "thumbnail", "$ref": "Optional.String" },
+      { "name": "fanart", "$ref": "Optional.String" }
     ],
     "returns": "string"
   },
@@ -1281,7 +1287,9 @@
       { "name": "artist", "type": [ "null", { "$ref": "Array.String", "required": true } ] },
       { "name": "genre", "type": [ "null", { "$ref": "Array.String", "required": true } ], "default": null },
       { "name": "track", "$ref": "Optional.Integer" },
-      { "name": "lastplayed", "$ref": "Optional.String" }
+      { "name": "lastplayed", "$ref": "Optional.String" },
+      { "name": "thumbnail", "$ref": "Optional.String" },
+      { "name": "fanart", "$ref": "Optional.String" }
     ],
     "returns": "string"
   },


### PR DESCRIPTION
This adds the possibility for JSON-RPC clients to update the URLs/paths from where XBMC caches a video's thumbnail and/or fanart. This is finally possible thanks to the new texture cache. Martijn has requested and tested this.
