### PR TITLE
Fix the aspect ratio to 4:3 for the teletext window (making it more readable)

### DIFF
--- a/language/English/strings.po
+++ b/language/English/strings.po
@@ -9896,6 +9896,10 @@ msgctxt "#23054"
 msgid "Running"
 msgstr ""
 
+msgctxt "#23055"
+msgid "Scale Teletext to 4:3"
+msgstr ""
+
 #strings 23100 thru 23150 reserved for external player
 #empty strings from id 23055 to 23099
 

--- a/xbmc/settings/GUISettings.cpp
+++ b/xbmc/settings/GUISettings.cpp
@@ -767,6 +767,7 @@ void CGUISettings::Initialize()
 #endif
   AddSeparator(vp, "videoplayer.sep5");
   AddBool(vp, "videoplayer.teletextenabled", 23050, true);
+  AddBool(vp, "Videoplayer.teletextscale", 23055, true);
 
   CSettingsCategory* vid = AddCategory(SETTINGS_VIDEOS, "myvideos", 14081);
 

--- a/xbmc/video/dialogs/GUIDialogTeletext.cpp
+++ b/xbmc/video/dialogs/GUIDialogTeletext.cpp
@@ -112,15 +112,26 @@ void CGUIDialogTeletext::Render()
 
 void CGUIDialogTeletext::OnInitWindow()
 {
+  float left, right, top, bottom;
+
   teletextFadeAmount  = 0;
   m_bClose            = false;
   m_windowLoaded      = true;
 
   g_graphicsContext.SetScalingResolution(m_coordsRes, m_needsScaling);
-  float left = g_graphicsContext.ScaleFinalXCoord(0, 0);
-  float right = g_graphicsContext.ScaleFinalXCoord((float)m_coordsRes.iWidth, 0);
-  float top = g_graphicsContext.ScaleFinalYCoord(0, 0);
-  float bottom = g_graphicsContext.ScaleFinalYCoord(0, (float)m_coordsRes.iHeight);
+  if (g_guiSettings.GetBool("videoplayer.teletextscale"))
+  {
+    /* Fixed aspect ratio to 4:3 for teletext */
+    left = g_graphicsContext.ScaleFinalXCoord((float)(m_coordsRes.iWidth-m_coordsRes.iHeight*4/3)/2, 0);
+    right = g_graphicsContext.ScaleFinalXCoord((float)m_coordsRes.iWidth-left, 0);
+  }
+  else
+  { 
+    left = g_graphicsContext.ScaleFinalXCoord(0, 0);
+    right = g_graphicsContext.ScaleFinalXCoord((float)m_coordsRes.iWidth, 0);
+  }
+  top = g_graphicsContext.ScaleFinalYCoord(0, 0);
+  bottom = g_graphicsContext.ScaleFinalYCoord(0, (float)m_coordsRes.iHeight);
 
   m_vertCoords.SetRect(left,
                        top,


### PR DESCRIPTION
The current scaling of teletext fonts on large widescreen display make it almost unreadable. This PR fix the aspect ratio to always be 4:3 for the teletext window.

It could be implemented as a user defined setting, but I haven't looked into how this could be done and IMHO I don't think anyone would use anything other the 4:3 aspect for this...?

Also discussed/requested here: http://forum.xbmc.org/showthread.php?tid=129640

screenshot of new behavior: http://www.alfredsson.nu/teletext4-3.png
