### PR TITLE
JSON-RPC: add GUI.ActivateWindow

### DIFF
--- a/xbmc/input/ButtonTranslator.cpp
+++ b/xbmc/input/ButtonTranslator.cpp
@@ -872,6 +872,15 @@ void CButtonTranslator::GetActions(std::vector<std::string> &actionList)
     actionList.push_back(actions[index].name);
 }
 
+void CButtonTranslator::GetWindows(std::vector<std::string> &windowList)
+{
+  unsigned int size = sizeof(windows) / sizeof(ActionMapping);
+  windowList.clear();
+  windowList.reserve(size);
+  for (unsigned int index = 0; index < size; index++)
+    windowList.push_back(windows[index].name);
+}
+
 CAction CButtonTranslator::GetAction(int window, const CKey &key, bool fallback)
 {
   CStdString strAction;

--- a/xbmc/input/ButtonTranslator.h
+++ b/xbmc/input/ButtonTranslator.h
@@ -70,6 +70,7 @@ public:
   void Clear();
 
   static void GetActions(std::vector<std::string> &actionList);
+  static void GetWindows(std::vector<std::string> &windowList);
 
   CAction GetAction(int window, const CKey &key, bool fallback = true);
 

--- a/xbmc/interfaces/json-rpc/GUIOperations.cpp
+++ b/xbmc/interfaces/json-rpc/GUIOperations.cpp
@@ -23,6 +23,7 @@
 #include "ApplicationMessenger.h"
 #include "GUIInfoManager.h"
 #include "guilib/GUIWindowManager.h"
+#include "interfaces/Builtins.h"
 #include "dialogs/GUIDialogKaiToast.h"
 #include "addons/AddonManager.h"
 #include "settings/GUISettings.h"
@@ -49,6 +50,21 @@ JSONRPC_STATUS CGUIOperations::GetProperties(const CStdString &method, ITranspor
   result = properties;
 
   return OK;
+}
+
+JSONRPC_STATUS CGUIOperations::ActivateWindow(const CStdString &method, ITransportLayer *transport, IClient *client, const CVariant &parameterObject, CVariant &result)
+{
+  CVariant params = parameterObject["parameters"];
+  std::string cmd = "ActivateWindow(" + parameterObject["window"].asString();
+  for (CVariant::iterator_array param = params.begin_array(); param != params.end_array(); param++)
+  {
+    if (param->isString() && !param->empty())
+      cmd += "," + param->asString();
+  }
+  cmd += ")";
+  CBuiltins::Execute(cmd);
+
+  return ACK;
 }
 
 JSONRPC_STATUS CGUIOperations::ShowNotification(const CStdString &method, ITransportLayer *transport, IClient *client, const CVariant &parameterObject, CVariant &result)

--- a/xbmc/interfaces/json-rpc/GUIOperations.h
+++ b/xbmc/interfaces/json-rpc/GUIOperations.h
@@ -29,6 +29,8 @@ namespace JSONRPC
   public:
     static JSONRPC_STATUS GetProperties(const CStdString &method, ITransportLayer *transport, IClient *client, const CVariant &parameterObject, CVariant &result);
 
+    static JSONRPC_STATUS ActivateWindow(const CStdString &method, ITransportLayer *transport, IClient *client, const CVariant &parameterObject, CVariant &result);
+
     static JSONRPC_STATUS ShowNotification(const CStdString &method, ITransportLayer *transport, IClient *client, const CVariant &parameterObject, CVariant &result);
     static JSONRPC_STATUS SetFullscreen(const CStdString &method, ITransportLayer *transport, IClient *client, const CVariant &parameterObject, CVariant &result);
   private:

--- a/xbmc/interfaces/json-rpc/JSONRPC.cpp
+++ b/xbmc/interfaces/json-rpc/JSONRPC.cpp
@@ -41,9 +41,13 @@ void CJSONRPC::Initialize()
     return;
 
   // Add some types/enums at runtime
-  vector<string> inputActions;
-  CButtonTranslator::GetActions(inputActions);
-  CJSONServiceDescription::AddEnum("Input.Action", inputActions);
+  vector<string> enumList;
+  CButtonTranslator::GetActions(enumList);
+  CJSONServiceDescription::AddEnum("Input.Action", enumList);
+
+  enumList.clear();
+  CButtonTranslator::GetWindows(enumList);
+  CJSONServiceDescription::AddEnum("GUI.Window", enumList);
 
   // filter-related enums
   vector<string> smartplaylistList;

--- a/xbmc/interfaces/json-rpc/JSONServiceDescription.cpp
+++ b/xbmc/interfaces/json-rpc/JSONServiceDescription.cpp
@@ -150,6 +150,7 @@ JsonRpcMethodMap CJSONServiceDescription::m_methodMaps[] = {
 
 // GUI operations
   { "GUI.GetProperties",                            CGUIOperations::GetProperties },
+  { "GUI.ActivateWindow",                           CGUIOperations::ActivateWindow },
   { "GUI.ShowNotification",                         CGUIOperations::ShowNotification },
   { "GUI.SetFullscreen",                            CGUIOperations::SetFullscreen },
 

--- a/xbmc/interfaces/json-rpc/ServiceDescription.h
+++ b/xbmc/interfaces/json-rpc/ServiceDescription.h
@@ -2531,6 +2531,17 @@ namespace JSONRPC
       "\"params\": [ ],"
       "\"returns\": \"string\""
     "}",
+    "\"GUI.ActivateWindow\": {"
+      "\"type\": \"method\","
+      "\"description\": \"Activates the given window\","
+      "\"transport\": \"Response\","
+      "\"permission\": \"ControlGUI\","
+      "\"params\": ["
+        "{ \"name\": \"window\", \"$ref\": \"GUI.Window\", \"required\": true },"
+        "{ \"name\": \"parameters\", \"type\": \"array\", \"items\": { \"type\": \"string\", \"minLength\": 1, \"required\": true }, \"minItems\": 1 }"
+      "],"
+      "\"returns\": \"string\""
+    "}",
     "\"GUI.ShowNotification\": {"
       "\"type\": \"method\","
       "\"description\": \"Shows a GUI notification\","

--- a/xbmc/interfaces/json-rpc/methods.json
+++ b/xbmc/interfaces/json-rpc/methods.json
@@ -1466,6 +1466,17 @@
     "params": [ ],
     "returns": "string"
   },
+  "GUI.ActivateWindow": {
+    "type": "method",
+    "description": "Activates the given window",
+    "transport": "Response",
+    "permission": "ControlGUI",
+    "params": [
+      { "name": "window", "$ref": "GUI.Window", "required": true },
+      { "name": "parameters", "type": "array", "items": { "type": "string", "minLength": 1, "required": true }, "minItems": 1 }
+    ],
+    "returns": "string"
+  },
   "GUI.ShowNotification": {
     "type": "method",
     "description": "Shows a GUI notification",


### PR DESCRIPTION
This adds a new method GUI.ActivateWindow which takes one mandatory parameter called "window" which must be a string and match one of the windows defined in CButtonTranslator and an additional option parameter called "parameters" which is an array of strings which is passed to the opened window in XBMC.

As an example to open the list of movie titles the parameters would look like this

```
"window": "videos", "parameters": [ "MovieTitles" ]
```

With this commit and #1404 JSON-RPC covers all the actions that the official iOS remote app from @joethefox still performs with the HTTP-API.
