### PR TITLE
[AE] Add AE::Suspend()/Resume() for external players and power saving

### DIFF
--- a/xbmc/ApplicationMessenger.cpp
+++ b/xbmc/ApplicationMessenger.cpp
@@ -41,6 +41,7 @@
 #include "GUIInfoManager.h"
 #include "utils/Splash.h"
 #include "cores/VideoRenderers/RenderManager.h"
+#include "cores/AudioEngine/AEFactory.h"
 #include "music/tags/MusicInfoTag.h"
 
 #include "powermanagement/PowerManager.h"
@@ -511,11 +512,22 @@ case TMSG_POWERDOWN:
       break;
 
     case TMSG_EXECUTE_OS:
+      /* Suspend AE temporarily so exclusive or hog-mode sinks */
+      /* don't block external player's access to audio device  */
+      if (!CAEFactory::Suspend())
+      {
+        CLog::Log(LOGNOTICE, __FUNCTION__, "Failed to suspend AudioEngine before launching external program");
+      }
 #if defined( _LINUX) && !defined(TARGET_DARWIN)
       CUtil::RunCommandLine(pMsg->strParam.c_str(), (pMsg->dwParam1 == 1));
 #elif defined(_WIN32)
       CWIN32Util::XBMCShellExecute(pMsg->strParam.c_str(), (pMsg->dwParam1 == 1));
 #endif
+      /* Resume AE processing of XBMC native audio */
+      if (!CAEFactory::Resume())
+      {
+        CLog::Log(LOGFATAL, __FUNCTION__, "Failed to restart AudioEngine after return from external player");
+      }
       break;
 
     case TMSG_HTTPAPI:

--- a/xbmc/cores/AudioEngine/AEFactory.cpp
+++ b/xbmc/cores/AudioEngine/AEFactory.cpp
@@ -130,6 +130,22 @@ bool CAEFactory::StartEngine()
   return false;
 }
 
+bool CAEFactory::Suspend()
+{
+  if(AE)
+    return AE->Suspend();
+
+  return false;
+}
+
+bool CAEFactory::Resume()
+{
+  if(AE)
+    return AE->Resume();
+
+  return false;
+}
+
 /* engine wrapping */
 IAESound *CAEFactory::MakeSound(const std::string &file)
 {

--- a/xbmc/cores/AudioEngine/AEFactory.cpp
+++ b/xbmc/cores/AudioEngine/AEFactory.cpp
@@ -146,6 +146,15 @@ bool CAEFactory::Resume()
   return false;
 }
 
+bool CAEFactory::IsSuspended()
+{
+  if(AE)
+    return AE->IsSuspended();
+
+  /* No engine to process audio */
+  return true;
+}
+
 /* engine wrapping */
 IAESound *CAEFactory::MakeSound(const std::string &file)
 {

--- a/xbmc/cores/AudioEngine/AEFactory.h
+++ b/xbmc/cores/AudioEngine/AEFactory.h
@@ -38,6 +38,8 @@ public:
   static bool LoadEngine();
   static void UnLoadEngine();
   static bool StartEngine();
+  static bool Suspend(); /** Suspends output and de-initializes output sink - used for external players or power saving */
+  static bool Resume(); /** Resumes output after Suspend - re-initializes sink */
   /* wrapp engine interface */
   static IAESound *MakeSound(const std::string &file);
   static void FreeSound(IAESound *sound);

--- a/xbmc/cores/AudioEngine/AEFactory.h
+++ b/xbmc/cores/AudioEngine/AEFactory.h
@@ -40,7 +40,8 @@ public:
   static bool StartEngine();
   static bool Suspend(); /** Suspends output and de-initializes output sink - used for external players or power saving */
   static bool Resume(); /** Resumes output after Suspend - re-initializes sink */
-  /* wrapp engine interface */
+  static bool IsSuspended(); /** Returns true if output has been suspended */
+  /* wrap engine interface */
   static IAESound *MakeSound(const std::string &file);
   static void FreeSound(IAESound *sound);
   static void SetSoundMode(const int mode);

--- a/xbmc/cores/AudioEngine/Encoders/AEEncoderFFmpeg.cpp
+++ b/xbmc/cores/AudioEngine/Encoders/AEEncoderFFmpeg.cpp
@@ -207,7 +207,7 @@ bool CAEEncoderFFmpeg::Initialize(AEAudioFormat &format)
   m_OutputRatio   = (double)m_NeededFrames / m_OutputSize;
   m_SampleRateMul = 1.0 / (double)m_CodecCtx->sample_rate;
 
-  CLog::Log(LOGERROR, "CAEEncoderFFmpeg::Initialize - %s encoder ready", m_CodecName.c_str());
+  CLog::Log(LOGNOTICE, "CAEEncoderFFmpeg::Initialize - %s encoder ready", m_CodecName.c_str());
   return true;
 }
 

--- a/xbmc/cores/AudioEngine/Engines/CoreAudio/CoreAudioAE.cpp
+++ b/xbmc/cores/AudioEngine/Engines/CoreAudio/CoreAudioAE.cpp
@@ -620,6 +620,23 @@ void CCoreAudioAE::Stop()
   HAL->Stop();
 }
 
+bool CCoreAudioAE::Suspend()
+{
+  /* TODO: add implementation in CA. See SoftAE for example. Code should */
+  /* release exclusive or hog mode and sleep each time packets would     */
+  /* normally be written to sink if m_isSuspended = true. False return   */
+  /* here will simply generate a debug log entry in externalplayer.cpp   */
+
+  return false;
+}
+
+bool CCoreAudio::Resume()
+{
+  /* TODO: see comments in Suspend() above */
+
+  return false;
+}
+
 //***********************************************************************************************
 // Rendering Methods
 //***********************************************************************************************

--- a/xbmc/cores/AudioEngine/Engines/CoreAudio/CoreAudioAE.cpp
+++ b/xbmc/cores/AudioEngine/Engines/CoreAudio/CoreAudioAE.cpp
@@ -395,6 +395,11 @@ bool CCoreAudioAE::IsMuted()
   return m_muted;
 }
 
+bool CCoreAudioAE::IsSuspended()
+{
+  return m_isSuspended;
+}
+
 void CCoreAudioAE::SetSoundMode(const int mode)
 {
   m_soundMode = mode;

--- a/xbmc/cores/AudioEngine/Engines/CoreAudio/CoreAudioAE.h
+++ b/xbmc/cores/AudioEngine/Engines/CoreAudio/CoreAudioAE.h
@@ -167,4 +167,5 @@ private:
   bool              m_muted;
   int               m_soundMode;
   bool              m_streamsPlaying;
+  bool              m_isSuspended;
 };

--- a/xbmc/cores/AudioEngine/Engines/CoreAudio/CoreAudioAE.h
+++ b/xbmc/cores/AudioEngine/Engines/CoreAudio/CoreAudioAE.h
@@ -75,6 +75,9 @@ public:
   virtual bool      Initialize();
   virtual void      OnSettingsChange(std::string setting);
 
+  virtual bool      Suspend(); /* Suspend output and de-initialize "hog-mode" sink for external players and power savings */
+  virtual bool      Resume();  /* Resume ouput and re-initialize sink after Suspend() above */
+
   unsigned int      GetSampleRate();
   unsigned int      GetEncodedSampleRate();
   CAEChannelInfo    GetChannelLayout();

--- a/xbmc/cores/AudioEngine/Engines/CoreAudio/CoreAudioAE.h
+++ b/xbmc/cores/AudioEngine/Engines/CoreAudio/CoreAudioAE.h
@@ -77,6 +77,7 @@ public:
 
   virtual bool      Suspend(); /* Suspend output and de-initialize "hog-mode" sink for external players and power savings */
   virtual bool      Resume();  /* Resume ouput and re-initialize sink after Suspend() above */
+  virtual bool      IsSuspended(); /* Returns true if in Suspend mode - used by players */
 
   unsigned int      GetSampleRate();
   unsigned int      GetEncodedSampleRate();

--- a/xbmc/cores/AudioEngine/Engines/PulseAE/PulseAE.cpp
+++ b/xbmc/cores/AudioEngine/Engines/PulseAE/PulseAE.cpp
@@ -151,6 +151,23 @@ bool CPulseAE::Initialize()
   return true;
 }
 
+bool CPulseAE::Suspend()
+{
+  /* TODO: add implementation here. See SoftAE for example. Code should */
+  /* release exclusive or hog mode and sleep each time packets would    */
+  /* normally be written to sink if m_isSuspended = true. False return  */
+  /* here will simply generate a debug log entry in externalplayer.cpp  */
+
+  return false;
+}
+
+bool CPulse::Resume()
+{
+  /* TODO: see comments in Suspend() above */
+
+  return false;
+}
+
 void CPulseAE::OnSettingsChange(std::string setting)
 {
 }

--- a/xbmc/cores/AudioEngine/Engines/PulseAE/PulseAE.h
+++ b/xbmc/cores/AudioEngine/Engines/PulseAE/PulseAE.h
@@ -46,6 +46,9 @@ public:
   virtual bool  Initialize      ();
   virtual void  OnSettingsChange(std::string setting);
 
+  virtual bool  Suspend(); /* Suspend output and de-initialize exclusive sink for external players and power savings */
+  virtual bool  Resume();  /* Resume ouput and re-initialize sink after Suspend() above */
+
   virtual float GetVolume();
   virtual void  SetVolume(float volume);
 

--- a/xbmc/cores/AudioEngine/Engines/SoftAE/SoftAE.cpp
+++ b/xbmc/cores/AudioEngine/Engines/SoftAE/SoftAE.cpp
@@ -852,6 +852,11 @@ double CSoftAE::GetCacheTotal()
   return total;
 }
 
+bool CSoftAE::IsSuspended()
+{
+  return m_isSuspended;
+}
+
 float CSoftAE::GetVolume()
 {
   return m_volume;

--- a/xbmc/cores/AudioEngine/Engines/SoftAE/SoftAE.cpp
+++ b/xbmc/cores/AudioEngine/Engines/SoftAE/SoftAE.cpp
@@ -672,7 +672,7 @@ void CSoftAE::PauseStream(CSoftAEStream *stream)
   stream->m_paused = true;
   streamLock.Leave();
 
-  OpenSink();
+  InternalOpenSink();
 }
 
 void CSoftAE::ResumeStream(CSoftAEStream *stream)
@@ -683,7 +683,7 @@ void CSoftAE::ResumeStream(CSoftAEStream *stream)
   streamLock.Leave();
 
   m_streamsPlaying = true;
-  OpenSink();
+  InternalOpenSink();
 }
 
 void CSoftAE::Stop()
@@ -721,7 +721,7 @@ IAEStream *CSoftAE::MakeStream(enum AEDataFormat dataFormat, unsigned int sample
   m_newStreams.push_back(stream);
   streamLock.Leave();
 
-  OpenSink();
+  InternalOpenSink();
   return stream;
 }
 

--- a/xbmc/cores/AudioEngine/Engines/SoftAE/SoftAE.cpp
+++ b/xbmc/cores/AudioEngine/Engines/SoftAE/SoftAE.cpp
@@ -43,6 +43,18 @@
 
 using namespace std;
 
+/* Define idle wait time based on platform in milliseconds */
+/* Higher wait times reduce thread CPU overhead when in    */
+/* idle or Suspend() modes                                 */
+#if defined (TARGET_WINDOWS) || defined (TARGET_LINUX) || \
+  defined (TARGET_DARWIN_OSX) || defined (TARGET_FREEBSD)
+#define SOFTAE_IDLE_WAIT_MSEC 50  // shorter sleep for HTPC's
+#elif defined (TARGET_RASPBERRY_PI) || defined (TARGET_ANDROID)
+#define SOFTAE_IDLE_WAIT_MSEC 100 // longer for R_PI and Android
+#else
+#define SOFTAE_IDLE_WAIT_MSEC 100 // catchall for undefined platforms
+#endif
+
 CSoftAE::CSoftAE():
   m_thread             (NULL        ),
   m_audiophile         (true        ),
@@ -908,7 +920,7 @@ void CSoftAE::Run()
         delete m_sink;
         m_sink = NULL;
       }
-      m_wake.WaitMSec(50);
+      m_wake.WaitMSec(SOFTAE_IDLE_WAIT_MSEC);
     }
 
     bool restart = false;

--- a/xbmc/cores/AudioEngine/Engines/SoftAE/SoftAE.h
+++ b/xbmc/cores/AudioEngine/Engines/SoftAE/SoftAE.h
@@ -57,6 +57,8 @@ public:
 
   virtual void   Run();
   virtual void   Stop();
+  virtual bool   Suspend();
+  virtual bool   Resume();
   virtual double GetDelay();
 
   virtual float GetVolume();
@@ -128,7 +130,7 @@ private:
   bool m_stereoUpmix;
 
   /* internal vars */
-  bool             m_running, m_reOpen;
+  bool             m_running, m_reOpen, m_isSuspended;
   CEvent           m_reOpenEvent;
   CEvent           m_wake;
 

--- a/xbmc/cores/AudioEngine/Engines/SoftAE/SoftAE.h
+++ b/xbmc/cores/AudioEngine/Engines/SoftAE/SoftAE.h
@@ -59,6 +59,7 @@ public:
   virtual void   Stop();
   virtual bool   Suspend();
   virtual bool   Resume();
+  virtual bool   IsSuspended();
   virtual double GetDelay();
 
   virtual float GetVolume();

--- a/xbmc/cores/AudioEngine/Interfaces/AE.h
+++ b/xbmc/cores/AudioEngine/Interfaces/AE.h
@@ -62,6 +62,20 @@ public:
    * Called when the application needs to terminate the engine
    */
   virtual void Shutdown() { }
+
+  /**
+   * Suspends output and de-initializes sink
+   * Used to avoid conflicts with external players or to reduce power consumption
+   * @return True if successful
+   */
+  virtual bool Suspend() = 0;
+
+  /**
+   * Resumes output and re-initializes sink
+   * Used to resume output from Suspend() state above
+   * @return True if successful
+   */
+  virtual bool Resume() = 0;
   
   /**
    * Callback to alert the AudioEngine of setting changes

--- a/xbmc/cores/AudioEngine/Interfaces/AE.h
+++ b/xbmc/cores/AudioEngine/Interfaces/AE.h
@@ -76,6 +76,14 @@ public:
    * @return True if successful
    */
   virtual bool Resume() = 0;
+
+  /**
+   * Get the current Suspend() state
+   * Used by players to determine if audio is being processed
+   * Default is true so players drop audio or pause if engine unloaded
+   * @return True if processing suspended
+   */
+  virtual bool IsSuspended() {return true;}
   
   /**
    * Callback to alert the AudioEngine of setting changes

--- a/xbmc/cores/AudioEngine/Interfaces/AEStream.h
+++ b/xbmc/cores/AudioEngine/Interfaces/AEStream.h
@@ -108,7 +108,7 @@ public:
   /**
    * Returns true if the is stream has finished draining
    */
-  virtual bool IsDrained() { return true; } /*FIXME: this should = 0 when done */
+  virtual bool IsDrained() = 0;
   
   /**
    * Flush all buffers dropping the audio data

--- a/xbmc/cores/AudioEngine/Sinks/AESinkWASAPI.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkWASAPI.cpp
@@ -127,7 +127,6 @@ CAESinkWASAPI::CAESinkWASAPI() :
   m_needDataEvent(0),
   m_pDevice(NULL),
   m_initialized(false),
-  m_isSuspended(false),
   m_running(false),
   m_encodedFormat(AE_FMT_INVALID),
   m_encodedChannels(0),
@@ -279,10 +278,6 @@ void CAESinkWASAPI::Deinitialize()
 {
   if (!m_initialized)
     return;
-
-  m_isSuspended = true;
-
-  Sleep((DWORD)(m_sinkLatency * 1100)); //TODO: remove when Drain() added
 
   if (m_running)
     m_pAudioClient->Stop();

--- a/xbmc/cores/AudioEngine/Sinks/AESinkWASAPI.h
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkWASAPI.h
@@ -72,7 +72,6 @@ private:
     bool                m_running;
     bool                m_initialized;
     bool                m_isDirty;        /* sink output failed - needs re-init or new device */
-    bool                m_isSuspended;    /* sink has been flagged to suspend output and shut down */
 
     unsigned int        m_uiBufferLen;    /* wasapi endpoint buffer size, in frames */
     double              m_avgTimeWaiting; /* time between next buffer of data from SoftAE and driver call for data */

--- a/xbmc/cores/AudioEngine/Sinks/AESinkWASAPI.h
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkWASAPI.h
@@ -72,6 +72,7 @@ private:
     bool                m_running;
     bool                m_initialized;
     bool                m_isDirty;        /* sink output failed - needs re-init or new device */
+    bool                m_isSuspended;    /* sink has been flagged to suspend output and shut down */
 
     unsigned int        m_uiBufferLen;    /* wasapi endpoint buffer size, in frames */
     double              m_avgTimeWaiting; /* time between next buffer of data from SoftAE and driver call for data */

--- a/xbmc/cores/ExternalPlayer/ExternalPlayer.cpp
+++ b/xbmc/cores/ExternalPlayer/ExternalPlayer.cpp
@@ -37,6 +37,7 @@
 #include "utils/XMLUtils.h"
 #include "utils/TimeUtils.h"
 #include "utils/log.h"
+#include "cores/AudioEngine/AEFactory.h"
 #if defined(_WIN32)
   #include "Windows.h"
   #ifdef HAS_IRSERVERSUITE
@@ -287,6 +288,15 @@ void CExternalPlayer::Process()
 #endif
 
   m_playbackStartTime = XbmcThreads::SystemClockMillis();
+
+  /* Suspend AE temporarily so exclusive or hog-mode sinks */
+  /* don't block external player's access to audio device  */
+  if (!CAEFactory::Suspend())
+  {
+    CLog::Log(LOGNOTICE, __FUNCTION__, "Failed to suspend AudioEngine before launching external player");
+  }
+
+
   BOOL ret = TRUE;
 #if defined(_WIN32)
   ret = ExecuteAppW32(strFName.c_str(),strFArgs.c_str());
@@ -348,6 +358,12 @@ void CExternalPlayer::Process()
     SetCursorPos(m_xPos,m_yPos);
   }
 #endif
+
+  /* Resume AE processing of XBMC native audio */
+  if (!CAEFactory::Resume())
+  {
+    CLog::Log(LOGFATAL, __FUNCTION__, "Failed to restart AudioEngine after return from external player");
+  }
 
   // We don't want to come back to an active screensaver
   g_application.ResetScreenSaver();

--- a/xbmc/cores/dvdplayer/DVDPlayerAudio.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayerAudio.cpp
@@ -31,6 +31,7 @@
 #include "utils/log.h"
 #include "utils/TimeUtils.h"
 #include "utils/MathUtils.h"
+#include "cores/AudioEngine/AEFactory.h"
 #include "cores/AudioEngine/Utils/AEUtil.h"
 
 #include <sstream>
@@ -252,8 +253,10 @@ void CDVDPlayerAudio::OpenStream( CDVDStreamInfo &hints, CDVDAudioCodec* codec )
 
 void CDVDPlayerAudio::CloseStream(bool bWaitForBuffers)
 {
+  bool bWait = bWaitForBuffers && m_speed > 0 && !CAEFactory::IsSuspended();
+
   // wait until buffers are empty
-  if (bWaitForBuffers && m_speed > 0) m_messageQueue.WaitUntilEmpty();
+  if (bWait) m_messageQueue.WaitUntilEmpty();
 
   // send abort message to the audio queue
   m_messageQueue.Abort();
@@ -265,7 +268,7 @@ void CDVDPlayerAudio::CloseStream(bool bWaitForBuffers)
 
   // destroy audio device
   CLog::Log(LOGNOTICE, "Closing audio device");
-  if (bWaitForBuffers && m_speed > 0)
+  if (bWait)
   {
     m_bStop = false;
     m_dvdAudio.Drain();
@@ -552,7 +555,8 @@ void CDVDPlayerAudio::Process()
   while (!m_bStop)
   {
     //Don't let anybody mess with our global variables
-    result = DecodeFrame(audioframe, m_speed > DVD_PLAYSPEED_NORMAL || m_speed < 0); // blocks if no audio is available, but leaves critical section before doing so
+    result = DecodeFrame(audioframe, m_speed > DVD_PLAYSPEED_NORMAL || m_speed < 0 ||
+                         CAEFactory::IsSuspended()); // blocks if no audio is available, but leaves critical section before doing so
 
     if( result & DECODE_FLAG_ERROR )
     {

--- a/xbmc/cores/paplayer/PAPlayer.cpp
+++ b/xbmc/cores/paplayer/PAPlayer.cpp
@@ -155,7 +155,7 @@ void PAPlayer::SoftStop(bool wait/* = false */, bool close/* = true */)
     lock.Enter();
 
     /* be sure they have faded out */
-    while(wait)
+    while(wait && !CAEFactory::IsSuspended())
     {
       wait = false;
       for(StreamList::iterator itt = m_streams.begin(); itt != m_streams.end(); ++itt)

--- a/xbmc/interfaces/python/xbmcmodule/xbmcmodule.cpp
+++ b/xbmc/interfaces/python/xbmcmodule/xbmcmodule.cpp
@@ -57,6 +57,7 @@
 #include "pyrendercapture.h"
 #include "monitor.h"
 #include "URL.h"
+#include "cores/AudioEngine/AEFactory.h"
 
 // include for constants
 #include "pyutil.h"
@@ -985,7 +986,37 @@ namespace PYXBMC
 
     return Py_BuildValue((char*)"b", ret);
   }
+  
+  // AudioSuspend() method
+  PyDoc_STRVAR(audioSuspend__doc__,
+    "AudioSuspend() -- Suspend Audio engine.\n"
+    "\n"
+    "example:\n"
+    "  xbmc.AudioSuspend()");
+  
+  PyObject* XBMC_AudioSuspend(PyObject *self)
+  {  
+    CAEFactory::Suspend();
+    
+    Py_INCREF(Py_None);
+    return Py_None;
+  }
 
+  // AudioResume() method
+  PyDoc_STRVAR(audioResume__doc__,
+    "AudioResume() -- Resume Audio engine.\n"
+    "\n"
+    "example:\n"
+    "  xbmc.AudioResume()");
+  
+  PyObject* XBMC_AudioResume(PyObject *self)
+  { 
+    CAEFactory::Resume();
+    
+    Py_INCREF(Py_None);
+    return Py_None;
+  }
+  
   // define c functions to be used in python here
   PyMethodDef xbmcMethods[] = {
     {(char*)"output", (PyCFunction)XBMC_Output, METH_VARARGS|METH_KEYWORDS, output__doc__},
@@ -1033,6 +1064,9 @@ namespace PYXBMC
     {(char*)"skinHasImage", (PyCFunction)XBMC_SkinHasImage, METH_VARARGS|METH_KEYWORDS, skinHasImage__doc__},
 
     {(char*)"startServer", (PyCFunction)XBMC_StartServer, METH_VARARGS|METH_KEYWORDS, startServer__doc__},
+    
+    {(char*)"AudioSuspend", (PyCFunction)XBMC_AudioSuspend, METH_VARARGS, audioSuspend__doc__},
+    {(char*)"AudioResume", (PyCFunction)XBMC_AudioResume, METH_VARARGS, audioResume__doc__},
 
     {NULL, NULL, 0, NULL}
   };

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -55,6 +55,7 @@ void CAdvancedSettings::Initialize()
   m_audioForceDirectSound = false;
   m_audioAudiophile = false;
   m_allChannelStereo = false;
+  m_streamSilence = false;
   m_audioSinkBufferDurationMsec = 50;
 
   //default hold time of 25 ms, this allows a 20 hertz sine to pass undistorted
@@ -371,6 +372,7 @@ void CAdvancedSettings::ParseSettingsFile(const CStdString &file)
     XMLUtils::GetBoolean(pElement, "forceDirectSound", m_audioForceDirectSound);
     XMLUtils::GetBoolean(pElement, "audiophile", m_audioAudiophile);
     XMLUtils::GetBoolean(pElement, "allchannelstereo", m_allChannelStereo);
+    XMLUtils::GetBoolean(pElement, "streamsilence", m_streamSilence);
     XMLUtils::GetString(pElement, "transcodeto", m_audioTranscodeTo);
     XMLUtils::GetInt(pElement, "audiosinkbufferdurationmsec", m_audioSinkBufferDurationMsec);
 

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -109,6 +109,7 @@ class CAdvancedSettings
     bool m_audioForceDirectSound;
     bool m_audioAudiophile;
     bool m_allChannelStereo;
+    bool m_streamSilence;
     int m_audioSinkBufferDurationMsec;
     CStdString m_audioTranscodeTo;
     float m_limiterHold;


### PR DESCRIPTION
This PR addresses a regression post-AE where external players could not access the audio device while some sinks were used, including WASAPI and CA in hog-mode.

AE maintains a continuous stream of output at all times, eliminating the "silent-stream" bug and receiver drop-outs, as well as reducing sink re-openings.

In exclusive modes this interferes with external players or system sounds.

This PR addresses the issue by implementing Suspend() and Resume() functions which halt active output with quiet sleeps and de-initialize the sink to cede access to the audio device.

It is currently only utilized by externalplayer.cpp in this context, but can equally be used to reduce power consumption if called during hibernation code.

Routines are implemented in SoftAE, but only fleshed-out in CA and Pulse engines.

Fixes Trac #13246
