### PR TITLE
EDL fix for seeking multiple times to same cut

### DIFF
--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -1777,11 +1777,6 @@ void CDVDPlayer::CheckAutoSceneSkip()
     m_EdlAutoSkipMarkers.commbreak_end   = cut.end;
     m_EdlAutoSkipMarkers.seek_to_start   = true; // Allow backwards Seek() to go directly to the start
   }
-
-  /*
-   * Reset the EDL automatic skip cut marker every 500 ms.
-   */
-  m_EdlAutoSkipMarkers.ResetCutMarker(500); // in msec
 }
 
 

--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -1749,7 +1749,7 @@ void CDVDPlayer::CheckAutoSceneSkip()
     /*
      * Seeking is NOT flushed so any content up to the demux point is retained when playing forwards.
      */
-    m_messenger.Put(new CDVDMsgPlayerSeek((int)seek, true, false, true, false));
+    m_messenger.Put(new CDVDMsgPlayerSeek((int)seek, true, false, true, false, true));
     /*
      * Seek doesn't always work reliably. Last physical seek time is recorded to prevent looping
      * if there was an error with seeking and it landed somewhere unexpected, perhaps back in the
@@ -1767,7 +1767,7 @@ void CDVDPlayer::CheckAutoSceneSkip()
     /*
      * Seeking is NOT flushed so any content up to the demux point is retained when playing forwards.
      */
-    m_messenger.Put(new CDVDMsgPlayerSeek(cut.end + 1, true, false, true, false));
+    m_messenger.Put(new CDVDMsgPlayerSeek(cut.end + 1, true, false, true, false, true));
     /*
      * Each commercial break is only skipped once so poorly detected commercial breaks can be
      * manually re-entered. Start and end are recorded to prevent looping and to allow seeking back

--- a/xbmc/cores/dvdplayer/DVDPlayer.h
+++ b/xbmc/cores/dvdplayer/DVDPlayer.h
@@ -451,31 +451,13 @@ protected:
       commbreak_start = -1;
       commbreak_end = -1;
       seek_to_start = false;
-      reset = 0;
       mute = false;
-    }
-
-    void ResetCutMarker(double timeout)
-    {
-      if(reset != 0
-      && reset + DVD_MSEC_TO_TIME(timeout) > CDVDClock::GetAbsoluteClock())
-        return;
-
-      /*
-       * Reset the automatic EDL skip marker for a cut so automatic seeking can happen again if,
-       * for example, the initial automatic skip ended up back in the cut due to seeking
-       * inaccuracies.
-       */
-      cut = -1;
-
-      reset = CDVDClock::GetAbsoluteClock();
     }
 
     int cut;              // last automatically skipped EDL cut seek position
     int commbreak_start;  // start time of the last commercial break automatically skipped
     int commbreak_end;    // end time of the last commercial break automatically skipped
     bool seek_to_start;   // whether seeking can go back to the start of a previously skipped break
-    double reset;         // last actual reset time
     bool mute;            // whether EDL mute is on
 
   } m_EdlAutoSkipMarkers;


### PR DESCRIPTION
The existing code that was being used to prevent seeking to a cut doesn't look like it would have worked ever since the code was changed to use the dts time and flushed seeking rather than the clock time and normal seeking.

There's also another small change the prevents the Seeking dialog showing for automated seeks by using the trickplay feature for seeking that was added to DVD player some time ago.
