### PR TITLE
grouping by movie set outside of the database

### DIFF
--- a/project/VS2010Express/XBMC.vcxproj
+++ b/project/VS2010Express/XBMC.vcxproj
@@ -1249,6 +1249,7 @@
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug Testsuite|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release (DirectX)|Win32'">true</ExcludedFromBuild>
     </ClCompile>
+    <ClCompile Include="..\..\xbmc\utils\GroupUtils.cpp" />
     <ClCompile Include="..\..\xbmc\utils\HTMLTable.cpp" />
     <ClCompile Include="..\..\xbmc\utils\HTMLUtil.cpp" />
     <ClCompile Include="..\..\xbmc\utils\HttpHeader.cpp" />
@@ -2395,6 +2396,7 @@
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug Testsuite|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release (DirectX)|Win32'">true</ExcludedFromBuild>
     </ClInclude>
+    <ClInclude Include="..\..\xbmc\utils\GroupUtils.h" />
     <ClInclude Include="..\..\xbmc\utils\HTMLTable.h" />
     <ClInclude Include="..\..\xbmc\utils\HTMLUtil.h" />
     <ClInclude Include="..\..\xbmc\utils\HttpHeader.h" />

--- a/project/VS2010Express/XBMC.vcxproj.filters
+++ b/project/VS2010Express/XBMC.vcxproj.filters
@@ -2942,6 +2942,9 @@
     <ClCompile Include="..\..\xbmc\filesystem\HTTPFile.cpp">
       <Filter>filesystem</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\xbmc\utils\GroupUtils.cpp">
+      <Filter>utils</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\xbmc\win32\pch.h">
@@ -5748,6 +5751,9 @@
     </ClInclude>
     <ClInclude Include="..\..\xbmc\filesystem\HTTPFile.h">
       <Filter>filesystem</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\xbmc\utils\GroupUtils.h">
+      <Filter>utils</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/xbmc/filesystem/SmartPlaylistDirectory.cpp
+++ b/xbmc/filesystem/SmartPlaylistDirectory.cpp
@@ -114,7 +114,7 @@ namespace XFILE
         videoUrl.AddOption(option, xsp);
         
         CDatabase::Filter dbfilter;
-        success = db.GetSortedVideos(mediaType, videoUrl.ToString(), sorting, items, dbfilter, true);
+        success = db.GetSortedVideos(mediaType, videoUrl.ToString(), sorting, items, dbfilter);
         db.Close();
 
         // if we retrieve a list of episodes and we didn't receive

--- a/xbmc/utils/EdenVideoArtUpdater.cpp
+++ b/xbmc/utils/EdenVideoArtUpdater.cpp
@@ -76,7 +76,7 @@ void CEdenVideoArtUpdater::Process()
   handle->SetTitle(g_localizeStrings.Get(12349));
 
   // movies
-  db.GetMoviesByWhere("videodb://1/2/", CDatabase::Filter(), items, false);
+  db.GetMoviesByWhere("videodb://1/2/", CDatabase::Filter(), items);
   for (int i = 0; i < items.Size(); i++)
   {
     CFileItemPtr item = items[i];

--- a/xbmc/utils/GroupUtils.cpp
+++ b/xbmc/utils/GroupUtils.cpp
@@ -1,0 +1,131 @@
+/*
+ *      Copyright (C) 2012 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include <map>
+#include <set>
+
+#include "GroupUtils.h"
+#include "FileItem.h"
+#include "utils/StringUtils.h"
+#include "utils/Variant.h"
+#include "video/VideoInfoTag.h"
+
+using namespace std;
+
+typedef map<int, set<CFileItemPtr> > SetMap;
+
+bool GroupUtils::Group(GroupBy groupBy, const CFileItemList &items, CFileItemList &groupedItems, GroupAttribute groupAttributes /* = GroupAttributeNone */)
+{
+  if (items.Size() <= 0 || groupBy == GroupByNone)
+    return false;
+
+  SetMap setMap;
+  for (int index = 0; index < items.Size(); index++)
+  {
+    bool add = true;
+    const CFileItemPtr item = items.Get(index);
+
+    // group by sets
+    if ((groupBy & GroupBySet) &&
+        item->HasVideoInfoTag() && item->GetVideoInfoTag()->m_iSetId > 0)
+    {
+      add = false;
+      setMap[item->GetVideoInfoTag()->m_iSetId].insert(item);
+    }
+
+    if (add)
+      groupedItems.Add(item);
+  }
+
+  if ((groupBy & GroupBySet) && setMap.size() > 0)
+  {
+    for (SetMap::const_iterator set = setMap.begin(); set != setMap.end(); set++)
+    {
+      // only one item in the set, so just re-add it
+      if (set->second.size() == 1 && (groupAttributes & GroupAttributeIgnoreSingleItems))
+      {
+        groupedItems.Add(*set->second.begin());
+        continue;
+      }
+
+      CFileItemPtr pItem(new CFileItem((*set->second.begin())->GetVideoInfoTag()->m_strSet));
+      pItem->GetVideoInfoTag()->m_iDbId = set->first;
+      pItem->GetVideoInfoTag()->m_type = "set";
+      pItem->SetPath(StringUtils::Format("videodb://1/7/%ld/", set->first));
+      pItem->m_bIsFolder = true;
+
+      CVideoInfoTag* setInfo = pItem->GetVideoInfoTag();
+      setInfo->m_strPath = pItem->GetPath();
+      setInfo->m_strTitle = pItem->GetLabel();
+
+      int ratings = 0;
+      int iWatched = 0; // have all the movies been played at least once?
+      for (std::set<CFileItemPtr>::const_iterator movie = set->second.begin(); movie != set->second.end(); movie++)
+      {
+        CVideoInfoTag* movieInfo = (*movie)->GetVideoInfoTag();
+        // handle rating
+        if (movieInfo->m_fRating > 0.0f)
+        {
+          ratings++;
+          setInfo->m_fRating += movieInfo->m_fRating;
+        }
+        
+        // handle year
+        if (movieInfo->m_iYear > setInfo->m_iYear)
+          setInfo->m_iYear = movieInfo->m_iYear;
+        
+        // handle lastplayed
+        if (movieInfo->m_lastPlayed.IsValid() && movieInfo->m_lastPlayed > setInfo->m_lastPlayed)
+          setInfo->m_lastPlayed = movieInfo->m_lastPlayed;
+        
+        // handle dateadded
+        if (movieInfo->m_dateAdded.IsValid() && movieInfo->m_dateAdded > setInfo->m_dateAdded)
+          setInfo->m_dateAdded = movieInfo->m_dateAdded;
+        
+        // handle playcount/watched
+        setInfo->m_playCount += movieInfo->m_playCount;
+        if (movieInfo->m_playCount > 0)
+          iWatched++;
+      }
+
+      if (ratings > 1)
+        pItem->GetVideoInfoTag()->m_fRating /= ratings;
+        
+      setInfo->m_playCount = iWatched >= (int)set->second.size() ? (setInfo->m_playCount / set->second.size()) : 0;
+      pItem->SetProperty("total", (int)set->second.size());
+      pItem->SetProperty("watched", iWatched);
+      pItem->SetProperty("unwatched", (int)set->second.size() - iWatched);
+      pItem->SetOverlayImage(CGUIListItem::ICON_OVERLAY_UNWATCHED, setInfo->m_playCount > 0);
+
+      groupedItems.Add(pItem);
+    }
+  }
+
+  return true;
+}
+
+bool GroupUtils::GroupAndSort(GroupBy groupBy, const CFileItemList &items, const SortDescription &sortDescription, CFileItemList &groupedItems, GroupAttribute groupAttributes /* = GroupAttributeNone */)
+{
+  if (!Group(groupBy, items, groupedItems, groupAttributes))
+    return false;
+
+  groupedItems.Sort(sortDescription);
+  return true;
+}

--- a/xbmc/utils/GroupUtils.h
+++ b/xbmc/utils/GroupUtils.h
@@ -1,0 +1,42 @@
+#pragma once
+/*
+ *      Copyright (C) 2012 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "SortUtils.h"
+
+class CFileItemList;
+
+// can be used as a flag
+typedef enum {
+  GroupByNone = 0x0,
+  GroupBySet  = 0x1
+} GroupBy;
+
+typedef enum {
+  GroupAttributeNone              = 0x0,
+  GroupAttributeIgnoreSingleItems = 0x1
+} GroupAttribute;
+
+class GroupUtils
+{
+public:
+  static bool Group(GroupBy groupBy, const CFileItemList &items, CFileItemList &groupedItems, GroupAttribute groupAttributes = GroupAttributeNone);
+  static bool GroupAndSort(GroupBy groupBy, const CFileItemList &items, const SortDescription &sortDescription, CFileItemList &groupedItems, GroupAttribute groupAttributes = GroupAttributeNone);
+};

--- a/xbmc/utils/Makefile
+++ b/xbmc/utils/Makefile
@@ -23,6 +23,7 @@ SRCS=AlarmClock.cpp \
      fstrcmp.c \
      fft.cpp \
      GLUtils.cpp \
+     GroupUtils.cpp \
      HTMLTable.cpp \
      HTMLUtil.cpp \
      HttpHeader.cpp \

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -640,14 +640,14 @@ public:
   bool ImportArtFromXML(const TiXmlNode *node, std::map<std::string, std::string> &artwork);
 
   // smart playlists and main retrieval work in these functions
-  bool GetMoviesByWhere(const CStdString& strBaseDir, const Filter &filter, CFileItemList& items, bool fetchSets = false, const SortDescription &sortDescription = SortDescription());
+  bool GetMoviesByWhere(const CStdString& strBaseDir, const Filter &filter, CFileItemList& items, const SortDescription &sortDescription = SortDescription());
   bool GetSetsByWhere(const CStdString& strBaseDir, const Filter &filter, CFileItemList& items, bool ignoreSingleMovieSets = false);
   bool GetTvShowsByWhere(const CStdString& strBaseDir, const Filter &filter, CFileItemList& items, const SortDescription &sortDescription = SortDescription());
   bool GetEpisodesByWhere(const CStdString& strBaseDir, const Filter &filter, CFileItemList& items, bool appendFullShowPath = true, const SortDescription &sortDescription = SortDescription());
   bool GetMusicVideosByWhere(const CStdString &baseDir, const Filter &filter, CFileItemList& items, bool checkLocks = true, const SortDescription &sortDescription = SortDescription());
   
   // retrieve sorted and limited items
-  bool GetSortedVideos(MediaType mediaType, const CStdString& strBaseDir, const SortDescription &sortDescription, CFileItemList& items, const Filter &filter = Filter(), bool fetchSets = false);
+  bool GetSortedVideos(MediaType mediaType, const CStdString& strBaseDir, const SortDescription &sortDescription, CFileItemList& items, const Filter &filter = Filter());
 
   // partymode
   int GetMusicVideoCount(const CStdString& strWhere);

--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -71,6 +71,7 @@
 #include "URL.h"
 #include "utils/EdenVideoArtUpdater.h"
 #include "GUIInfoManager.h"
+#include "utils/GroupUtils.h"
 
 using namespace std;
 using namespace XFILE;
@@ -1839,8 +1840,24 @@ bool CGUIWindowVideoBase::StackingAvailable(const CFileItemList &items) const
            url.GetProtocol() == "playlistvideo");
 }
 
-void CGUIWindowVideoBase::OnPrepareFileItems(CFileItemList &items)
+void CGUIWindowVideoBase::GetGroupedItems(CFileItemList &items)
 {
+  CGUIMediaWindow::GetGroupedItems(items);
+
+  CQueryParams params;
+  CVideoDatabaseDirectory dir;
+  dir.GetQueryParams(items.GetPath(), params);
+  if (items.GetContent().Equals("movies") && params.GetSetId() <= 0 &&
+      CVideoDatabaseDirectory::GetDirectoryChildType(items.GetPath()) != NODE_TYPE_RECENTLY_ADDED_MOVIES &&
+      g_guiSettings.GetBool("videolibrary.groupmoviesets"))
+  {
+    CFileItemList groupedItems;
+    if (GroupUtils::Group(GroupBySet, items, groupedItems, GroupAttributeIgnoreSingleItems))
+    {
+      items.ClearItems();
+      items.Append(groupedItems);
+    }
+  }
 }
 
 bool CGUIWindowVideoBase::CheckFilterAdvanced(CFileItemList &items) const

--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -1788,7 +1788,9 @@ bool CGUIWindowVideoBase::Update(const CStdString &strDirectory, bool updateFilt
   if (!CGUIMediaWindow::Update(strDirectory, updateFilterPath))
     return false;
 
-  m_thumbLoader.Load(*m_unfilteredItems);
+  // might already be running from GetGroupedItems
+  if (!m_thumbLoader.IsLoading())
+    m_thumbLoader.Load(*m_vecItems);
 
   return true;
 }
@@ -1858,6 +1860,12 @@ void CGUIWindowVideoBase::GetGroupedItems(CFileItemList &items)
       items.Append(groupedItems);
     }
   }
+
+  // reload thumbs after filtering and grouping
+  if (m_thumbLoader.IsLoading())
+    m_thumbLoader.StopThread();
+
+  m_thumbLoader.Load(items);
 }
 
 bool CGUIWindowVideoBase::CheckFilterAdvanced(CFileItemList &items) const

--- a/xbmc/video/windows/GUIWindowVideoBase.h
+++ b/xbmc/video/windows/GUIWindowVideoBase.h
@@ -88,7 +88,7 @@ protected:
   virtual bool Update(const CStdString &strDirectory, bool updateFilterPath = true);
   virtual bool GetDirectory(const CStdString &strDirectory, CFileItemList &items);
   virtual void OnItemLoaded(CFileItem* pItem) {};
-  virtual void OnPrepareFileItems(CFileItemList &items);
+  virtual void GetGroupedItems(CFileItemList &items);
 
   virtual bool CheckFilterAdvanced(CFileItemList &items) const;
   virtual bool CanContainFilter(const CStdString &strDirectory) const;

--- a/xbmc/video/windows/GUIWindowVideoNav.cpp
+++ b/xbmc/video/windows/GUIWindowVideoNav.cpp
@@ -537,23 +537,14 @@ void CGUIWindowVideoNav::UpdateButtons()
 
 bool CGUIWindowVideoNav::GetFilteredItems(const CStdString &filter, CFileItemList &items)
 {
-  bool listchanged = false;
-  bool updateItems = false;
-  if (!m_canFilterAdvanced)
-    listchanged = CGUIMediaWindow::GetFilteredItems(filter, items);
-  else
-    listchanged = CGUIMediaWindow::GetAdvanceFilteredItems(items, updateItems);
-
+  bool listchanged = CGUIMediaWindow::GetFilteredItems(filter, items);
   listchanged |= ApplyWatchedFilter(items);
 
   // there are new items so we need to run the thumbloader
-  if (updateItems)
-  {
-    if (m_thumbLoader.IsLoading())
-      m_thumbLoader.StopThread();
+  if (m_thumbLoader.IsLoading())
+    m_thumbLoader.StopThread();
 
-    m_thumbLoader.Load(items);
-  }
+  m_thumbLoader.Load(items);
 
   return listchanged;
 }

--- a/xbmc/video/windows/GUIWindowVideoNav.cpp
+++ b/xbmc/video/windows/GUIWindowVideoNav.cpp
@@ -540,12 +540,6 @@ bool CGUIWindowVideoNav::GetFilteredItems(const CStdString &filter, CFileItemLis
   bool listchanged = CGUIMediaWindow::GetFilteredItems(filter, items);
   listchanged |= ApplyWatchedFilter(items);
 
-  // there are new items so we need to run the thumbloader
-  if (m_thumbLoader.IsLoading())
-    m_thumbLoader.StopThread();
-
-  m_thumbLoader.Load(items);
-
   return listchanged;
 }
 

--- a/xbmc/windows/GUIMediaWindow.h
+++ b/xbmc/windows/GUIMediaWindow.h
@@ -86,7 +86,9 @@ protected:
   virtual bool Refresh(bool clearCache = false);
   virtual void FormatAndSort(CFileItemList &items);
   virtual void OnPrepareFileItems(CFileItemList &items);
+  virtual void OnCacheFileItems(CFileItemList &items);
   virtual void OnFinalizeFileItems(CFileItemList &items);
+  virtual void GetGroupedItems(CFileItemList &items) { }
 
   void ClearFileItems();
   virtual void SortItems(CFileItemList &items);
@@ -123,7 +125,7 @@ protected:
                      which were not present in the original list
   \sa GetFilteredItems
   */
-  virtual bool GetAdvanceFilteredItems(CFileItemList &items, bool &hasNewItems);
+  virtual bool GetAdvanceFilteredItems(CFileItemList &items);
 
   // check for a disc or connection
   virtual bool HaveDiscOrConnection(const CStdString& strPath, int iDriveType);


### PR DESCRIPTION
This is more of an RFC than an actual PR as I'd like to get some opinions on the general idea and the implementation.

A while ago I had a discussion with @jmarshallnz about doing the grouping of movies into movie sets outside of the videodatabase. The advantage would be that the code GetMoviesByWhere would become a lot easier and GetMoviesNav/GetMoviesByWhere will return a list of movies and not a mixed list of movies and movie sets. The grouping into movie sets would then happen before the movies are displayed in the GUI. I had this idea when I was working on the advanced filtering. When applying a filter it can happen that a filter only matches one of the movies in a movie set so XBMC should only show that single movie and not the whole movie set. While that's not a problem to achieve the problem arises when it comes to loading the artwork for items etc which is done in the background and on the initial list. So the "new" item which was previously part of a movie set does not have any artwork and other details assigned yet.

So I have written a utility class called GroupUtils which is called from CGUIWindowVideoBase after a list of movies has been retrieved from the database and filtered. It currently only supports grouping by movie sets (based on CVideoInfoTag::m_setId).

So what are your opinions? Does the grouping outside of the database make sense at all?
