### PR TITLE
Add Skin.AspectRatio infolabel

### DIFF
--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -55,6 +55,7 @@
 #include "utils/MathUtils.h"
 #include "utils/SeekHandler.h"
 #include "URL.h"
+#include "addons/Skin.h"
 
 // stuff for current song
 #include "music/MusicInfoLoader.h"
@@ -505,7 +506,8 @@ const infomap fanart_labels[] =  {{ "color1",           FANART_COLOR1 },
 const infomap skin_labels[] =    {{ "currenttheme",     SKIN_THEME },
                                   { "currentcolourtheme",SKIN_COLOUR_THEME },
                                   {"hasvideooverlay",   SKIN_HAS_VIDEO_OVERLAY},
-                                  {"hasmusicoverlay",   SKIN_HAS_MUSIC_OVERLAY}};
+                                  {"hasmusicoverlay",   SKIN_HAS_MUSIC_OVERLAY},
+                                  {"aspectratio",       SKIN_ASPECT_RATIO}};
 
 const infomap window_bools[] =   {{ "ismedia",          WINDOW_IS_MEDIA },
                                   { "isactive",         WINDOW_IS_ACTIVE },
@@ -1556,6 +1558,10 @@ CStdString CGUIInfoManager::GetLabel(int info, int contextWindow, CStdString *fa
     break;
   case SKIN_COLOUR_THEME:
     strLabel = g_guiSettings.GetString("lookandfeel.skincolors");
+    break;
+  case SKIN_ASPECT_RATIO:
+    if (g_SkinInfo)
+      strLabel = g_SkinInfo->GetCurrentAspect();
     break;
 #ifdef HAS_LCD
   case LCD_PROGRESS_BAR:

--- a/xbmc/GUIInfoManager.h
+++ b/xbmc/GUIInfoManager.h
@@ -340,6 +340,7 @@ namespace INFO
 #define SKIN_THEME                  604
 #define SKIN_COLOUR_THEME           605
 #define SKIN_HAS_THEME              606
+#define SKIN_ASPECT_RATIO           607
 
 #define SYSTEM_TOTAL_MEMORY         644
 #define SYSTEM_CPU_USAGE            645

--- a/xbmc/addons/Skin.cpp
+++ b/xbmc/addons/Skin.cpp
@@ -62,12 +62,14 @@ CSkinInfo::CSkinInfo(const cp_extension_t *ext)
       CStdString folder = CAddonMgr::Get().GetExtValue(*i, "@folder");
       float aspect = 0;
       CStdStringArray fracs;
-      StringUtils::SplitString(CAddonMgr::Get().GetExtValue(*i, "@aspect"), ":", fracs);
+      CStdString strAspect = CAddonMgr::Get().GetExtValue(*i, "@aspect");
+      StringUtils::SplitString(strAspect, ":", fracs);
       if (fracs.size() == 2)
         aspect = (float)(atof(fracs[0].c_str())/atof(fracs[1].c_str()));
       if (width > 0 && height > 0)
       {
         RESOLUTION_INFO res(width, height, aspect, folder);
+        res.strId = strAspect; // for skin usage, store aspect string in strId
         if (defRes)
           m_defaultRes = res;
         m_resolutions.push_back(res);
@@ -128,6 +130,14 @@ void CSkinInfo::Start()
       if (items[i]->m_bIsFolder && TranslateResolution(items[i]->GetLabel(), res))
         m_resolutions.push_back(res);
     }
+  }
+
+  if (!m_resolutions.empty())
+  {
+    // find the closest resolution
+    const RESOLUTION_INFO &target = g_graphicsContext.GetResInfo();
+    RESOLUTION_INFO& res = *std::min_element(m_resolutions.begin(), m_resolutions.end(), closestRes(target));
+    m_currentAspect = res.strId;
   }
 }
 

--- a/xbmc/addons/Skin.cpp
+++ b/xbmc/addons/Skin.cpp
@@ -100,21 +100,6 @@ CSkinInfo::~CSkinInfo()
 {
 }
 
-void CSkinInfo::Start()
-{
-  if (!m_resolutions.size())
-  { // try falling back to whatever resolutions exist in the directory
-    CFileItemList items;
-    CDirectory::GetDirectory(Path(), items, "", DIR_FLAG_NO_FILE_DIRS);
-    for (int i = 0; i < items.Size(); i++)
-    {
-      RESOLUTION_INFO res;
-      if (items[i]->m_bIsFolder && TranslateResolution(items[i]->GetLabel(), res))
-        m_resolutions.push_back(res);
-    }
-  }
-}
-
 struct closestRes
 {
   closestRes(const RESOLUTION_INFO &target) : m_target(target) { };
@@ -130,6 +115,21 @@ struct closestRes
   }
   RESOLUTION_INFO m_target;
 };
+
+void CSkinInfo::Start()
+{
+  if (!m_resolutions.size())
+  { // try falling back to whatever resolutions exist in the directory
+    CFileItemList items;
+    CDirectory::GetDirectory(Path(), items, "", DIR_FLAG_NO_FILE_DIRS);
+    for (int i = 0; i < items.Size(); i++)
+    {
+      RESOLUTION_INFO res;
+      if (items[i]->m_bIsFolder && TranslateResolution(items[i]->GetLabel(), res))
+        m_resolutions.push_back(res);
+    }
+  }
+}
 
 CStdString CSkinInfo::GetSkinPath(const CStdString& strFile, RESOLUTION_INFO *res, const CStdString& strBaseDir /* = "" */) const
 {

--- a/xbmc/addons/Skin.h
+++ b/xbmc/addons/Skin.h
@@ -105,6 +105,8 @@ public:
 
   bool IsInUse() const;
 
+  const CStdString& GetCurrentAspect() const { return m_currentAspect; }
+
 //  static bool Check(const CStdString& strSkinDir); // checks if everything is present and accounted for without loading the skin
   static double GetMinVersion();
   void LoadIncludes();
@@ -133,6 +135,7 @@ protected:
 
   float m_effectsSlowDown;
   CGUIIncludes m_includes;
+  CStdString m_currentAspect;
 
   std::vector<CStartupWindow> m_startupWindows;
   bool m_onlyAnimateToHome;


### PR DESCRIPTION
This is RFC PR, so before commenting code, please comment on approach.

I had some thoughts about what info is relevant:
- Skin.AspectRatio (always returning info from closest resolutution match from resolutions defined in addon.xml, no matter if proper <windowname>.xml file exist for this resolution)
- Window.AspectRatio (return info from resolution that is actually used for current window)

Few cases we have to consider about resolutions in addon.xml
1. They point to same folder then both Skin.AspectRatio and Window.AspectRatio would return same info
2. They point to different folders:
   - Window.AspectRatio wouldn't actually be needed, because we might just "hard code" stuff differently in each folder
   - Skin.AspectRatio might return "16:9" even if we are in "4:3" folder and this just _might_ actually have some value
   ---

I'm aware that this is little ugly (Skin.AspectRatio vs Window.AspectRatio). Perhaps we could allow to set closest resolution on window even if we are loading file from default resolution (f.e. forceresolution="true" attribute on non-default resolutions)? Then Window.AspectRatio would be indeed valuable info and we could seperate different aspect xml snippets in seperate folders without entire xml duplication and avoid stretching like it was described in Jezz_X comment in https://github.com/pieh/xbmc/commit/f019f8c2241625e788756cda2e623ed44b073361#commitcomment-1614658.
