### PR TITLE
[PVR] Changes to make PVR Groupmanager able to deal with groups again

### DIFF
--- a/xbmc/pvr/channels/PVRChannelGroups.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroups.cpp
@@ -304,6 +304,7 @@ int CPVRChannelGroups::GetGroupList(CFileItemList* results) const
     strPath.Format("channels/%s/%i", m_bRadio ? "radio" : "tv", (*it)->GroupID());
     CFileItemPtr group(new CFileItem(strPath, true));
     group->m_strTitle = (*it)->GroupName();
+    group->SetLabel((*it)->GroupName());
     results->Add(group);
     ++iReturn;
   }

--- a/xbmc/pvr/dialogs/GUIDialogPVRGroupManager.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRGroupManager.cpp
@@ -184,7 +184,7 @@ bool CGUIDialogPVRGroupManager::ActionButtonUngroupedChannels(CGUIMessage &messa
 
     if (iAction == ACTION_SELECT_ITEM || iAction == ACTION_MOUSE_LEFT_CLICK)
     {
-      if (m_channelGroups->GetFileCount() == 0)
+      if (m_channelGroups->GetFolderCount() == 0)
       {
         CGUIDialogOK::ShowAndGetInput(19033,19137,0,19138);
       }


### PR DESCRIPTION
I've opened ticket #13347 and also provided a fix for it.

This is the description that goes with the ticket:

I'm using the PVR Group manager and noticed the following issues:

Channel groups don't show names - Channels can't be moved to new groups
I've found the cause of this bug to be in the way the CFileItem is being used.

To display channel group names, GetGroupList in PVRChannelGroups should be changed to explicitly set the label to the groupname.

To be able to add ungrouped channels to a new group, the ActionButtonUngroupedChannels method should be changed. Instead of GetFileCount, GetFolderCount should be used.
