### PR TITLE
Compatibility for older fribidi versions

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -141,12 +141,15 @@ endif
 LIB_DIRS=\
 	lib/cximage-6.0 \
 	lib/libexif \
-	lib/cmyth \
 	lib/libhdhomerun \
 	lib/libid3tag \
 	lib/libapetag \
 	lib/cpluff \
 	lib/xbmc-dll-symbols
+
+ifeq (@USE_MYSQL@,1)
+LIB_DIRS += lib/cmyth
+endif
 
 SS_DIRS=
 ifneq (@DISABLE_RSXS@,1)
@@ -286,8 +289,12 @@ else
 endif
 libexif: dllloader
 	$(MAKE) -C lib/libexif
+ifeq (@USE_MYSQL@,1)
 cmyth: dllloader
 	$(MAKE) -C lib/cmyth
+else
+cmyth:
+endif
 libhdhomerun: dllloader
 	$(MAKE) -C lib/libhdhomerun
 libid3tag: dllloader
@@ -315,6 +322,7 @@ imagelib: dllloader
 
 codecs: papcodecs dvdpcodecs
 libs: cmyth libhdhomerun libid3tag imagelib libexif system/libcpluff-@ARCH@.so
+
 externals: codecs libs visualizations screensavers
 
 xcode_depends: \

--- a/configure.in
+++ b/configure.in
@@ -381,6 +381,11 @@ AC_ARG_ENABLE([asap-codec],
   [use_asap=$enableval],
   [use_asap=no])
 
+AC_ARG_ENABLE([mysql],
+  [AS_HELP_STRING([--disable-mysql],
+  [disable mysql])],
+  [use_mysql=$enableval],
+  [use_mysql=yes])
 AC_ARG_ENABLE([webserver],
   [AS_HELP_STRING([--disable-webserver],
   [disable webserver])],
@@ -733,14 +738,17 @@ else
 fi
 
 # platform common libraries
-AC_CHECK_PROG(MYSQL_CONFIG, mysql_config, "yes", "no")
-if test $MYSQL_CONFIG = "yes"; then
-  INCLUDES="$INCLUDES `mysql_config --include`"
-  MYSQL_LIBS=`mysql_config --libs`
-  LIBS="$LIBS $MYSQL_LIBS"
-  AC_SUBST(MYSQL_LIBS)
-else
-  AC_MSG_ERROR($missing_program)
+if test "$use_mysql" = "yes"; then
+  AC_CHECK_PROG(MYSQL_CONFIG, mysql_config, "yes", "no")
+  if test $MYSQL_CONFIG = "yes"; then
+    AC_DEFINE([HAVE_MYSQL],[1],["Define to 1 if you have the `mysql' library (-lmysqlclient)."])
+    INCLUDES="$INCLUDES `mysql_config --include`"
+    MYSQL_LIBS=`mysql_config --libs`
+    LIBS="$LIBS $MYSQL_LIBS"
+    AC_SUBST(MYSQL_LIBS)
+  else
+    AC_MSG_ERROR($missing_program)
+  fi
 fi
 AC_CHECK_HEADER([ass/ass.h],, AC_MSG_ERROR($missing_library))
 AC_CHECK_HEADER([mpeg2dec/mpeg2.h],, AC_MSG_ERROR($missing_library))
@@ -779,7 +787,9 @@ AC_CHECK_LIB([lzo2],        [main],, AC_MSG_ERROR($missing_library))
 AC_CHECK_LIB([z],           [main],, AC_MSG_ERROR($missing_library))
 AC_CHECK_LIB([crypto],      [main],, AC_MSG_ERROR($missing_library))
 AC_CHECK_LIB([ssl],         [main],, AC_MSG_ERROR($missing_library))
+if test "$use_mysql" = "yes"; then
 AC_CHECK_LIB([mysqlclient], [main],, AC_MSG_ERROR($missing_library))
+fi
 AC_CHECK_LIB([ssh],         [sftp_tell64],, AC_MSG_RESULT([Could not find suitable version of libssh]))
 AC_CHECK_LIB([bluetooth],   [hci_devid],, AC_MSG_RESULT([Could not find suitable version of libbluetooth]))
 AC_CHECK_LIB([yajl],        [main],, AC_MSG_ERROR($missing_library))
@@ -1879,6 +1889,13 @@ else
   final_message="$final_message\n  ASAP Codec:\tNo"
 fi
 
+if test "$use_mysql" = "yes"; then
+  final_message="$final_message\n  MySQL:\tYes"
+  USE_MYSQL=1
+else
+  final_message="$final_message\n  MySQL:\tNo"
+  USE_MYSQL=0
+fi
 if test "$use_webserver" = "yes"; then
   final_message="$final_message\n  Webserver:\tYes"
   USE_WEB_SERVER=1
@@ -2093,6 +2110,7 @@ AC_SUBST(USE_AIRTUNES)
 AC_SUBST(USE_LIBUDEV)
 AC_SUBST(USE_LIBUSB)
 AC_SUBST(USE_LIBCEC)
+AC_SUBST(USE_MYSQL)
 AC_SUBST(USE_WEB_SERVER)
 
 

--- a/xbmc/dbwrappers/Database.cpp
+++ b/xbmc/dbwrappers/Database.cpp
@@ -29,9 +29,11 @@
 #include "utils/AutoPtrHandle.h"
 #include "utils/log.h"
 #include "utils/URIUtils.h"
-#include "mysqldataset.h"
 #include "sqlitedataset.h"
 
+#ifdef HAVE_MYSQL
+#include "mysqldataset.h"
+#endif
 
 using namespace AUTOPTR;
 using namespace dbiplus;
@@ -363,10 +365,12 @@ bool CDatabase::Connect(const DatabaseSettings &dbSettings, bool create)
   {
     m_pDB.reset( new SqliteDatabase() ) ;
   }
+#ifdef HAVE_MYSQL
   else if (dbSettings.type.Equals("mysql"))
   {
     m_pDB.reset( new MysqlDatabase() ) ;
   }
+#endif
   else
   {
     CLog::Log(LOGERROR, "Unable to determine database type: %s", dbSettings.type.c_str());

--- a/xbmc/dbwrappers/mysqldataset.cpp
+++ b/xbmc/dbwrappers/mysqldataset.cpp
@@ -19,6 +19,7 @@
  *
  */
 
+#ifdef HAVE_MYSQL
 #include <iostream>
 #include <string>
 #include <set>
@@ -1598,3 +1599,4 @@ void MysqlDataset::interrupt() {
 
 }//namespace
 
+#endif //HAVE_MYSQL

--- a/xbmc/dbwrappers/mysqldataset.h
+++ b/xbmc/dbwrappers/mysqldataset.h
@@ -19,6 +19,7 @@
  *
  */
 
+#ifdef HAVE_MYSQL
 #ifndef _MYSQLDATASET_H
 #define _MYSQLDATASET_H
 
@@ -174,3 +175,4 @@ or insert() operations default = false) */
 };
 } //namespace
 #endif
+#endif //HAVE_MYSQL

--- a/xbmc/system.h
+++ b/xbmc/system.h
@@ -80,6 +80,9 @@
   #define HAS_AIRTUNES
 #endif
 
+#ifdef HAVE_MYSQL
+  #define HAS_MYSQL
+#endif
 /**********************
  * Non-free Components
  **********************/

--- a/xbmc/utils/CharsetConverter.cpp
+++ b/xbmc/utils/CharsetConverter.cpp
@@ -60,7 +60,11 @@ static iconv_t m_iconvUtf16LEtoUtf8              = (iconv_t)-1;
 static iconv_t m_iconvUtf8toW                    = (iconv_t)-1;
 static iconv_t m_iconvUcs2CharsetToUtf8          = (iconv_t)-1;
 
+#if defined(FRIBIDI_CHAR_SET_NOT_FOUND)
 static FriBidiCharSet m_stringFribidiCharset     = FRIBIDI_CHAR_SET_NOT_FOUND;
+#else /* compatibility to older version */
+static FriBidiCharSet m_stringFribidiCharset     = FRIBIDI_CHARSET_NOT_FOUND;
+#endif
 
 static CCriticalSection            m_critSection;
 
@@ -69,6 +73,7 @@ static struct SFribidMapping
   FriBidiCharSet name;
   const char*    charset;
 } g_fribidi[] = {
+#if defined(FRIBIDI_CHAR_SET_NOT_FOUND)
   { FRIBIDI_CHAR_SET_ISO8859_6, "ISO-8859-6"   }
 , { FRIBIDI_CHAR_SET_ISO8859_8, "ISO-8859-8"   }
 , { FRIBIDI_CHAR_SET_CP1255   , "CP1255"       }
@@ -76,6 +81,15 @@ static struct SFribidMapping
 , { FRIBIDI_CHAR_SET_CP1256   , "CP1256"       }
 , { FRIBIDI_CHAR_SET_CP1256   , "Windows-1256" }
 , { FRIBIDI_CHAR_SET_NOT_FOUND, NULL           }
+#else /* compatibility to older version */
+  { FRIBIDI_CHARSET_ISO8859_6, "ISO-8859-6"   }
+, { FRIBIDI_CHARSET_ISO8859_8, "ISO-8859-8"   }
+, { FRIBIDI_CHARSET_CP1255   , "CP1255"       }
+, { FRIBIDI_CHARSET_CP1255   , "Windows-1255" }
+, { FRIBIDI_CHARSET_CP1256   , "CP1256"       }
+, { FRIBIDI_CHARSET_CP1256   , "Windows-1256" }
+, { FRIBIDI_CHARSET_NOT_FOUND, NULL           }
+#endif
 };
 
 static struct SCharsetMapping
@@ -376,8 +390,11 @@ void CCharsetConverter::reset(void)
   ICONV_SAFE_CLOSE(m_iconvUtf8toW);
   ICONV_SAFE_CLOSE(m_iconvUcs2CharsetToUtf8);
 
-
+#if defined(FRIBIDI_CHAR_SET_NOT_FOUND) /* compatibility to older version */
   m_stringFribidiCharset = FRIBIDI_CHAR_SET_NOT_FOUND;
+#else
+  m_stringFribidiCharset = FRIBIDI_CHARSET_NOT_FOUND;
+#endif
 
   CStdString strCharset=g_langInfo.GetGuiCharSet();
   for(SFribidMapping *c = g_fribidi; c->charset; c++)
@@ -396,7 +413,11 @@ void CCharsetConverter::utf8ToW(const CStdStringA& utf8String, CStdStringW &wStr
   {
     CStdStringA strFlipped;
     FriBidiCharType charset = forceLTRReadingOrder ? FRIBIDI_TYPE_LTR : FRIBIDI_TYPE_PDF;
+#if defined(FRIBIDI_CHAR_SET_NOT_FOUND)
     logicalToVisualBiDi(utf8String, strFlipped, FRIBIDI_CHAR_SET_UTF8, charset, bWasFlipped);
+#else /* compatibility to older version */
+    logicalToVisualBiDi(utf8String, strFlipped, FRIBIDI_CHARSET_UTF8, charset, bWasFlipped);
+#endif
     CSingleLock lock(m_critSection);
     convert(m_iconvUtf8toW,sizeof(wchar_t),UTF8_SOURCE,WCHAR_CHARSET,strFlipped,wString);
   }
@@ -674,5 +695,9 @@ bool CCharsetConverter::isValidUtf8(const CStdString& str)
 
 void CCharsetConverter::utf8logicalToVisualBiDi(const CStdStringA& strSource, CStdStringA& strDest)
 {
+#if defined(FRIBIDI_CHAR_SET_NOT_FOUND)
   logicalToVisualBiDi(strSource, strDest, FRIBIDI_CHAR_SET_UTF8, FRIBIDI_TYPE_RTL);
+#else /* compatibility to older version */
+  logicalToVisualBiDi(strSource, strDest, FRIBIDI_CHARSET_UTF8, FRIBIDI_TYPE_RTL);
+#endif
 }


### PR DESCRIPTION
This path adds compatibility for older fribidi versions.
Basically just some defines that were named a little bit different.

For example version 0.10.4 uses these old define names.

This is a commit in regards to my project to port xbmc to stm sh4 cpu arch based soc´s like sti7111/sti7105 using OpenGLESv1.

For that I have to use an older fribidi version out of compatibility concerns to the existing used UI`s like Neutrino and Enigma2.
