### PR TITLE
forceClose enableSound bit-wise probably wrong.

### DIFF
--- a/xbmc/ApplicationMessenger.cpp
+++ b/xbmc/ApplicationMessenger.cpp
@@ -1142,7 +1142,7 @@ void CApplicationMessenger::Show(CGUIDialog *pDialog)
 void CApplicationMessenger::Close(CGUIWindow *window, bool forceClose, bool waitResult /*= true*/, int nextWindowID /*= 0*/, bool enableSound /*= true*/)
 {
   ThreadMessage tMsg = {TMSG_GUI_WINDOW_CLOSE, nextWindowID};
-  tMsg.dwParam2 = (DWORD)(forceClose ? 0x01 : 0 | enableSound ? 0x02 : 0);
+  tMsg.dwParam2 = (DWORD)((forceClose ? 0x01 : 0) | (enableSound ? 0x02 : 0));
   tMsg.lpVoid = window;
   SendMessage(tMsg, waitResult);
 }


### PR DESCRIPTION
I'm determined to figure out this git thing, yet once again I made a mess of a pull request. This should hopefully be better.

(forceClose ? 0x01 : 0 | enableSound ? 0x02 : 0);
is actually (forceClose ? 0x01 : (0 | enableSound) ? 0x02 : 0); based on operator precedence of bit-wise or.

I'm pretty sure based on usage at: https://github.com/xbmc/xbmc/blob/master/xbmc/ApplicationMessenger.cpp#L676

that it should be:
((forceClose ? 0x01 : 0) | (enableSound ? 0x02 : 0));

I'm going to admit I haven't tested this.
