### PR TITLE
[peripherals/udev] fixed do not close fd we got from udev and a race condition

### DIFF
--- a/xbmc/peripherals/bus/linux/PeripheralBusUSBLibUdev.cpp
+++ b/xbmc/peripherals/bus/linux/PeripheralBusUSBLibUdev.cpp
@@ -218,17 +218,15 @@ void CPeripheralBusUSB::Process(void)
 void CPeripheralBusUSB::Clear(void)
 {
   StopThread(false);
-  if (m_udevFd != -1)
-    close(m_udevFd);
 
-  udev_unref(m_udev);
+  m_udevFd = -1;
 
   CPeripheralBus::Clear();
 }
 
 bool CPeripheralBusUSB::WaitForUpdate()
 {
-  if (!m_udevFd)
+  if (m_udevFd == -1)
     return false;
 
   /* poll for udev changes */

--- a/xbmc/peripherals/bus/linux/PeripheralBusUSBLibUdev.cpp
+++ b/xbmc/peripherals/bus/linux/PeripheralBusUSBLibUdev.cpp
@@ -85,7 +85,6 @@ CPeripheralBusUSB::CPeripheralBusUSB(CPeripherals *manager) :
 
   m_udev          = NULL;
   m_udevMon       = NULL;
-  m_udevFd        = -1;
 
   if (!(m_udev = udev_new()))
   {
@@ -96,9 +95,8 @@ CPeripheralBusUSB::CPeripheralBusUSB(CPeripherals *manager) :
   /* set up a devices monitor that listen for any device change */
   m_udevMon = udev_monitor_new_from_netlink(m_udev, "udev");
   udev_monitor_enable_receiving(m_udevMon);
-  m_udevFd = udev_monitor_get_fd(m_udevMon);
 
-  CLog::Log(LOGDEBUG, "%s - initialised udev monitor: %d", __FUNCTION__, m_udevFd);
+  CLog::Log(LOGDEBUG, "%s - initialised udev monitor", __FUNCTION__);
 }
 
 CPeripheralBusUSB::~CPeripheralBusUSB(void)
@@ -219,15 +217,18 @@ void CPeripheralBusUSB::Clear(void)
 {
   StopThread(false);
 
-  m_udevFd = -1;
-
   CPeripheralBus::Clear();
 }
 
 bool CPeripheralBusUSB::WaitForUpdate()
 {
+  int m_udevFd = udev_monitor_get_fd(m_udevMon);
+
   if (m_udevFd < 0)
+  {
+    CLog::Log(LOGERROR, "%s - get udev monitor", __FUNCTION__);
     return false;
+  }
 
   /* poll for udev changes */
   struct pollfd pollFd;

--- a/xbmc/peripherals/bus/linux/PeripheralBusUSBLibUdev.cpp
+++ b/xbmc/peripherals/bus/linux/PeripheralBusUSBLibUdev.cpp
@@ -226,7 +226,7 @@ void CPeripheralBusUSB::Clear(void)
 
 bool CPeripheralBusUSB::WaitForUpdate()
 {
-  if (m_udevFd == -1)
+  if (m_udevFd < 0)
     return false;
 
   /* poll for udev changes */

--- a/xbmc/peripherals/bus/linux/PeripheralBusUSBLibUdev.h
+++ b/xbmc/peripherals/bus/linux/PeripheralBusUSBLibUdev.h
@@ -51,6 +51,5 @@ namespace PERIPHERALS
 
     struct udev *        m_udev;
     struct udev_monitor *m_udevMon;
-    int                  m_udevFd;
   };
 }


### PR DESCRIPTION
StopThread doesn't wait. On fast machines we do not see the race, on slow machines it can be that the tread is still running while we already unref a object from udev.
