### PR TITLE
slideshow: allow moving between pictures when not zoomed enough

### DIFF
--- a/xbmc/pictures/GUIWindowSlideShow.cpp
+++ b/xbmc/pictures/GUIWindowSlideShow.cpp
@@ -222,6 +222,9 @@ void CGUIWindowSlideShow::ShowNext()
     m_iNextSlide = 0;
 
   m_iDirection   = 1;
+  m_iZoomFactor  = 1;
+  m_fZoom        = 1.0f;
+  m_fRotate      = 0.0f;
   m_bLoadNextPic = true;
 }
 
@@ -233,7 +236,11 @@ void CGUIWindowSlideShow::ShowPrevious()
   m_iNextSlide = m_iCurrentSlide - 1;
   if (m_iNextSlide < 0)
     m_iNextSlide = m_slides->Size() - 1;
+
   m_iDirection   = -1;
+  m_iZoomFactor  = 1;
+  m_fZoom        = 1.0f;
+  m_fRotate      = 0.0f;
   m_bLoadNextPic = true;
 }
 
@@ -480,7 +487,8 @@ void CGUIWindowSlideShow::Process(unsigned int currentTime, CDirtyRegionList &re
     m_iCurrentSlide = m_iNextSlide;
     m_iNextSlide    = GetNextSlide();
 
-//    m_iZoomFactor = 1;
+    m_iZoomFactor = 1;
+    m_fZoom = 1.0f;
     m_fRotate = 0.0f;
   }
 
@@ -531,7 +539,7 @@ EVENT_RESULT CGUIWindowSlideShow::OnMouseEvent(const CPoint &point, const CMouse
   }
   else if (event.m_id == ACTION_GESTURE_PAN)
   { // on zoomlevel 1 just detect swipe left and right
-    if (m_iZoomFactor == 1)
+    if (m_iZoomFactor == 1 || !m_Image[m_iCurrentPic].m_bCanMoveHorizontally)
     {
       if (m_firstGesturePoint.x > 0 && fabs(point.x - m_firstGesturePoint.x) > 100)
       {
@@ -616,14 +624,14 @@ bool CGUIWindowSlideShow::OnAction(const CAction &action)
     break;
 
   case ACTION_MOVE_RIGHT:
-    if (m_iZoomFactor == 1)
+    if (m_iZoomFactor == 1 || !m_Image[m_iCurrentPic].m_bCanMoveHorizontally)
       ShowNext();
     else
       Move(PICTURE_MOVE_AMOUNT, 0);
     break;
 
   case ACTION_MOVE_LEFT:
-    if (m_iZoomFactor == 1)
+    if (m_iZoomFactor == 1 || !m_Image[m_iCurrentPic].m_bCanMoveHorizontally)
       ShowPrevious();
     else
       Move( -PICTURE_MOVE_AMOUNT, 0);
@@ -919,7 +927,6 @@ void CGUIWindowSlideShow::OnLoadPic(int iPic, int iSlideNumber, CBaseTexture* pT
       else
         m_Image[iPic].SetTexture(iSlideNumber, pTexture, CSlideShowPic::EFFECT_NO_TIMEOUT);
       m_Image[iPic].SetOriginalSize(iOriginalWidth, iOriginalHeight, bFullSize);
-      m_Image[iPic].Zoom(m_fZoom, true);
 
       m_Image[iPic].m_bIsComic = false;
       if (URIUtils::IsInRAR(m_slides->Get(m_iCurrentSlide)->GetPath()) || URIUtils::IsInZIP(m_slides->Get(m_iCurrentSlide)->GetPath())) // move to top for cbr/cbz

--- a/xbmc/pictures/SlideShowPicture.cpp
+++ b/xbmc/pictures/SlideShowPicture.cpp
@@ -439,6 +439,7 @@ void CSlideShowPic::Process(unsigned int currentTime, CDirtyRegionList &dirtyreg
     }
     float w = maxx - minx;
     float h = maxy - miny;
+    m_bCanMoveHorizontally = (w >= fScreenWidth);
     if (w >= fScreenWidth)
     { // must have no black bars
       if (minx + m_fZoomLeft*w > fOffsetX)

--- a/xbmc/pictures/SlideShowPicture.h
+++ b/xbmc/pictures/SlideShowPicture.h
@@ -79,6 +79,7 @@ public:
   float GetZoom() const { return m_fZoomAmount;};
 
   bool m_bIsComic;
+  bool m_bCanMoveHorizontally;
 private:
   void UpdateVertices(float cur_x[4], float cur_y[4], const float new_x[4], const float new_y[4], CDirtyRegionList &dirtyregions);
   void Render(float *x, float *y, CBaseTexture* pTexture, color_t color);


### PR DESCRIPTION
On request of @cptspiff I looked into http://trac.xbmc.org/ticket/10144 as I recently did some work on zooming/rotating in the slideshow implementation. Currently swipe left/right only works to change between pictures if the current picture is not zoomed. But often you can zoom a picture a bit without making it's width bigger than the screen width so you are still left with black bars on the left and right side of the picture. If you then try to swipe left/right it will most likely move the picture a bit up or down (because the swipe was not perfectly horizontal) but it stays on the same picture. With these changes it is possible to change between pictures using swipe left/right as long as there are black bars left/right of the picture so even if the picture is a bit zoomed.
