### PR TITLE
Workaround for swscale crashing on pictures with odd number of pixels in width

### DIFF
--- a/xbmc/guilib/Texture.cpp
+++ b/xbmc/guilib/Texture.cpp
@@ -91,6 +91,16 @@ void CBaseTexture::Allocate(unsigned int width, unsigned int height, unsigned in
     m_textureWidth = ((m_textureWidth + 3) / 4) * 4;
     m_textureHeight = ((m_textureHeight + 3) / 4) * 4;
   }
+  else
+  {
+    // align all textures so that they have an even width
+    // in some circumstances when we downsize a thumbnail
+    // which has an uneven number of pixels in width
+    // we crash in CPicture::ScaleImage in ffmpegs swscale
+    // because it tries to access beyond the source memory
+    // (happens on osx and ios)
+    m_textureWidth = ((m_textureWidth + 1) / 2) * 2;
+  }
 
   // check for max texture size
   #define CLAMP(x, y) { if (x > y) x = y; }


### PR DESCRIPTION
i have kind off tracked down the crash mentioned here:

http://forum.xbmc.org/showthread.php?tid=136153&page=2

Its easy to reproduce. Add a fake movie "Cars (2006)" - activate actors thumbnails and scrape it using TMDB. After it scraped go to info -> cast and scroll to "George Carlin".

It will download the actors image from here http://cf2.imgobject.com/t/p/original/5WSoAFzPlu1ZpKB3O8mqfIGOXB.jpg

and try to scale it to 720 pixels height.

This image is 753 pixels wide (odd number of pixels). libswscale will then do somthing in the context and sets context->chrSrcW to 377 (which should be the half but is somehow wrong rounded imho). It then accesses the source image with 377 as strideidx and gets a bad_access.

I couldn't track it down - i even tried to replicate the crash with the cmdline tools from ffmpeg and libav - but both use the mjpeg decoder/encoder for resizing on commandline instead of libswscale. So i couldn't reproduce it. 

output of ffmpeg tool:

http://pastebin.com/DKS0gK5V

It looks like its not using swscale at all.

I have done multiple tests with odd width in input and output image - crash only is definitly there when input image has odd width. The crash doesn't seem to occur on all platforms (doesn't crash on my atv2, but on my ipod and my osx rig).

I also played a bit with scaling flags see here:

http://pastebin.com/xptE3Vq2

Well nothing helped, but the commit in this PR (which feels quiet hacky).

@elupus @Anssi your comments are welcome :)
