### PR TITLE
texturepacker: crosscompile fixes

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -405,6 +405,12 @@ AC_ARG_ENABLE([texturepacker],
   [use_texturepacker=$enableval],
   [use_texturepacker=auto])
 
+AC_ARG_WITH([texturepacker-root],
+  [AS_HELP_STRING([--with-texturepacker-root],
+  [root dir to search for libraries and includes if building native TexturePacker (default is \$prefix)])],
+  [use_texturepacker_root=$withval],
+  [use_texturepacker_root=$prefix])
+
 AC_ARG_WITH([lirc-device],
   [AS_HELP_STRING([--with-lirc-device=file],
   [specify the default LIRC device (default is /dev/lircd)])],
@@ -516,8 +522,7 @@ case $host in
      use_cpu=cortex-a8
      check_sdl_arch=[`file /opt/local/lib/libSDL_image.dylib | awk '{V=7; print $V}'`]
      if test "x$check_sdl_arch" = "xi386"; then
-       use_texturepacker_native=yes
-       USE_TEXTUREPACKER_NATIVE_ROOT="/opt/local"
+       use_texturepacker_root="/opt/local"
      else
        use_texturepacker=no
      fi
@@ -533,8 +538,6 @@ case $host in
   *86*-apple-darwin*)
      use_joystick=no
      use_vtbdecoder=no
-     use_texturepacker_native=yes
-     USE_TEXTUREPACKER_NATIVE_ROOT="$prefix"
      ARCH="x86-osx"
      AC_SUBST(ARCH_DEFINES, "-DTARGET_POSIX -DTARGET_DARWIN -DTARGET_DARWIN_OSX -D_LINUX")
      ;;
@@ -1757,13 +1760,13 @@ fi
 
 USE_TEXTUREPACKER_NATIVE=0
 if test "x$use_texturepacker" != "xno"; then
-  final_message="$final_message\n  TexturePacker:Yes"
   USE_TEXTUREPACKER=1
-  if test "x$use_texturepacker_native" = "xyes"; then
+  if test "x$cross_compiling" = "xyes"; then
     USE_TEXTUREPACKER_NATIVE=1
-    if [[ ! -d "$USE_TEXTUREPACKER_NATIVE_ROOT" ]]; then 
-      USE_TEXTUREPACKER_NATIVE_ROOT= 
-    fi
+    USE_TEXTUREPACKER_NATIVE_ROOT="$use_texturepacker_root"
+    final_message="$final_message\n  TexturePacker:Native ($USE_TEXTUREPACKER_NATIVE_ROOT)"
+  else
+    final_message="$final_message\n  TexturePacker:Yes"
   fi
 else
   final_message="$final_message\n  TexturePacker:No"

--- a/lib/libsquish/Makefile.in
+++ b/lib/libsquish/Makefile.in
@@ -11,31 +11,34 @@ SRCS= \
   singlecolourfit.cpp \
   squish.cpp
 
-CXXFLAGS+=-I.
+LIB              = libsquish.a
+NATIVE_LIB       = libsquish-native.so
+CLEAN_FILES     += $(NATIVE_LIB)
+
+HOST_CXX        ?= g++
+CXXFLAGS        += -I.
+HOST_CXXFLAGS   += -I.
+
 ifeq ($(findstring powerpc,$(ARCH)),powerpc)
-  CXXFLAGS+=-DSQUISH_USE_ALTIVEC=1 -maltivec
+  CXXFLAGS      += -DSQUISH_USE_ALTIVEC=1 -maltivec
+  HOST_CXXFLAGS += -DSQUISH_USE_ALTIVEC=1 -maltivec
 else ifeq ($(findstring x86,$(ARCH)), x86)
-  CXXFLAGS+=-DSQUISH_USE_SSE=2 -msse2
+  CXXFLAGS      += -DSQUISH_USE_SSE=2 -msse2
+  HOST_CXXFLAGS += -DSQUISH_USE_SSE=2 -msse2
 endif
-
-LIB=libsquish.a
-
-ifeq (@USE_TEXTUREPACKER_NATIVE@,1)
-NATIVE_LIB=libsquish-native.so
-CLEAN_FILES+=$(NATIVE_LIB)
 
 ifeq ($(findstring osx,$(ARCH)),osx)
-NATIVE_ARCH=$(shell echo $(CXXFLAGS) | grep x86_64 >/dev/null && echo -m64 || echo -m32)
+  HOST_CXXFLAGS += $(shell echo $(CXXFLAGS) | grep x86_64 >/dev/null && echo -m64 || echo -m32)
 endif
 
-all: $(LIB) $(NATIVE_LIB)
+$(LIB): $(SRCS)
+
 # TexturePacker links to libsquish and needs to run on build system, so make a native flavor.
 $(NATIVE_LIB): $(SRCS)
 ifeq ($(findstring osx,$(ARCH)),osx)
-	g++ $(NATIVE_ARCH) -DSQUISH_USE_SSE=2 -msse2 -I. $(SRCS) -dynamiclib -install_name `pwd`/libsquish-native.so -o $@
+	$(HOST_CXX) $(HOST_CXXFLAGS) $(SRCS) -dynamiclib -install_name `pwd`/libsquish-native.so -o $@
 else
-	g++ -DSQUISH_USE_SSE=2 -msse2 -I. $(SRCS) -shared -fPIC -Wl,-soname,`pwd`/libsquish-native.so -o $@
-endif
+	$(HOST_CXX) $(HOST_CXXFLAGS) $(SRCS) -shared -fPIC -Wl,-soname,`pwd`/libsquish-native.so -o $@
 endif
 
 include ../../Makefile.include

--- a/tools/TexturePacker/Makefile.in
+++ b/tools/TexturePacker/Makefile.in
@@ -1,48 +1,51 @@
-DEFINES += -D_LINUX -DUSE_LZO_PACKING
+DEFINES       += -D_LINUX -DUSE_LZO_PACKING
 ifneq ($(or $(findstring powerpc,@ARCH@),$(findstring ppc, @ARCH@)),)
-DEFINES += -DHOST_BIGENDIAN
+DEFINES       += -DHOST_BIGENDIAN
 endif
 
-CXXFLAGS+= \
-  -I. \
-  -I@abs_top_srcdir@/lib \
-  -I@abs_top_srcdir@/xbmc \
-  -I@abs_top_srcdir@/xbmc/linux
-
-ifeq (@USE_TEXTUREPACKER_NATIVE@,1)
-NATIVE_ROOT_PATH=@USE_TEXTUREPACKER_NATIVE_ROOT@
-ifdef NATIVE_ROOT_PATH
-ifeq ($(findstring osx,@ARCH@),osx)
-DEFINES += -DTARGET_DARWIN
-NATIVE_ARCH=$(shell echo $(CXXFLAGS) | grep x86_64 >/dev/null && echo -m64 || echo -m32)
-endif
-CXXFLAGS+= -I$(NATIVE_ROOT_PATH)/include
-LIBS    += -L$(NATIVE_ROOT_PATH)/lib
-endif
-LIBS    += -L@abs_top_srcdir@/lib/libsquish -lsquish-native
-else
-LIBS    += -L@abs_top_srcdir@/lib/libsquish -lsquish
-endif
-
-LIBS    += -lSDL_image -lSDL -llzo2
-
-SRCS = \
+SRCS           = \
   md5.cpp \
   SDL_anigif.cpp \
   XBTFWriter.cpp \
   XBMCTex.cpp \
   @abs_top_srcdir@/xbmc/guilib/XBTF.cpp
 
-
-TARGET = TexturePacker
-CLEAN_FILES=$(TARGET)
+TARGET         = TexturePacker
+CLEAN_FILES    = $(TARGET)
 
 all: $(TARGET)
+
+HOST_CXX      ?= g++
+HOST_ROOT_PATH = @USE_TEXTUREPACKER_NATIVE_ROOT@
+
+LIBS          += -lSDL_image -lSDL -llzo2
+LIBS          += -L@abs_top_srcdir@/lib/libsquish -lsquish
+HOST_LIBS     += -L$(HOST_ROOT_PATH)/lib -lSDL_image -lSDL -llzo2
+HOST_LIBS     += -L@abs_top_srcdir@/lib/libsquish -lsquish-native
+
+CXXFLAGS      += \
+  -I. \
+  -I@abs_top_srcdir@/lib \
+  -I@abs_top_srcdir@/xbmc \
+  -I@abs_top_srcdir@/xbmc/linux
+
+HOST_CXXFLAGS += \
+  -I. \
+  -I@abs_top_srcdir@/lib \
+  -I@abs_top_srcdir@/xbmc \
+  -I@abs_top_srcdir@/xbmc/linux \
+  -I$(HOST_ROOT_PATH)/include
+
+ifeq ($(findstring osx,@ARCH@),osx)
+DEFINES       += -DTARGET_DARWIN
+HOST_CXXFLAGS += $(shell echo $(CXXFLAGS) | grep x86_64 >/dev/null && echo -m64 || echo -m32)
+endif
 
 ifeq (@USE_TEXTUREPACKER_NATIVE@,1)
 # TexturePacker run native on build system, build it with native tools
 $(TARGET): $(SRCS)
-	g++ $(DEFINES) $(NATIVE_ARCH) $(CXXFLAGS) $(SRCS) $(LIBS) -o $(TARGET)
+	make -C @abs_top_srcdir@/lib/libsquish libsquish-native.so
+	$(HOST_CXX) $(DEFINES) $(HOST_CXXFLAGS) $(SRCS) $(HOST_LIBS) -o $(TARGET)
 clean:
 	rm -f $(TARGET)
 else


### PR DESCRIPTION
this fixes:
- libsquish-native.so will be built even if TextuePacker is disabled
- libsquish-native.so will be built for target
- native TextuePacker will not be built if TexturePacker is enabled and we cross-compile

This change:
- adds '--with-texturepacker-root=" to configure script to configure the location of the host library and include dir to search if native T
  exturePacker should be build. If not configured it falls back to $prefix (the default location for most host tools). This location can be still hardcoded in configure.in with 'use_texturepacker_root='.
- if we enable TexturePacker building and we crosscompile we force the native building of TexturePacker.
- using $HOST_CXX for building native TexturePacker and native libsquish and fall back to 'g++'.
- using $HOST_CXXFLAGS and $HOST_LIBS for building native TexturePacker and native libsquish if configured.
