### PR TITLE
Windows: Create minidumps for threads terminated by exceptions

### DIFF
--- a/xbmc/threads/Thread.cpp
+++ b/xbmc/threads/Thread.cpp
@@ -196,7 +196,6 @@ void CThread::Sleep(unsigned int milliseconds)
 
 void CThread::Action()
 {
-
   try
   {
     OnStartup();
@@ -237,7 +236,7 @@ void CThread::Action()
   }
   catch (...)
   {
-    LOG(LOGERROR, "%s - thread %s, Unhandled exception caught in thread process, aborting. auto delete: %d", __FUNCTION__, m_ThreadName.c_str(), IsAutoDelete());
+    LOG(LOGERROR, "%s - thread %s, Unhandled exception caught in thread OnExit, aborting. auto delete: %d", __FUNCTION__, m_ThreadName.c_str(), IsAutoDelete());
   }
 }
 

--- a/xbmc/threads/platform/win/ThreadImpl.cpp
+++ b/xbmc/threads/platform/win/ThreadImpl.cpp
@@ -70,6 +70,8 @@ void CThread::SetThreadInfo()
   __except(EXCEPTION_EXECUTE_HANDLER)
   {
   }
+
+    win32_exception::install_handler();
 }
 
 ThreadIdentifier CThread::GetCurrentThreadId()

--- a/xbmc/threads/platform/win/Win32Exception.cpp
+++ b/xbmc/threads/platform/win/Win32Exception.cpp
@@ -21,8 +21,18 @@
 
 #include "Win32Exception.h"
 #include <eh.h>
+#include <dbghelp.h>
+#include "Util.h"
+#include "WIN32Util.h"
 
 #define LOG if(logger) logger->Log
+
+typedef BOOL (WINAPI *MINIDUMPWRITEDUMP)(HANDLE hProcess, DWORD dwPid, HANDLE hFile, MINIDUMP_TYPE DumpType,
+                                        CONST PMINIDUMP_EXCEPTION_INFORMATION ExceptionParam,
+                                        CONST PMINIDUMP_USER_STREAM_INFORMATION UserStreamParam,
+                                        CONST PMINIDUMP_CALLBACK_INFORMATION CallbackParam);
+
+std::string win32_exception::mVersion;
 
 void win32_exception::install_handler()
 {
@@ -64,6 +74,74 @@ void win32_exception::LogThrowMessage(const char *prefix)  const
     LOG(LOGERROR, "%s : %s (code:0x%08x) at 0x%08x", prefix, (unsigned int) what(), code(), where());
   else
     LOG(LOGERROR, "%s (code:0x%08x) at 0x%08x", what(), code(), where());
+}
+
+bool win32_exception::write_minidump(EXCEPTION_POINTERS* pEp)
+{
+  // Create the dump file where the xbmc.exe resides
+  CStdString errorMsg;
+  bool returncode = false;
+  CStdString dumpFileName;
+  SYSTEMTIME stLocalTime;
+  GetLocalTime(&stLocalTime);
+
+  dumpFileName.Format("xbmc_crashlog-%s-%04d%02d%02d-%02d%02d%02d.dmp",
+                      mVersion.c_str(),
+                      stLocalTime.wYear, stLocalTime.wMonth, stLocalTime.wDay,
+                      stLocalTime.wHour, stLocalTime.wMinute, stLocalTime.wSecond);
+
+  dumpFileName.Format("%s\\%s", CWIN32Util::GetProfilePath().c_str(), CUtil::MakeLegalFileName(dumpFileName));
+
+  HANDLE hDumpFile = CreateFile(dumpFileName.c_str(), GENERIC_WRITE, 0, 0, CREATE_ALWAYS, 0, 0);
+
+  if (hDumpFile == INVALID_HANDLE_VALUE)
+  {
+    LOG(LOGERROR, "CreateFile '%s' failed with error id %d", dumpFileName.c_str(), GetLastError());
+    goto cleanup;
+  }
+
+  // Load the DBGHELP DLL
+  HMODULE hDbgHelpDll = ::LoadLibrary("DBGHELP.DLL");
+  if (!hDbgHelpDll)
+  {
+    LOG(LOGERROR, "LoadLibrary 'DBGHELP.DLL' failed with error id %d", GetLastError());
+    goto cleanup;
+  }
+
+  MINIDUMPWRITEDUMP pDump = (MINIDUMPWRITEDUMP)::GetProcAddress(hDbgHelpDll, "MiniDumpWriteDump");
+  if (!pDump)
+  {
+    LOG(LOGERROR, "Failed to locate MiniDumpWriteDump with error id %d", GetLastError());
+    goto cleanup;
+  }
+
+  // Initialize minidump structure
+  MINIDUMP_EXCEPTION_INFORMATION mdei;
+  mdei.ThreadId = GetCurrentThreadId();
+  mdei.ExceptionPointers = pEp;
+  mdei.ClientPointers = FALSE;
+
+  // Call the minidump api with normal dumping
+  // We can get more detail information by using other minidump types but the dump file will be
+  // extremely large.
+  BOOL bMiniDumpSuccessful = pDump(GetCurrentProcess(), GetCurrentProcessId(), hDumpFile, MiniDumpNormal, &mdei, 0, NULL);
+  if( !bMiniDumpSuccessful )
+  {
+    LOG(LOGERROR, "MiniDumpWriteDump failed with error id %d", GetLastError());
+    goto cleanup;
+  }
+
+  returncode = true;
+
+cleanup:
+
+  if (hDumpFile != INVALID_HANDLE_VALUE)
+    CloseHandle(hDumpFile);
+
+  if (hDbgHelpDll)
+    FreeLibrary(hDbgHelpDll);
+
+  return returncode;
 }
 
 access_violation::access_violation(EXCEPTION_POINTERS* info) : 

--- a/xbmc/threads/platform/win/Win32Exception.cpp
+++ b/xbmc/threads/platform/win/Win32Exception.cpp
@@ -52,7 +52,7 @@ void win32_exception::translate(unsigned code, EXCEPTION_POINTERS* info)
 }
 
 win32_exception::win32_exception(EXCEPTION_POINTERS* info, const char* classname) :
-  XbmcCommons::Exception(classname ? classname : "win32_exception"),
+  XbmcCommons::UncheckedException(classname ? classname : "win32_exception"),
   mWhat("Win32 exception"), mWhere(info->ExceptionRecord->ExceptionAddress), mCode(info->ExceptionRecord->ExceptionCode), mExceptionPointers(info)
 {
   // Windows guarantees that *(info->ExceptionRecord) is valid
@@ -71,15 +71,15 @@ win32_exception::win32_exception(EXCEPTION_POINTERS* info, const char* classname
 void win32_exception::LogThrowMessage(const char *prefix)  const
 {
   if( prefix )
-    LOG(LOGERROR, "%s : %s (code:0x%08x) at 0x%08x", prefix, (unsigned int) what(), code(), where());
+    LOG(LOGERROR, "Unhandled exception in %s : %s (code:0x%08x) at 0x%08x", prefix, (unsigned int) what(), code(), where());
   else
-    LOG(LOGERROR, "%s (code:0x%08x) at 0x%08x", what(), code(), where());
+    LOG(LOGERROR, "Unhandled exception in %s (code:0x%08x) at 0x%08x", what(), code(), where());
+  write_minidump();
 }
 
 bool win32_exception::write_minidump(EXCEPTION_POINTERS* pEp)
 {
   // Create the dump file where the xbmc.exe resides
-  CStdString errorMsg;
   bool returncode = false;
   CStdString dumpFileName;
   SYSTEMTIME stLocalTime;
@@ -166,20 +166,22 @@ void access_violation::LogThrowMessage(const char *prefix) const
 {
   if( prefix )
     if( mAccessType == Write)
-      LOG(LOGERROR, "%s : %s at 0x%08x: Writing location 0x%08x", prefix, what(), where(), address());
+      LOG(LOGERROR, "Unhandled exception in %s : %s at 0x%08x: Writing location 0x%08x", prefix, what(), where(), address());
     else if( mAccessType == Read)
-      LOG(LOGERROR, "%s : %s at 0x%08x: Reading location 0x%08x", prefix, what(), where(), address());
+      LOG(LOGERROR, "Unhandled exception in %s : %s at 0x%08x: Reading location 0x%08x", prefix, what(), where(), address());
     else if( mAccessType == DEP)
-      LOG(LOGERROR, "%s : %s at 0x%08x: DEP violation, location 0x%08x", prefix, what(), where(), address());
+      LOG(LOGERROR, "Unhandled exception in %s : %s at 0x%08x: DEP violation, location 0x%08x", prefix, what(), where(), address());
     else
-      LOG(LOGERROR, "%s : %s at 0x%08x: unknown access type, location 0x%08x", prefix, what(), where(), address());
+      LOG(LOGERROR, "Unhandled exception in %s : %s at 0x%08x: unknown access type, location 0x%08x", prefix, what(), where(), address());
   else
     if( mAccessType == Write)
-      LOG(LOGERROR, "%s at 0x%08x: Writing location 0x%08x", what(), where(), address());
+      LOG(LOGERROR, "Unhandled exception in %s at 0x%08x: Writing location 0x%08x", what(), where(), address());
     else if( mAccessType == Read)
-      LOG(LOGERROR, "%s at 0x%08x: Reading location 0x%08x", what(), where(), address());
+      LOG(LOGERROR, "Unhandled exception in %s at 0x%08x: Reading location 0x%08x", what(), where(), address());
     else if( mAccessType == DEP)
-      LOG(LOGERROR, "%s at 0x%08x: DEP violation, location 0x%08x", what(), where(), address());
+      LOG(LOGERROR, "Unhandled exception in %s at 0x%08x: DEP violation, location 0x%08x", what(), where(), address());
     else
-      LOG(LOGERROR, "%s at 0x%08x: unknown access type, location 0x%08x", what(), where(), address());
+      LOG(LOGERROR, "Unhandled exception in %s at 0x%08x: unknown access type, location 0x%08x", what(), where(), address());
+
+  write_minidump();
 }

--- a/xbmc/threads/platform/win/Win32Exception.h
+++ b/xbmc/threads/platform/win/Win32Exception.h
@@ -25,7 +25,7 @@
 #include <exception>
 #include "commons/Exception.h"
 
-class win32_exception: public XbmcCommons::Exception
+class win32_exception: public XbmcCommons::UncheckedException
 {
 public:
     typedef const void* Address; // OK on Win32 platform
@@ -40,6 +40,8 @@ public:
 protected:
     win32_exception(EXCEPTION_POINTERS*, const char* classname = NULL);
     static void translate(unsigned code, EXCEPTION_POINTERS* info);
+
+    inline bool write_minidump() const { return write_minidump(mExceptionPointers); };
 private:
     const char* mWhat;
     Address mWhere;

--- a/xbmc/threads/platform/win/Win32Exception.h
+++ b/xbmc/threads/platform/win/Win32Exception.h
@@ -36,12 +36,13 @@ public:
     unsigned code() const { return mCode; };
     virtual void LogThrowMessage(const char *prefix) const;
 protected:
-    win32_exception(const EXCEPTION_RECORD& info, const char* classname = NULL);
+    win32_exception(EXCEPTION_POINTERS*, const char* classname = NULL);
     static void translate(unsigned code, EXCEPTION_POINTERS* info);
 private:
     const char* mWhat;
     Address mWhere;
     unsigned mCode;
+    EXCEPTION_POINTERS *mExceptionPointers;
 };
 
 class access_violation: public win32_exception
@@ -62,5 +63,5 @@ protected:
 private:
     access_type mAccessType;
     Address mBadAddress;
-    access_violation(const EXCEPTION_RECORD& info);
+    access_violation(EXCEPTION_POINTERS* info);
 };

--- a/xbmc/threads/platform/win/Win32Exception.h
+++ b/xbmc/threads/platform/win/Win32Exception.h
@@ -31,10 +31,12 @@ public:
     typedef const void* Address; // OK on Win32 platform
 
     static void install_handler();
+    static void set_version(std::string version) { mVersion = version; };
     virtual const char* what() const { return mWhat; };
     Address where() const { return mWhere; };
     unsigned code() const { return mCode; };
     virtual void LogThrowMessage(const char *prefix) const;
+    static bool write_minidump(EXCEPTION_POINTERS* pEp);
 protected:
     win32_exception(EXCEPTION_POINTERS*, const char* classname = NULL);
     static void translate(unsigned code, EXCEPTION_POINTERS* info);
@@ -43,6 +45,7 @@ private:
     Address mWhere;
     unsigned mCode;
     EXCEPTION_POINTERS *mExceptionPointers;
+    static std::string mVersion;
 };
 
 class access_violation: public win32_exception

--- a/xbmc/win32/XBMC_PC.cpp
+++ b/xbmc/win32/XBMC_PC.cpp
@@ -23,80 +23,19 @@
 #include "settings/AppParamParser.h"
 #include "utils/CharsetConverter.h"
 #include "utils/log.h"
-#include "WIN32Util.h"
+#include "threads/platform/win/Win32Exception.h"
 #include "shellapi.h"
 #include "dbghelp.h"
 #include "XBDateTime.h"
 #include "threads/Thread.h"
 #include "Application.h"
 #include "XbmcContext.h"
-
-typedef BOOL (WINAPI *MINIDUMPWRITEDUMP)(HANDLE hProcess, DWORD dwPid, HANDLE hFile, MINIDUMP_TYPE DumpType,
-                                        CONST PMINIDUMP_EXCEPTION_INFORMATION ExceptionParam,
-                                        CONST PMINIDUMP_USER_STREAM_INFORMATION UserStreamParam,
-                                        CONST PMINIDUMP_CALLBACK_INFORMATION CallbackParam);
-
+#include "GUIInfoManager.h"
 
 // Minidump creation function
 LONG WINAPI CreateMiniDump( EXCEPTION_POINTERS* pEp )
 {
-  // Create the dump file where the xbmc.exe resides
-  CStdString errorMsg;
-  CStdString dumpFile;
-  CDateTime now(CDateTime::GetCurrentDateTime());
-  dumpFile.Format("%s\\xbmc_crashlog-%s-%04i%02i%02i-%02i%02i%02i.dmp", CWIN32Util::GetProfilePath().c_str(), GIT_REV, now.GetYear(), now.GetMonth(), now.GetDay(), now.GetHour(), now.GetMinute(), now.GetSecond());
-  HANDLE hFile = CreateFile(dumpFile.c_str(), GENERIC_READ | GENERIC_WRITE, 0, NULL, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL );
-
-  // Call MiniDumpWriteDump api with the dump file
-  if ( hFile && ( hFile != INVALID_HANDLE_VALUE ) )
-  {
-    // Load the DBGHELP DLL
-    HMODULE hDbgHelpDll = ::LoadLibrary("DBGHELP.DLL");
-    if (hDbgHelpDll)
-    {
-      MINIDUMPWRITEDUMP pDump = (MINIDUMPWRITEDUMP)::GetProcAddress(hDbgHelpDll, "MiniDumpWriteDump");
-      if (pDump)
-      {
-        // Initialize minidump structure
-        MINIDUMP_EXCEPTION_INFORMATION mdei;
-        mdei.ThreadId           = CThread::GetCurrentThreadId();
-        mdei.ExceptionPointers  = pEp;
-        mdei.ClientPointers     = FALSE;
-
-        // Call the minidump api with normal dumping
-        // We can get more detail information by using other minidump types but the dump file will be
-        // extermely large.
-        BOOL rv = pDump(GetCurrentProcess(), GetCurrentProcessId(), hFile, MiniDumpNormal, &mdei, 0, NULL);
-        if( !rv )
-        {
-          errorMsg.Format("MiniDumpWriteDump failed with error id %d", GetLastError());
-          MessageBox(NULL, errorMsg.c_str(), "XBMC: Error", MB_OK|MB_ICONERROR);
-        }
-      }
-      else
-      {
-        errorMsg.Format("MiniDumpWriteDump failed to load with error id %d", GetLastError());
-        MessageBox(NULL, errorMsg.c_str(), "XBMC: Error", MB_OK|MB_ICONERROR);
-      }
-
-      // Close the DLL
-      FreeLibrary(hDbgHelpDll);
-    }
-    else
-    {
-      errorMsg.Format("LoadLibrary 'DBGHELP.DLL' failed with error id %d", GetLastError());
-      MessageBox(NULL, errorMsg.c_str(), "XBMC: Error", MB_OK|MB_ICONERROR);
-    }
-
-    // Close the file
-    CloseHandle( hFile );
-  }
-  else
-  {
-    errorMsg.Format("CreateFile '%s' failed with error id %d", dumpFile.c_str(), GetLastError());
-    MessageBox(NULL, errorMsg.c_str(), "XBMC: Error", MB_OK|MB_ICONERROR);
-  }
-
+  win32_exception::write_minidump(pEp);
   return pEp->ExceptionRecord->ExceptionCode;;
 }
 
@@ -121,6 +60,7 @@ INT WINAPI WinMain( HINSTANCE hInst, HINSTANCE, LPSTR commandLine, INT )
   CLog::SetLogLevel(g_advancedSettings.m_logLevel);
 
   // Initializes CreateMiniDump to handle exceptions.
+  win32_exception::set_version(g_infoManager.GetVersion());
   SetUnhandledExceptionFilter( CreateMiniDump );
 
   // check if XBMC is already running


### PR DESCRIPTION
This is just a resurrection of #813. I had to move the writedump methods to XBApplicationEx.cpp because they wasn't caught in thread.cpp.
I've added quite some code duplication in XBApplicationEx.cpp because I didn't want to introduce new methods or goto's. Please comment if there's a better way.
