### PR TITLE
Fix the Windows screensaver left disabled when XBMC loses focus.

### DIFF
--- a/xbmc/windowing/windows/WinEventsWin32.cpp
+++ b/xbmc/windowing/windows/WinEventsWin32.cpp
@@ -440,6 +440,14 @@ LRESULT CALLBACK CWinEventsWin32::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, L
           CLog::Log(LOGDEBUG, __FUNCTION__": Focus switched to process %s", procfile.c_str());
       }
       break;
+    case WM_SYSCOMMAND:
+      switch( wParam&0xFFF0 )
+      {
+        case SC_MONITORPOWER:
+        case SC_SCREENSAVE:
+          return 0;
+      }
+      break;
     case WM_SYSKEYDOWN:
       switch (wParam)
       {

--- a/xbmc/windowing/windows/WinSystemWin32.cpp
+++ b/xbmc/windowing/windows/WinSystemWin32.cpp
@@ -71,37 +71,6 @@ bool CWinSystemWin32::DestroyWindowSystem()
   return true;
 }
 
-bool CWinSystemWin32::IsSystemScreenSaverEnabled()
-{
-  // Check if system screen saver is enabled
-  // We are checking registry due to bug with SPI_GETSCREENSAVEACTIVE
-  HKEY hKeyScreenSaver = NULL;
-  long lReturn = NULL;
-  long lScreenSaver = NULL;
-  DWORD dwData = NULL;
-  bool result = false;
-
-  lReturn = RegOpenKeyEx(HKEY_CURRENT_USER, TEXT("Control Panel\\Desktop"),0,KEY_QUERY_VALUE,&hKeyScreenSaver);
-  if(lReturn == ERROR_SUCCESS)
-  {
-    lScreenSaver = RegQueryValueEx(hKeyScreenSaver,TEXT("SCRNSAVE.EXE"),NULL,NULL,NULL,&dwData);
-
-    // ScreenSaver is active
-    if(lScreenSaver == ERROR_SUCCESS)
-       result = true;
-  }
-  RegCloseKey(hKeyScreenSaver);
-
-  return result;
-}
-
-void CWinSystemWin32::EnableSystemScreenSaver(bool bEnable)
-{
-  SystemParametersInfo(SPI_SETSCREENSAVEACTIVE,bEnable,0,0);
-  if(!bEnable)
-    SetThreadExecutionState(ES_DISPLAY_REQUIRED|ES_CONTINUOUS);
-}
-
 bool CWinSystemWin32::CreateNewWindow(const CStdString& name, bool fullScreen, RESOLUTION_INFO& res, PHANDLE_EVENT_FUNC userFunction)
 {
   m_hInstance = ( HINSTANCE )GetModuleHandle( NULL );

--- a/xbmc/windowing/windows/WinSystemWin32.h
+++ b/xbmc/windowing/windows/WinSystemWin32.h
@@ -146,10 +146,6 @@ public:
   virtual bool Hide();
   virtual bool Show(bool raise = true);
 
-   // OS System screensaver
-  virtual void EnableSystemScreenSaver(bool bEnable);
-  virtual bool IsSystemScreenSaverEnabled();
-
   // CWinSystemWin32
   HWND GetHwnd() { return m_hWnd; }
   bool IsAlteringWindow() { return m_IsAlteringWindow; }


### PR DESCRIPTION
The screensaver should only be disabled while XBMC has focus.  This is
very important: XBMC is often used on plasma TVs, and they're still not
immune from burn-in.  I don't want to damage my TV just because I forgot
to refocus XBMC after jumping to the desktop to fix something, or
because something unexpectedly stole focus while I wasn't there.
