### PR TITLE
Music Scanner Bugfix

### DIFF
--- a/xbmc/music/infoscanner/MusicInfoScanner.cpp
+++ b/xbmc/music/infoscanner/MusicInfoScanner.cpp
@@ -739,6 +739,10 @@ void CMusicInfoScanner::FindArtForAlbums(VECALBUMS &albums, const CStdString &pa
   for (VECALBUMS::iterator i = albums.begin(); i != albums.end(); ++i)
   {
     CAlbum &album = *i;
+
+    if (albums.size() != 1)
+      albumArt = "";
+
     /*
      Find art that is common across these items
      If we find a single art image we treat it as the album art
@@ -772,7 +776,7 @@ void CMusicInfoScanner::FindArtForAlbums(VECALBUMS &albums, const CStdString &pa
       }
       for (VECSONGS::iterator k = album.songs.begin(); k != album.songs.end(); ++k)
         k->strThumb.clear();
-      albums[0].art["thumb"] = albumArt;
+      album.art["thumb"] = albumArt;
     }
     else
     { // more than one piece of art was found for these songs, so cache per song


### PR DESCRIPTION
1. Bugfix: Music scanner did not correctly load the image artwork for directories with more than 1 album (i.e. "Singles" directories).  Now it does.
