### PR TITLE
LCD: LCD-Modes (skins) for PVR TV and Radio

### DIFF
--- a/userdata/LCD.xml
+++ b/userdata/LCD.xml
@@ -37,4 +37,16 @@
       <line>Playing</line>
       <line>$INFO[System.LaunchXBE]</line>
    </xbelaunch>
+   <pvrtv>
+      <line>$INFO[VideoPlayer.ChannelName]</line>
+      <line>$INFO[VideoPlayer.Title]</line>
+      <line>$INFO[LCD.PlayIcon] $INFO[Player.Time]/$INFO[Player.Duration]</line>
+      <line>$INFO[LCD.ProgressBar]</line>
+   </pvrtv>
+   <pvrradio>
+      <line>$INFO[MusicPlayer.ChannelName]</line>
+      <line>$INFO[MusicPlayer.Title]</line>
+      <line>$INFO[LCD.PlayIcon] $INFO[Player.Time]/$INFO[Player.Duration]</line>
+      <line>$INFO[LCD.ProgressBar]</line>
+   </pvrradio>
 </lcd>

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -2932,6 +2932,10 @@ void CApplication::UpdateLCD()
   {
     if (g_application.NavigationIdleTime() < 5)
       g_lcd->Render(ILCD::LCD_MODE_NAVIGATION);
+    else if (g_PVRManager.IsPlayingTV())
+      g_lcd->Render(ILCD::LCD_MODE_PVRTV);
+    else if (g_PVRManager.IsPlayingRadio())
+      g_lcd->Render(ILCD::LCD_MODE_PVRRADIO);
     else if (IsPlayingVideo())
       g_lcd->Render(ILCD::LCD_MODE_VIDEO);
     else if (IsPlayingAudio())

--- a/xbmc/utils/LCD.cpp
+++ b/xbmc/utils/LCD.cpp
@@ -455,6 +455,14 @@ void ILCD::LoadSkin(const CStdString &xmlFile)
     { // xbe launch mode
       LoadMode(mode, LCD_MODE_XBE_LAUNCH);
     }
+    else if (strcmpi(mode->Value(), "pvrtv") == 0)
+    { // pvr tv mode
+      LoadMode(mode, LCD_MODE_PVRTV);
+    }
+    else if (strcmpi(mode->Value(), "pvrradio") == 0)
+    { // pvr radio mode
+      LoadMode(mode, LCD_MODE_PVRRADIO);
+    }
     mode = mode->NextSiblingElement();
   }
   TiXmlBase::SetCondenseWhiteSpace(condensed);

--- a/xbmc/utils/LCD.h
+++ b/xbmc/utils/LCD.h
@@ -41,6 +41,8 @@ public:
                         LCD_MODE_NAVIGATION,
                         LCD_MODE_SCREENSAVER,
                         LCD_MODE_XBE_LAUNCH,
+                        LCD_MODE_PVRTV,
+                        LCD_MODE_PVRRADIO,
                         LCD_MODE_MAX
                 };
   enum CUSTOM_CHARSET {


### PR DESCRIPTION
This PR adds two additional modes (skins?) to display specific information regarding currently playing TV or Radio channel on an enabled LC-Display.

Without this, the "video" and "music" LCD-modes are displayed. They might be "skinned" to display a play timer in line1, and the movie or music artist/title in line2, which would fill up two-line-displays completely. However, when playing PVR things, it might be desirable to show the current channel name in line1 instead of the play timer. The commit enables one to achieve this.

Note: Not quite sure about the check if we are in PVR (g_PVRManager->IsPlayingTV/Radio()) or somewhere else (where it's only IsPlayingVideo()). Works quite well so far, however.

Guess affecting linux only, again :-)
