### PR TITLE
Allow users to use curl based buffer for SMB sources through advanced se...

### DIFF
--- a/xbmc/filesystem/File.cpp
+++ b/xbmc/filesystem/File.cpp
@@ -27,6 +27,7 @@
 #include "utils/log.h"
 #include "utils/URIUtils.h"
 #include "utils/BitstreamStats.h"
+#include "settings/AdvancedSettings.h"
 #include "Util.h"
 
 #include "commons/Exception.h"
@@ -224,7 +225,7 @@ bool CFile::Open(const CStdString& strFileName, unsigned int flags)
     }
 
     CURL url(URIUtils::SubstitutePath(strFileName));
-    if ( (flags & READ_NO_CACHE) == 0 && URIUtils::IsInternetStream(url, true) && !CUtil::IsPicture(strFileName) )
+    if ( (flags & READ_NO_CACHE) == 0 && (URIUtils::IsInternetStream(url, true) || (URIUtils::IsSmb(strFileName) && g_advancedSettings.m_smbForceBuffer)) && !CUtil::IsPicture(strFileName) )
       m_flags |= READ_CACHED;
 
     if (m_flags & READ_CACHED)

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -284,6 +284,7 @@ void CAdvancedSettings::Initialize()
 
   m_measureRefreshrate = false;
 
+  m_smbForceBuffer = false;
   m_cacheMemBufferSize = 1024 * 1024 * 20;
 
   m_jsonOutputCompact = true;
@@ -660,6 +661,7 @@ void CAdvancedSettings::ParseSettingsFile(const CStdString &file)
   pElement = pRootElement->FirstChildElement("network");
   if (pElement)
   {
+    XMLUtils::GetBoolean(pElement, "smbforcebuffer", m_smbForceBuffer);
     XMLUtils::GetInt(pElement, "autodetectpingtime", m_autoDetectPingTime, 1, 240);
     XMLUtils::GetInt(pElement, "curlclienttimeout", m_curlconnecttimeout, 1, 1000);
     XMLUtils::GetInt(pElement, "curllowspeedtime", m_curllowspeedtime, 1, 1000);

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -331,6 +331,7 @@ class CAdvancedSettings
     int  m_guiAlgorithmDirtyRegions;
     int  m_guiDirtyRegionNoFlipTimeout;
 
+    bool m_smbForceBuffer;
     unsigned int m_cacheMemBufferSize;
 
     bool m_jsonOutputCompact;


### PR DESCRIPTION
...ttings. Default setting is false. Advanced settings item is "smbforcebuffer" and is located under "network" section.

Granted this will real only help people with less then optimal wireless connections which is why the default is false.
