### PR TITLE
Remove libxbtag.so from android packaging

### DIFF
--- a/tools/android/packaging/Makefile
+++ b/tools/android/packaging/Makefile
@@ -5,7 +5,7 @@ OBJS = libcurl.so \
   libafpclient.so  \
   libshairport.so libplist.so \
   libxbogg.so libxbvorbis.so libxbvorbisfile.so libxbFLAC.so libxbmpeg2.so \
-  libxbmpeg2convert.so libxbtag.so
+  libxbmpeg2convert.so
 
 PLATFORM_OBJS =
 


### PR DESCRIPTION
Since f6ca40f taglib is build statically and "make apk" fails with:
`cp: cannot stat `/Android/toolchain/android-14/staging/armeabi-v7a/lib/libxbtag.so': No such file or directory`

This commit removes the old dynamic library from packaging...
