### PR TITLE
[gui] Stack selection window - set focus immediately to avoid repeated keypress

### DIFF
--- a/xbmc/video/dialogs/GUIDialogFileStacking.cpp
+++ b/xbmc/video/dialogs/GUIDialogFileStacking.cpp
@@ -53,19 +53,6 @@ bool CGUIDialogFileStacking::OnMessage(CGUIMessage& message)
     {
       CGUIDialog::OnMessage(message);
       m_iSelectedFile = -1;
-      if (GetControl(STACK_LIST))
-      { // have the new stack list instead - fill it up
-        SendMessage(GUI_MSG_LABEL_RESET, GetID(), STACK_LIST);
-        for (int i = 0; i < m_iNumberOfFiles; i++)
-        {
-          CStdString label;
-          label.Format(g_localizeStrings.Get(23051).c_str(), i+1);
-          CFileItemPtr item(new CFileItem(label));
-          m_stackItems->Add(item);
-        }
-        CGUIMessage msg(GUI_MSG_LABEL_BIND, GetID(), STACK_LIST, 0, 0, m_stackItems);
-        OnMessage(msg);
-      }
       return true;
     }
     break;
@@ -96,4 +83,23 @@ int CGUIDialogFileStacking::GetSelectedFile() const
 void CGUIDialogFileStacking::SetNumberOfFiles(int iFiles)
 {
   m_iNumberOfFiles = iFiles;
+}
+
+void CGUIDialogFileStacking::OnInitWindow()
+{
+  if (GetControl(STACK_LIST))
+  { 
+    // have the new stack list instead - fill it up
+    SendMessage(GUI_MSG_LABEL_RESET, GetID(), STACK_LIST);
+    for (int i = 0; i < m_iNumberOfFiles; i++)
+    {
+      CStdString label;
+      label.Format(g_localizeStrings.Get(23051).c_str(), i+1);
+      CFileItemPtr item(new CFileItem(label));
+      m_stackItems->Add(item);
+    }
+    CGUIMessage msg(GUI_MSG_LABEL_BIND, GetID(), STACK_LIST, 0, 0, m_stackItems);
+    OnMessage(msg);
+  }
+  CGUIDialog::OnInitWindow();
 }

--- a/xbmc/video/dialogs/GUIDialogFileStacking.h
+++ b/xbmc/video/dialogs/GUIDialogFileStacking.h
@@ -36,6 +36,7 @@ public:
   int GetSelectedFile() const;
   void SetNumberOfFiles(int iFiles);
 protected:
+  virtual void OnInitWindow();
   int m_iSelectedFile;
   int m_iNumberOfFiles;
   CFileItemList* m_stackItems;


### PR DESCRIPTION
this simple PR improves usability of the part selection window by focusing immediately on the correct control. 

Without this, a user must press a key prior to actually using it: press one key to focus, then one or more keys to make selection. This is silly, so focus programmatically!
