### PR TITLE
Prevent using of uninitialized variable, some cosmetic in CPUInfo.cpp

### DIFF
--- a/xbmc/utils/CPUInfo.cpp
+++ b/xbmc/utils/CPUInfo.cpp
@@ -240,6 +240,7 @@ CCPUInfo::CCPUInfo(void)
 
 #endif
   readProcStat(m_userTicks, m_niceTicks, m_systemTicks, m_idleTicks, m_ioTicks);
+  m_lastReadTime = time(NULL);
 
   ReadCPUFeatures();
 
@@ -298,6 +299,7 @@ int CCPUInfo::getUsedPercentage()
   m_ioTicks += ioTicks;
 
   m_lastUsedPercentage = result;
+  m_lastReadTime = time(NULL);
 
   return result;
 }
@@ -488,7 +490,6 @@ bool CCPUInfo::readProcStat(unsigned long long& user, unsigned long long& nice,
   }
 #endif
 
-  m_lastReadTime = time(NULL);
   return true;
 }
 

--- a/xbmc/utils/CPUInfo.cpp
+++ b/xbmc/utils/CPUInfo.cpp
@@ -264,9 +264,7 @@ CCPUInfo::~CCPUInfo()
 int CCPUInfo::getUsedPercentage()
 {
   if (m_lastReadTime + MINIMUM_TIME_BETWEEN_READS > time(NULL))
-  {
     return m_lastUsedPercentage;
-  }
 
   unsigned long long userTicks;
   unsigned long long niceTicks;
@@ -275,9 +273,7 @@ int CCPUInfo::getUsedPercentage()
   unsigned long long ioTicks;
 
   if (!readProcStat(userTicks, niceTicks, systemTicks, idleTicks, ioTicks))
-  {
     return 0;
-  }
 
   userTicks -= m_userTicks;
   niceTicks -= m_niceTicks;
@@ -323,9 +319,7 @@ float CCPUInfo::getCPUFrequency()
   ret = RegQueryValueEx(hKey,"~MHz", NULL, NULL, (LPBYTE)&dwMHz, &dwSize);
   RegCloseKey(hKey);
   if(ret == 0)
-  {
     return float(dwMHz);
-  }
   else
     return 0.f;
 #else
@@ -605,13 +599,3 @@ void CCPUInfo::ReadCPUFeatures()
 }
 
 CCPUInfo g_cpuInfo;
-
-/*
-int main()
-{
-  CCPUInfo c;
-  usleep(...);
-  int r = c.getUsedPercentage();
-  printf("%d\n", r);
-}
-*/

--- a/xbmc/utils/CPUInfo.cpp
+++ b/xbmc/utils/CPUInfo.cpp
@@ -70,8 +70,8 @@
 
 using namespace std;
 
-// In seconds
-#define MINIMUM_TIME_BETWEEN_READS 2
+// In milliseconds
+#define MINIMUM_TIME_BETWEEN_READS 500
 
 #ifdef _WIN32
 /* replacement gettimeofday implementation, copy from dvdnav_internal.h */
@@ -240,7 +240,7 @@ CCPUInfo::CCPUInfo(void)
 
 #endif
   readProcStat(m_userTicks, m_niceTicks, m_systemTicks, m_idleTicks, m_ioTicks);
-  m_lastReadTime = time(NULL);
+  m_nextUsedReadTime.Set(MINIMUM_TIME_BETWEEN_READS);
 
   ReadCPUFeatures();
 
@@ -264,7 +264,7 @@ CCPUInfo::~CCPUInfo()
 
 int CCPUInfo::getUsedPercentage()
 {
-  if (m_lastReadTime + MINIMUM_TIME_BETWEEN_READS > time(NULL))
+  if (!m_nextUsedReadTime.IsTimePast())
     return m_lastUsedPercentage;
 
   unsigned long long userTicks;
@@ -299,7 +299,7 @@ int CCPUInfo::getUsedPercentage()
   m_ioTicks += ioTicks;
 
   m_lastUsedPercentage = result;
-  m_lastReadTime = time(NULL);
+  m_nextUsedReadTime.Set(MINIMUM_TIME_BETWEEN_READS);
 
   return result;
 }

--- a/xbmc/utils/CPUInfo.cpp
+++ b/xbmc/utils/CPUInfo.cpp
@@ -238,8 +238,8 @@ CCPUInfo::CCPUInfo(void)
     m_cpuModel = "Unknown";
   }
 
-  readProcStat(m_userTicks, m_niceTicks, m_systemTicks, m_idleTicks, m_ioTicks);
 #endif
+  readProcStat(m_userTicks, m_niceTicks, m_systemTicks, m_idleTicks, m_ioTicks);
 
   ReadCPUFeatures();
 

--- a/xbmc/utils/CPUInfo.cpp
+++ b/xbmc/utils/CPUInfo.cpp
@@ -273,7 +273,7 @@ int CCPUInfo::getUsedPercentage()
   unsigned long long ioTicks;
 
   if (!readProcStat(userTicks, niceTicks, systemTicks, idleTicks, ioTicks))
-    return 0;
+    return m_lastUsedPercentage;
 
   userTicks -= m_userTicks;
   niceTicks -= m_niceTicks;

--- a/xbmc/utils/CPUInfo.h
+++ b/xbmc/utils/CPUInfo.h
@@ -28,6 +28,7 @@
 #include "Temperature.h"
 #include <string>
 #include <map>
+#include "threads\SystemClock.h"
 
 #define CPU_FEATURE_MMX      1 << 0
 #define CPU_FEATURE_MMX2     1 << 1
@@ -91,7 +92,7 @@ private:
   unsigned long long m_ioTicks;
 
   int          m_lastUsedPercentage;
-  time_t       m_lastReadTime;
+  XbmcThreads::EndTime m_nextUsedReadTime; 
   std::string  m_cpuModel;
   int          m_cpuCount;
   unsigned int m_cpuFeatures;


### PR DESCRIPTION
Prevent using of uninitialized variable
Return last CPU usage instead of 0, when current usage not available
Update CPU usage twice per second instead of once in two seconds
Some cosmetic
