### PR TITLE
fix for bug #13098: Do not show PAUSE while skipping a paused track

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -2563,6 +2563,9 @@ bool CApplication::OnAction(const CAction &action)
   {
     if (IsPlaying() && m_pPlayer->SkipNext())
       return true;
+    
+    if (IsPaused())
+      m_pPlayer->Pause();
 
     g_playlistPlayer.PlayNext();
 


### PR DESCRIPTION
Fix for ticket <a href="http://trac.xbmc.org/ticket/13098">#13098</a>
Playing the next track from a paused one shows PAUSE while the track is playing.
