### PR TITLE
[ffmpeg] Convert from av_audio_convert API to the swresample one.

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -1412,6 +1412,13 @@ if test "$use_external_ffmpeg" = "yes"; then
   # libavcore is optional
   PKG_CHECK_EXISTS([libavcore], FFMPEG_LIBNAMES="$FFMPEG_LIBNAMES libavcore")
 
+  # one of libswresample or libavresample is needed
+  PKG_CHECK_EXISTS([libswresample], FFMPEG_LIBNAMES="$FFMPEG_LIBNAMES libswresample",
+                   [PKG_CHECK_EXISTS([libavresample],
+                                     FFMPEG_LIBNAMES="$FFMPEG_LIBNAMES libavresample",
+                                     AC_MSG_ERROR([You need either libswresample
+                                                   or libavresample.]))])
+
   PKG_CHECK_MODULES([FFMPEG], [$FFMPEG_LIBNAMES],
                     [INCLUDES="$INCLUDES $FFMPEG_CFLAGS"; LIBS="$LIBS $FFMPEG_LIBS"],
                     AC_MSG_ERROR($missing_library))
@@ -1444,6 +1451,9 @@ if test "$use_external_ffmpeg" = "yes"; then
   # We'll support the use of rgb2rgb.h if it exists.
   AC_CHECK_HEADERS([libswscale/rgb2rgb.h],,)
   AC_CHECK_HEADERS([ffmpeg/rgb2rgb.h],,)
+
+  # Check for libswresample or libavresample headers.
+  AC_CHECK_HEADERS([libswresample/swresample.h libavresample/avresample.h])
 
   # Check if AVFilterBufferRefVideoProps AVRational member is named
   # 'pixel_aspect' or 'sample_aspect_ratio'.

--- a/lib/DllAvCodec.h
+++ b/lib/DllAvCodec.h
@@ -58,20 +58,8 @@ extern "C" {
       #include <ffmpeg/avformat.h>
     #endif
   #endif
-
-  /* From non-public audioconvert.h */
-  struct AVAudioConvert;
-  typedef struct AVAudioConvert AVAudioConvert;
-  AVAudioConvert *av_audio_convert_alloc(enum AVSampleFormat out_fmt, int out_channels,
-                                         enum AVSampleFormat in_fmt, int in_channels,
-                                         const float *matrix, int flags);
-  void av_audio_convert_free(AVAudioConvert *ctx);
-  int av_audio_convert(AVAudioConvert *ctx,
-                             void * const out[6], const int out_stride[6],
-                       const void * const  in[6], const int  in_stride[6], int len);
 #else
   #include "libavcodec/avcodec.h"
-  #include "libavcodec/audioconvert.h"
 #endif
 }
 
@@ -115,13 +103,6 @@ public:
   virtual int avcodec_default_get_buffer(AVCodecContext *s, AVFrame *pic)=0;
   virtual void avcodec_default_release_buffer(AVCodecContext *s, AVFrame *pic)=0;
   virtual AVCodec *av_codec_next(AVCodec *c)=0;
-  virtual AVAudioConvert *av_audio_convert_alloc(enum AVSampleFormat out_fmt, int out_channels,
-                                                 enum AVSampleFormat in_fmt , int in_channels,
-                                                 const float *matrix        , int flags)=0;
-  virtual void av_audio_convert_free(AVAudioConvert *ctx)=0;
-  virtual int av_audio_convert(AVAudioConvert *ctx,
-                                     void * const out[6], const int out_stride[6],
-                               const void * const  in[6], const int  in_stride[6], int len)=0;
   virtual int av_dup_packet(AVPacket *pkt)=0;
   virtual void av_init_packet(AVPacket *pkt)=0;
 };
@@ -189,17 +170,6 @@ public:
   virtual void avcodec_default_release_buffer(AVCodecContext *s, AVFrame *pic) { ::avcodec_default_release_buffer(s, pic); }
   virtual enum PixelFormat avcodec_default_get_format(struct AVCodecContext *s, const enum PixelFormat *fmt) { return ::avcodec_default_get_format(s, fmt); }
   virtual AVCodec *av_codec_next(AVCodec *c) { return ::av_codec_next(c); }
-  virtual AVAudioConvert *av_audio_convert_alloc(enum AVSampleFormat out_fmt, int out_channels,
-                                                 enum AVSampleFormat in_fmt , int in_channels,
-                                                 const float *matrix        , int flags)
-          { return ::av_audio_convert_alloc(out_fmt, out_channels, in_fmt, in_channels, matrix, flags); }
-  virtual void av_audio_convert_free(AVAudioConvert *ctx)
-          { ::av_audio_convert_free(ctx); }
-
-  virtual int av_audio_convert(AVAudioConvert *ctx,
-                                     void * const out[6], const int out_stride[6],
-                               const void * const  in[6], const int  in_stride[6], int len)
-          { return ::av_audio_convert(ctx, out, out_stride, in, in_stride, len); }
 
   virtual int av_dup_packet(AVPacket *pkt) { return ::av_dup_packet(pkt); }
   virtual void av_init_packet(AVPacket *pkt) { return ::av_init_packet(pkt); }
@@ -251,13 +221,6 @@ class DllAvCodec : public DllDynamic, DllAvCodecInterface
   DEFINE_METHOD2(enum PixelFormat, avcodec_default_get_format, (struct AVCodecContext *p1, const enum PixelFormat *p2))
 
   DEFINE_METHOD1(AVCodec*, av_codec_next, (AVCodec *p1))
-  DEFINE_METHOD6(AVAudioConvert*, av_audio_convert_alloc, (enum AVSampleFormat p1, int p2,
-                                                           enum AVSampleFormat p3, int p4,
-                                                           const float *p5, int p6))
-  DEFINE_METHOD1(void, av_audio_convert_free, (AVAudioConvert *p1));
-  DEFINE_METHOD6(int,  av_audio_convert,      (AVAudioConvert *p1,
-                                                     void * const p2[6], const int p3[6],
-                                               const void * const p4[6], const int p5[6], int p6))
   BEGIN_METHOD_RESOLVE()
     RESOLVE_METHOD(avcodec_flush_buffers)
     RESOLVE_METHOD_RENAME(avcodec_open2,avcodec_open2_dont_call)
@@ -288,9 +251,6 @@ class DllAvCodec : public DllDynamic, DllAvCodecInterface
     RESOLVE_METHOD(avcodec_default_release_buffer)
     RESOLVE_METHOD(avcodec_default_get_format)
     RESOLVE_METHOD(av_codec_next)
-    RESOLVE_METHOD(av_audio_convert_alloc)
-    RESOLVE_METHOD(av_audio_convert_free)
-    RESOLVE_METHOD(av_audio_convert)
     RESOLVE_METHOD(av_dup_packet)
     RESOLVE_METHOD(av_init_packet)
   END_METHOD_RESOLVE()

--- a/lib/DllSwResample.h
+++ b/lib/DllSwResample.h
@@ -42,11 +42,20 @@ extern "C" {
 #endif
 }
 
+class DllSwResampleInterface
+{
+public:
+  virtual ~DllSwResampleInterface() {}
+  virtual struct SwrContext *swr_alloc_set_opts(struct SwrContext *s, int64_t out_ch_layout, enum AVSampleFormat out_sample_fmt, int out_sample_rate, int64_t in_ch_layout, enum AVSampleFormat in_sample_fmt, int in_sample_rate, int log_offset, void *log_ctx)=0;
+  virtual int swr_init(struct SwrContext *s)=0;
+  virtual void swr_free(struct SwrContext **s)=0;
+  virtual int swr_convert(struct SwrContext *s, uint8_t **out, int out_count, const uint8_t **in , int in_count)=0;
+};
 
 #if (defined USE_EXTERNAL_FFMPEG) || (defined TARGET_DARWIN) 
 
 // Use direct mapping
-class DllSwResample : public DllDynamic
+class DllSwResample : public DllDynamic, DllSwResampleInterface
 {
 public:
   virtual ~DllSwResample() {}
@@ -58,17 +67,30 @@ public:
     return true;
   }
   virtual void Unload() {}
+  virtual struct SwrContext *swr_alloc_set_opts(struct SwrContext *s, int64_t out_ch_layout, enum AVSampleFormat out_sample_fmt, int out_sample_rate, int64_t in_ch_layout, enum AVSampleFormat in_sample_fmt, int in_sample_rate, int log_offset, void *log_ctx) { return ::swr_alloc_set_opts(s, out_ch_layout, out_sample_fmt, out_sample_rate, in_ch_layout, in_sample_fmt, in_sample_rate, log_offset, log_ctx); }
+  virtual int swr_init(struct SwrContext *s) { return ::swr_init(s); }
+  virtual void swr_free(struct SwrContext **s){ return ::swr_free(s); }
+  virtual int swr_convert(struct SwrContext *s, uint8_t **out, int out_count, const uint8_t **in , int in_count){ return ::swr_convert(s, out, out_count, in, in_count); }
 };
 
 #else
 
-class DllSwResample : public DllDynamic
+class DllSwResample : public DllDynamic, DllSwResampleInterface
 {
   DECLARE_DLL_WRAPPER(DllSwResample, DLL_PATH_LIBSWRESAMPLE)
 
   LOAD_SYMBOLS()
 
+  DEFINE_METHOD9(SwrContext*, swr_alloc_set_opts, (struct SwrContext *p1, int64_t p2, enum AVSampleFormat p3, int p4, int64_t p5, enum AVSampleFormat p6, int p7, int p8, void * p9));
+  DEFINE_METHOD1(int, swr_init, (struct SwrContext *p1))
+  DEFINE_METHOD1(void, swr_free, (struct SwrContext **p1))
+  DEFINE_METHOD5(int, swr_convert, (struct SwrContext *p1, uint8_t **p2, int p3, const uint8_t **p4, int p5))
+
   BEGIN_METHOD_RESOLVE()
+    RESOLVE_METHOD(swr_alloc_set_opts)
+    RESOLVE_METHOD(swr_init)
+    RESOLVE_METHOD(swr_free)
+    RESOLVE_METHOD(swr_convert)
   END_METHOD_RESOLVE()
 
   /* dependencies of libavformat */

--- a/lib/DllSwResample.h
+++ b/lib/DllSwResample.h
@@ -24,6 +24,7 @@
   #include "config.h"
 #endif
 #include "DynamicDll.h"
+#include "utils/log.h"
 
 extern "C" {
 #ifndef HAVE_MMX
@@ -40,6 +41,8 @@ extern "C" {
     #include <libswresample/swresample.h>
   #elif HAVE_LIBAVRESAMPLE_AVRESAMPLE_H
     #include <libavresample/avresample.h>
+    #include <libavutil/opt.h>
+    #include <libavutil/samplefmt.h>
     #define SwrContext AVAudioResampleContext
   #else
     #error "Either libswresample or libavresample is needed!"

--- a/lib/DllSwResample.h
+++ b/lib/DllSwResample.h
@@ -36,7 +36,14 @@ extern "C" {
 #pragma warning(disable:4244)
 #endif
 #if (defined USE_EXTERNAL_FFMPEG)
-  #include <libswresample/swresample.h>
+  #if HAVE_LIBSWRESAMPLE_SWRESAMPLE_H
+    #include <libswresample/swresample.h>
+  #elif HAVE_LIBAVRESAMPLE_AVRESAMPLE_H
+    #include <libavresample/avresample.h>
+    #define SwrContext AVAudioResampleContext
+  #else
+    #error "Either libswresample or libavresample is needed!"
+  #endif
 #else
   #include "libswresample/swresample.h"
 #endif
@@ -54,6 +61,7 @@ public:
 
 #if (defined USE_EXTERNAL_FFMPEG) || (defined TARGET_DARWIN) 
 
+#if HAVE_LIBSWRESAMPLE_SWRESAMPLE_H || (defined TARGET_DARWIN)
 // Use direct mapping
 class DllSwResample : public DllDynamic, DllSwResampleInterface
 {
@@ -72,6 +80,35 @@ public:
   virtual void swr_free(struct SwrContext **s){ return ::swr_free(s); }
   virtual int swr_convert(struct SwrContext *s, uint8_t **out, int out_count, const uint8_t **in , int in_count){ return ::swr_convert(s, out, out_count, in, in_count); }
 };
+#else
+// Wrap the same API through libavresample.
+class DllSwResample : public DllDynamic, DllSwResampleInterface
+{
+public:
+  virtual ~DllSwResample() {}
+
+  // DLL faking.
+  virtual bool ResolveExports() { return true; }
+  virtual bool Load() {
+    CLog::Log(LOGDEBUG, "DllAvFormat: Using libavresample system library");
+    return true;
+  }
+  virtual void Unload() {}
+  virtual struct SwrContext *swr_alloc_set_opts(struct SwrContext *s, int64_t out_ch_layout, enum AVSampleFormat out_sample_fmt, int out_sample_rate, int64_t in_ch_layout, enum AVSampleFormat in_sample_fmt, int in_sample_rate, int log_offset, void *log_ctx) {
+          AVAudioResampleContext *ret = ::avresample_alloc_context();
+          av_opt_set_int(ret, "out_channel_layout", out_ch_layout  , 0);
+          av_opt_set_int(ret, "out_sample_fmt"    , out_sample_fmt , 0);
+          av_opt_set_int(ret, "out_sample_rate"   , out_sample_rate, 0);
+          av_opt_set_int(ret, "in_channel_layout" , in_ch_layout   , 0);
+          av_opt_set_int(ret, "in_sample_fmt"     , in_sample_fmt  , 0);
+          av_opt_set_int(ret, "in_sample_rate"    , in_sample_rate , 0);
+          return ret;
+  }
+  virtual int swr_init(struct SwrContext *s) { return ::avresample_open(s); }
+  virtual void swr_free(struct SwrContext **s){ ::avresample_close(*s); *s = NULL; }
+  virtual int swr_convert(struct SwrContext *s, uint8_t **out, int out_count, const uint8_t **in , int in_count){ return ::avresample_convert(s, (void**)out, 0, out_count, (void**)in, 0,in_count); }
+};
+#endif
 
 #else
 

--- a/xbmc/cores/dvdplayer/DVDCodecs/Audio/DVDAudioCodecFFmpeg.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Audio/DVDAudioCodecFFmpeg.cpp
@@ -56,7 +56,7 @@ bool CDVDAudioCodecFFmpeg::Open(CDVDStreamInfo &hints, CDVDCodecOptions &options
   AVCodec* pCodec;
   m_bOpenedCodec = false;
 
-  if (!m_dllAvUtil.Load() || !m_dllAvCodec.Load())
+  if (!m_dllAvUtil.Load() || !m_dllAvCodec.Load() || !m_dllSwResample.Load())
     return false;
 
   m_dllAvCodec.avcodec_register_all();
@@ -118,10 +118,7 @@ void CDVDAudioCodecFFmpeg::Dispose()
   m_pFrame1 = NULL;
 
   if (m_pConvert)
-  {
-    m_dllAvCodec.av_audio_convert_free(m_pConvert);
-    m_pConvert = NULL;
-  }
+    m_dllSwResample.swr_free(&m_pConvert);
 
   if (m_pCodecContext)
   {
@@ -185,18 +182,18 @@ void CDVDAudioCodecFFmpeg::ConvertToFloat()
   if(m_pCodecContext->sample_fmt != AV_SAMPLE_FMT_FLT && m_iBufferSize1 > 0)
   {
     if(m_pConvert && m_pCodecContext->sample_fmt != m_iSampleFormat)
-    {
-      m_dllAvCodec.av_audio_convert_free(m_pConvert);
-      m_pConvert = NULL;
-    }
+      m_dllSwResample.swr_free(&m_pConvert);
 
     if(!m_pConvert)
     {
       m_iSampleFormat = m_pCodecContext->sample_fmt;
-      m_pConvert = m_dllAvCodec.av_audio_convert_alloc(AV_SAMPLE_FMT_FLT, 1, m_pCodecContext->sample_fmt, 1, NULL, 0);
+      m_pConvert = m_dllSwResample.swr_alloc_set_opts(NULL,
+                      m_dllAvUtil.av_get_default_channel_layout(m_pCodecContext->channels), AV_SAMPLE_FMT_FLT, m_pCodecContext->sample_rate,
+                      m_dllAvUtil.av_get_default_channel_layout(m_pCodecContext->channels), m_pCodecContext->sample_fmt, m_pCodecContext->sample_rate,
+                      0, NULL);
     }
 
-    if(!m_pConvert)
+    if(!m_pConvert || m_dllSwResample.swr_init(m_pConvert) < 0)
     {
       CLog::Log(LOGERROR, "CDVDAudioCodecFFmpeg::Decode - Unable to convert %d to AV_SAMPLE_FMT_FLT", m_pCodecContext->sample_fmt);
       m_iBufferSize1 = 0;
@@ -204,12 +201,8 @@ void CDVDAudioCodecFFmpeg::ConvertToFloat()
       return;
     }
 
-    const void *ibuf[6] = { m_pFrame1->data[0] };
-    void       *obuf[6] = { m_pBuffer2 };
-    int         istr[6] = { m_dllAvUtil.av_get_bytes_per_sample(m_pCodecContext->sample_fmt) };
-    int         ostr[6] = { m_dllAvUtil.av_get_bytes_per_sample(AV_SAMPLE_FMT_FLT) };
-    int         len     = m_iBufferSize1 / istr[0];
-    if(m_dllAvCodec.av_audio_convert(m_pConvert, obuf, ostr, ibuf, istr, len) < 0)
+    int len = m_iBufferSize1 / m_dllAvUtil.av_get_bytes_per_sample(m_pCodecContext->sample_fmt);
+    if(m_dllSwResample.swr_convert(m_pConvert, &m_pBuffer2, len, (const uint8_t**)m_pFrame1->data, m_pFrame1->nb_samples) < 0)
     {
       CLog::Log(LOGERROR, "CDVDAudioCodecFFmpeg::Decode - Unable to convert %d to AV_SAMPLE_FMT_FLT", (int)m_pCodecContext->sample_fmt);
       m_iBufferSize1 = 0;
@@ -218,7 +211,7 @@ void CDVDAudioCodecFFmpeg::ConvertToFloat()
     }
 
     m_iBufferSize1 = 0;
-    m_iBufferSize2 = len * ostr[0];
+    m_iBufferSize2 = len * av_get_bytes_per_sample(AV_SAMPLE_FMT_FLT);
   }
 }
 

--- a/xbmc/cores/dvdplayer/DVDCodecs/Audio/DVDAudioCodecFFmpeg.h
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Audio/DVDAudioCodecFFmpeg.h
@@ -25,6 +25,7 @@
 #include "DllAvCodec.h"
 #include "DllAvFormat.h"
 #include "DllAvUtil.h"
+#include "DllSwResample.h"
 
 class CDVDAudioCodecFFmpeg : public CDVDAudioCodec
 {
@@ -47,7 +48,7 @@ public:
 
 protected:
   AVCodecContext*     m_pCodecContext;
-  AVAudioConvert*     m_pConvert;
+  SwrContext*         m_pConvert;
   enum AVSampleFormat m_iSampleFormat;  
   CAEChannelInfo      m_channelLayout;
   int                 m_iMapChannels;
@@ -66,6 +67,7 @@ protected:
 
   DllAvCodec m_dllAvCodec;
   DllAvUtil m_dllAvUtil;
+  DllSwResample m_dllSwResample;
 
   void BuildChannelMap();
   void ConvertToFloat();  


### PR DESCRIPTION
This is a followup on #882.
No new feature added, only switching from a deprecated internal API to a public one.

It includes support for libavresample if libswresample is not available, which should please libav boyz, but since libav has not made a single release with libavresample they will probably have to wait or use git master.
