### PR TITLE
ADD: add advanced settings allowing to customize the items of the "Recently Added" job

### DIFF
--- a/xbmc/playlists/SmartPlayList.cpp
+++ b/xbmc/playlists/SmartPlayList.cpp
@@ -207,7 +207,7 @@ bool CSmartPlaylistRule::Load(TiXmlElement *element, const CStdString &encoding 
   return true;
 }
 
-bool CSmartPlaylistRule::Load(const CVariant &obj)
+bool CSmartPlaylistRule::Load(const CVariant &obj)  
 {
   if (!obj.isObject() ||
       !obj.isMember("field") || !obj["field"].isString() ||

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -219,6 +219,11 @@ void CAdvancedSettings::Initialize()
   m_bVideoScannerIgnoreErrors = false;
   m_iVideoLibraryDateAdded = 1; // prefer mtime over ctime and current time
 
+  m_recentlyAddedJobMusicPath = "musicdb://4/";
+  m_recentlyAddedJobMoviePath = "videodb://4/";
+  m_recentlyAddedJobEpisodePath = "videodb://5/";
+  m_recentlyAddedJobMusicVideoPath = "videodb://6/";
+
   m_iTuxBoxStreamtsPort = 31339;
   m_bTuxBoxAudioChannelSelection = false;
   m_bTuxBoxSubMenuSelection = false;
@@ -653,6 +658,15 @@ void CAdvancedSettings::ParseSettingsFile(const CStdString &file)
   if (pElement)
   {
     XMLUtils::GetBoolean(pElement, "ignoreerrors", m_bVideoScannerIgnoreErrors);
+  }
+
+  pElement = pRootElement->FirstChildElement("recentlyaddedjob");
+  if (pElement)
+  {
+    XMLUtils::GetString(pElement, "musicpath", m_recentlyAddedJobMusicPath);
+    XMLUtils::GetString(pElement, "moviepath", m_recentlyAddedJobMoviePath);
+    XMLUtils::GetString(pElement, "episodepath", m_recentlyAddedJobEpisodePath);
+    XMLUtils::GetString(pElement, "musicvideopath", m_recentlyAddedJobMusicVideoPath);
   }
 
   // Backward-compatibility of ExternalPlayer config

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -256,6 +256,11 @@ class CAdvancedSettings
     bool m_bVideoScannerIgnoreErrors;
     int m_iVideoLibraryDateAdded;
 
+    CStdString m_recentlyAddedJobMusicPath;
+    CStdString m_recentlyAddedJobMoviePath;
+    CStdString m_recentlyAddedJobEpisodePath;
+    CStdString m_recentlyAddedJobMusicVideoPath;
+
     std::vector<CStdString> m_vecTokens; // cleaning strings tied to language
     //TuxBox
     int m_iTuxBoxStreamtsPort;

--- a/xbmc/utils/RecentlyAddedJob.cpp
+++ b/xbmc/utils/RecentlyAddedJob.cpp
@@ -56,7 +56,7 @@ bool CRecentlyAddedJob::UpdateVideo()
   
   videodatabase.Open();
 
-  if (videodatabase.GetRecentlyAddedMoviesNav("videodb://4/", items, NUM_ITEMS))
+  if (videodatabase.GetRecentlyAddedMoviesNav(g_advancedSettings.m_recentlyAddedJobMoviePath, items, NUM_ITEMS))
   {  
     for (; i < items.Size(); ++i)
     {
@@ -99,7 +99,7 @@ bool CRecentlyAddedJob::UpdateVideo()
   i = 0;
   CFileItemList  TVShowItems; 
  
-  if (videodatabase.GetRecentlyAddedEpisodesNav("videodb://5/", TVShowItems, NUM_ITEMS))
+  if (videodatabase.GetRecentlyAddedEpisodesNav(g_advancedSettings.m_recentlyAddedJobEpisodePath, TVShowItems, NUM_ITEMS))
   {
     for (; i < TVShowItems.Size(); ++i)
     {    
@@ -158,7 +158,7 @@ bool CRecentlyAddedJob::UpdateVideo()
   i = 0;
   CFileItemList MusicVideoItems;
 
-  if (videodatabase.GetRecentlyAddedMusicVideosNav("videodb://6/", MusicVideoItems, NUM_ITEMS))
+  if (videodatabase.GetRecentlyAddedMusicVideosNav(g_advancedSettings.m_recentlyAddedJobMusicVideoPath, MusicVideoItems, NUM_ITEMS))
   {
     for (; i < MusicVideoItems.Size(); ++i)
     {
@@ -214,7 +214,7 @@ bool CRecentlyAddedJob::UpdateMusic()
   
   musicdatabase.Open();
   
-  if (musicdatabase.GetRecentlyAddedAlbumSongs("musicdb://4/", musicItems, NUM_ITEMS))
+  if (musicdatabase.GetRecentlyAddedAlbumSongs(g_advancedSettings.m_recentlyAddedJobMusicPath, musicItems, NUM_ITEMS))
   {
     long idAlbum = -1;
     CStdString strAlbumThumb;

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -4624,20 +4624,21 @@ bool CVideoDatabase::GetSetsByWhere(const CStdString& strBaseDir, const Filter &
     if (NULL == m_pDS.get()) return false;
 
     CVideoDbUrl videoUrl;
-    if (!videoUrl.FromString(strBaseDir))
+    Filter extFilter = filter;
+    if (!videoUrl.FromString(strBaseDir) || !GetFilter(videoUrl, extFilter))
       return false;
 
     CStdString strSQL = "SELECT movieview.*, sets.strSet FROM movieview"
                         " JOIN sets ON movieview.idSet = sets.idSet ";
-    if (!filter.join.empty())
-      strSQL += filter.join;
-    if (!filter.where.empty())
-      strSQL += " WHERE (" + filter.where + ")";
+    if (!extFilter.join.empty())
+      strSQL += extFilter.join;
+    if (!extFilter.where.empty())
+      strSQL += " WHERE (" + extFilter.where + ")";
     strSQL += " ORDER BY sets.idSet";
-    if (!filter.order.empty())
-      strSQL += "," + filter.order;
-    if (!filter.limit.empty())
-      strSQL += " LIMIT " + filter.limit;
+    if (!extFilter.order.empty())
+      strSQL += "," + extFilter.order;
+    if (!extFilter.limit.empty())
+      strSQL += " LIMIT " + extFilter.limit;
 
     int iRowsFound = RunQuery(strSQL);
     if (iRowsFound <= 0)
@@ -6016,7 +6017,7 @@ bool CVideoDatabase::GetEpisodesByWhere(const CStdString& strBaseDir, const Filt
       strSQLExtra += DatabaseUtils::BuildLimitClause(sortDescription.limitEnd, sortDescription.limitStart);
     }
 
-    strSQL = PrepareSQL(strSQL, !extFilter.fields.empty() ? extFilter.fields.c_str() : "*") + strSQLExtra;
+    strSQL = PrepareSQL(strSQL, !extFilter.fields.empty() ? filter.fields.c_str() : "*") + strSQLExtra;
 
     int iRowsFound = RunQuery(strSQL);
     if (iRowsFound <= 0)


### PR DESCRIPTION
Allows to filter the recently added items, e.g.

``` xml
<recentlyaddedjob>
    <!-- Only use unseen movies -->
    <moviepath>videodb://4/?xsp={"type":"movies", "rules":[{"field":"playcount", "operator":"is", "value":"0"}]}</moviepath> 
    <!-- Only use unseen episodes from series "SerieA" or "SerieB" -->
    <episodepath>videodb://5/?xsp={"type":"episodes", "rules":[{"and":[{"field":"playcount", "operator":"is", "value":"0"}, {"or":[{"field":"tvshow", "operator":"contains", "value":"SerieA"}, {"field":"tvshow", "operator":"contains", "value":"SerieB"}]}]}]}</episodepath>
</recentlyaddedjob>
```
