### PR TITLE
Broken build : libxbmc.so

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -347,7 +347,7 @@ OBJSXBMC:=$(filter-out $(DYNOBJSXBMC), $(OBJSXBMC))
 
 LIBS += @PYTHON_LDFLAGS@
 
-libxbmc.so: $(OBJSXBMC) $(DYNOBJSXBMC)
+libxbmc.so: $(OBJSXBMC) $(DYNOBJSXBMC) $(NWAOBJSXBMC)
 ifeq ($(findstring osx,@ARCH@), osx)
 	$(SILENT_LD) $(CXX) $(LDFLAGS) -bundle -o $@ -Wl,-all_load,-ObjC $(DYNOBJSXBMC) $(NWAOBJSXBMC) $(OBJSXBMC) $(LIBS)
 else


### PR DESCRIPTION
https://github.com/xbmc/xbmc/commit/327710767d2257dad27e3885effba1d49d4557f0 has broken build of libxbmc. If NWAOBJSXBMC is required for link, it has to be a dependency of libxbmc.so for proper clean build.
