### PR TITLE
ADD: No-Op scraper support to allow nfo based only library

### DIFF
--- a/addons/metadata.local/addon.xml
+++ b/addons/metadata.local/addon.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<addon id="metadata.local"
+       name="Local information only"
+       version="1.0.0"
+       provider-name="Team XBMC">
+  <requires>
+    <import addon="xbmc.metadata" version="1.0"/>
+  </requires>
+  <extension point="xbmc.metadata.scraper.albums"
+             language="multi"
+             library="local.xml"/>
+  <extension point="xbmc.metadata.scraper.artists"
+             language="multi"
+             library="local.xml"/>
+  <extension point="xbmc.metadata.scraper.musicvideos"
+             language="multi"
+             library="local.xml"/>
+  <extension point="xbmc.metadata.scraper.tvshows"
+             language="multi"
+             library="local.xml"/>
+  <extension point="xbmc.metadata.scraper.movies"
+             language="multi"
+             library="local.xml"/>
+  <extension point="xbmc.addon.metadata">
+    <summary lang="en">Local Infomation only pseudo-scraper</summary>
+    <description lang="en">Use local information only</description>
+    <platform>all</platform>
+  </extension>
+</addon>

--- a/addons/metadata.local/local.xml
+++ b/addons/metadata.local/local.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<scraper framework="1.1">
+</scraper>

--- a/xbmc/NfoFile.cpp
+++ b/xbmc/NfoFile.cpp
@@ -131,6 +131,11 @@ CNfoFile::NFOResult CNfoFile::Create(const CStdString& strPath, const ScraperPtr
 // return value: 0 - success; 1 - no result; skip; 2 - error
 int CNfoFile::Scrape(ScraperPtr& scraper)
 {
+  if (scraper->IsNoop())
+  {
+    m_scurl = CScraperUrl();
+    return 0;
+  }
   if (scraper->Type() != m_type)
     return 1;
   scraper->ClearCache();

--- a/xbmc/addons/Scraper.cpp
+++ b/xbmc/addons/Scraper.cpp
@@ -412,11 +412,22 @@ bool CScraper::IsInUse() const
   return false;
 }
 
+bool CScraper::IsNoop()
+{
+    if (!Load())
+      throw CScraperError();
+
+    return m_parser.IsNoop();
+}
+
 // pass in contents of .nfo file; returns URL (possibly empty if none found)
 // and may populate strId, or throws CScraperError on error
 CScraperUrl CScraper::NfoUrl(const CStdString &sNfoContent)
 {
   CScraperUrl scurlRet;
+
+  if (IsNoop())
+    return scurlRet;
 
   // scraper function takes contents of .nfo file, returns XML (see below)
   vector<CStdString> vcsIn;
@@ -490,13 +501,17 @@ std::vector<CScraperUrl> CScraper::FindMovie(XFILE::CCurlFile &fcurl, const CStd
   CStdString sTitle, sTitleYear, sYear;
   CUtil::CleanString(sMovie, sTitle, sTitleYear, sYear, true/*fRemoveExt*/, fFirst);
 
-  if (!fFirst || Content() == CONTENT_MUSICVIDEOS)
-    sTitle.Replace("-"," ");
-
   CLog::Log(LOGDEBUG, "%s: Searching for '%s' using %s scraper "
     "(path: '%s', content: '%s', version: '%s')", __FUNCTION__, sTitle.c_str(),
     Name().c_str(), Path().c_str(),
     ADDON::TranslateContent(Content()).c_str(), Version().c_str());
+
+  std::vector<CScraperUrl> vcscurl;
+  if (IsNoop())
+    return vcscurl;
+
+  if (!fFirst || Content() == CONTENT_MUSICVIDEOS)
+    sTitle.Replace("-"," ");
 
   sTitle.ToLower();
 
@@ -509,7 +524,6 @@ std::vector<CScraperUrl> CScraper::FindMovie(XFILE::CCurlFile &fcurl, const CStd
   // request a search URL from the title/filename/etc.
   CScraperUrl scurl;
   vector<CStdString> vcsOut = Run("CreateSearchUrl", scurl, fcurl, &vcsIn);
-  std::vector<CScraperUrl> vcscurl;
   if (vcsOut.empty())
   {
     CLog::Log(LOGDEBUG, "%s: CreateSearchUrl failed", __FUNCTION__);
@@ -616,6 +630,10 @@ std::vector<CMusicAlbumInfo> CScraper::FindAlbum(CCurlFile &fcurl, const CStdStr
     sAlbum.c_str(), Name().c_str(), Path().c_str(),
     ADDON::TranslateContent(Content()).c_str(), Version().c_str());
 
+  std::vector<CMusicAlbumInfo> vcali;
+  if (IsNoop())
+    return vcali;
+
   // scraper function is given the album and artist as parameters and
   // returns an XML <url> element parseable by CScraperUrl
   std::vector<CStdString> extras(2);
@@ -628,7 +646,6 @@ std::vector<CMusicAlbumInfo> CScraper::FindAlbum(CCurlFile &fcurl, const CStdStr
   if (vcsOut.size() > 1)
     CLog::Log(LOGWARNING, "%s: scraper returned multiple results; using first", __FUNCTION__);
 
-  std::vector<CMusicAlbumInfo> vcali;
   if (vcsOut.empty() || vcsOut[0].empty())
     return vcali;
   scurl.ParseString(vcsOut[0]);
@@ -710,6 +727,10 @@ std::vector<CMusicArtistInfo> CScraper::FindArtist(CCurlFile &fcurl,
     Name().c_str(), Path().c_str(),
     ADDON::TranslateContent(Content()).c_str(), Version().c_str());
 
+  std::vector<CMusicArtistInfo> vcari;
+  if (IsNoop())
+    return vcari;
+
   // scraper function is given the artist as parameter and
   // returns an XML <url> element parseable by CScraperUrl
   std::vector<CStdString> extras(1);
@@ -718,7 +739,6 @@ std::vector<CMusicArtistInfo> CScraper::FindArtist(CCurlFile &fcurl,
   CScraperUrl scurl;
   vector<CStdString> vcsOut = RunNoThrow("CreateArtistSearchUrl", scurl, fcurl, &extras);
 
-  std::vector<CMusicArtistInfo> vcari;
   if (vcsOut.empty() || vcsOut[0].empty())
     return vcari;
   scurl.ParseString(vcsOut[0]);

--- a/xbmc/addons/Scraper.h
+++ b/xbmc/addons/Scraper.h
@@ -116,6 +116,7 @@ public:
   bool Supports(const CONTENT_TYPE &content) const;
 
   bool IsInUse() const;
+  bool IsNoop();
 
   // scraper media functions
   CScraperUrl NfoUrl(const CStdString &sNfoContent);

--- a/xbmc/utils/ScraperParser.cpp
+++ b/xbmc/utils/ScraperParser.cpp
@@ -42,6 +42,7 @@ CScraperParser::CScraperParser()
   m_document = NULL;
   m_SearchStringEncoding = "UTF-8";
   m_scraper = NULL;
+  m_isNoop = true;
 }
 
 CScraperParser::CScraperParser(const CScraperParser& parser)
@@ -50,6 +51,7 @@ CScraperParser::CScraperParser(const CScraperParser& parser)
   m_document = NULL;
   m_SearchStringEncoding = "UTF-8";
   m_scraper = NULL;
+  m_isNoop = true;
   *this = parser;
 }
 
@@ -115,6 +117,7 @@ bool CScraperParser::LoadFromXML()
     TiXmlElement* pChildElement = m_pRootElement->FirstChildElement("CreateSearchUrl");
     if (pChildElement)
     {
+      m_isNoop = false;
       if (!(m_SearchStringEncoding = pChildElement->Attribute("SearchStringEncoding")))
         m_SearchStringEncoding = "UTF-8";
     }
@@ -122,12 +125,14 @@ bool CScraperParser::LoadFromXML()
     pChildElement = m_pRootElement->FirstChildElement("CreateArtistSearchUrl");
     if (pChildElement)
     {
+      m_isNoop = false;
       if (!(m_SearchStringEncoding = pChildElement->Attribute("SearchStringEncoding")))
         m_SearchStringEncoding = "UTF-8";
     }
     pChildElement = m_pRootElement->FirstChildElement("CreateAlbumSearchUrl");
     if (pChildElement)
     {
+      m_isNoop = false;
       if (!(m_SearchStringEncoding = pChildElement->Attribute("SearchStringEncoding")))
         m_SearchStringEncoding = "UTF-8";
     }

--- a/xbmc/utils/ScraperParser.h
+++ b/xbmc/utils/ScraperParser.h
@@ -45,6 +45,7 @@ public:
   ~CScraperParser();
   CScraperParser& operator= (const CScraperParser& parser);
   bool Load(const CStdString& strXMLFile);
+  bool IsNoop() { return m_isNoop; };
 
   void Clear();
   const CStdString GetFilename() { return m_strFile; }
@@ -76,6 +77,7 @@ private:
   TiXmlElement* m_pRootElement;
 
   const char* m_SearchStringEncoding;
+  bool m_isNoop;
 
   CStdString m_strFile;
   ADDON::CScraper* m_scraper;

--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -511,7 +511,7 @@ bool CGUIWindowVideoBase::ShowIMDB(CFileItem *item, const ScraperPtr &info2)
       if (needsRefresh)
       {
         bHasInfo = true;
-        if (nfoResult == CNfoFile::URL_NFO || nfoResult == CNfoFile::COMBINED_NFO || nfoResult == CNfoFile::FULL_NFO)
+        if (!info->IsNoop() && (nfoResult == CNfoFile::URL_NFO || nfoResult == CNfoFile::COMBINED_NFO || nfoResult == CNfoFile::FULL_NFO))
         {
           if (CGUIDialogYesNo::ShowAndGetInput(13346,20446,20447,20022))
           {


### PR DESCRIPTION
As discussed here: http://forum.xbmc.org/showthread.php?tid=127896&pid=1152628#pid1152628

Allows to have a nfo-based only library.
