### PR TITLE
Prompt for rescan of music

### DIFF
--- a/language/English/strings.po
+++ b/language/English/strings.po
@@ -2784,7 +2784,21 @@ msgctxt "#798"
 msgid "Internet access"
 msgstr ""
 
-#empty strings from id 799 to 849
+msgctxt "#799"
+msgid "Library Update"
+msgstr ""
+
+#: xbmc/music/windows/GUIWindowMusicBase.cpp
+msgctxt "#800"
+msgid "Music library needs to rescan art from tags"
+msgstr ""
+
+#: xbmc/music/windows/GUIWindowMusicBase.cpp
+msgctxt "#801"
+msgid "Would you like to scan now?"
+msgstr ""
+
+#empty strings from id 802 to 849
 
 msgctxt "#850"
 msgid "Invalid port number entered"

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -5548,12 +5548,20 @@ void CApplication::StartVideoScan(const CStdString &strDirectory, bool scanAll)
   m_videoInfoScanner->Start(strDirectory,scanAll);
 }
 
-void CApplication::StartMusicScan(const CStdString &strDirectory)
+void CApplication::StartMusicScan(const CStdString &strDirectory, int flags)
 {
   if (m_musicInfoScanner->IsScanning())
     return;
 
-  if (!g_guiSettings.GetBool("musiclibrary.backgroundupdate"))
+  if (!flags)
+  { // setup default flags
+    if (g_guiSettings.GetBool("musiclibrary.downloadinfo"))
+      flags |= CMusicInfoScanner::SCAN_ONLINE;
+    if (g_guiSettings.GetBool("musiclibrary.backgroundupdate"))
+      flags |= CMusicInfoScanner::SCAN_BACKGROUND;
+  }
+
+  if (!(flags & CMusicInfoScanner::SCAN_BACKGROUND))
   {
     CGUIDialogMusicScan *musicScan = (CGUIDialogMusicScan *)g_windowManager.GetWindow(WINDOW_DIALOG_MUSIC_SCAN);
     if (musicScan)
@@ -5563,7 +5571,7 @@ void CApplication::StartMusicScan(const CStdString &strDirectory)
     }
   }
   SaveMusicScanSettings();
-  m_musicInfoScanner->Start(strDirectory);
+  m_musicInfoScanner->Start(strDirectory, flags);
 }
 
 void CApplication::StartMusicAlbumScan(const CStdString& strDirectory,

--- a/xbmc/Application.h
+++ b/xbmc/Application.h
@@ -230,7 +230,7 @@ public:
   void StartVideoCleanup();
 
   void StartVideoScan(const CStdString &path, bool scanAll = false);
-  void StartMusicScan(const CStdString &path);
+  void StartMusicScan(const CStdString &path, int flags = 0);
   void StartMusicAlbumScan(const CStdString& strDirectory, bool refresh=false);
   void StartMusicArtistScan(const CStdString& strDirectory, bool refresh=false);
 

--- a/xbmc/music/infoscanner/MusicInfoScanner.cpp
+++ b/xbmc/music/infoscanner/MusicInfoScanner.cpp
@@ -65,6 +65,7 @@ CMusicInfoScanner::CMusicInfoScanner() : CThread("CMusicInfoScanner")
   m_bCanInterrupt = false;
   m_currentItem=0;
   m_itemCount=0;
+  m_flags = 0;
 }
 
 CMusicInfoScanner::~CMusicInfoScanner()
@@ -205,11 +206,12 @@ void CMusicInfoScanner::Process()
     m_pObserver->OnFinished();
 }
 
-void CMusicInfoScanner::Start(const CStdString& strDirectory)
+void CMusicInfoScanner::Start(const CStdString& strDirectory, int flags)
 {
   m_pathsToScan.clear();
   m_albumsScanned.clear();
   m_artistsScanned.clear();
+  m_flags = flags;
 
   if (strDirectory.IsEmpty())
   { // scan all paths in the database.  We do this by scanning all paths in the db, and crossing them off the list as
@@ -565,7 +567,7 @@ int CMusicInfoScanner::RetrieveMusicInfo(CFileItemList& items, const CStdString&
     {
       CStdString strArtist = m_musicDatabase.GetArtistById(*it);
       m_artistsScanned.push_back(*it);
-      if (!m_bStop && g_guiSettings.GetBool("musiclibrary.downloadinfo"))
+      if (!m_bStop && (m_flags & SCAN_ONLINE))
       {
         CStdString strPath;
         strPath.Format("musicdb://2/%u/", *it);
@@ -581,7 +583,7 @@ int CMusicInfoScanner::RetrieveMusicInfo(CFileItemList& items, const CStdString&
     }
   }
 
-  if (g_guiSettings.GetBool("musiclibrary.downloadinfo"))
+  if (m_flags & SCAN_ONLINE)
   {
     for (set<long>::iterator it = albumsToScan.begin(); it != albumsToScan.end(); ++it)
     {

--- a/xbmc/music/infoscanner/MusicInfoScanner.cpp
+++ b/xbmc/music/infoscanner/MusicInfoScanner.cpp
@@ -380,7 +380,7 @@ bool CMusicInfoScanner::DoScan(const CStdString& strDirectory)
 
   // check whether we need to rescan or not
   CStdString dbHash;
-  if (!m_musicDatabase.GetPathHash(strDirectory, dbHash) || dbHash != hash)
+  if ((m_flags & SCAN_RESCAN) || !m_musicDatabase.GetPathHash(strDirectory, dbHash) || dbHash != hash)
   { // path has changed - rescan
     if (dbHash.IsEmpty())
       CLog::Log(LOGDEBUG, "%s Scanning dir '%s' as not in the database", __FUNCTION__, strDirectory.c_str());

--- a/xbmc/music/infoscanner/MusicInfoScanner.h
+++ b/xbmc/music/infoscanner/MusicInfoScanner.h
@@ -44,10 +44,16 @@ public:
 class CMusicInfoScanner : CThread, public IRunnable
 {
 public:
+  /*! \brief Flags for controlling the scanning process
+   */
+  enum SCAN_FLAGS { SCAN_NORMAL     = 0,
+                    SCAN_ONLINE     = 1 << 0,
+                    SCAN_BACKGROUND = 1 << 1 };
+
   CMusicInfoScanner();
   virtual ~CMusicInfoScanner();
 
-  void Start(const CStdString& strDirectory);
+  void Start(const CStdString& strDirectory, int flags);
   void FetchAlbumInfo(const CStdString& strDirectory, bool refresh=false);
   void FetchArtistInfo(const CStdString& strDirectory, bool refresh=false);
   bool IsScanning();
@@ -126,5 +132,6 @@ protected:
   std::set<CStdString> m_pathsToCount;
   std::vector<long> m_artistsScanned;
   std::vector<long> m_albumsScanned;
+  int m_flags;
 };
 }

--- a/xbmc/music/infoscanner/MusicInfoScanner.h
+++ b/xbmc/music/infoscanner/MusicInfoScanner.h
@@ -48,7 +48,8 @@ public:
    */
   enum SCAN_FLAGS { SCAN_NORMAL     = 0,
                     SCAN_ONLINE     = 1 << 0,
-                    SCAN_BACKGROUND = 1 << 1 };
+                    SCAN_BACKGROUND = 1 << 1,
+                    SCAN_RESCAN     = 1 << 2 };
 
   CMusicInfoScanner();
   virtual ~CMusicInfoScanner();

--- a/xbmc/music/windows/GUIWindowMusicBase.cpp
+++ b/xbmc/music/windows/GUIWindowMusicBase.cpp
@@ -50,6 +50,7 @@
 #include "music/tags/MusicInfoTag.h"
 #include "guilib/GUIWindowManager.h"
 #include "dialogs/GUIDialogOK.h"
+#include "dialogs/GUIDialogYesNo.h"
 #include "dialogs/GUIDialogKeyboard.h"
 #include "dialogs/GUIDialogProgress.h"
 #include "FileItem.h"
@@ -1342,6 +1343,21 @@ bool CGUIWindowMusicBase::GetDirectory(const CStdString &strDirectory, CFileItem
 
 void CGUIWindowMusicBase::OnPrepareFileItems(CFileItemList &items)
 {
+}
+
+void CGUIWindowMusicBase::OnInitWindow()
+{
+  CGUIMediaWindow::OnInitWindow();
+  if (g_settings.m_musicNeedsUpdate == 27 && !g_application.IsMusicScanning())
+  {
+    // rescan of music library required
+    if (CGUIDialogYesNo::ShowAndGetInput(799, 800, 801, -1))
+    {
+      g_application.StartMusicScan("", CMusicInfoScanner::SCAN_RESCAN);
+      g_settings.m_musicNeedsUpdate = false; // once is enough (user may interrupt, but that's up to them)
+      g_settings.Save();
+    }
+  }
 }
 
 CStdString CGUIWindowMusicBase::GetStartFolder(const CStdString &dir)

--- a/xbmc/music/windows/GUIWindowMusicBase.h
+++ b/xbmc/music/windows/GUIWindowMusicBase.h
@@ -51,6 +51,7 @@ public:
   void OnInfo(CFileItem *pItem, bool bShowInfo = false);
 
 protected:
+  virtual void OnInitWindow();
   /*!
   \brief Will be called when an popup context menu has been asked for
   \param itemNumber List/thumb control item that has been clicked on


### PR DESCRIPTION
Music needs rescanning so we can generate the new album/song art (plus also ensure we get the compilations correct, though I suspect this needs more work).

This prompts the user and starts a scan.

Discussion is needed as to whether or not we reset the scan trigger (a setting set on db update) when the user starts a scan using this - if the cancel the scan then it's not possible to rescan without removing the source, clearing things out and readding it.
