### PR TITLE
SortUtils: fix random sorting always being the same after restart

### DIFF
--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -32,10 +32,11 @@
 #ifdef _LINUX
 #include <sys/types.h>
 #include <dirent.h>
-#include <stdlib.h>
 #include <unistd.h>
 #include <sys/wait.h>
 #endif
+
+#include <stdlib.h>
 
 #include "Application.h"
 #include "Util.h"
@@ -110,6 +111,10 @@ static uint16_t oldrampBlue[256];
 static uint16_t flashrampRed[256];
 static uint16_t flashrampGreen[256];
 static uint16_t flashrampBlue[256];
+#endif
+
+#if !defined(TARGET_WINDOWS)
+unsigned int CUtil::s_randomSeed = time(NULL);
 #endif
 
 CUtil::CUtil(void)
@@ -2605,5 +2610,18 @@ bool CUtil::CanBindPrivileged()
   return true;
 
 #endif //_LINUX
+}
+
+int CUtil::GetRandomNumber()
+{
+#ifdef TARGET_WINDOWS
+  unsigned int number;
+  if (rand_s(&number) == 0)
+    return (int)number;
+#else
+  return rand_r(&s_randomSeed);
+#endif
+
+  return rand();
 }
 

--- a/xbmc/Util.h
+++ b/xbmc/Util.h
@@ -189,6 +189,16 @@ public:
   static CStdString GetFrameworksPath(bool forPython = false);
 
   static bool CanBindPrivileged();
+
+  /*!
+   * \brief Thread-safe random number generation
+   */
+  static int GetRandomNumber();
+
+#if !defined(TARGET_WINDOWS)
+private:
+  static unsigned int s_randomSeed;
+#endif
 };
 
 

--- a/xbmc/utils/SortUtils.cpp
+++ b/xbmc/utils/SortUtils.cpp
@@ -20,6 +20,7 @@
 
 #include "SortUtils.h"
 #include "URL.h"
+#include "Util.h"
 #include "XBDateTime.h"
 #include "settings/AdvancedSettings.h"
 #include "utils/CharsetConverter.h"
@@ -395,7 +396,7 @@ string ByListeners(SortAttribute attributes, const SortItem &values)
 string ByRandom(SortAttribute attributes, const SortItem &values)
 {
   CStdString label;
-  label.Format("%i", rand());
+  label.Format("%i", CUtil::GetRandomNumber());
   return label;
 }
 

--- a/xbmc/win32/pch.h
+++ b/xbmc/win32/pch.h
@@ -1,4 +1,5 @@
 #pragma once
+#define _CRT_RAND_S
 #include <vector>
 #include <map>
 #include <string>


### PR DESCRIPTION
This fixes SortByRandom which relies on rand() but does not call srand() beforehand. Therefore everytime XBMC is restarted the numbers returned by srand() are the same (or rather the sequence of numbers is the same) which does not really provide proper random behaviour.

I'm not sure if this is the best approach which is why I post this PR. If it's good I'd like to merge it in ASAP as it is a fix.
