### PR TITLE
bugfix: fixed initial playback of stacked iso images

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -3808,14 +3808,23 @@ bool CApplication::PlayStack(const CFileItem& item, bool bRestart)
         CLog::Log(LOGERROR, "%s - Cannot open VideoDatabase", __FUNCTION__);
     }
 
-    // set startoffset in movieitem, track stack item for updating purposes, and finally play disc part
-    if (selectedFile > 0 && selectedFile <= (int)movieList.Size())
+    // make sure that the selected part is within the boundaries
+    if (selectedFile <= 0)
     {
-      movieList[selectedFile - 1]->m_lStartOffset = startoffset > 0 ? STARTOFFSET_RESUME : 0;
-      movieList[selectedFile - 1]->SetProperty("stackFileItemToUpdate", true);
-      *m_stackFileItemToUpdate = item;
-      return PlayFile(*(movieList[selectedFile - 1]));
+      CLog::Log(LOGWARNING, "%s - Selected part %d out of range, playing part 1", __FUNCTION__, selectedFile);
+      selectedFile = 1;
     }
+    else if (selectedFile > movieList.Size())
+    {
+      CLog::Log(LOGWARNING, "%s - Selected part %d out of range, playing part %d", __FUNCTION__, selectedFile, movieList.Size());
+      selectedFile = movieList.Size();
+    }
+
+    // set startoffset in movieitem, track stack item for updating purposes, and finally play disc part
+    movieList[selectedFile - 1]->m_lStartOffset = startoffset > 0 ? STARTOFFSET_RESUME : 0;
+    movieList[selectedFile - 1]->SetProperty("stackFileItemToUpdate", true);
+    *m_stackFileItemToUpdate = item;
+    return PlayFile(*(movieList[selectedFile - 1]));
   }
   // case 2: all other stacks
   else

--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -69,7 +69,7 @@ CFileItem::CFileItem(const CSong& song)
   m_strPath = song.strFileName;
   GetMusicInfoTag()->SetSong(song);
   m_lStartOffset = song.iStartOffset;
-  m_lStartPartNumber = 0;
+  m_lStartPartNumber = 1;
   SetProperty("item_start", song.iStartOffset);
   m_lEndOffset = song.iEndOffset;
   m_strThumbnailImage = song.strThumb;
@@ -325,7 +325,7 @@ void CFileItem::Reset()
   m_dateTime.Reset();
   m_iDriveType = CMediaSource::SOURCE_TYPE_UNKNOWN;
   m_lStartOffset = 0;
-  m_lStartPartNumber = 0;
+  m_lStartPartNumber = 1;
   m_lEndOffset = 0;
   m_iprogramCount = 0;
   m_idepth = 1;


### PR DESCRIPTION
Currently, stacked iso movies don't play when pressing the play button.
There's no user feedback. (see log: http://pastebin.com/raw.php?i=XSqPvH87)
The files play fine, when choosing the part instead of just pressing play.

This PR initializes the FileItem's m_lStartPartNumber with 1 so that the playback starts on the first iso when the user didn't specify the part to play.

@Voyager-xbmc: I think this issue was introduced by #1099, could you review my fix?
