### PR TITLE
Wait for BGInfoLoader threads to stop before deleting them

### DIFF
--- a/xbmc/BackgroundInfoLoader.cpp
+++ b/xbmc/BackgroundInfoLoader.cpp
@@ -156,7 +156,7 @@ void CBackgroundInfoLoader::StopThread()
 
   for (int i=0; i<(int)m_workers.size(); i++)
   {
-    m_workers[i]->StopThread();
+    m_workers[i]->StopThread(true);
     delete m_workers[i];
   }
 


### PR DESCRIPTION
If we don't wait here, we access a freed pointer in
CJobQueue::CJobPointer::operator== on app exit while the infoloader
is still running.
