### PR TITLE
Plugins drop progress dialog

### DIFF
--- a/addons/skin.confluence/720p/DialogBusy.xml
+++ b/addons/skin.confluence/720p/DialogBusy.xml
@@ -39,6 +39,14 @@
 				<label>$LOCALIZE[31004]</label>
 				<font>font12</font>
 			</control>
+			<control type="progress" id="10">
+				<description>Progressbar</description>
+				<posx>20</posx>
+				<posy>65</posy>
+				<width>160</width>
+				<height>10</height>
+				<!-- <info>System.Progressbar</info> -->
+			</control>
 		</control>
 	</controls>
 </window>

--- a/xbmc/dialogs/GUIDialogBusy.cpp
+++ b/xbmc/dialogs/GUIDialogBusy.cpp
@@ -20,13 +20,17 @@
  */
 
 #include "GUIDialogBusy.h"
+#include "guilib/GUIProgressControl.h"
 #include "guilib/GUIWindowManager.h"
+
+#define PROGRESS_CONTROL 10
 
 CGUIDialogBusy::CGUIDialogBusy(void)
   : CGUIDialog(WINDOW_DIALOG_BUSY, "DialogBusy.xml"), m_bLastVisible(false)
 {
   m_loadOnDemand = false;
   m_bModal = true;
+  m_progress = 0;
 }
 
 CGUIDialogBusy::~CGUIDialogBusy(void)
@@ -40,6 +44,7 @@ void CGUIDialogBusy::Show_Internal()
   m_bModal = true;
   m_bLastVisible = true;
   m_closing = false;
+  m_progress = 0;
   g_windowManager.RouteToWindow(this);
 
   // active this window...
@@ -53,6 +58,16 @@ void CGUIDialogBusy::DoProcess(unsigned int currentTime, CDirtyRegionList &dirty
   if(!visible && m_bLastVisible)
     dirtyregions.push_back(m_renderRegion);
   m_bLastVisible = visible;
+
+  // update the progress control if available
+  const CGUIControl *control = GetControl(PROGRESS_CONTROL);
+  if (control && control->GetControlType() == CGUIControl::GUICONTROL_PROGRESS)
+  {
+    CGUIProgressControl *progress = (CGUIProgressControl *)control;
+    progress->SetPercentage(m_progress);
+    progress->SetVisible(m_progress > 0);
+  }
+
   CGUIDialog::DoProcess(currentTime, dirtyregions);
 }
 
@@ -67,4 +82,9 @@ bool CGUIDialogBusy::OnBack(int actionID)
 {
   m_bCanceled = true;
   return true;
+}
+
+void CGUIDialogBusy::SetProgress(float percent)
+{
+  m_progress = percent;
 }

--- a/xbmc/dialogs/GUIDialogBusy.h
+++ b/xbmc/dialogs/GUIDialogBusy.h
@@ -32,10 +32,15 @@ public:
   virtual bool OnBack(int actionID);
   virtual void DoProcess(unsigned int currentTime, CDirtyRegionList &dirtyregions);
   virtual void Render();
+  /*! \brief set the current progress of the busy operation
+   \param progress a percentage of progress
+   */
+  void SetProgress(float progress);
 
   bool IsCanceled() { return m_bCanceled; }
 protected:
   virtual void Show_Internal(); // modeless'ish
   bool m_bCanceled;
   bool m_bLastVisible;
+  float m_progress; ///< current progress
 };

--- a/xbmc/filesystem/Directory.cpp
+++ b/xbmc/filesystem/Directory.cpp
@@ -165,6 +165,7 @@ bool CDirectory::GetDirectory(const CStdString& strPath, CFileItemList &items, c
               if(dialog->IsCanceled())
               {
                 cancel = true;
+                pDirectory->CancelDirectory();
                 break;
               }
 

--- a/xbmc/filesystem/Directory.cpp
+++ b/xbmc/filesystem/Directory.cpp
@@ -162,6 +162,11 @@ bool CDirectory::GetDirectory(const CStdString& strPath, CFileItemList &items, c
             {
               CSingleLock lock(g_graphicsContext);
 
+              // update progress
+              float progress = pDirectory->GetProgress();
+              if (progress > 0)
+                dialog->SetProgress(progress);
+
               if(dialog->IsCanceled())
               {
                 cancel = true;

--- a/xbmc/filesystem/IDirectory.h
+++ b/xbmc/filesystem/IDirectory.h
@@ -70,6 +70,12 @@ public:
    */
   virtual bool GetDirectory(const CStdString& strPath, CFileItemList &items) = 0;
   /*!
+   \brief Retrieve the progress of the current directory fetch (if possible).
+   \return the progress as a float in the range 0..100.
+   \sa GetDirectory, CancelDirectory
+   */
+  virtual float GetProgress() const { return 0.0f; };
+  /*!
    \brief Cancel the current directory fetch (if possible).
    \sa GetDirectory
    */

--- a/xbmc/filesystem/IDirectory.h
+++ b/xbmc/filesystem/IDirectory.h
@@ -70,6 +70,11 @@ public:
    */
   virtual bool GetDirectory(const CStdString& strPath, CFileItemList &items) = 0;
   /*!
+   \brief Cancel the current directory fetch (if possible).
+   \sa GetDirectory
+   */
+  virtual void CancelDirectory() { };
+  /*!
   \brief Create the directory
   \param strPath Directory to create.
   \return Returns \e true, if directory is created or if it already exists

--- a/xbmc/filesystem/PluginDirectory.cpp
+++ b/xbmc/filesystem/PluginDirectory.cpp
@@ -516,19 +516,6 @@ bool CPluginDirectory::WaitOnScriptResult(const CStdString &scriptPath, const CS
 
     if (progressBar)
     { // update the progress bar and check for user cancel
-      if (retrievingDir)
-      {
-        CStdString label;
-        if (m_totalItems > 0)
-        {
-          label.Format(g_localizeStrings.Get(1042).c_str(), m_listItems->Size(), m_totalItems);
-          progressBar->SetPercentage((int)((m_listItems->Size() * 100 ) / m_totalItems));
-          progressBar->ShowProgressBar(true);
-        }
-        else
-          label.Format(g_localizeStrings.Get(1041).c_str(), m_listItems->Size());
-        progressBar->SetLine(2, label);
-      }
       progressBar->Progress();
       if (progressBar->IsCanceled())
       { // user has cancelled our process - cancel our process

--- a/xbmc/filesystem/PluginDirectory.cpp
+++ b/xbmc/filesystem/PluginDirectory.cpp
@@ -535,21 +535,21 @@ bool CPluginDirectory::WaitOnScriptResult(const CStdString &scriptPath, const CS
         m_cancelled = true;
       }
     }
-        if (!cancelled && m_cancelled)
-        {
-          cancelled = true;
-          startTime = XbmcThreads::SystemClockMillis();
-        }
-        if (cancelled && XbmcThreads::SystemClockMillis() - startTime > timeToKillScript)
-        { // cancel our script
+    if (!cancelled && m_cancelled)
+    {
+      cancelled = true;
+      startTime = XbmcThreads::SystemClockMillis();
+    }
+    if (cancelled && XbmcThreads::SystemClockMillis() - startTime > timeToKillScript)
+    { // cancel our script
 #ifdef HAS_PYTHON
-          int id = g_pythonParser.getScriptId(scriptPath.c_str());
-          if (id != -1 && g_pythonParser.isRunning(id))
-          {
-            CLog::Log(LOGDEBUG, "%s- cancelling plugin %s", __FUNCTION__, scriptName.c_str());
-            g_pythonParser.stopScript(id);
-            break;
-          }
+      int id = g_pythonParser.getScriptId(scriptPath.c_str());
+      if (id != -1 && g_pythonParser.isRunning(id))
+      {
+        CLog::Log(LOGDEBUG, "%s- cancelling plugin %s", __FUNCTION__, scriptName.c_str());
+        g_pythonParser.stopScript(id);
+        break;
+      }
 #endif
     }
   }

--- a/xbmc/filesystem/PluginDirectory.cpp
+++ b/xbmc/filesystem/PluginDirectory.cpp
@@ -634,3 +634,10 @@ void CPluginDirectory::CancelDirectory()
 {
   m_cancelled = true;
 }
+
+float CPluginDirectory::GetProgress() const
+{
+  if (m_totalItems > 0)
+    return (m_listItems->Size() * 100.0f) / m_totalItems;
+  return 0.0f;
+}

--- a/xbmc/filesystem/PluginDirectory.h
+++ b/xbmc/filesystem/PluginDirectory.h
@@ -47,6 +47,7 @@ public:
   virtual bool GetDirectory(const CStdString& strPath, CFileItemList& items);
   virtual bool IsAllowed(const CStdString &strFile) const { return true; };
   virtual bool Exists(const char* strPath) { return true; }
+  virtual float GetProgress() const;
   virtual void CancelDirectory();
   static bool RunScriptWithParams(const CStdString& strPath);
   static bool GetPluginResult(const CStdString& strPath, CFileItem &resultItem);

--- a/xbmc/filesystem/PluginDirectory.h
+++ b/xbmc/filesystem/PluginDirectory.h
@@ -47,6 +47,7 @@ public:
   virtual bool GetDirectory(const CStdString& strPath, CFileItemList& items);
   virtual bool IsAllowed(const CStdString &strFile) const { return true; };
   virtual bool Exists(const char* strPath) { return true; }
+  virtual void CancelDirectory();
   static bool RunScriptWithParams(const CStdString& strPath);
   static bool GetPluginResult(const CStdString& strPath, CFileItem &resultItem);
 


### PR DESCRIPTION
There's currently an issue with layered dialogs where a plugin throws up a keyboard dialog for search and the like.  The dialogs involved are:
1. Busy dialog from CDirectory::GetDirectory.
2. Progress dialog from CPluginDirectory::WaitForScriptResult.
3. Keyboard dialog from plugin.

The problem case is where the progress pops up after the keyboard dialog is on screen, which often happens in plugins which implement a search feature, such as youtube.

This fixes it by eliminating the progress dialog**.  This isn't ideal, as we lose the progress from the plugin (such as number of items to retrieve, and progress retrieving them).  I'm not sure whether or not many plugins use this or not.  IMO extending busy would be a nicer way to handle this either way - plugins that take a lot of time can throw up the progress themselves should they wish to (some already do).  One disadvantage with this is that it's not necessarily obvious that it can be cancelled perhaps?

An alternate fix would be to stop the progress popping up if another modal dialog pops up.  Trouble with this is it's hard to determine this case nicely inside the PluginDirectory class, as the app loop is running at this point, and thus there's potential races during tests for modal dialogs, as well as the busy gets in the way.

Yet another alternate might be that the progress stuff is moved into CDirectory::GetDirectory if the directory class can be cancelled.

Comments/criticisms welcome.

**Note that we don't have the same issues with busy being on screen, as it's automatically hidden when another dialog pops up over the top of it, and also the keyboard dialog can't pop up until it's on screen, which guarantees the keyboard is on top, thus receives input.
