### PR TITLE
addons: don't show a GUI notification for addons installed as a dependency of another addon installation

### DIFF
--- a/xbmc/addons/AddonInstaller.h
+++ b/xbmc/addons/AddonInstaller.h
@@ -51,7 +51,7 @@ public:
    \return true on successful install, false on failure.
    \sa DoInstall
    */
-  bool Install(const CStdString &addonID, bool force = false, const CStdString &referer="", bool background = true);
+  bool Install(const CStdString &addonID, bool force = false, const CStdString &referer="", bool background = true, bool dependency = false);
 
   /*! \brief Install an addon from the given zip path
    \param path the zip file to install from
@@ -121,7 +121,7 @@ private:
    \param background whether to install in the background or not. Defaults to true.
    \return true on successful install, false on failure.
    */
-  bool DoInstall(const ADDON::AddonPtr &addon, const CStdString &hash = "", bool update = false, const CStdString &referer = "", bool background = true);
+  bool DoInstall(const ADDON::AddonPtr &addon, const CStdString &hash = "", bool update = false, const CStdString &referer = "", bool background = true, bool dependency = false);
 
   CCriticalSection m_critSection;
   JobMap m_downloadJobs;
@@ -133,7 +133,7 @@ private:
 class CAddonInstallJob : public CFileOperationJob
 {
 public:
-  CAddonInstallJob(const ADDON::AddonPtr &addon, const CStdString &hash = "", bool update = false, const CStdString &referer = "");
+  CAddonInstallJob(const ADDON::AddonPtr &addon, const CStdString &hash = "", bool update = false, const CStdString &referer = "", bool dependency = false);
 
   virtual bool DoWork();
 
@@ -168,6 +168,7 @@ private:
   CStdString m_hash;
   bool m_update;
   CStdString m_referer;
+  bool m_dependency;
 };
 
 class CAddonUnInstallJob : public CFileOperationJob


### PR DESCRIPTION
So I recently installed a few addons and I got a GUI notification for every single dependency that was installed with it like the "Common Plugin Cache" or the "Simple Downloader for XBMC Plugins" which IMO can be a bit confusing if you just wanted to install youtube. These addons (services) will never be directly used by the user so why tell them that they have been installed?
