### PR TITLE
dirty regions: dont add invisible controls to the tracker

### DIFF
--- a/xbmc/guilib/GUIControl.cpp
+++ b/xbmc/guilib/GUIControl.cpp
@@ -129,7 +129,7 @@ void CGUIControl::DoProcess(unsigned int currentTime, CDirtyRegionList &dirtyreg
 {
   CRect dirtyRegion = m_renderRegion;
 
-  bool changed = m_bInvalidated;
+  bool changed = m_bInvalidated && IsVisible();
 
   changed |= Animate(currentTime);
 


### PR DESCRIPTION
fixes high cpu load in e.g. video menu
