### PR TITLE
CHG: CEC: Assign the "Setup menu" button to "Title", i.e. context menu

### DIFF
--- a/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
+++ b/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
@@ -863,6 +863,9 @@ void CPeripheralCecAdapter::PushCecKeypress(const cec_keypress &key)
     PushCecKeypress(xbmcKey);
     break;
   case CEC_USER_CONTROL_CODE_SETUP_MENU:
+    xbmcKey.iButton = XINPUT_IR_REMOTE_TITLE;
+    PushCecKeypress(xbmcKey);
+    break;
   case CEC_USER_CONTROL_CODE_CONTENTS_MENU:
   case CEC_USER_CONTROL_CODE_FAVORITE_MENU:
   case CEC_USER_CONTROL_CODE_ROOT_MENU:


### PR DESCRIPTION
On my Sony Bravia remote, I have both a "Home" button and a "Options" button.
Nowadays, both generate a "menu" action, i.e. previous menu.

It is obviously unfortunate in this case. I don't know if this patch would have undesirable effects on other setup...

Note that "rpi-cecd" generated the correct actions... 
