### PR TITLE
Fix watched-unwatched for TV shows and Seasons

### DIFF
--- a/xbmc/video/windows/GUIWindowVideoNav.cpp
+++ b/xbmc/video/windows/GUIWindowVideoNav.cpp
@@ -522,9 +522,9 @@ void CGUIWindowVideoNav::UpdateButtons()
 
 bool CGUIWindowVideoNav::GetFilteredItems(const CStdString &filter, CFileItemList &items)
 {
-  bool result = CGUIMediaWindow::GetFilteredItems(filter, items);
-  ApplyWatchedFilter(items);
-  return result || g_settings.GetWatchMode(m_vecItems->GetContent()) != VIDEO_SHOW_ALL;
+  bool listchanged = CGUIMediaWindow::GetFilteredItems(filter, items);
+  listchanged |= ApplyWatchedFilter(items);
+  return listchanged;
 }
 
 /// \brief Search for names, genres, artists, directors, and plots with search string \e strSearch in the
@@ -1564,8 +1564,9 @@ CStdString CGUIWindowVideoNav::GetStartFolder(const CStdString &dir)
   return CGUIWindowVideoBase::GetStartFolder(dir);
 }
 
-void CGUIWindowVideoNav::ApplyWatchedFilter(CFileItemList &items)
+bool CGUIWindowVideoNav::ApplyWatchedFilter(CFileItemList &items)
 {
+  bool listchanged = false;
   CVideoDatabaseDirectory dir;
   NODE_TYPE node = dir.GetDirectoryChildType(items.GetPath());
 
@@ -1599,7 +1600,10 @@ void CGUIWindowVideoNav::ApplyWatchedFilter(CFileItemList &items)
         item->GetVideoInfoTag()->m_iEpisode = (int)item->GetProperty("unwatchedepisodes").asInteger();
       if (watchMode == VIDEO_SHOW_WATCHED)
         item->GetVideoInfoTag()->m_iEpisode = (int)item->GetProperty("watchedepisodes").asInteger();
+      if (watchMode == VIDEO_SHOW_ALL)
+        item->GetVideoInfoTag()->m_iEpisode = (int)item->GetProperty("totalepisodes").asInteger();
       item->SetProperty("numepisodes", item->GetVideoInfoTag()->m_iEpisode);
+      listchanged = true;
     }
 
     if (filterWatched)
@@ -1609,9 +1613,17 @@ void CGUIWindowVideoNav::ApplyWatchedFilter(CFileItemList &items)
       {
         items.Remove(i);
         i--;
+        listchanged = true;
       }
     }
   }
+
+  if(node == NODE_TYPE_TITLE_TVSHOWS || node == NODE_TYPE_SEASONS)
+    // the watched filter may change the "numepisodes" property which is reflected in the TV_SHOWS and SEASONS nodes
+    // therefore, the items labels have to be refreshed, and possibly the list needs resorting as well.
+    FormatAndSort(items); 
+
+  return listchanged;
 }
 
 bool CGUIWindowVideoNav::GetItemsForTag(const CStdString &strHeading, const std::string &type, CFileItemList &items, int idTag /* = -1 */, bool showAll /* = true */)

--- a/xbmc/video/windows/GUIWindowVideoNav.h
+++ b/xbmc/video/windows/GUIWindowVideoNav.h
@@ -49,7 +49,7 @@ protected:
    */
   void LoadVideoInfo(CFileItemList &items);
 
-  void ApplyWatchedFilter(CFileItemList &items);
+  bool ApplyWatchedFilter(CFileItemList &items);
   virtual bool GetFilteredItems(const CStdString &filter, CFileItemList &items);
 
   virtual void OnItemLoaded(CFileItem* pItem) {};

--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -853,6 +853,7 @@ void CGUIMediaWindow::OnPrepareFileItems(CFileItemList &items)
 // to modify the fileitems. Eg. to modify the item label
 void CGUIMediaWindow::OnFinalizeFileItems(CFileItemList &items)
 {
+  m_unfilteredItems->SetPath(items.GetPath()); // use the original path - it'll likely be relied on for other things later.
   m_unfilteredItems->Append(items);
   
   CStdString filter(GetProperty("filter").asString());
@@ -1523,7 +1524,7 @@ void CGUIMediaWindow::OnFilterItems(const CStdString &filter)
   
   m_viewControl.Clear();
   
-  CFileItemList items;
+  CFileItemList items(m_unfilteredItems->GetPath()); // use the original path - it'll likely be relied on for other things later.
   items.Append(*m_unfilteredItems);
   if (GetFilteredItems(filter, items))
   {
@@ -1546,7 +1547,7 @@ bool CGUIMediaWindow::GetFilteredItems(const CStdString &filter, CFileItemList &
   if (trimmedFilter.IsEmpty())
     return true;
 
-  CFileItemList filteredItems;
+  CFileItemList filteredItems(items.GetPath()); // use the original path - it'll likely be relied on for other things later.
   bool numericMatch = StringUtils::IsNaturalNumber(trimmedFilter);
   for (int i = 0; i < items.Size(); i++)
   {


### PR DESCRIPTION
this is a fix to the issue described in http://forum.xbmc.org/showthread.php?tid=135982
the issue was introduced in https://github.com/xbmc/xbmc/pull/1022

notes:
- the path of the fileitemlist are necessary to the proper functioning of ApplyWatchedFilter (for checking the node type)
- calling FormatAndSort in ApplyWatchedFilter to reformat the label that displays the number of episodes
