### PR TITLE
Allow compiling without mysql dependency (--disable-mysql)

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -141,12 +141,15 @@ endif
 LIB_DIRS=\
 	lib/cximage-6.0 \
 	lib/libexif \
-	lib/cmyth \
 	lib/libhdhomerun \
 	lib/libid3tag \
 	lib/libapetag \
 	lib/cpluff \
 	lib/xbmc-dll-symbols
+
+ifeq (@USE_MYSQL@,1)
+LIB_DIRS += lib/cmyth
+endif
 
 SS_DIRS=
 ifneq (@DISABLE_RSXS@,1)
@@ -288,8 +291,12 @@ else
 endif
 libexif: dllloader
 	$(MAKE) -C lib/libexif
+ifeq (@USE_MYSQL@,1)
 cmyth: dllloader
 	$(MAKE) -C lib/cmyth
+else
+cmyth:
+endif
 libhdhomerun: dllloader
 	$(MAKE) -C lib/libhdhomerun
 libid3tag: dllloader

--- a/Makefile.in
+++ b/Makefile.in
@@ -349,7 +349,7 @@ OBJSXBMC:=$(filter-out $(DYNOBJSXBMC), $(OBJSXBMC))
 
 LIBS += @PYTHON_LDFLAGS@
 
-libxbmc.so: $(OBJSXBMC) $(DYNOBJSXBMC)
+libxbmc.so: $(OBJSXBMC) $(DYNOBJSXBMC) $(NWAOBJSXBMC)
 ifeq ($(findstring osx,@ARCH@), osx)
 	$(SILENT_LD) $(CXX) $(LDFLAGS) -bundle -o $@ -Wl,-all_load,-ObjC $(DYNOBJSXBMC) $(NWAOBJSXBMC) $(OBJSXBMC) $(LIBS)
 else

--- a/configure.in
+++ b/configure.in
@@ -381,6 +381,12 @@ AC_ARG_ENABLE([asap-codec],
   [use_asap=$enableval],
   [use_asap=no])
 
+AC_ARG_ENABLE([mysql],
+  [AS_HELP_STRING([--disable-mysql],
+  [disable mysql])],
+  [use_mysql=$enableval],
+  [use_mysql=yes])
+
 AC_ARG_ENABLE([webserver],
   [AS_HELP_STRING([--disable-webserver],
   [disable webserver])],
@@ -733,14 +739,17 @@ else
 fi
 
 # platform common libraries
-AC_CHECK_PROG(MYSQL_CONFIG, mysql_config, "yes", "no")
-if test $MYSQL_CONFIG = "yes"; then
-  INCLUDES="$INCLUDES `mysql_config --include`"
-  MYSQL_LIBS=`mysql_config --libs`
-  LIBS="$LIBS $MYSQL_LIBS"
-  AC_SUBST(MYSQL_LIBS)
-else
-  AC_MSG_ERROR($missing_program)
+if test "$use_mysql" = "yes"; then
+  AC_CHECK_PROG(MYSQL_CONFIG, mysql_config, "yes", "no")
+  if test $MYSQL_CONFIG = "yes"; then
+    AC_DEFINE([HAVE_MYSQL],[1],["Define to 1 if you have the `mysql' library (-lmysqlclient)."])
+    INCLUDES="$INCLUDES `mysql_config --include`"
+    MYSQL_LIBS=`mysql_config --libs`
+    LIBS="$LIBS $MYSQL_LIBS"
+    AC_SUBST(MYSQL_LIBS)
+  else
+    AC_MSG_ERROR($missing_program)
+  fi
 fi
 AC_CHECK_HEADER([ass/ass.h],, AC_MSG_ERROR($missing_library))
 AC_CHECK_HEADER([mpeg2dec/mpeg2.h],, AC_MSG_ERROR($missing_library))
@@ -779,7 +788,9 @@ AC_CHECK_LIB([lzo2],        [main],, AC_MSG_ERROR($missing_library))
 AC_CHECK_LIB([z],           [main],, AC_MSG_ERROR($missing_library))
 AC_CHECK_LIB([crypto],      [main],, AC_MSG_ERROR($missing_library))
 AC_CHECK_LIB([ssl],         [main],, AC_MSG_ERROR($missing_library))
-AC_CHECK_LIB([mysqlclient], [main],, AC_MSG_ERROR($missing_library))
+if test "$use_mysql" = "yes"; then
+  AC_CHECK_LIB([mysqlclient], [main],, AC_MSG_ERROR($missing_library))
+fi
 AC_CHECK_LIB([ssh],         [sftp_tell64],, AC_MSG_RESULT([Could not find suitable version of libssh]))
 AC_CHECK_LIB([bluetooth],   [hci_devid],, AC_MSG_RESULT([Could not find suitable version of libbluetooth]))
 AC_CHECK_LIB([yajl],        [main],, AC_MSG_ERROR($missing_library))
@@ -1880,6 +1891,13 @@ else
   final_message="$final_message\n  ASAP Codec:\tNo"
 fi
 
+if test "$use_mysql" = "yes"; then
+  final_message="$final_message\n  MySQL:\tYes"
+  USE_MYSQL=1
+else
+  final_message="$final_message\n  MySQL:\tNo"
+  USE_MYSQL=0
+fi
 if test "$use_webserver" = "yes"; then
   final_message="$final_message\n  Webserver:\tYes"
   USE_WEB_SERVER=1
@@ -2094,6 +2112,7 @@ AC_SUBST(USE_AIRTUNES)
 AC_SUBST(USE_LIBUDEV)
 AC_SUBST(USE_LIBUSB)
 AC_SUBST(USE_LIBCEC)
+AC_SUBST(USE_MYSQL)
 AC_SUBST(USE_WEB_SERVER)
 
 

--- a/xbmc/dbwrappers/Database.cpp
+++ b/xbmc/dbwrappers/Database.cpp
@@ -29,9 +29,11 @@
 #include "utils/AutoPtrHandle.h"
 #include "utils/log.h"
 #include "utils/URIUtils.h"
-#include "mysqldataset.h"
 #include "sqlitedataset.h"
 
+#ifdef HAS_MYSQL
+#include "mysqldataset.h"
+#endif
 
 using namespace AUTOPTR;
 using namespace dbiplus;
@@ -363,10 +365,12 @@ bool CDatabase::Connect(const DatabaseSettings &dbSettings, bool create)
   {
     m_pDB.reset( new SqliteDatabase() ) ;
   }
+#ifdef HAS_MYSQL
   else if (dbSettings.type.Equals("mysql"))
   {
     m_pDB.reset( new MysqlDatabase() ) ;
   }
+#endif
   else
   {
     CLog::Log(LOGERROR, "Unable to determine database type: %s", dbSettings.type.c_str());

--- a/xbmc/dbwrappers/Makefile
+++ b/xbmc/dbwrappers/Makefile
@@ -1,8 +1,11 @@
 SRCS=Database.cpp \
      dataset.cpp \
-     mysqldataset.cpp \
      qry_dat.cpp \
-     sqlitedataset.cpp \
+     sqlitedataset.cpp
+
+ifeq (@USE_MYSQL@,1)
+SRCS+=mysqldataset.cpp
+endif
 
 LIB=dbwrappers.a
 

--- a/xbmc/dbwrappers/mysqldataset.cpp
+++ b/xbmc/dbwrappers/mysqldataset.cpp
@@ -23,9 +23,11 @@
 #include <string>
 #include <set>
 
-#include "mysqldataset.h"
 #include "utils/log.h"
 #include "system.h" // for GetLastError()
+
+#ifdef HAS_MYSQL
+#include "mysqldataset.h"
 #include "mysql/errmsg.h"
 #ifdef _WIN32
 #pragma comment(lib, "mysqlclient.lib")
@@ -1597,4 +1599,5 @@ void MysqlDataset::interrupt() {
 }
 
 }//namespace
+#endif //HAS_MYSQL
 

--- a/xbmc/system.h
+++ b/xbmc/system.h
@@ -80,6 +80,10 @@
   #define HAS_AIRTUNES
 #endif
 
+#ifdef HAVE_MYSQL
+  #define HAS_MYSQL
+#endif
+
 /**********************
  * Non-free Components
  **********************/


### PR DESCRIPTION
This commit adds the possibility to build xbmc without mysql by just using sqlite (--disable-mysql).
This is needed as MySQL is a very heavy package and getting it to compile for **sh** cpu arch based embedded devices is probably not worth the trouble.

This also disables the build of cmyth if mysql is disabled, as cmyth depends on mysql.
But that does not hurt as **sh** cpu arch based devices are usally STBs with internal tuner and for that have no need for a myth connection to get livetv.
