### PR TITLE
[gl/renderer] - pass the video orientation down to the gl renderer and...

### DIFF
--- a/xbmc/cores/VideoRenderers/BaseRenderer.cpp
+++ b/xbmc/cores/VideoRenderers/BaseRenderer.cpp
@@ -265,6 +265,16 @@ inline void CBaseRenderer::ReorderDrawPoints()
       changeAspect = true;
       break;
   }
+  
+  // if renderer doesn't support rotation
+  // treat orientation as 0 degree so that
+  // ffmpeg might handle it.
+  if (!Supports(RENDERFEATURE_ROTATION))
+  {
+    pointOffset = 0;
+    changeAspect = false;
+  }
+  
 
   int diff = (m_destRect.Height() - m_destRect.Width()) / 2;
 

--- a/xbmc/cores/VideoRenderers/BaseRenderer.cpp
+++ b/xbmc/cores/VideoRenderers/BaseRenderer.cpp
@@ -38,6 +38,15 @@ CBaseRenderer::CBaseRenderer()
   m_sourceHeight = 480;
   m_resolution = RES_DESKTOP;
   m_fps = 0.0f;
+  m_renderOrientation = 0;
+  m_oldRenderOrientation = 0;
+  m_oldDestRect.SetRect(0.0f, 0.0f, 0.0f, 0.0f);
+
+  for(int i=0; i < 4; i++)
+  {
+    m_rotatedDestCoords[i].x = 0;
+    m_rotatedDestCoords[i].y = 0;    
+  }
 }
 
 CBaseRenderer::~CBaseRenderer()
@@ -232,6 +241,63 @@ void CBaseRenderer::GetVideoRect(CRect &source, CRect &dest)
   dest = m_destRect;
 }
 
+inline void CBaseRenderer::ReorderDrawPoints()
+{
+  // 0 - top left, 1 - top right, 2 - bottom right, 3 - bottom left
+  float origMat[4][2] = {{m_destRect.x1, m_destRect.y1}, 
+                         {m_destRect.x2, m_destRect.y1},
+                         {m_destRect.x2, m_destRect.y2},
+                         {m_destRect.x1, m_destRect.y2}};
+  bool changeAspect = false;
+  int pointOffset = 0;
+
+  switch (m_renderOrientation)
+  {
+    case 90:
+      pointOffset = 1;
+      changeAspect = true;
+      break;
+    case 180:
+      pointOffset = 2;
+      break;
+    case 270:
+      pointOffset = 3;
+      changeAspect = true;
+      break;
+  }
+
+  int diff = (m_destRect.Height() - m_destRect.Width()) / 2;
+
+  for (int destIdx=0, srcIdx=pointOffset; destIdx < 4; destIdx++, srcIdx = ++srcIdx % 4)
+  {
+    m_rotatedDestCoords[destIdx].x = origMat[srcIdx][0];
+    m_rotatedDestCoords[destIdx].y = origMat[srcIdx][1];
+
+    if (changeAspect)
+    {
+      switch (srcIdx)
+      {
+        case 0:
+          m_rotatedDestCoords[destIdx].x -= diff;
+          m_rotatedDestCoords[destIdx].y += diff;
+          break;
+        case 1:
+          m_rotatedDestCoords[destIdx].x += diff;
+          m_rotatedDestCoords[destIdx].y += diff;
+          break;
+        case 2:
+          m_rotatedDestCoords[destIdx].x += diff;
+          m_rotatedDestCoords[destIdx].y -= diff;
+          break;
+        case 3:
+          m_rotatedDestCoords[destIdx].x -= diff;
+          m_rotatedDestCoords[destIdx].y -= diff;
+          break;
+      }
+    }
+  }
+}
+
 void CBaseRenderer::CalcNormalDisplayRect(float offsetX, float offsetY, float screenWidth, float screenHeight, float inputFrameRatio, float zoomAmount, float verticalShift)
 {
   // if view window is empty, set empty destination
@@ -307,6 +373,15 @@ void CBaseRenderer::CalcNormalDisplayRect(float offsetX, float offsetY, float sc
       m_sourceRect.x2 += (m_destRect.x2 - original.x2) * scaleX;
       m_sourceRect.y2 += (m_destRect.y2 - original.y2) * scaleY;
     }
+  }
+
+  if (m_oldDestRect != m_destRect || m_oldRenderOrientation != m_renderOrientation)
+  {
+    // adapt the drawing rect points if we have to rotate
+    // and either destrect or orientation changed
+    ReorderDrawPoints();
+    m_oldDestRect = m_destRect;
+    m_oldRenderOrientation = m_renderOrientation;
   }
 }
 

--- a/xbmc/cores/VideoRenderers/BaseRenderer.h
+++ b/xbmc/cores/VideoRenderers/BaseRenderer.h
@@ -56,7 +56,8 @@ enum ERENDERFEATURE
   RENDERFEATURE_CONTRAST,
   RENDERFEATURE_NOISE,
   RENDERFEATURE_SHARPNESS,
-  RENDERFEATURE_NONLINSTRETCH
+  RENDERFEATURE_NONLINSTRETCH,
+  RENDERFEATURE_ROTATION
 };
 
 struct DVDVideoPicture;
@@ -76,6 +77,8 @@ public:
   virtual void Flush() {};
 
   virtual unsigned int GetProcessorSize() { return 0; }
+
+  virtual bool Supports(ERENDERFEATURE feature) { return false; }
 
   // Supported pixel formats, can be called before configure
   std::vector<ERenderFormat> SupportedFormats()  { return std::vector<ERenderFormat>(); }

--- a/xbmc/cores/VideoRenderers/BaseRenderer.h
+++ b/xbmc/cores/VideoRenderers/BaseRenderer.h
@@ -90,12 +90,22 @@ protected:
   void       CalculateFrameAspectRatio(unsigned int desired_width, unsigned int desired_height);
   void       ManageDisplay();
 
+  virtual void       ReorderDrawPoints();//might be overwritten (by egl e.x.)
+
   RESOLUTION m_resolution;    // the resolution we're running in
   unsigned int m_sourceWidth;
   unsigned int m_sourceHeight;
   float m_sourceFrameRatio;
   float m_fps;
 
+  unsigned int m_renderOrientation; // orientation of the video in degress counter clockwise
+  unsigned int m_oldRenderOrientation; // orientation of the previous frame
+  // for drawing the texture with glVertex4f (holds all 4 corner points of the destination rect
+  // with correct orientation based on m_renderOrientation
+  // 0 - top left, 1 - top right, 2 - bottom right, 3 - bottom left
+  CPoint m_rotatedDestCoords[4];
+
   CRect m_destRect;
+  CRect m_oldDestRect; // destrect of the previous frame
   CRect m_sourceRect;
 };

--- a/xbmc/cores/VideoRenderers/LinuxRendererGL.cpp
+++ b/xbmc/cores/VideoRenderers/LinuxRendererGL.cpp
@@ -3162,6 +3162,9 @@ bool CLinuxRendererGL::Supports(ERENDERFEATURE feature)
       return true;
   }
 
+  if (feature == RENDERFEATURE_ROTATION)
+    return true;
+
   return false;
 }
 

--- a/xbmc/cores/VideoRenderers/LinuxRendererGL.cpp
+++ b/xbmc/cores/VideoRenderers/LinuxRendererGL.cpp
@@ -267,10 +267,11 @@ bool CLinuxRendererGL::ValidateRenderTarget()
   return false;
 }
 
-bool CLinuxRendererGL::Configure(unsigned int width, unsigned int height, unsigned int d_width, unsigned int d_height, float fps, unsigned flags, ERenderFormat format, unsigned extended_format)
+bool CLinuxRendererGL::Configure(unsigned int width, unsigned int height, unsigned int d_width, unsigned int d_height, float fps, unsigned flags, ERenderFormat format, unsigned extended_format, unsigned int orientation)
 {
   m_sourceWidth = width;
   m_sourceHeight = height;
+  m_renderOrientation = orientation;
   m_fps = fps;
 
   // Save the flags.
@@ -698,39 +699,39 @@ void CLinuxRendererGL::DrawBlackBars()
   glBegin(GL_QUADS);
 
   //top quad
-  if (m_destRect.y1 > 0.0)
+  if (m_rotatedDestCoords[0].y > 0.0)
   {
-    glVertex4f(0.0,                          0.0,           0.0, 1.0);
-    glVertex4f(g_graphicsContext.GetWidth(), 0.0,           0.0, 1.0);
-    glVertex4f(g_graphicsContext.GetWidth(), m_destRect.y1, 0.0, 1.0);
-    glVertex4f(0.0,                          m_destRect.y1, 0.0, 1.0);
+    glVertex4f(0.0,                          0.0,                      0.0, 1.0);
+    glVertex4f(g_graphicsContext.GetWidth(), 0.0,                      0.0, 1.0);
+    glVertex4f(g_graphicsContext.GetWidth(), m_rotatedDestCoords[0].y, 0.0, 1.0);
+    glVertex4f(0.0,                          m_rotatedDestCoords[0].y, 0.0, 1.0);
   }
 
   //bottom quad
-  if (m_destRect.y2 < g_graphicsContext.GetHeight())
+  if (m_rotatedDestCoords[2].y < g_graphicsContext.GetHeight())
   {
-    glVertex4f(0.0,                          m_destRect.y2,                 0.0, 1.0);
-    glVertex4f(g_graphicsContext.GetWidth(), m_destRect.y2,                 0.0, 1.0);
+    glVertex4f(0.0,                          m_rotatedDestCoords[2].y,      0.0, 1.0);
+    glVertex4f(g_graphicsContext.GetWidth(), m_rotatedDestCoords[2].y,      0.0, 1.0);
     glVertex4f(g_graphicsContext.GetWidth(), g_graphicsContext.GetHeight(), 0.0, 1.0);
     glVertex4f(0.0,                          g_graphicsContext.GetHeight(), 0.0, 1.0);
   }
 
   //left quad
-  if (m_destRect.x1 > 0.0)
+  if (m_rotatedDestCoords[0].x > 0.0)
   {
-    glVertex4f(0.0,           m_destRect.y1, 0.0, 1.0);
-    glVertex4f(m_destRect.x1, m_destRect.y1, 0.0, 1.0);
-    glVertex4f(m_destRect.x1, m_destRect.y2, 0.0, 1.0);
-    glVertex4f(0.0,           m_destRect.y2, 0.0, 1.0);
+    glVertex4f(0.0,                      m_rotatedDestCoords[0].y, 0.0, 1.0);
+    glVertex4f(m_rotatedDestCoords[0].x, m_rotatedDestCoords[0].y, 0.0, 1.0);
+    glVertex4f(m_rotatedDestCoords[0].x, m_rotatedDestCoords[2].y, 0.0, 1.0);
+    glVertex4f(0.0,                      m_rotatedDestCoords[2].y, 0.0, 1.0);
   }
 
   //right quad
-  if (m_destRect.x2 < g_graphicsContext.GetWidth())
+  if (m_rotatedDestCoords[2].x < g_graphicsContext.GetWidth())
   {
-    glVertex4f(m_destRect.x2,                 m_destRect.y1, 0.0, 1.0);
-    glVertex4f(g_graphicsContext.GetWidth(),  m_destRect.y1, 0.0, 1.0);
-    glVertex4f(g_graphicsContext.GetWidth(),  m_destRect.y2, 0.0, 1.0);
-    glVertex4f(m_destRect.x2,                 m_destRect.y2, 0.0, 1.0);
+    glVertex4f(m_rotatedDestCoords[2].x,     m_rotatedDestCoords[0].y, 0.0, 1.0);
+    glVertex4f(g_graphicsContext.GetWidth(), m_rotatedDestCoords[0].y, 0.0, 1.0);
+    glVertex4f(g_graphicsContext.GetWidth(), m_rotatedDestCoords[2].y, 0.0, 1.0);
+    glVertex4f(m_rotatedDestCoords[2].x,     m_rotatedDestCoords[2].y, 0.0, 1.0);
   }
 
   glEnd();
@@ -1258,22 +1259,22 @@ void CLinuxRendererGL::RenderSinglePass(int index, int field)
   glMultiTexCoord2fARB(GL_TEXTURE0, planes[0].rect.x1, planes[0].rect.y1);
   glMultiTexCoord2fARB(GL_TEXTURE1, planes[1].rect.x1, planes[1].rect.y1);
   glMultiTexCoord2fARB(GL_TEXTURE2, planes[2].rect.x1, planes[2].rect.y1);
-  glVertex4f(m_destRect.x1, m_destRect.y1, 0, 1.0f );
+  glVertex4f(m_rotatedDestCoords[0].x, m_rotatedDestCoords[0].y, 0, 1.0f );//top left
 
   glMultiTexCoord2fARB(GL_TEXTURE0, planes[0].rect.x2, planes[0].rect.y1);
   glMultiTexCoord2fARB(GL_TEXTURE1, planes[1].rect.x2, planes[1].rect.y1);
   glMultiTexCoord2fARB(GL_TEXTURE2, planes[2].rect.x2, planes[2].rect.y1);
-  glVertex4f(m_destRect.x2, m_destRect.y1, 0, 1.0f);
+  glVertex4f(m_rotatedDestCoords[1].x, m_rotatedDestCoords[1].y, 0, 1.0f );//top right
 
   glMultiTexCoord2fARB(GL_TEXTURE0, planes[0].rect.x2, planes[0].rect.y2);
   glMultiTexCoord2fARB(GL_TEXTURE1, planes[1].rect.x2, planes[1].rect.y2);
   glMultiTexCoord2fARB(GL_TEXTURE2, planes[2].rect.x2, planes[2].rect.y2);
-  glVertex4f(m_destRect.x2, m_destRect.y2, 0, 1.0f);
+  glVertex4f(m_rotatedDestCoords[2].x, m_rotatedDestCoords[2].y, 0, 1.0f );//bottom right
 
   glMultiTexCoord2fARB(GL_TEXTURE0, planes[0].rect.x1, planes[0].rect.y2);
   glMultiTexCoord2fARB(GL_TEXTURE1, planes[1].rect.x1, planes[1].rect.y2);
   glMultiTexCoord2fARB(GL_TEXTURE2, planes[2].rect.x1, planes[2].rect.y2);
-  glVertex4f(m_destRect.x1, m_destRect.y2, 0, 1.0f);
+  glVertex4f(m_rotatedDestCoords[3].x, m_rotatedDestCoords[3].y, 0, 1.0f );//bottom left
 
   glEnd();
   VerifyGLState();
@@ -1471,16 +1472,16 @@ void CLinuxRendererGL::RenderMultiPass(int index, int field)
   glBegin(GL_QUADS);
 
   glMultiTexCoord2fARB(GL_TEXTURE0, 0.0f    , 0.0f);
-  glVertex4f(m_destRect.x1, m_destRect.y1, 0, 1.0f );
+  glVertex4f(m_rotatedDestCoords[0].x, m_rotatedDestCoords[0].y, 0, 1.0f );
 
   glMultiTexCoord2fARB(GL_TEXTURE0, imgwidth, 0.0f);
-  glVertex4f(m_destRect.x2, m_destRect.y1, 0, 1.0f);
+  glVertex4f(m_rotatedDestCoords[1].x, m_rotatedDestCoords[1].y, 0, 1.0f );
 
   glMultiTexCoord2fARB(GL_TEXTURE0, imgwidth, imgheight);
-  glVertex4f(m_destRect.x2, m_destRect.y2, 0, 1.0f);
-
+  glVertex4f(m_rotatedDestCoords[2].x, m_rotatedDestCoords[2].y, 0, 1.0f );
+  
   glMultiTexCoord2fARB(GL_TEXTURE0, 0.0f    , imgheight);
-  glVertex4f(m_destRect.x1, m_destRect.y2, 0, 1.0f);
+  glVertex4f(m_rotatedDestCoords[3].x, m_rotatedDestCoords[3].y, 0, 1.0f );
 
   glEnd();
 
@@ -1548,17 +1549,17 @@ void CLinuxRendererGL::RenderVDPAU(int index, int field)
   glBegin(GL_QUADS);
   if (m_textureTarget==GL_TEXTURE_2D)
   {
-    glTexCoord2f(0.0, 0.0);  glVertex2f(m_destRect.x1, m_destRect.y1);
-    glTexCoord2f(1.0, 0.0);  glVertex2f(m_destRect.x2, m_destRect.y1);
-    glTexCoord2f(1.0, 1.0);  glVertex2f(m_destRect.x2, m_destRect.y2);
-    glTexCoord2f(0.0, 1.0);  glVertex2f(m_destRect.x1, m_destRect.y2);
+    glTexCoord2f(0.0, 0.0);  glVertex2f(m_rotatedDestCoords[0].x, m_rotatedDestCoords[0].y);
+    glTexCoord2f(1.0, 0.0);  glVertex2f(m_rotatedDestCoords[1].x, m_rotatedDestCoords[1].y);
+    glTexCoord2f(1.0, 1.0);  glVertex2f(m_rotatedDestCoords[2].x, m_rotatedDestCoords[2].y);
+    glTexCoord2f(0.0, 1.0);  glVertex2f(m_rotatedDestCoords[3].x, m_rotatedDestCoords[3].y);
   }
   else
   {
-    glTexCoord2f(m_destRect.x1, m_destRect.y1); glVertex4f(m_destRect.x1, m_destRect.y1, 0.0f, 0.0f);
-    glTexCoord2f(m_destRect.x2, m_destRect.y1); glVertex4f(m_destRect.x2, m_destRect.y1, 1.0f, 0.0f);
-    glTexCoord2f(m_destRect.x2, m_destRect.y2); glVertex4f(m_destRect.x2, m_destRect.y2, 1.0f, 1.0f);
-    glTexCoord2f(m_destRect.x1, m_destRect.y2); glVertex4f(m_destRect.x1, m_destRect.y2, 0.0f, 1.0f);
+    glTexCoord2f(m_rotatedDestCoords[0].x, m_rotatedDestCoords[0].y); glVertex4f(m_rotatedDestCoords[0].x, m_rotatedDestCoords[0].y, 0.0f, 0.0f);
+    glTexCoord2f(m_rotatedDestCoords[1].x, m_rotatedDestCoords[1].y); glVertex4f(m_rotatedDestCoords[1].x, m_rotatedDestCoords[1].y, 1.0f, 0.0f);
+    glTexCoord2f(m_rotatedDestCoords[2].x, m_rotatedDestCoords[2].y); glVertex4f(m_rotatedDestCoords[2].x, m_rotatedDestCoords[2].y, 1.0f, 1.0f);
+    glTexCoord2f(m_rotatedDestCoords[3].x, m_rotatedDestCoords[3].y); glVertex4f(m_rotatedDestCoords[3].x, m_rotatedDestCoords[3].y, 0.0f, 1.0f);
   }
   glEnd();
   VerifyGLState();
@@ -1637,10 +1638,10 @@ void CLinuxRendererGL::RenderVAAPI(int index, int field)
   VerifyGLState();
 
   glBegin(GL_QUADS);
-  glTexCoord2f(0.0, 0.0);  glVertex2f(m_destRect.x1, m_destRect.y1);
-  glTexCoord2f(1.0, 0.0);  glVertex2f(m_destRect.x2, m_destRect.y1);
-  glTexCoord2f(1.0, 1.0);  glVertex2f(m_destRect.x2, m_destRect.y2);
-  glTexCoord2f(0.0, 1.0);  glVertex2f(m_destRect.x1, m_destRect.y2);
+  glTexCoord2f(0.0, 0.0);  glVertex2f(m_rotatedDestCoords[0].x, m_rotatedDestCoords[0].y);
+  glTexCoord2f(1.0, 0.0);  glVertex2f(m_rotatedDestCoords[1].x, m_rotatedDestCoords[1].y);
+  glTexCoord2f(1.0, 1.0);  glVertex2f(m_rotatedDestCoords[2].x, m_rotatedDestCoords[2].y);
+  glTexCoord2f(0.0, 1.0);  glVertex2f(m_rotatedDestCoords[3].x, m_rotatedDestCoords[3].y);
   glEnd();
 
   VerifyGLState();
@@ -1676,16 +1677,16 @@ void CLinuxRendererGL::RenderSoftware(int index, int field)
 
   glBegin(GL_QUADS);
   glTexCoord2f(planes[0].rect.x1, planes[0].rect.y1);
-  glVertex4f(m_destRect.x1, m_destRect.y1, 0, 1.0f );
+  glVertex4f(m_rotatedDestCoords[0].x, m_rotatedDestCoords[0].y, 0, 1.0f );
 
   glTexCoord2f(planes[0].rect.x2, planes[0].rect.y1);
-  glVertex4f(m_destRect.x2, m_destRect.y1, 0, 1.0f);
+  glVertex4f(m_rotatedDestCoords[1].x, m_rotatedDestCoords[1].y, 0, 1.0f);
 
   glTexCoord2f(planes[0].rect.x2, planes[0].rect.y2);
-  glVertex4f(m_destRect.x2, m_destRect.y2, 0, 1.0f);
+  glVertex4f(m_rotatedDestCoords[2].x, m_rotatedDestCoords[2].y, 0, 1.0f);
 
   glTexCoord2f(planes[0].rect.x1, planes[0].rect.y2);
-  glVertex4f(m_destRect.x1, m_destRect.y2, 0, 1.0f);
+  glVertex4f(m_rotatedDestCoords[3].x, m_rotatedDestCoords[3].y, 0, 1.0f);
 
   glEnd();
 
@@ -2838,6 +2839,7 @@ void CLinuxRendererGL::ToRGBFrame(YV12Image* im, unsigned flipIndexPlane, unsign
                                                  im->width, im->height, srcFormat,
                                                  im->width, im->height, PIX_FMT_BGRA,
                                                  SWS_FAST_BILINEAR | SwScaleCPUFlags(), NULL, NULL, NULL);
+
   uint8_t *dst[]       = { m_rgbBuffer, 0, 0, 0 };
   int      dstStride[] = { m_sourceWidth * 4, 0, 0, 0 };
   m_dllSwScale->sws_scale(m_context, src, srcStride, 0, im->height, dst, dstStride);

--- a/xbmc/cores/VideoRenderers/LinuxRendererGL.h
+++ b/xbmc/cores/VideoRenderers/LinuxRendererGL.h
@@ -130,7 +130,7 @@ public:
   bool RenderCapture(CRenderCapture* capture);
 
   // Player functions
-  virtual bool Configure(unsigned int width, unsigned int height, unsigned int d_width, unsigned int d_height, float fps, unsigned flags, ERenderFormat format, unsigned extended_format);
+  virtual bool Configure(unsigned int width, unsigned int height, unsigned int d_width, unsigned int d_height, float fps, unsigned flags, ERenderFormat format, unsigned extended_formatl, unsigned int orientation);
   virtual bool IsConfigured() { return m_bConfigured; }
   virtual int          GetImage(YV12Image *image, int source = AUTOSOURCE, bool readonly = false);
   virtual void         ReleaseImage(int source, bool preserve = false);
@@ -235,7 +235,7 @@ protected:
   unsigned short m_renderMethod;
   RenderQuality m_renderQuality;
   unsigned int m_flipindex; // just a counter to keep track of if a image has been uploaded
-
+  
   // Raw data used by renderer
   int m_currentField;
   int m_reloadShaders;

--- a/xbmc/cores/VideoRenderers/LinuxRendererGLES.cpp
+++ b/xbmc/cores/VideoRenderers/LinuxRendererGLES.cpp
@@ -1821,6 +1821,9 @@ bool CLinuxRendererGLES::Supports(ERENDERFEATURE feature)
   if (feature == RENDERFEATURE_NONLINSTRETCH)
     return false;
 
+  if (feature == RENDERFEATURE_ROTATION)
+    return true;
+
   return false;
 }
 

--- a/xbmc/cores/VideoRenderers/LinuxRendererGLES.h
+++ b/xbmc/cores/VideoRenderers/LinuxRendererGLES.h
@@ -129,7 +129,7 @@ public:
   bool RenderCapture(CRenderCapture* capture);
 
   // Player functions
-  virtual bool Configure(unsigned int width, unsigned int height, unsigned int d_width, unsigned int d_height, float fps, unsigned flags, ERenderFormat format, unsigned extended_format);
+  virtual bool Configure(unsigned int width, unsigned int height, unsigned int d_width, unsigned int d_height, float fps, unsigned flags, ERenderFormat format, unsigned extended_formatunsigned, unsigned int orientation);
   virtual bool IsConfigured() { return m_bConfigured; }
   virtual int          GetImage(YV12Image *image, int source = AUTOSOURCE, bool readonly = false);
   virtual void         ReleaseImage(int source, bool preserve = false);
@@ -137,6 +137,7 @@ public:
   virtual unsigned int PreInit();
   virtual void         UnInit();
   virtual void         Reset(); /* resets renderer after seek for example */
+  virtual void         ReorderDrawPoints();
 
   virtual void RenderUpdate(bool clear, DWORD flags = 0, DWORD alpha = 255);
 

--- a/xbmc/cores/VideoRenderers/RenderManager.cpp
+++ b/xbmc/cores/VideoRenderers/RenderManager.cpp
@@ -228,7 +228,7 @@ CStdString CXBMCRenderManager::GetVSyncState()
   return state;
 }
 
-bool CXBMCRenderManager::Configure(unsigned int width, unsigned int height, unsigned int d_width, unsigned int d_height, float fps, unsigned flags, ERenderFormat format, unsigned extended_format)
+bool CXBMCRenderManager::Configure(unsigned int width, unsigned int height, unsigned int d_width, unsigned int d_height, float fps, unsigned flags, ERenderFormat format, unsigned extended_format, unsigned int orientation)
 {
   /* make sure any queued frame was fully presented */
   double timeout = m_presenttime + 0.1;
@@ -248,7 +248,7 @@ bool CXBMCRenderManager::Configure(unsigned int width, unsigned int height, unsi
     return false;
   }
 
-  bool result = m_pRenderer->Configure(width, height, d_width, d_height, fps, flags, format, extended_format);
+  bool result = m_pRenderer->Configure(width, height, d_width, d_height, fps, flags, format, extended_format, orientation);
   if(result)
   {
     if( flags & CONF_FLAGS_FULLSCREEN )

--- a/xbmc/cores/VideoRenderers/RenderManager.h
+++ b/xbmc/cores/VideoRenderers/RenderManager.h
@@ -66,7 +66,7 @@ public:
   void SetViewMode(int iViewMode);
 
   // Functions called from mplayer
-  bool Configure(unsigned int width, unsigned int height, unsigned int d_width, unsigned int d_height, float fps, unsigned flags, ERenderFormat format, unsigned extended_format);
+  bool Configure(unsigned int width, unsigned int height, unsigned int d_width, unsigned int d_height, float fps, unsigned flags, ERenderFormat format, unsigned extended_format,  unsigned int orientation);
   bool IsConfigured();
 
   int AddVideoPicture(DVDVideoPicture& picture);

--- a/xbmc/cores/VideoRenderers/VideoShaders/WinVideoFilter.h
+++ b/xbmc/cores/VideoRenderers/VideoShaders/WinVideoFilter.h
@@ -70,7 +70,7 @@ class CYUV2RGBShader : public CWinShader
 public:
   virtual bool Create(unsigned int sourceWidth, unsigned int sourceHeight, ERenderFormat fmt);
   virtual void Render(CRect sourceRect,
-                      CRect destRect,
+                      CPoint destPoints[4],
                       float contrast,
                       float brightness,
                       unsigned int flags,
@@ -79,7 +79,7 @@ public:
 
 protected:
   virtual void PrepareParameters(CRect sourceRect,
-                                 CRect destRect,
+                                 CPoint destPoints[4],
                                  float contrast,
                                  float brightness,
                                  unsigned int flags);
@@ -111,7 +111,7 @@ public:
                                unsigned int sourceWidth, unsigned int sourceHeight,
                                unsigned int destWidth, unsigned int destHeight,
                                CRect sourceRect,
-                               CRect destRect) = 0;
+                               CPoint destPoints[4]) = 0;
   virtual ~CConvolutionShader();
 
 protected:
@@ -138,12 +138,12 @@ public:
                                unsigned int sourceWidth, unsigned int sourceHeight,
                                unsigned int destWidth, unsigned int destHeight,
                                CRect sourceRect,
-                               CRect destRect);
+                               CPoint destPoints[4]);
 
 protected:
   virtual void PrepareParameters(unsigned int sourceWidth, unsigned int sourceHeight,
                                CRect sourceRect,
-                               CRect destRect);
+                               CPoint destPoints[4]);
   virtual void SetShaderParameters(CD3DTexture &sourceTexture, float* texSteps, int texStepsCount);
 
 
@@ -161,7 +161,7 @@ public:
                                unsigned int sourceWidth, unsigned int sourceHeight,
                                unsigned int destWidth, unsigned int destHeight,
                                CRect sourceRect,
-                               CRect destRect);
+                               CPoint destPoints[4]);
   virtual ~CConvolutionShaderSeparable();
 
 protected:
@@ -171,7 +171,7 @@ protected:
   virtual void PrepareParameters(unsigned int sourceWidth, unsigned int sourceHeight,
                                unsigned int destWidth, unsigned int destHeight,
                                CRect sourceRect,
-                               CRect destRect);
+                               CPoint destPoints[4]);
   virtual void SetShaderParameters(CD3DTexture &sourceTexture, float* texSteps1, int texStepsCount1, float* texSteps2, int texStepsCount2);
 
 private:

--- a/xbmc/cores/VideoRenderers/WinRenderer.cpp
+++ b/xbmc/cores/VideoRenderers/WinRenderer.cpp
@@ -1034,6 +1034,12 @@ bool CWinRenderer::Supports(ERENDERFEATURE feature)
   if(feature == RENDERFEATURE_CONTRAST)
     return true;
 
+  if(feature == RENDERFEATURE_ROTATION)
+  {
+    if (m_renderMethod != RENDER_DXVA)
+      return true;
+  }
+
   return false;
 }
 

--- a/xbmc/cores/VideoRenderers/WinRenderer.cpp
+++ b/xbmc/cores/VideoRenderers/WinRenderer.cpp
@@ -211,7 +211,7 @@ bool CWinRenderer::UpdateRenderMethod()
   return true;
 }
 
-bool CWinRenderer::Configure(unsigned int width, unsigned int height, unsigned int d_width, unsigned int d_height, float fps, unsigned flags, ERenderFormat format, unsigned extended_format)
+bool CWinRenderer::Configure(unsigned int width, unsigned int height, unsigned int d_width, unsigned int d_height, float fps, unsigned flags, ERenderFormat format, unsigned extended_format, unsigned int orientation)
 {
   if(m_sourceWidth  != width
   || m_sourceHeight != height)
@@ -225,6 +225,7 @@ bool CWinRenderer::Configure(unsigned int width, unsigned int height, unsigned i
     m_bFilterInitialized = false;
   }
 
+  m_renderOrientation = orientation;
   m_fps = fps;
   m_flags = flags;
   m_format = format;
@@ -780,10 +781,10 @@ void CWinRenderer::ScaleFixedPipeline()
 
   VERTEX vertex[] =
   {
-    {m_destRect.x1, m_destRect.y1, 0.0f, 1.0f, diffuse, specular, m_sourceRect.x1 / srcWidth, m_sourceRect.y1 / srcHeight},
-    {m_destRect.x2, m_destRect.y1, 0.0f, 1.0f, diffuse, specular, m_sourceRect.x2 / srcWidth, m_sourceRect.y1 / srcHeight},
-    {m_destRect.x2, m_destRect.y2, 0.0f, 1.0f, diffuse, specular, m_sourceRect.x2 / srcWidth, m_sourceRect.y2 / srcHeight},
-    {m_destRect.x1, m_destRect.y2, 0.0f, 1.0f, diffuse, specular, m_sourceRect.x1 / srcWidth, m_sourceRect.y2 / srcHeight},
+    {m_rotatedDestCoords[0].x, m_rotatedDestCoords[0].y, 0.0f, 1.0f, diffuse, specular, m_sourceRect.x1 / srcWidth, m_sourceRect.y1 / srcHeight},
+    {m_rotatedDestCoords[1].x, m_rotatedDestCoords[1].y, 0.0f, 1.0f, diffuse, specular, m_sourceRect.x2 / srcWidth, m_sourceRect.y1 / srcHeight},
+    {m_rotatedDestCoords[2].x, m_rotatedDestCoords[2].y, 0.0f, 1.0f, diffuse, specular, m_sourceRect.x2 / srcWidth, m_sourceRect.y2 / srcHeight},
+    {m_rotatedDestCoords[3].x, m_rotatedDestCoords[3].y, 0.0f, 1.0f, diffuse, specular, m_sourceRect.x1 / srcWidth, m_sourceRect.y2 / srcHeight},
   };
 
   // Compensate for D3D coordinates system
@@ -861,7 +862,7 @@ void CWinRenderer::Stage1()
 {
   if (!m_bUseHQScaler)
   {
-      m_colorShader->Render(m_sourceRect, m_destRect,
+      m_colorShader->Render(m_sourceRect, m_rotatedDestCoords,
                             g_settings.m_currentVideoSettings.m_Contrast,
                             g_settings.m_currentVideoSettings.m_Brightness,
                             m_flags,
@@ -879,7 +880,7 @@ void CWinRenderer::Stage1()
     CRect srcRect(0.0f, 0.0f, m_sourceWidth, m_sourceHeight);
     CRect rtRect(0.0f, 0.0f, m_sourceWidth, m_sourceHeight);
 
-    m_colorShader->Render(srcRect, rtRect,
+    m_colorShader->Render(srcRect, m_rotatedDestCoords,
                           g_settings.m_currentVideoSettings.m_Contrast,
                           g_settings.m_currentVideoSettings.m_Brightness,
                           m_flags,
@@ -895,7 +896,7 @@ void CWinRenderer::Stage1()
 
 void CWinRenderer::Stage2()
 {
-  m_scalerShader->Render(m_IntermediateTarget, m_sourceWidth, m_sourceHeight, m_destWidth, m_destHeight, m_sourceRect, m_destRect);
+  m_scalerShader->Render(m_IntermediateTarget, m_sourceWidth, m_sourceHeight, m_destWidth, m_destHeight, m_sourceRect, m_rotatedDestCoords);
 }
 
 void CWinRenderer::RenderProcessor(DWORD flags)

--- a/xbmc/cores/VideoRenderers/WinRenderer.h
+++ b/xbmc/cores/VideoRenderers/WinRenderer.h
@@ -155,7 +155,7 @@ public:
   bool RenderCapture(CRenderCapture* capture);
 
   // Player functions
-  virtual bool         Configure(unsigned int width, unsigned int height, unsigned int d_width, unsigned int d_height, float fps, unsigned flags, ERenderFormat format, unsigned extended_format);
+  virtual bool         Configure(unsigned int width, unsigned int height, unsigned int d_width, unsigned int d_height, float fps, unsigned flags, ERenderFormat format, unsigned extended_format, unsigned int orientation);
   virtual int          GetImage(YV12Image *image, int source = AUTOSOURCE, bool readonly = false);
   virtual void         ReleaseImage(int source, bool preserve = false);
   virtual bool         AddVideoPicture(DVDVideoPicture* picture);

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodec.h
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodec.h
@@ -214,6 +214,7 @@ public:
     FILTER_DEINTERLACE_ANY     =  0xf,  /* use any deinterlace mode */
     FILTER_DEINTERLACE_FLAGGED = 0x10,  /* only deinterlace flagged frames */
     FILTER_DEINTERLACE_HALFED  = 0x20,  /* do half rate deinterlacing */
+    FILTER_ROTATE              = 0x40,  /* rotate image according to the codec hints */
   };
 
   /*

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
@@ -366,6 +366,24 @@ unsigned int CDVDVideoCodecFFmpeg::SetFilters(unsigned int flags)
   if(m_pHardware)
     return 0;
 
+  if(flags & FILTER_ROTATE)
+  {
+    switch(m_iOrientation)
+    {
+      case 90:
+        m_filters_next += "transpose=1";
+        break;
+      case 180:
+        m_filters_next += "vflip,hflip";
+        break;
+      case 270:  
+        m_filters_next += "transpose=2";
+        break;
+      default:
+        break;
+      }
+  }
+
   if(flags & FILTER_DEINTERLACE_YADIF)
   {
     if(flags & FILTER_DEINTERLACE_HALFED)

--- a/xbmc/cores/dvdplayer/DVDPlayerVideo.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayerVideo.cpp
@@ -526,6 +526,9 @@ void CDVDPlayerVideo::Process()
         if (mDeintMode == VS_DEINTERLACEMODE_AUTO && mFilters)
           mFilters |=  CDVDVideoCodec::FILTER_DEINTERLACE_FLAGGED;
       }
+      
+      if (!g_renderManager.Supports(RENDERFEATURE_ROTATION))
+        mFilters |= CDVDVideoCodec::FILTER_ROTATE;
 
       mFilters = m_pVideoCodec->SetFilters(mFilters);
 

--- a/xbmc/cores/dvdplayer/DVDPlayerVideo.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayerVideo.cpp
@@ -1120,7 +1120,7 @@ int CDVDPlayerVideo::OutputPicture(const DVDVideoPicture* src, double pts)
     }
 
     CLog::Log(LOGDEBUG,"%s - change configuration. %dx%d. framerate: %4.2f. format: %s",__FUNCTION__,pPicture->iWidth, pPicture->iHeight, config_framerate, formatstr.c_str());
-    if(!g_renderManager.Configure(pPicture->iWidth, pPicture->iHeight, pPicture->iDisplayWidth, pPicture->iDisplayHeight, config_framerate, flags, pPicture->format, pPicture->extended_format))
+    if(!g_renderManager.Configure(pPicture->iWidth, pPicture->iHeight, pPicture->iDisplayWidth, pPicture->iDisplayHeight, config_framerate, flags, pPicture->format, pPicture->extended_format, m_hints.orientation))
     {
       CLog::Log(LOGERROR, "%s - failed to configure renderer", __FUNCTION__);
       return EOS_ABORT;


### PR DESCRIPTION
...rotate the video texture accordingly.

This is not complete. Its for getting some feedback from more experienced devs. Its ment to finally close the trac ticket http://trac.xbmc.org/ticket/12231
1. This only implements rotation for OpenGL - i know. But i'm unsure if everything is right here. It crashs when using the Software Renderer (during libswscale) - i have no clue why this could happen.
2. I didn't get the knot out of my brain for reordering the points for GLES - there we use triangles and i just have not a freaken idea how to handle it correctly there.
3. All the GL HW Renderers are adapted blindly.

All in all i'm more then unsure with this stuff and hope someone can guide me.
