### PR TITLE
Set "Current.Location" property from weather addon.

### DIFF
--- a/addons/weather.wunderground/default.py
+++ b/addons/weather.wunderground/default.py
@@ -103,6 +103,10 @@ def forecast(city):
 
 def properties(query):
     weathercode = WEATHER_CODES[query['current_observation']['icon_url'][31:-4]]
+    location = __addon__.getSetting('Location%s' % sys.argv[1])
+    if (location == '') and (sys.argv[1] != '1'):
+        location = __addon__.getSetting('Location1')
+    set_property('Current.Location'      , location)
     set_property('Current.Condition'     , query['current_observation']['weather'])
     set_property('Current.Temperature'   , str(query['current_observation']['temp_c']))
     set_property('Current.Wind'          , str(query['current_observation']['wind_kph']))


### PR DESCRIPTION
Some skins (e.g. skin.transparency) display the location name on the home screen. Currently they display nothing (because the Current.Location property is empty). This commit sets this property and fixes the "problem".
