### PR TITLE
[AE] Fix inverted "Boost levels on downmix" naming and usage.

### DIFF
--- a/xbmc/cores/AudioEngine/Engines/SoftAE/SoftAE.cpp
+++ b/xbmc/cores/AudioEngine/Engines/SoftAE/SoftAE.cpp
@@ -482,7 +482,7 @@ void CSoftAE::OnSettingsChange(std::string setting)
     OpenSink();
   }
 
-  if (setting == "audiooutput.dontnormalizelevels" || setting == "audiooutput.stereoupmix")
+  if (setting == "audiooutput.normalizelevels" || setting == "audiooutput.stereoupmix")
   {
     /* re-init stream reamppers */
     CSingleLock streamLock(m_streamLock);

--- a/xbmc/cores/AudioEngine/Utils/AERemap.cpp
+++ b/xbmc/cores/AudioEngine/Utils/AERemap.cpp
@@ -193,7 +193,7 @@ bool CAERemap::Initialize(CAEChannelInfo input, CAEChannelInfo output, bool fina
     normalize = true;
   else
   {
-    normalize = !g_guiSettings.GetBool("audiooutput.dontnormalizelevels");
+    normalize = g_guiSettings.GetBool("audiooutput.normalizelevels");
     CLog::Log(LOGDEBUG, "AERemap: Downmix normalization is %s", (normalize ? "enabled" : "disabled"));
   }
 

--- a/xbmc/settings/GUISettings.cpp
+++ b/xbmc/settings/GUISettings.cpp
@@ -451,7 +451,7 @@ void CGUISettings::Initialize()
   for(int layout = AE_CH_LAYOUT_2_0; layout < AE_CH_LAYOUT_MAX; ++layout)
     channelLayout.insert(make_pair(34100+layout, layout));
   AddInt(ao, "audiooutput.channellayout", 34100, AE_CH_LAYOUT_2_0, channelLayout, SPIN_CONTROL_TEXT);
-  AddBool(ao, "audiooutput.dontnormalizelevels", 346, true);
+  AddBool(ao, "audiooutput.normalizelevels", 346, false);
   AddBool(ao, "audiooutput.stereoupmix", 252, false);
 
 #if defined(TARGET_DARWIN_IOS)


### PR DESCRIPTION
extracted from https://github.com/xbmc/xbmc/pull/1074

no brainer
