### PR TITLE
Cleanup resume

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -4012,6 +4012,14 @@ bool CApplication::PlayFile(const CFileItem& item, bool bRestart)
           options.starttime = bookmark.timeInSeconds;
           options.state = bookmark.playerState;
         }
+        /*
+         override with information from the actual item if available.  We do this as the VFS (eg plugins)
+         may set the resume point to override whatever XBMC has stored, yet we ignore it until now so that,
+         should the playerState be required, it is fetched from the database.
+         See the note in CGUIWindowVideoBase::ShowResumeMenu.
+         */
+        if (item.HasVideoInfoTag() && item.GetVideoInfoTag()->m_resumePoint.IsSet())
+          options.starttime = item.GetVideoInfoTag()->m_resumePoint.timeInSeconds;
       }
       else if (item.HasVideoInfoTag())
       {

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -3822,7 +3822,7 @@ bool CGUIInfoManager::GetItemInt(int &value, const CGUIListItem *item, int info)
   switch (info)
   {
   case LISTITEM_PERCENT_PLAYED:
-    if (item->IsFileItem() && ((const CFileItem *)item)->HasVideoInfoTag() && ((const CFileItem *)item)->GetVideoInfoTag()->m_resumePoint.totalTimeInSeconds > 0 && ((const CFileItem *)item)->GetVideoInfoTag()->m_resumePoint.timeInSeconds > 0)
+    if (item->IsFileItem() && ((const CFileItem *)item)->HasVideoInfoTag() && ((const CFileItem *)item)->GetVideoInfoTag()->m_resumePoint.IsPartWay())
       value = (int)(100 * ((const CFileItem *)item)->GetVideoInfoTag()->m_resumePoint.timeInSeconds / ((const CFileItem *)item)->GetVideoInfoTag()->m_resumePoint.totalTimeInSeconds);
     else
       value = 0;

--- a/xbmc/ThumbLoader.cpp
+++ b/xbmc/ThumbLoader.cpp
@@ -199,8 +199,7 @@ bool CVideoThumbLoader::LoadItem(CFileItem* pItem)
   m_database->Open();
 
   // resume point
-  if (pItem->HasVideoInfoTag() &&
-      pItem->GetVideoInfoTag()->m_resumePoint.type != CBookmark::RESUME && pItem->GetVideoInfoTag()->m_resumePoint.totalTimeInSeconds == 0)
+  if (pItem->HasVideoInfoTag() && !pItem->GetVideoInfoTag()->m_resumePoint.IsSet())
   {
     if (m_database->GetResumePoint(*pItem->GetVideoInfoTag()))
       pItem->SetInvalid();

--- a/xbmc/filesystem/PluginDirectory.cpp
+++ b/xbmc/filesystem/PluginDirectory.cpp
@@ -35,6 +35,7 @@
 #include "dialogs/GUIDialogProgress.h"
 #include "settings/GUISettings.h"
 #include "FileItem.h"
+#include "video/VideoInfoTag.h"
 #include "guilib/LocalizeStrings.h"
 #include "utils/log.h"
 #include "utils/TimeUtils.h"
@@ -148,6 +149,8 @@ bool CPluginDirectory::GetPluginResult(const CStdString& strPath, CFileItem &res
     resultItem.SetPath(newDir->m_fileResult->GetPath());
     resultItem.SetMimeType(newDir->m_fileResult->GetMimeType(false));
     resultItem.UpdateInfo(*newDir->m_fileResult);
+    if (newDir->m_fileResult->HasVideoInfoTag() && newDir->m_fileResult->GetVideoInfoTag()->m_resumePoint.IsSet())
+      resultItem.m_lStartOffset = STARTOFFSET_RESUME; // resume point set in the resume item, so force resume
   }
   delete newDir;
 

--- a/xbmc/interfaces/python/xbmcmodule/listitem.cpp
+++ b/xbmc/interfaces/python/xbmcmodule/listitem.cpp
@@ -755,13 +755,13 @@ namespace PYXBMC
     "       You can use the above as keywords for arguments and skip certain optional arguments.\n"
     "       Once you use a keyword, all following arguments require the keyword.\n"
     "\n"
-    " Some of these are treated internally by XBMC, such as the 'StartOffset' property, which is\n"
-    " the offset in seconds at which to start playback of an item.  Others may be used in the skin\n"
-    " to add extra information, such as 'WatchedCount' for tvshow items\n"
+    " Some of these are treated internally by XBMC.\n"
+    " Others may be used in the skin to add extra information, such as 'WatchedCount' for tvshow items\n"
     "\n"
     "example:\n"
     "  - self.list.getSelectedItem().setProperty('AspectRatio', '1.85 : 1')\n"
-    "  - self.list.getSelectedItem().setProperty('StartOffset', '256.4')\n");
+    "  - self.list.getSelectedItem().setProperty('TotalTime', '3668.4')\n"
+    "  - self.list.getSelectedItem().setProperty('ResumeTime', '306.8')\n");
 
   PyObject* ListItem_SetProperty(ListItem *self, PyObject *args, PyObject *kwds)
   {
@@ -798,6 +798,10 @@ namespace PYXBMC
     { // special case for mime type - don't actually stored in a property,
       self->item->SetMimeType(uText);
     }
+    else if (lowerKey.CompareNoCase("totaltime") == 0)
+      self->item->GetVideoInfoTag()->m_resumePoint.totalTimeInSeconds = (float)atof(uText.c_str());
+    else if (lowerKey.CompareNoCase("resumetime") == 0)
+      self->item->GetVideoInfoTag()->m_resumePoint.timeInSeconds = (float)atof(uText.c_str());
     else if (lowerKey.CompareNoCase("specialsort") == 0)
     {
       if (uText == "bottom")
@@ -851,6 +855,10 @@ namespace PYXBMC
       // we store it in item.m_lStartOffset instead
       value.Format("%f", self->item->m_lStartOffset / 75.0);
     }
+    else if (lowerKey.CompareNoCase("totaltime") == 0)
+      value.Format("%f", self->item->GetVideoInfoTag()->m_resumePoint.totalTimeInSeconds);
+    else if (lowerKey.CompareNoCase("resumetime") == 0)
+      value.Format("%f", self->item->GetVideoInfoTag()->m_resumePoint.timeInSeconds);
     else
       value = self->item->GetProperty(lowerKey.ToLower()).asString();
     PyXBMCGUIUnlock();

--- a/xbmc/video/Bookmark.cpp
+++ b/xbmc/video/Bookmark.cpp
@@ -36,3 +36,12 @@ void CBookmark::Reset()
   type = STANDARD;
 }
 
+bool CBookmark::IsSet() const
+{
+  return totalTimeInSeconds > 0.0f;
+}
+
+bool CBookmark::IsPartWay() const
+{
+  return totalTimeInSeconds > 0.0f && timeInSeconds > 0.0f;
+}

--- a/xbmc/video/Bookmark.h
+++ b/xbmc/video/Bookmark.h
@@ -29,6 +29,17 @@ class CBookmark
 public:
   CBookmark();
   void Reset();
+
+  /*! \brief returns true if this bookmark has been set.
+   \return true if totalTimeInSeconds is positive.
+   */
+  bool IsSet() const;
+
+  /*! \brief returns true if this bookmark is part way through the video file
+   \return true if both totalTimeInSeconds and timeInSeconds are positive.
+   */
+  bool IsPartWay() const;
+
   double timeInSeconds;
   double totalTimeInSeconds;
   long partNumber;

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -4130,9 +4130,12 @@ bool CVideoDatabase::GetPlayCounts(const CStdString &strPath, CFileItemList &ite
       if (item)
       {
         item->GetVideoInfoTag()->m_playCount = m_pDS->fv(1).get_asInt();
-        item->GetVideoInfoTag()->m_resumePoint.timeInSeconds = m_pDS->fv(2).get_asInt();
-        item->GetVideoInfoTag()->m_resumePoint.totalTimeInSeconds = m_pDS->fv(3).get_asInt();
-        item->GetVideoInfoTag()->m_resumePoint.type = CBookmark::RESUME;
+        if (!item->GetVideoInfoTag()->m_resumePoint.IsSet())
+        {
+          item->GetVideoInfoTag()->m_resumePoint.timeInSeconds = m_pDS->fv(2).get_asInt();
+          item->GetVideoInfoTag()->m_resumePoint.totalTimeInSeconds = m_pDS->fv(3).get_asInt();
+          item->GetVideoInfoTag()->m_resumePoint.type = CBookmark::RESUME;
+        }
       }
       m_pDS->next();
     }

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -402,6 +402,7 @@ public:
   void UpdateLastPlayed(const CFileItem &item);
 
   /*! \brief Get the playcount and resume point of a list of items
+   Note that if the resume point is already set on an item, it won't be overridden.
    \param path the path to fetch videos from
    \param items CFileItemList to fetch the playcounts for
    \sa GetPlayCount, SetPlayCount, IncrementPlayCount

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -1106,7 +1106,7 @@ namespace VIDEO
       m_database.SetPlayCount(*pItem, movieDetails.m_playCount, movieDetails.m_lastPlayed);
 
     if ((g_advancedSettings.m_bVideoLibraryImportResumePoint || libraryImport) &&
-        movieDetails.m_resumePoint.IsPartWay())
+        movieDetails.m_resumePoint.IsSet())
       m_database.AddBookMarkToFile(pItem->GetPath(), movieDetails.m_resumePoint, CBookmark::RESUME);
 
     m_database.Close();

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -1106,7 +1106,7 @@ namespace VIDEO
       m_database.SetPlayCount(*pItem, movieDetails.m_playCount, movieDetails.m_lastPlayed);
 
     if ((g_advancedSettings.m_bVideoLibraryImportResumePoint || libraryImport) &&
-        movieDetails.m_resumePoint.timeInSeconds > 0.0f && movieDetails.m_resumePoint.totalTimeInSeconds > 0.0f)
+        movieDetails.m_resumePoint.IsPartWay())
       m_database.AddBookMarkToFile(pItem->GetPath(), movieDetails.m_resumePoint, CBookmark::RESUME);
 
     m_database.Close();

--- a/xbmc/video/VideoInfoTag.cpp
+++ b/xbmc/video/VideoInfoTag.cpp
@@ -536,7 +536,7 @@ void CVideoInfoTag::ToSortable(SortItem& sortable)
   
   sortable[FieldSubtitleLanguage] = m_streamDetails.GetSubtitleLanguage();
 
-  sortable[FieldInProgress] = m_resumePoint.timeInSeconds > 0 && m_resumePoint.totalTimeInSeconds > 0;
+  sortable[FieldInProgress] = m_resumePoint.IsPartWay();
   sortable[FieldDateAdded] = m_dateAdded.IsValid() ? m_dateAdded.GetAsDBDateTime() : StringUtils::EmptyString;
   sortable[FieldMediaType] = DatabaseUtils::MediaTypeFromString(m_type);
 }

--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -827,7 +827,7 @@ void CGUIWindowVideoBase::GetResumeItemOffset(const CFileItem *item, int& starto
 
   if (!item->IsNFO() && !item->IsPlayList())
   {
-    if (item->HasVideoInfoTag() && item->GetVideoInfoTag()->m_resumePoint.IsPartWay())
+    if (item->HasVideoInfoTag() && item->GetVideoInfoTag()->m_resumePoint.IsSet())
     {
       startoffset = (int)(item->GetVideoInfoTag()->m_resumePoint.timeInSeconds*75);
       partNumber = item->GetVideoInfoTag()->m_resumePoint.partNumber;

--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -827,7 +827,7 @@ void CGUIWindowVideoBase::GetResumeItemOffset(const CFileItem *item, int& starto
 
   if (!item->IsNFO() && !item->IsPlayList())
   {
-    if (item->HasVideoInfoTag() && item->GetVideoInfoTag()->m_resumePoint.timeInSeconds > 0.0)
+    if (item->HasVideoInfoTag() && item->GetVideoInfoTag()->m_resumePoint.IsPartWay())
     {
       startoffset = (int)(item->GetVideoInfoTag()->m_resumePoint.timeInSeconds*75);
       partNumber = item->GetVideoInfoTag()->m_resumePoint.partNumber;

--- a/xbmc/video/windows/GUIWindowVideoBase.h
+++ b/xbmc/video/windows/GUIWindowVideoBase.h
@@ -50,7 +50,10 @@ public:
 
 
   /*! \brief Show the resume menu for this item (if it has a resume bookmark)
-   If a resume bookmark is found, we set the item's m_lStartOffset to STARTOFFSET_RESUME
+   If a resume bookmark is found, we set the item's m_lStartOffset to STARTOFFSET_RESUME.
+   Note that we do this in favour of setting the resume point, as we need additional
+   information from the database (in particular, the playerState) when resuming some items
+   (eg ISO/VIDEO_TS).
    \param item item to check for a resume bookmark
    \return true if an option was chosen, false if the resume menu was cancelled.
    */
@@ -77,7 +80,7 @@ public:
    \param item selected item
    \return string containing the resume position or an empty string if there is no resume position
    */
-  static CStdString GetResumeString(CFileItem item);
+  static CStdString GetResumeString(const CFileItem &item);
 
 protected:
   void OnScan(const CStdString& strPath, bool scanAll = false);


### PR DESCRIPTION
This cleans up the resume handling to use m_resumePoint in the videoinfotag if available.  It means we don't necessarily have to hit the database if we already have the information.

Further, it means that directory classes (eg plugins + upnp) can supply the details for resuming directly for those items that aren't in the local database (indeed, it would bypass the local database).  The intention is that a handler (eg using JSON-RPC) for these directory classes would then update the source of that information (eg update a upnp server) when an item from that directory class is stopped part-way.

There is a question of whether resume points should be stored for such items locally at all - currently there is no way to differentiate those, but now that the resume point structure is being used, this could be changed.

Plugins can also override any resume information during setResolvedUrl() on playback should they wish (request from plugin authors).

Comments welcome.
