### PR TITLE
Fix Remaining Coverity Static Analysis Warnings in XBMC

### DIFF
--- a/xbmc/URL.cpp
+++ b/xbmc/URL.cpp
@@ -161,9 +161,6 @@ void CURL::Parse(const CStdString& strURL1)
     return;
   }
 
-  // check for username/password - should occur before first /
-  if (iPos == -1) iPos = 0;
-
   // for protocols supporting options, chop that part off here
   // maybe we should invert this list instead?
   int iEnd = strURL.length();

--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -2233,7 +2233,5 @@ int CUtil::GetRandomNumber()
 #else
   return rand_r(&s_randomSeed);
 #endif
-
-  return rand();
 }
 

--- a/xbmc/cores/DllLoader/dll.cpp
+++ b/xbmc/cores/DllLoader/dll.cpp
@@ -58,9 +58,10 @@ extern "C" HMODULE __stdcall dllLoadLibraryExtended(LPCSTR lib_file, LPCSTR sour
   /* extract name */
   const char* p = strrchr(lib_file, PATH_SEPARATOR_CHAR);
   if (p)
-    strcpy(libname, p+1);
+    strncpy(libname, p+1, sizeof(libname) - 1);
   else
-    strcpy(libname, lib_file);
+    strncpy(libname, lib_file, sizeof(libname) - 1);
+  libname[sizeof(libname) - 1] = '\0';
 
   if( libname[0] == '\0' )
     return NULL;

--- a/xbmc/cores/DllLoader/exports/emu_kernel32.cpp
+++ b/xbmc/cores/DllLoader/exports/emu_kernel32.cpp
@@ -203,10 +203,14 @@ extern "C" DWORD WINAPI dllGetFileAttributesA(LPCSTR lpFileName)
   if (strncmp(lpFileName, "\\Device\\Cdrom0", 14) == 0)
   {
     // replace "\\Device\\Cdrom0" with "D:"
-    strcpy(str, "D:");
-    strcat(str, lpFileName + 14);
+    strncpy(str, "D:", sizeof(str) - 1);
+    strncat(str, lpFileName + 14, sizeof(str) - sizeof("D:") - 1);
   }
-  else strcpy(str, lpFileName);
+  else
+  {
+    strncpy(str, lpFileName, sizeof(str) - 1);
+    str[sizeof(str) - 1] = '\0';
+  }
 
 #ifndef _LINUX
   // convert '/' to '\\'

--- a/xbmc/cores/DllLoader/exports/emu_msvcrt.cpp
+++ b/xbmc/cores/DllLoader/exports/emu_msvcrt.cpp
@@ -1328,7 +1328,8 @@ extern "C"
       if (d == EOF)
         return -1;
 
-      dll_fseek(stream, -1, SEEK_CUR);
+      if (dll_fseek(stream, -1, SEEK_CUR)!=0)
+        return -1;
       if (c != d)
       {
         CLog::Log(LOGWARNING, "%s: c != d",  __FUNCTION__);
@@ -1336,7 +1337,10 @@ extern "C"
         if (d != c)
           CLog::Log(LOGERROR, "%s: Write failed!",  __FUNCTION__);
         else
-          dll_fseek(stream, -1, SEEK_CUR);
+        {
+          if (dll_fseek(stream, -1, SEEK_CUR)!=0)
+            return -1;
+        }
       }
       return d;
     }

--- a/xbmc/dialogs/GUIDialogMediaSource.cpp
+++ b/xbmc/dialogs/GUIDialogMediaSource.cpp
@@ -165,8 +165,7 @@ bool CGUIDialogMediaSource::ShowAndAddMediaSource(const CStdString &type)
 
 bool CGUIDialogMediaSource::ShowAndEditMediaSource(const CStdString &type, const CStdString&share)
 {
-  VECSOURCES* pShares=NULL;
-
+  VECSOURCES* pShares = g_settings.GetSourcesFromType(type);
   if (pShares)
   {
     for (unsigned int i=0;i<pShares->size();++i)
@@ -175,7 +174,6 @@ bool CGUIDialogMediaSource::ShowAndEditMediaSource(const CStdString &type, const
         return ShowAndEditMediaSource(type,(*pShares)[i]);
     }
   }
-
   return false;
 }
 

--- a/xbmc/filesystem/RTVFile.cpp
+++ b/xbmc/filesystem/RTVFile.cpp
@@ -66,8 +66,10 @@ bool CRTVFile::Open(const char* strHostName, const char* strFileName, int iport)
   // Set up global variables.  Don't set m_filePos to 0 because we use it to SEEK!
   m_fileSize = 0;
   m_rtvd = NULL;
-  strcpy(m_hostName, strHostName);
-  strcpy(m_fileName, strFileName);
+  strncpy(m_hostName, strHostName, sizeof(m_hostName) - 1);
+  m_hostName[sizeof(m_hostName) - 1] = '\0';
+  strncpy(m_fileName, strFileName, sizeof(m_fileName) - 1);
+  m_fileName[sizeof(m_fileName) - 1] = '\0';
   m_iport = iport;
 
   // Allow for ReplayTVs on ports other than 80

--- a/xbmc/filesystem/RarFile.cpp
+++ b/xbmc/filesystem/RarFile.cpp
@@ -648,7 +648,8 @@ bool CRarFile::OpenInArchive()
     if ((m_strPassword.size() > 0) &&
         (m_strPassword.size() < sizeof (m_pCmd->Password)))
     {
-      strcpy(m_pCmd->Password, m_strPassword.c_str());
+      strncpy(m_pCmd->Password, m_strPassword.c_str(), sizeof(m_pCmd->Password) - 1);
+      m_pCmd->Password[sizeof(m_pCmd->Password) - 1] = '\0';
     }
 
     m_pCmd->ParseDone();

--- a/xbmc/filesystem/RarManager.cpp
+++ b/xbmc/filesystem/RarManager.cpp
@@ -159,7 +159,7 @@ bool CRarManager::CacheRarredFile(CStdString& strPathInCache, const CStdString& 
 
     if (iOffset == -1 && j != m_ExFiles.end())  // grab from list
     {
-      for( ArchiveList_struct* pIterator = j->second.first; pIterator  ; pIterator ? pIterator = pIterator->next : NULL)
+      for( ArchiveList_struct* pIterator = j->second.first; pIterator; pIterator = pIterator->next)
       {
         CStdString strName;
 
@@ -258,7 +258,7 @@ bool CRarManager::GetFilesInRar(CFileItemList& vecpItems, const CStdString& strR
   CStdString strCompare = strPathInRar;
   if (!URIUtils::HasSlashAtEnd(strCompare) && !strCompare.IsEmpty())
     strCompare += '/';
-  for( pIterator = pFileList; pIterator  ; pIterator ? pIterator = pIterator->next : NULL)
+  for( pIterator = pFileList; pIterator; pIterator = pIterator->next )
   {
     CStdString strDirDelimiter = (pIterator->item.HostOS==3 ? "/":"\\"); // win32 or unix paths?
     CStdString strName;

--- a/xbmc/filesystem/iso9660.cpp
+++ b/xbmc/filesystem/iso9660.cpp
@@ -642,7 +642,8 @@ HANDLE iso9660::FindFirstFile( char *szLocalFolder, WIN32_FIND_DATA *wfdFile )
 
     if ( m_searchpointer )
     {
-      strcpy(wfdFile->cFileName, m_searchpointer->name );
+      strncpy(wfdFile->cFileName, m_searchpointer->name, sizeof(wfdFile->cFileName) - 1);
+      wfdFile->cFileName[sizeof(wfdFile->cFileName) - 1] = '\0';
 
       if ( m_searchpointer->type == 2 )
         wfdFile->dwFileAttributes |= FILE_ATTRIBUTE_DIRECTORY;
@@ -668,8 +669,8 @@ int iso9660::FindNextFile( HANDLE szLocalFolder, WIN32_FIND_DATA *wfdFile )
 
   if ( m_searchpointer )
   {
-    strcpy(wfdFile->cFileName, m_searchpointer->name );
-
+    strncpy(wfdFile->cFileName, m_searchpointer->name, sizeof(wfdFile->cFileName) - 1);
+    wfdFile->cFileName[sizeof(wfdFile->cFileName) - 1] = '\0';
     if ( m_searchpointer->type == 2 )
       wfdFile->dwFileAttributes |= FILE_ATTRIBUTE_DIRECTORY;
 
@@ -728,7 +729,8 @@ HANDLE iso9660::OpenFile(const char *filename)
   while ( strpbrk( pointer, "\\/" ) )
     pointer = strpbrk( pointer, "\\/" ) + 1;
 
-  strcpy(work, filename );
+  strncpy(work, filename, sizeof(work) - 1);
+  work[sizeof(work) - 1] = '\0';
   pointer2 = work;
 
   while ( strpbrk(pointer2 + 1, "\\" ) )

--- a/xbmc/input/linux/LIRC.cpp
+++ b/xbmc/input/linux/LIRC.cpp
@@ -134,7 +134,8 @@ void CRemoteControl::Initialize()
   
   m_lastInitAttempt = now;
   addr.sun_family = AF_UNIX;
-  strcpy(addr.sun_path, m_deviceName.c_str());
+  strncpy(addr.sun_path, m_deviceName.c_str(), sizeof(addr.sun_path) - 1);
+  addr.sun_path[sizeof(addr.sun_path) - 1] = '\0';
 
   CLog::Log(LOGINFO, "LIRC %s: using: %s", __FUNCTION__, addr.sun_path);
 

--- a/xbmc/input/linux/LIRC.cpp
+++ b/xbmc/input/linux/LIRC.cpp
@@ -223,14 +223,17 @@ bool CRemoteControl::CheckDevice() {
   int bufsize = sizeof(struct inotify_event) + PATH_MAX;
   char buf[bufsize];
   int ret = read(m_inotify_fd, buf, bufsize);
-  for (int i = 0; i + (int)sizeof(struct inotify_event) <= ret;) {
-    struct inotify_event* e = (struct inotify_event*)(buf+i);
-    if (e->mask & IN_DELETE_SELF) {
-      CLog::Log(LOGDEBUG, "LIRC device removed, disconnecting...");
-      Disconnect();
-      return false;
+  if (ret >= 0)
+  {
+    for (size_t i = 0; i + sizeof(struct inotify_event) <= (size_t)ret;) {
+      struct inotify_event* e = (struct inotify_event*)(buf+i);
+      if (e->mask & IN_DELETE_SELF) {
+        CLog::Log(LOGDEBUG, "LIRC device removed, disconnecting...");
+        Disconnect();
+        return false;
+      }
+      i += sizeof(struct inotify_event)+e->len;
     }
-    i += sizeof(struct inotify_event)+e->len;
   }
 #endif
   return true;

--- a/xbmc/interfaces/legacy/CallbackHandler.cpp
+++ b/xbmc/interfaces/legacy/CallbackHandler.cpp
@@ -145,11 +145,11 @@ namespace XBMCAddon
 #ifdef ENABLE_TRACE_API
         CLog::Log(LOGDEBUG,"%sNEWADDON removing callback 0x%lx for PyThreadState 0x%lx from queue", _tg.getSpaces(),(long)(p->cb.get()) ,(long)userData);
 #endif
-        g_callQueue.erase(iter);
+        iter = g_callQueue.erase(iter);
       }
       else
         iter++;
-    }  
+    }
   }
 }
 

--- a/xbmc/linux/XFileUtils.cpp
+++ b/xbmc/linux/XFileUtils.cpp
@@ -164,7 +164,8 @@ BOOL   FindNextFile(HANDLE hHandle, LPWIN32_FIND_DATA lpFindData)
   memset(lpFindData,0,sizeof(WIN32_FIND_DATA));
 
   lpFindData->dwFileAttributes = FILE_ATTRIBUTE_NORMAL;
-  strcpy(lpFindData->cFileName, strFileName.c_str());
+  strncpy(lpFindData->cFileName, strFileName.c_str(), sizeof(lpFindData->cFileName) - 1);
+  lpFindData->cFileName[sizeof(lpFindData->cFileName) - 1] = '\0';
 
   if (bIsDir)
     lpFindData->dwFileAttributes |= FILE_ATTRIBUTE_DIRECTORY;

--- a/xbmc/music/karaoke/karaokelyricscdg.cpp
+++ b/xbmc/music/karaoke/karaokelyricscdg.cpp
@@ -385,8 +385,8 @@ void CKaraokeLyricsCDG::cmdScroll( const char * data, bool copy )
 
     // Perform the actual scroll.
     unsigned char temp[CDG_FULL_HEIGHT][CDG_FULL_WIDTH];
-    int vInc = vScrollPixels + CDG_FULL_HEIGHT;
-    int hInc = hScrollPixels + CDG_FULL_WIDTH;
+    int vInc = vScrollPixels + (int)CDG_FULL_HEIGHT;
+    int hInc = hScrollPixels + (int)CDG_FULL_WIDTH;
     unsigned int ri; // row index
     unsigned int ci; // column index
 
@@ -416,7 +416,7 @@ void CKaraokeLyricsCDG::cmdScroll( const char * data, bool copy )
         {
             for (ci = 0; ci < CDG_FULL_WIDTH; ++ci) 
             {
-                for (ri = CDG_FULL_HEIGHT + vScrollPixels; ri < CDG_FULL_HEIGHT; ++ri) {
+                for (ri = (int)CDG_FULL_HEIGHT + vScrollPixels; ri < CDG_FULL_HEIGHT; ++ri) {
                     temp[ri][ci] = colour;
                 }
             }
@@ -433,7 +433,7 @@ void CKaraokeLyricsCDG::cmdScroll( const char * data, bool copy )
         } 
         else if (hScrollPixels < 0) 
         {
-            for (ci = CDG_FULL_WIDTH + hScrollPixels; ci < CDG_FULL_WIDTH; ++ci) 
+            for (ci = (int)CDG_FULL_WIDTH + hScrollPixels; ci < CDG_FULL_WIDTH; ++ci) 
             {
                 for (ri = 0; ri < CDG_FULL_HEIGHT; ++ri) {
                     temp[ri][ci] = colour;

--- a/xbmc/music/tags/TagLoaderTagLib.cpp
+++ b/xbmc/music/tags/TagLoaderTagLib.cpp
@@ -152,6 +152,7 @@ bool CTagLoaderTagLib::Load(const string& strFileName, CMusicInfoTag& tag, Embed
     if (!file || !file->isValid())
     {
       delete file;
+      oggFlacFile = NULL;
       file = oggVorbisFile = new Ogg::Vorbis::File(stream);
     }
   }

--- a/xbmc/network/WebServer.cpp
+++ b/xbmc/network/WebServer.cpp
@@ -395,7 +395,11 @@ int CWebServer::CreateFileDownloadResponse(struct MHD_Connection *connection, co
                                                      &CWebServer::ContentReaderCallback, file,
                                                      &CWebServer::ContentReaderFreeCallback);
       if (response == NULL)
+      {
+        file->Close();
+        delete file;
         return MHD_NO;
+      }
     }
     else
     {

--- a/xbmc/network/cddb.cpp
+++ b/xbmc/network/cddb.cpp
@@ -379,17 +379,20 @@ void Xcddb::addTitle(const char *buffer)
   if (buffer[7] == '=')
   { //Einstellig
     trk_nr = buffer[6] - 47;
-    strcpy(value, buffer + 8);
+    strncpy(value, buffer + 8, sizeof(value) - 1);
+    value[sizeof(value) - 1] = '\0';
   }
   else if (buffer[8] == '=')
   { //Zweistellig
     trk_nr = ((buffer[6] - 48) * 10) + buffer[7] - 47;
-    strcpy(value, buffer + 9);
+    strncpy(value, buffer + 9, sizeof(value) - 1);
+    value[sizeof(value) - 1] = '\0';
   }
   else if (buffer[9] == '=')
   { //Dreistellig
     trk_nr = ((buffer[6] - 48) * 100) + ((buffer[7] - 48) * 10) + buffer[8] - 47;
-    strcpy(value, buffer + 10);
+    strncpy(value, buffer + 10, sizeof(value) - 1);
+    value[sizeof(value) - 1] = '\0';
   }
   else
   {
@@ -595,17 +598,20 @@ void Xcddb::addExtended(const char *buffer)
   if (buffer[5] == '=')
   { //Einstellig
     trk_nr = buffer[4] - 47;
-    strcpy(value, buffer + 6);
+    strncpy(value, buffer + 6, sizeof(value) - 1);
+    value[sizeof(value) - 1] = '\0';
   }
   else if (buffer[6] == '=')
   { //Zweistellig
     trk_nr = ((buffer[4] - 48) * 10) + buffer[5] - 47;
-    strcpy(value, buffer + 7);
+    strncpy(value, buffer + 7, sizeof(value) - 1);
+    value[sizeof(value) - 1] = '\0';
   }
   else if (buffer[7] == '=')
   { //Dreistellig
     trk_nr = ((buffer[4] - 48) * 100) + ((buffer[5] - 48) * 10) + buffer[6] - 47;
-    strcpy(value, buffer + 8);
+    strncpy(value, buffer + 8, sizeof(value) - 1);
+    value[sizeof(value) - 1] = '\0';
   }
   else
   {

--- a/xbmc/network/linux/NetworkLinux.cpp
+++ b/xbmc/network/linux/NetworkLinux.cpp
@@ -81,10 +81,11 @@ CStdString& CNetworkInterfaceLinux::GetName(void)
 bool CNetworkInterfaceLinux::IsWireless()
 {
 #if defined(TARGET_DARWIN) || defined(TARGET_FREEBSD)
-  return false;
+   return false;
 #else
-  struct iwreq wrq;
-   strcpy(wrq.ifr_name, m_interfaceName.c_str());
+   struct iwreq wrq;
+   strncpy(wrq.ifr_name, m_interfaceName.c_str(), sizeof(wrq.ifr_name) - 1);
+   wrq.ifr_name[sizeof(wrq.ifr_name) - 1] = '\0';
    if (ioctl(m_network->GetSocket(), SIOCGIWNAME, &wrq) < 0)
       return false;
 #endif
@@ -95,7 +96,9 @@ bool CNetworkInterfaceLinux::IsWireless()
 bool CNetworkInterfaceLinux::IsEnabled()
 {
    struct ifreq ifr;
-   strcpy(ifr.ifr_name, m_interfaceName.c_str());
+   strncpy(ifr.ifr_name, m_interfaceName.c_str(), sizeof(ifr.ifr_name) - 1);
+   ifr.ifr_name[sizeof(ifr.ifr_name) - 1] = '\0';
+
    if (ioctl(m_network->GetSocket(), SIOCGIFFLAGS, &ifr) < 0)
       return false;
 
@@ -107,7 +110,8 @@ bool CNetworkInterfaceLinux::IsConnected()
    struct ifreq ifr;
    int zero = 0;
    memset(&ifr,0,sizeof(struct ifreq));
-   strcpy(ifr.ifr_name, m_interfaceName.c_str());
+   strncpy(ifr.ifr_name, m_interfaceName.c_str(), sizeof(ifr.ifr_name) - 1);
+   ifr.ifr_name[sizeof(ifr.ifr_name) - 1] = '\0';
    if (ioctl(m_network->GetSocket(), SIOCGIFFLAGS, &ifr) < 0)
       return false;
 
@@ -136,7 +140,8 @@ CStdString CNetworkInterfaceLinux::GetCurrentIPAddress(void)
    CStdString result = "";
 
    struct ifreq ifr;
-   strcpy(ifr.ifr_name, m_interfaceName.c_str());
+   strncpy(ifr.ifr_name, m_interfaceName.c_str(), sizeof(ifr.ifr_name) - 1);
+   ifr.ifr_name[sizeof(ifr.ifr_name) - 1] = '\0';
    ifr.ifr_addr.sa_family = AF_INET;
    if (ioctl(m_network->GetSocket(), SIOCGIFADDR, &ifr) >= 0)
    {
@@ -151,7 +156,8 @@ CStdString CNetworkInterfaceLinux::GetCurrentNetmask(void)
    CStdString result = "";
 
    struct ifreq ifr;
-   strcpy(ifr.ifr_name, m_interfaceName.c_str());
+   strncpy(ifr.ifr_name, m_interfaceName.c_str(), sizeof(ifr.ifr_name) - 1);
+   ifr.ifr_name[sizeof(ifr.ifr_name) - 1] = '\0';
    ifr.ifr_addr.sa_family = AF_INET;
    if (ioctl(m_network->GetSocket(), SIOCGIFNETMASK, &ifr) >= 0)
    {
@@ -170,7 +176,9 @@ CStdString CNetworkInterfaceLinux::GetCurrentWirelessEssId(void)
    memset(&essid, 0, sizeof(essid));
 
    struct iwreq wrq;
-   strcpy(wrq.ifr_name,  m_interfaceName.c_str());
+   strncpy(wrq.ifr_name,  m_interfaceName.c_str(), sizeof(wrq.ifr_name) - 1);
+   wrq.ifr_name[sizeof(wrq.ifr_name) - 1] = '\0';
+ 
    wrq.u.essid.pointer = (caddr_t) essid;
    wrq.u.essid.length = IW_ESSID_MAX_SIZE;
    wrq.u.essid.flags = 0;
@@ -384,7 +392,8 @@ void CNetworkLinux::GetMacAddress(CStdString interfaceName, char rawMac[6])
 #else
 
    struct ifreq ifr;
-   strcpy(ifr.ifr_name, interfaceName.c_str());
+   strncpy(ifr.ifr_name, interfaceName.c_str(), sizeof(ifr.ifr_name) - 1);
+   ifr.ifr_name[sizeof(ifr.ifr_name) - 1] = '\0';
    if (ioctl(GetSocket(), SIOCGIFHWADDR, &ifr) >= 0)
    {
       memcpy(rawMac, ifr.ifr_hwaddr.sa_data, 6);
@@ -538,7 +547,8 @@ std::vector<NetworkAccessPoint> CNetworkInterfaceLinux::GetAccessPoints(void)
    iwr.u.data.pointer = (caddr_t) rangebuffer;
    iwr.u.data.length = sizeof(rangebuffer);
    iwr.u.data.flags = 0;
-   strncpy(iwr.ifr_name, GetName().c_str(), IFNAMSIZ);
+   strncpy(iwr.ifr_name, GetName().c_str(), sizeof(iwr.ifr_name) - 1);
+   iwr.ifr_name[sizeof(iwr.ifr_name) - 1] = '\0';
    if (ioctl(m_network->GetSocket(), SIOCGIWRANGE, &iwr) < 0)
    {
       CLog::Log(LOGWARNING, "%-8.16s  Driver has no Wireless Extension version information.",

--- a/xbmc/network/linux/ZeroconfAvahi.cpp
+++ b/xbmc/network/linux/ZeroconfAvahi.cpp
@@ -387,7 +387,7 @@ void CZeroconfAvahi::addService(tServiceMap::mapped_type fp_service_info, AvahiC
   {
     if ((ret = avahi_entry_group_add_service_strlst(fp_service_info->mp_group, AVAHI_IF_UNSPEC, AVAHI_PROTO_UNSPEC, AvahiPublishFlags(0),
                                              fp_service_info->m_name.c_str(),
-                                             fp_service_info->m_type.c_str(), NULL, NULL, fp_service_info->m_port, fp_service_info->mp_txt) < 0))
+                                             fp_service_info->m_type.c_str(), NULL, NULL, fp_service_info->m_port, fp_service_info->mp_txt)) < 0)
     {
       if (ret == AVAHI_ERR_COLLISION)
       {

--- a/xbmc/pictures/PictureInfoTag.cpp
+++ b/xbmc/pictures/PictureInfoTag.cpp
@@ -595,7 +595,8 @@ void CPictureInfoTag::SetInfo(int info, const CStdString& value)
     }
   case SLIDE_EXIF_DATE_TIME:
     {
-      strcpy(m_exifInfo.DateTime, value.c_str());
+      strncpy(m_exifInfo.DateTime, value.c_str(), sizeof(m_exifInfo.DateTime) - 1);
+      m_exifInfo.DateTime[sizeof(m_exifInfo.DateTime) - 1] = '\0';
       break;
     }
   default:

--- a/xbmc/utils/BitstreamConverter.cpp
+++ b/xbmc/utils/BitstreamConverter.cpp
@@ -535,7 +535,10 @@ void CBitstreamConverter::Close(void)
       m_sps_pps_context.sps_pps_data = NULL;
     }
     if(m_convertBuffer)
+    {
       free(m_convertBuffer);
+      m_convertBuffer = NULL;
+    }
     m_convertSize       = 0;
   }
 

--- a/xbmc/utils/CharsetConverter.cpp
+++ b/xbmc/utils/CharsetConverter.cpp
@@ -296,7 +296,7 @@ static void logicalToVisualBiDi(const CStdStringA& strSource, CStdStringA& strDe
     FriBidiChar* visual = (FriBidiChar*) malloc((len + 1) * sizeof(FriBidiChar));
     FriBidiLevel* levels = (FriBidiLevel*) malloc((len + 1) * sizeof(FriBidiLevel));
 
-    if (fribidi_log2vis(logical, len, &base, visual, NULL, NULL, NULL))
+    if (fribidi_log2vis(logical, len, &base, visual, NULL, NULL, levels))
     {
       // Removes bidirectional marks
       len = fribidi_remove_bidi_marks(visual, len, NULL, NULL, NULL);

--- a/xbmc/utils/TuxBoxUtil.cpp
+++ b/xbmc/utils/TuxBoxUtil.cpp
@@ -364,7 +364,6 @@ bool CTuxBoxUtil::ParseChannelsEnigma2(TiXmlElement *root, CFileItemList &items,
     }
     while(pNode)
     {
-      pIt = pNode->FirstChildElement("e2servicereference");
       pIt = pNode->FirstChildElement("e2servicename");
       CStdString bqtName = pIt->FirstChild()->Value();
       pIt = pNode->FirstChildElement("e2servicelist");


### PR DESCRIPTION
This pull request resolves all remaining Coverity Static Analysis Warnings in XBMC.  Future static analysis issues should be very easy to spot now that there is no backlog of issues.

I understand that some of the changes for uninitialized members and string copy safety are probably not strictly required, but I don't see much harm in including them as they're good practice in general. If anyone objects to these changes, I'm happy to discuss amending them to something that's more agreeable.
