### PR TITLE
Set system timer precision back to 1ms - post getting rid of SDL fix

### DIFF
--- a/xbmc/win32/XBMC_PC.cpp
+++ b/xbmc/win32/XBMC_PC.cpp
@@ -185,6 +185,9 @@ INT WINAPI WinMain( HINSTANCE hInst, HINSTANCE, LPSTR commandLine, INT )
   WSADATA wd;
   WSAStartup(MAKEWORD(2,2), &wd);
 
+  // use 1 ms timer precision - like SDL initialization used to do
+  timeBeginPeriod(1);
+
   // Create and run the app
   if(!g_application.Create())
   {
@@ -216,6 +219,9 @@ INT WINAPI WinMain( HINSTANCE hInst, HINSTANCE, LPSTR commandLine, INT )
   }
 
   g_application.Run(true);
+
+  // clear previously set timer resolution
+  timeEndPeriod(1);		
 
   // the end
   WSACleanup();


### PR DESCRIPTION
Ever since SDL was finally removed (June 6th 2012) video playback suffers from fluctuating fps. The root cause is to be found in the timer precision. I analysed the SDL_StartTicks function. The only thing it does is setting Windows-wide timer precision to 1 ms, by calling timeBeginPeriod(1); 
I added just that line, and it has the same effect, so problem solved. The actual effect is on the timeGetTime() Windows function, which is used in our XbmcThreads::SystemClockMillis(). Without initialisation, the precision can be as bad as 5 ms, or worse, see Microsoft doc at http://msdn.microsoft.com/en-us/library/windows/desktop/dd757629(v=vs.85).aspx
Some people see this more severely than others, because the precision is system-dependent. 

Of course increasing timer precision to 1ms may potentially comes at the expense of reduced overall system performance, but it's ok IMO for an HTPC.
