### PR TITLE
Reserve xml size if available

### DIFF
--- a/xbmc/utils/XBMCTinyXML.cpp
+++ b/xbmc/utils/XBMCTinyXML.cpp
@@ -76,7 +76,8 @@ bool CXBMCTinyXML::LoadFile(const CStdString &_filename, TiXmlEncoding encoding)
   location.Clear();
 
   CStdString data;
-  data.reserve(8 * 1000);
+  int64_t fileSize = file.GetLength();
+  data.reserve( (fileSize > 0) ? fileSize : 8*1000);
   StreamIn(&file, &data);
   file.Close();
 


### PR DESCRIPTION
If we know the file size, then reserving the correct amount is best.
