### PR TITLE
Proposed fix for thumbs not auto-generating for some iPhone MOVs.

### DIFF
--- a/xbmc/cores/dvdplayer/DVDFileInfo.cpp
+++ b/xbmc/cores/dvdplayer/DVDFileInfo.cpp
@@ -154,6 +154,8 @@ bool CDVDFileInfo::ExtractThumb(const CStdString &strPath, CTextureDetails &deta
   }
 
   bool bOk = false;
+  int packetsTried = 0;
+
   if (nVideoStream != -1)
   {
     CDVDVideoCodec *pVideoCodec;
@@ -184,11 +186,14 @@ bool CDVDFileInfo::ExtractThumb(const CStdString &strPath, CTextureDetails &deta
         int iDecoderState = VC_ERROR;
         DVDVideoPicture picture;
 
-        // num streams * 40 frames, should get a valid frame, if not abort.
-        int abort_index = pDemuxer->GetNrOfStreams() * 40;
+        // num streams * 80 frames, should get a valid frame, if not abort.
+        int packetsToTry = 80;
+        int abort_index = pDemuxer->GetNrOfStreams() * packetsToTry;
         do
         {
           pPacket = pDemuxer->Read();
+          packetsTried++;
+
           if (!pPacket)
             break;
 
@@ -254,7 +259,7 @@ bool CDVDFileInfo::ExtractThumb(const CStdString &strPath, CTextureDetails &deta
         }
         else
         {
-          CLog::Log(LOGDEBUG,"%s - decode failed in %s", __FUNCTION__, strPath.c_str());
+          CLog::Log(LOGDEBUG,"%s - decode failed in %s after %d packets.", __FUNCTION__, strPath.c_str(), packetsTried);
         }
       }
       delete pVideoCodec;
@@ -274,7 +279,7 @@ bool CDVDFileInfo::ExtractThumb(const CStdString &strPath, CTextureDetails &deta
   }
 
   unsigned int nTotalTime = XbmcThreads::SystemClockMillis() - nTime;
-  CLog::Log(LOGDEBUG,"%s - measured %u ms to extract thumb from file <%s> ", __FUNCTION__, nTotalTime, strPath.c_str());
+  CLog::Log(LOGDEBUG,"%s - measured %u ms to extract thumb from file <%s> in %d packets. ", __FUNCTION__, nTotalTime, strPath.c_str(), packetsTried);
   return bOk;
 }
 


### PR DESCRIPTION
This is a fix for the problem I encountered and documented here:

http://forum.xbmc.org/showthread.php?tid=135725

It is a simple and conservative fix that simply doubles the hard coded limit for how many packets the thumb extraction will scan looking for a complete frame.  I found this was enough to extract a thumb from all the iPhone MOVs I have.  I also extended the logging to log how many packets it took to extract a thumb (or to fail to).

Questions remaining for me are:
1. Is this limit needed at all?
2. I can see that having a limit avoids long running threads while browsing, so is doubling the limit enough, or is there a way I could establish what a 'good' limit should be (I am not all familiar with these file formats)?
