### PR TITLE
[win32] add missing check for msvcr100 in win32env.cpp

### DIFF
--- a/xbmc/win32/win32env.cpp
+++ b/xbmc/win32/win32env.cpp
@@ -61,6 +61,9 @@ pgwin32_wputenv(const wchar_t *envval)
 			"msvcr90", 0, NULL
 		},						/* Visual Studio 2008 */
 		{
+			"msvcr100", 0, NULL
+		},						/* Visual Studio 2010 */
+		{
 			NULL, 0, NULL
 		}
 	};


### PR DESCRIPTION
Fix win32env didn't check (and use) for msvcr100 lib
