### PR TITLE
[libexif] Added character set conversion to UserComment

### DIFF
--- a/lib/libexif/ExifParse.cpp
+++ b/lib/libexif/ExifParse.cpp
@@ -451,11 +451,32 @@ void CExifParse::ProcessDir(const unsigned char* const DirStart,
 
       case TAG_USERCOMMENT:
       {
-        const int EXIF_COMMENT_HDR_LENGTH = 8;        // All comment tags have 8 bytes of header info
-        int length = max(ByteCount - EXIF_COMMENT_HDR_LENGTH, 0);
-        length = min(length, MAX_COMMENT);
-        strncpy(m_ExifInfo->Comments, (char *)ValuePtr+EXIF_COMMENT_HDR_LENGTH, length);
-//        FixComment(comment);                          // Ensure comment is printable
+        // The UserComment allows comments without the charset limitations of ImageDescription.
+        // Therefore the UserComment field is prefixed by a CharacterCode field (8 Byte):
+        //  - ASCII:         'ASCII\0\0\0'
+        //  - Unicode:       'UNICODE\0'
+        //  - JIS X208-1990: 'JIS\0\0\0\0\0'
+        //  - Unknown:       '\0\0\0\0\0\0\0\0' (application specific)
+
+        m_ExifInfo->CommentsCharset = EXIF_COMMENT_CHARSET_UNKNOWN;
+
+        const int EXIF_COMMENT_CHARSET_LENGTH = 8;
+        if (ByteCount >= EXIF_COMMENT_CHARSET_LENGTH)
+        {
+          // As some implementations use spaces instead of \0 for the padding,
+          // we're not so strict and check only the prefix.
+          if (memcmp(ValuePtr, "ASCII", 5) == 0)
+            m_ExifInfo->CommentsCharset = EXIF_COMMENT_CHARSET_ASCII;
+          else if (memcmp(ValuePtr, "UNICODE", 7) == 0)
+            m_ExifInfo->CommentsCharset = EXIF_COMMENT_CHARSET_UNICODE;
+          else if (memcmp(ValuePtr, "JIS", 3) == 0)
+            m_ExifInfo->CommentsCharset = EXIF_COMMENT_CHARSET_JIS;
+
+          int length = ByteCount - EXIF_COMMENT_CHARSET_LENGTH;
+          length = min(length, MAX_COMMENT);
+          memcpy(m_ExifInfo->Comments, ValuePtr + EXIF_COMMENT_CHARSET_LENGTH, length);
+//          FixComment(comment);                          // Ensure comment is printable
+        }
       }
       break;
 

--- a/lib/libexif/libexif.h
+++ b/lib/libexif/libexif.h
@@ -75,6 +75,12 @@ typedef struct {
   char ImageType[MAX_IPTC_STRING];
 } IPTCInfo_t;
 
+#define EXIF_COMMENT_CHARSET_CONVERTED -1 // Comments contains converted data
+#define EXIF_COMMENT_CHARSET_UNKNOWN    0 // Exif: Unknown
+#define EXIF_COMMENT_CHARSET_ASCII      2 // Exif: Ascii
+#define EXIF_COMMENT_CHARSET_UNICODE    3 // Exif: Unicode (UTF-16)
+#define EXIF_COMMENT_CHARSET_JIS        4 // Exif: JIS X208-1990
+
 #define MAX_COMMENT 2000
 #define MAX_DATE_COPIES 10
 
@@ -101,6 +107,7 @@ typedef struct {
     int   ExposureMode;
     int   ISOequivalent;
     int   LightSource;
+    int   CommentsCharset;             // EXIF_COMMENT_CHARSET_*
     char  Comments[MAX_COMMENT];
     char  Description[MAX_COMMENT];
 


### PR DESCRIPTION
This PR adds charset conversion to the EXIF UserComment field.

The current implementation does not handle Unicode comments correctly: 
http://trac.xbmc.org/ticket/12628: PicInformation, EXIF "User Comment" shows only 1 char.

My implementation adds a CommentsCharset field to libexif and does the actual conversion outside of the lib in PictureInfoTag.cpp (because we have the CharsetConverter class available there).

You can find the relevant part of the spec here: http://www.exif.org/Exif2-2.PDF (page 28).
I also added 2 example pictures to the bugreport for testing.
