### PR TITLE
Improved picture zooming and rotating on touch devices

### DIFF
--- a/xbmc/android/activity/AndroidTouch.cpp
+++ b/xbmc/android/activity/AndroidTouch.cpp
@@ -99,6 +99,18 @@ bool CAndroidTouch::OnSingleTouchStart(float x, float y)
   return true;
 }
 
+bool CAndroidTouch::OnMultiTouchStart(float x, float y, int32_t pointers /* = 2 */)
+{
+  XBMC_TouchGesture(ACTION_GESTURE_BEGIN, x, y, 0.0f, 0.0f);
+
+  return true;
+}
+
+bool CAndroidTouch::OnMultiTouchEnd(float x, float y, int32_t pointers /* = 2 */)
+{
+  XBMC_TouchGesture(ACTION_GESTURE_END, 0.0f, 0.0f, 0.0f, 0.0f);
+}
+
 bool CAndroidTouch::OnTouchGesturePanStart(float x, float y)
 {
   XBMC_TouchGesture(ACTION_GESTURE_BEGIN, x, y, 0.0f, 0.0f);

--- a/xbmc/android/activity/AndroidTouch.cpp
+++ b/xbmc/android/activity/AndroidTouch.cpp
@@ -109,6 +109,8 @@ bool CAndroidTouch::OnMultiTouchStart(float x, float y, int32_t pointers /* = 2 
 bool CAndroidTouch::OnMultiTouchEnd(float x, float y, int32_t pointers /* = 2 */)
 {
   XBMC_TouchGesture(ACTION_GESTURE_END, 0.0f, 0.0f, 0.0f, 0.0f);
+
+  return true;
 }
 
 bool CAndroidTouch::OnTouchGesturePanStart(float x, float y)
@@ -154,6 +156,11 @@ void CAndroidTouch::OnZoomPinch(float centerX, float centerY, float zoomFactor)
   XBMC_TouchGesture(ACTION_GESTURE_ZOOM, centerX, centerY, zoomFactor, 0);
 }
 
+void CAndroidTouch::OnRotate(float centerX, float centerY, float angle)
+{
+  XBMC_TouchGesture(ACTION_GESTURE_ROTATE, centerX, centerY, angle, 0);
+}
+
 void CAndroidTouch::XBMC_Touch(uint8_t type, uint8_t button, uint16_t x, uint16_t y)
 {
   XBMC_Event newEvent;
@@ -178,6 +185,6 @@ void CAndroidTouch::XBMC_TouchGesture(int32_t action, float posX, float posY, fl
     CApplicationMessenger::Get().SendAction(CAction(action, 0, posX, posY, offsetX, offsetY), WINDOW_INVALID, false);
   else if (action == ACTION_GESTURE_END)
     CApplicationMessenger::Get().SendAction(CAction(action, 0, posX, posY, offsetX, offsetY), WINDOW_INVALID, false);
-  else if (action == ACTION_GESTURE_ZOOM)
+  else if (action == ACTION_GESTURE_ZOOM || action == ACTION_GESTURE_ROTATE)
     CApplicationMessenger::Get().SendAction(CAction(action, 0, posX, posY, offsetX, 0), WINDOW_INVALID, false);
 }

--- a/xbmc/android/activity/AndroidTouch.h
+++ b/xbmc/android/activity/AndroidTouch.h
@@ -34,6 +34,9 @@ public:
 protected:
   virtual bool OnSingleTouchStart(float x, float y);
 
+  virtual bool OnMultiTouchStart(float x, float y, int32_t pointers = 2);
+  virtual bool OnMultiTouchEnd(float x, float y, int32_t pointers = 2);
+
   virtual bool OnTouchGesturePanStart(float x, float y);
   virtual bool OnTouchGesturePan(float x, float y, float offsetX, float offsetY, float velocityX, float velocityY);
   virtual bool OnTouchGesturePanEnd(float x, float y, float offsetX, float offsetY, float velocityX, float velocityY);

--- a/xbmc/android/activity/AndroidTouch.h
+++ b/xbmc/android/activity/AndroidTouch.h
@@ -44,6 +44,7 @@ protected:
   virtual void OnSingleTap(float x, float y);
   virtual void OnSingleLongPress(float x, float y);
   virtual void OnZoomPinch(float centerX, float centerY, float zoomFactor);
+  virtual void OnRotate(float centerX, float centerY, float angle);
 
 private:
   void XBMC_Touch(uint8_t type, uint8_t button, uint16_t x, uint16_t y);

--- a/xbmc/guilib/Key.h
+++ b/xbmc/guilib/Key.h
@@ -138,7 +138,8 @@
 #define ACTION_CALIBRATE_SWAP_ARROWS  47 // select next arrow. Can b used in: settingsScreenCalibration.xml windowid=11
 #define ACTION_CALIBRATE_RESET        48 // reset calibration to defaults. Can b used in: settingsScreenCalibration.xml windowid=11/settingsUICalibration.xml windowid=10
 #define ACTION_ANALOG_MOVE            49 // analog thumbstick move. Can b used in: slideshow.xml window id=2007/settingsScreenCalibration.xml windowid=11/settingsUICalibration.xml windowid=10
-#define ACTION_ROTATE_PICTURE         50 // rotate current picture during slideshow. Can b used in slideshow.xml window id=2007
+#define ACTION_ROTATE_PICTURE_CW      50 // rotate current picture clockwise during slideshow. Can be used in slideshow.xml window id=2007
+#define ACTION_ROTATE_PICTURE_CCW     51 // rotate current picture counterclockwise during slideshow. Can be used in slideshow.xml window id=2007
 
 #define ACTION_SUBTITLE_DELAY_MIN     52 // Decrease subtitle/movie Delay.  Can b used in videoFullScreen.xml window id=2005
 #define ACTION_SUBTITLE_DELAY_PLUS    53 // Increase subtitle/movie Delay.  Can b used in videoFullScreen.xml window id=2005

--- a/xbmc/input/ButtonTranslator.cpp
+++ b/xbmc/input/ButtonTranslator.cpp
@@ -98,7 +98,8 @@ static const ActionMapping actions[] =
         {"nextcalibration"   , ACTION_CALIBRATE_SWAP_ARROWS},
         {"resetcalibration"  , ACTION_CALIBRATE_RESET},
         {"analogmove"        , ACTION_ANALOG_MOVE},
-        {"rotate"            , ACTION_ROTATE_PICTURE},
+        {"rotate"            , ACTION_ROTATE_PICTURE_CW},
+        {"rotateccw"         , ACTION_ROTATE_PICTURE_CCW},
         {"close"             , ACTION_NAV_BACK}, // backwards compatibility
         {"subtitledelayminus", ACTION_SUBTITLE_DELAY_MIN},
         {"subtitledelay"     , ACTION_SUBTITLE_DELAY},

--- a/xbmc/input/TouchInput.h
+++ b/xbmc/input/TouchInput.h
@@ -219,6 +219,16 @@ public:
    \sa 
    */
   virtual void OnZoomPinch(float centerX, float centerY, float zoomFactor) { }
+  /*!
+   \brief Two simultaneous touches have been held down and moved to perform a rotating gesture
+
+   \param centerX       The x coordinate (with sub-pixel) of the center of the two touches
+   \param centerY       The y coordinate (with sub-pixel) of the center of the two touches
+   \param angle         The clockwise angle in degrees of the rotation
+   \return True if the event was handled otherwise false
+   \sa
+   */
+  virtual void OnRotate(float centerX, float centerY, float angle) { }
 };
 
 class CTouchInput : private ITouchHandler, private ITimerCallback
@@ -306,6 +316,7 @@ private:
 
   void handleMultiTouchGesture();
   void handleZoomPinch();
+  void handleRotation();
 
   // implementation of ITimerCallback
   virtual void OnTimeout();
@@ -335,12 +346,15 @@ private:
   virtual void OnDoubleTap(float x1, float y1, float x2, float y2);
   virtual void OnDoubleLongPress(float x1, float y1, float x2, float y2);
   virtual void OnZoomPinch(float centerX, float centerY, float zoomFactor);
+  virtual void OnRotate(float centerX, float centerY, float angle);
 
   CCriticalSection m_critical;
 
   int32_t m_holdTimeout;
   ITouchHandler *m_handler;
   CTimer *m_holdTimer;
+
+  float m_fRotateAngle;
 
   class Touch : public CVector {
     public:

--- a/xbmc/interfaces/http-api/XBMChttp.cpp
+++ b/xbmc/interfaces/http-api/XBMChttp.cpp
@@ -2151,7 +2151,7 @@ int CXbmcHttp::xbmcAction(int numParas, CStdString paras[], int theAction)
     {
       CGUIWindowSlideShow *pSlideShow = (CGUIWindowSlideShow *)g_windowManager.GetWindow(WINDOW_SLIDESHOW);
       if (pSlideShow) {
-        pSlideShow->OnAction(CAction(ACTION_ROTATE_PICTURE));
+        pSlideShow->OnAction(CAction(ACTION_ROTATE_PICTURE_CW));
         return SetResponse(openTag+"OK");
       }
       else

--- a/xbmc/interfaces/json-rpc/PlayerOperations.cpp
+++ b/xbmc/interfaces/json-rpc/PlayerOperations.cpp
@@ -441,7 +441,10 @@ JSONRPC_STATUS CPlayerOperations::Rotate(const CStdString &method, ITransportLay
   switch (GetPlayer(parameterObject["playerid"]))
   {
     case Picture:
-      SendSlideshowAction(ACTION_ROTATE_PICTURE);
+      if (parameterObject["value"].asString().compare("clockwise") == 0)
+        SendSlideshowAction(ACTION_ROTATE_PICTURE_CW);
+      else
+        SendSlideshowAction(ACTION_ROTATE_PICTURE_CCW);
       return ACK;
 
     case Video:

--- a/xbmc/interfaces/json-rpc/ServiceDescription.h
+++ b/xbmc/interfaces/json-rpc/ServiceDescription.h
@@ -1181,7 +1181,8 @@ namespace JSONRPC
       "\"transport\": \"Response\","
       "\"permission\": \"ControlPlayback\","
       "\"params\": ["
-        "{ \"name\": \"playerid\", \"$ref\": \"Player.Id\", \"required\": true }"
+        "{ \"name\": \"playerid\", \"$ref\": \"Player.Id\", \"required\": true },"
+        "{ \"name\": \"value\", \"type\": \"string\", \"enum\": [ \"clockwise\", \"counterclockwise\" ], \"default\": \"clockwise\" }"
       "],"
       "\"returns\": \"string\""
     "}",

--- a/xbmc/interfaces/json-rpc/methods.json
+++ b/xbmc/interfaces/json-rpc/methods.json
@@ -318,6 +318,7 @@
     "permission": "ControlPlayback",
     "params": [
       { "name": "playerid", "$ref": "Player.Id", "required": true }
+      { "name": "value", "type": "string", "enum": [ "clockwise", "counterclockwise" ], "default": "clockwise" }
     ],
     "returns": "string"
   },

--- a/xbmc/osx/ios/XBMCController.h
+++ b/xbmc/osx/ios/XBMCController.h
@@ -38,8 +38,6 @@
   /* Touch handling */
   CGSize screensize;
   CGPoint lastGesturePoint;
-  CGFloat lastPinchScale;
-  CGFloat currentPinchScale;  
   CGFloat screenScale;
   bool touchBeginSignaled;
   int  m_screenIdx;
@@ -50,8 +48,6 @@
 }
 @property (readonly, nonatomic, getter=isAnimating) BOOL animating;
 @property CGPoint lastGesturePoint;
-@property CGFloat lastPinchScale;
-@property CGFloat currentPinchScale;
 @property CGFloat screenScale;
 @property bool touchBeginSignaled;
 @property int  m_screenIdx;

--- a/xbmc/osx/ios/XBMCController.h
+++ b/xbmc/osx/ios/XBMCController.h
@@ -29,7 +29,7 @@
 
 @class IOSEAGLView;
 
-@interface XBMCController : UIViewController
+@interface XBMCController : UIViewController <UIGestureRecognizerDelegate>
 {
   UIWindow *m_window;
   IOSEAGLView  *m_glView;

--- a/xbmc/osx/ios/XBMCController.mm
+++ b/xbmc/osx/ios/XBMCController.mm
@@ -37,6 +37,13 @@
 #include "utils/TimeUtils.h"
 #include "Util.h"
 #include "threads/Event.h"
+#include <math.h>
+
+#ifndef M_PI
+#define M_PI 3.1415926535897932384626433832795028842
+#endif
+#define RADIANS_TO_DEGREES(radians) ((radians) * (180.0 / M_PI))
+
 #undef BOOL
 
 #import "IOSEAGLView.h"
@@ -142,6 +149,15 @@ extern NSString* kBRScreenSaverDismissed;
   CWinEventsIOS::MessagePush(&newEvent);
 }
 //--------------------------------------------------------------
+- (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer shouldRecognizeSimultaneouslyWithGestureRecognizer:(UIGestureRecognizer *)otherGestureRecognizer
+{
+  if ([gestureRecognizer isKindOfClass:[UIRotationGestureRecognizer class]] && [otherGestureRecognizer isKindOfClass:[UIPinchGestureRecognizer class]]) {
+    return YES;
+  }
+
+  return NO;
+}
+//--------------------------------------------------------------
 - (void)createGestureRecognizers 
 {
   //2 finger single tab - right mouse
@@ -189,8 +205,18 @@ extern NSString* kBRScreenSaverDismissed;
     initWithTarget:self action:@selector(handlePinch:)];
 
   pinch.delaysTouchesBegan = YES;
+  pinch.delegate = self;
   [self.view addGestureRecognizer:pinch];
   [pinch release];
+
+  //for rotate gesture
+  UIRotationGestureRecognizer *rotate = [[UIRotationGestureRecognizer alloc]
+                                         initWithTarget:self action:@selector(handleRotate:)];
+
+  rotate.delaysTouchesBegan = YES;
+  rotate.delegate = self;
+  [self.view addGestureRecognizer:rotate];
+  [rotate release];
 }
 //--------------------------------------------------------------
 - (void) activateKeyboard:(UIView *)view
@@ -224,6 +250,32 @@ extern NSString* kBRScreenSaverDismissed;
       case UIGestureRecognizerStateEnded:
         CApplicationMessenger::Get().SendAction(CAction(ACTION_GESTURE_END, 0, 0, 0,
                                                         0, 0), WINDOW_INVALID,false);
+        break;
+      default:
+        break;
+    }
+  }
+}
+//--------------------------------------------------------------
+-(void)handleRotate:(UIRotationGestureRecognizer*)sender
+{
+  if( [m_glView isXBMCAlive] )//NO GESTURES BEFORE WE ARE UP AND RUNNING
+  {
+    CGPoint point = [sender locationOfTouch:0 inView:m_glView];
+    point.x *= screenScale;
+    point.y *= screenScale;
+
+    switch(sender.state)
+    {
+      case UIGestureRecognizerStateBegan:
+        CApplicationMessenger::Get().SendAction(CAction(ACTION_GESTURE_BEGIN, 0, (float)point.x, (float)point.y,
+                                                        0, 0), WINDOW_INVALID,false);
+        break;
+      case UIGestureRecognizerStateChanged:
+        CApplicationMessenger::Get().SendAction(CAction(ACTION_GESTURE_ROTATE, 0, (float)point.x, (float)point.y,
+                                                        RADIANS_TO_DEGREES([sender rotation]), 0), WINDOW_INVALID,false);
+        break;
+      case UIGestureRecognizerStateEnded:
         break;
       default:
         break;

--- a/xbmc/osx/ios/XBMCController.mm
+++ b/xbmc/osx/ios/XBMCController.mm
@@ -68,8 +68,6 @@ extern NSString* kBRScreenSaverDismissed;
 @implementation XBMCController
 @synthesize animating;
 @synthesize lastGesturePoint;
-@synthesize lastPinchScale;
-@synthesize currentPinchScale;
 @synthesize screenScale;
 @synthesize lastEvent;
 @synthesize touchBeginSignaled;
@@ -193,8 +191,6 @@ extern NSString* kBRScreenSaverDismissed;
   pinch.delaysTouchesBegan = YES;
   [self.view addGestureRecognizer:pinch];
   [pinch release];
-  lastPinchScale = 1.0;
-  currentPinchScale = lastPinchScale;
 }
 //--------------------------------------------------------------
 - (void) activateKeyboard:(UIView *)view
@@ -214,21 +210,23 @@ extern NSString* kBRScreenSaverDismissed;
     CGPoint point = [sender locationOfTouch:0 inView:m_glView];  
     point.x *= screenScale;
     point.y *= screenScale;
-    currentPinchScale += [sender scale] - lastPinchScale;
-    lastPinchScale = [sender scale];  
   
     switch(sender.state)
     {
       case UIGestureRecognizerStateBegan:  
-      break;
+        CApplicationMessenger::Get().SendAction(CAction(ACTION_GESTURE_BEGIN, 0, (float)point.x, (float)point.y,
+                                                        0, 0), WINDOW_INVALID,false);
+        break;
       case UIGestureRecognizerStateChanged:
         CApplicationMessenger::Get().SendAction(CAction(ACTION_GESTURE_ZOOM, 0, (float)point.x, (float)point.y, 
-          currentPinchScale, 0), WINDOW_INVALID,false);    
-      break;
+                                                                   [sender scale], 0), WINDOW_INVALID,false);
+        break;
       case UIGestureRecognizerStateEnded:
-      break;
+        CApplicationMessenger::Get().SendAction(CAction(ACTION_GESTURE_END, 0, 0, 0,
+                                                        0, 0), WINDOW_INVALID,false);
+        break;
       default:
-      break;
+        break;
     }
   }
 }

--- a/xbmc/pictures/GUIWindowSlideShow.cpp
+++ b/xbmc/pictures/GUIWindowSlideShow.cpp
@@ -57,6 +57,8 @@ using namespace XFILE;
 #define PICTURE_VIEW_BOX_COLOR      0xffffff00 // YELLOW
 #define PICTURE_VIEW_BOX_BACKGROUND 0xff000000 // BLACK
 
+#define ROTATION_SNAP_RANGE              10.0f
+
 #define FPS                                 25
 
 #define BAR_IMAGE                            1
@@ -550,6 +552,17 @@ EVENT_RESULT CGUIWindowSlideShow::OnMouseEvent(const CPoint &point, const CMouse
   }
   else if (event.m_id == ACTION_GESTURE_END)
   {
+    if (m_fRotate != 0.0f)
+    {
+      // "snap" to nearest of 0, 90, 180 and 270 if the
+      // difference in angle is +/-10 degrees
+      float reminder = fmodf(m_fRotate, 90.0f);
+      if (reminder < ROTATION_SNAP_RANGE)
+        RotateRelative(-reminder);
+      else if (reminder > 90.0f - ROTATION_SNAP_RANGE)
+        RotateRelative(90.0f - reminder);
+    }
+
     m_fInitialZoom = 0.0f;
     m_fInitialRotate = 0.0f;
     return EVENT_RESULT_HANDLED;

--- a/xbmc/pictures/GUIWindowSlideShow.cpp
+++ b/xbmc/pictures/GUIWindowSlideShow.cpp
@@ -558,9 +558,9 @@ EVENT_RESULT CGUIWindowSlideShow::OnMouseEvent(const CPoint &point, const CMouse
       // difference in angle is +/-10 degrees
       float reminder = fmodf(m_fRotate, 90.0f);
       if (reminder < ROTATION_SNAP_RANGE)
-        RotateRelative(-reminder);
+        Rotate(-reminder);
       else if (reminder > 90.0f - ROTATION_SNAP_RANGE)
-        RotateRelative(90.0f - reminder);
+        Rotate(90.0f - reminder);
     }
 
     m_fInitialZoom = 0.0f;
@@ -574,7 +574,7 @@ EVENT_RESULT CGUIWindowSlideShow::OnMouseEvent(const CPoint &point, const CMouse
   }
   else if (event.m_id == ACTION_GESTURE_ROTATE)
   {
-    RotateRelative(m_fInitialRotate + event.m_offsetX - m_fRotate, true);
+    Rotate(m_fInitialRotate + event.m_offsetX - m_fRotate, true);
     return EVENT_RESULT_HANDLED;
   }
   return EVENT_RESULT_UNHANDLED;
@@ -660,8 +660,12 @@ bool CGUIWindowSlideShow::OnAction(const CAction &action)
     Zoom(m_iZoomFactor + 1);
     break;
 
-  case ACTION_ROTATE_PICTURE:
-    Rotate();
+  case ACTION_ROTATE_PICTURE_CW:
+    Rotate(90.0f);
+    break;
+
+  case ACTION_ROTATE_PICTURE_CCW:
+    Rotate(-90.0f);
     break;
 
   case ACTION_ZOOM_LEVEL_NORMAL:
@@ -819,12 +823,7 @@ void CGUIWindowSlideShow::RenderPause()
 
 }
 
-void CGUIWindowSlideShow::Rotate()
-{
-  RotateRelative(90.0f);
-}
-
-void CGUIWindowSlideShow::RotateRelative(float fAngle, bool immediate /* = false */)
+void CGUIWindowSlideShow::Rotate(float fAngle, bool immediate /* = false */)
 {
   if (m_Image[m_iCurrentPic].DrawNextImage())
     return;

--- a/xbmc/pictures/GUIWindowSlideShow.cpp
+++ b/xbmc/pictures/GUIWindowSlideShow.cpp
@@ -170,7 +170,8 @@ void CGUIWindowSlideShow::Reset()
   m_Image[1].UnLoad();
   m_Image[1].Close();
 
-  m_iRotate = 0;
+  m_fRotate = 0.0f;
+  m_fInitialRotate = 0.0f;
   m_iZoomFactor = 1;
   m_fZoom = 1.0f;
   m_fInitialZoom = 0.0f;
@@ -478,7 +479,7 @@ void CGUIWindowSlideShow::Process(unsigned int currentTime, CDirtyRegionList &re
     m_iNextSlide    = GetNextSlide();
 
 //    m_iZoomFactor = 1;
-    m_iRotate = 0;
+    m_fRotate = 0.0f;
   }
 
   if (m_Image[m_iCurrentPic].IsLoaded())
@@ -523,6 +524,7 @@ EVENT_RESULT CGUIWindowSlideShow::OnMouseEvent(const CPoint &point, const CMouse
   {
     m_firstGesturePoint = point;
     m_fInitialZoom = m_fZoom;
+    m_fInitialRotate = m_fRotate;
     return EVENT_RESULT_HANDLED;
   }
   else if (event.m_id == ACTION_GESTURE_PAN)
@@ -549,11 +551,17 @@ EVENT_RESULT CGUIWindowSlideShow::OnMouseEvent(const CPoint &point, const CMouse
   else if (event.m_id == ACTION_GESTURE_END)
   {
     m_fInitialZoom = 0.0f;
+    m_fInitialRotate = 0.0f;
     return EVENT_RESULT_HANDLED;
   }
   else if (event.m_id == ACTION_GESTURE_ZOOM)
   {
     ZoomRelative(m_fInitialZoom * event.m_offsetX, true);
+    return EVENT_RESULT_HANDLED;
+  }
+  else if (event.m_id == ACTION_GESTURE_ROTATE)
+  {
+    RotateRelative(m_fInitialRotate + event.m_offsetX - m_fRotate, true);
     return EVENT_RESULT_HANDLED;
   }
   return EVENT_RESULT_UNHANDLED;
@@ -800,8 +808,17 @@ void CGUIWindowSlideShow::RenderPause()
 
 void CGUIWindowSlideShow::Rotate()
 {
-  if (!m_Image[m_iCurrentPic].DrawNextImage() && m_iZoomFactor == 1)
-    m_Image[m_iCurrentPic].Rotate(++m_iRotate);
+  RotateRelative(90.0f);
+}
+
+void CGUIWindowSlideShow::RotateRelative(float fAngle, bool immediate /* = false */)
+{
+  if (m_Image[m_iCurrentPic].DrawNextImage() || m_fZoom > 1.0f)
+    return;
+
+  m_fRotate += fAngle;
+
+  m_Image[m_iCurrentPic].Rotate(fAngle, immediate);
 }
 
 void CGUIWindowSlideShow::Zoom(int iZoom)

--- a/xbmc/pictures/GUIWindowSlideShow.cpp
+++ b/xbmc/pictures/GUIWindowSlideShow.cpp
@@ -150,7 +150,6 @@ CGUIWindowSlideShow::~CGUIWindowSlideShow(void)
   delete m_slides;
 }
 
-
 bool CGUIWindowSlideShow::IsPlaying() const
 {
   return m_Image[m_iCurrentPic].IsLoaded();
@@ -373,14 +372,11 @@ void CGUIWindowSlideShow::Process(unsigned int currentTime, CDirtyRegionList &re
 
   // check if we should discard an already loaded next slide
   if (m_bLoadNextPic && m_Image[1 - m_iCurrentPic].IsLoaded() && m_Image[1 - m_iCurrentPic].SlideNumber() != m_iNextSlide)
-  {
     m_Image[1 - m_iCurrentPic].Close();
-  }
+
   // if we're reloading an image (for better res on zooming we need to close any open ones as well)
   if (m_bReloadImage && m_Image[1 - m_iCurrentPic].IsLoaded() && m_Image[1 - m_iCurrentPic].SlideNumber() != m_iCurrentSlide)
-  {
     m_Image[1 - m_iCurrentPic].Close();
-  }
 
   if (m_bReloadImage)
   {
@@ -396,8 +392,10 @@ void CGUIWindowSlideShow::Process(unsigned int currentTime, CDirtyRegionList &re
       GetCheckedSize((float)m_Image[m_iCurrentPic].GetOriginalWidth(), (float)m_Image[m_iCurrentPic].GetOriginalHeight(), width, height);
 
       // use the smaller of the two (no point zooming in more than we have to)
-      if (maxWidth < width) width = maxWidth;
-      if (maxHeight < height) height = maxHeight;
+      if (maxWidth < width)
+        width = maxWidth;
+      if (maxHeight < height)
+        height = maxHeight;
 
       m_pBackgroundLoader->LoadPic(m_iCurrentPic, m_iCurrentSlide, m_slides->Get(m_iCurrentSlide)->GetPath(), width, height);
     }
@@ -431,7 +429,8 @@ void CGUIWindowSlideShow::Process(unsigned int currentTime, CDirtyRegionList &re
     CApplicationMessenger::Get().PlayFile(*m_slides->Get(m_iCurrentSlide));
     m_iCurrentSlide = m_iNextSlide;
     m_iNextSlide    = GetNextSlide();
-  } 
+  }
+
   // Check if we should be transistioning immediately
   if (m_bLoadNextPic)
   {
@@ -499,26 +498,22 @@ void CGUIWindowSlideShow::Render()
 
 int CGUIWindowSlideShow::GetNextSlide()
 {
-  if(m_slides->Size() <= 1)
+  if (m_slides->Size() <= 1)
     return m_iCurrentSlide;
-  if(m_bSlideShow || m_iDirection >= 0)
-    return (m_iCurrentSlide + 1                   ) % m_slides->Size();
-  else
-    return (m_iCurrentSlide - 1 + m_slides->Size()) % m_slides->Size();
+  if (m_bSlideShow || m_iDirection >= 0)
+    return (m_iCurrentSlide + 1) % m_slides->Size();
+
+  return (m_iCurrentSlide - 1 + m_slides->Size()) % m_slides->Size();
 }
 
 EVENT_RESULT CGUIWindowSlideShow::OnMouseEvent(const CPoint &point, const CMouseEvent &event)
 {
   if (event.m_id == ACTION_GESTURE_NOTIFY)
   {
-    if( m_iZoomFactor == 1)//zoomed out - no inertial scrolling
-    {
+    if (m_iZoomFactor == 1) //zoomed out - no inertial scrolling
       return EVENT_RESULT_PAN_HORIZONTAL_WITHOUT_INERTIA;
-    }
-    else//zoomed in - with inertia 
-    {
-      return EVENT_RESULT_PAN_HORIZONTAL;
-    }
+
+    return EVENT_RESULT_PAN_HORIZONTAL;
   }  
   else if (event.m_id == ACTION_GESTURE_BEGIN)
   {
@@ -527,42 +522,34 @@ EVENT_RESULT CGUIWindowSlideShow::OnMouseEvent(const CPoint &point, const CMouse
   }
   else if (event.m_id == ACTION_GESTURE_PAN)
   { // on zoomlevel 1 just detect swipe left and right
-    if( m_iZoomFactor == 1 )
-    {   
-      if( m_firstGesturePoint.x > 0 && fabs(point.x - m_firstGesturePoint.x) > 100 )
+    if (m_iZoomFactor == 1)
+    {
+      if (m_firstGesturePoint.x > 0 && fabs(point.x - m_firstGesturePoint.x) > 100)
       {
-        if( point.x < m_firstGesturePoint.x )
-        {
+        if (point.x < m_firstGesturePoint.x)
           OnAction(CAction(ACTION_NEXT_PICTURE));
-        }
         else 
-        {
           OnAction(CAction(ACTION_PREV_PICTURE));
-        }
+
         m_firstGesturePoint.x = 0;
       }
     }
-    else//zoomed in - free move mode
+    else //zoomed in - free move mode
     {
-      Move(PICTURE_MOVE_AMOUNT_TOUCH/m_iZoomFactor*(m_firstGesturePoint.x-point.x),PICTURE_MOVE_AMOUNT_TOUCH/m_iZoomFactor*(m_firstGesturePoint.y-point.y));
+      Move(PICTURE_MOVE_AMOUNT_TOUCH / m_iZoomFactor * (m_firstGesturePoint.x - point.x), PICTURE_MOVE_AMOUNT_TOUCH / m_iZoomFactor * (m_firstGesturePoint.y - point.y));
       m_firstGesturePoint = point;
     }
     return EVENT_RESULT_HANDLED;
   }
   else if (event.m_id == ACTION_GESTURE_END)
-  {
     return EVENT_RESULT_HANDLED;
-  }
   else if (event.m_id == ACTION_GESTURE_ZOOM)
   {
-    if( event.m_offsetX > 1)
-    {
+    if (event.m_offsetX > 1)
       Zoom((int)event.m_offsetX);
-    }
     else 
-    {
       Zoom((int)(m_iZoomFactor - event.m_offsetX));
-    }
+
     return EVENT_RESULT_HANDLED;    
   }
   return EVENT_RESULT_UNHANDLED;
@@ -588,17 +575,21 @@ bool CGUIWindowSlideShow::OnAction(const CAction &action)
       }
     }
     break;
+
   case ACTION_PREVIOUS_MENU:
   case ACTION_NAV_BACK:
   case ACTION_STOP:
     g_windowManager.PreviousWindow();
     break;
+
   case ACTION_NEXT_PICTURE:
       ShowNext();
     break;
+
   case ACTION_PREV_PICTURE:
       ShowPrevious();
     break;
+
   case ACTION_MOVE_RIGHT:
     if (m_iZoomFactor == 1)
       ShowNext();
@@ -660,9 +651,11 @@ bool CGUIWindowSlideShow::OnAction(const CAction &action)
   case ACTION_ZOOM_LEVEL_9:
     Zoom((action.GetID() - ACTION_ZOOM_LEVEL_NORMAL) + 1);
     break;
+
   case ACTION_ANALOG_MOVE:
     Move(action.GetAmount()*PICTURE_MOVE_AMOUNT_ANALOG, -action.GetAmount(1)*PICTURE_MOVE_AMOUNT_ANALOG);
     break;
+
   default:
     return CGUIWindow::OnAction(action);
   }
@@ -699,9 +692,8 @@ bool CGUIWindowSlideShow::OnMessage(CGUIMessage& message)
 
       //   Reset();
       if (message.GetParam1() != WINDOW_PICTURES)
-      {
         m_ImageLib.Unload();
-      }
+
       g_windowManager.ShowOverlay(OVERLAY_STATE_SHOWN);
       FreeResources();
     }
@@ -713,19 +705,14 @@ bool CGUIWindowSlideShow::OnMessage(CGUIMessage& message)
 
       //FIXME: Use GUI resolution for now
       if (0 /*m_Resolution != g_guiSettings.m_LookAndFeelResolution && m_Resolution != INVALID && m_Resolution!=AUTORES*/)
-      {
         g_graphicsContext.SetVideoResolution(m_Resolution);
-      }
       else
-      {
         m_Resolution = g_graphicsContext.GetVideoResolution();
-      }
 
       CGUIWindow::OnMessage(message);
       if (message.GetParam1() != WINDOW_PICTURES)
-      {
         m_ImageLib.Load();
-      }
+
       g_windowManager.ShowOverlay(OVERLAY_STATE_HIDDEN);
 
       // turn off slideshow if we only have 1 image
@@ -735,6 +722,7 @@ bool CGUIWindowSlideShow::OnMessage(CGUIMessage& message)
       return true;
     }
     break;
+
   case GUI_MSG_START_SLIDESHOW:
     {
       CStdString strFolder = message.GetStringParam();
@@ -755,28 +743,31 @@ bool CGUIWindowSlideShow::OnMessage(CGUIMessage& message)
       RunSlideShow(strFolder, bRecursive, bRandom, bNotRandom);
     }
     break;
+
     case GUI_MSG_PLAYLISTPLAYER_STOPPED:
-    {
-      m_bPlayingVideo = false;
-      if (m_bSlideShow)
-        g_windowManager.ActivateWindow(WINDOW_SLIDESHOW);
-    }
-    break;
-    case GUI_MSG_PLAYBACK_STARTED:
-    {
-      if(m_bSlideShow && m_bPlayingVideo)
-        g_windowManager.ActivateWindow(WINDOW_FULLSCREEN_VIDEO);
-    }
-    break;
-    case GUI_MSG_PLAYBACK_STOPPED:
-    {
-      if (m_bSlideShow && m_bPlayingVideo)
       {
-        m_bSlideShow = false;
-        g_windowManager.PreviousWindow();
+        m_bPlayingVideo = false;
+        if (m_bSlideShow)
+          g_windowManager.ActivateWindow(WINDOW_SLIDESHOW);
       }
-    }
-    break;
+      break;
+
+    case GUI_MSG_PLAYBACK_STARTED:
+      {
+        if (m_bSlideShow && m_bPlayingVideo)
+          g_windowManager.ActivateWindow(WINDOW_FULLSCREEN_VIDEO);
+      }
+      break;
+
+    case GUI_MSG_PLAYBACK_STOPPED:
+      {
+        if (m_bSlideShow && m_bPlayingVideo)
+        {
+          m_bSlideShow = false;
+          g_windowManager.PreviousWindow();
+        }
+      }
+      break;
   }
   return CGUIWindow::OnMessage(message);
 }
@@ -806,15 +797,14 @@ void CGUIWindowSlideShow::RenderPause()
 void CGUIWindowSlideShow::Rotate()
 {
   if (!m_Image[m_iCurrentPic].DrawNextImage() && m_iZoomFactor == 1)
-  {
     m_Image[m_iCurrentPic].Rotate(++m_iRotate);
-  }
 }
 
 void CGUIWindowSlideShow::Zoom(int iZoom)
 {
   if (iZoom > MAX_ZOOM_FACTOR || iZoom < 1)
-    return ;
+    return;
+
   // set the zoom amount and then set so that the image is reloaded at the higher (or lower)
   // resolution as necessary
   if (!m_Image[m_iCurrentPic].DrawNextImage())
@@ -1000,8 +990,10 @@ void CGUIWindowSlideShow::GetCheckedSize(float width, float height, int &maxWidt
   }
   maxWidth = (int)width;
   maxHeight = (int)height;
-  if (maxWidth > (int)g_Windowing.GetMaxTextureSize()) maxWidth = g_Windowing.GetMaxTextureSize();
-  if (maxHeight > (int)g_Windowing.GetMaxTextureSize()) maxHeight = g_Windowing.GetMaxTextureSize();
+  if (maxWidth > (int)g_Windowing.GetMaxTextureSize())
+    maxWidth = g_Windowing.GetMaxTextureSize();
+  if (maxHeight > (int)g_Windowing.GetMaxTextureSize())
+    maxHeight = g_Windowing.GetMaxTextureSize();
 #else
   maxWidth = g_Windowing.GetMaxTextureSize();
   maxHeight = g_Windowing.GetMaxTextureSize();

--- a/xbmc/pictures/GUIWindowSlideShow.cpp
+++ b/xbmc/pictures/GUIWindowSlideShow.cpp
@@ -167,6 +167,8 @@ void CGUIWindowSlideShow::Reset()
   m_bScreensaver = false;
   m_Image[0].UnLoad();
   m_Image[0].Close();
+  m_Image[1].UnLoad();
+  m_Image[1].Close();
 
   m_iRotate = 0;
   m_iZoomFactor = 1;

--- a/xbmc/pictures/GUIWindowSlideShow.cpp
+++ b/xbmc/pictures/GUIWindowSlideShow.cpp
@@ -813,7 +813,7 @@ void CGUIWindowSlideShow::Rotate()
 
 void CGUIWindowSlideShow::RotateRelative(float fAngle, bool immediate /* = false */)
 {
-  if (m_Image[m_iCurrentPic].DrawNextImage() || m_fZoom > 1.0f)
+  if (m_Image[m_iCurrentPic].DrawNextImage())
     return;
 
   m_fRotate += fAngle;

--- a/xbmc/pictures/GUIWindowSlideShow.h
+++ b/xbmc/pictures/GUIWindowSlideShow.h
@@ -104,6 +104,7 @@ private:
   void RenderErrorMessage();
   void Rotate();
   void Zoom(int iZoom);
+  void ZoomRelative(float fZoom, bool immediate = false);
   void Move(float fX, float fY);
   void GetCheckedSize(float width, float height, int &maxWidth, int &maxHeight);
   int  GetNextSlide();
@@ -113,6 +114,8 @@ private:
   int m_iDirection;
   int m_iRotate;
   int m_iZoomFactor;
+  float m_fZoom;
+  float m_fInitialZoom;
 
   bool m_bShuffled;
   bool m_bSlideShow;

--- a/xbmc/pictures/GUIWindowSlideShow.h
+++ b/xbmc/pictures/GUIWindowSlideShow.h
@@ -102,8 +102,7 @@ private:
                 SortOrder order = SortOrderAscending);
   void RenderPause();
   void RenderErrorMessage();
-  void Rotate();
-  void RotateRelative(float fAngle, bool immediate = false);
+  void Rotate(float fAngle, bool immediate = false);
   void Zoom(int iZoom);
   void ZoomRelative(float fZoom, bool immediate = false);
   void Move(float fX, float fY);

--- a/xbmc/pictures/GUIWindowSlideShow.h
+++ b/xbmc/pictures/GUIWindowSlideShow.h
@@ -103,6 +103,7 @@ private:
   void RenderPause();
   void RenderErrorMessage();
   void Rotate();
+  void RotateRelative(float fAngle, bool immediate = false);
   void Zoom(int iZoom);
   void ZoomRelative(float fZoom, bool immediate = false);
   void Move(float fX, float fY);
@@ -112,7 +113,8 @@ private:
   int m_iCurrentSlide;
   int m_iNextSlide;
   int m_iDirection;
-  int m_iRotate;
+  float m_fRotate;
+  float m_fInitialRotate;
   int m_iZoomFactor;
   float m_fZoom;
   float m_fInitialZoom;

--- a/xbmc/pictures/SlideShowPicture.cpp
+++ b/xbmc/pictures/SlideShowPicture.cpp
@@ -246,8 +246,10 @@ void CSlideShowPic::Process(unsigned int currentTime, CDirtyRegionList &dirtyreg
         { // correct for any introduced inaccuracies.
           int i;
           for (i = 0; i < 10; i++)
-            if (fabs(m_fZoomAmount - zoomamount[i]) < 0.01*zoomamount[i])
+          {
+            if (fabs(m_fZoomAmount - zoomamount[i]) < 0.01 * zoomamount[i])
               break;
+          }
           m_fZoomAmount = zoomamount[i];
           m_bNoEffect = (m_fZoomAmount != 1.0f); // turn effect rendering back on.
         }
@@ -612,19 +614,19 @@ void CSlideShowPic::Rotate(int iRotate)
   m_transistionEnd.start = m_iCounter + m_transistionStart.length + (int)(g_graphicsContext.GetFPS() * g_guiSettings.GetInt("slideshow.staytime"));
 }
 
-void CSlideShowPic::Zoom(int iZoom, bool immediate /*= false*/)
+void CSlideShowPic::Zoom(float fZoom, bool immediate /* = false */)
 {
-  if (m_bDrawNextImage) return ;
-  if (m_transistionTemp.type == TRANSISTION_ROTATE) return ;
+  if (m_bDrawNextImage) return;
+  if (m_transistionTemp.type == TRANSISTION_ROTATE) return;
   if (immediate)
   {
-    m_fZoomAmount = zoomamount[iZoom - 1];
+    m_fZoomAmount = fZoom;
     return;
   }
   m_transistionTemp.type = TRANSISTION_ZOOM;
   m_transistionTemp.start = m_iCounter;
   m_transistionTemp.length = IMMEDIATE_TRANSISTION_TIME;
-  m_fTransistionZoom = (float)(zoomamount[iZoom - 1] - m_fZoomAmount) / (float)m_transistionTemp.length;
+  m_fTransistionZoom = (fZoom - m_fZoomAmount) / (float)m_transistionTemp.length;
   // reset the timer
   m_transistionEnd.start = m_iCounter + m_transistionStart.length + (int)(g_graphicsContext.GetFPS() * g_guiSettings.GetInt("slideshow.staytime"));
   // turn off the render effects until we're back down to normal zoom
@@ -646,7 +648,7 @@ void CSlideShowPic::Render()
   Render(m_ax, m_ay, m_pImage, (m_alpha << 24) | 0xFFFFFF);
 
   // now render the image in the top right corner if we're zooming
-  if (m_fZoomAmount == 1 || m_bIsComic) return ;
+  if (m_fZoomAmount == 1.0f || m_bIsComic) return ;
 
   Render(m_bx, m_by, NULL, PICTURE_VIEW_BOX_BACKGROUND);
   Render(m_sx, m_sy, m_pImage, 0xFFFFFFFF);

--- a/xbmc/pictures/SlideShowPicture.h
+++ b/xbmc/pictures/SlideShowPicture.h
@@ -66,7 +66,7 @@ public:
 
   int SlideNumber() const { return m_iSlideNumber;};
 
-  void Zoom(int iZoomAmount, bool immediate = false);
+  void Zoom(float fZoomAmount, bool immediate = false);
   void Rotate(int iRotateAmount);
   void Pause(bool bPause);
   void SetInSlideshow(bool slideshow);

--- a/xbmc/pictures/SlideShowPicture.h
+++ b/xbmc/pictures/SlideShowPicture.h
@@ -67,7 +67,7 @@ public:
   int SlideNumber() const { return m_iSlideNumber;};
 
   void Zoom(float fZoomAmount, bool immediate = false);
-  void Rotate(int iRotateAmount);
+  void Rotate(float fRotateAngle, bool immediate = false);
   void Pause(bool bPause);
   void SetInSlideshow(bool slideshow);
   void SetOriginalSize(int iOriginalWidth, int iOriginalHeight, bool bFullSize);


### PR DESCRIPTION
This PR contains better implementations for zooming/pinching and rotating images in CGUIWindowSlideShow when used with touch devices (and a few cosmetics).

This new implementation supports both the existing zooming/rotating by fixed levels (used for remote controls) and zooming/rotating by an arbitrary factor/angle which makes zooming/pinching/rotating with touch gestures much more intuitive. Nothing changes for zooming/rotating by fixed levels but for zooming/rotating by an arbitrary factor every zoom/pinch/rotation must start by sending the ACTION_GESTURE_BEGIN action and end by sending the ACTION_GESTURE_END action. In between (as it was already possible before, the ACTION_GESTURE_ZOOM/ACTION_GESTURE_ROTATE can be sent containing an arbitrary floating-point zoom factor/angle to perform zoom/pinch/rotation actions.

This PR only changes both implementation for Android and for iOS (thanks @Memphiz) but might need work on other touch input implementations but it's a lot more intuitive with this than it currently is. Currently touch based zooming/pinching is useless expect when zooming into an unzoomed image. Once the image has been zoomed any zoom/pinch action will result in unexpected behaviour. Rotation was not implemented at all because currently it is only possible to rotate in steps of 90 degrees clockwise and nothing else.

This implementation does not (yet) consider the center point of the zooming/pinching action. It will simply zoom with the center being the center of the currently visible part of the image.
