### PR TITLE
[LINUX] Get all the nameservers not only the first one

### DIFF
--- a/xbmc/network/linux/NetworkLinux.cpp
+++ b/xbmc/network/linux/NetworkLinux.cpp
@@ -496,7 +496,7 @@ std::vector<CStdString> CNetworkLinux::GetNameServers(void)
 
    for (int i = 0; i < _res.nscount; i ++)
    {
-      CStdString ns = inet_ntoa(((struct sockaddr_in *)&_res.nsaddr_list[0])->sin_addr);
+      CStdString ns = inet_ntoa(((struct sockaddr_in *)&_res.nsaddr_list[i])->sin_addr);
       result.push_back(ns);
    }
 #endif


### PR DESCRIPTION
This fixes the bug where Primary and Secondary DNS nameservers are the same under the Linux version.
