### PR TITLE
ffmpeg: fixed: DXVA2 playback artifacts on H264 content with mbaff frame...

### DIFF
--- a/lib/ffmpeg/libavcodec/dxva2_h264.c
+++ b/lib/ffmpeg/libavcodec/dxva2_h264.c
@@ -93,7 +93,8 @@ static void fill_picture_parameters(struct dxva_context *ctx, const H264Context 
     pp->num_ref_frames                = h->sps.ref_frame_count;
 
     pp->wBitFields                    = ((s->picture_structure != PICT_FRAME) <<  0) |
-                                        (h->sps.mb_aff                        <<  1) |
+                                        ((h->sps.mb_aff &&
+                                        (s->picture_structure == PICT_FRAME)) <<  1) |
                                         (h->sps.residual_color_transform_flag <<  2) |
                                         /* sp_for_switch_flag (not implemented by FFmpeg) */
                                         (0                                    <<  3) |


### PR DESCRIPTION
This fixes trac ticket #13165.

Backported commit b5e6aa6c3337dc740d67aa68116530fe604bae76 from ffmpeg upstream
