### PR TITLE
#11861 XBMC loses video settings in windowed mode. Fix.

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -815,8 +815,12 @@ bool CApplication::CreateGUI()
     g_guiSettings.SetResolution(RES_DESKTOP);
   }
 
-  // update the window resolution
-  g_Windowing.SetWindowResolution(g_guiSettings.GetInt("window.width"), g_guiSettings.GetInt("window.height"));
+  // Update the window resolution and preserve the overscan settings loaded from GUI settings
+  g_Windowing.SetWindowResolution(
+    g_guiSettings.GetInt("window.width"),
+    g_guiSettings.GetInt("window.height"),
+    false
+  );
 
   if (g_advancedSettings.m_startFullScreen && g_guiSettings.m_LookAndFeelResolution == RES_WINDOW)
     g_guiSettings.m_LookAndFeelResolution = RES_DESKTOP;

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -70,6 +70,8 @@ void CSettings::Initialize()
   vector<RESOLUTION_INFO>::iterator it = m_ResInfo.begin();
 
   m_ResInfo.insert(it, RES_CUSTOM, res);
+  /* Set the mode name for windowed mode so it can be properly persisted and loaded */
+  m_ResInfo[RES_WINDOW].strMode = "Windowed";
 
   for (int i = RES_HDTV_1080i; i <= RES_PAL60_16x9; i++)
   {
@@ -494,9 +496,6 @@ bool CSettings::LoadCalibration(const TiXmlElement* pRoot, const CStdString& str
     // find this resolution in our resolution vector
     for (unsigned int res = 0; res < m_ResInfo.size(); res++)
     {
-      if (res == RES_WINDOW)
-        continue;
-
       if (m_ResInfo[res].strMode == mode)
       { // found, read in the rest of the information for this item
         const TiXmlElement *pOverscan = pResolution->FirstChildElement("overscan");
@@ -517,7 +516,7 @@ bool CSettings::LoadCalibration(const TiXmlElement* pRoot, const CStdString& str
 
         GetInteger(pResolution, "subtitles", m_ResInfo[res].iSubtitles, (int)((1 - fSafe)*m_ResInfo[res].iHeight), m_ResInfo[res].iHeight / 2, m_ResInfo[res].iHeight*5 / 4);
         GetFloat(pResolution, "pixelratio", m_ResInfo[res].fPixelRatio, 128.0f / 117.0f, 0.5f, 2.0f);
-    /*    CLog::Log(LOGDEBUG, "  calibration for %s %ix%i", m_ResInfo[res].strMode, m_ResInfo[res].iWidth, m_ResInfo[res].iHeight);
+    /*    CLog::Log(LOGDEBUG, "  calibration for %s %ix%i", m_ResInfo[res].strMode.c_str(), m_ResInfo[res].iWidth, m_ResInfo[res].iHeight);
         CLog::Log(LOGDEBUG, "    subtitle yposition:%i pixelratio:%03.3f offsets:(%i,%i)->(%i,%i)",
                   m_ResInfo[res].iSubtitles, m_ResInfo[res].fPixelRatio,
                   m_ResInfo[res].Overscan.left, m_ResInfo[res].Overscan.top,

--- a/xbmc/windowing/WinSystem.cpp
+++ b/xbmc/windowing/WinSystem.cpp
@@ -85,13 +85,24 @@ void CWinSystemBase::UpdateResolutions()
   window.strMode = "Windowed";
 }
 
-void CWinSystemBase::SetWindowResolution(int width, int height)
+void CWinSystemBase::SetWindowResolution(
+  int width,
+  int height,
+  bool resetOverscanSettings /* = true */)
 {
   RESOLUTION_INFO& window = g_settings.m_ResInfo[RES_WINDOW];
   window.iWidth = width;
   window.iHeight = height;
   window.iSubtitles = (int)(0.965 * window.iHeight);
-  g_graphicsContext.ResetOverscan(window);
+  /* Reset overscan settings only if resetting is requested (for example on resolution
+     change or when the overscan settings don't make any sense. For example when they
+     are not initialized yet and left = right = 0. */
+  if (resetOverscanSettings
+      || (   window.Overscan.left >= window.Overscan.right
+          || window.Overscan.top  >= window.Overscan.bottom)
+  ) {
+    g_graphicsContext.ResetOverscan(window);
+  }
 }
 
 int CWinSystemBase::DesktopResolution(int screen)

--- a/xbmc/windowing/WinSystem.h
+++ b/xbmc/windowing/WinSystem.h
@@ -95,7 +95,7 @@ public:
   virtual int GetCurrentScreen() { return 0; }
   bool IsFullScreen() { return m_bFullScreen; }
   virtual void UpdateResolutions();
-  void SetWindowResolution(int width, int height);
+  void SetWindowResolution(int width, int height, bool resetOverscanSettings = true);
   int DesktopResolution(int screen);
   std::vector<RESOLUTION_WHR> ScreenResolutions(int screen);
   std::vector<REFRESHRATE> RefreshRates(int screen, int width, int height);


### PR DESCRIPTION
Hi,

I am trying to fix ticket #11861 since the problem is also a problem for me. This is my first change here, so please help me complying with your rules.

Please have a look at the ticket: http://trac.xbmc.org/ticket/11861

The fix is pretty simple, but there was more than one problem preventing the overscan settings to be restored.

First of all there was the following statement preventing the settings for windowed mode being loaded at all:

``` C++
@@ -494,9 +496,6 @@ bool CSettings::LoadCalibration(const TiXmlElement* pRoot, const CStdString& str
     // find this resolution in our resolution vector
     for (unsigned int res = 0; res < m_ResInfo.size(); res++)
     {
-      if (res == RES_WINDOW)
-        continue;
-
```

I don't know exactly where this came from, I kind of lost tracks on a merge back from some linux branch back in SVN, see below.

```
git log -1 45285e8                           
commit 45285e8a9300cd754a760560640b75b09f98035e
Author: AlTheKiller <AlTheKiller@svn>
Date:   Wed Sep 23 01:49:50 2009 +0000

    step 3/4: Move linuxport to trunk.  How'd I get roped into this?


    git-svn-id: https://xbmc.svn.sourceforge.net/svnroot/xbmc/trunk@23097 568bbfeb-2a22-0410-94d2-cc84cf5bfa90
```

The second problem was matching the stored resolution nodes to the res info structures. This failed since the RES_WINDOW Structure did not have set the strMode field to "Windowed" at this time.

``` C++
@@ -494,9 +496,6 @@ bool CSettings::LoadCalibration(const TiXmlElement* pRoot, const CStdString& str
     // find this resolution in our resolution vector
     for (unsigned int res = 0; res < m_ResInfo.size(); res++)
     {
...
       if (m_ResInfo[res].strMode == mode)
```

I fixed that by setting the strMode for windowed mode early in the constructor.

And finally the overscan settings where reset on every resolution change, including the initial setting. I overcame this by introducing a "reset overscan settings" flag with default to true to the method and additionally resetting the overscan values if the current settings don't make any sense.

Thanks for reading this and I hope this or a similar fix could make it into xbmc. I think some xbmc dev's comments would be helpfull.

regards,

Benjamin Peter
