### PR TITLE
[AE] correct BitsPerSample for bitstreaming formats

### DIFF
--- a/xbmc/cores/AudioEngine/Utils/AEUtil.cpp
+++ b/xbmc/cores/AudioEngine/Utils/AEUtil.cpp
@@ -102,12 +102,12 @@ const unsigned int CAEUtil::DataFormatToBits(const enum AEDataFormat dataFormat)
     sizeof(double) << 3, /* DOUBLE */
     sizeof(float ) << 3, /* FLOAT  */
 
-    8,                   /* AAC    */
-    8,                   /* AC3    */
-    8,                   /* DTS    */
-    8,                   /* EAC3   */
-    8,                   /* TRUEHD */
-    8,                   /* DTS-HD */
+    16,                  /* AAC    */
+    16,                  /* AC3    */
+    16,                  /* DTS    */
+    16,                  /* EAC3   */
+    16,                  /* TRUEHD */
+    16,                  /* DTS-HD */
     32                   /* LPCM   */
   };
 


### PR DESCRIPTION
Incorrect values for BitsPerSample leads to incorrect calculation of audio frame duration.
