### PR TITLE
[rbp] Allow OMXPlayer to try playing DVD/BD iso.

### DIFF
--- a/xbmc/cores/omxplayer/OMXPlayer.cpp
+++ b/xbmc/cores/omxplayer/OMXPlayer.cpp
@@ -590,8 +590,8 @@ retry:
   if (m_pInputStream && ( m_pInputStream->IsStreamType(DVDSTREAM_TYPE_DVD)
                        || m_pInputStream->IsStreamType(DVDSTREAM_TYPE_BLURAY) ) )
   {
-    CLog::Log(LOGINFO, "COMXPlayer::OpenInputStream - DVD/BD not supported");
-    return false;
+    CLog::Log(LOGINFO, "COMXPlayer::OpenInputStream - DVD/BD not supported - Will try...");
+    // return false;
   }
 
   // find any available external subtitles for non dvd files


### PR DESCRIPTION
Now that scaling is fixed, menus and DVD subtitle overlays behave as they should, and because license for MPG2 codec is available, allow iso playback with a warning in the debug log.
Testing suggests that a large portion of DVD iso's actually perform perfectly with and without menus, although there are problems with some gapless transitions.
