### PR TITLE
cleanup, sort out off_t, _off_t, __off_t, and friends and remove dead code

### DIFF
--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -1126,7 +1126,7 @@ void CUtil::Stat64ToStat(struct stat *result, struct __stat64 *stat)
     result->st_size = (_off_t)stat->st_size;
 #else
   if (sizeof(stat->st_size) <= sizeof(result->st_size) )
-    result->st_size = (off_t)stat->st_size;
+    result->st_size = stat->st_size;
 #endif
   else
   {
@@ -1153,7 +1153,7 @@ void CUtil::Stat64ToStat64i32(struct _stat64i32 *result, struct __stat64 *stat)
     result->st_size = (_off_t)stat->st_size;
 #else
   if (sizeof(stat->st_size) <= sizeof(result->st_size) )
-    result->st_size = (off_t)stat->st_size;
+    result->st_size = stat->st_size;
 #endif
   else
   {

--- a/xbmc/cores/DllLoader/exports/emu_msvcrt.cpp
+++ b/xbmc/cores/DllLoader/exports/emu_msvcrt.cpp
@@ -593,12 +593,6 @@ extern "C"
     return -1;
   }
 
-  int dll_fstatvfs64(int fd, struct statvfs64 *buf)
-  {
-    not_implement("msvcrt.dll incomplete function fstatvfs64(...) called\n");
-    return -1;
-  }
-
   int dll_close(int fd)
   {
     CFile* pFile = g_emuFileWrapper.GetFileXbmcByDescriptor(fd);

--- a/xbmc/cores/DllLoader/exports/emu_msvcrt.h
+++ b/xbmc/cores/DllLoader/exports/emu_msvcrt.h
@@ -27,6 +27,13 @@
 #define _onexit_t void*
 #endif
 
+#if defined(TARGET_DARWIN) || defined(TARGET_FREEBSD)
+typedef off_t __off_t;
+typedef int64_t off64_t;
+typedef off64_t __off64_t;
+typedef fpos_t fpos64_t;
+#endif
+
 #ifdef WIN32
 #include "win32-dirent.h"
 #else
@@ -167,7 +174,6 @@ extern "C"
   int dll_fstat64i32(int fd, struct _stat64i32 *buffer);
   int dll_open_osfhandle(intptr_t _OSFileHandle, int _Flags);
 #endif
-  int dll_fstatvfs64(int fd, struct statvfs64 *buf);
   int dll_setvbuf(FILE *stream, char *buf, int type, size_t size);
   int dll_filbuf(FILE *fp);
   int dll_flsbuf(int data, FILE*fp);

--- a/xbmc/cores/DllLoader/exports/wrapper.c
+++ b/xbmc/cores/DllLoader/exports/wrapper.c
@@ -37,13 +37,12 @@
 #include <dirent.h>
 #endif
 
-#if defined(TARGET_DARWIN) || defined(__FreeBSD__)
-typedef int64_t   off64_t;
+#if defined(TARGET_DARWIN) || defined(TARGET_FREEBSD)
 typedef off_t     __off_t;
+typedef int64_t   off64_t;
 typedef off64_t   __off64_t;
 typedef fpos_t    fpos64_t;
 #define stat64    stat
-#define statvfs64 statvfs
 #if defined(TARGET_DARWIN)
 #define _G_va_list va_list
 #endif
@@ -109,7 +108,6 @@ int dll_ftrylockfile(FILE *file);
 void dll_funlockfile(FILE *file);
 int dll_fstat64(int fd, struct stat64 *buf);
 int dll_fstat(int fd, struct _stat *buf);
-int dll_fstatvfs64(int fd, struct statvfs64 *buf);
 FILE* dll_popen(const char *command, const char *mode);
 int dll_setvbuf(FILE *stream, char *buf, int type, size_t size);
 struct mntent *dll_getmntent(FILE *fp);
@@ -423,11 +421,6 @@ void __wrap_funlockfile(FILE *file)
 int __wrap___fxstat64(int ver, int fd, struct stat64 *buf)
 {
   return dll_fstat64(fd, buf);
-}
-
-int __wrap_fstatvfs64(int fd, struct statvfs64 *buf)
-{
-  return dll_fstatvfs64(fd, buf);
 }
 
 int __wrap_fstat(int fd, struct _stat *buf)

--- a/xbmc/linux/PlatformDefs.h
+++ b/xbmc/linux/PlatformDefs.h
@@ -41,6 +41,8 @@
 #include <string.h>
 #if defined(TARGET_DARWIN)
 #include <stdio.h>
+#include <sched.h>
+#include <AvailabilityMacros.h>
 #ifndef __STDC_FORMAT_MACROS
   #define __STDC_FORMAT_MACROS
 #endif
@@ -354,30 +356,15 @@ typedef int (*LPTHREAD_START_ROUTINE)(void *);
 #define _O_TRUNC O_TRUNC
 #define _O_RDONLY O_RDONLY
 #define _O_WRONLY O_WRONLY
-#define _off_t off_t
 
-#if defined(TARGET_DARWIN)
-  #include <sched.h>
-  #include <AvailabilityMacros.h>
-  typedef int64_t   off64_t;
-  typedef off_t     __off_t;
-  typedef off64_t   __off64_t;
-  typedef fpos_t fpos64_t;
-  #define __stat64 stat
+#if defined(TARGET_DARWIN) || defined(TARGET_FREEBSD)
   #define stat64 stat
-  #if defined(TARGET_DARWIN_IOS)
+  #define __stat64 stat
+  #define fstat64 fstat
+  typedef int64_t off64_t;
+  #if defined(TARGET_DARWIN_IOS) || defined(TARGET_FREEBSD)
     #define statfs64 statfs
   #endif
-  #define fstat64 fstat
-#elif defined(__FreeBSD__)
-  typedef int64_t   off64_t;
-  typedef off_t     __off_t;
-  typedef off64_t   __off64_t;
-  typedef fpos_t fpos64_t;
-  #define __stat64 stat
-  #define stat64 stat
-  #define statfs64 statfs
-  #define fstat64 fstat
 #else
   #define __stat64 stat64
 #endif


### PR DESCRIPTION
off_f and friends were being spewed all over the place. this moves the defs out of PlatformDefs and move them to the two areas that they are actually used. Also some wacky casting and removed dll_fstatvfs64, it's a stub and nothing seems to be using it.

Tested on darwin (osx/ios), linux x86_64, arm and that platform of which we do not speak of.

Needs win dev sign off and I'd like more exposure under linux as this touches core.
