### PR TITLE
Fix fanart-based slideshow screensavers

### DIFF
--- a/xbmc/ApplicationMessenger.h
+++ b/xbmc/ApplicationMessenger.h
@@ -166,7 +166,7 @@ public:
 
   void PlayFile(const CFileItem &item, bool bRestart = false); // thread safe version of g_application.PlayFile()
   void PictureShow(std::string filename);
-  void PictureSlideShow(std::string pathname, bool bScreensaver = false, bool addTBN = false);
+  void PictureSlideShow(const CFileItemList &list, bool bScreensaver = false);
   void SetGUILanguage(const std::string &strLanguage);
   void Shutdown();
   void Powerdown();

--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -5051,3 +5051,35 @@ string CMusicDatabase::GetArtistArtForItem(int mediaId, const string &mediaType,
   std::string query = PrepareSQL("SELECT url FROM art WHERE media_id=(SELECT idArtist from %s_artist WHERE id%s=%i) AND media_type='artist' AND type='%s'", mediaType.c_str(), mediaType.c_str(), mediaId, artType.c_str());
   return GetSingleValue(query, m_pDS2);
 }
+
+bool CMusicDatabase::GetArtForType(const string &artType, CFileItemList &items)
+{
+  try
+  {
+    if (NULL == m_pDB.get()) return false;
+    if (NULL == m_pDS.get()) return false;
+
+    CStdString sql = PrepareSQL("SELECT url FROM art WHERE type='%s'", artType.c_str());
+    m_pDS->query(sql.c_str());
+
+    while (!m_pDS->eof())
+    {
+      CStdString url = m_pDS->fv(0).get_asString();
+      CFileItemPtr pItem(new CFileItem(url));
+      CURL::Encode(url);
+      pItem->SetPath("image://"+ url);
+      items.Add(pItem);
+      m_pDS->next();
+    }
+
+    // cleanup
+    m_pDS->close();
+    return items.Size() > 0;
+  }
+  catch (...)
+  {
+    CLog::Log(LOGERROR, "%s failed", __FUNCTION__);
+  }
+
+  return false;
+}

--- a/xbmc/music/MusicDatabase.h
+++ b/xbmc/music/MusicDatabase.h
@@ -291,9 +291,17 @@ public:
    */
   std::string GetArtistArtForItem(int mediaId, const std::string &mediaType, const std::string &artType);
 
+  /*! \brief Get artwork list associated with the given artwork type
+   \param type type of image to associate
+   \param items the returned items
+   \return true if items are found, false otherwise.
+   */
+  bool GetArtForType(const std::string &mediaType, CFileItemList &items);
+
 protected:
   std::map<CStdString, int /*CArtistCache*/> m_artistCache;
   std::map<CStdString, int /*CGenreCache*/> m_genreCache;
+
   std::map<CStdString, int /*CPathCache*/> m_pathCache;
   std::map<CStdString, int /*CPathCache*/> m_thumbCache;
   std::map<CStdString, CAlbumCache> m_albumCache;

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -3569,6 +3569,37 @@ bool CVideoDatabase::GetTvShowSeasonArt(int showId, map<int, string> &seasonArt)
   return false;
 }
 
+bool CVideoDatabase::GetArtForType(const string &artType, CFileItemList &items)
+{
+  try
+  {
+    if (NULL == m_pDB.get()) return false;
+    if (NULL == m_pDS.get()) return false;
+
+    CStdString sql = PrepareSQL("SELECT url FROM art WHERE type='%s'", artType.c_str());
+    m_pDS->query(sql.c_str());
+
+    while (!m_pDS->eof())
+    {
+      CStdString url = m_pDS->fv(0).get_asString();
+      CFileItemPtr pItem(new CFileItem(url));
+      CURL::Encode(url);
+      pItem->SetPath("image://"+ url);
+      items.Add(pItem);
+      m_pDS->next();
+    }
+
+    m_pDS->close();
+    return items.Size() > 0;
+  }
+  catch (...)
+  {
+    CLog::Log(LOGERROR, "%s failed", __FUNCTION__);
+  }
+
+  return false;
+}
+
 /// \brief GetStackTimes() obtains any saved video times for the stacked file
 /// \retval Returns true if the stack times exist, false otherwise.
 bool CVideoDatabase::GetStackTimes(const CStdString &filePath, vector<int> &times)

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -683,6 +683,13 @@ public:
   std::string GetArtForItem(int mediaId, const std::string &mediaType, const std::string &artType);
   bool GetTvShowSeasonArt(int mediaId, std::map<int, std::string> &seasonArt);
 
+  /*! \brief Get artwork list associated with the given artwork type
+   \param type type of image to associate
+   \param items the returned items
+   \return true if items are found, false otherwise.
+   */
+  bool GetArtForType(const std::string &mediaType, CFileItemList &items);
+
   int AddTag(const std::string &tag);
   void AddTagToItem(int idItem, int idTag, const std::string &type);
   void RemoveTagFromItem(int idItem, int idTag, const std::string &type);


### PR DESCRIPTION
Fixes http://trac.xbmc.org/ticket/13172

During the thumbnail and texture cache refactor the fanart-based slideshow screensavers got lost. This commit adds GetArtForType() to the music and video databases which will return a file item list with all 'image://' URLs for the associated artwork type - in this case 'fanart'. Thanks jm for the hints.
