### PR TITLE
Remove smb auth details in add source

### DIFF
--- a/xbmc/PasswordManager.cpp
+++ b/xbmc/PasswordManager.cpp
@@ -79,12 +79,21 @@ bool CPasswordManager::PromptToAuthenticateURL(CURL &url)
   url.SetUserName(username);
 
   // save the information for later
+  SaveAuthenticatedURL(url, saveDetails);
+  return true;
+}
+
+void CPasswordManager::SaveAuthenticatedURL(const CURL &url, bool saveToProfile)
+{
+  CSingleLock lock(m_critSection);
+
+  CStdString path = GetLookupPath(url);
   CStdString authenticatedPath = url.Get();
 
   if (!m_loaded)
     Load();
 
-  if (saveDetails)
+  if (saveToProfile)
   { // write to some random XML file...
     m_permanentCache[path] = authenticatedPath;
     Save();
@@ -93,7 +102,6 @@ bool CPasswordManager::PromptToAuthenticateURL(CURL &url)
   // save for both this path and more generally the server as a whole.
   m_temporaryCache[path] = authenticatedPath;
   m_temporaryCache[GetServerLookup(path)] = authenticatedPath;
-  return true;
 }
 
 void CPasswordManager::Clear()

--- a/xbmc/PasswordManager.h
+++ b/xbmc/PasswordManager.h
@@ -63,9 +63,21 @@ public:
    
    \param url the URL to authenticate.
    \return true if the user entered details, false if the user cancelled the dialog.
-   \sa CURL
+   \sa CURL, SaveAuthenticatedURL
    */
   bool PromptToAuthenticateURL(CURL &url);
+
+  /*!
+   \brief Save an authenticated URL.
+
+   This routine stores an authenticated URL in the temporary cache, and optionally
+   saves these details into the users profile.
+
+   \param url the URL to authenticate.
+   \param saveToProfile whether to save in the users profile, defaults to true.
+   \sa CURL, PromptToAuthenticateURL
+   */
+  void SaveAuthenticatedURL(const CURL &url, bool saveToProfile = true);
 
   /*!
    \brief Clear any previously cached passwords

--- a/xbmc/dialogs/GUIDialogMediaSource.cpp
+++ b/xbmc/dialogs/GUIDialogMediaSource.cpp
@@ -33,6 +33,7 @@
 #include "settings/Settings.h"
 #include "settings/GUISettings.h"
 #include "guilib/LocalizeStrings.h"
+#include "PasswordManager.h"
 
 using namespace std;
 using namespace XFILE;
@@ -467,7 +468,20 @@ vector<CStdString> CGUIDialogMediaSource::GetPaths()
 {
   vector<CStdString> paths;
   for (int i = 0; i < m_paths->Size(); i++)
+  {
     if (!m_paths->Get(i)->GetPath().IsEmpty())
-      paths.push_back(m_paths->Get(i)->GetPath());
+    { // strip off the user and password for smb paths (anything that the password manager can auth)
+      // and add the user/pass to the password manager - note, we haven't confirmed that it works
+      // at this point, but if it doesn't, the user will get prompted anyway in SMBDirectory.
+      CURL url(m_paths->Get(i)->GetPath());
+      if (url.GetProtocol() == "smb")
+      {
+        CPasswordManager::GetInstance().SaveAuthenticatedURL(url);
+        url.SetPassword("");
+        url.SetUserName("");
+      }
+      paths.push_back(url.Get());
+    }
+  }
   return paths;
 }


### PR DESCRIPTION
Currently when a user adds a smb:// source and specifies username/pass (from the GUI) before they add it, the username/pass is stored in sources.xml rather than in the password manager.

This changes it so that any username/pass is stripped off and stored in the password manager instead.  This ensures no user/pass in sources.xml or in the database on scan, which reduces dupes due to the same path being in the database with username + pass and without.

Completely untested.

@vdrfan - IIRC I discussed this with you a while back - mind giving it a test?
