### PR TITLE
Avfilter: Bring xbmc in line with the new avfilter API.

### DIFF
--- a/lib/DllAvFilter.h
+++ b/lib/DllAvFilter.h
@@ -74,7 +74,6 @@ public:
   virtual void avfilter_inout_free(AVFilterInOut **inout)=0;
   virtual int avfilter_graph_parse(AVFilterGraph *graph, const char *filters, AVFilterInOut **inputs, AVFilterInOut **outputs, void *log_ctx)=0;
   virtual int avfilter_graph_config(AVFilterGraph *graphctx, void *log_ctx)=0;
-  virtual int avfilter_poll_frame(AVFilterLink *link)=0;
   virtual int avfilter_request_frame(AVFilterLink *link)=0;
   virtual int av_vsrc_buffer_add_frame(AVFilterContext *buffer_filter, AVFrame *frame, int flags)=0;
   virtual AVFilterBufferRef *avfilter_get_video_buffer(AVFilterLink *link, int perms, int w, int h)=0;
@@ -133,7 +132,6 @@ public:
   {
     return ::avfilter_graph_config(graphctx, log_ctx);
   }
-  virtual int avfilter_poll_frame(AVFilterLink *link) { return ::avfilter_poll_frame(link); }
   virtual int avfilter_request_frame(AVFilterLink *link) { return ::avfilter_request_frame(link); }
   virtual int av_vsrc_buffer_add_frame(AVFilterContext *buffer_filter, AVFrame *frame, int flags) { return ::av_vsrc_buffer_add_frame(buffer_filter, frame, flags); }
   virtual AVFilterBufferRef *avfilter_get_video_buffer(AVFilterLink *link, int perms, int w, int h) { return ::avfilter_get_video_buffer(link, perms, w, h); }
@@ -168,7 +166,6 @@ class DllAvFilter : public DllDynamic, DllAvFilterInterface
   DEFINE_METHOD1(void, avfilter_inout_free_dont_call, (AVFilterInOut **p1))
   DEFINE_FUNC_ALIGNED5(int, __cdecl, avfilter_graph_parse_dont_call, AVFilterGraph *, const char *, AVFilterInOut **, AVFilterInOut **, void *)
   DEFINE_FUNC_ALIGNED2(int, __cdecl, avfilter_graph_config_dont_call, AVFilterGraph *, void *)
-  DEFINE_FUNC_ALIGNED1(int, __cdecl, avfilter_poll_frame, AVFilterLink *)
   DEFINE_FUNC_ALIGNED1(int, __cdecl, avfilter_request_frame, AVFilterLink*)
   DEFINE_METHOD3(int, av_vsrc_buffer_add_frame, (AVFilterContext *p1, AVFrame *p2, int p3))
   DEFINE_METHOD4(AVFilterBufferRef*, avfilter_get_video_buffer, (AVFilterLink *p1, int p2, int p3, int p4))
@@ -190,7 +187,6 @@ class DllAvFilter : public DllDynamic, DllAvFilterInterface
     RESOLVE_METHOD_RENAME(avfilter_inout_free, avfilter_inout_free_dont_call)
     RESOLVE_METHOD_RENAME(avfilter_graph_parse, avfilter_graph_parse_dont_call)
     RESOLVE_METHOD_RENAME(avfilter_graph_config, avfilter_graph_config_dont_call)
-    RESOLVE_METHOD(avfilter_poll_frame)
     RESOLVE_METHOD(avfilter_request_frame)
     RESOLVE_METHOD(av_vsrc_buffer_add_frame)
     RESOLVE_METHOD(avfilter_get_video_buffer)

--- a/lib/DllAvFilter.h
+++ b/lib/DllAvFilter.h
@@ -74,7 +74,11 @@ public:
   virtual void avfilter_inout_free(AVFilterInOut **inout)=0;
   virtual int avfilter_graph_parse(AVFilterGraph *graph, const char *filters, AVFilterInOut **inputs, AVFilterInOut **outputs, void *log_ctx)=0;
   virtual int avfilter_graph_config(AVFilterGraph *graphctx, void *log_ctx)=0;
+#if LIBAVFILTER_VERSION_INT < AV_VERSION_INT(3,0,0)
   virtual int av_vsrc_buffer_add_frame(AVFilterContext *buffer_filter, AVFrame *frame, int flags)=0;
+#else
+  virtual int av_buffersrc_add_frame(AVFilterContext *buffer_filter, AVFrame *frame, int flags)=0;
+#endif
   virtual void avfilter_unref_buffer(AVFilterBufferRef *ref)=0;
   virtual int avfilter_link(AVFilterContext *src, unsigned srcpad, AVFilterContext *dst, unsigned dstpad)=0;
   virtual int av_buffersink_get_buffer_ref(AVFilterContext *buffer_sink, AVFilterBufferRef **bufref, int flags)=0;
@@ -130,7 +134,11 @@ public:
   {
     return ::avfilter_graph_config(graphctx, log_ctx);
   }
+#if LIBAVFILTER_VERSION_INT < AV_VERSION_INT(3,0,0)
   virtual int av_vsrc_buffer_add_frame(AVFilterContext *buffer_filter, AVFrame *frame, int flags) { return ::av_vsrc_buffer_add_frame(buffer_filter, frame, flags); }
+#else
+  virtual int av_buffersrc_add_frame(AVFilterContext *buffer_filter, AVFrame* frame, int flags) { return ::av_buffersrc_add_frame(buffer_filter, frame, flags); }
+#endif
   virtual void avfilter_unref_buffer(AVFilterBufferRef *ref) { ::avfilter_unref_buffer(ref); }
   virtual int avfilter_link(AVFilterContext *src, unsigned srcpad, AVFilterContext *dst, unsigned dstpad) { return ::avfilter_link(src, srcpad, dst, dstpad); }
   virtual int av_buffersink_get_buffer_ref(AVFilterContext *buffer_sink, AVFilterBufferRef **bufref, int flags) { return ::av_buffersink_get_buffer_ref(buffer_sink, bufref, flags); }
@@ -162,7 +170,11 @@ class DllAvFilter : public DllDynamic, DllAvFilterInterface
   DEFINE_METHOD1(void, avfilter_inout_free_dont_call, (AVFilterInOut **p1))
   DEFINE_FUNC_ALIGNED5(int, __cdecl, avfilter_graph_parse_dont_call, AVFilterGraph *, const char *, AVFilterInOut **, AVFilterInOut **, void *)
   DEFINE_FUNC_ALIGNED2(int, __cdecl, avfilter_graph_config_dont_call, AVFilterGraph *, void *)
+#if LIBAVFILTER_VERSION_INT < AV_VERSION_INT(3,0,0)
   DEFINE_METHOD3(int, av_vsrc_buffer_add_frame, (AVFilterContext *p1, AVFrame *p2, int p3))
+#else
+  DEFINE_METHOD3(int, av_buffersrc_add_frame, (AVFilterContext *p1, AVFrame *p2, int p3))
+#endif
   DEFINE_METHOD1(void, avfilter_unref_buffer, (AVFilterBufferRef *p1))
   DEFINE_METHOD4(int, avfilter_link, (AVFilterContext *p1, unsigned p2, AVFilterContext *p3, unsigned p4))
   DEFINE_FUNC_ALIGNED3(int                , __cdecl, av_buffersink_get_buffer_ref, AVFilterContext *, AVFilterBufferRef **, int);
@@ -181,7 +193,11 @@ class DllAvFilter : public DllDynamic, DllAvFilterInterface
     RESOLVE_METHOD_RENAME(avfilter_inout_free, avfilter_inout_free_dont_call)
     RESOLVE_METHOD_RENAME(avfilter_graph_parse, avfilter_graph_parse_dont_call)
     RESOLVE_METHOD_RENAME(avfilter_graph_config, avfilter_graph_config_dont_call)
+#if LIBAVFILTER_VERSION_INT < AV_VERSION_INT(3,0,0)
     RESOLVE_METHOD(av_vsrc_buffer_add_frame)
+#else
+    RESOLVE_METHOD(av_buffersrc_add_frame)
+#endif
     RESOLVE_METHOD(avfilter_unref_buffer)
     RESOLVE_METHOD(avfilter_link)
     RESOLVE_METHOD(av_buffersink_get_buffer_ref)

--- a/lib/DllAvFilter.h
+++ b/lib/DllAvFilter.h
@@ -74,7 +74,6 @@ public:
   virtual void avfilter_inout_free(AVFilterInOut **inout)=0;
   virtual int avfilter_graph_parse(AVFilterGraph *graph, const char *filters, AVFilterInOut **inputs, AVFilterInOut **outputs, void *log_ctx)=0;
   virtual int avfilter_graph_config(AVFilterGraph *graphctx, void *log_ctx)=0;
-  virtual int avfilter_request_frame(AVFilterLink *link)=0;
   virtual int av_vsrc_buffer_add_frame(AVFilterContext *buffer_filter, AVFrame *frame, int flags)=0;
   virtual AVFilterBufferRef *avfilter_get_video_buffer(AVFilterLink *link, int perms, int w, int h)=0;
   virtual void avfilter_unref_buffer(AVFilterBufferRef *ref)=0;
@@ -132,7 +131,6 @@ public:
   {
     return ::avfilter_graph_config(graphctx, log_ctx);
   }
-  virtual int avfilter_request_frame(AVFilterLink *link) { return ::avfilter_request_frame(link); }
   virtual int av_vsrc_buffer_add_frame(AVFilterContext *buffer_filter, AVFrame *frame, int flags) { return ::av_vsrc_buffer_add_frame(buffer_filter, frame, flags); }
   virtual AVFilterBufferRef *avfilter_get_video_buffer(AVFilterLink *link, int perms, int w, int h) { return ::avfilter_get_video_buffer(link, perms, w, h); }
   virtual void avfilter_unref_buffer(AVFilterBufferRef *ref) { ::avfilter_unref_buffer(ref); }
@@ -166,7 +164,6 @@ class DllAvFilter : public DllDynamic, DllAvFilterInterface
   DEFINE_METHOD1(void, avfilter_inout_free_dont_call, (AVFilterInOut **p1))
   DEFINE_FUNC_ALIGNED5(int, __cdecl, avfilter_graph_parse_dont_call, AVFilterGraph *, const char *, AVFilterInOut **, AVFilterInOut **, void *)
   DEFINE_FUNC_ALIGNED2(int, __cdecl, avfilter_graph_config_dont_call, AVFilterGraph *, void *)
-  DEFINE_FUNC_ALIGNED1(int, __cdecl, avfilter_request_frame, AVFilterLink*)
   DEFINE_METHOD3(int, av_vsrc_buffer_add_frame, (AVFilterContext *p1, AVFrame *p2, int p3))
   DEFINE_METHOD4(AVFilterBufferRef*, avfilter_get_video_buffer, (AVFilterLink *p1, int p2, int p3, int p4))
   DEFINE_METHOD1(void, avfilter_unref_buffer, (AVFilterBufferRef *p1))
@@ -187,7 +184,6 @@ class DllAvFilter : public DllDynamic, DllAvFilterInterface
     RESOLVE_METHOD_RENAME(avfilter_inout_free, avfilter_inout_free_dont_call)
     RESOLVE_METHOD_RENAME(avfilter_graph_parse, avfilter_graph_parse_dont_call)
     RESOLVE_METHOD_RENAME(avfilter_graph_config, avfilter_graph_config_dont_call)
-    RESOLVE_METHOD(avfilter_request_frame)
     RESOLVE_METHOD(av_vsrc_buffer_add_frame)
     RESOLVE_METHOD(avfilter_get_video_buffer)
     RESOLVE_METHOD(avfilter_unref_buffer)

--- a/lib/DllAvFilter.h
+++ b/lib/DllAvFilter.h
@@ -75,7 +75,6 @@ public:
   virtual int avfilter_graph_parse(AVFilterGraph *graph, const char *filters, AVFilterInOut **inputs, AVFilterInOut **outputs, void *log_ctx)=0;
   virtual int avfilter_graph_config(AVFilterGraph *graphctx, void *log_ctx)=0;
   virtual int av_vsrc_buffer_add_frame(AVFilterContext *buffer_filter, AVFrame *frame, int flags)=0;
-  virtual AVFilterBufferRef *avfilter_get_video_buffer(AVFilterLink *link, int perms, int w, int h)=0;
   virtual void avfilter_unref_buffer(AVFilterBufferRef *ref)=0;
   virtual int avfilter_link(AVFilterContext *src, unsigned srcpad, AVFilterContext *dst, unsigned dstpad)=0;
   virtual int av_buffersink_get_buffer_ref(AVFilterContext *buffer_sink, AVFilterBufferRef **bufref, int flags)=0;
@@ -132,7 +131,6 @@ public:
     return ::avfilter_graph_config(graphctx, log_ctx);
   }
   virtual int av_vsrc_buffer_add_frame(AVFilterContext *buffer_filter, AVFrame *frame, int flags) { return ::av_vsrc_buffer_add_frame(buffer_filter, frame, flags); }
-  virtual AVFilterBufferRef *avfilter_get_video_buffer(AVFilterLink *link, int perms, int w, int h) { return ::avfilter_get_video_buffer(link, perms, w, h); }
   virtual void avfilter_unref_buffer(AVFilterBufferRef *ref) { ::avfilter_unref_buffer(ref); }
   virtual int avfilter_link(AVFilterContext *src, unsigned srcpad, AVFilterContext *dst, unsigned dstpad) { return ::avfilter_link(src, srcpad, dst, dstpad); }
   virtual int av_buffersink_get_buffer_ref(AVFilterContext *buffer_sink, AVFilterBufferRef **bufref, int flags) { return ::av_buffersink_get_buffer_ref(buffer_sink, bufref, flags); }
@@ -165,7 +163,6 @@ class DllAvFilter : public DllDynamic, DllAvFilterInterface
   DEFINE_FUNC_ALIGNED5(int, __cdecl, avfilter_graph_parse_dont_call, AVFilterGraph *, const char *, AVFilterInOut **, AVFilterInOut **, void *)
   DEFINE_FUNC_ALIGNED2(int, __cdecl, avfilter_graph_config_dont_call, AVFilterGraph *, void *)
   DEFINE_METHOD3(int, av_vsrc_buffer_add_frame, (AVFilterContext *p1, AVFrame *p2, int p3))
-  DEFINE_METHOD4(AVFilterBufferRef*, avfilter_get_video_buffer, (AVFilterLink *p1, int p2, int p3, int p4))
   DEFINE_METHOD1(void, avfilter_unref_buffer, (AVFilterBufferRef *p1))
   DEFINE_METHOD4(int, avfilter_link, (AVFilterContext *p1, unsigned p2, AVFilterContext *p3, unsigned p4))
   DEFINE_FUNC_ALIGNED3(int                , __cdecl, av_buffersink_get_buffer_ref, AVFilterContext *, AVFilterBufferRef **, int);
@@ -185,7 +182,6 @@ class DllAvFilter : public DllDynamic, DllAvFilterInterface
     RESOLVE_METHOD_RENAME(avfilter_graph_parse, avfilter_graph_parse_dont_call)
     RESOLVE_METHOD_RENAME(avfilter_graph_config, avfilter_graph_config_dont_call)
     RESOLVE_METHOD(av_vsrc_buffer_add_frame)
-    RESOLVE_METHOD(avfilter_get_video_buffer)
     RESOLVE_METHOD(avfilter_unref_buffer)
     RESOLVE_METHOD(avfilter_link)
     RESOLVE_METHOD(av_buffersink_get_buffer_ref)

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
@@ -776,10 +776,18 @@ int CDVDVideoCodecFFmpeg::FilterProcess(AVFrame* frame)
 
   if (frame)
   {
+#if LIBAVFILTER_VERSION_INT < AV_VERSION_INT(3,0,0)
     result = m_dllAvFilter.av_vsrc_buffer_add_frame(m_pFilterIn, frame, 0);
+#else
+    result = m_dllAvFilter.av_buffersrc_add_frame(m_pFilterIn, frame, 0);
+#endif
     if (result < 0)
     {
+#if LIBAVFILTER_VERSION_INT < AV_VERSION_INT(3,0,0)
       CLog::Log(LOGERROR, "CDVDVideoCodecFFmpeg::FilterProcess - av_vsrc_buffer_add_frame");
+#else
+      CLog::Log(LOGERROR, "CDVDVideoCodecFFmpeg::FilterProcess - av_buffersrc_add_frame");
+#endif
       return VC_ERROR;
     }
   }

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
@@ -792,7 +792,7 @@ int CDVDVideoCodecFFmpeg::FilterProcess(AVFrame* frame)
 
   if ((frames = m_dllAvFilter.av_buffersink_poll_frame(m_pFilterOut)) < 0)
   {
-    CLog::Log(LOGERROR, "CDVDVideoCodecFFmpeg::FilterProcess - avfilter_poll_frame");
+    CLog::Log(LOGERROR, "CDVDVideoCodecFFmpeg::FilterProcess - av_buffersink_poll_frame");
     return VC_ERROR;
   }
 


### PR DESCRIPTION
These changes remove deprecated (and now removed) functions from the avfilter wrapper and use the new av_buffersrc_add_frame instead of av_vsrc_buffer_add_frame with libavfilter version 3.
This makes xbmc build again against ffmpeg git master.

Those #ifdef for av_buffersrc_add_frame should be removed once the internal ffmpeg version is bumped to the new API, which will most likely be with ffmpeg-0.12. This will make updating to this version of ffmpeg easier.
