### PR TITLE
[GSoC] use CDatabase::Filter in CMusicDatabase

### DIFF
--- a/xbmc/PartyModeManager.cpp
+++ b/xbmc/PartyModeManager.cpp
@@ -113,11 +113,7 @@ bool CPartyModeManager::Enable(PartyModeContext context /*= PARTYMODECONTEXT_MUS
     {
       set<CStdString> playlists;
       if ( playlistLoaded )
-      {
         m_strCurrentFilterMusic = playlist.GetWhereClause(db, playlists);
-        if (!m_strCurrentFilterMusic.empty())
-          m_strCurrentFilterMusic = "WHERE " + m_strCurrentFilterMusic;
-      }
 
       CLog::Log(LOGINFO, "PARTY MODE MANAGER: Registering filter:[%s]", m_strCurrentFilterMusic.c_str());
       m_iMatchingSongs = (int)db.GetSongIDs(m_strCurrentFilterMusic, songIDs);
@@ -146,11 +142,7 @@ bool CPartyModeManager::Enable(PartyModeContext context /*= PARTYMODECONTEXT_MUS
     {
       set<CStdString> playlists;
       if ( playlistLoaded )
-      {
         m_strCurrentFilterVideo = playlist.GetWhereClause(db, playlists);
-        if (!m_strCurrentFilterVideo.empty())
-          m_strCurrentFilterVideo = "WHERE " + m_strCurrentFilterVideo;
-      }
 
       CLog::Log(LOGINFO, "PARTY MODE MANAGER: Registering filter:[%s]", m_strCurrentFilterVideo.c_str());
       m_iMatchingSongs += (int)db.GetMusicVideoIDs(m_strCurrentFilterVideo, songIDs2);
@@ -594,8 +586,8 @@ bool CPartyModeManager::AddInitialSongs(vector<pair<int,int> > &songIDs)
 
     vector<pair<int,int> > chosenSongIDs;
     GetRandomSelection(songIDs, iMissingSongs, chosenSongIDs);
-    CStdString sqlWhereMusic = "where songview.idSong in (";
-    CStdString sqlWhereVideo = "idMVideo in (";
+    CStdString sqlWhereMusic = "songview.idSong IN (";
+    CStdString sqlWhereVideo = "idMVideo IN (";
 
     for (vector< pair<int,int> >::iterator it = chosenSongIDs.begin(); it != chosenSongIDs.end(); it++)
     {
@@ -644,7 +636,7 @@ pair<CStdString,CStdString> CPartyModeManager::GetWhereClauseWithHistory() const
   if (m_history.size())
   {
     if (m_strCurrentFilterMusic.IsEmpty())
-      historyWhereMusic = "where songview.idSong not in (";
+      historyWhereMusic = "songview.idSong not in (";
     else
       historyWhereMusic = m_strCurrentFilterMusic + " and songview.idSong not in (";
     if (m_strCurrentFilterVideo.IsEmpty())

--- a/xbmc/dbwrappers/Database.cpp
+++ b/xbmc/dbwrappers/Database.cpp
@@ -41,6 +41,65 @@ using namespace dbiplus;
 
 #define MAX_COMPRESS_COUNT 20
 
+void CDatabase::Filter::AppendField(const std::string &strField)
+{
+  if (strField.empty())
+    return;
+
+  if (fields.empty() || fields == "*")
+    fields = strField;
+  else
+    fields += ", " + strField;
+}
+
+void CDatabase::Filter::AppendJoin(const std::string &strJoin)
+{
+  if (strJoin.empty())
+    return;
+
+  if (join.empty())
+    join = strJoin;
+  else
+    join += " " + strJoin;
+}
+
+void CDatabase::Filter::AppendWhere(const std::string &strWhere, bool combineWithAnd /* = true */)
+{
+  if (strWhere.empty())
+    return;
+
+  if (where.empty())
+    where = strWhere;
+  else
+  {
+    where = "(" + where + ") ";
+    where += combineWithAnd ? "AND" : "OR";
+    where += " (" + strWhere + ")";
+  }
+}
+
+void CDatabase::Filter::AppendOrder(const std::string &strOrder)
+{
+  if (strOrder.empty())
+    return;
+
+  if (order.empty())
+    order = strOrder;
+  else
+    order += ", " + strOrder;
+}
+
+void CDatabase::Filter::AppendGroup(const std::string &strGroup)
+{
+  if (strGroup.empty())
+    return;
+
+  if (group.empty())
+    group = strGroup;
+  else
+    group += ", " + strGroup;
+}
+
 CDatabase::CDatabase(void)
 {
   m_openCount = 0;

--- a/xbmc/dbwrappers/Database.h
+++ b/xbmc/dbwrappers/Database.h
@@ -35,6 +35,27 @@ class DatabaseSettings; // forward
 class CDatabase
 {
 public:
+  class Filter
+  {
+  public:
+    Filter() : fields("*") {};
+    Filter(const char *w) : fields("*"), where(w) {};
+    Filter(const std::string &w) : fields("*"), where(w) {};
+    
+    void AppendField(const std::string &strField);
+    void AppendJoin(const std::string &strJoin);
+    void AppendWhere(const std::string &strWhere, bool combineWithAnd = true);
+    void AppendOrder(const std::string &strOrder);
+    void AppendGroup(const std::string &strGroup);
+
+    std::string fields;
+    std::string join;
+    std::string where;
+    std::string order;
+    std::string group;
+    std::string limit;
+  };
+
   CDatabase(void);
   virtual ~CDatabase(void);
   bool IsOpen();

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeOverview.cpp
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeOverview.cpp
@@ -74,7 +74,8 @@ bool CDirectoryNodeOverview::GetContent(CFileItemList& items) const
   bool showSingles = false;
   if (musicDatabase.Open())
   {
-    if (musicDatabase.GetSongsCount("where idAlbum in (select idAlbum from album where strAlbum='')") > 0)
+    CDatabase::Filter filter("idAlbum IN (SELECT idAlbum FROM album WHERE strAlbum = '')");
+    if (musicDatabase.GetSongsCount(filter) > 0)
       showSingles = true;
   }
 

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeSingles.cpp
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeSingles.cpp
@@ -37,8 +37,9 @@ bool CDirectoryNodeSingles::GetContent(CFileItemList& items) const
   if (!musicdatabase.Open())
     return false;
 
-  CStdString strBaseDir=BuildPath();
-  bool bSuccess=musicdatabase.GetSongsByWhere(strBaseDir, "where idAlbum in (select idAlbum from album where strAlbum='')", items);
+  CDatabase::Filter filter;
+  filter.where = "idAlbum IN (SELECT idAlbum FROM album WHERE strAlbum = '')";
+  bool bSuccess=musicdatabase.GetSongsByWhere(BuildPath(), filter, items);
 
   musicdatabase.Close();
 

--- a/xbmc/filesystem/SmartPlaylistDirectory.cpp
+++ b/xbmc/filesystem/SmartPlaylistDirectory.cpp
@@ -99,10 +99,9 @@ namespace XFILE
       CMusicDatabase db;
       if (db.Open())
       {
-        CStdString whereClause = playlist.GetWhereClause(db, playlists);
-        if (!whereClause.empty())
-          whereClause = "WHERE " + whereClause;
-        success = db.GetAlbumsByWhere("musicdb://3/", whereClause, "", items, sorting);
+        CDatabase::Filter filter;
+        filter.where = playlist.GetWhereClause(db, playlists);
+        success = db.GetAlbumsByWhere("musicdb://3/", filter, items, sorting);
         items.SetContent("albums");
         db.Close();
       }
@@ -112,20 +111,14 @@ namespace XFILE
       CMusicDatabase db;
       if (db.Open())
       {
-        CStdString whereClause;
+        CDatabase::Filter filter;
+        CSmartPlaylist songPlaylist(playlist);
         if (playlist.GetType().IsEmpty() || playlist.GetType().Equals("mixed"))
-        {
-          CSmartPlaylist songPlaylist(playlist);
           songPlaylist.SetType("songs");
-          whereClause = songPlaylist.GetWhereClause(db, playlists);
-        }
-        else
-          whereClause = playlist.GetWhereClause(db, playlists);
 
-        if (!whereClause.empty())
-          whereClause = "WHERE " + whereClause;
+        filter.where = songPlaylist.GetWhereClause(db, playlists);
 
-        success = db.GetSongsByWhere("", whereClause, items, sorting);
+        success = db.GetSongsByWhere("", filter, items, sorting);
         items.SetContent("songs");
         db.Close();
       }

--- a/xbmc/filesystem/SmartPlaylistDirectory.cpp
+++ b/xbmc/filesystem/SmartPlaylistDirectory.cpp
@@ -71,7 +71,7 @@ namespace XFILE
       if (db.Open())
       {
         MediaType mediaType = DatabaseUtils::MediaTypeFromString(playlist.GetType());
-        CVideoDatabase::Filter filter;
+        CDatabase::Filter filter;
         filter.where = playlist.GetWhereClause(db, playlists);
 
         CStdString strBaseDir;
@@ -135,7 +135,7 @@ namespace XFILE
       CVideoDatabase db;
       if (db.Open())
       {
-        CVideoDatabase::Filter filter;
+        CDatabase::Filter filter;
         if (playlist.GetType().Equals("mixed"))
         {
           CSmartPlaylist mvidPlaylist(playlist);

--- a/xbmc/interfaces/http-api/XBMChttp.cpp
+++ b/xbmc/interfaces/http-api/XBMChttp.cpp
@@ -1030,7 +1030,6 @@ int CXbmcHttp::xbmcAddToPlayListFromDB(int numParas, CStdString paras[])
   if (type.Equals("songs"))
   {
     playList = PLAYLIST_MUSIC;
-    where = " where " + where;
 
     CMusicDatabase musicdatabase;
     if (!musicdatabase.Open())

--- a/xbmc/interfaces/json-rpc/AudioLibrary.cpp
+++ b/xbmc/interfaces/json-rpc/AudioLibrary.cpp
@@ -73,9 +73,8 @@ JSONRPC_STATUS CAudioLibrary::GetArtistDetails(const CStdString &method, ITransp
     return InternalError;
 
   CFileItemList items;
-  CStdString where;
-  where.Format("idArtist = %d", artistID);
-  if (!musicdatabase.GetArtistsByWhere("musicdb://2/", where, items) || items.Size() != 1)
+  CDatabase::Filter filter(musicdatabase.PrepareSQL("idArtist = %d", artistID));
+  if (!musicdatabase.GetArtistsByWhere("musicdb://2/", filter, items) || items.Size() != 1)
     return InvalidParams;
 
   HandleFileItem("artistid", false, "artistdetails", items[0], parameterObject, parameterObject["properties"], result, false);

--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -451,7 +451,7 @@ int CMusicDatabase::AddAlbum(const CStdString& strAlbum1, const CStdString &strA
     if (NULL == m_pDB.get()) return -1;
     if (NULL == m_pDS.get()) return -1;
 
-    map <CStdString, CAlbumCache>::const_iterator it;
+    map <CStdString, CAlbum>::const_iterator it;
 
     it = m_albumCache.find(strAlbum + strArtist);
     if (it != m_albumCache.end())
@@ -467,22 +467,22 @@ int CMusicDatabase::AddAlbum(const CStdString& strAlbum1, const CStdString &strA
       strSQL=PrepareSQL("insert into album (idAlbum, strAlbum, strArtists, strGenres, iYear, bCompilation) values( NULL, '%s', '%s', '%s', %i, %i)", strAlbum.c_str(), strArtist.c_str(), strGenre.c_str(), year, bCompilation);
       m_pDS->exec(strSQL.c_str());
 
-      CAlbumCache album;
+      CAlbum album;
       album.idAlbum = (int)m_pDS->lastinsertid();
       album.strAlbum = strAlbum;
       album.artist = StringUtils::Split(strArtist, g_advancedSettings.m_musicItemSeparator);
-      m_albumCache.insert(pair<CStdString, CAlbumCache>(album.strAlbum + strArtist, album));
+      m_albumCache.insert(pair<CStdString, CAlbum>(album.strAlbum + strArtist, album));
       return album.idAlbum;
     }
     else
     {
       // exists in our database and not scanned during this scan, so we should update it as the details
       // may have changed (there's a reason we're rescanning, afterall!)
-      CAlbumCache album;
+      CAlbum album;
       album.idAlbum = m_pDS->fv("idAlbum").get_asInt();
       album.strAlbum = strAlbum;
       album.artist = StringUtils::Split(strArtist, g_advancedSettings.m_musicItemSeparator);
-      m_albumCache.insert(pair<CStdString, CAlbumCache>(album.strAlbum + strArtist, album));
+      m_albumCache.insert(pair<CStdString, CAlbum>(album.strAlbum + strArtist, album));
       m_pDS->close();
       strSQL=PrepareSQL("update album set strGenres='%s', iYear=%i where idAlbum=%i", strGenre.c_str(), year, album.idAlbum);
       m_pDS->exec(strSQL.c_str());
@@ -2353,10 +2353,10 @@ void CMusicDatabase::DeleteAlbumInfo()
     m_pDS->close();
     CGUIDialogOK::ShowAndGetInput(313, 425, 0, 0);
   }
-  vector<CAlbumCache> vecAlbums;
+  vector<CAlbum> vecAlbums;
   while (!m_pDS->eof())
   {
-    CAlbumCache album;
+    CAlbum album;
     album.idAlbum = m_pDS->fv("album.idAlbum").get_asInt() ;
     album.strAlbum = m_pDS->fv("album.strAlbum").get_asString();
     album.artist = StringUtils::Split(m_pDS->fv("album.strArtists").get_asString(), g_advancedSettings.m_musicItemSeparator);
@@ -2373,7 +2373,7 @@ void CMusicDatabase::DeleteAlbumInfo()
     pDlg->Reset();
     for (int i = 0; i < (int)vecAlbums.size(); ++i)
     {
-      CMusicDatabase::CAlbumCache& album = vecAlbums[i];
+      CAlbum& album = vecAlbums[i];
       pDlg->Add(album.strAlbum + " - " + StringUtils::Join(album.artist, g_advancedSettings.m_musicItemSeparator));
     }
     pDlg->DoModal();
@@ -2386,7 +2386,7 @@ void CMusicDatabase::DeleteAlbumInfo()
       return ;
     }
 
-    CAlbumCache& album = vecAlbums[iSelectedAlbum];
+    CAlbum& album = vecAlbums[iSelectedAlbum];
     strSQL=PrepareSQL("delete from albuminfo where albuminfo.idAlbum=%i", album.idAlbum);
     if (!m_pDS->exec(strSQL.c_str())) return ;
 

--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -2715,9 +2715,10 @@ bool CMusicDatabase::GetYearsNav(const CStdString& strBaseDir, CFileItemList& it
 
 bool CMusicDatabase::GetAlbumsByYear(const CStdString& strBaseDir, CFileItemList& items, int year)
 {
-  CStdString where = PrepareSQL("where iYear=%ld", year);
+  Filter filter;
+  filter.where = PrepareSQL("iYear=%ld", year);
 
-  return GetAlbumsByWhere(strBaseDir, where, "", items);
+  return GetAlbumsByWhere(strBaseDir, filter, items);
 }
 
 bool CMusicDatabase::GetArtistsNav(const CStdString& strBaseDir, CFileItemList& items, int idGenre, bool albumArtistsOnly)
@@ -2789,16 +2790,24 @@ bool CMusicDatabase::GetArtistsNav(const CStdString& strBaseDir, CFileItemList& 
   return false;
 }
 
-bool CMusicDatabase::GetArtistsByWhere(const CStdString& strBaseDir, const CStdString &where, CFileItemList& items)
+bool CMusicDatabase::GetArtistsByWhere(const CStdString& strBaseDir, const Filter &filter, CFileItemList& items)
 {
   if (NULL == m_pDB.get()) return false;
   if (NULL == m_pDS.get()) return false;
 
   try
   {
-    CStdString strSQL = "select * from artistview";
-    if (!where.empty())
-       strSQL += " WHERE " + where;
+    CStdString strSQL = PrepareSQL("select %s from artistview ", !filter.fields.empty() ? filter.fields.c_str() : "*");
+    if (!filter.join.empty())
+      strSQL += filter.join;
+    if (!filter.where.empty())
+      strSQL += " WHERE " + filter.where;
+    if (!filter.group.empty())
+      strSQL += " GROUP BY " + filter.group;
+    if (!filter.order.empty())
+      strSQL += " ORDER BY " + filter.order;
+    if (!filter.limit.empty())
+      strSQL += " LIMIT " + filter.limit;
 
     // run query
     CLog::Log(LOGDEBUG, "%s query: %s", __FUNCTION__, strSQL.c_str());
@@ -2907,60 +2916,31 @@ bool CMusicDatabase::GetAlbumFromSong(const CSong &song, CAlbum &album)
 
 bool CMusicDatabase::GetAlbumsNav(const CStdString& strBaseDir, CFileItemList& items, int idGenre, int idArtist, int start, int end, const SortDescription &sortDescription /* = SortDescription() */)
 {
+  Filter filter;
   //Create limit
-  CStdString limit;
   if (start >= 0 && end >= 0)
-  {
-    limit.Format(" limit %i,%i", start, end);
-  }
+    filter.limit = PrepareSQL("%i,%i", start, end);
 
   // where clause
-  CStdString strWhere;
-  if (idGenre!=-1)
-  {
-    strWhere+=PrepareSQL("where (idAlbum IN "
-                          "("
-                          "select song.idAlbum from song " // All song genres
-                            "JOIN song_genre ON song.idSong=song_genre.idSong "
-                          "where song_genre.idGenre=%i"
-                          ")"
-                        ") " + limit
-                        , idGenre);
-  }
+  if (idGenre != -1)
+    filter.where = PrepareSQL("(idAlbum IN (SELECT song.idAlbum FROM song JOIN song_genre ON song.idSong = song_genre.idSong WHERE song_genre.idGenre = %i))", idGenre);
 
-  if (idArtist!=-1)
-  {
-    if (strWhere.IsEmpty())
-      strWhere += "where ";
-    else
-      strWhere += "and ";
-
-    strWhere +=PrepareSQL("(idAlbum IN "
-                            "("
-                              "select song.idAlbum from song "                 // All albums linked to this artist via songs
-                                "JOIN song_artist ON song.idSong=song_artist.idSong "
-                              "WHERE song_artist.idArtist=%i"
-                            ")"
-                          " or idAlbum IN "
-                            "("
-                              "select album_artist.idAlbum from album_artist " // All albums where album artists fit
-                              "where album_artist.idArtist=%i"
-                            ")"
-                          ") " + limit
-                          , idArtist, idArtist);
-  }
+  if (idArtist != -1)
+    filter.AppendWhere(PrepareSQL("(idAlbum IN "
+                                    // All albums linked to this artist via songs
+                                    "(SELECT song.idAlbum FROM song JOIN song_artist ON song.idSong = song_artist.idSong WHERE song_artist.idArtist = %i)"
+                                  " OR idAlbum IN "
+                                    // All albums where album artists fit
+                                    "(SELECT album_artist.idAlbum FROM album_artist WHERE album_artist.idArtist = %i)"
+                                  ")", idArtist, idArtist));
   else
-  { // no artist given, so exclude any single albums (aka empty tagged albums)
-    if (strWhere.IsEmpty())
-      strWhere += "where albumview.strAlbum <> ''" + limit;
-    else
-      strWhere += "and albumview.strAlbum <> ''" + limit;
-  }
+    // no artist given, so exclude any single albums (aka empty tagged albums)
+    filter.AppendWhere("albumview.strAlbum <> ''");
 
-  return GetAlbumsByWhere(strBaseDir, strWhere, "", items, sortDescription);
+  return GetAlbumsByWhere(strBaseDir, filter, items, sortDescription);
 }
 
-bool CMusicDatabase::GetAlbumsByWhere(const CStdString &baseDir, const CStdString &where, const CStdString &order, CFileItemList &items, const SortDescription &sortDescription /* = SortDescription() */)
+bool CMusicDatabase::GetAlbumsByWhere(const CStdString &baseDir, const Filter &filter, CFileItemList &items, const SortDescription &sortDescription /* = SortDescription() */)
 {
   if (m_pDB.get() == NULL || m_pDS.get() == NULL)
     return false;
@@ -2969,22 +2949,32 @@ bool CMusicDatabase::GetAlbumsByWhere(const CStdString &baseDir, const CStdStrin
   {
     int total = -1;
 
-    CStdString sql = "select * from albumview " + where;
+    CStdString strSQL = "select %s from albumview ";
+    CStdString strSQLExtra;
+    if (!filter.join.empty())
+      strSQLExtra += filter.join;
+    if (!filter.where.empty())
+      strSQLExtra += " WHERE " + filter.where;
+    if (!filter.group.empty())
+      strSQLExtra += " GROUP BY " + filter.group;
+    if (!filter.order.empty())
+      strSQLExtra += " ORDER BY " + filter.order;
+    if (!filter.limit.empty())
+      strSQLExtra += " LIMIT " + filter.limit;
     // Apply the limiting directly here if there's no special sorting but limiting
-    CStdString whereLower = where;
-    whereLower.ToLower();
-    if (whereLower.find(" limit ") == string::npos &&
-        sortDescription.sortBy == SortByNone &&
-       (sortDescription.limitStart > 0 || sortDescription.limitEnd > 0))
+    else if (sortDescription.sortBy == SortByNone &&
+            (sortDescription.limitStart > 0 || sortDescription.limitEnd > 0))
     {
-      total = (int)strtol(GetSingleValue("SELECT COUNT(1) FROM albumview " + where, m_pDS).c_str(), NULL, 10);
-      sql += DatabaseUtils::BuildLimitClause(sortDescription.limitEnd, sortDescription.limitStart);
+      total = (int)strtol(GetSingleValue(PrepareSQL(strSQL, "COUNT(1)") + strSQLExtra, m_pDS).c_str(), NULL, 10);
+      strSQLExtra += DatabaseUtils::BuildLimitClause(sortDescription.limitEnd, sortDescription.limitStart);
     }
 
-    CLog::Log(LOGDEBUG, "%s query: %s", __FUNCTION__, sql.c_str());
+    strSQL = PrepareSQL(strSQL, !filter.fields.empty() ? filter.fields.c_str() : "*") + strSQLExtra;
+
+    CLog::Log(LOGDEBUG, "%s query: %s", __FUNCTION__, strSQL.c_str());
     // run query
     unsigned int time = XbmcThreads::SystemClockMillis();
-    if (!m_pDS->query(sql.c_str()))
+    if (!m_pDS->query(strSQL.c_str()))
       return false;
     CLog::Log(LOGDEBUG, "%s - query took %i ms",
               __FUNCTION__, XbmcThreads::SystemClockMillis() - time); time = XbmcThreads::SystemClockMillis();
@@ -3037,12 +3027,12 @@ bool CMusicDatabase::GetAlbumsByWhere(const CStdString &baseDir, const CStdStrin
   catch (...)
   {
     m_pDS->close();
-    CLog::Log(LOGERROR, "%s (%s) failed", __FUNCTION__, where.c_str());
+    CLog::Log(LOGERROR, "%s (%s) failed", __FUNCTION__, filter.where.c_str());
   }
   return false;
 }
 
-bool CMusicDatabase::GetSongsByWhere(const CStdString &baseDir, const CStdString &whereClause, CFileItemList &items, const SortDescription &sortDescription /* = SortDescription() */)
+bool CMusicDatabase::GetSongsByWhere(const CStdString &baseDir, const Filter &filter, CFileItemList &items, const SortDescription &sortDescription /* = SortDescription() */)
 {
   if (m_pDB.get() == NULL || m_pDS.get() == NULL)
     return false;
@@ -3052,18 +3042,27 @@ bool CMusicDatabase::GetSongsByWhere(const CStdString &baseDir, const CStdString
     unsigned int time = XbmcThreads::SystemClockMillis();
     int total = -1;
 
-    // We don't use PrepareSQL here, as the WHERE clause is already formatted.
-    CStdString strSQL = "select * from songview " + whereClause;
+    CStdString strSQL = "select %s from songview ";
+    CStdString strSQLExtra;
+    if (!filter.join.empty())
+      strSQLExtra += filter.join;
+    if (!filter.where.empty())
+      strSQLExtra += " WHERE " + filter.where;
+    if (!filter.group.empty())
+      strSQLExtra += " GROUP BY " + filter.group;
+    if (!filter.order.empty())
+      strSQLExtra += " ORDER BY " + filter.order;
+    if (!filter.limit.empty())
+      strSQLExtra += " LIMIT " + filter.limit;
     // Apply the limiting directly here if there's no special sorting but limiting
-    CStdString whereLower = whereClause;
-    whereLower.ToLower();
-    if (whereLower.find(" limit ") == string::npos &&
-        sortDescription.sortBy == SortByNone &&
-       (sortDescription.limitStart > 0 || sortDescription.limitEnd > 0))
+    else if (sortDescription.sortBy == SortByNone &&
+            (sortDescription.limitStart > 0 || sortDescription.limitEnd > 0))
     {
-      total = (int)strtol(GetSingleValue("SELECT COUNT(1) FROM songview " + whereClause, m_pDS).c_str(), NULL, 10);
-      strSQL += DatabaseUtils::BuildLimitClause(sortDescription.limitEnd, sortDescription.limitStart);
+      total = (int)strtol(GetSingleValue(PrepareSQL(strSQL, "COUNT(1)") + strSQLExtra, m_pDS).c_str(), NULL, 10);
+      strSQLExtra += DatabaseUtils::BuildLimitClause(sortDescription.limitEnd, sortDescription.limitStart);
     }
+
+    strSQL = PrepareSQL(strSQL, !filter.fields.empty() ? filter.fields.c_str() : "*") + strSQLExtra;
 
     CLog::Log(LOGDEBUG, "%s query = %s", __FUNCTION__, strSQL.c_str());
     // run query
@@ -3107,77 +3106,48 @@ bool CMusicDatabase::GetSongsByWhere(const CStdString &baseDir, const CStdString
       catch (...)
       {
         m_pDS->close();
-        CLog::Log(LOGERROR, "%s: out of memory loading query: %s", __FUNCTION__, whereClause.c_str());
+        CLog::Log(LOGERROR, "%s: out of memory loading query: %s", __FUNCTION__, filter.where.c_str());
         return (items.Size() > 0);
       }
     }
     // cleanup
     m_pDS->close();
-    CLog::Log(LOGDEBUG, "%s(%s) - took %d ms", __FUNCTION__, whereClause.c_str(), XbmcThreads::SystemClockMillis() - time);
+    CLog::Log(LOGDEBUG, "%s(%s) - took %d ms", __FUNCTION__, filter.where.c_str(), XbmcThreads::SystemClockMillis() - time);
     return true;
   }
   catch (...)
   {
     // cleanup
     m_pDS->close();
-    CLog::Log(LOGERROR, "%s(%s) failed", __FUNCTION__, whereClause.c_str());
+    CLog::Log(LOGERROR, "%s(%s) failed", __FUNCTION__, filter.where.c_str());
   }
   return false;
 }
 
 bool CMusicDatabase::GetSongsByYear(const CStdString& baseDir, CFileItemList& items, int year)
 {
-  CStdString where=PrepareSQL("where (iYear=%ld)", year);
-  return GetSongsByWhere(baseDir, where, items);
+  Filter filter(PrepareSQL("iYear = %ld", year));
+  return GetSongsByWhere(baseDir, filter, items);
 }
 
 bool CMusicDatabase::GetSongsNav(const CStdString& strBaseDir, CFileItemList& items, int idGenre, int idArtist,int idAlbum, const SortDescription &sortDescription /* = SortDescription() */)
 {
-  CStdString strWhere;
-
+  Filter filter;
   if (idAlbum!=-1)
-    strWhere=PrepareSQL("where (idAlbum=%ld) ", idAlbum);
+    filter.where = PrepareSQL("idAlbum = %ld", idAlbum);
 
   if (idGenre!=-1)
-  {
-    if (strWhere.IsEmpty())
-      strWhere += "where ";
-    else
-      strWhere += "and ";
-
-    strWhere += PrepareSQL("(idSong IN "
-                            "("
-                            "SELECT song_genre.idSong FROM song_genre "
-                            "WHERE song_genre.idGenre = %i"
-                            ")"
-                          ") "
-                          , idGenre);
-  }
+    filter.AppendWhere(PrepareSQL("idSong IN (SELECT song_genre.idSong FROM song_genre WHERE song_genre.idGenre = %i)", idGenre));
 
   if (idArtist!=-1)
-  {
-    if (strWhere.IsEmpty())
-      strWhere += "where ";
-    else
-      strWhere += "and ";
-
-    strWhere += PrepareSQL("(idSong IN " // song artists
-                            "("
-                            "SELECT song_artist.idSong FROM song_artist "
-                            "WHERE song_artist.idArtist=%i"
-                            ") "
-                          "or idSong IN " // album artists
-                            "("
-                            "SELECT song.idSong FROM song "
-                            "JOIN album_artist ON song.idAlbum=album_artist.idAlbum "
-                            "WHERE album_artist.idArtist=%i"
-                            ")"
-                          ") "
-                          , idArtist, idArtist);
-  }
+    filter.AppendWhere(PrepareSQL("idSong IN (" // song artists
+                                    "SELECT song_artist.idSong FROM song_artist WHERE song_artist.idArtist = %i"
+                                  ") OR idSong IN (" // album artists
+                                    "SELECT song.idSong FROM song JOIN album_artist ON song.idAlbum=album_artist.idAlbum WHERE album_artist.idArtist = %i"
+                                  ")", idArtist, idArtist));
 
   // run query
-  return GetSongsByWhere(strBaseDir, strWhere, items, sortDescription);
+  return GetSongsByWhere(strBaseDir, filter, items, sortDescription);
 }
 
 bool CMusicDatabase::UpdateOldVersion(int version)
@@ -3521,14 +3491,25 @@ bool CMusicDatabase::UpdateOldVersion(int version)
   return true;
 }
 
-unsigned int CMusicDatabase::GetSongIDs(const CStdString& strWhere, vector<pair<int,int> > &songIDs)
+unsigned int CMusicDatabase::GetSongIDs(const Filter &filter, vector<pair<int,int> > &songIDs)
 {
   try
   {
     if (NULL == m_pDB.get()) return 0;
     if (NULL == m_pDS.get()) return 0;
 
-    CStdString strSQL = "select idSong from songview " + strWhere;
+    CStdString strSQL = "select idSong from songview ";
+    if (!filter.join.empty())
+      strSQL += filter.join;
+    if (!filter.where.empty())
+      strSQL += " WHERE " + filter.where;
+    if (!filter.group.empty())
+      strSQL += " GROUP BY " + filter.group;
+    if (!filter.order.empty())
+      strSQL += " ORDER BY " + filter.order;
+    if (!filter.limit.empty())
+      strSQL += " LIMIT " + filter.limit;
+
     if (!m_pDS->query(strSQL.c_str())) return 0;
     songIDs.clear();
     if (m_pDS->num_rows() == 0)
@@ -3547,19 +3528,30 @@ unsigned int CMusicDatabase::GetSongIDs(const CStdString& strWhere, vector<pair<
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "%s(%s) failed", __FUNCTION__, strWhere.c_str());
+    CLog::Log(LOGERROR, "%s(%) failed", __FUNCTION__, filter.where.c_str());
   }
   return 0;
 }
 
-int CMusicDatabase::GetSongsCount(const CStdString& strWhere)
+int CMusicDatabase::GetSongsCount(const Filter &filter)
 {
   try
   {
     if (NULL == m_pDB.get()) return 0;
     if (NULL == m_pDS.get()) return 0;
 
-    CStdString strSQL = "select count(idSong) as NumSongs from songview " + strWhere;
+    CStdString strSQL = "select count(idSong) as NumSongs from songview ";
+    if (!filter.join.empty())
+      strSQL += filter.join;
+    if (!filter.where.empty())
+      strSQL += " WHERE " + filter.where;
+    if (!filter.group.empty())
+      strSQL += " GROUP BY " + filter.group;
+    if (!filter.order.empty())
+      strSQL += " ORDER BY " + filter.order;
+    if (!filter.limit.empty())
+      strSQL += " LIMIT " + filter.limit;
+
     if (!m_pDS->query(strSQL.c_str())) return false;
     if (m_pDS->num_rows() == 0)
     {
@@ -3574,7 +3566,7 @@ int CMusicDatabase::GetSongsCount(const CStdString& strWhere)
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "%s(%s) failed", __FUNCTION__, strWhere.c_str());
+    CLog::Log(LOGERROR, "%s(%s) failed", __FUNCTION__, filter.where.c_str());
   }
   return 0;
 }
@@ -3789,13 +3781,13 @@ int CMusicDatabase::GetGenreByName(const CStdString& strGenre)
   return -1;
 }
 
-bool CMusicDatabase::GetRandomSong(CFileItem* item, int& idSong, const CStdString& strWhere)
+bool CMusicDatabase::GetRandomSong(CFileItem* item, int& idSong, const Filter &filter)
 {
   try
   {
     idSong = -1;
 
-    int iCount = GetSongsCount(strWhere);
+    int iCount = GetSongsCount(filter);
     if (iCount <= 0)
       return false;
     int iRandom = rand() % iCount;
@@ -3804,8 +3796,22 @@ bool CMusicDatabase::GetRandomSong(CFileItem* item, int& idSong, const CStdStrin
     if (NULL == m_pDS.get()) return false;
 
     // We don't use PrepareSQL here, as the WHERE clause is already formatted
-    CStdString strSQL;
-    strSQL.Format("select * from songview %s order by idSong limit 1 offset %i", strWhere.c_str(), iRandom);
+    CStdString strSQL = PrepareSQL("select %s from songview ", !filter.fields.empty() ? filter.fields.c_str() : "*");
+    Filter extFilter = filter;
+    extFilter.AppendOrder("idSong");
+    extFilter.limit = "1";
+
+    if (!extFilter.join.empty())
+      strSQL += extFilter.join;
+    if (!extFilter.where.empty())
+      strSQL += " WHERE " + extFilter.where;
+    if (!extFilter.group.empty())
+      strSQL += " GROUP BY " + extFilter.group;
+    if (!extFilter.order.empty())
+      strSQL += " ORDER BY " + extFilter.order;
+    if (!extFilter.limit.empty())
+      strSQL += " LIMIT " + extFilter.limit;
+    strSQL += PrepareSQL(" OFFSET %i", iRandom);
 
     CLog::Log(LOGDEBUG, "%s query = %s", __FUNCTION__, strSQL.c_str());
     // run query
@@ -3824,19 +3830,21 @@ bool CMusicDatabase::GetRandomSong(CFileItem* item, int& idSong, const CStdStrin
   }
   catch(...)
   {
-    CLog::Log(LOGERROR, "%s(%s) failed", __FUNCTION__, strWhere.c_str());
+    CLog::Log(LOGERROR, "%s(%s) failed", __FUNCTION__, filter.where.c_str());
   }
   return false;
 }
 
 bool CMusicDatabase::GetCompilationAlbums(const CStdString& strBaseDir, CFileItemList& items)
 {
-  return GetAlbumsByWhere(strBaseDir, "WHERE bCompilation = 1", "", items);
+  Filter filter("bCompilation = 1");
+  return GetAlbumsByWhere(strBaseDir, filter, items);
 }
 
 bool CMusicDatabase::GetCompilationSongs(const CStdString& strBaseDir, CFileItemList& items)
 {
-  return GetSongsByWhere(strBaseDir, "WHERE bCompilation = 1", items);
+  Filter filter("bCompilation = 1");
+  return GetSongsByWhere(strBaseDir, filter, items);
 }
 
 int CMusicDatabase::GetCompilationAlbumsCount()
@@ -4089,7 +4097,7 @@ bool CMusicDatabase::CommitTransaction()
 {
   if (CDatabase::CommitTransaction())
   { // number of items in the db has likely changed, so reset the infomanager cache
-    g_infoManager.SetLibraryBool(LIBRARY_HAS_MUSIC, GetSongsCount("") > 0);
+    g_infoManager.SetLibraryBool(LIBRARY_HAS_MUSIC, GetSongsCount() > 0);
     return true;
   }
   return false;

--- a/xbmc/music/MusicDatabase.h
+++ b/xbmc/music/MusicDatabase.h
@@ -88,33 +88,6 @@ class CMusicDatabase : public CDatabase
 {
   friend class DatabaseUtils;
 
-  class CArtistCache
-  {
-  public:
-    int idArtist;
-    CStdString strArtist;
-  };
-
-  class CPathCache
-  {
-  public:
-    int idPath;
-    CStdString strPath;
-  };
-
-  class CGenreCache
-  {
-  public:
-    int idGenre;
-    CStdString strGenre;
-  };
-
-  class CAlbumCache : public CAlbum
-  {
-  public:
-    int idAlbum;
-  };
-
 public:
   CMusicDatabase(void);
   virtual ~CMusicDatabase(void);
@@ -292,11 +265,11 @@ public:
   std::string GetArtistArtForItem(int mediaId, const std::string &mediaType, const std::string &artType);
 
 protected:
-  std::map<CStdString, int /*CArtistCache*/> m_artistCache;
-  std::map<CStdString, int /*CGenreCache*/> m_genreCache;
-  std::map<CStdString, int /*CPathCache*/> m_pathCache;
-  std::map<CStdString, int /*CPathCache*/> m_thumbCache;
-  std::map<CStdString, CAlbumCache> m_albumCache;
+  std::map<CStdString, int> m_artistCache;
+  std::map<CStdString, int> m_genreCache;
+  std::map<CStdString, int> m_pathCache;
+  std::map<CStdString, int> m_thumbCache;
+  std::map<CStdString, CAlbum> m_albumCache;
 
   virtual bool CreateTables();
   virtual int GetMinVersion() const { return 27; };

--- a/xbmc/music/MusicDatabase.h
+++ b/xbmc/music/MusicDatabase.h
@@ -156,13 +156,13 @@ public:
   bool GetAlbumsByYear(const CStdString &strBaseDir, CFileItemList& items, int year);
   bool GetSongsNav(const CStdString& strBaseDir, CFileItemList& items, int idGenre, int idArtist,int idAlbum, const SortDescription &sortDescription = SortDescription());
   bool GetSongsByYear(const CStdString& baseDir, CFileItemList& items, int year);
-  bool GetSongsByWhere(const CStdString &baseDir, const CStdString &whereClause, CFileItemList& items, const SortDescription &sortDescription = SortDescription());
-  bool GetAlbumsByWhere(const CStdString &baseDir, const CStdString &where, const CStdString &order, CFileItemList &items, const SortDescription &sortDescription = SortDescription());
-  bool GetArtistsByWhere(const CStdString& strBaseDir, const CStdString &where, CFileItemList& items);
-  bool GetRandomSong(CFileItem* item, int& idSong, const CStdString& strWhere);
+  bool GetSongsByWhere(const CStdString &baseDir, const Filter &filter, CFileItemList& items, const SortDescription &sortDescription = SortDescription());
+  bool GetAlbumsByWhere(const CStdString &baseDir, const Filter &filter, CFileItemList &items, const SortDescription &sortDescription = SortDescription());
+  bool GetArtistsByWhere(const CStdString& strBaseDir, const Filter &filter, CFileItemList& items);
+  bool GetRandomSong(CFileItem* item, int& idSong, const Filter &filter);
   int GetKaraokeSongsCount();
-  int GetSongsCount(const CStdString& strWhere = "");
-  unsigned int GetSongIDs(const CStdString& strWhere, std::vector<std::pair<int,int> > &songIDs);
+  int GetSongsCount(const Filter &filter = Filter());
+  unsigned int GetSongIDs(const Filter &filter, std::vector<std::pair<int,int> > &songIDs);
 
   bool GetAlbumPath(int idAlbum, CStdString &path);
   bool SaveAlbumThumb(int idAlbum, const CStdString &thumb);

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -321,20 +321,6 @@ class CVideoDatabase : public CDatabase
 {
 public:
 
-  class Filter
-  {
-  public:
-    Filter() : fields("*") {};
-    Filter(const char *w) : fields("*"), where(w) {};
-    Filter(const std::string &w) : fields("*"), where(w) {};
-    std::string fields;
-    std::string join;
-    std::string where;
-    std::string order;
-    std::string group;
-    std::string limit;
-  };
-
   class CActor    // used for actor retrieval for non-master users
   {
   public:


### PR DESCRIPTION
This work extends the usage of CDatabase::Filter, which was introduced a while ago for the videodb to also be used in the musicdb. It has the advantage of a single parameter to pass all custom SQL clauses (join, where, order, group, limit) and without having to know that you need to add "WHERE" at the beginning of every SQL WHERE clause passed into one of CMusicDatabase's methods.

The first commit of this PR is cherry-picked from #1150. Having the Filter class in CDatabase makes much more sense than in CVideoDatabase, especially now that also CMusicDatabase uses it.

The second commit just contains some cosmetics I ran across in CMusicDatabase and removes unused classes.
