### PR TITLE
Implementation of platform-independ environment manipulations

### DIFF
--- a/project/VS2010Express/XBMC.vcxproj
+++ b/project/VS2010Express/XBMC.vcxproj
@@ -1700,6 +1700,7 @@
     <ClCompile Include="..\..\xbmc\utils\UrlOptions.cpp" />
     <ClCompile Include="..\..\xbmc\utils\Variant.cpp" />
     <ClCompile Include="..\..\xbmc\utils\Weather.cpp" />
+    <ClCompile Include="..\..\xbmc\utils\Environment.cpp" />
     <ClCompile Include="..\..\xbmc\utils\XBMCTinyXML.cpp" />
     <ClCompile Include="..\..\xbmc\utils\XMLUtils.cpp" />
     <ClCompile Include="..\..\xbmc\video\Bookmark.cpp" />
@@ -2504,6 +2505,7 @@
     <ClInclude Include="..\..\xbmc\utils\UrlOptions.h" />
     <ClInclude Include="..\..\xbmc\utils\Variant.h" />
     <ClInclude Include="..\..\xbmc\utils\Weather.h" />
+    <ClInclude Include="..\..\xbmc\utils\Environment.h" />
     <ClInclude Include="..\..\xbmc\utils\XBMCTinyXML.h" />
     <ClInclude Include="..\..\xbmc\utils\XMLUtils.h" />
     <ClInclude Include="..\..\xbmc\video\Bookmark.h" />

--- a/project/VS2010Express/XBMC.vcxproj.filters
+++ b/project/VS2010Express/XBMC.vcxproj.filters
@@ -3033,6 +3033,9 @@
     <ClCompile Include="..\..\xbmc\cores\dvdplayer\DVDDemuxers\DVDDemuxCDDA.cpp">
       <Filter>cores\dvdplayer\DVDDemuxers</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\xbmc\utils\Environment.cpp">
+      <Filter>utils</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\xbmc\win32\pch.h">
@@ -5938,6 +5941,9 @@
     </ClInclude>
     <ClInclude Include="..\..\xbmc\cores\dvdplayer\DVDDemuxers\DVDDemuxCDDA.h">
       <Filter>cores\dvdplayer\DVDDemuxers</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\xbmc\utils\Environment.h">
+      <Filter>utils</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -345,6 +345,10 @@
 #include "linux/LinuxTimezone.h"
 #endif
 
+#ifdef TARGET_WINDOWS
+#include "utils/Environment.h"
+#endif
+
 using namespace std;
 using namespace ADDON;
 using namespace XFILE;
@@ -703,7 +707,7 @@ bool CApplication::Create()
 #elif defined(_LINUX)
   setenv("OS","Linux",true);
 #elif defined(_WIN32)
-  SetEnvironmentVariable("OS","win32");
+  CEnvironment::setenv("OS", "win32");
 #endif
 
   g_powerManager.Initialize();
@@ -1174,7 +1178,7 @@ bool CApplication::InitDirectoriesWin32()
   CStdString xbmcPath;
 
   CUtil::GetHomePath(xbmcPath);
-  SetEnvironmentVariable("XBMC_HOME", xbmcPath.c_str());
+  CEnvironment::setenv("XBMC_HOME", xbmcPath);
   CSpecialProtocol::SetXBMCBinPath(xbmcPath);
   CSpecialProtocol::SetXBMCPath(xbmcPath);
 
@@ -1185,7 +1189,7 @@ bool CApplication::InitDirectoriesWin32()
   CSpecialProtocol::SetMasterProfilePath(URIUtils::AddFileToFolder(strWin32UserFolder, "userdata"));
   CSpecialProtocol::SetTempPath(URIUtils::AddFileToFolder(strWin32UserFolder,"cache"));
 
-  SetEnvironmentVariable("XBMC_PROFILE_USERDATA",CSpecialProtocol::TranslatePath("special://masterprofile/").c_str());
+  CEnvironment::setenv("XBMC_PROFILE_USERDATA", CSpecialProtocol::TranslatePath("special://masterprofile/"));
 
   CreateUserDirs();
 

--- a/xbmc/utils/Environment.cpp
+++ b/xbmc/utils/Environment.cpp
@@ -1,0 +1,252 @@
+/*
+ *      Copyright (C) 2013 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+/**
+ * \file utils\Environment.cpp
+ * \brief Implements CEnvironment class functions.
+ *  
+ *  Some ideas were inspired by PostgreSQL's pgwin32_putenv function. 
+ *  Refined, updated, enhanced and modified for XBMC by Karlson2k.
+ */
+
+#include "Environment.h"
+#include <stdlib.h>
+#ifdef TARGET_WINDOWS
+#include <Windows.h>
+#endif
+
+// --------------------- Helper Functions ---------------------
+
+#ifdef TARGET_WINDOWS
+
+std::wstring CEnvironment::win32ConvertUtf8ToW(const std::string &text, bool *resultSuccessful /* = NULL*/)  
+{
+  if (text.empty())
+  {
+    if (resultSuccessful != NULL)
+      *resultSuccessful = true;
+    return L"";
+  }
+  if (resultSuccessful != NULL)
+    *resultSuccessful = false;
+
+  int bufSize = MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, text.c_str(), -1, NULL, 0);
+  if (bufSize == 0)
+    return L"";
+  wchar_t *converted = new wchar_t[bufSize];
+  if (MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, text.c_str(), -1, converted, bufSize) != bufSize)
+  {
+    delete[] converted;
+    return L"";
+  }
+
+  std::wstring Wret (converted);
+  delete[] converted;
+
+  if (resultSuccessful != NULL)
+    *resultSuccessful = true;
+  return Wret;
+}
+
+std::string CEnvironment::win32ConvertWToUtf8(const std::wstring &text, bool *resultSuccessful /*= NULL*/)  
+{
+  if (text.empty())
+  {
+    if (resultSuccessful != NULL)
+      *resultSuccessful = true;
+    return "";
+  }
+  if (resultSuccessful != NULL)
+    *resultSuccessful = false;
+
+  int bufSize = WideCharToMultiByte(CP_UTF8, MB_ERR_INVALID_CHARS, text.c_str(), -1, NULL, 0, NULL, NULL);
+  if (bufSize == 0)
+    return "";
+  char * converted = new char[bufSize];
+  if (WideCharToMultiByte(CP_UTF8, MB_ERR_INVALID_CHARS, text.c_str(), -1, converted, bufSize, NULL, NULL) != bufSize)
+  {
+    delete[] converted;
+    return "";
+  }
+
+  std::string ret(converted);
+  delete[] converted;
+  
+  if (resultSuccessful != NULL)
+    *resultSuccessful = true;
+  return converted;
+}
+
+// --------------------- Internal Function ---------------------
+
+typedef int (_cdecl * wputenvPtr) (const wchar_t *envstring);
+
+/**
+ * \fn int CEnvironment::win32_setenv(const std::wstring &name, const std::wstring &value = L"",
+ *     updateAction action = autoDetect)
+ * \brief Internal function used to manipulate with environment variables on win32.
+ * 		  
+ * This function make all dirty work with setting, deleting and modifying environment variables.
+ *
+ * \param name   The environment variable name.
+ * \param value  (optional) the new value of environment variable.
+ * \param action (optional) the action.
+ * \return Zero on success, 2 if at least one external runtime update failed, 4 if process
+ * 		   environment update failed, 8 if our runtime environment update failed or, in case of
+ * 		   several errors, sum of all errors values; non-zero in case of other errors.
+ */
+int CEnvironment::win32_setenv(const std::string &name, const std::string &value /* = "" */, enum updateAction action /* = autoDetect */)
+{
+  std::wstring Wname (win32ConvertUtf8ToW(name));
+  if (Wname.empty() || name.find('=') != std::wstring::npos)
+    return -1;
+  if ( (action == addOnly || action == addOrUpdateOnly) && value.empty() )
+    return -1;
+  if (action == addOnly && !(getenv(name).empty()) )
+    return 0;
+
+  bool convIsOK;
+  std::wstring Wvalue (win32ConvertUtf8ToW(value,&convIsOK));
+  if (!convIsOK)
+    return -1;
+
+  int retValue = 0;
+  std::wstring EnvString;
+  if (action == deleteVariable)
+    EnvString = Wname + L"=";
+  else
+    EnvString = Wname + L"=" + Wvalue;
+
+  static const wchar_t *modulesList[] =
+  {
+  /*{ L"msvcrt20.dll" }, // Visual C++ 2.0 / 2.1 / 2.2
+    { L"msvcrt40.dll" }, // Visual C++ 4.0 / 4.1 */ // too old and no UNICODE support - ignoring
+    { L"msvcrt.dll" },   // Visual Studio 6.0 / MinGW[-w64]
+    { L"msvcr70.dll" },  // Visual Studio 2002
+    { L"msvcr71.dll" },  // Visual Studio 2003
+    { L"msvcr80.dll" },  // Visual Studio 2005
+    { L"msvcr90.dll" },  // Visual Studio 2008
+    { L"msvcr100.dll" }, // Visual Studio 2010
+#ifdef _DEBUG
+    { L"msvcr100d.dll" },// Visual Studio 2010 (debug)
+#endif
+    { L"msvcr110.dll" }, // Visual Studio 2012
+    { NULL }             // Terminating NULL for list
+  };
+  
+  // Check all modules each function run, because modules can be loaded/unloaded at runtime
+  for (int i = 0; modulesList[i]; i++)
+  {
+    HMODULE hModule;
+    if (!GetModuleHandleExW(0, modulesList[i], &hModule) || hModule == NULL) // Flag 0 ensures that module will be kept loaded until it'll be freed
+      continue; // Module not loaded
+
+    wputenvPtr wputenvFunc = (wputenvPtr) GetProcAddress(hModule, "_wputenv");
+    if (wputenvFunc != NULL && wputenvFunc(EnvString.c_str()) != 0)
+      retValue |= 2; // At lest one external runtime library Environment update failed
+    FreeLibrary(hModule);
+  }
+
+  // Update process Environment used for current process and for future new child processes
+  if (action == deleteVariable || value.empty())
+    retValue += SetEnvironmentVariableW(Wname.c_str(), NULL) ? 0 : 4; // 4 if failed
+  else
+    retValue += SetEnvironmentVariableW(Wname.c_str(), Wvalue.c_str()) ? 0 : 4; // 4 if failed
+  
+  // Finally update our runtime Environment
+  retValue += (::_wputenv(EnvString.c_str()) == 0) ? 0 : 8; // 8 if failed
+  
+  return retValue;
+}
+#endif
+
+// --------------------- Main Functions ---------------------
+
+int CEnvironment::setenv(const std::string &name, const std::string &value, int overwrite /*= 1*/)
+{
+#ifdef TARGET_WINDOWS
+  return (win32_setenv(name, value, overwrite ? autoDetect : addOnly)==0) ? 0 : -1;
+#else
+  if (value.empty() && overwrite != 0)
+    return ::unsetenv(name.c_str());
+  return ::setenv(name.c_str(), value.c_str(), overwrite);
+#endif
+}
+
+std::string CEnvironment::getenv(const std::string &name)
+{
+#ifdef TARGET_WINDOWS
+  std::wstring Wname (win32ConvertUtf8ToW(name));
+  if (Wname.empty())
+    return "";
+
+  std::wstring Wvalue (::_wgetenv(Wname.c_str()));
+  if (!Wvalue.empty())
+    return win32ConvertWToUtf8(Wvalue);
+
+  // Not found in Environment of runtime library 
+  // Try Environment of process as fallback
+  int varSize = GetEnvironmentVariableW(Wname.c_str(), NULL, 0);
+  if (varSize == 0)
+    return ""; // Not found
+  wchar_t * valBuf = new wchar_t[varSize];
+  if (GetEnvironmentVariableW(Wname.c_str(), valBuf, varSize) != varSize-1)
+  {
+    delete[] valBuf;
+    return "";
+  }
+  Wvalue = valBuf;
+  delete[] valBuf;
+
+  return win32ConvertWToUtf8(Wvalue);
+#else
+  return ::getenv(name.c_str());
+#endif
+}
+
+int CEnvironment::unsetenv(const std::string &name)
+{
+#ifdef TARGET_WINDOWS
+  return (win32_setenv(name, "", deleteVariable)) == 0 ? 0 : -1;
+#else
+  return ::unsetenv(name.c_str());
+#endif
+}
+
+int CEnvironment::putenv(const std::string &envstring)
+{
+  if (envstring.empty())
+    return 0;
+  int pos = envstring.find('=');
+  if (pos == 0) // '=' is the first character
+    return -1;
+  if (pos == std::string::npos)
+    return unsetenv(envstring);
+  if (pos == envstring.length()-1) // '=' is in last position
+  {
+    std::string name(envstring);
+    name.erase(name.length()-1, 1);
+    return unsetenv(name);
+  }
+  std::string name(envstring, 0, pos), value(envstring, pos+1);
+
+  return setenv(name, value);
+}
+

--- a/xbmc/utils/Environment.h
+++ b/xbmc/utils/Environment.h
@@ -1,0 +1,106 @@
+#pragma once
+#ifndef XBMC_SETENV_H
+#define XBMC_SETENV_H
+/*
+ *      Copyright (C) 2013 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+/**
+ * \file utils\Environment.h
+ * \brief Declares CEnvironment class for platform-independent environment variables manipulations.
+ * 		
+ */
+#include <string>
+
+/**
+ * @class   CEnvironment
+ *
+ * @brief   Platform-independent environment variables manipulations.
+ *
+ * 	Provide analog for POSIX functions:
+ * 	+ setenv  
+ * 	+ unsetenv  
+ * 	+ putenv  
+ * 	+ getenv
+ *
+ * 	You can generally use the functions as you would normally in POSIX-style.
+ *  The differences below are just to make things more convenient through use of std::string (2,3),
+ *  and to also allow the Win32-style of unsetting variables (4,5) if wanted.
+ * 	1. CEnvironment::setenv  parameter 'overwrite' is optional, set by default to 1 (allow overwrite).
+ * 	2. CEnvironment::putenv  uses copy of provided string (rather than string itself) to change environment,
+ *                           so you can free parameter variable right after call of function.
+ * 	3. CEnvironment::getenv  returns a copy of environment variable value instead of pointer to value.
+ * 	4. CEnvironment::setenv  can be used to unset variables. Just pass empty string for 'value' parameter.  
+ * 	5. CEnvironment::putenv  can be used to unset variables. Set parameter to 'var=' (Windows style) or   
+ *                           just 'var' (POSIX style), and 'var' will be unset.  
+ * 	
+ * 	All 'std::string' types are supposed to be in UTF-8 encoding.
+ * 	All functions work on all platforms. Special care is taken on Windows platform where Environment is changed for process itself, 
+ * 	for process runtime library and for all runtime libraries (MSVCRT) loaded by third-party modules.
+ * 	Functions internally make all necessary UTF-8 <-> wide conversions.*
+ */
+
+class CEnvironment
+{
+public:
+  /**
+   * \fn static int CEnvironment::setenv(const std::string &name, const std::string &value,
+   *     int overwrite = 1);
+   * \brief Sets or unsets environment variable.
+   * \param name      The environment variable name to add/modify/delete.
+   * \param value     The environment variable new value. If set to empty string, variable will be 
+   * 					deleted from the environment.
+   * \param overwrite (optional) If set to non-zero, existing variable will be overwritten. If set to zero and
+   * 					variable is already present, then variable will be unchanged and function returns success.
+   * \return Zero on success, non-zero on error.
+   */
+  static int setenv(const std::string &name, const std::string &value, int overwrite = 1);
+  /**
+   * \fn static int CEnvironment::unsetenv(const std::string &name);
+   * \brief Deletes environment variable.
+   * \param name The environment variable name to delete.
+   * \return Zero on success, non-zero on error.
+   */
+  static int unsetenv(const std::string &name);
+
+  /**
+   * \fn static int CEnvironment:putenv(const std::string &envstring);
+   * \brief Adds/modifies/deletes environment variable.
+   * \param envstring The variable-value string in form 'var=value'. If set to 'var=' or 'var', then variable 
+   * 					will be deleted from the environment.
+   * \return Zero on success, non-zero on error.
+   */
+  static int putenv(const std::string &envstring);
+  /**
+   * \fn static std::string CEnvironment::getenv(const std::string &name);
+   * \brief Gets value of environment variable in UTF-8 encoding.
+   * \param name The name of environment variable.
+   * \return Copy of of environment variable value or empty string if variable in not present in environment.
+   * \sa xbmc_getenvUtf8, xbmc_getenvW
+   */
+  static std::string getenv(const std::string &name);
+#ifdef TARGET_WINDOWS
+private:
+  static std::wstring win32ConvertUtf8ToW(const std::string &text, bool *resultSuccessful = NULL);
+  static std::string win32ConvertWToUtf8(const std::wstring &text, bool *resultSuccessful = NULL);
+  enum updateAction:int {addOrUpdateOnly = -2, deleteVariable = -1, addOnly =  0, autoDetect = 1};
+  static int win32_setenv(const std::string &name, const std::string &value = "", updateAction action = autoDetect);
+#endif // TARGET_WINDOWS
+};
+#endif

--- a/xbmc/utils/Makefile.in
+++ b/xbmc/utils/Makefile.in
@@ -16,6 +16,7 @@ SRCS += DownloadQueue.cpp
 SRCS += DownloadQueueManager.cpp
 SRCS += EndianSwap.cpp
 SRCS += EdenVideoArtUpdater.cpp
+SRCS += Environment.cpp
 SRCS += Fanart.cpp
 SRCS += fastmemcpy.c
 SRCS += fastmemcpy-arm.S


### PR DESCRIPTION
While debugging of XBMC, I've discovered that win32 environment manipulation isn't working at all.
The problem is that win32 functions SetEnvironmentVariable/GetEnvironmentVariable and runtime functions getenv/putenv operate with separate copies of Environment. So after set (for example) of 'XBMC_HOME' with SetEnvironmentVariable, next call to getenv for 'XBMC_HOME' returns error (variable not set).
Other problem on win32 platform, that XBMC use UTF-8 for CStdString, but when it converted to 'char *' win32 use it as ANSI or OEM encoding. That can cause problems if variable value contains some national characters, as paths variables.
One more problem for win32 - different runtime libraries for third-party modules, which should be updated separately. This is done partially by win32env.c, but that implementation is buggy (new loaded libraries isn't checked, can potentially crash after library unload).
This implementation is uniform for all platforms, so we can drop a lot of "ifdef"s in code.
All UTF-8<->wide conversion is carefully implemented internally where is't needed.
Almost all strings forms used in XBMC is supported as arguments.

This PR is adds new functions support and only a few function uses (as a test), and only for win32 platform.
If it's OK, I'll create more PRs with total replace for setenv/getenv functions.
