### PR TITLE
dlopen: don't load all solibs with RTLD_GLOBAL

### DIFF
--- a/xbmc/cores/DllLoader/SoLoader.cpp
+++ b/xbmc/cores/DllLoader/SoLoader.cpp
@@ -48,7 +48,6 @@ bool SoLoader::Load()
 
   CStdString strFileName= CSpecialProtocol::TranslatePath(GetFileName());
   int flags = RTLD_LAZY;
-  if (m_bGlobal) flags |= RTLD_GLOBAL;
   if (strFileName == "xbmc.so")
   {
     CLog::Log(LOGDEBUG, "Loading Internal Library\n");


### PR DESCRIPTION
This was inadvertant, and a result of the meaning of the flag changing as it
moves down the abstraction chain. This flag SHOULD represent whether or not we
want debug symbols, which doesn't apply to *nix anyway.

Instead it ended up forcing all symbols to GLOBAL, meaning that when loading 2
libs with identical symbol names, the new ones would be ignored. This
manifested when loading libamlplayer because it contains ffmpeg's symbols,
which were skipped in favor of our internal ones.

Ideally this would be fixed further up the chain, but there are so many things
wrong I don't know where to start. But for sure, RTLD_GLOBAL has _nothing_ to
do with the flag we pass in, and has no business being used here.

Submitting as a PR as a courtesy because it could have some complicated implications, but I'm confident that this is the more correct behavior.
