### PR TITLE
Ability to skip specific key/button map translations when running in standalone mode

### DIFF
--- a/system/keymaps/joystick.Harmony.xml
+++ b/system/keymaps/joystick.Harmony.xml
@@ -114,7 +114,7 @@
       <!-- Info  	-->      <button id="31">XBMC.ActivateWindow(Settings)</button>
       <!-- Exit 	-->      <button id="51">XBMC.ActivateWindow(ShutdownMenu)</button>
       <!-- #enter	-->      <button id="36">XBMC.ActivateWindow(SystemInfo)</button>
-      <!-- 1 		-->      <button id="11">ToggleFullScreen</button>
+      <!-- 1 		-->      <button id="11" standalone="false">ToggleFullScreen</button>
     </joystick>
   </Home>
   <MyFiles>

--- a/system/keymaps/keyboard.xml
+++ b/system/keymaps/keyboard.xml
@@ -91,7 +91,7 @@
       <numpadseven>Number7</numpadseven>
       <numpadeight>Number8</numpadeight>
       <numpadnine>Number9</numpadnine>
-      <backslash>ToggleFullScreen</backslash>
+      <backslash standalone="false">ToggleFullScreen</backslash>
       <home>FirstPage</home>
       <end>LastPage</end>
       <!-- PVR windows -->

--- a/xbmc/input/ButtonTranslator.cpp
+++ b/xbmc/input/ButtonTranslator.cpp
@@ -20,6 +20,7 @@
  */
 
 #include "system.h"
+#include "Application.h"
 #include "interfaces/Builtins.h"
 #include "ButtonTranslator.h"
 #include "utils/URIUtils.h"
@@ -945,6 +946,21 @@ void CButtonTranslator::MapAction(uint32_t buttonCode, const char *szAction, but
   }
 }
 
+bool CButtonTranslator::SkipTranslation(TiXmlElement *pButton)
+{
+  if (g_application.IsStandAlone())
+  {
+    // in case we're running in standalone mode,
+    // check whether the button should be translated.
+    bool bStandAlone = true;
+    pButton->QueryBoolAttribute("standalone", &bStandAlone);
+    if (!bStandAlone)
+      return true;
+  }
+
+  return false;
+}
+
 bool CButtonTranslator::HasDeviceType(TiXmlNode *pWindow, CStdString type)
 {
   return pWindow->FirstChild(type) != NULL;
@@ -977,22 +993,25 @@ void CButtonTranslator::MapWindowActions(TiXmlNode *pWindow, int windowID)
 
       while (pButton)
       {
-        uint32_t buttonCode=0;
-        if (type == "gamepad")
-            buttonCode = TranslateGamepadString(pButton->Value());
-        else if (type == "remote")
-            buttonCode = TranslateRemoteString(pButton->Value());
-        else if (type == "universalremote")
-            buttonCode = TranslateUniversalRemoteString(pButton->Value());
-        else if (type == "keyboard")
-            buttonCode = TranslateKeyboardButton(pButton);
-        else if (type == "mouse")
-            buttonCode = TranslateMouseCommand(pButton->Value());
-        else if (type == "appcommand")
-            buttonCode = TranslateAppCommand(pButton->Value());
+        if (!SkipTranslation(pButton))
+        {
+          uint32_t buttonCode=0;
+          if (type == "gamepad")
+              buttonCode = TranslateGamepadString(pButton->Value());
+          else if (type == "remote")
+              buttonCode = TranslateRemoteString(pButton->Value());
+          else if (type == "universalremote")
+              buttonCode = TranslateUniversalRemoteString(pButton->Value());
+          else if (type == "keyboard")
+              buttonCode = TranslateKeyboardButton(pButton);
+          else if (type == "mouse")
+              buttonCode = TranslateMouseCommand(pButton->Value());
+          else if (type == "appcommand")
+              buttonCode = TranslateAppCommand(pButton->Value());
 
-        if (buttonCode && pButton->FirstChild())
-          MapAction(buttonCode, pButton->FirstChild()->Value(), map);
+          if (buttonCode && pButton->FirstChild())
+            MapAction(buttonCode, pButton->FirstChild()->Value(), map);
+        }
         pButton = pButton->NextSiblingElement();
       }
 

--- a/xbmc/input/ButtonTranslator.h
+++ b/xbmc/input/ButtonTranslator.h
@@ -121,6 +121,8 @@ private:
   void MapWindowActions(TiXmlNode *pWindow, int wWindowID);
   void MapAction(uint32_t buttonCode, const char *szAction, buttonMap &map);
 
+  bool SkipTranslation(TiXmlElement *pButton);
+
   bool LoadKeymap(const CStdString &keymapPath);
 #if defined(HAS_LIRC) || defined(HAS_IRSERVERSUITE)
   bool LoadLircMap(const CStdString &lircmapPath);


### PR DESCRIPTION
This commit disables the "ToggleFullScreen" mapping in standalone mode (only) without the need to hack the actual keymap files.
