### PR TITLE
Added advancedsetting to control relative navigation sound volume.

### DIFF
--- a/xbmc/XBApplicationEx.h
+++ b/xbmc/XBApplicationEx.h
@@ -35,7 +35,7 @@ class CXBApplicationEx : public IWindowManagerCallback
 {
 public:
   CXBApplicationEx();
-  ~CXBApplicationEx();
+  virtual ~CXBApplicationEx();
 
   // Variables for timing
   bool m_bStop;

--- a/xbmc/guilib/GUIAudioManager.cpp
+++ b/xbmc/guilib/GUIAudioManager.cpp
@@ -22,6 +22,7 @@
 #include "system.h"
 #include "GUIAudioManager.h"
 #include "Key.h"
+#include "settings/AdvancedSettings.h"
 #include "settings/GUISettings.h"
 #include "input/ButtonTranslator.h"
 #include "threads/SingleLock.h"
@@ -301,6 +302,8 @@ IAESound* CGUIAudioManager::LoadSound(const CStdString &filename)
   IAESound *sound = CAEFactory::AE->MakeSound(filename);
   if (!sound)
     return NULL;
+
+  sound->SetVolume(g_advancedSettings.m_navSoundLevel);
 
   CSoundInfo info;
   info.usage = 1;

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -56,6 +56,7 @@ void CAdvancedSettings::Initialize()
   m_audioAudiophile = false;
   m_allChannelStereo = false;
   m_audioSinkBufferDurationMsec = 50;
+  m_navSoundLevel = 0.3f;
 
   //default hold time of 25 ms, this allows a 20 hertz sine to pass undistorted
   m_limiterHold = 0.025f;
@@ -388,6 +389,9 @@ void CAdvancedSettings::ParseSettingsFile(const CStdString &file)
 
     XMLUtils::GetFloat(pElement, "limiterhold", m_limiterHold, 0.0f, 100.0f);
     XMLUtils::GetFloat(pElement, "limiterrelease", m_limiterRelease, 0.001f, 100.0f);
+
+    XMLUtils::GetFloat(pElement, "navsoundlevel", m_navSoundLevel, 0.0f, 1.0f);
+
   }
 
   pElement = pRootElement->FirstChildElement("karaoke");

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -104,6 +104,7 @@ class CAdvancedSettings
     CStdString m_audioTranscodeTo;
     float m_limiterHold;
     float m_limiterRelease;
+    float m_navSoundLevel;	// navigation sound volume relative to global system volume
 
     float m_videoSubsDelayRange;
     float m_videoAudioDelayRange;


### PR DESCRIPTION
The nav sounds are overwhelm with respect to video/music. The advancedsetting allows the user to set the nav sound volume with respect to the global volume. Refere former issue #475.
