### PR TITLE
AE: fix audio sync

### DIFF
--- a/xbmc/cores/dvdplayer/DVDAudio.cpp
+++ b/xbmc/cores/dvdplayer/DVDAudio.cpp
@@ -40,6 +40,11 @@ void CPTSOutputQueue::Add(double pts, double delay, double duration)
 {
   CSingleLock lock(m_sync);
 
+  // don't accept a re-add, since that would cause time moving back
+  double last = m_queue.empty() ? m_current.pts : m_queue.back().pts;
+  if(last == pts)
+    return;
+
   TPTSItem item;
   item.pts = pts;
   item.timestamp = CDVDClock::GetAbsoluteClock() + delay;

--- a/xbmc/cores/dvdplayer/DVDAudio.cpp
+++ b/xbmc/cores/dvdplayer/DVDAudio.cpp
@@ -30,6 +30,63 @@
 
 using namespace std;
 
+
+CPTSOutputQueue::CPTSOutputQueue()
+{
+  Flush();
+}
+
+void CPTSOutputQueue::Add(double pts, double delay, double duration)
+{
+  CSingleLock lock(m_sync);
+
+  TPTSItem item;
+  item.pts = pts;
+  item.timestamp = CDVDClock::GetAbsoluteClock() + delay;
+  item.duration = duration;
+
+  // first one is applied directly
+  if(m_queue.empty() && m_current.pts == DVD_NOPTS_VALUE)
+    m_current = item;
+  else
+    m_queue.push(item);
+
+  // call function to make sure the queue
+  // doesn't grow should nobody call it
+  Current();
+}
+void CPTSOutputQueue::Flush()
+{
+  CSingleLock lock(m_sync);
+
+  while( !m_queue.empty() ) m_queue.pop();
+  m_current.pts = DVD_NOPTS_VALUE;
+  m_current.timestamp = 0.0;
+  m_current.duration = 0.0;
+}
+
+double CPTSOutputQueue::Current()
+{
+  CSingleLock lock(m_sync);
+
+  if(!m_queue.empty() && m_current.pts == DVD_NOPTS_VALUE)
+  {
+    m_current = m_queue.front();
+    m_queue.pop();
+  }
+
+  while( !m_queue.empty() && CDVDClock::GetAbsoluteClock() >= m_queue.front().timestamp )
+  {
+    m_current = m_queue.front();
+    m_queue.pop();
+  }
+
+  if( m_current.timestamp == 0 ) return m_current.pts;
+
+  return m_current.pts + min(m_current.duration, (CDVDClock::GetAbsoluteClock() - m_current.timestamp));
+}
+
+
 CDVDAudio::CDVDAudio(volatile bool &bStop)
   : m_bStop(bStop)
 {

--- a/xbmc/cores/dvdplayer/DVDAudio.h
+++ b/xbmc/cores/dvdplayer/DVDAudio.h
@@ -25,6 +25,7 @@
 #endif
 #include "threads/CriticalSection.h"
 #include "PlatformDefs.h"
+#include <queue>
 
 #include "cores/AudioEngine/Utils/AEChannelInfo.h"
 class IAEStream;
@@ -45,6 +46,22 @@ extern "C" {
 }
 #endif
 typedef struct stDVDAudioFrame DVDAudioFrame;
+
+
+class CPTSOutputQueue
+{
+private:
+  typedef struct {double pts; double timestamp; double duration;} TPTSItem;
+  TPTSItem m_current;
+  std::queue<TPTSItem> m_queue;
+  CCriticalSection m_sync;
+
+public:
+  CPTSOutputQueue();
+  void Add(double pts, double delay, double duration);
+  void Flush();
+  double Current();
+};
 
 class CSingleLock;
 class IAudioCallback;

--- a/xbmc/cores/dvdplayer/DVDAudio.h
+++ b/xbmc/cores/dvdplayer/DVDAudio.h
@@ -85,6 +85,8 @@ public:
   void Destroy();
   DWORD AddPackets(const DVDAudioFrame &audioframe);
   double GetDelay(); // returns the time it takes to play a packet if we add one at this time
+  double GetPlayingPts() { return m_time.Current(); }
+  void   SetPlayingPts(double pts);
   double GetCacheTime();  // returns total amount of data cached in audio output at this time
   double GetCacheTotal(); // returns total amount the audio device can buffer
   void Flush();
@@ -96,6 +98,7 @@ public:
 
   IAEStream *m_pAudioStream;
 protected:
+  CPTSOutputQueue m_time;
   DWORD AddPacketsRenderer(unsigned char* data, DWORD len, CSingleLock &lock);
   BYTE* m_pBuffer; // should be [m_dwPacketSize]
   DWORD m_iBufferSize;

--- a/xbmc/cores/dvdplayer/DVDPlayerAudio.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayerAudio.cpp
@@ -243,9 +243,6 @@ void CDVDPlayerAudio::CloseStream(bool bWaitForBuffers)
     delete m_pAudioCodec;
     m_pAudioCodec = NULL;
   }
-
-  // flush any remaining pts values
-  m_ptsOutput.Flush();
 }
 
 // decode one audio frame and returns its uncompressed size
@@ -394,12 +391,11 @@ int CDVDPlayerAudio::DecodeFrame(DVDAudioFrame &audioframe, bool bDropPacket)
         m_audioClock = pMsgGeneralResync->m_timestamp;
 
       m_ptsInput.Flush();
-      m_ptsOutput.Flush();
-      m_ptsOutput.Add(m_audioClock, m_dvdAudio.GetDelay(), 0);
+      m_dvdAudio.SetPlayingPts(m_audioClock);
       if (pMsgGeneralResync->m_clock)
       {
         CLog::Log(LOGDEBUG, "CDVDPlayerAudio - CDVDMsg::GENERAL_RESYNC(%f, 1)", m_audioClock);
-        m_pClock->Discontinuity(m_ptsOutput.Current());
+        m_pClock->Discontinuity(m_dvdAudio.GetPlayingPts());
       }
       else
         CLog::Log(LOGDEBUG, "CDVDPlayerAudio - CDVDMsg::GENERAL_RESYNC(%f, 0)", m_audioClock);
@@ -414,7 +410,6 @@ int CDVDPlayerAudio::DecodeFrame(DVDAudioFrame &audioframe, bool bDropPacket)
     else if (pMsg->IsType(CDVDMsg::GENERAL_FLUSH))
     {
       m_dvdAudio.Flush();
-      m_ptsOutput.Flush();
       m_ptsInput.Flush();
       m_syncclock = true;
       m_stalled   = true;
@@ -460,7 +455,6 @@ int CDVDPlayerAudio::DecodeFrame(DVDAudioFrame &audioframe, bool bDropPacket)
       }
       else
       {
-        m_ptsOutput.Flush();
         m_syncclock = true;
         if (m_speed != DVD_PLAYSPEED_PAUSE)
           m_dvdAudio.Flush();
@@ -599,15 +593,6 @@ void CDVDPlayerAudio::Process()
         m_stalled = false;
     }
 
-    // store the delay for this pts value so we can calculate the current playing
-    if(packetadded)
-    {
-      if(m_speed == DVD_PLAYSPEED_PAUSE)
-        m_ptsOutput.Add(audioframe.pts, m_dvdAudio.GetDelay() - audioframe.duration, 0);
-      else
-        m_ptsOutput.Add(audioframe.pts, m_dvdAudio.GetDelay() - audioframe.duration, audioframe.duration);
-    }
-
     // signal to our parent that we have initialized
     if(m_started == false)
     {
@@ -615,7 +600,7 @@ void CDVDPlayerAudio::Process()
       m_messageParent.Put(new CDVDMsgInt(CDVDMsg::PLAYER_STARTED, DVDPLAYER_AUDIO));
     }
 
-    if( m_ptsOutput.Current() == DVD_NOPTS_VALUE )
+    if( m_dvdAudio.GetPlayingPts() == DVD_NOPTS_VALUE )
       continue;
 
     if( m_speed != DVD_PLAYSPEED_NORMAL )
@@ -657,7 +642,7 @@ void CDVDPlayerAudio::SetSyncType(bool passthrough)
 void CDVDPlayerAudio::HandleSyncError(double duration)
 {
   double clock = m_pClock->GetClock();
-  double error = m_ptsOutput.Current() - clock;
+  double error = m_dvdAudio.GetPlayingPts() - clock;
   int64_t now;
 
   if( fabs(error) > DVD_MSEC_TO_TIME(100) || m_syncclock )

--- a/xbmc/cores/dvdplayer/DVDPlayerAudio.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayerAudio.cpp
@@ -45,61 +45,6 @@
 
 using namespace std;
 
-CPTSOutputQueue::CPTSOutputQueue()
-{
-  Flush();
-}
-
-void CPTSOutputQueue::Add(double pts, double delay, double duration)
-{
-  CSingleLock lock(m_sync);
-
-  TPTSItem item;
-  item.pts = pts;
-  item.timestamp = CDVDClock::GetAbsoluteClock() + delay;
-  item.duration = duration;
-
-  // first one is applied directly
-  if(m_queue.empty() && m_current.pts == DVD_NOPTS_VALUE)
-    m_current = item;
-  else
-    m_queue.push(item);
-
-  // call function to make sure the queue
-  // doesn't grow should nobody call it
-  Current();
-}
-void CPTSOutputQueue::Flush()
-{
-  CSingleLock lock(m_sync);
-
-  while( !m_queue.empty() ) m_queue.pop();
-  m_current.pts = DVD_NOPTS_VALUE;
-  m_current.timestamp = 0.0;
-  m_current.duration = 0.0;
-}
-
-double CPTSOutputQueue::Current()
-{
-  CSingleLock lock(m_sync);
-
-  if(!m_queue.empty() && m_current.pts == DVD_NOPTS_VALUE)
-  {
-    m_current = m_queue.front();
-    m_queue.pop();
-  }
-
-  while( !m_queue.empty() && CDVDClock::GetAbsoluteClock() >= m_queue.front().timestamp )
-  {
-    m_current = m_queue.front();
-    m_queue.pop();
-  }
-
-  if( m_current.timestamp == 0 ) return m_current.pts;
-
-  return m_current.pts + min(m_current.duration, (CDVDClock::GetAbsoluteClock() - m_current.timestamp));
-}
-
 void CPTSInputQueue::Add(int64_t bytes, double pts)
 {
   CSingleLock lock(m_sync);

--- a/xbmc/cores/dvdplayer/DVDPlayerAudio.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayerAudio.cpp
@@ -675,9 +675,9 @@ void CDVDPlayerAudio::HandleSyncError(double duration)
   m_errorbuff += error;
   m_errorcount++;
 
-  //check if measured error for 1 second
+  //check if measured error for 2 seconds
   now = CurrentHostCounter();
-  if ((now - m_errortime) >= m_freq)
+  if ((now - m_errortime) >= m_freq * 2)
   {
     m_errortime = now;
     m_error = m_errorbuff / m_errorcount;

--- a/xbmc/cores/dvdplayer/DVDPlayerAudio.h
+++ b/xbmc/cores/dvdplayer/DVDPlayerAudio.h
@@ -116,7 +116,7 @@ public:
   CPTSOutputQueue m_ptsOutput;
   CPTSInputQueue  m_ptsInput;
 
-  double GetCurrentPts()                            { return m_ptsOutput.Current(); }
+  double GetCurrentPts()                            { return m_dvdAudio.GetPlayingPts(); }
 
   bool IsStalled()                                  { return m_stalled;  }
   bool IsPassthrough() const;

--- a/xbmc/cores/dvdplayer/DVDPlayerAudio.h
+++ b/xbmc/cores/dvdplayer/DVDPlayerAudio.h
@@ -63,21 +63,6 @@ typedef struct stDVDAudioFrame
   bool              passthrough;
 } DVDAudioFrame;
 
-class CPTSOutputQueue
-{
-private:
-  typedef struct {double pts; double timestamp; double duration;} TPTSItem;
-  TPTSItem m_current;
-  std::queue<TPTSItem> m_queue;
-  CCriticalSection m_sync;
-
-public:
-  CPTSOutputQueue();
-  void Add(double pts, double delay, double duration);
-  void Flush();
-  double Current();
-};
-
 class CPTSInputQueue
 {
 private:


### PR DESCRIPTION
This is a concept fix for a major bug in AE. GetDelay returned random values because it did not consider context switches. In particular this was noticeable when transcoding was active. The audio error in dvdplayer was jumping back and forth by > 100ms.

I have done and tested this only for SoftAE yet but should be easy to add to the other engines too.
Thoughts?
