### PR TITLE
fixed: build with libshairport without ao_set_metadata

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -1197,6 +1197,8 @@ if test "x$use_airtunes" != "xno"; then
   if test "x$use_airtunes" != "xno"; then
     XB_FIND_SONAME([SHAIRPORT], [shairport], [use_airtunes])
     USE_AIRTUNES=1
+    AC_CHECK_MEMBERS([struct AudioOutput.ao_set_metadata],,,
+                     [[#include <shairport/shairport.h>]])
   fi
 fi
 

--- a/xbmc/network/AirTunesServer.cpp
+++ b/xbmc/network/AirTunesServer.cpp
@@ -667,8 +667,10 @@ bool CAirTunesServer::Initialize(const CStdString &password)
     ao.ao_append_option = AudioOutputFunctions::ao_append_option;
     ao.ao_free_options = AudioOutputFunctions::ao_free_options;
     ao.ao_get_option = AudioOutputFunctions::ao_get_option;
+#ifdef HAVE_STRUCT_AUDIOOUTPUT_AO_SET_METADATA
     ao.ao_set_metadata = AudioOutputFunctions::ao_set_metadata;    
     ao.ao_set_metadata_coverart = AudioOutputFunctions::ao_set_metadata_coverart;        
+#endif
     struct printfPtr funcPtr;
     funcPtr.extprintf = shairport_log;
 


### PR DESCRIPTION
Fix build with libshairport without the
AudioOutput.ao_set_metadata and AudioOutput.ao_set_metadata_coverart
members (which were added to libshairport git two months ago).

A previous commit 537bec4 had already tried to do this, but it did not
work properly and was therefore reverted in f58b70a.
