### PR TITLE
Gui settings optimization part2

### DIFF
--- a/xbmc/settings/GUISettings.cpp
+++ b/xbmc/settings/GUISettings.cpp
@@ -1042,7 +1042,7 @@ void CGUISettings::SetFloat(const char *strSetting, float fSetting)
 
 void CGUISettings::LoadMasterLock(TiXmlElement *pRootElement)
 {
-  std::map<CStdString,CSetting*>::iterator it = settingsMap.find("masterlock.maxretries");
+  mapIter it = settingsMap.find("masterlock.maxretries");
   if (it != settingsMap.end())
     LoadFromXML(pRootElement, it);
   it = settingsMap.find("masterlock.startuplock");

--- a/xbmc/settings/GUISettings.h
+++ b/xbmc/settings/GUISettings.h
@@ -503,9 +503,9 @@ public:
   void Clear();
 
 private:
-  typedef std::map<CStdString, CSetting*>::iterator mapIter;
-  typedef std::map<CStdString, CSetting*>::const_iterator constMapIter;
-  std::map<CStdString, CSetting*> settingsMap;
+  typedef std::map<std::string, CSetting*>::iterator mapIter;
+  typedef std::map<std::string, CSetting*>::const_iterator constMapIter;
+  std::map<std::string, CSetting*> settingsMap;
   std::vector<CSettingsGroup *> settingsGroups;
   void LoadFromXML(TiXmlElement *pRootElement, mapIter &it, bool advanced = false);
 };


### PR DESCRIPTION
This is second part for #1252.
Using std::string as key should speed up settingsMap
