### PR TITLE
There's no Content-Length in this mode, so GetLength() returns 0.

### DIFF
--- a/xbmc/addons/Repository.cpp
+++ b/xbmc/addons/Repository.cpp
@@ -92,19 +92,21 @@ CStdString CRepository::FetchChecksum(const CStdString& url)
   CSingleLock lock(m_critSection);
   CFile file;
   file.Open(url);
-  CStdString checksum;
   try
   {
-    char* temp = new char[(size_t)file.GetLength()+1];
-    file.Read(temp,file.GetLength());
-    temp[file.GetLength()] = 0;
-    checksum = temp;
-    delete[] temp;
+    // we intentionally avoid using file.GetLength() for 
+    // Transfer-Encoding: chunked servers.
+    std::stringstream str;
+    char temp[1024];
+    int read;
+    while ((read=file.Read(temp, sizeof(temp))) > 0)
+      str.write(temp, read);
+    return str.str();
   }
   catch (...)
   {
+    return "";
   }
-  return checksum;
 }
 
 CStdString CRepository::GetAddonHash(const AddonPtr& addon)


### PR DESCRIPTION
This also avoids direct memory allocation.

Supercedes https://github.com/xbmc/xbmc/pull/1185 (will close).
