### PR TITLE
fixed: GetCachePercentage() was wrong for stacked items

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -5591,8 +5591,13 @@ float CApplication::GetPercentage() const
 float CApplication::GetCachePercentage() const
 {
   if (IsPlaying() && m_pPlayer)
-    return m_pPlayer->GetCachePercentage();
-
+  {
+    // Note that the player returns a relative cache percentage and we want an absolute percentage
+    // We also need to take into account the stack's total time vs. currently playing file's total time
+    float stackedTotalTime = (float) GetTotalTime();
+    if (stackedTotalTime > 0.0f)
+      return min( 100.0f, GetPercentage() + (m_pPlayer->GetCachePercentage() * m_pPlayer->GetTotalTime() / stackedTotalTime ) );
+  }
   return 0.0f;
 }
 

--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -2415,7 +2415,7 @@ float CDVDPlayer::GetPercentage()
 float CDVDPlayer::GetCachePercentage()
 {
   CSingleLock lock(m_StateSection);
-  return min(100.0, GetPercentage() + m_State.cache_offset * 100);
+  return m_State.cache_offset * 100; // NOTE: Percentage returned is relative
 }
 
 void CDVDPlayer::SetAVDelay(float fValue)


### PR DESCRIPTION
The values returned by CApp::GetCachePercentage() are wrong for stacked items causing eg. info labels to be incorrect. The problem is that DVDPlayer::GetCachePercentage() returns an absolute value and is not aware of any stacks (which are handled by CApp) ,(un)like CApp:GetPercentage(). I've fixed this by having DVDPlayer::GetCachePercentage() return a relative value instead and calculate the proper absolute value in CApp::GetCachePercentage(). This can be safely done since DVDPlayer::GetCachePercentage() is only used in one place.

@elupus: Please review. Perhaps it's better to move this into the Info Manager?
