### PR TITLE
Don't adjust refreshrate back to RES_DESKTOP while movie is still playing...

### DIFF
--- a/language/English/strings.po
+++ b/language/English/strings.po
@@ -9497,3 +9497,14 @@ msgctxt "#36033"
 msgid "Pause playback when switching to another source"
 msgstr ""
 
+#. adjust refreshrate  
+#: xbmc/settings/GUISettings.cpp
+msgctxt "#36035"
+msgid "Always"
+msgstr ""
+
+#. adjust refreshrate  
+#: xbmc/settings/GUISettings.cpp
+msgctxt "#36036"
+msgid "On start/stop"
+msgstr ""

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -2492,7 +2492,7 @@ bool CApplication::OnKey(const CKey& key)
 
   bool bResult = false;
 
-  // play sound before the action unless the button is held, 
+  // play sound before the action unless the button is held,
   // where we execute after the action as held actions aren't fired every time.
   if(action.GetHoldTime())
   {
@@ -3335,7 +3335,7 @@ bool CApplication::ProcessJoystickEvent(const std::string& joystickName, int wKe
      CAction action(actionID, fAmount, 0.0f, actionName, holdTime);
      bool bResult = false;
 
-     // play sound before the action unless the button is held, 
+     // play sound before the action unless the button is held,
      // where we execute after the action as held actions aren't fired every time.
      if(action.GetHoldTime())
      {

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -4282,6 +4282,9 @@ void CApplication::OnQueueNextItem()
 
 void CApplication::OnPlayBackStopped()
 {
+  //resets to res_desktop or look&feel resolution (including refreshrate)
+  g_graphicsContext.SetFullScreenVideo(false);
+
   if(m_bPlaybackStarting)
     return;
 
@@ -4567,6 +4570,9 @@ void CApplication::StopPlaying()
 
     if (m_pPlayer)
       m_pPlayer->CloseFile();
+
+    //resets to res_desktop or look&feel resolution (including refreshrate)
+    g_graphicsContext.SetFullScreenVideo(false);
 
     // turn off visualisation window when stopping
     if (iWin == WINDOW_VISUALISATION

--- a/xbmc/cores/VideoRenderers/BaseRenderer.cpp
+++ b/xbmc/cores/VideoRenderers/BaseRenderer.cpp
@@ -68,7 +68,7 @@ void CBaseRenderer::ChooseBestResolution(float fps)
 
   // Adjust refreshrate to match source fps
 #if !defined(TARGET_DARWIN_IOS)
-  if (g_guiSettings.GetBool("videoplayer.adjustrefreshrate"))
+  if (g_guiSettings.GetInt("videoplayer.adjustrefreshrate") != ADJUST_REFRESHRATE_OFF)
   {
     float weight;
     if (!FindResolutionFromOverride(fps, weight, false)) //find a refreshrate from overrides

--- a/xbmc/cores/VideoRenderers/BaseRenderer.cpp
+++ b/xbmc/cores/VideoRenderers/BaseRenderer.cpp
@@ -45,7 +45,7 @@ CBaseRenderer::CBaseRenderer()
   for(int i=0; i < 4; i++)
   {
     m_rotatedDestCoords[i].x = 0;
-    m_rotatedDestCoords[i].y = 0;    
+    m_rotatedDestCoords[i].y = 0;
   }
 
   m_RenderUpdateCallBackFn = NULL;
@@ -253,7 +253,7 @@ void CBaseRenderer::GetVideoRect(CRect &source, CRect &dest)
 inline void CBaseRenderer::ReorderDrawPoints()
 {
   // 0 - top left, 1 - top right, 2 - bottom right, 3 - bottom left
-  float origMat[4][2] = {{m_destRect.x1, m_destRect.y1}, 
+  float origMat[4][2] = {{m_destRect.x1, m_destRect.y1},
                          {m_destRect.x2, m_destRect.y1},
                          {m_destRect.x2, m_destRect.y2},
                          {m_destRect.x1, m_destRect.y2}};
@@ -274,7 +274,7 @@ inline void CBaseRenderer::ReorderDrawPoints()
       changeAspect = true;
       break;
   }
-  
+
   // if renderer doesn't support rotation
   // treat orientation as 0 degree so that
   // ffmpeg might handle it.
@@ -283,7 +283,7 @@ inline void CBaseRenderer::ReorderDrawPoints()
     pointOffset = 0;
     changeAspect = false;
   }
-  
+
 
   int diff = (int) ((m_destRect.Height() - m_destRect.Width()) / 2);
 

--- a/xbmc/cores/dvdplayer/DVDPlayerVideo.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayerVideo.cpp
@@ -526,7 +526,7 @@ void CDVDPlayerVideo::Process()
         if (mDeintMode == VS_DEINTERLACEMODE_AUTO && mFilters)
           mFilters |=  CDVDVideoCodec::FILTER_DEINTERLACE_FLAGGED;
       }
-      
+
       if (!g_renderManager.Supports(RENDERFEATURE_ROTATION))
         mFilters |= CDVDVideoCodec::FILTER_ROTATE;
 
@@ -538,7 +538,7 @@ void CDVDPlayerVideo::Process()
       if(m_pVideoCodec->GetConvergeCount() > 0)
       {
         m_packets.push_back(DVDMessageListItem(pMsg, 0));
-        if(m_packets.size() > m_pVideoCodec->GetConvergeCount() 
+        if(m_packets.size() > m_pVideoCodec->GetConvergeCount()
         || m_packets.size() * frametime > DVD_SEC_TO_TIME(10))
           m_packets.pop_front();
       }
@@ -609,7 +609,7 @@ void CDVDPlayerVideo::Process()
               m_iNrOfPicturesNotToSkip--;
             }
 
-            // validate picture timing, 
+            // validate picture timing,
             // if both dts/pts invalid, use pts calulated from picture.iDuration
             // if pts invalid use dts, else use picture.pts as passed
             if (picture.dts == DVD_NOPTS_VALUE && picture.pts == DVD_NOPTS_VALUE)

--- a/xbmc/cores/dvdplayer/DVDPlayerVideo.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayerVideo.cpp
@@ -223,7 +223,7 @@ void CDVDPlayerVideo::OpenStream(CDVDStreamInfo &hint, CDVDVideoCodec* codec)
   m_bFpsInvalid = (hint.fpsrate == 0 || hint.fpsscale == 0);
 
   m_bCalcFrameRate = g_guiSettings.GetBool("videoplayer.usedisplayasclock") ||
-                     g_guiSettings.GetBool("videoplayer.adjustrefreshrate");
+                     g_guiSettings.GetInt("videoplayer.adjustrefreshrate") != ADJUST_REFRESHRATE_OFF;
   ResetFrameRateCalc();
 
   m_iDroppedRequest = 0;

--- a/xbmc/guilib/GraphicContext.cpp
+++ b/xbmc/guilib/GraphicContext.cpp
@@ -43,19 +43,18 @@ extern bool g_fullScreen;
 static CSettingInt* g_guiSkinzoom = NULL;
 
 CGraphicContext::CGraphicContext(void) :
-  m_iScreenHeight(576), 
-  m_iScreenWidth(720), 
-  m_iScreenId(0), 
-  m_strMediaDir(""), 
-  /*m_videoRect,*/ 
-  m_bFullScreenRoot(false), 
+  m_iScreenHeight(576),
+  m_iScreenWidth(720),
+  m_iScreenId(0),
+  /*m_videoRect,*/
+  m_bFullScreenRoot(false),
   m_bFullScreenVideo(false),
-  m_bCalibrating(false), 
-  m_Resolution(RES_INVALID), 
+  m_bCalibrating(false),
+  m_Resolution(RES_INVALID),
   /*m_windowResolution,*/
-  m_guiScaleX(1.0f), 
-  m_guiScaleY(1.0f) 
-  /*,m_cameras, */ 
+  m_guiScaleX(1.0f),
+  m_guiScaleY(1.0f)
+  /*,m_cameras, */
   /*m_origins, */
   /*m_clipRegions,*/
   /*m_guiTransform,*/

--- a/xbmc/guilib/GraphicContext.cpp
+++ b/xbmc/guilib/GraphicContext.cpp
@@ -279,7 +279,8 @@ void CGraphicContext::SetFullScreenVideo(bool bOnOff)
 #if defined(HAS_VIDEO_PLAYBACK)
   if(m_bFullScreenRoot)
   {
-    if(m_bFullScreenVideo)
+    bool allowDesktopRes = g_guiSettings.GetInt("videoplayer.adjustrefreshrate") == ADJUST_REFRESHRATE_ALWAYS;
+    if(m_bFullScreenVideo || (!allowDesktopRes && g_application.IsPlayingVideo()))
       SetVideoResolution(g_renderManager.GetResolution());
     else if(g_guiSettings.m_LookAndFeelResolution > RES_DESKTOP)
       SetVideoResolution(g_guiSettings.m_LookAndFeelResolution);
@@ -340,7 +341,7 @@ void CGraphicContext::SetVideoResolution(RESOLUTION res, bool forceUpdate)
   {
     //pause the player during the refreshrate change
     int delay = g_guiSettings.GetInt("videoplayer.pauseafterrefreshchange");
-    if (delay > 0 && g_guiSettings.GetBool("videoplayer.adjustrefreshrate") && g_application.IsPlayingVideo() && !g_application.IsPaused())
+    if (delay > 0 && g_guiSettings.GetInt("videoplayer.adjustrefreshrate") != ADJUST_REFRESHRATE_OFF && g_application.IsPlayingVideo() && !g_application.IsPaused())
     {
       g_application.m_pPlayer->Pause();
       ThreadMessage msg = {TMSG_MEDIA_UNPAUSE};

--- a/xbmc/settings/GUISettings.cpp
+++ b/xbmc/settings/GUISettings.cpp
@@ -414,7 +414,7 @@ void CGUISettings::Initialize()
 #endif
   AddBool(showSetting ? vs : NULL, "videoscreen.fakefullscreen", 14083, fakeFullScreen);
 #ifdef TARGET_DARWIN_IOS
-  AddBool(NULL, "videoscreen.blankdisplays", 13130, false);  
+  AddBool(NULL, "videoscreen.blankdisplays", 13130, false);
 #else
   AddBool(vs, "videoscreen.blankdisplays", 13130, false);
 #endif
@@ -739,7 +739,7 @@ void CGUISettings::Initialize()
   myVideosSelectActions.insert(make_pair(208,   SELECT_ACTION_PLAY_OR_RESUME));
   myVideosSelectActions.insert(make_pair(13404, SELECT_ACTION_RESUME));
   myVideosSelectActions.insert(make_pair(22081, SELECT_ACTION_INFO));
-  
+
   AddInt(vid, "myvideos.selectaction", 22079, SELECT_ACTION_PLAY_OR_RESUME, myVideosSelectActions, SPIN_CONTROL_TEXT);
   AddBool(vid, "myvideos.extractflags",20433, true);
   AddBool(vid, "myvideos.replacelabels", 20419, true);
@@ -820,7 +820,7 @@ void CGUISettings::Initialize()
   CSettingsCategory* srvAirplay = AddCategory(6, "airplay", 1273);
   AddBool(srvAirplay, "services.airplay", 1270, false);
   AddBool(srvAirplay, "services.useairplaypassword", 1272, false);
-  AddString(srvAirplay, "services.airplaypassword", 733, "", EDIT_CONTROL_HIDDEN_INPUT, false, 733); 
+  AddString(srvAirplay, "services.airplaypassword", 733, "", EDIT_CONTROL_HIDDEN_INPUT, false, 733);
 #endif
 
 #ifndef _WIN32
@@ -847,21 +847,21 @@ void CGUISettings::Initialize()
   AddString(loc, "locale.language",248,"english", SPIN_CONTROL_TEXT);
   AddString(loc, "locale.country", 20026, "USA", SPIN_CONTROL_TEXT);
   AddString(loc, "locale.charset", 14091, "DEFAULT", SPIN_CONTROL_TEXT); // charset is set by the language file
-  
+
   bool use_timezone = false;
-  
+
 #if defined(_LINUX)
 #if defined(TARGET_DARWIN)
   if (g_sysinfo.IsAppleTV2() && GetIOSVersion() < 4.3)
 #endif
-    use_timezone = true;  
-  
+    use_timezone = true;
+
   if (use_timezone)
-  {  
+  {
     AddSeparator(loc, "locale.sep1");
     AddString(loc, "locale.timezonecountry", 14079, g_timezone.GetCountryByTimezone(g_timezone.GetOSConfiguredTimezone()), SPIN_CONTROL_TEXT);
     AddString(loc, "locale.timezone", 14080, g_timezone.GetOSConfiguredTimezone(), SPIN_CONTROL_TEXT);
-  }	
+  }
 #endif
 #ifdef HAS_TIME_SERVER
   AddSeparator(loc, "locale.sep2");
@@ -1259,24 +1259,24 @@ void CGUISettings::LoadXML(TiXmlElement *pRootElement, bool hideSettings /* = fa
   m_replayGain.iNoGainPreAmp = GetInt("musicplayer.replaygainnogainpreamp");
   m_replayGain.iType = GetInt("musicplayer.replaygaintype");
   m_replayGain.bAvoidClipping = GetBool("musicplayer.replaygainavoidclipping");
-  
+
   bool use_timezone = false;
-  
+
 #if defined(_LINUX)
-#if defined(TARGET_DARWIN) 
+#if defined(TARGET_DARWIN)
   if (g_sysinfo.IsAppleTV2() && GetIOSVersion() < 4.3)
 #endif
     use_timezone = true;
-  
+
   if (use_timezone)
-  {  
+  {
     CStdString timezone = GetString("locale.timezone");
     if(timezone == "0" || timezone.IsEmpty())
     {
       timezone = g_timezone.GetOSConfiguredTimezone();
       SetString("locale.timezone", timezone);
     }
-    g_timezone.SetTimezone(timezone);	
+    g_timezone.SetTimezone(timezone);
   }
 #endif
 

--- a/xbmc/settings/GUISettings.cpp
+++ b/xbmc/settings/GUISettings.cpp
@@ -683,11 +683,19 @@ void CGUISettings::Initialize()
   // FIXME: hide this setting until it is properly respected. In the meanwhile, default to AUTO.
   //AddInt(5, "videoplayer.displayresolution", 169, (int)RES_AUTORES, (int)RES_AUTORES, 1, (int)CUSTOM+MAX_RESOLUTIONS, SPIN_CONTROL_TEXT);
   AddInt(NULL, "videoplayer.displayresolution", 169, (int)RES_AUTORES, (int)RES_AUTORES, 1, (int)RES_AUTORES, SPIN_CONTROL_TEXT);
+
+  map<int, int> adjustTypes;
+  adjustTypes.insert(make_pair(351, ADJUST_REFRESHRATE_OFF));
+  adjustTypes.insert(make_pair(36035, ADJUST_REFRESHRATE_ALWAYS));
+  adjustTypes.insert(make_pair(36036, ADJUST_REFRESHRATE_ON_STARTSTOP));
+
 #if !defined(TARGET_DARWIN_IOS)
-  AddBool(vp, "videoplayer.adjustrefreshrate", 170, false);
+  AddInt(vp, "videoplayer.adjustrefreshrate", 170, ADJUST_REFRESHRATE_OFF, adjustTypes, SPIN_CONTROL_TEXT);
+//  AddBool(vp, "videoplayer.adjustrefreshrate", 170, false);
   AddInt(vp, "videoplayer.pauseafterrefreshchange", 13550, 0, 0, 1, MAXREFRESHCHANGEDELAY, SPIN_CONTROL_TEXT);
 #else
-  AddBool(NULL, "videoplayer.adjustrefreshrate", 170, false);
+  AddInt(NULL, "videoplayer.adjustrefreshrate", 170, ADJUST_REFRESHRATE_OFF, adjustTypes, SPIN_CONTROL_TEXT);
+  //AddBool(NULL, "videoplayer.adjustrefreshrate", 170, false);
   AddInt(NULL, "videoplayer.pauseafterrefreshchange", 13550, 0, 0, 1, MAXREFRESHCHANGEDELAY, SPIN_CONTROL_TEXT);
 #endif
   //sync settings not available on windows gl build

--- a/xbmc/settings/GUISettings.h
+++ b/xbmc/settings/GUISettings.h
@@ -163,6 +163,12 @@ class TiXmlElement;
 #define SYNC_SKIPDUP 1
 #define SYNC_RESAMPLE 2
 
+//adjust refreshrate options
+#define ADJUST_REFRESHRATE_OFF            0
+#define ADJUST_REFRESHRATE_ALWAYS         1
+#define ADJUST_REFRESHRATE_ON_STARTSTOP   2
+
+
 //resampler quality
 #define RESAMPLE_LOW 0
 #define RESAMPLE_MID 1

--- a/xbmc/settings/GUISettings.h
+++ b/xbmc/settings/GUISettings.h
@@ -301,11 +301,11 @@ public:
   virtual CStdString ToString() const;
 
   void SetData(int iData)
-  { 
+  {
     if (m_entries.empty())
     {
       m_iData = iData;
-      if (m_iData < m_iMin) m_iData = m_iMin; 
+      if (m_iData < m_iMin) m_iData = m_iMin;
       if (m_iData > m_iMax) m_iData = m_iMax;
     }
     else

--- a/xbmc/settings/GUIWindowSettingsCategory.cpp
+++ b/xbmc/settings/GUIWindowSettingsCategory.cpp
@@ -69,7 +69,7 @@
 #include "HALManager.h"
 #endif
 #endif
-#if defined(TARGET_DARWIN_OSX) 
+#if defined(TARGET_DARWIN_OSX)
 #include "XBMCHelper.h"
 #endif
 #include "network/GUIDialogAccessPoints.h"
@@ -693,7 +693,7 @@ void CGUIWindowSettingsCategory::UpdateSettings()
     else if (strSetting.Equals("audiocds.bitrate"))
     { // only visible if we are ripping to CBR
       CGUIControl *pControl = (CGUIControl *)GetControl(pSettingControl->GetID());
-      if (pControl) pControl->SetEnabled(g_guiSettings.GetInt("audiocds.encoder") != CDDARIP_ENCODER_WAV && 
+      if (pControl) pControl->SetEnabled(g_guiSettings.GetInt("audiocds.encoder") != CDDARIP_ENCODER_WAV &&
                                          g_guiSettings.GetInt("audiocds.encoder") != CDDARIP_ENCODER_FLAC &&
                                          g_guiSettings.GetInt("audiocds.quality") == CDDARIP_QUALITY_CBR);
     }
@@ -750,7 +750,7 @@ void CGUIWindowSettingsCategory::UpdateSettings()
     }
 #endif
 #ifdef HAS_AIRPLAY
-    else if ( strSetting.Equals("services.airplaypassword") || 
+    else if ( strSetting.Equals("services.airplaypassword") ||
               strSetting.Equals("services.useairplaypassword"))
     {
       if (strSetting.Equals("services.airplaypassword"))
@@ -761,19 +761,19 @@ void CGUIWindowSettingsCategory::UpdateSettings()
       }
       else//useairplaypassword
       {
-        CGUIRadioButtonControl *pControl = (CGUIRadioButtonControl *)GetControl(pSettingControl->GetID());    
+        CGUIRadioButtonControl *pControl = (CGUIRadioButtonControl *)GetControl(pSettingControl->GetID());
         if (pControl)
-          pControl->SetEnabled(g_guiSettings.GetBool("services.airplay"));      
+          pControl->SetEnabled(g_guiSettings.GetBool("services.airplay"));
       }
 
       //set credentials to airplay server
       if (g_guiSettings.GetBool("services.airplay"))
       {
         CStdString password = g_guiSettings.GetString("services.airplaypassword");
-        CAirPlayServer::SetCredentials(g_guiSettings.GetBool("services.useairplaypassword"), 
+        CAirPlayServer::SetCredentials(g_guiSettings.GetBool("services.useairplaypassword"),
                                        password);
-      }      
-    }  
+      }
+    }
 #endif//HAS_AIRPLAY
     else if (strSetting.Equals("network.ipaddress") || strSetting.Equals("network.subnet") || strSetting.Equals("network.gateway") || strSetting.Equals("network.dns"))
     {
@@ -919,7 +919,7 @@ void CGUIWindowSettingsCategory::UpdateSettings()
     else if (strSetting.Equals("videoplayer.pauseafterrefreshchange"))
     {
       CGUIControl *pControl = (CGUIControl *)GetControl(pSettingControl->GetID());
-      if (pControl) pControl->SetEnabled(g_guiSettings.GetBool("videoplayer.adjustrefreshrate"));
+      if (pControl) pControl->SetEnabled(g_guiSettings.GetInt("videoplayer.adjustrefreshrate") != ADJUST_REFRESHRATE_OFF);
     }
     else if (strSetting.Equals("videoplayer.synctype"))
     {
@@ -1242,8 +1242,8 @@ void CGUIWindowSettingsCategory::OnSettingChanged(CBaseSettingControl *pSettingC
 #endif
   }
   else if (strSetting.Equals("services.airplay"))
-  {  
-#ifdef HAS_AIRPLAY  
+  {
+#ifdef HAS_AIRPLAY
     if (g_guiSettings.GetBool("services.airplay"))
     {
 #ifdef HAS_ZEROCONF
@@ -1258,8 +1258,8 @@ void CGUIWindowSettingsCategory::OnSettingChanged(CBaseSettingControl *pSettingC
       g_application.StartAirplayServer();//will stop the server before internal
     }
     else
-      g_application.StopAirplayServer(true);//will stop the server before internal    
-#endif//HAS_AIRPLAY      
+      g_application.StopAirplayServer(true);//will stop the server before internal
+#endif//HAS_AIRPLAY
   }
   else if (strSetting.Equals("network.ipaddress"))
   {
@@ -1850,7 +1850,7 @@ void CGUIWindowSettingsCategory::OnSettingChanged(CBaseSettingControl *pSettingC
       g_guiSettings.SetString("audiooutput.passthroughdevice", m_DigitalAudioSinkMap[pControl->GetCurrentLabel()]);
     }
 #endif
-    
+
     CAEFactory::OnSettingsChange(strSetting);
   }
 
@@ -2113,9 +2113,9 @@ void CGUIWindowSettingsCategory::FillInSkinFonts(CSetting *pSetting)
 
         if (idAttr != NULL && isAllowed)
         {
-          if (idLocAttr) 
+          if (idLocAttr)
           {
-            pControl->AddLabel(g_localizeStrings.Get(atoi(idLocAttr)), iSkinFontSet); 
+            pControl->AddLabel(g_localizeStrings.Get(atoi(idLocAttr)), iSkinFontSet);
             m_SkinFontSetIDs[g_localizeStrings.Get(atoi(idLocAttr))] = idAttr;
           }
           else

--- a/xbmc/windowing/osx/WinSystemOSX.mm
+++ b/xbmc/windowing/osx/WinSystemOSX.mm
@@ -755,7 +755,7 @@ bool CWinSystemOSX::SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool bl
       // send pre-configuration change now and do not
       //  wait for switch videomode callback. This gives just
       //  a little more advanced notice of the display pre-change.
-      if (g_guiSettings.GetBool("videoplayer.adjustrefreshrate"))
+      if (g_guiSettings.GetInt("videoplayer.adjustrefreshrate") != ADJUST_REFRESHRATE_OFF)
         CheckDisplayChanging(kCGDisplayBeginConfigurationFlag);
 
       // switch videomode

--- a/xbmc/windowing/osx/WinSystemOSX.mm
+++ b/xbmc/windowing/osx/WinSystemOSX.mm
@@ -23,7 +23,7 @@
 
 //hack around problem with xbmc's typedef int BOOL
 // and obj-c's typedef unsigned char BOOL
-#define BOOL XBMC_BOOL 
+#define BOOL XBMC_BOOL
 #include "WinSystemOSX.h"
 #include "WinEventsOSX.h"
 #include "Application.h"
@@ -225,17 +225,17 @@ void SetMenuBarVisible(bool visible)
 {
   if(visible)
   {
-    [[NSApplication sharedApplication] 
-      setPresentationOptions:   NSApplicationPresentationDefault];  
+    [[NSApplication sharedApplication]
+      setPresentationOptions:   NSApplicationPresentationDefault];
   }
   else
   {
-    [[NSApplication sharedApplication] 
-      setPresentationOptions:   NSApplicationPresentationHideMenuBar | 
-                                NSApplicationPresentationHideDock];  
+    [[NSApplication sharedApplication]
+      setPresentationOptions:   NSApplicationPresentationHideMenuBar |
+                                NSApplicationPresentationHideDock];
   }
 }
-//---------------------------------------------------------------------------------        
+//---------------------------------------------------------------------------------
 CGDirectDisplayID GetDisplayID(int screen_index)
 {
   CGDirectDisplayID displayArray[MAX_DISPLAYS];
@@ -250,7 +250,7 @@ CGDirectDisplayID GetDisplayIDFromScreen(NSScreen *screen)
 {
   NSDictionary* screenInfo = [screen deviceDescription];
   NSNumber* screenID = [screenInfo objectForKey:@"NSScreenNumber"];
-  
+
   return (CGDirectDisplayID)[screenID longValue];
 }
 
@@ -273,13 +273,13 @@ void BlankOtherDisplays(int screen_index)
 {
   int i;
   int numDisplays = [[NSScreen screens] count];
-  
+
   // zero out blankingWindows for debugging
   for (i=0; i<MAX_DISPLAYS; i++)
   {
     blankingWindows[i] = 0;
   }
-  
+
   // Blank.
   for (i=0; i<numDisplays; i++)
   {
@@ -288,20 +288,20 @@ void BlankOtherDisplays(int screen_index)
       // Get the size.
       NSScreen* pScreen = [[NSScreen screens] objectAtIndex:i];
       NSRect    screenRect = [pScreen frame];
-          
+
       // Build a blanking window.
       screenRect.origin = NSZeroPoint;
       blankingWindows[i] = [[NSWindow alloc] initWithContentRect:screenRect
         styleMask:NSBorderlessWindowMask
         backing:NSBackingStoreBuffered
-        defer:NO 
+        defer:NO
         screen:pScreen];
-                                            
+
       [blankingWindows[i] setBackgroundColor:[NSColor blackColor]];
       [blankingWindows[i] setLevel:CGShieldingWindowLevel()];
       [blankingWindows[i] makeKeyAndOrderFront:nil];
     }
-  } 
+  }
 }
 
 void UnblankDisplays(void)
@@ -334,7 +334,7 @@ CGDisplayFadeReservationToken DisplayFadeToBlack(bool fade)
 
 void DisplayFadeFromBlack(CGDisplayFadeReservationToken fade_token, bool fade)
 {
-  if (fade_token != kCGDisplayFadeReservationInvalidToken) 
+  if (fade_token != kCGDisplayFadeReservationInvalidToken)
   {
     if (fade)
       CGDisplayFade(fade_token, 0.5, kCGDisplayBlendSolidColor, kCGDisplayBlendNormal, 0.0, 0.0, 0.0, FALSE);
@@ -432,19 +432,19 @@ CFDictionaryRef GetMode(int width, int height, double refreshrate, int screenIdx
 {
   if ( screenIdx >= (signed)[[NSScreen screens] count])
     return NULL;
-    
+
   Boolean stretched;
   Boolean interlaced;
   Boolean safeForHardware;
   Boolean televisionoutput;
   int w, h, bitsperpixel;
   double rate;
-  RESOLUTION_INFO res;   
-  
+  RESOLUTION_INFO res;
+
   CLog::Log(LOGDEBUG, "GetMode looking for suitable mode with %d x %d @ %f Hz on display %d\n", width, height, refreshrate, screenIdx);
 
   CFArrayRef displayModes = CGDisplayAvailableModes(GetDisplayID(screenIdx));
-  
+
   if (NULL == displayModes)
   {
     CLog::Log(LOGERROR, "GetMode - no displaymodes found!");
@@ -461,13 +461,13 @@ CFDictionaryRef GetMode(int width, int height, double refreshrate, int screenIdx
     safeForHardware = GetDictionaryBoolean(displayMode, kCGDisplayModeIsSafeForHardware);
     televisionoutput = GetDictionaryBoolean(displayMode, kCGDisplayModeIsTelevisionOutput);
     w = GetDictionaryInt(displayMode, kCGDisplayWidth);
-    h = GetDictionaryInt(displayMode, kCGDisplayHeight);      
+    h = GetDictionaryInt(displayMode, kCGDisplayHeight);
     rate = GetDictionaryDouble(displayMode, kCGDisplayRefreshRate);
 
 
-    if ((bitsperpixel == 32)      && 
-        (safeForHardware == YES)  && 
-        (stretched == NO)         && 
+    if ((bitsperpixel == 32)      &&
+        (safeForHardware == YES)  &&
+        (stretched == NO)         &&
         (interlaced == NO)        &&
         (w == width)              &&
         (h == height)             &&
@@ -482,7 +482,7 @@ CFDictionaryRef GetMode(int width, int height, double refreshrate, int screenIdx
 }
 
 //---------------------------------------------------------------------------------
-static void DisplayReconfigured(CGDirectDisplayID display, 
+static void DisplayReconfigured(CGDirectDisplayID display,
   CGDisplayChangeSummaryFlags flags, void* userData)
 {
   CWinSystemOSX *winsys = (CWinSystemOSX*)userData;
@@ -495,10 +495,10 @@ static void DisplayReconfigured(CGDirectDisplayID display,
     RESOLUTION res = g_graphicsContext.GetVideoResolution();
     if (res == RES_INVALID)
       return;
-    
+
     NSScreen* pScreen = nil;
     unsigned int screenIdx = g_settings.m_ResInfo[res].iScreen;
-    
+
     if ( screenIdx < [[NSScreen screens] count] )
     {
         pScreen = [[NSScreen screens] objectAtIndex:screenIdx];
@@ -543,10 +543,10 @@ bool CWinSystemOSX::InitWindowSystem()
   // set repeat to 10ms to ensure repeat time < frame time
   // so that hold times can be reliably detected
   SDL_EnableKeyRepeat(SDL_DEFAULT_REPEAT_DELAY, 10);
-  
+
   if (!CWinSystemBase::InitWindowSystem())
     return false;
-  
+
   m_osx_events = new CWinEventsOSX();
 
   if (m_can_display_switch)
@@ -572,7 +572,7 @@ bool CWinSystemOSX::InitWindowSystem()
 }
 
 bool CWinSystemOSX::DestroyWindowSystem()
-{  
+{
   NSNotificationCenter *center = [NSNotificationCenter defaultCenter];
   [center removeObserver:(windowDidMoveNoteClass*)m_windowDidMove name:NSWindowDidMoveNotification object:nil];
   [center removeObserver:(windowDidReSizeNoteClass*)m_windowDidReSize name:NSWindowDidResizeNotification object:nil];
@@ -606,7 +606,7 @@ bool CWinSystemOSX::CreateNewWindow(const CStdString& name, bool fullScreen, RES
   SDL_GL_SetAttribute(SDL_GL_DOUBLEBUFFER, 1);
 
   // Enable vertical sync to avoid any tearing.
-  SDL_GL_SetAttribute(SDL_GL_SWAP_CONTROL, 1);  
+  SDL_GL_SetAttribute(SDL_GL_SWAP_CONTROL, 1);
 
   m_SDLSurface = SDL_SetVideoMode(m_nWidth, m_nHeight, 0, SDL_OPENGL | SDL_RESIZABLE);
   if (!m_SDLSurface)
@@ -618,7 +618,7 @@ bool CWinSystemOSX::CreateNewWindow(const CStdString& name, bool fullScreen, RES
   NSView* view = [cur_context view];
   if (!view)
     return false;
-  
+
   // if we are not starting up windowed, then hide the initial SDL window
   // so we do not see it flash before the fade-out and switch to fullscreen.
   if (g_guiSettings.m_LookAndFeelResolution != RES_WINDOW)
@@ -626,7 +626,7 @@ bool CWinSystemOSX::CreateNewWindow(const CStdString& name, bool fullScreen, RES
 
   // disassociate view from context
   [cur_context clearDrawable];
-  
+
   // release the context
   if (m_lastOwnedContext == cur_context)
   {
@@ -634,12 +634,12 @@ bool CWinSystemOSX::CreateNewWindow(const CStdString& name, bool fullScreen, RES
     [ cur_context clearDrawable ];
     [ cur_context release ];
   }
-  
+
   // create a new context
   NSOpenGLContext* new_context = (NSOpenGLContext*)CreateWindowedContext(nil);
   if (!new_context)
     return false;
-  
+
   // associate with current view
   [new_context setView:view];
   [new_context makeCurrentContext];
@@ -661,17 +661,17 @@ bool CWinSystemOSX::DestroyWindow()
 {
   return true;
 }
-    
+
 extern "C" void SDL_SetWidthHeight(int w, int h);
 bool CWinSystemOSX::ResizeWindow(int newWidth, int newHeight, int newLeft, int newTop)
 {
   if (!m_glContext)
     return false;
-  
+
   NSOpenGLContext* context = [NSOpenGLContext currentContext];
   NSView* view;
   NSWindow* window;
-  
+
   view = [context view];
   if (view && (newWidth > 0) && (newHeight > 0))
   {
@@ -691,19 +691,19 @@ bool CWinSystemOSX::ResizeWindow(int newWidth, int newHeight, int newLeft, int n
   SDL_SetWidthHeight(newWidth, newHeight);
 
   [context makeCurrentContext];
-  
+
   m_nWidth = newWidth;
   m_nHeight = newHeight;
   m_glContext = context;
-  
+
   return true;
 }
 
 static bool needtoshowme = true;
 
 bool CWinSystemOSX::SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool blankOtherDisplays)
-{  
-  static NSWindow* windowedFullScreenwindow = NULL;  
+{
+  static NSWindow* windowedFullScreenwindow = NULL;
   static NSScreen* last_window_screen = NULL;
   static NSPoint last_window_origin;
   static NSView* last_view = NULL;
@@ -711,10 +711,10 @@ bool CWinSystemOSX::SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool bl
   static NSPoint last_view_origin;
   bool was_fullscreen = m_bFullScreen;
   NSOpenGLContext* cur_context;
-  
+
   // Fade to black to hide resolution-switching flicker and garbage.
   CGDisplayFadeReservationToken fade_token = DisplayFadeToBlack(needtoshowme);
-  
+
   // If we're already fullscreen then we must be moving to a different display.
   // Recurse to reset fullscreen mode and then continue.
   if (was_fullscreen && fullScreen)
@@ -725,7 +725,7 @@ bool CWinSystemOSX::SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool bl
     CWinSystemOSX::SetFullScreen(false, window, blankOtherDisplays);
     needtoshowme = true;
   }
-  
+
   m_nWidth      = res.iWidth;
   m_nHeight     = res.iHeight;
   m_bFullScreen = fullScreen;
@@ -733,7 +733,7 @@ bool CWinSystemOSX::SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool bl
   cur_context = [NSOpenGLContext currentContext];
   if (!cur_context)
   {
-    DisplayFadeFromBlack(fade_token, needtoshowme);  
+    DisplayFadeFromBlack(fade_token, needtoshowme);
     return false;
   }
 
@@ -744,7 +744,7 @@ bool CWinSystemOSX::SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool bl
       [windowedFullScreenwindow release];
     windowedFullScreenwindow = NULL;
   }
-  
+
   if (m_bFullScreen)
   {
     // FullScreen Mode
@@ -768,29 +768,29 @@ bool CWinSystemOSX::SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool bl
     last_view_origin = [last_view frame].origin;
     last_window_screen = [[last_view window] screen];
     last_window_origin = [[last_view window] frame].origin;
-   
+
     if (g_guiSettings.GetBool("videoscreen.fakefullscreen"))
     {
       // This is Cocca Windowed FullScreen Mode
-      // Get the screen rect of our current display      
+      // Get the screen rect of our current display
       NSScreen* pScreen = [[NSScreen screens] objectAtIndex:res.iScreen];
       NSRect    screenRect = [pScreen frame];
-      
+
       // remove frame origin offset of orginal display
       screenRect.origin = NSZeroPoint;
-      
+
       // make a new window to act as the windowedFullScreen
       windowedFullScreenwindow = [[NSWindow alloc] initWithContentRect:screenRect
         styleMask:NSBorderlessWindowMask
         backing:NSBackingStoreBuffered
-        defer:NO 
+        defer:NO
         screen:pScreen];
-                                              
+
       [windowedFullScreenwindow setBackgroundColor:[NSColor blackColor]];
       [windowedFullScreenwindow makeKeyAndOrderFront:nil];
-      
+
       // make our window the same level as the rest to enable cmd+tab switching
-      [windowedFullScreenwindow setLevel:NSNormalWindowLevel]; 
+      [windowedFullScreenwindow setLevel:NSNormalWindowLevel];
       // this will make our window topmost and hide all system messages
       //[windowedFullScreenwindow setLevel:CGShieldingWindowLevel()];
 
@@ -800,21 +800,21 @@ bool CWinSystemOSX::SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool bl
       // expand the mouse bounds in SDL view to fullscreen
       [ last_view setFrameOrigin:NSMakePoint(0.0, 0.0)];
       [ last_view setFrameSize:NSMakeSize(m_nWidth, m_nHeight) ];
-          
+
       NSView* blankView = [[NSView alloc] init];
       [windowedFullScreenwindow setContentView:blankView];
       [windowedFullScreenwindow setContentSize:NSMakeSize(m_nWidth, m_nHeight)];
       [windowedFullScreenwindow update];
       [blankView setFrameSize:NSMakeSize(m_nWidth, m_nHeight)];
-      
+
       // Obtain windowed pixel format and create a new context.
       newContext = (NSOpenGLContext*)CreateWindowedContext((void* )cur_context);
       [newContext setView:blankView];
-      
+
       // Hide the menu bar.
       if (GetDisplayID(res.iScreen) == kCGDirectMainDisplay)
         SetMenuBarVisible(false);
-          
+
       // Blank other displays if requested.
       if (blankOtherDisplays)
         BlankOtherDisplays(res.iScreen);
@@ -832,13 +832,13 @@ bool CWinSystemOSX::SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool bl
       newContext = (NSOpenGLContext*)CreateFullScreenContext(res.iScreen, (void*)cur_context);
       if (!newContext)
         return false;
-      
+
       // clear the current context
       [NSOpenGLContext clearCurrentContext];
-              
+
       // set fullscreen
       [newContext setFullScreen];
-      
+
       // Capture the display before going fullscreen.
       if (blankOtherDisplays == true)
         CGCaptureAllDisplays();
@@ -852,7 +852,7 @@ bool CWinSystemOSX::SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool bl
 
     // Hide the mouse.
     [NSCursor hide];
-    
+
     // Release old context if we created it.
     if (m_lastOwnedContext == cur_context)
     {
@@ -860,7 +860,7 @@ bool CWinSystemOSX::SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool bl
       [ cur_context clearDrawable ];
       [ cur_context release ];
     }
-    
+
     // activate context
     [newContext makeCurrentContext];
     m_lastOwnedContext = newContext;
@@ -870,9 +870,9 @@ bool CWinSystemOSX::SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool bl
     // Windowed Mode
     // exit fullscreen
     [cur_context clearDrawable];
-    
+
     [NSCursor unhide];
-    
+
     // Show menubar.
     if (GetDisplayID(res.iScreen) == kCGDirectMainDisplay)
       SetMenuBarVisible(true);
@@ -881,7 +881,7 @@ bool CWinSystemOSX::SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool bl
     {
       // restore the windowed window level
       [[last_view window] setLevel:NSNormalWindowLevel];
-      
+
       // Get rid of the new window we created.
       if (windowedFullScreenwindow != NULL)
       {
@@ -890,7 +890,7 @@ bool CWinSystemOSX::SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool bl
           [windowedFullScreenwindow release];
         windowedFullScreenwindow = NULL;
       }
-      
+
       // Unblank.
       // Force the unblank when returning from fullscreen, we get called with blankOtherDisplays set false.
       //if (blankOtherDisplays)
@@ -901,12 +901,12 @@ bool CWinSystemOSX::SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool bl
       // release displays
       CGReleaseAllDisplays();
     }
-    
+
     // create our new context (sharing with the current one)
     NSOpenGLContext* newContext = (NSOpenGLContext*)CreateWindowedContext((void* )cur_context);
     if (!newContext)
       return false;
-    
+
     // Assign view from old context, move back to original screen.
     [newContext setView:last_view];
     [[last_view window] setFrameOrigin:last_window_origin];
@@ -915,7 +915,7 @@ bool CWinSystemOSX::SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool bl
     [ last_view setFrameOrigin:last_view_origin ];
     // done with restoring windowed window, don't set last_view to NULL as we can lose it under dual displays.
     //last_window_screen = NULL;
-    
+
     // Release the fullscreen context.
     if (m_lastOwnedContext == cur_context)
     {
@@ -923,13 +923,13 @@ bool CWinSystemOSX::SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool bl
       [ cur_context clearDrawable ];
       [ cur_context release ];
     }
-    
+
     // Activate context.
     [newContext makeCurrentContext];
     m_lastOwnedContext = newContext;
   }
 
-  DisplayFadeFromBlack(fade_token, needtoshowme);  
+  DisplayFadeFromBlack(fade_token, needtoshowme);
 
   ShowHideNSWindow([last_view window], needtoshowme);
   // need to make sure SDL tracks any window size changes
@@ -947,21 +947,21 @@ void CWinSystemOSX::UpdateResolutions()
   double fps;
 
   // first screen goes into the current desktop mode
-  GetScreenResolution(&w, &h, &fps, 0);  
+  GetScreenResolution(&w, &h, &fps, 0);
   UpdateDesktopResolution(g_settings.m_ResInfo[RES_DESKTOP], 0, w, h, fps);
-  
+
   // see resolution.h enum RESOLUTION for how the resolutions
   // have to appear in the g_settings.m_ResInfo vector
   // add the desktop resolutions of the other screens
   for(int i = 1; i < GetNumScreens(); i++)
   {
-    RESOLUTION_INFO res;      
+    RESOLUTION_INFO res;
     // get current resolution of screen i
-    GetScreenResolution(&w, &h, &fps, i);      
+    GetScreenResolution(&w, &h, &fps, i);
     UpdateDesktopResolution(res, i, w, h, fps);
     g_settings.m_ResInfo.push_back(res);
   }
-  
+
   if (m_can_display_switch)
   {
     // now just fill in the possible reolutions for the attached screens
@@ -975,7 +975,7 @@ void* Cocoa_GL_CreateContext(void* pixFmt, void* shareCtx)
 {
   if (!pixFmt)
     return nil;
-    
+
   NSOpenGLContext* newContext = [[NSOpenGLContext alloc] initWithFormat:(NSOpenGLPixelFormat*)pixFmt
     shareContext:(NSOpenGLContext*)shareCtx];
 
@@ -987,7 +987,7 @@ void* Cocoa_GL_CreateContext(void* pixFmt, void* shareCtx)
   //  the cache size by issuing the following calls right after you create
   //  the OpenGL context.  The default cache size is 16."    --ryan.
   //
-  
+
   #ifndef GLI_ARRAY_FUNC_CACHE_MAX
   #define GLI_ARRAY_FUNC_CACHE_MAX 284
   #endif
@@ -1002,7 +1002,7 @@ void* Cocoa_GL_CreateContext(void* pixFmt, void* shareCtx)
       CGLSetParameter(ctx, (CGLContextParameter)GLI_SUBMIT_FUNC_CACHE_MAX, &cache_max);
       CGLSetParameter(ctx, (CGLContextParameter)GLI_ARRAY_FUNC_CACHE_MAX, &cache_max);
   }
-  
+
   // End Wisdom from Apple Engineer section. --ryan.
   return newContext;
 }
@@ -1023,7 +1023,7 @@ void* CWinSystemOSX::CreateWindowedContext(void* shareCtx)
   };
 
   NSOpenGLPixelFormat* pixFmt = [[NSOpenGLPixelFormat alloc] initWithAttributes:wattrs];
-  
+
   newContext = [[NSOpenGLContext alloc] initWithFormat:(NSOpenGLPixelFormat*)pixFmt
     shareContext:(NSOpenGLContext*)shareCtx];
   [pixFmt release];
@@ -1069,11 +1069,11 @@ void* CWinSystemOSX::CreateFullScreenContext(int screen_index, void* shareCtx)
     NSOpenGLPFAScreenMask, (NSOpenGLPixelFormatAttribute)CGDisplayIDToOpenGLDisplayMask(displayID),
     (NSOpenGLPixelFormatAttribute)0
   };
-  
+
   NSOpenGLPixelFormat* pixFmt = [[NSOpenGLPixelFormat alloc] initWithAttributes:fsattrs];
   if (!pixFmt)
     return nil;
-    
+
   NSOpenGLContext* newContext = [[NSOpenGLContext alloc] initWithFormat:(NSOpenGLPixelFormat*)pixFmt
     shareContext:(NSOpenGLContext*)shareCtx];
   [pixFmt release];
@@ -1087,23 +1087,23 @@ void CWinSystemOSX::GetScreenResolution(int* w, int* h, double* fps, int screenI
   if (screenIdx >= GetNumScreens())
     return;
   CGDirectDisplayID display_id = (CGDirectDisplayID)GetDisplayID(screenIdx);
-  
+
   NSOpenGLContext* context = [NSOpenGLContext currentContext];
   if (context)
   {
     NSView* view;
-  
+
     view = [context view];
     if (view)
     {
       NSWindow* window;
       window = [view window];
       if (window)
-        display_id = GetDisplayIDFromScreen( [window screen] );      
+        display_id = GetDisplayIDFromScreen( [window screen] );
     }
   }
-  CGDisplayModeRef mode  = CGDisplayCopyDisplayMode(display_id);  
-  *w = CGDisplayModeGetWidth(mode); 
+  CGDisplayModeRef mode  = CGDisplayCopyDisplayMode(display_id);
+  *w = CGDisplayModeGetWidth(mode);
   *h = CGDisplayModeGetHeight(mode);
   *fps = CGDisplayModeGetRefreshRate(mode);
   CGDisplayModeRelease(mode);
@@ -1116,7 +1116,7 @@ void CWinSystemOSX::GetScreenResolution(int* w, int* h, double* fps, int screenI
 
 void CWinSystemOSX::EnableVSync(bool enable)
 {
-  // OpenGL Flush synchronised with vertical retrace                       
+  // OpenGL Flush synchronised with vertical retrace
   GLint swapInterval = enable ? 1 : 0;
   [[NSOpenGLContext currentContext] setValues:&swapInterval forParameter:NSOpenGLCPSwapInterval];
 }
@@ -1128,7 +1128,7 @@ bool CWinSystemOSX::SwitchToVideoMode(int width, int height, double refreshrate,
   if( screenIdx >= GetNumScreens())
     return false;
 
-  boolean_t match = false;    
+  boolean_t match = false;
   CFDictionaryRef dispMode = NULL;
   // Figure out the screen size. (default to main screen)
   CGDirectDisplayID display_id = GetDisplayID(screenIdx);
@@ -1158,7 +1158,7 @@ bool CWinSystemOSX::SwitchToVideoMode(int width, int height, double refreshrate,
   CGConfigureDisplayMode(cfg, display_id, dispMode);
   CGError err = CGCompleteDisplayConfiguration(cfg, kCGConfigureForAppOnly);
   CGDisplayRelease(display_id);
-  
+
   Cocoa_CVDisplayLinkUpdate();
 
   return (err == kCGErrorSuccess);
@@ -1177,12 +1177,12 @@ void CWinSystemOSX::FillInVideoModes()
     Boolean televisionoutput;
     int w, h, bitsperpixel;
     double refreshrate;
-    RESOLUTION_INFO res;   
+    RESOLUTION_INFO res;
 
     CFArrayRef displayModes = CGDisplayAvailableModes(GetDisplayID(disp));
     NSString *dispName = screenNameForDisplay(GetDisplayID(disp));
     CLog::Log(LOGNOTICE, "Display %i has name %s", disp, [dispName UTF8String]);
-    
+
     if (NULL == displayModes)
       continue;
 
@@ -1196,13 +1196,13 @@ void CWinSystemOSX::FillInVideoModes()
       safeForHardware = GetDictionaryBoolean(displayMode, kCGDisplayModeIsSafeForHardware);
       televisionoutput = GetDictionaryBoolean(displayMode, kCGDisplayModeIsTelevisionOutput);
 
-      if ((bitsperpixel == 32)      && 
-          (safeForHardware == YES)  && 
-          (stretched == NO)         && 
+      if ((bitsperpixel == 32)      &&
+          (safeForHardware == YES)  &&
+          (stretched == NO)         &&
           (interlaced == NO))
       {
         w = GetDictionaryInt(displayMode, kCGDisplayWidth);
-        h = GetDictionaryInt(displayMode, kCGDisplayHeight);      
+        h = GetDictionaryInt(displayMode, kCGDisplayHeight);
         refreshrate = GetDictionaryDouble(displayMode, kCGDisplayRefreshRate);
         if ((int)refreshrate == 0)  // LCD display?
         {
@@ -1210,7 +1210,7 @@ void CWinSystemOSX::FillInVideoModes()
           refreshrate = 60.0;
         }
         CLog::Log(LOGNOTICE, "Found possible resolution for display %d with %d x %d @ %f Hz\n", disp, w, h, refreshrate);
-        
+
         UpdateDesktopResolution(res, disp, w, h, refreshrate);
 
         // overwrite the mode str because  UpdateDesktopResolution adds a
@@ -1332,7 +1332,7 @@ bool CWinSystemOSX::IsObscured(void)
     if (CGRectMakeWithDictionaryRepresentation(rectDictionary, &windowBounds))
     {
       if (CGRectContainsRect(windowBounds, bounds))
-      {   
+      {
         // if the windowBounds completely encloses our bounds, we are obscured.
         m_obscured = true;
         break;
@@ -1366,7 +1366,7 @@ bool CWinSystemOSX::IsObscured(void)
 void CWinSystemOSX::NotifyAppFocusChange(bool bGaining)
 {
   NSAutoreleasePool* pool = [[NSAutoreleasePool alloc] init];
-  
+
   if (m_bFullScreen && bGaining)
   {
     // find the window
@@ -1374,7 +1374,7 @@ void CWinSystemOSX::NotifyAppFocusChange(bool bGaining)
     if (context)
     {
       NSView* view;
-    
+
       view = [context view];
       if (view)
       {
@@ -1405,7 +1405,7 @@ void CWinSystemOSX::ShowOSMouse(bool show)
 bool CWinSystemOSX::Minimize()
 {
   NSAutoreleasePool* pool = [[NSAutoreleasePool alloc] init];
-  
+
   [[NSApplication sharedApplication] miniaturizeAll:nil];
 
   [pool release];
@@ -1415,7 +1415,7 @@ bool CWinSystemOSX::Minimize()
 bool CWinSystemOSX::Restore()
 {
   NSAutoreleasePool* pool = [[NSAutoreleasePool alloc] init];
-  
+
   [[NSApplication sharedApplication] unhide:nil];
 
   [pool release];
@@ -1425,9 +1425,9 @@ bool CWinSystemOSX::Restore()
 bool CWinSystemOSX::Hide()
 {
   NSAutoreleasePool* pool = [[NSAutoreleasePool alloc] init];
-  
+
   [[NSApplication sharedApplication] hide:nil];
-  
+
   [pool release];
   return true;
 }
@@ -1446,7 +1446,7 @@ void CWinSystemOSX::EnableSystemScreenSaver(bool bEnable)
   {
     CFStringRef reasonForActivity= CFSTR("XBMC requested disable system screen saver");
     IOPMAssertionCreateWithName(kIOPMAssertionTypeNoDisplaySleep,
-      kIOPMAssertionLevelOn, reasonForActivity, &assertionID); 
+      kIOPMAssertionLevelOn, reasonForActivity, &assertionID);
   }
   else if (assertionID != 0)
   {
@@ -1500,7 +1500,7 @@ bool CWinSystemOSX::Show(bool raise)
   {
     [[NSApplication sharedApplication] unhideWithoutActivation];
   }
-      
+
   [pool release];
   return true;
 }


### PR DESCRIPTION
This is a feature request from the forum and i really want this. 

When we play a movie with refreshrate adjustment and we switch to the menu while having the movie in the background - the desktop resoltution is set. In that case the refreshrate is also set back to 60hz normally. So whenever we change between fullscreen and menu overlay we get the annoying refreshrate switchtime (depends on the tv - but usually some secs black screen).

This PR only changes back to res_desktop when no movie is playing. So we get a smooth instant transition from videofullscreen to the overlay menu and only switch refreshrates when we start or stop a movie.
