### PR TITLE
fixed: GUIDialogLockSettings was broke after pvr merge

### DIFF
--- a/xbmc/settings/GUIDialogSettings.cpp
+++ b/xbmc/settings/GUIDialogSettings.cpp
@@ -201,7 +201,7 @@ void CGUIDialogSettings::UpdateSetting(unsigned int id)
       if (setting.formatFunction) pControl->SetTextValue(setting.formatFunction(value, setting.interval));
     }
   }
-  else if (setting.type == SettingInfo::BUTTON_DIALOG)
+  else if (setting.type == SettingInfo::BUTTON || setting.type == SettingInfo::BUTTON_DIALOG)
   {
     SET_CONTROL_LABEL(controlID,setting.name);
     CGUIButtonControl *pControl = (CGUIButtonControl *)GetControl(controlID);


### PR DESCRIPTION
SettingInfo::BUTTON's weren't updating their labels immediately.

Weirdly, after reading the code, the directory permissions portion of this dialog _should_ have worked as it passes a string to AddButton, however it didn't, along with the MasterLock settings
