### PR TITLE
GUI: fallback to default control if currently focused control can't be focused anymore

### DIFF
--- a/xbmc/guilib/GUIControlGroup.cpp
+++ b/xbmc/guilib/GUIControlGroup.cpp
@@ -464,6 +464,19 @@ int CGUIControlGroup::GetFocusedControlID() const
 
 CGUIControl *CGUIControlGroup::GetFocusedControl() const
 {
+  // try lookup first
+  if (m_focusedControl)
+  {
+    // we may have multiple controls with same id - we pick first that has focus
+    pair<LookupMap::const_iterator, LookupMap::const_iterator> range = m_lookup.equal_range(m_focusedControl);
+    for (LookupMap::const_iterator i = range.first; i != range.second; ++i)
+    {
+      if (i->second->HasFocus())
+        return i->second;
+    }
+  }
+
+  // if lookup didn't find focused control, iterate m_children to find it
   for (ciControls it = m_children.begin(); it != m_children.end(); ++it)
   {
     const CGUIControl* control = *it;

--- a/xbmc/guilib/GUIControlGroup.cpp
+++ b/xbmc/guilib/GUIControlGroup.cpp
@@ -480,15 +480,17 @@ CGUIControl *CGUIControlGroup::GetFocusedControl() const
   for (ciControls it = m_children.begin(); it != m_children.end(); ++it)
   {
     const CGUIControl* control = *it;
-    if (control->HasFocus())
+    // Avoid calling HasFocus() on control group as it will (possibly) recursively
+    // traverse entire group tree just to check if there is focused control.
+    // We are recursively traversing it here so no point in doing it twice.
+    if (control->IsGroup())
     {
-      if (control->IsGroup())
-      {
-        CGUIControlGroup *group = (CGUIControlGroup *)control;
-        return group->GetFocusedControl();
-      }
-      return (CGUIControl *)control;
+      CGUIControl* focusedControl = ((CGUIControlGroup *)control)->GetFocusedControl();
+      if (focusedControl)
+        return (CGUIControl *)focusedControl;
     }
+    else if (control->HasFocus())
+      return (CGUIControl *)control;
   }
   return NULL;
 }

--- a/xbmc/guilib/GUIWindow.cpp
+++ b/xbmc/guilib/GUIWindow.cpp
@@ -302,6 +302,12 @@ void CGUIWindow::DoProcess(unsigned int currentTime, CDirtyRegionList &dirtyregi
   CGUIControlGroup::DoProcess(currentTime, dirtyregions);
   if (size != g_graphicsContext.RemoveTransform())
     CLog::Log(LOGERROR, "Unbalanced UI transforms (was %d)", size);
+
+  // check if currently focused control can have it
+  // and fallback to default control if not
+  CGUIControl* focusedControl = GetFocusedControl();
+  if (focusedControl && !focusedControl->CanFocus())
+    SET_CONTROL_FOCUS(m_defaultControl, 0);
 }
 
 void CGUIWindow::DoRender()


### PR DESCRIPTION
This is attempt to fix http://trac.xbmc.org/ticket/13117

Currently control can hold focus even if it's no longer focusable - this checks if focused control is focusable and switch to default control in window if it's not.

Ideally default control should always be focusable - but sometimes it's not (f.e. sometime ago there was issue with selecting music scraper - list of scrapers was empty = not focusable and that list was default control). Not sure how to handle this nicely other than allowing to define list of default controls and picking first focusable control from that list and if none is focusable then just grab any focusable control.
