### PR TITLE
Only set season/epnum from filename when it is not already set by a scraper

### DIFF
--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -1357,8 +1357,13 @@ namespace VIDEO
         item.SetPath(file->strPath);
         if (!imdb.GetEpisodeDetails(guide->cScraperUrl, *item.GetVideoInfoTag(), pDlgProgress))
           return INFO_NOT_FOUND; // TODO: should we just skip to the next episode?
-        item.GetVideoInfoTag()->m_iSeason = guide->key.first;
-        item.GetVideoInfoTag()->m_iEpisode = guide->key.second;
+          
+        // Only set season/epnum from filename when it is not already set by a scraper
+        if (item.GetVideoInfoTag()->m_iSeason == -1)
+          item.GetVideoInfoTag()->m_iSeason = guide->key.first;
+        if (item.GetVideoInfoTag()->m_iEpisode == -1)
+          item.GetVideoInfoTag()->m_iEpisode = guide->key.second;
+          
         if (AddVideo(&item, CONTENT_TVSHOWS, file->isFolder, useLocal, idShow) < 0)
           return INFO_ERROR;
       }


### PR DESCRIPTION
This pull request allows the scraper to define the season/epnum that XBMC uses instead of forcing it to be the season/epnum that was gathered from the filename. If the scraper doesn't set the season/epnum then it falls back to the current method of using the filename.

The reasoning behind this request is to simply allow the season/epnum in the library to be set independently of what the filename indicates while using an external scraper. Since it can already be independently set using an .nfo file I think it makes sense to try to allow a scraper to do the same.

An example of a scenario where this is useful is Anime where the files are numbered absolutely (i.e. they are all part of one season 1x001...1x257) but the user wants them in the order that is provided by the scraper (i.e. across multiple seasons S1E1...S12E8). See http://forum.xbmc.org/showthread.php?tid=136169 for some background info.

I have tested the changes using various scrapers and the results are as expected so hopefully you will consider this request.
