### PR TITLE
[dvdplayer] fix DVD menu that doesn't update anymore at CELL CHANGE

### DIFF
--- a/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamNavigator.cpp
+++ b/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamNavigator.cpp
@@ -313,6 +313,7 @@ int CDVDInputStreamNavigator::ProcessBlock(BYTE* dest_buffer, int* read)
         // user input to make menus and other interactive stills work.
         // A length of 0xff means an indefinite still which has to be skipped
         // indirectly by some user interaction.
+        m_holdmode = HOLDMODE_NONE;
         iNavresult = m_pDVDPlayer->OnDVDNavResult(buf, DVDNAV_STILL_FRAME);
 
         /* if user didn't care for action, just skip it */


### PR DESCRIPTION
This PR deals with DVD (still) menus that have navigation issues:
- certain highlights not displaying when entering or returning to menu
- menu stuck when trying to navigate main menu -> submenu or back to main menu

Here are two examples of event sequences that lead to the menu issue:
1. DVDNAV_WAIT - DVDNAV_STILL_FRAME (several times) - DVDNAV_NOP - DVDNAV_VTS_CHANGE - DVDNAV_CELL_CHANGE
2. DVDNAV_WAIT - DVDNAV_STILL_FRAME (several times) - DVDNAV_HOP_CHANNEL - DVDNAV_CELL_CHANGE

In each of these sequences, there's no data block read before the CELL CHANGE, that would reset the hold mode to none. So the DVDNAV_CELL_CHANGE is called without holding, thus causing the issue.

In order to solve the issue the best solution seems to be to handle the DVDNAV_STILL_FRAME event like a data block (from the hold-mode perspective), so set holdmode to NONE when receiving DVDNAV_STILL_FRAME.
