### PR TITLE
[Updated] Karaoke video background player

### DIFF
--- a/xbmc/music/karaoke/GUIWindowKaraokeLyrics.cpp
+++ b/xbmc/music/karaoke/GUIWindowKaraokeLyrics.cpp
@@ -142,7 +142,7 @@ void CGUIWindowKaraokeLyrics::newSong(CKaraokeLyrics * lyrics)
 
     // Start the required video
     m_Lyrics->GetVideoParameters( path, offset );
-    m_Background->StartVideo( path, offset );
+    m_Background->StartVideo( path );
   }
   else if ( m_Lyrics->HasBackground() && g_advancedSettings.m_karaokeAlwaysEmptyOnCdgs )
   {

--- a/xbmc/music/karaoke/Makefile.in
+++ b/xbmc/music/karaoke/Makefile.in
@@ -9,6 +9,7 @@ SRCS=GUIDialogKaraokeSongSelector.cpp \
      karaokelyricstextlrc.cpp \
      karaokelyricstextustar.cpp \
      karaokewindowbackground.cpp \
+     karaokevideobackground.cpp
 
 LIB=karaoke.a
 

--- a/xbmc/music/karaoke/karaokevideobackground.cpp
+++ b/xbmc/music/karaoke/karaokevideobackground.cpp
@@ -1,0 +1,412 @@
+/*
+ *      Copyright (C) 2005-2010 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
+
+#include "system.h"
+#include "guilib/Texture.h"
+#include "guilib/GUITexture.h"
+#include "settings/Settings.h"
+#include "Application.h"
+#include "utils/MathUtils.h"
+#include "filesystem/SpecialProtocol.h"
+#include "settings/AdvancedSettings.h"
+#include "DllAvFormat.h"
+#include "DllAvCodec.h"
+#include "DllAvUtil.h"
+#include "DllSwScale.h"
+
+#include "karaokevideobackground.h"
+
+static bool PERSISTENT_OBJECT = 0;
+
+
+KaraokeVideoFFMpeg::KaraokeVideoFFMpeg()
+{
+  pFormatCtx = 0;
+  pCodecCtx = 0;
+  pCodec = 0;
+  pFrame = 0;
+  pFrameRGB = 0;
+  m_texture = 0;
+
+  m_maxFrame = 0;
+  m_currentFrameNumber = 0;
+  m_frameBase = 0;
+  
+  m_dllAvFormat = new DllAvFormat();
+  m_dllAvCodec = new DllAvCodec();
+  m_dllAvUtil = new DllAvUtil();
+  m_dllSwScale = new DllSwScale();
+}
+
+KaraokeVideoFFMpeg::~KaraokeVideoFFMpeg()
+{
+  Dismiss();
+  
+  delete m_dllAvFormat;
+  delete m_dllAvCodec;
+  delete m_dllAvUtil;
+  delete m_dllSwScale;
+
+  delete m_texture;
+}
+
+bool KaraokeVideoFFMpeg::Init()
+{
+  if ( !m_dllAvUtil->Load() || !m_dllAvCodec->Load() || !m_dllSwScale->Load() || !m_dllAvFormat->Load() )
+  {
+    CLog::Log( LOGERROR, "Karaoke Video Background: failed to load FFMpeg libraries" );
+    return false;
+  }
+
+  m_dllAvCodec->avcodec_register_all();
+  m_dllAvFormat->av_register_all();
+
+  CLog::Log( LOGDEBUG, "Karaoke Video Background: init succeed" );
+  return true;
+}
+
+void KaraokeVideoFFMpeg::Dismiss()
+{
+  closeVideoFile();
+  
+  m_dllAvCodec->Unload();
+  m_dllAvUtil->Unload();
+  m_dllSwScale->Unload();
+  m_dllAvFormat->Unload();
+  
+  CLog::Log( LOGDEBUG, "Karaoke Video Background: dismiss succeed" );
+}
+
+bool KaraokeVideoFFMpeg::openVideoFile( const CStdString& filename )
+{
+  // See http://dranger.com/ffmpeg/tutorial01.html
+  closeVideoFile();
+
+  CStdString realPath = CSpecialProtocol::TranslatePath( filename );
+  
+  // Open video file
+  if ( m_dllAvFormat->avformat_open_input( &pFormatCtx, realPath.c_str(), NULL, NULL ) < 0 )
+  {
+    CLog::Log( LOGERROR, "Karaoke Video Background: Could not open video file %s (%s)", filename.c_str(), realPath.c_str() );
+    return false;
+  }
+
+  // Retrieve stream information
+  if ( m_dllAvFormat->avformat_find_stream_info( pFormatCtx, 0 ) < 0 )
+  {
+    CLog::Log( LOGERROR, "Karaoke Video Background: Could not find stream information in the video file %s", filename.c_str() );
+    return false;
+  }
+
+  // Find the first video stream
+  videoStream = -1;
+
+  for ( unsigned i = 0; i < pFormatCtx->nb_streams; i++ )
+  {
+    if ( pFormatCtx->streams[i]->codec->codec_type == AVMEDIA_TYPE_VIDEO )
+    {
+      videoStream = i;
+      break;
+    }
+  }
+
+  if ( videoStream == -1 )
+  {
+    CLog::Log( LOGERROR, "Karaoke Video Background: Could not find playable video stream in the file %s", filename.c_str() );
+    return false;
+  }
+
+  m_fps_den = pFormatCtx->streams[videoStream]->r_frame_rate.den;
+  m_fps_num = pFormatCtx->streams[videoStream]->r_frame_rate.num;
+
+  if ( m_fps_den == 60000 )
+    m_fps_den = 30000;
+
+  // Get a pointer to the codec context for the video stream
+  pCodecCtx = pFormatCtx->streams[ videoStream ]->codec;
+
+  // Find the decoder for the video stream
+  pCodec = m_dllAvCodec->avcodec_find_decoder( pCodecCtx->codec_id );
+
+  if ( pCodec == NULL )
+  {
+    CLog::Log( LOGERROR, "Karaoke Video Background: Could not find the video decoder for the file %s", filename.c_str() );
+    return false;
+  }
+    
+  // Open the codec
+  if ( m_dllAvCodec->avcodec_open2( pCodecCtx, pCodec, 0 ) < 0 )
+  {
+    CLog::Log( LOGERROR, "Karaoke Video Background: Could not open the video decoder for the file %s", filename.c_str() );
+    return false;
+  }
+  
+  // Allocate video frames
+  pFrame = m_dllAvCodec->avcodec_alloc_frame();
+
+  if ( !pFrame )
+  {
+    CLog::Log( LOGERROR, "Karaoke Video Background: Could not allocate memory for frame" );
+    return false;
+  }
+  
+  // Init the rest of params
+  m_videoWidth = pCodecCtx->width;
+  m_videoHeight = pCodecCtx->height;
+  m_currentFrameNumber = 0;
+  m_maxFrame = 0;
+  m_curVideoFile = filename;
+  
+  // Find out the necessary aspect ratio for height (assuming fit by width) and width (assuming fit by height)
+  RESOLUTION res = g_graphicsContext.GetVideoResolution();
+  m_displayLeft = g_settings.m_ResInfo[res].Overscan.left;
+  m_displayRight = g_settings.m_ResInfo[res].Overscan.right;
+  m_displayTop = g_settings.m_ResInfo[res].Overscan.top;
+  m_displayBottom = g_settings.m_ResInfo[res].Overscan.bottom;
+  
+  int screen_width = m_displayRight - m_displayLeft;
+  int screen_height = m_displayBottom - m_displayTop;
+
+  // Do we need to modify the output video size? This could happen in two cases:
+  // 1. Either video dimension is larger than the screen - video needs to be downscaled
+  // 2. Both video dimensions are smaller than the screen - video needs to be upscaled
+  if ( (m_videoWidth > screen_width || m_videoHeight > screen_height )
+  || (  m_videoWidth < screen_width && m_videoHeight < screen_height ) )
+  {
+    // Calculate the scale coefficients for width/height separately
+    double scale_width = (double) screen_width / (double) m_videoWidth;
+    double scale_height = (double) screen_height / (double) m_videoHeight;
+
+    // And apply the smallest
+    double scale = scale_width < scale_height ? scale_width : scale_height;
+    m_videoWidth = (int) ((double) m_videoWidth * scale);
+    m_videoHeight = (int) ((double) m_videoHeight * scale);
+  }
+
+  // Allocate the conversion frame and relevant picture
+  pFrameRGB = (AVPicture*)m_dllAvUtil->av_mallocz(sizeof(AVPicture));
+
+  if ( !pFrameRGB )
+  {
+    CLog::Log( LOGERROR, "Karaoke Video Background: Could not allocate memory for frame" );
+    return false;
+  }
+  
+  // Due to a bug in swsscale we need to allocate one extra line of data
+  if ( m_dllAvCodec->avpicture_alloc( pFrameRGB, PIX_FMT_RGB32, m_videoWidth, m_videoHeight + 1 ) < 0 )
+  {
+    CLog::Log( LOGERROR, "Karaoke Video Background: Could not allocate memory for picture buf" );
+    return false;
+  }
+
+  // Calculate the desktop dimensions to show the video
+  if ( m_videoWidth < screen_width || m_videoHeight < screen_height )
+  {
+    m_displayLeft = (screen_width - m_videoWidth) / 2;
+    m_displayRight -= m_displayLeft;
+
+    m_displayTop = (screen_height - m_videoHeight) / 2;
+    m_displayBottom -= m_displayTop;
+  }
+  
+  CLog::Log( LOGDEBUG, "Karaoke Video Background: Video file %s (%dx%d) opened successfully, will be shown as %dx%d at (%d, %d - %d, %d) rectangle", 
+             filename.c_str(), 
+             pCodecCtx->width, pCodecCtx->height, 
+             m_videoWidth, m_videoHeight, 
+             m_displayLeft, m_displayTop, m_displayRight, m_displayBottom );
+  
+  return true;
+}
+
+void KaraokeVideoFFMpeg::closeVideoFile()
+{
+  // Free the YUV frame
+  if ( pFrame )
+    m_dllAvUtil->av_free( pFrame );
+
+  // Free the RGB frame
+  if ( pFrameRGB )
+  {
+    m_dllAvCodec->avpicture_free( pFrameRGB );
+    m_dllAvUtil->av_free( pFrameRGB );
+  }
+
+  // Close the codec
+  if ( pCodecCtx )
+    m_dllAvCodec->avcodec_close( pCodecCtx );
+
+  // Close the video file
+  if ( pFormatCtx )
+    m_dllAvFormat->avformat_close_input( &pFormatCtx );
+
+  pFormatCtx = 0;
+  pCodecCtx = 0;
+  pCodec = 0;
+  pFrame = 0;
+  pFrameRGB = 0;
+  m_curVideoFile.clear();
+}
+
+bool KaraokeVideoFFMpeg::readFrame( int frame )
+{
+  AVPacket packet;
+  int frameFinished;
+
+  while ( m_currentFrameNumber < frame )
+  {
+    // Read a frame
+    if ( m_dllAvFormat->av_read_frame( pFormatCtx, &packet ) < 0 )
+      return false;  // Frame read failed (e.g. end of stream)
+
+    if ( packet.stream_index == videoStream )
+    {
+      // Is this a packet from the video stream -> decode video frame
+      m_dllAvCodec->avcodec_decode_video2( pCodecCtx, pFrame, &frameFinished, &packet );
+
+      // Did we get a video frame?
+      if ( frameFinished )
+      {
+        m_currentFrameNumber++;
+
+        if ( m_currentFrameNumber >= frame )
+        {
+          // convert the picture
+          struct SwsContext * context = m_dllSwScale->sws_getContext( pCodecCtx->width, pCodecCtx->height, pCodecCtx->pix_fmt, 
+                      m_videoWidth, m_videoHeight, PIX_FMT_RGB32, SWS_FAST_BILINEAR, NULL, NULL, NULL );
+
+          m_dllSwScale->sws_scale( context, pFrame->data, pFrame->linesize, 0, pCodecCtx->height, pFrameRGB->data, pFrameRGB->linesize );
+          m_dllSwScale->sws_freeContext( context );
+          m_dllAvCodec->av_free_packet( &packet );
+          return true;
+        }
+      }
+    }
+    m_dllAvCodec->av_free_packet( &packet );
+  }
+  
+  return false;
+}
+
+void KaraokeVideoFFMpeg::Render()
+{
+  // Just in case
+  if ( !m_texture )
+    return;
+  
+  // Get the current song timing in ms.
+  // This will only fit songs up to 71,000 hours, so if you got a larger one, change to int64
+  unsigned int songTime = (unsigned int) MathUtils::round_int( g_application.GetTime() * 1000 );
+
+  // Which frame should we show?
+  int frame_for_time = m_frameBase + ((songTime * m_fps_num) / m_fps_den) / 1000;
+
+  if ( frame_for_time == 0 )
+    frame_for_time = 1;
+
+  // Loop if we know how many frames we have total
+  if ( m_maxFrame > 0 )
+    frame_for_time %= m_maxFrame;
+
+  // Read a new frame if necessary
+  while ( m_currentFrameNumber < frame_for_time )
+  {
+    if ( readFrame( frame_for_time ) )
+      break;
+
+    // End of video; restart
+    m_maxFrame = m_currentFrameNumber - 1;
+    m_currentFrameNumber = 0;
+    m_frameBase = 0;
+
+    // Reset the frame
+    frame_for_time = 0;
+
+    if ( m_dllAvFormat->av_seek_frame( pFormatCtx, videoStream, 0, 0 ) < 0 )
+      return;
+
+    m_dllAvCodec->avcodec_flush_buffers( pCodecCtx );
+  }
+
+  // We got a frame. Draw it.
+  m_texture->Update( m_videoWidth, m_videoHeight, m_videoWidth * 4, XB_FMT_A8R8G8B8, pFrameRGB->data[0], false );
+  CRect vertCoords((float) m_displayLeft, (float) m_displayTop, (float) m_displayRight, (float) m_displayBottom );
+  CGUITexture::DrawQuad(vertCoords, 0xffffffff, m_texture );
+}
+
+bool KaraokeVideoFFMpeg::Start( const CStdString& filename )
+{
+  if ( !m_dllAvFormat->IsLoaded() )
+  {
+    if ( !Init() )
+      return false;
+  }
+  
+  if ( !filename.empty() )
+  {
+     if ( !openVideoFile( filename ) )
+       return false;
+
+     m_frameBase = 0;
+  }
+  else
+  {
+     if ( !openVideoFile( g_advancedSettings.m_karaokeDefaultBackgroundFilePath ) )
+       return false;
+
+     int64_t timestamp = (m_frameBase * 1000 * m_fps_den) / m_fps_num;
+
+     if ( m_frameBase > 0 && m_dllAvFormat->av_seek_frame( pFormatCtx, videoStream, timestamp, 0 ) >= 0 )
+     {
+       m_dllAvCodec->avcodec_flush_buffers( pCodecCtx );
+       m_currentFrameNumber = m_frameBase - 1;
+     }
+     else
+       m_frameBase = 0;
+  }
+  
+  // Allocate the texture
+  m_texture = new CTexture( m_videoWidth, m_videoHeight, XB_FMT_A8R8G8B8 );
+  
+  if ( !m_texture )
+  {
+    CLog::Log( LOGERROR, "Karaoke Video Background: Could not allocate texture" );
+    return false;
+  }
+  
+  return true;
+}
+
+void KaraokeVideoFFMpeg::Stop()
+{
+  if ( !m_dllAvFormat->IsLoaded() )
+  {
+    CLog::Log( LOGERROR, "KaraokeVideoFFMpeg::Start: internal error, called on unitinialized object" );
+    return;
+  }
+
+  delete m_texture;
+  m_texture = 0;
+  
+  m_frameBase = m_currentFrameNumber;
+  
+  if ( !PERSISTENT_OBJECT )
+    Dismiss();
+}

--- a/xbmc/music/karaoke/karaokevideobackground.h
+++ b/xbmc/music/karaoke/karaokevideobackground.h
@@ -1,0 +1,111 @@
+#ifndef KARAOKEVIDEOFFMPEG_H
+#define KARAOKEVIDEOFFMPEG_H
+
+/*
+ *      Copyright (C) 2005-2010 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
+
+#include "DllAvFormat.h"
+#include "DllAvCodec.h"
+#include "DllAvUtil.h"
+#include "DllSwScale.h"
+
+class CBaseTexture;
+class m_dllAvFormat;
+class m_dllAvCodec;
+class m_dllAvUtil;
+class m_dllSwScale;
+
+struct AVFormatContext;
+struct AVCodecContext;
+struct AVCodec;
+struct AVFrame;
+
+// C++ Interface: karaokevideoffmpeg
+// Contact: oldnemesis
+//
+// FFMpeg-based background video decoder for Karaoke background.
+// We are not using DVDPlayer for this because:
+// 1. DVDPlayer was not designed to run at the same time when music is being played and other things (like lyrics) rendered. 
+// While this setup works from time to time, it constantly gets broken. Some modes, like VDPAU, lead to crash right away.
+//
+// 2. We do not need to decode audio, hence we don't have to use extra CPU.
+//
+// 3. We do not really care about frame rate. Jerky video is fine for the background. Lyrics sync is much more important.
+//
+class KaraokeVideoFFMpeg
+{
+public:
+  KaraokeVideoFFMpeg();
+  ~KaraokeVideoFFMpeg();
+  
+  // Start playing the video. It is called each time a new song is being played. Should continue playing existing 
+  // video from the position it was paused. If it returns false, the video rendering is disabled and 
+  // KaraokeVideoFFMpeg object is deleted. Must write the reason for failure into the log file.
+  bool Start( const CStdString& filename = "" );
+
+  // Render the current frame into the screen. This function also must handle video loops and 
+  // switching to the next video when necessary. Hence it shouldn't take too long.
+  void Render();
+
+  // Stops playing the video. It is called once the song is finished and the Render() is not going to be called anymore.
+  // The object, however, is kept and should keep its state because it must continue on next Start() call.
+  void Stop();
+  
+private:
+  // Initialize the object. This function is called only once when the object is created or after it has been dismissed. 
+  // If it returns false, the video rendering is disabled and KaraokeVideoFFMpeg object is deleted
+  bool Init();
+
+  // Dismisses the object, freeing all the memory and unloading the libraries. The object must be inited before using again.
+  void Dismiss();
+
+  bool openVideoFile( const CStdString& filename );
+  void closeVideoFile();
+  bool readFrame( int frame );
+  
+  // FFMpeg objects
+  DllAvFormat     *m_dllAvFormat;
+  DllAvCodec      *m_dllAvCodec;
+  DllAvUtil       *m_dllAvUtil;
+  DllSwScale      *m_dllSwScale;
+
+  CStdString      m_curVideoFile;
+  unsigned int	  skipFrames;
+  AVFormatContext *pFormatCtx;
+  int             videoStream;
+  AVCodecContext  *pCodecCtx;
+  AVCodec         *pCodec;
+  AVFrame         *pFrame;
+  AVPicture       *pFrameRGB;  
+  int              m_videoWidth;   // shown video width, i.e. upscaled or downscaled as necessary
+  int              m_videoHeight;  // shown video height, i.e. upscaled or downscaled as necessary
+  int              m_displayLeft, m_displayRight, m_displayTop, m_displayBottom;  // Video as shown at the display
+  
+  int              m_maxFrame;
+  int              m_fps_den;
+  int              m_fps_num;
+  int              m_currentFrameNumber;
+  int              m_frameBase;    // For video resuming
+  
+  CBaseTexture    *m_texture;
+};
+
+#endif

--- a/xbmc/music/karaoke/karaokewindowbackground.cpp
+++ b/xbmc/music/karaoke/karaokewindowbackground.cpp
@@ -28,11 +28,11 @@
 #include "GUIUserMessages.h"
 #include "guilib/GUIVisualisationControl.h"
 #include "guilib/GUIImage.h"
-#include "cores/dvdplayer/DVDPlayer.h"
 #include "threads/SingleLock.h"
 #include "utils/log.h"
 
 #include "karaokewindowbackground.h"
+#include "karaokevideobackground.h"
 
 
 #define CONTROL_ID_VIS           1
@@ -50,19 +50,13 @@ CKaraokeWindowBackground::CKaraokeWindowBackground()
 
   m_videoPlayer = 0;
   m_parentWindow = 0;
-  m_videoLastTime = 0;
-  m_playingDefaultVideo = false;
-  m_videoEnded = false;
 }
 
 
 CKaraokeWindowBackground::~CKaraokeWindowBackground()
 {
   if ( m_videoPlayer )
-  {
-     m_videoPlayer->CloseFile();
-     delete m_videoPlayer;
-  }
+    delete m_videoPlayer;
 }
 
 
@@ -95,7 +89,6 @@ void CKaraokeWindowBackground::Init(CGUIWindow * wnd)
   {
     CLog::Log( LOGDEBUG, "Karaoke default background is video %s", g_advancedSettings.m_karaokeDefaultBackgroundFilePath.c_str() );
     m_defaultMode = BACKGROUND_VIDEO;
-    m_path = g_advancedSettings.m_karaokeDefaultBackgroundFilePath;
   }
 }
 
@@ -141,31 +134,12 @@ bool CKaraokeWindowBackground::OnMessage(CGUIMessage & message)
 
 void CKaraokeWindowBackground::Render()
 {
-  // We cannot use CSingleLock on m_CritSectionVideoEnded, because OnPlayBackEnded() might be
-  // called from a different thread, and since we cannot proceed on m_CritSectionShared, we'll deadlock
-  bool ended;
-  {
-    CSingleLock lock( m_CritSectionVideoEnded );
-    ended = m_videoEnded;
-  }
-
   CSingleLock lock (m_CritSectionShared);
-  // Do we need to restart video?
-  if ( ended )
-  {
-    NextVideo();
-    return; // VERY important! Player thread is locked now, and if we continue, we'll lock in g_renderManager.Present()
-  }
 
   // Proceed with video rendering
-  if ( m_currentMode == BACKGROUND_VIDEO )
+  if ( m_currentMode == BACKGROUND_VIDEO && m_videoPlayer )
   {
-#ifdef HAS_VIDEO_PLAYBACK
-    if ( g_application.IsPresentFrame() )
-      g_renderManager.Present();
-    else
-      g_renderManager.RenderUpdate(true, 0, 255);
-#endif
+    m_videoPlayer->Render();
   }
 
   // For other visualisations just disable the screen saver
@@ -206,44 +180,19 @@ void CKaraokeWindowBackground::StartImage( const CStdString& path )
 }
 
 
-void CKaraokeWindowBackground::StartVideo( const CStdString& path, int64_t offset)
+void CKaraokeWindowBackground::StartVideo( const CStdString& path )
 {
-  CFileItem item( path, false);
-  m_videoEnded = false;
-
-  // Video options
-  CPlayerOptions options;
-  options.video_only = true;
-
-  if ( offset > 0 )
-    options.starttime = (double) (offset / 1000.0);
-
-  if ( !item.IsVideo() )
-  {
-    CLog::Log(LOGERROR, "KaraokeVideoBackground: file %s is not a video file, ignoring", path.c_str() );
-    return;
-  }
-
-  if ( item.IsDVD() )
-  {
-    CLog::Log(LOGERROR, "KaraokeVideoBackground: DVD video playback is not supported");
-    return;
-  }
-
   if ( !m_videoPlayer )
-    m_videoPlayer = new CDVDPlayer(*this);
+    m_videoPlayer = new KaraokeVideoFFMpeg();
 
-  if ( !m_videoPlayer )
-    return;
-
-  if ( !m_videoPlayer->OpenFile( item, options ) )
+  if ( !m_videoPlayer->Start( path ) )
   {
-    CLog::Log(LOGERROR, "KaraokeVideoBackground: error opening video file %s", item.GetPath().c_str());
+    delete m_videoPlayer;
+    m_videoPlayer = 0;
+    m_currentMode = BACKGROUND_NONE;
     return;
   }
-
-  CLog::Log(LOGDEBUG, "KaraokeVideoBackground: video file %s opened successfully", item.GetPath().c_str());
-
+  
   m_ImgControl->SetVisible( false );
   m_VisControl->SetVisible( false );
   m_currentMode = BACKGROUND_VIDEO;
@@ -267,10 +216,7 @@ void CKaraokeWindowBackground::StartDefault()
       break;
 
     case BACKGROUND_VIDEO:
-      StartVideo( m_path, m_videoLastTime );
-
-      if ( m_currentMode == BACKGROUND_VIDEO )
-        m_playingDefaultVideo = true;
+      StartVideo();
       break;
 
     default:
@@ -285,16 +231,8 @@ void CKaraokeWindowBackground::Stop()
   CSingleLock lock (m_CritSectionShared);
   m_currentMode = BACKGROUND_NONE;
 
-  // Disable and hide all control
   if ( m_videoPlayer )
-  {
-     if ( m_playingDefaultVideo )
-       m_videoLastTime = m_videoPlayer->GetTime();
-
-     m_videoPlayer->CloseFile();
-     delete m_videoPlayer;
-     m_videoPlayer = 0;
-  }
+    m_videoPlayer->Stop();
 
   CLog::Log( LOGDEBUG, "Karaoke background stopped" );
 }
@@ -302,29 +240,15 @@ void CKaraokeWindowBackground::Stop()
 
 void CKaraokeWindowBackground::OnPlayBackEnded()
 {
-  CSingleLock lock ( m_CritSectionVideoEnded );
-  m_videoEnded = true;
-/*  CSingleLock lock (m_CritSectionShared);
-
-  CLog::Log( LOGDEBUG, "KaraokeVideoBackground: stopping" );
-  Stop();
-  CLog::Log( LOGDEBUG, "KaraokeVideoBackground: stopped" );
-  m_videoLastTime = 0;
-  StartVideo( m_path, m_videoLastTime );
-  CLog::Log( LOGDEBUG, "KaraokeVideoBackground: restarting video from the beginning" );
-*/
 }
-
 
 void CKaraokeWindowBackground::OnPlayBackStarted()
 {
 }
 
-
 void CKaraokeWindowBackground::OnPlayBackStopped()
 {
 }
-
 
 void CKaraokeWindowBackground::OnQueueNextItem()
 {
@@ -332,27 +256,4 @@ void CKaraokeWindowBackground::OnQueueNextItem()
 
 void CKaraokeWindowBackground::Pause(bool now_paused)
 {
-  if ( m_currentMode == BACKGROUND_VIDEO && m_videoPlayer )
-  {
-    if ( (now_paused && !m_videoPlayer->IsPaused())
-    || ( !now_paused && m_videoPlayer->IsPaused() ) )
-      m_videoPlayer->Pause();
-  }
-}
-
-void CKaraokeWindowBackground::NextVideo()
-{
-  // This function should not be called directly from the callback! Deadlock!!!
-  m_videoPlayer->CloseFile();
-
-  // Only one video selected, restarting
-  m_videoLastTime = 0;
-
-  {
-    CSingleLock lock(m_CritSectionVideoEnded );
-    m_videoEnded = false;
-  }
-
-  StartVideo( m_path, m_videoLastTime );
-  CLog::Log( LOGDEBUG, "KaraokeVideoBackground: restarting video from the beginning" );
 }

--- a/xbmc/music/karaoke/karaokewindowbackground.h
+++ b/xbmc/music/karaoke/karaokewindowbackground.h
@@ -29,7 +29,7 @@
 class CGUIWindow;
 class CGUIImage;
 class CGUIVisualisationControl;
-class CDVDPlayer;
+class KaraokeVideoFFMpeg;
 
 class CKaraokeWindowBackground : public IPlayerCallback
 {
@@ -49,7 +49,7 @@ public:
   virtual void StartImage( const CStdString& path );
 
   // Start with song-specific video background
-  virtual void StartVideo( const CStdString& path, int64_t offset = 0 );
+  virtual void StartVideo( const CStdString& path = "" );
 
   // Start with default (setting-specific) background
   virtual void StartDefault();
@@ -59,9 +59,6 @@ public:
 
   // Stop any kind of background
   virtual void Stop();
-
-  // Switch to next video, or restart current one
-  virtual void NextVideo();
 
   // Function forwarders
   virtual bool OnAction(const CAction &action);
@@ -86,10 +83,6 @@ private:
   // This critical section protects all variables except m_videoEnded
   CCriticalSection          m_CritSectionShared;
 
-  // This critical section protects m_videoEnded, since it could be changed from a different thread
-  // while the section above is locked
-  CCriticalSection          m_CritSectionVideoEnded;
-
   // for visualization background
   CGUIVisualisationControl * m_VisControl;
   CGUIImage                * m_ImgControl;
@@ -100,14 +93,11 @@ private:
   CGUIWindow               * m_parentWindow;
 
   // Video player pointer
-  CDVDPlayer               * m_videoPlayer;
-  bool                       m_videoEnded;
+  KaraokeVideoFFMpeg       * m_videoPlayer;
 
   // For default visualisation mode
   BackgroundMode             m_defaultMode;
-  CStdString                 m_path; // image or video
-  int64_t                    m_videoLastTime; // video only
-  bool                       m_playingDefaultVideo; // whether to store the time
+  CStdString                 m_path; // image
 };
 
 #endif


### PR DESCRIPTION
Updated the pull request based on the latest master, so hopefully no rebase needed.

The existing version is based on a CDVDPlayer hack and since merging with AudioEngine it just crashes if enabled. And it has been broken for the last few months or so, hence the replacement. A new background video player is based on ffmpeg. It is quite simple because we don't care about sound or the frame rate synchronization, but it does the job.

For Windows/Mac you'll need to add new files xbmc/music/karaoke/karaokevideobackground.cpp / h into the build system, otherwise it won't link. For Linux it is already added.

Please let me know of any compilation errors on non-Linux platform (should be none on Linux)
