### PR TITLE
[keymapping] use 'back' to toggle between fullscreen video while playing

### DIFF
--- a/system/keymaps/remote.xml
+++ b/system/keymaps/remote.xml
@@ -88,6 +88,7 @@
       <info>XBMC.ActivateWindow(SystemInfo)</info>
       <clear>XBMC.ActivateWindow(Weather)</clear>
       <hash>XBMC.ActivateWindow(Settings)</hash>
+      <back>FullScreen</back>
     </remote>
   </Home>
   <MyFiles>


### PR DESCRIPTION
Like we found this weekend using a remote hitting 'backspace' on homescreen should toggle fullscreen video
