### PR TITLE
[Fix for 13160] Update supported settings types in AddonDll.h

### DIFF
--- a/xbmc/addons/AddonDll.h
+++ b/xbmc/addons/AddonDll.h
@@ -404,7 +404,7 @@ ADDON_STATUS CAddonDll<TheDll, TheStruct, TheProps>::TransferSettings()
       {
         if (strcmpi(type,"sep") == 0 || strcmpi(type,"lsep") == 0)
         {
-            /* Don't propagate separators */
+          /* Don't propagate separators */
         }
         else if (strcmpi(type, "text") == 0 || strcmpi(type, "ipaddress") == 0 ||
           strcmpi(type, "video") == 0 || strcmpi(type, "audio") == 0 ||
@@ -442,11 +442,10 @@ ADDON_STATUS CAddonDll<TheDll, TheStruct, TheProps>::TransferSettings()
           {
             status = m_pDll->SetSetting(id, (float*) &tmpf);
           }
-          
         }
         else
         {
-            /* Log unknowns as an error, but go ahead and transfer the string */
+          /* Log unknowns as an error, but go ahead and transfer the string */
           CLog::Log(LOGERROR, "Unknown setting type '%s' for %s", type, Name().c_str());
           status = m_pDll->SetSetting(id, (const char*) GetSetting(id).c_str());
         }

--- a/xbmc/addons/AddonDll.h
+++ b/xbmc/addons/AddonDll.h
@@ -398,19 +398,26 @@ ADDON_STATUS CAddonDll<TheDll, TheStruct, TheProps>::TransferSettings()
       ADDON_STATUS status = ADDON_STATUS_OK;
       const char *id = setting->Attribute("id");
       const char *type = setting->Attribute("type");
+      const char *option = setting->Attribute("option");
 
       if (type)
       {
-        if (strcmpi(type, "text") == 0 || strcmpi(type, "ipaddress") == 0 ||
-          strcmpi(type, "folder") == 0 || strcmpi(type, "action") == 0 ||
-          strcmpi(type, "music") == 0 || strcmpi(type, "pictures") == 0 ||
-          strcmpi(type, "folder") == 0 || strcmpi(type, "programs") == 0 ||
-          strcmpi(type, "files") == 0 || strcmpi(type, "fileenum") == 0)
+        if (strcmpi(type,"sep") == 0 || strcmpi(type,"lsep") == 0)
+        {
+            /* Don't propagate separators */
+        }
+        else if (strcmpi(type, "text") == 0 || strcmpi(type, "ipaddress") == 0 ||
+          strcmpi(type, "video") == 0 || strcmpi(type, "audio") == 0 ||
+          strcmpi(type, "image") == 0 || strcmpi(type, "folder") == 0 ||
+          strcmpi(type, "executable") == 0 || strcmpi(type, "file") == 0 ||
+          strcmpi(type, "action") == 0 || strcmpi(type, "date") == 0 ||
+          strcmpi(type, "time") == 0 || strcmpi(type, "select") == 0 ||
+          strcmpi(type, "addon") == 0 || strcmpi(type, "labelenum") == 0 ||
+          strcmpi(type, "fileenum") == 0 )
         {
           status = m_pDll->SetSetting(id, (const char*) GetSetting(id).c_str());
         }
-        else if (strcmpi(type, "integer") == 0 || strcmpi(type, "enum") == 0 ||
-          strcmpi(type, "labelenum") == 0 || strcmpi(type, "rangeofnum") == 0)
+        else if (strcmpi(type, "enum") == 0)
         {
           int tmp = atoi(GetSetting(id));
           status = m_pDll->SetSetting(id, (int*) &tmp);
@@ -420,9 +427,28 @@ ADDON_STATUS CAddonDll<TheDll, TheStruct, TheProps>::TransferSettings()
           bool tmp = (GetSetting(id) == "true") ? true : false;
           status = m_pDll->SetSetting(id, (bool*) &tmp);
         }
+        else if (strcmpi(type, "rangeofnum") == 0 || strcmpi(type, "slider") == 0 ||
+                 strcmpi(type, "number") == 0)
+        {
+          float tmpf = atof(GetSetting(id));
+          int   tmpi;
+
+          if (option && strcmpi(option,"int") == 0)
+          {
+            tmpi = (int)floor(tmpf);
+            status = m_pDll->SetSetting(id, (int*) &tmpi);
+          }
+          else
+          {
+            status = m_pDll->SetSetting(id, (float*) &tmpf);
+          }
+          
+        }
         else
         {
+            /* Log unknowns as an error, but go ahead and transfer the string */
           CLog::Log(LOGERROR, "Unknown setting type '%s' for %s", type, Name().c_str());
+          status = m_pDll->SetSetting(id, (const char*) GetSetting(id).c_str());
         }
 
         if (status == ADDON_STATUS_NEED_RESTART)

--- a/xbmc/addons/AddonDll.h
+++ b/xbmc/addons/AddonDll.h
@@ -398,19 +398,26 @@ ADDON_STATUS CAddonDll<TheDll, TheStruct, TheProps>::TransferSettings()
       ADDON_STATUS status = ADDON_STATUS_OK;
       const char *id = setting->Attribute("id");
       const char *type = setting->Attribute("type");
+      const char *option = setting->Attribute("option");
 
       if (type)
       {
-        if (strcmpi(type, "text") == 0 || strcmpi(type, "ipaddress") == 0 ||
-          strcmpi(type, "folder") == 0 || strcmpi(type, "action") == 0 ||
-          strcmpi(type, "music") == 0 || strcmpi(type, "pictures") == 0 ||
-          strcmpi(type, "folder") == 0 || strcmpi(type, "programs") == 0 ||
-          strcmpi(type, "files") == 0 || strcmpi(type, "fileenum") == 0)
+        if (strcmpi(type,"sep") == 0 || strcmpi(type,"lsep") == 0)
+        {
+          /* Don't propagate separators */
+        }
+        else if (strcmpi(type, "text") == 0 || strcmpi(type, "ipaddress") == 0 ||
+          strcmpi(type, "video") == 0 || strcmpi(type, "audio") == 0 ||
+          strcmpi(type, "image") == 0 || strcmpi(type, "folder") == 0 ||
+          strcmpi(type, "executable") == 0 || strcmpi(type, "file") == 0 ||
+          strcmpi(type, "action") == 0 || strcmpi(type, "date") == 0 ||
+          strcmpi(type, "time") == 0 || strcmpi(type, "select") == 0 ||
+          strcmpi(type, "addon") == 0 || strcmpi(type, "labelenum") == 0 ||
+          strcmpi(type, "fileenum") == 0 )
         {
           status = m_pDll->SetSetting(id, (const char*) GetSetting(id).c_str());
         }
-        else if (strcmpi(type, "integer") == 0 || strcmpi(type, "enum") == 0 ||
-          strcmpi(type, "labelenum") == 0 || strcmpi(type, "rangeofnum") == 0)
+        else if (strcmpi(type, "enum") == 0)
         {
           int tmp = atoi(GetSetting(id));
           status = m_pDll->SetSetting(id, (int*) &tmp);
@@ -420,9 +427,27 @@ ADDON_STATUS CAddonDll<TheDll, TheStruct, TheProps>::TransferSettings()
           bool tmp = (GetSetting(id) == "true") ? true : false;
           status = m_pDll->SetSetting(id, (bool*) &tmp);
         }
+        else if (strcmpi(type, "rangeofnum") == 0 || strcmpi(type, "slider") == 0 ||
+                 strcmpi(type, "number") == 0)
+        {
+          float tmpf = atof(GetSetting(id));
+          int   tmpi;
+
+          if (option && strcmpi(option,"int") == 0)
+          {
+            tmpi = (int)floor(tmpf);
+            status = m_pDll->SetSetting(id, (int*) &tmpi);
+          }
+          else
+          {
+            status = m_pDll->SetSetting(id, (float*) &tmpf);
+          }
+        }
         else
         {
+          /* Log unknowns as an error, but go ahead and transfer the string */
           CLog::Log(LOGERROR, "Unknown setting type '%s' for %s", type, Name().c_str());
+          status = m_pDll->SetSetting(id, (const char*) GetSetting(id).c_str());
         }
 
         if (status == ADDON_STATUS_NEED_RESTART)


### PR DESCRIPTION
- Updated the set of supported settings types to be transferred to dll addons
- Fixed a couple of errors in type conversion
- If the user indicated that a typically float item (slider, rangeofnum) should be handled as int (via "option" attribute), convert to int in call to SetSetting.
