### PR TITLE
Remove busydialog setting

### DIFF
--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -130,7 +130,6 @@ void CAdvancedSettings::Initialize()
   m_lcdHostName = "localhost";
 
   m_songInfoDuration = 10;
-  m_busyDialogDelay = 2000;
 
   m_cddbAddress = "freedb.freedb.org";
 
@@ -705,14 +704,13 @@ void CAdvancedSettings::ParseSettingsFile(const CStdString &file)
     g_advancedSettings.m_logLevel = std::max(g_advancedSettings.m_logLevel, g_advancedSettings.m_logLevelHint);
     CLog::SetLogLevel(g_advancedSettings.m_logLevel);
   }
-     
+
   XMLUtils::GetString(pRootElement, "cddbaddress", m_cddbAddress);
 
   //airtunes + airplay
   XMLUtils::GetBoolean(pRootElement, "enableairtunesdebuglog", m_logEnableAirtunes);
   XMLUtils::GetInt(pRootElement,     "airtunesport", m_airTunesPort);
   XMLUtils::GetInt(pRootElement,     "airplayport", m_airPlayPort);  
-  
 
   XMLUtils::GetBoolean(pRootElement, "handlemounting", m_handleMounting);
 
@@ -724,7 +722,6 @@ void CAdvancedSettings::ParseSettingsFile(const CStdString &file)
   XMLUtils::GetBoolean(pRootElement, "canwindowed", m_canWindowed);
 
   XMLUtils::GetInt(pRootElement, "songinfoduration", m_songInfoDuration, 0, INT_MAX);
-  XMLUtils::GetInt(pRootElement, "busydialogdelay", m_busyDialogDelay, 0, 5000);
   XMLUtils::GetInt(pRootElement, "playlistretries", m_playlistRetries, -1, 5000);
   XMLUtils::GetInt(pRootElement, "playlisttimeout", m_playlistTimeout, 0, 5000);
 
@@ -1141,5 +1138,5 @@ void CAdvancedSettings::SetDebugMode(bool debug)
     CLog::Log(LOGNOTICE, "Disabled debug logging due to GUI setting. Level %d.", level);
     m_logLevel = level;
     CLog::SetLogLevel(level);
-  }	
+  }
 }

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -176,15 +176,14 @@ class CAdvancedSettings
     CStdString m_lcdHostName;
 
     int m_songInfoDuration;
-    int m_busyDialogDelay;
     int m_logLevel;
     int m_logLevelHint;
     CStdString m_cddbAddress;
-    
+
     //airtunes + airplay
     bool m_logEnableAirtunes;
     int m_airTunesPort;
-    int m_airPlayPort;    
+    int m_airPlayPort;
 
     bool m_handleMounting;
 
@@ -288,7 +287,7 @@ class CAdvancedSettings
 
     bool m_fullScreen;
     bool m_startFullScreen;
-	bool m_showExitButton; /* Ideal for appliances to hide a 'useless' button */
+    bool m_showExitButton; /* Ideal for appliances to hide a 'useless' button */
     bool m_canWindowed;
     bool m_splashImage;
     bool m_alwaysOnTop;  /* makes xbmc to run always on top .. osx/win32 only .. */


### PR DESCRIPTION
The <busydialogdelay> seting in as.xml seems to be obsolete. The busy dialog afaik is only used by CDirectory & CDVDPlayer and have hardcoded time values. Doing a PR since I'm not 100% sure we are not going to (re)use it again. Also contains some whitespace/tab fixes (courtesy of VIM(tm) ;-))
