### PR TITLE
[AE] - Make sure, that m_channelLayout is updated, when user has set too...

### DIFF
--- a/xbmc/cores/AudioEngine/Sinks/AESinkALSA.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkALSA.cpp
@@ -257,8 +257,7 @@ bool CAESinkALSA::InitializeHW(AEAudioFormat &format)
   /* ensure we opened X channels or more */
   if (format.m_channelLayout.Count() > channelCount)
   {
-    CLog::Log(LOGERROR, "CAESinkALSA::InitializeHW - Unable to open the required number of channels");
-    return false;
+    CLog::Log(LOGINFO, "CAESinkALSA::InitializeHW - Unable to open the required number of channels");
   }
 
   /* update the channelLayout to what we managed to open */


### PR DESCRIPTION
If a user wrongly sets 6 channels but his output device does only support 2 channels, video playback will get really choppy. AE currently does not handle this error and I did not find a way to do this more sane. So at least give alsa a chance ...

See also the following comment, I think this was intended to get fixed at this point?
