### PR TITLE
[PVR] Stop only active instant recording

### DIFF
--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -639,8 +639,15 @@ bool CPVRManager::StartRecordingOnPlayingChannel(bool bOnOff)
     }
     else if (!bOnOff && channel->IsRecording())
     {
-      /* delete active timers */
-      bReturn = m_timers->DeleteTimersOnChannel(*channel, false, true);
+      /* delete active timer on this channel */
+      vector<CFileItemPtr> activeTags = g_PVRTimers->GetActiveRecordings();
+
+      for (unsigned int pat = 0; pat < activeTags.size(); pat++)
+      {
+        CFileItemPtr timer = activeTags.at(pat);
+        if (timer->GetPVRTimerInfoTag()->m_iClientChannelUid == channel->UniqueID())
+          bReturn = m_timers->DeleteTimer(*timer);
+      }
     }
   }
 


### PR DESCRIPTION
Currently all timers on channel are deleted if you stop active instant recording with XBMC.PlayerControl(record). There is also no notification.

With this fix only active recording on current channel is stopped. Any possible future timers on channel are not deleted.
Notification now works correctly.
PVR.IsRecording didn't return correct status when recording was stopped with XBMC.PlayerControl(record), now this is fixed.
