### PR TITLE
Android/Bionic doesn't implement rand_r

### DIFF
--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -2618,6 +2618,8 @@ int CUtil::GetRandomNumber()
   unsigned int number;
   if (rand_s(&number) == 0)
     return (int)number;
+#elif defined(TARGET_ANDROID)
+  srand(time(NULL));
 #else
   return rand_r(&s_randomSeed);
 #endif


### PR DESCRIPTION
This fixes Android build after #1448 was merged.
