### PR TITLE
Make weave double rate since we are unable to sync to specific field on output

### DIFF
--- a/xbmc/cores/VideoRenderers/RenderFlags.h
+++ b/xbmc/cores/VideoRenderers/RenderFlags.h
@@ -29,6 +29,7 @@
 
 #define RENDER_FLAG_FIELD0      0x80
 #define RENDER_FLAG_FIELD1      0x100
+#define RENDER_FLAG_WEAVE       0x200
 
 // #define RENDER_FLAG_LAST        0x40
 

--- a/xbmc/cores/VideoRenderers/RenderManager.cpp
+++ b/xbmc/cores/VideoRenderers/RenderManager.cpp
@@ -652,9 +652,9 @@ void CXBMCRenderManager::Render(bool clear, DWORD flags, DWORD alpha)
   CSharedLock lock(m_sharedSection);
 
   if( m_presentmethod == PRESENT_METHOD_BOB )
-    PresentBob(clear, flags, alpha);
+    PresentFields(clear, flags, alpha);
   else if( m_presentmethod == PRESENT_METHOD_WEAVE )
-    PresentBob(clear, flags | RENDER_FLAG_WEAVE, alpha);
+    PresentFields(clear, flags | RENDER_FLAG_WEAVE, alpha);
   else if( m_presentmethod == PRESENT_METHOD_BLEND )
     PresentBlend(clear, flags, alpha);
   else
@@ -698,7 +698,7 @@ void CXBMCRenderManager::PresentSingle(bool clear, DWORD flags, DWORD alpha)
 
 /* new simpler method of handling interlaced material, *
  * we just render the two fields right after eachother */
-void CXBMCRenderManager::PresentBob(bool clear, DWORD flags, DWORD alpha)
+void CXBMCRenderManager::PresentFields(bool clear, DWORD flags, DWORD alpha)
 {
   CSingleLock lock(g_graphicsContext);
 
@@ -735,16 +735,6 @@ void CXBMCRenderManager::PresentBlend(bool clear, DWORD flags, DWORD alpha)
     m_pRenderer->RenderUpdate(clear, flags | RENDER_FLAG_TOP | RENDER_FLAG_NOOSD, alpha);
     m_pRenderer->RenderUpdate(false, flags | RENDER_FLAG_BOT, alpha / 2);
   }
-  m_presentstep = PRESENT_IDLE;
-}
-
-/* renders the two fields as one, but doing fieldbased *
- * scaling then reinterlaceing resulting image         */
-void CXBMCRenderManager::PresentWeave(bool clear, DWORD flags, DWORD alpha)
-{
-  CSingleLock lock(g_graphicsContext);
-
-  m_pRenderer->RenderUpdate(clear, flags | RENDER_FLAG_BOTH, alpha);
   m_presentstep = PRESENT_IDLE;
 }
 

--- a/xbmc/cores/VideoRenderers/RenderManager.cpp
+++ b/xbmc/cores/VideoRenderers/RenderManager.cpp
@@ -654,7 +654,7 @@ void CXBMCRenderManager::Render(bool clear, DWORD flags, DWORD alpha)
   if( m_presentmethod == PRESENT_METHOD_BOB )
     PresentBob(clear, flags, alpha);
   else if( m_presentmethod == PRESENT_METHOD_WEAVE )
-    PresentWeave(clear, flags, alpha);
+    PresentBob(clear, flags | RENDER_FLAG_WEAVE, alpha);
   else if( m_presentmethod == PRESENT_METHOD_BLEND )
     PresentBlend(clear, flags, alpha);
   else

--- a/xbmc/cores/VideoRenderers/RenderManager.h
+++ b/xbmc/cores/VideoRenderers/RenderManager.h
@@ -135,8 +135,7 @@ protected:
   void Render(bool clear, DWORD flags, DWORD alpha);
 
   void PresentSingle(bool clear, DWORD flags, DWORD alpha);
-  void PresentWeave(bool clear, DWORD flags, DWORD alpha);
-  void PresentBob(bool clear, DWORD flags, DWORD alpha);
+  void PresentFields(bool clear, DWORD flags, DWORD alpha);
   void PresentBlend(bool clear, DWORD flags, DWORD alpha);
 
   EINTERLACEMETHOD AutoInterlaceMethodInternal(EINTERLACEMETHOD mInt);


### PR DESCRIPTION
This changes our weave implementation to a double rate version that should function without need to sync opengl buffer swaps to specific fields.

It can be somewhat slow since it requires double fps and multipass rendering. So in comparison to normal rendering it's rendering 4 times as much. 
