### PR TITLE
RAR backport fixes for Eden

### DIFF
--- a/lib/UnrarXLib/extract.cpp
+++ b/lib/UnrarXLib/extract.cpp
@@ -863,10 +863,7 @@ void CmdExtract::UnstoreFile(ComprDataIO &DataIO,Int64 DestUnpSize)
       }
       if (Code > 0)
       {
-        Code=Code<DestUnpSize ? Code:int64to32(DestUnpSize);
         DataIO.UnpWrite(&Buffer[0],Code);
-        if (DestUnpSize>=0)
-          DestUnpSize-=Code;
       }
       else 
       {

--- a/lib/UnrarXLib/volume.cpp
+++ b/lib/UnrarXLib/volume.cpp
@@ -15,6 +15,7 @@ bool MergeArchive(Archive &Arc,ComprDataIO *DataIO,bool ShowFileName,char Comman
     Log(Arc.FileName,St(MDataBadCRC),hd->FileName,Arc.FileName);
   }
 
+  Int64 PrevFullUnpSize = hd->FullUnpSize;
   Int64 PosBeforeClose=Arc.Tell();
   Arc.Close();
 
@@ -144,6 +145,13 @@ bool MergeArchive(Archive &Arc,ComprDataIO *DataIO,bool ShowFileName,char Comman
     }
   }
 #endif
+
+  if (hd->FullUnpSize == 0)
+  {
+    // some archives only have correct UnpSize in the first volume
+    hd->FullUnpSize = PrevFullUnpSize;
+  }
+
   if (DataIO!=NULL)
   {
     if (HeaderType==ENDARC_HEAD)

--- a/xbmc/filesystem/FileRar.cpp
+++ b/xbmc/filesystem/FileRar.cpp
@@ -310,6 +310,14 @@ unsigned int CFileRar::Read(void *lpBuf, int64_t uiBufSize)
 
     m_iDataInBuffer = MAXWINMEMSIZE-m_pExtract->GetDataIO().UnpackToMemorySize;
 
+    if (m_iDataInBuffer < 0 ||
+        m_iDataInBuffer > MAXWINMEMSIZE - (m_szStartOfBuffer - m_szBuffer))
+    {
+      // invalid data returned by UnrarXLib, prevent a crash
+      CLog::Log(LOGERROR, "CRarFile::Read - Data buffer in inconsistent state");
+      m_iDataInBuffer = 0;
+    }
+
     if (m_iDataInBuffer == 0)
       break;
 
@@ -471,6 +479,15 @@ int64_t CFileRar::Seek(int64_t iFilePosition, int iWhence)
   }
   m_iDataInBuffer = m_pExtract->GetDataIO().m_iSeekTo; // keep data
   m_iBufferStart = m_pExtract->GetDataIO().m_iStartOfBuffer;
+
+  if (m_iDataInBuffer < 0 || m_iDataInBuffer > MAXWINMEMSIZE)
+  {
+    // invalid data returned by UnrarXLib, prevent a crash
+    CLog::Log(LOGERROR, "CRarFile::Seek - Data buffer in inconsistent state");
+    m_iDataInBuffer = 0;
+    return -1;
+  }
+
   m_szStartOfBuffer = m_szBuffer+MAXWINMEMSIZE-m_iDataInBuffer;
   m_iFilePosition = iFilePosition;
 


### PR DESCRIPTION
These backports fix crashes with corrupted files, crashing on some multi-part archives, and read corruption in some cases. They've been in master for 2 months now.
