### PR TITLE
Keep GUIControls alive after window deinit

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -2185,6 +2185,7 @@ bool CApplication::LoadUserWindows()
             continue;
           }
           pWindow->SetVisibleCondition(visibleCondition);
+          pWindow->SetLoadType(CGUIWindow::KEEP_IN_MEMORY);
           g_windowManager.AddCustomWindow(pWindow);
         }
       }

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -5271,3 +5271,13 @@ CStdString CGUIInfoManager::GetSkinVariableString(int info,
 
   return "";
 }
+
+bool CGUIInfoManager::ConditionsChangedValues(const std::map<int, bool>& map)
+{
+  for (std::map<int, bool>::const_iterator it = map.begin() ; it != map.end() ; it++)
+  {
+    if (GetBoolValue(it->first) != it->second)
+      return true;
+  }
+  return false;
+}

--- a/xbmc/GUIInfoManager.h
+++ b/xbmc/GUIInfoManager.h
@@ -801,6 +801,9 @@ public:
   int RegisterSkinVariableString(const INFO::CSkinVariableString* info);
   int TranslateSkinVariableString(const CStdString& name, int context);
   CStdString GetSkinVariableString(int info, bool preferImage = false, const CGUIListItem *item=NULL);
+
+  /// \brief iterates through boolean conditions and compares their stored values to current values. Returns true if any condition changed value.
+  bool ConditionsChangedValues(const std::map<int, bool>& map);
 protected:
   friend class INFO::InfoSingle;
   bool GetBool(int condition, int contextWindow = 0, const CGUIListItem *item=NULL);

--- a/xbmc/addons/AddonCallbacksGUI.cpp
+++ b/xbmc/addons/AddonCallbacksGUI.cpp
@@ -1234,7 +1234,7 @@ CGUIAddonWindow::CGUIAddonWindow(int id, CStdString strXML, CAddon* addon)
  , m_actionEvent(true)
  , m_addon(addon)
 {
-  m_loadOnDemand  = false;
+  m_loadType = LOAD_ON_GUI_INIT;
   CBOnInit        = NULL;
   CBOnFocus       = NULL;
   CBOnClick       = NULL;
@@ -1482,7 +1482,6 @@ CGUIAddonWindowDialog::CGUIAddonWindowDialog(int id, CStdString strXML, CAddon* 
 : CGUIAddonWindow(id,strXML,addon)
 {
   m_bRunning = false;
-  m_loadOnDemand = false;
   m_bIsDialog = true;
 }
 

--- a/xbmc/addons/GUIDialogAddonInfo.cpp
+++ b/xbmc/addons/GUIDialogAddonInfo.cpp
@@ -54,6 +54,7 @@ CGUIDialogAddonInfo::CGUIDialogAddonInfo(void)
     : CGUIDialog(WINDOW_DIALOG_ADDON_INFO, "DialogAddonInfo.xml")
 {
   m_item = CFileItemPtr(new CFileItem);
+  m_loadType = KEEP_IN_MEMORY;
 }
 
 CGUIDialogAddonInfo::~CGUIDialogAddonInfo(void)

--- a/xbmc/addons/Skin.cpp
+++ b/xbmc/addons/Skin.cpp
@@ -180,9 +180,12 @@ void CSkinInfo::LoadIncludes()
   m_includes.LoadIncludes(includesPath);
 }
 
-void CSkinInfo::ResolveIncludes(TiXmlElement *node)
+void CSkinInfo::ResolveIncludes(TiXmlElement *node, std::map<int, bool>* xmlIncludeConditions /* = NULL */)
 {
-  m_includes.ResolveIncludes(node);
+  if(xmlIncludeConditions)
+    xmlIncludeConditions->clear();
+
+  m_includes.ResolveIncludes(node, xmlIncludeConditions);
 }
 
 int CSkinInfo::GetStartWindow() const

--- a/xbmc/addons/Skin.h
+++ b/xbmc/addons/Skin.h
@@ -92,7 +92,7 @@ public:
    */
   static bool TranslateResolution(const CStdString &name, RESOLUTION_INFO &res);
 
-  void ResolveIncludes(TiXmlElement *node);
+  void ResolveIncludes(TiXmlElement *node, std::map<int, bool>* xmlIncludeConditions = NULL);
 
   float GetEffectsSlowdown() const { return m_effectsSlowDown; };
 

--- a/xbmc/dialogs/GUIDialogBoxBase.cpp
+++ b/xbmc/dialogs/GUIDialogBoxBase.cpp
@@ -26,10 +26,15 @@
 
 using namespace std;
 
+#define CONTROL_HEADING 1
+#define CONTROL_LINES_START 2
+#define CONTROL_CHOICES_START 10
+
 CGUIDialogBoxBase::CGUIDialogBoxBase(int id, const CStdString &xmlFile)
     : CGUIDialog(id, xmlFile)
 {
   m_bConfirmed = false;
+  m_loadType = KEEP_IN_MEMORY;
 }
 
 CGUIDialogBoxBase::~CGUIDialogBoxBase(void)
@@ -58,45 +63,56 @@ bool CGUIDialogBoxBase::IsConfirmed() const
 
 void CGUIDialogBoxBase::SetHeading(const CVariant& heading)
 {
-  Initialize();
-  CGUIMessage msg(GUI_MSG_LABEL_SET, GetID(), 1);
-  msg.SetLabel(GetLocalized(heading));
-
-  if(g_application.IsCurrentThread())
-    OnMessage(msg);
-  else
-    g_windowManager.SendThreadMessage(msg, GetID());
+  m_strHeading = GetLocalized(heading);
+  if (IsActive())
+    SET_CONTROL_LABEL_THREAD_SAFE(1, m_strHeading);
 }
 
 void CGUIDialogBoxBase::SetLine(int iLine, const CVariant& line)
 {
-  Initialize();
-  CGUIMessage msg(GUI_MSG_LABEL_SET, GetID(), iLine + 2);
-  msg.SetLabel(GetLocalized(line));
+  if (iLine < 0 || iLine >= DIALOG_MAX_LINES)
+    return;
 
-  if(g_application.IsCurrentThread())
-    OnMessage(msg);
-  else
-    g_windowManager.SendThreadMessage(msg, GetID());
+  m_strLines[iLine] = GetLocalized(line);
+  if (IsActive())
+    SET_CONTROL_LABEL_THREAD_SAFE(CONTROL_LINES_START + iLine, m_strLines[iLine]);
 }
 
 void CGUIDialogBoxBase::SetChoice(int iButton, const CVariant &choice) // iButton == 0 for no, 1 for yes
 {
-  Initialize();
-  CGUIMessage msg(GUI_MSG_LABEL_SET, GetID(), 10+iButton);
-  msg.SetLabel(GetLocalized(choice));
+  if (iButton < 0 || iButton >= DIALOG_MAX_CHOICES)
+    return;
 
-  if(g_application.IsCurrentThread())
-    OnMessage(msg);
-  else
-    g_windowManager.SendThreadMessage(msg, GetID());
+  m_strChoices[iButton] = GetLocalized(choice);
+  if (IsActive())
+    SET_CONTROL_LABEL_THREAD_SAFE(CONTROL_CHOICES_START + iButton, m_strChoices[iButton]);
 }
 
 void CGUIDialogBoxBase::OnInitWindow()
 {
   // set focus to default
   m_lastControlID = m_defaultControl;
+
+  // set control labels
+  SET_CONTROL_LABEL(CONTROL_HEADING, m_strHeading);
+  for (int i = 0 ; i < DIALOG_MAX_LINES ; ++i)
+    SET_CONTROL_LABEL(CONTROL_LINES_START + i, m_strLines[i]);
+  for (int i = 0 ; i < DIALOG_MAX_CHOICES ; ++i)
+    SET_CONTROL_LABEL(CONTROL_CHOICES_START + i, m_strChoices[i]);
+
   CGUIDialog::OnInitWindow();
+}
+
+void CGUIDialogBoxBase::OnDeinitWindow(int nextWindowID)
+{
+  // make sure we set default labels for heading, lines and choices
+  SetHeading(GetDefaultLabel(CONTROL_HEADING));
+  for (int i = 0 ; i < DIALOG_MAX_LINES ; ++i)
+    SetLine(i, GetDefaultLabel(CONTROL_LINES_START + i));
+  for (int i = 0 ; i < DIALOG_MAX_CHOICES ; ++i)
+    SetChoice(i, GetDefaultLabel(CONTROL_CHOICES_START + i));
+
+  CGUIDialog::OnDeinitWindow(nextWindowID);
 }
 
 CStdString CGUIDialogBoxBase::GetLocalized(const CVariant &var) const
@@ -106,4 +122,15 @@ CStdString CGUIDialogBoxBase::GetLocalized(const CVariant &var) const
   else if (var.isInteger() && var.asInteger())
     return g_localizeStrings.Get((uint32_t)var.asInteger());
   return "";
+}
+
+CStdString CGUIDialogBoxBase::GetDefaultLabel(int controlId) const
+{
+  int labelId = GetDefaultLabelID(controlId);
+  return labelId != -1 ? g_localizeStrings.Get(labelId) : "";
+}
+
+int CGUIDialogBoxBase::GetDefaultLabelID(int controlId) const
+{
+  return -1;
 }

--- a/xbmc/dialogs/GUIDialogBoxBase.h
+++ b/xbmc/dialogs/GUIDialogBoxBase.h
@@ -24,6 +24,9 @@
 #include "guilib/GUIDialog.h"
 #include "utils/Variant.h"
 
+#define DIALOG_MAX_LINES 3
+#define DIALOG_MAX_CHOICES 2
+
 class CGUIDialogBoxBase :
       public CGUIDialog
 {
@@ -36,6 +39,8 @@ public:
   void SetHeading(const CVariant &heading);
   void SetChoice(int iButton, const CVariant &choice);
 protected:
+  CStdString GetDefaultLabel(int controlId) const;
+  virtual int GetDefaultLabelID(int controlId) const;
   /*! \brief Get a localized string from a variant
    If the varaint is already a string we return directly, else if it's an integer we return the corresponding
    localized string.
@@ -44,5 +49,12 @@ protected:
   CStdString GetLocalized(const CVariant &var) const;
 
   virtual void OnInitWindow();
+  virtual void OnDeinitWindow(int nextWindowID);
+
   bool m_bConfirmed;
+
+  // actual strings
+  std::string m_strHeading;
+  std::string m_strLines[DIALOG_MAX_LINES];
+  std::string m_strChoices[DIALOG_MAX_CHOICES];
 };

--- a/xbmc/dialogs/GUIDialogBusy.cpp
+++ b/xbmc/dialogs/GUIDialogBusy.cpp
@@ -25,7 +25,7 @@
 CGUIDialogBusy::CGUIDialogBusy(void)
   : CGUIDialog(WINDOW_DIALOG_BUSY, "DialogBusy.xml"), m_bLastVisible(false)
 {
-  m_loadOnDemand = false;
+  m_loadType = LOAD_ON_GUI_INIT;
   m_bModal = true;
 }
 

--- a/xbmc/dialogs/GUIDialogButtonMenu.cpp
+++ b/xbmc/dialogs/GUIDialogButtonMenu.cpp
@@ -29,6 +29,7 @@
 CGUIDialogButtonMenu::CGUIDialogButtonMenu(int id, const CStdString &xmlFile)
 : CGUIDialog(id, xmlFile)
 {
+  m_loadType = KEEP_IN_MEMORY;
 }
 
 CGUIDialogButtonMenu::~CGUIDialogButtonMenu(void)

--- a/xbmc/dialogs/GUIDialogContextMenu.cpp
+++ b/xbmc/dialogs/GUIDialogContextMenu.cpp
@@ -71,9 +71,12 @@ void CContextButtons::Add(unsigned int button, int label)
   push_back(pair<unsigned int, CStdString>(button, g_localizeStrings.Get(label)));
 }
 
-CGUIDialogContextMenu::CGUIDialogContextMenu(void):CGUIDialog(WINDOW_DIALOG_CONTEXT_MENU, "DialogContextMenu.xml")
+CGUIDialogContextMenu::CGUIDialogContextMenu(void)
+  : CGUIDialog(WINDOW_DIALOG_CONTEXT_MENU, "DialogContextMenu.xml")
 {
   m_clickedButton = -1;
+  m_backgroundImageSize = 0;
+  m_loadType = KEEP_IN_MEMORY;
 }
 
 CGUIDialogContextMenu::~CGUIDialogContextMenu(void)
@@ -184,12 +187,12 @@ void CGUIDialogContextMenu::SetupButtons()
       if (pGroupList->GetOrientation() == VERTICAL)
       {
         // keep gap between bottom edges of grouplist and background image
-        pControl->SetHeight(pControl->GetHeight() - pGroupList->Size() + pGroupList->GetHeight());
+        pControl->SetHeight(m_backgroundImageSize - pGroupList->Size() + pGroupList->GetHeight());
       }
       else
       {
         // keep gap between right edges of grouplist and background image
-        pControl->SetWidth(pControl->GetWidth() - pGroupList->Size() + pGroupList->GetWidth());
+        pControl->SetWidth(m_backgroundImageSize - pGroupList->Size() + pGroupList->GetWidth());
       }
     }
 #if PRE_SKIN_VERSION_11_COMPATIBILITY
@@ -671,15 +674,39 @@ CMediaSource *CGUIDialogContextMenu::GetShare(const CStdString &type, const CFil
 
 void CGUIDialogContextMenu::OnWindowLoaded()
 {
+  m_coordX = m_posX;
+  m_coordY = m_posY;
+  
+  const CGUIControlGroupList* pGroupList = NULL;
+  const CGUIControl* pControl = GetControl(GROUP_LIST);
+  if (pControl && pControl->GetControlType() == GUICONTROL_GROUPLIST)
+    pGroupList = (CGUIControlGroupList*)pControl;
+
+  pControl = (CGUIControl *)GetControl(BACKGROUND_IMAGE);
+  if (pControl && pGroupList)
+  {
+    if (pGroupList->GetOrientation() == VERTICAL)
+      m_backgroundImageSize = pControl->GetHeight();
+    else
+      m_backgroundImageSize = pControl->GetWidth();
+  }
+
   CGUIDialog::OnWindowLoaded();
-  SetInitialVisibility();
-  SetupButtons();
 }
 
-void CGUIDialogContextMenu::OnWindowUnload()
+void CGUIDialogContextMenu::OnDeinitWindow(int nextWindowID)
 {
+  //we can't be sure that controls are removed on window unload
+  //we have to remove them to be sure that they won't stay for next use of context menu
+  for (unsigned int i = 0; i < m_buttons.size(); i++)
+  {
+    const CGUIControl *control = GetControl(BUTTON_START + i);
+    if (control)
+      RemoveControl(control);
+  }
+
   m_buttons.clear();
-  CGUIDialog::OnWindowUnload();
+  CGUIDialog::OnDeinitWindow(nextWindowID);
 }
 
 CStdString CGUIDialogContextMenu::GetDefaultShareNameByType(const CStdString &strType)
@@ -746,6 +773,7 @@ int CGUIDialogContextMenu::ShowAndGetChoice(const CContextButtons &choices)
   {
     pMenu->m_buttons = choices;
     pMenu->Initialize();
+    pMenu->SetupButtons();
     pMenu->PositionAtCurrentFocus();
     pMenu->DoModal();
     return pMenu->m_clickedButton;
@@ -763,7 +791,7 @@ void CGUIDialogContextMenu::PositionAtCurrentFocus()
     {
       CPoint pos = focusedControl->GetRenderPosition() + CPoint(focusedControl->GetWidth() * 0.5f, focusedControl->GetHeight() * 0.5f)
                    + window->GetRenderPosition();
-      SetPosition(m_posX + pos.x - GetWidth() * 0.5f, m_posY + pos.y - GetHeight() * 0.5f);
+      SetPosition(m_coordX + pos.x - GetWidth() * 0.5f, m_coordY + pos.y - GetHeight() * 0.5f);
       return;
     }
   }

--- a/xbmc/dialogs/GUIDialogContextMenu.h
+++ b/xbmc/dialogs/GUIDialogContextMenu.h
@@ -179,13 +179,16 @@ protected:
   virtual float GetHeight() const;
   virtual void OnInitWindow();
   virtual void OnWindowLoaded();
-  virtual void OnWindowUnload();
+  virtual void OnDeinitWindow(int nextWindowID);
   static CStdString GetDefaultShareNameByType(const CStdString &strType);
   static void SetDefault(const CStdString &strType, const CStdString &strDefault);
   static void ClearDefault(const CStdString &strType);
   static CMediaSource *GetShare(const CStdString &type, const CFileItem *item);
 
 private:
+  float m_coordX, m_coordY;
+  /// \brief Stored size of background image (height or width depending on grouplist orientation)
+  float m_backgroundImageSize;
   int m_clickedButton;
   CContextButtons m_buttons;
 };

--- a/xbmc/dialogs/GUIDialogExtendedProgressBar.cpp
+++ b/xbmc/dialogs/GUIDialogExtendedProgressBar.cpp
@@ -58,7 +58,7 @@ void CGUIDialogProgressBarHandle::SetProgress(int currentItem, int itemCount)
 CGUIDialogExtendedProgressBar::CGUIDialogExtendedProgressBar(void)
   : CGUIDialog(WINDOW_DIALOG_EXT_PROGRESS, "DialogExtendedProgressBar.xml")
 {
-  m_loadOnDemand    = false;
+  m_loadType        = LOAD_ON_GUI_INIT;
   m_iLastSwitchTime = 0;
   m_iCurrentItem    = 0;
 }

--- a/xbmc/dialogs/GUIDialogFavourites.cpp
+++ b/xbmc/dialogs/GUIDialogFavourites.cpp
@@ -39,6 +39,7 @@ CGUIDialogFavourites::CGUIDialogFavourites(void)
     : CGUIDialog(WINDOW_DIALOG_FAVOURITES, "DialogFavourites.xml")
 {
   m_favourites = new CFileItemList;
+  m_loadType = KEEP_IN_MEMORY;
 }
 
 CGUIDialogFavourites::~CGUIDialogFavourites(void)

--- a/xbmc/dialogs/GUIDialogFileBrowser.cpp
+++ b/xbmc/dialogs/GUIDialogFileBrowser.cpp
@@ -72,6 +72,7 @@ CGUIDialogFileBrowser::CGUIDialogFileBrowser()
   m_thumbLoader.SetObserver(this);
   m_flipEnabled = false;
   m_multipleSelection = false;
+  m_loadType = KEEP_IN_MEMORY;
 }
 
 CGUIDialogFileBrowser::~CGUIDialogFileBrowser()

--- a/xbmc/dialogs/GUIDialogKaiToast.cpp
+++ b/xbmc/dialogs/GUIDialogKaiToast.cpp
@@ -37,7 +37,7 @@ CGUIDialogKaiToast::CGUIDialogKaiToast(void)
 : CGUIDialog(WINDOW_DIALOG_KAI_TOAST, "DialogKaiToast.xml")
 {
   m_defaultIcon = "";
-  m_loadOnDemand = false;
+  m_loadType = LOAD_ON_GUI_INIT;
   m_timer = 0;
   m_toastDisplayTime = 0;
   m_toastMessageTime = 0;

--- a/xbmc/dialogs/GUIDialogKeyboardGeneric.cpp
+++ b/xbmc/dialogs/GUIDialogKeyboardGeneric.cpp
@@ -68,6 +68,7 @@ CGUIDialogKeyboardGeneric::CGUIDialogKeyboardGeneric()
   m_keyType = LOWER;
   m_strHeading = "";
   m_lastRemoteClickTime = 0;
+  m_loadType = KEEP_IN_MEMORY;
 }
 
 void CGUIDialogKeyboardGeneric::OnInitWindow()

--- a/xbmc/dialogs/GUIDialogMediaSource.cpp
+++ b/xbmc/dialogs/GUIDialogMediaSource.cpp
@@ -60,6 +60,7 @@ CGUIDialogMediaSource::CGUIDialogMediaSource(void)
     : CGUIDialog(WINDOW_DIALOG_MEDIA_SOURCE, "DialogMediaSource.xml")
 {
   m_paths =  new CFileItemList;
+  m_loadType = KEEP_IN_MEMORY;
 }
 
 CGUIDialogMediaSource::~CGUIDialogMediaSource()
@@ -547,4 +548,13 @@ vector<CStdString> CGUIDialogMediaSource::GetPaths()
     }
   }
   return paths;
+}
+
+void CGUIDialogMediaSource::OnDeinitWindow(int nextWindowID)
+{
+  CGUIDialog::OnDeinitWindow(nextWindowID);
+
+  // clear paths container
+  CGUIMessage msg(GUI_MSG_LABEL_RESET, GetID(), CONTROL_PATH, 0);
+  OnMessage(msg);
 }

--- a/xbmc/dialogs/GUIDialogMediaSource.h
+++ b/xbmc/dialogs/GUIDialogMediaSource.h
@@ -33,6 +33,7 @@ public:
   CGUIDialogMediaSource(void);
   virtual ~CGUIDialogMediaSource(void);
   virtual bool OnMessage(CGUIMessage& message);
+  virtual void OnDeinitWindow(int nextWindowID);
   virtual bool OnBack(int actionID);
   virtual void OnWindowLoaded();
   static bool ShowAndAddMediaSource(const CStdString &type);

--- a/xbmc/dialogs/GUIDialogMuteBug.cpp
+++ b/xbmc/dialogs/GUIDialogMuteBug.cpp
@@ -28,7 +28,7 @@
 CGUIDialogMuteBug::CGUIDialogMuteBug(void)
     : CGUIDialog(WINDOW_DIALOG_MUTE_BUG, "DialogMuteBug.xml")
 {
-  m_loadOnDemand = false;
+  m_loadType = LOAD_ON_GUI_INIT;
 }
 
 CGUIDialogMuteBug::~CGUIDialogMuteBug(void)

--- a/xbmc/dialogs/GUIDialogNumeric.cpp
+++ b/xbmc/dialogs/GUIDialogNumeric.cpp
@@ -49,6 +49,7 @@ CGUIDialogNumeric::CGUIDialogNumeric(void)
   m_block = 0;
   memset(&m_datetime, 0, sizeof(SYSTEMTIME));
   m_dirty = false;
+  m_loadType = KEEP_IN_MEMORY;
 }
 
 CGUIDialogNumeric::~CGUIDialogNumeric(void)

--- a/xbmc/dialogs/GUIDialogOK.cpp
+++ b/xbmc/dialogs/GUIDialogOK.cpp
@@ -59,3 +59,10 @@ void CGUIDialogOK::ShowAndGetInput(const CVariant &heading, const CVariant &line
   dialog->SetLine(2, line2);
   dialog->DoModal();
 }
+
+int CGUIDialogOK::GetDefaultLabelID(int controlId) const
+{
+  if (controlId == ID_BUTTON_OK)
+    return 186;
+  return CGUIDialogBoxBase::GetDefaultLabelID(controlId);
+}

--- a/xbmc/dialogs/GUIDialogOK.h
+++ b/xbmc/dialogs/GUIDialogOK.h
@@ -31,4 +31,6 @@ public:
   virtual ~CGUIDialogOK(void);
   virtual bool OnMessage(CGUIMessage& message);
   static void ShowAndGetInput(const CVariant &heading, const CVariant &line0, const CVariant &line1, const CVariant &line2);
+protected:
+  virtual int GetDefaultLabelID(int controlId) const;
 };

--- a/xbmc/dialogs/GUIDialogPlayerControls.cpp
+++ b/xbmc/dialogs/GUIDialogPlayerControls.cpp
@@ -25,6 +25,7 @@
 CGUIDialogPlayerControls::CGUIDialogPlayerControls(void)
     : CGUIDialog(WINDOW_DIALOG_PLAYER_CONTROLS, "PlayerControls.xml")
 {
+  m_loadType = KEEP_IN_MEMORY;
 }
 
 CGUIDialogPlayerControls::~CGUIDialogPlayerControls(void)

--- a/xbmc/dialogs/GUIDialogProgress.cpp
+++ b/xbmc/dialogs/GUIDialogProgress.cpp
@@ -199,15 +199,9 @@ void CGUIDialogProgress::ShowProgressBar(bool bOnOff)
     g_windowManager.SendThreadMessage(msg, GetID());
 }
 
-void CGUIDialogProgress::SetHeading(const string& strLine)
+int CGUIDialogProgress::GetDefaultLabelID(int controlId) const
 {
-  m_strHeading = strLine;
-  CGUIDialogBoxBase::SetHeading(m_strHeading);
+  if (controlId == CONTROL_CANCEL_BUTTON)
+    return 222;
+  return CGUIDialogBoxBase::GetDefaultLabelID(controlId);
 }
-
-void CGUIDialogProgress::SetHeading(int iString)
-{
-  m_strHeading = g_localizeStrings.Get(iString);
-  CGUIDialogBoxBase::SetHeading(m_strHeading);
-}
-

--- a/xbmc/dialogs/GUIDialogProgress.h
+++ b/xbmc/dialogs/GUIDialogProgress.h
@@ -41,8 +41,6 @@ public:
   void SetPercentage(int iPercentage);
   int GetPercentage() const { return m_percentage; };
   void ShowProgressBar(bool bOnOff);
-  void SetHeading(const std::string& strLine);
-  void SetHeading(int iString);             // for convenience to lookup in strings.xml
 
   // Implements IProgressCallback
   virtual void SetProgressMax(int iMax);
@@ -52,9 +50,10 @@ public:
   void SetCanCancel(bool bCanCancel);
 
 protected:
+  virtual int GetDefaultLabelID(int controlId) const;
+
   bool m_bCanCancel;
   bool m_bCanceled;
-  std::string m_strHeading;
 
   int  m_iCurrent;
   int  m_iMax;

--- a/xbmc/dialogs/GUIDialogSeekBar.cpp
+++ b/xbmc/dialogs/GUIDialogSeekBar.cpp
@@ -37,7 +37,7 @@
 CGUIDialogSeekBar::CGUIDialogSeekBar(void)
     : CGUIDialog(WINDOW_DIALOG_SEEK_BAR, "DialogSeekBar.xml")
 {
-  m_loadOnDemand = false;    // the application class handles our resources
+  m_loadType = LOAD_ON_GUI_INIT;    // the application class handles our resources
 }
 
 CGUIDialogSeekBar::~CGUIDialogSeekBar(void)

--- a/xbmc/dialogs/GUIDialogSelect.cpp
+++ b/xbmc/dialogs/GUIDialogSelect.cpp
@@ -40,6 +40,7 @@ CGUIDialogSelect::CGUIDialogSelect(void)
   m_multiSelection = false;
   m_vecList = m_vecListInternal;
   m_iSelected = -1;
+  m_loadType = KEEP_IN_MEMORY;
 }
 
 CGUIDialogSelect::~CGUIDialogSelect(void)
@@ -55,7 +56,7 @@ bool CGUIDialogSelect::OnMessage(CGUIMessage& message)
   case GUI_MSG_WINDOW_DEINIT:
     {
       CGUIDialog::OnMessage(message);
-      m_viewControl.Reset();
+      m_viewControl.Clear();
 
       m_bButtonEnabled = false;
       m_useDetails = false;
@@ -336,4 +337,10 @@ void CGUIDialogSelect::OnInitWindow()
 
   if (m_iSelected >= 0)
     m_viewControl.SetSelectedItem(m_iSelected);
+}
+
+void CGUIDialogSelect::OnWindowUnload()
+{
+  CGUIDialog::OnWindowUnload();
+  m_viewControl.Reset();
 }

--- a/xbmc/dialogs/GUIDialogSelect.h
+++ b/xbmc/dialogs/GUIDialogSelect.h
@@ -59,6 +59,7 @@ protected:
   virtual CGUIControl *GetFirstFocusableControl(int id);
   virtual void OnWindowLoaded();
   virtual void OnInitWindow();
+  virtual void OnWindowUnload();
 
   bool m_bButtonEnabled;
   bool m_bButtonPressed;

--- a/xbmc/dialogs/GUIDialogSlider.cpp
+++ b/xbmc/dialogs/GUIDialogSlider.cpp
@@ -33,6 +33,7 @@ CGUIDialogSlider::CGUIDialogSlider(void)
 {
   m_callback = NULL;
   m_callbackData = NULL;
+  m_loadType = KEEP_IN_MEMORY;
 }
 
 CGUIDialogSlider::~CGUIDialogSlider(void)
@@ -63,6 +64,10 @@ bool CGUIDialogSlider::OnMessage(CGUIMessage& message)
         SET_CONTROL_LABEL(CONTROL_LABEL, slider->GetDescription());
       }
     }
+    break;
+  case GUI_MSG_WINDOW_DEINIT:
+    m_callback = NULL;
+    m_callbackData = NULL;
     break;
   }
   return CGUIDialog::OnMessage(message);

--- a/xbmc/dialogs/GUIDialogSmartPlaylistEditor.cpp
+++ b/xbmc/dialogs/GUIDialogSmartPlaylistEditor.cpp
@@ -72,6 +72,7 @@ CGUIDialogSmartPlaylistEditor::CGUIDialogSmartPlaylistEditor(void)
 {
   m_cancelled = false;
   m_ruleLabels = new CFileItemList;
+  m_loadType = KEEP_IN_MEMORY;
 }
 
 CGUIDialogSmartPlaylistEditor::~CGUIDialogSmartPlaylistEditor()
@@ -120,21 +121,6 @@ bool CGUIDialogSmartPlaylistEditor::OnMessage(CGUIMessage& message)
       else
         return CGUIDialog::OnMessage(message);
       return true;
-    }
-    break;
-  case GUI_MSG_WINDOW_INIT:
-    {
-      m_cancelled = false;
-      UpdateButtons();
-    }
-    break;
-  case GUI_MSG_WINDOW_DEINIT:
-    {
-      CGUIDialog::OnMessage(message);
-      // clear the rule list
-      CGUIMessage msg(GUI_MSG_LABEL_RESET, GetID(), CONTROL_RULE_LIST);
-      OnMessage(msg);
-      m_ruleLabels->Clear();
     }
     break;
   case GUI_MSG_FOCUSED:
@@ -340,6 +326,13 @@ void CGUIDialogSmartPlaylistEditor::OnWindowLoaded()
     msg.SetLabel(label);
     OnMessage(msg);
   }
+}
+
+void CGUIDialogSmartPlaylistEditor::OnInitWindow()
+{
+  m_cancelled = false;
+  UpdateButtons();
+
   SendMessage(GUI_MSG_ITEM_SELECT, CONTROL_LIMIT, m_playlist.m_limit);
 
   vector<PLAYLIST_TYPE> allowedTypes;
@@ -386,6 +379,16 @@ void CGUIDialogSmartPlaylistEditor::OnWindowLoaded()
 
   SendMessage(GUI_MSG_ITEM_SELECT, CONTROL_TYPE, type);
   m_playlist.SetType(ConvertType(type));
+
+  CGUIDialog::OnInitWindow();
+}
+
+void CGUIDialogSmartPlaylistEditor::OnDeinitWindow(int nextWindowID)
+{
+  CGUIDialog::OnDeinitWindow(nextWindowID);
+  CGUIMessage msg(GUI_MSG_LABEL_RESET, GetID(), CONTROL_RULE_LIST);
+  OnMessage(msg);
+  m_ruleLabels->Clear();
 }
 
 CGUIDialogSmartPlaylistEditor::PLAYLIST_TYPE CGUIDialogSmartPlaylistEditor::ConvertType(const CStdString &type)

--- a/xbmc/dialogs/GUIDialogSmartPlaylistEditor.h
+++ b/xbmc/dialogs/GUIDialogSmartPlaylistEditor.h
@@ -37,6 +37,8 @@ public:
   virtual bool OnMessage(CGUIMessage& message);
   virtual bool OnBack(int actionID);
   virtual void OnWindowLoaded();
+  virtual void OnInitWindow();
+  virtual void OnDeinitWindow(int nextWindowID);
 
   static bool EditPlaylist(const CStdString &path, const CStdString &type = "");
   static bool NewPlaylist(const CStdString &type);

--- a/xbmc/dialogs/GUIDialogSmartPlaylistRule.cpp
+++ b/xbmc/dialogs/GUIDialogSmartPlaylistRule.cpp
@@ -45,6 +45,7 @@ CGUIDialogSmartPlaylistRule::CGUIDialogSmartPlaylistRule(void)
     : CGUIDialog(WINDOW_DIALOG_SMART_PLAYLIST_RULE, "SmartPlaylistRule.xml")
 {
   m_cancelled = false;
+  m_loadType = KEEP_IN_MEMORY;
 }
 
 CGUIDialogSmartPlaylistRule::~CGUIDialogSmartPlaylistRule()
@@ -412,10 +413,17 @@ void CGUIDialogSmartPlaylistRule::AddOperatorLabel(CSmartPlaylistRule::SEARCH_OP
   OnMessage(select);
 }
 
+void CGUIDialogSmartPlaylistRule::OnWindowLoaded()
+{
+  CGUIWindow::OnWindowLoaded();
+  ChangeButtonToEdit(CONTROL_VALUE, true); // true for single label
+}
+
 void CGUIDialogSmartPlaylistRule::OnInitWindow()
 {
-  ChangeButtonToEdit(CONTROL_VALUE, true); // true for single label
   CGUIDialog::OnInitWindow();
+
+  SendMessage(GUI_MSG_LABEL_RESET, CONTROL_FIELD);
   // add the fields to the field spincontrol
   vector<Field> fields = CSmartPlaylistRule::GetFields(m_type);
   for (unsigned int i = 0; i < fields.size(); i++)
@@ -425,6 +433,16 @@ void CGUIDialogSmartPlaylistRule::OnInitWindow()
     OnMessage(msg);
   }
   UpdateButtons();
+}
+
+void CGUIDialogSmartPlaylistRule::OnDeinitWindow(int nextWindowID)
+{
+  CGUIDialog::OnDeinitWindow(nextWindowID);
+
+  // reset field spincontrolex
+  SendMessage(GUI_MSG_LABEL_RESET, CONTROL_FIELD);
+  // reset operator spincontrolex
+  SendMessage(GUI_MSG_LABEL_RESET, CONTROL_OPERATOR);
 }
 
 bool CGUIDialogSmartPlaylistRule::EditRule(CSmartPlaylistRule &rule, const CStdString& type)

--- a/xbmc/dialogs/GUIDialogSmartPlaylistRule.h
+++ b/xbmc/dialogs/GUIDialogSmartPlaylistRule.h
@@ -33,6 +33,8 @@ public:
   virtual bool OnMessage(CGUIMessage& message);
   virtual bool OnBack(int actionID);
   virtual void OnInitWindow();
+  virtual void OnWindowLoaded();
+  virtual void OnDeinitWindow(int nextWindowID);
 
   static bool EditRule(CSmartPlaylistRule &rule, const CStdString& type="songs");
 

--- a/xbmc/dialogs/GUIDialogTextViewer.cpp
+++ b/xbmc/dialogs/GUIDialogTextViewer.cpp
@@ -27,7 +27,9 @@
 
 CGUIDialogTextViewer::CGUIDialogTextViewer(void)
     : CGUIDialog(WINDOW_DIALOG_TEXT_VIEWER, "DialogTextViewer.xml")
-{}
+{
+  m_loadType = KEEP_IN_MEMORY;
+}
 
 CGUIDialogTextViewer::~CGUIDialogTextViewer(void)
 {}
@@ -79,3 +81,14 @@ void CGUIDialogTextViewer::SetHeading()
   OnMessage(msg);
 }
 
+void CGUIDialogTextViewer::OnDeinitWindow(int nextWindowID)
+{
+  CGUIDialog::OnDeinitWindow(nextWindowID);
+
+  // reset text area
+  CGUIMessage msgReset(GUI_MSG_LABEL_RESET, GetID(), CONTROL_TEXTAREA);
+  OnMessage(msgReset);
+
+  // reset heading
+  SET_CONTROL_LABEL(CONTROL_HEADING, "");
+}

--- a/xbmc/dialogs/GUIDialogTextViewer.h
+++ b/xbmc/dialogs/GUIDialogTextViewer.h
@@ -34,6 +34,8 @@ public:
   void SetText(const CStdString& strText) { m_strText = strText; }
   void SetHeading(const CStdString& strHeading) { m_strHeading = strHeading; }
 protected:
+  virtual void OnDeinitWindow(int nextWindowID);
+
   CStdString m_strText;
   CStdString m_strHeading;
 

--- a/xbmc/dialogs/GUIDialogVolumeBar.cpp
+++ b/xbmc/dialogs/GUIDialogVolumeBar.cpp
@@ -27,7 +27,7 @@
 CGUIDialogVolumeBar::CGUIDialogVolumeBar(void)
     : CGUIDialog(WINDOW_DIALOG_VOLUME_BAR, "DialogVolumeBar.xml")
 {
-  m_loadOnDemand = false;
+  m_loadType = LOAD_ON_GUI_INIT;
   SetAutoClose(VOLUME_BAR_DISPLAY_TIME);
 }
 

--- a/xbmc/dialogs/GUIDialogYesNo.cpp
+++ b/xbmc/dialogs/GUIDialogYesNo.cpp
@@ -22,6 +22,9 @@
 #include "GUIDialogYesNo.h"
 #include "guilib/GUIWindowManager.h"
 
+#define CONTROL_NO_BUTTON 10
+#define CONTROL_YES_BUTTON 11
+
 CGUIDialogYesNo::CGUIDialogYesNo(int overrideId /* = -1 */)
     : CGUIDialogBoxBase(overrideId == -1 ? WINDOW_DIALOG_YES_NO : overrideId, "DialogYesNo.xml")
 {
@@ -42,13 +45,13 @@ bool CGUIDialogYesNo::OnMessage(CGUIMessage& message)
       int iAction = message.GetParam1();
       if (1 || ACTION_SELECT_ITEM == iAction)
       {
-        if (iControl == 10)
+        if (iControl == CONTROL_NO_BUTTON)
         {
           m_bConfirmed = false;
           Close();
           return true;
         }
-        if (iControl == 11)
+        if (iControl == CONTROL_YES_BUTTON)
         {
           m_bConfirmed = true;
           Close();
@@ -93,8 +96,12 @@ bool CGUIDialogYesNo::ShowAndGetInput(int heading, int line0, int line1, int lin
     dialog->SetAutoClose(autoCloseTime);
   if (iNoLabel != -1)
     dialog->SetChoice(0,iNoLabel);
+  else
+    dialog->SetChoice(0,106);
   if (iYesLabel != -1)
     dialog->SetChoice(1,iYesLabel);
+  else
+    dialog->SetChoice(1,107);
   dialog->m_bCanceled = false;
   dialog->DoModal();
   bCanceled = dialog->m_bCanceled;
@@ -118,10 +125,22 @@ bool CGUIDialogYesNo::ShowAndGetInput(const CStdString& heading, const CStdStrin
   dialog->m_bCanceled = false;
   if (!noLabel.IsEmpty())
     dialog->SetChoice(0,noLabel);
+  else
+    dialog->SetChoice(0,106);
   if (!yesLabel.IsEmpty())
     dialog->SetChoice(1,yesLabel);
+  else
+    dialog->SetChoice(1,107);
   dialog->DoModal();
   bCanceled = dialog->m_bCanceled;
   return (dialog->IsConfirmed()) ? true : false;
 }
 
+int CGUIDialogYesNo::GetDefaultLabelID(int controlId) const
+{
+  if (controlId == CONTROL_NO_BUTTON)
+    return 106;
+  else if (controlId == CONTROL_YES_BUTTON)
+    return 107;
+  return CGUIDialogBoxBase::GetDefaultLabelID(controlId);
+}

--- a/xbmc/dialogs/GUIDialogYesNo.h
+++ b/xbmc/dialogs/GUIDialogYesNo.h
@@ -38,5 +38,7 @@ public:
   static bool ShowAndGetInput(const CStdString& heading, const CStdString& line0, const CStdString& line1, const CStdString& line2, const CStdString& noLabel="", const CStdString& yesLabel="");
   static bool ShowAndGetInput(const CStdString& heading, const CStdString& line0, const CStdString& line1, const CStdString& line2, bool &bCanceled, const CStdString& noLabel="", const CStdString& yesLabel="");
 protected:
+  virtual int GetDefaultLabelID(int controlId) const;
+
   bool m_bCanceled;
 };

--- a/xbmc/guilib/GUIBaseContainer.cpp
+++ b/xbmc/guilib/GUIBaseContainer.cpp
@@ -891,6 +891,12 @@ void CGUIBaseContainer::UpdateStaticItems(bool refreshItems)
   }
 }
 
+void CGUIBaseContainer::SetInitialVisibility()
+{
+  UpdateStaticItems(true);
+  CGUIControl::SetInitialVisibility();
+}
+
 void CGUIBaseContainer::CalculateLayout()
 {
   CGUIListItemLayout *oldFocusedLayout = m_focusedLayout;
@@ -1041,16 +1047,17 @@ void CGUIBaseContainer::LoadContent(TiXmlElement *content)
     }
     item = item->NextSiblingElement("item");
   }
-  SetStaticContent(items);
+  SetStaticContent(items, false);
 }
 
-void CGUIBaseContainer::SetStaticContent(const vector<CGUIListItemPtr> &items)
+void CGUIBaseContainer::SetStaticContent(const vector<CGUIListItemPtr> &items, bool forceUpdate /* = true */)
 {
   m_staticContent = true;
   m_staticUpdateTime = 0;
   m_staticItems.clear();
   m_staticItems.assign(items.begin(), items.end());
-  UpdateStaticItems(true);
+  if (forceUpdate)
+    UpdateStaticItems(true);
 }
 
 void CGUIBaseContainer::SetRenderOffset(const CPoint &offset)

--- a/xbmc/guilib/GUIBaseContainer.h
+++ b/xbmc/guilib/GUIBaseContainer.h
@@ -56,6 +56,7 @@ public:
   virtual void AllocResources();
   virtual void FreeResources(bool immediately = false);
   virtual void UpdateVisibility(const CGUIListItem *item = NULL);
+  virtual void SetInitialVisibility();
 
   virtual unsigned int GetRows() const;
 
@@ -85,7 +86,7 @@ public:
   virtual bool GetCondition(int condition, int data) const;
   CStdString GetLabel(int info) const;
 
-  void SetStaticContent(const std::vector<CGUIListItemPtr> &items);
+  void SetStaticContent(const std::vector<CGUIListItemPtr> &items, bool forceUpdate = true);
   
   /*! \brief Set the offset of the first item in the container from the container's position
    Useful for lists/panels where the focused item may be larger than the non-focused items and thus

--- a/xbmc/guilib/GUIIncludes.cpp
+++ b/xbmc/guilib/GUIIncludes.cpp
@@ -175,21 +175,21 @@ bool CGUIIncludes::HasIncludeFile(const CStdString &file) const
   return false;
 }
 
-void CGUIIncludes::ResolveIncludes(TiXmlElement *node)
+void CGUIIncludes::ResolveIncludes(TiXmlElement *node, std::map<int, bool>* xmlIncludeConditions /* = NULL */)
 {
   if (!node)
     return;
-  ResolveIncludesForNode(node);
+  ResolveIncludesForNode(node, xmlIncludeConditions);
 
   TiXmlElement *child = node->FirstChildElement();
   while (child)
   {
-    ResolveIncludes(child);
+    ResolveIncludes(child, xmlIncludeConditions);
     child = child->NextSiblingElement();
   }
 }
 
-void CGUIIncludes::ResolveIncludesForNode(TiXmlElement *node)
+void CGUIIncludes::ResolveIncludesForNode(TiXmlElement *node, std::map<int, bool>* xmlIncludeConditions /* = NULL */)
 {
   // we have a node, find any <include file="fileName">tagName</include> tags and replace
   // recursively with their real includes
@@ -226,7 +226,13 @@ void CGUIIncludes::ResolveIncludesForNode(TiXmlElement *node)
     const char *condition = include->Attribute("condition");
     if (condition)
     { // check this condition
-      if (!g_infoManager.EvaluateBool(condition))
+      int conditionID = g_infoManager.Register(condition);
+      bool value = g_infoManager.GetBoolValue(conditionID);
+
+      if (xmlIncludeConditions)
+        (*xmlIncludeConditions)[conditionID] = value;
+
+      if (!value)
       {
         include = include->NextSiblingElement("include");
         continue;

--- a/xbmc/guilib/GUIIncludes.h
+++ b/xbmc/guilib/GUIIncludes.h
@@ -48,11 +48,11 @@ public:
    "bar" from the include file "foo".
    \param node an XML Element - all child elements are traversed.
    */
-  void ResolveIncludes(TiXmlElement *node);
+  void ResolveIncludes(TiXmlElement *node, std::map<int, bool>* xmlIncludeConditions = NULL);
   const INFO::CSkinVariableString* CreateSkinVariable(const CStdString& name, int context);
 
 private:
-  void ResolveIncludesForNode(TiXmlElement *node);
+  void ResolveIncludesForNode(TiXmlElement *node, std::map<int, bool>* xmlIncludeConditions = NULL);
   CStdString ResolveConstant(const CStdString &constant) const;
   bool HasIncludeFile(const CStdString &includeFile) const;
   std::map<CStdString, TiXmlElement> m_includes;

--- a/xbmc/guilib/GUIMessage.h
+++ b/xbmc/guilib/GUIMessage.h
@@ -212,6 +212,20 @@ do { \
 
 /*!
  \ingroup winmsg
+ \brief Set the label of the current control
+ */
+#define SET_CONTROL_LABEL_THREAD_SAFE(controlID,label) \
+{ \
+ CGUIMessage msg(GUI_MSG_LABEL_SET, GetID(), controlID); \
+ msg.SetLabel(label); \
+ if(g_application.IsCurrentThread()) \
+   OnMessage(msg); \
+ else \
+   g_windowManager.SendThreadMessage(msg, GetID()); \
+}
+
+/*!
+ \ingroup winmsg
  \brief Set the second label of the current control
  */
 #define SET_CONTROL_LABEL2(controlID,label) \

--- a/xbmc/guilib/GUIWindow.cpp
+++ b/xbmc/guilib/GUIWindow.cpp
@@ -91,7 +91,21 @@ bool CGUIWindow::Load(const CStdString& strFileName, bool bContainsPath)
   int64_t start;
   start = CurrentHostCounter();
 #endif
-  CLog::Log(LOGINFO, "Loading skin file: %s", strFileName.c_str());
+  const char* strLoadType;
+  switch (m_loadType)
+  {
+  case LOAD_ON_GUI_INIT:
+    strLoadType = "LOAD_ON_GUI_INIT";
+    break;
+  case KEEP_IN_MEMORY:
+    strLoadType = "KEEP_IN_MEMORY";
+    break;
+  case LOAD_EVERY_TIME:
+  default:
+    strLoadType = "LOAD_EVERY_TIME";
+    break;
+  }
+  CLog::Log(LOGINFO, "Loading skin file: %s, load type: %s", strFileName.c_str(), strLoadType);
   
   // Find appropriate skin folder + resolution to load from
   CStdString strPath;

--- a/xbmc/guilib/GUIWindow.cpp
+++ b/xbmc/guilib/GUIWindow.cpp
@@ -139,8 +139,8 @@ bool CGUIWindow::Load(CXBMCTinyXML &xmlDoc)
   // be done with respect to the correct aspect ratio
   g_graphicsContext.SetScalingResolution(m_coordsRes, m_needsScaling);
 
-  // Resolve any includes that may be present
-  g_SkinInfo->ResolveIncludes(pRootElement);
+  // Resolve any includes that may be present and save conditions used to do it
+  g_SkinInfo->ResolveIncludes(pRootElement, &m_xmlIncludeConditions);
   // now load in the skin file
   SetDefaults();
 

--- a/xbmc/guilib/GUIWindow.cpp
+++ b/xbmc/guilib/GUIWindow.cpp
@@ -60,7 +60,7 @@ CGUIWindow::CGUIWindow(int id, const CStdString &xmlFile)
   m_isDialog = false;
   m_needsScaling = true;
   m_windowLoaded = false;
-  m_loadOnDemand = true;
+  m_loadType = LOAD_ON_DEMAND;
   m_closing = false;
   m_active = false;
   m_renderOrder = 0;
@@ -690,7 +690,7 @@ void CGUIWindow::AllocResources(bool forceLoad /*= FALSE */)
   bool bHasPath=false;
   if (xmlFile.Find("\\") > -1 || xmlFile.Find("/") > -1 )
     bHasPath = true;
-  if (xmlFile.size() && (forceLoad || m_loadOnDemand || !m_windowLoaded))
+  if (xmlFile.size() && (forceLoad || m_loadType == LOAD_ON_DEMAND || !m_windowLoaded))
     Load(xmlFile,bHasPath);
 
   int64_t slend;
@@ -714,7 +714,7 @@ void CGUIWindow::FreeResources(bool forceUnload /*= FALSE */)
   CGUIControlGroup::FreeResources();
   //g_TextureManager.Dump();
   // unload the skin
-  if (m_loadOnDemand || forceUnload) ClearAll();
+  if (m_loadType == LOAD_ON_DEMAND || forceUnload) ClearAll();
 }
 
 void CGUIWindow::DynamicResourceAlloc(bool bOnOff)

--- a/xbmc/guilib/GUIWindow.h
+++ b/xbmc/guilib/GUIWindow.h
@@ -80,6 +80,7 @@ class CGUIWindow : public CGUIControlGroup, protected CCriticalSection
 public:
 
   enum WINDOW_TYPE { WINDOW = 0, MODAL_DIALOG, MODELESS_DIALOG, BUTTON_MENU, SUB_MENU };
+  enum LOAD_TYPE { LOAD_ON_DEMAND, LOAD_ON_GUI_INIT};
 
   CGUIWindow(int id, const CStdString &xmlFile);
   virtual ~CGUIWindow(void);
@@ -144,8 +145,8 @@ public:
   virtual bool IsActive() const;
   void SetCoordsRes(const RESOLUTION_INFO &res) { m_coordsRes = res; };
   const RESOLUTION_INFO &GetCoordsRes() const { return m_coordsRes; };
-  void LoadOnDemand(bool loadOnDemand) { m_loadOnDemand = loadOnDemand; };
-  bool GetLoadOnDemand() { return m_loadOnDemand; }
+  void SetLoadType(LOAD_TYPE loadType) { m_loadType = loadType; };
+  LOAD_TYPE GetLoadType() { return m_loadType; } const
   int GetRenderOrder() { return m_renderOrder; };
   virtual void SetInitialVisibility();
   virtual bool IsVisible() const { return true; }; // windows are always considered visible as they implement their own
@@ -235,7 +236,7 @@ protected:
   RESOLUTION_INFO m_coordsRes; // resolution that the window coordinates are in.
   bool m_needsScaling;
   bool m_windowLoaded;  // true if the window's xml file has been loaded
-  bool m_loadOnDemand;  // true if the window should be loaded only as needed
+  LOAD_TYPE m_loadType;
   bool m_isDialog;      // true if we have a dialog, false otherwise.
   bool m_dynamicResourceAlloc;
   bool m_closing;

--- a/xbmc/guilib/GUIWindow.h
+++ b/xbmc/guilib/GUIWindow.h
@@ -194,7 +194,7 @@ public:
 protected:
   virtual EVENT_RESULT OnMouseEvent(const CPoint &point, const CMouseEvent &event);
   virtual bool LoadXML(const CStdString& strPath, const CStdString &strLowerPath);  ///< Loads from the given file
-  bool Load(CXBMCTinyXML &xmlDoc);                 ///< Loads from the given XML document
+  bool Load(TiXmlElement *pRootElement);                 ///< Loads from the given XML root element
   virtual void LoadAdditionalTags(TiXmlElement *root) {}; ///< Load additional information from the XML document
 
   virtual void SetDefaults();
@@ -269,6 +269,8 @@ protected:
 
   CGUIAction m_loadActions;
   CGUIAction m_unloadActions;
+
+  TiXmlElement* m_windowXMLRootElement;
 
   bool m_manualRunActions;
 

--- a/xbmc/guilib/GUIWindow.h
+++ b/xbmc/guilib/GUIWindow.h
@@ -275,7 +275,7 @@ protected:
 
 private:
   std::map<CStdString, CVariant, icompare> m_mapProperties;
-
+  std::map<int, bool> m_xmlIncludeConditions; ///< \brief used to store conditions used to resolve includes for this window
 };
 
 #endif

--- a/xbmc/guilib/GUIWindow.h
+++ b/xbmc/guilib/GUIWindow.h
@@ -80,7 +80,7 @@ class CGUIWindow : public CGUIControlGroup, protected CCriticalSection
 public:
 
   enum WINDOW_TYPE { WINDOW = 0, MODAL_DIALOG, MODELESS_DIALOG, BUTTON_MENU, SUB_MENU };
-  enum LOAD_TYPE { LOAD_ON_DEMAND, LOAD_ON_GUI_INIT};
+  enum LOAD_TYPE { LOAD_EVERY_TIME, LOAD_ON_GUI_INIT, KEEP_IN_MEMORY };
 
   CGUIWindow(int id, const CStdString &xmlFile);
   virtual ~CGUIWindow(void);

--- a/xbmc/guilib/GUIWindowManager.cpp
+++ b/xbmc/guilib/GUIWindowManager.cpp
@@ -856,7 +856,7 @@ void CGUIWindowManager::LoadNotOnDemandWindows()
   for (WindowMap::iterator it = m_mapWindows.begin(); it != m_mapWindows.end(); it++)
   {
     CGUIWindow *pWindow = (*it).second;
-    if (!pWindow ->GetLoadOnDemand())
+    if (pWindow->GetLoadType() == CGUIWindow::LOAD_ON_GUI_INIT)
     {
       pWindow->FreeResources(true);
       pWindow->Initialize();
@@ -870,7 +870,7 @@ void CGUIWindowManager::UnloadNotOnDemandWindows()
   for (WindowMap::iterator it = m_mapWindows.begin(); it != m_mapWindows.end(); it++)
   {
     CGUIWindow *pWindow = (*it).second;
-    if (!pWindow->GetLoadOnDemand())
+    if (pWindow->GetLoadType() == CGUIWindow::LOAD_ON_GUI_INIT)
     {
       pWindow->FreeResources(true);
     }

--- a/xbmc/guilib/GUIWindowManager.cpp
+++ b/xbmc/guilib/GUIWindowManager.cpp
@@ -870,7 +870,8 @@ void CGUIWindowManager::UnloadNotOnDemandWindows()
   for (WindowMap::iterator it = m_mapWindows.begin(); it != m_mapWindows.end(); it++)
   {
     CGUIWindow *pWindow = (*it).second;
-    if (pWindow->GetLoadType() == CGUIWindow::LOAD_ON_GUI_INIT)
+    if (pWindow->GetLoadType() == CGUIWindow::LOAD_ON_GUI_INIT ||
+        pWindow->GetLoadType() == CGUIWindow::KEEP_IN_MEMORY)
     {
       pWindow->FreeResources(true);
     }

--- a/xbmc/interfaces/python/xbmcmodule/GUIPythonWindow.cpp
+++ b/xbmc/interfaces/python/xbmcmodule/GUIPythonWindow.cpp
@@ -60,7 +60,7 @@ CGUIPythonWindow::CGUIPythonWindow(int id)
 {
   pCallbackWindow = NULL;
   m_threadState = NULL;
-  m_loadOnDemand = false;
+  m_loadType = LOAD_ON_GUI_INIT;
   m_destroyAfterDeinit = false;
 }
 

--- a/xbmc/interfaces/python/xbmcmodule/GUIPythonWindowDialog.cpp
+++ b/xbmc/interfaces/python/xbmcmodule/GUIPythonWindowDialog.cpp
@@ -26,7 +26,7 @@
 CGUIPythonWindowDialog::CGUIPythonWindowDialog(int id)
 :CGUIPythonWindow(id)
 {
-  m_loadOnDemand = false;
+  m_loadType = LOAD_ON_GUI_INIT;
 }
 
 CGUIPythonWindowDialog::~CGUIPythonWindowDialog(void)

--- a/xbmc/interfaces/python/xbmcmodule/GUIPythonWindowXML.cpp
+++ b/xbmc/interfaces/python/xbmcmodule/GUIPythonWindowXML.cpp
@@ -49,7 +49,7 @@ CGUIPythonWindowXML::CGUIPythonWindowXML(int id, CStdString strXML, CStdString s
 {
   pCallbackWindow = NULL;
   m_threadState = NULL;
-  m_loadOnDemand = false;
+  m_loadType = LOAD_ON_GUI_INIT;
   m_scriptPath = strFallBackPath;
   m_destroyAfterDeinit = false;
 }

--- a/xbmc/interfaces/python/xbmcmodule/GUIPythonWindowXML.cpp
+++ b/xbmc/interfaces/python/xbmcmodule/GUIPythonWindowXML.cpp
@@ -352,7 +352,7 @@ bool CGUIPythonWindowXML::LoadXML(const CStdString &strPath, const CStdString &s
   if (xmlDoc.Error())
     return false;
 
-  return Load(xmlDoc);
+  return Load(xmlDoc.RootElement());
 }
 
 void CGUIPythonWindowXML::FreeResources(bool forceUnLoad /*= FALSE */)

--- a/xbmc/interfaces/python/xbmcmodule/GUIPythonWindowXMLDialog.cpp
+++ b/xbmc/interfaces/python/xbmcmodule/GUIPythonWindowXMLDialog.cpp
@@ -26,7 +26,7 @@
 CGUIPythonWindowXMLDialog::CGUIPythonWindowXMLDialog(int id, CStdString strXML, CStdString strFallBackPath)
 : CGUIPythonWindowXML(id,strXML,strFallBackPath)
 {
-  m_loadOnDemand = false;
+  m_loadType = LOAD_ON_GUI_INIT;
 }
 
 CGUIPythonWindowXMLDialog::~CGUIPythonWindowXMLDialog(void)

--- a/xbmc/music/dialogs/GUIDialogMusicInfo.cpp
+++ b/xbmc/music/dialogs/GUIDialogMusicInfo.cpp
@@ -61,6 +61,7 @@ CGUIDialogMusicInfo::CGUIDialogMusicInfo(void)
 {
   m_bRefresh = false;
   m_albumSongs = new CFileItemList;
+  m_loadType = KEEP_IN_MEMORY;
 }
 
 CGUIDialogMusicInfo::~CGUIDialogMusicInfo(void)

--- a/xbmc/music/dialogs/GUIDialogMusicOSD.cpp
+++ b/xbmc/music/dialogs/GUIDialogMusicOSD.cpp
@@ -33,6 +33,7 @@
 CGUIDialogMusicOSD::CGUIDialogMusicOSD(void)
     : CGUIDialog(WINDOW_DIALOG_MUSIC_OSD, "MusicOSD.xml")
 {
+  m_loadType = KEEP_IN_MEMORY;
 }
 
 CGUIDialogMusicOSD::~CGUIDialogMusicOSD(void)

--- a/xbmc/music/dialogs/GUIDialogMusicOverlay.cpp
+++ b/xbmc/music/dialogs/GUIDialogMusicOverlay.cpp
@@ -29,6 +29,7 @@ CGUIDialogMusicOverlay::CGUIDialogMusicOverlay()
     : CGUIDialog(WINDOW_DIALOG_MUSIC_OVERLAY, "MusicOverlay.xml")
 {
   m_renderOrder = 0;
+  m_loadType = KEEP_IN_MEMORY;
 }
 
 CGUIDialogMusicOverlay::~CGUIDialogMusicOverlay()

--- a/xbmc/music/dialogs/GUIDialogMusicScan.cpp
+++ b/xbmc/music/dialogs/GUIDialogMusicScan.cpp
@@ -40,6 +40,7 @@ using namespace MUSIC_INFO;
 CGUIDialogMusicScan::CGUIDialogMusicScan(void)
 : CGUIDialog(WINDOW_DIALOG_MUSIC_SCAN, "DialogMusicScan.xml")
 {
+  m_loadType = KEEP_IN_MEMORY;
 }
 
 CGUIDialogMusicScan::~CGUIDialogMusicScan(void)

--- a/xbmc/music/dialogs/GUIDialogSongInfo.cpp
+++ b/xbmc/music/dialogs/GUIDialogSongInfo.cpp
@@ -53,6 +53,7 @@ CGUIDialogSongInfo::CGUIDialogSongInfo(void)
   m_cancelled = false;
   m_needsUpdate = false;
   m_startRating = -1;
+  m_loadType = KEEP_IN_MEMORY;
 }
 
 CGUIDialogSongInfo::~CGUIDialogSongInfo(void)

--- a/xbmc/music/dialogs/GUIDialogVisualisationPresetList.cpp
+++ b/xbmc/music/dialogs/GUIDialogVisualisationPresetList.cpp
@@ -39,6 +39,7 @@ CGUIDialogVisualisationPresetList::CGUIDialogVisualisationPresetList(void)
   m_currentPreset = 0;
   m_vecPresets = new CFileItemList;
   m_viz = NULL;
+  m_loadType = KEEP_IN_MEMORY;
 }
 
 CGUIDialogVisualisationPresetList::~CGUIDialogVisualisationPresetList(void)

--- a/xbmc/music/windows/GUIWindowVisualisation.cpp
+++ b/xbmc/music/windows/GUIWindowVisualisation.cpp
@@ -40,6 +40,7 @@ CGUIWindowVisualisation::CGUIWindowVisualisation(void)
       m_initTimer(true), m_lockedTimer(true)
 {
   m_bShowPreset = false;
+  m_loadType = KEEP_IN_MEMORY;
 }
 
 bool CGUIWindowVisualisation::OnAction(const CAction &action)

--- a/xbmc/network/GUIDialogNetworkSetup.cpp
+++ b/xbmc/network/GUIDialogNetworkSetup.cpp
@@ -43,6 +43,7 @@ CGUIDialogNetworkSetup::CGUIDialogNetworkSetup(void)
 {
   m_protocol = NET_PROTOCOL_SMB;
   m_confirmed = false;
+  m_loadType = KEEP_IN_MEMORY;
 }
 
 CGUIDialogNetworkSetup::~CGUIDialogNetworkSetup()
@@ -106,7 +107,7 @@ bool CGUIDialogNetworkSetup::ShowAndGetNetworkAddress(CStdString &path)
   return dialog->IsConfirmed();
 }
 
-void CGUIDialogNetworkSetup::OnInitWindow()
+void CGUIDialogNetworkSetup::OnWindowLoaded()
 {
   // replace our buttons with edits
   ChangeButtonToEdit(CONTROL_SERVER_ADDRESS);
@@ -115,6 +116,11 @@ void CGUIDialogNetworkSetup::OnInitWindow()
   ChangeButtonToEdit(CONTROL_PORT_NUMBER);
   ChangeButtonToEdit(CONTROL_PASSWORD);
 
+  CGUIDialog::OnWindowLoaded();
+}
+
+void CGUIDialogNetworkSetup::OnInitWindow()
+{
   // start as unconfirmed
   m_confirmed = false;
 
@@ -154,6 +160,16 @@ void CGUIDialogNetworkSetup::OnInitWindow()
 
   pSpin->SetValue(m_protocol);
   OnProtocolChange();
+}
+
+void CGUIDialogNetworkSetup::OnDeinitWindow(int nextWindowID)
+{
+  // clear protocol spinner
+  CGUISpinControlEx *pSpin = (CGUISpinControlEx *)GetControl(CONTROL_PROTOCOL);
+  if (pSpin)
+    pSpin->Clear();
+
+  CGUIDialog::OnDeinitWindow(nextWindowID);
 }
 
 void CGUIDialogNetworkSetup::OnServerBrowse()

--- a/xbmc/network/GUIDialogNetworkSetup.h
+++ b/xbmc/network/GUIDialogNetworkSetup.h
@@ -49,6 +49,8 @@ public:
   virtual bool OnMessage(CGUIMessage& message);
   virtual bool OnBack(int actionID);
   virtual void OnInitWindow();
+  virtual void OnWindowLoaded();
+  virtual void OnDeinitWindow(int nextWindowID);
 
   static bool ShowAndGetNetworkAddress(CStdString &path);
 

--- a/xbmc/peripherals/dialogs/GUIDialogPeripheralManager.cpp
+++ b/xbmc/peripherals/dialogs/GUIDialogPeripheralManager.cpp
@@ -39,6 +39,7 @@ CGUIDialogPeripheralManager::CGUIDialogPeripheralManager(void) :
     m_iSelected(0),
     m_peripheralItems(new CFileItemList)
 {
+  m_loadType = KEEP_IN_MEMORY;
 }
 
 CGUIDialogPeripheralManager::~CGUIDialogPeripheralManager(void)
@@ -69,13 +70,11 @@ bool CGUIDialogPeripheralManager::OnAction(const CAction &action)
   return CGUIDialog::OnAction(action);
 }
 
-bool CGUIDialogPeripheralManager::OnMessageInit(CGUIMessage &message)
+void CGUIDialogPeripheralManager::OnInitWindow()
 {
-  CGUIWindow::OnMessage(message);
+  CGUIWindow::OnInitWindow();
   m_iSelected = 0;
   Update();
-
-  return true;
 }
 
 bool CGUIDialogPeripheralManager::OnClickList(CGUIMessage &message)
@@ -137,11 +136,6 @@ bool CGUIDialogPeripheralManager::OnMessage(CGUIMessage& message)
       break;
     case GUI_MSG_ITEM_SELECT:
       return true;
-    case GUI_MSG_WINDOW_INIT:
-      {
-        OnMessageInit(message);
-        break;
-      }
     case GUI_MSG_CLICKED:
       return OnMessageClick(message);
   }

--- a/xbmc/peripherals/dialogs/GUIDialogPeripheralManager.h
+++ b/xbmc/peripherals/dialogs/GUIDialogPeripheralManager.h
@@ -32,6 +32,7 @@ namespace PERIPHERALS
     virtual ~CGUIDialogPeripheralManager(void);
     virtual bool OnMessage(CGUIMessage& message);
     virtual bool OnAction(const CAction& action);
+    virtual void OnInitWindow();
     virtual void OnWindowLoaded(void);
     virtual void OnWindowUnload(void);
     virtual bool HasListItems() const { return true; };
@@ -39,7 +40,6 @@ namespace PERIPHERALS
     virtual void Update(void);
 
   protected:
-    virtual bool OnMessageInit(CGUIMessage &message);
     virtual bool OnMessageClick(CGUIMessage &message);
 
     virtual bool OnClickList(CGUIMessage &message);

--- a/xbmc/pictures/GUIDialogPictureInfo.cpp
+++ b/xbmc/pictures/GUIDialogPictureInfo.cpp
@@ -34,6 +34,7 @@ CGUIDialogPictureInfo::CGUIDialogPictureInfo(void)
     : CGUIDialog(WINDOW_DIALOG_PICTURE_INFO, "DialogPictureInfo.xml")
 {
   m_pictureInfo = new CFileItemList;
+  m_loadType = KEEP_IN_MEMORY;
 }
 
 CGUIDialogPictureInfo::~CGUIDialogPictureInfo(void)

--- a/xbmc/pictures/GUIWindowSlideShow.h
+++ b/xbmc/pictures/GUIWindowSlideShow.h
@@ -87,7 +87,7 @@ public:
   virtual bool OnAction(const CAction &action);
   virtual void Render();
   virtual void Process(unsigned int currentTime, CDirtyRegionList &regions);
-  virtual void FreeResources();
+  virtual void OnDeinitWindow(int nextWindowID);
   void OnLoadPic(int iPic, int iSlideNumber, CBaseTexture* pTexture, bool bFullSize);
   int NumSlides() const;
   int CurrentSlide() const;

--- a/xbmc/settings/GUIDialogSettings.cpp
+++ b/xbmc/settings/GUIDialogSettings.cpp
@@ -59,6 +59,7 @@ CGUIDialogSettings::CGUIDialogSettings(int id, const char *xmlFile)
   m_pOriginalSlider = NULL;
   m_pOriginalSeparator = NULL;
   m_usePopupSliders = false;
+  m_loadType = KEEP_IN_MEMORY;
 }
 
 CGUIDialogSettings::~CGUIDialogSettings(void)

--- a/xbmc/settings/GUIWindowSettings.cpp
+++ b/xbmc/settings/GUIWindowSettings.cpp
@@ -26,6 +26,7 @@
 CGUIWindowSettings::CGUIWindowSettings(void)
     : CGUIWindow(WINDOW_SETTINGS_MENU, "Settings.xml")
 {
+  m_loadType = KEEP_IN_MEMORY;
 }
 
 CGUIWindowSettings::~CGUIWindowSettings(void)

--- a/xbmc/settings/GUIWindowSettingsCategory.cpp
+++ b/xbmc/settings/GUIWindowSettingsCategory.cpp
@@ -143,6 +143,7 @@ using namespace PERIPHERALS;
 CGUIWindowSettingsCategory::CGUIWindowSettingsCategory(void)
     : CGUIWindow(WINDOW_SETTINGS_MYPICTURES, "SettingsCategory.xml")
 {
+  m_loadType = KEEP_IN_MEMORY;
   m_pOriginalSpin = NULL;
   m_pOriginalRadioButton = NULL;
   m_pOriginalButton = NULL;

--- a/xbmc/settings/GUIWindowSettingsProfile.cpp
+++ b/xbmc/settings/GUIWindowSettingsProfile.cpp
@@ -46,6 +46,7 @@ CGUIWindowSettingsProfile::CGUIWindowSettingsProfile(void)
     : CGUIWindow(WINDOW_SETTINGS_PROFILES, "SettingsProfile.xml")
 {
   m_listItems = new CFileItemList;
+  m_loadType = KEEP_IN_MEMORY;
 }
 
 CGUIWindowSettingsProfile::~CGUIWindowSettingsProfile(void)

--- a/xbmc/video/dialogs/GUIDialogFullScreenInfo.cpp
+++ b/xbmc/video/dialogs/GUIDialogFullScreenInfo.cpp
@@ -24,6 +24,7 @@
 CGUIDialogFullScreenInfo::CGUIDialogFullScreenInfo(void)
     : CGUIDialog(WINDOW_DIALOG_FULLSCREEN_INFO, "DialogFullScreenInfo.xml")
 {
+  m_loadType = KEEP_IN_MEMORY;
 }
 
 CGUIDialogFullScreenInfo::~CGUIDialogFullScreenInfo(void)

--- a/xbmc/video/dialogs/GUIDialogVideoBookmarks.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoBookmarks.cpp
@@ -58,6 +58,7 @@ CGUIDialogVideoBookmarks::CGUIDialogVideoBookmarks()
     : CGUIDialog(WINDOW_DIALOG_VIDEO_BOOKMARKS, "VideoOSDBookmarks.xml")
 {
   m_vecItems = new CFileItemList;
+  m_loadType = KEEP_IN_MEMORY;
 }
 
 CGUIDialogVideoBookmarks::~CGUIDialogVideoBookmarks()

--- a/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
@@ -72,6 +72,7 @@ CGUIDialogVideoInfo::CGUIDialogVideoInfo(void)
   m_bRefresh = false;
   m_hasUpdatedThumb = false;
   m_castList = new CFileItemList;
+  m_loadType = KEEP_IN_MEMORY;
 }
 
 CGUIDialogVideoInfo::~CGUIDialogVideoInfo(void)

--- a/xbmc/video/dialogs/GUIDialogVideoOSD.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoOSD.cpp
@@ -34,6 +34,7 @@ using namespace PVR;
 CGUIDialogVideoOSD::CGUIDialogVideoOSD(void)
     : CGUIDialog(WINDOW_DIALOG_VIDEO_OSD, "VideoOSD.xml")
 {
+  m_loadType = KEEP_IN_MEMORY;
 }
 
 CGUIDialogVideoOSD::~CGUIDialogVideoOSD(void)

--- a/xbmc/video/dialogs/GUIDialogVideoOverlay.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoOverlay.cpp
@@ -35,6 +35,7 @@ CGUIDialogVideoOverlay::CGUIDialogVideoOverlay()
     : CGUIDialog(WINDOW_DIALOG_VIDEO_OVERLAY, "VideoOverlay.xml")
 {
   m_renderOrder = 0;
+  m_loadType = KEEP_IN_MEMORY;
 }
 
 CGUIDialogVideoOverlay::~CGUIDialogVideoOverlay()

--- a/xbmc/video/dialogs/GUIDialogVideoScan.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoScan.cpp
@@ -41,6 +41,7 @@ using namespace VIDEO;
 CGUIDialogVideoScan::CGUIDialogVideoScan(void)
 : CGUIDialog(WINDOW_DIALOG_VIDEO_SCAN, "DialogVideoScan.xml")
 {
+  m_loadType = KEEP_IN_MEMORY;
 }
 
 CGUIDialogVideoScan::~CGUIDialogVideoScan(void)
@@ -167,12 +168,17 @@ void CGUIDialogVideoScan::UpdateState()
       CGUIProgressControl* pProgressCtrl=(CGUIProgressControl*)GetControl(CONTROL_CURRENT_PROGRESS);
       if (pProgressCtrl) pProgressCtrl->SetPercentage(m_fCurrentPercentDone);
     }
+    else
+      SET_CONTROL_HIDDEN(CONTROL_CURRENT_PROGRESS);
+
     if (m_fPercentDone>-1.0f)
     {
       SET_CONTROL_VISIBLE(CONTROL_PROGRESS);
       CGUIProgressControl* pProgressCtrl=(CGUIProgressControl*)GetControl(CONTROL_PROGRESS);
       if (pProgressCtrl) pProgressCtrl->SetPercentage(m_fPercentDone);
     }
+    else
+      SET_CONTROL_HIDDEN(CONTROL_PROGRESS);
   }
   else
   {

--- a/xbmc/video/windows/GUIWindowFullScreen.cpp
+++ b/xbmc/video/windows/GUIWindowFullScreen.cpp
@@ -134,6 +134,7 @@ CGUIWindowFullScreen::CGUIWindowFullScreen(void)
   m_subsLayout = NULL;
   m_bGroupSelectShow = false;
   m_sliderAction = 0;
+  m_loadType = KEEP_IN_MEMORY;
   // audio
   //  - language
   //  - volume
@@ -155,19 +156,6 @@ CGUIWindowFullScreen::CGUIWindowFullScreen(void)
 
 CGUIWindowFullScreen::~CGUIWindowFullScreen(void)
 {}
-
-void CGUIWindowFullScreen::AllocResources(bool forceLoad)
-{
-  CGUIWindow::AllocResources(forceLoad);
-  DynamicResourceAlloc(false);
-}
-
-void CGUIWindowFullScreen::FreeResources(bool forceUnload)
-{
-  g_settings.Save();
-  DynamicResourceAlloc(true);
-  CGUIWindow::FreeResources(forceUnload);
-}
 
 bool CGUIWindowFullScreen::OnAction(const CAction &action)
 {
@@ -779,8 +767,6 @@ bool CGUIWindowFullScreen::OnMessage(CGUIMessage& message)
     }
   case GUI_MSG_WINDOW_DEINIT:
     {
-      CGUIWindow::OnMessage(message);
-
       CGUIDialog *pDialog = (CGUIDialog *)g_windowManager.GetWindow(WINDOW_DIALOG_OSD_TELETEXT);
       if (pDialog) pDialog->Close(true);
       CGUIDialogSlider *slider = (CGUIDialogSlider *)g_windowManager.GetWindow(WINDOW_DIALOG_SLIDER);
@@ -798,7 +784,9 @@ bool CGUIWindowFullScreen::OnMessage(CGUIMessage& message)
       pDialog = (CGUIDialog *)g_windowManager.GetWindow(WINDOW_DIALOG_PVR_OSD_CUTTER);
       if (pDialog) pDialog->Close(true);
 
-      FreeResources(true);
+      CGUIWindow::OnMessage(message);
+
+      g_settings.Save();
 
       CSingleLock lock (g_graphicsContext);
       g_graphicsContext.SetFullScreenVideo(false);

--- a/xbmc/video/windows/GUIWindowFullScreen.h
+++ b/xbmc/video/windows/GUIWindowFullScreen.h
@@ -33,8 +33,6 @@ class CGUIWindowFullScreen :
 public:
   CGUIWindowFullScreen(void);
   virtual ~CGUIWindowFullScreen(void);
-  virtual void AllocResources(bool forceLoad = false);
-  virtual void FreeResources(bool forceUnLoad = false);
   virtual bool OnMessage(CGUIMessage& message);
   virtual bool OnAction(const CAction &action);
   virtual void FrameMove();

--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -81,6 +81,7 @@ using namespace ADDON;
 CGUIMediaWindow::CGUIMediaWindow(int id, const char *xmlFile)
     : CGUIWindow(id, xmlFile)
 {
+  m_loadType = KEEP_IN_MEMORY;
   m_vecItems = new CFileItemList;
   m_unfilteredItems = new CFileItemList;
   m_vecItems->SetPath("?");

--- a/xbmc/windows/GUIWindowFileManager.cpp
+++ b/xbmc/windows/GUIWindowFileManager.cpp
@@ -102,6 +102,7 @@ CGUIWindowFileManager::CGUIWindowFileManager(void)
   m_Directory[0]->m_bIsFolder = true;
   m_Directory[1]->m_bIsFolder = true;
   bCheckShareConnectivity = true;
+  m_loadType = KEEP_IN_MEMORY;
 }
 
 CGUIWindowFileManager::~CGUIWindowFileManager(void)

--- a/xbmc/windows/GUIWindowHome.cpp
+++ b/xbmc/windows/GUIWindowHome.cpp
@@ -35,6 +35,7 @@ CGUIWindowHome::CGUIWindowHome(void) : CGUIWindow(WINDOW_HOME, "Home.xml"),
                                        m_cumulativeUpdateFlag(0)
 {
   m_updateRA = (Audio | Video | Totals);
+  m_loadType = KEEP_IN_MEMORY;
   
   CAnnouncementManager::AddAnnouncer(this);
 }

--- a/xbmc/windows/GUIWindowLoginScreen.cpp
+++ b/xbmc/windows/GUIWindowLoginScreen.cpp
@@ -58,6 +58,7 @@ CGUIWindowLoginScreen::CGUIWindowLoginScreen(void)
   watch.StartZero();
   m_vecItems = new CFileItemList;
   m_iSelectedItem = -1;
+  m_loadType = KEEP_IN_MEMORY;
 }
 
 CGUIWindowLoginScreen::~CGUIWindowLoginScreen(void)

--- a/xbmc/windows/GUIWindowPointer.cpp
+++ b/xbmc/windows/GUIWindowPointer.cpp
@@ -29,7 +29,7 @@ CGUIWindowPointer::CGUIWindowPointer(void)
     : CGUIDialog(WINDOW_DIALOG_POINTER, "Pointer.xml")
 {
   m_pointer = 0;
-  m_loadOnDemand = false;
+  m_loadType = LOAD_ON_GUI_INIT;
   m_needsScaling = false;
   m_active = false;
   m_renderOrder = INT_MAX - 1;

--- a/xbmc/windows/GUIWindowSystemInfo.cpp
+++ b/xbmc/windows/GUIWindowSystemInfo.cpp
@@ -44,6 +44,7 @@ CGUIWindowSystemInfo::CGUIWindowSystemInfo(void)
 :CGUIWindow(WINDOW_SYSTEM_INFORMATION, "SettingsSystemInfo.xml")
 {
   m_section = CONTROL_BT_DEFAULT;
+  m_loadType = KEEP_IN_MEMORY;
 }
 CGUIWindowSystemInfo::~CGUIWindowSystemInfo(void)
 {
@@ -65,6 +66,7 @@ bool CGUIWindowSystemInfo::OnMessage(CGUIMessage& message)
     {
       CGUIWindow::OnMessage(message);
       m_diskUsage.clear();
+      ResetLabels();
       return true;
     }
     break;

--- a/xbmc/windows/GUIWindowWeather.cpp
+++ b/xbmc/windows/GUIWindowWeather.cpp
@@ -68,6 +68,7 @@ FIXME'S
 CGUIWindowWeather::CGUIWindowWeather(void)
     : CGUIWindow(WINDOW_WEATHER, "MyWeather.xml"), m_maxLocation(0)
 {
+  m_loadType = KEEP_IN_MEMORY;
 }
 
 CGUIWindowWeather::~CGUIWindowWeather(void)


### PR DESCRIPTION
This is resurrection of #127 in much more complete state:

Window's controls are being deleted on window deinit. This results in loading xml, resolving includes, parsing resolved xml and creating controls everytime user activate window.

This will allow to keep controls objects in memory on window deinit. It also will store xml windows root node that could be used if load type is set to load_on_demand (old style - few windows are still like this) or if include condition have changed value.

Some numbers (tested on raspberry pi with slow sd card where it will have biggest impact I guess): compare alloc resources time for first and second window inits. (I didn't really gather data, just ran xbmc 3 times and given that results were similliar I called it done)

```
===== Results (numbers from Raspberry Pi) ====

  1. Home Window

     -- First window init will be same as usual --

    00:02:33 T:1096794832   DEBUG: ------ Window Init (Home.xml) ------
    00:02:33 T:1096794832    INFO: Loading skin file: Home.xml, load type: on demand and keep in memory after window deinit
    00:02:33 T:1096794832   DEBUG: Load Home.xml: 665.98ms
    00:02:34 T:1096794832   DEBUG: Alloc resources: 723.72ms  (666.55 ms skin load)

     -- Second window init --

    00:03:24 T:1096794832   DEBUG: ------ Window Init (Home.xml) ------
    00:03:24 T:1096794832   DEBUG: Window Home.xml was already loaded
    00:03:24 T:1096794832   DEBUG: Alloc resources: 22.07m

  2. Video Nav

    00:03:18 T:1096794832   DEBUG: ------ Window Init (MyVideoNav.xml) ------
    00:03:18 T:1096794832    INFO: Loading skin file: MyVideoNav.xml, load type: on demand and keep in memory after window deinit
    00:03:19 T:1096794832   DEBUG: Load MyVideoNav.xml: 776.83ms
    00:03:19 T:1096794832   DEBUG: Alloc resources: 827.03ms  (777.33 ms skin load)

    00:03:30 T:1096794832   DEBUG: ------ Window Init (MyVideoNav.xml) ------
    00:03:30 T:1096794832   DEBUG: Window MyVideoNav.xml was already loaded
    00:03:30 T:1096794832   DEBUG: Alloc resources: 27.48m
```

On android (skin.retouched) Home.xml was loaded 1st time: 126ms and 2nd time: 5ms (that's total alloc resources time). On my desktop with ssd - home.xml = 1st time: 42ms, 2nd time: 4ms. So it's not that spectacular everywhere. Note: alloc resources times don't include time spent in OnWindowInit (f.e. video nav window fetch directory there)!

Here's list of windows that weren't yet adjusted/tested if they will work "as-is":

```
Still on to-do list but not really high priority:
00:02:30 T:1096794832   DEBUG: GUIWindowManager: LOAD_ON_DEMAND window: screencalibration (file: SettingsScreenCalibration.xml, ID: 10011)
00:02:30 T:1096794832   DEBUG: GUIWindowManager: LOAD_ON_DEMAND window: filestackingdialog (file: DialogFileStacking.xml, ID: 12008)

Didn't have any karaoke samples so at least for now I leave them as they are with old style xml loading every init. Do they still work at all?
00:02:30 T:1096794832   DEBUG: GUIWindowManager: LOAD_ON_DEMAND window: karaokeselector (file: DialogKaraokeSongSelector.xml, ID: 10143)
00:02:30 T:1096794832   DEBUG: GUIWindowManager: LOAD_ON_DEMAND window: karaokelargeselector (file: DialogKaraokeSongSelectorLarge.xml, ID: 10144)
00:02:30 T:1096794832   DEBUG: GUIWindowManager: LOAD_ON_DEMAND window: karaoke (file: MusicKaraokeLyrics.xml, ID: 12009)

For no-xml windows load type doesn't matter so they can stay as they are.
00:02:30 T:1096794832   DEBUG: GUIWindowManager: LOAD_ON_DEMAND window: teletext (file: no xml file, ID: 10600)
00:02:30 T:1096794832   DEBUG: GUIWindowManager: LOAD_ON_DEMAND window: unkown window (file: no xml file, ID: 97) <= Dim Screensaver Window
00:02:30 T:1096794832   DEBUG: GUIWindowManager: LOAD_ON_DEMAND window: unkown window (file: no xml file, ID: 98) <= Debug Overlay Window
00:02:30 T:1096794832   DEBUG: GUIWindowManager: LOAD_ON_DEMAND window: screensaver (file: no xml file, ID: 12900)

CGUIDialogSubMenu class used only as base for "submenu" type custom windows (which wasn't used by any of few skins I have: confluence, aeon-nox, xeebo). No DialogSubMenu.xml in confluence. Nuke that window?
00:02:30 T:1096794832   DEBUG: GUIWindowManager: LOAD_ON_DEMAND window: submenu (file: DialogSubMenu.xml, ID: 10105)

Used only after playing with GUISetting that aren't shown in GUI. No DialogAccessPoints.xml in confluence. Nuke that window?
00:02:30 T:1096794832   DEBUG: GUIWindowManager: LOAD_ON_DEMAND window: accesspoints (file: DialogAccessPoints.xml, ID: 10141)

Loaded and shown once - no sense in keeping it in memory.
00:02:30 T:1096794832   DEBUG: GUIWindowManager: LOAD_ON_DEMAND window: startup (file: Startup.xml, ID: 12999)
```

And finally - my branch currently contains 2(3) last temporary commits (they will be removed later) to
1. help me notice what windows weren't adjusted yet (it generated window list above)
2. enable/disable feature on runtime (in gui settings) to check what impact it have
(3). add window loadtype to log on window load (depends on how verbose we want to be)
