### PR TITLE
fix fetching playcount for plugin listings with content set

### DIFF
--- a/xbmc/video/windows/GUIWindowVideoNav.cpp
+++ b/xbmc/video/windows/GUIWindowVideoNav.cpp
@@ -361,11 +361,16 @@ void CGUIWindowVideoNav::LoadVideoInfo(CFileItemList &items)
 {
   // TODO: this could possibly be threaded as per the music info loading,
   //       we could also cache the info
-  if (!items.GetContent().IsEmpty())
-    return; // don't load for listings that have content set
+  if (!items.GetContent().IsEmpty() && !items.IsPlugin())
+    return; // don't load for listings that have content set and weren't created from plugins
 
-  CStdString content = m_database.GetContentForPath(items.GetPath());
-  items.SetContent(content.IsEmpty() ? "files" : content);
+  CStdString content = items.GetContent();
+  // determine content only if it isn't set
+  if (content.IsEmpty())
+  {
+    content = m_database.GetContentForPath(items.GetPath());
+    items.SetContent(content.IsEmpty() ? "files" : content);
+  }
 
   /*
     If we have a matching item in the library, so we can assign the metadata to it. In addition, we can choose


### PR DESCRIPTION
This fixes problem described in http://forum.xbmc.org/showthread.php?tid=134027

Current routine to fetch additional info for videos is a bit flawed: it assume that if items have content set - then we don't have to fetch additional metadata/playcount. This doesn't work well for plugins (which might set items content).

I just added additional check to test if items were created from database (which I hope, means that metadata and playcount are already fetched).
