### PR TITLE
AudioEngine Bugfix

### DIFF
--- a/xbmc/cores/AudioEngine/Engines/SoftAE/SoftAEStream.cpp
+++ b/xbmc/cores/AudioEngine/Engines/SoftAE/SoftAEStream.cpp
@@ -576,6 +576,7 @@ void CSoftAEStream::InternalFlush()
   /* reset our counts */
   m_framesBuffered = 0;
   m_refillBuffer   = m_waterLevel;
+  m_draining       = false;
 }
 
 double CSoftAEStream::GetResampleRatio()


### PR DESCRIPTION
Bug Fix: I found that if the buffer reaches 0 the FPS will drop to like 3 or 4 and stay that way even if data is added to the buffer until the video is stopped and restarted. This was caused by Audio engine being stuck in in a drain state. 
