### PR TITLE
[gui] use a background job for fetching the directory for a multiimage

### DIFF
--- a/xbmc/TextureCache.cpp
+++ b/xbmc/TextureCache.cpp
@@ -73,7 +73,8 @@ bool CTextureCache::IsCachedImage(const CStdString &url) const
 bool CTextureCache::HasCachedImage(const CStdString &url)
 {
   CStdString cachedHash;
-  return !GetCachedImage(url, cachedHash).IsEmpty();
+  CStdString cachedImage(GetCachedImage(url, cachedHash));
+  return (!cachedImage.IsEmpty() && cachedImage != url);
 }
 
 CStdString CTextureCache::GetCachedImage(const CStdString &image, CStdString &cachedHash, bool trackUsage)

--- a/xbmc/TextureCache.h
+++ b/xbmc/TextureCache.h
@@ -92,7 +92,8 @@ public:
    */
   CStdString CacheImage(const CStdString &url, CBaseTexture **texture = NULL);
 
-  /*! \brief Check whether an image is cached
+  /*! \brief Check whether an image is in the cache
+   Note: If the image url won't normally be cached (eg a skin image) this function will return false.
    \param image url of the image
    \return true if the image is cached, false otherwise
    \sa ClearCachedImage


### PR DESCRIPTION
Fixes issues where the multiimage path might take some time to resolve (eg an http:// URL without file extension needs mimetype checking in order to know it's an image).  Such http:// URLs are used for fanart from htbackdrops.com.

Aeon Nox has this problem currently, this fixes it.
