### PR TITLE
[input] Add 'Enable Joystick' to GUI settings. Fix for http://trac.xbmc.org/ticket/13146

### DIFF
--- a/language/English/strings.po
+++ b/language/English/strings.po
@@ -9294,7 +9294,13 @@ msgctxt "#35009"
 msgid "Do not use the custom keymap for this device"
 msgstr ""
 
-#empty strings from id 35010 to 35499
+#empty strings from id 35010 to 35099
+
+msgctxt "#35100"
+msgid "Enable joystick and gamepad support"
+msgstr ""
+
+#empty strings from id 35101 to 35499
 
 msgctxt "#35500"
 msgid "Location"

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -1351,7 +1351,7 @@ bool CApplication::Initialize()
   ResetScreenSaver();
 
 #ifdef HAS_SDL_JOYSTICK
-  g_Joystick.Initialize();
+  g_Joystick.SetEnabled(g_guiSettings.GetBool("input.enablejoystick"));
 #endif
 
   return true;

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -2813,8 +2813,9 @@ bool CApplication::ProcessGamepad(float frameTime)
 #ifdef HAS_SDL_JOYSTICK
   if (!m_AppFocused)
     return false;
+
   int iWin = GetActiveWindowID();
-  int bid;
+  int bid = 0;
   g_Joystick.Update();
   if (g_Joystick.GetButton(bid))
   {
@@ -2873,7 +2874,7 @@ bool CApplication::ProcessGamepad(float frameTime)
       g_Joystick.ResetAxis(abs(bid));
     }
   }
-  int position;
+  int position = 0;
   if (g_Joystick.GetHat(bid, position))
   {
     // reset Idle Timer
@@ -2892,7 +2893,7 @@ bool CApplication::ProcessGamepad(float frameTime)
 
     bid = position<<16|bid;
 
-    if (CButtonTranslator::GetInstance().TranslateJoystickString(iWin, g_Joystick.GetJoystick().c_str(), bid, JACTIVE_HAT, actionID, actionName, fullrange))
+    if (bid && CButtonTranslator::GetInstance().TranslateJoystickString(iWin, g_Joystick.GetJoystick().c_str(), bid, JACTIVE_HAT, actionID, actionName, fullrange))
     {
       CAction action(actionID, 1.0f, 0.0f, actionName);
       g_audioManager.PlayActionSound(action);

--- a/xbmc/SystemGlobals.cpp
+++ b/xbmc/SystemGlobals.cpp
@@ -41,6 +41,13 @@
 #ifdef HAS_PYTHON
 #include "interfaces/python/XBPython.h"
 #endif
+#if defined(TARGET_WINDOWS)
+#include "input/windows/WINJoystick.h"
+#elif defined(HAS_SDL_JOYSTICK) || defined(HAS_EVENT_SERVER)
+#include "input/SDLJoystick.h"
+#endif
+
+
 
   CGUISettings       g_guiSettings;
   CSettings          g_settings;
@@ -57,6 +64,9 @@
   CGUITextureManager g_TextureManager;
   CGUILargeTextureManager g_largeTextureManager;
   CMouseStat         g_Mouse;
+#if defined(HAS_SDL_JOYSTICK) || defined(HAS_EVENT_SERVER)
+  CJoystick          g_Joystick; 
+#endif
   CGUIPassword       g_passwordManager;
   CGUIInfoManager    g_infoManager;
 

--- a/xbmc/input/SDLJoystick.cpp
+++ b/xbmc/input/SDLJoystick.cpp
@@ -32,8 +32,6 @@
 
 using namespace std;
 
-CJoystick g_Joystick; // global
-
 CJoystick::CJoystick()
 {
   Reset(true);

--- a/xbmc/input/SDLJoystick.cpp
+++ b/xbmc/input/SDLJoystick.cpp
@@ -36,7 +36,7 @@ CJoystick g_Joystick; // global
 
 CJoystick::CJoystick()
 {
-  Reset();
+  Reset(true);
   m_NumAxes = 0;
   m_AxisId = 0;
   m_JoyId = 0;
@@ -44,8 +44,6 @@ CJoystick::CJoystick()
   m_HatId = 0;
   m_HatState = SDL_HAT_CENTERED;
   m_ActiveFlags = JACTIVE_NONE;
-  for (int i = 0 ; i<MAX_AXES ; i++)
-    m_Amount[i] = 0;
   SetDeadzone(0);
 }
 
@@ -108,7 +106,7 @@ void CJoystick::Initialize()
   SDL_JoystickEventState(SDL_DISABLE);
 }
 
-void CJoystick::Reset(bool axis)
+void CJoystick::Reset(bool axis /*=false*/)
 {
   if (axis)
   {
@@ -304,7 +302,10 @@ void CJoystick::Update(SDL_Event& joyEvent)
 bool CJoystick::GetHat(int &id, int &position,bool consider_repeat) 
 {
   if (!IsHatActive())
+  {
+    id = position = 0;
     return false;
+  }
   position = m_HatState;
   id = m_HatId;
   if (!consider_repeat)
@@ -337,7 +338,10 @@ bool CJoystick::GetHat(int &id, int &position,bool consider_repeat)
 bool CJoystick::GetButton(int &id, bool consider_repeat)
 {
   if (!IsButtonActive())
+  {
+    id = 0;
     return false;
+  }
   if (!consider_repeat)
   {
     id = m_ButtonId;
@@ -370,6 +374,17 @@ bool CJoystick::GetButton(int &id, bool consider_repeat)
   }
   id = m_ButtonId;
   return true;
+}
+
+bool CJoystick::GetAxis (int &id)
+{ 
+  if (!IsAxisActive()) 
+  {
+    id = 0;
+    return false; 
+  }
+  id = m_AxisId; 
+  return true; 
 }
 
 int CJoystick::GetAxisWithMaxAmount()

--- a/xbmc/input/SDLJoystick.h
+++ b/xbmc/input/SDLJoystick.h
@@ -63,6 +63,8 @@ public:
   int GetAxisWithMaxAmount();
   float GetAmount(int axis);
   float GetAmount() { return GetAmount(m_AxisId); }
+  bool IsEnabled() const { return m_joystickEnabled; }
+  void SetEnabled(bool enabled = true);
   float SetDeadzone(float val);
   bool Reinitialize();
 
@@ -74,6 +76,8 @@ private:
   bool IsAxisActive() { return (m_ActiveFlags & JACTIVE_AXIS) == JACTIVE_AXIS; }
   bool IsHatActive() { return (m_ActiveFlags & JACTIVE_HAT) == JACTIVE_HAT; }
 
+  bool ReleaseJoysticks();
+
   int m_Amount[MAX_AXES];
   int m_AxisId;
   int m_ButtonId;
@@ -82,6 +86,7 @@ private:
   int m_JoyId;
   int m_NumAxes;
   int m_DeadzoneRange;
+  bool m_joystickEnabled;
   uint32_t m_pressTicksButton;
   uint32_t m_pressTicksHat;
   uint8_t m_ActiveFlags;

--- a/xbmc/input/SDLJoystick.h
+++ b/xbmc/input/SDLJoystick.h
@@ -57,7 +57,7 @@ public:
   void Update();
   void Update(SDL_Event& event);
   bool GetButton (int& id, bool consider_repeat=true);
-  bool GetAxis (int &id) { if (!IsAxisActive()) return false; id=m_AxisId; return true; }
+  bool GetAxis (int &id);
   bool GetHat (int &id, int &position, bool consider_repeat=true);
   std::string GetJoystick() { return (m_JoyId>-1)?m_JoystickNames[m_JoyId]:""; }
   int GetAxisWithMaxAmount();

--- a/xbmc/input/windows/WINJoystick.cpp
+++ b/xbmc/input/windows/WINJoystick.cpp
@@ -31,8 +31,6 @@
 
 using namespace std;
 
-CJoystick g_Joystick; // global
-
 extern HWND g_hWnd;
 
 #define MAX_AXISAMOUNT  32768

--- a/xbmc/input/windows/WINJoystick.cpp
+++ b/xbmc/input/windows/WINJoystick.cpp
@@ -53,7 +53,7 @@ extern HWND g_hWnd;
 
 CJoystick::CJoystick()
 {
-  Reset();
+  Reset(true);
   m_NumAxes = 0;
   m_AxisId = 0;
   m_JoyId = 0;
@@ -61,8 +61,6 @@ CJoystick::CJoystick()
   m_HatId = 0;
   m_HatState = SDL_HAT_CENTERED;
   m_ActiveFlags = JACTIVE_NONE;
-  for (int i = 0 ; i<MAX_AXES ; i++)
-    m_Amount[i] = 0;
   SetDeadzone(0);
 
   m_pDI = NULL;
@@ -88,6 +86,13 @@ void CJoystick::ReleaseJoysticks()
   m_pJoysticks.clear();
   m_JoystickNames.clear();
   m_devCaps.clear();
+  m_HatId = 0;
+  m_ButtonId = 0;
+  m_HatState = SDL_HAT_CENTERED;
+  m_ActiveFlags = JACTIVE_NONE;
+  Reset(true);
+  m_lastPressTicks = 0;
+  m_lastTicks = 0;
   // Release any DirectInput objects.
   SAFE_RELEASE( m_pDI );
 }
@@ -208,7 +213,7 @@ void CJoystick::Initialize()
   SetDeadzone(g_advancedSettings.m_controllerDeadzone);
 }
 
-void CJoystick::Reset(bool axis)
+void CJoystick::Reset(bool axis /*=true*/)
 {
   if (axis)
   {
@@ -361,7 +366,10 @@ void CJoystick::Update()
 bool CJoystick::GetHat(int &id, int &position,bool consider_repeat)
 {
   if (!IsHatActive())
+  {
+    id = position = 0;
     return false;
+  }
   position = m_HatState;
   id = m_HatId;
   if (!consider_repeat)
@@ -392,7 +400,10 @@ bool CJoystick::GetHat(int &id, int &position,bool consider_repeat)
 bool CJoystick::GetButton(int &id, bool consider_repeat)
 {
   if (!IsButtonActive())
+  {
+    id = 0;
     return false;
+  }
   if (!consider_repeat)
   {
     id = m_ButtonId;
@@ -423,6 +434,17 @@ bool CJoystick::GetButton(int &id, bool consider_repeat)
   }
   id = m_ButtonId;
   return true;
+}
+
+bool CJoystick::GetAxis (int &id)
+{ 
+  if (!IsAxisActive()) 
+  {
+    id = 0;
+    return false; 
+  }
+  id = m_AxisId; 
+  return true; 
 }
 
 int CJoystick::GetAxisWithMaxAmount()

--- a/xbmc/input/windows/WINJoystick.h
+++ b/xbmc/input/windows/WINJoystick.h
@@ -47,7 +47,7 @@ public:
   void ResetAxis(int axisId) { m_Amount[axisId] = 0; }
   void Update();
   bool GetButton (int& id, bool consider_repeat=true);
-  bool GetAxis (int &id) { if (!IsAxisActive()) return false; id=m_AxisId; return true; }
+  bool GetAxis (int &id);
   bool GetHat (int &id, int &position, bool consider_repeat=true);
   std::string GetJoystick() { return (m_JoyId>-1)?m_JoystickNames[m_JoyId]:""; }
   int GetAxisWithMaxAmount();

--- a/xbmc/input/windows/WINJoystick.h
+++ b/xbmc/input/windows/WINJoystick.h
@@ -53,6 +53,8 @@ public:
   int GetAxisWithMaxAmount();
   float GetAmount(int axis);
   float GetAmount() { return GetAmount(m_AxisId); }
+  bool IsEnabled() const { return m_joystickEnabled; }
+  void SetEnabled(bool enabled = true);
   float SetDeadzone(float val);
   bool Reinitialize();
   void Acquire();
@@ -77,6 +79,7 @@ private:
   int m_JoyId;
   int m_NumAxes;
   int m_DeadzoneRange;
+  bool m_joystickEnabled;
   uint32_t m_pressTicksButton;
   uint32_t m_pressTicksHat;
   uint8_t m_ActiveFlags;

--- a/xbmc/settings/GUISettings.cpp
+++ b/xbmc/settings/GUISettings.cpp
@@ -520,6 +520,9 @@ void CGUISettings::Initialize()
 #else
   AddBool(in, "input.enablemouse", 21369, true);
 #endif
+#if defined(HAS_SDL_JOYSTICK)
+  AddBool(in, "input.enablejoystick", 35100, true);
+#endif
 
   CSettingsCategory* net = AddCategory(4, "network", 798);
   if (g_application.IsStandAlone())

--- a/xbmc/settings/GUIWindowSettingsCategory.cpp
+++ b/xbmc/settings/GUIWindowSettingsCategory.cpp
@@ -92,6 +92,11 @@
 #include "Settings.h"
 #include "AdvancedSettings.h"
 #include "input/MouseStat.h"
+#if defined(TARGET_WINDOWS)
+#include "input/windows/WINJoystick.h"
+#elif defined(HAS_SDL_JOYSTICK)
+#include "input/SDLJoystick.h"
+#endif
 #include "guilib/LocalizeStrings.h"
 #include "LangInfo.h"
 #include "utils/StringUtils.h"
@@ -1387,6 +1392,12 @@ void CGUIWindowSettingsCategory::OnSettingChanged(CBaseSettingControl *pSettingC
   else if (strSetting.Equals("input.enablemouse"))
   {
     g_Mouse.SetEnabled(g_guiSettings.GetBool("input.enablemouse"));
+  }
+  else if (strSetting.Equals("input.enablejoystick"))
+  {
+#if defined(HAS_SDL_JOYSTICK)
+    g_Joystick.SetEnabled(g_guiSettings.GetBool("input.enablejoystick"));
+#endif
   }
   else if (strSetting.Equals("videoscreen.screen"))
   {


### PR DESCRIPTION
Added GUI settings for control Joystick usage.
Some addition to CJoystick class - identical to CStatMouse.
Now Joystick can be enabled/disabled (and Initialized/deinitialized) by calling g_Joystick.SetEnable (true / false)

Also can be used as workaround for popular iMON (SoundGraph) hardware on Windows, which with latest DirectInput patches falls into endless Remove/Insert loop. That's make remote iMon control and display unusable.
- iMON problem info:
  - Ticket: http://trac.xbmc.org/ticket/13146
  - Forum thread: http://forum.xbmc.org/showthread.php?tid=134074
  - iMON forum: http://www.soundgraph.com/forums/showthread.php?t=10536
  - Problem decription: see 'Cause' in http://www.soundgraph.com/forums/faq.php?faq=sg_faq_sw_imon_manager_g_01#faq_sg_faq_software_products_gamecontrol
  - Dev thread: http://forum.xbmc.org/showthread.php?tid=135218
