### PR TITLE
Pvrparse

### DIFF
--- a/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemux.h
+++ b/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemux.h
@@ -91,6 +91,7 @@ public:
     codec = (CodecID)0; // CODEC_ID_NONE
     codec_fourcc = 0;
     profile = FF_PROFILE_UNKNOWN;
+    level = 0;
     type = STREAM_NONE;
     source = STREAM_SOURCE_NONE;
     iDuration = 0;
@@ -119,7 +120,8 @@ public:
   int iPhysicalId; // id
   CodecID codec;
   unsigned int codec_fourcc; // if available
-  int profile;
+  int profile; // encoder profile of the stream reported by the decoder. used to qualify hw decoders.
+  int level;   // encoder level of the stream reported by the decoder. used to qualify hw decoders.
   StreamType type;
   int source;
 
@@ -156,8 +158,6 @@ public:
     iWidth = 0;
     fAspect = 0.0;
     bVFR = false;
-    iLevel = 0;
-    iProfile = 0;
     bPTSInvalid = false;
     bForcedAspect = false;
     type = STREAM_VIDEO;
@@ -172,8 +172,6 @@ public:
   int iWidth; // width of the stream reported by the demuxer
   float fAspect; // display aspect of stream
   bool bVFR;  // variable framerate
-  int iLevel; // encoder level of the stream reported by the decoder. used to qualify hw decoders.
-  int iProfile; // encoder profile of the stream reported by the decoder. used to qualify hw decoders.
   bool bPTSInvalid; // pts cannot be trusted (avi's).
   bool bForcedAspect; // aspect is forced from container
   int iOrientation; // orientation of the video in degress counter clockwise

--- a/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/dvdplayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -1007,8 +1007,6 @@ void CDVDDemuxFFmpeg::AddStream(int iId)
         st->iWidth = pStream->codec->width;
         st->iHeight = pStream->codec->height;
         st->fAspect = SelectAspect(pStream, &st->bForcedAspect) * pStream->codec->width / pStream->codec->height;
-        st->iLevel = pStream->codec->level;
-        st->iProfile = pStream->codec->profile;
         st->iOrientation = 0;
         st->iBitsPerPixel = pStream->codec->bits_per_coded_sample;
 
@@ -1111,6 +1109,8 @@ void CDVDDemuxFFmpeg::AddStream(int iId)
     m_streams[iId]->codec = pStream->codec->codec_id;
     m_streams[iId]->codec_fourcc = pStream->codec->codec_tag;
     m_streams[iId]->profile = pStream->codec->profile;
+    m_streams[iId]->level   = pStream->codec->level;
+
     m_streams[iId]->iId = iId;
     m_streams[iId]->source = STREAM_SOURCE_DEMUX;
     m_streams[iId]->pPrivate = pStream;

--- a/xbmc/cores/dvdplayer/DVDStreamInfo.cpp
+++ b/xbmc/cores/dvdplayer/DVDStreamInfo.cpp
@@ -174,6 +174,8 @@ void CDVDStreamInfo::Assign(const CDemuxStream& right, bool withextradata)
   codec = right.codec;
   type = right.type;
   codec_tag = right.codec_fourcc;
+  profile   = right.profile;
+  level     = right.level;
 
   if( withextradata && right.ExtraSize )
   {
@@ -200,8 +202,6 @@ void CDVDStreamInfo::Assign(const CDemuxStream& right, bool withextradata)
     width     = stream->iWidth;
     aspect    = stream->fAspect;
     vfr       = stream->bVFR;
-    level     = stream->iLevel;
-    profile   = stream->iProfile;
     ptsinvalid = stream->bPTSInvalid;
     forced_aspect = stream->bForcedAspect;
     orientation = stream->iOrientation;


### PR DESCRIPTION
This will continuously parse input streams from PVR manager for changes in codec parameters. This 
should reduce the burden on addons to provide data we need to init codecs.

This suffers same behaviour as the extradata parsing. On startup we will attempt to open a stream, without full knowledge of it's internals. This mean we will potentially re-open it again after first packet.
