### PR TITLE
Cachemembuffer Feature Addon

### DIFF
--- a/xbmc/cores/AudioEngine/Engines/SoftAE/SoftAEStream.cpp
+++ b/xbmc/cores/AudioEngine/Engines/SoftAE/SoftAEStream.cpp
@@ -576,7 +576,6 @@ void CSoftAEStream::InternalFlush()
   /* reset our counts */
   m_framesBuffered = 0;
   m_refillBuffer   = m_waterLevel;
-  m_draining       = false;
 }
 
 double CSoftAEStream::GetResampleRatio()

--- a/xbmc/cores/AudioEngine/Engines/SoftAE/SoftAEStream.cpp
+++ b/xbmc/cores/AudioEngine/Engines/SoftAE/SoftAEStream.cpp
@@ -576,6 +576,7 @@ void CSoftAEStream::InternalFlush()
   /* reset our counts */
   m_framesBuffered = 0;
   m_refillBuffer   = m_waterLevel;
+  m_draining       = false;
 }
 
 double CSoftAEStream::GetResampleRatio()

--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -655,7 +655,7 @@ bool CDVDPlayer::OpenDemuxStream()
   int64_t len = m_pInputStream->GetLength();
   int64_t tim = m_pDemuxer->GetStreamLength();
   if(len > 0 && tim > 0)
-    m_pInputStream->SetReadRate(len * 1000 / tim);
+    m_pInputStream->SetReadRate(len * 1000 * g_advancedSettings.m_cacheMemBufferThrottleMultiplier / tim);
 
   return true;
 }

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -298,6 +298,7 @@ void CAdvancedSettings::Initialize()
   m_logEnableAirtunes = false;
   m_airTunesPort = 36666;
   m_airPlayPort = 36667;
+  m_cacheMemBufferThrottleMultiplier = 1.0f;
   m_initialized = true;
 
   m_databaseMusic.Reset();
@@ -666,6 +667,7 @@ void CAdvancedSettings::ParseSettingsFile(const CStdString &file)
     XMLUtils::GetInt(pElement, "curlretries", m_curlretries, 0, 10);
     XMLUtils::GetBoolean(pElement,"disableipv6", m_curlDisableIPV6);
     XMLUtils::GetUInt(pElement, "cachemembuffersize", m_cacheMemBufferSize);
+    XMLUtils::GetFloat(pElement, "cachemembufferthrottlemultiplier", m_cacheMemBufferThrottleMultiplier, 1.0f, 100.0f);
   }
 
   pElement = pRootElement->FirstChildElement("jsonrpc");

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -332,6 +332,7 @@ class CAdvancedSettings
     int  m_guiDirtyRegionNoFlipTimeout;
 
     unsigned int m_cacheMemBufferSize;
+    float m_cacheMemBufferThrottleMultiplier;
 
     bool m_jsonOutputCompact;
     unsigned int m_jsonTcpPort;


### PR DESCRIPTION
Added a variable in advanced settings to allow users to increase read rate of dvdplayer as multiple of average bitrate for faster buffer filling (i.e. if user uses 3 as the multiple the buffer will be filled at 3X average bitrate until the buffer is filled and then will refill the buffer as it is being used at up to 3X average bitrate) 

Please Note: The variable "cachemembufferthrottlemultiplier" will need to be added to the advanced settings wiki. It should be placed in network section under cachemembuffer (it is a float minimum 1.0) with the following hint: "Adjusts the buffer filling throttle rate of cachemembuffer by X times average bitrate"
