### PR TITLE
Fix a minor possible memory leak.

### DIFF
--- a/xbmc/addons/Repository.cpp
+++ b/xbmc/addons/Repository.cpp
@@ -92,13 +92,16 @@ CStdString CRepository::FetchChecksum(const CStdString& url)
   CSingleLock lock(m_critSection);
   CFile file;
   file.Open(url);
-  CStdString checksum;
   try
   {
-    char* temp = checksum.GetBufferSetLength((int)file.GetLength());
-    file.Read(temp,file.GetLength());
-    checksum.ReleaseBuffer();
-    return checksum;
+    // we intentionally avoid using file.GetLength() for 
+    // Transfer-Encoding: chunked servers.
+    std::stringstream str;
+    char temp[1024];
+    int read;
+    while ((read=file.Read(temp, sizeof(temp))) > 0)
+      str.write(temp, read);
+    return str.str();
   }
   catch (...)
   {

--- a/xbmc/addons/Repository.cpp
+++ b/xbmc/addons/Repository.cpp
@@ -95,16 +95,15 @@ CStdString CRepository::FetchChecksum(const CStdString& url)
   CStdString checksum;
   try
   {
-    char* temp = new char[(size_t)file.GetLength()+1];
+    char* temp = checksum.GetBufferSetLength((int)file.GetLength());
     file.Read(temp,file.GetLength());
-    temp[file.GetLength()] = 0;
-    checksum = temp;
-    delete[] temp;
+    checksum.ReleaseBuffer();
+    return checksum;
   }
   catch (...)
   {
+    return "";
   }
-  return checksum;
 }
 
 CStdString CRepository::GetAddonHash(const AddonPtr& addon)


### PR DESCRIPTION
If file.Read() throws, then temp wasn't freed.  Fix by reading directly
into checksum, to avoid direct memory management in the first place.
