### PR TITLE
PVR: Show full screen video information even if stream isn't working

### DIFF
--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -3068,7 +3068,7 @@ CStdString CGUIInfoManager::GetImage(int info, int contextWindow, CStdString *fa
   }
   else if (info == VIDEOPLAYER_COVER)
   {
-    if (!g_application.IsPlayingVideo()) return "";
+    if (!g_application.IsPlayingVideo() && !m_currentFile->HasPVRChannelInfoTag()) return "";
     if (fallback)
       *fallback = "DefaultVideoCover.png";
     if(m_currentMovieThumb.IsEmpty())
@@ -3520,7 +3520,7 @@ CStdString CGUIInfoManager::GetMusicTagLabel(int info, const CFileItem *item)
 
 CStdString CGUIInfoManager::GetVideoLabel(int item)
 {
-  if (!g_application.IsPlayingVideo())
+  if (!g_application.IsPlayingVideo() && !m_currentFile->HasPVRChannelInfoTag())
     return "";
 
   if (item == VIDEOPLAYER_TITLE)


### PR DESCRIPTION
I'm moving this pull request from opdekamps repo here to continue the discussion on what the best solution for this problem is.

Old pull request for description and discussion history: https://github.com/opdenkamp/xbmc/pull/623

This may not be the cleanest way to do it but it fixes the described problem without breaking pvr radio visualizations. Any other suggestions?
