### PR TITLE
Handle "analog" seeking in a separate handler rather than in GUIDialogSeekBar

### DIFF
--- a/XBMC-ATV2.xcodeproj/project.pbxproj
+++ b/XBMC-ATV2.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		7C0A7FC913A9E75400AFC2BD /* DirtyRegionTracker.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C0A7FC613A9E75400AFC2BD /* DirtyRegionTracker.cpp */; };
 		7C0A7FCC13A9E76E00AFC2BD /* GUIWindowDebugInfo.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C0A7FCA13A9E76E00AFC2BD /* GUIWindowDebugInfo.cpp */; };
 		7C0B990A154B80200065A238 /* AEDeviceInfo.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C0B9908154B80200065A238 /* AEDeviceInfo.cpp */; };
+		7C1A493D15A968BA004AF4A4 /* SeekHandler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C1A493B15A968BA004AF4A4 /* SeekHandler.cpp */; };
 		7C1A89BB152671FB00C63311 /* TextureCacheJob.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C1A89B9152671FB00C63311 /* TextureCacheJob.cpp */; };
 		7C1D698B15A8142F00658B65 /* DatabaseManager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C1D698915A8142F00658B65 /* DatabaseManager.cpp */; };
 		7C1F6F8C13ED17CC001726AB /* LibraryDirectory.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C1F6F8A13ED17CC001726AB /* LibraryDirectory.cpp */; };
@@ -1027,6 +1028,8 @@
 		7C0B9908154B80200065A238 /* AEDeviceInfo.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = AEDeviceInfo.cpp; sourceTree = "<group>"; };
 		7C0B9909154B80200065A238 /* AEDeviceInfo.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AEDeviceInfo.h; sourceTree = "<group>"; };
 		7C1A494015A968D6004AF4A4 /* SaveFileStateJob.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SaveFileStateJob.h; sourceTree = "<group>"; };
+		7C1A493B15A968BA004AF4A4 /* SeekHandler.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SeekHandler.cpp; sourceTree = "<group>"; };
+		7C1A493C15A968BA004AF4A4 /* SeekHandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SeekHandler.h; sourceTree = "<group>"; };
 		7C1A89B9152671FB00C63311 /* TextureCacheJob.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TextureCacheJob.cpp; sourceTree = "<group>"; };
 		7C1A89BA152671FB00C63311 /* TextureCacheJob.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TextureCacheJob.h; sourceTree = "<group>"; };
 		7C1D698915A8142F00658B65 /* DatabaseManager.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = DatabaseManager.cpp; sourceTree = "<group>"; };
@@ -5454,6 +5457,8 @@
 				F56C775F131EC154000AD0F6 /* ScraperParser.h */,
 				F56C7760131EC154000AD0F6 /* ScraperUrl.cpp */,
 				F56C7761131EC154000AD0F6 /* ScraperUrl.h */,
+				7C1A493B15A968BA004AF4A4 /* SeekHandler.cpp */,
+				7C1A493C15A968BA004AF4A4 /* SeekHandler.h */,
 				36A9445B15821FAB00727135 /* SortUtils.cpp */,
 				36A9445C15821FAB00727135 /* SortUtils.h */,
 				F56C7762131EC154000AD0F6 /* Splash.cpp */,
@@ -7233,6 +7238,7 @@
 				DF08E84515829BA600058C77 /* Exception.cpp in Sources */,
 				36A9465315AA269B00727135 /* DirectoryNodeTags.cpp in Sources */,
 				7C1D698B15A8142F00658B65 /* DatabaseManager.cpp in Sources */,
+				7C1A493D15A968BA004AF4A4 /* SeekHandler.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/XBMC-IOS.xcodeproj/project.pbxproj
+++ b/XBMC-IOS.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 		7C0A7FB213A9E72E00AFC2BD /* DirtyRegionSolvers.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C0A7FAE13A9E72E00AFC2BD /* DirtyRegionSolvers.cpp */; };
 		7C0A7FB313A9E72E00AFC2BD /* DirtyRegionTracker.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C0A7FB013A9E72E00AFC2BD /* DirtyRegionTracker.cpp */; };
 		7C0B98F9154B7FF30065A238 /* AEDeviceInfo.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C0B98F7154B7FF30065A238 /* AEDeviceInfo.cpp */; };
+		7C1A495315A968FB004AF4A4 /* SeekHandler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C1A495115A968FB004AF4A4 /* SeekHandler.cpp */; };
 		7C1A89CE1526722200C63311 /* TextureCacheJob.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C1A89CC1526722200C63311 /* TextureCacheJob.cpp */; };
 		7C1D697815A8141000658B65 /* DatabaseManager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C1D697615A8141000658B65 /* DatabaseManager.cpp */; };
 		7C1F6F7A13ED178F001726AB /* LibraryDirectory.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C1F6F7813ED178F001726AB /* LibraryDirectory.cpp */; };
@@ -1027,6 +1028,8 @@
 		7C0B98F7154B7FF30065A238 /* AEDeviceInfo.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = AEDeviceInfo.cpp; sourceTree = "<group>"; };
 		7C0B98F8154B7FF30065A238 /* AEDeviceInfo.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AEDeviceInfo.h; sourceTree = "<group>"; };
 		7C1A495415A96908004AF4A4 /* SaveFileStateJob.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SaveFileStateJob.h; sourceTree = "<group>"; };
+		7C1A495115A968FB004AF4A4 /* SeekHandler.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SeekHandler.cpp; sourceTree = "<group>"; };
+		7C1A495215A968FB004AF4A4 /* SeekHandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SeekHandler.h; sourceTree = "<group>"; };
 		7C1A89CC1526722200C63311 /* TextureCacheJob.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TextureCacheJob.cpp; sourceTree = "<group>"; };
 		7C1A89CD1526722200C63311 /* TextureCacheJob.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TextureCacheJob.h; sourceTree = "<group>"; };
 		7C1D697615A8141000658B65 /* DatabaseManager.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = DatabaseManager.cpp; sourceTree = "<group>"; };
@@ -5819,6 +5822,8 @@
 				F56C874E131F42EC000AD0F6 /* ScraperParser.h */,
 				F56C874F131F42EC000AD0F6 /* ScraperUrl.cpp */,
 				F56C8750131F42EC000AD0F6 /* ScraperUrl.h */,
+				7C1A495115A968FB004AF4A4 /* SeekHandler.cpp */,
+				7C1A495215A968FB004AF4A4 /* SeekHandler.h */,
 				36A9445015821F5300727135 /* SortUtils.cpp */,
 				36A9445115821F5300727135 /* SortUtils.h */,
 				F56C8751131F42EC000AD0F6 /* Splash.cpp */,
@@ -7244,6 +7249,7 @@
 				DFC3867E158296EC008AE277 /* Exception.cpp in Sources */,
 				36A9465B15AA26BC00727135 /* DirectoryNodeTags.cpp in Sources */,
 				7C1D697815A8141000658B65 /* DatabaseManager.cpp in Sources */,
+				7C1A495315A968FB004AF4A4 /* SeekHandler.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/XBMC.xcodeproj/project.pbxproj
+++ b/XBMC.xcodeproj/project.pbxproj
@@ -258,6 +258,7 @@
 		43BF09AB1080D2ED00E25290 /* RdrConnectionManagerSCPD.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 43BF09A81080D2ED00E25290 /* RdrConnectionManagerSCPD.cpp */; };
 		7C0A7EC013A5DBCE00AFC2BD /* AppParamParser.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C0A7EBE13A5DBCE00AFC2BD /* AppParamParser.cpp */; };
 		7C0B98A4154B79C30065A238 /* AEDeviceInfo.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C0B98A1154B79C30065A238 /* AEDeviceInfo.cpp */; };
+		7C1A492315A962EE004AF4A4 /* SeekHandler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C1A492115A962EE004AF4A4 /* SeekHandler.cpp */; };
 		7C1A85661520522500C63311 /* TextureCacheJob.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C1A85631520522500C63311 /* TextureCacheJob.cpp */; };
 		7C1D682915A7D2FD00658B65 /* DatabaseManager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C1D682715A7D2FD00658B65 /* DatabaseManager.cpp */; };
 		7C1F6EBB13ECCFA7001726AB /* LibraryDirectory.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C1F6EB913ECCFA7001726AB /* LibraryDirectory.cpp */; };
@@ -1533,6 +1534,8 @@
 		7C0B98A1154B79C30065A238 /* AEDeviceInfo.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = AEDeviceInfo.cpp; sourceTree = "<group>"; };
 		7C0B98A2154B79C30065A238 /* AEDeviceInfo.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AEDeviceInfo.h; sourceTree = "<group>"; };
 		7C1A495B15A96918004AF4A4 /* SaveFileStateJob.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SaveFileStateJob.h; sourceTree = "<group>"; };
+		7C1A492115A962EE004AF4A4 /* SeekHandler.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SeekHandler.cpp; sourceTree = "<group>"; };
+		7C1A492215A962EE004AF4A4 /* SeekHandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SeekHandler.h; sourceTree = "<group>"; };
 		7C1A85631520522500C63311 /* TextureCacheJob.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TextureCacheJob.cpp; sourceTree = "<group>"; };
 		7C1A85641520522500C63311 /* TextureCacheJob.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TextureCacheJob.h; sourceTree = "<group>"; };
 		7C1D682715A7D2FD00658B65 /* DatabaseManager.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = DatabaseManager.cpp; sourceTree = "<group>"; };
@@ -5898,6 +5901,8 @@
 				E38E1E780D25F9FD00618676 /* ScraperParser.h */,
 				E36C29E70DA72486001F0C9D /* ScraperUrl.cpp */,
 				7CAA25381085971C0096DE39 /* ScraperUrl.h */,
+				7C1A492115A962EE004AF4A4 /* SeekHandler.cpp */,
+				7C1A492215A962EE004AF4A4 /* SeekHandler.h */,
 				36A9443F15821E7C00727135 /* SortUtils.cpp */,
 				36A9444015821E7C00727135 /* SortUtils.h */,
 				E38E1E7F0D25F9FD00618676 /* Splash.cpp */,
@@ -7325,6 +7330,7 @@
 				1DE0443515828F4B005DDB4D /* Exception.cpp in Sources */,
 				36A9464C15AA25FD00727135 /* DirectoryNodeTags.cpp in Sources */,
 				7C1D682915A7D2FD00658B65 /* DatabaseManager.cpp in Sources */,
+				7C1A492315A962EE004AF4A4 /* SeekHandler.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/project/VS2010Express/XBMC.vcxproj
+++ b/project/VS2010Express/XBMC.vcxproj
@@ -1110,6 +1110,7 @@
     <ClCompile Include="..\..\xbmc\utils\RssReader.cpp" />
     <ClCompile Include="..\..\xbmc\utils\ScraperParser.cpp" />
     <ClCompile Include="..\..\xbmc\utils\ScraperUrl.cpp" />
+    <ClCompile Include="..\..\xbmc\utils\SeekHandler.cpp" />
     <ClCompile Include="..\..\xbmc\utils\SortUtils.cpp" />
     <ClCompile Include="..\..\xbmc\utils\Splash.cpp" />
     <ClCompile Include="..\..\xbmc\utils\ssrc.cpp" />
@@ -1906,6 +1907,7 @@
     <ClInclude Include="..\..\xbmc\utils\SaveFileStateJob.h" />
     <ClInclude Include="..\..\xbmc\utils\ScraperParser.h" />
     <ClInclude Include="..\..\xbmc\utils\ScraperUrl.h" />
+    <ClInclude Include="..\..\xbmc\utils\SeekHandler.h" />
     <ClInclude Include="..\..\xbmc\utils\SortUtils.h" />
     <ClInclude Include="..\..\xbmc\utils\Splash.h" />
     <ClInclude Include="..\..\xbmc\utils\ssrc.h" />

--- a/project/VS2010Express/XBMC.vcxproj.filters
+++ b/project/VS2010Express/XBMC.vcxproj.filters
@@ -2581,6 +2581,9 @@
     <ClCompile Include="..\..\xbmc\network\AirTunesServer.cpp">
       <Filter>network</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\xbmc\utils\SeekHandler.cpp">
+      <Filter>utils</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\xbmc\utils\SortUtils.cpp">
       <Filter>utils</Filter>
     </ClCompile>
@@ -5214,6 +5217,9 @@
     </ClInclude>
     <ClInclude Include="..\..\xbmc\network\DllLibShairplay.h">
       <Filter>network</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\xbmc\utils\SeekHandler.h">
+      <Filter>utils</Filter>
     </ClInclude>
     <ClInclude Include="..\..\xbmc\utils\SortUtils.h">
       <Filter>utils</Filter>

--- a/xbmc/Application.h
+++ b/xbmc/Application.h
@@ -62,6 +62,7 @@ namespace MEDIA_DETECT
 #include "windowing/XBMC_events.h"
 #include "threads/Thread.h"
 
+class CSeekHandler;
 class CKaraokeLyricsManager;
 class CInertialScrollingHandler;
 class CApplicationMessenger;
@@ -337,6 +338,12 @@ public:
   bool ToggleDPMS(bool manual);
 
   float GetDimScreenSaverLevel() const;
+
+  /*! \brief Retrieve the applications seek handler.
+   \return a constant pointer to the seek handler.
+   \sa CSeekHandler
+   */
+  const CSeekHandler *GetSeekHandler() const { return m_seekHandler; };
 protected:
   bool LoadSkin(const CStdString& skinID);
   void LoadSkin(const boost::shared_ptr<ADDON::CSkinInfo>& skin);
@@ -436,6 +443,7 @@ protected:
   bool InitDirectoriesWin32();
   void CreateUserDirs();
 
+  CSeekHandler *m_seekHandler;
   CInertialScrollingHandler *m_pInertialScrollingHandler;
   CApplicationMessenger m_applicationMessenger;
 #if defined(HAS_LINUX_NETWORK)

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -20,7 +20,6 @@
  */
 
 #include "system.h"
-#include "dialogs/GUIDialogSeekBar.h"
 #include "windows/GUIMediaWindow.h"
 #include "dialogs/GUIDialogFileBrowser.h"
 #include "settings/GUIDialogContentSettings.h"
@@ -58,6 +57,7 @@
 #include "utils/CPUInfo.h"
 #include "utils/StringUtils.h"
 #include "utils/MathUtils.h"
+#include "utils/SeekHandler.h"
 
 // stuff for current song
 #include "music/tags/MusicInfoTagLoaderFactory.h"
@@ -1731,11 +1731,8 @@ bool CGUIInfoManager::GetInt(int &value, int info, int contextWindow, const CGUI
             value = (int)(g_application.GetCachePercentage());
             break;
           case PLAYER_SEEKBAR:
-            {
-              CGUIDialogSeekBar *seekBar = (CGUIDialogSeekBar*)g_windowManager.GetWindow(WINDOW_DIALOG_SEEK_BAR);
-              value = seekBar ? (int)seekBar->GetPercentage() : 0;
-              break;
-            }
+            value = (int)g_application.GetSeekHandler()->GetPercent();
+            break;
           case PLAYER_CACHELEVEL:
             value = (int)(g_application.m_pPlayer->GetCacheLevel());
             break;
@@ -2128,7 +2125,7 @@ bool CGUIInfoManager::GetBool(int condition1, int contextWindow, const CGUIListI
     break;
     case PLAYER_SEEKBAR:
       {
-        CGUIDialogSeekBar *seekBar = (CGUIDialogSeekBar*)g_windowManager.GetWindow(WINDOW_DIALOG_SEEK_BAR);
+        CGUIDialog *seekBar = (CGUIDialog*)g_windowManager.GetWindow(WINDOW_DIALOG_SEEK_BAR);
         bReturn = seekBar ? seekBar->IsDialogRunning() : false;
       }
     break;
@@ -2736,12 +2733,7 @@ CStdString CGUIInfoManager::GetMultiInfoLabel(const GUIInfo &info, int contextWi
   }
   else if (info.m_info == PLAYER_SEEKTIME)
   {
-    TIME_FORMAT format = (TIME_FORMAT)info.GetData1();
-    if (format == TIME_FORMAT_GUESS && GetTotalPlayTime() >= 3600)
-      format = TIME_FORMAT_HH_MM_SS;
-    CGUIDialogSeekBar *seekBar = (CGUIDialogSeekBar*)g_windowManager.GetWindow(WINDOW_DIALOG_SEEK_BAR);
-    if (seekBar)
-      return seekBar->GetSeekTimeLabel(format);
+    return GetCurrentSeekTime((TIME_FORMAT)info.GetData1());
   }
   else if (info.m_info == PLAYER_SEEKOFFSET)
   {
@@ -3491,6 +3483,14 @@ CStdString CGUIInfoManager::GetCurrentPlayTime(TIME_FORMAT format) const
   if (g_application.IsPlayingAudio() || g_application.IsPlayingVideo())
     return StringUtils::SecondsToTimeString((int)(GetPlayTime()/1000), format);
   return "";
+}
+
+CStdString CGUIInfoManager::GetCurrentSeekTime(TIME_FORMAT format) const
+{
+  if (format == TIME_FORMAT_GUESS && GetTotalPlayTime() >= 3600)
+    format = TIME_FORMAT_HH_MM_SS;
+  float time = GetTotalPlayTime() * g_application.GetSeekHandler()->GetPercent() * 0.01f;
+  return StringUtils::SecondsToTimeString((int)time, format);
 }
 
 int CGUIInfoManager::GetTotalPlayTime() const

--- a/xbmc/GUIInfoManager.h
+++ b/xbmc/GUIInfoManager.h
@@ -651,6 +651,7 @@ public:
 
   int64_t GetPlayTime() const;  // in ms
   CStdString GetCurrentPlayTime(TIME_FORMAT format = TIME_FORMAT_GUESS) const;
+  CStdString GetCurrentSeekTime(TIME_FORMAT format = TIME_FORMAT_GUESS) const;
   int GetPlayTimeRemaining() const;
   int GetTotalPlayTime() const;
   CStdString GetCurrentPlayTimeRemaining(TIME_FORMAT format) const;

--- a/xbmc/dialogs/GUIDialogSeekBar.cpp
+++ b/xbmc/dialogs/GUIDialogSeekBar.cpp
@@ -24,11 +24,7 @@
 #include "GUIUserMessages.h"
 #include "Application.h"
 #include "GUIInfoManager.h"
-#include "utils/TimeUtils.h"
 #include "utils/StringUtils.h"
-
-#define SEEK_BAR_DISPLAY_TIME 2000L
-#define SEEK_BAR_SEEK_TIME     500L
 
 #define POPUP_SEEK_SLIDER       401
 #define POPUP_SEEK_LABEL        402
@@ -36,8 +32,6 @@
 CGUIDialogSeekBar::CGUIDialogSeekBar(void)
     : CGUIDialog(WINDOW_DIALOG_SEEK_BAR, "DialogSeekBar.xml")
 {
-  m_fSeekPercentage = 0.0f;
-  m_bRequireSeek = false;
   m_loadOnDemand = false;    // the application class handles our resources
 }
 
@@ -49,40 +43,7 @@ bool CGUIDialogSeekBar::OnAction(const CAction &action)
 {
   if (action.GetID() == ACTION_ANALOG_SEEK_FORWARD || action.GetID() == ACTION_ANALOG_SEEK_BACK)
   {
-    if (!m_bRequireSeek)
-    { // start of seeking
-
-      if (g_infoManager.GetTotalPlayTime())
-        m_fSeekPercentage = (float)g_infoManager.GetPlayTime() / g_infoManager.GetTotalPlayTime() * 0.1f;
-      else
-        m_fSeekPercentage = 0.0f;
-
-      // tell info manager that we have started a seekbar operation
-      m_bRequireSeek = true;
-      g_infoManager.SetSeeking(true);
-    }
-
-    // calculate our seek amount
-    if (g_application.m_pPlayer && !g_infoManager.m_performingSeek)
-    {
-      //100% over 1 second.
-      float speed = 100.0f;
-      if( action.GetRepeat() )
-        speed *= action.GetRepeat();
-      else
-        speed /= g_infoManager.GetFPS();
-
-      if (action.GetID() == ACTION_ANALOG_SEEK_FORWARD)
-        m_fSeekPercentage += action.GetAmount() * action.GetAmount() * speed;
-      else
-        m_fSeekPercentage -= action.GetAmount() * action.GetAmount() * speed;
-      if (m_fSeekPercentage > 100.0f) m_fSeekPercentage = 100.0f;
-      if (m_fSeekPercentage < 0.0f) m_fSeekPercentage = 0.0f;
-      CGUISliderControl *pSlider = (CGUISliderControl*)GetControl(POPUP_SEEK_SLIDER);
-      if (pSlider) pSlider->SetPercentage((int)m_fSeekPercentage);   // Update our seek bar accordingly
-    }
-
-    ResetTimer();
+    m_handler.Seek(action.GetID() == ACTION_ANALOG_SEEK_FORWARD, action.GetAmount(), action.GetRepeat());
     return true;
   }
   return CGUIDialog::OnAction(action);
@@ -103,21 +64,13 @@ bool CGUIDialogSeekBar::OnMessage(CGUIMessage& message)
     }
     break;
   case GUI_MSG_PLAYBACK_STARTED:
-    { // new song started while our window is up - update our details
-
-      m_bRequireSeek = false;
-      m_fSeekPercentage = 0.0f;
-
+    { // new song started while our window is up - reset our seek handler
+      m_handler.Reset();
     }
     break;
 
   }
   return false; // don't process anything other than what we need!
-}
-
-void CGUIDialogSeekBar::ResetTimer()
-{
-  m_timer = CTimeUtils::GetFrameTime();
 }
 
 void CGUIDialogSeekBar::FrameMove()
@@ -128,12 +81,8 @@ void CGUIDialogSeekBar::FrameMove()
     return;
   }
 
-  // check if we should seek or exit
-  if (!g_infoManager.m_performingSeek && CTimeUtils::GetFrameTime() - m_timer > SEEK_BAR_DISPLAY_TIME)
-    g_infoManager.SetSeeking(false);
-
-  // render our controls
-  if (!m_bRequireSeek && !g_infoManager.m_performingSeek)
+  // update controls
+  if (!m_handler.InProgress() && !g_infoManager.m_performingSeek)
   { // position the bar at our current time
     CGUISliderControl *pSlider = (CGUISliderControl*)GetControl(POPUP_SEEK_SLIDER);
     if (pSlider && g_infoManager.GetTotalPlayTime())
@@ -145,25 +94,24 @@ void CGUIDialogSeekBar::FrameMove()
   }
   else
   {
+    CGUISliderControl *pSlider = (CGUISliderControl*)GetControl(POPUP_SEEK_SLIDER);
+    if (pSlider)
+      pSlider->SetPercentage((int)m_handler.GetPercent());
+
     CGUIMessage msg(GUI_MSG_LABEL_SET, GetID(), POPUP_SEEK_LABEL);
     msg.SetLabel(GetSeekTimeLabel());
     OnMessage(msg);
   }
 
   // Check for seek timeout, and perform the seek
-  if (m_bRequireSeek && CTimeUtils::GetFrameTime() - m_timer > SEEK_BAR_SEEK_TIME)
-  {
-    g_infoManager.m_performingSeek = true;
-    double time = g_infoManager.GetTotalPlayTime() * m_fSeekPercentage * 0.01;
-    g_application.SeekTime(time);
-    m_bRequireSeek = false;
-  }
+  m_handler.Process();
+
   CGUIDialog::FrameMove();
 }
 
 CStdString CGUIDialogSeekBar::GetSeekTimeLabel(TIME_FORMAT format)
 {
-  int time = (int)(g_infoManager.GetTotalPlayTime() * m_fSeekPercentage * 0.01f);
+  int time = (int)(g_infoManager.GetTotalPlayTime() * m_handler.GetPercent() * 0.01f);
   return StringUtils::SecondsToTimeString(time, format);
 }
 

--- a/xbmc/dialogs/GUIDialogSeekBar.h
+++ b/xbmc/dialogs/GUIDialogSeekBar.h
@@ -22,8 +22,6 @@
  */
 
 #include "guilib/GUIDialog.h"
-#include "XBDateTime.h"
-#include "utils/SeekHandler.h"
 
 class CGUIDialogSeekBar : public CGUIDialog
 {
@@ -31,10 +29,5 @@ public:
   CGUIDialogSeekBar(void);
   virtual ~CGUIDialogSeekBar(void);
   virtual bool OnMessage(CGUIMessage& message);
-  virtual bool OnAction(const CAction &action);
   virtual void FrameMove();
-  float GetPercentage() {return m_handler.GetPercent();};
-  CStdString GetSeekTimeLabel(TIME_FORMAT format = TIME_FORMAT_GUESS);
-protected:
-  CSeekHandler m_handler;
 };

--- a/xbmc/utils/Makefile
+++ b/xbmc/utils/Makefile
@@ -46,6 +46,7 @@ SRCS=AlarmClock.cpp \
      RssReader.cpp \
      ScraperParser.cpp \
      ScraperUrl.cpp \
+     SeekHandler.cpp \
      SortUtils.cpp \
      Splash.cpp \
      ssrc.cpp \

--- a/xbmc/utils/SeekHandler.cpp
+++ b/xbmc/utils/SeekHandler.cpp
@@ -1,0 +1,95 @@
+/*
+ *      Copyright (C) 2012 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
+
+#include "SeekHandler.h"
+#include "GUIInfoManager.h"
+#include "Application.h"
+
+CSeekHandler::CSeekHandler()
+: m_requireSeek(false),
+  m_percent(0.0f)
+{
+}
+
+void CSeekHandler::Reset()
+{
+  m_requireSeek = false;
+  m_percent = 0;
+}
+
+void CSeekHandler::Seek(bool forward, float amount, float duration)
+{
+  if (!m_requireSeek)
+  { // not yet seeking
+    if (g_infoManager.GetTotalPlayTime())
+      m_percent = (float)g_infoManager.GetPlayTime() / g_infoManager.GetTotalPlayTime() * 0.1f;
+    else
+      m_percent = 0.0f;
+
+    // tell info manager that we have started a seek operation
+    m_requireSeek = true;
+    g_infoManager.SetSeeking(true);
+  }
+  // calculate our seek amount
+  if (!g_infoManager.m_performingSeek)
+  {
+    //100% over 1 second.
+    float speed = 100.0f;
+    if( duration )
+      speed *= duration;
+    else
+      speed /= g_infoManager.GetFPS();
+
+    if (forward)
+      m_percent += amount * amount * speed;
+    else
+      m_percent -= amount * amount * speed;
+    if (m_percent > 100.0f) m_percent = 100.0f;
+    if (m_percent < 0.0f)   m_percent = 0.0f;
+  }
+  m_timer.StartZero();
+}
+
+float CSeekHandler::GetPercent() const
+{
+  return m_percent;
+}
+
+bool CSeekHandler::InProgress() const
+{
+  return m_requireSeek;
+}
+
+void CSeekHandler::Process()
+{
+  if (m_timer.GetElapsedMilliseconds() > time_before_seek)
+  {
+    if (!g_infoManager.m_performingSeek && m_timer.GetElapsedMilliseconds() > time_for_display) // TODO: Why?
+      g_infoManager.SetSeeking(false);
+    if (m_requireSeek)
+    {
+      g_infoManager.m_performingSeek = true;
+      double time = g_infoManager.GetTotalPlayTime() * m_percent * 0.01;
+      g_application.SeekTime(time);
+      m_requireSeek = false;
+    }
+  }
+}

--- a/xbmc/utils/SeekHandler.h
+++ b/xbmc/utils/SeekHandler.h
@@ -1,7 +1,6 @@
 #pragma once
-
 /*
- *      Copyright (C) 2005-2008 Team XBMC
+ *      Copyright (C) 2012 Team XBMC
  *      http://www.xbmc.org
  *
  *  This Program is free software; you can redistribute it and/or modify
@@ -21,20 +20,23 @@
  *
  */
 
-#include "guilib/GUIDialog.h"
-#include "XBDateTime.h"
-#include "utils/SeekHandler.h"
+#include "utils/Stopwatch.h"
 
-class CGUIDialogSeekBar : public CGUIDialog
+class CSeekHandler
 {
 public:
-  CGUIDialogSeekBar(void);
-  virtual ~CGUIDialogSeekBar(void);
-  virtual bool OnMessage(CGUIMessage& message);
-  virtual bool OnAction(const CAction &action);
-  virtual void FrameMove();
-  float GetPercentage() {return m_handler.GetPercent();};
-  CStdString GetSeekTimeLabel(TIME_FORMAT format = TIME_FORMAT_GUESS);
-protected:
-  CSeekHandler m_handler;
+  CSeekHandler();
+
+  void Seek(bool forward, float amount, float duration = 0);
+  void Process();
+  void Reset();
+
+  float GetPercent() const;
+  bool InProgress() const;
+private:
+  static const int time_before_seek = 500;
+  static const int time_for_display = 2000; // TODO: WTF?
+  bool       m_requireSeek;
+  float      m_percent;
+  CStopWatch m_timer;
 };


### PR DESCRIPTION
This moves seek handling to a separate handler, thus ensuring that analog seeking can be done if the seekbar dialog is on screen.  It fixes #11712.

As a pull req as there's build changes and a bit of reorg - should be a quick review.
