### PR TITLE
Save filestate on player pause

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -4344,7 +4344,7 @@ void CApplication::SaveFileState(bool bForeground /* = false */)
 void CApplication::UpdateFileState()
 {
   // Did the file change?
-  if (m_progressTrackingItem->GetPath() != "" && m_progressTrackingItem->GetPath() != CurrentFile())
+  if (m_progressTrackingItem->GetPath() != "" && (m_progressTrackingItem->GetPath() != CurrentFile() || IsPaused() ) )
   {
     SaveFileState();
 
@@ -4353,7 +4353,7 @@ void CApplication::UpdateFileState()
   }
   else
   {
-    if (IsPlayingVideo() || IsPlayingAudio())
+    if ( ( IsPlayingVideo() || IsPlayingAudio() ) && !IsPaused() )
     {
       if (m_progressTrackingItem->GetPath() == "")
       {


### PR DESCRIPTION
This PR implements a feature that has been asked for several times on the forum: saving the filestate on player pause. It furthermore changes the priority for our filestate save job to high, to make sure it gets processed ASAP (takes priority over eg. fanart & thumb creation and such).
