### PR TITLE
Fix: open correct streams in case of CDVDInputStreamNavigator

### DIFF
--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -676,6 +676,10 @@ bool CDVDPlayer::OpenDemuxStream()
 
 void CDVDPlayer::OpenDefaultStreams()
 {
+  // bypass for DVDs. The DVD Navigator has already dictated which streams to open.
+  if (m_pInputStream->IsStreamType(DVDSTREAM_TYPE_DVD))
+    return;
+
   SelectionStreams streams;
   bool valid;
 


### PR DESCRIPTION
This PR fixes the issue 13178 (http://trac.xbmc.org/ticket/13178). 

When DVDPlayer wants to open an (audio) stream, the stored stream ID has been set by CSelectionStreams::Update(), provided by a simple and non-unique counter, while iterating over the DVD Navigator's provided streams. Now OpenAudioStream is querying the demuxer to provide the stream for opening, based on that same id, but it's not the same as the one the demuxer has. E.g. the first audio stream was ID 0 according to CSelectionStreams, but opening it through the demuxer using this ID returned the video stream (since that is stream 0 according to the demuxer). As such no problem, but the hints / codec types were completely wrong, with no audio playback as a result. This fix makes sure that the ID set by the Update method is the same ID in use by the demuxer.

Update: 
Apparently the DVD menu (of the test video in the ticket) also suffers from a dvd_wait event not being processed correctly. the second commit addresses this and together with the stream id fix, this fully fixes the issue from the ticket.

Update: 
it turns out that the root cause is that OpenDefaultStreams is being called (with incorrect IDs) where it shouldn't be. The DVD navigator has already set the correct streams.
