### PR TITLE
IPlayer: change GetTotalTime() to return milliseconds in an int64_t

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -4522,7 +4522,7 @@ void CApplication::UpdateFileState()
 
       if (m_progressTrackingItem->IsVideo())
       {
-        if ((m_progressTrackingItem->IsDVDImage() || m_progressTrackingItem->IsDVDFile()) && m_pPlayer->GetTotalTime() > 15*60)
+        if ((m_progressTrackingItem->IsDVDImage() || m_progressTrackingItem->IsDVDFile()) && m_pPlayer->GetTotalTime() > 15*60*1000)
         {
           m_progressTrackingItem->GetVideoInfoTag()->m_streamDetails.Reset();
           m_pPlayer->GetStreamDetails(m_progressTrackingItem->GetVideoInfoTag()->m_streamDetails);
@@ -5500,7 +5500,7 @@ double CApplication::GetTotalTime() const
     if (m_itemCurrentFile->IsStack() && m_currentStack->Size() > 0)
       rc = (*m_currentStack)[m_currentStack->Size() - 1]->m_lEndOffset;
     else
-      rc = m_pPlayer->GetTotalTime();
+      rc = static_cast<double>(m_pPlayer->GetTotalTime() * 0.001f);
   }
 
   return rc;
@@ -5617,7 +5617,7 @@ float CApplication::GetCachePercentage() const
       float stackedTotalTime = (float) GetTotalTime();
       // We need to take into account the stack's total time vs. currently playing file's total time
       if (stackedTotalTime > 0.0f)
-        return min( 100.0f, GetPercentage() + (m_pPlayer->GetCachePercentage() * m_pPlayer->GetTotalTime() / stackedTotalTime ) );
+        return min( 100.0f, GetPercentage() + (m_pPlayer->GetCachePercentage() * m_pPlayer->GetTotalTime() * 0.001f / stackedTotalTime ) );
     }
     else
       return min( 100.0f, m_pPlayer->GetPercentage() + m_pPlayer->GetCachePercentage() );

--- a/xbmc/Application.h
+++ b/xbmc/Application.h
@@ -221,7 +221,17 @@ public:
   // Wakes up from the screensaver and / or DPMS. Returns true if woken up.
   bool WakeUpScreenSaverAndDPMS(bool bPowerOffKeyPressed = false);
   bool WakeUpScreenSaver(bool bPowerOffKeyPressed = false);
+  /*!
+   \brief Returns the total time in fractional seconds of the currently playing media
+
+   Beware that this method returns fractional seconds whereas IPlayer::GetTotalTime() returns milliseconds.
+   */
   double GetTotalTime() const;
+  /*!
+   \brief Returns the current time in fractional seconds of the currently playing media
+
+   Beware that this method returns fractional seconds whereas IPlayer::GetTime() returns milliseconds.
+   */
   double GetTime() const;
   float GetPercentage() const;
 

--- a/xbmc/cores/DummyVideoPlayer.cpp
+++ b/xbmc/cores/DummyVideoPlayer.cpp
@@ -144,7 +144,7 @@ bool CDummyVideoPlayer::CanSeek()
 
 void CDummyVideoPlayer::Seek(bool bPlus, bool bLargeStep)
 {
-  if (g_advancedSettings.m_videoUseTimeSeeking && GetTotalTime() > 2*g_advancedSettings.m_videoTimeSeekForwardBig)
+  if (g_advancedSettings.m_videoUseTimeSeeking && GetTotalTime() > 2000*g_advancedSettings.m_videoTimeSeekForwardBig)
   {
     int seek = 0;
     if (bLargeStep)
@@ -191,14 +191,13 @@ void CDummyVideoPlayer::SwitchToNextAudioLanguage()
 
 void CDummyVideoPlayer::SeekPercentage(float iPercent)
 {
-  int64_t iTotalMsec = GetTotalTime() * 1000;
-  int64_t iTime = (int64_t)(iTotalMsec * iPercent / 100);
+  int64_t iTime = (int64_t)(GetTotalTime() * iPercent / 100);
   SeekTime(iTime);
 }
 
 float CDummyVideoPlayer::GetPercentage()
 {
-  int64_t iTotalTime = GetTotalTime() * 1000;
+  int64_t iTotalTime = GetTotalTime();
 
   if (iTotalTime != 0)
   {
@@ -240,10 +239,10 @@ int64_t CDummyVideoPlayer::GetTime()
   return m_clock;
 }
 
-// return length in seconds.. this should be changed to return in milleseconds throughout xbmc
-int CDummyVideoPlayer::GetTotalTime()
+// return length in milliseconds
+int64_t CDummyVideoPlayer::GetTotalTime()
 {
-  return 1000;
+  return 1000000;
 }
 
 void CDummyVideoPlayer::ToFFRW(int iSpeed)

--- a/xbmc/cores/DummyVideoPlayer.h
+++ b/xbmc/cores/DummyVideoPlayer.h
@@ -68,7 +68,7 @@ public:
 
   virtual void SeekTime(int64_t iTime);
   virtual int64_t GetTime();
-  virtual int GetTotalTime();
+  virtual int64_t GetTotalTime();
   virtual void ToFFRW(int iSpeed);
   virtual void ShowOSD(bool bOnoff);
   virtual void DoAudioWork()                                    {}

--- a/xbmc/cores/ExternalPlayer/ExternalPlayer.cpp
+++ b/xbmc/cores/ExternalPlayer/ExternalPlayer.cpp
@@ -504,7 +504,7 @@ void CExternalPlayer::SeekPercentage(float iPercent)
 float CExternalPlayer::GetPercentage()
 {
   int64_t iTime = GetTime();
-  int64_t iTotalTime = GetTotalTime() * 1000;
+  int64_t iTotalTime = GetTotalTime();
 
   if (iTotalTime != 0)
   {
@@ -547,9 +547,9 @@ int64_t CExternalPlayer::GetTime() // in millis
   return m_time;
 }
 
-int CExternalPlayer::GetTotalTime() // in seconds
+int64_t CExternalPlayer::GetTotalTime() // in milliseconds
 {
-  return m_totalTime;
+  return m_totalTime * 1000;
 }
 
 void CExternalPlayer::ToFFRW(int iSpeed)

--- a/xbmc/cores/ExternalPlayer/ExternalPlayer.h
+++ b/xbmc/cores/ExternalPlayer/ExternalPlayer.h
@@ -72,7 +72,7 @@ public:
 
   virtual void SeekTime(int64_t iTime);
   virtual int64_t GetTime();
-  virtual int GetTotalTime();
+  virtual int64_t GetTotalTime();
   virtual void ToFFRW(int iSpeed);
   virtual void ShowOSD(bool bOnoff);
   virtual void DoAudioWork()                                    {}

--- a/xbmc/cores/IPlayer.h
+++ b/xbmc/cores/IPlayer.h
@@ -135,8 +135,14 @@ public:
 
   virtual float GetActualFPS() { return 0.0f; };
   virtual void SeekTime(int64_t iTime = 0){};
-  virtual int64_t GetTime(){ return 0;};
-  virtual int GetTotalTime(){ return 0;};
+  /*!
+   \brief current time in milliseconds
+   */
+  virtual int64_t GetTime() { return 0; }
+  /*!
+   \brief total time in milliseconds
+   */
+  virtual int64_t GetTotalTime() { return 0; }
   virtual int GetAudioBitrate(){ return 0;}
   virtual int GetVideoBitrate(){ return 0;}
   virtual int GetSourceBitrate(){ return 0;}

--- a/xbmc/cores/amlplayer/AMLPlayer.cpp
+++ b/xbmc/cores/amlplayer/AMLPlayer.cpp
@@ -716,7 +716,7 @@ void CAMLPlayer::Seek(bool bPlus, bool bLargeStep)
   int64_t seek_ms;
   if (g_advancedSettings.m_videoUseTimeSeeking)
   {
-    if (bLargeStep && (GetTotalTime() > (2 * g_advancedSettings.m_videoTimeSeekForwardBig)))
+    if (bLargeStep && (GetTotalTime() > (2000 * g_advancedSettings.m_videoTimeSeekForwardBig)))
       seek_ms = bPlus ? g_advancedSettings.m_videoTimeSeekForwardBig : g_advancedSettings.m_videoTimeSeekBackwardBig;
     else
       seek_ms = bPlus ? g_advancedSettings.m_videoTimeSeekForward    : g_advancedSettings.m_videoTimeSeekBackward;
@@ -1101,9 +1101,9 @@ __int64 CAMLPlayer::GetTime()
   return m_elapsed_ms;
 }
 
-int CAMLPlayer::GetTotalTime()
+__int64 CAMLPlayer::GetTotalTime()
 {
-  return m_duration_ms / 1000;
+  return m_duration_ms;
 }
 
 int CAMLPlayer::GetAudioBitrate()

--- a/xbmc/cores/amlplayer/AMLPlayer.h
+++ b/xbmc/cores/amlplayer/AMLPlayer.h
@@ -124,7 +124,7 @@ public:
   virtual float GetActualFPS();
   virtual void  SeekTime(__int64 iTime = 0);
   virtual __int64 GetTime();
-  virtual int   GetTotalTime();
+  virtual __int64 GetTotalTime();
   virtual int   GetAudioBitrate();
   virtual int   GetVideoBitrate();
   virtual int   GetSourceBitrate();

--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -2241,7 +2241,7 @@ void CDVDPlayer::Seek(bool bPlus, bool bLargeStep)
   }
 
   int64_t seek;
-  if (g_advancedSettings.m_videoUseTimeSeeking && GetTotalTime() > 2*g_advancedSettings.m_videoTimeSeekForwardBig)
+  if (g_advancedSettings.m_videoUseTimeSeeking && GetTotalTime() > 2000*g_advancedSettings.m_videoTimeSeekForwardBig)
   {
     if (bLargeStep)
       seek = bPlus ? g_advancedSettings.m_videoTimeSeekForwardBig : g_advancedSettings.m_videoTimeSeekBackwardBig;
@@ -2587,9 +2587,9 @@ int64_t CDVDPlayer::GetTotalTimeInMsec()
 }
 
 // return length in seconds.. this should be changed to return in milleseconds throughout xbmc
-int CDVDPlayer::GetTotalTime()
+int64_t CDVDPlayer::GetTotalTime()
 {
-  return (int)(GetTotalTimeInMsec() / 1000);
+  return GetTotalTimeInMsec();
 }
 
 void CDVDPlayer::ToFFRW(int iSpeed)
@@ -3803,7 +3803,7 @@ bool CDVDPlayer::GetStreamDetails(CStreamDetails &details)
     if (result && details.GetStreamCount(CStreamDetail::VIDEO) > 0) // this is more correct (dvds in particular)
     {
       GetVideoAspectRatio(((CStreamDetailVideo*)details.GetNthStream(CStreamDetail::VIDEO,0))->m_fAspect);
-      ((CStreamDetailVideo*)details.GetNthStream(CStreamDetail::VIDEO,0))->m_iDuration = GetTotalTime();
+      ((CStreamDetailVideo*)details.GetNthStream(CStreamDetail::VIDEO,0))->m_iDuration = GetTotalTime() / 1000;
     }
     return result;
   }

--- a/xbmc/cores/dvdplayer/DVDPlayer.h
+++ b/xbmc/cores/dvdplayer/DVDPlayer.h
@@ -219,7 +219,7 @@ public:
 
   virtual void SeekTime(int64_t iTime);
   virtual int64_t GetTime();
-  virtual int GetTotalTime();
+  virtual int64_t GetTotalTime();
   virtual void ToFFRW(int iSpeed);
   virtual bool OnAction(const CAction &action);
   virtual bool HasMenu();

--- a/xbmc/cores/paplayer/PAPlayer.cpp
+++ b/xbmc/cores/paplayer/PAPlayer.cpp
@@ -789,9 +789,9 @@ int64_t PAPlayer::GetTotalTime64()
   return total;
 }
 
-int PAPlayer::GetTotalTime()
+int64_t PAPlayer::GetTotalTime()
 {
-  return (int)m_playerGUIData.m_totalTime;
+  return m_playerGUIData.m_totalTime;
 }
 
 int PAPlayer::GetCacheLevel() const

--- a/xbmc/cores/paplayer/PAPlayer.h
+++ b/xbmc/cores/paplayer/PAPlayer.h
@@ -63,7 +63,7 @@ public:
   virtual void Update(bool bPauseDrawing = false) {}
   virtual void ToFFRW(int iSpeed = 0);
   virtual int GetCacheLevel() const;
-  virtual int GetTotalTime();
+  virtual int64_t GetTotalTime();
   virtual int GetAudioBitrate();
   virtual int GetChannels();
   virtual int GetBitsPerSample();

--- a/xbmc/network/AirPlayServer.cpp
+++ b/xbmc/network/AirPlayServer.cpp
@@ -821,7 +821,7 @@ int CAirPlayServer::CTCPClient::ProcessRequest( CStdString& responseHeader,
       if (g_application.m_pPlayer && g_application.m_pPlayer->GetTotalTime())
       {
         float position = ((float) g_application.m_pPlayer->GetTime()) / 1000;
-        responseBody.Format("duration: %d\r\nposition: %f", g_application.m_pPlayer->GetTotalTime(), position);
+        responseBody.Format("duration: %d\r\nposition: %f", g_application.m_pPlayer->GetTotalTime() / 1000, position);
       }
       else 
       {
@@ -921,9 +921,9 @@ int CAirPlayServer::CTCPClient::ProcessRequest( CStdString& responseHeader,
       if (g_application.m_pPlayer->GetTotalTime())
       {
         position = ((float) g_application.m_pPlayer->GetTime()) / 1000;
-        duration = (float) g_application.m_pPlayer->GetTotalTime();
+        duration = ((float) g_application.m_pPlayer->GetTotalTime()) / 1000;
         playing = g_application.m_pPlayer ? !g_application.m_pPlayer->IsPaused() : false;
-        cacheDuration = (float) g_application.m_pPlayer->GetTotalTime() * g_application.GetCachePercentage()/100.0f;
+        cacheDuration = (float) g_application.m_pPlayer->GetTotalTime() / 1000 * g_application.GetCachePercentage()/100.0f;
       }
 
       responseBody.Format(PLAYBACK_INFO, duration, cacheDuration, position, (playing ? 1 : 0), duration);


### PR DESCRIPTION
This changes the definition (and usage) of IPlayer::GetTotalTime() from returning seconds in an int to returning milliseconds in an int64_t. Up until now there was no documentation and no rule for it and DVDPlayer returned seconds while the new PAPlayer implementation returns milliseconds (which is how I noticed it).

After a short discussion with @cptspiff I decided to adjust the definition of IPlayer::GetTotalTime() to be the same as IPlayer::GetTime() which returns milliseconds in an int64_t.

I hope I caught all the usages of the calls to GetTotalTime() of the different IPlayer implementations.
