### PR TITLE
fix xbmc.desktop file syntax

### DIFF
--- a/tools/Linux/xbmc.desktop
+++ b/tools/Linux/xbmc.desktop
@@ -14,9 +14,9 @@ Actions=Fullscreen;Standalone
 [Desktop Action Fullscreen]
 Name=Open in fullscreen
 Exec=xbmc -fs
-OnlyShowIn=Unity
+OnlyShowIn=Unity;
 
 [Desktop Action Standalone]
 Name=Open in standalone mode
-Exect=xbmc --standalone
-OnlyShowIn=Unity
+Exec=xbmc --standalone
+OnlyShowIn=Unity;


### PR DESCRIPTION
"OnlyShowIn" values must have a semicolon as a trailing character, and correct the spelling of "Exec".

This allows the desktop file to be validated and installed using the "desktop-file-install" utility.
