### PR TITLE
native resolution ( disable upscaling ) option

### DIFF
--- a/xbmc/cores/VideoRenderers/BaseRenderer.cpp
+++ b/xbmc/cores/VideoRenderers/BaseRenderer.cpp
@@ -37,6 +37,7 @@ CBaseRenderer::CBaseRenderer()
   m_sourceWidth = 720;
   m_sourceHeight = 480;
   m_resolution = RES_DESKTOP;
+  m_bestResolution = m_resolution;
   m_fps = 0.0f;
 }
 
@@ -66,6 +67,69 @@ void CBaseRenderer::ChooseBestResolution(float fps)
 #endif
     CLog::Log(LOGNOTICE, "Display resolution %s : %s (%d)",
         m_resolution == RES_DESKTOP ? "DESKTOP" : "USER", g_settings.m_ResInfo[m_resolution].strMode.c_str(), m_resolution);
+        
+  m_bestResolution = m_resolution;                                   // save it
+  int iNatW = (int)m_sourceWidth;
+  int iNatH = (int)m_sourceHeight;
+
+  if( g_advancedSettings.m_nativeMaxWidth && iNatW > g_advancedSettings.m_nativeMaxWidth )
+    iNatW = 0;
+
+  if( g_advancedSettings.m_nativeMaxHeight && iNatH > g_advancedSettings.m_nativeMaxHeight )
+    iNatH = 0;
+
+  if( g_advancedSettings.m_nativeUpscaleMode && iNatW && iNatH )     // Native Upscale Mode
+  { 
+    CLog::Log(LOGNOTICE, "Searching for NATIVE resolution: %dx%d", m_sourceWidth, m_sourceHeight);
+    
+    bool bOverrideFPS = g_advancedSettings.m_nativeOverrideFPS;
+    double nfRD, fRD, fD, fODist = 100000000.0;
+    int iWD, iHD;
+    double fOrgRefreshRate = g_settings.m_ResInfo[m_resolution].fRefreshRate;
+    int iOrgScreen = g_settings.m_ResInfo[m_resolution].iScreen;
+
+    if(iNatW <= g_advancedSettings.m_nativeMinWidth && 
+       iNatH <= g_advancedSettings.m_nativeMinHeight)
+    {
+      iNatW = g_advancedSettings.m_nativeMinWidth;
+      iNatH = g_advancedSettings.m_nativeMinHeight;
+    }
+    
+    // best fit
+    for (size_t i = (int)RES_DESKTOP; i < g_settings.m_ResInfo.size(); i++)  
+    {
+      fRD = g_settings.m_ResInfo[i].fRefreshRate - fOrgRefreshRate;  // refreshrate delta
+      nfRD = g_settings.m_ResInfo[i].fRefreshRate / fOrgRefreshRate; // refreshrate fit
+      iWD = g_settings.m_ResInfo[i].iWidth - iNatW;                  // width delta 
+      iHD = g_settings.m_ResInfo[i].iHeight - iNatH;                 // height delta
+      // distance function:
+      // refreshrate, witdh and height deltas are multiplied by weight factors
+      // current weights values do not prefer any parameter (well, almost...)
+      // so we will search for lowest width, height and refresh rate which fit to the source parameters
+      // however if any of these parameters need to be preferred, bump up the weight value for it
+      fD = (iWD * 1.0) + (iHD * 1.0);                                // default weights for width and height resolution
+ 
+      if (!bOverrideFPS)
+      {                                                              // if original fps should be preserved, accept only these 
+        fRD = (fRD == 0.0) ? (0.0) : (-1.0);                         // resolutions where refreshrate is the same
+      }
+      else
+      {                                                              // preferred multiple fps     
+        fD += fRD + ( (abs(nfRD-floor(nfRD+0.5)) < 1e-6) ? 10.0 : 1000.0 );
+      }
+     
+      if( fRD >= 0.0 && iWD >= 0 && iHD >= 0 && fD <= fODist &&
+          g_settings.m_ResInfo[i].iScreen == iOrgScreen ) 
+      {
+        m_resolution = (RESOLUTION)i;         // if we are here, then this resolution is closer to 
+        fODist = fD;                          // the source parameters than previous one
+      }
+    }
+
+    CLog::Log(LOGNOTICE, "Display resolution ADJUST2 : %s (%d)",
+        g_settings.m_ResInfo[m_resolution].strMode.c_str(), m_resolution);
+  }
+        
 }
 
 bool CBaseRenderer::FindResolutionFromOverride(float fps, float& weight, bool fallback)
@@ -391,10 +455,12 @@ void CBaseRenderer::ManageDisplay()
 
 void CBaseRenderer::SetViewMode(int viewMode)
 {
+  int savedViewMode;
+
   if (viewMode < VIEW_MODE_NORMAL || viewMode > VIEW_MODE_CUSTOM)
     viewMode = VIEW_MODE_NORMAL;
 
-  g_settings.m_currentVideoSettings.m_ViewMode = viewMode;
+  g_settings.m_currentVideoSettings.m_ViewMode = savedViewMode = viewMode;
 
   // get our calibrated full screen resolution
   RESOLUTION res = GetResolution();
@@ -402,6 +468,27 @@ void CBaseRenderer::SetViewMode(int viewMode)
   float screenHeight = (float)(g_settings.m_ResInfo[res].Overscan.bottom - g_settings.m_ResInfo[res].Overscan.top);
   // and the source frame ratio
   float sourceFrameRatio = GetAspectRatio();
+
+  // if we upscale via external AVR device, correct the pixel ratio
+  if( g_advancedSettings.m_nativeUpscaleMode && m_bestResolution != m_resolution  
+   && g_advancedSettings.m_nativeCorrectPixelRatio ) 
+  {
+    float destWidth = (float)(g_advancedSettings.m_nativeDestWidth);
+    float destHeight = (float)(g_advancedSettings.m_nativeDestHeight);
+    float destFrameRatio = (float)destWidth / destHeight;
+    bool  destScreenIs43 = (destFrameRatio < 8.f/(3.f*sqrt(3.f)));   // final output
+    float outWidth = (float)(g_settings.m_ResInfo[m_resolution].iWidth);
+    float outHeight = (float)(g_settings.m_ResInfo[m_resolution].iHeight);
+    float outFrameRatio = (float)outWidth / outHeight;
+    bool  outScreenIs43 = (outFrameRatio < 8.f/(3.f*sqrt(3.f)));     // xbmc output
+
+    if( outScreenIs43 && !destScreenIs43 )         // final output is 16x9
+      viewMode = VIEW_MODE_STRETCH_16x9;
+    else if( !outScreenIs43 && destScreenIs43 )    // final output is 4x3
+      viewMode = VIEW_MODE_STRETCH_4x3;
+
+    g_settings.m_currentVideoSettings.m_ViewMode = viewMode;
+  }
 
   bool is43 = (sourceFrameRatio < 8.f/(3.f*sqrt(3.f)) &&
               g_settings.m_currentVideoSettings.m_ViewMode == VIEW_MODE_NORMAL);
@@ -494,8 +581,12 @@ void CBaseRenderer::SetViewMode(int viewMode)
     g_settings.m_fZoomAmount = 1.0;
   }
 
+  // restore original view mode
+  g_settings.m_currentVideoSettings.m_ViewMode = savedViewMode;
+
   g_settings.m_currentVideoSettings.m_CustomZoomAmount = g_settings.m_fZoomAmount;
   g_settings.m_currentVideoSettings.m_CustomPixelRatio = g_settings.m_fPixelRatio;
   g_settings.m_currentVideoSettings.m_CustomNonLinStretch = g_settings.m_bNonLinStretch;
   g_settings.m_currentVideoSettings.m_CustomVerticalShift = g_settings.m_fVerticalShift;
+
 }

--- a/xbmc/cores/VideoRenderers/BaseRenderer.h
+++ b/xbmc/cores/VideoRenderers/BaseRenderer.h
@@ -90,7 +90,8 @@ protected:
   void       CalculateFrameAspectRatio(unsigned int desired_width, unsigned int desired_height);
   void       ManageDisplay();
 
-  RESOLUTION m_resolution;    // the resolution we're running in
+  RESOLUTION m_resolution;      // the resolution we're running in
+  RESOLUTION m_bestResolution;  // the preferred resolution
   unsigned int m_sourceWidth;
   unsigned int m_sourceHeight;
   float m_sourceFrameRatio;

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -110,6 +110,16 @@ void CAdvancedSettings::Initialize()
   m_videoFpsDetect = 1;
   m_videoDefaultLatency = 0.0;
 
+  m_nativeUpscaleMode = false;
+  m_nativeOverrideFPS = true;
+  m_nativeCorrectPixelRatio = true;
+  m_nativeDestWidth = 1920;
+  m_nativeDestHeight = 1080;
+  m_nativeMinWidth = 0;
+  m_nativeMinHeight = 0;
+  m_nativeMaxWidth = 1024;
+  m_nativeMaxHeight = 768;
+
   m_musicUseTimeSeeking = true;
   m_musicTimeSeekForward = 10;
   m_musicTimeSeekBackward = -10;
@@ -470,6 +480,51 @@ void CAdvancedSettings::ParseSettingsFile(const CStdString &file)
     XMLUtils::GetBoolean(pElement,"allowmpeg4vaapi",m_videoAllowMpeg4VAAPI);    
     XMLUtils::GetBoolean(pElement, "disablebackgrounddeinterlace", m_videoDisableBackgroundDeinterlace);
     XMLUtils::GetInt(pElement, "useocclusionquery", m_videoCaptureUseOcclusionQuery, -1, 1);
+
+    TiXmlElement* pNativeUpscale = pElement->FirstChildElement("nativeupscale");
+    if (pNativeUpscale)
+    {
+      m_nativeUpscaleMode = true;
+
+      XMLUtils::GetBoolean(pNativeUpscale, "overridefps", m_nativeOverrideFPS);
+      XMLUtils::GetBoolean(pNativeUpscale, "correctpixelratio", m_nativeCorrectPixelRatio);
+
+      CStdString tmpStr;
+
+      if (XMLUtils::GetString(pNativeUpscale, "destres",tmpStr))
+      {
+        int destWidth, destHeight;
+
+        if( sscanf(tmpStr.c_str(), "%dx%d", &destWidth, &destHeight) == 2 )
+        { 
+          m_nativeDestWidth = destWidth;
+          m_nativeDestHeight = destHeight;
+        }
+      }
+
+      if (XMLUtils::GetString(pNativeUpscale, "minoutres",tmpStr))
+      {
+        int minWidth, minHeight;
+
+        if( sscanf(tmpStr.c_str(), "%dx%d", &minWidth, &minHeight) == 2 )
+        {
+          m_nativeMinWidth = minWidth;
+          m_nativeMinHeight = minHeight;
+        }
+      }
+
+      if (XMLUtils::GetString(pNativeUpscale, "maxsrcres",tmpStr))
+      {
+        int maxWidth, maxHeight;
+      
+        if( sscanf(tmpStr.c_str(), "%dx%d", &maxWidth, &maxHeight) == 2 )
+        {
+          m_nativeMaxWidth = maxWidth;
+          m_nativeMaxHeight = maxHeight;
+        }
+      }
+
+    }
 
     TiXmlElement* pAdjustRefreshrate = pElement->FirstChildElement("adjustrefreshrate");
     if (pAdjustRefreshrate)

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -153,6 +153,16 @@ class CAdvancedSettings
     bool m_DXVANoDeintProcForProgressive;
     int  m_videoFpsDetect;
 
+    bool m_nativeUpscaleMode;
+    bool m_nativeOverrideFPS;
+    bool m_nativeCorrectPixelRatio;
+    int  m_nativeDestWidth;
+    int  m_nativeDestHeight;
+    int  m_nativeMinWidth;
+    int  m_nativeMinHeight;
+    int  m_nativeMaxWidth;
+    int  m_nativeMaxHeight;
+
     CStdString m_videoDefaultPlayer;
     CStdString m_videoDefaultDVDPlayer;
     float m_videoPlayCountMinimumPercent;


### PR DESCRIPTION
http://forum.xbmc.org/showthread.php?tid=64139&pid=1131505#pid1131505

I spent few hours to dig into it and the results are promising. I'm pretty fresh to xbmc though, so maybe there is better way to deal with it. Anyway, what you need to run native resolution:
- apply the provided patch
- set in your advancedsettings.xml following variable in < video > section:

```
    <video>
        <upscalemode>1</upscalemode>      <!-- upscalemode: 0-default, 1-native scaling -->
    </video>
```
- set your receiver to upscaling mode - upscale source to maximum display resolution (1080p in my case)

How it works:
- the GUI works with maximum resolution
- when the player is spawned it reads the source dimension and sets the renderer to the lowest supported resolution which is the best match for the source resolution
- the movie is played with lowest acceptable resolution and is upscaled by the receiver to 1080p
- when the playback stops, the xbmc GUI is back to default resolution (1080p for me)

Here are few examples, where
USER = default screen resolution
NATIVE = movie resolution
ADJUST2 = final xbmc resolution for playback

<pre><code>
    NOTICE: Display resolution USER : default: 1920x1080 @ 24.00Hz (17)
    NOTICE: Searching for NATIVE resolution: 1920x1080
    NOTICE: Display resolution ADJUST2 : default: 1920x1080 @ 24.00Hz (17)
    .
    NOTICE: Display resolution USER : default: 1920x1080 @ 24.00Hz (17)
    NOTICE: Searching for NATIVE resolution: 1280x720
    NOTICE: Display resolution ADJUST2 : default: 1280x720 @ 50.00Hz (29)
    .
    NOTICE: Display resolution USER : default: 1920x1080 @ 24.00Hz (17)
    NOTICE: Searching for NATIVE resolution: 720x304
    NOTICE: Display resolution ADJUST2 : default: 720x576 @ 50.00Hz (37)
    .
    NOTICE: Display resolution USER : default: 1920x1080 @ 24.00Hz (17)
    NOTICE: Searching for NATIVE resolution: 608x336
    NOTICE: Display resolution ADJUST2 : default: 640x480 @ 60.00Hz (41)
    .
    NOTICE: Display resolution USER : default: 1920x1080 @ 24.00Hz (17)
    NOTICE: Searching for NATIVE resolution: 640x256
    NOTICE: Display resolution ADJUST2 : default: 640x480 @ 60.00Hz (41)
    .
    NOTICE: Display resolution USER : default: 1920x1080 @ 24.00Hz (17)
    NOTICE: Searching for NATIVE resolution: 640x272
    NOTICE: Display resolution ADJUST2 : default: 640x480 @ 60.00Hz (41)
    .
    NOTICE: Display resolution USER : default: 1920x1080 @ 24.00Hz (17)
    NOTICE: Searching for NATIVE resolution: 720x392
    NOTICE: Display resolution ADJUST2 : default: 720x576 @ 50.00Hz (37)
    .
    NOTICE: Display resolution USER : default: 1920x1080 @ 24.00Hz (17)
    NOTICE: Searching for NATIVE resolution: 608x256
    NOTICE: Display resolution ADJUST2 : default: 640x480 @ 60.00Hz (41)
    .
    NOTICE: Display resolution USER : default: 1920x1080 @ 24.00Hz (17)
    NOTICE: Searching for NATIVE resolution: 640x352
    NOTICE: Display resolution ADJUST2 : default: 640x480 @ 60.00Hz (41)
    .
    NOTICE: Display resolution USER : default: 1920x1080 @ 24.00Hz (17)
    NOTICE: Searching for NATIVE resolution: 624x224
    NOTICE: Display resolution ADJUST2 : default: 640x480 @ 60.00Hz (41)
    .
    NOTICE: Display resolution USER : default: 1920x1080 @ 24.00Hz (17)
    NOTICE: Searching for NATIVE resolution: 1280x544
    NOTICE: Display resolution ADJUST2 : default: 1280x720 @ 50.00Hz (29)
    .
    NOTICE: Display resolution USER : default: 1920x1080 @ 24.00Hz (17)
    NOTICE: Searching for NATIVE resolution: 624x352
    NOTICE: Display resolution ADJUST2 : default: 640x480 @ 60.00Hz (41)
</code></pre>


I have to say that results are surprisingly good. I'm using receiver with Marvell Qdeo chip and it is doing great job, the picture is visible better than when xbmc is upscaling directly to 1080p. Well, you need to try yourself to judge.

The function used to find the closest resolution match is very simple, perhaps it might be improved. For now it tries to find the lowest resolution which is equal or higher than source resolution and tries to keep as close as possible to original refresh rate for the display.
