### PR TITLE
AudioEngine BugFix

### DIFF
--- a/xbmc/cores/AudioEngine/Engines/SoftAE/SoftAEStream.cpp
+++ b/xbmc/cores/AudioEngine/Engines/SoftAE/SoftAEStream.cpp
@@ -576,6 +576,7 @@ void CSoftAEStream::InternalFlush()
   /* reset our counts */
   m_framesBuffered = 0;
   m_refillBuffer   = m_waterLevel;
+  m_draining       = false;
 }
 
 double CSoftAEStream::GetResampleRatio()


### PR DESCRIPTION
Bugfix:  AudioEngine would get stuck in Drain state if memcachebuffer reached 0.  It would cause the video to be stuck at 4-6 FPS and would not fix itself (even if buffer started getting filled) until video was stopped and restarted.

Already approved by  Memphiz on Closed (by me) Request #1196.

This is a commit cleanup request with the same changes as the last one was getting quite ugly...
