### PR TITLE
StringUtils extensions

### DIFF
--- a/xbmc/utils/StringUtils.cpp
+++ b/xbmc/utils/StringUtils.cpp
@@ -83,6 +83,123 @@ string StringUtils::FormatV(const string &fmt, va_list args)
   return str;
 }
 
+void StringUtils::ToUpper(string &str)
+{
+  transform(str.begin(), str.end(), str.begin(), ::toupper);
+}
+
+void StringUtils::ToLower(string &str)
+{
+  transform(str.begin(), str.end(), str.begin(), ::tolower);
+}
+
+bool StringUtils::EqualsNoCase(const std::string &str1, const std::string &str2)
+{
+  string tmp1 = str1;
+  string tmp2 = str2;
+  ToLower(tmp1);
+  ToLower(tmp2);
+  
+  return tmp1.compare(tmp2) == 0;
+}
+
+string StringUtils::Left(const string &str, size_t count)
+{
+  count = max((size_t)0, min(count, str.size()));
+  return str.substr(0, count);
+}
+
+string StringUtils::Mid(const string &str, size_t first, size_t count /* = string::npos */)
+{
+  if (first < 0)
+    first = 0;
+  
+  if (first + count > str.size())
+    count = str.size() - first;
+  
+  if (first > str.size())
+    return string();
+  
+  ASSERT(first >= 0);
+  ASSERT(first + count <= str.size());
+  
+  return str.substr(first, count);
+}
+
+string StringUtils::Right(const string &str, size_t count)
+{
+  count = max((size_t)0, min(count, str.size()));
+  return str.substr(str.size() - count);
+}
+
+std::string& StringUtils::Trim(std::string &str)
+{
+  TrimLeft(str);
+  return TrimRight(str);
+}
+
+std::string& StringUtils::TrimLeft(std::string &str)
+{
+  str.erase(str.begin(), ::find_if(str.begin(), str.end(), ::not1(::ptr_fun<int, int>(::isspace))));
+  return str;
+}
+
+std::string& StringUtils::TrimRight(std::string &str)
+{
+  str.erase(::find_if(str.rbegin(), str.rend(), ::not1(::ptr_fun<int, int>(::isspace))).base(), str.end());
+  return str;
+}
+
+int StringUtils::Replace(string &str, char oldChar, char newChar)
+{
+  int replacedChars = 0;
+  for (string::iterator it = str.begin(); it != str.end(); it++)
+  {
+    if (*it == oldChar)
+    {
+      *it = newChar;
+      replacedChars++;
+    }
+  }
+  
+  return replacedChars;
+}
+
+int StringUtils::Replace(std::string &str, const std::string &oldStr, const std::string &newStr)
+{
+  int replacedChars = 0;
+  size_t index = 0;
+  
+  while (index < str.size() && (index = str.find(oldStr, index)) != string::npos)
+  {
+    str.replace(index, oldStr.size(), newStr);
+    index += newStr.size();
+    replacedChars++;
+  }
+  
+  return replacedChars;
+}
+
+bool StringUtils::StartsWith(const std::string &str, const std::string &str2, bool useCase /* = false */)
+{
+  std::string left = StringUtils::Left(str, str2.size());
+  
+  if (useCase)
+    return left.compare(str2) == 0;
+
+  return StringUtils::EqualsNoCase(left, str2);
+}
+
+bool StringUtils::EndsWith(const std::string &str, const std::string &str2, bool useCase /* = false */)
+{
+  std::string right = StringUtils::Right(str, str2.size());
+  
+  if (useCase)
+    return right.compare(str2) == 0;
+
+  return StringUtils::EqualsNoCase(right, str2);
+}
+
 void StringUtils::JoinString(const CStdStringArray &strings, const CStdString& delimiter, CStdString& result)
 {
   result = "";

--- a/xbmc/utils/StringUtils.h
+++ b/xbmc/utils/StringUtils.h
@@ -29,16 +29,31 @@
 //
 //------------------------------------------------------------------------
 
-#include "XBDateTime.h"
-#include "utils/StdString.h"
 #include <vector>
 #include <stdint.h>
+#include <string>
+
+#include "XBDateTime.h"
+#include "utils/StdString.h"
 
 class StringUtils
 {
 public:
   static std::string Format(const std::string &fmt, ...);
   static std::string FormatV(const std::string &fmt, va_list args);
+  static void ToUpper(std::string &str);
+  static void ToLower(std::string &str);
+  static bool EqualsNoCase(const std::string &str1, const std::string &str2);
+  static std::string Left(const std::string &str, size_t count);
+  static std::string Mid(const std::string &str, size_t first, size_t count = std::string::npos);
+  static std::string Right(const std::string &str, size_t count);
+  static std::string& Trim(std::string &str);
+  static std::string& TrimLeft(std::string &str);
+  static std::string& TrimRight(std::string &str);
+  static int Replace(std::string &str, char oldChar, char newChar);
+  static int Replace(std::string &str, const std::string &oldStr, const std::string &newStr);
+  static bool StartsWith(const std::string &str, const std::string &str2, bool useCase = false);
+  static bool EndsWith(const std::string &str, const std::string &str2, bool useCase = false);
 
   static void JoinString(const CStdStringArray &strings, const CStdString& delimiter, CStdString& result);
   static CStdString JoinString(const CStdStringArray &strings, const CStdString& delimiter);

--- a/xbmc/utils/StringUtils.h
+++ b/xbmc/utils/StringUtils.h
@@ -1,3 +1,4 @@
+#pragma once
 /*
  *      Copyright (C) 2005-2012 Team XBMC
  *      http://www.xbmc.org
@@ -28,9 +29,6 @@
 //
 //------------------------------------------------------------------------
 
-#ifndef __STRINGUTILS_H_
-#define __STRINGUTILS_H_
-
 #include "XBDateTime.h"
 #include "utils/StdString.h"
 #include <vector>
@@ -39,6 +37,9 @@
 class StringUtils
 {
 public:
+  static std::string Format(const std::string &fmt, ...);
+  static std::string FormatV(const std::string &fmt, va_list args);
+
   static void JoinString(const CStdStringArray &strings, const CStdString& delimiter, CStdString& result);
   static CStdString JoinString(const CStdStringArray &strings, const CStdString& delimiter);
   static CStdString Join(const std::vector<std::string> &strings, const CStdString& delimiter);
@@ -92,5 +93,3 @@ public:
 private:
   static CStdString m_lastUUID;
 };
-
-#endif

--- a/xbmc/utils/test/TestStringUtils.cpp
+++ b/xbmc/utils/test/TestStringUtils.cpp
@@ -22,6 +22,180 @@
 
 #include "gtest/gtest.h"
 
+TEST(TestStringUtils, Format)
+{
+  std::string refstr = "test 25 2.7 ff FF";
+
+  std::string varstr = StringUtils::Format("%s %d %.1f %x %02X", "test", 25, 2.743f, 0x00ff, 0x00ff);
+  EXPECT_STREQ(refstr.c_str(), varstr.c_str());
+}
+
+TEST(TestStringUtils, ToUpper)
+{
+  std::string refstr = "TEST";
+
+  std::string varstr = "TeSt";
+  StringUtils::ToUpper(varstr);
+  EXPECT_STREQ(refstr.c_str(), varstr.c_str());
+}
+
+TEST(TestStringUtils, ToLower)
+{
+  std::string refstr = "test";
+  
+  std::string varstr = "TeSt";
+  StringUtils::ToLower(varstr);
+  EXPECT_STREQ(refstr.c_str(), varstr.c_str());
+}
+
+TEST(TestStringUtils, EqualsNoCase)
+{
+  std::string refstr = "TeSt";
+  
+  EXPECT_TRUE(StringUtils::EqualsNoCase(refstr, "TeSt"));
+  EXPECT_TRUE(StringUtils::EqualsNoCase(refstr, "tEsT"));
+}
+
+TEST(TestStringUtils, Left)
+{
+  std::string refstr, varstr;
+  std::string origstr = "test";
+  
+  refstr = "";
+  varstr = StringUtils::Left(origstr, 0);
+  EXPECT_STREQ(refstr.c_str(), varstr.c_str());
+  
+  refstr = "te";
+  varstr = StringUtils::Left(origstr, 2);
+  EXPECT_STREQ(refstr.c_str(), varstr.c_str());
+  
+  refstr = "test";
+  varstr = StringUtils::Left(origstr, 10);
+  EXPECT_STREQ(refstr.c_str(), varstr.c_str());
+}
+
+TEST(TestStringUtils, Mid)
+{
+  std::string refstr, varstr;
+  std::string origstr = "test";
+  
+  refstr = "";
+  varstr = StringUtils::Mid(origstr, 0, 0);
+  EXPECT_STREQ(refstr.c_str(), varstr.c_str());
+  
+  refstr = "te";
+  varstr = StringUtils::Mid(origstr, 0, 2);
+  EXPECT_STREQ(refstr.c_str(), varstr.c_str());
+  
+  refstr = "test";
+  varstr = StringUtils::Mid(origstr, 0, 10);
+  EXPECT_STREQ(refstr.c_str(), varstr.c_str());
+  
+  refstr = "st";
+  varstr = StringUtils::Mid(origstr, 2);
+  EXPECT_STREQ(refstr.c_str(), varstr.c_str());
+  
+  refstr = "st";
+  varstr = StringUtils::Mid(origstr, 2, 2);
+  EXPECT_STREQ(refstr.c_str(), varstr.c_str());
+  
+  refstr = "es";
+  varstr = StringUtils::Mid(origstr, 1, 2);
+  EXPECT_STREQ(refstr.c_str(), varstr.c_str());
+}
+
+TEST(TestStringUtils, Right)
+{
+  std::string refstr, varstr;
+  std::string origstr = "test";
+  
+  refstr = "";
+  varstr = StringUtils::Right(origstr, 0);
+  EXPECT_STREQ(refstr.c_str(), varstr.c_str());
+  
+  refstr = "st";
+  varstr = StringUtils::Right(origstr, 2);
+  EXPECT_STREQ(refstr.c_str(), varstr.c_str());
+  
+  refstr = "test";
+  varstr = StringUtils::Right(origstr, 10);
+  EXPECT_STREQ(refstr.c_str(), varstr.c_str());
+}
+
+TEST(TestStringUtils, Trim)
+{
+  std::string refstr = "test test";
+  
+  std::string varstr = " test test   ";
+  StringUtils::Trim(varstr);
+  EXPECT_STREQ(refstr.c_str(), varstr.c_str());
+}
+
+TEST(TestStringUtils, TrimLeft)
+{
+  std::string refstr = "test test   ";
+  
+  std::string varstr = " test test   ";
+  StringUtils::TrimLeft(varstr);
+  EXPECT_STREQ(refstr.c_str(), varstr.c_str());
+}
+
+TEST(TestStringUtils, TrimRight)
+{
+  std::string refstr = " test test";
+  
+  std::string varstr = " test test   ";
+  StringUtils::TrimRight(varstr);
+  EXPECT_STREQ(refstr.c_str(), varstr.c_str());
+}
+
+TEST(TestStringUtils, Replace)
+{
+  std::string refstr = "text text";
+  
+  std::string varstr = "test test";
+  EXPECT_EQ(StringUtils::Replace(varstr, 's', 'x'), 2);
+  EXPECT_STREQ(refstr.c_str(), varstr.c_str());
+  
+  EXPECT_EQ(StringUtils::Replace(varstr, 's', 'x'), 0);
+  EXPECT_STREQ(refstr.c_str(), varstr.c_str());
+  
+  varstr = "test test";
+  EXPECT_EQ(StringUtils::Replace(varstr, "s", "x"), 2);
+  EXPECT_STREQ(refstr.c_str(), varstr.c_str());
+  
+  EXPECT_EQ(StringUtils::Replace(varstr, "s", "x"), 0);
+  EXPECT_STREQ(refstr.c_str(), varstr.c_str());
+}
+
+TEST(TestStringUtils, StartsWith)
+{
+  std::string refstr = "test";
+  
+  EXPECT_FALSE(StringUtils::StartsWith(refstr, "x"));
+  
+  EXPECT_TRUE(StringUtils::StartsWith(refstr, "te", true));
+  EXPECT_TRUE(StringUtils::StartsWith(refstr, "test", true));
+  EXPECT_FALSE(StringUtils::StartsWith(refstr, "Te", true));
+  
+  EXPECT_TRUE(StringUtils::StartsWith(refstr, "Te", false));
+  EXPECT_TRUE(StringUtils::StartsWith(refstr, "TesT", false));
+}
+
+TEST(TestStringUtils, EndsWith)
+{
+  std::string refstr = "test";
+  
+  EXPECT_FALSE(StringUtils::EndsWith(refstr, "x"));
+  
+  EXPECT_TRUE(StringUtils::EndsWith(refstr, "st", true));
+  EXPECT_TRUE(StringUtils::EndsWith(refstr, "test", true));
+  EXPECT_FALSE(StringUtils::EndsWith(refstr, "sT", true));
+  
+  EXPECT_TRUE(StringUtils::EndsWith(refstr, "sT", false));
+  EXPECT_TRUE(StringUtils::EndsWith(refstr, "TesT", false));
+}
+
 TEST(TestStringUtils, JoinString)
 {
   CStdString refstr, varstr;


### PR DESCRIPTION
These two commits add some utility methods to the StringUtils class which are currently only available through CStdString and is often (at least for me) the only reason to use CStdString instead of std::string. I've heard multiple voices in the team complaining about this so I've put together some implementations like StringUtils::Format / AppendFormat / Left / Mid / Right / ToUpper / ToLower / ...
