### PR TITLE
home.xml existence testing

### DIFF
--- a/language/English/strings.po
+++ b/language/English/strings.po
@@ -8725,7 +8725,15 @@ msgctxt "#24101"
 msgid "Would you like to download this Add-on?"
 msgstr ""
 
-#empty strings from id 24102 to 24999
+msgctxt "#24102"
+msgid "Unable to load skin"
+msgstr ""
+
+msgctxt "#24103"
+msgid "Skin is missing some files"
+msgstr ""
+
+#empty strings from id 24104 to 24999
 
 msgctxt "#25000"
 msgid "Notifications"

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -1755,6 +1755,7 @@ void CApplication::LoadSkin(const SkinPtr& skin)
       CLog::Log(LOGERROR, "home.xml doesn't exist in skin: %s, fallback to \"%s\" skin", skin->ID().c_str(), DEFAULT_SKIN);
       g_guiSettings.SetString("lookandfeel.skin", DEFAULT_SKIN);
       LoadSkin(DEFAULT_SKIN);
+      CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Error, g_localizeStrings.Get(24102), g_localizeStrings.Get(24103));
       return ;
     }
   }

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -1746,6 +1746,19 @@ void CApplication::LoadSkin(const SkinPtr& skin)
     return ;
   }
 
+  if (!skin->HasSkinFile("Home.xml"))
+  {
+    // failed to find home.xml
+    // fallback to default skin
+    if (strcmpi(skin->ID().c_str(), DEFAULT_SKIN) != 0)
+    {
+      CLog::Log(LOGERROR, "home.xml doesn't exist in skin: %s, fallback to \"%s\" skin", skin->ID().c_str(), DEFAULT_SKIN);
+      g_guiSettings.SetString("lookandfeel.skin", DEFAULT_SKIN);
+      LoadSkin(DEFAULT_SKIN);
+      return ;
+    }
+  }
+
   bool bPreviousPlayingState=false;
   bool bPreviousRenderingState=false;
   if (g_application.m_pPlayer && g_application.IsPlayingVideo())
@@ -1811,19 +1824,6 @@ void CApplication::LoadSkin(const SkinPtr& skin)
   start = CurrentHostCounter();
 
   CLog::Log(LOGINFO, "  load new skin...");
-  CGUIWindowHome *pHome = (CGUIWindowHome *)g_windowManager.GetWindow(WINDOW_HOME);
-  if (!pHome || !pHome->Load("Home.xml"))
-  {
-    // failed to load home.xml
-    // fallback to default skin
-    if ( strcmpi(skin->ID().c_str(), DEFAULT_SKIN) != 0)
-    {
-      CLog::Log(LOGERROR, "failed to load home.xml for skin: %s, fallback to \"%s\" skin", skin->ID().c_str(), DEFAULT_SKIN);
-      g_guiSettings.SetString("lookandfeel.skin", DEFAULT_SKIN);
-      LoadSkin(DEFAULT_SKIN);
-      return ;
-    }
-  }
 
   // Load the user windows
   LoadUserWindows();


### PR DESCRIPTION
This fixes issue described in http://forum.xbmc.org/showthread.php?tid=132641

Currently when we load skin, we test if loading Home.xml window is ok: https://github.com/xbmc/xbmc/blob/master....cpp#L1815 . This can actually cause several issues:
a) window will stay in memory and next time we will show it we won't resolve our includes as window is already loaded
b) it will trigger home's window <onload> actions (which technically is correct as we load that window, but I doubt anyone want that)

Fix:
Instead of loading home.xml we just test if it exists. I also moved this test before loading any includes, etc. as we don't need them to test file existence.
In addition I notify user that something is wrong with skin and that's why we load default skin instead.
