### PR TITLE
Add __sh__ cpu arch support

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -310,7 +310,7 @@ ifeq (@USE_ASAP_CODEC@,1)
   endif
 endif
 	$(MAKE) -C lib/stsound/StSoundLibrary	
-ifeq ($(or $(findstring powerpc,@ARCH@),$(findstring x86_64-linux,@ARCH@),$(findstring arm, @ARCH@),$(findstring freebsd,@ARCH@)),)
+ifeq ($(or $(findstring powerpc,@ARCH@),$(findstring x86_64-linux,@ARCH@),$(findstring arm, @ARCH@),$(findstring freebsd,@ARCH@),$(findstring sh, @ARCH@)),)
 	$(MAKE) -C lib/snesapu/SNES/SNESAPU
 endif
 imagelib: dllloader

--- a/configure.in
+++ b/configure.in
@@ -561,6 +561,12 @@ case $host in
      use_arch="arm"
      AC_SUBST(ARCH_DEFINES, "-DTARGET_POSIX -DTARGET_LINUX -D_LINUX")
      ;;
+  sh*-*-linux-gnu*)
+     use_texturepacker=no
+     ARCH="sh"
+     use_arch="sh"
+     AC_SUBST(ARCH_DEFINES, "-DTARGET_POSIX -DTARGET_LINUX -D_LINUX")
+     ;;
   *)
      AC_MSG_ERROR(unsupported host ($host))
 esac

--- a/xbmc/cores/DllLoader/DllLoader.h
+++ b/xbmc/cores/DllLoader/DllLoader.h
@@ -24,7 +24,7 @@
 #include "coffldr.h"
 #include "LibraryLoader.h"
 
-#if defined(__linux__) && !defined(__powerpc__) && !defined(__arm__)
+#if defined(__linux__) && !defined(__powerpc__) && !defined(__arm__) && !defined(__sh__)
 #define USE_LDT_KEEPER
 #include "ldt_keeper.h"
 #endif

--- a/xbmc/cores/DllLoader/ldt_keeper.c
+++ b/xbmc/cores/DllLoader/ldt_keeper.c
@@ -19,7 +19,7 @@
  */
 
 //#ifndef __powerpc__
-#if !defined(__powerpc__) && !defined(__ppc__) && !defined(__arm__)
+#if !defined(__powerpc__) && !defined(__ppc__) && !defined(__arm__) && !defined(__sh__)
 
 #include "ldt_keeper.h"
 

--- a/xbmc/linux/PlatformDefs.h
+++ b/xbmc/linux/PlatformDefs.h
@@ -159,7 +159,7 @@
 #define __int64   long long
 #define __uint64  unsigned long long
 
-#if defined(__x86_64__) || defined(__powerpc__) || defined(__ppc__) || defined (__arm__) // should this be powerpc64 only?
+#if defined(__x86_64__) || defined(__powerpc__) || defined(__ppc__) || defined (__arm__) || defined (__sh__) // should this be powerpc64 only?
 #define __stdcall
 #else /* !__x86_64__ */
 #define __stdcall   __attribute__((__stdcall__))

--- a/xbmc/threads/Atomics.h
+++ b/xbmc/threads/Atomics.h
@@ -24,7 +24,7 @@
 
 // TODO: Inline these methods
 long cas(volatile long *pAddr, long expectedVal, long swapVal);
-#if !defined(__ppc__) && !defined(__powerpc__) && !defined(__arm__)
+#if !defined(__ppc__) && !defined(__powerpc__) && !defined(__arm__) && !defined(__sh__)
 long long cas2(volatile long long* pAddr, long long expectedVal, long long swapVal);
 #endif
 long AtomicIncrement(volatile long* pAddr);

--- a/xbmc/threads/LockFree.cpp
+++ b/xbmc/threads/LockFree.cpp
@@ -44,7 +44,7 @@ void lf_stack_push(lf_stack* pStack, lf_node* pNode)
     top = pStack->top;
     pNode->next.ptr = top.ptr; // Link in the new node
     newTop.ptr = pNode;
-#if defined(__ppc__) || defined(__powerpc__) || defined(__arm__)
+#if defined(__ppc__) || defined(__powerpc__) || defined(__arm__) || defined(__sh__)
   } while(cas((long*)&pStack->top, atomic_ptr_to_long(top), atomic_ptr_to_long(newTop)) != atomic_ptr_to_long(top));
 #else
     newTop.version = top.version + 1;
@@ -62,7 +62,7 @@ lf_node* lf_stack_pop(lf_stack* pStack)
     if (top.ptr == NULL)
       return NULL;
     newTop.ptr = ((lf_node*)top.ptr)->next.ptr; // Unlink the current top node
-#if defined(__ppc__) || defined(__powerpc__) || defined(__arm__)
+#if defined(__ppc__) || defined(__powerpc__) || defined(__arm__) || defined(__sh__)
   } while(cas((long*)&pStack->top, atomic_ptr_to_long(top), atomic_ptr_to_long(newTop)) != atomic_ptr_to_long(top));
 #else
     newTop.version = top.version + 1;
@@ -187,7 +187,7 @@ void lf_queue_enqueue(lf_queue* pQueue, void* value)
   {
     tail = pQueue->tail;
     next = ((lf_queue_node*)tail.ptr)->next;
-#if defined(__ppc__) || defined(__powerpc__) || defined(__arm__)
+#if defined(__ppc__) || defined(__powerpc__) || defined(__arm__) || defined(__sh__)
     if (atomic_ptr_to_long(tail) == atomic_ptr_to_long(pQueue->tail)) // Check consistency
 #else
     if (atomic_ptr_to_long_long(tail) == atomic_ptr_to_long_long(pQueue->tail)) // Check consistency
@@ -196,7 +196,7 @@ void lf_queue_enqueue(lf_queue* pQueue, void* value)
       if (next.ptr == NULL) // Was tail pointing to the last node?
       {
         node.ptr = pNode;
-#if defined(__ppc__) || defined(__powerpc__) || defined(__arm__)
+#if defined(__ppc__) || defined(__powerpc__) || defined(__arm__) || defined(__sh__)
         if (cas((long*)&((lf_queue_node*)tail.ptr)->next, atomic_ptr_to_long(next), atomic_ptr_to_long(node)) == atomic_ptr_to_long(next)) // Try to link node at end
 #else
         node.version = next.version + 1;
@@ -207,7 +207,7 @@ void lf_queue_enqueue(lf_queue* pQueue, void* value)
       else // tail was lagging, try to help...
       {
         node.ptr = next.ptr;
-#if defined(__ppc__) || defined(__powerpc__) || defined(__arm__)
+#if defined(__ppc__) || defined(__powerpc__) || defined(__arm__) || defined(__sh__)
         cas((long*)&pQueue->tail, atomic_ptr_to_long(tail), atomic_ptr_to_long(node)); // We don't care if we  are successful or not
 #else
         node.version = tail.version + 1;
@@ -217,7 +217,7 @@ void lf_queue_enqueue(lf_queue* pQueue, void* value)
     }
   } while (true); // Keep trying until the enqueue is done
   node.ptr = pNode;
-#if defined(__ppc__) || defined(__powerpc__) || defined(__arm__)
+#if defined(__ppc__) || defined(__powerpc__) || defined(__arm__) || defined(__sh__)
   cas((long*)&pQueue->tail, atomic_ptr_to_long(tail), atomic_ptr_to_long(node)); // Try to swing the tail to the new node
 #else
   node.version = tail.version + 1;
@@ -236,7 +236,7 @@ void* lf_queue_dequeue(lf_queue* pQueue)
     head = pQueue->head;
     tail = pQueue->tail;
     next = ((lf_queue_node*)head.ptr)->next;
-#if defined(__ppc__) || defined(__powerpc__) || defined(__arm__)
+#if defined(__ppc__) || defined(__powerpc__) || defined(__arm__) || defined(__sh__)
     if (atomic_ptr_to_long(head) == atomic_ptr_to_long(pQueue->head)) // Check consistency
 #else
     if (atomic_ptr_to_long_long(head) == atomic_ptr_to_long_long(pQueue->head)) // Check consistency
@@ -247,7 +247,7 @@ void* lf_queue_dequeue(lf_queue* pQueue)
         if (next.ptr == NULL) // Queue is empty
           return NULL;
         node.ptr = next.ptr;
-#if defined(__ppc__) || defined(__powerpc__) || defined(__arm__)
+#if defined(__ppc__) || defined(__powerpc__) || defined(__arm__) || defined(__sh__)
         cas((long*)&pQueue->tail, atomic_ptr_to_long(tail), atomic_ptr_to_long(node)); // Tail is lagging. Try to advance it.
 #else
         node.version = tail.version + 1;
@@ -258,7 +258,7 @@ void* lf_queue_dequeue(lf_queue* pQueue)
       {
         pVal = ((lf_queue_node*)next.ptr)->value;
         node.ptr = next.ptr;
-#if defined(__ppc__) || defined(__powerpc__) || defined(__arm__)
+#if defined(__ppc__) || defined(__powerpc__) || defined(__arm__) || defined(__sh__)
         if (cas((long*)&pQueue->head, atomic_ptr_to_long(head), atomic_ptr_to_long(node)) == atomic_ptr_to_long(head))
 #else
         node.version = head.version + 1;

--- a/xbmc/threads/LockFree.h
+++ b/xbmc/threads/LockFree.h
@@ -31,7 +31,7 @@
 // A unique-valued pointer. Version is incremented with each write.
 union atomic_ptr
 {
-#if !defined(__ppc__) && !defined(__powerpc__) && !defined(__arm__)
+#if !defined(__ppc__) && !defined(__powerpc__) && !defined(__arm__) && !defined(__sh__)
   long long d;
   struct {
     void* ptr;
@@ -45,7 +45,7 @@ union atomic_ptr
 #endif
 };
 
-#if defined(__ppc__) || defined(__powerpc__) || defined(__arm__)
+#if defined(__ppc__) || defined(__powerpc__) || defined(__arm__) || defined(__sh__)
   #define atomic_ptr_to_long(p) (long) *((long*)&p)
 #else
   // This is ugly but correct as long as sizeof(void*) == sizeof(long)...

--- a/xbmc/utils/CPUInfo.cpp
+++ b/xbmc/utils/CPUInfo.cpp
@@ -186,7 +186,11 @@ CCPUInfo::CCPUInfo(void)
           m_cores[nCurrId].m_strVendor.Trim();
         }
       }
+#if defined(__sh__)
+      else if (strncmp(buffer, "cpu type", strlen("cpu type"))==0)
+#else
       else if (strncmp(buffer, "model name", strlen("model name"))==0)
+#endif
       {
         char *needle = strstr(buffer, ":");
         if (needle && strlen(needle)>3)
@@ -337,7 +341,11 @@ float CCPUInfo::getCPUFrequency()
   rewind(m_fCPUInfo);
   fflush(m_fCPUInfo);
   while (fgets(buf, 256, m_fCPUInfo) != NULL) {
+#if defined(__sh__)
+    if (strncmp(buf, "bogomips", 8) == 0) {
+#else
     if (strncmp(buf, "cpu MHz", 7) == 0) {
+#endif
       needle = strchr(buf, ':');
       sscanf(++needle, "%f", &mhz);
       break;
@@ -597,7 +605,7 @@ void CCPUInfo::ReadCPUFeatures()
   #endif
 #elif defined(LINUX)
 // empty on purpose, the implementation is in the constructor
-#elif !defined(__powerpc__) && !defined(__ppc__) && !defined(__arm__)
+#elif !defined(__powerpc__) && !defined(__ppc__) && !defined(__arm__) && !defined(__sh__)
   m_cpuFeatures |= CPU_FEATURE_MMX;
 #elif defined(__powerpc__) || defined(__ppc__)
   m_cpuFeatures |= CPU_FEATURE_ALTIVEC;

--- a/xbmc/utils/MathUtils.h
+++ b/xbmc/utils/MathUtils.h
@@ -35,12 +35,14 @@
 
 #if defined(__ppc__) || \
     defined(__powerpc__) || \
+    defined(__sh__) || \
    (defined(__APPLE__) && defined(__arm__) && defined(__llvm__))
   #define DISABLE_MATHUTILS_ASM_ROUND_INT
 #endif
 
 #if defined(__ppc__) || \
     defined(__powerpc__) || \
+    defined(__sh__) || \
    (defined(__APPLE__) && defined(__llvm__)) 
   #define DISABLE_MATHUTILS_ASM_TRUNCATE_INT
 #endif

--- a/xbmc/utils/fastmemcpy.c
+++ b/xbmc/utils/fastmemcpy.c
@@ -21,7 +21,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston MA 02110-1301, USA.
  *****************************************************************************/
-#if !defined(_WIN32) && !defined(__ppc__) && !defined(__powerpc__) && !defined(__arm__) 
+#if !defined(_WIN32) && !defined(__ppc__) && !defined(__powerpc__) && !defined(__arm__) && !defined(__sh__) 
 #define HAVE_MMX2
 #define HAVE_SSE
 

--- a/xbmc/utils/fastmemcpy.h
+++ b/xbmc/utils/fastmemcpy.h
@@ -22,7 +22,7 @@
 extern "C" {
 #endif
 
-#if !defined(_WIN32) && !defined(__ppc__) && !defined(__powerpc__)
+#if !defined(_WIN32) && !defined(__ppc__) && !defined(__powerpc__) && !defined(__sh__)
 void * fast_memcpy(void * to, const void * from, size_t len);
 //#define fast_memcpy memcpy
 #else


### PR DESCRIPTION
This Patch adds the **sh** cpu arch to xbmc (--host=sh4-linux).

Note: Even with this patch you wont be able to compile a runnable version of xbmc for sh4, as for that you will need the OpenGL ESv1 patch which I am currently still trying to merge in a clean way with xbmc.

And of course the patch to access the video and audio hardware decoder by using gstreamer and bypassing paplayer and dvdplayer is also still in merging process.
