### PR TITLE
Remove unused code and messages for auto-detecting FTP servers on networked XBOXs

### DIFF
--- a/language/English/strings.po
+++ b/language/English/strings.po
@@ -3158,39 +3158,7 @@ msgctxt "#1235"
 msgid "Programs & pictures & video"
 msgstr ""
 
-#empty strings from id 1236 to 1249
-
-msgctxt "#1250"
-msgid "Auto-detection"
-msgstr ""
-
-msgctxt "#1251"
-msgid "Auto-detect system"
-msgstr ""
-
-msgctxt "#1252"
-msgid "Nickname"
-msgstr ""
-
-#empty string with id 1253
-
-msgctxt "#1254"
-msgid "Ask to connect"
-msgstr ""
-
-msgctxt "#1255"
-msgid "Send FTP user and password"
-msgstr ""
-
-msgctxt "#1256"
-msgid "Ping interval"
-msgstr ""
-
-msgctxt "#1257"
-msgid "Would you like to connect to the auto-detected system?"
-msgstr ""
-
-#empty string with id 1258
+#empty strings from id 1236 to 1258
 
 msgctxt "#1259"
 msgid "Zeroconf"

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -129,8 +129,6 @@ void CAdvancedSettings::Initialize()
   m_lcdScrolldelay = 1;
   m_lcdHostName = "localhost";
 
-  m_autoDetectPingTime = 30;
-
   m_songInfoDuration = 10;
   m_busyDialogDelay = 2000;
 
@@ -660,7 +658,6 @@ void CAdvancedSettings::ParseSettingsFile(const CStdString &file)
   pElement = pRootElement->FirstChildElement("network");
   if (pElement)
   {
-    XMLUtils::GetInt(pElement, "autodetectpingtime", m_autoDetectPingTime, 1, 240);
     XMLUtils::GetInt(pElement, "curlclienttimeout", m_curlconnecttimeout, 1, 1000);
     XMLUtils::GetInt(pElement, "curllowspeedtime", m_curllowspeedtime, 1, 1000);
     XMLUtils::GetInt(pElement, "curlretries", m_curlretries, 0, 10);

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -175,8 +175,6 @@ class CAdvancedSettings
     int m_lcdScrolldelay;
     CStdString m_lcdHostName;
 
-    int m_autoDetectPingTime;
-
     int m_songInfoDuration;
     int m_busyDialogDelay;
     int m_logLevel;


### PR DESCRIPTION
Orphaning commit is "cleanup: removed old legacy _XBOX and HAS_FTP_SERVER code"
- SVN r23852 http://xbmc.svn.sourceforge.net/viewvc/xbmc?view=revision&revision=23852
- GIT 5a4c8c6 https://github.com/xbmc/xbmc-antiquated/commit/5a4c8c66aeac4

Reason for PR is if messages should be deleted in other languages or if our translation system handles that automatically
