### PR TITLE
XLCDproc: read/flush socket after each write

### DIFF
--- a/xbmc/linux/XLCDproc.h
+++ b/xbmc/linux/XLCDproc.h
@@ -40,7 +40,10 @@ public:
   virtual void SetBackLight(int iLight);
   virtual void SetContrast(int iContrast);
   virtual int  GetColumns();
-  virtual int  GetRows(); 
+  virtual int  GetRows();
+
+  bool         SendLCDd(const CStdString &command);
+  void         ReadAndFlushSocket();
 
 protected:
   virtual void Process();


### PR DESCRIPTION
This PR makes the XLCDproc-interface read/flush the socket after write operations.

After i.e. watching LiveTV without switching channels for a longer time (almost happened after approx. 2h), I observed XBMC losing the connection to LCDd, showing the LCDproc server with "CLI:0" etc. on my SoundGraph iMon. At the same time, "connection lost" stuff got logged to xbmc.log.

Reading through http://lcdproc.sourceforge.net/docs/lcdproc-0-5-5-dev.html#language-messages reads "Not reading the messages will cause trouble !". After adding things to read back socket contents at least after each write, the described problem has been resolved.

This change obviously affects linux users only.
