### PR TITLE
Fix CircularCache::Open

### DIFF
--- a/xbmc/filesystem/CircularCache.cpp
+++ b/xbmc/filesystem/CircularCache.cpp
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2005-2008 Team XBMC
+ *      Copyright (C) 2005-2012 Team XBMC
  *      http://www.xbmc.org
  *
  *  This Program is free software; you can redistribute it and/or modify
@@ -51,7 +51,7 @@ int CCircularCache::Open()
 {
 #ifdef _WIN32
   m_handle = CreateFileMapping(INVALID_HANDLE_VALUE, NULL, PAGE_READWRITE, 0, m_size, NULL);
-  if(m_handle == INVALID_HANDLE_VALUE)
+  if(m_handle == NULL)
     return CACHE_RC_ERROR;
   m_buf = (uint8_t*)MapViewOfFile(m_handle, FILE_MAP_ALL_ACCESS, 0, 0, 0);
 #else


### PR DESCRIPTION
CreateFileMapping returns "NULL" on error (not "INVALID_HANDLE_VALUE")
