### PR TITLE
[UnrarXLib] check validity of ui ptr before access

### DIFF
--- a/lib/UnrarXLib/rar.cpp
+++ b/lib/UnrarXLib/rar.cpp
@@ -203,9 +203,12 @@ int urarlib_get(char *rarfile, char *targetPath, char *fileToExtract, char *libp
           if (bShowProgress)
           {
             pExtract->GetDataIO().m_pDlgProgress = (CGUIDialogProgress*)g_windowManager.GetWindow(WINDOW_DIALOG_PROGRESS);
-            pExtract->GetDataIO().m_pDlgProgress->SetHeading(fileToExtract);
-            pExtract->GetDataIO().m_pDlgProgress->SetCanCancel(false);
-            pExtract->GetDataIO().m_pDlgProgress->StartModal();
+            if (pExtract->GetDataIO().m_pDlgProgress)
+            {
+              pExtract->GetDataIO().m_pDlgProgress->SetHeading(fileToExtract);
+              pExtract->GetDataIO().m_pDlgProgress->SetCanCancel(false);
+              pExtract->GetDataIO().m_pDlgProgress->StartModal();
+            }
           }
 
           int64_t iOff=0;
@@ -234,7 +237,8 @@ int urarlib_get(char *rarfile, char *targetPath, char *fileToExtract, char *libp
             
             if (pExtract->GetDataIO().bQuit) 
             {
-              pExtract->GetDataIO().m_pDlgProgress->Close();
+              if (pExtract->GetDataIO().m_pDlgProgress)
+                pExtract->GetDataIO().m_pDlgProgress->Close();
               bRes = 2;
               break;
             }
@@ -269,7 +273,8 @@ int urarlib_get(char *rarfile, char *targetPath, char *fileToExtract, char *libp
             pExtract->GetDataIO().m_pDlgProgress->ShowProgressBar(false);
         }
         if (bShowProgress)
-          pExtract->GetDataIO().m_pDlgProgress->Close();
+          if (pExtract->GetDataIO().m_pDlgProgress)
+            pExtract->GetDataIO().m_pDlgProgress->Close();
       }
     }
   }


### PR DESCRIPTION
Check that pExtract->GetDataIO().m_pDlgProgress is valid
before accessing it.
