### PR TITLE
jsonrpc: make use of the new sorting and limiting functionality

### DIFF
--- a/xbmc/filesystem/SmartPlaylistDirectory.cpp
+++ b/xbmc/filesystem/SmartPlaylistDirectory.cpp
@@ -102,7 +102,7 @@ namespace XFILE
         CStdString whereClause = playlist.GetWhereClause(db, playlists);
         if (!whereClause.empty())
           whereClause = "WHERE " + whereClause;
-        success = db.GetSortedAlbums("musicdb://3/", sorting, items, whereClause);
+        success = db.GetAlbumsByWhere("musicdb://3/", whereClause, "", items, sorting);
         items.SetContent("albums");
         db.Close();
       }
@@ -125,7 +125,7 @@ namespace XFILE
         if (!whereClause.empty())
           whereClause = "WHERE " + whereClause;
 
-        success = db.GetSortedSongs("", sorting, items, whereClause);
+        success = db.GetSongsByWhere("", whereClause, items, sorting);
         items.SetContent("songs");
         db.Close();
       }

--- a/xbmc/interfaces/json-rpc/FileItemHandler.cpp
+++ b/xbmc/interfaces/json-rpc/FileItemHandler.cpp
@@ -175,19 +175,30 @@ void CFileItemHandler::FillDetails(ISerializable* info, CFileItemPtr item, const
   }
 }
 
-void CFileItemHandler::HandleFileItemList(const char *ID, bool allowFile, const char *resultname, CFileItemList &items, const CVariant &parameterObject, CVariant &result)
+void CFileItemHandler::HandleFileItemList(const char *ID, bool allowFile, const char *resultname, CFileItemList &items, const CVariant &parameterObject, CVariant &result, bool sortLimit /* = true */)
 {
-  int size  = items.Size();
+  HandleFileItemList(ID, allowFile, resultname, items, parameterObject, result, items.Size(), sortLimit);
+}
+
+void CFileItemHandler::HandleFileItemList(const char *ID, bool allowFile, const char *resultname, CFileItemList &items, const CVariant &parameterObject, CVariant &result, int size, bool sortLimit /* = true */)
+{
   int start = (int)parameterObject["limits"]["start"].asInteger();
   int end   = (int)parameterObject["limits"]["end"].asInteger();
   end = (end <= 0 || end > size) ? size : end;
   start = start > end ? end : start;
 
-  Sort(items, parameterObject["sort"]);
+  if (sortLimit)
+    Sort(items, parameterObject["sort"]);
 
   result["limits"]["start"] = start;
   result["limits"]["end"]   = end;
   result["limits"]["total"] = size;
+
+  if (!sortLimit)
+  {
+    start = 0;
+    end = items.Size();
+  }
 
   for (int i = start; i < end; i++)
   {
@@ -329,6 +340,99 @@ bool CFileItemHandler::FillFileItemList(const CVariant &parameterObject, CFileIt
   }
 
   return (list.Size() > 0);
+}
+
+bool CFileItemHandler::ParseSorting(const CVariant &parameterObject, SortBy &sortBy, SortOrder &sortOrder, SortAttribute &sortAttributes)
+{
+  CStdString method = parameterObject["sort"]["method"].asString();
+  CStdString order = parameterObject["sort"]["order"].asString();
+  method.ToLower();
+  order.ToLower();
+
+  sortAttributes = SortAttributeNone;
+  if (parameterObject["sort"]["ignorearticle"].asBoolean())
+    sortAttributes = SortAttributeIgnoreArticle;
+  else
+    sortAttributes = SortAttributeNone;
+
+  if (order.Equals("ascending"))
+    sortOrder = SortOrderAscending;
+  else if (order.Equals("descending"))
+    sortOrder = SortOrderDescending;
+  else
+    return false;
+
+  if (method.Equals("none"))
+    sortBy = SortByNone;
+  else if (method.Equals("label"))
+    sortBy = SortByLabel;
+  else if (method.Equals("date"))
+    sortBy = SortByDate;
+  else if (method.Equals("size"))
+    sortBy = SortBySize;
+  else if (method.Equals("file"))
+    sortBy = SortByFile;
+  else if (method.Equals("drivetype"))
+    sortBy = SortByDriveType;
+  else if (method.Equals("track"))
+    sortBy = SortByTrackNumber;
+  else if (method.Equals("duration") ||
+           method.Equals("videoruntime"))
+    sortBy = SortByTime;
+  else if (method.Equals("title") ||
+           method.Equals("videotitle"))
+    sortBy = SortByTitle;
+  else if (method.Equals("artist"))
+    sortBy = SortByArtist;
+  else if (method.Equals("album"))
+    sortBy = SortByAlbum;
+  else if (method.Equals("genre"))
+    sortBy = SortByGenre;
+  else if (method.Equals("country"))
+    sortBy = SortByCountry;
+  else if (method.Equals("year"))
+    sortBy = SortByYear;
+  else if (method.Equals("videorating") ||
+           method.Equals("songrating"))
+    sortBy = SortByRating;
+  else if (method.Equals("dateadded"))
+    sortBy = SortByDateAdded;
+  else if (method.Equals("programcount"))
+    sortBy = SortByProgramCount;
+  else if (method.Equals("playlist"))
+    sortBy = SortByPlaylistOrder;
+  else if (method.Equals("episode"))
+    sortBy = SortByEpisodeNumber;
+  else if (method.Equals("sorttitle"))
+    sortBy = SortBySortTitle;
+  else if (method.Equals("productioncode"))
+    sortBy = SortByProductionCode;
+  else if (method.Equals("mpaarating"))
+    sortBy = SortByMPAA;
+  else if (method.Equals("studio"))
+    sortBy = SortByStudio;
+  else if (method.Equals("fullpath"))
+    sortBy = SortByPath;
+  else if (method.Equals("lastplayed"))
+    sortBy = SortByLastPlayed;
+  else if (method.Equals("playcount"))
+    sortBy = SortByPlaycount;
+  else if (method.Equals("listeners"))
+    sortBy = SortByListeners;
+  else if (method.Equals("unsorted"))
+    sortBy = SortByRandom;
+  else if (method.Equals("bitrate"))
+    sortBy = SortByBitrate;
+  else
+    return false;
+
+  return true;
+}
+
+void CFileItemHandler::ParseLimits(const CVariant &parameterObject, int &limitStart, int &limitEnd)
+{
+  limitStart = (int)parameterObject["limits"]["start"].asInteger();
+  limitEnd = (int)parameterObject["limits"]["end"].asInteger();
 }
 
 bool CFileItemHandler::ParseSortMethods(const CStdString &method, const bool &ignorethe, const CStdString &order, SORT_METHOD &sortmethod, SortOrder &sortorder)

--- a/xbmc/interfaces/json-rpc/FileItemHandler.h
+++ b/xbmc/interfaces/json-rpc/FileItemHandler.h
@@ -31,10 +31,14 @@ namespace JSONRPC
   {
   protected:
     static void FillDetails(ISerializable* info, CFileItemPtr item, const CVariant& fields, CVariant &result);
-    static void HandleFileItemList(const char *ID, bool allowFile, const char *resultname, CFileItemList &items, const CVariant &parameterObject, CVariant &result);
+    static void HandleFileItemList(const char *ID, bool allowFile, const char *resultname, CFileItemList &items, const CVariant &parameterObject, CVariant &result, bool sortLimit = true);
+    static void HandleFileItemList(const char *ID, bool allowFile, const char *resultname, CFileItemList &items, const CVariant &parameterObject, CVariant &result, int size, bool sortLimit = true);
     static void HandleFileItem(const char *ID, bool allowFile, const char *resultname, CFileItemPtr item, const CVariant &parameterObject, const CVariant &validFields, CVariant &result, bool append = true);
 
     static bool FillFileItemList(const CVariant &parameterObject, CFileItemList &list);
+
+    static bool ParseSorting(const CVariant &parameterObject, SortBy &sortBy, SortOrder &sortOrder, SortAttribute &sortAttributes);
+    static void ParseLimits(const CVariant &parameterObject, int &limitStart, int &limitEnd);
   private:
     static bool ParseSortMethods(const CStdString &method, const bool &ignorethe, const CStdString &order, SORT_METHOD &sortmethod, SortOrder &sortorder);
     static void Sort(CFileItemList &items, const CVariant& parameterObject);

--- a/xbmc/interfaces/json-rpc/VideoLibrary.h
+++ b/xbmc/interfaces/json-rpc/VideoLibrary.h
@@ -20,6 +20,7 @@
  *
  */
 
+#include "utils/DatabaseUtils.h"
 #include "utils/StdString.h"
 #include "JSONRPC.h"
 #include "FileItemHandler.h"
@@ -69,6 +70,7 @@ namespace JSONRPC
     static bool FillFileItemList(const CVariant &parameterObject, CFileItemList &list);
 
   private:
+    static JSONRPC_STATUS GetVideos(MediaType mediaType, const CStdString &strBaseDir, const CVariant &parameterObject, CFileItemList &items, CVariant &result, CVideoDatabase &videodatabase);
     static JSONRPC_STATUS GetAdditionalMovieDetails(const CVariant &parameterObject, CFileItemList &items, CVariant &result, CVideoDatabase &videodatabase);
     static JSONRPC_STATUS GetAdditionalEpisodeDetails(const CVariant &parameterObject, CFileItemList &items, CVariant &result, CVideoDatabase &videodatabase);
     static JSONRPC_STATUS GetAdditionalMusicVideoDetails(const CVariant &parameterObject, CFileItemList &items, CVariant &result, CVideoDatabase &videodatabase);

--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -3093,6 +3093,8 @@ bool CMusicDatabase::GetAlbumsByWhere(const CStdString &baseDir, const CStdStrin
 
   try
   {
+    int total = -1;
+
     CStdString sql = "select * from albumview " + where;
     // Apply the limiting directly here if there's no special sorting but limiting
     CStdString whereLower = where;
@@ -3100,7 +3102,10 @@ bool CMusicDatabase::GetAlbumsByWhere(const CStdString &baseDir, const CStdStrin
     if (whereLower.find(" limit ") == string::npos &&
         sortDescription.sortBy == SortByNone &&
        (sortDescription.limitStart > 0 || sortDescription.limitEnd > 0))
+    {
+      total = (int)strtol(GetSingleValue("SELECT COUNT(1) FROM albumview " + where, m_pDS).c_str(), NULL, 10);
       sql += DatabaseUtils::BuildLimitClause(sortDescription.limitEnd, sortDescription.limitStart);
+    }
 
     CLog::Log(LOGDEBUG, "%s query: %s", __FUNCTION__, sql.c_str());
     // run query
@@ -3116,6 +3121,11 @@ bool CMusicDatabase::GetAlbumsByWhere(const CStdString &baseDir, const CStdStrin
       m_pDS->close();
       return false;
     }
+
+    // store the total value of items as a property
+    if (total < iRowsFound)
+      total = iRowsFound;
+    items.SetProperty("total", total);
     
     DatabaseResults results;
     results.reserve(iRowsFound);
@@ -3166,6 +3176,8 @@ bool CMusicDatabase::GetSongsByWhere(const CStdString &baseDir, const CStdString
   try
   {
     unsigned int time = XbmcThreads::SystemClockMillis();
+    int total = -1;
+
     // We don't use PrepareSQL here, as the WHERE clause is already formatted.
     CStdString strSQL = "select * from songview " + whereClause;
     // Apply the limiting directly here if there's no special sorting but limiting
@@ -3174,7 +3186,10 @@ bool CMusicDatabase::GetSongsByWhere(const CStdString &baseDir, const CStdString
     if (whereLower.find(" limit ") == string::npos &&
         sortDescription.sortBy == SortByNone &&
        (sortDescription.limitStart > 0 || sortDescription.limitEnd > 0))
+    {
+      total = (int)strtol(GetSingleValue("SELECT COUNT(1) FROM songview " + whereClause, m_pDS).c_str(), NULL, 10);
       strSQL += DatabaseUtils::BuildLimitClause(sortDescription.limitEnd, sortDescription.limitStart);
+    }
 
     CLog::Log(LOGDEBUG, "%s query = %s", __FUNCTION__, strSQL.c_str());
     // run query
@@ -3187,6 +3202,11 @@ bool CMusicDatabase::GetSongsByWhere(const CStdString &baseDir, const CStdString
       m_pDS->close();
       return false;
     }
+
+    // store the total value of items as a property
+    if (total < iRowsFound)
+      total = iRowsFound;
+    items.SetProperty("total", total);
     
     DatabaseResults results;
     results.reserve(iRowsFound);

--- a/xbmc/music/MusicDatabase.h
+++ b/xbmc/music/MusicDatabase.h
@@ -168,20 +168,17 @@ public:
   bool GetGenresNav(const CStdString& strBaseDir, CFileItemList& items);
   bool GetYearsNav(const CStdString& strBaseDir, CFileItemList& items);
   bool GetArtistsNav(const CStdString& strBaseDir, CFileItemList& items, int idGenre, bool albumArtistsOnly);
-  bool GetAlbumsNav(const CStdString& strBaseDir, CFileItemList& items, int idGenre, int idArtist, int start, int end);
+  bool GetAlbumsNav(const CStdString& strBaseDir, CFileItemList& items, int idGenre, int idArtist, int start, int end, const SortDescription &sortDescription = SortDescription());
   bool GetAlbumsByYear(const CStdString &strBaseDir, CFileItemList& items, int year);
-  bool GetSongsNav(const CStdString& strBaseDir, CFileItemList& items, int idGenre, int idArtist,int idAlbum);
+  bool GetSongsNav(const CStdString& strBaseDir, CFileItemList& items, int idGenre, int idArtist,int idAlbum, const SortDescription &sortDescription = SortDescription());
   bool GetSongsByYear(const CStdString& baseDir, CFileItemList& items, int year);
-  bool GetSongsByWhere(const CStdString &baseDir, const CStdString &whereClause, CFileItemList& items);
-  bool GetAlbumsByWhere(const CStdString &baseDir, const CStdString &where, const CStdString &order, CFileItemList &items);
+  bool GetSongsByWhere(const CStdString &baseDir, const CStdString &whereClause, CFileItemList& items, const SortDescription &sortDescription = SortDescription());
+  bool GetAlbumsByWhere(const CStdString &baseDir, const CStdString &where, const CStdString &order, CFileItemList &items, const SortDescription &sortDescription = SortDescription());
   bool GetArtistsByWhere(const CStdString& strBaseDir, const CStdString &where, CFileItemList& items);
   bool GetRandomSong(CFileItem* item, int& idSong, const CStdString& strWhere);
   int GetKaraokeSongsCount();
   int GetSongsCount(const CStdString& strWhere = "");
   unsigned int GetSongIDs(const CStdString& strWhere, std::vector<std::pair<int,int> > &songIDs);
-
-  bool GetSortedAlbums(const CStdString& strBaseDir, const SortDescription &sortDescription, CFileItemList& items, const CStdString &where = "");
-  bool GetSortedSongs(const CStdString& strBaseDir, const SortDescription &sortDescription, CFileItemList& items, const CStdString &where = "");
 
   bool GetAlbumPath(int idAlbum, CStdString &path);
   bool SaveAlbumThumb(int idAlbum, const CStdString &thumb);

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -5360,7 +5360,7 @@ bool CVideoDatabase::GetTvShowsByWhere(const CStdString& strBaseDir, const Filte
       }
     }
 
-    Stack(items, VIDEODB_CONTENT_TVSHOWS, !filter.order.empty());
+    Stack(items, VIDEODB_CONTENT_TVSHOWS, !filter.order.empty() || sortDescription.sortBy != SortByNone);
 
     // cleanup
     m_pDS->close();

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -5155,7 +5155,9 @@ bool CVideoDatabase::GetMoviesByWhere(const CStdString& strBaseDir, const Filter
     if (NULL == m_pDB.get()) return false;
     if (NULL == m_pDS.get()) return false;
 
-    CStdString strSQL = PrepareSQL("select %s from movieview ", !filter.fields.empty() ? filter.fields.c_str() : "*");
+    int total = -1;
+
+    CStdString strSQL;
     CFileItemList setItems;
     if (fetchSets && g_guiSettings.GetBool("videolibrary.groupmoviesets"))
     {
@@ -5204,17 +5206,27 @@ bool CVideoDatabase::GetMoviesByWhere(const CStdString& strBaseDir, const Filter
       strSQL += " ORDER BY " + filter.order;
     if (!filter.limit.empty())
       strSQL += " LIMIT " + filter.limit;
-    // Apply the limiting directly here if there's no special sorting but limiting
     else if (sortDescription.sortBy == SortByNone &&
             (sortDescription.limitStart > 0 || sortDescription.limitEnd > 0))
+    {
+      total = (int)strtol(GetSingleValue(PrepareSQL(strSQL.c_str(), "COUNT(1)"), m_pDS).c_str(), NULL, 10);
       strSQL += DatabaseUtils::BuildLimitClause(sortDescription.limitEnd, sortDescription.limitStart);
+    }
+
+    strSQL = PrepareSQL("select %s from movieview ", !filter.fields.empty() ? filter.fields.c_str() : "*") + strSQL;
 
     int iRowsFound = RunQuery(strSQL);
     if (iRowsFound <= 0 && setItems.Size() == 0)
       return iRowsFound == 0;
+
+    iRowsFound += setItems.Size();
+    // store the total value of items as a property
+    if (total < iRowsFound)
+      total = iRowsFound;
+    items.SetProperty("total", total);
     
     DatabaseResults results;
-    results.reserve(iRowsFound + setItems.Size());
+    results.reserve(iRowsFound);
 
     // Add the previously retrieved sets
     for (int index = 0; index < setItems.Size(); index++)
@@ -5305,7 +5317,9 @@ bool CVideoDatabase::GetTvShowsByWhere(const CStdString& strBaseDir, const Filte
     if (NULL == m_pDB.get()) return false;
     if (NULL == m_pDS.get()) return false;
 
-    CStdString strSQL = PrepareSQL("SELECT %s FROM tvshowview ", !filter.fields.empty() ? filter.fields.c_str() : "*");
+    int total = -1;
+
+    CStdString strSQL;
     if (!filter.join.empty())
       strSQL += filter.join;
     if (!filter.where.empty())
@@ -5319,11 +5333,21 @@ bool CVideoDatabase::GetTvShowsByWhere(const CStdString& strBaseDir, const Filte
     // Apply the limiting directly here if there's no special sorting but limiting
     else if (sortDescription.sortBy == SortByNone &&
             (sortDescription.limitStart > 0 || sortDescription.limitEnd > 0))
+    {
+      total = (int)strtol(GetSingleValue(PrepareSQL(strSQL.c_str(), "COUNT(1)"), m_pDS).c_str(), NULL, 10);
       strSQL += DatabaseUtils::BuildLimitClause(sortDescription.limitEnd, sortDescription.limitStart);
+    }
+
+    strSQL = PrepareSQL("SELECT %s FROM tvshowview ", !filter.fields.empty() ? filter.fields.c_str() : "*") + strSQL;
 
     int iRowsFound = RunQuery(strSQL);
     if (iRowsFound <= 0)
       return iRowsFound == 0;
+
+    // store the total value of items as a property
+    if (total < iRowsFound)
+      total = iRowsFound;
+    items.SetProperty("total", total);
     
     DatabaseResults results;
     results.reserve(iRowsFound);
@@ -5618,7 +5642,9 @@ bool CVideoDatabase::GetEpisodesByWhere(const CStdString& strBaseDir, const Filt
     if (NULL == m_pDB.get()) return false;
     if (NULL == m_pDS.get()) return false;
 
-    CStdString strSQL = PrepareSQL("select %s from episodeview ", !filter.fields.empty() ? filter.fields.c_str() : "*");
+    int total = -1;
+
+    CStdString strSQL;
     if (!filter.join.empty())
       strSQL += filter.join;
     if (!filter.where.empty())
@@ -5632,11 +5658,21 @@ bool CVideoDatabase::GetEpisodesByWhere(const CStdString& strBaseDir, const Filt
     // Apply the limiting directly here if there's no special sorting but limiting
     else if (sortDescription.sortBy == SortByNone &&
             (sortDescription.limitStart > 0 || sortDescription.limitEnd > 0))
+    {
+      total = (int)strtol(GetSingleValue(PrepareSQL(strSQL.c_str(), "COUNT(1)"), m_pDS).c_str(), NULL, 10);
       strSQL += DatabaseUtils::BuildLimitClause(sortDescription.limitEnd, sortDescription.limitStart);
+    }
+
+    strSQL = PrepareSQL("select %s from episodeview ", !filter.fields.empty() ? filter.fields.c_str() : "*") + strSQL;
 
     int iRowsFound = RunQuery(strSQL);
     if (iRowsFound <= 0)
       return iRowsFound == 0;
+
+    // store the total value of items as a property
+    if (total < iRowsFound)
+      total = iRowsFound;
+    items.SetProperty("total", total);
     
     DatabaseResults results;
     results.reserve(iRowsFound);
@@ -6465,8 +6501,9 @@ bool CVideoDatabase::GetMusicVideosByWhere(const CStdString &baseDir, const Filt
     if (NULL == m_pDB.get()) return false;
     if (NULL == m_pDS.get()) return false;
 
-    // We don't use PrepareSQL here, as the WHERE clause is already formatted.
-    CStdString strSQL = PrepareSQL("select %s from musicvideoview ", !filter.fields.empty() ? filter.fields.c_str() : "*");;
+    int total = -1;
+
+    CStdString strSQL;
     if (!filter.join.empty())
       strSQL += filter.join;
     if (!filter.where.empty())
@@ -6480,11 +6517,21 @@ bool CVideoDatabase::GetMusicVideosByWhere(const CStdString &baseDir, const Filt
     // Apply the limiting directly here if there's no special sorting but limiting
     else if (sortDescription.sortBy == SortByNone &&
             (sortDescription.limitStart > 0 || sortDescription.limitEnd > 0))
+    {
+      total = (int)strtol(GetSingleValue(PrepareSQL(strSQL.c_str(), "COUNT(1)"), m_pDS).c_str(), NULL, 10);
       strSQL += DatabaseUtils::BuildLimitClause(sortDescription.limitEnd, sortDescription.limitStart);
+    }
+
+    strSQL = PrepareSQL("select %s from musicvideoview ", !filter.fields.empty() ? filter.fields.c_str() : "*") + strSQL;
 
     int iRowsFound = RunQuery(strSQL);
     if (iRowsFound <= 0)
       return iRowsFound == 0;
+
+    // store the total value of items as a property
+    if (total < iRowsFound)
+      total = iRowsFound;
+    items.SetProperty("total", total);
     
     DatabaseResults results;
     results.reserve(iRowsFound);

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -5083,19 +5083,19 @@ bool CVideoDatabase::GetSortedVideos(MediaType mediaType, const CStdString& strB
   switch (mediaType)
   {
   case MediaTypeMovie:
-    success = GetSortedMovies(strBaseDir, sorting, items, filter, fetchSets);
+    success = GetMoviesByWhere(strBaseDir, filter, items, fetchSets, sorting);
     break;
       
   case MediaTypeTvShow:
-    success = GetSortedTvShows(strBaseDir, sorting, items, filter);
+    success = GetTvShowsByWhere(strBaseDir, filter, items, sorting);
     break;
       
   case MediaTypeEpisode:
-    success = GetSortedEpisodes(strBaseDir, sorting, items, filter);
+    success = GetEpisodesByWhere(strBaseDir, filter, items, true, sorting);
     break;
       
   case MediaTypeMusicVideo:
-    success = GetSortedMusicVideos(strBaseDir, sorting, items, filter);
+    success = GetMusicVideosByWhere(strBaseDir, filter, items, true, sorting);
     break;
 
   default:
@@ -5145,99 +5145,7 @@ bool CVideoDatabase::GetMoviesNav(const CStdString& strBaseDir, CFileItemList& i
   return GetMoviesByWhere(strBaseDir, filter, items, idSet == -1);
 }
 
-bool CVideoDatabase::GetMoviesByWhere(const CStdString& strBaseDir, const Filter &filter, CFileItemList& items, bool fetchSets /* = false */)
-{
-  try
-  {
-    movieTime = 0;
-    castTime = 0;
-
-    if (NULL == m_pDB.get()) return false;
-    if (NULL == m_pDS.get()) return false;
-
-    CStdString strSQL = PrepareSQL("select %s from movieview ", !filter.fields.empty() ? filter.fields.c_str() : "*");
-    if (fetchSets && g_guiSettings.GetBool("videolibrary.groupmoviesets"))
-    {
-      // user wants sets (and we're not fetching a particular set node), so grab all sets that match this where clause first
-      Filter setsFilter;
-      if (!filter.where.empty() || !filter.join.empty())
-      {
-        setsFilter.where = "movieview.idMovie in (select movieview.idMovie from movieview ";
-        if (!filter.join.empty())
-          setsFilter.where += filter.join;
-        if (!filter.where.empty())
-          setsFilter.where += " WHERE " + filter.where;
-        setsFilter.where += ")";
-      }
-      GetSetsByWhere("videodb://1/7/", setsFilter, items);
-      CStdString movieSetsWhere;
-      if (items.Size() > 0)
-      {
-        movieSetsWhere = "movieview.idMovie NOT IN (SELECT idMovie FROM setlinkmovie s1 JOIN(SELECT idSet, COUNT(1) AS c FROM setlinkmovie GROUP BY idSet HAVING c>1) s2 ON s2.idSet=s1.idSet WHERE s1.idSet IN (";
-        for (int index = 0; index < items.Size(); index++)
-          movieSetsWhere.AppendFormat("%s%d", index > 0 ? "," : "", items[index]->GetVideoInfoTag()->m_iDbId);
-        movieSetsWhere += "))";
-      }
-      if (!filter.join.empty())
-        strSQL += filter.join;
-      if (!filter.where.empty())
-      {
-        strSQL += " WHERE (" + filter.where + ")";
-        if (!movieSetsWhere.empty())
-          strSQL += " AND " + movieSetsWhere;
-      }
-      else if (!movieSetsWhere.empty())
-        strSQL += " WHERE " + movieSetsWhere;
-    }
-    else
-    {
-      if (!filter.join.empty())
-        strSQL += filter.join;
-      if (!filter.where.empty())
-        strSQL += " WHERE " + filter.where;
-    }
-
-    if (!filter.group.empty())
-      strSQL += " GROUP BY " + filter.group;
-    if (filter.order.size())
-      strSQL += " ORDER BY " + filter.order;
-    if (!filter.limit.empty())
-      strSQL += " LIMIT " + filter.limit;
-
-    int iRowsFound = RunQuery(strSQL);
-    if (iRowsFound <= 0)
-      return iRowsFound == 0;
-
-    // get data from returned rows
-    items.Reserve(items.Size() + iRowsFound);
-    while (!m_pDS->eof())
-    {
-      CVideoInfoTag movie = GetDetailsForMovie(m_pDS);
-      if (g_settings.GetMasterProfile().getLockMode() == LOCK_MODE_EVERYONE ||
-          g_passwordManager.bMasterUser                                   ||
-          g_passwordManager.IsDatabasePathUnlocked(movie.m_strPath, g_settings.m_videoSources))
-      {
-        CFileItemPtr pItem(new CFileItem(movie));
-        CStdString path; path.Format("%s%ld", strBaseDir.c_str(), movie.m_iDbId);
-        pItem->SetPath(path);
-        pItem->SetOverlayImage(CGUIListItem::ICON_OVERLAY_UNWATCHED,movie.m_playCount > 0);
-        items.Add(pItem);
-      }
-      m_pDS->next();
-    }
-
-    // cleanup
-    m_pDS->close();
-    return true;
-  }
-  catch (...)
-  {
-    CLog::Log(LOGERROR, "%s failed", __FUNCTION__);
-  }
-  return false;
-}
-
-bool CVideoDatabase::GetSortedMovies(const CStdString& strBaseDir, const SortDescription &sortDescription, CFileItemList& items, const Filter &filter /* = Filter() */, bool fetchSets /* = false */)
+bool CVideoDatabase::GetMoviesByWhere(const CStdString& strBaseDir, const Filter &filter, CFileItemList& items, bool fetchSets /* = false */, const SortDescription &sortDescription /* = SortDescription() */)
 {
   try
   {
@@ -5388,75 +5296,7 @@ bool CVideoDatabase::GetTvShowsNav(const CStdString& strBaseDir, CFileItemList& 
   return GetTvShowsByWhere(strBaseDir, filter, items);
 }
 
-bool CVideoDatabase::GetTvShowsByWhere(const CStdString& strBaseDir, const Filter &filter, CFileItemList& items)
-{
-  try
-  {
-    movieTime = 0;
-
-    if (NULL == m_pDB.get()) return false;
-    if (NULL == m_pDS.get()) return false;
-
-    CStdString strSQL = PrepareSQL("SELECT %s FROM tvshowview ", !filter.fields.empty() ? filter.fields.c_str() : "*");
-    if (!filter.join.empty())
-      strSQL += filter.join;
-    if (!filter.where.empty())
-      strSQL += " WHERE " + filter.where;
-    if (!filter.group.empty())
-      strSQL += " GROUP BY " + filter.group;
-    if (!filter.order.empty())
-      strSQL += " ORDER BY " + filter.order;
-    if (!filter.limit.empty())
-      strSQL += " LIMIT " + filter.limit;
-    int iRowsFound = RunQuery(strSQL);
-    if (iRowsFound <= 0)
-      return iRowsFound == 0;
-
-    // get data from returned rows
-    items.Reserve(iRowsFound);
-
-    while (!m_pDS->eof())
-    {
-      int idShow = m_pDS->fv("tvshow.idShow").get_asInt();
-      int numSeasons = m_pDS->fv(VIDEODB_DETAILS_TVSHOW_NUM_SEASONS).get_asInt();
-
-      CVideoInfoTag movie = GetDetailsForTvShow(m_pDS, false);
-      if ((g_settings.GetMasterProfile().getLockMode() == LOCK_MODE_EVERYONE ||
-           g_passwordManager.bMasterUser                                     ||
-           g_passwordManager.IsDatabasePathUnlocked(movie.m_strPath, g_settings.m_videoSources)) &&
-          (!g_advancedSettings.m_bVideoLibraryHideEmptySeries || movie.m_iEpisode > 0))
-      {
-        CFileItemPtr pItem(new CFileItem(movie));
-        CStdString path; path.Format("%s%ld/", strBaseDir.c_str(), idShow);
-        pItem->SetPath(path);
-        pItem->m_dateTime = movie.m_premiered;
-        pItem->GetVideoInfoTag()->m_iYear = pItem->m_dateTime.GetYear();
-        pItem->SetProperty("totalseasons", numSeasons);
-        pItem->SetProperty("totalepisodes", movie.m_iEpisode);
-        pItem->SetProperty("numepisodes", movie.m_iEpisode); // will be changed later to reflect watchmode setting
-        pItem->SetProperty("watchedepisodes", movie.m_playCount);
-        pItem->SetProperty("unwatchedepisodes", movie.m_iEpisode - movie.m_playCount);
-        pItem->GetVideoInfoTag()->m_playCount = (movie.m_iEpisode == movie.m_playCount) ? 1 : 0;
-        pItem->SetOverlayImage(CGUIListItem::ICON_OVERLAY_UNWATCHED, (pItem->GetVideoInfoTag()->m_playCount > 0) && (pItem->GetVideoInfoTag()->m_iEpisode > 0));
-        items.Add(pItem);
-      }
-      m_pDS->next();
-    }
-
-    Stack(items, VIDEODB_CONTENT_TVSHOWS, !filter.order.empty());
-
-    // cleanup
-    m_pDS->close();
-    return true;
-  }
-  catch (...)
-  {
-    CLog::Log(LOGERROR, "%s failed", __FUNCTION__);
-  }
-  return false;
-}
-
-bool CVideoDatabase::GetSortedTvShows(const CStdString& strBaseDir, const SortDescription &sortDescription, CFileItemList& items, const Filter &filter /* = Filter() */)
+bool CVideoDatabase::GetTvShowsByWhere(const CStdString& strBaseDir, const Filter &filter, CFileItemList& items, const SortDescription &sortDescription /* = SortDescription() */)
 {
   try
   {
@@ -5709,7 +5549,7 @@ void CVideoDatabase::Stack(CFileItemList& items, VIDEODB_CONTENT_TYPE type, bool
   }
 }
 
-bool CVideoDatabase::GetEpisodesNav(const CStdString& strBaseDir, CFileItemList& items, int idGenre, int idYear, int idActor, int idDirector, int idShow, int idSeason)
+bool CVideoDatabase::GetEpisodesNav(const CStdString& strBaseDir, CFileItemList& items, int idGenre, int idYear, int idActor, int idDirector, int idShow, int idSeason, const SortDescription &sortDescription /* = SortDescription() */)
 {
   Filter filter;
   CStdString strIn;
@@ -5756,7 +5596,7 @@ bool CVideoDatabase::GetEpisodesNav(const CStdString& strBaseDir, CFileItemList&
   URIUtils::GetParentPath(strBaseDir,parent);
   URIUtils::GetParentPath(parent,grandParent);
 
-  bool ret = GetEpisodesByWhere(grandParent, filter, items);
+  bool ret = GetEpisodesByWhere(grandParent, filter, items, true, sortDescription);
 
   if (idSeason == -1 && idShow != -1)
   { // add any linked movies
@@ -5768,72 +5608,7 @@ bool CVideoDatabase::GetEpisodesNav(const CStdString& strBaseDir, CFileItemList&
   return ret;
 }
 
-bool CVideoDatabase::GetEpisodesByWhere(const CStdString& strBaseDir, const Filter &filter, CFileItemList& items, bool appendFullShowPath /* = true */)
-{
-  try
-  {
-    movieTime = 0;
-    castTime = 0;
-
-    if (NULL == m_pDB.get()) return false;
-    if (NULL == m_pDS.get()) return false;
-
-    CStdString strSQL = PrepareSQL("select %s from episodeview ", !filter.fields.empty() ? filter.fields.c_str() : "*");
-    if (!filter.join.empty())
-      strSQL += filter.join;
-    if (!filter.where.empty())
-      strSQL += " WHERE " + filter.where;
-    if (!filter.group.empty())
-      strSQL += " GROUP BY " + filter.group;
-    if (!filter.order.empty())
-      strSQL += " ORDER BY " + filter.order;
-    if (!filter.limit.empty())
-      strSQL += " LIMIT " + filter.limit;
-    int iRowsFound = RunQuery(strSQL);
-    if (iRowsFound <= 0)
-      return iRowsFound == 0;
-
-    // get data from returned rows
-    items.Reserve(iRowsFound);
-    CLabelFormatter formatter("%H. %T", "");
-    while (!m_pDS->eof())
-    {
-      int idEpisode = m_pDS->fv("idEpisode").get_asInt();
-      int idShow = m_pDS->fv("idShow").get_asInt();
-
-      CVideoInfoTag movie = GetDetailsForEpisode(m_pDS);
-      if (g_settings.GetMasterProfile().getLockMode() == LOCK_MODE_EVERYONE ||
-          g_passwordManager.bMasterUser                                     ||
-          g_passwordManager.IsDatabasePathUnlocked(movie.m_strPath, g_settings.m_videoSources))
-      {
-        CFileItemPtr pItem(new CFileItem(movie));
-        formatter.FormatLabel(pItem.get());
-        CStdString path;
-        if (appendFullShowPath)
-          path.Format("%s%ld/%ld/%ld",strBaseDir.c_str(), idShow, movie.m_iSeason,idEpisode);
-        else
-          path.Format("%s%ld",strBaseDir.c_str(), idEpisode);
-        pItem->SetPath(path);
-        pItem->SetOverlayImage(CGUIListItem::ICON_OVERLAY_UNWATCHED,movie.m_playCount > 0);
-        pItem->m_dateTime = movie.m_firstAired;
-        pItem->GetVideoInfoTag()->m_iYear = pItem->m_dateTime.GetYear();
-        items.Add(pItem);
-      }
-      m_pDS->next();
-    }
-
-    // cleanup
-    m_pDS->close();
-    return true;
-  }
-  catch (...)
-  {
-    CLog::Log(LOGERROR, "%s failed", __FUNCTION__);
-  }
-  return false;
-}
-
-bool CVideoDatabase::GetSortedEpisodes(const CStdString& strBaseDir, const SortDescription &sortDescription, CFileItemList& items, const Filter &filter /* = Filter() */, bool appendFullShowPath /* = true */)
+bool CVideoDatabase::GetEpisodesByWhere(const CStdString& strBaseDir, const Filter &filter, CFileItemList& items, bool appendFullShowPath /* = true */, const SortDescription &sortDescription /* = SortDescription() */)
 {
   try
   {
@@ -5912,7 +5687,7 @@ bool CVideoDatabase::GetSortedEpisodes(const CStdString& strBaseDir, const SortD
   return false;
 }
 
-bool CVideoDatabase::GetMusicVideosNav(const CStdString& strBaseDir, CFileItemList& items, int idGenre, int idYear, int idArtist, int idDirector, int idStudio, int idAlbum)
+bool CVideoDatabase::GetMusicVideosNav(const CStdString& strBaseDir, CFileItemList& items, int idGenre, int idYear, int idArtist, int idDirector, int idStudio, int idAlbum, const SortDescription &sortDescription /* = SortDescription() */)
 {
   Filter filter;
   if (idGenre != -1)
@@ -5946,7 +5721,7 @@ bool CVideoDatabase::GetMusicVideosNav(const CStdString& strBaseDir, CFileItemLi
       filter.where += " and " + str2;
   }
 
-  return GetMusicVideosByWhere(strBaseDir, filter, items);
+  return GetMusicVideosByWhere(strBaseDir, filter, items, true, sortDescription);
 }
 
 bool CVideoDatabase::GetRecentlyAddedMoviesNav(const CStdString& strBaseDir, CFileItemList& items, unsigned int limit)
@@ -6680,76 +6455,7 @@ void CVideoDatabase::GetMusicVideosByAlbum(const CStdString& strSearch, CFileIte
   }
 }
 
-bool CVideoDatabase::GetMusicVideosByWhere(const CStdString &baseDir, const Filter &filter, CFileItemList &items, bool checkLocks /*= true*/)
-{
-  try
-  {
-    unsigned int time = XbmcThreads::SystemClockMillis();
-    movieTime = 0;
-    castTime = 0;
-
-    if (NULL == m_pDB.get()) return false;
-    if (NULL == m_pDS.get()) return false;
-
-    // We don't use PrepareSQL here, as the WHERE clause is already formatted.
-    CStdString strSQL = PrepareSQL("select %s from musicvideoview ", !filter.fields.empty() ? filter.fields.c_str() : "*");;
-    if (!filter.join.empty())
-      strSQL += filter.join;
-    if (!filter.where.empty())
-      strSQL += " WHERE " + filter.where;
-    if (!filter.group.empty())
-      strSQL += " GROUP BY " + filter.group;
-    if (!filter.order.empty())
-      strSQL += " ORDER BY " + filter.order;
-    if (!filter.limit.empty())
-      strSQL += " LIMIT " + filter.limit;
-    CLog::Log(LOGDEBUG, "%s query = %s", __FUNCTION__, strSQL.c_str());
-
-    // run query
-    if (!m_pDS->query(strSQL.c_str()))
-      return false;
-    CLog::Log(LOGDEBUG, "%s time for actual SQL query = %d", __FUNCTION__, XbmcThreads::SystemClockMillis() - time); time = XbmcThreads::SystemClockMillis();
-
-    int iRowsFound = m_pDS->num_rows();
-    if (iRowsFound == 0)
-    {
-      m_pDS->close();
-      return false;
-    }
-
-    // get data from returned rows
-    items.Reserve(iRowsFound);
-    // get songs from returned subtable
-    while (!m_pDS->eof())
-    {
-      int idMVideo = m_pDS->fv("idMVideo").get_asInt();
-      CVideoInfoTag musicvideo = GetDetailsForMusicVideo(m_pDS);
-      if (!checkLocks || g_settings.GetMasterProfile().getLockMode() == LOCK_MODE_EVERYONE || g_passwordManager.bMasterUser ||
-          g_passwordManager.IsDatabasePathUnlocked(musicvideo.m_strPath,g_settings.m_videoSources))
-      {
-        CFileItemPtr item(new CFileItem(musicvideo));
-        CStdString path; path.Format("%s%ld",baseDir,idMVideo);
-        item->SetPath(path);
-        item->SetOverlayImage(CGUIListItem::ICON_OVERLAY_UNWATCHED,musicvideo.m_playCount > 0);
-        items.Add(item);
-      }
-      m_pDS->next();
-    }
-
-    CLog::Log(LOGDEBUG, "%s time to retrieve from dataset = %d", __FUNCTION__, XbmcThreads::SystemClockMillis() - time); time = XbmcThreads::SystemClockMillis();
-
-    // cleanup
-    m_pDS->close();
-    return true;
-  }
-  catch (...)
-  {
-    CLog::Log(LOGERROR, "%s failed", __FUNCTION__);
-  }
-  return false;
-}
-
-bool CVideoDatabase::GetSortedMusicVideos(const CStdString& strBaseDir, const SortDescription &sortDescription, CFileItemList& items, const Filter &filter /* = Filter() */, bool checkLocks /* = true */)
+bool CVideoDatabase::GetMusicVideosByWhere(const CStdString &baseDir, const Filter &filter, CFileItemList &items, bool checkLocks /*= true*/, const SortDescription &sortDescription /* = SortDescription() */)
 {
   try
   {
@@ -6799,7 +6505,7 @@ bool CVideoDatabase::GetSortedMusicVideos(const CStdString& strBaseDir, const So
           g_passwordManager.IsDatabasePathUnlocked(musicvideo.m_strPath, g_settings.m_videoSources))
       {
         CFileItemPtr item(new CFileItem(musicvideo));
-        CStdString path; path.Format("%s%ld", strBaseDir, record->at(0).get_asInt());
+        CStdString path; path.Format("%s%ld", baseDir, record->at(0).get_asInt());
         item->SetPath(path);
         item->SetOverlayImage(CGUIListItem::ICON_OVERLAY_UNWATCHED, musicvideo.m_playCount > 0);
         items.Add(item);

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -583,8 +583,8 @@ public:
   bool GetMoviesNav(const CStdString& strBaseDir, CFileItemList& items, int idGenre=-1, int idYear=-1, int idActor=-1, int idDirector=-1, int idStudio=-1, int idCountry=-1, int idSet=-1);
   bool GetTvShowsNav(const CStdString& strBaseDir, CFileItemList& items, int idGenre=-1, int idYear=-1, int idActor=-1, int idDirector=-1, int idStudio=-1);
   bool GetSeasonsNav(const CStdString& strBaseDir, CFileItemList& items, int idActor=-1, int idDirector=-1, int idGenre=-1, int idYear=-1, int idShow=-1);
-  bool GetEpisodesNav(const CStdString& strBaseDir, CFileItemList& items, int idGenre=-1, int idYear=-1, int idActor=-1, int idDirector=-1, int idShow=-1, int idSeason=-1);
-  bool GetMusicVideosNav(const CStdString& strBaseDir, CFileItemList& items, int idGenre=-1, int idYear=-1, int idArtist=-1, int idDirector=-1, int idStudio=-1, int idAlbum=-1);
+  bool GetEpisodesNav(const CStdString& strBaseDir, CFileItemList& items, int idGenre=-1, int idYear=-1, int idActor=-1, int idDirector=-1, int idShow=-1, int idSeason=-1, const SortDescription &sortDescription = SortDescription());
+  bool GetMusicVideosNav(const CStdString& strBaseDir, CFileItemList& items, int idGenre=-1, int idYear=-1, int idArtist=-1, int idDirector=-1, int idStudio=-1, int idAlbum=-1, const SortDescription &sortDescription = SortDescription());
   
   bool GetRecentlyAddedMoviesNav(const CStdString& strBaseDir, CFileItemList& items, unsigned int limit=0);
   bool GetRecentlyAddedEpisodesNav(const CStdString& strBaseDir, CFileItemList& items, unsigned int limit=0);
@@ -633,18 +633,14 @@ public:
   bool ImportArtFromXML(const TiXmlNode *node, std::map<std::string, std::string> &artwork);
 
   // smart playlists and main retrieval work in these functions
-  bool GetMoviesByWhere(const CStdString& strBaseDir, const Filter &filter, CFileItemList& items, bool fetchSets = false);
+  bool GetMoviesByWhere(const CStdString& strBaseDir, const Filter &filter, CFileItemList& items, bool fetchSets = false, const SortDescription &sortDescription = SortDescription());
   bool GetSetsByWhere(const CStdString& strBaseDir, const Filter &filter, CFileItemList& items);
-  bool GetTvShowsByWhere(const CStdString& strBaseDir, const Filter &filter, CFileItemList& items);
-  bool GetEpisodesByWhere(const CStdString& strBaseDir, const Filter &filter, CFileItemList& items, bool appendFullShowPath = true);
-  bool GetMusicVideosByWhere(const CStdString &baseDir, const Filter &filter, CFileItemList& items, bool checkLocks = true);
+  bool GetTvShowsByWhere(const CStdString& strBaseDir, const Filter &filter, CFileItemList& items, const SortDescription &sortDescription = SortDescription());
+  bool GetEpisodesByWhere(const CStdString& strBaseDir, const Filter &filter, CFileItemList& items, bool appendFullShowPath = true, const SortDescription &sortDescription = SortDescription());
+  bool GetMusicVideosByWhere(const CStdString &baseDir, const Filter &filter, CFileItemList& items, bool checkLocks = true, const SortDescription &sortDescription = SortDescription());
   
   // retrieve sorted and limited items
   bool GetSortedVideos(MediaType mediaType, const CStdString& strBaseDir, const SortDescription &sortDescription, CFileItemList& items, const Filter &filter = Filter(), bool fetchSets = false);
-  bool GetSortedMovies(const CStdString& strBaseDir, const SortDescription &sortDescription, CFileItemList& items, const Filter &filter = Filter(), bool fetchSets = false);
-  bool GetSortedTvShows(const CStdString& strBaseDir, const SortDescription &sortDescription, CFileItemList& items, const Filter &filter = Filter());
-  bool GetSortedEpisodes(const CStdString& strBaseDir, const SortDescription &sortDescription, CFileItemList& items, const Filter &filter = Filter(), bool appendFullShowPath = true);
-  bool GetSortedMusicVideos(const CStdString& strBaseDir, const SortDescription &sortDescription, CFileItemList& items, const Filter &filter = Filter(), bool checkLocks = true);
 
   // partymode
   int GetMusicVideoCount(const CStdString& strWhere);


### PR DESCRIPTION
This PR makes use of the new sorting and limiting functionality introduced by myself two weeks or so ago in JSON-RPC. It has the advantage that especially any limit constraints on a listing request (e.g. GetMovies) will speed up the whole process of retrieving and returning items a lot. Up until now JSON-RPC always retrieved all full-blown CFileItem objects for all the items, then did the sorting and then the limiting. With the new sorting and limiting functionality all this is already done in the database layer and JSON-RPC only retrieves the CFileItem objects that it really needs. So now JSON-RPC clients can take pagination into account as a way to minimize waiting time on loading a long list of items. Before the request time didn't decrease (significantly) when only 10 out of 1000 items were retrieved but with these changes it will decrease drastically.

Furthermore I have done some cleanup work in CVideoDatabase and CMusicDatabase by merging GetFooByWhere() and GetSortedFoo() into GetFooByWhere(). So now there's no extra method in case we want to sort in the database layer. This saves quite some duplicate code.
There's also a fix for tvshow retrieval which I didn't notice until I played around with the sorting through JSON-RPC. It doesn't cause any problem in current master but it did for the changes I made to JSON-RPC.
