### PR TITLE
fix for duplicate subtitles found on windows

### DIFF
--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -2328,7 +2328,21 @@ void CUtil::ScanForExternalSubtitles(const CStdString& strMovie, std::vector<CSt
     {
       CStdString strPath2 = URIUtils::AddFileToFolder(strLookInPaths[i],common_sub_dirs[j]);
       if (CDirectory::Exists(strPath2))
-        strLookInPaths.push_back(strPath2);
+      {
+        //check that no duplicate paths are added for case-insesitive sources e.g.
+        //subs and Subs would cause duplicate subtitles to be loaded.
+        bool bInsert = true;
+        for (int k=0; k<strLookInPaths.size(); k++)
+        {
+          if(0 == strLookInPaths[k].CompareNoCase(strPath2))
+          {
+            bInsert = false;
+            break;
+          }
+        }
+        if (bInsert)
+          strLookInPaths.push_back(strPath2);
+      }
     }
   }
   // .. done checking for common subdirs


### PR DESCRIPTION
When using subtitles in a subs subdirectory on Windows XBMC loads the subtitles twice and displays twice as many subs/languages in the sub dialog.

I picked this solution since we can have a case sensitive source even if we're on Windows so it still checks for that and if a directory is found twice it skips adding it to the list.

Any feedback welcome.
