### PR TITLE
PAPlayer: add missing calls to IPlayerCallback's OnPlayBackResumed() and OnPlayBackPaused()

### DIFF
--- a/xbmc/cores/paplayer/PAPlayer.cpp
+++ b/xbmc/cores/paplayer/PAPlayer.cpp
@@ -731,11 +731,13 @@ void PAPlayer::Pause()
   {
     m_isPaused = false;
     SoftStart();
+    m_callback.OnPlayBackResumed();
   }
   else
   {
     m_isPaused = true;    
     SoftStop(true, false);
+    m_callback.OnPlayBackPaused();
   }
 }
 


### PR DESCRIPTION
This adds missing calls to IPlayerCallback::OnPlayBackResumed() and OnPlayBackPaused() in PAPlayer::Pause() which went missing because of the AE merge.

I will need some help in finding out why OnPlayBackStarted() is called twice when playing a song. It is called once from CApplication::PlayFile() and once from PAPlayer (which is also the case when playing a video with DVDPlayer) but the difference is that when playing a video the call to OnPlayBackStarted() from DVDPlayer returns early because CApplication::m_bPlaybackStarting is still set (i.e. DVDPlayer calls the callback before CApplication::PlayFile() does) but with PAPlayer this works differently. First CApplication::PlayFile sets CApplication::m_bPlaybackStarting to false and calls OnPlayBackStarted() (which results in no early return) and then PAPlayer calls OnPlayBackStarted() so in the end OnPlayBackStarted() is fully executed twice. Does this have to do with video playback switching to fullscreen and music playback not? I'll try to figure it out but would appreciate any pointers/hints.

EDIT: OK this seems to have to do with how PAPlayer works in PAPlayer::OpenFile(). DVDPlayer::OpenFile() returns after OnPlayBackStarted() has been called from its thread whereas PAPlayer::OpenFile() almost returns immediatelly and before OnPlayBackStarted() has been called from its thread.
