### PR TITLE
[droid] Enable API Level 9 (platforms/android-9) 

### DIFF
--- a/tools/android/packaging/xbmc/AndroidManifest.xml
+++ b/tools/android/packaging/xbmc/AndroidManifest.xml
@@ -6,7 +6,7 @@
         android:versionName="1.0">
 
     <!-- This is the platform API where NativeActivity was introduced. -->
-    <uses-sdk android:minSdkVersion="10" />
+    <uses-sdk android:minSdkVersion="9" />
 
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.INTERNET" />


### PR DESCRIPTION
The AndroidManifest.xml had the API level set to 10 when it should be 9. The change will allow a number of 2.3 devices to run XBMC instead of receiving an error at launch.

The documentation example also shows API level 9 used.

This was reported by an XDA user an a user of www.xbmcandroid.com/forums .  I worked with the users to ensure that this resolves a manifest error they received at launch.
