### PR TITLE
jsonrpc: only initialize the (Video|Music)ThumbLoader once when retrieving artwork for a list of items

### DIFF
--- a/xbmc/ThumbLoader.h
+++ b/xbmc/ThumbLoader.h
@@ -70,6 +70,14 @@ public:
   CThumbLoader(int nThreads=-1);
   virtual ~CThumbLoader();
 
+  virtual void Initialize() { };
+
+  /*! \brief helper function to fill the art for a library item
+   \param item a CFileItem
+   \return true if we fill art, false otherwise
+   */
+  virtual bool FillLibraryArt(CFileItem &item) { return false; }
+
   /*! \brief Checks whether the given item has an image listed in the texture database
    \param item CFileItem to check
    \param type the type of image to retrieve
@@ -90,6 +98,8 @@ class CVideoThumbLoader : public CThumbLoader, public CJobQueue
 public:
   CVideoThumbLoader();
   virtual ~CVideoThumbLoader();
+
+  virtual void Initialize();
   virtual bool LoadItem(CFileItem* pItem);
   void SetStreamDetailsObserver(IStreamDetailsObserver *pObs) { m_pStreamDetailsObs = pObs; }
 
@@ -111,7 +121,7 @@ public:
    \param item a video CFileItem
    \return true if we fill art, false otherwise
    */
-  bool FillLibraryArt(CFileItem *item);
+ virtual bool FillLibraryArt(CFileItem &item);
 
   /*!
    \brief Callback from CThumbExtractor on completion of a generated image
@@ -123,8 +133,8 @@ public:
   virtual void OnJobComplete(unsigned int jobID, bool success, CJob *job);
 
 protected:
-  virtual void OnLoaderStart() ;
-  virtual void OnLoaderFinish() ;
+  virtual void OnLoaderStart();
+  virtual void OnLoaderFinish();
 
   IStreamDetailsObserver *m_pStreamDetailsObs;
   CVideoDatabase *m_database;
@@ -165,13 +175,15 @@ class CMusicThumbLoader : public CThumbLoader
 public:
   CMusicThumbLoader();
   virtual ~CMusicThumbLoader();
+
+  virtual void Initialize();
   virtual bool LoadItem(CFileItem* pItem);
 
   /*! \brief helper function to fill the art for a video library item
    \param item a video CFileItem
    \return true if we fill art, false otherwise
    */
-  bool FillLibraryArt(CFileItem &item);
+  virtual bool FillLibraryArt(CFileItem &item);
 
   /*! \brief Fill the thumb of a music file/folder item
    First uses a cached thumb from a previous run, then checks for a local thumb

--- a/xbmc/interfaces/json-rpc/FileItemHandler.cpp
+++ b/xbmc/interfaces/json-rpc/FileItemHandler.cpp
@@ -41,7 +41,7 @@ using namespace MUSIC_INFO;
 using namespace JSONRPC;
 using namespace XFILE;
 
-void CFileItemHandler::FillDetails(ISerializable* info, CFileItemPtr item, const CVariant& fields, CVariant &result)
+void CFileItemHandler::FillDetails(ISerializable* info, CFileItemPtr item, const CVariant& fields, CVariant &result, CThumbLoader *thumbLoader /* = NULL */)
 {
   if (info == NULL || fields.size() == 0)
     return;
@@ -91,61 +91,34 @@ void CFileItemHandler::FillDetails(ISerializable* info, CFileItemPtr item, const
 
       if (field == "thumbnail")
       {
-        if (item->HasVideoInfoTag())
+        if (thumbLoader != NULL && !item->HasThumbnail() && !fetchedArt &&
+           ((item->HasVideoInfoTag() && item->GetVideoInfoTag()->m_iDbId > -1) || (item->HasMusicInfoTag() && item->GetMusicInfoTag()->GetDatabaseId() > -1)))
         {
-          if (!item->HasThumbnail() && !fetchedArt && item->GetVideoInfoTag()->m_iDbId > -1)
-          {
-            CVideoThumbLoader loader;
-            loader.FillLibraryArt(item.get());
-            fetchedArt = true;
-          }
+          thumbLoader->FillLibraryArt(*item);
+          fetchedArt = true;
         }
-        else if (item->HasPictureInfoTag())
-        {
-          if (!item->HasThumbnail())
-            item->SetThumbnailImage(CTextureCache::GetWrappedThumbURL(item->GetPath()));
-        }
-        else if (item->HasMusicInfoTag())
-        {
-          if (!item->HasThumbnail() && !fetchedArt && item->GetMusicInfoTag()->GetDatabaseId() > -1)
-          {
-            CMusicThumbLoader loader;
-            loader.FillLibraryArt(*item);
-            fetchedArt = true;
-          }
-        }
+        else if (item->HasPictureInfoTag() && !item->HasThumbnail())
+          item->SetThumbnailImage(CTextureCache::GetWrappedThumbURL(item->GetPath()));
+
         if (item->HasThumbnail())
           result["thumbnail"] = CTextureCache::GetWrappedImageURL(item->GetThumbnailImage());
-        if (!result.isMember("thumbnail"))
+        else
           result["thumbnail"] = "";
         continue;
       }
 
       if (field == "fanart")
       {
-        if (item->HasVideoInfoTag())
+        if (thumbLoader != NULL && !item->HasProperty("fanart_image") && !fetchedArt &&
+           ((item->HasVideoInfoTag() && item->GetVideoInfoTag()->m_iDbId > -1) || (item->HasMusicInfoTag() && item->GetMusicInfoTag()->GetDatabaseId() > -1)))
         {
-          if (!item->HasProperty("fanart_image") && !fetchedArt && item->GetVideoInfoTag()->m_iDbId > -1)
-          {
-            CVideoThumbLoader loader;
-            loader.FillLibraryArt(item.get());
-            fetchedArt = true;
-          }
-          if (item->HasProperty("fanart_image"))
-            result["fanart"] = CTextureCache::GetWrappedImageURL(item->GetProperty("fanart_image").asString());
+          thumbLoader->FillLibraryArt(*item);
+          fetchedArt = true;
         }
-        else if (item->HasMusicInfoTag())
-        {
-          if (!item->HasProperty("fanart_image") && !fetchedArt && item->GetMusicInfoTag()->GetDatabaseId() > -1)
-          {
-            CMusicThumbLoader loader;
-            loader.FillLibraryArt(*item);
-            fetchedArt = true;
-          }
-          if (item->HasProperty("fanart_image"))
-            result["fanart"] = CTextureCache::GetWrappedImageURL(item->GetProperty("fanart_image").asString());
-        }
-        if (!result.isMember("fanart"))
+
+        if (item->HasProperty("fanart_image"))
+          result["fanart"] = CTextureCache::GetWrappedImageURL(item->GetProperty("fanart_image").asString());
+        else
           result["fanart"] = "";
         continue;
       }
@@ -201,15 +174,29 @@ void CFileItemHandler::HandleFileItemList(const char *ID, bool allowFile, const 
     end = items.Size();
   }
 
+  CThumbLoader *thumbLoader = NULL;
+  if (end - start > 0)
+  {
+    if (items.Get(start)->HasVideoInfoTag())
+      thumbLoader = new CVideoThumbLoader();
+    else if (items.Get(start)->HasMusicInfoTag())
+      thumbLoader = new CMusicThumbLoader();
+
+    if (thumbLoader != NULL)
+      thumbLoader->Initialize();
+  }
+
   for (int i = start; i < end; i++)
   {
     CVariant object;
     CFileItemPtr item = items.Get(i);
-    HandleFileItem(ID, allowFile, resultname, item, parameterObject, parameterObject["properties"], result);
+    HandleFileItem(ID, allowFile, resultname, item, parameterObject, parameterObject["properties"], result, true, thumbLoader);
   }
+
+  delete thumbLoader;
 }
 
-void CFileItemHandler::HandleFileItem(const char *ID, bool allowFile, const char *resultname, CFileItemPtr item, const CVariant &parameterObject, const CVariant &validFields, CVariant &result, bool append /* = true */)
+void CFileItemHandler::HandleFileItem(const char *ID, bool allowFile, const char *resultname, CFileItemPtr item, const CVariant &parameterObject, const CVariant &validFields, CVariant &result, bool append /* = true */, CThumbLoader *thumbLoader /* = NULL */)
 {
   CVariant object;
   bool hasFileField = false;
@@ -283,14 +270,28 @@ void CFileItemHandler::HandleFileItem(const char *ID, bool allowFile, const char
       }
     }
 
-    FillDetails(item.get(), item, validFields, object);
+    FillDetails(item.get(), item, validFields, object, thumbLoader);
 
     if (item->HasVideoInfoTag())
-      FillDetails(item->GetVideoInfoTag(), item, validFields, object);
+    {
+      if (thumbLoader == NULL)
+      {
+        thumbLoader = new CVideoThumbLoader();
+        thumbLoader->Initialize();
+      }
+      FillDetails(item->GetVideoInfoTag(), item, validFields, object, thumbLoader);
+    }
     if (item->HasMusicInfoTag())
-      FillDetails(item->GetMusicInfoTag(), item, validFields, object);
+    {
+      if (thumbLoader == NULL)
+      {
+        thumbLoader = new CMusicThumbLoader();
+        thumbLoader->Initialize();
+      }
+      FillDetails(item->GetMusicInfoTag(), item, validFields, object, thumbLoader);
+    }
     if (item->HasPictureInfoTag())
-      FillDetails(item->GetPictureInfoTag(), item, validFields, object);
+      FillDetails(item->GetPictureInfoTag(), item, validFields, object, thumbLoader);
 
     object["label"] = item->GetLabel().c_str();
   }

--- a/xbmc/interfaces/json-rpc/FileItemHandler.h
+++ b/xbmc/interfaces/json-rpc/FileItemHandler.h
@@ -22,6 +22,7 @@
 #include "JSONRPC.h"
 #include "JSONUtils.h"
 #include "FileItem.h"
+#include "ThumbLoader.h"
 #include "utils/StdString.h"
 
 namespace JSONRPC
@@ -29,10 +30,10 @@ namespace JSONRPC
   class CFileItemHandler : public CJSONUtils
   {
   protected:
-    static void FillDetails(ISerializable* info, CFileItemPtr item, const CVariant& fields, CVariant &result);
+    static void FillDetails(ISerializable* info, CFileItemPtr item, const CVariant& fields, CVariant &result, CThumbLoader *thumbLoader = NULL);
     static void HandleFileItemList(const char *ID, bool allowFile, const char *resultname, CFileItemList &items, const CVariant &parameterObject, CVariant &result, bool sortLimit = true);
     static void HandleFileItemList(const char *ID, bool allowFile, const char *resultname, CFileItemList &items, const CVariant &parameterObject, CVariant &result, int size, bool sortLimit = true);
-    static void HandleFileItem(const char *ID, bool allowFile, const char *resultname, CFileItemPtr item, const CVariant &parameterObject, const CVariant &validFields, CVariant &result, bool append = true);
+    static void HandleFileItem(const char *ID, bool allowFile, const char *resultname, CFileItemPtr item, const CVariant &parameterObject, const CVariant &validFields, CVariant &result, bool append = true, CThumbLoader *thumbLoader = NULL);
 
     static bool FillFileItemList(const CVariant &parameterObject, CFileItemList &list);
 


### PR DESCRIPTION
These changes are a way to reduce the time it takes to retrieve big lists of items with their artwork (thumbnail and/or fanart). Currently we get a new instance of C(Video|Music)ThumbLoader for every item and open/close the connection to the database for every single item. On my system this results in a response time of a JSON-RPC request to AudioLibrary.GetSongs of ~14 seconds for 1500 songs. If I don't retrieve any artwork the response time is around 1s.

With these changes we only get a single instance of C(Video|Music)ThumbLoader and only open the connection to the database once for all the items which brings the response time of the request to AudioLibrary.GetSongs down to ~3.5 seconds. This is still quite a bit slower than the 1 second it takes when not retrieving artwork but it is a lot faster than the current 14 seconds.

This problem has been reported a lot in the JSON-RPC discussion thread and is present since the new implementation of the texture cache because it requires at least one additional SQL query for every item and artwork. Before the new texture cache we had 1 SQL query and now we have 1 + #items \* #artwork so for 1500 songs with thumbnail and fanart that's 1 + 1500 \* 2 = 3001 queries.
