### PR TITLE
DVDPlayer: Prevent using of uninitialized variable

### DIFF
--- a/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamNavigator.cpp
+++ b/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamNavigator.cpp
@@ -263,7 +263,7 @@ int CDVDInputStreamNavigator::ProcessBlock(BYTE* dest_buffer, int* read)
   if (!m_dvdnav) return -1;
 
   int result;
-  int len;
+  int len = 2048;
   int iNavresult = NAVRESULT_NOP;
 
   // m_tempbuffer will be used for anything that isn't a normal data block


### PR DESCRIPTION
Uninitialized "len" is used in memcpy when "m_holdmode" is "HOLDMODE_SKIP" and "m_lastevent" is "DVDNAV_BLOCK_OK"
