### PR TITLE
Fix SystemGlobals.cpp - remove g_Joystick when not needed

### DIFF
--- a/xbmc/SystemGlobals.cpp
+++ b/xbmc/SystemGlobals.cpp
@@ -43,7 +43,7 @@
 #endif
 #if defined(TARGET_WINDOWS)
 #include "input/windows/WINJoystick.h"
-#elif defined(HAS_SDL_JOYSTICK) || defined(HAS_EVENT_SERVER)
+#elif defined(HAS_SDL_JOYSTICK) 
 #include "input/SDLJoystick.h"
 #endif
 
@@ -64,7 +64,7 @@
   CGUITextureManager g_TextureManager;
   CGUILargeTextureManager g_largeTextureManager;
   CMouseStat         g_Mouse;
-#if defined(HAS_SDL_JOYSTICK) || defined(HAS_EVENT_SERVER)
+#if defined(HAS_SDL_JOYSTICK) 
   CJoystick          g_Joystick; 
 #endif
   CGUIPassword       g_passwordManager;


### PR DESCRIPTION
As commented here: https://github.com/xbmc/xbmc/commit/e00733fbdb336fb02aa4a32cc8389abb1b7a210a#commitcomment-1553832 
