### PR TITLE
Add basic OpenGLES1.1 implementation

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -99,6 +99,11 @@ DIRECTORY_ARCHIVES += xbmc/rendering/gles/rendering_gles.a
 DIRECTORY_ARCHIVES += xbmc/windowing/egl/windowing_egl.a
 endif
 
+ifeq (@USE_OPENGLESV1@,1)
+DIRECTORY_ARCHIVES += xbmc/rendering/gles/rendering_gles.a
+DIRECTORY_ARCHIVES += xbmc/windowing/egl/windowing_egl.a
+endif
+
 ifeq ($(findstring osx,@ARCH@),osx)
 DIRECTORY_ARCHIVES += xbmc/osx/osx.a
 DIRECTORY_ARCHIVES += xbmc/network/osx/network.a
@@ -153,8 +158,12 @@ ifneq (@DISABLE_RSXS@,1)
   SS_DIRS+= xbmc/screensavers/rsxs-0.9/xbmc
 endif
 
-VIS_DIRS=xbmc/visualizations/OpenGLSpectrum \
-         xbmc/visualizations/WaveForm
+VIS_DIRS=
+ifneq (@USE_OPENGLESV1@,1)
+  VIS_DIRS+=\
+	xbmc/visualizations/OpenGLSpectrum \
+	xbmc/visualizations/WaveForm
+endif
 
 ifneq (@DISABLE_PROJECTM@,1)
   VIS_DIRS+= xbmc/visualizations/XBMCProjectM

--- a/configure.in
+++ b/configure.in
@@ -195,6 +195,12 @@ AC_ARG_ENABLE([gles],
   [use_gles=$enableval],
   [use_gles=no])
 
+AC_ARG_ENABLE([glesv1],
+  [AS_HELP_STRING([--enable-glesv1],
+  [enable OpenGLESv1 rendering (default is no)])],
+  [use_glesv1=$enableval],
+  [use_glesv1=no])
+
 AC_ARG_ENABLE([sdl],
   [AS_HELP_STRING([--enable-sdl],
   [enable SDL (default is auto)])],
@@ -727,8 +733,19 @@ else
       AC_CHECK_LIB([GLU], [main],, AC_MSG_ERROR($missing_library))
     fi
   else
-    AC_MSG_RESULT(== WARNING: OpenGL support is disabled. XBMC will run VERY slow. ==)
-    AC_CHECK_LIB([SDL_gfx],[main])
+    if test "$use_glesv1" = "yes"; then
+      if test "$host_alias" = "sh4-linux" ; then
+        AC_DEFINE([HAVE_LIBEGL],[1],["Define to 1 if you have the `EGL' library (-lEGL)."])
+        AC_DEFINE([HAVE_LIBGLES],[1],["Define to 1 if you have the `GLES' library (-lGLES)."])
+        
+        PKG_CHECK_MODULES([STGLES],  [libstgles],
+	  INCLUDES="$INCLUDES $STGLES_CFLAGS"; LIBS="$LIBS $STGLES_LIBS"; use_stgles=yes],
+          AC_MSG_NOTICE($stgles_not_found); use_stgles=no)
+      fi
+    else
+      AC_MSG_RESULT(== WARNING: OpenGL support is disabled. XBMC will run VERY slow. ==)
+      AC_CHECK_LIB([SDL_gfx],[main])
+    fi
   fi
 fi
 
@@ -1640,16 +1657,23 @@ final_message="$final_message\n  target CPU:\t$use_cpu"
 if test "$use_gles" = "yes"; then
   final_message="$final_message\n  OpenGLES:\tYes"
   USE_OPENGLES=1
+  USE_OPENGLESV1=0
   USE_OPENGL=0
 else
   USE_OPENGLES=0
   if test "$use_gl" = "yes"; then
     final_message="$final_message\n  OpenGL:\tYes"
     USE_OPENGL=1
+    USE_OPENGLESV1=0
   else
-    final_message="$final_message\n  OpenGL:\tNo (Very Slow)"
-    SDL_DEFINES="-DHAS_SDL_2D"
     USE_OPENGL=0
+    final_message="$final_message\n  OpenGLESV1:\tYes"
+    if test "$use_glesv1" = "yes"; then
+      USE_OPENGLESV1=1
+    else
+      final_message="$final_message\n  OpenGL:\tNo (Very Slow)"
+      SDL_DEFINES="-DHAS_SDL_2D"
+    fi
   fi
 fi
 
@@ -2075,6 +2099,7 @@ AC_SUBST(LIBMEPG2_BASENAME)
 AC_SUBST_FILE(XBMC_STANDALONE_SH_PULSE)
 AC_SUBST(USE_OPENGL)
 AC_SUBST(USE_OPENGLES)
+AC_SUBST(USE_OPENGLESV1)
 AC_SUBST(USE_VDPAU)
 AC_SUBST(USE_VAAPI)
 AC_SUBST(USE_CRYSTALHD)

--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -928,7 +928,7 @@ void CUtil::TakeScreenshot(const CStdString &filename, bool sync)
   unsigned char* pixels = new unsigned char[stride * height];
 
   //read pixels from the backbuffer
-#if HAS_GLES == 2
+#if HAS_GLES == 2 || HAS_GLES == 1
   glReadPixels(viewport[0], viewport[1], viewport[2], viewport[3], GL_RGBA, GL_UNSIGNED_BYTE, (GLvoid*)pixels);
 #else
   glReadPixels(viewport[0], viewport[1], viewport[2], viewport[3], GL_BGRA, GL_UNSIGNED_BYTE, (GLvoid*)pixels);

--- a/xbmc/cores/VideoRenderers/LinuxRendererGLES.h
+++ b/xbmc/cores/VideoRenderers/LinuxRendererGLES.h
@@ -22,11 +22,13 @@
  *
  */
 
-#if HAS_GLES == 2
+#if HAS_GLES == 2 || HAS_GLES == 1
 
 #include "system_gl.h"
 
+#if HAS_GLES == 2
 #include "xbmc/guilib/FrameBufferObject.h"
+#endif
 #include "xbmc/guilib/Shader.h"
 #include "settings/VideoSettings.h"
 #include "RenderFlags.h"
@@ -193,7 +195,9 @@ protected:
   void RenderOpenMax(int index, int field);       // OpenMAX rgb texture
   void RenderCoreVideoRef(int index, int field);  // CoreVideo reference
 
+#if HAS_GLES == 2
   CFrameBufferObject m_fbo;
+#endif
 
   int m_iYV12RenderBuffer;
   int m_NumYV12Buffers;

--- a/xbmc/cores/VideoRenderers/Makefile.in
+++ b/xbmc/cores/VideoRenderers/Makefile.in
@@ -21,6 +21,12 @@ SRCS+= LinuxRendererGLES.cpp \
 
 endif
 
+ifeq (@USE_OPENGLESV1@,1)
+SRCS+= LinuxRendererGLES.cpp \
+       OverlayRendererGL.cpp \
+
+endif
+
 LIB=VideoRenderer.a
 
 include @abs_top_srcdir@/Makefile.include

--- a/xbmc/cores/VideoRenderers/OverlayRenderer.cpp
+++ b/xbmc/cores/VideoRenderers/OverlayRenderer.cpp
@@ -300,7 +300,7 @@ COverlay* CRenderer::Convert(CDVDOverlaySSA* o, double pts)
       return o->m_overlay->Acquire();
   }
 
-#if defined(HAS_GL) || defined(HAS_GLES)
+#if defined(HAS_GL) || (defined(HAS_GLES) && HAS_GLES == 2)
   return new COverlayGlyphGL(images, width, height);
 #elif defined(HAS_DX)
   return new COverlayQuadsDX(images, width, height);
@@ -326,7 +326,7 @@ COverlay* CRenderer::Convert(CDVDOverlay* o, double pts)
     return r;
   }
 
-#if defined(HAS_GL) || defined(HAS_GLES)
+#if defined(HAS_GL) || (defined(HAS_GLES) && HAS_GLES == 2)
   if     (o->IsOverlayType(DVDOVERLAY_TYPE_IMAGE))
     r = new COverlayTextureGL((CDVDOverlayImage*)o);
   else if(o->IsOverlayType(DVDOVERLAY_TYPE_SPU))

--- a/xbmc/cores/VideoRenderers/OverlayRendererGL.cpp
+++ b/xbmc/cores/VideoRenderers/OverlayRendererGL.cpp
@@ -26,7 +26,7 @@
 #include "OverlayRendererGL.h"
 #ifdef HAS_GL
   #include "LinuxRendererGL.h"
-#elif HAS_GLES == 2
+#elif HAS_GLES == 2 || HAS_GLES == 1
   #include "LinuxRendererGLES.h"
   #include "guilib/MatrixGLES.h"
 #endif
@@ -41,9 +41,9 @@
 #include "utils/GLUtils.h"
 #include "RenderManager.h"
 
-#if defined(HAS_GL) || HAS_GLES == 2
+#if defined(HAS_GL) || HAS_GLES == 2 || HAS_GLES == 1
 
-#if HAS_GLES == 2
+#if HAS_GLES == 2 || HAS_GLES == 1
 // GLES2.0 cant do CLAMP, but can do CLAMP_TO_EDGE.
 #define GL_CLAMP	GL_CLAMP_TO_EDGE
 #endif
@@ -407,6 +407,7 @@ void COverlayGlyphGL::Render(SRenderState& state)
 
   glPopMatrix();
 #else
+#if defined(HAS_GL) || HAS_GLES == 2
   g_matrices.MatrixMode(MM_MODELVIEW);
   g_matrices.PushMatrix();
   g_matrices.Translatef(state.x, state.y, 0.0f);
@@ -442,6 +443,7 @@ void COverlayGlyphGL::Render(SRenderState& state)
   g_Windowing.DisableGUIShader();
 
   g_matrices.PopMatrix();
+#endif
 #endif
 
   glDisable(GL_BLEND);
@@ -512,6 +514,7 @@ void COverlayTextureGL::Render(SRenderState& state)
   glVertex2f(rd.left , rd.bottom);
   glEnd();
 #else
+#if defined(HAS_GL) || HAS_GLES == 2
   g_Windowing.EnableGUIShader(SM_TEXTURE);
 
   GLfloat col[4][4];
@@ -555,6 +558,7 @@ void COverlayTextureGL::Render(SRenderState& state)
   glDisableVertexAttribArray(tex0Loc);
 
   g_Windowing.DisableGUIShader();
+#endif
 #endif
 
   glDisable(GL_BLEND);

--- a/xbmc/cores/VideoRenderers/OverlayRendererGL.h
+++ b/xbmc/cores/VideoRenderers/OverlayRendererGL.h
@@ -31,7 +31,7 @@ class CDVDOverlaySpu;
 class CDVDOverlaySSA;
 typedef struct ass_image ASS_Image;
 
-#if defined(HAS_GL) || HAS_GLES == 2
+#if defined(HAS_GL) || HAS_GLES == 2|| HAS_GLES == 1
 
 namespace OVERLAY {
 

--- a/xbmc/cores/VideoRenderers/RenderManager.cpp
+++ b/xbmc/cores/VideoRenderers/RenderManager.cpp
@@ -37,7 +37,7 @@
 
 #if defined(HAS_GL)
   #include "LinuxRendererGL.h"
-#elif HAS_GLES == 2
+#elif HAS_GLES == 2 || HAS_GLES == 1
   #include "LinuxRendererGLES.h"
 #elif defined(HAS_DX)
   #include "WinRenderer.h"

--- a/xbmc/cores/VideoRenderers/RenderManager.h
+++ b/xbmc/cores/VideoRenderers/RenderManager.h
@@ -113,7 +113,7 @@ public:
 
 #ifdef HAS_GL
   CLinuxRendererGL    *m_pRenderer;
-#elif HAS_GLES == 2
+#elif HAS_GLES == 2 || HAS_GLES == 1
   CLinuxRendererGLES  *m_pRenderer;
 #elif defined(HAS_DX)
   CWinRenderer        *m_pRenderer;

--- a/xbmc/guilib/Makefile.in
+++ b/xbmc/guilib/Makefile.in
@@ -3,7 +3,6 @@ SRCS=AnimatedGif.cpp \
      DirectXGraphics.cpp \
      DirtyRegionSolvers.cpp \
      DirtyRegionTracker.cpp \
-     FrameBufferObject.cpp \
      GraphicContext.cpp \
      GUIAction.cpp \
      GUIAudioManager.cpp \
@@ -76,17 +75,24 @@ SRCS=AnimatedGif.cpp \
      XBTFReader.cpp \
 
 ifeq (@USE_OPENGL@,1)
-SRCS+=TextureGL.cpp \
+SRCS+=FrameBufferObject.cpp \
+      TextureGL.cpp \
       GUIFontTTFGL.cpp \
       GUITextureGL.cpp
 endif
 ifeq (@USE_OPENGLES@,1)
-SRCS+=TextureGL.cpp \
+SRCS+=FrameBufferObject.cpp \
+      TextureGL.cpp \
       GUIFontTTFGL.cpp \
       GUITextureGLES.cpp \
       MatrixGLES.cpp \
-      GUIShader.cpp \
-
+      GUIShader.cpp
+endif
+ifeq (@USE_OPENGLESV1@,1)
+SRCS+=TextureGL.cpp \
+      GUIFontTTFGL.cpp \
+      GUITextureGLES.cpp \
+      MatrixGLES.cpp 
 endif
 
 LIB=guilib.a

--- a/xbmc/guilib/MatrixGLES.cpp
+++ b/xbmc/guilib/MatrixGLES.cpp
@@ -22,7 +22,7 @@
 
 #include "system.h"
 
-#if HAS_GLES == 2
+#if HAS_GLES == 2 || HAS_GLES == 1
 #include "system_gl.h"
 
 #include <cmath>

--- a/xbmc/guilib/Texture.cpp
+++ b/xbmc/guilib/Texture.cpp
@@ -69,6 +69,11 @@ CBaseTexture::~CBaseTexture()
 
 void CBaseTexture::Allocate(unsigned int width, unsigned int height, unsigned int format)
 {
+  if(m_imageWidth != width && m_imageHeight != height && m_format != format && m_pixels != NULL) {
+    //Nothing to do
+    return;
+  }
+
   m_imageWidth = width;
   m_imageHeight = height;
   m_format = format;

--- a/xbmc/guilib/TextureGL.cpp
+++ b/xbmc/guilib/TextureGL.cpp
@@ -56,7 +56,7 @@ void CGLTexture::DestroyTextureObject()
 
 void CGLTexture::LoadToGPU()
 {
-  if (!m_pixels)
+  if (m_loadedToGPU || !m_pixels)
   {
     // nothing to load - probably same image (no change)
     return;
@@ -194,6 +194,9 @@ void CGLTexture::BindToUnit(unsigned int unit)
 #else // GLES
   glActiveTexture((unit == 1) ? GL_TEXTURE1 : GL_TEXTURE0);
   glBindTexture(GL_TEXTURE_2D, m_texture);
+#if HAS_GLES == 1
+  glEnable(GL_TEXTURE_2D);
+#endif
 #endif
 }
 

--- a/xbmc/pictures/SlideShowPicture.cpp
+++ b/xbmc/pictures/SlideShowPicture.cpp
@@ -762,7 +762,7 @@ void CSlideShowPic::Render(float *x, float *y, CBaseTexture* pTexture, color_t c
 
   glEnd();
   g_graphicsContext.EndPaint();
-#elif defined(HAS_GLES)
+#elif defined(HAS_GLES) && HAS_GLES == 2
   g_graphicsContext.BeginPaint();
   if (pTexture)
   {
@@ -833,6 +833,7 @@ void CSlideShowPic::Render(float *x, float *y, CBaseTexture* pTexture, color_t c
   g_Windowing.DisableGUIShader();
 
   g_graphicsContext.EndPaint();
+#elif defined(HAS_GLES) && HAS_GLES == 1
 #else
 // SDL render
   g_Windowing.BlitToScreen(m_pImage, NULL, NULL);

--- a/xbmc/rendering/gles/RenderSystemGLES.cpp
+++ b/xbmc/rendering/gles/RenderSystemGLES.cpp
@@ -22,7 +22,7 @@
 
 #include "system.h"
 
-#if HAS_GLES == 2
+#if HAS_GLES == 2 || HAS_GLES == 1
 
 #include "guilib/GraphicContext.h"
 #include "settings/AdvancedSettings.h"
@@ -34,6 +34,7 @@
 #include "utils/SystemInfo.h"
 #include "utils/MathUtils.h"
 
+#if HAS_GLES == 2
 static const char* ShaderNames[SM_ESHADERCOUNT] =
     {"guishader_frag_default.glsl",
      "guishader_frag_texture.glsl",
@@ -44,11 +45,14 @@ static const char* ShaderNames[SM_ESHADERCOUNT] =
      "guishader_frag_rgba.glsl",
      "guishader_frag_rgba_blendcolor.glsl"
     };
+#endif
 
 CRenderSystemGLES::CRenderSystemGLES()
  : CRenderSystemBase()
+#if HAS_GLES == 2
  , m_pGUIshader(0)
  , m_method(SM_DEFAULT)
+#endif
 {
   m_enumRenderingSystem = RENDERING_SYSTEM_OPENGLES;
 }
@@ -117,9 +121,9 @@ bool CRenderSystemGLES::InitRenderSystem()
 
 
   m_bRenderCreated = true;
-  
+#if HAS_GLES == 2
   InitialiseGUIShader();
-
+#endif
   return true;
 }
 
@@ -153,6 +157,7 @@ bool CRenderSystemGLES::ResetRenderSystem(int width, int height, bool fullScreen
 
 bool CRenderSystemGLES::DestroyRenderSystem()
 {
+#if HAS_GLES == 2
   CLog::Log(LOGDEBUG, "GUI Shader - Destroying Shader : %p", m_pGUIshader);
 
   if (m_pGUIshader)
@@ -169,7 +174,7 @@ bool CRenderSystemGLES::DestroyRenderSystem()
     delete[] m_pGUIshader;
     m_pGUIshader = NULL;
   }
-
+#endif
   m_bRenderCreated = false;
 
   return true;
@@ -200,6 +205,10 @@ bool CRenderSystemGLES::ClearBuffers(color_t color)
   float g = GET_G(color) / 255.0f;
   float b = GET_B(color) / 255.0f;
   float a = GET_A(color) / 255.0f;
+#if HAS_GLES == 1
+  //TODO: Ugly Hack, somehow the alpha value goes missing, check this
+  a = 0.0f;
+#endif
 
   glClearColor(r, g, b, a);
 
@@ -424,6 +433,7 @@ bool CRenderSystemGLES::TestRender()
 {
   static float theta = 0.0;
 
+#if HAS_GLES == 2
   //RESOLUTION_INFO resInfo = g_settings.m_ResInfo[g_guiSettings.m_LookAndFeelResolution];
   //glViewport(0, 0, resInfo.iWidth, resInfo.iHeight);
 
@@ -466,6 +476,7 @@ bool CRenderSystemGLES::TestRender()
 
   theta += 1.0f;
 
+#endif
   return true;
 }
 
@@ -544,7 +555,7 @@ void CRenderSystemGLES::ResetScissors()
 {
   SetScissors(CRect(0, 0, (float)m_width, (float)m_height));
 }
-
+#if HAS_GLES == 2
 void CRenderSystemGLES::InitialiseGUIShader()
 {
   if (!m_pGUIshader)
@@ -626,5 +637,5 @@ GLint CRenderSystemGLES::GUIShaderGetCoord1()
 
   return -1;
 }
-
+#endif
 #endif

--- a/xbmc/rendering/gles/RenderSystemGLES.h
+++ b/xbmc/rendering/gles/RenderSystemGLES.h
@@ -27,6 +27,7 @@
 #include "system.h"
 #include "system_gl.h"
 #include "rendering/RenderSystem.h"
+#if HAS_GLES == 2
 #include "xbmc/guilib/GUIShader.h"
 
 enum ESHADERMETHOD
@@ -41,6 +42,7 @@ enum ESHADERMETHOD
   SM_TEXTURE_RGBA_BLENDCOLOR,
   SM_ESHADERCOUNT
 };
+#endif
 
 class CRenderSystemGLES : public CRenderSystemBase
 {
@@ -78,6 +80,7 @@ public:
 
   virtual void Project(float &x, float &y, float &z);
   
+#if HAS_GLES == 2
   void InitialiseGUIShader();
   void EnableGUIShader(ESHADERMETHOD method);
   void DisableGUIShader();
@@ -86,6 +89,7 @@ public:
   GLint GUIShaderGetCol();
   GLint GUIShaderGetCoord0();
   GLint GUIShaderGetCoord1();
+#endif
 
 protected:
   virtual void SetVSyncImpl(bool enable) = 0;
@@ -103,8 +107,10 @@ protected:
 
   CStdString m_RenderExtensions;
 
+#if HAS_GLES == 2
   CGUIShader  **m_pGUIshader;  // One GUI shader for each method
   ESHADERMETHOD m_method;      // Current GUI Shader method
+#endif
 
   GLfloat    m_view[16];
   GLfloat    m_projection[16];

--- a/xbmc/system_gl.h
+++ b/xbmc/system_gl.h
@@ -52,4 +52,7 @@
     #include <GLES2/gl2.h>
     #include <GLES2/gl2ext.h>
   #endif
+#elif HAS_GLES == 1
+  #include <GLES/gl.h>
+  #include <GLES/glext.h>
 #endif

--- a/xbmc/utils/GLUtils.cpp
+++ b/xbmc/utils/GLUtils.cpp
@@ -86,11 +86,13 @@ void LogGraphicsInfo()
   else
     CLog::Log(LOGNOTICE, "GL_VERSION = NULL");
 
+#if defined(HAS_GL) || (defined(HAS_GLES) && HAS_GLES == 2)
   s = glGetString(GL_SHADING_LANGUAGE_VERSION);
   if (s)
     CLog::Log(LOGNOTICE, "GL_SHADING_LANGUAGE_VERSION = %s", s);
   else
     CLog::Log(LOGNOTICE, "GL_SHADING_LANGUAGE_VERSION = NULL");
+#endif
 
   //GL_NVX_gpu_memory_info extension
 #define GL_GPU_MEMORY_INFO_DEDICATED_VIDMEM_NVX          0x9047

--- a/xbmc/visualizations/EGLHelpers/VisMatrixGLES.h
+++ b/xbmc/visualizations/EGLHelpers/VisMatrixGLES.h
@@ -24,8 +24,8 @@
   #include <OpenGLES/ES2/gl.h>                                                                                                                                                                                     
   #include <OpenGLES/ES2/glext.h>                                                                                                                                                                                  
 #else                                                                                                                                                                                                            
-  #include <GLES2/gl2.h>
-  #include <GLES2/gl2ext.h>
+#include <GLES2/gl2.h>
+#include <GLES2/gl2ext.h>
 #endif//__APPLE__
 
 #include <string.h>

--- a/xbmc/windowing/egl/WinBindingEGL.cpp
+++ b/xbmc/windowing/egl/WinBindingEGL.cpp
@@ -74,7 +74,7 @@ bool CWinBindingEGL::CreateWindow(EGLNativeDisplayType nativeDisplay, EGLNativeW
   m_nativeDisplay = nativeDisplay;
   m_nativeWindow  = nativeWindow;
 
-  m_display = eglGetDisplay(nativeDisplay);
+  m_display = eglGetDisplay(((intptr_t)(NativeDisplayType)nativeDisplay));
   if (m_display == EGL_NO_DISPLAY) 
   {
     CLog::Log(LOGERROR, "EGL failed to obtain display");
@@ -96,7 +96,12 @@ bool CWinBindingEGL::CreateWindow(EGLNativeDisplayType nativeDisplay, EGLNativeW
         EGL_SAMPLE_BUFFERS,  0,
         EGL_SAMPLES,         0,
         EGL_SURFACE_TYPE,    EGL_WINDOW_BIT,
-        EGL_RENDERABLE_TYPE, EGL_OPENGL_ES2_BIT,
+        EGL_RENDERABLE_TYPE, 
+#if HAS_GLES == 2
+		EGL_OPENGL_ES2_BIT,
+#else
+        EGL_OPENGL_ES_BIT, 
+#endif
         EGL_NONE
   };
 

--- a/xbmc/windowing/egl/WinSystemGLES.cpp
+++ b/xbmc/windowing/egl/WinSystemGLES.cpp
@@ -54,10 +54,14 @@ bool CWinSystemGLES::InitWindowSystem()
   CLog::Log(LOGDEBUG, "Video mode: %dx%d with %d bits per pixel.",
     m_fb_width, m_fb_height, m_fb_bpp);
 
-  m_display = EGL_DEFAULT_DISPLAY;
+  m_display = (void*)EGL_DEFAULT_DISPLAY;
+#ifdef fbdev_window
   m_window  = (fbdev_window*)calloc(1, sizeof(fbdev_window));
 	m_window->width  = m_fb_width;
 	m_window->height = m_fb_height;
+#else
+  m_window = NULL;
+#endif
 
   if (!CWinSystemBase::InitWindowSystem())
     return false;
@@ -106,6 +110,8 @@ bool CWinSystemGLES::ResizeWindow(int newWidth, int newHeight, int newLeft, int 
 bool CWinSystemGLES::SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool blankOtherDisplays)
 {
   CLog::Log(LOGDEBUG, "CWinSystemDFB::SetFullScreen");
+#if defined(__sh__) //TODO: Fix crash at this point
+#else
   m_nWidth  = res.iWidth;
   m_nHeight = res.iHeight;
   m_bFullScreen = fullScreen;
@@ -114,7 +120,7 @@ bool CWinSystemGLES::SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool b
   CreateNewWindow("", fullScreen, res, NULL);
 
   CRenderSystemGLES::ResetRenderSystem(res.iWidth, res.iHeight, true, 0);
-
+#endif
   return true;
 }
 

--- a/xbmc/windowing/egl/WinSystemGLES.h
+++ b/xbmc/windowing/egl/WinSystemGLES.h
@@ -45,6 +45,7 @@ public:
   virtual bool  ResizeWindow(int newWidth, int newHeight, int newLeft, int newTop);
   virtual bool  SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool blankOtherDisplays);
   virtual void  UpdateResolutions();
+  virtual int   GetNumScreens() { return 1; }
   virtual bool  IsExtSupported(const char* extension);
 
   virtual void  ShowOSMouse(bool show);
@@ -60,7 +61,11 @@ protected:
   virtual bool  PresentRenderImpl(const CDirtyRegionList &dirty);
   virtual void  SetVSyncImpl(bool enable);
   void                  *m_display;
+#ifdef fbdev_window
   fbdev_window          *m_window;
+#else
+  void                  *m_window;
+#endif
   CWinBindingEGL        *m_eglBinding;
   int                   m_fb_width;
   int                   m_fb_height;


### PR DESCRIPTION
Before we start, this pull request is mainly for discussing if openglesv1 support should ever be added to xbmc. This pull request is not yet complete and contains only very basic functionality to show what changes would be necessary to get basix opengles1.1 support.

ATM I am using GL_QUADS as the hardware blitter only knows 4point blits, 
but I think that I will switch to 4point TRIANGLES_STRIP to be more standard conform.
As I am also writing the opengl library switching would not be a problem.

I did not really take care of the VideoRender stuff as I will not need it. My hardware renders directly into a layer behind the framebuffer. So basically just removing all the shader stuff so it compiles. It would be better if I could compile xbmc without the videorenders, but atm to many dependencies.

I also deactivated the visualizations as audio is decoded by the hardware. A pcm stream could be routed back, but only if it is downmixed (Surround ->Stereo). If the audio is routed directly undecoded to the av receiver then there will be never a pcm stream in the system. So pcm based visualizations wont work anyway.

So this is really just the basic stuff to get xbmc working with my gles1.1 implementation for sti7105/sti7111/sti7168 sh4 cpu arch based devices.
