### PR TITLE
Cleanup ISO stack resume code

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -370,6 +370,7 @@ CApplication::CApplication(void)
 #endif
 #endif
   , m_itemCurrentFile(new CFileItem)
+  , m_stackFileItemToUpdate(new CFileItem)
   , m_progressTrackingVideoResumeBookmark(*new CBookmark)
   , m_progressTrackingItem(new CFileItem)
   , m_videoInfoScanner(new CVideoInfoScanner)
@@ -3605,26 +3606,35 @@ bool CApplication::PlayStack(const CFileItem& item, bool bRestart)
     CFileItemList movieList;
     dir.GetDirectory(item.GetPath(), movieList);
 
-    int selectedFile = 1; // if playing from beginning, play file 1.
-    long startoffset = item.m_lStartOffset;
+    // first assume values passed to the stack
+    int selectedFile = item.m_lStartPartNumber;
+    int startoffset = item.m_lStartOffset;
 
-    // We instructed the stack to resume.
+    // check if we instructed the stack to resume from default
     if (startoffset == STARTOFFSET_RESUME) // selected file is not specified, pick the 'last' resume point
-      startoffset = CGUIWindowVideoBase::GetResumeItemOffset(&item);
-
-    if (startoffset & 0xF0000000) /* selected part is specified as a flag */
     {
-      selectedFile = (startoffset>>28);
-      startoffset = startoffset & ~0xF0000000;
-
-      // set startoffset in movieitem. The remaining startoffset is either 0 (just play part from beginning) or positive (then we use STARTOFFSET_RESUME).
-      if (selectedFile > 0 && selectedFile <= (int)movieList.Size())
-        movieList[selectedFile - 1]->m_lStartOffset = startoffset > 0 ? STARTOFFSET_RESUME : 0;
+      if (dbs.Open())
+      {
+        CBookmark bookmark;
+        if (dbs.GetResumeBookMark(item.GetPath(), bookmark))
+        {
+          startoffset = (int)(bookmark.timeInSeconds*75);
+          selectedFile = bookmark.partNumber;
+        }
+        dbs.Close();
+      }
+      else
+        CLog::Log(LOGERROR, "%s - Cannot open VideoDatabase", __FUNCTION__);
     }
 
-    // finally play selected item
+    // set startoffset in movieitem, track stack item for updating purposes, and finally play disc part
     if (selectedFile > 0 && selectedFile <= (int)movieList.Size())
+    {
+      movieList[selectedFile - 1]->m_lStartOffset = startoffset > 0 ? STARTOFFSET_RESUME : 0;
+      movieList[selectedFile - 1]->SetProperty("stackFileItemToUpdate", true);
+      *m_stackFileItemToUpdate = item;
       return PlayFile(*(movieList[selectedFile - 1]));
+    }
   }
   // case 2: all other stacks
   else
@@ -4290,6 +4300,7 @@ void CApplication::SaveFileState(bool bForeground /* = false */)
   if (bForeground)
   {
     CSaveFileStateJob job(*m_progressTrackingItem,
+    *m_stackFileItemToUpdate,
     m_progressTrackingVideoResumeBookmark,
     m_progressTrackingPlayCountUpdate);
 
@@ -4299,6 +4310,7 @@ void CApplication::SaveFileState(bool bForeground /* = false */)
   else
   {
     CJob* job = new CSaveFileStateJob(*m_progressTrackingItem,
+        *m_stackFileItemToUpdate,
         m_progressTrackingVideoResumeBookmark,
         m_progressTrackingPlayCountUpdate);
     CJobManager::GetInstance().AddJob(job, NULL);

--- a/xbmc/Application.h
+++ b/xbmc/Application.h
@@ -370,6 +370,8 @@ protected:
 
   CFileItemPtr m_itemCurrentFile;
   CFileItemList* m_currentStack;
+  CFileItemPtr m_stackFileItemToUpdate;
+
   CStdString m_prevMedia;
   CSplash* m_splash;
   ThreadIdentifier m_threadID;       // application thread ID.  Used in applicationMessanger to know where we are firing a thread with delay from.

--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -74,6 +74,7 @@ CFileItem::CFileItem(const CSong& song)
   m_strPath = song.strFileName;
   GetMusicInfoTag()->SetSong(song);
   m_lStartOffset = song.iStartOffset;
+  m_lStartPartNumber = 0;
   SetProperty("item_start", song.iStartOffset);
   m_lEndOffset = song.iEndOffset;
   m_strThumbnailImage = song.strThumb;
@@ -297,6 +298,7 @@ const CFileItem& CFileItem::operator=(const CFileItem& item)
   }
 
   m_lStartOffset = item.m_lStartOffset;
+  m_lStartPartNumber = item.m_lStartPartNumber;
   m_lEndOffset = item.m_lEndOffset;
   m_strDVDLabel = item.m_strDVDLabel;
   m_strTitle = item.m_strTitle;
@@ -333,6 +335,7 @@ void CFileItem::Reset()
   m_dateTime.Reset();
   m_iDriveType = CMediaSource::SOURCE_TYPE_UNKNOWN;
   m_lStartOffset = 0;
+  m_lStartPartNumber = 0;
   m_lEndOffset = 0;
   m_iprogramCount = 0;
   m_idepth = 1;
@@ -371,6 +374,7 @@ void CFileItem::Archive(CArchive& ar)
     ar << m_iprogramCount;
     ar << m_idepth;
     ar << m_lStartOffset;
+    ar << m_lStartPartNumber;
     ar << m_lEndOffset;
     ar << m_iLockMode;
     ar << m_strLockCode;
@@ -417,6 +421,7 @@ void CFileItem::Archive(CArchive& ar)
     ar >> m_iprogramCount;
     ar >> m_idepth;
     ar >> m_lStartOffset;
+    ar >> m_lStartPartNumber;
     ar >> m_lEndOffset;
     int temp;
     ar >> temp;

--- a/xbmc/FileItem.h
+++ b/xbmc/FileItem.h
@@ -310,6 +310,7 @@ public:
   int m_iprogramCount;
   int m_idepth;
   int m_lStartOffset;
+  int m_lStartPartNumber;
   int m_lEndOffset;
   LockType m_iLockMode;
   CStdString m_strLockCode;

--- a/xbmc/dialogs/GUIDialogContextMenu.cpp
+++ b/xbmc/dialogs/GUIDialogContextMenu.cpp
@@ -308,7 +308,7 @@ void CGUIDialogContextMenu::GetContextButtons(const CStdString &type, const CFil
     {
       // We need to check if there is a detected is inserted!
       buttons.Add(CONTEXT_BUTTON_PLAY_DISC, 341); // Play CD/DVD!
-      if (CGUIWindowVideoBase::GetResumeItemOffset(item.get()) > 0)
+      if (CGUIWindowVideoBase::HasResumeItemOffset(item.get()))
         buttons.Add(CONTEXT_BUTTON_RESUME_DISC, CGUIWindowVideoBase::GetResumeString(*(item.get())));     // Resume Disc
 
       buttons.Add(CONTEXT_BUTTON_EJECT_DISC, 13391);  // Eject/Load CD/DVD!

--- a/xbmc/utils/SaveFileStateJob.h
+++ b/xbmc/utils/SaveFileStateJob.h
@@ -8,13 +8,16 @@
 class CSaveFileStateJob : public CJob
 {
   CFileItem m_item;
+  CFileItem m_item_discstack;
   CBookmark m_bookmark;
   bool      m_updatePlayCount;
 public:
                 CSaveFileStateJob(const CFileItem& item,
+                                  const CFileItem& item_discstack,
                                   const CBookmark& bookmark,
                                   bool updatePlayCount)
                   : m_item(item),
+                    m_item_discstack(item_discstack),
                     m_bookmark(bookmark),
                     m_updatePlayCount(updatePlayCount) {}
   virtual       ~CSaveFileStateJob() {}
@@ -84,6 +87,12 @@ bool CSaveFileStateJob::DoWork()
         {
           videodatabase.SetStreamDetailsForFile(m_item.GetVideoInfoTag()->m_streamDetails,progressTrackingFile);
           updateListing = true;
+        }
+        // in order to properly update the the list, we need to update the stack item which is held in g_application.m_stackFileItemToUpdate
+        if (m_item.HasProperty("stackFileItemToUpdate"))
+        {
+          m_item = m_item_discstack; // as of now, the item is replaced by the discstack item
+          videodatabase.GetResumePoint(*m_item.GetVideoInfoTag());
         }
         videodatabase.Close();
 

--- a/xbmc/video/Bookmark.cpp
+++ b/xbmc/video/Bookmark.cpp
@@ -32,6 +32,7 @@ void CBookmark::Reset()
   seasonNumber = 0;
   timeInSeconds = 0.0f;
   totalTimeInSeconds = 0.0f;
+  partNumber = 0;
   type = STANDARD;
 }
 

--- a/xbmc/video/Bookmark.h
+++ b/xbmc/video/Bookmark.h
@@ -31,6 +31,7 @@ public:
   void Reset();
   double timeInSeconds;
   double totalTimeInSeconds;
+  long partNumber;
   CStdString thumbNailImage;
   CStdString playerState;
   CStdString player;

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -2269,38 +2269,38 @@ void CVideoDatabase::GetBookMarksForFile(const CStdString& strFilenameAndPath, V
     }
     else
     {
-    int idFile = GetFileId(strFilenameAndPath);
-    if (idFile < 0) return ;
-    if (!bAppend)
-      bookmarks.erase(bookmarks.begin(), bookmarks.end());
-    if (NULL == m_pDB.get()) return ;
-    if (NULL == m_pDS.get()) return ;
+      int idFile = GetFileId(strFilenameAndPath);
+      if (idFile < 0) return ;
+      if (!bAppend)
+        bookmarks.erase(bookmarks.begin(), bookmarks.end());
+      if (NULL == m_pDB.get()) return ;
+      if (NULL == m_pDS.get()) return ;
 
-    CStdString strSQL=PrepareSQL("select * from bookmark where idFile=%i and type=%i order by timeInSeconds", idFile, (int)type);
-    m_pDS->query( strSQL.c_str() );
-    while (!m_pDS->eof())
-    {
-      CBookmark bookmark;
-      bookmark.timeInSeconds = m_pDS->fv("timeInSeconds").get_asDouble();
-      bookmark.partNumber = partNumber;
-      bookmark.totalTimeInSeconds = m_pDS->fv("totalTimeInSeconds").get_asDouble();
-      bookmark.thumbNailImage = m_pDS->fv("thumbNailImage").get_asString();
-      bookmark.playerState = m_pDS->fv("playerState").get_asString();
-      bookmark.player = m_pDS->fv("player").get_asString();
-      bookmark.type = type;
-      if (type == CBookmark::EPISODE)
+      CStdString strSQL=PrepareSQL("select * from bookmark where idFile=%i and type=%i order by timeInSeconds", idFile, (int)type);
+      m_pDS->query( strSQL.c_str() );
+      while (!m_pDS->eof())
       {
-        CStdString strSQL2=PrepareSQL("select c%02d, c%02d from episode where c%02d=%i order by c%02d, c%02d", VIDEODB_ID_EPISODE_EPISODE, VIDEODB_ID_EPISODE_SEASON, VIDEODB_ID_EPISODE_BOOKMARK, m_pDS->fv("idBookmark").get_asInt(), VIDEODB_ID_EPISODE_SORTSEASON, VIDEODB_ID_EPISODE_SORTEPISODE);
-        m_pDS2->query(strSQL2.c_str());
-        bookmark.episodeNumber = m_pDS2->fv(0).get_asInt();
-        bookmark.seasonNumber = m_pDS2->fv(1).get_asInt();
-        m_pDS2->close();
+        CBookmark bookmark;
+        bookmark.timeInSeconds = m_pDS->fv("timeInSeconds").get_asDouble();
+        bookmark.partNumber = partNumber;
+        bookmark.totalTimeInSeconds = m_pDS->fv("totalTimeInSeconds").get_asDouble();
+        bookmark.thumbNailImage = m_pDS->fv("thumbNailImage").get_asString();
+        bookmark.playerState = m_pDS->fv("playerState").get_asString();
+        bookmark.player = m_pDS->fv("player").get_asString();
+        bookmark.type = type;
+        if (type == CBookmark::EPISODE)
+        {
+          CStdString strSQL2=PrepareSQL("select c%02d, c%02d from episode where c%02d=%i order by c%02d, c%02d", VIDEODB_ID_EPISODE_EPISODE, VIDEODB_ID_EPISODE_SEASON, VIDEODB_ID_EPISODE_BOOKMARK, m_pDS->fv("idBookmark").get_asInt(), VIDEODB_ID_EPISODE_SORTSEASON, VIDEODB_ID_EPISODE_SORTEPISODE);
+          m_pDS2->query(strSQL2.c_str());
+          bookmark.episodeNumber = m_pDS2->fv(0).get_asInt();
+          bookmark.seasonNumber = m_pDS2->fv(1).get_asInt();
+          m_pDS2->close();
+        }
+        bookmarks.push_back(bookmark);
+        m_pDS->next();
       }
-      bookmarks.push_back(bookmark);
-      m_pDS->next();
-    }
-    //sort(bookmarks.begin(), bookmarks.end(), SortBookmarks);
-    m_pDS->close();
+      //sort(bookmarks.begin(), bookmarks.end(), SortBookmarks);
+      m_pDS->close();
     }
   }
   catch (...)
@@ -2983,17 +2983,17 @@ bool CVideoDatabase::GetResumePoint(CVideoInfoTag& tag)
     }
     else
     {
-    CStdString strSQL=PrepareSQL("select timeInSeconds, totalTimeInSeconds from bookmark where idFile=%i and type=%i order by timeInSeconds", tag.m_iFileId, CBookmark::RESUME);
-    m_pDS2->query( strSQL.c_str() );
-    if (!m_pDS2->eof())
-    {
-      tag.m_resumePoint.timeInSeconds = m_pDS2->fv(0).get_asDouble();
-      tag.m_resumePoint.totalTimeInSeconds = m_pDS2->fv(1).get_asDouble();
-      tag.m_resumePoint.partNumber = 0; // regular files or non-iso stacks don't need partNumber
-      tag.m_resumePoint.type = CBookmark::RESUME;
-      match = true;
-    }
-    m_pDS2->close();
+      CStdString strSQL=PrepareSQL("select timeInSeconds, totalTimeInSeconds from bookmark where idFile=%i and type=%i order by timeInSeconds", tag.m_iFileId, CBookmark::RESUME);
+      m_pDS2->query( strSQL.c_str() );
+      if (!m_pDS2->eof())
+      {
+        tag.m_resumePoint.timeInSeconds = m_pDS2->fv(0).get_asDouble();
+        tag.m_resumePoint.totalTimeInSeconds = m_pDS2->fv(1).get_asDouble();
+        tag.m_resumePoint.partNumber = 0; // regular files or non-iso stacks don't need partNumber
+        tag.m_resumePoint.type = CBookmark::RESUME;
+        match = true;
+      }
+      m_pDS2->close();
     }
   }
   catch (...)

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -463,7 +463,7 @@ public:
   bool GetStackTimes(const CStdString &filePath, std::vector<int> &times);
   void SetStackTimes(const CStdString &filePath, std::vector<int> &times);
 
-  void GetBookMarksForFile(const CStdString& strFilenameAndPath, VECBOOKMARKS& bookmarks, CBookmark::EType type = CBookmark::STANDARD, bool bAppend=false);
+  void GetBookMarksForFile(const CStdString& strFilenameAndPath, VECBOOKMARKS& bookmarks, CBookmark::EType type = CBookmark::STANDARD, bool bAppend=false, long partNumber=0);
   void AddBookMarkToFile(const CStdString& strFilenameAndPath, const CBookmark &bookmark, CBookmark::EType type = CBookmark::STANDARD);
   bool GetResumeBookMark(const CStdString& strFilenameAndPath, CBookmark &bookmark);
   void DeleteResumeBookMark(const CStdString &strFilenameAndPath);
@@ -472,7 +472,7 @@ public:
   bool GetBookMarkForEpisode(const CVideoInfoTag& tag, CBookmark& bookmark);
   void AddBookMarkForEpisode(const CVideoInfoTag& tag, const CBookmark& bookmark);
   void DeleteBookMarkForEpisode(const CVideoInfoTag& tag);
-  bool GetResumePoint(CVideoInfoTag& tag) const;
+  bool GetResumePoint(CVideoInfoTag& tag);
 
   // scraper settings
   void SetScraperForPath(const CStdString& filePath, const ADDON::ScraperPtr& info, const VIDEO::SScanSettings& settings);

--- a/xbmc/video/windows/GUIWindowVideoBase.h
+++ b/xbmc/video/windows/GUIWindowVideoBase.h
@@ -35,7 +35,8 @@ public:
   virtual bool OnAction(const CAction &action);
 
   void PlayMovie(const CFileItem *item);
-  static int GetResumeItemOffset(const CFileItem *item);
+  static void GetResumeItemOffset(const CFileItem *item, int& startoffset, int& partNumber);
+  static bool HasResumeItemOffset(const CFileItem *item);
 
   void AddToDatabase(int iItem);
   virtual void OnInfo(CFileItem* pItem, const ADDON::ScraperPtr& scraper);


### PR DESCRIPTION
this pull request addresses a number of things in the sphere of resume-play of ISO stacks. 

1) move the intelligence down from GUIWindowVideoBase to the VideoDatabase. All we need to know in the GUIWindowVideoBase is what to do with a Bookmark that contains a partnumber > 0.
The VideoDatabase methods GetBookmarksForFile and GetResumePoint know how to deal with ISO stacks now, which makes the code more reusable for non-GUI callers.

2) the resume "flag" as well as "percent complete" for an ISO stack (the little white triangle in Confluence lists) now correctly shows. This was not the case due to the VideoInfoTag resume bookmark not set (prior to the code changes described above in 1). The rule is that the bookmark of the "highest" part counts. 

3) additional code cleanup and refactoring - see comments below.
