### PR TITLE
fix episode sorting after filtering

### DIFF
--- a/xbmc/video/windows/GUIWindowVideoNav.cpp
+++ b/xbmc/video/windows/GUIWindowVideoNav.cpp
@@ -1619,9 +1619,12 @@ bool CGUIWindowVideoNav::ApplyWatchedFilter(CFileItemList &items)
   }
 
   if(node == NODE_TYPE_TITLE_TVSHOWS || node == NODE_TYPE_SEASONS)
+  {
     // the watched filter may change the "numepisodes" property which is reflected in the TV_SHOWS and SEASONS nodes
     // therefore, the items labels have to be refreshed, and possibly the list needs resorting as well.
-    FormatAndSort(items); 
+    items.ClearSortState(); // this is needed to force resorting even if sort method did not change
+    FormatAndSort(items);
+  }
 
   return listchanged;
 }


### PR DESCRIPTION
This is a small bugfix for the issue reported here:
http://forum.xbmc.org/showthread.php?tid=135982&pid=1169047#pid1169047

essentially, when you are filtering watched/unwatched episodes, the episode attribute is dynamically changed. Upon (re)display of the list, the code wants to sort the list on the episode (count) attribute, but in some cases it doesn't resort. It seems that the root cause is that the sortmethod or the sortorder don't change, and the list sorting method is bypassed, which is incorrect in this case.

Potentially, there can be other situations like this, but the application & gui reload the lists from the database in these cases (e.g. ignoring 'the' etc.).
