### PR TITLE
CacheMemBuffer Feature Addition

### DIFF
--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -655,7 +655,7 @@ bool CDVDPlayer::OpenDemuxStream()
   int64_t len = m_pInputStream->GetLength();
   int64_t tim = m_pDemuxer->GetStreamLength();
   if(len > 0 && tim > 0)
-    m_pInputStream->SetReadRate(len * 1000 / tim);
+    m_pInputStream->SetReadRate(len * 1000 * g_advancedSettings.m_cacheMemBufferThrottleMultiplier / tim);
 
   return true;
 }

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -285,6 +285,7 @@ void CAdvancedSettings::Initialize()
   m_measureRefreshrate = false;
 
   m_cacheMemBufferSize = 1024 * 1024 * 20;
+  m_cacheMemBufferThrottleMultiplier = 1.0f;
 
   m_jsonOutputCompact = true;
   m_jsonTcpPort = 9090;
@@ -666,6 +667,7 @@ void CAdvancedSettings::ParseSettingsFile(const CStdString &file)
     XMLUtils::GetInt(pElement, "curlretries", m_curlretries, 0, 10);
     XMLUtils::GetBoolean(pElement,"disableipv6", m_curlDisableIPV6);
     XMLUtils::GetUInt(pElement, "cachemembuffersize", m_cacheMemBufferSize);
+    XMLUtils::GetFloat(pElement, "cachemembufferthrottlemultiplier", m_cacheMemBufferThrottleMultiplier, 1.0f, 5.0f);
   }
 
   pElement = pRootElement->FirstChildElement("jsonrpc");

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -332,6 +332,7 @@ class CAdvancedSettings
     int  m_guiDirtyRegionNoFlipTimeout;
 
     unsigned int m_cacheMemBufferSize;
+    float m_cacheMemBufferThrottleMultiplier;
 
     bool m_jsonOutputCompact;
     unsigned int m_jsonTcpPort;


### PR DESCRIPTION
Added an advanced settings variable "cachemembufferthrottlemultiplier" which allows the user to fill the cachemembuffer at a multiplier of the average bitrate of the video. This will lead to faster buffer fills (i.e. if user uses 3 as the multiple the buffer will be filled at 3X average bitrate until the buffer is filled and then will refill the buffer as it is being used at up to 3X average bitrate)

NOTE: The variable "cachemembufferthrottlemultiplier" will need to be added to the advanced setting wiki.  It should be placed in network section and is a float with a minimum of 1.0.  The hint should be "Adjusts the buffer filling throttle of cachemembuffer by X times average bitrate"
