### PR TITLE
Dvdplayer fixes re. VTS_CHANGE

### DIFF
--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -1107,6 +1107,9 @@ void CDVDPlayer::Process()
       if(next == CDVDInputStream::NEXTSTREAM_OPEN)
       {
         SAFE_DELETE(m_pDemuxer);
+        m_CurrentAudio.stream = NULL;
+        m_CurrentVideo.stream = NULL;
+        m_CurrentSubtitle.stream = NULL;
         continue;
       }
 
@@ -3134,6 +3137,8 @@ int CDVDPlayer::OnDVDNavResult(void* pData, int iMessage)
 
         m_SelectionStreams.Clear(STREAM_NONE, STREAM_SOURCE_NAV);
         m_SelectionStreams.Update(m_pInputStream, m_pDemuxer);
+
+        return NAVRESULT_HOLD;
       }
       break;
     case DVDNAV_CELL_CHANGE:


### PR DESCRIPTION
fix for DVD playback containing VTS_CHANGE starting with stills. I had one dvd that starts like this and one time out of two, it would not even start playing... Some others jump back to a still menu after playback of the main movie, and the menu stays "black"... This fixes the issue.
