### PR TITLE
addons: deprecate plugin ability to set player.

### DIFF
--- a/xbmc/interfaces/legacy/ModuleXbmc.cpp
+++ b/xbmc/interfaces/legacy/ModuleXbmc.cpp
@@ -485,10 +485,13 @@ namespace XBMCAddon
 
     int getPLAYLIST_MUSIC() { return PLAYLIST_MUSIC; }
     int getPLAYLIST_VIDEO() { return PLAYLIST_VIDEO; }
-    int getPLAYER_CORE_AUTO() { return EPC_NONE; }
-    int getPLAYER_CORE_DVDPLAYER() { return EPC_DVDPLAYER; }
-    int getPLAYER_CORE_MPLAYER() { return EPC_MPLAYER; }
-    int getPLAYER_CORE_PAPLAYER() { return EPC_PAPLAYER; }
+
+    // deprecated/ignored for Frodo. Remove for Frodo+1.
+    int getPLAYER_CORE_AUTO() { return 0; }
+    int getPLAYER_CORE_DVDPLAYER() { return -1; }
+    int getPLAYER_CORE_MPLAYER() { return -1; }
+    int getPLAYER_CORE_PAPLAYER() { return -1; }
+
     int getTRAY_OPEN() { return TRAY_OPEN; }
     int getDRIVE_NOT_READY() { return DRIVE_NOT_READY; }
     int getTRAY_CLOSED_NO_MEDIA() { return TRAY_CLOSED_NO_MEDIA; }

--- a/xbmc/interfaces/legacy/Player.cpp
+++ b/xbmc/interfaces/legacy/Player.cpp
@@ -39,12 +39,8 @@ namespace XBMCAddon
     {
       iPlayList = PLAYLIST_MUSIC;
 
-      if (_playerCore == EPC_DVDPLAYER ||
-          _playerCore == EPC_MPLAYER ||
-          _playerCore == EPC_PAPLAYER)
-        playerCore = (EPLAYERCORES)_playerCore;
-      else
-        playerCore = EPC_NONE;
+    if (_playerCore != 0)
+      CLog::Log(LOGERROR, "xbmc.Player: Requested non-default player. This behavior is deprecated, plugins may no longer specify a player", _playerCore);
 
       // now that we're done, register hook me into the system
       if (languageHook)
@@ -67,9 +63,6 @@ namespace XBMCAddon
       {
         // set fullscreen or windowed
         g_settings.m_bStartVideoWindowed = windowed;
-
-        // force a playercore before playing
-        g_application.m_eForcedNextPlayer = playerCore;
 
         const AddonClass::Ref<xbmcgui::ListItem> listitem(plistitem);
 
@@ -95,9 +88,6 @@ namespace XBMCAddon
       // set fullscreen or windowed
       g_settings.m_bStartVideoWindowed = windowed;
 
-      // force a playercore before playing
-      g_application.m_eForcedNextPlayer = playerCore;
-
       // play current file in playlist
       if (g_playlistPlayer.GetCurrentPlaylist() != iPlayList)
         g_playlistPlayer.SetCurrentPlaylist(iPlayList);
@@ -111,9 +101,6 @@ namespace XBMCAddon
       {
         // set fullscreen or windowed
         g_settings.m_bStartVideoWindowed = windowed;
-
-        // force a playercore before playing
-        g_application.m_eForcedNextPlayer = playerCore;
 
         // play a python playlist (a playlist from playlistplayer.cpp)
         iPlayList = playlist->getPlayListId();
@@ -139,27 +126,18 @@ namespace XBMCAddon
     void Player::playnext()
     {
       TRACE;
-      // force a playercore before playing
-      g_application.m_eForcedNextPlayer = playerCore;
-
       CApplicationMessenger::Get().PlayListPlayerNext();
     }
 
     void Player::playprevious()
     {
       TRACE;
-      // force a playercore before playing
-      g_application.m_eForcedNextPlayer = playerCore;
-
       CApplicationMessenger::Get().PlayListPlayerPrevious();
     }
 
     void Player::playselected(int selected)
     {
       TRACE;
-      // force a playercore before playing
-      g_application.m_eForcedNextPlayer = playerCore;
-
       if (g_playlistPlayer.GetCurrentPlaylist() != iPlayList)
       {
         g_playlistPlayer.SetCurrentPlaylist(iPlayList);

--- a/xbmc/interfaces/legacy/Player.h
+++ b/xbmc/interfaces/legacy/Player.h
@@ -21,8 +21,6 @@
 
 #pragma once
 
-#include "cores/playercorefactory/PlayerCoreFactory.h"
-
 #include "ListItem.h"
 #include "PlayList.h"
 #include "InfoTagVideo.h"
@@ -45,11 +43,7 @@ namespace XBMCAddon
      * 
      * Player([core]) -- Creates a new Player with as default the xbmc music playlist.
      * 
-     * core     : (optional) Use a specified playcore instead of letting xbmc decide the playercore to use.
-     *          - xbmc.PLAYER_CORE_AUTO
-     *          - xbmc.PLAYER_CORE_DVDPLAYER
-     *          - xbmc.PLAYER_CORE_MPLAYER
-     *          - xbmc.PLAYER_CORE_PAPLAYER
+     * core     : (ignored) Use a specified playcore instead of letting xbmc decide the playercore to use.
      *
      * This class is a merge of what was previously in xbmcmodule/player.h
      *  and xbmcmodule/PythonPlayer.h without the python references. The
@@ -60,7 +54,6 @@ namespace XBMCAddon
     {
     private:
       int iPlayList;
-      EPLAYERCORES playerCore;
 
     public:
       /**
@@ -68,7 +61,7 @@ namespace XBMCAddon
        *  construction of a Player needs to identify whether or not any 
        *  callbacks will be executed asynchronously or not.
        */
-      Player(int playerCore = EPC_NONE);
+      Player(int playerCore = 0);
       virtual ~Player(void);
 
       /**
@@ -87,7 +80,7 @@ namespace XBMCAddon
        * example:
        *   - listitem = xbmcgui.ListItem('Ironman')
        *   - listitem.setInfo('video', {'Title': 'Ironman', 'Genre': 'Science Fiction'})
-       *   - xbmc.Player( xbmc.PLAYER_CORE_MPLAYER ).play(url, listitem, windowed)\n
+       *   - xbmc.Player().play(url, listitem, windowed)\n
        */
       void playStream(const String& item = emptyString, const XBMCAddon::xbmcgui::ListItem* listitem = NULL, bool windowed = false);
 
@@ -113,7 +106,7 @@ namespace XBMCAddon
        * windowed       : [opt] bool - true=play video windowed, false=play users preference.(default)
        * 
        * example:
-       *   - xbmc.Player( xbmc.PLAYER_CORE_MPLAYER ).play()
+       *   - xbmc.Player().play()
        */
       void playCurrent(bool windowed = false);
 


### PR DESCRIPTION
Now that we have multiple players in mainline, specifying a player in an addon should be considered a bug, and is deprecated for Frodo.

Instead, we always use the standard player detection logic.

@jimfcarroll please let me know if any other diddling is necessary with the code-generation. it appears as though this is all that's needed.
