### PR TITLE
Don't correct episode numbering from scraper

### DIFF
--- a/xbmc/addons/Scraper.cpp
+++ b/xbmc/addons/Scraper.cpp
@@ -832,25 +832,6 @@ EPISODELIST CScraper::GetEpisodeList(XFILE::CCurlFile &fcurl, const CScraperUrl 
     }
   }
 
-  // find minimum in each season
-  map<int, int> mpMin;
-  for (EPISODELIST::const_iterator i = vcep.begin(); i != vcep.end(); ++i)
-  {
-    map<int, int>::iterator iMin = mpMin.find(i->key.first);
-    if (iMin == mpMin.end())
-      mpMin.insert(i->key);
-    else if (i->key.second < iMin->second)
-      iMin->second = i->key.second;
-  }
-
-  // correct episode numbers
-  for (EPISODELIST::iterator i = vcep.begin(); i != vcep.end(); ++i)
-  {
-    i->key.second -= mpMin[i->key.first];
-    if (mpMin[i->key.first] > 0)
-      ++i->key.second;
-  }
-
   return vcep;
 }
 


### PR DESCRIPTION
This removes the code that corrects the episode numbers retrieved from a scraper so that the lowest episode number becomes episode 1.

Does this code have any legitimate use?  It just seems to cause the occasional confusion:
http://forum.xbmc.org/showthread.php?tid=128732
http://forum.xbmc.org/showthread.php?tid=132441
http://forum.xbmc.org/showthread.php?tid=134266
