### PR TITLE
AEConvert: Use a more extensible API.

### DIFF
--- a/xbmc/cores/AudioEngine/Engines/CoreAudio/CoreAudioAEStream.h
+++ b/xbmc/cores/AudioEngine/Engines/CoreAudio/CoreAudioAEStream.h
@@ -132,7 +132,7 @@ private:
   float                   m_rgain;         /* replay gain level */
   IAEStream               *m_slave;        /* slave aestream */
 
-  CAEConvert::AEConvertToFn m_convertFn;
+  CAEToFloatConv         *m_convertFn;
 
   CoreAudioRingBuffer    *m_Buffer;
   float                  *m_convertBuffer;      /* buffer for converted data */

--- a/xbmc/cores/AudioEngine/Engines/SoftAE/SoftAE.h
+++ b/xbmc/cores/AudioEngine/Engines/SoftAE/SoftAE.h
@@ -155,7 +155,7 @@ private:
   AEAudioFormat             m_encoderFormat;
   float                     m_encoderFrameSizeMul;
   unsigned int              m_bytesPerSample;
-  CAEConvert::AEConvertFrFn m_convertFn;
+  CAEFrFloatConv           *m_convertFn;
 
   /* currently playing sounds */
   typedef struct {

--- a/xbmc/cores/AudioEngine/Engines/SoftAE/SoftAEStream.h
+++ b/xbmc/cores/AudioEngine/Engines/SoftAE/SoftAEStream.h
@@ -115,8 +115,8 @@ private:
   float                   m_rgain;         /* replay gain level */
   unsigned int            m_waterLevel;    /* the fill level to fall below before calling the data callback */
   unsigned int            m_refillBuffer;  /* how many frames that need to be buffered before we return any frames */
+  CAEToFloatConv         *m_convertFn;
 
-  CAEConvert::AEConvertToFn m_convertFn;
 
   CAEBuffer           m_inputBuffer;
   unsigned int        m_bytesPerSample;

--- a/xbmc/cores/AudioEngine/Utils/AEConvert.h
+++ b/xbmc/cores/AudioEngine/Utils/AEConvert.h
@@ -23,40 +23,22 @@
 #include <stdint.h>
 #include "../AEAudioFormat.h"
 
-class CAEConvert{
-private:
-  static unsigned int U8_Float    (uint8_t *data, const unsigned int samples, float   *dest);
-  static unsigned int S8_Float    (uint8_t *data, const unsigned int samples, float   *dest);
-  static unsigned int S16LE_Float (uint8_t *data, const unsigned int samples, float   *dest);
-  static unsigned int S16BE_Float (uint8_t *data, const unsigned int samples, float   *dest);
-  static unsigned int S24LE4_Float(uint8_t *data, const unsigned int samples, float   *dest);
-  static unsigned int S24BE4_Float(uint8_t *data, const unsigned int samples, float   *dest);
-  static unsigned int S24LE3_Float(uint8_t *data, const unsigned int samples, float   *dest);
-  static unsigned int S24BE3_Float(uint8_t *data, const unsigned int samples, float   *dest);
-  static unsigned int S32LE_Float (uint8_t *data, const unsigned int samples, float   *dest);
-  static unsigned int S32BE_Float (uint8_t *data, const unsigned int samples, float   *dest);
-  static unsigned int DOUBLE_Float(uint8_t *data, const unsigned int samples, float   *dest);
-
-  static unsigned int Float_U8    (float   *data, const unsigned int samples, uint8_t *dest);
-  static unsigned int Float_S8    (float   *data, const unsigned int samples, uint8_t *dest);
-  static unsigned int Float_S16LE (float   *data, const unsigned int samples, uint8_t *dest);
-  static unsigned int Float_S16BE (float   *data, const unsigned int samples, uint8_t *dest);
-  static unsigned int Float_S24NE4(float   *data, const unsigned int samples, uint8_t *dest);
-  static unsigned int Float_S24NE3(float   *data, const unsigned int samples, uint8_t *dest);
-  static unsigned int Float_S32LE (float   *data, const unsigned int samples, uint8_t *dest);
-  static unsigned int Float_S32BE (float   *data, const unsigned int samples, uint8_t *dest);
-  static unsigned int Float_DOUBLE(float   *data, const unsigned int samples, uint8_t *dest);
-
-  static unsigned int S32LE_Float_Neon (uint8_t *data, const unsigned int samples, float   *dest);
-  static unsigned int S32BE_Float_Neon (uint8_t *data, const unsigned int samples, float   *dest);
-  static unsigned int Float_S32LE_Neon (float   *data, const unsigned int samples, uint8_t *dest);
-  static unsigned int Float_S32BE_Neon (float   *data, const unsigned int samples, uint8_t *dest);
-
+class CAEToFloatConv{
 public:
-  typedef unsigned int (*AEConvertToFn)(uint8_t *data, const unsigned int samples, float   *dest);
-  typedef unsigned int (*AEConvertFrFn)(float   *data, const unsigned int samples, uint8_t *dest);
-
-  static AEConvertToFn ToFloat(enum AEDataFormat dataFormat);
-  static AEConvertFrFn FrFloat(enum AEDataFormat dataFormat);
+  CAEToFloatConv(enum AEDataFormat dataFormat);
+  ~CAEToFloatConv();
+  unsigned int convert(const uint8_t *data, unsigned int samples, float   *dest);
+  bool is_valid();
+private:
+  void* priv_data;
 };
 
+class CAEFrFloatConv{
+public:
+  CAEFrFloatConv(enum AEDataFormat dataFormat);
+  ~CAEFrFloatConv();
+  unsigned int convert(const float   *data, unsigned int samples, uint8_t *dest);
+  bool is_valid();
+private:
+  void* priv_data;
+};

--- a/xbmc/cores/AudioEngine/Utils/AEWAVLoader.cpp
+++ b/xbmc/cores/AudioEngine/Utils/AEWAVLoader.cpp
@@ -161,12 +161,12 @@ bool CAEWAVLoader::Initialize(const std::string &filename, unsigned int resample
        isDATA        = m_frameCount > 0;
 
        /* get the conversion function */
-       CAEConvert::AEConvertToFn convertFn;
+       CAEToFloatConv *convertFn = NULL;
        switch (bitsPerSample)
        {
-         case 8 : convertFn = CAEConvert::ToFloat(AE_FMT_U8   ); break;
-         case 16: convertFn = CAEConvert::ToFloat(AE_FMT_S16LE); break;
-         case 32: convertFn = CAEConvert::ToFloat(AE_FMT_S32LE); break;
+         case 8 : convertFn = new CAEToFloatConv(AE_FMT_U8   ); break;
+         case 16: convertFn = new CAEToFloatConv(AE_FMT_S16LE); break;
+         case 32: convertFn = new CAEToFloatConv(AE_FMT_S32LE); break;
          default:
            CLog::Log(LOGERROR, "CAEWAVLoader::Initialize - Unsupported data format in wav: %s", m_filename.c_str());
            file.Close();
@@ -190,9 +190,10 @@ bool CAEWAVLoader::Initialize(const std::string &filename, unsigned int resample
          }
 
          /* convert the sample to float */
-         convertFn(raw, 1, &m_samples[s]);
+         convertFn->convert(raw, 1, &m_samples[s]);
        }
        _aligned_free(raw);
+       delete convertFn;
     }
     else
     {


### PR DESCRIPTION
New API is: create a CAE{Fr,To}FloatConv class foo.
The class is to be considered valid iff foo->is_valid is true.
Call foo->convert to make the conversion.
delete foo when done.

This follows from the discussion on #1290.
With this new API, it should be easy to implement AEConvert stuff based on swr/avr.

How to do this is still to decide:
1) a new .cpp file for the swr based converter, implementing the same classes, and chose at build time which file to build
2) #ifdefery in the current AEConvert.cpp

Anyway, a new converter depends on #1290 to be merged first.
