### PR TITLE
forceClose enableSound bit-wise probably wrong.

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -1197,6 +1197,8 @@ if test "x$use_airtunes" != "xno"; then
   if test "x$use_airtunes" != "xno"; then
     XB_FIND_SONAME([SHAIRPORT], [shairport], [use_airtunes])
     USE_AIRTUNES=1
+    AC_CHECK_MEMBERS([struct AudioOutput.ao_set_metadata],,,
+                     [[#include <shairport/shairport.h>]])
   fi
 fi
 

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -457,7 +457,7 @@ bool CApplication::OnEvent(XBMC_Event& newEvent)
   {
     case XBMC_QUIT:
       if (!g_application.m_bStop)
-        g_application.getApplicationMessenger().Quit();
+        CApplicationMessenger::Get().Quit();
       break;
     case XBMC_KEYDOWN:
       g_application.OnKey(g_Keyboard.ProcessKeyDown(newEvent.key.keysym));
@@ -501,7 +501,7 @@ bool CApplication::OnEvent(XBMC_Event& newEvent)
       }
       break;
     case XBMC_USEREVENT:
-      g_application.getApplicationMessenger().UserEvent(newEvent.user.code);
+      CApplicationMessenger::Get().UserEvent(newEvent.user.code);
       break;
     case XBMC_APPCOMMAND:
       return g_application.OnAppCommand(newEvent.appcommand.action);
@@ -1400,7 +1400,7 @@ bool CApplication::StartWebServer()
     }
 #ifdef HAS_HTTPAPI
     if (g_settings.m_HttpApiBroadcastLevel >= 1)
-      getApplicationMessenger().HttpApi("broadcastlevel; StartUp;1");
+      CApplicationMessenger::Get().HttpApi("broadcastlevel; StartUp;1");
 #endif
 
     return started;
@@ -2428,7 +2428,7 @@ bool CApplication::OnAction(const CAction &action)
   {
     CStdString tmp;
     tmp.Format("%i",action.GetID());
-    getApplicationMessenger().HttpApi("broadcastlevel; OnAction:"+tmp+";2");
+    CApplicationMessenger::Get().HttpApi("broadcastlevel; OnAction:"+tmp+";2");
   }
 #endif
 
@@ -3011,7 +3011,7 @@ void  CApplication::CheckForTitleChange()
         CStdString msg=m_pXbmcHttp->GetOpenTag()+"MovieTitle:"+tagVal->m_strTitle+m_pXbmcHttp->GetCloseTag();
         if (m_prevMedia!=msg && g_settings.m_HttpApiBroadcastLevel>=1)
         {
-          getApplicationMessenger().HttpApi("broadcastlevel; MediaChanged:"+msg+";1");
+          CApplicationMessenger::Get().HttpApi("broadcastlevel; MediaChanged:"+msg+";1");
           m_prevMedia=msg;
         }
       }
@@ -3028,7 +3028,7 @@ void  CApplication::CheckForTitleChange()
           msg+=m_pXbmcHttp->GetOpenTag()+"AudioArtist:"+StringUtils::Join(tagVal->GetArtist(), g_advancedSettings.m_musicItemSeparator)+m_pXbmcHttp->GetCloseTag();
         if (m_prevMedia!=msg)
         {
-          getApplicationMessenger().HttpApi("broadcastlevel; MediaChanged:"+msg+";1");
+          CApplicationMessenger::Get().HttpApi("broadcastlevel; MediaChanged:"+msg+";1");
           m_prevMedia=msg;
         }
       }
@@ -3402,7 +3402,7 @@ void CApplication::Stop(int exitCode)
     if (m_pXbmcHttp)
     {
       if (g_settings.m_HttpApiBroadcastLevel >= 1)
-        getApplicationMessenger().HttpApi("broadcastlevel; ShutDown;1");
+        CApplicationMessenger::Get().HttpApi("broadcastlevel; ShutDown;1");
 
       m_pXbmcHttp->shuttingDown = true;
     }
@@ -3436,7 +3436,7 @@ void CApplication::Stop(int exitCode)
     if (m_videoInfoScanner->IsScanning())
       m_videoInfoScanner->Stop();
 
-    m_applicationMessenger.Cleanup();
+    CApplicationMessenger::Get().Cleanup();
 
     StopServices();
     //Sleep(5000);
@@ -4065,7 +4065,7 @@ void CApplication::OnPlayBackEnded()
 #ifdef HAS_HTTPAPI
   // Let's tell the outside world as well
   if (g_settings.m_HttpApiBroadcastLevel>=1)
-    getApplicationMessenger().HttpApi("broadcastlevel; OnPlayBackEnded;1");
+    CApplicationMessenger::Get().HttpApi("broadcastlevel; OnPlayBackEnded;1");
 #endif
 
   CVariant data(CVariant::VariantTypeObject);
@@ -4099,7 +4099,7 @@ void CApplication::OnPlayBackStarted()
 #ifdef HAS_HTTPAPI
   // Let's tell the outside world as well
   if (g_settings.m_HttpApiBroadcastLevel>=1)
-    getApplicationMessenger().HttpApi("broadcastlevel; OnPlayBackStarted;1");
+    CApplicationMessenger::Get().HttpApi("broadcastlevel; OnPlayBackStarted;1");
 #endif
 
   CGUIMessage msg(GUI_MSG_PLAYBACK_STARTED, 0, 0);
@@ -4117,7 +4117,7 @@ void CApplication::OnQueueNextItem()
 #ifdef HAS_HTTPAPI
   // Let's tell the outside world as well
   if (g_settings.m_HttpApiBroadcastLevel>=1)
-    getApplicationMessenger().HttpApi("broadcastlevel; OnQueueNextItem;1");
+    CApplicationMessenger::Get().HttpApi("broadcastlevel; OnQueueNextItem;1");
 #endif
 
   if(IsPlayingAudio())
@@ -4147,7 +4147,7 @@ void CApplication::OnPlayBackStopped()
 #ifdef HAS_HTTPAPI
   // Let's tell the outside world as well
   if (g_settings.m_HttpApiBroadcastLevel>=1)
-    getApplicationMessenger().HttpApi("broadcastlevel; OnPlayBackStopped;1");
+    CApplicationMessenger::Get().HttpApi("broadcastlevel; OnPlayBackStopped;1");
 #endif
 
   CVariant data(CVariant::VariantTypeObject);
@@ -4170,7 +4170,7 @@ void CApplication::OnPlayBackPaused()
 #ifdef HAS_HTTPAPI
   // Let's tell the outside world as well
   if (g_settings.m_HttpApiBroadcastLevel>=1)
-    getApplicationMessenger().HttpApi("broadcastlevel; OnPlayBackPaused;1");
+    CApplicationMessenger::Get().HttpApi("broadcastlevel; OnPlayBackPaused;1");
 #endif
 
   CVariant param;
@@ -4188,7 +4188,7 @@ void CApplication::OnPlayBackResumed()
 #ifdef HAS_HTTPAPI
   // Let's tell the outside world as well
   if (g_settings.m_HttpApiBroadcastLevel>=1)
-    getApplicationMessenger().HttpApi("broadcastlevel; OnPlayBackResumed;1");
+    CApplicationMessenger::Get().HttpApi("broadcastlevel; OnPlayBackResumed;1");
 #endif
 
   CVariant param;
@@ -4209,7 +4209,7 @@ void CApplication::OnPlayBackSpeedChanged(int iSpeed)
   {
     CStdString tmp;
     tmp.Format("broadcastlevel; OnPlayBackSpeedChanged:%i;1",iSpeed);
-    getApplicationMessenger().HttpApi(tmp);
+    CApplicationMessenger::Get().HttpApi(tmp);
   }
 #endif
 
@@ -4231,7 +4231,7 @@ void CApplication::OnPlayBackSeek(int iTime, int seekOffset)
   {
     CStdString tmp;
     tmp.Format("broadcastlevel; OnPlayBackSeek:%i;1",iTime);
-    getApplicationMessenger().HttpApi(tmp);
+    CApplicationMessenger::Get().HttpApi(tmp);
   }
 #endif
 
@@ -4256,7 +4256,7 @@ void CApplication::OnPlayBackSeekChapter(int iChapter)
   {
     CStdString tmp;
     tmp.Format("broadcastlevel; OnPlayBackSkeekChapter:%i;1",iChapter);
-    getApplicationMessenger().HttpApi(tmp);
+    CApplicationMessenger::Get().HttpApi(tmp);
   }
 #endif
 }
@@ -4546,7 +4546,7 @@ bool CApplication::WakeUpScreenSaver(bool bPowerOffKeyPressed /* = false */)
       if (g_windowManager.GetActiveWindow() == WINDOW_SCREENSAVER)
         g_windowManager.PreviousWindow();  // show the previous window
       if (g_windowManager.GetActiveWindow() == WINDOW_SLIDESHOW)
-        g_application.getApplicationMessenger().SendAction(CAction(ACTION_STOP), WINDOW_SLIDESHOW);
+        CApplicationMessenger::Get().SendAction(CAction(ACTION_STOP), WINDOW_SLIDESHOW);
     }
     return true;
   }
@@ -4659,7 +4659,7 @@ void CApplication::ActivateScreenSaver(bool forceType /*= false */)
       path = "special://profile/Thumbnails/Video/Fanart";
     if (type == "1")
       path = "special://profile/Thumbnails/Music/Fanart";
-    m_applicationMessenger.PictureSlideShow(path, true, type != "2");
+    CApplicationMessenger::Get().PictureSlideShow(path, true, type != "2");
   }
   else if (m_screenSaver->ID() == "screensaver.xbmc.builtin.dim")
     return;
@@ -4697,7 +4697,7 @@ void CApplication::CheckShutdown()
     m_shutdownTimer.Stop();
 
     // Sleep the box
-    getApplicationMessenger().Shutdown();
+    CApplicationMessenger::Get().Shutdown();
   }
 }
 
@@ -4888,7 +4888,8 @@ bool CApplication::OnMessage(CGUIMessage& message)
         g_windowManager.PreviousWindow();
       }
 
-      if (IsEnableTestMode()) g_application.getApplicationMessenger().Quit();
+      if (IsEnableTestMode())
+        CApplicationMessenger::Get().Quit();
       return true;
     }
     break;
@@ -4960,7 +4961,7 @@ void CApplication::Process()
 
   // process messages which have to be send to the gui
   // (this can only be done after g_windowManager.Render())
-  m_applicationMessenger.ProcessWindowMessages();
+  CApplicationMessenger::Get().ProcessWindowMessages();
 
 #ifdef HAS_PYTHON
   // process any Python scripts
@@ -4968,7 +4969,7 @@ void CApplication::Process()
 #endif
 
   // process messages, even if a movie is playing
-  m_applicationMessenger.ProcessMessages();
+  CApplicationMessenger::Get().ProcessMessages();
   if (g_application.m_bStop) return; //we're done, everything has been unloaded
 
   // check how far we are through playing the current item
@@ -5422,7 +5423,7 @@ void CApplication::SeekTime( double dTime )
             item.m_lStartOffset = (long)((dTime - startOfNewFile) * 75.0);
             // don't just call "PlayFile" here, as we are quite likely called from the
             // player thread, so we won't be able to delete ourselves.
-            m_applicationMessenger.PlayFile(item, true);
+            CApplicationMessenger::Get().PlayFile(item, true);
           }
           return;
         }
@@ -5759,11 +5760,6 @@ bool CApplication::AlwaysProcess(const CAction& action)
   }
 
   return false;
-}
-
-CApplicationMessenger& CApplication::getApplicationMessenger()
-{
-   return m_applicationMessenger;
 }
 
 bool CApplication::IsCurrentThread() const

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -25,7 +25,6 @@
 #include "interfaces/Builtins.h"
 #include "utils/Variant.h"
 #include "utils/Splash.h"
-#include "input/KeyboardLayoutConfiguration.h"
 #include "LangInfo.h"
 #include "Util.h"
 #include "guilib/TextureManager.h"
@@ -142,9 +141,7 @@
 #include "music/karaoke/GUIDialogKaraokeSongSelector.h"
 #include "music/karaoke/GUIWindowKaraokeLyrics.h"
 #endif
-#include "guilib/GUIFontTTF.h"
 #include "network/Network.h"
-#include "storage/IoSupport.h"
 #include "network/Zeroconf.h"
 #include "network/ZeroconfBrowser.h"
 #ifndef _LINUX

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -1024,7 +1024,7 @@ bool CApplication::InitDirectoriesOSX()
   fontconfigPath = xbmcPath + "/system/players/dvdplayer/etc/fonts/fonts.conf";
   setenv("FONTCONFIG_FILE", fontconfigPath.c_str(), 0);
 #endif
-  
+
   // setup path to our internal dylibs so loader can find them
   CStdString frameworksPath = CUtil::GetFrameworksPath();
   CSpecialProtocol::SetXBMCFrameworksPath(frameworksPath);
@@ -1206,7 +1206,7 @@ bool CApplication::Initialize()
     g_windowManager.Add(new CGUIWindowLoginScreen);            // window id = 29
     g_windowManager.Add(new CGUIWindowSettingsProfile);          // window id = 34
     g_windowManager.Add(new CGUIWindowAddonBrowser);          // window id = 40
-    g_windowManager.Add(new CGUIWindowScreensaverDim);            // window id = 97  
+    g_windowManager.Add(new CGUIWindowScreensaverDim);            // window id = 97
     g_windowManager.Add(new CGUIWindowDebugInfo);            // window id = 98
     g_windowManager.Add(new CGUIWindowPointer);            // window id = 99
     g_windowManager.Add(new CGUIDialogYesNo);              // window id = 100
@@ -1385,7 +1385,7 @@ bool CApplication::StartWebServer()
     bool started = false;
     if (m_WebServer.Start(webPort, g_guiSettings.GetString("services.webserverusername"), g_guiSettings.GetString("services.webserverpassword")))
     {
-      std::map<std::string, std::string> txt; 
+      std::map<std::string, std::string> txt;
       started = true;
       // publish web frontend and API services
 #ifdef HAS_WEB_INTERFACE
@@ -1437,7 +1437,7 @@ void CApplication::StartAirplayServer()
     int listenPort = g_advancedSettings.m_airPlayPort;
     CStdString password = g_guiSettings.GetString("services.airplaypassword");
     bool usePassword = g_guiSettings.GetBool("services.useairplaypassword");
-    
+
     if (CAirPlayServer::StartServer(listenPort, true))
     {
       CAirPlayServer::SetCredentials(usePassword, password);
@@ -1460,11 +1460,11 @@ void CApplication::StartAirplayServer()
 #endif
 #ifdef HAS_AIRTUNES
   if (g_guiSettings.GetBool("services.airplay") && m_network.IsAvailable())
-  {   
-    int listenPort = g_advancedSettings.m_airTunesPort;  
+  {
+    int listenPort = g_advancedSettings.m_airTunesPort;
     CStdString password = g_guiSettings.GetString("services.airplaypassword");
     bool usePassword = g_guiSettings.GetBool("services.useairplaypassword");
-      
+
     if (!CAirTunesServer::StartServer(listenPort, true, usePassword, password))
     {
       CLog::Log(LOGERROR, "Failed to start AirTunes Server");
@@ -1491,7 +1491,7 @@ bool CApplication::StartJSONRPCServer()
   {
     if (CTCPServer::StartServer(g_advancedSettings.m_jsonTcpPort, g_guiSettings.GetBool("services.esallinterfaces")))
     {
-      std::map<std::string, std::string> txt;  
+      std::map<std::string, std::string> txt;
       CZeroconf::GetInstance()->PublishService("servers.jsonrpc-tpc", "_xbmc-jsonrpc._tcp", g_infoManager.GetLabel(SYSTEM_FRIENDLY_NAME), g_advancedSettings.m_jsonTcpPort, txt);
       return true;
     }
@@ -2472,7 +2472,7 @@ bool CApplication::OnAction(const CAction &action)
       m_navigationTimer.StartZero();
       return true;
     }
-  } 
+  }
 
   // handle extra global presses
 
@@ -2574,7 +2574,7 @@ bool CApplication::OnAction(const CAction &action)
   {
     if (IsPlaying() && m_pPlayer->SkipNext())
       return true;
-    
+
     if (IsPaused())
       m_pPlayer->Pause();
 
@@ -2989,11 +2989,11 @@ bool CApplication::ProcessMouse()
     return OnAction(mouseaction);
 
   // This is a mouse action so we need to record the mouse position
-  return OnAction(CAction(mouseaction.GetID(), 
-                          g_Mouse.GetHold(MOUSE_LEFT_BUTTON), 
-                          (float)g_Mouse.GetX(), 
-                          (float)g_Mouse.GetY(), 
-                          (float)g_Mouse.GetDX(), 
+  return OnAction(CAction(mouseaction.GetID(),
+                          g_Mouse.GetHold(MOUSE_LEFT_BUTTON),
+                          (float)g_Mouse.GetX(),
+                          (float)g_Mouse.GetY(),
+                          (float)g_Mouse.GetDX(),
                           (float)g_Mouse.GetDY(),
                           mouseaction.GetName()));
 }
@@ -3539,7 +3539,7 @@ void CApplication::Stop(int exitCode)
   // so we may never get to Destroy() in CXBApplicationEx::Run(), we call it here.
   Destroy();
 
-  // 
+  //
   Sleep(200);
 }
 
@@ -3722,7 +3722,7 @@ bool CApplication::PlayStack(const CFileItem& item, bool bRestart)
         }
         dbs.Close();
       }
-    }      
+    }
 
     *m_itemCurrentFile = item;
     m_currentStackPosition = 0;
@@ -3777,7 +3777,7 @@ bool CApplication::PlayFile(const CFileItem& item, bool bRestart)
     if (CGUIDialogPlayEject::ShowAndGetInput(item))
       // PlayDiscAskResume takes path to disc. No parameter means default DVD drive.
       // Can't do better as CGUIDialogPlayEject calls CMediaManager::IsDiscInDrive, which assumes default DVD drive anyway
-      return MEDIA_DETECT::CAutorun::PlayDiscAskResume(); 
+      return MEDIA_DETECT::CAutorun::PlayDiscAskResume();
 #endif
     return true;
   }
@@ -3836,7 +3836,7 @@ bool CApplication::PlayFile(const CFileItem& item, bool bRestart)
   }
 
   CPlayerOptions options;
-  
+
   if( item.HasProperty("StartPercent") )
   {
     double fallback = 0.0f;
@@ -3844,7 +3844,7 @@ bool CApplication::PlayFile(const CFileItem& item, bool bRestart)
       fallback = (double)atof(item.GetProperty("StartPercent").asString().c_str());
     options.startpercent = item.GetProperty("StartPercent").asDouble(fallback);
   }
-  
+
   PLAYERCOREID eNewCore = EPC_NONE;
   if( bRestart )
   {
@@ -3876,7 +3876,7 @@ bool CApplication::PlayFile(const CFileItem& item, bool bRestart)
         options.starttime = 0.0f;
         CBookmark bookmark;
         CStdString path = item.GetPath();
-        if (item.HasVideoInfoTag() && item.GetVideoInfoTag()->m_strFileNameAndPath.Find("removable://") == 0) 
+        if (item.HasVideoInfoTag() && item.GetVideoInfoTag()->m_strFileNameAndPath.Find("removable://") == 0)
           path = item.GetVideoInfoTag()->m_strFileNameAndPath;
         else if (item.HasProperty("original_listitem_url") && URIUtils::IsPlugin(item.GetProperty("original_listitem_url").asString()))
           path = item.GetProperty("original_listitem_url").asString();
@@ -4585,7 +4585,7 @@ void CApplication::CheckScreenSaverAndDPMS()
   // * Are we playing a video and it is not paused?
   if ((IsPlayingVideo() && !m_pPlayer->IsPaused())
       // * Are we playing some music in fullscreen vis?
-      || (IsPlayingAudio() && g_windowManager.GetActiveWindow() == WINDOW_VISUALISATION 
+      || (IsPlayingAudio() && g_windowManager.GetActiveWindow() == WINDOW_VISUALISATION
           && !g_guiSettings.GetString("musicplayer.visualisation").IsEmpty()))
   {
     ResetScreenSaverTimer();
@@ -4830,7 +4830,7 @@ bool CApplication::OnMessage(CGUIMessage& message)
           return true;
         }
       }
-      
+
       // In case playback ended due to user eg. skipping over the end, clear
       // our resume bookmark here
       if (message.GetMessage() == GUI_MSG_PLAYBACK_ENDED && m_progressTrackingPlayCountUpdate && g_advancedSettings.m_videoIgnorePercentAtEnd > 0)
@@ -5078,7 +5078,7 @@ void CApplication::ProcessSlow()
 #if defined(_LINUX) && defined(HAS_FILESYSTEM_SMB)
   smb.CheckIfIdle();
 #endif
-  
+
 #ifdef HAS_FILESYSTEM_NFS
   gNfsConnection.CheckIfIdle();
 #endif
@@ -5109,7 +5109,7 @@ void CApplication::ProcessSlow()
     }
   }
 #endif
-  
+
   if (!IsPlayingVideo())
     CAddonInstaller::Get().UpdateRepos();
 

--- a/xbmc/Application.h
+++ b/xbmc/Application.h
@@ -125,8 +125,8 @@ public:
   void StopServices();
   bool StartWebServer();
   void StopWebServer();
-  void StartAirplayServer();  
-  void StopAirplayServer(bool bWait);   
+  void StartAirplayServer();
+  void StopAirplayServer(bool bWait);
   bool StartJSONRPCServer();
   void StopJSONRPCServer(bool bWait);
   void StartUPnP();
@@ -405,7 +405,7 @@ protected:
   bool m_bEnableLegacyRes;
   bool m_bTestMode;
   bool m_bSystemScreenSaverEnable;
-  
+
   int        m_frameCount;
   CCriticalSection m_frameMutex;
   XbmcThreads::ConditionVariable  m_frameCond;

--- a/xbmc/Application.h
+++ b/xbmc/Application.h
@@ -25,6 +25,7 @@
 #include "XBApplicationEx.h"
 
 #include "guilib/IMsgTargetCallback.h"
+#include "guilib/Key.h"
 #include "threads/Condition.h"
 
 #include <map>
@@ -53,7 +54,6 @@ namespace MEDIA_DETECT
 #include "win32/WIN32Util.h"
 #endif
 #include "utils/Stopwatch.h"
-#include "ApplicationMessenger.h"
 #include "network/Network.h"
 #include "utils/CharsetConverter.h"
 #ifdef HAS_PERFORMANCE_SAMPLE
@@ -65,7 +65,6 @@ namespace MEDIA_DETECT
 class CSeekHandler;
 class CKaraokeLyricsManager;
 class CInertialScrollingHandler;
-class CApplicationMessenger;
 class DPMSSupport;
 class CSplash;
 class CBookmark;
@@ -242,7 +241,6 @@ public:
 
   static bool OnEvent(XBMC_Event& newEvent);
 
-  CApplicationMessenger& getApplicationMessenger();
 #if defined(HAS_LINUX_NETWORK)
   CNetworkLinux& getNetwork();
 #elif defined(HAS_WIN32_NETWORK)
@@ -344,13 +342,16 @@ public:
    \sa CSeekHandler
    */
   const CSeekHandler *GetSeekHandler() const { return m_seekHandler; };
+
+  bool SwitchToFullScreen();
+
+  CSplash* GetSplash() { return m_splash; }
 protected:
   bool LoadSkin(const CStdString& skinID);
   void LoadSkin(const boost::shared_ptr<ADDON::CSkinInfo>& skin);
 
   bool m_skinReloading; // if true we disallow LoadSkin until ReloadSkin is called
 
-  friend class CApplicationMessenger;
 #if defined(TARGET_DARWIN_IOS)
   friend class CWinEventsIOS;
 #endif
@@ -422,7 +423,6 @@ protected:
   void VolumeChanged() const;
 
   bool PlayStack(const CFileItem& item, bool bRestart);
-  bool SwitchToFullScreen();
   bool ProcessMouse();
   bool ProcessRemote(float frameTime);
   bool ProcessGamepad(float frameTime);
@@ -445,7 +445,6 @@ protected:
 
   CSeekHandler *m_seekHandler;
   CInertialScrollingHandler *m_pInertialScrollingHandler;
-  CApplicationMessenger m_applicationMessenger;
 #if defined(HAS_LINUX_NETWORK)
   CNetworkLinux m_network;
 #elif defined(HAS_WIN32_NETWORK)

--- a/xbmc/ApplicationMessenger.cpp
+++ b/xbmc/ApplicationMessenger.cpp
@@ -1136,7 +1136,7 @@ void CApplicationMessenger::Show(CGUIDialog *pDialog)
 void CApplicationMessenger::Close(CGUIWindow *window, bool forceClose, bool waitResult /*= true*/, int nextWindowID /*= 0*/, bool enableSound /*= true*/)
 {
   ThreadMessage tMsg = {TMSG_GUI_WINDOW_CLOSE, nextWindowID};
-  tMsg.dwParam2 = (DWORD)(forceClose ? 0x01 : 0 | enableSound ? 0x02 : 0);
+  tMsg.dwParam2 = (DWORD)((forceClose ? 0x01 : 0) | (enableSound ? 0x02 : 0));
   tMsg.lpVoid = window;
   SendMessage(tMsg, waitResult);
 }

--- a/xbmc/ApplicationMessenger.cpp
+++ b/xbmc/ApplicationMessenger.cpp
@@ -23,7 +23,6 @@
 #include "ApplicationMessenger.h"
 #include "Application.h"
 
-#include "guilib/TextureManager.h"
 #include "PlayListPlayer.h"
 #include "Util.h"
 #ifdef HAS_PYTHON
@@ -39,7 +38,6 @@
 #include "settings/GUISettings.h"
 #include "FileItem.h"
 #include "guilib/GUIDialog.h"
-#include "windowing/WindowingFactory.h"
 #include "GUIInfoManager.h"
 #include "utils/Splash.h"
 #include "cores/VideoRenderers/RenderManager.h"
@@ -67,8 +65,6 @@
 #include "playlists/PlayList.h"
 #include "FileItem.h"
 
-#include "utils/JobManager.h"
-#include "storage/DetectDVDType.h"
 #include "ThumbLoader.h"
 
 using namespace std;

--- a/xbmc/ApplicationMessenger.cpp
+++ b/xbmc/ApplicationMessenger.cpp
@@ -91,7 +91,17 @@ void CDelayedMessage::Process()
   Sleep(m_delay);
 
   if (!m_bStop)
-    g_application.getApplicationMessenger().SendMessage(m_msg, false);
+    CApplicationMessenger::Get().SendMessage(m_msg, false);
+}
+
+CApplicationMessenger& CApplicationMessenger::Get()
+{
+  static CApplicationMessenger s_messenger;
+  return s_messenger;
+}
+
+CApplicationMessenger::CApplicationMessenger()
+{
 }
 
 CApplicationMessenger::~CApplicationMessenger()
@@ -521,23 +531,23 @@ case TMSG_POWERDOWN:
       switch (m_pXbmcHttp->xbmcCommand(pMsg->strParam))
       {
         case 1:
-          g_application.getApplicationMessenger().Restart();
+          Restart();
           break;
 
         case 2:
-          g_application.getApplicationMessenger().Shutdown();
+          Shutdown();
           break;
 
         case 3:
-          g_application.getApplicationMessenger().Quit();
+          Quit();
           break;
 
         case 4:
-          g_application.getApplicationMessenger().Reset();
+          Reset();
           break;
 
         case 5:
-          g_application.getApplicationMessenger().RestartApp();
+          RestartApp();
           break;
       }
 #endif
@@ -761,8 +771,8 @@ case TMSG_POWERDOWN:
 
     case TMSG_SPLASH_MESSAGE:
       {
-        if (g_application.m_splash)
-          g_application.m_splash->Show(pMsg->strParam);
+        if (g_application.GetSplash())
+          g_application.GetSplash()->Show(pMsg->strParam);
       }
       break;
   }

--- a/xbmc/ApplicationMessenger.h
+++ b/xbmc/ApplicationMessenger.h
@@ -28,6 +28,8 @@
 #include "threads/Event.h"
 #include <boost/shared_ptr.hpp>
 
+#include "PlatformDefs.h"
+
 #include <queue>
 
 class CFileItem;
@@ -129,9 +131,12 @@ struct ThreadMessageCallback
 
 class CApplicationMessenger
 {
-
 public:
-  ~CApplicationMessenger();
+  /*!
+   \brief The only way through which the global instance of the CApplicationMessenger should be accessed.
+   \return the global instance.
+   */
+  static CApplicationMessenger& Get();
 
   void Cleanup();
   // if a message has to be send to the gui, use MSG_TYPE_WINDOW instead
@@ -211,13 +216,16 @@ public:
   void SetSplashMessage(int stringID);
 
 private:
+  // private construction, and no assignements; use the provided singleton methods
+  CApplicationMessenger();
+  CApplicationMessenger(const CApplicationMessenger&);
+  CApplicationMessenger const& operator=(CApplicationMessenger const&);
+  virtual ~CApplicationMessenger();
   void ProcessMessage(ThreadMessage *pMsg);
-
 
   std::queue<ThreadMessage*> m_vecMessages;
   std::queue<ThreadMessage*> m_vecWindowMessages;
   CCriticalSection m_critSection;
   CCriticalSection m_critBuffer;
   CStdString bufferResponse;
-
 };

--- a/xbmc/AutoSwitch.cpp
+++ b/xbmc/AutoSwitch.cpp
@@ -20,7 +20,6 @@
  */
 
 #include "AutoSwitch.h"
-#include "guilib/GUIBaseContainer.h" // for VIEW_TYPE_*
 #include "settings/Settings.h"
 #include "settings/GUISettings.h"
 #include "guilib/GUIWindowManager.h"

--- a/xbmc/Autorun.cpp
+++ b/xbmc/Autorun.cpp
@@ -25,7 +25,6 @@
 
 #include "Autorun.h"
 #include "Application.h"
-#include "Util.h"
 #include "GUIPassword.h"
 #include "GUIUserMessages.h"
 #include "PlayListPlayer.h"

--- a/xbmc/Autorun.cpp
+++ b/xbmc/Autorun.cpp
@@ -33,7 +33,6 @@
 #include "filesystem/DirectoryFactory.h"
 #include "filesystem/File.h"
 #include "settings/GUISettings.h"
-#include "settings/AdvancedSettings.h"
 #include "settings/Settings.h"
 #include "playlists/PlayList.h"
 #include "guilib/GUIWindowManager.h"

--- a/xbmc/Favourites.cpp
+++ b/xbmc/Favourites.cpp
@@ -22,7 +22,6 @@
 #include "Favourites.h"
 #include "filesystem/File.h"
 #include "Util.h"
-#include "guilib/Key.h"
 #include "settings/Settings.h"
 #include "FileItem.h"
 #include "utils/XBMCTinyXML.h"

--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -560,6 +560,12 @@ bool CFileItem::IsVideo() const
 
 bool CFileItem::IsDiscStub() const
 {
+  if (IsVideoDb() && HasVideoInfoTag())
+  {
+    CFileItem dbItem(m_bIsFolder ? GetVideoInfoTag()->m_strPath : GetVideoInfoTag()->m_strFileNameAndPath, m_bIsFolder);
+    return dbItem.IsDiscStub();
+  }
+
   CStdString strExtension;
   URIUtils::GetExtension(m_strPath, strExtension);
 

--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -26,18 +26,16 @@
 #include "Util.h"
 #include "playlists/PlayListFactory.h"
 #include "utils/Crc32.h"
-#include "filesystem/DirectoryCache.h"
+#include "filesystem/Directory.h"
 #include "filesystem/StackDirectory.h"
 #include "filesystem/CurlFile.h"
 #include "filesystem/MultiPathDirectory.h"
 #include "filesystem/MusicDatabaseDirectory.h"
 #include "filesystem/VideoDatabaseDirectory.h"
-#include "filesystem/DirectoryFactory.h"
 #include "music/tags/MusicInfoTagLoaderFactory.h"
 #include "CueDocument.h"
 #include "video/VideoDatabase.h"
 #include "music/MusicDatabase.h"
-#include "SortFileItem.h"
 #include "utils/TuxBoxUtil.h"
 #include "video/VideoInfoTag.h"
 #include "threads/SingleLock.h"
@@ -55,7 +53,6 @@
 #include "utils/Variant.h"
 #include "music/karaoke/karaokelyricsfactory.h"
 #include "utils/Mime.h"
-#include "utils/CharsetConverter.h"
 
 using namespace std;
 using namespace XFILE;

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -20,6 +20,7 @@
  */
 
 #include "system.h"
+#include "GUIInfoManager.h"
 #include "windows/GUIMediaWindow.h"
 #include "dialogs/GUIDialogProgress.h"
 #include "Application.h"
@@ -37,13 +38,11 @@
 #include "LangInfo.h"
 #include "utils/SystemInfo.h"
 #include "guilib/GUITextBox.h"
-#include "GUIInfoManager.h"
 #include "pictures/GUIWindowSlideShow.h"
 #include "music/LastFmManager.h"
 #include "pictures/PictureInfoTag.h"
 #include "music/tags/MusicInfoTag.h"
 #include "guilib/GUIWindowManager.h"
-#include "filesystem/File.h"
 #include "playlists/PlayList.h"
 #include "utils/TuxBoxUtil.h"
 #include "windowing/WindowingFactory.h"

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -3622,7 +3622,7 @@ string CGUIInfoManager::GetSystemHeatInfo(int info)
   { // update our variables
     m_lastSysHeatInfoTime = CTimeUtils::GetFrameTime();
 #if defined(_LINUX)
-    m_cpuTemp = g_cpuInfo.getTemperature();
+    g_cpuInfo.getTemperature(m_cpuTemp);
     m_gpuTemp = GetGPUTemperature();
 #endif
   }

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -21,8 +21,6 @@
 
 #include "system.h"
 #include "windows/GUIMediaWindow.h"
-#include "dialogs/GUIDialogFileBrowser.h"
-#include "settings/GUIDialogContentSettings.h"
 #include "dialogs/GUIDialogProgress.h"
 #include "Application.h"
 #include "Util.h"
@@ -36,7 +34,6 @@
 #ifdef HAS_LCD
 #include "utils/LCD.h"
 #endif
-#include "GUIPassword.h"
 #include "LangInfo.h"
 #include "utils/SystemInfo.h"
 #include "guilib/GUITextBox.h"
@@ -60,9 +57,7 @@
 #include "utils/SeekHandler.h"
 
 // stuff for current song
-#include "music/tags/MusicInfoTagLoaderFactory.h"
 #include "music/MusicInfoLoader.h"
-#include "utils/LabelFormatter.h"
 
 #include "GUIUserMessages.h"
 #include "video/dialogs/GUIDialogVideoInfo.h"
@@ -74,7 +69,6 @@
 
 #include "addons/AddonManager.h"
 #include "interfaces/info/InfoBool.h"
-#include "TextureCache.h"
 #include "ThumbLoader.h"
 #include "cores/AudioEngine/Utils/AEUtil.h"
 

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -55,6 +55,7 @@
 #include "utils/StringUtils.h"
 #include "utils/MathUtils.h"
 #include "utils/SeekHandler.h"
+#include "URL.h"
 
 // stuff for current song
 #include "music/MusicInfoLoader.h"

--- a/xbmc/GUILargeTextureManager.cpp
+++ b/xbmc/GUILargeTextureManager.cpp
@@ -22,7 +22,6 @@
 #include "threads/SystemClock.h"
 #include "GUILargeTextureManager.h"
 #include "settings/GUISettings.h"
-#include "FileItem.h"
 #include "guilib/Texture.h"
 #include "threads/SingleLock.h"
 #include "utils/TimeUtils.h"
@@ -30,7 +29,6 @@
 #include "guilib/GraphicContext.h"
 #include "utils/log.h"
 #include "TextureCache.h"
-#include "TextureCacheJob.h"
 
 using namespace std;
 

--- a/xbmc/GUIPassword.cpp
+++ b/xbmc/GUIPassword.cpp
@@ -29,7 +29,6 @@
 #include "settings/GUIDialogLockSettings.h"
 #include "settings/GUIDialogProfileSettings.h"
 #include "Util.h"
-#include "URL.h"
 #include "settings/Settings.h"
 #include "settings/GUISettings.h"
 #include "guilib/GUIWindowManager.h"

--- a/xbmc/GUIPassword.cpp
+++ b/xbmc/GUIPassword.cpp
@@ -21,7 +21,7 @@
 
 #include "GUIPassword.h"
 #include "GUIUserMessages.h"
-#include "Application.h"
+#include "ApplicationMessenger.h"
 #include "dialogs/GUIDialogGamepad.h"
 #include "dialogs/GUIDialogKeyboard.h"
 #include "dialogs/GUIDialogNumeric.h"
@@ -157,7 +157,7 @@ bool CGUIPassword::CheckStartUpLock()
   }
   else
   {
-    g_application.getApplicationMessenger().Shutdown(); // Turn off the box
+    CApplicationMessenger::Get().Shutdown(); // Turn off the box
     return false;
   }
 }

--- a/xbmc/GUIViewState.cpp
+++ b/xbmc/GUIViewState.cpp
@@ -29,7 +29,6 @@
 #include "utils/URIUtils.h"
 #include "URL.h"
 #include "GUIPassword.h"
-#include "guilib/GUIBaseContainer.h" // for VIEW_TYPE_*
 #include "ViewDatabase.h"
 #include "AutoSwitch.h"
 #include "guilib/GUIWindowManager.h"

--- a/xbmc/NfoFile.cpp
+++ b/xbmc/NfoFile.cpp
@@ -31,7 +31,6 @@
 #include "music/Album.h"
 #include "music/Artist.h"
 #include "settings/GUISettings.h"
-#include "LangInfo.h"
 #include "utils/log.h"
 
 #include <vector>

--- a/xbmc/NfoFile.cpp
+++ b/xbmc/NfoFile.cpp
@@ -27,7 +27,6 @@
 #include "addons/AddonManager.h"
 #include "filesystem/File.h"
 #include "settings/GUISettings.h"
-#include "Util.h"
 #include "FileItem.h"
 #include "music/Album.h"
 #include "music/Artist.h"

--- a/xbmc/TextureCache.cpp
+++ b/xbmc/TextureCache.cpp
@@ -28,6 +28,7 @@
 #include "settings/AdvancedSettings.h"
 #include "utils/log.h"
 #include "utils/URIUtils.h"
+#include "URL.h"
 
 using namespace XFILE;
 

--- a/xbmc/ThumbLoader.cpp
+++ b/xbmc/ThumbLoader.cpp
@@ -109,6 +109,7 @@ bool CThumbExtractor::DoWork()
   ||  m_item.IsDVDImage()
   ||  m_item.IsDVDFile(false, true)
   ||  m_item.IsInternetStream()
+  ||  m_item.IsDiscStub()
   ||  m_item.IsPlayList())
     return false;
 

--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -86,6 +86,7 @@
 #include "cores/dvdplayer/DVDSubtitles/DVDSubtitleTagSami.h"
 #include "cores/dvdplayer/DVDSubtitles/DVDSubtitleStream.h"
 #include "windowing/WindowingFactory.h"
+#include "URL.h"
 #ifdef HAVE_LIBCAP
   #include <sys/capability.h>
 #endif

--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -39,13 +39,11 @@
 #endif
 
 #include "Application.h"
-#include "utils/AutoPtrHandle.h"
 #include "Util.h"
 #include "addons/Addon.h"
-#include "storage/IoSupport.h"
+#include "filesystem/Directory.h"
 #include "filesystem/StackDirectory.h"
 #include "filesystem/MultiPathDirectory.h"
-#include "filesystem/DirectoryCache.h"
 #include "filesystem/SpecialProtocol.h"
 #include "filesystem/RSSDirectory.h"
 #ifdef HAS_FILESYSTEM_RAR
@@ -63,9 +61,6 @@
 #include "guilib/TextureManager.h"
 #include "utils/fstrcmp.h"
 #include "storage/MediaManager.h"
-#include "guilib/DirectXGraphics.h"
-#include "network/DNSNameCache.h"
-#include "guilib/GUIWindowManager.h"
 #ifdef _WIN32
 #include <shlobj.h>
 #include "WIN32Util.h"
@@ -75,7 +70,6 @@
 #endif
 #include "GUIUserMessages.h"
 #include "filesystem/File.h"
-#include "utils/Crc32.h"
 #include "settings/Settings.h"
 #include "utils/StringUtils.h"
 #include "settings/AdvancedSettings.h"
@@ -92,7 +86,6 @@
 #include "cores/dvdplayer/DVDSubtitles/DVDSubtitleTagSami.h"
 #include "cores/dvdplayer/DVDSubtitles/DVDSubtitleStream.h"
 #include "windowing/WindowingFactory.h"
-#include "video/VideoInfoTag.h"
 #ifdef HAVE_LIBCAP
   #include <sys/capability.h>
 #endif
@@ -104,7 +97,6 @@ using namespace XFILE;
 static const int64_t SECS_BETWEEN_EPOCHS = 11644473600LL;
 static const int64_t SECS_TO_100NS = 10000000;
 
-using namespace AUTOPTR;
 using namespace XFILE;
 using namespace PLAYLIST;
 

--- a/xbmc/addons/Addon.cpp
+++ b/xbmc/addons/Addon.cpp
@@ -34,6 +34,7 @@
 #endif
 #include "utils/log.h"
 #include "utils/URIUtils.h"
+#include "URL.h"
 #include <vector>
 #include <string.h>
 #include <ostream>

--- a/xbmc/addons/Addon.h
+++ b/xbmc/addons/Addon.h
@@ -23,11 +23,8 @@
 #include "IAddon.h"
 #include "addons/AddonVersion.h"
 #include "utils/XBMCTinyXML.h"
-#include "Util.h"
-#include "URL.h"
 #include "guilib/LocalizeStrings.h"
 
-class CURL;
 class TiXmlElement;
 
 typedef struct cp_plugin_info_t cp_plugin_info_t;

--- a/xbmc/addons/AddonInstaller.cpp
+++ b/xbmc/addons/AddonInstaller.cpp
@@ -39,6 +39,7 @@
 #include "utils/StringUtils.h"
 #include "dialogs/GUIDialogKaiToast.h"
 #include "dialogs/GUIDialogProgress.h"
+#include "URL.h"
 
 using namespace std;
 using namespace XFILE;

--- a/xbmc/addons/AddonInstaller.cpp
+++ b/xbmc/addons/AddonInstaller.cpp
@@ -28,7 +28,7 @@
 #include "filesystem/Directory.h"
 #include "settings/GUISettings.h"
 #include "settings/Settings.h"
-#include "Application.h"
+#include "ApplicationMessenger.h"
 #include "Favourites.h"
 #include "utils/JobManager.h"
 #include "dialogs/GUIDialogYesNo.h"
@@ -467,7 +467,7 @@ bool CAddonInstallJob::OnPreInstall()
   // check whether this is an active skin - we need to unload it if so
   if (g_guiSettings.GetString("lookandfeel.skin") == m_addon->ID())
   {
-    g_application.getApplicationMessenger().ExecBuiltIn("UnloadSkin", true);
+    CApplicationMessenger::Get().ExecBuiltIn("UnloadSkin", true);
     return true;
   }
 
@@ -572,7 +572,7 @@ void CAddonInstallJob::OnPostInstall(bool reloadAddon)
         toast->ResetTimer();
         toast->Close(true);
       }
-      g_application.getApplicationMessenger().ExecBuiltIn("ReloadSkin");
+      CApplicationMessenger::Get().ExecBuiltIn("ReloadSkin");
     }
   }
 

--- a/xbmc/addons/AddonManager.cpp
+++ b/xbmc/addons/AddonManager.cpp
@@ -45,6 +45,7 @@
 #include "Repository.h"
 #include "Skin.h"
 #include "Service.h"
+#include "Util.h"
 
 using namespace std;
 

--- a/xbmc/addons/AddonStatusHandler.cpp
+++ b/xbmc/addons/AddonStatusHandler.cpp
@@ -21,7 +21,7 @@
 #include "AddonStatusHandler.h"
 #include "AddonManager.h"
 #include "threads/SingleLock.h"
-#include "Application.h"
+#include "ApplicationMessenger.h"
 #include "guilib/GUIWindowManager.h"
 #include "GUIDialogAddonSettings.h"
 #include "dialogs/GUIDialogYesNo.h"
@@ -95,7 +95,7 @@ void CAddonStatusHandler::Process()
 
     //send message and wait for user input
     ThreadMessage tMsg = {TMSG_DIALOG_DOMODAL, WINDOW_DIALOG_YES_NO, g_windowManager.GetActiveWindow()};
-    g_application.getApplicationMessenger().SendMessage(tMsg, true);
+    CApplicationMessenger::Get().SendMessage(tMsg, true);
 
     if (pDialog->IsConfirmed())
       CAddonMgr::Get().GetCallbackForType(m_addon->Type())->RequestRestart(m_addon, false);
@@ -111,7 +111,7 @@ void CAddonStatusHandler::Process()
 
     //send message and wait for user input
     ThreadMessage tMsg = {TMSG_DIALOG_DOMODAL, WINDOW_DIALOG_OK, g_windowManager.GetActiveWindow()};
-    g_application.getApplicationMessenger().SendMessage(tMsg, true);
+    CApplicationMessenger::Get().SendMessage(tMsg, true);
 
     CAddonMgr::Get().GetCallbackForType(m_addon->Type())->RequestRestart(m_addon, true);
   }
@@ -128,7 +128,7 @@ void CAddonStatusHandler::Process()
 
     //send message and wait for user input
     ThreadMessage tMsg = {TMSG_DIALOG_DOMODAL, WINDOW_DIALOG_YES_NO, g_windowManager.GetActiveWindow()};
-    g_application.getApplicationMessenger().SendMessage(tMsg, true);
+    CApplicationMessenger::Get().SendMessage(tMsg, true);
 
     if (!pDialogYesNo->IsConfirmed()) return;
 
@@ -156,7 +156,7 @@ void CAddonStatusHandler::Process()
 
     //send message and wait for user input
     ThreadMessage tMsg = {TMSG_DIALOG_DOMODAL, WINDOW_DIALOG_OK, g_windowManager.GetActiveWindow()};
-    g_application.getApplicationMessenger().SendMessage(tMsg, true);
+    CApplicationMessenger::Get().SendMessage(tMsg, true);
   }
 }
 

--- a/xbmc/addons/GUIDialogAddonSettings.cpp
+++ b/xbmc/addons/GUIDialogAddonSettings.cpp
@@ -39,7 +39,7 @@
 #include "video/VideoInfoScanner.h"
 #include "addons/Scraper.h"
 #include "guilib/GUIWindowManager.h"
-#include "Application.h"
+#include "ApplicationMessenger.h"
 #include "dialogs/GUIDialogKeyboard.h"
 #include "FileItem.h"
 #include "settings/Settings.h"
@@ -409,7 +409,7 @@ bool CGUIDialogAddonSettings::ShowVirtualKeyboard(int iControl)
             action.Replace("$ID", m_addon->ID());
             if (option)
               bCloseDialog = (strcmpi(option, "close") == 0);
-            g_application.getApplicationMessenger().ExecBuiltIn(action);
+            CApplicationMessenger::Get().ExecBuiltIn(action);
           }
         }
         else if (strcmp(type, "date") == 0)

--- a/xbmc/addons/GUIDialogAddonSettings.cpp
+++ b/xbmc/addons/GUIDialogAddonSettings.cpp
@@ -49,6 +49,7 @@
 #include "GUIWindowAddonBrowser.h"
 #include "utils/log.h"
 #include "Util.h"
+#include "URL.h"
 
 using namespace std;
 using namespace ADDON;

--- a/xbmc/addons/GUIDialogAddonSettings.cpp
+++ b/xbmc/addons/GUIDialogAddonSettings.cpp
@@ -48,6 +48,7 @@
 #include "dialogs/GUIDialogSelect.h"
 #include "GUIWindowAddonBrowser.h"
 #include "utils/log.h"
+#include "Util.h"
 
 using namespace std;
 using namespace ADDON;

--- a/xbmc/addons/GUIDialogAddonSettings.cpp
+++ b/xbmc/addons/GUIDialogAddonSettings.cpp
@@ -98,7 +98,7 @@ bool CGUIDialogAddonSettings::OnMessage(CGUIMessage& message)
       bool bCloseDialog = false;
 
       if (iControl == ID_BUTTON_DEFAULT)
-        SetDefaults();
+        SetDefaultSettings();
       else if (iControl != ID_BUTTON_OK)
         bCloseDialog = ShowVirtualKeyboard(iControl);
 
@@ -1079,7 +1079,7 @@ CStdString CGUIDialogAddonSettings::GetString(const char *value, bool subSetting
 }
 
 // Go over all the settings and set their default values
-void CGUIDialogAddonSettings::SetDefaults()
+void CGUIDialogAddonSettings::SetDefaultSettings()
 {
   if(!m_addon)
     return;

--- a/xbmc/addons/GUIDialogAddonSettings.h
+++ b/xbmc/addons/GUIDialogAddonSettings.h
@@ -70,7 +70,7 @@ private:
   void FreeControls();
   void UpdateFromControls();
   void EnableControls();
-  void SetDefaults();
+  void SetDefaultSettings();
   bool GetCondition(const CStdString &condition, const int controlId);
 
   void SaveSettings(void);

--- a/xbmc/addons/Repository.cpp
+++ b/xbmc/addons/Repository.cpp
@@ -32,6 +32,7 @@
 #include "dialogs/GUIDialogYesNo.h"
 #include "dialogs/GUIDialogKaiToast.h"
 #include "TextureDatabase.h"
+#include "URL.h"
 
 using namespace XFILE;
 using namespace ADDON;

--- a/xbmc/addons/Repository.cpp
+++ b/xbmc/addons/Repository.cpp
@@ -92,19 +92,21 @@ CStdString CRepository::FetchChecksum(const CStdString& url)
   CSingleLock lock(m_critSection);
   CFile file;
   file.Open(url);
-  CStdString checksum;
   try
   {
-    char* temp = new char[(size_t)file.GetLength()+1];
-    file.Read(temp,file.GetLength());
-    temp[file.GetLength()] = 0;
-    checksum = temp;
-    delete[] temp;
+    // we intentionally avoid using file.GetLength() for 
+    // Transfer-Encoding: chunked servers.
+    std::stringstream str;
+    char temp[1024];
+    int read;
+    while ((read=file.Read(temp, sizeof(temp))) > 0)
+      str.write(temp, read);
+    return str.str();
   }
   catch (...)
   {
+    return "";
   }
-  return checksum;
 }
 
 CStdString CRepository::GetAddonHash(const AddonPtr& addon)

--- a/xbmc/addons/Repository.h
+++ b/xbmc/addons/Repository.h
@@ -23,7 +23,6 @@
 #include "Addon.h"
 #include "AddonManager.h"
 #include "XBDateTime.h"
-#include "URL.h"
 #include "utils/Job.h"
 #include "threads/CriticalSection.h"
 #include "threads/SingleLock.h"

--- a/xbmc/addons/Scraper.cpp
+++ b/xbmc/addons/Scraper.cpp
@@ -39,6 +39,8 @@
 #include "video/VideoDatabase.h"
 #include "music/Album.h"
 #include "music/Artist.h"
+#include "Util.h"
+
 #include <sstream>
 
 using namespace std;

--- a/xbmc/addons/Scraper.cpp
+++ b/xbmc/addons/Scraper.cpp
@@ -40,6 +40,7 @@
 #include "music/Album.h"
 #include "music/Artist.h"
 #include "Util.h"
+#include "URL.h"
 
 #include <sstream>
 

--- a/xbmc/cores/AudioEngine/Engines/SoftAE/SoftAEStream.cpp
+++ b/xbmc/cores/AudioEngine/Engines/SoftAE/SoftAEStream.cpp
@@ -576,6 +576,7 @@ void CSoftAEStream::InternalFlush()
   /* reset our counts */
   m_framesBuffered = 0;
   m_refillBuffer   = m_waterLevel;
+  m_draining       = false;
 }
 
 double CSoftAEStream::GetResampleRatio()

--- a/xbmc/cores/AudioEngine/Sinks/AESinkALSA.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkALSA.cpp
@@ -806,9 +806,9 @@ void CAESinkALSA::EnumerateDevicesEx(AEDeviceInfoList &list)
           continue;
         }
 
-        /* if we got here, the configuration is really weird, just give up */
-        it1->m_displayName = it1->m_deviceName;
-        it2->m_displayName = it2->m_deviceName;
+        /* if we got here, the configuration is really weird, just append the whole device string */
+        it1->m_displayName += " (" + it1->m_deviceName + ")";
+        it2->m_displayName += " (" + it2->m_deviceName + ")";
       }
     }
   }

--- a/xbmc/cores/AudioEngine/Sinks/AESinkALSA.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkALSA.cpp
@@ -768,10 +768,8 @@ void CAESinkALSA::EnumerateDevicesEx(AEDeviceInfoList &list)
        && it1->m_displayNameExtra == it2->m_displayNameExtra)
       {
         /* something needs to be done */
-        std::string cardString1;
-        std::string cardString2;
-        GetParamFromName(it1->m_deviceName, "CARD", cardString1);
-        GetParamFromName(it2->m_deviceName, "CARD", cardString2);
+        std::string cardString1 = GetParamFromName(it1->m_deviceName, "CARD");
+        std::string cardString2 = GetParamFromName(it2->m_deviceName, "CARD");
 
         if (cardString1 != cardString2)
         {
@@ -781,10 +779,8 @@ void CAESinkALSA::EnumerateDevicesEx(AEDeviceInfoList &list)
           continue;
         }
 
-        std::string devString1;
-        std::string devString2;
-        GetParamFromName(it1->m_deviceName, "DEV", devString1);
-        GetParamFromName(it2->m_deviceName, "DEV", devString2);
+        std::string devString1 = GetParamFromName(it1->m_deviceName, "DEV");
+        std::string devString2 = GetParamFromName(it2->m_deviceName, "DEV");
 
         if (devString1 != devString2)
         {
@@ -806,8 +802,7 @@ void CAESinkALSA::EnumerateDevicesEx(AEDeviceInfoList &list)
   {
     for (AEDeviceInfoList::iterator itl = list.begin(); itl != list.end(); ++itl)
     {
-      std::string cardString;
-      GetParamFromName(itl->m_deviceName, "CARD", cardString);
+      std::string cardString = GetParamFromName(itl->m_deviceName, "CARD");
       if (cardString == *it)
         /* "HDA NVidia (NVidia)", "HDA NVidia (NVidia_2)", ... */
         itl->m_displayName += " (" + cardString + ")";
@@ -820,12 +815,10 @@ void CAESinkALSA::EnumerateDevicesEx(AEDeviceInfoList &list)
     for (AEDeviceInfoList::iterator itl = list.begin(); itl != list.end(); ++itl)
     {
       std::string baseName = itl->m_deviceName.substr(0, itl->m_deviceName.find(':'));
-      std::string cardString;
-      GetParamFromName(itl->m_deviceName, "CARD", cardString);
+      std::string cardString = GetParamFromName(itl->m_deviceName, "CARD");
       if (baseName == it->first && cardString == it->second)
       {
-        std::string devString;
-        GetParamFromName(itl->m_deviceName, "DEV", devString);
+        std::string devString = GetParamFromName(itl->m_deviceName, "DEV");
         /* "HDMI #0", "HDMI #1" ... */
         itl->m_displayNameExtra += " #" + devString;
       }
@@ -833,19 +826,17 @@ void CAESinkALSA::EnumerateDevicesEx(AEDeviceInfoList &list)
   }
 }
 
-void CAESinkALSA::GetParamFromName(const std::string &name, const std::string &param, std::string &value)
+std::string CAESinkALSA::GetParamFromName(const std::string &name, const std::string &param)
 {
-  /* name = "hdmi:CARD=x,DEV=y" param = "CARD" => value = "x" */
+  /* name = "hdmi:CARD=x,DEV=y" param = "CARD" => return "x" */
   size_t parPos = name.find(param + '=');
   if (parPos != std::string::npos)
   {
     parPos += param.size() + 1;
-    value = name.substr(parPos, name.find_first_of(",'\"", parPos)-parPos);
+    return name.substr(parPos, name.find_first_of(",'\"", parPos)-parPos);
   }
-  else
-  {
-    value = "";
-  }
+
+  return "";
 }
 
 void CAESinkALSA::EnumerateDevice(AEDeviceInfoList &list, const std::string &device, const std::string &description, snd_config_t *config)

--- a/xbmc/cores/AudioEngine/Sinks/AESinkALSA.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkALSA.cpp
@@ -832,7 +832,7 @@ AEDeviceType CAESinkALSA::AEDeviceTypeFromName(const std::string &name)
 {
   if (name.substr(0, 4) == "hdmi")
     return AE_DEVTYPE_HDMI;
-  else if (name.substr(0, 6) == "iec958")
+  else if (name.substr(0, 6) == "iec958" || name.substr(0, 5) == "spdif")
     return AE_DEVTYPE_IEC958;
 
   return AE_DEVTYPE_PCM;

--- a/xbmc/cores/AudioEngine/Sinks/AESinkALSA.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkALSA.cpp
@@ -720,17 +720,31 @@ void CAESinkALSA::EnumerateDevicesEx(AEDeviceInfoList &list)
         if (strcmp(name, "front") != 0)
           EnumerateDevice(list, std::string("@") + (name+5), desc ? desc : name, config);
       }
+
+      /* Do not enumerate "default", it is already enumerated above. */
+
       /* Do not enumerate the sysdefault or surroundXX devices, those are
        * always accompanied with a "front" device and it is handled above
        * as "@". The below devices will be automatically used if available
        * for a "@" device. */
+
+      /* Ubuntu has patched their alsa-lib so that "defaults.namehint.extended"
+       * defaults to "on" instead of upstream "off", causing lots of unwanted
+       * extra devices (many of which are not actually routed properly) to be
+       * found by the enumeration process. Skip them as well ("hw", "dmix",
+       * "plughw", "dsnoop"). */
+
       else if (baseName != "default"
             && baseName != "sysdefault"
             && baseName != "surround40"
             && baseName != "surround41"
             && baseName != "surround50"
             && baseName != "surround51"
-            && baseName != "surround71")
+            && baseName != "surround71"
+            && baseName != "hw"
+            && baseName != "dmix"
+            && baseName != "plughw"
+            && baseName != "dsnoop")
       {
         EnumerateDevice(list, name, desc ? desc : name, config);
       }

--- a/xbmc/cores/AudioEngine/Sinks/AESinkALSA.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkALSA.cpp
@@ -933,7 +933,7 @@ void CAESinkALSA::EnumerateDevice(AEDeviceInfoList &list, const std::string &dev
               /* only trust badHDMI (= unconnected or non-existent port) on Intel
                * and NVIDIA where it has been confirmed to work, show the empty
                * port on other systems */
-              if (info.m_displayName.compare(0, 9, "HDA Intel") || info.m_displayName.compare(0, 10, "HDA NVidia"))
+              if (info.m_displayName.compare(0, 9, "HDA Intel") == 0 || info.m_displayName.compare(0, 10, "HDA NVidia") == 0)
               {
                 /* unconnected HDMI port */
                 CLog::Log(LOGDEBUG, "CAESinkALSA - Skipping HDMI device \"%s\" as it has no ELD data", device.c_str());

--- a/xbmc/cores/AudioEngine/Sinks/AESinkALSA.h
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkALSA.h
@@ -79,7 +79,7 @@ private:
   static bool OpenPCMDevice(const std::string &name, const std::string &params, int channels, snd_pcm_t **pcmp, snd_config_t *lconf, bool preferDmixStereo = false);
 
   static AEDeviceType AEDeviceTypeFromName(const std::string &name);
-  static void GetParamFromName(const std::string &name, const std::string &param, std::string &value);
+  static std::string GetParamFromName(const std::string &name, const std::string &param);
   static void EnumerateDevice(AEDeviceInfoList &list, const std::string &device, const std::string &description, snd_config_t *config);
   static bool SoundDeviceExists(const std::string& device);
   static bool GetELD(snd_hctl_t *hctl, int device, CAEDeviceInfo& info, bool& badHDMI);

--- a/xbmc/cores/AudioEngine/Sinks/AESinkALSA.h
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkALSA.h
@@ -78,6 +78,7 @@ private:
   static bool TryDeviceWithParams(const std::string &name, const std::string &params, snd_pcm_t **pcmp, snd_config_t *lconf);
   static bool OpenPCMDevice(const std::string &name, const std::string &params, int channels, snd_pcm_t **pcmp, snd_config_t *lconf, bool preferDmixStereo = false);
 
+  static AEDeviceType AEDeviceTypeFromName(const std::string &name);
   static void GetParamFromName(const std::string &name, const std::string &param, std::string &value);
   static void EnumerateDevice(AEDeviceInfoList &list, const std::string &device, const std::string &description, snd_config_t *config);
   static bool SoundDeviceExists(const std::string& device);

--- a/xbmc/cores/AudioEngine/Utils/AEBitstreamPacker.cpp
+++ b/xbmc/cores/AudioEngine/Utils/AEBitstreamPacker.cpp
@@ -58,6 +58,7 @@ void CAEBitstreamPacker::Pack(CAEStreamInfo &info, uint8_t* data, int size)
       PackDTSHD (info, data, size);
       break;
 
+    case CAEStreamInfo::STREAM_TYPE_DTSHD_CORE:
     case CAEStreamInfo::STREAM_TYPE_DTS_512:
       m_dataSize = CAEPackIEC61937::PackDTS_512(data, size, m_packedBuffer, info.IsLittleEndian());
       break;

--- a/xbmc/cores/AudioEngine/Utils/AEWAVLoader.cpp
+++ b/xbmc/cores/AudioEngine/Utils/AEWAVLoader.cpp
@@ -27,6 +27,7 @@
 #include "utils/EndianSwap.h"
 #include "filesystem/FileFactory.h"
 #include "filesystem/IFile.h"
+#include "URL.h"
 #include <samplerate.h>
 
 #include "AEConvert.h"

--- a/xbmc/cores/DllLoader/DllLoaderContainer.cpp
+++ b/xbmc/cores/DllLoader/DllLoaderContainer.cpp
@@ -32,6 +32,7 @@
 #include "utils/URIUtils.h"
 #include "utils/StringUtils.h"
 #include "utils/log.h"
+#include "URL.h"
 
 #define ENV_PARTIAL_PATH "special://xbmcbin/system/;" \
                  "special://xbmcbin/system/players/mplayer/;" \

--- a/xbmc/cores/VideoRenderers/OverlayRendererUtil.cpp
+++ b/xbmc/cores/VideoRenderers/OverlayRendererUtil.cpp
@@ -24,7 +24,6 @@
 #include "cores/dvdplayer/DVDCodecs/Overlay/DVDOverlayImage.h"
 #include "cores/dvdplayer/DVDCodecs/Overlay/DVDOverlaySpu.h"
 #include "cores/dvdplayer/DVDCodecs/Overlay/DVDOverlaySSA.h"
-#include "Application.h"
 #include "windowing/WindowingFactory.h"
 
 namespace OVERLAY {

--- a/xbmc/cores/VideoRenderers/RenderManager.cpp
+++ b/xbmc/cores/VideoRenderers/RenderManager.cpp
@@ -31,6 +31,7 @@
 #include "utils/log.h"
 
 #include "Application.h"
+#include "ApplicationMessenger.h"
 #include "settings/Settings.h"
 #include "settings/GUISettings.h"
 #include "settings/AdvancedSettings.h"
@@ -253,7 +254,7 @@ bool CXBMCRenderManager::Configure(unsigned int width, unsigned int height, unsi
     if( flags & CONF_FLAGS_FULLSCREEN )
     {
       lock.Leave();
-      g_application.getApplicationMessenger().SwitchToFullscreen();
+      CApplicationMessenger::Get().SwitchToFullscreen();
       lock.Enter();
     }
     m_pRenderer->Update(false);
@@ -372,7 +373,7 @@ bool CXBMCRenderManager::Flush()
   {
     ThreadMessage msg = {TMSG_RENDERER_FLUSH};
     m_flushEvent.Reset();
-    g_application.getApplicationMessenger().SendMessage(msg, false);
+    CApplicationMessenger::Get().SendMessage(msg, false);
     if (!m_flushEvent.WaitMSec(1000))
     {
       CLog::Log(LOGERROR, "%s - timed out waiting for renderer to flush", __FUNCTION__);

--- a/xbmc/cores/dvdplayer/DVDAudio.cpp
+++ b/xbmc/cores/dvdplayer/DVDAudio.cpp
@@ -22,7 +22,6 @@
 #include "threads/SingleLock.h"
 #include "utils/log.h"
 #include "DVDAudio.h"
-#include "Util.h"
 #include "DVDClock.h"
 #include "DVDCodecs/DVDCodecs.h"
 #include "DVDPlayerAudio.h"

--- a/xbmc/cores/dvdplayer/DVDDemuxSPU.cpp
+++ b/xbmc/cores/dvdplayer/DVDDemuxSPU.cpp
@@ -20,7 +20,6 @@
  */
 
 #include "DVDDemuxSPU.h"
-#include "Util.h"
 #include "DVDClock.h"
 #include "utils/log.h"
 

--- a/xbmc/cores/dvdplayer/DVDFileInfo.cpp
+++ b/xbmc/cores/dvdplayer/DVDFileInfo.cpp
@@ -187,8 +187,7 @@ bool CDVDFileInfo::ExtractThumb(const CStdString &strPath, CTextureDetails &deta
         DVDVideoPicture picture;
 
         // num streams * 80 frames, should get a valid frame, if not abort.
-        int packetsToTry = 80;
-        int abort_index = pDemuxer->GetNrOfStreams() * packetsToTry;
+        int abort_index = pDemuxer->GetNrOfStreams() * 80;
         do
         {
           pPacket = pDemuxer->Read();

--- a/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStream.h
+++ b/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStream.h
@@ -23,7 +23,7 @@
 
 #include <string>
 #include "utils/BitstreamStats.h"
-#include "filesystem/IFile.h"
+#include "filesystem/IFileTypes.h"
 
 #include "FileItem.h"
 

--- a/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamBluray.cpp
+++ b/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamBluray.cpp
@@ -641,7 +641,7 @@ void CDVDInputStreamBluray::OverlayCallback(const BD_OVERLAY * const ov)
     return;
   }
 
-  group->iPTSStartTime = ov->pts;
+  group->iPTSStartTime = (double) ov->pts;
   group->iPTSStopTime  = 0;
 
   if (ov->plane > 1)

--- a/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamBluray.cpp
+++ b/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamBluray.cpp
@@ -32,6 +32,7 @@
 #include "filesystem/File.h"
 #include "filesystem/Directory.h"
 #include "DllLibbluray.h"
+#include "URL.h"
 
 #define LIBBLURAY_BYTESEEK 0
 

--- a/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamFile.cpp
+++ b/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamFile.cpp
@@ -21,6 +21,7 @@
 
 #include "DVDInputStreamFile.h"
 #include "filesystem/File.h"
+#include "filesystem/IFile.h"
 #include "utils/log.h"
 #include "utils/URIUtils.h"
 

--- a/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamNavigator.cpp
+++ b/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamNavigator.cpp
@@ -20,7 +20,6 @@
  */
 
 #include "DVDInputStreamNavigator.h"
-#include "Util.h"
 #include "utils/LangCodeExpander.h"
 #include "../DVDDemuxSPU.h"
 #include "DVDStateSerializer.h"

--- a/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamNavigator.cpp
+++ b/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamNavigator.cpp
@@ -27,7 +27,6 @@
 #include "LangInfo.h"
 #include "utils/log.h"
 #include "guilib/Geometry.h"
-#include "filesystem/IFile.h"
 #if defined(TARGET_DARWIN)
 #include "CocoaInterface.h"
 #endif

--- a/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamRTMP.cpp
+++ b/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamRTMP.cpp
@@ -29,7 +29,6 @@
 #ifdef HAS_LIBRTMP
 #include "settings/AdvancedSettings.h"
 #include "DVDInputStreamRTMP.h"
-#include "filesystem/IFile.h"
 #include "threads/SingleLock.h"
 #include "utils/log.h"
 #include "utils/Variant.h"

--- a/xbmc/cores/dvdplayer/DVDPlayerAudio.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayerAudio.cpp
@@ -232,7 +232,9 @@ void CDVDPlayerAudio::OpenStream( CDVDStreamInfo &hints, CDVDAudioCodec* codec )
   m_started = false;
 
   m_synctype = SYNC_DISCON;
-  m_setsynctype = g_guiSettings.GetInt("videoplayer.synctype");
+  m_setsynctype = SYNC_DISCON;
+  if (g_guiSettings.GetBool("videoplayer.usedisplayasclock"))
+    m_setsynctype = g_guiSettings.GetInt("videoplayer.synctype");
   m_prevsynctype = -1;
 
   m_error = 0;

--- a/xbmc/cores/dvdplayer/DVDPlayerVideo.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayerVideo.cpp
@@ -35,7 +35,6 @@
 #include "DVDCodecs/Video/DVDVideoCodecFFmpeg.h"
 #include "DVDDemuxers/DVDDemux.h"
 #include "DVDDemuxers/DVDDemuxUtils.h"
-#include "../../Util.h"
 #include "DVDOverlayRenderer.h"
 #include "DVDPerformanceCounter.h"
 #include "DVDCodecs/DVDCodecs.h"

--- a/xbmc/cores/dvdplayer/DVDSubtitles/DVDFactorySubtitle.cpp
+++ b/xbmc/cores/dvdplayer/DVDSubtitles/DVDFactorySubtitle.cpp
@@ -29,7 +29,6 @@
 #include "DVDSubtitleParserSami.h"
 #include "DVDSubtitleParserSSA.h"
 #include "DVDSubtitleParserVplayer.h"
-#include "Util.h"
 #include "utils/log.h"
 
 using namespace std;

--- a/xbmc/cores/dvdplayer/DVDTSCorrection.cpp
+++ b/xbmc/cores/dvdplayer/DVDTSCorrection.cpp
@@ -19,11 +19,12 @@
  *
  */
 
-#include "Util.h"
 #include "DVDTSCorrection.h"
 #include "DVDClock.h"
 #include "DVDCodecs/DVDCodecUtils.h"
 #include "utils/log.h"
+
+#include <cmath>
 
 #define MAXERR DVD_MSEC_TO_TIME(2.5)
 

--- a/xbmc/cores/dvdplayer/DVDTSCorrection.h
+++ b/xbmc/cores/dvdplayer/DVDTSCorrection.h
@@ -23,6 +23,8 @@
 
 #include <vector>
 
+#include "utils/StdString.h"
+
 #define DIFFRINGSIZE 120
 
 class CPullupCorrection

--- a/xbmc/cores/dvdplayer/Edl.cpp
+++ b/xbmc/cores/dvdplayer/Edl.cpp
@@ -28,6 +28,7 @@
 #include "utils/log.h"
 #include "utils/XBMCTinyXML.h"
 #include "PlatformDefs.h"
+#include "URL.h"
 
 extern "C"
 {

--- a/xbmc/cores/dvdplayer/Edl.h
+++ b/xbmc/cores/dvdplayer/Edl.h
@@ -25,7 +25,6 @@
 #include <vector>
 #include <stdint.h>
 #include "utils/StdString.h"
-#include "URL.h"
 
 class CEdl
 {

--- a/xbmc/cores/paplayer/DVDPlayerCodec.cpp
+++ b/xbmc/cores/paplayer/DVDPlayerCodec.cpp
@@ -20,7 +20,6 @@
  */
 
 #include "DVDPlayerCodec.h"
-#include "Util.h"
 #include "cores/AudioEngine/Utils/AEUtil.h"
 
 #include "cores/dvdplayer/DVDInputStreams/DVDFactoryInputStream.h"

--- a/xbmc/cores/paplayer/DVDPlayerCodec.cpp
+++ b/xbmc/cores/paplayer/DVDPlayerCodec.cpp
@@ -29,6 +29,7 @@
 #include "cores/dvdplayer/DVDCodecs/DVDFactoryCodec.h"
 #include "utils/log.h"
 #include "settings/GUISettings.h"
+#include "URL.h"
 
 #include "AudioDecoder.h"
 

--- a/xbmc/cores/paplayer/PAPlayer.cpp
+++ b/xbmc/cores/paplayer/PAPlayer.cpp
@@ -21,7 +21,6 @@
 
 #include "PAPlayer.h"
 #include "CodecFactory.h"
-#include "GUIInfoManager.h"
 #include "FileItem.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/GUISettings.h"

--- a/xbmc/cores/paplayer/PAPlayer.cpp
+++ b/xbmc/cores/paplayer/PAPlayer.cpp
@@ -22,7 +22,6 @@
 #include "PAPlayer.h"
 #include "CodecFactory.h"
 #include "GUIInfoManager.h"
-#include "Application.h"
 #include "FileItem.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/GUISettings.h"

--- a/xbmc/cores/paplayer/TimidityCodec.cpp
+++ b/xbmc/cores/paplayer/TimidityCodec.cpp
@@ -20,6 +20,7 @@
  */
 
 #include "TimidityCodec.h"
+#include "URL.h"
 #include "../DllLoader/LibraryLoader.h"
 #include "../DllLoader/SoLoader.h"
 #include "../DllLoader/DllLoader.h"

--- a/xbmc/dbwrappers/Database.cpp
+++ b/xbmc/dbwrappers/Database.cpp
@@ -20,7 +20,6 @@
  */
 
 #include "Database.h"
-#include "Util.h"
 #include "settings/Settings.h"
 #include "settings/AdvancedSettings.h"
 #include "utils/Crc32.h"

--- a/xbmc/dialogs/GUIDialogCache.cpp
+++ b/xbmc/dialogs/GUIDialogCache.cpp
@@ -21,7 +21,7 @@
  
 #include "threads/SystemClock.h"
 #include "GUIDialogCache.h"
-#include "Application.h"
+#include "ApplicationMessenger.h"
 #include "guilib/GUIWindowManager.h"
 #include "dialogs/GUIDialogProgress.h"
 #include "guilib/LocalizeStrings.h"
@@ -56,7 +56,7 @@ void CGUIDialogCache::Close(bool bForceClose)
   // we cannot wait for the app thread to process the close message
   // as this might happen during player startup which leads to a deadlock
   if (m_pDlg->IsDialogRunning())
-    g_application.getApplicationMessenger().Close(m_pDlg,bForceClose,false);
+    CApplicationMessenger::Get().Close(m_pDlg,bForceClose,false);
 
   //Set stop, this will kill this object, when thread stops  
   CThread::m_bStop = true;

--- a/xbmc/dialogs/GUIDialogContextMenu.cpp
+++ b/xbmc/dialogs/GUIDialogContextMenu.cpp
@@ -44,6 +44,7 @@
 #include "guilib/LocalizeStrings.h"
 #include "TextureCache.h"
 #include "video/windows/GUIWindowVideoBase.h"
+#include "URL.h"
 
 #ifdef _WIN32
 #include "WIN32Util.h"

--- a/xbmc/dialogs/GUIDialogFileBrowser.cpp
+++ b/xbmc/dialogs/GUIDialogFileBrowser.cpp
@@ -44,6 +44,7 @@
 #include "settings/GUISettings.h"
 #include "guilib/LocalizeStrings.h"
 #include "utils/log.h"
+#include "URL.h"
 
 using namespace XFILE;
 

--- a/xbmc/dialogs/GUIDialogKeyboard.cpp
+++ b/xbmc/dialogs/GUIDialogKeyboard.cpp
@@ -31,10 +31,11 @@
 #include "GUIPassword.h"
 #include "utils/md5.h"
 #include "utils/TimeUtils.h"
-#include "Application.h"
+#include "ApplicationMessenger.h"
 #include "settings/AdvancedSettings.h"
 #include "guilib/LocalizeStrings.h"
 #include "interfaces/AnnouncementManager.h"
+#include "utils/CharsetConverter.h"
 
 // Symbol mapping (based on MS virtual keyboard - may need improving)
 static char symbol_map[37] = ")!@#$%^&*([]{}-_=+;:\'\",.<>/?\\|`~    ";
@@ -554,7 +555,7 @@ bool CGUIDialogKeyboard::ShowAndGetInput(CStdString& aTextString, const CVariant
   pKeyboard->SetText(aTextString);
   // do this using a thread message to avoid render() conflicts
   ThreadMessage tMsg = {TMSG_DIALOG_DOMODAL, WINDOW_DIALOG_KEYBOARD, g_windowManager.GetActiveWindow()};
-  g_application.getApplicationMessenger().SendMessage(tMsg, true);
+  CApplicationMessenger::Get().SendMessage(tMsg, true);
   pKeyboard->Close();
 
   // If have text - update this.

--- a/xbmc/dialogs/GUIDialogMediaSource.cpp
+++ b/xbmc/dialogs/GUIDialogMediaSource.cpp
@@ -34,6 +34,7 @@
 #include "settings/GUISettings.h"
 #include "guilib/LocalizeStrings.h"
 #include "PasswordManager.h"
+#include "URL.h"
 
 using namespace std;
 using namespace XFILE;

--- a/xbmc/filesystem/AddonsDirectory.cpp
+++ b/xbmc/filesystem/AddonsDirectory.cpp
@@ -32,6 +32,7 @@
 #include "guilib/TextureManager.h"
 #include "File.h"
 #include "utils/URIUtils.h"
+#include "URL.h"
 
 using namespace ADDON;
 

--- a/xbmc/filesystem/File.cpp
+++ b/xbmc/filesystem/File.cpp
@@ -19,6 +19,7 @@
 */
 
 #include "File.h"
+#include "IFile.h"
 #include "FileFactory.h"
 #include "Application.h"
 #include "DirectoryCache.h"
@@ -28,6 +29,7 @@
 #include "utils/URIUtils.h"
 #include "utils/BitstreamStats.h"
 #include "Util.h"
+#include "URL.h"
 
 #include "commons/Exception.h"
 
@@ -393,6 +395,13 @@ bool CFile::Exists(const CStdString& strFileName, bool bUseCache /* = true */)
 int CFile::Stat(struct __stat64 *buffer)
 {
   return m_pFile->Stat(buffer);
+}
+
+bool CFile::SkipNext()
+{
+  if (m_pFile)
+    return m_pFile->SkipNext();
+  return false;
 }
 
 int CFile::Stat(const CStdString& strFileName, struct __stat64* buffer)
@@ -763,6 +772,13 @@ int CFile::IoControl(EIoControl request, void* param)
   }
 
   return result;
+}
+
+int CFile::GetChunkSize()
+{
+  if (m_pFile)
+    return m_pFile->GetChunkSize();
+  return 0;
 }
 //*********************************************************************************************
 //*************** Stream IO for CFile objects *************************************************

--- a/xbmc/filesystem/File.h
+++ b/xbmc/filesystem/File.h
@@ -30,14 +30,18 @@
 #endif // _MSC_VER > 1000
 
 #include <iostream>
-#include "IFile.h"
 #include "utils/StdString.h"
+#include "IFileTypes.h"
+#include "PlatformDefs.h"
 
 class BitstreamStats;
 class CURL;
 
 namespace XFILE
 {
+
+class IFile;
+
 class IFileCallback
 {
 public:
@@ -78,7 +82,7 @@ public:
   int64_t GetPosition();
   int64_t GetLength();
   void Close();
-  int GetChunkSize() {if (m_pFile) return m_pFile->GetChunkSize(); return 0;}
+  int GetChunkSize();
 
   // will return a size, that is aligned to chunk size
   // but always greater or equal to the file's chunk size
@@ -90,7 +94,7 @@ public:
       return minimum;
   }
 
-  bool SkipNext(){if (m_pFile) return m_pFile->SkipNext(); return false;}
+  bool SkipNext();
   BitstreamStats* GetBitstreamStats() { return m_bitStreamStats; }
 
   int IoControl(EIoControl request, void* param);

--- a/xbmc/filesystem/FileReaderFile.h
+++ b/xbmc/filesystem/FileReaderFile.h
@@ -20,6 +20,7 @@
 */
 
 #include "File.h"
+#include "IFile.h"
 
 namespace XFILE
 {

--- a/xbmc/filesystem/HTSPDirectory.h
+++ b/xbmc/filesystem/HTSPDirectory.h
@@ -23,10 +23,10 @@
 #include "threads/Thread.h"
 #include "threads/CriticalSection.h"
 #include "threads/Event.h"
-#include "URL.h"
 #include "HTSPSession.h"
 #include "boost/shared_ptr.hpp"
 
+class CURL;
 class CFileItem; typedef boost::shared_ptr<CFileItem> CFileItemPtr;
 
 namespace HTSP

--- a/xbmc/filesystem/IFile.cpp
+++ b/xbmc/filesystem/IFile.cpp
@@ -19,6 +19,7 @@
 */
 
 #include "IFile.h"
+#include "URL.h"
 #include <cstring>
 #include <errno.h>
 
@@ -87,4 +88,14 @@ bool IFile::ReadString(char *szLine, int iLineLength)
     }
   }
   return true;
+}
+
+CRedirectException::CRedirectException() : 
+  m_pNewFileImp(NULL), m_pNewUrl(NULL)
+{
+}
+
+CRedirectException::CRedirectException(IFile *pNewFileImp, CURL *pNewUrl) :
+  m_pNewFileImp(pNewFileImp), m_pNewUrl(pNewUrl) 
+{
 }

--- a/xbmc/filesystem/IFile.h
+++ b/xbmc/filesystem/IFile.h
@@ -32,11 +32,13 @@
 #include "PlatformDefs.h" // for __stat64
 #endif
 
-#include "URL.h"
-
 #include <stdio.h>
 #include <stdint.h>
 #include <sys/stat.h>
+
+#include "utils/StdString.h"
+
+class CURL;
 
 namespace XFILE
 {
@@ -107,12 +109,9 @@ public:
   IFile *m_pNewFileImp;
   CURL  *m_pNewUrl;
 
-  CRedirectException() : m_pNewFileImp(NULL), m_pNewUrl(NULL) { }
+  CRedirectException();
   
-  CRedirectException(IFile *pNewFileImp, CURL *pNewUrl=NULL) 
-  : m_pNewFileImp(pNewFileImp)
-  , m_pNewUrl(pNewUrl) 
-  { }
+  CRedirectException(IFile *pNewFileImp, CURL *pNewUrl=NULL);
 };
 
 }

--- a/xbmc/filesystem/IFile.h
+++ b/xbmc/filesystem/IFile.h
@@ -37,32 +37,12 @@
 #include <sys/stat.h>
 
 #include "utils/StdString.h"
+#include "IFileTypes.h"
 
 class CURL;
 
 namespace XFILE
 {
-
-struct SNativeIoControl
-{
-  int   request;
-  void* param;
-};
-
-struct SCacheStatus
-{
-  uint64_t forward;  /**< number of bytes cached forward of current position */
-  unsigned maxrate;  /**< maximum number of bytes per second cache is allowed to fill */
-  unsigned currate;  /**< average read rate from source file since last position change */
-  bool     full;     /**< is the cache full */
-};
-
-typedef enum {
-  IOCTRL_NATIVE        = 1, /**< SNativeIoControl structure, containing what should be passed to native ioctrl */
-  IOCTRL_SEEK_POSSIBLE = 2, /**< return 0 if known not to work, 1 if it should work */
-  IOCTRL_CACHE_STATUS  = 3, /**< SCacheStatus structure */
-  IOCTRL_CACHE_SETRATE = 4, /**< unsigned int with speed limit for caching in bytes per second */
-} EIoControl;
 
 class IFile
 {
@@ -117,5 +97,3 @@ public:
 }
 
 #endif // !defined(AFX_IFILE_H__7EE73AC7_36BC_4822_93FF_44F3B0C766F6__INCLUDED_)
-
-

--- a/xbmc/filesystem/IFileTypes.h
+++ b/xbmc/filesystem/IFileTypes.h
@@ -1,0 +1,48 @@
+
+/*
+ *      Copyright (C) 2005-2012 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
+#pragma once
+
+namespace XFILE
+{
+
+struct SNativeIoControl
+{
+  int   request;
+  void* param;
+};
+
+struct SCacheStatus
+{
+  uint64_t forward;  /**< number of bytes cached forward of current position */
+  unsigned maxrate;  /**< maximum number of bytes per second cache is allowed to fill */
+  unsigned currate;  /**< average read rate from source file since last position change */
+  bool     full;     /**< is the cache full */
+};
+
+typedef enum {
+  IOCTRL_NATIVE        = 1, /**< SNativeIoControl structure, containing what should be passed to native ioctrl */
+  IOCTRL_SEEK_POSSIBLE = 2, /**< return 0 if known not to work, 1 if it should work */
+  IOCTRL_CACHE_STATUS  = 3, /**< SCacheStatus structure */
+  IOCTRL_CACHE_SETRATE = 4, /**< unsigned int with speed limit for caching in bytes per second */
+} EIoControl;
+
+}

--- a/xbmc/filesystem/ImageFile.h
+++ b/xbmc/filesystem/ImageFile.h
@@ -21,6 +21,7 @@
  */
 
 #include "File.h"
+#include "IFile.h"
 
 namespace XFILE
 {

--- a/xbmc/filesystem/MultiPathFile.h
+++ b/xbmc/filesystem/MultiPathFile.h
@@ -21,6 +21,7 @@
  */
 
 #include "File.h"
+#include "IFile.h"
 
 namespace XFILE
 {

--- a/xbmc/filesystem/MusicDatabaseFile.h
+++ b/xbmc/filesystem/MusicDatabaseFile.h
@@ -20,6 +20,7 @@
  *
  */
 
+#include "IFile.h"
 #include "File.h"
 
 namespace XFILE

--- a/xbmc/filesystem/PipeFile.cpp
+++ b/xbmc/filesystem/PipeFile.cpp
@@ -23,6 +23,7 @@
 #include "threads/SingleLock.h"
 #include "PipesManager.h"
 #include "utils/StringUtils.h"
+#include "URL.h"
 
 using namespace XFILE;
 

--- a/xbmc/filesystem/PluginDirectory.cpp
+++ b/xbmc/filesystem/PluginDirectory.cpp
@@ -38,7 +38,7 @@
 #include "guilib/LocalizeStrings.h"
 #include "utils/log.h"
 #include "utils/TimeUtils.h"
-#include "Application.h"
+#include "ApplicationMessenger.h"
 
 using namespace XFILE;
 using namespace std;
@@ -539,7 +539,7 @@ bool CPluginDirectory::WaitOnScriptResult(const CStdString &scriptPath, const CS
     }
   }
   if (progressBar)
-    g_application.getApplicationMessenger().Close(progressBar, false, false);
+    CApplicationMessenger::Get().Close(progressBar, false, false);
 
   return !m_cancelled && m_success;
 }

--- a/xbmc/filesystem/PluginDirectory.cpp
+++ b/xbmc/filesystem/PluginDirectory.cpp
@@ -39,6 +39,7 @@
 #include "utils/log.h"
 #include "utils/TimeUtils.h"
 #include "ApplicationMessenger.h"
+#include "URL.h"
 
 using namespace XFILE;
 using namespace std;

--- a/xbmc/filesystem/RarFile.h
+++ b/xbmc/filesystem/RarFile.h
@@ -26,6 +26,7 @@
 #define FILERAR_H_
 
 #include "File.h"
+#include "IFile.h"
 #include "threads/Thread.h"
 #include "threads/Event.h"
 

--- a/xbmc/filesystem/SAPFile.cpp
+++ b/xbmc/filesystem/SAPFile.cpp
@@ -20,6 +20,7 @@
 #include "SAPFile.h"
 #include "SAPDirectory.h"
 #include "threads/SingleLock.h"
+#include "URL.h"
 
 #include <sys/stat.h>
 #include <vector>

--- a/xbmc/filesystem/SFTPFile.cpp
+++ b/xbmc/filesystem/SFTPFile.cpp
@@ -28,6 +28,7 @@
 #include "utils/TimeUtils.h"
 #include "utils/Variant.h"
 #include "Util.h"
+#include "URL.h"
 #include <fcntl.h>
 #include <sstream>
 

--- a/xbmc/filesystem/SFTPFile.h
+++ b/xbmc/filesystem/SFTPFile.h
@@ -24,7 +24,6 @@
 #include "system.h"
 #ifdef HAS_FILESYSTEM_SFTP
 #include "IFile.h"
-#include "URL.h"
 #include "FileItem.h"
 #include "threads/CriticalSection.h"
 
@@ -33,6 +32,8 @@
 #include <string>
 #include <map>
 #include <boost/shared_ptr.hpp>
+
+class CURL;
 
 #if LIBSSH_VERSION_INT < SSH_VERSION_INT(0,3,2)
 #define ssh_session SSH_SESSION

--- a/xbmc/filesystem/SlingboxFile.cpp
+++ b/xbmc/filesystem/SlingboxFile.cpp
@@ -26,6 +26,7 @@
 #include "settings/Settings.h"
 #include "utils/log.h"
 #include "utils/XMLUtils.h"
+#include "URL.h"
 
 using namespace XFILE;
 using namespace std;

--- a/xbmc/filesystem/SpecialProtocolFile.h
+++ b/xbmc/filesystem/SpecialProtocolFile.h
@@ -21,6 +21,7 @@
  */
 
 #include "File.h"
+#include "IFile.h"
 
 namespace XFILE
 {

--- a/xbmc/filesystem/UPnPFile.cpp
+++ b/xbmc/filesystem/UPnPFile.cpp
@@ -24,6 +24,7 @@
 #include "FileFactory.h"
 #include "FileItem.h"
 #include "utils/log.h"
+#include "URL.h"
 
 using namespace XFILE;
 

--- a/xbmc/filesystem/udf25.cpp
+++ b/xbmc/filesystem/udf25.cpp
@@ -391,7 +391,7 @@ static int file_seek(CFile* fp, int blocks)
   pos = fp->Seek((off64_t)blocks * (off64_t)DVD_VIDEO_LB_LEN, SEEK_SET);
 
   if(pos < 0) {
-    return pos;
+    return (int) pos;
   }
   /* assert pos % DVD_VIDEO_LB_LEN == 0 */
   return (int) (pos / DVD_VIDEO_LB_LEN);
@@ -1236,7 +1236,7 @@ long udf25::ReadFile(HANDLE hFile, unsigned char *pBuffer, long lSize)
   if( bdfile == NULL || pBuffer == NULL )
     return -1;
 
-  seek_sector = bdfile->seek_pos / DVD_VIDEO_LB_LEN;
+  seek_sector =(unsigned int) (bdfile->seek_pos / DVD_VIDEO_LB_LEN);
   seek_byte   = bdfile->seek_pos % DVD_VIDEO_LB_LEN;
 
   numsec = ( ( seek_byte + lSize ) / DVD_VIDEO_LB_LEN ) +
@@ -1363,7 +1363,7 @@ udf_dir_t *udf25::OpenDir( const char *subdir )
 
   result->dir_location = UDFFileBlockPos(bd_file->file, 0);
   result->dir_current  = UDFFileBlockPos(bd_file->file, 0);
-  result->dir_length   = bd_file->filesize;
+  result->dir_length   = (uint32_t) bd_file->filesize;
   UDFFreeFile(bd_file->file);
   free(bd_file);
 

--- a/xbmc/guilib/GUIAudioManager.cpp
+++ b/xbmc/guilib/GUIAudioManager.cpp
@@ -31,7 +31,6 @@
 #include "cores/AudioEngine/AEFactory.h"
 
 using namespace std;
-using namespace XFILE;
 
 CGUIAudioManager g_audioManager;
 

--- a/xbmc/guilib/GUIDialog.cpp
+++ b/xbmc/guilib/GUIDialog.cpp
@@ -27,6 +27,7 @@
 #include "threads/SingleLock.h"
 #include "utils/TimeUtils.h"
 #include "Application.h"
+#include "ApplicationMessenger.h"
 
 CGUIDialog::CGUIDialog(int id, const CStdString &xmlFile)
     : CGUIWindow(id, xmlFile)
@@ -208,7 +209,7 @@ void CGUIDialog::DoModal(int iWindowID /*= WINDOW_INVALID */, const CStdString &
   {
     // make sure graphics lock is not held
     CSingleExit leaveIt(g_graphicsContext);
-    g_application.getApplicationMessenger().DoModal(this, iWindowID, param);
+    CApplicationMessenger::Get().DoModal(this, iWindowID, param);
   }
   else
     DoModal_Internal(iWindowID, param);
@@ -220,7 +221,7 @@ void CGUIDialog::Show()
   {
     // make sure graphics lock is not held
     CSingleExit leaveIt(g_graphicsContext);
-    g_application.getApplicationMessenger().Show(this);
+    CApplicationMessenger::Get().Show(this);
   }
   else
     Show_Internal();

--- a/xbmc/guilib/GUIFontManager.cpp
+++ b/xbmc/guilib/GUIFontManager.cpp
@@ -33,6 +33,7 @@
 #include "utils/URIUtils.h"
 #include "utils/StringUtils.h"
 #include "windowing/WindowingFactory.h"
+#include "URL.h"
 
 using namespace std;
 

--- a/xbmc/guilib/GUIListContainer.cpp
+++ b/xbmc/guilib/GUIListContainer.cpp
@@ -21,7 +21,6 @@
 
 #include "GUIListContainer.h"
 #include "GUIListItem.h"
-#include "GUIInfoManager.h"
 #include "Key.h"
 
 CGUIListContainer::CGUIListContainer(int parentID, int controlID, float posX, float posY, float width, float height, ORIENTATION orientation, const CScroller& scroller, int preloadItems)

--- a/xbmc/guilib/GUIWindow.cpp
+++ b/xbmc/guilib/GUIWindow.cpp
@@ -41,6 +41,7 @@
 #include "utils/XMLUtils.h"
 #include "GUIAudioManager.h"
 #include "Application.h"
+#include "ApplicationMessenger.h"
 #include "utils/Variant.h"
 
 #ifdef HAS_PERFORMANCE_SAMPLE
@@ -365,7 +366,7 @@ void CGUIWindow::Close(bool forceClose /*= false*/, int nextWindowID /*= 0*/, bo
   {
     // make sure graphics lock is not held
     CSingleExit leaveIt(g_graphicsContext);
-    g_application.getApplicationMessenger().Close(this, forceClose, true, nextWindowID, enableSound);
+    CApplicationMessenger::Get().Close(this, forceClose, true, nextWindowID, enableSound);
   }
   else
     Close_Internal(forceClose, nextWindowID, enableSound);

--- a/xbmc/guilib/GUIWindowManager.cpp
+++ b/xbmc/guilib/GUIWindowManager.cpp
@@ -23,6 +23,7 @@
 #include "GUIAudioManager.h"
 #include "GUIDialog.h"
 #include "Application.h"
+#include "ApplicationMessenger.h"
 #include "GUIPassword.h"
 #include "GUIInfoManager.h"
 #include "threads/SingleLock.h"
@@ -342,7 +343,7 @@ void CGUIWindowManager::ActivateWindow(int iWindowID, const vector<CStdString>& 
   {
     // make sure graphics lock is not held
     CSingleExit leaveIt(g_graphicsContext);
-    g_application.getApplicationMessenger().ActivateWindow(iWindowID, params, swappingWindows);
+    CApplicationMessenger::Get().ActivateWindow(iWindowID, params, swappingWindows);
   }
   else
   {

--- a/xbmc/guilib/GraphicContext.cpp
+++ b/xbmc/guilib/GraphicContext.cpp
@@ -23,6 +23,7 @@
 #include "GraphicContext.h"
 #include "threads/SingleLock.h"
 #include "Application.h"
+#include "ApplicationMessenger.h"
 #include "settings/GUISettings.h"
 #include "settings/Settings.h"
 #include "settings/AdvancedSettings.h"

--- a/xbmc/guilib/TextureManager.cpp
+++ b/xbmc/guilib/TextureManager.cpp
@@ -33,6 +33,7 @@
 #endif
 #include "filesystem/File.h"
 #include "filesystem/Directory.h"
+#include "URL.h"
 #include <assert.h>
 
 using namespace std;

--- a/xbmc/interfaces/Builtins.cpp
+++ b/xbmc/interfaces/Builtins.cpp
@@ -22,6 +22,7 @@
 #include "system.h"
 #include "utils/AlarmClock.h"
 #include "Application.h"
+#include "ApplicationMessenger.h"
 #include "Autorun.h"
 #include "Builtins.h"
 #include "input/ButtonTranslator.h"
@@ -245,35 +246,35 @@ int CBuiltins::Execute(const CStdString& execString)
 
   if (execute.Equals("reboot") || execute.Equals("restart"))  //Will reboot the xbox, aka cold reboot
   {
-    g_application.getApplicationMessenger().Restart();
+    CApplicationMessenger::Get().Restart();
   }
   else if (execute.Equals("shutdown"))
   {
-    g_application.getApplicationMessenger().Shutdown();
+    CApplicationMessenger::Get().Shutdown();
   }
   else if (execute.Equals("powerdown"))
   {
-    g_application.getApplicationMessenger().Powerdown();
+    CApplicationMessenger::Get().Powerdown();
   }
   else if (execute.Equals("restartapp"))
   {
-    g_application.getApplicationMessenger().RestartApp();
+    CApplicationMessenger::Get().RestartApp();
   }
   else if (execute.Equals("hibernate"))
   {
-    g_application.getApplicationMessenger().Hibernate();
+    CApplicationMessenger::Get().Hibernate();
   }
   else if (execute.Equals("suspend"))
   {
-    g_application.getApplicationMessenger().Suspend();
+    CApplicationMessenger::Get().Suspend();
   }
   else if (execute.Equals("quit"))
   {
-    g_application.getApplicationMessenger().Quit();
+    CApplicationMessenger::Get().Quit();
   }
   else if (execute.Equals("minimize"))
   {
-    g_application.getApplicationMessenger().Minimize();
+    CApplicationMessenger::Get().Minimize();
   }
   else if (execute.Equals("loadprofile"))
   {
@@ -313,7 +314,7 @@ int CBuiltins::Execute(const CStdString& execString)
   }
   else if (execute.Equals("reset")) //Will reset the xbox, aka soft reset
   {
-    g_application.getApplicationMessenger().Reset();
+    CApplicationMessenger::Get().Reset();
   }
   else if (execute.Equals("activatewindow") || execute.Equals("replacewindow"))
   {
@@ -388,13 +389,13 @@ int CBuiltins::Execute(const CStdString& execString)
 #endif
   else if (execute.Equals("system.exec"))
   {
-    g_application.getApplicationMessenger().Minimize();
-    g_application.getApplicationMessenger().ExecOS(parameter, false);
+    CApplicationMessenger::Get().Minimize();
+    CApplicationMessenger::Get().ExecOS(parameter, false);
   }
   else if (execute.Equals("system.execwait"))
   {
-    g_application.getApplicationMessenger().Minimize();
-    g_application.getApplicationMessenger().ExecOS(parameter, true);
+    CApplicationMessenger::Get().Minimize();
+    CApplicationMessenger::Get().ExecOS(parameter, true);
   }
   else if (execute.Equals("resolution"))
   {
@@ -712,7 +713,7 @@ int CBuiltins::Execute(const CStdString& execString)
       {
 #ifdef HAS_WEB_SERVER_BROADCAST
         if (m_pXbmcHttp && g_settings.m_HttpApiBroadcastLevel>=1)
-          g_application.getApplicationMessenger().HttpApi(g_application.m_pPlayer->IsRecording()?"broadcastlevel; RecordStopping;1":"broadcastlevel; RecordStarting;1");
+          CApplicationMessenger::Get().HttpApi(g_application.m_pPlayer->IsRecording()?"broadcastlevel; RecordStopping;1":"broadcastlevel; RecordStarting;1");
 #endif
         g_application.m_pPlayer->Record(!g_application.m_pPlayer->IsRecording());
       }
@@ -833,7 +834,7 @@ int CBuiltins::Execute(const CStdString& execString)
     {
       if(params.size() > 1 && params[1].Equals("showVolumeBar"))    
       {
-        g_application.getApplicationMessenger().ShowVolumeBar(oldVolume < volume);  
+        CApplicationMessenger::Get().ShowVolumeBar(oldVolume < volume);  
       }
     }
   }
@@ -1430,7 +1431,7 @@ int CBuiltins::Execute(const CStdString& execString)
     if (CButtonTranslator::TranslateActionString(params[0].c_str(), actionID))
     {
       int windowID = params.size() == 2 ? CButtonTranslator::TranslateWindow(params[1]) : WINDOW_INVALID;
-      g_application.getApplicationMessenger().SendAction(CAction(actionID), windowID);
+      CApplicationMessenger::Get().SendAction(CAction(actionID), windowID);
     }
   }
   else if (execute.Equals("setproperty") && params.size() >= 2)

--- a/xbmc/interfaces/Builtins.cpp
+++ b/xbmc/interfaces/Builtins.cpp
@@ -54,6 +54,7 @@
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
 #include "Util.h"
+#include "URL.h"
 
 #include "filesystem/PluginDirectory.h"
 #ifdef HAS_FILESYSTEM_RAR

--- a/xbmc/interfaces/http-api/HttpApi.cpp
+++ b/xbmc/interfaces/http-api/HttpApi.cpp
@@ -21,17 +21,17 @@ CStdString CHttpApi::MethodCall(CStdString &command, CStdString &parameter)
   int cnt=0;
 
   if (!parameter.IsEmpty())
-    g_application.getApplicationMessenger().HttpApi(command + "; " + parameter, true);
+    CApplicationMessenger::Get().HttpApi(command + "; " + parameter, true);
   else
-    g_application.getApplicationMessenger().HttpApi(command, true);
+    CApplicationMessenger::Get().HttpApi(command, true);
 
   //wait for response - max 20s
   Sleep(0);
-  CStdString response = g_application.getApplicationMessenger().GetResponse();
+  CStdString response = CApplicationMessenger::Get().GetResponse();
 
   while (response=="[No response yet]" && cnt++<200 && !g_application.m_bStop)
   {
-    response=g_application.getApplicationMessenger().GetResponse();
+    response=CApplicationMessenger::Get().GetResponse();
     CLog::Log(LOGDEBUG, "HttpApi: waiting %d", cnt);
     Sleep(100);
   }

--- a/xbmc/interfaces/http-api/Makefile
+++ b/xbmc/interfaces/http-api/Makefile
@@ -3,4 +3,4 @@ SRCS=HttpApi.cpp XBMChttp.cpp
 LIB=http-api.a
 
 include ../../../Makefile.include
-
+-include $(patsubst %.cpp,%.P,$(patsubst %.c,%.P,$(SRCS)))

--- a/xbmc/interfaces/http-api/XBMChttp.cpp
+++ b/xbmc/interfaces/http-api/XBMChttp.cpp
@@ -21,6 +21,7 @@
 #include "Util.h"
 #include "PlayListPlayer.h"
 #include "playlists/PlayList.h"
+#include "filesystem/CurlFile.h" 
 #include "filesystem/HDDirectory.h" 
 #include "filesystem/CDDADirectory.h"
 #include "filesystem/SpecialProtocol.h"

--- a/xbmc/interfaces/http-api/XBMChttp.cpp
+++ b/xbmc/interfaces/http-api/XBMChttp.cpp
@@ -11,6 +11,7 @@
 
 #include "threads/SystemClock.h"
 #include "Application.h"
+#include "ApplicationMessenger.h"
 #include "XBMCConfiguration.h"
 #include "XBMChttp.h"
 //#include "includes.h"
@@ -357,12 +358,12 @@ int CXbmcHttp::SetResponse(const CStdString &response)
   if (response.length()>=closeTag.length())
   {
     if ((response.Right(closeTag.length())!=closeTag) && closeFinalTag) 
-      return g_application.getApplicationMessenger().SetResponse(response+closeTag);
+      return CApplicationMessenger::Get().SetResponse(response+closeTag);
   }
   else 
     if (closeFinalTag)
-      return g_application.getApplicationMessenger().SetResponse(response+closeTag);
-  return g_application.getApplicationMessenger().SetResponse(response);
+      return CApplicationMessenger::Get().SetResponse(response+closeTag);
+  return CApplicationMessenger::Get().SetResponse(response);
 }
 
 int CXbmcHttp::displayDir(int numParas, CStdString paras[]) 
@@ -536,7 +537,7 @@ bool CXbmcHttp::LoadPlayList(CStdString strPath, int iPlaylist, bool clearList, 
   if ((playlist.size() == 1) && (autoStart))
   {
     // just 1 song? then play it (no need to have a playlist of 1 song)
-    g_application.getApplicationMessenger().MediaPlay(playlistItem->GetPath());
+    CApplicationMessenger::Get().MediaPlay(playlistItem->GetPath());
     return true;
   }
 
@@ -550,7 +551,7 @@ bool CXbmcHttp::LoadPlayList(CStdString strPath, int iPlaylist, bool clearList, 
     {
       g_playlistPlayer.SetCurrentPlaylist(iPlaylist);
       g_playlistPlayer.Reset();
-      g_application.getApplicationMessenger().PlayListPlayerPlay();
+      CApplicationMessenger::Get().PlayListPlayerPlay();
       return true;
     } 
     else
@@ -1825,7 +1826,7 @@ int CXbmcHttp::xbmcPlayerPlayFile(int numParas, CStdString paras[])
   }
   else
   {
-    g_application.getApplicationMessenger().MediaPlay(paras[0]);
+    CApplicationMessenger::Get().MediaPlay(paras[0]);
     if(g_application.IsPlaying())
       return SetResponse(openTag+"OK");
   }
@@ -2108,7 +2109,7 @@ int CXbmcHttp::xbmcAction(int numParas, CStdString paras[], int theAction)
         pSlideShow->OnAction(CAction(ACTION_PAUSE));
     }
     else
-      g_application.getApplicationMessenger().MediaPause();
+      CApplicationMessenger::Get().MediaPause();
     return SetResponse(openTag+"OK");
     break;
   case 2:
@@ -2119,7 +2120,7 @@ int CXbmcHttp::xbmcAction(int numParas, CStdString paras[], int theAction)
         pSlideShow->OnAction(CAction(ACTION_STOP));
     }
     else
-      g_application.getApplicationMessenger().MediaStop();
+      CApplicationMessenger::Get().MediaStop();
     return SetResponse(openTag+"OK");
     break;
   case 3:
@@ -2480,7 +2481,7 @@ int CXbmcHttp::xbmcShowPicture(int numParas, CStdString paras[])
   {
     if (!playableFile(paras[0]))
       return SetResponse(openTag+"Error:Unable to open file");
-    g_application.getApplicationMessenger().PictureShow(paras[0]);
+    CApplicationMessenger::Get().PictureShow(paras[0]);
     return SetResponse(openTag+"OK");
   }
 }
@@ -2505,7 +2506,7 @@ int CXbmcHttp::xbmcExecBuiltIn(int numParas, CStdString paras[])
     return SetResponse(openTag+"Error:Missing parameter");
   else
   {
-    g_application.getApplicationMessenger().ExecBuiltIn(paras[0]);
+    CApplicationMessenger::Get().ExecBuiltIn(paras[0]);
     return SetResponse(openTag+"OK");
   }
 }

--- a/xbmc/interfaces/http-api/XBMChttp.cpp
+++ b/xbmc/interfaces/http-api/XBMChttp.cpp
@@ -52,6 +52,7 @@
 #include "utils/log.h"
 #include "TextureCache.h"
 #include "ThumbLoader.h"
+#include "URL.h"
 
 #ifdef _WIN32
 extern "C" FILE *fopen_utf8(const char *_Filename, const char *_Mode);

--- a/xbmc/interfaces/json-rpc/ApplicationOperations.cpp
+++ b/xbmc/interfaces/json-rpc/ApplicationOperations.cpp
@@ -85,7 +85,7 @@ JSONRPC_STATUS CApplicationOperations::SetVolume(const CStdString &method, ITran
   else
     return InvalidParams;
 
-  g_application.getApplicationMessenger().ShowVolumeBar(up);
+  CApplicationMessenger::Get().ShowVolumeBar(up);
 
   return GetPropertyValue("volume", result);
 }
@@ -94,7 +94,7 @@ JSONRPC_STATUS CApplicationOperations::SetMute(const CStdString &method, ITransp
 {
   if ((parameterObject["mute"].isString() && parameterObject["mute"].asString().compare("toggle") == 0) ||
       (parameterObject["mute"].isBoolean() && parameterObject["mute"].asBoolean() != g_application.IsMuted()))
-    g_application.getApplicationMessenger().SendAction(CAction(ACTION_MUTE));
+    CApplicationMessenger::Get().SendAction(CAction(ACTION_MUTE));
   else if (!parameterObject["mute"].isBoolean() && !parameterObject["mute"].isString())
     return InvalidParams;
 
@@ -103,7 +103,7 @@ JSONRPC_STATUS CApplicationOperations::SetMute(const CStdString &method, ITransp
 
 JSONRPC_STATUS CApplicationOperations::Quit(const CStdString &method, ITransportLayer *transport, IClient *client, const CVariant &parameterObject, CVariant &result)
 {
-  g_application.getApplicationMessenger().Quit();
+  CApplicationMessenger::Get().Quit();
   return ACK;
 }
 

--- a/xbmc/interfaces/json-rpc/AudioLibrary.cpp
+++ b/xbmc/interfaces/json-rpc/AudioLibrary.cpp
@@ -29,7 +29,7 @@
 #include "music/Album.h"
 #include "music/Song.h"
 #include "music/Artist.h"
-#include "Application.h"
+#include "ApplicationMessenger.h"
 #include "filesystem/Directory.h"
 #include "filesystem/File.h"
 #include "settings/GUISettings.h"
@@ -415,7 +415,7 @@ JSONRPC_STATUS CAudioLibrary::Scan(const CStdString &method, ITransportLayer *tr
   else
     cmd.Format("updatelibrary(music, %s)", directory.c_str());
 
-  g_application.getApplicationMessenger().ExecBuiltIn(cmd);
+  CApplicationMessenger::Get().ExecBuiltIn(cmd);
   return ACK;
 }
 
@@ -429,13 +429,13 @@ JSONRPC_STATUS CAudioLibrary::Export(const CStdString &method, ITransportLayer *
       parameterObject["options"]["images"].asBoolean() ? "true" : "false",
       parameterObject["options"]["overwrite"].asBoolean() ? "true" : "false");
 
-  g_application.getApplicationMessenger().ExecBuiltIn(cmd);
+  CApplicationMessenger::Get().ExecBuiltIn(cmd);
   return ACK;
 }
 
 JSONRPC_STATUS CAudioLibrary::Clean(const CStdString &method, ITransportLayer *transport, IClient *client, const CVariant &parameterObject, CVariant &result)
 {
-  g_application.getApplicationMessenger().ExecBuiltIn("cleanlibrary(music)");
+  CApplicationMessenger::Get().ExecBuiltIn("cleanlibrary(music)");
   return ACK;
 }
 

--- a/xbmc/interfaces/json-rpc/FileItemHandler.cpp
+++ b/xbmc/interfaces/json-rpc/FileItemHandler.cpp
@@ -36,6 +36,7 @@
 #include "filesystem/File.h"
 #include "TextureCache.h"
 #include "ThumbLoader.h"
+#include "Util.h"
 
 using namespace MUSIC_INFO;
 using namespace JSONRPC;

--- a/xbmc/interfaces/json-rpc/GUIOperations.cpp
+++ b/xbmc/interfaces/json-rpc/GUIOperations.cpp
@@ -21,6 +21,7 @@
 
 #include "GUIOperations.h"
 #include "Application.h"
+#include "ApplicationMessenger.h"
 #include "GUIInfoManager.h"
 #include "guilib/GUIWindowManager.h"
 #include "dialogs/GUIDialogKaiToast.h"
@@ -76,7 +77,7 @@ JSONRPC_STATUS CGUIOperations::SetFullscreen(const CStdString &method, ITranspor
        parameterObject["fullscreen"].asString().compare("toggle") == 0) ||
       (parameterObject["fullscreen"].isBoolean() &&
        parameterObject["fullscreen"].asBoolean() != g_application.IsFullScreen()))
-    g_application.getApplicationMessenger().SendAction(CAction(ACTION_SHOW_GUI));
+    CApplicationMessenger::Get().SendAction(CAction(ACTION_SHOW_GUI));
   else if (!parameterObject["fullscreen"].isBoolean() && !parameterObject["fullscreen"].isString())
     return InvalidParams;
 

--- a/xbmc/interfaces/json-rpc/InputOperations.cpp
+++ b/xbmc/interfaces/json-rpc/InputOperations.cpp
@@ -21,6 +21,7 @@
 
 #include "InputOperations.h"
 #include "Application.h"
+#include "ApplicationMessenger.h"
 #include "guilib/GUIAudioManager.h"
 #include "guilib/GUIWindow.h"
 #include "guilib/GUIWindowManager.h"
@@ -79,7 +80,7 @@ JSONRPC_STATUS CInputOperations::SendAction(int actionID, bool wakeScreensaver /
   {
     g_application.ResetSystemIdleTimer();
     g_audioManager.PlayActionSound(actionID);
-    g_application.getApplicationMessenger().SendAction(CAction(actionID), WINDOW_INVALID, waitResult);
+    CApplicationMessenger::Get().SendAction(CAction(actionID), WINDOW_INVALID, waitResult);
   }
   return ACK;
 }
@@ -87,7 +88,7 @@ JSONRPC_STATUS CInputOperations::SendAction(int actionID, bool wakeScreensaver /
 JSONRPC_STATUS CInputOperations::activateWindow(int windowID)
 {
   if(!handleScreenSaver())
-    g_application.getApplicationMessenger().ActivateWindow(windowID, std::vector<CStdString>(), false);
+    CApplicationMessenger::Get().ActivateWindow(windowID, std::vector<CStdString>(), false);
 
   return ACK;
 }
@@ -105,7 +106,7 @@ JSONRPC_STATUS CInputOperations::SendText(const CStdString &method, ITransportLa
   CGUIMessage msg(GUI_MSG_SET_TEXT, 0, 0);
   msg.SetLabel(text);
   msg.SetParam1(parameterObject["done"].asBoolean() ? 1 : 0);
-  g_application.getApplicationMessenger().SendGUIMessage(msg, window->GetID());
+  CApplicationMessenger::Get().SendGUIMessage(msg, window->GetID());
   return ACK;
 }
 

--- a/xbmc/interfaces/json-rpc/Makefile
+++ b/xbmc/interfaces/json-rpc/Makefile
@@ -15,4 +15,4 @@ SRCS=ApplicationOperations.cpp \
 LIB=json-rpc.a
 
 include ../../../Makefile.include
-
+-include $(patsubst %.cpp,%.P,$(patsubst %.c,%.P,$(SRCS)))

--- a/xbmc/interfaces/json-rpc/PlayerOperations.cpp
+++ b/xbmc/interfaces/json-rpc/PlayerOperations.cpp
@@ -200,7 +200,7 @@ JSONRPC_STATUS CPlayerOperations::PlayPause(const CStdString &method, ITransport
       else
       {
         if (parameterObject["play"].asBoolean() == g_application.IsPaused())
-          g_application.getApplicationMessenger().MediaPause();
+          CApplicationMessenger::Get().MediaPause();
       }
       result["speed"] = g_application.IsPaused() ? 0 : g_application.GetPlaySpeed();
       return OK;
@@ -230,7 +230,7 @@ JSONRPC_STATUS CPlayerOperations::Stop(const CStdString &method, ITransportLayer
   {
     case Video:
     case Audio:
-      g_application.getApplicationMessenger().SendAction(CAction(ACTION_STOP));
+      CApplicationMessenger::Get().SendAction(CAction(ACTION_STOP));
       return ACK;
 
     case Picture:
@@ -476,7 +476,7 @@ JSONRPC_STATUS CPlayerOperations::Open(const CStdString &method, ITransportLayer
     {
       case PLAYLIST_MUSIC:
       case PLAYLIST_VIDEO:
-        g_application.getApplicationMessenger().MediaPlay(playlistid, (int)parameterObject["item"]["position"].asInteger());
+        CApplicationMessenger::Get().MediaPlay(playlistid, (int)parameterObject["item"]["position"].asInteger());
         OnPlaylistChanged();
         break;
 
@@ -540,7 +540,7 @@ JSONRPC_STATUS CPlayerOperations::Open(const CStdString &method, ITransportLayer
             list[0]->m_lStartOffset = (int)(ParseTimeInSeconds(optionResume) * 75.0);
         }
 
-        g_application.getApplicationMessenger().MediaPlay(list);
+        CApplicationMessenger::Get().MediaPlay(list);
       }
 
       return ACK;
@@ -558,7 +558,7 @@ JSONRPC_STATUS CPlayerOperations::GoPrevious(const CStdString &method, ITranspor
   {
     case Video:
     case Audio:
-      g_application.getApplicationMessenger().SendAction(CAction(ACTION_PREV_ITEM));
+      CApplicationMessenger::Get().SendAction(CAction(ACTION_PREV_ITEM));
       return ACK;
 
     case Picture:
@@ -577,7 +577,7 @@ JSONRPC_STATUS CPlayerOperations::GoNext(const CStdString &method, ITransportLay
   {
     case Video:
     case Audio:
-      g_application.getApplicationMessenger().SendAction(CAction(ACTION_NEXT_ITEM));
+      CApplicationMessenger::Get().SendAction(CAction(ACTION_NEXT_ITEM));
       return ACK;
 
     case Picture:
@@ -597,7 +597,7 @@ JSONRPC_STATUS CPlayerOperations::GoTo(const CStdString &method, ITransportLayer
   {
     case Video:
     case Audio:
-      g_application.getApplicationMessenger().PlayListPlayerPlay(position);
+      CApplicationMessenger::Get().PlayListPlayerPlay(position);
       break;
 
     case Picture:
@@ -617,7 +617,7 @@ JSONRPC_STATUS CPlayerOperations::Shuffle(const CStdString &method, ITransportLa
   {
     case Video:
     case Audio:
-      g_application.getApplicationMessenger().PlayListPlayerShuffle(GetPlaylist(GetPlayer(parameterObject["playerid"])), true);
+      CApplicationMessenger::Get().PlayListPlayerShuffle(GetPlaylist(GetPlayer(parameterObject["playerid"])), true);
       OnPlaylistChanged();
       break;
 
@@ -641,7 +641,7 @@ JSONRPC_STATUS CPlayerOperations::UnShuffle(const CStdString &method, ITransport
   {
     case Video:
     case Audio:
-      g_application.getApplicationMessenger().PlayListPlayerShuffle(GetPlaylist(GetPlayer(parameterObject["playerid"])), false);
+      CApplicationMessenger::Get().PlayListPlayerShuffle(GetPlaylist(GetPlayer(parameterObject["playerid"])), false);
       OnPlaylistChanged();
       break;
 
@@ -658,7 +658,7 @@ JSONRPC_STATUS CPlayerOperations::Repeat(const CStdString &method, ITransportLay
   {
     case Video:
     case Audio:
-      g_application.getApplicationMessenger().PlayListPlayerRepeat(GetPlaylist(GetPlayer(parameterObject["playerid"])), (REPEAT_STATE)ParseRepeatState(parameterObject["state"]));
+      CApplicationMessenger::Get().PlayListPlayerRepeat(GetPlaylist(GetPlayer(parameterObject["playerid"])), (REPEAT_STATE)ParseRepeatState(parameterObject["state"]));
       OnPlaylistChanged();
       break;
 
@@ -859,14 +859,14 @@ JSONRPC_STATUS CPlayerOperations::StartSlideshow(const std::string path, bool re
 
   CGUIMessage msg(GUI_MSG_START_SLIDESHOW, 0, 0, flags);
   msg.SetStringParam(path);
-  g_application.getApplicationMessenger().SendGUIMessage(msg, WINDOW_SLIDESHOW, true);
+  CApplicationMessenger::Get().SendGUIMessage(msg, WINDOW_SLIDESHOW, true);
 
   return ACK;
 }
 
 void CPlayerOperations::SendSlideshowAction(int actionID)
 {
-  g_application.getApplicationMessenger().SendAction(CAction(actionID), WINDOW_SLIDESHOW);
+  CApplicationMessenger::Get().SendAction(CAction(actionID), WINDOW_SLIDESHOW);
 }
 
 void CPlayerOperations::OnPlaylistChanged()

--- a/xbmc/interfaces/json-rpc/PlaylistOperations.cpp
+++ b/xbmc/interfaces/json-rpc/PlaylistOperations.cpp
@@ -25,7 +25,7 @@
 #include "Util.h"
 #include "guilib/GUIWindowManager.h"
 #include "GUIUserMessages.h"
-#include "Application.h"
+#include "ApplicationMessenger.h"
 #include "pictures/GUIWindowSlideShow.h"
 #include "pictures/PictureInfoTag.h"
 
@@ -80,7 +80,7 @@ JSONRPC_STATUS CPlaylistOperations::GetItems(const CStdString &method, ITranspor
   {
     case PLAYLIST_VIDEO:
     case PLAYLIST_MUSIC:
-      g_application.getApplicationMessenger().PlayListPlayerGetItems(playlist, list);
+      CApplicationMessenger::Get().PlayListPlayerGetItems(playlist, list);
       break;
 
     case PLAYLIST_PICTURE:
@@ -116,7 +116,7 @@ JSONRPC_STATUS CPlaylistOperations::Add(const CStdString &method, ITransportLaye
       if (!FillFileItemList(params["item"], list))
         return InvalidParams;
 
-      g_application.getApplicationMessenger().PlayListPlayerAdd(playlist, list);
+      CApplicationMessenger::Get().PlayListPlayerAdd(playlist, list);
 
       break;
 
@@ -163,7 +163,7 @@ JSONRPC_STATUS CPlaylistOperations::Insert(const CStdString &method, ITransportL
   if (!FillFileItemList(params["item"], list))
     return InvalidParams;
 
-  g_application.getApplicationMessenger().PlayListPlayerInsert(GetPlaylist(parameterObject["playlistid"]), list, (int)parameterObject["position"].asInteger());
+  CApplicationMessenger::Get().PlayListPlayerInsert(GetPlaylist(parameterObject["playlistid"]), list, (int)parameterObject["position"].asInteger());
 
   NotifyAll();
   return ACK;
@@ -179,7 +179,7 @@ JSONRPC_STATUS CPlaylistOperations::Remove(const CStdString &method, ITransportL
   if (g_playlistPlayer.GetCurrentPlaylist() == playlist && g_playlistPlayer.GetCurrentSong() == position)
     return InvalidParams;
 
-  g_application.getApplicationMessenger().PlayListPlayerRemove(playlist, position);
+  CApplicationMessenger::Get().PlayListPlayerRemove(playlist, position);
 
   NotifyAll();
   return ACK;
@@ -193,14 +193,14 @@ JSONRPC_STATUS CPlaylistOperations::Clear(const CStdString &method, ITransportLa
   {
     case PLAYLIST_MUSIC:
     case PLAYLIST_VIDEO:
-      g_application.getApplicationMessenger().PlayListPlayerClear(playlist);
+      CApplicationMessenger::Get().PlayListPlayerClear(playlist);
       break;
 
     case PLAYLIST_PICTURE:
        slideshow = (CGUIWindowSlideShow*)g_windowManager.GetWindow(WINDOW_SLIDESHOW);
        if (!slideshow)
          return FailedToExecute;
-       g_application.getApplicationMessenger().SendAction(CAction(ACTION_STOP), WINDOW_SLIDESHOW);
+       CApplicationMessenger::Get().SendAction(CAction(ACTION_STOP), WINDOW_SLIDESHOW);
        slideshow->Reset();
        break;
   }
@@ -215,7 +215,7 @@ JSONRPC_STATUS CPlaylistOperations::Swap(const CStdString &method, ITransportLay
   if (playlist == PLAYLIST_PICTURE)
     return FailedToExecute;
 
-  g_application.getApplicationMessenger().PlayListPlayerSwap(playlist, (int)parameterObject["position1"].asInteger(), (int)parameterObject["position2"].asInteger());
+  CApplicationMessenger::Get().PlayListPlayerSwap(playlist, (int)parameterObject["position1"].asInteger(), (int)parameterObject["position2"].asInteger());
 
   NotifyAll();
   return ACK;
@@ -267,7 +267,7 @@ JSONRPC_STATUS CPlaylistOperations::GetPropertyValue(int playlist, const CStdStr
     {
       case PLAYLIST_MUSIC:
       case PLAYLIST_VIDEO:
-        g_application.getApplicationMessenger().PlayListPlayerGetItems(playlist, list);
+        CApplicationMessenger::Get().PlayListPlayerGetItems(playlist, list);
         result = list.Size();
         break;
 

--- a/xbmc/interfaces/json-rpc/SystemOperations.cpp
+++ b/xbmc/interfaces/json-rpc/SystemOperations.cpp
@@ -20,7 +20,7 @@
  */
 
 #include "SystemOperations.h"
-#include "Application.h"
+#include "ApplicationMessenger.h"
 #include "interfaces/Builtins.h"
 #include "utils/Variant.h"
 #include "powermanagement/PowerManager.h"
@@ -55,7 +55,7 @@ JSONRPC_STATUS CSystemOperations::Shutdown(const CStdString &method, ITransportL
 {
   if (g_powerManager.CanPowerdown())
   {
-    g_application.getApplicationMessenger().Powerdown();
+    CApplicationMessenger::Get().Powerdown();
     return ACK;
   }
   else
@@ -66,7 +66,7 @@ JSONRPC_STATUS CSystemOperations::Suspend(const CStdString &method, ITransportLa
 {
   if (g_powerManager.CanSuspend())
   {
-    g_application.getApplicationMessenger().Suspend();
+    CApplicationMessenger::Get().Suspend();
     return ACK;
   }
   else
@@ -77,7 +77,7 @@ JSONRPC_STATUS CSystemOperations::Hibernate(const CStdString &method, ITransport
 {
   if (g_powerManager.CanHibernate())
   {
-    g_application.getApplicationMessenger().Hibernate();
+    CApplicationMessenger::Get().Hibernate();
     return ACK;
   }
   else
@@ -88,7 +88,7 @@ JSONRPC_STATUS CSystemOperations::Reboot(const CStdString &method, ITransportLay
 {
   if (g_powerManager.CanReboot())
   {
-    g_application.getApplicationMessenger().Restart();
+    CApplicationMessenger::Get().Restart();
     return ACK;
   }
   else

--- a/xbmc/interfaces/json-rpc/VideoLibrary.cpp
+++ b/xbmc/interfaces/json-rpc/VideoLibrary.cpp
@@ -20,7 +20,7 @@
  */
 
 #include "VideoLibrary.h"
-#include "Application.h"
+#include "ApplicationMessenger.h"
 #include "Util.h"
 #include "utils/URIUtils.h"
 #include "video/VideoDatabase.h"
@@ -509,7 +509,7 @@ JSONRPC_STATUS CVideoLibrary::Scan(const CStdString &method, ITransportLayer *tr
   else
     cmd.Format("updatelibrary(video, %s)", directory.c_str());
 
-  g_application.getApplicationMessenger().ExecBuiltIn(cmd);
+  CApplicationMessenger::Get().ExecBuiltIn(cmd);
   return ACK;
 }
 
@@ -524,13 +524,13 @@ JSONRPC_STATUS CVideoLibrary::Export(const CStdString &method, ITransportLayer *
       parameterObject["options"]["overwrite"].asBoolean() ? "true" : "false",
       parameterObject["options"]["actorthumbs"].asBoolean() ? "true" : "false");
 
-  g_application.getApplicationMessenger().ExecBuiltIn(cmd);
+  CApplicationMessenger::Get().ExecBuiltIn(cmd);
   return ACK;
 }
 
 JSONRPC_STATUS CVideoLibrary::Clean(const CStdString &method, ITransportLayer *transport, IClient *client, const CVariant &parameterObject, CVariant &result)
 {
-  g_application.getApplicationMessenger().ExecBuiltIn("cleanlibrary(video)");
+  CApplicationMessenger::Get().ExecBuiltIn("cleanlibrary(video)");
   return ACK;
 }
 

--- a/xbmc/interfaces/json-rpc/XBMCOperations.cpp
+++ b/xbmc/interfaces/json-rpc/XBMCOperations.cpp
@@ -20,7 +20,6 @@
  */
 
 #include "XBMCOperations.h"
-#include "Application.h"
 #include "ApplicationMessenger.h"
 #include "Util.h"
 #include "utils/Variant.h"
@@ -42,7 +41,7 @@ JSONRPC_STATUS CXBMCOperations::GetInfoLabels(const CStdString &method, ITranspo
 
   if (info.size() > 0)
   {
-    std::vector<CStdString> infoLabels = g_application.getApplicationMessenger().GetInfoLabels(info);
+    std::vector<CStdString> infoLabels = CApplicationMessenger::Get().GetInfoLabels(info);
     for (unsigned int i = 0; i < info.size(); i++)
     {
       if (i >= infoLabels.size())
@@ -83,7 +82,7 @@ JSONRPC_STATUS CXBMCOperations::GetInfoBooleans(const CStdString &method, ITrans
 
   if (info.size() > 0)
   {
-    std::vector<bool> infoLabels = g_application.getApplicationMessenger().GetInfoBooleans(info);
+    std::vector<bool> infoLabels = CApplicationMessenger::Get().GetInfoBooleans(info);
     for (unsigned int i = 0; i < info.size(); i++)
     {
       if (i >= infoLabels.size())

--- a/xbmc/interfaces/python/xbmcmodule/GUIPythonWindowDialog.cpp
+++ b/xbmc/interfaces/python/xbmcmodule/GUIPythonWindowDialog.cpp
@@ -21,7 +21,6 @@
 
 #include "GUIPythonWindowDialog.h"
 #include "guilib/GUIWindowManager.h"
-#include "Application.h"
 #include "threads/SingleLock.h"
 
 CGUIPythonWindowDialog::CGUIPythonWindowDialog(int id)

--- a/xbmc/interfaces/python/xbmcmodule/GUIPythonWindowXMLDialog.cpp
+++ b/xbmc/interfaces/python/xbmcmodule/GUIPythonWindowXMLDialog.cpp
@@ -21,7 +21,6 @@
 
 #include "GUIPythonWindowXMLDialog.h"
 #include "guilib/GUIWindowManager.h"
-#include "Application.h"
 #include "threads/SingleLock.h"
 
 CGUIPythonWindowXMLDialog::CGUIPythonWindowXMLDialog(int id, CStdString strXML, CStdString strFallBackPath)

--- a/xbmc/interfaces/python/xbmcmodule/control.cpp
+++ b/xbmc/interfaces/python/xbmcmodule/control.cpp
@@ -21,7 +21,6 @@
 
 #include "control.h"
 #include "pyutil.h"
-#include "GUIInfoManager.h"
 #include "guilib/GUIControlFactory.h"
 #include "guilib/GUITexture.h"
 #include "utils/StringUtils.h"

--- a/xbmc/interfaces/python/xbmcmodule/dialog.cpp
+++ b/xbmc/interfaces/python/xbmcmodule/dialog.cpp
@@ -21,7 +21,7 @@
 
 #include "dialog.h"
 
-#include "Application.h"
+#include "ApplicationMessenger.h"
 #include "settings/Settings.h"
 #include "pyutil.h"
 #include "pythreadstate.h"

--- a/xbmc/interfaces/python/xbmcmodule/keyboard.cpp
+++ b/xbmc/interfaces/python/xbmcmodule/keyboard.cpp
@@ -24,7 +24,7 @@
 #include "pyutil.h"
 #include "guilib/GUIWindowManager.h"
 #include "dialogs/GUIDialogKeyboard.h"
-#include "Application.h"
+#include "ApplicationMessenger.h"
 
 using namespace std;
 

--- a/xbmc/interfaces/python/xbmcmodule/player.cpp
+++ b/xbmc/interfaces/python/xbmcmodule/player.cpp
@@ -21,6 +21,7 @@
 
 #include "pyutil.h"
 #include "Application.h"
+#include "ApplicationMessenger.h"
 #include "GUIInfoManager.h"
 #include "PlayListPlayer.h"
 #include "player.h"
@@ -139,7 +140,7 @@ namespace PYXBMC
       }
 
       CPyThreadState pyState;
-      g_application.getApplicationMessenger().PlayListPlayerPlay(g_playlistPlayer.GetCurrentSong());
+      CApplicationMessenger::Get().PlayListPlayerPlay(g_playlistPlayer.GetCurrentSong());
     }
     else if ((PyString_Check(pObject) || PyUnicode_Check(pObject)) && pObjectListItem != NULL && ListItem_CheckExact(pObjectListItem))
     {
@@ -151,14 +152,14 @@ namespace PYXBMC
       pListItem->item->SetPath(PyString_AsString(pObject));
 
       CPyThreadState pyState;
-      g_application.getApplicationMessenger().PlayFile((const CFileItem)*pListItem->item, false);
+      CApplicationMessenger::Get().PlayFile((const CFileItem)*pListItem->item, false);
     }
     else if (PyString_Check(pObject) || PyUnicode_Check(pObject))
     {
       CFileItem item(PyString_AsString(pObject), false);
       
       CPyThreadState pyState;
-      g_application.getApplicationMessenger().MediaPlay(item.GetPath());
+      CApplicationMessenger::Get().MediaPlay(item.GetPath());
     }
     else if (PlayList_Check(pObject))
     {
@@ -168,7 +169,7 @@ namespace PYXBMC
       g_playlistPlayer.SetCurrentPlaylist(pPlayList->iPlayList);
 
       CPyThreadState pyState;
-      g_application.getApplicationMessenger().PlayListPlayerPlay();
+      CApplicationMessenger::Get().PlayListPlayerPlay();
     }
 
     Py_INCREF(Py_None);
@@ -182,7 +183,7 @@ namespace PYXBMC
   PyObject* pyPlayer_Stop(PyObject *self, PyObject *args)
   {
     CPyThreadState pyState;
-    g_application.getApplicationMessenger().MediaStop();
+    CApplicationMessenger::Get().MediaStop();
     pyState.Restore();
 
     Py_INCREF(Py_None);
@@ -196,7 +197,7 @@ namespace PYXBMC
   PyObject* Player_Pause(PyObject *self, PyObject *args)
   {
     CPyThreadState pyState;
-    g_application.getApplicationMessenger().MediaPause();
+    CApplicationMessenger::Get().MediaPause();
     pyState.Restore();
 
     Py_INCREF(Py_None);
@@ -213,7 +214,7 @@ namespace PYXBMC
     g_application.m_eForcedNextPlayer = self->playerCore;
 
     CPyThreadState pyState;
-    g_application.getApplicationMessenger().PlayListPlayerNext();
+    CApplicationMessenger::Get().PlayListPlayerNext();
     pyState.Restore();
 
     Py_INCREF(Py_None);
@@ -230,7 +231,7 @@ namespace PYXBMC
     g_application.m_eForcedNextPlayer = self->playerCore;
 
     CPyThreadState pyState;
-    g_application.getApplicationMessenger().PlayListPlayerPrevious();
+    CApplicationMessenger::Get().PlayListPlayerPrevious();
     pyState.Restore();
 
     Py_INCREF(Py_None);
@@ -256,7 +257,7 @@ namespace PYXBMC
     g_playlistPlayer.SetCurrentSong(iItem);
 
     CPyThreadState pyState;
-    g_application.getApplicationMessenger().PlayListPlayerPlay(iItem);
+    CApplicationMessenger::Get().PlayListPlayerPlay(iItem);
     pyState.Restore();
 
     //g_playlistPlayer.Play(iItem);

--- a/xbmc/interfaces/python/xbmcmodule/pyutil.cpp
+++ b/xbmc/interfaces/python/xbmcmodule/pyutil.cpp
@@ -29,7 +29,7 @@
 #include "utils/CharsetConverter.h"
 #include "threads/CriticalSection.h"
 #include "threads/SingleLock.h"
-#include "Application.h"
+#include "ApplicationMessenger.h"
 
 using namespace std;
 
@@ -87,7 +87,7 @@ namespace PYXBMC
   {
     CPyThreadState pyState;
     ThreadMessage tMsg = {message, param1, param2};
-    g_application.getApplicationMessenger().SendMessage(tMsg, true);
+    CApplicationMessenger::Get().SendMessage(tMsg, true);
   }
 
   static char defaultImage[1024];

--- a/xbmc/interfaces/python/xbmcmodule/window.cpp
+++ b/xbmc/interfaces/python/xbmcmodule/window.cpp
@@ -33,6 +33,7 @@
 #include "guilib/GUIWindowManager.h"
 #include "settings/Settings.h"
 #include "Application.h"
+#include "ApplicationMessenger.h"
 #include "threads/SingleLock.h"
 
 using namespace std;
@@ -425,13 +426,13 @@ namespace PYXBMC
       CPyThreadState pyState;
       ThreadMessage tMsg = {TMSG_GUI_PYTHON_DIALOG, WindowXMLDialog_Check(self) ? 1 : 0, 1};
       tMsg.lpVoid = self->pWindow;
-      g_application.getApplicationMessenger().SendMessage(tMsg, true);
+      CApplicationMessenger::Get().SendMessage(tMsg, true);
     }
     else
     {
       CPyThreadState pyState;
       vector<CStdString> params;
-      g_application.getApplicationMessenger().ActivateWindow(self->iWindowId, params, false);
+      CApplicationMessenger::Get().ActivateWindow(self->iWindowId, params, false);
     }
 
     Py_INCREF(Py_None);
@@ -463,13 +464,13 @@ namespace PYXBMC
       CPyThreadState pyState;
       ThreadMessage tMsg = {TMSG_GUI_PYTHON_DIALOG, WindowXMLDialog_Check(self) ? 1 : 0, 0};
       tMsg.lpVoid = self->pWindow;
-      g_application.getApplicationMessenger().SendMessage(tMsg, true);
+      CApplicationMessenger::Get().SendMessage(tMsg, true);
     }
     else
     {
       CPyThreadState pyState;
       vector<CStdString> params;
-      g_application.getApplicationMessenger().ActivateWindow(self->iOldWindowId, params, false);
+      CApplicationMessenger::Get().ActivateWindow(self->iOldWindowId, params, false);
     }
     self->iOldWindowId = 0;
 
@@ -705,7 +706,7 @@ namespace PYXBMC
       CPyThreadState state;
       CGUIMessage msg(GUI_MSG_ADD_CONTROL, 0, 0);
       msg.SetPointer(pControl->pGUIControl);
-      g_application.getApplicationMessenger().SendGUIMessage(msg, self->iWindowId, wait);
+      CApplicationMessenger::Get().SendGUIMessage(msg, self->iWindowId, wait);
     }
     return true;
   }
@@ -746,7 +747,7 @@ namespace PYXBMC
       CPyThreadState state;
       CGUIMessage msg(GUI_MSG_REMOVE_CONTROL, 0, 0);
       msg.SetPointer(pControl->pGUIControl);
-      g_application.getApplicationMessenger().SendGUIMessage(msg, self->iWindowId, wait);
+      CApplicationMessenger::Get().SendGUIMessage(msg, self->iWindowId, wait);
     }
 
     // initialize control to zero

--- a/xbmc/interfaces/python/xbmcmodule/xbmcmodule.cpp
+++ b/xbmc/interfaces/python/xbmcmodule/xbmcmodule.cpp
@@ -56,6 +56,7 @@
 #include "utils/log.h"
 #include "pyrendercapture.h"
 #include "monitor.h"
+#include "URL.h"
 
 // include for constants
 #include "pyutil.h"

--- a/xbmc/interfaces/python/xbmcmodule/xbmcmodule.cpp
+++ b/xbmc/interfaces/python/xbmcmodule/xbmcmodule.cpp
@@ -39,6 +39,7 @@
 #include "guilib/GUIWindowManager.h"
 #include "guilib/GUIAudioManager.h"
 #include "Application.h"
+#include "ApplicationMessenger.h"
 #include "utils/Crc32.h"
 #include "utils/URIUtils.h"
 #include "Util.h"
@@ -147,7 +148,7 @@ namespace PYXBMC
   PyObject* XBMC_Shutdown(PyObject *self, PyObject *args)
   {
     ThreadMessage tMsg = {TMSG_SHUTDOWN};
-    g_application.getApplicationMessenger().SendMessage(tMsg);
+    CApplicationMessenger::Get().SendMessage(tMsg);
 
     Py_INCREF(Py_None);
     return Py_None;
@@ -163,7 +164,7 @@ namespace PYXBMC
   PyObject* XBMC_Restart(PyObject *self, PyObject *args)
   {
     ThreadMessage tMsg = {TMSG_RESTART};
-    g_application.getApplicationMessenger().SendMessage(tMsg);
+    CApplicationMessenger::Get().SendMessage(tMsg);
 
     Py_INCREF(Py_None);
     return Py_None;
@@ -185,7 +186,7 @@ namespace PYXBMC
 
     ThreadMessage tMsg = {TMSG_EXECUTE_SCRIPT};
     tMsg.strParam = cLine;
-    g_application.getApplicationMessenger().SendMessage(tMsg);
+    CApplicationMessenger::Get().SendMessage(tMsg);
 
     Py_INCREF(Py_None);
     return Py_None;
@@ -211,7 +212,7 @@ namespace PYXBMC
     bool bWait = false;
     if (!PyArg_ParseTuple(args, (char*)"s|b", &cLine, &bWait)) return NULL;
 
-    g_application.getApplicationMessenger().ExecBuiltIn(cLine, bWait);
+    CApplicationMessenger::Get().ExecBuiltIn(cLine, bWait);
 
     Py_INCREF(Py_None);
     return Py_None;

--- a/xbmc/interfaces/python/xbmcmodule/xbmcmodule.cpp
+++ b/xbmc/interfaces/python/xbmcmodule/xbmcmodule.cpp
@@ -131,13 +131,13 @@ namespace PYXBMC
   PyDoc_STRVAR(output__doc__,
     "'xbmc.output()' is depreciated and will be removed in future releases,\n"
     "please use 'xbmc.log()' instead");
-  
+
   PyObject* XBMC_Output(PyObject *self, PyObject *args, PyObject *kwds)
   {
     CLog::Log(LOGWARNING,"'xbmc.output()' is depreciated and will be removed in future releases, please use 'xbmc.log()' instead");
     return XBMC_Log(self, args, kwds);
   }
-  
+
   // shutdown() method
   PyDoc_STRVAR(shutdown__doc__,
     "shutdown() -- Shutdown the xbox.\n"
@@ -937,7 +937,7 @@ namespace PYXBMC
 
     return Py_BuildValue((char*)"b", exists);
   }
-  
+
   // define c functions to be used in python here
   PyMethodDef xbmcMethods[] = {
     {(char*)"output", (PyCFunction)XBMC_Output, METH_VARARGS|METH_KEYWORDS, output__doc__},

--- a/xbmc/interfaces/python/xbmcmodule/xbmcvfsmodule.cpp
+++ b/xbmc/interfaces/python/xbmcmodule/xbmcvfsmodule.cpp
@@ -421,7 +421,7 @@ extern "C" {
         return NULL;
       int64_t size = self->pFile->GetLength();
       if (!readBytes || readBytes > size)
-        readBytes = size;
+        readBytes = (unsigned int) size;
       char* buffer = new char[readBytes + 1];
       PyObject* ret = NULL;
       if (buffer)
@@ -455,7 +455,7 @@ extern "C" {
         return NULL;
 
       CPyThreadState pyState;
-      bool bResult = self->pFile->Write( (void*) pBuffer, strlen( pBuffer ) + 1 );
+      bool bResult = self->pFile->Write( (void*) pBuffer, strlen( pBuffer ) + 1 ) > 0 ? true : false;
       pyState.Restore();
 
       return Py_BuildValue((char*)"b", bResult);

--- a/xbmc/music/LastFmManager.cpp
+++ b/xbmc/music/LastFmManager.cpp
@@ -24,6 +24,7 @@
 #include "Album.h"
 #include "Artist.h"
 #include "Application.h"
+#include "ApplicationMessenger.h"
 #include "PlayListPlayer.h"
 #include "playlists/PlayListFactory.h"
 #include "utils/md5.h"
@@ -881,7 +882,7 @@ bool CLastFmManager::Ban(const CMusicInfoTag& musicinfotag)
   if (CallXmlRpc("banTrack", StringUtils::Join(musicinfotag.GetArtist(), g_advancedSettings.m_musicItemSeparator), musicinfotag.GetTitle()))
   {
     //we banned this track so skip to the next track
-    g_application.getApplicationMessenger().ExecBuiltIn("playercontrol(next)");
+    CApplicationMessenger::Get().ExecBuiltIn("playercontrol(next)");
     m_CurrentSong.IsBanned = true;
     return true;
   }

--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -62,6 +62,7 @@
 #include "interfaces/AnnouncementManager.h"
 #include "dbwrappers/dataset.h"
 #include "utils/XMLUtils.h"
+#include "URL.h"
 
 using namespace std;
 using namespace AUTOPTR;

--- a/xbmc/music/dialogs/GUIDialogMusicInfo.cpp
+++ b/xbmc/music/dialogs/GUIDialogMusicInfo.cpp
@@ -21,7 +21,6 @@
 
 #include "GUIDialogMusicInfo.h"
 #include "guilib/GUIWindowManager.h"
-#include "Util.h"
 #include "guilib/GUIImage.h"
 #include "dialogs/GUIDialogFileBrowser.h"
 #include "GUIPassword.h"

--- a/xbmc/music/dialogs/GUIDialogMusicOSD.cpp
+++ b/xbmc/music/dialogs/GUIDialogMusicOSD.cpp
@@ -20,7 +20,6 @@
  */
 
 #include "GUIDialogMusicOSD.h"
-#include "Application.h"
 #include "guilib/GUIWindowManager.h"
 #include "input/MouseStat.h"
 #include "GUIUserMessages.h"

--- a/xbmc/music/dialogs/GUIDialogMusicOverlay.cpp
+++ b/xbmc/music/dialogs/GUIDialogMusicOverlay.cpp
@@ -20,7 +20,6 @@
  */
 
 #include "GUIDialogMusicOverlay.h"
-#include "GUIInfoManager.h"
 #include "guilib/GUIWindowManager.h"
 #include "input/MouseStat.h"
 

--- a/xbmc/music/dialogs/GUIDialogMusicScan.cpp
+++ b/xbmc/music/dialogs/GUIDialogMusicScan.cpp
@@ -22,6 +22,7 @@
 #include "GUIDialogMusicScan.h"
 #include "guilib/GUIProgressControl.h"
 #include "Application.h"
+#include "ApplicationMessenger.h"
 #include "Util.h"
 #include "URL.h"
 #include "guilib/GUIWindowManager.h"
@@ -124,7 +125,7 @@ void CGUIDialogMusicScan::OnFinished()
 
   if (!g_guiSettings.GetBool("musiclibrary.backgroundupdate"))
   {
-    g_application.getApplicationMessenger().Close(this, false, false);
+    CApplicationMessenger::Get().Close(this, false, false);
   }
 }
 

--- a/xbmc/music/dialogs/GUIDialogSongInfo.cpp
+++ b/xbmc/music/dialogs/GUIDialogSongInfo.cpp
@@ -20,7 +20,6 @@
  */
 
 #include "GUIDialogSongInfo.h"
-#include "Util.h"
 #include "utils/URIUtils.h"
 #include "utils/StringUtils.h"
 #include "dialogs/GUIDialogFileBrowser.h"

--- a/xbmc/music/infoscanner/MusicInfoScanner.cpp
+++ b/xbmc/music/infoscanner/MusicInfoScanner.cpp
@@ -930,16 +930,18 @@ bool CMusicInfoScanner::DownloadAlbumInfo(const CStdString& strPath, const CStdS
   }
 
   if (!scraper.GetAlbumCount())
+  {
     scraper.FindAlbumInfo(strAlbum, strArtist);
 
-  while (!scraper.Completed())
-  {
-    if (m_bStop)
+    while (!scraper.Completed())
     {
-      scraper.Cancel();
-      bCanceled = true;
+      if (m_bStop)
+      {
+        scraper.Cancel();
+        bCanceled = true;
+      }
+      Sleep(1);
     }
-    Sleep(1);
   }
 
   CGUIDialogSelect *pDlg=NULL;
@@ -1156,16 +1158,18 @@ bool CMusicInfoScanner::DownloadArtistInfo(const CStdString& strPath, const CStd
   }
 
   if (!scraper.GetArtistCount())
+  {
     scraper.FindArtistInfo(strArtist);
 
-  while (!scraper.Completed())
-  {
-    if (m_bStop)
+    while (!scraper.Completed())
     {
-      scraper.Cancel();
-      bCanceled = true;
+      if (m_bStop)
+      {
+        scraper.Cancel();
+        bCanceled = true;
+      }
+      Sleep(1);
     }
-    Sleep(1);
   }
 
   int iSelectedArtist = 0;

--- a/xbmc/music/infoscanner/MusicInfoScraper.cpp
+++ b/xbmc/music/infoscanner/MusicInfoScraper.cpp
@@ -22,6 +22,7 @@
 #include "MusicInfoScraper.h"
 #include "utils/CharsetConverter.h"
 #include "utils/log.h"
+#include "filesystem/CurlFile.h"
 
 using namespace MUSIC_GRABBER;
 using namespace ADDON;
@@ -34,11 +35,13 @@ CMusicInfoScraper::CMusicInfoScraper(const ADDON::ScraperPtr &scraper) : CThread
   m_iAlbum=-1;
   m_iArtist=-1;
   m_scraper = scraper;
+  m_http = new XFILE::CCurlFile;
 }
 
 CMusicInfoScraper::~CMusicInfoScraper(void)
 {
   StopThread();
+  delete m_http;
 }
 
 int CMusicInfoScraper::GetAlbumCount() const
@@ -80,13 +83,13 @@ void CMusicInfoScraper::FindArtistInfo(const CStdString& strArtist)
 
 void CMusicInfoScraper::FindAlbumInfo()
 {
-  m_vecAlbums = m_scraper->FindAlbum(m_http, m_strAlbum, m_strArtist);
+  m_vecAlbums = m_scraper->FindAlbum(*m_http, m_strAlbum, m_strArtist);
   m_bSucceeded = !m_vecAlbums.empty();
 }
 
 void CMusicInfoScraper::FindArtistInfo()
 {
-  m_vecArtists = m_scraper->FindArtist(m_http, m_strArtist);
+  m_vecArtists = m_scraper->FindArtist(*m_http, m_strArtist);
   m_bSucceeded = !m_vecArtists.empty();
 }
 
@@ -114,7 +117,7 @@ void CMusicInfoScraper::LoadAlbumInfo()
 
   CMusicAlbumInfo& album=m_vecAlbums[m_iAlbum];
   album.GetAlbum().artist.clear();
-  if (album.Load(m_http,m_scraper))
+  if (album.Load(*m_http,m_scraper))
     m_bSucceeded=true;
 }
 
@@ -125,7 +128,7 @@ void CMusicInfoScraper::LoadArtistInfo()
 
   CMusicArtistInfo& artist=m_vecArtists[m_iArtist];
   artist.GetArtist().strArtist.Empty();
-  if (artist.Load(m_http,m_scraper,m_strSearch))
+  if (artist.Load(*m_http,m_scraper,m_strSearch))
     m_bSucceeded=true;
 }
 
@@ -141,9 +144,9 @@ bool CMusicInfoScraper::Succeeded()
 
 void CMusicInfoScraper::Cancel()
 {
-  m_http.Cancel();
+  m_http->Cancel();
   m_bCanceled=true;
-  m_http.Reset();
+  m_http->Reset();
 }
 
 bool CMusicInfoScraper::IsCanceled()

--- a/xbmc/music/infoscanner/MusicInfoScraper.cpp
+++ b/xbmc/music/infoscanner/MusicInfoScraper.cpp
@@ -20,7 +20,6 @@
  */
 
 #include "MusicInfoScraper.h"
-#include "URL.h"
 #include "utils/CharsetConverter.h"
 #include "utils/log.h"
 

--- a/xbmc/music/infoscanner/MusicInfoScraper.h
+++ b/xbmc/music/infoscanner/MusicInfoScraper.h
@@ -25,7 +25,11 @@
 #include "MusicArtistInfo.h"
 #include "addons/Scraper.h"
 #include "threads/Thread.h"
-#include "filesystem/CurlFile.h"
+
+namespace XFILE
+{
+class CurlFile;
+}
 
 namespace MUSIC_GRABBER
 {
@@ -82,7 +86,7 @@ protected:
   int m_iArtist;
   bool m_bSucceeded;
   bool m_bCanceled;
-  XFILE::CCurlFile m_http;
+  XFILE::CCurlFile* m_http;
   ADDON::ScraperPtr m_scraper;
 };
 

--- a/xbmc/music/karaoke/GUIDialogKaraokeSongSelector.cpp
+++ b/xbmc/music/karaoke/GUIDialogKaraokeSongSelector.cpp
@@ -20,7 +20,7 @@
  */
 
 #include "GUIDialogKaraokeSongSelector.h"
-#include "Application.h"
+#include "PlayListPlayer.h"
 #include "playlists/PlayList.h"
 #include "guilib/LocalizeStrings.h"
 #include "utils/log.h"

--- a/xbmc/music/tags/FlacTag.cpp
+++ b/xbmc/music/tags/FlacTag.cpp
@@ -21,7 +21,6 @@
 
 #include "system.h"
 #include "FlacTag.h"
-#include "Util.h"
 #include "filesystem/File.h"
 #include "utils/log.h"
 #include "utils/EndianSwap.h"

--- a/xbmc/music/tags/Id3Tag.cpp
+++ b/xbmc/music/tags/Id3Tag.cpp
@@ -20,7 +20,6 @@
  */
 
 #include "Id3Tag.h"
-#include "Util.h"
 #include "utils/StringUtils.h"
 #include "settings/AdvancedSettings.h"
 #include "guilib/LocalizeStrings.h"

--- a/xbmc/music/tags/MusicInfoTagLoaderMP4.cpp
+++ b/xbmc/music/tags/MusicInfoTagLoaderMP4.cpp
@@ -20,7 +20,6 @@
  */
 
 #include "MusicInfoTagLoaderMP4.h"
-#include "Util.h"
 #include "id3v1genre.h"
 #include "MusicInfoTag.h"
 #include "guilib/LocalizeStrings.h"

--- a/xbmc/music/tags/MusicInfoTagLoaderWMA.cpp
+++ b/xbmc/music/tags/MusicInfoTagLoaderWMA.cpp
@@ -20,7 +20,6 @@
  */
 
 #include "MusicInfoTagLoaderWMA.h"
-#include "Util.h"
 #include "MusicInfoTag.h"
 #include "filesystem/File.h"
 #include "settings/AdvancedSettings.h"

--- a/xbmc/music/windows/GUIWindowMusicBase.cpp
+++ b/xbmc/music/windows/GUIWindowMusicBase.cpp
@@ -66,6 +66,7 @@
 #include "video/VideoInfoTag.h"
 #include "utils/StringUtils.h"
 #include "ThumbLoader.h"
+#include "URL.h"
 
 using namespace std;
 using namespace XFILE;

--- a/xbmc/music/windows/GUIWindowMusicNav.cpp
+++ b/xbmc/music/windows/GUIWindowMusicNav.cpp
@@ -49,6 +49,7 @@
 #include "utils/log.h"
 #include "utils/StringUtils.h"
 #include "TextureCache.h"
+#include "Util.h"
 
 using namespace std;
 using namespace XFILE;

--- a/xbmc/music/windows/GUIWindowMusicNav.cpp
+++ b/xbmc/music/windows/GUIWindowMusicNav.cpp
@@ -51,6 +51,7 @@
 #include "utils/StringUtils.h"
 #include "TextureCache.h"
 #include "Util.h"
+#include "URL.h"
 
 using namespace std;
 using namespace XFILE;

--- a/xbmc/music/windows/GUIWindowMusicNav.cpp
+++ b/xbmc/music/windows/GUIWindowMusicNav.cpp
@@ -43,6 +43,7 @@
 #include "filesystem/File.h"
 #include "FileItem.h"
 #include "Application.h"
+#include "ApplicationMessenger.h"
 #include "settings/Settings.h"
 #include "settings/AdvancedSettings.h"
 #include "guilib/LocalizeStrings.h"
@@ -642,7 +643,7 @@ bool CGUIWindowMusicNav::OnContextButton(int itemNumber, CONTEXT_BUTTON button)
       database.Open();
       CVideoInfoTag details;
       database.GetMusicVideoInfo("",details,database.GetMatchingMusicVideo(StringUtils::Join(item->GetMusicInfoTag()->GetArtist(), g_advancedSettings.m_musicItemSeparator),item->GetMusicInfoTag()->GetAlbum(),item->GetMusicInfoTag()->GetTitle()));
-      g_application.getApplicationMessenger().PlayFile(CFileItem(details));
+      CApplicationMessenger::Get().PlayFile(CFileItem(details));
       return true;
     }
 

--- a/xbmc/network/AirPlayServer.cpp
+++ b/xbmc/network/AirPlayServer.cpp
@@ -35,6 +35,7 @@
 #include "utils/md5.h"
 #include "utils/Variant.h"
 #include "guilib/GUIWindowManager.h"
+#include "URL.h"
 
 #ifdef TARGET_WINDOWS
 #define close closesocket

--- a/xbmc/network/AirPlayServer.cpp
+++ b/xbmc/network/AirPlayServer.cpp
@@ -29,7 +29,6 @@
 #include "utils/StringUtils.h"
 #include "threads/SingleLock.h"
 #include "filesystem/File.h"
-#include "Util.h"
 #include "FileItem.h"
 #include "Application.h"
 #include "utils/md5.h"

--- a/xbmc/network/AirPlayServer.cpp
+++ b/xbmc/network/AirPlayServer.cpp
@@ -31,6 +31,7 @@
 #include "filesystem/File.h"
 #include "FileItem.h"
 #include "Application.h"
+#include "ApplicationMessenger.h"
 #include "utils/md5.h"
 #include "utils/Variant.h"
 #include "guilib/GUIWindowManager.h"
@@ -666,7 +667,7 @@ int CAirPlayServer::CTCPClient::ProcessRequest( CStdString& responseHeader,
       {
         if (g_application.m_pPlayer && g_application.m_pPlayer->IsPlaying() && !g_application.m_pPlayer->IsPaused())
         {
-          g_application.getApplicationMessenger().MediaPause();
+          CApplicationMessenger::Get().MediaPause();
           ComposeReverseEvent(reverseHeader, reverseBody, sessionId, EVENT_PAUSED);
         }
       }
@@ -674,7 +675,7 @@ int CAirPlayServer::CTCPClient::ProcessRequest( CStdString& responseHeader,
       {
         if (g_application.m_pPlayer && g_application.m_pPlayer->IsPlaying() && g_application.m_pPlayer->IsPaused())
         {
-          g_application.getApplicationMessenger().MediaPause();
+          CApplicationMessenger::Get().MediaPause();
           ComposeReverseEvent(reverseHeader, reverseBody, sessionId, EVENT_PLAYING);
         }
       }
@@ -702,7 +703,7 @@ int CAirPlayServer::CTCPClient::ProcessRequest( CStdString& responseHeader,
         if(oldVolume != (int)volume)
         {
           g_application.SetVolume(volume);          
-          g_application.getApplicationMessenger().ShowVolumeBar(oldVolume < volume);
+          CApplicationMessenger::Get().ShowVolumeBar(oldVolume < volume);
         }
       }
   }
@@ -799,7 +800,7 @@ int CAirPlayServer::CTCPClient::ProcessRequest( CStdString& responseHeader,
 
       CFileItem fileToPlay(location, false);
       fileToPlay.SetProperty("StartPercent", position*100.0f);
-      g_application.getApplicationMessenger().MediaPlay(fileToPlay);
+      CApplicationMessenger::Get().MediaPlay(fileToPlay);
       ComposeReverseEvent(reverseHeader, reverseBody, sessionId, EVENT_PLAYING);
     }
   }
@@ -851,7 +852,7 @@ int CAirPlayServer::CTCPClient::ProcessRequest( CStdString& responseHeader,
     {
       if (IsPlaying()) //only stop player if we started him
       {
-        g_application.getApplicationMessenger().MediaStop();
+        CApplicationMessenger::Get().MediaStop();
         CAirPlayServer::m_isPlaying--;
       }
       else //if we are not playing and get the stop request - we just wanna stop picture streaming
@@ -891,7 +892,7 @@ int CAirPlayServer::CTCPClient::ProcessRequest( CStdString& responseHeader,
 
         if (writtenBytes > 0 && (unsigned int)writtenBytes == m_httpParser->getContentLength())
         {
-          g_application.getApplicationMessenger().PictureShow(tmpFileName);
+          CApplicationMessenger::Get().PictureShow(tmpFileName);
         }
         else
         {

--- a/xbmc/network/AirTunesServer.cpp
+++ b/xbmc/network/AirTunesServer.cpp
@@ -171,16 +171,16 @@ void* CAirTunesServer::AudioOutputFunctions::audio_init(void *cls, int bits, int
     return 0;
 
   ThreadMessage tMsg = { TMSG_MEDIA_STOP };
-  g_application.getApplicationMessenger().SendMessage(tMsg, true);
+  CApplicationMessenger::Get().SendMessage(tMsg, true);
 
   CFileItem item;
   item.SetPath(pipe->GetName());
   item.SetMimeType("audio/x-xbmc-pcm");
 
   ThreadMessage tMsg2 = { TMSG_GUI_ACTIVATE_WINDOW, WINDOW_VISUALISATION, 0 };
-  g_application.getApplicationMessenger().SendMessage(tMsg2, true);
+  CApplicationMessenger::Get().SendMessage(tMsg2, true);
 
-  g_application.getApplicationMessenger().PlayFile(item);
+  CApplicationMessenger::Get().PlayFile(item);
 
   return "XBMC-AirTunes";//session
 }
@@ -234,7 +234,7 @@ void  CAirTunesServer::AudioOutputFunctions::audio_destroy(void *cls, void *sess
 #endif
   {
     ThreadMessage tMsg = { TMSG_MEDIA_STOP };
-    g_application.getApplicationMessenger().SendMessage(tMsg, true);
+    CApplicationMessenger::Get().SendMessage(tMsg, true);
     CLog::Log(LOGDEBUG, "AIRTUNES: AirPlay not running - stopping player");
   }
 }
@@ -339,7 +339,7 @@ ao_device* CAirTunesServer::AudioOutputFunctions::ao_open_live(int driver_id, ao
     return 0;
 
   ThreadMessage tMsg = { TMSG_MEDIA_STOP };
-  g_application.getApplicationMessenger().SendMessage(tMsg, true);
+  CApplicationMessenger::Get().SendMessage(tMsg, true);
 
   CFileItem item;
   item.SetPath(device->pipe->GetName());
@@ -355,9 +355,9 @@ ao_device* CAirTunesServer::AudioOutputFunctions::ao_open_live(int driver_id, ao
     item.GetMusicInfoTag()->SetTitle(ao_get_option(option, "name"));
 
   ThreadMessage tMsg2 = { TMSG_GUI_ACTIVATE_WINDOW, WINDOW_VISUALISATION, 0 };
-  g_application.getApplicationMessenger().SendMessage(tMsg2, true);
+  CApplicationMessenger::Get().SendMessage(tMsg2, true);
 
-  g_application.getApplicationMessenger().PlayFile(item);
+  CApplicationMessenger::Get().PlayFile(item);
 
   return (ao_device*) device;
 }
@@ -380,7 +380,7 @@ int CAirTunesServer::AudioOutputFunctions::ao_close(ao_device *device)
 #endif
   {
     ThreadMessage tMsg = { TMSG_MEDIA_STOP };
-    g_application.getApplicationMessenger().SendMessage(tMsg, true);
+    CApplicationMessenger::Get().SendMessage(tMsg, true);
     CLog::Log(LOGDEBUG, "AIRTUNES: AirPlay not running - stopping player");
   }
 

--- a/xbmc/network/AirTunesServer.cpp
+++ b/xbmc/network/AirTunesServer.cpp
@@ -43,6 +43,7 @@
 #include "utils/Variant.h"
 #include "settings/AdvancedSettings.h"
 #include "utils/EndianSwap.h"
+#include "URL.h"
 
 #include <map>
 #include <string>

--- a/xbmc/network/AirTunesServer.cpp
+++ b/xbmc/network/AirTunesServer.cpp
@@ -667,8 +667,10 @@ bool CAirTunesServer::Initialize(const CStdString &password)
     ao.ao_append_option = AudioOutputFunctions::ao_append_option;
     ao.ao_free_options = AudioOutputFunctions::ao_free_options;
     ao.ao_get_option = AudioOutputFunctions::ao_get_option;
+#ifdef HAVE_STRUCT_AUDIOOUTPUT_AO_SET_METADATA
     ao.ao_set_metadata = AudioOutputFunctions::ao_set_metadata;    
     ao.ao_set_metadata_coverart = AudioOutputFunctions::ao_set_metadata_coverart;        
+#endif
     struct printfPtr funcPtr;
     funcPtr.extprintf = shairport_log;
 

--- a/xbmc/network/DNSNameCache.cpp
+++ b/xbmc/network/DNSNameCache.cpp
@@ -20,7 +20,6 @@
  */
 
 #include "DNSNameCache.h"
-#include "Application.h"
 #include "threads/SingleLock.h"
 #include "utils/log.h"
 

--- a/xbmc/network/Network.cpp
+++ b/xbmc/network/Network.cpp
@@ -22,6 +22,7 @@
 #include "system.h"
 #include "Network.h"
 #include "Application.h"
+#include "ApplicationMessenger.h"
 #include "libscrobbler/lastfmscrobbler.h"
 #include "libscrobbler/librefmscrobbler.h"
 #include "utils/RssReader.h"
@@ -94,12 +95,12 @@ bool in_ether (const char *bufp, unsigned char *addr)
 
 CNetwork::CNetwork()
 {
-   g_application.getApplicationMessenger().NetworkMessage(SERVICES_UP, 0);
+  CApplicationMessenger::Get().NetworkMessage(SERVICES_UP, 0);
 }
 
 CNetwork::~CNetwork()
 {
-   g_application.getApplicationMessenger().NetworkMessage(SERVICES_DOWN, 0);
+  CApplicationMessenger::Get().NetworkMessage(SERVICES_DOWN, 0);
 }
 
 int CNetwork::ParseHex(char *str, unsigned char *addr)

--- a/xbmc/network/UPnP.cpp
+++ b/xbmc/network/UPnP.cpp
@@ -24,7 +24,7 @@
 #include "UPnP.h"
 #include "utils/URIUtils.h"
 #include "Application.h"
-
+#include "ApplicationMessenger.h"
 #include "Network.h"
 #include "utils/log.h"
 #include "filesystem/MusicDatabaseDirectory.h"
@@ -1793,9 +1793,9 @@ CUPnPRenderer::OnNext(PLT_ActionReference& action)
 {
     if (g_windowManager.GetActiveWindow() == WINDOW_SLIDESHOW) {
         CAction action(ACTION_NEXT_PICTURE);
-        g_application.getApplicationMessenger().SendAction(action, WINDOW_SLIDESHOW);
+        CApplicationMessenger::Get().SendAction(action, WINDOW_SLIDESHOW);
     } else {
-        g_application.getApplicationMessenger().PlayListPlayerNext();
+        CApplicationMessenger::Get().PlayListPlayerNext();
     }
     return NPT_SUCCESS;
 }
@@ -1808,9 +1808,9 @@ CUPnPRenderer::OnPause(PLT_ActionReference& action)
 {
     if (g_windowManager.GetActiveWindow() == WINDOW_SLIDESHOW) {
         CAction action(ACTION_PAUSE);
-        g_application.getApplicationMessenger().SendAction(action, WINDOW_SLIDESHOW);
+        CApplicationMessenger::Get().SendAction(action, WINDOW_SLIDESHOW);
     } else if (!g_application.IsPaused())
-      g_application.getApplicationMessenger().MediaPause();
+      CApplicationMessenger::Get().MediaPause();
     return NPT_SUCCESS;
 }
 
@@ -1823,7 +1823,7 @@ CUPnPRenderer::OnPlay(PLT_ActionReference& action)
     if (g_windowManager.GetActiveWindow() == WINDOW_SLIDESHOW) {
         return NPT_SUCCESS;
     } else if (g_application.IsPaused()) {
-      g_application.getApplicationMessenger().MediaPause();
+      CApplicationMessenger::Get().MediaPause();
     } else if (!g_application.IsPlaying()) {
         NPT_String uri, meta;
         PLT_Service* service;
@@ -1846,9 +1846,9 @@ CUPnPRenderer::OnPrevious(PLT_ActionReference& action)
 {
     if (g_windowManager.GetActiveWindow() == WINDOW_SLIDESHOW) {
         CAction action(ACTION_PREV_PICTURE);
-        g_application.getApplicationMessenger().SendAction(action, WINDOW_SLIDESHOW);
+        CApplicationMessenger::Get().SendAction(action, WINDOW_SLIDESHOW);
     } else {
-        g_application.getApplicationMessenger().PlayListPlayerPrevious();
+        CApplicationMessenger::Get().PlayListPlayerPrevious();
     }
     return NPT_SUCCESS;
 }
@@ -1861,9 +1861,9 @@ CUPnPRenderer::OnStop(PLT_ActionReference& action)
 {
     if (g_windowManager.GetActiveWindow() == WINDOW_SLIDESHOW) {
         CAction action(ACTION_STOP);
-        g_application.getApplicationMessenger().SendAction(action, WINDOW_SLIDESHOW);
+        CApplicationMessenger::Get().SendAction(action, WINDOW_SLIDESHOW);
     } else {
-        g_application.getApplicationMessenger().MediaStop();
+        CApplicationMessenger::Get().MediaStop();
     }
     return NPT_SUCCESS;
 }
@@ -1955,13 +1955,13 @@ CUPnPRenderer::PlayMedia(const char* uri, const char* meta, PLT_Action* action)
         } else if (object->m_ObjectClass.type.StartsWith("object.item.imageItem")) {
             bImageFile = true;
         }
-        bImageFile?g_application.getApplicationMessenger().PictureShow(item.GetPath())
-                  :g_application.getApplicationMessenger().MediaPlay(item);
+        bImageFile?CApplicationMessenger::Get().PictureShow(item.GetPath())
+                  :CApplicationMessenger::Get().MediaPlay(item);
     } else {
         bImageFile = NPT_String(PLT_MediaObject::GetUPnPClass(uri)).StartsWith("object.item.imageItem", true);
 
-        bImageFile?g_application.getApplicationMessenger().PictureShow((const char*)uri)
-                  :g_application.getApplicationMessenger().MediaPlay((const char*)uri);
+        bImageFile?CApplicationMessenger::Get().PictureShow((const char*)uri)
+                  :CApplicationMessenger::Get().MediaPlay((const char*)uri);
     }
 
     if (g_application.IsPlaying() || g_windowManager.GetActiveWindow() == WINDOW_SLIDESHOW) {

--- a/xbmc/network/UPnP.cpp
+++ b/xbmc/network/UPnP.cpp
@@ -59,6 +59,7 @@
 #include "utils/md5.h"
 #include "guilib/Key.h"
 #include "ThumbLoader.h"
+#include "Util.h"
 
 using namespace std;
 using namespace MUSIC_INFO;

--- a/xbmc/network/UPnP.cpp
+++ b/xbmc/network/UPnP.cpp
@@ -65,8 +65,6 @@ using namespace std;
 using namespace MUSIC_INFO;
 using namespace XFILE;
 
-extern CGUIInfoManager g_infoManager;
-
 NPT_SET_LOCAL_LOGGER("xbmc.upnp")
 
 #define UPNP_DEFAULT_MAX_RETURNED_ITEMS 200

--- a/xbmc/network/WebServer.cpp
+++ b/xbmc/network/WebServer.cpp
@@ -28,6 +28,7 @@
 #include "utils/Base64.h"
 #include "threads/SingleLock.h"
 #include "XBDateTime.h"
+#include "URL.h"
 
 #ifdef _WIN32
 #pragma comment(lib, "libmicrohttpd.dll.lib")

--- a/xbmc/network/ZeroconfBrowser.h
+++ b/xbmc/network/ZeroconfBrowser.h
@@ -25,7 +25,12 @@
 #include <set>
 #include <vector>
 #include <map>
-#include "URL.h"
+
+#include "utils/StdString.h"
+
+#ifdef _WIN32
+#undef SetPort // WIN32INCLUDES this is defined as SetPortA in WinSpool.h which is being included _somewhere_
+#endif
 
 //forwards
 class CCriticalSection;

--- a/xbmc/network/httprequesthandler/HTTPVfsHandler.cpp
+++ b/xbmc/network/httprequesthandler/HTTPVfsHandler.cpp
@@ -21,7 +21,6 @@
 
 #include "HTTPVfsHandler.h"
 #include "network/WebServer.h"
-#include "URL.h"
 #include "filesystem/File.h"
 
 using namespace std;

--- a/xbmc/network/httprequesthandler/HTTPWebinterfaceHandler.cpp
+++ b/xbmc/network/httprequesthandler/HTTPWebinterfaceHandler.cpp
@@ -25,6 +25,7 @@
 #include "utils/URIUtils.h"
 #include "filesystem/Directory.h"
 #include "filesystem/File.h"
+#include "Util.h"
 
 #define DEFAULT_PAGE        "index.html"
 

--- a/xbmc/network/libscrobbler/scrobbler.cpp
+++ b/xbmc/network/libscrobbler/scrobbler.cpp
@@ -36,6 +36,7 @@
 #include "guilib/LocalizeStrings.h"
 #include "filesystem/File.h"
 #include "filesystem/CurlFile.h"
+#include "URL.h"
 
 #define SCROBBLER_CLIENT              "xbm"
 //#define SCROBBLER_CLIENT              "tst"     // For testing ONLY!

--- a/xbmc/osx/IOSEAGLView.mm
+++ b/xbmc/osx/IOSEAGLView.mm
@@ -30,6 +30,7 @@
 #include "AdvancedSettings.h"
 #include "FileItem.h"
 #include "Application.h"
+#include "ApplicationMessenger.h"
 #include "WindowingFactory.h"
 #include "VideoReferenceClock.h"
 #include "utils/log.h"
@@ -346,7 +347,7 @@
     if (!g_application.m_bStop)
     {
       ThreadMessage tMsg = {TMSG_QUIT};
-      g_application.getApplicationMessenger().SendMessage(tMsg);
+      CApplicationMessenger::Get().SendMessage(tMsg);
     }
     // wait for animation thread to die
     if ([animationThread isFinished] == NO)

--- a/xbmc/osx/ios/XBMCController.mm
+++ b/xbmc/osx/ios/XBMCController.mm
@@ -29,7 +29,7 @@
 #include "settings/AdvancedSettings.h"
 #include "settings/Settings.h"
 #include "FileItem.h"
-#include "Application.h"
+#include "ApplicationMessenger.h"
 #include "input/MouseStat.h"
 #include "windowing/WindowingFactory.h"
 #include "video/VideoReferenceClock.h"
@@ -212,7 +212,7 @@ extern NSString* kBRScreenSaverDismissed;
       case UIGestureRecognizerStateBegan:  
       break;
       case UIGestureRecognizerStateChanged:
-        g_application.getApplicationMessenger().SendAction(CAction(ACTION_GESTURE_ZOOM, 0, (float)point.x, (float)point.y, 
+        CApplicationMessenger::Get().SendAction(CAction(ACTION_GESTURE_ZOOM, 0, (float)point.x, (float)point.y, 
           currentPinchScale, 0), WINDOW_INVALID,false);    
       break;
       case UIGestureRecognizerStateEnded:
@@ -259,12 +259,12 @@ extern NSString* kBRScreenSaverDismissed;
       {
         if( !touchBeginSignaled )
         {
-          g_application.getApplicationMessenger().SendAction(CAction(ACTION_GESTURE_BEGIN, 0, (float)point.x, (float)point.y, 
+          CApplicationMessenger::Get().SendAction(CAction(ACTION_GESTURE_BEGIN, 0, (float)point.x, (float)point.y, 
                                                             0, 0), WINDOW_INVALID,false);
           touchBeginSignaled = true;
         }    
         
-        g_application.getApplicationMessenger().SendAction(CAction(ACTION_GESTURE_PAN, 0, (float)point.x, (float)point.y,
+        CApplicationMessenger::Get().SendAction(CAction(ACTION_GESTURE_PAN, 0, (float)point.x, (float)point.y,
                                                           xMovement, yMovement), WINDOW_INVALID,false);
         lastGesturePoint = point;
       }
@@ -274,7 +274,7 @@ extern NSString* kBRScreenSaverDismissed;
     {
       CGPoint velocity = [sender velocityInView:m_glView];
       //signal end of pan - this will start inertial scrolling with deacceleration in CApplication
-      g_application.getApplicationMessenger().SendAction(CAction(ACTION_GESTURE_END, 0, (float)velocity.x, (float)velocity.y, (int)lastGesturePoint.x, (int)lastGesturePoint.y),WINDOW_INVALID,false);
+      CApplicationMessenger::Get().SendAction(CAction(ACTION_GESTURE_END, 0, (float)velocity.x, (float)velocity.y, (int)lastGesturePoint.x, (int)lastGesturePoint.y),WINDOW_INVALID,false);
       touchBeginSignaled = false;
     }
   }

--- a/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
+++ b/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
@@ -24,6 +24,7 @@
 #include "PeripheralCecAdapter.h"
 #include "input/XBIRRemote.h"
 #include "Application.h"
+#include "ApplicationMessenger.h"
 #include "DynamicDll.h"
 #include "threads/SingleLock.h"
 #include "dialogs/GUIDialogKaiToast.h"
@@ -609,7 +610,7 @@ void CPeripheralCecAdapter::SetMenuLanguage(const char *strLanguage)
 
   if (!strGuiLanguage.IsEmpty())
   {
-    g_application.getApplicationMessenger().SetGUILanguage(strGuiLanguage);
+    CApplicationMessenger::Get().SetGUILanguage(strGuiLanguage);
     CLog::Log(LOGDEBUG, "%s - language set to '%s'", __FUNCTION__, strGuiLanguage.c_str());
   }
   else
@@ -637,9 +638,9 @@ int CPeripheralCecAdapter::CecCommand(void *cbParam, const cec_command &command)
       {
         adapter->m_bStarted = false;
         if (adapter->m_configuration.bPowerOffOnStandby == 1)
-          g_application.getApplicationMessenger().Suspend();
+          CApplicationMessenger::Get().Suspend();
         else if (adapter->m_configuration.bShutdownOnStandby == 1)
-          g_application.getApplicationMessenger().Shutdown();
+          CApplicationMessenger::Get().Shutdown();
       }
       break;
     case CEC_OPCODE_SET_MENU_LANGUAGE:

--- a/xbmc/pictures/GUIViewStatePictures.cpp
+++ b/xbmc/pictures/GUIViewStatePictures.cpp
@@ -27,7 +27,6 @@
 #include "settings/Settings.h"
 #include "filesystem/Directory.h"
 #include "filesystem/PluginDirectory.h"
-#include "Util.h"
 #include "guilib/LocalizeStrings.h"
 #include "guilib/Key.h"
 

--- a/xbmc/pictures/GUIWindowSlideShow.cpp
+++ b/xbmc/pictures/GUIWindowSlideShow.cpp
@@ -23,6 +23,7 @@
 #include "system.h"
 #include "GUIWindowSlideShow.h"
 #include "Application.h"
+#include "ApplicationMessenger.h"
 #include "utils/URIUtils.h"
 #include "URL.h"
 #include "guilib/TextureManager.h"
@@ -427,7 +428,7 @@ void CGUIWindowSlideShow::Process(unsigned int currentTime, CDirtyRegionList &re
   { 
     CLog::Log(LOGDEBUG, "Playing slide %s as video", m_slides->Get(m_iCurrentSlide)->GetPath().c_str());
     m_bPlayingVideo = true;
-    g_application.getApplicationMessenger().PlayFile(*m_slides->Get(m_iCurrentSlide));
+    CApplicationMessenger::Get().PlayFile(*m_slides->Get(m_iCurrentSlide));
     m_iCurrentSlide = m_iNextSlide;
     m_iNextSlide    = GetNextSlide();
   } 

--- a/xbmc/pictures/Picture.cpp
+++ b/xbmc/pictures/Picture.cpp
@@ -24,7 +24,6 @@
 #include "settings/GUISettings.h"
 #include "FileItem.h"
 #include "filesystem/File.h"
-#include "filesystem/CurlFile.h"
 #include "DllImageLib.h"
 #include "utils/log.h"
 #include "utils/URIUtils.h"

--- a/xbmc/pictures/PictureThumbLoader.cpp
+++ b/xbmc/pictures/PictureThumbLoader.cpp
@@ -21,7 +21,6 @@
 
 #include "PictureThumbLoader.h"
 #include "Picture.h"
-#include "URL.h"
 #include "filesystem/File.h"
 #include "FileItem.h"
 #include "TextureCache.h"

--- a/xbmc/playlists/SmartPlayList.cpp
+++ b/xbmc/playlists/SmartPlayList.cpp
@@ -690,7 +690,7 @@ CStdString CSmartPlaylistRule::GetWhereClause(CDatabase &db, const CStdString& s
       if (m_field == FieldGenre)
         query = GetField(FieldId, strType) + negate + " IN (SELECT song.idAlbum FROM song, song_genre, genre WHERE song.idSong = song_genre.idSong AND song_genre.idGenre = genre.idGenre AND genre.strGenre" + parameter + ")";
       else if (m_field == FieldArtist)
-        query = GetField(FieldId, strType) + negate + " IN (SELECT song.idAlbum FROM song, song_artist, artists WHERE song.idSong = song_artist.idSong AND song_artist.idArtist = artist.idArtist AND artist.strArtist" + parameter + ")";
+        query = GetField(FieldId, strType) + negate + " IN (SELECT song.idAlbum FROM song, song_artist, artist WHERE song.idSong = song_artist.idSong AND song_artist.idArtist = artist.idArtist AND artist.strArtist" + parameter + ")";
       else if (m_field == FieldAlbumArtist)
         query = GetField(FieldId, strType) + negate + " IN (SELECT album_artist.idAlbum FROM album_artist, artist WHERE album_artist.idArtist = artist.idArtist AND artist.strArtist" + parameter + ")";
     }

--- a/xbmc/powermanagement/linux/ConsoleDeviceKitPowerSyscall.cpp
+++ b/xbmc/powermanagement/linux/ConsoleDeviceKitPowerSyscall.cpp
@@ -24,7 +24,6 @@
 #include "utils/log.h"
 
 #ifdef HAS_DBUS
-#include "Application.h"
 #include "DBusUtil.h"
 
 CConsoleDeviceKitPowerSyscall::CConsoleDeviceKitPowerSyscall()

--- a/xbmc/powermanagement/linux/ConsoleUPowerSyscall.cpp
+++ b/xbmc/powermanagement/linux/ConsoleUPowerSyscall.cpp
@@ -24,7 +24,6 @@
 #include "utils/log.h"
 
 #ifdef HAS_DBUS
-#include "Application.h"
 
 CUPowerSource::CUPowerSource(const char *powerSource)
 {

--- a/xbmc/powermanagement/linux/HALPowerSyscall.cpp
+++ b/xbmc/powermanagement/linux/HALPowerSyscall.cpp
@@ -24,7 +24,6 @@
 #include "utils/log.h"
 
 #ifdef HAS_HAL
-#include "Application.h"
 #include <dbus/dbus.h>
 #include <stdlib.h>
 

--- a/xbmc/programs/GUIViewStatePrograms.cpp
+++ b/xbmc/programs/GUIViewStatePrograms.cpp
@@ -25,7 +25,6 @@
 #include "settings/GUISettings.h"
 #include "settings/Settings.h"
 #include "filesystem/Directory.h"
-#include "Util.h"
 #include "guilib/LocalizeStrings.h"
 #include "guilib/Key.h"
 

--- a/xbmc/settings/AppParamParser.cpp
+++ b/xbmc/settings/AppParamParser.cpp
@@ -25,6 +25,7 @@
 #include "PlayListPlayer.h"
 #include "FileItem.h"
 #include "Application.h"
+#include "ApplicationMessenger.h"
 #include "utils/log.h"
 #ifdef TARGET_WINDOWS
 #include "WIN32Util.h"
@@ -156,5 +157,5 @@ void CAppParamParser::PlayPlaylist()
   }
 
   ThreadMessage tMsg = {TMSG_PLAYLISTPLAYER_PLAY, (DWORD) -1};
-  g_application.getApplicationMessenger().SendMessage(tMsg, false);
+  CApplicationMessenger::Get().SendMessage(tMsg, false);
 }

--- a/xbmc/settings/GUIDialogContentSettings.cpp
+++ b/xbmc/settings/GUIDialogContentSettings.cpp
@@ -32,6 +32,8 @@
 #include "filesystem/AddonsDirectory.h"
 #include "dialogs/GUIDialogKaiToast.h"
 
+#include <climits>
+
 #define CONTROL_CONTENT_TYPE        3
 #define CONTROL_SCRAPER_LIST        4
 #define CONTROL_SCRAPER_SETTINGS    6

--- a/xbmc/settings/GUIWindowSettingsCategory.cpp
+++ b/xbmc/settings/GUIWindowSettingsCategory.cpp
@@ -23,6 +23,7 @@
 #include "GUIUserMessages.h"
 #include "GUIWindowSettingsCategory.h"
 #include "Application.h"
+#include "ApplicationMessenger.h"
 #include "interfaces/Builtins.h"
 #include "input/KeyboardLayoutConfiguration.h"
 #include "filesystem/Directory.h"
@@ -1609,7 +1610,7 @@ void CGUIWindowSettingsCategory::OnSettingChanged(CBaseSettingControl *pSettingC
     if (CGUIDialogYesNo::ShowAndGetInput(14038, 14039, 14040, -1, -1))
     {
       g_settings.Save();
-      g_application.getApplicationMessenger().RestartApp();
+      CApplicationMessenger::Get().RestartApp();
     }
   }
   else if (strSetting.Equals("services.upnpserver"))

--- a/xbmc/settings/GUIWindowSettingsProfile.cpp
+++ b/xbmc/settings/GUIWindowSettingsProfile.cpp
@@ -33,7 +33,6 @@
 #include "guilib/GUIWindowManager.h"
 #include "filesystem/Directory.h"
 #include "FileItem.h"
-#include "Util.h"
 #include "Settings.h"
 #include "guilib/LocalizeStrings.h"
 

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -744,7 +744,7 @@ bool CSettings::LoadSettings(const CStdString& strSettingsFile)
 
   // Add the list of disc stub extensions (if any) to the list of video extensions
   if (!m_discStubExtensions.IsEmpty())
- 	g_settings.m_videoExtensions += "|" + m_discStubExtensions;
+    g_settings.m_videoExtensions += "|" + m_discStubExtensions;
 
   // Default players?
   CLog::Log(LOGNOTICE, "Default DVD Player: %s", g_advancedSettings.m_videoDefaultDVDPlayer.c_str());

--- a/xbmc/storage/MediaManager.cpp
+++ b/xbmc/storage/MediaManager.cpp
@@ -24,7 +24,6 @@
 #include "guilib/LocalizeStrings.h"
 #include "IoSupport.h"
 #include "URL.h"
-#include "Util.h"
 #include "utils/URIUtils.h"
 #ifdef _WIN32
 #include "WIN32Util.h"

--- a/xbmc/storage/MediaManager.h
+++ b/xbmc/storage/MediaManager.h
@@ -25,7 +25,6 @@
 #ifdef HAS_DVD_DRIVE
 #include "cdioSupport.h"
 #endif
-#include "URL.h"
 #include "utils/Job.h"
 #include "IStorageProvider.h"
 #include "threads/CriticalSection.h"

--- a/xbmc/utils/AlarmClock.cpp
+++ b/xbmc/utils/AlarmClock.cpp
@@ -20,7 +20,7 @@
  */
 
 #include "AlarmClock.h"
-#include "Application.h"
+#include "ApplicationMessenger.h"
 #include "guilib/LocalizeStrings.h"
 #include "threads/SingleLock.h"
 #include "log.h"
@@ -114,7 +114,7 @@ void CAlarmClock::Stop(const CStdString& strName, bool bSilent /* false */)
   }
   else
   {
-    g_application.getApplicationMessenger().ExecBuiltIn(iter->second.m_strCommand);
+    CApplicationMessenger::Get().ExecBuiltIn(iter->second.m_strCommand);
     if (iter->second.m_loop)
     {
       iter->second.watch.Reset();

--- a/xbmc/utils/AliasShortcutUtils.cpp
+++ b/xbmc/utils/AliasShortcutUtils.cpp
@@ -26,7 +26,6 @@
 #else
 #endif
 
-#include "Util.h"
 #include "AliasShortcutUtils.h"
 
 bool IsAliasShortcut(CStdString &path)

--- a/xbmc/utils/AsyncFileCopy.cpp
+++ b/xbmc/utils/AsyncFileCopy.cpp
@@ -25,6 +25,7 @@
 #include "guilib/GUIWindowManager.h"
 #include "log.h"
 #include "utils/TimeUtils.h"
+#include "URL.h"
 
 CAsyncFileCopy::CAsyncFileCopy() : CThread("CAsyncFileCopy")
 {

--- a/xbmc/utils/CPUInfo.cpp
+++ b/xbmc/utils/CPUInfo.cpp
@@ -240,6 +240,7 @@ CCPUInfo::CCPUInfo(void)
 
 #endif
   readProcStat(m_userTicks, m_niceTicks, m_systemTicks, m_idleTicks, m_ioTicks);
+  m_lastReadTime = time(NULL);
 
   ReadCPUFeatures();
 
@@ -298,6 +299,7 @@ int CCPUInfo::getUsedPercentage()
   m_ioTicks += ioTicks;
 
   m_lastUsedPercentage = result;
+  m_lastReadTime = time(NULL);
 
   return result;
 }
@@ -488,7 +490,6 @@ bool CCPUInfo::readProcStat(unsigned long long& user, unsigned long long& nice,
   }
 #endif
 
-  m_lastReadTime = time(NULL);
   return true;
 }
 

--- a/xbmc/utils/CPUInfo.cpp
+++ b/xbmc/utils/CPUInfo.cpp
@@ -20,6 +20,7 @@
  */
 
 #include "CPUInfo.h"
+#include "Temperature.h"
 #include <string>
 #include <string.h>
 
@@ -343,7 +344,7 @@ float CCPUInfo::getCPUFrequency()
 #endif
 }
 
-CTemperature CCPUInfo::getTemperature()
+bool CCPUInfo::getTemperature(CTemperature& temperature)
 {
   int         value = 0,
               ret   = 0;
@@ -351,8 +352,10 @@ CTemperature CCPUInfo::getTemperature()
   FILE        *p    = NULL;
   CStdString  cmd   = g_advancedSettings.m_cpuTempCmd;
 
+  temperature.SetState(CTemperature::invalid);
+
   if (cmd.IsEmpty() && m_fProcTemperature == NULL)
-    return CTemperature();
+    return false;
 
   if (!cmd.IsEmpty())
   {
@@ -384,13 +387,16 @@ CTemperature CCPUInfo::getTemperature()
   }
 
   if (ret != 2)
-    return CTemperature();
+    return false; 
 
   if (scale == 'C' || scale == 'c')
-    return CTemperature::CreateFromCelsius(value);
-  if (scale == 'F' || scale == 'f')
-    return CTemperature::CreateFromFahrenheit(value);
-  return CTemperature();
+    temperature = CTemperature::CreateFromCelsius(value);
+  else if (scale == 'F' || scale == 'f')
+    temperature = CTemperature::CreateFromFahrenheit(value);
+  else
+    return false;
+  
+  return true;
 }
 
 bool CCPUInfo::HasCoreId(int nCoreId) const

--- a/xbmc/utils/CPUInfo.cpp
+++ b/xbmc/utils/CPUInfo.cpp
@@ -264,9 +264,7 @@ CCPUInfo::~CCPUInfo()
 int CCPUInfo::getUsedPercentage()
 {
   if (m_lastReadTime + MINIMUM_TIME_BETWEEN_READS > time(NULL))
-  {
     return m_lastUsedPercentage;
-  }
 
   unsigned long long userTicks;
   unsigned long long niceTicks;
@@ -275,9 +273,7 @@ int CCPUInfo::getUsedPercentage()
   unsigned long long ioTicks;
 
   if (!readProcStat(userTicks, niceTicks, systemTicks, idleTicks, ioTicks))
-  {
     return 0;
-  }
 
   userTicks -= m_userTicks;
   niceTicks -= m_niceTicks;
@@ -323,9 +319,7 @@ float CCPUInfo::getCPUFrequency()
   ret = RegQueryValueEx(hKey,"~MHz", NULL, NULL, (LPBYTE)&dwMHz, &dwSize);
   RegCloseKey(hKey);
   if(ret == 0)
-  {
     return float(dwMHz);
-  }
   else
     return 0.f;
 #else
@@ -605,13 +599,3 @@ void CCPUInfo::ReadCPUFeatures()
 }
 
 CCPUInfo g_cpuInfo;
-
-/*
-int main()
-{
-  CCPUInfo c;
-  usleep(...);
-  int r = c.getUsedPercentage();
-  printf("%d\n", r);
-}
-*/

--- a/xbmc/utils/CPUInfo.cpp
+++ b/xbmc/utils/CPUInfo.cpp
@@ -70,8 +70,8 @@
 
 using namespace std;
 
-// In seconds
-#define MINIMUM_TIME_BETWEEN_READS 2
+// In milliseconds
+#define MINIMUM_TIME_BETWEEN_READS 500
 
 #ifdef _WIN32
 /* replacement gettimeofday implementation, copy from dvdnav_internal.h */
@@ -240,7 +240,7 @@ CCPUInfo::CCPUInfo(void)
 
 #endif
   readProcStat(m_userTicks, m_niceTicks, m_systemTicks, m_idleTicks, m_ioTicks);
-  m_lastReadTime = time(NULL);
+  m_nextUsedReadTime.Set(MINIMUM_TIME_BETWEEN_READS);
 
   ReadCPUFeatures();
 
@@ -264,7 +264,7 @@ CCPUInfo::~CCPUInfo()
 
 int CCPUInfo::getUsedPercentage()
 {
-  if (m_lastReadTime + MINIMUM_TIME_BETWEEN_READS > time(NULL))
+  if (!m_nextUsedReadTime.IsTimePast())
     return m_lastUsedPercentage;
 
   unsigned long long userTicks;
@@ -299,7 +299,7 @@ int CCPUInfo::getUsedPercentage()
   m_ioTicks += ioTicks;
 
   m_lastUsedPercentage = result;
-  m_lastReadTime = time(NULL);
+  m_nextUsedReadTime.Set(MINIMUM_TIME_BETWEEN_READS);
 
   return result;
 }

--- a/xbmc/utils/CPUInfo.cpp
+++ b/xbmc/utils/CPUInfo.cpp
@@ -238,8 +238,8 @@ CCPUInfo::CCPUInfo(void)
     m_cpuModel = "Unknown";
   }
 
-  readProcStat(m_userTicks, m_niceTicks, m_systemTicks, m_idleTicks, m_ioTicks);
 #endif
+  readProcStat(m_userTicks, m_niceTicks, m_systemTicks, m_idleTicks, m_ioTicks);
 
   ReadCPUFeatures();
 

--- a/xbmc/utils/CPUInfo.cpp
+++ b/xbmc/utils/CPUInfo.cpp
@@ -273,7 +273,7 @@ int CCPUInfo::getUsedPercentage()
   unsigned long long ioTicks;
 
   if (!readProcStat(userTicks, niceTicks, systemTicks, idleTicks, ioTicks))
-    return 0;
+    return m_lastUsedPercentage;
 
   userTicks -= m_userTicks;
   niceTicks -= m_niceTicks;

--- a/xbmc/utils/CPUInfo.h
+++ b/xbmc/utils/CPUInfo.h
@@ -28,7 +28,7 @@
 #include "Temperature.h"
 #include <string>
 #include <map>
-#include "threads\SystemClock.h"
+#include "threads/SystemClock.h"
 
 #define CPU_FEATURE_MMX      1 << 0
 #define CPU_FEATURE_MMX2     1 << 1

--- a/xbmc/utils/CPUInfo.h
+++ b/xbmc/utils/CPUInfo.h
@@ -28,6 +28,7 @@
 #include "Temperature.h"
 #include <string>
 #include <map>
+#include "threads\SystemClock.h"
 
 #define CPU_FEATURE_MMX      1 << 0
 #define CPU_FEATURE_MMX2     1 << 1
@@ -91,7 +92,7 @@ private:
   unsigned long long m_ioTicks;
 
   int          m_lastUsedPercentage;
-  time_t       m_lastReadTime;
+  XbmcThreads::EndTime m_nextUsedReadTime; 
   std::string  m_cpuModel;
   int          m_cpuCount;
   unsigned int m_cpuFeatures;

--- a/xbmc/utils/CPUInfo.h
+++ b/xbmc/utils/CPUInfo.h
@@ -25,10 +25,11 @@
 #include <stdio.h>
 #include <time.h>
 #include "Archive.h"
-#include "Temperature.h"
 #include <string>
 #include <map>
 #include "threads/SystemClock.h"
+
+class CTemperature;
 
 #define CPU_FEATURE_MMX      1 << 0
 #define CPU_FEATURE_MMX2     1 << 1
@@ -66,7 +67,7 @@ public:
   int getUsedPercentage();
   int getCPUCount() { return m_cpuCount; }
   float getCPUFrequency();
-  CTemperature getTemperature();
+  bool getTemperature(CTemperature& temperature);
   std::string& getCPUModel() { return m_cpuModel; }
 
   const CoreInfo &GetCoreInfo(int nCoreId);

--- a/xbmc/utils/FileOperationJob.cpp
+++ b/xbmc/utils/FileOperationJob.cpp
@@ -29,6 +29,7 @@
 #include "log.h"
 #include "Util.h"
 #include "URIUtils.h"
+#include "URL.h"
 #include "guilib/LocalizeStrings.h"
 #ifdef HAS_FILESYSTEM_RAR
 #include "filesystem/RarManager.h"

--- a/xbmc/utils/StringUtils.cpp
+++ b/xbmc/utils/StringUtils.cpp
@@ -33,7 +33,6 @@
 #include "StringUtils.h"
 #include "utils/RegExp.h"
 #include "utils/fstrcmp.h"
-#include "LangInfo.h"
 #include <locale>
 
 #include <math.h>

--- a/xbmc/utils/TuxBoxUtil.cpp
+++ b/xbmc/utils/TuxBoxUtil.cpp
@@ -28,6 +28,7 @@
 #include "filesystem/CurlFile.h"
 #include "dialogs/GUIDialogContextMenu.h"
 #include "Application.h"
+#include "ApplicationMessenger.h"
 #include "GUIInfoManager.h"
 #include "video/VideoInfoTag.h"
 #include "guilib/GUIWindowManager.h"
@@ -120,7 +121,7 @@ void CTuxBoxService::Process()
         if (strCurrentServiceName != g_tuxbox.sCurSrvData.service_name && g_application.IsPlaying() && !g_tuxbox.sZapstream.available)
         {
           CLog::Log(LOGDEBUG," - ERROR: Non controlled channel change detected! Stopping current playing stream!");
-          g_application.getApplicationMessenger().MediaStop();
+          CApplicationMessenger::Get().MediaStop();
           break;
         }
       }
@@ -579,7 +580,7 @@ bool CTuxBoxUtil::GetZapUrl(const CStdString& strPath, CFileItem &items )
       }
 
       if (g_application.IsPlaying() && !g_tuxbox.sZapstream.available)
-        g_application.getApplicationMessenger().MediaStop();
+        CApplicationMessenger::Get().MediaStop();
 
       strLabel.Format("%s: %s %s-%s",items.GetLabel().c_str(), sCurSrvData.current_event_date.c_str(),sCurSrvData.current_event_start.c_str(), sCurSrvData.current_event_start.c_str());
       strLabel2.Format("%s", sCurSrvData.current_event_description.c_str());
@@ -1439,7 +1440,7 @@ bool CTuxBoxUtil::GetVideoSubChannels(CStdString& strVideoSubChannelName, CStdSt
 
   // IsPlaying, Stop it..
   if(g_application.IsPlaying())
-    g_application.getApplicationMessenger().MediaStop();
+    CApplicationMessenger::Get().MediaStop();
 
   // popup the context menu
   CContextButtons buttons;

--- a/xbmc/video/GUIViewStateVideo.cpp
+++ b/xbmc/video/GUIViewStateVideo.cpp
@@ -29,7 +29,6 @@
 #include "settings/AdvancedSettings.h"
 #include "settings/Settings.h"
 #include "FileItem.h"
-#include "Util.h"
 #include "guilib/Key.h"
 #include "guilib/LocalizeStrings.h"
 

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -52,6 +52,7 @@
 #include "dbwrappers/dataset.h"
 #include "utils/LabelFormatter.h"
 #include "XBDateTime.h"
+#include "URL.h"
 
 using namespace std;
 using namespace dbiplus;

--- a/xbmc/video/VideoInfoDownloader.cpp
+++ b/xbmc/video/VideoInfoDownloader.cpp
@@ -37,6 +37,17 @@ using namespace std;
 #pragma warning (disable:4018)
 #endif
 
+CVideoInfoDownloader::CVideoInfoDownloader(const ADDON::ScraperPtr &scraper) :
+  CThread("CVideoInfoDownloader"), m_info(scraper)
+{
+  m_http = new XFILE::CCurlFile;
+}
+
+CVideoInfoDownloader::~CVideoInfoDownloader()
+{
+  delete m_http;
+}
+
 // return value: 0 = we failed, -1 = we failed and reported an error, 1 = success
 int CVideoInfoDownloader::InternalFindMovie(const CStdString &strMovie,
                                             MOVIELIST& movielist,
@@ -44,7 +55,7 @@ int CVideoInfoDownloader::InternalFindMovie(const CStdString &strMovie,
 {
   try
   {
-    movielist = m_info->FindMovie(m_http, strMovie, cleanChars);
+    movielist = m_info->FindMovie(*m_http, strMovie, cleanChars);
   }
   catch (const ADDON::CScraperError &sce)
   {
@@ -177,7 +188,7 @@ bool CVideoInfoDownloader::GetDetails(const CScraperUrl &url,
     return true;
   }
   else  // unthreaded
-    return m_info->GetVideoDetails(m_http, url, true/*fMovie*/, movieDetails);
+    return m_info->GetVideoDetails(*m_http, url, true/*fMovie*/, movieDetails);
 }
 
 bool CVideoInfoDownloader::GetEpisodeDetails(const CScraperUrl &url,
@@ -212,7 +223,7 @@ bool CVideoInfoDownloader::GetEpisodeDetails(const CScraperUrl &url,
     return true;
   }
   else  // unthreaded
-    return m_info->GetVideoDetails(m_http, url, false/*fMovie*/, movieDetails);
+    return m_info->GetVideoDetails(*m_http, url, false/*fMovie*/, movieDetails);
 }
 
 bool CVideoInfoDownloader::GetEpisodeList(const CScraperUrl& url,
@@ -247,14 +258,14 @@ bool CVideoInfoDownloader::GetEpisodeList(const CScraperUrl& url,
     return true;
   }
   else  // unthreaded
-    return !(movieDetails = m_info->GetEpisodeList(m_http, url)).empty();
+    return !(movieDetails = m_info->GetEpisodeList(*m_http, url)).empty();
 }
 
 void CVideoInfoDownloader::CloseThread()
 {
-  m_http.Cancel();
+  m_http->Cancel();
   StopThread();
-  m_http.Reset();
+  m_http->Reset();
   m_state = DO_NOTHING;
   m_found = 0;
 }

--- a/xbmc/video/VideoInfoDownloader.cpp
+++ b/xbmc/video/VideoInfoDownloader.cpp
@@ -25,7 +25,7 @@
 #include "NfoFile.h"
 #include "dialogs/GUIDialogProgress.h"
 #include "dialogs/GUIDialogOK.h"
-#include "Application.h"
+#include "ApplicationMessenger.h"
 #include "guilib/GUIWindowManager.h"
 #include "guilib/LocalizeStrings.h"
 #include "utils/log.h"
@@ -61,7 +61,7 @@ void CVideoInfoDownloader::ShowErrorDialog(const ADDON::CScraperError &sce)
     CGUIDialogOK *pdlg = (CGUIDialogOK *)g_windowManager.GetWindow(WINDOW_DIALOG_OK);
     pdlg->SetHeading(sce.Title());
     pdlg->SetLine(0, sce.Message());
-    g_application.getApplicationMessenger().DoModal(pdlg, WINDOW_DIALOG_OK);
+    CApplicationMessenger::Get().DoModal(pdlg, WINDOW_DIALOG_OK);
   }
 }
 

--- a/xbmc/video/VideoInfoDownloader.cpp
+++ b/xbmc/video/VideoInfoDownloader.cpp
@@ -20,7 +20,6 @@
  */
 
 #include "VideoInfoDownloader.h"
-#include "Util.h"
 #include "utils/XMLUtils.h"
 #include "utils/RegExp.h"
 #include "NfoFile.h"

--- a/xbmc/video/VideoInfoDownloader.h
+++ b/xbmc/video/VideoInfoDownloader.h
@@ -42,8 +42,8 @@ typedef std::vector<CScraperUrl> MOVIELIST;
 class CVideoInfoDownloader : public CThread
 {
 public:
-  CVideoInfoDownloader(const ADDON::ScraperPtr &scraper) : CThread("CVideoInfoDownloader"), m_info(scraper) {}
-  virtual ~CVideoInfoDownloader() {}
+  CVideoInfoDownloader(const ADDON::ScraperPtr &scraper);
+  virtual ~CVideoInfoDownloader();
 
   // threaded lookup functions
 
@@ -67,7 +67,7 @@ protected:
                       GET_EPISODE_LIST = 3,
                       GET_EPISODE_DETAILS = 4 };
 
-  XFILE::CCurlFile m_http;
+  XFILE::CCurlFile* m_http;
   CStdString        m_strMovie;
   MOVIELIST         m_movieList;
   CVideoInfoTag     m_movieDetails;

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -47,6 +47,7 @@
 #include "utils/Variant.h"
 #include "ThumbLoader.h"
 #include "TextureCache.h"
+#include "URL.h"
 
 using namespace std;
 using namespace XFILE;

--- a/xbmc/video/VideoInfoScanner.h
+++ b/xbmc/video/VideoInfoScanner.h
@@ -23,7 +23,6 @@
 #include "VideoDatabase.h"
 #include "addons/Scraper.h"
 #include "NfoFile.h"
-#include "VideoInfoDownloader.h"
 #include "XBDateTime.h"
 
 class CRegExp;

--- a/xbmc/video/dialogs/GUIDialogAudioSubtitleSettings.cpp
+++ b/xbmc/video/dialogs/GUIDialogAudioSubtitleSettings.cpp
@@ -23,7 +23,6 @@
 #include "GUIDialogAudioSubtitleSettings.h"
 #include "dialogs/GUIDialogFileBrowser.h"
 #include "GUIPassword.h"
-#include "Util.h"
 #include "utils/URIUtils.h"
 #include "Application.h"
 #include "video/VideoDatabase.h"

--- a/xbmc/video/dialogs/GUIDialogVideoBookmarks.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoBookmarks.cpp
@@ -41,6 +41,7 @@
 #include "threads/SingleLock.h"
 #include "utils/log.h"
 #include "utils/Variant.h"
+#include "Util.h"
 
 using namespace std;
 

--- a/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
@@ -46,6 +46,7 @@
 #include "GUIUserMessages.h"
 #include "TextureCache.h"
 #include "music/MusicDatabase.h"
+#include "URL.h"
 
 using namespace std;
 using namespace XFILE;

--- a/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
@@ -28,7 +28,7 @@
 #include "video/windows/GUIWindowVideoNav.h"
 #include "dialogs/GUIDialogFileBrowser.h"
 #include "video/VideoInfoScanner.h"
-#include "Application.h"
+#include "ApplicationMessenger.h"
 #include "video/VideoInfoTag.h"
 #include "guilib/GUIWindowManager.h"
 #include "dialogs/GUIDialogOK.h"
@@ -791,9 +791,9 @@ void CGUIDialogVideoInfo::PlayTrailer()
   Close(true);
 
   if (item.IsPlayList())
-    g_application.getApplicationMessenger().MediaPlay(item);
+    CApplicationMessenger::Get().MediaPlay(item);
   else
-    g_application.getApplicationMessenger().PlayFile(item);
+    CApplicationMessenger::Get().PlayFile(item);
 }
 
 void CGUIDialogVideoInfo::SetLabel(int iControl, const CStdString &strLabel)

--- a/xbmc/video/dialogs/GUIDialogVideoOverlay.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoOverlay.cpp
@@ -20,7 +20,6 @@
  */
 
 #include "GUIDialogVideoOverlay.h"
-#include "GUIInfoManager.h"
 #include "guilib/GUIWindowManager.h"
 
 #define CONTROL_PLAYTIME     2

--- a/xbmc/video/dialogs/GUIDialogVideoScan.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoScan.cpp
@@ -28,6 +28,7 @@
 #include "ApplicationMessenger.h"
 #include "threads/SingleLock.h"
 #include "utils/log.h"
+#include "URL.h"
 
 #define CONTROL_LABELSTATUS       401
 #define CONTROL_LABELDIRECTORY    402

--- a/xbmc/video/dialogs/GUIDialogVideoScan.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoScan.cpp
@@ -25,7 +25,7 @@
 #include "Util.h"
 #include "guilib/GUIWindowManager.h"
 #include "settings/GUISettings.h"
-#include "Application.h"
+#include "ApplicationMessenger.h"
 #include "threads/SingleLock.h"
 #include "utils/log.h"
 
@@ -141,7 +141,7 @@ void CGUIDialogVideoScan::OnFinished()
 
   if (!g_guiSettings.GetBool("videolibrary.backgroundupdate"))
   {
-    g_application.getApplicationMessenger().Close(this,false,false);
+    CApplicationMessenger::Get().Close(this,false,false);
   }
 }
 

--- a/xbmc/video/dialogs/GUIDialogVideoSettings.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoSettings.cpp
@@ -23,7 +23,6 @@
 #include "GUIDialogVideoSettings.h"
 #include "guilib/GUIWindowManager.h"
 #include "GUIPassword.h"
-#include "Util.h"
 #include "utils/MathUtils.h"
 #include "settings/GUISettings.h"
 #ifdef HAS_VIDEO_PLAYBACK

--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -67,6 +67,7 @@
 #include "addons/Skin.h"
 #include "storage/MediaManager.h"
 #include "Autorun.h"
+#include "URL.h"
 
 using namespace std;
 using namespace XFILE;

--- a/xbmc/video/windows/GUIWindowVideoNav.cpp
+++ b/xbmc/video/windows/GUIWindowVideoNav.cpp
@@ -42,6 +42,7 @@
 #include "filesystem/File.h"
 #include "FileItem.h"
 #include "Application.h"
+#include "ApplicationMessenger.h"
 #include "settings/Settings.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/GUISettings.h"
@@ -1356,7 +1357,7 @@ bool CGUIWindowVideoNav::OnContextButton(int itemNumber, CONTEXT_BUTTON button)
                                                                         m_vecItems->Get(itemNumber)->GetVideoInfoTag()->m_strTitle),
                                                                         song))
       {
-        g_application.getApplicationMessenger().PlayFile(song);
+        CApplicationMessenger::Get().PlayFile(song);
       }
       return true;
     }

--- a/xbmc/windowing/WinEventsSDL.cpp
+++ b/xbmc/windowing/WinEventsSDL.cpp
@@ -25,6 +25,7 @@
 #include "WinEvents.h"
 #include "WinEventsSDL.h"
 #include "Application.h"
+#include "ApplicationMessenger.h"
 #include "guilib/GUIWindowManager.h"
 #ifdef HAS_SDL_JOYSTICK
 #include "input/SDLJoystick.h"
@@ -222,7 +223,8 @@ bool CWinEventsSDL::MessagePump()
     switch(event.type)
     {
       case SDL_QUIT:
-        if (!g_application.m_bStop) g_application.getApplicationMessenger().Quit();
+        if (!g_application.m_bStop) 
+          CApplicationMessenger::Get().Quit();
         break;
 
 #ifdef HAS_SDL_JOYSTICK
@@ -402,7 +404,7 @@ bool CWinEventsSDL::ProcessOSXShortcuts(SDL_Event& event)
     {
     case SDLK_q:  // CMD-q to quit
       if (!g_application.m_bStop)
-        g_application.getApplicationMessenger().Quit();
+        CApplicationMessenger::Get().Quit();
       return true;
 
     case SDLK_f: // CMD-f to toggle fullscreen
@@ -415,7 +417,7 @@ bool CWinEventsSDL::ProcessOSXShortcuts(SDL_Event& event)
 
     case SDLK_h: // CMD-h to hide (but we minimize for now)
     case SDLK_m: // CMD-m to minimize
-      g_application.getApplicationMessenger().Minimize();
+      CApplicationMessenger::Get().Minimize();
       return true;
 
     default:

--- a/xbmc/windowing/windows/WinEventsWin32.cpp
+++ b/xbmc/windowing/windows/WinEventsWin32.cpp
@@ -439,16 +439,6 @@ LRESULT CALLBACK CWinEventsWin32::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, L
         if (CWIN32Util::GetFocussedProcess(procfile))
           CLog::Log(LOGDEBUG, __FUNCTION__": Focus switched to process %s", procfile.c_str());
       }
-      if(GetForegroundWindow() == hWnd)
-      {
-        CLog::Log(LOGDEBUG, __FUNCTION__": Got Focus, deactivating system screensaver");
-        g_Windowing.EnableSystemScreenSaver(false);
-      }
-      else
-      {
-        CLog::Log(LOGDEBUG, __FUNCTION__": Lost Focus, activating system screensaver");
-        g_Windowing.EnableSystemScreenSaver(true);
-      }
       break;
     case WM_SYSKEYDOWN:
       switch (wParam)

--- a/xbmc/windowing/windows/WinEventsWin32.cpp
+++ b/xbmc/windowing/windows/WinEventsWin32.cpp
@@ -440,6 +440,14 @@ LRESULT CALLBACK CWinEventsWin32::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, L
           CLog::Log(LOGDEBUG, __FUNCTION__": Focus switched to process %s", procfile.c_str());
       }
       break;
+    case WM_SYSCOMMAND:
+      switch( wParam&0xFFF0 )
+      {
+        case SC_MONITORPOWER:
+        case SC_SCREENSAVE:
+          return 0;
+      }
+      break;
     case WM_SYSKEYDOWN:
       switch (wParam)
       {

--- a/xbmc/windowing/windows/WinEventsWin32.cpp
+++ b/xbmc/windowing/windows/WinEventsWin32.cpp
@@ -439,6 +439,16 @@ LRESULT CALLBACK CWinEventsWin32::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, L
         if (CWIN32Util::GetFocussedProcess(procfile))
           CLog::Log(LOGDEBUG, __FUNCTION__": Focus switched to process %s", procfile.c_str());
       }
+      if(GetForegroundWindow() == hWnd)
+      {
+        CLog::Log(LOGDEBUG, __FUNCTION__": Got Focus, deactivating system screensaver");
+        g_Windowing.EnableSystemScreenSaver(false);
+      }
+      else
+      {
+        CLog::Log(LOGDEBUG, __FUNCTION__": Lost Focus, activating system screensaver");
+        g_Windowing.EnableSystemScreenSaver(true);
+      }
       break;
     case WM_SYSKEYDOWN:
       switch (wParam)

--- a/xbmc/windowing/windows/WinSystemWin32.cpp
+++ b/xbmc/windowing/windows/WinSystemWin32.cpp
@@ -71,37 +71,6 @@ bool CWinSystemWin32::DestroyWindowSystem()
   return true;
 }
 
-bool CWinSystemWin32::IsSystemScreenSaverEnabled()
-{
-  // Check if system screen saver is enabled
-  // We are checking registry due to bug with SPI_GETSCREENSAVEACTIVE
-  HKEY hKeyScreenSaver = NULL;
-  long lReturn = NULL;
-  long lScreenSaver = NULL;
-  DWORD dwData = NULL;
-  bool result = false;
-
-  lReturn = RegOpenKeyEx(HKEY_CURRENT_USER, TEXT("Control Panel\\Desktop"),0,KEY_QUERY_VALUE,&hKeyScreenSaver);
-  if(lReturn == ERROR_SUCCESS)
-  {
-    lScreenSaver = RegQueryValueEx(hKeyScreenSaver,TEXT("SCRNSAVE.EXE"),NULL,NULL,NULL,&dwData);
-
-    // ScreenSaver is active
-    if(lScreenSaver == ERROR_SUCCESS)
-       result = true;
-  }
-  RegCloseKey(hKeyScreenSaver);
-
-  return result;
-}
-
-void CWinSystemWin32::EnableSystemScreenSaver(bool bEnable)
-{
-  SystemParametersInfo(SPI_SETSCREENSAVEACTIVE,bEnable,0,0);
-  if(!bEnable)
-    SetThreadExecutionState(ES_DISPLAY_REQUIRED|ES_CONTINUOUS);
-}
-
 bool CWinSystemWin32::CreateNewWindow(const CStdString& name, bool fullScreen, RESOLUTION_INFO& res, PHANDLE_EVENT_FUNC userFunction)
 {
   m_hInstance = ( HINSTANCE )GetModuleHandle( NULL );

--- a/xbmc/windowing/windows/WinSystemWin32.h
+++ b/xbmc/windowing/windows/WinSystemWin32.h
@@ -146,10 +146,6 @@ public:
   virtual bool Hide();
   virtual bool Show(bool raise = true);
 
-   // OS System screensaver
-  virtual void EnableSystemScreenSaver(bool bEnable);
-  virtual bool IsSystemScreenSaverEnabled();
-
   // CWinSystemWin32
   HWND GetHwnd() { return m_hWnd; }
   bool IsAlteringWindow() { return m_IsAlteringWindow; }

--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -41,6 +41,7 @@
 #include "dialogs/GUIDialogProgress.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/GUISettings.h"
+#include "URL.h"
 
 #include "dialogs/GUIDialogSmartPlaylistEditor.h"
 #include "addons/GUIDialogAddonSettings.h"

--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -30,6 +30,7 @@
 #include "filesystem/MultiPathDirectory.h"
 #include "GUIPassword.h"
 #include "Application.h"
+#include "ApplicationMessenger.h"
 #include "network/Network.h"
 #include "utils/RegExp.h"
 #include "PartyModeManager.h"
@@ -1466,7 +1467,7 @@ bool CGUIMediaWindow::OnContextButton(int itemNumber, CONTEXT_BUTTON button)
     {
       CStdString action;
       action.Format("contextmenuaction(%i)", button - CONTEXT_BUTTON_USER1);
-      g_application.getApplicationMessenger().ExecBuiltIn(m_vecItems->Get(itemNumber)->GetProperty(action).asString());
+      CApplicationMessenger::Get().ExecBuiltIn(m_vecItems->Get(itemNumber)->GetProperty(action).asString());
       return true;
     }
   default:

--- a/xbmc/windows/GUIWindowDebugInfo.cpp
+++ b/xbmc/windows/GUIWindowDebugInfo.cpp
@@ -35,6 +35,8 @@
 #include "GUIInfoManager.h"
 #include "utils/Variant.h"
 
+#include <climits>
+
 CGUIWindowDebugInfo::CGUIWindowDebugInfo(void)
     : CGUIDialog(98, "")
 {

--- a/xbmc/windows/GUIWindowFileManager.cpp
+++ b/xbmc/windows/GUIWindowFileManager.cpp
@@ -58,6 +58,7 @@
 #include "utils/FileUtils.h"
 #include "utils/URIUtils.h"
 #include "Autorun.h"
+#include "URL.h"
 
 using namespace std;
 using namespace XFILE;

--- a/xbmc/windows/GUIWindowLoginScreen.cpp
+++ b/xbmc/windows/GUIWindowLoginScreen.cpp
@@ -21,6 +21,7 @@
 
 #include "system.h"
 #include "Application.h"
+#include "ApplicationMessenger.h"
 #include "GUIWindowLoginScreen.h"
 #include "settings/GUIWindowSettingsProfile.h"
 #include "dialogs/GUIDialogContextMenu.h"
@@ -228,7 +229,7 @@ bool CGUIWindowLoginScreen::OnPopupMenu(int iItem)
     if (g_passwordManager.CheckLock(g_settings.GetMasterProfile().getLockMode(),g_settings.GetMasterProfile().getLockCode(),20075))
       g_passwordManager.iMasterLockRetriesLeft = g_guiSettings.GetInt("masterlock.maxretries");
     else // be inconvenient
-      g_application.getApplicationMessenger().Shutdown();
+      CApplicationMessenger::Get().Shutdown();
 
     return true;
   }


### PR DESCRIPTION
(forceClose ? 0x01 : 0 | enableSound ? 0x02 : 0);
is actually (forceClose ? 0x01 : (0 | enableSound) ? 0x02 : 0); based on operator precedence of bit-wise or.

I'm pretty sure based on usage at: https://github.com/xbmc/xbmc/blob/master/xbmc/ApplicationMessenger.cpp#L676

that it should be:
((forceClose ? 0x01 : 0) | (enableSound ? 0x02 : 0));

I'm going to admit I haven't tested this.
