### PR TITLE
Python based screensavers

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -4498,6 +4498,10 @@ bool CApplication::WakeUpScreenSaver()
     }
     else if (m_screenSaver->ID() == "screensaver.xbmc.builtin.dim" || m_screenSaver->ID() == "screensaver.xbmc.builtin.black")
       return true;
+#ifdef HAS_PYTHON
+    else if (URIUtils::GetExtension(m_screenSaver->LibPath()).Equals(".py", false))
+      return true;
+#endif
     else if (!m_screenSaver->ID().IsEmpty())
     { // we're in screensaver window
       if (g_windowManager.GetActiveWindow() == WINDOW_SCREENSAVER)
@@ -4622,6 +4626,13 @@ void CApplication::ActivateScreenSaver(bool forceType /*= false */)
     return;
   else if (m_screenSaver->ID() == "screensaver.xbmc.builtin.black")
     return;
+#ifdef HAS_PYTHON
+  else if (URIUtils::GetExtension(m_screenSaver->LibPath()).Equals(".py", false))
+  {
+    if (!g_pythonParser.StopScript(m_screenSaver->LibPath()))
+      g_pythonParser.evalFile(m_screenSaver->LibPath(), m_screenSaver);
+  }
+#endif
   else if (!m_screenSaver->ID().IsEmpty())
     g_windowManager.ActivateWindow(WINDOW_SCREENSAVER);
 }

--- a/xbmc/addons/AddonManager.cpp
+++ b/xbmc/addons/AddonManager.cpp
@@ -116,6 +116,12 @@ AddonPtr CAddonMgr::Factory(const cp_extension_t *props)
         { // built in screensaver
           return AddonPtr(new CAddon(props));
         }
+        if (type == ADDON_SCREENSAVER)
+        { // Python screensaver
+          CStdString library = CAddonMgr::Get().GetExtValue(props->configuration, "@library");
+          if (URIUtils::GetExtension(library).Equals(".py", false))
+            return AddonPtr(new CAddon(props));
+        }
 #if defined(_LINUX) && !defined(TARGET_DARWIN)
         if ((value = GetExtValue(props->plugin->extensions->configuration, "@library_linux")) && value.empty())
           break;


### PR DESCRIPTION
Please don't see this as complete pull request - at the moment it is more a proof-of-concept.

These changes should do the following:
- add "xbmc.python.screensaver" extension point for addons
- show the new kind of screensaver addon in the screensaver select dialog in settings (in addition to the binary ones)
- run the addon on CApplication::ActivateScreenSaver()
- pass on CApplication::WakeUpScreenSaver()

the screensaver addon should exit itself via waiting for the onScreensaverDeactivated-announcement

I created a simple python addon for demonstrating, you can get it from here: 
https://github.com/downloads/dersphere/script.screensaver.test/script.screensaver.test-0.0.1.zip
source is here: https://github.com/dersphere/script.screensaver.test

It works already, means, you can add this addon, set it as screensaver and it gets started and exits like a normal screensaver.

Of course there would still some things to do:
ex. combine both types of screensaver-addons in AddonsDirectory

But I'm more interested in your opinions about the general idea of having python based screensavers and if its worth more work.

regards,
sphere
