### PR TITLE
Fix Python playPlaylist Error

### DIFF
--- a/xbmc/interfaces/legacy/Player.cpp
+++ b/xbmc/interfaces/legacy/Player.cpp
@@ -104,7 +104,7 @@ namespace XBMCAddon
       CApplicationMessenger::Get().PlayListPlayerPlay(g_playlistPlayer.GetCurrentSong());
     }
 
-    void Player::playPlaylist(const PlayList* playlist, bool windowed)
+    void Player::playPlaylist(const XBMCAddon::xbmc::PlayList* playlist, bool windowed)
     {
       TRACE;
       if (playlist != NULL)

--- a/xbmc/interfaces/legacy/Player.h
+++ b/xbmc/interfaces/legacy/Player.h
@@ -105,7 +105,7 @@ namespace XBMCAddon
        * 
        * example:
        */
-      void playPlaylist(const PlayList* playlist = NULL, bool windowed = false);
+      void playPlaylist(const XBMCAddon::xbmc::PlayList* playlist = NULL, bool windowed = false);
 
       /**
        * play() -- try to play the current item in the current playlist.


### PR DESCRIPTION
"Hints" the code generator to generate the correct Type of PlayList  for static  function playPlaylist
from "p.PlayList" to "p.XBMCAddon::xbmc::PlayList"

solving the error
ERROR: EXCEPTION: Incorrect type passed to "playPlaylist", was expecting a "p.PlayList" but received a "p.XBMCAddon::xbmc::PlayList"
