### PR TITLE
[GSoC] videodb:// and musicdb:// URL extensions

### DIFF
--- a/XBMC-ATV2.xcodeproj/project.pbxproj
+++ b/XBMC-ATV2.xcodeproj/project.pbxproj
@@ -22,6 +22,10 @@
 		36A9445915821F8300727135 /* DatabaseUtils.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 36A9445715821F8300727135 /* DatabaseUtils.cpp */; };
 		36A9445D15821FAC00727135 /* SortUtils.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 36A9445B15821FAB00727135 /* SortUtils.cpp */; };
 		36A9465315AA269B00727135 /* DirectoryNodeTags.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 36A9465115AA269B00727135 /* DirectoryNodeTags.cpp */; };
+		36A9468415CF213000727135 /* DbUrl.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 36A9468215CF213000727135 /* DbUrl.cpp */; };
+		36A9468815CF214300727135 /* VideoDbUrl.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 36A9468615CF214300727135 /* VideoDbUrl.cpp */; };
+		36A9468B15CF215300727135 /* UrlOptions.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 36A9468915CF215300727135 /* UrlOptions.cpp */; };
+		36A9468E15CF217400727135 /* MusicDbUrl.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 36A9468C15CF217400727135 /* MusicDbUrl.cpp */; };
 		4D5D2E131301753F006ABC13 /* CFNetwork.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4D5D2E121301753F006ABC13 /* CFNetwork.framework */; };
 		7C0A7ECD13A5DBF900AFC2BD /* AppParamParser.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C0A7ECB13A5DBF900AFC2BD /* AppParamParser.cpp */; };
 		7C0A7FC813A9E75400AFC2BD /* DirtyRegionSolvers.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C0A7FC413A9E75400AFC2BD /* DirtyRegionSolvers.cpp */; };
@@ -1013,6 +1017,14 @@
 		36A9445C15821FAB00727135 /* SortUtils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SortUtils.h; sourceTree = "<group>"; };
 		36A9465115AA269B00727135 /* DirectoryNodeTags.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = DirectoryNodeTags.cpp; sourceTree = "<group>"; };
 		36A9465215AA269B00727135 /* DirectoryNodeTags.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DirectoryNodeTags.h; sourceTree = "<group>"; };
+		36A9468215CF213000727135 /* DbUrl.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = DbUrl.cpp; sourceTree = "<group>"; };
+		36A9468315CF213000727135 /* DbUrl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DbUrl.h; sourceTree = "<group>"; };
+		36A9468615CF214300727135 /* VideoDbUrl.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = VideoDbUrl.cpp; sourceTree = "<group>"; };
+		36A9468715CF214300727135 /* VideoDbUrl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VideoDbUrl.h; sourceTree = "<group>"; };
+		36A9468915CF215300727135 /* UrlOptions.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = UrlOptions.cpp; sourceTree = "<group>"; };
+		36A9468A15CF215300727135 /* UrlOptions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = UrlOptions.h; sourceTree = "<group>"; };
+		36A9468C15CF217400727135 /* MusicDbUrl.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MusicDbUrl.cpp; sourceTree = "<group>"; };
+		36A9468D15CF217400727135 /* MusicDbUrl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MusicDbUrl.h; sourceTree = "<group>"; };
 		4D5D2E121301753F006ABC13 /* CFNetwork.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CFNetwork.framework; path = System/Library/Frameworks/CFNetwork.framework; sourceTree = SDKROOT; };
 		7C0A7ECB13A5DBF900AFC2BD /* AppParamParser.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = AppParamParser.cpp; sourceTree = "<group>"; };
 		7C0A7ECC13A5DBF900AFC2BD /* AppParamParser.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AppParamParser.h; sourceTree = "<group>"; };
@@ -3574,6 +3586,8 @@
 				F56C77D9131EC154000AD0F6 /* CueDocument.h */,
 				7C1D698915A8142F00658B65 /* DatabaseManager.cpp */,
 				7C1D698A15A8142F00658B65 /* DatabaseManager.h */,
+				36A9468215CF213000727135 /* DbUrl.cpp */,
+				36A9468315CF213000727135 /* DbUrl.h */,
 				F56C77DC131EC154000AD0F6 /* DynamicDll.cpp */,
 				F56C77DD131EC154000AD0F6 /* DynamicDll.h */,
 				F56C77DE131EC154000AD0F6 /* Favourites.cpp */,
@@ -4906,6 +4920,8 @@
 				F56C7640131EC153000AD0F6 /* LastFmManager.h */,
 				F56C7641131EC153000AD0F6 /* MusicDatabase.cpp */,
 				F56C7642131EC153000AD0F6 /* MusicDatabase.h */,
+				36A9468C15CF217400727135 /* MusicDbUrl.cpp */,
+				36A9468D15CF217400727135 /* MusicDbUrl.h */,
 				F56C7643131EC153000AD0F6 /* MusicInfoLoader.cpp */,
 				F56C7644131EC153000AD0F6 /* MusicInfoLoader.h */,
 				F56C7645131EC153000AD0F6 /* Song.cpp */,
@@ -5473,6 +5489,8 @@
 				F56C776D131EC154000AD0F6 /* TuxBoxUtil.h */,
 				F56C7714131EC153000AD0F6 /* URIUtils.cpp */,
 				F56C7715131EC154000AD0F6 /* URIUtils.h */,
+				36A9468915CF215300727135 /* UrlOptions.cpp */,
+				36A9468A15CF215300727135 /* UrlOptions.h */,
 				F56C776E131EC154000AD0F6 /* Variant.cpp */,
 				F56C776F131EC154000AD0F6 /* Variant.h */,
 				F56C7770131EC154000AD0F6 /* Weather.cpp */,
@@ -5500,6 +5518,8 @@
 				F56C77A0131EC154000AD0F6 /* TeletextDefines.h */,
 				F56C77A1131EC154000AD0F6 /* VideoDatabase.cpp */,
 				F56C77A2131EC154000AD0F6 /* VideoDatabase.h */,
+				36A9468615CF214300727135 /* VideoDbUrl.cpp */,
+				36A9468715CF214300727135 /* VideoDbUrl.h */,
 				F56C77A3131EC154000AD0F6 /* VideoInfoDownloader.cpp */,
 				F56C77A4131EC154000AD0F6 /* VideoInfoDownloader.h */,
 				F56C77A5131EC154000AD0F6 /* VideoInfoScanner.cpp */,
@@ -7227,6 +7247,10 @@
 				7C1A493D15A968BA004AF4A4 /* SeekHandler.cpp in Sources */,
 				DF830D4815BB2CFC00602BE6 /* GUIKeyboardFactory.cpp in Sources */,
 				DF830D4B15BB2D2300602BE6 /* GUIDialogKeyboardGeneric.cpp in Sources */,
+				36A9468415CF213000727135 /* DbUrl.cpp in Sources */,
+				36A9468815CF214300727135 /* VideoDbUrl.cpp in Sources */,
+				36A9468B15CF215300727135 /* UrlOptions.cpp in Sources */,
+				36A9468E15CF217400727135 /* MusicDbUrl.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/XBMC-IOS.xcodeproj/project.pbxproj
+++ b/XBMC-IOS.xcodeproj/project.pbxproj
@@ -23,6 +23,10 @@
 		36A9444E15821F2C00727135 /* DatabaseUtils.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 36A9444C15821F2C00727135 /* DatabaseUtils.cpp */; };
 		36A9445215821F5300727135 /* SortUtils.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 36A9445015821F5300727135 /* SortUtils.cpp */; };
 		36A9465B15AA26BC00727135 /* DirectoryNodeTags.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 36A9465915AA26BC00727135 /* DirectoryNodeTags.cpp */; };
+		36A9467415CF208B00727135 /* MusicDbUrl.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 36A9467215CF208B00727135 /* MusicDbUrl.cpp */; };
+		36A9467815CF20A500727135 /* UrlOptions.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 36A9467615CF20A500727135 /* UrlOptions.cpp */; };
+		36A9467B15CF20BD00727135 /* VideoDbUrl.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 36A9467915CF20BD00727135 /* VideoDbUrl.cpp */; };
+		36A9467E15CF20E100727135 /* DbUrl.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 36A9467C15CF20E100727135 /* DbUrl.cpp */; };
 		4D5D2E1E1301758F006ABC13 /* CFNetwork.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4D5D2E1D1301758F006ABC13 /* CFNetwork.framework */; };
 		7C0A7EDE13A5DC2800AFC2BD /* AppParamParser.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C0A7EDC13A5DC2800AFC2BD /* AppParamParser.cpp */; };
 		7C0A7F9D13A9E70800AFC2BD /* GUIWindowDebugInfo.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C0A7F9B13A9E70800AFC2BD /* GUIWindowDebugInfo.cpp */; };
@@ -1015,6 +1019,14 @@
 		36A9445115821F5300727135 /* SortUtils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SortUtils.h; sourceTree = "<group>"; };
 		36A9465915AA26BC00727135 /* DirectoryNodeTags.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = DirectoryNodeTags.cpp; sourceTree = "<group>"; };
 		36A9465A15AA26BC00727135 /* DirectoryNodeTags.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DirectoryNodeTags.h; sourceTree = "<group>"; };
+		36A9467215CF208B00727135 /* MusicDbUrl.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MusicDbUrl.cpp; sourceTree = "<group>"; };
+		36A9467315CF208B00727135 /* MusicDbUrl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MusicDbUrl.h; sourceTree = "<group>"; };
+		36A9467615CF20A500727135 /* UrlOptions.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = UrlOptions.cpp; sourceTree = "<group>"; };
+		36A9467715CF20A500727135 /* UrlOptions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = UrlOptions.h; sourceTree = "<group>"; };
+		36A9467915CF20BD00727135 /* VideoDbUrl.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = VideoDbUrl.cpp; sourceTree = "<group>"; };
+		36A9467A15CF20BD00727135 /* VideoDbUrl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VideoDbUrl.h; sourceTree = "<group>"; };
+		36A9467C15CF20E100727135 /* DbUrl.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = DbUrl.cpp; sourceTree = "<group>"; };
+		36A9467D15CF20E100727135 /* DbUrl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DbUrl.h; sourceTree = "<group>"; };
 		4D5D2E1D1301758F006ABC13 /* CFNetwork.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CFNetwork.framework; path = System/Library/Frameworks/CFNetwork.framework; sourceTree = SDKROOT; };
 		7C0A7EDC13A5DC2800AFC2BD /* AppParamParser.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = AppParamParser.cpp; sourceTree = "<group>"; };
 		7C0A7EDD13A5DC2800AFC2BD /* AppParamParser.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AppParamParser.h; sourceTree = "<group>"; };
@@ -3937,6 +3949,8 @@
 				F56C87C6131F42ED000AD0F6 /* CueDocument.h */,
 				7C1D697615A8141000658B65 /* DatabaseManager.cpp */,
 				7C1D697715A8141000658B65 /* DatabaseManager.h */,
+				36A9467C15CF20E100727135 /* DbUrl.cpp */,
+				36A9467D15CF20E100727135 /* DbUrl.h */,
 				F56C87C9131F42ED000AD0F6 /* DynamicDll.cpp */,
 				F56C87CA131F42ED000AD0F6 /* DynamicDll.h */,
 				F56C87CB131F42ED000AD0F6 /* Favourites.cpp */,
@@ -5270,6 +5284,8 @@
 				F56C8623131F42EA000AD0F6 /* LastFmManager.h */,
 				F56C8624131F42EA000AD0F6 /* MusicDatabase.cpp */,
 				F56C8625131F42EA000AD0F6 /* MusicDatabase.h */,
+				36A9467215CF208B00727135 /* MusicDbUrl.cpp */,
+				36A9467315CF208B00727135 /* MusicDbUrl.h */,
 				F56C8626131F42EA000AD0F6 /* MusicInfoLoader.cpp */,
 				F56C8627131F42EA000AD0F6 /* MusicInfoLoader.h */,
 				F56C8628131F42EA000AD0F6 /* Song.cpp */,
@@ -5846,6 +5862,8 @@
 				F56C875C131F42EC000AD0F6 /* TuxBoxUtil.h */,
 				F56C8703131F42EB000AD0F6 /* URIUtils.cpp */,
 				F56C8704131F42EB000AD0F6 /* URIUtils.h */,
+				36A9467615CF20A500727135 /* UrlOptions.cpp */,
+				36A9467715CF20A500727135 /* UrlOptions.h */,
 				F56C875D131F42EC000AD0F6 /* Variant.cpp */,
 				F56C875E131F42EC000AD0F6 /* Variant.h */,
 				F56C875F131F42EC000AD0F6 /* Weather.cpp */,
@@ -5873,6 +5891,8 @@
 				F56C878F131F42EC000AD0F6 /* TeletextDefines.h */,
 				F56C8790131F42EC000AD0F6 /* VideoDatabase.cpp */,
 				F56C8791131F42EC000AD0F6 /* VideoDatabase.h */,
+				36A9467915CF20BD00727135 /* VideoDbUrl.cpp */,
+				36A9467A15CF20BD00727135 /* VideoDbUrl.h */,
 				F56C8792131F42EC000AD0F6 /* VideoInfoDownloader.cpp */,
 				F56C8793131F42EC000AD0F6 /* VideoInfoDownloader.h */,
 				F56C8794131F42EC000AD0F6 /* VideoInfoScanner.cpp */,
@@ -7252,6 +7272,10 @@
 				DF02A888153382A60084754E /* IOSKeyboard.mm in Sources */,
 				DF830C9515BB20FC00602BE6 /* GUIDialogKeyboardGeneric.cpp in Sources */,
 				DF830C9E15BB215500602BE6 /* GUIKeyboardFactory.cpp in Sources */,
+				36A9467415CF208B00727135 /* MusicDbUrl.cpp in Sources */,
+				36A9467815CF20A500727135 /* UrlOptions.cpp in Sources */,
+				36A9467B15CF20BD00727135 /* VideoDbUrl.cpp in Sources */,
+				36A9467E15CF20E100727135 /* DbUrl.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/XBMC.xcodeproj/project.pbxproj
+++ b/XBMC.xcodeproj/project.pbxproj
@@ -195,6 +195,10 @@
 		36A9443D15821E2800727135 /* DatabaseUtils.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 36A9443B15821E2800727135 /* DatabaseUtils.cpp */; };
 		36A9444115821E7C00727135 /* SortUtils.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 36A9443F15821E7C00727135 /* SortUtils.cpp */; };
 		36A9464C15AA25FD00727135 /* DirectoryNodeTags.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 36A9464A15AA25FD00727135 /* DirectoryNodeTags.cpp */; };
+		36A9466315CF1FA600727135 /* DbUrl.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 36A9466115CF1FA600727135 /* DbUrl.cpp */; };
+		36A9466715CF1FD200727135 /* MusicDbUrl.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 36A9466515CF1FD200727135 /* MusicDbUrl.cpp */; };
+		36A9466A15CF1FED00727135 /* UrlOptions.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 36A9466815CF1FED00727135 /* UrlOptions.cpp */; };
+		36A9466D15CF201F00727135 /* VideoDbUrl.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 36A9466B15CF201F00727135 /* VideoDbUrl.cpp */; };
 		3802709A13D5A653009493DD /* SystemClock.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3802709813D5A653009493DD /* SystemClock.cpp */; };
 		384718D81325BA04000486D6 /* XBDateTime.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 384718D61325BA04000486D6 /* XBDateTime.cpp */; };
 		38F4E57013CCCB3B00664821 /* Implementation.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 38F4E56C13CCCB3B00664821 /* Implementation.cpp */; };
@@ -1379,6 +1383,14 @@
 		36A9444015821E7C00727135 /* SortUtils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SortUtils.h; sourceTree = "<group>"; };
 		36A9464A15AA25FD00727135 /* DirectoryNodeTags.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = DirectoryNodeTags.cpp; sourceTree = "<group>"; };
 		36A9464B15AA25FD00727135 /* DirectoryNodeTags.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DirectoryNodeTags.h; sourceTree = "<group>"; };
+		36A9466115CF1FA600727135 /* DbUrl.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = DbUrl.cpp; sourceTree = "<group>"; };
+		36A9466215CF1FA600727135 /* DbUrl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DbUrl.h; sourceTree = "<group>"; };
+		36A9466515CF1FD200727135 /* MusicDbUrl.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MusicDbUrl.cpp; sourceTree = "<group>"; };
+		36A9466615CF1FD200727135 /* MusicDbUrl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MusicDbUrl.h; sourceTree = "<group>"; };
+		36A9466815CF1FED00727135 /* UrlOptions.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = UrlOptions.cpp; sourceTree = "<group>"; };
+		36A9466915CF1FED00727135 /* UrlOptions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = UrlOptions.h; sourceTree = "<group>"; };
+		36A9466B15CF201F00727135 /* VideoDbUrl.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = VideoDbUrl.cpp; sourceTree = "<group>"; };
+		36A9466C15CF201F00727135 /* VideoDbUrl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VideoDbUrl.h; sourceTree = "<group>"; };
 		3802709713D5A62D009493DD /* ThreadLocal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ThreadLocal.h; sourceTree = "<group>"; };
 		3802709813D5A653009493DD /* SystemClock.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SystemClock.cpp; sourceTree = "<group>"; };
 		3802709913D5A653009493DD /* SystemClock.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SystemClock.h; sourceTree = "<group>"; };
@@ -3457,6 +3469,8 @@
 				E38E185B0D25F9FA00618676 /* LastFmManager.h */,
 				E38E1D8F0D25F9FD00618676 /* MusicDatabase.cpp */,
 				E38E1D900D25F9FD00618676 /* MusicDatabase.h */,
+				36A9466515CF1FD200727135 /* MusicDbUrl.cpp */,
+				36A9466615CF1FD200727135 /* MusicDbUrl.h */,
 				E38E1D910D25F9FD00618676 /* MusicInfoLoader.cpp */,
 				E38E1D920D25F9FD00618676 /* MusicInfoLoader.h */,
 				E38E1E0D0D25F9FD00618676 /* Song.cpp */,
@@ -4010,6 +4024,8 @@
 				F5E55B6F10741340006E788A /* TeletextDefines.h */,
 				E38E1E930D25F9FD00618676 /* VideoDatabase.cpp */,
 				E38E1E940D25F9FD00618676 /* VideoDatabase.h */,
+				36A9466B15CF201F00727135 /* VideoDbUrl.cpp */,
+				36A9466C15CF201F00727135 /* VideoDbUrl.h */,
 				E38E1E4A0D25F9FD00618676 /* VideoInfoDownloader.cpp */,
 				E38E1E4B0D25F9FD00618676 /* VideoInfoDownloader.h */,
 				E38E1E950D25F9FD00618676 /* VideoInfoScanner.cpp */,
@@ -4336,6 +4352,8 @@
 				E38E167F0D25F9FA00618676 /* CueDocument.h */,
 				7C1D682715A7D2FD00658B65 /* DatabaseManager.cpp */,
 				7C1D682815A7D2FD00658B65 /* DatabaseManager.h */,
+				36A9466115CF1FA600727135 /* DbUrl.cpp */,
+				36A9466215CF1FA600727135 /* DbUrl.h */,
 				E38E168C0D25F9FA00618676 /* DynamicDll.cpp */,
 				E38E168D0D25F9FA00618676 /* DynamicDll.h */,
 				E38E16900D25F9FA00618676 /* Favourites.cpp */,
@@ -5917,6 +5935,8 @@
 				E38E1E8A0D25F9FD00618676 /* TuxBoxUtil.h */,
 				18B7C8EC12942613009E7A26 /* URIUtils.cpp */,
 				18B7C8ED12942613009E7A26 /* URIUtils.h */,
+				36A9466815CF1FED00727135 /* UrlOptions.cpp */,
+				36A9466915CF1FED00727135 /* UrlOptions.h */,
 				7CF1FB09123B1AF000B2CBCB /* Variant.cpp */,
 				7CF1FB0A123B1AF000B2CBCB /* Variant.h */,
 				E38E1E8D0D25F9FD00618676 /* Weather.cpp */,
@@ -7319,6 +7339,10 @@
 				7C1A492315A962EE004AF4A4 /* SeekHandler.cpp in Sources */,
 				DF830D0C15BB260C00602BE6 /* GUIDialogKeyboardGeneric.cpp in Sources */,
 				DF830D1215BB262700602BE6 /* GUIKeyboardFactory.cpp in Sources */,
+				36A9466315CF1FA600727135 /* DbUrl.cpp in Sources */,
+				36A9466715CF1FD200727135 /* MusicDbUrl.cpp in Sources */,
+				36A9466A15CF1FED00727135 /* UrlOptions.cpp in Sources */,
+				36A9466D15CF201F00727135 /* VideoDbUrl.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/project/VS2010Express/XBMC.vcxproj
+++ b/project/VS2010Express/XBMC.vcxproj
@@ -321,6 +321,7 @@
     <ClCompile Include="..\..\xbmc\cores\VideoRenderers\RenderCapture.cpp" />
     <ClCompile Include="..\..\xbmc\cores\VideoRenderers\VideoShaders\WinVideoFilter.cpp" />
     <ClCompile Include="..\..\xbmc\CueDocument.cpp" />
+    <ClCompile Include="..\..\xbmc\DbUrl.cpp" />
     <ClCompile Include="..\..\xbmc\dbwrappers\Database.cpp" />
     <ClCompile Include="..\..\xbmc\dbwrappers\dataset.cpp" />
     <ClCompile Include="..\..\xbmc\dbwrappers\mysqldataset.cpp" />
@@ -746,6 +747,7 @@
     <ClCompile Include="..\..\xbmc\music\karaoke\karaokewindowbackground.cpp" />
     <ClCompile Include="..\..\xbmc\music\LastFmManager.cpp" />
     <ClCompile Include="..\..\xbmc\music\MusicDatabase.cpp" />
+    <ClCompile Include="..\..\xbmc\music\MusicDbUrl.cpp" />
     <ClCompile Include="..\..\xbmc\music\MusicInfoLoader.cpp" />
     <ClCompile Include="..\..\xbmc\music\Song.cpp" />
     <ClCompile Include="..\..\xbmc\music\tags\APEv2Tag.cpp" />
@@ -923,6 +925,7 @@
     <ClInclude Include="..\..\xbmc\cores\dvdplayer\DVDCodecs\Audio\DVDAudioCodecPassthrough.h" />
     <ClInclude Include="..\..\xbmc\cores\paplayer\PCMCodec.h" />
     <ClInclude Include="..\..\xbmc\dialogs\GUIDialogKeyboardGeneric.h" />
+    <ClInclude Include="..\..\xbmc\DbUrl.h" />
     <ClInclude Include="..\..\xbmc\filesystem\ImageFile.h" />
     <ClInclude Include="..\..\xbmc\filesystem\VideoDatabaseDirectory\DirectoryNodeTags.h" />
     <ClInclude Include="..\..\xbmc\filesystem\windows\WINFileSMB.h" />
@@ -931,6 +934,7 @@
     <ClInclude Include="..\..\xbmc\guilib\GUIKeyboardFactory.h" />
     <ClInclude Include="..\..\xbmc\input\windows\WINJoystick.h" />
     <ClInclude Include="..\..\xbmc\interfaces\python\xbmcmodule\pythreadstate.h" />
+    <ClInclude Include="..\..\xbmc\music\MusicDbUrl.h" />
     <ClInclude Include="..\..\xbmc\network\httprequesthandler\HTTPImageHandler.h" />
     <ClInclude Include="..\..\xbmc\network\AirTunesServer.h" />
     <ClInclude Include="..\..\xbmc\network\DllLibShairplay.h" />
@@ -1124,6 +1128,7 @@
     <ClCompile Include="..\..\xbmc\utils\TimeUtils.cpp" />
     <ClCompile Include="..\..\xbmc\utils\TuxBoxUtil.cpp" />
     <ClCompile Include="..\..\xbmc\utils\URIUtils.cpp" />
+    <ClCompile Include="..\..\xbmc\utils\UrlOptions.cpp" />
     <ClCompile Include="..\..\xbmc\utils\Variant.cpp" />
     <ClCompile Include="..\..\xbmc\utils\Weather.cpp" />
     <ClCompile Include="..\..\xbmc\utils\XBMCTinyXML.cpp" />
@@ -1142,6 +1147,7 @@
     <ClCompile Include="..\..\xbmc\video\GUIViewStateVideo.cpp" />
     <ClCompile Include="..\..\xbmc\video\Teletext.cpp" />
     <ClCompile Include="..\..\xbmc\video\VideoDatabase.cpp" />
+    <ClCompile Include="..\..\xbmc\video\VideoDbUrl.cpp" />
     <ClCompile Include="..\..\xbmc\video\VideoInfoDownloader.cpp" />
     <ClCompile Include="..\..\xbmc\video\VideoInfoScanner.cpp" />
     <ClCompile Include="..\..\xbmc\video\VideoInfoTag.cpp" />
@@ -1918,6 +1924,7 @@
     <ClInclude Include="..\..\xbmc\utils\TimeUtils.h" />
     <ClInclude Include="..\..\xbmc\utils\TuxBoxUtil.h" />
     <ClInclude Include="..\..\xbmc\utils\URIUtils.h" />
+    <ClInclude Include="..\..\xbmc\utils\UrlOptions.h" />
     <ClInclude Include="..\..\xbmc\utils\Variant.h" />
     <ClInclude Include="..\..\xbmc\utils\Weather.h" />
     <ClInclude Include="..\..\xbmc\utils\XBMCTinyXML.h" />
@@ -1937,6 +1944,7 @@
     <ClInclude Include="..\..\xbmc\video\Teletext.h" />
     <ClInclude Include="..\..\xbmc\video\TeletextDefines.h" />
     <ClInclude Include="..\..\xbmc\video\VideoDatabase.h" />
+    <ClInclude Include="..\..\xbmc\video\VideoDbUrl.h" />
     <ClInclude Include="..\..\xbmc\video\VideoInfoDownloader.h" />
     <ClInclude Include="..\..\xbmc\video\VideoInfoScanner.h" />
     <ClInclude Include="..\..\xbmc\video\VideoInfoTag.h" />

--- a/project/VS2010Express/XBMC.vcxproj.filters
+++ b/project/VS2010Express/XBMC.vcxproj.filters
@@ -2590,6 +2590,16 @@
     <ClCompile Include="..\..\xbmc\dialogs\GUIDialogKeyboardGeneric.cpp">
       <Filter>dialogs</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\xbmc\video\VideoDbUrl.cpp">
+      <Filter>video</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\xbmc\DbUrl.cpp" />
+    <ClCompile Include="..\..\xbmc\utils\UrlOptions.cpp">
+      <Filter>utils</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\xbmc\music\MusicDbUrl.cpp">
+      <Filter>music</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\xbmc\win32\pch.h">
@@ -5223,6 +5233,16 @@
     </ClInclude>
     <ClInclude Include="..\..\xbmc\dialogs\GUIDialogKeyboardGeneric.h">
       <Filter>dialogs</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\xbmc\video\VideoDbUrl.h">
+      <Filter>video</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\xbmc\DbUrl.h" />
+    <ClInclude Include="..\..\xbmc\utils\UrlOptions.h">
+      <Filter>utils</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\xbmc\music\MusicDbUrl.h">
+      <Filter>music</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/xbmc/DbUrl.cpp
+++ b/xbmc/DbUrl.cpp
@@ -1,0 +1,81 @@
+/*
+ *      Copyright (C) 2012 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include <sstream>
+
+#include "DbUrl.h"
+#include "utils/StringUtils.h"
+#include "utils/URIUtils.h"
+
+using namespace std;
+
+CDbUrl::CDbUrl()
+{
+  Reset();
+}
+
+CDbUrl::~CDbUrl()
+{ }
+
+void CDbUrl::Reset()
+{
+  m_valid = false;
+  m_type.clear();
+  m_url.Reset();
+  m_options.clear();
+}
+
+std::string CDbUrl::ToString() const
+{
+  if (!m_valid)
+    return "";
+
+  return m_url.Get();
+}
+
+bool CDbUrl::FromString(const std::string &dbUrl)
+{
+  Reset();
+
+  m_url.Parse(dbUrl);
+  m_valid = parse();
+
+  if (!m_valid)
+    Reset();
+
+  return m_valid;
+}
+
+void CDbUrl::AppendPath(const std::string &subPath)
+{
+  if (!m_valid || subPath.empty())
+    return;
+
+  m_url.SetFileName(URIUtils::AddFileToFolder(m_url.GetFileName(), subPath));
+}
+
+void CDbUrl::updateOptions()
+{
+  // Update the options string in the CURL object
+  string options = GetOptionsString();
+  if (!options.empty())
+    options = "?" + options;
+
+  m_url.SetOptions(options);
+}

--- a/xbmc/DbUrl.h
+++ b/xbmc/DbUrl.h
@@ -1,0 +1,59 @@
+#pragma once
+/*
+ *      Copyright (C) 2012 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include <map>
+#include <string>
+
+#include "URL.h"
+#include "utils/UrlOptions.h"
+
+class CDbUrl : public CUrlOptions
+{
+public:
+  CDbUrl();
+  virtual ~CDbUrl();
+
+  bool IsValid() const { return m_valid; }
+  void Reset();
+
+  std::string ToString() const;
+  bool FromString(const std::string &dbUrl);
+
+  const std::string& GetType() const { return m_type; }
+  void AppendPath(const std::string &subPath);
+
+  virtual void AddOption(const std::string &key, const std::string &value) { CUrlOptions::AddOption(key, value); updateOptions(); }
+  virtual void AddOption(const std::string &key, int value) { CUrlOptions::AddOption(key, value); updateOptions(); }
+  virtual void AddOption(const std::string &key, float value) { CUrlOptions::AddOption(key, value); updateOptions(); }
+  virtual void AddOption(const std::string &key, double value) { CUrlOptions::AddOption(key, value); updateOptions(); }
+  virtual void AddOption(const std::string &key, bool value) { CUrlOptions::AddOption(key, value); updateOptions(); }
+  virtual void AddOptions(const std::string &options) { CUrlOptions::AddOptions(options); updateOptions(); }
+
+protected:
+  virtual bool parse() = 0;
+  
+  CURL m_url;
+  std::string m_type;
+
+private:
+  void updateOptions();
+
+  bool m_valid;
+};

--- a/xbmc/Makefile.in
+++ b/xbmc/Makefile.in
@@ -5,6 +5,7 @@ SRCS=Application.cpp \
      BackgroundInfoLoader.cpp \
      CueDocument.cpp \
      DatabaseManager.cpp \
+     DbUrl.cpp \
      DynamicDll.cpp \
      Favourites.cpp \
      FileItem.cpp \

--- a/xbmc/PartyModeManager.cpp
+++ b/xbmc/PartyModeManager.cpp
@@ -606,7 +606,7 @@ bool CPartyModeManager::AddInitialSongs(vector<pair<int,int> > &songIDs)
       sqlWhereMusic[sqlWhereMusic.size() - 1] = ')'; // replace the last comma with closing bracket
       CMusicDatabase database;
       database.Open();
-      database.GetSongsByWhere("", sqlWhereMusic, items);
+      database.GetSongsByWhere("musicdb://4/", sqlWhereMusic, items);
     }
     if (sqlWhereVideo.size() > 19)
     {

--- a/xbmc/PartyModeManager.cpp
+++ b/xbmc/PartyModeManager.cpp
@@ -113,11 +113,7 @@ bool CPartyModeManager::Enable(PartyModeContext context /*= PARTYMODECONTEXT_MUS
     {
       set<CStdString> playlists;
       if ( playlistLoaded )
-      {
         m_strCurrentFilterMusic = playlist.GetWhereClause(db, playlists);
-        if (!m_strCurrentFilterMusic.empty())
-          m_strCurrentFilterMusic = "WHERE " + m_strCurrentFilterMusic;
-      }
 
       CLog::Log(LOGINFO, "PARTY MODE MANAGER: Registering filter:[%s]", m_strCurrentFilterMusic.c_str());
       m_iMatchingSongs = (int)db.GetSongIDs(m_strCurrentFilterMusic, songIDs);
@@ -146,11 +142,7 @@ bool CPartyModeManager::Enable(PartyModeContext context /*= PARTYMODECONTEXT_MUS
     {
       set<CStdString> playlists;
       if ( playlistLoaded )
-      {
         m_strCurrentFilterVideo = playlist.GetWhereClause(db, playlists);
-        if (!m_strCurrentFilterVideo.empty())
-          m_strCurrentFilterVideo = "WHERE " + m_strCurrentFilterVideo;
-      }
 
       CLog::Log(LOGINFO, "PARTY MODE MANAGER: Registering filter:[%s]", m_strCurrentFilterVideo.c_str());
       m_iMatchingSongs += (int)db.GetMusicVideoIDs(m_strCurrentFilterVideo, songIDs2);
@@ -594,8 +586,8 @@ bool CPartyModeManager::AddInitialSongs(vector<pair<int,int> > &songIDs)
 
     vector<pair<int,int> > chosenSongIDs;
     GetRandomSelection(songIDs, iMissingSongs, chosenSongIDs);
-    CStdString sqlWhereMusic = "where songview.idSong in (";
-    CStdString sqlWhereVideo = "idMVideo in (";
+    CStdString sqlWhereMusic = "songview.idSong IN (";
+    CStdString sqlWhereVideo = "idMVideo IN (";
 
     for (vector< pair<int,int> >::iterator it = chosenSongIDs.begin(); it != chosenSongIDs.end(); it++)
     {
@@ -644,7 +636,7 @@ pair<CStdString,CStdString> CPartyModeManager::GetWhereClauseWithHistory() const
   if (m_history.size())
   {
     if (m_strCurrentFilterMusic.IsEmpty())
-      historyWhereMusic = "where songview.idSong not in (";
+      historyWhereMusic = "songview.idSong not in (";
     else
       historyWhereMusic = m_strCurrentFilterMusic + " and songview.idSong not in (";
     if (m_strCurrentFilterVideo.IsEmpty())

--- a/xbmc/URL.cpp
+++ b/xbmc/URL.cpp
@@ -161,7 +161,8 @@ void CURL::Parse(const CStdString& strURL1)
   if(m_strProtocol.Equals("rss") ||
      m_strProtocol.Equals("rar") ||
      m_strProtocol.Equals("addons") ||
-     m_strProtocol.Equals("image"))
+     m_strProtocol.Equals("image") ||
+     m_strProtocol.Equals("videodb"))
     sep = "?";
   else
   if(strProtocol2.Equals("http")

--- a/xbmc/URL.cpp
+++ b/xbmc/URL.cpp
@@ -162,7 +162,8 @@ void CURL::Parse(const CStdString& strURL1)
      m_strProtocol.Equals("rar") ||
      m_strProtocol.Equals("addons") ||
      m_strProtocol.Equals("image") ||
-     m_strProtocol.Equals("videodb"))
+     m_strProtocol.Equals("videodb") ||
+     m_strProtocol.Equals("musicdb"))
     sep = "?";
   else
   if(strProtocol2.Equals("http")

--- a/xbmc/URL.cpp
+++ b/xbmc/URL.cpp
@@ -707,6 +707,20 @@ void CURL::Encode(CStdString& strURLData)
   strURLData = strResult;
 }
 
+std::string CURL::Decode(const std::string& strURLData)
+{
+  CStdString url = strURLData;
+  Decode(url);
+  return url;
+}
+
+std::string CURL::Encode(const std::string& strURLData)
+{
+  CStdString url = strURLData;
+  Encode(url);
+  return url;
+}
+
 CStdString CURL::TranslateProtocol(const CStdString& prot)
 {
   if (prot == "shout"

--- a/xbmc/URL.h
+++ b/xbmc/URL.h
@@ -71,6 +71,8 @@ public:
   static bool IsFullPath(const CStdString &url); ///< return true if the url includes the full path
   static void Decode(CStdString& strURLData);
   static void Encode(CStdString& strURLData);
+  static std::string Decode(const std::string& strURLData);
+  static std::string Encode(const std::string& strURLData);
   static CStdString TranslateProtocol(const CStdString& prot);
 
 protected:

--- a/xbmc/dbwrappers/Database.cpp
+++ b/xbmc/dbwrappers/Database.cpp
@@ -681,3 +681,20 @@ bool CDatabase::UpdateVersionNumber()
   return true;
 }
 
+bool CDatabase::BuildSQL(const CStdString &strQuery, const Filter &filter, CStdString &strSQL)
+{
+  strSQL = strQuery;
+
+  if (!filter.join.empty())
+    strSQL += filter.join;
+  if (!filter.where.empty())
+    strSQL += " WHERE " + filter.where;
+  if (!filter.group.empty())
+    strSQL += " GROUP BY " + filter.group;
+  if (!filter.order.empty())
+    strSQL += " ORDER BY " + filter.order;
+  if (!filter.limit.empty())
+    strSQL += " LIMIT " + filter.limit;
+
+  return true;
+}

--- a/xbmc/dbwrappers/Database.cpp
+++ b/xbmc/dbwrappers/Database.cpp
@@ -40,6 +40,65 @@ using namespace dbiplus;
 
 #define MAX_COMPRESS_COUNT 20
 
+void CDatabase::Filter::AppendField(const std::string &strField)
+{
+  if (strField.empty())
+    return;
+
+  if (fields.empty() || fields == "*")
+    fields = strField;
+  else
+    fields += ", " + strField;
+}
+
+void CDatabase::Filter::AppendJoin(const std::string &strJoin)
+{
+  if (strJoin.empty())
+    return;
+
+  if (join.empty())
+    join = strJoin;
+  else
+    join += " " + strJoin;
+}
+
+void CDatabase::Filter::AppendWhere(const std::string &strWhere, bool combineWithAnd /* = true */)
+{
+  if (strWhere.empty())
+    return;
+
+  if (where.empty())
+    where = strWhere;
+  else
+  {
+    where = "(" + where + ") ";
+    where += combineWithAnd ? "AND" : "OR";
+    where += " (" + strWhere + ")";
+  }
+}
+
+void CDatabase::Filter::AppendOrder(const std::string &strOrder)
+{
+  if (strOrder.empty())
+    return;
+
+  if (order.empty())
+    order = strOrder;
+  else
+    order += ", " + strOrder;
+}
+
+void CDatabase::Filter::AppendGroup(const std::string &strGroup)
+{
+  if (strGroup.empty())
+    return;
+
+  if (group.empty())
+    group = strGroup;
+  else
+    group += ", " + strGroup;
+}
+
 CDatabase::CDatabase(void)
 {
   m_openCount = 0;

--- a/xbmc/dbwrappers/Database.h
+++ b/xbmc/dbwrappers/Database.h
@@ -152,6 +152,8 @@ protected:
   int GetDBVersion();
   bool UpdateVersion(const CStdString &dbName);
 
+  bool BuildSQL(const CStdString &strQuery, const Filter &filter, CStdString &strSQL);
+
   bool m_sqlite; ///< \brief whether we use sqlite (defaults to true)
 
   std::auto_ptr<dbiplus::Database> m_pDB;

--- a/xbmc/dbwrappers/Database.h
+++ b/xbmc/dbwrappers/Database.h
@@ -35,6 +35,27 @@ class DatabaseSettings; // forward
 class CDatabase
 {
 public:
+  class Filter
+  {
+  public:
+    Filter() : fields("*") {};
+    Filter(const char *w) : fields("*"), where(w) {};
+    Filter(const std::string &w) : fields("*"), where(w) {};
+    
+    void AppendField(const std::string &strField);
+    void AppendJoin(const std::string &strJoin);
+    void AppendWhere(const std::string &strWhere, bool combineWithAnd = true);
+    void AppendOrder(const std::string &strOrder);
+    void AppendGroup(const std::string &strGroup);
+
+    std::string fields;
+    std::string join;
+    std::string where;
+    std::string order;
+    std::string group;
+    std::string limit;
+  };
+
   CDatabase(void);
   virtual ~CDatabase(void);
   bool IsOpen();

--- a/xbmc/dialogs/GUIDialogSmartPlaylistRule.cpp
+++ b/xbmc/dialogs/GUIDialogSmartPlaylistRule.cpp
@@ -118,7 +118,7 @@ void CGUIDialogSmartPlaylistRule::OnBrowse()
     if (m_type.Equals("tvshows") || m_type.Equals("episodes") || m_type.Equals("movies"))
       videodatabase.GetGenresNav("videodb://2/1/",items,type);
     else if (m_type.Equals("songs") || m_type.Equals("albums") || m_type.Equals("mixed"))
-      database.GetGenresNav("musicdb://4/",items);
+      database.GetGenresNav("musicdb://1/",items);
     if (m_type.Equals("musicvideos") || m_type.Equals("mixed"))
     {
       CFileItemList items2;
@@ -135,7 +135,7 @@ void CGUIDialogSmartPlaylistRule::OnBrowse()
   else if (m_rule.m_field == FieldArtist || m_rule.m_field == FieldAlbumArtist)
   {
     if (m_type.Equals("songs") || m_type.Equals("mixed") || m_type.Equals("albums"))
-      database.GetArtistsNav("musicdb://5/",items,-1,m_rule.m_field == FieldAlbumArtist);
+      database.GetArtistsNav("musicdb://2/",items,-1,m_rule.m_field == FieldAlbumArtist);
     if (m_type.Equals("musicvideos") || m_type.Equals("mixed"))
     {
       CFileItemList items2;
@@ -147,7 +147,7 @@ void CGUIDialogSmartPlaylistRule::OnBrowse()
   else if (m_rule.m_field == FieldAlbum)
   {
     if (m_type.Equals("songs") || m_type.Equals("mixed") || m_type.Equals("albums"))
-      database.GetAlbumsNav("musicdb://6/",items,-1,-1,-1,-1);
+      database.GetAlbumsNav("musicdb://3/", items);
     if (m_type.Equals("musicvideos") || m_type.Equals("mixed"))
     {
       CFileItemList items2;
@@ -164,7 +164,7 @@ void CGUIDialogSmartPlaylistRule::OnBrowse()
   else if (m_rule.m_field == FieldYear)
   {
     if (m_type.Equals("songs") || m_type.Equals("mixed") || m_type.Equals("albums"))
-      database.GetYearsNav("", items);
+      database.GetYearsNav("musicdb://9/", items);
     if (!m_type.Equals("songs") && !m_type.Equals("albums"))
     {
       CFileItemList items2;

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNode.cpp
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNode.cpp
@@ -88,6 +88,9 @@ CDirectoryNode* CDirectoryNode::ParseURL(const CStdString& strPath)
     pParent=pNode;
   }
 
+  // Add all the additional URL options to the last node
+  pNode->AddOptions(url.GetOptions());
+
   return pNode;
 }
 
@@ -217,7 +220,19 @@ CStdString CDirectoryNode::BuildPath() const
   for (int i=0; i<(int)array.size(); ++i)
     strPath+=array[i]+"/";
 
+  string options = m_options.GetOptionsString();
+  if (!options.empty())
+    strPath += "?" + options;
+
   return strPath;
+}
+
+void CDirectoryNode::AddOptions(const CStdString &options)
+{
+  if (options.empty())
+    return;
+
+  m_options.AddOptions(options);
 }
 
 //  Collects Query params from this and all parent nodes. If a NODE_TYPE can
@@ -253,6 +268,7 @@ bool CDirectoryNode::GetChilds(CFileItemList& items)
   bool bSuccess=false;
   if (pNode.get())
   {
+    pNode->m_options = m_options;
     bSuccess=pNode->GetContent(items);
     if (bSuccess)
     {

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNode.h
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNode.h
@@ -20,8 +20,8 @@
  *
  */
 
-
 #include "utils/StdString.h"
+#include "utils/UrlOptions.h"
 
 class CFileItemList;
 
@@ -82,6 +82,7 @@ namespace XFILE
       CDirectoryNode(NODE_TYPE Type, const CStdString& strName, CDirectoryNode* pParent);
       static CDirectoryNode* CreateNode(NODE_TYPE Type, const CStdString& strName, CDirectoryNode* pParent);
 
+      void AddOptions(const CStdString &options);
       void CollectQueryParams(CQueryParams& params) const;
 
       const CStdString& GetName() const;
@@ -99,6 +100,7 @@ namespace XFILE
       NODE_TYPE m_Type;
       CStdString m_strName;
       CDirectoryNode* m_pParent;
+      CUrlOptions m_options;
     };
   }
 }

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeAlbum.cpp
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeAlbum.cpp
@@ -55,7 +55,7 @@ bool CDirectoryNodeAlbum::GetContent(CFileItemList& items) const
   CQueryParams params;
   CollectQueryParams(params);
 
-  bool bSuccess=musicdatabase.GetAlbumsNav(BuildPath(), items, params.GetGenreId(), params.GetArtistId(),-1,-1);
+  bool bSuccess=musicdatabase.GetAlbumsNav(BuildPath(), items, params.GetGenreId(), params.GetArtistId());
 
   musicdatabase.Close();
 

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeOverview.cpp
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeOverview.cpp
@@ -74,7 +74,8 @@ bool CDirectoryNodeOverview::GetContent(CFileItemList& items) const
   bool showSingles = false;
   if (musicDatabase.Open())
   {
-    if (musicDatabase.GetSongsCount("where idAlbum in (select idAlbum from album where strAlbum='')") > 0)
+    CDatabase::Filter filter("idAlbum IN (SELECT idAlbum FROM album WHERE strAlbum = '')");
+    if (musicDatabase.GetSongsCount(filter) > 0)
       showSingles = true;
   }
 

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeSingles.cpp
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeSingles.cpp
@@ -37,8 +37,9 @@ bool CDirectoryNodeSingles::GetContent(CFileItemList& items) const
   if (!musicdatabase.Open())
     return false;
 
-  CStdString strBaseDir=BuildPath();
-  bool bSuccess=musicdatabase.GetSongsByWhere(strBaseDir, "where idAlbum in (select idAlbum from album where strAlbum='')", items);
+  CDatabase::Filter filter;
+  filter.where = "idAlbum IN (SELECT idAlbum FROM album WHERE strAlbum = '')";
+  bool bSuccess=musicdatabase.GetSongsByWhere(BuildPath(), filter, items);
 
   musicdatabase.Close();
 

--- a/xbmc/filesystem/SmartPlaylistDirectory.cpp
+++ b/xbmc/filesystem/SmartPlaylistDirectory.cpp
@@ -106,10 +106,9 @@ namespace XFILE
       CMusicDatabase db;
       if (db.Open())
       {
-        CStdString whereClause = playlist.GetWhereClause(db, playlists);
-        if (!whereClause.empty())
-          whereClause = "WHERE " + whereClause;
-        success = db.GetAlbumsByWhere("musicdb://3/", whereClause, "", items, sorting);
+        CDatabase::Filter filter;
+        filter.where = playlist.GetWhereClause(db, playlists);
+        success = db.GetAlbumsByWhere("musicdb://3/", filter, items, sorting);
         items.SetContent("albums");
         db.Close();
       }
@@ -119,20 +118,14 @@ namespace XFILE
       CMusicDatabase db;
       if (db.Open())
       {
-        CStdString whereClause;
+        CDatabase::Filter filter;
+        CSmartPlaylist songPlaylist(playlist);
         if (playlist.GetType().IsEmpty() || playlist.GetType().Equals("mixed"))
-        {
-          CSmartPlaylist songPlaylist(playlist);
           songPlaylist.SetType("songs");
-          whereClause = songPlaylist.GetWhereClause(db, playlists);
-        }
-        else
-          whereClause = playlist.GetWhereClause(db, playlists);
 
-        if (!whereClause.empty())
-          whereClause = "WHERE " + whereClause;
+        filter.where = songPlaylist.GetWhereClause(db, playlists);
 
-        success = db.GetSongsByWhere("", whereClause, items, sorting);
+        success = db.GetSongsByWhere("", filter, items, sorting);
         items.SetContent("songs");
         db.Close();
       }

--- a/xbmc/filesystem/SmartPlaylistDirectory.cpp
+++ b/xbmc/filesystem/SmartPlaylistDirectory.cpp
@@ -106,9 +106,16 @@ namespace XFILE
       CMusicDatabase db;
       if (db.Open())
       {
+        CMusicDbUrl musicUrl;
+        CStdString xsp;
+        if (!musicUrl.FromString("musicdb://3/") || !playlist.SaveAsJson(xsp, false))
+          return false;
+
+        // store the smartplaylist as JSON in the URL as well
+        musicUrl.AddOption("xsp", xsp);
+
         CDatabase::Filter filter;
-        filter.where = playlist.GetWhereClause(db, playlists);
-        success = db.GetAlbumsByWhere("musicdb://3/", filter, items, sorting);
+        success = db.GetAlbumsByWhere(musicUrl.ToString(), filter, items, sorting);
         items.SetContent("albums");
         db.Close();
       }
@@ -118,14 +125,20 @@ namespace XFILE
       CMusicDatabase db;
       if (db.Open())
       {
-        CDatabase::Filter filter;
         CSmartPlaylist songPlaylist(playlist);
         if (playlist.GetType().IsEmpty() || playlist.GetType().Equals("mixed"))
           songPlaylist.SetType("songs");
+        
+        CMusicDbUrl musicUrl;
+        CStdString xsp;
+        if (!musicUrl.FromString("musicdb://4/") || !songPlaylist.SaveAsJson(xsp, false))
+          return false;
 
-        filter.where = songPlaylist.GetWhereClause(db, playlists);
+        // store the smartplaylist as JSON in the URL as well
+        musicUrl.AddOption("xsp", xsp);
 
-        success = db.GetSongsByWhere("", filter, items, sorting);
+        CDatabase::Filter filter;
+        success = db.GetSongsByWhere(musicUrl.ToString(), filter, items, sorting);
         items.SetContent("songs");
         db.Close();
       }

--- a/xbmc/filesystem/SmartPlaylistDirectory.cpp
+++ b/xbmc/filesystem/SmartPlaylistDirectory.cpp
@@ -71,8 +71,6 @@ namespace XFILE
       if (db.Open())
       {
         MediaType mediaType = DatabaseUtils::MediaTypeFromString(playlist.GetType());
-        CDatabase::Filter filter;
-        filter.where = playlist.GetWhereClause(db, playlists);
 
         CStdString strBaseDir;
         switch (mediaType)
@@ -90,7 +88,16 @@ namespace XFILE
           return false;
         }
 
-        success = db.GetSortedVideos(mediaType, strBaseDir, sorting, items, filter, true);
+        CVideoDbUrl videoUrl;
+        CStdString xsp;
+        if (!videoUrl.FromString(strBaseDir) || !playlist.SaveAsJson(xsp, false))
+          return false;
+
+        // store the smartplaylist as JSON in the URL as well
+        videoUrl.AddOption("xsp", xsp);
+        
+        CDatabase::Filter filter;
+        success = db.GetSortedVideos(mediaType, videoUrl.ToString(), sorting, items, filter, true);
         db.Close();
       }
     }
@@ -135,18 +142,20 @@ namespace XFILE
       CVideoDatabase db;
       if (db.Open())
       {
-        CDatabase::Filter filter;
+        CSmartPlaylist mvidPlaylist(playlist);
         if (playlist.GetType().Equals("mixed"))
-        {
-          CSmartPlaylist mvidPlaylist(playlist);
           mvidPlaylist.SetType("musicvideos");
-          filter.where = mvidPlaylist.GetWhereClause(db, playlists);
-        }
-        else
-          filter.where = playlist.GetWhereClause(db, playlists);
 
+        CVideoDbUrl videoUrl;
+        CStdString xsp;
+        if (!videoUrl.FromString("videodb://3/2/") || !mvidPlaylist.SaveAsJson(xsp, false))
+          return false;
+
+        // store the smartplaylist as JSON in the URL as well
+        videoUrl.AddOption("xsp", xsp);
+        
         CFileItemList items2;
-        success2 = db.GetSortedVideos(MediaTypeMusicVideo, "videodb://3/2/", sorting, items2, filter);
+        success2 = db.GetSortedVideos(MediaTypeMusicVideo, videoUrl.ToString(), sorting, items2);
         db.Close();
 
         items.Append(items2);

--- a/xbmc/filesystem/SmartPlaylistDirectory.cpp
+++ b/xbmc/filesystem/SmartPlaylistDirectory.cpp
@@ -71,7 +71,7 @@ namespace XFILE
       if (db.Open())
       {
         MediaType mediaType = DatabaseUtils::MediaTypeFromString(playlist.GetType());
-        CVideoDatabase::Filter filter;
+        CDatabase::Filter filter;
         filter.where = playlist.GetWhereClause(db, playlists);
 
         CStdString strBaseDir;
@@ -135,7 +135,7 @@ namespace XFILE
       CVideoDatabase db;
       if (db.Open())
       {
-        CVideoDatabase::Filter filter;
+        CDatabase::Filter filter;
         if (playlist.GetType().Equals("mixed"))
         {
           CSmartPlaylist mvidPlaylist(playlist);

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNode.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNode.cpp
@@ -94,6 +94,9 @@ CDirectoryNode* CDirectoryNode::ParseURL(const CStdString& strPath)
     pParent=pNode;
   }
 
+  // Add all the additional URL options to the last node
+  pNode->AddOptions(url.GetOptions());
+
   return pNode;
 }
 
@@ -227,7 +230,19 @@ CStdString CDirectoryNode::BuildPath() const
   for (int i=0; i<(int)array.size(); ++i)
     strPath+=array[i]+"/";
 
+  string options = m_options.GetOptionsString();
+  if (!options.empty())
+    strPath += "?" + options;
+
   return strPath;
+}
+
+void CDirectoryNode::AddOptions(const CStdString &options)
+{
+  if (options.empty())
+    return;
+
+  m_options.AddOptions(options);
 }
 
 //  Collects Query params from this and all parent nodes. If a NODE_TYPE can
@@ -263,6 +278,7 @@ bool CDirectoryNode::GetChilds(CFileItemList& items)
   bool bSuccess=false;
   if (pNode.get())
   {
+    pNode->m_options = m_options;
     bSuccess=pNode->GetContent(items);
     if (bSuccess)
     {

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNode.h
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNode.h
@@ -20,8 +20,8 @@
  *
  */
 
-
 #include "utils/StdString.h"
+#include "utils/UrlOptions.h"
 
 class CFileItemList;
 
@@ -84,6 +84,7 @@ namespace XFILE
       CDirectoryNode(NODE_TYPE Type, const CStdString& strName, CDirectoryNode* pParent);
       static CDirectoryNode* CreateNode(NODE_TYPE Type, const CStdString& strName, CDirectoryNode* pParent);
 
+      void AddOptions(const CStdString &options);
       void CollectQueryParams(CQueryParams& params) const;
 
       const CStdString& GetName() const;
@@ -101,6 +102,7 @@ namespace XFILE
       NODE_TYPE m_Type;
       CStdString m_strName;
       CDirectoryNode* m_pParent;
+      CUrlOptions m_options;
     };
   }
 }

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeEpisodes.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeEpisodes.cpp
@@ -40,13 +40,11 @@ bool CDirectoryNodeEpisodes::GetContent(CFileItemList& items) const
   CQueryParams params;
   CollectQueryParams(params);
 
-  CStdString strBaseDir=BuildPath();
-
   int season = (int)params.GetSeason();
   if (season == -2)
     season = -1;
 
-  bool bSuccess=videodatabase.GetEpisodesNav(strBaseDir, items, params.GetGenreId(), params.GetYear(), params.GetActorId(), params.GetDirectorId(), params.GetTvShowId(), season);
+  bool bSuccess=videodatabase.GetEpisodesNav(BuildPath(), items, params.GetGenreId(), params.GetYear(), params.GetActorId(), params.GetDirectorId(), params.GetTvShowId(), season);
 
   videodatabase.Close();
 

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeMoviesOverview.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeMoviesOverview.cpp
@@ -23,6 +23,7 @@
 #include "FileItem.h"
 #include "guilib/LocalizeStrings.h"
 #include "video/VideoDatabase.h"
+#include "video/VideoDbUrl.h"
 
 using namespace XFILE::VIDEODATABASEDIRECTORY;
 using namespace std;
@@ -64,6 +65,10 @@ CStdString CDirectoryNodeMoviesOverview::GetLocalizedName() const
 
 bool CDirectoryNodeMoviesOverview::GetContent(CFileItemList& items) const
 {
+  CVideoDbUrl videoUrl;
+  if (!videoUrl.FromString(BuildPath()))
+    return false;
+  
   for (unsigned int i = 0; i < sizeof(MovieChildren) / sizeof(Node); ++i)
   {
     if (i == 6)
@@ -72,9 +77,12 @@ bool CDirectoryNodeMoviesOverview::GetContent(CFileItemList& items) const
       if (db.Open() && !db.HasSets())
         continue;
     }
-    CStdString path;
-    path.Format("%s%ld/", BuildPath().c_str(), MovieChildren[i].id);
-    CFileItemPtr pItem(new CFileItem(path, true));
+
+    CVideoDbUrl itemUrl = videoUrl;
+    CStdString strDir; strDir.Format("%ld/", MovieChildren[i].id);
+    itemUrl.AppendPath(strDir);
+
+    CFileItemPtr pItem(new CFileItem(itemUrl.ToString(), true));
     pItem->SetLabel(g_localizeStrings.Get(MovieChildren[i].label));
     pItem->SetCanQueue(false);
     items.Add(pItem);

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeMusicVideosOverview.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeMusicVideosOverview.cpp
@@ -22,6 +22,7 @@
 #include "DirectoryNodeMusicVideosOverview.h"
 #include "FileItem.h"
 #include "guilib/LocalizeStrings.h"
+#include "video/VideoDbUrl.h"
 
 using namespace XFILE::VIDEODATABASEDIRECTORY;
 
@@ -60,12 +61,19 @@ CStdString CDirectoryNodeMusicVideosOverview::GetLocalizedName() const
 
 bool CDirectoryNodeMusicVideosOverview::GetContent(CFileItemList& items) const
 {
+  CVideoDbUrl videoUrl;
+  if (!videoUrl.FromString(BuildPath()))
+    return false;
+  
   for (unsigned int i = 0; i < sizeof(MusicVideoChildren) / sizeof(Node); ++i)
   {
     CFileItemPtr pItem(new CFileItem(g_localizeStrings.Get(MusicVideoChildren[i].label)));
-    CStdString strDir;
-    strDir.Format("%ld/", MusicVideoChildren[i].id);
-    pItem->SetPath(BuildPath() + strDir);
+
+    CVideoDbUrl itemUrl = videoUrl;
+    CStdString strDir; strDir.Format("%ld/", MusicVideoChildren[i].id);
+    itemUrl.AppendPath(strDir);
+    pItem->SetPath(itemUrl.ToString());
+
     pItem->m_bIsFolder = true;
     pItem->SetCanQueue(false);
     items.Add(pItem);

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeOverview.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeOverview.cpp
@@ -25,6 +25,7 @@
 #include "settings/Settings.h"
 #include "FileItem.h"
 #include "guilib/LocalizeStrings.h"
+#include "video/VideoDbUrl.h"
 
 using namespace XFILE::VIDEODATABASEDIRECTORY;
 using namespace std;
@@ -64,6 +65,10 @@ CStdString CDirectoryNodeOverview::GetLocalizedName() const
 
 bool CDirectoryNodeOverview::GetContent(CFileItemList& items) const
 {
+  CVideoDbUrl videoUrl;
+  if (!videoUrl.FromString(BuildPath()))
+    return false;
+  
   CVideoDatabase database;
   database.Open();
   bool hasMovies = database.HasContent(VIDEODB_CONTENT_MOVIES);
@@ -100,10 +105,14 @@ bool CDirectoryNodeOverview::GetContent(CFileItemList& items) const
     if (hasMusicVideos)
       vec.push_back(make_pair("6", 20390)); // Recently Added Music Videos
   }
-  CStdString path = BuildPath();
+
   for (unsigned int i = 0; i < vec.size(); ++i)
   {
-    CFileItemPtr pItem(new CFileItem(path + vec[i].first + "/", true));
+    CVideoDbUrl itemUrl = videoUrl;
+    CStdString strDir; strDir.Format("%s/", vec[i].first);
+    itemUrl.AppendPath(strDir);
+
+    CFileItemPtr pItem(new CFileItem(itemUrl.ToString()));
     pItem->SetLabel(g_localizeStrings.Get(vec[i].second));
     pItem->SetLabelPreformated(true);
     pItem->SetCanQueue(false);

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeRecentlyAddedEpisodes.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeRecentlyAddedEpisodes.cpp
@@ -41,9 +41,8 @@ bool CDirectoryNodeRecentlyAddedEpisodes::GetContent(CFileItemList& items) const
   CVideoDatabase videodatabase;
   if (!videodatabase.Open())
     return false;
-
-  CStdString strBaseDir=BuildPath();
-  bool bSuccess=videodatabase.GetRecentlyAddedEpisodesNav(strBaseDir, items);
+  
+  bool bSuccess=videodatabase.GetRecentlyAddedEpisodesNav(BuildPath(), items);
 
   videodatabase.Close();
 

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeRecentlyAddedMovies.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeRecentlyAddedMovies.cpp
@@ -41,9 +41,8 @@ bool CDirectoryNodeRecentlyAddedMovies::GetContent(CFileItemList& items) const
   CVideoDatabase videodatabase;
   if (!videodatabase.Open())
     return false;
-
-  CStdString strBaseDir=BuildPath();
-  bool bSuccess=videodatabase.GetRecentlyAddedMoviesNav(strBaseDir, items);
+  
+  bool bSuccess=videodatabase.GetRecentlyAddedMoviesNav(BuildPath(), items);
 
   videodatabase.Close();
 

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeRecentlyAddedMusicVideos.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeRecentlyAddedMusicVideos.cpp
@@ -41,9 +41,8 @@ bool CDirectoryNodeRecentlyAddedMusicVideos::GetContent(CFileItemList& items) co
   CVideoDatabase videodatabase;
   if (!videodatabase.Open())
     return false;
-
-  CStdString strBaseDir=BuildPath();
-  bool bSuccess=videodatabase.GetRecentlyAddedMusicVideosNav(strBaseDir, items);
+  
+  bool bSuccess=videodatabase.GetRecentlyAddedMusicVideosNav(BuildPath(), items);
 
   videodatabase.Close();
 

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeSeasons.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeSeasons.cpp
@@ -22,6 +22,7 @@
 #include "DirectoryNodeSeasons.h"
 #include "QueryParams.h"
 #include "video/VideoDatabase.h"
+#include "video/VideoDbUrl.h"
 #include "settings/GUISettings.h"
 #include "settings/Settings.h"
 #include "FileItem.h"
@@ -92,8 +93,14 @@ bool CDirectoryNodeSeasons::GetContent(CFileItemList& items) const
   if (bFlatten)
   { // flatten if one season or flatten always
     items.Clear();
-    bSuccess=videodatabase.GetEpisodesNav(BuildPath()+"-2/",items,params.GetGenreId(),params.GetYear(),params.GetActorId(),params.GetDirectorId(),params.GetTvShowId());
-    items.SetPath(BuildPath()+"-2/");
+
+    CVideoDbUrl videoUrl;
+    if (!videoUrl.FromString(BuildPath()))
+      return false;
+  
+    videoUrl.AppendPath("-2/");
+    bSuccess=videodatabase.GetEpisodesNav(videoUrl.ToString(), items, params.GetGenreId(), params.GetYear(), params.GetActorId(), params.GetDirectorId(), params.GetTvShowId());
+    items.SetPath(videoUrl.ToString());
   }
 
   videodatabase.Close();

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeTitleMovies.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeTitleMovies.cpp
@@ -40,8 +40,7 @@ bool CDirectoryNodeTitleMovies::GetContent(CFileItemList& items) const
   CQueryParams params;
   CollectQueryParams(params);
 
-  CStdString strBaseDir=BuildPath();
-  bool bSuccess=videodatabase.GetMoviesNav(strBaseDir, items, params.GetGenreId(), params.GetYear(), params.GetActorId(), params.GetDirectorId(), params.GetStudioId(), params.GetCountryId(), params.GetSetId(), params.GetTagId());
+  bool bSuccess=videodatabase.GetMoviesNav(BuildPath(), items, params.GetGenreId(), params.GetYear(), params.GetActorId(), params.GetDirectorId(), params.GetStudioId(), params.GetCountryId(), params.GetSetId(), params.GetTagId());
 
   videodatabase.Close();
 

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeTitleMusicVideos.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeTitleMusicVideos.cpp
@@ -40,8 +40,7 @@ bool CDirectoryNodeTitleMusicVideos::GetContent(CFileItemList& items) const
   CQueryParams params;
   CollectQueryParams(params);
 
-  CStdString strBaseDir=BuildPath();
-  bool bSuccess=videodatabase.GetMusicVideosNav(strBaseDir, items, params.GetGenreId(), params.GetYear(), params.GetActorId(), params.GetDirectorId(),params.GetStudioId(),params.GetAlbumId());
+  bool bSuccess=videodatabase.GetMusicVideosNav(BuildPath(), items, params.GetGenreId(), params.GetYear(), params.GetActorId(), params.GetDirectorId(),params.GetStudioId(),params.GetAlbumId());
 
   videodatabase.Close();
 

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeTvShowsOverview.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeTvShowsOverview.cpp
@@ -22,6 +22,7 @@
 #include "DirectoryNodeTvShowsOverview.h"
 #include "FileItem.h"
 #include "guilib/LocalizeStrings.h"
+#include "video/VideoDbUrl.h"
 
 using namespace XFILE::VIDEODATABASEDIRECTORY;
 
@@ -61,12 +62,19 @@ CStdString CDirectoryNodeTvShowsOverview::GetLocalizedName() const
 
 bool CDirectoryNodeTvShowsOverview::GetContent(CFileItemList& items) const
 {
+  CVideoDbUrl videoUrl;
+  if (!videoUrl.FromString(BuildPath()))
+    return false;
+
   for (unsigned int i = 0; i < sizeof(TvShowChildren) / sizeof(Node); ++i)
   {
     CFileItemPtr pItem(new CFileItem(g_localizeStrings.Get(TvShowChildren[i].label)));
-    CStdString strDir;
-    strDir.Format("%ld/", TvShowChildren[i].id);
-    pItem->SetPath(BuildPath() + strDir);
+
+    CVideoDbUrl itemUrl = videoUrl;
+    CStdString strDir; strDir.Format("%ld/", TvShowChildren[i].id);
+    itemUrl.AppendPath(strDir);
+    pItem->SetPath(itemUrl.ToString());
+
     pItem->m_bIsFolder = true;
     pItem->SetCanQueue(false);
     items.Add(pItem);

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeYear.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeYear.cpp
@@ -57,8 +57,7 @@ bool CDirectoryNodeYear::GetContent(CFileItemList& items) const
   CQueryParams params;
   CollectQueryParams(params);
 
-  CStdString strBaseDir=BuildPath();
-  bool bSuccess=videodatabase.GetYearsNav(strBaseDir, items, params.GetContentType());
+  bool bSuccess=videodatabase.GetYearsNav(BuildPath(), items, params.GetContentType());
 
   videodatabase.Close();
 

--- a/xbmc/interfaces/http-api/XBMChttp.cpp
+++ b/xbmc/interfaces/http-api/XBMChttp.cpp
@@ -1037,7 +1037,7 @@ int CXbmcHttp::xbmcAddToPlayListFromDB(int numParas, CStdString paras[])
     CMusicDatabase musicdatabase;
     if (!musicdatabase.Open())
       return SetResponse(openTag+ "Error: Could not open music database");
-    musicdatabase.GetSongsByWhere("", where, filelist);
+    musicdatabase.GetSongsByWhere("musicdb://4/", where, filelist);
     musicdatabase.Close();
   }
   else if (type.Equals("movies") || 

--- a/xbmc/interfaces/http-api/XBMChttp.cpp
+++ b/xbmc/interfaces/http-api/XBMChttp.cpp
@@ -1033,7 +1033,6 @@ int CXbmcHttp::xbmcAddToPlayListFromDB(int numParas, CStdString paras[])
   if (type.Equals("songs"))
   {
     playList = PLAYLIST_MUSIC;
-    where = " where " + where;
 
     CMusicDatabase musicdatabase;
     if (!musicdatabase.Open())

--- a/xbmc/interfaces/json-rpc/AudioLibrary.cpp
+++ b/xbmc/interfaces/json-rpc/AudioLibrary.cpp
@@ -73,9 +73,8 @@ JSONRPC_STATUS CAudioLibrary::GetArtistDetails(const CStdString &method, ITransp
     return InternalError;
 
   CFileItemList items;
-  CStdString where;
-  where.Format("idArtist = %d", artistID);
-  if (!musicdatabase.GetArtistsByWhere("musicdb://2/", where, items) || items.Size() != 1)
+  CDatabase::Filter filter(musicdatabase.PrepareSQL("idArtist = %d", artistID));
+  if (!musicdatabase.GetArtistsByWhere("musicdb://2/", filter, items) || items.Size() != 1)
     return InvalidParams;
 
   HandleFileItem("artistid", false, "artistdetails", items[0], parameterObject, parameterObject["properties"], result, false);

--- a/xbmc/music/Makefile
+++ b/xbmc/music/Makefile
@@ -3,6 +3,7 @@ SRCS=Album.cpp \
      GUIViewStateMusic.cpp \
      LastFmManager.cpp \
      MusicDatabase.cpp \
+     MusicDbUrl.cpp \
      MusicInfoLoader.cpp \
      Song.cpp \
      

--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -2716,9 +2716,10 @@ bool CMusicDatabase::GetYearsNav(const CStdString& strBaseDir, CFileItemList& it
 
 bool CMusicDatabase::GetAlbumsByYear(const CStdString& strBaseDir, CFileItemList& items, int year)
 {
-  CStdString where = PrepareSQL("where iYear=%ld", year);
+  Filter filter;
+  filter.where = PrepareSQL("iYear=%ld", year);
 
-  return GetAlbumsByWhere(strBaseDir, where, "", items);
+  return GetAlbumsByWhere(strBaseDir, filter, items);
 }
 
 bool CMusicDatabase::GetArtistsNav(const CStdString& strBaseDir, CFileItemList& items, int idGenre, bool albumArtistsOnly)
@@ -2790,16 +2791,24 @@ bool CMusicDatabase::GetArtistsNav(const CStdString& strBaseDir, CFileItemList& 
   return false;
 }
 
-bool CMusicDatabase::GetArtistsByWhere(const CStdString& strBaseDir, const CStdString &where, CFileItemList& items)
+bool CMusicDatabase::GetArtistsByWhere(const CStdString& strBaseDir, const Filter &filter, CFileItemList& items)
 {
   if (NULL == m_pDB.get()) return false;
   if (NULL == m_pDS.get()) return false;
 
   try
   {
-    CStdString strSQL = "select * from artistview";
-    if (!where.empty())
-       strSQL += " WHERE " + where;
+    CStdString strSQL = PrepareSQL("select %s from artistview ", !filter.fields.empty() ? filter.fields.c_str() : "*");
+    if (!filter.join.empty())
+      strSQL += filter.join;
+    if (!filter.where.empty())
+      strSQL += " WHERE " + filter.where;
+    if (!filter.group.empty())
+      strSQL += " GROUP BY " + filter.group;
+    if (!filter.order.empty())
+      strSQL += " ORDER BY " + filter.order;
+    if (!filter.limit.empty())
+      strSQL += " LIMIT " + filter.limit;
 
     // run query
     CLog::Log(LOGDEBUG, "%s query: %s", __FUNCTION__, strSQL.c_str());
@@ -2908,60 +2917,31 @@ bool CMusicDatabase::GetAlbumFromSong(const CSong &song, CAlbum &album)
 
 bool CMusicDatabase::GetAlbumsNav(const CStdString& strBaseDir, CFileItemList& items, int idGenre, int idArtist, int start, int end, const SortDescription &sortDescription /* = SortDescription() */)
 {
+  Filter filter;
   //Create limit
-  CStdString limit;
   if (start >= 0 && end >= 0)
-  {
-    limit.Format(" limit %i,%i", start, end);
-  }
+    filter.limit = PrepareSQL("%i,%i", start, end);
 
   // where clause
-  CStdString strWhere;
-  if (idGenre!=-1)
-  {
-    strWhere+=PrepareSQL("where (idAlbum IN "
-                          "("
-                          "select song.idAlbum from song " // All song genres
-                            "JOIN song_genre ON song.idSong=song_genre.idSong "
-                          "where song_genre.idGenre=%i"
-                          ")"
-                        ") " + limit
-                        , idGenre);
-  }
+  if (idGenre != -1)
+    filter.where = PrepareSQL("(idAlbum IN (SELECT song.idAlbum FROM song JOIN song_genre ON song.idSong = song_genre.idSong WHERE song_genre.idGenre = %i))", idGenre);
 
-  if (idArtist!=-1)
-  {
-    if (strWhere.IsEmpty())
-      strWhere += "where ";
-    else
-      strWhere += "and ";
-
-    strWhere +=PrepareSQL("(idAlbum IN "
-                            "("
-                              "select song.idAlbum from song "                 // All albums linked to this artist via songs
-                                "JOIN song_artist ON song.idSong=song_artist.idSong "
-                              "WHERE song_artist.idArtist=%i"
-                            ")"
-                          " or idAlbum IN "
-                            "("
-                              "select album_artist.idAlbum from album_artist " // All albums where album artists fit
-                              "where album_artist.idArtist=%i"
-                            ")"
-                          ") " + limit
-                          , idArtist, idArtist);
-  }
+  if (idArtist != -1)
+    filter.AppendWhere(PrepareSQL("(idAlbum IN "
+                                    // All albums linked to this artist via songs
+                                    "(SELECT song.idAlbum FROM song JOIN song_artist ON song.idSong = song_artist.idSong WHERE song_artist.idArtist = %i)"
+                                  " OR idAlbum IN "
+                                    // All albums where album artists fit
+                                    "(SELECT album_artist.idAlbum FROM album_artist WHERE album_artist.idArtist = %i)"
+                                  ")", idArtist, idArtist));
   else
-  { // no artist given, so exclude any single albums (aka empty tagged albums)
-    if (strWhere.IsEmpty())
-      strWhere += "where albumview.strAlbum <> ''" + limit;
-    else
-      strWhere += "and albumview.strAlbum <> ''" + limit;
-  }
+    // no artist given, so exclude any single albums (aka empty tagged albums)
+    filter.AppendWhere("albumview.strAlbum <> ''");
 
-  return GetAlbumsByWhere(strBaseDir, strWhere, "", items, sortDescription);
+  return GetAlbumsByWhere(strBaseDir, filter, items, sortDescription);
 }
 
-bool CMusicDatabase::GetAlbumsByWhere(const CStdString &baseDir, const CStdString &where, const CStdString &order, CFileItemList &items, const SortDescription &sortDescription /* = SortDescription() */)
+bool CMusicDatabase::GetAlbumsByWhere(const CStdString &baseDir, const Filter &filter, CFileItemList &items, const SortDescription &sortDescription /* = SortDescription() */)
 {
   if (m_pDB.get() == NULL || m_pDS.get() == NULL)
     return false;
@@ -2970,22 +2950,32 @@ bool CMusicDatabase::GetAlbumsByWhere(const CStdString &baseDir, const CStdStrin
   {
     int total = -1;
 
-    CStdString sql = "select * from albumview " + where;
+    CStdString strSQL = "select %s from albumview ";
+    CStdString strSQLExtra;
+    if (!filter.join.empty())
+      strSQLExtra += filter.join;
+    if (!filter.where.empty())
+      strSQLExtra += " WHERE " + filter.where;
+    if (!filter.group.empty())
+      strSQLExtra += " GROUP BY " + filter.group;
+    if (!filter.order.empty())
+      strSQLExtra += " ORDER BY " + filter.order;
+    if (!filter.limit.empty())
+      strSQLExtra += " LIMIT " + filter.limit;
     // Apply the limiting directly here if there's no special sorting but limiting
-    CStdString whereLower = where;
-    whereLower.ToLower();
-    if (whereLower.find(" limit ") == string::npos &&
-        sortDescription.sortBy == SortByNone &&
-       (sortDescription.limitStart > 0 || sortDescription.limitEnd > 0))
+    else if (sortDescription.sortBy == SortByNone &&
+            (sortDescription.limitStart > 0 || sortDescription.limitEnd > 0))
     {
-      total = (int)strtol(GetSingleValue("SELECT COUNT(1) FROM albumview " + where, m_pDS).c_str(), NULL, 10);
-      sql += DatabaseUtils::BuildLimitClause(sortDescription.limitEnd, sortDescription.limitStart);
+      total = (int)strtol(GetSingleValue(PrepareSQL(strSQL, "COUNT(1)") + strSQLExtra, m_pDS).c_str(), NULL, 10);
+      strSQLExtra += DatabaseUtils::BuildLimitClause(sortDescription.limitEnd, sortDescription.limitStart);
     }
 
-    CLog::Log(LOGDEBUG, "%s query: %s", __FUNCTION__, sql.c_str());
+    strSQL = PrepareSQL(strSQL, !filter.fields.empty() ? filter.fields.c_str() : "*") + strSQLExtra;
+
+    CLog::Log(LOGDEBUG, "%s query: %s", __FUNCTION__, strSQL.c_str());
     // run query
     unsigned int time = XbmcThreads::SystemClockMillis();
-    if (!m_pDS->query(sql.c_str()))
+    if (!m_pDS->query(strSQL.c_str()))
       return false;
     CLog::Log(LOGDEBUG, "%s - query took %i ms",
               __FUNCTION__, XbmcThreads::SystemClockMillis() - time); time = XbmcThreads::SystemClockMillis();
@@ -3038,12 +3028,12 @@ bool CMusicDatabase::GetAlbumsByWhere(const CStdString &baseDir, const CStdStrin
   catch (...)
   {
     m_pDS->close();
-    CLog::Log(LOGERROR, "%s (%s) failed", __FUNCTION__, where.c_str());
+    CLog::Log(LOGERROR, "%s (%s) failed", __FUNCTION__, filter.where.c_str());
   }
   return false;
 }
 
-bool CMusicDatabase::GetSongsByWhere(const CStdString &baseDir, const CStdString &whereClause, CFileItemList &items, const SortDescription &sortDescription /* = SortDescription() */)
+bool CMusicDatabase::GetSongsByWhere(const CStdString &baseDir, const Filter &filter, CFileItemList &items, const SortDescription &sortDescription /* = SortDescription() */)
 {
   if (m_pDB.get() == NULL || m_pDS.get() == NULL)
     return false;
@@ -3053,18 +3043,27 @@ bool CMusicDatabase::GetSongsByWhere(const CStdString &baseDir, const CStdString
     unsigned int time = XbmcThreads::SystemClockMillis();
     int total = -1;
 
-    // We don't use PrepareSQL here, as the WHERE clause is already formatted.
-    CStdString strSQL = "select * from songview " + whereClause;
+    CStdString strSQL = "select %s from songview ";
+    CStdString strSQLExtra;
+    if (!filter.join.empty())
+      strSQLExtra += filter.join;
+    if (!filter.where.empty())
+      strSQLExtra += " WHERE " + filter.where;
+    if (!filter.group.empty())
+      strSQLExtra += " GROUP BY " + filter.group;
+    if (!filter.order.empty())
+      strSQLExtra += " ORDER BY " + filter.order;
+    if (!filter.limit.empty())
+      strSQLExtra += " LIMIT " + filter.limit;
     // Apply the limiting directly here if there's no special sorting but limiting
-    CStdString whereLower = whereClause;
-    whereLower.ToLower();
-    if (whereLower.find(" limit ") == string::npos &&
-        sortDescription.sortBy == SortByNone &&
-       (sortDescription.limitStart > 0 || sortDescription.limitEnd > 0))
+    else if (sortDescription.sortBy == SortByNone &&
+            (sortDescription.limitStart > 0 || sortDescription.limitEnd > 0))
     {
-      total = (int)strtol(GetSingleValue("SELECT COUNT(1) FROM songview " + whereClause, m_pDS).c_str(), NULL, 10);
-      strSQL += DatabaseUtils::BuildLimitClause(sortDescription.limitEnd, sortDescription.limitStart);
+      total = (int)strtol(GetSingleValue(PrepareSQL(strSQL, "COUNT(1)") + strSQLExtra, m_pDS).c_str(), NULL, 10);
+      strSQLExtra += DatabaseUtils::BuildLimitClause(sortDescription.limitEnd, sortDescription.limitStart);
     }
+
+    strSQL = PrepareSQL(strSQL, !filter.fields.empty() ? filter.fields.c_str() : "*") + strSQLExtra;
 
     CLog::Log(LOGDEBUG, "%s query = %s", __FUNCTION__, strSQL.c_str());
     // run query
@@ -3108,77 +3107,48 @@ bool CMusicDatabase::GetSongsByWhere(const CStdString &baseDir, const CStdString
       catch (...)
       {
         m_pDS->close();
-        CLog::Log(LOGERROR, "%s: out of memory loading query: %s", __FUNCTION__, whereClause.c_str());
+        CLog::Log(LOGERROR, "%s: out of memory loading query: %s", __FUNCTION__, filter.where.c_str());
         return (items.Size() > 0);
       }
     }
     // cleanup
     m_pDS->close();
-    CLog::Log(LOGDEBUG, "%s(%s) - took %d ms", __FUNCTION__, whereClause.c_str(), XbmcThreads::SystemClockMillis() - time);
+    CLog::Log(LOGDEBUG, "%s(%s) - took %d ms", __FUNCTION__, filter.where.c_str(), XbmcThreads::SystemClockMillis() - time);
     return true;
   }
   catch (...)
   {
     // cleanup
     m_pDS->close();
-    CLog::Log(LOGERROR, "%s(%s) failed", __FUNCTION__, whereClause.c_str());
+    CLog::Log(LOGERROR, "%s(%s) failed", __FUNCTION__, filter.where.c_str());
   }
   return false;
 }
 
 bool CMusicDatabase::GetSongsByYear(const CStdString& baseDir, CFileItemList& items, int year)
 {
-  CStdString where=PrepareSQL("where (iYear=%ld)", year);
-  return GetSongsByWhere(baseDir, where, items);
+  Filter filter(PrepareSQL("iYear = %ld", year));
+  return GetSongsByWhere(baseDir, filter, items);
 }
 
 bool CMusicDatabase::GetSongsNav(const CStdString& strBaseDir, CFileItemList& items, int idGenre, int idArtist,int idAlbum, const SortDescription &sortDescription /* = SortDescription() */)
 {
-  CStdString strWhere;
-
+  Filter filter;
   if (idAlbum!=-1)
-    strWhere=PrepareSQL("where (idAlbum=%ld) ", idAlbum);
+    filter.where = PrepareSQL("idAlbum = %ld", idAlbum);
 
   if (idGenre!=-1)
-  {
-    if (strWhere.IsEmpty())
-      strWhere += "where ";
-    else
-      strWhere += "and ";
-
-    strWhere += PrepareSQL("(idSong IN "
-                            "("
-                            "SELECT song_genre.idSong FROM song_genre "
-                            "WHERE song_genre.idGenre = %i"
-                            ")"
-                          ") "
-                          , idGenre);
-  }
+    filter.AppendWhere(PrepareSQL("idSong IN (SELECT song_genre.idSong FROM song_genre WHERE song_genre.idGenre = %i)", idGenre));
 
   if (idArtist!=-1)
-  {
-    if (strWhere.IsEmpty())
-      strWhere += "where ";
-    else
-      strWhere += "and ";
-
-    strWhere += PrepareSQL("(idSong IN " // song artists
-                            "("
-                            "SELECT song_artist.idSong FROM song_artist "
-                            "WHERE song_artist.idArtist=%i"
-                            ") "
-                          "or idSong IN " // album artists
-                            "("
-                            "SELECT song.idSong FROM song "
-                            "JOIN album_artist ON song.idAlbum=album_artist.idAlbum "
-                            "WHERE album_artist.idArtist=%i"
-                            ")"
-                          ") "
-                          , idArtist, idArtist);
-  }
+    filter.AppendWhere(PrepareSQL("idSong IN (" // song artists
+                                    "SELECT song_artist.idSong FROM song_artist WHERE song_artist.idArtist = %i"
+                                  ") OR idSong IN (" // album artists
+                                    "SELECT song.idSong FROM song JOIN album_artist ON song.idAlbum=album_artist.idAlbum WHERE album_artist.idArtist = %i"
+                                  ")", idArtist, idArtist));
 
   // run query
-  return GetSongsByWhere(strBaseDir, strWhere, items, sortDescription);
+  return GetSongsByWhere(strBaseDir, filter, items, sortDescription);
 }
 
 bool CMusicDatabase::UpdateOldVersion(int version)
@@ -3522,14 +3492,25 @@ bool CMusicDatabase::UpdateOldVersion(int version)
   return true;
 }
 
-unsigned int CMusicDatabase::GetSongIDs(const CStdString& strWhere, vector<pair<int,int> > &songIDs)
+unsigned int CMusicDatabase::GetSongIDs(const Filter &filter, vector<pair<int,int> > &songIDs)
 {
   try
   {
     if (NULL == m_pDB.get()) return 0;
     if (NULL == m_pDS.get()) return 0;
 
-    CStdString strSQL = "select idSong from songview " + strWhere;
+    CStdString strSQL = "select idSong from songview ";
+    if (!filter.join.empty())
+      strSQL += filter.join;
+    if (!filter.where.empty())
+      strSQL += " WHERE " + filter.where;
+    if (!filter.group.empty())
+      strSQL += " GROUP BY " + filter.group;
+    if (!filter.order.empty())
+      strSQL += " ORDER BY " + filter.order;
+    if (!filter.limit.empty())
+      strSQL += " LIMIT " + filter.limit;
+
     if (!m_pDS->query(strSQL.c_str())) return 0;
     songIDs.clear();
     if (m_pDS->num_rows() == 0)
@@ -3548,19 +3529,30 @@ unsigned int CMusicDatabase::GetSongIDs(const CStdString& strWhere, vector<pair<
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "%s(%s) failed", __FUNCTION__, strWhere.c_str());
+    CLog::Log(LOGERROR, "%s(%) failed", __FUNCTION__, filter.where.c_str());
   }
   return 0;
 }
 
-int CMusicDatabase::GetSongsCount(const CStdString& strWhere)
+int CMusicDatabase::GetSongsCount(const Filter &filter)
 {
   try
   {
     if (NULL == m_pDB.get()) return 0;
     if (NULL == m_pDS.get()) return 0;
 
-    CStdString strSQL = "select count(idSong) as NumSongs from songview " + strWhere;
+    CStdString strSQL = "select count(idSong) as NumSongs from songview ";
+    if (!filter.join.empty())
+      strSQL += filter.join;
+    if (!filter.where.empty())
+      strSQL += " WHERE " + filter.where;
+    if (!filter.group.empty())
+      strSQL += " GROUP BY " + filter.group;
+    if (!filter.order.empty())
+      strSQL += " ORDER BY " + filter.order;
+    if (!filter.limit.empty())
+      strSQL += " LIMIT " + filter.limit;
+
     if (!m_pDS->query(strSQL.c_str())) return false;
     if (m_pDS->num_rows() == 0)
     {
@@ -3575,7 +3567,7 @@ int CMusicDatabase::GetSongsCount(const CStdString& strWhere)
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "%s(%s) failed", __FUNCTION__, strWhere.c_str());
+    CLog::Log(LOGERROR, "%s(%s) failed", __FUNCTION__, filter.where.c_str());
   }
   return 0;
 }
@@ -3790,13 +3782,13 @@ int CMusicDatabase::GetGenreByName(const CStdString& strGenre)
   return -1;
 }
 
-bool CMusicDatabase::GetRandomSong(CFileItem* item, int& idSong, const CStdString& strWhere)
+bool CMusicDatabase::GetRandomSong(CFileItem* item, int& idSong, const Filter &filter)
 {
   try
   {
     idSong = -1;
 
-    int iCount = GetSongsCount(strWhere);
+    int iCount = GetSongsCount(filter);
     if (iCount <= 0)
       return false;
     int iRandom = rand() % iCount;
@@ -3805,8 +3797,22 @@ bool CMusicDatabase::GetRandomSong(CFileItem* item, int& idSong, const CStdStrin
     if (NULL == m_pDS.get()) return false;
 
     // We don't use PrepareSQL here, as the WHERE clause is already formatted
-    CStdString strSQL;
-    strSQL.Format("select * from songview %s order by idSong limit 1 offset %i", strWhere.c_str(), iRandom);
+    CStdString strSQL = PrepareSQL("select %s from songview ", !filter.fields.empty() ? filter.fields.c_str() : "*");
+    Filter extFilter = filter;
+    extFilter.AppendOrder("idSong");
+    extFilter.limit = "1";
+
+    if (!extFilter.join.empty())
+      strSQL += extFilter.join;
+    if (!extFilter.where.empty())
+      strSQL += " WHERE " + extFilter.where;
+    if (!extFilter.group.empty())
+      strSQL += " GROUP BY " + extFilter.group;
+    if (!extFilter.order.empty())
+      strSQL += " ORDER BY " + extFilter.order;
+    if (!extFilter.limit.empty())
+      strSQL += " LIMIT " + extFilter.limit;
+    strSQL += PrepareSQL(" OFFSET %i", iRandom);
 
     CLog::Log(LOGDEBUG, "%s query = %s", __FUNCTION__, strSQL.c_str());
     // run query
@@ -3825,19 +3831,21 @@ bool CMusicDatabase::GetRandomSong(CFileItem* item, int& idSong, const CStdStrin
   }
   catch(...)
   {
-    CLog::Log(LOGERROR, "%s(%s) failed", __FUNCTION__, strWhere.c_str());
+    CLog::Log(LOGERROR, "%s(%s) failed", __FUNCTION__, filter.where.c_str());
   }
   return false;
 }
 
 bool CMusicDatabase::GetCompilationAlbums(const CStdString& strBaseDir, CFileItemList& items)
 {
-  return GetAlbumsByWhere(strBaseDir, "WHERE bCompilation = 1", "", items);
+  Filter filter("bCompilation = 1");
+  return GetAlbumsByWhere(strBaseDir, filter, items);
 }
 
 bool CMusicDatabase::GetCompilationSongs(const CStdString& strBaseDir, CFileItemList& items)
 {
-  return GetSongsByWhere(strBaseDir, "WHERE bCompilation = 1", items);
+  Filter filter("bCompilation = 1");
+  return GetSongsByWhere(strBaseDir, filter, items);
 }
 
 int CMusicDatabase::GetCompilationAlbumsCount()
@@ -4090,7 +4098,7 @@ bool CMusicDatabase::CommitTransaction()
 {
   if (CDatabase::CommitTransaction())
   { // number of items in the db has likely changed, so reset the infomanager cache
-    g_infoManager.SetLibraryBool(LIBRARY_HAS_MUSIC, GetSongsCount("") > 0);
+    g_infoManager.SetLibraryBool(LIBRARY_HAS_MUSIC, GetSongsCount() > 0);
     return true;
   }
   return false;

--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -2799,16 +2799,8 @@ bool CMusicDatabase::GetArtistsByWhere(const CStdString& strBaseDir, const Filte
   try
   {
     CStdString strSQL = PrepareSQL("select %s from artistview ", !filter.fields.empty() ? filter.fields.c_str() : "*");
-    if (!filter.join.empty())
-      strSQL += filter.join;
-    if (!filter.where.empty())
-      strSQL += " WHERE " + filter.where;
-    if (!filter.group.empty())
-      strSQL += " GROUP BY " + filter.group;
-    if (!filter.order.empty())
-      strSQL += " ORDER BY " + filter.order;
-    if (!filter.limit.empty())
-      strSQL += " LIMIT " + filter.limit;
+    if (!BuildSQL(strSQL, filter, strSQL))
+      return false;
 
     // run query
     CLog::Log(LOGDEBUG, "%s query: %s", __FUNCTION__, strSQL.c_str());
@@ -2951,20 +2943,15 @@ bool CMusicDatabase::GetAlbumsByWhere(const CStdString &baseDir, const Filter &f
     int total = -1;
 
     CStdString strSQL = "select %s from albumview ";
+
     CStdString strSQLExtra;
-    if (!filter.join.empty())
-      strSQLExtra += filter.join;
-    if (!filter.where.empty())
-      strSQLExtra += " WHERE " + filter.where;
-    if (!filter.group.empty())
-      strSQLExtra += " GROUP BY " + filter.group;
-    if (!filter.order.empty())
-      strSQLExtra += " ORDER BY " + filter.order;
-    if (!filter.limit.empty())
-      strSQLExtra += " LIMIT " + filter.limit;
+    if (!BuildSQL(strSQLExtra, filter, strSQLExtra))
+      return false;
+
     // Apply the limiting directly here if there's no special sorting but limiting
-    else if (sortDescription.sortBy == SortByNone &&
-            (sortDescription.limitStart > 0 || sortDescription.limitEnd > 0))
+    if (filter.limit.empty() &&
+        sortDescription.sortBy == SortByNone &&
+       (sortDescription.limitStart > 0 || sortDescription.limitEnd > 0))
     {
       total = (int)strtol(GetSingleValue(PrepareSQL(strSQL, "COUNT(1)") + strSQLExtra, m_pDS).c_str(), NULL, 10);
       strSQLExtra += DatabaseUtils::BuildLimitClause(sortDescription.limitEnd, sortDescription.limitStart);
@@ -3044,20 +3031,15 @@ bool CMusicDatabase::GetSongsByWhere(const CStdString &baseDir, const Filter &fi
     int total = -1;
 
     CStdString strSQL = "select %s from songview ";
+
     CStdString strSQLExtra;
-    if (!filter.join.empty())
-      strSQLExtra += filter.join;
-    if (!filter.where.empty())
-      strSQLExtra += " WHERE " + filter.where;
-    if (!filter.group.empty())
-      strSQLExtra += " GROUP BY " + filter.group;
-    if (!filter.order.empty())
-      strSQLExtra += " ORDER BY " + filter.order;
-    if (!filter.limit.empty())
-      strSQLExtra += " LIMIT " + filter.limit;
+    if (!BuildSQL(strSQLExtra, filter, strSQLExtra))
+      return false;
+
     // Apply the limiting directly here if there's no special sorting but limiting
-    else if (sortDescription.sortBy == SortByNone &&
-            (sortDescription.limitStart > 0 || sortDescription.limitEnd > 0))
+    if (filter.limit.empty() &&
+        sortDescription.sortBy == SortByNone &&
+       (sortDescription.limitStart > 0 || sortDescription.limitEnd > 0))
     {
       total = (int)strtol(GetSingleValue(PrepareSQL(strSQL, "COUNT(1)") + strSQLExtra, m_pDS).c_str(), NULL, 10);
       strSQLExtra += DatabaseUtils::BuildLimitClause(sortDescription.limitEnd, sortDescription.limitStart);
@@ -3500,16 +3482,8 @@ unsigned int CMusicDatabase::GetSongIDs(const Filter &filter, vector<pair<int,in
     if (NULL == m_pDS.get()) return 0;
 
     CStdString strSQL = "select idSong from songview ";
-    if (!filter.join.empty())
-      strSQL += filter.join;
-    if (!filter.where.empty())
-      strSQL += " WHERE " + filter.where;
-    if (!filter.group.empty())
-      strSQL += " GROUP BY " + filter.group;
-    if (!filter.order.empty())
-      strSQL += " ORDER BY " + filter.order;
-    if (!filter.limit.empty())
-      strSQL += " LIMIT " + filter.limit;
+    if (!BuildSQL(strSQL, filter, strSQL))
+      return false;
 
     if (!m_pDS->query(strSQL.c_str())) return 0;
     songIDs.clear();
@@ -3542,16 +3516,8 @@ int CMusicDatabase::GetSongsCount(const Filter &filter)
     if (NULL == m_pDS.get()) return 0;
 
     CStdString strSQL = "select count(idSong) as NumSongs from songview ";
-    if (!filter.join.empty())
-      strSQL += filter.join;
-    if (!filter.where.empty())
-      strSQL += " WHERE " + filter.where;
-    if (!filter.group.empty())
-      strSQL += " GROUP BY " + filter.group;
-    if (!filter.order.empty())
-      strSQL += " ORDER BY " + filter.order;
-    if (!filter.limit.empty())
-      strSQL += " LIMIT " + filter.limit;
+    if (!BuildSQL(strSQL, filter, strSQL))
+      return false;
 
     if (!m_pDS->query(strSQL.c_str())) return false;
     if (m_pDS->num_rows() == 0)
@@ -3802,16 +3768,9 @@ bool CMusicDatabase::GetRandomSong(CFileItem* item, int& idSong, const Filter &f
     extFilter.AppendOrder("idSong");
     extFilter.limit = "1";
 
-    if (!extFilter.join.empty())
-      strSQL += extFilter.join;
-    if (!extFilter.where.empty())
-      strSQL += " WHERE " + extFilter.where;
-    if (!extFilter.group.empty())
-      strSQL += " GROUP BY " + extFilter.group;
-    if (!extFilter.order.empty())
-      strSQL += " ORDER BY " + extFilter.order;
-    if (!extFilter.limit.empty())
-      strSQL += " LIMIT " + extFilter.limit;
+    if (!BuildSQL(strSQL, extFilter, strSQL))
+      return false;
+
     strSQL += PrepareSQL(" OFFSET %i", iRandom);
 
     CLog::Log(LOGDEBUG, "%s query = %s", __FUNCTION__, strSQL.c_str());

--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -5136,6 +5136,17 @@ bool CMusicDatabase::GetFilter(const CMusicDbUrl &musicUrl, Filter &filter)
   else
     return false;
 
+  option = options.find("xsp");
+  if (option != options.end())
+  {
+    CSmartPlaylist xsp;
+    if (!xsp.LoadFromJson(option->second.asString()))
+      return false;
+
+    std::set<CStdString> playlists;
+    filter.AppendWhere(xsp.GetWhereClause(*this, playlists));
+  }
+
   return true;
 }
 

--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -452,7 +452,7 @@ int CMusicDatabase::AddAlbum(const CStdString& strAlbum1, const CStdString &strA
     if (NULL == m_pDB.get()) return -1;
     if (NULL == m_pDS.get()) return -1;
 
-    map <CStdString, CAlbumCache>::const_iterator it;
+    map <CStdString, CAlbum>::const_iterator it;
 
     it = m_albumCache.find(strAlbum + strArtist);
     if (it != m_albumCache.end())
@@ -468,22 +468,22 @@ int CMusicDatabase::AddAlbum(const CStdString& strAlbum1, const CStdString &strA
       strSQL=PrepareSQL("insert into album (idAlbum, strAlbum, strArtists, strGenres, iYear, bCompilation) values( NULL, '%s', '%s', '%s', %i, %i)", strAlbum.c_str(), strArtist.c_str(), strGenre.c_str(), year, bCompilation);
       m_pDS->exec(strSQL.c_str());
 
-      CAlbumCache album;
+      CAlbum album;
       album.idAlbum = (int)m_pDS->lastinsertid();
       album.strAlbum = strAlbum;
       album.artist = StringUtils::Split(strArtist, g_advancedSettings.m_musicItemSeparator);
-      m_albumCache.insert(pair<CStdString, CAlbumCache>(album.strAlbum + strArtist, album));
+      m_albumCache.insert(pair<CStdString, CAlbum>(album.strAlbum + strArtist, album));
       return album.idAlbum;
     }
     else
     {
       // exists in our database and not scanned during this scan, so we should update it as the details
       // may have changed (there's a reason we're rescanning, afterall!)
-      CAlbumCache album;
+      CAlbum album;
       album.idAlbum = m_pDS->fv("idAlbum").get_asInt();
       album.strAlbum = strAlbum;
       album.artist = StringUtils::Split(strArtist, g_advancedSettings.m_musicItemSeparator);
-      m_albumCache.insert(pair<CStdString, CAlbumCache>(album.strAlbum + strArtist, album));
+      m_albumCache.insert(pair<CStdString, CAlbum>(album.strAlbum + strArtist, album));
       m_pDS->close();
       strSQL=PrepareSQL("update album set strGenres='%s', iYear=%i where idAlbum=%i", strGenre.c_str(), year, album.idAlbum);
       m_pDS->exec(strSQL.c_str());
@@ -2354,10 +2354,10 @@ void CMusicDatabase::DeleteAlbumInfo()
     m_pDS->close();
     CGUIDialogOK::ShowAndGetInput(313, 425, 0, 0);
   }
-  vector<CAlbumCache> vecAlbums;
+  vector<CAlbum> vecAlbums;
   while (!m_pDS->eof())
   {
-    CAlbumCache album;
+    CAlbum album;
     album.idAlbum = m_pDS->fv("album.idAlbum").get_asInt() ;
     album.strAlbum = m_pDS->fv("album.strAlbum").get_asString();
     album.artist = StringUtils::Split(m_pDS->fv("album.strArtists").get_asString(), g_advancedSettings.m_musicItemSeparator);
@@ -2374,7 +2374,7 @@ void CMusicDatabase::DeleteAlbumInfo()
     pDlg->Reset();
     for (int i = 0; i < (int)vecAlbums.size(); ++i)
     {
-      CMusicDatabase::CAlbumCache& album = vecAlbums[i];
+      CAlbum& album = vecAlbums[i];
       pDlg->Add(album.strAlbum + " - " + StringUtils::Join(album.artist, g_advancedSettings.m_musicItemSeparator));
     }
     pDlg->DoModal();
@@ -2387,7 +2387,7 @@ void CMusicDatabase::DeleteAlbumInfo()
       return ;
     }
 
-    CAlbumCache& album = vecAlbums[iSelectedAlbum];
+    CAlbum& album = vecAlbums[iSelectedAlbum];
     strSQL=PrepareSQL("delete from albuminfo where albuminfo.idAlbum=%i", album.idAlbum);
     if (!m_pDS->exec(strSQL.c_str())) return ;
 

--- a/xbmc/music/MusicDatabase.h
+++ b/xbmc/music/MusicDatabase.h
@@ -27,6 +27,7 @@
 #include "Album.h"
 #include "addons/Scraper.h"
 #include "utils/SortUtils.h"
+#include "MusicDbUrl.h"
 
 class CArtist;
 class CFileItem;
@@ -152,7 +153,7 @@ public:
   bool GetGenresNav(const CStdString& strBaseDir, CFileItemList& items);
   bool GetYearsNav(const CStdString& strBaseDir, CFileItemList& items);
   bool GetArtistsNav(const CStdString& strBaseDir, CFileItemList& items, int idGenre, bool albumArtistsOnly);
-  bool GetAlbumsNav(const CStdString& strBaseDir, CFileItemList& items, int idGenre, int idArtist, int start, int end, const SortDescription &sortDescription = SortDescription());
+  bool GetAlbumsNav(const CStdString& strBaseDir, CFileItemList& items, int idGenre = -1, int idArtist = -1, const SortDescription &sortDescription = SortDescription());
   bool GetAlbumsByYear(const CStdString &strBaseDir, CFileItemList& items, int year);
   bool GetSongsNav(const CStdString& strBaseDir, CFileItemList& items, int idGenre, int idArtist,int idAlbum, const SortDescription &sortDescription = SortDescription());
   bool GetSongsByYear(const CStdString& baseDir, CFileItemList& items, int year);
@@ -263,6 +264,8 @@ public:
    \sa GetArtForItem
    */
   std::string GetArtistArtForItem(int mediaId, const std::string &mediaType, const std::string &artType);
+
+  bool GetFilter(const CMusicDbUrl &musicUrl, Filter &filter);
 
 protected:
   std::map<CStdString, int> m_artistCache;
@@ -387,4 +390,6 @@ private:
 
   void AnnounceRemove(std::string content, int id);
   void AnnounceUpdate(std::string content, int id);
+
+  bool BuildSQL(const CStdString &strBaseDir, const CStdString &strQuery, Filter &filter, CStdString &strSQL, CMusicDbUrl &musicUrl);
 };

--- a/xbmc/music/MusicDatabase.h
+++ b/xbmc/music/MusicDatabase.h
@@ -88,33 +88,6 @@ class CMusicDatabase : public CDatabase
 {
   friend class DatabaseUtils;
 
-  class CArtistCache
-  {
-  public:
-    int idArtist;
-    CStdString strArtist;
-  };
-
-  class CPathCache
-  {
-  public:
-    int idPath;
-    CStdString strPath;
-  };
-
-  class CGenreCache
-  {
-  public:
-    int idGenre;
-    CStdString strGenre;
-  };
-
-  class CAlbumCache : public CAlbum
-  {
-  public:
-    int idAlbum;
-  };
-
 public:
   CMusicDatabase(void);
   virtual ~CMusicDatabase(void);
@@ -292,11 +265,11 @@ public:
   std::string GetArtistArtForItem(int mediaId, const std::string &mediaType, const std::string &artType);
 
 protected:
-  std::map<CStdString, int /*CArtistCache*/> m_artistCache;
-  std::map<CStdString, int /*CGenreCache*/> m_genreCache;
-  std::map<CStdString, int /*CPathCache*/> m_pathCache;
-  std::map<CStdString, int /*CPathCache*/> m_thumbCache;
-  std::map<CStdString, CAlbumCache> m_albumCache;
+  std::map<CStdString, int> m_artistCache;
+  std::map<CStdString, int> m_genreCache;
+  std::map<CStdString, int> m_pathCache;
+  std::map<CStdString, int> m_thumbCache;
+  std::map<CStdString, CAlbum> m_albumCache;
 
   virtual bool CreateTables();
   virtual int GetMinVersion() const { return 27; };

--- a/xbmc/music/MusicDatabase.h
+++ b/xbmc/music/MusicDatabase.h
@@ -156,13 +156,13 @@ public:
   bool GetAlbumsByYear(const CStdString &strBaseDir, CFileItemList& items, int year);
   bool GetSongsNav(const CStdString& strBaseDir, CFileItemList& items, int idGenre, int idArtist,int idAlbum, const SortDescription &sortDescription = SortDescription());
   bool GetSongsByYear(const CStdString& baseDir, CFileItemList& items, int year);
-  bool GetSongsByWhere(const CStdString &baseDir, const CStdString &whereClause, CFileItemList& items, const SortDescription &sortDescription = SortDescription());
-  bool GetAlbumsByWhere(const CStdString &baseDir, const CStdString &where, const CStdString &order, CFileItemList &items, const SortDescription &sortDescription = SortDescription());
-  bool GetArtistsByWhere(const CStdString& strBaseDir, const CStdString &where, CFileItemList& items);
-  bool GetRandomSong(CFileItem* item, int& idSong, const CStdString& strWhere);
+  bool GetSongsByWhere(const CStdString &baseDir, const Filter &filter, CFileItemList& items, const SortDescription &sortDescription = SortDescription());
+  bool GetAlbumsByWhere(const CStdString &baseDir, const Filter &filter, CFileItemList &items, const SortDescription &sortDescription = SortDescription());
+  bool GetArtistsByWhere(const CStdString& strBaseDir, const Filter &filter, CFileItemList& items);
+  bool GetRandomSong(CFileItem* item, int& idSong, const Filter &filter);
   int GetKaraokeSongsCount();
-  int GetSongsCount(const CStdString& strWhere = "");
-  unsigned int GetSongIDs(const CStdString& strWhere, std::vector<std::pair<int,int> > &songIDs);
+  int GetSongsCount(const Filter &filter = Filter());
+  unsigned int GetSongIDs(const Filter &filter, std::vector<std::pair<int,int> > &songIDs);
 
   bool GetAlbumPath(int idAlbum, CStdString &path);
   bool SaveAlbumThumb(int idAlbum, const CStdString &thumb);

--- a/xbmc/music/MusicDbUrl.cpp
+++ b/xbmc/music/MusicDbUrl.cpp
@@ -1,0 +1,149 @@
+/*
+ *      Copyright (C) 2012 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "MusicDbUrl.h"
+#include "filesystem/MusicDatabaseDirectory.h"
+#include "utils/StringUtils.h"
+#include "utils/Variant.h"
+
+using namespace std;
+using namespace XFILE;
+using namespace XFILE::MUSICDATABASEDIRECTORY;
+
+CMusicDbUrl::CMusicDbUrl()
+  : CDbUrl()
+{ }
+
+CMusicDbUrl::~CMusicDbUrl()
+{ }
+
+bool CMusicDbUrl::parse()
+{
+  // the URL must start with musicdb://
+  if (m_url.GetProtocol() != "musicdb" || m_url.GetFileName().empty())
+    return false;
+
+  CStdString path = m_url.Get();
+  NODE_TYPE dirType = CMusicDatabaseDirectory::GetDirectoryType(path);
+  NODE_TYPE childType = CMusicDatabaseDirectory::GetDirectoryChildType(path);
+
+  switch (dirType)
+  {
+    case NODE_TYPE_ARTIST:
+      m_type = "artists";
+      break;
+      
+    case NODE_TYPE_ALBUM:
+    case NODE_TYPE_ALBUM_RECENTLY_ADDED:
+    case NODE_TYPE_ALBUM_RECENTLY_PLAYED:
+    case NODE_TYPE_ALBUM_TOP100:
+    case NODE_TYPE_ALBUM_COMPILATIONS:
+    case NODE_TYPE_YEAR_ALBUM:
+    case NODE_TYPE_SINGLES:
+      m_type = "albums";
+      break;
+
+    case NODE_TYPE_ALBUM_RECENTLY_ADDED_SONGS:
+    case NODE_TYPE_ALBUM_RECENTLY_PLAYED_SONGS:
+    case NODE_TYPE_ALBUM_TOP100_SONGS:
+    case NODE_TYPE_ALBUM_COMPILATIONS_SONGS:
+    case NODE_TYPE_SONG:
+    case NODE_TYPE_SONG_TOP100:
+    case NODE_TYPE_YEAR_SONG:
+      m_type = "songs";
+      break;
+
+    default:
+      break;
+  }
+
+  switch (childType)
+  {
+    case NODE_TYPE_ARTIST:
+      m_type = "artists";
+      break;
+      
+    case NODE_TYPE_ALBUM:
+    case NODE_TYPE_ALBUM_RECENTLY_ADDED:
+    case NODE_TYPE_ALBUM_RECENTLY_PLAYED:
+    case NODE_TYPE_ALBUM_TOP100:
+    case NODE_TYPE_YEAR_ALBUM:
+      m_type = "albums";
+      break;
+      
+    case NODE_TYPE_SONG:
+    case NODE_TYPE_ALBUM_RECENTLY_ADDED_SONGS:
+    case NODE_TYPE_ALBUM_RECENTLY_PLAYED_SONGS:
+    case NODE_TYPE_ALBUM_TOP100_SONGS:
+    case NODE_TYPE_ALBUM_COMPILATIONS_SONGS:
+    case NODE_TYPE_SONG_TOP100:
+    case NODE_TYPE_YEAR_SONG:
+      m_type = "songs";
+      break;
+
+    case NODE_TYPE_GENRE:
+      m_type = "genres";
+      break;
+      
+    case NODE_TYPE_YEAR:
+      m_type = "years";
+      break;
+      
+    case NODE_TYPE_ALBUM_COMPILATIONS:
+      m_type = "albums";
+      break;
+      
+    case NODE_TYPE_SINGLES:
+      m_type = "albums";
+      break;
+
+    case NODE_TYPE_TOP100:
+      m_type = "top100";
+      break;
+      
+    case NODE_TYPE_ROOT:
+    case NODE_TYPE_OVERVIEW:
+    default:
+      return false;
+  }
+
+  if (m_type.empty())
+    return false;
+
+  // parse query params
+  CQueryParams queryParams;
+  CDirectoryNode::GetDatabaseInfo(path, queryParams);
+
+  // retrieve and parse all options
+  AddOptions(m_url.GetOptions());
+
+  // add options based on the QueryParams
+  if (queryParams.GetArtistId() != -1)
+    AddOption("artistid", queryParams.GetArtistId());
+  if (queryParams.GetAlbumId() != -1)
+    AddOption("albumid", queryParams.GetAlbumId());
+  if (queryParams.GetGenreId() != -1)
+    AddOption("genreid", queryParams.GetGenreId());
+  if (queryParams.GetSongId() != -1)
+    AddOption("songid", queryParams.GetSongId());
+  if (queryParams.GetYear() != -1)
+    AddOption("year", queryParams.GetYear());
+
+  return true;
+}

--- a/xbmc/music/MusicDbUrl.h
+++ b/xbmc/music/MusicDbUrl.h
@@ -1,0 +1,33 @@
+#pragma once
+/*
+ *      Copyright (C) 2012 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include <string>
+
+#include "DbUrl.h"
+
+class CMusicDbUrl : public CDbUrl
+{
+public:
+  CMusicDbUrl();
+  virtual ~CMusicDbUrl();
+
+protected:
+  virtual bool parse();
+};

--- a/xbmc/music/infoscanner/MusicInfoScanner.cpp
+++ b/xbmc/music/infoscanner/MusicInfoScanner.cpp
@@ -239,7 +239,7 @@ void CMusicInfoScanner::FetchAlbumInfo(const CStdString& strDirectory,
   if (strDirectory.IsEmpty())
   {
     m_musicDatabase.Open();
-    m_musicDatabase.GetAlbumsNav("musicdb://3/",items,-1,-1,-1,-1);
+    m_musicDatabase.GetAlbumsNav("musicdb://3/", items);
     m_musicDatabase.Close();
   }
   else

--- a/xbmc/playlists/SmartPlayList.h
+++ b/xbmc/playlists/SmartPlayList.h
@@ -28,6 +28,7 @@
 #include "utils/XBMCTinyXML.h"
 
 class CDatabase;
+class CVariant;
 
 class CSmartPlaylistRule
 {
@@ -63,9 +64,11 @@ public:
                   };
 
   bool Load(TiXmlElement *element, const CStdString &encoding = "UTF-8");
+  bool Load(const CVariant &obj);
   bool Save(TiXmlNode *parent) const;
+  bool Save(CVariant &obj) const;
 
-  CStdString GetWhereClause(CDatabase &db, const CStdString& strType) const;
+  CStdString                  GetWhereClause(const CDatabase &db, const CStdString& strType) const;
   static Field                TranslateField(const char *field);
   static CStdString           TranslateField(Field field);
   static SortBy               TranslateOrder(const char *order);
@@ -98,7 +101,12 @@ public:
   CSmartPlaylist();
 
   bool Load(const CStdString &path);
-  bool Save(const CStdString &path);
+  bool Load(const CVariant &obj);
+  bool LoadFromXml(const CStdString &xml);
+  bool LoadFromJson(const CStdString &json);
+  bool Save(const CStdString &path) const;
+  bool Save(CVariant &obj, bool full = true) const;
+  bool SaveAsJson(CStdString &json, bool full = true) const;
 
   TiXmlElement *OpenAndReadName(const CStdString &path);
   bool LoadFromXML(TiXmlElement *root, const CStdString &encoding = "UTF-8");
@@ -130,13 +138,17 @@ public:
    \param referencedPlaylists a set of playlists to know when we reach a cycle
    \param needWhere whether we need to prepend the where clause with "WHERE "
    */
-  CStdString GetWhereClause(CDatabase &db, std::set<CStdString> &referencedPlaylists) const;
+  CStdString GetWhereClause(const CDatabase &db, std::set<CStdString> &referencedPlaylists) const;
 
   const std::vector<CSmartPlaylistRule> &GetRules() const;
 
   CStdString GetSaveLocation() const;
 private:
   friend class CGUIDialogSmartPlaylistEditor;
+
+  TiXmlElement* readName();
+  TiXmlElement *readNameFromXml(const CStdString &xml);
+  bool load(TiXmlElement *root);
 
   std::vector<CSmartPlaylistRule> m_playlistRules;
   CStdString m_playlistName;

--- a/xbmc/utils/Makefile
+++ b/xbmc/utils/Makefile
@@ -58,6 +58,7 @@ SRCS=AlarmClock.cpp \
      TimeUtils.cpp \
      TuxBoxUtil.cpp \
      URIUtils.cpp \
+     UrlOptions.cpp \
      Variant.cpp \
      Weather.cpp \
      XBMCTinyXML.cpp \

--- a/xbmc/utils/RecentlyAddedJob.cpp
+++ b/xbmc/utils/RecentlyAddedJob.cpp
@@ -214,7 +214,7 @@ bool CRecentlyAddedJob::UpdateMusic()
   
   musicdatabase.Open();
   
-  if (musicdatabase.GetRecentlyAddedAlbumSongs("musicdb://", musicItems, NUM_ITEMS))
+  if (musicdatabase.GetRecentlyAddedAlbumSongs("musicdb://4/", musicItems, NUM_ITEMS))
   {
     long idAlbum = -1;
     CStdString strAlbumThumb;

--- a/xbmc/utils/UrlOptions.cpp
+++ b/xbmc/utils/UrlOptions.cpp
@@ -1,0 +1,122 @@
+/*
+ *      Copyright (C) 2012 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include <sstream>
+
+#include "UrlOptions.h"
+#include "URL.h"
+#include "utils/StringUtils.h"
+
+using namespace std;
+
+CUrlOptions::CUrlOptions()
+{ }
+
+CUrlOptions::~CUrlOptions()
+{ }
+
+std::string CUrlOptions::GetOptionsString() const
+{
+  std::string options;
+  for (UrlOptions::const_iterator opt = m_options.begin(); opt != m_options.end(); opt++)
+  {
+    if (opt != m_options.begin())
+      options += "&";
+
+    options += CURL::Encode(opt->first) + "=" + CURL::Encode(opt->second.asString());
+  }
+
+  return options;
+}
+
+void CUrlOptions::AddOption(const std::string &key, const std::string &value)
+{
+  if (key.empty())
+    return;
+
+  UrlOptions::iterator option = m_options.find(key);
+  if (!value.empty())
+    m_options[key] = value;
+  else if (option != m_options.end())
+    m_options.erase(option);
+}
+
+void CUrlOptions::AddOption(const std::string &key, int value)
+{
+  if (key.empty())
+    return;
+
+  m_options[key] = value;
+}
+
+void CUrlOptions::AddOption(const std::string &key, float value)
+{
+  if (key.empty())
+    return;
+
+  m_options[key] = value;
+}
+
+void CUrlOptions::AddOption(const std::string &key, double value)
+{
+  if (key.empty())
+    return;
+
+  m_options[key] = value;
+}
+
+void CUrlOptions::AddOption(const std::string &key, bool value)
+{
+  if (key.empty())
+    return;
+
+  m_options[key] = value;
+}
+
+void CUrlOptions::AddOptions(const std::string &options)
+{
+  if (options.empty())
+    return;
+
+  string strOptions = options;
+
+  // remove leading ? if present
+  if (strOptions.at(0) == '?')
+    strOptions.erase(0, 1);
+
+  // split the options by & and process them one by one
+  vector<string> optionList = StringUtils::Split(strOptions, "&");
+  for (vector<string>::const_iterator option = optionList.begin(); option != optionList.end(); option++)
+  {
+    if (option->empty())
+      continue;
+
+    // every option must have the format key=value
+    size_t pos = option->find('=');
+    if (pos == string::npos || pos == 0 || pos >= option->size() - 1)
+      continue;
+
+    string key = CURL::Decode(option->substr(0, pos));
+    string value = CURL::Decode(option->substr(pos + 1));
+
+    // the key cannot be empty
+    if (!key.empty())
+      AddOption(key, value);
+  }
+}

--- a/xbmc/utils/UrlOptions.h
+++ b/xbmc/utils/UrlOptions.h
@@ -1,0 +1,46 @@
+#pragma once
+/*
+ *      Copyright (C) 2012 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include <map>
+#include <string>
+
+#include "utils/Variant.h"
+
+class CUrlOptions
+{
+public:
+  typedef std::map<std::string, CVariant> UrlOptions;
+
+  CUrlOptions();
+  virtual ~CUrlOptions();
+
+  virtual const UrlOptions& GetOptions() const { return m_options; }
+  virtual std::string GetOptionsString() const;
+
+  virtual void AddOption(const std::string &key, const std::string &value);
+  virtual void AddOption(const std::string &key, int value);
+  virtual void AddOption(const std::string &key, float value);
+  virtual void AddOption(const std::string &key, double value);
+  virtual void AddOption(const std::string &key, bool value);
+  virtual void AddOptions(const std::string &options);
+
+protected:
+  UrlOptions m_options;
+};

--- a/xbmc/video/Makefile
+++ b/xbmc/video/Makefile
@@ -2,6 +2,7 @@ SRCS=Bookmark.cpp \
      GUIViewStateVideo.cpp \
      Teletext.cpp \
      VideoDatabase.cpp \
+     VideoDbUrl.cpp \
      VideoInfoDownloader.cpp \
      VideoInfoScanner.cpp \
      VideoInfoTag.cpp \

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -54,6 +54,7 @@
 #include "XBDateTime.h"
 #include "URL.h"
 #include "video/VideoDbUrl.h"
+#include "playlists/SmartPlayList.h"
 
 using namespace std;
 using namespace dbiplus;
@@ -9079,6 +9080,17 @@ bool CVideoDatabase::GetFilter(const CVideoDbUrl &videoUrl, Filter &filter) cons
   }
   else
     return false;
+
+  option = options.find("xsp");
+  if (option != options.end())
+  {
+    CSmartPlaylist xsp;
+    if (!xsp.LoadFromJson(option->second.asString()))
+      return false;
+
+    std::set<CStdString> playlists;
+    filter.AppendWhere(xsp.GetWhereClause(*this, playlists));
+  }
 
   return true;
 }

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -4410,21 +4410,9 @@ bool CVideoDatabase::GetNavCommon(const CStdString& strBaseDir, CFileItemList& i
         return false;
     }
 
-    // parse the base path to get additional filters
     CVideoDbUrl videoUrl;
-    if (!videoUrl.FromString(strBaseDir) || !GetFilter(videoUrl, extFilter))
+    if (!BuildSQL(strBaseDir, strSQL, extFilter, strSQL, videoUrl))
       return false;
-
-    if (!extFilter.join.empty())
-      strSQL += extFilter.join;
-    if (!extFilter.where.empty())
-      strSQL += " WHERE " + extFilter.where;
-    if (!extFilter.group.empty())
-      strSQL += " GROUP BY " + extFilter.group;
-    if (!extFilter.order.empty())
-      strSQL += " ORDER BY " + extFilter.order;
-    if (!extFilter.limit.empty())
-      strSQL += " LIMIT " + extFilter.limit;
 
     int iRowsFound = RunQuery(strSQL);
     if (iRowsFound <= 0)
@@ -4533,19 +4521,8 @@ bool CVideoDatabase::GetTagsNav(const CStdString& strBaseDir, CFileItemList& ite
 
     // parse the base path to get additional filters
     CVideoDbUrl videoUrl;
-    if (!videoUrl.FromString(strBaseDir) || !GetFilter(videoUrl, extFilter))
+    if (!BuildSQL(strBaseDir, strSQL, extFilter, strSQL, videoUrl))
       return false;
-
-    if (!extFilter.join.empty())
-      strSQL += extFilter.join;
-    if (!extFilter.where.empty())
-      strSQL += " WHERE " + extFilter.where;
-    if (!extFilter.group.empty())
-      strSQL += " GROUP BY " + extFilter.group;
-    if (!extFilter.order.empty())
-      strSQL += " ORDER BY " + extFilter.order;
-    if (!extFilter.limit.empty())
-      strSQL += " LIMIT " + extFilter.limit;
 
     int iRowsFound = RunQuery(strSQL);
     if (iRowsFound <= 0)
@@ -4744,21 +4721,9 @@ bool CVideoDatabase::GetMusicVideoAlbumsNav(const CStdString& strBaseDir, CFileI
 
     extFilter.AppendGroup(PrepareSQL("musicvideoview.c%02d", VIDEODB_ID_MUSICVIDEO_ALBUM));
 
-    // parse the base path to get additional filters
     CVideoDbUrl videoUrl;
-    if (!videoUrl.FromString(strBaseDir) || !GetFilter(videoUrl, extFilter))
+    if (!BuildSQL(strBaseDir, strSQL, extFilter, strSQL, videoUrl))
       return false;
-
-    if (!extFilter.join.empty())
-      strSQL += extFilter.join;
-    if (!extFilter.where.empty())
-      strSQL += " WHERE " + extFilter.where;
-    if (!extFilter.group.empty())
-      strSQL += " GROUP BY " + extFilter.group;
-    if (!extFilter.order.empty())
-      strSQL += " ORDER BY " + extFilter.order;
-    if (!extFilter.limit.empty())
-      strSQL += " LIMIT " + extFilter.limit;
 
     int iRowsFound = RunQuery(strSQL);
     if (iRowsFound <= 0)
@@ -4949,21 +4914,9 @@ bool CVideoDatabase::GetPeopleNav(const CStdString& strBaseDir, CFileItemList& i
         return false;
     }
 
-    // parse the base path to get additional filters
     CVideoDbUrl videoUrl;
-    if (!videoUrl.FromString(strBaseDir) || !GetFilter(videoUrl, extFilter))
+    if (!BuildSQL(strBaseDir, strSQL, extFilter, strSQL, videoUrl))
       return false;
-
-    if (!extFilter.join.empty())
-      strSQL += extFilter.join;
-    if (!extFilter.where.empty())
-      strSQL += " WHERE " + extFilter.where;
-    if (!extFilter.group.empty())
-      strSQL += " GROUP BY " + extFilter.group;
-    if (!extFilter.order.empty())
-      strSQL += " ORDER BY " + extFilter.order;
-    if (!extFilter.limit.empty())
-      strSQL += " LIMIT " + extFilter.limit;
 
     // run query
     unsigned int time = XbmcThreads::SystemClockMillis();
@@ -5119,21 +5072,9 @@ bool CVideoDatabase::GetYearsNav(const CStdString& strBaseDir, CFileItemList& it
         return false;
     }
 
-    // parse the base path to get additional filters
     CVideoDbUrl videoUrl;
-    if (!videoUrl.FromString(strBaseDir) || !GetFilter(videoUrl, extFilter))
+    if (!BuildSQL(strBaseDir, strSQL, extFilter, strSQL, videoUrl))
       return false;
-
-    if (!extFilter.join.empty())
-      strSQL += extFilter.join;
-    if (!extFilter.where.empty())
-      strSQL += " WHERE " + extFilter.where;
-    if (!extFilter.group.empty())
-      strSQL += " GROUP BY " + extFilter.group;
-    if (!extFilter.order.empty())
-      strSQL += " ORDER BY " + extFilter.order;
-    if (!extFilter.limit.empty())
-      strSQL += " LIMIT " + extFilter.limit;
 
     int iRowsFound = RunQuery(strSQL);
     if (iRowsFound <= 0)
@@ -9138,6 +9079,33 @@ bool CVideoDatabase::GetFilter(const CVideoDbUrl &videoUrl, Filter &filter) cons
   }
   else
     return false;
+
+  return true;
+}
+
+bool CVideoDatabase::BuildSQL(const CStdString &strBaseDir, const CStdString &strQuery, const Filter &filter, CStdString &strSQL, CVideoDbUrl &videoUrl)
+{
+  if (strQuery.empty())
+    return false;
+
+  // parse the base path to get additional filters
+  Filter extFilter = filter;
+  videoUrl.Reset();
+  if (!videoUrl.FromString(strBaseDir) || !GetFilter(videoUrl, extFilter))
+    return false;
+
+  strSQL = strQuery;
+
+  if (!extFilter.join.empty())
+    strSQL += extFilter.join;
+  if (!extFilter.where.empty())
+    strSQL += " WHERE " + extFilter.where;
+  if (!extFilter.group.empty())
+    strSQL += " GROUP BY " + extFilter.group;
+  if (!extFilter.order.empty())
+    strSQL += " ORDER BY " + extFilter.order;
+  if (!extFilter.limit.empty())
+    strSQL += " LIMIT " + extFilter.limit;
 
   return true;
 }

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -24,6 +24,7 @@
 #include "addons/Scraper.h"
 #include "Bookmark.h"
 #include "utils/SortUtils.h"
+#include "video/VideoDbUrl.h"
 
 #include <memory>
 #include <set>
@@ -674,6 +675,8 @@ public:
   void AddTagToItem(int idItem, int idTag, const std::string &type);
   void RemoveTagFromItem(int idItem, int idTag, const std::string &type);
 
+  bool GetFilter(const CVideoDbUrl &videoUrl, Filter &filter) const;
+
 protected:
   int GetMovieId(const CStdString& strFilenameAndPath);
   int GetMusicVideoId(const CStdString& strFilenameAndPath);
@@ -802,7 +805,7 @@ private:
   void SplitPath(const CStdString& strFileNameAndPath, CStdString& strPath, CStdString& strFileName);
   void InvalidatePathHash(const CStdString& strPath);
 
-  bool GetStackedTvShowList(int idShow, CStdString& strIn);
+  bool GetStackedTvShowList(int idShow, CStdString& strIn) const;
   void Stack(CFileItemList& items, VIDEODB_CONTENT_TYPE type, bool maintainSortOrder = false);
 
   /*! \brief Get a safe filename from a given string

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -818,5 +818,5 @@ private:
   void AnnounceRemove(std::string content, int id);
   void AnnounceUpdate(std::string content, int id);
 
-  bool BuildSQL(const CStdString &strBaseDir, const CStdString &strQuery, const Filter &filter, CStdString &strSQL, CVideoDbUrl &videoUrl);
+  bool BuildSQL(const CStdString &strBaseDir, const CStdString &strQuery, Filter &filter, CStdString &strSQL, CVideoDbUrl &videoUrl);
 };

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -817,4 +817,6 @@ private:
 
   void AnnounceRemove(std::string content, int id);
   void AnnounceUpdate(std::string content, int id);
+
+  bool BuildSQL(const CStdString &strBaseDir, const CStdString &strQuery, const Filter &filter, CStdString &strSQL, CVideoDbUrl &videoUrl);
 };

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -321,20 +321,6 @@ class CVideoDatabase : public CDatabase
 {
 public:
 
-  class Filter
-  {
-  public:
-    Filter() : fields("*") {};
-    Filter(const char *w) : fields("*"), where(w) {};
-    Filter(const std::string &w) : fields("*"), where(w) {};
-    std::string fields;
-    std::string join;
-    std::string where;
-    std::string order;
-    std::string group;
-    std::string limit;
-  };
-
   class CActor    // used for actor retrieval for non-master users
   {
   public:

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -566,16 +566,16 @@ public:
   bool ArbitraryExec(const CStdString& strExec);
 
   // general browsing
-  bool GetGenresNav(const CStdString& strBaseDir, CFileItemList& items, int idContent=-1);
-  bool GetCountriesNav(const CStdString& strBaseDir, CFileItemList& items, int idContent=-1);
-  bool GetStudiosNav(const CStdString& strBaseDir, CFileItemList& items, int idContent=-1);
-  bool GetYearsNav(const CStdString& strBaseDir, CFileItemList& items, int idContent=-1);
-  bool GetActorsNav(const CStdString& strBaseDir, CFileItemList& items, int idContent=-1);
-  bool GetDirectorsNav(const CStdString& strBaseDir, CFileItemList& items, int idContent=-1);
-  bool GetWritersNav(const CStdString& strBaseDir, CFileItemList& items, int idContent=-1);
+  bool GetGenresNav(const CStdString& strBaseDir, CFileItemList& items, int idContent=-1, const Filter &filter = Filter());
+  bool GetCountriesNav(const CStdString& strBaseDir, CFileItemList& items, int idContent=-1, const Filter &filter = Filter());
+  bool GetStudiosNav(const CStdString& strBaseDir, CFileItemList& items, int idContent=-1, const Filter &filter = Filter());
+  bool GetYearsNav(const CStdString& strBaseDir, CFileItemList& items, int idContent=-1, const Filter &filter = Filter());
+  bool GetActorsNav(const CStdString& strBaseDir, CFileItemList& items, int idContent=-1, const Filter &filter = Filter());
+  bool GetDirectorsNav(const CStdString& strBaseDir, CFileItemList& items, int idContent=-1, const Filter &filter = Filter());
+  bool GetWritersNav(const CStdString& strBaseDir, CFileItemList& items, int idContent=-1, const Filter &filter = Filter());
   bool GetSetsNav(const CStdString& strBaseDir, CFileItemList& items, int idContent=-1);
-  bool GetTagsNav(const CStdString& strBaseDir, CFileItemList& items, int idContent=-1);
-  bool GetMusicVideoAlbumsNav(const CStdString& strBaseDir, CFileItemList& items, int idArtist);
+  bool GetTagsNav(const CStdString& strBaseDir, CFileItemList& items, int idContent=-1, const Filter &filter = Filter());
+  bool GetMusicVideoAlbumsNav(const CStdString& strBaseDir, CFileItemList& items, int idArtist, const Filter &filter = Filter());
 
   bool GetMoviesNav(const CStdString& strBaseDir, CFileItemList& items, int idGenre=-1, int idYear=-1, int idActor=-1, int idDirector=-1, int idStudio=-1, int idCountry=-1, int idSet=-1, int idTag=-1);
   bool GetTvShowsNav(const CStdString& strBaseDir, CFileItemList& items, int idGenre=-1, int idYear=-1, int idActor=-1, int idDirector=-1, int idStudio=-1);
@@ -748,8 +748,8 @@ protected:
   CVideoInfoTag GetDetailsForMusicVideo(const dbiplus::sql_record* const record);
   void GetCommonDetails(std::auto_ptr<dbiplus::Dataset> &pDS, CVideoInfoTag &details);
   void GetCommonDetails(const dbiplus::sql_record* const record, CVideoInfoTag &details);
-  bool GetPeopleNav(const CStdString& strBaseDir, CFileItemList& items, const CStdString& type, int idContent=-1);
-  bool GetNavCommon(const CStdString& strBaseDir, CFileItemList& items, const CStdString& type, int idContent=-1);
+  bool GetPeopleNav(const CStdString& strBaseDir, CFileItemList& items, const CStdString& type, int idContent=-1, const Filter &filter = Filter());
+  bool GetNavCommon(const CStdString& strBaseDir, CFileItemList& items, const CStdString& type, int idContent=-1, const Filter &filter = Filter());
   void GetCast(const CStdString &table, const CStdString &table_id, int type_id, std::vector<SActorInfo> &cast);
 
   void GetDetailsFromDB(std::auto_ptr<dbiplus::Dataset> &pDS, int min, int max, const SDbTableOffsets *offsets, CVideoInfoTag &details, int idxOffset = 2);

--- a/xbmc/video/VideoDbUrl.cpp
+++ b/xbmc/video/VideoDbUrl.cpp
@@ -1,0 +1,188 @@
+/*
+ *      Copyright (C) 2012 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "VideoDbUrl.h"
+#include "filesystem/VideoDatabaseDirectory.h"
+#include "utils/StringUtils.h"
+#include "utils/Variant.h"
+
+using namespace std;
+using namespace XFILE;
+
+CVideoDbUrl::CVideoDbUrl()
+  : CDbUrl()
+{ }
+
+CVideoDbUrl::~CVideoDbUrl()
+{ }
+
+bool CVideoDbUrl::parse()
+{
+  // the URL must start with videodb://
+  if (m_url.GetProtocol() != "videodb" || m_url.GetFileName().empty())
+    return false;
+
+  CStdString path = m_url.Get();
+  VIDEODATABASEDIRECTORY::NODE_TYPE dirType = CVideoDatabaseDirectory::GetDirectoryType(path);
+  VIDEODATABASEDIRECTORY::NODE_TYPE childType = CVideoDatabaseDirectory::GetDirectoryChildType(path);
+
+  switch (dirType)
+  {
+    case VIDEODATABASEDIRECTORY::NODE_TYPE_MOVIES_OVERVIEW:
+    case VIDEODATABASEDIRECTORY::NODE_TYPE_RECENTLY_ADDED_MOVIES:
+    case VIDEODATABASEDIRECTORY::NODE_TYPE_TITLE_MOVIES:
+    case VIDEODATABASEDIRECTORY::NODE_TYPE_SETS:
+      m_type = "movies";
+      break;
+
+    case VIDEODATABASEDIRECTORY::NODE_TYPE_TVSHOWS_OVERVIEW:
+    case VIDEODATABASEDIRECTORY::NODE_TYPE_TITLE_TVSHOWS:
+    case VIDEODATABASEDIRECTORY::NODE_TYPE_SEASONS:
+    case VIDEODATABASEDIRECTORY::NODE_TYPE_EPISODES:
+    case VIDEODATABASEDIRECTORY::NODE_TYPE_RECENTLY_ADDED_EPISODES:
+      m_type = "tvshows";
+      break;
+
+
+    case VIDEODATABASEDIRECTORY::NODE_TYPE_MUSICVIDEOS_OVERVIEW:
+    case VIDEODATABASEDIRECTORY::NODE_TYPE_RECENTLY_ADDED_MUSICVIDEOS:
+    case VIDEODATABASEDIRECTORY::NODE_TYPE_TITLE_MUSICVIDEOS:
+    case VIDEODATABASEDIRECTORY::NODE_TYPE_MUSICVIDEOS_ALBUM:
+      m_type = "musicvideos";
+
+    default:
+      break;
+  }
+
+  switch (childType)
+  {
+    case VIDEODATABASEDIRECTORY::NODE_TYPE_MOVIES_OVERVIEW:
+    case VIDEODATABASEDIRECTORY::NODE_TYPE_TITLE_MOVIES:
+    case VIDEODATABASEDIRECTORY::NODE_TYPE_RECENTLY_ADDED_MOVIES:
+      m_type = "movies";
+      m_itemType = "movies";
+      break;
+
+    case VIDEODATABASEDIRECTORY::NODE_TYPE_TVSHOWS_OVERVIEW:
+    case VIDEODATABASEDIRECTORY::NODE_TYPE_TITLE_TVSHOWS:
+      m_type = "tvshows";
+      m_itemType = "tvshows";
+      break;
+
+    case VIDEODATABASEDIRECTORY::NODE_TYPE_SEASONS:
+      m_type = "tvshows";
+      m_itemType = "seasons";
+      break;
+
+    case VIDEODATABASEDIRECTORY::NODE_TYPE_EPISODES:
+    case VIDEODATABASEDIRECTORY::NODE_TYPE_RECENTLY_ADDED_EPISODES:
+      m_type = "tvshows";
+      m_itemType = "episodes";
+      break;
+
+    case VIDEODATABASEDIRECTORY::NODE_TYPE_MUSICVIDEOS_OVERVIEW:
+    case VIDEODATABASEDIRECTORY::NODE_TYPE_RECENTLY_ADDED_MUSICVIDEOS:
+    case VIDEODATABASEDIRECTORY::NODE_TYPE_TITLE_MUSICVIDEOS:
+      m_type = "musicvideos";
+      m_itemType = "musicvideos";
+      break;
+
+    case VIDEODATABASEDIRECTORY::NODE_TYPE_GENRE:
+      m_itemType = "genres";
+      break;
+
+    case VIDEODATABASEDIRECTORY::NODE_TYPE_ACTOR:
+      m_itemType = "actors";
+      break;
+
+    case VIDEODATABASEDIRECTORY::NODE_TYPE_YEAR:
+      m_itemType = "years";
+      break;
+
+    case VIDEODATABASEDIRECTORY::NODE_TYPE_DIRECTOR:
+      m_itemType = "directors";
+      break;
+
+    case VIDEODATABASEDIRECTORY::NODE_TYPE_STUDIO:
+      m_itemType = "studios";
+      break;
+
+    case VIDEODATABASEDIRECTORY::NODE_TYPE_COUNTRY:
+      m_itemType = "countries";
+      break;
+
+    case VIDEODATABASEDIRECTORY::NODE_TYPE_SETS:
+      m_itemType = "sets";
+      break;
+
+    case VIDEODATABASEDIRECTORY::NODE_TYPE_MUSICVIDEOS_ALBUM:
+      m_itemType = "albums";
+      break;
+
+    case VIDEODATABASEDIRECTORY::NODE_TYPE_TAGS:
+      m_itemType = "tags";
+      break;
+      
+    case VIDEODATABASEDIRECTORY::NODE_TYPE_ROOT:
+    case VIDEODATABASEDIRECTORY::NODE_TYPE_OVERVIEW:
+    default:
+      return false;
+  }
+
+  if (m_type.empty() || m_itemType.empty())
+    return false;
+
+  // parse query params
+  VIDEODATABASEDIRECTORY::CQueryParams queryParams;
+  if (!CVideoDatabaseDirectory::GetQueryParams(path, queryParams))
+    return false;
+
+  // retrieve and parse all options
+  AddOptions(m_url.GetOptions());
+
+  // add options based on the QueryParams
+  if (queryParams.GetActorId() != -1)
+    AddOption("actorid", queryParams.GetActorId());
+  if (queryParams.GetAlbumId() != -1)
+    AddOption("albumid", queryParams.GetAlbumId());
+  if (queryParams.GetCountryId() != -1)
+    AddOption("countryid", queryParams.GetCountryId());
+  if (queryParams.GetDirectorId() != -1)
+    AddOption("directorid", queryParams.GetDirectorId());
+  if (queryParams.GetEpisodeId() != -1)
+    AddOption("episodeid", queryParams.GetEpisodeId());
+  if (queryParams.GetGenreId() != -1)
+    AddOption("genreid", queryParams.GetGenreId());
+  if (queryParams.GetMovieId() != -1)
+    AddOption("movieid", queryParams.GetMovieId());
+  if (queryParams.GetMVideoId() != -1)
+    AddOption("musicvideoid", queryParams.GetMVideoId());
+  if (queryParams.GetSeason() != -1 && queryParams.GetSeason() >= -2)
+    AddOption("season", queryParams.GetSeason());
+  if (queryParams.GetSetId() != -1)
+    AddOption("setid", queryParams.GetSetId());
+  if (queryParams.GetStudioId() != -1)
+    AddOption("studioid", queryParams.GetStudioId());
+  if (queryParams.GetTvShowId() != -1)
+    AddOption("tvshowid", queryParams.GetTvShowId());
+  if (queryParams.GetYear() != -1)
+    AddOption("year", queryParams.GetYear());
+
+  return true;
+}

--- a/xbmc/video/VideoDbUrl.h
+++ b/xbmc/video/VideoDbUrl.h
@@ -1,0 +1,36 @@
+#pragma once
+/*
+ *      Copyright (C) 2012 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "DbUrl.h"
+
+class CVideoDbUrl : public CDbUrl
+{
+public:
+  CVideoDbUrl();
+  virtual ~CVideoDbUrl();
+
+  const std::string& GetItemType() const { return m_itemType; }
+
+protected:
+  virtual bool parse();
+
+private:
+  std::string m_itemType;
+};


### PR DESCRIPTION
This is more of an RFC for now because I have only discussed the idea with @jmarshallnz in the context of my GSoC work. There are two "problems" that this work tries (and succeeds) to solve:
1. When e.g. making a smartplaylist with the rule "Director contains James Cameron" and the user has a "Terminator Collection" set (as provided by TMDb) containing all four Terminator movies, the resulting list will show the "Terminator Collection" set in the list (and not the individual movies). When entering the set it will show all 4 movies even though only the first two Terminator movies were directed by James Cameron while the last two were not. The same result can be achieved by going to Videos -> Library -> Movies -> Directors -> James Cameron. The problem is that when retrieving the movies in the set we don't know about the previously applied filter(s) and simply ignore them and retrieve all movies belonging to the set.
2. In my GSoC work for advanced filtering I use a smartplaylist which contains all the filters specified by the user. This works great for movies, tvshows and musicvideos but doesn't really work for episodes because in the GUI they are "pre-filtered" by tvshow and season. But the advanced filter has no clue about this pre-filtering because it's only really visible in the videodb:// URL of those items (which is used by CVideoDatabaseDirectory et. al.) and nowhere else.

To solve these two problems (which also apply to the music database, but I started with the video database as a proof-of-concept) I have added two classes CDbUrl and CVideoDbUrl (derived from CDbUrl) which are meant to handle and extend a videodb:// URL with additional information about the current context. The current URL schema is not changed but in addition GET options are added so when e.g. viewing all movies directed by James Cameron through Videos -> Library -> Movies -> Directors -> James Cameron the resulting URL will look like this: videodb://1/5/1234/?directorid=1234. When the user then enters the "Terminator Collection" set, that CFileItem will have the URL videodb://1/7/5678/?directorid=1234 and therefore knows that it also has to filter by the director with ID 1234 (which is James Cameron in this example). Adding those options is done in CVideoDatabase::GetFooNav() etc and the handling of those options is done in CVideoDatabase::GetFooByWhere() etc by first parsing the videodb:// URL using CVideoDbUrl::FromString and then calling CVideoDatabase::GetFilter() which will put together all the JOIN/WHERE SQL clauses necessary to do the proper filtering.
To also cover filtering by a smartplaylist, the smartplaylist is converted into a CVariant object and then serialized as a JSON object and that JSON object (or rather its string representation) is then added as an option to the videodb:// URL. I went with a JSON representation because it is less verbose than XML and a lot easier to read (although this might only come in handy during debugging).

The disadvantages of this approach are that the URLs can get rather long (but we never output them to the user) and that it is more crucial to actually provide to correct base path when calling CVideoDatabase::GetFooNav(). The second disadvantage might however actually be an advantage because it will make it easier to hunt down incorrectly provided base paths (e.g. videodb://1/1/ instead of videodb://1/2/ for the retrieval of all movie titles).
