### PR TITLE
[WIN32] fixed a crash with the wasapi sink and dts wav. m_Channels and m...

### DIFF
--- a/xbmc/cores/paplayer/DVDPlayerCodec.cpp
+++ b/xbmc/cores/paplayer/DVDPlayerCodec.cpp
@@ -147,7 +147,7 @@ bool DVDPlayerCodec::Init(const CStdString &strFile, unsigned int filecache)
   // we have to decode initial data in order to get channels/samplerate
   // for sanity - we read no more than 10 packets
   int nErrors = 0;
-  for (int nPacket=0; nPacket < 10 && (m_Channels == 0 || m_SampleRate == 0); nPacket++)
+  for (int nPacket=0; nPacket < 10 && (m_Channels <= 0 || m_SampleRate <= 0); nPacket++)
   {
     BYTE dummy[256];
     int nSize = 256;


### PR DESCRIPTION
..._ChannelInfo get -842150451 and thus the loop will exit but it later crashes in paplayer l670 with division by zero as si->m_bytesPerSample is 0. With this change another ReadPCM loop is happen with the correct m_Channel\* member.

I dunno if this is the right spot for the fix nor do I think that it solves the root but at least it prevents xbmc from crashing and as it seems playing normal. I can't fully test it because I don't have hdmi output so this could be a part of the problem :)
the dts wav plays fine with the directsound sink and analog.
