### PR TITLE
LCD/XLCDproc: Two AS-configurables - scrolltext separator & render frequency

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -2884,7 +2884,8 @@ void CApplication::UpdateLCD()
 
   if (!g_lcd || !g_guiSettings.GetBool("videoscreen.haslcd"))
     return ;
-  unsigned int lTimeOut = 1000;
+  // refreshrate == Hertz
+  unsigned int lTimeOut = 1000 / g_advancedSettings.m_lcdRefreshRate;
   if ( m_iPlaySpeed != 1)
     lTimeOut = 0;
   if ( (XbmcThreads::SystemClockMillis() - lTickCount) >= lTimeOut)

--- a/xbmc/linux/XLCDproc.cpp
+++ b/xbmc/linux/XLCDproc.cpp
@@ -373,7 +373,7 @@ void XLCDproc::SetLine(int iLine, const CStdString& strLine)
     strLineLong.append(m_iColumns - strLineLong.size(), ' ');
   //else if the string doesn't fit the display, lcdproc will scroll it, so we need a space
   else if (strLineLong.size() > m_iColumns)
-    strLineLong += " ";
+    strLineLong += g_advancedSettings.m_lcdScrollSeparator;
 
   if (strLineLong != m_strLine[iLine])
   {

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -129,7 +129,9 @@ void CAdvancedSettings::Initialize()
 
   m_lcdHeartbeat = false;
   m_lcdDimOnScreenSave = false;
+  m_lcdScrollSeparator = " ";
   m_lcdScrolldelay = 1;
+  m_lcdRefreshRate = 4; // Hertz
   m_lcdHostName = "localhost";
 
   m_songInfoDuration = 10;
@@ -675,8 +677,14 @@ void CAdvancedSettings::ParseSettingsFile(const CStdString &file)
   {
     XMLUtils::GetBoolean(pElement, "heartbeat", m_lcdHeartbeat);
     XMLUtils::GetBoolean(pElement, "dimonscreensave", m_lcdDimOnScreenSave);
+    XMLUtils::GetString(pElement, "scrollseparator", m_lcdScrollSeparator);
     XMLUtils::GetInt(pElement, "scrolldelay", m_lcdScrolldelay, -8, 8);
+    XMLUtils::GetInt(pElement, "refreshrate", m_lcdRefreshRate, 1, 20);
     XMLUtils::GetString(pElement, "hostname", m_lcdHostName);
+
+    // add whitespace around separator
+    if (m_lcdScrollSeparator != " ")
+      m_lcdScrollSeparator = " " + m_lcdScrollSeparator + " ";
   }
   pElement = pRootElement->FirstChildElement("network");
   if (pElement)

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -175,7 +175,9 @@ class CAdvancedSettings
 
     bool m_lcdHeartbeat;
     bool m_lcdDimOnScreenSave;
+    CStdString m_lcdScrollSeparator;
     int m_lcdScrolldelay;
+    int m_lcdRefreshRate;
     CStdString m_lcdHostName;
 
     int m_songInfoDuration;

--- a/xbmc/utils/LCD.cpp
+++ b/xbmc/utils/LCD.cpp
@@ -325,7 +325,7 @@ CStdString ILCD::GetBigDigit( UINT _nCharset, int _nDigit, UINT _nLine, UINT _nM
     _nDigit = -_nDigit;
   }
 
-  // Set the current size, and value (base numer)
+  // Set the current size, and value (base number)
   nCurrentSize = 1;
   nCurrentValue = 10;
 
@@ -342,7 +342,7 @@ CStdString ILCD::GetBigDigit( UINT _nCharset, int _nDigit, UINT _nLine, UINT _nM
     for ( UINT nX = 0; nX < arrSizes[ _nCharset ][0]; nX++ )
     {
       // Add a space if we have more than one digit, and the given
-      // digit is smaller than the current value (base numer) we are dealing with
+      // digit is smaller than the current value (base number) we are dealing with
       if ( _bSpacePadding && ((nCurrentValue / 10) > (UINT)_nDigit ) && ( nCurrentSize > 1 ) )
       {
         strCurrentDigit += " ";


### PR DESCRIPTION
This PR adds two configurables to advancedsettings.xml:advancedsettings/lcd/:
- "scrollseparator" provides a changeable separator for scrolling lines on the LCD to be able to better distinguish line end/start. The option defaults to the original " " (single whitespace). If one or more characters are given, it/they will be pre/suffixed by a whitespace. This is done in the config parser to save time on that while rendering LCD lines.
- "refreshrate" lets the user change the frequency (in Hertz) in which UpdateLCD() calls g_lcd->Render() to allow for more frequent updating of LCD content (can e.g. improve playtimer update "accuracy").

The second unrelated commit removes two comment typos.

This (again) should affect linux only.

Note: At least the "refreshrate" option originates from Trac Ticket#8981 (iMon/mdm166a icon support) which I'd soon like to send a PR for, too.
