### PR TITLE
Fix for GUITextLayout.cpp

### DIFF
--- a/xbmc/guilib/GUITextLayout.cpp
+++ b/xbmc/guilib/GUITextLayout.cpp
@@ -53,6 +53,7 @@ CGUITextLayout::CGUITextLayout(CGUIFont *font, bool wrap, float fHeight, CGUIFon
   m_maxHeight = fHeight;
   m_textWidth = 0;
   m_textHeight = 0;
+  m_lastText = StringUtils::EmptyString;
 }
 
 void CGUITextLayout::SetWrap(bool bWrap)


### PR DESCRIPTION
Just initialize m_lastText with EmptyString.
I my case this fixed crash on CGUITextLayout::UpdateW at text.Equals(m_lastText).
