### PR TITLE
[pvr] Show resume indicator for recordings + some cleanups

### DIFF
--- a/addons/skin.confluence/720p/ViewsPVR.xml
+++ b/addons/skin.confluence/720p/ViewsPVR.xml
@@ -678,6 +678,15 @@
 						<width>20</width>
 						<height>16</height>
 						<texture>$INFO[ListItem.Overlay]</texture>
+						<visible>!ListItem.IsResumable</visible>
+					</control>
+					<control type="image">
+						<posx>730</posx>
+						<posy>14</posy>
+						<width>16</width>
+						<height>16</height>
+						<texture>OverlayWatching.png</texture>
+						<visible>ListItem.IsResumable</visible>
 					</control>
 				</itemlayout>
 				<focusedlayout height="40" width="760">
@@ -744,6 +753,15 @@
 						<width>20</width>
 						<height>16</height>
 						<texture>$INFO[ListItem.Overlay]</texture>
+						<visible>!ListItem.IsResumable</visible>
+					</control>
+					<control type="image">
+						<posx>730</posx>
+						<posy>14</posy>
+						<width>16</width>
+						<height>16</height>
+						<texture>OverlayWatching.png</texture>
+						<visible>ListItem.IsResumable</visible>
 					</control>
 				</focusedlayout>
 			</control>

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -4154,6 +4154,8 @@ bool CGUIInfoManager::GetItemInt(int &value, const CGUIListItem *item, int info)
   case LISTITEM_PERCENT_PLAYED:
     if (item->IsFileItem() && ((const CFileItem *)item)->HasVideoInfoTag() && ((const CFileItem *)item)->GetVideoInfoTag()->m_resumePoint.IsPartWay())
       value = (int)(100 * ((const CFileItem *)item)->GetVideoInfoTag()->m_resumePoint.timeInSeconds / ((const CFileItem *)item)->GetVideoInfoTag()->m_resumePoint.totalTimeInSeconds);
+    else if (item->IsFileItem() && ((const CFileItem *)item)->HasPVRRecordingInfoTag() && ((const CFileItem *)item)->GetPVRRecordingInfoTag()->m_resumePoint.IsPartWay())
+      value = (int)(100 * ((const CFileItem *)item)->GetPVRRecordingInfoTag()->m_resumePoint.timeInSeconds / ((const CFileItem *)item)->GetPVRRecordingInfoTag()->m_resumePoint.totalTimeInSeconds);
     else
       value = 0;
     return true;
@@ -4886,7 +4888,15 @@ bool CGUIInfoManager::GetItemBool(const CGUIListItem *item, int condition) const
   else if (condition == LISTITEM_IS_FOLDER)
     return item->m_bIsFolder;
   else if (condition == LISTITEM_IS_RESUMABLE)
-    return (item->IsFileItem() && ((const CFileItem *)item)->HasVideoInfoTag() && ((const CFileItem *)item)->GetVideoInfoTag()->m_resumePoint.timeInSeconds > 0);
+  {
+    if (item->IsFileItem())
+    {
+      if (((const CFileItem *)item)->HasVideoInfoTag())
+        return ((const CFileItem *)item)->GetVideoInfoTag()->m_resumePoint.timeInSeconds > 0;
+      else if (((const CFileItem *)item)->HasPVRRecordingInfoTag())
+        return ((const CFileItem *)item)->GetPVRRecordingInfoTag()->m_resumePoint.timeInSeconds > 0;
+    }
+  }
   else if (item->IsFileItem())
   {
     const CFileItem *pItem = (const CFileItem *)item;

--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -1961,11 +1961,6 @@ void CDVDPlayer::OnExit()
     }
     m_pSubtitleDemuxer = NULL;
 
-    if (m_pInputStream->IsStreamType(DVDSTREAM_TYPE_PVRMANAGER) && g_PVRManager.IsPlayingRecording())
-    {
-      g_PVRManager.UpdateCurrentLastPlayedPosition(m_State.time / 1000);
-    }
-
     // destroy the inputstream
     if (m_pInputStream)
     {

--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -887,47 +887,6 @@ bool CPVRManager::UpdateItem(CFileItem& item)
   return false;
 }
 
-
-bool CPVRManager::UpdateCurrentLastPlayedPosition(int lastplayedposition)
-{
-  // Only anything but recordings we fake success
-  if (!IsPlayingRecording())
-    return true;
-
-  bool rc = false;
-  CPVRRecording currentRecording;
-
-  if (m_addons)
-  {
-    PVR_ERROR error;
-    rc = m_addons->GetPlayingRecording(currentRecording) && m_addons->SetRecordingLastPlayedPosition(currentRecording, lastplayedposition, &error);
-  }
-  return rc;
-}
-
-bool CPVRManager::SetRecordingLastPlayedPosition(const CPVRRecording &recording, int lastplayedposition)
-{
-  bool rc = false;
-
-  if (m_addons)
-  {
-    PVR_ERROR error;
-    rc = m_addons->SetRecordingLastPlayedPosition(recording, lastplayedposition, &error);
-  }
-  return rc;
-}
-
-int CPVRManager::GetRecordingLastPlayedPosition(const CPVRRecording &recording)
-{
-  int rc = 0;
-
-  if (m_addons)
-  {
-    rc = m_addons->GetRecordingLastPlayedPosition(recording);
-  }
-  return rc;
-}
-
 bool CPVRManager::StartPlayback(const CPVRChannel *channel, bool bPreview /* = false */)
 {
   g_settings.m_bStartVideoWindowed = bPreview;

--- a/xbmc/pvr/PVRManager.h
+++ b/xbmc/pvr/PVRManager.h
@@ -447,27 +447,6 @@ namespace PVR
      */
     bool SetWakeupCommand(void);
 
-    /*!
-     * @brief Update the last played position for the current playing file
-     * @param lastplayedposition channel The channel to start to play.
-     */
-    bool UpdateCurrentLastPlayedPosition(int lastplayedposition);
-
-    /*!
-     * @brief Set the last watched position of a recording on the backend.
-     * @param recording The recording.
-     * @param position The last watched position in seconds
-     * @return True if the last played position was updated successfully, false otherwise
-    */
-    bool SetRecordingLastPlayedPosition(const CPVRRecording &recording, int lastplayedposition);
-
-    /*!
-    * @brief Retrieve the last watched position of a recording on the backend.
-    * @param recording The recording.
-    * @return The last watched position in seconds
-    */
-    int GetRecordingLastPlayedPosition(const CPVRRecording &recording);
-
   protected:
     /*!
      * @brief PVR update and control thread.

--- a/xbmc/pvr/recordings/PVRRecording.cpp
+++ b/xbmc/pvr/recordings/PVRRecording.cpp
@@ -131,6 +131,7 @@ bool CPVRRecording::Rename(const CStdString &strNewName)
 bool CPVRRecording::SetPlayCount(int count)
 {
   PVR_ERROR error;
+  m_playCount = count;
   m_iRecPlayCount = count;
   if (g_PVRClients->SupportsRecordingPlayCount(m_iClientId) &&
       !g_PVRClients->SetRecordingPlayCount(*this, count, &error))
@@ -140,6 +141,35 @@ bool CPVRRecording::SetPlayCount(int count)
   }
 
   return true;
+}
+
+bool CPVRRecording::IncrementPlayCount()
+{
+  return SetPlayCount(m_iRecPlayCount + 1);
+}
+
+bool CPVRRecording::SetLastPlayedPosition(int lastplayedposition)
+{
+  PVR_ERROR error;
+  if (g_PVRClients->SupportsRecordingPlayCount(m_iClientId) &&
+      !g_PVRClients->SetRecordingLastPlayedPosition(*this, lastplayedposition, &error))
+  {
+    DisplayError(error);
+    return false;
+  }
+  return true;
+}
+
+int CPVRRecording::GetLastPlayedPosition() const
+{
+  int rc = 0;
+  if (g_PVRClients->SupportsRecordingPlayCount(m_iClientId))
+  {
+    rc = g_PVRClients->GetRecordingLastPlayedPosition(*this);
+    if (rc < 0)
+      DisplayError(PVR_ERROR_SERVER_ERROR);
+  }
+  return rc;
 }
 
 void CPVRRecording::DisplayError(PVR_ERROR err) const

--- a/xbmc/pvr/recordings/PVRRecording.h
+++ b/xbmc/pvr/recordings/PVRRecording.h
@@ -93,6 +93,25 @@ namespace PVR
     bool SetPlayCount(int count);
 
     /*!
+     * @brief Increment this recording's play count on the client (if supported).
+     * @return True if play count was set successfully, false otherwise.
+     */
+    bool IncrementPlayCount();
+
+    /*!
+     * @brief Set the last watched position of a recording on the backend.
+     * @param position The last watched position in seconds
+     * @return True if the last played position was updated successfully, false otherwise
+     */
+    bool SetLastPlayedPosition(int lastplayedposition);
+
+    /*!
+     * @brief Retrieve the last watched position of a recording on the backend.
+     * @return The last watched position in seconds
+     */
+    int GetLastPlayedPosition() const;
+
+    /*!
      * @brief Update this tag with the contents of the given tag.
      * @param tag The new tag info.
      */

--- a/xbmc/pvr/recordings/PVRRecordings.cpp
+++ b/xbmc/pvr/recordings/PVRRecordings.cpp
@@ -122,7 +122,7 @@ void CPVRRecordings::GetContents(const CStdString &strDirectory, CFileItemList *
     pFileItem->SetOverlayImage(CGUIListItem::ICON_OVERLAY_UNWATCHED, pFileItem->GetPVRRecordingInfoTag()->m_playCount > 0);
 
     // Set the resumePoint either directly from client (if supported) or from video db
-    int positionInSeconds = g_PVRManager.GetRecordingLastPlayedPosition(*current);
+    int positionInSeconds = current->GetLastPlayedPosition();
     if (positionInSeconds > 0)
     {
       // If the back-end does report a saved position then make sure there is a corresponding resume bookmark

--- a/xbmc/pvr/recordings/PVRRecordings.cpp
+++ b/xbmc/pvr/recordings/PVRRecordings.cpp
@@ -121,6 +121,28 @@ void CPVRRecordings::GetContents(const CStdString &strDirectory, CFileItemList *
     }
     pFileItem->SetOverlayImage(CGUIListItem::ICON_OVERLAY_UNWATCHED, pFileItem->GetPVRRecordingInfoTag()->m_playCount > 0);
 
+    // Set the resumePoint either directly from client (if supported) or from video db
+    int positionInSeconds = g_PVRManager.GetRecordingLastPlayedPosition(*current);
+    if (positionInSeconds > 0)
+    {
+      // If the back-end does report a saved position then make sure there is a corresponding resume bookmark
+      CBookmark bookmark;
+      bookmark.timeInSeconds = positionInSeconds;
+      bookmark.totalTimeInSeconds = (double)current->GetDuration();
+      pFileItem->GetPVRRecordingInfoTag()->m_resumePoint = bookmark;
+    }
+    else if (positionInSeconds < 0)
+    {
+      CVideoDatabase db;
+      if (db.Open())
+      {
+        CBookmark bookmark;
+        if (db.GetResumeBookMark(current->m_strFileNameAndPath, bookmark))
+          pFileItem->GetPVRRecordingInfoTag()->m_resumePoint = bookmark;
+        db.Close();
+      }
+    }
+
     results->Add(pFileItem);
   }
 }

--- a/xbmc/pvr/recordings/PVRRecordings.cpp
+++ b/xbmc/pvr/recordings/PVRRecordings.cpp
@@ -413,7 +413,10 @@ bool CPVRRecordings::SetRecordingsPlayCount(const CFileItemPtr &item, int count)
 
       // Clear resume bookmark
       if (count > 0)
+      {
         database.ClearBookMarksOfFile(pItem->GetPath(), CBookmark::RESUME);
+        pItem->GetPVRRecordingInfoTag()->SetLastPlayedPosition(0);
+      }
 
       database.SetPlayCount(*pItem, count);
     }

--- a/xbmc/pvr/windows/GUIWindowPVRRecordings.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRRecordings.cpp
@@ -67,8 +67,7 @@ CStdString CGUIWindowPVRRecordings::GetResumeString(const CFileItem& item)
   {
 
     // First try to find the resume position on the back-end, if that fails use video database
-    CPVRRecording recording = *item.GetPVRRecordingInfoTag();
-    int positionInSeconds = g_PVRManager.GetRecordingLastPlayedPosition(recording);
+    int positionInSeconds = item.GetPVRRecordingInfoTag()->GetLastPlayedPosition();
     // If the back-end does report a saved position then make sure there is a corresponding resume bookmark
     if (positionInSeconds > 0)
     {

--- a/xbmc/pvr/windows/GUIWindowPVRRecordings.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRRecordings.cpp
@@ -74,6 +74,7 @@ CStdString CGUIWindowPVRRecordings::GetResumeString(const CFileItem& item)
     {
       CBookmark bookmark;
       bookmark.timeInSeconds = positionInSeconds;
+      bookmark.totalTimeInSeconds = (double)item.GetPVRRecordingInfoTag()->GetDuration();
       CVideoDatabase db;
       if (db.Open())
       {

--- a/xbmc/utils/SaveFileStateJob.h
+++ b/xbmc/utils/SaveFileStateJob.h
@@ -4,6 +4,8 @@
 
 #include "Job.h"
 #include "FileItem.h"
+#include "pvr/PVRManager.h"
+#include "pvr/recordings/PVRRecordings.h"
 
 class CSaveFileStateJob : public CJob
 {
@@ -57,6 +59,11 @@ bool CSaveFileStateJob::DoWork()
             // consider this item as played
             videodatabase.IncrementPlayCount(m_item);
             m_item.GetVideoInfoTag()->m_playCount++;
+
+            // PVR: Set recording's play count on the backend (if supported)
+            if (m_item.HasPVRRecordingInfoTag())
+              m_item.GetPVRRecordingInfoTag()->IncrementPlayCount();
+
             m_item.SetOverlayImage(CGUIListItem::ICON_OVERLAY_UNWATCHED, true);
             updateListing = true;
           }
@@ -71,6 +78,15 @@ bool CSaveFileStateJob::DoWork()
               videodatabase.AddBookMarkToFile(progressTrackingFile, m_bookmark, CBookmark::RESUME);
             if (m_item.HasVideoInfoTag())
               m_item.GetVideoInfoTag()->m_resumePoint = m_bookmark;
+
+            // PVR: Set/clear recording's resume bookmark on the backend (if supported)
+            if (m_item.HasPVRRecordingInfoTag())
+            {
+              PVR::CPVRRecording *recording = m_item.GetPVRRecordingInfoTag();
+              recording->SetLastPlayedPosition(m_bookmark.timeInSeconds <= 0.0f ? 0 : (int)m_bookmark.timeInSeconds);
+              recording->m_resumePoint = m_bookmark;
+            }
+
             updateListing = true;
           }
         }

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -51,8 +51,6 @@
 #include "dbwrappers/dataset.h"
 #include "utils/LabelFormatter.h"
 #include "XBDateTime.h"
-#include "pvr/PVRManager.h"
-#include "pvr/recordings/PVRRecordings.h"
 #include "URL.h"
 #include "video/VideoDbUrl.h"
 #include "playlists/SmartPlayList.h"
@@ -62,7 +60,6 @@ using namespace dbiplus;
 using namespace XFILE;
 using namespace VIDEO;
 using namespace ADDON;
-using namespace PVR;
 
 //********************************************************************************************************************************
 CVideoDatabase::CVideoDatabase(void)
@@ -4327,10 +4324,6 @@ void CVideoDatabase::SetPlayCount(const CFileItem &item, int count, const CDateT
     }
 
     m_pDS->exec(strSQL.c_str());
-
-    // PVR: Set recording's play count on the backend (if supported)
-    if (item.HasPVRRecordingInfoTag() && g_PVRManager.IsStarted())
-      g_PVRRecordings->SetPlayCount(item, count);
 
     // We only need to announce changes to video items in the library
     if (item.HasVideoInfoTag() && item.GetVideoInfoTag()->m_iDbId > 0)


### PR DESCRIPTION
This PR contains some smaller changes closely related to the 'set play count' / 'set play position' on the addon features.

First, it adds the resume indicator (arrow) to the recordings view so that you see the partly watched recordings at a glance. Also when a recoding is marked as watched via the context menu, we now clear the resume bookmark on the backend (SetLastPlayedPosition).

In addition, the PR adds some cleanups. Whereas 'set play count' / 'set play position' are quite similar, they're currently called from completely different locations:
When the player stops, the play count is set in the video database and the play position is set in dvdplayer.
I moved both now to SaveFileStateJob.

@Red-F You are mentioning that you had this in dvdplayer on purpose: https://github.com/opdenkamp/xbmc/pull/536
If I get the whole player concept right, it should go to SaveFileStateJob to have it also working on rpi and other platforms. Or is dvdplayer used everywhere? Maybe you could explain your point and we can get it fixed.

@opdenkamp I'd also like to unify the method calls a bit. Is it ok to move Set/GetRecordingLastPlayedPosition from PVRManager to PVRRecording (where SetPlayCount is)? Or better move SetPlayCount into the manager? I'd then add an additional commit.

Cheers,
Christian
