### PR TITLE
[droid] Fix Android manifest so API Level 9 (platforms/android-9) devices will no longer receive an error

### DIFF
--- a/tools/android/packaging/xbmc/AndroidManifest.xml
+++ b/tools/android/packaging/xbmc/AndroidManifest.xml
@@ -6,7 +6,7 @@
         android:versionName="1.0">
 
     <!-- This is the platform API where NativeActivity was introduced. -->
-    <uses-sdk android:minSdkVersion="10" />
+    <uses-sdk android:minSdkVersion="9" />
 
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.INTERNET" />

--- a/xbmc/guilib/GUITexture.cpp
+++ b/xbmc/guilib/GUITexture.cpp
@@ -322,8 +322,6 @@ bool CGUITextureBase::AllocResources()
 
         m_texture = texture;
 
-        m_info.orientation = m_texture.m_orientation;
-
         changed = true;
       }
       else


### PR DESCRIPTION
The AndroidManifest.xml had the API level set to 10 when it should be 9.  The change will allow a number of 2.3 devices to run XBMC instead of receiving an error at launch.  

The documentation example also shows API level 9 used.
