### PR TITLE
GUIDialogSelect: fix crashes on skin reload when select dialog is active

### DIFF
--- a/xbmc/addons/GUIWindowAddonBrowser.cpp
+++ b/xbmc/addons/GUIWindowAddonBrowser.cpp
@@ -471,7 +471,7 @@ int CGUIWindowAddonBrowser::SelectAddonID(const vector<ADDON::TYPE> &types, CStd
     g_windowManager.ActivateWindow(WINDOW_ADDON_BROWSER, params);
     return 2;
   }
-  if (!multipleSelection && dialog->GetSelectedLabel() == -1)
+  if (!dialog->IsConfirmed())
     return 0;
   addonIDs.clear();
   const CFileItemList& list = dialog->GetSelectedItems();

--- a/xbmc/dialogs/GUIDialogSelect.cpp
+++ b/xbmc/dialogs/GUIDialogSelect.cpp
@@ -186,7 +186,12 @@ void CGUIDialogSelect::Add(const CFileItem* pItem)
 
 void CGUIDialogSelect::SetItems(CFileItemList* pList)
 {
-  m_vecList = pList;
+  // need to make internal copy of list to be sure dialog is owner of it
+  m_vecListInternal->Clear();
+  if (pList)
+    m_vecListInternal->Copy(*pList);
+
+  m_vecList = m_vecListInternal;
 }
 
 int CGUIDialogSelect::GetSelectedLabel() const

--- a/xbmc/dialogs/GUIDialogSelect.cpp
+++ b/xbmc/dialogs/GUIDialogSelect.cpp
@@ -35,17 +35,16 @@ CGUIDialogSelect::CGUIDialogSelect(void)
   m_bButtonEnabled = false;
   m_buttonString = -1;
   m_useDetails = false;
-  m_vecListInternal = new CFileItemList;
+  m_vecList = new CFileItemList;
   m_selectedItems = new CFileItemList;
   m_multiSelection = false;
-  m_vecList = m_vecListInternal;
   m_iSelected = -1;
   m_loadType = KEEP_IN_MEMORY;
 }
 
 CGUIDialogSelect::~CGUIDialogSelect(void)
 {
-  delete m_vecListInternal;
+  delete m_vecList;
   delete m_selectedItems;
 }
 
@@ -76,8 +75,7 @@ bool CGUIDialogSelect::OnMessage(CGUIMessage& message)
         }
       }
 
-      m_vecListInternal->Clear();
-      m_vecList = m_vecListInternal;
+      m_vecList->Clear();
 
       m_buttonString = -1;
       SET_CONTROL_LABEL(CONTROL_BUTTON, "");
@@ -158,15 +156,14 @@ void CGUIDialogSelect::Reset()
   m_useDetails = false;
   m_multiSelection = false;
   m_iSelected = -1;
-  m_vecListInternal->Clear();
+  m_vecList->Clear();
   m_selectedItems->Clear();
-  m_vecList = m_vecListInternal;
 }
 
 void CGUIDialogSelect::Add(const CStdString& strLabel)
 {
   CFileItemPtr pItem(new CFileItem(strLabel));
-  m_vecListInternal->Add(pItem);
+  m_vecList->Add(pItem);
 }
 
 void CGUIDialogSelect::Add(const CFileItemList& items)
@@ -181,17 +178,15 @@ void CGUIDialogSelect::Add(const CFileItemList& items)
 void CGUIDialogSelect::Add(const CFileItem* pItem)
 {
   CFileItemPtr item(new CFileItem(*pItem));
-  m_vecListInternal->Add(item);
+  m_vecList->Add(item);
 }
 
 void CGUIDialogSelect::SetItems(CFileItemList* pList)
 {
   // need to make internal copy of list to be sure dialog is owner of it
-  m_vecListInternal->Clear();
+  m_vecList->Clear();
   if (pList)
-    m_vecListInternal->Copy(*pList);
-
-  m_vecList = m_vecListInternal;
+    m_vecList->Copy(*pList);
 }
 
 int CGUIDialogSelect::GetSelectedLabel() const

--- a/xbmc/dialogs/GUIDialogSelect.h
+++ b/xbmc/dialogs/GUIDialogSelect.h
@@ -69,7 +69,6 @@ protected:
   bool m_multiSelection;
 
   CFileItemList* m_selectedItems;
-  CFileItemList* m_vecListInternal;
   CFileItemList* m_vecList;
   CGUIViewControl m_viewControl;
 };


### PR DESCRIPTION
This commits are fixes for problem described in http://forum.xbmc.org/showthread.php?tid=137326

I put detailed fixes description in commit messages. Second fix seems more like bandaid - maybe instead of that I should try more general approach of announcing that we force cleanup of given texture and let controls that have use this texture to adjust (null texture pointer or whatever we do). I was a bit lost in texture classes maze so I just did easy fix + problem description for now and saved myself figuring out how texture stuff really work in case I don't need to ;)
