### PR TITLE
Fix New Coverity Static Analysis Warnings Since PVR and RPI Merges

### DIFF
--- a/lib/addons/library.xbmc.addon/libXBMC_addon.cpp
+++ b/lib/addons/library.xbmc.addon/libXBMC_addon.cpp
@@ -122,7 +122,7 @@ DLLEXPORT const char* XBMC_get_dvd_menu_language()
     return "";
 
   string buffer = m_cb->GetDVDMenuLanguage(m_Handle->addonData);
-  return buffer.c_str();
+  return strdup(buffer.c_str());
 }
 
 };

--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -198,7 +198,7 @@ CFileItem::CFileItem(const CPVRChannel& channel)
         StringUtils::EmptyString :
         g_localizeStrings.Get(19055); // no information available
 
-  if (channel.IsRadio() && bHasEpgNow)
+  if (channel.IsRadio())
   {
     CMusicInfoTag* musictag = GetMusicInfoTag();
     if (musictag)

--- a/xbmc/addons/AddonCallbacksGUI.cpp
+++ b/xbmc/addons/AddonCallbacksGUI.cpp
@@ -622,7 +622,7 @@ const char* CAddonCallbacksGUI::Window_GetProperty(void *addonData, GUIHANDLE ha
   string value = pWindow->GetProperty(lowerKey.ToLower()).asString();
   Unlock();
 
-  return value.c_str();
+  return strdup(value.c_str());
 }
 
 int CAddonCallbacksGUI::Window_GetPropertyInt(void *addonData, GUIHANDLE handle, const char *key)

--- a/xbmc/addons/AddonCallbacksPVR.cpp
+++ b/xbmc/addons/AddonCallbacksPVR.cpp
@@ -81,8 +81,14 @@ CPVRClient *CAddonCallbacksPVR::GetPVRClient(void *addonData)
 
 void CAddonCallbacksPVR::PVRTransferChannelGroup(void *addonData, const ADDON_HANDLE handle, const PVR_CHANNEL_GROUP *group)
 {
+  if (!handle)
+  {
+    CLog::Log(LOGERROR, "PVR - %s - invalid handler data", __FUNCTION__);
+    return;
+  }
+
   CPVRChannelGroups *xbmcGroups = static_cast<CPVRChannelGroups *>(handle->dataAddress);
-  if (!handle || !group || !xbmcGroups)
+  if (!group || !xbmcGroups)
   {
     CLog::Log(LOGERROR, "PVR - %s - invalid handler data", __FUNCTION__);
     return;
@@ -101,9 +107,15 @@ void CAddonCallbacksPVR::PVRTransferChannelGroup(void *addonData, const ADDON_HA
 
 void CAddonCallbacksPVR::PVRTransferChannelGroupMember(void *addonData, const ADDON_HANDLE handle, const PVR_CHANNEL_GROUP_MEMBER *member)
 {
+  if (!handle)
+  {
+    CLog::Log(LOGERROR, "PVR - %s - invalid handler data", __FUNCTION__);
+    return;
+  }
+  
   CPVRClient *client      = GetPVRClient(addonData);
   CPVRChannelGroup *group = static_cast<CPVRChannelGroup *>(handle->dataAddress);
-  if (!handle || !member || !client || !group)
+  if (!member || !client || !group)
   {
     CLog::Log(LOGERROR, "PVR - %s - invalid handler data", __FUNCTION__);
     return;
@@ -123,8 +135,14 @@ void CAddonCallbacksPVR::PVRTransferChannelGroupMember(void *addonData, const AD
 
 void CAddonCallbacksPVR::PVRTransferEpgEntry(void *addonData, const ADDON_HANDLE handle, const EPG_TAG *epgentry)
 {
+  if (!handle)
+  {
+    CLog::Log(LOGERROR, "PVR - %s - invalid handler data", __FUNCTION__);
+    return;
+  }
+
   CEpg *xbmcEpg = static_cast<CEpg *>(handle->dataAddress);
-  if (!handle || !xbmcEpg)
+  if (!xbmcEpg)
   {
     CLog::Log(LOGERROR, "PVR - %s - invalid handler data", __FUNCTION__);
     return;
@@ -136,9 +154,15 @@ void CAddonCallbacksPVR::PVRTransferEpgEntry(void *addonData, const ADDON_HANDLE
 
 void CAddonCallbacksPVR::PVRTransferChannelEntry(void *addonData, const ADDON_HANDLE handle, const PVR_CHANNEL *channel)
 {
+  if (!handle)
+  {
+    CLog::Log(LOGERROR, "PVR - %s - invalid handler data", __FUNCTION__);
+    return;
+  }
+
   CPVRClient *client                     = GetPVRClient(addonData);
   CPVRChannelGroupInternal *xbmcChannels = static_cast<CPVRChannelGroupInternal *>(handle->dataAddress);
-  if (!handle || !channel || !client || !xbmcChannels)
+  if (!channel || !client || !xbmcChannels)
   {
     CLog::Log(LOGERROR, "PVR - %s - invalid handler data", __FUNCTION__);
     return;
@@ -151,9 +175,15 @@ void CAddonCallbacksPVR::PVRTransferChannelEntry(void *addonData, const ADDON_HA
 
 void CAddonCallbacksPVR::PVRTransferRecordingEntry(void *addonData, const ADDON_HANDLE handle, const PVR_RECORDING *recording)
 {
+  if (!handle)
+  {
+    CLog::Log(LOGERROR, "PVR - %s - invalid handler data", __FUNCTION__);
+    return;
+  }
+
   CPVRClient *client             = GetPVRClient(addonData);
   CPVRRecordings *xbmcRecordings = static_cast<CPVRRecordings *>(handle->dataAddress);
-  if (!handle || !recording || !client || !xbmcRecordings)
+  if (!recording || !client || !xbmcRecordings)
   {
     CLog::Log(LOGERROR, "PVR - %s - invalid handler data", __FUNCTION__);
     return;
@@ -166,9 +196,15 @@ void CAddonCallbacksPVR::PVRTransferRecordingEntry(void *addonData, const ADDON_
 
 void CAddonCallbacksPVR::PVRTransferTimerEntry(void *addonData, const ADDON_HANDLE handle, const PVR_TIMER *timer)
 {
+  if (!handle)
+  {
+    CLog::Log(LOGERROR, "PVR - %s - invalid handler data", __FUNCTION__);
+    return;
+  }
+
   CPVRClient *client     = GetPVRClient(addonData);
   CPVRTimers *xbmcTimers = static_cast<CPVRTimers *>(handle->dataAddress);
-  if (!handle || !timer || !client || !xbmcTimers)
+  if (!timer || !client || !xbmcTimers)
   {
     CLog::Log(LOGERROR, "PVR - %s - invalid handler data", __FUNCTION__);
     return;

--- a/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxPVRClient.cpp
+++ b/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxPVRClient.cpp
@@ -178,9 +178,9 @@ bool CDVDDemuxPVRClient::ParsePacket(DemuxPacket* pPacket)
   {
     CDemuxStream* st = m_streamsToParse[pPacket->iStreamId];
     AVCodecParserContext* pParser = NULL;
-    if (st->type == STREAM_VIDEO)
+    if (st && st->type == STREAM_VIDEO)
       pParser = ((CDemuxStreamVideoPVRClient*)st)->m_pParser;
-    else if (st->type == STREAM_AUDIO)
+    else if (st && st->type == STREAM_AUDIO)
       pParser = ((CDemuxStreamAudioPVRClient*)st)->m_pParser;
 
     if (st && pParser)

--- a/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxPVRClient.h
+++ b/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxPVRClient.h
@@ -50,7 +50,7 @@ class CDemuxStreamVideoPVRClient : public CDemuxStreamVideo
   CDVDDemuxPVRClient *m_parent;
 public:
   CDemuxStreamVideoPVRClient(CDVDDemuxPVRClient *parent)
-    : m_parent(parent)
+    : m_parent(parent), m_pParser(NULL)
   {}
   virtual ~CDemuxStreamVideoPVRClient();
   virtual void GetStreamInfo(std::string& strInfo);

--- a/xbmc/epg/EpgContainer.cpp
+++ b/xbmc/epg/EpgContainer.cpp
@@ -313,8 +313,7 @@ CEpg *CEpgContainer::CreateChannelEpg(CPVRChannelPtr channel)
     epg->RegisterObserver(this);
   }
 
-  if (epg)
-    epg->SetChannel(channel);
+  epg->SetChannel(channel);
 
   m_bPreventUpdates = false;
   CDateTime::GetCurrentDateTime().GetAsUTCDateTime().GetAsTime(m_iNextEpgUpdate);

--- a/xbmc/epg/EpgContainer.cpp
+++ b/xbmc/epg/EpgContainer.cpp
@@ -512,21 +512,18 @@ bool CEpgContainer::UpdateEPG(bool bOnlyPending /* = false */)
       ++iUpdatedTables;
   }
 
-  if (!bInterrupted)
+  if (bInterrupted)
   {
-    if (bInterrupted)
-    {
-      /* the update has been interrupted. try again later */
-      time_t iNow;
-      CDateTime::GetCurrentDateTime().GetAsUTCDateTime().GetAsTime(iNow);
-      m_iNextEpgUpdate = iNow + g_advancedSettings.m_iEpgRetryInterruptedUpdateInterval;
-    }
-    else
-    {
-      CDateTime::GetCurrentDateTime().GetAsUTCDateTime().GetAsTime(m_iNextEpgUpdate);
-      m_iNextEpgUpdate += g_advancedSettings.m_iEpgUpdateCheckInterval;
-      m_bHasPendingUpdates = false;
-    }
+    /* the update has been interrupted. try again later */
+    time_t iNow;
+    CDateTime::GetCurrentDateTime().GetAsUTCDateTime().GetAsTime(iNow);
+    m_iNextEpgUpdate = iNow + g_advancedSettings.m_iEpgRetryInterruptedUpdateInterval;
+  }
+  else
+  {
+    CDateTime::GetCurrentDateTime().GetAsUTCDateTime().GetAsTime(m_iNextEpgUpdate);
+    m_iNextEpgUpdate += g_advancedSettings.m_iEpgUpdateCheckInterval;
+    m_bHasPendingUpdates = false;
   }
 
   if (bShowProgress && !bOnlyPending)

--- a/xbmc/epg/GUIEPGGridContainer.cpp
+++ b/xbmc/epg/GUIEPGGridContainer.cpp
@@ -710,7 +710,7 @@ bool CGUIEPGGridContainer::OnMessage(CGUIMessage& message)
         m_programmeItems.push_back(items->Get(i));
 
       ClearGridIndex();
-      m_gridIndex = (struct GridItemsPtr **) calloc(1,m_channelItems.size()*sizeof(struct GridItemsPtr));
+      m_gridIndex = (struct GridItemsPtr **) calloc(1,m_channelItems.size()*sizeof(struct GridItemsPtr*));
       if (m_gridIndex != NULL)
       {
         for (unsigned int i = 0; i < m_channelItems.size(); i++)

--- a/xbmc/filesystem/MythFile.h
+++ b/xbmc/filesystem/MythFile.h
@@ -101,7 +101,6 @@ protected:
   cmyth_recorder_t  m_recorder;
   cmyth_proginfo_t  m_program;
   cmyth_file_t      m_file;
-  cmyth_timestamp_t m_starttime;
   CStdString        m_filename;
   CVideoInfoTag     m_infotag;
 

--- a/xbmc/linux/XFileUtils.cpp
+++ b/xbmc/linux/XFileUtils.cpp
@@ -450,27 +450,34 @@ BOOL CopyFile(LPCTSTR lpExistingFileName, LPCTSTR lpNewFileName, BOOL bFailIfExi
     }
   }
 
+  // Read and write chunks of 16K
+  char buf[16384];
+  int64_t bytesRead = 1;
+  int64_t bytesWritten = 1;
+
   if (sf != -1 && df != -1)
   {
-    // Read and write chunks of 16K
-    char buf[16384];
-    int64_t bytesRead = 1;
-    int64_t bytesWritten = 1;
-
     while (bytesRead > 0 && bytesWritten > 0)
     {
       bytesRead = read(sf, buf, sizeof(buf));
       if (bytesRead > 0)
         bytesWritten = write(df, buf, bytesRead);
     }
-
-    // Done
-    close(sf);
-    close(df);
-    
-    if (bytesRead == -1 || bytesWritten == -1)
-      return 0;
   }
+  else
+  {
+    bytesRead = -1;
+    bytesWritten = -1;
+  }
+
+  // Done
+  if (sf != -1)  
+    close(sf);
+  if (df != -1)
+    close(df);
+
+  if (bytesRead == -1 || bytesWritten == -1)
+    return 0;
   return 1;
 }
 

--- a/xbmc/pvr/PVRGUIInfo.cpp
+++ b/xbmc/pvr/PVRGUIInfo.cpp
@@ -94,8 +94,8 @@ void CPVRGUIInfo::ResetProperties(void)
 void CPVRGUIInfo::ClearQualityInfo(PVR_SIGNAL_STATUS &qualityInfo)
 {
   memset(&qualityInfo, 0, sizeof(qualityInfo));
-  strncpy(qualityInfo.strAdapterName, g_localizeStrings.Get(13106).c_str(), 1024);
-  strncpy(qualityInfo.strAdapterStatus, g_localizeStrings.Get(13106).c_str(), 1024);
+  strncpy(qualityInfo.strAdapterName, g_localizeStrings.Get(13106).c_str(), PVR_ADDON_NAME_STRING_LENGTH - 1);
+  strncpy(qualityInfo.strAdapterStatus, g_localizeStrings.Get(13106).c_str(), PVR_ADDON_NAME_STRING_LENGTH - 1);
 }
 
 void CPVRGUIInfo::Start(void)

--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -297,7 +297,8 @@ void CPVRManager::StopUpdateThreads(void)
 bool CPVRManager::Load(void)
 {
   /* start the add-on update thread */
-  m_addons->Start();
+  if (m_addons)
+    m_addons->Start();
 
   /* load at least one client */
   while (GetState() == ManagerStateStarting && m_addons && !m_addons->HasConnectedClients())

--- a/xbmc/pvr/addons/PVRClient.cpp
+++ b/xbmc/pvr/addons/PVRClient.cpp
@@ -1292,13 +1292,13 @@ void CPVRClient::ResetQualityData(PVR_SIGNAL_STATUS &qualityInfo)
   memset(&qualityInfo, 0, sizeof(qualityInfo));
   if (g_guiSettings.GetBool("pvrplayback.signalquality"))
   {
-    strncpy(qualityInfo.strAdapterName, g_localizeStrings.Get(13205).c_str(), 1024);
-    strncpy(qualityInfo.strAdapterStatus, g_localizeStrings.Get(13205).c_str(), 1024);
+    strncpy(qualityInfo.strAdapterName, g_localizeStrings.Get(13205).c_str(), PVR_ADDON_NAME_STRING_LENGTH - 1);
+    strncpy(qualityInfo.strAdapterStatus, g_localizeStrings.Get(13205).c_str(), PVR_ADDON_NAME_STRING_LENGTH - 1);
   }
   else
   {
-    strncpy(qualityInfo.strAdapterName, g_localizeStrings.Get(13106).c_str(), 1024);
-    strncpy(qualityInfo.strAdapterStatus, g_localizeStrings.Get(13106).c_str(), 1024);
+    strncpy(qualityInfo.strAdapterName, g_localizeStrings.Get(13106).c_str(), PVR_ADDON_NAME_STRING_LENGTH - 1);
+    strncpy(qualityInfo.strAdapterStatus, g_localizeStrings.Get(13106).c_str(), PVR_ADDON_NAME_STRING_LENGTH - 1);
   }
 }
 

--- a/xbmc/pvr/addons/PVRClients.cpp
+++ b/xbmc/pvr/addons/PVRClients.cpp
@@ -1259,6 +1259,8 @@ PVR_STREAM_PROPERTIES CPVRClients::GetCurrentStreamProperties(void)
 {
   PVR_STREAM_PROPERTIES props;
   PVR_CLIENT client;
+  
+  memset(&props, 0, sizeof(props));
   if (GetPlayingClient(client))
     client->GetStreamProperties(&props);
 

--- a/xbmc/pvr/addons/PVRClients.cpp
+++ b/xbmc/pvr/addons/PVRClients.cpp
@@ -629,7 +629,7 @@ bool CPVRClients::GetMenuHooks(int iClientID, PVR_MENUHOOKS *hooks)
   PVR_CLIENT client;
   if (GetConnectedClient(iClientID, client) && client->HaveMenuHooks())
   {
-    hooks = client->GetMenuHooks();
+    *hooks = *(client->GetMenuHooks());
     bReturn = true;
   }
 

--- a/xbmc/pvr/channels/PVRChannelGroups.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroups.cpp
@@ -199,7 +199,7 @@ bool CPVRChannelGroups::UpdateGroupsEntries(const CPVRChannelGroups &groups)
   }
 
   // go through the groups list and check for new groups
-  for (std::vector<CPVRChannelGroupPtr>::const_iterator it = groups.m_groups.begin(); it != m_groups.end(); it++)
+  for (std::vector<CPVRChannelGroupPtr>::const_iterator it = groups.m_groups.begin(); it != groups.m_groups.end(); it++)
   {
     // check if this group is present in this container
     CPVRChannelGroupPtr existingGroup = GetByName((*it)->GroupName());

--- a/xbmc/pvr/dialogs/GUIDialogPVRGuideInfo.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRGuideInfo.cpp
@@ -52,9 +52,10 @@ bool CGUIDialogPVRGuideInfo::ActionStartTimer(const CEpgInfoTag *tag)
 {
   bool bReturn = false;
 
-  CPVRChannelPtr channel;
-  if (tag)
-    channel = tag->ChannelTag();
+  if (!tag)
+    return false;
+
+  CPVRChannelPtr channel = tag->ChannelTag();
   if (!channel || !g_PVRManager.CheckParentalLock(*channel))
     return false;
 

--- a/xbmc/pvr/timers/PVRTimerInfoTag.cpp
+++ b/xbmc/pvr/timers/PVRTimerInfoTag.cpp
@@ -417,6 +417,7 @@ CPVRTimerInfoTag *CPVRTimerInfoTag::CreateFromEpg(const CEpgInfoTag &tag)
   if (!channel)
   {
     CLog::Log(LOGERROR, "%s - no channel set", __FUNCTION__);
+    delete newTag;
     return NULL;
   }
 
@@ -424,6 +425,7 @@ CPVRTimerInfoTag *CPVRTimerInfoTag::CreateFromEpg(const CEpgInfoTag &tag)
   if (tag.EndAsLocalTime() < CDateTime::GetCurrentDateTime())
   {
     CLog::Log(LOGERROR, "%s - end time is in the past", __FUNCTION__);
+    delete newTag;
     return NULL;
   }
 

--- a/xbmc/pvr/timers/PVRTimers.cpp
+++ b/xbmc/pvr/timers/PVRTimers.cpp
@@ -438,7 +438,7 @@ bool CPVRTimers::DeleteTimersOnChannel(const CPVRChannel &channel, bool bDeleteR
 
   for (map<CDateTime, vector<CPVRTimerInfoTagPtr>* >::reverse_iterator it = m_tags.rbegin(); it != m_tags.rend(); it++)
   {
-    for (vector<CPVRTimerInfoTagPtr>::iterator timerIt = it->second->begin(); timerIt != it->second->end(); timerIt++)
+    for (vector<CPVRTimerInfoTagPtr>::iterator timerIt = it->second->begin(); timerIt != it->second->end(); )
     {
       CPVRTimerInfoTagPtr timer = (*timerIt);
 
@@ -453,8 +453,10 @@ bool CPVRTimers::DeleteTimersOnChannel(const CPVRChannel &channel, bool bDeleteR
       if (timer->ChannelNumber() == channel.ChannelNumber() && timer->m_bIsRadio == channel.IsRadio())
       {
         bReturn = timer->DeleteFromClient(true) || bReturn;
-        it->second->erase(timerIt);
+        timerIt = it->second->erase(timerIt);
       }
+      else
+        timerIt++;
     }
   }
 

--- a/xbmc/pvr/windows/GUIWindowPVRCommon.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRCommon.cpp
@@ -553,7 +553,7 @@ bool CGUIWindowPVRCommon::ActionDeleteChannel(CFileItem *item)
 
   /* show a confirmation dialog */
   CGUIDialogYesNo* pDialog = (CGUIDialogYesNo*) g_windowManager.GetWindow(WINDOW_DIALOG_YES_NO);
-  if (pDialog)
+  if (!pDialog)
     return false;
   pDialog->SetHeading(19039);
   pDialog->SetLine(0, "");
@@ -689,7 +689,7 @@ bool CGUIWindowPVRCommon::PlayFile(CFileItem *item, bool bPlayMinimized /* = fal
 
     CPVRChannel *channel = item->HasPVRChannelInfoTag() ? item->GetPVRChannelInfoTag() : NULL;
 
-    if (g_PVRManager.CheckParentalLock(*channel))
+    if (channel && g_PVRManager.CheckParentalLock(*channel))
     {
       /* try a fast switch */
       if (channel && (g_PVRManager.IsPlayingTV() || g_PVRManager.IsPlayingRadio()) &&

--- a/xbmc/pvr/windows/GUIWindowPVRRecordings.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRRecordings.cpp
@@ -60,7 +60,7 @@ void CGUIWindowPVRRecordings::ResetObservers(void)
   g_infoManager.RegisterObserver(this);
 }
 
-CStdString CGUIWindowPVRRecordings::GetResumeString(CFileItem item)
+CStdString CGUIWindowPVRRecordings::GetResumeString(const CFileItem& item)
 {
   CStdString resumeString;
   if (item.IsPVRRecording())

--- a/xbmc/pvr/windows/GUIWindowPVRRecordings.h
+++ b/xbmc/pvr/windows/GUIWindowPVRRecordings.h
@@ -35,7 +35,7 @@ namespace PVR
     CGUIWindowPVRRecordings(CGUIWindowPVR *parent);
     virtual ~CGUIWindowPVRRecordings(void) {};
 
-    static CStdString GetResumeString(CFileItem item);
+    static CStdString GetResumeString(const CFileItem& item);
 
     void GetContextButtons(int itemNumber, CContextButtons &buttons) const;
     bool OnAction(const CAction &action);


### PR DESCRIPTION
This PR contains a set of Coverity Static Analysis warning fixes for issues that have been introduced since the PVR and RPI merges.

I welcome feedback on any of my proposed changes. (And don't worry, I've revoked my push access to the main xbmc repo)
