### PR TITLE
[NfoFile] Fix for nfofile with URL

### DIFF
--- a/language/English/strings.po
+++ b/language/English/strings.po
@@ -7721,9 +7721,7 @@ msgctxt "#21415"
 msgid "Default music video scraper"
 msgstr ""
 
-msgctxt "#21416"
-msgid "Enable fallback based on scraper language"
-msgstr ""
+#empty string id 21416
 
 msgctxt "#21417"
 msgid "- Settings"

--- a/xbmc/NfoFile.h
+++ b/xbmc/NfoFile.h
@@ -81,8 +81,6 @@ private:
 
   int Load(const CStdString&);
   int Scrape(ADDON::ScraperPtr& scraper);
-  void AddScrapers(ADDON::VECADDONS& addons,
-                   std::vector<ADDON::ScraperPtr>& vecScrapers);
 };
 
 #endif // !defined(AFX_NfoFile_H__641CCF68_6D2A_426E_9204_C0E4BEF12D00__INCLUDED_)

--- a/xbmc/settings/GUISettings.cpp
+++ b/xbmc/settings/GUISettings.cpp
@@ -778,7 +778,6 @@ void CGUISettings::Initialize()
   AddDefaultAddon(NULL, "scrapers.moviesdefault", 21413, "metadata.themoviedb.org", ADDON_SCRAPER_MOVIES);
   AddDefaultAddon(NULL, "scrapers.tvshowsdefault", 21414, "metadata.tvdb.com", ADDON_SCRAPER_TVSHOWS);
   AddDefaultAddon(NULL, "scrapers.musicvideosdefault", 21415, "metadata.musicvideos.last.fm", ADDON_SCRAPER_MUSICVIDEOS);
-  AddBool(NULL, "scrapers.langfallback", 21416, false);
 
   // service settings
   AddGroup(6, 14036);


### PR DESCRIPTION
.nfo files wasn't processed, as it should. 
If .nfo file contains scrapper URL that scrapper can be found only if it have same language as default scrapper.
Now it's fixed so it's possible to set default movie scrapper to TMDB (for example) and use kinopoisk for individual files as described here: http://wiki.xbmc.org/index.php?title=Import-export_library#Video_nfo_files_containing_an_URL 
