### PR TITLE
[Feature] Loading/Play external audio tracks

### DIFF
--- a/xbmc/Util.h
+++ b/xbmc/Util.h
@@ -88,6 +88,8 @@ public:
   static int ScanArchiveForSubtitles( const CStdString& strArchivePath, const CStdString& strMovieFileNameNoExt, std::vector<CStdString>& vecSubtitles );
   static bool FindVobSubPair( const std::vector<CStdString>& vecSubtitles, const CStdString& strIdxPath, CStdString& strSubPath );
   static bool IsVobSub( const std::vector<CStdString>& vecSubtitles, const CStdString& strSubPath );  
+  static void ScanForExternalAudio(const CStdString& strMovie, std::vector<CStdString>& vecAudio );
+  static int ScanArchiveForAudio( const CStdString& strArchivePath, const CStdString& strMovieFileNameNoExt, std::vector<CStdString>& vecAudio );
   static int64_t ToInt64(uint32_t high, uint32_t low);
   static CStdString GetNextFilename(const CStdString &fn_template, int max);
   static CStdString GetNextPathname(const CStdString &path_template, int max);

--- a/xbmc/cores/dvdplayer/DVDFileInfo.cpp
+++ b/xbmc/cores/dvdplayer/DVDFileInfo.cpp
@@ -49,6 +49,7 @@
 #include "DllSwScale.h"
 #include "filesystem/File.h"
 #include "TextureCache.h"
+#include "Util.h"
 
 
 bool CDVDFileInfo::GetFileDuration(const CStdString &path, int& duration)
@@ -136,7 +137,7 @@ bool CDVDFileInfo::ExtractThumb(const CStdString &strPath, CTextureDetails &deta
   }
 
   if (pStreamDetails)
-    DemuxerToStreamDetails(pInputStream, pDemuxer, *pStreamDetails, strPath);
+    DemuxerToStreamDetails(pInputStream, pDemuxer, *pStreamDetails, true, strPath);
 
   CDemuxStream* pStream = NULL;
   int nVideoStream = -1;
@@ -315,7 +316,7 @@ bool CDVDFileInfo::GetFileStreamDetails(CFileItem *pItem)
   CDVDDemux *pDemuxer = CDVDFactoryDemuxer::CreateDemuxer(pInputStream);
   if (pDemuxer)
   {
-    bool retVal = DemuxerToStreamDetails(pInputStream, pDemuxer, pItem->GetVideoInfoTag()->m_streamDetails, strFileNameAndPath);
+    bool retVal = DemuxerToStreamDetails(pInputStream, pDemuxer, pItem->GetVideoInfoTag()->m_streamDetails, true, strFileNameAndPath);
     delete pDemuxer;
     delete pInputStream;
     return retVal;
@@ -327,8 +328,40 @@ bool CDVDFileInfo::GetFileStreamDetails(CFileItem *pItem)
   }
 }
 
+bool CDVDFileInfo::DemuxerToStreamDetails(CDVDInputStream *pInputStream, CDVDDemux *pDemux, std::vector<CDVDDemux*> m_extDemuxer, CStreamDetails &details, const CStdString &path)
+{
+  bool retVal = false;
+  details.Reset();
+  retVal = DemuxerToStreamDetails(pInputStream, pDemux, details, false, path);
+
+  if(! retVal)
+    return false;
+
+  // process external audio streams
+  for (unsigned int i = 0; i < m_extDemuxer.size(); i++)
+  {
+    if (m_extDemuxer[i])
+    {
+      CDemuxStream *stream = m_extDemuxer[i]->GetStream(0);
+
+      if (stream->type == STREAM_AUDIO)
+      {
+        CStreamDetailAudio *p = new CStreamDetailAudio();
+        p->m_iChannels = ((CDemuxStreamAudio *)stream)->iChannels;
+        if (strlen(stream->language) > 0)
+          p->m_strLanguage = stream->language;
+        pDemux->GetStreamCodecName(0, p->m_strCodec);
+        details.AddStream(p);
+        retVal = true;
+      }
+    }
+  }
+
+  details.DetermineBestStreams();
+  return retVal;
+}
 /* returns true if details have been added */
-bool CDVDFileInfo::DemuxerToStreamDetails(CDVDInputStream *pInputStream, CDVDDemux *pDemux, CStreamDetails &details, const CStdString &path)
+bool CDVDFileInfo::DemuxerToStreamDetails(CDVDInputStream *pInputStream, CDVDDemux *pDemux, CStreamDetails &details, bool handleExternalAudio, const CStdString &path)
 {
   bool retVal = false;
   details.Reset();
@@ -390,6 +423,16 @@ bool CDVDFileInfo::DemuxerToStreamDetails(CDVDInputStream *pInputStream, CDVDDem
     }
   }  /* for iStream */
 
+  CStdString video_path;
+  if (path.empty())
+    video_path = pInputStream->GetFileName();
+  else
+    video_path = path;
+
+  // include external audio tracks
+  if (handleExternalAudio)
+    retVal |= AddExternalAudioToDetails(video_path, details);
+
   details.DetermineBestStreams();
 #ifdef HAVE_LIBBLURAY
   // correct bluray runtime. we need the duration from the input stream, not the demuxer.
@@ -404,3 +447,76 @@ bool CDVDFileInfo::DemuxerToStreamDetails(CDVDInputStream *pInputStream, CDVDDem
   return retVal;
 }
 
+bool CDVDFileInfo::AddExternalAudioToDetails(const CStdString &path, CStreamDetails &details)
+{
+  bool retVal = false;
+  // find any available external audio track
+  std::vector<CStdString> filenames;
+  CUtil::ScanForExternalAudio( path, filenames );
+  for(unsigned int i=0;i<filenames.size();i++)
+  {
+    CDVDInputStream* ext_pInputStream;
+    CFileItem ext_item = CFileItem(filenames[i]);
+    CStdString ext_mimeType = ext_item.GetMimeType();
+    ext_pInputStream = CDVDFactoryInputStream::CreateInputStream(NULL, filenames[i], ext_mimeType);
+    if(ext_pInputStream == NULL)
+    {
+      CLog::Log(LOGERROR, "CDVDPlayer::OpenInputStream - unable to create input stream for external audio file [%s]", filenames[i].c_str());
+      continue;
+    }
+    else
+      ext_pInputStream->SetFileItem(ext_item);
+
+    if (!ext_pInputStream->Open(filenames[i].c_str(), ext_mimeType))
+    {
+      CLog::Log(LOGERROR, "CDVDPlayer::OpenInputStream - error opening  external audio file [%s]", filenames[i].c_str());
+      continue;
+    }
+    CDVDDemux* extDemuxer = NULL;
+    try
+    {
+      int attempts = 10;
+      while(attempts-- > 0)
+      {
+        extDemuxer = CDVDFactoryDemuxer::CreateDemuxer(ext_pInputStream);
+        if(!extDemuxer && ext_pInputStream->NextStream() != CDVDInputStream::NEXTSTREAM_NONE)
+        {
+          CLog::Log(LOGDEBUG, "%s - New stream available from input, retry open", __FUNCTION__);
+          continue;
+        }
+        break;
+      }
+
+      if(!extDemuxer)
+      {
+        CLog::Log(LOGERROR, "%s - Error creating external audio demuxer for file %s", __FUNCTION__, ext_pInputStream->GetFileName().c_str());
+        continue;
+      }
+
+    }
+    catch(...)
+    {
+      CLog::Log(LOGERROR, "%s - Exception thrown when opening external audio demuxer for file %s", __FUNCTION__, ext_pInputStream->GetFileName().c_str());
+      continue;
+    }
+    if(extDemuxer)
+    {
+      //filter strange external audio files
+      if(extDemuxer->GetNrOfStreams() > 1 || extDemuxer->GetStream(0)->type != STREAM_AUDIO)
+        continue;
+
+      CDemuxStream *stream = extDemuxer->GetStream(0);
+      if (stream->type == STREAM_AUDIO)
+      {
+        CStreamDetailAudio *p = new CStreamDetailAudio();
+        p->m_iChannels = ((CDemuxStreamAudio *)stream)->iChannels;
+        if (strlen(stream->language) > 0)
+          p->m_strLanguage = stream->language;
+        extDemuxer->GetStreamCodecName(0, p->m_strCodec);
+        details.AddStream(p);
+        retVal = true;
+      }
+    }
+  }
+  return retVal;
+}

--- a/xbmc/cores/dvdplayer/DVDFileInfo.h
+++ b/xbmc/cores/dvdplayer/DVDFileInfo.h
@@ -36,6 +36,8 @@ public:
   // Probe the files streams and store the info in the VideoInfoTag
   static bool GetFileStreamDetails(CFileItem *pItem);
   static bool DemuxerToStreamDetails(CDVDInputStream* pInputStream, CDVDDemux *pDemux, CStreamDetails &details, const CStdString &path = "");
-
+  static bool DemuxerToStreamDetails(CDVDInputStream* pInputStream, CDVDDemux *pDemux, std::vector<CDVDDemux*> m_extDemuxer, CStreamDetails &details, const CStdString &path = "");
+  static bool DemuxerToStreamDetails(CDVDInputStream* pInputStream, CDVDDemux *pDemux, CStreamDetails &details, bool handleExternalAudio, const CStdString &path = "");
   static bool GetFileDuration(const CStdString &path, int &duration);
+  static bool AddExternalAudioToDetails(const CStdString &path, CStreamDetails &details);
 };

--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -410,6 +410,8 @@ CDVDPlayer::CDVDPlayer(IPlayerCallback& callback)
   m_pSubtitleDemuxer = NULL;
   m_pInputStream = NULL;
 
+  m_extInputStreams.clear();
+
   m_dvd.Clear();
   m_State.Clear();
   m_EdlAutoSkipMarkers.Clear();
@@ -542,6 +544,56 @@ void CDVDPlayer::OnStartup()
 
   g_dvdPerformanceCounter.EnableMainPerformance(this);
   CUtil::ClearTempFonts();
+}
+
+bool CDVDPlayer::OpenExternalAudioInputStreams()
+{
+  if (!m_pInputStream)
+    return false;
+
+  for(unsigned int i = 0; i < m_extInputStreams.size(); i++)
+  {
+    if(m_extInputStreams[i])
+      SAFE_DELETE(m_extInputStreams[i]);
+  }
+  
+  // find any available external audio track
+  if (!m_pInputStream->IsStreamType(DVDSTREAM_TYPE_DVD)
+    &&  !m_pInputStream->IsStreamType(DVDSTREAM_TYPE_TV)
+    &&  !m_pInputStream->IsStreamType(DVDSTREAM_TYPE_HTSP))
+  {
+    std::vector<CStdString> filenames;
+    CUtil::ScanForExternalAudio( m_filename, filenames );
+
+    if (!filenames.empty())
+      CLog::Log(LOGNOTICE, "Creating InputStreams for external audio files");
+
+    for(unsigned int i=0;i<filenames.size();i++)
+    {
+      CDVDInputStream* ext_pInputStream = NULL;
+      CFileItem ext_item = CFileItem(filenames[i]);
+      CStdString ext_mimeType = ext_item.GetMimeType();
+      ext_pInputStream = CDVDFactoryInputStream::CreateInputStream(this, filenames[i], ext_mimeType);
+      if(ext_pInputStream == NULL)
+      {
+        CLog::Log(LOGERROR, "CDVDPlayer::OpenInputStream - unable to create input stream for external audio file [%s]", filenames[i].c_str());
+        continue;
+      }
+      else
+        ext_pInputStream->SetFileItem(ext_item);
+
+      if (!ext_pInputStream->Open(filenames[i].c_str(), ext_mimeType))
+      {
+        CLog::Log(LOGERROR, "CDVDPlayer::OpenInputStream - error opening  external audio file [%s]", filenames[i].c_str());
+        continue;
+      }
+      m_extInputStreams.push_back(ext_pInputStream);
+    }
+  }
+  if(m_extInputStreams.size() == 0)
+    return false;
+  else
+    return true;
 }
 
 bool CDVDPlayer::OpenInputStream()
@@ -918,6 +970,8 @@ void CDVDPlayer::Process()
     return;
   }
 
+  OpenExternalAudioInputStreams();
+
   if(m_pInputStream->IsStreamType(DVDSTREAM_TYPE_DVD))
   {
     CLog::Log(LOGNOTICE, "DVDPlayer: playing a dvd with menu's");
@@ -1042,6 +1096,7 @@ void CDVDPlayer::Process()
         m_bAbortRequest = true;
         break;
       }
+      OpenExternalAudioInputStreams();
     }
 
     // should we open a new demuxer?
@@ -1966,6 +2021,16 @@ void CDVDPlayer::OnExit()
     }
     m_pInputStream = NULL;
 
+    for(unsigned int i = 0; i < m_extInputStreams.size(); i++)
+    {
+      if(m_extInputStreams[i])
+      {
+        CLog::Log(LOGNOTICE, "CDVDPlayer::OnExit() deleting external input stream");
+        delete m_extInputStreams[i];
+      }
+    }
+    m_extInputStreams.clear();
+
     // clean up all selection streams
     m_SelectionStreams.Clear(STREAM_NONE, STREAM_SOURCE_NONE);
 
@@ -1977,6 +2042,7 @@ void CDVDPlayer::OnExit()
     CLog::Log(LOGERROR, "%s - Exception thrown when trying to close down player, memory leak will follow", __FUNCTION__);
     m_pInputStream = NULL;
     m_pDemuxer = NULL;
+    m_extInputStreams.clear();
   }
 
   m_bStop = true;

--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -2348,8 +2348,8 @@ void CDVDPlayer::HandleMessages()
         {
           if (m_extAudio && m_extDemuxer[m_extAudioId])
           {
-            if(!m_extDemuxer[m_extAudioId]->SeekChapter(msg.GetChapter(), &start))
-              CLog::Log(LOGDEBUG, "failed to seek chpters on external audio demuxer: %d, success", time);
+            if(!m_extDemuxer[m_extAudioId]->SeekTime(DVD_TIME_TO_MSEC(start)))
+              CLog::Log(LOGDEBUG, "failed to seek to chapter %d on external audio demuxer, time: %d", msg.GetChapter(), DVD_TIME_TO_MSEC(start));
           }
 
           FlushBuffers(false, start, true);

--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -88,6 +88,10 @@
 using namespace std;
 using namespace PVR;
 
+// remove
+int rate = 50;
+// remove
+
 void CSelectionStreams::Clear(StreamType type, StreamSource source)
 {
   CSingleLock lock(m_section);
@@ -392,6 +396,15 @@ void CSelectionStreams::Update(CDVDInputStream* input, CDVDDemux* demuxer)
   }
 }
 
+/* Upate the selection streams with data from external audio files*/
+void CSelectionStreams::UpdateExtAudio(CDVDInputStream* input, CDVDDemux* ext_demuxer)
+{
+  int last = m_Streams.size();
+  Update(input, ext_demuxer);
+  if (last < m_Streams.size())
+    m_Streams[last].id =last;
+}
+
 CDVDPlayer::CDVDPlayer(IPlayerCallback& callback)
     : IPlayer(callback),
       CThread("CDVDPlayer"),
@@ -410,7 +423,10 @@ CDVDPlayer::CDVDPlayer(IPlayerCallback& callback)
   m_pSubtitleDemuxer = NULL;
   m_pInputStream = NULL;
 
+  m_extDemuxer.clear();
   m_extInputStreams.clear();
+  m_extAudio = false;
+  m_extAudioOffset = 0;
 
   m_dvd.Clear();
   m_State.Clear();
@@ -507,6 +523,12 @@ bool CDVDPlayer::CloseFile()
   // tell demuxer to abort
   if(m_pDemuxer)
     m_pDemuxer->Abort();
+
+  for(unsigned int i = 0; i < m_extDemuxer.size(); i++)
+  {
+    if(m_extDemuxer[i])
+      m_extDemuxer[i]->Abort();
+  }
 
   if(m_pSubtitleDemuxer)
     m_pSubtitleDemuxer->Abort();
@@ -684,6 +706,94 @@ bool CDVDPlayer::OpenInputStream()
   return true;
 }
 
+bool CDVDPlayer::OpenExternalAudioDemuxStreams()
+{
+  if(!m_pDemuxer)
+    return false;
+
+  for(unsigned int i = 0; i < m_extDemuxer.size(); i++)
+  {
+    if(m_extDemuxer[i])
+      SAFE_DELETE(m_extDemuxer[i]);
+  }
+
+  m_extAudio = false;
+
+  CLog::Log(LOGNOTICE, "Creating external audio demuxers");
+
+  // store the offset for proper access to the external streams
+  m_extAudioOffset = m_SelectionStreams.Count(STREAM_NONE);
+
+  // add any available external audio
+  vector<CDVDInputStream*>::iterator iter = m_extInputStreams.begin();
+  while (iter != m_extInputStreams.end())
+  {
+    CDVDInputStream* extInput = *iter;
+    if(extInput)
+    {
+      CDVDDemux* extDemuxer = NULL;
+      try
+      {
+        int attempts = 10;
+        while(!m_bStop && attempts-- > 0)
+        {
+          extDemuxer = CDVDFactoryDemuxer::CreateDemuxer(extInput);
+          if(!extDemuxer && extInput->NextStream() != CDVDInputStream::NEXTSTREAM_NONE)
+          {
+            CLog::Log(LOGDEBUG, "%s - New stream available from input, retry open", __FUNCTION__);
+            continue;
+          }
+          break;
+        }
+
+        if(!extDemuxer)
+        {
+          CLog::Log(LOGERROR, "%s - Error creating external audio demuxer for file %s", __FUNCTION__, extInput->GetFileName().c_str());
+          
+          // delete invalid InputStreams
+          iter = m_extInputStreams.erase(iter);
+          SAFE_DELETE(extInput);
+          continue;
+        }
+
+      }
+      catch(...)
+      {
+        CLog::Log(LOGERROR, "%s - Exception thrown when opening external audio demuxer for file %s", __FUNCTION__, extInput->GetFileName().c_str());
+        continue;
+      }
+      if(extDemuxer)
+      {
+        //filter strange external audio files
+        if(extDemuxer->GetNrOfStreams() > 1 || extDemuxer->GetStream(0)->type != STREAM_AUDIO)
+        {
+          iter = m_extInputStreams.erase(iter);
+          SAFE_DELETE(extInput);
+          delete extDemuxer;
+          continue;
+        }
+
+        m_SelectionStreams.UpdateExtAudio(extInput,extDemuxer);
+
+        int64_t len = extInput->GetLength();
+        int64_t tim = extDemuxer->GetStreamLength();
+        extInput->SetReadRate(len * 1000 / tim);
+        m_extDemuxer.push_back(extDemuxer);
+      }
+      ++iter;
+    }
+    else
+    {
+      iter = m_extInputStreams.erase(iter);
+      SAFE_DELETE(extInput);
+    }
+  }
+  if(m_extDemuxer.size() == 0)
+    return false;
+  else
+    return true;
+}
+
 bool CDVDPlayer::OpenDemuxStream()
 {
   if(m_pDemuxer)
@@ -799,7 +909,39 @@ void CDVDPlayer::OpenDefaultStreams(bool reset)
     CloseTeletextStream(true);
 }
 
-bool CDVDPlayer::ReadPacket(DemuxPacket*& packet, CDemuxStream*& stream)
+bool CDVDPlayer::ReadExternalAudioPacket(DemuxPacket*& packet, CDemuxStream*& stream)
+{
+  if(m_extAudio && m_extDemuxer[m_extAudioId])
+    packet = m_extDemuxer[m_extAudioId]->Read();
+
+  if(packet)
+  {
+    UpdateCorrection(packet, m_offset_pts);
+    if(packet->iStreamId < 0)
+      return true;
+
+    stream =  m_extDemuxer[m_extAudioId]->GetStream(packet->iStreamId);
+    if (!stream)
+    {
+      CLog::Log(LOGERROR, "%s - Error demux packet doesn't belong to a valid stream", __FUNCTION__);
+      return false;
+    }
+    if(stream->source == STREAM_SOURCE_NONE)
+    {
+      /*I'm not sure what to do here, any ideas?
+      Maybe replace the corresponding SelectionStream?
+      */
+
+      //m_SelectionStreams.Clear(STREAM_NONE, STREAM_SOURCE_DEMUX);
+      //m_SelectionStreams.m_Streams.erase(m_SelectionStreams.m_Streams.begin() + (m_CurrentAudio.id));
+      //m_SelectionStreams.UpdateExtAudio(m_extInputStreams[streamId], m_extDemuxer[streamId]);
+    }
+    return true;
+  }
+  return false;
+}
+
+bool CDVDPlayer::ReadPacket(DemuxPacket*& packet, CDemuxStream*& stream, bool onlyVideo)
 {
 
   // check if we should read from subtitle demuxer
@@ -832,6 +974,28 @@ bool CDVDPlayer::ReadPacket(DemuxPacket*& packet, CDemuxStream*& stream)
   // read a data frame from stream.
   if(m_pDemuxer)
     packet = m_pDemuxer->Read();
+
+
+  if(onlyVideo)
+  {
+    StreamType st;
+    CDemuxStream* s;
+    if (packet)
+    {
+      s = m_pDemuxer->GetStream(packet->iStreamId);
+      st = s->type;
+      while (st == STREAM_AUDIO && m_extAudio && packet)
+      {
+        packet = m_pDemuxer->Read();
+        if (packet)
+        {
+          s = m_pDemuxer->GetStream(packet->iStreamId);
+          st = s->type;
+        }
+        else break;
+      }
+    }
+  }
 
   if(packet)
   {
@@ -892,7 +1056,11 @@ bool CDVDPlayer::IsValidStream(CCurrentStream& stream)
   }
   if(source == STREAM_SOURCE_DEMUX)
   {
-    CDemuxStream* st = m_pDemuxer->GetStream(stream.id);
+    CDemuxStream* st;
+    if(m_extAudio && stream.type == STREAM_AUDIO)
+      st = m_extDemuxer[m_extAudioId]->GetStream(0);
+    else
+      st = m_pDemuxer->GetStream(stream.id);
     if(st == NULL || st->disabled)
       return false;
     if(st->type != stream.type)
@@ -992,6 +1160,9 @@ void CDVDPlayer::Process()
     return;
   }
 
+  if (!m_extInputStreams.empty())
+    OpenExternalAudioDemuxStreams();
+
   // allow renderer to switch to fullscreen if requested
   m_dvdPlayerVideo.EnableFullscreen(m_PlayerOptions.fullscreen);
 
@@ -1061,6 +1232,17 @@ void CDVDPlayer::Process()
       else
         CLog::Log(LOGDEBUG, "%s - failed to start subtitle demuxing from: %d", __FUNCTION__, starttime);
     }
+
+    for (unsigned int i = 0; i < m_extDemuxer.size(); i++)
+    {
+      if(m_extDemuxer[i])
+      {
+        if(m_extDemuxer[i]->SeekTime(starttime, false, &startpts))
+          CLog::Log(LOGDEBUG, "%s - starting external audio file demuxer from: %d", __FUNCTION__, starttime);
+        else
+          CLog::Log(LOGDEBUG, "%s - failed to start external audio file demuxing from: %d", __FUNCTION__, starttime);
+      }
+    }
   }
 
   // make sure all selected stream have data on startup
@@ -1114,6 +1296,8 @@ void CDVDPlayer::Process()
         break;
       }
 
+      if (!m_extInputStreams.empty())
+        OpenExternalAudioDemuxStreams();
       OpenDefaultStreams();
 
       if (CachePVRStream())
@@ -1150,7 +1334,16 @@ void CDVDPlayer::Process()
 
     DemuxPacket* pPacket = NULL;
     CDemuxStream *pStream = NULL;
-    ReadPacket(pPacket, pStream);
+
+    if (m_CurrentAudio.id != -1 && m_extAudio)
+      {
+        if(m_dvdPlayerAudio.GetLevel() < rate)
+          ReadExternalAudioPacket(pPacket, pStream);
+        else
+          ReadPacket(pPacket, pStream, true);
+    }
+    else
+      ReadPacket(pPacket, pStream, false);
     if (pPacket && !pStream)
     {
       /* probably a empty packet, just free it and move on */
@@ -1191,6 +1384,12 @@ void CDVDPlayer::Process()
       if(next == CDVDInputStream::NEXTSTREAM_OPEN)
       {
         SAFE_DELETE(m_pDemuxer);
+        for(unsigned int i = 0; i < m_extDemuxer.size(); i++)
+        {
+          if(m_extDemuxer[i])
+            SAFE_DELETE(m_extDemuxer[i]);
+        }
+
         m_CurrentAudio.stream = NULL;
         m_CurrentVideo.stream = NULL;
         m_CurrentSubtitle.stream = NULL;
@@ -1295,7 +1494,8 @@ void CDVDPlayer::ProcessPacket(CDemuxStream* pStream, DemuxPacket* pPacket)
 
     try
     {
-      if (pPacket->iStreamId == m_CurrentAudio.id && pStream->source == m_CurrentAudio.source && pStream->type == STREAM_AUDIO)
+      if (pPacket->iStreamId == m_CurrentAudio.id && pStream->source == m_CurrentAudio.source && pStream->type == STREAM_AUDIO
+        || m_extAudio && pStream->source == m_CurrentAudio.source && pStream->type == STREAM_AUDIO)
         ProcessAudioData(pStream, pPacket);
       else if (pPacket->iStreamId == m_CurrentVideo.id && pStream->source == m_CurrentVideo.source && pStream->type == STREAM_VIDEO)
         ProcessVideoData(pStream, pPacket);
@@ -2006,6 +2206,16 @@ void CDVDPlayer::OnExit()
     }
     m_pDemuxer = NULL;
 
+    for (unsigned int i = 0; i < m_extDemuxer.size(); i++)
+    {
+      if(m_extDemuxer[i])
+      {
+        CLog::Log(LOGNOTICE, "CDVDPlayer::OnExit() deleting external demuxer");
+        delete m_extDemuxer[i];
+      }
+    }
+    m_extDemuxer.clear();
+
     if (m_pSubtitleDemuxer)
     {
       CLog::Log(LOGNOTICE, "CDVDPlayer::OnExit() deleting subtitle demuxer");
@@ -2043,6 +2253,7 @@ void CDVDPlayer::OnExit()
     m_pInputStream = NULL;
     m_pDemuxer = NULL;
     m_extInputStreams.clear();
+    m_extDemuxer.clear();
   }
 
   m_bStop = true;
@@ -2104,6 +2315,17 @@ void CDVDPlayer::HandleMessages()
             if(!m_pSubtitleDemuxer->SeekTime(time, msg.GetBackward()))
               CLog::Log(LOGDEBUG, "failed to seek subtitle demuxer: %d, success", time);
           }
+          for(unsigned int i = 0; i < m_extDemuxer.size(); i++)
+          {
+            if(m_extDemuxer[i])
+            {
+              if(!m_extDemuxer[i]->SeekTime(time, msg.GetBackward(), &start))
+                CLog::Log(LOGDEBUG, "failed to seek external audio demuxer: %d, success", time);
+              else
+                CLog::Log(LOGDEBUG, "external audio demuxer seek to: %d, success", time);
+            }
+          }
+
           FlushBuffers(!msg.GetFlush(), start, msg.GetAccurate());
         }
         else
@@ -2129,6 +2351,12 @@ void CDVDPlayer::HandleMessages()
         // This should always be the case.
         if(m_pDemuxer && m_pDemuxer->SeekChapter(msg.GetChapter(), &start))
         {
+          for(unsigned int i = 0; i < m_extDemuxer.size(); i++)
+          {
+            if(m_extDemuxer[i])
+              m_extDemuxer[i]->SeekChapter(msg.GetChapter(), &start);
+          }
+
           FlushBuffers(false, start, true);
           m_callback.OnPlayBackSeekChapter(msg.GetChapter());
         }
@@ -2146,6 +2374,11 @@ void CDVDPlayer::HandleMessages()
             m_pDemuxer->Reset();
           if(m_pSubtitleDemuxer)
             m_pSubtitleDemuxer->Reset();
+          for(unsigned int i = 0; i < m_extDemuxer.size(); i++)
+          {
+            if(m_extDemuxer[i])
+              m_extDemuxer[i]->Reset();
+          }
       }
       else if (pMsg->IsType(CDVDMsg::PLAYER_SET_AUDIOSTREAM))
       {
@@ -2273,6 +2506,13 @@ void CDVDPlayer::HandleMessages()
         //        until our buffers are somewhat filled
         if(m_pDemuxer)
           m_pDemuxer->SetSpeed(speed);
+
+        for(unsigned int i = 0; i < m_extDemuxer.size(); i++)
+        {
+          if(m_extDemuxer[i])
+            m_extDemuxer[i]->SetSpeed(speed);
+        }
+
       }
       else if (pMsg->IsType(CDVDMsg::PLAYER_CHANNEL_SELECT_NUMBER) && m_messenger.GetPacketCount(CDVDMsg::PLAYER_CHANNEL_SELECT_NUMBER) == 0)
       {
@@ -2881,10 +3121,27 @@ bool CDVDPlayer::OpenAudioStream(int iStream, int source, bool reset)
   if (!m_pDemuxer)
     return false;
 
-  CDemuxStream* pStream = m_pDemuxer->GetStream(iStream);
+  CDemuxStream* pStream;
+
+  if(iStream >= m_extAudioOffset && iStream < ((int) (m_extAudioOffset + m_extDemuxer.size())))
+  {
+    m_extAudio = true;
+    m_extAudioId = iStream - m_extAudioOffset;
+  }
+  else
+    m_extAudio = false;
+
+  if(m_extAudio)
+  {
+    // Stream 0, so no fancy ext audio files with more than one stream
+    // we already filterd out these files
+    pStream = m_extDemuxer[m_extAudioId]->GetStream(0);
+
   if (!pStream || pStream->disabled)
     return false;
-
+  }
+  else
+    pStream = m_pDemuxer->GetStream(iStream);
   if( m_CurrentAudio.id < 0 &&  m_CurrentVideo.id >= 0 )
   {
     // up until now we wheren't playing audio, but we did play video
@@ -3977,9 +4234,15 @@ void CDVDPlayer::UpdatePlayState(double timeout)
   else
     state.time_offset = DVD_MSEC_TO_TIME(state.time) - state.dts;
 
-  if (m_CurrentAudio.id >= 0 && m_pDemuxer)
+  if (m_CurrentAudio.id >= 0 && m_pDemuxer && !m_extAudio)
   {
     CDemuxStream* pStream = m_pDemuxer->GetStream(m_CurrentAudio.id);
+    if (pStream && pStream->type == STREAM_AUDIO)
+      ((CDemuxStreamAudio*)pStream)->GetStreamInfo(state.demux_audio);
+  }
+  else if (m_extAudio && m_extDemuxer[m_extAudioId])
+  {
+    CDemuxStream* pStream = m_extDemuxer[m_extAudioId]->GetStream(0);
     if (pStream && pStream->type == STREAM_AUDIO)
       ((CDemuxStreamAudio*)pStream)->GetStreamInfo(state.demux_audio);
   }
@@ -4069,9 +4332,15 @@ bool CDVDPlayer::Record(bool bOnOff)
 
 int CDVDPlayer::GetChannels()
 {
-  if (m_pDemuxer && (m_CurrentAudio.id != -1))
+  if (m_pDemuxer && (m_CurrentAudio.id != -1) && !m_extAudio)
   {
     CDemuxStreamAudio* stream = static_cast<CDemuxStreamAudio*>(m_pDemuxer->GetStream(m_CurrentAudio.id));
+    if (stream)
+      return stream->iChannels;
+  } 
+  else if (m_extAudio && m_extDemuxer[m_extAudioId])
+  {
+    CDemuxStreamAudio* stream = static_cast<CDemuxStreamAudio*>(m_extDemuxer[m_extAudioId]->GetStream(0));
     if (stream)
       return stream->iChannels;
   }
@@ -4081,8 +4350,11 @@ int CDVDPlayer::GetChannels()
 CStdString CDVDPlayer::GetAudioCodecName()
 {
   CStdString retVal;
-  if (m_pDemuxer && (m_CurrentAudio.id != -1))
+  if (m_pDemuxer && (m_CurrentAudio.id != -1) && ! m_extAudio)
     m_pDemuxer->GetStreamCodecName(m_CurrentAudio.id, retVal);
+  else if (m_extAudio && m_extDemuxer[m_extAudioId])
+    m_extDemuxer[m_extAudioId]->GetStreamCodecName(0, retVal);
+
   return retVal;
 }
 

--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -4392,7 +4392,7 @@ bool CDVDPlayer::GetStreamDetails(CStreamDetails &details)
 {
   if (m_pDemuxer)
   {
-    bool result=CDVDFileInfo::DemuxerToStreamDetails(m_pInputStream, m_pDemuxer, details);
+    bool result=CDVDFileInfo::DemuxerToStreamDetails(m_pInputStream, m_pDemuxer, m_extDemuxer, details);
     if (result && details.GetStreamCount(CStreamDetail::VIDEO) > 0) // this is more correct (dvds in particular)
     {
       GetVideoAspectRatio(((CStreamDetailVideo*)details.GetNthStream(CStreamDetail::VIDEO,0))->m_fAspect);

--- a/xbmc/cores/dvdplayer/DVDPlayer.h
+++ b/xbmc/cores/dvdplayer/DVDPlayer.h
@@ -157,6 +157,7 @@ public:
 
   void             Update  (SelectionStream& s);
   void             Update  (CDVDInputStream* input, CDVDDemux* demuxer);
+  void             UpdateExtAudio  (CDVDInputStream* input, CDVDDemux* ext_demuxer);
 };
 
 
@@ -329,7 +330,8 @@ protected:
   void UpdateTimestamps(CCurrentStream& current, DemuxPacket* pPacket);
   void SendPlayerMessage(CDVDMsg* pMsg, unsigned int target);
 
-  bool ReadPacket(DemuxPacket*& packet, CDemuxStream*& stream);
+  bool ReadPacket(DemuxPacket*& packet, CDemuxStream*& stream, bool onlyVideo);
+  bool ReadExternalAudioPacket(DemuxPacket*& packet, CDemuxStream*& stream);
   bool IsValidStream(CCurrentStream& stream);
   bool IsBetterStream(CCurrentStream& current, CDemuxStream* stream);
   bool CheckDelayedChannelEntry(void);
@@ -338,6 +340,7 @@ protected:
   bool OpenExternalAudioInputStreams();
   bool OpenDemuxStream();
   void OpenDefaultStreams(bool reset = true);
+  bool OpenExternalAudioDemuxStreams();
 
   void UpdateApplication(double timeout);
   void UpdatePlayState(double timeout);
@@ -385,6 +388,10 @@ protected:
 
   CStdString m_lastSub;
   std::vector<CDVDInputStream*> m_extInputStreams;
+  std::vector<CDVDDemux*> m_extDemuxer;
+  bool m_extAudio;
+  int m_extAudioOffset;
+  int m_extAudioId;
 
   struct SDVDInfo
   {

--- a/xbmc/cores/dvdplayer/DVDPlayer.h
+++ b/xbmc/cores/dvdplayer/DVDPlayer.h
@@ -335,6 +335,7 @@ protected:
   bool CheckDelayedChannelEntry(void);
 
   bool OpenInputStream();
+  bool OpenExternalAudioInputStreams();
   bool OpenDemuxStream();
   void OpenDefaultStreams(bool reset = true);
 
@@ -383,6 +384,7 @@ protected:
   CDVDDemux* m_pSubtitleDemuxer;
 
   CStdString m_lastSub;
+  std::vector<CDVDInputStream*> m_extInputStreams;
 
   struct SDVDInfo
   {


### PR DESCRIPTION
This PR adds the possibility to play external audio tracks together with video files and stacked videos.
At the moment the files have to be placed either in the same directory or in a subdirectory named "audio" or "tracks". The files can also be zipped or rared.
The recognised file extensions are read from `g_settings.m_musicExtensions`.

This closes ticket http://trac.xbmc.org/ticket/11446 .
