### PR TITLE
[AE] fix remapping - downmixing algorithm

### DIFF
--- a/xbmc/cores/AudioEngine/Utils/AERemap.cpp
+++ b/xbmc/cores/AudioEngine/Utils/AERemap.cpp
@@ -344,21 +344,24 @@ void CAERemap::Remap(float * const in, float * const out, const unsigned int fra
 
         /* the compiler has a better chance of optimizing this if it is done in parallel */
         int i = 0;
+        float f1 = 0.0, f2 = 0.0, f3 = 0.0, f4 = 0.0;
         for (; i < blocks; i += 4)
         {
-          *outOffset += inOffset[info->srcIndex[i].index] * info->srcIndex[i].level, i++;
-          *outOffset += inOffset[info->srcIndex[i].index] * info->srcIndex[i].level, i++;
-          *outOffset += inOffset[info->srcIndex[i].index] * info->srcIndex[i].level, i++;
-          *outOffset += inOffset[info->srcIndex[i].index] * info->srcIndex[i].level, i++;
+          f1 += inOffset[info->srcIndex[i].index] * info->srcIndex[i].level;
+          f2 += inOffset[info->srcIndex[i+1].index] * info->srcIndex[i+1].level;
+          f3 += inOffset[info->srcIndex[i+2].index] * info->srcIndex[i+2].level;
+          f4 += inOffset[info->srcIndex[i+3].index] * info->srcIndex[i+3].level;
         }
 
         /* unrolled loop for higher performance */
         switch (info->srcCount & 0x3)
         {
-          case 3: *outOffset += inOffset[info->srcIndex[i].index] * info->srcIndex[i].level, i++;
-          case 2: *outOffset += inOffset[info->srcIndex[i].index] * info->srcIndex[i].level, i++;
-          case 1: *outOffset += inOffset[info->srcIndex[i].index] * info->srcIndex[i].level;
+          case 3: f3 += inOffset[info->srcIndex[i+2].index] * info->srcIndex[i+2].level;
+          case 2: f2 += inOffset[info->srcIndex[i+1].index] * info->srcIndex[i+1].level;
+          case 1: f1 += inOffset[info->srcIndex[i].index] * info->srcIndex[i].level;
         }
+
+        *outOffset += (f1+f2+f3+f4);
       }
     }
   }


### PR DESCRIPTION
The basic algorithm failed when a given output channel is mixing more than 4 sources. I discovered this when playing a 6.1 DTS-ES on stereo output. I didn't have the center channel, which turned out to be the 5th channel in the mix!!

So when doing 7 ch -> 2 ch, each channel is taking more than 4 sources (e.g. FR = FR+ SR+ BC+ LFE+ FC)

The code seems to optimize in "blocks of 4", by performing loop unrolling, but there was double index increase (inside the unrolled loop plus in the for statement), thereby jumping from 3 to 8 instead of 3 to 4. Channel index 4 was the front center.

Tested the change, and voilà the 6.1 sounds downmix correctly now.

update: next to this, the loop has been improved for better parallelism.
