### PR TITLE
[pvr] Use correct title for recordings (if available)

### DIFF
--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -3539,6 +3539,8 @@ CStdString CGUIInfoManager::GetVideoLabel(int item)
               StringUtils::EmptyString :
               g_localizeStrings.Get(19055); // no information available
     }
+    if (m_currentFile->HasPVRRecordingInfoTag() && !m_currentFile->GetPVRRecordingInfoTag()->m_strTitle.IsEmpty())
+      return m_currentFile->GetPVRRecordingInfoTag()->m_strTitle;
     if (m_currentFile->HasVideoInfoTag() && !m_currentFile->GetVideoInfoTag()->m_strTitle.IsEmpty())
       return m_currentFile->GetVideoInfoTag()->m_strTitle;
     // don't have the title, so use dvdplayer, label, or drop down to title from path


### PR DESCRIPTION
This fixes a small issue when playing recordings.
Currently the title for the ui is taken from teletext (dvdplayer) which is not always incorrect.
The PR changes GetVideoLabel to return the title from PVRRecordingInfoTag for recordings.
