### PR TITLE
[dvdplayer] On unpause of a movie seek back a given number of seconds...

### DIFF
--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -2173,6 +2173,15 @@ void CDVDPlayer::Pause()
   // return to normal speed if it was paused before, pause otherwise
   if (m_playSpeed == DVD_PLAYSPEED_PAUSE)
   {
+    //check for the jumpback feature
+    //if set jumpback given secs on unpause
+    //for getting back into the story ;)
+    if(g_advancedSettings.m_videoUnpauseJumpBackSecs && 
+       GetTime() > g_advancedSettings.m_videoUnpauseJumpBackSecs * 1000)
+    {
+      SeekTime(GetTime() - g_advancedSettings.m_videoUnpauseJumpBackSecs * 1000);
+    }
+  
     SetPlaySpeed(DVD_PLAYSPEED_NORMAL);
     m_callback.OnPlayBackResumed();
   }

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -94,6 +94,7 @@ void CAdvancedSettings::Initialize()
   m_videoDefaultDVDPlayer = "dvdplayer";
   m_videoIgnoreSecondsAtStart = 3*60;
   m_videoIgnorePercentAtEnd   = 8.0f;
+  m_videoUnpauseJumpBackSecs      = 0;
   m_videoPlayCountMinimumPercent = 90.0f;
   m_videoVDPAUScaling = false;
   m_videoNonLinStretchRatio = 0.5f;
@@ -426,6 +427,7 @@ void CAdvancedSettings::ParseSettingsFile(const CStdString &file)
     // 101 on purpose - can be used to never automark as watched
     XMLUtils::GetFloat(pElement, "playcountminimumpercent", m_videoPlayCountMinimumPercent, 0.0f, 101.0f);
     XMLUtils::GetInt(pElement, "ignoresecondsatstart", m_videoIgnoreSecondsAtStart, 0, 900);
+    XMLUtils::GetInt(pElement, "unpausejumpbacksecs", m_videoUnpauseJumpBackSecs);
     XMLUtils::GetFloat(pElement, "ignorepercentatend", m_videoIgnorePercentAtEnd, 0, 100.0f);
 
     XMLUtils::GetInt(pElement, "smallstepbackseconds", m_videoSmallStepBackSeconds, 1, INT_MAX);

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -132,6 +132,7 @@ class CAdvancedSettings
     int m_musicPercentSeekBackwardBig;
     int m_videoBlackBarColour;
     int m_videoIgnoreSecondsAtStart;
+    int m_videoUnpauseJumpBackSecs;
     float m_videoIgnorePercentAtEnd;
     CStdString m_audioHost;
     bool m_audioApplyDrc;


### PR DESCRIPTION
... this is for coming back into the story of a movie after unpause.

Its based on that feature requests:

http://forum.xbmc.org/showthread.php?tid=135278

and

http://forum.xbmc.org/showthread.php?tid=134837

Do we want this? Would this even deserve a GUI option maybe? 

If we want it - @elupus should give a comment if the implementation is correct.
