### PR TITLE
d-r: enable dirty-regions by default

### DIFF
--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -306,8 +306,8 @@ void CAdvancedSettings::Initialize()
 
   m_canWindowed = true;
   m_guiVisualizeDirtyRegions = false;
-  m_guiAlgorithmDirtyRegions = 0;
-  m_guiDirtyRegionNoFlipTimeout = -1;
+  m_guiAlgorithmDirtyRegions = 3;
+  m_guiDirtyRegionNoFlipTimeout = 0;
   m_logEnableAirtunes = false;
   m_airTunesPort = 36666;
   m_airPlayPort = 36667;


### PR DESCRIPTION
As decided at devcon. Enable dirty-regions by default on all platforms.
## 

This enables the all-or-nothing mode, which means that we repaint the entire
screen if there's a single dirty region.

Also, nofliptimeout=0 is set to ensure that we never flip without rendering.

With these combined, this should be universally safe (and within spec) for all
gfx cards/drivers.

The main possible side-effect is the slow-motion effect brought about on slower
cpus that can't keep up at times and produce wild timestamps. With our improved
decoding and caching, this is now quite rare.
