### PR TITLE
[GUI] Small fixes

### DIFF
--- a/xbmc/guilib/GUIFontTTFDX.cpp
+++ b/xbmc/guilib/GUIFontTTFDX.cpp
@@ -181,7 +181,7 @@ CBaseTexture* CGUIFontTTFDX::ReallocTexture(unsigned int& newHeight)
   // There might be data to copy from the previous texture
   if ((newSpeedupTexture && m_speedupTexture) || (newTexture && m_texture))
   {
-    if (m_speedupTexture)
+    if (m_speedupTexture && newSpeedupTexture)
     {
       m_speedupTexture->GetSurfaceLevel(0, &pSource);
       newSpeedupTexture->GetSurfaceLevel(0, &pTarget);

--- a/xbmc/guilib/TextureManager.cpp
+++ b/xbmc/guilib/TextureManager.cpp
@@ -393,7 +393,7 @@ int CGUITextureManager::Load(const CStdString& strTextureName, bool checkBundleO
   int width = 0, height = 0;
   if (bundle >= 0)
   {
-    if (FAILED(m_TexBundle[bundle].LoadTexture(strTextureName, &pTexture, width, height)))
+    if (!m_TexBundle[bundle].LoadTexture(strTextureName, &pTexture, width, height))
     {
       CLog::Log(LOGERROR, "Texture manager unable to load bundled file: %s", strTextureName.c_str());
       return 0;


### PR DESCRIPTION
Two fixes: 
- wrongly use "FAILED" on bool result ("FAILED" macro checks for "<0", while for "bool" we should check for "== 0")
- dereferencing possibly NULL pointer (if memory allocation failed)
