### PR TITLE
[pvr] parse/split input streams for extra data

### DIFF
--- a/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxPVRClient.h
+++ b/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxPVRClient.h
@@ -22,6 +22,8 @@
 
 #include "DVDDemux.h"
 #include <map>
+#include "DllAvCodec.h"
+#include "DllAvFormat.h"
 
 #ifndef _LINUX
 #include <libavformat/avformat.h>
@@ -51,7 +53,9 @@ public:
   CDemuxStreamVideoPVRClient(CDVDDemuxPVRClient *parent)
     : m_parent(parent)
   {}
+  virtual ~CDemuxStreamVideoPVRClient();
   virtual void GetStreamInfo(std::string& strInfo);
+  AVCodecParserContext* m_pParser;
 };
 
 class CDemuxStreamAudioPVRClient : public CDemuxStreamAudio
@@ -61,7 +65,9 @@ public:
   CDemuxStreamAudioPVRClient(CDVDDemuxPVRClient *parent)
     : m_parent(parent)
   {}
+  virtual ~CDemuxStreamAudioPVRClient();
   virtual void GetStreamInfo(std::string& strInfo);
+  AVCodecParserContext* m_pParser;
 };
 
 class CDemuxStreamSubtitlePVRClient : public CDemuxStreamSubtitle
@@ -77,6 +83,9 @@ public:
 
 class CDVDDemuxPVRClient : public CDVDDemux
 {
+  friend class CDemuxStreamVideoPVRClient;
+  friend class CDemuxStreamAudioPVRClient;
+
 public:
 
   CDVDDemuxPVRClient();
@@ -102,10 +111,14 @@ protected:
   #define MAX_STREAMS 100
 #endif
   CDemuxStream* m_streams[MAX_STREAMS]; // maximum number of streams that ffmpeg can handle
+  CDemuxStream* m_streamsToParse[MAX_STREAMS];
   boost::shared_ptr<PVR::CPVRClient> m_pvrClient;
+
+  DllAvCodec  m_dllAvCodec;
 
 private:
   void RequestStreams();
   void UpdateStreams(PVR_STREAM_PROPERTIES *props);
+  bool ParsePacket(DemuxPacket* pPacket);
 };
 


### PR DESCRIPTION
The primary motivation for this change was making ChrystalHD work with pvr. Chd won't open without extra data. 
