### PR TITLE
[rbp] Fix missing USE_OMXPLAYER

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -678,6 +678,7 @@ case $use_platform in
      ARCH="arm"
      AC_SUBST(ARCH_DEFINES, "-DTARGET_POSIX -DTARGET_LINUX -D_LINUX -D_ARMEL -DTARGET_RASPBERRY_PI")
      AC_DEFINE(HAS_EGLGLES, [1], [Define if supporting EGL based GLES Framebuffer])
+     USE_OMXPLAYER=1; AC_DEFINE([HAVE_OMXPLAYER],[1],["Define to 1 if OMX Player is enabled"])
      USE_OMXLIB=1; AC_DEFINE([HAVE_OMXLIB],[1],["Define to 1 if OMX libs is enabled"])
      CFLAGS="$CFLAGS"
      CXXFLAGS="$CXXFLAGS"


### PR DESCRIPTION
--with-platform=raspberry-pi has to define this as TARGET_RASPBERRY_PI will assume USE_OMXPLAYER is defined

This was present before, I'm just re-adding it. Must've been lost in a merge
