### PR TITLE
Bunch of changes for libcmyth to match upstream

### DIFF
--- a/lib/cmyth/Win32/include/mysql/mysql.h
+++ b/lib/cmyth/Win32/include/mysql/mysql.h
@@ -50,7 +50,7 @@ typedef char my_bool;
 #define __WIN__
 #endif
 #ifdef __WIN__
-#include <winsock.h>				/* For windows */
+#include <winsock2.h>				/* For windows */
 #endif
 #if !defined(__WIN__)
 #define STDCALL

--- a/lib/cmyth/Win32/libcmyth.def
+++ b/lib/cmyth/Win32/libcmyth.def
@@ -137,7 +137,7 @@ EXPORTS
 	cmyth_proginfo_host
 	cmyth_proginfo_card_id
 	cmyth_proginfo_recgroup
-	cmyth_proginfo_prodyear
+	cmyth_proginfo_year
 	cmyth_get_delete_list
 	cmyth_proglist_create
 	cmyth_proglist_get_item

--- a/lib/cmyth/Win32/libcmyth.def
+++ b/lib/cmyth/Win32/libcmyth.def
@@ -91,7 +91,7 @@ EXPORTS
 	cmyth_get_bookmark_mark
 	cmyth_get_bookmark_offset
 	cmyth_mysql_get_commbreak_list
-	cmyth_mythtv_remove_previos_recorded
+	cmyth_mythtv_remove_previous_recorded
 	cmyth_mysql_testdb_connection
 	cmyth_chanlist_create
 	cmyth_chanlist_get_item
@@ -216,3 +216,8 @@ EXPORTS
 	cmyth_file_read
 	cmyth_livetv_read
 	cmyth_get_cutlist
+	cmyth_tuner_type_check
+	cmyth_update_bookmark_setting
+	cmyth_proginfo_port
+	cmyth_proginfo_season
+	cmyth_proginfo_episode

--- a/lib/cmyth/include/cmyth/cmyth.h
+++ b/lib/cmyth/include/cmyth/cmyth.h
@@ -1056,6 +1056,7 @@ extern cmyth_freespace_t cmyth_freespace_create(void);
  */
 extern long long cmyth_get_bookmark(cmyth_conn_t conn, cmyth_proginfo_t prog);
 extern int cmyth_get_bookmark_offset(cmyth_database_t db, long chanid, long long mark);
+extern int cmyth_update_bookmark_setting(cmyth_database_t, cmyth_proginfo_t);
 extern int cmyth_get_bookmark_mark(cmyth_database_t, cmyth_proginfo_t, long long);
 extern int cmyth_set_bookmark(cmyth_conn_t conn, cmyth_proginfo_t prog,
 	long long bookmark);

--- a/lib/cmyth/include/cmyth/cmyth.h
+++ b/lib/cmyth/include/cmyth/cmyth.h
@@ -579,6 +579,7 @@ extern int cmyth_livetv_read(cmyth_recorder_t rec,
 extern int cmyth_livetv_keep_recording(cmyth_recorder_t rec, cmyth_database_t db, int keep);
 
 extern int mythtv_new_livetv(void);
+extern int cmyth_tuner_type_check(cmyth_database_t db, cmyth_recorder_t rec, int check_tuner_enabled);
 
 /*
  * -----------------------------------------------------------------

--- a/lib/cmyth/include/cmyth/cmyth.h
+++ b/lib/cmyth/include/cmyth/cmyth.h
@@ -81,12 +81,12 @@ typedef enum {
 	CHANNEL_DIRECTION_UP = 0,
 	CHANNEL_DIRECTION_DOWN = 1,
 	CHANNEL_DIRECTION_FAVORITE = 2,
-	CHANNEL_DIRECTION_SAME = 4
+	CHANNEL_DIRECTION_SAME = 4,
 } cmyth_channeldir_t;
 
 typedef enum {
 	ADJ_DIRECTION_UP = 1,
-	ADJ_DIRECTION_DOWN = 0
+	ADJ_DIRECTION_DOWN = 0,
 } cmyth_adjdir_t;
 
 typedef enum {
@@ -95,13 +95,13 @@ typedef enum {
 	BROWSE_DIRECTION_DOWN = 2,
 	BROWSE_DIRECTION_LEFT = 3,
 	BROWSE_DIRECTION_RIGHT = 4,
-	BROWSE_DIRECTION_FAVORITE = 5
+	BROWSE_DIRECTION_FAVORITE = 5,
 } cmyth_browsedir_t;
 
 typedef enum {
 	WHENCE_SET = 0,
 	WHENCE_CUR = 1,
-	WHENCE_END = 2
+	WHENCE_END = 2,
 } cmyth_whence_t;
 
 typedef enum {
@@ -121,13 +121,13 @@ typedef enum {
 	CMYTH_EVENT_SYSTEM_EVENT,
 	CMYTH_EVENT_UPDATE_FILE_SIZE,
 	CMYTH_EVENT_GENERATED_PIXMAP,
-	CMYTH_EVENT_CLEAR_SETTINGS_CACHE
+	CMYTH_EVENT_CLEAR_SETTINGS_CACHE,
 } cmyth_event_t;
 
 #define CMYTH_NUM_SORTS 2
 typedef enum {
 	MYTHTV_SORT_DATE_RECORDED = 0,
-	MYTHTV_SORT_ORIGINAL_AIRDATE
+	MYTHTV_SORT_ORIGINAL_AIRDATE,
 } cmyth_proglist_sort_t;
 
 struct cmyth_timestamp;
@@ -706,7 +706,7 @@ typedef enum {
 	RS_LATER_SHOWING = 8,
 	RS_REPEAT = 9,
 	RS_LOW_DISKSPACE = 11,
-	RS_TUNER_BUSY = 12
+	RS_TUNER_BUSY = 12,
 } cmyth_proginfo_rec_status_t;
 
 /**

--- a/lib/cmyth/include/cmyth/cmyth.h
+++ b/lib/cmyth/include/cmyth/cmyth.h
@@ -1119,7 +1119,7 @@ extern int cmyth_get_delete_list(cmyth_conn_t, char *, cmyth_proglist_t);
 
 #define PROGRAM_ADJUST  3600
 
-extern int cmyth_mythtv_remove_previos_recorded(cmyth_database_t db,char *query);
+extern int cmyth_mythtv_remove_previous_recorded(cmyth_database_t db,char *query);
 
 extern cmyth_chanlist_t cmyth_mysql_get_chanlist(cmyth_database_t db);
 #endif /* __CMYTH_H */

--- a/lib/cmyth/include/cmyth/cmyth.h
+++ b/lib/cmyth/include/cmyth/cmyth.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2004-2006, Eric Lund, Jon Gettler
+ *  Copyright (C) 2004-2012, Eric Lund, Jon Gettler
  *  http://www.mvpmc.org/
  *
  *  This library is free software; you can redistribute it and/or
@@ -15,6 +15,22 @@
  *  You should have received a copy of the GNU Lesser General Public
  *  License along with this library; if not, write to the Free Software
  *  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+
+/*! \mainpage cmyth
+ *
+ * cmyth is a library that provides a C language API to access and control
+ * a MythTV backend.
+ *
+ * \section projectweb Project website
+ * http://www.mvpmc.org/
+ *
+ * \section repos Source repositories
+ * http://git.mvpmc.org/
+ *
+ * \section libraries Libraries
+ * \li \link cmyth.h libcmyth \endlink
+ * \li \link refmem.h librefmem \endlink
  */
 
 /** \file cmyth.h
@@ -234,7 +250,7 @@ extern cmyth_conn_t cmyth_conn_connect_event(char *server,
 					     unsigned buflen, int tcp_rcvbuf);
 
 /**
- * Create a file connection to a backend.
+ * Create a file connection to a backend for reading a recording.
  * \param prog program handle
  * \param control control handle
  * \param buflen buffer size for the connection to use
@@ -364,6 +380,11 @@ extern char * cmyth_conn_get_setting(cmyth_conn_t conn,
  */
 extern cmyth_event_t cmyth_event_get(cmyth_conn_t conn, char * data, int len);
 
+/**
+ * Selects on the event socket, waiting for an event to show up.
+ * allows nonblocking access to events.
+ * \return <= 0 on failure
+ */
 extern int cmyth_event_select(cmyth_conn_t conn, struct timeval *timeout);
 
 /*

--- a/lib/cmyth/include/cmyth/cmyth.h
+++ b/lib/cmyth/include/cmyth/cmyth.h
@@ -1056,7 +1056,7 @@ extern cmyth_freespace_t cmyth_freespace_create(void);
  * -------
  */
 extern long long cmyth_get_bookmark(cmyth_conn_t conn, cmyth_proginfo_t prog);
-extern int cmyth_get_bookmark_offset(cmyth_database_t db, long chanid, long long mark);
+extern int cmyth_get_bookmark_offset(cmyth_database_t db, long chanid, long long mark, char *starttime, int mode);
 extern int cmyth_update_bookmark_setting(cmyth_database_t, cmyth_proginfo_t);
 extern long long cmyth_get_bookmark_mark(cmyth_database_t, cmyth_proginfo_t, long long, int);
 extern int cmyth_set_bookmark(cmyth_conn_t conn, cmyth_proginfo_t prog,

--- a/lib/cmyth/include/cmyth/cmyth.h
+++ b/lib/cmyth/include/cmyth/cmyth.h
@@ -965,9 +965,9 @@ extern char *cmyth_proginfo_chanicon(cmyth_proginfo_t prog);
 /**
  * Retrieve the production year for this program info
  * \param prog proginfo handle
- * \return null-terminated string
+ * \return production year
  */
-extern char *cmyth_proginfo_prodyear(cmyth_proginfo_t prog);
+extern unsigned short cmyth_proginfo_year(cmyth_proginfo_t prog);
 
 /*
  * -----------------------------------------------------------------

--- a/lib/cmyth/include/cmyth/cmyth.h
+++ b/lib/cmyth/include/cmyth/cmyth.h
@@ -883,6 +883,8 @@ extern long long cmyth_proginfo_length(cmyth_proginfo_t prog);
  */
 extern char *cmyth_proginfo_host(cmyth_proginfo_t prog);
 
+extern int cmyth_proginfo_port(cmyth_proginfo_t prog);
+
 /**
  * Determine if two proginfo handles refer to the same program.
  * \param a proginfo handle a

--- a/lib/cmyth/include/cmyth/cmyth.h
+++ b/lib/cmyth/include/cmyth/cmyth.h
@@ -214,7 +214,7 @@ extern void cmyth_dbg_none(void);
 extern void cmyth_dbg(int level, char *fmt, ...);
 
 /**
- * Define a callback to use to send messages rather than using stderr
+ * Define a callback to use to send messages rather than using stdout
  * \param msgcb function pointer to pass a string to
  */
 extern void cmyth_set_dbg_msgcallback(void (*msgcb)(int level,char *));

--- a/lib/cmyth/include/cmyth/cmyth.h
+++ b/lib/cmyth/include/cmyth/cmyth.h
@@ -1058,7 +1058,7 @@ extern cmyth_freespace_t cmyth_freespace_create(void);
 extern long long cmyth_get_bookmark(cmyth_conn_t conn, cmyth_proginfo_t prog);
 extern int cmyth_get_bookmark_offset(cmyth_database_t db, long chanid, long long mark);
 extern int cmyth_update_bookmark_setting(cmyth_database_t, cmyth_proginfo_t);
-extern int cmyth_get_bookmark_mark(cmyth_database_t, cmyth_proginfo_t, long long);
+extern long long cmyth_get_bookmark_mark(cmyth_database_t, cmyth_proginfo_t, long long, int);
 extern int cmyth_set_bookmark(cmyth_conn_t conn, cmyth_proginfo_t prog,
 	long long bookmark);
 extern cmyth_commbreaklist_t cmyth_commbreaklist_create(void);

--- a/lib/cmyth/include/debug.h
+++ b/lib/cmyth/include/debug.h
@@ -1,4 +1,4 @@
-/** \file mvp_debug.h
+/** \file debug.h
  * A C library for generating and controlling debug output
  */
 

--- a/lib/cmyth/include/debug.h
+++ b/lib/cmyth/include/debug.h
@@ -7,6 +7,7 @@
 
 #include <stdio.h>
 #include <stdarg.h>
+#include <string.h>
 
 typedef struct {
 	char *name;

--- a/lib/cmyth/include/debug.h
+++ b/lib/cmyth/include/debug.h
@@ -2,8 +2,8 @@
  * A C library for generating and controlling debug output
  */
 
-#ifndef __MVP_DEBUG_H
-#define  __MVP_DEBUG_H
+#ifndef __CMYTH_DEBUG_H
+#define  __CMYTH_DEBUG_H
 
 #include <stdio.h>
 #include <stdarg.h>
@@ -13,16 +13,16 @@ typedef struct {
 	int  cur_level;
 	int  (*selector)(int plevel, int slevel);
 	void (*msg_callback)(int level, char *msg);
-} mvp_debug_ctx_t;
+} cmyth_debug_ctx_t;
 
 /**
- * Make a static initializer for an mvp_debug_ctx_t which provides a debug
+ * Make a static initializer for an cmyth_debug_ctx_t which provides a debug
  * context for a subsystem.  This is a macro.
  * \param n subsystem name (a static string is fine)
  * \param l initial debug level for the subsystem
  * \param s custom selector function pointer (NULL is okay)
  */
-#define MVP_DEBUG_CTX_INIT(n,l,s) { n, l, s, NULL }
+#define CMYTH_DEBUG_CTX_INIT(n,l,s) { n, l, s, NULL }
 
 /**
  * Set the debug level to be used for the subsystem
@@ -31,7 +31,7 @@ typedef struct {
  * \return an integer subsystem id used for future interaction
  */
 static inline void
-mvp_dbg_setlevel(mvp_debug_ctx_t *ctx, int level)
+__cmyth_dbg_setlevel(cmyth_debug_ctx_t *ctx, int level)
 {
 	if (ctx != NULL) {
 		ctx->cur_level = level;
@@ -46,7 +46,7 @@ mvp_dbg_setlevel(mvp_debug_ctx_t *ctx, int level)
  * \param ... arguments to the format
  */
 static inline void
-mvp_dbg(mvp_debug_ctx_t *ctx, int level, char *fmt, va_list ap)
+__cmyth_dbg(cmyth_debug_ctx_t *ctx, int level, char *fmt, va_list ap)
 {
 	char msg[4096];
 	int len;
@@ -65,4 +65,4 @@ mvp_dbg(mvp_debug_ctx_t *ctx, int level, char *fmt, va_list ap)
 	}
 }
 
-#endif /*  __MVP_DEBUG_H */
+#endif /*  __CMYTH_DEBUG_H */

--- a/lib/cmyth/include/refmem/atomic.h
+++ b/lib/cmyth/include/refmem/atomic.h
@@ -1,3 +1,22 @@
+/*
+ *  Copyright (C) 2004-2008, Eric Lund, Jon Gettler
+ *  http://www.mvpmc.org/
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2.1 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+
 #ifndef __MVP_ATOMIC_H
 #define __MVP_ATOMIC_H
 

--- a/lib/cmyth/include/refmem/refmem.h
+++ b/lib/cmyth/include/refmem/refmem.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2004-2006, Eric Lund, Jon Gettler
+ *  Copyright (C) 2004-2012, Eric Lund, Jon Gettler
  *  http://www.mvpmc.org/
  *
  *  This library is free software; you can redistribute it and/or

--- a/lib/cmyth/libcmyth/bookmark.c
+++ b/lib/cmyth/libcmyth/bookmark.c
@@ -32,7 +32,7 @@ long long cmyth_get_bookmark(cmyth_conn_t conn, cmyth_proginfo_t prog)
 	int err;
 	long long ret;
 	int count;
-	long long ll;
+	int64_t ll;
 	int r;
 	char start_ts_dt[CMYTH_TIMESTAMP_LEN + 1];
 	cmyth_datetime_to_string(start_ts_dt, prog->proginfo_rec_start_ts);
@@ -58,9 +58,9 @@ long long cmyth_get_bookmark(cmyth_conn_t conn, cmyth_proginfo_t prog)
 		ret = count;
 		goto out;
 	}
-	if ((r=cmyth_rcv_long_long(conn, &err, &ll, count)) < 0) {
+	if ((r=cmyth_rcv_int64(conn, &err, &ll, count)) < 0) {
 		cmyth_dbg(CMYTH_DBG_ERROR,
-			"%s: cmyth_rcv_long_long() failed (%d)\n",
+			"%s: cmyth_rcv_int64() failed (%d)\n",
 			__FUNCTION__, r);
 		ret = err;
 		goto out;

--- a/lib/cmyth/libcmyth/bookmark.c
+++ b/lib/cmyth/libcmyth/bookmark.c
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2006, Jon Gettler
+ *  Copyright (C) 2005-2009, Jon Gettler
  *  http://www.mvpmc.org/
  *
  *  This library is free software; you can redistribute it and/or

--- a/lib/cmyth/libcmyth/cmyth_local.h
+++ b/lib/cmyth/libcmyth/cmyth_local.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2004-2006, Eric Lund, Jon Gettler
+ *  Copyright (C) 2004-2012, Eric Lund, Jon Gettler
  *  http://www.mvpmc.org/
  *
  *  This library is free software; you can redistribute it and/or

--- a/lib/cmyth/libcmyth/cmyth_local.h
+++ b/lib/cmyth/libcmyth/cmyth_local.h
@@ -256,7 +256,7 @@ struct cmyth_proginfo {
 	unsigned long proginfo_audioproperties; /* new in v35 */
 	unsigned long proginfo_videoproperties; /* new in v35 */
 	unsigned long proginfo_subtitletype; /* new in v35 */
-	char *proginfo_prodyear; /* new in v41 */
+	unsigned short proginfo_year; /* new in v43 */
 };
 
 struct cmyth_proglist {

--- a/lib/cmyth/libcmyth/cmyth_local.h
+++ b/lib/cmyth/libcmyth/cmyth_local.h
@@ -150,10 +150,10 @@ struct cmyth_file {
 	long file_id;			/**< file identifier */
 	/** callback when close is completed */
 	void (*closed_callback)(cmyth_file_t file);
-	unsigned long long file_start;	/**< file start offest */
-	unsigned long long file_length;	/**< file length */
-	unsigned long long file_pos;	/**< current file position */
-	unsigned long long file_req;	/**< current file position requested */
+	uint64_t file_start;	/**< file start offest */
+	uint64_t file_length;	/**< file length */
+	uint64_t file_pos;	/**< current file position */
+	uint64_t file_req;	/**< current file position requested */
 	cmyth_conn_t file_control;	/**< master backend connection */
 };
 
@@ -161,10 +161,10 @@ struct cmyth_ringbuf {
 	cmyth_conn_t conn_data;
 	long file_id;
 	char *ringbuf_url;
-	unsigned long long ringbuf_size;
-	unsigned long long file_length;
-	unsigned long long file_pos;
-	unsigned long long ringbuf_fill;
+	uint64_t ringbuf_size;
+	uint64_t file_length;
+	uint64_t file_pos;
+	uint64_t ringbuf_fill;
 	char *ringbuf_hostname;
 	int ringbuf_port;
 };
@@ -177,7 +177,7 @@ struct cmyth_rec_num {
 
 struct cmyth_keyframe {
 	unsigned long keyframe_number;
-	unsigned long long keyframe_pos;
+	uint64_t keyframe_pos;
 };
 
 struct cmyth_posmap {
@@ -186,8 +186,8 @@ struct cmyth_posmap {
 };
 
 struct cmyth_freespace {
-	unsigned long long freespace_total;
-	unsigned long long freespace_used;
+	uint64_t freespace_total;
+	uint64_t freespace_used;
 };
 
 struct cmyth_timestamp {
@@ -213,7 +213,7 @@ struct cmyth_proginfo {
 	char *proginfo_channame;  /* Deprecated in V8, simulated for compat. */
 	char *proginfo_chanicon;  /* New in V8 */
 	char *proginfo_url;
-	long long proginfo_Length;
+	int64_t proginfo_Length;
 	cmyth_timestamp_t proginfo_start_ts;
 	cmyth_timestamp_t proginfo_end_ts;
 	unsigned long proginfo_conflicting; /* Deprecated in V8, always 0 */
@@ -295,14 +295,27 @@ extern int cmyth_rcv_short(cmyth_conn_t conn, int *err, short *buf, int count);
 extern int cmyth_rcv_long(cmyth_conn_t conn, int *err, long *buf, int count);
 #define cmyth_rcv_u_long(c, e, b, n) cmyth_rcv_long(c, e, (long*)b, n)
 
-#define cmyth_rcv_long_long __cmyth_rcv_long_long
-extern int cmyth_rcv_long_long(cmyth_conn_t conn, int *err, long long *buf,
+#define cmyth_rcv_old_int64 __cmyth_rcv_old_int64
+extern int cmyth_rcv_old_int64(cmyth_conn_t conn, int *err, int64_t *buf,
 			       int count);
-#define cmyth_rcv_u_long_long(c, e, b, n) cmyth_rcv_long_long(c, e, (long long*)b, n)
 
-#define cmyth_rcv_int64 __cmyth_rcv_int64
-extern int cmyth_rcv_int64(cmyth_conn_t conn, int *err, long long *buf,
-			       int count);
+#define cmyth_rcv_new_int64 __cmyth_rcv_new_int64
+extern int cmyth_rcv_new_int64(cmyth_conn_t conn, int *err, int64_t *buf,
+			       int count, int forced);
+
+#define cmyth_rcv_old_uint64 __cmyth_rcv_old_uint64
+extern int cmyth_rcv_old_uint64(cmyth_conn_t conn, int *err, uint64_t *buf,
+				int count);
+
+#define cmyth_rcv_new_uint64 __cmyth_rcv_new_uint64
+extern int cmyth_rcv_new_uint64(cmyth_conn_t conn, int *err, uint64_t *buf,
+				int count, int forced);
+
+#define cmyth_rcv_int64(conn, err, buf, count)	\
+	cmyth_rcv_new_int64(conn, err, buf, count, 0)
+
+#define cmyth_rcv_uint64(conn, err, buf, count)	\
+	cmyth_rcv_new_uint64(conn, err, buf, count, 0)
 
 #define cmyth_rcv_ubyte __cmyth_rcv_ubyte
 extern int cmyth_rcv_ubyte(cmyth_conn_t conn, int *err, unsigned char *buf,

--- a/lib/cmyth/libcmyth/cmyth_local.h
+++ b/lib/cmyth/libcmyth/cmyth_local.h
@@ -25,56 +25,36 @@
 #ifndef __CMYTH_LOCAL_H
 #define __CMYTH_LOCAL_H
 
-#ifdef _MSC_VER
 #include <stdio.h>
-#include <malloc.h>
-#else
-#include <unistd.h>
+#include <stdlib.h>
+#if !defined(_MSC_VER)
+#include <sys/time.h>
 #endif
 #include <refmem/refmem.h>
 #include <cmyth/cmyth.h>
 #include <time.h>
-#include <mysql/mysql.h>
 #include <stdint.h>
+#include <mysql/mysql.h>
 
-#ifdef _MSC_VER
-#pragma warning(disable:4267)
-#define pthread_mutex_lock(a)
-#define pthread_mutex_unlock(a)
-#define PTHREAD_MUTEX_INITIALIZER NULL;
-typedef void* pthread_mutex_t;
-extern pthread_mutex_t mutex;
-#define mutex __cmyth_mutex
-#define SHUT_RDWR SD_BOTH
-typedef SOCKET cmyth_socket_t;
-typedef int socklen_t;
-#define snprintf _snprintf
-#define sleep(a) Sleep(a*1000)
-#define usleep(a) Sleep(a/1000)
-static inline struct tm* localtime_r (const time_t *clock, struct tm *result) { 
-	struct tm* data;
-  if (!clock || !result) return NULL;
-  data = localtime(clock);
-  if (!data) return NULL;
-	memcpy(result,data,sizeof(*result)); 
-	return result; 
-}
-static inline __int64 atoll(const char* s)
-{
-  __int64 value;
-  if(sscanf(s,"%I64d", &value))
-    return value;
-  else
-    return 0;
-}
-
+#if defined(_MSC_VER)
+#include "cmyth_msc.h"
 #else
+#include <unistd.h>
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <sys/select.h>
+#include <netinet/in.h>
+#include <netdb.h>
+#include <arpa/inet.h>
 #include <pthread.h>
+
+typedef int cmyth_socket_t;
+#define closesocket(fd) close(fd)
+#endif /* _MSC_VER */
+
 #define mutex __cmyth_mutex
 extern pthread_mutex_t mutex;
-#define closesocket(fd) close(fd)
-typedef int cmyth_socket_t;
-#endif
+
 /*
  * Some useful constants
  */

--- a/lib/cmyth/libcmyth/cmyth_msc.h
+++ b/lib/cmyth/libcmyth/cmyth_msc.h
@@ -1,0 +1,79 @@
+/*
+ *  Copyright (C) 2012, Jon Gettler
+ *  http://www.mvpmc.org/
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2.1 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+
+/**
+ * \file cmyth_msc.h
+ * Contain most of the Microsoft related differences in a single file.
+ */
+
+#ifndef __CMYTH_MSC_H
+#define __CMYTH_MSC_H
+
+#if !defined(_MSC_VER)
+#error This file may only be included on windows builds!
+#endif /* !_MSC_VER */
+
+#include <malloc.h>
+#include <winsock2.h>
+#include <Ws2tcpip.h>
+
+#pragma warning(disable:4267)
+#pragma warning(disable:4996)
+
+#define pthread_mutex_lock(a)
+#define pthread_mutex_unlock(a)
+#define PTHREAD_MUTEX_INITIALIZER NULL;
+typedef void *pthread_mutex_t;
+
+#undef ECANCELED
+#undef ETIMEDOUT
+
+#define ECANCELED -1
+#define ETIMEDOUT -1
+#define SHUT_RDWR SD_BOTH
+
+typedef SOCKET cmyth_socket_t;
+typedef int socklen_t;
+
+#define snprintf _snprintf
+#define sleep(a) Sleep(a*1000)
+#define usleep(a) Sleep(a/1000)
+
+static inline struct tm *localtime_r(const time_t * clock, struct tm *result)
+{
+	struct tm *data;
+	if (!clock || !result)
+		return NULL;
+	data = localtime(clock);
+	if (!data)
+		return NULL;
+	memcpy(result, data, sizeof(*result));
+	return result;
+}
+
+static inline __int64 atoll(const char *s)
+{
+	__int64 value;
+	if (sscanf(s, "%I64d", &value))
+		return value;
+	else
+		return 0;
+}
+
+#endif /* __CMYTH_MSC_H */

--- a/lib/cmyth/libcmyth/commbreak.c
+++ b/lib/cmyth/libcmyth/commbreak.c
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2006, Jon Gettler
+ *  Copyright (C) 2005-2012, Jon Gettler
  *  http://www.mvpmc.org/
  *
  *  This library is free software; you can redistribute it and/or

--- a/lib/cmyth/libcmyth/commbreak.c
+++ b/lib/cmyth/libcmyth/commbreak.c
@@ -190,7 +190,7 @@ int cmyth_rcv_commbreaklist(cmyth_conn_t conn, int *err,
 	int consumed;
 	int total = 0;
 	long rows;
-	long long mark;
+	int64_t mark;
 	long long start = -1;
 	char *failed = NULL;
 	cmyth_commbreak_t commbreak;
@@ -229,7 +229,7 @@ int cmyth_rcv_commbreaklist(cmyth_conn_t conn, int *err,
 			goto fail;
 		}
 
-		consumed = cmyth_rcv_long_long(conn, err, &mark, count);
+		consumed = cmyth_rcv_int64(conn, err, &mark, count);
 		count -= consumed;
 		total += consumed;
 		if (*err) {

--- a/lib/cmyth/libcmyth/commbreak.c
+++ b/lib/cmyth/libcmyth/commbreak.c
@@ -294,7 +294,11 @@ cmyth_mysql_get_commbreaklist(cmyth_database_t db, cmyth_conn_t conn, cmyth_prog
 	}
 
 	fprintf(stderr, "Found %li commercial breaks for current program.\n", breaklist->commbreak_count);
-
+	if (r != breaklist->commbreak_count) {
+		fprintf(stderr, "commbreak error.  Setting number of commercial breaks to zero\n");
+		cmyth_dbg(CMYTH_DBG_ERROR, "%s  - returned rows=%d commbreak_count=%li\n",__FUNCTION__, r,breaklist->commbreak_count);
+		breaklist->commbreak_count = 0;
+	}
 	out:
 	pthread_mutex_unlock(&mutex);
 	return breaklist;

--- a/lib/cmyth/libcmyth/commbreak.c
+++ b/lib/cmyth/libcmyth/commbreak.c
@@ -197,7 +197,6 @@ int cmyth_rcv_commbreaklist(cmyth_conn_t conn, int *err,
 	unsigned short type;
 	unsigned short start_type;
 	int i;
-	int j;
 
 	if (count <= 0) {
 		*err = EINVAL;
@@ -242,8 +241,8 @@ int cmyth_rcv_commbreaklist(cmyth_conn_t conn, int *err,
 			start_type = type;
 		} else if (type == CMYTH_COMMBREAK_END || type == CMYTH_CUTLIST_END) {
 			if (start >= 0 &&
-			   (type == CMYTH_COMMBREAK_END && start_type == CMYTH_COMMBREAK_START
-			    || type == CMYTH_CUTLIST_END && start_type == CMYTH_CUTLIST_START))
+			    ((type == CMYTH_COMMBREAK_END && start_type == CMYTH_COMMBREAK_START)
+			     || (type == CMYTH_CUTLIST_END && start_type == CMYTH_CUTLIST_START)))
 			{
 				commbreak = cmyth_commbreak_create();
 				commbreak->start_mark = start;

--- a/lib/cmyth/libcmyth/connection.c
+++ b/lib/cmyth/libcmyth/connection.c
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2004-2006, Eric Lund, Jon Gettler
+ *  Copyright (C) 2004-2012, Eric Lund, Jon Gettler
  *  http://www.mvpmc.org/
  *
  *  This library is free software; you can redistribute it and/or

--- a/lib/cmyth/libcmyth/connection.c
+++ b/lib/cmyth/libcmyth/connection.c
@@ -564,6 +564,10 @@ cmyth_conn_connect_file(cmyth_proginfo_t prog,  cmyth_conn_t control,
 	if (control->conn_version >= 17) {
 		myth_host = cmyth_conn_get_setting_unlocked(control, prog->proginfo_host,
 		                                   "BackendServerIP");
+		if (myth_host && (strcmp(myth_host, "-1") == 0)) {
+			ref_release(myth_host);
+			myth_host = NULL;
+		}
 	}
 	if (!myth_host) {
 		cmyth_dbg(CMYTH_DBG_PROTO,

--- a/lib/cmyth/libcmyth/connection.c
+++ b/lib/cmyth/libcmyth/connection.c
@@ -1360,18 +1360,6 @@ cmyth_conn_get_free_recorder_count(cmyth_conn_t conn)
 	return ret;
 }
 
-char *
-cmyth_conn_get_setting(cmyth_conn_t conn, const char* hostname, const char* setting)
-{
-	char* result = NULL;
-
-	pthread_mutex_lock(&mutex);
-	result = cmyth_conn_get_setting_unlocked(conn, hostname, setting);
-	pthread_mutex_unlock(&mutex);
-
-	return result;
-}
-
 static char *
 cmyth_conn_get_setting_unlocked(cmyth_conn_t conn, const char* hostname, const char* setting)
 {
@@ -1431,3 +1419,14 @@ err:
 	return NULL;
 }
 
+char *
+cmyth_conn_get_setting(cmyth_conn_t conn, const char* hostname, const char* setting)
+{
+	char* result = NULL;
+
+	pthread_mutex_lock(&mutex);
+	result = cmyth_conn_get_setting_unlocked(conn, hostname, setting);
+	pthread_mutex_unlock(&mutex);
+
+	return result;
+}

--- a/lib/cmyth/libcmyth/connection.c
+++ b/lib/cmyth/libcmyth/connection.c
@@ -655,6 +655,10 @@ cmyth_conn_connect_file(cmyth_proginfo_t prog,  cmyth_conn_t control,
 		goto shut;
 	}
 	count -= r;
+	if (count != 0) {
+		cmyth_dbg(CMYTH_DBG_ERROR, "%s: %d leftover bytes\n",
+			  __FUNCTION__, count);
+	}
 	free(announcement);
 	ref_release(conn);
 	ref_release(myth_host);

--- a/lib/cmyth/libcmyth/connection.c
+++ b/lib/cmyth/libcmyth/connection.c
@@ -35,7 +35,7 @@ static char * cmyth_conn_get_setting_unlocked(cmyth_conn_t conn, const char* hos
 pthread_mutex_t mutex = PTHREAD_MUTEX_INITIALIZER;
 
 typedef struct {
-	int version;
+	unsigned int version;
 	char token[9]; // 8 characters + the terminating NULL character
 } myth_protomap_t;
 

--- a/lib/cmyth/libcmyth/connection.c
+++ b/lib/cmyth/libcmyth/connection.c
@@ -634,10 +634,10 @@ cmyth_conn_connect_file(cmyth_proginfo_t prog,  cmyth_conn_t control,
 		goto shut;
 	}
 	count -= r;
-	r = cmyth_rcv_u_long_long(conn, &err, &ret->file_length, count);
+	r = cmyth_rcv_uint64(conn, &err, &ret->file_length, count);
 	if (err) {
 		cmyth_dbg(CMYTH_DBG_ERROR,
-			  "%s: (length) cmyth_rcv_u_long_long() failed (%d)\n",
+			  "%s: (length) cmyth_rcv_uint64() failed (%d)\n",
 			  __FUNCTION__, err);
 		goto shut;
 	}
@@ -784,10 +784,10 @@ cmyth_conn_connect_path(char* path, cmyth_conn_t control,
 		goto shut;
 	}
 	count -= r;
-	r = cmyth_rcv_u_long_long(conn, &err, &ret->file_length, count);
+	r = cmyth_rcv_uint64(conn, &err, &ret->file_length, count);
 	if (err) {
 		cmyth_dbg(CMYTH_DBG_ERROR,
-			  "%s: (length) cmyth_rcv_u_long_long() failed (%d)\n",
+			  "%s: (length) cmyth_rcv_uint64() failed (%d)\n",
 			  __FUNCTION__, err);
 		goto shut;
 	}
@@ -1197,7 +1197,7 @@ cmyth_conn_get_freespace(cmyth_conn_t control,
 	int r;
 	char msg[256];
 	char reply[256];
-	long long lreply;
+	int64_t lreply;
 
 	if (control == NULL)
 		return -EINVAL;
@@ -1231,19 +1231,17 @@ cmyth_conn_get_freespace(cmyth_conn_t control,
 	}
 	
 	if (control->conn_version >= 17) {
-		if ((r=cmyth_rcv_long_long(control, &err, &lreply,
-					   count)) < 0) {
+		if ((r=cmyth_rcv_int64(control, &err, &lreply, count)) < 0) {
 			cmyth_dbg(CMYTH_DBG_ERROR,
-				  "%s: cmyth_rcv_long_long() failed (%d)\n",
+				  "%s: cmyth_rcv_int64() failed (%d)\n",
 				  __FUNCTION__, err);
 			ret = err;
 			goto out;
 		}
 		*total = lreply;
-		if ((r=cmyth_rcv_long_long(control, &err, &lreply,
-					   count-r)) < 0) {
+		if ((r=cmyth_rcv_int64(control, &err, &lreply, count - r)) < 0) {
 			cmyth_dbg(CMYTH_DBG_ERROR,
-				  "%s: cmyth_rcv_long_long() failed (%d)\n",
+				  "%s: cmyth_rcv_int64() failed (%d)\n",
 				  __FUNCTION__, err);
 			ret = err;
 			goto out;

--- a/lib/cmyth/libcmyth/connection.c
+++ b/lib/cmyth/libcmyth/connection.c
@@ -65,7 +65,7 @@ static myth_protomap_t protomap[] = {
 	{71, "05e82186"},
 	{72, "D78EFD6F"},
 	{73, "D7FE8D6F"},
-	{0, 0}
+	{0, ""}
 };
 
 /*

--- a/lib/cmyth/libcmyth/connection.c
+++ b/lib/cmyth/libcmyth/connection.c
@@ -23,21 +23,8 @@
  * interacting with those connections.  
  */
 
-#include <sys/types.h>
 #include <stdlib.h>
-#ifndef _MSC_VER
-#include <unistd.h>
-#endif
 #include <stdio.h>
-#ifdef _MSC_VER
-#include <winsock2.h>
-#include <Ws2tcpip.h>
-#else
-#include <sys/socket.h>
-#include <netinet/in.h>
-#include <netdb.h>
-#include <arpa/inet.h>
-#endif
 #include <errno.h>
 #include <string.h>
 #include <signal.h>

--- a/lib/cmyth/libcmyth/connection.c
+++ b/lib/cmyth/libcmyth/connection.c
@@ -953,7 +953,7 @@ int
 cmyth_conn_check_block(cmyth_conn_t conn, unsigned long size)
 {
 	fd_set check;
-	struct timeval timeout = {0,0};
+	struct timeval timeout;
 	int length;
 	int err = 0;
 	unsigned long sent;
@@ -961,6 +961,7 @@ cmyth_conn_check_block(cmyth_conn_t conn, unsigned long size)
 	if (!conn) {
 		return -EINVAL;
 	}
+	timeout.tv_sec = timeout.tv_usec = 0;
 	FD_ZERO(&check);
 	FD_SET(conn->conn_fd, &check);
 	if (select((int)conn->conn_fd + 1, &check, NULL, NULL, &timeout) < 0) {

--- a/lib/cmyth/libcmyth/debug.c
+++ b/lib/cmyth/libcmyth/debug.c
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2004-2006, Eric Lund
+ *  Copyright (C) 2004-2009, Eric Lund
  *  http://www.mvpmc.org/
  *
  *  This library is free software; you can redistribute it and/or

--- a/lib/cmyth/libcmyth/debug.c
+++ b/lib/cmyth/libcmyth/debug.c
@@ -27,9 +27,9 @@
 
 #include "debug.h"
 
-static mvp_debug_ctx_t cmyth_debug_ctx = MVP_DEBUG_CTX_INIT("cmyth",
-							    CMYTH_DBG_NONE,
-							    NULL);
+static cmyth_debug_ctx_t cmyth_debug_ctx = CMYTH_DEBUG_CTX_INIT("cmyth",
+								CMYTH_DBG_NONE,
+								NULL);
 
 /*
  * cmyth_dbg_level(int l)
@@ -49,7 +49,7 @@ static mvp_debug_ctx_t cmyth_debug_ctx = MVP_DEBUG_CTX_INIT("cmyth",
 void
 cmyth_dbg_level(int l)
 {
-	mvp_dbg_setlevel(&cmyth_debug_ctx, l);
+	__cmyth_dbg_setlevel(&cmyth_debug_ctx, l);
 }
 
 /*
@@ -68,7 +68,7 @@ cmyth_dbg_level(int l)
 void
 cmyth_dbg_all()
 {
-	mvp_dbg_setlevel(&cmyth_debug_ctx, CMYTH_DBG_ALL);
+	__cmyth_dbg_setlevel(&cmyth_debug_ctx, CMYTH_DBG_ALL);
 }
 
 /*
@@ -87,7 +87,7 @@ cmyth_dbg_all()
 void
 cmyth_dbg_none()
 {
-	mvp_dbg_setlevel(&cmyth_debug_ctx, CMYTH_DBG_NONE);
+	__cmyth_dbg_setlevel(&cmyth_debug_ctx, CMYTH_DBG_NONE);
 }
 
 /*
@@ -111,7 +111,7 @@ cmyth_dbg(int level, char *fmt, ...)
 	va_list ap;
 
 	va_start(ap, fmt);
-	mvp_dbg(&cmyth_debug_ctx, level, fmt, ap);
+	__cmyth_dbg(&cmyth_debug_ctx, level, fmt, ap);
 	va_end(ap);
 }
 

--- a/lib/cmyth/libcmyth/event.c
+++ b/lib/cmyth/libcmyth/event.c
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2006, Jon Gettler
+ *  Copyright (C) 2005-2012, Jon Gettler
  *  http://www.mvpmc.org/
  *
  *  This library is free software; you can redistribute it and/or

--- a/lib/cmyth/libcmyth/file.c
+++ b/lib/cmyth/libcmyth/file.c
@@ -21,9 +21,7 @@
 #include <stdlib.h>
 #include <errno.h>
 #include <inttypes.h>
-#ifndef _MSC_VER
-#include <sys/socket.h>
-#endif
+#include <sys/types.h>
 #include <cmyth_local.h>
 
 /*

--- a/lib/cmyth/libcmyth/file.c
+++ b/lib/cmyth/libcmyth/file.c
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2004-2006, Eric Lund
+ *  Copyright (C) 2004-2012, Eric Lund
  *  http://www.mvpmc.org/
  *
  *  This library is free software; you can redistribute it and/or

--- a/lib/cmyth/libcmyth/file.c
+++ b/lib/cmyth/libcmyth/file.c
@@ -424,7 +424,7 @@ cmyth_file_seek(cmyth_file_t file, long long offset, int whence)
 	char msg[128];
 	int err;
 	int count;
-	long long c;
+	int64_t c;
 	long r;
 	long long ret;
 
@@ -486,9 +486,9 @@ cmyth_file_seek(cmyth_file_t file, long long offset, int whence)
 		ret = count;
 		goto out;
 	}
-	if ((r=cmyth_rcv_long_long(file->file_control, &err, &c, count)) < 0) {
+	if ((r=cmyth_rcv_int64(file->file_control, &err, &c, count)) < 0) {
 		cmyth_dbg(CMYTH_DBG_ERROR,
-			  "%s: cmyth_rcv_long_long() failed (%d)\n",
+			  "%s: cmyth_rcv_int64() failed (%d)\n",
 			  __FUNCTION__, r);
 		ret = err;
 		goto out;
@@ -539,7 +539,7 @@ int cmyth_file_read(cmyth_file_t file, char *buf, unsigned long len)
 	int ret, req, nfds, rec;
 	char *end, *cur;
 	char msg[256];
-	long long len64;
+	int64_t len64;
 	struct timeval tv;
 	fd_set fds;
 
@@ -622,9 +622,20 @@ int cmyth_file_read(cmyth_file_t file, char *buf, unsigned long len)
 				goto out;
 			}
 
-			if ((ret=cmyth_rcv_int64 (file->file_control, &err, &len64, count))< 0) {
+			/*
+			 * MythTV originally sent back a signed 32bit value but was changed to a
+			 * signed 64bit value in http://svn.mythtv.org/trac/changeset/18011 (1-Aug-2008).
+			 *
+			 * libcmyth now retrieves the 64-bit signed value, does error-checking,
+			 * and then converts to a 32bit unsigned.
+			 *
+			 * This rcv_ method needs to be forced to use new_int64 to pull back a
+			 * single 64bit number otherwise the handling in rcv_int64 will revert to
+			 * the old two 32bit hi and lo long values.
+			 */
+			if ((ret=cmyth_rcv_new_int64 (file->file_control, &err, &len64, count, 1))< 0) {
 				cmyth_dbg (CMYTH_DBG_ERROR,
-				           "%s: cmyth_rcv_int64() failed (%d)\n",
+				           "%s: cmyth_rcv_new_int64() failed (%d)\n",
 				           __FUNCTION__, ret);
 				ret = err;
 				goto out;
@@ -632,8 +643,8 @@ int cmyth_file_read(cmyth_file_t file, char *buf, unsigned long len)
 			if (len64 >= 0x100000000LL || len64 < 0) {
 				/* -1 seems to be a common result, but isn't valid so use 0 instead. */
 				cmyth_dbg (CMYTH_DBG_WARN,
-				           "%s: cmyth_rcv_int64() returned out of bound value (%d). Using 0\n",
-				           __FUNCTION__, (long)len64);
+				           "%s: cmyth_rcv_new_int64() returned out of bound value (%"PRId64"). Using 0 instead.\n",
+				           __FUNCTION__, len64);
 				len64 = 0;
 			}
 			len = (unsigned long)len64;
@@ -642,8 +653,8 @@ int cmyth_file_read(cmyth_file_t file, char *buf, unsigned long len)
 
 			if (file->file_req < file->file_pos) {
 				cmyth_dbg (CMYTH_DBG_ERROR,
-				           "%s: received invalid invalid length, read position is ahead of request (req: %d, rec: %d, len: %d)\n",
-				           __FUNCTION__, file->file_req, file->file_pos, len);
+				           "%s: received invalid invalid length, read position is ahead of request (req: %"PRIu64", pos: %"PRIu64", len: %"PRId64")\n",
+				           __FUNCTION__, file->file_req, file->file_pos, len64);
 				ret = -1;
 				goto out;
 			}

--- a/lib/cmyth/libcmyth/freespace.c
+++ b/lib/cmyth/libcmyth/freespace.c
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2004-2006, Eric Lund
+ *  Copyright (C) 2004-2010, Eric Lund
  *  http://www.mvpmc.org/
  *
  *  This library is free software; you can redistribute it and/or

--- a/lib/cmyth/libcmyth/freespace.c
+++ b/lib/cmyth/libcmyth/freespace.c
@@ -20,13 +20,7 @@
 /*
  * freespace.c - functions to manage freespace structures.
  */
-#include <sys/types.h>
 #include <stdlib.h>
-#ifndef _MSC_VER
-#include <unistd.h>
-#endif
-#include <stdio.h>
-#include <errno.h>
 #include <cmyth_local.h>
 
 /*

--- a/lib/cmyth/libcmyth/keyframe.c
+++ b/lib/cmyth/libcmyth/keyframe.c
@@ -23,9 +23,6 @@
  */
 #include <sys/types.h>
 #include <stdlib.h>
-#ifndef _MSC_VER
-#include <unistd.h>
-#endif
 #include <string.h>
 #include <stdio.h>
 #include <cmyth_local.h>

--- a/lib/cmyth/libcmyth/keyframe.c
+++ b/lib/cmyth/libcmyth/keyframe.c
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2004-2006, Eric Lund
+ *  Copyright (C) 2004-2010, Eric Lund
  *  http://www.mvpmc.org/
  *
  *  This library is free software; you can redistribute it and/or

--- a/lib/cmyth/libcmyth/livetv.c
+++ b/lib/cmyth/libcmyth/livetv.c
@@ -427,7 +427,6 @@ cmyth_livetv_chain_update(cmyth_recorder_t rec, char * chainid,
 {
 	int ret=0;
 	char url[1024];
-	cmyth_conn_t control;
 	cmyth_proginfo_t loc_prog;
 	cmyth_file_t ft;
 
@@ -435,8 +434,6 @@ cmyth_livetv_chain_update(cmyth_recorder_t rec, char * chainid,
 		cmyth_dbg(CMYTH_DBG_ERROR, "%s: rec is NULL\n", __FUNCTION__);
 		goto out;
 	}
-
-	control = rec->rec_conn;
 
 	loc_prog = cmyth_recorder_get_cur_proginfo(rec);
 	pthread_mutex_lock(&mutex);

--- a/lib/cmyth/libcmyth/livetv.c
+++ b/lib/cmyth/libcmyth/livetv.c
@@ -662,7 +662,6 @@ cmyth_livetv_chain_switch(cmyth_recorder_t rec, int dir)
 	ret = 0;
 
 	if(dir == LAST) {
-		PRINTF("**SSDEBUG:(cmyth_livetv_chain_switch) dir: %d\n", dir);
 		dir = rec->rec_livetv_chain->chain_ct
 				- rec->rec_livetv_chain->chain_current - 1;
 		ret = 1;
@@ -673,8 +672,6 @@ cmyth_livetv_chain_switch(cmyth_recorder_t rec, int dir)
 			  rec->rec_livetv_chain->chain_ct - dir )) {
 		ref_release(rec->rec_livetv_file);
 		ret = rec->rec_livetv_chain->chain_current += dir;
-		PRINTF("**SSDEBUG:(cmyth_livetv_chain_switch): %s:%d\n",
-		"dooingSwitcheroo",ret);
 		rec->rec_livetv_file = ref_hold(rec->rec_livetv_chain->chain_files[ret]);
 		rec->rec_livetv_chain
 					->prog_update_callback(rec->rec_livetv_chain->progs[ret]);
@@ -708,7 +705,6 @@ cmyth_livetv_chain_switch_last(cmyth_recorder_t rec)
 	pthread_mutex_lock(&mutex);
 	dir = rec->rec_livetv_chain->chain_ct
 			- rec->rec_livetv_chain->chain_current - 1;
-	PRINTF("#@@@@#SSDEBUG: switch file changing adjusted dir: %d\n", dir);
 	if(dir != 0) {
 		cmyth_livetv_chain_switch(rec, dir);
 	}
@@ -756,8 +752,6 @@ cmyth_livetv_chain_request_block(cmyth_recorder_t rec, unsigned long len)
 		ret = cmyth_file_request_block(rec->rec_livetv_file, len);
 		if (ret == 0) { /* We've gotten to the end, need to progress in the chain */
 			/* Switch if there are files left in the chain */
-			PRINTF("**SSDEBUG:(cmyth_livetv_request_block): %s\n",
-			"reached end of stream must dooSwitcheroo");
 			retry = cmyth_livetv_chain_switch(rec, 1);
 		}
 	}
@@ -789,8 +783,6 @@ int cmyth_livetv_chain_read(cmyth_recorder_t rec, char *buf, unsigned long len)
 		ret = cmyth_file_read(rec->rec_livetv_file, buf, len);	
 		if (ret == 0) {
 			/* eof, switch to next file */
-			PRINTF("**SSDEBUG:(cmyth_livetv_chain_read): %s\n",
-			"reached end of stream must dooSwitcheroo");
 			retry = cmyth_livetv_chain_switch(rec, 1);
 		}
 	} while(retry);
@@ -891,8 +883,6 @@ cmyth_livetv_chain_seek(cmyth_recorder_t rec, long long offset, int whence)
 	pthread_mutex_lock(&mutex);
 
 	ret = cmyth_file_seek(fp, offset, whence);
-
-	PRINTF("** SSDEBUG: new pos %lld after seek command\n", ret);
 
 	cur -= rec->rec_livetv_chain->chain_current;
 	if (ret >= 0 && cur) {
@@ -1037,7 +1027,6 @@ cmyth_spawn_live_tv(cmyth_recorder_t rec, unsigned buflen, int tcp_rcvbuf,
 	cmyth_recorder_t rtrn = NULL;
 	int i;
 
-	//printf("** SSDEBUG: version is %ld\n", rec->rec_conn->conn_version);
 	if(rec->rec_conn->conn_version >= 26) {
 		if (cmyth_recorder_spawn_chain_livetv(rec, channame) != 0) {
 			*err = "Spawn livetv failed.";

--- a/lib/cmyth/libcmyth/livetv.c
+++ b/lib/cmyth/libcmyth/livetv.c
@@ -24,28 +24,12 @@
  *                This allows the watcher to do things like pause, rewind
  *                and so forth on live-tv.
  */
-#include <sys/types.h>
 #include <stdlib.h>
-#ifndef _MSC_VER
-#include <unistd.h>
-#include <sys/socket.h>
-#endif
 #include <stdio.h>
 #include <errno.h>
 #include <string.h>
+#include <sys/types.h>
 #include <cmyth_local.h>
-
-#ifdef _MSC_VER
-static void nullprint(a, ...) { return; }
-#define PRINTF nullprint
-#define TRC  nullprint
-#elif 0
-#define PRINTF(x...) PRINTF(x)
-#define TRC(fmt, args...) PRINTF(fmt, ## args) 
-#else
-#define PRINTF(x...)
-#define TRC(fmt, args...) 
-#endif
 
 #define LAST 0x7FFFFFFF
 

--- a/lib/cmyth/libcmyth/livetv.c
+++ b/lib/cmyth/libcmyth/livetv.c
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2006, Sergio Slobodrian
+ *  Copyright (C) 2006-2012, Sergio Slobodrian
  *  http://www.mvpmc.org/
  *
  *  This library is free software; you can redistribute it and/or

--- a/lib/cmyth/libcmyth/mysql_query.c
+++ b/lib/cmyth/libcmyth/mysql_query.c
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2006, Simon Hyde
+ *  Copyright (C) 2006-2009, Simon Hyde
  *  http://www.mvpmc.org/
  *
  *  This library is free software; you can redistribute it and/or

--- a/lib/cmyth/libcmyth/mythtv_mysql.c
+++ b/lib/cmyth/libcmyth/mythtv_mysql.c
@@ -665,6 +665,31 @@ fill_program_recording_status(cmyth_conn_t conn, char * msg)
 	}
 	return err;
 }
+int
+cmyth_update_bookmark_setting(cmyth_database_t db, cmyth_proginfo_t prog)
+{
+	MYSQL_RES *res = NULL;
+	const char *query_str = "UPDATE recorded SET bookmark = 1 WHERE chanid = ? AND starttime = ?";
+	cmyth_mysql_query_t * query;
+	char starttime[CMYTH_TIMESTAMP_LEN + 1];
+
+	cmyth_timestamp_to_string(starttime, prog->proginfo_rec_start_ts);
+	query = cmyth_mysql_query_create(db,query_str);
+	if (cmyth_mysql_query_param_long(query, prog->proginfo_chanId) < 0
+		|| cmyth_mysql_query_param_str(query, starttime) < 0 ) {
+		cmyth_dbg(CMYTH_DBG_ERROR,"%s, binding of query parameters failed! Maybe we're out of memory?\n", __FUNCTION__);
+		ref_release(query);
+		return -1;
+	}
+	res = cmyth_mysql_query_result(query);
+	ref_release(query);
+	if (res == NULL) {
+		cmyth_dbg(CMYTH_DBG_ERROR, "%s, finalisation/execution of query failed!\n", __FUNCTION__);
+		return -1;
+	}
+	mysql_free_result(res);
+	return (1);
+}
 
 int 
 cmyth_get_bookmark_mark(cmyth_database_t db, cmyth_proginfo_t prog, long long bk)

--- a/lib/cmyth/libcmyth/mythtv_mysql.c
+++ b/lib/cmyth/libcmyth/mythtv_mysql.c
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2004-2006, Eric Lund
+ *  Copyright (C) 2004-2012, Eric Lund
  *  http://www.mvpmc.org/
  *
  *  This library is free software; you can redistribute it and/or

--- a/lib/cmyth/libcmyth/mythtv_mysql.c
+++ b/lib/cmyth/libcmyth/mythtv_mysql.c
@@ -926,6 +926,7 @@ cmyth_mythtv_remove_previos_recorded(cmyth_database_t db,char *query)
 		cmyth_dbg(CMYTH_DBG_ERROR, "%s: mysql_query() Failed: %s\n", 
 			__FUNCTION__, mysql_error(db->mysql));
 	}
+	mysql_free_result(res);
 
 	return rows;
 }

--- a/lib/cmyth/libcmyth/mythtv_mysql.c
+++ b/lib/cmyth/libcmyth/mythtv_mysql.c
@@ -964,7 +964,7 @@ cmyth_tuner_type_check(cmyth_database_t db, cmyth_recorder_t rec, int check_tune
 }
 
 int
-cmyth_mythtv_remove_previos_recorded(cmyth_database_t db,char *query)
+cmyth_mythtv_remove_previous_recorded(cmyth_database_t db,char *query)
 {
 	MYSQL_RES *res=NULL;
 	char N_query[128];

--- a/lib/cmyth/libcmyth/mythtv_mysql.c
+++ b/lib/cmyth/libcmyth/mythtv_mysql.c
@@ -125,7 +125,6 @@ cmyth_database_set_name(cmyth_database_t db, char *name)
 static int
 cmyth_db_check_connection(cmyth_database_t db)
 {
-    int new_conn = 0;
     if(db->mysql != NULL)
     {
 	/* Fetch the mysql stats (uptime and stuff) to check the connection is
@@ -139,7 +138,6 @@ cmyth_db_check_connection(cmyth_database_t db)
     if(db->mysql == NULL)
     {
 	db->mysql = mysql_init(NULL);
-	new_conn = 1;
 	if(db->mysql == NULL)
 	{
 	    fprintf(stderr,"%s: mysql_init() failed, insufficient memory?",

--- a/lib/cmyth/libcmyth/mythtv_mysql.c
+++ b/lib/cmyth/libcmyth/mythtv_mysql.c
@@ -76,7 +76,6 @@ cmyth_database_init(char *host, char *db_name, char *user, char *pass)
 int
 cmyth_database_set_host(cmyth_database_t db, char *host)
 {
-	PRINTF("** SSDEBUG: setting the db host to %s\n", host);
 	cmyth_database_close(db);
 	ref_release(db->db_host);
 	db->db_host = ref_strdup(host);
@@ -89,7 +88,6 @@ cmyth_database_set_host(cmyth_database_t db, char *host)
 int
 cmyth_database_set_user(cmyth_database_t db, char *user)
 {
-	PRINTF("** SSDEBUG: setting the db user to %s\n", user);
 	cmyth_database_close(db);
 	ref_release(db->db_user);
 	db->db_user = ref_strdup(user);
@@ -102,7 +100,6 @@ cmyth_database_set_user(cmyth_database_t db, char *user)
 int
 cmyth_database_set_pass(cmyth_database_t db, char *pass)
 {
-	PRINTF("** SSDEBUG: setting the db pass to %s\n", pass);
 	cmyth_database_close(db);
 	ref_release(db->db_user);
 	db->db_pass = ref_strdup(pass);
@@ -115,7 +112,6 @@ cmyth_database_set_pass(cmyth_database_t db, char *pass)
 int
 cmyth_database_set_name(cmyth_database_t db, char *name)
 {
-	PRINTF("** SSDEBUG: setting the db name to %s\n", name);
 	cmyth_database_close(db);
 	ref_release(db->db_name);
 	db->db_name = ref_strdup(name);

--- a/lib/cmyth/libcmyth/mythtv_mysql.c
+++ b/lib/cmyth/libcmyth/mythtv_mysql.c
@@ -17,35 +17,13 @@
  *  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  */
 
-#include <sys/types.h>
 #include <stdlib.h>
-#ifndef _MSC_VER
-#include <unistd.h>
-#endif
 #include <stdio.h>
 #include <errno.h>
 #include <string.h>
-#ifdef _MSC_VER
-#include <time.h>
-#else
-#include <sys/time.h>
-#endif
 #include <mysql/mysql.h>
 #include <cmyth_local.h>
 #include <safe_string.h>
-
-#ifdef _MSC_VER
-static void nullprint(a, ...) { return; }
-#define PRINTF nullprint
-#define TRC  nullprint
-#elif 0
-#define PRINTF(x...) PRINTF(x)
-#define TRC(fmt, args...) PRINTF(fmt, ## args) 
-#else
-#define PRINTF(x...)
-#define TRC(fmt, args...) 
-#endif
-
 
 void
 cmyth_database_close(cmyth_database_t db)

--- a/lib/cmyth/libcmyth/mythtv_mysql.c
+++ b/lib/cmyth/libcmyth/mythtv_mysql.c
@@ -922,6 +922,48 @@ cmyth_mysql_get_commbreak_list(cmyth_database_t db, int chanid, char * start_ts_
 }
 
 int
+cmyth_tuner_type_check(cmyth_database_t db, cmyth_recorder_t rec, int check_tuner_type) {
+	MYSQL_RES *res=NULL;
+	MYSQL_ROW row;
+	const char * query_str = "SELECT cardtype from capturecard WHERE cardid=?";
+	cmyth_mysql_query_t * query;
+
+	if ( check_tuner_type == 0 ) {
+		cmyth_dbg(CMYTH_DBG_ERROR,"MythTV Tuner check not enabled in Mythtv Options\n");
+		return (1);
+	}
+	
+
+	query = cmyth_mysql_query_create(db,query_str);
+	if (cmyth_mysql_query_param_uint(query,rec->rec_id) < 0) {
+		cmyth_dbg(CMYTH_DBG_ERROR,"%s, binding of query failed\n",__FUNCTION__);
+		ref_release(query);
+		return -1;
+	}
+	res = cmyth_mysql_query_result(query);
+
+	if(res == NULL) {
+		cmyth_dbg(CMYTH_DBG_ERROR,"%s, finalisation/execution\n",__FUNCTION__);
+		return -1;
+	}
+	row = mysql_fetch_row(res);
+	ref_release(query);
+	mysql_free_result(res);
+	if (strcmp(row[0],"MPEG") == 0) {
+		return (1); //return the first available MPEG tuner
+	}
+	else if (strcmp(row[0],"HDHOMERUN") == 0) {
+		return (1); //return the first available MPEG2TS tuner
+	}
+	else if (strcmp(row[0],"DVB") == 0) {
+		return (1); //return the first available DVB tuner
+	}
+	else {
+		return (0);
+	}
+}
+
+int
 cmyth_mythtv_remove_previos_recorded(cmyth_database_t db,char *query)
 {
 	MYSQL_RES *res=NULL;

--- a/lib/cmyth/libcmyth/posmap.c
+++ b/lib/cmyth/libcmyth/posmap.c
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2004-2006, Eric Lund
+ *  Copyright (C) 2004-2010, Eric Lund
  *  http://www.mvpmc.org/
  *
  *  This library is free software; you can redistribute it and/or

--- a/lib/cmyth/libcmyth/posmap.c
+++ b/lib/cmyth/libcmyth/posmap.c
@@ -25,11 +25,7 @@
  *            be markers inserted by commercial detection.  A position
  *            map collects these in one place.
  */
-#include <sys/types.h>
 #include <stdlib.h>
-#ifndef _MSC_VER
-#include <unistd.h>
-#endif
 #include <stdio.h>
 #include <cmyth_local.h>
 

--- a/lib/cmyth/libcmyth/proginfo.c
+++ b/lib/cmyth/libcmyth/proginfo.c
@@ -26,11 +26,7 @@
  *              also retrieve and manipulate recordings and program
  *              material based on program information.
  */
-#include <sys/types.h>
 #include <stdlib.h>
-#ifndef _MSC_VER
-#include <unistd.h>
-#endif
 #include <stdio.h>
 #include <errno.h>
 #include <string.h>

--- a/lib/cmyth/libcmyth/proginfo.c
+++ b/lib/cmyth/libcmyth/proginfo.c
@@ -152,6 +152,9 @@ cmyth_proginfo_destroy(cmyth_proginfo_t p)
 	if (p->proginfo_storagegroup) {
 		ref_release(p->proginfo_storagegroup);
 	}
+	if (p->proginfo_recpriority_2) {
+		ref_release(p->proginfo_recpriority_2);
+	}
 	if (p->proginfo_prodyear) {
 		ref_release(p->proginfo_prodyear);
 	}

--- a/lib/cmyth/libcmyth/proginfo.c
+++ b/lib/cmyth/libcmyth/proginfo.c
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2004-2006, Eric Lund
+ *  Copyright (C) 2004-2010, Eric Lund
  *  http://www.mvpmc.org/
  *
  *  This library is free software; you can redistribute it and/or

--- a/lib/cmyth/libcmyth/proginfo.c
+++ b/lib/cmyth/libcmyth/proginfo.c
@@ -473,86 +473,85 @@ delete_command(cmyth_conn_t control, cmyth_proginfo_t prog, char *cmd)
 			  "%s: delete not supported with protocol ver %d\n",
 			  __FUNCTION__, control->conn_version);
 		return -EINVAL;
+	}
+	sprintf(buf, "%s 0[]:[]", cmd);
+	sprintf(buf + strlen(buf), "%s[]:[]",  S(prog->proginfo_title));
+	sprintf(buf + strlen(buf), "%s[]:[]",  S(prog->proginfo_subtitle));
+	sprintf(buf + strlen(buf), "%s[]:[]",  S(prog->proginfo_description));
+	if (control->conn_version >= 67) {
+		sprintf(buf + strlen(buf), "%u[]:[]", prog->proginfo_season);
+		sprintf(buf + strlen(buf), "%u[]:[]", prog->proginfo_episode);
+	}
+	sprintf(buf + strlen(buf), "%s[]:[]",  S(prog->proginfo_category));
+	sprintf(buf + strlen(buf), "%ld[]:[]", prog->proginfo_chanId);
+	sprintf(buf + strlen(buf), "%s[]:[]",  S(prog->proginfo_chanstr));
+	sprintf(buf + strlen(buf), "%s[]:[]",  S(prog->proginfo_chansign));
+	sprintf(buf + strlen(buf), "%s[]:[]",  S(prog->proginfo_channame));
+	sprintf(buf + strlen(buf), "%s[]:[]",  S(prog->proginfo_url));
+	if (control->conn_version >= 57) {
+		sprintf(buf + strlen(buf), "%"PRId64"[]:[]", prog->proginfo_Length);
 	} else {
-		sprintf(buf, "%s 0[]:[]", cmd);
-		sprintf(buf + strlen(buf), "%s[]:[]",  S(prog->proginfo_title));
-		sprintf(buf + strlen(buf), "%s[]:[]",  S(prog->proginfo_subtitle));
-		sprintf(buf + strlen(buf), "%s[]:[]",  S(prog->proginfo_description));
-		if (control->conn_version >= 67) {
-			sprintf(buf + strlen(buf), "%u[]:[]", prog->proginfo_season);
-			sprintf(buf + strlen(buf), "%u[]:[]", prog->proginfo_episode);
-		}
-		sprintf(buf + strlen(buf), "%s[]:[]",  S(prog->proginfo_category));
-		sprintf(buf + strlen(buf), "%ld[]:[]", prog->proginfo_chanId);
-		sprintf(buf + strlen(buf), "%s[]:[]",  S(prog->proginfo_chanstr));
-		sprintf(buf + strlen(buf), "%s[]:[]",  S(prog->proginfo_chansign));
-		sprintf(buf + strlen(buf), "%s[]:[]",  S(prog->proginfo_channame));
-		sprintf(buf + strlen(buf), "%s[]:[]",  S(prog->proginfo_url));
-		if (control->conn_version >= 57) {
-			sprintf(buf + strlen(buf), "%"PRId64"[]:[]", prog->proginfo_Length);
-		} else {
-			sprintf(buf + strlen(buf), "%d[]:[]", (int32_t)(prog->proginfo_Length >> 32));
-			sprintf(buf + strlen(buf), "%d[]:[]", (int32_t)(prog->proginfo_Length & 0xffffffff));
-		}
-		sprintf(buf + strlen(buf), "%s[]:[]",  start_ts);
-		sprintf(buf + strlen(buf), "%s[]:[]",  end_ts);
-		if (control->conn_version < 57) {
-			sprintf(buf + strlen(buf), "%s[]:[]",  S(prog->proginfo_unknown_0)); // "duplicate"
-			sprintf(buf + strlen(buf), "%ld[]:[]", 0L); // "shareable"
-		}
-		sprintf(buf + strlen(buf), "%ld[]:[]", 0L); // "findid"
-		sprintf(buf + strlen(buf), "%s[]:[]",  S(prog->proginfo_hostname));
-		sprintf(buf + strlen(buf), "%ld[]:[]", prog->proginfo_source_id);
-		sprintf(buf + strlen(buf), "%ld[]:[]", prog->proginfo_card_id);
-		sprintf(buf + strlen(buf), "%ld[]:[]", prog->proginfo_input_id);
-		sprintf(buf + strlen(buf), "%s[]:[]",  S(prog->proginfo_rec_priority));
-		sprintf(buf + strlen(buf), "%ld[]:[]", prog->proginfo_rec_status);
-		sprintf(buf + strlen(buf), "%ld[]:[]", prog->proginfo_record_id);
-		sprintf(buf + strlen(buf), "%ld[]:[]", prog->proginfo_rec_type);
-		sprintf(buf + strlen(buf), "%ld[]:[]", prog->proginfo_rec_dups);
-		sprintf(buf + strlen(buf), "%ld[]:[]", prog->proginfo_unknown_1); // "dupmethod"
-		sprintf(buf + strlen(buf), "%s[]:[]",  rec_start_ts);
-		sprintf(buf + strlen(buf), "%s[]:[]",  rec_end_ts);
-		if (control->conn_version < 57) {
-			sprintf(buf + strlen(buf), "%ld[]:[]", prog->proginfo_repeat);
-		}
-		sprintf(buf + strlen(buf), "%ld[]:[]", prog->proginfo_program_flags);
-		sprintf(buf + strlen(buf), "%s[]:[]",  S(prog->proginfo_recgroup));
-		if (control->conn_version < 57) {
-			sprintf(buf + strlen(buf), "%s[]:[]",  S(prog->proginfo_chancommfree));
-		}
-		sprintf(buf + strlen(buf), "%s[]:[]",  S(prog->proginfo_chan_output_filters));
-		sprintf(buf + strlen(buf), "%s[]:[]",  S(prog->proginfo_seriesid));
-		sprintf(buf + strlen(buf), "%s[]:[]",  S(prog->proginfo_programid));
-		if (control->conn_version >= 67) {
-			sprintf(buf + strlen(buf), "%s[]:[]", S(prog->proginfo_inetref));
-		}
-		sprintf(buf + strlen(buf), "%s[]:[]",  lastmodified);
-		sprintf(buf + strlen(buf), "%s[]:[]",  S(prog->proginfo_stars));
-		sprintf(buf + strlen(buf), "%s[]:[]",  originalairdate);
-		if (control->conn_version >= 15 && control->conn_version < 57) {
-			sprintf(buf + strlen(buf), "%ld[]:[]", prog->proginfo_hasairdate);
-		}
-		if (control->conn_version >= 18) {
-			sprintf(buf + strlen(buf), "%s[]:[]", S(prog->proginfo_playgroup));
-		}
-		if (control->conn_version >= 25) {
-			sprintf(buf + strlen(buf), "%s[]:[]", S(prog->proginfo_recpriority_2));
-		}
-		if (control->conn_version >= 31) {
-			sprintf(buf + strlen(buf), "%ld[]:[]", prog->proginfo_parentid);
-		}
-		if (control->conn_version >= 32) {
-			sprintf(buf + strlen(buf), "%s[]:[]", S(prog->proginfo_storagegroup));
-		}
-		if (control->conn_version >= 35) {
-			sprintf(buf + strlen(buf), "%ld[]:[]", prog->proginfo_audioproperties);
-			sprintf(buf + strlen(buf), "%ld[]:[]", prog->proginfo_videoproperties);
-			sprintf(buf + strlen(buf), "%ld[]:[]", prog->proginfo_subtitletype);
-		}
-		if (control->conn_version >= 41) {
-			sprintf(buf + strlen(buf), "%s[]:[]", S(prog->proginfo_prodyear));
-		}
+		sprintf(buf + strlen(buf), "%d[]:[]", (int32_t)(prog->proginfo_Length >> 32));
+		sprintf(buf + strlen(buf), "%d[]:[]", (int32_t)(prog->proginfo_Length & 0xffffffff));
+	}
+	sprintf(buf + strlen(buf), "%s[]:[]",  start_ts);
+	sprintf(buf + strlen(buf), "%s[]:[]",  end_ts);
+	if (control->conn_version < 57) {
+		sprintf(buf + strlen(buf), "%s[]:[]",  S(prog->proginfo_unknown_0)); // "duplicate"
+		sprintf(buf + strlen(buf), "%ld[]:[]", 0L); // "shareable"
+	}
+	sprintf(buf + strlen(buf), "%ld[]:[]", 0L); // "findid"
+	sprintf(buf + strlen(buf), "%s[]:[]",  S(prog->proginfo_hostname));
+	sprintf(buf + strlen(buf), "%ld[]:[]", prog->proginfo_source_id);
+	sprintf(buf + strlen(buf), "%ld[]:[]", prog->proginfo_card_id);
+	sprintf(buf + strlen(buf), "%ld[]:[]", prog->proginfo_input_id);
+	sprintf(buf + strlen(buf), "%s[]:[]",  S(prog->proginfo_rec_priority));
+	sprintf(buf + strlen(buf), "%ld[]:[]", prog->proginfo_rec_status);
+	sprintf(buf + strlen(buf), "%ld[]:[]", prog->proginfo_record_id);
+	sprintf(buf + strlen(buf), "%ld[]:[]", prog->proginfo_rec_type);
+	sprintf(buf + strlen(buf), "%ld[]:[]", prog->proginfo_rec_dups);
+	sprintf(buf + strlen(buf), "%ld[]:[]", prog->proginfo_unknown_1); // "dupmethod"
+	sprintf(buf + strlen(buf), "%s[]:[]",  rec_start_ts);
+	sprintf(buf + strlen(buf), "%s[]:[]",  rec_end_ts);
+	if (control->conn_version < 57) {
+		sprintf(buf + strlen(buf), "%ld[]:[]", prog->proginfo_repeat);
+	}
+	sprintf(buf + strlen(buf), "%ld[]:[]", prog->proginfo_program_flags);
+	sprintf(buf + strlen(buf), "%s[]:[]",  S(prog->proginfo_recgroup));
+	if (control->conn_version < 57) {
+		sprintf(buf + strlen(buf), "%s[]:[]",  S(prog->proginfo_chancommfree));
+	}
+	sprintf(buf + strlen(buf), "%s[]:[]",  S(prog->proginfo_chan_output_filters));
+	sprintf(buf + strlen(buf), "%s[]:[]",  S(prog->proginfo_seriesid));
+	sprintf(buf + strlen(buf), "%s[]:[]",  S(prog->proginfo_programid));
+	if (control->conn_version >= 67) {
+		sprintf(buf + strlen(buf), "%s[]:[]", S(prog->proginfo_inetref));
+	}
+	sprintf(buf + strlen(buf), "%s[]:[]",  lastmodified);
+	sprintf(buf + strlen(buf), "%s[]:[]",  S(prog->proginfo_stars));
+	sprintf(buf + strlen(buf), "%s[]:[]",  originalairdate);
+	if (control->conn_version >= 15 && control->conn_version < 57) {
+		sprintf(buf + strlen(buf), "%ld[]:[]", prog->proginfo_hasairdate);
+	}
+	if (control->conn_version >= 18) {
+		sprintf(buf + strlen(buf), "%s[]:[]", S(prog->proginfo_playgroup));
+	}
+	if (control->conn_version >= 25) {
+		sprintf(buf + strlen(buf), "%s[]:[]", S(prog->proginfo_recpriority_2));
+	}
+	if (control->conn_version >= 31) {
+		sprintf(buf + strlen(buf), "%ld[]:[]", prog->proginfo_parentid);
+	}
+	if (control->conn_version >= 32) {
+		sprintf(buf + strlen(buf), "%s[]:[]", S(prog->proginfo_storagegroup));
+	}
+	if (control->conn_version >= 35) {
+		sprintf(buf + strlen(buf), "%ld[]:[]", prog->proginfo_audioproperties);
+		sprintf(buf + strlen(buf), "%ld[]:[]", prog->proginfo_videoproperties);
+		sprintf(buf + strlen(buf), "%ld[]:[]", prog->proginfo_subtitletype);
+	}
+	if (control->conn_version >= 41) {
+		sprintf(buf + strlen(buf), "%s[]:[]", S(prog->proginfo_prodyear));
 	}
 #undef S
 

--- a/lib/cmyth/libcmyth/proginfo.c
+++ b/lib/cmyth/libcmyth/proginfo.c
@@ -151,9 +151,6 @@ cmyth_proginfo_destroy(cmyth_proginfo_t p)
 	if (p->proginfo_recpriority_2) {
 		ref_release(p->proginfo_recpriority_2);
 	}
-	if (p->proginfo_prodyear) {
-		ref_release(p->proginfo_prodyear);
-	}
 	cmyth_dbg(CMYTH_DBG_DEBUG, "%s }\n", __FUNCTION__);
 }
 
@@ -265,7 +262,7 @@ cmyth_proginfo_create(void)
 	ret->proginfo_audioproperties = 0;
 	ret->proginfo_videoproperties = 0;
 	ret->proginfo_subtitletype = 0;
-	ret->proginfo_prodyear = NULL;
+	ret->proginfo_year = 0;
 	cmyth_dbg(CMYTH_DBG_DEBUG, "%s }\n", __FUNCTION__);
 	return ret;
 
@@ -358,7 +355,7 @@ cmyth_proginfo_dup(cmyth_proginfo_t p)
 	ret->proginfo_audioproperties = p->proginfo_audioproperties;
 	ret->proginfo_videoproperties = p->proginfo_videoproperties;
 	ret->proginfo_subtitletype = p->proginfo_subtitletype;
-	ret->proginfo_prodyear = ref_hold(p->proginfo_prodyear);
+	ret->proginfo_year = p->proginfo_year;
 	cmyth_dbg(CMYTH_DBG_DEBUG, "%s }\n", __FUNCTION__);
 	return ret;
 }
@@ -428,7 +425,6 @@ delete_command(cmyth_conn_t control, cmyth_proginfo_t prog, char *cmd)
 	len += strlen(S(prog->proginfo_inetref));
 	len += strlen(S(prog->proginfo_recpriority_2));
 	len += strlen(S(prog->proginfo_storagegroup));
-	len += strlen(S(prog->proginfo_prodyear));
 
 	buf = alloca(len + 1+2048);
 	if (!buf) {
@@ -546,8 +542,8 @@ delete_command(cmyth_conn_t control, cmyth_proginfo_t prog, char *cmd)
 		sprintf(buf + strlen(buf), "%ld[]:[]", prog->proginfo_videoproperties);
 		sprintf(buf + strlen(buf), "%ld[]:[]", prog->proginfo_subtitletype);
 	}
-	if (control->conn_version >= 41) {
-		sprintf(buf + strlen(buf), "%s[]:[]", S(prog->proginfo_prodyear));
+	if (control->conn_version >= 43) {
+		sprintf(buf + strlen(buf), "%d[]:[]", prog->proginfo_year);
 	}
 #undef S
 
@@ -1272,33 +1268,29 @@ cmyth_proginfo_flags(cmyth_proginfo_t prog)
 }
 
 /*
- * cmyth_proginfo_prodyear(cmyth_proginfo_t prog)
+ * cmyth_proginfo_year(cmyth_proginfo_t prog)
  *
  *
  * Scope: PUBLIC
  *
  * Description
  *
- * Retrieves the 'proginfo_prodyear' field of a program info
+ * Retrieves the 'proginfo_year' field of a program info
  * structure.
- *
- * The returned string is a pointer to the string within the program
- * info structure, so it should not be modified by the caller.  The
- * return value is a 'char *' for this reason.
  *
  * Return Value:
  *
- * Success: A pointer to a 'char *' pointing to the field.
+ * Success: the production year for the program
  *
- * Failure: NULL
+ * Failure: 0
  */
-char *
-cmyth_proginfo_prodyear(cmyth_proginfo_t prog)
+unsigned short
+cmyth_proginfo_year(cmyth_proginfo_t prog)
 {
 	if (!prog) {
-		return NULL;
+		return 0;
 	}
-	return ref_hold(prog->proginfo_prodyear);
+	return prog->proginfo_year;
 }
 
 static int
@@ -1340,7 +1332,6 @@ fill_command(cmyth_conn_t control, cmyth_proginfo_t prog, char *cmd)
 	len += strlen(S(prog->proginfo_inetref));
 	len += strlen(S(prog->proginfo_recpriority_2));
 	len += strlen(S(prog->proginfo_storagegroup));
-	len += strlen(S(prog->proginfo_prodyear));
 
 	buf = alloca(len + 1+2048);
 	if (!buf) {
@@ -1458,8 +1449,8 @@ fill_command(cmyth_conn_t control, cmyth_proginfo_t prog, char *cmd)
 		sprintf(buf + strlen(buf), "%ld[]:[]", prog->proginfo_videoproperties);
 		sprintf(buf + strlen(buf), "%ld[]:[]", prog->proginfo_subtitletype);
 	}
-	if (control->conn_version >= 41) {
-		sprintf(buf + strlen(buf), "%s[]:[]", S(prog->proginfo_prodyear));
+	if (control->conn_version >= 43) {
+		sprintf(buf + strlen(buf), "%d[]:[]", prog->proginfo_year);
 	}
 #undef S
 

--- a/lib/cmyth/libcmyth/proginfo.c
+++ b/lib/cmyth/libcmyth/proginfo.c
@@ -1683,6 +1683,18 @@ cmyth_proginfo_host(cmyth_proginfo_t prog)
 	return ref_hold(prog->proginfo_host);
 }
 
+int
+cmyth_proginfo_port(cmyth_proginfo_t prog)
+{
+	if (!prog) {
+		cmyth_dbg(CMYTH_DBG_ERROR,
+			  "%s: no program info\n", __FUNCTION__);
+		return -1;
+	}
+
+	return prog->proginfo_port;
+}
+
 long
 cmyth_proginfo_card_id(cmyth_proginfo_t prog)
 {

--- a/lib/cmyth/libcmyth/proginfo.c
+++ b/lib/cmyth/libcmyth/proginfo.c
@@ -1385,86 +1385,85 @@ fill_command(cmyth_conn_t control, cmyth_proginfo_t prog, char *cmd)
 			  "%s: fill not supported with protocol ver %d\n",
 			  __FUNCTION__, control->conn_version);
 		return -EINVAL;
+	}
+	sprintf(buf, "%s %s[]:[]0[]:[]", cmd, host);
+	sprintf(buf + strlen(buf), "%s[]:[]",  S(prog->proginfo_title));
+	sprintf(buf + strlen(buf), "%s[]:[]",  S(prog->proginfo_subtitle));
+	sprintf(buf + strlen(buf), "%s[]:[]",  S(prog->proginfo_description));
+	if (control->conn_version >= 67) {
+		sprintf(buf + strlen(buf), "%u[]:[]", prog->proginfo_season);
+		sprintf(buf + strlen(buf), "%u[]:[]", prog->proginfo_episode);
+	}
+	sprintf(buf + strlen(buf), "%s[]:[]",  S(prog->proginfo_category));
+	sprintf(buf + strlen(buf), "%ld[]:[]", prog->proginfo_chanId);
+	sprintf(buf + strlen(buf), "%s[]:[]",  S(prog->proginfo_chanstr));
+	sprintf(buf + strlen(buf), "%s[]:[]",  S(prog->proginfo_chansign));
+	sprintf(buf + strlen(buf), "%s[]:[]",  S(prog->proginfo_channame));
+	sprintf(buf + strlen(buf), "%s[]:[]",  S(prog->proginfo_url));
+	if (control->conn_version >= 57) {
+		sprintf(buf + strlen(buf), "%"PRId64"[]:[]", prog->proginfo_Length);
 	} else {
-		sprintf(buf, "%s %s[]:[]0[]:[]", cmd, host);
-		sprintf(buf + strlen(buf), "%s[]:[]",  S(prog->proginfo_title));
-		sprintf(buf + strlen(buf), "%s[]:[]",  S(prog->proginfo_subtitle));
-		sprintf(buf + strlen(buf), "%s[]:[]",  S(prog->proginfo_description));
-		if (control->conn_version >= 67) {
-			sprintf(buf + strlen(buf), "%u[]:[]", prog->proginfo_season);
-			sprintf(buf + strlen(buf), "%u[]:[]", prog->proginfo_episode);
-		}
-		sprintf(buf + strlen(buf), "%s[]:[]",  S(prog->proginfo_category));
-		sprintf(buf + strlen(buf), "%ld[]:[]", prog->proginfo_chanId);
-		sprintf(buf + strlen(buf), "%s[]:[]",  S(prog->proginfo_chanstr));
-		sprintf(buf + strlen(buf), "%s[]:[]",  S(prog->proginfo_chansign));
-		sprintf(buf + strlen(buf), "%s[]:[]",  S(prog->proginfo_channame));
-		sprintf(buf + strlen(buf), "%s[]:[]",  S(prog->proginfo_url));
-		if (control->conn_version >= 57) {
-			sprintf(buf + strlen(buf), "%"PRId64"[]:[]", prog->proginfo_Length);
-		} else {
-			sprintf(buf + strlen(buf), "%d[]:[]", (int32_t)(prog->proginfo_Length >> 32));
-			sprintf(buf + strlen(buf), "%d[]:[]", (int32_t)(prog->proginfo_Length & 0xffffffff));
-		}
-		sprintf(buf + strlen(buf), "%s[]:[]",  start_ts);
-		sprintf(buf + strlen(buf), "%s[]:[]",  end_ts);
-		if (control->conn_version < 57) {
-			sprintf(buf + strlen(buf), "%s[]:[]",  S(prog->proginfo_unknown_0)); // "duplicate"
-			sprintf(buf + strlen(buf), "%ld[]:[]", 0L); // "shareable"
-		}
-		sprintf(buf + strlen(buf), "%ld[]:[]", 0L); // "findid"
-		sprintf(buf + strlen(buf), "%s[]:[]",  S(prog->proginfo_hostname));
-		sprintf(buf + strlen(buf), "%ld[]:[]", prog->proginfo_source_id);
-		sprintf(buf + strlen(buf), "%ld[]:[]", prog->proginfo_card_id);
-		sprintf(buf + strlen(buf), "%ld[]:[]", prog->proginfo_input_id);
-		sprintf(buf + strlen(buf), "%s[]:[]",  S(prog->proginfo_rec_priority));
-		sprintf(buf + strlen(buf), "%ld[]:[]", prog->proginfo_rec_status);
-		sprintf(buf + strlen(buf), "%ld[]:[]", prog->proginfo_record_id);
-		sprintf(buf + strlen(buf), "%ld[]:[]", prog->proginfo_rec_type);
-		sprintf(buf + strlen(buf), "%ld[]:[]", prog->proginfo_rec_dups);
-		sprintf(buf + strlen(buf), "%ld[]:[]", prog->proginfo_unknown_1); // "dupmethod"
-		sprintf(buf + strlen(buf), "%s[]:[]",  rec_start_ts);
-		sprintf(buf + strlen(buf), "%s[]:[]",  rec_end_ts);
-		if (control->conn_version < 57) {
-			sprintf(buf + strlen(buf), "%ld[]:[]", prog->proginfo_repeat);
-		}
-		sprintf(buf + strlen(buf), "%ld[]:[]", prog->proginfo_program_flags);
-		sprintf(buf + strlen(buf), "%s[]:[]",  S(prog->proginfo_recgroup));
-		if (control->conn_version < 57) {
-			sprintf(buf + strlen(buf), "%s[]:[]",  S(prog->proginfo_chancommfree));
-		}
-		sprintf(buf + strlen(buf), "%s[]:[]",  S(prog->proginfo_chan_output_filters));
-		sprintf(buf + strlen(buf), "%s[]:[]",  S(prog->proginfo_seriesid));
-		sprintf(buf + strlen(buf), "%s[]:[]",  S(prog->proginfo_programid));
-		if (control->conn_version >= 67) {
-			sprintf(buf + strlen(buf), "%s[]:[]", S(prog->proginfo_inetref));
-		}
-		sprintf(buf + strlen(buf), "%s[]:[]",  lastmodified);
-		sprintf(buf + strlen(buf), "%s[]:[]",  S(prog->proginfo_stars));
-		sprintf(buf + strlen(buf), "%s[]:[]",  originalairdate);
-		if (control->conn_version >= 15 && control->conn_version < 57) {
-			sprintf(buf + strlen(buf), "%ld[]:[]", prog->proginfo_hasairdate);
-		}
-		if (control->conn_version >= 18) {
-			sprintf(buf + strlen(buf), "%s[]:[]", S(prog->proginfo_playgroup));
-		}
-		if (control->conn_version >= 25) {
-			sprintf(buf + strlen(buf), "%s[]:[]", S(prog->proginfo_recpriority_2));
-		}
-		if (control->conn_version >= 31) {
-			sprintf(buf + strlen(buf), "%ld[]:[]", prog->proginfo_parentid);
-		}
-		if (control->conn_version >= 32) {
-			sprintf(buf + strlen(buf), "%s[]:[]", S(prog->proginfo_storagegroup));
-		}
-		if (control->conn_version >= 35) {
-			sprintf(buf + strlen(buf), "%ld[]:[]", prog->proginfo_audioproperties);
-			sprintf(buf + strlen(buf), "%ld[]:[]", prog->proginfo_videoproperties);
-			sprintf(buf + strlen(buf), "%ld[]:[]", prog->proginfo_subtitletype);
-		}
-		if (control->conn_version >= 41) {
-			sprintf(buf + strlen(buf), "%s[]:[]", S(prog->proginfo_prodyear));
-		}
+		sprintf(buf + strlen(buf), "%d[]:[]", (int32_t)(prog->proginfo_Length >> 32));
+		sprintf(buf + strlen(buf), "%d[]:[]", (int32_t)(prog->proginfo_Length & 0xffffffff));
+	}
+	sprintf(buf + strlen(buf), "%s[]:[]",  start_ts);
+	sprintf(buf + strlen(buf), "%s[]:[]",  end_ts);
+	if (control->conn_version < 57) {
+		sprintf(buf + strlen(buf), "%s[]:[]",  S(prog->proginfo_unknown_0)); // "duplicate"
+		sprintf(buf + strlen(buf), "%ld[]:[]", 0L); // "shareable"
+	}
+	sprintf(buf + strlen(buf), "%ld[]:[]", 0L); // "findid"
+	sprintf(buf + strlen(buf), "%s[]:[]",  S(prog->proginfo_hostname));
+	sprintf(buf + strlen(buf), "%ld[]:[]", prog->proginfo_source_id);
+	sprintf(buf + strlen(buf), "%ld[]:[]", prog->proginfo_card_id);
+	sprintf(buf + strlen(buf), "%ld[]:[]", prog->proginfo_input_id);
+	sprintf(buf + strlen(buf), "%s[]:[]",  S(prog->proginfo_rec_priority));
+	sprintf(buf + strlen(buf), "%ld[]:[]", prog->proginfo_rec_status);
+	sprintf(buf + strlen(buf), "%ld[]:[]", prog->proginfo_record_id);
+	sprintf(buf + strlen(buf), "%ld[]:[]", prog->proginfo_rec_type);
+	sprintf(buf + strlen(buf), "%ld[]:[]", prog->proginfo_rec_dups);
+	sprintf(buf + strlen(buf), "%ld[]:[]", prog->proginfo_unknown_1); // "dupmethod"
+	sprintf(buf + strlen(buf), "%s[]:[]",  rec_start_ts);
+	sprintf(buf + strlen(buf), "%s[]:[]",  rec_end_ts);
+	if (control->conn_version < 57) {
+		sprintf(buf + strlen(buf), "%ld[]:[]", prog->proginfo_repeat);
+	}
+	sprintf(buf + strlen(buf), "%ld[]:[]", prog->proginfo_program_flags);
+	sprintf(buf + strlen(buf), "%s[]:[]",  S(prog->proginfo_recgroup));
+	if (control->conn_version < 57) {
+		sprintf(buf + strlen(buf), "%s[]:[]",  S(prog->proginfo_chancommfree));
+	}
+	sprintf(buf + strlen(buf), "%s[]:[]",  S(prog->proginfo_chan_output_filters));
+	sprintf(buf + strlen(buf), "%s[]:[]",  S(prog->proginfo_seriesid));
+	sprintf(buf + strlen(buf), "%s[]:[]",  S(prog->proginfo_programid));
+	if (control->conn_version >= 67) {
+		sprintf(buf + strlen(buf), "%s[]:[]", S(prog->proginfo_inetref));
+	}
+	sprintf(buf + strlen(buf), "%s[]:[]",  lastmodified);
+	sprintf(buf + strlen(buf), "%s[]:[]",  S(prog->proginfo_stars));
+	sprintf(buf + strlen(buf), "%s[]:[]",  originalairdate);
+	if (control->conn_version >= 15 && control->conn_version < 57) {
+		sprintf(buf + strlen(buf), "%ld[]:[]", prog->proginfo_hasairdate);
+	}
+	if (control->conn_version >= 18) {
+		sprintf(buf + strlen(buf), "%s[]:[]", S(prog->proginfo_playgroup));
+	}
+	if (control->conn_version >= 25) {
+		sprintf(buf + strlen(buf), "%s[]:[]", S(prog->proginfo_recpriority_2));
+	}
+	if (control->conn_version >= 31) {
+		sprintf(buf + strlen(buf), "%ld[]:[]", prog->proginfo_parentid);
+	}
+	if (control->conn_version >= 32) {
+		sprintf(buf + strlen(buf), "%s[]:[]", S(prog->proginfo_storagegroup));
+	}
+	if (control->conn_version >= 35) {
+		sprintf(buf + strlen(buf), "%ld[]:[]", prog->proginfo_audioproperties);
+		sprintf(buf + strlen(buf), "%ld[]:[]", prog->proginfo_videoproperties);
+		sprintf(buf + strlen(buf), "%ld[]:[]", prog->proginfo_subtitletype);
+	}
+	if (control->conn_version >= 41) {
+		sprintf(buf + strlen(buf), "%s[]:[]", S(prog->proginfo_prodyear));
 	}
 #undef S
 

--- a/lib/cmyth/libcmyth/proginfo.c
+++ b/lib/cmyth/libcmyth/proginfo.c
@@ -1320,7 +1320,7 @@ fill_command(cmyth_conn_t control, cmyth_proginfo_t prog, char *cmd)
 	char lastmodified[CMYTH_TIMESTAMP_LEN + 1];
 	int err = 0;
 	int ret = 0;
-	char *host = "mediamvp";
+	char *host = "libcmyth";
 
 	if (!prog) {
 		cmyth_dbg(CMYTH_DBG_ERROR, "%s: no program info\n",

--- a/lib/cmyth/libcmyth/proglist.c
+++ b/lib/cmyth/libcmyth/proglist.c
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2004-2006, Eric Lund
+ *  Copyright (C) 2004-2010, Eric Lund
  *  http://www.mvpmc.org/
  *
  *  This library is free software; you can redistribute it and/or

--- a/lib/cmyth/libcmyth/proglist.c
+++ b/lib/cmyth/libcmyth/proglist.c
@@ -23,11 +23,7 @@
  *               and cmyth_proglist_t and between long long and
  *               cmyth_proglist_t.
  */
-#include <sys/types.h>
 #include <stdlib.h>
-#ifndef _MSC_VER
-#include <unistd.h>
-#endif
 #include <stdio.h>
 #include <errno.h>
 #include <string.h>

--- a/lib/cmyth/libcmyth/rec_num.c
+++ b/lib/cmyth/libcmyth/rec_num.c
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2004-2006, Eric Lund
+ *  Copyright (C) 2004-2010, Eric Lund
  *  http://www.mvpmc.org/
  *
  *  This library is free software; you can redistribute it and/or

--- a/lib/cmyth/libcmyth/rec_num.c
+++ b/lib/cmyth/libcmyth/rec_num.c
@@ -21,14 +21,9 @@
  * rec_num.c -  functions to manage recorder number structures.  Mostly
  *              just allocating, freeing, and filling them out.
  */
-#include <sys/types.h>
 #include <stdlib.h>
-#ifndef _MSC_VER
-#include <unistd.h>
-#endif
 #include <stdio.h>
 #include <string.h>
-#include <errno.h>
 #include <cmyth_local.h>
 
 /*

--- a/lib/cmyth/libcmyth/recorder.c
+++ b/lib/cmyth/libcmyth/recorder.c
@@ -26,32 +26,12 @@
  *                owns the tuner and channel information (i.e. program
  *                guide data).
  */
-#include <sys/types.h>
 #include <stdlib.h>
-#ifndef _MSC_VER
-#include <unistd.h>
-#endif
 #include <stdio.h>
 #include <errno.h>
 #include <string.h>
-#ifdef _MSC_VER
 #include <time.h>
-#else
-#include <sys/time.h>
-#endif
 #include <cmyth_local.h>
-
-#ifdef _MSC_VER
-static void nullprint(a, ...) { return; }
-#define PRINTF nullprint
-#define TRC  nullprint
-#elif 0
-#define PRINTF(x...) PRINTF(x)
-#define TRC(fmt, args...) PRINTF(fmt, ## args) 
-#else
-#define PRINTF(x...)
-#define TRC(fmt, args...) 
-#endif
 
 /*
  * cmyth_recorder_destroy(cmyth_recorder_t rec)

--- a/lib/cmyth/libcmyth/recorder.c
+++ b/lib/cmyth/libcmyth/recorder.c
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2004-2006, Eric Lund, Jon Gettler
+ *  Copyright (C) 2004-2009, Eric Lund, Jon Gettler
  *  http://www.mvpmc.org/
  *
  *  This library is free software; you can redistribute it and/or

--- a/lib/cmyth/libcmyth/recorder.c
+++ b/lib/cmyth/libcmyth/recorder.c
@@ -509,7 +509,6 @@ cmyth_recorder_pause(cmyth_recorder_t rec)
 
 	pthread_mutex_lock(&mutex);
 
-	PRINTF("** SSDEBUG: trying to pause recorder:%p:%p\n",rec,rec->rec_conn);
 	sprintf(Buffer, "QUERY_RECORDER %ld[]:[]PAUSE", (long) rec->rec_id);
 	if ((ret=cmyth_send_message(rec->rec_conn, Buffer)) < 0) {
 		cmyth_dbg(CMYTH_DBG_ERROR,
@@ -527,7 +526,6 @@ cmyth_recorder_pause(cmyth_recorder_t rec)
 	ret = 0;
 
     err:
-	PRINTF("** SSDEBUG: recorder paused:\n");
 	pthread_mutex_unlock(&mutex);
 
 	return ret;

--- a/lib/cmyth/libcmyth/ringbuf.c
+++ b/lib/cmyth/libcmyth/ringbuf.c
@@ -131,7 +131,7 @@ cmyth_ringbuf_setup(cmyth_recorder_t rec)
 
 	int err, count;
 	int r;
-	long long size, fill;
+	int64_t size, fill;
 	char msg[256];
 	char url[1024];
 	char buf[32];
@@ -167,7 +167,7 @@ cmyth_ringbuf_setup(cmyth_recorder_t rec)
 	r = cmyth_rcv_string(control, &err, url, sizeof(url)-1, count); 
 	count -= r;
 
-	if ((r=cmyth_rcv_long_long(control, &err, &size, count)) < 0) {
+	if ((r=cmyth_rcv_int64(control, &err, &size, count)) < 0) {
 		cmyth_dbg(CMYTH_DBG_ERROR,
 			  "%s: cmyth_rcv_length() failed (%d)\n",
 			  __FUNCTION__, r);
@@ -175,7 +175,7 @@ cmyth_ringbuf_setup(cmyth_recorder_t rec)
 	}
 	count -= r;
 
-	if ((r=cmyth_rcv_long_long(control, &err, &fill, count)) < 0) {
+	if ((r=cmyth_rcv_int64(control, &err, &fill, count)) < 0) {
 		cmyth_dbg(CMYTH_DBG_ERROR,
 			  "%s: cmyth_rcv_length() failed (%d)\n",
 			  __FUNCTION__, r);
@@ -528,7 +528,7 @@ cmyth_ringbuf_seek(cmyth_recorder_t rec,
 	char msg[128];
 	int err;
 	int count;
-	long long c;
+	int64_t c;
 	long r;
 	long long ret;
 	cmyth_ringbuf_t ring;
@@ -561,7 +561,7 @@ cmyth_ringbuf_seek(cmyth_recorder_t rec,
 	}
 
 	count = cmyth_rcv_length(rec->rec_conn);
-	if ((r=cmyth_rcv_long_long(rec->rec_conn, &err, &c, count)) < 0) {
+	if ((r=cmyth_rcv_int64(rec->rec_conn, &err, &c, count)) < 0) {
 		cmyth_dbg(CMYTH_DBG_ERROR,
 			  "%s: cmyth_rcv_length() failed (%d)\n",
 			  __FUNCTION__, r);

--- a/lib/cmyth/libcmyth/ringbuf.c
+++ b/lib/cmyth/libcmyth/ringbuf.c
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2004-2006, Eric Lund
+ *  Copyright (C) 2004-2012, Eric Lund
  *  http://www.mvpmc.org/
  *
  *  This library is free software; you can redistribute it and/or

--- a/lib/cmyth/libcmyth/ringbuf.c
+++ b/lib/cmyth/libcmyth/ringbuf.c
@@ -24,15 +24,11 @@
  *                This allows the watcher to do things like pause, rewind
  *                and so forth on live-tv.
  */
-#include <sys/types.h>
 #include <stdlib.h>
-#ifndef _MSC_VER
-#include <unistd.h>
-#include <sys/socket.h>
-#endif
 #include <stdio.h>
 #include <errno.h>
 #include <string.h>
+#include <sys/types.h>
 #include <cmyth_local.h>
 
 /*

--- a/lib/cmyth/libcmyth/safe_string.h
+++ b/lib/cmyth/libcmyth/safe_string.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2006, Simon Hyde
+ *  Copyright (C) 2006-2009, Simon Hyde
  *  http://www.mvpmc.org/
  *
  *  This library is free software; you can redistribute it and/or

--- a/lib/cmyth/libcmyth/safe_string.h
+++ b/lib/cmyth/libcmyth/safe_string.h
@@ -17,12 +17,12 @@
  *  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  */
 
-/** \file mvp_string.h
+/** \file safe_string.h
  * Some basic string handling routines to help avoid segfaults/buffer overflows
  */
 
-#ifndef __MVP_STRING_H
-#define __MVP_STRING_H
+#ifndef __CMYTH_STRING_H
+#define __CMYTH_STRING_H
 
 #include <stdio.h>
 
@@ -46,4 +46,4 @@ static inline char * safe_strncpy(char *dest,const char *src,size_t n)
 #define safe_atoll(str) (((str) == NULL)? (long long)0: atoll(str))
 #define safe_atoi(str) (((str) == NULL)? (int)0: atoi(str))
 
-#endif /* __MVP_STRING_H */
+#endif /* __CMYTH_STRING_H */

--- a/lib/cmyth/libcmyth/socket.c
+++ b/lib/cmyth/libcmyth/socket.c
@@ -367,7 +367,7 @@ cmyth_rcv_string(cmyth_conn_t conn, int *err, char *buf, int buflen, int count)
 			}
 		}
 
-		if (conn->conn_buf[conn->conn_pos] == *state) {
+		if (conn->conn_buf[conn->conn_pos] == (unsigned char)*state) {
 			/*
 			 * We matched the next (possibly first) step
 			 * of a separator, advance to the next.
@@ -460,7 +460,7 @@ cmyth_rcv_ulong(cmyth_conn_t conn, int *err, unsigned long *buf,
 	int consumed;
 	int tmp;
 
-  *buf = 0;
+	*buf = 0;
 
 	if (!err) {
 		err = &tmp;
@@ -1446,7 +1446,7 @@ cmyth_proginfo_parse_url(cmyth_proginfo_t p)
 	}
 
     out:
-	if (host && port) {
+	if (host && port && path) {
 		char tmp = *(port - 1);
 		*(port - 1) = '\0';
 		if (p->proginfo_host)
@@ -2890,7 +2890,7 @@ cmyth_rcv_data(cmyth_conn_t conn, int *err, unsigned char *buf, int count)
 		*err = EINVAL;
 		return 0;
 	}
-	err = 0;
+	*err = 0;
 	if (!conn) {
 		cmyth_dbg(CMYTH_DBG_ERROR, "%s: no connection\n",
 			  __FUNCTION__);

--- a/lib/cmyth/libcmyth/socket.c
+++ b/lib/cmyth/libcmyth/socket.c
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2004-2006, Eric Lund
+ *  Copyright (C) 2004-2012, Eric Lund
  *  http://www.mvpmc.org/
  *
  *  This library is free software; you can redistribute it and/or

--- a/lib/cmyth/libcmyth/socket.c
+++ b/lib/cmyth/libcmyth/socket.c
@@ -21,16 +21,12 @@
  * socket.c - functions to handle low level socket interactions with a
  *            MythTV frontend.  
  */
-#include <sys/types.h>
 #include <stdlib.h>
-#ifndef _MSC_VER
-#include <unistd.h>
-#include <sys/socket.h>
-#endif
 #include <stdio.h>
-#include <string.h>
 #include <ctype.h>
+#include <string.h>
 #include <errno.h>
+#include <sys/types.h>
 #include <cmyth_local.h>
 
 #define __UNSIGNED	"0123456789"

--- a/lib/cmyth/libcmyth/socket.c
+++ b/lib/cmyth/libcmyth/socket.c
@@ -832,7 +832,7 @@ cmyth_rcv_short(cmyth_conn_t conn, int *err, short *buf, int count)
 }
 
 /*
- * cmyth_rcv_long_long(cmyth_conn_t conn, int *err, long long *buf, int count)
+ * cmyth_rcv_old_int64(cmyth_conn_t conn, int *err, long long *buf, int count)
  * 
  * Scope: PRIVATE (mapped to __cmyth_rcv_long)
  *
@@ -863,9 +863,9 @@ cmyth_rcv_short(cmyth_conn_t conn, int *err, short *buf, int count)
  * EINVAL       The token received is not numeric
  */
 int
-cmyth_rcv_long_long(cmyth_conn_t conn, int *err, long long *buf, int count)
+cmyth_rcv_old_int64(cmyth_conn_t conn, int *err, int64_t *buf, int count)
 {
-	long long val;
+	int64_t val;
 	int consumed;
 	int tmp;
 	unsigned long hi, lo;
@@ -879,36 +879,21 @@ cmyth_rcv_long_long(cmyth_conn_t conn, int *err, long long *buf, int count)
 		return 0;
 	}
 
-	if (conn->conn_version >= 66) {
-		/*
-		 * Since protocol 66 mythbackend now sends a single 64 bit integer rather than two hi and lo
-		 * 32 bit integers for ALL 64 bit values.
-		 */
-		consumed = cmyth_rcv_int64(conn, err, &val, count);
-		if (*err) {
-			cmyth_dbg(CMYTH_DBG_ERROR,
-				  "%s: cmyth_rcv_int64() failed (%d)\n",
-				  __FUNCTION__, consumed);
-			return consumed;
-		}
+	consumed = cmyth_rcv_u_long(conn, err, &hi, count);
+	if (*err) {
+		cmyth_dbg(CMYTH_DBG_ERROR,
+			  "%s: cmyth_rcv_u_long() failed (%d)\n",
+			  __FUNCTION__, consumed);
+		return consumed;
 	}
-	else {
-		consumed = cmyth_rcv_u_long(conn, err, &hi, count);
-		if (*err) {
-			cmyth_dbg(CMYTH_DBG_ERROR,
-				  "%s: cmyth_rcv_u_long_long() failed (%d)\n",
-				  __FUNCTION__, consumed);
-			return consumed;
-		}
-		consumed += cmyth_rcv_u_long(conn, err, &lo, count-consumed);
-		if (*err) {
-			cmyth_dbg(CMYTH_DBG_ERROR,
-				  "%s: cmyth_rcv_u_long_long() failed (%d)\n",
-				  __FUNCTION__, consumed);
-			return consumed;
-		}
-		val = (((long long)hi) << 32) | ((long long)(lo & 0xFFFFFFFF));
+	consumed += cmyth_rcv_u_long(conn, err, &lo, count-consumed);
+	if (*err) {
+		cmyth_dbg(CMYTH_DBG_ERROR,
+			  "%s: cmyth_rcv_u_long() failed (%d)\n",
+			  __FUNCTION__, consumed);
+		return consumed;
 	}
+	val = (((long long)hi) << 32) | ((long long)(lo & 0xFFFFFFFF));
 
 	*err = 0;
 	*buf = val;
@@ -917,7 +902,7 @@ cmyth_rcv_long_long(cmyth_conn_t conn, int *err, long long *buf, int count)
 }
 
 /*
- * cmyth_rcv_int64(cmyth_conn_t conn, int *err, long long *buf, int count)
+ * cmyth_rcv_new_int64(cmyth_conn_t conn, int *err, long long *buf, int count)
  *
  * Scope: PRIVATE (mapped to __cmyth_rcv_long)
  *
@@ -953,7 +938,8 @@ cmyth_rcv_long_long(cmyth_conn_t conn, int *err, long long *buf, int count)
  * EINVAL       The token received is not numeric
  */
 int
-cmyth_rcv_int64(cmyth_conn_t conn, int *err, long long *buf, int count)
+cmyth_rcv_new_int64(cmyth_conn_t conn, int *err, int64_t *buf, int count,
+		    int forced)
 {
 	char num[32];
 	char *num_p = num;
@@ -962,6 +948,123 @@ cmyth_rcv_int64(cmyth_conn_t conn, int *err, long long *buf, int count)
 	long long limit = 0x7fffffffffffffffLL;
 	int consumed;
 	int tmp;
+
+	/*
+	 * Between protocols 57 and 66, not all messages used the new
+	 * format for 64-bit values.
+	 */
+	if ((conn->conn_version < 57) ||
+	    ((conn->conn_version < 66) && !forced)) {
+		return cmyth_rcv_old_int64(conn, err, buf, count);
+	}
+
+	if (!err) {
+		err = &tmp;
+	}
+	if (count <= 0) {
+		*err = EINVAL;
+		return 0;
+	}
+	*err = 0;
+	consumed = cmyth_rcv_string(conn, err, num, sizeof(num), count);
+	if (*err) {
+		cmyth_dbg(CMYTH_DBG_ERROR,
+			"%s: cmyth_rcv_string() failed (%d)\n",
+			__FUNCTION__, consumed);
+		return consumed;
+	}
+	if (*num_p && (*num_p == '-')) {
+		++num_p;
+		sign = -1;
+	}
+	while (*num_p) {
+		if (!isdigit(*num_p)) {
+			cmyth_dbg(CMYTH_DBG_ERROR,
+				  "%s: received illegal integer: '%s'\n",
+				  __FUNCTION__, num);
+			*err = EINVAL;
+			return consumed;
+		}
+		val *= 10;
+		val += ((*num_p) - '0');
+		/*
+		 * Check and make sure we are still under the limit (this is
+		 * an absolute value limit, sign will be applied later).
+		 */
+		if (val > (unsigned long long)limit) {
+			cmyth_dbg(CMYTH_DBG_ERROR,
+				  "%s: long long out of range: '%s'\n",
+				  __FUNCTION__, num, limit);
+			*err = ERANGE;
+			return consumed;
+		}
+		num_p++;
+	}
+
+	/*
+	 * Got a result, return it.
+	 */
+	*buf = (long long)(sign * val);
+
+	return consumed;
+}
+
+/*
+ * cmyth_rcv_new_uint64(cmyth_conn_t conn, int *err, uint64_t *buf, int count)
+ *
+ * Scope: PRIVATE (mapped to __cmyth_rcv_long)
+ *
+ * Description
+ *
+ * Receive a long long (signed 64 bit) integer token from a list of tokens
+ * in a MythTV Protocol message.  Tokens in MythTV Protocol messages
+ * are separated by the string: []:[] or terminated by running out of
+ * message.  Up to 'count' Bytes will be consumed from the socket
+ * specified by 'conn' (stopping when a separator is seen or 'count'
+ * is exhausted).  The long integer value of the token is placed in
+ * the location pointed to by 'buf'.  If an error is encountered and
+ * 'err' is not NULL, an indication of the nature of the error will be
+ * recorded by placing an error code in the location pointed to by
+ * 'err'.  If all goes well, 'err' wil be set to 0.
+ *
+ * As of protocol version 57, Myth now sends a single 64bit string instead
+ * of 2 32bit strings when sending proginfo data.  This does not seem to
+ * apply uniformly though. For instance 'ANN FILETRANSFER' still uses
+ * the old method
+ *
+ * Return Value:
+ *
+ * A value >=0 indicating the number of bytes consumed.
+ *
+ * Error Codes:
+ *
+ * In addition to system call error codes, the following errors may be
+ * placed in 'err':
+ *
+ * ERANGE       The token received is too large to fit in a long integer
+ *
+ * EINVAL       The token received is not numeric
+ */
+int
+cmyth_rcv_new_uint64(cmyth_conn_t conn, int *err, uint64_t *buf, int count,
+		     int forced)
+{
+	char num[32];
+	char *num_p = num;
+	uint64_t val = 0;
+	int sign = 1;
+	long long limit = 0x7fffffffffffffffLL;
+	int consumed;
+	int tmp;
+
+	/*
+	 * Between protocols 57 and 66, not all messages used the new
+	 * format for 64-bit values.
+	 */
+	if ((conn->conn_version < 57) ||
+	    ((conn->conn_version < 66) && !forced)) {
+		return cmyth_rcv_old_uint64(conn, err, buf, count);
+	}
 
 	if (!err) {
 		err = &tmp;
@@ -1179,16 +1282,14 @@ cmyth_rcv_ushort(cmyth_conn_t conn, int *err, unsigned short *buf, int count)
  * EINVAL       The token received is not numeric or is signed
  */
 int
-cmyth_rcv_ulong_long(cmyth_conn_t conn, int *err,
-		     unsigned long long *buf, int count)
+cmyth_rcv_old_uint64(cmyth_conn_t conn, int *err, uint64_t *buf, int count)
 {
 	unsigned long long val;
-	long long val64;
 	unsigned long hi, lo;
 	int consumed;
 	int tmp;
 
-  *buf = 0;
+	*buf = 0;
 
 	if (!err) {
 		err = &tmp;
@@ -1199,44 +1300,22 @@ cmyth_rcv_ulong_long(cmyth_conn_t conn, int *err,
 		return 0;
 	}
 	
-	if (conn->conn_version >= 66) {
-		/*
-		 * Since protocol 66 mythbackend now sends a single 64 bit integer rather than two hi and lo
-		 * 32 bit integers for ALL 64 bit values.
-		 */
-		consumed = cmyth_rcv_int64(conn, err, &val64, count);
-		if (*err) {
-			cmyth_dbg(CMYTH_DBG_ERROR,
-				  "%s: cmyth_rcv_int64() failed (%d)\n",
-				  __FUNCTION__, consumed);
-			return consumed;
-		}
-		if (val64 < 0) {
-			cmyth_dbg(CMYTH_DBG_ERROR,
-				  "%s: cmyth_rcv_int64() failed as signed 64 bit integer received\n",
-				  __FUNCTION__, consumed);
-			*err = EINVAL;
-			return consumed;
-		}
-		val = (unsigned long long)val64;
+	consumed = cmyth_rcv_u_long(conn, err, &hi, count);
+	if (*err) {
+		cmyth_dbg(CMYTH_DBG_ERROR,
+			  "%s: cmyth_rcv_u_long() failed (%d)\n",
+			  __FUNCTION__, consumed);
+		return consumed;
 	}
-	else {
-		consumed = cmyth_rcv_u_long(conn, err, &hi, count);
-		if (*err) {
-			cmyth_dbg(CMYTH_DBG_ERROR,
-				  "%s: cmyth_rcv_u_long_long() failed (%d)\n",
-				  __FUNCTION__, consumed);
-			return consumed;
-		}
-		consumed += cmyth_rcv_u_long(conn, err, &lo, count);
-		if (*err) {
-			cmyth_dbg(CMYTH_DBG_ERROR,
-				  "%s: cmyth_rcv_u_long_long() failed (%d)\n",
-				  __FUNCTION__, consumed);
-			return consumed;
-		}
-		val = (((unsigned long long)hi) << 32) | ((unsigned long long)(lo & 0xFFFFFFFF));
+	consumed += cmyth_rcv_u_long(conn, err, &lo, count - consumed);
+	if (*err) {
+		cmyth_dbg(CMYTH_DBG_ERROR,
+			  "%s: cmyth_rcv_u_long() failed (%d)\n",
+			  __FUNCTION__, consumed);
+		return consumed;
 	}
+	val = (((unsigned long long)hi) << 32) | ((unsigned long long)(lo & 0xFFFFFFFF));
+
 	*err = 0;
 	*buf = val;
 
@@ -1504,7 +1583,6 @@ cmyth_rcv_proginfo(cmyth_conn_t conn, int *err, cmyth_proginfo_t buf,
 	int total = 0;
 	char *failed = NULL;
 	char tmp_str[32768];
-	int (*rcv_64)(cmyth_conn_t, int *, long long *, int);
 
 	if (count <= 0) {
 		*err = EINVAL;
@@ -1517,15 +1595,6 @@ cmyth_rcv_proginfo(cmyth_conn_t conn, int *err, cmyth_proginfo_t buf,
 	cmyth_dbg(CMYTH_DBG_DEBUG, "%s: VERSION IS %ld\n",
 		  __FUNCTION__, buf->proginfo_version);
 
-	if (buf->proginfo_version >= 57) {
-		/*
-		 * Since protocol 57 mythbackend now sends a single 64 bit integer rather than two 32 bit
-		 * hi and lo integers for the proginfo length.
-		 */
-		rcv_64 = &cmyth_rcv_int64;
-	} else {
-		rcv_64 = &cmyth_rcv_long_long;
-	}
 	/*
 	 * Get proginfo_title (string)
 	 */
@@ -1703,7 +1772,18 @@ cmyth_rcv_proginfo(cmyth_conn_t conn, int *err, cmyth_proginfo_t buf,
 	/*
 	 * Get proginfo_Length (long_long)
 	 */
-	consumed = rcv_64(conn, err, &buf->proginfo_Length, count);
+	if (buf->proginfo_version < 57) {
+		consumed = cmyth_rcv_old_int64(conn, err, &buf->proginfo_Length,
+					       count);
+	} else {
+		/*
+		 * Since protocol 57 mythbackend now sends a single 64 bit
+		 * integer rather than two 32 bit hi and lo integers for the
+		 * proginfo length.
+		 */
+		consumed = cmyth_rcv_new_int64(conn, err, &buf->proginfo_Length,
+					       count, 1);
+	}
 	count -= consumed;
 	total += consumed;
 	if (*err) {

--- a/lib/cmyth/libcmyth/socket.c
+++ b/lib/cmyth/libcmyth/socket.c
@@ -2345,23 +2345,22 @@ cmyth_rcv_proginfo(cmyth_conn_t conn, int *err, cmyth_proginfo_t buf,
 			failed = "cmyth_rcv_ulong subtitletype";
 			goto fail;
 		}
-	}
-  if (buf->proginfo_version >= 41) {
-		/*
-		* Get proginfo_prodyear (string)
-		*/
-		consumed = cmyth_rcv_string(conn, err,
-							tmp_str, sizeof(tmp_str) - 1, count);
+	}	
+
+	/*
+	 * Get Year
+	 */
+	if (buf->proginfo_version >= 43) {
+		consumed = cmyth_rcv_ushort(conn, err, &buf->proginfo_year,
+						count);
 		count -= consumed;
 		total += consumed;
 		if (*err) {
-			failed = "cmyth_rcv_string";
+			failed = "cmyth_rcv_ushort proginfo_year";
 			goto fail;
 		}
-		if (buf->proginfo_prodyear)
-			ref_release(buf->proginfo_prodyear);
-		buf->proginfo_prodyear = ref_strdup(tmp_str);
-  }
+	}
+
 	cmyth_dbg(CMYTH_DBG_INFO, "%s: got recording info\n", __FUNCTION__);
 
 	cmyth_proginfo_parse_url(buf);

--- a/lib/cmyth/libcmyth/socket.c
+++ b/lib/cmyth/libcmyth/socket.c
@@ -2292,8 +2292,8 @@ cmyth_rcv_proginfo(cmyth_conn_t conn, int *err, cmyth_proginfo_t buf,
 	return total;
 
     fail:
-	cmyth_dbg(CMYTH_DBG_ERROR, "%s: %s() failed (%d)\n",
-		  __FUNCTION__, failed, *err);
+	cmyth_dbg(CMYTH_DBG_ERROR, "%s: %s() failed (%d) (count = %d)\n",
+		  __FUNCTION__, failed, *err, count);
 	return total;
 }
 
@@ -2560,8 +2560,8 @@ cmyth_rcv_chaninfo(cmyth_conn_t conn, int *err, cmyth_proginfo_t buf,
 	return total;
 
     fail:
-	cmyth_dbg(CMYTH_DBG_ERROR, "%s: %s() failed (%d)\n",
-		  __FUNCTION__, failed, *err);
+	cmyth_dbg(CMYTH_DBG_ERROR, "%s: %s() failed (%d) (count = %d)\n",
+		  __FUNCTION__, failed, *err, count);
 	return total;
 }
 

--- a/lib/cmyth/libcmyth/timestamp.c
+++ b/lib/cmyth/libcmyth/timestamp.c
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2004-2006, Eric Lund
+ *  Copyright (C) 2004-2010, Eric Lund
  *  http://www.mvpmc.org/
  *
  *  This library is free software; you can redistribute it and/or

--- a/lib/cmyth/libcmyth/timestamp.c
+++ b/lib/cmyth/libcmyth/timestamp.c
@@ -23,18 +23,12 @@
  *               and cmyth_timestamp_t and between time_t and
  *               cmyth_timestamp_t.
  */
-#include <sys/types.h>
 #include <stdlib.h>
-#ifndef _MSC_VER
-#include <unistd.h>
-#endif
-#include <ctype.h>
 #include <stdio.h>
+#include <ctype.h>
 #include <errno.h>
 #include <string.h>
 #include <cmyth_local.h>
-#include <time.h>
-
 
 /*
  * cmyth_timestamp_create(void)

--- a/lib/cmyth/librefmem/debug_refmem.c
+++ b/lib/cmyth/librefmem/debug_refmem.c
@@ -30,7 +30,7 @@
 
 #include "debug.h"
 
-static mvp_debug_ctx_t refmem_debug_ctx = MVP_DEBUG_CTX_INIT("refmem",
+static cmyth_debug_ctx_t refmem_debug_ctx = CMYTH_DEBUG_CTX_INIT("refmem",
 							     REF_DBG_NONE,
 							     NULL);
 /*
@@ -51,7 +51,7 @@ static mvp_debug_ctx_t refmem_debug_ctx = MVP_DEBUG_CTX_INIT("refmem",
 void
 refmem_dbg_level(int l)
 {
-	mvp_dbg_setlevel(&refmem_debug_ctx, l);
+	__cmyth_dbg_setlevel(&refmem_debug_ctx, l);
 }
 
 /*
@@ -70,7 +70,7 @@ refmem_dbg_level(int l)
 void
 refmem_dbg_all()
 {
-	mvp_dbg_setlevel(&refmem_debug_ctx, REF_DBG_ALL);
+	__cmyth_dbg_setlevel(&refmem_debug_ctx, REF_DBG_ALL);
 }
 
 /*
@@ -89,7 +89,7 @@ refmem_dbg_all()
 void
 refmem_dbg_none()
 {
-	mvp_dbg_setlevel(&refmem_debug_ctx, REF_DBG_NONE);
+	__cmyth_dbg_setlevel(&refmem_debug_ctx, REF_DBG_NONE);
 }
 
 /*
@@ -113,6 +113,6 @@ refmem_dbg(int level, char *fmt, ...)
 	va_list ap;
 
 	va_start(ap, fmt);
-	mvp_dbg(&refmem_debug_ctx, level, fmt, ap);
+	__cmyth_dbg(&refmem_debug_ctx, level, fmt, ap);
 	va_end(ap);
 }

--- a/xbmc/filesystem/DllLibCMyth.h
+++ b/xbmc/filesystem/DllLibCMyth.h
@@ -106,7 +106,7 @@ public:
   virtual cmyth_timestamp_t proginfo_rec_start      (cmyth_proginfo_t prog)=0;
   virtual cmyth_timestamp_t proginfo_rec_end        (cmyth_proginfo_t prog)=0;
   virtual cmyth_proginfo_rec_status_t proginfo_rec_status(cmyth_proginfo_t prog)=0;
-  virtual char*             proginfo_prodyear       (cmyth_proginfo_t prog)=0;
+  virtual unsigned short    proginfo_year           (cmyth_proginfo_t prog)=0;
   virtual cmyth_proginfo_t  proginfo_get_from_basename   (cmyth_conn_t control, const char* basename)=0;
   virtual int               proginfo_delete_recording(cmyth_conn_t control, cmyth_proginfo_t prog)=0;
   virtual int               proginfo_stop_recording(cmyth_conn_t control, cmyth_proginfo_t prog)=0;
@@ -207,7 +207,7 @@ class DllLibCMyth : public DllDynamic, DllLibCMythInterface
   DEFINE_METHOD1(cmyth_timestamp_t,   proginfo_rec_end,         (cmyth_proginfo_t p1))
   DEFINE_METHOD1(cmyth_proginfo_rec_status_t, proginfo_rec_status, (cmyth_proginfo_t p1))
   DEFINE_METHOD1(unsigned long,       proginfo_flags,           (cmyth_proginfo_t p1))
-  DEFINE_METHOD1(char*,               proginfo_prodyear,        (cmyth_proginfo_t p1))
+  DEFINE_METHOD1(unsigned short,      proginfo_year,            (cmyth_proginfo_t p1))
   DEFINE_METHOD2(cmyth_proginfo_t,    proginfo_get_from_basename,    (cmyth_conn_t p1, const char* p2))
   DEFINE_METHOD2(int,                 proginfo_delete_recording, (cmyth_conn_t p1, cmyth_proginfo_t p2))
   DEFINE_METHOD2(int,                 proginfo_stop_recording,  (cmyth_conn_t p1, cmyth_proginfo_t p2))
@@ -302,7 +302,7 @@ class DllLibCMyth : public DllDynamic, DllLibCMythInterface
     RESOLVE_METHOD_RENAME(cmyth_proginfo_rec_end, proginfo_rec_end)
     RESOLVE_METHOD_RENAME(cmyth_proginfo_rec_status, proginfo_rec_status)
     RESOLVE_METHOD_RENAME(cmyth_proginfo_flags, proginfo_flags)
-    RESOLVE_METHOD_RENAME(cmyth_proginfo_prodyear, proginfo_prodyear)
+    RESOLVE_METHOD_RENAME(cmyth_proginfo_year, proginfo_year)
     RESOLVE_METHOD_RENAME(cmyth_proginfo_get_from_basename, proginfo_get_from_basename)
     RESOLVE_METHOD_RENAME(cmyth_proginfo_delete_recording, proginfo_delete_recording)
     RESOLVE_METHOD_RENAME(cmyth_proginfo_stop_recording, proginfo_stop_recording)

--- a/xbmc/filesystem/MythDirectory.cpp
+++ b/xbmc/filesystem/MythDirectory.cpp
@@ -309,9 +309,9 @@ bool CMythDirectory::GetRecordings(const CStdString& base, CFileItemList &items,
          * lookups.
          */
         CStdString label(item->m_strTitle);
-        CStdString prodyear = GetValue(m_dll->proginfo_prodyear(program));
-        if (!prodyear.IsEmpty())
-          label += " (" + prodyear + ")";
+        unsigned short year = m_dll->proginfo_year(program);
+        if (year > 0)
+          label.AppendFormat(" (%d)", year);
         item->SetLabel(label);
         item->SetLabelPreformated(true);
       }


### PR DESCRIPTION
There are still quite a number of changes to be made to match XBMC, upstream libcmyth and the changes that tsp has made for the PVR addon. Might as well start getting them reviewed. Once the code matches I'll start the process of somehow pointing upstream rather than including the source in XBMC.

Biggest change is probably related to the upstream handling of the 64 bit integers. Maintainer of upstream preferred having explicit methods than using a function pointer to swap behaviour in the places where that was needed.

@elupus, you probably want to have a look at this. I'll hopefully get most of the other changes made prior to the 1st July ready for the merge window.

If someone can check that this compiles still with the Microsoft compiler that would be handy.
