### PR TITLE
change AE definition and usage of GetCacheTime to match how it is used in players

### DIFF
--- a/xbmc/cores/AudioEngine/Engines/SoftAE/SoftAE.cpp
+++ b/xbmc/cores/AudioEngine/Engines/SoftAE/SoftAE.cpp
@@ -809,7 +809,7 @@ double CSoftAE::GetCacheTime()
   CSharedLock sinkLock(m_sinkLock);
 
   double time;
-  time  = (double)m_buffer.Free() * m_sinkFormatFrameSizeMul * m_sinkFormatSampleRateMul;
+  time  = (double)m_buffer.Used() * m_sinkFormatFrameSizeMul * m_sinkFormatSampleRateMul;
   time += m_sink->GetCacheTime();
 
   return time;

--- a/xbmc/cores/AudioEngine/Engines/SoftAE/SoftAEStream.cpp
+++ b/xbmc/cores/AudioEngine/Engines/SoftAE/SoftAEStream.cpp
@@ -489,8 +489,8 @@ double CSoftAEStream::GetCacheTime()
     return 0.0;
 
   double time;
-  time  = (double)(m_inputBuffer.Free() / m_format.m_frameSize) / (double)m_format.m_sampleRate;
-  time += (double)(m_waterLevel - m_refillBuffer)               / (double)AE.GetSampleRate();
+  time  = (double)(m_inputBuffer.Used() / m_format.m_frameSize) / (double)m_format.m_sampleRate;
+  time += (double)(m_waterLevel - m_framesBuffered)             / (double)AE.GetSampleRate();
   time += AE.GetCacheTime();
   return time;
 }

--- a/xbmc/cores/AudioEngine/Interfaces/AESink.h
+++ b/xbmc/cores/AudioEngine/Interfaces/AESink.h
@@ -53,22 +53,24 @@ public:
   virtual bool IsCompatible(const AEAudioFormat format, const std::string device) = 0;
 
   /*
-    This method must return the delay in seconds till new data will be sent out
+    This method returns the time in seconds that it will take
+    for the next added packet to be heard from the speakers.
   */
   virtual double GetDelay() = 0;
 
   /*
-    This method returns the time in seconds till the sink's cache is full
+    This method returns the time in seconds that it will take
+    to underrun the cache if no sample is added.
   */
   virtual double GetCacheTime() = 0;
 
   /*
-    This method returns the total length of the cache in seconds
+    This method returns the total time in seconds of the cache.
   */
   virtual double GetCacheTotal() = 0;
 
   /*
-    Adds packets to be sent out, must block after at-least one block is being rendered
+    Adds packets to be sent out, this routine MUST block or sleep.
   */
   virtual unsigned int AddPackets(uint8_t *data, unsigned int frames) = 0;
 

--- a/xbmc/cores/AudioEngine/Interfaces/AEStream.h
+++ b/xbmc/cores/AudioEngine/Interfaces/AEStream.h
@@ -59,8 +59,9 @@ public:
   virtual unsigned int AddData(void *data, unsigned int size) = 0;
 
   /**
-   * Returns how long until new data will be played
-   * @return The delay in seconds
+   * Returns the time in seconds that it will take
+   * for the next added packet to be heard from the speakers.
+   * @return seconds
    */
   virtual double GetDelay() = 0;
 
@@ -71,14 +72,15 @@ public:
   virtual bool IsBuffering() = 0;
 
   /**
-   * Returns how long until playback will start
-   * @return The delay in seconds
+   * Returns the time in seconds that it will take
+   * to underrun the cache if no sample is added.
+   * @return seconds
    */
   virtual double GetCacheTime() = 0;
 
   /**
-   * Returns the total length of the cache before playback will start
-   * @return The delay in seconds
+   * Returns the total time in seconds of the cache
+   * @return seconds
    */
   virtual double GetCacheTotal() = 0;
 

--- a/xbmc/cores/AudioEngine/Sinks/AESinkWASAPI.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkWASAPI.cpp
@@ -332,19 +332,7 @@ bool CAESinkWASAPI::IsCompatible(const AEAudioFormat format, const std::string d
 
 double CAESinkWASAPI::GetDelay()
 {
-  HRESULT hr;
-  if (!m_initialized)
-    return 0.0;
-
-  hr = m_pAudioClient->GetBufferSize(&m_uiBufferLen);
-  if (FAILED(hr))
-  {
-    #ifdef _DEBUG
-    CLog::Log(LOGERROR, __FUNCTION__": GetBufferSize Failed : %s", WASAPIErrToStr(hr));
-    #endif
-    return 0.0;
-  }
-  return (double)m_uiBufferLen / (double)m_format.m_sampleRate;
+  return GetCacheTime();
 }
 
 double CAESinkWASAPI::GetCacheTime()
@@ -352,11 +340,14 @@ double CAESinkWASAPI::GetCacheTime()
   if (!m_initialized)
     return 0.0;
 
-  REFERENCE_TIME hnsLatency;
-  HRESULT hr = m_pAudioClient->GetStreamLatency(&hnsLatency);
-
-  /** returns buffer duration in seconds */
-  return hnsLatency / 10.0;
+  unsigned int numPaddingFrames;
+  HRESULT hr = m_pAudioClient->GetCurrentPadding(&numPaddingFrames);
+  if (FAILED(hr))
+  {
+    CLog::Log(LOGERROR, __FUNCTION__": GetCurrentPadding Failed : %s", WASAPIErrToStr(hr));
+    return 0.0;
+  }
+  return (double)numPaddingFrames / (double)m_format.m_sampleRate;
 }
 
 double CAESinkWASAPI::GetCacheTotal()


### PR DESCRIPTION
Major bork in AE, the def/usage of GetCacheTime is wrong with respect to the players that call AE. Players rule so AE needs to change.

Engines:
 SoftAE usage is correct with this pull/req.
 PulseAE needs checking.
 CoreAudio usage is correct.

SoftAE Sinks:
  AESinkALSA looks wrong, someone familiar with ALSA needs to help fix it.
  AESinkOSS looks wrong, someone familiar with OSS needs to help fix it.
  AESinkNULL is totally borked and needs fixing.
  AESinkWASAPI needs checking and fixing if required.
  AESikkDirectSound usage is correct.
