### PR TITLE
[libcmyth/refmem] Pull across upstream changes to support other architec...

### DIFF
--- a/lib/cmyth/include/refmem/refmem.h
+++ b/lib/cmyth/include/refmem/refmem.h
@@ -24,11 +24,16 @@
 #ifndef __REFMEM_H
 #define __REFMEM_H
 
+#include "atomic.h"
+
 /*
  * -----------------------------------------------------------------
  * Types
  * -----------------------------------------------------------------
  */
+
+/* Return current number of references outstanding for everything */
+extern int ref_get_refcount();
 
 /**
  * Release a reference to allocated memory.
@@ -94,5 +99,32 @@ extern void ref_set_destroy(void *block, ref_destroy_t func);
  * Print allocation information to stdout.
  */
 extern void ref_alloc_show(void);
+
+/*
+ * Debug level constants used to determine the level of debug tracing
+ * to be done and the debug level of any given message.
+ */
+
+#define REF_DBG_NONE    -1
+#define REF_DBG_ERRORS   0
+#define REF_DBG_COUNTERS 1
+#define REF_DBG_DEBUG    2
+#define REF_DBG_ALL      3
+
+/**
+ * Set librefmem debug level.
+ * \param l debugging level (-1 for none, 3 for all)
+ */
+void refmem_dbg_level(int l);
+
+/**
+ * Enable all librefmem debugging.
+ */
+void refmem_dbg_all();
+
+/**
+ * Disable all librefmem debugging.
+ */
+void refmem_dbg_none();
 
 #endif /* __REFMEM_H */

--- a/lib/cmyth/librefmem/refmem_local.h
+++ b/lib/cmyth/librefmem/refmem_local.h
@@ -1,20 +1,25 @@
+/*
+ *  Copyright (C) 2004-2012, Eric Lund, Jon Gettler
+ *  http://www.mvpmc.org/
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2.1 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+
 #ifndef __REFMEM_LOCAL_H
 #define __REFMEM_LOCAL_H
 
-/*
- * Debug level constants used to determine the level of debug tracing
- * to be done and the debug level of any given message.
- */
-
-#define REF_DBG_NONE  -1
-#define REF_DBG_DEBUG  0
-#define REF_DBG_ALL    0
-
-void refmem_dbg_level(int l);
-
-void refmem_dbg_all();
-
-void refmem_dbg_none();
-
 void refmem_dbg(int level, char *fmt, ...);
+
 #endif /* __REFMEM_LOCAL_H */


### PR DESCRIPTION
...tures.

RFC: This PR contains a number of updates from upstream for the refmem bits within the cmyth library. I'm not familiar with this area much so this is really an exercise to try and get XBMC and upstream in sync. I've reviewed the diffs and made the changes to both sides that seem sensible but I don't know enough about what this code is supposed to do for the new architectures that it supports, e.g. ANDROID, ARM, APPLE. I'd really appreciate it if the devs who know more about those platforms could have a look.

The associated upstream cmyth diff to get XBMC and upstream to finally match can be found at https://github.com/dteirney/cmyth/commit/5991469bcc20cff93140f94c84a7918d3f67df40
