### PR TITLE
Fix AirTunes volume control range

### DIFF
--- a/xbmc/network/AirTunesServer.cpp
+++ b/xbmc/network/AirTunesServer.cpp
@@ -187,8 +187,8 @@ void* CAirTunesServer::AudioOutputFunctions::audio_init(void *cls, int bits, int
 
 void  CAirTunesServer::AudioOutputFunctions::audio_set_volume(void *cls, void *session, float volume)
 {
-  //volume from -144 - 0
-  float volPercent = 1 - volume/-144;
+  // iOS reports volume in 16 steps of -1.8 dB each from -28.8 dB to 0 dB
+  float volPercent = 1 - (volume / -28.8f);
   g_application.SetVolume(volPercent, false);//non-percent volume 0.0-1.0
 }
 

--- a/xbmc/network/AirTunesServer.cpp
+++ b/xbmc/network/AirTunesServer.cpp
@@ -187,8 +187,8 @@ void* CAirTunesServer::AudioOutputFunctions::audio_init(void *cls, int bits, int
 
 void  CAirTunesServer::AudioOutputFunctions::audio_set_volume(void *cls, void *session, float volume)
 {
-  // iOS reports volume in 16 steps of -1.8 dB each from -28.8 dB to 0 dB
-  float volPercent = 1 - (volume / -28.8f);
+  // iOS reports volume in dB units with 0 dB as full volume reference and -144 dB as soft mute.
+  float volPercent = pow(10.0f, volume / 20.0f);
   g_application.SetVolume(volPercent, false);//non-percent volume 0.0-1.0
 }
 

--- a/xbmc/network/AirTunesServer.cpp
+++ b/xbmc/network/AirTunesServer.cpp
@@ -188,7 +188,8 @@ void* CAirTunesServer::AudioOutputFunctions::audio_init(void *cls, int bits, int
 void  CAirTunesServer::AudioOutputFunctions::audio_set_volume(void *cls, void *session, float volume)
 {
   // iOS reports volume in dB units with 0 dB as full volume reference and -144 dB as soft mute.
-  float volPercent = pow(10.0f, volume / 20.0f);
+  // The actual range seems to be approx 30 dB, so clip to mute for any value lower than -30 dB
+  float volPercent = (volume < -30.0f) ? 0.0f : (1 - (volume / -30.0f));
   g_application.SetVolume(volPercent, false);//non-percent volume 0.0-1.0
 }
 


### PR DESCRIPTION
Installed 8 July 2012 nightly binary on Win XP and found AirTunes (audio-only) was working. Only problem was that volume changes done on the iOS device from 0 to 100% would get translated to 80-100% on XBMC. Modified the volume calculation formula in AirTunesServer.cpp and all is well. Tested with iPhone 4S running iOS 5.1.1 and XBMC git head from 14 July 2012 running on Win XP SP3. Would be nice if this is merged into official repo.
