### PR TITLE
make skin controls positioning more flexible

### DIFF
--- a/xbmc/guilib/GUIControlFactory.cpp
+++ b/xbmc/guilib/GUIControlFactory.cpp
@@ -174,6 +174,20 @@ bool CGUIControlFactory::GetFloatRange(const TiXmlNode* pRootNode, const char* s
   return true;
 }
 
+bool CGUIControlFactory::GetPosition(const TiXmlElement *pControlNode, const char* strTag, float& value, float parentSize)
+{
+  const TiXmlElement* pNode = pControlNode->FirstChildElement(strTag);
+  if (!pNode || !pNode->FirstChild()) return false;
+
+  const char* pos = pNode->FirstChild()->Value();
+  char* end;
+  value = (float)strtod(pos, &end);
+  if (end && *end == 'r')
+    value = parentSize - value;
+
+  return true;
+}
+
 bool CGUIControlFactory::GetDimension(const TiXmlNode *pRootNode, const char* strTag, float &value, float &min)
 {
   const TiXmlElement* pNode = pRootNode->FirstChildElement(strTag);
@@ -691,17 +705,8 @@ CGUIControl* CGUIControlFactory::Create(int parentID, const CRect &rect, TiXmlEl
   // TODO: Perhaps we should check here whether id is valid for focusable controls
   // such as buttons etc.  For labels/fadelabels/images it does not matter
 
-  XMLUtils::GetFloat(pControlNode, "posx", posX);
-  XMLUtils::GetFloat(pControlNode, "posy", posY);
-  // Convert these from relative coords
-  CStdString pos;
-  XMLUtils::GetString(pControlNode, "posx", pos);
-  if (pos.Right(1) == "r")
-    posX = rect.Width() - posX;
-  XMLUtils::GetString(pControlNode, "posy", pos);
-  if (pos.Right(1) == "r")
-    posY = rect.Height() - posY;
-
+  GetPosition(pControlNode, "posx", posX, rect.Width());
+  GetPosition(pControlNode, "posy", posY, rect.Height());
   GetDimension(pControlNode, "width", width, minWidth);
   GetDimension(pControlNode, "height", height, minHeight);
   XMLUtils::GetFloat(pControlNode, "offsetx", offset.x);

--- a/xbmc/guilib/GUIControlFactory.cpp
+++ b/xbmc/guilib/GUIControlFactory.cpp
@@ -705,10 +705,57 @@ CGUIControl* CGUIControlFactory::Create(int parentID, const CRect &rect, TiXmlEl
   // TODO: Perhaps we should check here whether id is valid for focusable controls
   // such as buttons etc.  For labels/fadelabels/images it does not matter
 
-  GetPosition(pControlNode, "posx", posX, rect.Width());
-  GetPosition(pControlNode, "posy", posY, rect.Height());
-  GetDimension(pControlNode, "width", width, minWidth);
-  GetDimension(pControlNode, "height", height, minHeight);
+  {
+    // determine position and size of control
+    // horizontal
+    bool hasLeft = false;
+    bool hasWidth = false;
+
+    if (GetPosition(pControlNode, "left", posX, rect.Width()) ||
+        GetPosition(pControlNode, "posx", posX, rect.Width()))
+      hasLeft = true;
+
+    if (GetDimension(pControlNode, "width", width, minWidth))
+      hasWidth = true;
+
+    if (hasLeft != hasWidth) // poor man xor, we have to have at least 1 to continue
+    {
+      // if we have just one of <posx>, <width> we search for <right>
+      float right;
+      if (GetPosition(pControlNode, "right", right, rect.Width()))
+      {
+        if (hasLeft)
+          width = (rect.Width() - right) - posX;
+        else // if (hasWidth)
+          posX = (rect.Width() - right) - width;
+      }
+    }
+
+    // vertical
+    bool hasTop = false;
+    bool hasHeight = false;
+
+    if (GetPosition(pControlNode, "top", posY, rect.Height()) ||
+        GetPosition(pControlNode, "posy", posY, rect.Height()))
+      hasTop = true;
+
+    if (GetDimension(pControlNode, "height", height, minHeight))
+      hasHeight = true;
+
+    if (hasTop != hasHeight) // poor man xor, we have to have at least 1 to continue
+    {
+      // if we have just one of <posy>, <height> we search for <bottom>
+      float bottom;
+      if (GetPosition(pControlNode, "bottom", bottom, rect.Height()))
+      {
+        if (hasTop)
+          height = (rect.Height() - bottom) - posY;
+        else // if (hasHeight)
+          posY = (rect.Height() - bottom) - height;
+      }
+    }
+  }
+
   XMLUtils::GetFloat(pControlNode, "offsetx", offset.x);
   XMLUtils::GetFloat(pControlNode, "offsety", offset.y);
 

--- a/xbmc/guilib/GUIControlFactory.cpp
+++ b/xbmc/guilib/GUIControlFactory.cpp
@@ -174,17 +174,21 @@ bool CGUIControlFactory::GetFloatRange(const TiXmlNode* pRootNode, const char* s
   return true;
 }
 
+float CGUIControlFactory::ParsePosition(const char* pos, float parentSize)
+{
+  char* end;
+  float value = (float)strtod(pos, &end);
+  if (end && *end == 'r')
+    value = parentSize - value;
+  return value;
+}
+
 bool CGUIControlFactory::GetPosition(const TiXmlElement *pControlNode, const char* strTag, float& value, float parentSize)
 {
   const TiXmlElement* pNode = pControlNode->FirstChildElement(strTag);
   if (!pNode || !pNode->FirstChild()) return false;
 
-  const char* pos = pNode->FirstChild()->Value();
-  char* end;
-  value = (float)strtod(pos, &end);
-  if (end && *end == 'r')
-    value = parentSize - value;
-
+  value = ParsePosition(pNode->FirstChild()->Value(), parentSize);
   return true;
 }
 

--- a/xbmc/guilib/GUIControlFactory.h
+++ b/xbmc/guilib/GUIControlFactory.h
@@ -72,7 +72,7 @@ public:
    \param min minimum value - set != 0 if auto is used.
    \return true if we found and read the tag.
    */
-  static bool GetDimension(const TiXmlNode* pRootNode, const char* strTag, float &value, float &min);
+  static bool GetDimension(const TiXmlNode* pRootNode, const char* strTag, float &value, float &min, float parentSize);
   static bool GetAspectRatio(const TiXmlNode* pRootNode, const char* strTag, CAspectRatio &aspectRatio);
   static bool GetInfoTexture(const TiXmlNode* pRootNode, const char* strTag, CTextureInfo &image, CGUIInfoLabel &info, int parentID);
   static bool GetTexture(const TiXmlNode* pRootNode, const char* strTag, CTextureInfo &image);

--- a/xbmc/guilib/GUIControlFactory.h
+++ b/xbmc/guilib/GUIControlFactory.h
@@ -102,6 +102,7 @@ public:
   static bool GetHitRect(const TiXmlNode* pRootNode, CRect &rect);
   static bool GetScroller(const TiXmlNode *pControlNode, const CStdString &scrollerTag, CScroller& scroller);
 private:
+  static float ParsePosition(const char* pos, float parentSize);
   static bool GetPosition(const TiXmlElement *pControlNode, const char* strTag, float& value, float parentSize);
   static CStdString GetType(const TiXmlElement *pControlNode);
   static bool GetConditionalVisibility(const TiXmlNode* control, CStdString &condition, CStdString &allowHiddenFocus);

--- a/xbmc/guilib/GUIControlFactory.h
+++ b/xbmc/guilib/GUIControlFactory.h
@@ -102,6 +102,7 @@ public:
   static bool GetHitRect(const TiXmlNode* pRootNode, CRect &rect);
   static bool GetScroller(const TiXmlNode *pControlNode, const CStdString &scrollerTag, CScroller& scroller);
 private:
+  static bool GetPosition(const TiXmlElement *pControlNode, const char* strTag, float& value, float parentSize);
   static CStdString GetType(const TiXmlElement *pControlNode);
   static bool GetConditionalVisibility(const TiXmlNode* control, CStdString &condition, CStdString &allowHiddenFocus);
   bool GetString(const TiXmlNode* pRootNode, const char* strTag, CStdString& strString);


### PR DESCRIPTION
This patches allow more flexible controls placement and sizing. Currently xbmc only allow using &lt;posx&gt;,&lt;posy&gt; to define top left corner of control (relative to its parent control) and &lt;width&gt;,&lt;height&gt; for its size.

This adds &lt;right&gt; and &lt;bottom&gt; tags (and &lt;left&gt;,&lt;top&gt; aliases to &lt;posx&gt;,&lt;posy&gt; for consistency with new tags). &lt;right&gt; and &lt;bottom&gt; tags specify how far right/bottom edge of the control should placed from right/bottom edge of parent. It allows to use combination of 2 from:
- &lt;left/posx&gt;, &lt;width&gt;, &lt;right&gt; (for horizontal placement and sizing)
- &lt;top/posy&gt;, &lt;height&gt;, &lt;bottom&gt; (for vertical placement and sizing)
  It also allow using percentage values instead of absolute values (concrete value will be calculated based on parent width or height).

Here are some examples what can be done with this (using just horizontal tags, I hope they are self-explanatory)

<pre>
&lt;control&gt;
  &lt;left&gt;10%&lt;/left&gt;
  &lt;width&gt;50%&lt;/width&gt;
&lt;/control&gt;

&lt;control&gt;
  &lt;left&gt;30&lt;/left&gt;
  &lt;right&gt;30&lt;/right&gt;
&lt;/control&gt;

&lt;control&gt;
  &lt;right&gt;20&lt;/right&gt;
  &lt;width&gt;50%&lt;/right&gt;
&lt;/control&gt;
</pre>

Current usage of 'r' suffix for relative positioning is working (in fact with this it would be possible to use it in other tags than posx/posy), but I'd like to mark it as deprecated if this would be pulled.
