### PR TITLE
Fix Coverity Static Analysis Issues in XBMC

### DIFF
--- a/tools/TexturePacker/XBMCTex.cpp
+++ b/tools/TexturePacker/XBMCTex.cpp
@@ -143,32 +143,33 @@ void CreateSkeletonHeaderImpl(CXBTF& xbtf, std::string fullPath, std::string rel
 
       //stat to check for dir type (reiserfs fix)
       std::string fileN = fullPath + "/" + dp->d_name;
-      stat(fileN.c_str(), &stat_p);
-
-      if (dp->d_type == DT_DIR || stat_p.st_mode & S_IFDIR)
+      if (stat(fileN.c_str(), &stat_p) == 0)
       {
-        std::string tmpPath = relativePath;
-        if (tmpPath.size() > 0)
+        if (dp->d_type == DT_DIR || stat_p.st_mode & S_IFDIR)
         {
-          tmpPath += "/";
-        }
+          std::string tmpPath = relativePath;
+          if (tmpPath.size() > 0)
+          {
+            tmpPath += "/";
+          }
 
-        CreateSkeletonHeaderImpl(xbtf, fullPath + DIR_SEPARATOR + dp->d_name, tmpPath + dp->d_name);
-      }
-      else if (IsGraphicsFile(dp->d_name))
-      {
-        std::string fileName = "";
-        if (relativePath.size() > 0)
+          CreateSkeletonHeaderImpl(xbtf, fullPath + DIR_SEPARATOR + dp->d_name, tmpPath + dp->d_name);
+        }
+        else if (IsGraphicsFile(dp->d_name))
         {
-          fileName += relativePath;
-          fileName += "/";
+          std::string fileName = "";
+          if (relativePath.size() > 0)
+          {
+            fileName += relativePath;
+            fileName += "/";
+          }
+
+          fileName += dp->d_name;
+
+          CXBTFFile file;
+          file.SetPath(fileName);
+          xbtf.GetFiles().push_back(file);
         }
-
-        fileName += dp->d_name;
-
-        CXBTFFile file;
-        file.SetPath(fileName);
-        xbtf.GetFiles().push_back(file);
       }
     }
 

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -415,6 +415,15 @@ CApplication::CApplication(void)
 #ifdef HAS_DVD_DRIVE
   m_Autorun = new CAutorun();
 #endif
+
+  m_splash = NULL;
+  m_threadID = 0;
+  m_eCurrentPlayer = EPC_NONE;
+  m_progressTrackingPlayCountUpdate = false;
+  m_currentStackPosition = 0;
+  m_lastFrameTime = 0;
+  m_lastRenderTime = 0;
+  m_bTestMode = false;
 }
 
 CApplication::~CApplication(void)

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -1837,16 +1837,24 @@ void CApplication::ReloadSkin()
   m_skinReloading = false;
   CGUIMessage msg(GUI_MSG_LOAD_SKIN, -1, g_windowManager.GetActiveWindow());
   g_windowManager.SendMessage(msg);
+  
   // Reload the skin, restoring the previously focused control.  We need this as
   // the window unload will reset all control states.
+  int iCtrlID = -1;
   CGUIWindow* pWindow = g_windowManager.GetWindow(g_windowManager.GetActiveWindow());
-  int iCtrlID = pWindow->GetFocusedControlID();
+  if (pWindow)
+    iCtrlID = pWindow->GetFocusedControlID();
+  
   g_application.LoadSkin(g_guiSettings.GetString("lookandfeel.skin"));
-  pWindow = g_windowManager.GetWindow(g_windowManager.GetActiveWindow());
-  if (pWindow && pWindow->HasSaveLastControl())
+ 
+  if (iCtrlID != -1)
   {
-    CGUIMessage msg3(GUI_MSG_SETFOCUS, g_windowManager.GetActiveWindow(), iCtrlID, 0);
-    pWindow->OnMessage(msg3);
+    pWindow = g_windowManager.GetWindow(g_windowManager.GetActiveWindow());
+    if (pWindow && pWindow->HasSaveLastControl())
+    {
+      CGUIMessage msg3(GUI_MSG_SETFOCUS, g_windowManager.GetActiveWindow(), iCtrlID, 0);
+      pWindow->OnMessage(msg3);
+    }
   }
 }
 
@@ -4674,7 +4682,10 @@ bool CApplication::WakeUpScreenSaver(bool bPowerOffKeyPressed /* = false */)
       {
         m_iScreenSaveLock = 2;
         CGUIMessage msg(GUI_MSG_CHECK_LOCK,0,0);
-        g_windowManager.GetWindow(WINDOW_SCREENSAVER)->OnMessage(msg);
+
+        CGUIWindow* pWindow = g_windowManager.GetWindow(WINDOW_SCREENSAVER);
+        if (pWindow)
+          pWindow->OnMessage(msg);
       }
     if (m_iScreenSaveLock == -1)
     {

--- a/xbmc/Application.h
+++ b/xbmc/Application.h
@@ -409,8 +409,6 @@ protected:
   CSplash* m_splash;
   ThreadIdentifier m_threadID;       // application thread ID.  Used in applicationMessanger to know where we are firing a thread with delay from.
   PLAYERCOREID m_eCurrentPlayer;
-  bool m_bSettingsLoaded;
-  bool m_bAllSettingsLoaded;
   bool m_bInitializing;
   bool m_bPlatformDirectories;
 

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -97,6 +97,11 @@ CGUIInfoManager::CGUIInfoManager(void)
   m_frameCounter = 0;
   m_lastFPSTime = 0;
   m_updateTime = 1;
+  m_MusicBitrate = 0;
+  m_playerShowTime = false;
+  m_playerShowCodec = false;
+  m_playerShowInfo = false;
+  m_fps = 0.0f;
   ResetLibraryBools();
 }
 

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -3927,6 +3927,7 @@ CStdString CGUIInfoManager::GetItemLabel(const CFileItem *item, int info, CStdSt
   case LISTITEM_DIRECTOR:
     if (item->HasVideoInfoTag())
       return StringUtils::Join(item->GetVideoInfoTag()->m_director, g_advancedSettings.m_videoItemSeparator);
+    break;
   case LISTITEM_ALBUM:
     if (item->HasVideoInfoTag())
       return item->GetVideoInfoTag()->m_strAlbum;

--- a/xbmc/NfoFile.h
+++ b/xbmc/NfoFile.h
@@ -36,7 +36,7 @@
 class CNfoFile
 {
 public:
-  CNfoFile() : m_doc(NULL), m_headofdoc(NULL) {}
+  CNfoFile() : m_doc(NULL), m_headofdoc(NULL), m_type(ADDON::ADDON_UNKNOWN) {}
   virtual ~CNfoFile() { Close(); }
 
   enum NFOResult

--- a/xbmc/addons/AddonDll.h
+++ b/xbmc/addons/AddonDll.h
@@ -183,10 +183,16 @@ bool CAddonDll<TheDll, TheStruct, TheProps>::LoadDll()
     new CAddonStatusHandler(ID(), ADDON_STATUS_UNKNOWN, "Can't load Dll", false);
     return false;
   }
+
   m_pStruct = (TheStruct*)malloc(sizeof(TheStruct));
-  ZeroMemory(m_pStruct, sizeof(TheStruct));
-  m_pDll->GetAddon(m_pStruct);
-  return (m_pStruct != NULL);
+  if (m_pStruct)
+  {
+    ZeroMemory(m_pStruct, sizeof(TheStruct));
+    m_pDll->GetAddon(m_pStruct);
+    return true;
+  }
+
+  return false;
 }
 
 template<class TheDll, typename TheStruct, typename TheProps>

--- a/xbmc/cores/dvdplayer/DVDClock.cpp
+++ b/xbmc/cores/dvdplayer/DVDClock.cpp
@@ -45,6 +45,7 @@ CDVDClock::CDVDClock()
   m_speedadjust = false;
 
   m_ismasterclock = true;
+  m_startClock = 0;
 }
 
 CDVDClock::~CDVDClock()

--- a/xbmc/cores/dvdplayer/DVDCodecs/Audio/DVDAudioCodecFFmpeg.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Audio/DVDAudioCodecFFmpeg.cpp
@@ -45,6 +45,7 @@ CDVDAudioCodecFFmpeg::CDVDAudioCodecFFmpeg() : CDVDAudioCodec()
   m_bLpcmMode = false;
 
   m_pFrame1 = NULL;
+  m_iSampleFormat = AV_SAMPLE_FMT_NONE;
 }
 
 CDVDAudioCodecFFmpeg::~CDVDAudioCodecFFmpeg()

--- a/xbmc/cores/dvdplayer/DVDCodecs/Audio/DVDAudioCodecFFmpeg.h
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Audio/DVDAudioCodecFFmpeg.h
@@ -50,7 +50,6 @@ protected:
   AVAudioConvert*     m_pConvert;
   enum AVSampleFormat m_iSampleFormat;  
   CAEChannelInfo      m_channelLayout;
-  int                 m_iMapChannels;
   bool                m_bLpcmMode;  
 
   AVFrame* m_pFrame1;

--- a/xbmc/cores/dvdplayer/DVDCodecs/Audio/DVDAudioCodecLPcm.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Audio/DVDAudioCodecLPcm.cpp
@@ -26,6 +26,7 @@ CDVDAudioCodecLPcm::CDVDAudioCodecLPcm() : CDVDAudioCodecPcm()
 {
   m_codecID = CODEC_ID_NONE;
   m_bufferSize = LPCM_BUFFER_SIZE;
+  memset(m_buffer, 0, sizeof(m_buffer));
 }
 
 bool CDVDAudioCodecLPcm::Open(CDVDStreamInfo &hints, CDVDCodecOptions &options)

--- a/xbmc/cores/dvdplayer/DVDCodecs/Audio/DVDAudioCodecLibMad.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Audio/DVDAudioCodecLibMad.cpp
@@ -25,6 +25,18 @@
 CDVDAudioCodecLibMad::CDVDAudioCodecLibMad() : CDVDAudioCodec()
 {
   m_bInitialized = false;
+  
+  memset(&m_synth, 0, sizeof(m_synth));
+  memset(&m_stream, 0, sizeof(m_stream));
+  memset(&m_frame, 0, sizeof(m_frame));
+  
+  m_iDecodedDataSize = 0;
+  
+  m_iSourceSampleRate = 0;
+  m_iSourceChannels = 0;
+  m_iSourceBitrate = 0;
+  
+  m_iInputBufferSize = 0;
 }
 
 CDVDAudioCodecLibMad::~CDVDAudioCodecLibMad()

--- a/xbmc/cores/dvdplayer/DVDCodecs/Audio/DVDAudioCodecPcm.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Audio/DVDAudioCodecPcm.cpp
@@ -114,8 +114,11 @@ CDVDAudioCodecPcm::CDVDAudioCodecPcm() : CDVDAudioCodec()
   m_iSourceSampleRate = 0;
   m_iSourceBitrate = 0;
   m_decodedDataSize = 0;
-  m_pInputBuffer = NULL;
   m_codecID = CODEC_ID_NONE;
+  m_iOutputChannels = 0;
+
+  memset(m_decodedData, 0, sizeof(m_decodedData));
+  memset(table, 0, sizeof(table));
 }
 
 CDVDAudioCodecPcm::~CDVDAudioCodecPcm()
@@ -275,7 +278,6 @@ int CDVDAudioCodecPcm::GetData(BYTE** dst)
 
 void CDVDAudioCodecPcm::SetDefault()
 {
-  m_pInputBuffer = m_inputBuffer;
   m_iSourceChannels = 0;
   m_iSourceSampleRate = 0;
   m_iSourceBitrate = 0;

--- a/xbmc/cores/dvdplayer/DVDCodecs/Audio/DVDAudioCodecPcm.h
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Audio/DVDAudioCodecPcm.h
@@ -42,9 +42,6 @@ public:
 protected:
   virtual void SetDefault();
 
-  BYTE m_inputBuffer[4096];
-  BYTE* m_pInputBuffer;
-
   short m_decodedData[131072]; // could be a bit to big
   int m_decodedDataSize;
 

--- a/xbmc/cores/dvdplayer/DVDCodecs/DVDFactoryCodec.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/DVDFactoryCodec.cpp
@@ -353,6 +353,7 @@ CDVDOverlayCodec* CDVDFactoryCodec::CreateOverlayCodec( CDVDStreamInfo &hint )
     case CODEC_ID_TEXT:
       pCodec = OpenCodec(new CDVDOverlayCodecText(), hint, options);
       if( pCodec ) return pCodec;
+      break;
 
     case CODEC_ID_SSA:
       pCodec = OpenCodec(new CDVDOverlayCodecSSA(), hint, options);
@@ -360,14 +361,17 @@ CDVDOverlayCodec* CDVDFactoryCodec::CreateOverlayCodec( CDVDStreamInfo &hint )
 
       pCodec = OpenCodec(new CDVDOverlayCodecText(), hint, options);
       if( pCodec ) return pCodec;
+      break;
 
     case CODEC_ID_MOV_TEXT:
       pCodec = OpenCodec(new CDVDOverlayCodecTX3G(), hint, options);
       if( pCodec ) return pCodec;
+      break;
 
     default:
       pCodec = OpenCodec(new CDVDOverlayCodecFFmpeg(), hint, options);
       if( pCodec ) return pCodec;
+      break;
   }
 
   return NULL;

--- a/xbmc/cores/dvdplayer/DVDCodecs/Overlay/DVDOverlayText.h
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Overlay/DVDOverlayText.h
@@ -43,6 +43,7 @@ public:
   public:
     CElement(ElementType type)
     {
+      pNext = NULL;
       m_type = type;
     }
 

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/CrystalHD.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/CrystalHD.cpp
@@ -269,6 +269,7 @@ CPictureBuffer::CPictureBuffer(ERenderFormat format, int width, int height)
   m_color_range = 0;
   m_color_matrix = 4;
   m_format = format;
+  m_framerate = 0;
   
   switch(m_format)
   {
@@ -332,10 +333,20 @@ CMPCOutputThread::CMPCOutputThread(void *device, DllLibCrystalHD *dll, bool has_
   m_timeout(20),
   m_format_valid(false),
   m_is_live_stream(false),
+  m_width(0),
+  m_height(0),
+  m_timestamp(0),
+  m_PictureNumber(0),
+  m_color_space(0),
+  m_color_range(0),
+  m_color_matrix(0),
+  m_interlace(0),
   m_framerate_tracking(false),
   m_framerate_cnt(0),
   m_framerate_timestamp(0.0),
-  m_framerate(0.0)
+  m_framerate(0.0),
+  m_aspectratio_x(1),
+  m_aspectratio_y(1)
 {
   m_sw_scale_ctx = NULL;
   m_dllSwScale = new DllSwScale;
@@ -1086,8 +1097,25 @@ CCrystalHD::CCrystalHD() :
   m_has_bcm70015(false),
   m_color_space(BCM::MODE420),
   m_drop_state(false),
-  m_pOutputThread(NULL)
+  m_skip_state(false),
+  m_timeout(0),
+  m_wait_timeout(0),
+  m_field(0),
+  m_width(0),
+  m_height(0),
+  m_reset(0),
+  m_last_pict_num(0),
+  m_last_demuxer_pts(0.0),
+  m_last_decoder_pts(0.0),
+  m_pOutputThread(NULL),
+  m_sps_pps_size(0),
+  m_convert_bitstream(false)
 {
+#if (HAVE_LIBCRYSTALHD == 2)
+  memset(&m_bc_info_crystal, 0, sizeof(m_bc_info_crystal));
+#endif
+
+  memset(&m_chd_params, 0, sizeof(m_chd_params));
 
   m_dll = new DllLibCrystalHD;
 #ifdef _WIN32

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecCrystalHD.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecCrystalHD.cpp
@@ -40,7 +40,8 @@ CDVDVideoCodecCrystalHD::CDVDVideoCodecCrystalHD() :
   m_Codec(NULL),
   m_DropPictures(false),
   m_Duration(0.0),
-  m_pFormatName("")
+  m_pFormatName(""),
+  m_CodecType(CRYSTALHD_CODEC_ID_MPEG2)
 {
 }
 

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
@@ -137,6 +137,7 @@ CDVDVideoCodecFFmpeg::CDVDVideoCodecFFmpeg() : CDVDVideoCodec()
 
   m_iScreenWidth = 0;
   m_iScreenHeight = 0;
+  m_iOrientation = 0;
   m_bSoftware = false;
   m_pHardware = NULL;
   m_iLastKeyframe = 0;

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecLibMpeg2.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecLibMpeg2.cpp
@@ -63,6 +63,7 @@ CDVDVideoCodecLibMpeg2::CDVDVideoCodecLibMpeg2()
   m_irffpattern = 0;
   m_bFilm = false;
   m_bIs422 = false;
+  m_hurry = 0;
   m_dts = DVD_NOPTS_VALUE;
   m_dts2 = DVD_NOPTS_VALUE;
 }

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoPPFFmpeg.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoPPFFmpeg.cpp
@@ -28,6 +28,7 @@ CDVDVideoPPFFmpeg::CDVDVideoPPFFmpeg(const CStdString& mType)
   m_pMode = m_pContext = NULL;
   m_pSource = m_pTarget = NULL;
   m_iInitWidth = m_iInitHeight = 0;
+  m_deinterlace = false;
   memset(&m_FrameBuffer, 0, sizeof(DVDVideoPicture));
 }
 CDVDVideoPPFFmpeg::~CDVDVideoPPFFmpeg()

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/VAAPI.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/VAAPI.cpp
@@ -185,7 +185,7 @@ int CDecoder::GetBuffer(AVCodecContext *avctx, AVFrame *pic)
   {
     /* reget call */
     for(; it != m_surfaces_free.end(); it++)
-    {    
+    {
       if((*it)->m_id == surface)
       {
         wrapper = it->get();
@@ -194,10 +194,10 @@ int CDecoder::GetBuffer(AVCodecContext *avctx, AVFrame *pic)
         break;
       }
     }
-    if(it == m_surfaces_free.end())
+    if(!wrapper)
     {
       CLog::Log(LOGERROR, "VAAPI - unable to find requested surface");
-      return -1;      
+      return -1; 
     }
   }
   else

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/VAAPI.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/VAAPI.cpp
@@ -149,6 +149,7 @@ CDecoder::CDecoder()
   m_config          = 0;
   m_context         = 0;
   m_hwaccel         = (vaapi_context*)calloc(1, sizeof(vaapi_context));
+  memset(m_surfaces, 0, sizeof(*m_surfaces));
 }
 
 CDecoder::~CDecoder()

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/VDPAU.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/VDPAU.cpp
@@ -1035,7 +1035,7 @@ bool CVDPAU::FiniOutputMethod()
   {
     vdp_st = vdp_video_mixer_destroy(videoMixer);
     videoMixer = VDP_INVALID_HANDLE;
-    if (CheckStatus(vdp_st, __LINE__));
+    CheckStatus(vdp_st, __LINE__);
   }
 
   if (m_BlackBar)

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/VDPAU.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/VDPAU.cpp
@@ -878,10 +878,12 @@ void CVDPAU::ReadFormatOf( PixelFormat fmt
     case PIX_FMT_VDPAU_MPEG4:
       vdp_decoder_profile = VDP_DECODER_PROFILE_MPEG4_PART2_ASP;
       vdp_chroma_type     = VDP_CHROMA_TYPE_420;
+      break;
 #endif
     default:
       vdp_decoder_profile = 0;
       vdp_chroma_type     = 0;
+      break;
   }
 }
 

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/VDPAU.cpp
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/VDPAU.cpp
@@ -102,8 +102,13 @@ CVDPAU::CVDPAU()
   vdp_flip_target = VDP_INVALID_HANDLE;
   vdp_flip_queue = VDP_INVALID_HANDLE;
   vid_width = vid_height = OutWidth = OutHeight = 0;
-  memset(&outRect, 0, sizeof(VdpRect));
-  memset(&outRectVid, 0, sizeof(VdpRect));
+  surface_width = surface_height = 0;
+  
+  memset(&decoder, 0, sizeof(decoder));
+  memset(&outRect, 0, sizeof(outRect));
+  memset(&outRectVid, 0, sizeof(outRectVid));
+
+  m_Display = NULL;
 
   tmpBrightness  = 0;
   tmpContrast    = 0;
@@ -118,7 +123,31 @@ CVDPAU::CVDPAU()
   videoMixer = VDP_INVALID_HANDLE;
   m_BlackBar = NULL;
 
+  memset(m_features, 0, sizeof(m_features));
+  m_feature_count = 0;
+  m_vdpauOutputMethod = OUTPUT_NONE;
+
   upScale = g_advancedSettings.m_videoVDPAUScaling;
+
+  vdp_video_mixer_set_attribute_values = NULL;
+  vdp_generate_csc_matrix = NULL;
+  vdp_presentation_queue_target_destroy = NULL;
+  vdp_presentation_queue_create = NULL;
+  vdp_presentation_queue_destroy = NULL;
+  vdp_presentation_queue_display = NULL;
+  vdp_presentation_queue_block_until_surface_idle = NULL;
+  vdp_presentation_queue_target_create_x11 = NULL;
+  vdp_presentation_queue_query_surface_status = NULL;
+  vdp_presentation_queue_get_time = NULL;
+  vdp_get_error_string = NULL;
+  vdp_decoder_create = NULL;
+  vdp_decoder_destroy = NULL;
+  vdp_decoder_render = NULL;
+  vdp_decoder_query_caps = NULL;
+  vdp_preemption_callback_register = NULL;
+  dl_vdp_device_create_x11 = NULL;
+  dl_vdp_get_proc_address = NULL;
+  dl_vdp_preemption_callback_register = NULL;
 }
 
 bool CVDPAU::Open(AVCodecContext* avctx, const enum PixelFormat, unsigned int surfaces)
@@ -706,6 +735,12 @@ void CVDPAU::InitVDPAUProcs()
     CSingleLock lock(g_graphicsContext);
     m_Display = g_Windowing.GetDisplay();
   }
+  else
+  {
+    CLog::Log(LOGERROR,"(VDPAU) - Unable to get dl_vdp_device_create_x11 in %s", __FUNCTION__);
+    vdp_device = VDP_INVALID_HANDLE;
+    return;
+  }
 
   int mScreen = DefaultScreen(m_Display);
   VdpStatus vdp_st;
@@ -727,12 +762,6 @@ void CVDPAU::InitVDPAUProcs()
     return;
   }
 
-  if (vdp_st != VDP_STATUS_OK)
-  {
-    CLog::Log(LOGERROR,"(VDPAU) - Unable to create X11 device in %s",__FUNCTION__);
-    vdp_device = VDP_INVALID_HANDLE;
-    return;
-  }
 #define VDP_PROC(id, proc) \
   do { \
     vdp_st = vdp_get_proc_address(vdp_device, id, (void**)&proc); \

--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/VDPAU.h
+++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/VDPAU.h
@@ -219,7 +219,7 @@ public:
   bool Supports(EINTERLACEMETHOD method);
   EINTERLACEMETHOD AutoInterlaceMethod();
 
-  VdpVideoMixerFeature m_features[10];
+  VdpVideoMixerFeature m_features[13];
   int                  m_feature_count;
 
   static bool IsVDPAUFormat(PixelFormat fmt);

--- a/xbmc/cores/dvdplayer/DVDDemuxSPU.cpp
+++ b/xbmc/cores/dvdplayer/DVDDemuxSPU.cpp
@@ -307,6 +307,7 @@ CDVDOverlaySpu* CDVDDemuxSPU::ParsePacket(SPUData* pSPUData)
 
       default:
         DebugLog("GetPacket, error parsing control sequence");
+        delete pSPUInfo;
         return NULL;
         break;
       }

--- a/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -771,7 +771,7 @@ DemuxPacket* CDVDDemuxFFmpeg::Read()
   if (!pPacket) return NULL;
 
   // check streams, can we make this a bit more simple?
-  if (pPacket && pPacket->iStreamId >= 0 && pPacket->iStreamId <= MAX_STREAMS)
+  if (pPacket && pPacket->iStreamId >= 0 && pPacket->iStreamId < MAX_STREAMS)
   {
     if (!m_streams[pPacket->iStreamId] ||
         m_streams[pPacket->iStreamId]->pPrivate != m_pFormatContext->streams[pPacket->iStreamId] ||

--- a/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -1049,8 +1049,7 @@ void CDVDDemuxFFmpeg::AddStream(int iId)
         {
           CDemuxStreamSubtitleFFmpeg* st = new CDemuxStreamSubtitleFFmpeg(this, pStream);
           m_streams[iId] = st;
-          if(pStream->codec)
-            st->identifier = pStream->codec->sub_id;
+          st->identifier = pStream->codec->sub_id;
 	    
           if(m_dllAvUtil.av_dict_get(pStream->metadata, "title", NULL, 0))
             st->m_description = m_dllAvUtil.av_dict_get(pStream->metadata, "title", NULL, 0)->value;

--- a/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -210,6 +210,10 @@ CDVDDemuxFFmpeg::CDVDDemuxFFmpeg() : CDVDDemux()
   m_ioContext = NULL;
   for (int i = 0; i < MAX_STREAMS; i++) m_streams[i] = NULL;
   m_iCurrentPts = DVD_NOPTS_VALUE;
+  m_bMatroska = false;
+  m_bAVI = false;
+  m_speed = DVD_PLAYSPEED_NORMAL;
+  m_program = UINT_MAX;
 }
 
 CDVDDemuxFFmpeg::~CDVDDemuxFFmpeg()

--- a/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxHTSP.cpp
+++ b/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxHTSP.cpp
@@ -325,7 +325,10 @@ void CDVDDemuxHTSP::SubscriptionStart (htsmsg_t *m)
     }
 
     if((lang = htsmsg_get_str(sub, "language")))
+    {
       strncpy(st.g->language, lang, sizeof(st.g->language));
+      st.g->language[sizeof(st.g->language) - 1] = '\0';
+    }
 
     st.g->iId         = m_Streams.size();
     st.g->iPhysicalId = index;

--- a/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxShoutcast.cpp
+++ b/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxShoutcast.cpp
@@ -49,6 +49,7 @@ CDVDDemuxShoutcast::CDVDDemuxShoutcast() : CDVDDemux()
 {
   m_pInput = NULL;
   m_pDemuxStream = NULL;
+  m_iMetaStreamInterval = 0;
 }
 
 CDVDDemuxShoutcast::~CDVDDemuxShoutcast()

--- a/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxVobsub.h
+++ b/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxVobsub.h
@@ -53,7 +53,7 @@ private:
   {
   public:
     CStream(CDVDDemuxVobsub* parent)
-      : m_parent(parent)
+      : m_discard(AVDISCARD_NONE), m_parent(parent)
     {}
     virtual void      SetDiscard(AVDiscard discard) { m_discard = discard; }
     virtual AVDiscard GetDiscard()                  { return m_discard; }
@@ -75,11 +75,6 @@ private:
   std::vector<STimestamp>            m_Timestamps;
   std::vector<STimestamp>::iterator  m_Timestamp;
   std::vector<CStream*> m_Streams;
-
-  int m_width;
-  int m_height;
-  int m_left;
-  int m_top;
 
   typedef struct SState
   {

--- a/xbmc/cores/dvdplayer/DVDFileInfo.cpp
+++ b/xbmc/cores/dvdplayer/DVDFileInfo.cpp
@@ -186,6 +186,8 @@ bool CDVDFileInfo::ExtractThumb(const CStdString &strPath, CTextureDetails &deta
         int iDecoderState = VC_ERROR;
         DVDVideoPicture picture;
 
+        memset(&picture, 0, sizeof(picture));
+
         // num streams * 80 frames, should get a valid frame, if not abort.
         int abort_index = pDemuxer->GetNrOfStreams() * 80;
         do
@@ -374,8 +376,7 @@ bool CDVDFileInfo::DemuxerToStreamDetails(CDVDInputStream *pInputStream, CDVDDem
     {
       CStreamDetailAudio *p = new CStreamDetailAudio();
       p->m_iChannels = ((CDemuxStreamAudio *)stream)->iChannels;
-      if (stream->language)
-        p->m_strLanguage = stream->language;
+      p->m_strLanguage = stream->language;
       pDemux->GetStreamCodecName(iStream, p->m_strCodec);
       details.AddStream(p);
       retVal = true;

--- a/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamBluray.cpp
+++ b/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamBluray.cpp
@@ -59,10 +59,10 @@ void DllLibbluray::file_close(BD_FILE_H *file)
 {
   if (file)
   {
+    CLog::Log(LOGDEBUG, "CDVDInputStreamBluray - Closed file (%p)\n", file);
+    
     delete static_cast<CFile*>(file->internal);
     delete file;
-
-    CLog::Log(LOGDEBUG, "CDVDInputStreamBluray - Closed file (%p)\n", file);
   }
 }
 
@@ -125,10 +125,10 @@ BD_FILE_H * DllLibbluray::file_open(const char* filename, const char *mode)
       return file;
     }
 
+    CLog::Log(LOGDEBUG, "CDVDInputStreamBluray - Error opening file! (%p)", file);
+    
     delete fp;
     delete file;
-
-    CLog::Log(LOGDEBUG, "CDVDInputStreamBluray - Error opening file! (%p)", file);
 
     return NULL;
 }

--- a/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamBluray.cpp
+++ b/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamBluray.cpp
@@ -221,6 +221,10 @@ CDVDInputStreamBluray::CDVDInputStreamBluray(IDVDPlayer* player) :
   }
   m_content = "video/x-mpegts";
   m_player  = player;
+  m_title_playing = false;
+  m_navmode = false;
+  m_hold = HOLD_NONE;
+  memset(&m_event, 0, sizeof(m_event));
 }
 
 CDVDInputStreamBluray::~CDVDInputStreamBluray()

--- a/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamNavigator.cpp
+++ b/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamNavigator.cpp
@@ -50,6 +50,11 @@ CDVDInputStreamNavigator::CDVDInputStreamNavigator(IDVDPlayer* player) : CDVDInp
   m_iTitle = m_iTitleCount = 0;
   m_iPart = m_iPartCount = 0;
   m_iTime = m_iTotalTime = 0;
+  m_bEOF = false;
+  m_icurrentGroupId = 0;
+  m_lastevent = DVDNAV_NOP;
+
+  memset(m_lastblock, 0, sizeof(m_lastblock));
 }
 
 CDVDInputStreamNavigator::~CDVDInputStreamNavigator()

--- a/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamNavigator.cpp
+++ b/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamNavigator.cpp
@@ -1269,9 +1269,6 @@ int CDVDInputStreamNavigator::ConvertAudioStreamId_ExternalToXBMC(int id)
     // non VTS_DOMAIN, only one stream is available
     return 0;
   }
-
-  CLog::Log(LOGWARNING, "%s - no stream found %d", __FUNCTION__, id);
-  return -1;
 }
 
 int CDVDInputStreamNavigator::ConvertSubtitleStreamId_XBMCToExternal(int id)
@@ -1343,7 +1340,4 @@ int CDVDInputStreamNavigator::ConvertSubtitleStreamId_ExternalToXBMC(int id)
     // non VTS_DOMAIN, only one stream is available
     return 0;
   }
-
-  CLog::Log(LOGWARNING, "%s - no stream found %d", __FUNCTION__, id);
-  return -1;
 }

--- a/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamRTMP.cpp
+++ b/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamRTMP.cpp
@@ -90,6 +90,7 @@ CDVDInputStreamRTMP::CDVDInputStreamRTMP() : CDVDInputStream(DVDSTREAM_TYPE_RTMP
   m_eof = true;
   m_bPaused = false;
   m_sStreamPlaying = NULL;
+  m_rtmp = NULL;
 }
 
 CDVDInputStreamRTMP::~CDVDInputStreamRTMP()

--- a/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamStack.cpp
+++ b/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamStack.cpp
@@ -35,6 +35,7 @@ CDVDInputStreamStack::CDVDInputStreamStack() : CDVDInputStream(DVDSTREAM_TYPE_FI
 {
   m_eof = true;
   m_pos = 0;
+  m_length = 0;
 }
 
 CDVDInputStreamStack::~CDVDInputStreamStack()

--- a/xbmc/cores/dvdplayer/DVDMessageQueue.cpp
+++ b/xbmc/cores/dvdplayer/DVDMessageQueue.cpp
@@ -40,6 +40,7 @@ CDVDMessageQueue::CDVDMessageQueue(const string &owner) : m_hEvent(true)
   m_TimeBack      = DVD_NOPTS_VALUE;
   m_TimeFront     = DVD_NOPTS_VALUE;
   m_TimeSize      = 1.0 / 4.0; /* 4 seconds */
+  m_iMaxDataSize  = 0;
 }
 
 CDVDMessageQueue::~CDVDMessageQueue()

--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -458,10 +458,13 @@ bool CDVDPlayer::OpenFile(const CFileItem& file, const CPlayerOptions &options)
     if(!m_ready.WaitMSec(100))
     {
       CGUIDialogBusy* dialog = (CGUIDialogBusy*)g_windowManager.GetWindow(WINDOW_DIALOG_BUSY);
-      dialog->Show();
-      while(!m_ready.WaitMSec(1))
-        g_windowManager.ProcessRenderLoop(false);
-      dialog->Close();
+      if(dialog)
+      {
+        dialog->Show();
+        while(!m_ready.WaitMSec(1))
+          g_windowManager.ProcessRenderLoop(false);
+        dialog->Close();
+      }
     }
 
     // Playback might have been stopped due to some error
@@ -785,16 +788,19 @@ bool CDVDPlayer::ReadPacket(DemuxPacket*& packet, CDemuxStream*& stream)
     if(packet->iStreamId < 0)
       return true;
 
-    stream = m_pDemuxer->GetStream(packet->iStreamId);
-    if (!stream)
+    if(m_pDemuxer)
     {
-      CLog::Log(LOGERROR, "%s - Error demux packet doesn't belong to a valid stream", __FUNCTION__);
-      return false;
-    }
-    if(stream->source == STREAM_SOURCE_NONE)
-    {
-      m_SelectionStreams.Clear(STREAM_NONE, STREAM_SOURCE_DEMUX);
-      m_SelectionStreams.Update(m_pInputStream, m_pDemuxer);
+      stream = m_pDemuxer->GetStream(packet->iStreamId);
+      if (!stream)
+      {
+        CLog::Log(LOGERROR, "%s - Error demux packet doesn't belong to a valid stream", __FUNCTION__);
+        return false;
+      }
+      if(stream->source == STREAM_SOURCE_NONE)
+      {
+        m_SelectionStreams.Clear(STREAM_NONE, STREAM_SOURCE_DEMUX);
+        m_SelectionStreams.Update(m_pInputStream, m_pDemuxer);
+      }
     }
     return true;
   }

--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -404,12 +404,16 @@ CDVDPlayer::CDVDPlayer(IPlayerCallback& callback)
 
   m_dvd.Clear();
   m_State.Clear();
+  m_EdlAutoSkipMarkers.Clear();
   m_UpdateApplication = 0;
 
   m_bAbortRequest = false;
   m_errorCount = 0;
+  m_offset_pts = 0.0;
   m_playSpeed = DVD_PLAYSPEED_NORMAL;
   m_caching = CACHESTATE_DONE;
+
+  memset(&m_SpeedState, 0, sizeof(m_SpeedState));
 
 #ifdef DVDDEBUG_MESSAGE_TRACKER
   g_dvdMessageTracker.Init();

--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -3668,7 +3668,7 @@ void CDVDPlayer::UpdatePlayState(double timeout)
   }
 
   state.player_state = "";
-  if (m_pInputStream->IsStreamType(DVDSTREAM_TYPE_DVD))
+  if (m_pInputStream && m_pInputStream->IsStreamType(DVDSTREAM_TYPE_DVD))
   {
     state.time_offset = DVD_MSEC_TO_TIME(state.time) - state.dts;
     if(!((CDVDInputStreamNavigator*)m_pInputStream)->GetNavigatorState(state.player_state))

--- a/xbmc/cores/dvdplayer/DVDPlayerAudio.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayerAudio.cpp
@@ -166,11 +166,24 @@ CDVDPlayerAudio::CDVDPlayerAudio(CDVDClock* pClock, CDVDMessageQueue& parent)
   m_speed = DVD_PLAYSPEED_NORMAL;
   m_stalled = true;
   m_started = false;
+  m_silence = false;
   m_duration = 0.0;
   m_resampleratio = 1.0;
+  m_synctype = SYNC_DISCON;
+  m_setsynctype = SYNC_DISCON;
+  m_prevsynctype = -1;
+  m_error = 0;
+  m_errorbuff = 0;
+  m_errorcount = 0;
+  m_syncclock = true;
+  m_integral = 0;
+  m_skipdupcount = 0;
+  m_prevskipped = false;
+  m_maxspeedadjust = 0.0;
 
   m_freq = CurrentHostFrequency();
 
+  m_decode.Release();
   m_messageQueue.SetMaxDataSize(6 * 1024 * 1024);
   m_messageQueue.SetMaxTimeSize(8.0);
   g_dvdPerformanceCounter.EnableAudioQueue(&m_messageQueue);

--- a/xbmc/cores/dvdplayer/DVDPlayerAudioResampler.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayerAudioResampler.cpp
@@ -32,8 +32,10 @@ CDVDPlayerResampler::CDVDPlayerResampler()
 {
   m_nrchannels = -1;
   m_converter = NULL;
-  m_converterdata.end_of_input = 0;
+  
+  memset(&m_converterdata, 0, sizeof(m_converterdata));
   m_converterdata.src_ratio = 1.0;
+  
   m_quality = SRC_LINEAR;
   m_ratio = 1.0;
 

--- a/xbmc/cores/dvdplayer/DVDPlayerVideo.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayerVideo.cpp
@@ -139,6 +139,9 @@ CDVDPlayerVideo::CDVDPlayerVideo( CDVDClock* pClock
   m_started = false;
   m_iVideoDelay = 0;
   m_iSubtitleDelay = 0;
+  m_FlipTimeStamp = 0.0;
+  m_iLateFrames = 0;
+  m_iDroppedRequest = 0;
   m_fForcedAspectRatio = 0;
   m_iNrOfPicturesNotToSkip = 0;
   m_messageQueue.SetMaxDataSize(40 * 1024 * 1024);
@@ -148,8 +151,17 @@ CDVDPlayerVideo::CDVDPlayerVideo( CDVDClock* pClock
   m_iCurrentPts = DVD_NOPTS_VALUE;
   m_iDroppedFrames = 0;
   m_fFrameRate = 25;
+  m_bCalcFrameRate = false;
+  m_fStableFrameRate = 0.0;
+  m_iFrameRateCount = 0;
+  m_bAllowDrop = false;
+  m_iFrameRateErr = 0;
+  m_iFrameRateLength = 0;
   m_bFpsInvalid = false;
   m_bAllowFullscreen = false;
+  m_droptime = 0.0;
+  m_dropbase = 0.0;
+  m_autosync = 1;
   memset(&m_output, 0, sizeof(m_output));
 }
 
@@ -1287,8 +1299,8 @@ int CDVDPlayerVideo::OutputPicture(const DVDVideoPicture* src, double pts)
   }
   else
   {
-    m_droptime = 0.0f;
-    m_dropbase = 0.0f;
+    m_droptime = 0.0;
+    m_dropbase = 0.0;
   }
 
   // set fieldsync if picture is interlaced

--- a/xbmc/cores/dvdplayer/DVDStreamInfo.cpp
+++ b/xbmc/cores/dvdplayer/DVDStreamInfo.cpp
@@ -59,6 +59,7 @@ void CDVDStreamInfo::Clear()
   level    = 0;
   profile  = 0;
   ptsinvalid = false;
+  forced_aspect = false;
 
   channels   = 0;
   samplerate = 0;

--- a/xbmc/cores/dvdplayer/DVDSubtitles/DVDSubtitleParserMPL2.cpp
+++ b/xbmc/cores/dvdplayer/DVDSubtitles/DVDSubtitleParserMPL2.cpp
@@ -30,7 +30,7 @@
 using namespace std;
 
 CDVDSubtitleParserMPL2::CDVDSubtitleParserMPL2(CDVDSubtitleStream* stream, const string& filename)
-    : CDVDSubtitleParserText(stream, filename)
+    : CDVDSubtitleParserText(stream, filename), m_framerate(DVD_TIME_BASE / 10.0)
 {
 
 }

--- a/xbmc/cores/dvdplayer/DVDSubtitles/DVDSubtitleParserMicroDVD.cpp
+++ b/xbmc/cores/dvdplayer/DVDSubtitles/DVDSubtitleParserMicroDVD.cpp
@@ -31,7 +31,7 @@
 using namespace std;
 
 CDVDSubtitleParserMicroDVD::CDVDSubtitleParserMicroDVD(CDVDSubtitleStream* stream, const string& filename)
-    : CDVDSubtitleParserText(stream, filename)
+    : CDVDSubtitleParserText(stream, filename), m_framerate( DVD_TIME_BASE / 25.0 )
 {
 
 }

--- a/xbmc/cores/dvdplayer/DVDSubtitles/DVDSubtitleParserVplayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDSubtitles/DVDSubtitleParserVplayer.cpp
@@ -28,7 +28,7 @@
 using namespace std;
 
 CDVDSubtitleParserVplayer::CDVDSubtitleParserVplayer(CDVDSubtitleStream* pStream, const string& strFile)
-    : CDVDSubtitleParserText(pStream, strFile)
+    : CDVDSubtitleParserText(pStream, strFile), m_framerate(DVD_TIME_BASE)
 {
 }
 

--- a/xbmc/cores/dvdplayer/DVDSubtitles/DVDSubtitlesLibass.cpp
+++ b/xbmc/cores/dvdplayer/DVDSubtitles/DVDSubtitlesLibass.cpp
@@ -43,6 +43,7 @@ CDVDSubtitlesLibass::CDVDSubtitlesLibass()
 
   m_track = NULL;
   m_library = NULL;
+  m_renderer = NULL;
   m_references = 1;
 
   if(!m_dll.Load())

--- a/xbmc/cores/dvdplayer/DVDTSCorrection.cpp
+++ b/xbmc/cores/dvdplayer/DVDTSCorrection.cpp
@@ -47,6 +47,7 @@ void CPullupCorrection::Flush()
   m_patternlength = 0;
   m_frameduration = DVD_NOPTS_VALUE;
   m_trackingpts   = DVD_NOPTS_VALUE;
+  memset(m_diffring, 0, sizeof(m_diffring));
 }
 
 void CPullupCorrection::Add(double pts)

--- a/xbmc/cores/dvdplayer/Edl.cpp
+++ b/xbmc/cores/dvdplayer/Edl.cpp
@@ -219,7 +219,7 @@ bool CEdl::ReadEdl(const CStdString& strMovie, const float fFramesPerSecond)
         StringUtils::SplitString(strFields[i], ".", fieldParts);
         if (fieldParts.size() == 1) // No ms
         {
-          iCutStartEnd[i] = StringUtils::TimeStringToSeconds(fieldParts[0]) * 1000; // seconds to ms
+          iCutStartEnd[i] = StringUtils::TimeStringToSeconds(fieldParts[0]) * (int64_t)1000; // seconds to ms
         }
         else if (fieldParts.size() == 2) // Has ms. Everything after the dot (.) is ms
         {

--- a/xbmc/cores/paplayer/ADPCMCodec.cpp
+++ b/xbmc/cores/paplayer/ADPCMCodec.cpp
@@ -54,7 +54,6 @@ bool ADPCMCodec::Init(const CStdString &strFile, unsigned int filecache)
   m_BitsPerSample = 16;//m_dll.GetSampleSize(m_adpcm);
   m_DataFormat = AE_FMT_S16NE;
   m_TotalTime = m_dll.GetLength(m_adpcm); // fixme?
-  m_iDataPos = 0;
 
   return true;
 }

--- a/xbmc/cores/paplayer/ADPCMCodec.h
+++ b/xbmc/cores/paplayer/ADPCMCodec.h
@@ -42,7 +42,6 @@ private:
   bool m_bIsPlaying;
 
   DllADPCM m_dll;
-  int64_t m_iDataPos;
 };
 
 #endif

--- a/xbmc/cores/paplayer/CDDAcodec.cpp
+++ b/xbmc/cores/paplayer/CDDAcodec.cpp
@@ -89,7 +89,7 @@ int64_t CDDACodec::Seek(int64_t iSeekTime)
 
   // ... and look if we really got there.
   int iNewSeekTime=(iNewOffset/CDIO_CD_FRAMESIZE_RAW)/CDIO_CD_FRAMES_PER_SEC;
-  return iNewSeekTime*1000; // ms
+  return iNewSeekTime*(int64_t)1000; // ms
 }
 
 int CDDACodec::ReadPCM(BYTE *pBuffer, int size, int *actualsize)

--- a/xbmc/cores/paplayer/CachingCodec.h
+++ b/xbmc/cores/paplayer/CachingCodec.h
@@ -28,7 +28,7 @@ class CachingCodec : public ICodec
 {
 public:
   virtual ~CachingCodec() {}
-  virtual int GetCacheLevel() { return -1; }
+  virtual int GetCacheLevel() const { return -1; }
 
 protected:
   XFILE::CFile m_file;

--- a/xbmc/cores/paplayer/DVDPlayerCodec.cpp
+++ b/xbmc/cores/paplayer/DVDPlayerCodec.cpp
@@ -39,6 +39,7 @@ DVDPlayerCodec::DVDPlayerCodec()
   m_pDemuxer = NULL;
   m_pInputStream = NULL;
   m_pAudioCodec = NULL;
+  m_nAudioStream = -1;
   m_audioPos = 0;
   m_pPacket = NULL;
   m_decoded = NULL;;

--- a/xbmc/cores/paplayer/ICodec.h
+++ b/xbmc/cores/paplayer/ICodec.h
@@ -38,7 +38,9 @@ public:
   {
     m_TotalTime = 0;
     m_SampleRate = 0;
+    m_EncodedSampleRate = 0;
     m_BitsPerSample = 0;
+    m_DataFormat = AE_FMT_INVALID;
     m_Channels = 0;
     m_Bitrate = 0;
     m_CodecName = "";

--- a/xbmc/cores/paplayer/MP3codec.cpp
+++ b/xbmc/cores/paplayer/MP3codec.cpp
@@ -50,6 +50,7 @@ MP3Codec::MP3Codec()
 
   // mp3 related
   m_CallAgainWithSameBuffer = false;
+  m_readRetries = 5;
   m_lastByteOffset = 0;
   m_InputBufferSize = 64*1024;         // 64k is a reasonable amount, considering that we actual are
                                        // using a background reader thread now that caches in advance.
@@ -71,6 +72,7 @@ MP3Codec::MP3Codec()
   
   memset(&mxhouse, 0, sizeof(madx_house));
   memset(&mxstat,  0, sizeof(madx_stat));
+  mxsig = ERROR_OCCURED;
   
   m_HaveData = false;
   flushcnt = 0;

--- a/xbmc/cores/paplayer/MP3codec.h
+++ b/xbmc/cores/paplayer/MP3codec.h
@@ -80,9 +80,7 @@ private:
   int Read(int size, bool init = false);
 
   /* TODO decoder vars */
-  int m_BytesDecoded;
   bool m_HaveData;
-  unsigned int m_formatdata[8];
   unsigned char  flushcnt;
 
   madx_house mxhouse;

--- a/xbmc/cores/paplayer/NSFCodec.cpp
+++ b/xbmc/cores/paplayer/NSFCodec.cpp
@@ -26,11 +26,14 @@
 
 NSFCodec::NSFCodec()
 {
+  m_iTrack = 0;
   m_CodecName = "NSF";
-  m_nsf = 0;
+  m_nsf = NULL;
   m_bIsPlaying = false;
-  m_iDataInBuffer = 0;
   m_szBuffer = NULL;
+  m_szStartOfBuffer = NULL;
+  m_iDataInBuffer = 0;
+  m_iDataPos = 0;
 }
 
 NSFCodec::~NSFCodec()

--- a/xbmc/cores/paplayer/OGGcodec.cpp
+++ b/xbmc/cores/paplayer/OGGcodec.cpp
@@ -39,8 +39,8 @@ OGGCodec::OGGCodec() : m_callback(m_file)
   m_TimeOffset = 0.0;
   m_CurrentStream=0;
   m_TotalTime = 0;
-  m_VorbisFile.datasource = NULL;
   m_inited = false;
+  memset(&m_VorbisFile, 0, sizeof(m_VorbisFile));
 }
 
 OGGCodec::~OGGCodec()

--- a/xbmc/cores/paplayer/PAPlayer.cpp
+++ b/xbmc/cores/paplayer/PAPlayer.cpp
@@ -62,7 +62,7 @@ PAPlayer::PAPlayer(IPlayerCallback& callback) :
   m_audioCallback      (NULL ),
   m_FileItem           (new CFileItem())
 {
-  m_playerGUIData.m_codec[20] = 0;
+  memset(&m_playerGUIData, 0, sizeof(m_playerGUIData));
 }
 
 PAPlayer::~PAPlayer()

--- a/xbmc/cores/paplayer/PCMCodec.h
+++ b/xbmc/cores/paplayer/PCMCodec.h
@@ -33,8 +33,5 @@ public:
   virtual int ReadPCM(BYTE *pBuffer, int size, int *actualsize);
   virtual bool CanInit();
   virtual void SetMimeParams(const CStdString& strMimeParams);
-private:
-  int iBytesPerSecond;
 };
-
 

--- a/xbmc/cores/paplayer/TimidityCodec.cpp
+++ b/xbmc/cores/paplayer/TimidityCodec.cpp
@@ -40,6 +40,7 @@ TimidityCodec::TimidityCodec()
   m_iTrack = -1;
   m_iDataPos = -1;
   m_loader = NULL;
+  memset(&m_dll, 0, sizeof(m_dll));
 }
 
 TimidityCodec::~TimidityCodec()

--- a/xbmc/cores/paplayer/WAVcodec.cpp
+++ b/xbmc/cores/paplayer/WAVcodec.cpp
@@ -50,8 +50,9 @@ WAVCodec::WAVCodec()
   m_Channels = 0;
   m_BitsPerSample = 0;
   m_DataFormat = AE_FMT_INVALID;
-  m_iDataStart=0;
-  m_iDataLen=0;
+  m_iDataStart = 0;
+  m_iDataLen = 0;
+  m_ChannelMask = 0;
   m_Bitrate = 0;
   m_CodecName = "WAV";
 }

--- a/xbmc/filesystem/udf25.cpp
+++ b/xbmc/filesystem/udf25.cpp
@@ -129,11 +129,9 @@ static int UDFPartition( uint8_t *data, uint16_t *Flags, uint16_t *Number,
 
 static int UDFLogVolume( uint8_t *data, char *VolumeDescriptor )
 {
-  uint32_t lbsize, MT_L, N_PM;
+  uint32_t lbsize;
   Unicodedecode(&data[84], 128, VolumeDescriptor);
   lbsize = GETN4(212);  /* should be 2048 */
-  MT_L = GETN4(264);    /* should be 6 */
-  N_PM = GETN4(268);    /* should be 1 */
   if (lbsize != DVD_VIDEO_LB_LEN) return 1;
   return 0;
 }

--- a/xbmc/guilib/AnimatedGif.cpp
+++ b/xbmc/guilib/AnimatedGif.cpp
@@ -283,11 +283,15 @@ int CAnimatedGifSet::LoadGIF (const char * szFileName)
       GlobalColorMap[n].r = getbyte(fd);
       GlobalColorMap[n].g = getbyte(fd);
       GlobalColorMap[n].b = getbyte(fd);
+      GlobalColorMap[n].x = 0;
     }
 
   else // GIF standard says to provide an internal default Palette:
     for (n = 0;n < 256;n++)
+    {
       GlobalColorMap[n].r = GlobalColorMap[n].g = GlobalColorMap[n].b = n;
+      GlobalColorMap[n].x = 0;
+    }
 
   // *4* NOW WE HAVE 3 POSSIBILITIES:
   //  4a) Get and Extension Block (Blocks with additional information)

--- a/xbmc/guilib/AnimatedGif.cpp
+++ b/xbmc/guilib/AnimatedGif.cpp
@@ -516,8 +516,8 @@ int LZWDecoder (char * bufIn, char * bufOut,
   short OutCode;      // Code to output
 
   // Translation Table:
-  short Prefix[4096];    // Prefix: index of another Code
-  unsigned char Suffix[4096];    // Suffix: terminating character
+  short Prefix[4096] = {};    // Prefix: index of another Code
+  unsigned char Suffix[4096] = {};    // Suffix: terminating character
   short FirstEntry;     // Index of first free entry in table
   short NextEntry;     // Index of next free entry in table
 

--- a/xbmc/guilib/GUIAudioManager.h
+++ b/xbmc/guilib/GUIAudioManager.h
@@ -81,7 +81,6 @@ private:
   pythonSoundsMap     m_pythonSounds;
 
   CStdString          m_strMediaDir;
-  bool                m_bInitialized;
   bool                m_bEnabled;
 
   CCriticalSection    m_cs;

--- a/xbmc/guilib/GUIBaseContainer.cpp
+++ b/xbmc/guilib/GUIBaseContainer.cpp
@@ -60,6 +60,7 @@ CGUIBaseContainer::CGUIBaseContainer(int parentID, int controlID, float posX, fl
   m_focusedLayout = NULL;
   m_cacheItems = preloadItems;
   m_scrollItemsPerFrame = 0.0f;
+  m_type = VIEW_TYPE_NONE;
 }
 
 CGUIBaseContainer::~CGUIBaseContainer(void)

--- a/xbmc/guilib/GUIControl.cpp
+++ b/xbmc/guilib/GUIControl.cpp
@@ -83,6 +83,7 @@ CGUIControl::CGUIControl(int parentID, int controlID, float posX, float posY, fl
   m_hasCamera = false;
   m_pushedUpdates = false;
   m_pulseOnSelect = false;
+  m_controlIsDirty = false;
 }
 
 

--- a/xbmc/guilib/GUIControlProfiler.cpp
+++ b/xbmc/guilib/GUIControlProfiler.cpp
@@ -26,7 +26,7 @@
 bool CGUIControlProfiler::m_bIsRunning = false;
 
 CGUIControlProfilerItem::CGUIControlProfilerItem(CGUIControlProfiler *pProfiler, CGUIControlProfilerItem *pParent, CGUIControl *pControl)
-: m_pProfiler(pProfiler), m_pParent(pParent), m_pControl(pControl), m_visTime(0), m_renderTime(0)
+: m_pProfiler(pProfiler), m_pParent(pParent), m_pControl(pControl), m_visTime(0), m_renderTime(0), m_i64VisStart(0), m_i64RenderStart(0)
 {
   if (m_pControl)
   {
@@ -239,7 +239,7 @@ CGUIControlProfilerItem *CGUIControlProfilerItem::FindOrAddControl(CGUIControl *
 }
 
 CGUIControlProfiler::CGUIControlProfiler(void)
-: m_ItemHead(NULL, NULL, NULL), m_pLastItem(NULL), m_iMaxFrameCount(200)
+: m_ItemHead(NULL, NULL, NULL), m_pLastItem(NULL), m_iMaxFrameCount(200), m_iFrameCount(0)
 // m_bIsRunning(false), no isRunning because it is static
 {
   m_fPerfScale = 100000.0f / CurrentHostFrequency();

--- a/xbmc/guilib/GUIFadeLabelControl.cpp
+++ b/xbmc/guilib/GUIFadeLabelControl.cpp
@@ -53,6 +53,7 @@ CGUIFadeLabelControl::CGUIFadeLabelControl(const CGUIFadeLabelControl &from)
   m_currentLabel = 0;
   m_lastLabel = -1;
   ControlType = GUICONTROL_FADELABEL;
+  m_shortText = from.m_shortText;
 }
 
 CGUIFadeLabelControl::~CGUIFadeLabelControl(void)

--- a/xbmc/guilib/GUIFixedListContainer.cpp
+++ b/xbmc/guilib/GUIFixedListContainer.cpp
@@ -249,7 +249,6 @@ bool CGUIFixedListContainer::SelectItemFromPoint(const CPoint &point)
     SetCursor(cursor);
     return true;
   }
-  return InsideLayout(m_focusedLayout, point);
 }
 
 void CGUIFixedListContainer::SelectItem(int item)

--- a/xbmc/guilib/GUIFontTTFGL.cpp
+++ b/xbmc/guilib/GUIFontTTFGL.cpp
@@ -178,6 +178,7 @@ CBaseTexture* CGUIFontTTFGL::ReallocTexture(unsigned int& newHeight)
   if (!newTexture || newTexture->GetPixels() == NULL)
   {
     CLog::Log(LOGERROR, "GUIFontTTFGL::CacheCharacter: Error creating new cache texture for size %f", m_height);
+    delete newTexture;
     return NULL;
   }
   m_textureHeight = newTexture->GetHeight();

--- a/xbmc/guilib/GUIKeyboardFactory.cpp
+++ b/xbmc/guilib/GUIKeyboardFactory.cpp
@@ -95,9 +95,12 @@ bool CGUIKeyboardFactory::ShowAndGetInput(CStdString& aTextString, const CVarian
     needsFreeing = false;
   }
 
-  confirmed = kb->ShowAndGetInput(keyTypedCB, aTextString, aTextString, headingStr, hiddenInput);
-  if(needsFreeing)
-    delete kb;
+  if(kb)
+  {
+    confirmed = kb->ShowAndGetInput(keyTypedCB, aTextString, aTextString, headingStr, hiddenInput);
+    if(needsFreeing)
+      delete kb;
+  }
 
   if (confirmed)
   {

--- a/xbmc/guilib/GUILabelControl.cpp
+++ b/xbmc/guilib/GUILabelControl.cpp
@@ -34,7 +34,6 @@ CGUILabelControl::CGUILabelControl(int parentID, int controlID, float posX, floa
   m_dwCounter = 0;
   ControlType = GUICONTROL_LABEL;
   m_startHighlight = m_endHighlight = 0;
-  m_autoWidth = false;
   m_minWidth = 0;
   if ((labelInfo.align & XBFONT_RIGHT) && m_width)
     m_posX -= m_width;

--- a/xbmc/guilib/GUILabelControl.cpp
+++ b/xbmc/guilib/GUILabelControl.cpp
@@ -34,6 +34,7 @@ CGUILabelControl::CGUILabelControl(int parentID, int controlID, float posX, floa
   m_dwCounter = 0;
   ControlType = GUICONTROL_LABEL;
   m_startHighlight = m_endHighlight = 0;
+  m_autoWidth = false;
   m_minWidth = 0;
   if ((labelInfo.align & XBFONT_RIGHT) && m_width)
     m_posX -= m_width;

--- a/xbmc/guilib/GUILabelControl.h
+++ b/xbmc/guilib/GUILabelControl.h
@@ -75,7 +75,6 @@ protected:
   unsigned int m_dwCounter;
 
   // stuff for autowidth
-  bool m_autoWidth;
   float m_minWidth;
 
   // multi-info stuff

--- a/xbmc/guilib/GUIMultiImage.cpp
+++ b/xbmc/guilib/GUIMultiImage.cpp
@@ -62,6 +62,7 @@ CGUIMultiImage::CGUIMultiImage(const CGUIMultiImage &from)
     m_currentPath = m_texturePath.GetLabel(WINDOW_INVALID);
   m_currentImage = 0;
   ControlType = GUICONTROL_MULTI_IMAGE;
+  m_jobID = 0;
 }
 
 CGUIMultiImage::~CGUIMultiImage(void)

--- a/xbmc/guilib/GUIRSSControl.cpp
+++ b/xbmc/guilib/GUIRSSControl.cpp
@@ -52,6 +52,7 @@ CGUIRSSControl::CGUIRSSControl(const CGUIRSSControl &from)
   m_channelColor = from.m_channelColor;
   m_strRSSTags = from.m_strRSSTags;
   m_pReader = NULL;
+  m_rtl = from.m_rtl;
   ControlType = GUICONTROL_RSS;
 }
 

--- a/xbmc/guilib/GUIResizeControl.cpp
+++ b/xbmc/guilib/GUIResizeControl.cpp
@@ -40,6 +40,7 @@ CGUIResizeControl::CGUIResizeControl(int parentID, int controlID, float posX, fl
   m_fMaxSpeed = 10.0;  // TODO: implement correct computation of maxspeed
   ControlType = GUICONTROL_RESIZE;
   SetLimits(0, 0, 720, 576); // defaults
+  m_nDirection = DIRECTION_NONE;
 }
 
 CGUIResizeControl::~CGUIResizeControl(void)

--- a/xbmc/guilib/GUITextureGL.cpp
+++ b/xbmc/guilib/GUITextureGL.cpp
@@ -32,6 +32,7 @@
 CGUITextureGL::CGUITextureGL(float posX, float posY, float width, float height, const CTextureInfo &texture)
 : CGUITextureBase(posX, posY, width, height, texture)
 {
+  memset(m_col, 0, sizeof(m_col));
 }
 
 void CGUITextureGL::Begin(color_t color)

--- a/xbmc/guilib/GUIVisualisationControl.cpp
+++ b/xbmc/guilib/GUIVisualisationControl.cpp
@@ -41,7 +41,7 @@ CGUIVisualisationControl::CGUIVisualisationControl(int parentID, int controlID, 
 }
 
 CGUIVisualisationControl::CGUIVisualisationControl(const CGUIVisualisationControl &from)
-: CGUIRenderingControl(from)
+: CGUIRenderingControl(from), m_bAttemptedLoad(false)
 {
   ControlType = GUICONTROL_VISUALISATION;
 }

--- a/xbmc/guilib/JpegIO.cpp
+++ b/xbmc/guilib/JpegIO.cpp
@@ -487,6 +487,7 @@ bool CJpegIO::CreateThumbnailFromSurface(unsigned char* buffer, unsigned int wid
   else
   {
     CLog::Log(LOGWARNING, "JpegIO::CreateThumbnailFromSurface Unsupported format");
+    free(result);
     return false;
   }
 

--- a/xbmc/guilib/JpegIO.cpp
+++ b/xbmc/guilib/JpegIO.cpp
@@ -237,6 +237,7 @@ CJpegIO::CJpegIO()
   m_inputBuffSize = 0;
   m_inputBuff = NULL;
   m_texturePath = "";
+  memset(&m_cinfo, 0, sizeof(m_cinfo));
 }
 
 CJpegIO::~CJpegIO()

--- a/xbmc/guilib/TextureBundleXBT.cpp
+++ b/xbmc/guilib/TextureBundleXBT.cpp
@@ -40,6 +40,7 @@
 CTextureBundleXBT::CTextureBundleXBT(void)
 {
   m_themeBundle = false;
+  m_TimeStamp = 0;
 }
 
 CTextureBundleXBT::~CTextureBundleXBT(void)

--- a/xbmc/guilib/TextureBundleXPR.cpp
+++ b/xbmc/guilib/TextureBundleXPR.cpp
@@ -101,6 +101,7 @@ CTextureBundleXPR::CTextureBundleXPR(void)
 {
   m_hFile = NULL;
   m_themeBundle = false;
+  m_TimeStamp = 0;
 }
 
 CTextureBundleXPR::~CTextureBundleXPR(void)

--- a/xbmc/guilib/TextureBundleXPR.cpp
+++ b/xbmc/guilib/TextureBundleXPR.cpp
@@ -301,12 +301,17 @@ bool CTextureBundleXPR::LoadFile(const CStdString& Filename, CAutoTexBuffer& Unp
   }
 
   // read the file into our buffer
-  DWORD n;
-  fseek(m_hFile, file->second.Offset, SEEK_SET);
-  n = fread(buffer, 1, ReadSize, m_hFile);
+  if (fseek(m_hFile, file->second.Offset, SEEK_SET) != 0)
+  {
+    CLog::Log(LOGERROR, "Error loading texture: %s: %s: Seek error", Filename.c_str(), strerror(ferror(m_hFile)));
+    free(buffer);
+    return false;            
+  }
+  
+  DWORD n = fread(buffer, 1, ReadSize, m_hFile);
   if (n < ReadSize && !feof(m_hFile))
   {
-    CLog::Log(LOGERROR, "Error loading texture: %s: %s", Filename.c_str(), strerror(ferror(m_hFile)));
+    CLog::Log(LOGERROR, "Error loading texture: %s: %s: Read error", Filename.c_str(), strerror(ferror(m_hFile)));
     free(buffer);
     return false;
   }

--- a/xbmc/guilib/TextureManager.cpp
+++ b/xbmc/guilib/TextureManager.cpp
@@ -327,6 +327,8 @@ int CGUITextureManager::Load(const CStdString& strTextureName, bool checkBundleO
       if (!nImages)
       {
         CLog::Log(LOGERROR, "Texture manager unable to load bundled file: %s", strTextureName.c_str());
+        delete [] pTextures;
+        delete [] Delay;
         return 0;
       }
 

--- a/xbmc/guilib/XBTF.cpp
+++ b/xbmc/guilib/XBTF.cpp
@@ -29,6 +29,7 @@ CXBTFFrame::CXBTFFrame()
   m_unpackedSize = 0;
   m_offset = 0;
   m_format = XB_FMT_UNKNOWN;
+  m_duration = 0;
 }
 
 uint32_t CXBTFFrame::GetWidth() const

--- a/xbmc/interfaces/python/XBPyThread.cpp
+++ b/xbmc/interfaces/python/XBPyThread.cpp
@@ -75,6 +75,7 @@ XBPyThread::XBPyThread(XBPython *pExecuter, int id) : CThread("XBPyThread")
   m_argv        = NULL;
   m_source      = NULL;
   m_argc        = 0;
+  m_type        = 0;
 }
 
 XBPyThread::~XBPyThread()

--- a/xbmc/interfaces/python/XBPython.cpp
+++ b/xbmc/interfaces/python/XBPython.cpp
@@ -75,6 +75,8 @@ XBPython::XBPython()
   m_mainThreadState   = NULL;
   m_ThreadId          = CThread::GetCurrentThreadId();
   m_iDllScriptCounter = 0;
+  m_endtime           = 0;
+  m_pDll              = NULL;
   m_vecPlayerCallbackList.clear();
   m_vecMonitorCallbackList.clear();
   CAnnouncementManager::AddAnnouncer(this);
@@ -630,7 +632,6 @@ void XBPython::Finalize()
     // The implementation for osx can never unload the python dylib.
     DllLoaderContainer::ReleaseModule(m_pDll);
 #endif
-    m_hModule         = NULL;
     m_mainThreadState = NULL;
     m_bInitialized    = false;
   }

--- a/xbmc/interfaces/python/XBPython.h
+++ b/xbmc/interfaces/python/XBPython.h
@@ -128,7 +128,6 @@ private:
   ThreadIdentifier  m_ThreadId;
   bool              m_bInitialized;
   int               m_iDllScriptCounter; // to keep track of the total scripts running that need the dll
-  HMODULE           m_hModule;
   unsigned int      m_endtime;
 
   //Vector with list of threads used for running scripts

--- a/xbmc/music/tags/MusicInfoTag.cpp
+++ b/xbmc/music/tags/MusicInfoTag.cpp
@@ -182,7 +182,7 @@ const std::vector<std::string>& CMusicInfoTag::GetAlbumArtist() const
   return m_albumArtist;
 }
 
-const std::vector<std::string> CMusicInfoTag::GetGenre() const
+const std::vector<std::string>& CMusicInfoTag::GetGenre() const
 {
   return m_genre;
 }

--- a/xbmc/music/tags/MusicInfoTag.h
+++ b/xbmc/music/tags/MusicInfoTag.h
@@ -72,7 +72,7 @@ public:
   const CStdString& GetAlbum() const;
   int GetAlbumId() const;
   const std::vector<std::string>& GetAlbumArtist() const;
-  const std::vector<std::string> GetGenre() const;
+  const std::vector<std::string>& GetGenre() const;
   int GetTrackNumber() const;
   int GetDiscNumber() const;
   int GetTrackAndDiskNumber() const;

--- a/xbmc/settings/GUIWindowSettingsCategory.cpp
+++ b/xbmc/settings/GUIWindowSettingsCategory.cpp
@@ -1949,8 +1949,8 @@ CGUIControl* CGUIWindowSettingsCategory::AddSetting(CSetting *pSetting, float wi
   {
     pControl->AllocResources();
     group->AddControl(pControl);
-    m_vecSettings.push_back(pSettingControl);
   }
+  m_vecSettings.push_back(pSettingControl);
   return pControl;
 }
 

--- a/xbmc/storage/cdioSupport.cpp
+++ b/xbmc/storage/cdioSupport.cpp
@@ -850,6 +850,8 @@ CCdInfo* CCdIoSupport::GetCdInfo(char* cDeviceFileName)
       ti.isofs_size = m_nIsofsSize;
       ti.nJolietLevel = m_nJolietLevel;
       ti.nFrames = ::cdio_get_track_lba(cdio, i);
+      ti.nMins = 0;
+      ti.nSecs = 0;
       info->SetDiscLabel(m_strDiscLabel);
 
 

--- a/xbmc/threads/platform/pthreads/ThreadLocal.h
+++ b/xbmc/threads/platform/pthreads/ThreadLocal.h
@@ -33,7 +33,7 @@ namespace XbmcThreads
   {
     pthread_key_t key;
   public:
-    inline ThreadLocal() { pthread_key_create(&key,NULL); }
+    inline ThreadLocal() : key(0) { pthread_key_create(&key,NULL); }
 
     inline ~ThreadLocal() { pthread_key_delete(key); }
 

--- a/xbmc/utils/POUtils.cpp
+++ b/xbmc/utils/POUtils.cpp
@@ -215,7 +215,7 @@ std::string CPODocument::UnescapeString(const std::string &strInput)
                   "POParser: warning, unhandled escape character "
                   "at line-end. Problematic entry: %s",
                   m_Entry.Content.c_str());
-        continue;
+        break;
       }
       switch (*it++)
       {

--- a/xbmc/utils/PerformanceStats.cpp
+++ b/xbmc/utils/PerformanceStats.cpp
@@ -55,7 +55,7 @@ void CPerformanceStats::AddSample(const string &strStatName, const PerformanceCo
 
 void CPerformanceStats::AddSample(const string &strStatName, double dTime)
 {
-  AddSample(strStatName, *(new PerformanceCounter(dTime)));
+  AddSample(strStatName, PerformanceCounter(dTime));
 }
 
 void CPerformanceStats::DumpStats()

--- a/xbmc/utils/RegExp.cpp
+++ b/xbmc/utils/RegExp.cpp
@@ -36,6 +36,8 @@ CRegExp::CRegExp(bool caseless)
 
   m_bMatched    = false;
   m_iMatchCount = 0;
+
+  memset(m_iOvector, 0, sizeof(m_iOvector));
 }
 
 CRegExp::CRegExp(const CRegExp& re)

--- a/xbmc/utils/RssReader.cpp
+++ b/xbmc/utils/RssReader.cpp
@@ -50,6 +50,8 @@ CRssReader::CRssReader() : CThread("CRssReader")
   m_spacesBetweenFeeds = 0;
   m_bIsRunning = false;
   m_SavedScrollPos = 0;
+  m_rtlText = false;
+  m_requestRefresh = false;
 }
 
 CRssReader::~CRssReader()

--- a/xbmc/utils/ScraperParser.cpp
+++ b/xbmc/utils/ScraperParser.cpp
@@ -292,22 +292,24 @@ void CScraperParser::ParseExpression(const CStdString& input, CStdString& dest, 
       // nasty hack #1 - & means \0 in a replace string
       strCurOutput.Replace("&","!!!AMPAMP!!!");
       char* result = reg.GetReplaceString(strCurOutput.c_str());
-      if (result && strlen(result))
+      if (result)
       {
-        CStdString strResult(result);
-        strResult.Replace("!!!AMPAMP!!!","&");
-        Clean(strResult);
-        ReplaceBuffers(strResult);
-        if (iCompare > -1)
+        if (strlen(result))
         {
-          CStdString strResultNoCase = strResult;
-          strResultNoCase.ToLower();
-          if (strResultNoCase.Find(m_param[iCompare-1]) != -1)
+          CStdString strResult(result);
+          strResult.Replace("!!!AMPAMP!!!","&");
+          Clean(strResult);
+          ReplaceBuffers(strResult);
+          if (iCompare > -1)
+          {
+            CStdString strResultNoCase = strResult;
+            strResultNoCase.ToLower();
+            if (strResultNoCase.Find(m_param[iCompare-1]) != -1)
+              dest += strResult;
+          }
+          else
             dest += strResult;
         }
-        else
-          dest += strResult;
-
         free(result);
       }
       if (bRepeat && iLen > 0)

--- a/xbmc/utils/ScraperParser.cpp
+++ b/xbmc/utils/ScraperParser.cpp
@@ -42,6 +42,7 @@ CScraperParser::CScraperParser()
   m_pRootElement = NULL;
   m_document = NULL;
   m_SearchStringEncoding = "UTF-8";
+  m_scraper = NULL;
 }
 
 CScraperParser::CScraperParser(const CScraperParser& parser)
@@ -62,6 +63,8 @@ CScraperParser &CScraperParser::operator=(const CScraperParser &parser)
       m_document = new CXBMCTinyXML(*parser.m_document);
       LoadFromXML();
     }
+    else
+      m_scraper = NULL;
   }
   return *this;
 }

--- a/xbmc/utils/ScraperUrl.cpp
+++ b/xbmc/utils/ScraperUrl.cpp
@@ -157,7 +157,11 @@ const CScraperUrl::SUrlEntry CScraperUrl::GetFirstThumb() const
     if (iter->m_type == URL_TYPE_GENERAL)
       return *iter;
   }
+
   SUrlEntry result;
+  result.m_type = URL_TYPE_GENERAL;
+  result.m_post = false;
+  result.m_isgz = false;
   result.m_season = -1;
   return result;
 }
@@ -169,7 +173,11 @@ const CScraperUrl::SUrlEntry CScraperUrl::GetSeasonThumb(int season) const
     if (iter->m_type == URL_TYPE_SEASON && iter->m_season == season)
       return *iter;
   }
+
   SUrlEntry result;
+  result.m_type = URL_TYPE_GENERAL;
+  result.m_post = false;
+  result.m_isgz = false;
   result.m_season = -1;
   return result;
 }

--- a/xbmc/utils/ScraperUrl.cpp
+++ b/xbmc/utils/ScraperUrl.cpp
@@ -208,14 +208,16 @@ bool CScraperUrl::Get(const SUrlEntry& scrURL, std::string& strHTML, XFILE::CCur
     if (XFILE::CFile::Exists(strCachePath))
     {
       XFILE::CFile file;
-      file.Open(strCachePath);
-      char* temp = new char[(int)file.GetLength()];
-      file.Read(temp,file.GetLength());
-      strHTML.clear();
-      strHTML.append(temp,temp+file.GetLength());
-      file.Close();
-      delete[] temp;
-      return true;
+      if (file.Open(strCachePath))
+      {
+        char* temp = new char[(int)file.GetLength()];
+        file.Read(temp,file.GetLength());
+        strHTML.clear();
+        strHTML.append(temp,temp+file.GetLength());
+        file.Close();
+        delete[] temp;
+        return true;
+      }
     }
   }
 

--- a/xbmc/utils/StreamDetails.h
+++ b/xbmc/utils/StreamDetails.h
@@ -35,7 +35,7 @@ public:
     SUBTITLE
   };
 
-  CStreamDetail(StreamType type) : m_eType(type) {};
+  CStreamDetail(StreamType type) : m_eType(type), m_pParent(NULL) {};
   virtual void Archive(CArchive& ar);
   virtual void Serialize(CVariant& value);
   virtual bool IsWorseThan(CStreamDetail *that) { return true; };

--- a/xbmc/utils/SystemInfo.cpp
+++ b/xbmc/utils/SystemInfo.cpp
@@ -212,6 +212,7 @@ void CSysInfo::Reset()
 
 CSysInfo::CSysInfo(void) : CInfoLoader(15 * 1000)
 {
+  memset(MD5_Sign, 0, sizeof(MD5_Sign));
 }
 
 CSysInfo::~CSysInfo()
@@ -280,7 +281,14 @@ bool CSysInfo::GetDiskSpace(const CStdString drive,int& iTotal, int& iTotalFree,
     iTotal = (int)( ULTotal.QuadPart / MB );
     iTotalFree = (int)( ULTotalFree.QuadPart / MB );
     iTotalUsed = iTotal - iTotalFree;
-    iPercentUsed = (int)( 100.0f * ( ULTotal.QuadPart - ULTotalFree.QuadPart ) / ULTotal.QuadPart + 0.5f );
+    if( ULTotal.QuadPart > 0 )
+    {
+      iPercentUsed = (int)( 100.0f * ( ULTotal.QuadPart - ULTotalFree.QuadPart ) / ULTotal.QuadPart + 0.5f );
+    }
+    else
+    {
+      iPercentUsed = 0;
+    }
     iPercentFree = 100 - iPercentUsed;
   }
 

--- a/xbmc/utils/TuxBoxUtil.cpp
+++ b/xbmc/utils/TuxBoxUtil.cpp
@@ -58,6 +58,8 @@ CTuxBoxService::~CTuxBoxService()
 CTuxBoxUtil::CTuxBoxUtil(void)
 {
   sCurSrvData.requested_audio_channel = 0;
+  sZapstream.initialized = false;
+  sZapstream.available = false;
 }
 CTuxBoxUtil::~CTuxBoxUtil(void)
 {
@@ -797,9 +799,9 @@ bool CTuxBoxUtil::StreamInformations(TiXmlElement *pRootElement)
 
   TiXmlNode *pNode = NULL;
   TiXmlNode *pIt = NULL;
-  CStdString strRoot = pRootElement->Value();
-  if(pRootElement !=NULL)
+  if(pRootElement != NULL)
   {
+    CStdString strRoot = pRootElement->Value();
     pNode = pRootElement->FirstChild("frontend");
     if (pNode)
     {

--- a/xbmc/utils/Weather.cpp
+++ b/xbmc/utils/Weather.cpp
@@ -70,6 +70,7 @@ bool CWeatherJob::m_imagesOkay = false;
 CWeatherJob::CWeatherJob(int location)
 {
   m_location = location;
+  m_info.Reset();
 }
 
 bool CWeatherJob::DoWork()
@@ -330,55 +331,58 @@ void CWeatherJob::SetFromProperties()
   if (!m_localizedTokens.size())
     LoadLocalizedToken();
 
-  CGUIWindow* window        = g_windowManager.GetWindow(WINDOW_WEATHER);
-  CDateTime time=CDateTime::GetCurrentDateTime();
-  m_info.lastUpdateTime     = time.GetAsLocalizedDateTime(false, false);
-  m_info.currentConditions  = window->GetProperty("Current.Condition").asString();
-  m_info.currentIcon = ConstructPath(window->GetProperty("Current.OutlookIcon").asString());
-  LocalizeOverview(m_info.currentConditions);
-  FormatTemperature(m_info.currentTemperature,
-      strtol(window->GetProperty("Current.Temperature").asString().c_str(),0,10));
-  FormatTemperature(m_info.currentFeelsLike,
-      strtol(window->GetProperty("Current.FeelsLike").asString().c_str(),0,10));
-  m_info.currentUVIndex     = window->GetProperty("Current.UVIndex").asString();
-  LocalizeOverview(m_info.currentUVIndex);
-  int speed = ConvertSpeed(strtol(window->GetProperty("Current.Wind").asString().c_str(),0,10));
-  CStdString direction = window->GetProperty("Current.WindDirection").asString();
-  if (direction ==  "CALM")
-    m_info.currentWind = g_localizeStrings.Get(1410);
-  else
+  CGUIWindow* window = g_windowManager.GetWindow(WINDOW_WEATHER);
+  if (window)
   {
-    LocalizeOverviewToken(direction);
-    m_info.currentWind.Format(g_localizeStrings.Get(434).c_str(),
-        direction, speed, g_langInfo.GetSpeedUnitString().c_str());
-  }
-  CStdString windspeed;
-  windspeed.Format("%i %s",speed,g_langInfo.GetSpeedUnitString().c_str());
-  window->SetProperty("Current.WindSpeed",windspeed);
-  FormatTemperature(m_info.currentDewPoint,
-      strtol(window->GetProperty("Current.DewPoint").asString().c_str(),0,10));
-  if (window->GetProperty("Current.Humidity").asString().empty())
-    m_info.currentHumidity.clear();
-  else
-    m_info.currentHumidity.Format("%s%%",window->GetProperty("Current.Humidity").asString().c_str());
-  m_info.location           = window->GetProperty("Current.Location").asString();
-  for (int i=0;i<NUM_DAYS;++i)
-  {
-    CStdString strDay;
-    strDay.Format("Day%i.Title",i);
-    m_info.forecast[i].m_day = window->GetProperty(strDay).asString();
-    LocalizeOverviewToken(m_info.forecast[i].m_day);
-    strDay.Format("Day%i.HighTemp",i);
-    FormatTemperature(m_info.forecast[i].m_high,
-                  strtol(window->GetProperty(strDay).asString().c_str(),0,10));
-    strDay.Format("Day%i.LowTemp",i);
-    FormatTemperature(m_info.forecast[i].m_low,
-                  strtol(window->GetProperty(strDay).asString().c_str(),0,10));
-    strDay.Format("Day%i.OutlookIcon",i);
-    m_info.forecast[i].m_icon = ConstructPath(window->GetProperty(strDay).asString());
-    strDay.Format("Day%i.Outlook",i);
-    m_info.forecast[i].m_overview = window->GetProperty(strDay).asString();
-    LocalizeOverview(m_info.forecast[i].m_overview);
+    CDateTime time = CDateTime::GetCurrentDateTime();
+    m_info.lastUpdateTime = time.GetAsLocalizedDateTime(false, false);
+    m_info.currentConditions = window->GetProperty("Current.Condition").asString();
+    m_info.currentIcon = ConstructPath(window->GetProperty("Current.OutlookIcon").asString());
+    LocalizeOverview(m_info.currentConditions);
+    FormatTemperature(m_info.currentTemperature,
+        strtol(window->GetProperty("Current.Temperature").asString().c_str(),0,10));
+    FormatTemperature(m_info.currentFeelsLike,
+        strtol(window->GetProperty("Current.FeelsLike").asString().c_str(),0,10));
+    m_info.currentUVIndex = window->GetProperty("Current.UVIndex").asString();
+    LocalizeOverview(m_info.currentUVIndex);
+    int speed = ConvertSpeed(strtol(window->GetProperty("Current.Wind").asString().c_str(),0,10));
+    CStdString direction = window->GetProperty("Current.WindDirection").asString();
+    if (direction == "CALM")
+      m_info.currentWind = g_localizeStrings.Get(1410);
+    else
+    {
+      LocalizeOverviewToken(direction);
+      m_info.currentWind.Format(g_localizeStrings.Get(434).c_str(),
+          direction, speed, g_langInfo.GetSpeedUnitString().c_str());
+    }
+    CStdString windspeed;
+    windspeed.Format("%i %s",speed,g_langInfo.GetSpeedUnitString().c_str());
+    window->SetProperty("Current.WindSpeed",windspeed);
+    FormatTemperature(m_info.currentDewPoint,
+        strtol(window->GetProperty("Current.DewPoint").asString().c_str(),0,10));
+    if (window->GetProperty("Current.Humidity").asString().empty())
+      m_info.currentHumidity.clear();
+    else
+      m_info.currentHumidity.Format("%s%%",window->GetProperty("Current.Humidity").asString().c_str());
+    m_info.location = window->GetProperty("Current.Location").asString();
+    for (int i=0;i<NUM_DAYS;++i)
+    {
+      CStdString strDay;
+      strDay.Format("Day%i.Title",i);
+      m_info.forecast[i].m_day = window->GetProperty(strDay).asString();
+      LocalizeOverviewToken(m_info.forecast[i].m_day);
+      strDay.Format("Day%i.HighTemp",i);
+      FormatTemperature(m_info.forecast[i].m_high,
+                    strtol(window->GetProperty(strDay).asString().c_str(),0,10));
+      strDay.Format("Day%i.LowTemp",i);
+      FormatTemperature(m_info.forecast[i].m_low,
+                    strtol(window->GetProperty(strDay).asString().c_str(),0,10));
+      strDay.Format("Day%i.OutlookIcon",i);
+      m_info.forecast[i].m_icon = ConstructPath(window->GetProperty(strDay).asString());
+      strDay.Format("Day%i.Outlook",i);
+      m_info.forecast[i].m_overview = window->GetProperty(strDay).asString();
+      LocalizeOverview(m_info.forecast[i].m_overview);
+    }
   }
 }
 
@@ -421,9 +425,13 @@ CStdString CWeather::TranslateInfo(int info) const
 CStdString CWeather::GetLocation(int iLocation)
 {
   CGUIWindow* window = g_windowManager.GetWindow(WINDOW_WEATHER);
-  CStdString setting;
-  setting.Format("Location%i", iLocation);
-  return window->GetProperty(setting).asString();
+  if (window)
+  {
+    CStdString setting;
+    setting.Format("Location%i", iLocation);
+    return window->GetProperty(setting).asString();
+  }
+  return "";
 }
 
 void CWeather::Reset()

--- a/xbmc/video/Teletext.cpp
+++ b/xbmc/video/Teletext.cpp
@@ -1662,7 +1662,7 @@ void CTeletextDecoder::Decode_ADIP() /* additional information table */
     m_txtCache->ADIP_Pg[i] = 0; /* completely decoded: clear entry */
   } /* next adip page i */
 
-  while (!m_txtCache->ADIP_Pg[m_txtCache->ADIP_PgMax] && (m_txtCache->ADIP_PgMax >= 0)) /* and shrink table */
+  while ((m_txtCache->ADIP_PgMax >= 0) && !m_txtCache->ADIP_Pg[m_txtCache->ADIP_PgMax]) /* and shrink table */
     m_txtCache->ADIP_PgMax--;
 }
 

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -5511,7 +5511,9 @@ bool CVideoDatabase::GetMoviesByWhere(const CStdString& strBaseDir, const Filter
       }
 
       CVideoDbUrl setUrl;
-      setUrl.FromString("videodb://1/7/");
+      if (!setUrl.FromString("videodb://1/7/"))
+        return false;
+ 
       setUrl.AddOptions(videoUrl.GetOptionsString());
       GetSetsByWhere(setUrl.ToString(), setsFilter, setItems);
 
@@ -8496,9 +8498,9 @@ void CVideoDatabase::ImportFromXML(const CStdString &path)
               int seasonNum = -1;
               season->Attribute("num", &seasonNum);
               map<string, string> artwork;
-              ImportArtFromXML(season, artwork);
+              
               int seasonID = AddSeason(showID, seasonNum);
-              if (seasonID > -1)
+              if (ImportArtFromXML(season, artwork) &&  seasonID > -1)
                 SetArtForItem(seasonID, "season", artwork);
             }
             season = season->NextSiblingElement("season");

--- a/xbmc/video/VideoInfoDownloader.cpp
+++ b/xbmc/video/VideoInfoDownloader.cpp
@@ -38,7 +38,7 @@ using namespace std;
 #endif
 
 CVideoInfoDownloader::CVideoInfoDownloader(const ADDON::ScraperPtr &scraper) :
-  CThread("CVideoInfoDownloader"), m_info(scraper)
+  CThread("CVideoInfoDownloader"), m_state(DO_NOTHING), m_found(0), m_info(scraper)
 {
   m_http = new XFILE::CCurlFile;
 }

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -944,8 +944,8 @@ namespace VIDEO
             offset += regexp2pos + reg2.GetFindLen();
           }
         }
-        free(remainder);
       }
+      free(remainder);
       return true;
     }
     return false;
@@ -1592,7 +1592,10 @@ namespace VIDEO
             art.insert(make_pair(0, items[i]->GetPath()));
           else if (reg.RegFind(name) > -1)
           {
-            int season = atoi(reg.GetReplaceString("\\1"));
+            char* seasonStr = reg.GetReplaceString("\\1");
+            int season = atoi(seasonStr);
+            free(seasonStr);
+
             art.insert(make_pair(season, items[i]->GetPath()));
           }
         }

--- a/xbmc/video/VideoReferenceClock.cpp
+++ b/xbmc/video/VideoReferenceClock.cpp
@@ -116,9 +116,29 @@ CVideoReferenceClock::CVideoReferenceClock() : CThread("CVideoReferenceClock")
   m_UseVblank = false;
   m_Started.Reset();
 
+  m_CurrTime = 0;
+  m_LastIntTime = 0;
+  m_CurrTimeFract = 0.0;
+  m_LastRefreshTime = 0;
+  m_fineadjust = 0.0;
+  m_RefreshRate = 0;
+  m_PrevRefreshRate = 0;
+  m_MissedVblanks = 0;
+  m_RefreshChanged = 0;
+  m_VblankTime = 0;
+
 #if defined(HAS_GLX) && defined(HAS_XRANDR)
+  m_glXWaitVideoSyncSGI = NULL;
+  m_glXGetVideoSyncSGI = NULL;
   m_Dpy = NULL;
+  m_vInfo = NULL;
+  m_Window = 0;
+  m_Context = NULL;
+  m_pixmap = None;
+  m_glPixmap = None;
+  m_RREventBase = 0;
   m_UseNvSettings = true;
+  m_bIsATI = false;
 #endif
 }
 


### PR DESCRIPTION
I've managed to get XBMC added to the list of Open Source projects that is scanned for free by the Coverity Static Analysis tool. See http://scan.coverity.com/ for more details about this program.

For other developers that are interested in viewing the static analysis output, please contact me for login information.

This pull request aggregates all of my commits to fix these static analysis issues.  Please note that some of the uninitialized class member "fixes" may not resolve actual bugs, but instead follow good practice of initializing class members in the constructor.
