### PR TITLE
add the ability to run a split gui/display resolution for embedded platforms.

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -890,7 +890,7 @@ bool CApplication::CreateGUI()
     return false;
 
   int iResolution = g_graphicsContext.GetVideoResolution();
-  CLog::Log(LOGINFO, "GUI format %ix%i %s",
+  CLog::Log(LOGINFO, "GUI format %ix%i, Display %s",
             g_settings.m_ResInfo[iResolution].iWidth,
             g_settings.m_ResInfo[iResolution].iHeight,
             g_settings.m_ResInfo[iResolution].strMode.c_str());

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -1493,14 +1493,14 @@ CStdString CGUIInfoManager::GetLabel(int info, int contextWindow, CStdString *fa
   case SYSTEM_SCREEN_RESOLUTION:
     if(g_Windowing.IsFullScreen())
       strLabel.Format("%ix%i@%.2fHz - %s (%02.2f fps)",
-        g_settings.m_ResInfo[g_guiSettings.m_LookAndFeelResolution].iWidth,
-        g_settings.m_ResInfo[g_guiSettings.m_LookAndFeelResolution].iHeight,
+        g_settings.m_ResInfo[g_guiSettings.m_LookAndFeelResolution].iScreenWidth,
+        g_settings.m_ResInfo[g_guiSettings.m_LookAndFeelResolution].iScreenHeight,
         g_settings.m_ResInfo[g_guiSettings.m_LookAndFeelResolution].fRefreshRate,
         g_localizeStrings.Get(244), GetFPS());
     else
       strLabel.Format("%ix%i - %s (%02.2f fps)",
-        g_settings.m_ResInfo[g_guiSettings.m_LookAndFeelResolution].iWidth,
-        g_settings.m_ResInfo[g_guiSettings.m_LookAndFeelResolution].iHeight,
+        g_settings.m_ResInfo[g_guiSettings.m_LookAndFeelResolution].iScreenWidth,
+        g_settings.m_ResInfo[g_guiSettings.m_LookAndFeelResolution].iScreenHeight,
         g_localizeStrings.Get(242), GetFPS());
     return strLabel;
     break;
@@ -1620,10 +1620,10 @@ CStdString CGUIInfoManager::GetLabel(int info, int contextWindow, CStdString *fa
     strLabel = g_settings.m_ResInfo[g_graphicsContext.GetVideoResolution()].strMode;
     break;
   case SYSTEM_SCREEN_WIDTH:
-    strLabel.Format("%i", g_settings.m_ResInfo[g_graphicsContext.GetVideoResolution()].iWidth);
+    strLabel.Format("%i", g_settings.m_ResInfo[g_graphicsContext.GetVideoResolution()].iScreenWidth);
     break;
   case SYSTEM_SCREEN_HEIGHT:
-    strLabel.Format("%i", g_settings.m_ResInfo[g_graphicsContext.GetVideoResolution()].iHeight);
+    strLabel.Format("%i", g_settings.m_ResInfo[g_graphicsContext.GetVideoResolution()].iScreenHeight);
     break;
   case SYSTEM_CURRENT_WINDOW:
     return g_localizeStrings.Get(g_windowManager.GetFocusedWindow());

--- a/xbmc/guilib/GraphicContext.cpp
+++ b/xbmc/guilib/GraphicContext.cpp
@@ -580,6 +580,8 @@ void CGraphicContext::ResetScreenParameters(RESOLUTION res)
   default:
     break;
   }
+  g_settings.m_ResInfo[res].iScreenWidth  = g_settings.m_ResInfo[res].iWidth;
+  g_settings.m_ResInfo[res].iScreenHeight = g_settings.m_ResInfo[res].iHeight;
   ResetOverscan(res, g_settings.m_ResInfo[res].Overscan);
 }
 

--- a/xbmc/guilib/Resolution.h
+++ b/xbmc/guilib/Resolution.h
@@ -88,6 +88,8 @@ struct RESOLUTION_INFO
   int iScreen;
   int iWidth;
   int iHeight;
+  int iScreenWidth;
+  int iScreenHeight;
   int iSubtitles;
   uint32_t dwFlags;
   float fPixelRatio;
@@ -100,6 +102,8 @@ public:
   {
     iWidth = width;
     iHeight = height;
+    iScreenWidth = width;
+    iScreenHeight = height;
     fPixelRatio = aspect ? ((float)width)/height / aspect : 1.0f;
     strMode = mode;
     bFullScreen = true;
@@ -114,6 +118,7 @@ public:
   {
     Overscan = res.Overscan; bFullScreen = res.bFullScreen;
     iScreen = res.iScreen; iWidth = res.iWidth; iHeight = res.iHeight;
+    iScreenWidth = res.iScreenWidth; iScreenHeight = res.iScreenHeight;
     iSubtitles = res.iSubtitles; dwFlags = res.dwFlags;
     fPixelRatio = res.fPixelRatio; fRefreshRate = res.fRefreshRate;
     strMode = res.strMode; strOutput = res.strOutput; strId = res.strId;

--- a/xbmc/settings/GUISettings.cpp
+++ b/xbmc/settings/GUISettings.cpp
@@ -1526,8 +1526,8 @@ RESOLUTION CGUISettings::GetResFromString(const CStdString &res)
       const RESOLUTION_INFO &info = g_settings.m_ResInfo[i];
       if (info.iScreen != screen)
         continue;
-      float score = 10 * (square_error((float)info.iWidth, (float)width) +
-        square_error((float)info.iHeight, (float)height) +
+      float score = 10 * (square_error((float)info.iScreenWidth, (float)width) +
+        square_error((float)info.iScreenHeight, (float)height) +
         square_error(info.fRefreshRate, refresh) +
         square_error((float)((info.dwFlags & D3DPRESENTFLAG_INTERLACED) ? 100:200), interlaced));
       if (score < bestScore)
@@ -1552,7 +1552,7 @@ void CGUISettings::SetResolution(RESOLUTION res)
   {
     const RESOLUTION_INFO &info = g_settings.m_ResInfo[res];
     mode.Format("%1i%05i%05i%09.5f%s", info.iScreen,
-      info.iWidth, info.iHeight, info.fRefreshRate,
+      info.iScreenWidth, info.iScreenHeight, info.fRefreshRate,
       (info.dwFlags & D3DPRESENTFLAG_INTERLACED) ? "i":"p");
   }
   else

--- a/xbmc/settings/GUIWindowSettingsCategory.cpp
+++ b/xbmc/settings/GUIWindowSettingsCategory.cpp
@@ -2392,8 +2392,8 @@ void CGUIWindowSettingsCategory::FillInResolutions(CStdString strSetting, Displa
       RESOLUTION_INFO res1 = g_settings.m_ResInfo[res];
       RESOLUTION_INFO res2 = g_settings.m_ResInfo[resolutions[idx].ResInfo_Index];
       if (   res1.iScreen == res2.iScreen
-          && res1.iWidth  == res2.iWidth
-          && res1.iHeight == res2.iHeight
+          && res1.iScreenWidth  == res2.iScreenWidth
+          && res1.iScreenHeight == res2.iScreenHeight
           && (res1.dwFlags & D3DPRESENTFLAG_INTERLACED) == (res2.dwFlags & D3DPRESENTFLAG_INTERLACED))
         spinres = (RESOLUTION) resolutions[idx].ResInfo_Index;
     }
@@ -2430,13 +2430,13 @@ void CGUIWindowSettingsCategory::FillInResolutions(CStdString strSetting, Displa
 
 void CGUIWindowSettingsCategory::FillInRefreshRates(CStdString strSetting, RESOLUTION res, bool UserChange)
 {
-  // The only meaningful parts of res here are iScreen, iWidth, iHeight
+  // The only meaningful parts of res here are iScreen, iScreenWidth, iScreenHeight
 
   vector<REFRESHRATE> refreshrates;
   if (res > RES_WINDOW)
     refreshrates = g_Windowing.RefreshRates(g_settings.m_ResInfo[res].iScreen,
-      g_settings.m_ResInfo[res].iWidth,
-      g_settings.m_ResInfo[res].iHeight,
+      g_settings.m_ResInfo[res].iScreenWidth,
+      g_settings.m_ResInfo[res].iScreenHeight,
       g_settings.m_ResInfo[res].dwFlags);
 
   // The control setting doesn't exist when not in standalone mode, don't manipulate it

--- a/xbmc/settings/GUIWindowSettingsScreenCalibration.cpp
+++ b/xbmc/settings/GUIWindowSettingsScreenCalibration.cpp
@@ -352,12 +352,12 @@ void CGUIWindowSettingsScreenCalibration::UpdateFromControl(int iControl)
   // set the label control correctly
   CStdString strText;
   if (g_Windowing.IsFullScreen())
-    strText.Format("%ix%i@%.2f - %s | %s", g_settings.m_ResInfo[m_Res[m_iCurRes]].iWidth,
-      g_settings.m_ResInfo[m_Res[m_iCurRes]].iHeight, g_settings.m_ResInfo[m_Res[m_iCurRes]].fRefreshRate,
+    strText.Format("%ix%i@%.2f - %s | %s", g_settings.m_ResInfo[m_Res[m_iCurRes]].iScreenWidth,
+      g_settings.m_ResInfo[m_Res[m_iCurRes]].iScreenHeight, g_settings.m_ResInfo[m_Res[m_iCurRes]].fRefreshRate,
       g_localizeStrings.Get(244).c_str(), strStatus.c_str());
   else
-    strText.Format("%ix%i - %s | %s", g_settings.m_ResInfo[m_Res[m_iCurRes]].iWidth,
-      g_settings.m_ResInfo[m_Res[m_iCurRes]].iHeight,
+    strText.Format("%ix%i - %s | %s", g_settings.m_ResInfo[m_Res[m_iCurRes]].iScreenWidth,
+      g_settings.m_ResInfo[m_Res[m_iCurRes]].iScreenHeight,
       g_localizeStrings.Get(242).c_str(), strStatus.c_str());
 
   SET_CONTROL_LABEL(CONTROL_LABEL_ROW1, strText);

--- a/xbmc/video/windows/GUIWindowFullScreen.cpp
+++ b/xbmc/video/windows/GUIWindowFullScreen.cpp
@@ -1008,13 +1008,13 @@ void CGUIWindowFullScreen::FrameMove()
       CStdString strStatus;
       if (g_Windowing.IsFullScreen())
         strStatus.Format("%s %ix%i@%.2fHz - %s",
-          g_localizeStrings.Get(13287), g_settings.m_ResInfo[iResolution].iWidth,
-          g_settings.m_ResInfo[iResolution].iHeight, g_settings.m_ResInfo[iResolution].fRefreshRate,
+          g_localizeStrings.Get(13287), g_settings.m_ResInfo[iResolution].iScreenWidth,
+          g_settings.m_ResInfo[iResolution].iScreenHeight, g_settings.m_ResInfo[iResolution].fRefreshRate,
           g_localizeStrings.Get(244));
       else
         strStatus.Format("%s %ix%i - %s",
-          g_localizeStrings.Get(13287), g_settings.m_ResInfo[iResolution].iWidth,
-          g_settings.m_ResInfo[iResolution].iHeight, g_localizeStrings.Get(242));
+          g_localizeStrings.Get(13287), g_settings.m_ResInfo[iResolution].iScreenWidth,
+          g_settings.m_ResInfo[iResolution].iScreenHeight, g_localizeStrings.Get(242));
 
       CGUIMessage msg(GUI_MSG_LABEL_SET, GetID(), LABEL_ROW3);
       msg.SetLabel(strStatus);

--- a/xbmc/windowing/WinSystem.cpp
+++ b/xbmc/windowing/WinSystem.cpp
@@ -63,6 +63,8 @@ void CWinSystemBase::UpdateDesktopResolution(RESOLUTION_INFO& newRes, int screen
   newRes.fPixelRatio = 1.0f;
   newRes.iWidth = width;
   newRes.iHeight = height;
+  newRes.iScreenWidth = width;
+  newRes.iScreenHeight = height;
   newRes.strMode.Format("%dx%d", width, height);
   if (refreshRate > 1)
     newRes.strMode.Format("%s @ %.2f%s - Full Screen", newRes.strMode, refreshRate, dwFlags & D3DPRESENTFLAG_INTERLACED ? "i" : "");
@@ -79,6 +81,8 @@ void CWinSystemBase::UpdateResolutions()
     window.iWidth = 720;
   if (window.iHeight == 0)
     window.iHeight = 480;
+  window.iScreenWidth  = window.iWidth;
+  window.iScreenHeight = window.iHeight;
   if (window.iSubtitles == 0)
     window.iSubtitles = (int)(0.965 * window.iHeight);
   window.fPixelRatio = 1.0f;
@@ -90,6 +94,8 @@ void CWinSystemBase::SetWindowResolution(int width, int height)
   RESOLUTION_INFO& window = g_settings.m_ResInfo[RES_WINDOW];
   window.iWidth = width;
   window.iHeight = height;
+  window.iScreenWidth = width;
+  window.iScreenHeight = height;
   window.iSubtitles = (int)(0.965 * window.iHeight);
   g_graphicsContext.ResetOverscan(window);
 }
@@ -105,8 +111,8 @@ int CWinSystemBase::DesktopResolution(int screen)
 
 static void AddResolution(vector<RESOLUTION_WHR> &resolutions, unsigned int addindex)
 {
-  int width = g_settings.m_ResInfo[addindex].iWidth;
-  int height = g_settings.m_ResInfo[addindex].iHeight;
+  int width  = g_settings.m_ResInfo[addindex].iScreenWidth;
+  int height = g_settings.m_ResInfo[addindex].iScreenHeight;
   int interlaced = g_settings.m_ResInfo[addindex].dwFlags & D3DPRESENTFLAG_INTERLACED;
 
   for (unsigned int idx = 0; idx < resolutions.size(); idx++)
@@ -163,8 +169,8 @@ vector<REFRESHRATE> CWinSystemBase::RefreshRates(int screen, int width, int heig
 
   for (unsigned int idx = RES_DESKTOP; idx < g_settings.m_ResInfo.size(); idx++)
     if (   g_settings.m_ResInfo[idx].iScreen == screen
-        && g_settings.m_ResInfo[idx].iWidth  == width
-        && g_settings.m_ResInfo[idx].iHeight == height
+        && g_settings.m_ResInfo[idx].iScreenWidth  == width
+        && g_settings.m_ResInfo[idx].iScreenHeight == height
         && (g_settings.m_ResInfo[idx].dwFlags & D3DPRESENTFLAG_INTERLACED) == (dwFlags & D3DPRESENTFLAG_INTERLACED))
       AddRefreshRate(refreshrates, idx);
 

--- a/xbmc/windowing/X11/WinSystemX11.cpp
+++ b/xbmc/windowing/X11/WinSystemX11.cpp
@@ -269,6 +269,8 @@ void CWinSystemX11::UpdateResolutions()
       RESOLUTION_INFO res;
       res.iWidth  = mode.w;
       res.iHeight = mode.h;
+      res.iScreenWidth  = mode.w;
+      res.iScreenHeight = mode.h;
       if (mode.h>0 && mode.w>0 && out.hmm>0 && out.wmm>0)
         res.fPixelRatio = ((float)out.wmm/(float)mode.w) / (((float)out.hmm/(float)mode.h));
       else

--- a/xbmc/windowing/X11/WinSystemX11GLES.cpp
+++ b/xbmc/windowing/X11/WinSystemX11GLES.cpp
@@ -292,6 +292,8 @@ void CWinSystemX11GLES::UpdateResolutions()
       RESOLUTION_INFO res;
       res.iWidth  = mode.w;
       res.iHeight = mode.h;
+      res.iScreenWidth  = mode.w;
+      res.iScreenHeight = mode.h;
       if (mode.h>0 && mode.w>0 && out.hmm>0 && out.wmm>0)
         res.fPixelRatio = ((float)out.wmm/(float)mode.w) / (((float)out.hmm/(float)mode.h));
       else

--- a/xbmc/windowing/egl/WinEGLPlatformGeneric.cpp
+++ b/xbmc/windowing/egl/WinEGLPlatformGeneric.cpp
@@ -43,8 +43,8 @@ CWinEGLPlatformGeneric::CWinEGLPlatformGeneric()
   m_desktopRes.iScreen = 0;
   m_desktopRes.iWidth  = 1280;
   m_desktopRes.iHeight = 720;
-  //m_desktopRes.iScreenWidth  = 1280;
-  //m_desktopRes.iScreenHeight = 720;
+  m_desktopRes.iScreenWidth  = 1280;
+  m_desktopRes.iScreenHeight = 720;
   m_desktopRes.fRefreshRate = 60.0f;
   m_desktopRes.bFullScreen = true;
   m_desktopRes.iSubtitles = (int)(0.965 * 720);
@@ -101,12 +101,9 @@ bool CWinEGLPlatformGeneric::ProbeDisplayResolutions(std::vector<RESOLUTION_INFO
   res.fPixelRatio   = 1.0f;
   res.iWidth        = gui_width;
   res.iHeight       = gui_height;
-  //res.iScreenWidth  = gui_width;
-  //res.iScreenHeight = gui_height;
+  res.iScreenWidth  = gui_width;
+  res.iScreenHeight = gui_height;
   res.dwFlags       = D3DPRESENTFLAG_PROGRESSIVE | D3DPRESENTFLAG_WIDESCREEN;
-  // temp until split gui/display res comes in
-  //res.iScreenWidth  = width;
-  //res.iScreenHeight = height;
   res.strMode.Format("%dx%d @ %.2f - Full Screen", gui_width, gui_height, gui_refresh);
 
   resolutions.push_back(res);

--- a/xbmc/windowing/egl/WinEGLPlatformRaspberryPI.cpp
+++ b/xbmc/windowing/egl/WinEGLPlatformRaspberryPI.cpp
@@ -270,11 +270,11 @@ EGLNativeWindowType CWinEGLPlatformRaspberryPI::InitWindowSystem(EGLNativeDispla
   m_desktopRes.iSubtitles   = (int)(0.965 * m_tv_state.height);
   m_desktopRes.iWidth       = m_tv_state.width;
   m_desktopRes.iHeight      = m_tv_state.height;
+  m_desktopRes.iScreenWidth = m_tv_state.width;
+  m_desktopRes.iScreenHeight= m_tv_state.height;
   m_desktopRes.dwFlags      = m_tv_state.scan_mode ? D3DPRESENTFLAG_INTERLACED : D3DPRESENTFLAG_PROGRESSIVE;
   m_desktopRes.fRefreshRate = (float)m_tv_state.frame_rate;
   m_sdMode                  = false;
-  //m_desktopRes.iScreenWidth  = m_tv_state.width;
-  //m_desktopRes.iScreenHeight = m_tv_state.height;
   m_desktopRes.strMode.Format("%dx%d", m_tv_state.width, m_tv_state.height);
   if((float)m_tv_state.frame_rate > 1)
   {
@@ -675,8 +675,8 @@ void CWinEGLPlatformRaspberryPI::GetSupportedModes(HDMI_RES_GROUP_T group, std::
       res.fPixelRatio   = 1.0f;
       res.iWidth        = width;
       res.iHeight       = tv->height;
-      //res.iScreenWidth  = width;
-      //res.iScreenHeight = tv->height;
+      res.iScreenWidth  = width;
+      res.iScreenHeight = tv->height;
       res.strMode.Format("%dx%d", width, tv->height);
       if((float)tv->frame_rate > 1)
       {

--- a/xbmc/windowing/egl/WinSystemGLES.cpp
+++ b/xbmc/windowing/egl/WinSystemGLES.cpp
@@ -78,7 +78,11 @@ bool CWinSystemGLES::DestroyWindowSystem()
 
 bool CWinSystemGLES::CreateNewWindow(const CStdString& name, bool fullScreen, RESOLUTION_INFO& res, PHANDLE_EVENT_FUNC userFunction)
 {
-  if (m_bWindowCreated && m_nWidth == res.iWidth && m_nHeight == res.iHeight && m_fRefreshRate == res.fRefreshRate && m_bFullScreen == fullScreen)
+  if (m_bWindowCreated &&
+    m_nWidth == res.iWidth && m_nHeight == res.iHeight &&
+    m_nScreenWidth == res.iScreenWidth && m_nScreenHeight == res.iScreenHeight &&
+    m_bFullScreen  == fullScreen &&
+    m_fRefreshRate == res.fRefreshRate)
   {
     CLog::Log(LOGDEBUG, "CWinSystemGLES::CreateNewWindow: No need to create a new window");
     return true;
@@ -86,8 +90,10 @@ bool CWinSystemGLES::CreateNewWindow(const CStdString& name, bool fullScreen, RE
 
   m_nWidth  = res.iWidth;
   m_nHeight = res.iHeight;
-  m_bFullScreen = fullScreen;
-  m_fRefreshRate = res.fRefreshRate;
+  m_nScreenWidth  = res.iScreenWidth;
+  m_nScreenHeight = res.iScreenHeight;
+  m_bFullScreen   = fullScreen;
+  m_fRefreshRate  = res.fRefreshRate;
   
   // Destroy any existing window
   if (m_bWindowCreated)
@@ -138,7 +144,6 @@ void CWinSystemGLES::UpdateResolutions()
 {
   CWinSystemBase::UpdateResolutions();
 
-  //std::vector<CStdString> resolutions;
   std::vector<RESOLUTION_INFO> resolutions;
 
   m_eglplatform->ProbeDisplayResolutions(resolutions);
@@ -147,9 +152,6 @@ void CWinSystemGLES::UpdateResolutions()
 
   RESOLUTION ResDesktop = RES_INVALID;
   RESOLUTION res_index  = RES_DESKTOP;
-
-  // Clear old resolutions
-  //g_settings.m_ResInfo.clear();
 
   for (size_t i = 0; i < resolutions.size(); i++)
   {
@@ -173,17 +175,23 @@ void CWinSystemGLES::UpdateResolutions()
     g_graphicsContext.ResetOverscan(resolutions[i]);
     g_settings.m_ResInfo[res_index] = resolutions[i];
 
-    CLog::Log(LOGNOTICE, "Found resolution for display %d with %d x %d @ %f Hz\n",
+    CLog::Log(LOGNOTICE, "Found resolution %d x %d for display %d with %d x %d%s @ %f Hz\n",
       resolutions[i].iScreen,
       resolutions[i].iWidth,
       resolutions[i].iHeight,
+      resolutions[i].iScreenWidth,
+      resolutions[i].iScreenHeight,
+      resolutions[i].dwFlags & D3DPRESENTFLAG_INTERLACED ? "i" : "",
       resolutions[i].fRefreshRate);
 
     if(m_eglplatform->FixedDesktop())
     {
       if(resDesktop.iWidth == resolutions[i].iWidth &&
          resDesktop.iHeight == resolutions[i].iHeight &&
-         resDesktop.fRefreshRate == resolutions[i].fRefreshRate)
+         resDesktop.iScreenWidth == resolutions[i].iScreenWidth &&
+         resDesktop.iScreenHeight == resolutions[i].iScreenHeight &&
+         resDesktop.fRefreshRate == resolutions[i].fRefreshRate &&
+         resDesktop.dwFlags == resolutions[i].dwFlags)
       {
         ResDesktop = res_index;
       }
@@ -195,8 +203,11 @@ void CWinSystemGLES::UpdateResolutions()
   // swap desktop index for desktop res if available
   if (ResDesktop != RES_INVALID)
   {
-    CLog::Log(LOGNOTICE, "Found (%dx%d@%f) at %d, setting to RES_DESKTOP at %d",
-              resDesktop.iWidth, resDesktop.iHeight, resDesktop.fRefreshRate, (int)ResDesktop, (int)RES_DESKTOP);
+    CLog::Log(LOGNOTICE, "Found (%dx%d%s@%f) at %d, setting to RES_DESKTOP at %d",
+      resDesktop.iWidth, resDesktop.iHeight,
+      resDesktop.dwFlags & D3DPRESENTFLAG_INTERLACED ? "i" : "",
+      resDesktop.fRefreshRate,
+      (int)ResDesktop, (int)RES_DESKTOP);
 
     RESOLUTION_INFO desktop = g_settings.m_ResInfo[RES_DESKTOP];
     g_settings.m_ResInfo[RES_DESKTOP] = g_settings.m_ResInfo[ResDesktop];

--- a/xbmc/windowing/egl/WinSystemGLES.h
+++ b/xbmc/windowing/egl/WinSystemGLES.h
@@ -63,6 +63,8 @@ protected:
   void                  *m_display;
   EGLNativeWindowType   m_window;
   CWinEGLPlatform       *m_eglplatform;
+  int                   m_nScreenWidth;
+  int                   m_nScreenHeight;
 };
 
 XBMC_GLOBAL_REF(CWinSystemGLES,g_Windowing);

--- a/xbmc/windowing/windows/WinSystemWin32.cpp
+++ b/xbmc/windowing/windows/WinSystemWin32.cpp
@@ -541,6 +541,8 @@ void CWinSystemWin32::AddResolution(const RESOLUTION_INFO &res)
     if (g_settings.m_ResInfo[i].iScreen      == res.iScreen &&
         g_settings.m_ResInfo[i].iWidth       == res.iWidth &&
         g_settings.m_ResInfo[i].iHeight      == res.iHeight &&
+        g_settings.m_ResInfo[i].iScreenWidth == res.iScreenWidth &&
+        g_settings.m_ResInfo[i].iScreenHeight== res.iScreenHeight &&
         g_settings.m_ResInfo[i].fRefreshRate == res.fRefreshRate &&
         g_settings.m_ResInfo[i].dwFlags      == res.dwFlags)
       return; // already have this resolution


### PR DESCRIPTION
This is transparent on desktop and is used primarily on embedded platforms where the GUI is not powerful enough to render GLES at 1080p with a decent fps but the hardware video decoders have no problem running at 1080p. This type of hardware typically has multiple display layers with a hw scaler to handle scaling/blending of the GUI to display resolution. 

So we setup and run GLES at a lower resolution (ie, 1280 x 720) and configure the hw scaler to scale to the full 1920 x 1080 display resolution. This type of setup is used for amlogic, sigma and cex41xx. RaspberryPi seems to have a very strong GUI and can render the GUI at 1080p without problems.
