### PR TITLE
[pvr] leave calculation of time to demuxer when playing recordings

### DIFF
--- a/xbmc/filesystem/PVRFile.cpp
+++ b/xbmc/filesystem/PVRFile.cpp
@@ -123,7 +123,8 @@ int64_t CPVRFile::GetPosition()
 
 int CPVRFile::GetTotalTime()
 {
-  return g_PVRManager.GetTotalTime();
+  // for recordings leave this to demuxer
+  return m_isPlayRecording ? 0 : g_PVRManager.GetTotalTime();
 }
 
 int CPVRFile::GetStartTime()


### PR DESCRIPTION
fix correct display of time when playing pvr (vnsi) recordings.
