### PR TITLE
removed the fatalerrorhandler and exit gracefully

### DIFF
--- a/xbmc/Application.h
+++ b/xbmc/Application.h
@@ -443,7 +443,6 @@ protected:
 
   void SetHardwareVolume(float hardwareVolume);
   void UpdateLCD();
-  void FatalErrorHandler(bool WindowSystemInitialized, bool MapDrives, bool InitNetwork);
 
   void VolumeChanged() const;
 


### PR DESCRIPTION
I assume the fatalerrorhandler is a remnant of the xbox days. Our main functions already exit gracefully and display some more meaningful error messages.
This might fix the problem on windows that windows just throws the messages that a program end premature when we call abort().
