### PR TITLE
fix possible crash in CDVDAudioCodecFFmpeg::Dispose()

### DIFF
--- a/xbmc/cores/dvdplayer/DVDCodecs/Audio/DVDAudioCodecFFmpeg.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Audio/DVDAudioCodecFFmpeg.cpp
@@ -43,6 +43,8 @@ CDVDAudioCodecFFmpeg::CDVDAudioCodecFFmpeg() : CDVDAudioCodec()
   m_layout = 0;
   
   m_bLpcmMode = false;
+
+  m_pFrame1 = NULL;
 }
 
 CDVDAudioCodecFFmpeg::~CDVDAudioCodecFFmpeg()


### PR DESCRIPTION
fixes this issue: https://github.com/opdenkamp/xbmc/issues/618
