### PR TITLE
[Confluence] Addon shortcuts update

### DIFF
--- a/addons/skin.confluence/720p/IncludesHomeMenuItems.xml
+++ b/addons/skin.confluence/720p/IncludesHomeMenuItems.xml
@@ -289,35 +289,35 @@
 	<include name="HomeAddonItemsVideos">
 		<item>
 			<label>$INFO[system.addontitle(Skin.String(HomeVideosButton1))]</label>
-			<onclick>RunAddon($INFO[Skin.String(HomeVideosButton1)])</onclick>
+			<onclick>ActivateWindow(Videos,plugin://$INFO[Skin.String(HomeVideosButton1)])</onclick>
 			<icon>$INFO[system.addonicon(Skin.String(HomeVideosButton1))]</icon>
 			<thumb>-</thumb>
 			<visible>!IsEmpty(Skin.String(HomeVideosButton1))</visible>
 		</item>
 		<item>
 			<label>$INFO[system.addontitle(Skin.String(HomeVideosButton2))]</label>
-			<onclick>RunAddon($INFO[Skin.String(HomeVideosButton2)])</onclick>
+			<onclick>ActivateWindow(Videos,plugin://$INFO[Skin.String(HomeVideosButton2)])</onclick>
 			<icon>$INFO[system.addonicon(Skin.String(HomeVideosButton2))]</icon>
 			<thumb>-</thumb>
 			<visible>!IsEmpty(Skin.String(HomeVideosButton2))</visible>
 		</item>
 		<item>
 			<label>$INFO[system.addontitle(Skin.String(HomeVideosButton3))]</label>
-			<onclick>RunAddon($INFO[Skin.String(HomeVideosButton3)])</onclick>
+			<onclick>ActivateWindow(Videos,plugin://$INFO[Skin.String(HomeVideosButton3)])</onclick>
 			<icon>$INFO[system.addonicon(Skin.String(HomeVideosButton3))]</icon>
 			<thumb>-</thumb>
 			<visible>!IsEmpty(Skin.String(HomeVideosButton3))</visible>
 		</item>
 		<item>
 			<label>$INFO[system.addontitle(Skin.String(HomeVideosButton4))]</label>
-			<onclick>RunAddon($INFO[Skin.String(HomeVideosButton4)])</onclick>
+			<onclick>ActivateWindow(Videos,plugin://$INFO[Skin.String(HomeVideosButton4)])</onclick>
 			<icon>$INFO[system.addonicon(Skin.String(HomeVideosButton4))]</icon>
 			<thumb>-</thumb>
 			<visible>!IsEmpty(Skin.String(HomeVideosButton4))</visible>
 		</item>
 		<item>
 			<label>$INFO[system.addontitle(Skin.String(HomeVideosButton5))]</label>
-			<onclick>RunAddon($INFO[Skin.String(HomeVideosButton5)])</onclick>
+			<onclick>ActivateWindow(Videos,plugin://$INFO[Skin.String(HomeVideosButton5)])</onclick>
 			<icon>$INFO[system.addonicon(Skin.String(HomeVideosButton5))]</icon>
 			<thumb>-</thumb>
 			<visible>!IsEmpty(Skin.String(HomeVideosButton5))</visible>
@@ -326,35 +326,35 @@
 	<include name="HomeAddonItemsMusic">
 		<item>
 			<label>$INFO[system.addontitle(Skin.String(HomeMusicButton1))]</label>
-			<onclick>RunAddon($INFO[Skin.String(HomeMusicButton1)])</onclick>
+			<onclick>ActivateWindow(Music,plugin://$INFO[Skin.String(HomeMusicButton1)])</onclick>
 			<icon>$INFO[system.addonicon(Skin.String(HomeMusicButton1))]</icon>
 			<thumb>-</thumb>
 			<visible>!IsEmpty(Skin.String(HomeMusicButton1))</visible>
 		</item>
 		<item>
 			<label>$INFO[system.addontitle(Skin.String(HomeMusicButton2))]</label>
-			<onclick>RunAddon($INFO[Skin.String(HomeMusicButton2)])</onclick>
+			<onclick>ActivateWindow(Music,plugin://$INFO[Skin.String(HomeMusicButton2)])</onclick>
 			<icon>$INFO[system.addonicon(Skin.String(HomeMusicButton2))]</icon>
 			<thumb>-</thumb>
 			<visible>!IsEmpty(Skin.String(HomeMusicButton2))</visible>
 		</item>
 		<item>
 			<label>$INFO[system.addontitle(Skin.String(HomeMusicButton3))]</label>
-			<onclick>RunAddon($INFO[Skin.String(HomeMusicButton3)])</onclick>
+			<onclick>ActivateWindow(Music,plugin://$INFO[Skin.String(HomeMusicButton3)])</onclick>
 			<icon>$INFO[system.addonicon(Skin.String(HomeMusicButton3))]</icon>
 			<thumb>-</thumb>
 			<visible>!IsEmpty(Skin.String(HomeMusicButton3))</visible>
 		</item>
 		<item>
 			<label>$INFO[system.addontitle(Skin.String(HomeMusicButton4))]</label>
-			<onclick>RunAddon($INFO[Skin.String(HomeMusicButton4)])</onclick>
+			<onclick>ActivateWindow(Music,plugin://$INFO[Skin.String(HomeMusicButton4)])</onclick>
 			<icon>$INFO[system.addonicon(Skin.String(HomeMusicButton4))]</icon>
 			<thumb>-</thumb>
 			<visible>!IsEmpty(Skin.String(HomeMusicButton4))</visible>
 		</item>
 		<item>
 			<label>$INFO[system.addontitle(Skin.String(HomeMusicButton5))]</label>
-			<onclick>RunAddon($INFO[Skin.String(HomeMusicButton5)])</onclick>
+			<onclick>ActivateWindow(Music,plugin://$INFO[Skin.String(HomeMusicButton5)])</onclick>
 			<icon>$INFO[system.addonicon(Skin.String(HomeMusicButton5))]</icon>
 			<thumb>-</thumb>
 			<visible>!IsEmpty(Skin.String(HomeMusicButton5))</visible>
@@ -363,35 +363,35 @@
 	<include name="HomeAddonItemsPictures">
 		<item>
 			<label>$INFO[system.addontitle(Skin.String(HomePictureButton1))]</label>
-			<onclick>RunAddon($INFO[Skin.String(HomePictureButton1)])</onclick>
+			<onclick>ActivateWindow(Pictures,plugin://$INFO[Skin.String(HomePictureButton1)])</onclick>
 			<icon>$INFO[system.addonicon(Skin.String(HomePictureButton1))]</icon>
 			<thumb>-</thumb>
 			<visible>!IsEmpty(Skin.String(HomePictureButton1))</visible>
 		</item>
 		<item>
 			<label>$INFO[system.addontitle(Skin.String(HomePictureButton2))]</label>
-			<onclick>RunAddon($INFO[Skin.String(HomePictureButton2)])</onclick>
+			<onclick>ActivateWindow(Pictures,plugin://$INFO[Skin.String(HomePictureButton2)])</onclick>
 			<icon>$INFO[system.addonicon(Skin.String(HomePictureButton2))]</icon>
 			<thumb>-</thumb>
 			<visible>!IsEmpty(Skin.String(HomePictureButton2))</visible>
 		</item>
 		<item>
 			<label>$INFO[system.addontitle(Skin.String(HomePictureButton3))]</label>
-			<onclick>RunAddon($INFO[Skin.String(HomePictureButton3)])</onclick>
+			<onclick>ActivateWindow(Pictures,plugin://$INFO[Skin.String(HomePictureButton3)])</onclick>
 			<icon>$INFO[system.addonicon(Skin.String(HomePictureButton3))]</icon>
 			<thumb>-</thumb>
 			<visible>!IsEmpty(Skin.String(HomePictureButton3))</visible>
 		</item>
 		<item>
 			<label>$INFO[system.addontitle(Skin.String(HomePictureButton4))]</label>
-			<onclick>RunAddon($INFO[Skin.String(HomePictureButton4)])</onclick>
+			<onclick>ActivateWindow(Pictures,plugin://$INFO[Skin.String(HomePictureButton4)])</onclick>
 			<icon>$INFO[system.addonicon(Skin.String(HomePictureButton4))]</icon>
 			<thumb>-</thumb>
 			<visible>!IsEmpty(Skin.String(HomePictureButton4))</visible>
 		</item>
 		<item>
 			<label>$INFO[system.addontitle(Skin.String(HomePictureButton5))]</label>
-			<onclick>RunAddon($INFO[Skin.String(HomePictureButton5)])</onclick>
+			<onclick>ActivateWindow(Pictures,plugin://$INFO[Skin.String(HomePictureButton5)])</onclick>
 			<icon>$INFO[system.addonicon(Skin.String(HomePictureButton5))]</icon>
 			<thumb>-</thumb>
 			<visible>!IsEmpty(Skin.String(HomePictureButton5))</visible>
@@ -400,35 +400,35 @@
 	<include name="HomeAddonItemsPrograms">
 		<item>
 			<label>$INFO[system.addontitle(Skin.String(HomeProgramButton1))]</label>
-			<onclick>RunAddon($INFO[Skin.String(HomeProgramButton1)])</onclick>
+			<onclick>ActivateWindow(Programs,plugin://$INFO[Skin.String(HomeProgramButton1)])</onclick>
 			<icon>$INFO[system.addonicon(Skin.String(HomeProgramButton1))]</icon>
 			<thumb>-</thumb>
 			<visible>!IsEmpty(Skin.String(HomeProgramButton1))</visible>
 		</item>
 		<item>
 			<label>$INFO[system.addontitle(Skin.String(HomeProgramButton2))]</label>
-			<onclick>RunAddon($INFO[Skin.String(HomeProgramButton2)])</onclick>
+			<onclick>ActivateWindow(Programs,plugin://$INFO[Skin.String(HomeProgramButton2)])</onclick>
 			<icon>$INFO[system.addonicon(Skin.String(HomeProgramButton2))]</icon>
 			<thumb>-</thumb>
 			<visible>!IsEmpty(Skin.String(HomeProgramButton2))</visible>
 		</item>
 		<item>
 			<label>$INFO[system.addontitle(Skin.String(HomeProgramButton3))]</label>
-			<onclick>RunAddon($INFO[Skin.String(HomeProgramButton3)])</onclick>
+			<onclick>ActivateWindow(Programs,plugin://$INFO[Skin.String(HomeProgramButton3)])</onclick>
 			<icon>$INFO[system.addonicon(Skin.String(HomeProgramButton3))]</icon>
 			<thumb>-</thumb>
 			<visible>!IsEmpty(Skin.String(HomeProgramButton3))</visible>
 		</item>
 		<item>
 			<label>$INFO[system.addontitle(Skin.String(HomeProgramButton4))]</label>
-			<onclick>RunAddon($INFO[Skin.String(HomeProgramButton4)])</onclick>
+			<onclick>ActivateWindow(Programs,plugin://$INFO[Skin.String(HomeProgramButton4)])</onclick>
 			<icon>$INFO[system.addonicon(Skin.String(HomeProgramButton4))]</icon>
 			<thumb>-</thumb>
 			<visible>!IsEmpty(Skin.String(HomeProgramButton4))</visible>
 		</item>
 		<item>
 			<label>$INFO[system.addontitle(Skin.String(HomeProgramButton5))]</label>
-			<onclick>RunAddon($INFO[Skin.String(HomeProgramButton5)])</onclick>
+			<onclick>ActivateWindow(Programs,plugin://$INFO[Skin.String(HomeProgramButton5)])</onclick>
 			<icon>$INFO[system.addonicon(Skin.String(HomeProgramButton5))]</icon>
 			<thumb>-</thumb>
 			<visible>!IsEmpty(Skin.String(HomeProgramButton5))</visible>


### PR DESCRIPTION
Addon shortcuts should act like going to addons sub-menu and selecting the addon for the particular menu it is assigned to (so that views work properly when an addon has more than 1 provides type).
