### PR TITLE
Fix deadlock when using xbmcgui.DialogProgress in plugin

### DIFF
--- a/xbmc/filesystem/PluginDirectory.cpp
+++ b/xbmc/filesystem/PluginDirectory.cpp
@@ -515,7 +515,15 @@ bool CPluginDirectory::WaitOnScriptResult(const CStdString &scriptPath, const CS
           label.Format(g_localizeStrings.Get(1041).c_str(), m_listItems->Size());
         progressBar->SetLine(2, label);
       }
-      progressBar->Progress();
+    }
+
+    {
+      CSingleLock lock(g_graphicsContext);
+      g_windowManager.ProcessRenderLoop(false);
+    }
+
+    if (progressBar)
+    {
       if (progressBar->IsCanceled())
       { // user has cancelled our process - cancel our process
         if (!m_cancelled)


### PR DESCRIPTION
This fixes http://trac.xbmc.org/ticket/13113

Currently xbmc deadlocks when using xbmcgui.DialogProgress in plugin before we setup DialogProgress in https://github.com/xbmc/xbmc/blob/master/xbmc/filesystem/PluginDirectory.cpp#L481 :
- CPluginDirectory::WaitOnScriptResult is blocking GUI thread while waiting for plugin results and it will only run render loop (progressBar->Progress(); on L518) if we wait 1500 ms and don't have active DialogProgress
- script can't finish because closing ProcessDialog (from python: either directly via xbmcgui.DialogProgress.close() or on python's obj dealloc) needs running render loop

This commit simply adds processing render loop while waiting for plugin results even if we don't show DialogProgress from CPluginDirectory::WaitOnScriptResult.
