### PR TITLE
[win32] fix some warnings

### DIFF
--- a/xbmc/cores/AudioEngine/Engines/SoftAE/SoftAEStream.cpp
+++ b/xbmc/cores/AudioEngine/Engines/SoftAE/SoftAEStream.cpp
@@ -192,8 +192,8 @@ void CSoftAEStream::Initialize()
     m_ssrcData.data_in       = m_convertBuffer;
     m_internalRatio          = (double)AE.GetSampleRate() / (double)m_initSampleRate;
     m_ssrcData.src_ratio     = m_internalRatio;
-    m_ssrcData.data_out      = (float*)_aligned_malloc(m_format.m_frameSamples * std::ceil(m_ssrcData.src_ratio) * sizeof(float), 16);
-    m_ssrcData.output_frames = m_format.m_frames * std::ceil(m_ssrcData.src_ratio);
+    m_ssrcData.data_out      = (float*)_aligned_malloc(m_format.m_frameSamples * (int)std::ceil(m_ssrcData.src_ratio) * sizeof(float), 16);
+    m_ssrcData.output_frames = m_format.m_frames * (long)std::ceil(m_ssrcData.src_ratio);
     m_ssrcData.end_of_input  = 0;
   }
 
@@ -595,7 +595,7 @@ bool CSoftAEStream::SetResampleRatio(double ratio)
 
   CSharedLock lock(m_lock);
 
-  int oldRatioInt = std::ceil(m_ssrcData.src_ratio);
+  int oldRatioInt = (int)std::ceil(m_ssrcData.src_ratio);
 
   m_resampleRatio = ratio;
 
@@ -606,8 +606,8 @@ bool CSoftAEStream::SetResampleRatio(double ratio)
   if (oldRatioInt < std::ceil(m_ssrcData.src_ratio))
   {
     _aligned_free(m_ssrcData.data_out);
-    m_ssrcData.data_out      = (float*)_aligned_malloc(m_format.m_frameSamples * std::ceil(m_ssrcData.src_ratio) * sizeof(float), 16);
-    m_ssrcData.output_frames = m_format.m_frames * std::ceil(m_ssrcData.src_ratio);
+    m_ssrcData.data_out      = (float*)_aligned_malloc(m_format.m_frameSamples * (int)std::ceil(m_ssrcData.src_ratio) * sizeof(float), 16);
+    m_ssrcData.output_frames = m_format.m_frames * (long)std::ceil(m_ssrcData.src_ratio);
   }
   return true;
 }

--- a/xbmc/cores/VideoRenderers/VideoShaders/YUV2RGBShader.cpp
+++ b/xbmc/cores/VideoRenderers/VideoShaders/YUV2RGBShader.cpp
@@ -120,9 +120,9 @@ void CalculateYUVMatrix(TransformMatrix &matrix
 
   if(format == RENDER_FMT_YUV420P10)
   {
-    matrix *= TransformMatrix::CreateScaler(65535.0 / 1023.0
-                                          , 65535.0 / 1023.0
-                                          , 65535.0 / 1023.0);
+    matrix *= TransformMatrix::CreateScaler(65535.0f / 1023.0f
+                                          , 65535.0f / 1023.0f
+                                          , 65535.0f / 1023.0f);
   }
 }
 

--- a/xbmc/cores/dvdplayer/DVDCodecs/Audio/DVDAudioCodecPassthroughFFmpeg.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Audio/DVDAudioCodecPassthroughFFmpeg.cpp
@@ -465,11 +465,7 @@ int CDVDAudioCodecPassthroughFFmpeg::GetChannels()
 {
   //Can't return correct channels here as this is used to keep sync.
   //should probably have some other way to find out this
-  switch(m_codec)
-  {
-    default:
-      return 2;
-  }
+  return 2;
 }
 
 int CDVDAudioCodecPassthroughFFmpeg::GetSampleRate()
@@ -642,9 +638,5 @@ CAEChannelInfo CDVDAudioCodecPassthroughFFmpeg::GetChannelMap()
     {AE_CH_RAW, AE_CH_RAW, AE_CH_RAW, AE_CH_RAW, AE_CH_RAW, AE_CH_RAW, AE_CH_RAW, AE_CH_RAW, AE_CH_NULL}
   };
 
-  switch(m_codec)
-  {
-    default:
-      return map[0];
-  }
+  return map[0];
 }

--- a/xbmc/cores/dvdplayer/DVDMessageQueue.cpp
+++ b/xbmc/cores/dvdplayer/DVDMessageQueue.cpp
@@ -264,7 +264,7 @@ int CDVDMessageQueue::GetTimeSize() const
   if(IsDataBased())
     return 0;
   else
-    return (m_TimeFront - m_TimeBack) / DVD_TIME_BASE;
+    return (int)((m_TimeFront - m_TimeBack) / DVD_TIME_BASE);
 }
 
 bool CDVDMessageQueue::IsDataBased() const

--- a/xbmc/dbwrappers/mysqldataset.cpp
+++ b/xbmc/dbwrappers/mysqldataset.cpp
@@ -460,7 +460,7 @@ string MysqlDatabase::vprepare(const char *format, va_list args)
 
 #define etINVALID     0 /* Any unrecognized conversion type */
 
-#define ARRAYSIZE(X)    ((int)(sizeof(X)/sizeof(X[0])))
+#define ARRAY_SIZE(X)    ((int)(sizeof(X)/sizeof(X[0])))
 
 /*
 ** An "etByte" is an 8-bit unsigned value.
@@ -732,7 +732,7 @@ void MysqlDatabase::mysqlVXPrintf(
     /* Fetch the info entry for the field */
     infop = &fmtinfo[0];
     xtype = etINVALID;
-    for(idx=0; idx<ARRAYSIZE(fmtinfo); idx++){
+    for(idx=0; idx<ARRAY_SIZE(fmtinfo); idx++){
       if( c==fmtinfo[idx].fmttype ){
         infop = &fmtinfo[idx];
         if( useExtended || (infop->flags & FLAG_INTERN)==0 ){

--- a/xbmc/filesystem/udf25.cpp
+++ b/xbmc/filesystem/udf25.cpp
@@ -422,7 +422,7 @@ static int file_read(CFile* fp, void *buffer, int blocks, int flags)
       /* Nothing more to read.  Return all of the whole blocks, if any.
        * Adjust the file position back to the previous block boundary. */
       size_t bytes = (size_t)blocks * DVD_VIDEO_LB_LEN - len;
-      off_t over_read = -(bytes % DVD_VIDEO_LB_LEN);
+      off_t over_read = -(off_t)(bytes % DVD_VIDEO_LB_LEN);
       /*off_t pos =*/ fp->Seek(over_read, SEEK_CUR);
       /* should have pos % 2048 == 0 */
       return (int) (bytes / DVD_VIDEO_LB_LEN);


### PR DESCRIPTION
These commits fix some warnings the VC++ compiler throws at us. IMO the only non straight forward fix is in udf25.cpp. Not sure if this behaviour is/was intended and shouldn't be fixed or if it is a bug.
